### PR TITLE
Let a window's background follow the theme it is shown under

### DIFF
--- a/magda/daw/ui/components/chain/custom_ui/FaustCodeEditorWindow.cpp
+++ b/magda/daw/ui/components/chain/custom_ui/FaustCodeEditorWindow.cpp
@@ -126,4 +126,9 @@ void FaustCodeEditorWindow::closeButtonPressed() {
     setVisible(false);
 }
 
+void FaustCodeEditorWindow::lookAndFeelChanged() {
+    juce::DocumentWindow::lookAndFeelChanged();
+    setBackgroundColour(DarkTheme::getColour(DarkTheme::BACKGROUND));
+}
+
 }  // namespace magda::daw::ui

--- a/magda/daw/ui/components/chain/custom_ui/FaustCodeEditorWindow.hpp
+++ b/magda/daw/ui/components/chain/custom_ui/FaustCodeEditorWindow.hpp
@@ -20,6 +20,11 @@ class FaustCodeEditorWindow : public juce::DocumentWindow {
 
     void closeButtonPressed() override;
 
+    // The background is a per-component colour override, so it outlives the
+    // look-and-feel change that repaints everything else. Re-resolve it, or a
+    // window left open across a theme switch keeps the old palette.
+    void lookAndFeelChanged() override;
+
   private:
     class Content;
     std::unique_ptr<Content> content_;

--- a/magda/daw/ui/components/chain/modulation/LFOCurveEditorWindow.cpp
+++ b/magda/daw/ui/components/chain/modulation/LFOCurveEditorWindow.cpp
@@ -587,4 +587,9 @@ void LFOCurveEditorWindow::closeButtonPressed() {
     }
 }
 
+void LFOCurveEditorWindow::lookAndFeelChanged() {
+    juce::DocumentWindow::lookAndFeelChanged();
+    setBackgroundColour(DarkTheme::getColour(DarkTheme::BACKGROUND));
+}
+
 }  // namespace magda::daw::ui

--- a/magda/daw/ui/components/chain/modulation/LFOCurveEditorWindow.hpp
+++ b/magda/daw/ui/components/chain/modulation/LFOCurveEditorWindow.hpp
@@ -87,6 +87,11 @@ class LFOCurveEditorWindow : public juce::DocumentWindow {
 
     void closeButtonPressed() override;
 
+    // The background is a per-component colour override, so it outlives the
+    // look-and-feel change that repaints everything else. Re-resolve it, or a
+    // window left open across a theme switch keeps the old palette.
+    void lookAndFeelChanged() override;
+
     // Get the curve editor for syncing
     magda::LFOCurveEditor& getCurveEditor() {
         return content_.getCurveEditor();

--- a/magda/daw/ui/components/common/FloatingHostWindow.hpp
+++ b/magda/daw/ui/components/common/FloatingHostWindow.hpp
@@ -30,6 +30,14 @@ class FloatingHostWindow : public juce::DocumentWindow {
         setTitleBarHeight(MainLookAndFeel::kTitleBarHeight);
         setAlwaysOnTop(true);
     }
+
+    // The background is a per-component colour override, so it outlives the
+    // look-and-feel change that repaints everything else. Re-resolve it, or a
+    // window left open across a theme switch keeps the old palette.
+    void lookAndFeelChanged() override {
+        juce::DocumentWindow::lookAndFeelChanged();
+        setBackgroundColour(DarkTheme::getColour(DarkTheme::BACKGROUND));
+    }
 };
 
 }  // namespace magda::daw::ui

--- a/magda/daw/ui/components/tracks/TrackHeadersPanel.cpp
+++ b/magda/daw/ui/components/tracks/TrackHeadersPanel.cpp
@@ -1351,6 +1351,7 @@ void TrackHeadersPanel::updateHeaderSelectionColours() {
 }
 
 void TrackHeadersPanel::lookAndFeelChanged() {
+    sliderLookAndFeel_.refreshThemeColours();
     // Per-track header labels cache concrete text colours, so a repaint alone
     // won't refresh them after a theme switch. Name labels are selection-aware
     // (handled by updateHeaderSelectionColours); the compact peak and column

--- a/magda/daw/ui/debug/DebugDialog.cpp
+++ b/magda/daw/ui/debug/DebugDialog.cpp
@@ -301,6 +301,11 @@ void DebugDialog::closeButtonPressed() {
     hide();
 }
 
+void DebugDialog::lookAndFeelChanged() {
+    juce::DocumentWindow::lookAndFeelChanged();
+    setBackgroundColour(DarkTheme::getColour(DarkTheme::PANEL_BACKGROUND));
+}
+
 void DebugDialog::show() {
     if (!instance_) {
         instance_ = std::make_unique<DebugDialog>();

--- a/magda/daw/ui/debug/DebugDialog.hpp
+++ b/magda/daw/ui/debug/DebugDialog.hpp
@@ -18,6 +18,11 @@ class DebugDialog : public juce::DocumentWindow {
 
     void closeButtonPressed() override;
 
+    // The background is a per-component colour override, so it outlives the
+    // look-and-feel change that repaints everything else. Re-resolve it, or a
+    // window left open across a theme switch keeps the old palette.
+    void lookAndFeelChanged() override;
+
     // Show the dialog (creates if needed)
     static void show();
     static void hide();

--- a/magda/daw/ui/dialogs/AISettingsDialog.cpp
+++ b/magda/daw/ui/dialogs/AISettingsDialog.cpp
@@ -2533,6 +2533,10 @@ void AISettingsDialog::paint(juce::Graphics& g) {
     g.fillAll(DarkTheme::getColour(DarkTheme::PANEL_BACKGROUND));
 }
 
+void AISettingsDialog::lookAndFeelChanged() {
+    refreshHostWindowBackground(*this);
+}
+
 void AISettingsDialog::resized() {
     auto bounds = getLocalBounds().reduced(8);
 

--- a/magda/daw/ui/dialogs/AISettingsDialog.hpp
+++ b/magda/daw/ui/dialogs/AISettingsDialog.hpp
@@ -23,6 +23,10 @@ class AISettingsDialog : public juce::Component {
     void resized() override;
     void paint(juce::Graphics& g) override;
 
+    // The hosting window's background is a colour override handed over once at
+    // construction, so it does not follow a live theme switch on its own.
+    void lookAndFeelChanged() override;
+
     // initialTabName selects a tab by its title (e.g. "Stems") once the
     // dialog is up; empty keeps the default tab.
     static void showDialog(juce::Component* parent, const juce::String& initialTabName = {});

--- a/magda/daw/ui/dialogs/AudioSettingsDialog.cpp
+++ b/magda/daw/ui/dialogs/AudioSettingsDialog.cpp
@@ -473,6 +473,10 @@ void AudioSettingsDialog::paint(juce::Graphics& g) {
     g.fillAll(DarkTheme::getColour(DarkTheme::PANEL_BACKGROUND));
 }
 
+void AudioSettingsDialog::lookAndFeelChanged() {
+    refreshHostWindowBackground(*this);
+}
+
 void AudioSettingsDialog::resized() {
     auto bounds = getLocalBounds().reduced(10);
 

--- a/magda/daw/ui/dialogs/AudioSettingsDialog.hpp
+++ b/magda/daw/ui/dialogs/AudioSettingsDialog.hpp
@@ -59,6 +59,10 @@ class AudioSettingsDialog : public juce::Component,
     void resized() override;
     void paint(juce::Graphics& g) override;
 
+    // The hosting window's background is a colour override handed over once at
+    // construction, so it does not follow a live theme switch on its own.
+    void lookAndFeelChanged() override;
+
     // Re-list the device combos when the driver type or device changes (e.g. the
     // user picks a different driver in the AudioDeviceSelectorComponent).
     void changeListenerCallback(juce::ChangeBroadcaster* source) override;

--- a/magda/daw/ui/dialogs/ExportAudioDialog.cpp
+++ b/magda/daw/ui/dialogs/ExportAudioDialog.cpp
@@ -153,6 +153,10 @@ void ExportAudioDialog::paint(juce::Graphics& g) {
     g.fillAll(DarkTheme::getColour(DarkTheme::PANEL_BACKGROUND));
 }
 
+void ExportAudioDialog::lookAndFeelChanged() {
+    refreshHostWindowBackground(*this);
+}
+
 void ExportAudioDialog::resized() {
     auto bounds = getLocalBounds().reduced(20);
 

--- a/magda/daw/ui/dialogs/ExportAudioDialog.hpp
+++ b/magda/daw/ui/dialogs/ExportAudioDialog.hpp
@@ -35,6 +35,10 @@ class ExportAudioDialog : public juce::Component {
     void resized() override;
     void paint(juce::Graphics& g) override;
 
+    // The hosting window's background is a colour override handed over once at
+    // construction, so it does not follow a live theme switch on its own.
+    void lookAndFeelChanged() override;
+
     // Get current settings from dialog
     Settings getSettings() const;
 

--- a/magda/daw/ui/dialogs/ExportMidiDialog.cpp
+++ b/magda/daw/ui/dialogs/ExportMidiDialog.cpp
@@ -72,6 +72,10 @@ void ExportMidiDialog::paint(juce::Graphics& g) {
     g.fillAll(DarkTheme::getColour(DarkTheme::PANEL_BACKGROUND));
 }
 
+void ExportMidiDialog::lookAndFeelChanged() {
+    refreshHostWindowBackground(*this);
+}
+
 void ExportMidiDialog::resized() {
     auto bounds = getLocalBounds().reduced(20);
 

--- a/magda/daw/ui/dialogs/ExportMidiDialog.hpp
+++ b/magda/daw/ui/dialogs/ExportMidiDialog.hpp
@@ -22,6 +22,10 @@ class ExportMidiDialog : public juce::Component {
     void resized() override;
     void paint(juce::Graphics& g) override;
 
+    // The hosting window's background is a colour override handed over once at
+    // construction, so it does not follow a live theme switch on its own.
+    void lookAndFeelChanged() override;
+
     Settings getSettings() const;
 
     std::function<void(const Settings&)> onExport;

--- a/magda/daw/ui/dialogs/GainStagingDialog.cpp
+++ b/magda/daw/ui/dialogs/GainStagingDialog.cpp
@@ -64,6 +64,10 @@ void GainStagingDialog::paint(juce::Graphics& g) {
     g.fillAll(DarkTheme::getColour(DarkTheme::PANEL_BACKGROUND));
 }
 
+void GainStagingDialog::lookAndFeelChanged() {
+    refreshHostWindowBackground(*this);
+}
+
 void GainStagingDialog::resized() {
     auto bounds = getLocalBounds().reduced(20);
 

--- a/magda/daw/ui/dialogs/GainStagingDialog.hpp
+++ b/magda/daw/ui/dialogs/GainStagingDialog.hpp
@@ -25,6 +25,10 @@ class GainStagingDialog : public juce::Component {
     void resized() override;
     void paint(juce::Graphics& g) override;
 
+    // The hosting window's background is a colour override handed over once at
+    // construction, so it does not follow a live theme switch on its own.
+    void lookAndFeelChanged() override;
+
     Settings getSettings() const;
 
     std::function<void(const Settings&)> onStart;

--- a/magda/daw/ui/dialogs/ParameterConfigDialog.cpp
+++ b/magda/daw/ui/dialogs/ParameterConfigDialog.cpp
@@ -679,6 +679,10 @@ void ParameterConfigDialog::paint(juce::Graphics& g) {
     }
 }
 
+void ParameterConfigDialog::lookAndFeelChanged() {
+    refreshHostWindowBackground(*this);
+}
+
 void ParameterConfigDialog::resized() {
     auto bounds = getLocalBounds().reduced(16);
 

--- a/magda/daw/ui/dialogs/ParameterConfigDialog.cpp
+++ b/magda/daw/ui/dialogs/ParameterConfigDialog.cpp
@@ -73,6 +73,13 @@ class AIPromptEditorComponent : public juce::Component {
         setSize(520, 250);
     }
 
+    // Launched async into a DialogWindow of its own, so it can be on screen
+    // when the theme changes under it. The hosting window's background is a
+    // colour override handed over once at construction.
+    void lookAndFeelChanged() override {
+        refreshHostWindowBackground(*this);
+    }
+
     void resized() override {
         auto bounds = getLocalBounds().reduced(16);
         description_.setBounds(bounds.removeFromTop(24));

--- a/magda/daw/ui/dialogs/ParameterConfigDialog.hpp
+++ b/magda/daw/ui/dialogs/ParameterConfigDialog.hpp
@@ -53,6 +53,10 @@ class ParameterConfigDialog : public juce::Component,
     ~ParameterConfigDialog() override;
 
     void paint(juce::Graphics& g) override;
+
+    // The hosting window's background is a colour override handed over once at
+    // construction, so it does not follow a live theme switch on its own.
+    void lookAndFeelChanged() override;
     void resized() override;
 
     // TableListBoxModel interface

--- a/magda/daw/ui/dialogs/PreferencesDialog.cpp
+++ b/magda/daw/ui/dialogs/PreferencesDialog.cpp
@@ -3001,10 +3001,7 @@ void PreferencesDialog::lookAndFeelChanged() {
     for (int i = 0; i < tabbedComponent.getNumTabs(); ++i)
         tabbedComponent.setTabBackgroundColour(i, background);
 
-    if (auto* window = findParentComponentOfClass<juce::DialogWindow>()) {
-        window->setBackgroundColour(background);
-        window->repaint();
-    }
+    refreshHostWindowBackground(*this);
 
     repaint();
 }

--- a/magda/daw/ui/dialogs/ProjectSettingsDialog.cpp
+++ b/magda/daw/ui/dialogs/ProjectSettingsDialog.cpp
@@ -139,6 +139,10 @@ void ProjectSettingsDialog::paint(juce::Graphics& g) {
     g.fillAll(DarkTheme::getColour(DarkTheme::PANEL_BACKGROUND));
 }
 
+void ProjectSettingsDialog::lookAndFeelChanged() {
+    refreshHostWindowBackground(*this);
+}
+
 void ProjectSettingsDialog::resized() {
     auto bounds = getLocalBounds().reduced(kPad);
 

--- a/magda/daw/ui/dialogs/ProjectSettingsDialog.hpp
+++ b/magda/daw/ui/dialogs/ProjectSettingsDialog.hpp
@@ -20,6 +20,10 @@ class ProjectSettingsDialog : public juce::Component {
     void resized() override;
     void paint(juce::Graphics& g) override;
 
+    // The hosting window's background is a colour override handed over once at
+    // construction, so it does not follow a live theme switch on its own.
+    void lookAndFeelChanged() override;
+
     static void showDialog(juce::Component* parent);
 
   private:

--- a/magda/daw/ui/dialogs/SplashScreen.cpp
+++ b/magda/daw/ui/dialogs/SplashScreen.cpp
@@ -242,6 +242,11 @@ SplashScreen::SplashScreen()
     setAlwaysOnTop(true);
 }
 
+void SplashScreen::lookAndFeelChanged() {
+    juce::DocumentWindow::lookAndFeelChanged();
+    setBackgroundColour(DarkTheme::getColour(DarkTheme::PANEL_BACKGROUND));
+}
+
 void SplashScreen::dismiss() {
     setVisible(false);
 }

--- a/magda/daw/ui/dialogs/SplashScreen.hpp
+++ b/magda/daw/ui/dialogs/SplashScreen.hpp
@@ -12,6 +12,11 @@ class SplashScreen : public juce::DocumentWindow {
 
     void closeButtonPressed() override {}
 
+    // The background is a per-component colour override, so it outlives the
+    // look-and-feel change that repaints everything else. Re-resolve it, or a
+    // window left open across a theme switch keeps the old palette.
+    void lookAndFeelChanged() override;
+
     void dismiss();
     void setStatus(const juce::String& text);
 

--- a/magda/daw/ui/panels/content/MediaDbBrowserContent.cpp
+++ b/magda/daw/ui/panels/content/MediaDbBrowserContent.cpp
@@ -2572,6 +2572,14 @@ class MediaDbBrowserContent::PopOutWindow : public juce::DocumentWindow {
         delete this;
     }
 
+    // The background is a per-component colour override, so it outlives the
+    // look-and-feel change that repaints everything else. Re-resolve it, or a
+    // window left open across a theme switch keeps the old palette.
+    void lookAndFeelChanged() override {
+        juce::DocumentWindow::lookAndFeelChanged();
+        setBackgroundColour(DarkTheme::getColour(DarkTheme::BACKGROUND));
+    }
+
   private:
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(PopOutWindow)
 };

--- a/magda/daw/ui/panels/content/TrackChainContent.cpp
+++ b/magda/daw/ui/panels/content/TrackChainContent.cpp
@@ -1162,6 +1162,7 @@ TrackChainContent::TrackChainContent()
 }
 
 void TrackChainContent::lookAndFeelChanged() {
+    mixerLookAndFeel_.refreshThemeColours();
     if (chainBypassButton_) {
         chainBypassButton_->setNormalColor(DarkTheme::getColour(DarkTheme::STATUS_ERROR));
         chainBypassButton_->setActiveColor(juce::Colours::white);

--- a/magda/daw/ui/themes/DarkTheme.hpp
+++ b/magda/daw/ui/themes/DarkTheme.hpp
@@ -569,6 +569,20 @@ inline juce::Colour deriveClipBody(juce::Colour stored) {
     return ThemeManager::isLightTheme() ? swatch : swatch.darker(0.3f);
 }
 
+// A window's background is a per-component colour override, handed over once
+// when the window is constructed. JUCE keeps such overrides across a
+// look-and-feel change, so unlike a colour read inside paint() it does not
+// follow a live theme switch on its own. Nor is it always hidden behind the
+// content: the in-window menu bar draws its fill at 40% alpha, and JUCE's own
+// dialog chrome leaves margins, so the stale colour shows through.
+//
+// Call this from the hosted content's lookAndFeelChanged() to re-resolve it.
+inline void refreshHostWindowBackground(juce::Component& content,
+                                        ColourRole role = ColourRole::PANEL_BACKGROUND) {
+    if (auto* window = content.findParentComponentOfClass<juce::ResizableWindow>())
+        window->setBackgroundColour(DarkTheme::getColour(role));
+}
+
 // Keeps named colours in a custom device UI bound to a role without forcing
 // every paint call to spell out DarkTheme::getColour(). The conversion and
 // common modifiers resolve the active palette at the point of use.

--- a/magda/daw/ui/themes/FileBrowserLookAndFeel.hpp
+++ b/magda/daw/ui/themes/FileBrowserLookAndFeel.hpp
@@ -15,14 +15,22 @@ namespace magda::daw::ui {
 class FileBrowserLookAndFeel : public juce::LookAndFeel_V4 {
   public:
     FileBrowserLookAndFeel() {
-        setColour(juce::ScrollBar::thumbColourId,
-                  DarkTheme::getColour(DarkTheme::ACCENT_PRIMARY).withAlpha(0.5f));
-        setColour(juce::ScrollBar::backgroundColourId, juce::Colours::transparentBlack);
+        refreshThemeColours();
 
         // Keep the source drawable untouched; drawFileItem tints a short-lived
         // copy so existing rows follow a live theme switch.
         midiDrawable_ =
             juce::Drawable::createFromImageData(BinaryData::midi_svg, BinaryData::midi_svgSize);
+    }
+
+    // A LookAndFeel is not a Component, so it never hears the look-and-feel
+    // broadcast a live theme switch sends. This colour is pushed into its own
+    // table and would keep the palette the singleton was built under, so
+    // MainWindow re-applies it alongside the other shared look-and-feels.
+    void refreshThemeColours() {
+        setColour(juce::ScrollBar::thumbColourId,
+                  DarkTheme::getColour(DarkTheme::ACCENT_PRIMARY).withAlpha(0.5f));
+        setColour(juce::ScrollBar::backgroundColourId, juce::Colours::transparentBlack);
     }
     ~FileBrowserLookAndFeel() override = default;
 

--- a/magda/daw/ui/themes/MixerLookAndFeel.cpp
+++ b/magda/daw/ui/themes/MixerLookAndFeel.cpp
@@ -7,7 +7,12 @@
 namespace magda {
 
 MixerLookAndFeel::MixerLookAndFeel() {
-    // Set default slider colors
+    refreshThemeColours();
+}
+
+// Reached for slider styles this class does not draw itself, which fall through
+// to LookAndFeel_V4 and resolve these ids.
+void MixerLookAndFeel::refreshThemeColours() {
     setColour(juce::Slider::trackColourId, DarkTheme::getColour(DarkTheme::SURFACE));
     setColour(juce::Slider::backgroundColourId, DarkTheme::getColour(DarkTheme::SURFACE));
     setColour(juce::Slider::thumbColourId, DarkTheme::getColour(DarkTheme::TEXT_PRIMARY));

--- a/magda/daw/ui/themes/MixerLookAndFeel.hpp
+++ b/magda/daw/ui/themes/MixerLookAndFeel.hpp
@@ -13,6 +13,12 @@ class MixerLookAndFeel : public juce::LookAndFeel_V4 {
     MixerLookAndFeel();
     ~MixerLookAndFeel() override;
 
+    // A LookAndFeel is not a Component, so it never hears the look-and-feel
+    // broadcast that a live theme switch sends. The colours below are pushed
+    // into its own colour table and would keep the palette this instance was
+    // constructed under; owners re-apply them from their lookAndFeelChanged().
+    void refreshThemeColours();
+
     // Override linear slider drawing for custom fader appearance
     void drawLinearSlider(juce::Graphics& g, int x, int y, int width, int height, float sliderPos,
                           float minSliderPos, float maxSliderPos,

--- a/magda/daw/ui/views/MixerView.cpp
+++ b/magda/daw/ui/views/MixerView.cpp
@@ -1686,6 +1686,12 @@ void MixerView::ChannelStrip::resetPeak() {
         peakLabel->setText("-inf", juce::dontSendNotification);
 }
 
+// The fader look-and-feel is a plain member, not a Component, so the theme
+// broadcast never reaches it on its own.
+void MixerView::lookAndFeelChanged() {
+    mixerLookAndFeel_.refreshThemeColours();
+}
+
 void MixerView::ChannelStrip::lookAndFeelChanged() {
     // trackLabel and peakLabel cache a concrete text colour, so a repaint alone
     // won't refresh them after a theme switch. trackLabel's colour is

--- a/magda/daw/ui/views/MixerView.hpp
+++ b/magda/daw/ui/views/MixerView.hpp
@@ -59,6 +59,7 @@ class MixerView : public juce::Component,
 
     void paint(juce::Graphics& g) override;
     void resized() override;
+    void lookAndFeelChanged() override;
     bool keyPressed(const juce::KeyPress& key) override;
     void mouseMove(const juce::MouseEvent& event) override;
     void mouseDown(const juce::MouseEvent& event) override;

--- a/magda/daw/ui/views/SessionClipEditor.cpp
+++ b/magda/daw/ui/views/SessionClipEditor.cpp
@@ -390,4 +390,9 @@ void SessionClipEditorWindow::closeButtonPressed() {
         setVisible(false);
 }
 
+void SessionClipEditorWindow::lookAndFeelChanged() {
+    juce::DocumentWindow::lookAndFeelChanged();
+    setBackgroundColour(DarkTheme::getColour(DarkTheme::BACKGROUND));
+}
+
 }  // namespace magda

--- a/magda/daw/ui/views/SessionClipEditor.hpp
+++ b/magda/daw/ui/views/SessionClipEditor.hpp
@@ -80,6 +80,11 @@ class SessionClipEditorWindow : public juce::DocumentWindow {
 
     void closeButtonPressed() override;
 
+    // The background is a per-component colour override, so it outlives the
+    // look-and-feel change that repaints everything else. Re-resolve it, or a
+    // window left open across a theme switch keeps the old palette.
+    void lookAndFeelChanged() override;
+
   private:
     std::unique_ptr<SessionClipEditor> editor_;
 

--- a/magda/daw/ui/windows/MainWindow.cpp
+++ b/magda/daw/ui/windows/MainWindow.cpp
@@ -27,6 +27,7 @@
 #include "../state/TimelineEvents.hpp"
 #include "../themes/DarkTheme.hpp"
 #include "../themes/DialogLookAndFeel.hpp"
+#include "../themes/FileBrowserLookAndFeel.hpp"
 #include "../themes/MixerMetrics.hpp"
 #include "../themes/SmallButtonLookAndFeel.hpp"
 #include "../themes/SmallComboBoxLookAndFeel.hpp"
@@ -441,6 +442,9 @@ void MainWindow::refreshThemedLookAndFeels() {
     DarkTheme::applyToLookAndFeel(daw::ui::SmallButtonLookAndFeel::getInstance());
     DarkTheme::applyToLookAndFeel(daw::ui::FlatTabButtonLookAndFeel::getInstance());
     DarkTheme::applyToLookAndFeel(daw::ui::SmallComboBoxLookAndFeel::getInstance());
+    // Not a DarkTheme::applyToLookAndFeel target: it pushes its own scrollbar
+    // colour into its table, which no repaint would refresh.
+    daw::ui::FileBrowserLookAndFeel::getInstance().refreshThemeColours();
 
 #if JUCE_WINDOWS
     // Keep native chrome in step with live theme changes. DWM expects FALSE
@@ -465,6 +469,16 @@ void MainWindow::refreshThemedLookAndFeels() {
 
 void MainWindow::closeButtonPressed() {
     juce::JUCEApplication::getInstance()->systemRequestedQuit();
+}
+
+// A window's background is a per-component colour override, so it survives the
+// look-and-feel change that repaints everything else and would keep the palette
+// the window was constructed under. It is not hidden behind the content either:
+// the in-window menu bar (Windows and Linux) draws its fill at 40% alpha, so the
+// stale colour shows straight through as a strip along the top of the window.
+void MainWindow::lookAndFeelChanged() {
+    juce::DocumentWindow::lookAndFeelChanged();
+    setBackgroundColour(DarkTheme::getBackgroundColour());
 }
 
 void MainWindow::applyPanelVisibilityFromConfig() {

--- a/magda/daw/ui/windows/MainWindow.hpp
+++ b/magda/daw/ui/windows/MainWindow.hpp
@@ -44,6 +44,7 @@ class MainWindow : public juce::DocumentWindow,
     ~MainWindow() override;
 
     void closeButtonPressed() override;
+    void lookAndFeelChanged() override;
 
     // ProjectManagerListener
     void projectOpened(const ProjectInfo& info) override;


### PR DESCRIPTION
Fixes #2073.

## What was actually stale

Every border MAGDA *draws* resolves its colour inside `paint()`, so the repaint that a look-and-feel change triggers already heals it. That covers all of `MainView`, `TabbedPanel`, `FooterBar`, `PanelTabBar`, `TimelineHeaderPanel`, `MarkerLaneComponent` and the piano-roll lanes. None of them was the strip in the report.

The strip is not drawn at all. `LookAndFeel_V4::drawMenuBarBackground` fills at 40% alpha, so what shows through the in-window menu bar is the window's own background. That background is a per-component colour override handed to `DocumentWindow` once at construction, and JUCE keeps such overrides across a look-and-feel change, so it stays on whichever theme was active when the window was built.

Sampling the reported screenshot pins it exactly. The strip measured `#979A9D`; the app body measured `#0C0F14`, the dark theme's `BACKGROUND`:

| | value |
|---|---|
| dark `BUTTON_NORMAL` at 40% over **light** `BACKGROUND` (`#F4F6F8`) | `(151, 154, 157)` |
| measured strip | `(151, 154, 157)` |
| after this change (over live dark `BACKGROUND`) | `(12, 15, 20)` |

So the window was constructed under Light and never let go of it, while everything around it repainted in Dark.

## The change

`refreshHostWindowBackground()` in `DarkTheme.hpp`, and a `lookAndFeelChanged()` on each place that froze the same colour:

- **Windows**: `MainWindow` (the reported one), `FloatingHostWindow`, `LFOCurveEditorWindow`, `FaustCodeEditorWindow`, `SessionClipEditorWindow`, `DebugDialog`, `MediaDbBrowserContent::PopOutWindow`, `SplashScreen`
- **Dialog contents** that hand a background to their `DialogWindow`: AI settings, audio settings, audio export, MIDI export, gain staging, parameter config, project settings. `PreferencesDialog` had already grown this inline and now shares the helper.
- **LookAndFeels**: `MixerLookAndFeel` and `FileBrowserLookAndFeel` cached theme colours in their constructors. A `LookAndFeel` is not a `Component`, so no broadcast reaches it. Both gained a `refreshThemeColours()`; the mixer one is called by its three owners, the file browser singleton by `refreshThemedLookAndFeels()`.

The window-level fix is what the issue reported; the rest is the sibling sweep it asked for. The `setColour`-on-child-widget cases (search boxes, combos, inspector labels) are a separate and much larger family and are not touched here.

## Verification

- `make debug` clean
- `make test`: 2877 cases, 599511 assertions, 0 failures (13 pre-existing skips)
- `make test-juce-build` clean
- `make format` clean

Not verified on a live theme switch on Windows; the arithmetic above is what identifies the defect, and the mechanism is platform-independent (the strip is only visible where the menu bar is in-window, so Windows and Linux).
