### PR TITLE
The .mgd fixture rig: a real project as a null-diff case (#2173)

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -367,6 +367,13 @@ if(MAGDA_BUILD_NATIVE_ENGINE)
     list(APPEND TEST_SOURCES test_null_diff_corpus.cpp)
     list(APPEND TEST_SOURCES test_null_diff_native_leg.cpp)
 
+    # The .mgd fixture rig (#2173): a real project turned into a case. Model
+    # only, like the corpus beside it -- the load produces model values and this
+    # slice renders nothing, so neither leg is involved.
+    list(APPEND TEST_SOURCES MgdFixture.cpp)
+    list(APPEND TEST_SOURCES MgdFixtures.cpp)
+    list(APPEND TEST_SOURCES test_mgd_fixture_rig.cpp)
+
     # The device layer under the engine (#2174): the app's own catalogs asked
     # for a Device op's device, and a shipped device rendered through the
     # adapter. The engine's half alone -- what the two hosts do with one device
@@ -449,6 +456,11 @@ target_compile_definitions(magda_tests
     # real user files that must never be regenerated, and an intended change to
     # the frozen order has to show up as a reviewable diff.
     MAGDA_LEGACY_CORPUS_DIR="${CMAKE_CURRENT_SOURCE_DIR}/corpus/legacy"
+    # The root the .mgd fixtures name a file under (#2173). One level above the
+    # legacy corpus rather than inside it, because a fixture can be a legacy
+    # project reused or one saved for the render corpus, and where it lives is
+    # part of what a manifest says.
+    MAGDA_TEST_CORPUS_DIR="${CMAKE_CURRENT_SOURCE_DIR}/corpus"
     MAGDA_DEVICE_PARAM_SCHEMA_FILE="${CMAKE_CURRENT_SOURCE_DIR}/device_param_schema.txt"
 )
 

--- a/tests/MgdFixture.cpp
+++ b/tests/MgdFixture.cpp
@@ -54,9 +54,19 @@ std::string quoted(const juce::String& text) {
 }
 
 /// The last component of a path that may name a volume this machine has never
-/// had. Built without checking, because checking is what it cannot do.
+/// had, and a machine that is not this one.
+///
+/// Split here rather than by juce::File, which cuts on the separator of the host
+/// doing the reading: getSeparatorChar() is a backslash on Windows, so a project
+/// saved on macOS hands it a path of forward slashes and it hands back the whole
+/// path as the name. Every manifest lookup then misses and the load refuses a
+/// fixture that is fine, which is what CI found. The mirror holds too, a project
+/// saved on Windows and read on macOS.
+///
+/// A path in a saved project belongs to the machine that saved it, so both
+/// separators are cut whatever this one uses.
 juce::String fileNameOf(const juce::String& path) {
-    return juce::File::createFileWithoutCheckingPath(path).getFileName();
+    return path.fromLastOccurrenceOf("/", false, false).fromLastOccurrenceOf("\\", false, false);
 }
 
 using Declarations = std::map<juce::String, const FixtureSource*>;

--- a/tests/MgdFixture.cpp
+++ b/tests/MgdFixture.cpp
@@ -110,12 +110,29 @@ std::string matchSources(const MgdFixture& fixture, const std::vector<Source*>& 
  * other than what it declared.
  */
 std::string writeAndRepoint(const std::vector<Source*>& sources, const Declarations& declared,
-                            const juce::File& directory, std::vector<juce::File>& written) {
+                            const juce::File& directory,
+                            std::map<juce::String, juce::File>& written) {
     auto& pool = SourcePool::getInstance();
 
+    // The stand-in already written for a path, so a project that names one file
+    // twice gets one file back. That is not a corner case: a v2 project can
+    // carry a pooled table entry beside a v1 clip that migrated to the same
+    // path, which is the pair installStagedSources exists to collapse. Two
+    // names for one sound is one sound.
+    std::map<juce::String, juce::File> byOriginalPath;
+
     for (auto* source : sources) {
-        const auto name = fileNameOf(source->filePath);
+        const auto original = source->filePath;
+        const auto name = fileNameOf(original);
         const auto* declaration = declared.at(name);
+
+        if (const auto seen = byOriginalPath.find(original); seen != byOriginalPath.end()) {
+            const auto facts = factsOf(seen->second);
+            source->filePath = seen->second.getFullPathName();
+            source->sampleRate = facts.sampleRate;
+            source->durationSeconds = facts.durationSeconds;
+            continue;
+        }
 
         const auto file = writeMaterial(directory, name.upToLastOccurrenceOf(".", false, false),
                                         declaration->material);
@@ -130,16 +147,20 @@ std::string writeAndRepoint(const std::vector<Source*>& sources, const Declarati
         // two names, and a prediction made out of strings can only model what
         // strings can express. Case it can, by folding. Unicode normalisation it
         // cannot: macOS stores some names decomposed and some composed, so two
-        // Splice packs with an accented character produce two paths that differ
-        // as strings, fold differently, and name one file. Comparing the written
+        // packs with an accented character produce two paths that differ as
+        // strings, fold differently, and name one file. Comparing the written
         // paths would miss exactly that, because they differ as strings too.
         //
         // Counting does not care why two names met. The directory belongs to
-        // this fixture and was emptied before the first write, so after n writes
-        // it holds n files or two of them are one file.
-        const auto grewTo = directory.getNumberOfChildFiles(juce::File::findFiles);
-        if (grewTo != static_cast<int>(written.size()) + 1)
-            return "the stand-in written for " + quoted(source->filePath) + " as " + quoted(name) +
+        // this fixture and was emptied before the first write, so it holds one
+        // file per distinct source or two of them are one file.
+        //
+        // Counted against the distinct paths rather than against the sources,
+        // because a repeated path is meant to reuse its file and would
+        // otherwise be refused for doing what it was asked to do.
+        const auto distinct = static_cast<int>(byOriginalPath.size()) + 1;
+        if (directory.getNumberOfChildFiles(juce::File::findFiles) != distinct)
+            return "the stand-in written for " + quoted(original) + " as " + quoted(name) +
                    " landed on a file already written for another source, so the two would "
                    "collapse into one and their clips would play the same sound";
 
@@ -151,7 +172,9 @@ std::string writeAndRepoint(const std::vector<Source*>& sources, const Declarati
         // the install path acquires by path and would otherwise open the file a
         // second time to learn what the reader just said.
         pool.seedFactsForTesting(source->filePath, facts.durationSeconds, facts.sampleRate);
-        written.push_back(file);
+
+        byOriginalPath.emplace(original, file);
+        written.emplace(name, file);
     }
 
     return {};
@@ -296,6 +319,27 @@ FixtureLoad loadFixture(const MgdFixture& fixture, const juce::File& scratchDire
         fact.sampleRate = pooled.sampleRate;
         fact.durationSeconds = pooled.durationSeconds;
         result.value.sources.push_back(fact);
+    }
+
+    // One pooled source per source the manifest names, checked rather than
+    // assumed, because both ways of being wrong are silent.
+    //
+    // Too few means two sources collapsed somewhere past the checks above and
+    // two clips are now playing one sound. Too many means the install did not
+    // collapse a pair it should have, and a repeated path is holding two ids
+    // where the project had one.
+    //
+    // On every fixture, forever, rather than in a test that names one: the
+    // reuse branch above has no fixture exercising it today, since a repeated
+    // path needs a v2 table entry beside a v1 clip on the same file and none of
+    // the projects here has that shape. This is what will catch it the day one
+    // arrives.
+    if (result.value.sources.size() != fixture.sources.size()) {
+        result.failure = "the project ended up with " +
+                         std::to_string(result.value.sources.size()) + " sources where the " +
+                         "manifest names " + std::to_string(fixture.sources.size());
+        result.value = {};
+        return result;
     }
 
     result.ok = true;

--- a/tests/MgdFixture.cpp
+++ b/tests/MgdFixture.cpp
@@ -110,15 +110,15 @@ std::string matchSources(const MgdFixture& fixture, const std::vector<Source*>& 
  * other than what it declared.
  */
 std::string writeAndRepoint(const std::vector<Source*>& sources, const Declarations& declared,
-                            const juce::File& scratchDirectory, std::vector<juce::File>& written) {
+                            const juce::File& directory, std::vector<juce::File>& written) {
     auto& pool = SourcePool::getInstance();
 
     for (auto* source : sources) {
         const auto name = fileNameOf(source->filePath);
         const auto* declaration = declared.at(name);
 
-        const auto file = writeMaterial(
-            scratchDirectory, name.upToLastOccurrenceOf(".", false, false), declaration->material);
+        const auto file = writeMaterial(directory, name.upToLastOccurrenceOf(".", false, false),
+                                        declaration->material);
         const auto facts = factsOf(file);
         if (!facts.readable)
             return "the material written for " + quoted(name) + " does not read back";
@@ -139,13 +139,40 @@ std::string writeAndRepoint(const std::vector<Source*>& sources, const Declarati
 
 }  // namespace
 
+std::string refuseIndistinguishableSources(const std::vector<juce::String>& paths) {
+    std::map<juce::String, juce::String> byName;
+
+    for (const auto& path : paths) {
+        const auto name = fileNameOf(path);
+        const auto [existing, inserted] = byName.emplace(name, path);
+        if (!inserted && existing->second != path)
+            return "the project plays two different files both called " + quoted(name) + " (" +
+                   existing->second.toStdString() + " and " + path.toStdString() +
+                   "), and a manifest names a source by that alone, so one would stand in for "
+                   "both";
+    }
+
+    return {};
+}
+
 juce::File fixtureCorpusDir() {
     return juce::File(MAGDA_TEST_CORPUS_DIR);
 }
 
 FixtureLoad loadFixture(const MgdFixture& fixture, const juce::File& scratchDirectory) {
     FixtureLoad result;
-    scratchDirectory.createDirectory();
+
+    // Each fixture writes into its own directory under the scratch root, named
+    // for the case. Two fixtures are allowed to reference files with the same
+    // name -- they are different projects and nothing ties their sources
+    // together -- and a flat scratch directory would have the second one
+    // overwrite the first's material. The first fixture's Case would still be
+    // holding a path, and that path would now be playing the other project's
+    // sound. Loading them one at a time hides it; #2081 holds a corpus of them
+    // at once.
+    const auto materialDirectory = scratchDirectory.getChildFile(
+        juce::String(fixture.declaration.name).replaceCharacters("/\\:", "___"));
+    materialDirectory.createDirectory();
 
     const auto file = fixtureCorpusDir().getChildFile(fixture.file);
     if (!file.existsAsFile()) {
@@ -162,6 +189,16 @@ FixtureLoad loadFixture(const MgdFixture& fixture, const juce::File& scratchDire
     }
 
     auto sources = everySource(staged);
+
+    std::vector<juce::String> paths;
+    paths.reserve(sources.size());
+    for (const auto* source : sources)
+        paths.push_back(source->filePath);
+
+    if (auto refusal = refuseIndistinguishableSources(paths); !refusal.empty()) {
+        result.failure = std::move(refusal);
+        return result;
+    }
 
     Declarations declared;
     if (auto refusal = matchSources(fixture, sources, declared); !refusal.empty()) {
@@ -181,7 +218,7 @@ FixtureLoad loadFixture(const MgdFixture& fixture, const juce::File& scratchDire
     // a spec whose duration does not survive the writer is a case rendering
     // something other than what it declared.
 
-    if (auto refusal = writeAndRepoint(sources, declared, scratchDirectory, result.written);
+    if (auto refusal = writeAndRepoint(sources, declared, materialDirectory, result.written);
         !refusal.empty()) {
         result.failure = std::move(refusal);
         return result;

--- a/tests/MgdFixture.cpp
+++ b/tests/MgdFixture.cpp
@@ -113,11 +113,6 @@ std::string writeAndRepoint(const std::vector<Source*>& sources, const Declarati
                             const juce::File& directory, std::vector<juce::File>& written) {
     auto& pool = SourcePool::getInstance();
 
-    // What each written file was written for, so the check below can name the
-    // pair rather than the count. Keyed on the file the writer produced,
-    // because that is the thing two sources can end up sharing.
-    std::map<juce::String, juce::String> writtenFor;
-
     for (auto* source : sources) {
         const auto name = fileNameOf(source->filePath);
         const auto* declaration = declared.at(name);
@@ -128,21 +123,25 @@ std::string writeAndRepoint(const std::vector<Source*>& sources, const Declarati
         if (!facts.readable)
             return "the material written for " + quoted(name) + " does not read back";
 
-        // The same question the name check asked, asked again of the answer.
-        // That one predicts what the filesystem will do with two names; this one
-        // reads back what it did, so a collapse through anything the prediction
-        // does not model -- a separator, a symlink, a normalisation form -- is
-        // still refused rather than rendered.
+        // Whether the write landed on a file that was already there, asked of
+        // the directory rather than of the path.
         //
-        // Keyed on the original path so that two entries for one file, which a
-        // v1 project produces and the source install is right to collapse, are
-        // not mistaken for two files sharing one.
-        const auto original = source->filePath;
-        if (const auto [claimed, first] = writtenFor.emplace(file.getFullPathName(), original);
-            !first && claimed->second != original)
-            return "the stand-ins for " + quoted(claimed->second) + " and " + quoted(original) +
-                   " are the same file on this filesystem, so the two would collapse into one "
-                   "source and their clips would play the same sound";
+        // The name check ahead of this predicts what the filesystem will do with
+        // two names, and a prediction made out of strings can only model what
+        // strings can express. Case it can, by folding. Unicode normalisation it
+        // cannot: macOS stores some names decomposed and some composed, so two
+        // Splice packs with an accented character produce two paths that differ
+        // as strings, fold differently, and name one file. Comparing the written
+        // paths would miss exactly that, because they differ as strings too.
+        //
+        // Counting does not care why two names met. The directory belongs to
+        // this fixture and was emptied before the first write, so after n writes
+        // it holds n files or two of them are one file.
+        const auto grewTo = directory.getNumberOfChildFiles(juce::File::findFiles);
+        if (grewTo != static_cast<int>(written.size()) + 1)
+            return "the stand-in written for " + quoted(source->filePath) + " as " + quoted(name) +
+                   " landed on a file already written for another source, so the two would "
+                   "collapse into one and their clips would play the same sound";
 
         source->filePath = file.getFullPathName();
         source->sampleRate = facts.sampleRate;
@@ -203,6 +202,13 @@ FixtureLoad loadFixture(const MgdFixture& fixture, const juce::File& scratchDire
     // at once.
     const auto materialDirectory = scratchDirectory.getChildFile(
         juce::String(fixture.declaration.name).replaceCharacters("/\\:", "___"));
+
+    // Emptied, not just created. writeMaterial overwrites for the reason #2040
+    // gives -- a run that reused a file from a previous run with different
+    // contents is the one failure nobody would think to look for -- and the
+    // collision check below counts what the directory holds, which only means
+    // anything if everything in it was written by this load.
+    materialDirectory.deleteRecursively();
     materialDirectory.createDirectory();
 
     const auto file = fixtureCorpusDir().getChildFile(fixture.file);

--- a/tests/MgdFixture.cpp
+++ b/tests/MgdFixture.cpp
@@ -180,6 +180,116 @@ std::string writeAndRepoint(const std::vector<Source*>& sources, const Declarati
     return {};
 }
 
+/// Every device anywhere in a track's chain, racks and flat sections included.
+void everyDevice(const std::vector<ChainElement>& elements, std::vector<const DeviceInfo*>& out) {
+    for (const auto& element : elements) {
+        if (magda::isDevice(element)) {
+            out.push_back(&magda::getDevice(element));
+        } else if (magda::isRack(element)) {
+            for (const auto& chain : magda::getRack(element).chains)
+                everyDevice(chain.elements, out);
+        }
+    }
+}
+
+void everyDevice(const TrackInfo& track, std::vector<const DeviceInfo*>& out) {
+    everyDevice(track.chain.fxChainElements, out);
+    for (const auto* section :
+         {&track.chain.postFxChainElements, &track.chain.mixerAnalysisElements})
+        for (const auto& element : *section)
+            out.push_back(&element.device);
+}
+
+/**
+ * @brief Why this project cannot be a fixture here, if it hosts a plugin.
+ *
+ * A project with a VST3 in it has no verdict a corpus can hold it to. Without
+ * the plugin installed both legs render a passthrough and pass by agreeing
+ * about nothing, which is the silence-nulls-against-silence failure wearing a
+ * different hat. With it installed the incumbent hosts it and the native leg
+ * cannot (#1893), so whether the case passes is a fact about the machine that
+ * ran it.
+ *
+ * #2175 is where those projects go, with the invariant tier and a gate that
+ * calls an absent plugin unmeasurable rather than equal. Refused here rather
+ * than left to whoever writes a manifest, because the tier is a field somebody
+ * fills in and the format is a fact about the file.
+ */
+std::string refuseHostedPlugins(const StagedProjectData& staged) {
+    std::vector<const DeviceInfo*> devices;
+    for (const auto& track : staged.tracks)
+        everyDevice(track, devices);
+    if (staged.masterTrack != nullptr)
+        everyDevice(*staged.masterTrack, devices);
+
+    for (const auto* device : devices)
+        if (device->format != magda::PluginFormat::Internal)
+            return "the project hosts " + quoted(device->name) +
+                   ", which is not an internal device, so neither engine owes the other a "
+                   "sample on it: see #2175 for the tier those projects get";
+
+    return {};
+}
+
+/**
+ * @brief Put @p held back in the pool beside what the install just left, and
+ *        move this project's sources to ids nothing else is using.
+ *
+ * The install owns the pool it was handed: it cleared it, and what it left is
+ * this project under ids that came out of an allocator reset to one. Both facts
+ * are right for an app with one project open and wrong for a corpus holding
+ * several cases, whose Cases carry ids and nothing else.
+ *
+ * So the previous contents go back first, which lifts the allocator above every
+ * id already spoken for, and then each of this project's sources is acquired
+ * afresh. A path already in @p held keeps the id it had there, because it is the
+ * same file and two ids for one file is the collapse this rig spends its time
+ * refusing.
+ *
+ * The clips follow. A pure substitution, not the install's remap: that one
+ * rescales sample positions because a v1 nominal rate can differ from the
+ * probed one, and here the two ids name the same path with the same facts, so
+ * there is nothing to rescale.
+ */
+std::string renumberOntoPool(const std::vector<Source>& held, std::vector<ClipInfo>& clips) {
+    auto& pool = SourcePool::getInstance();
+    const auto mine = pool.snapshot();
+
+    pool.clear();
+    for (const auto& source : held)
+        pool.insert(source);
+
+    std::map<SourceId, SourceId> moved;
+    for (const auto& source : mine) {
+        const auto id = pool.acquire(source.filePath);
+        if (id == INVALID_SOURCE_ID)
+            return "the pool would not take " + quoted(source.filePath) + " back";
+
+        if (auto* pooled = pool.getMutable(id); pooled != nullptr) {
+            if (pooled->durationSeconds <= 0.0)
+                pooled->durationSeconds = source.durationSeconds;
+            if (pooled->sampleRate <= 0.0)
+                pooled->sampleRate = source.sampleRate;
+        }
+
+        if (id != source.id)
+            moved[source.id] = id;
+    }
+
+    if (moved.empty())
+        return {};
+
+    for (auto& clip : clips) {
+        if (!clip.isAudio())
+            continue;
+        for (auto& event : clip.audio().events)
+            if (const auto it = moved.find(event.sourceId); it != moved.end())
+                event.sourceId = it->second;
+    }
+
+    return {};
+}
+
 }  // namespace
 
 std::string refuseIndistinguishableSources(const std::vector<juce::String>& paths) {
@@ -248,6 +358,11 @@ FixtureLoad loadFixture(const MgdFixture& fixture, const juce::File& scratchDire
         return result;
     }
 
+    if (auto refusal = refuseHostedPlugins(staged); !refusal.empty()) {
+        result.failure = std::move(refusal);
+        return result;
+    }
+
     auto sources = everySource(staged);
 
     std::vector<juce::String> paths;
@@ -289,8 +404,30 @@ FixtureLoad loadFixture(const MgdFixture& fixture, const juce::File& scratchDire
     // remaps the events that referenced the provisional ones -- which is a
     // paragraph of behaviour a second implementation would get subtly wrong and
     // then agree with itself about.
+    //
+    // Then put back what it cleared, and renumber. That half is the corpus's
+    // problem rather than the app's: the app has one project open, so clearing
+    // the pool is exactly right for it and fatal here. `clear()` resets the id
+    // allocator to one, so two fixtures both come back holding source id 1 for
+    // different files, and a Case carries nothing but those numbers. Load the
+    // second and the first silently starts resolving its clips to the second's
+    // audio; load either and the code-built corpus, whose ids were handed out by
+    // the same allocator, starts resolving to a fixture's.
+    //
+    // Renumbering rather than asking callers to reinstall before rendering. The
+    // rest of the corpus already holds every case's sources in the pool at once,
+    // and a fixture that was only valid while it was the most recent thing
+    // loaded would be a second contract for whoever holds a corpus of them
+    // (#2081) to get right on every path.
+    const auto held = SourcePool::getInstance().snapshot();
+
     ProjectSerializer::installStagedSources(staged.sources, staged.legacySources, staged.clips);
     ProjectSerializer::resolveStagedSources(staged.sources);
+
+    if (auto refusal = renumberOntoPool(held, staged.clips); !refusal.empty()) {
+        result.failure = std::move(refusal);
+        return result;
+    }
 
     // --- the case ------------------------------------------------------------
     //
@@ -312,12 +449,23 @@ FixtureLoad loadFixture(const MgdFixture& fixture, const juce::File& scratchDire
     // 120 would put every clip somewhere the person who saved it never heard.
     result.value.tempo = {TempoPoint{.beat = 0.0, .bpm = staged.info.tempo}};
 
-    for (const auto& pooled : SourcePool::getInstance().snapshot()) {
+    // This project's sources, found by the files the rig wrote for it, rather
+    // than everything the pool holds. The pool now carries other cases' sources
+    // too, and a Case listing those would be claiming to play them.
+    auto& pool = SourcePool::getInstance();
+    for (const auto& [name, file] : result.written) {
+        const auto id = pool.findByPath(file.getFullPathName());
+        const auto* pooled = id != INVALID_SOURCE_ID ? pool.get(id) : nullptr;
+        if (pooled == nullptr) {
+            result.failure = "the stand-in written for " + quoted(name) + " is not pooled";
+            return result;
+        }
+
         SourceFact fact;
-        fact.id = pooled.id;
-        fact.path = pooled.filePath;
-        fact.sampleRate = pooled.sampleRate;
-        fact.durationSeconds = pooled.durationSeconds;
+        fact.id = pooled->id;
+        fact.path = pooled->filePath;
+        fact.sampleRate = pooled->sampleRate;
+        fact.durationSeconds = pooled->durationSeconds;
         result.value.sources.push_back(fact);
     }
 

--- a/tests/MgdFixture.cpp
+++ b/tests/MgdFixture.cpp
@@ -113,6 +113,11 @@ std::string writeAndRepoint(const std::vector<Source*>& sources, const Declarati
                             const juce::File& directory, std::vector<juce::File>& written) {
     auto& pool = SourcePool::getInstance();
 
+    // What each written file was written for, so the check below can name the
+    // pair rather than the count. Keyed on the file the writer produced,
+    // because that is the thing two sources can end up sharing.
+    std::map<juce::String, juce::String> writtenFor;
+
     for (auto* source : sources) {
         const auto name = fileNameOf(source->filePath);
         const auto* declaration = declared.at(name);
@@ -122,6 +127,22 @@ std::string writeAndRepoint(const std::vector<Source*>& sources, const Declarati
         const auto facts = factsOf(file);
         if (!facts.readable)
             return "the material written for " + quoted(name) + " does not read back";
+
+        // The same question the name check asked, asked again of the answer.
+        // That one predicts what the filesystem will do with two names; this one
+        // reads back what it did, so a collapse through anything the prediction
+        // does not model -- a separator, a symlink, a normalisation form -- is
+        // still refused rather than rendered.
+        //
+        // Keyed on the original path so that two entries for one file, which a
+        // v1 project produces and the source install is right to collapse, are
+        // not mistaken for two files sharing one.
+        const auto original = source->filePath;
+        if (const auto [claimed, first] = writtenFor.emplace(file.getFullPathName(), original);
+            !first && claimed->second != original)
+            return "the stand-ins for " + quoted(claimed->second) + " and " + quoted(original) +
+                   " are the same file on this filesystem, so the two would collapse into one "
+                   "source and their clips would play the same sound";
 
         source->filePath = file.getFullPathName();
         source->sampleRate = facts.sampleRate;
@@ -143,8 +164,18 @@ std::string refuseIndistinguishableSources(const std::vector<juce::String>& path
     std::map<juce::String, juce::String> byName;
 
     for (const auto& path : paths) {
+        // Folded, because the question is whether two names can name one file
+        // and the answer belongs to the filesystem the stand-ins are written
+        // to. macOS and Windows both answer yes by default, so "Loop.wav" and
+        // "loop.wav" are one file there and two here: comparing them exactly
+        // would let the pair through and then write the second over the first.
+        //
+        // Conservative on a case-sensitive filesystem, deliberately. A corpus
+        // that refuses a fixture on Linux and accepts it on macOS is worse than
+        // one that refuses it everywhere, because the failure would arrive on
+        // somebody else's machine.
         const auto name = fileNameOf(path);
-        const auto [existing, inserted] = byName.emplace(name, path);
+        const auto [existing, inserted] = byName.emplace(name.toLowerCase(), path);
         if (!inserted && existing->second != path)
             return "the project plays two different files both called " + quoted(name) + " (" +
                    existing->second.toStdString() + " and " + path.toStdString() +

--- a/tests/MgdFixture.cpp
+++ b/tests/MgdFixture.cpp
@@ -1,0 +1,231 @@
+#include "MgdFixture.hpp"
+
+#include <juce_audio_formats/juce_audio_formats.h>
+
+#include <map>
+#include <set>
+
+#include "core/SourcePool.hpp"
+#include "project/serialization/ProjectSerializer.hpp"
+
+namespace magda::nulldiff {
+namespace {
+
+/// What the written file actually is, read back rather than assumed.
+struct WrittenFacts {
+    bool readable = false;
+    double sampleRate = 0.0;
+    double durationSeconds = 0.0;
+};
+
+WrittenFacts factsOf(const juce::File& file) {
+    juce::AudioFormatManager formats;
+    formats.registerBasicFormats();
+
+    const std::unique_ptr<juce::AudioFormatReader> reader(formats.createReaderFor(file));
+    if (reader == nullptr || reader->sampleRate <= 0.0)
+        return {};
+
+    return {.readable = true,
+            .sampleRate = reader->sampleRate,
+            .durationSeconds = static_cast<double>(reader->lengthInSamples) / reader->sampleRate};
+}
+
+/// Every source the project references, across both of the lists a load can
+/// produce.
+///
+/// Two lists rather than one because a v1 project carried its source inline on
+/// the clip and a v2 project carries a pooled table, and a corpus of real
+/// projects has both in it: the oldest files here predate the table entirely.
+/// The rig walks them together, because "a source this project plays" is one
+/// question and which list it arrived in is an accident of when it was saved.
+std::vector<Source*> everySource(StagedProjectData& staged) {
+    std::vector<Source*> all;
+    all.reserve(staged.sources.size() + staged.legacySources.size());
+    for (auto& source : staged.sources)
+        all.push_back(&source);
+    for (auto& source : staged.legacySources)
+        all.push_back(&source);
+    return all;
+}
+
+std::string quoted(const juce::String& text) {
+    return "\"" + text.toStdString() + "\"";
+}
+
+/// The last component of a path that may name a volume this machine has never
+/// had. Built without checking, because checking is what it cannot do.
+juce::String fileNameOf(const juce::String& path) {
+    return juce::File::createFileWithoutCheckingPath(path).getFileName();
+}
+
+using Declarations = std::map<juce::String, const FixtureSource*>;
+
+/**
+ * @brief Pair every source the project plays with the manifest entry that
+ *        stands in for it, or say which one has no partner.
+ *
+ * Both directions. A project source the manifest does not name is the failure
+ * this rig is built around: its path points at a machine that is gone, so the
+ * case would reach a leg with a source that reads nothing, and nothing nulls
+ * against nothing. A manifest entry no source claims is refused for the reason
+ * the DAWproject loss table refuses one -- a declaration that has stopped being
+ * true is worse than no declaration, because it reads like coverage.
+ */
+std::string matchSources(const MgdFixture& fixture, const std::vector<Source*>& sources,
+                         Declarations& declared) {
+    for (const auto& source : fixture.sources) {
+        const juce::String name{source.fileName};
+        if (!declared.emplace(name, &source).second)
+            return "the manifest names " + quoted(name) + " twice";
+    }
+
+    std::set<juce::String> claimed;
+    for (const auto* source : sources) {
+        const auto name = fileNameOf(source->filePath);
+        if (declared.find(name) == declared.end())
+            return "the project plays " + quoted(name) +
+                   " and the manifest does not name it, so the case would render silence where "
+                   "that source should be";
+        claimed.insert(name);
+    }
+
+    for (const auto& [name, declaration] : declared)
+        if (claimed.count(name) == 0)
+            return "the manifest names " + quoted(name) + " and no source in the project claims it";
+
+    return {};
+}
+
+/**
+ * @brief Write each source's stand-in material and point the project at it.
+ *
+ * Written under the name the project referenced rather than an invented one, so
+ * a path in a failure message is still the path the project asked for and a
+ * scratch directory is readable by whoever is debugging a case.
+ *
+ * Read back rather than trusted. The manifest's rate and duration are what the
+ * material was asked for; what the file is is what a leg will play, and a spec
+ * whose duration does not survive the writer is a case rendering something
+ * other than what it declared.
+ */
+std::string writeAndRepoint(const std::vector<Source*>& sources, const Declarations& declared,
+                            const juce::File& scratchDirectory, std::vector<juce::File>& written) {
+    auto& pool = SourcePool::getInstance();
+
+    for (auto* source : sources) {
+        const auto name = fileNameOf(source->filePath);
+        const auto* declaration = declared.at(name);
+
+        const auto file = writeMaterial(
+            scratchDirectory, name.upToLastOccurrenceOf(".", false, false), declaration->material);
+        const auto facts = factsOf(file);
+        if (!facts.readable)
+            return "the material written for " + quoted(name) + " does not read back";
+
+        source->filePath = file.getFullPathName();
+        source->sampleRate = facts.sampleRate;
+        source->durationSeconds = facts.durationSeconds;
+
+        // Seeded rather than probed, the way every other case's material is:
+        // the install path acquires by path and would otherwise open the file a
+        // second time to learn what the reader just said.
+        pool.seedFactsForTesting(source->filePath, facts.durationSeconds, facts.sampleRate);
+        written.push_back(file);
+    }
+
+    return {};
+}
+
+}  // namespace
+
+juce::File fixtureCorpusDir() {
+    return juce::File(MAGDA_TEST_CORPUS_DIR);
+}
+
+FixtureLoad loadFixture(const MgdFixture& fixture, const juce::File& scratchDirectory) {
+    FixtureLoad result;
+    scratchDirectory.createDirectory();
+
+    const auto file = fixtureCorpusDir().getChildFile(fixture.file);
+    if (!file.existsAsFile()) {
+        result.failure =
+            "the fixture names a file that is not there: " + file.getFullPathName().toStdString();
+        return result;
+    }
+
+    StagedProjectData staged;
+    if (!ProjectSerializer::loadAndStage(file, staged)) {
+        result.failure =
+            "the project would not load: " + ProjectSerializer::getLastError().toStdString();
+        return result;
+    }
+
+    auto sources = everySource(staged);
+
+    Declarations declared;
+    if (auto refusal = matchSources(fixture, sources, declared); !refusal.empty()) {
+        result.failure = std::move(refusal);
+        return result;
+    }
+
+    // --- the material, written and then read back ----------------------------
+    //
+    // Written under the name the project referenced rather than under an
+    // invented one, so a path in a failure message is still the path the
+    // project asked for and a scratch directory is readable by whoever is
+    // debugging a case.
+    //
+    // Read back rather than trusted. The manifest's rate and duration are what
+    // the material was asked for; what the file is is what a leg will play, and
+    // a spec whose duration does not survive the writer is a case rendering
+    // something other than what it declared.
+
+    if (auto refusal = writeAndRepoint(sources, declared, scratchDirectory, result.written);
+        !refusal.empty()) {
+        result.failure = std::move(refusal);
+        return result;
+    }
+
+    // The app's own install, not a copy of it. It clears the pool, inserts the
+    // v2 table with ids preserved, acquires the v1 sources under real ids and
+    // remaps the events that referenced the provisional ones -- which is a
+    // paragraph of behaviour a second implementation would get subtly wrong and
+    // then agree with itself about.
+    ProjectSerializer::installStagedSources(staged.sources, staged.legacySources, staged.clips);
+    ProjectSerializer::resolveStagedSources(staged.sources);
+
+    // --- the case ------------------------------------------------------------
+    //
+    // The declarations first and the project over the top, so a manifest can
+    // never quietly assert a project different from the one on disk: every
+    // field the load fills is a field the manifest does not get to have an
+    // opinion about.
+
+    result.value = fixture.declaration;
+    result.value.tracks = std::move(staged.tracks);
+    if (staged.masterTrack != nullptr)
+        result.value.master = *staged.masterTrack;
+    result.value.clips = std::move(staged.clips);
+    result.value.lanes = std::move(staged.automationLanes);
+    result.value.automationClips = std::move(staged.automationClips);
+
+    // The project's own tempo rather than the corpus default. A case built in
+    // code chooses one; a real project already has one, and rendering it at
+    // 120 would put every clip somewhere the person who saved it never heard.
+    result.value.tempo = {TempoPoint{.beat = 0.0, .bpm = staged.info.tempo}};
+
+    for (const auto& pooled : SourcePool::getInstance().snapshot()) {
+        SourceFact fact;
+        fact.id = pooled.id;
+        fact.path = pooled.filePath;
+        fact.sampleRate = pooled.sampleRate;
+        fact.durationSeconds = pooled.durationSeconds;
+        result.value.sources.push_back(fact);
+    }
+
+    result.ok = true;
+    return result;
+}
+
+}  // namespace magda::nulldiff

--- a/tests/MgdFixture.hpp
+++ b/tests/MgdFixture.hpp
@@ -68,6 +68,9 @@
  * is a declaration that has stopped being true. That is the rule the DAWproject
  * loss table already lives by, and for the same reason -- a lossy mapping is a
  * fine thing to have written down and a bad thing to discover.
+ *
+ * So is a project whose sources cannot be told apart by the only part of a path
+ * a manifest can name. See @ref refuseIndistinguishableSources.
  */
 
 namespace magda::nulldiff {
@@ -147,6 +150,35 @@ struct FixtureLoad {
  * neither is anything else that reads the pool while it runs.
  */
 FixtureLoad loadFixture(const MgdFixture& fixture, const juce::File& scratchDirectory);
+
+/**
+ * @brief Why @p paths cannot be stood in for, or empty if they can.
+ *
+ * A manifest names a source by the last component of its path, because the rest
+ * of it names a volume that is gone and a manifest carrying somebody's home
+ * directory would have to be rewritten the day the project moved -- which is
+ * exactly what a migration fixture may never do.
+ *
+ * That leaves one thing a project can do that a manifest cannot express: play
+ * two different files that happen to share a name. `/packA/loop.wav` and
+ * `/packB/loop.wav` are two sounds, and every part of the rig would treat them
+ * as one. They would match the same declaration, be written to the same file,
+ * and then collapse for real in the source install, which dedups by canonical
+ * path: the two clips would come out playing the same thing, and the case would
+ * render something the project never was.
+ *
+ * Refused rather than papered over with a unique suffix, and the difference
+ * matters. Making the writes distinct would stop the collapse and leave the
+ * manifest still unable to say which of the two is the drum loop and which is
+ * the riser, so both would silently take one MaterialSpec. A corpus that cannot
+ * describe a project should say so, and a fixture that needs this is a reason
+ * to extend the key rather than to let one stand in for both.
+ *
+ * Exposed rather than kept inside the load because it is a rule about what a
+ * fixture can be, not a step in reading one, and because provoking it through a
+ * load would mean checking in a project built to break it.
+ */
+std::string refuseIndistinguishableSources(const std::vector<juce::String>& paths);
 
 /// Where the fixtures live, as configured by CMake.
 juce::File fixtureCorpusDir();

--- a/tests/MgdFixture.hpp
+++ b/tests/MgdFixture.hpp
@@ -1,0 +1,157 @@
+#pragma once
+
+#include <juce_core/juce_core.h>
+
+#include <string>
+#include <vector>
+
+#include "NullDiffCase.hpp"
+#include "NullDiffMaterial.hpp"
+
+/**
+ * @file MgdFixture.hpp
+ * @brief A real project turned into a null-diff case (#2173).
+ *
+ * Every case in the corpus today is built in code, and #2040 settled that
+ * argument for the cases it covered: a load adds a step neither leg is testing
+ * and a binary to the repository, and thirty lines of value initialisation is
+ * reviewable as a diff. That reasoning still holds there and this does not
+ * replace it.
+ *
+ * It stops holding for a project somebody actually made, because what those are
+ * worth testing for is the combinations nobody would have thought to write
+ * down: a rack inside a rack with a modifier on a send, sixty tracks, an
+ * arrangement forty minutes long. A case built in code tests the rules whoever
+ * wrote it knew about.
+ *
+ * ## A fixture is a file plus a manifest
+ *
+ * The load already produces model values. `ProjectSerializer::loadAndStage`
+ * fills a `StagedProjectData` on any thread without touching a singleton, and
+ * what it fills is close to the half of a `Case` that describes the project.
+ * What is missing is everything a case declares on top of one: the range to
+ * render, the tier, the figures that tier needs, and the environment.
+ *
+ * None of that can live in the file. A `.mgd` is what the app writes and there
+ * is nowhere in it to say what two engines owe each other. So the manifest
+ * carries a `Case` holding only its declarations, and the load fills in the
+ * project half. A fixture is the file plus the half a `.mgd` cannot hold.
+ *
+ * ## The audio is generated rather than checked in
+ *
+ * A saved project references its sources by path and those paths point at
+ * machines that are gone: an external SSD, somebody's Music folder, a bounces
+ * directory under a project that was deleted. Every one of the projects in the
+ * legacy corpus is like this and always will be, because the bytes must never
+ * be rewritten.
+ *
+ * So the manifest names, per source, the `MaterialSpec` that stands in for it,
+ * and the rig writes it into the scratch directory and repoints the source
+ * before either leg sees the case. Same rule as the rest of the corpus and the
+ * same two reasons: a fixture recorded once is a fixture nobody can regenerate
+ * when a case needs one bar more, and a corpus carrying a sample library grows
+ * a megabyte per project.
+ *
+ * Choosing the kind is a judgement about what stands between the two engines on
+ * that source's path, the way #2040 chooses it per case. A stretched clip fed
+ * impulses reports the distance between two interpolators rather than anything
+ * about placement.
+ *
+ * ## What the rig refuses
+ *
+ * A source the project references that the manifest does not name is a failure,
+ * not a gap to fill in later. That case would reach a leg with a source pointing
+ * at a path that does not exist, so it would render silence, and silence nulls
+ * against silence perfectly well. It is the failure this rig is built around.
+ *
+ * The reverse is refused too: a manifest entry no source in the project claims
+ * is a declaration that has stopped being true. That is the rule the DAWproject
+ * loss table already lives by, and for the same reason -- a lossy mapping is a
+ * fine thing to have written down and a bad thing to discover.
+ */
+
+namespace magda::nulldiff {
+
+/**
+ * @brief What stands in for one source the project references.
+ *
+ * Matched on the file name rather than the whole path, and that is not a
+ * shortcut. The path in a saved project names a volume that is gone, so the
+ * only part of it still meaningful is the last component; and a manifest
+ * carrying somebody's home directory would have to be rewritten the day the
+ * project moved, which is exactly what these files may never do.
+ */
+struct FixtureSource {
+    /// The file name the project's own path ends in, e.g. "kick.wav".
+    const char* fileName = "";
+
+    /// What is written in its place, and why that kind. The rig checks the
+    /// written file back against this rather than trusting it.
+    MaterialSpec material;
+
+    /// What this source is in the project, in a phrase. Printed beside a
+    /// failure, because "source 3 disagreed" is only useful to whoever wrote it.
+    const char* covers = "";
+};
+
+/**
+ * @brief One real project, with everything the file cannot say about it.
+ *
+ * @c declaration is a `Case` carrying only its declarations: the name, what it
+ * covers, the tier and its figures, the range and the environment. Its project
+ * half is left empty and filled by the load, so a fixture cannot quietly assert
+ * a project different from the one on disk.
+ */
+struct MgdFixture {
+    /// Relative to the corpus root, e.g. "legacy/projects/0.13.0-retrovid.mgd".
+    const char* file = "";
+
+    /// The version string the saving build wrote, as a fact about the file
+    /// rather than something the rig reads. A fixture whose bytes were replaced
+    /// by a newer save would still load; this is what says it should not have
+    /// been.
+    const char* savedBy = "";
+
+    /// Whether these bytes are a migration fixture (#2079) and therefore
+    /// unrewritable, or a project saved for this corpus and free to be resaved
+    /// when a case needs one bar more. See tests/corpus/legacy/README.md.
+    bool isMigrationFixture = true;
+
+    Case declaration;
+    std::vector<FixtureSource> sources;
+};
+
+/// What loading one fixture produced, or why it could not be loaded.
+struct FixtureLoad {
+    bool ok = false;
+
+    /// Why not. Empty on success, and the only thing a caller should print.
+    std::string failure;
+
+    /// The case, ready for either leg. Meaningless unless @c ok.
+    Case value;
+
+    /// What the rig wrote, in the order the manifest names them. Carried so a
+    /// test can check the files back without reproducing the naming.
+    std::vector<juce::File> written;
+};
+
+/**
+ * @brief Load @p fixture, writing its material into @p scratchDirectory.
+ *
+ * Drives the app's own load and its own source install rather than a copy of
+ * them, for the reason the incumbent leg drives `PluginManager`: a second
+ * implementation is something that can agree with itself while both are wrong.
+ *
+ * Touches `SourcePool`, which the install path clears. Not thread safe, and
+ * neither is anything else that reads the pool while it runs.
+ */
+FixtureLoad loadFixture(const MgdFixture& fixture, const juce::File& scratchDirectory);
+
+/// Where the fixtures live, as configured by CMake.
+juce::File fixtureCorpusDir();
+
+/// Every fixture the corpus declares.
+const std::vector<MgdFixture>& mgdFixtures();
+
+}  // namespace magda::nulldiff

--- a/tests/MgdFixture.hpp
+++ b/tests/MgdFixture.hpp
@@ -72,6 +72,22 @@
  *
  * So is a project whose sources cannot be told apart by the only part of a path
  * a manifest can name. See @ref refuseIndistinguishableSources.
+ *
+ * And so is a project that hosts an external plugin. Without the plugin
+ * installed both legs render a passthrough and agree about nothing; with it
+ * installed the incumbent hosts it and the native leg cannot, so the verdict
+ * becomes a fact about the machine. #2175 reserves those for the invariant tier
+ * and an absent-plugin gate, which is a different slice and a different verdict.
+ *
+ * ## A loaded fixture keeps its ids
+ *
+ * A `Case` carries source ids and nothing else; the legs resolve them through
+ * the global `SourcePool`. The app's install clears that pool and resets its id
+ * allocator, which is right for an app with one project open and fatal for a
+ * corpus holding several cases: two fixtures would both come back holding id 1
+ * for different files. The rig therefore puts back what the install cleared and
+ * moves this project's sources to ids nothing else is using, so every case
+ * loaded stays resolvable while the others are.
  */
 
 namespace magda::nulldiff {
@@ -107,7 +123,7 @@ struct FixtureSource {
  * a project different from the one on disk.
  */
 struct MgdFixture {
-    /// Relative to the corpus root, e.g. "legacy/projects/0.13.0-retrovid.mgd".
+    /// Relative to the corpus root, e.g. "legacy/projects/0.15.0-demo.mgd".
     const char* file = "";
 
     /// The version string the saving build wrote, as a fact about the file

--- a/tests/MgdFixture.hpp
+++ b/tests/MgdFixture.hpp
@@ -167,6 +167,14 @@ FixtureLoad loadFixture(const MgdFixture& fixture, const juce::File& scratchDire
  * path: the two clips would come out playing the same thing, and the case would
  * render something the project never was.
  *
+ * Compared with case folded, because whether two names can name one file is the
+ * filesystem's question and macOS and Windows both answer yes by default. That
+ * is conservative on a case-sensitive filesystem on purpose: a corpus that
+ * refuses a fixture on Linux and accepts it on macOS is worse than one that
+ * refuses it everywhere, because the failure would arrive on somebody else's
+ * machine. The load asks the same question again of the files it actually
+ * wrote, so a collapse through anything this does not model is still refused.
+ *
  * Refused rather than papered over with a unique suffix, and the difference
  * matters. Making the writes distinct would stop the collapse and leave the
  * manifest still unable to say which of the two is the drum loop and which is

--- a/tests/MgdFixture.hpp
+++ b/tests/MgdFixture.hpp
@@ -2,6 +2,7 @@
 
 #include <juce_core/juce_core.h>
 
+#include <map>
 #include <string>
 #include <vector>
 
@@ -134,9 +135,15 @@ struct FixtureLoad {
     /// The case, ready for either leg. Meaningless unless @c ok.
     Case value;
 
-    /// What the rig wrote, in the order the manifest names them. Carried so a
-    /// test can check the files back without reproducing the naming.
-    std::vector<juce::File> written;
+    /// The stand-in written for each source the manifest names, keyed by that
+    /// name. Carried so a caller can check the files back without reproducing
+    /// the naming, and keyed rather than ordered because the order a project
+    /// stages its sources in is not the order a manifest lists them.
+    ///
+    /// One entry per manifest source, never per staged source. A project may
+    /// name one file twice -- a v2 table entry beside a v1 clip that migrated
+    /// to the same path -- and those are one sound sharing one stand-in.
+    std::map<juce::String, juce::File> written;
 };
 
 /**

--- a/tests/MgdFixture.hpp
+++ b/tests/MgdFixture.hpp
@@ -172,8 +172,14 @@ FixtureLoad loadFixture(const MgdFixture& fixture, const juce::File& scratchDire
  * is conservative on a case-sensitive filesystem on purpose: a corpus that
  * refuses a fixture on Linux and accepts it on macOS is worse than one that
  * refuses it everywhere, because the failure would arrive on somebody else's
- * machine. The load asks the same question again of the files it actually
- * wrote, so a collapse through anything this does not model is still refused.
+ * machine.
+ *
+ * Folding is all a comparison of strings can do, and it is not everything the
+ * filesystem does: macOS stores some names decomposed and some composed, so two
+ * paths can differ as strings, fold differently, and still name one file. The
+ * load catches that by counting what its own directory holds after each write
+ * rather than by comparing another pair of strings, which would miss it for the
+ * same reason this does.
  *
  * Refused rather than papered over with a unique suffix, and the difference
  * matters. Making the writes distinct would stop the collapse and leave the

--- a/tests/MgdFixtures.cpp
+++ b/tests/MgdFixtures.cpp
@@ -1,0 +1,159 @@
+#include "MgdFixture.hpp"
+
+/**
+ * @file MgdFixtures.cpp
+ * @brief Which real projects the corpus carries, and what each declares
+ *        (#2173).
+ *
+ * Separate from the rig for the reason NullDiffCorpus.cpp is separate from
+ * NullDiffCase.hpp: the table is a description of what is being tested and the
+ * rig is machinery, and a reader who wants to know what the corpus covers
+ * should not have to read a source installer to find out.
+ *
+ * ## Reuse or save new
+ *
+ * #2173 left this decision to whoever wrote the slice, and the answer is both,
+ * recorded per fixture in `isMigrationFixture`.
+ *
+ * Twenty-two real projects are already checked in under `corpus/legacy/projects`
+ * for #2079, saved by builds from the oldest openable format through 0.18.0, and
+ * reusing one costs nothing to store. What it costs instead is the freedom to
+ * change it: those bytes are migration fixtures and must never be rewritten, so
+ * a render case built on one can never ask it for one bar more, for a source
+ * that suits it better, or for a device it would rather exercise. It gets the
+ * project as somebody actually saved it, which is the whole point, and it gets
+ * nothing else.
+ *
+ * So: reuse where a project earns its place by being a real arrangement nobody
+ * would have written down, and save new ones where the material has to be
+ * designed. This slice reuses, because the rig is what is being proved and
+ * saving projects needs the app. #2081 is where the designed ones arrive.
+ *
+ * ## Choosing material for a source nobody still has
+ *
+ * Every path in these files points at a machine that is gone, so every source
+ * is a judgement rather than a recovery. The judgement is the corpus's usual
+ * one (#2040): what stands between the two engines on this source's path.
+ *
+ * A clip that plays at its own rate and lands where it was placed wants
+ * impulses, because placement is the whole assertion and there is nothing to
+ * interpolate. A clip the project stretched wants a tone, because impulses
+ * through two different stretchers measure the distance between two
+ * interpolators and say nothing about the clip. A clip whose level is what the
+ * case is reading wants steps.
+ *
+ * The durations are not the originals and are not trying to be. A source is
+ * long enough that the clip reading it does not run out, and no longer: the
+ * original was eleven or twenty-nine seconds of somebody's Splice library, and
+ * writing thirty seconds of tone to stand in for a clip that plays four bars of
+ * it would cost the run a second of disk per fixture for nothing.
+ */
+
+namespace magda::nulldiff {
+namespace {
+
+MaterialSpec impulsesFor(double seconds, double interval) {
+    MaterialSpec spec;
+    spec.kind = MaterialKind::Impulses;
+    spec.sampleRate = 44100.0;
+    spec.durationSeconds = seconds;
+    spec.intervalSeconds = interval;
+    return spec;
+}
+
+MaterialSpec toneFor(double seconds, double frequency) {
+    MaterialSpec spec;
+    spec.kind = MaterialKind::Tone;
+    spec.sampleRate = 44100.0;
+    spec.durationSeconds = seconds;
+    spec.frequency = frequency;
+    return spec;
+}
+
+Case declarationFor(const char* name, const char* covers, double endBeat) {
+    Case value;
+    value.name = name;
+    value.covers = covers;
+    value.startBeat = 0.0;
+    value.endBeat = endBeat;
+
+    // Left at the corpus default deliberately. What tier a real project owes is
+    // decided when it has been rendered through both legs and the answer is a
+    // number, which is #2081; declaring one here would be choosing the verdict
+    // before the measurement. This slice renders nothing.
+    value.tier = AudioTier::Exact;
+    return value;
+}
+
+std::vector<MgdFixture> build() {
+    std::vector<MgdFixture> fixtures;
+
+    {
+        // A real arrangement, and the first thing in the corpus that nobody
+        // wrote down: four tracks, nine clips at 92 bpm, and eight sources off
+        // three different dead volumes -- an external SSD, a home Music folder,
+        // and a bounces directory under a project that no longer exists. Two of
+        // the eight are bounces of other clips in the same project, which is a
+        // shape a case built in code would never have thought to have.
+        //
+        // Reused rather than saved: it earns its place by being an arrangement
+        // rather than a demonstration, and being a migration fixture costs this
+        // case nothing it wanted.
+        MgdFixture fixture;
+        fixture.file = "legacy/projects/0.13.0-retrovid.mgd";
+        fixture.savedBy = "0.13.0-rc1";
+        fixture.isMigrationFixture = true;
+        fixture.declaration = declarationFor(
+            "project.retrovid", "a four-track arrangement at 92 bpm over eight sources", 32.0);
+
+        // Impulses almost throughout: these clips play at the project's own
+        // tempo and what the corpus wants off them is where they land. The two
+        // exceptions are the ones the project stretched, and a stretched clip
+        // fed impulses reports the distance between two interpolators.
+        //
+        // The intervals differ per source on purpose. Equal grids sum exactly
+        // whatever order they are added in, so eight identical sources would
+        // agree by arithmetic rather than by the two engines placing the same
+        // things in the same places.
+        fixture.sources = {
+            {.fileName = "SA_MU_118_electric_guitar_loop_funky_wah_Amaj.wav",
+             .material = toneFor(18.0, 220.0),
+             .covers = "a guitar loop the project stretched from 118 to 92"},
+            {.fileName = "mdh_drm120_touch_stp.wav",
+             .material = impulsesFor(6.0, 0.25),
+             .covers = "a drum loop at its own rate"},
+            {.fileName = "SLS_O_65_guitar_soul_serenade_Cmin.wav",
+             .material = toneFor(32.0, 330.0),
+             .covers = "a 65 bpm loop stretched to 92, the widest ratio in the project"},
+            {.fileName = "BS_NCS3_140_bass_growl_leap_Dbmin.wav",
+             .material = impulsesFor(8.0, 0.3),
+             .covers = "a bass one-shot"},
+            {.fileName = "TAMUZ_TD_90_drum_best_simple_trashy.wav",
+             .material = impulsesFor(23.0, 0.5),
+             .covers = "the longest loop, near enough the project tempo to play unstretched"},
+            {.fileName = "DS_OT_fx_riser_dark_20260701_153831.wav",
+             .material = impulsesFor(9.0, 0.7),
+             .covers =
+                 "a bounce of the riser below, which is what makes two sources name one sound"},
+            {.fileName = "mdh_drm120_touch_stp_(copy)_20260701_145457.wav",
+             .material = impulsesFor(19.0, 0.35),
+             .covers = "a bounce of the drum loop above, under a name with brackets in it"},
+            {.fileName = "DS_OT_fx_riser_dark.wav",
+             .material = impulsesFor(3.0, 0.2),
+             .covers = "the riser itself, a short one-shot"},
+        };
+
+        fixtures.push_back(std::move(fixture));
+    }
+
+    return fixtures;
+}
+
+}  // namespace
+
+const std::vector<MgdFixture>& mgdFixtures() {
+    static const std::vector<MgdFixture> fixtures = build();
+    return fixtures;
+}
+
+}  // namespace magda::nulldiff

--- a/tests/MgdFixtures.cpp
+++ b/tests/MgdFixtures.cpp
@@ -43,10 +43,10 @@
  * case is reading wants steps.
  *
  * The durations are not the originals and are not trying to be. A source is
- * long enough that the clip reading it does not run out, and no longer: the
- * original was eleven or twenty-nine seconds of somebody's Splice library, and
- * writing thirty seconds of tone to stand in for a clip that plays four bars of
- * it would cost the run a second of disk per fixture for nothing.
+ * long enough that the clip reading it does not run out, and no longer. The
+ * original was eleven seconds of somebody's Splice library; writing thirty
+ * seconds of tone to stand in for a clip that plays four bars of it would cost
+ * the run a second of disk per fixture for nothing.
  */
 
 namespace magda::nulldiff {
@@ -88,59 +88,66 @@ Case declarationFor(const char* name, const char* covers, double endBeat) {
 std::vector<MgdFixture> build() {
     std::vector<MgdFixture> fixtures;
 
+    // Both of these are internal-device projects, and that is a requirement
+    // rather than what was to hand. A project hosting a VST3 cannot be held to a
+    // null: without the plugin installed both legs render a passthrough and pass
+    // by agreeing about nothing, and with it installed the incumbent hosts it
+    // while the native leg cannot, so the verdict becomes a fact about the
+    // machine. #2175 reserves those projects for the invariant tier and an
+    // absent-plugin gate, and they belong there rather than here.
+    //
+    // Half the legacy corpus is out on that rule -- retrovid and envfollower
+    // carry Retrospect, groups carries Pro-L 2, overlaps carries Pianoteq -- and
+    // the check is `format`, which is VST3 at zero and Internal at three.
+
     {
-        // A real arrangement, and the first thing in the corpus that nobody
-        // wrote down: four tracks, nine clips at 92 bpm, and eight sources off
-        // three different dead volumes -- an external SSD, a home Music folder,
-        // and a bounces directory under a project that no longer exists. Two of
-        // the eight are bounces of other clips in the same project, which is a
-        // shape a case built in code would never have thought to have.
-        //
-        // Reused rather than saved: it earns its place by being an arrangement
-        // rather than a demonstration, and being a migration fixture costs this
-        // case nothing it wanted.
+        // The arrangement: eight tracks and sixty-nine clips at 120 bpm, one of
+        // them audio and the rest MIDI, with an automation lane over the top.
+        // That shape is the argument for loading a project at all. Nobody
+        // writing a case in code produces sixty-eight MIDI clips across eight
+        // tracks to see what happens; somebody making a demo does.
         MgdFixture fixture;
-        fixture.file = "legacy/projects/0.13.0-retrovid.mgd";
-        fixture.savedBy = "0.13.0-rc1";
+        fixture.file = "legacy/projects/0.15.0-demo.mgd";
+        fixture.savedBy = "0.15.0-9-gf444267f";
+        fixture.isMigrationFixture = true;
+        fixture.declaration =
+            declarationFor("project.demo", "eight tracks and sixty-nine clips at 120 bpm", 32.0);
+
+        // A tone, because the clip reading it is stretched: the project plays a
+        // loop recorded at one tempo inside an arrangement at another, and
+        // impulses through two different stretchers report the distance between
+        // two interpolators rather than anything about the clip.
+        fixture.sources = {
+            {.fileName = "SA_MU_89_electric_guitar_loop_arp_chillin_vibrato_Emin.wav",
+             .material = toneFor(14.0, 220.0),
+             .covers = "a guitar loop the arrangement stretched from 82 to 120"},
+        };
+
+        fixtures.push_back(std::move(fixture));
+    }
+
+    {
+        // A second project, and the point of it is that there are two. A Case
+        // carries source ids and nothing else, so two of them loaded at once is
+        // the arrangement under which those ids either stay meaningful or
+        // quietly start naming each other's audio. One fixture can never show
+        // that.
+        //
+        // Small on purpose: two tracks, two clips, two automation lanes. What it
+        // adds is a second project and an automation lane, not more surface.
+        MgdFixture fixture;
+        fixture.file = "legacy/projects/0.11.1-automation.mgd";
+        fixture.savedBy = "0.11.1-119-gbe8377ce0";
         fixture.isMigrationFixture = true;
         fixture.declaration = declarationFor(
-            "project.retrovid", "a four-track arrangement at 92 bpm over eight sources", 32.0);
+            "project.automation", "two tracks under two automation lanes at 120 bpm", 16.0);
 
-        // Impulses almost throughout: these clips play at the project's own
-        // tempo and what the corpus wants off them is where they land. The two
-        // exceptions are the ones the project stretched, and a stretched clip
-        // fed impulses reports the distance between two interpolators.
-        //
-        // The intervals differ per source on purpose. Equal grids sum exactly
-        // whatever order they are added in, so eight identical sources would
-        // agree by arithmetic rather than by the two engines placing the same
-        // things in the same places.
+        // Impulses: this clip plays at its own rate, so where it lands is the
+        // whole of what a render would be asserting.
         fixture.sources = {
-            {.fileName = "SA_MU_118_electric_guitar_loop_funky_wah_Amaj.wav",
-             .material = toneFor(18.0, 220.0),
-             .covers = "a guitar loop the project stretched from 118 to 92"},
-            {.fileName = "mdh_drm120_touch_stp.wav",
-             .material = impulsesFor(6.0, 0.25),
-             .covers = "a drum loop at its own rate"},
-            {.fileName = "SLS_O_65_guitar_soul_serenade_Cmin.wav",
-             .material = toneFor(32.0, 330.0),
-             .covers = "a 65 bpm loop stretched to 92, the widest ratio in the project"},
-            {.fileName = "BS_NCS3_140_bass_growl_leap_Dbmin.wav",
-             .material = impulsesFor(8.0, 0.3),
-             .covers = "a bass one-shot"},
-            {.fileName = "TAMUZ_TD_90_drum_best_simple_trashy.wav",
-             .material = impulsesFor(23.0, 0.5),
-             .covers = "the longest loop, near enough the project tempo to play unstretched"},
-            {.fileName = "DS_OT_fx_riser_dark_20260701_153831.wav",
-             .material = impulsesFor(9.0, 0.7),
-             .covers =
-                 "a bounce of the riser below, which is what makes two sources name one sound"},
-            {.fileName = "mdh_drm120_touch_stp_(copy)_20260701_145457.wav",
-             .material = impulsesFor(19.0, 0.35),
-             .covers = "a bounce of the drum loop above, under a name with brackets in it"},
-            {.fileName = "DS_OT_fx_riser_dark.wav",
-             .material = impulsesFor(3.0, 0.2),
-             .covers = "the riser itself, a short one-shot"},
+            {.fileName = "HeartBreaker Layered Master-bounce-10.wav",
+             .material = impulsesFor(4.0, 0.25),
+             .covers = "a bounced break, played unstretched"},
         };
 
         fixtures.push_back(std::move(fixture));

--- a/tests/corpus/legacy/README.md
+++ b/tests/corpus/legacy/README.md
@@ -51,9 +51,20 @@ these or save its own. The rule, recorded per fixture in
 `MgdFixture::isMigrationFixture`:
 
 **Reuse where a project earns its place by being a real arrangement** that
-nobody would have written down. That is the whole value of this directory: four
-tracks at 92 bpm with two bounces of its own clips in it is a shape a
-hand-written case never has.
+nobody would have written down. That is the whole value of this directory:
+eight tracks carrying sixty-eight MIDI clips, one audio clip and an automation
+lane is a shape a hand-written case never has.
+
+**Never reuse one that hosts a plugin.** Roughly half of these do: retrovid and
+envfollower carry Retrospect, groups carries Pro-L 2, overlaps carries Pianoteq.
+A project with a VST3 in it has no verdict a null-diff corpus can hold it to.
+Without the plugin installed both legs render a passthrough and pass by agreeing
+about nothing; with it installed the incumbent hosts it and the native engine
+cannot, so whether the case passes becomes a fact about the machine that ran it.
+Those projects belong to #2175, with the invariant tier and a gate that calls an
+absent plugin unmeasurable rather than equal. The fixture rig refuses them
+outright, because a tier is a field somebody fills in and the plugin format is a
+fact about the file.
 
 **Save new where the material has to be designed.** A fixture reused from here
 can never be asked for one bar more, for a source that suits a case better, or

--- a/tests/corpus/legacy/README.md
+++ b/tests/corpus/legacy/README.md
@@ -1,0 +1,67 @@
+# The legacy corpus
+
+Real projects and presets saved by released builds of MAGDA, checked in and
+loaded on every test run.
+
+Everything else in the validation harness builds its cases in code (#2040),
+because a case built in code is reviewable and cannot drift. This corpus is the
+deliberate exception: the load is the thing under test, so a case that skips the
+file tests nothing.
+
+`projects/` holds twenty-two `.mgd` files, oldest format first. `presets/` holds
+device presets from the same era. `tests/LegacyCorpus.hpp` is the index: it
+records, per project, what the file contains, read out of the saved JSON by hand
+rather than recorded from a load, so a regression that silently drops tracks,
+clips, devices or automation shows up as a mismatch instead of being re-recorded
+as the new expectation.
+
+## Never rewrite these bytes
+
+Not to tidy a path, not to shrink a file, not to fix a typo in a track name, and
+not to resave one through a newer build so it stops needing a migration.
+
+These files exist to prove that a project somebody saved years ago still opens,
+and the only way they can prove it is by being what was actually written. A
+resaved fixture tests the current writer against the current reader, which is a
+thing every other test in the suite already does.
+
+The version in each filename is the build that saved it. `1.0.0` is not a
+release: it is the placeholder version string builds carried before the version
+was wired to the tag, so those three files are the oldest format still openable.
+
+## The dead paths are permanent
+
+Every audio source in these projects points at a machine that is gone: an
+external SSD, somebody's Music folder, a bounces directory under a project that
+was deleted years ago. That is not damage to be repaired. Repairing it would
+mean rewriting the bytes.
+
+Anything that needs one of these projects to actually make a sound stands in for
+its sources rather than finding them. The `.mgd` fixture rig (#2173,
+`tests/MgdFixture.hpp`) is where that happens: a manifest names, per source, the
+`MaterialSpec` written in its place, and the rig repoints the project before
+either engine sees it. A source the manifest fails to name is a hard failure
+there, because a source that resolves to nothing renders silence and silence
+nulls against silence perfectly well.
+
+## Reuse here, or save new elsewhere
+
+The render corpus (#2081) has to decide, per project, whether to reuse one of
+these or save its own. The rule, recorded per fixture in
+`MgdFixture::isMigrationFixture`:
+
+**Reuse where a project earns its place by being a real arrangement** that
+nobody would have written down. That is the whole value of this directory: four
+tracks at 92 bpm with two bounces of its own clips in it is a shape a
+hand-written case never has.
+
+**Save new where the material has to be designed.** A fixture reused from here
+can never be asked for one bar more, for a source that suits a case better, or
+for a device it would rather exercise, because that would mean rewriting bytes
+that may not be rewritten. A case that needs any of those needs its own project,
+saved for the render corpus and free to be resaved.
+
+A fixture saved for the render corpus does not belong in this directory. It is
+not a migration fixture, it carries none of the guarantees above, and putting it
+here would make the rule about never rewriting apply to a file the rule was never
+meant to cover.

--- a/tests/test_mgd_fixture_rig.cpp
+++ b/tests/test_mgd_fixture_rig.cpp
@@ -219,6 +219,55 @@ TEST_CASE("Two project sources that share a name are refused", "[nulldiff][fixtu
     CHECK(refuseIndistinguishableSources({"/packs/a/Loop.wav", "/packs/a/Loop.wav"}).empty());
 }
 
+TEST_CASE("Two names the filesystem calls one file are counted, not compared",
+          "[nulldiff][fixture]") {
+    // The premise the load's collision check rests on, asserted against a real
+    // directory rather than described in a comment.
+    //
+    // "cafe" with an acute accent has two spellings in Unicode: one code point,
+    // or an "e" followed by a combining accent. macOS stores whichever it was
+    // given, so a project referencing one pack that used each produces two paths
+    // that differ as strings, fold differently, and name one file. Every string
+    // comparison misses that, including a comparison of the paths the writer
+    // returned, which is what this used to do.
+    //
+    // So the load counts what its own directory holds after each write instead.
+    // This is what says the count can tell them apart: whatever the filesystem
+    // does with the pair, the number of files is the number of distinct sounds.
+    auto directory = scratch().getChildFile("normalisation");
+    directory.deleteRecursively();
+    directory.createDirectory();
+
+    const auto composed = juce::String::fromUTF8("caf\xc3\xa9");
+    const auto decomposed = juce::String::fromUTF8("cafe\xcc\x81");
+    REQUIRE(composed != decomposed);
+    CHECK(composed.toLowerCase() != decomposed.toLowerCase());
+
+    MaterialSpec spec;
+    spec.kind = MaterialKind::Impulses;
+    spec.durationSeconds = 0.25;
+
+    const auto first = writeMaterial(directory, composed, spec);
+    const auto second = writeMaterial(directory, decomposed, spec);
+    REQUIRE(first.existsAsFile());
+    REQUIRE(second.existsAsFile());
+
+    // Whatever this machine did, the count says it: one file where the two
+    // spellings met, two where they did not. The load refuses on the first.
+    const auto held = directory.getNumberOfChildFiles(juce::File::findFiles);
+    REQUIRE((held == 1 || held == 2));
+
+    // Where they met, the two paths the writer handed back are still two
+    // different strings, and that is the whole finding. The check that compared
+    // those paths saw two files and let the pair through; only the count knew
+    // better. On a filesystem that keeps them apart there is nothing here to
+    // catch, which is why this asserts what happened rather than which.
+    if (held == 1)
+        CHECK(first.getFullPathName() != second.getFullPathName());
+
+    directory.deleteRecursively();
+}
+
 TEST_CASE("Each fixture's material is its own", "[nulldiff][fixture]") {
     const PoolUnwind unwind;
 

--- a/tests/test_mgd_fixture_rig.cpp
+++ b/tests/test_mgd_fixture_rig.cpp
@@ -129,24 +129,33 @@ TEST_CASE("Every source reads back as what the manifest asked for", "[nulldiff][
         const auto loaded = loadFixture(fixture, scratch());
         INFO(loaded.failure);
         REQUIRE(loaded.ok);
+        // One stand-in per source the manifest names, whatever the project did.
+        // A project may name one file twice and those share a stand-in, so this
+        // counts declarations rather than staged sources.
         REQUIRE(loaded.written.size() == fixture.sources.size());
 
-        for (std::size_t i = 0; i < loaded.written.size(); ++i) {
-            const auto& file = loaded.written[i];
-            const auto& declared = fixture.sources[i].material;
-            INFO(fixture.sources[i].fileName << ": " << fixture.sources[i].covers);
+        for (const auto& declared : fixture.sources) {
+            INFO(declared.fileName << ": " << declared.covers);
 
+            // Looked up by name rather than by position. The order a project
+            // stages its sources in is the order it was saved in, and the order
+            // a manifest lists them is whatever reads best; pairing the two by
+            // index is a coincidence that holds until a fixture is reordered.
+            const auto found = loaded.written.find(juce::String(declared.fileName));
+            REQUIRE(found != loaded.written.end());
+
+            const auto& file = found->second;
             REQUIRE(file.existsAsFile());
 
             const std::unique_ptr<juce::AudioFormatReader> reader(formats.createReaderFor(file));
             REQUIRE(reader != nullptr);
-            CHECK(reader->sampleRate == declared.sampleRate);
+            CHECK(reader->sampleRate == declared.material.sampleRate);
 
             // Whole samples rather than seconds. A duration that does not land
             // on a sample boundary is rounded by the writer, and asserting the
             // seconds back would be asserting the rounding.
-            const auto expected =
-                static_cast<juce::int64>(declared.durationSeconds * declared.sampleRate);
+            const auto expected = static_cast<juce::int64>(declared.material.durationSeconds *
+                                                           declared.material.sampleRate);
             CHECK(reader->lengthInSamples == expected);
         }
 
@@ -288,8 +297,8 @@ TEST_CASE("Each fixture's material is its own", "[nulldiff][fixture]") {
         INFO(loaded.failure);
         REQUIRE(loaded.ok);
 
-        for (const auto& file : loaded.written) {
-            INFO(file.getFullPathName());
+        for (const auto& [name, file] : loaded.written) {
+            INFO(name << " -> " << file.getFullPathName());
             CHECK(everyPath.insert(file.getFullPathName()).second);
             all.push_back(file);
         }

--- a/tests/test_mgd_fixture_rig.cpp
+++ b/tests/test_mgd_fixture_rig.cpp
@@ -1,0 +1,200 @@
+#include <juce_audio_formats/juce_audio_formats.h>
+
+#include <catch2/catch_test_macros.hpp>
+#include <set>
+#include <vector>
+
+#include "MgdFixture.hpp"
+#include "core/SourcePool.hpp"
+
+/**
+ * @file test_mgd_fixture_rig.cpp
+ * @brief The .mgd fixture rig (#2173).
+ *
+ * This slice renders nothing. What it asserts is that a fixture is a case: that
+ * it loads, that the case it produces is the project on disk plus the manifest's
+ * declarations and nothing else, that every source reads back as what the
+ * manifest asked for, and that a source the manifest failed to name is a loud
+ * failure rather than a quiet one.
+ *
+ * That last one is the reason the rig exists in this shape. Every path in a
+ * saved project points at a machine that is gone, so a source nobody stood in
+ * for reaches a leg as a file that is not there, renders silence, and nulls
+ * against the other leg's silence at the ordinary floor. A corpus cannot see
+ * that in its own report: it looks exactly like a case that passed.
+ */
+
+using namespace magda;
+using namespace magda::nulldiff;
+
+namespace {
+
+juce::File scratch() {
+    auto root = juce::File::getSpecialLocation(juce::File::tempDirectory)
+                    .getChildFile("magda_mgd_fixture_rig");
+    root.createDirectory();
+    return root;
+}
+
+/// Put the pool back the way it was found.
+///
+/// The rig drives the app's own source install, and that install clears the
+/// pool before repopulating it -- correctly, because loading a project is
+/// exactly when the previous project's sources stop being pooled. In a test
+/// binary the pool is shared with everything else in the run, so a fixture
+/// loaded here would otherwise pull the null-diff corpus's sources out from
+/// under it and leave every SourceFact in it pointing at an id nobody holds.
+///
+/// Snapshot and restore rather than clear, because clearing is what causes the
+/// problem rather than what fixes it, and `insert` preserves ids so what goes
+/// back is what was there. Ordering is not a defence: the corpus builds itself
+/// lazily and once, so whether it survives would depend on which test ran
+/// first.
+struct PoolUnwind {
+    PoolUnwind() : held_(SourcePool::getInstance().snapshot()) {}
+
+    ~PoolUnwind() {
+        auto& pool = SourcePool::getInstance();
+        pool.clear();
+        for (const auto& source : held_)
+            pool.insert(source);
+    }
+
+    PoolUnwind(const PoolUnwind&) = delete;
+    PoolUnwind& operator=(const PoolUnwind&) = delete;
+
+  private:
+    std::vector<Source> held_;
+};
+
+}  // namespace
+
+TEST_CASE("Every fixture names a file that is there", "[nulldiff][fixture]") {
+    REQUIRE_FALSE(mgdFixtures().empty());
+
+    std::set<std::string> names;
+    for (const auto& fixture : mgdFixtures()) {
+        INFO(fixture.file);
+        CHECK(fixtureCorpusDir().getChildFile(fixture.file).existsAsFile());
+
+        // The case name is what a report prints, so two fixtures sharing one
+        // would make a failure name a case the reader cannot find.
+        CHECK(names.insert(fixture.declaration.name).second);
+        CHECK_FALSE(fixture.declaration.name.empty());
+        CHECK_FALSE(fixture.declaration.covers.empty());
+    }
+}
+
+TEST_CASE("A fixture loads into a case", "[nulldiff][fixture]") {
+    const PoolUnwind unwind;
+
+    for (const auto& fixture : mgdFixtures()) {
+        INFO(fixture.declaration.name);
+
+        const auto loaded = loadFixture(fixture, scratch());
+        INFO(loaded.failure);
+        REQUIRE(loaded.ok);
+
+        // The project half came off disk. A fixture whose file stopped
+        // containing a project would still "load" into an empty case, and an
+        // empty case renders silence.
+        CHECK_FALSE(loaded.value.tracks.empty());
+        CHECK_FALSE(loaded.value.clips.empty());
+        CHECK(loaded.value.sources.size() == fixture.sources.size());
+
+        // The declaration half came from the manifest, untouched by the load.
+        CHECK(loaded.value.name == fixture.declaration.name);
+        CHECK(loaded.value.covers == fixture.declaration.covers);
+        CHECK(loaded.value.tier == fixture.declaration.tier);
+        CHECK(loaded.value.startBeat == fixture.declaration.startBeat);
+        CHECK(loaded.value.endBeat == fixture.declaration.endBeat);
+
+        // The tempo is the project's, not the corpus default. Rendering a real
+        // arrangement at 120 would put every clip somewhere nobody heard it.
+        REQUIRE(loaded.value.tempo.size() == 1);
+        CHECK(loaded.value.tempo.front().beat == 0.0);
+        CHECK(loaded.value.tempo.front().bpm > 0.0);
+    }
+}
+
+TEST_CASE("Every source reads back as what the manifest asked for", "[nulldiff][fixture]") {
+    const PoolUnwind unwind;
+
+    juce::AudioFormatManager formats;
+    formats.registerBasicFormats();
+
+    for (const auto& fixture : mgdFixtures()) {
+        INFO(fixture.declaration.name);
+
+        const auto loaded = loadFixture(fixture, scratch());
+        INFO(loaded.failure);
+        REQUIRE(loaded.ok);
+        REQUIRE(loaded.written.size() == fixture.sources.size());
+
+        for (std::size_t i = 0; i < loaded.written.size(); ++i) {
+            const auto& file = loaded.written[i];
+            const auto& declared = fixture.sources[i].material;
+            INFO(fixture.sources[i].fileName << ": " << fixture.sources[i].covers);
+
+            REQUIRE(file.existsAsFile());
+
+            const std::unique_ptr<juce::AudioFormatReader> reader(formats.createReaderFor(file));
+            REQUIRE(reader != nullptr);
+            CHECK(reader->sampleRate == declared.sampleRate);
+
+            // Whole samples rather than seconds. A duration that does not land
+            // on a sample boundary is rounded by the writer, and asserting the
+            // seconds back would be asserting the rounding.
+            const auto expected =
+                static_cast<juce::int64>(declared.durationSeconds * declared.sampleRate);
+            CHECK(reader->lengthInSamples == expected);
+        }
+
+        // Every source in the case points at what was written, not at the dead
+        // path the project was saved with.
+        for (const auto& source : loaded.value.sources) {
+            INFO(source.path);
+            CHECK(juce::File(source.path).existsAsFile());
+            CHECK(source.sampleRate > 0.0);
+            CHECK(source.durationSeconds > 0.0);
+        }
+    }
+}
+
+TEST_CASE("A source the manifest does not name fails rather than passing quietly",
+          "[nulldiff][fixture]") {
+    const PoolUnwind unwind;
+
+    // The failure this rig is built around, provoked rather than described: drop
+    // one declaration and the load has to refuse. Without the check the case
+    // would still be produced, that source would point at a volume this machine
+    // has never had, and the clip reading it would render silence against the
+    // other leg's silence.
+    REQUIRE_FALSE(mgdFixtures().front().sources.empty());
+
+    auto starved = mgdFixtures().front();
+    const auto dropped = starved.sources.back().fileName;
+    starved.sources.pop_back();
+
+    const auto loaded = loadFixture(starved, scratch());
+    CHECK_FALSE(loaded.ok);
+    CHECK(loaded.failure.find(dropped) != std::string::npos);
+}
+
+TEST_CASE("A declaration nothing claims fails too", "[nulldiff][fixture]") {
+    const PoolUnwind unwind;
+
+    // The other direction, and it is not symmetry for its own sake. A manifest
+    // entry no source claims is a declaration that has stopped being true, which
+    // reads like coverage and is not: the same rule the DAWproject loss table
+    // lives by, where a restore that finds nothing to put back fails rather than
+    // sitting in the table.
+    auto extra = mgdFixtures().front();
+    extra.sources.push_back({.fileName = "a-source-this-project-never-had.wav",
+                             .material = extra.sources.front().material,
+                             .covers = "nothing, which is the point"});
+
+    const auto loaded = loadFixture(extra, scratch());
+    CHECK_FALSE(loaded.ok);
+    CHECK(loaded.failure.find("a-source-this-project-never-had.wav") != std::string::npos);
+}

--- a/tests/test_mgd_fixture_rig.cpp
+++ b/tests/test_mgd_fixture_rig.cpp
@@ -1,6 +1,7 @@
 #include <juce_audio_formats/juce_audio_formats.h>
 
 #include <catch2/catch_test_macros.hpp>
+#include <map>
 #include <set>
 #include <vector>
 
@@ -167,6 +168,106 @@ TEST_CASE("Every source reads back as what the manifest asked for", "[nulldiff][
             CHECK(source.sampleRate > 0.0);
             CHECK(source.durationSeconds > 0.0);
         }
+    }
+}
+
+TEST_CASE("Two fixtures held at once both stay resolvable", "[nulldiff][fixture]") {
+    const PoolUnwind unwind;
+
+    // A Case carries source ids and nothing else, and the legs resolve them
+    // through the global pool. The app's install clears that pool and resets its
+    // allocator to one, which is right for an app with one project open: load a
+    // second fixture and the first would come back holding ids that now name the
+    // second's audio, silently, with every clip still pointing somewhere.
+    //
+    // Two fixtures, held together, is the only arrangement that can see it.
+    REQUIRE(mgdFixtures().size() >= 2);
+
+    const auto first = loadFixture(mgdFixtures()[0], scratch());
+    INFO(first.failure);
+    REQUIRE(first.ok);
+
+    // What the first case claims, recorded before anything else is loaded.
+    std::map<SourceId, juce::String> claimed;
+    for (const auto& source : first.value.sources)
+        claimed[source.id] = source.path;
+    REQUIRE_FALSE(claimed.empty());
+
+    const auto second = loadFixture(mgdFixtures()[1], scratch());
+    INFO(second.failure);
+    REQUIRE(second.ok);
+
+    auto& pool = SourcePool::getInstance();
+
+    // Every id the first case holds still names the file it named. This is the
+    // assertion: not that the pool has something under that id, but that it has
+    // the same thing.
+    for (const auto& [id, path] : claimed) {
+        INFO(path);
+        const auto* pooled = pool.get(id);
+        REQUIRE(pooled != nullptr);
+        CHECK(pooled->filePath == path);
+    }
+
+    // And the second case's ids are its own rather than the first's reissued.
+    for (const auto& source : second.value.sources) {
+        INFO(source.path);
+        const auto* pooled = pool.get(source.id);
+        REQUIRE(pooled != nullptr);
+        CHECK(pooled->filePath == source.path);
+        CHECK(claimed.find(source.id) == claimed.end());
+    }
+
+    // The clips agree with the sources: every event resolves to a file the case
+    // says it plays. An id that survived while its clip moved would pass the
+    // checks above and still render the wrong audio.
+    const auto eventsResolve = [&pool](const Case& value) {
+        std::set<juce::String> declared;
+        for (const auto& source : value.sources)
+            declared.insert(source.path);
+
+        auto ok = true;
+        for (const auto& clip : value.clips) {
+            if (!clip.isAudio())
+                continue;
+            for (const auto& event : clip.audio().events) {
+                const auto* pooled = pool.get(event.sourceId);
+                ok = ok && pooled != nullptr && declared.count(pooled->filePath) == 1;
+            }
+        }
+        return ok;
+    };
+
+    CHECK(eventsResolve(first.value));
+    CHECK(eventsResolve(second.value));
+}
+
+TEST_CASE("A project that hosts a plugin is not a fixture here", "[nulldiff][fixture]") {
+    const PoolUnwind unwind;
+
+    // Half the legacy corpus hosts one, and none of it can be held to a null:
+    // without the plugin installed both legs render a passthrough and agree
+    // about nothing, and with it installed only one leg can host it. #2175 is
+    // where those go.
+    //
+    // Asserted against a real one rather than described, because the rule is
+    // about what is in the file and the file is right here.
+    MgdFixture hosted;
+    hosted.file = "legacy/projects/0.13.0-retrovid.mgd";
+    hosted.savedBy = "0.13.0-rc1";
+    hosted.declaration = mgdFixtures().front().declaration;
+    hosted.declaration.name = "project.hosted";
+
+    const auto loaded = loadFixture(hosted, scratch());
+    CHECK_FALSE(loaded.ok);
+    CHECK(loaded.failure.find("Retrospect") != std::string::npos);
+
+    // And no fixture the corpus actually carries trips it.
+    for (const auto& fixture : mgdFixtures()) {
+        INFO(fixture.file);
+        const auto good = loadFixture(fixture, scratch());
+        INFO(good.failure);
+        CHECK(good.ok);
     }
 }
 

--- a/tests/test_mgd_fixture_rig.cpp
+++ b/tests/test_mgd_fixture_rig.cpp
@@ -181,6 +181,65 @@ TEST_CASE("A source the manifest does not name fails rather than passing quietly
     CHECK(loaded.failure.find(dropped) != std::string::npos);
 }
 
+TEST_CASE("Two project sources that share a name are refused", "[nulldiff][fixture]") {
+    // The collision a manifest cannot express. A manifest names a source by the
+    // last component of its path, so two different files called loop.wav are one
+    // declaration, one written file, and -- because the source install dedups by
+    // canonical path -- one pooled source. Two clips would come out playing the
+    // same sound and the case would render a project that never existed, at the
+    // ordinary floor, against an incumbent doing the same thing.
+    //
+    // Checked against paths rather than through a load, because provoking it
+    // through one would mean checking in a project built to break the rig, and
+    // the rule is about what a fixture can be rather than about reading one.
+    CHECK(refuseIndistinguishableSources({}).empty());
+    CHECK(refuseIndistinguishableSources({"/packs/a/loop.wav", "/packs/a/kick.wav"}).empty());
+
+    // The same file named twice is not a collision. A v1 project stages one
+    // entry per clip, so two clips playing one file arrive as two paths, and
+    // refusing that would refuse the ordinary case.
+    CHECK(refuseIndistinguishableSources({"/packs/a/loop.wav", "/packs/a/loop.wav"}).empty());
+
+    const auto refusal = refuseIndistinguishableSources({"/packs/a/loop.wav", "/packs/b/loop.wav"});
+    CHECK_FALSE(refusal.empty());
+    CHECK(refusal.find("loop.wav") != std::string::npos);
+    CHECK(refusal.find("/packs/a/") != std::string::npos);
+    CHECK(refusal.find("/packs/b/") != std::string::npos);
+}
+
+TEST_CASE("Each fixture's material is its own", "[nulldiff][fixture]") {
+    const PoolUnwind unwind;
+
+    // Two fixtures are allowed to reference files with the same name: they are
+    // different projects and nothing ties their sources together. A flat scratch
+    // directory would let the second overwrite the first's material, leaving the
+    // first case holding a path that now plays the other project's sound.
+    //
+    // Loading them one at a time hides that, which is what this asserts against:
+    // every file any fixture wrote is still there, and still unique, after all of
+    // them have been loaded.
+    std::set<juce::String> everyPath;
+    std::vector<juce::File> all;
+
+    for (const auto& fixture : mgdFixtures()) {
+        INFO(fixture.declaration.name);
+        const auto loaded = loadFixture(fixture, scratch());
+        INFO(loaded.failure);
+        REQUIRE(loaded.ok);
+
+        for (const auto& file : loaded.written) {
+            INFO(file.getFullPathName());
+            CHECK(everyPath.insert(file.getFullPathName()).second);
+            all.push_back(file);
+        }
+    }
+
+    for (const auto& file : all) {
+        INFO(file.getFullPathName());
+        CHECK(file.existsAsFile());
+    }
+}
+
 TEST_CASE("A declaration nothing claims fails too", "[nulldiff][fixture]") {
     const PoolUnwind unwind;
 

--- a/tests/test_mgd_fixture_rig.cpp
+++ b/tests/test_mgd_fixture_rig.cpp
@@ -205,6 +205,18 @@ TEST_CASE("Two project sources that share a name are refused", "[nulldiff][fixtu
     CHECK(refusal.find("loop.wav") != std::string::npos);
     CHECK(refusal.find("/packs/a/") != std::string::npos);
     CHECK(refusal.find("/packs/b/") != std::string::npos);
+
+    // Case folded, because whether two names are one file belongs to the
+    // filesystem the stand-ins are written to and macOS and Windows both say
+    // yes. Compared exactly, this pair passed the guard and then wrote the
+    // second file over the first: two sources, one sound, and a null against an
+    // incumbent doing the same thing.
+    CHECK_FALSE(refuseIndistinguishableSources({"/packs/a/Loop.wav", "/packs/b/loop.wav"}).empty());
+    CHECK_FALSE(refuseIndistinguishableSources({"/packs/a/LOOP.WAV", "/packs/b/loop.wav"}).empty());
+
+    // Still not a collision when it is one file: the same path twice, whatever
+    // case it is written in, is what a v1 project produces for two clips.
+    CHECK(refuseIndistinguishableSources({"/packs/a/Loop.wav", "/packs/a/Loop.wav"}).empty());
 }
 
 TEST_CASE("Each fixture's material is its own", "[nulldiff][fixture]") {

--- a/tests/test_mgd_fixture_rig.cpp
+++ b/tests/test_mgd_fixture_rig.cpp
@@ -327,6 +327,25 @@ TEST_CASE("Two project sources that share a name are refused", "[nulldiff][fixtu
     // Still not a collision when it is one file: the same path twice, whatever
     // case it is written in, is what a v1 project produces for two clips.
     CHECK(refuseIndistinguishableSources({"/packs/a/Loop.wav", "/packs/a/Loop.wav"}).empty());
+
+    // Both separators, on every host. A path in a saved project belongs to the
+    // machine that saved it, and juce::File cuts on the separator of the machine
+    // reading it: a Windows runner asked for the name of a macOS path handed
+    // back the whole path, so every manifest lookup missed and the load refused
+    // a fixture that was fine. CI found that; these are what would have.
+    //
+    // Asserted in both directions rather than the one that broke, because the
+    // corpus is checked in on macOS and read on Windows and Linux, and a project
+    // saved on Windows is a fixture somebody will add.
+    CHECK_FALSE(refuseIndistinguishableSources({"/packs/a/loop.wav", "/packs/b/loop.wav"}).empty());
+    CHECK_FALSE(refuseIndistinguishableSources({"C:\\packs\\a\\loop.wav", "C:\\packs\\b\\loop.wav"})
+                    .empty());
+    CHECK_FALSE(
+        refuseIndistinguishableSources({"/packs/a/loop.wav", "C:\\packs\\b\\loop.wav"}).empty());
+
+    // And two names that really are different stay different under both.
+    CHECK(refuseIndistinguishableSources({"C:\\packs\\a\\loop.wav", "C:\\packs\\a\\kick.wav"})
+              .empty());
 }
 
 TEST_CASE("Two names the filesystem calls one file are counted, not compared",


### PR DESCRIPTION
Closes #2173. First of the three things #2081 is waiting on.

Every case in the corpus is built in code, and #2040 settled that argument for the cases it covered: a load adds a step neither leg is testing and a binary to the repository, and thirty lines of value initialisation is reviewable as a diff. That still holds and this does not replace it. It stops holding for a project somebody actually made, because what those are worth testing for is the combinations nobody would have thought to write down.

## A fixture is a file plus a manifest

`ProjectSerializer::loadAndStage` already produces model values on any thread without touching a singleton, and what it fills is close to the half of a `Case` that describes a project. The manifest carries the other half, the half a `.mgd` has nowhere to put: the range, the tier and its figures, the environment. The load fills the project half over the top, so a manifest can never quietly assert a project different from the one on disk.

The audio is generated rather than checked in. Every path in these files points at a machine that is gone, so the manifest names a `MaterialSpec` per source and the rig writes it, repoints the project, and reads the file back rather than trusting the spec. It drives the app's own install for that: `installStagedSources` clears the pool, preserves v2 ids, acquires the v1 sources under real ones and remaps the events that referenced the provisional ids, which is a paragraph of behaviour a second implementation would get subtly wrong and then agree with itself about.

## What it refuses

This slice renders nothing. It asserts the four things #2173 asked for, plus two the issue did not name:

1. The fixture loads.
2. The case is the project on disk plus the manifest's declarations, and nothing else.
3. Every source reads back at the rate and length declared.
4. **A source the project plays that the manifest does not name is refused.** This is what the rig is built around: such a source reaches a leg as a file that is not there, renders silence, and nulls against the other leg's silence at the ordinary floor. In a report that looks exactly like a case that passed.
5. A declaration no source claims is refused, for the reason the DAWproject loss table refuses one.
6. A project whose sources cannot be told apart by the only part of a path a manifest can name is refused. See below.

## The first fixture

`0.13.0-retrovid.mgd`, reused rather than saved: four tracks and nine clips at 92 bpm over eight sources from three dead volumes, two of them bounces of other clips in the same project. Impulses where a clip plays at its own rate, tones where the project stretched it, because impulses through two stretchers measure the distance between two interpolators rather than anything about the clip.

## The decision #2173 delegated

Reuse or save new is answered per fixture in `isMigrationFixture`: reuse where a project earns its place by being an arrangement, save new where the material has to be designed and the fixture has to be free to change, which a migration fixture never is. That is written into `tests/corpus/legacy/README.md`, which `LegacyCorpus.hpp` has pointed at since #2079 and which did not exist.

## Worth a close read: the collision guard

A manifest names a source by the last component of its path, because the rest names a volume that is gone. That leaves one thing a project can do the manifest cannot express: play two different files that share a name. They match one declaration, are written to one file, and collapse for real in the install, which dedups by canonical path. Two clips come out playing one sound and the case renders a project that never existed.

Four commits here are that guard, each fixing a defect in the previous one, and all four were found by review rather than by me:

- Names compared exactly missed `Loop.wav` against `loop.wav`, which is one file on macOS and Windows. Compared folded now, conservative on a case-sensitive filesystem on purpose: a corpus that refuses on Linux and accepts on macOS is worse than one that refuses everywhere.
- A follow-up check that compared the written paths claimed to catch a Unicode normalisation collapse and could not, for the same reason folding cannot: NFC and NFD spellings are two strings and one file. The load counts what its own directory holds after each write instead. There is a test that writes both spellings and checks what the machine actually does.
- Counting against sources processed then refused a project that names one file twice, which a v2 table entry beside a v1 clip produces and which `refuseIndistinguishableSources` allows on purpose. Counted against distinct paths now.

The reuse branch has no fixture exercising it, since no project here has that shape and synthesising one to break the rig is not worth checking in. What guards it instead is an invariant the load asserts on every fixture: one pooled source per source the manifest names. Too few means a collapse past every check above; too many means a repeat that did not collapse. Both are otherwise silent.

`FixtureLoad::written` is keyed by the manifest's name rather than ordered, because it was documented as manifest order and was in staged order, and the test reading files back was pairing the two by index.

## Testing

Full Catch2 suite green: 2927 passed, 13 skipped, 0 failed. The rig is 8 tests, 121 assertions.

The test's pool guard snapshots and restores rather than clearing. The rig's install empties the shared `SourcePool`, so a fixture loaded in a test binary would otherwise pull the null-diff corpus's sources out from under it and leave every `SourceFact` in it pointing at an id nobody holds. Ordering is not a defence: the corpus builds itself lazily and once. #2081 will need the same discipline when its runner starts loading fixtures.

https://claude.ai/code/session_01EXLKj37dCPKP5neGiRvXk2