### PR TITLE
Put the parameters in front of the fork (#2123)

### DIFF
--- a/docs/architecture/native-engine.md
+++ b/docs/architecture/native-engine.md
@@ -29,7 +29,7 @@ is. When the two disagree, the headers are right and this file is stale.
 | Clip model: container from content | [#1901](https://github.com/Conceptual-Machines/magda-core/issues/1901) | done |
 | **Engine core: plan, executor, PDC** | [#1889](https://github.com/Conceptual-Machines/magda-core/issues/1889) | **all 10 slices done** |
 | **Arranger clip playback** | [#1890](https://github.com/Conceptual-Machines/magda-core/issues/1890) | **all 7 slices done** |
-| Parameters, modifiers, macros, automation | [#1891](https://github.com/Conceptual-Machines/magda-core/issues/1891) | not started |
+| **Parameters, modifiers, macros, automation** | [#1891](https://github.com/Conceptual-Machines/magda-core/issues/1891) | **all 8 slices done** |
 | Rack graph: pins, summing, multi-out, nesting | [#1892](https://github.com/Conceptual-Machines/magda-core/issues/1892) | not started |
 | External plugin hosting and hardware inserts | [#1893](https://github.com/Conceptual-Machines/magda-core/issues/1893) | not started |
 | Clip launcher and session playback | [#1894](https://github.com/Conceptual-Machines/magda-core/issues/1894) | not started |
@@ -55,6 +55,19 @@ stretch and pitch ([#2037](https://github.com/Conceptual-Machines/magda-core/iss
 warp, beat detection and loop info ([#2038](https://github.com/Conceptual-Machines/magda-core/issues/2038)),
 MIDI clips ([#2039](https://github.com/Conceptual-Machines/magda-core/issues/2039)),
 the null-diff corpus ([#2040](https://github.com/Conceptual-Machines/magda-core/issues/2040)).
+
+Parameters, slice by slice: the value lane and what a device reads
+([#2116](https://github.com/Conceptual-Machines/magda-core/issues/2116)),
+publication, addressing and the link graph
+([#2117](https://github.com/Conceptual-Machines/magda-core/issues/2117)),
+the automation bake ([#2118](https://github.com/Conceptual-Machines/magda-core/issues/2118)),
+the LFO ([#2119](https://github.com/Conceptual-Machines/magda-core/issues/2119)),
+ADSR, random and the envelope follower
+([#2120](https://github.com/Conceptual-Machines/magda-core/issues/2120)),
+macros at track, rack and device scope
+([#2121](https://github.com/Conceptual-Machines/magda-core/issues/2121)),
+value read-back taps ([#2122](https://github.com/Conceptual-Machines/magda-core/issues/2122)),
+parity cases ([#2123](https://github.com/Conceptual-Machines/magda-core/issues/2123)).
 
 Validation, slice by slice. Done: whole-project cases and the tiered oracle
 ([#2075](https://github.com/Conceptual-Machines/magda-core/issues/2075)),
@@ -537,10 +550,10 @@ there while its session path applies it, which is a gap in the sync layer rather
 Six of the clip slices were judged by tests written beside them, and a test asserts what its
 author believed the rule was. The corpus
 ([#2040](https://github.com/Conceptual-Machines/magda-core/issues/2040)) is the one thing here
-that cannot: twenty-nine projects, each built as model values and handed to both engines,
+that cannot: thirty-eight projects, each built as model values and handed to both engines,
 neither of which gets a say in what the other produces. It lives in `tests/NullDiff*` and runs in
 `magda_juce_tests`, because the incumbent leg is a `te::Edit`. The canonical report it prints
-names the count, so `cases=29` at the top of a run is the figure this paragraph has to match.
+names the count, so `cases=38` at the top of a run is the figure this paragraph has to match.
 
 **Nothing is golden.** A checked-in reference render would freeze the fork at the moment it was
 recorded, so the day the fork changes the corpus would report an engine that broke. Both legs
@@ -618,12 +631,13 @@ than a different verdict.
 **The mixer** is where the corpus first has more than one track. `resolvePlanValues` implements
 the fader law, the linear pan law, mute inheritance and solo through destination routing, and
 until [#2075](https://github.com/Conceptual-Machines/magda-core/issues/2075) none of it had been
-compared against the incumbent at all. Seven `mix.*` cases now do: summing, the fader across its
-range, the bottom of that range on its own, the pan law at its ends, mute, solo, and the master's
-own fader and pan. The incumbent leg drives them through the same four calls
-`AudioBridge::trackPropertyChanged` makes.
+compared against the incumbent at all. Eight `mix.*` cases now do: summing, the fader across its
+range, the bottom of that range on its own, the fader past both ends where the clamp is, the pan
+law at its ends, mute, solo, and the master's own fader and pan. The incumbent leg drives them
+through the same four calls `AudioBridge::trackPropertyChanged` makes.
 
-None of them has more than three tracks, and that is a constraint rather than a preference. Four
+Only `mix.summing` has more than three tracks, which used to be a constraint rather than a
+preference. Four
 audio tracks in one Edit collide in the fork's node-identity hash, so the graph's uniqueness
 assertion fires; it reproduces on four tracks carrying one impulse clip each, which is nothing to
 do with the mixer. The runner refuses to certify a case that provoked an assertion, so this is a
@@ -636,6 +650,54 @@ The incumbent's sends live on `te::AuxSendPlugin` instances that `PluginManagerS
 which wants a `PluginManager` and the device layer behind it, and writing those plugins straight
 into the leg would be the second sync the corpus refuses to have. They belong with the rest of
 the routing graph, in [#1892](https://github.com/Conceptual-Machines/magda-core/issues/1892).
+
+**Parameters are where the corpus first runs a device.** Until
+[#2123](https://github.com/Conceptual-Machines/magda-core/issues/2123) a `Device` op resolved to
+a stand-in that passed signal through and the incumbent instantiated none of the model's devices,
+so a parameter that nothing reads was a parameter nothing could compare. That is now a gain with
+one parameter, written once as a contract (`tests/NullDiffGain.hpp`) and implemented in both legs
+the way the MIDI capture already was: a `te::Plugin` in the app's own registry, hidden from the
+browser, and its opposite number bound to the native leg's `Device` op. What a gain device
+renders is the value of its own parameter, so a case that plays a constant into it draws the
+curve directly.
+
+Nine cases: the stored value, a step curve over it, a square LFO over it, both at once, the
+stored value under each of those, a macro at track scope and at device scope, and the fader past
+both ends of its range where the clamp is. All nine null. Each drives the incumbent through the
+app's own paths rather than through a second set written here: the curve is emitted by the same
+`bakeLaneIntoCurve` the playback engine uses, and the modifiers and macros are built by
+`ModifierSyncWalker`, the same walker `PluginManager` drives.
+
+**The steps land on the half beat and the impulses land on the beat**, and that is the whole
+reason these compare at the ordinary floor. Both engines settle a parameter at the top of a
+block, because that is what an `AutomatableParameter` is, so they agree wherever a curve is
+holding still and can differ by up to a block wherever it jumps. Eleven thousand samples of
+silence either side of every jump covers a block at 4096 as well as at 512, which is why these
+cases are also bit identical across the invariance gate rather than exempt from it. The rule is
+#2040's, applied to a new dimension: choose the material so a residual can only be a bug, never
+the tolerance.
+
+**Three things are named rather than covered**, each after being tried. Rack-scope macros need a
+`te::RackType` that `RackSyncManager` builds out of a `PluginManager`, which is the boundary
+sends stop at and moves with #1892. The random walk cannot be nulled by anybody, since the fork
+seeds its generator from the clock and does not render the same numbers twice. The envelope
+follower is fed by a `FollowerSourceTapPlugin` that `PluginManager` installs, so without the
+device layer the fork's follower is handed nothing.
+
+The envelope is the fourth, and it is a finding rather than a boundary. Its note gate is behind
+that same device layer, and its transport gate is the fork asking
+`TransportControl::isPlaying()`, which is false throughout every offline render: a
+transport-triggered envelope therefore does nothing in a bounce in the current engine, while the
+engine being built plays it, because its transport gate is a property of the block. The case was
+written and renders 0.625 against silence. It is not in the corpus, for the reason reverse-plus-
+warp is not: a case that pinned it would be asking the engine to reproduce a bug.
+
+The slice also found one in the fork's LFO. `std::fmod` keeps the sign of its left-hand side, so
+a negative edit time gave `Ramp::setPosition` a negative position, which it asserts on and then
+clamps to zero. Two ordinary things produce a negative edit time: a count-in, and the lead-in an
+offline render primes the graph with, which is half a second of it on every bounce. Forty-four
+assertions per case, and a phase pinned at the top of the cycle for as long as the time stayed
+negative. The fix wraps forward instead.
 
 **Properties over generated edits**
 ([#2077](https://github.com/Conceptual-Machines/magda-core/issues/2077)) are the same argument
@@ -726,9 +788,10 @@ vocoder's state, so the two renders of the same clip came out a decibel apart. T
 cell now, which is the unit the voice actually drives it in.
 
 What the rig still does not cover is the rest of
-[#1896](https://github.com/Conceptual-Machines/magda-core/issues/1896): no case carries a real
-device, because nothing yet runs one under both engines; the interactive paths have no runner;
-and none of the migration half exists.
+[#1896](https://github.com/Conceptual-Machines/magda-core/issues/1896): no case carries a device
+either engine ships, because nothing yet runs one of those under both of them, and the gain
+device the parameter cases play through was written for the corpus; the interactive paths have no
+runner; and none of the migration half exists.
 
 ---
 
@@ -736,9 +799,6 @@ and none of the migration half exists.
 
 Worth knowing before reading the code and wondering where something is:
 
-- **Parameters and automation** ([#1891](https://github.com/Conceptual-Machines/magda-core/issues/1891)).
-  `PlanValues` carries mixer values; automation curves, modifiers and macros do not exist in the
-  engine yet.
 - **Racks, the rest of them** ([#1892](https://github.com/Conceptual-Machines/magda-core/issues/1892)).
   The ordinary shape already compiles: `PlanCompiler::emitRack` emits chain faders, the rack
   mix, its MIDI merges and its output fader, nested racks included, and the compiler and

--- a/docs/architecture/native-engine.md
+++ b/docs/architecture/native-engine.md
@@ -653,51 +653,42 @@ the routing graph, in [#1892](https://github.com/Conceptual-Machines/magda-core/
 
 **Parameters are where the corpus first runs a device.** Until
 [#2123](https://github.com/Conceptual-Machines/magda-core/issues/2123) a `Device` op resolved to
-a stand-in that passed signal through and the incumbent instantiated none of the model's devices,
-so a parameter that nothing reads was a parameter nothing could compare. That is now a gain with
-one parameter, written once as a contract (`tests/NullDiffGain.hpp`) and implemented in both legs
-the way the MIDI capture already was: a `te::Plugin` in the app's own registry, hidden from the
-browser, and its opposite number bound to the native leg's `Device` op. What a gain device
-renders is the value of its own parameter, so a case that plays a constant into it draws the
-curve directly.
+a stand-in and the incumbent instantiated none of the model's devices, so a parameter nothing
+reads was a parameter nothing could compare. That is now a gain with one parameter, written once
+as a contract (`tests/NullDiffGain.hpp`) and implemented in both legs the way the MIDI capture
+already was. What a gain device renders is the value of its own parameter, so a case that plays a
+constant into it draws the curve directly.
 
-Nine cases: the stored value, a step curve over it, a square LFO over it, both at once, the
-stored value under each of those, a macro at track scope and at device scope, and the fader past
-both ends of its range where the clamp is. All nine null. Each drives the incumbent through the
-app's own paths rather than through a second set written here: the curve is emitted by the same
-`bakeLaneIntoCurve` the playback engine uses, and the modifiers and macros are built by
-`ModifierSyncWalker`, the same walker `PluginManager` drives.
+Nine cases, all nulling: the stored value, a step curve over it, a square LFO over it, both at
+once, the stored value under each, a macro at track and at device scope, and the fader past both
+ends of its range where the clamp is. Each drives the incumbent through the app's own paths
+rather than a second set written here: the curve is emitted by the same `bakeLaneIntoCurve` the
+playback engine uses, and the modifiers and macros are built by `ModifierSyncWalker`, the walker
+`PluginManager` drives.
 
-**The steps land on the half beat and the impulses land on the beat**, and that is the whole
-reason these compare at the ordinary floor. Both engines settle a parameter at the top of a
-block, because that is what an `AutomatableParameter` is, so they agree wherever a curve is
-holding still and can differ by up to a block wherever it jumps. Eleven thousand samples of
-silence either side of every jump covers a block at 4096 as well as at 512, which is why these
-cases are also bit identical across the invariance gate rather than exempt from it. The rule is
-#2040's, applied to a new dimension: choose the material so a residual can only be a bug, never
-the tolerance.
+**The steps land on the half beat and the impulses land on the beat**, which is why these compare
+at the ordinary floor. Both engines settle a parameter at the top of a block, so they agree
+wherever a curve is holding still and can differ by up to a block wherever it jumps; eleven
+thousand samples of silence either side of every jump covers a block at 4096 as well as at 512,
+so these cases are also bit identical across the invariance gate rather than exempt from it.
 
 **Three things are named rather than covered**, each after being tried. Rack-scope macros need a
-`te::RackType` that `RackSyncManager` builds out of a `PluginManager`, which is the boundary
-sends stop at and moves with #1892. The random walk cannot be nulled by anybody, since the fork
-seeds its generator from the clock and does not render the same numbers twice. The envelope
-follower is fed by a `FollowerSourceTapPlugin` that `PluginManager` installs, so without the
-device layer the fork's follower is handed nothing.
+`te::RackType` that `RackSyncManager` builds out of a `PluginManager`, which is the boundary sends
+stop at and moves with #1892. The random walk cannot be nulled by anybody, since the fork seeds
+its generator from the clock. The envelope follower is fed by a `FollowerSourceTapPlugin` that
+`PluginManager` installs, so without the device layer the fork's follower is handed nothing.
 
-The envelope is the fourth, and it is a finding rather than a boundary. Its note gate is behind
-that same device layer, and its transport gate is the fork asking
-`TransportControl::isPlaying()`, which is false throughout every offline render: a
-transport-triggered envelope therefore does nothing in a bounce in the current engine, while the
-engine being built plays it, because its transport gate is a property of the block. The case was
-written and renders 0.625 against silence. It is not in the corpus, for the reason reverse-plus-
-warp is not: a case that pinned it would be asking the engine to reproduce a bug.
+The envelope is a finding rather than a boundary. Its note gate is behind that same device layer,
+and its transport gate is the fork asking `TransportControl::isPlaying()`, which is false
+throughout every offline render: a transport-triggered envelope does nothing in a bounce in the
+current engine, while the engine being built plays it. The case was written and renders 0.625
+against silence. It is not in the corpus, for the reason reverse-plus-warp is not.
 
 The slice also found one in the fork's LFO. `std::fmod` keeps the sign of its left-hand side, so
 a negative edit time gave `Ramp::setPosition` a negative position, which it asserts on and then
-clamps to zero. Two ordinary things produce a negative edit time: a count-in, and the lead-in an
-offline render primes the graph with, which is half a second of it on every bounce. Forty-four
-assertions per case, and a phase pinned at the top of the cycle for as long as the time stayed
-negative. The fix wraps forward instead.
+clamps to zero. A count-in produces one, and so does the lead-in an offline render primes the
+graph with, which is half a second of it on every bounce: forty-four assertions per case and a
+phase pinned at the top of its cycle throughout. The fix wraps forward instead.
 
 **Properties over generated edits**
 ([#2077](https://github.com/Conceptual-Machines/magda-core/issues/2077)) are the same argument

--- a/magda/daw/audio/CMakeLists.txt
+++ b/magda/daw/audio/CMakeLists.txt
@@ -414,6 +414,8 @@ target_sources(magda_daw PRIVATE
     racks/InstrumentRackManager.cpp
     racks/RackSyncManager.cpp
     modifiers/ModifierSync.cpp
+    automation/AutomationBake.cpp
+    automation/AutomationBake.hpp
     automation/ControlTargetResolver.cpp
     automation/ControlTargetResolver.hpp
     automation/AutomationPlaybackEngine.cpp

--- a/magda/daw/audio/automation/AutomationBake.cpp
+++ b/magda/daw/audio/automation/AutomationBake.cpp
@@ -9,15 +9,11 @@ namespace magda {
 
 namespace {
 
-/// How far ahead of a step's edge the holding point goes, in beats. Small
-/// enough to be inaudible at any tempo, large enough that Tracktion keeps it as
-/// a separate point rather than folding it into the edge.
+/// How far ahead of a step's edge the holding point goes, in beats.
 constexpr double kStepEpsilon = 0.0001;
 
-/// How many pieces a curved segment is cut into. Coarse on purpose: the
-/// iterator is linear, and each point is a ValueTree mutation with a listener
-/// fan-out behind it, so a fine tessellation is paid for on the message thread
-/// every time a point moves.
+/// How many pieces a curved segment is cut into. Coarse on purpose: each point
+/// is a ValueTree mutation with a listener fan-out behind it.
 constexpr int kBezierSegments = 12;
 
 }  // namespace
@@ -27,18 +23,15 @@ void bakeLaneIntoCurve(te::AutomationCurve& curve, const AutomationLaneInfo& lan
                        const std::function<double(double)>& valueAtBeat,
                        const std::function<float(double)>& toParameterValue) {
     // One Tracktion point per MAGDA point, plus whatever a shape needs on top.
-    // Tracktion interpolates linearly between its own points, which is what a
-    // Linear segment already is, so a dense resampling of every lane would be
-    // thousands of ValueTree mutations describing a line.
+    // A dense resampling would be thousands of mutations describing a line.
     const std::vector<AutomationPoint>* sourcePoints = nullptr;
     std::vector<AutomationPoint> clipFlattened;
 
     if (lane.isAbsolute()) {
         sourcePoints = &lane.absolutePoints;
     } else if (lane.isClipBased()) {
-        // A clip-based lane unrolled into an absolute-style breakpoint list --
-        // loop iterations, gap holds and wrap jumps included -- so the loop
-        // below treats it exactly like an absolute lane.
+        // Unrolled into an absolute-style breakpoint list, loop iterations
+        // and gap holds included, so the loop below treats it as one.
         clipFlattened = flattenClipLane(lane, getClip, valueAtBeat);
         sourcePoints = &clipFlattened;
     }
@@ -47,8 +40,7 @@ void bakeLaneIntoCurve(te::AutomationCurve& curve, const AutomationLaneInfo& lan
         return;
 
     const auto addPoint = [&](double beat, double normalized) {
-        // Stored as beats, so a tempo edit moves the curve with the grid rather
-        // than leaving it pinned at the seconds it was baked at.
+        // Beats, so a tempo edit moves the curve with the grid.
         curve.addPoint(te::EditPosition{te::BeatPosition::fromBeats(beat)},
                        toParameterValue(normalized), 0.0f, nullptr);
     };
@@ -56,20 +48,17 @@ void bakeLaneIntoCurve(te::AutomationCurve& curve, const AutomationLaneInfo& lan
     for (std::size_t i = 0; i < sourcePoints->size(); ++i) {
         const auto& point = (*sourcePoints)[i];
 
-        // A step holds the previous value right up to this point and then
-        // jumps. Without the holding point the linear iterator ramps between
-        // the two and lets every value in between through.
+        // A step holds right up to this point and then jumps; without the
+        // holding point the linear iterator ramps between the two.
         if (i > 0 && (*sourcePoints)[i - 1].curveType == AutomationCurveType::Step) {
             const auto preStepBeat = point.beatPosition - kStepEpsilon;
             if (preStepBeat > (*sourcePoints)[i - 1].beatPosition)
                 addPoint(preStepBeat, valueAtBeat(preStepBeat));
         }
 
-        // Anything that is not a straight line between its endpoints has to be
-        // cut into pieces, because a linear iterator handed two endpoints plays
-        // a straight line whatever the user drew. Bezier always; a Linear
-        // segment whenever tension or a handle bends it; a hard corner because
-        // its shape is not its endpoints either.
+        // Anything not a straight line between its endpoints is cut into
+        // pieces: bezier always, a Linear segment whenever tension or a handle
+        // bends it, and a hard corner.
         if (i > 0) {
             const auto& previous = (*sourcePoints)[i - 1];
             const auto bezier = previous.curveType == AutomationCurveType::Bezier;

--- a/magda/daw/audio/automation/AutomationBake.cpp
+++ b/magda/daw/audio/automation/AutomationBake.cpp
@@ -1,0 +1,98 @@
+#include "automation/AutomationBake.hpp"
+
+#include <cmath>
+#include <vector>
+
+#include "../../core/ClipLaneFlattener.hpp"
+
+namespace magda {
+
+namespace {
+
+/// How far ahead of a step's edge the holding point goes, in beats. Small
+/// enough to be inaudible at any tempo, large enough that Tracktion keeps it as
+/// a separate point rather than folding it into the edge.
+constexpr double kStepEpsilon = 0.0001;
+
+/// How many pieces a curved segment is cut into. Coarse on purpose: the
+/// iterator is linear, and each point is a ValueTree mutation with a listener
+/// fan-out behind it, so a fine tessellation is paid for on the message thread
+/// every time a point moves.
+constexpr int kBezierSegments = 12;
+
+}  // namespace
+
+void bakeLaneIntoCurve(te::AutomationCurve& curve, const AutomationLaneInfo& lane,
+                       const std::function<const AutomationClipInfo*(AutomationClipId)>& getClip,
+                       const std::function<double(double)>& valueAtBeat,
+                       const std::function<float(double)>& toParameterValue) {
+    // One Tracktion point per MAGDA point, plus whatever a shape needs on top.
+    // Tracktion interpolates linearly between its own points, which is what a
+    // Linear segment already is, so a dense resampling of every lane would be
+    // thousands of ValueTree mutations describing a line.
+    const std::vector<AutomationPoint>* sourcePoints = nullptr;
+    std::vector<AutomationPoint> clipFlattened;
+
+    if (lane.isAbsolute()) {
+        sourcePoints = &lane.absolutePoints;
+    } else if (lane.isClipBased()) {
+        // A clip-based lane unrolled into an absolute-style breakpoint list --
+        // loop iterations, gap holds and wrap jumps included -- so the loop
+        // below treats it exactly like an absolute lane.
+        clipFlattened = flattenClipLane(lane, getClip, valueAtBeat);
+        sourcePoints = &clipFlattened;
+    }
+
+    if (sourcePoints == nullptr || sourcePoints->empty())
+        return;
+
+    const auto addPoint = [&](double beat, double normalized) {
+        // Stored as beats, so a tempo edit moves the curve with the grid rather
+        // than leaving it pinned at the seconds it was baked at.
+        curve.addPoint(te::EditPosition{te::BeatPosition::fromBeats(beat)},
+                       toParameterValue(normalized), 0.0f, nullptr);
+    };
+
+    for (std::size_t i = 0; i < sourcePoints->size(); ++i) {
+        const auto& point = (*sourcePoints)[i];
+
+        // A step holds the previous value right up to this point and then
+        // jumps. Without the holding point the linear iterator ramps between
+        // the two and lets every value in between through.
+        if (i > 0 && (*sourcePoints)[i - 1].curveType == AutomationCurveType::Step) {
+            const auto preStepBeat = point.beatPosition - kStepEpsilon;
+            if (preStepBeat > (*sourcePoints)[i - 1].beatPosition)
+                addPoint(preStepBeat, valueAtBeat(preStepBeat));
+        }
+
+        // Anything that is not a straight line between its endpoints has to be
+        // cut into pieces, because a linear iterator handed two endpoints plays
+        // a straight line whatever the user drew. Bezier always; a Linear
+        // segment whenever tension or a handle bends it; a hard corner because
+        // its shape is not its endpoints either.
+        if (i > 0) {
+            const auto& previous = (*sourcePoints)[i - 1];
+            const auto bezier = previous.curveType == AutomationCurveType::Bezier;
+            const auto shaped = !previous.outHandle.isZero() || !point.inHandle.isZero();
+            const auto bentLinear = previous.curveType == AutomationCurveType::Linear &&
+                                    (std::abs(previous.tension) >= 0.001 || shaped);
+            const auto hardCorner = previous.curveType == AutomationCurveType::HardCorner;
+
+            if (bezier || bentLinear || hardCorner) {
+                const auto span = point.beatPosition - previous.beatPosition;
+                if (span > 0.0) {
+                    for (auto segment = 1; segment < kBezierSegments; ++segment) {
+                        const auto position =
+                            static_cast<double>(segment) / static_cast<double>(kBezierSegments);
+                        const auto beat = previous.beatPosition + (span * position);
+                        addPoint(beat, valueAtBeat(beat));
+                    }
+                }
+            }
+        }
+
+        addPoint(point.beatPosition, point.value);
+    }
+}
+
+}  // namespace magda

--- a/magda/daw/audio/automation/AutomationBake.hpp
+++ b/magda/daw/audio/automation/AutomationBake.hpp
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <tracktion_engine/tracktion_engine.h>
+
+#include <functional>
+
+#include "../../core/AutomationInfo.hpp"
+
+namespace magda {
+
+namespace te = tracktion;
+
+/**
+ * @brief Write one MAGDA lane into one Tracktion curve.
+ *
+ * MAGDA owns the curve model and Tracktion's iterator is linear only, so a
+ * lane is not copied across: it is emitted as the breakpoints a linear
+ * iterator has to be given for the two to describe the same shape. A step
+ * segment gets a point just before its edge so the old value holds right up to
+ * the jump; a bezier, a tensioned linear or a hard corner is tessellated,
+ * because two endpoints would be baked as a straight ramp whatever the user
+ * drew.
+ *
+ * Pure, and every input a callback, for the reason `flattenClipLane` is: this
+ * runs from the playback engine over the automation singleton, and from the
+ * null-diff corpus over a case's own lanes (#2123). One implementation is what
+ * makes those two comparable at all. A bake written a second time for the
+ * harness would be a harness that agrees with itself.
+ *
+ * @param curve             the Tracktion curve to fill; cleared by the caller
+ * @param lane              the lane to emit
+ * @param getClip           resolves a clip id for a clip-based lane
+ * @param valueAtBeat       the lane's value at a timeline beat
+ * @param toParameterValue  MAGDA's normalised 0..1 to what the parameter stores
+ */
+void bakeLaneIntoCurve(te::AutomationCurve& curve, const AutomationLaneInfo& lane,
+                       const std::function<const AutomationClipInfo*(AutomationClipId)>& getClip,
+                       const std::function<double(double)>& valueAtBeat,
+                       const std::function<float(double)>& toParameterValue);
+
+}  // namespace magda

--- a/magda/daw/audio/automation/AutomationBake.hpp
+++ b/magda/daw/audio/automation/AutomationBake.hpp
@@ -13,19 +13,15 @@ namespace te = tracktion;
 /**
  * @brief Write one MAGDA lane into one Tracktion curve.
  *
- * MAGDA owns the curve model and Tracktion's iterator is linear only, so a
- * lane is not copied across: it is emitted as the breakpoints a linear
- * iterator has to be given for the two to describe the same shape. A step
- * segment gets a point just before its edge so the old value holds right up to
- * the jump; a bezier, a tensioned linear or a hard corner is tessellated,
- * because two endpoints would be baked as a straight ramp whatever the user
- * drew.
+ * Tracktion's iterator is linear only, so a lane is emitted as the breakpoints
+ * that iterator needs to describe the same shape: a step gets a point just
+ * before its edge, and a bezier, tensioned linear or hard corner is tessellated
+ * because two endpoints would play as a straight ramp whatever the user drew.
  *
- * Pure, and every input a callback, for the reason `flattenClipLane` is: this
- * runs from the playback engine over the automation singleton, and from the
- * null-diff corpus over a case's own lanes (#2123). One implementation is what
- * makes those two comparable at all. A bake written a second time for the
- * harness would be a harness that agrees with itself.
+ * Pure, every input a callback, for the reason `flattenClipLane` is: this runs
+ * from the playback engine over the automation singleton and from the null-diff
+ * corpus over a case's own lanes (#2123). A second bake written for the harness
+ * would be a harness that agrees with itself.
  *
  * @param curve             the Tracktion curve to fill; cleared by the caller
  * @param lane              the lane to emit

--- a/magda/daw/audio/automation/AutomationPlaybackEngine.cpp
+++ b/magda/daw/audio/automation/AutomationPlaybackEngine.cpp
@@ -4,11 +4,11 @@
 #include <cmath>
 
 #include "../../core/AutomationManager.hpp"
-#include "../../core/ClipLaneFlattener.hpp"
 #include "../../core/ParameterInfo.hpp"
 #include "../../core/ParameterUtils.hpp"
 #include "../../core/TrackManager.hpp"
 #include "AudioBridge.hpp"
+#include "automation/AutomationBake.hpp"
 
 // INVARIANT — Parameter value representations across MAGDA:
 //
@@ -407,83 +407,13 @@ void AutomationPlaybackEngine::bakeLane(const AutomationLaneInfo& lane) {
             .value;
     };
 
-    // Bake: write ONE TE point per source MAGDA point. te::AutomationCurve
-    // already linearly interpolates between its stored points (matching
-    // MAGDA's Linear curve type), so the dense 10ms resampling we used to
-    // do was redundant — and each te::AutomationCurve::addPoint is ~2ms
-    // (valueTree mutation + listener fan-out), so 3000 samples = 6 seconds
-    // of main-thread stall per bake, which is what was locking up the UI
-    // after every automation edit. For bezier / step curves we inject a
-    // couple of helper points so TE's linear-only iterator still matches
-    // the MAGDA shape.
-    const std::vector<AutomationPoint>* sourcePoints = nullptr;
-    std::vector<AutomationPoint> clipFlattened;
-    if (lane.isAbsolute()) {
-        sourcePoints = &lane.absolutePoints;
-    } else if (lane.isClipBased()) {
-        // Unroll the lane's clips (loop iterations, gap holds, wrap jumps)
-        // into an absolute-style breakpoint list; the emission loop below
-        // then treats it exactly like an absolute lane. Its tessellation
-        // queries go through getValueAtBeat, which resolves clips natively.
-        clipFlattened = flattenClipLane(
-            lane, [&](AutomationClipId clipId) { return autoMgr.getClip(clipId); },
-            [&](double beat) { return autoMgr.getValueAtBeat(lane.id, beat); });
-        sourcePoints = &clipFlattened;
-    }
-
-    auto addTEPoint = [&](double beat, double normalizedValue) {
-        float teValue = convertValue(normalizedValue);
-        // Store as beats so tempo changes shift the curve with the grid
-        // instead of leaving it pinned at seconds offsets from bake time.
-        curve.addPoint(te::EditPosition{te::BeatPosition::fromBeats(beat)}, teValue, 0.0f, nullptr);
-    };
-
-    if (sourcePoints && !sourcePoints->empty()) {
-        constexpr double kStepEpsilon = 0.0001;  // tiny beat offset for step edges
-        constexpr int kBezierSegments = 12;      // coarse tessellation for bezier curves
-        for (size_t i = 0; i < sourcePoints->size(); ++i) {
-            const auto& point = (*sourcePoints)[i];
-
-            // Step curve: hold the previous segment's value right up to this
-            // point's position, then jump — TE's linear iterator otherwise
-            // ramps between the two points and lets the old value through.
-            if (i > 0 && (*sourcePoints)[i - 1].curveType == AutomationCurveType::Step) {
-                double preStepBeat = point.beatPosition - kStepEpsilon;
-                if (preStepBeat > (*sourcePoints)[i - 1].beatPosition)
-                    addTEPoint(preStepBeat, autoMgr.getValueAtBeat(lane.id, preStepBeat));
-            }
-
-            // Tessellate any non-straight segment so TE's linear iterator
-            // follows the shape. Bezier always needs it; Linear segments need
-            // it whenever tension is non-zero (the UI bends the slope via
-            // interpolateWithTension, which without tessellation would be
-            // baked as just the two endpoints and play back as a straight
-            // ramp regardless of the visible curve).
-            if (i > 0) {
-                const auto& prev = (*sourcePoints)[i - 1];
-                const bool isBezier = prev.curveType == AutomationCurveType::Bezier;
-                // The shaper bends a Linear segment via bezier handles (tension
-                // stays 0), so tessellate when either is set, else the bake
-                // writes a straight ramp regardless of the visible curve.
-                const bool hasShaper = !prev.outHandle.isZero() || !point.inHandle.isZero();
-                const bool isCurvedLinear = prev.curveType == AutomationCurveType::Linear &&
-                                            (std::abs(prev.tension) >= 0.001 || hasShaper);
-                const bool isHardCorner = prev.curveType == AutomationCurveType::HardCorner;
-                if (isBezier || isCurvedLinear || isHardCorner) {
-                    const double span = point.beatPosition - prev.beatPosition;
-                    if (span > 0.0) {
-                        for (int s = 1; s < kBezierSegments; ++s) {
-                            double t = static_cast<double>(s) / kBezierSegments;
-                            double beat = prev.beatPosition + span * t;
-                            addTEPoint(beat, autoMgr.getValueAtBeat(lane.id, beat));
-                        }
-                    }
-                }
-            }
-
-            addTEPoint(point.beatPosition, point.value);
-        }
-    }
+    // The shape, emitted as the breakpoints a linear iterator needs to
+    // describe it. Shared with the null-diff corpus (AutomationBake.hpp), which
+    // bakes a case's own lanes through the same code: two bakes would be a
+    // corpus that agrees with itself.
+    bakeLaneIntoCurve(
+        curve, lane, [&](AutomationClipId clipId) { return autoMgr.getClip(clipId); },
+        [&](double beat) { return autoMgr.getValueAtBeat(lane.id, beat); }, convertValue);
 
     // Force synchronous AutomationIterator rebuild. Without this, TE defers
     // the rebuild to a 10ms timer, during which the curve is invisible to the

--- a/tests/DawProjectRoundTrip.cpp
+++ b/tests/DawProjectRoundTrip.cpp
@@ -331,6 +331,50 @@ Loss tempoMap() {
 
 /// The table. Keyed by case name so that the corpus stays a description of what
 /// the two engines have to agree about, with nothing in it about a file format.
+/// A track's own modulation, which rides on TrackInfo rather than on its chain.
+///
+/// Separate from internalDevices() because it is a separate field and a
+/// separate reason. The chain is lost because DAWproject has no representation
+/// for an internal device; the macros and modifiers are lost because the format
+/// has no representation for modulation at all -- there is no macro knob in it
+/// and nothing that means "an LFO linked to a parameter at a depth".
+///
+/// Restored by counting what is linked rather than by comparing the arrays.
+/// Every track carries sixteen macros and the empty ones survive the trip as
+/// empty, so a comparison of the arrays would fire on a case that lost nothing;
+/// what is at stake is whether a link came back, and that is a count.
+Loss trackModulation() {
+    return {.field = "TrackInfo::macros, TrackInfo::mods",
+            .reason = "DAWproject has no representation for modulation: no macro knob, and "
+                      "nothing that means an LFO linked to a parameter at a depth. A track's "
+                      "macros and modifiers come back as the empty defaults",
+            .restore = [](Case& imported, const Case& original) {
+                const auto links = [](const TrackInfo& track) {
+                    auto count = std::size_t{0};
+                    for (const auto& macro : track.macros)
+                        count += macro.links.size();
+                    for (const auto& mod : track.mods)
+                        if (mod.enabled)
+                            count += mod.links.size();
+                    return count;
+                };
+
+                bool restored = false;
+
+                for (auto& track : imported.tracks)
+                    for (const auto& source : original.tracks) {
+                        if (source.name != track.name || links(track) == links(source))
+                            continue;
+
+                        track.macros = source.macros;
+                        track.mods = source.mods;
+                        restored = true;
+                    }
+
+                return restored;
+            }};
+}
+
 const std::map<std::string, std::vector<Loss>>& lossTable() {
     static const std::map<std::string, std::vector<Loss>> table{
         {"fades.curves", {fades()}},
@@ -345,6 +389,14 @@ const std::map<std::string, std::vector<Loss>>& lossTable() {
         {"stretch.broadband", {speedRatio(), stretchMode()}},
         {"warp.audio", {warp(), stretchMode()}},
         {"takes.comp", {takesAndComp()}},
+        {"param.base", {internalDevices()}},
+        {"param.automation", {internalDevices()}},
+        {"param.modifier", {internalDevices(), trackModulation()}},
+        {"param.both", {internalDevices(), trackModulation()}},
+        {"param.hostwrite.automation", {internalDevices()}},
+        {"param.hostwrite.modifier", {internalDevices(), trackModulation()}},
+        {"macro.track", {internalDevices(), trackModulation()}},
+        {"macro.device", {internalDevices()}},
         {"project.mixed", {internalDevices()}},
         {"midi.notes", {internalDevices()}},
         {"midi.cc", {internalDevices(), controllers()}},

--- a/tests/DawProjectRoundTrip.cpp
+++ b/tests/DawProjectRoundTrip.cpp
@@ -333,16 +333,12 @@ Loss tempoMap() {
 /// the two engines have to agree about, with nothing in it about a file format.
 /// A track's own modulation, which rides on TrackInfo rather than on its chain.
 ///
-/// Separate from internalDevices() because it is a separate field and a
-/// separate reason. The chain is lost because DAWproject has no representation
-/// for an internal device; the macros and modifiers are lost because the format
-/// has no representation for modulation at all -- there is no macro knob in it
-/// and nothing that means "an LFO linked to a parameter at a depth".
+/// Separate from internalDevices(): the chain is lost because the format has no
+/// internal device, this is lost because it has no modulation at all.
 ///
 /// Restored by counting what is linked rather than by comparing the arrays.
-/// Every track carries sixteen macros and the empty ones survive the trip as
-/// empty, so a comparison of the arrays would fire on a case that lost nothing;
-/// what is at stake is whether a link came back, and that is a count.
+/// Every track carries sixteen macros and the empty ones survive as empty, so
+/// comparing the arrays would fire on a case that lost nothing.
 Loss trackModulation() {
     return {.field = "TrackInfo::macros, TrackInfo::mods",
             .reason = "DAWproject has no representation for modulation: no macro knob, and "

--- a/tests/NullDiffCase.hpp
+++ b/tests/NullDiffCase.hpp
@@ -90,15 +90,10 @@ struct Case {
     std::vector<TempoPoint> tempo{{0.0, 120.0}};
 
     /// The automation the project plays, and the clips a clip-based lane names
-    /// (#2123). Empty for every case that is not about automation, which is
-    /// most of them.
-    ///
-    /// Carried on the case rather than installed into AutomationManager by a
-    /// leg, for the reason every other part of a case is model values: both
-    /// legs are handed the same lanes and each builds its own world from them.
-    /// The engine compiles them into segment lanes through
-    /// `resolvePlanValues`; the incumbent bakes them into the fork's own
-    /// `AutomationCurve` on the parameter the target names.
+    /// (#2123). Model values like the rest of a case: both legs are handed the
+    /// same lanes and each builds its own world from them. The engine compiles
+    /// them into segment lanes, the incumbent bakes them into the fork's own
+    /// AutomationCurve.
     std::vector<AutomationLaneInfo> lanes;
     std::vector<AutomationClipInfo> automationClips;
 

--- a/tests/NullDiffCase.hpp
+++ b/tests/NullDiffCase.hpp
@@ -7,6 +7,7 @@
 #include <vector>
 
 #include "NullDiffCompare.hpp"
+#include "core/AutomationInfo.hpp"
 #include "core/ClipInfo.hpp"
 #include "core/TrackInfo.hpp"
 #include "core/TypeIds.hpp"
@@ -87,6 +88,19 @@ struct Case {
     std::vector<ClipInfo> clips;
     std::vector<SourceFact> sources;
     std::vector<TempoPoint> tempo{{0.0, 120.0}};
+
+    /// The automation the project plays, and the clips a clip-based lane names
+    /// (#2123). Empty for every case that is not about automation, which is
+    /// most of them.
+    ///
+    /// Carried on the case rather than installed into AutomationManager by a
+    /// leg, for the reason every other part of a case is model values: both
+    /// legs are handed the same lanes and each builds its own world from them.
+    /// The engine compiles them into segment lanes through
+    /// `resolvePlanValues`; the incumbent bakes them into the fork's own
+    /// `AutomationCurve` on the parameter the target names.
+    std::vector<AutomationLaneInfo> lanes;
+    std::vector<AutomationClipInfo> automationClips;
 
     /// The groove templates the clips may name, as the fork keeps them: a
     /// <GROOVETEMPLATES> document. One string feeds both legs, which is what

--- a/tests/NullDiffCorpus.cpp
+++ b/tests/NullDiffCorpus.cpp
@@ -166,14 +166,9 @@ TrackInfo mixTrack(TrackId id, const char* name) {
     return track;
 }
 
-/// A track carrying one gain device, which is the only device either engine
-/// really runs (#2123, NullDiffGain.hpp).
-///
-/// The parameter's stored value is the case's, because that is what a host
-/// write is: a knob move, a control surface, a preset load and a restored
-/// project all set the same number, and the engine keeps it in a lane
-/// modulation never writes to. A case that leaves it at unity is a case with no
-/// host write in it.
+/// A track carrying one gain device, the only device either engine really runs
+/// (#2123, NullDiffGain.hpp). The parameter's stored value is the case's, which
+/// is what a host write is; a case that leaves it at unity has none in it.
 TrackInfo gainTrackOn(TrackId trackId, DeviceId deviceId, const char* name, float base) {
     TrackInfo track;
     track.id = trackId;
@@ -190,20 +185,14 @@ ControlTarget gainTarget(TrackId trackId, DeviceId deviceId) {
                                       kGainParamIndex);
 }
 
-/// A curve that holds and jumps, rather than one that travels.
+/// A curve that holds and jumps rather than one that travels.
 ///
-/// Every `param.*` case steps, and none of them ramps, for a reason that is
-/// about the comparison rather than about automation. The engine settles a
-/// parameter at the top of a block, because that is what the fork does with an
-/// AutomatableParameter, so the two agree everywhere the curve is holding
-/// still and can differ by up to a block wherever it moves. A ramp moves
-/// everywhere, so a ramping case would measure block alignment; a step moves at
-/// four instants, and the material is silent at all four.
-///
-/// So the steps land on the half beat and the impulses land on the beat. At 120
-/// bpm that is 11025 samples of silence either side of every jump, which covers
-/// a block at every size the invariance gate renders at (#2078) as well as the
-/// 512 the corpus renders at.
+/// Both engines settle a parameter at the top of a block, so they agree
+/// everywhere a curve is holding still and can differ by up to a block wherever
+/// it moves: a ramping case would measure block alignment. So the steps land on
+/// the half beat and the impulses land on the beat, which at 120 bpm is 11025
+/// samples of silence either side of every jump -- a block at every size the
+/// invariance gate renders at (#2078).
 AutomationLaneInfo stepLane(AutomationLaneId id, const ControlTarget& target,
                             std::vector<std::pair<double, double>> steps) {
     AutomationLaneInfo lane;
@@ -228,29 +217,24 @@ AutomationLaneInfo stepLane(AutomationLaneId id, const ControlTarget& target,
 
 /// A square LFO locked to the transport, driving @p target.
 ///
-/// Square because it is the one shape whose output holds still between its
-/// edges, which is what lets a modulated case be compared sample for sample:
-/// the two engines advance a modifier once per block, so a shape that moves
-/// continuously moves at a different instant in each of them and at every block
-/// size. A square moves four times over this case and the material is silent at
-/// all four.
+/// Square because its output holds still between its edges, which is what lets
+/// a modulated case be compared sample for sample: both engines advance a
+/// modifier once per block, so a continuous shape moves at a different instant
+/// in each and at every block size.
 ///
-/// Locked to the transport rather than free running, and that is not a
-/// preference either: a free-running LFO accumulates its phase per block, so
-/// where it has got to depends on how the callbacks were cut up. A
-/// transport-locked one is a function of where the block is (ModLfo.cpp), which
-/// is the same thing the render is supposed to be.
+/// Transport-locked rather than free running for the same reason: a free LFO
+/// accumulates phase per block, a transport-locked one is a function of where
+/// the block is (ModLfo.cpp).
 ///
-/// A cycle of two seconds with an eighth of a cycle of offset puts its edges at
-/// 0.75, 1.75, 2.75 and 3.75 seconds, which is a quarter of a beat off every
-/// impulse.
+/// A two-second cycle with an eighth of a cycle of offset puts its edges at
+/// 0.75, 1.75, 2.75 and 3.75 seconds, a quarter of a beat off every impulse.
 ///
-/// @p tempoSynced picks which of them says so. Half a hertz and one bar at 120
-/// bpm are the same two seconds, and they are the same LFO everywhere except in
-/// the fork, where the two are separate branches of one timer: hertz runs a
-/// ramp off the edit time, a division reads the bar grid. Both are covered
-/// because a corpus that exercised one of them would have found neither the
-/// bar-origin bug (#2128) nor the negative-ramp one below it.
+/// @p tempoSynced picks which way that period is said. Half a hertz and one bar
+/// at 120 bpm are the same LFO everywhere but in the fork, where they are
+/// separate branches of one timer: hertz runs a ramp off the edit time, a
+/// division reads the bar grid. Both are covered, because a corpus exercising
+/// one would have found neither the bar-origin bug (#2128) nor the
+/// negative-ramp one below it.
 ModInfo squareLfo(ModId id, const ControlTarget& target, float amount, bool tempoSynced = false) {
     ModInfo mod;
     mod.id = id;
@@ -274,11 +258,9 @@ ModInfo squareLfo(ModId id, const ControlTarget& target, float amount, bool temp
     return mod;
 }
 
-/// A macro knob at @p value, linked to @p target with @p amount.
-///
-/// Written into the array a scope already has rather than appended, because a
-/// macro is addressed by its index: the model gives every track, rack and
-/// device sixteen of them and a macro's identity is where it sits.
+/// A macro knob at @p value, linked to @p target with @p amount. Written into
+/// the array a scope already has rather than appended: a macro is addressed by
+/// its index, so its identity is where it sits.
 void linkMacro(MacroArray& macros, int index, float value, const ControlTarget& target,
                float amount) {
     auto& macro = macros[static_cast<std::size_t>(index)];
@@ -451,11 +433,9 @@ Case newMixCase(const char* name, const char* covers, std::vector<TrackInfo> tra
     return value;
 }
 
-/// A `param.*` case: one track, one gain device, two bars.
-///
-/// Two bars for the reason the mixer cases are: what these assert repeats every
-/// beat, and every case is rendered four more times by the invariance gate, so
-/// its length is paid for five times over.
+/// A `param.*` case: one track, one gain device, two bars. Two bars for the
+/// reason the mixer cases are -- what these assert repeats every beat, and the
+/// invariance gate renders each case four more times.
 Case newParamCase(const char* name, const char* covers, TrackInfo track) {
     std::vector<TrackInfo> tracks;
     tracks.push_back(std::move(track));
@@ -976,24 +956,15 @@ std::vector<Case> buildCorpus(const juce::File& scratchDirectory) {
     // --- the fader's own ends -------------------------------------------------
 
     {
-        // The fader past both ends of its range, which is where the clamp is
-        // and the one part of the law the three points in mix.volume cannot
-        // reach.
+        // The fader past both ends of its range, which mix.volume's three
+        // points cannot reach.
         //
-        // The fader stores a slider position rather than a gain, so a volume is
-        // turned into decibels, the decibels into a position, and the position
-        // clamped to [0, 1] before it becomes a gain again. That clamp is the
-        // whole subject: above it the fader tops out at +6 dB however large the
-        // number is, below it the position floors and the track goes silent
-        // rather than merely very quiet. A model that scaled instead of
-        // clipping, on either side, is a project that plays back louder than it
-        // was mixed.
-        //
-        // Both ends and the exact top, in one case, because they are three
-        // readings of one function. mix.volume.silent already asks what a
-        // volume of zero does; this asks what a volume the range cannot hold
-        // does, which is a different question with the same answer at only one
-        // of its two ends.
+        // The fader stores a slider position rather than a gain: a volume
+        // becomes decibels, the decibels a position, and the position clamps to
+        // [0, 1] before it is a gain again. Above the clamp the fader tops out
+        // at +6 dB however large the number; below it the position floors and
+        // the track goes silent rather than merely quiet. A model that scaled
+        // instead of clipping plays back louder than it was mixed.
         auto value = newMixCase("mix.volume.clamp", "the fader past both ends of its range",
                                 {mixTrack(1, "Over"), mixTrack(2, "Top"), mixTrack(3, "Under")});
 
@@ -1017,23 +988,18 @@ std::vector<Case> buildCorpus(const juce::File& scratchDirectory) {
 
     // --- parameters, automation, modifiers and macros --------------------------
     //
-    // The first cases in the corpus that run a device under both engines, and
-    // therefore the first that put any of #1891 in front of the fork: the value
-    // lane, the automation bake, the modifier engines and macros at two of
-    // their three scopes had all been judged by tests written beside them.
+    // The first cases that run a device under both engines, and therefore the
+    // first that put any of #1891 in front of the fork.
     //
-    // Every one of them plays impulses on the beat through a gain whose
-    // parameter is what the case is about, so the render is the parameter's own
-    // curve sampled eight times. A value wrong in the fourth decimal is visible
-    // and nothing else is in the path: no fader but unity, no pan, no
+    // Each plays impulses on the beat through a gain whose parameter is what
+    // the case is about, so the render is the parameter's own curve sampled
+    // eight times. Nothing else is in the path: no fader but unity, no pan, no
     // interpolator, no stretcher.
     //
     // **The steps land on the half beat.** Both engines settle a parameter at
-    // the top of a block, so they agree wherever it is holding still and can
-    // differ by up to a block wherever it jumps. Eleven thousand samples of
-    // silence either side of every jump is what makes the ordinary floor apply
-    // rather than a tolerance, and it is the same rule the rest of the corpus
-    // follows: choose the material so a residual can only be a bug.
+    // the top of a block, so eleven thousand samples of silence either side of
+    // every jump is what makes the ordinary floor apply rather than a
+    // tolerance. Choose the material so a residual can only be a bug.
     //
     // **Rack scope is missing from the macro cases**, and deliberately. A
     // rack's macros live on a te::RackType that RackSyncManager builds out of a
@@ -1041,35 +1007,23 @@ std::vector<Case> buildCorpus(const juce::File& scratchDirectory) {
     // corpus refuses to have. It is the boundary sends stop at, and it moves
     // with #1892.
     //
-    // **Three of the four modifier engines are not here either**, and each for
-    // a reason of its own rather than for want of a case. Each was written
-    // after trying, which is the only way to find out.
+    // **Three of the four modifier engines are not here either**, each after
+    // being tried rather than for want of a case.
     //
-    // The random walk cannot be nulled by anybody. The fork seeds its generator
-    // from the clock, so it does not render the same numbers twice, let alone
-    // the same numbers as an engine that seeds from a modifier's address on
-    // purpose (ModRandom.hpp). There is no null to claim, and a case that
-    // claimed one would be claiming something about a coincidence.
+    // The random walk cannot be nulled by anybody: the fork seeds from the
+    // clock, so it does not render the same numbers twice (ModRandom.hpp).
     //
-    // The envelope follower is fed by a FollowerSourceTapPlugin that
-    // PluginManager installs, and MAGDA always drives the fork's follower from
-    // it (ModifierSync sets usesExternalInput). Without the device layer the
-    // fork's follower is handed nothing at all, so the case would compare a
-    // level against a silence. Same boundary as the sends, and it moves with
-    // the same issue.
+    // The envelope follower is fed by a FollowerSourceTapPlugin PluginManager
+    // installs, so without the device layer the fork's follower is handed
+    // nothing. Same boundary as the sends.
     //
-    // The envelope has no gate a render can open. Its note gate comes from
-    // MAGDA's held-note model through PluginManager, which is that same
-    // boundary; and its transport gate is the fork asking
+    // The envelope has no gate a render can open. Its note gate is behind that
+    // same boundary, and its transport gate is the fork asking
     // TransportControl::isPlaying(), which is false throughout every offline
-    // render. So a transport-gated envelope does nothing in a bounce there,
-    // while the engine, whose transport gate is a property of the block, plays
-    // it. The case was written, it renders 0.625 against silence, and it is not
-    // in the corpus: what it asserts is a bug in the incumbent, and a corpus
-    // case that pins one would be asking the engine to reproduce it. The LFO
-    // is the engine that carries this dimension instead, in both of its rate
-    // modes, and the envelope's own stages are pinned where the answer is a
-    // number, in ModAdsr's tests.
+    // render: a transport-gated envelope does nothing in a bounce there, while
+    // the engine plays it. The case was written and renders 0.625 against
+    // silence; pinning it would ask the engine to reproduce a bug. The LFO
+    // carries this dimension instead, in both rate modes.
 
     {
         auto value = newParamCase("param.base", "a device parameter's stored value, heard",
@@ -1084,9 +1038,9 @@ std::vector<Case> buildCorpus(const juce::File& scratchDirectory) {
 
     {
         // A curve over a parameter, and the first time the bake has been
-        // compared against anything but itself. Both legs read the same lane:
-        // the engine compiles it into segments, the incumbent emits it into a
-        // te::AutomationCurve through the app's own bake (AutomationBake.hpp).
+        // compared against anything but itself. One lane, two legs: the engine
+        // compiles it into segments, the incumbent emits it into a
+        // te::AutomationCurve through the app's own bake.
         auto value = newParamCase("param.automation", "a step curve over a device parameter",
                                   gainTrackOn(kTrack, 911, "Automated", 1.0f));
 
@@ -1102,11 +1056,10 @@ std::vector<Case> buildCorpus(const juce::File& scratchDirectory) {
     }
 
     {
-        // A modifier over a parameter. The link is unipolar at full depth over
-        // a base of zero, so the parameter is the modifier's own output and the
-        // render is its shape: the two engines either agree about what a square
-        // LFO locked to the transport is doing, or the impulses come out at
-        // different heights.
+        // A modifier over a parameter. Unipolar at full depth over a base of
+        // zero, so the parameter is the modifier's own output and the render is
+        // its shape: the two engines agree about the square, or the impulses
+        // come out at different heights.
         auto track = gainTrackOn(kTrack, 912, "Modulated", 0.0f);
         track.mods.push_back(squareLfo(0, gainTarget(kTrack, 912), 1.0f));
 
@@ -1121,17 +1074,13 @@ std::vector<Case> buildCorpus(const juce::File& scratchDirectory) {
     }
 
     {
-        // Both lanes at once, which is the case the precedence rules exist for:
-        // automation replaces the base, and modulation is added to whichever of
-        // the two applied. Half depth over a curve that steps between an eighth
-        // and three quarters, so every combination lands somewhere different
-        // and a leg that dropped either lane renders a different height at
-        // every impulse.
+        // Both lanes at once, which is what the precedence rules exist for:
+        // automation replaces the base, modulation is added to whichever
+        // applied. Every combination lands somewhere different, so a leg that
+        // dropped either renders a different height at every impulse.
         //
-        // Tempo synced, where param.modifier runs in hertz. The two are the
-        // same two-second cycle and the same edges; in the fork they are
-        // separate branches of one timer, and this is where the second of them
-        // is covered.
+        // Tempo synced, where param.modifier runs in hertz: same cycle, the
+        // fork's other timer branch.
         auto track = gainTrackOn(kTrack, 913, "Both", 1.0f);
         track.mods.push_back(squareLfo(0, gainTarget(kTrack, 913), 0.25f, true));
 
@@ -1149,16 +1098,12 @@ std::vector<Case> buildCorpus(const juce::File& scratchDirectory) {
     }
 
     {
-        // A host write under automation. The stored value is nothing the curve
-        // ever reaches, so a leg that let the base through anywhere renders an
-        // impulse the other does not have.
-        //
-        // What it asserts is the first precedence rule: a lane that covers the
-        // block replaces the base rather than adding to it. The fork agrees,
-        // for its own reason -- an automated parameter is written from its
-        // curve every block, so the last host write is simply overwritten --
-        // and the two arriving at the same audio from different arrangements is
-        // the whole point of comparing them.
+        // A host write under automation: a lane that covers the block replaces
+        // the base rather than adding to it. The stored value is nothing the
+        // curve reaches, so a leg that let it through renders an impulse the
+        // other does not have. The fork agrees for its own reason, an automated
+        // parameter being rewritten from its curve every block, and the two
+        // arriving at the same audio from different arrangements is the point.
         auto value = newParamCase("param.hostwrite.automation",
                                   "a stored value under a curve that covers it",
                                   gainTrackOn(kTrack, 914, "Written", 0.9f));
@@ -1175,24 +1120,16 @@ std::vector<Case> buildCorpus(const juce::File& scratchDirectory) {
 
     {
         // A host write under a modifier: the stored value is what modulation is
-        // added to, rather than something modulation replaces.
+        // added to, not something it replaces. A quarter under half a square,
+        // so the parameter is a quarter or three quarters and neither is
+        // reachable without both lanes.
         //
-        // A quarter of a stored value under half a square, so the parameter is
-        // a quarter or three quarters and neither is reachable without both
-        // lanes: a leg that let modulation overwrite the base renders zero or a
-        // half instead, at every impulse, and one that ignored the modifier
-        // renders a flat quarter.
-        //
-        // What it does not pin, and the corpus checked rather than assumed:
-        // that a write arriving mid-playback survives. The bug class #1891 was
-        // arranged around is a runtime one -- Tracktion's setParameter returns
-        // early only while the modifier's output is non-zero at that instant --
-        // and an offline render is a batch job with nobody's hand on a knob
-        // during it. Running the corpus with the leg's write swapped for
-        // setParameter leaves this case nulling, which is how that was found.
-        // The lane arrangement is what makes the class impossible and it is
-        // asserted here; the timing is asserted where a gesture exists, in the
-        // parameter suites.
+        // What it does not pin, checked rather than assumed: that a write
+        // arriving mid-playback survives. That bug is a runtime one --
+        // setParameter returns early only while the modifier's output is
+        // non-zero at that instant -- and an offline render has nobody's hand
+        // on a knob during it. Swapping the leg's write for setParameter leaves
+        // this case nulling, which is how that was found.
         auto track = gainTrackOn(kTrack, 915, "Written", 0.25f);
         track.mods.push_back(squareLfo(0, gainTarget(kTrack, 915), 0.5f));
 
@@ -1207,10 +1144,9 @@ std::vector<Case> buildCorpus(const juce::File& scratchDirectory) {
     }
 
     {
-        // A macro at track scope, which is a knob that owns nothing and drives
-        // whatever it is linked to. Base zero and full depth, so the parameter
-        // is the macro's position and the render says whether the two engines
-        // agree about what a macro is worth.
+        // A macro at track scope: a knob that owns nothing and drives what it
+        // is linked to. Base zero and full depth, so the parameter is the
+        // macro's position.
         auto track = gainTrackOn(kTrack, 916, "Track Macro", 0.0f);
         linkMacro(track.macros, 0, 0.625f, gainTarget(kTrack, 916), 1.0f);
 
@@ -1225,15 +1161,11 @@ std::vector<Case> buildCorpus(const juce::File& scratchDirectory) {
     }
 
     {
-        // The same knob at device scope. A different macro array, a different
-        // node in the walker, and in the fork a different owner for the macro
-        // parameter, so it is a case rather than a repetition: a leg that
-        // resolved every macro against the track would render this one
-        // identically and prove nothing.
-        //
-        // A depth of three quarters over a base of an eighth, so the answer is
-        // neither the macro's position nor the base and a leg that dropped
-        // either is audible.
+        // The same knob at device scope: a different macro array and a
+        // different node in the walker, so a leg that resolved every macro
+        // against the track would render this one identically and prove
+        // nothing. Three quarters depth over an eighth of base, so the answer
+        // is neither the macro's position nor the base.
         auto track = gainTrackOn(kTrack, 917, "Device Macro", 0.125f);
         auto& device = magda::getDevice(track.chain.fxChainElements.front());
         linkMacro(device.macros, 0, 0.5f, gainTarget(kTrack, 917), 0.75f);

--- a/tests/NullDiffCorpus.cpp
+++ b/tests/NullDiffCorpus.cpp
@@ -4,6 +4,7 @@
 #include <map>
 
 #include "NullDiffCase.hpp"
+#include "NullDiffGain.hpp"
 #include "NullDiffMaterial.hpp"
 #include "core/DeviceInfo.hpp"
 #include "core/SourcePool.hpp"
@@ -165,6 +166,131 @@ TrackInfo mixTrack(TrackId id, const char* name) {
     return track;
 }
 
+/// A track carrying one gain device, which is the only device either engine
+/// really runs (#2123, NullDiffGain.hpp).
+///
+/// The parameter's stored value is the case's, because that is what a host
+/// write is: a knob move, a control surface, a preset load and a restored
+/// project all set the same number, and the engine keeps it in a lane
+/// modulation never writes to. A case that leaves it at unity is a case with no
+/// host write in it.
+TrackInfo gainTrackOn(TrackId trackId, DeviceId deviceId, const char* name, float base) {
+    TrackInfo track;
+    track.id = trackId;
+    track.type = TrackType::Audio;
+    track.name = name;
+    track.audioOutputDevice = "master";
+    track.chain.fxChainElements.emplace_back(gainDevice(deviceId, base));
+    return track;
+}
+
+/// Where a link or a lane addresses that device's one parameter.
+ControlTarget gainTarget(TrackId trackId, DeviceId deviceId) {
+    return ControlTarget::pluginParam(ChainNodePath::topLevelDevice(trackId, deviceId),
+                                      kGainParamIndex);
+}
+
+/// A curve that holds and jumps, rather than one that travels.
+///
+/// Every `param.*` case steps, and none of them ramps, for a reason that is
+/// about the comparison rather than about automation. The engine settles a
+/// parameter at the top of a block, because that is what the fork does with an
+/// AutomatableParameter, so the two agree everywhere the curve is holding
+/// still and can differ by up to a block wherever it moves. A ramp moves
+/// everywhere, so a ramping case would measure block alignment; a step moves at
+/// four instants, and the material is silent at all four.
+///
+/// So the steps land on the half beat and the impulses land on the beat. At 120
+/// bpm that is 11025 samples of silence either side of every jump, which covers
+/// a block at every size the invariance gate renders at (#2078) as well as the
+/// 512 the corpus renders at.
+AutomationLaneInfo stepLane(AutomationLaneId id, const ControlTarget& target,
+                            std::vector<std::pair<double, double>> steps) {
+    AutomationLaneInfo lane;
+    lane.id = id;
+    lane.target = target;
+    lane.type = AutomationLaneType::Absolute;
+    lane.authorityState = AutomationAuthorityState::Reading;
+    lane.paramName = "Gain";
+
+    AutomationPointId pointId = 1;
+    for (const auto& [beat, value] : steps) {
+        AutomationPoint point;
+        point.id = pointId++;
+        point.beatPosition = beat;
+        point.value = value;
+        point.curveType = AutomationCurveType::Step;
+        lane.absolutePoints.push_back(point);
+    }
+
+    return lane;
+}
+
+/// A square LFO locked to the transport, driving @p target.
+///
+/// Square because it is the one shape whose output holds still between its
+/// edges, which is what lets a modulated case be compared sample for sample:
+/// the two engines advance a modifier once per block, so a shape that moves
+/// continuously moves at a different instant in each of them and at every block
+/// size. A square moves four times over this case and the material is silent at
+/// all four.
+///
+/// Locked to the transport rather than free running, and that is not a
+/// preference either: a free-running LFO accumulates its phase per block, so
+/// where it has got to depends on how the callbacks were cut up. A
+/// transport-locked one is a function of where the block is (ModLfo.cpp), which
+/// is the same thing the render is supposed to be.
+///
+/// A cycle of two seconds with an eighth of a cycle of offset puts its edges at
+/// 0.75, 1.75, 2.75 and 3.75 seconds, which is a quarter of a beat off every
+/// impulse.
+///
+/// @p tempoSynced picks which of them says so. Half a hertz and one bar at 120
+/// bpm are the same two seconds, and they are the same LFO everywhere except in
+/// the fork, where the two are separate branches of one timer: hertz runs a
+/// ramp off the edit time, a division reads the bar grid. Both are covered
+/// because a corpus that exercised one of them would have found neither the
+/// bar-origin bug (#2128) nor the negative-ramp one below it.
+ModInfo squareLfo(ModId id, const ControlTarget& target, float amount, bool tempoSynced = false) {
+    ModInfo mod;
+    mod.id = id;
+    mod.name = "LFO " + juce::String(static_cast<int>(id) + 1);
+    mod.type = ModType::LFO;
+    mod.enabled = true;
+    mod.waveform = LFOWaveform::Square;
+    mod.rate = 0.5f;
+    mod.phaseOffset = 0.125f;
+    mod.tempoSync = tempoSynced;
+    mod.syncDivision = SyncDivision::Whole;
+    mod.triggerMode = LFOTriggerMode::Transport;
+
+    ModLink link;
+    link.target = target;
+    link.amount = amount;
+    link.bipolar = false;
+    link.enabled = true;
+    mod.links.push_back(link);
+
+    return mod;
+}
+
+/// A macro knob at @p value, linked to @p target with @p amount.
+///
+/// Written into the array a scope already has rather than appended, because a
+/// macro is addressed by its index: the model gives every track, rack and
+/// device sixteen of them and a macro's identity is where it sits.
+void linkMacro(MacroArray& macros, int index, float value, const ControlTarget& target,
+               float amount) {
+    auto& macro = macros[static_cast<std::size_t>(index)];
+    macro.value = value;
+
+    MacroLink link;
+    link.target = target;
+    link.amount = amount;
+    link.bipolar = false;
+    macro.links.push_back(link);
+}
+
 // --- material ----------------------------------------------------------------
 
 SourceFact writeSource(const juce::File& directory, const juce::String& name,
@@ -321,6 +447,19 @@ Case newMixCase(const char* name, const char* covers, std::vector<TrackInfo> tra
     // Only the mixer cases. Everything above plays material whose length is part
     // of what it covers: a loop has to tile, a stretched clip has to hold its
     // ratio, and a folding groove needs the bars to fold over.
+    value.endBeat = 8.0;
+    return value;
+}
+
+/// A `param.*` case: one track, one gain device, two bars.
+///
+/// Two bars for the reason the mixer cases are: what these assert repeats every
+/// beat, and every case is rendered four more times by the invariance gate, so
+/// its length is paid for five times over.
+Case newParamCase(const char* name, const char* covers, TrackInfo track) {
+    std::vector<TrackInfo> tracks;
+    tracks.push_back(std::move(track));
+    auto value = newTrackCase(name, covers, std::move(tracks));
     value.endBeat = 8.0;
     return value;
 }
@@ -830,6 +969,281 @@ std::vector<Case> buildCorpus(const juce::File& scratchDirectory) {
             value.clips.push_back(audioClipOn(static_cast<TrackId>(index + 1),
                                               static_cast<ClipId>(250 + index), 0.0, 4.0, source));
         }
+
+        corpus.push_back(std::move(value));
+    }
+
+    // --- the fader's own ends -------------------------------------------------
+
+    {
+        // The fader past both ends of its range, which is where the clamp is
+        // and the one part of the law the three points in mix.volume cannot
+        // reach.
+        //
+        // The fader stores a slider position rather than a gain, so a volume is
+        // turned into decibels, the decibels into a position, and the position
+        // clamped to [0, 1] before it becomes a gain again. That clamp is the
+        // whole subject: above it the fader tops out at +6 dB however large the
+        // number is, below it the position floors and the track goes silent
+        // rather than merely very quiet. A model that scaled instead of
+        // clipping, on either side, is a project that plays back louder than it
+        // was mixed.
+        //
+        // Both ends and the exact top, in one case, because they are three
+        // readings of one function. mix.volume.silent already asks what a
+        // volume of zero does; this asks what a volume the range cannot hold
+        // does, which is a different question with the same answer at only one
+        // of its two ends.
+        auto value = newMixCase("mix.volume.clamp", "the fader past both ends of its range",
+                                {mixTrack(1, "Over"), mixTrack(2, "Top"), mixTrack(3, "Under")});
+
+        // Four times unity is +12 dB, well past the +6 the position allows;
+        // 1.9952623 is +6 dB exactly, which is the position at its top; and a
+        // millionth is -120 dB, past the -100 the position floors at.
+        const std::array<float, 3> volumes{4.0f, 1.9952623f, 0.000001f};
+        for (auto index = 0; index < 3; ++index) {
+            value.tracks[static_cast<std::size_t>(index)].volume =
+                volumes[static_cast<std::size_t>(index)];
+
+            const auto source = writeSource(scratchDirectory, "clamp" + juce::String(index),
+                                            stepsEvery(0.5 + 0.125 * index));
+            value.sources.push_back(source);
+            value.clips.push_back(audioClipOn(static_cast<TrackId>(index + 1),
+                                              static_cast<ClipId>(270 + index), 0.0, 4.0, source));
+        }
+
+        corpus.push_back(std::move(value));
+    }
+
+    // --- parameters, automation, modifiers and macros --------------------------
+    //
+    // The first cases in the corpus that run a device under both engines, and
+    // therefore the first that put any of #1891 in front of the fork: the value
+    // lane, the automation bake, the modifier engines and macros at two of
+    // their three scopes had all been judged by tests written beside them.
+    //
+    // Every one of them plays impulses on the beat through a gain whose
+    // parameter is what the case is about, so the render is the parameter's own
+    // curve sampled eight times. A value wrong in the fourth decimal is visible
+    // and nothing else is in the path: no fader but unity, no pan, no
+    // interpolator, no stretcher.
+    //
+    // **The steps land on the half beat.** Both engines settle a parameter at
+    // the top of a block, so they agree wherever it is holding still and can
+    // differ by up to a block wherever it jumps. Eleven thousand samples of
+    // silence either side of every jump is what makes the ordinary floor apply
+    // rather than a tolerance, and it is the same rule the rest of the corpus
+    // follows: choose the material so a residual can only be a bug.
+    //
+    // **Rack scope is missing from the macro cases**, and deliberately. A
+    // rack's macros live on a te::RackType that RackSyncManager builds out of a
+    // PluginManager, and writing one into the leg is the second sync this
+    // corpus refuses to have. It is the boundary sends stop at, and it moves
+    // with #1892.
+    //
+    // **Three of the four modifier engines are not here either**, and each for
+    // a reason of its own rather than for want of a case. Each was written
+    // after trying, which is the only way to find out.
+    //
+    // The random walk cannot be nulled by anybody. The fork seeds its generator
+    // from the clock, so it does not render the same numbers twice, let alone
+    // the same numbers as an engine that seeds from a modifier's address on
+    // purpose (ModRandom.hpp). There is no null to claim, and a case that
+    // claimed one would be claiming something about a coincidence.
+    //
+    // The envelope follower is fed by a FollowerSourceTapPlugin that
+    // PluginManager installs, and MAGDA always drives the fork's follower from
+    // it (ModifierSync sets usesExternalInput). Without the device layer the
+    // fork's follower is handed nothing at all, so the case would compare a
+    // level against a silence. Same boundary as the sends, and it moves with
+    // the same issue.
+    //
+    // The envelope has no gate a render can open. Its note gate comes from
+    // MAGDA's held-note model through PluginManager, which is that same
+    // boundary; and its transport gate is the fork asking
+    // TransportControl::isPlaying(), which is false throughout every offline
+    // render. So a transport-gated envelope does nothing in a bounce there,
+    // while the engine, whose transport gate is a property of the block, plays
+    // it. The case was written, it renders 0.625 against silence, and it is not
+    // in the corpus: what it asserts is a bug in the incumbent, and a corpus
+    // case that pins one would be asking the engine to reproduce it. The LFO
+    // is the engine that carries this dimension instead, in both of its rate
+    // modes, and the envelope's own stages are pinned where the answer is a
+    // number, in ModAdsr's tests.
+
+    {
+        auto value = newParamCase("param.base", "a device parameter's stored value, heard",
+                                  gainTrackOn(kTrack, 910, "Base", 0.5f));
+
+        const auto source = writeSource(scratchDirectory, "parambase", impulses(0.5));
+        value.sources.push_back(source);
+        value.clips.push_back(audioClip(280, 0.0, 8.0, source));
+
+        corpus.push_back(std::move(value));
+    }
+
+    {
+        // A curve over a parameter, and the first time the bake has been
+        // compared against anything but itself. Both legs read the same lane:
+        // the engine compiles it into segments, the incumbent emits it into a
+        // te::AutomationCurve through the app's own bake (AutomationBake.hpp).
+        auto value = newParamCase("param.automation", "a step curve over a device parameter",
+                                  gainTrackOn(kTrack, 911, "Automated", 1.0f));
+
+        const auto source = writeSource(scratchDirectory, "paramauto", impulses(0.5));
+        value.sources.push_back(source);
+        value.clips.push_back(audioClip(281, 0.0, 8.0, source));
+
+        value.lanes.push_back(
+            stepLane(1, gainTarget(kTrack, 911),
+                     {{0.0, 1.0}, {1.5, 0.25}, {2.5, 0.75}, {4.5, 0.125}, {6.5, 1.0}}));
+
+        corpus.push_back(std::move(value));
+    }
+
+    {
+        // A modifier over a parameter. The link is unipolar at full depth over
+        // a base of zero, so the parameter is the modifier's own output and the
+        // render is its shape: the two engines either agree about what a square
+        // LFO locked to the transport is doing, or the impulses come out at
+        // different heights.
+        auto track = gainTrackOn(kTrack, 912, "Modulated", 0.0f);
+        track.mods.push_back(squareLfo(0, gainTarget(kTrack, 912), 1.0f));
+
+        auto value = newParamCase("param.modifier", "a square LFO over a device parameter",
+                                  std::move(track));
+
+        const auto source = writeSource(scratchDirectory, "parammod", impulses(0.5));
+        value.sources.push_back(source);
+        value.clips.push_back(audioClip(282, 0.0, 8.0, source));
+
+        corpus.push_back(std::move(value));
+    }
+
+    {
+        // Both lanes at once, which is the case the precedence rules exist for:
+        // automation replaces the base, and modulation is added to whichever of
+        // the two applied. Half depth over a curve that steps between an eighth
+        // and three quarters, so every combination lands somewhere different
+        // and a leg that dropped either lane renders a different height at
+        // every impulse.
+        //
+        // Tempo synced, where param.modifier runs in hertz. The two are the
+        // same two-second cycle and the same edges; in the fork they are
+        // separate branches of one timer, and this is where the second of them
+        // is covered.
+        auto track = gainTrackOn(kTrack, 913, "Both", 1.0f);
+        track.mods.push_back(squareLfo(0, gainTarget(kTrack, 913), 0.25f, true));
+
+        auto value = newParamCase("param.both", "automation and a modifier on one parameter",
+                                  std::move(track));
+
+        const auto source = writeSource(scratchDirectory, "paramboth", impulses(0.5));
+        value.sources.push_back(source);
+        value.clips.push_back(audioClip(283, 0.0, 8.0, source));
+
+        value.lanes.push_back(
+            stepLane(1, gainTarget(kTrack, 913), {{0.0, 0.125}, {2.5, 0.75}, {5.5, 0.375}}));
+
+        corpus.push_back(std::move(value));
+    }
+
+    {
+        // A host write under automation. The stored value is nothing the curve
+        // ever reaches, so a leg that let the base through anywhere renders an
+        // impulse the other does not have.
+        //
+        // What it asserts is the first precedence rule: a lane that covers the
+        // block replaces the base rather than adding to it. The fork agrees,
+        // for its own reason -- an automated parameter is written from its
+        // curve every block, so the last host write is simply overwritten --
+        // and the two arriving at the same audio from different arrangements is
+        // the whole point of comparing them.
+        auto value = newParamCase("param.hostwrite.automation",
+                                  "a stored value under a curve that covers it",
+                                  gainTrackOn(kTrack, 914, "Written", 0.9f));
+
+        const auto source = writeSource(scratchDirectory, "paramwriteauto", impulses(0.5));
+        value.sources.push_back(source);
+        value.clips.push_back(audioClip(284, 0.0, 8.0, source));
+
+        value.lanes.push_back(
+            stepLane(1, gainTarget(kTrack, 914), {{0.0, 0.2}, {1.5, 0.6}, {4.5, 0.2}}));
+
+        corpus.push_back(std::move(value));
+    }
+
+    {
+        // A host write under a modifier: the stored value is what modulation is
+        // added to, rather than something modulation replaces.
+        //
+        // A quarter of a stored value under half a square, so the parameter is
+        // a quarter or three quarters and neither is reachable without both
+        // lanes: a leg that let modulation overwrite the base renders zero or a
+        // half instead, at every impulse, and one that ignored the modifier
+        // renders a flat quarter.
+        //
+        // What it does not pin, and the corpus checked rather than assumed:
+        // that a write arriving mid-playback survives. The bug class #1891 was
+        // arranged around is a runtime one -- Tracktion's setParameter returns
+        // early only while the modifier's output is non-zero at that instant --
+        // and an offline render is a batch job with nobody's hand on a knob
+        // during it. Running the corpus with the leg's write swapped for
+        // setParameter leaves this case nulling, which is how that was found.
+        // The lane arrangement is what makes the class impossible and it is
+        // asserted here; the timing is asserted where a gesture exists, in the
+        // parameter suites.
+        auto track = gainTrackOn(kTrack, 915, "Written", 0.25f);
+        track.mods.push_back(squareLfo(0, gainTarget(kTrack, 915), 0.5f));
+
+        auto value = newParamCase("param.hostwrite.modifier",
+                                  "a stored value under an active modifier", std::move(track));
+
+        const auto source = writeSource(scratchDirectory, "paramwritemod", impulses(0.5));
+        value.sources.push_back(source);
+        value.clips.push_back(audioClip(285, 0.0, 8.0, source));
+
+        corpus.push_back(std::move(value));
+    }
+
+    {
+        // A macro at track scope, which is a knob that owns nothing and drives
+        // whatever it is linked to. Base zero and full depth, so the parameter
+        // is the macro's position and the render says whether the two engines
+        // agree about what a macro is worth.
+        auto track = gainTrackOn(kTrack, 916, "Track Macro", 0.0f);
+        linkMacro(track.macros, 0, 0.625f, gainTarget(kTrack, 916), 1.0f);
+
+        auto value = newParamCase("macro.track", "a track macro driving a device parameter",
+                                  std::move(track));
+
+        const auto source = writeSource(scratchDirectory, "macrotrack", impulses(0.5));
+        value.sources.push_back(source);
+        value.clips.push_back(audioClip(286, 0.0, 8.0, source));
+
+        corpus.push_back(std::move(value));
+    }
+
+    {
+        // The same knob at device scope. A different macro array, a different
+        // node in the walker, and in the fork a different owner for the macro
+        // parameter, so it is a case rather than a repetition: a leg that
+        // resolved every macro against the track would render this one
+        // identically and prove nothing.
+        //
+        // A depth of three quarters over a base of an eighth, so the answer is
+        // neither the macro's position nor the base and a leg that dropped
+        // either is audible.
+        auto track = gainTrackOn(kTrack, 917, "Device Macro", 0.125f);
+        auto& device = magda::getDevice(track.chain.fxChainElements.front());
+        linkMacro(device.macros, 0, 0.5f, gainTarget(kTrack, 917), 0.75f);
+
+        auto value = newParamCase("macro.device", "a device macro driving its own parameter",
+                                  std::move(track));
+
+        const auto source = writeSource(scratchDirectory, "macrodevice", impulses(0.5));
+        value.sources.push_back(source);
+        value.clips.push_back(audioClip(287, 0.0, 8.0, source));
 
         corpus.push_back(std::move(value));
     }

--- a/tests/NullDiffGain.hpp
+++ b/tests/NullDiffGain.hpp
@@ -10,51 +10,28 @@
  * @brief The one device both engines run, and the contract that makes its
  *        renders comparable (#2123).
  *
- * The corpus had no device with a parameter until this slice, and could not
- * have one: a Device op resolved to a stand-in that passed signal through, and
- * the incumbent instantiated nothing at all. So the whole of #1891 -- the value
- * lane, automation, the modifier engines, macros at each scope -- had never
- * been put in front of the fork. A parameter that nothing reads is a parameter
- * that cannot be compared.
+ * The corpus had no device with a parameter until this slice: a Device op
+ * resolved to a stand-in and the incumbent instantiated nothing, so the whole
+ * of #1891 had never been put in front of the fork. A parameter nothing reads
+ * is a parameter nothing can compare.
  *
  * This is the smallest device that fixes that. One parameter, linear, zero to
- * one, applied as a gain. Nothing else, and deliberately nothing else: what a
- * gain device renders is the value of its own parameter, so a case that plays a
- * constant into it renders the parameter's curve directly and a value wrong in
- * the fourth decimal is visible. It is the same argument `fades.curves` makes
- * about a fade.
+ * one, applied as a gain, so what it renders is the value of its own parameter
+ * and a case that plays a constant into it draws the curve directly. No MAGDA
+ * device runs under both engines yet (#1893, #1836), which is why it is written
+ * for the corpus, in both legs, from one contract -- the arrangement the MIDI
+ * capture already uses.
  *
- * ## Why a purpose-built device rather than a real one
+ * Both legs owe the same law: a gain of `v` multiplies by `v`, with no
+ * smoothing, because a smoother is state and two smoothers primed differently
+ * never agree.
  *
- * No MAGDA device runs under both engines today, and nothing in this slice
- * makes one. The engine has no device implementations (#1893 and the device SDK
- * in #1836 are where they arrive), and the incumbent's live in `PluginManager`
- * behind the sync layer the corpus refuses to duplicate. A device written for
- * the corpus, in both legs, from one contract, is what lets the parameter
- * system be compared before the devices exist. It is the same arrangement the
- * MIDI capture already uses: a te::Plugin registered in the app's own registry,
- * hidden from the browser, and its opposite number in the native leg.
- *
- * ## What both legs owe
- *
- * **The same law.** A gain of `v` multiplies by `v`. No smoothing, no ramp, no
- * dB anywhere: a smoother is state, state is memory, and two smoothers primed
- * differently never agree. The device is arithmetic so that a residual is the
- * parameter rather than the device.
- *
- * **The value at the sample being written, on the engine's side.** The engine
- * resolves a parameter into segments and the device reads the one covering each
- * sample, which is what keeps a render a function of timeline position rather
- * than of how the callback was cut up (#2078). The fork settles a parameter at
- * a block boundary and holds it for the block, because that is what
- * `AutomatableParameter` does.
- *
- * Those two differ, and the corpus does not paper over it: a case is built so
- * that the material is silent wherever the two could disagree, which is inside
- * one block of a step. That is the rule this corpus lives by -- choose the
- * material so that a residual can only be a bug, never the tolerance -- and it
- * is why every `param.*` case steps its curves on the half beat while its
- * impulses land on the beat.
+ * They differ in when they read it. The engine reads the value at the sample
+ * being written, which is what keeps a render a function of timeline position
+ * (#2078); the fork settles a parameter at a block boundary and holds it. The
+ * corpus does not paper over that: every `param.*` case steps its curves on the
+ * half beat and lands its impulses on the beat, so the material is silent
+ * wherever the two could disagree.
  */
 
 namespace magda::nulldiff {
@@ -67,17 +44,15 @@ inline constexpr const char* kGainPluginId = "nulldiffgain";
 /// parameters by the index it declared them at.
 inline constexpr int kGainParamIndex = 0;
 
-/// What the parameter is worth when a case says nothing: unity, so a device
-/// nobody automated, modulated or linked is inaudible.
+/// Unity, so a device nobody automated, modulated or linked is inaudible.
 inline constexpr float kGainDefault = 1.0f;
 
 /// The model parameter, as both legs read it.
 ///
-/// Zero to one, linear, and the same range on the TE side (`teMinValue` /
-/// `teMaxValue`), so the model value and the value the fork's parameter stores
-/// are the same number and neither leg converts. A parameter whose two ranges
-/// differed would put a conversion between the engines and the residual would
-/// be measuring it.
+/// The same range on both sides, so the model value and the value the fork's
+/// parameter stores are the same number and neither leg converts. Two ranges
+/// would put a conversion between the engines and the residual would measure
+/// it.
 inline magda::ParameterInfo gainParameter(float value = kGainDefault) {
     magda::ParameterInfo info;
     info.paramIndex = kGainParamIndex;
@@ -97,9 +72,7 @@ inline magda::ParameterInfo gainParameter(float value = kGainDefault) {
  * @brief The model device, with its parameter at @p value.
  *
  * `format` is Internal and says so: the block-size gate reads it to decide
- * whether a project has anything to attribute a difference to (#2078), and a
- * stand-in mislabelled as a VST3 would hand the corpus an allowance it has no
- * use for and no right to.
+ * whether a project has anything to attribute a difference to (#2078).
  */
 inline magda::DeviceInfo gainDevice(magda::DeviceId id, float value = kGainDefault) {
     magda::DeviceInfo device;

--- a/tests/NullDiffGain.hpp
+++ b/tests/NullDiffGain.hpp
@@ -1,0 +1,122 @@
+#pragma once
+
+#include <juce_core/juce_core.h>
+
+#include "core/DeviceInfo.hpp"
+#include "core/TypeIds.hpp"
+
+/**
+ * @file NullDiffGain.hpp
+ * @brief The one device both engines run, and the contract that makes its
+ *        renders comparable (#2123).
+ *
+ * The corpus had no device with a parameter until this slice, and could not
+ * have one: a Device op resolved to a stand-in that passed signal through, and
+ * the incumbent instantiated nothing at all. So the whole of #1891 -- the value
+ * lane, automation, the modifier engines, macros at each scope -- had never
+ * been put in front of the fork. A parameter that nothing reads is a parameter
+ * that cannot be compared.
+ *
+ * This is the smallest device that fixes that. One parameter, linear, zero to
+ * one, applied as a gain. Nothing else, and deliberately nothing else: what a
+ * gain device renders is the value of its own parameter, so a case that plays a
+ * constant into it renders the parameter's curve directly and a value wrong in
+ * the fourth decimal is visible. It is the same argument `fades.curves` makes
+ * about a fade.
+ *
+ * ## Why a purpose-built device rather than a real one
+ *
+ * No MAGDA device runs under both engines today, and nothing in this slice
+ * makes one. The engine has no device implementations (#1893 and the device SDK
+ * in #1836 are where they arrive), and the incumbent's live in `PluginManager`
+ * behind the sync layer the corpus refuses to duplicate. A device written for
+ * the corpus, in both legs, from one contract, is what lets the parameter
+ * system be compared before the devices exist. It is the same arrangement the
+ * MIDI capture already uses: a te::Plugin registered in the app's own registry,
+ * hidden from the browser, and its opposite number in the native leg.
+ *
+ * ## What both legs owe
+ *
+ * **The same law.** A gain of `v` multiplies by `v`. No smoothing, no ramp, no
+ * dB anywhere: a smoother is state, state is memory, and two smoothers primed
+ * differently never agree. The device is arithmetic so that a residual is the
+ * parameter rather than the device.
+ *
+ * **The value at the sample being written, on the engine's side.** The engine
+ * resolves a parameter into segments and the device reads the one covering each
+ * sample, which is what keeps a render a function of timeline position rather
+ * than of how the callback was cut up (#2078). The fork settles a parameter at
+ * a block boundary and holds it for the block, because that is what
+ * `AutomatableParameter` does.
+ *
+ * Those two differ, and the corpus does not paper over it: a case is built so
+ * that the material is silent wherever the two could disagree, which is inside
+ * one block of a step. That is the rule this corpus lives by -- choose the
+ * material so that a residual can only be a bug, never the tolerance -- and it
+ * is why every `param.*` case steps its curves on the half beat while its
+ * impulses land on the beat.
+ */
+
+namespace magda::nulldiff {
+
+/// The device's id in the app's internal registry. Registered by the incumbent
+/// leg, hidden from the browser, and only ever inside a test binary.
+inline constexpr const char* kGainPluginId = "nulldiffgain";
+
+/// The one parameter it has. Index zero, because a device reads its own
+/// parameters by the index it declared them at.
+inline constexpr int kGainParamIndex = 0;
+
+/// What the parameter is worth when a case says nothing: unity, so a device
+/// nobody automated, modulated or linked is inaudible.
+inline constexpr float kGainDefault = 1.0f;
+
+/// The model parameter, as both legs read it.
+///
+/// Zero to one, linear, and the same range on the TE side (`teMinValue` /
+/// `teMaxValue`), so the model value and the value the fork's parameter stores
+/// are the same number and neither leg converts. A parameter whose two ranges
+/// differed would put a conversion between the engines and the residual would
+/// be measuring it.
+inline magda::ParameterInfo gainParameter(float value = kGainDefault) {
+    magda::ParameterInfo info;
+    info.paramIndex = kGainParamIndex;
+    info.stableId = "gain";
+    info.name = "Gain";
+    info.minValue = 0.0f;
+    info.maxValue = 1.0f;
+    info.defaultValue = kGainDefault;
+    info.currentValue = value;
+    info.teMinValue = 0.0f;
+    info.teMaxValue = 1.0f;
+    info.scale = magda::ParameterScale::Linear;
+    return info;
+}
+
+/**
+ * @brief The model device, with its parameter at @p value.
+ *
+ * `format` is Internal and says so: the block-size gate reads it to decide
+ * whether a project has anything to attribute a difference to (#2078), and a
+ * stand-in mislabelled as a VST3 would hand the corpus an allowance it has no
+ * use for and no right to.
+ */
+inline magda::DeviceInfo gainDevice(magda::DeviceId id, float value = kGainDefault) {
+    magda::DeviceInfo device;
+    device.id = id;
+    device.name = "Null Diff Gain";
+    device.pluginId = kGainPluginId;
+    device.deviceType = magda::DeviceType::Effect;
+    device.isInstrument = false;
+    device.canReceiveMidi = false;
+    device.format = magda::PluginFormat::Internal;
+    device.parameters.push_back(gainParameter(value));
+    return device;
+}
+
+/// Whether @p device is one of these, asked the way both legs ask it.
+inline bool isGainDevice(const magda::DeviceInfo& device) {
+    return device.pluginId == kGainPluginId;
+}
+
+}  // namespace magda::nulldiff

--- a/tests/NullDiffNativeLeg.cpp
+++ b/tests/NullDiffNativeLeg.cpp
@@ -110,18 +110,12 @@ class Passthrough final : public EngineDevice {
 
 /// The one device the corpus runs under both engines (#2123).
 ///
-/// Multiplies by parameter zero and does nothing else, so what it renders is
-/// the value of its own parameter: a constant played through it draws the
-/// curve automation, a modifier or a macro put on that parameter. See
-/// NullDiffGain.hpp for the contract the incumbent's twin is held to.
+/// Multiplies by parameter zero and nothing else, so what it renders is the
+/// value of its own parameter. NullDiffGain.hpp has the contract.
 ///
-/// Read per sample rather than once at the top of the block. The engine
-/// resolves a parameter into segments precisely so that the audio is a function
-/// of timeline position rather than of how the host cut its callbacks up, and a
-/// device reading only the block's opening value would give that up here and
-/// fail the block-size gate (#2078). The fork holds a parameter for the block
-/// because that is what AutomatableParameter does; where the two could differ,
-/// which is inside one block of a step, the cases play silence.
+/// Read per sample rather than once at the top of the block: a device reading
+/// only the block's opening value would give up the invariance the segments
+/// exist for and fail the block-size gate (#2078).
 class GainDevice final : public EngineDevice {
   public:
     void process(DeviceBlock& block) override {
@@ -148,19 +142,10 @@ class GainDevice final : public EngineDevice {
 
 /// Every device the case declares, by the identity the plan addresses it with.
 ///
-/// Walked from the model rather than carried on the ops, because a Device op
-/// names an identity and the model is what says what stands behind it. Racks
-/// included, so a device inside one is bound the same way a top-level one is.
-///
-/// Keyed by DeviceKey and not by DeviceId, which is the difference between
-/// binding the device the op named and binding one that shares its number. A
-/// device id is unique within a chain segment and not across them (#1899), so
-/// the post-FX chain and the mixer analysis chain each have their own id space:
-/// a map keyed by the number alone would let a post-FX device stand in for the
-/// FX device with the same one, and the executor would hand the plan's gain op
-/// whatever that other device happened to be. The plan is already careful about
-/// this -- OpKey::deviceKey() carries the segment for exactly this reason -- so
-/// the lookup has to be as well.
+/// Keyed by DeviceKey and not by DeviceId: an id is unique within a chain
+/// segment and not across them (#1899), so a map keyed by the number alone
+/// would let a post-FX device stand in for the FX device with the same one.
+/// OpKey::deviceKey() carries the segment for that reason; this has to match.
 void collectDevices(const std::vector<magda::ChainElement>& elements,
                     std::map<DeviceKey, const magda::DeviceInfo*>& out) {
     for (const auto& element : elements) {
@@ -168,8 +153,7 @@ void collectDevices(const std::vector<magda::ChainElement>& elements,
             const auto& device = magda::getDevice(element);
             out[DeviceKey{ChainSegment::Fx, device.id}] = &device;
         } else if (magda::isRack(element)) {
-            // A rack's chains are part of the FX segment: the compiler emits
-            // their devices with the segment the rack itself sits in.
+            // A rack's chains sit in the segment the rack itself does.
             for (const auto& chain : magda::getRack(element).chains)
                 collectDevices(chain.elements, out);
         }
@@ -340,20 +324,11 @@ NativeRender renderNative(const Case& value) {
 
             case OpKind::Device: {
                 // A gain device where the model says the project has one, and a
-                // stand-in everywhere else.
-                //
-                // Transparent is what the incumbent does with the devices it
-                // does not instantiate, which until this slice was all of them:
-                // a stand-in exists because the executor refuses a plan with an
-                // unbound Device op, not because the corpus wants to hear what a
-                // device would do. A stand-in that cleared the buffer would
-                // silence an audio track that merely carries an effect, and the
-                // two legs would differ over a device neither is running.
-                //
-                // The gain device is the exception, and the point of this slice
-                // (#2123): the incumbent really does instantiate its twin, so
-                // both legs run a device with a parameter and the parameter is
-                // what the render is measuring.
+                // stand-in everywhere else. The stand-in exists because the
+                // executor refuses an unbound Device op, and it passes signal
+                // because that is what the incumbent does with a device it does
+                // not instantiate. The gain is the exception the slice is for:
+                // the incumbent really does instantiate its twin.
                 const auto found = modelDevices.find(op.key.deviceKey());
                 const auto* model = found == modelDevices.end() ? nullptr : found->second;
 
@@ -391,28 +366,23 @@ NativeRender renderNative(const Case& value) {
         }
 
     // The op values and the parameter table together, out of one call, so the
-    // two cannot be published out of step (#2117). The lanes are the case's
-    // own: a project with no automation passes an empty span and pays for no
-    // table it would not read.
+    // two cannot be published out of step (#2117).
     PlanValues values;
     for (const auto& diagnostic : resolvePlanValues(plan, value.tracks, value.master, values,
                                                     value.lanes, value.automationClips))
         result.diagnostics.push_back("values: " + diagnostic);
 
-    // What the table itself could not honour: a link naming something the
-    // project does not have, a lane over a target the table does not carry, a
-    // cycle. Nothing is refused for these, so a case with one renders and would
-    // otherwise pass having quietly dropped the very thing it exists to
-    // compare.
+    // What the table could not honour: a link naming something the project does
+    // not have, a lane over a target it does not carry, a cycle. Nothing is
+    // refused for these, so a case with one would otherwise pass having dropped
+    // the thing it exists to compare.
     if (values.params != nullptr)
         for (const auto& diagnostic : values.params->diagnostics)
             result.diagnostics.push_back("params: " + diagnostic);
 
-    // Prepared against that table rather than against none. Without it the
-    // executor sizes no parameter storage and no modifier state, every device
-    // is handed an empty window, and a case built to hear its parameter would
-    // render at whatever the device does with nothing -- which for the gain
-    // device is unity, so the project would sound plausible and assert nothing.
+    // Prepared against that table rather than against none: without it every
+    // device is handed an empty window, and the gain device reads that as
+    // unity, so the project would sound plausible and assert nothing.
     PlanExecutor executor;
     for (const auto& diagnostic :
          executor.prepare(plan, bindings, context, nullptr, values.params.get()))

--- a/tests/NullDiffNativeLeg.cpp
+++ b/tests/NullDiffNativeLeg.cpp
@@ -146,32 +146,44 @@ class GainDevice final : public EngineDevice {
     }
 };
 
-/// Every device the case declares, by the id the plan addresses it with.
+/// Every device the case declares, by the identity the plan addresses it with.
 ///
 /// Walked from the model rather than carried on the ops, because a Device op
 /// names an identity and the model is what says what stands behind it. Racks
 /// included, so a device inside one is bound the same way a top-level one is.
+///
+/// Keyed by DeviceKey and not by DeviceId, which is the difference between
+/// binding the device the op named and binding one that shares its number. A
+/// device id is unique within a chain segment and not across them (#1899), so
+/// the post-FX chain and the mixer analysis chain each have their own id space:
+/// a map keyed by the number alone would let a post-FX device stand in for the
+/// FX device with the same one, and the executor would hand the plan's gain op
+/// whatever that other device happened to be. The plan is already careful about
+/// this -- OpKey::deviceKey() carries the segment for exactly this reason -- so
+/// the lookup has to be as well.
 void collectDevices(const std::vector<magda::ChainElement>& elements,
-                    std::map<DeviceId, const magda::DeviceInfo*>& out) {
+                    std::map<DeviceKey, const magda::DeviceInfo*>& out) {
     for (const auto& element : elements) {
         if (magda::isDevice(element)) {
             const auto& device = magda::getDevice(element);
-            out[device.id] = &device;
+            out[DeviceKey{ChainSegment::Fx, device.id}] = &device;
         } else if (magda::isRack(element)) {
+            // A rack's chains are part of the FX segment: the compiler emits
+            // their devices with the segment the rack itself sits in.
             for (const auto& chain : magda::getRack(element).chains)
                 collectDevices(chain.elements, out);
         }
     }
 }
 
-std::map<DeviceId, const magda::DeviceInfo*> devicesIn(const Case& value) {
-    std::map<DeviceId, const magda::DeviceInfo*> devices;
+std::map<DeviceKey, const magda::DeviceInfo*> devicesIn(const Case& value) {
+    std::map<DeviceKey, const magda::DeviceInfo*> devices;
     for (const auto& track : value.tracks) {
         collectDevices(track.chain.fxChainElements, devices);
         for (const auto& element : track.chain.postFxChainElements)
-            devices[element.device.id] = &element.device;
+            devices[DeviceKey{ChainSegment::PostFx, element.device.id}] = &element.device;
         for (const auto& element : track.chain.mixerAnalysisElements)
-            devices[element.device.id] = &element.device;
+            devices[DeviceKey{ChainSegment::MixerAnalysis, element.device.id}] = &element.device;
     }
     return devices;
 }
@@ -342,7 +354,7 @@ NativeRender renderNative(const Case& value) {
                 // (#2123): the incumbent really does instantiate its twin, so
                 // both legs run a device with a parameter and the parameter is
                 // what the render is measuring.
-                const auto found = modelDevices.find(op.key.deviceId);
+                const auto found = modelDevices.find(op.key.deviceKey());
                 const auto* model = found == modelDevices.end() ? nullptr : found->second;
 
                 if (model != nullptr && isGainDevice(*model)) {

--- a/tests/NullDiffNativeLeg.cpp
+++ b/tests/NullDiffNativeLeg.cpp
@@ -7,6 +7,7 @@
 #include <memory>
 #include <set>
 
+#include "NullDiffGain.hpp"
 #include "clip/ClipAudioSource.hpp"
 #include "clip/ClipMidiSource.hpp"
 #include "clip/ClipSnapshotCompiler.hpp"
@@ -106,6 +107,74 @@ class Passthrough final : public EngineDevice {
   public:
     void process(DeviceBlock&) override {}
 };
+
+/// The one device the corpus runs under both engines (#2123).
+///
+/// Multiplies by parameter zero and does nothing else, so what it renders is
+/// the value of its own parameter: a constant played through it draws the
+/// curve automation, a modifier or a macro put on that parameter. See
+/// NullDiffGain.hpp for the contract the incumbent's twin is held to.
+///
+/// Read per sample rather than once at the top of the block. The engine
+/// resolves a parameter into segments precisely so that the audio is a function
+/// of timeline position rather than of how the host cut its callbacks up, and a
+/// device reading only the block's opening value would give that up here and
+/// fail the block-size gate (#2078). The fork holds a parameter for the block
+/// because that is what AutomatableParameter does; where the two could differ,
+/// which is inside one block of a step, the cases play silence.
+class GainDevice final : public EngineDevice {
+  public:
+    void process(DeviceBlock& block) override {
+        const auto gain = block.params[kGainParamIndex];
+        if (gain.empty())
+            return;
+
+        const auto numSamples = static_cast<int>(block.audio.getNumSamples());
+        const auto numChannels = static_cast<int>(block.audio.getNumChannels());
+
+        if (gain.isConstant()) {
+            block.audio.multiplyBy(gain.value());
+            return;
+        }
+
+        for (auto sample = 0; sample < numSamples; ++sample) {
+            const auto value = gain.valueAt(sample);
+            for (auto channel = 0; channel < numChannels; ++channel)
+                block.audio.setSample(channel, sample,
+                                      block.audio.getSample(channel, sample) * value);
+        }
+    }
+};
+
+/// Every device the case declares, by the id the plan addresses it with.
+///
+/// Walked from the model rather than carried on the ops, because a Device op
+/// names an identity and the model is what says what stands behind it. Racks
+/// included, so a device inside one is bound the same way a top-level one is.
+void collectDevices(const std::vector<magda::ChainElement>& elements,
+                    std::map<DeviceId, const magda::DeviceInfo*>& out) {
+    for (const auto& element : elements) {
+        if (magda::isDevice(element)) {
+            const auto& device = magda::getDevice(element);
+            out[device.id] = &device;
+        } else if (magda::isRack(element)) {
+            for (const auto& chain : magda::getRack(element).chains)
+                collectDevices(chain.elements, out);
+        }
+    }
+}
+
+std::map<DeviceId, const magda::DeviceInfo*> devicesIn(const Case& value) {
+    std::map<DeviceId, const magda::DeviceInfo*> devices;
+    for (const auto& track : value.tracks) {
+        collectDevices(track.chain.fxChainElements, devices);
+        for (const auto& element : track.chain.postFxChainElements)
+            devices[element.device.id] = &element.device;
+        for (const auto& element : track.chain.mixerAnalysisElements)
+            devices[element.device.id] = &element.device;
+    }
+    return devices;
+}
 
 engine::TempoMap tempoMapFor(const Case& value) {
     // Consecutive changes ramp: the tempo travels from one to the next across
@@ -221,6 +290,9 @@ NativeRender renderNative(const Case& value) {
     std::map<TrackId, std::unique_ptr<ClipAudioSource>> audioSources;
     std::map<TrackId, std::unique_ptr<ClipMidiSource>> midiSources;
     std::vector<std::unique_ptr<Passthrough>> passthroughs;
+    std::vector<std::unique_ptr<GainDevice>> gains;
+
+    const auto modelDevices = devicesIn(value);
 
     // The tracks the corpus compares MIDI for, which is the same question the
     // incumbent asks when it decides where to put a capture. Asked once, of the
@@ -255,12 +327,32 @@ NativeRender renderNative(const Case& value) {
             }
 
             case OpKind::Device: {
-                // Transparent, always. A device stand-in exists because the
-                // executor refuses a plan with an unbound Device op, not because
-                // the corpus wants to hear what a device would do, and it no
-                // longer decides anything about where MIDI is observed. The
-                // incumbent instantiates none of the model's devices either, so
-                // passing signal is also what it does.
+                // A gain device where the model says the project has one, and a
+                // stand-in everywhere else.
+                //
+                // Transparent is what the incumbent does with the devices it
+                // does not instantiate, which until this slice was all of them:
+                // a stand-in exists because the executor refuses a plan with an
+                // unbound Device op, not because the corpus wants to hear what a
+                // device would do. A stand-in that cleared the buffer would
+                // silence an audio track that merely carries an effect, and the
+                // two legs would differ over a device neither is running.
+                //
+                // The gain device is the exception, and the point of this slice
+                // (#2123): the incumbent really does instantiate its twin, so
+                // both legs run a device with a parameter and the parameter is
+                // what the render is measuring.
+                const auto found = modelDevices.find(op.key.deviceId);
+                const auto* model = found == modelDevices.end() ? nullptr : found->second;
+
+                if (model != nullptr && isGainDevice(*model)) {
+                    auto device = std::make_unique<GainDevice>();
+                    device->prepare(context);
+                    bindings.devices[op.key.deviceKey()] = device.get();
+                    gains.push_back(std::move(device));
+                    break;
+                }
+
                 auto device = std::make_unique<Passthrough>();
                 device->prepare(context);
                 bindings.devices[op.key.deviceKey()] = device.get();
@@ -286,12 +378,32 @@ NativeRender renderNative(const Case& value) {
             taps[trackId] = std::move(tap);
         }
 
+    // The op values and the parameter table together, out of one call, so the
+    // two cannot be published out of step (#2117). The lanes are the case's
+    // own: a project with no automation passes an empty span and pays for no
+    // table it would not read.
     PlanValues values;
-    for (const auto& diagnostic : resolvePlanValues(plan, value.tracks, value.master, values))
+    for (const auto& diagnostic : resolvePlanValues(plan, value.tracks, value.master, values,
+                                                    value.lanes, value.automationClips))
         result.diagnostics.push_back("values: " + diagnostic);
 
+    // What the table itself could not honour: a link naming something the
+    // project does not have, a lane over a target the table does not carry, a
+    // cycle. Nothing is refused for these, so a case with one renders and would
+    // otherwise pass having quietly dropped the very thing it exists to
+    // compare.
+    if (values.params != nullptr)
+        for (const auto& diagnostic : values.params->diagnostics)
+            result.diagnostics.push_back("params: " + diagnostic);
+
+    // Prepared against that table rather than against none. Without it the
+    // executor sizes no parameter storage and no modifier state, every device
+    // is handed an empty window, and a case built to hear its parameter would
+    // render at whatever the device does with nothing -- which for the gain
+    // device is unity, so the project would sound plausible and assert nothing.
     PlanExecutor executor;
-    for (const auto& diagnostic : executor.prepare(plan, bindings, context))
+    for (const auto& diagnostic :
+         executor.prepare(plan, bindings, context, nullptr, values.params.get()))
         result.diagnostics.push_back("prepare: " + diagnostic);
 
     if (!executor.isPrepared()) {

--- a/tests/NullDiffTeLeg.cpp
+++ b/tests/NullDiffTeLeg.cpp
@@ -5,16 +5,24 @@
 
 #include <algorithm>
 #include <cmath>
+#include <functional>
+#include <map>
 #include <memory>
 #include <vector>
 
+#include "NullDiffGain.hpp"
 #include "SharedTestEngine.hpp"
 #include "magda/daw/audio/TrackController.hpp"
 #include "magda/daw/audio/WarpMarkerManager.hpp"
+#include "magda/daw/audio/automation/AutomationBake.hpp"
+#include "magda/daw/audio/modifiers/ModifierSync.hpp"
 #include "magda/daw/audio/plugins/InternalPluginRegistry.hpp"
 #include "magda/daw/audio/plugins/tracktion/TracktionInternalPluginAdapter.hpp"
 #include "magda/daw/audio/session/ClipSynchronizer.hpp"
+#include "magda/daw/core/AutomationCurve.hpp"
+#include "magda/daw/core/ChainNode.hpp"
 #include "magda/daw/core/ClipManager.hpp"
+#include "magda/daw/core/ParameterUtils.hpp"
 #include "magda/daw/engine/OfflineRenderHelper.hpp"
 #include "magda/daw/project/ProjectManager.hpp"
 #include "plan/PlanCompiler.hpp"
@@ -148,6 +156,181 @@ void registerCaptureDevice(magda::daw::audio::InternalPluginRegistry& registry) 
 }
 
 const bool captureDeviceRegistered = magda::daw::audio::registerDevicePack(registerCaptureDevice);
+
+// =============================================================================
+// The device with a parameter (#2123)
+// =============================================================================
+
+/// The property the gain's value is stored under, and the one the parameter is
+/// attached to. Its own name rather than one of TE's IDs, because nothing else
+/// in the Edit means the same thing by it.
+const juce::Identifier kGainProperty("nulldiffGain");
+
+/// The incumbent's half of the contract in NullDiffGain.hpp.
+///
+/// One parameter, applied as a plain multiply. No smoothing and no ramp: a
+/// smoother is state, state is memory, and two smoothers primed differently
+/// never agree, so a residual would be measuring the device rather than the
+/// parameter.
+///
+/// The value is read once, at the top of the block, which is what an
+/// AutomatableParameter is: TE settles every parameter from its automation and
+/// its modifiers before the graph runs and holds it for the block. The engine's
+/// twin reads per sample instead. Where the two could differ, which is inside
+/// one block of a step, the cases play silence.
+class GainPlugin final : public te::Plugin {
+  public:
+    explicit GainPlugin(te::PluginCreationInfo info) : te::Plugin(info) {
+        auto* undo = getUndoManager();
+        value_.referTo(state, kGainProperty, undo, kGainDefault);
+
+        gain = addParam(
+            "gain", "Gain", {0.0f, 1.0f}, [](float value) { return juce::String(value, 4); },
+            [](const juce::String& text) { return text.getFloatValue(); });
+        gain->attachToCurrentValue(value_);
+    }
+
+    ~GainPlugin() override {
+        notifyListenersOfDeletion();
+        if (gain != nullptr)
+            gain->detachFromCurrentValue();
+    }
+
+    static const char* getPluginName() {
+        return "Null Diff Gain";
+    }
+
+    juce::String getName() const override {
+        return getPluginName();
+    }
+    juce::String getPluginType() override {
+        return kGainPluginId;
+    }
+    juce::String getShortName(int) override {
+        return "NDGain";
+    }
+    juce::String getSelectableDescription() override {
+        return getName();
+    }
+
+    bool takesAudioInput() override {
+        return true;
+    }
+    bool takesMidiInput() override {
+        return false;
+    }
+    bool producesAudioWhenNoAudioInput() override {
+        return false;
+    }
+    bool canBeAddedToClip() override {
+        return false;
+    }
+    bool needsConstantBufferSize() override {
+        return false;
+    }
+
+    void initialise(const te::PluginInitialisationInfo&) override {}
+    void deinitialise() override {}
+
+    void applyToBuffer(const te::PluginRenderContext& context) override {
+        if (context.destBuffer == nullptr)
+            return;
+
+        context.destBuffer->applyGain(context.bufferStartSample, context.bufferNumSamples,
+                                      gain->getCurrentValue());
+    }
+
+    void restorePluginStateFromValueTree(const juce::ValueTree& tree) override {
+        te::copyPropertiesToCachedValues(tree, value_);
+    }
+
+    te::AutomatableParameter* gain = nullptr;
+
+  private:
+    juce::CachedValue<float> value_;
+};
+
+void registerGainDevice(magda::daw::audio::InternalPluginRegistry& registry) {
+    magda::daw::audio::InternalPluginSpec spec;
+    spec.pluginId = kGainPluginId;
+    spec.displayName = GainPlugin::getPluginName();
+    spec.browserCategory = "Utility";
+    spec.description = "A gain with one parameter, for the null-diff corpus.";
+    spec.createMode = magda::daw::audio::InternalPluginCreateMode::FreshValueTree;
+    spec.canCreateDetached = false;
+    spec.canCreateOnTrack = false;
+    spec.showInBrowser = false;
+    spec.matchesPlugin = [](magda::daw::audio::DevicePluginRef plugin) {
+        return dynamic_cast<GainPlugin*>(
+                   magda::daw::audio::tracktion_adapter::pluginFromRef(plugin)) != nullptr;
+    };
+    spec.createPlugin = [](const magda::daw::audio::DevicePluginCreationContext& context) {
+        return magda::daw::audio::tracktion_adapter::pluginHandle(
+            new GainPlugin(magda::daw::audio::tracktion_adapter::creationInfo(context)));
+    };
+
+    registry.registerPlugin(spec);
+}
+
+const bool gainDeviceRegistered = magda::daw::audio::registerDevicePack(registerGainDevice);
+
+/// Where a link's target lives, for the walker that wires modifiers and macros.
+///
+/// The app's own lookup is PluginManager's, which resolves any device anywhere
+/// in the chain hierarchy. This resolves the only devices this leg installs, by
+/// the id their path names. It is a lookup rather than a sync: the wiring is
+/// still ModifierSyncWalker's, which is the point -- a second walker written
+/// for the harness would be a harness agreeing with itself about what a
+/// modifier does.
+class GainPluginLookup final : public magda::TargetPluginLookup {
+  public:
+    void add(magda::DeviceId id, te::Plugin* plugin) {
+        plugins_[id] = plugin;
+    }
+
+    te::Plugin* getPlugin(const magda::ChainNodePath& path) const override {
+        const auto found = plugins_.find(path.getDeviceId());
+        return found == plugins_.end() ? nullptr : found->second;
+    }
+
+  private:
+    std::map<magda::DeviceId, te::Plugin*> plugins_;
+};
+
+/// Everything one scope's modifiers and macros need to live in, for as long as
+/// the Edit does.
+///
+/// The walker writes into references it is handed, because in the app these
+/// live on PluginManager's synced-device records. Here they live for the length
+/// of a render, and they are torn down before the Edit is: a macro parameter
+/// outliving its list, or a modifier outliving the track it was inserted on, is
+/// a crash in TE's own bookkeeping rather than a leak.
+struct ScopeModifiers {
+    std::map<magda::ModId, te::Modifier::Ptr> modifiers;
+    std::map<magda::ModId, std::unique_ptr<magda::CurveSnapshotHolder>> curveSnapshots;
+    std::map<int, te::MacroParameter*> macroParams;
+
+    magda::ModifierSyncState state() {
+        return magda::ModifierSyncState{modifiers, curveSnapshots, macroParams};
+    }
+};
+
+/// Whether anything in @p node is worth building TE state for. A track with the
+/// default sixteen empty macros and no modifiers gets none, which keeps every
+/// case that is not about modulation exactly as it was.
+bool carriesModulation(const magda::ConstChainNode& node) {
+    if (node.mods != nullptr)
+        for (const auto& mod : *node.mods)
+            if (mod.enabled && mod.isLinked())
+                return true;
+
+    if (node.macros != nullptr)
+        for (const auto& macro : *node.macros)
+            if (macro.isLinked())
+                return true;
+
+    return false;
+}
 
 void pumpMessageThread(int milliseconds) {
     if (auto* manager = juce::MessageManager::getInstanceWithoutCreating())
@@ -283,6 +466,255 @@ IncumbentRender renderIncumbent(const Case& value) {
         const auto volume = value.master.muted ? 0.0f : value.master.volume;
         masterPlugin->setVolumeDb(volume > 0.0f ? juce::Decibels::gainToDecibels(volume) : -100.0f);
         masterPlugin->setPan(value.master.pan);
+    }
+
+    // --- the device with a parameter -----------------------------------------
+    //
+    // One GainPlugin per model gain device, in chain order, at the head of the
+    // track's plugin list so it sits where the plan puts its Device op: ahead
+    // of the fader, behind nothing. The corpus installs no other device, and
+    // every other device in the model is still a thing neither leg runs.
+    //
+    // This is the first case of the corpus running a device under both engines
+    // at all (#2123). Until it did, every parameter, every curve, every
+    // modifier and every macro in #1891 had been judged only by tests written
+    // beside them.
+
+    GainPluginLookup lookup;
+    std::map<DeviceId, GainPlugin*> gains;
+
+    for (const auto& track : value.tracks) {
+        auto* audioTrack = trackController.getAudioTrack(track.id);
+        if (audioTrack == nullptr)
+            continue;
+
+        auto slot = 0;
+        for (const auto& element : track.chain.fxChainElements) {
+            if (!magda::isDevice(element))
+                continue;
+
+            const auto& device = magda::getDevice(element);
+            if (!isGainDevice(device))
+                continue;
+
+            juce::ValueTree state(te::IDs::PLUGIN);
+            state.setProperty(te::IDs::type, kGainPluginId, nullptr);
+
+            auto plugin = edit->getPluginCache().createNewPlugin(state);
+            auto* gain = dynamic_cast<GainPlugin*>(plugin.get());
+            if (gain == nullptr) {
+                result.failure = "the gain device could not be created";
+                ClipManager::getInstance().clearAllClips();
+                ProjectManager::getInstance().setTempo(previousTempo);
+                return result;
+            }
+
+            audioTrack->pluginList.insertPlugin(plugin, slot++, nullptr);
+
+            lookup.add(device.id, plugin.get());
+            gains[device.id] = gain;
+        }
+    }
+
+    // Where the modulation this render builds lives, and what unwinds it.
+    //
+    // Declared here, ahead of both sections that fill them, because the order
+    // they are destroyed in is load bearing. The unwinder's teardown reaches
+    // into the scope maps, so it has to run while they are still alive, and
+    // every one of them has to be gone before the Edit is: a macro parameter
+    // destroyed while its list is already tearing down, or one holding a
+    // populated curve, unwinds TE's per-edit-element bookkeeping in the wrong
+    // order. The app's playback engine clears its own baked curves in its
+    // destructor for the same reason.
+    //
+    // A guard rather than a pair of loops at the end, because this function has
+    // an exit that does not reach the end: a proxy that never arrives returns
+    // from the middle of the wait below.
+    std::map<TrackId, ScopeModifiers> trackModulation;
+    std::map<DeviceId, ScopeModifiers> deviceModulation;
+    std::vector<std::unique_ptr<magda::CurveSnapshotHolder>> deferredHolders;
+
+    struct Unwind {
+        std::vector<te::AutomatableParameter*> bakedParams;
+        std::vector<std::function<void()>> modulation;
+
+        ~Unwind() {
+            for (auto* param : bakedParams) {
+                param->getCurve().clear(nullptr);
+                param->updateStream();
+            }
+            for (auto& tearDown : modulation)
+                tearDown();
+        }
+    } unwind;
+
+    auto& bakedParams = unwind.bakedParams;
+    auto& tearDownModulation = unwind.modulation;
+
+    // --- automation ----------------------------------------------------------
+    //
+    // Baked into the fork's own curve on the parameter the lane names, through
+    // the same emission the app's playback engine uses (AutomationBake.hpp): a
+    // second bake written here would be a corpus agreeing with itself about
+    // what a step or a bezier means.
+    //
+    // Device parameters only. Every other target -- a fader, a send, a macro,
+    // a modifier's rate -- resolves through ControlTargetResolver, which wants
+    // a PluginManager and the device layer behind it, and that is the second
+    // sync this corpus refuses to have. It is the same boundary sends stop at,
+    // and it moves with #1892.
+
+    for (const auto& lane : value.lanes) {
+        if (lane.target.kind != ControlTarget::Kind::PluginParam) {
+            result.failure = "a lane plays over a target this leg cannot resolve";
+            ClipManager::getInstance().clearAllClips();
+            ProjectManager::getInstance().setTempo(previousTempo);
+            return result;
+        }
+
+        const auto found = gains.find(lane.target.devicePath.getDeviceId());
+        if (found == gains.end() || lane.target.paramIndex != kGainParamIndex) {
+            result.failure = "a lane plays over a parameter this project does not have";
+            ClipManager::getInstance().clearAllClips();
+            ProjectManager::getInstance().setTempo(previousTempo);
+            return result;
+        }
+
+        auto* param = found->second->gain;
+        auto& curve = param->getCurve();
+        curve.clear(nullptr);
+
+        const auto getClip = [&](AutomationClipId clipId) -> const AutomationClipInfo* {
+            for (const auto& clip : value.automationClips)
+                if (clip.id == clipId)
+                    return &clip;
+            return nullptr;
+        };
+
+        // The gain parameter is zero to one on both sides, so a lane's
+        // normalised position is already what the parameter stores and neither
+        // leg converts. See NullDiffGain.hpp for why that is the contract
+        // rather than a convenience.
+        bakeLaneIntoCurve(
+            curve, lane, getClip,
+            [&](double beat) { return magda::automation::laneValueAtBeat(lane, getClip, beat); },
+            [](double normalized) { return juce::jlimit(0.0f, 1.0f, (float)normalized); });
+
+        param->updateStream();
+        bakedParams.push_back(param);
+    }
+
+    // --- modifiers and macros ------------------------------------------------
+    //
+    // The app's own walker, at the two scopes a track can carry without a rack:
+    // the track itself, and each top-level device. Both take the track's
+    // modifier list and the track's macro list, which is exactly what
+    // PluginManager::syncDeviceModifiers hands them for a non-instrument
+    // device.
+    //
+    // Rack scope is the third the model has and is not here. A rack's
+    // modifiers and macros live on a te::RackType that RackSyncManager builds
+    // out of a PluginManager, so wiring one up would be the second sync the
+    // corpus refuses; it moves with the rest of the routing graph in #1892.
+    for (const auto& track : value.tracks) {
+        auto* audioTrack = trackController.getAudioTrack(track.id);
+        if (audioTrack == nullptr)
+            continue;
+
+        auto* modifierList = audioTrack->getModifierList();
+        auto* macroList = &audioTrack->getMacroParameterListForWriting();
+
+        // Every plugin the walker may have to scrub a stale assignment off.
+        const auto forEachPlugin = [audioTrack](const std::function<void(te::Plugin*)>& visit) {
+            for (auto* plugin : audioTrack->pluginList)
+                visit(plugin);
+        };
+
+        const auto sync = [&](magda::ConstChainNode node, ScopeModifiers& scope) {
+            magda::ModifierSyncContext ctx;
+            ctx.modifierList = modifierList;
+            ctx.macroList = macroList;
+            ctx.lookup = &lookup;
+            ctx.forEachScopePlugin = forEachPlugin;
+            ctx.hasCrossTrackSidechain = false;
+
+            auto state = scope.state();
+            magda::ModifierSyncWalker::syncStructure(node, ctx, state, deferredHolders);
+
+            // Torn down through the same walker, handed a node with nothing on
+            // it, which is the path a bypassed device already takes. The macro
+            // parameters and the modifiers have to be gone before the Edit is:
+            // a macro outliving its list unwinds TE's own bookkeeping in the
+            // wrong order, which the app's playback engine had to learn too.
+            tearDownModulation.emplace_back([&scope, ctx, this_node = node]() mutable {
+                this_node.mods = nullptr;
+                this_node.macros = nullptr;
+                std::vector<std::unique_ptr<magda::CurveSnapshotHolder>> discarded;
+                auto state = scope.state();
+                magda::ModifierSyncWalker::syncStructure(this_node, ctx, state, discarded);
+            });
+        };
+
+        magda::ConstChainNode trackNode;
+        trackNode.scope = magda::ChainScope::Track;
+        trackNode.trackId = track.id;
+        trackNode.mods = &track.mods;
+        trackNode.macros = &track.macros;
+
+        if (carriesModulation(trackNode))
+            sync(trackNode, trackModulation[track.id]);
+
+        for (const auto& element : track.chain.fxChainElements) {
+            if (!magda::isDevice(element))
+                continue;
+
+            const auto& device = magda::getDevice(element);
+
+            magda::ConstChainNode deviceNode;
+            deviceNode.scope = magda::ChainScope::Device;
+            deviceNode.trackId = track.id;
+            deviceNode.deviceId = device.id;
+            deviceNode.mods = &device.mods;
+            deviceNode.macros = &device.macros;
+            deviceNode.params = &device.parameters;
+
+            if (carriesModulation(deviceNode))
+                sync(deviceNode, deviceModulation[device.id]);
+        }
+    }
+
+    // --- the host write ------------------------------------------------------
+    //
+    // Last, and that ordering is the case rather than an implementation detail.
+    // A stored value is what a knob move, a control surface, a preset load or a
+    // restored project sets, and every one of those arrives at a parameter that
+    // already has whatever automation and modifiers the project gave it. Writing
+    // it before the modifier was attached would be writing to a parameter
+    // nothing was modulating, which is the one arrangement where the bug this
+    // asserts against cannot happen.
+    //
+    // setParameterFromHost rather than setParameter, because that is the rule
+    // for a host write and this leg is the app's paths rather than a second set
+    // of them. What it is not is what makes the host-write cases pass: the
+    // fork's guard is a runtime condition (setParameter returns early only
+    // while currentModifierValue is non-zero), so a write made before the
+    // render starts goes through either call. The corpus was run both ways to
+    // find that out, and the case's own comment says what it does and does not
+    // therefore pin.
+    for (const auto& track : value.tracks) {
+        for (const auto& element : track.chain.fxChainElements) {
+            if (!magda::isDevice(element))
+                continue;
+
+            const auto& device = magda::getDevice(element);
+            const auto found = gains.find(device.id);
+            if (found == gains.end())
+                continue;
+
+            const auto* info = device.parameters.empty() ? nullptr : &device.parameters.front();
+            found->second->gain->setParameterFromHost(
+                info == nullptr ? kGainDefault : info->currentValue, juce::dontSendNotification);
+        }
     }
 
     // The capture devices, where the plan on the other side has them. Inserted

--- a/tests/NullDiffTeLeg.cpp
+++ b/tests/NullDiffTeLeg.cpp
@@ -161,23 +161,14 @@ const bool captureDeviceRegistered = magda::daw::audio::registerDevicePack(regis
 // The device with a parameter (#2123)
 // =============================================================================
 
-/// The property the gain's value is stored under, and the one the parameter is
-/// attached to. Its own name rather than one of TE's IDs, because nothing else
-/// in the Edit means the same thing by it.
+/// The property the gain's value is stored under.
 const juce::Identifier kGainProperty("nulldiffGain");
 
 /// The incumbent's half of the contract in NullDiffGain.hpp.
 ///
-/// One parameter, applied as a plain multiply. No smoothing and no ramp: a
-/// smoother is state, state is memory, and two smoothers primed differently
-/// never agree, so a residual would be measuring the device rather than the
-/// parameter.
-///
-/// The value is read once, at the top of the block, which is what an
-/// AutomatableParameter is: TE settles every parameter from its automation and
-/// its modifiers before the graph runs and holds it for the block. The engine's
-/// twin reads per sample instead. Where the two could differ, which is inside
-/// one block of a step, the cases play silence.
+/// One parameter, a plain multiply, no smoothing. The value is read once at the
+/// top of the block, which is what an AutomatableParameter is; the engine's twin
+/// reads per sample, and the cases play silence wherever that could differ.
 class GainPlugin final : public te::Plugin {
   public:
     explicit GainPlugin(te::PluginCreationInfo info) : te::Plugin(info) {
@@ -276,21 +267,13 @@ const bool gainDeviceRegistered = magda::daw::audio::registerDevicePack(register
 
 /// Where a link's target lives, for the walker that wires modifiers and macros.
 ///
-/// The app's own lookup is PluginManager's, which resolves any device anywhere
-/// in the chain hierarchy. This resolves the only devices this leg installs. It
-/// is a lookup rather than a sync: the wiring is still ModifierSyncWalker's,
-/// which is the point -- a second walker written for the harness would be a
-/// harness agreeing with itself about what a modifier does.
+/// A lookup rather than a sync: the wiring is still ModifierSyncWalker's, which
+/// is the point. The app's own lookup is PluginManager's; this resolves the
+/// only devices this leg installs.
 ///
-/// Keyed by the whole path and not by the device id in it. A device id is
-/// unique within a chain segment rather than across the hierarchy (#1899), so
-/// a link naming a rack-inner or post-FX device could carry the same number as
-/// a top-level one; matching on the number would wire the modifier onto the
-/// plugin this leg happens to have installed and then compare a project against
-/// a differently connected one. Matching on the path returns nullptr instead,
-/// which is what the walker already does something sensible with: the link is
-/// dropped, the native leg's table reports it as a target the project does not
-/// have, and the runner refuses the case rather than certifying it.
+/// Keyed by the whole path, not by the device id in it. An id is unique within
+/// a chain segment and not across the hierarchy (#1899), so matching on the
+/// number would wire a rack-inner or post-FX target onto the top-level plugin.
 class GainPluginLookup final : public magda::TargetPluginLookup {
   public:
     void add(const magda::ChainNodePath& path, te::Plugin* plugin) {
@@ -306,14 +289,9 @@ class GainPluginLookup final : public magda::TargetPluginLookup {
     std::map<magda::ChainNodePath, te::Plugin*> plugins_;
 };
 
-/// Everything one scope's modifiers and macros need to live in, for as long as
-/// the Edit does.
-///
-/// The walker writes into references it is handed, because in the app these
-/// live on PluginManager's synced-device records. Here they live for the length
-/// of a render, and they are torn down before the Edit is: a macro parameter
-/// outliving its list, or a modifier outliving the track it was inserted on, is
-/// a crash in TE's own bookkeeping rather than a leak.
+/// Where one scope's modifiers and macros live. The walker writes into
+/// references it is handed; in the app these sit on PluginManager's synced
+/// device records, here they last the length of a render.
 struct ScopeModifiers {
     std::map<magda::ModId, te::Modifier::Ptr> modifiers;
     std::map<magda::ModId, std::unique_ptr<magda::CurveSnapshotHolder>> curveSnapshots;
@@ -324,9 +302,8 @@ struct ScopeModifiers {
     }
 };
 
-/// Whether anything in @p node is worth building TE state for. A track with the
-/// default sixteen empty macros and no modifiers gets none, which keeps every
-/// case that is not about modulation exactly as it was.
+/// Whether @p node is worth building TE state for. A track with the default
+/// sixteen empty macros and no modifiers gets none.
 bool carriesModulation(const magda::ConstChainNode& node) {
     if (node.mods != nullptr)
         for (const auto& mod : *node.mods)
@@ -480,14 +457,9 @@ IncumbentRender renderIncumbent(const Case& value) {
     // --- the device with a parameter -----------------------------------------
     //
     // One GainPlugin per model gain device, in chain order, at the head of the
-    // track's plugin list so it sits where the plan puts its Device op: ahead
-    // of the fader, behind nothing. The corpus installs no other device, and
-    // every other device in the model is still a thing neither leg runs.
-    //
-    // This is the first case of the corpus running a device under both engines
-    // at all (#2123). Until it did, every parameter, every curve, every
-    // modifier and every macro in #1891 had been judged only by tests written
-    // beside them.
+    // track's plugin list so it sits where the plan puts its Device op. The
+    // first device the corpus runs under both engines at all (#2123); every
+    // other device in the model is still a thing neither leg runs.
 
     GainPluginLookup lookup;
     std::map<ChainNodePath, GainPlugin*> gains;
@@ -530,20 +502,16 @@ IncumbentRender renderIncumbent(const Case& value) {
 
     // Where the modulation this render builds lives, and what unwinds it.
     //
-    // Declared here, ahead of both sections that fill them, because the order
-    // they are destroyed in is load bearing. The unwinder's teardown reaches
-    // into the scope maps, so it has to run while they are still alive, and
-    // every one of them has to be gone before the Edit is: a macro parameter
-    // destroyed while its list is already tearing down, or one holding a
-    // populated curve, unwinds TE's per-edit-element bookkeeping in the wrong
-    // order. The app's playback engine clears its own baked curves in its
-    // destructor for the same reason.
+    // Declared ahead of both sections that fill them because destruction order
+    // is load bearing: the teardown reaches into the scope maps, and everything
+    // has to be gone before the Edit is. A macro destroyed while its list is
+    // already tearing down, or one holding a populated curve, unwinds TE's
+    // bookkeeping in the wrong order.
     //
-    // A guard rather than a pair of loops at the end, because this function has
-    // an exit that does not reach the end: a proxy that never arrives returns
-    // from the middle of the wait below.
+    // A guard rather than loops at the end, because a proxy that never arrives
+    // returns from the middle of the wait below.
     std::map<TrackId, ScopeModifiers> trackModulation;
-    std::map<DeviceId, ScopeModifiers> deviceModulation;
+    std::map<ChainNodePath, ScopeModifiers> deviceModulation;
     std::vector<std::unique_ptr<magda::CurveSnapshotHolder>> deferredHolders;
 
     struct Unwind {
@@ -565,16 +533,13 @@ IncumbentRender renderIncumbent(const Case& value) {
 
     // --- automation ----------------------------------------------------------
     //
-    // Baked into the fork's own curve on the parameter the lane names, through
-    // the same emission the app's playback engine uses (AutomationBake.hpp): a
-    // second bake written here would be a corpus agreeing with itself about
-    // what a step or a bezier means.
+    // Baked through the same emission the app's playback engine uses
+    // (AutomationBake.hpp): a second bake here would be a corpus agreeing with
+    // itself about what a step means.
     //
-    // Device parameters only. Every other target -- a fader, a send, a macro,
-    // a modifier's rate -- resolves through ControlTargetResolver, which wants
-    // a PluginManager and the device layer behind it, and that is the second
-    // sync this corpus refuses to have. It is the same boundary sends stop at,
-    // and it moves with #1892.
+    // Device parameters only. Every other target resolves through
+    // ControlTargetResolver, which wants a PluginManager -- the second sync
+    // this corpus refuses, and the boundary sends stop at too (#1892).
 
     for (const auto& lane : value.lanes) {
         if (lane.target.kind != ControlTarget::Kind::PluginParam) {
@@ -603,10 +568,8 @@ IncumbentRender renderIncumbent(const Case& value) {
             return nullptr;
         };
 
-        // The gain parameter is zero to one on both sides, so a lane's
-        // normalised position is already what the parameter stores and neither
-        // leg converts. See NullDiffGain.hpp for why that is the contract
-        // rather than a convenience.
+        // Zero to one on both sides, so the lane's normalised position is
+        // already what the parameter stores (NullDiffGain.hpp).
         bakeLaneIntoCurve(
             curve, lane, getClip,
             [&](double beat) { return magda::automation::laneValueAtBeat(lane, getClip, beat); },
@@ -619,15 +582,60 @@ IncumbentRender renderIncumbent(const Case& value) {
     // --- modifiers and macros ------------------------------------------------
     //
     // The app's own walker, at the two scopes a track can carry without a rack:
-    // the track itself, and each top-level device. Both take the track's
-    // modifier list and the track's macro list, which is exactly what
+    // the track itself and each top-level device. Both take the track's
+    // modifier and macro lists, which is what
     // PluginManager::syncDeviceModifiers hands them for a non-instrument
-    // device.
-    //
-    // Rack scope is the third the model has and is not here. A rack's
-    // modifiers and macros live on a te::RackType that RackSyncManager builds
-    // out of a PluginManager, so wiring one up would be the second sync the
-    // corpus refuses; it moves with the rest of the routing graph in #1892.
+    // device. Rack scope needs a te::RackType only RackSyncManager builds, so
+    // it is refused below rather than skipped (#1892).
+    // What the walker would drop in silence, refused out loud first: it wires
+    // nothing for a target this leg has no plugin for, while the native table
+    // resolves it and modulates. That is a modulated render compared against an
+    // unmodulated one, and where the target is inaudible it is a false null.
+    const auto unwirable = [&](const ControlTarget& target,
+                               const magda::ModArray& scopeMods) -> std::string {
+        switch (target.kind) {
+            case ControlTarget::Kind::PluginParam:
+                if (gains.count(target.devicePath) == 0)
+                    return "a device this leg does not install: " +
+                           target.devicePath.toString().toStdString();
+                return {};
+
+            case ControlTarget::Kind::ModParam:
+                // Same scope only, which is the walker's own rule.
+                for (const auto& mod : scopeMods)
+                    if (mod.id == target.modId)
+                        return {};
+                return "a modifier outside the scope the link lives in";
+
+            default:
+                // A fader, a send, a macro. The native table carries the first
+                // two; the walker wires none of them.
+                return std::string("a ") + magda::toString(target.kind) +
+                       " target, which this leg cannot wire";
+        }
+    };
+
+    const auto refuseUnwirableLinks = [&](const magda::ConstChainNode& node) -> std::string {
+        if (node.mods != nullptr)
+            for (const auto& mod : *node.mods)
+                if (mod.enabled)
+                    for (const auto& link : mod.links)
+                        if (link.enabled && link.isValid())
+                            if (auto why = unwirable(link.target, *node.mods); !why.empty())
+                                return "a modifier links to " + why;
+
+        if (node.macros != nullptr)
+            for (const auto& macro : *node.macros)
+                for (const auto& link : macro.links)
+                    if (link.target.isValid())
+                        if (auto why = unwirable(
+                                link.target, node.mods == nullptr ? magda::ModArray{} : *node.mods);
+                            !why.empty())
+                            return "a macro links to " + why;
+
+        return {};
+    };
+
     for (const auto& track : value.tracks) {
         auto* audioTrack = trackController.getAudioTrack(track.id);
         if (audioTrack == nullptr)
@@ -653,11 +661,8 @@ IncumbentRender renderIncumbent(const Case& value) {
             auto state = scope.state();
             magda::ModifierSyncWalker::syncStructure(node, ctx, state, deferredHolders);
 
-            // Torn down through the same walker, handed a node with nothing on
-            // it, which is the path a bypassed device already takes. The macro
-            // parameters and the modifiers have to be gone before the Edit is:
-            // a macro outliving its list unwinds TE's own bookkeeping in the
-            // wrong order, which the app's playback engine had to learn too.
+            // Torn down through the same walker handed an empty node, which
+            // is the path a bypassed device already takes.
             tearDownModulation.emplace_back([&scope, ctx, this_node = node]() mutable {
                 this_node.mods = nullptr;
                 this_node.macros = nullptr;
@@ -667,14 +672,43 @@ IncumbentRender renderIncumbent(const Case& value) {
             });
         };
 
+        const auto refuse = [&](const std::string& why) {
+            result.failure = why;
+            ClipManager::getInstance().clearAllClips();
+            ProjectManager::getInstance().setTempo(previousTempo);
+        };
+
         magda::ConstChainNode trackNode;
         trackNode.scope = magda::ChainScope::Track;
         trackNode.trackId = track.id;
         trackNode.mods = &track.mods;
         trackNode.macros = &track.macros;
 
-        if (carriesModulation(trackNode))
+        if (carriesModulation(trackNode)) {
+            if (auto why = refuseUnwirableLinks(trackNode); !why.empty()) {
+                refuse(why);
+                return result;
+            }
             sync(trackNode, trackModulation[track.id]);
+        }
+
+        // A rack's own modifiers and macros need a te::RackType this leg does
+        // not build (#1892). Refused rather than skipped.
+        for (const auto& element : track.chain.fxChainElements) {
+            if (!magda::isRack(element))
+                continue;
+
+            const auto& rack = magda::getRack(element);
+            magda::ConstChainNode rackNode;
+            rackNode.scope = magda::ChainScope::Rack;
+            rackNode.mods = &rack.mods;
+            rackNode.macros = &rack.macros;
+
+            if (carriesModulation(rackNode)) {
+                refuse("a rack carries modulation, which this leg cannot sync");
+                return result;
+            }
+        }
 
         for (const auto& element : track.chain.fxChainElements) {
             if (!magda::isDevice(element))
@@ -690,29 +724,26 @@ IncumbentRender renderIncumbent(const Case& value) {
             deviceNode.macros = &device.macros;
             deviceNode.params = &device.parameters;
 
-            if (carriesModulation(deviceNode))
-                sync(deviceNode, deviceModulation[device.id]);
+            if (carriesModulation(deviceNode)) {
+                if (auto why = refuseUnwirableLinks(deviceNode); !why.empty()) {
+                    refuse(why);
+                    return result;
+                }
+                sync(deviceNode,
+                     deviceModulation[ChainNodePath::topLevelDevice(track.id, device.id)]);
+            }
         }
     }
 
     // --- the host write ------------------------------------------------------
     //
-    // Last, and that ordering is the case rather than an implementation detail.
-    // A stored value is what a knob move, a control surface, a preset load or a
-    // restored project sets, and every one of those arrives at a parameter that
-    // already has whatever automation and modifiers the project gave it. Writing
-    // it before the modifier was attached would be writing to a parameter
-    // nothing was modulating, which is the one arrangement where the bug this
-    // asserts against cannot happen.
+    // Last, and the ordering is the case rather than a detail: a stored value
+    // arrives at a parameter that already has whatever the project gave it.
     //
-    // setParameterFromHost rather than setParameter, because that is the rule
-    // for a host write and this leg is the app's paths rather than a second set
-    // of them. What it is not is what makes the host-write cases pass: the
-    // fork's guard is a runtime condition (setParameter returns early only
-    // while currentModifierValue is non-zero), so a write made before the
-    // render starts goes through either call. The corpus was run both ways to
-    // find that out, and the case's own comment says what it does and does not
-    // therefore pin.
+    // setParameterFromHost because that is the rule for a host write, not
+    // because it is what makes these cases pass: the fork's guard is a runtime
+    // condition, so a write made before the render starts goes through either
+    // call. The corpus was run both ways to find that out.
     for (const auto& track : value.tracks) {
         for (const auto& element : track.chain.fxChainElements) {
             if (!magda::isDevice(element))

--- a/tests/NullDiffTeLeg.cpp
+++ b/tests/NullDiffTeLeg.cpp
@@ -277,24 +277,33 @@ const bool gainDeviceRegistered = magda::daw::audio::registerDevicePack(register
 /// Where a link's target lives, for the walker that wires modifiers and macros.
 ///
 /// The app's own lookup is PluginManager's, which resolves any device anywhere
-/// in the chain hierarchy. This resolves the only devices this leg installs, by
-/// the id their path names. It is a lookup rather than a sync: the wiring is
-/// still ModifierSyncWalker's, which is the point -- a second walker written
-/// for the harness would be a harness agreeing with itself about what a
-/// modifier does.
+/// in the chain hierarchy. This resolves the only devices this leg installs. It
+/// is a lookup rather than a sync: the wiring is still ModifierSyncWalker's,
+/// which is the point -- a second walker written for the harness would be a
+/// harness agreeing with itself about what a modifier does.
+///
+/// Keyed by the whole path and not by the device id in it. A device id is
+/// unique within a chain segment rather than across the hierarchy (#1899), so
+/// a link naming a rack-inner or post-FX device could carry the same number as
+/// a top-level one; matching on the number would wire the modifier onto the
+/// plugin this leg happens to have installed and then compare a project against
+/// a differently connected one. Matching on the path returns nullptr instead,
+/// which is what the walker already does something sensible with: the link is
+/// dropped, the native leg's table reports it as a target the project does not
+/// have, and the runner refuses the case rather than certifying it.
 class GainPluginLookup final : public magda::TargetPluginLookup {
   public:
-    void add(magda::DeviceId id, te::Plugin* plugin) {
-        plugins_[id] = plugin;
+    void add(const magda::ChainNodePath& path, te::Plugin* plugin) {
+        plugins_[path] = plugin;
     }
 
     te::Plugin* getPlugin(const magda::ChainNodePath& path) const override {
-        const auto found = plugins_.find(path.getDeviceId());
+        const auto found = plugins_.find(path);
         return found == plugins_.end() ? nullptr : found->second;
     }
 
   private:
-    std::map<magda::DeviceId, te::Plugin*> plugins_;
+    std::map<magda::ChainNodePath, te::Plugin*> plugins_;
 };
 
 /// Everything one scope's modifiers and macros need to live in, for as long as
@@ -481,7 +490,7 @@ IncumbentRender renderIncumbent(const Case& value) {
     // beside them.
 
     GainPluginLookup lookup;
-    std::map<DeviceId, GainPlugin*> gains;
+    std::map<ChainNodePath, GainPlugin*> gains;
 
     for (const auto& track : value.tracks) {
         auto* audioTrack = trackController.getAudioTrack(track.id);
@@ -511,8 +520,11 @@ IncumbentRender renderIncumbent(const Case& value) {
 
             audioTrack->pluginList.insertPlugin(plugin, slot++, nullptr);
 
-            lookup.add(device.id, plugin.get());
-            gains[device.id] = gain;
+            // The path the model addresses it by, which is what a lane's target
+            // and a link's target both carry.
+            const auto path = ChainNodePath::topLevelDevice(track.id, device.id);
+            lookup.add(path, plugin.get());
+            gains[path] = gain;
         }
     }
 
@@ -572,7 +584,7 @@ IncumbentRender renderIncumbent(const Case& value) {
             return result;
         }
 
-        const auto found = gains.find(lane.target.devicePath.getDeviceId());
+        const auto found = gains.find(lane.target.devicePath);
         if (found == gains.end() || lane.target.paramIndex != kGainParamIndex) {
             result.failure = "a lane plays over a parameter this project does not have";
             ClipManager::getInstance().clearAllClips();
@@ -707,7 +719,7 @@ IncumbentRender renderIncumbent(const Case& value) {
                 continue;
 
             const auto& device = magda::getDevice(element);
-            const auto found = gains.find(device.id);
+            const auto found = gains.find(ChainNodePath::topLevelDevice(track.id, device.id));
             if (found == gains.end())
                 continue;
 

--- a/tests/NullDiffTeLeg.cpp
+++ b/tests/NullDiffTeLeg.cpp
@@ -591,7 +591,7 @@ IncumbentRender renderIncumbent(const Case& value) {
     // nothing for a target this leg has no plugin for, while the native table
     // resolves it and modulates. That is a modulated render compared against an
     // unmodulated one, and where the target is inaudible it is a false null.
-    const auto unwirable = [&](const ControlTarget& target,
+    const auto unwirable = [&](const ControlTarget& target, const ChainNodePath& scopePath,
                                const magda::ModArray& scopeMods) -> std::string {
         switch (target.kind) {
             case ControlTarget::Kind::PluginParam:
@@ -601,11 +601,26 @@ IncumbentRender renderIncumbent(const Case& value) {
                 return {};
 
             case ControlTarget::Kind::ModParam:
-                // Same scope only, which is the walker's own rule.
+                // Same scope, asked of the path rather than of the id.
+                // resolveSameScopeModParam looks the modifier up by id alone,
+                // so a target naming another scope is wired to whichever local
+                // modifier shares its number while the native table resolves
+                // the whole path to a different parameter. The two then differ
+                // over a link both of them think they honoured.
+                if (target.devicePath != scopePath)
+                    return "a modifier in another scope (" +
+                           target.devicePath.toString().toStdString() +
+                           "), which the walker resolves by id alone";
+
+                // Rate is the only parameter the native table gives a modifier;
+                // the walker also resolves index 1 to depth.
+                if (target.modParamIndex != 0)
+                    return "a modifier parameter that is not its Rate";
+
                 for (const auto& mod : scopeMods)
-                    if (mod.id == target.modId)
+                    if (mod.id == target.modId && mod.enabled)
                         return {};
-                return "a modifier outside the scope the link lives in";
+                return "a modifier this scope does not have, or one that is off";
 
             default:
                 // A fader, a send, a macro. The native table carries the first
@@ -615,22 +630,23 @@ IncumbentRender renderIncumbent(const Case& value) {
         }
     };
 
-    const auto refuseUnwirableLinks = [&](const magda::ConstChainNode& node) -> std::string {
-        if (node.mods != nullptr)
-            for (const auto& mod : *node.mods)
-                if (mod.enabled)
-                    for (const auto& link : mod.links)
-                        if (link.enabled && link.isValid())
-                            if (auto why = unwirable(link.target, *node.mods); !why.empty())
-                                return "a modifier links to " + why;
+    const auto refuseUnwirableLinks = [&](const magda::ConstChainNode& node,
+                                          const ChainNodePath& scopePath) -> std::string {
+        static const magda::ModArray noMods;
+        const auto& mods = node.mods == nullptr ? noMods : *node.mods;
+
+        for (const auto& mod : mods)
+            if (mod.enabled)
+                for (const auto& link : mod.links)
+                    if (link.enabled && link.isValid())
+                        if (auto why = unwirable(link.target, scopePath, mods); !why.empty())
+                            return "a modifier links to " + why;
 
         if (node.macros != nullptr)
             for (const auto& macro : *node.macros)
                 for (const auto& link : macro.links)
                     if (link.target.isValid())
-                        if (auto why = unwirable(
-                                link.target, node.mods == nullptr ? magda::ModArray{} : *node.mods);
-                            !why.empty())
+                        if (auto why = unwirable(link.target, scopePath, mods); !why.empty())
                             return "a macro links to " + why;
 
         return {};
@@ -685,7 +701,8 @@ IncumbentRender renderIncumbent(const Case& value) {
         trackNode.macros = &track.macros;
 
         if (carriesModulation(trackNode)) {
-            if (auto why = refuseUnwirableLinks(trackNode); !why.empty()) {
+            if (auto why = refuseUnwirableLinks(trackNode, ChainNodePath::trackLevel(track.id));
+                !why.empty()) {
                 refuse(why);
                 return result;
             }
@@ -725,12 +742,13 @@ IncumbentRender renderIncumbent(const Case& value) {
             deviceNode.params = &device.parameters;
 
             if (carriesModulation(deviceNode)) {
-                if (auto why = refuseUnwirableLinks(deviceNode); !why.empty()) {
+                const auto devicePath = ChainNodePath::topLevelDevice(track.id, device.id);
+
+                if (auto why = refuseUnwirableLinks(deviceNode, devicePath); !why.empty()) {
                     refuse(why);
                     return result;
                 }
-                sync(deviceNode,
-                     deviceModulation[ChainNodePath::topLevelDevice(track.id, device.id)]);
+                sync(deviceNode, deviceModulation[devicePath]);
             }
         }
     }

--- a/tests/test_null_diff_corpus.cpp
+++ b/tests/test_null_diff_corpus.cpp
@@ -36,7 +36,7 @@ juce::File scratch() {
 TEST_CASE("The corpus builds and covers what the slice claims", "[nulldiff][corpus]") {
     const auto corpus = sharedCorpus(scratch());
 
-    REQUIRE(corpus.size() == 29);
+    REQUIRE(corpus.size() == 38);
 
     std::set<std::string> names;
     for (const auto& value : corpus)
@@ -67,6 +67,15 @@ TEST_CASE("The corpus builds and covers what the slice claims", "[nulldiff][corp
                                  "mix.mute",
                                  "mix.solo",
                                  "mix.master",
+                                 "mix.volume.clamp",
+                                 "param.base",
+                                 "param.automation",
+                                 "param.modifier",
+                                 "param.both",
+                                 "param.hostwrite.automation",
+                                 "param.hostwrite.modifier",
+                                 "macro.track",
+                                 "macro.device",
                                  "project.mixed",
                                  "midi.notes",
                                  "midi.cc",
@@ -189,6 +198,78 @@ TEST_CASE("Every case says what it covers and what it plays", "[nulldiff][corpus
             CHECK(std::any_of(value.tracks.begin(), value.tracks.end(), [](const TrackInfo& track) {
                 return magda::engine::chainConsumesMidi(track);
             }));
+    }
+}
+
+TEST_CASE("Every lane and every link names something the project has", "[nulldiff][corpus]") {
+    // A parameter case asserts what a curve, a modifier or a macro does to a
+    // device parameter, and the way for one to assert nothing is for its target
+    // to miss. A lane over a device the project does not carry is dropped by
+    // the table with a diagnostic, a link to a parameter that is not there is
+    // dropped the same way, and in both cases the two legs render the same
+    // unmodulated audio and the case passes having compared nothing.
+    //
+    // The native leg does report those diagnostics and the runner refuses a
+    // case that produced one, so this is the second half rather than the only
+    // half: the runner catches it when the corpus is rendered, and this catches
+    // it in the model-only target, in a second, without an Edit.
+    for (const auto& value : sharedCorpus(scratch())) {
+        INFO(value.name);
+
+        const auto namesADeviceParameter = [&](const ControlTarget& target) {
+            if (target.kind != ControlTarget::Kind::PluginParam)
+                return true;  // Not this rule's business; the table reports it.
+
+            for (const auto& track : value.tracks)
+                for (const auto& element : track.chain.fxChainElements)
+                    if (magda::isDevice(element)) {
+                        const auto& device = magda::getDevice(element);
+                        if (device.id != target.devicePath.getDeviceId())
+                            continue;
+
+                        for (const auto& parameter : device.parameters)
+                            if (parameter.paramIndex == target.paramIndex)
+                                return true;
+                    }
+
+            return false;
+        };
+
+        for (const auto& lane : value.lanes) {
+            // A lane the model is not playing is a lane the table leaves out,
+            // so a case carrying one would be asserting the base value under a
+            // name that says automation.
+            CHECK(lane.authorityState == AutomationAuthorityState::Reading);
+            CHECK(lane.hasData());
+            CHECK(namesADeviceParameter(lane.target));
+        }
+
+        for (const auto& track : value.tracks) {
+            for (const auto& mod : track.mods)
+                for (const auto& link : mod.links)
+                    if (mod.enabled && link.enabled)
+                        CHECK(namesADeviceParameter(link.target));
+
+            for (const auto& macro : track.macros)
+                for (const auto& link : macro.links)
+                    CHECK(namesADeviceParameter(link.target));
+
+            for (const auto& element : track.chain.fxChainElements) {
+                if (!magda::isDevice(element))
+                    continue;
+
+                const auto& device = magda::getDevice(element);
+
+                for (const auto& mod : device.mods)
+                    for (const auto& link : mod.links)
+                        if (mod.enabled && link.enabled)
+                            CHECK(namesADeviceParameter(link.target));
+
+                for (const auto& macro : device.macros)
+                    for (const auto& link : macro.links)
+                        CHECK(namesADeviceParameter(link.target));
+            }
+        }
     }
 }
 

--- a/tests/test_null_diff_corpus.cpp
+++ b/tests/test_null_diff_corpus.cpp
@@ -202,25 +202,19 @@ TEST_CASE("Every case says what it covers and what it plays", "[nulldiff][corpus
 }
 
 TEST_CASE("Every lane and every link names something the project has", "[nulldiff][corpus]") {
-    // A parameter case asserts what a curve, a modifier or a macro does to a
-    // device parameter, and the way for one to assert nothing is for its target
-    // to miss. A lane over a device the project does not carry is dropped by
-    // the table with a diagnostic, a link to a parameter that is not there is
-    // dropped the same way, and in both cases the two legs render the same
-    // unmodulated audio and the case passes having compared nothing.
+    // The way a parameter case asserts nothing is for its target to miss: the
+    // table drops the lane or the link with a diagnostic, both legs render the
+    // same unmodulated audio, and the case passes having compared nothing.
     //
-    // The native leg does report those diagnostics and the runner refuses a
-    // case that produced one, so this is the second half rather than the only
-    // half: the runner catches it when the corpus is rendered, and this catches
-    // it in the model-only target, in a second, without an Edit.
+    // The runner catches that when the corpus is rendered. This catches it in
+    // the model-only target, in a second, without an Edit.
     for (const auto& value : sharedCorpus(scratch())) {
         INFO(value.name);
 
-        // Matched on the whole path rather than on the device id inside it. A
-        // device id is unique within a chain segment and not across the
-        // hierarchy (#1899), so a target naming a post-FX device would be
-        // satisfied here by the FX device with the same number, and the rule
-        // would pass on exactly the case it exists to catch.
+        // Matched on the whole path, not the device id in it: an id is unique
+        // within a chain segment and not across the hierarchy (#1899), so a
+        // post-FX target would otherwise be satisfied by the FX device with the
+        // same number.
         const auto namesADeviceParameter = [&](const ControlTarget& target) {
             if (target.kind != ControlTarget::Kind::PluginParam)
                 return true;  // Not this rule's business; the table reports it.
@@ -259,9 +253,9 @@ TEST_CASE("Every lane and every link names something the project has", "[nulldif
         };
 
         for (const auto& lane : value.lanes) {
-            // A lane the model is not playing is a lane the table leaves out,
-            // so a case carrying one would be asserting the base value under a
-            // name that says automation.
+            // A lane the model is not playing is one the table leaves out, so
+            // a case carrying one asserts the base under a name that says
+            // automation.
             CHECK(lane.authorityState == AutomationAuthorityState::Reading);
             CHECK(lane.hasData());
             CHECK(namesADeviceParameter(lane.target));

--- a/tests/test_null_diff_corpus.cpp
+++ b/tests/test_null_diff_corpus.cpp
@@ -216,21 +216,44 @@ TEST_CASE("Every lane and every link names something the project has", "[nulldif
     for (const auto& value : sharedCorpus(scratch())) {
         INFO(value.name);
 
+        // Matched on the whole path rather than on the device id inside it. A
+        // device id is unique within a chain segment and not across the
+        // hierarchy (#1899), so a target naming a post-FX device would be
+        // satisfied here by the FX device with the same number, and the rule
+        // would pass on exactly the case it exists to catch.
         const auto namesADeviceParameter = [&](const ControlTarget& target) {
             if (target.kind != ControlTarget::Kind::PluginParam)
                 return true;  // Not this rule's business; the table reports it.
 
-            for (const auto& track : value.tracks)
+            const auto declares = [&](const DeviceInfo& device, const ChainNodePath& path) {
+                if (path != target.devicePath)
+                    return false;
+
+                for (const auto& parameter : device.parameters)
+                    if (parameter.paramIndex == target.paramIndex)
+                        return true;
+
+                return false;
+            };
+
+            for (const auto& track : value.tracks) {
                 for (const auto& element : track.chain.fxChainElements)
                     if (magda::isDevice(element)) {
                         const auto& device = magda::getDevice(element);
-                        if (device.id != target.devicePath.getDeviceId())
-                            continue;
-
-                        for (const auto& parameter : device.parameters)
-                            if (parameter.paramIndex == target.paramIndex)
-                                return true;
+                        if (declares(device, ChainNodePath::topLevelDevice(track.id, device.id)))
+                            return true;
                     }
+
+                for (const auto& element : track.chain.postFxChainElements)
+                    if (declares(element.device,
+                                 ChainNodePath::postFxDevice(track.id, element.device.id)))
+                        return true;
+
+                for (const auto& element : track.chain.mixerAnalysisElements)
+                    if (declares(element.device,
+                                 ChainNodePath::mixerAnalysisDevice(track.id, element.device.id)))
+                        return true;
+            }
 
             return false;
         };


### PR DESCRIPTION
Closes #2123. Slice 8 of #1891, the parity slice.

Seven slices built the parameter system and every one of them was judged by tests written beside it. The corpus could not judge any of it: a `Device` op resolved to a stand-in that passed signal through, the incumbent instantiated none of the model's devices, and a parameter nothing reads is a parameter nothing can compare.

So the corpus runs a device now. One gain, one parameter, written once as a contract in `tests/NullDiffGain.hpp` and implemented in both legs the way the MIDI capture already was. What a gain device renders is the value of its own parameter, so a case that plays a constant into it draws the curve directly.

## The cases

Nine, and all nine null at the ordinary floor:

| Case | What it pins |
| --- | --- |
| `param.base` | a device parameter's stored value, heard |
| `param.automation` | a step curve over a device parameter |
| `param.modifier` | a square LFO over it, hertz mode |
| `param.both` | automation and a modifier at once, tempo-synced mode |
| `param.hostwrite.automation` | a stored value under a curve that covers it |
| `param.hostwrite.modifier` | a stored value under an active modifier |
| `macro.track` | a track macro driving a device parameter |
| `macro.device` | a device macro driving its own |
| `mix.volume.clamp` | the fader past both ends of its range |

The incumbent leg drives the app's own paths rather than a second set written for the harness. The curve is emitted by the same bake the playback engine uses, extracted to `AutomationBake.hpp` for the purpose and otherwise unchanged; the modifiers and macros are built by `ModifierSyncWalker`, the same walker `PluginManager` drives.

**The steps land on the half beat and the impulses land on the beat.** Both engines settle a parameter at the top of a block, so they agree wherever a curve is holding still and can differ by up to a block wherever it jumps. Eleven thousand samples of silence either side of every jump covers a block at 4096 as well as at 512, which is why these cases are also bit identical across the block-size gate rather than exempt from it. Choose the material, never the tolerance.

## Two findings in the fork

**Fixed.** A transport-synced LFO in hertz mode handed `Ramp::setPosition` a negative position for every block of an offline render's lead-in, which is about half a second of it on every bounce: `std::fmod` keeps the sign of its left-hand side, and `setPosition` asserts on a negative and then clamps it to zero, pinning the phase at the top of the cycle for the duration. Forty-four assertions per case. Conceptual-Machines/tracktion_engine#33, merged, and the submodule points at it.

**Not fixed.** A transport-gated envelope asks `TransportControl::isPlaying()`, which is false throughout every offline render, so a transport-triggered envelope does nothing in a bounce today while it is audible on playback. The engine being built plays it, because its transport gate is a property of the block. The case was written and renders 0.625 against silence; it is not in the corpus, for the reason reverse-plus-warp is not, since pinning it would ask the engine to reproduce a bug. Worth its own issue.

## Named rather than covered

Each after being tried, and each written down in `NullDiffCorpus.cpp` beside the cases:

- **Rack-scope macros** need a `te::RackType` that `RackSyncManager` builds out of a `PluginManager`. Same boundary sends stop at; moves with #1892.
- **The random walk** cannot be nulled by anybody: the fork seeds its generator from the clock and does not render the same numbers twice.
- **The envelope follower** is fed by a `FollowerSourceTapPlugin` that `PluginManager` installs, so without the device layer the fork's follower is handed nothing.

And one correction to a claim rather than a gap: the host-write cases pin the precedence, not the runtime drop. The fork's guard fires only while a modifier's output is non-zero at the instant of the write, and an offline render is a batch job with nobody's hand on a knob during it. Found by running the corpus with `setParameter` in place of `setParameterFromHost`; it still nulled, and the case's comment says so.

## The second commit

Two lookups matched a device on the id inside its address rather than on the address. A device id is unique within a chain segment and not across the hierarchy (#1899), which is why the plan carries a `DeviceKey` with the segment in it and a `ControlTarget` carries a whole `ChainNodePath`. Both legs and the corpus's own shape rule now match on the identity.

## Verification

`cases=38` in the corpus report, up from 29. Full `magda_tests` and `magda_juce_tests` pass, block-size gate included: every new case is held to bit identity at 64, 96, 512 and 4096.

https://claude.ai/code/session_012wuYCTJYYofVqPPy81cJmS