### PR TITLE
Report a delta solo the plan cannot take (#2136)

### DIFF
--- a/magda/engine/plan/PlanCompiler.cpp
+++ b/magda/engine/plan/PlanCompiler.cpp
@@ -613,19 +613,10 @@ ChainSignal Compiler::emitDevice(const DeviceInfo& device, const ChainSite& site
     const bool hasTargets = ownsMultiOutPairs && targets != multiOutTargets_.end();
 
     if (device.bypassed) {
-        // Bypass removes the device from the plan, so there is no output to
-        // measure a difference against and the chain passes through unchanged,
-        // which is what the current engine does: bypass reaches it as
-        // `Plugin::setEnabled(false)` and PluginNode's delta subtraction is
-        // guarded on the plugin being enabled.
-        //
-        // The model's own setters cannot produce this pair - bypassing clears
-        // delta solo and enabling delta solo clears bypass, for devices and for
-        // racks (TrackManager::setDeviceBypassed and the rest) - so a project
-        // holding both came in through deserialisation, which writes the two
-        // fields straight into the struct. Reported rather than ignored,
-        // because the delta button will be lit over a device that is passing
-        // its input through, and nothing else would say why.
+        // The model's setters keep bypass and delta solo apart, so a project
+        // holding both arrived through deserialisation, which writes the fields
+        // straight into the struct. The chain passes through, which is parity,
+        // and the flag is reported rather than dropped in silence.
         if (device.deltaSolo)
             diagnose("device " + std::to_string(device.id) + " on track " +
                      std::to_string(site.trackId) +
@@ -702,14 +693,10 @@ ChainSignal Compiler::emitDevice(const DeviceInfo& device, const ChainSite& site
     // subtracts it too: those are MAGDA's own and sit outside the plugin, so
     // what they trim and report is the delta while one is being heard.
     //
-    // A transparent tap has none of the four. Its output is its input, so the
-    // difference it would take is silence whatever the signal, and the model
-    // cannot ask for it: the delta button belongs to DeviceType::Effect alone
-    // (DeviceSlotHeaderSpec's `visibility.delta`), and nothing else writes the
-    // flag. A stored project can still carry one, because the field is
-    // serialised on every device, and that is worth a word rather than a
-    // silence - the plan hands back the chain where the flag asks for nothing
-    // at all.
+    // A transparent tap has none of the four: its output is its input, so the
+    // difference is silence whatever the signal, and the delta button does not
+    // offer it (DeviceType::Effect only). A stored project can carry the flag
+    // anyway, and the plan hands back the chain, so it says so.
     if (isTransparentTap(device) && device.deltaSolo)
         diagnose("device " + std::to_string(device.id) + " on track " +
                  std::to_string(site.trackId) +
@@ -748,9 +735,7 @@ ChainSignal Compiler::emitDevice(const DeviceInfo& device, const ChainSite& site
 
 ChainSignal Compiler::emitRack(const RackInfo& rack, const ChainSite& site, ChainSignal signal) {
     if (rack.bypassed) {
-        // The device case one level up, and unreachable the same way: the
-        // model's setters keep a rack's bypass and its delta solo apart, so
-        // both together arrived from a stored project.
+        // The device case one level up, unreachable the same way.
         if (rack.deltaSolo)
             diagnose("rack " + std::to_string(rack.id) +
                      ": delta solo on a bypassed rack measures nothing, the chain passes through "

--- a/magda/engine/plan/PlanCompiler.cpp
+++ b/magda/engine/plan/PlanCompiler.cpp
@@ -612,8 +612,27 @@ ChainSignal Compiler::emitDevice(const DeviceInfo& device, const ChainSite& site
     const auto targets = multiOutTargets_.find({site.trackId, device.id});
     const bool hasTargets = ownsMultiOutPairs && targets != multiOutTargets_.end();
 
-    if (device.bypassed)
+    if (device.bypassed) {
+        // Bypass removes the device from the plan, so there is no output to
+        // measure a difference against and the chain passes through unchanged,
+        // which is what the current engine does: bypass reaches it as
+        // `Plugin::setEnabled(false)` and PluginNode's delta subtraction is
+        // guarded on the plugin being enabled.
+        //
+        // The model's own setters cannot produce this pair - bypassing clears
+        // delta solo and enabling delta solo clears bypass, for devices and for
+        // racks (TrackManager::setDeviceBypassed and the rest) - so a project
+        // holding both came in through deserialisation, which writes the two
+        // fields straight into the struct. Reported rather than ignored,
+        // because the delta button will be lit over a device that is passing
+        // its input through, and nothing else would say why.
+        if (device.deltaSolo)
+            diagnose("device " + std::to_string(device.id) + " on track " +
+                     std::to_string(site.trackId) +
+                     ": delta solo on a bypassed device measures nothing, the chain passes "
+                     "through unchanged");
         return signal;
+    }
 
     const auto node = routing::makeRoutingNode(device);
 
@@ -683,9 +702,20 @@ ChainSignal Compiler::emitDevice(const DeviceInfo& device, const ChainSite& site
     // subtracts it too: those are MAGDA's own and sit outside the plugin, so
     // what they trim and report is the delta while one is being heard.
     //
-    // A transparent tap has none of the four: its output is its input, so its
-    // delta is silence by construction and there is nothing for the subtract to
-    // find.
+    // A transparent tap has none of the four. Its output is its input, so the
+    // difference it would take is silence whatever the signal, and the model
+    // cannot ask for it: the delta button belongs to DeviceType::Effect alone
+    // (DeviceSlotHeaderSpec's `visibility.delta`), and nothing else writes the
+    // flag. A stored project can still carry one, because the field is
+    // serialised on every device, and that is worth a word rather than a
+    // silence - the plan hands back the chain where the flag asks for nothing
+    // at all.
+    if (isTransparentTap(device) && device.deltaSolo)
+        diagnose("device " + std::to_string(device.id) + " on track " +
+                 std::to_string(site.trackId) +
+                 ": delta solo on an analysis device has nothing to subtract, the chain passes "
+                 "through unchanged");
+
     if (!isTransparentTap(device)) {
         key.role = OpRole::DeviceDelta;
         out.audio = emitDelta(key, out.audio, signal.audio);
@@ -717,8 +747,16 @@ ChainSignal Compiler::emitDevice(const DeviceInfo& device, const ChainSite& site
 }
 
 ChainSignal Compiler::emitRack(const RackInfo& rack, const ChainSite& site, ChainSignal signal) {
-    if (rack.bypassed)
+    if (rack.bypassed) {
+        // The device case one level up, and unreachable the same way: the
+        // model's setters keep a rack's bypass and its delta solo apart, so
+        // both together arrived from a stored project.
+        if (rack.deltaSolo)
+            diagnose("rack " + std::to_string(rack.id) +
+                     ": delta solo on a bypassed rack measures nothing, the chain passes through "
+                     "unchanged");
         return signal;
+    }
 
     // A rack-level sidechain drives the rack's own followers and triggered
     // modifiers. It is still not a signal edge into the rack, because a rack

--- a/tests/PlanEditSequence.cpp
+++ b/tests/PlanEditSequence.cpp
@@ -551,6 +551,11 @@ bool apply(const Edit& edit, Project& project) {
             return true;
         }
 
+        // Bypass and delta solo are one switch with three positions, not two
+        // switches: TrackManager clears each when the other is set, for devices
+        // and for racks. A generator that set them independently would build a
+        // project no user can reach, and the compiler reports that pair rather
+        // than compiling it.
         case EditKind::BypassDevice: {
             DeviceAt at;
             if (!findDevice(project, edit.deviceId, at))
@@ -560,6 +565,8 @@ bool apply(const Edit& edit, Project& project) {
             if (device.bypassed == edit.flag)
                 return false;
             device.bypassed = edit.flag;
+            if (edit.flag)
+                device.deltaSolo = false;
             return true;
         }
 
@@ -572,6 +579,8 @@ bool apply(const Edit& edit, Project& project) {
             if (device.deltaSolo == edit.flag)
                 return false;
             device.deltaSolo = edit.flag;
+            if (edit.flag)
+                device.bypassed = false;
             return true;
         }
 

--- a/tests/test_render_plan_compiler.cpp
+++ b/tests/test_render_plan_compiler.cpp
@@ -1167,7 +1167,6 @@ TEST_CASE("Every device slot and every rack carries the subtract a delta is take
 
         const auto plan = magda::engine::compileRenderPlan(tracks, makeMaster());
         requireWellFormed(plan);
-        CHECK(plan.diagnostics.empty());
 
         // The chain, not silence, which is parity: bypass reaches the current
         // engine as `Plugin::setEnabled(false)`, and PluginNode skips the
@@ -1175,6 +1174,69 @@ TEST_CASE("Every device slot and every rack carries the subtract a delta is take
         // that does nothing is silence because subtracting its input from its
         // output leaves nothing, not because the flag is on.
         CHECK(countRole(plan, OpRole::DeviceDelta) == 0);
+
+        // And the pair is reported, because it is a pair the model's own
+        // setters refuse to make: this one was written by hand, the way
+        // deserialisation writes it.
+        REQUIRE(plan.diagnostics.size() == 1);
+        CHECK(plan.diagnostics.front().find("delta solo on a bypassed device measures nothing") !=
+              std::string::npos);
+    }
+
+    SECTION("a bypassed rack is the same one level up") {
+        RackInfo rack;
+        rack.id = 4;
+        rack.bypassed = true;
+        rack.deltaSolo = true;
+        ChainInfo chain;
+        chain.id = 10;
+        chain.elements.push_back(makeDeviceElement(makeEffect(7)));
+        rack.chains.push_back(std::move(chain));
+
+        std::vector<TrackInfo> tracks{makeTrack(1)};
+        tracks[0].chain.fxChainElements.push_back(makeRackElement(std::move(rack)));
+
+        const auto plan = magda::engine::compileRenderPlan(tracks, makeMaster());
+        requireWellFormed(plan);
+
+        CHECK(countRole(plan, OpRole::RackDelta) == 0);
+        REQUIRE(plan.diagnostics.size() == 1);
+        CHECK(plan.diagnostics.front().find("delta solo on a bypassed rack measures nothing") !=
+              std::string::npos);
+    }
+
+    SECTION("an analysis device has no difference to take, and says so") {
+        // The delta button is DeviceType::Effect alone, so this flag cannot be
+        // set from the UI at all. It can be stored, because the field is
+        // serialised on every device, and a plan that quietly handed back the
+        // chain would leave the project saying one thing and the engine doing
+        // another with nothing in between to notice.
+        auto analysis = makeEffect(7);
+        analysis.deviceType = DeviceType::Analysis;
+        analysis.deltaSolo = true;
+
+        std::vector<TrackInfo> tracks{makeTrack(1)};
+        tracks[0].chain.fxChainElements.push_back(makeDeviceElement(analysis));
+
+        const auto plan = magda::engine::compileRenderPlan(tracks, makeMaster());
+        requireWellFormed(plan);
+
+        CHECK(countRole(plan, OpRole::DeviceDelta) == 0);
+        REQUIRE(plan.diagnostics.size() == 1);
+        CHECK(plan.diagnostics.front().find(
+                  "delta solo on an analysis device has nothing to subtract") != std::string::npos);
+    }
+
+    SECTION("an analysis device without the flag is not reported at all") {
+        auto analysis = makeEffect(7);
+        analysis.deviceType = DeviceType::Analysis;
+
+        std::vector<TrackInfo> tracks{makeTrack(1)};
+        tracks[0].chain.fxChainElements.push_back(makeDeviceElement(analysis));
+
+        const auto plan = magda::engine::compileRenderPlan(tracks, makeMaster());
+        requireWellFormed(plan);
+        CHECK(plan.diagnostics.empty());
     }
 }
 


### PR DESCRIPTION
Follow-up to the review on #2161. Both comments name a defect that is not reachable, and both
are circling one that is.

## What the code already does

**The delta button is `DeviceType::Effect` alone.** `DeviceSlotHeaderSpec.cpp` sets
`visibility.delta = device.deviceType == magda::DeviceType::Effect`, and that one flag drives
both `getExpandedVisibility` and `getCollapsedVisibility`. `setDeviceDeltaSoloByPath` has exactly
one caller in the tree — that button's `onClick` — with no API, DSL or OSC route to it. So delta
solo cannot be turned on for an analysis device, and the `!isTransparentTap(device)` gate lines
up with the UI rather than diverging from it. Both read the same field, so they cannot disagree.

**Bypass and delta solo are one switch with three positions.** Every setter clears each when the
other is set, in both directions and at both scopes: `setDeviceInChainBypassedByPath`,
`setDeviceDeltaSoloByPath`, `setDeviceBypassed`, `setDeviceBypassedByPath`, `setRackBypassed`,
`setRackBypassedByPath`, `setRackDeltaSoloByPath`. The UI enforces it a second time in both
button handlers. A bypassed device with delta solo enabled is not a state the model can be put
into, so the implementation and #2136 are not in conflict about anything reachable and the issue
text stands.

## What is real

`deltaSolo` and `bypassed` are serialised independently and read straight back into the struct
(`TrackSerializer.cpp:444/594` for devices, `771/821` for racks), so a stored project can hold
either combination whatever the setters allow. The compiler ignored both in silence, which is
the one thing it is not allowed to do — a model configuration it cannot express belongs in
`diagnostics`. The delta button would be lit over a device passing its input through, and
nothing anywhere would say why.

The compiler test that codified this built exactly that state by hand and asserted
`diagnostics.empty()`, which was the wrong assertion to make.

## The change

All three cases are reported and none of them changes the plan:

- a bypassed device — `delta solo on a bypassed device measures nothing, the chain passes through unchanged`
- a bypassed rack — the same, one level up
- a transparent tap — `delta solo on an analysis device has nothing to subtract, the chain passes through unchanged`

Emitting the subtract for analysis devices instead — the other option offered — would put a
`Subtract` and its dry delay on every analysis device in every plan, permanently, to compute a
difference no UI can ask for; the mixer-analysis rail means most tracks carry one. Making them
ineligible "throughout the model" is already true in the UI, and doing it in the model would mean
removing a serialised field, which costs a migration for the same outcome the diagnostic gives.

## The generator was building it too

`BypassDevice` and `DeltaSoloDevice` wrote their fields independently while `TrackManager` does
not, so random sequences produced the unreachable pair. It mirrors the setters now, which is what
"every edit here is one a user can perform" already claimed. Reverting that leaves four sequences
reporting the new diagnostic — that is how it was found.

## Testing

Each diagnostic verified negatively: reverting `PlanCompiler.cpp` alone fails all three new
assertions. Full suite green — 2889 cases, ~600k assertions, deep property sweep included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
