### PR TITLE
Give both arrangement columns the same idea of a row

### DIFF
--- a/magda/daw/ui/components/tracks/TrackContentPanel.cpp
+++ b/magda/daw/ui/components/tracks/TrackContentPanel.cpp
@@ -17,6 +17,7 @@
 #include "../clips/ClipComponent.hpp"
 #include "../common/InternalFileDrag.hpp"
 #include "Config.hpp"
+#include "TrackControlsPolicy.hpp"
 #include "core/AppPaths.hpp"
 #include "core/AutomationCommands.hpp"
 #include "core/ClipCommands.hpp"
@@ -275,6 +276,9 @@ void TrackContentPanel::tracksChanged() {
         const auto* track = trackManager.getTrack(trackId);
         if (!track || !track->isVisibleIn(currentViewMode_))
             return;
+
+        if (!occupiesArrangementRow(track->type))
+            return;  // Rendered in the aux strip instead — see the predicate.
 
         visibleTrackIds_.push_back(trackId);
 

--- a/magda/daw/ui/components/tracks/TrackControlsPolicy.hpp
+++ b/magda/daw/ui/components/tracks/TrackControlsPolicy.hpp
@@ -12,6 +12,24 @@ namespace magda {
  * decide where and how the controls are laid out; whether a control exists
  * for a track type is declared here and nowhere else.
  */
+/**
+ * @brief Whether a track occupies a row in the scrolling arrangement columns.
+ *
+ * Aux returns do not. They have their own fixed strip below the arrangement —
+ * `MainView`'s `AuxHeadersPanel` and `AuxContentPanel`, sized from the aux count
+ * — so a row up here as well would render the same track twice.
+ *
+ * This is one function rather than one condition in each panel because the
+ * header column and the content column are locked to a single scroll offset.
+ * A track present in one and absent from the other shifts everything below it
+ * by that track's height, and the two columns drift apart the further you
+ * scroll. That is exactly what happened when aux tracks gained their own strip:
+ * the header column learned to skip them and the content column did not.
+ */
+inline bool occupiesArrangementRow(TrackType type) {
+    return type != TrackType::Aux;
+}
+
 struct TrackControlsPolicy {
     // What stands in for the mute toggle.
     enum class MuteStyle {

--- a/magda/daw/ui/components/tracks/TrackHeadersPanel.cpp
+++ b/magda/daw/ui/components/tracks/TrackHeadersPanel.cpp
@@ -907,8 +907,8 @@ void TrackHeadersPanel::tracksChanged() {
         if (!track || !track->isVisibleIn(currentViewMode_))
             return;
 
-        if (track->type == TrackType::Aux)
-            return;  // Aux tracks rendered in separate section
+        if (!occupiesArrangementRow(track->type))
+            return;  // Rendered in the aux strip instead — see the predicate.
 
         visibleTrackIds_.push_back(trackId);
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -577,6 +577,7 @@ target_sources(magda_juce_tests PRIVATE
     ../magda/daw/ui/components/common/InternalFileDrag.cpp
     ../magda/daw/ui/themes/CursorManager.cpp
     ../magda/daw/ui/themes/FontManager.cpp
+    test_arrangement_row_alignment_juce.cpp
     test_automation_modes_juce.cpp
     test_arrangement_transport_loop_juce.cpp
     test_external_plugin_state_restore_juce.cpp

--- a/tests/test_arrangement_row_alignment_juce.cpp
+++ b/tests/test_arrangement_row_alignment_juce.cpp
@@ -1,0 +1,109 @@
+#include <juce_gui_basics/juce_gui_basics.h>
+
+#include "JuceTestStateGuard.hpp"
+#include "magda/daw/core/TrackManager.hpp"
+#include "magda/daw/ui/components/tracks/TrackContentPanel.hpp"
+#include "magda/daw/ui/components/tracks/TrackControlsPolicy.hpp"
+
+/**
+ * The arrangement's two columns agree on which tracks have rows.
+ *
+ * The header column and the content column are separate viewports driven to one
+ * scroll offset, so they are only ever aligned because they lay out the same
+ * tracks at the same heights. A track present in one and absent from the other
+ * shifts everything below it by that track's height, and the columns drift
+ * further apart the more you scroll.
+ *
+ * That is what aux returns did. They gained their own fixed strip below the
+ * arrangement, the header column learned to skip them, and the content column
+ * kept giving them a lane — so it rendered every aux track twice and pushed the
+ * rest of its lanes down. It survived six months because it needs an aux track
+ * to exist with something below it, and nothing in the UI creates one by
+ * default.
+ *
+ * `TrackHeadersPanel` is not in this target, so the assertions here are on the
+ * shared predicate both columns now consult and on the content column's own
+ * row count. Pinning the predicate is what matters: the bug was one condition
+ * written in one panel and not the other, and it can only come back by someone
+ * reintroducing that split.
+ */
+
+using namespace magda;
+
+namespace {
+
+class ArrangementRowAlignmentTest final : public juce::UnitTest {
+  public:
+    ArrangementRowAlignmentTest() : juce::UnitTest("Arrangement Row Alignment Tests", "magda") {}
+
+    void runTest() override {
+        testAuxIsTheOnlyTypeWithoutARow();
+        testContentColumnGivesNoLaneToAux();
+        testAuxDoesNotDisplaceTheTracksBelowIt();
+    }
+
+  private:
+    void testAuxIsTheOnlyTypeWithoutARow() {
+        beginTest("Aux is the only track type without an arrangement row");
+
+        expect(!occupiesArrangementRow(TrackType::Aux), "aux belongs in its own strip");
+
+        for (const auto type : {TrackType::Audio, TrackType::Group, TrackType::Chord,
+                                TrackType::Master, TrackType::MultiOut}) {
+            expect(occupiesArrangementRow(type),
+                   "every non-aux type keeps its row: " + juce::String(static_cast<int>(type)));
+        }
+    }
+
+    void testContentColumnGivesNoLaneToAux() {
+        beginTest("The content column gives an aux return no lane");
+
+        test::resetJuceProjectState();
+        auto& trackManager = TrackManager::getInstance();
+        trackManager.createTrack("Audio", TrackType::Audio);
+        trackManager.createTrack("Send", TrackType::Aux);
+        trackManager.createTrack("Below", TrackType::Audio);
+
+        TrackContentPanel panel;
+        panel.setSize(2000, 400);
+
+        // Three tracks exist; two of them have lanes here. The aux return is
+        // rendered by MainView's aux strip instead.
+        expectEquals(panel.getNumTracks(), 2, "aux should not occupy a lane");
+    }
+
+    void testAuxDoesNotDisplaceTheTracksBelowIt() {
+        beginTest("An aux return does not push the lanes below it down");
+
+        test::resetJuceProjectState();
+        auto& trackManager = TrackManager::getInstance();
+        trackManager.createTrack("First", TrackType::Audio);
+        trackManager.createTrack("Second", TrackType::Audio);
+
+        TrackContentPanel withoutAux;
+        withoutAux.setSize(2000, 400);
+        const int secondRowY = withoutAux.getTrackYPosition(1);
+        expect(secondRowY > 0, "the second lane should sit below the first");
+
+        // The same two audio tracks, with an aux return created between them.
+        // Its row must not exist, so the second audio track keeps its position —
+        // which is what keeps it level with its header.
+        test::resetJuceProjectState();
+        trackManager.createTrack("First", TrackType::Audio);
+        trackManager.createTrack("Send", TrackType::Aux);
+        trackManager.createTrack("Second", TrackType::Audio);
+
+        TrackContentPanel withAux;
+        withAux.setSize(2000, 400);
+        expectEquals(withAux.getNumTracks(), 2, "aux should not occupy a lane");
+        // The last lane, not index 1: with the bug present index 1 *is* the aux
+        // row and sits exactly where the second audio track should, so an
+        // assertion there passes either way. What moves is the track after it.
+        expectEquals(withAux.getTrackYPosition(withAux.getNumTracks() - 1), secondRowY,
+                     "an aux return between two tracks must not move the lower one");
+    }
+};
+
+ArrangementRowAlignmentTest arrangementRowAlignmentTest;
+
+}  // namespace


### PR DESCRIPTION
## The bug

An aux return gets a lane in the scrolling **content** column and no row in the scrolling **header** column. Both viewports are locked to a single Y offset (`MainView.cpp:1511`), so from that track downward the two columns sit one track-height apart — and it looks like the header drifting further out of step the more you scroll.

## Why

`905d550e` (2026-02-09, #653) gave aux returns their own fixed strip below the arrangement — `AuxHeadersPanel` + `AuxContentPanel`, sized `auxCount * AUX_ROW_HEIGHT` — and taught `TrackHeadersPanel` to skip them:

```cpp
if (track->type == TrackType::Aux)
    return;  // Aux tracks rendered in separate section
```

`TrackContentPanel` was never taught the same rule. It kept building a lane for a track `MainView` was already rendering in the aux strip: the same aux drawn twice, and every lane below it pushed down.

It stayed hidden for six months because it needs an aux return to exist with a track below it, and nothing creates one by default — you have to go looking for **Add aux**, or create one over the remote API, which is how it surfaced.

## The fix

The rule moves into `occupiesArrangementRow()` next to `TrackControlsPolicy`, which already declares itself the single source of truth for per-track-type decisions shared across views. Both panels consult it.

That placement is the point. The missing line was only the symptom; the defect was a rule that had to be written identically in two files and wasn't. As one condition in each panel it can silently diverge again the next time a track type earns its own section.

## Tests

New `test_arrangement_row_alignment_juce.cpp` pins the predicate, that the content column gives an aux no lane, and that an aux between two audio tracks does not move the lower one.

Verified negatively — with the content-panel call removed:

```
!!! Test 1 failed: aux should not occupy a lane -- Expected value: 2, Actual value: 3
```

One wrinkle worth knowing, and commented in the test: the Y-position assertion reads the **last** lane rather than index 1. With the bug present, index 1 *is* the aux row and sits exactly where the second audio track belongs, so an assertion there passes either way. My first version made that mistake and only the negative run caught it.

`TrackHeadersPanel.cpp` isn't in the JUCE test target, so the cross-column agreement is pinned via the shared predicate rather than by instantiating both panels.

`make test` exits 0; Clip Nudge and Repaint Invariance suites still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)