### PR TITLE
Put sends, rack macros and the follower under both null-diff legs (#2174)

### DIFF
--- a/docs/architecture/native-engine.md
+++ b/docs/architecture/native-engine.md
@@ -30,11 +30,11 @@ is. When the two disagree, the headers are right and this file is stale.
 | **Engine core: plan, executor, PDC** | [#1889](https://github.com/Conceptual-Machines/magda-core/issues/1889) | **all 10 slices done** |
 | **Arranger clip playback** | [#1890](https://github.com/Conceptual-Machines/magda-core/issues/1890) | **all 7 slices done** |
 | **Parameters, modifiers, macros, automation** | [#1891](https://github.com/Conceptual-Machines/magda-core/issues/1891) | **all 8 slices done** |
-| Rack graph: pins, summing, multi-out, nesting | [#1892](https://github.com/Conceptual-Machines/magda-core/issues/1892) | 3 of 5 slices done |
+| **Rack graph: pins, summing, multi-out, nesting** | [#1892](https://github.com/Conceptual-Machines/magda-core/issues/1892) | **all 5 slices done** |
 | External plugin hosting and hardware inserts | [#1893](https://github.com/Conceptual-Machines/magda-core/issues/1893) | not started |
 | Clip launcher and session playback | [#1894](https://github.com/Conceptual-Machines/magda-core/issues/1894) | not started |
 | Live input, monitoring, recording | [#1895](https://github.com/Conceptual-Machines/magda-core/issues/1895) | not started |
-| Null-diff validation harness | [#1896](https://github.com/Conceptual-Machines/magda-core/issues/1896) | rig built, 3 of 8 slices done |
+| Null-diff validation harness | [#1896](https://github.com/Conceptual-Machines/magda-core/issues/1896) | rig built, 6 of 8 slices done |
 | Cutover: bridge rewrite, dual-engine release | [#1897](https://github.com/Conceptual-Machines/magda-core/issues/1897) | not started |
 
 Engine core, slice by slice: plan IR and compiler ([#2010](https://github.com/Conceptual-Machines/magda-core/issues/2010)),
@@ -74,8 +74,8 @@ Racks, slice by slice: aux outputs and multi-out tracks
 delta solo at device and rack scope
 ([#2136](https://github.com/Conceptual-Machines/magda-core/issues/2136)),
 nesting, recursion and op-key identity
-([#2137](https://github.com/Conceptual-Machines/magda-core/issues/2137)).
-Open: pins, channel counts and implicit summing
+([#2137](https://github.com/Conceptual-Machines/magda-core/issues/2137)),
+pins, channel counts and implicit summing
 ([#2138](https://github.com/Conceptual-Machines/magda-core/issues/2138)),
 parity cases for rack topologies
 ([#2139](https://github.com/Conceptual-Machines/magda-core/issues/2139)).
@@ -85,10 +85,13 @@ Validation, slice by slice. Done: whole-project cases and the tiered oracle
 plan goldens ([#2076](https://github.com/Conceptual-Machines/magda-core/issues/2076)),
 differ property tests ([#2077](https://github.com/Conceptual-Machines/magda-core/issues/2077)),
 the block-size invariance gate
-([#2078](https://github.com/Conceptual-Machines/magda-core/issues/2078)).
-Open: migrators ([#2079](https://github.com/Conceptual-Machines/magda-core/issues/2079)),
-the DAWproject cross-check ([#2080](https://github.com/Conceptual-Machines/magda-core/issues/2080)),
-the real-project corpus ([#2081](https://github.com/Conceptual-Machines/magda-core/issues/2081)),
+([#2078](https://github.com/Conceptual-Machines/magda-core/issues/2078)),
+project and preset migrators
+([#2079](https://github.com/Conceptual-Machines/magda-core/issues/2079)),
+the DAWproject cross-check
+([#2080](https://github.com/Conceptual-Machines/magda-core/issues/2080)).
+Open: the real-project corpus
+([#2081](https://github.com/Conceptual-Machines/magda-core/issues/2081)),
 the parity envelope suite ([#2082](https://github.com/Conceptual-Machines/magda-core/issues/2082)).
 Parity cases for a feature live with the feature, so #1891 through #1895 each carry their own,
 the way #2040 was the last slice of #1890.
@@ -734,12 +737,25 @@ do with the mixer. The runner refuses to certify a case that provoked an asserti
 failure rather than a quiet pass, and the collision is
 [#2085](https://github.com/Conceptual-Machines/magda-core/issues/2085).
 
-Sends are the one routing dimension left out, and not because they are hard to model: the
-compiler emits `SendTap` pre and post fader and the value layer resolves the levels already.
-The incumbent's sends live on `te::AuxSendPlugin` instances that `PluginManagerSync` creates,
-which wants a `PluginManager` and the device layer behind it, and writing those plugins straight
-into the leg would be the second sync the corpus refuses to have. They belong with the rest of
-the routing graph, in [#1892](https://github.com/Conceptual-Machines/magda-core/issues/1892).
+Sends were the one routing dimension left out, and never because they were hard to model: the
+compiler emits `SendTap` pre and post fader and the value layer resolved the levels all along.
+What they waited for was the other leg, since the incumbent's sends live on `te::AuxSendPlugin`
+instances `PluginManagerSync` creates from a `PluginManager`. Three cases carry them now
+([#2174](https://github.com/Conceptual-Machines/magda-core/issues/2174)). Where the tap sits is
+read off the fader it sits after: one project renders three quarters of an impulse with the send
+post-fader and unity with it pre-fader, so what the pair measures is the flag rather than whether
+a send exists at all. The third pins a claim `PlanValues.cpp` had only made in a comment, that a
+muted track keeps feeding its aux, because the tap is upstream of the muting stage in both
+engines.
+
+Nothing in those cases is panned, and that is a correction. They were first written with the
+source hard left and the return hard right so the dry and the send could be read out of separate
+channels. A post-fader tap is taken after the fader and the fader is where the pan is applied, so
+what reached the return was already hard left and the return's own hard right multiplied it away:
+both post-fader cases measured silence down the path they existed to measure, and nulled, because
+the incumbent was doing the same thing. They are read as one total now, and the runner refuses a
+case whose two renders are both silent -- which does not reach this one, since the dry path kept
+the render audible, and the limit is written down beside the guard.
 
 **Parameters are where the corpus first runs a device.** Until
 [#2123](https://github.com/Conceptual-Machines/magda-core/issues/2123) a `Device` op resolved to
@@ -749,9 +765,9 @@ as a contract (`tests/NullDiffGain.hpp`) and implemented in both legs the way th
 already was. What a gain device renders is the value of its own parameter, so a case that plays a
 constant into it draws the curve directly.
 
-Nine cases, all nulling: the stored value, a step curve over it, a square LFO over it, both at
-once, the stored value under each, a macro at track and at device scope, and the fader past both
-ends of its range where the clamp is. Each drives the incumbent through the app's own paths
+Eleven cases, all nulling: the stored value, a step curve over it, a square LFO over it, both at
+once, the stored value under each, a macro at all three scopes, an envelope follower, and the
+fader past both ends of its range where the clamp is. Each drives the incumbent through the app's own paths
 rather than a second set written here: the curve is emitted by the same `bakeLaneIntoCurve` the
 playback engine uses, and the modifiers and macros are built by `ModifierSyncWalker`, the walker
 `PluginManager` drives.
@@ -762,17 +778,30 @@ wherever a curve is holding still and can differ by up to a block wherever it ju
 thousand samples of silence either side of every jump covers a block at 4096 as well as at 512,
 so these cases are also bit identical across the invariance gate rather than exempt from it.
 
-**Three things are named rather than covered**, each after being tried. Rack-scope macros need a
-`te::RackType` that `RackSyncManager` builds out of a `PluginManager`, which is the boundary sends
-stop at and moves with #1892. The random walk cannot be nulled by anybody, since the fork seeds
-its generator from the clock. The envelope follower is fed by a `FollowerSourceTapPlugin` that
-`PluginManager` installs, so without the device layer the fork's follower is handed nothing.
+**Rack-scope macros and the envelope follower are covered now**, and both for the same reason the
+sends are: each wanted something only a `PluginManager` builds -- a `te::RackType` for the one, a
+`FollowerSourceTapPlugin` for the other -- and the leg drives that manager. The macro case links
+one of a rack's two chains and leaves the other fixed, so its sum says the macro resolved at rack
+scope rather than that something modulated. The follower case is cross-track: the modifier sits on
+the target's gain device and that device's audio sidechain names the source.
 
-The envelope is a finding rather than a boundary. Its note gate is behind that same device layer,
-and its transport gate is the fork asking `TransportControl::isPlaying()`, which is false
-throughout every offline render: a transport-triggered envelope does nothing in a bounce in the
-current engine, while the engine being built plays it. The case was written and renders 0.625
-against silence. It is not in the corpus, for the reason reverse-plus-warp is not.
+The follower case pins the steady state and deliberately not the envelope's timing. Its source
+plays a square, so the source's magnitude is one constant and every block's peak is the same
+number at every block size, which is what lets it null at all: the plan resolves parameters at the
+top of a block, so what a follower follows is the block before this one (`ModFollower.hpp`), and a
+lag makes no difference to a level that is not moving. A case built on a swell would be measuring
+that lag against a fork whose own ordering is the graph's rather than a rule.
+
+**One thing is still named rather than covered.** The random walk cannot be nulled by anybody,
+since the fork seeds its generator from the clock.
+
+The envelope has one gate a render cannot open and one nobody has tried. Its transport gate is the
+fork asking `TransportControl::isPlaying()`, which is false throughout every offline render: a
+transport-triggered envelope does nothing in a bounce in the current engine, while the engine
+being built plays it. The case was written and renders 0.625 against silence, and pinning it would
+ask the engine to reproduce a bug, so it is out for the reason reverse-plus-warp is. Its note gate
+was behind the device layer, which has moved; whether the fork's MIDI monitor opens one in an
+offline render is untested rather than settled.
 
 The slice also found one in the fork's LFO. `std::fmod` keeps the sign of its left-hand side, so
 a negative edit time gave `Ramp::setPosition` a negative position, which it asserts on and then
@@ -882,7 +911,7 @@ still one-sided is the other leg. The incumbent instantiates the two devices the
 and nothing else, so a case carrying a shipped device would be comparing a rendered device
 against a device nobody built, which is a residual that says nothing about either engine. Driving
 the app's own device path from that leg is what makes such a case worth writing, and it is what
-rack-scope macros, sends and the envelope follower are each waiting on.
+rack-scope macros, sends and the envelope follower were each waiting on.
 
 ---
 
@@ -895,10 +924,11 @@ Worth knowing before reading the code and wondering where something is:
   the devices MAGDA ships: `magda_engine_devices` hosts a `MagdaDevice` behind a `Device` op the
   way `magda_tracktion_compat_devices` hosts one behind a `te::Plugin`, so a device is written
   once and both engines run that one. What has not moved to the SDK the engine cannot run, and
-  the factory says so rather than standing something in. The corpus still contains no case with
-  one in it: the incumbent leg instantiates only the two devices the corpus declares, and until
-  it drives the app's own device path a case with a shipped device would be comparing something
-  against nothing. Rack-scope macros, sends and the envelope follower queue behind that.
+  the factory says so rather than standing something in. Both legs cross the boundary now: the
+  incumbent drives `PluginManager` rather than a copy of it, which is what let the sends,
+  rack-scope macros and the envelope follower into the corpus. What is left is a case whose
+  devices are the ones MAGDA ships rather than the corpus's own gain, which is the real-project
+  corpus ([#2081](https://github.com/Conceptual-Machines/magda-core/issues/2081)).
 - **External plugins** ([#1893](https://github.com/Conceptual-Machines/magda-core/issues/1893)).
   A `Device` op for one resolves to nothing. Nothing hosts VST3 yet.
 - **Launcher and recording** ([#1894](https://github.com/Conceptual-Machines/magda-core/issues/1894),

--- a/tests/DawProjectRoundTrip.cpp
+++ b/tests/DawProjectRoundTrip.cpp
@@ -421,6 +421,19 @@ const std::map<std::string, std::vector<Loss>>& lossTable() {
         {"param.hostwrite.modifier", {internalDevices(), trackModulation()}},
         {"macro.track", {internalDevices(), trackModulation()}},
         {"macro.device", {internalDevices()}},
+        // Rack-scope macros and a device-scope follower both ride inside the
+        // chain -- on RackInfo::macros and on DeviceInfo::mods -- so the one
+        // declaration that loses the chain loses them with it, and restoring
+        // the chain puts them back. Neither wants trackModulation() beside it:
+        // that covers what rides on TrackInfo, and a declared loss that finds
+        // nothing to restore fails here rather than sitting in the table.
+        //
+        // The three send cases are deliberately absent. DAWproject has sends
+        // and aux channels of its own, so they make the trip intact, and that
+        // is a result rather than an omission: the format carries the one piece
+        // of mixer topology the corpus has.
+        {"macro.rack", {internalDevices()}},
+        {"mod.follower", {internalDevices()}},
         // The rack cases (#2139). A rack is chains of internal devices, and the
         // format has nowhere to put either half, so the same declaration covers
         // the whole of it: the chain comes back empty and is restored wholesale.

--- a/tests/NullDiffCorpus.cpp
+++ b/tests/NullDiffCorpus.cpp
@@ -166,6 +166,42 @@ TrackInfo mixTrack(TrackId id, const char* name) {
     return track;
 }
 
+/// The return side of a send: an ordinary track carrying no clips, whose
+/// `auxBusIndex` is what makes the incumbent give it an AuxReturnPlugin and what
+/// an older project's send names its destination by.
+///
+/// `TrackType::Aux` alongside it because that is what the app stores, and for no
+/// other reason: neither engine reads the type here, the incumbent builds the
+/// same te::AudioTrack for it as for any other, and the plan routes it off
+/// `audioOutputDevice` like the rest. Written the way a project writes it so the
+/// case is a project rather than the subset of one the two legs happen to read.
+TrackInfo auxTrack(TrackId trackId, const char* name, int busIndex) {
+    TrackInfo track;
+    track.id = trackId;
+    track.type = TrackType::Aux;
+    track.name = name;
+    track.audioOutputDevice = "master";
+    track.auxBusIndex = busIndex;
+    return track;
+}
+
+/// A send from a track to @p destination, at @p level, tapped either side of the
+/// fader.
+///
+/// Both the bus index and the destination id are set, because the two engines
+/// read different ones: the incumbent matches an AuxSendPlugin's bus number
+/// against an AuxReturnPlugin's, and the plan resolves `destTrackId` and only
+/// falls back to the bus when a project predates the field. A case that set one
+/// would be handing one leg a send and the other nothing.
+SendInfo sendTo(TrackId destination, int busIndex, float level, bool preFader) {
+    SendInfo send;
+    send.busIndex = busIndex;
+    send.destTrackId = destination;
+    send.level = level;
+    send.preFader = preFader;
+    return send;
+}
+
 /// A track carrying one gain device, the only device either engine really runs
 /// (#2123, NullDiffGain.hpp). The parameter's stored value is the case's, which
 /// is what a host write is; a case that leaves it at unity has none in it.
@@ -291,6 +327,45 @@ ModInfo squareLfo(ModId id, const ControlTarget& target, float amount, bool temp
     mod.tempoSync = tempoSynced;
     mod.syncDivision = SyncDivision::Whole;
     mod.triggerMode = LFOTriggerMode::Transport;
+
+    ModLink link;
+    link.target = target;
+    link.amount = amount;
+    link.bipolar = false;
+    link.enabled = true;
+    mod.links.push_back(link);
+
+    return mod;
+}
+
+/// An envelope follower over whatever its scope listens to, driving @p target.
+///
+/// Its times are the shortest the two engines both honour rather than the
+/// model's defaults, and that is the case's design rather than a preference.
+/// The detector reduces a block to one peak in both engines, so a follower's
+/// output is a function of the block grid wherever the source's amplitude is
+/// moving -- which the block-size gate would report as the engine failing to be
+/// a function of timeline position (#2078), and it would be right. A millisecond
+/// either side settles the envelope inside a block at every size the gate
+/// renders at, so the only grid-dependent stretch is the one at the very start,
+/// and the case's material is silent there.
+///
+/// The input gain is not a default either. It is the one stage both engines
+/// place by hand: TE's own gain is held at unity and the decibels are applied
+/// source-side, before the band limits and before detection, because a level
+/// that has been detected has no frequency content left to filter
+/// (ModFollower.hpp, applyFollowerProperties). A follower at 0 dB would render
+/// the same whether either engine had done that or not.
+ModInfo envelopeFollower(ModId id, const ControlTarget& target, float amount, float gainDb) {
+    ModInfo mod;
+    mod.id = id;
+    mod.name = "Follower " + juce::String(static_cast<int>(id) + 1);
+    mod.type = ModType::Follower;
+    mod.enabled = true;
+    mod.followerGainDb = gainDb;
+    mod.followerAttackMs = 1.0f;
+    mod.followerHoldMs = 0.0f;
+    mod.followerReleaseMs = 1.0f;
 
     ModLink link;
     link.target = target;
@@ -849,11 +924,11 @@ std::vector<Case> buildCorpus(const juce::File& scratchDirectory) {
     // gone with it, and
     // mix.summing carries a fourth track to keep the case that found it.
     //
-    // Sends are absent on purpose. The native leg could render one today, and
-    // the incumbent's live on te::AuxSendPlugin instances that PluginManagerSync
-    // creates from a PluginManager and the device layer behind it. Writing those
-    // plugins straight into the leg would be the second sync this corpus refuses
-    // to have. They belong with the rest of the routing graph, in #1892.
+    // Sends are below rather than absent. They used to be absent because the
+    // incumbent's live on te::AuxSendPlugin instances PluginManagerSync creates
+    // from a PluginManager, and writing those into the leg would have been the
+    // second sync this corpus refuses to have. The leg drives that manager now
+    // (#2174), so the sends are the manager's rather than the harness's.
 
     {
         // Four tracks, which is where the node-identity collision in #2085 used
@@ -1043,6 +1118,114 @@ std::vector<Case> buildCorpus(const juce::File& scratchDirectory) {
         corpus.push_back(std::move(value));
     }
 
+    // --- sends -----------------------------------------------------------------
+    //
+    // A send is the mixer's one piece of topology: everything above routes a
+    // track to exactly one place, and a send is the track reaching a second one
+    // without leaving the first. The two engines build it least alike of
+    // anything in this section -- the incumbent hangs an AuxSendPlugin in the
+    // source's plugin list and an AuxReturnPlugin at the head of the
+    // destination's, and the two find each other by bus number through TE's own
+    // aux routing; the plan emits a SendTap op and queues its port onto the
+    // destination track's pending inputs, so the sum happens where every other
+    // sum in the plan happens. Nothing about those two descriptions makes them
+    // agree, which is why they are rendered.
+    //
+    // Nothing here is panned, and that is a correction rather than an omission.
+    // These cases were first written with the source hard left and the return
+    // hard right, so that the dry path and the send path could be read out of
+    // different channels. A post-fader tap is taken after the fader and the
+    // fader is where the pan is applied, so what reached the return was already
+    // hard left; the return's own hard right then multiplied it away, and both
+    // post-fader cases rendered silence down the path they existed to measure
+    // while still nulling against an incumbent doing the same thing. A case
+    // that agrees with itself about nothing is the one failure a null-diff
+    // corpus cannot see.
+    //
+    // So the dry and the send sum at the master and each case is read as one
+    // total. What distinguishes them is the total: the same project renders
+    // three quarters with the tap after the fader and unity with it before, and
+    // the muted one renders the send alone. Impulses, so the ordinary floor
+    // applies and a level wrong in the fourth decimal shows up.
+
+    {
+        // Where the tap sits, read off the fader it sits after.
+        //
+        // The source's fader is at half and its send at half, so the dry path
+        // carries a half and the return carries a quarter of what the clip
+        // played: three quarters of an impulse at the master. The pair with
+        // send.prefader below is the case, because those two projects are
+        // identical but for the flag and the total is what the flag decides. A
+        // leg that ignored it would render one of the two correctly, and one of
+        // two is not a coincidence either way.
+        auto source = mixTrack(1, "Source");
+        source.volume = 0.5f;
+        source.sends.push_back(sendTo(2, 0, 0.5f, false));
+
+        auto value = newMixCase("send.postfader", "a post-fader send carries the fader with it",
+                                {std::move(source), auxTrack(2, "Return", 0)});
+
+        const auto material = writeSource(scratchDirectory, "sendpost", impulses(0.25));
+        value.sources.push_back(material);
+        value.clips.push_back(audioClipOn(1, 330, 0.0, 4.0, material));
+
+        corpus.push_back(std::move(value));
+    }
+
+    {
+        // The same project with the flag turned over: the tap is ahead of the
+        // fader, so the return carries half of what the clip played rather than
+        // a quarter of it while the dry path is unchanged at a half, and the
+        // master sums to unity rather than three quarters.
+        //
+        // The fader is what makes the two readable. With the source at unity
+        // both flags render the same samples and the pair would assert that a
+        // send exists rather than where it is tapped.
+        auto source = mixTrack(1, "Source");
+        source.volume = 0.5f;
+        source.sends.push_back(sendTo(2, 0, 0.5f, true));
+
+        auto value = newMixCase("send.prefader", "a pre-fader send is tapped ahead of the fader",
+                                {std::move(source), auxTrack(2, "Return", 0)});
+
+        const auto material = writeSource(scratchDirectory, "sendpre", impulses(0.25));
+        value.sources.push_back(material);
+        value.clips.push_back(audioClipOn(1, 331, 0.0, 4.0, material));
+
+        corpus.push_back(std::move(value));
+    }
+
+    {
+        // A muted track keeps feeding its aux, which is a claim the plan makes
+        // in a comment (PlanValues.cpp, OpRole::SendTap) and nothing had
+        // rendered. The send taps ahead of the muting stage in both engines, and
+        // the current one only zeroes an aux send when it stops processing the
+        // track's contents at all, which MAGDA never does: it processes muted
+        // tracks so their meters stay alive.
+        //
+        // Post-fader, because that is the tap the claim is least obvious for: a
+        // pre-fader send sits ahead of the fader as well as the mute and would
+        // pass whatever the mute did.
+        //
+        // The mute takes the dry path out, so what reaches the master is the
+        // send and nothing else: half an impulse, through a fader left at
+        // unity. That makes the total say both halves of the claim at once. A
+        // leg whose mute reached the send renders silence, and a leg whose mute
+        // reached nothing renders the impulse and a half.
+        auto source = mixTrack(1, "Muted");
+        source.muted = true;
+        source.sends.push_back(sendTo(2, 0, 0.5f, false));
+
+        auto value = newMixCase("send.mute", "a muted track still feeds its aux",
+                                {std::move(source), auxTrack(2, "Return", 0)});
+
+        const auto material = writeSource(scratchDirectory, "sendmute", impulses(0.25));
+        value.sources.push_back(material);
+        value.clips.push_back(audioClipOn(1, 332, 0.0, 4.0, material));
+
+        corpus.push_back(std::move(value));
+    }
+
     // --- parameters, automation, modifiers and macros --------------------------
     //
     // The first cases that run a device under both engines, and therefore the
@@ -1058,29 +1241,27 @@ std::vector<Case> buildCorpus(const juce::File& scratchDirectory) {
     // every jump is what makes the ordinary floor apply rather than a
     // tolerance. Choose the material so a residual can only be a bug.
     //
-    // **Rack scope is missing from the macro cases**, and deliberately. A
-    // rack's macros live on a te::RackType that RackSyncManager builds out of a
-    // PluginManager, and writing one into the leg is the second sync this
-    // corpus refuses to have. It is the boundary sends stop at, and it moves
-    // with #1892.
+    // **All three macro scopes are here**, rack included. Rack scope used to be
+    // missing because a rack's macros live on a te::RackType only
+    // RackSyncManager builds out of a PluginManager, which was the boundary the
+    // sends stopped at too; the leg drives that manager now (#2174).
     //
-    // **Three of the four modifier engines are not here either**, each after
-    // being tried rather than for want of a case.
+    // **Two of the four modifier engines are still not here**, each after being
+    // tried rather than for want of a case.
     //
     // The random walk cannot be nulled by anybody: the fork seeds from the
     // clock, so it does not render the same numbers twice (ModRandom.hpp).
     //
-    // The envelope follower is fed by a FollowerSourceTapPlugin PluginManager
-    // installs, so without the device layer the fork's follower is handed
-    // nothing. Same boundary as the sends.
-    //
-    // The envelope has no gate a render can open. Its note gate is behind that
-    // same boundary, and its transport gate is the fork asking
-    // TransportControl::isPlaying(), which is false throughout every offline
-    // render: a transport-gated envelope does nothing in a bounce there, while
-    // the engine plays it. The case was written and renders 0.625 against
-    // silence; pinning it would ask the engine to reproduce a bug. The LFO
-    // carries this dimension instead, in both rate modes.
+    // The envelope has one gate a render cannot open and one this slice did not
+    // try. Its transport gate is the fork asking TransportControl::isPlaying(),
+    // which is false throughout every offline render: a transport-gated
+    // envelope does nothing in a bounce there while the engine plays it. That
+    // case was written and renders 0.625 against silence, and pinning it would
+    // ask the engine to reproduce a bug. Its note gate was behind the device
+    // layer, which has moved (#2174); whether the fork's MIDI monitor opens it
+    // in an offline render is untested rather than settled, and it belongs with
+    // whoever writes it. The LFO carries this dimension meanwhile, in both rate
+    // modes.
 
     {
         auto value = newParamCase("param.base", "a device parameter's stored value, heard",
@@ -1233,6 +1414,106 @@ std::vector<Case> buildCorpus(const juce::File& scratchDirectory) {
         const auto source = writeSource(scratchDirectory, "macrodevice", impulses(0.5));
         value.sources.push_back(source);
         value.clips.push_back(audioClip(287, 0.0, 8.0, source));
+
+        corpus.push_back(std::move(value));
+    }
+
+    {
+        // The third scope, and the one that was out of reach: a rack's macros
+        // live on a te::RackType that only RackSyncManager builds.
+        //
+        // Two chains, and only the first one's device is linked. That is what
+        // makes the case able to say the macro resolved at rack scope rather
+        // than merely that something modulated: chain one's gain is a quarter
+        // stored and 0.625 driven, chain two's is a fixed quarter, and the sum
+        // is 0.875 rather than the 0.5 a leg that left the link unresolved
+        // would render. Neither the macro's own position nor the base appears in
+        // the answer.
+        auto rack = rackOf(712, "Rack Macro",
+                           {gainChain(1, "Driven", 966, 0.25f), gainChain(2, "Fixed", 967, 0.25f)});
+        linkMacro(rack.macros, 0, 0.75f,
+                  ControlTarget::pluginParam(ChainNodePath::chainDevice(kTrack, 712, 1, 966),
+                                             kGainParamIndex),
+                  0.5f);
+
+        auto value =
+            newParamCase("macro.rack", "a rack macro driving a device in one of its chains",
+                         rackTrack(kTrack, "Rack Macro", std::move(rack)));
+
+        const auto source = writeSource(scratchDirectory, "macrorack", impulses(0.5));
+        value.sources.push_back(source);
+        value.clips.push_back(audioClip(288, 0.0, 8.0, source));
+
+        corpus.push_back(std::move(value));
+    }
+
+    {
+        // The envelope follower, which is the one modifier that is not a
+        // function of time: it answers "how loud is that", and the that is
+        // audio the modifier does not own. Until the device layer moved (#2174)
+        // the fork's follower was handed nothing at all here, because what feeds
+        // it is a FollowerSourceTapPlugin PluginManager installs on the source
+        // track, and this corpus had no PluginManager.
+        //
+        // Two tracks, and the modifier is on neither one's own scope: the
+        // follower sits on the target's gain device, and that device's audio
+        // sidechain names the source. That is the cross-track shape, and it is
+        // the one worth rendering -- a follower listening to its own track
+        // drives a device whose output it is downstream of, which is a loop in
+        // both engines and a case about feedback rather than about following.
+        //
+        // **What this case pins is the steady state, and deliberately not the
+        // envelope's timing.** The source's material is a square wave, so its
+        // magnitude is one constant for the whole render and every block's peak
+        // is the same number whatever the block grid is. That is what lets the
+        // case null at all: the engines read the source a block apart -- the
+        // plan resolves every parameter at the top of a block, so what a
+        // follower follows is the block before this one (ModFollower.hpp) --
+        // and a lag makes no difference to a level that is not moving. A case
+        // built on a swell would be measuring that lag, and measuring it
+        // against a fork whose own ordering is the graph's rather than a rule.
+        //
+        // The chain of numbers is therefore readable end to end: the square is
+        // at half, the follower's input gain takes 6 dB off it, and the link
+        // carries the whole of what is left onto a parameter stored at zero. So
+        // the device's gain settles at a quarter, which is not the source's
+        // level, not the parameter's base and not unity: a leg that dropped the
+        // input gain would render a half, and one that dropped the follower
+        // would render silence.
+        //
+        // The target's clip starts a beat in. The one stretch of this render
+        // that does depend on the block grid is the first block of it, where
+        // the detector has no previous block to have read and the envelope
+        // starts from zero; half a second is longer than the largest block the
+        // invariance gate renders at, by an order of magnitude.
+        auto source = mixTrack(1, "Source");
+
+        auto target = gainTrackOn(2, 968, "Target", 0.0f);
+        auto& device = magda::getDevice(target.chain.fxChainElements.front());
+        device.sidechain.type = SidechainConfig::Type::Audio;
+        device.sidechain.sourceTrackId = 1;
+        device.mods.push_back(envelopeFollower(0, gainTarget(2, 968), 1.0f, -6.0f));
+
+        auto value = newTrackCase("mod.follower",
+                                  "an envelope follower over another track's post-fader level",
+                                  {std::move(source), std::move(target)});
+        value.endBeat = 8.0;
+
+        // The square is what the follower is following, and a square is the one
+        // material whose peak is the same in every block: |x| never moves, so
+        // the detector's answer is a constant and the two engines' block grids
+        // have nothing to disagree about.
+        const auto square = writeSource(scratchDirectory, "followersource", steps());
+        value.sources.push_back(square);
+        value.clips.push_back(audioClipOn(1, 333, 0.0, 8.0, square));
+
+        // A tone on the target, because what the follower does to it has to be
+        // legible in the residual: a modulated square would put two constants
+        // on top of each other and a level error would look like a level error
+        // in either of them.
+        const auto carrier = writeSource(scratchDirectory, "followercarrier", tone());
+        value.sources.push_back(carrier);
+        value.clips.push_back(audioClipOn(2, 334, 1.0, 7.0, carrier));
 
         corpus.push_back(std::move(value));
     }

--- a/tests/test_null_diff_corpus.cpp
+++ b/tests/test_null_diff_corpus.cpp
@@ -36,7 +36,7 @@ juce::File scratch() {
 TEST_CASE("The corpus builds and covers what the slice claims", "[nulldiff][corpus]") {
     const auto corpus = sharedCorpus(scratch());
 
-    REQUIRE(corpus.size() == 50);
+    REQUIRE(corpus.size() == 55);
 
     std::set<std::string> names;
     for (const auto& value : corpus)
@@ -68,6 +68,9 @@ TEST_CASE("The corpus builds and covers what the slice claims", "[nulldiff][corp
                                  "mix.solo",
                                  "mix.master",
                                  "mix.volume.clamp",
+                                 "send.postfader",
+                                 "send.prefader",
+                                 "send.mute",
                                  "param.base",
                                  "param.automation",
                                  "param.modifier",
@@ -76,6 +79,8 @@ TEST_CASE("The corpus builds and covers what the slice claims", "[nulldiff][corp
                                  "param.hostwrite.modifier",
                                  "macro.track",
                                  "macro.device",
+                                 "macro.rack",
+                                 "mod.follower",
                                  "rack.parallel",
                                  "rack.chain.fader",
                                  "rack.fader",

--- a/tests/test_null_diff_juce.cpp
+++ b/tests/test_null_diff_juce.cpp
@@ -51,6 +51,15 @@ juce::File scratchDirectory() {
     return root;
 }
 
+/// The largest magnitude anywhere in @p buffer, which is all the silence guard
+/// below needs: it asks whether a render happened, not how loud it was.
+float peakOf(const juce::AudioBuffer<float>& buffer) {
+    float peak = 0.0f;
+    for (int channel = 0; channel < buffer.getNumChannels(); ++channel)
+        peak = std::max(peak, buffer.getMagnitude(channel, 0, buffer.getNumSamples()));
+    return peak;
+}
+
 /**
  * @brief What the suite has to complain about, given a run.
  *
@@ -724,6 +733,37 @@ class NullDiffCorpusTests : public juce::UnitTest {
             }
 
             report.passed = midiHeld;
+            return report;
+        }
+
+        // Two silences agree. Every comparison below measures how far the two
+        // renders sit apart and nothing measures whether either of them is a
+        // render at all, so a case that reaches the master with nothing on it
+        // nulls perfectly and asserts nothing -- and it does so at the ordinary
+        // floor, printed as an ordinary pass, which is the one failure a
+        // null-diff corpus cannot see by reading its own report.
+        //
+        // The corpus already knew this by hand: rack.aux carries an audible
+        // chain beside the one it expects to be dropped, "so the assertion is a
+        // comparison instead of two silences agreeing". This is that sentence
+        // enforced rather than repeated per case.
+        //
+        // What it does not reach is a path silenced inside a render that is not
+        // silent, and that is worth writing down because it is what actually
+        // happened here: the send cases were first written with the source hard
+        // left and the return hard right, and a post-fader tap is taken after
+        // the fader, which is where the pan is applied -- so the return was
+        // handed a hard-left signal and panned it away. The dry path was still
+        // audible, so this guard would have passed them. Catching that needs a
+        // case to declare what level it expects to render, which is a change to
+        // every case in the corpus and not this one's. Until then it is the
+        // reason the send cases are read as one total rather than by channel.
+        //
+        // Both legs, because either one alone would let the other's silence
+        // through, and a case where one leg renders nothing is a difference the
+        // residual below already reports loudly.
+        if (peakOf(native.audio) <= 0.0f && peakOf(incumbent.audio) <= 0.0f) {
+            report.unmeasurable = "the case asserts nothing: both renders are silent";
             return report;
         }
 


### PR DESCRIPTION
Closes #2174.

#2184 landed the device layer, and with it the three things #2174 named as riding on it. Each had been left out of the corpus with the same reason written beside it: the incumbent's half lived behind a `PluginManager` the harness would have had to reimplement, and a second sync is something that can agree with itself while both engines are wrong. The leg drives that manager now, so the reasons are gone rather than relaxed.

Five new cases, all nulling bit-identically against the fork.

## Sends

`send.postfader` and `send.prefader` are one project with the flag flipped: the source's fader is at half and its send at half, so the master sums to three quarters with the tap after the fader and to unity with it before. What the pair measures is the flag rather than whether a send exists at all, and a leg that ignored it renders one of the two correctly.

`send.mute` pins a claim `PlanValues.cpp` had only made in a comment and nothing had rendered: a muted track keeps feeding its aux, because the tap is upstream of the muting stage in both engines.

DAWproject carries all three intact, so they are absent from the round-trip loss table on purpose. The format holds the one piece of mixer topology the corpus has.

## Rack-scope macros

`macro.rack` links one of a rack's two chains and leaves the other fixed, so the sum is 0.875 rather than the 0.5 a leg that left the link unresolved would render. Neither the macro's own position nor the base appears in the answer.

## The envelope follower

`mod.follower` is cross-track: the modifier sits on the target's gain device and that device's audio sidechain names the source. It pins the steady state and **deliberately not the envelope's timing**. The source plays a square, so its magnitude is one constant and every block's peak is the same number at every block size -- which is what lets the case null at all, since the plan resolves parameters at the top of a block and what a follower follows is the block before this one (`ModFollower.hpp`). A lag makes no difference to a level that is not moving; a case built on a swell would be measuring that lag against a fork whose own ordering is the graph's rather than a rule.

The chain of numbers is readable end to end: square at half, 6 dB off it at the detector's input gain, the whole of what is left onto a parameter stored at zero, so the gain settles at a quarter. A leg that dropped the input gain renders a half and one that dropped the follower renders silence.

## A silence guard, and what it does not catch

Every comparison in the runner measures how far two renders sit apart, and nothing measured whether either was a render. A case reaching the master with nothing on it nulled at the ordinary floor and printed as an ordinary pass. `rack.aux` already carried an audible chain by hand "so the assertion is a comparison instead of two silences agreeing"; that is enforced now rather than repeated per case.

Its limit is written down beside it, because it would not have caught the bug found while writing this. The send cases were first panned, source hard left and return hard right, to read the dry and the send out of separate channels. A post-fader tap is taken after the fader and the fader is where the pan is applied, so the return was handed a hard-left signal and panned it away: both post-fader cases measured silence down the path they existed to measure, and nulled, because the incumbent was doing the same thing. The dry path kept the render audible, so the guard would have passed them. Catching that needs a case to declare what level it expects to render, which is a change to every case in the corpus and not this one's. They are read as one total now.

## Also

The architecture doc described the state before the boundary moved -- sends as "the one routing dimension left out", three things "named rather than covered", all three queuing behind a leg that had not crossed it. Corrected, along with two state-table rows that had gone stale for the same reason: the rack graph closed its last two slices (#2138, #2139) and validation closed the migrators and the DAWproject cross-check (#2079, #2080), which the "Open:" lists still named as open.

The envelope keeps its paragraph with one sentence changed. Its transport gate is still the fork asking `TransportControl::isPlaying()`, false throughout every offline render, so pinning it would ask the engine to reproduce a bug. Its note gate is no longer behind a boundary, but whether the fork's MIDI monitor opens one in an offline render is untested rather than settled, and it is recorded as untested.

## Testing

Full Catch2 suite (2919 passed, 13 skipped) and full JUCE suite both green, including the block-size invariance gate over the follower case and the DAWproject round trip.

https://claude.ai/code/session_01EXLKj37dCPKP5neGiRvXk2