### PR TITLE
Document what 0.19 added that the manual had no page for

### DIFF
--- a/manual/docs/clips.md
+++ b/manual/docs/clips.md
@@ -150,10 +150,12 @@ To make both clips sound where they overlap, right-click either one and tick **P
 
 Either clip can carry the switch, which matters because the clip you reach for when something goes quiet is the one that went quiet, and that is the one underneath.
 
-Creating a [crossfade](#crossfades) turns it on for you, on both clips. A crossfade needs both sides sounding to have anything to fade into, so it sets the fade and the play-through together.
+Asking for a [crossfade](#crossfades) turns it on for you, on both clips: right-click and choose **Crossfade with Previous Clip** or **Crossfade with Next Clip**, or drag a crossfade handle. Asking for a fade region is asking for both clips to be heard across it, so the gesture sets the fade and the play-through together.
 
-!!! note "Auto-crossfade does not keep a clip audible"
-    Auto-crossfade shapes an overlap that is already playing both, so audio fades into audio instead of both running flat. It cannot keep a covered clip alive on its own. **Play Through Overlap** is the switch that decides whether both sound; the crossfade only decides how they meet.
+!!! note "The Auto Crossfade property does not do this"
+    **Auto Crossfade** marks a clip as eligible to crossfade; it does not create a fade region, and it leaves play-through alone. The same goes for the **Auto-crossfade new audio clips** preference, which only sets that property on new clips.
+
+    This matters because auto-crossfade cannot keep a covered clip audible on its own. It shapes an overlap that is already playing both, so audio fades into audio instead of both running flat. **Play Through Overlap** is what decides whether both sound; the crossfade only decides how they meet.
 
 ## Flatten MIDI Loop
 

--- a/manual/docs/clips.md
+++ b/manual/docs/clips.md
@@ -150,10 +150,10 @@ To make both clips sound where they overlap, right-click either one and tick **P
 
 Either clip can carry the switch, which matters because the clip you reach for when something goes quiet is the one that went quiet, and that is the one underneath.
 
-New clips take their starting value from **New clips play through overlaps** in [Preferences](interface/preferences.md). Changing that preference leaves existing clips alone.
+Creating a [crossfade](#crossfades) turns it on for you, on both clips. A crossfade needs both sides sounding to have anything to fade into, so it sets the fade and the play-through together.
 
 !!! note "Auto-crossfade does not keep a clip audible"
-    [Auto-crossfade](#crossfades) shapes an overlap that is already playing both, so audio fades into audio instead of both running flat. It cannot keep a covered clip alive on its own. If you want both audio clips to sound across an overlap, **Play Through Overlap** is the switch that does it; the crossfade only decides how they meet.
+    Auto-crossfade shapes an overlap that is already playing both, so audio fades into audio instead of both running flat. It cannot keep a covered clip alive on its own. **Play Through Overlap** is the switch that decides whether both sound; the crossfade only decides how they meet.
 
 ## Flatten MIDI Loop
 

--- a/manual/docs/clips.md
+++ b/manual/docs/clips.md
@@ -131,6 +131,22 @@ Disabling a clip removes it from playback without deleting it. Right-click a cli
 
 The enabled state is per-clip: disabling one member of a [link group](#linked-ghost-clips) does not silence its ghost siblings.
 
+## Overlapping clips
+
+Arrangement clips stack rather than erase each other. Drag a clip onto one that is already there and the clip underneath keeps its position and its full contents; it is covered, not trimmed. Move the covering clip away again and the material underneath comes back on its own, because what a clip plays is worked out from the lane each time rather than stored.
+
+The clip on top owns the span it covers, and the one underneath plays what is left. A clip covered end to end plays nothing while staying exactly where it is. Which clip is on top is set when you place or move it, so the most recently moved clip wins, and the lane draws in that same order: what you see stacked is what you hear.
+
+Two cases deliberately do not occlude:
+
+- A partial overlap between two audio clips that both have [auto-crossfade](#crossfades) on. That overlap is a crossfade, and both clips sound across it.
+- A clip you disabled by hand, which covers nothing because it is already silent.
+
+**Play through an overlap.** A clip can be set to sound even where something covers it. New clips take their starting value from **New clips play through overlaps** in [Preferences](interface/preferences.md); changing that preference leaves existing clips alone.
+
+!!! note "Dropping a clip inside a longer one"
+    A clip dropped entirely within a longer one splits that clip into three pieces, because a head and a tail cannot be a single audible span. The slice under the drop is kept as a clip of its own rather than deleted, so it is simply covered: silent while the drop sits on it, audible again the moment the drop moves away. The seams stay visible, but no material is lost.
+
 ## Flatten MIDI Loop
 
 When a MIDI clip is looping, right-click it and choose **Flatten MIDI Loop** to write the repetitions out as real notes. The loop cycles (including any offset phase) are baked into actual MIDI across the clip's full length, looping is switched off, and the offset resets to zero. The clip stays a MIDI clip in place, ready for per-note editing in the [Piano Roll](panels/piano-roll.md); the operation is a single undoable step.

--- a/manual/docs/clips.md
+++ b/manual/docs/clips.md
@@ -137,15 +137,23 @@ Arrangement clips stack rather than erase each other. Drag a clip onto one that 
 
 The clip on top owns the span it covers, and the one underneath plays what is left. A clip covered end to end plays nothing while staying exactly where it is. Which clip is on top is set when you place or move it, so the most recently moved clip wins, and the lane draws in that same order: what you see stacked is what you hear.
 
-Two cases deliberately do not occlude:
+Where a cover lands decides what the clip underneath becomes:
 
-- A partial overlap between two audio clips that both have [auto-crossfade](#crossfades) on. That overlap is a crossfade, and both clips sound across it.
-- A clip you disabled by hand, which covers nothing because it is already silent.
+- **Overlapping an edge** shortens it. The audible span pulls in to the edge of the cover, which is a shorter clip rather than a hole in one.
+- **Landing strictly inside it** leaves a hole. The clip keeps its start and end and goes silent across the covered span only. A MIDI clip plays around the hole by dropping the notes that start inside it; an audio clip carries the hole through to playback. Nothing is cut and nothing is split, so the material comes back intact when the cover moves away.
 
-**Play through an overlap.** A clip can be set to sound even where something covers it. New clips take their starting value from **New clips play through overlaps** in [Preferences](interface/preferences.md); changing that preference leaves existing clips alone.
+A clip you disabled by hand covers nothing, because it is already silent. Letting it occlude would silence the clip below on behalf of silence.
 
-!!! note "Dropping a clip inside a longer one"
-    A clip dropped entirely within a longer one splits that clip into three pieces, because a head and a tail cannot be a single audible span. The slice under the drop is kept as a clip of its own rather than deleted, so it is simply covered: silent while the drop sits on it, audible again the moment the drop moves away. The seams stay visible, but no material is lost.
+### Play Through Overlap
+
+To make both clips sound where they overlap, right-click either one and tick **Play Through Overlap**. The lane hatches the shared span to show it is playing both.
+
+Either clip can carry the switch, which matters because the clip you reach for when something goes quiet is the one that went quiet, and that is the one underneath.
+
+New clips take their starting value from **New clips play through overlaps** in [Preferences](interface/preferences.md). Changing that preference leaves existing clips alone.
+
+!!! note "Auto-crossfade does not keep a clip audible"
+    [Auto-crossfade](#crossfades) shapes an overlap that is already playing both, so audio fades into audio instead of both running flat. It cannot keep a covered clip alive on its own. If you want both audio clips to sound across an overlap, **Play Through Overlap** is the switch that does it; the crossfade only decides how they meet.
 
 ## Flatten MIDI Loop
 

--- a/manual/docs/interface/connections.md
+++ b/manual/docs/interface/connections.md
@@ -72,6 +72,8 @@ Underneath the client list is a tail of what has actually been asked for, and ho
 
 MAGDA can be driven by an Open Sound Control surface — a tablet layout, a lighting desk, anything that sends OSC.
 
+MAGDA understands a fixed set of addresses out of the box, so a stock mixer template works with no mapping step. See the [OSC Address Reference](../reference/osc-addresses.md) for what to send and what comes back.
+
 - **Listen for OSC** — Whether the socket is open at all.
 - **Listen on** — **All interfaces (0.0.0.0)** or **This computer only (127.0.0.1)**. OSC has no authentication, so which interfaces answer is the whole of its access control; loopback is the safe default if the surface runs on this machine.
 - **Receive port** — Where MAGDA listens. Committed when the field loses focus, so typing part of a port number does not rebind the socket.

--- a/manual/docs/interface/preferences.md
+++ b/manual/docs/interface/preferences.md
@@ -18,7 +18,6 @@ The dialog is organised into sections; each section is described below.
 - **Panel visibility defaults** — Choose which panels are shown on startup
 - **Behavior settings** — Configure UI interaction preferences
 - **Auto-crossfade new audio clips** - New audio clips overlap into a [crossfade](../clips.md#crossfades) automatically when they meet a neighbour
-- **New clips play through overlaps** - What a new clip starts with when something covers it. Off, the clip on top owns the span it covers and the clip underneath plays only what is left; on, both sound across the overlap. This is only the starting value, so changing it leaves existing clips alone; per clip, right-click and tick **Play Through Overlap**. See [Overlapping clips](../clips.md#overlapping-clips)
 - **New tracks run post-FX after the fader** - The side of the track fader a new track's [post-FX section](../fx-chain.md#post-fx-section) starts on. Existing tracks keep their own setting, which you change from the fader tag on the post-FX panel
 - **Duplicate Loop Range: grow / advance** - When you duplicate the loop range, choose whether the loop grows to cover the copy or advances past it
 - **Auto-hide arrangement scrollbars** — Keep the arrangement scrollbars hidden until you hover near them, for a cleaner workspace

--- a/manual/docs/interface/preferences.md
+++ b/manual/docs/interface/preferences.md
@@ -18,6 +18,7 @@ The dialog is organised into sections; each section is described below.
 - **Panel visibility defaults** — Choose which panels are shown on startup
 - **Behavior settings** — Configure UI interaction preferences
 - **Auto-crossfade new audio clips** - New audio clips overlap into a [crossfade](../clips.md#crossfades) automatically when they meet a neighbour
+- **New clips play through overlaps** - What a new clip starts with when something covers it. Off, the clip on top owns the span it covers and the clip underneath plays only what is left; on, both play. This is the starting value for new clips, so changing it leaves existing ones alone. See [Overlapping clips](../clips.md#overlapping-clips)
 - **New tracks run post-FX after the fader** - The side of the track fader a new track's [post-FX section](../fx-chain.md#post-fx-section) starts on. Existing tracks keep their own setting, which you change from the fader tag on the post-FX panel
 - **Duplicate Loop Range: grow / advance** - When you duplicate the loop range, choose whether the loop grows to cover the copy or advances past it
 - **Auto-hide arrangement scrollbars** — Keep the arrangement scrollbars hidden until you hover near them, for a cleaner workspace

--- a/manual/docs/interface/preferences.md
+++ b/manual/docs/interface/preferences.md
@@ -18,7 +18,7 @@ The dialog is organised into sections; each section is described below.
 - **Panel visibility defaults** — Choose which panels are shown on startup
 - **Behavior settings** — Configure UI interaction preferences
 - **Auto-crossfade new audio clips** - New audio clips overlap into a [crossfade](../clips.md#crossfades) automatically when they meet a neighbour
-- **New clips play through overlaps** - What a new clip starts with when something covers it. Off, the clip on top owns the span it covers and the clip underneath plays only what is left; on, both play. This is the starting value for new clips, so changing it leaves existing ones alone. See [Overlapping clips](../clips.md#overlapping-clips)
+- **New clips play through overlaps** - What a new clip starts with when something covers it. Off, the clip on top owns the span it covers and the clip underneath plays only what is left; on, both sound across the overlap. This is only the starting value, so changing it leaves existing clips alone; per clip, right-click and tick **Play Through Overlap**. See [Overlapping clips](../clips.md#overlapping-clips)
 - **New tracks run post-FX after the fader** - The side of the track fader a new track's [post-FX section](../fx-chain.md#post-fx-section) starts on. Existing tracks keep their own setting, which you change from the fader tag on the post-FX panel
 - **Duplicate Loop Range: grow / advance** - When you duplicate the loop range, choose whether the loop grows to cover the copy or advances past it
 - **Auto-hide arrangement scrollbars** — Keep the arrangement scrollbars hidden until you hover near them, for a cleaner workspace

--- a/manual/docs/reference/osc-addresses.md
+++ b/manual/docs/reference/osc-addresses.md
@@ -1,0 +1,82 @@
+# OSC Address Reference
+
+MAGDA answers a fixed set of OSC addresses out of the box. A stock TouchOSC mixer template drives it with no mapping step and no learn gesture: point the surface at MAGDA's receive port and the addresses below already mean something.
+
+Turning the socket on, choosing which interfaces answer, and setting the receive and feedback ports all happen in **Settings → Connections → OSC**. See [Connections](../interface/connections.md#osc) for those, and for the status area that tells you which surfaces MAGDA has heard from.
+
+## Transport
+
+| Address | Argument | Meaning |
+|---|---|---|
+| `/magda/transport/play` | none, or non-zero | Start playback |
+| `/magda/transport/stop` | none, or non-zero | Stop playback |
+| `/magda/transport/record` | `0`/`1`, or none | Recording on or off; no argument flips it |
+| `/magda/transport/loop` | `0`/`1`, or none | Loop on or off; no argument flips it |
+| `/magda/transport/tempo` | float BPM | Set the tempo |
+| `/magda/transport/position` | float beats | Locate to a position |
+| `/magda/transport/seek` | float beats | Move by this much, clamped at zero |
+| `/magda/transport/seek/bars` | int bars | Move by this many bars, meter-aware |
+
+## Tracks
+
+| Address | Argument | Meaning |
+|---|---|---|
+| `/magda/track/{n}/volume` | float 0-1 | Track fader |
+| `/magda/track/{n}/pan` | float 0-1 | Pan, `0.5` centre |
+| `/magda/track/{n}/mute` | `0`/`1`, or none | Mute on or off; no argument flips it |
+| `/magda/track/{n}/solo` | `0`/`1`, or none | Solo on or off; no argument flips it |
+| `/magda/track/{n}/send/{m}` | float 0-1 | Send level |
+
+## Master and focused device
+
+| Address | Argument | Meaning |
+|---|---|---|
+| `/magda/master/volume` | float 0-1 | Master fader |
+| `/magda/master/pan` | float 0-1 | Master pan |
+| `/magda/focused/macro/{k}` | float 0-1 | Macro of the [focused device](../modulation/macros.md) |
+
+## How the numbers work
+
+`n`, `m` and `k` are all 1-based, the way surface templates and mixer strips are numbered.
+
+**`n` is a mixer position, not a track ID.** Track IDs survive a reload but go sparse: delete tracks 2 and 3 and the remaining ones are 1, 4 and 5. A template addressing eight strips needs eight dense numbers, so `n` counts positions in the mixer's visible track order instead. A position with no track behind it is ignored, which means a sixteen-strip template on an eight-track project drives the eight that exist rather than failing.
+
+The ceilings are 128 tracks, 8 sends per track, and 16 macros. A number past its ceiling is ignored rather than clamped, so a misconfigured template cannot land a fader on the wrong track.
+
+## Strict parsing
+
+Addresses are matched exactly. These are all rejected rather than interpreted:
+
+- An OSC address **pattern** where a number belongs, such as `/magda/track/*/volume`. Patterns are a real part of the protocol, and reading one as an index would drive every track at once when the template author meant one.
+- A **leading zero**, such as `/magda/track/03/volume`, which would otherwise be a second spelling of strip 3 that could drift apart from the first.
+- An **out-of-range** index, or a **trailing component** after a complete address.
+
+Nothing here is an error: an address this list does not cover is simply passed to the binding layer instead.
+
+## Buttons and toggles
+
+Surfaces send both a press and a release down the same address, so the two are told apart by argument:
+
+- **Triggers** (`play`, `stop`) act on a press. No argument or a non-zero one fires; a zero argument is the release half and does nothing. Without that rule, letting go of Play would stop the transport.
+- **Toggles** (`record`, `loop`, `mute`, `solo`) take `0` or `1` as a state. Sent with no argument at all they flip whatever the state currently is, so a momentary button works as well as a latching one.
+
+`seek` and `seek/bars` are distances rather than positions, and they accumulate: two rewind presses move two bars.
+
+## Feedback
+
+MAGDA echoes its own state back so a surface shows the right values instead of whatever its template defaulted to. Set the feedback port in [Connections](../interface/connections.md#osc). There is no destination address to configure: MAGDA answers whoever is talking to it.
+
+What gets sent:
+
+- **On change** - track and master volume, pan, mute, solo and sends, and the focused device's macros.
+- **Sampled at 30 Hz** - play, record, loop, tempo and the playhead.
+
+A value only goes out when it differs from what was last sent, and an address is sent at most once per flush however often it changed in between, so a moving fader does not flood the surface.
+
+A value the surface just sent is not echoed straight back, which would fight a motorised control. The one send you do get after a gesture ends is the confirmation of what MAGDA rounded your value to.
+
+A full snapshot is sent when the feedback destination changes, and when inbound traffic resumes after five seconds of silence. Large snapshots are spread over consecutive flushes rather than dropped, so a sixty-track project takes a few ticks to populate rather than arriving incomplete.
+
+## Beyond the fixed namespace
+
+The addresses above cover a mixer surface. Binding an arbitrary OSC address to any parameter MAGDA can name is a separate mechanism layered on top, and it has no interface yet, so it is not something you can set up from the app in this release.

--- a/manual/mkdocs.yml
+++ b/manual/mkdocs.yml
@@ -105,6 +105,7 @@ nav:
   - Reference:
       - DSL Reference: reference/dsl.md
       - Controller Profile Format: reference/controller-profile-format.md
+      - OSC Address Reference: reference/osc-addresses.md
       - Lua Scripting: reference/lua-scripting.md
       - Keyboard Shortcuts: reference/keyboard-shortcuts.md
       - File Formats: reference/file-formats.md


### PR DESCRIPTION
Manual coverage for what landed in 0.19. I walked all 77 commits since `v0.18.0` and checked each user-facing one against the manual, rather than guessing at what looked new.

## Two real gaps

**OSC had settings but no namespace.** `connections.md` tells you how to open the socket, which interfaces answer, and what the status area means, then stops. Nothing said what to actually *send*. The fixed address space is the entire reason a stock TouchOSC template drives MAGDA with no mapping step, and it was documented only in `OscAddress.hpp`.

New page, `reference/osc-addresses.md`:

- The address tables (transport, tracks, master, focused-device macros)
- Why `n` is a mixer position and not a `TrackId`, and what happens when a template addresses more strips than the project has
- Strict parsing: patterns, leading zeros, out-of-range and trailing components are rejected, and why each one would be worse if it were coerced
- The trigger vs toggle argument convention, which is what stops releasing Play from stopping the transport
- Feedback: what is published on change against what is sampled at 30 Hz, echo suppression, and when a full snapshot fires

**Clip layering was undocumented.** Clips stopped erasing each other in #2005, which a user meets the first time they drag one clip onto another. New `## Overlapping clips` section in `clips.md` covering stacking and stack order, the two cases that deliberately do not occlude, the three-way split when a clip is dropped inside a longer one, and the per-clip play-through setting. The preference that appears to seed it, **New clips play through overlaps**, turned out not to be wired up at all, so it is not documented here. See the follow-up commits below.

## Checked, already covered

Worth stating so the gap list reads as deliberate:

- **Menus.** All 81 menu labels in `MenuManager.cpp` resolve to text present in `menus.md`, including the new **Connections** entry. Verified by diffing the translation keys against the page, not by eye.
- **Connections / MCP / WebSocket** shipped with `connections.md` in #2154.
- **Pre/post-fader toggle** (#2099) and **relative transport seek** (#2092) both came with their manual entries.
- The rest of the 0.19 log is native-engine internals, remote-API plumbing, test corpora and CI, none of which surfaces in the manual.

## Deliberately not documented

The **OSC binding layer** (#2062). `BindingSourceKind::Osc` exists, `OscRouter` and the feedback projector both read it, but nothing in the UI reaches it. The page says so in one line rather than describing something a user cannot set up. Worth a follow-up issue if the UI is planned.

## Verification

`mkdocs build --strict` passes. Anchors confirmed in the rendered output: `#overlapping-clips` and `#crossfades` in `clips/`, `#osc` in `interface/connections/`, and the new reference page renders its address tables.

No screenshots added, per the manual's convention.



## Follow-up commits on this branch

Two corrections after review, both from checking the code rather than the commit messages:

**The overlap section described an intermediate behaviour.** I sourced it from #2005's commit message, and two of its statements were superseded later in that same branch. Auto-crossfade is not an exception to occlusion (`ClipOcclusion.hpp` says it "cannot keep a clip alive on its own"), and a clip dropped inside a longer one leaves a hole rather than splitting into three (`resolveOverlaps no longer splits one`). Rewritten from `ClipOcclusion.cpp`.

**The preference is inert.** `Config::getClipOverlapPlaysBoth()` is read in exactly one place: the Preferences dialog setting its own toggle from it. No clip-creation path consults it and `ClipInfo::overlapPlaysBoth` defaults to `false`, so the toggle changes nothing. Filed as #2160. The bullet is out of `preferences.md` until it works, rather than shipping a manual that describes a dead control.

What the page documents instead is what does happen: creating a crossfade sets play-through on both clips, because a fade needs both sides sounding to have anything to fade into.
