### PR TITLE
Stop discrete cells writing on rebuild; keep transport readouts clear of their captions

### DIFF
--- a/magda/daw/core/ParameterUtils.cpp
+++ b/magda/daw/core/ParameterUtils.cpp
@@ -273,6 +273,43 @@ float modelToTeValue(ParameterModelValue model, const ParameterInfo& info) {
     return info.teMinValue + normalized.value * teSpan;
 }
 
+bool modelHoldsTeNativeValue(const ParameterInfo& info) {
+    // The branch normalizedToModelValue() / modelToNormalizedValue() take when
+    // they leave the value in TE's domain, named so widgets can ask the same
+    // question instead of guessing at the value's meaning.
+    return !infoMatchesTeRange(info) && !isDisplayMappedInternalValue(info);
+}
+
+int choiceIndexForModelValue(ParameterModelValue model, const ParameterInfo& info) {
+    const int count = static_cast<int>(info.choices.size());
+    if (count <= 0)
+        return -1;
+
+    if (modelHoldsTeNativeValue(info)) {
+        const float normalized = modelToNormalizedValue(model, info).value;
+        return juce::jlimit(
+            0, count - 1,
+            static_cast<int>(std::lround(normalized * static_cast<float>(count - 1))));
+    }
+
+    return juce::jlimit(0, count - 1, static_cast<int>(std::lround(model.value)));
+}
+
+ParameterModelValue modelValueForChoiceIndex(int index, const ParameterInfo& info) {
+    const int count = static_cast<int>(info.choices.size());
+    if (count <= 0)
+        return {0.0f};
+    index = juce::jlimit(0, count - 1, index);
+
+    if (modelHoldsTeNativeValue(info)) {
+        const float normalized =
+            count > 1 ? static_cast<float>(index) / static_cast<float>(count - 1) : 0.0f;
+        return normalizedToModelValue(ParameterNormalizedValue::clamped(normalized), info);
+    }
+
+    return {static_cast<float>(index)};
+}
+
 float modulationOffset(float modValue, float amount, bool bipolar) {
     // modValue is 0-1, convert to -1 to +1 if bipolar, then scale by the depth.
     return (bipolar ? (modValue * 2.0f - 1.0f) : modValue) * amount;

--- a/magda/daw/core/ParameterUtils.hpp
+++ b/magda/daw/core/ParameterUtils.hpp
@@ -137,6 +137,36 @@ ParameterNormalizedValue modelToNormalizedValue(ParameterModelValue model,
 float modelToTeValue(ParameterModelValue model, const ParameterInfo& info);
 
 /**
+ * @brief True when DeviceInfo::currentValue for @p info is the TE-native value
+ *        rather than a scaled real one.
+ *
+ * This is the external-plugin case: a saved parameter config or AI-Detect gave
+ * the parameter a display range (or a choice list) while TE keeps storing it
+ * normalized, and normalizedToModelValue() deliberately leaves the model in
+ * TE's domain so it cannot fight the plugin's own listener. Everything else
+ * (internal devices, external params without an override) carries the scaled
+ * value the display range describes.
+ */
+bool modelHoldsTeNativeValue(const ParameterInfo& info);
+
+/**
+ * @brief The choice a Discrete parameter's model value selects.
+ *
+ * Internal devices store the choice index itself, so this is a rounding. An
+ * external parameter whose saved config marks it discrete stores TE's
+ * normalized value (see modelHoldsTeNativeValue), which has to be spread over
+ * the choice list: Serum's Bend Up at 0.54167 with 49 choices is "+2", not
+ * choice 1. Returns -1 when there are no choices.
+ */
+int choiceIndexForModelValue(ParameterModelValue model, const ParameterInfo& info);
+
+/**
+ * @brief The model value that selects choice @p index. Inverse of
+ *        choiceIndexForModelValue().
+ */
+ParameterModelValue modelValueForChoiceIndex(int index, const ParameterInfo& info);
+
+/**
  * @brief What one modulation link adds to a normalized value.
  *
  * The polarity and depth rule on its own, with no base and no clamp, because

--- a/magda/daw/ui/components/chain/params/ParamSlotComponent.cpp
+++ b/magda/daw/ui/components/chain/params/ParamSlotComponent.cpp
@@ -472,12 +472,10 @@ void ParamSlotComponent::syncBooleanToggle(double value) {
 }
 
 void ParamSlotComponent::syncDiscreteSelection(double value) {
-    const int count = static_cast<int>(paramInfo_.choices.size());
-    if (count <= 0)
+    const int selected = magda::ParameterUtils::choiceIndexForModelValue(
+        magda::ParameterModelValue{static_cast<float>(value)}, paramInfo_);
+    if (selected < 0)
         return;
-
-    // Discrete params carry the choice index as their value.
-    const int selected = juce::jlimit(0, count - 1, static_cast<int>(std::lround(value)));
 
     if (discreteCombo_ && discreteCombo_->isVisible())
         discreteCombo_->setSelectedItemIndex(selected, juce::dontSendNotification);
@@ -568,6 +566,16 @@ void ParamSlotComponent::setParameterInfo(const magda::ParameterInfo& info) {
         if (onValueChanged)
             onValueChanged(v);
     };
+    // The discrete widgets report a choice index. What that index means as a
+    // parameter value depends on the parameter: internal devices store the
+    // index, an external plugin with a saved discrete config stores TE's
+    // normalized value. Map it here, against the slot's current info.
+    auto deferChoiceToSlot = [this](double index) {
+        if (onValueChanged)
+            onValueChanged(magda::ParameterUtils::modelValueForChoiceIndex(
+                               static_cast<int>(std::lround(index)), paramInfo_)
+                               .value);
+    };
 
     if (info.scale == magda::ParameterScale::Boolean) {
         if (info.momentary) {
@@ -587,13 +595,13 @@ void ParamSlotComponent::setParameterInfo(const magda::ParameterInfo& info) {
         }
     } else if (info.scale == magda::ParameterScale::Discrete && !info.choices.empty()) {
         if (wantsSegmentedChoices(info)) {
-            rebuildChoiceButtons(info, deferToSlot);
+            rebuildChoiceButtons(info, deferChoiceToSlot);
         } else {
             if (!discreteCombo_) {
                 discreteCombo_ = std::make_unique<juce::ComboBox>();
                 addAndMakeVisible(*discreteCombo_);
             }
-            configureDiscreteCombo(*discreteCombo_, info, deferToSlot);
+            configureDiscreteCombo(*discreteCombo_, info, deferChoiceToSlot);
             discreteCombo_->setVisible(true);
         }
     } else {
@@ -617,10 +625,8 @@ void ParamSlotComponent::rebuildChoiceButtons(const magda::ParameterInfo& info,
         }
     }
 
-    // Discrete params carry the choice index as their value, matching what the
-    // dropdown reports through configureDiscreteCombo.
-    const int selected =
-        juce::jlimit(0, count - 1, static_cast<int>(std::lround(info.currentValue)));
+    const int selected = magda::ParameterUtils::choiceIndexForModelValue(
+        magda::ParameterModelValue{info.currentValue}, info);
     for (int i = 0; i < count; ++i) {
         auto& button = *choiceButtons_[static_cast<size_t>(i)];
         configureChoiceButton(button, info.choices[static_cast<size_t>(i)], i, count,

--- a/magda/daw/ui/components/chain/params/ParamWidgetSetup.cpp
+++ b/magda/daw/ui/components/chain/params/ParamWidgetSetup.cpp
@@ -123,7 +123,6 @@ void configureDiscreteCombo(juce::ComboBox& combo, const magda::ParameterInfo& i
     combo.setColour(juce::ComboBox::outlineColourId, juce::Colours::transparentBlack);
     combo.setJustificationType(juce::Justification::centred);
 
-    int numChoices = static_cast<int>(info.choices.size());
     combo.onChange = [&combo, cb = std::move(onValueChanged)]() {
         if (cb) {
             int selected = combo.getSelectedItemIndex();
@@ -131,14 +130,21 @@ void configureDiscreteCombo(juce::ComboBox& combo, const magda::ParameterInfo& i
         }
     };
 
-    combo.clear();
+    // ComboBox::clear() defaults to sendNotificationAsync. A slot is reused
+    // across rebuilds, so from the second configure on the combo already holds
+    // a selection and clearing it queues an onChange that lands AFTER the
+    // items below are re-added and the current choice re-selected: the
+    // callback then reads that selection and writes it back to the parameter
+    // as if the user had picked it. That is how a Serum loaded with a saved
+    // discrete config came back transposed after a view switch.
+    combo.clear(juce::dontSendNotification);
     int id = 1;
     for (const auto& choice : info.choices) {
         combo.addItem(choice, id++);
     }
 
-    int selectedIndex = static_cast<int>(std::round(info.currentValue));
-    combo.setSelectedItemIndex(juce::jlimit(0, numChoices - 1, selectedIndex),
+    combo.setSelectedItemIndex(magda::ParameterUtils::choiceIndexForModelValue(
+                                   magda::ParameterModelValue{info.currentValue}, info),
                                juce::dontSendNotification);
 }
 

--- a/magda/daw/ui/components/chain/params/ParamWidgetSetup.hpp
+++ b/magda/daw/ui/components/chain/params/ParamWidgetSetup.hpp
@@ -32,8 +32,9 @@ void configureMomentaryButton(MomentaryParamButton& button,
  * @brief Create/configure a combo box for a discrete parameter with named choices.
  *
  * Populates the combo with the choices in @p info and sets the current
- * selection. The callback is wired to fire @p onValueChanged with a
- * normalized 0–1 value.
+ * selection. The callback is wired to fire @p onValueChanged with the selected
+ * choice index; the caller maps that onto the parameter's model value (see
+ * ParameterUtils::modelValueForChoiceIndex).
  */
 void configureDiscreteCombo(juce::ComboBox& combo, const magda::ParameterInfo& info,
                             std::function<void(double)> onValueChanged);

--- a/magda/daw/ui/components/common/BarsBeatsTicksLabel.cpp
+++ b/magda/daw/ui/components/common/BarsBeatsTicksLabel.cpp
@@ -49,16 +49,20 @@ void BarsBeatsTicksLabel::setDrawBackground(bool draw) {
     repaint();
 }
 
+void BarsBeatsTicksLabel::setTrailingInset(int px) {
+    px = juce::jmax(0, px);
+    if (trailingInset_ == px)
+        return;
+    trailingInset_ = px;
+    resized();
+    repaint();
+}
+
 void BarsBeatsTicksLabel::setRange(double min, double max, double defaultValue) {
-    // The segment shares are worked out from how large each number can get, so
-    // anything that changes that has to relayout, not just repaint.
-    const bool reshapes = maxValue_ != max;
     minValue_ = min;
     maxValue_ = max;
     defaultValue_ = juce::jlimit(min, max, defaultValue);
     value_ = juce::jlimit(minValue_, maxValue_, value_);
-    if (reshapes)
-        resized();
     updateSegmentTexts();
     repaint();
 }
@@ -76,22 +80,14 @@ void BarsBeatsTicksLabel::setValue(double newValue, juce::NotificationType notif
 }
 
 void BarsBeatsTicksLabel::setBeatsPerBar(int beatsPerBar) {
-    const bool reshapes = beatsPerBar_ != beatsPerBar;
     beatsPerBar_ = beatsPerBar;
-    // A wider time signature means a wider beat number and fewer bars, which
-    // moves the boundary between the two segments.
-    if (reshapes)
-        resized();
+    // updateSegmentTexts relayouts if the bar or beat number changes width.
     updateSegmentTexts();
     repaint();
 }
 
 void BarsBeatsTicksLabel::setBarsBeatsIsPosition(bool isPosition) {
-    const bool reshapes = barsBeatsIsPosition_ != isPosition;
     barsBeatsIsPosition_ = isPosition;
-    // One-indexed positions can carry a digit the zero-indexed form cannot.
-    if (reshapes)
-        resized();
     updateSegmentTexts();
     repaint();
 }
@@ -147,6 +143,15 @@ void BarsBeatsTicksLabel::updateSegmentTexts() {
     barsSegment_->setDisplayValue(bars + offset);
     beatsSegment_->setDisplayValue(beats + offset);
     ticksSegment_->setDisplayValue(ticks);
+
+    // The strip is shared out by the digits shown, so a bar or beat number
+    // that gains or loses a digit moves the segment boundaries.
+    const std::array<int, 2> digits{juce::String(bars + offset).length(),
+                                    juce::String(beats + offset).length()};
+    if (digits != laidOutDigits_) {
+        laidOutDigits_ = digits;
+        resized();
+    }
 }
 
 void BarsBeatsTicksLabel::paint(juce::Graphics& g) {
@@ -228,17 +233,17 @@ std::array<int, 3> BarsBeatsTicksLabel::segmentWidthsFor(double maxValue, int mi
     const int maxBars = static_cast<int>(maxValue / lowBeatsPerBar) + offset;
     const int maxBeats = highBeatsPerBar - 1 + offset;
 
-    const auto font = FontManager::getInstance().getUIFont(kTextFontSize);
-    // Measure a string of the widest digit rather than the number itself, so a
-    // value made of narrow digits does not under-size the segment.
-    const auto widthOfDigits = [&font](int digits) {
-        return juce::GlyphArrangement::getStringWidthInt(
-                   font, juce::String::repeatedString("8", digits)) +
-               kSegmentPad;
-    };
-
     return {widthOfDigits(juce::String(maxBars).length()),
             widthOfDigits(juce::String(maxBeats).length()), widthOfDigits(3)};
+}
+
+int BarsBeatsTicksLabel::widthOfDigits(int digits) {
+    // Measure a string of the widest digit rather than the number itself, so a
+    // value made of narrow digits does not under-size the segment.
+    const auto font = FontManager::getInstance().getUIFont(kTextFontSize);
+    return juce::GlyphArrangement::getStringWidthInt(font,
+                                                     juce::String::repeatedString("8", digits)) +
+           kSegmentPad;
 }
 
 int BarsBeatsTicksLabel::preferredWidthForRange(double maxValue, int minBeatsPerBar,
@@ -247,17 +252,25 @@ int BarsBeatsTicksLabel::preferredWidthForRange(double maxValue, int minBeatsPer
     return needed[0] + needed[1] + needed[2] + (2 * kDotWidth) + (2 * kEdgeInset);
 }
 
-std::array<int, 3> BarsBeatsTicksLabel::segmentWidths() const {
-    return segmentWidthsFor(maxValue_, beatsPerBar_, beatsPerBar_, barsBeatsIsPosition_);
+std::array<int, 3> BarsBeatsTicksLabel::shownSegmentWidths() const {
+    return {widthOfDigits(juce::String(barsSegment_->getDisplayValue()).length()),
+            widthOfDigits(juce::String(beatsSegment_->getDisplayValue()).length()),
+            widthOfDigits(3)};
 }
 
 void BarsBeatsTicksLabel::resized() {
     auto bounds = getLocalBounds().reduced(kEdgeInset, 0);
+    // The glyphs already stop kEdgeInset + half a segment pad short of the
+    // edge; the inset only has to take the rest off the strip.
+    bounds.removeFromRight(juce::jmax(0, trailingInset_ - kEdgeInset - (kSegmentPad / 2)));
 
-    // Share the strip out in proportion to what each segment has to show. A
-    // fixed quarter for the bar number clipped long positions while leaving
-    // the three-digit tick segment half the box.
-    const auto needed = segmentWidths();
+    // Share the strip out in proportion to the digits on screen. Shared by
+    // the largest value the range allows, a bar segment showing "1" was
+    // mostly air and pushed the ticks against the far edge; shared by what it
+    // shows, "1.1.000" sits balanced, and a bar number that gains a digit
+    // takes the room when it needs it (updateSegmentTexts relayouts then). A
+    // box sized by preferredWidthForRange() still holds the widest value.
+    const auto needed = shownSegmentWidths();
     const int total = juce::jmax(1, needed[0] + needed[1] + needed[2]);
     const int available = juce::jmax(3, bounds.getWidth() - (2 * kDotWidth));
 

--- a/magda/daw/ui/components/common/BarsBeatsTicksLabel.hpp
+++ b/magda/daw/ui/components/common/BarsBeatsTicksLabel.hpp
@@ -32,8 +32,10 @@ class BarsBeatsTicksLabel : public juce::Component {
                                       bool isPosition);
 
     /** Width each segment needs for the widest value it can show, in the order
-     *  bars, beats, ticks. resized() shares the strip out in these proportions,
-     *  so this is also what the segments get at the preferred width. */
+     *  bars, beats, ticks. preferredWidthForRange() adds these up; the live
+     *  layout shares the strip out by the digits on screen instead (see
+     *  resized()), so a box sized for this holds the widest value while a
+     *  typical one reads balanced. */
     static std::array<int, 3> segmentWidthsFor(double maxValue, int minBeatsPerBar,
                                                int maxBeatsPerBar, bool isPosition);
 
@@ -68,6 +70,22 @@ class BarsBeatsTicksLabel : public juce::Component {
     // Whether to draw background fill + border (default: true)
     void setDrawBackground(bool draw);
 
+    /** Width at the right end of the label its glyphs keep clear, for a caption
+     *  or icon the owner draws over the box's end. The owner measures that
+     *  decoration and adds the same number to the box it gives this label
+     *  (TransportLayout does), so the digits never sit under it. The glyphs
+     *  already stop kEdgeInset + kSegmentPad / 2 short of the edge, so only
+     *  what the decoration needs beyond that comes off the strip. Zero by
+     *  default. */
+    void setTrailingInset(int px);
+
+    // Geometry shared by resized() and preferredWidthForRange(). Public, like
+    // kTextFontSize, so a caller sizing a box around this label can reason
+    // about where its glyphs stop.
+    static constexpr int kEdgeInset = 2;   // left/right inset of the segment strip
+    static constexpr int kDotWidth = 6;    // gap between two segments, where the dot is drawn
+    static constexpr int kSegmentPad = 4;  // air around a segment's digits
+
     // Text override: when set, displays this text instead of bars.beats.ticks segments
     void setTextOverride(const juce::String& text);
     void clearTextOverride();
@@ -83,12 +101,16 @@ class BarsBeatsTicksLabel : public juce::Component {
     void resized() override;
 
   private:
-    // Geometry shared by resized() and preferredWidthForRange().
-    static constexpr int kEdgeInset = 2;   // left/right inset of the segment strip
-    static constexpr int kDotWidth = 6;    // gap between two segments, where the dot is drawn
-    static constexpr int kSegmentPad = 4;  // air around a segment's digits
+    // Width each segment needs for the digits it is showing right now; the
+    // strip is shared out in these proportions.
+    std::array<int, 3> shownSegmentWidths() const;
+    // Width of a run of `digits` of the widest digit, plus the segment's air.
+    static int widthOfDigits(int digits);
 
-    std::array<int, 3> segmentWidths() const;
+    int trailingInset_ = 0;
+    // Digit counts of the bar and beat numbers last laid out for, so a value
+    // that gains or loses a digit relayouts rather than just repaints.
+    std::array<int, 2> laidOutDigits_{0, 0};
 
     static constexpr int TICKS_PER_BEAT = 480;
     static constexpr int TICKS_PER_16TH = 120;  // 480 / 4

--- a/magda/daw/ui/dialogs/AudioSettingsDialog.cpp
+++ b/magda/daw/ui/dialogs/AudioSettingsDialog.cpp
@@ -534,8 +534,13 @@ void AudioSettingsDialog::resized() {
 }
 
 void AudioSettingsDialog::populateDeviceLists() {
-    inputDeviceComboBox_.clear();
-    outputDeviceComboBox_.clear();
+    // clear() defaults to sendNotificationAsync: on a re-list (every device
+    // change notification lands here) the queued onChange fires after the
+    // current device is re-selected below and re-applies the device setup,
+    // which broadcasts another change. The selection below is explicit, so
+    // nothing here wants that notification.
+    inputDeviceComboBox_.clear(juce::dontSendNotification);
+    outputDeviceComboBox_.clear(juce::dontSendNotification);
     updateDevicePickerMode();
 
     // List devices from the ACTIVE driver type (see activeDeviceTypeFor): using

--- a/magda/daw/ui/panels/TransportLayout.cpp
+++ b/magda/daw/ui/panels/TransportLayout.cpp
@@ -86,7 +86,8 @@ struct Metrics {
     int timeBoxSlack = 0;
 
     // Measured widths
-    int timeBox = 0;  // a bars.beats.ticks readout; grown by the flex pass
+    int timeBoxDecoration = 0;  // the right end of a readout its glyphs keep clear
+    int timeBox = 0;            // a bars.beats.ticks readout; grown by the flex pass
     int tempoCell = 0;
     int timeSigNum = 0;
     int timeSigDen = 0;
@@ -130,7 +131,13 @@ Metrics metricsFor(int width, int height, const TextWidths& text, float densityS
     m.timeBoxSlack = scaled(kTimeBoxSlack, densityScale);
 
     const int cellPad = scaled(kCellPad, densityScale);
-    m.timeBox = text.timecodeBox;
+    // A readout's glyphs stop short of its right end, where TransportPanel
+    // draws the group caption (SEL / LOOP / CUR) and the punch box carries its
+    // icons. The wider of the two, so every readout stays the same width. The
+    // label keeps its glyphs clear of exactly this much (setTrailingInset), and
+    // the box grows by what that needs beyond the inset the glyphs keep anyway.
+    m.timeBoxDecoration = juce::jmax(text.timecodeCaption, m.punchIcon + kPunchIconInset);
+    m.timeBox = text.timecodeBox + juce::jmax(0, m.timeBoxDecoration - text.timecodeGlyphInset);
     m.tempoCell = text.tempo + (2 * cellPad);
     m.timeSigNum = text.timeSigNumerator + (2 * cellPad);
     m.timeSigDen = text.timeSigDenominator + (2 * cellPad);
@@ -381,6 +388,7 @@ Layout compute(int width, int height, const TextWidths& text, float densityScale
     const SectionWidths widths = measureAll(m);
 
     Layout l;
+    l.timeBoxTrailingInset = m.timeBoxDecoration;
     const int required = resolveVisibility(l, widths, width);
 
     // Spare width goes to the timecode readouts, which read better with air

--- a/magda/daw/ui/panels/TransportLayout.hpp
+++ b/magda/daw/ui/panels/TransportLayout.hpp
@@ -18,6 +18,8 @@ namespace magda::daw::ui::transport {
  */
 struct TextWidths {
     int timecodeBox = 0;         // a whole bars.beats.ticks readout, as it sizes itself
+    int timecodeCaption = 0;     // the widest of the SEL / LOOP / CUR captions, in their font
+    int timecodeGlyphInset = 0;  // how far inside a readout's edge its last glyph already stops
     int tempo = 0;               // "999.99" in the BPM readout font
     int timeSigNumerator = 0;    // "16/" -- the numerator carries the slash
     int timeSigDenominator = 0;  // "16"
@@ -60,6 +62,11 @@ struct Layout {
     bool automationWriteLabelFits = true;
 
     bool isVisible(Section section) const;
+
+    // What every timecode readout keeps clear at its right end, where the
+    // group caption is drawn over it and the punch box carries its icons. The
+    // readouts' widths include it; TransportPanel hands it to each label.
+    int timeBoxTrailingInset = 0;
 
     // Right edge of each separator-delimited band, in panel coordinates.
     int transportRight = 0;

--- a/magda/daw/ui/panels/TransportPanel.cpp
+++ b/magda/daw/ui/panels/TransportPanel.cpp
@@ -147,19 +147,20 @@ void TransportPanel::paint(juce::Graphics& g) {
 
         // Group label at top-right
         g.setColour(groupColour.withAlpha(0.5f));
-        g.setFont(FontManager::getInstance().getUIFont(7.0f));
+        g.setFont(FontManager::getInstance().getUIFont(transport::kTimecodeCaptionFontSize));
         g.drawText(groupName, wrapperBounds.toNearestInt().reduced(2, 1),
                    juce::Justification::topRight, false);
     };
 
     if (layout_.selLoopTimesVisible) {
         drawGroupWrapper(selectionStartLabel->getBounds().getUnion(selectionEndLabel->getBounds()),
-                         "SEL", DarkTheme::getColour(DarkTheme::ACCENT_PRIMARY));
-        drawGroupWrapper(loopStartLabel->getBounds().getUnion(loopEndLabel->getBounds()), "LOOP",
-                         DarkTheme::getColour(DarkTheme::ACCENT_POSITIVE));
+                         transport::kSelectionCaption,
+                         DarkTheme::getColour(DarkTheme::ACCENT_PRIMARY));
+        drawGroupWrapper(loopStartLabel->getBounds().getUnion(loopEndLabel->getBounds()),
+                         transport::kLoopCaption, DarkTheme::getColour(DarkTheme::ACCENT_POSITIVE));
     }
     drawGroupWrapper(playheadPositionLabel->getBounds().getUnion(editCursorLabel->getBounds()),
-                     "CUR", DarkTheme::getColour(DarkTheme::ACCENT_ATTENTION));
+                     transport::kCursorCaption, DarkTheme::getColour(DarkTheme::ACCENT_ATTENTION));
     if (layout_.punchVisible) {
         drawGroupWrapper(punchInButton->getBounds()
                              .getUnion(punchStartLabel->getBounds())
@@ -242,6 +243,13 @@ void TransportPanel::resized() {
     layout_ = transport::compute(getWidth(), getHeight(), transport::measureTextWidths(),
                                  LayoutConfig::getInstance().densityScale);
     const auto& l = layout_;
+
+    // The readouts keep their digits clear of the caption / punch icons drawn
+    // over their right end; the layout measured that zone into their width.
+    for (auto* label : {selectionStartLabel.get(), selectionEndLabel.get(), loopStartLabel.get(),
+                        loopEndLabel.get(), playheadPositionLabel.get(), editCursorLabel.get(),
+                        punchStartLabel.get(), punchEndLabel.get()})
+        label->setTrailingInset(l.timeBoxTrailingInset);
 
     // Visibility first: a dropped section keeps the empty rectangle the layout
     // left it, so no z-order or paint call can read a stale position.

--- a/magda/daw/ui/panels/TransportTextWidths.cpp
+++ b/magda/daw/ui/panels/TransportTextWidths.cpp
@@ -30,12 +30,23 @@ TextWidths measureTextWidths() {
         fonts.getUIFontBold(SmallButtonLookAndFeel::getInstance().getFontSize());
     const auto cpuTitleFont = fonts.getUIFont(kCpuTitleFontSize);
     const auto cpuValueFont = fonts.getMonoFont(kCpuValueFontSize);
+    const auto captionFont = fonts.getUIFont(kTimecodeCaptionFontSize);
 
     TextWidths text;
     // The readout sizes itself: it knows its own segment shares and how large a
     // bar number the range can reach, which a box drawn around it does not.
     text.timecodeBox = BarsBeatsTicksLabel::preferredWidthForRange(
         kTimecodeMaxBeats, MIN_TIME_SIGNATURE_VALUE, MAX_TIME_SIGNATURE_VALUE, true);
+    // The caption TransportPanel draws over the box's top-right corner. The
+    // layout reserves this much at the end of every readout, and the readout
+    // keeps its digits out of it.
+    for (const char* caption : {kSelectionCaption, kLoopCaption, kCursorCaption})
+        text.timecodeCaption = juce::jmax(text.timecodeCaption, widthOf(captionFont, caption));
+    // The readout's glyphs stop this far inside its edge on their own (the strip
+    // inset plus half a segment's air), so the box only has to grow by what the
+    // caption needs beyond that.
+    text.timecodeGlyphInset =
+        BarsBeatsTicksLabel::kEdgeInset + (BarsBeatsTicksLabel::kSegmentPad / 2);
     text.tempo = widthOf(readoutFont, juce::String(MAX_VALID_BPM, 2));
     text.timeSigNumerator = widthOf(readoutFont, juce::String(MAX_TIME_SIGNATURE_VALUE) + "/");
     text.timeSigDenominator = widthOf(readoutFont, juce::String(MAX_TIME_SIGNATURE_VALUE));

--- a/magda/daw/ui/panels/TransportTextWidths.hpp
+++ b/magda/daw/ui/panels/TransportTextWidths.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "TransportLayout.hpp"
+#include "core/TempoUtils.hpp"
 
 namespace magda::daw::ui::transport {
 
@@ -21,10 +22,23 @@ inline constexpr float kCpuTitleFontSize = 8.0f;
 inline constexpr float kCpuValueFontSize = 11.0f;
 inline constexpr float kBannerFontSize = 10.0f;  // the AUTOMATION WRITE banner
 
-// The range the timecode readouts accept, in beats. Declared here so the
-// labels and the width measured for them agree on how large a bar number the
-// box has to hold.
-inline constexpr double kTimecodeMaxBeats = 100000.0;
+// The group captions drawn over the top-right corner of the timecode boxes,
+// and the size they are drawn at. Here for the same reason as the AUTO / SNAP
+// captions: the string measured and the string drawn are one string.
+inline constexpr const char* kSelectionCaption = "SEL";
+inline constexpr const char* kLoopCaption = "LOOP";
+inline constexpr const char* kCursorCaption = "CUR";
+inline constexpr float kTimecodeCaptionFontSize = 7.0f;
+
+// The largest bar number the timecode readouts show, in any meter: five
+// digits. The range the labels accept follows from it, in beats at the fewest
+// beats per bar, so the labels and the width measured for them agree on how
+// large a bar number the box has to hold. (A round beat count at one beat per
+// bar put a sixth digit on the one-indexed bar number, and every readout in
+// every meter paid for it.)
+inline constexpr int kTimecodeMaxBars = 99999;
+inline constexpr double kTimecodeMaxBeats =
+    static_cast<double>((kTimecodeMaxBars - 1) * MIN_TIME_SIGNATURE_VALUE);
 
 // How far the retained peak has to run ahead of the average before the CPU
 // readout shows it as well.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -530,6 +530,9 @@ target_sources(magda_juce_tests PRIVATE
     # ParamSlotComponent builds into magda_daw_app, so the test target needs it
     # and the param helpers it calls into compiled in directly.
     test_param_slot_boolean_sync_juce.cpp
+    # A discrete cell's dropdown must not write the parameter on rebuild, and
+    # must map an external plugin's TE-native value onto its choices.
+    test_param_slot_discrete_combo_juce.cpp
     ../magda/daw/ui/components/chain/params/ParamSlotComponent.cpp
     ../magda/daw/ui/components/chain/params/ParamWidgetSetup.cpp
     ../magda/daw/ui/components/chain/params/ParamLinkResolver.cpp
@@ -681,6 +684,9 @@ add_test(NAME config_path_redirect_juce
 
 add_test(NAME param_slot_boolean_sync_juce
          COMMAND magda_juce_tests "Param Slot Boolean Sync Tests")
+
+add_test(NAME param_slot_discrete_combo_juce
+         COMMAND magda_juce_tests "Param Slot Discrete Combo Tests")
 
 add_test(NAME timeline_extreme_zoom_paint_juce
          COMMAND magda_juce_tests "Timeline Extreme Zoom Paint Tests")

--- a/tests/test_param_slot_discrete_combo_juce.cpp
+++ b/tests/test_param_slot_discrete_combo_juce.cpp
@@ -1,0 +1,157 @@
+// A discrete parameter's dropdown must not write the parameter when the cell
+// is rebuilt, and must show / write the choice the parameter's value actually
+// selects.
+//
+// Serum loaded with a saved parameter config that marks Bend Up, Bend Down,
+// Transpose, A Octave and A Semi as discrete came back transposed after a view
+// switch. Slots are reused across rebuilds; configureDiscreteCombo cleared the
+// combo with ComboBox::clear(), whose default notification is async, so the
+// second configure queued an onChange that fired after the choices were
+// re-added and the current one re-selected, and wrote that selection back.
+// With the index read as round(0.54167) = 1 and written back as 1.0, an
+// octave control landed on its rail.
+
+#include <juce_gui_basics/juce_gui_basics.h>
+
+#include <vector>
+
+#include "magda/daw/core/ParameterUtils.hpp"
+#include "magda/daw/ui/components/chain/params/ParamSlotComponent.hpp"
+
+namespace {
+
+using Slot = magda::daw::ui::ParamSlotComponent;
+
+// Serum's "Bend Up" as the saved config describes it: 49 semitone choices
+// over a display range of [0, 48], while TE keeps the parameter normalized and
+// the model holds that normalized value. +2 semitones is 26/48.
+magda::ParameterInfo externalDiscreteParam(float currentValue) {
+    magda::ParameterInfo param;
+    param.paramIndex = 7;
+    param.name = "Bend Up";
+    param.scale = magda::ParameterScale::Discrete;
+    for (int semitones = -24; semitones <= 24; ++semitones)
+        param.choices.push_back(juce::String(semitones));
+    param.minValue = 0.0f;
+    param.maxValue = 48.0f;
+    param.teMinValue = 0.0f;
+    param.teMaxValue = 1.0f;
+    param.displayText = std::make_shared<magda::ParameterInfo::DisplayTextProvider>();
+    param.currentValue = currentValue;
+    return param;
+}
+
+// An internal device's discrete parameter: the model value is the choice index.
+magda::ParameterInfo internalDiscreteParam(float currentValue) {
+    magda::ParameterInfo param;
+    param.paramIndex = 0;
+    param.name = "Slope";
+    param.scale = magda::ParameterScale::Discrete;
+    param.choices = {"6 dB", "12 dB", "24 dB"};
+    param.minValue = 0.0f;
+    param.maxValue = 2.0f;
+    param.teMinValue = 0.0f;
+    param.teMaxValue = 2.0f;
+    param.currentValue = currentValue;
+    return param;
+}
+
+// The combo is a private member, so assert on what the cell actually shows:
+// its visible ComboBox child.
+juce::ComboBox* visibleComboIn(juce::Component& slot) {
+    for (int i = 0; i < slot.getNumChildComponents(); ++i) {
+        if (auto* combo = dynamic_cast<juce::ComboBox*>(slot.getChildComponent(i)))
+            if (combo->isVisible())
+                return combo;
+    }
+    return nullptr;
+}
+
+void drainMessageQueue() {
+    juce::MessageManager::getInstance()->runDispatchLoopUntil(50);
+}
+
+}  // namespace
+
+class ParamSlotDiscreteComboTest final : public juce::UnitTest {
+  public:
+    ParamSlotDiscreteComboTest() : juce::UnitTest("Param Slot Discrete Combo Tests", "magda") {}
+
+    void runTest() override {
+        const float plusTwo = 26.0f / 48.0f;
+
+        beginTest("Rebuilding a discrete cell does not write the parameter");
+        {
+            Slot slot{0};
+            std::vector<double> writes;
+            slot.onValueChanged = [&writes](double v) { writes.push_back(v); };
+
+            // First configure, then the rebuild every view / track switch and
+            // setNodePath performs on the same, reused slot.
+            slot.setParameterInfo(externalDiscreteParam(plusTwo));
+            drainMessageQueue();
+            slot.setParameterInfo(externalDiscreteParam(plusTwo));
+            drainMessageQueue();
+
+            expectEquals(static_cast<int>(writes.size()), 0,
+                         "Reconfiguring the dropdown must not write the parameter");
+        }
+
+        beginTest("The dropdown shows the choice the plugin is at");
+        {
+            Slot slot{0};
+            slot.setParameterInfo(externalDiscreteParam(plusTwo));
+
+            auto* combo = visibleComboIn(slot);
+            expect(combo != nullptr, "A discrete param with choices must show a dropdown");
+            if (combo != nullptr) {
+                expectEquals(combo->getSelectedItemIndex(), 26);
+                expectEquals(combo->getText(), juce::String("2"));
+            }
+
+            // A value-only refresh (automation / plugin UI echo) moves it too.
+            slot.setParamValue(0.0);
+            if (combo != nullptr)
+                expectEquals(combo->getText(), juce::String("-24"));
+        }
+
+        beginTest("Picking a choice writes the value the plugin wants for it");
+        {
+            Slot slot{0};
+            std::vector<double> writes;
+            slot.onValueChanged = [&writes](double v) { writes.push_back(v); };
+            slot.setParameterInfo(externalDiscreteParam(plusTwo));
+
+            auto* combo = visibleComboIn(slot);
+            expect(combo != nullptr);
+            if (combo == nullptr)
+                return;
+
+            combo->setSelectedItemIndex(27, juce::sendNotificationSync);  // "+3"
+            expectEquals(static_cast<int>(writes.size()), 1);
+            if (!writes.empty())
+                expectWithinAbsoluteError(writes.back(), 27.0 / 48.0, 1.0e-5);
+        }
+
+        beginTest("An internal discrete parameter still carries the choice index");
+        {
+            Slot slot{0};
+            std::vector<double> writes;
+            slot.onValueChanged = [&writes](double v) { writes.push_back(v); };
+            slot.setParameterInfo(internalDiscreteParam(1.0f));
+
+            auto* combo = visibleComboIn(slot);
+            expect(combo != nullptr);
+            if (combo == nullptr)
+                return;
+
+            expectEquals(combo->getSelectedItemIndex(), 1);
+            combo->setSelectedItemIndex(2, juce::sendNotificationSync);
+            expectEquals(static_cast<int>(writes.size()), 1);
+            if (!writes.empty())
+                expectWithinAbsoluteError(writes.back(), 2.0, 1.0e-9);
+        }
+    }
+};
+
+static ParamSlotDiscreteComboTest paramSlotDiscreteComboTest;

--- a/tests/test_parameter_utils.cpp
+++ b/tests/test_parameter_utils.cpp
@@ -911,3 +911,71 @@ TEST_CASE("ParameterUtils - model value passes through a matching TE range",
     REQUIRE(ParameterUtils::modelToTeValue(ParameterModelValue{440.0f}, info) ==
             Catch::Approx(440.0f));
 }
+
+// ============================================================================
+// Choice index <-> model value (discrete widgets)
+// ============================================================================
+
+// An internal device's discrete parameter stores the choice index itself.
+TEST_CASE("ParameterUtils - choice index is the model value for an internal discrete parameter",
+          "[parameter][conversion][model][discrete]") {
+    ParameterInfo info;
+    info.scale = ParameterScale::Discrete;
+    info.choices = {"Off", "Low", "High"};
+    info.minValue = 0.0f;
+    info.maxValue = 2.0f;
+    info.teMinValue = 0.0f;
+    info.teMaxValue = 2.0f;
+
+    REQUIRE_FALSE(ParameterUtils::modelHoldsTeNativeValue(info));
+    REQUIRE(ParameterUtils::choiceIndexForModelValue(ParameterModelValue{1.0f}, info) == 1);
+    REQUIRE(ParameterUtils::choiceIndexForModelValue(ParameterModelValue{2.4f}, info) == 2);
+    REQUIRE(ParameterUtils::choiceIndexForModelValue(ParameterModelValue{7.0f}, info) == 2);
+    REQUIRE(ParameterUtils::modelValueForChoiceIndex(2, info).value == Catch::Approx(2.0f));
+    REQUIRE(ParameterUtils::modelValueForChoiceIndex(-1, info).value == Catch::Approx(0.0f));
+}
+
+// Serum's "Bend Up" once a saved parameter config marks it discrete: 49
+// choices "-24".."24" over a display range of [0, 48], while TE still stores
+// the parameter normalized and the model keeps that normalized value. The
+// plugin at +2 semitones reports 26/48 = 0.54167; read as an index that is
+// choice 1 ("-23"), and written back as choice 1 it is 1.0, the top of the
+// range. That write is the "synth comes back two octaves up" report.
+TEST_CASE("ParameterUtils - choice index spreads a TE-native model value over the choices",
+          "[parameter][conversion][model][discrete]") {
+    ParameterInfo info;
+    info.scale = ParameterScale::Discrete;
+    for (int semitones = -24; semitones <= 24; ++semitones)
+        info.choices.push_back(juce::String(semitones));
+    info.minValue = 0.0f;
+    info.maxValue = 48.0f;
+    info.teMinValue = 0.0f;
+    info.teMaxValue = 1.0f;
+    info.displayText = std::make_shared<ParameterInfo::DisplayTextProvider>();
+
+    REQUIRE(ParameterUtils::modelHoldsTeNativeValue(info));
+
+    const float plusTwo = 26.0f / 48.0f;
+    REQUIRE(ParameterUtils::choiceIndexForModelValue(ParameterModelValue{plusTwo}, info) == 26);
+    REQUIRE(info.choices[26] == "2");
+
+    // And back: picking "+2" writes the value the plugin is already at, not 26.
+    const auto written = ParameterUtils::modelValueForChoiceIndex(26, info);
+    REQUIRE(written.value == Catch::Approx(plusTwo));
+
+    // Every choice survives the round trip, and every write stays in TE's range.
+    for (int index = 0; index < static_cast<int>(info.choices.size()); ++index) {
+        const auto model = ParameterUtils::modelValueForChoiceIndex(index, info);
+        INFO("choice " << index);
+        REQUIRE(model.value >= info.teMinValue);
+        REQUIRE(model.value <= info.teMaxValue);
+        REQUIRE(ParameterUtils::choiceIndexForModelValue(model, info) == index);
+    }
+}
+
+TEST_CASE("ParameterUtils - choice index without choices", "[parameter][conversion][discrete]") {
+    ParameterInfo info;
+    info.scale = ParameterScale::Discrete;
+    REQUIRE(ParameterUtils::choiceIndexForModelValue(ParameterModelValue{0.7f}, info) == -1);
+    REQUIRE(ParameterUtils::modelValueForChoiceIndex(3, info).value == Catch::Approx(0.0f));
+}

--- a/tests/test_transport_layout.cpp
+++ b/tests/test_transport_layout.cpp
@@ -21,12 +21,14 @@ namespace {
 // without invalidating the test.
 TextWidths nominalText() {
     TextWidths text;
-    text.timecodeBox = 93;
+    text.timecodeBox = 85;
+    text.timecodeCaption = 20;
+    text.timecodeGlyphInset = 4;
     text.tempo = 43;
     text.timeSigNumerator = 20;
     text.timeSigDenominator = 16;
     text.cpuTitle = 17;
-    text.cpuValue = 23;
+    text.cpuValue = 40;
     text.gridDivision = 18;
     text.gridToggle = 26;
     return text;
@@ -66,6 +68,7 @@ TEST_CASE("It keeps fitting as the text around it grows", "[ui][transport-layout
     for (int extra = 0; extra <= 3; ++extra) {
         auto text = nominalText();
         text.timecodeBox += extra * 4;
+        text.timecodeCaption += extra;
         text.tempo += extra * 2;
         text.timeSigNumerator += extra;
         text.timeSigDenominator += extra;
@@ -225,7 +228,8 @@ TEST_CASE("Spare width goes to the timecode readouts, up to a cap", "[ui][transp
     const auto roomy = compute(snug + 120, height, text, 1.0f);
     const auto huge = compute(snug + 1200, height, text, 1.0f);
 
-    REQUIRE(tight.playhead.getWidth() == text.timecodeBox);
+    REQUIRE(tight.playhead.getWidth() ==
+            text.timecodeBox + tight.timeBoxTrailingInset - text.timecodeGlyphInset);
     REQUIRE(roomy.playhead.getWidth() > tight.playhead.getWidth());
     REQUIRE(huge.playhead.getWidth() == roomy.playhead.getWidth());
 
@@ -233,4 +237,35 @@ TEST_CASE("Spare width goes to the timecode readouts, up to a cap", "[ui][transp
     REQUIRE(roomy.selectionStart.getWidth() == roomy.playhead.getWidth());
     REQUIRE(roomy.loopEnd.getWidth() == roomy.playhead.getWidth());
     REQUIRE(roomy.punchStart.getWidth() == roomy.playhead.getWidth());
+}
+
+// ---------------------------------------------------------------------------
+// What is drawn over a readout's right end: the group caption (SEL / LOOP /
+// CUR) and, in the punch box, the in/out icons. The readout's digits have to
+// stop short of it, so the box carries that zone on top of the digits.
+// ---------------------------------------------------------------------------
+
+TEST_CASE("A readout is wider than its digits by what is drawn over its end",
+          "[ui][transport-layout]") {
+    const int height = defaultTransportHeight();
+    const auto text = nominalText();
+
+    for (int width = 600; width <= 1600; width += 50) {
+        const auto l = compute(width, height, text, 1.0f);
+        INFO("width " << width);
+
+        // The inset covers the caption and the punch icons, whichever is wider,
+        // and the readout grew by what that needs beyond the air its glyphs
+        // keep at the edge anyway.
+        REQUIRE(l.timeBoxTrailingInset >= text.timecodeCaption);
+        REQUIRE(l.playhead.getWidth() >=
+                text.timecodeBox + l.timeBoxTrailingInset - text.timecodeGlyphInset);
+
+        if (l.punchVisible) {
+            // The punch icons sit inside the zone the digits keep clear.
+            REQUIRE(l.punchIn.getRight() <= l.punchStart.getRight());
+            REQUIRE(l.punchIn.getX() >= l.punchStart.getRight() - l.timeBoxTrailingInset);
+            REQUIRE(l.punchOut.getX() >= l.punchEnd.getRight() - l.timeBoxTrailingInset);
+        }
+    }
 }

--- a/tests/test_transport_layout_juce.cpp
+++ b/tests/test_transport_layout_juce.cpp
@@ -28,13 +28,15 @@ class TransportLayoutFontsTest final : public juce::UnitTest {
 
         beginTest("Measured widths are real numbers");
         const auto text = measureTextWidths();
-        logMessage("timecodeBox=" + juce::String(text.timecodeBox) + " tempo=" +
-                   juce::String(text.tempo) + " sigNum=" + juce::String(text.timeSigNumerator) +
+        logMessage("timecodeBox=" + juce::String(text.timecodeBox) + " timecodeCaption=" +
+                   juce::String(text.timecodeCaption) + " tempo=" + juce::String(text.tempo) +
+                   " sigNum=" + juce::String(text.timeSigNumerator) +
                    " sigDen=" + juce::String(text.timeSigDenominator) + " cpuTitle=" +
                    juce::String(text.cpuTitle) + " cpuValue=" + juce::String(text.cpuValue) +
                    " gridDivision=" + juce::String(text.gridDivision) +
                    " gridToggle=" + juce::String(text.gridToggle));
         expect(text.timecodeBox > 0);
+        expect(text.timecodeCaption > 0);
         expect(text.tempo > 0);
         expect(text.timeSigNumerator > 0);
         expect(text.timeSigDenominator > 0);
@@ -116,36 +118,68 @@ class TransportLayoutFontsTest final : public juce::UnitTest {
             expect(l.playhead.getWidth() >= needed[0] + needed[1] + needed[2]);
         }
 
-        beginTest("A new time signature re-proportions the readout's segments");
+        beginTest("A bar number that gains a digit re-proportions the readout's segments");
         {
-            // The segment shares depend on how large the beat number can get,
-            // so changing the time signature is a relayout, not a repaint. A
-            // stale 4/4 layout clips a perfectly valid beat 16.
+            // The strip is shared out by the digits on screen, so "1.1.000"
+            // reads balanced instead of reserving the width of a five-digit
+            // bar number, and a value that grows a digit relayouts rather than
+            // clipping or just repainting.
             magda::BarsBeatsTicksLabel label;
             label.setRange(0.0, kTimecodeMaxBeats, 0.0);
             label.setBarsBeatsIsPosition(true);
             label.setBeatsPerBar(4);
             label.setSize(text.timecodeBox, 20);
+            expect(label.getNumChildComponents() == 3, "expected three segments");
 
-            juce::Array<juce::Rectangle<int>> before;
-            for (auto* child : label.getChildren())
-                before.add(child->getBounds());
-            expect(before.size() == 3, "expected three segments");
+            const auto barsBefore = label.getChildComponent(0)->getBounds();
+            const auto ticksBefore = label.getChildComponent(2)->getBounds();
+            // A one-digit bar number gets no more of the strip than the
+            // one-digit beat number beside it.
+            expect(barsBefore.getWidth() == label.getChildComponent(1)->getWidth(),
+                   "a one-digit bar number took more room than a one-digit beat number");
 
-            label.setBeatsPerBar(magda::MAX_TIME_SIGNATURE_VALUE);
+            label.setValue(9.0 * 4.0, juce::dontSendNotification);  // bar 10
+            expect(label.getChildComponent(0)->getWidth() > barsBefore.getWidth(),
+                   "the bar segment did not grow for its second digit");
+            expect(label.getChildComponent(2)->getBounds() != ticksBefore,
+                   "the segments kept their one-digit proportions");
 
-            bool reproportioned = false;
-            for (int i = 0; i < before.size(); ++i)
-                reproportioned |= label.getChildComponent(i)->getBounds() != before[i];
-            expect(reproportioned, "the segments kept their 4/4 proportions");
-
-            // ...and the beat segment is the one that grew.
-            const auto narrow =
+            // The widest value the range allows still fits, segment by segment.
+            label.setValue(kTimecodeMaxBeats, juce::dontSendNotification);
+            const auto needed =
                 magda::BarsBeatsTicksLabel::segmentWidthsFor(kTimecodeMaxBeats, 4, 4, true);
-            const auto wide = magda::BarsBeatsTicksLabel::segmentWidthsFor(
-                kTimecodeMaxBeats, magda::MAX_TIME_SIGNATURE_VALUE, magda::MAX_TIME_SIGNATURE_VALUE,
-                true);
-            expect(wide[1] > narrow[1]);
+            for (int i = 0; i < 3; ++i)
+                expect(label.getChildComponent(i)->getWidth() >= needed[i],
+                       "segment " + juce::String(i) + " clips the largest position");
+        }
+
+        beginTest("The digits stay clear of what is drawn over the readout's end");
+        {
+            // TransportPanel draws the group caption over the box's top-right
+            // corner and the punch box carries its icons there. The layout
+            // adds that zone to every readout and hands it to the label, which
+            // keeps its strip out of it.
+            expect(l.timeBoxTrailingInset >= text.timecodeCaption,
+                   "the inset does not cover the caption");
+
+            magda::BarsBeatsTicksLabel label;
+            label.setRange(0.0, kTimecodeMaxBeats, 0.0);
+            label.setBarsBeatsIsPosition(true);
+            label.setSize(l.playhead.getWidth(), l.playhead.getHeight());
+            label.setTrailingInset(l.timeBoxTrailingInset);
+            label.setValue(kTimecodeMaxBeats, juce::dontSendNotification);
+
+            // The last glyph sits half a segment pad inside its segment.
+            const int glyphRight = label.getChildComponent(2)->getRight() -
+                                   (magda::BarsBeatsTicksLabel::kSegmentPad / 2);
+            expect(glyphRight <= label.getWidth() - l.timeBoxTrailingInset,
+                   "the ticks run under the caption");
+            const auto needed = magda::BarsBeatsTicksLabel::segmentWidthsFor(
+                kTimecodeMaxBeats, magda::DEFAULT_TIME_SIGNATURE_NUMERATOR,
+                magda::DEFAULT_TIME_SIGNATURE_NUMERATOR, true);
+            for (int i = 0; i < 3; ++i)
+                expect(label.getChildComponent(i)->getWidth() >= needed[i],
+                       "segment " + juce::String(i) + " lost room to the inset");
         }
 
         beginTest("The CPU slot holds the peak form, not just the average");


### PR DESCRIPTION
Two fixes, both found today.

## Serum jumps octaves after a view switch

A track with a step sequencer into Serum played about two octaves up after switching away from its track and back. Six Serum parameters moved together, all to a rail: Bend Up to 1, Bend Down to 0, Swing Div / Transpose / A Octave / A Semi to 1. A Octave at its maximum is the audible part.

Those six are exactly the six that the saved parameter config for Serum 2 (`PluginConfigs/VST3-Serum_2-*.xml`, an AI Detect run) marks as discrete with a choice list, so the param grid builds a dropdown for each. `configureDiscreteCombo` cleared that dropdown with `juce::ComboBox::clear()`, whose default notification is async. Slots are reused across rebuilds: the constructor configures once, `setNodePath` rebuilds straight after, and every view or track switch rebuilds again. From the second configure on the combo already holds a selection, `clear()` queues an `onChange`, the choices are re-added and the current one re-selected without notification, and on the next message-loop tick the queued `onChange` fires and writes the selection back as if the user had picked it. The selection was `round(currentValue)` with `currentValue` in TE's normalized domain: 0.54167 became 1, 0.45833 became 0, 0.5 became 1. It never showed at load because the native chunk overlay overwrote it.

- `clear(juce::dontSendNotification)` removes the write. `AudioSettingsDialog` cleared its device combos the same way on every device-change broadcast, with an `onChange` that re-applies the device setup; same fix.
- The reason the write was harmful at all: the discrete widgets read the model value as a choice index and wrote the index back. For an internal device that is the contract; for an external plugin whose saved config marks a parameter discrete, the model holds TE's normalized value, so Bend Up at +2 semitones showed "-23" and picking "+2" wrote 1.0. `ParameterUtils::choiceIndexForModelValue` / `modelValueForChoiceIndex` (with `modelHoldsTeNativeValue` naming the branch the existing conversions already take) map index and model value for both cases; the dropdown, the segmented buttons and the value-only refresh use them.

Tests: a JUCE test that rebuilds a discrete cell twice, pumps the message queue and expects no write (it fails with the old `clear()`), shows and writes the right choice for an external parameter, and keeps the index contract for an internal one; plus Catch2 cases for the mapping.

## Transport readouts overlap their captions (regression from #2153)

Since the transport started measuring itself, every timecode box sized itself from its digits alone. Every box had its ticks running into the SEL / LOOP / CUR caption in its top-right corner, the punch box into its in/out icons, and a wide gap to the left of the bar number.

- The box was digits plus nothing, while `TransportPanel` draws the caption over the corner and the punch icons ride the right end; the fixed 100-130px box of before happened to leave room. The caption is now measured like every other string, the layout reserves the wider of the caption and the punch icon zone at the end of every readout, and the label keeps its glyphs out of it (`BarsBeatsTicksLabel::setTrailingInset`). The box grows only by what that needs beyond the air the glyphs already keep at the edge, so the 1200px budget holds: nothing collapses at any density, at any transport height, or with strings 15% wider, asserted against the widths the shipped fonts really produce.
- The strip was shared in proportion to the largest value the range allowed (five-digit bars beside two-digit beats), so "1.1.000" had a mostly empty bar segment and the ticks pushed to the far end. The label shares the strip by the digits on screen instead, which for ordinary positions is the balance the old fixed quarters gave, and relayouts when a bar or beat number gains a digit, so a long position widens its segment rather than clipping.
- The range was 100000 beats, which at one beat per bar is a six-digit one-indexed bar number every readout in every meter paid for. It is now 99999 bars in any meter.

Tests: the Catch2 fixture carries the real font widths (the CPU slot had been understated); readouts are asserted wider than their digits by the decoration with the punch icons inside the zone the digits keep clear; the JUCE test checks the glyphs stay clear of the caption, that a bar number gaining a digit re-proportions the segments, and that the largest position still fits.

https://claude.ai/code/session_01EKfFA9ZU2RGJusE2K1Tbxa
