### PR TITLE
Make selected text visible in a TextEditor

### DIFF
--- a/magda/daw/ui/components/common/BarsBeatsTicksLabel.cpp
+++ b/magda/daw/ui/components/common/BarsBeatsTicksLabel.cpp
@@ -423,8 +423,14 @@ void BarsBeatsTicksLabel::SegmentLabel::startEditing() {
                        DarkTheme::getColour(DarkTheme::SURFACE));
     editor_->setColour(juce::TextEditor::textColourId,
                        DarkTheme::getColour(DarkTheme::TEXT_PRIMARY));
+    // The field opens with everything selected, so the accent covers the whole
+    // value at an opaque strength. Text sitting on it is on-accent content, not
+    // text on a surface, and TEXT_PRIMARY is the wrong end of the palette for
+    // that on a light theme.
     editor_->setColour(juce::TextEditor::highlightColourId,
                        DarkTheme::getColour(DarkTheme::ACCENT_PRIMARY));
+    editor_->setColour(juce::TextEditor::highlightedTextColourId,
+                       DarkTheme::getColour(DarkTheme::ICON_ON_ACCENT));
     editor_->setColour(juce::TextEditor::outlineColourId, juce::Colours::transparentBlack);
     editor_->setColour(juce::TextEditor::focusedOutlineColourId, juce::Colours::transparentBlack);
 

--- a/magda/daw/ui/components/common/ValueLabelControl.cpp
+++ b/magda/daw/ui/components/common/ValueLabelControl.cpp
@@ -179,8 +179,13 @@ void ValueLabelControl::showEditor(const juce::String& initialText) {
                        DarkTheme::getColour(DarkTheme::SURFACE));
     editor_->setColour(juce::TextEditor::textColourId,
                        customTextColour_.value_or(DarkTheme::getColour(DarkTheme::TEXT_PRIMARY)));
+    // Opens fully selected, so the accent covers the whole value at an opaque
+    // strength and the text on it is on-accent content. A caller's custom text
+    // colour is chosen against SURFACE and does not carry over.
     editor_->setColour(juce::TextEditor::highlightColourId,
                        DarkTheme::getColour(DarkTheme::ACCENT_PRIMARY));
+    editor_->setColour(juce::TextEditor::highlightedTextColourId,
+                       DarkTheme::getColour(DarkTheme::ICON_ON_ACCENT));
     editor_->setColour(juce::TextEditor::outlineColourId, juce::Colours::transparentBlack);
     editor_->setColour(juce::TextEditor::focusedOutlineColourId, juce::Colours::transparentBlack);
 

--- a/magda/daw/ui/themes/DarkTheme.cpp
+++ b/magda/daw/ui/themes/DarkTheme.cpp
@@ -791,6 +791,14 @@ void DarkTheme::applyToLookAndFeel(juce::LookAndFeel_V4& laf) {
     laf.setColour(juce::TextEditor::backgroundColourId, getColour(SURFACE));
     laf.setColour(juce::TextEditor::outlineColourId, getColour(BORDER));
     laf.setColour(juce::TextEditor::focusedOutlineColourId, getColour(ACCENT_PRIMARY));
+    // A selection has to be spelled out here. V4 derives its two halves from
+    // opposite ends of the scheme, the fill from `defaultFill` and the text
+    // from `highlightedText`, so it pairs a BUTTON_NORMAL wash with
+    // ICON_ON_ACCENT lettering. Neither role is meant for the other: on Dark
+    // that is near-black on near-black, and on Light it is white on a pale
+    // surface. Either way the selected text disappears.
+    laf.setColour(juce::TextEditor::highlightColourId, getColour(ACCENT_PRIMARY).withAlpha(0.4f));
+    laf.setColour(juce::TextEditor::highlightedTextColourId, getColour(TEXT_PRIMARY));
     laf.setColour(juce::CaretComponent::caretColourId, getColour(TEXT_PRIMARY));
 
     // Button colors


### PR DESCRIPTION
Selecting the MCP or WebSocket JSON snippet in the Connections dialog painted the selection as black text on a near-black fill, so the text under the selection vanished. Confirmed on every OS, which fits: nothing about it is platform specific.

## Cause

`LookAndFeel_V4` assembles a `TextEditor` selection out of two unrelated scheme roles. The fill comes from `defaultFill` and the lettering from `highlightedText`. Through `DarkTheme::applyToLookAndFeel` those are `BUTTON_NORMAL` and `ICON_ON_ACCENT`, a pair nobody chose to sit together:

| Palette | Fill | Lettering | Result |
|---|---|---|---|
| Dark | `BUTTON_NORMAL` `0xFF0C0F14` at 40% over `SURFACE` | `ICON_ON_ACCENT` `0xFF1E1E1E` | near-black on near-black |
| Light | `BUTTON_NORMAL` `0xFFF7F9FA` at 40% over `SURFACE` | `ICON_ON_ACCENT` `0xFFFFFFFF` | white on a pale surface |

Both disappear. The Connections dialog's read-only snippet fields style their background, text and outline but never the selection, so they took the broken default.

## Fix

`applyToLookAndFeel` now names both halves of the selection: an `ACCENT_PRIMARY` wash at 40% with `TEXT_PRIMARY` on top. That is already the pairing MediaExplorer, PluginBrowser, the AI console and the Faust editor set on their own editors, so this makes the default match what the codebase had been fixing up by hand. The snippet fields inherit it through `DialogLookAndFeel`, and `refreshThemedLookAndFeels` re-runs `applyToLookAndFeel`, so it survives a live theme switch.

Per-component `setColour` still wins over the look and feel, so every editor that already styles its selection is untouched.

## Adjacent fix

Two value editors fill with an *opaque* accent rather than a wash, and set no selected-text colour, so they would have inherited the new `TEXT_PRIMARY` and gone dark-on-dark under Light. `BarsBeatsTicksLabel` and `ValueLabelControl` now name `ICON_ON_ACCENT` for their own selected text. That is the role for content drawn on an accent fill and it flips per theme, so both keep reading correctly.

`AutomationCurveEditor` already uses a translucent accent, so the new default suits it as is.

## Testing

Colour-only change, not built here. To see it: open Settings > Connections, enable MCP or the WebSocket, and drag-select the JSON snippet in the copyable field. Worth a look under both Dark and Light, and on a bars/beats field and a value readout for the adjacent fix.

https://claude.ai/code/session_01EXLKj37dCPKP5neGiRvXk2