### PR TITLE
Give an output pair the track that opened it (#2135)

### DIFF
--- a/magda/engine/exec/EngineDevice.hpp
+++ b/magda/engine/exec/EngineDevice.hpp
@@ -3,6 +3,8 @@
 #include <juce_audio_basics/juce_audio_basics.h>
 #include <juce_dsp/juce_dsp.h>
 
+#include <span>
+
 #include "exec/RenderContext.hpp"
 #include "param/ParamBlock.hpp"
 
@@ -80,6 +82,25 @@ struct DeviceBlock {
     /// Sidechain audio. A zero-channel block when the slot is unconnected, so
     /// devices check getNumChannels() rather than assuming a source.
     juce::dsp::AudioBlock<const float> sidechain;
+
+    /**
+     * @brief A multi-out instrument's further output pairs.
+     *
+     * `extraOutputs[k]` is pair k + 1: pair 0 is `audio` above, which is what
+     * the device's own chain carries on from. Empty for every device that is
+     * not multi-out, which is almost all of them.
+     *
+     * One block per pair the device declares, whether or not a MultiOut track
+     * was opened for it, so a device writes its outputs where its own layout
+     * says they go and never has to ask what is being listened to. That is what
+     * the current engine does too: the instrument writes every pin of the rack
+     * around it, and it is the RackInstance for a pair that decides whether
+     * anyone reads those pins. A pair no track opened is rendered and dropped.
+     *
+     * Each block arrives cleared, so a device that writes only the pairs it has
+     * material for leaves the rest silent rather than stale.
+     */
+    std::span<juce::dsp::AudioBlock<float>> extraOutputs;
 
     /**
      * @brief The device's parameters, resolved for this block (#2116).

--- a/magda/engine/exec/PlanExecutor.cpp
+++ b/magda/engine/exec/PlanExecutor.cpp
@@ -1,6 +1,7 @@
 #include "exec/PlanExecutor.hpp"
 
 #include <algorithm>
+#include <array>
 #include <cmath>
 #include <map>
 #include <set>
@@ -1232,6 +1233,19 @@ void PlanExecutor::renderOp(OpId id, const OpValue& published, const BlockInfo& 
                 deviceMidiOut = &midiOut(id, 1);
                 deviceMidiOut->clear();
             }
+            // A multi-out instrument's further pairs sit on the ports after
+            // the main audio and any MIDI, so the count is what is left.
+            //
+            // Cleared here, ahead of everything that can leave this op early,
+            // rather than beside the call that hands them over. A pair the
+            // device does not write this block, because the track is silent or
+            // because nothing is bound, would otherwise give the track reading
+            // it the block before.
+            const auto firstMultiOutPort = producesMidi ? 2 : 1;
+            const auto multiOutPairs = std::min(
+                static_cast<int>(op.outputs.size()) - firstMultiOutPort, kMaxMultiOutPairs);
+            for (int pair = 0; pair < multiOutPairs; ++pair)
+                audioOut(id, firstMultiOutPort + pair, numSamples).clear();
 
             if (value.silent) {
                 audio.clear();
@@ -1259,7 +1273,22 @@ void PlanExecutor::renderOp(OpId id, const OpValue& published, const BlockInfo& 
                                     .block = block};
             if (op.inputs[2].valid())
                 deviceBlock.sidechain = audioIn(op.inputs[2], numSamples);
-            device->process(deviceBlock);
+
+            // The pair blocks are gathered on the stack rather than on the
+            // executor: the parallel executor runs Device ops on any thread it
+            // likes, and anything shared here would be two devices writing one
+            // array. Built only where there are pairs, so the devices that have
+            // none, which is nearly all of them, pay nothing for it.
+            if (multiOutPairs <= 0) {
+                device->process(deviceBlock);
+            } else {
+                std::array<juce::dsp::AudioBlock<float>, kMaxMultiOutPairs> pairs;
+                for (int pair = 0; pair < multiOutPairs; ++pair)
+                    pairs[static_cast<std::size_t>(pair)] =
+                        audioOut(id, firstMultiOutPort + pair, numSamples);
+                deviceBlock.extraOutputs = {pairs.data(), static_cast<std::size_t>(multiOutPairs)};
+                device->process(deviceBlock);
+            }
             jassert(deviceMidiOut == nullptr || deviceMidiOut->data.size() <= kMaxMidiBytesPerPort);
             break;
         }

--- a/magda/engine/plan/PlanCompiler.cpp
+++ b/magda/engine/plan/PlanCompiler.cpp
@@ -171,6 +171,12 @@ class Compiler {
     void diagnose(std::string message);
 
     const TrackInfo* findTrack(TrackId id) const;
+
+    /// The top-level FX device @p deviceId on @p trackId, which is where a
+    /// multi-out instrument sits and the only place a MultiOutTrackLink can
+    /// name: the link carries no section, and TrackManager::getDevice resolves
+    /// it against the track's own chain rather than inside its racks.
+    const DeviceInfo* findMultiOutSource(TrackId trackId, DeviceId deviceId) const;
     TrackId resolveSendDestination(const SendInfo& send) const;
     std::vector<const TrackInfo*> computeTrackOrder();
 
@@ -254,10 +260,6 @@ class Compiler {
     /// instrument is an FX-section device, which is the one space those ids can
     /// come from.
     std::map<std::pair<TrackId, DeviceId>, std::map<int, TrackId>> multiOutTargets_;
-    /// MultiOut tracks whose link named a pair the model actually has. A link
-    /// that resolved to nothing is what emitTrack reports; a resolved pair on a
-    /// bypassed instrument is silent without being wrong.
-    std::set<TrackId> multiOutResolved_;
     /// Tracks whose MIDI another track reads, through a MIDI sidechain or an
     /// internal MIDI route. Their MIDI clips have to be compiled even when
     /// their own chain has nothing that consumes MIDI.
@@ -301,6 +303,17 @@ const TrackInfo* Compiler::findTrack(TrackId id) const {
     const auto found =
         std::ranges::find_if(tracks_, [id](const TrackInfo& track) { return track.id == id; });
     return found == tracks_.end() ? nullptr : &*found;
+}
+
+const DeviceInfo* Compiler::findMultiOutSource(TrackId trackId, DeviceId deviceId) const {
+    const auto* track = findTrack(trackId);
+    if (track == nullptr)
+        return nullptr;
+
+    for (const auto& element : track->chain.fxChainElements)
+        if (isDevice(element) && getDevice(element).id == deviceId)
+            return &getDevice(element);
+    return nullptr;
 }
 
 bool Compiler::carriesClips(const TrackInfo& track) const {
@@ -524,16 +537,8 @@ ChainSignal Compiler::emitDevice(const DeviceInfo& device, const ChainSite& site
                                        kMaxMultiOutPairs)
                           : 0;
 
-    // Resolved before the bypass check below, because a bypassed instrument
-    // makes its pairs silent rather than unrouted: the link is still the one
-    // the model meant, and reporting it would put a diagnostic in front of an
-    // ordinary edit.
     const auto targets = multiOutTargets_.find({site.trackId, device.id});
     const bool hasTargets = ownsMultiOutPairs && targets != multiOutTargets_.end();
-    if (hasTargets)
-        for (const auto& [pairIndex, targetTrack] : targets->second)
-            if (pairIndex <= multiOutPairCount)
-                multiOutResolved_.insert(targetTrack);
 
     if (device.bypassed)
         return signal;
@@ -787,19 +792,13 @@ void Compiler::emitTrack(const TrackInfo& track) {
 
     // --- chain head ---
 
-    // The pair itself arrives through pendingInputs_, put there by the device
-    // that owns it: the source track is ordered ahead of this one, so by now it
-    // is either waiting or it never existed. Only the second case is reported,
-    // and only here, because a pair the source device does not have is a broken
-    // link rather than a configuration the plan cannot express.
-    if (track.multiOutLink && !multiOutResolved_.contains(track.id)) {
-        const auto& link = *track.multiOutLink;
-        diagnose("track " + std::to_string(track.id) + ": multi-out pair " +
-                 std::to_string(link.outputPairIndex) + " of device " +
-                 std::to_string(link.sourceDeviceId) + " on track " +
-                 std::to_string(link.sourceTrackId) +
-                 " is not a pair that device has, the track renders silence");
-    }
+    // A multi-out pair arrives through pendingInputs_, put there by the device
+    // that owns it, and nothing is reported here: whether the link names a pair
+    // that exists was settled against the model in run(). Whether the device is
+    // compiled at all is a separate question with its own answers, and none of
+    // them is the link's doing. A pair whose instrument is bypassed, or whose
+    // track has its insert chain powered off, is silent for the same reason
+    // everything else on that chain is.
 
     // Freeze is structural: the current engine renders the track, disables its
     // plugins and plays the render back. Compiling the live chain both diverges
@@ -1136,6 +1135,22 @@ RenderPlan Compiler::run() {
                      std::to_string(link.sourceDeviceId) + " is not a pair this track can read");
             continue;
         }
+        // Whether the link names a pair that exists is a question about the
+        // model, so it is answered from the model. Asking emission instead
+        // would make every reason a device is not compiled look like a broken
+        // link: chain power off and bypass both leave an instrument out of the
+        // plan, and neither is anything to do with the link.
+        const auto* device = findMultiOutSource(link.sourceTrackId, link.sourceDeviceId);
+        if (device == nullptr || !device->multiOut.isMultiOut ||
+            link.outputPairIndex >= static_cast<int>(device->multiOut.outputPairs.size())) {
+            diagnose("track " + std::to_string(track.id) + ": multi-out pair " +
+                     std::to_string(link.outputPairIndex) + " of device " +
+                     std::to_string(link.sourceDeviceId) + " on track " +
+                     std::to_string(link.sourceTrackId) +
+                     " is not a pair that device has, the track renders silence");
+            continue;
+        }
+
         auto& pairs = multiOutTargets_[{link.sourceTrackId, link.sourceDeviceId}];
         if (const auto [owner, inserted] = pairs.emplace(link.outputPairIndex, track.id); !inserted)
             diagnose("track " + std::to_string(track.id) + ": multi-out pair " +

--- a/magda/engine/plan/PlanCompiler.cpp
+++ b/magda/engine/plan/PlanCompiler.cpp
@@ -177,6 +177,13 @@ class Compiler {
     /// name: the link carries no section, and TrackManager::getDevice resolves
     /// it against the track's own chain rather than inside its racks.
     const DeviceInfo* findMultiOutSource(TrackId trackId, DeviceId deviceId) const;
+
+    /// Whether @p link will actually carry signal to @p reader, which is what
+    /// ordering has to agree with. Everything emission checks is checked here:
+    /// the link resolved to a pair of a real multi-out device and this reader
+    /// won it, the source track's insert chain is running, and the instrument
+    /// is not bypassed.
+    bool multiOutPairIsConnected(const MultiOutTrackLink& link, TrackId reader) const;
     TrackId resolveSendDestination(const SendInfo& send) const;
     std::vector<const TrackInfo*> computeTrackOrder();
 
@@ -316,6 +323,23 @@ const DeviceInfo* Compiler::findMultiOutSource(TrackId trackId, DeviceId deviceI
     return nullptr;
 }
 
+bool Compiler::multiOutPairIsConnected(const MultiOutTrackLink& link, TrackId reader) const {
+    const auto targets = multiOutTargets_.find({link.sourceTrackId, link.sourceDeviceId});
+    if (targets == multiOutTargets_.end())
+        return false;
+
+    // Not just that the pair was claimed, but that this reader is the one that
+    // claimed it: a second track on the same pair is reported and carries
+    // nothing, so it has no dependency either.
+    const auto pair = targets->second.find(link.outputPairIndex);
+    if (pair == targets->second.end() || pair->second != reader)
+        return false;
+
+    const auto* source = findTrack(link.sourceTrackId);
+    const auto* device = findMultiOutSource(link.sourceTrackId, link.sourceDeviceId);
+    return source != nullptr && source->chain.enabled && device != nullptr && !device->bypassed;
+}
+
 bool Compiler::carriesClips(const TrackInfo& track) const {
     return track.id != master_.id && track.type != TrackType::Aux &&
            track.type != TrackType::Group && track.type != TrackType::MultiOut;
@@ -389,13 +413,14 @@ std::vector<const TrackInfo*> Compiler::computeTrackOrder() {
         // Sidechains, internal input routes and multi-out pairs read another
         // track, so that track comes first. Every edge here has to correspond
         // to a connection emission will actually make, which is why the
-        // multi-out edge is gated on the same thing emission is: a link naming
-        // pair zero or a pair past what the engine can address connects
-        // nothing, so ordering for it would be inventing a dependency.
+        // multi-out edge asks the same question emission does rather than
+        // reading the link's numbers. An edge for a pair nothing will carry can
+        // invent a cycle, and the breaker resolves a cycle by dropping a
+        // connection: a real one would go so that an imaginary one could have
+        // its ordering.
         std::set<TrackId> upstream;
         collectSidechainSources(track, std::nullopt, upstream);
-        if (track.multiOutLink && track.multiOutLink->outputPairIndex > 0 &&
-            track.multiOutLink->outputPairIndex <= kMaxMultiOutPairs)
+        if (track.multiOutLink && multiOutPairIsConnected(*track.multiOutLink, track.id))
             upstream.insert(track.multiOutLink->sourceTrackId);
 
         // Deliberately not the modulation sources. A modifier listening to
@@ -529,13 +554,18 @@ ChainSignal Compiler::emitDevice(const DeviceInfo& device, const ChainSite& site
     // resolves it against the track's own chain rather than inside its racks.
     const bool ownsMultiOutPairs = site.rackId == INVALID_RACK_ID &&
                                    site.segment == ChainSegment::Fx && device.multiOut.isMultiOut;
-    // Clamped at both ends. A device flagged multi-out with no pairs listed is
-    // a plugin that has not finished reporting its channels yet, and it has to
+    // Floored at zero: a device flagged multi-out with no pairs listed is a
+    // plugin that has not finished reporting its channels yet, and it has to
     // come out as no extra ports rather than as a negative count.
-    const auto multiOutPairCount =
-        ownsMultiOutPairs ? std::clamp(static_cast<int>(device.multiOut.outputPairs.size()) - 1, 0,
-                                       kMaxMultiOutPairs)
+    const auto declaredPairs =
+        ownsMultiOutPairs ? std::max(static_cast<int>(device.multiOut.outputPairs.size()) - 1, 0)
                           : 0;
+    const auto multiOutPairCount = std::min(declaredPairs, kMaxMultiOutPairs);
+    if (declaredPairs > multiOutPairCount)
+        diagnose("device " + std::to_string(device.id) + " on track " +
+                 std::to_string(site.trackId) + ": " + std::to_string(declaredPairs) +
+                 " output pairs is past the " + std::to_string(kMaxMultiOutPairs) +
+                 " one device can carry, the rest are not compiled");
 
     const auto targets = multiOutTargets_.find({site.trackId, device.id});
     const bool hasTargets = ownsMultiOutPairs && targets != multiOutTargets_.end();
@@ -1125,11 +1155,10 @@ RenderPlan Compiler::run() {
         if (!track.multiOutLink)
             continue;
         const auto& link = *track.multiOutLink;
-        if (link.outputPairIndex <= 0 || link.outputPairIndex > kMaxMultiOutPairs) {
+        if (link.outputPairIndex <= 0) {
             // Pair 0 is the instrument's main output, which stays on its own
             // track's chain: a MultiOut track claiming it would read the signal
-            // twice. Out of range is the model naming a pin the engine cannot
-            // address.
+            // twice.
             diagnose("track " + std::to_string(track.id) + ": multi-out pair " +
                      std::to_string(link.outputPairIndex) + " of device " +
                      std::to_string(link.sourceDeviceId) + " is not a pair this track can read");
@@ -1148,6 +1177,17 @@ RenderPlan Compiler::run() {
                      std::to_string(link.sourceDeviceId) + " on track " +
                      std::to_string(link.sourceTrackId) +
                      " is not a pair that device has, the track renders silence");
+            continue;
+        }
+
+        // The device has the pair and the engine cannot carry it, which is a
+        // different thing from the link being wrong and says so separately.
+        if (link.outputPairIndex > kMaxMultiOutPairs) {
+            diagnose("track " + std::to_string(track.id) + ": multi-out pair " +
+                     std::to_string(link.outputPairIndex) + " of device " +
+                     std::to_string(link.sourceDeviceId) + " is past the " +
+                     std::to_string(kMaxMultiOutPairs) +
+                     " pairs one device can carry, the track renders silence");
             continue;
         }
 

--- a/magda/engine/plan/PlanCompiler.cpp
+++ b/magda/engine/plan/PlanCompiler.cpp
@@ -5,6 +5,7 @@
 #include <optional>
 #include <set>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "core/ChainRoutingModel.hpp"
@@ -244,8 +245,19 @@ class Compiler {
     /// whatever its own chain made of it.
     std::map<TrackId, PortRef> trackMidiInput_;
     /// Signals waiting to be summed into a track that has not been emitted yet:
-    /// child track outputs and incoming send taps.
+    /// child track outputs, incoming send taps and multi-out pairs.
     std::map<TrackId, std::vector<PortRef>> pendingInputs_;
+    /// Which MultiOut track reads each output pair of each multi-out instrument,
+    /// collected before emission because the device has to declare its ports in
+    /// one go and only the tracks know which pairs anyone reads. Keyed on the
+    /// device's own track and id: a link names no section, and a multi-out
+    /// instrument is an FX-section device, which is the one space those ids can
+    /// come from.
+    std::map<std::pair<TrackId, DeviceId>, std::map<int, TrackId>> multiOutTargets_;
+    /// MultiOut tracks whose link named a pair the model actually has. A link
+    /// that resolved to nothing is what emitTrack reports; a resolved pair on a
+    /// bypassed instrument is silent without being wrong.
+    std::set<TrackId> multiOutResolved_;
     /// Tracks whose MIDI another track reads, through a MIDI sidechain or an
     /// internal MIDI route. Their MIDI clips have to be compiled even when
     /// their own chain has nothing that consumes MIDI.
@@ -361,12 +373,17 @@ std::vector<const TrackInfo*> Compiler::computeTrackOrder() {
             if (const auto destination = indexOf(resolveSendDestination(send)); destination >= 0)
                 addEdge(i, static_cast<std::size_t>(destination));
 
-        // Sidechains and internal input routes read another track, so that
-        // track comes first. Every edge here has to correspond to a connection
-        // emission will actually make; multi-out is not compiled at all, so it
-        // contributes no edge either.
+        // Sidechains, internal input routes and multi-out pairs read another
+        // track, so that track comes first. Every edge here has to correspond
+        // to a connection emission will actually make, which is why the
+        // multi-out edge is gated on the same thing emission is: a link naming
+        // pair zero or a pair past what the engine can address connects
+        // nothing, so ordering for it would be inventing a dependency.
         std::set<TrackId> upstream;
         collectSidechainSources(track, std::nullopt, upstream);
+        if (track.multiOutLink && track.multiOutLink->outputPairIndex > 0 &&
+            track.multiOutLink->outputPairIndex <= kMaxMultiOutPairs)
+            upstream.insert(track.multiOutLink->sourceTrackId);
 
         // Deliberately not the modulation sources. A modifier listening to
         // another track needs that track's tap to exist, and it does: the taps
@@ -489,6 +506,35 @@ std::vector<PortRef> Compiler::alignInputs(const OpKey& key, OpKind kind,
 
 ChainSignal Compiler::emitDevice(const DeviceInfo& device, const ChainSite& site,
                                  ChainSignal signal) {
+    // A multi-out instrument declares a port for every pair it has past the
+    // main one, opened or not, so that a port's position is its pair number and
+    // the device never has to ask what is being listened to. Which of them a
+    // MultiOut track reads is a separate question, answered below.
+    //
+    // Top level and the FX section only, which is where a multi-out instrument
+    // sits: a link names an id with no section, and TrackManager::getDevice
+    // resolves it against the track's own chain rather than inside its racks.
+    const bool ownsMultiOutPairs = site.rackId == INVALID_RACK_ID &&
+                                   site.segment == ChainSegment::Fx && device.multiOut.isMultiOut;
+    // Clamped at both ends. A device flagged multi-out with no pairs listed is
+    // a plugin that has not finished reporting its channels yet, and it has to
+    // come out as no extra ports rather than as a negative count.
+    const auto multiOutPairCount =
+        ownsMultiOutPairs ? std::clamp(static_cast<int>(device.multiOut.outputPairs.size()) - 1, 0,
+                                       kMaxMultiOutPairs)
+                          : 0;
+
+    // Resolved before the bypass check below, because a bypassed instrument
+    // makes its pairs silent rather than unrouted: the link is still the one
+    // the model meant, and reporting it would put a diagnostic in front of an
+    // ordinary edit.
+    const auto targets = multiOutTargets_.find({site.trackId, device.id});
+    const bool hasTargets = ownsMultiOutPairs && targets != multiOutTargets_.end();
+    if (hasTargets)
+        for (const auto& [pairIndex, targetTrack] : targets->second)
+            if (pairIndex <= multiOutPairCount)
+                multiOutResolved_.insert(targetTrack);
+
     if (device.bypassed)
         return signal;
 
@@ -533,11 +579,27 @@ ChainSignal Compiler::emitDevice(const DeviceInfo& device, const ChainSite& site
     if (producesMidi)
         outputs.push_back(SignalKind::Midi);
 
+    // The further pairs are ports on the same op, after the main audio and any
+    // MIDI. They carry the device's raw output: the slot's gain trim and meter
+    // are the main pair's, and the current engine puts them on the instance the
+    // track's chain reads rather than on the one an output pair gets.
+    const auto firstMultiOutPort = static_cast<int>(outputs.size());
+    outputs.insert(outputs.end(), static_cast<std::size_t>(multiOutPairCount), SignalKind::Audio);
+
     OpKey key{site.trackId,          site.rackId, site.chainId, device.id,
               OpRole::DeviceProcess, 0,           site.segment};
     const auto processOp = addOp(
         OpKind::Device, key, alignInputs(key, OpKind::Device, {signal.audio, midiIn, sidechainIn}),
         std::move(outputs));
+
+    // Pair n is port firstMultiOutPort + n - 1. A pair no track opened stays
+    // unread, which is what the current engine does with a pin no RackInstance
+    // was made for.
+    if (hasTargets)
+        for (const auto& [pairIndex, targetTrack] : targets->second)
+            if (pairIndex <= multiOutPairCount)
+                pendingInputs_[targetTrack].push_back(
+                    PortRef{processOp, firstMultiOutPort + pairIndex - 1});
 
     ChainSignal out;
     out.audio = PortRef{processOp, 0};
@@ -612,12 +674,18 @@ ChainSignal Compiler::emitRack(const RackInfo& rack, const ChainSite& site, Chai
 
     for (const auto& chain : rack.chains) {
         if (chain.outputIndex != 0) {
-            // Rack aux outputs feed multi-out tracks, which this compiler does
-            // not wire yet. Compiling nothing for the chain is wrong in a
-            // visible way; compiling it into the main mix would be wrong
-            // silently, and compiling it nowhere would leave dead ops behind.
+            // Not the same mechanism as a multi-out track, which reads an
+            // output pair of an instrument rather than a chain of a user rack.
+            // A chain routed to an aux output is silent in the current engine
+            // too: RackSyncManager wires it to output pins 3 and up, and the
+            // rack instance on the track reads pins 1 and 2, so nothing is on
+            // the other end of them. Compiling nothing is therefore parity,
+            // and it is reported because the model says something the signal
+            // flow does not: routing a chain to an aux output loses it, and
+            // silently dropping it here would look like the plan's doing.
             diagnose("rack " + std::to_string(rack.id) + " chain " + std::to_string(chain.id) +
-                     ": aux output " + std::to_string(chain.outputIndex) + " is not routed yet");
+                     ": aux output " + std::to_string(chain.outputIndex) +
+                     " reaches nothing, the chain is silent");
             continue;
         }
 
@@ -719,11 +787,19 @@ void Compiler::emitTrack(const TrackInfo& track) {
 
     // --- chain head ---
 
-    if (track.multiOutLink)
+    // The pair itself arrives through pendingInputs_, put there by the device
+    // that owns it: the source track is ordered ahead of this one, so by now it
+    // is either waiting or it never existed. Only the second case is reported,
+    // and only here, because a pair the source device does not have is a broken
+    // link rather than a configuration the plan cannot express.
+    if (track.multiOutLink && !multiOutResolved_.contains(track.id)) {
+        const auto& link = *track.multiOutLink;
         diagnose("track " + std::to_string(track.id) + ": multi-out pair " +
-                 std::to_string(track.multiOutLink->outputPairIndex) + " of device " +
-                 std::to_string(track.multiOutLink->sourceDeviceId) +
-                 " is not routed yet, the track renders silence");
+                 std::to_string(link.outputPairIndex) + " of device " +
+                 std::to_string(link.sourceDeviceId) + " on track " +
+                 std::to_string(link.sourceTrackId) +
+                 " is not a pair that device has, the track renders silence");
+    }
 
     // Freeze is structural: the current engine renders the track, disables its
     // plugins and plays the render back. Compiling the live chain both diverges
@@ -1042,6 +1118,31 @@ RenderPlan Compiler::run() {
     // a note-triggered modifier reads the notes reaching its source's chain
     // head, and a source with no MIDI ops compiled has no chain head to read.
     midiSourceTracks_.insert(noteSourceTracks_.begin(), noteSourceTracks_.end());
+
+    // Which multi-out pairs anyone reads, before any device declares its ports.
+    // A device emits a port per pair a track links to and no others, so a pair
+    // nobody opened costs nothing and a dead port never reaches the plan.
+    for (const auto& track : tracks_) {
+        if (!track.multiOutLink)
+            continue;
+        const auto& link = *track.multiOutLink;
+        if (link.outputPairIndex <= 0 || link.outputPairIndex > kMaxMultiOutPairs) {
+            // Pair 0 is the instrument's main output, which stays on its own
+            // track's chain: a MultiOut track claiming it would read the signal
+            // twice. Out of range is the model naming a pin the engine cannot
+            // address.
+            diagnose("track " + std::to_string(track.id) + ": multi-out pair " +
+                     std::to_string(link.outputPairIndex) + " of device " +
+                     std::to_string(link.sourceDeviceId) + " is not a pair this track can read");
+            continue;
+        }
+        auto& pairs = multiOutTargets_[{link.sourceTrackId, link.sourceDeviceId}];
+        if (const auto [owner, inserted] = pairs.emplace(link.outputPairIndex, track.id); !inserted)
+            diagnose("track " + std::to_string(track.id) + ": multi-out pair " +
+                     std::to_string(link.outputPairIndex) + " of device " +
+                     std::to_string(link.sourceDeviceId) + " is already read by track " +
+                     std::to_string(owner->second) + ", this track renders silence");
+    }
 
     for (const auto* track : computeTrackOrder())
         emitTrack(*track);

--- a/magda/engine/plan/PlanCompiler.cpp
+++ b/magda/engine/plan/PlanCompiler.cpp
@@ -1148,9 +1148,13 @@ RenderPlan Compiler::run() {
     // head, and a source with no MIDI ops compiled has no chain head to read.
     midiSourceTracks_.insert(noteSourceTracks_.begin(), noteSourceTracks_.end());
 
-    // Which multi-out pairs anyone reads, before any device declares its ports.
-    // A device emits a port per pair a track links to and no others, so a pair
-    // nobody opened costs nothing and a dead port never reaches the plan.
+    // Who reads which multi-out pair, collected before emission because a track
+    // is where that is written down and the device that owns the pair is
+    // compiled first. It decides where a pair goes, not whether it exists: a
+    // device declares a port for every pair it has, so port position stays the
+    // pair number whatever any track does, and a pair nobody opened is rendered
+    // and dropped the way the current engine drops a pin with no RackInstance
+    // reading it.
     for (const auto& track : tracks_) {
         if (!track.multiOutLink)
             continue;

--- a/magda/engine/plan/RenderPlan.hpp
+++ b/magda/engine/plan/RenderPlan.hpp
@@ -47,6 +47,21 @@ constexpr OpId INVALID_OP_ID = -1;
 /** Which kind of signal a port carries. */
 enum class SignalKind : std::uint8_t { Audio, Midi };
 
+// Output ports of a Device op, in order. Port 0 is the device's audio output,
+// and it is the one the chain carries on from. A device that writes MIDI has it
+// at port 1. Anything after that is a multi-out instrument's further output
+// pairs, in pair order, and those leave the chain rather than continuing along
+// it: each is read by the MultiOut track whose MultiOutTrackLink names that
+// pair, the way the current engine gives the pair its own RackInstance reading
+// its own pins. The order is what makes the two existing shapes, {Audio} and
+// {Audio, Midi}, special cases of it rather than something a reader has to tell
+// apart.
+
+/// Output pairs past the main one that one device may have. The current engine
+/// clamps rack output pins to the same figure (RackSyncManager), and a plan
+/// carrying more would address pins it cannot reach.
+constexpr int kMaxMultiOutPairs = 31;
+
 /**
  * @brief What an op computes.
  *

--- a/magda/engine/plan/RenderPlan.hpp
+++ b/magda/engine/plan/RenderPlan.hpp
@@ -57,10 +57,20 @@ enum class SignalKind : std::uint8_t { Audio, Midi };
 // {Audio, Midi}, special cases of it rather than something a reader has to tell
 // apart.
 
-/// Output pairs past the main one that one device may have. The current engine
-/// clamps rack output pins to the same figure (RackSyncManager), and a plan
-/// carrying more would address pins it cannot reach.
-constexpr int kMaxMultiOutPairs = 31;
+/// Output pairs past the main one that one Device op may carry.
+///
+/// Not a limit the model has. `InstrumentRackManager::wrapMultiOutInstrument`
+/// adds one rack pin per channel with no clamp, and a device's pairs are read
+/// off the plugin's own buses, so the model will describe as many as the plugin
+/// reports. (The clamp in `RackSyncManager` is the user-rack chain mechanism,
+/// which is unrelated: see the aux-output note in PlanCompiler::emitRack.)
+///
+/// What is bounded is the executor, which gathers a device's pair blocks on the
+/// stack because the parallel executor runs Device ops on any thread and shared
+/// storage would be two devices writing one array. This is that budget, and it
+/// is generous next to the widest plugins in use: 64 pairs is 128 channels.
+/// A device with more is reported by the compiler rather than quietly shortened.
+constexpr int kMaxMultiOutPairs = 64;
 
 /**
  * @brief What an op computes.

--- a/tests/test_remote_permissions.cpp
+++ b/tests/test_remote_permissions.cpp
@@ -582,7 +582,7 @@ TEST_CASE("Entries can be read back for one client", "[remote][permissions][audi
 TEST_CASE("A registered secret never survives into a log line",
           "[remote][permissions][redaction]") {
     forgetAllRemoteSecrets();
-    const juce::String token = "9f3a1c7e5b2d8406";
+    const juce::String token = "9f3a1c7e5b2d8406";  // gitleaks:allow, a test fixture
     registerRemoteSecret(token);
 
     const auto redacted = redactSecrets("connecting with token " + token + " to the endpoint");
@@ -630,7 +630,7 @@ TEST_CASE("An audit detail is redacted on the way in", "[remote][permissions][re
     // At the one point every entry passes through, rather than at each call
     // site — where each new one is a chance to forget.
     forgetAllRemoteSecrets();
-    const juce::String token = "abcdef0123456789";
+    const juce::String token = "abcdef0123456789";  // gitleaks:allow, a test fixture
     registerRemoteSecret(token);
 
     auto log = std::make_shared<RemoteAuditLog>();

--- a/tests/test_render_plan_compiler.cpp
+++ b/tests/test_render_plan_compiler.cpp
@@ -1808,7 +1808,8 @@ TEST_CASE("A multi-out link survives its source not being compiled", "[engine][p
     // questions. Everything that leaves an instrument out of the plan would
     // otherwise read as a broken link, and the track would be told its pair
     // does not exist when the only thing that happened is that the chain it
-    // sits on is not running.
+    // sits on is not running. Bypass is the other way in, and has its own case
+    // above.
     SECTION("the source track's insert chain is powered off") {
         std::vector<TrackInfo> tracks{makeTrack(1), makeMultiOutTrack(2, 1, 7, 1)};
         tracks[0].chain.enabled = false;
@@ -1820,18 +1821,6 @@ TEST_CASE("A multi-out link survives its source not being compiled", "[engine][p
         CHECK(plan.diagnostics.empty());
         CHECK(deviceProcess(plan, 7) == magda::engine::INVALID_OP_ID);
         CHECK(plan.ops[static_cast<std::size_t>(trackInput(plan, 2))].inputs.empty());
-    }
-
-    SECTION("the instrument is bypassed") {
-        auto instrument = makeMultiOutInstrument(7, 3);
-        instrument.bypassed = true;
-
-        std::vector<TrackInfo> tracks{makeTrack(1), makeMultiOutTrack(2, 1, 7, 1)};
-        tracks[0].chain.fxChainElements.push_back(makeDeviceElement(instrument));
-
-        const auto plan = magda::engine::compileRenderPlan(tracks, makeMaster());
-        requireWellFormed(plan);
-        CHECK(plan.diagnostics.empty());
     }
 
     SECTION("but a link to a track that does not exist is still reported") {

--- a/tests/test_render_plan_compiler.cpp
+++ b/tests/test_render_plan_compiler.cpp
@@ -1832,3 +1832,81 @@ TEST_CASE("A multi-out link survives its source not being compiled", "[engine][p
         CHECK(anyDiagnosticContains(plan, "is not a pair that device has"));
     }
 }
+
+TEST_CASE("A multi-out pair that carries nothing is not an ordering dependency",
+          "[engine][plan][compiler]") {
+    // The edge only exists where a connection does. An edge for a pair nothing
+    // carries can invent a cycle, and the breaker resolves a cycle by dropping
+    // a connection: a real one would go so an imaginary one could be ordered.
+    auto instrument = makeMultiOutInstrument(7, 3);
+    instrument.bypassed = true;
+
+    // Track 2 reads a pair of the bypassed instrument on track 1, and track 1
+    // takes track 2's output as its own input. Only the multi-out edge can
+    // close that loop, and it must not.
+    std::vector<TrackInfo> tracks{makeTrack(1), makeMultiOutTrack(2, 1, 7, 1)};
+    tracks[0].chain.fxChainElements.push_back(makeDeviceElement(instrument));
+    tracks[1].audioOutputDevice = "track:1";
+
+    const auto plan = magda::engine::compileRenderPlan(tracks, makeMaster());
+    requireWellFormed(plan);
+
+    CHECK_FALSE(anyDiagnosticContains(plan, "routing cycle"));
+    CHECK_FALSE(anyDiagnosticContains(plan, "arrived after it was compiled"));
+
+    // Track 2's real connection into track 1 survives, which is what a dropped
+    // edge would have cost: track 1's own clips, and track 2's output.
+    const auto input = trackInput(plan, 1);
+    REQUIRE(input != magda::engine::INVALID_OP_ID);
+    REQUIRE(plan.ops[static_cast<std::size_t>(input)].inputs.size() == 2);
+
+    magda::engine::OpId readerMute = magda::engine::INVALID_OP_ID;
+    for (const auto op : opsWithRole(plan, OpRole::TrackMute))
+        if (plan.ops[static_cast<std::size_t>(op)].key.trackId == 2)
+            readerMute = op;
+    REQUIRE(readerMute != magda::engine::INVALID_OP_ID);
+    CHECK(inputOp(plan, input, 1) == readerMute);
+}
+
+TEST_CASE("A device with more pairs than one op can carry says so", "[engine][plan][compiler]") {
+    const auto overBudget = magda::engine::kMaxMultiOutPairs + 2;
+
+    SECTION("the device reports the pairs it could not compile") {
+        std::vector<TrackInfo> tracks{makeTrack(1)};
+        tracks[0].chain.fxChainElements.push_back(
+            makeDeviceElement(makeMultiOutInstrument(7, overBudget + 1)));
+
+        const auto plan = magda::engine::compileRenderPlan(tracks, makeMaster());
+        requireWellFormed(plan);
+
+        // Never a silent shortening: the ports stop at the budget and the drop
+        // is named.
+        CHECK(anyDiagnosticContains(plan, "one device can carry, the rest are not compiled"));
+        const auto process = deviceProcess(plan, 7);
+        CHECK(plan.ops[static_cast<std::size_t>(process)].outputs.size() ==
+              static_cast<std::size_t>(magda::engine::kMaxMultiOutPairs) + 1);
+    }
+
+    SECTION("a track reading past the budget is told which limit it hit") {
+        std::vector<TrackInfo> tracks{makeTrack(1), makeMultiOutTrack(2, 1, 7, overBudget)};
+        tracks[0].chain.fxChainElements.push_back(
+            makeDeviceElement(makeMultiOutInstrument(7, overBudget + 1)));
+
+        const auto plan = magda::engine::compileRenderPlan(tracks, makeMaster());
+        requireWellFormed(plan);
+
+        // The device has that pair, so this is not the broken-link message.
+        CHECK(anyDiagnosticContains(plan, "pairs one device can carry"));
+        CHECK_FALSE(anyDiagnosticContains(plan, "is not a pair that device has"));
+    }
+
+    SECTION("a pair inside the budget still routes on the same device") {
+        std::vector<TrackInfo> tracks{makeTrack(1), makeMultiOutTrack(2, 1, 7, 1)};
+        tracks[0].chain.fxChainElements.push_back(
+            makeDeviceElement(makeMultiOutInstrument(7, overBudget + 1)));
+
+        const auto plan = magda::engine::compileRenderPlan(tracks, makeMaster());
+        requireWellFormed(plan);
+        CHECK(plan.ops[static_cast<std::size_t>(trackInput(plan, 2))].inputs.size() == 1);
+    }
+}

--- a/tests/test_render_plan_compiler.cpp
+++ b/tests/test_render_plan_compiler.cpp
@@ -1802,3 +1802,44 @@ TEST_CASE("A rack chain routed to an aux output reaches nothing and says so",
     CHECK(countRole(plan, OpRole::RackChainFader) == 1);
     CHECK(deviceProcess(plan, 8) == magda::engine::INVALID_OP_ID);
 }
+
+TEST_CASE("A multi-out link survives its source not being compiled", "[engine][plan][compiler]") {
+    // Whether the link is sound and whether the device is in the plan are two
+    // questions. Everything that leaves an instrument out of the plan would
+    // otherwise read as a broken link, and the track would be told its pair
+    // does not exist when the only thing that happened is that the chain it
+    // sits on is not running.
+    SECTION("the source track's insert chain is powered off") {
+        std::vector<TrackInfo> tracks{makeTrack(1), makeMultiOutTrack(2, 1, 7, 1)};
+        tracks[0].chain.enabled = false;
+        tracks[0].chain.fxChainElements.push_back(makeDeviceElement(makeMultiOutInstrument(7, 3)));
+
+        const auto plan = magda::engine::compileRenderPlan(tracks, makeMaster());
+        requireWellFormed(plan);
+
+        CHECK(plan.diagnostics.empty());
+        CHECK(deviceProcess(plan, 7) == magda::engine::INVALID_OP_ID);
+        CHECK(plan.ops[static_cast<std::size_t>(trackInput(plan, 2))].inputs.empty());
+    }
+
+    SECTION("the instrument is bypassed") {
+        auto instrument = makeMultiOutInstrument(7, 3);
+        instrument.bypassed = true;
+
+        std::vector<TrackInfo> tracks{makeTrack(1), makeMultiOutTrack(2, 1, 7, 1)};
+        tracks[0].chain.fxChainElements.push_back(makeDeviceElement(instrument));
+
+        const auto plan = magda::engine::compileRenderPlan(tracks, makeMaster());
+        requireWellFormed(plan);
+        CHECK(plan.diagnostics.empty());
+    }
+
+    SECTION("but a link to a track that does not exist is still reported") {
+        std::vector<TrackInfo> tracks{makeTrack(1), makeMultiOutTrack(2, 9, 7, 1)};
+        tracks[0].chain.fxChainElements.push_back(makeDeviceElement(makeMultiOutInstrument(7, 3)));
+
+        const auto plan = magda::engine::compileRenderPlan(tracks, makeMaster());
+        requireWellFormed(plan);
+        CHECK(anyDiagnosticContains(plan, "is not a pair that device has"));
+    }
+}

--- a/tests/test_render_plan_compiler.cpp
+++ b/tests/test_render_plan_compiler.cpp
@@ -1606,3 +1606,199 @@ TEST_CASE("Section-local device ids have distinct plan identities",
                          {ChainSegment::MixerAnalysis, 3},
                      });
 }
+
+namespace {
+
+/// An instrument with @p pairs stereo output pairs, the first of which is its
+/// main output. Pins follow the current engine's layout, two channels per pair
+/// from pin 1, which is what InstrumentRackManager reads a pair off.
+DeviceInfo makeMultiOutInstrument(DeviceId id, int pairs) {
+    auto device = makeInstrument(id);
+    device.multiOut.isMultiOut = true;
+    device.multiOut.totalOutputChannels = pairs * 2;
+    for (int pair = 0; pair < pairs; ++pair) {
+        MultiOutOutputPair out;
+        out.outputIndex = pair;
+        out.name = "St." + juce::String(pair * 2 + 1) + "-" + juce::String(pair * 2 + 2);
+        out.firstPin = 1 + pair * 2;
+        out.numChannels = 2;
+        device.multiOut.outputPairs.push_back(out);
+    }
+    return device;
+}
+
+/// A MultiOut track reading @p pair of @p deviceId on @p sourceTrack.
+TrackInfo makeMultiOutTrack(TrackId id, TrackId sourceTrack, DeviceId deviceId, int pair) {
+    auto track = makeTrack(id, TrackType::MultiOut);
+    track.multiOutLink = MultiOutTrackLink{sourceTrack, deviceId, pair};
+    return track;
+}
+
+/// The chain-head mix of one track.
+magda::engine::OpId trackInput(const RenderPlan& plan, TrackId trackId) {
+    for (const auto op : opsWithRole(plan, OpRole::TrackAudioInput))
+        if (plan.ops[static_cast<std::size_t>(op)].key.trackId == trackId)
+            return op;
+    return magda::engine::INVALID_OP_ID;
+}
+
+/// The device's process op, whatever else it emits.
+magda::engine::OpId deviceProcess(const RenderPlan& plan, DeviceId deviceId) {
+    for (std::size_t i = 0; i < plan.ops.size(); ++i) {
+        const auto& key = plan.ops[i].key;
+        if (key.deviceId == deviceId && key.role == OpRole::DeviceProcess)
+            return static_cast<magda::engine::OpId>(i);
+    }
+    return magda::engine::INVALID_OP_ID;
+}
+
+bool anyDiagnosticContains(const RenderPlan& plan, const std::string& text) {
+    return std::ranges::any_of(plan.diagnostics, [&text](const std::string& message) {
+        return message.find(text) != std::string::npos;
+    });
+}
+
+}  // namespace
+
+TEST_CASE("A multi-out pair feeds the track that opened it", "[engine][plan][compiler]") {
+    // The reading track is declared before its source, so only the multi-out
+    // dependency can put the source first.
+    std::vector<TrackInfo> tracks{makeMultiOutTrack(2, 1, 7, 1), makeTrack(1)};
+    tracks[1].chain.fxChainElements.push_back(makeDeviceElement(makeMultiOutInstrument(7, 3)));
+
+    const auto plan = magda::engine::compileRenderPlan(tracks, makeMaster());
+    requireWellFormed(plan);
+    CHECK(plan.diagnostics.empty());
+
+    const auto process = deviceProcess(plan, 7);
+    REQUIRE(process != magda::engine::INVALID_OP_ID);
+
+    // Three pairs: the main output at port 0, and one port each for pairs 1
+    // and 2, whether or not a track opened them.
+    const auto& outputs = plan.ops[static_cast<std::size_t>(process)].outputs;
+    REQUIRE(outputs.size() == 3);
+    CHECK(std::ranges::all_of(outputs, [](magda::engine::SignalKind kind) {
+        return kind == magda::engine::SignalKind::Audio;
+    }));
+
+    // The reading track's chain head is that pair's port and nothing else.
+    const auto input = trackInput(plan, 2);
+    REQUIRE(input != magda::engine::INVALID_OP_ID);
+    const auto& inputs = plan.ops[static_cast<std::size_t>(input)].inputs;
+    REQUIRE(inputs.size() == 1);
+    CHECK(rawInputOp(plan, input, 0) == process);
+    CHECK(inputs[0].port == 1);
+}
+
+TEST_CASE("A multi-out link the source device cannot honour is reported",
+          "[engine][plan][compiler]") {
+    SECTION("a pair the device does not have") {
+        std::vector<TrackInfo> tracks{makeTrack(1), makeMultiOutTrack(2, 1, 7, 4)};
+        tracks[0].chain.fxChainElements.push_back(makeDeviceElement(makeMultiOutInstrument(7, 2)));
+
+        const auto plan = magda::engine::compileRenderPlan(tracks, makeMaster());
+        requireWellFormed(plan);
+        CHECK(anyDiagnosticContains(plan, "is not a pair that device has"));
+        CHECK(plan.ops[static_cast<std::size_t>(trackInput(plan, 2))].inputs.empty());
+    }
+
+    SECTION("a device that is not multi-out at all") {
+        std::vector<TrackInfo> tracks{makeTrack(1), makeMultiOutTrack(2, 1, 7, 1)};
+        tracks[0].chain.fxChainElements.push_back(makeDeviceElement(makeInstrument(7)));
+
+        const auto plan = magda::engine::compileRenderPlan(tracks, makeMaster());
+        requireWellFormed(plan);
+        CHECK(anyDiagnosticContains(plan, "is not a pair that device has"));
+    }
+
+    SECTION("the main pair, which stays on the source track") {
+        std::vector<TrackInfo> tracks{makeTrack(1), makeMultiOutTrack(2, 1, 7, 0)};
+        tracks[0].chain.fxChainElements.push_back(makeDeviceElement(makeMultiOutInstrument(7, 3)));
+
+        const auto plan = magda::engine::compileRenderPlan(tracks, makeMaster());
+        requireWellFormed(plan);
+        CHECK(anyDiagnosticContains(plan, "is not a pair this track can read"));
+    }
+
+    SECTION("two tracks on one pair") {
+        std::vector<TrackInfo> tracks{makeTrack(1), makeMultiOutTrack(2, 1, 7, 1),
+                                      makeMultiOutTrack(3, 1, 7, 1)};
+        tracks[0].chain.fxChainElements.push_back(makeDeviceElement(makeMultiOutInstrument(7, 2)));
+
+        const auto plan = magda::engine::compileRenderPlan(tracks, makeMaster());
+        requireWellFormed(plan);
+        CHECK(anyDiagnosticContains(plan, "is already read by track 2"));
+
+        // The first claim stands; the second track reads nothing.
+        CHECK(plan.ops[static_cast<std::size_t>(trackInput(plan, 2))].inputs.size() == 1);
+        CHECK(plan.ops[static_cast<std::size_t>(trackInput(plan, 3))].inputs.empty());
+    }
+}
+
+TEST_CASE("A bypassed multi-out instrument silences its pairs without reporting them",
+          "[engine][plan][compiler]") {
+    auto instrument = makeMultiOutInstrument(7, 3);
+    instrument.bypassed = true;
+
+    std::vector<TrackInfo> tracks{makeTrack(1), makeMultiOutTrack(2, 1, 7, 1)};
+    tracks[0].chain.fxChainElements.push_back(makeDeviceElement(instrument));
+
+    const auto plan = magda::engine::compileRenderPlan(tracks, makeMaster());
+    requireWellFormed(plan);
+
+    // A bypassed device is not in the plan, so the pair has nothing to read;
+    // the link is still the one the model meant, so nothing is reported.
+    CHECK(plan.diagnostics.empty());
+    CHECK(deviceProcess(plan, 7) == magda::engine::INVALID_OP_ID);
+    CHECK(plan.ops[static_cast<std::size_t>(trackInput(plan, 2))].inputs.empty());
+}
+
+TEST_CASE("A multi-out instrument that also writes MIDI keeps its pairs after it",
+          "[engine][plan][compiler]") {
+    auto instrument = makeMultiOutInstrument(7, 2);
+    instrument.producesMidi = true;
+
+    std::vector<TrackInfo> tracks{makeTrack(1), makeMultiOutTrack(2, 1, 7, 1)};
+    tracks[0].chain.fxChainElements.push_back(makeDeviceElement(instrument));
+
+    const auto plan = magda::engine::compileRenderPlan(tracks, makeMaster());
+    requireWellFormed(plan);
+    CHECK(plan.diagnostics.empty());
+
+    const auto process = deviceProcess(plan, 7);
+    const auto& outputs = plan.ops[static_cast<std::size_t>(process)].outputs;
+    REQUIRE(outputs.size() == 3);
+    CHECK(outputs[0] == magda::engine::SignalKind::Audio);
+    CHECK(outputs[1] == magda::engine::SignalKind::Midi);
+    CHECK(outputs[2] == magda::engine::SignalKind::Audio);
+
+    const auto input = trackInput(plan, 2);
+    CHECK(plan.ops[static_cast<std::size_t>(input)].inputs[0].port == 2);
+}
+
+TEST_CASE("A rack chain routed to an aux output reaches nothing and says so",
+          "[engine][plan][compiler]") {
+    RackInfo rack;
+    rack.id = 4;
+    ChainInfo mainChain;
+    mainChain.id = 10;
+    mainChain.elements.push_back(makeDeviceElement(makeEffect(7)));
+    ChainInfo auxChain;
+    auxChain.id = 11;
+    auxChain.outputIndex = 1;
+    auxChain.elements.push_back(makeDeviceElement(makeEffect(8)));
+    rack.chains.push_back(std::move(mainChain));
+    rack.chains.push_back(std::move(auxChain));
+
+    std::vector<TrackInfo> tracks{makeTrack(1)};
+    tracks[0].chain.fxChainElements.push_back(makeRackElement(std::move(rack)));
+
+    const auto plan = magda::engine::compileRenderPlan(tracks, makeMaster());
+    requireWellFormed(plan);
+
+    CHECK(anyDiagnosticContains(plan, "reaches nothing, the chain is silent"));
+
+    // Only the main chain is compiled, and the device on the aux chain with it.
+    CHECK(countRole(plan, OpRole::RackChainFader) == 1);
+    CHECK(deviceProcess(plan, 8) == magda::engine::INVALID_OP_ID);
+}

--- a/tests/test_render_plan_executor.cpp
+++ b/tests/test_render_plan_executor.cpp
@@ -1560,3 +1560,164 @@ TEST_CASE("A chain out of the mix silences a nested rack's MIDI too", "[engine][
         CHECK(harness.outputSample() == approx(0.0f));
     }
 }
+
+namespace {
+
+/// Writes a different DC level to every output pair it has, so which pair a
+/// track is reading is visible in that track's meter. The main pair carries
+/// `base`, and pair n carries base * (n + 1).
+class MultiOutInstrument final : public EngineDevice {
+  public:
+    explicit MultiOutInstrument(float base) : base_(base) {}
+
+    void process(DeviceBlock& block) override {
+        ++processedBlocks;
+        sawExtraOutputs = static_cast<int>(block.extraOutputs.size());
+
+        block.audio.fill(base_);
+        for (std::size_t pair = 0; pair < block.extraOutputs.size(); ++pair)
+            block.extraOutputs[pair].fill(base_ * static_cast<float>(pair + 2));
+    }
+
+    int processedBlocks = 0;
+    int sawExtraOutputs = 0;
+
+  private:
+    float base_;
+};
+
+DeviceInfo makeMultiOutInstrument(DeviceId id, int pairs) {
+    auto device = makeInstrument(id);
+    device.multiOut.isMultiOut = true;
+    device.multiOut.totalOutputChannels = pairs * 2;
+    for (int pair = 0; pair < pairs; ++pair) {
+        MultiOutOutputPair out;
+        out.outputIndex = pair;
+        out.firstPin = 1 + pair * 2;
+        out.numChannels = 2;
+        device.multiOut.outputPairs.push_back(out);
+    }
+    return device;
+}
+
+TrackInfo makeMultiOutTrack(TrackId id, TrackId sourceTrack, DeviceId deviceId, int pair) {
+    auto track = makeTrack(id, TrackType::MultiOut);
+    track.multiOutLink = MultiOutTrackLink{sourceTrack, deviceId, pair};
+    return track;
+}
+
+}  // namespace
+
+TEST_CASE("Each multi-out pair reaches the track that opened it", "[engine][exec]") {
+    auto source = makeTrack(1);
+    source.chain.fxChainElements.push_back(makeDeviceElement(makeMultiOutInstrument(7, 3)));
+
+    Harness harness({source, makeMultiOutTrack(2, 1, 7, 1), makeMultiOutTrack(3, 1, 7, 2)},
+                    makeMaster());
+    ConstantSource silence(0.0f);
+    NoteSource notes(64);
+    MultiOutInstrument instrument(0.1f);
+    harness.bindings.clipAudio[1] = &silence;
+    harness.bindings.clipMidi[1] = &notes;
+    harness.bindings.devices[DeviceKey{7}] = &instrument;
+
+    harness.prepareCleanly();
+    harness.render();
+
+    // Two pairs past the main one, whether or not both were opened.
+    CHECK(instrument.processedBlocks == 1);
+    CHECK(instrument.sawExtraOutputs == 2);
+
+    // Each track reads its own pair, and the source track keeps the main one.
+    CHECK(harness.takeMeterFor(OpRole::TrackMeter, 1) == approx(0.1f));
+    CHECK(harness.takeMeterFor(OpRole::TrackMeter, 2) == approx(0.2f));
+    CHECK(harness.takeMeterFor(OpRole::TrackMeter, 3) == approx(0.3f));
+
+    // All three land on the master, which is what a multi-out setup sounds
+    // like with nothing else done to it.
+    CHECK(harness.outputSample() == approx(0.6f));
+}
+
+TEST_CASE("A multi-out pair nobody opened is rendered and dropped", "[engine][exec]") {
+    auto source = makeTrack(1);
+    source.chain.fxChainElements.push_back(makeDeviceElement(makeMultiOutInstrument(7, 3)));
+
+    Harness harness({source, makeMultiOutTrack(2, 1, 7, 1)}, makeMaster());
+    ConstantSource silence(0.0f);
+    NoteSource notes(64);
+    MultiOutInstrument instrument(0.1f);
+    harness.bindings.clipAudio[1] = &silence;
+    harness.bindings.clipMidi[1] = &notes;
+    harness.bindings.devices[DeviceKey{7}] = &instrument;
+
+    harness.prepareCleanly();
+    harness.render();
+
+    // The device still writes both pairs: its output layout is its own, and
+    // the plan decides what is read rather than what is produced.
+    CHECK(instrument.sawExtraOutputs == 2);
+    CHECK(harness.takeMeterFor(OpRole::TrackMeter, 2) == approx(0.2f));
+
+    // Pair 2 reaches nothing, so the master carries the main pair and pair 1.
+    CHECK(harness.outputSample() == approx(0.3f));
+}
+
+TEST_CASE("An ordinary device is handed no extra outputs", "[engine][exec]") {
+    auto track = makeTrack(1);
+    track.chain.fxChainElements.push_back(makeDeviceElement(makeInstrument(7)));
+
+    Harness harness({track}, makeMaster());
+    ConstantSource silence(0.0f);
+    NoteSource notes(64);
+    MultiOutInstrument instrument(0.25f);
+    harness.bindings.clipAudio[1] = &silence;
+    harness.bindings.clipMidi[1] = &notes;
+    harness.bindings.devices[DeviceKey{7}] = &instrument;
+
+    harness.prepareCleanly();
+    harness.render();
+
+    CHECK(instrument.sawExtraOutputs == 0);
+    CHECK(harness.outputSample() == approx(0.25f));
+}
+
+TEST_CASE("A multi-out pair the device stops writing goes silent", "[engine][exec]") {
+    // Writes its pairs on the first block only, which is what any instrument
+    // with nothing to play on a pair does. The pair has to go silent rather
+    // than repeat the block it last had material for, and the only thing that
+    // makes that true is the executor clearing the port before the call.
+    class WritesOnceInstrument final : public EngineDevice {
+      public:
+        void process(DeviceBlock& block) override {
+            block.audio.fill(0.1f);
+            if (blocks++ > 0)
+                return;
+            for (std::size_t pair = 0; pair < block.extraOutputs.size(); ++pair)
+                block.extraOutputs[pair].fill(0.2f);
+        }
+
+        int blocks = 0;
+    };
+
+    auto source = makeTrack(1);
+    source.chain.fxChainElements.push_back(makeDeviceElement(makeMultiOutInstrument(7, 2)));
+
+    Harness harness({source, makeMultiOutTrack(2, 1, 7, 1)}, makeMaster());
+    ConstantSource silence(0.0f);
+    NoteSource notes(64);
+    WritesOnceInstrument instrument;
+    harness.bindings.clipAudio[1] = &silence;
+    harness.bindings.clipMidi[1] = &notes;
+    harness.bindings.devices[DeviceKey{7}] = &instrument;
+
+    harness.prepareCleanly();
+    harness.render();
+    REQUIRE(harness.takeMeterFor(OpRole::TrackMeter, 2) == approx(0.2f));
+
+    harness.render(kBlockSize, kBlockSize);
+    CHECK(instrument.blocks == 2);
+    CHECK(harness.takeMeterFor(OpRole::TrackMeter, 2) == approx(0.0f));
+
+    // The main pair is unaffected: it is written every block.
+    CHECK(harness.takeMeterFor(OpRole::TrackMeter, 1) == approx(0.1f));
+}


### PR DESCRIPTION
Closes #2135. Slice 1 of #1892.

The issue asked for aux outputs and multi-out tracks as one thing. They are two, and only one of them was work.

## The one that was work

A multi-out instrument's further output pairs are now ports on its own `Device` op, after the main audio and any MIDI. There is one port per pair the device declares rather than one per pair a track opened, so a port's position is its pair number and the device writes its outputs where its own layout says they go without having to ask what is being listened to.

That is what the current engine does. `InstrumentRackManager::wrapMultiOutInstrument` puts the instrument in a rack, the instrument writes every pin of that rack, and it is the `RackInstance` made for a pair, with its own `leftFrom`/`rightFrom`, that decides whether anyone reads those pins. A pair nobody opened is rendered and dropped in both engines.

The MultiOut track reading a pair picks it up through `pendingInputs_`, the same route a send or a group child takes into a track compiled after it, and the link is an ordering edge so the source is always compiled first. The comment in `computeTrackOrder` saying multi-out contributes no edge because it is not compiled goes with it.

Each pair port is cleared before the device is called and before anything that can leave the op early. A pair the device has nothing to play on this block therefore goes silent instead of handing the track reading it the block it last had material for.

## The one that was not

`PlanCompiler.cpp:614` reported a rack chain routed to an aux output as "not routed yet", and its comment said those chains feed multi-out tracks. They do not, and it is not the same mechanism: a `MultiOutTrackLink` names a device, `ChainInfo::outputIndex` names a chain of a user rack, and nothing connects the two.

Such a chain is silent in the current engine too. `RackSyncManager` wires it to output pins 3 and up via `ensureRackOutputPair`, and the rack instance it makes for the track never sets `leftFrom`/`rightFrom`, so it reads pins 1 and 2 and nothing is on the other end. `InstrumentRackManager` is the only caller that sets those properties, and only for multi-out instruments.

Compiling nothing is therefore already parity. The message now says the chain reaches nothing rather than promising to route it later. The path is also reachable only from the agent DSL: `setChainOutput` has no UI caller.

## The second commit

The first pass judged a link by whether the device that owns the pair reached emission. Everything that keeps an instrument out of the plan then read as a broken link. Bypass I had handled by resolving ahead of the bypass check; chain power was the other way in, and `emitTrack` only walks `fxChainElements` when `chain.enabled`, so powering off the source track's insert chain told the MultiOut track its pair does not exist.

Patching the second case would have left the third. Whether a link names a pair that exists is a question about the model, so it is answered from the model now, once, before emission. Whether the device is compiled is a separate question, and a pair whose instrument is bypassed or whose chain is powered off is silent for the same reason everything else on that chain is.

Found by the stop-time review, not by me.

## Cases

Nine, five on the compiler and four on the executor:

| Case | What it pins |
| --- | --- |
| pair feeds the track that opened it | routing, and a port per declared pair |
| a link the device cannot honour | a missing pair, a device that is not multi-out, pair 0, two tracks on one pair |
| a bypassed instrument | silent, and not reported |
| a link survives its source not being compiled | chain power off; a link to a missing track still reported |
| multi-out that also writes MIDI | pairs sit after the MIDI port |
| an aux-routed rack chain | reaches nothing, and says so |
| each pair reaches its track | 0.1, 0.2 and 0.3 read off three track meters |
| a pair nobody opened | rendered, dropped, and the master carries the rest |
| an ordinary device | handed no extra outputs at all |
| a pair the device stops writing | goes silent rather than repeating its last block |

## Not in this slice

Channel counts. `MultiOutOutputPair` carries `numChannels`, and the current engine honours a mono pair by pointing `leftFrom` and `rightFrom` at the same pin, but `RenderContext::numChannels` is 2 and says so in its own comment. Every pair here is stereo. That is #2138, where the plan gets a channel model and mono devices and instrument injection come with it.

## Two findings from review

**The ordering edge was gated on arithmetic, not on connectivity.** It read the link's pair number and nothing else, while emission asks four further questions: does the pair resolve, did this track win it, is the source chain running, is the instrument bypassed. An edge with no connection behind it can close a loop that is not there, and `computeTrackOrder`'s cycle breaker resolves a loop by dropping a connection, so a real one would have gone to give an imaginary one its ordering. Both sides ask the same question now, through `multiOutPairIsConnected`.

**The pair cap cited the wrong code.** I justified `kMaxMultiOutPairs = 31` by `RackSyncManager`'s pin clamp, which is the user-rack chain mechanism this PR spends a section proving is unrelated. `wrapMultiOutInstrument` adds a pin per channel with no clamp, and a device's pairs are read off the plugin's own buses. The only real bound is the executor's stack budget, so the constant is that now, at 64 pairs, and a device with more is reported rather than quietly shortened. A link past the budget is told which limit it hit instead of being called a broken link.

Both are pinned by cases: a bypassed multi-out source whose reader routes back into it, which is the shape that used to invent a cycle, and a device declaring more pairs than the budget.

## One unrelated commit

Gitleaks commented on this PR about two tokens in `tests/test_remote_permissions.cpp`, a file it does not touch: the scan runs `--no-git --source .` over the whole tree and uploads SARIF, so every PR gets told about every finding in the repository. Neither is a secret. One is sixteen hex characters, the other is the hex alphabet in order, and both are handed to `registerRemoteSecret` so the test can prove the value never reaches a log line. Marked with gitleaks' own inline signature, which is where a reader of the test will see it. Verified against gitleaks 8.18.1, the version CI installs: two findings before, none after, and the tree is clean.

## Verification

`[compiler]`, `[exec]`, `[goldens]`, `[diff]`, `[crossfade]`, `[layout]`, `[properties]`, `[session]` and `[taps]` pass.

https://claude.ai/code/session_012wuYCTJYYofVqPPy81cJmS
