### PR TITLE
Give an MCP host a bridge path that is still there next time (#1858)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -886,9 +886,10 @@ jobs:
           Write-Warning "magda_plugin_scanner.exe not found at $scanner"
         }
 
-        # The MCP bridge (#1858). An MCP host is configured with its absolute
-        # path, so it has to land in the install directory beside MAGDA.exe —
-        # that is the path the AI settings page tells the user to paste.
+        # The MCP bridge (#1858). Staged here for the installer to pick up; the
+        # installer puts it under %ProgramData%\MAGDA\bin rather than $INSTDIR,
+        # because a host that splits its configured command on whitespace chokes
+        # on the space in "C:\Program Files". See magda-installer.nsi.
         $mcpBridge = Join-Path $exeDir "magda-mcp.exe"
         if (Test-Path $mcpBridge) {
           Copy-Item $mcpBridge "$stage\magda-mcp.exe"
@@ -1137,10 +1138,11 @@ jobs:
           echo "Warning: magda_plugin_scanner not found"
         fi
 
-        # The MCP bridge (#1858), beside the binary like everywhere else so the
-        # AI settings page can name it. Also kept as a standalone release asset
-        # below: an AppImage is a single squashfs file, so a path inside it only
-        # exists while it is mounted and cannot go in an MCP host's config.
+        # The MCP bridge (#1858). An AppImage is a single squashfs file, so this
+        # path only exists while the image is mounted and cannot itself go in an
+        # MCP host's config. MAGDA copies it out to the data dir on first use and
+        # publishes that path instead, so shipping it inside is enough — see
+        # McpPage::stagedBridgeExecutable in ConnectionsDialog.cpp.
         MCP_BRIDGE=$(find build -name "magda-mcp" -type f -executable | head -1)
         if [ -n "$MCP_BRIDGE" ]; then
           echo "Found MCP bridge: $MCP_BRIDGE"
@@ -1248,23 +1250,6 @@ jobs:
         sha256sum "$APPIMAGE" > "${APPIMAGE}.sha256"
         cat "${APPIMAGE}.sha256"
 
-        # The MCP bridge ships separately on Linux because the AppImage cannot
-        # expose a stable path to anything inside it. Users drop this on their
-        # PATH and name it in their MCP host's config; it finds MAGDA through the
-        # discovery record either way, so it does not care where it lives.
-        MCP_BRIDGE=$(find build -name "magda-mcp" -type f -executable | head -1)
-        if [ -n "$MCP_BRIDGE" ]; then
-          cp "$MCP_BRIDGE" "magda-mcp-${VERSION}-Linux-x86_64"
-          chmod +x "magda-mcp-${VERSION}-Linux-x86_64"
-          sha256sum "magda-mcp-${VERSION}-Linux-x86_64" > "magda-mcp-${VERSION}-Linux-x86_64.sha256"
-          cat "magda-mcp-${VERSION}-Linux-x86_64.sha256"
-        else
-          # The asset Linux users are told to download, so its absence is the
-          # whole feature missing on that platform rather than a detail.
-          echo "::error::magda-mcp not found; the Linux MCP asset would be missing"
-          exit 1
-        fi
-
     - name: Upload artifact
       uses: actions/upload-artifact@v7
       with:
@@ -1272,8 +1257,6 @@ jobs:
         path: |
           MAGDA-*-Linux-x86_64.AppImage
           MAGDA-*-Linux-x86_64.AppImage.sha256
-          magda-mcp-*-Linux-x86_64
-          magda-mcp-*-Linux-x86_64.sha256
 
   create-release:
     # Publish a GitHub Release only for tag pushes. A workflow_dispatch run is

--- a/docs/remote-api-mcp.md
+++ b/docs/remote-api-mcp.md
@@ -113,25 +113,32 @@ without noticing.
 
 ### Where the bridge lives
 
-The build stages `magda-mcp` beside the MAGDA executable, which is the one
-location that means something on all three platforms:
+A host stores the bridge's absolute path once and launches it later, on its own
+schedule, with MAGDA possibly closed. So the path has to be permanent, and it has
+to survive whatever the host does to the string. Only macOS meets that with the
+copy staged beside MAGDA:
 
 | Platform | Path |
 |---|---|
 | macOS | `/Applications/MAGDA.app/Contents/MacOS/magda-mcp` |
-| Windows | `C:\Program Files\MAGDA\magda-mcp.exe` |
-| Linux | published as a **separate release asset**, `magda-mcp-<version>-Linux-x86_64` |
+| Windows | `C:\ProgramData\MAGDA\bin\magda-mcp.exe` |
+| Linux | `<data dir>/bin/magda-mcp`, staged on first use |
 
-Linux is the exception because an AppImage is a single squashfs file: a path
-inside it exists only while it is mounted, and a mount point is different every
-run, so nothing inside can go in a host's config. The bridge is in the AppImage
-too — beside the binary, for an extracted install — but the asset is what a user
-should point at. Drop it anywhere on `PATH`; it locates MAGDA through the
-discovery record and does not care where it was run from.
+**Windows** installs the bridge to `%ProgramData%` rather than `$INSTDIR`. Hosts
+disagree on whether a configured command is an argv array or a string they split
+on whitespace, and for the splitters the space in `C:\Program Files\MAGDA` breaks
+the command in two. `%ProgramData%` is a fixed name on every supported Windows and
+holds no user name, so it is space-free whoever is logged in.
 
-The settings page knows this: running from an AppImage it prints a placeholder
-and disables Copy rather than publishing its own `/tmp/.mount_…` path, which
-would stop existing the moment MAGDA quit.
+**Linux** ships the bridge inside the AppImage, which is a single squashfs file:
+a path inside it exists only while mounted, and the mount point differs every run.
+So the first time the MCP page is opened, MAGDA copies the bridge out to
+`<data dir>/bin/` and publishes that path. It re-copies whenever the staged binary
+stops matching the one in the image, so upgrading the AppImage upgrades the bridge.
+
+None of this moves the bridge away from MAGDA in any sense that matters — it
+locates a running instance through the discovery record, not by relative path, so
+it works from wherever it is run.
 
 It is signed on macOS and Windows in its own right, not just as part of the
 bundle. An MCP host launches it directly, so Gatekeeper and SmartScreen judge it

--- a/lang/en.json
+++ b/lang/en.json
@@ -501,7 +501,7 @@
     "mcp.status_off": "Not listening",
     "mcp.field_caption": "{0} host configuration",
     "mcp.hint": "Paste this into your {0} host's config. It stays correct across restarts: the helper it names finds {1}'s current port and token each time, so neither has to be written down.",
-    "mcp.bridge_missing": "Download magda-mcp from the {1} release and put it somewhere permanent, then replace the path below. It finds {1} on its own, so it works wherever you keep it.",
+    "mcp.bridge_missing": "{1} could not find magda-mcp. Reinstalling {1} puts it back; otherwise replace the path below with wherever you have it. It finds {1} on its own, so it works from anywhere.",
     "ws.blurb": "Lets a script, a control surface, or any other program drive this session over a {0}, and pushes changes back as they happen. It listens on this machine only, on its own port and with its own token.",
     "ws.enable": "Enable the {0} {1}",
     "ws.status_listening": "Listening on port {0}",

--- a/magda/daw/ui/dialogs/ConnectionsDialog.cpp
+++ b/magda/daw/ui/dialogs/ConnectionsDialog.cpp
@@ -5,6 +5,11 @@
 #include <utility>
 #include <vector>
 
+// For the access(X_OK) check on the staged bridge in McpPage.
+#if !JUCE_WINDOWS && !JUCE_MAC
+    #include <unistd.h>
+#endif
+
 #include "../../api/remote_api_host.hpp"
 #include "../../api/remote_audit.hpp"
 #include "../../api/remote_clients.hpp"
@@ -462,6 +467,14 @@ class McpPage : public TransportPage {
         return std::getenv("APPIMAGE") != nullptr || std::getenv("APPDIR") != nullptr;
     }
 
+    /// Whether this process could actually exec the file. `juce::File` can set
+    /// the execute bit but not ask about it, and the question here is the
+    /// effective one — owner, group, and mode together — which is what
+    /// `access(2)` answers.
+    static bool isExecutable(const juce::File& file) {
+        return ::access(file.getFullPathName().toRawUTF8(), X_OK) == 0;
+    }
+
     /**
      * @brief The AppImage's bridge, copied to a path that outlives the mount.
      *
@@ -472,8 +485,10 @@ class McpPage : public TransportPage {
      *
      * Re-staged whenever the copy no longer matches the binary in the mount, so
      * upgrading the AppImage upgrades the bridge without the user having to know
-     * a copy was ever made. Size plus modification time is enough to tell: the
-     * squashfs carries the build's timestamps, so a rebuild moves both.
+     * a copy was ever made. Size plus modification time identifies the build —
+     * the squashfs carries the build's timestamps, so a rebuild moves both — and
+     * the execute bit is checked alongside them, because a copy that is the
+     * right build but no longer runnable is no more use than a stale one.
      *
      * Returns {} if the copy cannot be made, which the page renders as its
      * "point this somewhere yourself" fallback rather than a path that will not
@@ -497,19 +512,44 @@ class McpPage : public TransportPage {
             return {};
 
         const auto staged = paths::dataDir().getChildFile("bin").getChildFile("magda-mcp");
+
+        // Size and mtime say it is the right build; the execute bit says a host
+        // can actually launch it. A restored backup, an rsync without -p, or a
+        // move across filesystems can preserve the first two and drop the third,
+        // and publishing a path that cannot be executed fails inside the host
+        // with nothing pointing back here. Repair the bit if it is ours to
+        // repair, and re-stage from scratch if it is not.
         if (staged.existsAsFile() && staged.getSize() == source.getSize() &&
-            staged.getLastModificationTime() == source.getLastModificationTime())
+            staged.getLastModificationTime() == source.getLastModificationTime() &&
+            (isExecutable(staged) || staged.setExecutePermission(true)))
             return staged;
 
         if (!staged.getParentDirectory().createDirectory())
             return {};
 
-        // JUCE's POSIX copy is a stream copy into a freshly created file: it
-        // carries neither the execute bit nor the timestamp, and this needs
-        // both — the first to run at all, the second so the next launch can tell
-        // this copy from the one a newer AppImage would bring.
-        if (!source.copyFileTo(staged) || !staged.setExecutePermission(true))
+        // Build the replacement beside the destination, then rename over it.
+        // JUCE's POSIX copy deletes the destination before it starts writing, so
+        // copying straight onto `staged` would throw away a working bridge to
+        // make room for one that might not finish — and that path is the one
+        // every already-configured host has been told to launch. rename(2)
+        // within a directory is atomic, so a host starting mid-upgrade gets
+        // either the old bridge or the new one, never a partial file.
+        const auto incoming = staged.getSiblingFile("magda-mcp.incoming").getNonexistentSibling();
+
+        // The copy is a stream copy into a fresh file, so it carries neither the
+        // execute bit nor the timestamp and both have to be put back: the first
+        // to run at all, the second so the next launch can tell this copy from
+        // the one a newer AppImage would bring.
+        if (!source.copyFileTo(incoming) || !incoming.setExecutePermission(true) ||
+            !incoming.moveFileTo(staged)) {
+            incoming.deleteFile();
             return {};
+        }
+
+        // Best-effort, and deliberately not a reason to fail: a filesystem that
+        // will not take a timestamp costs a re-stage on each launch, which is
+        // wasteful but works. Failing here would leave the user with no bridge
+        // at all over a field that only feeds the freshness check.
         staged.setLastModificationTime(source.getLastModificationTime());
 
         return staged;

--- a/magda/daw/ui/dialogs/ConnectionsDialog.cpp
+++ b/magda/daw/ui/dialogs/ConnectionsDialog.cpp
@@ -5,19 +5,13 @@
 #include <utility>
 #include <vector>
 
-// For the AppImage-safe /proc/self/exe lookup in RemoteApiPage::bridgeExecutable.
-#if !JUCE_WINDOWS && !JUCE_MAC
-    #include <unistd.h>
-
-    #include <climits>
-#endif
-
 #include "../../api/remote_api_host.hpp"
 #include "../../api/remote_audit.hpp"
 #include "../../api/remote_clients.hpp"
 #include "../themes/DarkTheme.hpp"
 #include "../themes/DialogLookAndFeel.hpp"
 #include "../themes/FontManager.hpp"
+#include "core/AppPaths.hpp"
 #include "core/Config.hpp"
 #include "core/StringTable.hpp"
 #include "core/TechnicalText.hpp"
@@ -395,21 +389,22 @@ class McpPage : public TransportPage {
     /**
      * @brief Where this install's bridge lives.
      *
-     * The same resolution `PluginScanCoordinator::getScannerExecutable()` uses,
-     * and for the same reasons — this is the second helper binary MAGDA stages
-     * beside itself, and "beside itself" means something different on each
-     * platform.
+     * A user pastes whatever this returns into their MCP host's config, so the
+     * requirement is stronger than "find the binary": the path has to still be
+     * valid tomorrow, in another process, with MAGDA closed. Two of the three
+     * platforms cannot meet that with the copy staged beside MAGDA, and each
+     * fails differently — see the branches below.
      *
-     * `paths::executableDir()` is deliberately not used: it is built on JUCE's
-     * `currentApplicationFile`, which for a bundled Mac app returns the `.app`
-     * itself, so its parent is `/Applications` rather than the directory holding
-     * the binary. And on Linux that same call goes through `dladdr`, which
-     * inside an AppImage yields the user's download folder rather than the
-     * mounted `usr/bin`.
+     * `appBundle` is only good enough for the fallbacks. `currentApplicationFile`
+     * returns the `.app` itself on macOS, so its parent is `/Applications` rather
+     * than the directory holding the binary; on Linux it resolves through
+     * `dladdr` to argv[0], which under an AppImage is the outer launcher. Where
+     * the real binary's directory is what's wanted, `paths::executableDir()`
+     * handles both.
      *
-     * A user pastes whatever this returns into their MCP host's config, so a
-     * plausible-but-wrong path is the worst outcome available: it fails at
-     * launch, inside another application, with no hint of where it came from.
+     * A plausible-but-wrong path is the worst outcome available here: it fails
+     * at launch, inside another application, with no hint of where it came from.
+     * Every branch returns something that exists or nothing at all.
      */
     static juce::File bridgeExecutable() {
         const auto appBundle = juce::File::getSpecialLocation(juce::File::currentApplicationFile);
@@ -422,37 +417,102 @@ class McpPage : public TransportPage {
         // Unbundled, as a console or test build produces.
         return appBundle.getParentDirectory().getChildFile("magda-mcp");
 #elif JUCE_WINDOWS
+        // Installed under %ProgramData%, deliberately not beside MAGDA.exe. The
+        // default install path is C:\Program Files\MAGDA, and an MCP host that
+        // splits its configured command on whitespace rather than taking an argv
+        // array turns that space into two broken arguments. %ProgramData% is a
+        // fixed name on every supported Windows and carries no user name, so it
+        // is space-free whoever is logged in.
+        if (const auto installed = commonDataBridge(); installed.existsAsFile())
+            return installed;
+        // A build tree, where the bridge is staged beside the host binary.
         return appBundle.getParentDirectory().getChildFile("magda-mcp.exe");
 #else
-        // Inside an AppImage there is no usable answer. The bridge is in there,
-        // under a /tmp/.mount_… path — but that mount is torn down when MAGDA
-        // exits and gets a different name every launch, so publishing it would
-        // hand the user a command that stops existing the moment they quit. The
-        // Linux release ships `magda-mcp` as its own asset for exactly this
-        // reason, and the page says so instead of guessing.
+        // Inside an AppImage the bridge is present, but only at a /tmp/.mount_…
+        // path: torn down when MAGDA exits, and named differently every launch.
+        // An MCP host stores an absolute path and runs it on its own schedule,
+        // so that path is worthless to it. Stage a copy that outlives the mount.
         if (isRunningFromAppImage())
-            return {};
+            return stagedBridgeExecutable();
 
-        // Resolve the real binary rather than argv[0]: even outside an AppImage,
-        // JUCE's lookup goes through dladdr, which on glibc yields argv[0].
-        char buffer[PATH_MAX];
-        if (const auto length = ::readlink("/proc/self/exe", buffer, sizeof(buffer) - 1);
-            length > 0) {
-            buffer[length] = '\0';
-            const juce::File selfExe(juce::String::fromUTF8(buffer));
-            if (const auto sibling = selfExe.getParentDirectory().getChildFile("magda-mcp");
-                sibling.existsAsFile())
-                return sibling;
-        }
+        // `paths::executableDir()` resolves /proc/self/exe rather than argv[0],
+        // which is what an ordinary install needs and what a build tree gets too.
+        if (const auto sibling = paths::executableDir().getChildFile("magda-mcp");
+            sibling.existsAsFile())
+            return sibling;
         return appBundle.getParentDirectory().getChildFile("magda-mcp");
 #endif
     }
+
+#if JUCE_WINDOWS
+    /// Where the installer puts the bridge: `commonApplicationDataDirectory` is
+    /// %ProgramData%, and `magda-installer.nsi` writes `MAGDA\bin` under it.
+    static juce::File commonDataBridge() {
+        return juce::File::getSpecialLocation(juce::File::commonApplicationDataDirectory)
+            .getChildFile("MAGDA")
+            .getChildFile("bin")
+            .getChildFile("magda-mcp.exe");
+    }
+#endif
 
 #if !JUCE_WINDOWS && !JUCE_MAC
     /// The type-2 AppImage runtime exports both of these; neither is set for an
     /// ordinary install.
     static bool isRunningFromAppImage() {
         return std::getenv("APPIMAGE") != nullptr || std::getenv("APPDIR") != nullptr;
+    }
+
+    /**
+     * @brief The AppImage's bridge, copied to a path that outlives the mount.
+     *
+     * `dataDir()` is the natural home. It already outlives any one run, and the
+     * bridge resolves it independently — `MAGDA_DATA_DIR`, then `config.json`,
+     * then the OS default — to find the discovery record. A copy sitting there
+     * is no further from MAGDA than one sitting beside it.
+     *
+     * Re-staged whenever the copy no longer matches the binary in the mount, so
+     * upgrading the AppImage upgrades the bridge without the user having to know
+     * a copy was ever made. Size plus modification time is enough to tell: the
+     * squashfs carries the build's timestamps, so a rebuild moves both.
+     *
+     * Returns {} if the copy cannot be made, which the page renders as its
+     * "point this somewhere yourself" fallback rather than a path that will not
+     * run.
+     *
+     * Done once per session. `fieldText()` runs on a one-second timer for as
+     * long as the page is open, and a data dir that cannot be written to would
+     * otherwise mean a failed multi-megabyte copy every tick — on the message
+     * thread. A stage that did not work now will not work a second from now.
+     * (This also pins the answer if the data dir is repointed in Preferences,
+     * which already needs a restart to take full effect.)
+     */
+    static juce::File stagedBridgeExecutable() {
+        static const juce::File staged = stageBridgeOutOfAppImage();
+        return staged;
+    }
+
+    static juce::File stageBridgeOutOfAppImage() {
+        const auto source = paths::executableDir().getChildFile("magda-mcp");
+        if (!source.existsAsFile())
+            return {};
+
+        const auto staged = paths::dataDir().getChildFile("bin").getChildFile("magda-mcp");
+        if (staged.existsAsFile() && staged.getSize() == source.getSize() &&
+            staged.getLastModificationTime() == source.getLastModificationTime())
+            return staged;
+
+        if (!staged.getParentDirectory().createDirectory())
+            return {};
+
+        // JUCE's POSIX copy is a stream copy into a freshly created file: it
+        // carries neither the execute bit nor the timestamp, and this needs
+        // both — the first to run at all, the second so the next launch can tell
+        // this copy from the one a newer AppImage would bring.
+        if (!source.copyFileTo(staged) || !staged.setExecutePermission(true))
+            return {};
+        staged.setLastModificationTime(source.getLastModificationTime());
+
+        return staged;
     }
 #endif
 

--- a/packaging/windows/magda-installer.nsi
+++ b/packaging/windows/magda-installer.nsi
@@ -11,6 +11,10 @@ InstallDirRegKey HKLM "Software\MAGDA" "Install_Dir"
 RequestExecutionLevel admin
 Unicode True
 
+; %ProgramData%\MAGDA\bin — where the MCP bridge is installed. See the Install
+; section for why it is not under $INSTDIR.
+Var McpBinDir
+
 ; UI settings
 !define MUI_ABORTWARNING
 
@@ -62,9 +66,31 @@ vc_redist_ok:
     File "${__FILEDIR__}\MAGDA.exe"
     File "${__FILEDIR__}\mgd_doc_icon.ico"
     File /nonfatal "${__FILEDIR__}\magda_plugin_scanner.exe"
-    ; The MCP bridge (#1858). An MCP host is configured with its absolute
-    ; path under $INSTDIR, which is what the AI settings page hands the user.
+
+    ; The MCP bridge (#1858) goes to %ProgramData%\MAGDA\bin, NOT $INSTDIR.
+    ; An MCP host is configured with its absolute path and launches it itself,
+    ; and hosts differ on whether that string is an argv array or something they
+    ; split on whitespace. The default $INSTDIR is "C:\Program Files\MAGDA", so
+    ; for the splitters the space breaks the command. %ProgramData% is a fixed
+    ; name on every supported Windows and carries no user name, making it
+    ; space-free regardless of who is logged in.
+    ;
+    ; The bridge does not need to sit beside MAGDA: it locates a running
+    ; instance through the discovery record under the data dir, not by relative
+    ; path. SetShellVarContext is restored straight away so the Start Menu and
+    ; Desktop shortcuts below stay per-user as before.
+    SetShellVarContext all
+    StrCpy $McpBinDir "$APPDATA\MAGDA\bin"
+    SetShellVarContext current
+
+    SetOutPath "$McpBinDir"
     File /nonfatal "${__FILEDIR__}\magda-mcp.exe"
+    SetOutPath $INSTDIR
+
+    ; Upgrading in place over an install that predates the move: the copy left
+    ; in $INSTDIR is never used again, and leaving it invites someone to
+    ; configure a host with the path that has the space in it.
+    Delete "$INSTDIR\magda-mcp.exe"
 
     ; All runtime DLLs staged next to MAGDA.exe: ONNX Runtime (a load-time app
     ; dependency) and libxml2 + its transitive deps (DAWproject XSD validation).
@@ -157,6 +183,7 @@ Section "Uninstall"
     Delete "$INSTDIR\MAGDA.exe"
     Delete "$INSTDIR\mgd_doc_icon.ico"
     Delete "$INSTDIR\magda_plugin_scanner.exe"
+    ; Installs predating the move to %ProgramData% put the bridge here.
     Delete "$INSTDIR\magda-mcp.exe"
     Delete "$INSTDIR\*.dll"
     Delete "$INSTDIR\Uninstall.exe"
@@ -168,6 +195,15 @@ Section "Uninstall"
     RMDir /r "$INSTDIR\dawproject"
     RMDir /r "$INSTDIR\models"
     RMDir "$INSTDIR"
+
+    ; The MCP bridge, out under %ProgramData%. Both RMDirs are non-recursive on
+    ; purpose: MAGDA\bin goes only if the bridge was all it held, and MAGDA only
+    ; if nothing else has since been written there.
+    SetShellVarContext all
+    Delete "$APPDATA\MAGDA\bin\magda-mcp.exe"
+    RMDir "$APPDATA\MAGDA\bin"
+    RMDir "$APPDATA\MAGDA"
+    SetShellVarContext current
 
     Delete "$SMPROGRAMS\MAGDA\*.*"
     RMDir "$SMPROGRAMS\MAGDA"

--- a/tools/transport_check/README.md
+++ b/tools/transport_check/README.md
@@ -151,10 +151,10 @@ Stands up a stub MAGDA — WebSocket, MCP in both eras, OSC, and a stand-in
 bridge — and runs the whole harness against it. Needs no MAGDA and no network,
 so it belongs anywhere CI can run Python.
 
-One check is *expected* to fail there: `magda-mcp is staged beside the MAGDA
-executable` looks beside the binary behind the record's pid, which under the
-self-test is the Python interpreter. The self-test asserts that it fails, since
-a pass would mean the check was not looking at anything.
+One check is *expected* to fail there: `magda-mcp is where the settings page
+points` resolves the binary behind the record's pid, which under the self-test is
+the Python interpreter. The self-test asserts that it fails, since a pass would
+mean the check was not looking at anything.
 
 ### Proving the checks are not vacuous
 

--- a/tools/transport_check/mutation_test.py
+++ b/tools/transport_check/mutation_test.py
@@ -30,7 +30,7 @@ HARNESS = Path(__file__).resolve().parent
 
 #: The one check the stub cannot satisfy, so it fails in every run including
 #: the baseline. See `selftest.EXPECTED_FAILURES`.
-ALWAYS_FAILS = {"magda-mcp is staged beside the MAGDA executable"}
+ALWAYS_FAILS = {"magda-mcp is where the settings page points"}
 
 #: (what is broken, the text to replace in selftest.py, what to replace it with)
 MUTATIONS: list[tuple[str, str, str]] = [

--- a/tools/transport_check/selftest.py
+++ b/tools/transport_check/selftest.py
@@ -719,11 +719,12 @@ def main() -> int:
     return verdict(report)
 
 
-#: The one check the stub cannot satisfy. The harness looks for `magda-mcp`
-#: beside the executable behind the discovery record's pid, and that pid here
-#: is the Python running this file. A *passing* result would mean the check was
-#: not looking at anything, so it is expected to fail rather than excused.
-EXPECTED_FAILURES = {"magda-mcp is staged beside the MAGDA executable"}
+#: The one check the stub cannot satisfy. The harness resolves the executable
+#: behind the discovery record's pid, and that pid here is the Python running
+#: this file, so the bridge is never where a real install would put it. A
+#: *passing* result would mean the check was not looking at anything, so it is
+#: expected to fail rather than excused.
+EXPECTED_FAILURES = {"magda-mcp is where the settings page points"}
 
 
 def verdict(report) -> int:

--- a/tools/transport_check/suites.py
+++ b/tools/transport_check/suites.py
@@ -248,25 +248,48 @@ def run_discovery(context: Context, others: list[discovery.Record]) -> None:
             ),
         )
 
-    # -- packaging: is the bridge staged beside the executable? ------------
+    # -- packaging: is the bridge where the settings page will point? -------
+
+    def bridge_location(exe: Path) -> tuple[Path, str]:
+        """Mirror of `McpPage::bridgeExecutable` — where the page sends a host.
+
+        Two platforms deliberately do not publish the copy beside MAGDA: Windows
+        because the space in `C:\\Program Files` breaks hosts that split their
+        configured command on whitespace, Linux because an AppImage's mount is
+        gone the moment MAGDA exits.
+        """
+        if sys.platform == "win32":
+            program_data = Path(os.environ.get("PROGRAMDATA", r"C:\ProgramData"))
+            installed = program_data / "MAGDA" / "bin" / bridge_name()
+            if installed.exists():
+                return installed, "installed under %ProgramData%"
+            return exe.parent / bridge_name(), "build tree, beside MAGDA"
+        if ".mount_" in str(exe):
+            return (
+                discovery.data_dir(context.data_dir) / "bin" / bridge_name(),
+                "staged out of the AppImage",
+            )
+        return exe.parent / bridge_name(), "beside MAGDA"
 
     def staged() -> tuple[Status, str, dict]:
         exe = executable_for_pid(record.pid)
         if exe is None:
             return unclear(f"could not resolve the executable behind pid {record.pid}")
-        if "/tmp/.mount_" in str(exe) or ".mount_" in str(exe):
-            return unclear(
-                f"running from an AppImage ({exe}); the settings page is expected to "
-                "show a placeholder here and publish magda-mcp as a separate asset"
-            )
-        candidate = exe.parent / bridge_name()
+        candidate, where = bridge_location(exe)
         if not candidate.exists():
+            # Staging out of an AppImage is lazy — MAGDA writes the copy when the
+            # MCP page is first opened — so a fresh run legitimately has nothing
+            # there yet. That is not the same finding as a packaging miss.
+            if ".mount_" in str(exe):
+                return unclear(
+                    f"{candidate} not staged yet; open the MCP settings page once"
+                )
             return fail(f"{candidate} does not exist", expected=str(candidate))
         if sys.platform != "win32" and not os.access(candidate, os.X_OK):
             return fail(f"{candidate} is not executable")
-        return ok(str(candidate), path=str(candidate))
+        return ok(f"{candidate} ({where})", path=str(candidate))
 
-    runner.check("magda-mcp is staged beside the MAGDA executable", staged)
+    runner.check("magda-mcp is where the settings page points", staged)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
An MCP host stores `magda-mcp`'s absolute path once and launches it later, on its own schedule, with MAGDA possibly closed. Two platforms could not meet that with the copy staged beside MAGDA, and each failed differently.

## Linux

Inside an AppImage the bridge lives under `/tmp/.mount_…` — torn down on exit, renamed every launch. The settings page published a placeholder and disabled Copy, and the release shipped `magda-mcp` as a **separate asset** the user had to download and put on `PATH` themselves.

Now MAGDA copies it out of the mount to `<data dir>/bin/magda-mcp` and publishes that. It re-stages when size or mtime stops matching the binary in the image, so upgrading the AppImage upgrades the bridge.

Staging is done once per session: `fieldText()` runs on a one-second timer while the page is open, and retrying a failed multi-megabyte copy every tick on the message thread is worse than showing the fallback text. Tradeoff: if staging fails (read-only or full data dir), it won't retry until the next launch.

The two Linux release assets (`magda-mcp-<version>-Linux-x86_64` + `.sha256`) go away with it.

## Windows

The installer now places the bridge in `%ProgramData%\MAGDA\bin` rather than `$INSTDIR`. Hosts disagree on whether a configured command is an argv array or a string they split on whitespace, and for the splitters the space in `C:\Program Files\MAGDA` breaks the command in two. `%ProgramData%` is a fixed name on every supported Windows and carries no user name, so it is space-free whoever is logged in, and its default ACL lets a non-elevated host execute it.

Both install and uninstall clear the old `$INSTDIR` copy, so an in-place upgrade leaves nothing pointing at the path with the space.

Signing is unaffected — `sign-release.ps1` signs the staged copy before NSIS packages it, so what lands in `%ProgramData%` is the signed binary.

macOS is unchanged; the bundle path was already permanent.

## Also

- Drops the hand-rolled `/proc/self/exe` lookup for `paths::executableDir()`, which already does exactly that, and corrects the doc comment that claimed otherwise.
- The `transport_check` packaging check asserted "magda-mcp is staged beside the MAGDA executable", now wrong on two platforms. It mirrors `McpPage::bridgeExecutable` instead.
- `mcp.bridge_missing` told users to download an asset we no longer publish (en.json only — Crowdin owns the rest).

## Verified

- Debug build: 1386/1386, links clean, no diagnostics from `ConnectionsDialog.cpp`
- `transport_check` self-test: 52 checks behaved as expected, renamed check registers as the intended expected-failure
- `release.yml` valid YAML, `lang/en.json` parses, Python compiles

## Not verified — needs CI

- The Linux staging path only runs when `$APPIMAGE`/`$APPDIR` are set, so a local build never enters it. Needs a real AppImage.
- The NSIS change needs an installer build; `makensis` isn't available locally, so the script isn't syntax-checked.

Both land on the same CI job, so a tag or `workflow_dispatch` run covers them.

## Note

`dev/0.20.0` branched off `main` before `f8aa3e4c` and won't have this after 0.19.0 ships. Worth carrying across before 0.20.0 touches `magda-installer.nsi` or the AppImage staging block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)