### PR TITLE
Let the overlap preference reach the clips it is meant to seed

### DIFF
--- a/magda/daw/core/ClipManager.cpp
+++ b/magda/daw/core/ClipManager.cpp
@@ -370,6 +370,10 @@ ClipId ClipManager::createAudioClipBeats(TrackId trackId, double startBeats, dou
     // auto-crossfade audio clips play as crossfades instead of trimming.
     clip.autoCrossfade = Config::getInstance().getAutoCrossfadeByDefault();
 
+    // What a new clip starts with when something covers it (#2003). Per clip
+    // from here on: the preference seeds it and never speaks for it again.
+    clip.overlapPlaysBoth = Config::getInstance().getClipOverlapPlaysBoth();
+
     const double bpm = isValidBpm(projectBPM) ? projectBPM : currentProjectTempoOrDefault();
 
     clip.setPlacementBeats(startBeats, lengthBeats);
@@ -529,6 +533,9 @@ ClipId ClipManager::createMidiClipBeats(TrackId trackId, double startBeats, doub
     clip.trackId = trackId;
     clip.setMidiContent();
     clip.view = view;
+    // Occlusion applies to audio and MIDI alike, so the preference seeds both
+    // (#2003). Per clip from here on.
+    clip.overlapPlaysBoth = Config::getInstance().getClipOverlapPlaysBoth();
     clip.name = generateClipName(ClipType::MIDI);
     // Chord-track clips are chord progressions, not generic MIDI clips.
     if (const auto* nameTrack = TrackManager::getInstance().getTrack(trackId);

--- a/manual/docs/interface/preferences.md
+++ b/manual/docs/interface/preferences.md
@@ -18,6 +18,7 @@ The dialog is organised into sections; each section is described below.
 - **Panel visibility defaults** — Choose which panels are shown on startup
 - **Behavior settings** — Configure UI interaction preferences
 - **Auto-crossfade new audio clips** - New audio clips overlap into a [crossfade](../clips.md#crossfades) automatically when they meet a neighbour
+- **New clips play through overlaps** - What a new clip starts with when something covers it. Off, the clip on top owns the span it covers and the clip underneath plays only what is left; on, both sound across the overlap. This is only the starting value, so changing it leaves existing clips alone; per clip, right-click and tick **Play Through Overlap**. See [Overlapping clips](../clips.md#overlapping-clips)
 - **New tracks run post-FX after the fader** - The side of the track fader a new track's [post-FX section](../fx-chain.md#post-fx-section) starts on. Existing tracks keep their own setting, which you change from the fader tag on the post-FX panel
 - **Duplicate Loop Range: grow / advance** - When you duplicate the loop range, choose whether the loop grows to cover the copy or advances past it
 - **Auto-hide arrangement scrollbars** — Keep the arrangement scrollbars hidden until you hover near them, for a cleaner workspace

--- a/manual/docs/interface/preferences.md
+++ b/manual/docs/interface/preferences.md
@@ -18,7 +18,7 @@ The dialog is organised into sections; each section is described below.
 - **Panel visibility defaults** — Choose which panels are shown on startup
 - **Behavior settings** — Configure UI interaction preferences
 - **Auto-crossfade new audio clips** - New audio clips overlap into a [crossfade](../clips.md#crossfades) automatically when they meet a neighbour
-- **New clips play through overlaps** - What a new clip starts with when something covers it. Off, the clip on top owns the span it covers and the clip underneath plays only what is left; on, both sound across the overlap. This is only the starting value, so changing it leaves existing clips alone; per clip, right-click and tick **Play Through Overlap**. See [Overlapping clips](../clips.md#overlapping-clips)
+- **New clips play through overlaps** - What a new clip starts with when something covers it. Off, the clip on top owns the span it covers and the clip underneath plays only what is left; on, both sound across the overlap. This is only the starting value, so changing it leaves existing clips alone; per clip, right-click and tick **Play Through Overlap**. See [Clips](../clips.md) for how overlapping clips stack
 - **New tracks run post-FX after the fader** - The side of the track fader a new track's [post-FX section](../fx-chain.md#post-fx-section) starts on. Existing tracks keep their own setting, which you change from the fader tag on the post-FX panel
 - **Duplicate Loop Range: grow / advance** - When you duplicate the loop range, choose whether the loop grows to cover the copy or advances past it
 - **Auto-hide arrangement scrollbars** — Keep the arrangement scrollbars hidden until you hover near them, for a cleaner workspace

--- a/manual/docs/interface/preferences.md
+++ b/manual/docs/interface/preferences.md
@@ -18,7 +18,7 @@ The dialog is organised into sections; each section is described below.
 - **Panel visibility defaults** — Choose which panels are shown on startup
 - **Behavior settings** — Configure UI interaction preferences
 - **Auto-crossfade new audio clips** - New audio clips overlap into a [crossfade](../clips.md#crossfades) automatically when they meet a neighbour
-- **New clips play through overlaps** - What a new clip starts with when something covers it. Off, the clip on top owns the span it covers and the clip underneath plays only what is left; on, both sound across the overlap. This is only the starting value, so changing it leaves existing clips alone; per clip, right-click and tick **Play Through Overlap**. See [Clips](../clips.md) for how overlapping clips stack
+- **New clips play through overlaps** - What a new clip starts with when something covers it. Off, the clip on top owns the span it covers and the clip underneath plays only what is left; on, both sound across the overlap. This is only the starting value, so changing it leaves existing clips alone; per clip, right-click and tick **Play Through Overlap**. See [Overlapping clips](../clips.md#overlapping-clips)
 - **New tracks run post-FX after the fader** - The side of the track fader a new track's [post-FX section](../fx-chain.md#post-fx-section) starts on. Existing tracks keep their own setting, which you change from the fader tag on the post-FX panel
 - **Duplicate Loop Range: grow / advance** - When you duplicate the loop range, choose whether the loop grows to cover the copy or advances past it
 - **Auto-hide arrangement scrollbars** — Keep the arrangement scrollbars hidden until you hover near them, for a cleaner workspace

--- a/tests/test_clip_crossfades.cpp
+++ b/tests/test_clip_crossfades.cpp
@@ -94,6 +94,51 @@ TEST_CASE("new audio clips follow the auto-crossfade config default", "[crossfad
     CHECK(cm.getClip(id)->autoCrossfade == Config::getInstance().getAutoCrossfadeByDefault());
 }
 
+// The sibling preference. It shipped unread: the dialog set its own toggle from
+// it and no creation path ever asked, so a new clip started false whatever it
+// said (#2160). Both clip types, because occlusion applies to both.
+TEST_CASE("new clips follow the overlap-plays-both config default", "[crossfade][occlusion]") {
+    auto& config = Config::getInstance();
+    const bool original = config.getClipOverlapPlaysBoth();
+
+    for (const bool preference : {true, false}) {
+        resetState();
+        config.setClipOverlapPlaysBoth(preference);
+        auto& cm = ClipManager::getInstance();
+        const auto trackId = createTrack();
+
+        const ClipId audio = createAudioBeats(trackId, 0.0, 4.0);
+        CHECK(cm.getClip(audio)->overlapPlaysBoth == preference);
+
+        const ClipId midi = cm.createMidiClipBeats(trackId, 8.0, 4.0, ClipView::Arrangement);
+        CHECK(cm.getClip(midi)->overlapPlaysBoth == preference);
+    }
+
+    config.setClipOverlapPlaysBoth(original);
+}
+
+// The preference seeds and then stops speaking for the clip, which is what
+// makes the per-clip Play Through Overlap switch meaningful.
+TEST_CASE("changing the overlap default leaves existing clips alone", "[crossfade][occlusion]") {
+    auto& config = Config::getInstance();
+    const bool original = config.getClipOverlapPlaysBoth();
+
+    resetState();
+    config.setClipOverlapPlaysBoth(false);
+    auto& cm = ClipManager::getInstance();
+    const auto trackId = createTrack();
+    const ClipId existing = createAudioBeats(trackId, 0.0, 4.0);
+    REQUIRE(cm.getClip(existing)->overlapPlaysBoth == false);
+
+    config.setClipOverlapPlaysBoth(true);
+    CHECK(cm.getClip(existing)->overlapPlaysBoth == false);
+
+    const ClipId fresh = createAudioBeats(trackId, 8.0, 4.0);
+    CHECK(cm.getClip(fresh)->overlapPlaysBoth == true);
+
+    config.setClipOverlapPlaysBoth(original);
+}
+
 // ============================================================================
 // setCrossfadeBeats — creation, resize, removal
 // ============================================================================


### PR DESCRIPTION
Closes #2160.

## The bug

**Settings > Preferences > UI > "New clips play through overlaps"** did nothing. `Config::getClipOverlapPlaysBoth()` had exactly one caller in the tree:

```
PreferencesDialog.cpp:325
    clipOverlapPlaysBothToggle.setToggleState(config.getClipOverlapPlaysBoth(), ...)
```

That is the dialog setting its own toggle from the stored value. No creation path ever asked, and `ClipInfo::overlapPlaysBoth` defaults to `false`, so a new clip started there whatever the toggle said. The control looked live and was inert.

`Config.hpp:462` says what it is for — *"What NEW clips start with (#2003)"* — so this was missing wiring from #2003, not a decision.

## The fix

Seed it where the clip is built, beside `autoCrossfade`, which is the sibling preference and was already wired exactly this way. Both creation paths (`createAudioClipBeats`, `createMidiClipBeats`), because occlusion applies to audio and MIDI alike.

Duplicates and deserialized clips carry their own value and are untouched, which is what *"per clip from then on"* in the Config comment means.

## Tests

Two, in `test_clip_crossfades.cpp` next to the existing auto-crossfade-default test:

- both clip types follow the preference, tested both ways round
- flipping it afterwards moves new clips and leaves existing ones alone

I confirmed they fail without the change rather than assuming: removing the two seeding lines fails 3 assertions across 2 cases. They pass with it.

## Verification

- `make test`: 2883 cases, 599911 assertions, 0 failures
- `make debug` clean

## Docs

The manual bullet for this preference was pulled in #2159 rather than shipping a page describing a dead control. It is restored here, in the same branch that makes it true, linking to the `#overlapping-clips` section #2159 added.

Branch has dev merged in, so the link is verified against the real page rather than assumed: the docs build reports no dangling anchors.
