### PR TITLE
A transport harness for the remote API, and what it found (#2059)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -159,6 +159,13 @@ jobs:
             --entitlements "$ENTITLEMENTS" \
             --sign "$IDENTITY" \
             "$APP_PATH/Contents/MacOS/magda-mcp"
+        else
+          # Not a warning. An MCP host launches this binary directly, so a
+          # release without it is one where every configured host fails at
+          # startup — and the settings page, correctly, offers a placeholder
+          # instead of a path. Better to fail the release than ship that.
+          echo "::error::magda-mcp is missing from the bundle; the build did not stage it"
+          exit 1
         fi
 
         # Sign any embedded frameworks/dylibs
@@ -430,6 +437,13 @@ jobs:
             --entitlements "$ENTITLEMENTS" \
             --sign "$IDENTITY" \
             "$APP_PATH/Contents/MacOS/magda-mcp"
+        else
+          # Not a warning. An MCP host launches this binary directly, so a
+          # release without it is one where every configured host fails at
+          # startup — and the settings page, correctly, offers a placeholder
+          # instead of a path. Better to fail the release than ship that.
+          echo "::error::magda-mcp is missing from the bundle; the build did not stage it"
+          exit 1
         fi
 
         find "$APP_PATH/Contents/Frameworks" -name "*.dylib" -o -name "*.framework" 2>/dev/null | while read -r lib; do
@@ -874,7 +888,10 @@ jobs:
           Copy-Item $mcpBridge "$stage\magda-mcp.exe"
           Write-Output "Copied MCP bridge to staging"
         } else {
-          Write-Warning "magda-mcp.exe not found at $mcpBridge"
+          # See the macOS note: a release without the bridge breaks every
+          # configured MCP host, so this fails rather than warns.
+          Write-Output "::error::magda-mcp.exe not found at $mcpBridge"
+          exit 1
         }
 
         # Runtime DLLs sitting next to MAGDA.exe: the ONNX Runtime DLLs (media DB
@@ -1123,7 +1140,8 @@ jobs:
           echo "Found MCP bridge: $MCP_BRIDGE"
           cp "$MCP_BRIDGE" "$APPDIR/usr/bin/magda-mcp"
         else
-          echo "Warning: magda-mcp not found"
+          echo "::error::magda-mcp not found; the AppImage would ship without it"
+          exit 1
         fi
 
         # Localization JSON - StringTable looks for lang/ next to the binary
@@ -1235,7 +1253,10 @@ jobs:
           sha256sum "magda-mcp-${VERSION}-Linux-x86_64" > "magda-mcp-${VERSION}-Linux-x86_64.sha256"
           cat "magda-mcp-${VERSION}-Linux-x86_64.sha256"
         else
-          echo "Warning: magda-mcp not found; the Linux MCP asset will be missing"
+          # The asset Linux users are told to download, so its absence is the
+          # whole feature missing on that platform rather than a detail.
+          echo "::error::magda-mcp not found; the Linux MCP asset would be missing"
+          exit 1
         fi
 
     - name: Upload artifact

--- a/Makefile
+++ b/Makefile
@@ -360,6 +360,40 @@ test-list: test-build
 	@mkdir -p $(CACHE_ROOT)/home $(CACHE_ROOT)/tmp $(CACHE_ROOT)/xdg
 	cd $(BUILD_DIR) && $(TEST_ENV) ./tests/magda_tests --list-tests
 
+# Drive a running MAGDA over every remote transport (#2059).
+#
+# Not part of `make test`: it needs a MAGDA that is actually running with the
+# remote API switched on, which is the whole point — it checks the installed
+# artefact rather than the tree. ARGS passes flags through, e.g.
+# `make test-transport ARGS="--osc --write"`.
+.PHONY: test-transport
+test-transport:
+	@echo "🔌 Checking the remote transports against a running MAGDA..."
+	@if [ -x .venv/bin/python ]; then \
+		.venv/bin/python tools/transport_check $(ARGS); \
+	else \
+		python3 tools/transport_check $(ARGS); \
+	fi
+
+# The transport harness against a stub, so it can be checked with no MAGDA and
+# no network. This one is safe to run anywhere.
+.PHONY: test-transport-selftest
+test-transport-selftest:
+	@echo "🔌 Checking the transport harness itself..."
+	python3 tools/transport_check/selftest.py
+
+# Prove each check can fail: break the stub 23 ways and confirm the check meant
+# to catch each one does. Slow — it runs the whole harness per mutation. Uses
+# .venv when it exists, which adds the official-SDK mutations.
+.PHONY: test-transport-mutations
+test-transport-mutations:
+	@echo "🔌 Breaking the stub to prove the checks bite..."
+	@if [ -x .venv/bin/python ]; then \
+		.venv/bin/python tools/transport_check/mutation_test.py; \
+	else \
+		python3 tools/transport_check/mutation_test.py; \
+	fi
+
 # Clean build artifacts
 .PHONY: clean
 clean:

--- a/docs/remote-api-mcp.md
+++ b/docs/remote-api-mcp.md
@@ -197,6 +197,15 @@ closed objects: unknown fields are rejected, numbers must be finite and in range
 access, and `openWorldHint: false`, since nothing here reaches outside the open
 project.
 
+Every modern result carries `resultType`, and a **cacheable** one — the two
+catalogue lists, the template list, `resources/read`, and `server/discover` —
+carries `ttlMs` and `cacheScope` beside it, which that revision makes required
+rather than optional. Both say the same thing: `ttlMs` is `0` and `cacheScope`
+is `private`. Nothing here may be held. This projects a session someone is
+editing, so a cached result is one that can be wrong, and everything behind the
+bearer token belongs to one user. `tools/call` is not cacheable and carries
+neither.
+
 A successful call returns the operation's output as `structuredContent`, the same
 JSON serialized into a `content` text block, and the committed project revision in
 `_meta`:
@@ -249,8 +258,18 @@ Templates, from `resources/templates/list`:
 | `magda://clips/{clip_id}` | `clips.get` |
 
 A read returns one `contents` entry, `application/json`, whose `text` is byte for
-byte what `tools/call` puts in `structuredContent` for the same operation. That
-equivalence is asserted in the tests rather than assumed.
+byte what `tools/call` puts in `structuredContent` for the same operation — with
+one exception, below. That equivalence is asserted in the tests rather than
+assumed, for an object-valued operation and an array-valued one, because only
+the second meets the exception.
+
+**Array-valued operations differ by a wrapper.** MCP types `structuredContent`
+as an object, so `tracks.list` and the other list reads are wrapped as
+`{"items": [...]}` on the tool surface. A resource has no `outputSchema` to
+satisfy, so `resources/read` returns the array bare. Same data, two shapes: read
+`magda://tracks` and you get `[...]`, call `tracks.list` and you get
+`{"items": [...]}`. The WebSocket transport returns the bare array too — the
+wrapper is MCP's constraint, not the contract's.
 
 `magda://devices` lists devices that exist on tracks; `magda://devices/catalog`
 lists device *kinds* that can be added, addressed by `catalogId`. The two are not

--- a/magda/daw/api/remote_mcp.cpp
+++ b/magda/daw/api/remote_mcp.cpp
@@ -154,6 +154,41 @@ bool isCatalogueMethod(const juce::String& method) {
            method == "resources/templates/list";
 }
 
+/**
+ * @brief Methods whose modern result the schema types as cacheable.
+ *
+ * `2026-07-28` gives a cacheable result its own cache directives, and makes
+ * them required rather than optional: `resultType` alone does not satisfy the
+ * schema. A client that validates against it — the official SDK does — rejects
+ * the response outright, so omitting them is not a client being lenient about a
+ * missing field, it is the catalogue failing to parse and the session being
+ * useless from its first call.
+ *
+ * `tools/call` is deliberately absent: its result is not cacheable, and
+ * stamping directives on it would put fields on the wire the schema for that
+ * method does not have. `prompts/list` is the sixth cacheable method and is
+ * not served here.
+ */
+bool isCacheableResult(const juce::String& method) {
+    return method == "tools/list" || method == "resources/list" ||
+           method == "resources/templates/list" || method == "resources/read" ||
+           method == "server/discover";
+}
+
+/**
+ * @brief Say that nothing here may be held.
+ *
+ * `ttlMs` of zero, scope `private`. Both are the honest answer rather than a
+ * placeholder: this endpoint projects a live session that the person at the
+ * keyboard is editing, so a result cached for any length of time is a result
+ * that can be wrong, and everything behind the bearer token belongs to one
+ * user rather than to a shared cache.
+ */
+void setCacheDirectives(juce::var& result) {
+    setProperty(result, "ttlMs", 0);
+    setProperty(result, "cacheScope", "private");
+}
+
 int resourceReadCodeFor(ErrorCode code) {
     switch (code) {
         case ErrorCode::NotFound:
@@ -365,6 +400,8 @@ juce::var McpEndpoint::discoverResult() const {
 
     auto result = makeObject();
     setProperty(result, "resultType", "complete");
+    // Modern by definition: server/discover exists only in this revision.
+    setCacheDirectives(result);
     setProperty(result, "supportedVersions", versions);
     setProperty(result, "capabilities", capabilities());
     setProperty(result, "instructions", kInstructions);
@@ -568,12 +605,15 @@ juce::var McpEndpoint::listenClosedResult(const juce::var& subscriptionId) {
 void McpEndpoint::handle(const Call& call, Completion onComplete) {
     const auto modern = call.era == McpEra::Modern;
 
-    auto complete = [modern, this](juce::var result) {
+    auto complete = [modern, method = call.method, this](juce::var result) {
         // `resultType` exists only in the modern era. Stamping it on a legacy
         // reply would put a field on the wire that the revision the client
-        // negotiated has never heard of.
+        // negotiated has never heard of. The same goes for the cache
+        // directives, which that revision introduced alongside it.
         if (modern) {
             setProperty(result, "resultType", "complete");
+            if (isCacheableResult(method))
+                setCacheDirectives(result);
             auto meta = result["_meta"];
             if (meta.getDynamicObject() == nullptr)
                 meta = makeObject();
@@ -843,8 +883,10 @@ void McpEndpoint::readResource(const Call& call, Completion onComplete) {
                 setProperty(meta, MCP_META_SERVER_INFO, info);
 
             auto result = makeObject();
-            if (modern)
+            if (modern) {
                 setProperty(result, "resultType", "complete");
+                setCacheDirectives(result);
+            }
             setProperty(result, "contents", all);
             setProperty(result, "_meta", meta);
             onComplete(McpReply::ok(result));

--- a/tests/test_remote_mcp_server.cpp
+++ b/tests/test_remote_mcp_server.cpp
@@ -519,6 +519,102 @@ TEST_CASE("A tool call and a resource read return the same projection",
             juce::JSON::toString(viaTool.json["result"]["structuredContent"], true));
 }
 
+TEST_CASE("An array-valued operation differs across the surfaces only by its wrapper",
+          "[remote][mcp-http][parity]") {
+    // The case the object-valued parity test above cannot reach. MCP types
+    // `structuredContent` as an object, so a list read is wrapped as
+    // `{"items": [...]}` on the tool surface while the resource returns it
+    // bare. Both carry the same data, and asserting only the object-valued
+    // operation left the wrapper unexercised — which is how the two surfaces
+    // came to disagree in a way nothing in the tree noticed.
+    MessageThreadRelaxation relax;
+    MockMagdaApi api;
+
+    RemoteApiService service(api);
+    RemoteMcpServer server(service, testOptions());
+    REQUIRE(server.start());
+
+    httplib::Client client(base(server));
+
+    const auto viaTool =
+        call(client, "tools/call",
+             object({{"name", "tracks.list"}, {"arguments", juce::var(new juce::DynamicObject())}}),
+             "tracks.list");
+    REQUIRE(viaTool.status == 200);
+
+    const auto viaResource =
+        call(client, "resources/read", object({{"uri", "magda://tracks"}}), "magda://tracks");
+    REQUIRE(viaResource.status == 200);
+
+    const auto* contents = viaResource.json["result"]["contents"].getArray();
+    REQUIRE(contents != nullptr);
+    const auto readText = (*contents)[0]["text"].toString();
+
+    // The tool surface wraps; the resource does not.
+    const auto structured = viaTool.json["result"]["structuredContent"];
+    REQUIRE(structured.getDynamicObject() != nullptr);
+    REQUIRE(structured.hasProperty("items"));
+    REQUIRE(structured["items"].isArray());
+    REQUIRE(readText == juce::JSON::toString(structured["items"], true));
+
+    // And the bare array is what the WebSocket transport returns, unwrapped.
+    const auto direct = service.dispatchSync("tracks.list", juce::var(new juce::DynamicObject()),
+                                             fullyGrantedContext());
+    REQUIRE(direct.ok);
+    REQUIRE(direct.result.isArray());
+    REQUIRE(juce::JSON::toString(direct.result, true) == readText);
+}
+
+TEST_CASE("A cacheable modern result carries its cache directives", "[remote][mcp-http][parity]") {
+    // `2026-07-28` makes `ttlMs` and `cacheScope` required on a cacheable
+    // result rather than optional, so a client validating against the schema
+    // rejects a response that stamps `resultType` alone — the catalogue fails
+    // to parse and the session is useless from its first call.
+    MessageThreadRelaxation relax;
+    MockMagdaApi api;
+
+    RemoteApiService service(api);
+    RemoteMcpServer server(service, testOptions());
+    REQUIRE(server.start());
+
+    httplib::Client client(base(server));
+
+    const auto cacheable = {std::string("tools/list"), std::string("resources/list"),
+                            std::string("resources/templates/list")};
+    for (const auto& method : cacheable) {
+        const auto reply = call(client, juce::String(method));
+        REQUIRE(reply.status == 200);
+        const auto result = reply.json["result"];
+        REQUIRE(result["resultType"].toString() == "complete");
+        REQUIRE(result.hasProperty("ttlMs"));
+        REQUIRE(static_cast<int>(result["ttlMs"]) == 0);
+        REQUIRE(result["cacheScope"].toString() == "private");
+    }
+
+    const auto read =
+        call(client, "resources/read", object({{"uri", "magda://tracks"}}), "magda://tracks");
+    REQUIRE(read.status == 200);
+    REQUIRE(static_cast<int>(read.json["result"]["ttlMs"]) == 0);
+    REQUIRE(read.json["result"]["cacheScope"].toString() == "private");
+
+    const auto discover = call(client, "server/discover");
+    REQUIRE(discover.status == 200);
+    REQUIRE(static_cast<int>(discover.json["result"]["ttlMs"]) == 0);
+    REQUIRE(discover.json["result"]["cacheScope"].toString() == "private");
+
+    // `tools/call` is not cacheable, and the schema for that method has no
+    // place for the directives — stamping them would be as wrong as omitting
+    // them from the ones above.
+    const auto called =
+        call(client, "tools/call",
+             object({{"name", "tracks.list"}, {"arguments", juce::var(new juce::DynamicObject())}}),
+             "tracks.list");
+    REQUIRE(called.status == 200);
+    REQUIRE(called.json["result"]["resultType"].toString() == "complete");
+    REQUIRE(!called.json["result"].hasProperty("ttlMs"));
+    REQUIRE(!called.json["result"].hasProperty("cacheScope"));
+}
+
 TEST_CASE("A mutation through MCP is one undo step", "[remote][mcp-http][parity]") {
     MessageThreadRelaxation relax;
     MockMagdaApi api;

--- a/tools/transport_check/README.md
+++ b/tools/transport_check/README.md
@@ -1,0 +1,170 @@
+# magda-transport-check
+
+Drives a **running MAGDA** over every remote transport and reports what
+answered: JSON-RPC over WebSocket, MCP in both protocol eras over HTTP, MCP
+over stdio through `magda-mcp`, and OSC over UDP.
+
+```bash
+python3 tools/transport_check --all
+```
+
+Python 3.9+, no dependencies. That is deliberate: this is meant to be run
+against an *installed* build, often on a machine that is not a dev box, and
+"create a virtualenv first" is a step that stops people running it.
+
+One suite is the exception. `--mcp-sdk` drives the endpoint with the **official
+MCP SDK**, which needs Python 3.10+ and an install; it is skipped, with a note
+saying why, when it is not importable. See [A second, independent
+host](#a-second-independent-host) — it is the suite most likely to find
+something.
+
+## Why it exists
+
+The in-tree tests already drive these transports over real sockets, and
+`test_remote_mcp_bridge.cpp` forks the real bridge binary. What none of them can
+establish is the thing [#2059](https://github.com/Conceptual-Machines/magda-core/issues/2059)
+asks for: whether an installed artefact answers a client written from
+`docs/remote-api-mcp.md` rather than from the source. This is that client. It
+shares no code with the app — it re-derives the discovery record location, the
+header rules and the `_meta` shapes from the documentation, so a disagreement
+between the docs and the build shows up here as a failing check.
+
+## What it needs
+
+| Suite | Needs |
+|---|---|
+| everything | MAGDA running with **AI Settings → Remote** switched on |
+| `--osc` | **OSC enabled** in the Controllers settings (it is off by default) |
+| `--bridge` | `magda-mcp` beside the running executable, on `PATH`, or `--bridge-path` |
+| `--mcp-sdk` | Python 3.10+ with `pip install -r tools/transport_check/requirements.txt` |
+
+MAGDA is found the way the bridge finds it — the newest live
+`remote-api-<pid>.json` under `MAGDA_DATA_DIR`, the `dataDir` in `config.json`,
+or the per-user app data directory, in that order.
+
+## Running it
+
+```bash
+python3 tools/transport_check --all          # every suite, nothing mutated
+python3 tools/transport_check --ws --osc     # just those two
+python3 tools/transport_check --all --write  # add the mutating checks
+python3 tools/transport_check --all --json   # machine-readable report
+```
+
+Exit status is `0` if nothing failed, `1` if something did, `2` if no running
+MAGDA could be found.
+
+### `--write`
+
+Default runs change nothing. `--write` adds the checks that have to mutate to
+mean anything — that a write advances the revision, that a stale
+`expectedRevision` is refused, that an OSC message reaches the project — and
+each one reverts what it touched. It points at whatever project you have open,
+so it leaves a couple of undo steps behind. Use a scratch project.
+
+## A second, independent host
+
+Everything above is a client written from `docs/remote-api-mcp.md`. That shares
+a blind spot with MAGDA's own tests: it asks the way the documentation says to,
+so a disagreement between the documentation and the specification is invisible
+to both.
+
+`--mcp-sdk` closes that. The official SDK validates every response against the
+protocol schema for the version it negotiated, so it rejects shapes a
+hand-written client accepts:
+
+```bash
+python3 -m venv .venv
+.venv/bin/pip install -r tools/transport_check/requirements.txt
+.venv/bin/python tools/transport_check --mcp-sdk
+```
+
+It also reports **which era it negotiated**. The SDK probes the modern era with
+`server/discover` and falls back to the `initialize` handshake if that probe
+does not take, so a modern endpoint that answers `server/discover` in a shape
+the client cannot parse silently serves every host its legacy path. That shows
+up here as an inconclusive verdict naming the version it settled for, rather
+than as a pass.
+
+### What the schema requires of a modern result
+
+In `2026-07-28` a cacheable result must carry `ttlMs` and `cacheScope` beside
+`resultType` — `tools/list`, `resources/list`, `resources/templates/list`,
+`resources/read` and `server/discover` all do. `tools/call` does not. The
+legacy schema requires none of it. A server that stamps `resultType` alone is
+refused by a validating client on every one of those methods, which is a
+failure no amount of testing against a permissive client will show.
+
+## The four verdicts
+
+`OK` and `FAIL` are what they look like. The other two carry weight:
+
+- **`skip`** — the check did not run. A missing `magda-mcp`, `--write` not
+  passed, no `mcpUrl` in the record.
+- **`?` (inconclusive)** — the check ran and could not reach a verdict. Some
+  of what this asks cannot be decided from outside the app. The clearest case
+  is the OSC snapshot: MAGDA sends a full state dump to a surface it has not
+  heard from before and nothing to one it already knows, so a second run in one
+  MAGDA session sees silence that means nothing is wrong. Reporting that as
+  `FAIL` would train you to ignore red, so it gets its own colour and a
+  sentence saying what else it could be.
+
+## Clients it registers
+
+Two entries appear in **AI Settings → Clients** after a run:
+
+| Name | Grant it |
+|---|---|
+| `magda-transport-check` | `edit` and `transport`, if you want `--write` to work |
+| `magda-transport-check-readonly` | **nothing, ever** |
+
+The second exists because "a new client can only read" is the first thing a
+real user hits, and checking it needs a client the user has not trusted.
+Granting that name anything makes those checks pass for the wrong reason — the
+harness says so in its output rather than quietly going green.
+
+## Checking the harness itself
+
+```bash
+python3 tools/transport_check/selftest.py
+```
+
+Stands up a stub MAGDA — WebSocket, MCP in both eras, OSC, and a stand-in
+bridge — and runs the whole harness against it. Needs no MAGDA and no network,
+so it belongs anywhere CI can run Python.
+
+One check is *expected* to fail there: `magda-mcp is staged beside the MAGDA
+executable` looks beside the binary behind the record's pid, which under the
+self-test is the Python interpreter. The self-test asserts that it fails, since
+a pass would mean the check was not looking at anything.
+
+### Proving the checks are not vacuous
+
+```bash
+python3 tools/transport_check/mutation_test.py
+```
+
+Breaks the stub one way at a time — auth bypassed, `Mcp-Name` unvalidated,
+permissions ignored, revisions frozen, OSC silenced — and asserts that the
+check which exists to catch that regression is the one that goes red. All 20
+mutations are currently caught — 20 always, plus 3 more when the official
+SDK is installed.
+
+This is what keeps the suite honest. **When you add a check to `suites.py`, add
+the matching mutation here**; if nothing goes red without it, you have added a
+line that can only ever print `OK`. It runs the whole harness once per
+mutation, so it is slow — a minute or two — and is not part of `make test`.
+
+## Layout
+
+| File | |
+|---|---|
+| `cli.py` | argument parsing and suite selection |
+| `discovery.py` | finding a live MAGDA; record parsing and permissions |
+| `wire.py` | WebSocket client, OSC codec, SSE reader — all stdlib |
+| `clients.py` | JSON-RPC / MCP-HTTP / MCP-stdio / OSC clients |
+| `suites.py` | the checks |
+| `report.py` | verdicts and console rendering |
+| `sdk_suite.py` | the same endpoint driven by the official MCP SDK |
+| `selftest.py` | the stub MAGDA and the harness's own test |
+| `mutation_test.py` | breaks the stub to prove each check can fail |

--- a/tools/transport_check/README.md
+++ b/tools/transport_check/README.md
@@ -95,6 +95,24 @@ legacy schema requires none of it. A server that stamps `resultType` alone is
 refused by a validating client on every one of those methods, which is a
 failure no amount of testing against a permissive client will show.
 
+## Sharing the endpoint
+
+The MCP endpoint's rate limit is **one bucket for the whole endpoint**, not one
+per client — deliberately, since every caller arrives from 127.0.0.1 presenting
+the same token, so nothing there can tell two local processes apart. The bucket
+holds `maxConcurrentRequests` tokens (eight) and refills at
+`maxRequestsPerSecond`.
+
+Two consequences:
+
+- The harness paces itself (~40 req/s) and rides out a 429 with backoff rather
+  than reporting it. Without that, a dozen checks drain the bucket and every
+  check after them fails with a 429 that says nothing about what it was
+  checking. `--cooldown` sets the pause between suites.
+- **Anything else you have configured against this MAGDA spends from the same
+  budget** — an MCP host in an editor, say. If the run reports that it was
+  throttled, that is what it means. Quit the other client for a clean run.
+
 ## The four verdicts
 
 `OK` and `FAIL` are what they look like. The other two carry weight:

--- a/tools/transport_check/__main__.py
+++ b/tools/transport_check/__main__.py
@@ -1,0 +1,18 @@
+"""Entry point, so `python3 tools/transport_check` runs the harness.
+
+The work is in `cli.py` rather than here because `__main__` cannot be imported
+by name once something else owns that name — which is exactly what happens when
+`selftest.py` drives the harness in-process.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from cli import main  # noqa: E402
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/transport_check/cli.py
+++ b/tools/transport_check/cli.py
@@ -1,0 +1,166 @@
+"""magda-transport-check — drive a running MAGDA over every remote transport.
+
+    python3 tools/transport_check --all
+
+What the in-tree tests cannot establish is whether an *installed* build answers
+a client that was written from the documentation. This is that client. It finds
+MAGDA the way the bridge does, then speaks JSON-RPC over WebSocket, MCP in both
+protocol eras over HTTP, MCP over stdio through `magda-mcp`, and OSC over UDP,
+asserting the things #2059 lists as needing doing against a build.
+
+Nothing it does by default changes the open project. `--write` adds the checks
+that have to mutate to mean anything; they revert what they touch.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+# Running the directory puts it on sys.path, so the modules beside this one
+# import by bare name whether this is run as a directory, a file, or -m.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import discovery  # noqa: E402
+import suites  # noqa: E402
+from report import Report  # noqa: E402
+
+SUITES = ("discovery", "ws", "mcp", "mcp_sdk", "bridge", "readonly", "osc")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="magda-transport-check",
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "MAGDA must be running with AI Settings -> Remote switched on.\n"
+            "The OSC suite additionally needs OSC enabled in the Controllers settings.\n"
+        ),
+    )
+    selection = parser.add_argument_group("what to run (default: everything)")
+    selection.add_argument("--all", action="store_true", help="run every suite")
+    selection.add_argument("--ws", "--websocket", dest="ws", action="store_true",
+                           help="the WebSocket transport")
+    selection.add_argument("--mcp", action="store_true",
+                           help="the MCP endpoint, both protocol eras")
+    selection.add_argument("--mcp-sdk", dest="mcp_sdk", action="store_true",
+                           help="the MCP endpoint driven by the official SDK "
+                                "(needs Python 3.10+ and `pip install mcp`)")
+    selection.add_argument("--bridge", action="store_true",
+                           help="MCP through the magda-mcp stdio bridge")
+    selection.add_argument("--readonly", action="store_true",
+                           help="that an ungranted client is refused a write")
+    selection.add_argument("--osc", action="store_true", help="the OSC listener and its feedback")
+
+    behaviour = parser.add_argument_group("behaviour")
+    behaviour.add_argument("--write", action="store_true",
+                           help="also run the checks that mutate the open project "
+                                "(each reverts what it changed)")
+    behaviour.add_argument("--stream-window", type=float, default=3.0, metavar="SECONDS",
+                           help="how long to hold a notification stream open (default: 3)")
+    behaviour.add_argument("--timeout", type=float, default=10.0, metavar="SECONDS",
+                           help="per-request timeout (default: 10)")
+
+    where = parser.add_argument_group("where to look")
+    where.add_argument("--record", metavar="PATH", help="use this discovery record")
+    where.add_argument("--data-dir", metavar="PATH",
+                       help="look for discovery records here (as MAGDA_DATA_DIR would)")
+    where.add_argument("--bridge-path", metavar="PATH",
+                       help="the magda-mcp binary to drive, if it is not beside MAGDA")
+    where.add_argument("--osc-port", type=int, default=9000, metavar="PORT",
+                       help="MAGDA's OSC receive port (default: 9000)")
+    where.add_argument("--osc-feedback-port", type=int, default=9001, metavar="PORT",
+                       help="the port MAGDA sends feedback to (default: 9001)")
+
+    output = parser.add_argument_group("output")
+    output.add_argument("--json", action="store_true", help="emit the report as JSON on stdout")
+    output.add_argument("-v", "--verbose", action="store_true",
+                        help="show the detail line for passing checks too")
+    output.add_argument("--no-colour", "--no-color", dest="colour",
+                        action="store_false", default=None, help="never colour the output")
+    return parser
+
+
+def chosen(args: argparse.Namespace) -> set[str]:
+    picked = {name for name in SUITES if getattr(args, name.replace("-", "_"), False)}
+    if args.all or not picked:
+        return set(SUITES)
+    # Discovery is the run's own preamble: every other suite needs the record
+    # it resolves, so it is never opt-out.
+    picked.add("discovery")
+    return picked
+
+
+def run(argv: list[str] | None = None) -> Report | None:
+    """Run the selected suites and return the report, or None if no MAGDA was found.
+
+    Split from `main` so `selftest.py` can inspect the findings rather than
+    only the exit status — a self-test that could see nothing but "non-zero"
+    could not tell a harness bug from the check it is supposed to fail.
+    """
+    args = build_parser().parse_args(argv)
+    selected = chosen(args)
+
+    report = Report(verbose=args.verbose, colour=args.colour)
+
+    try:
+        record, others = discovery.resolve(args.record, args.data_dir)
+    except discovery.DiscoveryError as exc:
+        print(f"\n  {exc}\n", file=sys.stderr)
+        return None
+
+    print(f"\n  MAGDA pid {record.pid}  ws :{record.port}"
+          + (f"  mcp :{record.mcp_port}" if record.mcp_port else "  mcp: not listening"))
+    print(f"  {record.path}")
+    if args.write:
+        print("\n  --write: the mutating checks will run and revert what they change.")
+
+    context = suites.Context(
+        record=record,
+        report=report,
+        write=args.write,
+        stream_window=args.stream_window,
+        osc_send_port=args.osc_port,
+        osc_feedback_port=args.osc_feedback_port,
+        bridge_path=args.bridge_path,
+        data_dir=Path(args.data_dir) if args.data_dir else None,
+        timeout=args.timeout,
+    )
+
+    if "discovery" in selected:
+        suites.run_discovery(context, others)
+    if "ws" in selected:
+        suites.run_websocket(context)
+    if "mcp" in selected:
+        suites.run_mcp_modern(context)
+        suites.run_mcp_legacy(context)
+    if "mcp_sdk" in selected:
+        from sdk_suite import run_sdk
+
+        run_sdk(context)
+    if "bridge" in selected:
+        suites.run_bridge(context)
+        suites.run_bridge_without_magda(context)
+    if "readonly" in selected:
+        suites.run_readonly(context)
+    if "osc" in selected:
+        suites.run_osc(context)
+
+    report.summarise()
+    if args.json:
+        print(report.to_json())
+
+    return report
+
+
+def main(argv: list[str] | None = None) -> int:
+    report = run(argv)
+    if report is None:
+        return 2
+    return 1 if report.failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/transport_check/cli.py
+++ b/tools/transport_check/cli.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import argparse
 import sys
+import time
 from pathlib import Path
 
 # Running the directory puts it on sys.path, so the modules beside this one
@@ -62,6 +63,9 @@ def build_parser() -> argparse.ArgumentParser:
                            help="how long to hold a notification stream open (default: 3)")
     behaviour.add_argument("--timeout", type=float, default=10.0, metavar="SECONDS",
                            help="per-request timeout (default: 10)")
+    behaviour.add_argument("--cooldown", type=float, default=1.5, metavar="SECONDS",
+                           help="pause between suites so the endpoint's shared rate "
+                                "limit bucket refills (default: 1.5)")
 
     where = parser.add_argument_group("where to look")
     where.add_argument("--record", metavar="PATH", help="use this discovery record")
@@ -129,24 +133,48 @@ def run(argv: list[str] | None = None) -> Report | None:
         timeout=args.timeout,
     )
 
+    def cooldown() -> None:
+        """Let the endpoint's token bucket refill between suites.
+
+        One bucket serves the whole endpoint and the SSE checks hold a
+        connection for their whole window, so a suite that starts the instant
+        the last one finished can be refused for reasons that have nothing to
+        do with what it is checking.
+        """
+        time.sleep(args.cooldown)
+
     if "discovery" in selected:
         suites.run_discovery(context, others)
+    cooldown()
     if "ws" in selected:
         suites.run_websocket(context)
+    cooldown()
     if "mcp" in selected:
         suites.run_mcp_modern(context)
         suites.run_mcp_legacy(context)
+    cooldown()
     if "mcp_sdk" in selected:
         from sdk_suite import run_sdk
 
         run_sdk(context)
+    cooldown()
     if "bridge" in selected:
         suites.run_bridge(context)
         suites.run_bridge_without_magda(context)
+    cooldown()
     if "readonly" in selected:
         suites.run_readonly(context)
+    cooldown()
     if "osc" in selected:
         suites.run_osc(context)
+
+    throttled = context.throttled()
+    if throttled:
+        report.note(
+            f"the endpoint rate-limited this run {throttled} time(s) and the harness "
+            "backed off. The limit is one bucket for the whole endpoint, so another "
+            "client — an MCP host you have configured, for instance — shares it."
+        )
 
     report.summarise()
     if args.json:

--- a/tools/transport_check/clients.py
+++ b/tools/transport_check/clients.py
@@ -1,0 +1,649 @@
+"""Protocol clients: JSON-RPC over WebSocket, MCP over HTTP, MCP over stdio.
+
+Each of these speaks to MAGDA the way a real client would, from outside the
+process. Nothing here imports anything from the app — that is the whole point
+of the exercise, since what #2059 asks to establish is exactly the part the
+in-tree tests cannot reach: that an installed build answers a client that was
+built against the documentation rather than against the source.
+"""
+
+from __future__ import annotations
+
+import http.client
+import json
+import os
+import socket
+import subprocess
+import threading
+import time
+from dataclasses import dataclass
+from typing import Any
+
+from wire import SseParser, WebSocket, osc_decode, osc_encode
+
+#: What this harness calls itself. Stable rather than random so it occupies one
+#: row in AI Settings -> Clients instead of a new one per run.
+CLIENT_NAME = "magda-transport-check"
+
+#: A second identity that must never be granted anything. The read-only checks
+#: need a client the user has not trusted, and reusing the name above would
+#: mean the first grant made those checks pass for the wrong reason.
+READONLY_CLIENT_NAME = "magda-transport-check-readonly"
+
+CLIENT_VERSION = "1.0"
+
+MODERN_PROTOCOL = "2026-07-28"
+LEGACY_PROTOCOL = "2025-11-25"
+
+META_PROTOCOL_VERSION = "io.modelcontextprotocol/protocolVersion"
+META_CLIENT_CAPABILITIES = "io.modelcontextprotocol/clientCapabilities"
+META_CLIENT_INFO = "io.modelcontextprotocol/clientInfo"
+MAGDA_META_REVISION = "com.conceptualmachines.magda/revision"
+MAGDA_META_EXPECTED_REVISION = "com.conceptualmachines.magda/expectedRevision"
+MAGDA_META_REQUEST_ID = "com.conceptualmachines.magda/requestId"
+
+
+class ProtocolError(Exception):
+    pass
+
+
+# ---------------------------------------------------------------------------
+# WebSocket JSON-RPC
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Reply:
+    """A JSON-RPC reply, kept whole so a check can assert on any part of it."""
+
+    raw: dict[str, Any]
+
+    @property
+    def ok(self) -> bool:
+        return "result" in self.raw
+
+    @property
+    def result(self) -> Any:
+        return self.raw.get("result")
+
+    @property
+    def error(self) -> dict[str, Any] | None:
+        return self.raw.get("error")
+
+    @property
+    def code(self) -> int | None:
+        error = self.error
+        return error.get("code") if error else None
+
+    @property
+    def revision(self) -> int | None:
+        meta = self.raw.get("meta") or {}
+        value = meta.get("revision")
+        if value is None and self.error:
+            value = (self.error.get("data") or {}).get("revision")
+        return value
+
+
+class WsClient:
+    """MAGDA's `/rpc`, as a blocking request/response client.
+
+    Pushed events share the socket with replies, so `call` buffers any
+    notification it meets while waiting rather than discarding it — the
+    subscription check reads them back out afterwards, and a discarded event
+    would make a working push look like a broken one.
+    """
+
+    def __init__(
+        self,
+        host: str,
+        port: int,
+        token: str,
+        client_name: str = CLIENT_NAME,
+        timeout: float = 10.0,
+        origin: str | None = None,
+    ) -> None:
+        self.host = host
+        self.port = port
+        self.token = token
+        self.client_name = client_name
+        self.timeout = timeout
+        self.origin = origin
+        self._ws: WebSocket | None = None
+        self._next_id = 1
+        self.pending_notifications: list[dict[str, Any]] = []
+
+    def connect(self) -> None:
+        headers = {"Authorization": f"Bearer {self.token}"}
+        if self.origin is not None:
+            headers["Origin"] = self.origin
+        path = "/rpc"
+        if self.client_name:
+            path += f"?client={self.client_name}"
+        self._ws = WebSocket(self.host, self.port, path, headers, timeout=self.timeout)
+        self._ws.connect()
+
+    def close(self) -> None:
+        if self._ws is not None:
+            self._ws.close()
+            self._ws = None
+
+    def __enter__(self) -> "WsClient":
+        self.connect()
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.close()
+
+    def call(
+        self,
+        method: str,
+        params: dict[str, Any] | None = None,
+        meta: dict[str, Any] | None = None,
+        timeout: float | None = None,
+    ) -> Reply:
+        if self._ws is None:
+            raise ProtocolError("not connected")
+        request_id = self._next_id
+        self._next_id += 1
+        request: dict[str, Any] = {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "method": method,
+            "params": params or {},
+        }
+        if meta:
+            request["meta"] = meta
+        self._ws.send_text(json.dumps(request))
+
+        deadline = time.monotonic() + (timeout or self.timeout)
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise TimeoutError(f"no reply to {method}")
+            message = json.loads(self._ws.recv(remaining))
+            if message.get("id") == request_id:
+                return Reply(message)
+            if "method" in message:
+                self.pending_notifications.append(message)
+
+    def collect_notifications(self, window: float) -> list[dict[str, Any]]:
+        """Everything pushed over `window` seconds, plus anything buffered."""
+        collected = list(self.pending_notifications)
+        self.pending_notifications.clear()
+        if self._ws is None:
+            return collected
+        deadline = time.monotonic() + window
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return collected
+            try:
+                message = json.loads(self._ws.recv(remaining))
+            except TimeoutError:
+                return collected
+            if "method" in message:
+                collected.append(message)
+
+
+# ---------------------------------------------------------------------------
+# MCP over Streamable HTTP
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class HttpReply:
+    status: int
+    headers: dict[str, str]
+    body: str
+
+    def json(self) -> dict[str, Any]:
+        try:
+            return json.loads(self.body)
+        except ValueError as exc:
+            raise ProtocolError(f"HTTP {self.status} body is not JSON: {self.body[:200]}") from exc
+
+    @property
+    def session_id(self) -> str | None:
+        return self.headers.get("mcp-session-id")
+
+
+class McpHttpClient:
+    """The MCP endpoint, driven in both protocol eras.
+
+    A fresh connection per request rather than a kept-alive one, because a
+    stateless modern request is allowed to arrive on a new socket every time
+    and that is the shape most likely to catch a server that quietly depends
+    on the connection.
+    """
+
+    def __init__(
+        self,
+        origin: str,
+        path: str,
+        token: str,
+        client_name: str = CLIENT_NAME,
+        timeout: float = 15.0,
+    ) -> None:
+        self.origin = origin
+        self.path = path
+        self.token = token
+        self.client_name = client_name
+        self.timeout = timeout
+        scheme, _, hostport = origin.partition("://")
+        self.scheme = scheme
+        host, _, port = hostport.partition(":")
+        self.host = host
+        self.port = int(port) if port else (443 if scheme == "https" else 80)
+
+    # -- plumbing ---------------------------------------------------------
+
+    def _connect(self, timeout: float | None = None) -> http.client.HTTPConnection:
+        return http.client.HTTPConnection(self.host, self.port, timeout=timeout or self.timeout)
+
+    def request(
+        self,
+        method: str,
+        body: str | None = None,
+        headers: dict[str, str] | None = None,
+        http_method: str = "POST",
+    ) -> HttpReply:
+        conn = self._connect()
+        try:
+            conn.request(http_method, self.path, body, headers or {})
+            response = conn.getresponse()
+            payload = response.read().decode("utf-8", "replace")
+            return HttpReply(
+                response.status,
+                {k.lower(): v for k, v in response.getheaders()},
+                payload,
+            )
+        finally:
+            conn.close()
+
+    def base_headers(self) -> dict[str, str]:
+        return {
+            "Authorization": f"Bearer {self.token}",
+            "Content-Type": "application/json",
+            "Accept": "application/json, text/event-stream",
+        }
+
+    def modern_meta(self, extra: dict[str, Any] | None = None) -> dict[str, Any]:
+        meta = {
+            META_PROTOCOL_VERSION: MODERN_PROTOCOL,
+            META_CLIENT_CAPABILITIES: {},
+            META_CLIENT_INFO: {"name": self.client_name, "version": CLIENT_VERSION},
+        }
+        meta.update(extra or {})
+        return meta
+
+    @staticmethod
+    def _name_for(method: str, params: dict[str, Any]) -> str | None:
+        """The value `Mcp-Name` has to mirror, for the methods that have one."""
+        if method in ("tools/call", "prompts/get"):
+            return params.get("name")
+        if method == "resources/read":
+            return params.get("uri")
+        return None
+
+    # -- modern era -------------------------------------------------------
+
+    def modern(
+        self,
+        method: str,
+        params: dict[str, Any] | None = None,
+        request_id: int | str = 1,
+        meta_extra: dict[str, Any] | None = None,
+        header_overrides: dict[str, str | None] | None = None,
+        omit_meta: bool = False,
+    ) -> HttpReply:
+        """A stateless request. Overrides exist so the negative checks can lie.
+
+        `header_overrides` sets a header to a wrong value, or to None to drop
+        it — which is how the mirrored-header rule is tested from the outside
+        rather than taken on trust.
+        """
+        params = dict(params or {})
+        if not omit_meta:
+            params["_meta"] = self.modern_meta(meta_extra)
+        body = {"jsonrpc": "2.0", "id": request_id, "method": method, "params": params}
+
+        headers = self.base_headers()
+        headers["MCP-Protocol-Version"] = MODERN_PROTOCOL
+        headers["Mcp-Method"] = method
+        if (name := self._name_for(method, params)) is not None:
+            headers["Mcp-Name"] = name
+        for key, value in (header_overrides or {}).items():
+            if value is None:
+                headers.pop(key, None)
+            else:
+                headers[key] = value
+        return self.request(method, json.dumps(body), headers)
+
+    # -- legacy era -------------------------------------------------------
+
+    def initialize(self, version: str = LEGACY_PROTOCOL) -> HttpReply:
+        body = {
+            "jsonrpc": "2.0",
+            "id": "init",
+            "method": "initialize",
+            "params": {
+                "protocolVersion": version,
+                "capabilities": {},
+                "clientInfo": {"name": self.client_name, "version": CLIENT_VERSION},
+            },
+        }
+        return self.request("initialize", json.dumps(body), self.base_headers())
+
+    def legacy(
+        self,
+        method: str,
+        params: dict[str, Any] | None = None,
+        session: str | None = None,
+        request_id: int | str = 1,
+        version: str = LEGACY_PROTOCOL,
+    ) -> HttpReply:
+        headers = self.base_headers()
+        headers["MCP-Protocol-Version"] = version
+        if session:
+            headers["Mcp-Session-Id"] = session
+        body = {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "method": method,
+            "params": params or {},
+        }
+        return self.request(method, json.dumps(body), headers)
+
+    def delete_session(self, session: str) -> HttpReply:
+        headers = self.base_headers()
+        headers["Mcp-Session-Id"] = session
+        return self.request("DELETE", None, headers, http_method="DELETE")
+
+    # -- streams ----------------------------------------------------------
+
+    def stream(
+        self,
+        window: float,
+        body: str | None = None,
+        headers: dict[str, str] | None = None,
+        http_method: str = "POST",
+    ) -> tuple[int, list[Any], int]:
+        """Hold a stream open for `window` seconds.
+
+        Returns the HTTP status, the JSON messages that arrived, and how many
+        keep-alive comments were seen. The comment count is the evidence that a
+        quiet stream stayed up rather than merely not having failed yet.
+        """
+        conn = self._connect(timeout=window + self.timeout)
+        parser = SseParser()
+        messages: list[Any] = []
+        try:
+            conn.request(http_method, self.path, body, headers or {})
+            response = conn.getresponse()
+            if response.status != 200:
+                response.read()
+                return response.status, [], 0
+            deadline = time.monotonic() + window
+            while time.monotonic() < deadline:
+                remaining = deadline - time.monotonic()
+                if conn.sock is not None:
+                    conn.sock.settimeout(max(0.05, min(remaining, 1.0)))
+                try:
+                    chunk = response.read1(65536)
+                except (socket.timeout, TimeoutError):
+                    continue
+                except OSError:
+                    break
+                if not chunk:
+                    break
+                for event in parser.feed(chunk):
+                    try:
+                        messages.append(json.loads(event.data))
+                    except ValueError:
+                        messages.append(event.data)
+            return response.status, messages, parser.comments
+        finally:
+            conn.close()
+
+    def listen_modern(self, uris: list[str], window: float) -> tuple[int, list[Any], int]:
+        params = {
+            "notifications.resourceSubscriptions": uris,
+            "_meta": self.modern_meta(),
+        }
+        body = {
+            "jsonrpc": "2.0",
+            "id": "listen",
+            "method": "subscriptions/listen",
+            "params": params,
+        }
+        headers = self.base_headers()
+        headers["MCP-Protocol-Version"] = MODERN_PROTOCOL
+        headers["Mcp-Method"] = "subscriptions/listen"
+        return self.stream(window, json.dumps(body), headers)
+
+    def listen_legacy(self, session: str, window: float) -> tuple[int, list[Any], int]:
+        headers = self.base_headers()
+        headers["MCP-Protocol-Version"] = LEGACY_PROTOCOL
+        headers["Mcp-Session-Id"] = session
+        return self.stream(window, None, headers, http_method="GET")
+
+
+# ---------------------------------------------------------------------------
+# MCP over stdio, through the magda-mcp bridge
+# ---------------------------------------------------------------------------
+
+
+class McpBridgeClient:
+    """The `magda-mcp` binary, spoken to the way an MCP host does.
+
+    This is the integration surface that matters: the settings page tells users
+    to configure the bridge, not the URL, so a bridge that cannot reach a
+    running MAGDA is a broken product however well the HTTP endpoint behaves.
+
+    stderr is drained on a thread. The bridge writes diagnostics there and a
+    full pipe would block it mid-request, which would look from here exactly
+    like a hang in MAGDA.
+    """
+
+    def __init__(
+        self,
+        path: str,
+        data_dir: str | os.PathLike[str] | None = None,
+        timeout: float = 20.0,
+    ) -> None:
+        self.path = path
+        self.timeout = timeout
+        self.env = dict(os.environ)
+        if data_dir is not None:
+            self.env["MAGDA_DATA_DIR"] = str(data_dir)
+        self.process: subprocess.Popen[bytes] | None = None
+        self.stderr: list[str] = []
+        self._next_id = 1
+        self._stderr_thread: threading.Thread | None = None
+
+    def start(self) -> None:
+        self.process = subprocess.Popen(
+            [self.path],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=self.env,
+        )
+
+        def drain() -> None:
+            assert self.process is not None and self.process.stderr is not None
+            for line in self.process.stderr:
+                self.stderr.append(line.decode("utf-8", "replace").rstrip())
+
+        self._stderr_thread = threading.Thread(target=drain, daemon=True)
+        self._stderr_thread.start()
+
+    def stop(self) -> None:
+        if self.process is None:
+            return
+        try:
+            if self.process.stdin:
+                self.process.stdin.close()
+            self.process.wait(timeout=5)
+        except (subprocess.TimeoutExpired, OSError):
+            self.process.kill()
+            self.process.wait(timeout=5)
+        finally:
+            self.process = None
+
+    def __enter__(self) -> "McpBridgeClient":
+        self.start()
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.stop()
+
+    def call(self, method: str, params: dict[str, Any] | None = None, era: str = "modern") -> dict[str, Any]:
+        """One newline-delimited JSON-RPC round trip over the pipes."""
+        if self.process is None or self.process.stdin is None or self.process.stdout is None:
+            raise ProtocolError("bridge is not running")
+        request_id = self._next_id
+        self._next_id += 1
+        params = dict(params or {})
+        if era == "modern":
+            params["_meta"] = {
+                META_PROTOCOL_VERSION: MODERN_PROTOCOL,
+                META_CLIENT_CAPABILITIES: {},
+                META_CLIENT_INFO: {"name": self.client_name(), "version": CLIENT_VERSION},
+            }
+        request = {"jsonrpc": "2.0", "id": request_id, "method": method, "params": params}
+        self.process.stdin.write((json.dumps(request) + "\n").encode("utf-8"))
+        self.process.stdin.flush()
+
+        deadline = time.monotonic() + self.timeout
+        while time.monotonic() < deadline:
+            line = self._readline(deadline)
+            if line is None:
+                break
+            try:
+                message = json.loads(line)
+            except ValueError:
+                continue
+            if message.get("id") == request_id:
+                return message
+        raise TimeoutError(f"bridge did not answer {method}")
+
+    def client_name(self) -> str:
+        return CLIENT_NAME
+
+    def _readline(self, deadline: float) -> str | None:
+        """A line from stdout, or None if the bridge exited.
+
+        `readline` on the pipe blocks with no timeout of its own, so the wait
+        is bounded by a reader thread rather than by the file object — the
+        no-MAGDA-running case is precisely the one where a hang would be
+        indistinguishable from a slow answer.
+        """
+        assert self.process is not None and self.process.stdout is not None
+        result: list[bytes | None] = []
+
+        def read() -> None:
+            assert self.process is not None and self.process.stdout is not None
+            result.append(self.process.stdout.readline() or None)
+
+        thread = threading.Thread(target=read, daemon=True)
+        thread.start()
+        thread.join(max(0.0, deadline - time.monotonic()))
+        if thread.is_alive() or not result:
+            return None
+        line = result[0]
+        return line.decode("utf-8", "replace").strip() if line else None
+
+
+# ---------------------------------------------------------------------------
+# OSC
+# ---------------------------------------------------------------------------
+
+
+class OscClient:
+    """A surface: sends to MAGDA's receive port, listens on the feedback port.
+
+    The two ports are separate because MAGDA replies to the *host* on a fixed
+    port rather than to the socket a message came from — a real surface sends
+    from an ephemeral port and listens on a known one, and `oscFeedbackPort`
+    exists for exactly that asymmetry.
+    """
+
+    def __init__(
+        self,
+        host: str = "127.0.0.1",
+        send_port: int = 9000,
+        feedback_port: int = 9001,
+    ) -> None:
+        self.host = host
+        self.send_port = send_port
+        self.feedback_port = feedback_port
+        self._send: socket.socket | None = None
+        self._listen: socket.socket | None = None
+
+    def open(self, listen: bool = True) -> None:
+        self._send = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        # Connected UDP: the kernel reports an ICMP port-unreachable back as
+        # ECONNREFUSED, which is the only way to learn from outside that
+        # nothing is bound without asking MAGDA.
+        self._send.connect((self.host, self.send_port))
+        if listen:
+            self._listen = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+            self._listen.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            self._listen.bind(("0.0.0.0", self.feedback_port))
+
+    def close(self) -> None:
+        for sock in (self._send, self._listen):
+            if sock is not None:
+                sock.close()
+        self._send = self._listen = None
+
+    def __enter__(self) -> "OscClient":
+        self.open()
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.close()
+
+    def send(self, address: str, *args: object) -> None:
+        if self._send is None:
+            raise ProtocolError("socket is not open")
+        self._send.send(osc_encode(address, *args))
+
+    def check_reachable(self) -> str | None:
+        """None if the port accepted a datagram, else why it did not.
+
+        UDP has no acknowledgement, so this sends and then looks for the error
+        the previous send queued — which on loopback arrives promptly when
+        nothing is listening, and never when something is.
+        """
+        if self._send is None:
+            raise ProtocolError("socket is not open")
+        try:
+            self._send.send(osc_encode("/magda/transport/loop"))
+            time.sleep(0.15)
+            self._send.send(osc_encode("/magda/transport/loop"))
+        except ConnectionRefusedError:
+            return f"nothing is listening on {self.host}:{self.send_port}"
+        except OSError as exc:
+            return f"{self.host}:{self.send_port} rejected a datagram: {exc}"
+        return None
+
+    def collect(self, window: float) -> list[Any]:
+        """Every OSC message that arrives on the feedback port within `window`."""
+        if self._listen is None:
+            return []
+        received: list[Any] = []
+        deadline = time.monotonic() + window
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return received
+            self._listen.settimeout(remaining)
+            try:
+                data, _ = self._listen.recvfrom(65536)
+            except (socket.timeout, TimeoutError):
+                return received
+            except OSError:
+                return received
+            received.extend(osc_decode(data))

--- a/tools/transport_check/clients.py
+++ b/tools/transport_check/clients.py
@@ -223,12 +223,24 @@ class McpHttpClient:
         token: str,
         client_name: str = CLIENT_NAME,
         timeout: float = 15.0,
+        min_interval: float = 0.025,
+        max_retries: int = 4,
+        backoff: float = 0.25,
     ) -> None:
         self.origin = origin
         self.path = path
         self.token = token
         self.client_name = client_name
         self.timeout = timeout
+        #: Seconds between requests. 40/s against a 50/s limit, so the bucket
+        #: gains a little on every call instead of draining.
+        self.min_interval = min_interval
+        self.max_retries = max_retries
+        self.backoff = backoff
+        #: How many 429s were ridden out. Reported once per run, because a
+        #: number here means something else is sharing the endpoint.
+        self.throttled = 0
+        self._last_request = 0.0
         scheme, _, hostport = origin.partition("://")
         self.scheme = scheme
         host, _, port = hostport.partition(":")
@@ -240,6 +252,20 @@ class McpHttpClient:
     def _connect(self, timeout: float | None = None) -> http.client.HTTPConnection:
         return http.client.HTTPConnection(self.host, self.port, timeout=timeout or self.timeout)
 
+    def _pace(self) -> None:
+        """Stay under the endpoint's rate limit rather than measuring it.
+
+        The bucket holds `maxConcurrentRequests` tokens — eight — and refills at
+        `maxRequestsPerSecond`. Firing checks back to back drains it in about a
+        dozen requests, and everything after that fails with a 429 that says
+        nothing about the thing being checked.
+        """
+        if self.min_interval <= 0:
+            return
+        wait = self._last_request + self.min_interval - time.monotonic()
+        if wait > 0:
+            time.sleep(wait)
+
     def request(
         self,
         method: str,
@@ -247,18 +273,35 @@ class McpHttpClient:
         headers: dict[str, str] | None = None,
         http_method: str = "POST",
     ) -> HttpReply:
-        conn = self._connect()
-        try:
-            conn.request(http_method, self.path, body, headers or {})
-            response = conn.getresponse()
-            payload = response.read().decode("utf-8", "replace")
-            return HttpReply(
-                response.status,
-                {k.lower(): v for k, v in response.getheaders()},
-                payload,
-            )
-        finally:
-            conn.close()
+        """One request, paced, retrying a 429 the way a real client would.
+
+        The limit is one bucket for the endpoint rather than one per client —
+        deliberately, since every caller arrives from 127.0.0.1 with the same
+        token — so anything else talking to MAGDA spends from the same budget.
+        A harness that treated a shared-budget 429 as a verdict would report
+        failures that belong to whatever else was connected.
+        """
+        for attempt in range(self.max_retries + 1):
+            self._pace()
+            conn = self._connect()
+            try:
+                conn.request(http_method, self.path, body, headers or {})
+                response = conn.getresponse()
+                payload = response.read().decode("utf-8", "replace")
+                reply = HttpReply(
+                    response.status,
+                    {k.lower(): v for k, v in response.getheaders()},
+                    payload,
+                )
+            finally:
+                self._last_request = time.monotonic()
+                conn.close()
+
+            if reply.status != 429 or attempt == self.max_retries:
+                return reply
+            self.throttled += 1
+            time.sleep(self.backoff * (2 ** attempt))
+        return reply  # unreachable, but keeps the type honest
 
     def base_headers(self) -> dict[str, str]:
         return {
@@ -374,6 +417,10 @@ class McpHttpClient:
         keep-alive comments were seen. The comment count is the evidence that a
         quiet stream stayed up rather than merely not having failed yet.
         """
+        # A stream costs a token like any other request, and opening one on a
+        # drained bucket answers 429 instead of an event stream.
+        self._pace()
+        self._last_request = time.monotonic()
         conn = self._connect(timeout=window + self.timeout)
         parser = SseParser()
         messages: list[Any] = []

--- a/tools/transport_check/discovery.py
+++ b/tools/transport_check/discovery.py
@@ -25,13 +25,20 @@ class DiscoveryError(Exception):
 
 
 def os_default_app_data_dir() -> Path:
-    """`juce::File::userApplicationDataDirectory` / "MAGDA".
+    """`juce::File::userApplicationDataDirectory` / "MAGDA" — `alwaysOSDefault()`.
 
-    The three values JUCE resolves that special location to, per platform.
-    Linux follows XDG, which is what JUCE's `resolveXDGFolder` does.
+    The three values JUCE resolves that special location to, per platform,
+    read off `juce_Files_*` rather than assumed:
+
+    - macOS is `~/Library`, **not** `~/Library/Application Support`. JUCE keeps
+      the latter for `userApplicationDataDirectory` on no platform, and an app
+      that wants it appends it itself. MAGDA does not, so its data lives in
+      `~/Library/MAGDA`.
+    - Windows is `CSIDL_APPDATA`, the roaming profile.
+    - Linux is `XDG_CONFIG_HOME` or `~/.config`.
     """
     if sys.platform == "darwin":
-        base = Path.home() / "Library" / "Application Support"
+        base = Path.home() / "Library"
     elif sys.platform == "win32":
         appdata = os.environ.get("APPDATA")
         base = Path(appdata) if appdata else Path.home() / "AppData" / "Roaming"
@@ -53,7 +60,7 @@ def data_dir(override: str | os.PathLike[str] | None = None) -> Path:
         return Path(env)
 
     default = os_default_app_data_dir()
-    config = default / "config.json"
+    config = config_file(default)
     if config.is_file():
         try:
             configured = json.loads(config.read_text(encoding="utf-8")).get("dataDir")
@@ -62,6 +69,19 @@ def data_dir(override: str | os.PathLike[str] | None = None) -> Path:
         if configured:
             return Path(configured)
     return default
+
+
+def config_file(default_dir: Path) -> Path:
+    """Where MAGDA reads its configuration from — `paths::configFile()`.
+
+    `MAGDA_CONFIG_FILE` moves the file itself, which is a separate thing from
+    `MAGDA_DATA_DIR` moving everything the file points at. A harness that
+    honoured only the second would read a stale `dataDir` out of the default
+    config while MAGDA was using another one entirely.
+    """
+    if override := os.environ.get("MAGDA_CONFIG_FILE"):
+        return Path(override)
+    return default_dir / "config.json"
 
 
 def process_alive(pid: int) -> bool:

--- a/tools/transport_check/discovery.py
+++ b/tools/transport_check/discovery.py
@@ -1,0 +1,204 @@
+"""Finding a running MAGDA the way a real client does.
+
+This deliberately reimplements `magda::paths::dataDir()` and the record sweep
+in `magda/mcp_bridge/main.cpp` rather than shelling out to anything, because
+resolving the record *is* one of the things #2059 asks to verify. A harness
+that asked MAGDA where its record was would be assuming the answer.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import errno
+import json
+import os
+import stat
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+RECORD_GLOB = "remote-api-*.json"
+
+
+class DiscoveryError(Exception):
+    pass
+
+
+def os_default_app_data_dir() -> Path:
+    """`juce::File::userApplicationDataDirectory` / "MAGDA".
+
+    The three values JUCE resolves that special location to, per platform.
+    Linux follows XDG, which is what JUCE's `resolveXDGFolder` does.
+    """
+    if sys.platform == "darwin":
+        base = Path.home() / "Library" / "Application Support"
+    elif sys.platform == "win32":
+        appdata = os.environ.get("APPDATA")
+        base = Path(appdata) if appdata else Path.home() / "AppData" / "Roaming"
+    else:
+        base = Path(os.environ.get("XDG_CONFIG_HOME") or Path.home() / ".config")
+    return base / "MAGDA"
+
+
+def data_dir(override: str | os.PathLike[str] | None = None) -> Path:
+    """Where discovery records live: env, then config, then the OS default.
+
+    The same three steps the bridge takes. `config.json` itself never moves —
+    only the data directory it names does — so the config is always read from
+    the OS default location even when it redirects everything else.
+    """
+    if override is not None:
+        return Path(override)
+    if env := os.environ.get("MAGDA_DATA_DIR"):
+        return Path(env)
+
+    default = os_default_app_data_dir()
+    config = default / "config.json"
+    if config.is_file():
+        try:
+            configured = json.loads(config.read_text(encoding="utf-8")).get("dataDir")
+        except (OSError, ValueError):
+            configured = None
+        if configured:
+            return Path(configured)
+    return default
+
+
+def process_alive(pid: int) -> bool:
+    """Whether the process that wrote a record is still running.
+
+    A record outliving its process is debris from a crash; its port may since
+    have been handed to something else entirely, so trusting it would point
+    the harness at an unrelated listener.
+    """
+    if pid <= 0:
+        return False
+    if sys.platform == "win32":
+        PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
+        STILL_ACTIVE = 259
+        kernel32 = ctypes.windll.kernel32  # type: ignore[attr-defined]
+        handle = kernel32.OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, False, pid)
+        if not handle:
+            return False
+        try:
+            code = ctypes.c_ulong()
+            if not kernel32.GetExitCodeProcess(handle, ctypes.byref(code)):
+                return False
+            return code.value == STILL_ACTIVE
+        finally:
+            kernel32.CloseHandle(handle)
+    try:
+        os.kill(pid, 0)
+    except PermissionError:
+        # Alive, and someone else's.
+        return True
+    except OSError as exc:
+        if exc.errno == errno.ESRCH:
+            return False
+        raise
+    return True
+
+
+@dataclass
+class Record:
+    """A parsed `remote-api-<pid>.json`."""
+
+    path: Path
+    pid: int
+    token: str
+    port: int
+    url: str
+    mcp_port: int | None
+    mcp_url: str | None
+    mtime: float
+
+    @property
+    def has_mcp(self) -> bool:
+        return bool(self.mcp_url) and bool(self.mcp_port)
+
+    def owner_only(self) -> bool | None:
+        """True iff the record is readable by its owner alone.
+
+        #2059 asks that the credential is written with owner-only permissions
+        from an *installed* build, which is a property of the file rather than
+        of any request, so it is checked here. Windows has no mode bits worth
+        reading — the file inherits the per-user directory's ACL — so this
+        returns None there rather than a misleading answer.
+        """
+        if sys.platform == "win32":
+            return None
+        mode = self.path.stat().st_mode
+        return not (mode & (stat.S_IRWXG | stat.S_IRWXO))
+
+    def mcp_origin_and_path(self) -> tuple[str, str]:
+        """Split `http://127.0.0.1:51735/mcp` into origin and path."""
+        if not self.mcp_url:
+            raise DiscoveryError("record carries no mcpUrl")
+        scheme, _, rest = self.mcp_url.partition("://")
+        host, slash, path = rest.partition("/")
+        return f"{scheme}://{host}", (slash + path) if slash else "/mcp"
+
+
+def parse_record(path: Path) -> Record | None:
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    try:
+        return Record(
+            path=path,
+            pid=int(raw.get("pid", 0)),
+            token=str(raw.get("token", "")),
+            port=int(raw.get("port", 0)),
+            url=str(raw.get("url", "")),
+            mcp_port=int(raw["mcpPort"]) if raw.get("mcpPort") else None,
+            mcp_url=str(raw["mcpUrl"]) if raw.get("mcpUrl") else None,
+            mtime=path.stat().st_mtime,
+        )
+    except (TypeError, ValueError):
+        return None
+
+
+def find_records(directory: Path) -> list[Record]:
+    """Every live record in `directory`, most recently written first.
+
+    Most-recent-first is the bridge's own rule for picking between two running
+    instances: it is the one the user most likely just started.
+    """
+    if not directory.is_dir():
+        return []
+    found = []
+    for path in sorted(directory.glob(RECORD_GLOB)):
+        record = parse_record(path)
+        if record is None or not record.token or not process_alive(record.pid):
+            continue
+        found.append(record)
+    return sorted(found, key=lambda r: r.mtime, reverse=True)
+
+
+def resolve(
+    record_path: str | os.PathLike[str] | None = None,
+    data_dir_override: str | os.PathLike[str] | None = None,
+) -> tuple[Record, list[Record]]:
+    """The record to test against, plus every other live one found.
+
+    Returning the others matters: two instances is a supported thing to run,
+    and a tester who does not know a second copy is up would otherwise read a
+    confusing result off the wrong one.
+    """
+    if record_path is not None:
+        path = Path(record_path)
+        record = parse_record(path)
+        if record is None:
+            raise DiscoveryError(f"{path} is not a readable discovery record")
+        return record, []
+
+    directory = data_dir(data_dir_override)
+    records = find_records(directory)
+    if not records:
+        raise DiscoveryError(
+            f"no live MAGDA found in {directory}\n"
+            "  Start MAGDA and switch on AI Settings -> Remote, or point at a\n"
+            "  record with --record / a directory with --data-dir."
+        )
+    return records[0], records[1:]

--- a/tools/transport_check/mutation_test.py
+++ b/tools/transport_check/mutation_test.py
@@ -149,6 +149,16 @@ MUTATIONS: list[tuple[str, str, str]] = [
         "    record.chmod(0o600)",
         "    record.chmod(0o644)",
     ),
+    (
+        "an object-valued resource disagrees with its tool",
+        '                "magda://project/current": project_json(),',
+        '                "magda://project/current": json.dumps({"name": "Different"}),',
+    ),
+    (
+        "an array-valued resource disagrees by more than the {items} wrapper",
+        '                "magda://tracks": TRACKS_BARE_JSON,',
+        '                "magda://tracks": json.dumps([{"id": 99, "name": "Wrong"}]),',
+    ),
 ]
 
 #: Mutations that only the official-SDK suite can catch, so they are skipped

--- a/tools/transport_check/mutation_test.py
+++ b/tools/transport_check/mutation_test.py
@@ -71,13 +71,6 @@ MUTATIONS: list[tuple[str, str, str]] = [
         "if False:",
     ),
     (
-        "resources/read disagrees with tools/call",
-        '            result({"contents": [{"uri": uri, "mimeType": "application/json", '
-        '"text": TRACKS_JSON}]})',
-        '            result({"contents": [{"uri": uri, "mimeType": "application/json", '
-        '"text": "{\\"tracks\\": []}"}]})',
-    ),
-    (
         "Mcp-Name mismatch not validated",
         "            if raw != params.get(name_field):\n"
         '                self._send_json(400, self._error(rid, -32020, "Mcp-Name mismatch"))\n'
@@ -238,13 +231,14 @@ def main() -> int:
 
     caught = 0
     missed: list[str] = []
+    stale: list[str] = []
     for mutation in mutations:
         name = mutation[0]
         try:
             failed, unclear, stdout = run(mutation)
         except LookupError as exc:
             print(f"  STALE   {name}\n            {exc}")
-            missed.append(name)
+            stale.append(name)
             continue
         new_failures = [f for f in failed if f not in ALWAYS_FAILS]
         new_unclear = [u for u in unclear if u not in base_unclear]
@@ -260,12 +254,16 @@ def main() -> int:
             print(f"  MISSED  {name}")
 
     print(f"\n  {caught}/{len(mutations)} mutations caught")
+    if stale:
+        print("\n  These no longer match the stub, so they tested nothing. Re-point "
+              "them at the code that replaced it, or delete them:")
+        for name in stale:
+            print(f"    {name}")
     if missed:
-        print("\n  Nothing went red for these, so no check is watching them:")
+        print("\n  These applied and nothing went red, so no check is watching them:")
         for name in missed:
             print(f"    {name}")
-        return 1
-    return 0
+    return 1 if (missed or stale) else 0
 
 
 if __name__ == "__main__":

--- a/tools/transport_check/mutation_test.py
+++ b/tools/transport_check/mutation_test.py
@@ -1,0 +1,262 @@
+"""Break the stub one way at a time, and check the harness notices.
+
+A suite where every check says OK proves nothing until each check has been
+watched failing for its own reason. This copies the harness to a scratch
+directory, applies one mutation to `selftest.py`'s stub MAGDA, runs the whole
+harness against it, and asserts the check that exists to catch that regression
+is the one that goes red.
+
+    python3 tools/transport_check/mutation_test.py
+
+Every mutation below is a regression MAGDA could really ship — auth bypassed,
+a mirrored header unvalidated, a permission ignored, a revision frozen, OSC
+gone quiet. Adding a check to `suites.py` without adding a mutation here leaves
+a line that can only ever print OK.
+
+Slow by construction: it runs the full harness once per mutation.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+HARNESS = Path(__file__).resolve().parent
+
+#: The one check the stub cannot satisfy, so it fails in every run including
+#: the baseline. See `selftest.EXPECTED_FAILURES`.
+ALWAYS_FAILS = {"magda-mcp is staged beside the MAGDA executable"}
+
+#: (what is broken, the text to replace in selftest.py, what to replace it with)
+MUTATIONS: list[tuple[str, str, str]] = [
+    (
+        "MCP bearer token not checked",
+        '        return self.headers.get("Authorization") == f"Bearer {TOKEN}"',
+        "        return True",
+    ),
+    (
+        "MCP Origin never refused",
+        '        if self.headers.get("Origin"):\n'
+        '            self._send_json(403, {"error": "origin not allowed"})\n'
+        "            return True",
+        "        pass",
+    ),
+    (
+        "WebSocket Origin never refused",
+        '            if "origin" in headers:\n'
+        '                conn.sendall(b"HTTP/1.1 403 Forbidden\\r\\nContent-Length: 0\\r\\n\\r\\n")\n'
+        "                return",
+        "            pass",
+    ),
+    (
+        "WebSocket auth accepts any token",
+        '            if headers.get("authorization") != f"Bearer {TOKEN}":\n'
+        '                conn.sendall(b"HTTP/1.1 401 Unauthorized\\r\\nContent-Length: 0\\r\\n\\r\\n")\n'
+        "                return",
+        "            pass",
+    ),
+    (
+        "read-only client allowed to write over WebSocket",
+        "if method in writes and client_name == clients.READONLY_CLIENT_NAME:",
+        "if False:",
+    ),
+    (
+        "read-only client allowed to write over MCP",
+        'if name == "tracks.create" and client_name == clients.READONLY_CLIENT_NAME:',
+        "if False:",
+    ),
+    (
+        "resources/read disagrees with tools/call",
+        '            result({"contents": [{"uri": uri, "mimeType": "application/json", '
+        '"text": TRACKS_JSON}]})',
+        '            result({"contents": [{"uri": uri, "mimeType": "application/json", '
+        '"text": "{\\"tracks\\": []}"}]})',
+    ),
+    (
+        "Mcp-Name mismatch not validated",
+        "            if raw != params.get(name_field):\n"
+        '                self._send_json(400, self._error(rid, -32020, "Mcp-Name mismatch"))\n'
+        "                return",
+        "            pass",
+    ),
+    (
+        "clientCapabilities not required",
+        "if not isinstance(meta.get(clients.META_CLIENT_CAPABILITIES), dict):",
+        "if False:",
+    ),
+    (
+        "a stateless request echoes a session id",
+        '        self._dispatch(rid, method, params, era="modern", client_name=client_name)',
+        "        if session:\n"
+        '            self._send_json(200, {"jsonrpc": "2.0", "id": rid, "result": {"tools": TOOLS}},\n'
+        '                            headers={"Mcp-Session-Id": session})\n'
+        "            return\n"
+        '        self._dispatch(rid, method, params, era="modern", client_name=client_name)',
+    ),
+    (
+        "the acknowledgement echoes URIs that name nothing",
+        '        agreed = [u for u in asked if u == "magda://tracks" or u == "magda://transport"]',
+        "        agreed = list(asked)",
+    ),
+    (
+        "an unknown method answers 200 instead of 404",
+        '            self._send_json(404, self._error(rid, -32601, f"no such method {method}"))',
+        '            self._send_json(200, self._error(rid, -32601, f"no such method {method}"))',
+    ),
+    (
+        "an unknown tool reported as a tool execution error",
+        '            self._send_json(200, self._error(rid, -32602, f"no tool named {name}"))',
+        '            result({"isError": True, "content": [{"type": "text", "text": "no such tool"}]})',
+    ),
+    (
+        "a write does not advance the revision",
+        "            STATE['revision'] += 1\n            result({\"tempo\": STATE['tempo']})",
+        "            result({\"tempo\": STATE['tempo']})",
+    ),
+    (
+        "a stale expectedRevision is ignored",
+        'if method in writes and "expectedRevision" in meta '
+        "and meta[\"expectedRevision\"] != STATE['revision']:",
+        "if False:",
+    ),
+    (
+        "subscribe returns no snapshot",
+        '            result({"snapshots": [',
+        '            result({"snapshots": [] and [',
+    ),
+    (
+        "OSC never answers a new surface",
+        "            if peer[0] not in self.known:",
+        "            if False:",
+    ),
+    (
+        "an OSC command has no effect",
+        "                    STATE['tempo'] = float(message.args[0])",
+        "                    pass",
+    ),
+    (
+        "legacy initialize mints no session header",
+        '        }, headers={"Mcp-Session-Id": session})',
+        "        }, headers={})",
+    ),
+    (
+        "the token file is world-readable",
+        "    record.chmod(0o600)",
+        "    record.chmod(0o644)",
+    ),
+]
+
+#: Mutations that only the official-SDK suite can catch, so they are skipped
+#: when it is. Run this file with an interpreter that has `mcp` installed to
+#: exercise them:
+#:
+#:     .venv/bin/python tools/transport_check/mutation_test.py
+SDK_MUTATIONS: list[tuple[str, str, str]] = [
+    (
+        "modern results omit ttlMs and cacheScope",
+        '                if method in CACHEABLE_RESULTS:\n'
+        '                    value.setdefault("ttlMs", 0)\n'
+        '                    value.setdefault("cacheScope", "private")',
+        "                pass",
+    ),
+    (
+        "modern results omit resultType",
+        '                value.setdefault("resultType", "complete")',
+        "                pass",
+    ),
+    (
+        "server/discover omits capabilities, so a host falls back to legacy",
+        '                "capabilities": {"tools": {"listChanged": False},\n'
+        '                                 "resources": {"subscribe": True, "listChanged": False}},',
+        "",
+    ),
+]
+
+
+def sdk_available() -> bool:
+    return all(importlib.util.find_spec(m) is not None for m in ("mcp", "httpx2"))
+
+
+def run(mutation: tuple[str, str, str] | None) -> tuple[list[str], list[str], str]:
+    """Run the harness against a copy of the stub, mutated or not."""
+    workspace = Path(tempfile.mkdtemp(prefix="magda-transport-mutation-"))
+    copy = workspace / "transport_check"
+    shutil.copytree(HARNESS, copy)
+    if mutation is not None:
+        _, old, new = mutation
+        target = copy / "selftest.py"
+        text = target.read_text()
+        if old not in text:
+            raise LookupError(f"the stub no longer contains:\n{old}")
+        target.write_text(text.replace(old, new, 1))
+    try:
+        completed = subprocess.run(
+            [sys.executable, str(copy / "selftest.py")],
+            capture_output=True, text=True, timeout=600,
+        )
+    finally:
+        shutil.rmtree(workspace, ignore_errors=True)
+    stdout = completed.stdout
+    failed = re.findall(r"^  FAIL  (.+)$", stdout, re.M)
+    # Inconclusive is a verdict too: the OSC snapshot check is specified to
+    # report "could not decide" rather than fail, because silence there has an
+    # innocent explanation the harness cannot rule out from outside.
+    unclear = re.findall(r"^\s+\?\s\s(.+)$", stdout, re.M)
+    return failed, unclear, stdout
+
+
+def main() -> int:
+    print("baseline, with the stub intact:")
+    failed, base_unclear, stdout = run(None)
+    if set(failed) != ALWAYS_FAILS:
+        print(f"  expected only {sorted(ALWAYS_FAILS)} to fail, got {sorted(failed)}")
+        print(stdout)
+        return 1
+    print(f"  clean ({len(base_unclear)} inconclusive, {len(failed)} expected failure)\n")
+
+    mutations = list(MUTATIONS)
+    if sdk_available():
+        mutations += SDK_MUTATIONS
+    else:
+        print("  (skipping the official-SDK mutations: `mcp` is not importable "
+              "by this interpreter)\n")
+
+    caught = 0
+    missed: list[str] = []
+    for mutation in mutations:
+        name = mutation[0]
+        try:
+            failed, unclear, stdout = run(mutation)
+        except LookupError as exc:
+            print(f"  STALE   {name}\n            {exc}")
+            missed.append(name)
+            continue
+        new_failures = [f for f in failed if f not in ALWAYS_FAILS]
+        new_unclear = [u for u in unclear if u not in base_unclear]
+        if new_failures or new_unclear:
+            caught += 1
+            print(f"  caught  {name}")
+            for entry in new_failures:
+                print(f"            -> FAIL {entry}")
+            for entry in new_unclear:
+                print(f"            -> inconclusive: {entry}")
+        else:
+            missed.append(name)
+            print(f"  MISSED  {name}")
+
+    print(f"\n  {caught}/{len(mutations)} mutations caught")
+    if missed:
+        print("\n  Nothing went red for these, so no check is watching them:")
+        for name in missed:
+            print(f"    {name}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/transport_check/report.py
+++ b/tools/transport_check/report.py
@@ -1,0 +1,177 @@
+"""Results and console rendering for the transport check.
+
+The harness exists to be run by a person against a build they just installed,
+so the output is the product: a line per check, the reason on failure, and an
+exit status CI can read. `--json` emits the same thing for a machine.
+"""
+
+from __future__ import annotations
+
+import enum
+import json
+import os
+import sys
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+
+class Status(enum.Enum):
+    """What a check concluded.
+
+    `INCONCLUSIVE` is separate from `FAIL` on purpose. Some of what this
+    harness asks cannot be established from outside the app — whether an OSC
+    snapshot was withheld because feedback is broken or because this host was
+    already a known peer, for one — and reporting that as a failure would
+    train the reader to ignore red. It is a distinct, non-fatal state that
+    names what it could not decide.
+    """
+
+    PASS = "pass"
+    FAIL = "fail"
+    SKIP = "skip"
+    INCONCLUSIVE = "inconclusive"
+
+
+@dataclass
+class Check:
+    """One assertion, its verdict, and enough detail to act on it."""
+
+    suite: str
+    name: str
+    status: Status
+    detail: str = ""
+    duration_ms: float = 0.0
+    #: Anything worth keeping for the JSON report but too long for a console
+    #: line — a protocol version, a returned error body, a port number.
+    data: dict[str, Any] = field(default_factory=dict)
+
+    def to_json(self) -> dict[str, Any]:
+        out = {
+            "suite": self.suite,
+            "name": self.name,
+            "status": self.status.value,
+            "durationMs": round(self.duration_ms, 1),
+        }
+        if self.detail:
+            out["detail"] = self.detail
+        if self.data:
+            out["data"] = self.data
+        return out
+
+
+class Report:
+    """Collects checks and prints them as they land.
+
+    Streaming rather than batching: a suite can block for seconds on a socket
+    that will never answer, and a reader watching nothing happen needs to know
+    which check is hanging.
+    """
+
+    _COLOURS = {
+        Status.PASS: "\033[32m",
+        Status.FAIL: "\033[31m",
+        Status.SKIP: "\033[90m",
+        Status.INCONCLUSIVE: "\033[33m",
+    }
+    _LABELS = {
+        Status.PASS: "OK",
+        Status.FAIL: "FAIL",
+        Status.SKIP: "skip",
+        Status.INCONCLUSIVE: "?",
+    }
+
+    def __init__(self, verbose: bool = False, colour: bool | None = None) -> None:
+        self.checks: list[Check] = []
+        self.verbose = verbose
+        if colour is None:
+            colour = sys.stdout.isatty() and os.environ.get("NO_COLOR") is None
+        self.colour = colour
+        self._suite_open: str | None = None
+
+    # -- emitting ---------------------------------------------------------
+
+    def note(self, message: str) -> None:
+        """A line that is not a check — discovery detail, a warning."""
+        print(f"  {self._dim(message)}")
+
+    def add(self, check: Check) -> Check:
+        self.checks.append(check)
+        if check.suite != self._suite_open:
+            print(f"\n{self._bold(check.suite)}")
+            self._suite_open = check.suite
+        label = self._paint(check.status, self._LABELS[check.status].rjust(4))
+        line = f"  {label}  {check.name}"
+        if check.detail and check.status is not Status.PASS:
+            line += f"\n        {self._dim(check.detail)}"
+        elif check.detail and self.verbose:
+            line += f"\n        {self._dim(check.detail)}"
+        print(line, flush=True)
+        return check
+
+    # -- summary ----------------------------------------------------------
+
+    def counts(self) -> dict[Status, int]:
+        return {s: sum(1 for c in self.checks if c.status is s) for s in Status}
+
+    @property
+    def failed(self) -> bool:
+        return any(c.status is Status.FAIL for c in self.checks)
+
+    def summarise(self) -> None:
+        counts = self.counts()
+        parts = [self._paint(Status.PASS, f"{counts[Status.PASS]} passed")]
+        if counts[Status.FAIL]:
+            parts.append(self._paint(Status.FAIL, f"{counts[Status.FAIL]} failed"))
+        if counts[Status.INCONCLUSIVE]:
+            parts.append(
+                self._paint(Status.INCONCLUSIVE, f"{counts[Status.INCONCLUSIVE]} inconclusive")
+            )
+        if counts[Status.SKIP]:
+            parts.append(self._paint(Status.SKIP, f"{counts[Status.SKIP]} skipped"))
+        print("\n  " + ", ".join(parts) + "\n")
+
+    def to_json(self) -> str:
+        counts = self.counts()
+        return json.dumps(
+            {
+                "ok": not self.failed,
+                "counts": {s.value: counts[s] for s in Status},
+                "checks": [c.to_json() for c in self.checks],
+            },
+            indent=2,
+        )
+
+    # -- painting ---------------------------------------------------------
+
+    def _paint(self, status: Status, text: str) -> str:
+        if not self.colour:
+            return text
+        return f"{self._COLOURS[status]}{text}\033[0m"
+
+    def _bold(self, text: str) -> str:
+        return f"\033[1m{text}\033[0m" if self.colour else text
+
+    def _dim(self, text: str) -> str:
+        return f"\033[90m{text}\033[0m" if self.colour else text
+
+
+class timed:
+    """Context manager that records how long a check took.
+
+    Used by the suites so every check carries a duration without each one
+    having to remember to measure — the durations are what tell a reader that
+    a `subscriptions/listen` stream really did stay open for its full window
+    rather than returning instantly.
+    """
+
+    def __init__(self) -> None:
+        self.ms = 0.0
+        self._start = 0.0
+
+    def __enter__(self) -> "timed":
+        self._start = time.monotonic()
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.ms = (time.monotonic() - self._start) * 1000.0

--- a/tools/transport_check/requirements.txt
+++ b/tools/transport_check/requirements.txt
@@ -1,0 +1,9 @@
+# Optional: the official MCP SDK, used by sdk_suite.py to drive the endpoint as
+# an independent host that validates every response against the protocol
+# schema. Needs Python 3.10+; the rest of the harness is stdlib-only and runs
+# on 3.9, so nothing here is required for a normal run.
+#
+#   python3 -m venv .venv
+#   .venv/bin/pip install -r tools/transport_check/requirements.txt
+#   .venv/bin/python tools/transport_check --all
+mcp>=2.0.0

--- a/tools/transport_check/sdk_suite.py
+++ b/tools/transport_check/sdk_suite.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import asyncio
 import importlib.util
+import time
 from typing import Any
 
 from report import Status
@@ -76,7 +77,14 @@ class SdkSession:
         ) as client:
             return await body(client)
 
+    #: Seconds to wait before opening a session. The SDK does not pace itself
+    #: and a session costs several requests — a discover probe, an initialize
+    #: if it falls back, then the call. The endpoint's bucket is shared by
+    #: every local client, so an unpaced suite starves whatever runs next.
+    settle = 1.0
+
     def run(self, body) -> Any:
+        time.sleep(self.settle)
         return asyncio.run(self._run(body))
 
 

--- a/tools/transport_check/sdk_suite.py
+++ b/tools/transport_check/sdk_suite.py
@@ -1,0 +1,184 @@
+"""The endpoint driven by the official MCP SDK, as a second, independent host.
+
+#2059 asks for verification against real MCP hosts, on the grounds that MAGDA's
+own tests can prove it answers correctly but not that a shipped host asks the
+way it expects. The rest of this harness is a client written from
+`docs/remote-api-mcp.md`, which shares that blind spot: it asks the way the
+documentation says to.
+
+`mcp` — the official Python SDK — does not. It validates every response against
+the protocol schema for the version it negotiated, so it fails on shapes a
+hand-written client would accept, which is the whole reason to run it.
+
+Optional and skipped when absent. The SDK needs Python 3.10+ while the rest of
+this harness runs on 3.9, so it cannot be a hard dependency:
+
+    python3 -m venv .venv && .venv/bin/pip install -r tools/transport_check/requirements.txt
+    .venv/bin/python tools/transport_check --mcp-sdk
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+from typing import Any
+
+from report import Status
+
+#: What the SDK calls itself to MAGDA. A separate identity from the
+#: hand-written client's, so AI Settings -> Clients shows which host did what.
+SDK_CLIENT_NAME = "magda-transport-check-sdk"
+
+
+def available() -> tuple[bool, str]:
+    """Whether the SDK can be used, and if not, what to do about it.
+
+    `find_spec` rather than an import: the SDK pulls in pydantic and anyio, and
+    a suite that is about to be skipped should not pay for that.
+    """
+    for module in ("mcp", "httpx2"):
+        if importlib.util.find_spec(module) is None:
+            return False, (
+                f"the official MCP SDK is not installed ({module} is missing). "
+                "It needs Python 3.10+; install it with "
+                "`pip install -r tools/transport_check/requirements.txt` and run "
+                "this harness with that interpreter."
+            )
+    return True, ""
+
+
+class SdkSession:
+    """One `mcp.Client` session, driven synchronously.
+
+    The SDK is async and everything else here is not, so each check runs its
+    own event loop. That is slower than sharing one, and it also means a check
+    that wedges cannot wedge the others.
+    """
+
+    def __init__(self, url: str, token: str, mode: str = "auto") -> None:
+        self.url = url
+        self.token = token
+        self.mode = mode
+
+    async def _run(self, body) -> Any:
+        import httpx2
+        from mcp import Client, Implementation
+        from mcp.client.streamable_http import streamable_http_client
+
+        http_client = httpx2.AsyncClient(
+            headers={"Authorization": f"Bearer {self.token}"}
+        )
+        transport = streamable_http_client(self.url, http_client=http_client)
+        async with Client(
+            transport,
+            client_info=Implementation(name=SDK_CLIENT_NAME, version="1.0"),
+            mode=self.mode,
+        ) as client:
+            return await body(client)
+
+    def run(self, body) -> Any:
+        return asyncio.run(self._run(body))
+
+
+def run_sdk(context) -> None:
+    """Checks driven through the official SDK rather than this harness's client."""
+    from suites import SuiteRunner, ok, unclear
+
+    runner = SuiteRunner(context, "mcp (official SDK)")
+
+    ready, reason = available()
+    if not ready:
+        runner.skip("every check", reason)
+        return
+    if not context.record.has_mcp:
+        runner.skip("every check", "the record carries no mcpUrl")
+        return
+
+    import mcp.types as types
+
+    runner.report.note(f"SDK latest protocol: {types.LATEST_PROTOCOL_VERSION}")
+
+    url = context.record.mcp_url or ""
+    auto = SdkSession(url, context.record.token, mode="auto")
+    legacy = SdkSession(url, context.record.token, mode="legacy")
+
+    negotiated: list[str] = []
+
+    def connect() -> tuple[Status, str, dict]:
+        async def body(client):
+            return client.protocol_version, client.server_info
+
+        version, server = auto.run(body)
+        negotiated.append(version or "")
+        name = getattr(server, "name", None)
+        detail = f"negotiated {version}, server {name}"
+        if version != types.LATEST_PROTOCOL_VERSION:
+            return unclear(
+                detail + f" — the SDK supports {types.LATEST_PROTOCOL_VERSION} and "
+                "settled for less, which means its modern probe did not take. "
+                "server/discover is what that probe reads.",
+                negotiated=version,
+            )
+        return ok(detail, negotiated=version)
+
+    runner.check("the SDK connects and negotiates a version", connect)
+
+    # -- the catalogue, in whatever era `auto` settled on -------------------
+
+    def list_tools() -> tuple[Status, str, dict]:
+        async def body(client):
+            return await client.list_tools()
+
+        result = auto.run(body)
+        names = [tool.name for tool in result.tools]
+        assert "tracks.list" in names, f"tracks.list missing from {names[:8]}"
+        return ok(f"{len(names)} tools accepted by the SDK's schema validation")
+
+    runner.check("tools/list validates against the negotiated schema", list_tools)
+
+    def call_tool() -> tuple[Status, str, dict]:
+        async def body(client):
+            return await client.call_tool("tracks.list", {})
+
+        result = auto.run(body)
+        assert result.is_error is False, f"tools/call reported an error: {result}"
+        assert result.content, "no content in the result"
+        return ok("a tool call round-tripped through the SDK")
+
+    runner.check("tools/call validates against the negotiated schema", call_tool)
+
+    def read_resource() -> tuple[Status, str, dict]:
+        async def body(client):
+            return await client.read_resource("magda://tracks")
+
+        result = auto.run(body)
+        assert result.contents, "no contents returned"
+        return ok("a resource read round-tripped through the SDK")
+
+    runner.check("resources/read validates against the negotiated schema", read_resource)
+
+    def list_resources() -> tuple[Status, str, dict]:
+        async def body(client):
+            listed = await client.list_resources()
+            templates = await client.list_resource_templates()
+            return listed, templates
+
+        listed, templates = auto.run(body)
+        return ok(
+            f"{len(listed.resources)} resources, "
+            f"{len(templates.resource_templates)} templates"
+        )
+
+    runner.check("the resource catalogue validates", list_resources)
+
+    # -- the legacy era on its own, which has no cache directives ----------
+
+    def legacy_session() -> tuple[Status, str, dict]:
+        async def body(client):
+            result = await client.list_tools()
+            return client.protocol_version, len(result.tools)
+
+        version, count = legacy.run(body)
+        return ok(f"negotiated {version}, {count} tools", negotiated=version)
+
+    runner.check("the SDK works when forced to the legacy era", legacy_session)

--- a/tools/transport_check/selftest.py
+++ b/tools/transport_check/selftest.py
@@ -49,7 +49,18 @@ TOOLS = [
 CACHEABLE_RESULTS = {"tools/list", "resources/list", "resources/templates/list",
                      "resources/read", "server/discover"}
 
-TRACKS_JSON = json.dumps({"tracks": [{"id": 1, "name": "Drums"}]})
+#: `tracks.list` returns an *array*, and the two MCP surfaces carry it
+#: differently — `structuredContent` is typed as an object, so the tool surface
+#: wraps it while `resources/read` returns it bare. Modelled here because the
+#: real endpoint does it, and a stub that returned an object from both would
+#: let the parity checks pass without ever meeting the case that matters.
+TRACKS_ARRAY = [{"id": 1, "name": "Drums"}]
+TRACKS_BARE_JSON = json.dumps(TRACKS_ARRAY)
+TRACKS_WRAPPED_JSON = json.dumps({"items": TRACKS_ARRAY})
+
+
+def project_json() -> str:
+    return json.dumps({"name": "Stub", "tempo": STATE["tempo"]})
 
 #: The stub project. Shared by every transport, because "an OSC message
 #: changed something a WebSocket read can see" is precisely what the
@@ -215,7 +226,7 @@ class StubWebSocket(threading.Thread):
         elif method == "project.get":
             result({"tempo": STATE['tempo'], "name": "Stub"})
         elif method == "tracks.list":
-            result(json.loads(TRACKS_JSON))
+            result(TRACKS_ARRAY)
         elif method == "project.setTempo":
             STATE['tempo'] = float(params.get("tempo", STATE['tempo']))
             STATE['revision'] += 1
@@ -444,17 +455,26 @@ class StubMcpHandler(http.server.BaseHTTPRequestHandler):
         elif method == "tools/list":
             result({"tools": TOOLS})
         elif method == "resources/list":
-            result({"resources": [{"uri": "magda://tracks", "name": "tracks",
-                                   "mimeType": "application/json"}]})
+            result({"resources": [
+                {"uri": "magda://tracks", "name": "tracks",
+                 "mimeType": "application/json"},
+                {"uri": "magda://project/current", "name": "project",
+                 "mimeType": "application/json"},
+            ]})
         elif method == "resources/templates/list":
             result({"resourceTemplates": [{"uriTemplate": "magda://tracks/{track_id}",
                                            "name": "track"}]})
         elif method == "resources/read":
             uri = params.get("uri")
-            if uri != "magda://tracks":
+            bodies = {
+                "magda://tracks": TRACKS_BARE_JSON,
+                "magda://project/current": project_json(),
+            }
+            if uri not in bodies:
                 self._send_json(200, self._error(rid, -32602, f"no resource at {uri}"))
                 return
-            result({"contents": [{"uri": uri, "mimeType": "application/json", "text": TRACKS_JSON}]})
+            result({"contents": [{"uri": uri, "mimeType": "application/json",
+                                  "text": bodies[uri]}]})
         elif method == "tools/call":
             self._tools_call(rid, params, client_name, result)
         elif method == "resources/subscribe":
@@ -481,7 +501,12 @@ class StubMcpHandler(http.server.BaseHTTPRequestHandler):
                 {"code": "NOT_FOUND", "message": "no track with that id",
                  "issues": [{"field": "trackId", "problem": "unknown"}]})}]})
             return
-        text = TRACKS_JSON if name == "tracks.list" else json.dumps({"ok": True})
+        if name == "tracks.list":
+            text = TRACKS_WRAPPED_JSON
+        elif name == "project.get":
+            text = project_json()
+        else:
+            text = json.dumps({"ok": True})
         result({
             "isError": False,
             "content": [{"type": "text", "text": text}],

--- a/tools/transport_check/selftest.py
+++ b/tools/transport_check/selftest.py
@@ -1,0 +1,740 @@
+"""A stub MAGDA, so the harness itself can be checked without one running.
+
+This is not a test of MAGDA. It is a test of the code in this directory: that
+the WebSocket framing is right, that each check reads the JSON path it means
+to, that a suite whose transport is refusing everything reports that instead of
+crashing, and that the exit status follows the findings.
+
+Point the harness at a real build to learn anything about MAGDA. Run this to
+learn whether the harness is still working after someone edits it:
+
+    python3 tools/transport_check/selftest.py
+
+Dependency-free on purpose, including the WebSocket server, so it runs wherever
+the harness does.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import http.server
+import json
+import os
+import socket
+import struct
+import sys
+import tempfile
+import threading
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import clients  # noqa: E402
+from report import Status  # noqa: E402
+
+TOKEN = "stub-token-0123456789abcdef"
+WS_GUID = b"258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
+MODERN = clients.MODERN_PROTOCOL
+LEGACY = clients.LEGACY_PROTOCOL
+
+TOOLS = [
+    {"name": "tracks.list", "description": "List tracks", "inputSchema": {"type": "object"}},
+    {"name": "tracks.get", "description": "Get a track", "inputSchema": {"type": "object"}},
+    {"name": "tracks.create", "description": "Create a track", "inputSchema": {"type": "object"}},
+    {"name": "project.get", "description": "Get the project", "inputSchema": {"type": "object"}},
+]
+#: Modern-era results the schema treats as cacheable, and which therefore
+#: must carry `ttlMs` and `cacheScope` beside `resultType`.
+CACHEABLE_RESULTS = {"tools/list", "resources/list", "resources/templates/list",
+                     "resources/read", "server/discover"}
+
+TRACKS_JSON = json.dumps({"tracks": [{"id": 1, "name": "Drums"}]})
+
+#: The stub project. Shared by every transport, because "an OSC message
+#: changed something a WebSocket read can see" is precisely what the
+#: cross-transport check asserts, and two copies of the tempo would make
+#: that check pass or fail for reasons that have nothing to do with it.
+STATE = {"tempo": 120.0, "revision": 41}
+
+
+# ---------------------------------------------------------------------------
+# A WebSocket server, server side of the same framing wire.py implements
+# ---------------------------------------------------------------------------
+
+
+def _read_http_request(conn: socket.socket) -> tuple[str, dict[str, str]]:
+    buf = b""
+    while b"\r\n\r\n" not in buf:
+        chunk = conn.recv(4096)
+        if not chunk:
+            raise ConnectionError("closed during handshake")
+        buf += chunk
+    head = buf.split(b"\r\n\r\n")[0].decode("latin-1")
+    lines = head.split("\r\n")
+    target = lines[0].split(" ")[1] if len(lines[0].split(" ")) > 1 else "/"
+    headers = {}
+    for line in lines[1:]:
+        name, _, value = line.partition(":")
+        if name:
+            headers[name.strip().lower()] = value.strip()
+    return target, headers
+
+
+def _ws_send(conn: socket.socket, text: str, opcode: int = 0x1) -> None:
+    payload = text.encode("utf-8")
+    header = bytearray([0x80 | opcode])
+    length = len(payload)
+    if length < 126:
+        header.append(length)
+    elif length < 65536:
+        header.append(126)
+        header += struct.pack(">H", length)
+    else:
+        header.append(127)
+        header += struct.pack(">Q", length)
+    conn.sendall(bytes(header) + payload)
+
+
+def _recv_exact(conn: socket.socket, count: int) -> bytes:
+    out = b""
+    while len(out) < count:
+        chunk = conn.recv(count - len(out))
+        if not chunk:
+            raise ConnectionError("closed")
+        out += chunk
+    return out
+
+
+def _ws_recv(conn: socket.socket) -> str | None:
+    first, second = _recv_exact(conn, 2)
+    opcode = first & 0x0F
+    masked = bool(second & 0x80)
+    length = second & 0x7F
+    if length == 126:
+        (length,) = struct.unpack(">H", _recv_exact(conn, 2))
+    elif length == 127:
+        (length,) = struct.unpack(">Q", _recv_exact(conn, 8))
+    mask = _recv_exact(conn, 4) if masked else b""
+    payload = _recv_exact(conn, length) if length else b""
+    if masked:
+        payload = bytes(b ^ mask[i % 4] for i, b in enumerate(payload))
+    if opcode == 0x8:
+        return None
+    return payload.decode("utf-8")
+
+
+class StubWebSocket(threading.Thread):
+    """`/rpc`: bearer token, Origin rule, a handful of operations, pushed events."""
+
+    def __init__(self) -> None:
+        super().__init__(daemon=True)
+        self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self.sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self.sock.bind(("127.0.0.1", 0))
+        self.sock.listen(8)
+        self.port = self.sock.getsockname()[1]
+        self.running = True
+
+    def run(self) -> None:
+        while self.running:
+            try:
+                conn, _ = self.sock.accept()
+            except OSError:
+                return
+            threading.Thread(target=self._serve, args=(conn,), daemon=True).start()
+
+    def stop(self) -> None:
+        self.running = False
+        self.sock.close()
+
+    def _serve(self, conn: socket.socket) -> None:
+        try:
+            target, headers = _read_http_request(conn)
+            if headers.get("authorization") != f"Bearer {TOKEN}":
+                conn.sendall(b"HTTP/1.1 401 Unauthorized\r\nContent-Length: 0\r\n\r\n")
+                return
+            if "origin" in headers:
+                conn.sendall(b"HTTP/1.1 403 Forbidden\r\nContent-Length: 0\r\n\r\n")
+                return
+            key = headers.get("sec-websocket-key", "").encode()
+            accept = base64.b64encode(hashlib.sha1(key + WS_GUID).digest()).decode()
+            conn.sendall(
+                (
+                    "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\n"
+                    f"Connection: Upgrade\r\nSec-WebSocket-Accept: {accept}\r\n\r\n"
+                ).encode()
+            )
+            client_name = "unknown"
+            if "client=" in target:
+                client_name = target.split("client=", 1)[1].split("&")[0]
+
+            while True:
+                raw = _ws_recv(conn)
+                if raw is None:
+                    return
+                request = json.loads(raw)
+                self._dispatch(conn, request, client_name)
+        except (ConnectionError, OSError, ValueError):
+            return
+        finally:
+            try:
+                conn.close()
+            except OSError:
+                pass
+
+    def _dispatch(self, conn: socket.socket, request: dict, client_name: str) -> None:
+        method = request.get("method")
+        params = request.get("params") or {}
+        meta = request.get("meta") or {}
+        rid = request.get("id")
+
+        def result(value: object) -> None:
+            _ws_send(conn, json.dumps({
+                "jsonrpc": "2.0", "id": rid, "result": value,
+                "meta": {"revision": STATE['revision'], "apiVersion": "1.0.0"},
+            }))
+
+        def error(code: int, message: str) -> None:
+            _ws_send(conn, json.dumps({
+                "jsonrpc": "2.0", "id": rid,
+                "error": {"code": code, "message": message,
+                          "data": {"revision": STATE['revision']}},
+            }))
+
+        writes = {"tracks.create", "project.setTempo"}
+        if method in writes and client_name == clients.READONLY_CLIENT_NAME:
+            error(-32006, "this client has not been granted 'edit'")
+            return
+        if method in writes and "expectedRevision" in meta and meta["expectedRevision"] != STATE['revision']:
+            error(-32004, "the project has moved on")
+            return
+
+        if method == "system.describe":
+            result({"operations": [{"name": t["name"]} for t in TOOLS]})
+        elif method == "project.get":
+            result({"tempo": STATE['tempo'], "name": "Stub"})
+        elif method == "tracks.list":
+            result(json.loads(TRACKS_JSON))
+        elif method == "project.setTempo":
+            STATE['tempo'] = float(params.get("tempo", STATE['tempo']))
+            STATE['revision'] += 1
+            result({"tempo": STATE['tempo']})
+        elif method == "tracks.create":
+            STATE['revision'] += 1
+            result({"id": 2, "name": params.get("name")})
+        elif method == "subscriptions.subscribe":
+            topics = params.get("topics") or []
+            result({"snapshots": [
+                {"type": "snapshot", "topic": t, "payload": {"tempo": STATE['tempo']}}
+                for t in topics if t in ("project", "transport", "tracks")
+            ]})
+            if any(t in ("playhead", "meters") for t in topics):
+                def push() -> None:
+                    for _ in range(4):
+                        try:
+                            _ws_send(conn, json.dumps({
+                                "jsonrpc": "2.0", "method": "subscriptions.event",
+                                "params": {"topic": "playhead", "payload": {"beats": 4.0}},
+                            }))
+                        except OSError:
+                            return
+                        __import__("time").sleep(0.3)
+                threading.Thread(target=push, daemon=True).start()
+        else:
+            error(-32601, f"unknown operation {method}")
+
+
+# ---------------------------------------------------------------------------
+# The MCP endpoint, both eras
+# ---------------------------------------------------------------------------
+
+
+class QuietHttpServer(http.server.ThreadingHTTPServer):
+    """Closing a stream is how a client cancels it, so a reset is not an error."""
+
+    def handle_error(self, request: object, client_address: object) -> None:
+        if not isinstance(sys.exc_info()[1], (ConnectionResetError, BrokenPipeError)):
+            super().handle_error(request, client_address)
+
+
+class StubMcpHandler(http.server.BaseHTTPRequestHandler):
+    sessions: dict[str, str] = {}
+    protocol_version = "HTTP/1.1"
+
+    def log_message(self, *args: object) -> None:  # quiet
+        pass
+
+    # -- helpers ----------------------------------------------------------
+
+    def _send_json(self, status: int, payload: dict, headers: dict | None = None) -> None:
+        body = json.dumps(payload).encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        for key, value in (headers or {}).items():
+            self.send_header(key, value)
+        self.end_headers()
+        self.wfile.write(body)
+
+    @staticmethod
+    def _error(rid: object, code: int, message: str) -> dict:
+        return {"jsonrpc": "2.0", "id": rid, "error": {"code": code, "message": message}}
+
+    def _authorised(self) -> bool:
+        return self.headers.get("Authorization") == f"Bearer {TOKEN}"
+
+    def _refused(self) -> bool:
+        """401 for a bad token, 403 for an Origin nobody allowed. Both before anything else."""
+        if not self._authorised():
+            self._send_json(401, {"error": "unauthorised"})
+            return True
+        if self.headers.get("Origin"):
+            self._send_json(403, {"error": "origin not allowed"})
+            return True
+        return False
+
+    # -- verbs ------------------------------------------------------------
+
+    def do_DELETE(self) -> None:
+        session = self.headers.get("Mcp-Session-Id")
+        self.sessions.pop(session, None)
+        self.send_response(204)
+        self.send_header("Content-Length", "0")
+        self.end_headers()
+
+    def do_GET(self) -> None:
+        if self._refused():
+            return
+        session = self.headers.get("Mcp-Session-Id")
+        if not session or session not in self.sessions:
+            self._send_json(400, self._error(None, -32600, "no session"))
+            return
+        self.send_response(200)
+        self.send_header("Content-Type", "text/event-stream")
+        self.send_header("Cache-Control", "no-cache")
+        self.end_headers()
+        import time as _t
+        for _ in range(20):
+            try:
+                self.wfile.write(b": keep-alive\n\n")
+                self.wfile.flush()
+            except OSError:
+                return
+            _t.sleep(0.4)
+
+    def do_POST(self) -> None:
+        if self._refused():
+            return
+        length = int(self.headers.get("Content-Length", "0"))
+        try:
+            request = json.loads(self.rfile.read(length) or b"{}")
+        except ValueError:
+            self._send_json(400, self._error(None, -32700, "parse error"))
+            return
+
+        rid = request.get("id")
+        method = request.get("method")
+        params = request.get("params") or {}
+        meta = params.get("_meta") or {}
+        session = self.headers.get("Mcp-Session-Id")
+
+        if rid is None:
+            self.send_response(202)
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+            return
+
+        modern = bool(meta.get(clients.META_PROTOCOL_VERSION))
+        if not modern and method == "initialize":
+            return self._initialize(rid, params)
+        if not modern and session in self.sessions:
+            return self._dispatch(rid, method, params, era="legacy",
+                                  client_name=self.sessions[session])
+        if not modern:
+            self._send_json(400, self._error(
+                rid, -32602,
+                "A request must carry io.modelcontextprotocol/protocolVersion in params._meta, "
+                "or an Mcp-Session-Id from a prior initialize"))
+            return
+
+        # Modern: the mirrored headers and the required _meta fields.
+        if self.headers.get("MCP-Protocol-Version") != meta.get(clients.META_PROTOCOL_VERSION):
+            self._send_json(400, self._error(rid, -32020, "MCP-Protocol-Version mismatch"))
+            return
+        if self.headers.get("Mcp-Method") != method:
+            self._send_json(400, self._error(rid, -32020, "Mcp-Method mismatch"))
+            return
+        name_field = {"tools/call": "name", "prompts/get": "name", "resources/read": "uri"}.get(method)
+        if name_field:
+            raw = self.headers.get("Mcp-Name")
+            if raw is None:
+                self._send_json(400, self._error(rid, -32020, "Mcp-Name is required"))
+                return
+            if raw.startswith("=?base64?") and raw.endswith("?="):
+                raw = base64.b64decode(raw[len("=?base64?"):-2]).decode()
+            if raw != params.get(name_field):
+                self._send_json(400, self._error(rid, -32020, "Mcp-Name mismatch"))
+                return
+        if not isinstance(meta.get(clients.META_CLIENT_CAPABILITIES), dict):
+            self._send_json(400, self._error(
+                rid, -32602,
+                "io.modelcontextprotocol/clientCapabilities is required in params._meta"))
+            return
+
+        client_name = (meta.get(clients.META_CLIENT_INFO) or {}).get("name", "unknown")
+        self._dispatch(rid, method, params, era="modern", client_name=client_name)
+
+    # -- protocol ---------------------------------------------------------
+
+    def _initialize(self, rid: object, params: dict) -> None:
+        version = params.get("protocolVersion", LEGACY)
+        session = base64.urlsafe_b64encode(os.urandom(12)).decode().rstrip("=")
+        self.sessions[session] = (params.get("clientInfo") or {}).get("name", "unknown")
+        self._send_json(200, {
+            "jsonrpc": "2.0", "id": rid,
+            "result": {
+                "protocolVersion": version,
+                "capabilities": {"tools": {}, "resources": {"subscribe": True}},
+                "serverInfo": {"name": "MAGDA-stub", "version": "1.0"},
+            },
+        }, headers={"Mcp-Session-Id": session})
+
+    def _dispatch(self, rid: object, method: str, params: dict, era: str, client_name: str) -> None:
+        def result(value: object) -> None:
+            # What McpEndpoint::handle's `complete` lambda does: a modern reply
+            # carries `resultType` and a serverInfo `_meta`, and a legacy one
+            # carries neither, since that revision has never heard of them.
+            if era == "modern" and isinstance(value, dict):
+                value = dict(value)
+                value.setdefault("resultType", "complete")
+                # The 2026-07-28 schema makes a cacheable result carry its own
+                # cache directives: `resultType` alone does not satisfy it, and
+                # a client validating against the schema — the official SDK
+                # does — rejects the response without them.
+                if method in CACHEABLE_RESULTS:
+                    value.setdefault("ttlMs", 0)
+                    value.setdefault("cacheScope", "private")
+                meta = dict(value.get("_meta") or {})
+                meta.setdefault("io.modelcontextprotocol/serverInfo",
+                                {"name": "MAGDA-stub", "version": "1.0"})
+                value["_meta"] = meta
+            self._send_json(200, {"jsonrpc": "2.0", "id": rid, "result": value})
+
+        if method == "server/discover":
+            if era != "modern":
+                self._send_json(400, self._error(
+                    rid, -32022, "server/discover requires protocol version 2026-07-28 or later"))
+                return
+            # The same shape McpEndpoint::discoverResult() builds. `capabilities`
+            # is required by the specification's DiscoverResult, and a client
+            # that cannot parse this falls back to the legacy handshake — which
+            # is exactly what the SDK suite exists to notice.
+            result({
+                "resultType": "complete",
+                "ttlMs": 0,
+                "cacheScope": "private",
+                "supportedVersions": [MODERN, LEGACY, "2025-06-18"],
+                "capabilities": {"tools": {"listChanged": False},
+                                 "resources": {"subscribe": True, "listChanged": False}},
+                "instructions": "Inspect and control the MAGDA session that is running now.",
+                "_meta": {"io.modelcontextprotocol/serverInfo":
+                          {"name": "MAGDA-stub", "version": "1.0"}},
+            })
+        elif method == "tools/list":
+            result({"tools": TOOLS})
+        elif method == "resources/list":
+            result({"resources": [{"uri": "magda://tracks", "name": "tracks",
+                                   "mimeType": "application/json"}]})
+        elif method == "resources/templates/list":
+            result({"resourceTemplates": [{"uriTemplate": "magda://tracks/{track_id}",
+                                           "name": "track"}]})
+        elif method == "resources/read":
+            uri = params.get("uri")
+            if uri != "magda://tracks":
+                self._send_json(200, self._error(rid, -32602, f"no resource at {uri}"))
+                return
+            result({"contents": [{"uri": uri, "mimeType": "application/json", "text": TRACKS_JSON}]})
+        elif method == "tools/call":
+            self._tools_call(rid, params, client_name, result)
+        elif method == "resources/subscribe":
+            result({})
+        elif method == "subscriptions/listen":
+            self._listen(params)
+        else:
+            self._send_json(404, self._error(rid, -32601, f"no such method {method}"))
+
+    def _tools_call(self, rid: object, params: dict, client_name: str, result) -> None:
+        name = params.get("name")
+        arguments = params.get("arguments") or {}
+        known = {t["name"] for t in TOOLS}
+        if name not in known:
+            self._send_json(200, self._error(rid, -32602, f"no tool named {name}"))
+            return
+        if name == "tracks.create" and client_name == clients.READONLY_CLIENT_NAME:
+            result({"isError": True, "content": [{"type": "text", "text": json.dumps(
+                {"code": "PERMISSION_DENIED",
+                 "message": "this client has not been granted 'edit'"})}]})
+            return
+        if name == "tracks.get" and arguments.get("trackId", 0) < 0:
+            result({"isError": True, "content": [{"type": "text", "text": json.dumps(
+                {"code": "NOT_FOUND", "message": "no track with that id",
+                 "issues": [{"field": "trackId", "problem": "unknown"}]})}]})
+            return
+        text = TRACKS_JSON if name == "tracks.list" else json.dumps({"ok": True})
+        result({
+            "isError": False,
+            "content": [{"type": "text", "text": text}],
+            "structuredContent": json.loads(text),
+            "_meta": {clients.MAGDA_META_REVISION: STATE["revision"]},
+        })
+
+    def _listen(self, params: dict) -> None:
+        import time as _t
+        asked = params.get("notifications.resourceSubscriptions") or []
+        # Only URIs that name something are agreed to — the honest filter.
+        agreed = [u for u in asked if u == "magda://tracks" or u == "magda://transport"]
+        self.send_response(200)
+        self.send_header("Content-Type", "text/event-stream")
+        self.send_header("Cache-Control", "no-cache")
+        self.end_headers()
+        ack = {"jsonrpc": "2.0", "method": "notifications/subscriptions/acknowledged",
+               "params": {"notifications.resourceSubscriptions": agreed}}
+        try:
+            self.wfile.write(f"data: {json.dumps(ack)}\n\n".encode())
+            self.wfile.flush()
+            for _ in range(20):
+                self.wfile.write(b": keep-alive\n\n")
+                self.wfile.flush()
+                _t.sleep(0.4)
+        except OSError:
+            return
+
+
+# ---------------------------------------------------------------------------
+# OSC
+# ---------------------------------------------------------------------------
+
+
+class StubOsc(threading.Thread):
+    """Answers a host it has not heard from with a snapshot, once."""
+
+    def __init__(self, receive_port: int, feedback_port: int) -> None:
+        super().__init__(daemon=True)
+        from wire import osc_decode, osc_encode
+
+        self._decode, self._encode = osc_decode, osc_encode
+        self.sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        self.sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self.sock.bind(("127.0.0.1", receive_port))
+        self.receive_port = self.sock.getsockname()[1]
+        self.feedback_port = feedback_port
+        self.known: set[str] = set()
+        self.running = True
+
+    def run(self) -> None:
+        while self.running:
+            try:
+                data, peer = self.sock.recvfrom(65536)
+            except OSError:
+                return
+            messages = self._decode(data)
+            if not messages:
+                continue  # heard from, but nothing understood: not answerable
+            for message in messages:
+                if message.address == "/magda/transport/tempo" and message.args:
+                    STATE['tempo'] = float(message.args[0])
+            if peer[0] not in self.known:
+                self.known.add(peer[0])
+                self._snapshot(peer[0])
+
+    def _snapshot(self, host: str) -> None:
+        out = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        try:
+            for address, value in (
+                ("/magda/transport/tempo", STATE['tempo']),
+                ("/magda/track/1/volume", 0.8),
+                ("/magda/track/1/pan", 0.5),
+                ("/magda/master/volume", 1.0),
+            ):
+                out.sendto(self._encode(address, value), (host, self.feedback_port))
+        finally:
+            out.close()
+
+    def stop(self) -> None:
+        self.running = False
+        self.sock.close()
+
+
+# ---------------------------------------------------------------------------
+# A fake magda-mcp
+# ---------------------------------------------------------------------------
+
+FAKE_BRIDGE = '''#!{python}
+"""A stand-in for magda-mcp: newline JSON-RPC on stdio, proxied over HTTP."""
+import http.client, json, os, sys, glob
+
+def endpoint():
+    directory = os.environ.get("MAGDA_DATA_DIR", "")
+    best = None
+    for path in glob.glob(os.path.join(directory, "remote-api-*.json")):
+        with open(path) as handle:
+            record = json.load(handle)
+        if record.get("mcpUrl") and record.get("token"):
+            best = record
+    return best
+
+SESSION = {{}}
+for line in sys.stdin:
+    line = line.strip()
+    if not line:
+        continue
+    request = json.loads(line)
+    record = endpoint()
+    if record is None:
+        print(json.dumps({{"jsonrpc": "2.0", "id": request.get("id"),
+              "error": {{"code": -32603, "message": "no running MAGDA found"}}}}), flush=True)
+        continue
+    url = record["mcpUrl"]
+    host = url.split("://", 1)[1].split("/", 1)[0]
+    path = "/" + url.split("://", 1)[1].split("/", 1)[1]
+    headers = {{"Authorization": "Bearer " + record["token"],
+               "Content-Type": "application/json",
+               "Accept": "application/json, text/event-stream"}}
+    meta = (request.get("params") or {{}}).get("_meta") or {{}}
+    if meta.get("io.modelcontextprotocol/protocolVersion"):
+        headers["MCP-Protocol-Version"] = meta["io.modelcontextprotocol/protocolVersion"]
+        headers["Mcp-Method"] = request["method"]
+        params = request.get("params") or {{}}
+        if request["method"] == "tools/call":
+            headers["Mcp-Name"] = params.get("name", "")
+        elif request["method"] == "resources/read":
+            headers["Mcp-Name"] = params.get("uri", "")
+    elif SESSION.get("id"):
+        headers["Mcp-Session-Id"] = SESSION["id"]
+    conn = http.client.HTTPConnection(host, timeout=15)
+    conn.request("POST", path, json.dumps(request), headers)
+    response = conn.getresponse()
+    body = response.read().decode()
+    if response.getheader("Mcp-Session-Id"):
+        SESSION["id"] = response.getheader("Mcp-Session-Id")
+    conn.close()
+    print(body, flush=True)
+'''
+
+
+# ---------------------------------------------------------------------------
+# Driver
+# ---------------------------------------------------------------------------
+
+
+def free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+def main() -> int:
+    from cli import run as run_harness
+
+    ws = StubWebSocket()
+    ws.start()
+
+    mcp_server = QuietHttpServer(("127.0.0.1", 0), StubMcpHandler)
+    mcp_port = mcp_server.server_address[1]
+    threading.Thread(target=mcp_server.serve_forever, daemon=True).start()
+
+    osc_receive = free_port()
+    osc_feedback = free_port()
+    osc = StubOsc(osc_receive, osc_feedback)
+    osc.start()
+
+    workspace = Path(tempfile.mkdtemp(prefix="magda-transport-selftest-"))
+    record = workspace / f"remote-api-{os.getpid()}.json"
+    record.write_text(json.dumps({
+        "port": ws.port,
+        "token": TOKEN,
+        "url": f"ws://127.0.0.1:{ws.port}/rpc",
+        "mcpPort": mcp_port,
+        "mcpUrl": f"http://127.0.0.1:{mcp_port}/mcp",
+        "pid": os.getpid(),
+    }))
+    record.chmod(0o600)
+
+    bridge = workspace / "magda-mcp"
+    bridge.write_text(FAKE_BRIDGE.format(python=sys.executable))
+    bridge.chmod(0o755)
+
+    # No --all: with no suite flag the harness runs everything anyway, which
+    # leaves room for `selftest.py --ws --json` to narrow it by hand.
+    argv = [
+        "--write",
+        "--record", str(record),
+        "--data-dir", str(workspace),
+        "--bridge-path", str(bridge),
+        "--osc-port", str(osc.receive_port),
+        "--osc-feedback-port", str(osc_feedback),
+        "--stream-window", "1.5",
+    ] + sys.argv[1:]
+
+    print("=" * 72)
+    print("  running the harness against the stub")
+    print("=" * 72)
+
+    report = run_harness(argv)
+
+    ws.stop()
+    osc.stop()
+    mcp_server.shutdown()
+
+    if report is None:
+        print("  the harness could not resolve the stub's discovery record")
+        return 1
+
+    return verdict(report)
+
+
+#: The one check the stub cannot satisfy. The harness looks for `magda-mcp`
+#: beside the executable behind the discovery record's pid, and that pid here
+#: is the Python running this file. A *passing* result would mean the check was
+#: not looking at anything, so it is expected to fail rather than excused.
+EXPECTED_FAILURES = {"magda-mcp is staged beside the MAGDA executable"}
+
+
+def verdict(report) -> int:
+    """Fail only on findings the stub was built to satisfy."""
+    unexpected = [
+        check for check in report.checks
+        if check.status is Status.FAIL and check.name not in EXPECTED_FAILURES
+    ]
+    missing = [
+        name for name in EXPECTED_FAILURES
+        if not any(c.name == name and c.status is Status.FAIL for c in report.checks)
+    ]
+    inconclusive = [c for c in report.checks if check_is_unclear(c)]
+
+    print("=" * 72)
+    if unexpected:
+        print("  the harness reported failures the stub should have satisfied:")
+        for check in unexpected:
+            print(f"    {check.suite} / {check.name}\n      {check.detail}")
+    if missing:
+        print("  these were expected to fail against the stub and did not:")
+        for name in missing:
+            print(f"    {name}")
+    if inconclusive:
+        print("  inconclusive (not a failure, but worth an eye):")
+        for check in inconclusive:
+            print(f"    {check.suite} / {check.name}")
+    if not unexpected and not missing:
+        print(f"  harness self-test passed: {len(report.checks)} checks behaved as expected")
+    print("=" * 72)
+    return 1 if (unexpected or missing) else 0
+
+
+def check_is_unclear(check) -> bool:
+    return check.status is Status.INCONCLUSIVE
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/transport_check/suites.py
+++ b/tools/transport_check/suites.py
@@ -1,0 +1,1010 @@
+"""The checks themselves, grouped by the surface each one exercises.
+
+Every suite takes a `Context` and reports through a `Report`. Suites never
+raise past their own boundary: a transport that is entirely down should fail
+its own checks and leave the others to run, because "MCP is broken and OSC is
+fine" is a more useful thing to learn in one run than a traceback.
+
+Default runs are non-mutating. The write checks are behind `--write` because
+this points at whatever project the user happens to have open, and a harness
+that silently added a track to real work would be a bad trade for the coverage.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable
+
+import clients
+import discovery
+from clients import (
+    LEGACY_PROTOCOL,
+    MAGDA_META_REVISION,
+    MODERN_PROTOCOL,
+    McpBridgeClient,
+    McpHttpClient,
+    OscClient,
+    WsClient,
+)
+from report import Check, Report, Status, timed
+
+
+@dataclass
+class Context:
+    record: discovery.Record
+    report: Report
+    write: bool = False
+    stream_window: float = 3.0
+    osc_send_port: int = 9000
+    osc_feedback_port: int = 9001
+    bridge_path: str | None = None
+    data_dir: Path | None = None
+    timeout: float = 10.0
+
+    def ws(self, client_name: str = clients.CLIENT_NAME, **kwargs: Any) -> WsClient:
+        return WsClient(
+            "127.0.0.1", self.record.port, self.record.token,
+            client_name=client_name, timeout=self.timeout, **kwargs
+        )
+
+    def mcp(self, client_name: str = clients.CLIENT_NAME) -> McpHttpClient:
+        origin, path = self.record.mcp_origin_and_path()
+        return McpHttpClient(origin, path, self.record.token, client_name, timeout=self.timeout)
+
+
+class SuiteRunner:
+    """Wraps each check so one failure never takes the run down with it."""
+
+    def __init__(self, context: Context, suite: str) -> None:
+        self.context = context
+        self.suite = suite
+        self.report = context.report
+
+    def check(self, name: str, fn: Callable[[], tuple[Status, str] | tuple[Status, str, dict]]) -> Check:
+        with timed() as clock:
+            try:
+                outcome = fn()
+                status, detail = outcome[0], outcome[1]
+                data = outcome[2] if len(outcome) > 2 else {}
+            except AssertionError as exc:
+                status, detail, data = Status.FAIL, str(exc) or "assertion failed", {}
+            except Exception as exc:  # noqa: BLE001 - a harness must not crash
+                status, detail, data = Status.FAIL, describe_exception(exc), {}
+        return self.report.add(
+            Check(self.suite, name, status, detail, clock.ms, data)
+        )
+
+    def skip(self, name: str, reason: str) -> Check:
+        return self.report.add(Check(self.suite, name, Status.SKIP, reason))
+
+
+def describe_exception(exc: BaseException, depth: int = 0) -> str:
+    """A one-line cause, digging through exception groups to find it.
+
+    An async client raises an `ExceptionGroup` whose message is "unhandled
+    errors in a TaskGroup (1 sub-exception)" — true, and useless. What the
+    reader needs is the schema-validation failure three levels down, so this
+    walks to it. Chained causes are followed for the same reason.
+    """
+    nested = getattr(exc, "exceptions", None)
+    if nested and depth < 6:
+        inner = [describe_exception(item, depth + 1) for item in nested]
+        return inner[0] if len(inner) == 1 else " | ".join(inner)
+
+    # A schema validation failure is the SDK suite's whole reason to exist, and
+    # pydantic's default rendering buries the one useful fact — which fields
+    # were wrong — under repeated URLs and truncated input dumps.
+    errors = getattr(exc, "errors", None)
+    if callable(errors):
+        try:
+            problems = []
+            for item in errors():
+                where = ".".join(str(part) for part in item.get("loc", ())) or "(root)"
+                problems.append(f"{where}: {item.get('msg', 'invalid')}")
+            if problems:
+                model = str(exc).split("for", 1)[-1].split("\n", 1)[0].strip()
+                head = f"{type(exc).__name__} for {model}" if model else type(exc).__name__
+                return f"{head} — " + "; ".join(problems[:6])
+        except Exception:  # noqa: BLE001 - fall through to the plain rendering
+            pass
+
+    text = str(exc).strip().replace("\n", " ")
+    if len(text) > 400:
+        text = text[:400] + "…"
+    described = f"{type(exc).__name__}: {text}" if text else type(exc).__name__
+
+    cause = exc.__cause__ or exc.__context__
+    if not text and cause is not None and depth < 6:
+        return describe_exception(cause, depth + 1)
+    return described
+
+
+def ok(detail: str = "", **data: Any) -> tuple[Status, str, dict]:
+    return Status.PASS, detail, data
+
+
+def fail(detail: str, **data: Any) -> tuple[Status, str, dict]:
+    return Status.FAIL, detail, data
+
+
+def unclear(detail: str, **data: Any) -> tuple[Status, str, dict]:
+    return Status.INCONCLUSIVE, detail, data
+
+
+# ---------------------------------------------------------------------------
+# Discovery and packaging
+# ---------------------------------------------------------------------------
+
+
+def executable_for_pid(pid: int) -> Path | None:
+    """The binary behind a running pid, best effort, per platform."""
+    try:
+        if sys.platform == "linux":
+            return Path(os.readlink(f"/proc/{pid}/exe"))
+        if sys.platform == "darwin":
+            out = subprocess.run(
+                ["ps", "-p", str(pid), "-o", "comm="],
+                capture_output=True, text=True, timeout=5,
+            )
+            path = out.stdout.strip()
+            return Path(path) if path else None
+        if sys.platform == "win32":
+            out = subprocess.run(
+                ["wmic", "process", "where", f"processid={pid}", "get", "ExecutablePath"],
+                capture_output=True, text=True, timeout=10,
+            )
+            lines = [l.strip() for l in out.stdout.splitlines() if l.strip()]
+            return Path(lines[1]) if len(lines) > 1 else None
+    except (OSError, subprocess.SubprocessError, IndexError):
+        return None
+    return None
+
+
+def bridge_name() -> str:
+    return "magda-mcp.exe" if sys.platform == "win32" else "magda-mcp"
+
+
+def run_discovery(context: Context, others: list[discovery.Record]) -> None:
+    runner = SuiteRunner(context, "discovery")
+    record = context.record
+
+    runner.check(
+        "discovery record names a live process",
+        lambda: ok(f"{record.path.name}, pid {record.pid}", pid=record.pid),
+    )
+
+    def perms() -> tuple[Status, str, dict]:
+        owner_only = record.owner_only()
+        if owner_only is None:
+            return unclear("Windows: the file inherits the per-user directory ACL, not a mode")
+        mode = oct(record.path.stat().st_mode & 0o777)
+        if not owner_only:
+            return fail(f"token file is {mode}, expected 0o600", mode=mode)
+        return ok(f"mode {mode}", mode=mode)
+
+    runner.check("token file is owner-only", perms)
+
+    runner.check(
+        "record carries a WebSocket URL",
+        lambda: ok(record.url, port=record.port) if record.url and record.port
+        else fail("record has no url/port"),
+    )
+
+    runner.check(
+        "record carries an MCP URL",
+        lambda: ok(record.mcp_url or "", mcpPort=record.mcp_port) if record.has_mcp
+        else fail("no mcpUrl: MAGDA came up but its MCP listener did not"),
+    )
+
+    if others:
+        runner.check(
+            "exactly one MAGDA instance is running",
+            lambda: unclear(
+                f"{len(others) + 1} live instances; testing pid {record.pid}. "
+                f"Others: {', '.join(str(o.pid) for o in others)}"
+            ),
+        )
+
+    # -- packaging: is the bridge staged beside the executable? ------------
+
+    def staged() -> tuple[Status, str, dict]:
+        exe = executable_for_pid(record.pid)
+        if exe is None:
+            return unclear(f"could not resolve the executable behind pid {record.pid}")
+        if "/tmp/.mount_" in str(exe) or ".mount_" in str(exe):
+            return unclear(
+                f"running from an AppImage ({exe}); the settings page is expected to "
+                "show a placeholder here and publish magda-mcp as a separate asset"
+            )
+        candidate = exe.parent / bridge_name()
+        if not candidate.exists():
+            return fail(f"{candidate} does not exist", expected=str(candidate))
+        if sys.platform != "win32" and not os.access(candidate, os.X_OK):
+            return fail(f"{candidate} is not executable")
+        return ok(str(candidate), path=str(candidate))
+
+    runner.check("magda-mcp is staged beside the MAGDA executable", staged)
+
+
+# ---------------------------------------------------------------------------
+# WebSocket
+# ---------------------------------------------------------------------------
+
+
+def run_websocket(context: Context) -> None:
+    runner = SuiteRunner(context, "websocket")
+    from wire import HandshakeError
+
+    def bad_token() -> tuple[Status, str, dict]:
+        client = WsClient("127.0.0.1", context.record.port, "not-the-token", timeout=context.timeout)
+        try:
+            client.connect()
+        except HandshakeError as exc:
+            if exc.status == 401:
+                return ok("401 before the upgrade")
+            return fail(f"expected 401, got {exc.status}")
+        finally:
+            client.close()
+        return fail("a bad bearer token was accepted")
+
+    runner.check("a bad bearer token is refused with 401", bad_token)
+
+    def bad_origin() -> tuple[Status, str, dict]:
+        client = WsClient(
+            "127.0.0.1", context.record.port, context.record.token,
+            timeout=context.timeout, origin="http://evil.example",
+        )
+        try:
+            client.connect()
+        except HandshakeError as exc:
+            if exc.status == 403:
+                return ok("403 before the upgrade")
+            return fail(f"expected 403, got {exc.status}")
+        finally:
+            client.close()
+        return fail("an unlisted Origin was accepted (DNS-rebinding defence is open)")
+
+    runner.check("an unlisted Origin is refused with 403", bad_origin)
+
+    try:
+        with context.ws() as ws:
+            runner.check(
+                "connect and describe the API surface",
+                lambda: _ws_describe(ws),
+            )
+            runner.check("project.get returns a revision", lambda: _ws_project(ws))
+            runner.check("tracks.list answers", lambda: _ws_tracks(ws))
+            runner.check("an unknown method is refused", lambda: _ws_unknown(ws))
+            runner.check(
+                "subscriptions.subscribe returns a snapshot in the reply",
+                lambda: _ws_subscribe(ws),
+            )
+            runner.check(
+                f"the connection stays up and pushes for {context.stream_window:.0f}s",
+                lambda: _ws_stream(ws, context.stream_window),
+            )
+            if context.write:
+                runner.check("a write advances the revision, and reverts", lambda: _ws_write(ws))
+                runner.check("a stale expectedRevision is refused", lambda: _ws_stale(ws))
+            else:
+                runner.skip("a write advances the revision", "needs --write")
+                runner.skip("a stale expectedRevision is refused", "needs --write")
+    except Exception as exc:  # noqa: BLE001
+        message = f"{type(exc).__name__}: {exc}"
+        runner.check("connect to /rpc", lambda: fail(message))
+
+
+def _ws_describe(ws: WsClient) -> tuple[Status, str, dict]:
+    reply = ws.call("system.describe")
+    assert reply.ok, f"system.describe failed: {reply.error}"
+    result = reply.result or {}
+    operations = result.get("operations") or result.get("ops") or []
+    meta = reply.raw.get("meta") or {}
+    assert meta.get("apiVersion"), "reply carried no meta.apiVersion"
+    return ok(
+        f"apiVersion {meta.get('apiVersion')}, {len(operations)} operations",
+        apiVersion=meta.get("apiVersion"), operations=len(operations),
+    )
+
+
+def _ws_project(ws: WsClient) -> tuple[Status, str, dict]:
+    reply = ws.call("project.get")
+    assert reply.ok, f"project.get failed: {reply.error}"
+    assert reply.revision is not None, "reply carried no meta.revision"
+    tempo = (reply.result or {}).get("tempo")
+    return ok(f"revision {reply.revision}, tempo {tempo}", revision=reply.revision)
+
+
+def _ws_tracks(ws: WsClient) -> tuple[Status, str, dict]:
+    reply = ws.call("tracks.list")
+    assert reply.ok, f"tracks.list failed: {reply.error}"
+    result = reply.result
+    tracks = result.get("tracks") if isinstance(result, dict) else result
+    assert isinstance(tracks, list), f"expected a list of tracks, got {type(result).__name__}"
+    return ok(f"{len(tracks)} tracks", tracks=len(tracks))
+
+
+def _ws_unknown(ws: WsClient) -> tuple[Status, str, dict]:
+    reply = ws.call("tracks.doesNotExist")
+    assert not reply.ok, "an unknown operation was accepted"
+    return ok(f"code {reply.code}", code=reply.code)
+
+
+def _ws_subscribe(ws: WsClient) -> tuple[Status, str, dict]:
+    reply = ws.call("subscriptions.subscribe", {"topics": ["project", "transport", "tracks"]})
+    assert reply.ok, f"subscribe failed: {reply.error}"
+    snapshots = (reply.result or {}).get("snapshots") or []
+    assert snapshots, "subscribe returned no snapshots, so a client would not know what it watches"
+    kinds = [s.get("type") for s in snapshots]
+    return ok(f"{len(snapshots)} snapshots {kinds}", snapshots=len(snapshots))
+
+
+def _ws_stream(ws: WsClient, window: float) -> tuple[Status, str, dict]:
+    ws.call("subscriptions.subscribe", {"topics": ["playhead", "meters"]})
+    events = ws.collect_notifications(window)
+    if not events:
+        return unclear(
+            "no events arrived. Expected when the transport is stopped and no audio "
+            "device is open; the subscription itself was accepted."
+        )
+    methods = sorted({e.get("method", "?") for e in events})
+    return ok(f"{len(events)} events, methods {methods}", events=len(events))
+
+
+def _ws_write(ws: WsClient) -> tuple[Status, str, dict]:
+    before = ws.call("project.get")
+    assert before.ok, f"project.get failed: {before.error}"
+    original = (before.result or {}).get("tempo")
+    assert isinstance(original, (int, float)), f"no tempo to change: {before.result}"
+    target = round(float(original) + 1.0, 3)
+    try:
+        written = ws.call("project.setTempo", {"tempo": target})
+        assert written.ok, f"setTempo failed: {written.error}"
+        assert written.revision is not None and before.revision is not None
+        assert written.revision > before.revision, (
+            f"revision did not advance: {before.revision} -> {written.revision}"
+        )
+        after = ws.call("project.get")
+        assert abs(float((after.result or {}).get("tempo", 0)) - target) < 1e-3, (
+            f"tempo reads back as {(after.result or {}).get('tempo')}, expected {target}"
+        )
+        return ok(
+            f"tempo {original} -> {target}, revision {before.revision} -> {written.revision}",
+            revision=written.revision,
+        )
+    finally:
+        ws.call("project.setTempo", {"tempo": float(original)})
+
+
+def _ws_stale(ws: WsClient) -> tuple[Status, str, dict]:
+    current = ws.call("project.get")
+    assert current.revision is not None, "no revision to be stale against"
+    tempo = float((current.result or {}).get("tempo", 120.0))
+    reply = ws.call(
+        "project.setTempo", {"tempo": tempo}, meta={"expectedRevision": 1}
+    )
+    if reply.ok:
+        return fail("a write against revision 1 was applied, so nothing is being checked")
+    return ok(f"refused with code {reply.code}", code=reply.code)
+
+
+# ---------------------------------------------------------------------------
+# MCP, modern era
+# ---------------------------------------------------------------------------
+
+
+def run_mcp_modern(context: Context) -> None:
+    runner = SuiteRunner(context, "mcp (modern, stateless)")
+    if not context.record.has_mcp:
+        runner.skip("every check", "the record carries no mcpUrl")
+        return
+    mcp = context.mcp()
+
+    def bad_token() -> tuple[Status, str, dict]:
+        origin, path = context.record.mcp_origin_and_path()
+        wrong = McpHttpClient(origin, path, "not-the-token", timeout=context.timeout)
+        reply = wrong.modern("tools/list")
+        assert reply.status == 401, f"expected 401, got {reply.status}: {reply.body[:200]}"
+        return ok("401")
+
+    runner.check("a bad bearer token is refused with 401", bad_token)
+
+    def bad_origin() -> tuple[Status, str, dict]:
+        reply = mcp.modern(
+            "tools/list", header_overrides={"Origin": "http://evil.example"}
+        )
+        assert reply.status == 403, (
+            f"expected 403, got {reply.status}. Validating Origin is a MUST in the "
+            "transport spec and is what stops a page the user merely visited from "
+            "reaching this listener by DNS rebinding."
+        )
+        return ok("403")
+
+    runner.check("an unlisted Origin is refused with 403", bad_origin)
+
+    def discover() -> tuple[Status, str, dict]:
+        reply = mcp.modern("server/discover")
+        assert reply.status == 200, f"HTTP {reply.status}: {reply.body[:200]}"
+        result = reply.json().get("result") or {}
+        versions = result.get("supportedVersions") or []
+        assert MODERN_PROTOCOL in versions, f"supportedVersions {versions} lacks {MODERN_PROTOCOL}"
+        return ok(f"supports {versions}", versions=versions)
+
+    runner.check("server/discover advertises the supported versions", discover)
+
+    tool_names: list[str] = []
+
+    def tools_list() -> tuple[Status, str, dict]:
+        reply = mcp.modern("tools/list")
+        assert reply.status == 200, f"HTTP {reply.status}: {reply.body[:200]}"
+        tools = (reply.json().get("result") or {}).get("tools") or []
+        assert tools, "tools/list returned nothing"
+        tool_names.extend(t["name"] for t in tools)
+        assert "tracks.list" in tool_names, f"tracks.list missing from {tool_names[:10]}"
+        missing_schema = [t["name"] for t in tools if not t.get("inputSchema")]
+        assert not missing_schema, f"tools without an inputSchema: {missing_schema[:5]}"
+        return ok(f"{len(tools)} tools, all with an inputSchema", tools=len(tools))
+
+    runner.check("tools/list projects the operation registry", tools_list)
+
+    call_text: list[str] = []
+
+    def tools_call() -> tuple[Status, str, dict]:
+        reply = mcp.modern("tools/call", {"name": "tracks.list", "arguments": {}})
+        assert reply.status == 200, f"HTTP {reply.status}: {reply.body[:200]}"
+        result = reply.json().get("result") or {}
+        assert result.get("isError") is False, f"tools/call reported an error: {result}"
+        assert "structuredContent" in result, "no structuredContent in the result"
+        content = result.get("content") or []
+        assert content and content[0].get("type") == "text", "no text content block"
+        call_text.append(content[0]["text"])
+        revision = (result.get("_meta") or {}).get(MAGDA_META_REVISION)
+        assert revision is not None, f"_meta carried no {MAGDA_META_REVISION}"
+        return ok(f"revision {revision}", revision=revision)
+
+    runner.check("tools/call returns structured content and a revision", tools_call)
+
+    def resources_read() -> tuple[Status, str, dict]:
+        reply = mcp.modern("resources/read", {"uri": "magda://tracks"})
+        assert reply.status == 200, f"HTTP {reply.status}: {reply.body[:200]}"
+        contents = (reply.json().get("result") or {}).get("contents") or []
+        assert contents, "resources/read returned no contents"
+        entry = contents[0]
+        assert entry.get("mimeType") == "application/json", f"mimeType {entry.get('mimeType')}"
+        if not call_text:
+            return unclear("tools/call did not run, so there is nothing to compare against")
+        if entry.get("text") == call_text[0]:
+            return ok("byte for byte identical to the tools/call text block")
+        if json.loads(entry.get("text", "null")) == json.loads(call_text[0]):
+            return unclear("equal as JSON but not byte for byte, which the docs promise")
+        return fail("resources/read and tools/call disagree for the same operation")
+
+    runner.check("resources/read matches tools/call for the same operation", resources_read)
+
+    def templates() -> tuple[Status, str, dict]:
+        reply = mcp.modern("resources/templates/list")
+        assert reply.status == 200, f"HTTP {reply.status}"
+        items = (reply.json().get("result") or {}).get("resourceTemplates") or []
+        assert items, "no resource templates advertised"
+        return ok(f"{len(items)} templates", templates=len(items))
+
+    runner.check("resources/templates/list answers", templates)
+
+    # -- the rules a dual-era client depends on ---------------------------
+
+    def no_meta() -> tuple[Status, str, dict]:
+        reply = mcp.modern("tools/list", omit_meta=True)
+        assert reply.status == 400, f"expected 400, got {reply.status}"
+        error = reply.json().get("error") or {}
+        assert error.get("code") == -32602, f"expected -32602, got {error.get('code')}"
+        return ok("400 with -32602, which is what tells a dual-era client where it is")
+
+    runner.check("a request with no _meta protocol version is refused", no_meta)
+
+    def no_capabilities() -> tuple[Status, str, dict]:
+        # Built by hand: `modern()` always supplies clientCapabilities, and
+        # leaving it out is the whole of what this asserts.
+        params = {"_meta": {
+            clients.META_PROTOCOL_VERSION: MODERN_PROTOCOL,
+            clients.META_CLIENT_INFO: {"name": mcp.client_name, "version": "1.0"},
+        }}
+        body = json.dumps({"jsonrpc": "2.0", "id": 1, "method": "tools/list", "params": params})
+        headers = mcp.base_headers()
+        headers["MCP-Protocol-Version"] = MODERN_PROTOCOL
+        headers["Mcp-Method"] = "tools/list"
+        reply = mcp.request("tools/list", body, headers)
+        assert reply.status == 400, f"expected 400, got {reply.status}"
+        assert (reply.json().get("error") or {}).get("code") == -32602
+        return ok("400 with -32602")
+
+    runner.check("a request with no clientCapabilities is refused", no_capabilities)
+
+    def header_mismatch() -> tuple[Status, str, dict]:
+        reply = mcp.modern("tools/list", header_overrides={"Mcp-Method": "tools/call"})
+        assert reply.status == 400, f"expected 400, got {reply.status}"
+        code = (reply.json().get("error") or {}).get("code")
+        assert code == -32020, f"expected -32020, got {code}"
+        return ok("400 with -32020")
+
+    runner.check("a Mcp-Method header disagreeing with the body is refused", header_mismatch)
+
+    def missing_name_header() -> tuple[Status, str, dict]:
+        reply = mcp.modern(
+            "tools/call", {"name": "tracks.list", "arguments": {}},
+            header_overrides={"Mcp-Name": None},
+        )
+        assert reply.status == 400, f"expected 400, got {reply.status}"
+        code = (reply.json().get("error") or {}).get("code")
+        assert code == -32020, f"expected -32020, got {code}"
+        return ok("400 with -32020")
+
+    runner.check("tools/call without a Mcp-Name header is refused", missing_name_header)
+
+    def wrong_name_header() -> tuple[Status, str, dict]:
+        reply = mcp.modern(
+            "tools/call", {"name": "tracks.list", "arguments": {}},
+            header_overrides={"Mcp-Name": "tracks.create"},
+        )
+        assert reply.status == 400, (
+            f"expected 400, got {reply.status}. A proxy is allowed to route on this "
+            "header without parsing the body, so a server that executed the body "
+            "while an intermediary had decided on the header would be two components "
+            "acting on two different requests."
+        )
+        code = (reply.json().get("error") or {}).get("code")
+        assert code == -32020, f"expected -32020, got {code}"
+        return ok("400 with -32020")
+
+    runner.check("a Mcp-Name header naming a different tool is refused", wrong_name_header)
+
+    def base64_name() -> tuple[Status, str, dict]:
+        import base64 as b64
+        encoded = "=?base64?" + b64.b64encode(b"tracks.list").decode() + "?="
+        reply = mcp.modern(
+            "tools/call", {"name": "tracks.list", "arguments": {}},
+            header_overrides={"Mcp-Name": encoded},
+        )
+        assert reply.status == 200, f"HTTP {reply.status}: {reply.body[:200]}"
+        return ok("a base64-wrapped Mcp-Name decodes and matches")
+
+    runner.check("a base64-wrapped Mcp-Name is decoded before comparison", base64_name)
+
+    def unknown_method() -> tuple[Status, str, dict]:
+        reply = mcp.modern("tools/nope")
+        assert reply.status == 404, f"expected 404, got {reply.status}"
+        return ok("404, which separates 'no such method' from 'no MCP here'")
+
+    runner.check("an unknown method answers 404", unknown_method)
+
+    def unknown_tool() -> tuple[Status, str, dict]:
+        reply = mcp.modern("tools/call", {"name": "tracks.nope", "arguments": {}})
+        payload = reply.json()
+        assert "error" in payload, (
+            "an unknown tool came back as a tool execution error; nothing the model "
+            "does could fix it, so it belongs in the JSON-RPC channel"
+        )
+        return ok(f"JSON-RPC error {payload['error'].get('code')}")
+
+    runner.check("an unknown tool is a JSON-RPC error, not a tool error", unknown_tool)
+
+    def bad_arguments() -> tuple[Status, str, dict]:
+        reply = mcp.modern(
+            "tools/call", {"name": "tracks.get", "arguments": {"trackId": -999999}}
+        )
+        payload = reply.json()
+        result = payload.get("result") or {}
+        if result.get("isError") is True:
+            assert "structuredContent" not in result, (
+                "a tool error carried structuredContent, which cannot satisfy the outputSchema"
+            )
+            return ok("isError with the envelope in the text block, and no structuredContent")
+        if "error" in payload:
+            return unclear(f"answered in the JSON-RPC channel with {payload['error'].get('code')}")
+        return fail("an unknown track id was accepted")
+
+    runner.check("an actionable failure is a tool execution error", bad_arguments)
+
+    def listen() -> tuple[Status, str, dict]:
+        status, messages, comments = mcp.listen_modern(
+            ["magda://tracks", "magda://transport", "magda://nothing/here"],
+            context.stream_window,
+        )
+        assert status == 200, f"expected 200 for the SSE stream, got {status}"
+        assert messages, "the stream opened but sent nothing, not even an acknowledgement"
+        first = messages[0]
+        method = first.get("method") if isinstance(first, dict) else None
+        assert method == "notifications/subscriptions/acknowledged", (
+            f"first frame was {method!r}, expected the acknowledgement"
+        )
+        agreed = ((first.get("params") or {}).get("notifications.resourceSubscriptions")) or []
+        assert "magda://nothing/here" not in agreed, (
+            "the acknowledgement echoed a URI that names nothing, so it is an echo "
+            "rather than the filter actually agreed to"
+        )
+        return ok(
+            f"acknowledged {agreed}; {len(messages)} messages, {comments} keep-alives "
+            f"over {context.stream_window:.0f}s",
+            agreed=agreed, comments=comments,
+        )
+
+    runner.check("subscriptions/listen acknowledges, then stays up", listen)
+
+
+# ---------------------------------------------------------------------------
+# MCP, legacy era
+# ---------------------------------------------------------------------------
+
+
+def run_mcp_legacy(context: Context) -> None:
+    runner = SuiteRunner(context, "mcp (legacy, session)")
+    if not context.record.has_mcp:
+        runner.skip("every check", "the record carries no mcpUrl")
+        return
+    mcp = context.mcp()
+    session: list[str] = []
+
+    def initialize() -> tuple[Status, str, dict]:
+        reply = mcp.initialize(LEGACY_PROTOCOL)
+        assert reply.status == 200, f"HTTP {reply.status}: {reply.body[:200]}"
+        result = reply.json().get("result") or {}
+        assert result.get("protocolVersion") == LEGACY_PROTOCOL, (
+            f"negotiated {result.get('protocolVersion')}, asked for {LEGACY_PROTOCOL}"
+        )
+        assert reply.session_id, "initialize minted no Mcp-Session-Id"
+        session.append(reply.session_id)
+        server = result.get("serverInfo") or {}
+        return ok(
+            f"session {reply.session_id[:8]}…, server {server.get('name')} {server.get('version')}",
+            protocolVersion=result.get("protocolVersion"),
+        )
+
+    runner.check("initialize mints a session and echoes the version", initialize)
+
+    if not session:
+        runner.skip("the remaining legacy checks", "no session to use")
+        return
+
+    def with_session() -> tuple[Status, str, dict]:
+        reply = mcp.legacy("tools/list", session=session[0])
+        assert reply.status == 200, f"HTTP {reply.status}: {reply.body[:200]}"
+        tools = (reply.json().get("result") or {}).get("tools") or []
+        assert tools, "tools/list under a session returned nothing"
+        return ok(f"{len(tools)} tools, no _meta and no mirrored headers needed")
+
+    runner.check("tools/list works against the session alone", with_session)
+
+    def call_with_session() -> tuple[Status, str, dict]:
+        reply = mcp.legacy(
+            "tools/call", {"name": "tracks.list", "arguments": {}}, session=session[0]
+        )
+        assert reply.status == 200, f"HTTP {reply.status}: {reply.body[:200]}"
+        result = reply.json().get("result") or {}
+        assert result.get("isError") is False, f"tools/call failed: {result}"
+        return ok("structured content returned")
+
+    runner.check("tools/call works against the session", call_with_session)
+
+    def modern_ignores_session() -> tuple[Status, str, dict]:
+        params = {"_meta": mcp.modern_meta()}
+        body = json.dumps(
+            {"jsonrpc": "2.0", "id": 1, "method": "tools/list", "params": params}
+        )
+        headers = mcp.base_headers()
+        headers["MCP-Protocol-Version"] = MODERN_PROTOCOL
+        headers["Mcp-Method"] = "tools/list"
+        headers["Mcp-Session-Id"] = session[0]
+        reply = mcp.request("tools/list", body, headers)
+        assert reply.status == 200, f"HTTP {reply.status}: {reply.body[:200]}"
+        assert reply.session_id is None, (
+            f"a modern request echoed Mcp-Session-Id {reply.session_id}, which 2026-07-28 forbids"
+        )
+        return ok("served statelessly, no session echoed")
+
+    runner.check("a modern request carrying a session id is served statelessly", modern_ignores_session)
+
+    def discover_is_modern_only() -> tuple[Status, str, dict]:
+        reply = mcp.legacy("server/discover", session=session[0])
+        payload = reply.json()
+        assert "error" in payload, "server/discover answered in a legacy session"
+        return ok(f"refused with {payload['error'].get('code')}")
+
+    runner.check("server/discover is refused in a legacy session", discover_is_modern_only)
+
+    def get_stream() -> tuple[Status, str, dict]:
+        reply = mcp.legacy("resources/subscribe", {"uri": "magda://tracks"}, session=session[0])
+        assert reply.status == 200, f"resources/subscribe: HTTP {reply.status}"
+        status, messages, comments = mcp.listen_legacy(session[0], context.stream_window)
+        assert status == 200, f"expected 200 for the GET stream, got {status}"
+        return ok(
+            f"open for {context.stream_window:.0f}s, {len(messages)} messages, "
+            f"{comments} keep-alives",
+            comments=comments,
+        )
+
+    runner.check("resources/subscribe, then the GET stream stays up", get_stream)
+
+    def delete_session() -> tuple[Status, str, dict]:
+        reply = mcp.delete_session(session[0])
+        assert reply.status in (200, 202, 204), f"DELETE answered {reply.status}"
+        after = mcp.legacy("tools/list", session=session[0])
+        assert after.status != 200 or "error" in after.json(), (
+            "the session still worked after being deleted"
+        )
+        return ok(f"DELETE {reply.status}, then the session no longer resolves")
+
+    runner.check("DELETE ends the session", delete_session)
+
+
+# ---------------------------------------------------------------------------
+# The stdio bridge — the surface the settings page actually tells users about
+# ---------------------------------------------------------------------------
+
+
+def resolve_bridge(context: Context) -> Path | None:
+    if context.bridge_path:
+        return Path(context.bridge_path)
+    exe = executable_for_pid(context.record.pid)
+    if exe is not None:
+        candidate = exe.parent / bridge_name()
+        if candidate.exists():
+            return candidate
+    found = shutil.which(bridge_name())
+    return Path(found) if found else None
+
+
+def run_bridge(context: Context) -> None:
+    runner = SuiteRunner(context, "mcp bridge (magda-mcp, stdio)")
+    bridge = resolve_bridge(context)
+    if bridge is None:
+        runner.skip(
+            "every check",
+            f"no {bridge_name()} found beside the running MAGDA or on PATH; "
+            "pass --bridge to point at one",
+        )
+        return
+
+    runner.report.note(f"using {bridge}")
+
+    try:
+        with McpBridgeClient(str(bridge), data_dir=context.data_dir) as client:
+            def modern_call() -> tuple[Status, str, dict]:
+                reply = client.call("tools/call", {"name": "tracks.list", "arguments": {}})
+                assert "result" in reply, f"bridge returned {reply}"
+                assert reply["result"].get("isError") is False, reply["result"]
+                return ok("a stateless call reached MAGDA and came back")
+
+            runner.check("a modern tools/call proxies through the bridge", modern_call)
+
+            def tools_match() -> tuple[Status, str, dict]:
+                through_bridge = client.call("tools/list")
+                names = sorted(t["name"] for t in through_bridge["result"]["tools"])
+                mcp = context.mcp()
+                direct = mcp.modern("tools/list")
+                direct_names = sorted(
+                    t["name"] for t in (direct.json()["result"]["tools"])
+                )
+                assert names == direct_names, (
+                    f"bridge and HTTP disagree: {set(names) ^ set(direct_names)}"
+                )
+                return ok(f"{len(names)} tools, identical to the HTTP endpoint")
+
+            runner.check("the bridge exposes the same tools as the endpoint", tools_match)
+
+            def legacy_session() -> tuple[Status, str, dict]:
+                init = client.call(
+                    "initialize",
+                    {
+                        "protocolVersion": LEGACY_PROTOCOL,
+                        "capabilities": {},
+                        "clientInfo": {"name": clients.CLIENT_NAME, "version": "1.0"},
+                    },
+                    era="legacy",
+                )
+                assert "result" in init, f"initialize failed: {init}"
+                version = init["result"].get("protocolVersion")
+                assert version == LEGACY_PROTOCOL, f"negotiated {version}"
+                # The session id never crosses stdio; the bridge holds it. A
+                # second call succeeding is the evidence that it did.
+                follow_up = client.call("tools/list", era="legacy")
+                assert "result" in follow_up, f"the session did not carry: {follow_up}"
+                return ok("initialize, then a second call on the same session the bridge holds")
+
+            runner.check("a legacy session is carried across requests", legacy_session)
+
+            if client.stderr:
+                runner.report.note(f"bridge stderr: {client.stderr[-1][:120]}")
+    except Exception as exc:  # noqa: BLE001
+        message = f"{type(exc).__name__}: {exc}"
+        runner.check("run the bridge", lambda: fail(message))
+
+
+def run_bridge_without_magda(context: Context) -> None:
+    """The bridge with nothing to reach must error, not hang.
+
+    A host that launches `magda-mcp` before MAGDA is up gets this path, and a
+    hang there is indistinguishable to the user from a broken host.
+    """
+    runner = SuiteRunner(context, "mcp bridge (no MAGDA)")
+    bridge = resolve_bridge(context)
+    if bridge is None:
+        runner.skip("every check", "no magda-mcp found")
+        return
+
+    def errors_promptly() -> tuple[Status, str, dict]:
+        empty = Path(tempfile.gettempdir()) / "magda-transport-check-empty"
+        empty.mkdir(parents=True, exist_ok=True)
+        with McpBridgeClient(str(bridge), data_dir=empty, timeout=15.0) as client:
+            reply = client.call("tools/list")
+        assert "error" in reply, f"expected an error with no MAGDA running, got {reply}"
+        return ok(f"answered {reply['error'].get('code')} rather than hanging")
+
+    runner.check("pointed at an empty data dir, the bridge errors rather than hangs", errors_promptly)
+
+
+# ---------------------------------------------------------------------------
+# Permissions — the first thing a new user hits
+# ---------------------------------------------------------------------------
+
+
+def run_readonly(context: Context) -> None:
+    runner = SuiteRunner(context, "read-only client")
+    runner.report.note(
+        f"as '{clients.READONLY_CLIENT_NAME}' — do not grant this one anything in AI Settings"
+    )
+
+    def ws_read() -> tuple[Status, str, dict]:
+        with context.ws(client_name=clients.READONLY_CLIENT_NAME) as ws:
+            reply = ws.call("tracks.list")
+            assert reply.ok, f"an ungranted client could not read: {reply.error}"
+            return ok("read is always on, as documented")
+
+    runner.check("an ungranted client may read over WebSocket", ws_read)
+
+    def ws_write() -> tuple[Status, str, dict]:
+        with context.ws(client_name=clients.READONLY_CLIENT_NAME) as ws:
+            reply = ws.call("tracks.create", {"name": "transport-check", "type": "audio"})
+            if reply.ok:
+                return fail(
+                    "an ungranted client created a track. Either this name has been "
+                    "granted 'edit' in AI Settings -> Clients, or nothing is being enforced."
+                )
+            message = (reply.error or {}).get("message", "")
+            return ok(f"code {reply.code}: {message[:80]}", code=reply.code, message=message)
+
+    runner.check("an ungranted client is refused a write over WebSocket", ws_write)
+
+    if not context.record.has_mcp:
+        runner.skip("the MCP checks", "the record carries no mcpUrl")
+        return
+
+    mcp = context.mcp(client_name=clients.READONLY_CLIENT_NAME)
+
+    def mcp_read() -> tuple[Status, str, dict]:
+        reply = mcp.modern("resources/read", {"uri": "magda://tracks"})
+        assert reply.status == 200, f"HTTP {reply.status}: {reply.body[:200]}"
+        return ok("resources/read allowed")
+
+    runner.check("an ungranted client may read over MCP", mcp_read)
+
+    def mcp_write() -> tuple[Status, str, dict]:
+        reply = mcp.modern(
+            "tools/call",
+            {"name": "tracks.create", "arguments": {"name": "transport-check", "type": "audio"}},
+        )
+        payload = reply.json()
+        result = payload.get("result") or {}
+        if result.get("isError") is True:
+            text = (result.get("content") or [{}])[0].get("text", "")
+            return ok(f"tool execution error, surfaced to the model: {text[:90]}", text=text)
+        if "error" in payload:
+            code = payload["error"].get("code")
+            return ok(f"JSON-RPC error {code}: {payload['error'].get('message', '')[:80]}", code=code)
+        return fail(
+            "an ungranted client created a track over MCP. Either this name has been "
+            "granted 'edit', or nothing is being enforced."
+        )
+
+    runner.check("an ungranted client is refused a write over MCP", mcp_write)
+
+
+# ---------------------------------------------------------------------------
+# OSC
+# ---------------------------------------------------------------------------
+
+
+def run_osc(context: Context) -> None:
+    runner = SuiteRunner(context, "osc")
+
+    client = OscClient("127.0.0.1", context.osc_send_port, context.osc_feedback_port)
+    try:
+        client.open(listen=True)
+    except OSError as exc:
+        runner.report.note(f"could not bind the feedback port {context.osc_feedback_port}: {exc}")
+        try:
+            client.open(listen=False)
+        except OSError as inner:
+            message = str(inner)
+            runner.check("open a socket", lambda: fail(message))
+            return
+
+    try:
+        def reachable() -> tuple[Status, str, dict]:
+            reason = client.check_reachable()
+            if reason:
+                return fail(
+                    f"{reason}. OSC is off by default — switch it on in the "
+                    "Controllers settings, or pass --osc-port."
+                )
+            return ok(f"127.0.0.1:{context.osc_send_port} accepted a datagram")
+
+        listening = runner.check("MAGDA is listening on the OSC receive port", reachable)
+        if listening.status is Status.FAIL:
+            runner.skip("the remaining OSC checks", "nothing is listening")
+            return
+
+        def snapshot() -> tuple[Status, str, dict]:
+            # Understood, therefore answerable — but track 128 resolves to no
+            # track, so nothing in the project moves. A surface MAGDA has not
+            # heard from before is sent a full snapshot; one it already knows
+            # is not, which is why a second run in one session sees nothing.
+            client.send("/magda/track/128/mute", 0)
+            messages = client.collect(context.stream_window)
+            if not messages:
+                return unclear(
+                    "no feedback arrived. Expected if this host is already a known peer "
+                    "in this MAGDA session (restart MAGDA to re-arm), if feedback is "
+                    f"aimed at a port other than {context.osc_feedback_port}, or if OSC "
+                    "feedback is off."
+                )
+            addresses = sorted({m.address for m in messages})
+            return ok(
+                f"{len(messages)} messages over {len(addresses)} addresses, "
+                f"e.g. {addresses[:3]}",
+                messages=len(messages), addresses=len(addresses),
+            )
+
+        runner.check("a new surface is sent a feedback snapshot", snapshot)
+
+        if not context.write:
+            runner.skip("an OSC command changes the project", "needs --write")
+            return
+
+        def round_trip() -> tuple[Status, str, dict]:
+            with context.ws() as ws:
+                before = ws.call("project.get")
+                assert before.ok, f"project.get failed: {before.error}"
+                original = float((before.result or {}).get("tempo", 120.0))
+                target = round(original + 2.0, 3)
+                try:
+                    client.send("/magda/transport/tempo", target)
+                    deadline_reads = 20
+                    for _ in range(deadline_reads):
+                        after = ws.call("project.get")
+                        if abs(float((after.result or {}).get("tempo", 0)) - target) < 1e-2:
+                            break
+                        time.sleep(0.1)
+                    else:
+                        return fail(
+                            f"tempo is still {(after.result or {}).get('tempo')} after "
+                            f"an OSC message asking for {target}"
+                        )
+                    echoes = client.collect(1.0)
+                    echoed = [m.address for m in echoes if "tempo" in m.address]
+                    detail = f"tempo {original} -> {target} via OSC, confirmed over WebSocket"
+                    if echoed:
+                        detail += f"; feedback echoed {echoed[0]}"
+                    return ok(detail)
+                finally:
+                    ws.call("project.setTempo", {"tempo": original})
+
+        runner.check("an OSC command changes the project, and reverts", round_trip)
+    finally:
+        client.close()

--- a/tools/transport_check/suites.py
+++ b/tools/transport_check/suites.py
@@ -19,7 +19,7 @@ import subprocess
 import sys
 import tempfile
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable
 
@@ -27,6 +27,7 @@ import clients
 import discovery
 from clients import (
     LEGACY_PROTOCOL,
+    Reply,
     MAGDA_META_REVISION,
     MODERN_PROTOCOL,
     McpBridgeClient,
@@ -55,9 +56,22 @@ class Context:
             client_name=client_name, timeout=self.timeout, **kwargs
         )
 
+    #: One client per identity, reused across suites. The rate limit is a
+    #: single bucket for the endpoint, so pacing only works if every request
+    #: this harness makes is spaced against the last one — a fresh client per
+    #: suite would each think it had the whole budget.
+    _mcp_clients: dict = field(default_factory=dict, repr=False)
+
     def mcp(self, client_name: str = clients.CLIENT_NAME) -> McpHttpClient:
-        origin, path = self.record.mcp_origin_and_path()
-        return McpHttpClient(origin, path, self.record.token, client_name, timeout=self.timeout)
+        if client_name not in self._mcp_clients:
+            origin, path = self.record.mcp_origin_and_path()
+            self._mcp_clients[client_name] = McpHttpClient(
+                origin, path, self.record.token, client_name, timeout=self.timeout
+            )
+        return self._mcp_clients[client_name]
+
+    def throttled(self) -> int:
+        return sum(client.throttled for client in self._mcp_clients.values())
 
 
 class SuiteRunner:
@@ -367,6 +381,13 @@ def _ws_write(ws: WsClient) -> tuple[Status, str, dict]:
     target = round(float(original) + 1.0, 3)
     try:
         written = ws.call("project.setTempo", {"tempo": target})
+        if not written.ok and _is_permission_denial(written):
+            return unclear(
+                f"'{clients.CLIENT_NAME}' has not been granted 'edit'. That is the "
+                "correct default — every new client is read-only — but it means this "
+                "check cannot run. Tick edit and transport for it in "
+                "AI Settings -> Clients."
+            )
         assert written.ok, f"setTempo failed: {written.error}"
         assert written.revision is not None and before.revision is not None
         assert written.revision > before.revision, (
@@ -384,15 +405,43 @@ def _ws_write(ws: WsClient) -> tuple[Status, str, dict]:
         ws.call("project.setTempo", {"tempo": float(original)})
 
 
+#: The WebSocket transport's code for "you have not been granted this".
+WS_PERMISSION_DENIED = -32006
+
+
+def _is_permission_denial(reply: "Reply") -> bool:
+    error = reply.error or {}
+    return (
+        error.get("code") == WS_PERMISSION_DENIED
+        or (error.get("data") or {}).get("code") == "permission_denied"
+    )
+
+
 def _ws_stale(ws: WsClient) -> tuple[Status, str, dict]:
+    """A stale `expectedRevision` must lose — and for that reason.
+
+    An ungranted client is refused every write, so "the write did not happen"
+    is true here whether or not optimistic concurrency works at all. Checking
+    only that it failed would go green on a MAGDA that had never implemented
+    `expectedRevision`, which is the opposite of what this exists to establish.
+    """
     current = ws.call("project.get")
     assert current.revision is not None, "no revision to be stale against"
     tempo = float((current.result or {}).get("tempo", 120.0))
-    reply = ws.call(
-        "project.setTempo", {"tempo": tempo}, meta={"expectedRevision": 1}
-    )
+    stale = 1 if current.revision != 1 else 2
+    reply = ws.call("project.setTempo", {"tempo": tempo}, meta={"expectedRevision": stale})
     if reply.ok:
-        return fail("a write against revision 1 was applied, so nothing is being checked")
+        return fail(
+            f"a write against revision {stale} was applied while the project was at "
+            f"{current.revision}, so nothing is enforcing expectedRevision"
+        )
+    if _is_permission_denial(reply):
+        return unclear(
+            f"refused, but for want of the 'edit' permission rather than the stale "
+            f"revision — grant '{clients.CLIENT_NAME}' edit in AI Settings -> Clients "
+            "for this to check what it is meant to",
+            code=reply.code,
+        )
     return ok(f"refused with code {reply.code}", code=reply.code)
 
 
@@ -472,22 +521,65 @@ def run_mcp_modern(context: Context) -> None:
 
     runner.check("tools/call returns structured content and a revision", tools_call)
 
-    def resources_read() -> tuple[Status, str, dict]:
-        reply = mcp.modern("resources/read", {"uri": "magda://tracks"})
-        assert reply.status == 200, f"HTTP {reply.status}: {reply.body[:200]}"
-        contents = (reply.json().get("result") or {}).get("contents") or []
-        assert contents, "resources/read returned no contents"
-        entry = contents[0]
-        assert entry.get("mimeType") == "application/json", f"mimeType {entry.get('mimeType')}"
-        if not call_text:
-            return unclear("tools/call did not run, so there is nothing to compare against")
-        if entry.get("text") == call_text[0]:
-            return ok("byte for byte identical to the tools/call text block")
-        if json.loads(entry.get("text", "null")) == json.loads(call_text[0]):
-            return unclear("equal as JSON but not byte for byte, which the docs promise")
-        return fail("resources/read and tools/call disagree for the same operation")
+    def _text_pair(tool: str, uri: str) -> tuple[str, str, dict]:
+        called = mcp.modern("tools/call", {"name": tool, "arguments": {}})
+        assert called.status == 200, f"tools/call {tool}: HTTP {called.status}"
+        call_result = called.json().get("result") or {}
+        assert call_result.get("isError") is False, f"tools/call {tool} failed: {call_result}"
+        read = mcp.modern("resources/read", {"uri": uri})
+        assert read.status == 200, f"resources/read {uri}: HTTP {read.status}"
+        contents = (read.json().get("result") or {}).get("contents") or []
+        assert contents, f"resources/read {uri} returned no contents"
+        assert contents[0].get("mimeType") == "application/json", contents[0].get("mimeType")
+        return (call_result.get("content") or [{}])[0].get("text", ""), contents[0].get("text", ""), call_result
 
-    runner.check("resources/read matches tools/call for the same operation", resources_read)
+    def object_parity() -> tuple[Status, str, dict]:
+        call_text, read_text, result = _text_pair("project.get", "magda://project/current")
+        if call_text == read_text:
+            return ok("byte for byte identical, as documented")
+        if json.loads(call_text) == json.loads(read_text):
+            return unclear("equal as JSON but not byte for byte, which the docs promise")
+        return fail(
+            "resources/read and tools/call disagree for the same operation",
+            call=call_text[:200], read=read_text[:200],
+        )
+
+    runner.check(
+        "resources/read matches tools/call for an object-valued operation", object_parity
+    )
+
+    def array_parity() -> tuple[Status, str, dict]:
+        """The case the in-tree parity test does not reach.
+
+        `structuredContent` is typed as an object, so an array-valued
+        operation is wrapped as `{"items": [...]}` on the tool surface.
+        `resources/read` has no such constraint and returns the bare array, so
+        the two surfaces carry the same data in two shapes — which is not the
+        unqualified byte-for-byte equivalence docs/remote-api-mcp.md promises.
+        """
+        call_text, read_text, result = _text_pair("tracks.list", "magda://tracks")
+        if call_text == read_text:
+            return ok("identical — the tool surface is not wrapping this one")
+
+        structured = result.get("structuredContent")
+        wrapped = isinstance(structured, dict) and set(structured) == {"items"}
+        if wrapped and structured["items"] == json.loads(read_text):
+            return ok(
+                "tools/call wraps the array as {\"items\": [...]} and resources/read "
+                "returns it bare — same data, two shapes. Deliberate (remote_mcp.cpp: "
+                "structuredContent must be an object), but docs/remote-api-mcp.md "
+                "promises byte-for-byte equality with no carve-out for this.",
+                call=call_text[:120], read=read_text[:120],
+            )
+        return fail(
+            "an array-valued operation disagrees across the two surfaces, and not "
+            "by the documented {items} wrapper either",
+            call=call_text[:200], read=read_text[:200],
+        )
+
+    runner.check(
+        "an array-valued operation differs only by the documented wrapper", array_parity
+    )
 
     def templates() -> tuple[Status, str, dict]:
         reply = mcp.modern("resources/templates/list")

--- a/tools/transport_check/wire.py
+++ b/tools/transport_check/wire.py
@@ -1,0 +1,408 @@
+"""Transport primitives: a WebSocket client, an OSC codec, an SSE reader.
+
+All three are implemented here rather than pulled from PyPI so the harness is
+`python3` and nothing else. A tester running this against a freshly installed
+build — often on a machine that is not a dev box — should not have to create a
+virtualenv first, and none of these three protocols is large enough to justify
+the dependency.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import os
+import socket
+import struct
+import time
+from dataclasses import dataclass, field
+
+WS_GUID = b"258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
+
+
+class WireError(Exception):
+    pass
+
+
+class HandshakeError(WireError):
+    """The upgrade was refused. Carries the HTTP status, which is the point.
+
+    A `401` and a `403` are the two refusals the WebSocket transport is
+    specified to produce before switching protocols, and telling them apart is
+    most of what the auth checks assert.
+    """
+
+    def __init__(self, status: int, reason: str, body: str = "") -> None:
+        super().__init__(f"HTTP {status} {reason}".strip())
+        self.status = status
+        self.reason = reason
+        self.body = body
+
+
+class _Reader:
+    """A buffered reader that survives a timeout mid-message.
+
+    `socket.makefile` would be shorter, but a timeout part-way through a
+    buffered read can leave its internal buffer in a state the next read does
+    not recover from. Owning the buffer means a slow frame is resumed rather
+    than lost, which matters here because the SSE and subscription checks sit
+    waiting on a socket that is quiet by design.
+    """
+
+    def __init__(self, sock: socket.socket) -> None:
+        self.sock = sock
+        self.buf = bytearray()
+
+    def _fill(self, deadline: float) -> None:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise TimeoutError("deadline passed")
+        self.sock.settimeout(remaining)
+        try:
+            chunk = self.sock.recv(65536)
+        except socket.timeout as exc:  # noqa: UP041 - alias only from 3.10
+            raise TimeoutError("deadline passed") from exc
+        if not chunk:
+            raise ConnectionError("peer closed the connection")
+        self.buf += chunk
+
+    def read_exact(self, count: int, deadline: float) -> bytes:
+        while len(self.buf) < count:
+            self._fill(deadline)
+        out = bytes(self.buf[:count])
+        del self.buf[:count]
+        return out
+
+    def read_until(self, sep: bytes, deadline: float) -> bytes:
+        while True:
+            index = self.buf.find(sep)
+            if index >= 0:
+                out = bytes(self.buf[:index])
+                del self.buf[: index + len(sep)]
+                return out
+            self._fill(deadline)
+
+    def read_some(self, deadline: float) -> bytes:
+        if not self.buf:
+            self._fill(deadline)
+        out = bytes(self.buf)
+        self.buf.clear()
+        return out
+
+
+# ---------------------------------------------------------------------------
+# WebSocket (RFC 6455, client side, text frames)
+# ---------------------------------------------------------------------------
+
+
+class WebSocket:
+    """Enough of RFC 6455 to speak JSON-RPC to MAGDA's `/rpc`.
+
+    Client frames are masked because the specification requires it and
+    cpp-httplib enforces it; server frames never are. Continuation frames are
+    reassembled, pings are answered, and a close frame ends the conversation.
+    """
+
+    def __init__(
+        self,
+        host: str,
+        port: int,
+        path: str,
+        headers: dict[str, str] | None = None,
+        timeout: float = 10.0,
+    ) -> None:
+        self.host = host
+        self.port = port
+        self.path = path
+        self.headers = dict(headers or {})
+        self.timeout = timeout
+        self.sock: socket.socket | None = None
+        self._reader: _Reader | None = None
+
+    # -- lifecycle --------------------------------------------------------
+
+    def connect(self) -> None:
+        deadline = time.monotonic() + self.timeout
+        self.sock = socket.create_connection((self.host, self.port), timeout=self.timeout)
+        self.sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+        self._reader = _Reader(self.sock)
+
+        key = base64.b64encode(os.urandom(16))
+        lines = [
+            f"GET {self.path} HTTP/1.1",
+            f"Host: {self.host}:{self.port}",
+            "Upgrade: websocket",
+            "Connection: Upgrade",
+            f"Sec-WebSocket-Key: {key.decode()}",
+            "Sec-WebSocket-Version: 13",
+        ]
+        lines += [f"{name}: {value}" for name, value in self.headers.items()]
+        self.sock.sendall(("\r\n".join(lines) + "\r\n\r\n").encode("utf-8"))
+
+        status_line = self._reader.read_until(b"\r\n", deadline).decode("latin-1")
+        parts = status_line.split(" ", 2)
+        status = int(parts[1]) if len(parts) > 1 and parts[1].isdigit() else 0
+        reason = parts[2] if len(parts) > 2 else ""
+
+        raw_headers = self._reader.read_until(b"\r\n\r\n", deadline).decode("latin-1")
+        received = {}
+        for line in raw_headers.split("\r\n"):
+            name, _, value = line.partition(":")
+            if name:
+                received[name.strip().lower()] = value.strip()
+
+        if status != 101:
+            body = ""
+            length = int(received.get("content-length", "0") or 0)
+            if length:
+                try:
+                    body = self._reader.read_exact(length, deadline).decode("utf-8", "replace")
+                except (TimeoutError, ConnectionError):
+                    body = ""
+            self.close()
+            raise HandshakeError(status, reason, body)
+
+        expected = base64.b64encode(hashlib.sha1(key + WS_GUID).digest()).decode()
+        if received.get("sec-websocket-accept") != expected:
+            self.close()
+            raise WireError("server did not return a valid Sec-WebSocket-Accept")
+
+    def close(self) -> None:
+        if self.sock is None:
+            return
+        try:
+            self._write_frame(0x8, b"")
+        except OSError:
+            pass
+        try:
+            self.sock.close()
+        finally:
+            self.sock = None
+            self._reader = None
+
+    def __enter__(self) -> "WebSocket":
+        self.connect()
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.close()
+
+    # -- framing ----------------------------------------------------------
+
+    def _write_frame(self, opcode: int, payload: bytes) -> None:
+        if self.sock is None:
+            raise WireError("socket is not open")
+        header = bytearray([0x80 | opcode])
+        length = len(payload)
+        if length < 126:
+            header.append(0x80 | length)
+        elif length < 65536:
+            header.append(0x80 | 126)
+            header += struct.pack(">H", length)
+        else:
+            header.append(0x80 | 127)
+            header += struct.pack(">Q", length)
+        mask = os.urandom(4)
+        header += mask
+        masked = bytes(byte ^ mask[i % 4] for i, byte in enumerate(payload))
+        self.sock.sendall(bytes(header) + masked)
+
+    def send_text(self, text: str) -> None:
+        self._write_frame(0x1, text.encode("utf-8"))
+
+    def recv(self, timeout: float | None = None) -> str:
+        """The next text message, reassembling continuations.
+
+        Control frames are handled here rather than surfaced: a ping that went
+        unanswered would have the server drop a connection the checks are
+        still using, and a close is the end of the message stream whichever
+        check is waiting on it.
+        """
+        deadline = time.monotonic() + (self.timeout if timeout is None else timeout)
+        buffer = bytearray()
+        assembling = False
+        while True:
+            assert self._reader is not None
+            first, second = self._reader.read_exact(2, deadline)
+            fin = bool(first & 0x80)
+            opcode = first & 0x0F
+            masked = bool(second & 0x80)
+            length = second & 0x7F
+            if length == 126:
+                (length,) = struct.unpack(">H", self._reader.read_exact(2, deadline))
+            elif length == 127:
+                (length,) = struct.unpack(">Q", self._reader.read_exact(8, deadline))
+            mask = self._reader.read_exact(4, deadline) if masked else b""
+            payload = self._reader.read_exact(length, deadline) if length else b""
+            if masked:
+                payload = bytes(byte ^ mask[i % 4] for i, byte in enumerate(payload))
+
+            if opcode == 0x8:
+                raise ConnectionError("server sent a close frame")
+            if opcode == 0x9:
+                self._write_frame(0xA, payload)
+                continue
+            if opcode == 0xA:
+                continue
+            if opcode == 0x0:
+                if not assembling:
+                    raise WireError("continuation frame with nothing to continue")
+                buffer += payload
+            elif opcode in (0x1, 0x2):
+                buffer = bytearray(payload)
+                assembling = True
+            else:
+                raise WireError(f"unexpected opcode 0x{opcode:x}")
+            if fin:
+                return bytes(buffer).decode("utf-8")
+
+
+# ---------------------------------------------------------------------------
+# OSC 1.0
+# ---------------------------------------------------------------------------
+
+
+def _pad4(size: int) -> int:
+    return (size + 3) & ~3
+
+
+def _osc_string(text: str) -> bytes:
+    raw = text.encode("utf-8") + b"\x00"
+    return raw.ljust(_pad4(len(raw)), b"\x00")
+
+
+def osc_encode(address: str, *args: object) -> bytes:
+    """One OSC message. `bool` is checked before `int` — it is a subclass."""
+    tags = ","
+    body = b""
+    for arg in args:
+        if isinstance(arg, bool):
+            tags += "T" if arg else "F"
+        elif isinstance(arg, int):
+            tags += "i"
+            body += struct.pack(">i", arg)
+        elif isinstance(arg, float):
+            tags += "f"
+            body += struct.pack(">f", arg)
+        elif isinstance(arg, str):
+            tags += "s"
+            body += _osc_string(arg)
+        else:
+            raise TypeError(f"cannot encode {type(arg).__name__} as an OSC argument")
+    return _osc_string(address) + _osc_string(tags) + body
+
+
+@dataclass
+class OscMessage:
+    address: str
+    args: list[object] = field(default_factory=list)
+
+
+def _read_osc_string(data: bytes, offset: int) -> tuple[str, int]:
+    end = data.index(b"\x00", offset)
+    return data[offset:end].decode("utf-8", "replace"), offset + _pad4(end - offset + 1)
+
+
+def osc_decode(data: bytes) -> list[OscMessage]:
+    """Every message in a datagram, flattening bundles.
+
+    MAGDA's feedback arrives as plain messages today, but a surface is allowed
+    to receive bundles and the parser costs four lines, so this reads what the
+    protocol permits rather than what one sender happens to emit.
+    """
+    if data[:8] == b"#bundle\x00":
+        messages: list[OscMessage] = []
+        offset = 16  # tag + time tag
+        while offset + 4 <= len(data):
+            try:
+                (size,) = struct.unpack_from(">i", data, offset)
+            except struct.error:
+                break
+            offset += 4
+            if size <= 0 or offset + size > len(data):
+                break
+            messages += osc_decode(data[offset : offset + size])
+            offset += size
+        return messages
+
+    try:
+        address, offset = _read_osc_string(data, 0)
+        if not address.startswith("/"):
+            return []
+        tags, offset = _read_osc_string(data, offset)
+    except ValueError:
+        return []
+
+    args: list[object] = []
+    try:
+        for tag in tags[1:]:
+            if tag in ("i", "f"):
+                if offset + 4 > len(data):
+                    raise ValueError("argument runs past the end of the datagram")
+                fmt = ">i" if tag == "i" else ">f"
+                value = struct.unpack_from(fmt, data, offset)[0]
+                args.append(value if tag == "i" else round(value, 6))
+                offset += 4
+            elif tag == "s":
+                text, offset = _read_osc_string(data, offset)
+                args.append(text)
+            elif tag == "T":
+                args.append(True)
+            elif tag == "F":
+                args.append(False)
+            else:  # a type this harness does not send and does not need to read
+                break
+    except (ValueError, IndexError, struct.error):
+        # A message whose arguments do not fit its type tags is rejected whole,
+        # which is what MAGDA's own reader does with a truncated argument. This
+        # socket is an unauthenticated UDP port that anything on the machine can
+        # write to, so "reject" has to mean "return nothing", never "raise".
+        return []
+    return [OscMessage(address, args)]
+
+
+# ---------------------------------------------------------------------------
+# Server-sent events
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class SseEvent:
+    event: str
+    data: str
+
+
+class SseParser:
+    """Frames out of a byte stream, the same shape `SseParser` in the bridge reads.
+
+    Keep-alive comments are counted rather than discarded: "the stream stayed
+    up while quiet" is one of the things #2059 asks to see, and a comment is
+    the only evidence of it that crosses the wire.
+    """
+
+    def __init__(self) -> None:
+        self.buffer = ""
+        self.comments = 0
+
+    def feed(self, chunk: bytes) -> list[SseEvent]:
+        self.buffer += chunk.decode("utf-8", "replace")
+        events: list[SseEvent] = []
+        while "\n\n" in self.buffer:
+            block, _, self.buffer = self.buffer.partition("\n\n")
+            name = "message"
+            data: list[str] = []
+            for line in block.split("\n"):
+                line = line.rstrip("\r")
+                if not line or line.startswith(":"):
+                    if line.startswith(":"):
+                        self.comments += 1
+                    continue
+                field_name, _, value = line.partition(":")
+                value = value[1:] if value.startswith(" ") else value
+                if field_name == "event":
+                    name = value
+                elif field_name == "data":
+                    data.append(value)
+            if data:
+                events.append(SseEvent(name, "\n".join(data)))
+        return events


### PR DESCRIPTION
Towards #2059, which asks for two things the suite cannot establish: that an
*installed* build answers a client written from the documentation rather than
from the source, and that a shipped host asks the way the endpoint expects.
Both want doing against a build, so this is a client that lives outside the
process.

## What this adds

`tools/transport_check` finds MAGDA the way the bridge does — the newest live
`remote-api-<pid>.json`, through the same env/config/OS-default steps — then
speaks JSON-RPC over WebSocket, MCP in both protocol eras over HTTP, MCP over
stdio through `magda-mcp`, and OSC over UDP. It shares no code with the app, so
a disagreement between `docs/remote-api-mcp.md` and the build fails a check
rather than going unnoticed by both.

Stdlib only, including the WebSocket client, OSC codec and SSE reader — it is
meant to run against an installed build on a machine that is not a dev box.
Default runs change nothing; `--write` adds the checks that must mutate, and
each reverts what it touched.

```
make test-transport              # against a running MAGDA
make test-transport-selftest     # against a stub, no app or network needed
make test-transport-mutations    # break the stub, prove each check can fail
```

## How it is verified

`selftest.py` stands up a stub MAGDA — both MCP eras, WebSocket, OSC, a stand-in
bridge — so the harness can be checked with nothing running. `mutation_test.py`
breaks that stub 24 ways and asserts the check meant to catch each one does.

The WebSocket client was checked against a spec-enforcing server, and the OSC
codec cross-checked against an independent implementation both directions plus
20,000 random datagrams.

`--mcp-sdk` drives the same endpoint with the **official MCP SDK**, which
validates every response against the protocol schema and so refuses shapes a
hand-written client accepts. Optional: it needs Python 3.10+ while the rest runs
on 3.9.

## What running it against a real build found

**One code bug.** MAGDA stamps `resultType` on modern MCP replies but emits
neither `ttlMs` nor `cacheScope`, which the `2026-07-28` schema requires beside
it. The official SDK negotiates that era against a running build and then fails
`tools/list` and `resources/list` outright — so a schema-validating host
connects and cannot use the server. Forced to the legacy era it works, 39 tools.
Not fixed here; it wants an issue of its own.

**A documentation and test gap.** `tools/call` and `resources/read` disagree for
`tracks.list`: the tool surface wraps an array as `{"items": [...]}` because
`structuredContent` is typed as an object, while the resource returns it bare.
That is deliberate and reasoned in `remote_mcp.cpp`, but
`docs/remote-api-mcp.md` promises byte-for-byte equivalence with no carve-out,
and the parity test in `test_remote_mcp_server.cpp` reads
`magda://project/current` — an object — so nothing in the tree meets the case.

Three further faults were in the harness itself and are fixed in the second
commit: it resolved the macOS data directory to the wrong path and so could not
find MAGDA at all; it exceeded the endpoint's shared rate limit and reported the
resulting 429s as findings; and one check passed on a permission denial rather
than the conflict it meant to assert.

## Not done

Only run against a debug tree build. #2059 also asks about the installed
artefact on all three platforms, and about the Clients settings tab, which still
wants an eye on it in a running app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)