### PR TITLE
Collapse the project media tree to three roots (#2170)

### DIFF
--- a/magda/daw/audio/ClipCommands.cpp
+++ b/magda/daw/audio/ClipCommands.cpp
@@ -1248,7 +1248,8 @@ void RenderClipCommand::execute() {
     juce::String trackName = trackInfo ? trackInfo->name : "Track";
     juce::String clipName =
         clip->name.isNotEmpty() ? clip->name : sourceFile.getFileNameWithoutExtension();
-    renderedFile_ = rendersDir.getChildFile(expandRenderPattern(clipName, trackName) + ".wav");
+    renderedFile_ =
+        rendersDir.getNonexistentChildFile(expandRenderPattern(clipName, trackName), ".wav", false);
 
     const double projectBPM = currentProjectBpm();
     const double renderStart = clip->getTimelineStart(projectBPM);
@@ -1403,8 +1404,8 @@ void RenderTimeSelectionCommand::execute() {
         juce::String trackName = trackInfo ? trackInfo->name : "Track";
         auto* firstClipInfo = clipManager.getClip(overlappingIds[0]);
         juce::String clipName = firstClipInfo ? firstClipInfo->name : trackName;
-        trackState.renderedFile =
-            rendersDir.getChildFile(expandRenderPattern(clipName, trackName) + ".wav");
+        trackState.renderedFile = rendersDir.getNonexistentChildFile(
+            expandRenderPattern(clipName, trackName), ".wav", false);
 
         const auto& project = ProjectManager::getInstance().getCurrentProjectInfo();
         OfflineRenderRequest request;
@@ -2093,7 +2094,12 @@ void BounceInPlaceCommand::execute() {
         auto* trackInfo = TrackManager::getInstance().getTrack(clip->trackId);
         juce::String trackName = trackInfo ? trackInfo->name : "Track";
         juce::String clipName = clip->name.isNotEmpty() ? clip->name : "clip";
-        renderedFile_ = rendersDir.getChildFile(expandBouncePattern(clipName, trackName) + ".wav");
+        // Renders and bounces share this folder and expand independently
+        // configurable patterns, so the two can name the same file. Claim a
+        // free name: overwriting would leave another clip playing this audio
+        // and let undo delete a file it does not own.
+        renderedFile_ = rendersDir.getNonexistentChildFile(expandBouncePattern(clipName, trackName),
+                                                           ".wav", false);
     }
 
     // Match the original bounce lifecycle: stop before capture or FX bypass,
@@ -2303,7 +2309,12 @@ void BounceToNewTrackCommand::execute() {
         auto* trackInfo = TrackManager::getInstance().getTrack(clip->trackId);
         juce::String trackName = trackInfo ? trackInfo->name : "Track";
         juce::String clipName = clip->name.isNotEmpty() ? clip->name : "clip";
-        renderedFile_ = rendersDir.getChildFile(expandBouncePattern(clipName, trackName) + ".wav");
+        // Renders and bounces share this folder and expand independently
+        // configurable patterns, so the two can name the same file. Claim a
+        // free name: overwriting would leave another clip playing this audio
+        // and let undo delete a file it does not own.
+        renderedFile_ = rendersDir.getNonexistentChildFile(expandBouncePattern(clipName, trackName),
+                                                           ".wav", false);
     }
 
     PlaybackResumeScope playbackScope(*engine_);

--- a/magda/daw/audio/ClipCommands.cpp
+++ b/magda/daw/audio/ClipCommands.cpp
@@ -2068,23 +2068,23 @@ void BounceInPlaceCommand::execute() {
         return;
     }
 
-    // Determine output file path — always the project's bounces directory.
+    // Determine output file path — always the project's renders directory.
     // A bounce file is referenced by a clip inside the project, so it must live
     // in the project media tree (so save/collect/move keeps it). It must NOT
     // honour Config::getRenderFolder(): that is the global Export-to-file
     // folder, and letting it hijack bounce output drops the file outside the
     // project (e.g. on the Desktop) where the project can't track it.
-    auto bouncesDir = ProjectManager::getInstance().getBouncesDirectory();
-    if (bouncesDir == juce::File())
-        bouncesDir = engine_->getEditFile().getParentDirectory().getChildFile("bounces");
+    auto rendersDir = ProjectManager::getInstance().getRendersDirectory();
+    if (rendersDir == juce::File())
+        rendersDir = engine_->getEditFile().getParentDirectory().getChildFile("renders");
     // Verify the destination is actually writable before handing the renderer a
     // dead destFile. On a read-only / unavailable project media tree the render
     // would otherwise fail with only a DBG line and no bounced clip, leaving the
     // user with nothing and no explanation. Bail with a visible error instead.
     // Safe to return here: the transport hasn't been touched yet.
-    if (bouncesDir.createDirectory().failed() || !bouncesDir.hasWriteAccess()) {
+    if (rendersDir.createDirectory().failed() || !rendersDir.hasWriteAccess()) {
         errorMessage_ =
-            "Bounce failed: can't write to the bounces folder:\n" + bouncesDir.getFullPathName();
+            "Bounce failed: can't write to the renders folder:\n" + rendersDir.getFullPathName();
         juce::Logger::writeToLog(errorMessage_);
         return;
     }
@@ -2093,7 +2093,7 @@ void BounceInPlaceCommand::execute() {
         auto* trackInfo = TrackManager::getInstance().getTrack(clip->trackId);
         juce::String trackName = trackInfo ? trackInfo->name : "Track";
         juce::String clipName = clip->name.isNotEmpty() ? clip->name : "clip";
-        renderedFile_ = bouncesDir.getChildFile(expandBouncePattern(clipName, trackName) + ".wav");
+        renderedFile_ = rendersDir.getChildFile(expandBouncePattern(clipName, trackName) + ".wav");
     }
 
     // Match the original bounce lifecycle: stop before capture or FX bypass,
@@ -2278,23 +2278,23 @@ void BounceToNewTrackCommand::execute() {
     const auto sourceClipColour = clip->colour;
     const auto sourceTrackId = clip->trackId;
 
-    // Determine output file path — always the project's bounces directory.
+    // Determine output file path — always the project's renders directory.
     // A bounce file is referenced by a clip inside the project, so it must live
     // in the project media tree (so save/collect/move keeps it). It must NOT
     // honour Config::getRenderFolder(): that is the global Export-to-file
     // folder, and letting it hijack bounce output drops the file outside the
     // project (e.g. on the Desktop) where the project can't track it.
-    auto bouncesDir = ProjectManager::getInstance().getBouncesDirectory();
-    if (bouncesDir == juce::File())
-        bouncesDir = engine_->getEditFile().getParentDirectory().getChildFile("bounces");
+    auto rendersDir = ProjectManager::getInstance().getRendersDirectory();
+    if (rendersDir == juce::File())
+        rendersDir = engine_->getEditFile().getParentDirectory().getChildFile("renders");
     // Verify the destination is actually writable before handing the renderer a
     // dead destFile. On a read-only / unavailable project media tree the render
     // would otherwise fail with only a DBG line and no bounced clip, leaving the
     // user with nothing and no explanation. Bail with a visible error instead.
     // Safe to return here: the transport hasn't been touched yet.
-    if (bouncesDir.createDirectory().failed() || !bouncesDir.hasWriteAccess()) {
+    if (rendersDir.createDirectory().failed() || !rendersDir.hasWriteAccess()) {
         errorMessage_ =
-            "Bounce failed: can't write to the bounces folder:\n" + bouncesDir.getFullPathName();
+            "Bounce failed: can't write to the renders folder:\n" + rendersDir.getFullPathName();
         juce::Logger::writeToLog(errorMessage_);
         return;
     }
@@ -2303,7 +2303,7 @@ void BounceToNewTrackCommand::execute() {
         auto* trackInfo = TrackManager::getInstance().getTrack(clip->trackId);
         juce::String trackName = trackInfo ? trackInfo->name : "Track";
         juce::String clipName = clip->name.isNotEmpty() ? clip->name : "clip";
-        renderedFile_ = bouncesDir.getChildFile(expandBouncePattern(clipName, trackName) + ".wav");
+        renderedFile_ = rendersDir.getChildFile(expandBouncePattern(clipName, trackName) + ".wav");
     }
 
     PlaybackResumeScope playbackScope(*engine_);

--- a/magda/daw/audio/plugins/MagdaSamplerPlugin.cpp
+++ b/magda/daw/audio/plugins/MagdaSamplerPlugin.cpp
@@ -583,6 +583,39 @@ void MagdaSamplerPlugin::loadSample(const juce::File& file) {
     loopEndValue = loopEndClamped;
 }
 
+void MagdaSamplerPlugin::relocateSample(const juce::File& file) {
+    // See the header: the audio is unchanged, only its path moved, so how the
+    // user set the sampler up to interpret it has to survive the reload.
+    const int savedRootNote = rootNoteValue.get();
+    const float savedStart = sampleStartValue.get();
+    const float savedEnd = sampleEndValue.get();
+    const float savedLoopStart = loopStartValue.get();
+    const float savedLoopEnd = loopEndValue.get();
+
+    loadSample(file);
+
+    // loadSample() only adopts the path once it has a reader for it. If it
+    // bailed, it also reset nothing, so there is nothing to put back.
+    if (getSampleFile() != file)
+        return;
+
+    setRootNote(savedRootNote);
+
+    // Same audio means the saved markers still fit, but clamp anyway rather
+    // than trust that the file on the other end is byte-identical.
+    const auto maxLen = static_cast<float>(getSampleLengthSeconds());
+    const auto restore = [maxLen](const te::AutomatableParameter::Ptr& param,
+                                  juce::CachedValue<float>& cached, float saved) {
+        const float clamped = clampToParameterRange(param, juce::jmin(saved, maxLen));
+        param->setParameterFromHost(clamped, juce::dontSendNotification);
+        cached = clamped;
+    };
+    restore(sampleStartParam, sampleStartValue, savedStart);
+    restore(sampleEndParam, sampleEndValue, savedEnd);
+    restore(loopStartParam, loopStartValue, savedLoopStart);
+    restore(loopEndParam, loopEndValue, savedLoopEnd);
+}
+
 juce::File MagdaSamplerPlugin::getSampleFile() const {
     return juce::File(samplePathValue.get());
 }

--- a/magda/daw/audio/plugins/MagdaSamplerPlugin.hpp
+++ b/magda/daw/audio/plugins/MagdaSamplerPlugin.hpp
@@ -190,6 +190,19 @@ class MagdaSamplerPlugin : public te::Plugin {
     //==============================================================================
     // Sample loading
     void loadSample(const juce::File& file);
+
+    /**
+     * @brief Point the sampler at the same audio in a new location.
+     *
+     * loadSample() treats its argument as a newly chosen sample: it re-derives
+     * the root note from file metadata and resets the sample and loop markers.
+     * That is wrong for a file that merely moved — collecting media or folding
+     * the project media tree would silently undo a custom root note or a
+     * trimmed/looped region — so this reloads the audio and puts those
+     * interpretation settings back.
+     */
+    void relocateSample(const juce::File& file);
+
     juce::File getSampleFile() const;
     const juce::AudioBuffer<float>* getWaveform() const;
     double getSampleLengthSeconds() const;

--- a/magda/daw/core/ClipManager.cpp
+++ b/magda/daw/core/ClipManager.cpp
@@ -101,7 +101,7 @@ juce::File midiLibraryFileForClip(const ClipInfo& clip, const juce::File& midiDi
     return midiDir.getNonexistentChildFile(safeName + "_" + juce::String(clip.id), ".mid");
 }
 
-juce::File externalEditFileForClip(const ClipInfo& clip, const juce::File& editsDir,
+juce::File externalEditFileForClip(const ClipInfo& clip, const juce::File& destDir,
                                    const juce::File& sourceFile) {
     auto safeName = juce::File::createLegalFileName(clip.name);
     if (safeName.isEmpty()) {
@@ -110,7 +110,7 @@ juce::File externalEditFileForClip(const ClipInfo& clip, const juce::File& edits
     if (safeName.isEmpty()) {
         safeName = "audio_clip";
     }
-    return editsDir.getNonexistentChildFile(safeName, sourceFile.getFileExtension(), false);
+    return destDir.getNonexistentChildFile(safeName, sourceFile.getFileExtension(), false);
 }
 
 bool isLaunchableExternalAudioEditor(const juce::File& editor) {
@@ -999,15 +999,17 @@ bool ClipManager::editAudioClipSourceInExternalEditor(ClipId clipId, juce::Strin
         return false;
     }
 
-    auto editsDir = ProjectManager::getInstance().getExternalEditsDirectory();
-    if (editsDir == juce::File() || !editsDir.createDirectory()) {
-        errorMessage = "Could not create the project external-edits folder.";
+    // The edit copy is audio that came from outside this timeline, so it lands
+    // beside the collected media rather than in a root of its own (#2170).
+    auto importedDir = ProjectManager::getInstance().getImportedDirectory();
+    if (importedDir == juce::File() || !importedDir.createDirectory()) {
+        errorMessage = "Could not create the project imported media folder.";
         return false;
     }
 
-    const auto editFile = externalEditFileForClip(*clip, editsDir, sourceFile);
+    const auto editFile = externalEditFileForClip(*clip, importedDir, sourceFile);
     if (!sourceFile.copyFileTo(editFile) || !editFile.existsAsFile()) {
-        errorMessage = "Could not copy the clip source into the project external-edits folder.";
+        errorMessage = "Could not copy the clip source into the project imported media folder.";
         return false;
     }
 

--- a/magda/daw/engine/TracktionEngineWrapper.cpp
+++ b/magda/daw/engine/TracktionEngineWrapper.cpp
@@ -110,8 +110,10 @@ std::vector<SamplerMediaReference> TracktionEngineWrapper::getSamplerMediaRefere
         tracktion::Plugin::Ptr keepAlive(sampler);
         references.push_back(
             {sampler->getSampleFile(), [keepAlive](const juce::File& replacement) {
+                 // relocateSample, not loadSample: the file moved, the user's
+                 // root note and trim/loop markers did not.
                  if (auto* live = dynamic_cast<daw::audio::MagdaSamplerPlugin*>(keepAlive.get()))
-                     live->loadSample(replacement);
+                     live->relocateSample(replacement);
              }});
     };
 

--- a/magda/daw/project/ProjectManager.cpp
+++ b/magda/daw/project/ProjectManager.cpp
@@ -82,13 +82,24 @@ void resetTransportForProjectBoundary() {
     audioEngine->locate(0.0);
 }
 
+// What to do with a file whose destination name is already taken. Never
+// overwrite either way: clobbering would destroy a file some other clip still
+// points at.
+enum class OnCollision {
+    // Land beside it under a unique name. For a move that writes its new paths
+    // out in the same operation, so nothing may be left behind.
+    Uniquify,
+    // Leave the file where it is. For the legacy fold, whose new paths only
+    // reach the .mgd when the user next saves — a file that stays put keeps the
+    // path already in the .mgd valid, and keeps every file that did move
+    // resolvable by name alone.
+    Skip,
+};
+
 // Move every file under srcDir into dstDir, nested structure intact, recording
-// where each one landed so the references to it can follow. A name already
-// taken at the destination is uniquified rather than overwritten: folding two
-// media roots into one can collide, and clobbering would destroy the file some
-// other clip still points at.
+// where each one landed so the references to it can follow.
 void moveMediaTree(const juce::File& srcDir, const juce::File& dstDir,
-                   std::map<juce::String, juce::String>& moves) {
+                   std::map<juce::String, juce::String>& moves, OnCollision onCollision) {
     if (!srcDir.isDirectory() || srcDir == dstDir)
         return;
 
@@ -99,13 +110,17 @@ void moveMediaTree(const juce::File& srcDir, const juce::File& dstDir,
     for (const auto& srcFile : srcDir.findChildFiles(juce::File::findFiles, true)) {
         auto dstFile = dstDir.getChildFile(srcFile.getRelativePathFrom(srcDir));
         dstFile.getParentDirectory().createDirectory();
-        if (dstFile.exists())
+        if (dstFile.exists()) {
+            if (onCollision == OnCollision::Skip)
+                continue;
             dstFile = dstFile.getNonexistentSibling();
+        }
         if (srcFile.moveFileTo(dstFile))
             moves[srcFile.getFullPathName()] = dstFile.getFullPathName();
     }
 
-    // Only the empty skeleton is left once every file has moved out.
+    // Only the empty skeleton is left once every file has moved out. A skipped
+    // collision keeps the directory alive, and the next load tries it again.
     if (srcDir.findChildFiles(juce::File::findFiles, true).isEmpty())
         srcDir.deleteRecursively();
 }
@@ -277,10 +292,6 @@ bool ProjectManager::saveProject() {
 }
 
 bool ProjectManager::saveProjectAs(const juce::File& file) {
-    // Capture live plugin state before serializing
-    if (onBeforeSave)
-        onBeforeSave();
-
     // Ensure the .mgd file lives inside a wrapper folder named after the project.
     // If the user picked /path/to/MyProject.mgd, wrap it as /path/to/MyProject/MyProject.mgd.
     // If it's already inside a matching folder, use it as-is.
@@ -308,6 +319,14 @@ bool ProjectManager::saveProjectAs(const juce::File& file) {
     if (oldMediaDir != juce::File() && oldMediaDir != targetMediaDir && oldMediaDir.isDirectory()) {
         migrateMediaFiles(oldMediaDir, targetMediaDir);
     }
+
+    // Capture live plugin state before serializing. Runs after the migration
+    // above, not before it: the migration re-points samplers and drum pads at
+    // the files it just moved, and a state captured before that would freeze
+    // the pre-move paths into the .mgd, leaving their samples missing when the
+    // saved project is reopened.
+    if (onBeforeSave)
+        onBeforeSave();
 
     // Prepare updated project info without mutating currentProject_ yet
     ProjectInfo newProject = currentProject_;
@@ -849,14 +868,20 @@ void ProjectManager::migrateMediaFiles(const juce::File& oldDir, const juce::Fil
     if (!oldDir.isDirectory() || oldDir == newDir)
         return;
 
+    // Uniquify rather than skip: the .mgd is written from the relinked model at
+    // the end of this same save, so a file that lands under a new name is
+    // recorded correctly, and nothing may be stranded in the directory being
+    // left behind.
     std::map<juce::String, juce::String> moves;
     for (auto* subdir : kMediaSubdirs)
-        moveMediaTree(oldDir.getChildFile(subdir), newDir.getChildFile(subdir), moves);
+        moveMediaTree(oldDir.getChildFile(subdir), newDir.getChildFile(subdir), moves,
+                      OnCollision::Uniquify);
 
     // A Save-As from a project opened before #2170 can still be carrying the
     // retired roots, so fold them on the way across rather than stranding them.
     for (const auto& legacy : kLegacyMediaSubdirs)
-        moveMediaTree(oldDir.getChildFile(legacy.from), newDir.getChildFile(legacy.to), moves);
+        moveMediaTree(oldDir.getChildFile(legacy.from), newDir.getChildFile(legacy.to), moves,
+                      OnCollision::Uniquify);
 
     relinkMediaPaths([&moves](const juce::String& path) -> juce::String {
         const auto it = moves.find(path);
@@ -877,8 +902,8 @@ void ProjectManager::foldLegacyMediaDirectories(const juce::File& mediaRoot) {
 
     std::map<juce::String, juce::String> moves;
     for (const auto& legacy : kLegacyMediaSubdirs)
-        moveMediaTree(mediaRoot.getChildFile(legacy.from), mediaRoot.getChildFile(legacy.to),
-                      moves);
+        moveMediaTree(mediaRoot.getChildFile(legacy.from), mediaRoot.getChildFile(legacy.to), moves,
+                      OnCollision::Skip);
 
     const auto rootPath = mediaRoot.getFullPathName();
     const auto resolve = [&moves, &rootPath, &mediaRoot](const juce::String& path) -> juce::String {
@@ -887,15 +912,19 @@ void ProjectManager::foldLegacyMediaDirectories(const juce::File& mediaRoot) {
             return it->second;
 
         // A project folded on an earlier load but never saved still names the
-        // retired folders in its .mgd. Those files moved back then, so follow
-        // them to where they live now — unless the fold had to rename, in which
-        // case the file is genuinely ambiguous and the clip stays unresolved
-        // until the user saves.
+        // retired folders in its .mgd, so follow the name into the replacement
+        // root. That is unambiguous only because the fold skips collisions: a
+        // file that would have had to share a name never moved, so a name that
+        // has left the retired root and is present in the replacement can only
+        // be the same file. Uniquifying here instead would let a stale path
+        // land on an unrelated file that merely shares its name.
         for (const auto& legacy : kLegacyMediaSubdirs) {
             const auto prefix = rootPath + juce::File::getSeparatorString() + legacy.from +
                                 juce::File::getSeparatorString();
             if (!path.startsWith(prefix))
                 continue;
+            if (juce::File(path).existsAsFile())
+                return {};  // Skipped by the fold — it still lives where it says.
 
             const auto moved =
                 mediaRoot.getChildFile(legacy.to).getChildFile(path.substring(prefix.length()));

--- a/magda/daw/project/ProjectManager.cpp
+++ b/magda/daw/project/ProjectManager.cpp
@@ -4,8 +4,11 @@
 #include <juce_gui_basics/juce_gui_basics.h>
 
 #include <algorithm>
+#include <functional>
+#include <map>
 #include <unordered_set>
 
+#include "../audio/AudioThumbnailManager.hpp"
 #include "../core/AutomationManager.hpp"
 #include "../core/ClipManager.hpp"
 #include "../core/Config.hpp"
@@ -18,13 +21,26 @@
 
 namespace magda {
 
-// Subdirectory names used by the media directory
+// The media directory has three roots, each with a distinct meaning to the
+// user: what they recorded, what MAGDA computed from the timeline, and what
+// they brought in from outside. kMediaSubdirs is the single source of truth —
+// creation and migration both read it, and every accessor below derives from
+// it (#2170).
 static const char* const kRecordingsDir = "recordings";
 static const char* const kRendersDir = "renders";
-static const char* const kBouncesDir = "bounces";
-static const char* const kExternalEditsDir = "external-edits";
 static const char* const kImportedDir = "imported";
-static const char* const kStemsDir = "stems";
+static const char* const kMediaSubdirs[] = {kRecordingsDir, kRendersDir, kImportedDir};
+
+// Roots retired by #2170, and the surviving root each one folds into.
+struct LegacyMediaSubdir {
+    const char* from;
+    const char* to;
+};
+static const LegacyMediaSubdir kLegacyMediaSubdirs[] = {
+    {"bounces", kRendersDir},
+    {"external-edits", kImportedDir},
+    {"stems", kRendersDir},
+};
 static const char* const kTempRootDir = "MAGDA";
 static const char* const kTempPrefix = "UnsavedProject_";
 static constexpr int kStaleTempDays = 7;
@@ -64,6 +80,112 @@ void resetTransportForProjectBoundary() {
     audioEngine->deactivateAllSessionClips();
     audioEngine->setLooping(false);
     audioEngine->locate(0.0);
+}
+
+// Move every file under srcDir into dstDir, nested structure intact, recording
+// where each one landed so the references to it can follow. A name already
+// taken at the destination is uniquified rather than overwritten: folding two
+// media roots into one can collide, and clobbering would destroy the file some
+// other clip still points at.
+void moveMediaTree(const juce::File& srcDir, const juce::File& dstDir,
+                   std::map<juce::String, juce::String>& moves) {
+    if (!srcDir.isDirectory() || srcDir == dstDir)
+        return;
+
+    dstDir.createDirectory();
+
+    // Snapshot the listing before moving anything — iterating a directory while
+    // emptying it is not something every platform defines.
+    for (const auto& srcFile : srcDir.findChildFiles(juce::File::findFiles, true)) {
+        auto dstFile = dstDir.getChildFile(srcFile.getRelativePathFrom(srcDir));
+        dstFile.getParentDirectory().createDirectory();
+        if (dstFile.exists())
+            dstFile = dstFile.getNonexistentSibling();
+        if (srcFile.moveFileTo(dstFile))
+            moves[srcFile.getFullPathName()] = dstFile.getFullPathName();
+    }
+
+    // Only the empty skeleton is left once every file has moved out.
+    if (srcDir.findChildFiles(juce::File::findFiles, true).isEmpty())
+        srcDir.deleteRecursively();
+}
+
+// Re-point everything that can name a media file — pooled clip sources, take
+// paths, and sampler/drum-pad samples — through `resolve`, which returns the
+// new path for a file that moved or an empty string for one that did not.
+// Returns true if anything was re-pointed.
+bool relinkMediaPaths(const std::function<juce::String(const juce::String&)>& resolve) {
+    auto& clipManager = ClipManager::getInstance();
+    auto& pool = SourcePool::getInstance();
+    auto& thumbs = AudioThumbnailManager::getInstance();
+
+    std::vector<ClipId> updatedClipIds;
+    std::unordered_set<SourceId> relinkedSources;
+
+    for (const auto& clipInfo : clipManager.getClips()) {
+        if (!clipInfo.isAudio())
+            continue;
+
+        bool touched = false;
+
+        // Sources are pooled per file, so a moved file is relinked once however
+        // many clips reference it; the clip loop only decides which clips need
+        // re-notifying.
+        for (const auto& event : clipInfo.audio().events) {
+            const auto oldPath = event.sourceFilePath();
+            const auto newPath = resolve(oldPath);
+            if (newPath.isEmpty())
+                continue;
+
+            touched = true;
+            if (event.sourceId == INVALID_SOURCE_ID ||
+                !relinkedSources.insert(event.sourceId).second)
+                continue;
+
+            const auto owner = pool.relink(event.sourceId, newPath);
+            if (owner != INVALID_SOURCE_ID && owner != event.sourceId) {
+                // The destination was already pooled under another source: move
+                // the events across rather than leaving two entries claiming
+                // one file.
+                clipManager.repointEventsToSource(event.sourceId, owner);
+            }
+            thumbs.invalidateFile(oldPath);
+            thumbs.invalidateFile(newPath);
+        }
+
+        if (auto* clip = clipManager.getClip(clipInfo.id)) {
+            for (auto& take : clip->audio().takes) {
+                const auto newPath = resolve(take.filePath);
+                if (newPath.isEmpty())
+                    continue;
+                thumbs.invalidateFile(take.filePath);
+                thumbs.invalidateFile(newPath);
+                take.filePath = newPath;
+                touched = true;
+            }
+        }
+
+        if (touched)
+            updatedClipIds.push_back(clipInfo.id);
+    }
+
+    if (!updatedClipIds.empty())
+        clipManager.forceNotifyMultipleClipPropertiesChanged(updatedClipIds);
+
+    // Collected samples live in imported/, so a media tree that moves takes the
+    // samplers and drum pads pointing into it along too.
+    bool relinkedSamplers = false;
+    if (auto* audioEngine = TrackManager::getInstance().getAudioEngine()) {
+        for (auto& reference : audioEngine->getSamplerMediaReferences()) {
+            const auto newPath = resolve(reference.source.getFullPathName());
+            if (newPath.isNotEmpty()) {
+                reference.replace(juce::File(newPath));
+                relinkedSamplers = true;
+            }
+        }
+    }
+
+    return !updatedClipIds.empty() || relinkedSamplers;
 }
 
 }  // namespace
@@ -279,6 +401,10 @@ bool ProjectManager::loadProject(const juce::File& file,
     UndoManager::getInstance().clearHistory();
     clearDirty();
 
+    // Projects saved before #2170 still have the retired media roots on disk.
+    // Runs after clearDirty() so the dirty flag it raises survives.
+    foldLegacyMediaDirectories(mediaDirectory_);
+
     // If we recovered from autosave, mark dirty so the user can save properly
     if (fileToLoad != file) {
         markDirty();
@@ -474,6 +600,11 @@ void ProjectManager::loadProjectAsync(const juce::File& file,
                 // one — its commands reference ids that are gone.
                 UndoManager::getInstance().clearHistory();
                 clearDirty();
+
+                // Projects saved before #2170 still have the retired media
+                // roots on disk. Runs after clearDirty() so the dirty flag it
+                // raises survives.
+                foldLegacyMediaDirectories(mediaDirectory_);
 
                 if (recoveredFromAutosave) {
                     markDirty();
@@ -679,28 +810,10 @@ juce::File ProjectManager::getRendersDirectory() const {
     return mediaDirectory_.getChildFile(kRendersDir);
 }
 
-juce::File ProjectManager::getBouncesDirectory() const {
-    if (mediaDirectory_ == juce::File())
-        return {};
-    return mediaDirectory_.getChildFile(kBouncesDir);
-}
-
-juce::File ProjectManager::getExternalEditsDirectory() const {
-    if (mediaDirectory_ == juce::File())
-        return {};
-    return mediaDirectory_.getChildFile(kExternalEditsDir);
-}
-
 juce::File ProjectManager::getImportedDirectory() const {
     if (mediaDirectory_ == juce::File())
         return {};
     return mediaDirectory_.getChildFile(kImportedDir);
-}
-
-juce::File ProjectManager::getStemsDirectory() const {
-    if (mediaDirectory_ == juce::File())
-        return {};
-    return mediaDirectory_.getChildFile(kStemsDir);
 }
 
 void ProjectManager::createTempMediaDirectory() {
@@ -727,8 +840,7 @@ void ProjectManager::createTempMediaDirectory() {
 void ProjectManager::ensureMediaSubdirectories(const juce::File& mediaRoot) {
     if (mediaRoot == juce::File())
         return;
-    const char* subdirs[] = {kRecordingsDir, kRendersDir, kBouncesDir, kExternalEditsDir};
-    for (auto* subdir : subdirs) {
+    for (auto* subdir : kMediaSubdirs) {
         mediaRoot.getChildFile(subdir).createDirectory();
     }
 }
@@ -737,71 +849,19 @@ void ProjectManager::migrateMediaFiles(const juce::File& oldDir, const juce::Fil
     if (!oldDir.isDirectory() || oldDir == newDir)
         return;
 
-    auto oldPath = oldDir.getFullPathName();
-    auto newPath = newDir.getFullPathName();
-    std::vector<ClipId> updatedClipIds;
+    std::map<juce::String, juce::String> moves;
+    for (auto* subdir : kMediaSubdirs)
+        moveMediaTree(oldDir.getChildFile(subdir), newDir.getChildFile(subdir), moves);
 
-    // Move files from each subdirectory
-    const char* subdirs[] = {kRecordingsDir, kRendersDir, kBouncesDir, kExternalEditsDir};
-    for (auto* subdir : subdirs) {
-        auto srcDir = oldDir.getChildFile(subdir);
-        auto dstDir = newDir.getChildFile(subdir);
-        dstDir.createDirectory();
+    // A Save-As from a project opened before #2170 can still be carrying the
+    // retired roots, so fold them on the way across rather than stranding them.
+    for (const auto& legacy : kLegacyMediaSubdirs)
+        moveMediaTree(oldDir.getChildFile(legacy.from), newDir.getChildFile(legacy.to), moves);
 
-        if (srcDir.isDirectory()) {
-            for (const auto& entry : juce::RangedDirectoryIterator(srcDir, false)) {
-                auto srcFile = entry.getFile();
-                auto dstFile = dstDir.getChildFile(srcFile.getFileName());
-                srcFile.moveFileTo(dstFile);
-            }
-        }
-    }
-
-    // Update clip audio paths that reference the old media directory
-    auto& clipManager = ClipManager::getInstance();
-    auto updateClipPaths = [&](const std::vector<ClipInfo>& clips) {
-        // Sources are pooled per file, so a moved file is relinked once even
-        // when several clips reference it; the clip loop only decides which
-        // clips need re-notifying.
-        auto& pool = SourcePool::getInstance();
-        std::unordered_set<SourceId> relinked;
-        for (const auto& clipInfo : clips) {
-            const auto* event = clipInfo.primaryEvent();
-            if (event == nullptr)
-                continue;
-            const auto sourcePath = event->sourceFilePath();
-            const bool sourceMoved = sourcePath.isNotEmpty() && sourcePath.startsWith(oldPath);
-            bool anyTakeMoved = false;
-            for (const auto& take : clipInfo.audio().takes) {
-                if (take.filePath.startsWith(oldPath)) {
-                    anyTakeMoved = true;
-                    break;
-                }
-            }
-            if (!sourceMoved && !anyTakeMoved)
-                continue;
-            auto* clip = clipManager.getClip(clipInfo.id);
-            if (clip) {
-                if (sourceMoved && relinked.insert(event->sourceId).second) {
-                    const auto moved = event->sourceId;
-                    const auto owner =
-                        pool.relink(moved, sourcePath.replace(oldPath, newPath, false));
-                    if (owner != INVALID_SOURCE_ID && owner != moved)
-                        clipManager.repointEventsToSource(moved, owner);
-                }
-                for (auto& take : clip->audio().takes)
-                    if (take.filePath.startsWith(oldPath))
-                        take.filePath = take.filePath.replace(oldPath, newPath, false);
-                updatedClipIds.push_back(clip->id);
-            }
-        }
-    };
-
-    updateClipPaths(clipManager.getArrangementClips());
-    updateClipPaths(clipManager.getSessionClips());
-
-    if (!updatedClipIds.empty())
-        clipManager.forceNotifyMultipleClipPropertiesChanged(updatedClipIds);
+    relinkMediaPaths([&moves](const juce::String& path) -> juce::String {
+        const auto it = moves.find(path);
+        return it == moves.end() ? juce::String() : it->second;
+    });
 
     // Remove old temp directory if it's empty or under the temp root
     auto tempRoot =
@@ -809,6 +869,46 @@ void ProjectManager::migrateMediaFiles(const juce::File& oldDir, const juce::Fil
     if (oldDir.isAChildOf(tempRoot)) {
         oldDir.deleteRecursively();
     }
+}
+
+void ProjectManager::foldLegacyMediaDirectories(const juce::File& mediaRoot) {
+    if (mediaRoot == juce::File() || !mediaRoot.isDirectory())
+        return;
+
+    std::map<juce::String, juce::String> moves;
+    for (const auto& legacy : kLegacyMediaSubdirs)
+        moveMediaTree(mediaRoot.getChildFile(legacy.from), mediaRoot.getChildFile(legacy.to),
+                      moves);
+
+    const auto rootPath = mediaRoot.getFullPathName();
+    const auto resolve = [&moves, &rootPath, &mediaRoot](const juce::String& path) -> juce::String {
+        const auto it = moves.find(path);
+        if (it != moves.end())
+            return it->second;
+
+        // A project folded on an earlier load but never saved still names the
+        // retired folders in its .mgd. Those files moved back then, so follow
+        // them to where they live now — unless the fold had to rename, in which
+        // case the file is genuinely ambiguous and the clip stays unresolved
+        // until the user saves.
+        for (const auto& legacy : kLegacyMediaSubdirs) {
+            const auto prefix = rootPath + juce::File::getSeparatorString() + legacy.from +
+                                juce::File::getSeparatorString();
+            if (!path.startsWith(prefix))
+                continue;
+
+            const auto moved =
+                mediaRoot.getChildFile(legacy.to).getChildFile(path.substring(prefix.length()));
+            if (moved.existsAsFile())
+                return moved.getFullPathName();
+        }
+        return {};
+    };
+
+    // The paths in the .mgd on disk still name folders that just went away, so
+    // the project genuinely differs from its file until it is saved again.
+    if (relinkMediaPaths(resolve))
+        markDirty();
 }
 
 void ProjectManager::cleanupStaleTempDirectories() {

--- a/magda/daw/project/ProjectManager.cpp
+++ b/magda/daw/project/ProjectManager.cpp
@@ -41,6 +41,9 @@ static const LegacyMediaSubdir kLegacyMediaSubdirs[] = {
     {"external-edits", kImportedDir},
     {"stems", kRendersDir},
 };
+// Written into the media root when a fold actually moves something, so a later
+// load can tell where a file went instead of guessing from its name (#2170).
+static const char* const kMediaMovesFile = ".magda-media-moves.json";
 static const char* const kTempRootDir = "MAGDA";
 static const char* const kTempPrefix = "UnsavedProject_";
 static constexpr int kStaleTempDays = 7;
@@ -80,6 +83,37 @@ void resetTransportForProjectBoundary() {
     audioEngine->deactivateAllSessionClips();
     audioEngine->setLooping(false);
     audioEngine->locate(0.0);
+}
+
+// Paths are recorded relative to the media root, with '/' separators, so the
+// record survives the project folder being moved, renamed, or opened on another
+// platform. Returns an empty string for a path outside the tree.
+juce::String mediaRelativePath(const juce::File& mediaRoot, const juce::File& file) {
+    if (!file.isAChildOf(mediaRoot))
+        return {};
+    return file.getRelativePathFrom(mediaRoot).replaceCharacter('\\', '/');
+}
+
+std::map<juce::String, juce::String> readMediaMoves(const juce::File& mediaRoot) {
+    std::map<juce::String, juce::String> record;
+    const auto file = mediaRoot.getChildFile(kMediaMovesFile);
+    if (!file.existsAsFile())
+        return record;
+
+    const auto parsed = juce::JSON::parse(file.loadFileAsString());
+    if (auto* object = parsed.getDynamicObject())
+        for (const auto& entry : object->getProperties())
+            record[entry.name.toString()] = entry.value.toString();
+    return record;
+}
+
+void writeMediaMoves(const juce::File& mediaRoot,
+                     const std::map<juce::String, juce::String>& record) {
+    auto object = std::make_unique<juce::DynamicObject>();
+    for (const auto& [from, to] : record)
+        object->setProperty(from, to);
+    mediaRoot.getChildFile(kMediaMovesFile)
+        .replaceWithText(juce::JSON::toString(juce::var(object.release())));
 }
 
 // What to do with a file whose destination name is already taken. Never
@@ -900,38 +934,46 @@ void ProjectManager::foldLegacyMediaDirectories(const juce::File& mediaRoot) {
     if (mediaRoot == juce::File() || !mediaRoot.isDirectory())
         return;
 
+    auto record = readMediaMoves(mediaRoot);
+
     std::map<juce::String, juce::String> moves;
     for (const auto& legacy : kLegacyMediaSubdirs)
         moveMediaTree(mediaRoot.getChildFile(legacy.from), mediaRoot.getChildFile(legacy.to), moves,
                       OnCollision::Skip);
 
-    const auto rootPath = mediaRoot.getFullPathName();
-    const auto resolve = [&moves, &rootPath, &mediaRoot](const juce::String& path) -> juce::String {
+    // Record what moved before relinking. The new paths only reach the .mgd
+    // when the user next saves, so without this the next load would have
+    // nothing but a filename to go on.
+    if (!moves.empty()) {
+        for (const auto& [from, to] : moves) {
+            const auto fromRel = mediaRelativePath(mediaRoot, juce::File(from));
+            const auto toRel = mediaRelativePath(mediaRoot, juce::File(to));
+            if (fromRel.isNotEmpty() && toRel.isNotEmpty())
+                record[fromRel] = toRel;
+        }
+        writeMediaMoves(mediaRoot, record);
+    }
+
+    const auto resolve = [&moves, &record, &mediaRoot](const juce::String& path) -> juce::String {
         const auto it = moves.find(path);
         if (it != moves.end())
             return it->second;
 
         // A project folded on an earlier load but never saved still names the
-        // retired folders in its .mgd, so follow the name into the replacement
-        // root. That is unambiguous only because the fold skips collisions: a
-        // file that would have had to share a name never moved, so a name that
-        // has left the retired root and is present in the replacement can only
-        // be the same file. Uniquifying here instead would let a stale path
-        // land on an unrelated file that merely shares its name.
-        for (const auto& legacy : kLegacyMediaSubdirs) {
-            const auto prefix = rootPath + juce::File::getSeparatorString() + legacy.from +
-                                juce::File::getSeparatorString();
-            if (!path.startsWith(prefix))
-                continue;
-            if (juce::File(path).existsAsFile())
-                return {};  // Skipped by the fold — it still lives where it says.
+        // old location in its .mgd. Only the record of what a fold actually
+        // moved can say where the file went: a destination that merely shares
+        // the name may be an unrelated file, and the .mgd may name something
+        // that was already missing before any fold ran.
+        const auto relative = mediaRelativePath(mediaRoot, juce::File(path));
+        if (relative.isEmpty())
+            return {};
 
-            const auto moved =
-                mediaRoot.getChildFile(legacy.to).getChildFile(path.substring(prefix.length()));
-            if (moved.existsAsFile())
-                return moved.getFullPathName();
-        }
-        return {};
+        const auto recorded = record.find(relative);
+        if (recorded == record.end())
+            return {};
+
+        const auto moved = mediaRoot.getChildFile(recorded->second);
+        return moved.existsAsFile() ? moved.getFullPathName() : juce::String();
     };
 
     // The paths in the .mgd on disk still name folders that just went away, so

--- a/magda/daw/project/ProjectManager.hpp
+++ b/magda/daw/project/ProjectManager.hpp
@@ -283,35 +283,21 @@ class ProjectManager : private juce::Timer {
     juce::File getRecordingsDirectory() const;
 
     /**
-     * @brief Get the renders subdirectory
+     * @brief Get the renders subdirectory.
+     *
+     * Everything MAGDA computed from the timeline: clip and track renders,
+     * comp renders, bounces, and one sub-folder per stem split (#1288).
      */
     juce::File getRendersDirectory() const;
 
     /**
-     * @brief Get the bounces subdirectory
-     */
-    juce::File getBouncesDirectory() const;
-
-    /**
-     * @brief Get the copy-on-edit external sample edits subdirectory
-     */
-    juce::File getExternalEditsDirectory() const;
-
-    /**
-     * @brief Get the collected/imported media subdirectory.
+     * @brief Get the imported media subdirectory.
      *
-     * Where "Collect files" copies externally-referenced audio (clip sources,
-     * sampler and drum-pad samples) so the project is self-contained (#1407).
+     * Everything that arrived from outside the timeline: audio copied in by
+     * "Collect files" (clip sources, sampler and drum-pad samples, #1407) and
+     * the copy-on-edit files handed to an external audio editor.
      */
     juce::File getImportedDirectory() const;
-
-    /**
-     * @brief Get the stem separation output subdirectory (#1288).
-     *
-     * Where "Split into Stems" writes the separated stem WAVs, one
-     * sub-folder per split.
-     */
-    juce::File getStemsDirectory() const;
 
     /**
      * @brief Delete temp media directories older than 7 days.
@@ -387,6 +373,17 @@ class ProjectManager : private juce::Timer {
      * @brief Migrate media files from old directory to new, updating clip paths
      */
     void migrateMediaFiles(const juce::File& oldDir, const juce::File& newDir);
+
+    /**
+     * @brief Fold the media roots retired by #2170 into the surviving three.
+     *
+     * A project saved before the collapse still has bounces/, external-edits/
+     * and stems/ on disk. Their contents move into renders/ and imported/ and
+     * every clip, take and sampler reference follows. Marks the project dirty
+     * when anything moved: the .mgd on disk still names folders that just
+     * went away.
+     */
+    void foldLegacyMediaDirectories(const juce::File& mediaRoot);
 };
 
 }  // namespace magda

--- a/magda/daw/stem_separation/StemSeparationService.cpp
+++ b/magda/daw/stem_separation/StemSeparationService.cpp
@@ -233,7 +233,7 @@ void StemSeparationService::splitClipIntoStems(ClipId sourceClipId, Engine engin
     const int sceneIndex = clip->sceneIndex;
     const double bpm = projectBpm();
 
-    const juce::File stemsRoot = ProjectManager::getInstance().getStemsDirectory();
+    const juce::File rendersRoot = ProjectManager::getInstance().getRendersDirectory();
 
     // Phase 1, immediately on the message thread: the empty stem tracks and
     // their group appear the moment the user clicks, so the track area
@@ -284,7 +284,7 @@ void StemSeparationService::splitClipIntoStems(ClipId sourceClipId, Engine engin
     };
 
     pool_->addJob([this, sourceClipId, engine, filePath, baseName, sourceTrackId, startBeat,
-                   sceneIndex, bpm, stemsRoot, stemTrackIds, groupId, report = std::move(report),
+                   sceneIndex, bpm, rendersRoot, stemTrackIds, groupId, report = std::move(report),
                    failAndCleanup = std::move(failAndCleanup),
                    enqueueGeneration = cancelGeneration_.load()]() {
         // Cancelled iff cancelAll() ran after this job was enqueued.
@@ -334,8 +334,8 @@ void StemSeparationService::splitClipIntoStems(ClipId sourceClipId, Engine engin
                 return;
             }
 
-            // One folder per split: <media>/stems/<source> - <engine>/
-            juce::File dir = stemsRoot.getChildFile(baseName + " - " + separator->modelId());
+            // One folder per split: <media>/renders/<source> - <engine>/
+            juce::File dir = rendersRoot.getChildFile(baseName + " - " + separator->modelId());
             if (dir.exists())
                 dir = dir.getNonexistentSibling();
             if (!dir.createDirectory().wasOk()) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -508,6 +508,7 @@ target_sources(magda_juce_tests PRIVATE
     test_timeline_loop_activation_juce.cpp
     test_midi_signal_routing_juce.cpp
     test_drum_grid_serialization_juce.cpp
+    test_sampler_relocate_juce.cpp
     test_device_services_juce.cpp
     test_device_param_schema_juce.cpp
     # pluginState v1 -> v2 over the legacy corpus (#2079). Here rather than in

--- a/tests/test_project_serialization.cpp
+++ b/tests/test_project_serialization.cpp
@@ -670,6 +670,93 @@ TEST_CASE("Project Serialization Basics", "[project][serialization]") {
 
         // The .mgd on disk still names the folders that just went away.
         REQUIRE(projectManager.isDirty());
+
+        // Saving is what makes the fold durable, and it leaves the project
+        // clean again. Left dirty, the next test's newProject() would block on
+        // the unsaved-changes dialog, since ProjectManager is a singleton and
+        // Catch2 sections share it.
+        REQUIRE(projectManager.saveProject());
+        REQUIRE_FALSE(projectManager.isDirty());
+
+        StagedProjectData staged;
+        REQUIRE(ProjectSerializer::loadAndStage(actualFile, staged));
+        juce::StringArray savedPaths;
+        for (const auto& clip : staged.clips)
+            if (clip.isAudio())
+                savedPaths.add(magda::audioEventRef(clip).sourceFilePath());
+        REQUIRE(savedPaths.contains(foldedBounce.getFullPathName()));
+        REQUIRE(savedPaths.contains(foldedEdit.getFullPathName()));
+        REQUIRE(savedPaths.contains(foldedStem.getFullPathName()));
+    }
+
+    SECTION("Plugin state is captured after the media migration") {
+        // onBeforeSave snapshots sampler and drum-pad sample paths. Capturing
+        // it before the migration would freeze the pre-move paths into the
+        // .mgd, leaving those samples missing when the project is reopened.
+        auto& projectManager = ProjectManager::getInstance();
+        REQUIRE(projectManager.newProject());
+
+        auto sourceFile = projectManager.getImportedDirectory().getChildFile("sample.wav");
+        REQUIRE(sourceFile.getParentDirectory().createDirectory());
+        REQUIRE(sourceFile.replaceWithText("placeholder audio"));
+
+        auto tempFile = fixture.createTempProjectFile(".mgd");
+        auto actualFile = ProjectTestFixture::wrappedPath(tempFile);
+        auto expectedFile = actualFile.getParentDirectory()
+                                .getChildFile(actualFile.getFileNameWithoutExtension() + "_Media")
+                                .getChildFile("imported")
+                                .getChildFile("sample.wav");
+
+        bool sawMigratedMedia = false;
+        projectManager.onBeforeSave = [&sawMigratedMedia, expectedFile]() {
+            sawMigratedMedia = expectedFile.existsAsFile();
+        };
+        const bool saved = projectManager.saveProjectAs(tempFile);
+        projectManager.onBeforeSave = nullptr;
+
+        REQUIRE(saved);
+        REQUIRE(sawMigratedMedia);
+    }
+
+    SECTION("Folding leaves a colliding legacy file where it is") {
+        auto& projectManager = ProjectManager::getInstance();
+        REQUIRE(projectManager.newProject());
+
+        auto trackId = TrackManager::getInstance().createTrack("Audio Track", TrackType::Media);
+
+        auto tempFile = fixture.createTempProjectFile(".mgd");
+        auto actualFile = ProjectTestFixture::wrappedPath(tempFile);
+        auto mediaDir = actualFile.getParentDirectory().getChildFile(
+            actualFile.getFileNameWithoutExtension() + "_Media");
+
+        auto renderFile = mediaDir.getChildFile("renders").getChildFile("kick.wav");
+        auto bounceFile = mediaDir.getChildFile("bounces").getChildFile("kick.wav");
+        REQUIRE(renderFile.getParentDirectory().createDirectory());
+        REQUIRE(bounceFile.getParentDirectory().createDirectory());
+        REQUIRE(renderFile.replaceWithText("the render"));
+        REQUIRE(bounceFile.replaceWithText("the bounce"));
+
+        REQUIRE(ClipManager::getInstance().createAudioClipBeats(
+                    trackId, 0.0, 4.0, bounceFile.getFullPathName(), ClipView::Arrangement,
+                    120.0) != INVALID_CLIP_ID);
+
+        REQUIRE(projectManager.saveProjectAs(tempFile));
+        REQUIRE(projectManager.loadProject(actualFile));
+
+        // Nothing overwritten, nothing renamed, nothing substituted: the clip
+        // keeps pointing at the path its .mgd already names, so a later load
+        // that finds the folder gone cannot mistake the render for the bounce.
+        REQUIRE(bounceFile.existsAsFile());
+        REQUIRE(bounceFile.loadFileAsString() == "the bounce");
+        REQUIRE(renderFile.loadFileAsString() == "the render");
+        REQUIRE_FALSE(mediaDir.getChildFile("renders").getChildFile("kick_2.wav").exists());
+
+        auto clips = ClipManager::getInstance().getClips();
+        REQUIRE(clips.size() == 1);
+        REQUIRE(magda::audioEventRef(clips[0]).sourceFilePath() == bounceFile.getFullPathName());
+
+        // Nothing moved, so there is nothing the .mgd is out of date about.
+        REQUIRE_FALSE(projectManager.isDirty());
     }
 
     SECTION("Project info serialization roundtrip") {

--- a/tests/test_project_serialization.cpp
+++ b/tests/test_project_serialization.cpp
@@ -759,6 +759,88 @@ TEST_CASE("Project Serialization Basics", "[project][serialization]") {
         REQUIRE_FALSE(projectManager.isDirty());
     }
 
+    SECTION("A folded path resolves on reload from the recorded move") {
+        // The fold's new paths only reach the .mgd when the user saves. Until
+        // then the next load has to learn where the file went from the record
+        // the fold left behind.
+        auto& projectManager = ProjectManager::getInstance();
+        REQUIRE(projectManager.newProject());
+
+        auto trackId = TrackManager::getInstance().createTrack("Audio Track", TrackType::Media);
+
+        auto tempFile = fixture.createTempProjectFile(".mgd");
+        auto actualFile = ProjectTestFixture::wrappedPath(tempFile);
+        auto mediaDir = actualFile.getParentDirectory().getChildFile(
+            actualFile.getFileNameWithoutExtension() + "_Media");
+
+        auto bounceFile = mediaDir.getChildFile("bounces").getChildFile("kick.wav");
+        REQUIRE(bounceFile.getParentDirectory().createDirectory());
+        REQUIRE(bounceFile.replaceWithText("the bounce"));
+
+        REQUIRE(ClipManager::getInstance().createAudioClipBeats(
+                    trackId, 0.0, 4.0, bounceFile.getFullPathName(), ClipView::Arrangement,
+                    120.0) != INVALID_CLIP_ID);
+        REQUIRE(projectManager.saveProjectAs(tempFile));
+
+        // Stand in for a previous load that folded and was never saved: the
+        // file has moved and the record says so, but the .mgd still names the
+        // old location.
+        auto foldedFile = mediaDir.getChildFile("renders").getChildFile("kick.wav");
+        REQUIRE(foldedFile.getParentDirectory().createDirectory());
+        REQUIRE(bounceFile.moveFileTo(foldedFile));
+        mediaDir.getChildFile("bounces").deleteRecursively();
+        REQUIRE(mediaDir.getChildFile(".magda-media-moves.json")
+                    .replaceWithText(R"({"bounces/kick.wav": "renders/kick.wav"})"));
+
+        REQUIRE(projectManager.loadProject(actualFile));
+
+        auto clips = ClipManager::getInstance().getClips();
+        REQUIRE(clips.size() == 1);
+        REQUIRE(magda::audioEventRef(clips[0]).sourceFilePath() == foldedFile.getFullPathName());
+
+        REQUIRE(projectManager.saveProject());
+    }
+
+    SECTION("A legacy path missing before any fold is left alone") {
+        // Nothing moved it, so nothing knows where it went. A file in the
+        // replacement root that happens to share its name is a different file,
+        // and relinking to it would silently play unrelated audio.
+        auto& projectManager = ProjectManager::getInstance();
+        REQUIRE(projectManager.newProject());
+
+        auto trackId = TrackManager::getInstance().createTrack("Audio Track", TrackType::Media);
+
+        auto tempFile = fixture.createTempProjectFile(".mgd");
+        auto actualFile = ProjectTestFixture::wrappedPath(tempFile);
+        auto mediaDir = actualFile.getParentDirectory().getChildFile(
+            actualFile.getFileNameWithoutExtension() + "_Media");
+
+        auto bounceFile = mediaDir.getChildFile("bounces").getChildFile("ghost.wav");
+        REQUIRE(bounceFile.getParentDirectory().createDirectory());
+        REQUIRE(bounceFile.replaceWithText("the bounce"));
+
+        REQUIRE(ClipManager::getInstance().createAudioClipBeats(
+                    trackId, 0.0, 4.0, bounceFile.getFullPathName(), ClipView::Arrangement,
+                    120.0) != INVALID_CLIP_ID);
+        REQUIRE(projectManager.saveProjectAs(tempFile));
+
+        // The referenced bounce is gone — deleted outside MAGDA, say — and an
+        // unrelated render happens to carry the same name.
+        REQUIRE(bounceFile.deleteFile());
+        mediaDir.getChildFile("bounces").deleteRecursively();
+        auto unrelated = mediaDir.getChildFile("renders").getChildFile("ghost.wav");
+        REQUIRE(unrelated.getParentDirectory().createDirectory());
+        REQUIRE(unrelated.replaceWithText("a different render"));
+
+        REQUIRE(projectManager.loadProject(actualFile));
+
+        auto clips = ClipManager::getInstance().getClips();
+        REQUIRE(clips.size() == 1);
+        REQUIRE(magda::audioEventRef(clips[0]).sourceFilePath() == bounceFile.getFullPathName());
+        REQUIRE(unrelated.loadFileAsString() == "a different render");
+        REQUIRE_FALSE(projectManager.isDirty());
+    }
+
     SECTION("Project info serialization roundtrip") {
         ProjectInfo info;
         info.name = "Test Project";

--- a/tests/test_project_serialization.cpp
+++ b/tests/test_project_serialization.cpp
@@ -560,6 +560,118 @@ TEST_CASE("Project Serialization Basics", "[project][serialization]") {
         REQUIRE(expectedFile.existsAsFile());
     }
 
+    SECTION("Save As moves nested media content and relinks it") {
+        // Stem splits nest one level below their root, and the pre-#2170
+        // migration iterator was non-recursive, so they were left behind.
+        auto& projectManager = ProjectManager::getInstance();
+        REQUIRE(projectManager.newProject());
+
+        auto trackId = TrackManager::getInstance().createTrack("Audio Track", TrackType::Media);
+
+        auto splitDir = projectManager.getRendersDirectory().getChildFile("Vocals - htdemucs");
+        REQUIRE(splitDir.createDirectory());
+        auto stemFile = splitDir.getChildFile("vocals.wav");
+        REQUIRE(stemFile.replaceWithText("placeholder audio"));
+
+        auto clipId = ClipManager::getInstance().createAudioClipBeats(
+            trackId, 0.0, 4.0, stemFile.getFullPathName(), ClipView::Arrangement, 120.0);
+        REQUIRE(clipId != INVALID_CLIP_ID);
+
+        auto tempFile = fixture.createTempProjectFile(".mgd");
+        auto actualFile = ProjectTestFixture::wrappedPath(tempFile);
+        REQUIRE(projectManager.saveProjectAs(tempFile));
+
+        auto expectedFile = projectManager.getRendersDirectory()
+                                .getChildFile("Vocals - htdemucs")
+                                .getChildFile("vocals.wav");
+        REQUIRE(expectedFile.existsAsFile());
+        REQUIRE_FALSE(stemFile.existsAsFile());
+
+        StagedProjectData staged;
+        REQUIRE(ProjectSerializer::loadAndStage(actualFile, staged));
+        REQUIRE(staged.clips.size() == 1);
+        REQUIRE(magda::audioEventRef(staged.clips[0]).sourceFilePath() ==
+                expectedFile.getFullPathName());
+    }
+
+    SECTION("A saved project declares exactly the three media roots") {
+        auto& projectManager = ProjectManager::getInstance();
+        REQUIRE(projectManager.newProject());
+
+        auto tempFile = fixture.createTempProjectFile(".mgd");
+        REQUIRE(projectManager.saveProjectAs(tempFile));
+
+        auto mediaDir = projectManager.getMediaDirectory();
+        REQUIRE(mediaDir.getChildFile("recordings").isDirectory());
+        REQUIRE(mediaDir.getChildFile("renders").isDirectory());
+        REQUIRE(mediaDir.getChildFile("imported").isDirectory());
+        REQUIRE_FALSE(mediaDir.getChildFile("bounces").exists());
+        REQUIRE_FALSE(mediaDir.getChildFile("external-edits").exists());
+        REQUIRE_FALSE(mediaDir.getChildFile("stems").exists());
+    }
+
+    SECTION("Loading folds the retired media roots and relinks the clips") {
+        auto& projectManager = ProjectManager::getInstance();
+        REQUIRE(projectManager.newProject());
+
+        auto trackId = TrackManager::getInstance().createTrack("Audio Track", TrackType::Media);
+
+        // Build a project laid out the pre-#2170 way: the clips point straight
+        // at the retired roots inside the media tree the save is about to
+        // create, so nothing folds them until the load does.
+        auto tempFile = fixture.createTempProjectFile(".mgd");
+        auto actualFile = ProjectTestFixture::wrappedPath(tempFile);
+        auto mediaDir = actualFile.getParentDirectory().getChildFile(
+            actualFile.getFileNameWithoutExtension() + "_Media");
+
+        auto bounceFile = mediaDir.getChildFile("bounces").getChildFile("kick.wav");
+        auto editFile = mediaDir.getChildFile("external-edits").getChildFile("vox.wav");
+        auto stemFile = mediaDir.getChildFile("stems")
+                            .getChildFile("Vocals - htdemucs")
+                            .getChildFile("vocals.wav");
+        for (const auto& legacyFile : {bounceFile, editFile, stemFile}) {
+            REQUIRE(legacyFile.getParentDirectory().createDirectory());
+            REQUIRE(legacyFile.replaceWithText("placeholder audio"));
+        }
+
+        for (const auto& legacyFile : {bounceFile, editFile, stemFile}) {
+            REQUIRE(ClipManager::getInstance().createAudioClipBeats(
+                        trackId, 0.0, 4.0, legacyFile.getFullPathName(), ClipView::Arrangement,
+                        120.0) != INVALID_CLIP_ID);
+        }
+
+        REQUIRE(projectManager.saveProjectAs(tempFile));
+        REQUIRE(bounceFile.existsAsFile());
+
+        REQUIRE(projectManager.loadProject(actualFile));
+
+        // Retired roots are gone, their content folded into the survivors.
+        REQUIRE_FALSE(mediaDir.getChildFile("bounces").exists());
+        REQUIRE_FALSE(mediaDir.getChildFile("external-edits").exists());
+        REQUIRE_FALSE(mediaDir.getChildFile("stems").exists());
+
+        auto foldedBounce = mediaDir.getChildFile("renders").getChildFile("kick.wav");
+        auto foldedEdit = mediaDir.getChildFile("imported").getChildFile("vox.wav");
+        auto foldedStem = mediaDir.getChildFile("renders")
+                              .getChildFile("Vocals - htdemucs")
+                              .getChildFile("vocals.wav");
+        REQUIRE(foldedBounce.existsAsFile());
+        REQUIRE(foldedEdit.existsAsFile());
+        REQUIRE(foldedStem.existsAsFile());
+
+        juce::StringArray clipPaths;
+        for (const auto& clip : ClipManager::getInstance().getClips())
+            if (clip.isAudio())
+                clipPaths.add(magda::audioEventRef(clip).sourceFilePath());
+        REQUIRE(clipPaths.size() == 3);
+        REQUIRE(clipPaths.contains(foldedBounce.getFullPathName()));
+        REQUIRE(clipPaths.contains(foldedEdit.getFullPathName()));
+        REQUIRE(clipPaths.contains(foldedStem.getFullPathName()));
+
+        // The .mgd on disk still names the folders that just went away.
+        REQUIRE(projectManager.isDirty());
+    }
+
     SECTION("Project info serialization roundtrip") {
         ProjectInfo info;
         info.name = "Test Project";

--- a/tests/test_sampler_relocate_juce.cpp
+++ b/tests/test_sampler_relocate_juce.cpp
@@ -1,0 +1,170 @@
+// Relocating a sampler's file must not re-interpret the sample (#2170).
+
+#include <juce_core/juce_core.h>
+#include <tracktion_engine/tracktion_engine.h>
+
+#include "JuceTestStateGuard.hpp"
+#include "SharedTestEngine.hpp"
+#include "magda/daw/audio/plugins/MagdaSamplerPlugin.hpp"
+#include "third_party/tracktion_engine/modules/tracktion_engine/utilities/tracktion_TestUtilities.h"
+
+namespace te = tracktion;
+using magda::daw::audio::MagdaSamplerPlugin;
+
+namespace {
+
+te::Plugin::Ptr createCustomPlugin(te::Edit& edit, const juce::String& type) {
+    juce::ValueTree state(te::IDs::PLUGIN);
+    state.setProperty(te::IDs::type, type, nullptr);
+    return edit.getPluginCache().createNewPlugin(state);
+}
+
+juce::File testScratchDir() {
+    auto dir =
+        juce::File(juce::SystemStats::getEnvironmentVariable(
+                       "TMPDIR",
+                       juce::File::getSpecialLocation(juce::File::tempDirectory).getFullPathName()))
+            .getChildFile("magda_juce_tests");
+    dir.createDirectory();
+    return dir;
+}
+
+// Mirrors how the plugin itself moves a marker: through the host-write path,
+// with the CachedValue kept in step, since that is what relocateSample reads.
+void setMarker(const te::AutomatableParameter::Ptr& param, juce::CachedValue<float>& cached,
+               float seconds) {
+    param->setParameterFromHost(seconds, juce::dontSendNotification);
+    cached = seconds;
+}
+
+// One second of sine, long enough that trim markers have somewhere to sit other
+// than the defaults.
+bool writeTestWav(const juce::File& destination) {
+    constexpr double sampleRate = 44100.0;
+    constexpr int numSamples = 44100;
+    juce::AudioBuffer<float> buffer(1, numSamples);
+    const auto phaseInc =
+        static_cast<float>(440.0 * juce::MathConstants<double>::twoPi / sampleRate);
+    float phase = 0.0f;
+    for (int i = 0; i < numSamples; ++i) {
+        buffer.setSample(0, i, 0.5f * std::sin(phase));
+        phase += phaseInc;
+    }
+
+    destination.deleteFile();
+    juce::WavAudioFormat wavFormat;
+    std::unique_ptr<juce::AudioFormatWriter> writer(wavFormat.createWriterFor(
+        new juce::FileOutputStream(destination), sampleRate, 1, 16, {}, 0));
+    if (writer == nullptr)
+        return false;
+    return writer->writeFromAudioSampleBuffer(buffer, 0, numSamples);
+}
+
+}  // namespace
+
+class SamplerRelocateTest final : public juce::UnitTest {
+  public:
+    SamplerRelocateTest() : juce::UnitTest("Sampler Relocate Tests", "magda") {}
+
+    void runTest() override {
+        testRelocatePreservesInterpretation();
+        testLoadSampleStillResets();
+    }
+
+  private:
+    // A sampler holding `sampleFile` with deliberately non-default
+    // interpretation settings, or nullptr if the fixture could not be built.
+    MagdaSamplerPlugin* prepare(te::Edit& edit, const juce::File& sampleFile,
+                                te::Plugin::Ptr& keepAlive) {
+        keepAlive = createCustomPlugin(edit, MagdaSamplerPlugin::xmlTypeName);
+        auto* sampler = dynamic_cast<MagdaSamplerPlugin*>(keepAlive.get());
+        expect(sampler != nullptr, "Sampler plugin must be created");
+        if (sampler == nullptr)
+            return nullptr;
+
+        sampler->loadSample(sampleFile);
+        expectEquals(sampler->getSampleFile().getFullPathName(), sampleFile.getFullPathName(),
+                     "Sampler must have adopted the sample");
+
+        sampler->setRootNote(48);
+        setMarker(sampler->sampleStartParam, sampler->sampleStartValue, 0.25f);
+        setMarker(sampler->sampleEndParam, sampler->sampleEndValue, 0.75f);
+        setMarker(sampler->loopStartParam, sampler->loopStartValue, 0.3f);
+        setMarker(sampler->loopEndParam, sampler->loopEndValue, 0.6f);
+        return sampler;
+    }
+
+    void testRelocatePreservesInterpretation() {
+        beginTest("Relocating a sample keeps root note and trim/loop markers");
+
+        auto& wrapper = magda::test::getSharedEngine();
+        auto edit = te::test_utilities::createTestEdit(*wrapper.getEngine(), 1);
+        expect(edit != nullptr, "Test edit must be created");
+        if (!edit)
+            return;
+
+        auto original = testScratchDir().getNonexistentChildFile("relocate_source", ".wav");
+        expect(writeTestWav(original), "Test sample must be written");
+
+        te::Plugin::Ptr keepAlive;
+        auto* sampler = prepare(*edit, original, keepAlive);
+        if (sampler == nullptr)
+            return;
+
+        // Same audio, new home — exactly what a media migration does.
+        auto moved = testScratchDir().getNonexistentChildFile("relocate_dest", ".wav");
+        expect(original.moveFileTo(moved), "Sample must move");
+
+        sampler->relocateSample(moved);
+
+        expectEquals(sampler->getSampleFile().getFullPathName(), moved.getFullPathName(),
+                     "Sampler must follow the file");
+        expectEquals(sampler->getRootNote(), 48, "Root note must survive relocation");
+        expectWithinAbsoluteError(sampler->sampleStartValue.get(), 0.25f, 0.0001f,
+                                  "Sample start must survive relocation");
+        expectWithinAbsoluteError(sampler->sampleEndValue.get(), 0.75f, 0.0001f,
+                                  "Sample end must survive relocation");
+        expectWithinAbsoluteError(sampler->loopStartValue.get(), 0.3f, 0.0001f,
+                                  "Loop start must survive relocation");
+        expectWithinAbsoluteError(sampler->loopEndValue.get(), 0.6f, 0.0001f,
+                                  "Loop end must survive relocation");
+
+        moved.deleteFile();
+    }
+
+    void testLoadSampleStillResets() {
+        beginTest("Choosing a genuinely new sample still resets interpretation");
+
+        auto& wrapper = magda::test::getSharedEngine();
+        auto edit = te::test_utilities::createTestEdit(*wrapper.getEngine(), 1);
+        expect(edit != nullptr, "Test edit must be created");
+        if (!edit)
+            return;
+
+        auto original = testScratchDir().getNonexistentChildFile("reset_source", ".wav");
+        expect(writeTestWav(original), "Test sample must be written");
+
+        te::Plugin::Ptr keepAlive;
+        auto* sampler = prepare(*edit, original, keepAlive);
+        if (sampler == nullptr)
+            return;
+
+        // relocateSample narrows loadSample, it does not replace it: picking a
+        // different sample must still start from a clean interpretation.
+        auto other = testScratchDir().getNonexistentChildFile("reset_other", ".wav");
+        expect(writeTestWav(other), "Second test sample must be written");
+
+        sampler->loadSample(other);
+
+        expectEquals(sampler->getRootNote(), 60, "A newly chosen sample resets the root note");
+        expectWithinAbsoluteError(sampler->sampleStartValue.get(), 0.0f, 0.0001f,
+                                  "A newly chosen sample resets the start marker");
+        expectWithinAbsoluteError(sampler->loopStartValue.get(), 0.0f, 0.0001f,
+                                  "A newly chosen sample resets the loop start");
+
+        original.deleteFile();
+        other.deleteFile();
+    }
+};
+
+static SamplerRelocateTest samplerRelocateTest;


### PR DESCRIPTION
Closes #2170.

## Layout

Six roots become three, each with a meaning to the user:

```
MyProject_Media/
├── recordings/        captured from an input
├── renders/           anything MAGDA computed from the timeline
│   ├── comp_42.wav              comp render
│   ├── Kick_2026-08-24.wav      clip/track render, bounce
│   └── Vocals - htdemucs/       one folder per stem split
└── imported/          anything that arrived from outside
    ├── amen_break.wav           collected files
    └── Vox.wav                  copy-on-edit for an external editor
```

`renders` and `bounces` held the same kind of thing, and `external-edits` / `imported` / `stems` were three roots for "audio from outside this timeline" with exactly one caller each.

## Single source of truth

`kMediaSubdirs[]` is now the only list, read by both creation and migration. Previously `ensureMediaSubdirectories()` created four of the six and `migrateMediaFiles()` moved the same four — so `imported/` and `stems/` were created ad hoc by their callers, and a Save-As or project move stranded them in the old tree while their clips kept pointing at the old path. `kLegacyMediaSubdirs[]` maps each retired root to its replacement.

## Migration

- **Recursive**, so the folder a stem split nests (`stems/<source> - <model>/`) actually moves. The old iterator was `RangedDirectoryIterator(srcDir, false)`.
- Reports an old→new path map instead of rewriting path prefixes. A name already taken at the destination is uniquified rather than clobbered — folding two roots into one can collide, and overwriting would destroy a file another clip still references.
- Relinks **sampler and drum-pad samples** alongside clip sources and takes. Collected samples live in `imported/`, which never migrated at all before. Also walks every audio event per clip rather than only `primaryEvent()`.

## Existing projects

On load, `foldLegacyMediaDirectories()` moves the retired roots into their replacement and relinks in memory. That leaves the `.mgd` on disk naming folders that just went away, so the project is marked dirty and the user gets the save prompt on close. If they decline, the next load still resolves: a path under a retired root whose file is gone is followed to the same relative path under the replacement when that file exists. The one case that can't self-heal is a name that collided during the fold and was uniquified — that clip reads as missing until the user saves or relinks.

Save-As has no such window: `migrateMediaFiles()` folds on the way across and runs before serializing, so tree and file always agree.

If a move fails (read-only volume, permissions) no mapping is recorded, the legacy folder isn't deleted because files remain, and the clip keeps pointing at the file that's still there — it degrades to a no-op rather than to broken links.

## Call sites

Bounce commands → `getRendersDirectory()`; stem separation → `renders/<source> - <model>/`; external edits → `getImportedDirectory()`. `getBouncesDirectory()`, `getExternalEditsDirectory()` and `getStemsDirectory()` are gone. User-facing error strings updated to match.

## Testing

Three new sections in `test_project_serialization.cpp`: nested content survives Save-As, a saved project declares exactly the three roots and none of the retired ones, and loading a legacy project folds all three retired roots (including the nested stem folder), relinks the clips and marks dirty.

Verified negatively — making the iterator non-recursive fails the nested tests, and disabling the fold call fails the fold test.

Full Catch2 suite green (2920 passed, 13 skipped) plus the four ProjectManager-touching JUCE suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)