### PR TITLE
Subtract the dry signal a device or rack was handed (#2136)

### DIFF
--- a/docs/architecture/native-engine.md
+++ b/docs/architecture/native-engine.md
@@ -200,21 +200,30 @@ flowchart TD
     L --> M["12 Output"]
 ```
 
-Two things that look like clutter and are not:
+Three things that look like clutter and are not:
 
-**An ordinary device is three ops.** Its processing, its gain trim and its meter tap are
-separate, so the differ can carry, rebuild and crossfade each independently. A device whose trim
-changed does not rebuild.
+**An ordinary device is four ops.** Its processing, its delta, its gain trim and its meter tap
+are separate, so the differ can carry, rebuild and crossfade each independently. A device whose
+trim changed does not rebuild.
 
-Three is the usual shape rather than a rule: an analysis device is a transparent passthrough
-with no trim and no tap, so it compiles to a bare process op, and a compile with device meters
-switched off emits no meter ops at all. A device soloing its delta gets a fourth, a `Subtract`
-between the processing and the trim, reading the device's output and the dry signal the device
-was handed. A rack soloing its delta gets the same op one level up, around its own fader. The
-dry edge is taken in front of whatever aligned the device's own input, so the alignment it needs
-is an ordinary `Delay` on the subtract's own fan-in rather than a second latency concept: what
-that delay resolves to is the whole distance the wet path travelled, the processing's latency
-included.
+Four is the usual shape rather than a rule: an analysis device is a transparent passthrough with
+no trim, no tap and no difference to take, so it compiles to a bare process op, and a compile
+with device meters switched off emits no meter ops at all.
+
+**The delta is a `Subtract`,** between the processing and the trim, reading the device's output
+and the dry signal the device was handed; a rack gets the same op one level up, around its own
+fader. The dry edge is taken in front of whatever aligned the device's own input, so the
+alignment it needs is an ordinary `Delay` on the subtract's own fan-in rather than a second
+latency concept: what that delay resolves to is the whole distance the wet path travelled, the
+processing's latency included.
+
+It is in the plan whether or not anything is soloing that delta, and what the model decides is
+only whether the subtraction happens (`OpValue::subtractsDry`). The delay on the dry edge is a
+delay line, and a delay line is history: one that came into being at the moment the button was
+pressed would hand back its own length in silence, so a device with any real latency would leak
+its wet signal for that long and then step. The current engine keeps the same line running for
+the same reason. Delta solo is therefore a value like mute, not structure like bypass, and
+turning it on compiles nothing.
 
 **Every op has a key.** `T1/D7:deviceGain` is the model location plus the structural role, and
 `validatePlan` proves keys are unique. That key is how a new plan recognises an op in the old

--- a/docs/architecture/native-engine.md
+++ b/docs/architecture/native-engine.md
@@ -208,15 +208,21 @@ changed does not rebuild.
 
 Three is the usual shape rather than a rule: an analysis device is a transparent passthrough
 with no trim and no tap, so it compiles to a bare process op, and a compile with device meters
-switched off emits no meter ops at all.
+switched off emits no meter ops at all. A device soloing its delta gets a fourth, a `Subtract`
+between the processing and the trim, reading the device's output and the dry signal the device
+was handed. A rack soloing its delta gets the same op one level up, around its own fader. The
+dry edge is taken in front of whatever aligned the device's own input, so the alignment it needs
+is an ordinary `Delay` on the subtract's own fan-in rather than a second latency concept: what
+that delay resolves to is the whole distance the wet path travelled, the processing's latency
+included.
 
 **Every op has a key.** `T1/D7:deviceGain` is the model location plus the structural role, and
 `validatePlan` proves keys are unique. That key is how a new plan recognises an op in the old
 one, which is the whole of section 4.
 
 The op vocabulary is deliberately small: `ClipAudio`, `ClipMidi`, `AudioInput`, `MidiInput`,
-`Device`, `MixAudio`, `MergeMidi`, `Delay`, `Crossfade`, `Gain`, `Fader`, `SendTap`, `Meter`,
-`Output`.
+`Device`, `MixAudio`, `MergeMidi`, `Subtract`, `Delay`, `Crossfade`, `Gain`, `Fader`, `SendTap`,
+`Meter`, `ModSource`, `Output`.
 
 ---
 

--- a/magda/engine/exec/PlanExecutor.cpp
+++ b/magda/engine/exec/PlanExecutor.cpp
@@ -1157,6 +1157,24 @@ void PlanExecutor::renderOp(OpId id, const OpValue& published, const BlockInfo& 
             break;
         }
 
+        case OpKind::Subtract: {
+            // What the processing added: its output, minus the dry signal it
+            // was handed, which the compiler has already aligned to it. An
+            // unconnected dry side leaves the output alone, the way every other
+            // op here treats a slot its arity declares and its plan did not
+            // fill.
+            auto out = audioOut(id, 0, numSamples);
+            if (value.silent || !op.inputs[0].valid()) {
+                out.clear();
+                break;
+            }
+            if (!writesInPlace(i))
+                out.copyFrom(audioIn(op.inputs[0], numSamples));
+            if (op.inputs[1].valid())
+                out.subtract(audioIn(op.inputs[1], numSamples));
+            break;
+        }
+
         case OpKind::Delay: {
             // A delay runs whatever the value layer says about the ops
             // around it. One that stopped writing while its chain was

--- a/magda/engine/exec/PlanExecutor.cpp
+++ b/magda/engine/exec/PlanExecutor.cpp
@@ -1159,10 +1159,12 @@ void PlanExecutor::renderOp(OpId id, const OpValue& published, const BlockInfo& 
 
         case OpKind::Subtract: {
             // What the processing added: its output, minus the dry signal it
-            // was handed, which the compiler has already aligned to it. An
-            // unconnected dry side leaves the output alone, the way every other
-            // op here treats a slot its arity declares and its plan did not
-            // fill.
+            // was handed, which the compiler has already aligned to it. Whether
+            // anything is taken away is the value layer's to say, and while it
+            // says no this is a passthrough, one the buffer assignment has
+            // usually already let write in place. An unconnected dry side
+            // leaves the output alone too, the way every other op here treats a
+            // slot its arity declares and its plan did not fill.
             auto out = audioOut(id, 0, numSamples);
             if (value.silent || !op.inputs[0].valid()) {
                 out.clear();
@@ -1170,7 +1172,7 @@ void PlanExecutor::renderOp(OpId id, const OpValue& published, const BlockInfo& 
             }
             if (!writesInPlace(i))
                 out.copyFrom(audioIn(op.inputs[0], numSamples));
-            if (op.inputs[1].valid())
+            if (value.subtractsDry && op.inputs[1].valid())
                 out.subtract(audioIn(op.inputs[1], numSamples));
             break;
         }

--- a/magda/engine/exec/PlanLayout.cpp
+++ b/magda/engine/exec/PlanLayout.cpp
@@ -78,6 +78,10 @@ std::optional<std::size_t> inPlaceInputOf(const PlanOp& op) {
         case OpKind::SendTap:
         case OpKind::Meter:
         case OpKind::Fader:
+        // A difference is taken in the buffer holding the signal it measures.
+        // The dry side it subtracts is a different port, and one op reading a
+        // port is what lets that port be written over at all.
+        case OpKind::Subtract:
             return op.inputs.empty() || !op.inputs.front().valid() ? std::nullopt
                                                                    : std::optional<std::size_t>(0);
 

--- a/magda/engine/exec/PlanValues.cpp
+++ b/magda/engine/exec/PlanValues.cpp
@@ -377,6 +377,32 @@ void Resolver::resolveOp(OpId id, OpValue& value) {
             break;
         }
 
+        // The two ops the model toggles rather than recompiles. The subtract
+        // and the delay feeding it are in every plan, so turning delta solo on
+        // is a value away and the dry line has been running all along; what
+        // happens here is only whether anything is taken off the wet path.
+        case OpRole::DeviceDelta: {
+            const auto* device = findDevice(*track, key);
+            if (device == nullptr) {
+                report(id, "no device " + std::to_string(key.deviceId) +
+                               " in the model, leaving its delta unheard");
+                break;
+            }
+            value.subtractsDry = device->deltaSolo;
+            break;
+        }
+
+        case OpRole::RackDelta: {
+            const auto* rack = findRack(*track, key.rackId);
+            if (rack == nullptr) {
+                report(id, "no rack " + std::to_string(key.rackId) +
+                               " in the model, leaving its delta unheard");
+                break;
+            }
+            value.subtractsDry = rack->deltaSolo;
+            break;
+        }
+
         case OpRole::RackChainFader: {
             const auto* rack = findRack(*track, key.rackId);
             const auto* chain = rack == nullptr ? nullptr : findChain(*rack, key.chainId);
@@ -429,12 +455,10 @@ void Resolver::resolveOp(OpId id, OpValue& value) {
         case OpRole::TrackAudioInput:
         case OpRole::TrackMidiInput:
         case OpRole::DeviceProcess:
-        case OpRole::DeviceDelta:
         case OpRole::DeviceMeter:
         case OpRole::ChainMidiMerge:
         case OpRole::RackMix:
         case OpRole::RackMidiMix:
-        case OpRole::RackDelta:
         case OpRole::TrackMeter:
         // A modulation tap reads what reached it and has no value of its own.
         // Not even a mute: a modifier following a track is following what that

--- a/magda/engine/exec/PlanValues.cpp
+++ b/magda/engine/exec/PlanValues.cpp
@@ -419,9 +419,9 @@ void Resolver::resolveOp(OpId id, OpValue& value) {
             break;
         }
 
-        // Sources, sums, merges, devices, meters and the output carry no value
-        // of their own: what they render comes from their bindings, and what
-        // they pass on is whatever reached them.
+        // Sources, sums, merges, differences, devices, meters and the output
+        // carry no value of their own: what they render comes from their
+        // bindings, and what they pass on is whatever reached them.
         case OpRole::ClipAudio:
         case OpRole::ClipMidi:
         case OpRole::LiveAudioInput:
@@ -429,10 +429,12 @@ void Resolver::resolveOp(OpId id, OpValue& value) {
         case OpRole::TrackAudioInput:
         case OpRole::TrackMidiInput:
         case OpRole::DeviceProcess:
+        case OpRole::DeviceDelta:
         case OpRole::DeviceMeter:
         case OpRole::ChainMidiMerge:
         case OpRole::RackMix:
         case OpRole::RackMidiMix:
+        case OpRole::RackDelta:
         case OpRole::TrackMeter:
         // A modulation tap reads what reached it and has no value of its own.
         // Not even a mute: a modifier following a track is following what that
@@ -446,6 +448,7 @@ void Resolver::resolveOp(OpId id, OpValue& value) {
         case OpRole::MergeInputDelay:
         case OpRole::DeviceInputDelay:
         case OpRole::FaderInputDelay:
+        case OpRole::SubtractInputDelay:
         case OpRole::EdgeCrossfade:
             break;
     }

--- a/magda/engine/exec/PlanValues.hpp
+++ b/magda/engine/exec/PlanValues.hpp
@@ -43,6 +43,15 @@ struct OpValue {
     /// mute or by a sibling's solo) gates the chain's MIDI as well as its
     /// audio, and no gain can silence a MIDI stream.
     bool silent = false;
+
+    /// Whether a Subtract takes its dry side away, which is whether the device
+    /// or rack it is keyed to is soloing its delta. Its own field rather than a
+    /// gain on the dry edge, because the safe reading of a value that does not
+    /// apply is "unchanged", and for a difference that is taking nothing away
+    /// rather than taking all of it. kUnityValue would otherwise mean every
+    /// delta in the plan, which for a device that passes its input through is
+    /// the whole track going quiet.
+    bool subtractsDry = false;
 };
 
 /**

--- a/magda/engine/plan/PlanCompiler.cpp
+++ b/magda/engine/plan/PlanCompiler.cpp
@@ -213,6 +213,20 @@ class Compiler {
     ChainSignal emitDevice(const DeviceInfo& device, const ChainSite& site, ChainSignal signal);
     ChainSignal emitRack(const RackInfo& rack, const ChainSite& site, ChainSignal signal);
 
+    /// Delta solo: @p wet minus @p dry, which is what the device or rack the
+    /// key names added to the signal. Both sides go through alignInputs, so
+    /// the dry edge meets the wet one through the same PDC delay every other
+    /// fan-in uses rather than through a second latency concept. What that
+    /// delay resolves to is the whole distance the wet path travelled, the
+    /// processing's own latency included.
+    PortRef emitDelta(const OpKey& key, PortRef wet, PortRef dry);
+
+    /// The same thing around a rack instance, or @p wet where the rack is not
+    /// soloing its delta. Two call sites, because a rack with no chains still
+    /// has an output of its own to measure: its fader is applied on the wet
+    /// path whether or not there are chains under it.
+    PortRef emitRackDelta(const RackInfo& rack, const ChainSite& site, PortRef wet, PortRef dry);
+
     /// Sums `sources` into one audio port, always through an op so the op's
     /// identity survives sources appearing and disappearing.
     PortRef emitMix(const OpKey& key, const std::vector<PortRef>& sources);
@@ -496,6 +510,26 @@ PortRef Compiler::emitMix(const OpKey& key, const std::vector<PortRef>& sources)
                    0};
 }
 
+PortRef Compiler::emitDelta(const OpKey& key, PortRef wet, PortRef dry) {
+    return PortRef{addOp(OpKind::Subtract, key, alignInputs(key, OpKind::Subtract, {wet, dry}),
+                         {SignalKind::Audio}),
+                   0};
+}
+
+PortRef Compiler::emitRackDelta(const RackInfo& rack, const ChainSite& site, PortRef wet,
+                                PortRef dry) {
+    if (!rack.deltaSolo)
+        return wet;
+
+    // The dry edge the current engine keeps around every rack instance,
+    // delayed to match the wet path. One level up from a device's, and the
+    // same shape: the rack's output, its own volume and pan included, minus
+    // what reached it.
+    const OpKey key{site.trackId,      rack.id, INVALID_CHAIN_ID, INVALID_DEVICE_ID,
+                    OpRole::RackDelta, 0,       site.segment};
+    return emitDelta(key, wet, dry);
+}
+
 std::vector<PortRef> Compiler::alignInputs(const OpKey& key, OpKind kind,
                                            std::vector<PortRef> inputs) {
     // One input is its own maximum, so its compensation is zero in every
@@ -519,6 +553,8 @@ std::vector<PortRef> Compiler::alignInputs(const OpKey& key, OpKind kind,
                 return OpRole::DeviceInputDelay;
             case OpKind::Fader:
                 return OpRole::FaderInputDelay;
+            case OpKind::Subtract:
+                return OpRole::SubtractInputDelay;
             default:
                 jassertfalse;  // nothing else fans in
                 return OpRole::MixInputDelay;
@@ -572,16 +608,6 @@ ChainSignal Compiler::emitDevice(const DeviceInfo& device, const ChainSite& site
 
     if (device.bypassed)
         return signal;
-
-    // Delta solo subtracts the device's dry input, aligned to its output, from
-    // that output. The alignment is a delay like any other now; what is still
-    // missing is the edge carrying the dry signal past the device and the op
-    // that subtracts it.
-    if (device.deltaSolo)
-        diagnose("device " + std::to_string(device.id) + " on track " +
-                 std::to_string(site.trackId) +
-                 ": delta solo needs a dry edge past the device and an op to subtract it, "
-                 "which the plan does not carry yet");
 
     const auto node = routing::makeRoutingNode(device);
 
@@ -639,6 +665,22 @@ ChainSignal Compiler::emitDevice(const DeviceInfo& device, const ChainSite& site
     ChainSignal out;
     out.audio = PortRef{processOp, 0};
 
+    // Delta solo: what the device added, which is its output minus the dry
+    // signal it was handed. The dry edge is that signal rather than the device's
+    // own input slot, which may already carry a delay lining the audio up with a
+    // sidechain: a delay reading a delay would count that edge's compensation
+    // twice, and taken from in front of it the subtract's own delay resolves to
+    // the whole distance instead, the input alignment and the device's latency
+    // together.
+    //
+    // Ahead of the slot's gain and meter, which is where the current engine
+    // subtracts it too: those are MAGDA's own and sit outside the plugin, so
+    // what they trim and report is the delta once there is one.
+    if (device.deltaSolo) {
+        key.role = OpRole::DeviceDelta;
+        out.audio = emitDelta(key, out.audio, signal.audio);
+    }
+
     if (!isTransparentTap(device)) {
         key.role = OpRole::DeviceGain;
         out.audio = PortRef{addOp(OpKind::Gain, key, {out.audio}, {SignalKind::Audio}), 0};
@@ -677,15 +719,6 @@ ChainSignal Compiler::emitRack(const RackInfo& rack, const ChainSite& site, Chai
     // that track is the edge, and collectModulationSources is what puts the
     // source ahead of this rack's own track in the compile order (#2120).
 
-    // Same dry path a device's delta solo needs, one level up: the rack
-    // instance subtracts its own input, aligned to its wet output, from that
-    // output. The current engine keeps a dry edge around every rack instance
-    // for exactly this, and delays it to match the wet path.
-    if (rack.deltaSolo)
-        diagnose("rack " + std::to_string(rack.id) +
-                 ": delta solo needs a dry edge around the rack and an op to subtract it, "
-                 "which the plan does not carry yet");
-
     // A rack with no chains passes signal rather than silence: compiling it to
     // a zero-input mix would silence the track. It is not fully transparent
     // though, because rack volume and pan land on the instance's output gains,
@@ -698,10 +731,9 @@ ChainSignal Compiler::emitRack(const RackInfo& rack, const ChainSite& site, Chai
     if (rack.chains.empty()) {
         const OpKey faderKey{site.trackId,      rack.id, INVALID_CHAIN_ID, INVALID_DEVICE_ID,
                              OpRole::RackFader, 0,       site.segment};
-        return {
-            PortRef{addOp(OpKind::Fader, faderKey, {signal.audio, noInput()}, {SignalKind::Audio}),
-                    0},
-            signal.midi};
+        const PortRef faded{
+            addOp(OpKind::Fader, faderKey, {signal.audio, noInput()}, {SignalKind::Audio}), 0};
+        return {emitRackDelta(rack, site, faded, signal.audio), signal.midi};
     }
 
     std::vector<PortRef> chainAudio;
@@ -765,6 +797,7 @@ ChainSignal Compiler::emitRack(const RackInfo& rack, const ChainSite& site, Chai
     const OpKey faderKey{site.trackId,      rack.id, INVALID_CHAIN_ID, INVALID_DEVICE_ID,
                          OpRole::RackFader, 0,       site.segment};
     out.audio = PortRef{addOp(OpKind::Fader, faderKey, {mixed, noInput()}, {SignalKind::Audio}), 0};
+    out.audio = emitRackDelta(rack, site, out.audio, signal.audio);
 
     if (chainMidi.empty()) {
         out.midi = signal.midi;

--- a/magda/engine/plan/PlanCompiler.cpp
+++ b/magda/engine/plan/PlanCompiler.cpp
@@ -219,13 +219,23 @@ class Compiler {
     /// fan-in uses rather than through a second latency concept. What that
     /// delay resolves to is the whole distance the wet path travelled, the
     /// processing's own latency included.
+    ///
+    /// Emitted whether or not anything is soloing its delta, because the delay
+    /// on the dry edge is a delay line and a delay line is history. One that
+    /// came into being at the moment the button was pressed would hand back
+    /// silence for its whole length, so a device with any real latency would
+    /// leak its wet signal for that long and then step. The current engine
+    /// keeps the same line running for the same reason: PluginNode builds it
+    /// from the plugin's latency alone and writes into it every block, and only
+    /// the read is conditional. So the subtraction is what the model decides,
+    /// and it decides it in the value layer (OpValue::subtractsDry) where a
+    /// toggle costs no recompile at all.
     PortRef emitDelta(const OpKey& key, PortRef wet, PortRef dry);
 
-    /// The same thing around a rack instance, or @p wet where the rack is not
-    /// soloing its delta. Two call sites, because a rack with no chains still
-    /// has an output of its own to measure: its fader is applied on the wet
-    /// path whether or not there are chains under it.
-    PortRef emitRackDelta(const RackInfo& rack, const ChainSite& site, PortRef wet, PortRef dry);
+    /// The same thing around a rack instance. Two call sites, because a rack
+    /// with no chains still has an output of its own to measure: its fader is
+    /// applied on the wet path whether or not there are chains under it.
+    PortRef emitRackDelta(const ChainSite& site, RackId rackId, PortRef wet, PortRef dry);
 
     /// Sums `sources` into one audio port, always through an op so the op's
     /// identity survives sources appearing and disappearing.
@@ -516,17 +526,13 @@ PortRef Compiler::emitDelta(const OpKey& key, PortRef wet, PortRef dry) {
                    0};
 }
 
-PortRef Compiler::emitRackDelta(const RackInfo& rack, const ChainSite& site, PortRef wet,
-                                PortRef dry) {
-    if (!rack.deltaSolo)
-        return wet;
-
+PortRef Compiler::emitRackDelta(const ChainSite& site, RackId rackId, PortRef wet, PortRef dry) {
     // The dry edge the current engine keeps around every rack instance,
     // delayed to match the wet path. One level up from a device's, and the
     // same shape: the rack's output, its own volume and pan included, minus
     // what reached it.
-    const OpKey key{site.trackId,      rack.id, INVALID_CHAIN_ID, INVALID_DEVICE_ID,
-                    OpRole::RackDelta, 0,       site.segment};
+    const OpKey key{site.trackId,      rackId, INVALID_CHAIN_ID, INVALID_DEVICE_ID,
+                    OpRole::RackDelta, 0,      site.segment};
     return emitDelta(key, wet, dry);
 }
 
@@ -665,23 +671,25 @@ ChainSignal Compiler::emitDevice(const DeviceInfo& device, const ChainSite& site
     ChainSignal out;
     out.audio = PortRef{processOp, 0};
 
-    // Delta solo: what the device added, which is its output minus the dry
-    // signal it was handed. The dry edge is that signal rather than the device's
-    // own input slot, which may already carry a delay lining the audio up with a
-    // sidechain: a delay reading a delay would count that edge's compensation
-    // twice, and taken from in front of it the subtract's own delay resolves to
-    // the whole distance instead, the input alignment and the device's latency
-    // together.
+    // A slot is four ops rather than three, and the first of them is where its
+    // delta is taken: the device's output minus the dry signal it was handed.
+    // The dry edge is that signal rather than the device's own input slot,
+    // which may already carry a delay lining the audio up with a sidechain: a
+    // delay reading a delay would count that edge's compensation twice, and
+    // taken from in front of it the subtract's own delay resolves to the whole
+    // distance instead, the input alignment and the device's latency together.
     //
     // Ahead of the slot's gain and meter, which is where the current engine
     // subtracts it too: those are MAGDA's own and sit outside the plugin, so
-    // what they trim and report is the delta once there is one.
-    if (device.deltaSolo) {
+    // what they trim and report is the delta while one is being heard.
+    //
+    // A transparent tap has none of the four: its output is its input, so its
+    // delta is silence by construction and there is nothing for the subtract to
+    // find.
+    if (!isTransparentTap(device)) {
         key.role = OpRole::DeviceDelta;
         out.audio = emitDelta(key, out.audio, signal.audio);
-    }
 
-    if (!isTransparentTap(device)) {
         key.role = OpRole::DeviceGain;
         out.audio = PortRef{addOp(OpKind::Gain, key, {out.audio}, {SignalKind::Audio}), 0};
 
@@ -733,7 +741,7 @@ ChainSignal Compiler::emitRack(const RackInfo& rack, const ChainSite& site, Chai
                              OpRole::RackFader, 0,       site.segment};
         const PortRef faded{
             addOp(OpKind::Fader, faderKey, {signal.audio, noInput()}, {SignalKind::Audio}), 0};
-        return {emitRackDelta(rack, site, faded, signal.audio), signal.midi};
+        return {emitRackDelta(site, rack.id, faded, signal.audio), signal.midi};
     }
 
     std::vector<PortRef> chainAudio;
@@ -797,7 +805,7 @@ ChainSignal Compiler::emitRack(const RackInfo& rack, const ChainSite& site, Chai
     const OpKey faderKey{site.trackId,      rack.id, INVALID_CHAIN_ID, INVALID_DEVICE_ID,
                          OpRole::RackFader, 0,       site.segment};
     out.audio = PortRef{addOp(OpKind::Fader, faderKey, {mixed, noInput()}, {SignalKind::Audio}), 0};
-    out.audio = emitRackDelta(rack, site, out.audio, signal.audio);
+    out.audio = emitRackDelta(site, rack.id, out.audio, signal.audio);
 
     if (chainMidi.empty()) {
         out.midi = signal.midi;

--- a/magda/engine/plan/RenderPlan.cpp
+++ b/magda/engine/plan/RenderPlan.cpp
@@ -25,6 +25,8 @@ int arityOf(OpKind kind) {
             return 2;  // audio, MIDI
         case OpKind::Crossfade:
             return 2;  // the edge as it was, the edge as it is
+        case OpKind::Subtract:
+            return 2;  // the processed signal, the dry signal it is measured against
         case OpKind::MixAudio:
         case OpKind::MergeMidi:
             return -1;  // variadic
@@ -56,6 +58,8 @@ const char* toString(OpKind kind) {
             return "MixAudio";
         case OpKind::MergeMidi:
             return "MergeMidi";
+        case OpKind::Subtract:
+            return "Subtract";
         case OpKind::Delay:
             return "Delay";
         case OpKind::Crossfade:
@@ -92,6 +96,8 @@ const char* toString(OpRole role) {
             return "trackMidiInput";
         case OpRole::DeviceProcess:
             return "deviceProcess";
+        case OpRole::DeviceDelta:
+            return "deviceDelta";
         case OpRole::DeviceGain:
             return "deviceGain";
         case OpRole::DeviceMeter:
@@ -106,6 +112,8 @@ const char* toString(OpRole role) {
             return "rackMidiMix";
         case OpRole::RackFader:
             return "rackFader";
+        case OpRole::RackDelta:
+            return "rackDelta";
         case OpRole::TrackFader:
             return "trackFader";
         case OpRole::TrackMeter:
@@ -126,6 +134,8 @@ const char* toString(OpRole role) {
             return "deviceInputDelay";
         case OpRole::FaderInputDelay:
             return "faderInputDelay";
+        case OpRole::SubtractInputDelay:
+            return "subtractInputDelay";
         case OpRole::EdgeCrossfade:
             return "edgeCrossfade";
     }
@@ -203,6 +213,7 @@ bool isInputDelayRole(OpRole role) {
         case OpRole::MergeInputDelay:
         case OpRole::DeviceInputDelay:
         case OpRole::FaderInputDelay:
+        case OpRole::SubtractInputDelay:
             return true;
         default:
             return false;

--- a/magda/engine/plan/RenderPlan.hpp
+++ b/magda/engine/plan/RenderPlan.hpp
@@ -88,6 +88,7 @@ enum class OpKind : std::uint8_t {
     Device,      ///< a device instance (instrument, effect, MIDI or analysis)
     MixAudio,   ///< ordered sum of audio inputs (summing order is compiled, never scheduling order)
     MergeMidi,  ///< ordered merge of MIDI inputs
+    Subtract,   ///< one audio input minus another: what a delta solo hears
     Delay,      ///< latency compensation on one edge; the sample count is bound at prepare time
     Crossfade,  ///< an edge as it was and as it is, ramped from one to the other
     Gain,       ///< scalar gain
@@ -113,6 +114,7 @@ enum class OpRole : std::uint8_t {
     TrackAudioInput,  ///< sum of everything feeding the track's chain head
     TrackMidiInput,   ///< merge of everything feeding the track's chain head
     DeviceProcess,    ///< the device itself
+    DeviceDelta,      ///< the device's output minus the dry input it was handed
     DeviceGain,       ///< the device slot's gain trim
     DeviceMeter,      ///< the device slot's level tap
     ChainMidiMerge,   ///< raw chain MIDI merged with a device's MIDI output
@@ -120,6 +122,7 @@ enum class OpRole : std::uint8_t {
     RackMix,          ///< sum of a rack's chains
     RackMidiMix,      ///< merge of a rack's chain MIDI outputs
     RackFader,        ///< the rack's output volume + pan
+    RackDelta,        ///< the rack's output minus the dry input it was handed
     TrackFader,       ///< the track fader
     TrackMeter,       ///< the track's post-fader, pre-mute level tap
     TrackMute,        ///< mute and solo, applied after the meter and sidechain tap
@@ -132,10 +135,11 @@ enum class OpRole : std::uint8_t {
     // and OpKey::index says which slot. Two ops of the same kind never share a
     // location, so this is unique wherever the compiler emits it, which
     // validatePlan's key check is what actually guarantees.
-    MixInputDelay,     ///< aligns one input of a MixAudio
-    MergeInputDelay,   ///< aligns one input of a MergeMidi
-    DeviceInputDelay,  ///< aligns one input slot of a Device
-    FaderInputDelay,   ///< aligns one input slot of a Fader
+    MixInputDelay,       ///< aligns one input of a MixAudio
+    MergeInputDelay,     ///< aligns one input of a MergeMidi
+    DeviceInputDelay,    ///< aligns one input slot of a Device
+    FaderInputDelay,     ///< aligns one input slot of a Fader
+    SubtractInputDelay,  ///< aligns one input slot of a Subtract
 
     // A fade sits on one edge, like a delay, so its identity is the op it feeds
     // plus the slot it fills. Unlike a delay it has no role of its own to say

--- a/tests/PlanEditSequence.cpp
+++ b/tests/PlanEditSequence.cpp
@@ -425,6 +425,9 @@ std::string toString(const Edit& edit) {
         case EditKind::BypassDevice:
             out << "bypassDevice D" << edit.deviceId << " " << (edit.flag ? "on" : "off");
             break;
+        case EditKind::DeltaSoloDevice:
+            out << "deltaSoloDevice D" << edit.deviceId << " " << (edit.flag ? "on" : "off");
+            break;
         case EditKind::SetDeviceLatency:
             out << "setDeviceLatency D" << edit.deviceId << " " << edit.latencySamples;
             break;
@@ -557,6 +560,18 @@ bool apply(const Edit& edit, Project& project) {
             if (device.bypassed == edit.flag)
                 return false;
             device.bypassed = edit.flag;
+            return true;
+        }
+
+        case EditKind::DeltaSoloDevice: {
+            DeviceAt at;
+            if (!findDevice(project, edit.deviceId, at))
+                return false;
+
+            auto& device = getDevice((*at.container)[at.index]);
+            if (device.deltaSolo == edit.flag)
+                return false;
+            device.deltaSolo = edit.flag;
             return true;
         }
 
@@ -801,6 +816,7 @@ std::set<TrackId> touched(const Edit& edit, const Project& before) {
         case EditKind::RemoveDevice:
         case EditKind::MoveDevice:
         case EditKind::BypassDevice:
+        case EditKind::DeltaSoloDevice:
         case EditKind::SetDeviceLatency:
             add(ownerOfDevice(edit.deviceId));
             break;
@@ -977,6 +993,7 @@ std::vector<Edit> generate(std::uint64_t seed, int length) {
                 case EditKind::RemoveDevice:
                 case EditKind::MoveDevice:
                 case EditKind::BypassDevice:
+                case EditKind::DeltaSoloDevice:
                 case EditKind::SetDeviceLatency:
                 case EditKind::SetSidechain: {
                     if (inventory.devices.empty())

--- a/tests/PlanEditSequence.hpp
+++ b/tests/PlanEditSequence.hpp
@@ -129,6 +129,7 @@ enum class EditKind : std::uint8_t {
     RemoveDevice,
     MoveDevice,
     BypassDevice,
+    DeltaSoloDevice,
     SetDeviceLatency,
     AddRack,
     RemoveRack,

--- a/tests/PlanGoldenFixtures.cpp
+++ b/tests/PlanGoldenFixtures.cpp
@@ -105,7 +105,7 @@ Fixture bareTrack() {
 Fixture deviceChain() {
     Fixture value;
     value.name = "device-chain";
-    value.covers = "chain order, and the three ops a device slot compiles to";
+    value.covers = "chain order, and the four ops a device slot compiles to";
     value.tracks = {track(1)};
     value.tracks[0].chain.fxChainElements.push_back(makeDeviceElement(effect(7)));
     value.tracks[0].chain.fxChainElements.push_back(makeDeviceElement(effect(8)));
@@ -201,19 +201,22 @@ Fixture sidechain() {
 
 /// Delta solo at both scopes at once (#2136): a device measured against what it
 /// was handed, inside a rack measured against what reached the rack. The device
-/// reports latency, so the dry edges have something to wait for and the goldens
-/// pin what the alignment resolves to as well as where the ops went.
+/// reports latency, so the dry edges have something to wait for and the golden
+/// pins what their alignment resolves to as well as where the ops went.
+///
+/// No flag is set on either, because none is needed: whether a delta is heard
+/// is a value, and a golden is structure. The subtracts and their dry lines are
+/// in every plan so that turning one on does not create the delay line it is
+/// about to read.
 Fixture deltaSolo() {
     Fixture value;
     value.name = "delta-solo";
-    value.covers = "a device and the rack around it, each against the dry signal it was handed";
+    value.covers = "a device's delta inside a rack's, and what their dry edges wait for";
 
-    auto processed = effect(7);
-    processed.deltaSolo = true;
+    const auto processed = effect(7);
 
     auto rack = std::make_unique<RackInfo>();
     rack->id = 5;
-    rack->deltaSolo = true;
     ChainInfo chain;
     chain.id = 10;
     chain.elements.push_back(makeDeviceElement(processed));

--- a/tests/PlanGoldenFixtures.cpp
+++ b/tests/PlanGoldenFixtures.cpp
@@ -199,6 +199,34 @@ Fixture sidechain() {
     return value;
 }
 
+/// Delta solo at both scopes at once (#2136): a device measured against what it
+/// was handed, inside a rack measured against what reached the rack. The device
+/// reports latency, so the dry edges have something to wait for and the goldens
+/// pin what the alignment resolves to as well as where the ops went.
+Fixture deltaSolo() {
+    Fixture value;
+    value.name = "delta-solo";
+    value.covers = "a device and the rack around it, each against the dry signal it was handed";
+
+    auto processed = effect(7);
+    processed.deltaSolo = true;
+
+    auto rack = std::make_unique<RackInfo>();
+    rack->id = 5;
+    rack->deltaSolo = true;
+    ChainInfo chain;
+    chain.id = 10;
+    chain.elements.push_back(makeDeviceElement(processed));
+    rack->chains.push_back(std::move(chain));
+
+    value.tracks = {track(1)};
+    value.tracks[0].chain.fxChainElements.push_back(ChainElement{std::move(rack)});
+    value.master = master();
+    value.options = withoutMeters();
+    value.deviceLatency = {{deviceAt(1, 7, 5, 10), 64}};
+    return value;
+}
+
 Fixture sectionLocalDeviceIds() {
     Fixture value;
     value.name = "section-local-device-ids";
@@ -442,6 +470,7 @@ std::vector<Fixture> planFixtures() {
     fixtures.push_back(cascadedLatency());
     fixtures.push_back(rackChains());
     fixtures.push_back(sidechain());
+    fixtures.push_back(deltaSolo());
     fixtures.push_back(sectionLocalDeviceIds());
     fixtures.push_back(groupRouting());
     fixtures.push_back(parameterLinks());

--- a/tests/goldens/plan/cascaded-latency.txt
+++ b/tests/goldens/plan/cascaded-latency.txt
@@ -5,58 +5,76 @@
 
 == plan ==
 magda-render-plan v1
-ops=23 outputs=1
+ops=32 outputs=1
 [  0] ClipAudio   det   T1:clipAudio                   in=-                out=audio       deps=0
 [  1] MixAudio    det   T1:trackAudioInput             in=0:0              out=audio       deps=1
 [  2] Device      det   T1/D7:deviceProcess            in=1:0,-,-          out=audio       deps=1
-[  3] Gain        det   T1/D7:deviceGain               in=2:0              out=audio       deps=1
-[  4] Device      det   T1/D8:deviceProcess            in=3:0,-,-          out=audio       deps=1
-[  5] Gain        det   T1/D8:deviceGain               in=4:0              out=audio       deps=1
-[  6] Fader       det   T1:trackFader                  in=5:0,-            out=audio       deps=1
-[  7] SendTap     det   T1:sendTap                     in=6:0              out=audio       deps=1
-[  8] Meter       det   T1:trackMeter                  in=6:0              out=audio       deps=1
-[  9] Gain        det   T1:trackMute                   in=8:0              out=audio       deps=1
-[ 10] MixAudio    det   T2:trackAudioInput             in=7:0              out=audio       deps=1
-[ 11] Device      det   T2/D9:deviceProcess            in=10:0,-,-         out=audio       deps=1
-[ 12] Gain        det   T2/D9:deviceGain               in=11:0             out=audio       deps=1
-[ 13] Fader       det   T2:trackFader                  in=12:0,-           out=audio       deps=1
-[ 14] Meter       det   T2:trackMeter                  in=13:0             out=audio       deps=1
-[ 15] Gain        det   T2:trackMute                   in=14:0             out=audio       deps=1
-[ 16] Delay       det   T-2:mixInputDelay              in=9:0              out=audio       deps=1
-[ 17] Delay       det   T-2:mixInputDelay#1            in=15:0             out=audio       deps=1
-[ 18] MixAudio    det   T-2:trackAudioInput            in=16:0,17:0        out=audio       deps=2
-[ 19] Fader       det   T-2:trackFader                 in=18:0,-           out=audio       deps=1
-[ 20] Meter       det   T-2:trackMeter                 in=19:0             out=audio       deps=1
-[ 21] Gain        det   T-2:trackMute                  in=20:0             out=audio       deps=1
-[ 22] Output      det   T-2:hardwareOutput             in=21:0             out=-           deps=1
+[  3] Delay       det   T1/D7:subtractInputDelay       in=2:0              out=audio       deps=1
+[  4] Delay       det   T1/D7:subtractInputDelay#1     in=1:0              out=audio       deps=1
+[  5] Subtract    det   T1/D7:deviceDelta              in=3:0,4:0          out=audio       deps=2
+[  6] Gain        det   T1/D7:deviceGain               in=5:0              out=audio       deps=1
+[  7] Device      det   T1/D8:deviceProcess            in=6:0,-,-          out=audio       deps=1
+[  8] Delay       det   T1/D8:subtractInputDelay       in=7:0              out=audio       deps=1
+[  9] Delay       det   T1/D8:subtractInputDelay#1     in=6:0              out=audio       deps=1
+[ 10] Subtract    det   T1/D8:deviceDelta              in=8:0,9:0          out=audio       deps=2
+[ 11] Gain        det   T1/D8:deviceGain               in=10:0             out=audio       deps=1
+[ 12] Fader       det   T1:trackFader                  in=11:0,-           out=audio       deps=1
+[ 13] SendTap     det   T1:sendTap                     in=12:0             out=audio       deps=1
+[ 14] Meter       det   T1:trackMeter                  in=12:0             out=audio       deps=1
+[ 15] Gain        det   T1:trackMute                   in=14:0             out=audio       deps=1
+[ 16] MixAudio    det   T2:trackAudioInput             in=13:0             out=audio       deps=1
+[ 17] Device      det   T2/D9:deviceProcess            in=16:0,-,-         out=audio       deps=1
+[ 18] Delay       det   T2/D9:subtractInputDelay       in=17:0             out=audio       deps=1
+[ 19] Delay       det   T2/D9:subtractInputDelay#1     in=16:0             out=audio       deps=1
+[ 20] Subtract    det   T2/D9:deviceDelta              in=18:0,19:0        out=audio       deps=2
+[ 21] Gain        det   T2/D9:deviceGain               in=20:0             out=audio       deps=1
+[ 22] Fader       det   T2:trackFader                  in=21:0,-           out=audio       deps=1
+[ 23] Meter       det   T2:trackMeter                  in=22:0             out=audio       deps=1
+[ 24] Gain        det   T2:trackMute                   in=23:0             out=audio       deps=1
+[ 25] Delay       det   T-2:mixInputDelay              in=15:0             out=audio       deps=1
+[ 26] Delay       det   T-2:mixInputDelay#1            in=24:0             out=audio       deps=1
+[ 27] MixAudio    det   T-2:trackAudioInput            in=25:0,26:0        out=audio       deps=2
+[ 28] Fader       det   T-2:trackFader                 in=27:0,-           out=audio       deps=1
+[ 29] Meter       det   T-2:trackMeter                 in=28:0             out=audio       deps=1
+[ 30] Gain        det   T-2:trackMute                  in=29:0             out=audio       deps=1
+[ 31] Output      det   T-2:hardwareOutput             in=30:0             out=-           deps=1
 ready=0
 
 == layout ==
 magda-plan-layout v1
-audioSlots=3 midiSlots=0 outputLatency=176
+audioSlots=5 midiSlots=0 outputLatency=176
 [  0] ClipAudio   T1:clipAudio                   lat=0       ports=a0
 [  1] MixAudio    T1:trackAudioInput             lat=0       ports=a0          inplace
-[  2] Device      T1/D7:deviceProcess            lat=32      ports=a0          inplace
-[  3] Gain        T1/D7:deviceGain               lat=32      ports=a0          inplace
-[  4] Device      T1/D8:deviceProcess            lat=160     ports=a0          inplace
-[  5] Gain        T1/D8:deviceGain               lat=160     ports=a0          inplace
-[  6] Fader       T1:trackFader                  lat=160     ports=a0          inplace
-[  7] SendTap     T1:sendTap                     lat=160     ports=a1
-[  8] Meter       T1:trackMeter                  lat=160     ports=a2
-[  9] Gain        T1:trackMute                   lat=160     ports=a2          inplace
-[ 10] MixAudio    T2:trackAudioInput             lat=160     ports=a1          inplace
-[ 11] Device      T2/D9:deviceProcess            lat=176     ports=a1          inplace
-[ 12] Gain        T2/D9:deviceGain               lat=176     ports=a1          inplace
-[ 13] Fader       T2:trackFader                  lat=176     ports=a1          inplace
-[ 14] Meter       T2:trackMeter                  lat=176     ports=a1          inplace
-[ 15] Gain        T2:trackMute                   lat=176     ports=a1          inplace
-[ 16] Delay       T-2:mixInputDelay              lat=176     ports=a2          hold=16 inplace
-[ 17] Delay       T-2:mixInputDelay#1            lat=176     ports=a1          hold=0 elided
-[ 18] MixAudio    T-2:trackAudioInput            lat=176     ports=a2          inplace
-[ 19] Fader       T-2:trackFader                 lat=176     ports=a2          inplace
-[ 20] Meter       T-2:trackMeter                 lat=176     ports=a2          inplace
-[ 21] Gain        T-2:trackMute                  lat=176     ports=a2          inplace
-[ 22] Output      T-2:hardwareOutput             lat=-       ports=-
+[  2] Device      T1/D7:deviceProcess            lat=32      ports=a1
+[  3] Delay       T1/D7:subtractInputDelay       lat=32      ports=a1          hold=0 elided
+[  4] Delay       T1/D7:subtractInputDelay#1     lat=32      ports=a2          hold=32
+[  5] Subtract    T1/D7:deviceDelta              lat=32      ports=a1          inplace
+[  6] Gain        T1/D7:deviceGain               lat=32      ports=a1          inplace
+[  7] Device      T1/D8:deviceProcess            lat=160     ports=a0
+[  8] Delay       T1/D8:subtractInputDelay       lat=160     ports=a0          hold=0 elided
+[  9] Delay       T1/D8:subtractInputDelay#1     lat=160     ports=a2          hold=128
+[ 10] Subtract    T1/D8:deviceDelta              lat=160     ports=a0          inplace
+[ 11] Gain        T1/D8:deviceGain               lat=160     ports=a0          inplace
+[ 12] Fader       T1:trackFader                  lat=160     ports=a0          inplace
+[ 13] SendTap     T1:sendTap                     lat=160     ports=a1
+[ 14] Meter       T1:trackMeter                  lat=160     ports=a2
+[ 15] Gain        T1:trackMute                   lat=160     ports=a2          inplace
+[ 16] MixAudio    T2:trackAudioInput             lat=160     ports=a1          inplace
+[ 17] Device      T2/D9:deviceProcess            lat=176     ports=a3
+[ 18] Delay       T2/D9:subtractInputDelay       lat=176     ports=a3          hold=0 elided
+[ 19] Delay       T2/D9:subtractInputDelay#1     lat=176     ports=a4          hold=16
+[ 20] Subtract    T2/D9:deviceDelta              lat=176     ports=a3          inplace
+[ 21] Gain        T2/D9:deviceGain               lat=176     ports=a3          inplace
+[ 22] Fader       T2:trackFader                  lat=176     ports=a3          inplace
+[ 23] Meter       T2:trackMeter                  lat=176     ports=a3          inplace
+[ 24] Gain        T2:trackMute                   lat=176     ports=a3          inplace
+[ 25] Delay       T-2:mixInputDelay              lat=176     ports=a2          hold=16 inplace
+[ 26] Delay       T-2:mixInputDelay#1            lat=176     ports=a3          hold=0 elided
+[ 27] MixAudio    T-2:trackAudioInput            lat=176     ports=a2          inplace
+[ 28] Fader       T-2:trackFader                 lat=176     ports=a2          inplace
+[ 29] Meter       T-2:trackMeter                 lat=176     ports=a2          inplace
+[ 30] Gain        T-2:trackMute                  lat=176     ports=a2          inplace
+[ 31] Output      T-2:hardwareOutput             lat=-       ports=-
 
 == params ==
 magda-param-table v1

--- a/tests/goldens/plan/delta-solo.txt
+++ b/tests/goldens/plan/delta-solo.txt
@@ -1,0 +1,60 @@
+# delta-solo
+# a device and the rack around it, each against the dry signal it was handed
+#
+# Generated. See tests/test_plan_goldens.cpp to regenerate.
+
+== plan ==
+magda-render-plan v1
+ops=21 outputs=1
+[  0] ClipAudio   det   T1:clipAudio                   in=-                out=audio       deps=0
+[  1] MixAudio    det   T1:trackAudioInput             in=0:0              out=audio       deps=1
+[  2] Device      det   T1/R5/C10/D7:deviceProcess     in=1:0,-,-          out=audio       deps=1
+[  3] Delay       det   T1/R5/C10/D7:subtractInputDelay in=2:0              out=audio       deps=1
+[  4] Delay       det   T1/R5/C10/D7:subtractInputDelay#1 in=1:0              out=audio       deps=1
+[  5] Subtract    det   T1/R5/C10/D7:deviceDelta       in=3:0,4:0          out=audio       deps=2
+[  6] Gain        det   T1/R5/C10/D7:deviceGain        in=5:0              out=audio       deps=1
+[  7] Fader       det   T1/R5/C10:rackChainFader       in=6:0,-            out=audio       deps=1
+[  8] MixAudio    det   T1/R5:rackMix                  in=7:0              out=audio       deps=1
+[  9] Fader       det   T1/R5:rackFader                in=8:0,-            out=audio       deps=1
+[ 10] Delay       det   T1/R5:subtractInputDelay       in=9:0              out=audio       deps=1
+[ 11] Delay       det   T1/R5:subtractInputDelay#1     in=1:0              out=audio       deps=1
+[ 12] Subtract    det   T1/R5:rackDelta                in=10:0,11:0        out=audio       deps=2
+[ 13] Fader       det   T1:trackFader                  in=12:0,-           out=audio       deps=1
+[ 14] Meter       det   T1:trackMeter                  in=13:0             out=audio       deps=1
+[ 15] Gain        det   T1:trackMute                   in=14:0             out=audio       deps=1
+[ 16] MixAudio    det   T-2:trackAudioInput            in=15:0             out=audio       deps=1
+[ 17] Fader       det   T-2:trackFader                 in=16:0,-           out=audio       deps=1
+[ 18] Meter       det   T-2:trackMeter                 in=17:0             out=audio       deps=1
+[ 19] Gain        det   T-2:trackMute                  in=18:0             out=audio       deps=1
+[ 20] Output      det   T-2:hardwareOutput             in=19:0             out=-           deps=1
+ready=0
+
+== layout ==
+magda-plan-layout v1
+audioSlots=4 midiSlots=0 outputLatency=64
+[  0] ClipAudio   T1:clipAudio                   lat=0       ports=a0
+[  1] MixAudio    T1:trackAudioInput             lat=0       ports=a0          inplace
+[  2] Device      T1/R5/C10/D7:deviceProcess     lat=64      ports=a1
+[  3] Delay       T1/R5/C10/D7:subtractInputDelay lat=64      ports=a1          hold=0 elided
+[  4] Delay       T1/R5/C10/D7:subtractInputDelay#1 lat=64      ports=a2          hold=64
+[  5] Subtract    T1/R5/C10/D7:deviceDelta       lat=64      ports=a1          inplace
+[  6] Gain        T1/R5/C10/D7:deviceGain        lat=64      ports=a1          inplace
+[  7] Fader       T1/R5/C10:rackChainFader       lat=64      ports=a1          inplace
+[  8] MixAudio    T1/R5:rackMix                  lat=64      ports=a1          inplace
+[  9] Fader       T1/R5:rackFader                lat=64      ports=a1          inplace
+[ 10] Delay       T1/R5:subtractInputDelay       lat=64      ports=a1          hold=0 elided
+[ 11] Delay       T1/R5:subtractInputDelay#1     lat=64      ports=a3          hold=64
+[ 12] Subtract    T1/R5:rackDelta                lat=64      ports=a1          inplace
+[ 13] Fader       T1:trackFader                  lat=64      ports=a1          inplace
+[ 14] Meter       T1:trackMeter                  lat=64      ports=a1          inplace
+[ 15] Gain        T1:trackMute                   lat=64      ports=a1          inplace
+[ 16] MixAudio    T-2:trackAudioInput            lat=64      ports=a1          inplace
+[ 17] Fader       T-2:trackFader                 lat=64      ports=a1          inplace
+[ 18] Meter       T-2:trackMeter                 lat=64      ports=a1          inplace
+[ 19] Gain        T-2:trackMute                  lat=64      ports=a1          inplace
+[ 20] Output      T-2:hardwareOutput             lat=-       ports=-
+
+== params ==
+magda-param-table v1
+params=0 modifiers=0 links=0
+order:

--- a/tests/goldens/plan/delta-solo.txt
+++ b/tests/goldens/plan/delta-solo.txt
@@ -1,5 +1,5 @@
 # delta-solo
-# a device and the rack around it, each against the dry signal it was handed
+# a device's delta inside a rack's, and what their dry edges wait for
 #
 # Generated. See tests/test_plan_goldens.cpp to regenerate.
 

--- a/tests/goldens/plan/device-chain.txt
+++ b/tests/goldens/plan/device-chain.txt
@@ -1,48 +1,60 @@
 # device-chain
-# chain order, and the three ops a device slot compiles to
+# chain order, and the four ops a device slot compiles to
 #
 # Generated. See tests/test_plan_goldens.cpp to regenerate.
 
 == plan ==
 magda-render-plan v1
-ops=16 outputs=1
+ops=22 outputs=1
 [  0] ClipAudio   det   T1:clipAudio                   in=-                out=audio       deps=0
 [  1] MixAudio    det   T1:trackAudioInput             in=0:0              out=audio       deps=1
 [  2] Device      det   T1/D7:deviceProcess            in=1:0,-,-          out=audio       deps=1
-[  3] Gain        det   T1/D7:deviceGain               in=2:0              out=audio       deps=1
-[  4] Meter       det   T1/D7:deviceMeter              in=3:0              out=audio       deps=1
-[  5] Device      det   T1/D8:deviceProcess            in=4:0,-,-          out=audio       deps=1
-[  6] Gain        det   T1/D8:deviceGain               in=5:0              out=audio       deps=1
-[  7] Meter       det   T1/D8:deviceMeter              in=6:0              out=audio       deps=1
-[  8] Fader       det   T1:trackFader                  in=7:0,-            out=audio       deps=1
-[  9] Meter       det   T1:trackMeter                  in=8:0              out=audio       deps=1
-[ 10] Gain        det   T1:trackMute                   in=9:0              out=audio       deps=1
-[ 11] MixAudio    det   T-2:trackAudioInput            in=10:0             out=audio       deps=1
-[ 12] Fader       det   T-2:trackFader                 in=11:0,-           out=audio       deps=1
-[ 13] Meter       det   T-2:trackMeter                 in=12:0             out=audio       deps=1
-[ 14] Gain        det   T-2:trackMute                  in=13:0             out=audio       deps=1
-[ 15] Output      det   T-2:hardwareOutput             in=14:0             out=-           deps=1
+[  3] Delay       det   T1/D7:subtractInputDelay       in=2:0              out=audio       deps=1
+[  4] Delay       det   T1/D7:subtractInputDelay#1     in=1:0              out=audio       deps=1
+[  5] Subtract    det   T1/D7:deviceDelta              in=3:0,4:0          out=audio       deps=2
+[  6] Gain        det   T1/D7:deviceGain               in=5:0              out=audio       deps=1
+[  7] Meter       det   T1/D7:deviceMeter              in=6:0              out=audio       deps=1
+[  8] Device      det   T1/D8:deviceProcess            in=7:0,-,-          out=audio       deps=1
+[  9] Delay       det   T1/D8:subtractInputDelay       in=8:0              out=audio       deps=1
+[ 10] Delay       det   T1/D8:subtractInputDelay#1     in=7:0              out=audio       deps=1
+[ 11] Subtract    det   T1/D8:deviceDelta              in=9:0,10:0         out=audio       deps=2
+[ 12] Gain        det   T1/D8:deviceGain               in=11:0             out=audio       deps=1
+[ 13] Meter       det   T1/D8:deviceMeter              in=12:0             out=audio       deps=1
+[ 14] Fader       det   T1:trackFader                  in=13:0,-           out=audio       deps=1
+[ 15] Meter       det   T1:trackMeter                  in=14:0             out=audio       deps=1
+[ 16] Gain        det   T1:trackMute                   in=15:0             out=audio       deps=1
+[ 17] MixAudio    det   T-2:trackAudioInput            in=16:0             out=audio       deps=1
+[ 18] Fader       det   T-2:trackFader                 in=17:0,-           out=audio       deps=1
+[ 19] Meter       det   T-2:trackMeter                 in=18:0             out=audio       deps=1
+[ 20] Gain        det   T-2:trackMute                  in=19:0             out=audio       deps=1
+[ 21] Output      det   T-2:hardwareOutput             in=20:0             out=-           deps=1
 ready=0
 
 == layout ==
 magda-plan-layout v1
-audioSlots=1 midiSlots=0 outputLatency=0
+audioSlots=2 midiSlots=0 outputLatency=0
 [  0] ClipAudio   T1:clipAudio                   lat=0       ports=a0
 [  1] MixAudio    T1:trackAudioInput             lat=0       ports=a0          inplace
-[  2] Device      T1/D7:deviceProcess            lat=0       ports=a0          inplace
-[  3] Gain        T1/D7:deviceGain               lat=0       ports=a0          inplace
-[  4] Meter       T1/D7:deviceMeter              lat=0       ports=a0          inplace
-[  5] Device      T1/D8:deviceProcess            lat=0       ports=a0          inplace
-[  6] Gain        T1/D8:deviceGain               lat=0       ports=a0          inplace
-[  7] Meter       T1/D8:deviceMeter              lat=0       ports=a0          inplace
-[  8] Fader       T1:trackFader                  lat=0       ports=a0          inplace
-[  9] Meter       T1:trackMeter                  lat=0       ports=a0          inplace
-[ 10] Gain        T1:trackMute                   lat=0       ports=a0          inplace
-[ 11] MixAudio    T-2:trackAudioInput            lat=0       ports=a0          inplace
-[ 12] Fader       T-2:trackFader                 lat=0       ports=a0          inplace
-[ 13] Meter       T-2:trackMeter                 lat=0       ports=a0          inplace
-[ 14] Gain        T-2:trackMute                  lat=0       ports=a0          inplace
-[ 15] Output      T-2:hardwareOutput             lat=-       ports=-
+[  2] Device      T1/D7:deviceProcess            lat=0       ports=a1
+[  3] Delay       T1/D7:subtractInputDelay       lat=0       ports=a1          hold=0 elided
+[  4] Delay       T1/D7:subtractInputDelay#1     lat=0       ports=a0          hold=0 elided
+[  5] Subtract    T1/D7:deviceDelta              lat=0       ports=a1          inplace
+[  6] Gain        T1/D7:deviceGain               lat=0       ports=a1          inplace
+[  7] Meter       T1/D7:deviceMeter              lat=0       ports=a1          inplace
+[  8] Device      T1/D8:deviceProcess            lat=0       ports=a0
+[  9] Delay       T1/D8:subtractInputDelay       lat=0       ports=a0          hold=0 elided
+[ 10] Delay       T1/D8:subtractInputDelay#1     lat=0       ports=a1          hold=0 elided
+[ 11] Subtract    T1/D8:deviceDelta              lat=0       ports=a0          inplace
+[ 12] Gain        T1/D8:deviceGain               lat=0       ports=a0          inplace
+[ 13] Meter       T1/D8:deviceMeter              lat=0       ports=a0          inplace
+[ 14] Fader       T1:trackFader                  lat=0       ports=a0          inplace
+[ 15] Meter       T1:trackMeter                  lat=0       ports=a0          inplace
+[ 16] Gain        T1:trackMute                   lat=0       ports=a0          inplace
+[ 17] MixAudio    T-2:trackAudioInput            lat=0       ports=a0          inplace
+[ 18] Fader       T-2:trackFader                 lat=0       ports=a0          inplace
+[ 19] Meter       T-2:trackMeter                 lat=0       ports=a0          inplace
+[ 20] Gain        T-2:trackMute                  lat=0       ports=a0          inplace
+[ 21] Output      T-2:hardwareOutput             lat=-       ports=-
 
 == params ==
 magda-param-table v1

--- a/tests/goldens/plan/edit-insert-device.txt
+++ b/tests/goldens/plan/edit-insert-device.txt
@@ -5,54 +5,66 @@
 
 == plan ==
 magda-render-plan v1
-ops=21 outputs=1
+ops=27 outputs=1
 [  0] ClipAudio   det   T1:clipAudio                   in=-                out=audio       deps=0
 [  1] MixAudio    det   T1:trackAudioInput             in=0:0              out=audio       deps=1
 [  2] Device      det   T1/D7:deviceProcess            in=1:0,-,-          out=audio       deps=1
-[  3] Gain        det   T1/D7:deviceGain               in=2:0              out=audio       deps=1
-[  4] Fader       det   T1:trackFader                  in=3:0,-            out=audio       deps=1
-[  5] Meter       det   T1:trackMeter                  in=4:0              out=audio       deps=1
-[  6] Gain        det   T1:trackMute                   in=5:0              out=audio       deps=1
-[  7] ClipAudio   det   T2:clipAudio                   in=-                out=audio       deps=0
-[  8] MixAudio    det   T2:trackAudioInput             in=7:0              out=audio       deps=1
-[  9] Device      det   T2/D8:deviceProcess            in=8:0,-,-          out=audio       deps=1
-[ 10] Gain        det   T2/D8:deviceGain               in=9:0              out=audio       deps=1
-[ 11] Fader       det   T2:trackFader                  in=10:0,-           out=audio       deps=1
-[ 12] Meter       det   T2:trackMeter                  in=11:0             out=audio       deps=1
-[ 13] Gain        det   T2:trackMute                   in=12:0             out=audio       deps=1
-[ 14] Delay       det   T-2:mixInputDelay              in=6:0              out=audio       deps=1
-[ 15] Delay       det   T-2:mixInputDelay#1            in=13:0             out=audio       deps=1
-[ 16] MixAudio    det   T-2:trackAudioInput            in=14:0,15:0        out=audio       deps=2
-[ 17] Fader       det   T-2:trackFader                 in=16:0,-           out=audio       deps=1
-[ 18] Meter       det   T-2:trackMeter                 in=17:0             out=audio       deps=1
-[ 19] Gain        det   T-2:trackMute                  in=18:0             out=audio       deps=1
-[ 20] Output      det   T-2:hardwareOutput             in=19:0             out=-           deps=1
-ready=0,7
+[  3] Delay       det   T1/D7:subtractInputDelay       in=2:0              out=audio       deps=1
+[  4] Delay       det   T1/D7:subtractInputDelay#1     in=1:0              out=audio       deps=1
+[  5] Subtract    det   T1/D7:deviceDelta              in=3:0,4:0          out=audio       deps=2
+[  6] Gain        det   T1/D7:deviceGain               in=5:0              out=audio       deps=1
+[  7] Fader       det   T1:trackFader                  in=6:0,-            out=audio       deps=1
+[  8] Meter       det   T1:trackMeter                  in=7:0              out=audio       deps=1
+[  9] Gain        det   T1:trackMute                   in=8:0              out=audio       deps=1
+[ 10] ClipAudio   det   T2:clipAudio                   in=-                out=audio       deps=0
+[ 11] MixAudio    det   T2:trackAudioInput             in=10:0             out=audio       deps=1
+[ 12] Device      det   T2/D8:deviceProcess            in=11:0,-,-         out=audio       deps=1
+[ 13] Delay       det   T2/D8:subtractInputDelay       in=12:0             out=audio       deps=1
+[ 14] Delay       det   T2/D8:subtractInputDelay#1     in=11:0             out=audio       deps=1
+[ 15] Subtract    det   T2/D8:deviceDelta              in=13:0,14:0        out=audio       deps=2
+[ 16] Gain        det   T2/D8:deviceGain               in=15:0             out=audio       deps=1
+[ 17] Fader       det   T2:trackFader                  in=16:0,-           out=audio       deps=1
+[ 18] Meter       det   T2:trackMeter                  in=17:0             out=audio       deps=1
+[ 19] Gain        det   T2:trackMute                   in=18:0             out=audio       deps=1
+[ 20] Delay       det   T-2:mixInputDelay              in=9:0              out=audio       deps=1
+[ 21] Delay       det   T-2:mixInputDelay#1            in=19:0             out=audio       deps=1
+[ 22] MixAudio    det   T-2:trackAudioInput            in=20:0,21:0        out=audio       deps=2
+[ 23] Fader       det   T-2:trackFader                 in=22:0,-           out=audio       deps=1
+[ 24] Meter       det   T-2:trackMeter                 in=23:0             out=audio       deps=1
+[ 25] Gain        det   T-2:trackMute                  in=24:0             out=audio       deps=1
+[ 26] Output      det   T-2:hardwareOutput             in=25:0             out=-           deps=1
+ready=0,10
 
 == layout ==
 magda-plan-layout v1
-audioSlots=2 midiSlots=0 outputLatency=0
+audioSlots=4 midiSlots=0 outputLatency=0
 [  0] ClipAudio   T1:clipAudio                   lat=0       ports=a0
 [  1] MixAudio    T1:trackAudioInput             lat=0       ports=a0          inplace
-[  2] Device      T1/D7:deviceProcess            lat=0       ports=a0          inplace
-[  3] Gain        T1/D7:deviceGain               lat=0       ports=a0          inplace
-[  4] Fader       T1:trackFader                  lat=0       ports=a0          inplace
-[  5] Meter       T1:trackMeter                  lat=0       ports=a0          inplace
-[  6] Gain        T1:trackMute                   lat=0       ports=a0          inplace
-[  7] ClipAudio   T2:clipAudio                   lat=0       ports=a1
-[  8] MixAudio    T2:trackAudioInput             lat=0       ports=a1          inplace
-[  9] Device      T2/D8:deviceProcess            lat=0       ports=a1          inplace
-[ 10] Gain        T2/D8:deviceGain               lat=0       ports=a1          inplace
-[ 11] Fader       T2:trackFader                  lat=0       ports=a1          inplace
-[ 12] Meter       T2:trackMeter                  lat=0       ports=a1          inplace
-[ 13] Gain        T2:trackMute                   lat=0       ports=a1          inplace
-[ 14] Delay       T-2:mixInputDelay              lat=0       ports=a0          hold=0 elided
-[ 15] Delay       T-2:mixInputDelay#1            lat=0       ports=a1          hold=0 elided
-[ 16] MixAudio    T-2:trackAudioInput            lat=0       ports=a0          inplace
-[ 17] Fader       T-2:trackFader                 lat=0       ports=a0          inplace
-[ 18] Meter       T-2:trackMeter                 lat=0       ports=a0          inplace
-[ 19] Gain        T-2:trackMute                  lat=0       ports=a0          inplace
-[ 20] Output      T-2:hardwareOutput             lat=-       ports=-
+[  2] Device      T1/D7:deviceProcess            lat=0       ports=a1
+[  3] Delay       T1/D7:subtractInputDelay       lat=0       ports=a1          hold=0 elided
+[  4] Delay       T1/D7:subtractInputDelay#1     lat=0       ports=a0          hold=0 elided
+[  5] Subtract    T1/D7:deviceDelta              lat=0       ports=a1          inplace
+[  6] Gain        T1/D7:deviceGain               lat=0       ports=a1          inplace
+[  7] Fader       T1:trackFader                  lat=0       ports=a1          inplace
+[  8] Meter       T1:trackMeter                  lat=0       ports=a1          inplace
+[  9] Gain        T1:trackMute                   lat=0       ports=a1          inplace
+[ 10] ClipAudio   T2:clipAudio                   lat=0       ports=a2
+[ 11] MixAudio    T2:trackAudioInput             lat=0       ports=a2          inplace
+[ 12] Device      T2/D8:deviceProcess            lat=0       ports=a3
+[ 13] Delay       T2/D8:subtractInputDelay       lat=0       ports=a3          hold=0 elided
+[ 14] Delay       T2/D8:subtractInputDelay#1     lat=0       ports=a2          hold=0 elided
+[ 15] Subtract    T2/D8:deviceDelta              lat=0       ports=a3          inplace
+[ 16] Gain        T2/D8:deviceGain               lat=0       ports=a3          inplace
+[ 17] Fader       T2:trackFader                  lat=0       ports=a3          inplace
+[ 18] Meter       T2:trackMeter                  lat=0       ports=a3          inplace
+[ 19] Gain        T2:trackMute                   lat=0       ports=a3          inplace
+[ 20] Delay       T-2:mixInputDelay              lat=0       ports=a1          hold=0 elided
+[ 21] Delay       T-2:mixInputDelay#1            lat=0       ports=a3          hold=0 elided
+[ 22] MixAudio    T-2:trackAudioInput            lat=0       ports=a1          inplace
+[ 23] Fader       T-2:trackFader                 lat=0       ports=a1          inplace
+[ 24] Meter       T-2:trackMeter                 lat=0       ports=a1          inplace
+[ 25] Gain        T-2:trackMute                  lat=0       ports=a1          inplace
+[ 26] Output      T-2:hardwareOutput             lat=-       ports=-
 
 == params ==
 magda-param-table v1
@@ -61,86 +73,114 @@ order:
 
 == edited plan ==
 magda-render-plan v1
-ops=23 outputs=1
+ops=32 outputs=1
 [  0] ClipAudio   det   T1:clipAudio                   in=-                out=audio       deps=0
 [  1] MixAudio    det   T1:trackAudioInput             in=0:0              out=audio       deps=1
 [  2] Device      det   T1/D9:deviceProcess            in=1:0,-,-          out=audio       deps=1
-[  3] Gain        det   T1/D9:deviceGain               in=2:0              out=audio       deps=1
-[  4] Device      det   T1/D7:deviceProcess            in=3:0,-,-          out=audio       deps=1
-[  5] Gain        det   T1/D7:deviceGain               in=4:0              out=audio       deps=1
-[  6] Fader       det   T1:trackFader                  in=5:0,-            out=audio       deps=1
-[  7] Meter       det   T1:trackMeter                  in=6:0              out=audio       deps=1
-[  8] Gain        det   T1:trackMute                   in=7:0              out=audio       deps=1
-[  9] ClipAudio   det   T2:clipAudio                   in=-                out=audio       deps=0
-[ 10] MixAudio    det   T2:trackAudioInput             in=9:0              out=audio       deps=1
-[ 11] Device      det   T2/D8:deviceProcess            in=10:0,-,-         out=audio       deps=1
-[ 12] Gain        det   T2/D8:deviceGain               in=11:0             out=audio       deps=1
-[ 13] Fader       det   T2:trackFader                  in=12:0,-           out=audio       deps=1
-[ 14] Meter       det   T2:trackMeter                  in=13:0             out=audio       deps=1
-[ 15] Gain        det   T2:trackMute                   in=14:0             out=audio       deps=1
-[ 16] Delay       det   T-2:mixInputDelay              in=8:0              out=audio       deps=1
-[ 17] Delay       det   T-2:mixInputDelay#1            in=15:0             out=audio       deps=1
-[ 18] MixAudio    det   T-2:trackAudioInput            in=16:0,17:0        out=audio       deps=2
-[ 19] Fader       det   T-2:trackFader                 in=18:0,-           out=audio       deps=1
-[ 20] Meter       det   T-2:trackMeter                 in=19:0             out=audio       deps=1
-[ 21] Gain        det   T-2:trackMute                  in=20:0             out=audio       deps=1
-[ 22] Output      det   T-2:hardwareOutput             in=21:0             out=-           deps=1
-ready=0,9
+[  3] Delay       det   T1/D9:subtractInputDelay       in=2:0              out=audio       deps=1
+[  4] Delay       det   T1/D9:subtractInputDelay#1     in=1:0              out=audio       deps=1
+[  5] Subtract    det   T1/D9:deviceDelta              in=3:0,4:0          out=audio       deps=2
+[  6] Gain        det   T1/D9:deviceGain               in=5:0              out=audio       deps=1
+[  7] Device      det   T1/D7:deviceProcess            in=6:0,-,-          out=audio       deps=1
+[  8] Delay       det   T1/D7:subtractInputDelay       in=7:0              out=audio       deps=1
+[  9] Delay       det   T1/D7:subtractInputDelay#1     in=6:0              out=audio       deps=1
+[ 10] Subtract    det   T1/D7:deviceDelta              in=8:0,9:0          out=audio       deps=2
+[ 11] Gain        det   T1/D7:deviceGain               in=10:0             out=audio       deps=1
+[ 12] Fader       det   T1:trackFader                  in=11:0,-           out=audio       deps=1
+[ 13] Meter       det   T1:trackMeter                  in=12:0             out=audio       deps=1
+[ 14] Gain        det   T1:trackMute                   in=13:0             out=audio       deps=1
+[ 15] ClipAudio   det   T2:clipAudio                   in=-                out=audio       deps=0
+[ 16] MixAudio    det   T2:trackAudioInput             in=15:0             out=audio       deps=1
+[ 17] Device      det   T2/D8:deviceProcess            in=16:0,-,-         out=audio       deps=1
+[ 18] Delay       det   T2/D8:subtractInputDelay       in=17:0             out=audio       deps=1
+[ 19] Delay       det   T2/D8:subtractInputDelay#1     in=16:0             out=audio       deps=1
+[ 20] Subtract    det   T2/D8:deviceDelta              in=18:0,19:0        out=audio       deps=2
+[ 21] Gain        det   T2/D8:deviceGain               in=20:0             out=audio       deps=1
+[ 22] Fader       det   T2:trackFader                  in=21:0,-           out=audio       deps=1
+[ 23] Meter       det   T2:trackMeter                  in=22:0             out=audio       deps=1
+[ 24] Gain        det   T2:trackMute                   in=23:0             out=audio       deps=1
+[ 25] Delay       det   T-2:mixInputDelay              in=14:0             out=audio       deps=1
+[ 26] Delay       det   T-2:mixInputDelay#1            in=24:0             out=audio       deps=1
+[ 27] MixAudio    det   T-2:trackAudioInput            in=25:0,26:0        out=audio       deps=2
+[ 28] Fader       det   T-2:trackFader                 in=27:0,-           out=audio       deps=1
+[ 29] Meter       det   T-2:trackMeter                 in=28:0             out=audio       deps=1
+[ 30] Gain        det   T-2:trackMute                  in=29:0             out=audio       deps=1
+[ 31] Output      det   T-2:hardwareOutput             in=30:0             out=-           deps=1
+ready=0,15
 
 == diff ==
 magda-plan-diff v1
-ops=23 carried=20 retired=1
+ops=32 carried=25 retired=2
 [  0] carry   T1:clipAudio                   from=T1:clipAudio
 [  1] carry   T1:trackAudioInput             from=T1:trackAudioInput
 [  2] new     T1/D9:deviceProcess
-[  3] new     T1/D9:deviceGain
-[  4] new     T1/D7:deviceProcess
-[  5] carry   T1/D7:deviceGain               from=T1/D7:deviceGain
-[  6] carry   T1:trackFader                  from=T1:trackFader
-[  7] carry   T1:trackMeter                  from=T1:trackMeter
-[  8] carry   T1:trackMute                   from=T1:trackMute
-[  9] carry   T2:clipAudio                   from=T2:clipAudio
-[ 10] carry   T2:trackAudioInput             from=T2:trackAudioInput
-[ 11] carry   T2/D8:deviceProcess            from=T2/D8:deviceProcess
-[ 12] carry   T2/D8:deviceGain               from=T2/D8:deviceGain
-[ 13] carry   T2:trackFader                  from=T2:trackFader
-[ 14] carry   T2:trackMeter                  from=T2:trackMeter
-[ 15] carry   T2:trackMute                   from=T2:trackMute
-[ 16] carry   T-2:mixInputDelay              from=T-2:mixInputDelay
-[ 17] carry   T-2:mixInputDelay#1            from=T-2:mixInputDelay#1
-[ 18] carry   T-2:trackAudioInput            from=T-2:trackAudioInput
-[ 19] carry   T-2:trackFader                 from=T-2:trackFader
-[ 20] carry   T-2:trackMeter                 from=T-2:trackMeter
-[ 21] carry   T-2:trackMute                  from=T-2:trackMute
-[ 22] carry   T-2:hardwareOutput             from=T-2:hardwareOutput
+[  3] new     T1/D9:subtractInputDelay
+[  4] new     T1/D9:subtractInputDelay#1
+[  5] new     T1/D9:deviceDelta
+[  6] new     T1/D9:deviceGain
+[  7] new     T1/D7:deviceProcess
+[  8] carry   T1/D7:subtractInputDelay       from=T1/D7:subtractInputDelay
+[  9] new     T1/D7:subtractInputDelay#1
+[ 10] carry   T1/D7:deviceDelta              from=T1/D7:deviceDelta
+[ 11] carry   T1/D7:deviceGain               from=T1/D7:deviceGain
+[ 12] carry   T1:trackFader                  from=T1:trackFader
+[ 13] carry   T1:trackMeter                  from=T1:trackMeter
+[ 14] carry   T1:trackMute                   from=T1:trackMute
+[ 15] carry   T2:clipAudio                   from=T2:clipAudio
+[ 16] carry   T2:trackAudioInput             from=T2:trackAudioInput
+[ 17] carry   T2/D8:deviceProcess            from=T2/D8:deviceProcess
+[ 18] carry   T2/D8:subtractInputDelay       from=T2/D8:subtractInputDelay
+[ 19] carry   T2/D8:subtractInputDelay#1     from=T2/D8:subtractInputDelay#1
+[ 20] carry   T2/D8:deviceDelta              from=T2/D8:deviceDelta
+[ 21] carry   T2/D8:deviceGain               from=T2/D8:deviceGain
+[ 22] carry   T2:trackFader                  from=T2:trackFader
+[ 23] carry   T2:trackMeter                  from=T2:trackMeter
+[ 24] carry   T2:trackMute                   from=T2:trackMute
+[ 25] carry   T-2:mixInputDelay              from=T-2:mixInputDelay
+[ 26] carry   T-2:mixInputDelay#1            from=T-2:mixInputDelay#1
+[ 27] carry   T-2:trackAudioInput            from=T-2:trackAudioInput
+[ 28] carry   T-2:trackFader                 from=T-2:trackFader
+[ 29] carry   T-2:trackMeter                 from=T-2:trackMeter
+[ 30] carry   T-2:trackMute                  from=T-2:trackMute
+[ 31] carry   T-2:hardwareOutput             from=T-2:hardwareOutput
 retired T1/D7:deviceProcess
+retired T1/D7:subtractInputDelay#1
 
 == crossfaded ==
-inserted=1 unfaded=0
+inserted=1 unfaded=1
 magda-render-plan v1
-ops=24 outputs=1
+ops=33 outputs=1
 [  0] ClipAudio   det   T1:clipAudio                   in=-                out=audio       deps=0
 [  1] MixAudio    det   T1:trackAudioInput             in=0:0              out=audio       deps=1
 [  2] Device      det   T1/D9:deviceProcess            in=1:0,-,-          out=audio       deps=1
-[  3] Gain        det   T1/D9:deviceGain               in=2:0              out=audio       deps=1
-[  4] Crossfade   det   T1/D7:edgeCrossfade(deviceProcess slot 0) in=1:0,3:0          out=audio       deps=2
-[  5] Device      det   T1/D7:deviceProcess            in=4:0,-,-          out=audio       deps=1
-[  6] Gain        det   T1/D7:deviceGain               in=5:0              out=audio       deps=1
-[  7] Fader       det   T1:trackFader                  in=6:0,-            out=audio       deps=1
-[  8] Meter       det   T1:trackMeter                  in=7:0              out=audio       deps=1
-[  9] Gain        det   T1:trackMute                   in=8:0              out=audio       deps=1
-[ 10] ClipAudio   det   T2:clipAudio                   in=-                out=audio       deps=0
-[ 11] MixAudio    det   T2:trackAudioInput             in=10:0             out=audio       deps=1
-[ 12] Device      det   T2/D8:deviceProcess            in=11:0,-,-         out=audio       deps=1
-[ 13] Gain        det   T2/D8:deviceGain               in=12:0             out=audio       deps=1
-[ 14] Fader       det   T2:trackFader                  in=13:0,-           out=audio       deps=1
-[ 15] Meter       det   T2:trackMeter                  in=14:0             out=audio       deps=1
-[ 16] Gain        det   T2:trackMute                   in=15:0             out=audio       deps=1
-[ 17] Delay       det   T-2:mixInputDelay              in=9:0              out=audio       deps=1
-[ 18] Delay       det   T-2:mixInputDelay#1            in=16:0             out=audio       deps=1
-[ 19] MixAudio    det   T-2:trackAudioInput            in=17:0,18:0        out=audio       deps=2
-[ 20] Fader       det   T-2:trackFader                 in=19:0,-           out=audio       deps=1
-[ 21] Meter       det   T-2:trackMeter                 in=20:0             out=audio       deps=1
-[ 22] Gain        det   T-2:trackMute                  in=21:0             out=audio       deps=1
-[ 23] Output      det   T-2:hardwareOutput             in=22:0             out=-           deps=1
-ready=0,10
+[  3] Delay       det   T1/D9:subtractInputDelay       in=2:0              out=audio       deps=1
+[  4] Delay       det   T1/D9:subtractInputDelay#1     in=1:0              out=audio       deps=1
+[  5] Subtract    det   T1/D9:deviceDelta              in=3:0,4:0          out=audio       deps=2
+[  6] Gain        det   T1/D9:deviceGain               in=5:0              out=audio       deps=1
+[  7] Crossfade   det   T1/D7:edgeCrossfade(deviceProcess slot 0) in=1:0,6:0          out=audio       deps=2
+[  8] Device      det   T1/D7:deviceProcess            in=7:0,-,-          out=audio       deps=1
+[  9] Delay       det   T1/D7:subtractInputDelay       in=8:0              out=audio       deps=1
+[ 10] Delay       det   T1/D7:subtractInputDelay#1     in=6:0              out=audio       deps=1
+[ 11] Subtract    det   T1/D7:deviceDelta              in=9:0,10:0         out=audio       deps=2
+[ 12] Gain        det   T1/D7:deviceGain               in=11:0             out=audio       deps=1
+[ 13] Fader       det   T1:trackFader                  in=12:0,-           out=audio       deps=1
+[ 14] Meter       det   T1:trackMeter                  in=13:0             out=audio       deps=1
+[ 15] Gain        det   T1:trackMute                   in=14:0             out=audio       deps=1
+[ 16] ClipAudio   det   T2:clipAudio                   in=-                out=audio       deps=0
+[ 17] MixAudio    det   T2:trackAudioInput             in=16:0             out=audio       deps=1
+[ 18] Device      det   T2/D8:deviceProcess            in=17:0,-,-         out=audio       deps=1
+[ 19] Delay       det   T2/D8:subtractInputDelay       in=18:0             out=audio       deps=1
+[ 20] Delay       det   T2/D8:subtractInputDelay#1     in=17:0             out=audio       deps=1
+[ 21] Subtract    det   T2/D8:deviceDelta              in=19:0,20:0        out=audio       deps=2
+[ 22] Gain        det   T2/D8:deviceGain               in=21:0             out=audio       deps=1
+[ 23] Fader       det   T2:trackFader                  in=22:0,-           out=audio       deps=1
+[ 24] Meter       det   T2:trackMeter                  in=23:0             out=audio       deps=1
+[ 25] Gain        det   T2:trackMute                   in=24:0             out=audio       deps=1
+[ 26] Delay       det   T-2:mixInputDelay              in=15:0             out=audio       deps=1
+[ 27] Delay       det   T-2:mixInputDelay#1            in=25:0             out=audio       deps=1
+[ 28] MixAudio    det   T-2:trackAudioInput            in=26:0,27:0        out=audio       deps=2
+[ 29] Fader       det   T-2:trackFader                 in=28:0,-           out=audio       deps=1
+[ 30] Meter       det   T-2:trackMeter                 in=29:0             out=audio       deps=1
+[ 31] Gain        det   T-2:trackMute                  in=30:0             out=audio       deps=1
+[ 32] Output      det   T-2:hardwareOutput             in=31:0             out=-           deps=1
+ready=0,16

--- a/tests/goldens/plan/edit-remove-device.txt
+++ b/tests/goldens/plan/edit-remove-device.txt
@@ -5,40 +5,52 @@
 
 == plan ==
 magda-render-plan v1
-ops=14 outputs=1
+ops=20 outputs=1
 [  0] ClipAudio   det   T1:clipAudio                   in=-                out=audio       deps=0
 [  1] MixAudio    det   T1:trackAudioInput             in=0:0              out=audio       deps=1
 [  2] Device      det   T1/D7:deviceProcess            in=1:0,-,-          out=audio       deps=1
-[  3] Gain        det   T1/D7:deviceGain               in=2:0              out=audio       deps=1
-[  4] Device      det   T1/D8:deviceProcess            in=3:0,-,-          out=audio       deps=1
-[  5] Gain        det   T1/D8:deviceGain               in=4:0              out=audio       deps=1
-[  6] Fader       det   T1:trackFader                  in=5:0,-            out=audio       deps=1
-[  7] Meter       det   T1:trackMeter                  in=6:0              out=audio       deps=1
-[  8] Gain        det   T1:trackMute                   in=7:0              out=audio       deps=1
-[  9] MixAudio    det   T-2:trackAudioInput            in=8:0              out=audio       deps=1
-[ 10] Fader       det   T-2:trackFader                 in=9:0,-            out=audio       deps=1
-[ 11] Meter       det   T-2:trackMeter                 in=10:0             out=audio       deps=1
-[ 12] Gain        det   T-2:trackMute                  in=11:0             out=audio       deps=1
-[ 13] Output      det   T-2:hardwareOutput             in=12:0             out=-           deps=1
+[  3] Delay       det   T1/D7:subtractInputDelay       in=2:0              out=audio       deps=1
+[  4] Delay       det   T1/D7:subtractInputDelay#1     in=1:0              out=audio       deps=1
+[  5] Subtract    det   T1/D7:deviceDelta              in=3:0,4:0          out=audio       deps=2
+[  6] Gain        det   T1/D7:deviceGain               in=5:0              out=audio       deps=1
+[  7] Device      det   T1/D8:deviceProcess            in=6:0,-,-          out=audio       deps=1
+[  8] Delay       det   T1/D8:subtractInputDelay       in=7:0              out=audio       deps=1
+[  9] Delay       det   T1/D8:subtractInputDelay#1     in=6:0              out=audio       deps=1
+[ 10] Subtract    det   T1/D8:deviceDelta              in=8:0,9:0          out=audio       deps=2
+[ 11] Gain        det   T1/D8:deviceGain               in=10:0             out=audio       deps=1
+[ 12] Fader       det   T1:trackFader                  in=11:0,-           out=audio       deps=1
+[ 13] Meter       det   T1:trackMeter                  in=12:0             out=audio       deps=1
+[ 14] Gain        det   T1:trackMute                   in=13:0             out=audio       deps=1
+[ 15] MixAudio    det   T-2:trackAudioInput            in=14:0             out=audio       deps=1
+[ 16] Fader       det   T-2:trackFader                 in=15:0,-           out=audio       deps=1
+[ 17] Meter       det   T-2:trackMeter                 in=16:0             out=audio       deps=1
+[ 18] Gain        det   T-2:trackMute                  in=17:0             out=audio       deps=1
+[ 19] Output      det   T-2:hardwareOutput             in=18:0             out=-           deps=1
 ready=0
 
 == layout ==
 magda-plan-layout v1
-audioSlots=1 midiSlots=0 outputLatency=0
+audioSlots=2 midiSlots=0 outputLatency=0
 [  0] ClipAudio   T1:clipAudio                   lat=0       ports=a0
 [  1] MixAudio    T1:trackAudioInput             lat=0       ports=a0          inplace
-[  2] Device      T1/D7:deviceProcess            lat=0       ports=a0          inplace
-[  3] Gain        T1/D7:deviceGain               lat=0       ports=a0          inplace
-[  4] Device      T1/D8:deviceProcess            lat=0       ports=a0          inplace
-[  5] Gain        T1/D8:deviceGain               lat=0       ports=a0          inplace
-[  6] Fader       T1:trackFader                  lat=0       ports=a0          inplace
-[  7] Meter       T1:trackMeter                  lat=0       ports=a0          inplace
-[  8] Gain        T1:trackMute                   lat=0       ports=a0          inplace
-[  9] MixAudio    T-2:trackAudioInput            lat=0       ports=a0          inplace
-[ 10] Fader       T-2:trackFader                 lat=0       ports=a0          inplace
-[ 11] Meter       T-2:trackMeter                 lat=0       ports=a0          inplace
-[ 12] Gain        T-2:trackMute                  lat=0       ports=a0          inplace
-[ 13] Output      T-2:hardwareOutput             lat=-       ports=-
+[  2] Device      T1/D7:deviceProcess            lat=0       ports=a1
+[  3] Delay       T1/D7:subtractInputDelay       lat=0       ports=a1          hold=0 elided
+[  4] Delay       T1/D7:subtractInputDelay#1     lat=0       ports=a0          hold=0 elided
+[  5] Subtract    T1/D7:deviceDelta              lat=0       ports=a1          inplace
+[  6] Gain        T1/D7:deviceGain               lat=0       ports=a1          inplace
+[  7] Device      T1/D8:deviceProcess            lat=0       ports=a0
+[  8] Delay       T1/D8:subtractInputDelay       lat=0       ports=a0          hold=0 elided
+[  9] Delay       T1/D8:subtractInputDelay#1     lat=0       ports=a1          hold=0 elided
+[ 10] Subtract    T1/D8:deviceDelta              lat=0       ports=a0          inplace
+[ 11] Gain        T1/D8:deviceGain               lat=0       ports=a0          inplace
+[ 12] Fader       T1:trackFader                  lat=0       ports=a0          inplace
+[ 13] Meter       T1:trackMeter                  lat=0       ports=a0          inplace
+[ 14] Gain        T1:trackMute                   lat=0       ports=a0          inplace
+[ 15] MixAudio    T-2:trackAudioInput            lat=0       ports=a0          inplace
+[ 16] Fader       T-2:trackFader                 lat=0       ports=a0          inplace
+[ 17] Meter       T-2:trackMeter                 lat=0       ports=a0          inplace
+[ 18] Gain        T-2:trackMute                  lat=0       ports=a0          inplace
+[ 19] Output      T-2:hardwareOutput             lat=-       ports=-
 
 == params ==
 magda-param-table v1
@@ -47,54 +59,67 @@ order:
 
 == edited plan ==
 magda-render-plan v1
-ops=12 outputs=1
+ops=15 outputs=1
 [  0] ClipAudio   det   T1:clipAudio                   in=-                out=audio       deps=0
 [  1] MixAudio    det   T1:trackAudioInput             in=0:0              out=audio       deps=1
 [  2] Device      det   T1/D8:deviceProcess            in=1:0,-,-          out=audio       deps=1
-[  3] Gain        det   T1/D8:deviceGain               in=2:0              out=audio       deps=1
-[  4] Fader       det   T1:trackFader                  in=3:0,-            out=audio       deps=1
-[  5] Meter       det   T1:trackMeter                  in=4:0              out=audio       deps=1
-[  6] Gain        det   T1:trackMute                   in=5:0              out=audio       deps=1
-[  7] MixAudio    det   T-2:trackAudioInput            in=6:0              out=audio       deps=1
-[  8] Fader       det   T-2:trackFader                 in=7:0,-            out=audio       deps=1
-[  9] Meter       det   T-2:trackMeter                 in=8:0              out=audio       deps=1
-[ 10] Gain        det   T-2:trackMute                  in=9:0              out=audio       deps=1
-[ 11] Output      det   T-2:hardwareOutput             in=10:0             out=-           deps=1
+[  3] Delay       det   T1/D8:subtractInputDelay       in=2:0              out=audio       deps=1
+[  4] Delay       det   T1/D8:subtractInputDelay#1     in=1:0              out=audio       deps=1
+[  5] Subtract    det   T1/D8:deviceDelta              in=3:0,4:0          out=audio       deps=2
+[  6] Gain        det   T1/D8:deviceGain               in=5:0              out=audio       deps=1
+[  7] Fader       det   T1:trackFader                  in=6:0,-            out=audio       deps=1
+[  8] Meter       det   T1:trackMeter                  in=7:0              out=audio       deps=1
+[  9] Gain        det   T1:trackMute                   in=8:0              out=audio       deps=1
+[ 10] MixAudio    det   T-2:trackAudioInput            in=9:0              out=audio       deps=1
+[ 11] Fader       det   T-2:trackFader                 in=10:0,-           out=audio       deps=1
+[ 12] Meter       det   T-2:trackMeter                 in=11:0             out=audio       deps=1
+[ 13] Gain        det   T-2:trackMute                  in=12:0             out=audio       deps=1
+[ 14] Output      det   T-2:hardwareOutput             in=13:0             out=-           deps=1
 ready=0
 
 == diff ==
 magda-plan-diff v1
-ops=12 carried=11 retired=3
+ops=15 carried=13 retired=7
 [  0] carry   T1:clipAudio                   from=T1:clipAudio
 [  1] carry   T1:trackAudioInput             from=T1:trackAudioInput
 [  2] new     T1/D8:deviceProcess
-[  3] carry   T1/D8:deviceGain               from=T1/D8:deviceGain
-[  4] carry   T1:trackFader                  from=T1:trackFader
-[  5] carry   T1:trackMeter                  from=T1:trackMeter
-[  6] carry   T1:trackMute                   from=T1:trackMute
-[  7] carry   T-2:trackAudioInput            from=T-2:trackAudioInput
-[  8] carry   T-2:trackFader                 from=T-2:trackFader
-[  9] carry   T-2:trackMeter                 from=T-2:trackMeter
-[ 10] carry   T-2:trackMute                  from=T-2:trackMute
-[ 11] carry   T-2:hardwareOutput             from=T-2:hardwareOutput
+[  3] carry   T1/D8:subtractInputDelay       from=T1/D8:subtractInputDelay
+[  4] new     T1/D8:subtractInputDelay#1
+[  5] carry   T1/D8:deviceDelta              from=T1/D8:deviceDelta
+[  6] carry   T1/D8:deviceGain               from=T1/D8:deviceGain
+[  7] carry   T1:trackFader                  from=T1:trackFader
+[  8] carry   T1:trackMeter                  from=T1:trackMeter
+[  9] carry   T1:trackMute                   from=T1:trackMute
+[ 10] carry   T-2:trackAudioInput            from=T-2:trackAudioInput
+[ 11] carry   T-2:trackFader                 from=T-2:trackFader
+[ 12] carry   T-2:trackMeter                 from=T-2:trackMeter
+[ 13] carry   T-2:trackMute                  from=T-2:trackMute
+[ 14] carry   T-2:hardwareOutput             from=T-2:hardwareOutput
 retired T1/D7:deviceProcess
+retired T1/D7:subtractInputDelay
+retired T1/D7:subtractInputDelay#1
+retired T1/D7:deviceDelta
 retired T1/D7:deviceGain
 retired T1/D8:deviceProcess
+retired T1/D8:subtractInputDelay#1
 
 == crossfaded ==
-inserted=0 unfaded=1
+inserted=0 unfaded=2
 magda-render-plan v1
-ops=12 outputs=1
+ops=15 outputs=1
 [  0] ClipAudio   det   T1:clipAudio                   in=-                out=audio       deps=0
 [  1] MixAudio    det   T1:trackAudioInput             in=0:0              out=audio       deps=1
 [  2] Device      det   T1/D8:deviceProcess            in=1:0,-,-          out=audio       deps=1
-[  3] Gain        det   T1/D8:deviceGain               in=2:0              out=audio       deps=1
-[  4] Fader       det   T1:trackFader                  in=3:0,-            out=audio       deps=1
-[  5] Meter       det   T1:trackMeter                  in=4:0              out=audio       deps=1
-[  6] Gain        det   T1:trackMute                   in=5:0              out=audio       deps=1
-[  7] MixAudio    det   T-2:trackAudioInput            in=6:0              out=audio       deps=1
-[  8] Fader       det   T-2:trackFader                 in=7:0,-            out=audio       deps=1
-[  9] Meter       det   T-2:trackMeter                 in=8:0              out=audio       deps=1
-[ 10] Gain        det   T-2:trackMute                  in=9:0              out=audio       deps=1
-[ 11] Output      det   T-2:hardwareOutput             in=10:0             out=-           deps=1
+[  3] Delay       det   T1/D8:subtractInputDelay       in=2:0              out=audio       deps=1
+[  4] Delay       det   T1/D8:subtractInputDelay#1     in=1:0              out=audio       deps=1
+[  5] Subtract    det   T1/D8:deviceDelta              in=3:0,4:0          out=audio       deps=2
+[  6] Gain        det   T1/D8:deviceGain               in=5:0              out=audio       deps=1
+[  7] Fader       det   T1:trackFader                  in=6:0,-            out=audio       deps=1
+[  8] Meter       det   T1:trackMeter                  in=7:0              out=audio       deps=1
+[  9] Gain        det   T1:trackMute                   in=8:0              out=audio       deps=1
+[ 10] MixAudio    det   T-2:trackAudioInput            in=9:0              out=audio       deps=1
+[ 11] Fader       det   T-2:trackFader                 in=10:0,-           out=audio       deps=1
+[ 12] Meter       det   T-2:trackMeter                 in=11:0             out=audio       deps=1
+[ 13] Gain        det   T-2:trackMute                  in=12:0             out=audio       deps=1
+[ 14] Output      det   T-2:hardwareOutput             in=13:0             out=-           deps=1
 ready=0

--- a/tests/goldens/plan/edit-reorder-devices.txt
+++ b/tests/goldens/plan/edit-reorder-devices.txt
@@ -5,40 +5,52 @@
 
 == plan ==
 magda-render-plan v1
-ops=14 outputs=1
+ops=20 outputs=1
 [  0] ClipAudio   det   T1:clipAudio                   in=-                out=audio       deps=0
 [  1] MixAudio    det   T1:trackAudioInput             in=0:0              out=audio       deps=1
 [  2] Device      det   T1/D7:deviceProcess            in=1:0,-,-          out=audio       deps=1
-[  3] Gain        det   T1/D7:deviceGain               in=2:0              out=audio       deps=1
-[  4] Device      det   T1/D8:deviceProcess            in=3:0,-,-          out=audio       deps=1
-[  5] Gain        det   T1/D8:deviceGain               in=4:0              out=audio       deps=1
-[  6] Fader       det   T1:trackFader                  in=5:0,-            out=audio       deps=1
-[  7] Meter       det   T1:trackMeter                  in=6:0              out=audio       deps=1
-[  8] Gain        det   T1:trackMute                   in=7:0              out=audio       deps=1
-[  9] MixAudio    det   T-2:trackAudioInput            in=8:0              out=audio       deps=1
-[ 10] Fader       det   T-2:trackFader                 in=9:0,-            out=audio       deps=1
-[ 11] Meter       det   T-2:trackMeter                 in=10:0             out=audio       deps=1
-[ 12] Gain        det   T-2:trackMute                  in=11:0             out=audio       deps=1
-[ 13] Output      det   T-2:hardwareOutput             in=12:0             out=-           deps=1
+[  3] Delay       det   T1/D7:subtractInputDelay       in=2:0              out=audio       deps=1
+[  4] Delay       det   T1/D7:subtractInputDelay#1     in=1:0              out=audio       deps=1
+[  5] Subtract    det   T1/D7:deviceDelta              in=3:0,4:0          out=audio       deps=2
+[  6] Gain        det   T1/D7:deviceGain               in=5:0              out=audio       deps=1
+[  7] Device      det   T1/D8:deviceProcess            in=6:0,-,-          out=audio       deps=1
+[  8] Delay       det   T1/D8:subtractInputDelay       in=7:0              out=audio       deps=1
+[  9] Delay       det   T1/D8:subtractInputDelay#1     in=6:0              out=audio       deps=1
+[ 10] Subtract    det   T1/D8:deviceDelta              in=8:0,9:0          out=audio       deps=2
+[ 11] Gain        det   T1/D8:deviceGain               in=10:0             out=audio       deps=1
+[ 12] Fader       det   T1:trackFader                  in=11:0,-           out=audio       deps=1
+[ 13] Meter       det   T1:trackMeter                  in=12:0             out=audio       deps=1
+[ 14] Gain        det   T1:trackMute                   in=13:0             out=audio       deps=1
+[ 15] MixAudio    det   T-2:trackAudioInput            in=14:0             out=audio       deps=1
+[ 16] Fader       det   T-2:trackFader                 in=15:0,-           out=audio       deps=1
+[ 17] Meter       det   T-2:trackMeter                 in=16:0             out=audio       deps=1
+[ 18] Gain        det   T-2:trackMute                  in=17:0             out=audio       deps=1
+[ 19] Output      det   T-2:hardwareOutput             in=18:0             out=-           deps=1
 ready=0
 
 == layout ==
 magda-plan-layout v1
-audioSlots=1 midiSlots=0 outputLatency=0
+audioSlots=2 midiSlots=0 outputLatency=0
 [  0] ClipAudio   T1:clipAudio                   lat=0       ports=a0
 [  1] MixAudio    T1:trackAudioInput             lat=0       ports=a0          inplace
-[  2] Device      T1/D7:deviceProcess            lat=0       ports=a0          inplace
-[  3] Gain        T1/D7:deviceGain               lat=0       ports=a0          inplace
-[  4] Device      T1/D8:deviceProcess            lat=0       ports=a0          inplace
-[  5] Gain        T1/D8:deviceGain               lat=0       ports=a0          inplace
-[  6] Fader       T1:trackFader                  lat=0       ports=a0          inplace
-[  7] Meter       T1:trackMeter                  lat=0       ports=a0          inplace
-[  8] Gain        T1:trackMute                   lat=0       ports=a0          inplace
-[  9] MixAudio    T-2:trackAudioInput            lat=0       ports=a0          inplace
-[ 10] Fader       T-2:trackFader                 lat=0       ports=a0          inplace
-[ 11] Meter       T-2:trackMeter                 lat=0       ports=a0          inplace
-[ 12] Gain        T-2:trackMute                  lat=0       ports=a0          inplace
-[ 13] Output      T-2:hardwareOutput             lat=-       ports=-
+[  2] Device      T1/D7:deviceProcess            lat=0       ports=a1
+[  3] Delay       T1/D7:subtractInputDelay       lat=0       ports=a1          hold=0 elided
+[  4] Delay       T1/D7:subtractInputDelay#1     lat=0       ports=a0          hold=0 elided
+[  5] Subtract    T1/D7:deviceDelta              lat=0       ports=a1          inplace
+[  6] Gain        T1/D7:deviceGain               lat=0       ports=a1          inplace
+[  7] Device      T1/D8:deviceProcess            lat=0       ports=a0
+[  8] Delay       T1/D8:subtractInputDelay       lat=0       ports=a0          hold=0 elided
+[  9] Delay       T1/D8:subtractInputDelay#1     lat=0       ports=a1          hold=0 elided
+[ 10] Subtract    T1/D8:deviceDelta              lat=0       ports=a0          inplace
+[ 11] Gain        T1/D8:deviceGain               lat=0       ports=a0          inplace
+[ 12] Fader       T1:trackFader                  lat=0       ports=a0          inplace
+[ 13] Meter       T1:trackMeter                  lat=0       ports=a0          inplace
+[ 14] Gain        T1:trackMute                   lat=0       ports=a0          inplace
+[ 15] MixAudio    T-2:trackAudioInput            lat=0       ports=a0          inplace
+[ 16] Fader       T-2:trackFader                 lat=0       ports=a0          inplace
+[ 17] Meter       T-2:trackMeter                 lat=0       ports=a0          inplace
+[ 18] Gain        T-2:trackMute                  lat=0       ports=a0          inplace
+[ 19] Output      T-2:hardwareOutput             lat=-       ports=-
 
 == params ==
 magda-param-table v1
@@ -47,61 +59,81 @@ order:
 
 == edited plan ==
 magda-render-plan v1
-ops=14 outputs=1
+ops=20 outputs=1
 [  0] ClipAudio   det   T1:clipAudio                   in=-                out=audio       deps=0
 [  1] MixAudio    det   T1:trackAudioInput             in=0:0              out=audio       deps=1
 [  2] Device      det   T1/D8:deviceProcess            in=1:0,-,-          out=audio       deps=1
-[  3] Gain        det   T1/D8:deviceGain               in=2:0              out=audio       deps=1
-[  4] Device      det   T1/D7:deviceProcess            in=3:0,-,-          out=audio       deps=1
-[  5] Gain        det   T1/D7:deviceGain               in=4:0              out=audio       deps=1
-[  6] Fader       det   T1:trackFader                  in=5:0,-            out=audio       deps=1
-[  7] Meter       det   T1:trackMeter                  in=6:0              out=audio       deps=1
-[  8] Gain        det   T1:trackMute                   in=7:0              out=audio       deps=1
-[  9] MixAudio    det   T-2:trackAudioInput            in=8:0              out=audio       deps=1
-[ 10] Fader       det   T-2:trackFader                 in=9:0,-            out=audio       deps=1
-[ 11] Meter       det   T-2:trackMeter                 in=10:0             out=audio       deps=1
-[ 12] Gain        det   T-2:trackMute                  in=11:0             out=audio       deps=1
-[ 13] Output      det   T-2:hardwareOutput             in=12:0             out=-           deps=1
+[  3] Delay       det   T1/D8:subtractInputDelay       in=2:0              out=audio       deps=1
+[  4] Delay       det   T1/D8:subtractInputDelay#1     in=1:0              out=audio       deps=1
+[  5] Subtract    det   T1/D8:deviceDelta              in=3:0,4:0          out=audio       deps=2
+[  6] Gain        det   T1/D8:deviceGain               in=5:0              out=audio       deps=1
+[  7] Device      det   T1/D7:deviceProcess            in=6:0,-,-          out=audio       deps=1
+[  8] Delay       det   T1/D7:subtractInputDelay       in=7:0              out=audio       deps=1
+[  9] Delay       det   T1/D7:subtractInputDelay#1     in=6:0              out=audio       deps=1
+[ 10] Subtract    det   T1/D7:deviceDelta              in=8:0,9:0          out=audio       deps=2
+[ 11] Gain        det   T1/D7:deviceGain               in=10:0             out=audio       deps=1
+[ 12] Fader       det   T1:trackFader                  in=11:0,-           out=audio       deps=1
+[ 13] Meter       det   T1:trackMeter                  in=12:0             out=audio       deps=1
+[ 14] Gain        det   T1:trackMute                   in=13:0             out=audio       deps=1
+[ 15] MixAudio    det   T-2:trackAudioInput            in=14:0             out=audio       deps=1
+[ 16] Fader       det   T-2:trackFader                 in=15:0,-           out=audio       deps=1
+[ 17] Meter       det   T-2:trackMeter                 in=16:0             out=audio       deps=1
+[ 18] Gain        det   T-2:trackMute                  in=17:0             out=audio       deps=1
+[ 19] Output      det   T-2:hardwareOutput             in=18:0             out=-           deps=1
 ready=0
 
 == diff ==
 magda-plan-diff v1
-ops=14 carried=11 retired=3
+ops=20 carried=15 retired=5
 [  0] carry   T1:clipAudio                   from=T1:clipAudio
 [  1] carry   T1:trackAudioInput             from=T1:trackAudioInput
 [  2] new     T1/D8:deviceProcess
-[  3] carry   T1/D8:deviceGain               from=T1/D8:deviceGain
-[  4] new     T1/D7:deviceProcess
-[  5] carry   T1/D7:deviceGain               from=T1/D7:deviceGain
-[  6] new     T1:trackFader
-[  7] carry   T1:trackMeter                  from=T1:trackMeter
-[  8] carry   T1:trackMute                   from=T1:trackMute
-[  9] carry   T-2:trackAudioInput            from=T-2:trackAudioInput
-[ 10] carry   T-2:trackFader                 from=T-2:trackFader
-[ 11] carry   T-2:trackMeter                 from=T-2:trackMeter
-[ 12] carry   T-2:trackMute                  from=T-2:trackMute
-[ 13] carry   T-2:hardwareOutput             from=T-2:hardwareOutput
+[  3] carry   T1/D8:subtractInputDelay       from=T1/D8:subtractInputDelay
+[  4] new     T1/D8:subtractInputDelay#1
+[  5] carry   T1/D8:deviceDelta              from=T1/D8:deviceDelta
+[  6] carry   T1/D8:deviceGain               from=T1/D8:deviceGain
+[  7] new     T1/D7:deviceProcess
+[  8] carry   T1/D7:subtractInputDelay       from=T1/D7:subtractInputDelay
+[  9] new     T1/D7:subtractInputDelay#1
+[ 10] carry   T1/D7:deviceDelta              from=T1/D7:deviceDelta
+[ 11] carry   T1/D7:deviceGain               from=T1/D7:deviceGain
+[ 12] new     T1:trackFader
+[ 13] carry   T1:trackMeter                  from=T1:trackMeter
+[ 14] carry   T1:trackMute                   from=T1:trackMute
+[ 15] carry   T-2:trackAudioInput            from=T-2:trackAudioInput
+[ 16] carry   T-2:trackFader                 from=T-2:trackFader
+[ 17] carry   T-2:trackMeter                 from=T-2:trackMeter
+[ 18] carry   T-2:trackMute                  from=T-2:trackMute
+[ 19] carry   T-2:hardwareOutput             from=T-2:hardwareOutput
 retired T1/D7:deviceProcess
+retired T1/D7:subtractInputDelay#1
 retired T1/D8:deviceProcess
+retired T1/D8:subtractInputDelay#1
 retired T1:trackFader
 
 == crossfaded ==
-inserted=1 unfaded=2
+inserted=1 unfaded=4
 magda-render-plan v1
-ops=15 outputs=1
+ops=21 outputs=1
 [  0] ClipAudio   det   T1:clipAudio                   in=-                out=audio       deps=0
 [  1] MixAudio    det   T1:trackAudioInput             in=0:0              out=audio       deps=1
 [  2] Device      det   T1/D8:deviceProcess            in=1:0,-,-          out=audio       deps=1
-[  3] Gain        det   T1/D8:deviceGain               in=2:0              out=audio       deps=1
-[  4] Crossfade   det   T1/D7:edgeCrossfade(deviceProcess slot 0) in=1:0,3:0          out=audio       deps=2
-[  5] Device      det   T1/D7:deviceProcess            in=4:0,-,-          out=audio       deps=1
-[  6] Gain        det   T1/D7:deviceGain               in=5:0              out=audio       deps=1
-[  7] Fader       det   T1:trackFader                  in=6:0,-            out=audio       deps=1
-[  8] Meter       det   T1:trackMeter                  in=7:0              out=audio       deps=1
-[  9] Gain        det   T1:trackMute                   in=8:0              out=audio       deps=1
-[ 10] MixAudio    det   T-2:trackAudioInput            in=9:0              out=audio       deps=1
-[ 11] Fader       det   T-2:trackFader                 in=10:0,-           out=audio       deps=1
-[ 12] Meter       det   T-2:trackMeter                 in=11:0             out=audio       deps=1
-[ 13] Gain        det   T-2:trackMute                  in=12:0             out=audio       deps=1
-[ 14] Output      det   T-2:hardwareOutput             in=13:0             out=-           deps=1
+[  3] Delay       det   T1/D8:subtractInputDelay       in=2:0              out=audio       deps=1
+[  4] Delay       det   T1/D8:subtractInputDelay#1     in=1:0              out=audio       deps=1
+[  5] Subtract    det   T1/D8:deviceDelta              in=3:0,4:0          out=audio       deps=2
+[  6] Gain        det   T1/D8:deviceGain               in=5:0              out=audio       deps=1
+[  7] Crossfade   det   T1/D7:edgeCrossfade(deviceProcess slot 0) in=1:0,6:0          out=audio       deps=2
+[  8] Device      det   T1/D7:deviceProcess            in=7:0,-,-          out=audio       deps=1
+[  9] Delay       det   T1/D7:subtractInputDelay       in=8:0              out=audio       deps=1
+[ 10] Delay       det   T1/D7:subtractInputDelay#1     in=6:0              out=audio       deps=1
+[ 11] Subtract    det   T1/D7:deviceDelta              in=9:0,10:0         out=audio       deps=2
+[ 12] Gain        det   T1/D7:deviceGain               in=11:0             out=audio       deps=1
+[ 13] Fader       det   T1:trackFader                  in=12:0,-           out=audio       deps=1
+[ 14] Meter       det   T1:trackMeter                  in=13:0             out=audio       deps=1
+[ 15] Gain        det   T1:trackMute                   in=14:0             out=audio       deps=1
+[ 16] MixAudio    det   T-2:trackAudioInput            in=15:0             out=audio       deps=1
+[ 17] Fader       det   T-2:trackFader                 in=16:0,-           out=audio       deps=1
+[ 18] Meter       det   T-2:trackMeter                 in=17:0             out=audio       deps=1
+[ 19] Gain        det   T-2:trackMute                  in=18:0             out=audio       deps=1
+[ 20] Output      det   T-2:hardwareOutput             in=19:0             out=-           deps=1
 ready=0

--- a/tests/goldens/plan/fan-in.txt
+++ b/tests/goldens/plan/fan-in.txt
@@ -5,50 +5,56 @@
 
 == plan ==
 magda-render-plan v1
-ops=19 outputs=1
+ops=22 outputs=1
 [  0] ClipAudio   det   T1:clipAudio                   in=-                out=audio       deps=0
 [  1] MixAudio    det   T1:trackAudioInput             in=0:0              out=audio       deps=1
 [  2] Device      det   T1/D7:deviceProcess            in=1:0,-,-          out=audio       deps=1
-[  3] Gain        det   T1/D7:deviceGain               in=2:0              out=audio       deps=1
-[  4] Fader       det   T1:trackFader                  in=3:0,-            out=audio       deps=1
-[  5] Meter       det   T1:trackMeter                  in=4:0              out=audio       deps=1
-[  6] Gain        det   T1:trackMute                   in=5:0              out=audio       deps=1
-[  7] ClipAudio   det   T2:clipAudio                   in=-                out=audio       deps=0
-[  8] MixAudio    det   T2:trackAudioInput             in=7:0              out=audio       deps=1
-[  9] Fader       det   T2:trackFader                  in=8:0,-            out=audio       deps=1
-[ 10] Meter       det   T2:trackMeter                  in=9:0              out=audio       deps=1
-[ 11] Gain        det   T2:trackMute                   in=10:0             out=audio       deps=1
-[ 12] Delay       det   T-2:mixInputDelay              in=6:0              out=audio       deps=1
-[ 13] Delay       det   T-2:mixInputDelay#1            in=11:0             out=audio       deps=1
-[ 14] MixAudio    det   T-2:trackAudioInput            in=12:0,13:0        out=audio       deps=2
-[ 15] Fader       det   T-2:trackFader                 in=14:0,-           out=audio       deps=1
-[ 16] Meter       det   T-2:trackMeter                 in=15:0             out=audio       deps=1
-[ 17] Gain        det   T-2:trackMute                  in=16:0             out=audio       deps=1
-[ 18] Output      det   T-2:hardwareOutput             in=17:0             out=-           deps=1
-ready=0,7
+[  3] Delay       det   T1/D7:subtractInputDelay       in=2:0              out=audio       deps=1
+[  4] Delay       det   T1/D7:subtractInputDelay#1     in=1:0              out=audio       deps=1
+[  5] Subtract    det   T1/D7:deviceDelta              in=3:0,4:0          out=audio       deps=2
+[  6] Gain        det   T1/D7:deviceGain               in=5:0              out=audio       deps=1
+[  7] Fader       det   T1:trackFader                  in=6:0,-            out=audio       deps=1
+[  8] Meter       det   T1:trackMeter                  in=7:0              out=audio       deps=1
+[  9] Gain        det   T1:trackMute                   in=8:0              out=audio       deps=1
+[ 10] ClipAudio   det   T2:clipAudio                   in=-                out=audio       deps=0
+[ 11] MixAudio    det   T2:trackAudioInput             in=10:0             out=audio       deps=1
+[ 12] Fader       det   T2:trackFader                  in=11:0,-           out=audio       deps=1
+[ 13] Meter       det   T2:trackMeter                  in=12:0             out=audio       deps=1
+[ 14] Gain        det   T2:trackMute                   in=13:0             out=audio       deps=1
+[ 15] Delay       det   T-2:mixInputDelay              in=9:0              out=audio       deps=1
+[ 16] Delay       det   T-2:mixInputDelay#1            in=14:0             out=audio       deps=1
+[ 17] MixAudio    det   T-2:trackAudioInput            in=15:0,16:0        out=audio       deps=2
+[ 18] Fader       det   T-2:trackFader                 in=17:0,-           out=audio       deps=1
+[ 19] Meter       det   T-2:trackMeter                 in=18:0             out=audio       deps=1
+[ 20] Gain        det   T-2:trackMute                  in=19:0             out=audio       deps=1
+[ 21] Output      det   T-2:hardwareOutput             in=20:0             out=-           deps=1
+ready=0,10
 
 == layout ==
 magda-plan-layout v1
-audioSlots=2 midiSlots=0 outputLatency=64
+audioSlots=4 midiSlots=0 outputLatency=64
 [  0] ClipAudio   T1:clipAudio                   lat=0       ports=a0
 [  1] MixAudio    T1:trackAudioInput             lat=0       ports=a0          inplace
-[  2] Device      T1/D7:deviceProcess            lat=64      ports=a0          inplace
-[  3] Gain        T1/D7:deviceGain               lat=64      ports=a0          inplace
-[  4] Fader       T1:trackFader                  lat=64      ports=a0          inplace
-[  5] Meter       T1:trackMeter                  lat=64      ports=a0          inplace
-[  6] Gain        T1:trackMute                   lat=64      ports=a0          inplace
-[  7] ClipAudio   T2:clipAudio                   lat=0       ports=a1
-[  8] MixAudio    T2:trackAudioInput             lat=0       ports=a1          inplace
-[  9] Fader       T2:trackFader                  lat=0       ports=a1          inplace
-[ 10] Meter       T2:trackMeter                  lat=0       ports=a1          inplace
-[ 11] Gain        T2:trackMute                   lat=0       ports=a1          inplace
-[ 12] Delay       T-2:mixInputDelay              lat=64      ports=a0          hold=0 elided
-[ 13] Delay       T-2:mixInputDelay#1            lat=64      ports=a1          hold=64 inplace
-[ 14] MixAudio    T-2:trackAudioInput            lat=64      ports=a0          inplace
-[ 15] Fader       T-2:trackFader                 lat=64      ports=a0          inplace
-[ 16] Meter       T-2:trackMeter                 lat=64      ports=a0          inplace
-[ 17] Gain        T-2:trackMute                  lat=64      ports=a0          inplace
-[ 18] Output      T-2:hardwareOutput             lat=-       ports=-
+[  2] Device      T1/D7:deviceProcess            lat=64      ports=a1
+[  3] Delay       T1/D7:subtractInputDelay       lat=64      ports=a1          hold=0 elided
+[  4] Delay       T1/D7:subtractInputDelay#1     lat=64      ports=a2          hold=64
+[  5] Subtract    T1/D7:deviceDelta              lat=64      ports=a1          inplace
+[  6] Gain        T1/D7:deviceGain               lat=64      ports=a1          inplace
+[  7] Fader       T1:trackFader                  lat=64      ports=a1          inplace
+[  8] Meter       T1:trackMeter                  lat=64      ports=a1          inplace
+[  9] Gain        T1:trackMute                   lat=64      ports=a1          inplace
+[ 10] ClipAudio   T2:clipAudio                   lat=0       ports=a3
+[ 11] MixAudio    T2:trackAudioInput             lat=0       ports=a3          inplace
+[ 12] Fader       T2:trackFader                  lat=0       ports=a3          inplace
+[ 13] Meter       T2:trackMeter                  lat=0       ports=a3          inplace
+[ 14] Gain        T2:trackMute                   lat=0       ports=a3          inplace
+[ 15] Delay       T-2:mixInputDelay              lat=64      ports=a1          hold=0 elided
+[ 16] Delay       T-2:mixInputDelay#1            lat=64      ports=a3          hold=64 inplace
+[ 17] MixAudio    T-2:trackAudioInput            lat=64      ports=a1          inplace
+[ 18] Fader       T-2:trackFader                 lat=64      ports=a1          inplace
+[ 19] Meter       T-2:trackMeter                 lat=64      ports=a1          inplace
+[ 20] Gain        T-2:trackMute                  lat=64      ports=a1          inplace
+[ 21] Output      T-2:hardwareOutput             lat=-       ports=-
 
 == params ==
 magda-param-table v1

--- a/tests/goldens/plan/group-routing.txt
+++ b/tests/goldens/plan/group-routing.txt
@@ -5,7 +5,7 @@
 
 == plan ==
 magda-render-plan v1
-ops=16 outputs=1
+ops=19 outputs=1
 [  0] ClipAudio   det   T1:clipAudio                   in=-                out=audio       deps=0
 [  1] MixAudio    det   T1:trackAudioInput             in=0:0              out=audio       deps=1
 [  2] Fader       det   T1:trackFader                  in=1:0,-            out=audio       deps=1
@@ -13,36 +13,42 @@ ops=16 outputs=1
 [  4] Gain        det   T1:trackMute                   in=3:0              out=audio       deps=1
 [  5] MixAudio    det   T2:trackAudioInput             in=4:0              out=audio       deps=1
 [  6] Device      det   T2/D7:deviceProcess            in=5:0,-,-          out=audio       deps=1
-[  7] Gain        det   T2/D7:deviceGain               in=6:0              out=audio       deps=1
-[  8] Fader       det   T2:trackFader                  in=7:0,-            out=audio       deps=1
-[  9] Meter       det   T2:trackMeter                  in=8:0              out=audio       deps=1
-[ 10] Gain        det   T2:trackMute                   in=9:0              out=audio       deps=1
-[ 11] MixAudio    det   T-2:trackAudioInput            in=10:0             out=audio       deps=1
-[ 12] Fader       det   T-2:trackFader                 in=11:0,-           out=audio       deps=1
-[ 13] Meter       det   T-2:trackMeter                 in=12:0             out=audio       deps=1
-[ 14] Gain        det   T-2:trackMute                  in=13:0             out=audio       deps=1
-[ 15] Output      det   T-2:hardwareOutput             in=14:0             out=-           deps=1
+[  7] Delay       det   T2/D7:subtractInputDelay       in=6:0              out=audio       deps=1
+[  8] Delay       det   T2/D7:subtractInputDelay#1     in=5:0              out=audio       deps=1
+[  9] Subtract    det   T2/D7:deviceDelta              in=7:0,8:0          out=audio       deps=2
+[ 10] Gain        det   T2/D7:deviceGain               in=9:0              out=audio       deps=1
+[ 11] Fader       det   T2:trackFader                  in=10:0,-           out=audio       deps=1
+[ 12] Meter       det   T2:trackMeter                  in=11:0             out=audio       deps=1
+[ 13] Gain        det   T2:trackMute                   in=12:0             out=audio       deps=1
+[ 14] MixAudio    det   T-2:trackAudioInput            in=13:0             out=audio       deps=1
+[ 15] Fader       det   T-2:trackFader                 in=14:0,-           out=audio       deps=1
+[ 16] Meter       det   T-2:trackMeter                 in=15:0             out=audio       deps=1
+[ 17] Gain        det   T-2:trackMute                  in=16:0             out=audio       deps=1
+[ 18] Output      det   T-2:hardwareOutput             in=17:0             out=-           deps=1
 ready=0
 
 == layout ==
 magda-plan-layout v1
-audioSlots=1 midiSlots=0 outputLatency=0
+audioSlots=2 midiSlots=0 outputLatency=0
 [  0] ClipAudio   T1:clipAudio                   lat=0       ports=a0
 [  1] MixAudio    T1:trackAudioInput             lat=0       ports=a0          inplace
 [  2] Fader       T1:trackFader                  lat=0       ports=a0          inplace
 [  3] Meter       T1:trackMeter                  lat=0       ports=a0          inplace
 [  4] Gain        T1:trackMute                   lat=0       ports=a0          inplace
 [  5] MixAudio    T2:trackAudioInput             lat=0       ports=a0          inplace
-[  6] Device      T2/D7:deviceProcess            lat=0       ports=a0          inplace
-[  7] Gain        T2/D7:deviceGain               lat=0       ports=a0          inplace
-[  8] Fader       T2:trackFader                  lat=0       ports=a0          inplace
-[  9] Meter       T2:trackMeter                  lat=0       ports=a0          inplace
-[ 10] Gain        T2:trackMute                   lat=0       ports=a0          inplace
-[ 11] MixAudio    T-2:trackAudioInput            lat=0       ports=a0          inplace
-[ 12] Fader       T-2:trackFader                 lat=0       ports=a0          inplace
-[ 13] Meter       T-2:trackMeter                 lat=0       ports=a0          inplace
-[ 14] Gain        T-2:trackMute                  lat=0       ports=a0          inplace
-[ 15] Output      T-2:hardwareOutput             lat=-       ports=-
+[  6] Device      T2/D7:deviceProcess            lat=0       ports=a1
+[  7] Delay       T2/D7:subtractInputDelay       lat=0       ports=a1          hold=0 elided
+[  8] Delay       T2/D7:subtractInputDelay#1     lat=0       ports=a0          hold=0 elided
+[  9] Subtract    T2/D7:deviceDelta              lat=0       ports=a1          inplace
+[ 10] Gain        T2/D7:deviceGain               lat=0       ports=a1          inplace
+[ 11] Fader       T2:trackFader                  lat=0       ports=a1          inplace
+[ 12] Meter       T2:trackMeter                  lat=0       ports=a1          inplace
+[ 13] Gain        T2:trackMute                   lat=0       ports=a1          inplace
+[ 14] MixAudio    T-2:trackAudioInput            lat=0       ports=a1          inplace
+[ 15] Fader       T-2:trackFader                 lat=0       ports=a1          inplace
+[ 16] Meter       T-2:trackMeter                 lat=0       ports=a1          inplace
+[ 17] Gain        T-2:trackMute                  lat=0       ports=a1          inplace
+[ 18] Output      T-2:hardwareOutput             lat=-       ports=-
 
 == params ==
 magda-param-table v1

--- a/tests/goldens/plan/instrument-track.txt
+++ b/tests/goldens/plan/instrument-track.txt
@@ -5,7 +5,7 @@
 
 == plan ==
 magda-render-plan v1
-ops=20 outputs=1
+ops=26 outputs=1
 [  0] ClipAudio   det   T1:clipAudio                   in=-                out=audio       deps=0
 [  1] MixAudio    det   T1:trackAudioInput             in=0:0              out=audio       deps=1
 [  2] ClipMidi    det   T1:clipMidi                    in=-                out=midi        deps=0
@@ -13,44 +13,56 @@ ops=20 outputs=1
 [  4] Delay       det   T1/D3:deviceInputDelay         in=1:0              out=audio       deps=1
 [  5] Delay       det   T1/D3:deviceInputDelay#1       in=3:0              out=midi        deps=1
 [  6] Device      det   T1/D3:deviceProcess            in=4:0,5:0,-        out=audio       deps=2
-[  7] Gain        det   T1/D3:deviceGain               in=6:0              out=audio       deps=1
-[  8] Delay       det   T1/D7:deviceInputDelay         in=7:0              out=audio       deps=1
-[  9] Delay       det   T1/D7:deviceInputDelay#1       in=3:0              out=midi        deps=1
-[ 10] Device      det   T1/D7:deviceProcess            in=8:0,9:0,-        out=audio       deps=2
-[ 11] Gain        det   T1/D7:deviceGain               in=10:0             out=audio       deps=1
-[ 12] Fader       det   T1:trackFader                  in=11:0,-           out=audio       deps=1
-[ 13] Meter       det   T1:trackMeter                  in=12:0             out=audio       deps=1
-[ 14] Gain        det   T1:trackMute                   in=13:0             out=audio       deps=1
-[ 15] MixAudio    det   T-2:trackAudioInput            in=14:0             out=audio       deps=1
-[ 16] Fader       det   T-2:trackFader                 in=15:0,-           out=audio       deps=1
-[ 17] Meter       det   T-2:trackMeter                 in=16:0             out=audio       deps=1
-[ 18] Gain        det   T-2:trackMute                  in=17:0             out=audio       deps=1
-[ 19] Output      det   T-2:hardwareOutput             in=18:0             out=-           deps=1
+[  7] Delay       det   T1/D3:subtractInputDelay       in=6:0              out=audio       deps=1
+[  8] Delay       det   T1/D3:subtractInputDelay#1     in=1:0              out=audio       deps=1
+[  9] Subtract    det   T1/D3:deviceDelta              in=7:0,8:0          out=audio       deps=2
+[ 10] Gain        det   T1/D3:deviceGain               in=9:0              out=audio       deps=1
+[ 11] Delay       det   T1/D7:deviceInputDelay         in=10:0             out=audio       deps=1
+[ 12] Delay       det   T1/D7:deviceInputDelay#1       in=3:0              out=midi        deps=1
+[ 13] Device      det   T1/D7:deviceProcess            in=11:0,12:0,-      out=audio       deps=2
+[ 14] Delay       det   T1/D7:subtractInputDelay       in=13:0             out=audio       deps=1
+[ 15] Delay       det   T1/D7:subtractInputDelay#1     in=10:0             out=audio       deps=1
+[ 16] Subtract    det   T1/D7:deviceDelta              in=14:0,15:0        out=audio       deps=2
+[ 17] Gain        det   T1/D7:deviceGain               in=16:0             out=audio       deps=1
+[ 18] Fader       det   T1:trackFader                  in=17:0,-           out=audio       deps=1
+[ 19] Meter       det   T1:trackMeter                  in=18:0             out=audio       deps=1
+[ 20] Gain        det   T1:trackMute                   in=19:0             out=audio       deps=1
+[ 21] MixAudio    det   T-2:trackAudioInput            in=20:0             out=audio       deps=1
+[ 22] Fader       det   T-2:trackFader                 in=21:0,-           out=audio       deps=1
+[ 23] Meter       det   T-2:trackMeter                 in=22:0             out=audio       deps=1
+[ 24] Gain        det   T-2:trackMute                  in=23:0             out=audio       deps=1
+[ 25] Output      det   T-2:hardwareOutput             in=24:0             out=-           deps=1
 ready=0,2
 
 == layout ==
 magda-plan-layout v1
-audioSlots=1 midiSlots=2 outputLatency=0
+audioSlots=2 midiSlots=2 outputLatency=0
 [  0] ClipAudio   T1:clipAudio                   lat=0       ports=a0
 [  1] MixAudio    T1:trackAudioInput             lat=0       ports=a0          inplace
 [  2] ClipMidi    T1:clipMidi                    lat=0       ports=m0
 [  3] MergeMidi   T1:trackMidiInput              lat=0       ports=m1
 [  4] Delay       T1/D3:deviceInputDelay         lat=0       ports=a0          hold=0 elided
 [  5] Delay       T1/D3:deviceInputDelay#1       lat=0       ports=m1          hold=0 elided
-[  6] Device      T1/D3:deviceProcess            lat=0       ports=a0          inplace
-[  7] Gain        T1/D3:deviceGain               lat=0       ports=a0          inplace
-[  8] Delay       T1/D7:deviceInputDelay         lat=0       ports=a0          hold=0 elided
-[  9] Delay       T1/D7:deviceInputDelay#1       lat=0       ports=m1          hold=0 elided
-[ 10] Device      T1/D7:deviceProcess            lat=0       ports=a0          inplace
-[ 11] Gain        T1/D7:deviceGain               lat=0       ports=a0          inplace
-[ 12] Fader       T1:trackFader                  lat=0       ports=a0          inplace
-[ 13] Meter       T1:trackMeter                  lat=0       ports=a0          inplace
-[ 14] Gain        T1:trackMute                   lat=0       ports=a0          inplace
-[ 15] MixAudio    T-2:trackAudioInput            lat=0       ports=a0          inplace
-[ 16] Fader       T-2:trackFader                 lat=0       ports=a0          inplace
-[ 17] Meter       T-2:trackMeter                 lat=0       ports=a0          inplace
-[ 18] Gain        T-2:trackMute                  lat=0       ports=a0          inplace
-[ 19] Output      T-2:hardwareOutput             lat=-       ports=-
+[  6] Device      T1/D3:deviceProcess            lat=0       ports=a1
+[  7] Delay       T1/D3:subtractInputDelay       lat=0       ports=a1          hold=0 elided
+[  8] Delay       T1/D3:subtractInputDelay#1     lat=0       ports=a0          hold=0 elided
+[  9] Subtract    T1/D3:deviceDelta              lat=0       ports=a1          inplace
+[ 10] Gain        T1/D3:deviceGain               lat=0       ports=a1          inplace
+[ 11] Delay       T1/D7:deviceInputDelay         lat=0       ports=a1          hold=0 elided
+[ 12] Delay       T1/D7:deviceInputDelay#1       lat=0       ports=m1          hold=0 elided
+[ 13] Device      T1/D7:deviceProcess            lat=0       ports=a0
+[ 14] Delay       T1/D7:subtractInputDelay       lat=0       ports=a0          hold=0 elided
+[ 15] Delay       T1/D7:subtractInputDelay#1     lat=0       ports=a1          hold=0 elided
+[ 16] Subtract    T1/D7:deviceDelta              lat=0       ports=a0          inplace
+[ 17] Gain        T1/D7:deviceGain               lat=0       ports=a0          inplace
+[ 18] Fader       T1:trackFader                  lat=0       ports=a0          inplace
+[ 19] Meter       T1:trackMeter                  lat=0       ports=a0          inplace
+[ 20] Gain        T1:trackMute                   lat=0       ports=a0          inplace
+[ 21] MixAudio    T-2:trackAudioInput            lat=0       ports=a0          inplace
+[ 22] Fader       T-2:trackFader                 lat=0       ports=a0          inplace
+[ 23] Meter       T-2:trackMeter                 lat=0       ports=a0          inplace
+[ 24] Gain        T-2:trackMute                  lat=0       ports=a0          inplace
+[ 25] Output      T-2:hardwareOutput             lat=-       ports=-
 
 == params ==
 magda-param-table v1

--- a/tests/goldens/plan/modulation-sources.txt
+++ b/tests/goldens/plan/modulation-sources.txt
@@ -5,72 +5,90 @@
 
 == plan ==
 magda-render-plan v1
-ops=30 outputs=1
+ops=39 outputs=1
 [  0] ClipAudio   det   T1:clipAudio                   in=-                out=audio       deps=0
 [  1] MixAudio    det   T1:trackAudioInput             in=0:0              out=audio       deps=1
 [  2] Device      det   T1/R4/C10/D7:deviceProcess     in=1:0,-,-          out=audio       deps=1
-[  3] Gain        det   T1/R4/C10/D7:deviceGain        in=2:0              out=audio       deps=1
-[  4] Fader       det   T1/R4/C10:rackChainFader       in=3:0,-            out=audio       deps=1
-[  5] MixAudio    det   T1/R4:rackMix                  in=4:0              out=audio       deps=1
-[  6] Fader       det   T1/R4:rackFader                in=5:0,-            out=audio       deps=1
-[  7] Fader       det   T1:trackFader                  in=6:0,-            out=audio       deps=1
-[  8] Meter       det   T1:trackMeter                  in=7:0              out=audio       deps=1
-[  9] Gain        det   T1:trackMute                   in=8:0              out=audio       deps=1
-[ 10] ClipAudio   det   T2:clipAudio                   in=-                out=audio       deps=0
-[ 11] MixAudio    det   T2:trackAudioInput             in=10:0             out=audio       deps=1
-[ 12] ClipMidi    det   T2:clipMidi                    in=-                out=midi        deps=0
-[ 13] MergeMidi   det   T2:trackMidiInput              in=12:0             out=midi        deps=1
-[ 14] Delay       det   T2/D9:deviceInputDelay         in=11:0             out=audio       deps=1
-[ 15] Delay       det   T2/D9:deviceInputDelay#1       in=13:0             out=midi        deps=1
-[ 16] Device      det   T2/D9:deviceProcess            in=14:0,15:0,-      out=audio       deps=2
-[ 17] Gain        det   T2/D9:deviceGain               in=16:0             out=audio       deps=1
-[ 18] Fader       det   T2:trackFader                  in=17:0,-           out=audio       deps=1
-[ 19] Meter       det   T2:trackMeter                  in=18:0             out=audio       deps=1
-[ 20] Gain        det   T2:trackMute                   in=19:0             out=audio       deps=1
-[ 21] Delay       det   T-2:mixInputDelay              in=9:0              out=audio       deps=1
-[ 22] Delay       det   T-2:mixInputDelay#1            in=20:0             out=audio       deps=1
-[ 23] MixAudio    det   T-2:trackAudioInput            in=21:0,22:0        out=audio       deps=2
-[ 24] Fader       det   T-2:trackFader                 in=23:0,-           out=audio       deps=1
-[ 25] Meter       det   T-2:trackMeter                 in=24:0             out=audio       deps=1
-[ 26] Gain        det   T-2:trackMute                  in=25:0             out=audio       deps=1
-[ 27] Output      det   T-2:hardwareOutput             in=26:0             out=-           deps=1
-[ 28] ModSource   det   T2:modulationTap               in=11:0,13:0        out=-           deps=2
-[ 29] ModSource   det   T2:modulationTap#1             in=19:0,-           out=-           deps=1
-ready=0,10,12
+[  3] Delay       det   T1/R4/C10/D7:subtractInputDelay in=2:0              out=audio       deps=1
+[  4] Delay       det   T1/R4/C10/D7:subtractInputDelay#1 in=1:0              out=audio       deps=1
+[  5] Subtract    det   T1/R4/C10/D7:deviceDelta       in=3:0,4:0          out=audio       deps=2
+[  6] Gain        det   T1/R4/C10/D7:deviceGain        in=5:0              out=audio       deps=1
+[  7] Fader       det   T1/R4/C10:rackChainFader       in=6:0,-            out=audio       deps=1
+[  8] MixAudio    det   T1/R4:rackMix                  in=7:0              out=audio       deps=1
+[  9] Fader       det   T1/R4:rackFader                in=8:0,-            out=audio       deps=1
+[ 10] Delay       det   T1/R4:subtractInputDelay       in=9:0              out=audio       deps=1
+[ 11] Delay       det   T1/R4:subtractInputDelay#1     in=1:0              out=audio       deps=1
+[ 12] Subtract    det   T1/R4:rackDelta                in=10:0,11:0        out=audio       deps=2
+[ 13] Fader       det   T1:trackFader                  in=12:0,-           out=audio       deps=1
+[ 14] Meter       det   T1:trackMeter                  in=13:0             out=audio       deps=1
+[ 15] Gain        det   T1:trackMute                   in=14:0             out=audio       deps=1
+[ 16] ClipAudio   det   T2:clipAudio                   in=-                out=audio       deps=0
+[ 17] MixAudio    det   T2:trackAudioInput             in=16:0             out=audio       deps=1
+[ 18] ClipMidi    det   T2:clipMidi                    in=-                out=midi        deps=0
+[ 19] MergeMidi   det   T2:trackMidiInput              in=18:0             out=midi        deps=1
+[ 20] Delay       det   T2/D9:deviceInputDelay         in=17:0             out=audio       deps=1
+[ 21] Delay       det   T2/D9:deviceInputDelay#1       in=19:0             out=midi        deps=1
+[ 22] Device      det   T2/D9:deviceProcess            in=20:0,21:0,-      out=audio       deps=2
+[ 23] Delay       det   T2/D9:subtractInputDelay       in=22:0             out=audio       deps=1
+[ 24] Delay       det   T2/D9:subtractInputDelay#1     in=17:0             out=audio       deps=1
+[ 25] Subtract    det   T2/D9:deviceDelta              in=23:0,24:0        out=audio       deps=2
+[ 26] Gain        det   T2/D9:deviceGain               in=25:0             out=audio       deps=1
+[ 27] Fader       det   T2:trackFader                  in=26:0,-           out=audio       deps=1
+[ 28] Meter       det   T2:trackMeter                  in=27:0             out=audio       deps=1
+[ 29] Gain        det   T2:trackMute                   in=28:0             out=audio       deps=1
+[ 30] Delay       det   T-2:mixInputDelay              in=15:0             out=audio       deps=1
+[ 31] Delay       det   T-2:mixInputDelay#1            in=29:0             out=audio       deps=1
+[ 32] MixAudio    det   T-2:trackAudioInput            in=30:0,31:0        out=audio       deps=2
+[ 33] Fader       det   T-2:trackFader                 in=32:0,-           out=audio       deps=1
+[ 34] Meter       det   T-2:trackMeter                 in=33:0             out=audio       deps=1
+[ 35] Gain        det   T-2:trackMute                  in=34:0             out=audio       deps=1
+[ 36] Output      det   T-2:hardwareOutput             in=35:0             out=-           deps=1
+[ 37] ModSource   det   T2:modulationTap               in=17:0,19:0        out=-           deps=2
+[ 38] ModSource   det   T2:modulationTap#1             in=28:0,-           out=-           deps=1
+ready=0,16,18
 
 == layout ==
 magda-plan-layout v1
-audioSlots=4 midiSlots=2 outputLatency=0
+audioSlots=5 midiSlots=2 outputLatency=0
 [  0] ClipAudio   T1:clipAudio                   lat=0       ports=a0
 [  1] MixAudio    T1:trackAudioInput             lat=0       ports=a0          inplace
-[  2] Device      T1/R4/C10/D7:deviceProcess     lat=0       ports=a0          inplace
-[  3] Gain        T1/R4/C10/D7:deviceGain        lat=0       ports=a0          inplace
-[  4] Fader       T1/R4/C10:rackChainFader       lat=0       ports=a0          inplace
-[  5] MixAudio    T1/R4:rackMix                  lat=0       ports=a0          inplace
-[  6] Fader       T1/R4:rackFader                lat=0       ports=a0          inplace
-[  7] Fader       T1:trackFader                  lat=0       ports=a0          inplace
-[  8] Meter       T1:trackMeter                  lat=0       ports=a0          inplace
-[  9] Gain        T1:trackMute                   lat=0       ports=a0          inplace
-[ 10] ClipAudio   T2:clipAudio                   lat=0       ports=a1
-[ 11] MixAudio    T2:trackAudioInput             lat=0       ports=a1          inplace
-[ 12] ClipMidi    T2:clipMidi                    lat=0       ports=m0
-[ 13] MergeMidi   T2:trackMidiInput              lat=0       ports=m1
-[ 14] Delay       T2/D9:deviceInputDelay         lat=0       ports=a1          hold=0 elided
-[ 15] Delay       T2/D9:deviceInputDelay#1       lat=0       ports=m1          hold=0 elided
-[ 16] Device      T2/D9:deviceProcess            lat=0       ports=a2
-[ 17] Gain        T2/D9:deviceGain               lat=0       ports=a2          inplace
-[ 18] Fader       T2:trackFader                  lat=0       ports=a2          inplace
-[ 19] Meter       T2:trackMeter                  lat=0       ports=a2          inplace
-[ 20] Gain        T2:trackMute                   lat=0       ports=a3
-[ 21] Delay       T-2:mixInputDelay              lat=0       ports=a0          hold=0 elided
-[ 22] Delay       T-2:mixInputDelay#1            lat=0       ports=a3          hold=0 elided
-[ 23] MixAudio    T-2:trackAudioInput            lat=0       ports=a0          inplace
-[ 24] Fader       T-2:trackFader                 lat=0       ports=a0          inplace
-[ 25] Meter       T-2:trackMeter                 lat=0       ports=a0          inplace
-[ 26] Gain        T-2:trackMute                  lat=0       ports=a0          inplace
-[ 27] Output      T-2:hardwareOutput             lat=-       ports=-
-[ 28] ModSource   T2:modulationTap               lat=-       ports=-
-[ 29] ModSource   T2:modulationTap#1             lat=-       ports=-
+[  2] Device      T1/R4/C10/D7:deviceProcess     lat=0       ports=a1
+[  3] Delay       T1/R4/C10/D7:subtractInputDelay lat=0       ports=a1          hold=0 elided
+[  4] Delay       T1/R4/C10/D7:subtractInputDelay#1 lat=0       ports=a0          hold=0 elided
+[  5] Subtract    T1/R4/C10/D7:deviceDelta       lat=0       ports=a1          inplace
+[  6] Gain        T1/R4/C10/D7:deviceGain        lat=0       ports=a1          inplace
+[  7] Fader       T1/R4/C10:rackChainFader       lat=0       ports=a1          inplace
+[  8] MixAudio    T1/R4:rackMix                  lat=0       ports=a1          inplace
+[  9] Fader       T1/R4:rackFader                lat=0       ports=a1          inplace
+[ 10] Delay       T1/R4:subtractInputDelay       lat=0       ports=a1          hold=0 elided
+[ 11] Delay       T1/R4:subtractInputDelay#1     lat=0       ports=a0          hold=0 elided
+[ 12] Subtract    T1/R4:rackDelta                lat=0       ports=a1          inplace
+[ 13] Fader       T1:trackFader                  lat=0       ports=a1          inplace
+[ 14] Meter       T1:trackMeter                  lat=0       ports=a1          inplace
+[ 15] Gain        T1:trackMute                   lat=0       ports=a1          inplace
+[ 16] ClipAudio   T2:clipAudio                   lat=0       ports=a2
+[ 17] MixAudio    T2:trackAudioInput             lat=0       ports=a2          inplace
+[ 18] ClipMidi    T2:clipMidi                    lat=0       ports=m0
+[ 19] MergeMidi   T2:trackMidiInput              lat=0       ports=m1
+[ 20] Delay       T2/D9:deviceInputDelay         lat=0       ports=a2          hold=0 elided
+[ 21] Delay       T2/D9:deviceInputDelay#1       lat=0       ports=m1          hold=0 elided
+[ 22] Device      T2/D9:deviceProcess            lat=0       ports=a3
+[ 23] Delay       T2/D9:subtractInputDelay       lat=0       ports=a3          hold=0 elided
+[ 24] Delay       T2/D9:subtractInputDelay#1     lat=0       ports=a2          hold=0 elided
+[ 25] Subtract    T2/D9:deviceDelta              lat=0       ports=a3          inplace
+[ 26] Gain        T2/D9:deviceGain               lat=0       ports=a3          inplace
+[ 27] Fader       T2:trackFader                  lat=0       ports=a3          inplace
+[ 28] Meter       T2:trackMeter                  lat=0       ports=a3          inplace
+[ 29] Gain        T2:trackMute                   lat=0       ports=a4
+[ 30] Delay       T-2:mixInputDelay              lat=0       ports=a1          hold=0 elided
+[ 31] Delay       T-2:mixInputDelay#1            lat=0       ports=a4          hold=0 elided
+[ 32] MixAudio    T-2:trackAudioInput            lat=0       ports=a1          inplace
+[ 33] Fader       T-2:trackFader                 lat=0       ports=a1          inplace
+[ 34] Meter       T-2:trackMeter                 lat=0       ports=a1          inplace
+[ 35] Gain        T-2:trackMute                  lat=0       ports=a1          inplace
+[ 36] Output      T-2:hardwareOutput             lat=-       ports=-
+[ 37] ModSource   T2:modulationTap               lat=-       ports=-
+[ 38] ModSource   T2:modulationTap#1             lat=-       ports=-
 
 == params ==
 magda-param-table v1

--- a/tests/goldens/plan/parameter-links.txt
+++ b/tests/goldens/plan/parameter-links.txt
@@ -5,36 +5,42 @@
 
 == plan ==
 magda-render-plan v1
-ops=12 outputs=1
+ops=15 outputs=1
 [  0] ClipAudio   det   T1:clipAudio                   in=-                out=audio       deps=0
 [  1] MixAudio    det   T1:trackAudioInput             in=0:0              out=audio       deps=1
 [  2] Device      det   T1/D7:deviceProcess            in=1:0,-,-          out=audio       deps=1
-[  3] Gain        det   T1/D7:deviceGain               in=2:0              out=audio       deps=1
-[  4] Fader       det   T1:trackFader                  in=3:0,-            out=audio       deps=1
-[  5] Meter       det   T1:trackMeter                  in=4:0              out=audio       deps=1
-[  6] Gain        det   T1:trackMute                   in=5:0              out=audio       deps=1
-[  7] MixAudio    det   T-2:trackAudioInput            in=6:0              out=audio       deps=1
-[  8] Fader       det   T-2:trackFader                 in=7:0,-            out=audio       deps=1
-[  9] Meter       det   T-2:trackMeter                 in=8:0              out=audio       deps=1
-[ 10] Gain        det   T-2:trackMute                  in=9:0              out=audio       deps=1
-[ 11] Output      det   T-2:hardwareOutput             in=10:0             out=-           deps=1
+[  3] Delay       det   T1/D7:subtractInputDelay       in=2:0              out=audio       deps=1
+[  4] Delay       det   T1/D7:subtractInputDelay#1     in=1:0              out=audio       deps=1
+[  5] Subtract    det   T1/D7:deviceDelta              in=3:0,4:0          out=audio       deps=2
+[  6] Gain        det   T1/D7:deviceGain               in=5:0              out=audio       deps=1
+[  7] Fader       det   T1:trackFader                  in=6:0,-            out=audio       deps=1
+[  8] Meter       det   T1:trackMeter                  in=7:0              out=audio       deps=1
+[  9] Gain        det   T1:trackMute                   in=8:0              out=audio       deps=1
+[ 10] MixAudio    det   T-2:trackAudioInput            in=9:0              out=audio       deps=1
+[ 11] Fader       det   T-2:trackFader                 in=10:0,-           out=audio       deps=1
+[ 12] Meter       det   T-2:trackMeter                 in=11:0             out=audio       deps=1
+[ 13] Gain        det   T-2:trackMute                  in=12:0             out=audio       deps=1
+[ 14] Output      det   T-2:hardwareOutput             in=13:0             out=-           deps=1
 ready=0
 
 == layout ==
 magda-plan-layout v1
-audioSlots=1 midiSlots=0 outputLatency=0
+audioSlots=2 midiSlots=0 outputLatency=0
 [  0] ClipAudio   T1:clipAudio                   lat=0       ports=a0
 [  1] MixAudio    T1:trackAudioInput             lat=0       ports=a0          inplace
-[  2] Device      T1/D7:deviceProcess            lat=0       ports=a0          inplace
-[  3] Gain        T1/D7:deviceGain               lat=0       ports=a0          inplace
-[  4] Fader       T1:trackFader                  lat=0       ports=a0          inplace
-[  5] Meter       T1:trackMeter                  lat=0       ports=a0          inplace
-[  6] Gain        T1:trackMute                   lat=0       ports=a0          inplace
-[  7] MixAudio    T-2:trackAudioInput            lat=0       ports=a0          inplace
-[  8] Fader       T-2:trackFader                 lat=0       ports=a0          inplace
-[  9] Meter       T-2:trackMeter                 lat=0       ports=a0          inplace
-[ 10] Gain        T-2:trackMute                  lat=0       ports=a0          inplace
-[ 11] Output      T-2:hardwareOutput             lat=-       ports=-
+[  2] Device      T1/D7:deviceProcess            lat=0       ports=a1
+[  3] Delay       T1/D7:subtractInputDelay       lat=0       ports=a1          hold=0 elided
+[  4] Delay       T1/D7:subtractInputDelay#1     lat=0       ports=a0          hold=0 elided
+[  5] Subtract    T1/D7:deviceDelta              lat=0       ports=a1          inplace
+[  6] Gain        T1/D7:deviceGain               lat=0       ports=a1          inplace
+[  7] Fader       T1:trackFader                  lat=0       ports=a1          inplace
+[  8] Meter       T1:trackMeter                  lat=0       ports=a1          inplace
+[  9] Gain        T1:trackMute                   lat=0       ports=a1          inplace
+[ 10] MixAudio    T-2:trackAudioInput            lat=0       ports=a1          inplace
+[ 11] Fader       T-2:trackFader                 lat=0       ports=a1          inplace
+[ 12] Meter       T-2:trackMeter                 lat=0       ports=a1          inplace
+[ 13] Gain        T-2:trackMute                  lat=0       ports=a1          inplace
+[ 14] Output      T-2:hardwareOutput             lat=-       ports=-
 
 == params ==
 magda-param-table v1

--- a/tests/goldens/plan/rack-chains.txt
+++ b/tests/goldens/plan/rack-chains.txt
@@ -5,52 +5,70 @@
 
 == plan ==
 magda-render-plan v1
-ops=20 outputs=1
+ops=29 outputs=1
 [  0] ClipAudio   det   T1:clipAudio                   in=-                out=audio       deps=0
 [  1] MixAudio    det   T1:trackAudioInput             in=0:0              out=audio       deps=1
 [  2] Device      det   T1/R5/C10/D10:deviceProcess    in=1:0,-,-          out=audio       deps=1
-[  3] Gain        det   T1/R5/C10/D10:deviceGain       in=2:0              out=audio       deps=1
-[  4] Fader       det   T1/R5/C10:rackChainFader       in=3:0,-            out=audio       deps=1
-[  5] Device      det   T1/R5/C11/D11:deviceProcess    in=1:0,-,-          out=audio       deps=1
-[  6] Gain        det   T1/R5/C11/D11:deviceGain       in=5:0              out=audio       deps=1
-[  7] Fader       det   T1/R5/C11:rackChainFader       in=6:0,-            out=audio       deps=1
-[  8] Delay       det   T1/R5:mixInputDelay            in=4:0              out=audio       deps=1
-[  9] Delay       det   T1/R5:mixInputDelay#1          in=7:0              out=audio       deps=1
-[ 10] MixAudio    det   T1/R5:rackMix                  in=8:0,9:0          out=audio       deps=2
-[ 11] Fader       det   T1/R5:rackFader                in=10:0,-           out=audio       deps=1
-[ 12] Fader       det   T1:trackFader                  in=11:0,-           out=audio       deps=1
-[ 13] Meter       det   T1:trackMeter                  in=12:0             out=audio       deps=1
-[ 14] Gain        det   T1:trackMute                   in=13:0             out=audio       deps=1
-[ 15] MixAudio    det   T-2:trackAudioInput            in=14:0             out=audio       deps=1
-[ 16] Fader       det   T-2:trackFader                 in=15:0,-           out=audio       deps=1
-[ 17] Meter       det   T-2:trackMeter                 in=16:0             out=audio       deps=1
-[ 18] Gain        det   T-2:trackMute                  in=17:0             out=audio       deps=1
-[ 19] Output      det   T-2:hardwareOutput             in=18:0             out=-           deps=1
+[  3] Delay       det   T1/R5/C10/D10:subtractInputDelay in=2:0              out=audio       deps=1
+[  4] Delay       det   T1/R5/C10/D10:subtractInputDelay#1 in=1:0              out=audio       deps=1
+[  5] Subtract    det   T1/R5/C10/D10:deviceDelta      in=3:0,4:0          out=audio       deps=2
+[  6] Gain        det   T1/R5/C10/D10:deviceGain       in=5:0              out=audio       deps=1
+[  7] Fader       det   T1/R5/C10:rackChainFader       in=6:0,-            out=audio       deps=1
+[  8] Device      det   T1/R5/C11/D11:deviceProcess    in=1:0,-,-          out=audio       deps=1
+[  9] Delay       det   T1/R5/C11/D11:subtractInputDelay in=8:0              out=audio       deps=1
+[ 10] Delay       det   T1/R5/C11/D11:subtractInputDelay#1 in=1:0              out=audio       deps=1
+[ 11] Subtract    det   T1/R5/C11/D11:deviceDelta      in=9:0,10:0         out=audio       deps=2
+[ 12] Gain        det   T1/R5/C11/D11:deviceGain       in=11:0             out=audio       deps=1
+[ 13] Fader       det   T1/R5/C11:rackChainFader       in=12:0,-           out=audio       deps=1
+[ 14] Delay       det   T1/R5:mixInputDelay            in=7:0              out=audio       deps=1
+[ 15] Delay       det   T1/R5:mixInputDelay#1          in=13:0             out=audio       deps=1
+[ 16] MixAudio    det   T1/R5:rackMix                  in=14:0,15:0        out=audio       deps=2
+[ 17] Fader       det   T1/R5:rackFader                in=16:0,-           out=audio       deps=1
+[ 18] Delay       det   T1/R5:subtractInputDelay       in=17:0             out=audio       deps=1
+[ 19] Delay       det   T1/R5:subtractInputDelay#1     in=1:0              out=audio       deps=1
+[ 20] Subtract    det   T1/R5:rackDelta                in=18:0,19:0        out=audio       deps=2
+[ 21] Fader       det   T1:trackFader                  in=20:0,-           out=audio       deps=1
+[ 22] Meter       det   T1:trackMeter                  in=21:0             out=audio       deps=1
+[ 23] Gain        det   T1:trackMute                   in=22:0             out=audio       deps=1
+[ 24] MixAudio    det   T-2:trackAudioInput            in=23:0             out=audio       deps=1
+[ 25] Fader       det   T-2:trackFader                 in=24:0,-           out=audio       deps=1
+[ 26] Meter       det   T-2:trackMeter                 in=25:0             out=audio       deps=1
+[ 27] Gain        det   T-2:trackMute                  in=26:0             out=audio       deps=1
+[ 28] Output      det   T-2:hardwareOutput             in=27:0             out=-           deps=1
 ready=0
 
 == layout ==
 magda-plan-layout v1
-audioSlots=3 midiSlots=0 outputLatency=48
+audioSlots=5 midiSlots=0 outputLatency=48
 [  0] ClipAudio   T1:clipAudio                   lat=0       ports=a0
 [  1] MixAudio    T1:trackAudioInput             lat=0       ports=a0          inplace
 [  2] Device      T1/R5/C10/D10:deviceProcess    lat=48      ports=a1
-[  3] Gain        T1/R5/C10/D10:deviceGain       lat=48      ports=a1          inplace
-[  4] Fader       T1/R5/C10:rackChainFader       lat=48      ports=a1          inplace
-[  5] Device      T1/R5/C11/D11:deviceProcess    lat=0       ports=a2
-[  6] Gain        T1/R5/C11/D11:deviceGain       lat=0       ports=a2          inplace
-[  7] Fader       T1/R5/C11:rackChainFader       lat=0       ports=a2          inplace
-[  8] Delay       T1/R5:mixInputDelay            lat=48      ports=a1          hold=0 elided
-[  9] Delay       T1/R5:mixInputDelay#1          lat=48      ports=a2          hold=48 inplace
-[ 10] MixAudio    T1/R5:rackMix                  lat=48      ports=a1          inplace
-[ 11] Fader       T1/R5:rackFader                lat=48      ports=a1          inplace
-[ 12] Fader       T1:trackFader                  lat=48      ports=a1          inplace
-[ 13] Meter       T1:trackMeter                  lat=48      ports=a1          inplace
-[ 14] Gain        T1:trackMute                   lat=48      ports=a1          inplace
-[ 15] MixAudio    T-2:trackAudioInput            lat=48      ports=a1          inplace
-[ 16] Fader       T-2:trackFader                 lat=48      ports=a1          inplace
-[ 17] Meter       T-2:trackMeter                 lat=48      ports=a1          inplace
-[ 18] Gain        T-2:trackMute                  lat=48      ports=a1          inplace
-[ 19] Output      T-2:hardwareOutput             lat=-       ports=-
+[  3] Delay       T1/R5/C10/D10:subtractInputDelay lat=48      ports=a1          hold=0 elided
+[  4] Delay       T1/R5/C10/D10:subtractInputDelay#1 lat=48      ports=a2          hold=48
+[  5] Subtract    T1/R5/C10/D10:deviceDelta      lat=48      ports=a1          inplace
+[  6] Gain        T1/R5/C10/D10:deviceGain       lat=48      ports=a1          inplace
+[  7] Fader       T1/R5/C10:rackChainFader       lat=48      ports=a1          inplace
+[  8] Device      T1/R5/C11/D11:deviceProcess    lat=0       ports=a3
+[  9] Delay       T1/R5/C11/D11:subtractInputDelay lat=0       ports=a3          hold=0 elided
+[ 10] Delay       T1/R5/C11/D11:subtractInputDelay#1 lat=0       ports=a0          hold=0 elided
+[ 11] Subtract    T1/R5/C11/D11:deviceDelta      lat=0       ports=a3          inplace
+[ 12] Gain        T1/R5/C11/D11:deviceGain       lat=0       ports=a3          inplace
+[ 13] Fader       T1/R5/C11:rackChainFader       lat=0       ports=a3          inplace
+[ 14] Delay       T1/R5:mixInputDelay            lat=48      ports=a1          hold=0 elided
+[ 15] Delay       T1/R5:mixInputDelay#1          lat=48      ports=a3          hold=48 inplace
+[ 16] MixAudio    T1/R5:rackMix                  lat=48      ports=a1          inplace
+[ 17] Fader       T1/R5:rackFader                lat=48      ports=a1          inplace
+[ 18] Delay       T1/R5:subtractInputDelay       lat=48      ports=a1          hold=0 elided
+[ 19] Delay       T1/R5:subtractInputDelay#1     lat=48      ports=a4          hold=48
+[ 20] Subtract    T1/R5:rackDelta                lat=48      ports=a1          inplace
+[ 21] Fader       T1:trackFader                  lat=48      ports=a1          inplace
+[ 22] Meter       T1:trackMeter                  lat=48      ports=a1          inplace
+[ 23] Gain        T1:trackMute                   lat=48      ports=a1          inplace
+[ 24] MixAudio    T-2:trackAudioInput            lat=48      ports=a1          inplace
+[ 25] Fader       T-2:trackFader                 lat=48      ports=a1          inplace
+[ 26] Meter       T-2:trackMeter                 lat=48      ports=a1          inplace
+[ 27] Gain        T-2:trackMute                  lat=48      ports=a1          inplace
+[ 28] Output      T-2:hardwareOutput             lat=-       ports=-
 
 == params ==
 magda-param-table v1

--- a/tests/goldens/plan/section-local-device-ids.txt
+++ b/tests/goldens/plan/section-local-device-ids.txt
@@ -5,42 +5,54 @@
 
 == plan ==
 magda-render-plan v1
-ops=15 outputs=1
+ops=21 outputs=1
 [  0] ClipAudio   det   T1:clipAudio                   in=-                out=audio       deps=0
 [  1] MixAudio    det   T1:trackAudioInput             in=0:0              out=audio       deps=1
 [  2] Device      det   T1/D3:deviceProcess            in=1:0,-,-          out=audio       deps=1
-[  3] Gain        det   T1/D3:deviceGain               in=2:0              out=audio       deps=1
-[  4] Fader       det   T1:trackFader                  in=3:0,-            out=audio       deps=1
-[  5] Device      det   T1/PF/D3:deviceProcess         in=4:0,-,-          out=audio       deps=1
-[  6] Gain        det   T1/PF/D3:deviceGain            in=5:0              out=audio       deps=1
-[  7] Device      det   T1/MA/D3:deviceProcess         in=6:0,-,-          out=audio       deps=1
-[  8] Meter       det   T1:trackMeter                  in=7:0              out=audio       deps=1
-[  9] Gain        det   T1:trackMute                   in=8:0              out=audio       deps=1
-[ 10] MixAudio    det   T-2:trackAudioInput            in=9:0              out=audio       deps=1
-[ 11] Fader       det   T-2:trackFader                 in=10:0,-           out=audio       deps=1
-[ 12] Meter       det   T-2:trackMeter                 in=11:0             out=audio       deps=1
-[ 13] Gain        det   T-2:trackMute                  in=12:0             out=audio       deps=1
-[ 14] Output      det   T-2:hardwareOutput             in=13:0             out=-           deps=1
+[  3] Delay       det   T1/D3:subtractInputDelay       in=2:0              out=audio       deps=1
+[  4] Delay       det   T1/D3:subtractInputDelay#1     in=1:0              out=audio       deps=1
+[  5] Subtract    det   T1/D3:deviceDelta              in=3:0,4:0          out=audio       deps=2
+[  6] Gain        det   T1/D3:deviceGain               in=5:0              out=audio       deps=1
+[  7] Fader       det   T1:trackFader                  in=6:0,-            out=audio       deps=1
+[  8] Device      det   T1/PF/D3:deviceProcess         in=7:0,-,-          out=audio       deps=1
+[  9] Delay       det   T1/PF/D3:subtractInputDelay    in=8:0              out=audio       deps=1
+[ 10] Delay       det   T1/PF/D3:subtractInputDelay#1  in=7:0              out=audio       deps=1
+[ 11] Subtract    det   T1/PF/D3:deviceDelta           in=9:0,10:0         out=audio       deps=2
+[ 12] Gain        det   T1/PF/D3:deviceGain            in=11:0             out=audio       deps=1
+[ 13] Device      det   T1/MA/D3:deviceProcess         in=12:0,-,-         out=audio       deps=1
+[ 14] Meter       det   T1:trackMeter                  in=13:0             out=audio       deps=1
+[ 15] Gain        det   T1:trackMute                   in=14:0             out=audio       deps=1
+[ 16] MixAudio    det   T-2:trackAudioInput            in=15:0             out=audio       deps=1
+[ 17] Fader       det   T-2:trackFader                 in=16:0,-           out=audio       deps=1
+[ 18] Meter       det   T-2:trackMeter                 in=17:0             out=audio       deps=1
+[ 19] Gain        det   T-2:trackMute                  in=18:0             out=audio       deps=1
+[ 20] Output      det   T-2:hardwareOutput             in=19:0             out=-           deps=1
 ready=0
 
 == layout ==
 magda-plan-layout v1
-audioSlots=1 midiSlots=0 outputLatency=112
+audioSlots=3 midiSlots=0 outputLatency=112
 [  0] ClipAudio   T1:clipAudio                   lat=0       ports=a0
 [  1] MixAudio    T1:trackAudioInput             lat=0       ports=a0          inplace
-[  2] Device      T1/D3:deviceProcess            lat=16      ports=a0          inplace
-[  3] Gain        T1/D3:deviceGain               lat=16      ports=a0          inplace
-[  4] Fader       T1:trackFader                  lat=16      ports=a0          inplace
-[  5] Device      T1/PF/D3:deviceProcess         lat=48      ports=a0          inplace
-[  6] Gain        T1/PF/D3:deviceGain            lat=48      ports=a0          inplace
-[  7] Device      T1/MA/D3:deviceProcess         lat=112     ports=a0          inplace
-[  8] Meter       T1:trackMeter                  lat=112     ports=a0          inplace
-[  9] Gain        T1:trackMute                   lat=112     ports=a0          inplace
-[ 10] MixAudio    T-2:trackAudioInput            lat=112     ports=a0          inplace
-[ 11] Fader       T-2:trackFader                 lat=112     ports=a0          inplace
-[ 12] Meter       T-2:trackMeter                 lat=112     ports=a0          inplace
-[ 13] Gain        T-2:trackMute                  lat=112     ports=a0          inplace
-[ 14] Output      T-2:hardwareOutput             lat=-       ports=-
+[  2] Device      T1/D3:deviceProcess            lat=16      ports=a1
+[  3] Delay       T1/D3:subtractInputDelay       lat=16      ports=a1          hold=0 elided
+[  4] Delay       T1/D3:subtractInputDelay#1     lat=16      ports=a2          hold=16
+[  5] Subtract    T1/D3:deviceDelta              lat=16      ports=a1          inplace
+[  6] Gain        T1/D3:deviceGain               lat=16      ports=a1          inplace
+[  7] Fader       T1:trackFader                  lat=16      ports=a1          inplace
+[  8] Device      T1/PF/D3:deviceProcess         lat=48      ports=a0
+[  9] Delay       T1/PF/D3:subtractInputDelay    lat=48      ports=a0          hold=0 elided
+[ 10] Delay       T1/PF/D3:subtractInputDelay#1  lat=48      ports=a2          hold=32
+[ 11] Subtract    T1/PF/D3:deviceDelta           lat=48      ports=a0          inplace
+[ 12] Gain        T1/PF/D3:deviceGain            lat=48      ports=a0          inplace
+[ 13] Device      T1/MA/D3:deviceProcess         lat=112     ports=a0          inplace
+[ 14] Meter       T1:trackMeter                  lat=112     ports=a0          inplace
+[ 15] Gain        T1:trackMute                   lat=112     ports=a0          inplace
+[ 16] MixAudio    T-2:trackAudioInput            lat=112     ports=a0          inplace
+[ 17] Fader       T-2:trackFader                 lat=112     ports=a0          inplace
+[ 18] Meter       T-2:trackMeter                 lat=112     ports=a0          inplace
+[ 19] Gain        T-2:trackMute                  lat=112     ports=a0          inplace
+[ 20] Output      T-2:hardwareOutput             lat=-       ports=-
 
 == params ==
 magda-param-table v1

--- a/tests/goldens/plan/sidechain.txt
+++ b/tests/goldens/plan/sidechain.txt
@@ -5,7 +5,7 @@
 
 == plan ==
 magda-render-plan v1
-ops=21 outputs=1
+ops=24 outputs=1
 [  0] ClipAudio   det   T2:clipAudio                   in=-                out=audio       deps=0
 [  1] MixAudio    det   T2:trackAudioInput             in=0:0              out=audio       deps=1
 [  2] Fader       det   T2:trackFader                  in=1:0,-            out=audio       deps=1
@@ -16,22 +16,25 @@ ops=21 outputs=1
 [  7] Delay       det   T1/D7:deviceInputDelay         in=6:0              out=audio       deps=1
 [  8] Delay       det   T1/D7:deviceInputDelay#2       in=3:0              out=audio       deps=1
 [  9] Device      det   T1/D7:deviceProcess            in=7:0,-,8:0        out=audio       deps=2
-[ 10] Gain        det   T1/D7:deviceGain               in=9:0              out=audio       deps=1
-[ 11] Fader       det   T1:trackFader                  in=10:0,-           out=audio       deps=1
-[ 12] Meter       det   T1:trackMeter                  in=11:0             out=audio       deps=1
-[ 13] Gain        det   T1:trackMute                   in=12:0             out=audio       deps=1
-[ 14] Delay       det   T-2:mixInputDelay              in=4:0              out=audio       deps=1
-[ 15] Delay       det   T-2:mixInputDelay#1            in=13:0             out=audio       deps=1
-[ 16] MixAudio    det   T-2:trackAudioInput            in=14:0,15:0        out=audio       deps=2
-[ 17] Fader       det   T-2:trackFader                 in=16:0,-           out=audio       deps=1
-[ 18] Meter       det   T-2:trackMeter                 in=17:0             out=audio       deps=1
-[ 19] Gain        det   T-2:trackMute                  in=18:0             out=audio       deps=1
-[ 20] Output      det   T-2:hardwareOutput             in=19:0             out=-           deps=1
+[ 10] Delay       det   T1/D7:subtractInputDelay       in=9:0              out=audio       deps=1
+[ 11] Delay       det   T1/D7:subtractInputDelay#1     in=6:0              out=audio       deps=1
+[ 12] Subtract    det   T1/D7:deviceDelta              in=10:0,11:0        out=audio       deps=2
+[ 13] Gain        det   T1/D7:deviceGain               in=12:0             out=audio       deps=1
+[ 14] Fader       det   T1:trackFader                  in=13:0,-           out=audio       deps=1
+[ 15] Meter       det   T1:trackMeter                  in=14:0             out=audio       deps=1
+[ 16] Gain        det   T1:trackMute                   in=15:0             out=audio       deps=1
+[ 17] Delay       det   T-2:mixInputDelay              in=4:0              out=audio       deps=1
+[ 18] Delay       det   T-2:mixInputDelay#1            in=16:0             out=audio       deps=1
+[ 19] MixAudio    det   T-2:trackAudioInput            in=17:0,18:0        out=audio       deps=2
+[ 20] Fader       det   T-2:trackFader                 in=19:0,-           out=audio       deps=1
+[ 21] Meter       det   T-2:trackMeter                 in=20:0             out=audio       deps=1
+[ 22] Gain        det   T-2:trackMute                  in=21:0             out=audio       deps=1
+[ 23] Output      det   T-2:hardwareOutput             in=22:0             out=-           deps=1
 ready=0,5
 
 == layout ==
 magda-plan-layout v1
-audioSlots=3 midiSlots=0 outputLatency=0
+audioSlots=4 midiSlots=0 outputLatency=0
 [  0] ClipAudio   T2:clipAudio                   lat=0       ports=a0
 [  1] MixAudio    T2:trackAudioInput             lat=0       ports=a0          inplace
 [  2] Fader       T2:trackFader                  lat=0       ports=a0          inplace
@@ -41,18 +44,21 @@ audioSlots=3 midiSlots=0 outputLatency=0
 [  6] MixAudio    T1:trackAudioInput             lat=0       ports=a2          inplace
 [  7] Delay       T1/D7:deviceInputDelay         lat=0       ports=a2          hold=0 elided
 [  8] Delay       T1/D7:deviceInputDelay#2       lat=0       ports=a0          hold=0 elided
-[  9] Device      T1/D7:deviceProcess            lat=0       ports=a2          inplace
-[ 10] Gain        T1/D7:deviceGain               lat=0       ports=a2          inplace
-[ 11] Fader       T1:trackFader                  lat=0       ports=a2          inplace
-[ 12] Meter       T1:trackMeter                  lat=0       ports=a2          inplace
-[ 13] Gain        T1:trackMute                   lat=0       ports=a2          inplace
-[ 14] Delay       T-2:mixInputDelay              lat=0       ports=a1          hold=0 elided
-[ 15] Delay       T-2:mixInputDelay#1            lat=0       ports=a2          hold=0 elided
-[ 16] MixAudio    T-2:trackAudioInput            lat=0       ports=a1          inplace
-[ 17] Fader       T-2:trackFader                 lat=0       ports=a1          inplace
-[ 18] Meter       T-2:trackMeter                 lat=0       ports=a1          inplace
-[ 19] Gain        T-2:trackMute                  lat=0       ports=a1          inplace
-[ 20] Output      T-2:hardwareOutput             lat=-       ports=-
+[  9] Device      T1/D7:deviceProcess            lat=0       ports=a3
+[ 10] Delay       T1/D7:subtractInputDelay       lat=0       ports=a3          hold=0 elided
+[ 11] Delay       T1/D7:subtractInputDelay#1     lat=0       ports=a2          hold=0 elided
+[ 12] Subtract    T1/D7:deviceDelta              lat=0       ports=a3          inplace
+[ 13] Gain        T1/D7:deviceGain               lat=0       ports=a3          inplace
+[ 14] Fader       T1:trackFader                  lat=0       ports=a3          inplace
+[ 15] Meter       T1:trackMeter                  lat=0       ports=a3          inplace
+[ 16] Gain        T1:trackMute                   lat=0       ports=a3          inplace
+[ 17] Delay       T-2:mixInputDelay              lat=0       ports=a1          hold=0 elided
+[ 18] Delay       T-2:mixInputDelay#1            lat=0       ports=a3          hold=0 elided
+[ 19] MixAudio    T-2:trackAudioInput            lat=0       ports=a1          inplace
+[ 20] Fader       T-2:trackFader                 lat=0       ports=a1          inplace
+[ 21] Meter       T-2:trackMeter                 lat=0       ports=a1          inplace
+[ 22] Gain        T-2:trackMute                  lat=0       ports=a1          inplace
+[ 23] Output      T-2:hardwareOutput             lat=-       ports=-
 
 == params ==
 magda-param-table v1

--- a/tests/test_parallel_executor.cpp
+++ b/tests/test_parallel_executor.cpp
@@ -512,6 +512,37 @@ Scene rackScene() {
     return scene;
 }
 
+/// Delta solo at both scopes, which is where an op reads two live buffers and
+/// writes over one of them. The dry edge has to survive the whole of the
+/// processing it is measured against, and a schedule that lets its buffer be
+/// reused meanwhile is a race this executor finds and the reference one does
+/// not.
+Scene deltaScene() {
+    Scene scene;
+    auto rack = std::make_unique<RackInfo>();
+    rack->id = 5;
+    rack->deltaSolo = true;
+    rack->volume = -3.0f;
+
+    auto processed = makeEffect(500);
+    processed.deltaSolo = true;
+
+    ChainInfo chain;
+    chain.id = 10;
+    chain.elements.push_back(makeDeviceElement(processed));
+    chain.elements.push_back(makeDeviceElement(makeEffect(501)));
+    rack->chains.push_back(std::move(chain));
+
+    auto track = makeTrack(1);
+    track.chain.fxChainElements.push_back(ChainElement{std::move(rack)});
+    scene.tracks.push_back(track);
+
+    scene.bindings.clipAudio[1] = scene.own(std::make_unique<RampSource>(13));
+    scene.bindings.devices[DeviceKey{500}] = scene.own(std::make_unique<LatentDevice>(53));
+    scene.bindings.devices[DeviceKey{501}] = scene.own(std::make_unique<GainDevice>(0.6f));
+    return scene;
+}
+
 /// Devices that really are late, so the plan carries delays and the paths
 /// meeting at the master have to be aligned by them rather than by luck.
 Scene latencyScene() {
@@ -606,7 +637,7 @@ struct NamedScene {
 const std::vector<NamedScene> kScenes = {
     {"one chain", chainScene},      {"eight tracks", wideScene}, {"sends into an aux", sendScene},
     {"a rack's chains", rackScene}, {"latency", latencyScene},   {"MIDI", midiScene},
-    {"a group track", groupScene},
+    {"a group track", groupScene},  {"delta solo", deltaScene},
 };
 
 /// The thread counts every scene is rendered at. Zero workers is the parallel

--- a/tests/test_plan_crossfade.cpp
+++ b/tests/test_plan_crossfade.cpp
@@ -320,8 +320,8 @@ TEST_CASE("A device removed has nothing to fade from", "[engine][plan][crossfade
 
 TEST_CASE("A reorder fades the one edge that can be faded", "[engine][plan][crossfade]") {
     // Two devices swapped. The edge into the chain's new first device can fade,
-    // because what it used to read is still upstream of it; the other two edges
-    // read something that has itself changed, or something that now comes after
+    // because what it used to read is still upstream of it; the rest read
+    // something that has itself changed, or something that now comes after
     // them, and neither is the old signal.
     Bench bench;
     bench.setChain({7, 8});
@@ -334,7 +334,11 @@ TEST_CASE("A reorder fades the one edge that can be faded", "[engine][plan][cros
     INFO(magda::engine::dumpPlan(faded.plan));
 
     CHECK(faded.inserted == 1);
-    CHECK(faded.unfaded == 2);
+
+    // Four rather than two: each device is fed twice now, once into its
+    // processing and once into the dry edge of its own delta, and a reorder
+    // moves both.
+    CHECK(faded.unfaded == 4);
     CHECK(validatePlan(faded.plan).empty());
 }
 

--- a/tests/test_plan_edit_properties.cpp
+++ b/tests/test_plan_edit_properties.cpp
@@ -843,6 +843,15 @@ struct Transient {
     bool faded = false;
     bool flushed = false;
     bool reached = false;
+
+    /// The edit compiled to the plan that was already running, so no edge
+    /// moved and the fade pass had nothing to smooth. What changed is a value,
+    /// and a value arrives when it is published. Delta solo is the one the
+    /// generator toggles; mute and every fader position work the same way and
+    /// are not edits here. Declared and counted rather than passed over,
+    /// because an exemption that covered a swap would be the bound quietly
+    /// ceasing to exist.
+    bool valueOnly = false;
 };
 
 std::optional<std::string> checkStepBounds(const Transient& transient, Report* report) {
@@ -862,10 +871,12 @@ std::optional<std::string> checkStepBounds(const Transient& transient, Report* r
                    std::to_string(sample) + ": " + std::to_string(value);
     }
 
-    // A path that starts from silence steps by whatever it was carrying, and
-    // an edge the pass refused steps by whatever it had left: both are declared
-    // divergences rather than failures, and both are counted where they happen.
-    if (!transient.faded || transient.flushed) {
+    // A path that starts from silence steps by whatever it was carrying, an
+    // edge the pass refused steps by whatever it had left, and a publish that
+    // compiled to the running plan steps by whatever the model asked to hear:
+    // all three are declared divergences rather than failures, and all three
+    // are counted where they happen.
+    if (!transient.faded || transient.flushed || transient.valueOnly) {
         if (report != nullptr && transient.reached)
             ++report->transientsExempt;
         return std::nullopt;
@@ -989,6 +1000,12 @@ std::optional<std::string> transientProperty(const std::vector<Edit>& edits, Rep
             transient.before = steady[trackId];
             transient.faded = published.faded.unfaded == 0;
             transient.flushed = pathStartsFlushed(upstream, before, published);
+            // The compiler's output on both sides, rather than the diff: a
+            // spent fade leaving the plan retires an op without anything
+            // having moved, and that is the pass tidying up after the previous
+            // edit rather than this one changing the graph.
+            transient.valueOnly = engine::planFingerprint(before.compiled) ==
+                                  engine::planFingerprint(published.compiled);
             transient.reached = std::ranges::any_of(
                 touchedTracks, [&upstream](TrackId touched) { return upstream.contains(touched); });
 

--- a/tests/test_plan_layout.cpp
+++ b/tests/test_plan_layout.cpp
@@ -273,9 +273,10 @@ TEST_CASE("A delay holding no samples is not a buffer and not an op",
                 ++held;
         }
 
-        // The master sums both tracks, and track 2's side of that sum is the
-        // one that has to wait.
-        CHECK(held == 1);
+        // Two: track 2's side of the master's sum, which waits for track 1's
+        // device, and the dry edge of that device's own delta, which waits for
+        // the device itself.
+        CHECK(held == 2);
     }
 }
 
@@ -312,25 +313,30 @@ TEST_CASE("Latency accumulates along a chain and meets at a fan-in",
 
 TEST_CASE("A delta solo's dry edge waits for the processing it is measured against",
           "[engine][exec][layout][pdc]") {
-    const auto dryDelays = [](const Layout& layout) {
+    // The delays aligning one delta's two sides, by the slot each fills. Every
+    // device slot and every rack carries a delta now, so which one is being
+    // asked about has to be named: keyed on the op the delays belong to rather
+    // than on the role alone, or the section would be reading whichever delta
+    // the compiler happened to emit last.
+    const auto dryDelays = [](const Layout& layout, DeviceId deviceId, RackId rackId) {
         std::map<int, int> bySlot;
-        for (std::size_t i = 0; i < layout.plan.ops.size(); ++i)
-            if (layout.plan.ops[i].key.role == OpRole::SubtractInputDelay)
-                bySlot[layout.plan.ops[i].key.index] = layout.delaySamples[i];
+        for (std::size_t i = 0; i < layout.plan.ops.size(); ++i) {
+            const auto& key = layout.plan.ops[i].key;
+            if (key.role == OpRole::SubtractInputDelay && key.deviceId == deviceId &&
+                key.rackId == rackId)
+                bySlot[key.index] = layout.delaySamples[i];
+        }
         return bySlot;
     };
 
     SECTION("a device: its own latency, and nothing on the wet side") {
-        auto effect = makeEffect(7);
-        effect.deltaSolo = true;
-
         std::vector<TrackInfo> tracks{makeTrack(1)};
-        tracks[0].chain.fxChainElements.push_back(makeDeviceElement(effect));
+        tracks[0].chain.fxChainElements.push_back(makeDeviceElement(makeEffect(7)));
 
         const auto layout = layoutOf(tracks, makeMaster(), {{7, 100}});
         INFO(magda::engine::dumpPlan(layout.plan));
 
-        const auto delays = dryDelays(layout);
+        const auto delays = dryDelays(layout, 7, INVALID_RACK_ID);
         REQUIRE(delays.size() == 2);
         CHECK(delays.at(0) == 0);
         CHECK(delays.at(1) == 100);
@@ -338,7 +344,6 @@ TEST_CASE("A delta solo's dry edge waits for the processing it is measured again
 
     SECTION("and whatever aligned the device's own input, on top of it") {
         auto compressor = makeEffect(7);
-        compressor.deltaSolo = true;
         compressor.sidechain.type = SidechainConfig::Type::Audio;
         compressor.sidechain.sourceTrackId = 2;
 
@@ -351,7 +356,7 @@ TEST_CASE("A delta solo's dry edge waits for the processing it is measured again
         const auto layout = layoutOf(tracks, makeMaster(), {{7, 100}, {8, 40}});
         INFO(magda::engine::dumpPlan(layout.plan));
 
-        const auto delays = dryDelays(layout);
+        const auto delays = dryDelays(layout, 7, INVALID_RACK_ID);
         REQUIRE(delays.size() == 2);
         CHECK(delays.at(0) == 0);
         CHECK(delays.at(1) == 140);
@@ -360,7 +365,6 @@ TEST_CASE("A delta solo's dry edge waits for the processing it is measured again
     SECTION("a rack: everything its chains and its own alignment came to") {
         auto rack = std::make_unique<RackInfo>();
         rack->id = 5;
-        rack->deltaSolo = true;
         for (const ChainId chainId : {ChainId{10}, ChainId{11}}) {
             ChainInfo chain;
             chain.id = chainId;
@@ -376,7 +380,7 @@ TEST_CASE("A delta solo's dry edge waits for the processing it is measured again
         const auto layout = layoutOf(tracks, makeMaster(), {{10, 48}, {11, 16}});
         INFO(magda::engine::dumpPlan(layout.plan));
 
-        const auto delays = dryDelays(layout);
+        const auto delays = dryDelays(layout, INVALID_DEVICE_ID, 5);
         REQUIRE(delays.size() == 2);
         CHECK(delays.at(0) == 0);
         CHECK(delays.at(1) == 48);

--- a/tests/test_plan_layout.cpp
+++ b/tests/test_plan_layout.cpp
@@ -309,3 +309,76 @@ TEST_CASE("Latency accumulates along a chain and meets at a fan-in",
     CHECK(delays[0] == 0);
     CHECK(delays[1] == 120);
 }
+
+TEST_CASE("A delta solo's dry edge waits for the processing it is measured against",
+          "[engine][exec][layout][pdc]") {
+    const auto dryDelays = [](const Layout& layout) {
+        std::map<int, int> bySlot;
+        for (std::size_t i = 0; i < layout.plan.ops.size(); ++i)
+            if (layout.plan.ops[i].key.role == OpRole::SubtractInputDelay)
+                bySlot[layout.plan.ops[i].key.index] = layout.delaySamples[i];
+        return bySlot;
+    };
+
+    SECTION("a device: its own latency, and nothing on the wet side") {
+        auto effect = makeEffect(7);
+        effect.deltaSolo = true;
+
+        std::vector<TrackInfo> tracks{makeTrack(1)};
+        tracks[0].chain.fxChainElements.push_back(makeDeviceElement(effect));
+
+        const auto layout = layoutOf(tracks, makeMaster(), {{7, 100}});
+        INFO(magda::engine::dumpPlan(layout.plan));
+
+        const auto delays = dryDelays(layout);
+        REQUIRE(delays.size() == 2);
+        CHECK(delays.at(0) == 0);
+        CHECK(delays.at(1) == 100);
+    }
+
+    SECTION("and whatever aligned the device's own input, on top of it") {
+        auto compressor = makeEffect(7);
+        compressor.deltaSolo = true;
+        compressor.sidechain.type = SidechainConfig::Type::Audio;
+        compressor.sidechain.sourceTrackId = 2;
+
+        std::vector<TrackInfo> tracks{makeTrack(1), makeTrack(2)};
+        tracks[0].chain.fxChainElements.push_back(makeDeviceElement(compressor));
+        tracks[1].chain.fxChainElements.push_back(makeDeviceElement(makeEffect(8)));
+
+        // The key arrives 40 samples late, so the device's own audio input is
+        // held back that far before the device adds its 100.
+        const auto layout = layoutOf(tracks, makeMaster(), {{7, 100}, {8, 40}});
+        INFO(magda::engine::dumpPlan(layout.plan));
+
+        const auto delays = dryDelays(layout);
+        REQUIRE(delays.size() == 2);
+        CHECK(delays.at(0) == 0);
+        CHECK(delays.at(1) == 140);
+    }
+
+    SECTION("a rack: everything its chains and its own alignment came to") {
+        auto rack = std::make_unique<RackInfo>();
+        rack->id = 5;
+        rack->deltaSolo = true;
+        for (const ChainId chainId : {ChainId{10}, ChainId{11}}) {
+            ChainInfo chain;
+            chain.id = chainId;
+            chain.elements.push_back(makeDeviceElement(makeEffect(static_cast<DeviceId>(chainId))));
+            rack->chains.push_back(std::move(chain));
+        }
+
+        std::vector<TrackInfo> tracks{makeTrack(1)};
+        tracks[0].chain.fxChainElements.push_back(ChainElement{std::move(rack)});
+
+        // The rack's output is as late as its latest chain, which is what its
+        // own mix aligned the other one to.
+        const auto layout = layoutOf(tracks, makeMaster(), {{10, 48}, {11, 16}});
+        INFO(magda::engine::dumpPlan(layout.plan));
+
+        const auto delays = dryDelays(layout);
+        REQUIRE(delays.size() == 2);
+        CHECK(delays.at(0) == 0);
+        CHECK(delays.at(1) == 48);
+    }
+}

--- a/tests/test_render_plan_compiler.cpp
+++ b/tests/test_render_plan_compiler.cpp
@@ -64,21 +64,25 @@ int countRole(const RenderPlan& plan, OpRole role) {
     return static_cast<int>(opsWithRole(plan, role).size());
 }
 
-/// The op an input slot reads, or -1 when the slot is unconnected. Latency
-/// compensation is looked through: a delay stands for the op behind it, and
-/// these tests are about what is routed where rather than about the delays,
-/// which have their own.
+/// The op an input slot reads, or -1 when the slot is unconnected. The two ops
+/// every slot carries whatever the model says are looked through: a delay
+/// stands for the op behind it, and so does the subtract that would take a
+/// delta on it, which passes its wet side along until something is soloing
+/// that delta. These tests are about what is routed where; both have their own.
 magda::engine::OpId inputOp(const RenderPlan& plan, magda::engine::OpId op, std::size_t slot) {
     const auto& inputs = plan.ops[static_cast<std::size_t>(op)].inputs;
     if (slot >= inputs.size())
         return magda::engine::INVALID_OP_ID;
 
-    const auto source = inputs[slot].op;
-    if (source == magda::engine::INVALID_OP_ID)
-        return source;
-
-    const auto& producer = plan.ops[static_cast<std::size_t>(source)];
-    return producer.kind == magda::engine::OpKind::Delay ? producer.inputs.front().op : source;
+    auto source = inputs[slot].op;
+    while (source != magda::engine::INVALID_OP_ID) {
+        const auto& producer = plan.ops[static_cast<std::size_t>(source)];
+        if (producer.kind != magda::engine::OpKind::Delay &&
+            producer.kind != magda::engine::OpKind::Subtract)
+            break;
+        source = producer.inputs.front().op;
+    }
+    return source;
 }
 
 /// The op an input slot reads without looking through anything.
@@ -162,20 +166,23 @@ TEST_CASE("The plan dump is the compiler's golden surface", "[engine][plan][comp
     requireWellFormed(plan);
 
     CHECK(magda::engine::dumpPlan(plan) == R"(magda-render-plan v1
-ops=13 outputs=1
+ops=16 outputs=1
 [  0] ClipAudio   det   T1:clipAudio                   in=-                out=audio       deps=0
 [  1] MixAudio    det   T1:trackAudioInput             in=0:0              out=audio       deps=1
 [  2] Device      det   T1/D7:deviceProcess            in=1:0,-,-          out=audio       deps=1
-[  3] Gain        det   T1/D7:deviceGain               in=2:0              out=audio       deps=1
-[  4] Meter       det   T1/D7:deviceMeter              in=3:0              out=audio       deps=1
-[  5] Fader       det   T1:trackFader                  in=4:0,-            out=audio       deps=1
-[  6] Meter       det   T1:trackMeter                  in=5:0              out=audio       deps=1
-[  7] Gain        det   T1:trackMute                   in=6:0              out=audio       deps=1
-[  8] MixAudio    det   T-2:trackAudioInput            in=7:0              out=audio       deps=1
-[  9] Fader       det   T-2:trackFader                 in=8:0,-            out=audio       deps=1
-[ 10] Meter       det   T-2:trackMeter                 in=9:0              out=audio       deps=1
-[ 11] Gain        det   T-2:trackMute                  in=10:0             out=audio       deps=1
-[ 12] Output      det   T-2:hardwareOutput             in=11:0             out=-           deps=1
+[  3] Delay       det   T1/D7:subtractInputDelay       in=2:0              out=audio       deps=1
+[  4] Delay       det   T1/D7:subtractInputDelay#1     in=1:0              out=audio       deps=1
+[  5] Subtract    det   T1/D7:deviceDelta              in=3:0,4:0          out=audio       deps=2
+[  6] Gain        det   T1/D7:deviceGain               in=5:0              out=audio       deps=1
+[  7] Meter       det   T1/D7:deviceMeter              in=6:0              out=audio       deps=1
+[  8] Fader       det   T1:trackFader                  in=7:0,-            out=audio       deps=1
+[  9] Meter       det   T1:trackMeter                  in=8:0              out=audio       deps=1
+[ 10] Gain        det   T1:trackMute                   in=9:0              out=audio       deps=1
+[ 11] MixAudio    det   T-2:trackAudioInput            in=10:0             out=audio       deps=1
+[ 12] Fader       det   T-2:trackFader                 in=11:0,-           out=audio       deps=1
+[ 13] Meter       det   T-2:trackMeter                 in=12:0             out=audio       deps=1
+[ 14] Gain        det   T-2:trackMute                  in=13:0             out=audio       deps=1
+[ 15] Output      det   T-2:hardwareOutput             in=14:0             out=-           deps=1
 ready=0
 )");
 }
@@ -194,28 +201,31 @@ TEST_CASE("A second track is a fan-in, and a fan-in is where the delays go",
     requireWellFormed(plan);
 
     CHECK(magda::engine::dumpPlan(plan) == R"(magda-render-plan v1
-ops=20 outputs=1
+ops=23 outputs=1
 [  0] ClipAudio   det   T1:clipAudio                   in=-                out=audio       deps=0
 [  1] MixAudio    det   T1:trackAudioInput             in=0:0              out=audio       deps=1
 [  2] Device      det   T1/D7:deviceProcess            in=1:0,-,-          out=audio       deps=1
-[  3] Gain        det   T1/D7:deviceGain               in=2:0              out=audio       deps=1
-[  4] Meter       det   T1/D7:deviceMeter              in=3:0              out=audio       deps=1
-[  5] Fader       det   T1:trackFader                  in=4:0,-            out=audio       deps=1
-[  6] Meter       det   T1:trackMeter                  in=5:0              out=audio       deps=1
-[  7] Gain        det   T1:trackMute                   in=6:0              out=audio       deps=1
-[  8] ClipAudio   det   T2:clipAudio                   in=-                out=audio       deps=0
-[  9] MixAudio    det   T2:trackAudioInput             in=8:0              out=audio       deps=1
-[ 10] Fader       det   T2:trackFader                  in=9:0,-            out=audio       deps=1
-[ 11] Meter       det   T2:trackMeter                  in=10:0             out=audio       deps=1
-[ 12] Gain        det   T2:trackMute                   in=11:0             out=audio       deps=1
-[ 13] Delay       det   T-2:mixInputDelay              in=7:0              out=audio       deps=1
-[ 14] Delay       det   T-2:mixInputDelay#1            in=12:0             out=audio       deps=1
-[ 15] MixAudio    det   T-2:trackAudioInput            in=13:0,14:0        out=audio       deps=2
-[ 16] Fader       det   T-2:trackFader                 in=15:0,-           out=audio       deps=1
-[ 17] Meter       det   T-2:trackMeter                 in=16:0             out=audio       deps=1
-[ 18] Gain        det   T-2:trackMute                  in=17:0             out=audio       deps=1
-[ 19] Output      det   T-2:hardwareOutput             in=18:0             out=-           deps=1
-ready=0,8
+[  3] Delay       det   T1/D7:subtractInputDelay       in=2:0              out=audio       deps=1
+[  4] Delay       det   T1/D7:subtractInputDelay#1     in=1:0              out=audio       deps=1
+[  5] Subtract    det   T1/D7:deviceDelta              in=3:0,4:0          out=audio       deps=2
+[  6] Gain        det   T1/D7:deviceGain               in=5:0              out=audio       deps=1
+[  7] Meter       det   T1/D7:deviceMeter              in=6:0              out=audio       deps=1
+[  8] Fader       det   T1:trackFader                  in=7:0,-            out=audio       deps=1
+[  9] Meter       det   T1:trackMeter                  in=8:0              out=audio       deps=1
+[ 10] Gain        det   T1:trackMute                   in=9:0              out=audio       deps=1
+[ 11] ClipAudio   det   T2:clipAudio                   in=-                out=audio       deps=0
+[ 12] MixAudio    det   T2:trackAudioInput             in=11:0             out=audio       deps=1
+[ 13] Fader       det   T2:trackFader                  in=12:0,-           out=audio       deps=1
+[ 14] Meter       det   T2:trackMeter                  in=13:0             out=audio       deps=1
+[ 15] Gain        det   T2:trackMute                   in=14:0             out=audio       deps=1
+[ 16] Delay       det   T-2:mixInputDelay              in=10:0             out=audio       deps=1
+[ 17] Delay       det   T-2:mixInputDelay#1            in=15:0             out=audio       deps=1
+[ 18] MixAudio    det   T-2:trackAudioInput            in=16:0,17:0        out=audio       deps=2
+[ 19] Fader       det   T-2:trackFader                 in=18:0,-           out=audio       deps=1
+[ 20] Meter       det   T-2:trackMeter                 in=19:0             out=audio       deps=1
+[ 21] Gain        det   T-2:trackMute                  in=20:0             out=audio       deps=1
+[ 22] Output      det   T-2:hardwareOutput             in=21:0             out=-           deps=1
+ready=0,11
 )");
 }
 
@@ -964,14 +974,34 @@ TEST_CASE("A rack-level sidechain is an edge to the modulation system",
     }
 }
 
-TEST_CASE("Delta solo subtracts the dry signal from what the processing made",
+TEST_CASE("Every device slot and every rack carries the subtract a delta is taken on",
           "[engine][plan][compiler]") {
-    SECTION("a device is measured against the audio it was handed") {
-        auto effect = makeEffect(7);
-        effect.deltaSolo = true;
+    SECTION("the flag does not change the plan at all") {
+        // Delta solo is a value, not structure. The subtract and the delay
+        // feeding it are in the plan whatever the model says, because that
+        // delay is a delay line and a delay line is history: one created at the
+        // moment the button was pressed would hand back its own length in
+        // silence first. So the two plans are the same plan, and the toggle is
+        // a value away.
+        std::vector<TrackInfo> off{makeTrack(1)};
+        off[0].chain.fxChainElements.push_back(makeDeviceElement(makeEffect(7)));
 
+        auto soloed = makeEffect(7);
+        soloed.deltaSolo = true;
+        std::vector<TrackInfo> on{makeTrack(1)};
+        on[0].chain.fxChainElements.push_back(makeDeviceElement(soloed));
+
+        const auto planOff = magda::engine::compileRenderPlan(off, makeMaster());
+        const auto planOn = magda::engine::compileRenderPlan(on, makeMaster());
+        requireWellFormed(planOff);
+
+        CHECK(magda::engine::dumpPlan(planOff) == magda::engine::dumpPlan(planOn));
+        CHECK(magda::engine::planFingerprint(planOff) == magda::engine::planFingerprint(planOn));
+    }
+
+    SECTION("a device is measured against the audio it was handed") {
         std::vector<TrackInfo> tracks{makeTrack(1)};
-        tracks[0].chain.fxChainElements.push_back(makeDeviceElement(effect));
+        tracks[0].chain.fxChainElements.push_back(makeDeviceElement(makeEffect(7)));
 
         const auto plan = magda::engine::compileRenderPlan(tracks, makeMaster());
         requireWellFormed(plan);
@@ -987,13 +1017,12 @@ TEST_CASE("Delta solo subtracts the dry signal from what the processing made",
         CHECK(inputOp(plan, delta, 1) == deviceInput(plan, 7));
 
         // In front of the slot's gain and meter, which read the delta rather
-        // than the device once there is one.
-        CHECK(inputOp(plan, opsWithRole(plan, OpRole::DeviceGain).front(), 0) == delta);
+        // than the device whenever one is being heard.
+        CHECK(rawInputOp(plan, opsWithRole(plan, OpRole::DeviceGain).front(), 0) == delta);
     }
 
     SECTION("the dry edge is taken in front of the device's own input alignment") {
         auto compressor = makeEffect(7);
-        compressor.deltaSolo = true;
         compressor.sidechain.type = SidechainConfig::Type::Audio;
         compressor.sidechain.sourceTrackId = 2;
 
@@ -1024,7 +1053,6 @@ TEST_CASE("Delta solo subtracts the dry signal from what the processing made",
     SECTION("a rack is measured one level up, around its own fader") {
         RackInfo rack;
         rack.id = 4;
-        rack.deltaSolo = true;
         ChainInfo chain;
         chain.id = 10;
         chain.elements.push_back(makeDeviceElement(makeEffect(7)));
@@ -1044,7 +1072,7 @@ TEST_CASE("Delta solo subtracts the dry signal from what the processing made",
         CHECK(plan.ops[static_cast<std::size_t>(delta)].key.rackId == 4);
 
         // The rack's volume and pan are on the wet path in the current engine
-        // whether or not delta solo is on, so the fader is inside what is
+        // whether or not a delta is being heard, so the fader is inside what is
         // measured; the dry side is what reached the rack.
         CHECK(inputOp(plan, delta, 0) == opsWithRole(plan, OpRole::RackFader).front());
 
@@ -1057,7 +1085,6 @@ TEST_CASE("Delta solo subtracts the dry signal from what the processing made",
     SECTION("a rack with no chains still has an output of its own to measure") {
         RackInfo rack;
         rack.id = 4;
-        rack.deltaSolo = true;
 
         std::vector<TrackInfo> tracks{makeTrack(1)};
         tracks[0].chain.fxChainElements.push_back(makeRackElement(std::move(rack)));
@@ -1077,14 +1104,11 @@ TEST_CASE("Delta solo subtracts the dry signal from what the processing made",
     }
 
     SECTION("a device inside a rack inside a rack is keyed where it sits") {
-        auto effect = makeEffect(7);
-        effect.deltaSolo = true;
-
         RackInfo inner;
         inner.id = 5;
         ChainInfo innerChain;
         innerChain.id = 11;
-        innerChain.elements.push_back(makeDeviceElement(effect));
+        innerChain.elements.push_back(makeDeviceElement(makeEffect(7)));
         inner.chains.push_back(std::move(innerChain));
 
         RackInfo outer;
@@ -1113,9 +1137,27 @@ TEST_CASE("Delta solo subtracts the dry signal from what the processing made",
         CHECK(key.deviceId == 7);
         CHECK(inputOp(plan, delta, 0) == opsWithRole(plan, OpRole::DeviceProcess).front());
         CHECK(inputOp(plan, delta, 1) == deviceInput(plan, 7));
+
+        // Both racks are measured too, each around its own fader.
+        CHECK(countRole(plan, OpRole::RackDelta) == 2);
     }
 
-    SECTION("a bypassed device is not in the plan, so nothing is subtracted") {
+    SECTION("a transparent tap has nothing to measure") {
+        // Its output is its input, so its delta is silence by construction and
+        // there is no difference for a subtract to find. The same reason it has
+        // no gain trim and no meter of its own.
+        auto analysis = makeEffect(7);
+        analysis.deviceType = DeviceType::Analysis;
+
+        std::vector<TrackInfo> tracks{makeTrack(1)};
+        tracks[0].chain.fxChainElements.push_back(makeDeviceElement(analysis));
+
+        const auto plan = magda::engine::compileRenderPlan(tracks, makeMaster());
+        requireWellFormed(plan);
+        CHECK(countRole(plan, OpRole::DeviceDelta) == 0);
+    }
+
+    SECTION("a bypassed device is not in the plan, so nothing measures it") {
         auto effect = makeEffect(7);
         effect.deltaSolo = true;
         effect.bypassed = true;

--- a/tests/test_render_plan_compiler.cpp
+++ b/tests/test_render_plan_compiler.cpp
@@ -964,8 +964,9 @@ TEST_CASE("A rack-level sidechain is an edge to the modulation system",
     }
 }
 
-TEST_CASE("Delta solo is reported on devices and on racks", "[engine][plan][compiler]") {
-    SECTION("device") {
+TEST_CASE("Delta solo subtracts the dry signal from what the processing made",
+          "[engine][plan][compiler]") {
+    SECTION("a device is measured against the audio it was handed") {
         auto effect = makeEffect(7);
         effect.deltaSolo = true;
 
@@ -974,16 +975,53 @@ TEST_CASE("Delta solo is reported on devices and on racks", "[engine][plan][comp
 
         const auto plan = magda::engine::compileRenderPlan(tracks, makeMaster());
         requireWellFormed(plan);
+        CHECK(plan.diagnostics.empty());
 
-        // The plan has no dry edge past a device and no delay line to align it
-        // with, so the device compiles as if delta solo were off. Named rather
-        // than passed over, like every other gap.
-        REQUIRE(plan.diagnostics.size() == 1);
-        CHECK(plan.diagnostics.front().find("device 7") != std::string::npos);
-        CHECK(plan.diagnostics.front().find("delta solo") != std::string::npos);
+        const auto deltas = opsWithRole(plan, OpRole::DeviceDelta);
+        REQUIRE(deltas.size() == 1);
+        const auto delta = deltas.front();
+        CHECK(plan.ops[static_cast<std::size_t>(delta)].kind == OpKind::Subtract);
+
+        const auto process = opsWithRole(plan, OpRole::DeviceProcess).front();
+        CHECK(inputOp(plan, delta, 0) == process);
+        CHECK(inputOp(plan, delta, 1) == deviceInput(plan, 7));
+
+        // In front of the slot's gain and meter, which read the delta rather
+        // than the device once there is one.
+        CHECK(inputOp(plan, opsWithRole(plan, OpRole::DeviceGain).front(), 0) == delta);
     }
 
-    SECTION("rack") {
+    SECTION("the dry edge is taken in front of the device's own input alignment") {
+        auto compressor = makeEffect(7);
+        compressor.deltaSolo = true;
+        compressor.sidechain.type = SidechainConfig::Type::Audio;
+        compressor.sidechain.sourceTrackId = 2;
+
+        std::vector<TrackInfo> tracks{makeTrack(1), makeTrack(2)};
+        tracks[0].chain.fxChainElements.push_back(makeDeviceElement(compressor));
+
+        const auto plan = magda::engine::compileRenderPlan(tracks, makeMaster());
+        requireWellFormed(plan);
+        CHECK(plan.diagnostics.empty());
+
+        // A sidechain gives the device's audio slot a delay of its own. The
+        // delta's dry delay hangs off the same producer rather than off that
+        // one: a delay reading a delay would count the edge twice, and
+        // validatePlan rejects it, which requireWellFormed has just asserted.
+        const auto delta = opsWithRole(plan, OpRole::DeviceDelta).front();
+        const auto process = opsWithRole(plan, OpRole::DeviceProcess).front();
+        const auto dryDelay = rawInputOp(plan, delta, 1);
+        const auto deviceDelay = rawInputOp(plan, process, 0);
+        REQUIRE(dryDelay != magda::engine::INVALID_OP_ID);
+        REQUIRE(deviceDelay != magda::engine::INVALID_OP_ID);
+        CHECK(plan.ops[static_cast<std::size_t>(dryDelay)].kind == OpKind::Delay);
+        CHECK(plan.ops[static_cast<std::size_t>(deviceDelay)].kind == OpKind::Delay);
+        CHECK(dryDelay != deviceDelay);
+        CHECK(plan.ops[static_cast<std::size_t>(dryDelay)].inputs.front() ==
+              plan.ops[static_cast<std::size_t>(deviceDelay)].inputs.front());
+    }
+
+    SECTION("a rack is measured one level up, around its own fader") {
         RackInfo rack;
         rack.id = 4;
         rack.deltaSolo = true;
@@ -997,13 +1035,87 @@ TEST_CASE("Delta solo is reported on devices and on racks", "[engine][plan][comp
 
         const auto plan = magda::engine::compileRenderPlan(tracks, makeMaster());
         requireWellFormed(plan);
+        CHECK(plan.diagnostics.empty());
 
-        REQUIRE(plan.diagnostics.size() == 1);
-        CHECK(plan.diagnostics.front().find("rack 4") != std::string::npos);
-        CHECK(plan.diagnostics.front().find("delta solo") != std::string::npos);
+        const auto deltas = opsWithRole(plan, OpRole::RackDelta);
+        REQUIRE(deltas.size() == 1);
+        const auto delta = deltas.front();
+        CHECK(plan.ops[static_cast<std::size_t>(delta)].kind == OpKind::Subtract);
+        CHECK(plan.ops[static_cast<std::size_t>(delta)].key.rackId == 4);
+
+        // The rack's volume and pan are on the wet path in the current engine
+        // whether or not delta solo is on, so the fader is inside what is
+        // measured; the dry side is what reached the rack.
+        CHECK(inputOp(plan, delta, 0) == opsWithRole(plan, OpRole::RackFader).front());
+
+        const auto dry = inputOp(plan, delta, 1);
+        REQUIRE(dry != magda::engine::INVALID_OP_ID);
+        CHECK(plan.ops[static_cast<std::size_t>(dry)].key.role == OpRole::TrackAudioInput);
+        CHECK(plan.ops[static_cast<std::size_t>(dry)].key.trackId == 1);
     }
 
-    SECTION("a bypassed device is not in the plan, so it is not reported") {
+    SECTION("a rack with no chains still has an output of its own to measure") {
+        RackInfo rack;
+        rack.id = 4;
+        rack.deltaSolo = true;
+
+        std::vector<TrackInfo> tracks{makeTrack(1)};
+        tracks[0].chain.fxChainElements.push_back(makeRackElement(std::move(rack)));
+
+        const auto plan = magda::engine::compileRenderPlan(tracks, makeMaster());
+        requireWellFormed(plan);
+        CHECK(plan.diagnostics.empty());
+
+        REQUIRE(countRole(plan, OpRole::RackDelta) == 1);
+        const auto delta = opsWithRole(plan, OpRole::RackDelta).front();
+        CHECK(inputOp(plan, delta, 0) == opsWithRole(plan, OpRole::RackFader).front());
+
+        const auto dry = inputOp(plan, delta, 1);
+        REQUIRE(dry != magda::engine::INVALID_OP_ID);
+        CHECK(plan.ops[static_cast<std::size_t>(dry)].key.role == OpRole::TrackAudioInput);
+        CHECK(plan.ops[static_cast<std::size_t>(dry)].key.trackId == 1);
+    }
+
+    SECTION("a device inside a rack inside a rack is keyed where it sits") {
+        auto effect = makeEffect(7);
+        effect.deltaSolo = true;
+
+        RackInfo inner;
+        inner.id = 5;
+        ChainInfo innerChain;
+        innerChain.id = 11;
+        innerChain.elements.push_back(makeDeviceElement(effect));
+        inner.chains.push_back(std::move(innerChain));
+
+        RackInfo outer;
+        outer.id = 4;
+        ChainInfo outerChain;
+        outerChain.id = 10;
+        outerChain.elements.push_back(makeRackElement(std::move(inner)));
+        outer.chains.push_back(std::move(outerChain));
+
+        std::vector<TrackInfo> tracks{makeTrack(1)};
+        tracks[0].chain.fxChainElements.push_back(makeRackElement(std::move(outer)));
+
+        const auto plan = magda::engine::compileRenderPlan(tracks, makeMaster());
+        requireWellFormed(plan);
+        CHECK(plan.diagnostics.empty());
+
+        // The dry edge crosses no boundary the keys do not already carry: it is
+        // the chain audio at the device's own site, which is where the device
+        // op is keyed too.
+        REQUIRE(countRole(plan, OpRole::DeviceDelta) == 1);
+        const auto delta = opsWithRole(plan, OpRole::DeviceDelta).front();
+        const auto& key = plan.ops[static_cast<std::size_t>(delta)].key;
+        CHECK(key.trackId == 1);
+        CHECK(key.rackId == 5);
+        CHECK(key.chainId == 11);
+        CHECK(key.deviceId == 7);
+        CHECK(inputOp(plan, delta, 0) == opsWithRole(plan, OpRole::DeviceProcess).front());
+        CHECK(inputOp(plan, delta, 1) == deviceInput(plan, 7));
+    }
+
+    SECTION("a bypassed device is not in the plan, so nothing is subtracted") {
         auto effect = makeEffect(7);
         effect.deltaSolo = true;
         effect.bypassed = true;
@@ -1014,6 +1126,13 @@ TEST_CASE("Delta solo is reported on devices and on racks", "[engine][plan][comp
         const auto plan = magda::engine::compileRenderPlan(tracks, makeMaster());
         requireWellFormed(plan);
         CHECK(plan.diagnostics.empty());
+
+        // The chain, not silence, which is parity: bypass reaches the current
+        // engine as `Plugin::setEnabled(false)`, and PluginNode skips the
+        // subtraction for a plugin that is not enabled. Delta solo on a device
+        // that does nothing is silence because subtracting its input from its
+        // output leaves nothing, not because the flag is on.
+        CHECK(countRole(plan, OpRole::DeviceDelta) == 0);
     }
 }
 

--- a/tests/test_render_plan_executor.cpp
+++ b/tests/test_render_plan_executor.cpp
@@ -753,6 +753,89 @@ TEST_CASE("A rack sums its chains through their faders and its own output law", 
     CHECK(harness.outputSample() == approx(chainGain * juce::Decibels::decibelsToGain(-6.0f)));
 }
 
+TEST_CASE("Delta solo hears what the device added", "[engine][exec]") {
+    auto effect = makeEffect(7);
+    effect.deltaSolo = true;
+
+    auto track = makeTrack(1);
+    track.chain.fxChainElements.push_back(makeDeviceElement(effect));
+
+    SECTION("a device that changes the signal leaves its difference behind") {
+        Harness harness({track}, makeMaster());
+        ConstantSource source(0.5f);
+        GainDevice device(0.25f);
+        harness.bindings.clipAudio[1] = &source;
+        harness.bindings.devices[DeviceKey{7}] = &device;
+
+        harness.prepareCleanly();
+        harness.render();
+
+        CHECK(harness.outputSample() == approx(0.5f * 0.25f - 0.5f));
+    }
+
+    SECTION("a device that changes nothing leaves nothing") {
+        Harness harness({track}, makeMaster());
+        ConstantSource source(0.5f);
+        GainDevice device(1.0f);
+        harness.bindings.clipAudio[1] = &source;
+        harness.bindings.devices[DeviceKey{7}] = &device;
+
+        harness.prepareCleanly();
+        harness.render();
+
+        CHECK(device.processedBlocks == 1);
+        CHECK(harness.outputSample() == approx(0.0f));
+    }
+}
+
+TEST_CASE("A delta solo's dry edge is delayed to meet the wet one", "[engine][exec]") {
+    // A device that only delays adds nothing, so its delta is silence - but
+    // only once the dry side has been held back to meet it. Compensate it
+    // wrongly and the impulse comes out twice, once from each side.
+    auto effect = makeEffect(7);
+    effect.deltaSolo = true;
+
+    auto track = makeTrack(1);
+    track.chain.fxChainElements.push_back(makeDeviceElement(effect));
+
+    Harness harness({track}, makeMaster());
+    ImpulseSource source(1.0f);
+    LatentDevice device(32);
+    harness.bindings.clipAudio[1] = &source;
+    harness.bindings.devices[DeviceKey{7}] = &device;
+
+    harness.prepareCleanly();
+
+    const auto stream = renderStream(harness, 2);
+    INFO(magda::engine::dumpPlan(harness.plan));
+    CHECK(soundingSamples(stream).empty());
+}
+
+TEST_CASE("Delta solo around a rack measures its output against its input", "[engine][exec]") {
+    auto rack = std::make_unique<RackInfo>();
+    rack->id = 5;
+    rack->deltaSolo = true;
+
+    ChainInfo chain;
+    chain.id = 10;
+    chain.elements.push_back(makeDeviceElement(makeEffect(7)));
+    rack->chains.push_back(std::move(chain));
+
+    auto track = makeTrack(1);
+    track.chain.fxChainElements.push_back(ChainElement{std::move(rack)});
+
+    Harness harness({track}, makeMaster());
+    ConstantSource source(1.0f);
+    GainDevice device(0.5f);
+    harness.bindings.clipAudio[1] = &source;
+    harness.bindings.devices[DeviceKey{7}] = &device;
+
+    harness.prepareCleanly();
+    harness.render();
+
+    CHECK(harness.outputSample() == approx(0.5f - 1.0f));
+}
+
 TEST_CASE("A rack chain out of the mix contributes neither audio nor MIDI", "[engine][exec]") {
     auto rack = std::make_unique<RackInfo>();
     rack->id = 5;

--- a/tests/test_render_plan_executor.cpp
+++ b/tests/test_render_plan_executor.cpp
@@ -811,6 +811,48 @@ TEST_CASE("A delta solo's dry edge is delayed to meet the wet one", "[engine][ex
     CHECK(soundingSamples(stream).empty());
 }
 
+TEST_CASE("Delta solo turned on mid-render reads a dry line that has been running",
+          "[engine][exec]") {
+    // The point of compiling the subtract and its dry delay whether or not
+    // anything is soloing a delta. A delay line is history: one that came into
+    // being when the button was pressed would hand back its own length in
+    // silence, so a device with any real latency would leak its wet signal for
+    // that long and then step. The current engine keeps the same line running
+    // for the same reason - PluginNode's deltaLatencyProcessor is built from
+    // the plugin's latency alone and written every block, and only the read is
+    // conditional (see the regression in tests/test_delta_solo.cpp).
+    //
+    // A device that only delays adds nothing, so its delta is silence. Reaching
+    // that on the very first block after the toggle is possible only if the dry
+    // line already holds the samples the wet side is now arriving with.
+    auto track = makeTrack(1);
+    track.chain.fxChainElements.push_back(makeDeviceElement(makeEffect(7)));
+
+    Harness harness({track}, makeMaster());
+    RampSource source;
+    LatentDevice device(kBlockSize);
+    harness.bindings.clipAudio[1] = &source;
+    harness.bindings.devices[DeviceKey{7}] = &device;
+
+    harness.prepareCleanly();
+    INFO(magda::engine::dumpPlan(harness.plan));
+
+    // Block 0 with the delta unheard: the device's own delay is still filling,
+    // and nothing is taken off what comes out of it.
+    harness.render(kBlockSize, 0);
+
+    // Now the model says to hear it, which is a value away: the plan does not
+    // change, so nothing is rebuilt and the line keeps its contents.
+    getDevice(harness.tracks[0].chain.fxChainElements[0]).deltaSolo = true;
+    harness.valueMessages = magda::engine::resolvePlanValues(harness.plan, harness.tracks,
+                                                             harness.master, harness.values);
+    REQUIRE(harness.valueMessages.empty());
+
+    harness.render(kBlockSize, kBlockSize);
+    for (int sample = 0; sample < kBlockSize; ++sample)
+        CHECK(harness.outputSample(0, sample) == approx(0.0f));
+}
+
 TEST_CASE("Delta solo around a rack measures its output against its input", "[engine][exec]") {
     auto rack = std::make_unique<RackInfo>();
     rack->id = 5;
@@ -1548,7 +1590,10 @@ TEST_CASE("What is in flight survives the plan being replaced", "[engine][exec][
 
     SECTION("taking over from the epoch being replaced") {
         REQUIRE(second.prepare(plan, bindings, context, &first).empty());
-        CHECK(second.carriedDelayLines() == 1);
+
+        // The master's alignment of track 2, and the dry edge of the latent
+        // device's own delta: both hold samples, and both carry.
+        CHECK(second.carriedDelayLines() == 2);
 
         // Block 1, on the new executor: the impulse comes out where it would
         // have if nothing had happened.


### PR DESCRIPTION
Slice 2 of #1892. Closes #2136.

Delta solo, at device and rack scope. Both sites were already named in the compiler and both said the same thing: the alignment is a delay like any other now, and what was missing was the edge carrying the dry signal past the processing and the op that subtracts it.

## What it settles

**A subtract with its own kind.** `OpKind::Subtract`, arity two (wet, dry), rather than a gain of -1 into a mix, so the differ, the dump and the layout can name it. Roles: `deviceDelta`, `rackDelta`, and `subtractInputDelay` for its fan-in.

**Where it sits.** For a device, between the process op and the slot's gain and meter — where the current engine subtracts it, since those are MAGDA's own and sit outside the plugin. For a rack, around the instance's own fader, so the rack's volume and pan are inside what is measured: they are the `RackInstance`'s output levels and the current engine applies them on the wet path whether or not a delta is heard. A rack with no chains gets one too, for the same reason its fader still applies there. A transparent tap gets none: its output is its input, so its delta is silence by construction.

**Where the dry edge is taken from.** The chain audio in front of whatever aligned the device's own input, not the device's input slot. Taken from the slot, a sidechained device produces a delay reading a delay — double-counting that edge's compensation, which `validatePlan` already rejects. Taken from in front of it, the subtract's own dry delay resolves to the whole distance instead: the input alignment and the device's latency together.

**The alignment is the existing PDC delay.** Both sides go through `alignInputs`. The wet delay resolves to nothing and is elided; the dry one holds exactly the wet path's distance. No second latency concept.

**It is in every plan, and the flag is a value.** The dry edge's delay is a delay line, and a delay line is history: one created at the moment the button was pressed would hand back its own length in silence, so a device with any real latency would leak its wet signal for that long and then step, well past what a 5 ms graph fade can cover. The current engine keeps the same line running for the same reason — `PluginNode` builds `deltaLatencyProcessor` from the plugin's latency alone and writes into it every block, gating only the read. So the subtract and its delay are compiled unconditionally and the model decides only whether the subtraction happens, through `OpValue::subtractsDry`. Toggling delta solo compiles nothing: the plan is identical either way (pinned by fingerprint), so it publishes values only and the line keeps its contents.

**Nesting.** A device inside a rack inside a rack keys its delta `T1/R5/C11/D7:deviceDelta` — the dry edge crosses no boundary the op keys do not already carry.

## What it costs

A device slot is four ops rather than three, and a device no longer writes its output over its input buffer, because the chain audio now has a second reader — one block copy per device, which is the copy `PluginNode` makes unconditionally anyway. The dry delay elides to nothing where the device reports no latency, which is the rule TE uses to decide whether to build its line at all. Every golden shows this.

## One judgement call worth reviewing

The issue says "a bypassed device's delta is silence rather than the chain". This keeps structural bypass compiling to no delta at all, which is parity: MAGDA's bypass reaches the current engine as `Plugin::setEnabled(false)`, and `PluginNode` skips `applyDeltaSolo` for a plugin that is not enabled, handing back the chain. The reading here is that the delta of a device that does nothing is silence because subtracting its input from its output leaves nothing — which is now literally true for any transparent processing — not because the flag is on. Discussed inline; say the word and it is three lines the other way.

## Tests

- Compiler: the flag changing nothing about the plan, both scopes, the sidechain case, the empty rack, the doubly nested device, transparent taps, bypass.
- Layout: what each dry delay resolves to — including 140 samples for a device with 100 of its own behind a key that arrives 40 late.
- Executor: the difference itself; a unity device netting to silence; a pure-delay device netting to silence, which only passes if the compensation is right; and **the toggle mid-render**, where a device that only delays is silent on the very first block after the flag flips, which is reachable only if the dry line was already running.
- A `delta solo` scene joins the parallel executor's comparison: this is the one op that reads two live buffers and writes over one of them.
- A `deltaSoloDevice` edit joins the random sequence generator. It found that a value-only publish steps rather than ramps; that is exempt in the transient property now, with the reason at `Transient::valueOnly` — nothing moved, so there was nothing to fade, and mute and every fader position have the same shape today. The deep sweep still bounds 1603 transients that did move.
- A `delta-solo` golden pinning a device's delta inside a rack's, and what their dry edges wait for.

Negative checks: removing `alignInputs` from `emitDelta` fails exactly the five alignment assertions; taking the dry edge off the device's input slot trips `validatePlan`'s delay rules; compiling the subtract conditionally fails the mid-render toggle on every sample of the block after the flip.

Full suite green locally (2874 passed, 13 skipped), property sweeps included. Not run under TSan: `make test-tsan` cannot link on this machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)