### PR TITLE
Keep the bridge's own filename out of the translated string

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -501,7 +501,7 @@
     "mcp.status_off": "Not listening",
     "mcp.field_caption": "{0} host configuration",
     "mcp.hint": "Paste this into your {0} host's config. It stays correct across restarts: the helper it names finds {1}'s current port and token each time, so neither has to be written down.",
-    "mcp.bridge_missing": "{1} could not find magda-mcp. Reinstalling {1} puts it back; otherwise replace the path below with wherever you have it. It finds {1} on its own, so it works from anywhere.",
+    "mcp.bridge_missing": "{1} could not find {0}. Reinstalling {1} puts it back; otherwise replace the path below with wherever you have it. It finds {1} on its own, so it works from anywhere.",
     "ws.blurb": "Lets a script, a control surface, or any other program drive this session over a {0}, and pushes changes back as they happen. It listens on this machine only, on its own port and with its own token.",
     "ws.enable": "Enable the {0} {1}",
     "ws.status_listening": "Listening on port {0}",

--- a/magda/daw/core/TechnicalText.hpp
+++ b/magda/daw/core/TechnicalText.hpp
@@ -43,6 +43,7 @@ enum class TechnicalTextToken {
     Osc,
     Api,
     Mcp,
+    MagdaMcp,
     WebSocket,
 };
 
@@ -121,6 +122,10 @@ inline juce::String technicalText(TechnicalTextToken token) {
             return "API";
         case TechnicalTextToken::Mcp:
             return "MCP";
+        // The bridge executable's own name, which is a filename on disk and
+        // stays that in every locale.
+        case TechnicalTextToken::MagdaMcp:
+            return "magda-mcp";
         case TechnicalTextToken::WebSocket:
             return "WebSocket";
     }

--- a/magda/daw/ui/dialogs/ConnectionsDialog.cpp
+++ b/magda/daw/ui/dialogs/ConnectionsDialog.cpp
@@ -563,8 +563,10 @@ class McpPage : public TransportPage {
         // Named as it will be typed, JSON-escaped so a Windows path's
         // backslashes survive being pasted.
         auto* server = new juce::DynamicObject();
-        server->setProperty("command", haveBridge ? bridge.getFullPathName()
-                                                  : juce::String("/path/to/magda-mcp"));
+        server->setProperty(
+            "command",
+            haveBridge ? bridge.getFullPathName()
+                       : "/path/to/" + magda::technicalText(magda::TechnicalTextToken::MagdaMcp));
         auto* servers = new juce::DynamicObject();
         servers->setProperty("magda", juce::var(server));
         auto* root = new juce::DynamicObject();
@@ -577,6 +579,7 @@ class McpPage : public TransportPage {
             snippet =
                 commentBlock(
                     key("bridge_missing")
+                        .replace("{0}", magda::technicalText(magda::TechnicalTextToken::MagdaMcp))
                         .replace("{1}", magda::technicalText(magda::TechnicalTextToken::Magda))) +
                 snippet;
         }


### PR DESCRIPTION
`magda-mcp` sat inside `mcp.bridge_missing` as ordinary prose (`lang/en.json:504`), so it was handed to translators as text to translate — and the existing ja, ru and zh translations each carry it inline, one of them twice.

It is the name of an executable on disk. Whatever a locale renders it as, the file is still called `magda-mcp`, and a translated one sends somebody looking for a binary that does not exist.

Every other technical term in that dialog already goes through `TechnicalTextToken` — `MCP` and `MAGDA` both do, in this very string — so this adds the token that was missing rather than a new mechanism:

- `TechnicalTextToken::MagdaMcp` → `"magda-mcp"`, beside `Mcp`
- `en.json:504` — `"{1} could not find magda-mcp."` → `"{1} could not find {0}."`
- `ConnectionsDialog.cpp` supplies `{0}` from the token, and the `/path/to/magda-mcp` placeholder in the generated snippet is built from it too, so the name has one source rather than two spellings that can drift

**Translations are left to Crowdin.** `ja/ru/zh` are untouched here. A source change invalidates them, which is the pipeline working; until a translator gets to them they render the name inline, which is still the right name.

**Note on landing:** merging this fires the Crowdin Sync workflow, and main and dev push to the same un-branched Crowdin project, so the string diverges between the two branches until this is merged forward into `dev/0.20.0`.

Builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)