### PR TITLE
Say what a track is, once, where the type is declared

### DIFF
--- a/docs/specs/track-model-architecture.md
+++ b/docs/specs/track-model-architecture.md
@@ -35,14 +35,24 @@ The track model is the single source of truth. Views are lenses that present and
 
 ```cpp
 enum class TrackType {
-    Audio,      // Audio clips, recording
-    Instrument, // MIDI → plugin → audio
-    MIDI,       // MIDI only, routes to other tracks
-    Group,      // Contains child tracks, routing hub
-    Aux,        // Receives from sends
-    Master      // Final output
+    Media = 0,     // Clips of any kind, instruments, effects, input
+    Group = 3,     // Contains child tracks, routing hub
+    Aux = 4,       // Receives from sends
+    Master = 5,    // Final output
+    MultiOut = 6,  // Output track for a multi-out instrument pair
+    Chord = 7      // Singleton chord-progression track, monitor-only
 };
 ```
+
+This began as `Audio`, `Instrument` and `MIDI` as three separate types. They
+collapsed into one hybrid track, which kept the name `Audio` and so read as a
+statement about content for years after it had stopped being one; it is `Media`
+now. The ordinals that Instrument and MIDI used are skipped rather than reused,
+because the numbers are written into every `.mgd` and are pinned
+(`tests/test_persisted_enum_pins.cpp`).
+
+What each type can do is declared once in `TrackTypeTraits`, not re-derived per
+call site. See `magda/daw/core/TrackTypes.hpp`.
 
 ### 1.2 Track Hierarchy
 

--- a/examples/lua_smoke.cpp
+++ b/examples/lua_smoke.cpp
@@ -41,12 +41,12 @@ int main(int argc, char** argv) {
         magda::TrackInfo a;
         a.id = 1;
         a.name = "Drums";
-        a.type = magda::TrackType::Audio;
+        a.type = magda::TrackType::Media;
         a.volume = 0.8f;
         magda::TrackInfo b;
         b.id = 2;
         b.name = "Bass";
-        b.type = magda::TrackType::Audio;
+        b.type = magda::TrackType::Media;
         b.volume = 0.6f;
         mock.tracks_.tracks.push_back(a);
         mock.tracks_.tracks.push_back(b);

--- a/magda/agents/dsl_interpreter.cpp
+++ b/magda/agents/dsl_interpreter.cpp
@@ -1822,14 +1822,14 @@ bool Interpreter::executeSelectClips(Tokenizer& tok) {
 
 TrackType Interpreter::parseTrackType(const Params& params) {
     if (!params.has("type"))
-        return TrackType::Audio;
+        return TrackType::Media;
 
     std::string typeStr = params.get("type");
     if (typeStr == "group")
         return TrackType::Group;
     if (typeStr == "aux")
         return TrackType::Aux;
-    return TrackType::Audio;
+    return TrackType::Media;
 }
 
 int Interpreter::findTrackByName(const juce::String& name) const {

--- a/magda/agents/instruction_executor.cpp
+++ b/magda/agents/instruction_executor.cpp
@@ -414,7 +414,7 @@ bool InstructionExecutor::executeTrack(const TrackOp& op) {
         }
 
         auto createCmd = std::make_unique<CreateTrackCommand>(
-            TrackType::Audio, op.name.isEmpty() ? trackName : op.name);
+            TrackType::Media, op.name.isEmpty() ? trackName : op.name);
         auto* createPtr = createCmd.get();
         api_.undo().executeCommand(std::move(createCmd));
         currentTrackId_ = createPtr->getCreatedTrackId();
@@ -429,7 +429,7 @@ bool InstructionExecutor::executeTrack(const TrackOp& op) {
         return true;
     }
 
-    auto createCmd = std::make_unique<CreateTrackCommand>(TrackType::Audio, op.name);
+    auto createCmd = std::make_unique<CreateTrackCommand>(TrackType::Media, op.name);
     auto* createPtr = createCmd.get();
     api_.undo().executeCommand(std::move(createCmd));
     currentTrackId_ = createPtr->getCreatedTrackId();

--- a/magda/daw/api/remote_api_projection.cpp
+++ b/magda/daw/api/remote_api_projection.cpp
@@ -33,7 +33,7 @@ void assertMessageThread() {
 
 juce::String trackTypeName(TrackType type) {
     switch (type) {
-        case TrackType::Audio:
+        case TrackType::Media:
             return "audio";
         case TrackType::Group:
             return "group";

--- a/magda/daw/api/remote_handlers.cpp
+++ b/magda/daw/api/remote_handlers.cpp
@@ -118,7 +118,7 @@ HandlerResult notFound(const juce::String& what, int id) {
 
 std::optional<TrackType> parseTrackType(const juce::String& type) {
     if (type == "audio")
-        return TrackType::Audio;
+        return TrackType::Media;
     if (type == "group")
         return TrackType::Group;
     if (type == "aux")

--- a/magda/daw/audio/ClipCommands.cpp
+++ b/magda/daw/audio/ClipCommands.cpp
@@ -2362,7 +2362,7 @@ void BounceToNewTrackCommand::execute() {
     auto& trackManager = TrackManager::getInstance();
     juce::String trackName =
         sourceClipName.isNotEmpty() ? sourceClipName + " (bounced)" : "Bounced";
-    newTrackId_ = trackManager.createTrack(trackName, TrackType::Audio);
+    newTrackId_ = trackManager.createTrack(trackName, TrackType::Media);
 
     // Move new track to position after source track
     int sourceIndex = trackManager.getTrackIndex(sourceTrackId);
@@ -2923,7 +2923,7 @@ void buildDrumGridFromSlices(const std::vector<SliceRegion>& slices, const ClipI
     auto& trackManager = TrackManager::getInstance();
     juce::String clipName =
         clip.name.isNotEmpty() ? clip.name : audioFile.getFileNameWithoutExtension();
-    TrackId newTrackId = trackManager.createTrack("Drum Grid - " + clipName, TrackType::Audio);
+    TrackId newTrackId = trackManager.createTrack("Drum Grid - " + clipName, TrackType::Media);
     if (newTrackId == INVALID_TRACK_ID)
         return;
 

--- a/magda/daw/audio/ClipCommands.cpp
+++ b/magda/daw/audio/ClipCommands.cpp
@@ -17,6 +17,7 @@
 #include "audio/racks/InstrumentRackManager.hpp"
 #include "core/ClipOcclusion.hpp"
 #include "core/ClipOperations.hpp"
+#include "core/ClipPlacementPolicy.hpp"
 #include "core/Config.hpp"
 #include "core/ControlTarget.hpp"
 #include "core/TrackManager.hpp"
@@ -520,7 +521,16 @@ MoveClipToTrackCommand::MoveClipToTrackCommand(ClipId clipId, TrackId newTrackId
 
 bool MoveClipToTrackCommand::canExecute() const {
     auto* clip = ClipManager::getInstance().getClip(clipId_);
-    return clip && newTrackId_ != INVALID_TRACK_ID;
+    if (clip == nullptr || newTrackId_ == INVALID_TRACK_ID)
+        return false;
+
+    // Where a clip may go is decided here rather than only at the gestures that
+    // move one. A drag and a nudge can each decline to offer a bad target, and
+    // both did so separately, which is how they came to disagree; the command
+    // is the one place the API, the scripting layer and the next caller all go
+    // through.
+    const auto* track = TrackManager::getInstance().getTrack(newTrackId_);
+    return track != nullptr && trackAcceptsClip(*track, *clip);
 }
 
 void MoveClipToTrackCommand::execute() {

--- a/magda/daw/cli/magda_cli_main.cpp
+++ b/magda/daw/cli/magda_cli_main.cpp
@@ -106,7 +106,7 @@ std::optional<int> parsePositiveInt(const juce::String& text) {
 std::optional<magda::TrackType> parseTrackType(const juce::String& text) {
     auto normalized = text.trim().toLowerCase();
     if (normalized == "audio" || normalized == "midi")
-        return magda::TrackType::Audio;
+        return magda::TrackType::Media;
     if (normalized == "group")
         return magda::TrackType::Group;
     if (normalized == "aux")

--- a/magda/daw/core/ClipPlacementPolicy.hpp
+++ b/magda/daw/core/ClipPlacementPolicy.hpp
@@ -1,0 +1,55 @@
+#pragma once
+
+#include "ClipInfo.hpp"
+#include "TrackInfo.hpp"
+
+/**
+ * @file ClipPlacementPolicy.hpp
+ * @brief Whether a clip may be placed on a track, asked with the clip in hand.
+ *
+ * TrackTypeTraits says what a lane accepts by kind, which is as much as a file
+ * drop knows before it has read anything. Moving an existing clip knows more,
+ * and for one lane the difference decides the answer: the chord track holds
+ * progressions, and whether a MIDI clip is one is a fact about that clip rather
+ * than about MIDI.
+ *
+ * Kept here rather than on TrackInfo so that core's track header does not have
+ * to know what a clip is.
+ */
+
+namespace magda {
+
+/**
+ * @brief Whether @p clip may be placed on @p track.
+ *
+ * Every path that moves a clip asks this: the drag, the keyboard nudge, and
+ * MoveClipToTrackCommand itself, which is what makes it hold for the paths
+ * nobody has written yet. The command is the one that must, because a UI that
+ * only declines to offer a bad target still leaves the command reachable from
+ * the API, the scripting layer and whatever comes next.
+ */
+inline bool trackAcceptsClip(const TrackInfo& track, const ClipInfo& clip) {
+    switch (traitsOf(track.type).userClips) {
+        case UserClipAcceptance::None:
+            return false;
+
+        case UserClipAcceptance::Any:
+            return true;
+
+        case UserClipAcceptance::MidiOnly:
+            return clip.isMidi();
+
+        case UserClipAcceptance::Progressions:
+            // Moving is not importing. An import reads a file and can work the
+            // harmony out on the way in, which is what dropping a .mid on the
+            // chord track does. A move can only take the clip as it already is,
+            // so what it takes is a clip that is already a progression --
+            // silently rewriting the contents of a clip somebody dragged would
+            // be a conversion wearing a move's undo step.
+            return clip.isMidi() && !clip.chordAnnotations.empty();
+    }
+
+    return false;
+}
+
+}  // namespace magda

--- a/magda/daw/core/TrackCommands.cpp
+++ b/magda/daw/core/TrackCommands.cpp
@@ -140,7 +140,7 @@ void CreateTrackCommand::undo() {
 
 juce::String CreateTrackCommand::getDescription() const {
     switch (type_) {
-        case TrackType::Audio:
+        case TrackType::Media:
             return "Create Track";
         case TrackType::Group:
             return "Create Group Track";

--- a/magda/daw/core/TrackCommands.hpp
+++ b/magda/daw/core/TrackCommands.hpp
@@ -11,7 +11,7 @@ namespace magda {
  */
 class CreateTrackCommand : public UndoableCommand {
   public:
-    explicit CreateTrackCommand(TrackType type = TrackType::Audio,
+    explicit CreateTrackCommand(TrackType type = TrackType::Media,
                                 const juce::String& name = juce::String(),
                                 TrackId afterTrackId = INVALID_TRACK_ID);
 

--- a/magda/daw/core/TrackInfo.hpp
+++ b/magda/daw/core/TrackInfo.hpp
@@ -41,7 +41,7 @@ enum class TrackPlaybackMode { Arrangement, Session };
  */
 struct TrackInfo {
     TrackId id = INVALID_TRACK_ID;      // Unique identifier
-    TrackType type = TrackType::Audio;  // Track type
+    TrackType type = TrackType::Media;  // Track type
     juce::String name;                  // Track name
     juce::Colour colour;                // Track color
 
@@ -224,20 +224,22 @@ struct TrackInfo {
         return parentId == INVALID_TRACK_ID;
     }
 
-    // True for tracks that take external audio/MIDI input and can be recorded /
-    // monitored. Aux send buses and Group summing tracks only pass signal from
-    // elsewhere, so they never take external input. Single source of truth for
-    // the input/record/monitor guards across TrackManager and MidiInputRouter.
+    // Both of these used to be their own list of types to exclude, and the two
+    // lists differed by one member. They now read the same table every other
+    // question reads (TrackTypes.hpp), which is what stops them drifting.
     bool takesExternalInput() const {
-        return type != TrackType::Aux && type != TrackType::Group;
+        return traitsOf(type).takesExternalInput;
     }
 
-    // True for tracks that can host an instrument device. Aux/Group summing
-    // buses and the Master track only process signal from elsewhere, so they
-    // never host instruments. Single source of truth for the instrument-add
-    // guards across TrackManager (track and rack-chain add paths).
     bool canHostInstrument() const {
-        return type != TrackType::Aux && type != TrackType::Group && type != TrackType::Master;
+        return traitsOf(type).hostsInstrument;
+    }
+
+    // Whether a user may put an arbitrary clip on this track: drop a file on
+    // it, drag one in, nudge one over. See TrackTypeTraits::acceptsUserClips
+    // for why this is narrower than "has a timeline".
+    bool acceptsUserClips() const {
+        return traitsOf(type).acceptsUserClips;
     }
 
     // Enforce the track-type invariants on this struct's own fields. Input-less

--- a/magda/daw/core/TrackInfo.hpp
+++ b/magda/daw/core/TrackInfo.hpp
@@ -235,11 +235,31 @@ struct TrackInfo {
         return traitsOf(type).hostsInstrument;
     }
 
-    // Whether a user may put an arbitrary clip on this track: drop a file on
-    // it, drag one in, nudge one over. See TrackTypeTraits::acceptsUserClips
-    // for why this is narrower than "has a timeline".
-    bool acceptsUserClips() const {
-        return traitsOf(type).acceptsUserClips;
+    // Whether a user may put a clip of this kind on the track: drop a file on
+    // it, drag one in, nudge one over. See UserClipAcceptance for why this
+    // takes the kind rather than answering yes or no for the whole track.
+    //
+    // A Progressions lane answers yes to MIDI, because a progression is a MIDI
+    // clip. Whether the material really is a progression is a question about
+    // content, so it is asked where the content is readable -- at the drop,
+    // which has the file.
+    bool acceptsUserClip(ClipType clipType) const {
+        switch (traitsOf(type).userClips) {
+            case UserClipAcceptance::None:
+                return false;
+            case UserClipAcceptance::Any:
+                return true;
+            case UserClipAcceptance::MidiOnly:
+            case UserClipAcceptance::Progressions:
+                return clipType == ClipType::MIDI;
+        }
+        return false;
+    }
+
+    // Whether anything at all may be placed here, for the callers that have no
+    // clip in hand yet.
+    bool acceptsAnyUserClip() const {
+        return traitsOf(type).userClips != UserClipAcceptance::None;
     }
 
     // Enforce the track-type invariants on this struct's own fields. Input-less

--- a/magda/daw/core/TrackManager.cpp
+++ b/magda/daw/core/TrackManager.cpp
@@ -322,7 +322,7 @@ TrackId TrackManager::createTrackWithPlugin(const juce::DynamicObject& pluginObj
     DeviceInfo device = deviceInfoFromPluginObject(pluginObj);
 
     // Determine track type
-    TrackType trackType = TrackType::Audio;
+    TrackType trackType = TrackType::Media;
 
     // Create the track named after the plugin
     juce::String pluginName = pluginObj.getProperty("name").toString();

--- a/magda/daw/core/TrackManager.hpp
+++ b/magda/daw/core/TrackManager.hpp
@@ -200,7 +200,7 @@ class TrackManager : public daw::audio::DeviceIdAllocator, public daw::audio::De
     static TrackId createTrackWithPlugin(const juce::DynamicObject& pluginObj);
 
     // Track operations
-    TrackId createTrack(const juce::String& name = "", TrackType type = TrackType::Audio);
+    TrackId createTrack(const juce::String& name = "", TrackType type = TrackType::Media);
     TrackId createGroupTrack(const juce::String& name = "");
 
     // Chord track is a strict singleton (TrackType::Chord). It lives in the
@@ -243,7 +243,7 @@ class TrackManager : public daw::audio::DeviceIdAllocator, public daw::audio::De
     // 1-based position of a track among its siblings (0 if not found).
     int getTrackSiblingPosition(TrackId trackId) const;
     TrackId createTrackInGroup(TrackId groupId, const juce::String& name = "",
-                               TrackType type = TrackType::Audio);
+                               TrackType type = TrackType::Media);
     std::vector<TrackId> getChildTracks(TrackId groupId) const;
     std::vector<TrackId> getTopLevelTracks() const;
     std::vector<TrackId> getAllDescendants(TrackId trackId) const;

--- a/magda/daw/core/TrackManagerDevices.cpp
+++ b/magda/daw/core/TrackManagerDevices.cpp
@@ -707,9 +707,7 @@ bool TrackManager::moveChainElement(const ChainNodePath& sourceElementPath,
     }
 
     if (auto* destinationTrack = getTrack(destinationChainPath.trackId)) {
-        const bool destinationCannotHostInstruments = destinationTrack->type == TrackType::Aux ||
-                                                      destinationTrack->type == TrackType::Group ||
-                                                      destinationTrack->type == TrackType::Master;
+        const bool destinationCannotHostInstruments = !destinationTrack->canHostInstrument();
         if (destinationCannotHostInstruments && elementContainsInstrument(*sourceIt)) {
             return false;
         }

--- a/magda/daw/core/TrackTypes.hpp
+++ b/magda/daw/core/TrackTypes.hpp
@@ -33,6 +33,37 @@ enum class TrackType {
 };
 
 /**
+ * @brief What a user may put on a track's lane.
+ *
+ * Having a lane is not the same as taking anything that is aimed at it, and
+ * the difference is per type rather than per gesture: a drop, a drag and a
+ * nudge all ask this one question.
+ */
+enum class UserClipAcceptance {
+    /// No lane, or a lane the user does not place clips on.
+    None,
+
+    /// Audio or MIDI, whichever the material is. The Media track.
+    Any,
+
+    /// MIDI only. A multi-out lane belongs to a device's output pair and the
+    /// MIDI on it plays the parent instrument, the same way MidiInputRouter
+    /// already routes live input through such a track to its parent. Audio has
+    /// nothing to do there.
+    ///
+    /// Worth knowing rather than worth forbidding: deactivating the output pair
+    /// erases the track without taking its clips along, so what is placed here
+    /// does not outlive that pair.
+    MidiOnly,
+
+    /// Chord progressions only -- a .mid carrying CHORD: markers. The lane is
+    /// typed rather than closed: dropping a progression on the chord track is
+    /// the obvious gesture and it works, while an ordinary MIDI clip landing
+    /// there would change what the track means.
+    Progressions,
+};
+
+/**
  * @brief The facts a track type declares about itself.
  *
  * Every question the app asks of a track type is a field here, so that asking
@@ -42,42 +73,40 @@ enum class TrackType {
  */
 struct TrackTypeTraits {
     /// Owns a lane in the arrangement that clips live on.
-    bool hasTimeline;
+    bool hasTimeline = false;
 
-    /// A user may put an arbitrary clip on that lane -- drop a file, drag one
-    /// in, nudge one over. Narrower than hasTimeline on purpose. A Chord track
-    /// has clips and they are progressions, so an ordinary MIDI clip landing
-    /// there would change what the track means; a MultiOut lane is erased with
-    /// its output pair without taking its clips along, so anything put there is
-    /// orphaned the moment the user switches that output off.
-    bool acceptsUserClips;
+    /// What a user may place on that lane -- drop a file, drag a clip in, nudge
+    /// one over. Narrower than hasTimeline on purpose, and not a bool, because
+    /// three lanes accept three different things and a bool could only say
+    /// which of them were "not Media".
+    UserClipAcceptance userClips = UserClipAcceptance::None;
 
     /// Takes external audio/MIDI input, so it can be monitored and record-armed.
     /// Buses only pass on what reaches them from elsewhere.
-    bool takesExternalInput;
+    bool takesExternalInput = false;
 
     /// Can host an instrument device. Buses and the master process signal from
     /// elsewhere and never originate it.
-    bool hostsInstrument;
+    bool hostsInstrument = false;
 
     /// Occupies a row in the scrolling arrangement columns. Aux returns do not:
     /// they have their own fixed strip below the arrangement, so a row here as
     /// well would render the same track twice, and the header and content
     /// columns would drift apart by that track's height as you scroll.
-    bool occupiesArrangementRow;
+    bool occupiesArrangementRow = false;
 
     /// Can contain child tracks.
-    bool canHaveChildren;
+    bool canHaveChildren = false;
 
     /// Contributes to the rendered mix. The chord track is monitor-only.
-    bool isRendered;
+    bool isRendered = false;
 
     /// At most one exists in a project, created on demand rather than by the
     /// user adding a track.
-    bool isSingleton;
+    bool isSingleton = false;
 
     /// Exists because a device's output pair does, and is destroyed with it.
-    bool isDeviceOwned;
+    bool isDeviceOwned = false;
 };
 
 /**
@@ -90,36 +119,98 @@ struct TrackTypeTraits {
  */
 constexpr TrackTypeTraits traitsOf(TrackType type) {
     switch (type) {
+        // The regular track. The only one a user puts an arbitrary clip on.
         case TrackType::Media:
-            return {/* hasTimeline */ true,
-                    /* acceptsUserClips */ true,
-                    /* takesExternalInput */ true,
-                    /* hostsInstrument */ true,
-                    /* occupiesArrangementRow */ true,
-                    /* canHaveChildren */ false,
-                    /* isRendered */ true,
-                    /* isSingleton */ false,
-                    /* isDeviceOwned */ false};
+            return {
+                .hasTimeline = true,
+                .userClips = UserClipAcceptance::Any,
+                .takesExternalInput = true,
+                .hostsInstrument = true,
+                .occupiesArrangementRow = true,
+                .canHaveChildren = false,
+                .isRendered = true,
+                .isSingleton = false,
+                .isDeviceOwned = false,
+            };
 
+        // Sums the children it owns. A bus: nothing originates here.
         case TrackType::Group:
-            return {false, false, false, false, true, true, true, false, false};
+            return {
+                .hasTimeline = false,
+                .userClips = UserClipAcceptance::None,
+                .takesExternalInput = false,
+                .hostsInstrument = false,
+                .occupiesArrangementRow = true,
+                .canHaveChildren = true,
+                .isRendered = true,
+                .isSingleton = false,
+                .isDeviceOwned = false,
+            };
 
+        // Fed by sends. No arrangement row of its own -- aux returns live in
+        // the fixed strip below, and a row here as well would draw them twice.
         case TrackType::Aux:
-            return {false, false, false, false, false, false, true, false, false};
+            return {
+                .hasTimeline = false,
+                .userClips = UserClipAcceptance::None,
+                .takesExternalInput = false,
+                .hostsInstrument = false,
+                .occupiesArrangementRow = false,
+                .canHaveChildren = false,
+                .isRendered = true,
+                .isSingleton = false,
+                .isDeviceOwned = false,
+            };
 
+        // The one output. Takes input like a media track and originates none.
         case TrackType::Master:
-            return {false, false, true, false, true, false, true, true, false};
+            return {
+                .hasTimeline = false,
+                .userClips = UserClipAcceptance::None,
+                .takesExternalInput = true,
+                .hostsInstrument = false,
+                .occupiesArrangementRow = true,
+                .canHaveChildren = false,
+                .isRendered = true,
+                .isSingleton = true,
+                .isDeviceOwned = false,
+            };
 
+        // A device's output pair, wearing a lane. MIDI on it plays the parent
+        // instrument, which is what MidiInputRouter already does with live
+        // input arriving here. Audio has nothing to do on such a lane.
         case TrackType::MultiOut:
-            return {true, false, true, true, true, false, true, false, true};
+            return {
+                .hasTimeline = true,
+                .userClips = UserClipAcceptance::MidiOnly,
+                .takesExternalInput = true,
+                .hostsInstrument = true,
+                .occupiesArrangementRow = true,
+                .canHaveChildren = false,
+                .isRendered = true,
+                .isSingleton = false,
+                .isDeviceOwned = true,
+            };
 
+        // Auditions chords and stays out of the mix. Its lane is typed rather
+        // than closed: progressions belong on it, ordinary clips do not.
         case TrackType::Chord:
-            return {true, false, true, true, true, false, false, true, false};
+            return {
+                .hasTimeline = true,
+                .userClips = UserClipAcceptance::Progressions,
+                .takesExternalInput = true,
+                .hostsInstrument = true,
+                .occupiesArrangementRow = true,
+                .canHaveChildren = false,
+                .isRendered = false,
+                .isSingleton = true,
+                .isDeviceOwned = false,
+            };
     }
 
     // Unreachable for any declared type; a value cast in from outside the enum
     // gets the most restrictive answer rather than the most permissive one.
-    return {false, false, false, false, false, false, false, false, false};
+    return {};
 }
 
 /**

--- a/magda/daw/core/TrackTypes.hpp
+++ b/magda/daw/core/TrackTypes.hpp
@@ -3,14 +3,28 @@
 namespace magda {
 
 /**
- * @brief Track types
+ * @brief What a track is.
  *
- * All regular tracks are Audio (hybrid — can hold audio clips, MIDI clips,
- * instruments, and effects). The remaining types have genuine behavioral
- * differences (routing, hierarchy, output).
+ * One axis, and it is the structural one: where a track's signal comes from and
+ * who owns the track. It is deliberately NOT a statement about what kind of
+ * material a track carries, because that distinction no longer exists -- a
+ * Media track holds audio clips and MIDI clips alike, hosts instruments and
+ * effects, and takes either kind of input.
+ *
+ * That is why the ordinals skip 1 and 2: they were Instrument and MIDI, and
+ * when those collapsed into one hybrid track the survivor kept the name
+ * `Audio`, which then read as a kind for years after it had stopped being one.
+ * Renaming it to Media is the point of this enum's current shape -- the numbers
+ * are unchanged and pinned, so nothing on disk moves.
+ *
+ * What each type can do is declared once, in TrackTypeTraits below, rather than
+ * re-derived at each call site. Sixteen call sites used to answer questions
+ * like "may a clip go here" with their own list of types to exclude, no two
+ * lists agreeing, and #2172 is what that produced: a file drop and a clip drag
+ * held different views of the same track.
  */
 enum class TrackType {
-    Audio = 0,     // Regular hybrid track
+    Media = 0,     // The regular track: clips of any kind, instruments, effects, input
     Group = 3,     // Contains child tracks, routing hub
     Aux = 4,       // Receives from sends
     Master = 5,    // Final output
@@ -19,12 +33,102 @@ enum class TrackType {
 };
 
 /**
+ * @brief The facts a track type declares about itself.
+ *
+ * Every question the app asks of a track type is a field here, so that asking
+ * it is a lookup rather than an exclusion list. Adding a track type is a new
+ * row in traitsOf() below, and the switch there has no default: a type that
+ * forgets to declare itself does not compile.
+ */
+struct TrackTypeTraits {
+    /// Owns a lane in the arrangement that clips live on.
+    bool hasTimeline;
+
+    /// A user may put an arbitrary clip on that lane -- drop a file, drag one
+    /// in, nudge one over. Narrower than hasTimeline on purpose. A Chord track
+    /// has clips and they are progressions, so an ordinary MIDI clip landing
+    /// there would change what the track means; a MultiOut lane is erased with
+    /// its output pair without taking its clips along, so anything put there is
+    /// orphaned the moment the user switches that output off.
+    bool acceptsUserClips;
+
+    /// Takes external audio/MIDI input, so it can be monitored and record-armed.
+    /// Buses only pass on what reaches them from elsewhere.
+    bool takesExternalInput;
+
+    /// Can host an instrument device. Buses and the master process signal from
+    /// elsewhere and never originate it.
+    bool hostsInstrument;
+
+    /// Occupies a row in the scrolling arrangement columns. Aux returns do not:
+    /// they have their own fixed strip below the arrangement, so a row here as
+    /// well would render the same track twice, and the header and content
+    /// columns would drift apart by that track's height as you scroll.
+    bool occupiesArrangementRow;
+
+    /// Can contain child tracks.
+    bool canHaveChildren;
+
+    /// Contributes to the rendered mix. The chord track is monitor-only.
+    bool isRendered;
+
+    /// At most one exists in a project, created on demand rather than by the
+    /// user adding a track.
+    bool isSingleton;
+
+    /// Exists because a device's output pair does, and is destroyed with it.
+    bool isDeviceOwned;
+};
+
+/**
+ * @brief The traits of @p type.
+ *
+ * The switch is exhaustive and has no default, so -Wswitch fails the build on a
+ * type that was added without declaring what it is. That is the whole
+ * mechanism: the compiler asks the questions this enum used to leave to
+ * whoever wrote the next call site.
+ */
+constexpr TrackTypeTraits traitsOf(TrackType type) {
+    switch (type) {
+        case TrackType::Media:
+            return {/* hasTimeline */ true,
+                    /* acceptsUserClips */ true,
+                    /* takesExternalInput */ true,
+                    /* hostsInstrument */ true,
+                    /* occupiesArrangementRow */ true,
+                    /* canHaveChildren */ false,
+                    /* isRendered */ true,
+                    /* isSingleton */ false,
+                    /* isDeviceOwned */ false};
+
+        case TrackType::Group:
+            return {false, false, false, false, true, true, true, false, false};
+
+        case TrackType::Aux:
+            return {false, false, false, false, false, false, true, false, false};
+
+        case TrackType::Master:
+            return {false, false, true, false, true, false, true, true, false};
+
+        case TrackType::MultiOut:
+            return {true, false, true, true, true, false, true, false, true};
+
+        case TrackType::Chord:
+            return {true, false, true, true, true, false, false, true, false};
+    }
+
+    // Unreachable for any declared type; a value cast in from outside the enum
+    // gets the most restrictive answer rather than the most permissive one.
+    return {false, false, false, false, false, false, false, false, false};
+}
+
+/**
  * @brief Get display name for track type
  */
 inline const char* getTrackTypeName(TrackType type) {
     switch (type) {
-        case TrackType::Audio:
-            return "Audio";
+        case TrackType::Media:
+            return "Media";
         case TrackType::Group:
             return "Group";
         case TrackType::Aux:
@@ -42,14 +146,15 @@ inline const char* getTrackTypeName(TrackType type) {
 /**
  * @brief Deserialize a track type from an integer, mapping legacy values.
  *
- * Old projects stored Instrument=1 and MIDI=2; both map to Audio now.
+ * Old projects stored Instrument=1 and MIDI=2; both map to Media now, which is
+ * the track they had already become before it was named that.
  */
 inline TrackType trackTypeFromInt(int v) {
     switch (v) {
         case 0:
         case 1:
         case 2:
-            return TrackType::Audio;
+            return TrackType::Media;
         case 3:
             return TrackType::Group;
         case 4:
@@ -61,7 +166,7 @@ inline TrackType trackTypeFromInt(int v) {
         case 7:
             return TrackType::Chord;
         default:
-            return TrackType::Audio;
+            return TrackType::Media;
     }
 }
 
@@ -69,7 +174,7 @@ inline TrackType trackTypeFromInt(int v) {
  * @brief Check if track type can have children
  */
 inline bool canHaveChildren(TrackType type) {
-    return type == TrackType::Group;
+    return traitsOf(type).canHaveChildren;
 }
 
 }  // namespace magda

--- a/magda/daw/project/serialization/DawProjectXmlAdapter.cpp
+++ b/magda/daw/project/serialization/DawProjectXmlAdapter.cpp
@@ -1165,7 +1165,7 @@ bool DawProjectXmlAdapter::fromProjectXml(const juce::String& xml, ProjectDocume
                     trackElement->getStringAttribute("name", "Track " + juce::String(track.id));
                 track.colour = colourFromDawProject(trackElement->getStringAttribute("color"));
                 const auto contentType = trackElement->getStringAttribute("contentType");
-                track.type = contentType.contains("tracks") ? TrackType::Group : TrackType::Audio;
+                track.type = contentType.contains("tracks") ? TrackType::Group : TrackType::Media;
                 track.parentId = parentId;
                 const size_t trackIndex = document.tracks.size();
 

--- a/magda/daw/stem_separation/StemSeparationService.cpp
+++ b/magda/daw/stem_separation/StemSeparationService.cpp
@@ -248,7 +248,7 @@ void StemSeparationService::splitClipIntoStems(ClipId sourceClipId, Engine engin
         TrackId after = sourceTrackId;
         for (const auto& stemName : stemNamesFor(engine)) {
             auto trackCmd =
-                std::make_unique<magda::CreateTrackCommand>(TrackType::Audio, stemName, after);
+                std::make_unique<magda::CreateTrackCommand>(TrackType::Media, stemName, after);
             auto* trackPtr = trackCmd.get();
             undo.executeCommand(std::move(trackCmd));
             const TrackId trackId = trackPtr->getCreatedTrackId();

--- a/magda/daw/transcription/TranscriptionService.cpp
+++ b/magda/daw/transcription/TranscriptionService.cpp
@@ -252,7 +252,7 @@ void TranscriptionService::transcribeAudioClip(ClipId sourceClipId, Completion o
 
             auto trackCmd = std::make_unique<magda::CreateTrackWithDeviceCommand>(
                 sourceName.isNotEmpty() ? sourceName : juce::String("Transcription"),
-                TrackType::Audio, makeFourOscDevice());
+                TrackType::Media, makeFourOscDevice());
             auto* trackPtr = trackCmd.get();
             magda::UndoManager::getInstance().executeCommand(std::move(trackCmd));
             const TrackId newTrackId = trackPtr->getCreatedTrackId();

--- a/magda/daw/ui/components/clips/ClipComponent.cpp
+++ b/magda/daw/ui/components/clips/ClipComponent.cpp
@@ -3318,7 +3318,7 @@ void ClipComponent::showContextMenu() {
     std::vector<TrackId> progressionTargets;
     if (isChord && !isMultiSelection) {
         for (const auto& t : TrackManager::getInstance().getTracks())
-            if (t.type == TrackType::Audio)
+            if (t.type == TrackType::Media)
                 progressionTargets.push_back(t.id);
     }
 

--- a/magda/daw/ui/components/mixer/RoutingSyncHelper.hpp
+++ b/magda/daw/ui/components/mixer/RoutingSyncHelper.hpp
@@ -118,7 +118,7 @@ inline void populateAudioInputOptions(RoutingSelector* selector, juce::AudioIODe
                 continue;
             if (trackManager.wouldCreateInputRoutingCycle(currentTrackId, t.id))
                 continue;
-            if (t.type == TrackType::Audio || t.type == TrackType::Group ||
+            if (t.type == TrackType::Media || t.type == TrackType::Group ||
                 t.type == TrackType::Aux) {
                 trackOptions.push_back({id, t.name});
                 if (outInputTrackMapping)
@@ -204,7 +204,7 @@ inline void populateAudioOutputOptions(RoutingSelector* selector, TrackId curren
         }
 
         for (const auto& t : allTracks) {
-            if (t.type != TrackType::Audio || t.id == currentTrackId)
+            if (t.type != TrackType::Media || t.id == currentTrackId)
                 continue;
             // Hide source track from its own multi-out tracks
             if (t.id == multiOutSourceId)
@@ -278,7 +278,7 @@ inline void populateAudioOutputOptions(RoutingSelector* selector, TrackId curren
         }
         id = 400;
         for (const auto& t : allTracks) {
-            if (t.type == TrackType::Audio && t.id != currentTrackId) {
+            if (t.type == TrackType::Media && t.id != currentTrackId) {
                 if (std::find(descendants.begin(), descendants.end(), t.id) != descendants.end())
                     continue;
                 outTrackMapping[id++] = t.id;
@@ -324,7 +324,7 @@ inline void populateMidiInputOptions(RoutingSelector* selector, MidiBridge* midi
                 continue;
             // Chord tracks are valid MIDI sources: their progression clip
             // plays live and drives instrument tracks (issue #1507)
-            if (t.type != TrackType::Audio && t.type != TrackType::Chord)
+            if (t.type != TrackType::Media && t.type != TrackType::Chord)
                 continue;
             if (trackManager.wouldCreateInputRoutingCycle(currentTrackId, t.id))
                 continue;
@@ -374,7 +374,7 @@ inline void populateMidiOutputOptions(RoutingSelector* selector, MidiBridge* mid
         for (const auto& t : allTracks) {
             if (t.id == currentTrackId)
                 continue;
-            if (t.type != TrackType::Audio)
+            if (t.type != TrackType::Media)
                 continue;
             // The edge created is candidate ← current (candidate listens to
             // the current track), so the candidate is the destination here.

--- a/magda/daw/ui/components/tracks/TrackContentPanel.cpp
+++ b/magda/daw/ui/components/tracks/TrackContentPanel.cpp
@@ -3394,27 +3394,8 @@ void TrackContentPanel::importFilesAtPosition(const juce::StringArray& files, in
 
     TrackId targetTrackId = INVALID_TRACK_ID;
 
-    if (trackIndex >= 0 && trackIndex < static_cast<int>(visibleTrackIds_.size())) {
-        // Dropped on an existing track
-        targetTrackId = visibleTrackIds_[trackIndex];
-        auto* track = TrackManager::getInstance().getTrack(targetTrackId);
-        if (!track)
-            return;
-
-        // One question about the target, and none at all about the file. A
-        // Media track is hybrid, so what is dropped decides which clip gets
-        // made and never whether it is allowed. A Drum Grid on the chain used
-        // to refuse every dropped file here, which made the track likeliest to
-        // want a .mid the one that would not take one (#2172).
-        if (!track->acceptsUserClips()) {
-            juce::AlertWindow::showMessageBoxAsync(juce::AlertWindow::WarningIcon, "Drop Failed",
-                                                   "Clips cannot be placed on this track.");
-            return;
-        }
-    }
-    // If targetTrackId is still INVALID, we'll create a new track below
-
-    // Separate audio and MIDI files
+    // Which kind each file is, worked out before the target is vetted: what a
+    // track accepts is per kind, so the check below needs to know what it has.
     juce::StringArray audioFiles, midiFiles;
     for (const auto& filePath : files) {
         if (filePath.endsWithIgnoreCase(".mid") || filePath.endsWithIgnoreCase(".midi"))
@@ -3424,6 +3405,70 @@ void TrackContentPanel::importFilesAtPosition(const juce::StringArray& files, in
                  filePath.endsWithIgnoreCase(".ogg") || filePath.endsWithIgnoreCase(".flac"))
             audioFiles.add(filePath);
     }
+
+    if (trackIndex >= 0 && trackIndex < static_cast<int>(visibleTrackIds_.size())) {
+        // Dropped on an existing track
+        targetTrackId = visibleTrackIds_[trackIndex];
+        auto* track = TrackManager::getInstance().getTrack(targetTrackId);
+        if (!track)
+            return;
+
+        // What the target accepts, asked of the table every other path asks
+        // (TrackTypes.hpp). Nothing here is a question about the Drum Grid: a
+        // Media track is hybrid and takes both kinds, and a chain device used
+        // to refuse every dropped file here, which made the track likeliest to
+        // want a .mid the one that would not take one (#2172).
+        const auto refuse = [](const juce::String& why) {
+            juce::AlertWindow::showMessageBoxAsync(juce::AlertWindow::WarningIcon, "Drop Failed",
+                                                   why);
+        };
+
+        if (!audioFiles.isEmpty() && !track->acceptsUserClip(ClipType::Audio)) {
+            if (midiFiles.isEmpty()) {
+                refuse("Audio clips cannot be placed on this track.");
+                return;
+            }
+
+            // A mixed drop still imports what the track does take, and says
+            // what it left. Refusing all of it because one file was the wrong
+            // kind is the shape of the bug this replaces.
+            refuse("Audio clips cannot be placed on this track, so only the MIDI was imported.");
+            audioFiles.clear();
+        }
+
+        if (!midiFiles.isEmpty() && !track->acceptsUserClip(ClipType::MIDI)) {
+            if (audioFiles.isEmpty()) {
+                refuse("MIDI clips cannot be placed on this track.");
+                return;
+            }
+            refuse("MIDI clips cannot be placed on this track, so only the audio was imported.");
+            midiFiles.clear();
+        }
+
+        // A progressions lane says yes to MIDI above, because a progression is
+        // a MIDI clip. Whether this material is one is a question about content
+        // rather than about kind, and here is where the content can be read.
+        if (traitsOf(track->type).userClips == UserClipAcceptance::Progressions) {
+            juce::StringArray progressions;
+            for (const auto& path : midiFiles)
+                if (!magda::daw::readChordMarkers(juce::File(path)).empty())
+                    progressions.add(path);
+
+            if (progressions.size() != midiFiles.size()) {
+                if (progressions.isEmpty()) {
+                    refuse("Only chord progressions can be placed on the chord track.");
+                    return;
+                }
+                refuse("Only chord progressions can be placed on the chord track, so the rest "
+                       "was left out.");
+            }
+            midiFiles = progressions;
+        }
+
+        if (audioFiles.isEmpty() && midiFiles.isEmpty())
+            return;
+    }
+    // If targetTrackId is still INVALID, we'll create a new track below
 
     int importedCount = 0;
 

--- a/magda/daw/ui/components/tracks/TrackContentPanel.cpp
+++ b/magda/daw/ui/components/tracks/TrackContentPanel.cpp
@@ -3401,22 +3401,15 @@ void TrackContentPanel::importFilesAtPosition(const juce::StringArray& files, in
         if (!track)
             return;
 
-        // Block drops on group/aux tracks (no clip timeline)
-        if (track->type == TrackType::Group || track->type == TrackType::Aux) {
-            juce::AlertWindow::showMessageBoxAsync(
-                juce::AlertWindow::WarningIcon, "Drop Failed",
-                "Files cannot be dropped on group or aux tracks.");
+        // One question about the target, and none at all about the file. A
+        // Media track is hybrid, so what is dropped decides which clip gets
+        // made and never whether it is allowed. A Drum Grid on the chain used
+        // to refuse every dropped file here, which made the track likeliest to
+        // want a .mid the one that would not take one (#2172).
+        if (!track->acceptsUserClips()) {
+            juce::AlertWindow::showMessageBoxAsync(juce::AlertWindow::WarningIcon, "Drop Failed",
+                                                   "Clips cannot be placed on this track.");
             return;
-        }
-
-        // Block drops on tracks with a DrumGrid plugin
-        for (const auto& element : track->chain.fxChainElements) {
-            if (isDevice(element) && getDevice(element).pluginId.containsIgnoreCase("drumgrid")) {
-                juce::AlertWindow::showMessageBoxAsync(
-                    juce::AlertWindow::WarningIcon, "Drop Failed",
-                    "Files cannot be dropped on Drum Grid tracks.");
-                return;
-            }
         }
     }
     // If targetTrackId is still INVALID, we'll create a new track below
@@ -3455,7 +3448,7 @@ void TrackContentPanel::importFilesAtPosition(const juce::StringArray& files, in
 
                 juce::String trackName = audioFile.getFileNameWithoutExtension();
                 auto createTrackCmd =
-                    std::make_unique<CreateTrackCommand>(TrackType::Audio, trackName, insertAfter);
+                    std::make_unique<CreateTrackCommand>(TrackType::Media, trackName, insertAfter);
                 auto* createTrackPtr = createTrackCmd.get();
                 UndoManager::getInstance().executeCommand(std::move(createTrackCmd));
                 TrackId clipTrackId = createTrackPtr->getCreatedTrackId();
@@ -3585,7 +3578,7 @@ void TrackContentPanel::importFilesAtPosition(const juce::StringArray& files, in
                         trackName += " " + juce::String(listIdx + 1);
 
                     auto createTrackCmd =
-                        std::make_unique<CreateTrackCommand>(TrackType::Audio, trackName);
+                        std::make_unique<CreateTrackCommand>(TrackType::Media, trackName);
                     auto* createTrackPtr = createTrackCmd.get();
                     UndoManager::getInstance().executeCommand(std::move(createTrackCmd));
                     clipTrackId = createTrackPtr->getCreatedTrackId();
@@ -3758,7 +3751,7 @@ void TrackContentPanel::itemDropped(const SourceDetails& details) {
 
     if (auto* obj = details.description.getDynamicObject()) {
         auto device = TrackManager::deviceInfoFromPluginObject(*obj);
-        TrackType trackType = TrackType::Audio;
+        TrackType trackType = TrackType::Media;
         juce::String pluginName = obj->getProperty("name").toString();
         auto cmd = std::make_unique<CreateTrackWithDeviceCommand>(pluginName, trackType, device);
         UndoManager::getInstance().executeCommand(std::move(cmd));

--- a/magda/daw/ui/components/tracks/TrackContentPanel.cpp
+++ b/magda/daw/ui/components/tracks/TrackContentPanel.cpp
@@ -20,6 +20,7 @@
 #include "TrackControlsPolicy.hpp"
 #include "core/AppPaths.hpp"
 #include "core/AutomationCommands.hpp"
+#include "core/ChordProgressionConverter.hpp"
 #include "core/ClipCommands.hpp"
 #include "core/MidiChordMarkers.hpp"
 #include "core/PasteTargetResolver.hpp"
@@ -3445,26 +3446,6 @@ void TrackContentPanel::importFilesAtPosition(const juce::StringArray& files, in
             midiFiles.clear();
         }
 
-        // A progressions lane says yes to MIDI above, because a progression is
-        // a MIDI clip. Whether this material is one is a question about content
-        // rather than about kind, and here is where the content can be read.
-        if (traitsOf(track->type).userClips == UserClipAcceptance::Progressions) {
-            juce::StringArray progressions;
-            for (const auto& path : midiFiles)
-                if (!magda::daw::readChordMarkers(juce::File(path)).empty())
-                    progressions.add(path);
-
-            if (progressions.size() != midiFiles.size()) {
-                if (progressions.isEmpty()) {
-                    refuse("Only chord progressions can be placed on the chord track.");
-                    return;
-                }
-                refuse("Only chord progressions can be placed on the chord track, so the rest "
-                       "was left out.");
-            }
-            midiFiles = progressions;
-        }
-
         if (audioFiles.isEmpty() && midiFiles.isEmpty())
             return;
     }
@@ -3707,6 +3688,38 @@ void TrackContentPanel::importFilesAtPosition(const juce::StringArray& files, in
                     }
                     ann.chordGroup = linkedAny ? groupId : 0;
                     clip->chordAnnotations.push_back(ann);
+                }
+
+                // A .mid that carried no CHORD: markers still becomes chords
+                // when it lands on the chord track, because that is what the
+                // track is for and it is what a user dropping one there means.
+                // The same detection the piano roll's own button runs, from the
+                // same converter, so a dropped progression and a detected one
+                // are the same thing.
+                //
+                // Only on that track: detecting over every imported .mid would
+                // annotate parts that are not harmony and were never asked to
+                // be read as it.
+                if (clip->chordAnnotations.empty() && !clip->midiNotes.empty()) {
+                    if (const auto* clipTrack = TrackManager::getInstance().getTrack(clipTrackId);
+                        clipTrack != nullptr &&
+                        traitsOf(clipTrack->type).userClips == UserClipAcceptance::Progressions) {
+                        for (const auto& detected :
+                             extractChordsFromNotes(clip->midiNotes, beatsPerBar)) {
+                            ClipInfo::ChordAnnotation ann;
+                            ann.beatPosition = detected.startBeat;
+                            ann.lengthBeats = detected.lengthBeats;
+                            ann.chordName = detected.name;
+
+                            const int groupId = clip->nextChordGroupId++;
+                            for (const auto noteIndex : detected.noteIndices)
+                                if (noteIndex < clip->midiNotes.size())
+                                    clip->midiNotes[noteIndex].chordGroup = groupId;
+
+                            ann.chordGroup = detected.noteIndices.empty() ? 0 : groupId;
+                            clip->chordAnnotations.push_back(ann);
+                        }
+                    }
                 }
 
                 ClipManager::getInstance().forceNotifyClipPropertyChanged(clipId);

--- a/magda/daw/ui/components/tracks/TrackContentPanel.cpp
+++ b/magda/daw/ui/components/tracks/TrackContentPanel.cpp
@@ -22,6 +22,7 @@
 #include "core/AutomationCommands.hpp"
 #include "core/ChordProgressionConverter.hpp"
 #include "core/ClipCommands.hpp"
+#include "core/ClipPlacementPolicy.hpp"
 #include "core/MidiChordMarkers.hpp"
 #include "core/PasteTargetResolver.hpp"
 #include "core/SelectionManager.hpp"
@@ -2476,6 +2477,13 @@ void TrackContentPanel::rebuildClipComponents() {
         };
 
         clipComp->onClipMovedToTrack = [](ClipId id, TrackId newTrackId) {
+            // The same question the command asks, asked first so a refused move
+            // is not an undo step that does nothing.
+            const auto* target = TrackManager::getInstance().getTrack(newTrackId);
+            const auto* dragged = ClipManager::getInstance().getClip(id);
+            if (target == nullptr || dragged == nullptr || !trackAcceptsClip(*target, *dragged))
+                return;
+
             auto cmd = std::make_unique<MoveClipToTrackCommand>(id, newTrackId);
             UndoManager::getInstance().executeCommand(std::move(cmd));
         };

--- a/magda/daw/ui/components/tracks/TrackContentPanelClipDrag.cpp
+++ b/magda/daw/ui/components/tracks/TrackContentPanelClipDrag.cpp
@@ -8,6 +8,7 @@
 #include "../clips/ClipComponent.hpp"
 #include "TrackContentPanel.hpp"
 #include "core/ClipCommands.hpp"
+#include "core/ClipPlacementPolicy.hpp"
 #include "core/GestureRouter.hpp"
 #include "core/SelectionManager.hpp"
 #include "core/TempoUtils.hpp"
@@ -340,9 +341,18 @@ void TrackContentPanel::finishMultiClipDrag() {
                 juce::jlimit(0, numTracks - 1, dragInfo.originalTrackIndex + trackDelta);
             TrackId targetTrackId = visibleTrackIds_[static_cast<size_t>(targetIdx)];
             if (targetTrackId != dragInfo.originalTrackId) {
-                auto trackCmd =
-                    std::make_unique<MoveClipToTrackCommand>(dragInfo.clipId, targetTrackId);
-                UndoManager::getInstance().executeCommand(std::move(trackCmd));
+                // Asked before the command is built, not because the command
+                // would let it through -- it refuses the same targets -- but
+                // because a refused command is still an undo step that does
+                // nothing, and the clip stays where it was either way.
+                const auto* target = TrackManager::getInstance().getTrack(targetTrackId);
+                const auto* dragged = ClipManager::getInstance().getClip(dragInfo.clipId);
+                if (target != nullptr && dragged != nullptr &&
+                    trackAcceptsClip(*target, *dragged)) {
+                    auto trackCmd =
+                        std::make_unique<MoveClipToTrackCommand>(dragInfo.clipId, targetTrackId);
+                    UndoManager::getInstance().executeCommand(std::move(trackCmd));
+                }
             }
         }
 
@@ -411,11 +421,11 @@ namespace {
 // notes play the parent instrument, and has nothing to do with audio. A mixed
 // selection therefore needs a track that accepts every kind in it, since a
 // nudge moves the selection as one block and cannot leave half of it behind.
-bool canHostNudgedClips(const TrackInfo& track, const std::vector<ClipType>& kinds) {
-    for (const auto kind : kinds)
-        if (!track.acceptsUserClip(kind))
+bool canHostNudgedClips(const TrackInfo& track, const std::vector<const ClipInfo*>& moving) {
+    for (const auto* clip : moving)
+        if (clip == nullptr || !trackAcceptsClip(track, *clip))
             return false;
-    return !kinds.empty();
+    return !moving.empty();
 }
 
 // The clips a nudge acts on: the arrangement half of the selection. Session
@@ -547,20 +557,20 @@ bool TrackContentPanel::nudgeSelectedClipsToAdjacentTrack(int direction) {
     auto& trackManager = TrackManager::getInstance();
     auto& clipManager = ClipManager::getInstance();
 
-    // What is moving, so a destination can be judged against it.
-    std::vector<ClipType> movingKinds;
-    for (const ClipId clipId : clips) {
-        if (const auto* clip = clipManager.getClip(clipId)) {
-            const auto kind = clip->getType();
-            if (std::find(movingKinds.begin(), movingKinds.end(), kind) == movingKinds.end())
-                movingKinds.push_back(kind);
-        }
-    }
+    // What is moving, so a destination can be judged against it. The clips
+    // themselves rather than their kinds: a chord lane takes a MIDI clip that
+    // is already a progression and not one that merely could have been, and a
+    // kind cannot tell those apart.
+    std::vector<const ClipInfo*> moving;
+    moving.reserve(clips.size());
+    for (const ClipId clipId : clips)
+        if (const auto* clip = clipManager.getClip(clipId))
+            moving.push_back(clip);
 
     std::vector<TrackId> hostTrackIds;
     for (TrackId trackId : visibleTrackIds_) {
         const auto* track = trackManager.getTrack(trackId);
-        if (track != nullptr && canHostNudgedClips(*track, movingKinds) && !track->frozen)
+        if (track != nullptr && canHostNudgedClips(*track, moving) && !track->frozen)
             hostTrackIds.push_back(trackId);
     }
     if (hostTrackIds.size() < 2)

--- a/magda/daw/ui/components/tracks/TrackContentPanelClipDrag.cpp
+++ b/magda/daw/ui/components/tracks/TrackContentPanelClipDrag.cpp
@@ -402,18 +402,11 @@ void TrackContentPanel::cancelMultiClipDrag() {
 
 namespace {
 
-// Tracks a nudge may move a clip onto. Group and aux tracks are buses with no
-// clip timeline, the master track has no lane, and the chord track is a
-// singleton whose clips are chord progressions — a MIDI clip landing there
-// would change meaning. Multi-out tracks look like ordinary lanes but are
-// owned by a device's output pair: deactivateMultiOutPair() erases the track
-// outright without touching its clips, so anything parked there is orphaned
-// the moment the user switches that output off. Vertical nudging steps over
-// all of them.
+// Tracks a nudge may move a clip onto, which is the same set that a file drop
+// and a clip drag may target. The reasons live with the types themselves now,
+// so vertical nudging steps over whatever the table says it must.
 bool canHostNudgedClips(const TrackInfo& track) {
-    return track.type != TrackType::Group && track.type != TrackType::Aux &&
-           track.type != TrackType::Master && track.type != TrackType::Chord &&
-           track.type != TrackType::MultiOut;
+    return track.acceptsUserClips();
 }
 
 // The clips a nudge acts on: the arrangement half of the selection. Session

--- a/magda/daw/ui/components/tracks/TrackContentPanelClipDrag.cpp
+++ b/magda/daw/ui/components/tracks/TrackContentPanelClipDrag.cpp
@@ -1,6 +1,7 @@
 // TrackContentPanel — Multi-clip drag, time selection clip handling, and clip ghost methods.
 // Split from TrackContentPanel.cpp for file-size compliance.
 
+#include <algorithm>
 #include <limits>
 
 #include "../../interaction/ClipNudge.hpp"
@@ -402,11 +403,19 @@ void TrackContentPanel::cancelMultiClipDrag() {
 
 namespace {
 
-// Tracks a nudge may move a clip onto, which is the same set that a file drop
-// and a clip drag may target. The reasons live with the types themselves now,
-// so vertical nudging steps over whatever the table says it must.
-bool canHostNudgedClips(const TrackInfo& track) {
-    return track.acceptsUserClips();
+// Tracks a nudge may move this selection onto, which is the same question a
+// file drop and a clip drag ask, of the same table (TrackTypes.hpp).
+//
+// Asked with the selection in hand rather than of the track alone, because a
+// lane can accept one kind and not another: a multi-out lane takes MIDI, whose
+// notes play the parent instrument, and has nothing to do with audio. A mixed
+// selection therefore needs a track that accepts every kind in it, since a
+// nudge moves the selection as one block and cannot leave half of it behind.
+bool canHostNudgedClips(const TrackInfo& track, const std::vector<ClipType>& kinds) {
+    for (const auto kind : kinds)
+        if (!track.acceptsUserClip(kind))
+            return false;
+    return !kinds.empty();
 }
 
 // The clips a nudge acts on: the arrangement half of the selection. Session
@@ -536,10 +545,22 @@ bool TrackContentPanel::nudgeSelectedClipsToAdjacentTrack(int direction) {
     // the model out of step with its rendered audio. Skipping them (rather
     // than refusing) keeps a frozen lane from walling off the tracks below it.
     auto& trackManager = TrackManager::getInstance();
+    auto& clipManager = ClipManager::getInstance();
+
+    // What is moving, so a destination can be judged against it.
+    std::vector<ClipType> movingKinds;
+    for (const ClipId clipId : clips) {
+        if (const auto* clip = clipManager.getClip(clipId)) {
+            const auto kind = clip->getType();
+            if (std::find(movingKinds.begin(), movingKinds.end(), kind) == movingKinds.end())
+                movingKinds.push_back(kind);
+        }
+    }
+
     std::vector<TrackId> hostTrackIds;
     for (TrackId trackId : visibleTrackIds_) {
         const auto* track = trackManager.getTrack(trackId);
-        if (track != nullptr && canHostNudgedClips(*track) && !track->frozen)
+        if (track != nullptr && canHostNudgedClips(*track, movingKinds) && !track->frozen)
             hostTrackIds.push_back(trackId);
     }
     if (hostTrackIds.size() < 2)
@@ -552,7 +573,6 @@ bool TrackContentPanel::nudgeSelectedClipsToAdjacentTrack(int direction) {
     std::vector<ClipTrackIndex> moves;
     moves.reserve(clips.size());
 
-    auto& clipManager = ClipManager::getInstance();
     int minTrackIndex = std::numeric_limits<int>::max();
     int maxTrackIndex = std::numeric_limits<int>::min();
     for (ClipId clipId : clips) {

--- a/magda/daw/ui/components/tracks/TrackControlsPolicy.hpp
+++ b/magda/daw/ui/components/tracks/TrackControlsPolicy.hpp
@@ -27,7 +27,7 @@ namespace magda {
  * the header column learned to skip them and the content column did not.
  */
 inline bool occupiesArrangementRow(TrackType type) {
-    return type != TrackType::Aux;
+    return traitsOf(type).occupiesArrangementRow;
 }
 
 struct TrackControlsPolicy {
@@ -73,7 +73,7 @@ struct TrackControlsPolicy {
         p.gain = true;
         p.meter = true;
         switch (type) {
-            case TrackType::Audio:
+            case TrackType::Media:
                 // Regular hybrid track — everything. This includes multi-out
                 // parents (type Audio with children): they host the instrument,
                 // so they keep record/monitor and their input routing.

--- a/magda/daw/ui/components/tracks/TrackHeadersPanel.cpp
+++ b/magda/daw/ui/components/tracks/TrackHeadersPanel.cpp
@@ -2971,7 +2971,7 @@ void TrackHeadersPanel::showContextMenu(int trackIndex, juce::Point<int> positio
 
         addSendTargets(TrackType::Aux);
         addSendTargets(TrackType::Group);
-        addSendTargets(TrackType::Audio);
+        addSendTargets(TrackType::Media);
 
         if (hasOptions) {
             menu.addSubMenu(tr("tracks.add_send"), sendMenu);
@@ -2990,7 +2990,7 @@ void TrackHeadersPanel::showContextMenu(int trackIndex, juce::Point<int> positio
     }
 
     // Freeze/Unfreeze (for regular tracks only)
-    if (track->type == TrackType::Audio) {
+    if (track->type == TrackType::Media) {
         menu.addSeparator();
         menu.addItem(ToggleFreeze, track->frozen ? tr("tracks.unfreeze") : tr("tracks.freeze"));
     }
@@ -3071,7 +3071,7 @@ void TrackHeadersPanel::showContextMenu(int trackIndex, juce::Point<int> positio
                 UndoManager::getInstance().executeCommand(std::move(cmd));
             } else if (result == AddAudioTrack) {
                 UndoManager::getInstance().executeCommand(
-                    std::make_unique<CreateTrackCommand>(TrackType::Audio));
+                    std::make_unique<CreateTrackCommand>(TrackType::Media));
             } else if (result == AddGroupTrack) {
                 UndoManager::getInstance().executeCommand(
                     std::make_unique<CreateTrackCommand>(TrackType::Group));
@@ -3138,7 +3138,7 @@ void TrackHeadersPanel::showAddTrackContextMenu(juce::Point<int> position) {
                            localAreaToGlobal(juce::Rectangle<int>(position.x, position.y, 1, 1))),
                        [](int result) {
                            juce::PopupMenu::dismissAllActiveMenus();
-                           TrackType type = TrackType::Audio;
+                           TrackType type = TrackType::Media;
                            if (result == AddGroup)
                                type = TrackType::Group;
                            else if (result == AddAux)
@@ -3728,7 +3728,7 @@ void TrackHeadersPanel::itemDropped(const SourceDetails& details) {
             } else {
                 compoundScope = std::make_unique<CompoundOperationScope>(
                     copy ? "Copy Devices to New Track" : "Move Devices to New Track");
-                auto create = std::make_unique<CreateTrackCommand>(TrackType::Audio, "Track");
+                auto create = std::make_unique<CreateTrackCommand>(TrackType::Media, "Track");
                 auto* createPtr = create.get();
                 UndoManager::getInstance().executeCommand(std::move(create));
                 targetTrackId = createPtr->getCreatedTrackId();
@@ -3771,7 +3771,7 @@ void TrackHeadersPanel::itemDropped(const SourceDetails& details) {
                                                << trackId);
     } else {
         // Dropped on empty area → create new track with plugin
-        TrackType trackType = TrackType::Audio;
+        TrackType trackType = TrackType::Media;
         juce::String pluginName = obj->getProperty("name").toString();
         auto cmd = std::make_unique<CreateTrackWithDeviceCommand>(pluginName, trackType, device);
         UndoManager::getInstance().executeCommand(std::move(cmd));

--- a/magda/daw/ui/panels/BottomPanel.cpp
+++ b/magda/daw/ui/panels/BottomPanel.cpp
@@ -1714,7 +1714,7 @@ void BottomPanel::itemDropped(const SourceDetails& details) {
 
     if (auto* obj = details.description.getDynamicObject()) {
         auto device = TrackManager::deviceInfoFromPluginObject(*obj);
-        TrackType trackType = TrackType::Audio;
+        TrackType trackType = TrackType::Media;
         juce::String pluginName = obj->getProperty("name").toString();
         auto cmd = std::make_unique<CreateTrackWithDeviceCommand>(pluginName, trackType, device);
         UndoManager::getInstance().executeCommand(std::move(cmd));

--- a/magda/daw/ui/panels/content/AIChatConsoleContent.cpp
+++ b/magda/daw/ui/panels/content/AIChatConsoleContent.cpp
@@ -3648,7 +3648,7 @@ static juce::String applyFourOscPresetToFocusedDevice(magda::MagdaApi& api,
         newDevice.deviceType = magda::DeviceType::Instrument;
         newDevice.format = magda::PluginFormat::Internal;
 
-        const auto trackId = tm.createTrack(trackName, magda::TrackType::Audio);
+        const auto trackId = tm.createTrack(trackName, magda::TrackType::Media);
         if (trackId == magda::INVALID_TRACK_ID)
             return "(could not create track for preset)";
         const auto deviceId = tm.addDeviceToTrack(trackId, newDevice);

--- a/magda/daw/ui/panels/content/inspector/TrackInspector.cpp
+++ b/magda/daw/ui/panels/content/inspector/TrackInspector.cpp
@@ -1603,7 +1603,7 @@ void TrackInspector::showAddSendMenu() {
 
     addTracksOfType(magda::TrackType::Aux);
     addTracksOfType(magda::TrackType::Group);
-    addTracksOfType(magda::TrackType::Audio);
+    addTracksOfType(magda::TrackType::Media);
 
     if (menu.getNumItems() == 0) {
         menu.addItem(-1, "(No available tracks)", false);

--- a/magda/daw/ui/views/MainView.cpp
+++ b/magda/daw/ui/views/MainView.cpp
@@ -478,7 +478,7 @@ void MainView::setupComponents() {
     setupCornerButton(addTrackButton, "AddTrack", BinaryData::add_svg, BinaryData::add_svgSize);
     addTrackButton->onClick = []() {
         UndoManager::getInstance().executeCommand(
-            std::make_unique<CreateTrackCommand>(TrackType::Audio));
+            std::make_unique<CreateTrackCommand>(TrackType::Media));
     };
     addTrackButton->setTooltip("Add track");
 

--- a/magda/daw/ui/views/MixerView.cpp
+++ b/magda/daw/ui/views/MixerView.cpp
@@ -2921,7 +2921,7 @@ void MixerView::itemDropped(const SourceDetails& details) {
         }
     } else {
         // Drop on empty area — create new track with plugin
-        TrackType trackType = TrackType::Audio;
+        TrackType trackType = TrackType::Media;
         juce::String pluginName = obj->getProperty("name").toString();
         auto cmd = std::make_unique<CreateTrackWithDeviceCommand>(pluginName, trackType, device);
         UndoManager::getInstance().executeCommand(std::move(cmd));

--- a/magda/daw/ui/views/SessionView.cpp
+++ b/magda/daw/ui/views/SessionView.cpp
@@ -3895,7 +3895,7 @@ void SessionView::filesDropped(const juce::StringArray& files, int x, int y) {
         for (const auto& filePath : audioFiles) {
             juce::String trackName = juce::File(filePath).getFileNameWithoutExtension();
             auto cmd =
-                std::make_unique<CreateTrackCommand>(TrackType::Audio, trackName, insertAfter);
+                std::make_unique<CreateTrackCommand>(TrackType::Media, trackName, insertAfter);
             auto* cmdPtr = cmd.get();
             UndoManager::getInstance().executeCommand(std::move(cmd));
             TrackId trackId = cmdPtr->getCreatedTrackId();
@@ -4179,7 +4179,7 @@ void SessionView::itemDropped(const SourceDetails& details) {
             TrackManager::getInstance().addDeviceToTrack(trackId, device);
         } else {
             // Drop past last track — create new track with plugin
-            TrackType trackType = TrackType::Audio;
+            TrackType trackType = TrackType::Media;
             juce::String pluginName = obj->getProperty("name").toString();
             auto cmd =
                 std::make_unique<CreateTrackWithDeviceCommand>(pluginName, trackType, device);

--- a/magda/daw/ui/windows/MainWindowCommands.cpp
+++ b/magda/daw/ui/windows/MainWindowCommands.cpp
@@ -1958,7 +1958,7 @@ bool MainWindow::MainComponent::perform(const InvocationInfo& info) {
 
         case newAudioTrack: {
             TrackId selectedTrack = SelectionManager::getInstance().getSelectedTrack();
-            auto cmd = std::make_unique<CreateTrackCommand>(TrackType::Audio, juce::String(),
+            auto cmd = std::make_unique<CreateTrackCommand>(TrackType::Media, juce::String(),
                                                             selectedTrack);
             UndoManager::getInstance().executeCommand(std::move(cmd));
             return true;

--- a/magda/daw/ui/windows/MainWindowMenus.cpp
+++ b/magda/daw/ui/windows/MainWindowMenus.cpp
@@ -822,7 +822,7 @@ void MainWindow::setupMenuCallbacks() {
 
     // Track menu callbacks - all track operations go through the undo system
     callbacks.onAddTrack = []() {
-        auto cmd = std::make_unique<CreateTrackCommand>(TrackType::Audio);
+        auto cmd = std::make_unique<CreateTrackCommand>(TrackType::Media);
         UndoManager::getInstance().executeCommand(std::move(cmd));
     };
 

--- a/magda/scripting/MagdaApiLuaBindings.cpp
+++ b/magda/scripting/MagdaApiLuaBindings.cpp
@@ -236,7 +236,7 @@ int lua_selection_clear_notes(lua_State* L) {
 
 TrackType parseTrackType(const char* s) {
     if (juce::String(s).equalsIgnoreCase("audio"))
-        return TrackType::Audio;
+        return TrackType::Media;
     if (juce::String(s).equalsIgnoreCase("group"))
         return TrackType::Group;
     if (juce::String(s).equalsIgnoreCase("aux"))
@@ -246,12 +246,12 @@ TrackType parseTrackType(const char* s) {
     if (juce::String(s).equalsIgnoreCase("multi_out") ||
         juce::String(s).equalsIgnoreCase("multiout"))
         return TrackType::MultiOut;
-    return TrackType::Audio;
+    return TrackType::Media;
 }
 
 const char* trackTypeToLuaString(TrackType t) {
     switch (t) {
-        case TrackType::Audio:
+        case TrackType::Media:
             return "audio";
         case TrackType::Group:
             return "group";

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -520,6 +520,8 @@ target_sources(magda_juce_tests PRIVATE
     test_multi_clip_resize_preview_juce.cpp
     test_clip_paint_juce.cpp
     test_clip_nudge_juce.cpp
+    # A .mid dropped on the chord track arrives as chords
+    test_chord_track_file_drop_juce.cpp
     test_multiband_curve_view_juce.cpp
     # The transport layout against the widths the shipped fonts really produce
     # (#2071). Needs a graphics context, so it lives here rather than in

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -162,6 +162,8 @@ set(TEST_SOURCES
     test_midi_context.cpp
     test_llama_model_manager.cpp
     test_track_reorder.cpp
+    # What each track type declares about itself (#2172)
+    test_track_type_traits.cpp
     # New tracks take their post-FX fader side from the preference (#2094)
     test_post_fx_fader_default.cpp
     test_automation_modes.cpp

--- a/tests/NullDiffCorpus.cpp
+++ b/tests/NullDiffCorpus.cpp
@@ -56,7 +56,7 @@ constexpr double kSourceSeconds = 12.0;
 TrackInfo plainTrack() {
     TrackInfo track;
     track.id = kTrack;
-    track.type = TrackType::Audio;
+    track.type = TrackType::Media;
     track.name = "Null Diff";
     track.audioOutputDevice = "master";
     return track;
@@ -70,7 +70,7 @@ TrackInfo plainTrack() {
 TrackInfo instrumentTrackOn(TrackId trackId, DeviceId deviceId, const char* name) {
     TrackInfo track;
     track.id = trackId;
-    track.type = TrackType::Audio;
+    track.type = TrackType::Media;
     track.name = name;
     track.audioOutputDevice = "master";
 
@@ -160,7 +160,7 @@ TrackInfo masterTrack() {
 TrackInfo mixTrack(TrackId id, const char* name) {
     TrackInfo track;
     track.id = id;
-    track.type = TrackType::Audio;
+    track.type = TrackType::Media;
     track.name = name;
     track.audioOutputDevice = "master";
     return track;
@@ -172,7 +172,7 @@ TrackInfo mixTrack(TrackId id, const char* name) {
 TrackInfo gainTrackOn(TrackId trackId, DeviceId deviceId, const char* name, float base) {
     TrackInfo track;
     track.id = trackId;
-    track.type = TrackType::Audio;
+    track.type = TrackType::Media;
     track.name = name;
     track.audioOutputDevice = "master";
     track.chain.fxChainElements.emplace_back(gainDevice(deviceId, base));

--- a/tests/PlanEditSequence.cpp
+++ b/tests/PlanEditSequence.cpp
@@ -233,7 +233,7 @@ DeviceInfo instrument(DeviceId id) {
 TrackInfo audioTrack(TrackId id) {
     TrackInfo track;
     track.id = id;
-    track.type = TrackType::Audio;
+    track.type = TrackType::Media;
     track.name = "Track " + juce::String(id);
     track.audioOutputDevice = "master";
     track.chain.mixerAnalysisElements.push_back(PostFxChainElement{captureDevice(id)});

--- a/tests/PlanGoldenFixtures.cpp
+++ b/tests/PlanGoldenFixtures.cpp
@@ -20,7 +20,7 @@
 namespace magda::goldens {
 namespace {
 
-TrackInfo track(TrackId id, TrackType type = TrackType::Audio) {
+TrackInfo track(TrackId id, TrackType type = TrackType::Media) {
     TrackInfo value;
     value.id = id;
     value.type = type;

--- a/tests/test_agent_device_catalog.cpp
+++ b/tests/test_agent_device_catalog.cpp
@@ -184,7 +184,7 @@ TEST_CASE("Command state exposes bounded selected-track and selected-device cont
     TrackInfo track;
     track.id = 42;
     track.name = "Selected Synth";
-    track.type = TrackType::Audio;
+    track.type = TrackType::Media;
 
     DeviceInfo synth;
     synth.id = 7;
@@ -263,7 +263,7 @@ TEST_CASE("DSL fx.add executes documented internal-device compatibility aliases"
         REQUIRE(expected != nullptr);
 
         const auto trackId =
-            tracks.createTrack("DSL alias " + juce::String(static_cast<int>(i)), TrackType::Audio);
+            tracks.createTrack("DSL alias " + juce::String(static_cast<int>(i)), TrackType::Media);
         const auto command = "track(id=" + juce::String(static_cast<int>(i) + 1) +
                              ").fx.add(name=\"" + alias + "\")";
 
@@ -289,7 +289,7 @@ TEST_CASE("InstructionExecutor executes documented internal-device compatibility
         REQUIRE(expected != nullptr);
 
         const auto trackId = tracks.createTrack(
-            "Compact alias " + juce::String(static_cast<int>(i)), TrackType::Audio);
+            "Compact alias " + juce::String(static_cast<int>(i)), TrackType::Media);
         const auto compact = "FX " + juce::String(static_cast<int>(i) + 1) + " " + alias;
         const auto instructions = parser.parse(compact);
 

--- a/tests/test_arrangement_row_alignment_juce.cpp
+++ b/tests/test_arrangement_row_alignment_juce.cpp
@@ -48,7 +48,7 @@ class ArrangementRowAlignmentTest final : public juce::UnitTest {
 
         expect(!occupiesArrangementRow(TrackType::Aux), "aux belongs in its own strip");
 
-        for (const auto type : {TrackType::Audio, TrackType::Group, TrackType::Chord,
+        for (const auto type : {TrackType::Media, TrackType::Group, TrackType::Chord,
                                 TrackType::Master, TrackType::MultiOut}) {
             expect(occupiesArrangementRow(type),
                    "every non-aux type keeps its row: " + juce::String(static_cast<int>(type)));
@@ -60,9 +60,9 @@ class ArrangementRowAlignmentTest final : public juce::UnitTest {
 
         test::resetJuceProjectState();
         auto& trackManager = TrackManager::getInstance();
-        trackManager.createTrack("Audio", TrackType::Audio);
+        trackManager.createTrack("Audio", TrackType::Media);
         trackManager.createTrack("Send", TrackType::Aux);
-        trackManager.createTrack("Below", TrackType::Audio);
+        trackManager.createTrack("Below", TrackType::Media);
 
         TrackContentPanel panel;
         panel.setSize(2000, 400);
@@ -77,8 +77,8 @@ class ArrangementRowAlignmentTest final : public juce::UnitTest {
 
         test::resetJuceProjectState();
         auto& trackManager = TrackManager::getInstance();
-        trackManager.createTrack("First", TrackType::Audio);
-        trackManager.createTrack("Second", TrackType::Audio);
+        trackManager.createTrack("First", TrackType::Media);
+        trackManager.createTrack("Second", TrackType::Media);
 
         TrackContentPanel withoutAux;
         withoutAux.setSize(2000, 400);
@@ -89,9 +89,9 @@ class ArrangementRowAlignmentTest final : public juce::UnitTest {
         // Its row must not exist, so the second audio track keeps its position —
         // which is what keeps it level with its header.
         test::resetJuceProjectState();
-        trackManager.createTrack("First", TrackType::Audio);
+        trackManager.createTrack("First", TrackType::Media);
         trackManager.createTrack("Send", TrackType::Aux);
-        trackManager.createTrack("Second", TrackType::Audio);
+        trackManager.createTrack("Second", TrackType::Media);
 
         TrackContentPanel withAux;
         withAux.setSize(2000, 400);

--- a/tests/test_automation_agent.cpp
+++ b/tests/test_automation_agent.cpp
@@ -29,7 +29,7 @@ void resetState() {
 }
 
 TrackId makeTrack(const juce::String& name) {
-    return TrackManager::getInstance().createTrack(name, TrackType::Audio);
+    return TrackManager::getInstance().createTrack(name, TrackType::Media);
 }
 
 std::vector<AutoInstruction> parseOrFail(AutomationParser& parser, const juce::String& text) {

--- a/tests/test_automation_api_surface.cpp
+++ b/tests/test_automation_api_surface.cpp
@@ -39,8 +39,8 @@ TEST_CASE("Automation lanes and their targets are enumerable through the facade"
     auto& tracks = TrackManager::getInstance();
     auto& automation = AutomationManager::getInstance();
 
-    const auto trackA = tracks.createTrack("A", TrackType::Audio);
-    const auto trackB = tracks.createTrack("B", TrackType::Audio);
+    const auto trackA = tracks.createTrack("A", TrackType::Media);
+    const auto trackB = tracks.createTrack("B", TrackType::Media);
 
     const auto laneA = automation.createLane(volumeTarget(trackA), AutomationLaneType::Absolute);
     const auto laneB = automation.createLane(volumeTarget(trackB), AutomationLaneType::Absolute);
@@ -67,7 +67,7 @@ TEST_CASE("Edit-scoped lanes are enumerable even though no track owns them",
           "[automation-api][enumeration]") {
     resetState();
     auto& automation = AutomationManager::getInstance();
-    const auto trackId = TrackManager::getInstance().createTrack("A", TrackType::Audio);
+    const auto trackId = TrackManager::getInstance().createTrack("A", TrackType::Media);
 
     const auto trackLane =
         automation.createLane(volumeTarget(trackId), AutomationLaneType::Absolute);
@@ -87,7 +87,7 @@ TEST_CASE("Edit-scoped lanes are enumerable even though no track owns them",
 TEST_CASE("Bulk point writes are one undo step", "[automation-api][bulk]") {
     resetState();
     auto& automation = AutomationManager::getInstance();
-    const auto trackId = TrackManager::getInstance().createTrack("A", TrackType::Audio);
+    const auto trackId = TrackManager::getInstance().createTrack("A", TrackType::Media);
     const auto laneId = automation.createLane(volumeTarget(trackId), AutomationLaneType::Absolute);
 
     AutomationApiLive api;
@@ -124,7 +124,7 @@ TEST_CASE("Bulk point writes are one undo step", "[automation-api][bulk]") {
 TEST_CASE("Bulk point writes replace rather than append", "[automation-api][bulk]") {
     resetState();
     auto& automation = AutomationManager::getInstance();
-    const auto trackId = TrackManager::getInstance().createTrack("A", TrackType::Audio);
+    const auto trackId = TrackManager::getInstance().createTrack("A", TrackType::Media);
     const auto laneId = automation.createLane(volumeTarget(trackId), AutomationLaneType::Absolute);
 
     AutomationApiLive api;
@@ -154,7 +154,7 @@ TEST_CASE("Bulk point writes replace rather than append", "[automation-api][bulk
 TEST_CASE("Bulk point writes are refused where they do not apply", "[automation-api][bulk]") {
     resetState();
     auto& automation = AutomationManager::getInstance();
-    const auto trackId = TrackManager::getInstance().createTrack("A", TrackType::Audio);
+    const auto trackId = TrackManager::getInstance().createTrack("A", TrackType::Media);
     AutomationApiLive api;
 
     SECTION("unknown lane") {
@@ -174,7 +174,7 @@ TEST_CASE("Bulk point writes are refused where they do not apply", "[automation-
 TEST_CASE("Deleting a lane through the facade is undoable", "[automation-api][bulk]") {
     resetState();
     auto& automation = AutomationManager::getInstance();
-    const auto trackId = TrackManager::getInstance().createTrack("A", TrackType::Audio);
+    const auto trackId = TrackManager::getInstance().createTrack("A", TrackType::Media);
     const auto laneId = automation.createLane(volumeTarget(trackId), AutomationLaneType::Absolute);
 
     AutomationApiLive api;

--- a/tests/test_automation_clip_lanes.cpp
+++ b/tests/test_automation_clip_lanes.cpp
@@ -21,7 +21,7 @@ struct ClipLaneFixture {
     ClipLaneFixture() {
         AutomationManager::getInstance().clearAll();
         TrackManager::getInstance().clearAllTracks();
-        auto trackId = TrackManager::getInstance().createTrack("T", TrackType::Audio);
+        auto trackId = TrackManager::getInstance().createTrack("T", TrackType::Media);
         laneId = AutomationManager::getInstance().getOrCreateLane(
             ControlTarget::trackVolume(trackId), AutomationLaneType::ClipBased);
     }
@@ -318,7 +318,7 @@ TEST_CASE("convertLaneToClipBased wraps points into one clip", "[automation][cli
     AutomationManager::getInstance().clearAll();
     TrackManager::getInstance().clearAllTracks();
     auto& mgr = AutomationManager::getInstance();
-    auto trackId = TrackManager::getInstance().createTrack("T", TrackType::Audio);
+    auto trackId = TrackManager::getInstance().createTrack("T", TrackType::Media);
     auto laneId =
         mgr.getOrCreateLane(ControlTarget::trackVolume(trackId), AutomationLaneType::Absolute);
     mgr.clearLanePoints(laneId);
@@ -373,7 +373,7 @@ TEST_CASE("ConvertAutomationLaneTypeCommand - undo restores exact state",
     UndoManager::getInstance().clearHistory();
     auto& mgr = AutomationManager::getInstance();
     auto& undoMgr = UndoManager::getInstance();
-    auto trackId = TrackManager::getInstance().createTrack("T", TrackType::Audio);
+    auto trackId = TrackManager::getInstance().createTrack("T", TrackType::Media);
     auto laneId =
         mgr.getOrCreateLane(ControlTarget::trackVolume(trackId), AutomationLaneType::Absolute);
     mgr.clearLanePoints(laneId);
@@ -490,7 +490,7 @@ TEST_CASE("New clips inherit the track colour", "[automation][cliplane]") {
     mgr.clearAll();
     trackMgr.clearAllTracks();
 
-    const auto trackId = trackMgr.createTrack("T", TrackType::Audio);
+    const auto trackId = trackMgr.createTrack("T", TrackType::Media);
     trackMgr.setTrackColour(trackId, juce::Colour(0xFFAB4321));
     const auto laneId =
         mgr.getOrCreateLane(ControlTarget::trackVolume(trackId), AutomationLaneType::ClipBased);

--- a/tests/test_automation_modes.cpp
+++ b/tests/test_automation_modes.cpp
@@ -41,7 +41,7 @@ AutomationTarget panTarget(TrackId id) {
 TEST_CASE("AutomationManager touch baseline: set / get / clear round-trip",
           "[automation][modes][touch-baseline]") {
     resetState();
-    auto trackId = TrackManager::getInstance().createTrack("T", TrackType::Audio);
+    auto trackId = TrackManager::getInstance().createTrack("T", TrackType::Media);
     auto& mgr = AutomationManager::getInstance();
     auto target = volumeTarget(trackId);
 
@@ -59,7 +59,7 @@ TEST_CASE("AutomationManager touch baseline: set / get / clear round-trip",
 TEST_CASE("AutomationManager touch baseline: setting twice overwrites the value",
           "[automation][modes][touch-baseline]") {
     resetState();
-    auto trackId = TrackManager::getInstance().createTrack("T", TrackType::Audio);
+    auto trackId = TrackManager::getInstance().createTrack("T", TrackType::Media);
     auto& mgr = AutomationManager::getInstance();
     auto target = volumeTarget(trackId);
 
@@ -72,7 +72,7 @@ TEST_CASE("AutomationManager touch baseline: setting twice overwrites the value"
 TEST_CASE("AutomationManager touch baseline: per-target storage is independent",
           "[automation][modes][touch-baseline]") {
     resetState();
-    auto trackId = TrackManager::getInstance().createTrack("T", TrackType::Audio);
+    auto trackId = TrackManager::getInstance().createTrack("T", TrackType::Media);
     auto& mgr = AutomationManager::getInstance();
     auto vol = volumeTarget(trackId);
     auto pan = panTarget(trackId);
@@ -91,7 +91,7 @@ TEST_CASE("AutomationManager touch baseline: per-target storage is independent",
 TEST_CASE("AutomationManager: getUserTouchedTargets reflects current set",
           "[automation][modes][touch-baseline]") {
     resetState();
-    auto trackId = TrackManager::getInstance().createTrack("T", TrackType::Audio);
+    auto trackId = TrackManager::getInstance().createTrack("T", TrackType::Media);
     auto& mgr = AutomationManager::getInstance();
 
     REQUIRE(mgr.getUserTouchedTargets().empty());
@@ -116,7 +116,7 @@ TEST_CASE("AutomationManager seeds device macro lanes from the live macro value"
     resetState();
 
     auto& trackManager = TrackManager::getInstance();
-    auto trackId = trackManager.createTrack("T", TrackType::Audio);
+    auto trackId = trackManager.createTrack("T", TrackType::Media);
 
     DeviceInfo device;
     device.name = "Filter";

--- a/tests/test_automation_singleton.cpp
+++ b/tests/test_automation_singleton.cpp
@@ -29,7 +29,7 @@ void resetState() {
 }
 
 TrackId makeTrack(const juce::String& name) {
-    return TrackManager::getInstance().createTrack(name, TrackType::Audio);
+    return TrackManager::getInstance().createTrack(name, TrackType::Media);
 }
 
 AutomationTarget volumeTarget(TrackId id) {

--- a/tests/test_automation_stepped_targets.cpp
+++ b/tests/test_automation_stepped_targets.cpp
@@ -24,7 +24,7 @@ void resetState() {
 /// automation target pointing at it.
 AutomationTarget targetForParamWithScale(ParameterScale scale) {
     auto& tm = TrackManager::getInstance();
-    const auto trackId = tm.createTrack("T", TrackType::Audio);
+    const auto trackId = tm.createTrack("T", TrackType::Media);
 
     ParameterInfo param;
     param.paramIndex = 0;
@@ -79,7 +79,7 @@ TEST_CASE("Discrete plugin params are not treated as switches", "[automation][st
 TEST_CASE("Track volume does not want stepped automation", "[automation][stepped]") {
     resetState();
     auto& tm = TrackManager::getInstance();
-    const auto trackId = tm.createTrack("T", TrackType::Audio);
+    const auto trackId = tm.createTrack("T", TrackType::Media);
     CHECK_FALSE(targetWantsSteppedAutomation(ControlTarget::trackVolume(trackId)));
 }
 

--- a/tests/test_chord_track_file_drop_juce.cpp
+++ b/tests/test_chord_track_file_drop_juce.cpp
@@ -1,0 +1,140 @@
+#include <juce_gui_basics/juce_gui_basics.h>
+
+#include "JuceTestStateGuard.hpp"
+#include "magda/daw/core/ClipManager.hpp"
+#include "magda/daw/core/TrackManager.hpp"
+#include "magda/daw/ui/components/tracks/TrackContentPanel.hpp"
+#include "magda/daw/ui/state/TimelineController.hpp"
+
+/**
+ * Dropping a .mid on the chord track
+ *
+ * The chord track's lane is typed: what belongs on it is a progression. That
+ * makes two drops worth pinning, and they used to be one refusal.
+ *
+ * A .mid carrying CHORD: markers is already a progression and arrives as one.
+ * A .mid carrying only notes is what a user means to turn into chords by
+ * dropping it there, so the import runs the same detection the piano roll's own
+ * button runs. Neither is refused, and neither arrives as a bare MIDI clip that
+ * happens to sit on the chord track.
+ *
+ * Driven through the panel's real `filesDropped`, because what is under test is
+ * the decision the drop makes about its target, and the import beneath it would
+ * happily create a clip either way.
+ */
+
+using namespace magda;
+
+namespace {
+
+constexpr double testTempoBPM = 120.0;
+constexpr double testZoomPixelsPerBeat = 40.0;
+
+juce::File scratchDirectory() {
+    auto directory =
+        juce::File::getSpecialLocation(juce::File::tempDirectory).getChildFile("magda_chord_drop");
+    directory.createDirectory();
+    return directory;
+}
+
+/// One bar of a C major triad, held. No CHORD: markers: this is the file that
+/// has to have its harmony worked out on the way in.
+juce::File writeTriadMidiFile() {
+    const auto file = scratchDirectory().getChildFile("triad.mid");
+    file.deleteFile();
+
+    juce::MidiMessageSequence sequence;
+    for (const int note : {60, 64, 67}) {
+        sequence.addEvent(juce::MidiMessage::noteOn(1, note, 0.8f), 0.0);
+        sequence.addEvent(juce::MidiMessage::noteOff(1, note), 3840.0);
+    }
+
+    juce::MidiFile midi;
+    midi.setTicksPerQuarterNote(960);
+    midi.addTrack(sequence);
+
+    if (auto stream = std::unique_ptr<juce::FileOutputStream>(file.createOutputStream()))
+        midi.writeTo(*stream);
+
+    return file;
+}
+
+struct ChordTrackFixture {
+    TimelineController controller;
+    TrackContentPanel panel;
+    TrackId chordTrackId = INVALID_TRACK_ID;
+
+    ChordTrackFixture() {
+        chordTrackId = TrackManager::getInstance().ensureChordTrack();
+
+        panel.setSize(2000, 400);
+        panel.setTempo(testTempoBPM);
+        panel.setZoom(testZoomPixelsPerBeat);
+        panel.setController(&controller);
+    }
+};
+
+}  // namespace
+
+class ChordTrackFileDropTest final : public juce::UnitTest {
+  public:
+    ChordTrackFileDropTest() : juce::UnitTest("Chord Track File Drop", "magda") {}
+
+    void runTest() override {
+        testPlainMidiBecomesChords();
+    }
+
+  private:
+    void testPlainMidiBecomesChords() {
+        beginTest("A .mid of bare notes dropped on the chord track arrives as chords");
+
+        magda::test::runWithCleanJuceState([this] {
+            ChordTrackFixture fixture;
+            expect(fixture.chordTrackId != INVALID_TRACK_ID, "no chord track was created");
+
+            const auto midiFile = writeTriadMidiFile();
+            expect(midiFile.existsAsFile(), "no .mid was written to drop");
+
+            fixture.panel.filesDropped({midiFile.getFullPathName()}, 200, 10);
+
+            const auto clips = ClipManager::getInstance().getClipsOnTrack(fixture.chordTrackId);
+            expect(clips.size() == 1,
+                   "expected one clip on the chord track, got " + juce::String((int)clips.size()));
+            if (clips.empty())
+                return;
+
+            const auto* clip = ClipManager::getInstance().getClip(clips.front());
+            expect(clip != nullptr, "a clip id with no clip behind it");
+            if (clip == nullptr)
+                return;
+
+            // The notes are still there, and they are now spoken for.
+            expect(!clip->midiNotes.empty(), "the clip arrived with no notes");
+
+            // The point of the case: bare notes on this track are harmony, and
+            // a clip with none of it worked out is the failure this pins.
+            expect(!clip->chordAnnotations.empty(),
+                   "the clip arrived with no chords detected, so it is a plain MIDI clip "
+                   "sitting on the chord track");
+
+            if (!clip->chordAnnotations.empty()) {
+                const auto& first = clip->chordAnnotations.front();
+                expect(first.chordName.isNotEmpty(), "a chord was annotated with no name");
+
+                // C-E-G. The name carries the octave ("C4 maj"), so this asks
+                // what the chord is rather than how it is spelled.
+                expect(first.chordName.containsIgnoreCase("maj"),
+                       "a held C major triad was read as \"" + first.chordName + "\"");
+
+                // The notes are tied to the chord, which is what lets the
+                // editor re-detect and revoice it later.
+                const bool anyGrouped =
+                    std::any_of(clip->midiNotes.begin(), clip->midiNotes.end(),
+                                [](const auto& note) { return note.chordGroup != 0; });
+                expect(anyGrouped, "no note was linked to the chord it belongs to");
+            }
+        });
+    }
+};
+
+static ChordTrackFileDropTest chordTrackFileDropTest;

--- a/tests/test_clip_batch_edit.cpp
+++ b/tests/test_clip_batch_edit.cpp
@@ -81,7 +81,7 @@ TEST_CASE("SetClipPropertyCommand restores setter side effects", "[undo][clip][p
     ClipManager::getInstance().clearAllClips();
     TrackManager::getInstance().clearAllTracks();
 
-    auto trackId = TrackManager::getInstance().createTrack("Track", TrackType::Audio);
+    auto trackId = TrackManager::getInstance().createTrack("Track", TrackType::Media);
     auto clipId = ClipManager::getInstance().createAudioClip(trackId, 0.0, 4.0, "test.wav",
                                                              ClipView::Arrangement);
     auto* clip = ClipManager::getInstance().getClip(clipId);

--- a/tests/test_clip_commands.cpp
+++ b/tests/test_clip_commands.cpp
@@ -33,7 +33,7 @@ static void resetState() {
     TrackManager::getInstance().clearAllTracks();
 }
 
-static TrackId createTrack(const char* name = "Track", TrackType type = TrackType::Audio) {
+static TrackId createTrack(const char* name = "Track", TrackType type = TrackType::Media) {
     return TrackManager::getInstance().createTrack(name, type);
 }
 
@@ -222,7 +222,7 @@ TEST_CASE("DuplicateClipCommand - session undo removes duplicate only",
 
 TEST_CASE("DuplicateClipCommand - audio clip", "[clip][command][duplicate]") {
     resetState();
-    TrackId track = createTrack("Audio Track", TrackType::Audio);
+    TrackId track = createTrack("Audio Track", TrackType::Media);
     ClipId original = createAudio(track, 1.0, 3.0);
 
     DuplicateClipCommand cmd(original);
@@ -248,7 +248,7 @@ TEST_CASE("DuplicateClipCommand - audio clip startBeats stays in sync with start
     proj.setTempo(90.0);
     REQUIRE(proj.getCurrentProjectInfo().tempo == Catch::Approx(90.0));
 
-    TrackId track = createTrack("Audio Track", TrackType::Audio);
+    TrackId track = createTrack("Audio Track", TrackType::Media);
     ClipId original = createAudio(track, 2.0, 4.0);
 
     auto* origBeforeDup = ClipManager::getInstance().getClip(original);
@@ -315,7 +315,7 @@ TEST_CASE("copyTimeRangeToClipboard + paste - preserves internal clip spacing",
     const double originalTempo = proj.getCurrentProjectInfo().tempo;
     proj.setTempo(90.0);
 
-    TrackId track = createTrack("Audio Track", TrackType::Audio);
+    TrackId track = createTrack("Audio Track", TrackType::Media);
     // Selection [2.0, 6.0] (4 seconds = 6 beats at 90 BPM).
     // Two audio clips inside the range, 0.5s of internal gap.
     ClipId a = createAudio(track, 2.0, 1.5);  // ends at 3.5
@@ -356,7 +356,7 @@ TEST_CASE("copyTimeRangeToClipboard + paste - trimmed audio keeps beat placement
     const double originalTempo = proj.getCurrentProjectInfo().tempo;
     proj.setTempo(90.0);
 
-    TrackId track = createTrack("Audio Track", TrackType::Audio);
+    TrackId track = createTrack("Audio Track", TrackType::Media);
     ClipId sourceId = createAudio(track, 1.0, 8.0);
 
     auto& cm = ClipManager::getInstance();
@@ -395,7 +395,7 @@ TEST_CASE(
     const double originalTempo = proj.getCurrentProjectInfo().tempo;
     proj.setTempo(120.0);
 
-    TrackId track = createTrack("Audio Track", TrackType::Audio);
+    TrackId track = createTrack("Audio Track", TrackType::Media);
     ClipId sourceId = createAudio(track, 1.0, 2.0);
 
     auto& cm = ClipManager::getInstance();
@@ -442,7 +442,7 @@ TEST_CASE("copyTimeRangeToClipboard + paste - exact beat slice keeps waveform id
     const double originalTempo = proj.getCurrentProjectInfo().tempo;
     proj.setTempo(120.0);
 
-    TrackId track = createTrack("Audio Track", TrackType::Audio);
+    TrackId track = createTrack("Audio Track", TrackType::Media);
     ClipId sourceId = createAudio(track, 0.5, 0.5);
 
     auto& cm = ClipManager::getInstance();
@@ -787,7 +787,7 @@ TEST_CASE("JoinClipsCommand - canExecute validation", "[clip][command][join]") {
     }
 
     SECTION("Cannot join clips of different types") {
-        TrackId audioTrack = createTrack("Audio", TrackType::Audio);
+        TrackId audioTrack = createTrack("Audio", TrackType::Media);
         ClipId midi = createMidi(track1, 0.0, 2.0);
         ClipId audio = createAudio(audioTrack, 2.0, 2.0);
         JoinClipsCommand cmd(midi, audio);
@@ -1673,7 +1673,7 @@ TEST_CASE("resolveOverlaps - covering a clip leaves it whole and gives it back",
     proj.setTempo(120.0);
 
     auto& cm = ClipManager::getInstance();
-    TrackId track = createTrack("Track", TrackType::Audio);
+    TrackId track = createTrack("Track", TrackType::Media);
 
     SECTION("covered end to end") {
         ClipId covered = createAudio(track, 2.0, 2.0);  // [4,8] beats
@@ -1726,8 +1726,8 @@ TEST_CASE("resolveOverlaps - a clip dropped inside another leaves it whole",
     proj.setTempo(120.0);
 
     auto& cm = ClipManager::getInstance();
-    TrackId trackC = createTrack("Long", TrackType::Audio);
-    TrackId trackS = createTrack("Source", TrackType::Audio);
+    TrackId trackC = createTrack("Long", TrackType::Media);
+    TrackId trackS = createTrack("Source", TrackType::Media);
 
     ClipId longClip = createAudio(trackC, 0.0, 8.0);  // [0,16] beats
     ClipId source = createAudio(trackS, 0.0, 2.0);    // [0,4] beats
@@ -1774,7 +1774,7 @@ TEST_CASE("resolveOverlaps - dropping a clip inside a MIDI clip keeps it whole",
     proj.setTempo(120.0);
 
     auto& cm = ClipManager::getInstance();
-    TrackId track = createTrack("Track", TrackType::Audio);
+    TrackId track = createTrack("Track", TrackType::Media);
 
     // [0,16] beats with a note before, under and after the drop.
     ClipId part = createMidi(track, 0.0, 8.0, {2.0, 8.0, 14.0});
@@ -1921,7 +1921,7 @@ TEST_CASE("FlattenClipStackCommand - commits what the stack plays into one clip"
     config.setClipOverlapPlaysBoth(false);
 
     auto& cm = ClipManager::getInstance();
-    TrackId track = createTrack("Track", TrackType::Audio);
+    TrackId track = createTrack("Track", TrackType::Media);
 
     // [0,16] with notes at 2, 8 and 14; the drop covers [6,10], so the note at
     // 8 is the one nobody hears.
@@ -1987,7 +1987,7 @@ TEST_CASE("FlattenClipStackCommand - only offers itself when there is a stack to
     proj.setTempo(120.0);
 
     auto& cm = ClipManager::getInstance();
-    TrackId track = createTrack("Track", TrackType::Audio);
+    TrackId track = createTrack("Track", TrackType::Media);
 
     SECTION("abutting clips are not a stack") {
         ClipId a = createMidi(track, 0.0, 4.0, {0.0});

--- a/tests/test_clip_crossfades.cpp
+++ b/tests/test_clip_crossfades.cpp
@@ -44,7 +44,7 @@ void resetState() {
 }
 
 TrackId createTrack() {
-    return TrackManager::getInstance().createTrack("Track", TrackType::Audio);
+    return TrackManager::getInstance().createTrack("Track", TrackType::Media);
 }
 
 // Creates an audio clip with source headroom on both sides (offset 10 s into a

--- a/tests/test_clip_nudge_juce.cpp
+++ b/tests/test_clip_nudge_juce.cpp
@@ -57,10 +57,10 @@ struct NudgeFixture {
 
     NudgeFixture() {
         auto& trackManager = TrackManager::getInstance();
-        topTrack = trackManager.createTrack("Top", TrackType::Audio);
+        topTrack = trackManager.createTrack("Top", TrackType::Media);
         groupTrack = trackManager.createTrack("Group", TrackType::Group);
-        middleTrack = trackManager.createTrack("Middle", TrackType::Audio);
-        bottomTrack = trackManager.createTrack("Bottom", TrackType::Audio);
+        middleTrack = trackManager.createTrack("Middle", TrackType::Media);
+        bottomTrack = trackManager.createTrack("Bottom", TrackType::Media);
 
         panel.setSize(2000, 400);
         panel.setTempo(testTempoBPM);

--- a/tests/test_device_api.cpp
+++ b/tests/test_device_api.cpp
@@ -24,7 +24,7 @@ TrackId freshTrack(const juce::String& name) {
     auto& tracks = TrackManager::getInstance();
     tracks.clearAllTracks();
     UndoManager::getInstance().clearHistory();
-    return tracks.createTrack(name, TrackType::Audio);
+    return tracks.createTrack(name, TrackType::Media);
 }
 
 }  // namespace
@@ -79,7 +79,7 @@ TEST_CASE("Live device lookup rejects paths that address nothing", "[device-api]
 TEST_CASE("Device parameters are reported in real units", "[device-api][inspection]") {
     auto& tracks = TrackManager::getInstance();
     tracks.clearAllTracks();
-    const auto trackId = tracks.createTrack("Synth", TrackType::Audio);
+    const auto trackId = tracks.createTrack("Synth", TrackType::Media);
 
     DeviceInfo device;
     device.name = "Filter";

--- a/tests/test_dsl_rack_commands.cpp
+++ b/tests/test_dsl_rack_commands.cpp
@@ -11,7 +11,7 @@ using Catch::Approx;
 TEST_CASE("DSL creates and configures a rack and its chains", "[dsl][racks]") {
     auto& tracks = TrackManager::getInstance();
     tracks.clearAllTracks();
-    const auto trackId = tracks.createTrack("Bass", TrackType::Audio);
+    const auto trackId = tracks.createTrack("Bass", TrackType::Media);
 
     MagdaApiLive api;
     dsl::Interpreter interpreter(api);
@@ -47,7 +47,7 @@ TEST_CASE("DSL creates and configures a rack and its chains", "[dsl][racks]") {
 TEST_CASE("DSL fx.add after rack.new lands inside the rack chain", "[dsl][racks]") {
     auto& tracks = TrackManager::getInstance();
     tracks.clearAllTracks();
-    const auto trackId = tracks.createTrack("Bass", TrackType::Audio);
+    const auto trackId = tracks.createTrack("Bass", TrackType::Media);
 
     MagdaApiLive api;
     dsl::Interpreter interpreter(api);

--- a/tests/test_dsl_track_workflow.cpp
+++ b/tests/test_dsl_track_workflow.cpp
@@ -15,7 +15,7 @@ void addTrack(test::MockMagdaApi& api, TrackId id, const juce::String& name) {
     TrackInfo t;
     t.id = id;
     t.name = name;
-    t.type = TrackType::Audio;
+    t.type = TrackType::Media;
     api.tracks_.tracks.push_back(t);
     api.tracks_.nextId = std::max(api.tracks_.nextId, id + 1);
 }
@@ -37,9 +37,9 @@ TEST_CASE("DSL filter(tracks) groups every track and is undoable", "[dsl][tracks
     auto& tm = TrackManager::getInstance();
     tm.clearAllTracks();
     UndoManager::getInstance().clearHistory();
-    auto k = tm.createTrack("Kick", TrackType::Audio);
-    auto s = tm.createTrack("Snare", TrackType::Audio);
-    auto b = tm.createTrack("Bass", TrackType::Audio);
+    auto k = tm.createTrack("Kick", TrackType::Media);
+    auto s = tm.createTrack("Snare", TrackType::Media);
+    auto b = tm.createTrack("Bass", TrackType::Media);
 
     MagdaApiLive api;
     dsl::Interpreter interp(api);
@@ -127,9 +127,9 @@ TEST_CASE("DSL groups explicit track ids and chains colour onto the group",
     auto& tm = TrackManager::getInstance();
     tm.clearAllTracks();
     UndoManager::getInstance().clearHistory();
-    auto k = tm.createTrack("Kick", TrackType::Audio);
-    auto s = tm.createTrack("Snare", TrackType::Audio);
-    auto h = tm.createTrack("Hat", TrackType::Audio);
+    auto k = tm.createTrack("Kick", TrackType::Media);
+    auto s = tm.createTrack("Snare", TrackType::Media);
+    auto h = tm.createTrack("Hat", TrackType::Media);
 
     MagdaApiLive api;
     dsl::Interpreter interp(api);
@@ -170,11 +170,11 @@ TEST_CASE("DSL explicit track ids stay stable after grouping reorders tracks",
     auto& tm = TrackManager::getInstance();
     tm.clearAllTracks();
     UndoManager::getInstance().clearHistory();
-    auto k = tm.createTrack("Kick", TrackType::Audio);
-    auto s = tm.createTrack("Snare", TrackType::Audio);
-    auto b = tm.createTrack("Bass", TrackType::Audio);
-    auto lv = tm.createTrack("Lead Vox", TrackType::Audio);
-    auto dv = tm.createTrack("Double Vox", TrackType::Audio);
+    auto k = tm.createTrack("Kick", TrackType::Media);
+    auto s = tm.createTrack("Snare", TrackType::Media);
+    auto b = tm.createTrack("Bass", TrackType::Media);
+    auto lv = tm.createTrack("Lead Vox", TrackType::Media);
+    auto dv = tm.createTrack("Double Vox", TrackType::Media);
 
     MagdaApiLive api;
     dsl::Interpreter interp(api);

--- a/tests/test_engine_session.cpp
+++ b/tests/test_engine_session.cpp
@@ -30,7 +30,7 @@ namespace {
 
 constexpr int kBlockSize = 64;
 
-TrackInfo makeTrack(TrackId id, TrackType type = TrackType::Audio) {
+TrackInfo makeTrack(TrackId id, TrackType type = TrackType::Media) {
     TrackInfo track;
     track.id = id;
     track.type = type;

--- a/tests/test_focused_api_live.cpp
+++ b/tests/test_focused_api_live.cpp
@@ -29,8 +29,8 @@ TEST_CASE("FocusedApiLive cycleDevice selects top-level devices on the selected 
     auto& tm = TrackManager::getInstance();
     auto& sel = SelectionManager::getInstance();
 
-    const auto otherTrack = tm.createTrack("Other", TrackType::Audio);
-    const auto selectedTrack = tm.createTrack("Selected", TrackType::Audio);
+    const auto otherTrack = tm.createTrack("Other", TrackType::Media);
+    const auto selectedTrack = tm.createTrack("Selected", TrackType::Media);
 
     const auto otherDevice = tm.addDeviceToTrack(otherTrack, makeDevice("Other EQ"));
     const auto firstDevice = tm.addDeviceToTrack(selectedTrack, makeDevice("EQ"));

--- a/tests/test_ghost_clips.cpp
+++ b/tests/test_ghost_clips.cpp
@@ -25,7 +25,7 @@ static void resetState() {
 }
 
 static TrackId createTrack(const char* name = "Track") {
-    return TrackManager::getInstance().createTrack(name, TrackType::Audio);
+    return TrackManager::getInstance().createTrack(name, TrackType::Media);
 }
 
 static ClipId createMidi(TrackId trackId, double start, double length,

--- a/tests/test_group_tracks_and_macros.cpp
+++ b/tests/test_group_tracks_and_macros.cpp
@@ -248,9 +248,9 @@ TEST_CASE("Group selected tracks creates group before selected tracks",
           "[group_track][selection]") {
     GroupMacroTestFixture fixture;
 
-    auto firstId = fixture.tm().createTrack("Drums", TrackType::Audio);
-    auto secondId = fixture.tm().createTrack("Bass", TrackType::Audio);
-    auto thirdId = fixture.tm().createTrack("Lead", TrackType::Audio);
+    auto firstId = fixture.tm().createTrack("Drums", TrackType::Media);
+    auto secondId = fixture.tm().createTrack("Bass", TrackType::Media);
+    auto thirdId = fixture.tm().createTrack("Lead", TrackType::Media);
 
     auto groupId = fixture.tm().groupTracks({thirdId, firstId, secondId}, "Selected Group");
 
@@ -271,8 +271,8 @@ TEST_CASE("Group selected tracks creates group before selected tracks",
 TEST_CASE("Ungroup track restores children and deletes empty group", "[group_track][selection]") {
     GroupMacroTestFixture fixture;
 
-    auto firstId = fixture.tm().createTrack("Drums", TrackType::Audio);
-    auto secondId = fixture.tm().createTrack("Bass", TrackType::Audio);
+    auto firstId = fixture.tm().createTrack("Drums", TrackType::Media);
+    auto secondId = fixture.tm().createTrack("Bass", TrackType::Media);
     auto groupId = fixture.tm().groupTracks({firstId, secondId}, "Selected Group");
 
     auto childIds = fixture.tm().ungroupTrack(groupId);
@@ -290,9 +290,9 @@ TEST_CASE("Group selected child tracks creates nested group inside parent",
     GroupMacroTestFixture fixture;
 
     auto parentId = fixture.tm().createGroupTrack("Parent");
-    auto firstId = fixture.tm().createTrackInGroup(parentId, "Drums", TrackType::Audio);
-    auto secondId = fixture.tm().createTrackInGroup(parentId, "Bass", TrackType::Audio);
-    auto thirdId = fixture.tm().createTrackInGroup(parentId, "Lead", TrackType::Audio);
+    auto firstId = fixture.tm().createTrackInGroup(parentId, "Drums", TrackType::Media);
+    auto secondId = fixture.tm().createTrackInGroup(parentId, "Bass", TrackType::Media);
+    auto thirdId = fixture.tm().createTrackInGroup(parentId, "Lead", TrackType::Media);
 
     auto nestedGroupId = fixture.tm().groupTracks({secondId, firstId}, "Nested Group");
 
@@ -323,13 +323,13 @@ TEST_CASE("Audio and Instrument tracks accept instruments", "[group_track][instr
     instrument.isInstrument = true;
 
     SECTION("Audio track accepts instrument") {
-        auto trackId = fixture.tm().createTrack("Audio", TrackType::Audio);
+        auto trackId = fixture.tm().createTrack("Audio", TrackType::Media);
         auto id = fixture.tm().addDeviceToTrack(trackId, instrument);
         REQUIRE(id != INVALID_DEVICE_ID);
     }
 
     SECTION("Instrument track accepts instrument") {
-        auto trackId = fixture.tm().createTrack("Inst", TrackType::Audio);
+        auto trackId = fixture.tm().createTrack("Inst", TrackType::Media);
         auto id = fixture.tm().addDeviceToTrack(trackId, instrument);
         REQUIRE(id != INVALID_DEVICE_ID);
     }

--- a/tests/test_instruction_executor_context.cpp
+++ b/tests/test_instruction_executor_context.cpp
@@ -36,7 +36,7 @@ void resetState() {
 }
 
 TrackId makeTrack(const juce::String& name) {
-    return TrackManager::getInstance().createTrack(name, TrackType::Audio);
+    return TrackManager::getInstance().createTrack(name, TrackType::Media);
 }
 
 std::vector<Instruction> parseOrFail(CompactParser& p, const juce::String& text) {

--- a/tests/test_internal_track_routing.cpp
+++ b/tests/test_internal_track_routing.cpp
@@ -22,7 +22,7 @@ struct InternalRoutingFixture {
     }
 
     TrackId createTrack(const juce::String& name = "Track") {
-        return tm().createTrack(name, TrackType::Audio);
+        return tm().createTrack(name, TrackType::Media);
     }
 
     static juce::String trackInput(TrackId id) {

--- a/tests/test_magda_api_lua_bindings.cpp
+++ b/tests/test_magda_api_lua_bindings.cpp
@@ -86,7 +86,7 @@ TEST_CASE("magda.tracks.create routes to TrackApi", "[lua_bindings][tracks]") {
     REQUIRE(id.has_value());
     REQUIRE(mock.tracks_.created.size() == 1);
     REQUIRE(mock.tracks_.created[0].name == "Drums");
-    REQUIRE(mock.tracks_.created[0].type == magda::TrackType::Audio);
+    REQUIRE(mock.tracks_.created[0].type == magda::TrackType::Media);
     REQUIRE(*id == mock.tracks_.created[0].id);
 }
 
@@ -102,7 +102,7 @@ TEST_CASE("magda.tracks.create accepts every track-type alias", "[lua_bindings][
     REQUIRE(rt.eval("magda.tracks.create('mo', 'multi_out')"));
 
     REQUIRE(mock.tracks_.created.size() == 5);
-    REQUIRE(mock.tracks_.created[0].type == magda::TrackType::Audio);
+    REQUIRE(mock.tracks_.created[0].type == magda::TrackType::Media);
     REQUIRE(mock.tracks_.created[1].type == magda::TrackType::Group);
     REQUIRE(mock.tracks_.created[2].type == magda::TrackType::Aux);
     REQUIRE(mock.tracks_.created[3].type == magda::TrackType::Master);
@@ -171,7 +171,7 @@ TEST_CASE("magda.tracks.list returns a snapshot table per track", "[lua_bindings
     magda::TrackInfo a;
     a.id = 1;
     a.name = "Drums";
-    a.type = magda::TrackType::Audio;
+    a.type = magda::TrackType::Media;
     a.volume = 0.8f;
     a.pan = -0.2f;
     a.muted = true;
@@ -210,7 +210,7 @@ TEST_CASE("magda.tracks.master returns the master track", "[lua_bindings][tracks
     magda::TrackInfo ordinary;
     ordinary.id = 1;
     ordinary.name = "Drums";
-    ordinary.type = magda::TrackType::Audio;
+    ordinary.type = magda::TrackType::Media;
     mock.tracks_.tracks.push_back(ordinary);
 
     LuaRuntime rt;

--- a/tests/test_midi_clip_split.cpp
+++ b/tests/test_midi_clip_split.cpp
@@ -54,7 +54,7 @@ TEST_CASE("MIDI clip split - basic operation", "[midi][clip][split]") {
     // Setup
     clipManager.clearAllClips();
     trackManager.clearAllTracks();
-    TrackId trackId = trackManager.createTrack("Test Track", TrackType::Audio);
+    TrackId trackId = trackManager.createTrack("Test Track", TrackType::Media);
 
     SECTION("Split clip with notes at different positions") {
         // Create clip: 0-4 seconds (8 beats at 120 BPM)
@@ -107,7 +107,7 @@ TEST_CASE("MIDI clip split - note position adjustment", "[midi][clip][split][not
     // Setup
     clipManager.clearAllClips();
     trackManager.clearAllTracks();
-    TrackId trackId = trackManager.createTrack("Test Track", TrackType::Audio);
+    TrackId trackId = trackManager.createTrack("Test Track", TrackType::Media);
 
     SECTION("Right clip notes adjusted relative to split point") {
         // Create clip with notes at beats: 1, 3, 5, 7
@@ -164,7 +164,7 @@ TEST_CASE("MIDI clip split - sequential operations", "[midi][clip][split][sequen
     // Setup
     clipManager.clearAllClips();
     trackManager.clearAllTracks();
-    TrackId trackId = trackManager.createTrack("Test Track", TrackType::Audio);
+    TrackId trackId = trackManager.createTrack("Test Track", TrackType::Media);
 
     SECTION("Multiple splits maintain correct note positions") {
         // Create clip: 0-8 seconds (16 beats)
@@ -241,7 +241,7 @@ TEST_CASE("MIDI clip split - edge cases", "[midi][clip][split][edge]") {
     // Setup
     clipManager.clearAllClips();
     trackManager.clearAllTracks();
-    TrackId trackId = trackManager.createTrack("Test Track", TrackType::Audio);
+    TrackId trackId = trackManager.createTrack("Test Track", TrackType::Media);
 
     SECTION("Split with existing midiOffset") {
         ClipId clipId = createMidiClipWithNotes(trackId, 0.0, 4.0, {2.0, 4.0, 6.0});
@@ -311,7 +311,7 @@ TEST_CASE("MIDI clip split - undo/redo", "[midi][clip][split][undo]") {
     // Setup
     clipManager.clearAllClips();
     trackManager.clearAllTracks();
-    TrackId trackId = trackManager.createTrack("Test Track", TrackType::Audio);
+    TrackId trackId = trackManager.createTrack("Test Track", TrackType::Media);
 
     SECTION("Undo restores original clip state") {
         ClipId clipId = createMidiClipWithNotes(trackId, 0.0, 4.0, {0.0, 2.0, 4.0, 6.0});
@@ -382,7 +382,7 @@ TEST_CASE("Looped MIDI clip split - both halves keep notes", "[midi][clip][split
 
     clipManager.clearAllClips();
     trackManager.clearAllTracks();
-    TrackId trackId = trackManager.createTrack("Test Track", TrackType::Audio);
+    TrackId trackId = trackManager.createTrack("Test Track", TrackType::Media);
 
     SECTION("Split in middle preserves notes on both sides") {
         // Looped clip: 8 seconds (16 beats at 120 BPM), loop = 4 beats

--- a/tests/test_midi_legato.cpp
+++ b/tests/test_midi_legato.cpp
@@ -14,7 +14,7 @@ using Catch::Approx;
 static ClipId makeClip(const std::vector<std::pair<double, double>>& notes, int pitch = 60) {
     auto& clipManager = ClipManager::getInstance();
     ClipId clipId =
-        clipManager.createMidiClip(TrackManager::getInstance().createTrack("T", TrackType::Audio),
+        clipManager.createMidiClip(TrackManager::getInstance().createTrack("T", TrackType::Media),
                                    0.0, 64.0, ClipView::Arrangement);
     auto* clip = clipManager.getClip(clipId);
     for (const auto& [start, len] : notes) {

--- a/tests/test_midi_signal_routing_juce.cpp
+++ b/tests/test_midi_signal_routing_juce.cpp
@@ -1487,7 +1487,7 @@ class MidiSignalRoutingTest final : public juce::UnitTest {
 
         auto& trackManager = magda::TrackManager::getInstance();
         const auto targetTrackId = trackManager.createTrack("Step Sequencer Pattern Paste Target",
-                                                            magda::TrackType::Audio);
+                                                            magda::TrackType::Media);
         const auto targetColour = juce::Colour(0xff3366aa);
         trackManager.setTrackColour(targetTrackId, targetColour);
 
@@ -1580,7 +1580,7 @@ class MidiSignalRoutingTest final : public juce::UnitTest {
 
         auto& trackManager = magda::TrackManager::getInstance();
         const auto targetTrackId = trackManager.createTrack("Poly Sequencer Pattern Paste Target",
-                                                            magda::TrackType::Audio);
+                                                            magda::TrackType::Media);
         const auto targetColour = juce::Colour(0xff8844aa);
         trackManager.setTrackColour(targetTrackId, targetColour);
 

--- a/tests/test_mod_feeds.cpp
+++ b/tests/test_mod_feeds.cpp
@@ -523,7 +523,7 @@ TEST_CASE("A modulation feed does not order the tracks", "[engine][mod][feeds]")
     listener.chain.fxChainElements.push_back(makeRackElement(std::move(rack)));
 
     auto sink = makeTrack(2);
-    sink.type = TrackType::Audio;
+    sink.type = TrackType::Media;
 
     // Declared source-last, which is the order that used to invent the cycle.
     const std::vector<TrackInfo> tracks{sink, listener};
@@ -561,7 +561,7 @@ TEST_CASE("A modifier added as a follower listens at the far end", "[engine][mod
     auto& manager = TrackManager::getInstance();
     manager.clearAllTracks();
 
-    const auto trackId = manager.createTrack("Source", TrackType::Audio);
+    const auto trackId = manager.createTrack("Source", TrackType::Media);
     const auto path = ChainNodePath::trackLevel(trackId);
 
     manager.addMod(path, 0, ModType::Follower, LFOWaveform::Sine);

--- a/tests/test_modulation_baker.cpp
+++ b/tests/test_modulation_baker.cpp
@@ -276,7 +276,7 @@ AutomationPoint bakedPoint(double beat, double value) {
 TEST_CASE("replacePointsInRange - replaces inside, preserves outside", "[automation][bake]") {
     resetManagers();
     auto& autoMgr = AutomationManager::getInstance();
-    auto trackId = TrackManager::getInstance().createTrack("T", TrackType::Audio);
+    auto trackId = TrackManager::getInstance().createTrack("T", TrackType::Media);
     auto target = ControlTarget::trackVolume(trackId);
 
     auto laneId = autoMgr.getOrCreateLane(target, AutomationLaneType::Absolute);
@@ -323,7 +323,7 @@ TEST_CASE("BakeModulationCommand - execute/undo round-trip with link disable",
     auto& autoMgr = AutomationManager::getInstance();
     auto& undoMgr = UndoManager::getInstance();
 
-    auto trackId = tracks.createTrack("T", TrackType::Audio);
+    auto trackId = tracks.createTrack("T", TrackType::Media);
     auto path = ChainNodePath::trackLevel(trackId);
     auto target = ControlTarget::trackVolume(trackId);
 
@@ -392,7 +392,7 @@ TEST_CASE("BakeModulationToClipCommand - activates the lane and restores disable
     auto& autoMgr = AutomationManager::getInstance();
     auto& undoMgr = UndoManager::getInstance();
 
-    const auto trackId = tracks.createTrack("T", TrackType::Audio);
+    const auto trackId = tracks.createTrack("T", TrackType::Media);
     const auto path = ChainNodePath::trackLevel(trackId);
     const auto target = ControlTarget::trackVolume(trackId);
 
@@ -455,7 +455,7 @@ TEST_CASE("BakeModulationCommand - new lane is part of the bake transition", "[a
     auto& autoMgr = AutomationManager::getInstance();
     auto& undoMgr = UndoManager::getInstance();
 
-    const auto trackId = tracks.createTrack("T", TrackType::Audio);
+    const auto trackId = tracks.createTrack("T", TrackType::Media);
     const auto path = ChainNodePath::trackLevel(trackId);
     const auto target = ControlTarget::trackVolume(trackId);
     tracks.addMod(path, 0, ModType::LFO);
@@ -502,7 +502,7 @@ TEST_CASE("BakeModulationToClipCommand - undo restores lane preparation state",
     auto& autoMgr = AutomationManager::getInstance();
     auto& undoMgr = UndoManager::getInstance();
 
-    const auto trackId = tracks.createTrack("T", TrackType::Audio);
+    const auto trackId = tracks.createTrack("T", TrackType::Media);
     const auto path = ChainNodePath::trackLevel(trackId);
     const auto target = ControlTarget::trackVolume(trackId);
     tracks.addMod(path, 0, ModType::LFO);
@@ -555,7 +555,7 @@ TEST_CASE("BakeModulationCommand - undo does not re-enable links that were alrea
     auto& autoMgr = AutomationManager::getInstance();
     auto& undoMgr = UndoManager::getInstance();
 
-    auto trackId = tracks.createTrack("T", TrackType::Audio);
+    auto trackId = tracks.createTrack("T", TrackType::Media);
     auto path = ChainNodePath::trackLevel(trackId);
     auto target = ControlTarget::trackVolume(trackId);
 

--- a/tests/test_multi_out_tracks.cpp
+++ b/tests/test_multi_out_tracks.cpp
@@ -31,7 +31,7 @@ class MultiOutTestFixture {
     };
 
     MultiOutSetup createMultiOutTrack(const juce::String& name = "Inst") {
-        auto trackId = tm().createTrack(name, TrackType::Audio);
+        auto trackId = tm().createTrack(name, TrackType::Media);
 
         DeviceInfo instrument;
         instrument.name = "MultiOutSynth";

--- a/tests/test_null_diff_block_size.cpp
+++ b/tests/test_null_diff_block_size.cpp
@@ -363,7 +363,7 @@ TEST_CASE("An epsilon is bought by a plugin, not declared", "[nulldiff][blocksiz
 
         TrackInfo track;
         track.id = 1;
-        track.type = TrackType::Audio;
+        track.type = TrackType::Media;
         track.name = "Track";
         track.audioOutputDevice = "master";
 

--- a/tests/test_null_diff_native_leg.cpp
+++ b/tests/test_null_diff_native_leg.cpp
@@ -96,7 +96,7 @@ TEST_CASE("A routed MIDI source is not captured", "[nulldiff][native]") {
 
     TrackInfo source;
     source.id = 1;
-    source.type = TrackType::Audio;
+    source.type = TrackType::Media;
     source.name = "Source";
     source.audioOutputDevice = "master";
     {
@@ -111,7 +111,7 @@ TEST_CASE("A routed MIDI source is not captured", "[nulldiff][native]") {
 
     TrackInfo destination;
     destination.id = 2;
-    destination.type = TrackType::Audio;
+    destination.type = TrackType::Media;
     destination.name = "Synth";
     destination.audioOutputDevice = "master";
     // What makes the source a source: an internal MIDI route, live only while
@@ -188,7 +188,7 @@ TEST_CASE("An eligible track with nothing to play is still captured", "[nulldiff
     const auto instrumentTrack = [](TrackId trackId, DeviceId deviceId, const char* name) {
         TrackInfo track;
         track.id = trackId;
-        track.type = TrackType::Audio;
+        track.type = TrackType::Media;
         track.name = name;
         track.audioOutputDevice = "master";
 

--- a/tests/test_offline_render.cpp
+++ b/tests/test_offline_render.cpp
@@ -32,7 +32,7 @@ namespace {
 
 constexpr double kSampleRate = 44100.0;
 
-TrackInfo makeTrack(TrackId id, TrackType type = TrackType::Audio) {
+TrackInfo makeTrack(TrackId id, TrackType type = TrackType::Media) {
     TrackInfo track;
     track.id = id;
     track.type = type;

--- a/tests/test_parallel_executor.cpp
+++ b/tests/test_parallel_executor.cpp
@@ -72,7 +72,7 @@ std::int64_t timelineSampleOf(const BlockInfo& block) {
     return static_cast<std::int64_t>(block.startBeat * kSamplesPerBeat + 0.5);
 }
 
-TrackInfo makeTrack(TrackId id, TrackType type = TrackType::Audio) {
+TrackInfo makeTrack(TrackId id, TrackType type = TrackType::Media) {
     TrackInfo track;
     track.id = id;
     track.type = type;

--- a/tests/test_persisted_enum_pins.cpp
+++ b/tests/test_persisted_enum_pins.cpp
@@ -80,7 +80,7 @@ static_assert(time_stretch_mode::kSignalsmith == 15);
 
 // --- Tracks ------------------------------------------------------------------
 
-static_assert(static_cast<int>(TrackType::Audio) == 0);
+static_assert(static_cast<int>(TrackType::Media) == 0);
 static_assert(static_cast<int>(TrackType::Group) == 3);
 static_assert(static_cast<int>(TrackType::Aux) == 4);
 static_assert(static_cast<int>(TrackType::Master) == 5);
@@ -286,7 +286,7 @@ std::vector<Pin> allPins() {
         PIN(MidiCurveType, Step, 0),
         PIN(MidiCurveType, Linear, 1),
         PIN(MidiCurveType, Bezier, 2),
-        PIN(TrackType, Audio, 0),
+        PIN(TrackType, Media, 0),
         PIN(TrackType, Group, 3),
         PIN(TrackType, Aux, 4),
         PIN(TrackType, Master, 5),

--- a/tests/test_plan_crossfade.cpp
+++ b/tests/test_plan_crossfade.cpp
@@ -64,7 +64,7 @@ BlockInfo blockAt(std::int64_t timelineSample, int numSamples) {
     return block;
 }
 
-TrackInfo makeTrack(TrackId id, TrackType type = TrackType::Audio) {
+TrackInfo makeTrack(TrackId id, TrackType type = TrackType::Media) {
     TrackInfo track;
     track.id = id;
     track.type = type;

--- a/tests/test_plan_diff.cpp
+++ b/tests/test_plan_diff.cpp
@@ -15,7 +15,7 @@ using magda::engine::RenderPlan;
 
 namespace {
 
-TrackInfo makeTrack(TrackId id, TrackType type = TrackType::Audio) {
+TrackInfo makeTrack(TrackId id, TrackType type = TrackType::Media) {
     TrackInfo track;
     track.id = id;
     track.type = type;

--- a/tests/test_plan_layout.cpp
+++ b/tests/test_plan_layout.cpp
@@ -20,7 +20,7 @@ using magda::engine::SignalKind;
 
 namespace {
 
-TrackInfo makeTrack(TrackId id, TrackType type = TrackType::Audio) {
+TrackInfo makeTrack(TrackId id, TrackType type = TrackType::Media) {
     TrackInfo track;
     track.id = id;
     track.type = type;

--- a/tests/test_post_fx_fader_default.cpp
+++ b/tests/test_post_fx_fader_default.cpp
@@ -19,7 +19,7 @@ struct PostFxDefaultFixture {
 
     bool sideOfNewTrack(bool preferPostFader) {
         Config::getInstance().setPostFxPostFaderByDefault(preferPostFader);
-        const auto trackId = TrackManager::getInstance().createTrack("PostFx", TrackType::Audio);
+        const auto trackId = TrackManager::getInstance().createTrack("PostFx", TrackType::Media);
         return TrackManager::getInstance().isPostFxPostFader(trackId);
     }
 

--- a/tests/test_post_fx_fader_order_juce.cpp
+++ b/tests/test_post_fx_fader_order_juce.cpp
@@ -120,7 +120,7 @@ class PostFxFaderOrderTest final : public juce::UnitTest {
             return f;
 
         auto& tm = TrackManager::getInstance();
-        f.trackId = tm.createTrack("PostFx", TrackType::Audio);
+        f.trackId = tm.createTrack("PostFx", TrackType::Media);
         const auto deviceId = tm.addDeviceToPostFx(f.trackId, makePostFxDevice());
         f.devicePath = ChainNodePath::postFxDevice(f.trackId, deviceId);
         f.bridge->syncTrackPlugins(f.trackId);
@@ -205,7 +205,7 @@ class PostFxFaderOrderTest final : public juce::UnitTest {
             return;
 
         auto& tm = TrackManager::getInstance();
-        const auto trackId = tm.createTrack("Levels", TrackType::Audio);
+        const auto trackId = tm.createTrack("Levels", TrackType::Media);
 
         DeviceInfo levels;
         levels.name = "Levels";
@@ -335,7 +335,7 @@ class PostFxFaderOrderTest final : public juce::UnitTest {
             return;
 
         auto& tm = TrackManager::getInstance();
-        const auto trackId = tm.createTrack("Sends", TrackType::Audio);
+        const auto trackId = tm.createTrack("Sends", TrackType::Media);
 
         SendInfo pre;
         pre.busIndex = 0;
@@ -408,7 +408,7 @@ class PostFxFaderOrderTest final : public juce::UnitTest {
         // instrument declares its output pairs and activating one creates the
         // child track and its link. A hand-made link is not enough — the sync
         // path resolves the source device and returns early without it.
-        const auto sourceId = tm.createTrack("Source", TrackType::Audio);
+        const auto sourceId = tm.createTrack("Source", TrackType::Media);
         DeviceInfo instrument;
         instrument.name = "MultiOutSynth";
         instrument.format = PluginFormat::Internal;

--- a/tests/test_project_document_adapters.cpp
+++ b/tests/test_project_document_adapters.cpp
@@ -50,7 +50,7 @@ TEST_CASE("NativeProjectDocumentAdapter captures current manager state",
     info.name = "Adapter Capture";
     info.tempo = 132.0;
 
-    auto trackId = TrackManager::getInstance().createTrack("Keys", TrackType::Audio);
+    auto trackId = TrackManager::getInstance().createTrack("Keys", TrackType::Media);
     auto clipId = ClipManager::getInstance().createMidiClipBeats(trackId, 4.0, 2.0);
     auto* clip = ClipManager::getInstance().getClip(clipId);
     REQUIRE(clip != nullptr);
@@ -439,7 +439,7 @@ TEST_CASE("ProjectSerializer exports and stages dawproject archives",
     info.version = "0.serializer";
     info.tempo = 126.0;
 
-    auto trackId = TrackManager::getInstance().createTrack("Arp", TrackType::Audio);
+    auto trackId = TrackManager::getInstance().createTrack("Arp", TrackType::Media);
     auto clipId = ClipManager::getInstance().createMidiClipBeats(trackId, 0.0, 2.0);
     auto* clip = ClipManager::getInstance().getClip(clipId);
     REQUIRE(clip != nullptr);
@@ -1033,7 +1033,7 @@ TEST_CASE("DawProjectXmlAdapter exports master role and send routing and roundtr
     TrackInfo audio;
     audio.id = 1;
     audio.name = "Audio 1";
-    audio.type = TrackType::Audio;
+    audio.type = TrackType::Media;
 
     TrackInfo aux;
     aux.id = 2;

--- a/tests/test_project_serialization.cpp
+++ b/tests/test_project_serialization.cpp
@@ -529,7 +529,7 @@ TEST_CASE("Project Serialization Basics", "[project][serialization]") {
         auto& projectManager = ProjectManager::getInstance();
         REQUIRE(projectManager.newProject());
 
-        auto trackId = TrackManager::getInstance().createTrack("Audio Track", TrackType::Audio);
+        auto trackId = TrackManager::getInstance().createTrack("Audio Track", TrackType::Media);
 
         auto sourceFile =
             projectManager.getRecordingsDirectory().getChildFile("unsaved_recording.wav");
@@ -594,7 +594,7 @@ TEST_CASE("Audio clip serialization separates source facts from interpretation",
           "[project][serialization][audio]") {
     ProjectTestFixture fixture;
 
-    auto trackId = TrackManager::getInstance().createTrack("Audio", TrackType::Audio);
+    auto trackId = TrackManager::getInstance().createTrack("Audio", TrackType::Media);
 
     ClipInfo clip;
     clip.id = 42;
@@ -683,7 +683,7 @@ TEST_CASE("Audio clip serialization separates source facts from interpretation",
 TEST_CASE("Session clip follow action settings roundtrip", "[project][serialization][session]") {
     ProjectTestFixture fixture;
 
-    auto trackId = TrackManager::getInstance().createTrack("MIDI", TrackType::Audio);
+    auto trackId = TrackManager::getInstance().createTrack("MIDI", TrackType::Media);
 
     ClipInfo clip;
     clip.id = 91;
@@ -732,7 +732,7 @@ TEST_CASE("Clip enabled state roundtrips and missing property defaults to enable
           "[project][serialization][clip]") {
     ProjectTestFixture fixture;
 
-    auto trackId = TrackManager::getInstance().createTrack("MIDI", TrackType::Audio);
+    auto trackId = TrackManager::getInstance().createTrack("MIDI", TrackType::Media);
 
     ClipInfo clip;
     clip.id = 93;
@@ -778,7 +778,7 @@ TEST_CASE("Looped MIDI clip serialization preserves loop region separate from pl
           "[project][serialization][midi][loop]") {
     ProjectTestFixture fixture;
 
-    auto trackId = TrackManager::getInstance().createTrack("MIDI", TrackType::Audio);
+    auto trackId = TrackManager::getInstance().createTrack("MIDI", TrackType::Media);
 
     ClipInfo clip;
     clip.id = 92;
@@ -838,7 +838,7 @@ TEST_CASE("Saving a MIDI clip to the media library writes and indexes a generate
     ProjectTestFixture fixture;
     ScopedTestDataDir dataDir("magda-midi-library-test");
 
-    auto trackId = TrackManager::getInstance().createTrack("MIDI Track", TrackType::Audio);
+    auto trackId = TrackManager::getInstance().createTrack("MIDI Track", TrackType::Media);
     auto clipId =
         ClipManager::getInstance().createMidiClipBeats(trackId, 0.0, 4.0, ClipView::Arrangement);
     REQUIRE(clipId != INVALID_CLIP_ID);
@@ -888,7 +888,7 @@ TEST_CASE("Saved audio library warp markers survive BPM mismatch re-import",
     auto sourceFile = dataDir.dir.getChildFile("drum_loop_135bpm.wav");
     REQUIRE(sourceFile.replaceWithText("not decoded in this regression test"));
 
-    auto trackId = TrackManager::getInstance().createTrack("Audio Track", TrackType::Audio);
+    auto trackId = TrackManager::getInstance().createTrack("Audio Track", TrackType::Media);
     auto clipId = ClipManager::getInstance().createAudioClip(
         trackId, 0.0, 4.0, sourceFile.getFullPathName(), ClipView::Arrangement, 120.0);
     REQUIRE(clipId != INVALID_CLIP_ID);
@@ -989,7 +989,7 @@ TEST_CASE("MidiFileWriter writes MIDI clip data to a stable destination",
 TEST_CASE("Clip serialization validates type and audio schema", "[project][serialization][audio]") {
     ProjectTestFixture fixture;
 
-    auto trackId = TrackManager::getInstance().createTrack("Track", TrackType::Audio);
+    auto trackId = TrackManager::getInstance().createTrack("Track", TrackType::Media);
 
     ClipInfo clip;
     clip.id = 7;
@@ -1155,7 +1155,7 @@ TEST_CASE("Automation serialization uses beat-domain property names",
           "[project][serialization][automation][beats]") {
     ProjectTestFixture fixture;
 
-    auto trackId = TrackManager::getInstance().createTrack("Automation", TrackType::Audio);
+    auto trackId = TrackManager::getInstance().createTrack("Automation", TrackType::Media);
     auto& automation = AutomationManager::getInstance();
     const auto target = ControlTarget::trackVolume(trackId);
     auto laneId = automation.createLane(target, AutomationLaneType::ClipBased);
@@ -1265,7 +1265,7 @@ TEST_CASE("Automation serialization persists only explicit disablement",
           "[project][serialization][automation][authority]") {
     ProjectTestFixture fixture;
 
-    const auto trackId = TrackManager::getInstance().createTrack("Automation", TrackType::Audio);
+    const auto trackId = TrackManager::getInstance().createTrack("Automation", TrackType::Media);
     auto& automation = AutomationManager::getInstance();
     const auto laneId =
         automation.createLane(ControlTarget::trackVolume(trackId), AutomationLaneType::Absolute);
@@ -1361,8 +1361,8 @@ TEST_CASE("Project with Tracks", "[project][serialization][tracks]") {
         auto& projectManager = ProjectManager::getInstance();
 
         // Create a couple tracks
-        trackManager.createTrack("Audio 1", TrackType::Audio);
-        trackManager.createTrack("MIDI 1", TrackType::Audio);
+        trackManager.createTrack("Audio 1", TrackType::Media);
+        trackManager.createTrack("MIDI 1", TrackType::Media);
 
         REQUIRE(trackManager.getTracks().size() == 2);
 
@@ -1386,9 +1386,9 @@ TEST_CASE("Project with Tracks", "[project][serialization][tracks]") {
         const auto& tracks = trackManager.getTracks();
         REQUIRE(tracks.size() == 2);
         REQUIRE(tracks[0].name == "Audio 1");
-        REQUIRE(tracks[0].type == TrackType::Audio);
+        REQUIRE(tracks[0].type == TrackType::Media);
         REQUIRE(tracks[1].name == "MIDI 1");
-        REQUIRE(tracks[1].type == TrackType::Audio);
+        REQUIRE(tracks[1].type == TrackType::Media);
 
         // Cleanup
         trackManager.clearAllTracks();
@@ -1431,7 +1431,7 @@ TEST_CASE("normalizeForType clears input state on input-less tracks",
 
     SECTION("Input-taking track keeps its input state") {
         TrackInfo audio;
-        audio.type = TrackType::Audio;
+        audio.type = TrackType::Media;
         audio.recordArmed = true;
         audio.inputMonitor = InputMonitorMode::In;
         audio.midiInputDevice = "all";
@@ -1511,7 +1511,7 @@ TEST_CASE("Project Manager State", "[project][manager]") {
         REQUIRE(projectManager.hasUnsavedChanges() == false);
 
         // Make a change
-        trackManager.createTrack("Test", TrackType::Audio);
+        trackManager.createTrack("Test", TrackType::Media);
         projectManager.markDirty();
 
         REQUIRE(projectManager.hasUnsavedChanges() == true);
@@ -1631,7 +1631,7 @@ TEST_CASE("Comprehensive Project Serialization", "[project][serialization][compr
         auto& clipManager = ClipManager::getInstance();
 
         // Create a track
-        auto trackId = trackManager.createTrack("Test MIDI Track", TrackType::Audio);
+        auto trackId = trackManager.createTrack("Test MIDI Track", TrackType::Media);
         auto* track = trackManager.getTrack(trackId);
         REQUIRE(track != nullptr);
 
@@ -1688,7 +1688,7 @@ TEST_CASE("Comprehensive Project Serialization", "[project][serialization][compr
         // Verify the track was restored
         const auto& tracks = trackManager.getTracks();
         REQUIRE(tracks.size() == 1);
-        REQUIRE(tracks[0].type == TrackType::Audio);
+        REQUIRE(tracks[0].type == TrackType::Media);
 
         // Verify the device was restored
         REQUIRE(tracks[0].chain.fxChainElements.size() == 1);
@@ -1714,7 +1714,7 @@ TEST_CASE("Comprehensive Project Serialization", "[project][serialization][compr
         auto& trackManager = TrackManager::getInstance();
 
         // Create a track
-        auto trackId = trackManager.createTrack("Test Audio Track", TrackType::Audio);
+        auto trackId = trackManager.createTrack("Test Audio Track", TrackType::Media);
 
         // Add a rack to the track
         auto rackId = trackManager.addRackToTrack(trackId, "Test Rack");
@@ -1804,7 +1804,7 @@ TEST_CASE("DeviceInfo pluginState roundtrip", "[project][serialization][pluginSt
     SECTION("pluginState is serialized and deserialized") {
         auto& trackManager = TrackManager::getInstance();
 
-        auto trackId = trackManager.createTrack("Plugin State Track", TrackType::Audio);
+        auto trackId = trackManager.createTrack("Plugin State Track", TrackType::Media);
 
         DeviceInfo device;
         device.id = 1;
@@ -1840,7 +1840,7 @@ TEST_CASE("DeviceInfo pluginState roundtrip", "[project][serialization][pluginSt
         auto& trackManager = TrackManager::getInstance();
         auto& projectManager = ProjectManager::getInstance();
 
-        auto trackId = trackManager.createTrack("No State Track", TrackType::Audio);
+        auto trackId = trackManager.createTrack("No State Track", TrackType::Media);
 
         DeviceInfo device;
         device.id = 1;
@@ -1870,7 +1870,7 @@ TEST_CASE("TrackInfo persistent runtime seeds roundtrip", "[project][serializati
     ProjectTestFixture fixture;
 
     auto& trackManager = TrackManager::getInstance();
-    auto trackId = trackManager.createTrack("Session Track", TrackType::Audio);
+    auto trackId = trackManager.createTrack("Session Track", TrackType::Media);
     auto* track = trackManager.getTrack(trackId);
     REQUIRE(track != nullptr);
     track->volume = 0.25f;
@@ -1916,7 +1916,7 @@ TEST_CASE("TrackInfo mixer layout commands undo redo",
 
     auto& trackManager = TrackManager::getInstance();
     auto& undoManager = UndoManager::getInstance();
-    auto trackId = trackManager.createTrack("Resizable", TrackType::Audio);
+    auto trackId = trackManager.createTrack("Resizable", TrackType::Media);
     auto* track = trackManager.getTrack(trackId);
     REQUIRE(track != nullptr);
 
@@ -1974,7 +1974,7 @@ TEST_CASE("DeviceInfo panel UI state roundtrip", "[project][serialization][devic
     ProjectTestFixture fixture;
 
     auto& trackManager = TrackManager::getInstance();
-    auto trackId = trackManager.createTrack("Device Track", TrackType::Audio);
+    auto trackId = trackManager.createTrack("Device Track", TrackType::Media);
 
     DeviceInfo device;
     device.id = 23;
@@ -2009,7 +2009,7 @@ TEST_CASE("Device channel counts survive a project roundtrip", "[project][serial
     ProjectTestFixture fixture;
 
     auto& trackManager = TrackManager::getInstance();
-    auto trackId = trackManager.createTrack("Channel Counts", TrackType::Audio);
+    auto trackId = trackManager.createTrack("Channel Counts", TrackType::Media);
 
     DeviceInfo mono;
     mono.id = 31;
@@ -2114,7 +2114,7 @@ TEST_CASE("Section-scoped device ids survive project roundtrip",
     ProjectTestFixture fixture;
 
     auto& trackManager = TrackManager::getInstance();
-    auto trackId = trackManager.createTrack("Section IDs", TrackType::Audio);
+    auto trackId = trackManager.createTrack("Section IDs", TrackType::Media);
 
     DeviceInfo fx;
     fx.name = "FX";
@@ -2160,7 +2160,7 @@ TEST_CASE("Post-FX parameter selections survive project roundtrip",
     ProjectTestFixture fixture;
 
     auto& trackManager = TrackManager::getInstance();
-    auto trackId = trackManager.createTrack("Post FX Params", TrackType::Audio);
+    auto trackId = trackManager.createTrack("Post FX Params", TrackType::Media);
 
     DeviceInfo fx;
     fx.name = "FX";
@@ -2211,8 +2211,8 @@ TEST_CASE("Mixer analysis plugin state survives project roundtrip",
 
     auto& trackManager = TrackManager::getInstance();
     auto& projectManager = ProjectManager::getInstance();
-    auto firstTrackId = trackManager.createTrack("First", TrackType::Audio);
-    auto secondTrackId = trackManager.createTrack("Second", TrackType::Audio);
+    auto firstTrackId = trackManager.createTrack("First", TrackType::Media);
+    auto secondTrackId = trackManager.createTrack("Second", TrackType::Media);
 
     DeviceInfo firstScope;
     firstScope.name = "Oscilloscope";
@@ -2275,7 +2275,7 @@ TEST_CASE("Master mixer analysis plugin state survives project roundtrip",
     REQUIRE(masterTrack->chain.mixerAnalysisElements[0].device.pluginState ==
             juce::String("<PLUGIN type=\"oscilloscope\" traceColour=\"3\"/>"));
 
-    auto childTrackId = trackManager.createTrack("Later Track", TrackType::Audio);
+    auto childTrackId = trackManager.createTrack("Later Track", TrackType::Media);
     DeviceInfo siblingScope = scope;
     siblingScope.pluginState = "<PLUGIN type=\"oscilloscope\" traceColour=\"6\"/>";
     REQUIRE(trackManager.addDeviceToMixerAnalysis(childTrackId, siblingScope) == 2);
@@ -2287,7 +2287,7 @@ TEST_CASE("Post-fx device params are not automation targets",
 
     auto& trackManager = TrackManager::getInstance();
     auto& automationManager = AutomationManager::getInstance();
-    auto trackId = trackManager.createTrack("Automation Section IDs", TrackType::Audio);
+    auto trackId = trackManager.createTrack("Automation Section IDs", TrackType::Media);
 
     DeviceInfo fx;
     fx.name = "FX";
@@ -2321,7 +2321,7 @@ TEST_CASE("ParameterInfo display metadata roundtrip", "[project][serialization][
     ProjectTestFixture fixture;
 
     auto& trackManager = TrackManager::getInstance();
-    auto trackId = trackManager.createTrack("Parameter Track", TrackType::Audio);
+    auto trackId = trackManager.createTrack("Parameter Track", TrackType::Media);
 
     ParameterInfo param;
     param.paramIndex = 12;
@@ -2430,7 +2430,7 @@ TEST_CASE("ParameterInfo display metadata roundtrip", "[project][serialization][
 TEST_CASE("MIDI controller curve metadata roundtrip", "[project][serialization][midi]") {
     ProjectTestFixture fixture;
 
-    auto trackId = TrackManager::getInstance().createTrack("MIDI", TrackType::Audio);
+    auto trackId = TrackManager::getInstance().createTrack("MIDI", TrackType::Media);
 
     ClipInfo clip;
     clip.id = 51;
@@ -2560,7 +2560,7 @@ TEST_CASE("Saved automation targets keep the flag that makes a track path valid"
     automation.clearAll();
     tracks.clearAllTracks();
 
-    const auto trackId = tracks.createTrack("Bass", TrackType::Audio);
+    const auto trackId = tracks.createTrack("Bass", TrackType::Media);
 
     AutomationTarget target;
     target.kind = ControlTarget::Kind::TrackVolume;

--- a/tests/test_remote_model_bridge.cpp
+++ b/tests/test_remote_model_bridge.cpp
@@ -55,7 +55,7 @@ TEST_CASE("A track created outside the remote API reaches subscribers", "[remote
     // The case the bridge exists for: this is what the MAGDA UI does, with no
     // remote client involved. Without the bridge a subscriber would never hear
     // about it.
-    TrackManager::getInstance().createTrack("From the UI", TrackType::Audio);
+    TrackManager::getInstance().createTrack("From the UI", TrackType::Media);
     fixture.service.changes().flush();
 
     REQUIRE(fixture.sawTopic(Topic::Tracks));
@@ -69,7 +69,7 @@ TEST_CASE("A locally committed change makes a client's expected revision stale",
     // A client reads the revision, the user then edits in the UI, and the
     // client's write must not silently land on changed state.
     const auto clientView = fixture.service.currentRevision();
-    TrackManager::getInstance().createTrack("Meanwhile", TrackType::Audio);
+    TrackManager::getInstance().createTrack("Meanwhile", TrackType::Media);
 
     auto context = fullyGrantedContext();
     context.expectedRevision = clientView;
@@ -89,7 +89,7 @@ TEST_CASE("A locally committed change makes a client's expected revision stale",
 
 TEST_CASE("Device notifications land on the devices topic", "[remote][bridge]") {
     BridgeFixture fixture;
-    const auto trackId = TrackManager::getInstance().createTrack("FX", TrackType::Audio);
+    const auto trackId = TrackManager::getInstance().createTrack("FX", TrackType::Media);
     fixture.service.changes().flush();
     fixture.seen.clear();
 
@@ -101,7 +101,7 @@ TEST_CASE("Device notifications land on the devices topic", "[remote][bridge]") 
 
 TEST_CASE("A burst of model notifications coalesces to one delivery", "[remote][bridge]") {
     BridgeFixture fixture;
-    const auto trackId = TrackManager::getInstance().createTrack("Busy", TrackType::Audio);
+    const auto trackId = TrackManager::getInstance().createTrack("Busy", TrackType::Media);
     fixture.service.changes().flush();
     fixture.seen.clear();
 
@@ -125,7 +125,7 @@ TEST_CASE("Destroying the bridge detaches it from the model", "[remote][bridge][
     fixture.seen.clear();
 
     // Must not notify, and must not touch the destroyed listener.
-    TrackManager::getInstance().createTrack("After detach", TrackType::Audio);
+    TrackManager::getInstance().createTrack("After detach", TrackType::Media);
     fixture.service.changes().flush();
 
     REQUIRE(fixture.seen.empty());
@@ -151,7 +151,7 @@ TEST_CASE("A shut-down service ignores model notifications", "[remote][bridge][l
     fixture.service.shutdown();
     fixture.seen.clear();
 
-    TrackManager::getInstance().createTrack("After shutdown", TrackType::Audio);
+    TrackManager::getInstance().createTrack("After shutdown", TrackType::Media);
     fixture.service.changes().flush();
 
     REQUIRE(fixture.seen.empty());
@@ -164,7 +164,7 @@ TEST_CASE("Clip and track notifications also invalidate the session grid", "[rem
     // The session grid is projected out of the clips and keyed by track, so a
     // subscriber watching only `session` has to hear about both. Marking only
     // the obvious topic would leave it showing a grid the project no longer has.
-    TrackManager::getInstance().createTrack("Drums", TrackType::Audio);
+    TrackManager::getInstance().createTrack("Drums", TrackType::Media);
     ClipManager::getInstance().clearAllClips();
     fixture.service.changes().flush();
 

--- a/tests/test_remote_service_live_juce.cpp
+++ b/tests/test_remote_service_live_juce.cpp
@@ -99,7 +99,7 @@ class RemoteServiceLiveTest final : public juce::UnitTest {
             const auto before = fixture.service.currentRevision();
             // Not routed through the dispatcher, so the re-entrancy guard must
             // not suppress it — this is what the bridge exists for.
-            TrackManager::getInstance().createTrack("By hand", TrackType::Audio);
+            TrackManager::getInstance().createTrack("By hand", TrackType::Media);
             expect(fixture.service.currentRevision() > before);
         }
 
@@ -107,7 +107,7 @@ class RemoteServiceLiveTest final : public juce::UnitTest {
         {
             Fixture fixture;
             const auto trackId =
-                TrackManager::getInstance().createTrack("Automated", TrackType::Audio);
+                TrackManager::getInstance().createTrack("Automated", TrackType::Media);
             const auto before = fixture.service.currentRevision();
 
             {
@@ -328,7 +328,7 @@ class RemoteServiceLiveTest final : public juce::UnitTest {
         {
             Fixture fixture;
             const auto trackId =
-                TrackManager::getInstance().createTrack("Device host", TrackType::Audio);
+                TrackManager::getInstance().createTrack("Device host", TrackType::Media);
 
             auto* path = new juce::DynamicObject();
             path->setProperty("trackId", static_cast<int>(trackId));
@@ -407,7 +407,7 @@ class RemoteServiceLiveTest final : public juce::UnitTest {
     };
 
     static AutomationLaneId createLane(AutomationLaneType type) {
-        const auto trackId = TrackManager::getInstance().createTrack("Auto", TrackType::Audio);
+        const auto trackId = TrackManager::getInstance().createTrack("Auto", TrackType::Media);
         AutomationTarget target;
         target.kind = ControlTarget::Kind::TrackVolume;
         target.devicePath = ChainNodePath::trackLevel(trackId);

--- a/tests/test_remote_subscriptions.cpp
+++ b/tests/test_remote_subscriptions.cpp
@@ -133,7 +133,7 @@ TrackInfo makeTrack(TrackId id, const juce::String& name) {
     TrackInfo track;
     track.id = id;
     track.name = name;
-    track.type = TrackType::Audio;
+    track.type = TrackType::Media;
     return track;
 }
 

--- a/tests/test_remote_websocket_live_juce.cpp
+++ b/tests/test_remote_websocket_live_juce.cpp
@@ -135,7 +135,7 @@ class RemoteWebSocketLiveTest final : public juce::UnitTest {
 
             // Not through the API — this is the user doing something in MAGDA
             // while a client is connected, which is what the model bridge is for.
-            TrackManager::getInstance().createTrack("By hand", TrackType::Audio);
+            TrackManager::getInstance().createTrack("By hand", TrackType::Media);
 
             const auto reply = fixture.exchange(requestJson("tracks.list", object({})));
             const auto* tracks = reply["result"].getArray();
@@ -158,7 +158,7 @@ class RemoteWebSocketLiveTest final : public juce::UnitTest {
             // pump — and the hop from a model listener to a socket write — is
             // actually exercised.
             const auto pushed = fixture.subscribeThenObserve({"tracks"}, [] {
-                TrackManager::getInstance().createTrack("By hand", TrackType::Audio);
+                TrackManager::getInstance().createTrack("By hand", TrackType::Media);
             });
 
             expect(pushed["method"].toString() == "subscriptions.event");

--- a/tests/test_render_plan_compiler.cpp
+++ b/tests/test_render_plan_compiler.cpp
@@ -18,7 +18,7 @@ using magda::engine::RenderPlan;
 
 namespace {
 
-TrackInfo makeTrack(TrackId id, TrackType type = TrackType::Audio) {
+TrackInfo makeTrack(TrackId id, TrackType type = TrackType::Media) {
     TrackInfo track;
     track.id = id;
     track.type = type;

--- a/tests/test_render_plan_executor.cpp
+++ b/tests/test_render_plan_executor.cpp
@@ -58,7 +58,7 @@ std::int64_t timelineSampleOf(const BlockInfo& block) {
     return std::llround(block.startBeat * kSamplesPerBeat);
 }
 
-TrackInfo makeTrack(TrackId id, TrackType type = TrackType::Audio) {
+TrackInfo makeTrack(TrackId id, TrackType type = TrackType::Media) {
     TrackInfo track;
     track.id = id;
     track.type = type;

--- a/tests/test_repaint_invariance_juce.cpp
+++ b/tests/test_repaint_invariance_juce.cpp
@@ -160,7 +160,7 @@ class RepaintInvarianceTests : public juce::UnitTest {
             // The ghost outlines in the report were the lane border: drawn
             // around the damaged rectangle, it boxed in the clip's old bounds.
             PaintFixture fixture;
-            TrackManager::getInstance().createTrack("Lane", TrackType::Audio);
+            TrackManager::getInstance().createTrack("Lane", TrackType::Media);
             fixture.panel.tracksChanged();
             fixture.panel.setSize(400, 200);
 

--- a/tests/test_selection_manager_listeners.cpp
+++ b/tests/test_selection_manager_listeners.cpp
@@ -35,9 +35,9 @@ TEST_CASE("SelectionManager - clip range selection follows visible track order",
     tm.clearAllTracks();
     sm.clearSelection();
 
-    TrackId firstCreated = tm.createTrack("First", TrackType::Audio);
-    TrackId secondCreated = tm.createTrack("Second", TrackType::Audio);
-    TrackId thirdCreated = tm.createTrack("Third", TrackType::Audio);
+    TrackId firstCreated = tm.createTrack("First", TrackType::Media);
+    TrackId secondCreated = tm.createTrack("Second", TrackType::Media);
+    TrackId thirdCreated = tm.createTrack("Third", TrackType::Media);
 
     tm.moveTrack(thirdCreated, 0);
 
@@ -75,7 +75,7 @@ TEST_CASE("SelectionManager - note range selection uses anchored time and pitch 
     tm.clearAllTracks();
     sm.clearSelection();
 
-    TrackId trackId = tm.createTrack("Notes", TrackType::Audio);
+    TrackId trackId = tm.createTrack("Notes", TrackType::Media);
     ClipId clipId = cm.createMidiClip(trackId, 0.0, 8.0, ClipView::Arrangement);
     auto* clip = cm.getClip(clipId);
     REQUIRE(clip != nullptr);
@@ -119,8 +119,8 @@ TEST_CASE("SelectionManager - track toggle ignores stale track set from other se
     tm.clearAllTracks();
     sm.clearSelection();
 
-    TrackId first = tm.createTrack("First", TrackType::Audio);
-    TrackId second = tm.createTrack("Second", TrackType::Audio);
+    TrackId first = tm.createTrack("First", TrackType::Media);
+    TrackId second = tm.createTrack("Second", TrackType::Media);
     ClipId clipId = cm.createMidiClip(first, 0.0, 2.0, ClipView::Arrangement);
 
     sm.selectTrack(first);
@@ -147,8 +147,8 @@ TEST_CASE("SelectionManager - track and clip multi-selections are mutually exclu
     tm.clearAllTracks();
     sm.clearSelection();
 
-    TrackId trackA = tm.createTrack("A", TrackType::Audio);
-    TrackId trackB = tm.createTrack("B", TrackType::Audio);
+    TrackId trackA = tm.createTrack("A", TrackType::Media);
+    TrackId trackB = tm.createTrack("B", TrackType::Media);
     ClipId clipA = cm.createMidiClip(trackA, 0.0, 2.0, ClipView::Arrangement);
     ClipId clipB = cm.createMidiClip(trackA, 2.0, 2.0, ClipView::Arrangement);
 

--- a/tests/test_sends_and_track_deletion.cpp
+++ b/tests/test_sends_and_track_deletion.cpp
@@ -25,7 +25,7 @@ struct SendsTestFixture {
     }
 
     TrackId createTrack(const juce::String& name = "Track") {
-        return tm().createTrack(name, TrackType::Audio);
+        return tm().createTrack(name, TrackType::Media);
     }
 };
 

--- a/tests/test_track_api_nested_racks.cpp
+++ b/tests/test_track_api_nested_racks.cpp
@@ -39,7 +39,7 @@ struct TopLevel {
 
 TopLevel makeTopLevel(MockMagdaApi& api) {
     TopLevel built;
-    built.track = api.tracks().createTrack("Bus", TrackType::Audio);
+    built.track = api.tracks().createTrack("Bus", TrackType::Media);
     built.rack = api.tracks().addRackToTrack(built.track, "Outer");
     REQUIRE(built.rack != INVALID_RACK_ID);
 

--- a/tests/test_track_api_nested_racks_live_juce.cpp
+++ b/tests/test_track_api_nested_racks_live_juce.cpp
@@ -29,7 +29,7 @@ class TrackApiNestedRacksLiveTest final : public juce::UnitTest {
             Fixture fixture;
             TrackApiLive api;
 
-            const auto track = api.createTrack("Bus", TrackType::Audio);
+            const auto track = api.createTrack("Bus", TrackType::Media);
             const auto outerRack = api.addRackToTrack(track, "Outer");
             expect(outerRack != INVALID_RACK_ID);
 
@@ -79,7 +79,7 @@ class TrackApiNestedRacksLiveTest final : public juce::UnitTest {
             Fixture fixture;
             TrackApiLive api;
 
-            const auto track = api.createTrack("Bus", TrackType::Audio);
+            const auto track = api.createTrack("Bus", TrackType::Media);
             const auto outerRack = api.addRackToTrack(track, "Outer");
             const auto outerRackPath = ChainNodePath::rack(track, outerRack);
             const auto outerChainPath =
@@ -114,7 +114,7 @@ class TrackApiNestedRacksLiveTest final : public juce::UnitTest {
             Fixture fixture;
             TrackApiLive api;
 
-            const auto track = api.createTrack("Bus", TrackType::Audio);
+            const auto track = api.createTrack("Bus", TrackType::Media);
             const auto rackId = api.addRackToTrack(track, "Outer");
             const auto rackPath = ChainNodePath::rack(track, rackId);
             const auto chainId = api.getRackByPath(rackPath)->chains.front().id;
@@ -135,7 +135,7 @@ class TrackApiNestedRacksLiveTest final : public juce::UnitTest {
             Fixture fixture;
             TrackApiLive api;
 
-            const auto track = api.createTrack("Bus", TrackType::Audio);
+            const auto track = api.createTrack("Bus", TrackType::Media);
             const auto rackId = api.addRackToTrack(track, "Outer");
             const auto rackPath = ChainNodePath::rack(track, rackId);
             const auto chainId = api.getRackByPath(rackPath)->chains.front().id;
@@ -203,7 +203,7 @@ class TrackApiNestedRacksLiveTest final : public juce::UnitTest {
             Fixture fixture;
             TrackApiLive api;
 
-            const auto track = api.createTrack("Bus", TrackType::Audio);
+            const auto track = api.createTrack("Bus", TrackType::Media);
             const auto rackA = api.addRackToTrack(track, "A");
             const auto rackB = api.addRackToTrack(track, "B");
             const auto pathA = ChainNodePath::rack(track, rackA);
@@ -278,7 +278,7 @@ class TrackApiNestedRacksLiveTest final : public juce::UnitTest {
             TrackManager& model = TrackManager::getInstance();
             TrackApiLive api;
 
-            const auto track = api.createTrack("Bus", TrackType::Audio);
+            const auto track = api.createTrack("Bus", TrackType::Media);
             const auto rackId = api.addRackToTrack(track, "Outer");
             const auto rackPath = ChainNodePath::rack(track, rackId);
             const auto chain1 = api.getRackByPath(rackPath)->chains.front().id;

--- a/tests/test_track_level_control_writes.cpp
+++ b/tests/test_track_level_control_writes.cpp
@@ -69,7 +69,7 @@ TEST_CASE("track volume writes do not leak into the master channel", "[controlle
     auto& tm = TrackManager::getInstance();
 
     const float masterBefore = tm.getMasterChannel().volume;
-    const TrackId id = tm.createTrack("Drums", TrackType::Audio);
+    const TrackId id = tm.createTrack("Drums", TrackType::Media);
     tm.setTrackVolume(id, 0.25f);
 
     const auto* track = tm.getTrack(id);

--- a/tests/test_track_reorder.cpp
+++ b/tests/test_track_reorder.cpp
@@ -22,9 +22,9 @@ struct ReorderFixture {
 
 TEST_CASE("moveTrackToPosition reorders top-level tracks", "[tracks][reorder]") {
     ReorderFixture fx;
-    auto a = fx.tm().createTrack("A", TrackType::Audio);
-    auto b = fx.tm().createTrack("B", TrackType::Audio);
-    auto c = fx.tm().createTrack("C", TrackType::Audio);
+    auto a = fx.tm().createTrack("A", TrackType::Media);
+    auto b = fx.tm().createTrack("B", TrackType::Media);
+    auto c = fx.tm().createTrack("C", TrackType::Media);
 
     SECTION("move last to the front") {
         fx.tm().moveTrackToPosition(c, 1);
@@ -49,9 +49,9 @@ TEST_CASE("moveTrackToPosition reorders top-level tracks", "[tracks][reorder]") 
 
 TEST_CASE("moveTrackToPosition reorders within a group, not across", "[tracks][reorder][group]") {
     ReorderFixture fx;
-    auto k = fx.tm().createTrack("Kick", TrackType::Audio);
-    auto s = fx.tm().createTrack("Snare", TrackType::Audio);
-    auto h = fx.tm().createTrack("Hat", TrackType::Audio);
+    auto k = fx.tm().createTrack("Kick", TrackType::Media);
+    auto s = fx.tm().createTrack("Snare", TrackType::Media);
+    auto h = fx.tm().createTrack("Hat", TrackType::Media);
 
     auto group = fx.tm().groupTracks({k, s, h}, "Drums");
     REQUIRE(group != INVALID_TRACK_ID);
@@ -71,9 +71,9 @@ TEST_CASE("MoveTrackCommand reorders and undo restores the original position",
           "[tracks][reorder][undo]") {
     ReorderFixture fx;
     UndoManager::getInstance().clearHistory();
-    auto a = fx.tm().createTrack("A", TrackType::Audio);
-    auto b = fx.tm().createTrack("B", TrackType::Audio);
-    auto c = fx.tm().createTrack("C", TrackType::Audio);
+    auto a = fx.tm().createTrack("A", TrackType::Media);
+    auto b = fx.tm().createTrack("B", TrackType::Media);
+    auto c = fx.tm().createTrack("C", TrackType::Media);
 
     UndoManager::getInstance().executeCommand(std::make_unique<MoveTrackCommand>(c, 1));
     REQUIRE(fx.tm().getTopLevelTracks() == std::vector<TrackId>{c, a, b});
@@ -89,9 +89,9 @@ TEST_CASE("MoveTrackCommand reorders and undo restores the original position",
 TEST_CASE("GroupTracksCommand / UngroupTrackCommand round-trip", "[tracks][group][undo]") {
     ReorderFixture fx;
     UndoManager::getInstance().clearHistory();
-    auto a = fx.tm().createTrack("A", TrackType::Audio);
-    auto b = fx.tm().createTrack("B", TrackType::Audio);
-    auto c = fx.tm().createTrack("C", TrackType::Audio);
+    auto a = fx.tm().createTrack("A", TrackType::Media);
+    auto b = fx.tm().createTrack("B", TrackType::Media);
+    auto c = fx.tm().createTrack("C", TrackType::Media);
 
     SECTION("group, undo dissolves, redo regroups") {
         UndoManager::getInstance().executeCommand(
@@ -122,9 +122,9 @@ TEST_CASE("GroupTracksCommand / UngroupTrackCommand round-trip", "[tracks][group
 
 TEST_CASE("getTrackSiblingPosition is 1-based among siblings", "[tracks][reorder]") {
     ReorderFixture fx;
-    auto a = fx.tm().createTrack("A", TrackType::Audio);
-    auto b = fx.tm().createTrack("B", TrackType::Audio);
-    auto c = fx.tm().createTrack("C", TrackType::Audio);
+    auto a = fx.tm().createTrack("A", TrackType::Media);
+    auto b = fx.tm().createTrack("B", TrackType::Media);
+    auto c = fx.tm().createTrack("C", TrackType::Media);
 
     REQUIRE(fx.tm().getTrackSiblingPosition(a) == 1);
     REQUIRE(fx.tm().getTrackSiblingPosition(c) == 3);

--- a/tests/test_track_type_traits.cpp
+++ b/tests/test_track_type_traits.cpp
@@ -132,8 +132,10 @@ TEST_CASE("A track answers for itself what its type declares", "[track][types]")
     CHECK(track.acceptsUserClip(ClipType::MIDI));
     CHECK_FALSE(track.acceptsUserClip(ClipType::Audio));
 
-    // A progression is a MIDI clip, so the type-level answer is yes and the
-    // content check happens at the drop, where the file can be read.
+    // A progression is a MIDI clip, so the chord lane says yes to MIDI. What
+    // makes the lane typed is what the import does with it -- a .mid without
+    // CHORD: markers has its chords detected on the way in -- rather than a
+    // refusal at the door.
     track.type = TrackType::Chord;
     CHECK(track.acceptsUserClip(ClipType::MIDI));
     CHECK_FALSE(track.acceptsUserClip(ClipType::Audio));

--- a/tests/test_track_type_traits.cpp
+++ b/tests/test_track_type_traits.cpp
@@ -1,0 +1,121 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "magda/daw/core/TrackInfo.hpp"
+#include "magda/daw/core/TrackTypes.hpp"
+
+/**
+ * What each track type is (#2172 and what it exposed).
+ *
+ * The enum used to be answered by exclusion: sixteen call sites across the app
+ * each kept their own list of types that could not do a thing, no two lists
+ * agreed, and a file drop and a clip drag ended up holding different views of
+ * where a clip was allowed to go. The table in TrackTypes.hpp replaces those
+ * lists, so this pins the table.
+ *
+ * Written as the facts rather than as a copy of traitsOf(): asserting the
+ * function against itself would pass whatever it was changed to. Each
+ * expectation below is a sentence somebody could disagree with.
+ */
+
+using namespace magda;
+
+TEST_CASE("A Media track is the one that carries material", "[track][types]") {
+    const auto media = traitsOf(TrackType::Media);
+
+    // The hybrid track, and the only one a user puts clips on directly.
+    CHECK(media.hasTimeline);
+    CHECK(media.acceptsUserClips);
+    CHECK(media.takesExternalInput);
+    CHECK(media.hostsInstrument);
+    CHECK(media.occupiesArrangementRow);
+    CHECK(media.isRendered);
+
+    // It is an ordinary track: the user makes as many as they like, and
+    // nothing else owns its lifetime.
+    CHECK_FALSE(media.isSingleton);
+    CHECK_FALSE(media.isDeviceOwned);
+    CHECK_FALSE(media.canHaveChildren);
+
+    // Nothing about the enum says what kind of material it holds, because it
+    // holds both. This is the fact the old name denied: `Audio` was the
+    // survivor of Instrument and MIDI collapsing into one track, and the
+    // ordinals those two used are still skipped rather than reused.
+    //
+    // The ordinals themselves are pinned in test_persisted_enum_pins.cpp,
+    // which fails the build rather than the test. What is asserted here is
+    // where the retired two land, since that is a decision about meaning
+    // rather than about the wire.
+    CHECK(trackTypeFromInt(1) == TrackType::Media);
+    CHECK(trackTypeFromInt(2) == TrackType::Media);
+}
+
+TEST_CASE("Buses carry signal from elsewhere and originate none", "[track][types]") {
+    for (const auto type : {TrackType::Group, TrackType::Aux, TrackType::Master}) {
+        const auto bus = traitsOf(type);
+        INFO("track type " << getTrackTypeName(type));
+
+        CHECK_FALSE(bus.hasTimeline);
+        CHECK_FALSE(bus.acceptsUserClips);
+        CHECK_FALSE(bus.hostsInstrument);
+    }
+
+    // Where the three differ. A group sums children it owns; an aux is fed by
+    // sends and has no arrangement row of its own because it lives in the aux
+    // strip; the master is the one output and takes input like a media track.
+    CHECK(traitsOf(TrackType::Group).canHaveChildren);
+    CHECK_FALSE(traitsOf(TrackType::Aux).canHaveChildren);
+
+    CHECK(traitsOf(TrackType::Group).occupiesArrangementRow);
+    CHECK_FALSE(traitsOf(TrackType::Aux).occupiesArrangementRow);
+
+    CHECK(traitsOf(TrackType::Master).isSingleton);
+    CHECK(traitsOf(TrackType::Master).takesExternalInput);
+}
+
+TEST_CASE("A timeline is not permission to put a clip on it", "[track][types]") {
+    // The distinction the old exclusion lists kept getting wrong. Both of these
+    // have lanes with clips on them, and neither takes a clip the user aims at
+    // it: a chord track's clips are progressions, so an ordinary MIDI clip
+    // landing there would change what the track means, and a multi-out lane is
+    // erased with its device's output pair without its clips going too.
+    for (const auto type : {TrackType::Chord, TrackType::MultiOut}) {
+        INFO("track type " << getTrackTypeName(type));
+        CHECK(traitsOf(type).hasTimeline);
+        CHECK_FALSE(traitsOf(type).acceptsUserClips);
+    }
+
+    CHECK(traitsOf(TrackType::MultiOut).isDeviceOwned);
+    CHECK(traitsOf(TrackType::Chord).isSingleton);
+
+    // Monitor-only: it auditions chords and is left out of the mix.
+    CHECK_FALSE(traitsOf(TrackType::Chord).isRendered);
+    CHECK(traitsOf(TrackType::Media).isRendered);
+}
+
+TEST_CASE("Exactly one track type accepts a clip the user aims at it", "[track][types]") {
+    // Stated as a count rather than per type, because this is the property the
+    // drop, the drag and the nudge each have to agree on, and the way they
+    // disagreed before was by one of them admitting one type too many.
+    int accepting = 0;
+    for (const auto type : {TrackType::Media, TrackType::Group, TrackType::Aux, TrackType::Master,
+                            TrackType::MultiOut, TrackType::Chord})
+        if (traitsOf(type).acceptsUserClips)
+            ++accepting;
+
+    CHECK(accepting == 1);
+}
+
+TEST_CASE("A track answers for itself what its type declares", "[track][types]") {
+    // The predicates on TrackInfo are the same table, so a track and its type
+    // can never give different answers.
+    TrackInfo track;
+    track.type = TrackType::Aux;
+    CHECK_FALSE(track.takesExternalInput());
+    CHECK_FALSE(track.canHostInstrument());
+    CHECK_FALSE(track.acceptsUserClips());
+
+    track.type = TrackType::Media;
+    CHECK(track.takesExternalInput());
+    CHECK(track.canHostInstrument());
+    CHECK(track.acceptsUserClips());
+}

--- a/tests/test_track_type_traits.cpp
+++ b/tests/test_track_type_traits.cpp
@@ -24,7 +24,7 @@ TEST_CASE("A Media track is the one that carries material", "[track][types]") {
 
     // The hybrid track, and the only one a user puts clips on directly.
     CHECK(media.hasTimeline);
-    CHECK(media.acceptsUserClips);
+    CHECK(media.userClips == UserClipAcceptance::Any);
     CHECK(media.takesExternalInput);
     CHECK(media.hostsInstrument);
     CHECK(media.occupiesArrangementRow);
@@ -55,7 +55,7 @@ TEST_CASE("Buses carry signal from elsewhere and originate none", "[track][types
         INFO("track type " << getTrackTypeName(type));
 
         CHECK_FALSE(bus.hasTimeline);
-        CHECK_FALSE(bus.acceptsUserClips);
+        CHECK(bus.userClips == UserClipAcceptance::None);
         CHECK_FALSE(bus.hostsInstrument);
     }
 
@@ -72,19 +72,23 @@ TEST_CASE("Buses carry signal from elsewhere and originate none", "[track][types
     CHECK(traitsOf(TrackType::Master).takesExternalInput);
 }
 
-TEST_CASE("A timeline is not permission to put a clip on it", "[track][types]") {
-    // The distinction the old exclusion lists kept getting wrong. Both of these
-    // have lanes with clips on them, and neither takes a clip the user aims at
-    // it: a chord track's clips are progressions, so an ordinary MIDI clip
-    // landing there would change what the track means, and a multi-out lane is
-    // erased with its device's output pair without its clips going too.
-    for (const auto type : {TrackType::Chord, TrackType::MultiOut}) {
-        INFO("track type " << getTrackTypeName(type));
-        CHECK(traitsOf(type).hasTimeline);
-        CHECK_FALSE(traitsOf(type).acceptsUserClips);
-    }
+TEST_CASE("A lane can be typed without being closed", "[track][types]") {
+    // The distinction the old exclusion lists could not express, so they
+    // refused both of these outright. Each has a lane, and each takes one
+    // particular thing rather than anything aimed at it.
 
+    // MIDI on a multi-out lane plays the parent instrument, which is what
+    // MidiInputRouter already does with live input arriving there. Audio has
+    // nothing to do on one.
+    CHECK(traitsOf(TrackType::MultiOut).hasTimeline);
+    CHECK(traitsOf(TrackType::MultiOut).userClips == UserClipAcceptance::MidiOnly);
     CHECK(traitsOf(TrackType::MultiOut).isDeviceOwned);
+
+    // The chord track holds progressions. Dropping one on it is the obvious
+    // gesture and has to work; an ordinary MIDI clip would change what the
+    // track means.
+    CHECK(traitsOf(TrackType::Chord).hasTimeline);
+    CHECK(traitsOf(TrackType::Chord).userClips == UserClipAcceptance::Progressions);
     CHECK(traitsOf(TrackType::Chord).isSingleton);
 
     // Monitor-only: it auditions chords and is left out of the mix.
@@ -92,17 +96,16 @@ TEST_CASE("A timeline is not permission to put a clip on it", "[track][types]") 
     CHECK(traitsOf(TrackType::Media).isRendered);
 }
 
-TEST_CASE("Exactly one track type accepts a clip the user aims at it", "[track][types]") {
-    // Stated as a count rather than per type, because this is the property the
-    // drop, the drag and the nudge each have to agree on, and the way they
-    // disagreed before was by one of them admitting one type too many.
-    int accepting = 0;
+TEST_CASE("Only the Media track takes whatever is aimed at it", "[track][types]") {
+    // The property the drop, the drag and the nudge each have to agree on. The
+    // way they disagreed before was by one of them admitting a type the others
+    // refused, so this is stated over every type rather than for one.
     for (const auto type : {TrackType::Media, TrackType::Group, TrackType::Aux, TrackType::Master,
-                            TrackType::MultiOut, TrackType::Chord})
-        if (traitsOf(type).acceptsUserClips)
-            ++accepting;
-
-    CHECK(accepting == 1);
+                            TrackType::MultiOut, TrackType::Chord}) {
+        INFO("track type " << getTrackTypeName(type));
+        const bool takesEverything = traitsOf(type).userClips == UserClipAcceptance::Any;
+        CHECK(takesEverything == (type == TrackType::Media));
+    }
 }
 
 TEST_CASE("A track answers for itself what its type declares", "[track][types]") {
@@ -112,10 +115,26 @@ TEST_CASE("A track answers for itself what its type declares", "[track][types]")
     track.type = TrackType::Aux;
     CHECK_FALSE(track.takesExternalInput());
     CHECK_FALSE(track.canHostInstrument());
-    CHECK_FALSE(track.acceptsUserClips());
+    CHECK_FALSE(track.acceptsAnyUserClip());
+    CHECK_FALSE(track.acceptsUserClip(ClipType::Audio));
+    CHECK_FALSE(track.acceptsUserClip(ClipType::MIDI));
 
     track.type = TrackType::Media;
     CHECK(track.takesExternalInput());
     CHECK(track.canHostInstrument());
-    CHECK(track.acceptsUserClips());
+    CHECK(track.acceptsUserClip(ClipType::Audio));
+    CHECK(track.acceptsUserClip(ClipType::MIDI));
+
+    // The kind is the question, not the track. A multi-out lane takes the MIDI
+    // that plays its parent instrument and refuses the audio that has nowhere
+    // to go, and answering yes or no for the whole track could say neither.
+    track.type = TrackType::MultiOut;
+    CHECK(track.acceptsUserClip(ClipType::MIDI));
+    CHECK_FALSE(track.acceptsUserClip(ClipType::Audio));
+
+    // A progression is a MIDI clip, so the type-level answer is yes and the
+    // content check happens at the drop, where the file can be read.
+    track.type = TrackType::Chord;
+    CHECK(track.acceptsUserClip(ClipType::MIDI));
+    CHECK_FALSE(track.acceptsUserClip(ClipType::Audio));
 }

--- a/tests/test_track_type_traits.cpp
+++ b/tests/test_track_type_traits.cpp
@@ -1,5 +1,6 @@
 #include <catch2/catch_test_macros.hpp>
 
+#include "magda/daw/core/ClipPlacementPolicy.hpp"
 #include "magda/daw/core/TrackInfo.hpp"
 #include "magda/daw/core/TrackTypes.hpp"
 
@@ -139,4 +140,39 @@ TEST_CASE("A track answers for itself what its type declares", "[track][types]")
     track.type = TrackType::Chord;
     CHECK(track.acceptsUserClip(ClipType::MIDI));
     CHECK_FALSE(track.acceptsUserClip(ClipType::Audio));
+}
+
+TEST_CASE("Moving a clip asks what the clip is, not only what kind", "[track][types]") {
+    // The gap a kind-only check leaves. A chord lane accepts MIDI by kind,
+    // because a progression is a MIDI clip -- so a check that stopped at the
+    // kind would let any MIDI clip be dragged or nudged onto the chord track,
+    // where nothing would turn it into harmony. Detection happens on import,
+    // and a move is not an import.
+    TrackInfo chordTrack;
+    chordTrack.type = TrackType::Chord;
+
+    ClipInfo plainMidi;
+    plainMidi.content = MidiClipModel{};
+    CHECK(chordTrack.acceptsUserClip(ClipType::MIDI));     // by kind, yes
+    CHECK_FALSE(trackAcceptsClip(chordTrack, plainMidi));  // with the clip in hand, no
+
+    ClipInfo progression;
+    progression.content = MidiClipModel{};
+    progression.chordAnnotations.push_back({});
+    CHECK(trackAcceptsClip(chordTrack, progression));
+
+    // A multi-out lane has no such distinction: MIDI is MIDI there.
+    TrackInfo multiOut;
+    multiOut.type = TrackType::MultiOut;
+    CHECK(trackAcceptsClip(multiOut, plainMidi));
+
+    ClipInfo audio;
+    audio.content = AudioClipModel{};
+    CHECK_FALSE(trackAcceptsClip(multiOut, audio));
+
+    // And a bus takes neither, whatever the clip turns out to be.
+    TrackInfo group;
+    group.type = TrackType::Group;
+    CHECK_FALSE(trackAcceptsClip(group, audio));
+    CHECK_FALSE(trackAcceptsClip(group, progression));
 }


### PR DESCRIPTION
`TrackType` named a distinction that stopped existing, and the app has been paying for it at every call site.

## The name

`Audio`, `Instrument` and `MIDI` were three types until they collapsed into one hybrid track. The survivor kept the name `Audio`, so the enum read as a statement about *content* for years after it had stopped being one — `TrackTypes.hpp` documented this in a comment (`// Regular hybrid track`) rather than in the name. It is `Media` now.

The ordinals Instrument and MIDI used (1 and 2) stay skipped. They are written into every `.mgd` and pinned by `tests/test_persisted_enum_pins.cpp`, whose header explains the failure mode: *"an Aux track becomes a Master. Nothing complains, because the integer is still in range."* Closing the gap would renumber five types in every saved project, and `trackTypeFromInt` could not tell an old `3` from a new one without threading the schema version through. That `static_assert` is also what caught the rename mid-refactor, which is the gate working.

## The larger half

Because the enum said what a track was *called* rather than what it could *do*, every call site needing a capability derived it by listing the types that lacked it. There are sixteen such lists in `magda/daw` and no two agree:

- `takesExternalInput()` excludes two types, `canHostInstrument()` excludes three — each documented as "single source of truth".
- The file drop excluded Group and Aux. The clip drag and the keyboard nudge excluded those **plus** Master, Chord and MultiOut.

#2172 is what falls out of that: a Drum Grid track refused the MIDI files it was likeliest to want, while the identical clip could be dragged onto it from a neighbour.

Each type now declares its facts once, in `TrackTypeTraits`. Asking is a lookup. The switch filling the table has no `default`, so a track type added without declaring itself fails `-Wswitch` rather than silently inheriting whatever the first exclusion list omitted.

## What a lane takes

Having a lane is not the same as taking anything aimed at it, and the first pass of this got it wrong by using a bool — a bool can only sort tracks into Media and not-Media, and two lanes fall in between:

| Lane | Takes |
| --- | --- |
| Media | audio or MIDI |
| MultiOut | MIDI only — those notes play the parent instrument, the same way `MidiInputRouter` already routes live input arriving there to its parent. Audio has nothing to do on one. |
| Chord | chord progressions only — a `.mid` carrying `CHORD:` markers |
| Group, Aux, Master | nothing |

So `UserClipAcceptance` replaces the bool, and a track is asked what it takes **of a given kind**. A progressions lane answers yes to MIDI, because a progression *is* a MIDI clip; whether the material really is one is a question about content, asked at the drop, which is the only place holding the file.

A mixed drop now imports the kinds the track takes and says what it left, rather than refusing all of it because one file was the wrong kind — refusing everything over one file is the shape of the bug this PR removes.

The nudge asks with the selection in hand for the same reason: it moves the selection as one block, so a destination has to accept every kind in it.

## Behaviour changes

- **The Drum Grid gate is gone** — the same deletion as #2176, which targets `main` for the rc0 re-tag. Whichever lands second resolves to the same end state.
- **The file drop now refuses Group, Aux and Master**, and refuses audio on a multi-out lane. Previously it accepted all of them, and an audio clip dropped on a multi-out lane was orphaned the moment that output was switched off.
- **The nudge now allows MIDI onto a multi-out lane**, which it previously refused outright.
- `getTrackTypeName` returns `"Media"` rather than `"Audio"`. Visible to the agent DSL (`dsl_interpreter.cpp`) and the CLI; not a user-facing UI string.

## Verified

Full headless suite: 2910 passed, 13 skipped, 0 failed across 2923 cases. New `test_track_type_traits.cpp` states each type's facts as sentences rather than by re-reading `traitsOf()`, so it fails if the table is changed to something else rather than agreeing with whatever it becomes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
