### PR TITLE
Run the compiled Faust devices under the native engine (#2192)

### DIFF
--- a/magda/daw/audio/CMakeLists.txt
+++ b/magda/daw/audio/CMakeLists.txt
@@ -352,8 +352,9 @@ set(_magda_neutral_base_device_sources
 # effects share MagdaCompiledEffect; both lists are just "who has crossed".
 foreach(_magda_neutral_device IN ITEMS
         Bell Clap Djembe FM Hat Kick Marimba Snare Tom
-        Bitcrusher Chorus Clipper Delay Flanger FreqShift
-        GateExpander GrainDelay Grit Mod Phaser RingMod Saturator)
+        Bitcrusher Chorus Clipper Compressor Delay Dimension Filter Flanger
+        FreqShift GateExpander GrainDelay Grit Mod Phaser Pitch Reverb RingMod
+        Eq Limiter Multiband Saturator Utility)
     list(APPEND _magda_neutral_base_device_sources
         "${CMAKE_CURRENT_SOURCE_DIR}/plugins/compiled/Magda${_magda_neutral_device}CompiledPlugin.cpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/plugins/compiled/Magda${_magda_neutral_device}CompiledPlugin.hpp"

--- a/magda/daw/audio/CMakeLists.txt
+++ b/magda/daw/audio/CMakeLists.txt
@@ -342,14 +342,21 @@ set(_magda_neutral_base_device_sources
     "${CMAKE_CURRENT_SOURCE_DIR}/plugins/SpectrumAnalyzerPlugin.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/plugins/compiled/CompiledFaustInterface.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/plugins/compiled/CompiledPluginRegistry.hpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/plugins/compiled/MagdaCompiledEffect.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/plugins/compiled/MagdaCompiledEffect.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/plugins/compiled/MagdaCompiledPolyInstrument.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/plugins/compiled/MagdaCompiledPolyInstrument.hpp"
 )
-foreach(_magda_neutral_instrument IN ITEMS
-        Bell Clap Djembe FM Hat Kick Marimba Snare Tom)
+# Devices that are MagdaDevice implementations: one DSP, hosted by whichever
+# engine is running it (#2192). Instruments share MagdaCompiledPolyInstrument,
+# effects share MagdaCompiledEffect; both lists are just "who has crossed".
+foreach(_magda_neutral_device IN ITEMS
+        Bell Clap Djembe FM Hat Kick Marimba Snare Tom
+        Bitcrusher Chorus Clipper Delay Flanger FreqShift
+        GateExpander GrainDelay Grit Mod Phaser RingMod Saturator)
     list(APPEND _magda_neutral_base_device_sources
-        "${CMAKE_CURRENT_SOURCE_DIR}/plugins/compiled/Magda${_magda_neutral_instrument}CompiledPlugin.cpp"
-        "${CMAKE_CURRENT_SOURCE_DIR}/plugins/compiled/Magda${_magda_neutral_instrument}CompiledPlugin.hpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/plugins/compiled/Magda${_magda_neutral_device}CompiledPlugin.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/plugins/compiled/Magda${_magda_neutral_device}CompiledPlugin.hpp"
     )
 endforeach()
 

--- a/magda/daw/audio/CMakeLists.txt
+++ b/magda/daw/audio/CMakeLists.txt
@@ -351,7 +351,7 @@ set(_magda_neutral_base_device_sources
 # engine is running it (#2192). Instruments share MagdaCompiledPolyInstrument,
 # effects share MagdaCompiledEffect; both lists are just "who has crossed".
 foreach(_magda_neutral_device IN ITEMS
-        Bell Clap Djembe FM Hat Kick Marimba Snare Tom
+        Bell Clap Djembe FM Hat Kick Marimba PolySynth Snare Tom
         Bitcrusher Chorus Clipper Compressor Delay Dimension Filter Flanger
         FreqShift GateExpander GrainDelay Grit Mod Phaser Pitch Reverb RingMod
         Eq Limiter Multiband Saturator Utility)

--- a/magda/daw/audio/plugins/MagdaDevice.hpp
+++ b/magda/daw/audio/plugins/MagdaDevice.hpp
@@ -21,6 +21,11 @@ struct DeviceProperties {
     bool canSidechain = false;
     double latencySeconds = 0.0;
     double tailLengthSeconds = 0.0;
+    /// Output channels the device always produces, whatever it is handed. Zero
+    /// means it follows its input, which is what most effects do; a device sets
+    /// this when its DSP has a fixed output width (a mono-in/stereo-out
+    /// widener, a stereo-only dynamics stage).
+    int outputChannelCount = 0;
 };
 
 struct DevicePrepareContext {

--- a/magda/daw/audio/plugins/MagdaDevice.hpp
+++ b/magda/daw/audio/plugins/MagdaDevice.hpp
@@ -26,6 +26,10 @@ struct DeviceProperties {
     /// this when its DSP has a fixed output width (a mono-in/stereo-out
     /// widener, a stereo-only dynamics stage).
     int outputChannelCount = 0;
+    /// Input channels the device reads, sidechain key included. Zero means the
+    /// host decides. What the model wires from: a device asking for more inputs
+    /// than it outputs is asking for a key.
+    int inputChannelCount = 0;
 };
 
 struct DevicePrepareContext {
@@ -86,6 +90,17 @@ class DeviceMidiBuffer {
 
 struct DeviceProcessContext {
     juce::AudioBuffer<float>* audio = nullptr;
+    /**
+     * First channel of @ref audio carrying the device's sidechain key, or -1
+     * when the host routed nothing to it.
+     *
+     * The key arrives as further channels of the same buffer, after the ones
+     * the device reads and writes as its own signal, which is how MAGDA's
+     * compiled dynamics DSPs are written and what both hosts can supply
+     * without a copy. A device with no sidechain never sees anything above its
+     * own width.
+     */
+    int sidechainInputChannel = -1;
     DeviceMidiBuffer* midi = nullptr;
     const DeviceTempoMap* tempoMap = nullptr;
     int startSample = 0;

--- a/magda/daw/audio/plugins/compiled/MagdaBitcrusherCompiledPlugin.cpp
+++ b/magda/daw/audio/plugins/compiled/MagdaBitcrusherCompiledPlugin.cpp
@@ -1,336 +1,65 @@
 #include "plugins/compiled/MagdaBitcrusherCompiledPlugin.hpp"
 
-#include <algorithm>
-#include <cmath>
-#include <map>
-
-#include "core/ParameterUtils.hpp"
+#include "core/ParameterInfo.hpp"
 #include "faust/dsp/dsp.h"
 #include "faust/gui/UI.h"
 #include "faust/gui/meta.h"
 #include "magda_bitcrusher.generated.cpp"
-#include "plugins/FaustMetadataParser.hpp"
-#include "plugins/FaustParamInfo.hpp"
 #include "plugins/compiled/CompiledPluginRegistry.hpp"
-#include "plugins/tracktion/TracktionDeviceAdapters.hpp"
 
 namespace magda::daw::audio::compiled {
 
 const char* MagdaBitcrusherCompiledPlugin::xmlTypeName = "magda_bitcrusher";
 
-namespace {
-
-struct CrusherHarvest {
-    struct Control {
-        int idx = -1;
-        FaustParamSlot::Kind kind = FaustParamSlot::Kind::Continuous;
-        FAUSTFLOAT* zone = nullptr;
-    };
-    std::vector<Control> controls;
-};
-
-class CrusherHarvester : public ::UI {
-  public:
-    CrusherHarvest harvest;
-
-    void openTabBox(const char*) override {}
-    void openHorizontalBox(const char*) override {}
-    void openVerticalBox(const char*) override {}
-    void closeBox() override {}
-
-    void addButton(const char* label, FAUSTFLOAT* zone) override {
-        emitControl(FaustParamSlot::Kind::Boolean, label, zone);
-    }
-    void addCheckButton(const char* label, FAUSTFLOAT* zone) override {
-        emitControl(FaustParamSlot::Kind::Boolean, label, zone);
-    }
-    void addVerticalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT, FAUSTFLOAT, FAUSTFLOAT,
-                           FAUSTFLOAT) override {
-        emitControl(FaustParamSlot::Kind::Continuous, label, zone);
-    }
-    void addHorizontalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT, FAUSTFLOAT,
-                             FAUSTFLOAT, FAUSTFLOAT) override {
-        emitControl(FaustParamSlot::Kind::Continuous, label, zone);
-    }
-    void addNumEntry(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT, FAUSTFLOAT, FAUSTFLOAT,
-                     FAUSTFLOAT) override {
-        emitControl(FaustParamSlot::Kind::Continuous, label, zone);
-    }
-    void addHorizontalBargraph(const char*, FAUSTFLOAT*, FAUSTFLOAT, FAUSTFLOAT) override {}
-    void addVerticalBargraph(const char*, FAUSTFLOAT*, FAUSTFLOAT, FAUSTFLOAT) override {}
-    void addSoundfile(const char*, const char*, Soundfile**) override {}
-
-    void declare(FAUSTFLOAT* zone, const char* key, const char* value) override {
-        if (zone == nullptr)
-            return;
-        const auto k = juce::String::fromUTF8(key != nullptr ? key : "").toLowerCase();
-        const auto v = juce::String::fromUTF8(value != nullptr ? value : "");
-        applyFaustAnnotation(k, v, pendingByZone_[zone]);
-    }
-
-  private:
-    void emitControl(FaustParamSlot::Kind kind, const char* rawLabel, FAUSTFLOAT* zone) {
-        const auto parsed =
-            parseFaustLabel(juce::String::fromUTF8(rawLabel != nullptr ? rawLabel : ""));
-        ControlMetadata merged = parsed.metadata;
-        if (zone != nullptr) {
-            if (auto it = pendingByZone_.find(zone); it != pendingByZone_.end()) {
-                mergeFaustMetadata(merged, it->second);
-                pendingByZone_.erase(it);
-            }
-        }
-
-        CrusherHarvest::Control c;
-        c.idx = merged.slotIndex;
-        c.kind = merged.isChoiceStyle() ? FaustParamSlot::Kind::Discrete : kind;
-        c.zone = zone;
-        harvest.controls.push_back(std::move(c));
-    }
-
-    std::map<FAUSTFLOAT*, ControlMetadata> pendingByZone_;
-};
-
-const CrusherHarvest::Control* findByIdx(const CrusherHarvest& h, int idx) {
-    for (const auto& c : h.controls)
-        if (c.idx == idx)
-            return &c;
-    return nullptr;
+MagdaBitcrusherCompiledPlugin::MagdaBitcrusherCompiledPlugin() {
+    initEffect();
 }
 
-magda::ParameterInfo parameterInfoForSlot(const CompiledHostSlotInfo& s) {
-    magda::ParameterInfo info;
-    info.minValue = s.minValue;
-    info.maxValue = s.maxValue;
-    info.defaultValue = s.defaultValue;
-    info.unit = s.unit;
-    info.scale = s.scale;
-    if (std::isfinite(s.scaleAnchor))
-        info.scaleAnchor = s.scaleAnchor;
-    info.choices = s.choices;
-    return info;
+::dsp* MagdaBitcrusherCompiledPlugin::createEngineDsp(int) const {
+    return new MagdaBitcrusherDsp();
 }
 
-}  // namespace
+std::vector<MagdaBitcrusherCompiledPlugin::HostSlotInfo> MagdaBitcrusherCompiledPlugin::slotInfos()
+    const {
+    std::vector<HostSlotInfo> infos(kHostSlotCount);
+    infos[kRateSlot] = {.name = "Rate",
+                        .unit = magda::technicalText(magda::TechnicalTextToken::Hertz),
+                        .scale = magda::ParameterScale::Logarithmic,
+                        .minValue = 100.0f,
+                        .maxValue = 48000.0f,
+                        .defaultValue = 8000.0f,
+                        .scaleAnchor = 4000.0f};
+    infos[kBitsSlot] = {.name = "Bits",
+                        .scale = magda::ParameterScale::Linear,
+                        .minValue = 1.0f,
+                        .maxValue = 16.0f,
+                        .defaultValue = 8.0f};
+    infos[kDriveSlot] = {.name = "Drive",
+                         .unit = magda::technicalText(magda::TechnicalTextToken::Decibels),
+                         .scale = magda::ParameterScale::Linear,
+                         .minValue = 0.0f,
+                         .maxValue = 24.0f,
+                         .defaultValue = 0.0f};
+    infos[kToneSlot] = {.name = "Tone",
+                        .unit = magda::technicalText(magda::TechnicalTextToken::Hertz),
+                        .scale = magda::ParameterScale::Logarithmic,
+                        .minValue = 200.0f,
+                        .maxValue = 20000.0f,
+                        .defaultValue = 20000.0f,
+                        .scaleAnchor = 2000.0f};
+    infos[kMixSlot] = {.name = "Mix",
+                       .scale = magda::ParameterScale::Linear,
+                       .minValue = 0.0f,
+                       .maxValue = 1.0f,
+                       .defaultValue = 1.0f};
+    infos[kOutputSlot] = {.name = "Output",
+                          .unit = magda::technicalText(magda::TechnicalTextToken::Decibels),
+                          .scale = magda::ParameterScale::Linear,
+                          .minValue = -24.0f,
+                          .maxValue = 12.0f,
+                          .defaultValue = 0.0f};
 
-MagdaBitcrusherCompiledPlugin::MagdaBitcrusherCompiledPlugin(const te::PluginCreationInfo& info)
-    : te::Plugin(info) {
-    dsp_ = std::make_unique<MagdaBitcrusherDsp>();
-    constexpr int kProvisionalSampleRate = 44100;
-    rebuildEngineState(kProvisionalSampleRate);
-    buildHostParameters();
-}
-
-MagdaBitcrusherCompiledPlugin::~MagdaBitcrusherCompiledPlugin() {
-    notifyListenersOfDeletion();
-    for (auto& p : hostParams_)
-        if (p)
-            p->detachFromCurrentValue();
-}
-
-juce::String MagdaBitcrusherCompiledPlugin::getName() const {
-    return "Bitcrusher";
-}
-juce::String MagdaBitcrusherCompiledPlugin::getPluginType() {
-    return xmlTypeName;
-}
-juce::String MagdaBitcrusherCompiledPlugin::getShortName(int) {
-    return "Crush";
-}
-juce::String MagdaBitcrusherCompiledPlugin::getSelectableDescription() {
-    return "Bitcrusher";
-}
-
-void MagdaBitcrusherCompiledPlugin::rebuildEngineState(int sampleRate) {
-    if (!dsp_)
-        return;
-    dsp_->init(sampleRate);
-    numInputs_ = dsp_->getNumInputs();
-    numOutputs_ = dsp_->getNumOutputs();
-
-    CrusherHarvester harvester;
-    dsp_->buildUserInterface(&harvester);
-
-    zones_.fill(nullptr);
-    for (int i = 0; i < kHostSlotCount; ++i) {
-        if (auto* c = findByIdx(harvester.harvest, i))
-            zones_[static_cast<size_t>(i)] = c->zone;
-    }
-}
-
-void MagdaBitcrusherCompiledPlugin::buildHostParameters() {
-    hostSlotInfo_[kRateSlot] = {.name = "Rate",
-                                .unit = magda::technicalText(magda::TechnicalTextToken::Hertz),
-                                .scale = magda::ParameterScale::Logarithmic,
-                                .minValue = 100.0f,
-                                .maxValue = 48000.0f,
-                                .defaultValue = 8000.0f,
-                                .scaleAnchor = 4000.0f};
-    hostSlotInfo_[kBitsSlot] = {.name = "Bits",
-                                .scale = magda::ParameterScale::Linear,
-                                .minValue = 1.0f,
-                                .maxValue = 16.0f,
-                                .defaultValue = 8.0f};
-    hostSlotInfo_[kDriveSlot] = {.name = "Drive",
-                                 .unit = magda::technicalText(magda::TechnicalTextToken::Decibels),
-                                 .scale = magda::ParameterScale::Linear,
-                                 .minValue = 0.0f,
-                                 .maxValue = 24.0f,
-                                 .defaultValue = 0.0f};
-    hostSlotInfo_[kToneSlot] = {.name = "Tone",
-                                .unit = magda::technicalText(magda::TechnicalTextToken::Hertz),
-                                .scale = magda::ParameterScale::Logarithmic,
-                                .minValue = 200.0f,
-                                .maxValue = 20000.0f,
-                                .defaultValue = 20000.0f,
-                                .scaleAnchor = 2000.0f};
-    hostSlotInfo_[kMixSlot] = {.name = "Mix",
-                               .scale = magda::ParameterScale::Linear,
-                               .minValue = 0.0f,
-                               .maxValue = 1.0f,
-                               .defaultValue = 1.0f};
-    hostSlotInfo_[kOutputSlot] = {.name = "Output",
-                                  .unit = magda::technicalText(magda::TechnicalTextToken::Decibels),
-                                  .scale = magda::ParameterScale::Linear,
-                                  .minValue = -24.0f,
-                                  .maxValue = 12.0f,
-                                  .defaultValue = 0.0f};
-
-    juce::NormalisableRange<float> normalisedRange{0.0f, 1.0f};
-    auto* undoManager = getUndoManager();
-
-    for (int i = 0; i < kHostSlotCount; ++i) {
-        const auto& slot = hostSlotInfo_[i];
-        const juce::String id = "magda_bitcrusher_" + slot.name.toLowerCase().replace(" ", "_");
-        const juce::Identifier identifier(id);
-        const auto info = parameterInfoForSlot(slot);
-        const float defaultNormalized =
-            magda::ParameterUtils::realToNormalized(slot.defaultValue, info);
-        hostCached_[i].referTo(state, identifier, undoManager, defaultNormalized);
-
-        auto param = addParam(
-            id, slot.name, normalisedRange,
-            [info](float normalized) {
-                const float real = magda::ParameterUtils::normalizedToReal(normalized, info);
-                return magda::ParameterUtils::formatValue(real, info);
-            },
-            [info](const juce::String& text) {
-                auto parsed = magda::ParameterUtils::parseValue(text, info);
-                if (parsed)
-                    return magda::ParameterUtils::realToNormalized(*parsed, info);
-                return 0.0f;
-            });
-        param->attachToCurrentValue(hostCached_[i]);
-        hostParams_[i] = param;
-    }
-}
-
-void MagdaBitcrusherCompiledPlugin::initialise(const te::PluginInitialisationInfo& info) {
-    rebuildEngineState(static_cast<int>(info.sampleRate));
-    scratchIn_.setSize(numInputs_, info.blockSizeSamples, false, true, true);
-    scratchOut_.setSize(numOutputs_, info.blockSizeSamples, false, true, true);
-    inPtrs_.assign(static_cast<size_t>(numInputs_), nullptr);
-    outPtrs_.assign(static_cast<size_t>(numOutputs_), nullptr);
-}
-
-void MagdaBitcrusherCompiledPlugin::deinitialise() {
-    scratchIn_.setSize(0, 0);
-    scratchOut_.setSize(0, 0);
-    inPtrs_.clear();
-    outPtrs_.clear();
-}
-
-void MagdaBitcrusherCompiledPlugin::reset() {
-    if (dsp_)
-        dsp_->instanceClear();
-}
-
-void MagdaBitcrusherCompiledPlugin::applyToBuffer(const te::PluginRenderContext& fc) {
-    if (!fc.destBuffer || fc.bufferNumSamples <= 0 || !dsp_)
-        return;
-
-    auto writeSlot = [&](int slot) {
-        if (auto* zone = zones_[static_cast<size_t>(slot)]) {
-            const auto info = parameterInfoForSlot(hostSlotInfo_[static_cast<size_t>(slot)]);
-            const float norm = hostParams_[static_cast<size_t>(slot)]->getCurrentValue();
-            *zone = static_cast<FAUSTFLOAT>(magda::ParameterUtils::normalizedToReal(norm, info));
-        }
-    };
-    for (int i = 0; i < kHostSlotCount; ++i)
-        writeSlot(i);
-
-    const int numSamples = fc.bufferNumSamples;
-    const int startSample = fc.bufferStartSample;
-    const int hostChannels = fc.destBuffer->getNumChannels();
-    if (hostChannels <= 0 || numInputs_ <= 0 || numOutputs_ <= 0)
-        return;
-
-    if (scratchIn_.getNumChannels() < numInputs_ || scratchIn_.getNumSamples() < numSamples)
-        scratchIn_.setSize(numInputs_, numSamples, false, true, true);
-    if (scratchOut_.getNumChannels() < numOutputs_ || scratchOut_.getNumSamples() < numSamples)
-        scratchOut_.setSize(numOutputs_, numSamples, false, true, true);
-    if (static_cast<int>(inPtrs_.size()) < numInputs_)
-        inPtrs_.resize(static_cast<size_t>(numInputs_), nullptr);
-    if (static_cast<int>(outPtrs_.size()) < numOutputs_)
-        outPtrs_.resize(static_cast<size_t>(numOutputs_), nullptr);
-
-    for (int ch = 0; ch < numInputs_; ++ch) {
-        float* dst = scratchIn_.getWritePointer(ch);
-        if (ch < hostChannels) {
-            const float* src = fc.destBuffer->getReadPointer(ch, startSample);
-            std::copy(src, src + numSamples, dst);
-        } else {
-            std::fill(dst, dst + numSamples, 0.0f);
-        }
-        inPtrs_[static_cast<size_t>(ch)] = dst;
-    }
-    for (int ch = 0; ch < numOutputs_; ++ch) {
-        outPtrs_[static_cast<size_t>(ch)] = (ch < hostChannels)
-                                                ? fc.destBuffer->getWritePointer(ch, startSample)
-                                                : scratchOut_.getWritePointer(ch);
-    }
-
-    dsp_->compute(numSamples, inPtrs_.data(), outPtrs_.data());
-
-    const int channelsToSanitise = std::min(hostChannels, numOutputs_);
-    for (int ch = 0; ch < channelsToSanitise; ++ch) {
-        float* out = fc.destBuffer->getWritePointer(ch, startSample);
-        for (int i = 0; i < numSamples; ++i) {
-            const float sample = out[i];
-            out[i] = std::isfinite(sample) ? juce::jlimit(-16.0f, 16.0f, sample) : 0.0f;
-        }
-    }
-    for (int ch = numOutputs_; ch < hostChannels; ++ch)
-        fc.destBuffer->clear(ch, startSample, numSamples);
-}
-
-te::AutomatableParameter* MagdaBitcrusherCompiledPlugin::getSlotParameter(int slotIndex) const {
-    if (slotIndex < 0 || slotIndex >= kHostSlotCount)
-        return nullptr;
-    return hostParams_[static_cast<size_t>(slotIndex)].get();
-}
-
-const MagdaBitcrusherCompiledPlugin::HostSlotInfo& MagdaBitcrusherCompiledPlugin::getSlotInfo(
-    int slotIndex) const {
-    static const HostSlotInfo kEmpty;
-    if (slotIndex < 0 || slotIndex >= kHostSlotCount)
-        return kEmpty;
-    return hostSlotInfo_[static_cast<size_t>(slotIndex)];
-}
-
-float MagdaBitcrusherCompiledPlugin::displayValueToNativeValue(int slotIndex,
-                                                               float displayValue) const {
-    if (slotIndex < 0 || slotIndex >= kHostSlotCount)
-        return displayValue;
-    const auto info = parameterInfoForSlot(hostSlotInfo_[static_cast<size_t>(slotIndex)]);
-    return magda::ParameterUtils::realToNormalized(displayValue, info);
-}
-
-float MagdaBitcrusherCompiledPlugin::nativeValueToDisplayValue(int slotIndex,
-                                                               float nativeValue) const {
-    if (slotIndex < 0 || slotIndex >= kHostSlotCount)
-        return nativeValue;
-    const auto info = parameterInfoForSlot(hostSlotInfo_[static_cast<size_t>(slotIndex)]);
-    return magda::ParameterUtils::normalizedToReal(nativeValue, info);
+    return infos;
 }
 
 constexpr AliasSpec kAliases[] = {
@@ -350,9 +79,8 @@ const CompiledPluginSpec& getMagdaBitcrusherSpec() {
             "Drive shifts the quantization landing point for crunchier or softer attacks. "
             "Tone tames aliasing with a post-crush low-pass. "
             "Mix and Output blend and trim.",
-        .createPlugin = [](const DevicePluginCreationContext& context) -> DevicePluginPtr {
-            return tracktion_adapter::pluginHandle(
-                new MagdaBitcrusherCompiledPlugin(tracktion_adapter::creationInfo(context)));
+        .createDevice = [](const DevicePluginCreationContext&) -> std::unique_ptr<MagdaDevice> {
+            return std::make_unique<MagdaBitcrusherCompiledPlugin>();
         },
         .aliases = kAliases,
         .aliasCount = static_cast<int>(sizeof(kAliases) / sizeof(kAliases[0])),

--- a/magda/daw/audio/plugins/compiled/MagdaBitcrusherCompiledPlugin.hpp
+++ b/magda/daw/audio/plugins/compiled/MagdaBitcrusherCompiledPlugin.hpp
@@ -1,14 +1,8 @@
 #pragma once
 
-#include <tracktion_engine/tracktion_engine.h>
-
-#include <array>
-#include <memory>
 #include <vector>
 
-#include "../FaustParamPool.hpp"
-#include "core/ParameterInfo.hpp"
-#include "plugins/compiled/tracktion/CompiledFaustTracktionAdapter.hpp"
+#include "plugins/compiled/MagdaCompiledEffect.hpp"
 
 class dsp;
 
@@ -21,41 +15,11 @@ namespace magda::daw::audio::compiled {
  * post-crush tone (1-pole low-pass). Single-engine compiled plugin,
  * same single-engine harvest pattern as Grit / Saturator / Delay.
  */
-class MagdaBitcrusherCompiledPlugin : public te::Plugin, public ICompiledFaustPlugin {
+class MagdaBitcrusherCompiledPlugin : public MagdaCompiledEffect {
   public:
     static const char* xmlTypeName;
 
-    explicit MagdaBitcrusherCompiledPlugin(const te::PluginCreationInfo& info);
-    ~MagdaBitcrusherCompiledPlugin() override;
-
-    juce::String getName() const override;
-    juce::String getPluginType() override;
-    juce::String getShortName(int) override;
-    juce::String getSelectableDescription() override;
-
-    void initialise(const te::PluginInitialisationInfo& info) override;
-    void deinitialise() override;
-    void reset() override;
-    void applyToBuffer(const te::PluginRenderContext& fc) override;
-
-    bool takesMidiInput() override {
-        return false;
-    }
-    bool takesAudioInput() override {
-        return true;
-    }
-    bool isSynth() override {
-        return false;
-    }
-    int getNumOutputChannelsGivenInputs(int) override {
-        return 2;
-    }
-    bool producesAudioWhenNoAudioInput() override {
-        return false;
-    }
-    double getTailLength() const override {
-        return 0.0;
-    }
+    MagdaBitcrusherCompiledPlugin();
 
     static constexpr int kRateSlot = 0;
     static constexpr int kBitsSlot = 1;
@@ -65,49 +29,27 @@ class MagdaBitcrusherCompiledPlugin : public te::Plugin, public ICompiledFaustPl
     static constexpr int kOutputSlot = 5;
     static constexpr int kHostSlotCount = 6;
 
-    te::AutomatableParameter* getSlotParameter(int slotIndex) const;
+    juce::String devicePluginId() const override {
+        return xmlTypeName;
+    }
+    juce::String deviceName() const override {
+        return "Bitcrusher";
+    }
+    juce::String deviceShortName() const override {
+        return "Crush";
+    }
 
-    float displayValueToNativeValue(int slotIndex, float displayValue) const;
-    float nativeValueToDisplayValue(int slotIndex, float nativeValue) const;
-
-    using HostSlotInfo = CompiledHostSlotInfo;
-    const HostSlotInfo& getSlotInfo(int slotIndex) const;
-
-    int hostSlotCount() const override {
-        return kHostSlotCount;
+  protected:
+    ::dsp* createEngineDsp(int engineIndex) const override;
+    std::vector<HostSlotInfo> slotInfos() const override;
+    const char* slotIdPrefix() const override {
+        return "magda_bitcrusher_";
     }
-    const CompiledHostSlotInfo& hostSlotInfo(int slotIndex) const override {
-        return getSlotInfo(slotIndex);
-    }
-    DeviceParameterHandle hostSlotParameter(int slotIndex) const override {
-        return tracktion_adapter::parameterHandle(getSlotParameter(slotIndex));
-    }
-    float displayToNormalized(int slotIndex, float displayValue) const override {
-        return displayValueToNativeValue(slotIndex, displayValue);
-    }
-    float normalizedToDisplay(int slotIndex, float normalizedValue) const override {
-        return nativeValueToDisplayValue(slotIndex, normalizedValue);
+    int outputChannelCount() const override {
+        return 2;
     }
 
   private:
-    void buildHostParameters();
-    void rebuildEngineState(int sampleRate);
-
-    std::unique_ptr<::dsp> dsp_;
-    int numInputs_ = 0;
-    int numOutputs_ = 0;
-
-    std::array<FAUSTFLOAT*, kHostSlotCount> zones_{};
-
-    std::array<HostSlotInfo, kHostSlotCount> hostSlotInfo_;
-    std::array<te::AutomatableParameter::Ptr, kHostSlotCount> hostParams_;
-    std::array<juce::CachedValue<float>, kHostSlotCount> hostCached_;
-
-    juce::AudioBuffer<float> scratchIn_;
-    juce::AudioBuffer<float> scratchOut_;
-    std::vector<float*> inPtrs_;
-    std::vector<float*> outPtrs_;
-
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(MagdaBitcrusherCompiledPlugin)
 };
 

--- a/magda/daw/audio/plugins/compiled/MagdaChorusCompiledPlugin.cpp
+++ b/magda/daw/audio/plugins/compiled/MagdaChorusCompiledPlugin.cpp
@@ -1,462 +1,96 @@
 #include "plugins/compiled/MagdaChorusCompiledPlugin.hpp"
 
-#include <algorithm>
-#include <cmath>
-#include <limits>
-#include <map>
-
-#include "core/ParameterUtils.hpp"
+#include "core/ParameterInfo.hpp"
 #include "faust/dsp/dsp.h"
 #include "faust/gui/UI.h"
 #include "faust/gui/meta.h"
 #include "magda_chorus.generated.cpp"
-#include "plugins/FaustMetadataParser.hpp"
-#include "plugins/FaustParamInfo.hpp"
 #include "plugins/compiled/CompiledPluginRegistry.hpp"
-#include "plugins/tracktion/TracktionDeviceAdapters.hpp"
 
 namespace magda::daw::audio::compiled {
 
 const char* MagdaChorusCompiledPlugin::xmlTypeName = "magda_chorus";
 
-namespace {
-
-struct ChorusHarvest {
-    struct Control {
-        int idx = -1;
-        FaustParamSlot::Kind kind = FaustParamSlot::Kind::Continuous;
-        FAUSTFLOAT* zone = nullptr;
-        std::vector<std::pair<float, juce::String>> choices;
-        int gateSlotIndex = -1;
-        bool gateNegated = false;
-    };
-    std::vector<Control> controls;
-};
-
-class ChorusHarvester : public ::UI {
-  public:
-    ChorusHarvest harvest;
-
-    void openTabBox(const char*) override {}
-    void openHorizontalBox(const char*) override {}
-    void openVerticalBox(const char*) override {}
-    void closeBox() override {}
-
-    void addButton(const char* label, FAUSTFLOAT* zone) override {
-        emitControl(FaustParamSlot::Kind::Boolean, label, zone);
-    }
-    void addCheckButton(const char* label, FAUSTFLOAT* zone) override {
-        emitControl(FaustParamSlot::Kind::Boolean, label, zone);
-    }
-    void addVerticalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT, FAUSTFLOAT, FAUSTFLOAT,
-                           FAUSTFLOAT) override {
-        emitControl(FaustParamSlot::Kind::Continuous, label, zone);
-    }
-    void addHorizontalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT, FAUSTFLOAT,
-                             FAUSTFLOAT, FAUSTFLOAT) override {
-        emitControl(FaustParamSlot::Kind::Continuous, label, zone);
-    }
-    void addNumEntry(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT, FAUSTFLOAT, FAUSTFLOAT,
-                     FAUSTFLOAT) override {
-        emitControl(FaustParamSlot::Kind::Continuous, label, zone);
-    }
-    void addHorizontalBargraph(const char*, FAUSTFLOAT*, FAUSTFLOAT, FAUSTFLOAT) override {}
-    void addVerticalBargraph(const char*, FAUSTFLOAT*, FAUSTFLOAT, FAUSTFLOAT) override {}
-    void addSoundfile(const char*, const char*, Soundfile**) override {}
-
-    void declare(FAUSTFLOAT* zone, const char* key, const char* value) override {
-        if (zone == nullptr)
-            return;
-        const auto k = juce::String::fromUTF8(key != nullptr ? key : "").toLowerCase();
-        const auto v = juce::String::fromUTF8(value != nullptr ? value : "");
-        applyFaustAnnotation(k, v, pendingByZone_[zone]);
-    }
-
-  private:
-    void emitControl(FaustParamSlot::Kind kind, const char* rawLabel, FAUSTFLOAT* zone) {
-        const auto parsed =
-            parseFaustLabel(juce::String::fromUTF8(rawLabel != nullptr ? rawLabel : ""));
-        ControlMetadata merged = parsed.metadata;
-        if (zone != nullptr) {
-            if (auto it = pendingByZone_.find(zone); it != pendingByZone_.end()) {
-                mergeFaustMetadata(merged, it->second);
-                pendingByZone_.erase(it);
-            }
-        }
-
-        ChorusHarvest::Control c;
-        c.idx = merged.slotIndex;
-        c.kind = merged.isChoiceStyle() ? FaustParamSlot::Kind::Discrete : kind;
-        c.zone = zone;
-        c.choices = merged.menuChoices;
-        c.gateSlotIndex = merged.gateSlotIndex;
-        c.gateNegated = merged.gateNegated;
-        harvest.controls.push_back(std::move(c));
-    }
-
-    std::map<FAUSTFLOAT*, ControlMetadata> pendingByZone_;
-};
-
-const ChorusHarvest::Control* findByIdx(const ChorusHarvest& h, int idx) {
-    for (const auto& c : h.controls)
-        if (c.idx == idx)
-            return &c;
-    return nullptr;
+MagdaChorusCompiledPlugin::MagdaChorusCompiledPlugin() {
+    initEffect();
 }
 
-}  // namespace
-
-MagdaChorusCompiledPlugin::MagdaChorusCompiledPlugin(const te::PluginCreationInfo& info)
-    : te::Plugin(info) {
-    dsp_ = std::make_unique<MagdaChorusDsp>();
-    constexpr int kProvisionalSampleRate = 44100;
-    rebuildEngineState(kProvisionalSampleRate);
-    buildHostParameters();
+::dsp* MagdaChorusCompiledPlugin::createEngineDsp(int) const {
+    return new MagdaChorusDsp();
 }
 
-MagdaChorusCompiledPlugin::~MagdaChorusCompiledPlugin() {
-    notifyListenersOfDeletion();
-    for (auto& p : hostParams_)
-        if (p)
-            p->detachFromCurrentValue();
-}
+std::vector<MagdaChorusCompiledPlugin::HostSlotInfo> MagdaChorusCompiledPlugin::slotInfos() const {
+    std::vector<HostSlotInfo> infos(kHostSlotCount);
+    // The Division choices are the dsp's own [style:menu{...}]: the labels
+    // read as musical divisions and the values are the quarter-note
+    // multipliers the zone wants, so neither list is restated here.
+    const auto divisionValues = menuValuesForIdx(kDivisionSlot);
+    infos[kVoicesSlot].name = "Voices";
+    infos[kVoicesSlot].scale = magda::ParameterScale::Discrete;
+    infos[kVoicesSlot].choices = {"1", "2", "3"};
+    infos[kVoicesSlot].minValue = 0.0f;
+    infos[kVoicesSlot].maxValue = static_cast<float>(infos[kVoicesSlot].choices.size() - 1);
+    infos[kVoicesSlot].defaultValue = 1.0f;  // 2 voices
 
-juce::String MagdaChorusCompiledPlugin::getName() const {
-    return "Chorus";
-}
-juce::String MagdaChorusCompiledPlugin::getPluginType() {
-    return xmlTypeName;
-}
-juce::String MagdaChorusCompiledPlugin::getShortName(int) {
-    return "Chorus";
-}
-juce::String MagdaChorusCompiledPlugin::getSelectableDescription() {
-    return "Chorus";
-}
+    infos[kSyncSlot] = {.name = "Sync",
+                        .scale = magda::ParameterScale::Discrete,
+                        .minValue = 0.0f,
+                        .maxValue = 1.0f,
+                        .defaultValue = 0.0f,
+                        .scaleAnchor = std::numeric_limits<float>::quiet_NaN(),
+                        .choices = {"Off", "On"}};
 
-void MagdaChorusCompiledPlugin::rebuildEngineState(int sampleRate) {
-    if (!dsp_)
-        return;
-    dsp_->init(sampleRate);
-    numInputs_ = dsp_->getNumInputs();
-    numOutputs_ = dsp_->getNumOutputs();
+    infos[kRateSlot] = {.name = "Rate",
+                        .unit = magda::technicalText(magda::TechnicalTextToken::Hertz),
+                        .scale = magda::ParameterScale::Logarithmic,
+                        .minValue = 0.05f,
+                        .maxValue = 10.0f,
+                        .defaultValue = 0.5f,
+                        .scaleAnchor = 0.5f};
 
-    ChorusHarvester harvester;
-    dsp_->buildUserInterface(&harvester);
+    infos[kDivisionSlot].name = "Division";
+    infos[kDivisionSlot].scale = magda::ParameterScale::Discrete;
+    infos[kDivisionSlot].minValue = 0.0f;
+    infos[kDivisionSlot].maxValue = 0.0f;
+    infos[kDivisionSlot].defaultValue = 0.0f;
 
-    zones_.fill(nullptr);
-    bpmZone_ = nullptr;
-    divisionChoiceValues_.clear();
-    divisionChoiceLabels_.clear();
+    infos[kDepthSlot] = {.name = "Depth",
+                         .scale = magda::ParameterScale::Linear,
+                         .minValue = 0.0f,
+                         .maxValue = 1.0f,
+                         .defaultValue = 0.5f};
 
-    for (int i = 0; i < kHostSlotCount; ++i) {
-        harvestedGates_[static_cast<size_t>(i)] = {-1, false};
-        if (auto* c = findByIdx(harvester.harvest, i)) {
-            zones_[static_cast<size_t>(i)] = c->zone;
-            harvestedGates_[static_cast<size_t>(i)] = {c->gateSlotIndex, c->gateNegated};
-        }
-    }
-    if (auto* c = findByIdx(harvester.harvest, kBpmSlot))
-        bpmZone_ = c->zone;
+    infos[kFeedbackSlot] = {.name = "Feedback",
+                            .scale = magda::ParameterScale::Linear,
+                            .minValue = -0.9f,
+                            .maxValue = 0.9f,
+                            .defaultValue = 0.0f};
 
-    if (auto* c = findByIdx(harvester.harvest, kDivisionSlot)) {
-        auto sorted = c->choices;
-        std::sort(sorted.begin(), sorted.end(),
-                  [](const auto& a, const auto& b) { return a.first < b.first; });
-        divisionChoiceValues_.reserve(sorted.size());
-        divisionChoiceLabels_.reserve(sorted.size());
-        for (const auto& choice : sorted) {
-            divisionChoiceValues_.push_back(choice.first);
-            divisionChoiceLabels_.push_back(choice.second);
-        }
-    }
-}
+    infos[kMixSlot] = {.name = "Mix",
+                       .scale = magda::ParameterScale::Linear,
+                       .minValue = 0.0f,
+                       .maxValue = 1.0f,
+                       .defaultValue = 0.5f};
 
-void MagdaChorusCompiledPlugin::buildHostParameters() {
-    hostSlotInfo_[kVoicesSlot].name = "Voices";
-    hostSlotInfo_[kVoicesSlot].scale = magda::ParameterScale::Discrete;
-    hostSlotInfo_[kVoicesSlot].choices = {"1", "2", "3"};
-    hostSlotInfo_[kVoicesSlot].minValue = 0.0f;
-    hostSlotInfo_[kVoicesSlot].maxValue =
-        static_cast<float>(hostSlotInfo_[kVoicesSlot].choices.size() - 1);
-    hostSlotInfo_[kVoicesSlot].defaultValue = 1.0f;  // 2 voices
+    infos[kWidthSlot] = {.name = "Width",
+                         .scale = magda::ParameterScale::Linear,
+                         .minValue = 0.0f,
+                         .maxValue = 1.0f,
+                         .defaultValue = 0.5f};
 
-    hostSlotInfo_[kSyncSlot] = {.name = "Sync",
-                                .scale = magda::ParameterScale::Discrete,
-                                .minValue = 0.0f,
-                                .maxValue = 1.0f,
-                                .defaultValue = 0.0f,
-                                .scaleAnchor = std::numeric_limits<float>::quiet_NaN(),
-                                .choices = {"Off", "On"}};
-
-    hostSlotInfo_[kRateSlot] = {.name = "Rate",
-                                .unit = magda::technicalText(magda::TechnicalTextToken::Hertz),
-                                .scale = magda::ParameterScale::Logarithmic,
-                                .minValue = 0.05f,
-                                .maxValue = 10.0f,
-                                .defaultValue = 0.5f,
-                                .scaleAnchor = 0.5f};
-
-    hostSlotInfo_[kDivisionSlot].name = "Division";
-    hostSlotInfo_[kDivisionSlot].scale = magda::ParameterScale::Discrete;
-    hostSlotInfo_[kDivisionSlot].minValue = 0.0f;
-    hostSlotInfo_[kDivisionSlot].maxValue = 0.0f;
-    hostSlotInfo_[kDivisionSlot].defaultValue = 0.0f;
-
-    hostSlotInfo_[kDepthSlot] = {.name = "Depth",
-                                 .scale = magda::ParameterScale::Linear,
-                                 .minValue = 0.0f,
-                                 .maxValue = 1.0f,
-                                 .defaultValue = 0.5f};
-
-    hostSlotInfo_[kFeedbackSlot] = {.name = "Feedback",
-                                    .scale = magda::ParameterScale::Linear,
-                                    .minValue = -0.9f,
-                                    .maxValue = 0.9f,
-                                    .defaultValue = 0.0f};
-
-    hostSlotInfo_[kMixSlot] = {.name = "Mix",
-                               .scale = magda::ParameterScale::Linear,
-                               .minValue = 0.0f,
-                               .maxValue = 1.0f,
-                               .defaultValue = 0.5f};
-
-    hostSlotInfo_[kWidthSlot] = {.name = "Width",
-                                 .scale = magda::ParameterScale::Linear,
-                                 .minValue = 0.0f,
-                                 .maxValue = 1.0f,
-                                 .defaultValue = 0.5f};
-
-    if (!divisionChoiceValues_.empty()) {
-        const int n = static_cast<int>(divisionChoiceValues_.size());
-        hostSlotInfo_[kDivisionSlot].choices = divisionChoiceLabels_;
-        hostSlotInfo_[kDivisionSlot].maxValue = static_cast<float>(n - 1);
+    if (!divisionValues.empty()) {
+        const int n = static_cast<int>(divisionValues.size());
+        infos[kDivisionSlot].choices = menuLabelsForIdx(kDivisionSlot);
+        infos[kDivisionSlot].maxValue = static_cast<float>(n - 1);
         for (int i = 0; i < n; ++i) {
-            if (std::abs(divisionChoiceValues_[static_cast<size_t>(i)] - 1.0f) < 1e-3f) {
-                hostSlotInfo_[kDivisionSlot].defaultValue = static_cast<float>(i);
+            if (std::abs(divisionValues[static_cast<size_t>(i)] - 1.0f) < 1e-3f) {
+                infos[kDivisionSlot].defaultValue = static_cast<float>(i);
                 break;
             }
         }
     }
 
-    juce::NormalisableRange<float> normalisedRange{0.0f, 1.0f};
-    auto* undoManager = getUndoManager();
-
-    auto buildInfo = [](const HostSlotInfo& s) {
-        magda::ParameterInfo info;
-        info.minValue = s.minValue;
-        info.maxValue = s.maxValue;
-        info.defaultValue = s.defaultValue;
-        info.unit = s.unit;
-        info.scale = s.scale;
-        if (std::isfinite(s.scaleAnchor))
-            info.scaleAnchor = s.scaleAnchor;
-        info.choices = s.choices;
-        return info;
-    };
-
-    for (int i = 0; i < kHostSlotCount; ++i) {
-        const auto& slot = hostSlotInfo_[i];
-        const juce::String id = "magda_chorus_" + slot.name.toLowerCase().replace(" ", "_");
-        const juce::Identifier identifier(id);
-        const auto info = buildInfo(slot);
-        const float defaultNormalized =
-            magda::ParameterUtils::realToNormalized(slot.defaultValue, info);
-        hostCached_[i].referTo(state, identifier, undoManager, defaultNormalized);
-
-        auto param = addParam(
-            id, slot.name, normalisedRange,
-            [info](float normalized) {
-                const float real = magda::ParameterUtils::normalizedToReal(normalized, info);
-                return magda::ParameterUtils::formatValue(real, info);
-            },
-            [info](const juce::String& text) {
-                auto parsed = magda::ParameterUtils::parseValue(text, info);
-                if (parsed)
-                    return magda::ParameterUtils::realToNormalized(*parsed, info);
-                return 0.0f;
-            });
-        param->attachToCurrentValue(hostCached_[i]);
-        hostParams_[i] = param;
-    }
-
-    for (int i = 0; i < kHostSlotCount; ++i) {
-        hostSlotInfo_[static_cast<size_t>(i)].gateSlotIndex =
-            harvestedGates_[static_cast<size_t>(i)].slotIndex;
-        hostSlotInfo_[static_cast<size_t>(i)].gateNegated =
-            harvestedGates_[static_cast<size_t>(i)].negated;
-    }
-}
-
-void MagdaChorusCompiledPlugin::initialise(const te::PluginInitialisationInfo& info) {
-    rebuildEngineState(static_cast<int>(info.sampleRate));
-    scratchIn_.setSize(numInputs_, info.blockSizeSamples, false, true, true);
-    scratchOut_.setSize(numOutputs_, info.blockSizeSamples, false, true, true);
-    inPtrs_.assign(static_cast<size_t>(numInputs_), nullptr);
-    outPtrs_.assign(static_cast<size_t>(numOutputs_), nullptr);
-}
-
-void MagdaChorusCompiledPlugin::deinitialise() {
-    scratchIn_.setSize(0, 0);
-    scratchOut_.setSize(0, 0);
-    inPtrs_.clear();
-    outPtrs_.clear();
-}
-
-void MagdaChorusCompiledPlugin::reset() {
-    if (dsp_)
-        dsp_->instanceClear();
-}
-
-void MagdaChorusCompiledPlugin::applyToBuffer(const te::PluginRenderContext& fc) {
-    if (!fc.destBuffer || fc.bufferNumSamples <= 0 || !dsp_)
-        return;
-
-    if (fc.isPlaying && !wasPlaying_)
-        dsp_->instanceClear();
-    wasPlaying_ = fc.isPlaying;
-
-    auto writeContinuous = [&](int slot) {
-        if (auto* zone = zones_[static_cast<size_t>(slot)]) {
-            const auto& s = hostSlotInfo_[static_cast<size_t>(slot)];
-            magda::ParameterInfo info;
-            info.minValue = s.minValue;
-            info.maxValue = s.maxValue;
-            info.scale = s.scale;
-            if (std::isfinite(s.scaleAnchor))
-                info.scaleAnchor = s.scaleAnchor;
-            const float norm = hostParams_[static_cast<size_t>(slot)]->getCurrentValue();
-            *zone = static_cast<FAUSTFLOAT>(magda::ParameterUtils::normalizedToReal(norm, info));
-        }
-    };
-    writeContinuous(kRateSlot);
-    writeContinuous(kDepthSlot);
-    writeContinuous(kFeedbackSlot);
-    writeContinuous(kMixSlot);
-    writeContinuous(kWidthSlot);
-
-    auto writeMenuIndex = [&](int slot) {
-        if (auto* z = zones_[static_cast<size_t>(slot)]) {
-            const auto& s = hostSlotInfo_[static_cast<size_t>(slot)];
-            const float norm = hostParams_[static_cast<size_t>(slot)]->getCurrentValue();
-            const int count = static_cast<int>(s.choices.size());
-            const int idx =
-                count > 1 ? juce::jlimit(
-                                0, count - 1,
-                                static_cast<int>(std::round(norm * static_cast<float>(count - 1))))
-                          : 0;
-            *z = static_cast<FAUSTFLOAT>(idx);
-        }
-    };
-    writeMenuIndex(kVoicesSlot);
-
-    if (auto* z = zones_[kSyncSlot])
-        *z = hostParams_[kSyncSlot]->getCurrentValue() >= 0.5f ? FAUSTFLOAT(1) : FAUSTFLOAT(0);
-
-    if (auto* z = zones_[kDivisionSlot]; z && !divisionChoiceValues_.empty()) {
-        const float norm = hostParams_[kDivisionSlot]->getCurrentValue();
-        const int count = static_cast<int>(divisionChoiceValues_.size());
-        const int idx = juce::jlimit(
-            0, count - 1, static_cast<int>(std::round(norm * static_cast<float>(count - 1))));
-        *z = static_cast<FAUSTFLOAT>(divisionChoiceValues_[static_cast<size_t>(idx)]);
-    }
-
-    const double bpm = edit.tempoSequence.getBpmAt(fc.editTime.getStart());
-    currentBpm_.store(static_cast<float>(bpm), std::memory_order_relaxed);
-    if (bpmZone_)
-        *bpmZone_ = static_cast<FAUSTFLOAT>(bpm);
-
-    const int numSamples = fc.bufferNumSamples;
-    const int startSample = fc.bufferStartSample;
-    const int hostChannels = fc.destBuffer->getNumChannels();
-    if (hostChannels <= 0 || numInputs_ <= 0 || numOutputs_ <= 0)
-        return;
-
-    if (scratchIn_.getNumChannels() < numInputs_ || scratchIn_.getNumSamples() < numSamples)
-        scratchIn_.setSize(numInputs_, numSamples, false, true, true);
-    if (scratchOut_.getNumChannels() < numOutputs_ || scratchOut_.getNumSamples() < numSamples)
-        scratchOut_.setSize(numOutputs_, numSamples, false, true, true);
-    if (static_cast<int>(inPtrs_.size()) < numInputs_)
-        inPtrs_.resize(static_cast<size_t>(numInputs_), nullptr);
-    if (static_cast<int>(outPtrs_.size()) < numOutputs_)
-        outPtrs_.resize(static_cast<size_t>(numOutputs_), nullptr);
-
-    for (int ch = 0; ch < numInputs_; ++ch) {
-        float* dst = scratchIn_.getWritePointer(ch);
-        if (ch < hostChannels) {
-            const float* src = fc.destBuffer->getReadPointer(ch, startSample);
-            std::copy(src, src + numSamples, dst);
-        } else {
-            std::fill(dst, dst + numSamples, 0.0f);
-        }
-        inPtrs_[static_cast<size_t>(ch)] = dst;
-    }
-    for (int ch = 0; ch < numOutputs_; ++ch) {
-        outPtrs_[static_cast<size_t>(ch)] = (ch < hostChannels)
-                                                ? fc.destBuffer->getWritePointer(ch, startSample)
-                                                : scratchOut_.getWritePointer(ch);
-    }
-
-    dsp_->compute(numSamples, inPtrs_.data(), outPtrs_.data());
-
-    const int channelsToSanitise = std::min(hostChannels, numOutputs_);
-    for (int ch = 0; ch < channelsToSanitise; ++ch) {
-        float* out = fc.destBuffer->getWritePointer(ch, startSample);
-        for (int i = 0; i < numSamples; ++i) {
-            const float sample = out[i];
-            out[i] = std::isfinite(sample) ? juce::jlimit(-16.0f, 16.0f, sample) : 0.0f;
-        }
-    }
-}
-
-te::AutomatableParameter* MagdaChorusCompiledPlugin::getSlotParameter(int slotIndex) const {
-    if (slotIndex < 0 || slotIndex >= kHostSlotCount)
-        return nullptr;
-    return hostParams_[static_cast<size_t>(slotIndex)].get();
-}
-
-const MagdaChorusCompiledPlugin::HostSlotInfo& MagdaChorusCompiledPlugin::getSlotInfo(
-    int slotIndex) const {
-    static const HostSlotInfo kEmpty;
-    if (slotIndex < 0 || slotIndex >= kHostSlotCount)
-        return kEmpty;
-    return hostSlotInfo_[static_cast<size_t>(slotIndex)];
-}
-
-float MagdaChorusCompiledPlugin::divisionFaustValueForIndex(int index) const {
-    if (divisionChoiceValues_.empty())
-        return 1.0f;
-    const int safeIdx = juce::jlimit(0, static_cast<int>(divisionChoiceValues_.size()) - 1, index);
-    return divisionChoiceValues_[static_cast<size_t>(safeIdx)];
-}
-
-float MagdaChorusCompiledPlugin::displayValueToNativeValue(int slotIndex,
-                                                           float displayValue) const {
-    if (slotIndex < 0 || slotIndex >= kHostSlotCount)
-        return displayValue;
-    const auto& s = hostSlotInfo_[static_cast<size_t>(slotIndex)];
-    magda::ParameterInfo info;
-    info.minValue = s.minValue;
-    info.maxValue = s.maxValue;
-    info.scale = s.scale;
-    if (std::isfinite(s.scaleAnchor))
-        info.scaleAnchor = s.scaleAnchor;
-    info.choices = s.choices;
-    return magda::ParameterUtils::realToNormalized(displayValue, info);
-}
-
-float MagdaChorusCompiledPlugin::nativeValueToDisplayValue(int slotIndex, float nativeValue) const {
-    if (slotIndex < 0 || slotIndex >= kHostSlotCount)
-        return nativeValue;
-    const auto& s = hostSlotInfo_[static_cast<size_t>(slotIndex)];
-    magda::ParameterInfo info;
-    info.minValue = s.minValue;
-    info.maxValue = s.maxValue;
-    info.scale = s.scale;
-    if (std::isfinite(s.scaleAnchor))
-        info.scaleAnchor = s.scaleAnchor;
-    info.choices = s.choices;
-    return magda::ParameterUtils::normalizedToReal(nativeValue, info);
+    return infos;
 }
 
 constexpr AliasSpec kAliases[] = {
@@ -478,9 +112,8 @@ const CompiledPluginSpec& getMagdaChorusSpec() {
             "Voices share a single LFO with per-voice phase offsets for spread. "
             "Rate runs free in Hz or locks to tempo Division. "
             "Depth, Feedback, Mix and Width complete the controls.",
-        .createPlugin = [](const DevicePluginCreationContext& context) -> DevicePluginPtr {
-            return tracktion_adapter::pluginHandle(
-                new MagdaChorusCompiledPlugin(tracktion_adapter::creationInfo(context)));
+        .createDevice = [](const DevicePluginCreationContext&) -> std::unique_ptr<MagdaDevice> {
+            return std::make_unique<MagdaChorusCompiledPlugin>();
         },
         .aliases = kAliases,
         .aliasCount = static_cast<int>(sizeof(kAliases) / sizeof(kAliases[0])),

--- a/magda/daw/audio/plugins/compiled/MagdaChorusCompiledPlugin.hpp
+++ b/magda/daw/audio/plugins/compiled/MagdaChorusCompiledPlugin.hpp
@@ -1,15 +1,8 @@
 #pragma once
 
-#include <tracktion_engine/tracktion_engine.h>
-
-#include <array>
-#include <atomic>
-#include <memory>
 #include <vector>
 
-#include "../FaustParamPool.hpp"
-#include "core/ParameterInfo.hpp"
-#include "plugins/compiled/tracktion/CompiledFaustTracktionAdapter.hpp"
+#include "plugins/compiled/MagdaCompiledEffect.hpp"
 
 class dsp;
 
@@ -22,40 +15,12 @@ namespace magda::daw::audio::compiled {
  * free (Hz) or tempo-synced via a musical-division menu — same plumbing
  * the delay / mod devices use. Width spreads voice phases and L/R offset.
  */
-class MagdaChorusCompiledPlugin : public te::Plugin, public ICompiledFaustPlugin {
+class MagdaChorusCompiledPlugin : public MagdaCompiledEffect {
   public:
     static const char* xmlTypeName;
 
-    explicit MagdaChorusCompiledPlugin(const te::PluginCreationInfo& info);
-    ~MagdaChorusCompiledPlugin() override;
+    MagdaChorusCompiledPlugin();
 
-    juce::String getName() const override;
-    juce::String getPluginType() override;
-    juce::String getShortName(int) override;
-    juce::String getSelectableDescription() override;
-
-    void initialise(const te::PluginInitialisationInfo& info) override;
-    void deinitialise() override;
-    void reset() override;
-    void applyToBuffer(const te::PluginRenderContext& fc) override;
-
-    bool takesMidiInput() override {
-        return false;
-    }
-    bool takesAudioInput() override {
-        return true;
-    }
-    bool isSynth() override {
-        return false;
-    }
-    bool producesAudioWhenNoAudioInput() override {
-        return false;
-    }
-    double getTailLength() const override {
-        return 0.1;
-    }
-
-    // Slot ordering matches [idx:N] pins inside magda_chorus.dsp.
     static constexpr int kVoicesSlot = 0;
     static constexpr int kSyncSlot = 1;
     static constexpr int kRateSlot = 2;
@@ -67,68 +32,32 @@ class MagdaChorusCompiledPlugin : public te::Plugin, public ICompiledFaustPlugin
     static constexpr int kHostSlotCount = 8;
     static constexpr int kBpmSlot = 63;
 
-    te::AutomatableParameter* getSlotParameter(int slotIndex) const;
-
-    float displayValueToNativeValue(int slotIndex, float displayValue) const;
-    float nativeValueToDisplayValue(int slotIndex, float nativeValue) const;
-
-    using HostSlotInfo = CompiledHostSlotInfo;
-    const HostSlotInfo& getSlotInfo(int slotIndex) const;
-
-    float divisionFaustValueForIndex(int index) const;
-
-    float currentBpm() const {
-        return currentBpm_.load(std::memory_order_relaxed);
+    /// The Faust quarter-note multiplier behind Division choice @p index.
+    float divisionFaustValueForIndex(int index) const {
+        return menuValueForChoice(kDivisionSlot, index);
     }
 
-    // ICompiledFaustPlugin
-    int hostSlotCount() const override {
-        return kHostSlotCount;
+    juce::String devicePluginId() const override {
+        return xmlTypeName;
     }
-    const CompiledHostSlotInfo& hostSlotInfo(int slotIndex) const override {
-        return getSlotInfo(slotIndex);
+    juce::String deviceName() const override {
+        return "Chorus";
     }
-    DeviceParameterHandle hostSlotParameter(int slotIndex) const override {
-        return tracktion_adapter::parameterHandle(getSlotParameter(slotIndex));
+
+  protected:
+    ::dsp* createEngineDsp(int engineIndex) const override;
+    std::vector<HostSlotInfo> slotInfos() const override;
+    const char* slotIdPrefix() const override {
+        return "magda_chorus_";
     }
-    float displayToNormalized(int slotIndex, float displayValue) const override {
-        return displayValueToNativeValue(slotIndex, displayValue);
+    double tailSeconds() const override {
+        return 0.1;
     }
-    float normalizedToDisplay(int slotIndex, float normalizedValue) const override {
-        return nativeValueToDisplayValue(slotIndex, normalizedValue);
+    bool resetsOnPlayStart() const override {
+        return true;
     }
 
   private:
-    void buildHostParameters();
-    void rebuildEngineState(int sampleRate);
-
-    std::unique_ptr<::dsp> dsp_;
-    int numInputs_ = 0;
-    int numOutputs_ = 0;
-
-    std::array<FAUSTFLOAT*, kHostSlotCount> zones_{};
-    FAUSTFLOAT* bpmZone_ = nullptr;
-    std::vector<float> divisionChoiceValues_;
-    std::vector<juce::String> divisionChoiceLabels_;
-
-    struct GateSpec {
-        int slotIndex = -1;
-        bool negated = false;
-    };
-    std::array<GateSpec, kHostSlotCount> harvestedGates_{};
-
-    std::array<HostSlotInfo, kHostSlotCount> hostSlotInfo_;
-    std::array<te::AutomatableParameter::Ptr, kHostSlotCount> hostParams_;
-    std::array<juce::CachedValue<float>, kHostSlotCount> hostCached_;
-
-    juce::AudioBuffer<float> scratchIn_;
-    juce::AudioBuffer<float> scratchOut_;
-    std::vector<float*> inPtrs_;
-    std::vector<float*> outPtrs_;
-
-    std::atomic<float> currentBpm_{120.0f};
-    bool wasPlaying_ = false;
-
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(MagdaChorusCompiledPlugin)
 };
 

--- a/magda/daw/audio/plugins/compiled/MagdaClipperCompiledPlugin.cpp
+++ b/magda/daw/audio/plugins/compiled/MagdaClipperCompiledPlugin.cpp
@@ -2,343 +2,66 @@
 
 #include <algorithm>
 #include <cmath>
-#include <map>
 
-#include "core/ParameterUtils.hpp"
+#include "core/ParameterInfo.hpp"
 #include "faust/dsp/dsp.h"
 #include "faust/gui/UI.h"
 #include "faust/gui/meta.h"
 #include "magda_clipper.generated.cpp"
-#include "plugins/FaustMetadataParser.hpp"
-#include "plugins/FaustParamInfo.hpp"
 #include "plugins/compiled/CompiledPluginRegistry.hpp"
-#include "plugins/tracktion/TracktionDeviceAdapters.hpp"
 
 namespace magda::daw::audio::compiled {
 
 const char* MagdaClipperCompiledPlugin::xmlTypeName = "magda_clipper";
 
-namespace {
+MagdaClipperCompiledPlugin::MagdaClipperCompiledPlugin() {
+    initEffect();
+}
 
-struct ClipperHarvest {
-    struct Control {
-        int idx = -1;
-        FaustParamSlot::Kind kind = FaustParamSlot::Kind::Continuous;
-        FAUSTFLOAT* zone = nullptr;
+::dsp* MagdaClipperCompiledPlugin::createEngineDsp(int) const {
+    return new MagdaClipperDsp();
+}
+
+std::vector<MagdaClipperCompiledPlugin::HostSlotInfo> MagdaClipperCompiledPlugin::slotInfos()
+    const {
+    using magda::ParameterScale;
+    return {
+        {.name = "Drive",
+         .unit = magda::technicalText(magda::TechnicalTextToken::Decibels),
+         .scale = ParameterScale::Linear,
+         .minValue = 0.0f,
+         .maxValue = 24.0f,
+         .defaultValue = 0.0f},
+        {.name = "Mode",
+         .scale = ParameterScale::Discrete,
+         .minValue = 0.0f,
+         .maxValue = static_cast<float>(kModeCount - 1),
+         .defaultValue = 0.0f,
+         .choices = {"Hard", "Soft", "Tanh", "Hyperbolic", "Sine"}},
+        {.name = "Output",
+         .unit = magda::technicalText(magda::TechnicalTextToken::Decibels),
+         .scale = ParameterScale::Linear,
+         .minValue = -24.0f,
+         .maxValue = 12.0f,
+         .defaultValue = 0.0f},
     };
-    std::vector<Control> controls;
-};
+}
 
-class ClipperHarvester : public ::UI {
-  public:
-    ClipperHarvest harvest;
+void MagdaClipperCompiledPlugin::beforeCompute(DeviceProcessContext& context, int engineIndex) {
+    // Pre-DSP peak, for the dot that rides the transfer curve. Read off the
+    // channels the engine is about to consume rather than the whole buffer, so
+    // a host block wider than the dsp does not report a peak the curve never
+    // sees.
+    const int channels = std::min(context.audio->getNumChannels(), engineInputCount(engineIndex));
 
-    void openTabBox(const char*) override {}
-    void openHorizontalBox(const char*) override {}
-    void openVerticalBox(const char*) override {}
-    void closeBox() override {}
-
-    void addButton(const char* label, FAUSTFLOAT* zone) override {
-        emitControl(FaustParamSlot::Kind::Boolean, label, zone);
-    }
-    void addCheckButton(const char* label, FAUSTFLOAT* zone) override {
-        emitControl(FaustParamSlot::Kind::Boolean, label, zone);
-    }
-    void addVerticalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT, FAUSTFLOAT, FAUSTFLOAT,
-                           FAUSTFLOAT) override {
-        emitControl(FaustParamSlot::Kind::Continuous, label, zone);
-    }
-    void addHorizontalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT, FAUSTFLOAT,
-                             FAUSTFLOAT, FAUSTFLOAT) override {
-        emitControl(FaustParamSlot::Kind::Continuous, label, zone);
-    }
-    void addNumEntry(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT, FAUSTFLOAT, FAUSTFLOAT,
-                     FAUSTFLOAT) override {
-        emitControl(FaustParamSlot::Kind::Continuous, label, zone);
-    }
-    void addHorizontalBargraph(const char*, FAUSTFLOAT*, FAUSTFLOAT, FAUSTFLOAT) override {}
-    void addVerticalBargraph(const char*, FAUSTFLOAT*, FAUSTFLOAT, FAUSTFLOAT) override {}
-    void addSoundfile(const char*, const char*, Soundfile**) override {}
-
-    void declare(FAUSTFLOAT* zone, const char* key, const char* value) override {
-        if (zone == nullptr)
-            return;
-        const auto k = juce::String::fromUTF8(key != nullptr ? key : "").toLowerCase();
-        const auto v = juce::String::fromUTF8(value != nullptr ? value : "");
-        applyFaustAnnotation(k, v, pendingByZone_[zone]);
+    float peak = 0.0f;
+    for (int channel = 0; channel < channels; ++channel) {
+        const float* samples = context.audio->getReadPointer(channel, context.startSample);
+        for (int i = 0; i < context.numSamples; ++i)
+            peak = std::max(peak, std::fabs(samples[i]));
     }
 
-  private:
-    void emitControl(FaustParamSlot::Kind kind, const char* rawLabel, FAUSTFLOAT* zone) {
-        const auto parsed =
-            parseFaustLabel(juce::String::fromUTF8(rawLabel != nullptr ? rawLabel : ""));
-        ControlMetadata merged = parsed.metadata;
-        if (zone != nullptr) {
-            if (auto it = pendingByZone_.find(zone); it != pendingByZone_.end()) {
-                mergeFaustMetadata(merged, it->second);
-                pendingByZone_.erase(it);
-            }
-        }
-
-        ClipperHarvest::Control c;
-        c.idx = merged.slotIndex;
-        c.kind = merged.isChoiceStyle() ? FaustParamSlot::Kind::Discrete : kind;
-        c.zone = zone;
-        harvest.controls.push_back(std::move(c));
-    }
-
-    std::map<FAUSTFLOAT*, ControlMetadata> pendingByZone_;
-};
-
-const ClipperHarvest::Control* findByIdx(const ClipperHarvest& h, int idx) {
-    for (const auto& c : h.controls)
-        if (c.idx == idx)
-            return &c;
-    return nullptr;
-}
-
-}  // namespace
-
-MagdaClipperCompiledPlugin::MagdaClipperCompiledPlugin(const te::PluginCreationInfo& info)
-    : te::Plugin(info) {
-    dsp_ = std::make_unique<MagdaClipperDsp>();
-    constexpr int kProvisionalSampleRate = 44100;
-    rebuildEngineState(kProvisionalSampleRate);
-    buildHostParameters();
-}
-
-MagdaClipperCompiledPlugin::~MagdaClipperCompiledPlugin() {
-    notifyListenersOfDeletion();
-    for (auto& p : hostParams_)
-        if (p)
-            p->detachFromCurrentValue();
-}
-
-juce::String MagdaClipperCompiledPlugin::getName() const {
-    return "Clipper";
-}
-juce::String MagdaClipperCompiledPlugin::getPluginType() {
-    return xmlTypeName;
-}
-juce::String MagdaClipperCompiledPlugin::getShortName(int) {
-    return "Clipper";
-}
-juce::String MagdaClipperCompiledPlugin::getSelectableDescription() {
-    return "Clipper";
-}
-
-void MagdaClipperCompiledPlugin::rebuildEngineState(int sampleRate) {
-    if (!dsp_)
-        return;
-    dsp_->init(sampleRate);
-    numInputs_ = dsp_->getNumInputs();
-    numOutputs_ = dsp_->getNumOutputs();
-
-    ClipperHarvester harvester;
-    dsp_->buildUserInterface(&harvester);
-
-    zones_.fill(nullptr);
-    for (int i = 0; i < kHostSlotCount; ++i) {
-        if (auto* c = findByIdx(harvester.harvest, i))
-            zones_[static_cast<size_t>(i)] = c->zone;
-    }
-}
-
-void MagdaClipperCompiledPlugin::buildHostParameters() {
-    hostSlotInfo_[kDriveSlot] = {.name = "Drive",
-                                 .unit = magda::technicalText(magda::TechnicalTextToken::Decibels),
-                                 .scale = magda::ParameterScale::Linear,
-                                 .minValue = 0.0f,
-                                 .maxValue = 24.0f,
-                                 .defaultValue = 0.0f};
-    hostSlotInfo_[kModeSlot].name = "Mode";
-    hostSlotInfo_[kModeSlot].scale = magda::ParameterScale::Discrete;
-    hostSlotInfo_[kModeSlot].choices = {"Hard", "Soft", "Tanh", "Hyperbolic", "Sine"};
-    hostSlotInfo_[kModeSlot].minValue = 0.0f;
-    hostSlotInfo_[kModeSlot].maxValue = static_cast<float>(kModeCount - 1);
-    hostSlotInfo_[kModeSlot].defaultValue = 0.0f;
-    hostSlotInfo_[kOutputSlot] = {.name = "Output",
-                                  .unit = magda::technicalText(magda::TechnicalTextToken::Decibels),
-                                  .scale = magda::ParameterScale::Linear,
-                                  .minValue = -24.0f,
-                                  .maxValue = 12.0f,
-                                  .defaultValue = 0.0f};
-    juce::NormalisableRange<float> normalisedRange{0.0f, 1.0f};
-    auto* undoManager = getUndoManager();
-
-    auto buildInfo = [](const HostSlotInfo& s) {
-        magda::ParameterInfo info;
-        info.minValue = s.minValue;
-        info.maxValue = s.maxValue;
-        info.defaultValue = s.defaultValue;
-        info.unit = s.unit;
-        info.scale = s.scale;
-        if (std::isfinite(s.scaleAnchor))
-            info.scaleAnchor = s.scaleAnchor;
-        info.choices = s.choices;
-        return info;
-    };
-
-    for (int i = 0; i < kHostSlotCount; ++i) {
-        const auto& slot = hostSlotInfo_[i];
-        const juce::String id = "magda_clipper_" + slot.name.toLowerCase().replace(" ", "_");
-        const juce::Identifier identifier(id);
-        const auto info = buildInfo(slot);
-        const float defaultNormalized =
-            magda::ParameterUtils::realToNormalized(slot.defaultValue, info);
-        hostCached_[i].referTo(state, identifier, undoManager, defaultNormalized);
-
-        auto param = addParam(
-            id, slot.name, normalisedRange,
-            [info](float normalized) {
-                const float real = magda::ParameterUtils::normalizedToReal(normalized, info);
-                return magda::ParameterUtils::formatValue(real, info);
-            },
-            [info](const juce::String& text) {
-                auto parsed = magda::ParameterUtils::parseValue(text, info);
-                if (parsed)
-                    return magda::ParameterUtils::realToNormalized(*parsed, info);
-                return 0.0f;
-            });
-        param->attachToCurrentValue(hostCached_[i]);
-        hostParams_[i] = param;
-    }
-}
-
-void MagdaClipperCompiledPlugin::initialise(const te::PluginInitialisationInfo& info) {
-    rebuildEngineState(static_cast<int>(info.sampleRate));
-    scratchIn_.setSize(numInputs_, info.blockSizeSamples, false, true, true);
-    scratchOut_.setSize(numOutputs_, info.blockSizeSamples, false, true, true);
-    inPtrs_.assign(static_cast<size_t>(numInputs_), nullptr);
-    outPtrs_.assign(static_cast<size_t>(numOutputs_), nullptr);
-}
-
-void MagdaClipperCompiledPlugin::deinitialise() {
-    scratchIn_.setSize(0, 0);
-    scratchOut_.setSize(0, 0);
-    inPtrs_.clear();
-    outPtrs_.clear();
-}
-
-void MagdaClipperCompiledPlugin::reset() {
-    if (dsp_)
-        dsp_->instanceClear();
-}
-
-void MagdaClipperCompiledPlugin::applyToBuffer(const te::PluginRenderContext& fc) {
-    if (!fc.destBuffer || fc.bufferNumSamples <= 0 || !dsp_)
-        return;
-
-    auto writeSlot = [&](int slot) {
-        if (auto* zone = zones_[static_cast<size_t>(slot)]) {
-            const auto& s = hostSlotInfo_[static_cast<size_t>(slot)];
-            magda::ParameterInfo info;
-            info.minValue = s.minValue;
-            info.maxValue = s.maxValue;
-            info.scale = s.scale;
-            if (std::isfinite(s.scaleAnchor))
-                info.scaleAnchor = s.scaleAnchor;
-            // Discrete params need choices populated — normalizedToReal
-            // returns 0 when choices is empty, which silently breaks
-            // dropdowns like Mode.
-            info.choices = s.choices;
-            const float norm = hostParams_[static_cast<size_t>(slot)]->getCurrentValue();
-            *zone = static_cast<FAUSTFLOAT>(magda::ParameterUtils::normalizedToReal(norm, info));
-        }
-    };
-    for (int i = 0; i < kHostSlotCount; ++i)
-        writeSlot(i);
-
-    const int numSamples = fc.bufferNumSamples;
-    const int startSample = fc.bufferStartSample;
-    const int hostChannels = fc.destBuffer->getNumChannels();
-    if (hostChannels <= 0 || numInputs_ <= 0 || numOutputs_ <= 0)
-        return;
-
-    if (scratchIn_.getNumChannels() < numInputs_ || scratchIn_.getNumSamples() < numSamples)
-        scratchIn_.setSize(numInputs_, numSamples, false, true, true);
-    if (scratchOut_.getNumChannels() < numOutputs_ || scratchOut_.getNumSamples() < numSamples)
-        scratchOut_.setSize(numOutputs_, numSamples, false, true, true);
-    if (static_cast<int>(inPtrs_.size()) < numInputs_)
-        inPtrs_.resize(static_cast<size_t>(numInputs_), nullptr);
-    if (static_cast<int>(outPtrs_.size()) < numOutputs_)
-        outPtrs_.resize(static_cast<size_t>(numOutputs_), nullptr);
-
-    float inputPeak = 0.0f;
-    for (int ch = 0; ch < numInputs_; ++ch) {
-        float* dst = scratchIn_.getWritePointer(ch);
-        if (ch < hostChannels) {
-            const float* src = fc.destBuffer->getReadPointer(ch, startSample);
-            std::copy(src, src + numSamples, dst);
-            for (int i = 0; i < numSamples; ++i)
-                inputPeak = std::max(inputPeak, std::fabs(dst[i]));
-        } else {
-            std::fill(dst, dst + numSamples, 0.0f);
-        }
-        inPtrs_[static_cast<size_t>(ch)] = dst;
-    }
-    for (int ch = 0; ch < numOutputs_; ++ch) {
-        outPtrs_[static_cast<size_t>(ch)] = (ch < hostChannels)
-                                                ? fc.destBuffer->getWritePointer(ch, startSample)
-                                                : scratchOut_.getWritePointer(ch);
-    }
-
-    dsp_->compute(numSamples, inPtrs_.data(), outPtrs_.data());
-
-    const int channelsToSanitise = std::min(hostChannels, numOutputs_);
-    for (int ch = 0; ch < channelsToSanitise; ++ch) {
-        float* out = fc.destBuffer->getWritePointer(ch, startSample);
-        for (int i = 0; i < numSamples; ++i) {
-            const float sample = out[i];
-            out[i] = std::isfinite(sample) ? juce::jlimit(-16.0f, 16.0f, sample) : 0.0f;
-        }
-    }
-
-    inputPeakDb_.store(20.0f * std::log10(std::max(inputPeak, 1.0e-6f)), std::memory_order_relaxed);
-}
-
-te::AutomatableParameter* MagdaClipperCompiledPlugin::getSlotParameter(int slotIndex) const {
-    if (slotIndex < 0 || slotIndex >= kHostSlotCount)
-        return nullptr;
-    return hostParams_[static_cast<size_t>(slotIndex)].get();
-}
-
-const MagdaClipperCompiledPlugin::HostSlotInfo& MagdaClipperCompiledPlugin::getSlotInfo(
-    int slotIndex) const {
-    static const HostSlotInfo kEmpty;
-    if (slotIndex < 0 || slotIndex >= kHostSlotCount)
-        return kEmpty;
-    return hostSlotInfo_[static_cast<size_t>(slotIndex)];
-}
-
-float MagdaClipperCompiledPlugin::displayValueToNativeValue(int slotIndex,
-                                                            float displayValue) const {
-    if (slotIndex < 0 || slotIndex >= kHostSlotCount)
-        return displayValue;
-    const auto& s = hostSlotInfo_[static_cast<size_t>(slotIndex)];
-    magda::ParameterInfo info;
-    info.minValue = s.minValue;
-    info.maxValue = s.maxValue;
-    info.scale = s.scale;
-    if (std::isfinite(s.scaleAnchor))
-        info.scaleAnchor = s.scaleAnchor;
-    info.choices = s.choices;
-    return magda::ParameterUtils::realToNormalized(displayValue, info);
-}
-
-float MagdaClipperCompiledPlugin::nativeValueToDisplayValue(int slotIndex,
-                                                            float nativeValue) const {
-    if (slotIndex < 0 || slotIndex >= kHostSlotCount)
-        return nativeValue;
-    const auto& s = hostSlotInfo_[static_cast<size_t>(slotIndex)];
-    magda::ParameterInfo info;
-    info.minValue = s.minValue;
-    info.maxValue = s.maxValue;
-    info.scale = s.scale;
-    if (std::isfinite(s.scaleAnchor))
-        info.scaleAnchor = s.scaleAnchor;
-    info.choices = s.choices;
-    return magda::ParameterUtils::normalizedToReal(nativeValue, info);
+    inputPeakDb_.store(20.0f * std::log10(std::max(peak, 1.0e-6f)), std::memory_order_relaxed);
 }
 
 constexpr AliasSpec kAliases[] = {
@@ -361,9 +84,8 @@ const CompiledPluginSpec& getMagdaClipperSpec() {
                        "<b>Sine</b>: sin(atan(x)) for asymmetric, harmonically rich clipping.\n"
                        "All five are instantiated in parallel for glitch-free Mode switching. "
                        "Drive pushes the input into the curve; Output trims the result.",
-        .createPlugin = [](const DevicePluginCreationContext& context) -> DevicePluginPtr {
-            return tracktion_adapter::pluginHandle(
-                new MagdaClipperCompiledPlugin(tracktion_adapter::creationInfo(context)));
+        .createDevice = [](const DevicePluginCreationContext&) -> std::unique_ptr<MagdaDevice> {
+            return std::make_unique<MagdaClipperCompiledPlugin>();
         },
         .aliases = kAliases,
         .aliasCount = static_cast<int>(sizeof(kAliases) / sizeof(kAliases[0])),

--- a/magda/daw/audio/plugins/compiled/MagdaClipperCompiledPlugin.hpp
+++ b/magda/daw/audio/plugins/compiled/MagdaClipperCompiledPlugin.hpp
@@ -1,15 +1,9 @@
 #pragma once
 
-#include <tracktion_engine/tracktion_engine.h>
-
-#include <array>
 #include <atomic>
-#include <memory>
 #include <vector>
 
-#include "../FaustParamPool.hpp"
-#include "core/ParameterInfo.hpp"
-#include "plugins/compiled/tracktion/CompiledFaustTracktionAdapter.hpp"
+#include "plugins/compiled/MagdaCompiledEffect.hpp"
 
 class dsp;
 
@@ -22,38 +16,11 @@ namespace magda::daw::audio::compiled {
  * picks one of five ADAA curves from aa.lib (Hard / Soft / Tanh /
  * Hyperbolic / Sine) and drives the input into it.
  */
-class MagdaClipperCompiledPlugin : public te::Plugin, public ICompiledFaustPlugin {
+class MagdaClipperCompiledPlugin : public MagdaCompiledEffect {
   public:
     static const char* xmlTypeName;
 
-    explicit MagdaClipperCompiledPlugin(const te::PluginCreationInfo& info);
-    ~MagdaClipperCompiledPlugin() override;
-
-    juce::String getName() const override;
-    juce::String getPluginType() override;
-    juce::String getShortName(int) override;
-    juce::String getSelectableDescription() override;
-
-    void initialise(const te::PluginInitialisationInfo& info) override;
-    void deinitialise() override;
-    void reset() override;
-    void applyToBuffer(const te::PluginRenderContext& fc) override;
-
-    bool takesMidiInput() override {
-        return false;
-    }
-    bool takesAudioInput() override {
-        return true;
-    }
-    bool isSynth() override {
-        return false;
-    }
-    bool producesAudioWhenNoAudioInput() override {
-        return false;
-    }
-    double getTailLength() const override {
-        return 0.0;
-    }
+    MagdaClipperCompiledPlugin();
 
     static constexpr int kDriveSlot = 0;
     static constexpr int kModeSlot = 1;
@@ -63,55 +30,27 @@ class MagdaClipperCompiledPlugin : public te::Plugin, public ICompiledFaustPlugi
     enum class ClipperMode { Hard = 0, Soft, Tanh, Hyperbolic, Sine };
     static constexpr int kModeCount = 5;
 
-    te::AutomatableParameter* getSlotParameter(int slotIndex) const;
-
-    float displayValueToNativeValue(int slotIndex, float displayValue) const;
-    float nativeValueToDisplayValue(int slotIndex, float nativeValue) const;
-
     // Audio-thread metering tap for the transfer-curve dot.
     float getInputPeakDb() const {
         return inputPeakDb_.load(std::memory_order_relaxed);
     }
 
-    using HostSlotInfo = CompiledHostSlotInfo;
-    const HostSlotInfo& getSlotInfo(int slotIndex) const;
+    juce::String devicePluginId() const override {
+        return xmlTypeName;
+    }
+    juce::String deviceName() const override {
+        return "Clipper";
+    }
 
-    // ICompiledFaustPlugin
-    int hostSlotCount() const override {
-        return kHostSlotCount;
+  protected:
+    ::dsp* createEngineDsp(int engineIndex) const override;
+    std::vector<HostSlotInfo> slotInfos() const override;
+    const char* slotIdPrefix() const override {
+        return "magda_clipper_";
     }
-    const CompiledHostSlotInfo& hostSlotInfo(int slotIndex) const override {
-        return getSlotInfo(slotIndex);
-    }
-    DeviceParameterHandle hostSlotParameter(int slotIndex) const override {
-        return tracktion_adapter::parameterHandle(getSlotParameter(slotIndex));
-    }
-    float displayToNormalized(int slotIndex, float displayValue) const override {
-        return displayValueToNativeValue(slotIndex, displayValue);
-    }
-    float normalizedToDisplay(int slotIndex, float normalizedValue) const override {
-        return nativeValueToDisplayValue(slotIndex, normalizedValue);
-    }
+    void beforeCompute(DeviceProcessContext& context, int engineIndex) override;
 
   private:
-    void buildHostParameters();
-    void rebuildEngineState(int sampleRate);
-
-    std::unique_ptr<::dsp> dsp_;
-    int numInputs_ = 0;
-    int numOutputs_ = 0;
-
-    std::array<FAUSTFLOAT*, kHostSlotCount> zones_{};
-
-    std::array<HostSlotInfo, kHostSlotCount> hostSlotInfo_;
-    std::array<te::AutomatableParameter::Ptr, kHostSlotCount> hostParams_;
-    std::array<juce::CachedValue<float>, kHostSlotCount> hostCached_;
-
-    juce::AudioBuffer<float> scratchIn_;
-    juce::AudioBuffer<float> scratchOut_;
-    std::vector<float*> inPtrs_;
-    std::vector<float*> outPtrs_;
-
     std::atomic<float> inputPeakDb_{-120.0f};
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(MagdaClipperCompiledPlugin)

--- a/magda/daw/audio/plugins/compiled/MagdaCompiledEffect.cpp
+++ b/magda/daw/audio/plugins/compiled/MagdaCompiledEffect.cpp
@@ -1,0 +1,491 @@
+#include "plugins/compiled/MagdaCompiledEffect.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <map>
+
+#include "core/ParameterUtils.hpp"
+#include "faust/dsp/dsp.h"
+#include "faust/gui/UI.h"
+#include "faust/gui/meta.h"
+#include "plugins/FaustMetadataParser.hpp"
+
+namespace magda::daw::audio::compiled {
+
+namespace {
+
+/// The one [idx:N] harvester the compiled effects used to each carry a copy of.
+///
+/// Records every numeric control by the slot index its label pins it to, plus
+/// its menu, its gate condition and its role tag: everything the base needs to
+/// bind a host slot to a zone without knowing which device it is looking at.
+class EffectZoneHarvester : public ::UI {
+  public:
+    struct Control {
+        int idx = -1;
+        FAUSTFLOAT* zone = nullptr;
+        std::vector<std::pair<float, juce::String>> menuChoices;
+        int gateSlotIndex = -1;
+        bool gateNegated = false;
+        bool isProjectTempo = false;
+    };
+
+    std::vector<Control> controls;
+
+    void openTabBox(const char*) override {}
+    void openHorizontalBox(const char*) override {}
+    void openVerticalBox(const char*) override {}
+    void closeBox() override {}
+
+    void addButton(const char* label, FAUSTFLOAT* zone) override {
+        emit(label, zone);
+    }
+    void addCheckButton(const char* label, FAUSTFLOAT* zone) override {
+        emit(label, zone);
+    }
+    void addVerticalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT, FAUSTFLOAT, FAUSTFLOAT,
+                           FAUSTFLOAT) override {
+        emit(label, zone);
+    }
+    void addHorizontalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT, FAUSTFLOAT,
+                             FAUSTFLOAT, FAUSTFLOAT) override {
+        emit(label, zone);
+    }
+    void addNumEntry(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT, FAUSTFLOAT, FAUSTFLOAT,
+                     FAUSTFLOAT) override {
+        emit(label, zone);
+    }
+    void addHorizontalBargraph(const char*, FAUSTFLOAT*, FAUSTFLOAT, FAUSTFLOAT) override {}
+    void addVerticalBargraph(const char*, FAUSTFLOAT*, FAUSTFLOAT, FAUSTFLOAT) override {}
+    void addSoundfile(const char*, const char*, Soundfile**) override {}
+
+    void declare(FAUSTFLOAT* zone, const char* key, const char* value) override {
+        if (zone == nullptr)
+            return;
+        const auto k = juce::String::fromUTF8(key != nullptr ? key : "").toLowerCase();
+        const auto v = juce::String::fromUTF8(value != nullptr ? value : "");
+        applyFaustAnnotation(k, v, pendingByZone_[zone]);
+    }
+
+  private:
+    void emit(const char* rawLabel, FAUSTFLOAT* zone) {
+        if (zone == nullptr)
+            return;
+
+        const auto parsed =
+            parseFaustLabel(juce::String::fromUTF8(rawLabel != nullptr ? rawLabel : ""));
+        ControlMetadata merged = parsed.metadata;
+        if (auto it = pendingByZone_.find(zone); it != pendingByZone_.end()) {
+            mergeFaustMetadata(merged, it->second);
+            pendingByZone_.erase(it);
+        }
+
+        Control control;
+        control.idx = merged.slotIndex;
+        control.zone = zone;
+        control.menuChoices = merged.menuChoices;
+        control.gateSlotIndex = merged.gateSlotIndex;
+        control.gateNegated = merged.gateNegated;
+        control.isProjectTempo = merged.role == FaustControlRole::ProjectTempo;
+        controls.push_back(std::move(control));
+    }
+
+    std::map<FAUSTFLOAT*, ControlMetadata> pendingByZone_;
+};
+
+}  // namespace
+
+// ===========================================================================
+
+MagdaCompiledEffect::MagdaCompiledEffect() = default;
+MagdaCompiledEffect::~MagdaCompiledEffect() = default;
+
+::dsp* MagdaCompiledEffect::createEngineDsp(int) const {
+    return nullptr;
+}
+
+void MagdaCompiledEffect::initEffect() {
+    // The harvest first, because a device builds its slot table out of what the
+    // dsp declared: the tempo-synced effects take their Division choices
+    // straight from the menu rather than restating the list in C++.
+    //
+    // The real sample rate arrives with prepare(); this provisional one makes
+    // the device answerable from the moment it is constructed, which is what
+    // the app does with one before it ever reaches a graph.
+    constexpr int kProvisionalSampleRate = 44100;
+    createEngines(kProvisionalSampleRate);
+
+    hostSlotInfo_ = slotInfos();
+    applyHarvestedGates();
+    buildHostParameters();
+    bindSlots();
+}
+
+void MagdaCompiledEffect::createEngines(int sampleRate) {
+    sampleRate_.store(static_cast<double>(sampleRate), std::memory_order_relaxed);
+
+    const int count = std::max(0, engineCount());
+    engines_.clear();
+    engines_.resize(static_cast<size_t>(count));
+
+    for (int engineIndex = 0; engineIndex < count; ++engineIndex) {
+        auto& engine = engines_[static_cast<size_t>(engineIndex)];
+        engine.instance.reset(createEngineDsp(engineIndex));
+        if (engine.instance == nullptr)
+            continue;
+
+        engine.instance->init(sampleRate);
+        engine.numInputs = engine.instance->getNumInputs();
+        engine.numOutputs = engine.instance->getNumOutputs();
+
+        EffectZoneHarvester harvester;
+        engine.instance->buildUserInterface(&harvester);
+
+        for (const auto& control : harvester.controls) {
+            if (control.isProjectTempo)
+                engine.projectTempoZone = control.zone;
+            if (control.idx < 0)
+                continue;
+
+            HarvestedControl harvested;
+            harvested.idx = control.idx;
+            harvested.zone = control.zone;
+            harvested.gateSlotIndex = control.gateSlotIndex;
+            harvested.gateNegated = control.gateNegated;
+            harvested.isProjectTempo = control.isProjectTempo;
+
+            auto sorted = control.menuChoices;
+            std::sort(sorted.begin(), sorted.end(),
+                      [](const auto& a, const auto& b) { return a.first < b.first; });
+            harvested.menuValues.reserve(sorted.size());
+            harvested.menuLabels.reserve(sorted.size());
+            for (const auto& choice : sorted) {
+                harvested.menuValues.push_back(choice.first);
+                harvested.menuLabels.push_back(choice.second);
+            }
+
+            engine.harvested.push_back(std::move(harvested));
+        }
+    }
+}
+
+void MagdaCompiledEffect::bindSlots() {
+    for (auto& engine : engines_) {
+        engine.zonesBySlot.assign(static_cast<size_t>(hostSlotCountValue()), nullptr);
+        for (const auto& harvested : engine.harvested)
+            if (harvested.idx < hostSlotCountValue())
+                engine.zonesBySlot[static_cast<size_t>(harvested.idx)] = harvested.zone;
+    }
+}
+
+void MagdaCompiledEffect::applyHarvestedGates() {
+    // After slotInfos(), never before: a device builds its table with
+    // designated initializers, which zero every field it does not name, so a
+    // gate written in first would be wiped by the device's own table.
+    for (int slotIndex = 0; slotIndex < hostSlotCountValue(); ++slotIndex) {
+        const auto* harvested = harvestedForIdx(slotIndex);
+        if (harvested == nullptr || harvested->gateSlotIndex < 0)
+            continue;
+
+        auto& slot = hostSlotInfo_[static_cast<size_t>(slotIndex)];
+        slot.gateSlotIndex = harvested->gateSlotIndex;
+        slot.gateNegated = harvested->gateNegated;
+    }
+}
+
+const MagdaCompiledEffect::HarvestedControl* MagdaCompiledEffect::harvestedForIdx(int idx) const {
+    for (const auto& engine : engines_)
+        for (const auto& harvested : engine.harvested)
+            if (harvested.idx == idx)
+                return &harvested;
+    return nullptr;
+}
+
+std::vector<juce::String> MagdaCompiledEffect::menuLabelsForIdx(int idx) const {
+    const auto* harvested = harvestedForIdx(idx);
+    return harvested != nullptr ? harvested->menuLabels : std::vector<juce::String>{};
+}
+
+std::vector<float> MagdaCompiledEffect::menuValuesForIdx(int idx) const {
+    const auto* harvested = harvestedForIdx(idx);
+    return harvested != nullptr ? harvested->menuValues : std::vector<float>{};
+}
+
+float MagdaCompiledEffect::menuValueForChoice(int idx, int choiceIndex) const {
+    const auto* harvested = harvestedForIdx(idx);
+    if (harvested == nullptr || harvested->menuValues.empty())
+        return 0.0f;
+
+    const int safeIndex =
+        juce::jlimit(0, static_cast<int>(harvested->menuValues.size()) - 1, choiceIndex);
+    return harvested->menuValues[static_cast<size_t>(safeIndex)];
+}
+
+void MagdaCompiledEffect::buildHostParameters() {
+    hostParams_.clear();
+    hostParams_.reserve(hostSlotInfo_.size());
+
+    for (int slotIndex = 0; slotIndex < hostSlotCountValue(); ++slotIndex) {
+        const auto& slot = hostSlotInfo_[static_cast<size_t>(slotIndex)];
+        hostParams_.push_back(std::make_unique<CompiledParameterValue>(
+            magda::ParameterUtils::realToNormalized(slot.defaultValue, infoForSlot(slotIndex))));
+    }
+}
+
+magda::ParameterInfo MagdaCompiledEffect::infoForSlot(int slotIndex) const {
+    magda::ParameterInfo info;
+    if (slotIndex < 0 || slotIndex >= hostSlotCountValue())
+        return info;
+
+    const auto& slot = hostSlotInfo_[static_cast<size_t>(slotIndex)];
+    info.minValue = slot.minValue;
+    info.maxValue = slot.maxValue;
+    info.defaultValue = slot.defaultValue;
+    info.unit = slot.unit;
+    info.scale = slot.scale;
+    if (std::isfinite(slot.scaleAnchor))
+        info.scaleAnchor = slot.scaleAnchor;
+    info.choices = slot.choices;
+    return info;
+}
+
+DeviceParameterHandle MagdaCompiledEffect::getSlotParameter(int slotIndex) const {
+    if (slotIndex < 0 || slotIndex >= static_cast<int>(hostParams_.size()))
+        return {};
+    return hostParams_[static_cast<size_t>(slotIndex)]->handle();
+}
+
+const MagdaCompiledEffect::HostSlotInfo& MagdaCompiledEffect::getSlotInfo(int slotIndex) const {
+    static const HostSlotInfo kEmpty;
+    if (slotIndex < 0 || slotIndex >= hostSlotCountValue())
+        return kEmpty;
+    return hostSlotInfo_[static_cast<size_t>(slotIndex)];
+}
+
+juce::String MagdaCompiledEffect::slotId(int slotIndex) const {
+    if (slotIndex < 0 || slotIndex >= hostSlotCountValue())
+        return {};
+    return juce::String(slotIdPrefix()) +
+           hostSlotInfo_[static_cast<size_t>(slotIndex)].name.toLowerCase().replace(" ", "_");
+}
+
+juce::String MagdaCompiledEffect::hostSlotId(int slotIndex) const {
+    return slotId(slotIndex);
+}
+
+float MagdaCompiledEffect::displayValueToNativeValue(int slotIndex, float displayValue) const {
+    if (slotIndex < 0 || slotIndex >= hostSlotCountValue())
+        return displayValue;
+    return magda::ParameterUtils::realToNormalized(displayValue, infoForSlot(slotIndex));
+}
+
+float MagdaCompiledEffect::nativeValueToDisplayValue(int slotIndex, float nativeValue) const {
+    if (slotIndex < 0 || slotIndex >= hostSlotCountValue())
+        return nativeValue;
+    return magda::ParameterUtils::normalizedToReal(nativeValue, infoForSlot(slotIndex));
+}
+
+float MagdaCompiledEffect::slotDisplayValue(int slotIndex) const {
+    return nativeValueToDisplayValue(slotIndex, getSlotParameter(slotIndex).currentValue());
+}
+
+int MagdaCompiledEffect::activeEngine() const {
+    const int slot = engineSlot();
+    if (slot < 0 || engines_.empty())
+        return 0;
+    return juce::jlimit(0, static_cast<int>(engines_.size()) - 1,
+                        static_cast<int>(std::lround(slotDisplayValue(slot))));
+}
+
+float* MagdaCompiledEffect::zoneForIdx(int engineIndex, int idx) const {
+    if (engineIndex < 0 || engineIndex >= static_cast<int>(engines_.size()))
+        return nullptr;
+
+    for (const auto& harvested : engines_[static_cast<size_t>(engineIndex)].harvested)
+        if (harvested.idx == idx)
+            return harvested.zone;
+    return nullptr;
+}
+
+int MagdaCompiledEffect::engineInputCount(int engineIndex) const {
+    if (engineIndex < 0 || engineIndex >= static_cast<int>(engines_.size()))
+        return 0;
+    return engines_[static_cast<size_t>(engineIndex)].numInputs;
+}
+
+int MagdaCompiledEffect::engineOutputCount(int engineIndex) const {
+    if (engineIndex < 0 || engineIndex >= static_cast<int>(engines_.size()))
+        return 0;
+    return engines_[static_cast<size_t>(engineIndex)].numOutputs;
+}
+
+DeviceProperties MagdaCompiledEffect::properties() const {
+    return {
+        .pluginId = devicePluginId(),
+        .name = deviceName(),
+        .shortName = deviceShortName(),
+        .takesMidiInput = wantsMidiInput(),
+        .takesAudioInput = true,
+        .isSynth = false,
+        .producesAudioWithoutInput = false,
+        .canSidechain = wantsSidechain(),
+        .latencySeconds = latencySeconds(),
+        .tailLengthSeconds = tailSeconds(),
+        .outputChannelCount = outputChannelCount(),
+    };
+}
+
+void MagdaCompiledEffect::prepare(const DevicePrepareContext& context) {
+    createEngines(static_cast<int>(context.sampleRate));
+    bindSlots();
+
+    int maxInputs = 0;
+    int maxOutputs = 0;
+    for (const auto& engine : engines_) {
+        maxInputs = std::max(maxInputs, engine.numInputs);
+        maxOutputs = std::max(maxOutputs, engine.numOutputs);
+    }
+
+    scratchIn_.setSize(maxInputs, context.maximumBlockSize, false, true, true);
+    scratchOut_.setSize(maxOutputs, context.maximumBlockSize, false, true, true);
+    inPtrs_.assign(static_cast<size_t>(maxInputs), nullptr);
+    outPtrs_.assign(static_cast<size_t>(maxOutputs), nullptr);
+
+    onPrepare(context.sampleRate, context.maximumBlockSize);
+}
+
+void MagdaCompiledEffect::release() {
+    onRelease();
+    scratchIn_.setSize(0, 0);
+    scratchOut_.setSize(0, 0);
+    inPtrs_.clear();
+    outPtrs_.clear();
+}
+
+void MagdaCompiledEffect::reset() {
+    for (auto& engine : engines_)
+        if (engine.instance)
+            engine.instance->instanceClear();
+    onReset();
+}
+
+float MagdaCompiledEffect::sanitise(float sample) {
+    return std::isfinite(sample) ? juce::jlimit(-16.0f, 16.0f, sample) : 0.0f;
+}
+
+void MagdaCompiledEffect::writeZones(DeviceProcessContext& context) {
+    const float bpm =
+        context.tempoMap != nullptr
+            ? static_cast<float>(context.tempoMap->bpmAtSeconds(context.timelineStartSeconds))
+            : currentBpm_.load(std::memory_order_relaxed);
+    currentBpm_.store(bpm, std::memory_order_relaxed);
+
+    // Every engine, not only the running one: a device that switches engines
+    // has to find the user's settings already in the one it switches to.
+    for (int engineIndex = 0; engineIndex < static_cast<int>(engines_.size()); ++engineIndex) {
+        auto& engine = engines_[static_cast<size_t>(engineIndex)];
+        if (engine.instance == nullptr)
+            continue;
+
+        for (const auto& harvested : engine.harvested) {
+            const int slotIndex = harvested.idx;
+            if (slotIndex >= hostSlotCountValue() || harvested.zone == nullptr)
+                continue;
+
+            const float normalized = getSlotParameter(slotIndex).currentValue();
+            if (!harvested.menuValues.empty()) {
+                // A menu's Faust value is whatever the dsp declared for that
+                // choice, which is not always its position in the list.
+                const int count = static_cast<int>(harvested.menuValues.size());
+                const int choice = juce::jlimit(
+                    0, count - 1,
+                    static_cast<int>(std::lround(normalized * static_cast<float>(count - 1))));
+                *harvested.zone =
+                    static_cast<FAUSTFLOAT>(harvested.menuValues[static_cast<size_t>(choice)]);
+                continue;
+            }
+
+            *harvested.zone = static_cast<FAUSTFLOAT>(
+                magda::ParameterUtils::normalizedToReal(normalized, infoForSlot(slotIndex)));
+        }
+
+        if (engine.projectTempoZone != nullptr)
+            *engine.projectTempoZone = static_cast<FAUSTFLOAT>(bpm);
+
+        writeExtraZones(engineIndex);
+    }
+}
+
+void MagdaCompiledEffect::computeEngine(int engineIndex, DeviceProcessContext& context) {
+    if (engineIndex < 0 || engineIndex >= static_cast<int>(engines_.size()))
+        return;
+
+    auto& engine = engines_[static_cast<size_t>(engineIndex)];
+    if (engine.instance == nullptr || context.audio == nullptr)
+        return;
+
+    const int numSamples = context.numSamples;
+    const int startSample = context.startSample;
+    const int hostChannels = context.audio->getNumChannels();
+    const int numInputs = engine.numInputs;
+    const int numOutputs = engine.numOutputs;
+    if (numSamples <= 0 || hostChannels <= 0 || numOutputs <= 0)
+        return;
+
+    if (scratchIn_.getNumChannels() < numInputs || scratchIn_.getNumSamples() < numSamples)
+        scratchIn_.setSize(numInputs, numSamples, false, true, true);
+    if (scratchOut_.getNumChannels() < numOutputs || scratchOut_.getNumSamples() < numSamples)
+        scratchOut_.setSize(numOutputs, numSamples, false, true, true);
+    if (static_cast<int>(inPtrs_.size()) < numInputs)
+        inPtrs_.resize(static_cast<size_t>(numInputs), nullptr);
+    if (static_cast<int>(outPtrs_.size()) < numOutputs)
+        outPtrs_.resize(static_cast<size_t>(numOutputs), nullptr);
+
+    // Faust does not allow input and output to alias, so the input is copied
+    // out first. Channels the host does not have read as silence.
+    for (int channel = 0; channel < numInputs; ++channel) {
+        float* destination = scratchIn_.getWritePointer(channel);
+        if (channel < hostChannels) {
+            const float* source = context.audio->getReadPointer(channel, startSample);
+            std::copy(source, source + numSamples, destination);
+        } else {
+            std::fill(destination, destination + numSamples, 0.0f);
+        }
+        inPtrs_[static_cast<size_t>(channel)] = destination;
+    }
+
+    for (int channel = 0; channel < numOutputs; ++channel)
+        outPtrs_[static_cast<size_t>(channel)] =
+            channel < hostChannels ? context.audio->getWritePointer(channel, startSample)
+                                   : scratchOut_.getWritePointer(channel);
+
+    engine.instance->compute(numSamples, inPtrs_.data(), outPtrs_.data());
+
+    for (int channel = 0; channel < std::min(hostChannels, numOutputs); ++channel) {
+        float* out = context.audio->getWritePointer(channel, startSample);
+        for (int i = 0; i < numSamples; ++i)
+            out[i] = sanitise(out[i]);
+    }
+}
+
+void MagdaCompiledEffect::processAudio(DeviceProcessContext& context) {
+    computeEngine(activeEngine(), context);
+}
+
+void MagdaCompiledEffect::process(DeviceProcessContext& context) {
+    if (context.audio == nullptr || context.numSamples <= 0)
+        return;
+
+    if (context.isPlaying && !wasPlaying_ && resetsOnPlayStart())
+        reset();
+    wasPlaying_ = context.isPlaying;
+
+    writeZones(context);
+
+    const int engineIndex = activeEngine();
+    beforeCompute(context, engineIndex);
+    processAudio(context);
+    afterCompute(context, engineIndex);
+}
+
+}  // namespace magda::daw::audio::compiled

--- a/magda/daw/audio/plugins/compiled/MagdaCompiledEffect.cpp
+++ b/magda/daw/audio/plugins/compiled/MagdaCompiledEffect.cpp
@@ -490,9 +490,18 @@ void MagdaCompiledEffect::computeEngine(int engineIndex, DeviceProcessContext& c
     // channels, so anything above them is not its output -- it is the input it
     // was handed, and passing that through would leak the dry signal around a
     // widener that was asked to replace it.
-    if (outputChannelCount() > 0)
-        for (int channel = numOutputs; channel < hostChannels; ++channel)
+    //
+    // The key is not the device's to clear, though. It arrives as channels of
+    // this buffer but it belongs to whatever produced it, the engine hands it
+    // over read-only, and the same source may be fanned out to other ops: zeroing
+    // it here would empty their input from under them. Stop at the first key
+    // channel when there is one.
+    if (outputChannelCount() > 0) {
+        const int firstForeignChannel =
+            context.sidechainInputChannel >= 0 ? context.sidechainInputChannel : hostChannels;
+        for (int channel = numOutputs; channel < firstForeignChannel; ++channel)
             context.audio->clear(channel, startSample, numSamples);
+    }
 }
 
 void MagdaCompiledEffect::processAudio(DeviceProcessContext& context) {

--- a/magda/daw/audio/plugins/compiled/MagdaCompiledEffect.cpp
+++ b/magda/daw/audio/plugins/compiled/MagdaCompiledEffect.cpp
@@ -225,14 +225,29 @@ float MagdaCompiledEffect::menuValueForChoice(int idx, int choiceIndex) const {
 }
 
 void MagdaCompiledEffect::buildHostParameters() {
+    // The domains first: every conversion after this one reads them, including
+    // the ones on the audio thread, which is the point of caching them.
+    slotDomains_.clear();
+    slotDomains_.reserve(hostSlotInfo_.size());
+    for (int slotIndex = 0; slotIndex < hostSlotCountValue(); ++slotIndex)
+        slotDomains_.push_back(magda::ParameterUtils::domainOf(infoForSlot(slotIndex)));
+
     hostParams_.clear();
     hostParams_.reserve(hostSlotInfo_.size());
 
     for (int slotIndex = 0; slotIndex < hostSlotCountValue(); ++slotIndex) {
         const auto& slot = hostSlotInfo_[static_cast<size_t>(slotIndex)];
         hostParams_.push_back(std::make_unique<CompiledParameterValue>(
-            magda::ParameterUtils::realToNormalized(slot.defaultValue, infoForSlot(slotIndex))));
+            magda::ParameterUtils::realToNormalized(slot.defaultValue, domainForSlot(slotIndex))));
     }
+}
+
+const magda::ParameterUtils::ParameterDomain& MagdaCompiledEffect::domainForSlot(
+    int slotIndex) const {
+    static const magda::ParameterUtils::ParameterDomain kEmpty;
+    if (slotIndex < 0 || slotIndex >= static_cast<int>(slotDomains_.size()))
+        return kEmpty;
+    return slotDomains_[static_cast<size_t>(slotIndex)];
 }
 
 magda::ParameterInfo MagdaCompiledEffect::infoForSlot(int slotIndex) const {
@@ -279,13 +294,13 @@ juce::String MagdaCompiledEffect::hostSlotId(int slotIndex) const {
 float MagdaCompiledEffect::displayValueToNativeValue(int slotIndex, float displayValue) const {
     if (slotIndex < 0 || slotIndex >= hostSlotCountValue())
         return displayValue;
-    return magda::ParameterUtils::realToNormalized(displayValue, infoForSlot(slotIndex));
+    return magda::ParameterUtils::realToNormalized(displayValue, domainForSlot(slotIndex));
 }
 
 float MagdaCompiledEffect::nativeValueToDisplayValue(int slotIndex, float nativeValue) const {
     if (slotIndex < 0 || slotIndex >= hostSlotCountValue())
         return nativeValue;
-    return magda::ParameterUtils::normalizedToReal(nativeValue, infoForSlot(slotIndex));
+    return magda::ParameterUtils::normalizedToReal(nativeValue, domainForSlot(slotIndex));
 }
 
 float MagdaCompiledEffect::slotDisplayValue(int slotIndex) const {
@@ -410,7 +425,7 @@ void MagdaCompiledEffect::writeZones(DeviceProcessContext& context) {
             }
 
             *harvested.zone = static_cast<FAUSTFLOAT>(
-                magda::ParameterUtils::normalizedToReal(normalized, infoForSlot(slotIndex)));
+                magda::ParameterUtils::normalizedToReal(normalized, domainForSlot(slotIndex)));
         }
 
         if (engine.projectTempoZone != nullptr)

--- a/magda/daw/audio/plugins/compiled/MagdaCompiledEffect.cpp
+++ b/magda/daw/audio/plugins/compiled/MagdaCompiledEffect.cpp
@@ -149,6 +149,7 @@ void MagdaCompiledEffect::createEngines(int sampleRate) {
 
             HarvestedControl harvested;
             harvested.idx = control.idx;
+            harvested.slotIndex = slotForDspIdx(control.idx);
             harvested.zone = control.zone;
             harvested.gateSlotIndex = control.gateSlotIndex;
             harvested.gateNegated = control.gateNegated;
@@ -173,8 +174,8 @@ void MagdaCompiledEffect::bindSlots() {
     for (auto& engine : engines_) {
         engine.zonesBySlot.assign(static_cast<size_t>(hostSlotCountValue()), nullptr);
         for (const auto& harvested : engine.harvested)
-            if (harvested.idx < hostSlotCountValue())
-                engine.zonesBySlot[static_cast<size_t>(harvested.idx)] = harvested.zone;
+            if (harvested.slotIndex >= 0 && harvested.slotIndex < hostSlotCountValue())
+                engine.zonesBySlot[static_cast<size_t>(harvested.slotIndex)] = harvested.zone;
     }
 }
 
@@ -182,14 +183,16 @@ void MagdaCompiledEffect::applyHarvestedGates() {
     // After slotInfos(), never before: a device builds its table with
     // designated initializers, which zero every field it does not name, so a
     // gate written in first would be wiped by the device's own table.
-    for (int slotIndex = 0; slotIndex < hostSlotCountValue(); ++slotIndex) {
-        const auto* harvested = harvestedForIdx(slotIndex);
-        if (harvested == nullptr || harvested->gateSlotIndex < 0)
-            continue;
+    for (const auto& engine : engines_) {
+        for (const auto& harvested : engine.harvested) {
+            if (harvested.gateSlotIndex < 0 || harvested.slotIndex < 0 ||
+                harvested.slotIndex >= hostSlotCountValue())
+                continue;
 
-        auto& slot = hostSlotInfo_[static_cast<size_t>(slotIndex)];
-        slot.gateSlotIndex = harvested->gateSlotIndex;
-        slot.gateNegated = harvested->gateNegated;
+            auto& slot = hostSlotInfo_[static_cast<size_t>(harvested.slotIndex)];
+            slot.gateSlotIndex = slotForDspIdx(harvested.gateSlotIndex);
+            slot.gateNegated = harvested.gateNegated;
+        }
     }
 }
 
@@ -327,11 +330,12 @@ DeviceProperties MagdaCompiledEffect::properties() const {
         .takesMidiInput = wantsMidiInput(),
         .takesAudioInput = true,
         .isSynth = false,
-        .producesAudioWithoutInput = false,
+        .producesAudioWithoutInput = producesAudioWithoutInput(),
         .canSidechain = wantsSidechain(),
         .latencySeconds = latencySeconds(),
         .tailLengthSeconds = tailSeconds(),
         .outputChannelCount = outputChannelCount(),
+        .inputChannelCount = inputChannelCount(),
     };
 }
 
@@ -388,8 +392,8 @@ void MagdaCompiledEffect::writeZones(DeviceProcessContext& context) {
             continue;
 
         for (const auto& harvested : engine.harvested) {
-            const int slotIndex = harvested.idx;
-            if (slotIndex >= hostSlotCountValue() || harvested.zone == nullptr)
+            const int slotIndex = harvested.slotIndex;
+            if (slotIndex < 0 || slotIndex >= hostSlotCountValue() || harvested.zone == nullptr)
                 continue;
 
             const float normalized = getSlotParameter(slotIndex).currentValue();
@@ -466,6 +470,14 @@ void MagdaCompiledEffect::computeEngine(int engineIndex, DeviceProcessContext& c
         for (int i = 0; i < numSamples; ++i)
             out[i] = sanitise(out[i]);
     }
+
+    // A device that declares a fixed output width owns exactly that many
+    // channels, so anything above them is not its output -- it is the input it
+    // was handed, and passing that through would leak the dry signal around a
+    // widener that was asked to replace it.
+    if (outputChannelCount() > 0)
+        for (int channel = numOutputs; channel < hostChannels; ++channel)
+            context.audio->clear(channel, startSample, numSamples);
 }
 
 void MagdaCompiledEffect::processAudio(DeviceProcessContext& context) {

--- a/magda/daw/audio/plugins/compiled/MagdaCompiledEffect.hpp
+++ b/magda/daw/audio/plugins/compiled/MagdaCompiledEffect.hpp
@@ -155,12 +155,25 @@ class MagdaCompiledEffect : public CompiledFaustDevice {
     virtual int engineSlot() const {
         return -1;
     }
+    /// Which host slot a dsp control's [idx:N] drives, and which slot a
+    /// `[gate:N]` refers to. The identity by default: a device pins its dsp
+    /// indices to its slot indices. A device whose table interleaves
+    /// wrapper-only controls (the Filter's Engine and Limit) says otherwise.
+    /// Return -1 for a dsp index no host slot owns.
+    virtual int slotForDspIdx(int idx) const {
+        return idx;
+    }
 
     // ---- Properties -------------------------------------------------------
     virtual bool wantsMidiInput() const {
         return false;
     }
     virtual bool wantsSidechain() const {
+        return false;
+    }
+    /// Whether the host should keep pumping the device once dry input stops. A
+    /// device with a tail in its delay lines says yes, or the trail is cut.
+    virtual bool producesAudioWithoutInput() const {
         return false;
     }
     virtual double tailSeconds() const {
@@ -172,6 +185,11 @@ class MagdaCompiledEffect : public CompiledFaustDevice {
     /// Fixed output width, or 0 to follow the input. See
     /// DeviceProperties::outputChannelCount.
     virtual int outputChannelCount() const {
+        return 0;
+    }
+    /// Input channels the device reads, sidechain key included, or 0 to let the
+    /// host decide. See DeviceProperties::inputChannelCount.
+    virtual int inputChannelCount() const {
         return 0;
     }
     /// Whether a stopped->playing edge clears the dsp. An LFO-driven effect
@@ -215,7 +233,8 @@ class MagdaCompiledEffect : public CompiledFaustDevice {
   private:
     /// What one dsp control declared about itself.
     struct HarvestedControl {
-        int idx = -1;
+        int idx = -1;        ///< The dsp's own [idx:N].
+        int slotIndex = -1;  ///< The host slot it drives, via slotForDspIdx().
         float* zone = nullptr;
         std::vector<float> menuValues;
         std::vector<juce::String> menuLabels;

--- a/magda/daw/audio/plugins/compiled/MagdaCompiledEffect.hpp
+++ b/magda/daw/audio/plugins/compiled/MagdaCompiledEffect.hpp
@@ -1,0 +1,268 @@
+#pragma once
+
+#include <atomic>
+#include <memory>
+#include <vector>
+
+#include "core/ParameterInfo.hpp"
+#include "plugins/compiled/CompiledFaustInterface.hpp"
+
+// The Faust dsp is forward-declared via its own base so this header does not
+// pull in the Faust SDK; the .cpp owns it.
+class dsp;
+
+namespace magda::daw::audio::compiled {
+
+/**
+ * @brief Shared base for MAGDA's compiled-Faust effects.
+ *
+ * The effect half of what MagdaCompiledPolyInstrument is for the instruments
+ * (#2192). Every compiled effect was carrying its own copy of the same six
+ * hundred lines -- an [idx:N] zone harvester, a normalized-parameter table, a
+ * scratch-buffer dance around dsp::compute(), and a sanitising pass -- with the
+ * device's actual identity in about forty of them. That duplication is why they
+ * were still host-engine plugin subclasses: porting fifty independent copies of
+ * the same plumbing is fifty jobs, and porting the plumbing once is one.
+ *
+ * What the base owns:
+ *
+ *  - **The slot table.** A concrete device returns slotInfos() once; the base
+ *    builds a normalized CompiledParameterValue per slot, answers the whole
+ *    ICompiledFaustPlugin surface from it, and derives each parameter's stable
+ *    id as `slotIdPrefix() + name` (override slotId() when a device needs its
+ *    own scheme).
+ *
+ *  - **The harvest.** Every dsp control is read for its [idx:N] slot, its
+ *    `[style:menu{...}]` choices, its `[gate:N]` enable condition and its
+ *    `[role:...]` tag before slotInfos() is asked for anything, so a device can
+ *    build its slot table out of what the dsp declared rather than restating
+ *    it. Gates are applied to the finished table by the base: a device never
+ *    has to re-apply them after its own designated initializers wipe them.
+ *
+ *  - **The Faust engines.** engineCount() dsp instances, each harvested the
+ *    same way, so a host slot finds its zone in whichever engines expose it.
+ *    Every engine is written every block, not just the running one, so
+ *    switching engines mid-project keeps the user's settings. A device with no
+ *    Faust dsp at all (EQ, Utility) returns nothing from createEngineDsp() and
+ *    overrides processAudio().
+ *
+ *  - **Project tempo.** A dsp control tagged `[role:projectTempo]` gets the
+ *    host's BPM written into it every block, from the tempo map the process
+ *    context carries. The tempo-synced effects used to reach into the current
+ *    engine's tempo sequence for this, which is exactly the kind of reach that
+ *    kept them tied to one engine.
+ *
+ *  - **The block.** Input copied out of the shared buffer (Faust forbids
+ *    aliasing), compute(), then a finite/limit pass over what came back.
+ *
+ * A concrete device supplies its dsp factory, its slot table, its id and names,
+ * and calls initEffect() from its constructor. Metering taps and any state that
+ * is not a parameter hang off the beforeCompute()/afterCompute() hooks.
+ */
+class MagdaCompiledEffect : public CompiledFaustDevice {
+  public:
+    MagdaCompiledEffect();
+    ~MagdaCompiledEffect() override;
+
+    using HostSlotInfo = CompiledHostSlotInfo;
+
+    void prepare(const DevicePrepareContext& context) override;
+    void release() override;
+    void reset() override;
+    void process(DeviceProcessContext& context) override;
+
+    DeviceProperties properties() const override;
+
+    int hostSlotCountValue() const {
+        return static_cast<int>(hostSlotInfo_.size());
+    }
+
+    DeviceParameterHandle getSlotParameter(int slotIndex) const;
+    const HostSlotInfo& getSlotInfo(int slotIndex) const;
+    float displayValueToNativeValue(int slotIndex, float displayValue) const;
+    float nativeValueToDisplayValue(int slotIndex, float nativeValue) const;
+
+    /// The slot's display-domain value as it is right now -- the value the last
+    /// block wrote into the dsp. What a device UI reads.
+    float slotDisplayValue(int slotIndex) const;
+
+    double currentSampleRate() const {
+        return sampleRate_.load(std::memory_order_relaxed);
+    }
+
+    /// Project tempo as of the last processed block. Tempo-synced devices draw
+    /// their beat grid from this rather than re-querying the host.
+    float currentBpm() const {
+        return currentBpm_.load(std::memory_order_relaxed);
+    }
+
+    // ---- What the dsp declared, by [idx:N] --------------------------------
+    // Valid from the first line of slotInfos() onward. A menu's labels are what
+    // a device puts in a slot's choices; a menu's values are what the dsp wants
+    // written into the zone, and the two are not always the same list.
+    std::vector<juce::String> menuLabelsForIdx(int idx) const;
+    std::vector<float> menuValuesForIdx(int idx) const;
+    /// The Faust value the menu declared for @p choiceIndex, or 0 when there is
+    /// no menu at that idx. A device UI that has to reconstruct what the dsp is
+    /// doing (a delay's echo spacing from its Division choice) asks this.
+    float menuValueForChoice(int idx, int choiceIndex) const;
+
+    // ICompiledFaustPlugin
+    int hostSlotCount() const override {
+        return hostSlotCountValue();
+    }
+    const CompiledHostSlotInfo& hostSlotInfo(int slotIndex) const override {
+        return getSlotInfo(slotIndex);
+    }
+    DeviceParameterHandle hostSlotParameter(int slotIndex) const override {
+        return getSlotParameter(slotIndex);
+    }
+    juce::String hostSlotId(int slotIndex) const override;
+    float displayToNormalized(int slotIndex, float displayValue) const override {
+        return displayValueToNativeValue(slotIndex, displayValue);
+    }
+    float normalizedToDisplay(int slotIndex, float normalizedValue) const override {
+        return nativeValueToDisplayValue(slotIndex, normalizedValue);
+    }
+    int activeEngine() const override;
+
+  protected:
+    // ---- Identity, supplied by the concrete device ------------------------
+    /// The device's slots, in slot order. Called once, after the dsp has been
+    /// harvested, so it may read menuLabelsForIdx() and friends.
+    virtual std::vector<HostSlotInfo> slotInfos() const = 0;
+    /// Parameter-id prefix, e.g. "magda_clipper_". Must be stable: it keys state.
+    virtual const char* slotIdPrefix() const = 0;
+    virtual juce::String devicePluginId() const = 0;
+    virtual juce::String deviceName() const = 0;
+    virtual juce::String deviceShortName() const {
+        return deviceName();
+    }
+    /// Default is slotIdPrefix() + the slot name lowercased with spaces as
+    /// underscores. Override where a device pins ids that do not follow it.
+    virtual juce::String slotId(int slotIndex) const;
+
+    // ---- The dsp ----------------------------------------------------------
+    /// How many Faust engines this device switches between. One for most.
+    virtual int engineCount() const {
+        return 1;
+    }
+    /// Allocate engine @p engineIndex's dsp, or null for a device that has none
+    /// and overrides processAudio() instead.
+    virtual ::dsp* createEngineDsp(int engineIndex) const;
+    /// The slot whose value picks the running engine. -1 for a single-engine
+    /// device.
+    virtual int engineSlot() const {
+        return -1;
+    }
+
+    // ---- Properties -------------------------------------------------------
+    virtual bool wantsMidiInput() const {
+        return false;
+    }
+    virtual bool wantsSidechain() const {
+        return false;
+    }
+    virtual double tailSeconds() const {
+        return 0.0;
+    }
+    virtual double latencySeconds() const {
+        return 0.0;
+    }
+    /// Fixed output width, or 0 to follow the input. See
+    /// DeviceProperties::outputChannelCount.
+    virtual int outputChannelCount() const {
+        return 0;
+    }
+    /// Whether a stopped->playing edge clears the dsp. An LFO-driven effect
+    /// wants its phase back at zero every time the transport starts, so the
+    /// modulation lines up with the song rather than with whenever the graph
+    /// happened to be built.
+    virtual bool resetsOnPlayStart() const {
+        return false;
+    }
+
+    // ---- Per-device hooks -------------------------------------------------
+    virtual void onPrepare(double /*sampleRate*/, int /*maximumBlockSize*/) {}
+    virtual void onRelease() {}
+    virtual void onReset() {}
+    /// Zones the slot table does not cover, and any cross-slot correction the
+    /// dsp needs. Called once per engine, after that engine's slot writes.
+    virtual void writeExtraZones(int /*engineIndex*/) {}
+    /// Audio thread, after the zone writes and before compute().
+    virtual void beforeCompute(DeviceProcessContext& /*context*/, int /*engineIndex*/) {}
+    /// Audio thread, after compute() and after the output has been sanitised.
+    virtual void afterCompute(DeviceProcessContext& /*context*/, int /*engineIndex*/) {}
+    /// The whole block. The default runs the active Faust engine; a device with
+    /// no dsp overrides this and does its own work.
+    virtual void processAudio(DeviceProcessContext& context);
+
+    /// Concrete constructors call this once, after their hooks are valid.
+    void initEffect();
+
+    // ---- What a subclass may read ----------------------------------------
+    float* zoneForIdx(int engineIndex, int idx) const;
+    int engineInputCount(int engineIndex) const;
+    int engineOutputCount(int engineIndex) const;
+    magda::ParameterInfo infoForSlot(int slotIndex) const;
+    /// Runs the given engine's dsp over the context's buffer, in place.
+    void computeEngine(int engineIndex, DeviceProcessContext& context);
+
+    /// Finite, and inside the same +/-16 ceiling every compiled device applies
+    /// before handing a block back to the host.
+    static float sanitise(float sample);
+
+  private:
+    /// What one dsp control declared about itself.
+    struct HarvestedControl {
+        int idx = -1;
+        float* zone = nullptr;
+        std::vector<float> menuValues;
+        std::vector<juce::String> menuLabels;
+        int gateSlotIndex = -1;
+        bool gateNegated = false;
+        bool isProjectTempo = false;
+    };
+
+    struct EngineState {
+        std::unique_ptr<::dsp> instance;
+        std::vector<HarvestedControl> harvested;
+        /// Zone per host slot, null where this engine does not expose it. Bound
+        /// once the slot table exists.
+        std::vector<float*> zonesBySlot;
+        float* projectTempoZone = nullptr;
+        int numInputs = 0;
+        int numOutputs = 0;
+    };
+
+    void createEngines(int sampleRate);
+    void bindSlots();
+    void applyHarvestedGates();
+    void buildHostParameters();
+    void writeZones(DeviceProcessContext& context);
+    /// The first engine that declares anything about @p idx, which is where the
+    /// menus and gates come from. Engines of one device agree about a shared
+    /// control; where they do not, the first to declare it wins.
+    const HarvestedControl* harvestedForIdx(int idx) const;
+
+    std::vector<EngineState> engines_;
+
+    std::vector<HostSlotInfo> hostSlotInfo_;
+    // Individually allocated so a DeviceParameterHandle handed out early stays
+    // valid if the slot container is ever extended.
+    std::vector<std::unique_ptr<CompiledParameterValue>> hostParams_;
+
+    std::atomic<double> sampleRate_{44100.0};
+    std::atomic<float> currentBpm_{120.0f};
+    /// Audio thread only: the transport state the previous block ran under.
+    bool wasPlaying_ = false;
+
+    juce::AudioBuffer<float> scratchIn_;
+    juce::AudioBuffer<float> scratchOut_;
+    std::vector<float*> inPtrs_;
+    std::vector<float*> outPtrs_;
+
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(MagdaCompiledEffect)
+};
+
+}  // namespace magda::daw::audio::compiled

--- a/magda/daw/audio/plugins/compiled/MagdaCompiledEffect.hpp
+++ b/magda/daw/audio/plugins/compiled/MagdaCompiledEffect.hpp
@@ -5,6 +5,7 @@
 #include <vector>
 
 #include "core/ParameterInfo.hpp"
+#include "core/ParameterUtils.hpp"
 #include "plugins/compiled/CompiledFaustInterface.hpp"
 
 // The Faust dsp is forward-declared via its own base so this header does not
@@ -223,6 +224,14 @@ class MagdaCompiledEffect : public CompiledFaustDevice {
     int engineInputCount(int engineIndex) const;
     int engineOutputCount(int engineIndex) const;
     magda::ParameterInfo infoForSlot(int slotIndex) const;
+    /// The slot's conversion domain, cached when the table was built.
+    ///
+    /// What the audio thread converts through. ParameterInfo carries the slot's
+    /// name, unit and choice list, and building one per slot per block copies
+    /// that choice vector -- a heap allocation, in process(), on every discrete
+    /// parameter of every device. ParameterDomain is the same conversion with
+    /// none of the strings.
+    const magda::ParameterUtils::ParameterDomain& domainForSlot(int slotIndex) const;
     /// Runs the given engine's dsp over the context's buffer, in place.
     void computeEngine(int engineIndex, DeviceProcessContext& context);
 
@@ -267,6 +276,7 @@ class MagdaCompiledEffect : public CompiledFaustDevice {
     std::vector<EngineState> engines_;
 
     std::vector<HostSlotInfo> hostSlotInfo_;
+    std::vector<magda::ParameterUtils::ParameterDomain> slotDomains_;
     // Individually allocated so a DeviceParameterHandle handed out early stays
     // valid if the slot container is ever extended.
     std::vector<std::unique_ptr<CompiledParameterValue>> hostParams_;

--- a/magda/daw/audio/plugins/compiled/MagdaCompiledPolyInstrument.cpp
+++ b/magda/daw/audio/plugins/compiled/MagdaCompiledPolyInstrument.cpp
@@ -262,6 +262,10 @@ void MagdaCompiledPolyInstrument::buildHostParameters() {
 
 void MagdaCompiledPolyInstrument::prepare(const DevicePrepareContext& context) {
     rebuildEngineState(static_cast<int>(context.sampleRate));
+    // Mono and Legato push onto this from process(), so its storage is taken
+    // here rather than at the first note. One entry per MIDI pitch is the whole
+    // range and nothing can ask for more.
+    heldNotes_.reserve(128);
     scratchOut_.setSize(std::max(numOutputs_, 2), context.maximumBlockSize, false, true, true);
     outPtrs_.assign(static_cast<size_t>(std::max(numOutputs_, 2)), nullptr);
     limEnv_ = 0.0f;

--- a/magda/daw/audio/plugins/compiled/MagdaCompiledPolyInstrument.cpp
+++ b/magda/daw/audio/plugins/compiled/MagdaCompiledPolyInstrument.cpp
@@ -226,23 +226,37 @@ magda::ParameterInfo MagdaCompiledPolyInstrument::infoForSlot(int slotIndex) con
     return info;
 }
 
+const magda::ParameterUtils::ParameterDomain& MagdaCompiledPolyInstrument::domainForSlot(
+    int slotIndex) const {
+    static const magda::ParameterUtils::ParameterDomain kEmpty;
+    if (slotIndex < 0 || slotIndex >= static_cast<int>(slotDomains_.size()))
+        return kEmpty;
+    return slotDomains_[static_cast<size_t>(slotIndex)];
+}
+
 float MagdaCompiledPolyInstrument::slotRealValue(int slotIndex) const {
     if (slotIndex < 0 || slotIndex >= hostSlotCountValue())
         return 0.0f;
     const float norm = hostParams_[static_cast<size_t>(slotIndex)]->getCurrentValue();
-    return magda::ParameterUtils::normalizedToReal(norm, infoForSlot(slotIndex));
+    return magda::ParameterUtils::normalizedToReal(norm, domainForSlot(slotIndex));
 }
 
 void MagdaCompiledPolyInstrument::buildHostParameters() {
     hostSlotInfo_ = slotInfos();
 
+    // The domains first: every conversion after this one reads them, including
+    // the per-block fan-out onto the voices.
+    slotDomains_.clear();
+    slotDomains_.reserve(hostSlotInfo_.size());
+    for (int i = 0; i < hostSlotCountValue(); ++i)
+        slotDomains_.push_back(magda::ParameterUtils::domainOf(infoForSlot(i)));
+
     hostParams_.clear();
     hostParams_.reserve(static_cast<size_t>(hostSlotCountValue()));
     for (int i = 0; i < hostSlotCountValue(); ++i) {
         const auto& slot = hostSlotInfo_[static_cast<size_t>(i)];
-        const auto info = infoForSlot(i);
         hostParams_.push_back(std::make_unique<CompiledParameterValue>(
-            magda::ParameterUtils::realToNormalized(slot.defaultValue, info)));
+            magda::ParameterUtils::realToNormalized(slot.defaultValue, domainForSlot(i))));
     }
 }
 
@@ -509,14 +523,14 @@ float MagdaCompiledPolyInstrument::displayValueToNativeValue(int slotIndex,
                                                              float displayValue) const {
     if (slotIndex < 0 || slotIndex >= hostSlotCountValue())
         return displayValue;
-    return magda::ParameterUtils::realToNormalized(displayValue, infoForSlot(slotIndex));
+    return magda::ParameterUtils::realToNormalized(displayValue, domainForSlot(slotIndex));
 }
 
 float MagdaCompiledPolyInstrument::nativeValueToDisplayValue(int slotIndex,
                                                              float nativeValue) const {
     if (slotIndex < 0 || slotIndex >= hostSlotCountValue())
         return nativeValue;
-    return magda::ParameterUtils::normalizedToReal(nativeValue, infoForSlot(slotIndex));
+    return magda::ParameterUtils::normalizedToReal(nativeValue, domainForSlot(slotIndex));
 }
 
 }  // namespace magda::daw::audio::compiled

--- a/magda/daw/audio/plugins/compiled/MagdaCompiledPolyInstrument.cpp
+++ b/magda/daw/audio/plugins/compiled/MagdaCompiledPolyInstrument.cpp
@@ -151,9 +151,21 @@ std::vector<MagdaCompiledPolyInstrument::HostSlotInfo> MagdaCompiledPolyInstrume
     return infos;
 }
 
+void MagdaCompiledPolyInstrument::reserveHeldNotes() {
+    // Mono and Legato push onto the held-note stack from process(), so its
+    // storage is taken on a thread that may allocate. handleMonoNoteOn() keeps
+    // one entry per pitch, so the whole MIDI range is the most it can ever hold
+    // and this is the only allocation it needs.
+    //
+    // Done at construction as well as in prepare(), so the guarantee does not
+    // rest on a host having called prepare() first.
+    heldNotes_.reserve(kMaxHeldNotes);
+}
+
 void MagdaCompiledPolyInstrument::initInstrument() {
     // The table first: the zone binding below runs over it, and a device with a
     // panel of its own decides how wide it is.
+    reserveHeldNotes();
     voiceSlotInfos_ = voiceSlotInfos();
     buildHostParameters();
 
@@ -262,10 +274,7 @@ void MagdaCompiledPolyInstrument::buildHostParameters() {
 
 void MagdaCompiledPolyInstrument::prepare(const DevicePrepareContext& context) {
     rebuildEngineState(static_cast<int>(context.sampleRate));
-    // Mono and Legato push onto this from process(), so its storage is taken
-    // here rather than at the first note. One entry per MIDI pitch is the whole
-    // range and nothing can ask for more.
-    heldNotes_.reserve(128);
+    reserveHeldNotes();
     scratchOut_.setSize(std::max(numOutputs_, 2), context.maximumBlockSize, false, true, true);
     outPtrs_.assign(static_cast<size_t>(std::max(numOutputs_, 2)), nullptr);
     limEnv_ = 0.0f;
@@ -312,6 +321,23 @@ void MagdaCompiledPolyInstrument::releasePolyVoicesForPitch(int pitch) {
 bool MagdaCompiledPolyInstrument::handleMonoNoteOn(int note, int velocity, int mode) {
     const float g = static_cast<float>(velocity) / 127.0f;
     const bool wasEmpty = heldNotes_.empty();
+
+    // One entry per pitch, so a repeat note-on for a pitch already down moves it
+    // to the top of the stack rather than adding a second copy of it.
+    //
+    // Two reasons, and the second is why the stack can be sized once and never
+    // grown. A pitch held twice needs two note-offs to be let go, and one of the
+    // two is all an unbalanced stream sends -- the same duplicate on/off
+    // delivery releasePolyVoicesForPitch() exists to survive on the poly side,
+    // where a recorded clip playing back merged with the live input that fed it
+    // sends a pitch twice. Appending would strand it here as permanently held.
+    // And appending has no bound: MIDI note numbers stop at 128 but note-ons do
+    // not, so the stack would keep growing and reallocate under process().
+    for (auto it = heldNotes_.begin(); it != heldNotes_.end(); ++it)
+        if (it->note == note) {
+            heldNotes_.erase(it);
+            break;
+        }
     heldNotes_.push_back({note, g});
     if (monoFreqZone_)
         *monoFreqZone_ = midiNoteToHz(note);

--- a/magda/daw/audio/plugins/compiled/MagdaCompiledPolyInstrument.cpp
+++ b/magda/daw/audio/plugins/compiled/MagdaCompiledPolyInstrument.cpp
@@ -107,7 +107,7 @@ class PolyVoiceHarvester : public ::UI {
             zonesByIdx[merged.slotIndex].push_back(zone);
         } else {
             const auto name = parsed.cleanLabel.toLowerCase();
-            if (name == "freq" || name == "gain" || name == "gate")
+            if (name == "freq" || name == "gain" || name == "gate" || name == "bend")
                 reservedByName[name].push_back(zone);
         }
     }
@@ -129,11 +129,36 @@ inline float midiNoteToHz(int note) {
 MagdaCompiledPolyInstrument::MagdaCompiledPolyInstrument() = default;
 MagdaCompiledPolyInstrument::~MagdaCompiledPolyInstrument() = default;
 
+std::vector<MagdaCompiledPolyInstrument::HostSlotInfo> MagdaCompiledPolyInstrument::slotInfos()
+    const {
+    using magda::ParameterScale;
+
+    auto infos = voiceSlotInfos_;
+    infos.resize(static_cast<size_t>(voiceSlotCount() + (hasVoiceModes() ? 2 : 1)));
+    infos[static_cast<size_t>(voiceSlotCount())] = {.name = "Gain",
+                                                    .unit = "dB",
+                                                    .scale = ParameterScale::Linear,
+                                                    .minValue = -24.0f,
+                                                    .maxValue = 6.0f,
+                                                    .defaultValue = -6.0f};
+    if (hasVoiceModes())
+        infos[static_cast<size_t>(voiceSlotCount() + 1)] = {.name = "Voice Mode",
+                                                            .scale = ParameterScale::Discrete,
+                                                            .minValue = 0.0f,
+                                                            .maxValue = 2.0f,
+                                                            .defaultValue = 0.0f,
+                                                            .choices = {"Poly", "Mono", "Legato"}};
+    return infos;
+}
+
 void MagdaCompiledPolyInstrument::initInstrument() {
+    // The table first: the zone binding below runs over it, and a device with a
+    // panel of its own decides how wide it is.
     voiceSlotInfos_ = voiceSlotInfos();
+    buildHostParameters();
+
     constexpr int kProvisionalSampleRate = 44100;
     rebuildEngineState(kProvisionalSampleRate);
-    buildHostParameters();
 }
 
 void MagdaCompiledPolyInstrument::rebuildEngineState(int sampleRate) {
@@ -146,22 +171,27 @@ void MagdaCompiledPolyInstrument::rebuildEngineState(int sampleRate) {
     PolyVoiceHarvester harvester;
     poly_->buildUserInterface(&harvester);
 
-    voiceZonesBySlot_.assign(static_cast<size_t>(voiceSlotCount()), {});
-    for (int i = 0; i < voiceSlotCount(); ++i)
+    // Every slot the dsp pins an [idx:N] for; the rest stay empty and are
+    // wrapper-only controls (Gain, Voice Mode).
+    voiceZonesBySlot_.assign(static_cast<size_t>(hostSlotCountValue()), {});
+    for (int i = 0; i < hostSlotCountValue(); ++i)
         if (auto it = harvester.zonesByIdx.find(i); it != harvester.zonesByIdx.end())
             voiceZonesBySlot_[static_cast<size_t>(i)] = it->second;
+    voiceBendZones_.clear();
+    if (auto it = harvester.reservedByName.find("bend"); it != harvester.reservedByName.end())
+        voiceBendZones_ = it->second;
 
     // Dedicated mono voice (driven directly; the poly allocator skips idle
     // voices). Harvest its reserved freq/gain/gate plus its copy of each voice
     // macro zone.
-    monoZonesBySlot_.assign(static_cast<size_t>(voiceSlotCount()), nullptr);
-    monoFreqZone_ = monoGainZone_ = monoGateZone_ = nullptr;
+    monoZonesBySlot_.assign(static_cast<size_t>(hostSlotCountValue()), nullptr);
+    monoFreqZone_ = monoGainZone_ = monoGateZone_ = monoBendZone_ = nullptr;
     if (hasVoiceModes()) {
         monoVoice_.reset(createVoiceDsp());
         monoVoice_->init(sampleRate);
         PolyVoiceHarvester monoH;
         monoVoice_->buildUserInterface(&monoH);
-        for (int i = 0; i < voiceSlotCount(); ++i)
+        for (int i = 0; i < hostSlotCountValue(); ++i)
             if (auto it = monoH.zonesByIdx.find(i);
                 it != monoH.zonesByIdx.end() && !it->second.empty())
                 monoZonesBySlot_[static_cast<size_t>(i)] = it->second.front();
@@ -173,10 +203,12 @@ void MagdaCompiledPolyInstrument::rebuildEngineState(int sampleRate) {
         monoFreqZone_ = first(monoH.reservedByName, "freq");
         monoGainZone_ = first(monoH.reservedByName, "gain");
         monoGateZone_ = first(monoH.reservedByName, "gate");
+        monoBendZone_ = first(monoH.reservedByName, "bend");
     } else {
         monoVoice_.reset();
     }
     heldNotes_.clear();
+    currentBend_ = 0.0f;
 }
 
 magda::ParameterInfo MagdaCompiledPolyInstrument::infoForSlot(int slotIndex) const {
@@ -202,25 +234,7 @@ float MagdaCompiledPolyInstrument::slotRealValue(int slotIndex) const {
 }
 
 void MagdaCompiledPolyInstrument::buildHostParameters() {
-    using magda::ParameterScale;
-
-    // [voice macros ...] then the control slots: Gain, then Voice Mode (if any).
-    hostSlotInfo_ = voiceSlotInfos_;
-    hostSlotInfo_.resize(static_cast<size_t>(hostSlotCountValue()));
-    hostSlotInfo_[static_cast<size_t>(gainSlot())] = {.name = "Gain",
-                                                      .unit = "dB",
-                                                      .scale = ParameterScale::Linear,
-                                                      .minValue = -24.0f,
-                                                      .maxValue = 6.0f,
-                                                      .defaultValue = -6.0f};
-    if (hasVoiceModes())
-        hostSlotInfo_[static_cast<size_t>(voiceModeSlot())] = {
-            .name = "Voice Mode",
-            .scale = ParameterScale::Discrete,
-            .minValue = 0.0f,
-            .maxValue = 2.0f,
-            .defaultValue = 0.0f,
-            .choices = {"Poly", "Mono", "Legato"}};
+    hostSlotInfo_ = slotInfos();
 
     hostParams_.clear();
     hostParams_.reserve(static_cast<size_t>(hostSlotCountValue()));
@@ -334,7 +348,7 @@ void MagdaCompiledPolyInstrument::process(DeviceProcessContext& context) {
 
     // Fan each voice macro out to every poly voice (Glide forced to 0 so reused
     // voices never portamento) and to the mono voice (real value, incl. Glide).
-    for (int slot = 0; slot < voiceSlotCount(); ++slot) {
+    for (int slot = 0; slot < hostSlotCountValue(); ++slot) {
         const auto real = static_cast<FAUSTFLOAT>(slotRealValue(slot));
         const FAUSTFLOAT polyReal = (slot == glideVoiceSlot()) ? FAUSTFLOAT(0) : real;
         for (FAUSTFLOAT* zone : voiceZonesBySlot_[static_cast<size_t>(slot)])
@@ -343,6 +357,15 @@ void MagdaCompiledPolyInstrument::process(DeviceProcessContext& context) {
         if (hasVoiceModes() && monoZonesBySlot_[static_cast<size_t>(slot)])
             *monoZonesBySlot_[static_cast<size_t>(slot)] = real;
     }
+
+    // The wheel's last position, refreshed every block: a rebuilt engine state
+    // or a mode switch has to pick up where the player left it rather than
+    // snapping back to centre.
+    for (FAUSTFLOAT* zone : voiceBendZones_)
+        if (zone)
+            *zone = currentBend_;
+    if (monoBendZone_)
+        *monoBendZone_ = currentBend_;
 
     const int n = context.numSamples;
     const int start = context.startSample;
@@ -358,7 +381,9 @@ void MagdaCompiledPolyInstrument::process(DeviceProcessContext& context) {
     ::dsp* active =
         (mode == Poly) ? static_cast<::dsp*>(poly_.get()) : static_cast<::dsp*>(monoVoice_.get());
 
-    const float gain = juce::Decibels::decibelsToGain(slotRealValue(gainSlot()));
+    const bool hasOutputStage = gainSlot() >= 0;
+    const float gain =
+        hasOutputStage ? juce::Decibels::decibelsToGain(slotRealValue(gainSlot())) : 1.0f;
     outPtrs_.resize(static_cast<size_t>(numOutputs_));
     const int scratchCh = scratchOut_.getNumChannels();
     const int maxChunk = std::min(MIX_BUFFER_SIZE, scratchOut_.getNumSamples());
@@ -373,23 +398,27 @@ void MagdaCompiledPolyInstrument::process(DeviceProcessContext& context) {
                 outPtrs_[static_cast<size_t>(ch)] = scratchOut_.getWritePointer(ch % scratchCh);
             active->compute(chunk, nullptr, outPtrs_.data());
 
-            for (int i = 0; i < chunk; ++i) {
-                float mono = scratchOut_.getSample(0, i) * gain;
-                if (!std::isfinite(mono)) {
-                    limEnv_ = 0.0f;
-                    active->instanceClear();
-                    for (int ch = 0; ch < numOutputs_; ++ch)
-                        scratchOut_.setSample(ch, i, 0.0f);
-                    continue;
+            // Gain, peak limiter and NaN panic, for a device that leaves its
+            // output stage to the wrapper. A synth whose dsp trims and
+            // soft-clips per voice has already done all three.
+            if (hasOutputStage)
+                for (int i = 0; i < chunk; ++i) {
+                    float mono = scratchOut_.getSample(0, i) * gain;
+                    if (!std::isfinite(mono)) {
+                        limEnv_ = 0.0f;
+                        active->instanceClear();
+                        for (int ch = 0; ch < numOutputs_; ++ch)
+                            scratchOut_.setSample(ch, i, 0.0f);
+                        continue;
+                    }
+                    limEnv_ = juce::jmax(std::abs(mono), limEnv_ * 0.9997f);
+                    const float factor = (limEnv_ > kCeiling) ? (kCeiling / limEnv_) : 1.0f;
+                    for (int ch = 0; ch < numOutputs_; ++ch) {
+                        float v = scratchOut_.getSample(ch, i) * gain * factor;
+                        v = juce::jlimit(-kCeiling, kCeiling, v);
+                        scratchOut_.setSample(ch, i, v);
+                    }
                 }
-                limEnv_ = juce::jmax(std::abs(mono), limEnv_ * 0.9997f);
-                const float factor = (limEnv_ > kCeiling) ? (kCeiling / limEnv_) : 1.0f;
-                for (int ch = 0; ch < numOutputs_; ++ch) {
-                    float v = scratchOut_.getSample(ch, i) * gain * factor;
-                    v = juce::jlimit(-kCeiling, kCeiling, v);
-                    scratchOut_.setSample(ch, i, v);
-                }
-            }
 
             for (int ch = 0; ch < hostChannels; ++ch) {
                 const int srcCh = (numOutputs_ == 1) ? 0 : (ch % numOutputs_);
@@ -410,7 +439,14 @@ void MagdaCompiledPolyInstrument::process(DeviceProcessContext& context) {
             renderSegment(cursor, evSample - cursor);
             cursor = evSample;
 
-            if (mode == Poly) {
+            if (m.isPitchWheel()) {
+                currentBend_ = static_cast<float>(m.getPitchWheelValue() - 8192) / 8192.0f;
+                for (FAUSTFLOAT* zone : voiceBendZones_)
+                    if (zone)
+                        *zone = currentBend_;
+                if (monoBendZone_)
+                    *monoBendZone_ = currentBend_;
+            } else if (mode == Poly) {
                 if (m.isNoteOn()) {
                     // Release any voice still sounding this pitch before
                     // re-triggering, so the allocator never accumulates orphan

--- a/magda/daw/audio/plugins/compiled/MagdaCompiledPolyInstrument.hpp
+++ b/magda/daw/audio/plugins/compiled/MagdaCompiledPolyInstrument.hpp
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "core/ParameterInfo.hpp"
+#include "core/ParameterUtils.hpp"
 #include "plugins/compiled/CompiledFaustInterface.hpp"
 
 // mydsp_poly (Faust's polyphonic voice allocator) and the single-voice dsp are
@@ -165,6 +166,11 @@ class MagdaCompiledPolyInstrument : public CompiledFaustDevice {
     void buildHostParameters();
     void rebuildEngineState(int sampleRate);
     magda::ParameterInfo infoForSlot(int slotIndex) const;
+    /// The slot's conversion domain, cached when the table was built. What the
+    /// audio thread converts through: a ParameterInfo built per slot per block
+    /// copies the slot's choice list, which allocates, and a synth fans out
+    /// forty of them every callback.
+    const magda::ParameterUtils::ParameterDomain& domainForSlot(int slotIndex) const;
     float slotRealValue(int slotIndex) const;
 
     // ---- Voice-mode (Mono/Legato/glide) handling, active only when
@@ -229,6 +235,7 @@ class MagdaCompiledPolyInstrument : public CompiledFaustDevice {
 
     std::vector<HostSlotInfo> voiceSlotInfos_;  // cached from the hook
     std::vector<HostSlotInfo> hostSlotInfo_;    // voice macros + Gain
+    std::vector<magda::ParameterUtils::ParameterDomain> slotDomains_;
     // Individually allocated so every DeviceParameterHandle remains stable
     // even if the slot container is extended in a future migration.
     std::vector<std::unique_ptr<CompiledParameterValue>> hostParams_;

--- a/magda/daw/audio/plugins/compiled/MagdaCompiledPolyInstrument.hpp
+++ b/magda/daw/audio/plugins/compiled/MagdaCompiledPolyInstrument.hpp
@@ -191,6 +191,10 @@ class MagdaCompiledPolyInstrument : public CompiledFaustDevice {
     // still-monitored live input that fed it), so unbalanced deliveries must
     // never strand a sounding voice.
     void releasePolyVoicesForPitch(int pitch);
+    /// Takes the held-note stack's storage, off the audio thread.
+    void reserveHeldNotes();
+    /// One entry per MIDI pitch, which handleMonoNoteOn() keeps it to.
+    static constexpr int kMaxHeldNotes = 128;
 
     std::unique_ptr<::dsp_poly> poly_;
     // Dedicated single voice for Mono/Legato (the poly allocator skips idle

--- a/magda/daw/audio/plugins/compiled/MagdaCompiledPolyInstrument.hpp
+++ b/magda/daw/audio/plugins/compiled/MagdaCompiledPolyInstrument.hpp
@@ -67,19 +67,18 @@ class MagdaCompiledPolyInstrument : public CompiledFaustDevice {
     int voiceSlotCount() const {
         return static_cast<int>(voiceSlotInfos_.size());
     }
-    // Control slots follow the voice macros: Gain always, then Voice Mode when
-    // the device supports mono/legato.
-    int gainSlot() const {
+    // Where the control slots sit. The defaults put them after the voice macros
+    // -- Gain always, then Voice Mode when the device supports mono/legato --
+    // which is the layout slotInfos() composes for a drum voice. A device with
+    // a panel of its own overrides slotInfos() and says where they went.
+    virtual int gainSlot() const {
         return voiceSlotCount();
     }
-    int voiceModeSlot() const {
+    virtual int voiceModeSlot() const {
         return hasVoiceModes() ? voiceSlotCount() + 1 : -1;
     }
-    int controlSlotCount() const {
-        return hasVoiceModes() ? 2 : 1;
-    }
     int hostSlotCountValue() const {
-        return voiceSlotCount() + controlSlotCount();
+        return static_cast<int>(hostSlotInfo_.size());
     }
 
     DeviceParameterHandle getSlotParameter(int slotIndex) const;
@@ -122,8 +121,21 @@ class MagdaCompiledPolyInstrument : public CompiledFaustDevice {
     // base wraps it in mydsp_poly.
     virtual ::dsp* createVoiceDsp() const = 0;
     // The voice-macro slots, in [idx:0..N-1] order. Their count defines where
-    // the Gain control slot begins.
-    virtual std::vector<HostSlotInfo> voiceSlotInfos() const = 0;
+    // the Gain control slot begins. A device that overrides slotInfos()
+    // outright has no use for this and returns nothing.
+    virtual std::vector<HostSlotInfo> voiceSlotInfos() const {
+        return {};
+    }
+    /// The whole slot table. The default is the voice macros followed by Gain,
+    /// and Voice Mode where the device has one, which is what a struck voice
+    /// wants. A device whose dsp pins controls the host does not own -- a synth
+    /// with a filter section and its own output stage -- returns its own table
+    /// and names the control slots through gainSlot() / voiceModeSlot().
+    ///
+    /// Any slot the dsp declares an [idx:N] for is fanned out to the voices;
+    /// the rest are wrapper-only. Return -1 from gainSlot() when the dsp
+    /// applies the output gain itself.
+    virtual std::vector<HostSlotInfo> slotInfos() const;
     // Parameter-id prefix, e.g. "magda_kick_". Must be stable (it keys state).
     virtual const char* slotIdPrefix() const = 0;
     virtual juce::String devicePluginId() const = 0;
@@ -187,6 +199,12 @@ class MagdaCompiledPolyInstrument : public CompiledFaustDevice {
     float* monoGainZone_ = nullptr;
     float* monoGateZone_ = nullptr;
     std::vector<float*> monoZonesBySlot_;
+    // Every voice's pitch-bend zone, plus the mono voice's. Driven from the
+    // wheel rather than from a slot: bend is a performance input, not a
+    // parameter, and a dsp that declares no `bend` control simply has none.
+    std::vector<float*> voiceBendZones_;
+    float* monoBendZone_ = nullptr;
+    float currentBend_ = 0.0f;
     struct HeldNote {
         int note = 0;
         float gain = 0.0f;

--- a/magda/daw/audio/plugins/compiled/MagdaCompressorCompiledPlugin.cpp
+++ b/magda/daw/audio/plugins/compiled/MagdaCompressorCompiledPlugin.cpp
@@ -2,22 +2,14 @@
 
 #include <algorithm>
 #include <cmath>
-#include <map>
 
-#include "core/ParameterUtils.hpp"
+#include "core/ParameterInfo.hpp"
 #include "faust/dsp/dsp.h"
 #include "faust/gui/UI.h"
 #include "faust/gui/meta.h"
-#include "plugins/FaustMetadataParser.hpp"
-#include "plugins/FaustParamInfo.hpp"
-#include "plugins/compiled/CompiledPluginRegistry.hpp"
-#include "plugins/tracktion/TracktionDeviceAdapters.hpp"
-
-// Both engine DSPs are #included into THIS translation unit only — each
-// generated `.cpp` defines a self-contained class, so co-locating them lets
-// us instantiate both without conflicts. Mirrors the MagdaFilter wrapper.
 #include "magda_compressor.generated.cpp"
 #include "magda_compressor_glue.generated.cpp"
+#include "plugins/compiled/CompiledPluginRegistry.hpp"
 
 namespace magda::daw::audio::compiled {
 
@@ -25,108 +17,14 @@ const char* MagdaCompressorCompiledPlugin::xmlTypeName = "magda_compressor";
 
 namespace {
 
-// ============================================================================
-// EngineHarvester — stripped-down UI that records each control's idx, kind,
-// and zone pointer. Same shape the MagdaFilter wrapper uses.
-// ============================================================================
-
-struct EngineHarvest {
-    struct Control {
-        int idx = -1;
-        FaustParamSlot::Kind kind = FaustParamSlot::Kind::Continuous;
-        FAUSTFLOAT* zone = nullptr;
-    };
-    std::vector<Control> controls;
-};
-
-class EngineHarvester : public ::UI {
-  public:
-    EngineHarvest harvest;
-
-    void openTabBox(const char*) override {}
-    void openHorizontalBox(const char*) override {}
-    void openVerticalBox(const char*) override {}
-    void closeBox() override {}
-
-    void addButton(const char* label, FAUSTFLOAT* zone) override {
-        emitControl(FaustParamSlot::Kind::Boolean, label, zone);
-    }
-    void addCheckButton(const char* label, FAUSTFLOAT* zone) override {
-        emitControl(FaustParamSlot::Kind::Boolean, label, zone);
-    }
-    void addVerticalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT, FAUSTFLOAT, FAUSTFLOAT,
-                           FAUSTFLOAT) override {
-        emitControl(FaustParamSlot::Kind::Continuous, label, zone);
-    }
-    void addHorizontalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT, FAUSTFLOAT,
-                             FAUSTFLOAT, FAUSTFLOAT) override {
-        emitControl(FaustParamSlot::Kind::Continuous, label, zone);
-    }
-    void addNumEntry(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT, FAUSTFLOAT, FAUSTFLOAT,
-                     FAUSTFLOAT) override {
-        emitControl(FaustParamSlot::Kind::Continuous, label, zone);
-    }
-    void addHorizontalBargraph(const char*, FAUSTFLOAT*, FAUSTFLOAT, FAUSTFLOAT) override {}
-    void addVerticalBargraph(const char*, FAUSTFLOAT*, FAUSTFLOAT, FAUSTFLOAT) override {}
-    void addSoundfile(const char*, const char*, Soundfile**) override {}
-
-    void declare(FAUSTFLOAT* zone, const char* key, const char* value) override {
-        if (zone == nullptr)
-            return;
-        const auto k = juce::String::fromUTF8(key != nullptr ? key : "").toLowerCase();
-        const auto v = juce::String::fromUTF8(value != nullptr ? value : "");
-        applyFaustAnnotation(k, v, pendingByZone_[zone]);
-    }
-
-  private:
-    void emitControl(FaustParamSlot::Kind kind, const char* rawLabel, FAUSTFLOAT* zone) {
-        const auto parsed =
-            parseFaustLabel(juce::String::fromUTF8(rawLabel != nullptr ? rawLabel : ""));
-        ControlMetadata merged = parsed.metadata;
-        if (zone != nullptr) {
-            if (auto it = pendingByZone_.find(zone); it != pendingByZone_.end()) {
-                mergeFaustMetadata(merged, it->second);
-                pendingByZone_.erase(it);
-            }
-        }
-
-        EngineHarvest::Control c;
-        c.idx = merged.slotIndex;
-        c.kind = merged.isChoiceStyle() ? FaustParamSlot::Kind::Discrete : kind;
-        c.zone = zone;
-        harvest.controls.push_back(std::move(c));
-    }
-
-    std::map<FAUSTFLOAT*, ControlMetadata> pendingByZone_;
-};
-
-const EngineHarvest::Control* findByIdx(const EngineHarvest& h, int idx) {
-    for (const auto& c : h.controls)
-        if (c.idx == idx)
-            return &c;
-    return nullptr;
-}
-
-magda::ParameterInfo parameterInfoForSlot(const CompiledHostSlotInfo& s) {
-    magda::ParameterInfo info;
-    info.minValue = s.minValue;
-    info.maxValue = s.maxValue;
-    info.defaultValue = s.defaultValue;
-    info.unit = s.unit;
-    info.scale = s.scale;
-    if (std::isfinite(s.scaleAnchor))
-        info.scaleAnchor = s.scaleAnchor;
-    info.choices = s.choices;
-    return info;
-}
-
 float ampToDb(float amp) {
     return 20.0f * std::log10(std::max(amp, 1.0e-6f));
 }
 
-// Static transfer-curve gain reduction for the curve view. Both engines
-// respond similarly to threshold/ratio/knee at steady state, so a single
-// formula is good enough for the visualisation.
+/// The reduction the curve view draws at @p levelDb. A read of the same static
+/// curve the dsp implements, not a tap of what it did: the dsp reports no gain
+/// signal, and a meter that lagged the knobs by an envelope would read as the
+/// device being wrong about its own settings.
 float gainReductionForLevel(float levelDb, float thresholdDb, float ratio, float kneeDb) {
     ratio = std::max(1.0f, ratio);
     kneeDb = std::max(0.0f, kneeDb);
@@ -150,373 +48,167 @@ float gainReductionForLevel(float levelDb, float thresholdDb, float ratio, float
     return std::max(0.0f, over - compressedOver);
 }
 
+/// Peak magnitude over one channel range of @p buffer.
+float peakOfChannels(const juce::AudioBuffer<float>& buffer, int firstChannel, int lastChannel,
+                     int startSample, int numSamples) {
+    float peak = 0.0f;
+    for (int channel = firstChannel; channel < std::min(lastChannel, buffer.getNumChannels());
+         ++channel) {
+        const float* samples = buffer.getReadPointer(channel, startSample);
+        for (int i = 0; i < numSamples; ++i)
+            peak = std::max(peak, std::fabs(samples[i]));
+    }
+    return peak;
+}
+
 }  // namespace
 
-MagdaCompressorCompiledPlugin::MagdaCompressorCompiledPlugin(const te::PluginCreationInfo& info)
-    : te::Plugin(info) {
-    engines_[static_cast<size_t>(CompressorEngine::Clean)].dsp =
-        std::make_unique<MagdaCompressorDsp>();
-    engines_[static_cast<size_t>(CompressorEngine::Glue)].dsp =
-        std::make_unique<MagdaCompressorGlueDsp>();
-
-    constexpr int kProvisionalSampleRate = 44100;
-    rebuildEngineState(kProvisionalSampleRate);
-    buildHostParameters();
+MagdaCompressorCompiledPlugin::MagdaCompressorCompiledPlugin() {
+    initEffect();
 }
 
-MagdaCompressorCompiledPlugin::~MagdaCompressorCompiledPlugin() {
-    notifyListenersOfDeletion();
-    for (auto& p : hostParams_)
-        if (p)
-            p->detachFromCurrentValue();
-}
-
-juce::String MagdaCompressorCompiledPlugin::getName() const {
-    return "Compressor";
-}
-juce::String MagdaCompressorCompiledPlugin::getPluginType() {
-    return xmlTypeName;
-}
-juce::String MagdaCompressorCompiledPlugin::getShortName(int) {
-    return "Comp";
-}
-juce::String MagdaCompressorCompiledPlugin::getSelectableDescription() {
-    return "Compressor";
-}
-
-void MagdaCompressorCompiledPlugin::getChannelNames(juce::StringArray* ins,
-                                                    juce::StringArray* outs) {
-    if (ins)
-        ins->addArray({"Left", "Right", "Sidechain"});
-    if (outs)
-        outs->addArray({"Left", "Right"});
-}
-
-void MagdaCompressorCompiledPlugin::rebuildEngineState(int sampleRate) {
-    for (size_t engineIdx = 0; engineIdx < engines_.size(); ++engineIdx) {
-        auto& e = engines_[engineIdx];
-        if (!e.dsp)
-            continue;
-        e.dsp->init(sampleRate);
-        e.numInputs = e.dsp->getNumInputs();
-        e.numOutputs = e.dsp->getNumOutputs();
-
-        EngineHarvester harvester;
-        e.dsp->buildUserInterface(&harvester);
-
-        e.zones.fill(nullptr);
-        e.useSidechainZone = nullptr;
-
-        // Slot 0 (Engine) lives only in the wrapper — no DSP zone. All other
-        // slots are looked up by their `[idx:N]` annotation, with N == host
-        // slot index. Engines that don't expose a given slot simply yield
-        // nullptr, and the audio path skips writing it.
-        for (int i = 1; i < kHostSlotCount; ++i) {
-            if (auto* c = findByIdx(harvester.harvest, i))
-                e.zones[static_cast<size_t>(i)] = c->zone;
-        }
-        if (auto* c = findByIdx(harvester.harvest, kUseSidechainHiddenSlot))
-            e.useSidechainZone = c->zone;
+::dsp* MagdaCompressorCompiledPlugin::createEngineDsp(int engineIndex) const {
+    switch (static_cast<CompressorEngine>(engineIndex)) {
+        case CompressorEngine::Clean:
+            return new MagdaCompressorDsp();
+        case CompressorEngine::Glue:
+            return new MagdaCompressorGlueDsp();
     }
+    return nullptr;
 }
 
-void MagdaCompressorCompiledPlugin::buildHostParameters() {
-    hostSlotInfo_[kEngineSlot].name = "Engine";
-    hostSlotInfo_[kEngineSlot].scale = magda::ParameterScale::Discrete;
-    hostSlotInfo_[kEngineSlot].choices = {"Clean", "Glue"};
-    hostSlotInfo_[kEngineSlot].minValue = 0.0f;
-    hostSlotInfo_[kEngineSlot].maxValue =
-        static_cast<float>(hostSlotInfo_[kEngineSlot].choices.size() - 1);
-    hostSlotInfo_[kEngineSlot].defaultValue = 0.0f;
+std::vector<MagdaCompressorCompiledPlugin::HostSlotInfo> MagdaCompressorCompiledPlugin::slotInfos()
+    const {
+    std::vector<HostSlotInfo> infos(kHostSlotCount);
+    infos[kEngineSlot].name = "Engine";
+    infos[kEngineSlot].scale = magda::ParameterScale::Discrete;
+    infos[kEngineSlot].choices = {"Clean", "Glue"};
+    infos[kEngineSlot].minValue = 0.0f;
+    infos[kEngineSlot].maxValue = static_cast<float>(infos[kEngineSlot].choices.size() - 1);
+    infos[kEngineSlot].defaultValue = 0.0f;
 
-    hostSlotInfo_[kThresholdSlot] = {.name = "Threshold",
-                                     .unit =
-                                         magda::technicalText(magda::TechnicalTextToken::Decibels),
-                                     .scale = magda::ParameterScale::Linear,
-                                     .minValue = -60.0f,
-                                     .maxValue = 0.0f,
-                                     .defaultValue = -18.0f};
-    hostSlotInfo_[kRatioSlot] = {.name = "Ratio",
-                                 .scale = magda::ParameterScale::Logarithmic,
-                                 .minValue = 1.0f,
-                                 .maxValue = 50.0f,
-                                 .defaultValue = 4.0f,
-                                 .scaleAnchor = 4.0f};
-    hostSlotInfo_[kAttackSlot] = {.name = "Attack",
-                                  .unit =
-                                      magda::technicalText(magda::TechnicalTextToken::Milliseconds),
-                                  .scale = magda::ParameterScale::Logarithmic,
-                                  .minValue = 0.1f,
-                                  .maxValue = 200.0f,
-                                  .defaultValue = 10.0f,
-                                  .scaleAnchor = 10.0f};
-    hostSlotInfo_[kReleaseSlot] = {
-        .name = "Release",
-        .unit = magda::technicalText(magda::TechnicalTextToken::Milliseconds),
-        .scale = magda::ParameterScale::Logarithmic,
-        .minValue = 5.0f,
-        .maxValue = 1000.0f,
-        .defaultValue = 120.0f,
-        .scaleAnchor = 100.0f};
-    hostSlotInfo_[kKneeSlot] = {.name = "Knee",
-                                .unit = magda::technicalText(magda::TechnicalTextToken::Decibels),
-                                .scale = magda::ParameterScale::Linear,
-                                .minValue = 0.0f,
-                                .maxValue = 24.0f,
-                                .defaultValue = 6.0f};
-    hostSlotInfo_[kMakeupSlot] = {.name = "Makeup",
-                                  .unit = magda::technicalText(magda::TechnicalTextToken::Decibels),
-                                  .scale = magda::ParameterScale::Linear,
-                                  .minValue = 0.0f,
-                                  .maxValue = 24.0f,
-                                  .defaultValue = 0.0f};
-    hostSlotInfo_[kMixSlot] = {.name = "Mix",
-                               .scale = magda::ParameterScale::Linear,
-                               .minValue = 0.0f,
-                               .maxValue = 1.0f,
-                               .defaultValue = 1.0f};
-    hostSlotInfo_[kOutputSlot] = {.name = "Output",
-                                  .unit = magda::technicalText(magda::TechnicalTextToken::Decibels),
-                                  .scale = magda::ParameterScale::Linear,
-                                  .minValue = -24.0f,
-                                  .maxValue = 12.0f,
-                                  .defaultValue = 0.0f};
+    infos[kThresholdSlot] = {.name = "Threshold",
+                             .unit = magda::technicalText(magda::TechnicalTextToken::Decibels),
+                             .scale = magda::ParameterScale::Linear,
+                             .minValue = -60.0f,
+                             .maxValue = 0.0f,
+                             .defaultValue = -18.0f};
+    infos[kRatioSlot] = {.name = "Ratio",
+                         .scale = magda::ParameterScale::Logarithmic,
+                         .minValue = 1.0f,
+                         .maxValue = 50.0f,
+                         .defaultValue = 4.0f,
+                         .scaleAnchor = 4.0f};
+    infos[kAttackSlot] = {.name = "Attack",
+                          .unit = magda::technicalText(magda::TechnicalTextToken::Milliseconds),
+                          .scale = magda::ParameterScale::Logarithmic,
+                          .minValue = 0.1f,
+                          .maxValue = 200.0f,
+                          .defaultValue = 10.0f,
+                          .scaleAnchor = 10.0f};
+    infos[kReleaseSlot] = {.name = "Release",
+                           .unit = magda::technicalText(magda::TechnicalTextToken::Milliseconds),
+                           .scale = magda::ParameterScale::Logarithmic,
+                           .minValue = 5.0f,
+                           .maxValue = 1000.0f,
+                           .defaultValue = 120.0f,
+                           .scaleAnchor = 100.0f};
+    infos[kKneeSlot] = {.name = "Knee",
+                        .unit = magda::technicalText(magda::TechnicalTextToken::Decibels),
+                        .scale = magda::ParameterScale::Linear,
+                        .minValue = 0.0f,
+                        .maxValue = 24.0f,
+                        .defaultValue = 6.0f};
+    infos[kMakeupSlot] = {.name = "Makeup",
+                          .unit = magda::technicalText(magda::TechnicalTextToken::Decibels),
+                          .scale = magda::ParameterScale::Linear,
+                          .minValue = 0.0f,
+                          .maxValue = 24.0f,
+                          .defaultValue = 0.0f};
+    infos[kMixSlot] = {.name = "Mix",
+                       .scale = magda::ParameterScale::Linear,
+                       .minValue = 0.0f,
+                       .maxValue = 1.0f,
+                       .defaultValue = 1.0f};
+    infos[kOutputSlot] = {.name = "Output",
+                          .unit = magda::technicalText(magda::TechnicalTextToken::Decibels),
+                          .scale = magda::ParameterScale::Linear,
+                          .minValue = -24.0f,
+                          .maxValue = 12.0f,
+                          .defaultValue = 0.0f};
 
-    hostSlotInfo_[kDetectorSlot].name = "Detector";
-    hostSlotInfo_[kDetectorSlot].scale = magda::ParameterScale::Discrete;
-    hostSlotInfo_[kDetectorSlot].choices = {"Peak", "RMS"};
-    hostSlotInfo_[kDetectorSlot].minValue = 0.0f;
-    hostSlotInfo_[kDetectorSlot].maxValue = 1.0f;
-    hostSlotInfo_[kDetectorSlot].defaultValue = 0.0f;
+    infos[kDetectorSlot].name = "Detector";
+    infos[kDetectorSlot].scale = magda::ParameterScale::Discrete;
+    infos[kDetectorSlot].choices = {"Peak", "RMS"};
+    infos[kDetectorSlot].minValue = 0.0f;
+    infos[kDetectorSlot].maxValue = 1.0f;
+    infos[kDetectorSlot].defaultValue = 0.0f;
 
-    hostSlotInfo_[kLinkSlot] = {.name = "Link",
-                                .scale = magda::ParameterScale::Linear,
-                                .minValue = 0.0f,
-                                .maxValue = 1.0f,
-                                .defaultValue = 1.0f};
-    hostSlotInfo_[kSidechainHpfSlot] = {.name = "SC HPF",
-                                        .unit =
-                                            magda::technicalText(magda::TechnicalTextToken::Hertz),
-                                        .scale = magda::ParameterScale::Logarithmic,
-                                        .minValue = 20.0f,
-                                        .maxValue = 500.0f,
-                                        .defaultValue = 20.0f,
-                                        .scaleAnchor = 120.0f};
-    hostSlotInfo_[kFbffSlot] = {.name = "FBFF",
-                                .scale = magda::ParameterScale::Linear,
-                                .minValue = 0.0f,
-                                .maxValue = 1.0f,
-                                .defaultValue = 0.5f};
-    hostSlotInfo_[kStyleSlot].name = "Style";
-    hostSlotInfo_[kStyleSlot].scale = magda::ParameterScale::Discrete;
-    hostSlotInfo_[kStyleSlot].choices = {"Pre", "Post"};
-    hostSlotInfo_[kStyleSlot].minValue = 0.0f;
-    hostSlotInfo_[kStyleSlot].maxValue = 1.0f;
-    hostSlotInfo_[kStyleSlot].defaultValue = 0.0f;
-    hostSlotInfo_[kAutogainSlot].name = "Autogain";
-    hostSlotInfo_[kAutogainSlot].scale = magda::ParameterScale::Discrete;
-    hostSlotInfo_[kAutogainSlot].choices = {"Off", "On"};
-    hostSlotInfo_[kAutogainSlot].minValue = 0.0f;
-    hostSlotInfo_[kAutogainSlot].maxValue = 1.0f;
-    hostSlotInfo_[kAutogainSlot].defaultValue = 0.0f;
+    infos[kLinkSlot] = {.name = "Link",
+                        .scale = magda::ParameterScale::Linear,
+                        .minValue = 0.0f,
+                        .maxValue = 1.0f,
+                        .defaultValue = 1.0f};
+    infos[kSidechainHpfSlot] = {.name = "SC HPF",
+                                .unit = magda::technicalText(magda::TechnicalTextToken::Hertz),
+                                .scale = magda::ParameterScale::Logarithmic,
+                                .minValue = 20.0f,
+                                .maxValue = 500.0f,
+                                .defaultValue = 20.0f,
+                                .scaleAnchor = 120.0f};
+    infos[kFbffSlot] = {.name = "FBFF",
+                        .scale = magda::ParameterScale::Linear,
+                        .minValue = 0.0f,
+                        .maxValue = 1.0f,
+                        .defaultValue = 0.5f};
+    infos[kStyleSlot].name = "Style";
+    infos[kStyleSlot].scale = magda::ParameterScale::Discrete;
+    infos[kStyleSlot].choices = {"Pre", "Post"};
+    infos[kStyleSlot].minValue = 0.0f;
+    infos[kStyleSlot].maxValue = 1.0f;
+    infos[kStyleSlot].defaultValue = 0.0f;
+    infos[kAutogainSlot].name = "Autogain";
+    infos[kAutogainSlot].scale = magda::ParameterScale::Discrete;
+    infos[kAutogainSlot].choices = {"Off", "On"};
+    infos[kAutogainSlot].minValue = 0.0f;
+    infos[kAutogainSlot].maxValue = 1.0f;
+    infos[kAutogainSlot].defaultValue = 0.0f;
 
-    juce::NormalisableRange<float> normalisedRange{0.0f, 1.0f};
-    auto* undoManager = getUndoManager();
-
-    for (int i = 0; i < kHostSlotCount; ++i) {
-        const auto& slot = hostSlotInfo_[i];
-        const juce::String id = "magda_compressor_" + slot.name.toLowerCase().replace(" ", "_");
-        const juce::Identifier identifier(id);
-        const auto info = parameterInfoForSlot(slot);
-        const float defaultNormalized =
-            magda::ParameterUtils::realToNormalized(slot.defaultValue, info);
-        hostCached_[i].referTo(state, identifier, undoManager, defaultNormalized);
-
-        auto param = addParam(
-            id, slot.name, normalisedRange,
-            [info](float normalized) {
-                const float real = magda::ParameterUtils::normalizedToReal(normalized, info);
-                return magda::ParameterUtils::formatValue(real, info);
-            },
-            [info](const juce::String& text) {
-                auto parsed = magda::ParameterUtils::parseValue(text, info);
-                if (parsed)
-                    return magda::ParameterUtils::realToNormalized(*parsed, info);
-                return 0.0f;
-            });
-        param->attachToCurrentValue(hostCached_[i]);
-        hostParams_[i] = param;
-    }
+    return infos;
 }
 
-void MagdaCompressorCompiledPlugin::initialise(const te::PluginInitialisationInfo& info) {
-    rebuildEngineState(static_cast<int>(info.sampleRate));
+void MagdaCompressorCompiledPlugin::beforeCompute(DeviceProcessContext& context, int engineIndex) {
+    const bool external = context.sidechainInputChannel >= 0;
 
-    int maxIn = 0, maxOut = 0;
-    for (const auto& e : engines_) {
-        maxIn = std::max(maxIn, e.numInputs);
-        maxOut = std::max(maxOut, e.numOutputs);
-    }
-    scratchIn_.setSize(maxIn, info.blockSizeSamples, false, true, true);
-    scratchOut_.setSize(maxOut, info.blockSizeSamples, false, true, true);
-    inPtrs_.assign(static_cast<size_t>(maxIn), nullptr);
-    outPtrs_.assign(static_cast<size_t>(maxOut), nullptr);
-}
+    // The hidden zone that tells the dsp to detect off the key rather than off
+    // its own input. Only the Clean engine has one; Glue has no external
+    // sidechain and simply yields null here.
+    if (auto* useSidechain = zoneForIdx(engineIndex, kUseSidechainHiddenSlot))
+        *useSidechain = external ? 1.0f : 0.0f;
 
-void MagdaCompressorCompiledPlugin::deinitialise() {
-    scratchIn_.setSize(0, 0);
-    scratchOut_.setSize(0, 0);
-    inPtrs_.clear();
-    outPtrs_.clear();
-}
-
-void MagdaCompressorCompiledPlugin::reset() {
-    for (auto& e : engines_)
-        if (e.dsp)
-            e.dsp->instanceClear();
-}
-
-void MagdaCompressorCompiledPlugin::applyToBuffer(const te::PluginRenderContext& fc) {
-    if (!fc.destBuffer || fc.bufferNumSamples <= 0)
-        return;
-
-    // Read all slot values up front (normalized 0..1, denormalized once).
-    auto realForSlot = [&](int slot) -> float {
-        const auto& s = hostSlotInfo_[static_cast<size_t>(slot)];
-        const auto info = parameterInfoForSlot(s);
-        const float norm = hostParams_[static_cast<size_t>(slot)]->getCurrentValue();
-        return magda::ParameterUtils::normalizedToReal(norm, info);
-    };
-
-    const float engineNorm = hostParams_[kEngineSlot]->getCurrentValue();
-    const int engineIndex = juce::jlimit(
-        0, kEngineCount - 1,
-        static_cast<int>(std::round(engineNorm * static_cast<float>(kEngineCount - 1))));
-    activeEngine_.store(engineIndex);
-
-    // Write shared zones into BOTH engines so an engine swap preserves the
-    // user's settings on first sample of the new engine.
-    for (int slot = 1; slot < kHostSlotCount; ++slot) {
-        const float real = realForSlot(slot);
-        for (auto& e : engines_) {
-            if (auto* zone = e.zones[static_cast<size_t>(slot)])
-                *zone = static_cast<FAUSTFLOAT>(real);
-        }
-    }
-
-    auto& active = engines_[static_cast<size_t>(engineIndex)];
-    if (active.useSidechainZone != nullptr)
-        *active.useSidechainZone = getSidechainSourceID().isValid() ? FAUSTFLOAT(1) : FAUSTFLOAT(0);
-
-    if (!active.dsp)
-        return;
-
-    const int numSamples = fc.bufferNumSamples;
-    const int startSample = fc.bufferStartSample;
-    const int hostChannels = fc.destBuffer->getNumChannels();
-    const int numInputs = active.numInputs;
-    const int numOutputs = active.numOutputs;
-    if (hostChannels <= 0 || numInputs <= 0 || numOutputs <= 0)
-        return;
-
-    if (scratchIn_.getNumChannels() < numInputs || scratchIn_.getNumSamples() < numSamples)
-        scratchIn_.setSize(numInputs, numSamples, false, true, true);
-    if (scratchOut_.getNumChannels() < numOutputs || scratchOut_.getNumSamples() < numSamples)
-        scratchOut_.setSize(numOutputs, numSamples, false, true, true);
-    if (static_cast<int>(inPtrs_.size()) < numInputs)
-        inPtrs_.resize(static_cast<size_t>(numInputs), nullptr);
-    if (static_cast<int>(outPtrs_.size()) < numOutputs)
-        outPtrs_.resize(static_cast<size_t>(numOutputs), nullptr);
-
-    float inputPeak = 0.0f;
-    float keyPeak = 0.0f;
-    const bool externalSidechain = getSidechainSourceID().isValid();
-
-    for (int ch = 0; ch < numInputs; ++ch) {
-        float* dst = scratchIn_.getWritePointer(ch);
-        if (ch < hostChannels) {
-            const float* src = fc.destBuffer->getReadPointer(ch, startSample);
-            std::copy(src, src + numSamples, dst);
-        } else {
-            std::fill(dst, dst + numSamples, 0.0f);
-        }
-        inPtrs_[static_cast<size_t>(ch)] = dst;
-
-        if (ch < 2) {
-            for (int i = 0; i < numSamples; ++i)
-                inputPeak = std::max(inputPeak, std::fabs(dst[i]));
-        }
-        if ((externalSidechain && ch == 2) || (!externalSidechain && ch < 2)) {
-            for (int i = 0; i < numSamples; ++i)
-                keyPeak = std::max(keyPeak, std::fabs(dst[i]));
-        }
-    }
-    for (int ch = 0; ch < numOutputs; ++ch) {
-        outPtrs_[static_cast<size_t>(ch)] = (ch < hostChannels)
-                                                ? fc.destBuffer->getWritePointer(ch, startSample)
-                                                : scratchOut_.getWritePointer(ch);
-    }
-
-    active.dsp->compute(numSamples, inPtrs_.data(), outPtrs_.data());
-
-    float outputPeak = 0.0f;
-    const int channelsToSanitise = std::min(hostChannels, numOutputs);
-    for (int ch = 0; ch < channelsToSanitise; ++ch) {
-        float* out = fc.destBuffer->getWritePointer(ch, startSample);
-        for (int i = 0; i < numSamples; ++i) {
-            const float sample = out[i];
-            out[i] = std::isfinite(sample) ? juce::jlimit(-16.0f, 16.0f, sample) : 0.0f;
-            outputPeak = std::max(outputPeak, std::fabs(out[i]));
-        }
-    }
-    for (int ch = numOutputs; ch < hostChannels; ++ch)
-        fc.destBuffer->clear(ch, startSample, numSamples);
-
-    const float thresholdDb = realForSlot(kThresholdSlot);
-    const float ratio = realForSlot(kRatioSlot);
-    const float kneeDb = realForSlot(kKneeSlot);
-    const float keyDb = ampToDb(keyPeak);
+    const float inputPeak =
+        peakOfChannels(*context.audio, 0, 2, context.startSample, context.numSamples);
+    const float keyPeak = external ? peakOfChannels(*context.audio, context.sidechainInputChannel,
+                                                    context.sidechainInputChannel + 1,
+                                                    context.startSample, context.numSamples)
+                                   : inputPeak;
 
     inputPeakDb_.store(ampToDb(inputPeak), std::memory_order_relaxed);
-    keyPeakDb_.store(keyDb, std::memory_order_relaxed);
-    outputPeakDb_.store(ampToDb(outputPeak), std::memory_order_relaxed);
-    gainReductionDb_.store(gainReductionForLevel(keyDb, thresholdDb, ratio, kneeDb),
+    keyPeakDb_.store(ampToDb(keyPeak), std::memory_order_relaxed);
+    usingExternalSidechain_.store(external, std::memory_order_relaxed);
+
+    const float keyDb = ampToDb(keyPeak);
+    gainReductionDb_.store(gainReductionForLevel(keyDb, slotDisplayValue(kThresholdSlot),
+                                                 slotDisplayValue(kRatioSlot),
+                                                 slotDisplayValue(kKneeSlot)),
                            std::memory_order_relaxed);
-    usingExternalSidechain_.store(externalSidechain, std::memory_order_relaxed);
 }
 
-te::AutomatableParameter* MagdaCompressorCompiledPlugin::getSlotParameter(int slotIndex) const {
-    if (slotIndex < 0 || slotIndex >= kHostSlotCount)
-        return nullptr;
-    return hostParams_[static_cast<size_t>(slotIndex)].get();
-}
-
-const MagdaCompressorCompiledPlugin::HostSlotInfo& MagdaCompressorCompiledPlugin::getSlotInfo(
-    int slotIndex) const {
-    static const HostSlotInfo kEmpty;
-    if (slotIndex < 0 || slotIndex >= kHostSlotCount)
-        return kEmpty;
-    return hostSlotInfo_[static_cast<size_t>(slotIndex)];
-}
-
-int MagdaCompressorCompiledPlugin::activeEngineIndex() const {
-    return activeEngine_.load(std::memory_order_relaxed);
-}
-
-float MagdaCompressorCompiledPlugin::displayValueToNativeValue(int slotIndex,
-                                                               float displayValue) const {
-    if (slotIndex < 0 || slotIndex >= kHostSlotCount)
-        return displayValue;
-    const auto info = parameterInfoForSlot(hostSlotInfo_[static_cast<size_t>(slotIndex)]);
-    return magda::ParameterUtils::realToNormalized(displayValue, info);
-}
-
-float MagdaCompressorCompiledPlugin::nativeValueToDisplayValue(int slotIndex,
-                                                               float nativeValue) const {
-    if (slotIndex < 0 || slotIndex >= kHostSlotCount)
-        return nativeValue;
-    const auto info = parameterInfoForSlot(hostSlotInfo_[static_cast<size_t>(slotIndex)]);
-    return magda::ParameterUtils::normalizedToReal(nativeValue, info);
+void MagdaCompressorCompiledPlugin::afterCompute(DeviceProcessContext& context, int engineIndex) {
+    juce::ignoreUnused(engineIndex);
+    outputPeakDb_.store(
+        ampToDb(peakOfChannels(*context.audio, 0, 2, context.startSample, context.numSamples)),
+        std::memory_order_relaxed);
 }
 
 constexpr AliasSpec kAliases[] = {
@@ -544,9 +236,8 @@ const CompiledPluginSpec& getMagdaCompressorSpec() {
             "sidechain HPF, external audio sidechain, parallel mix, output safety limiting.\n"
             "<b>Glue</b>: Brouns FBFF compressor with exposed character controls "
             "(Detector Peak/RMS, Style Pre/Post, FBFF blend). No external sidechain.",
-        .createPlugin = [](const DevicePluginCreationContext& context) -> DevicePluginPtr {
-            return tracktion_adapter::pluginHandle(
-                new MagdaCompressorCompiledPlugin(tracktion_adapter::creationInfo(context)));
+        .createDevice = [](const DevicePluginCreationContext&) -> std::unique_ptr<MagdaDevice> {
+            return std::make_unique<MagdaCompressorCompiledPlugin>();
         },
         .aliases = kAliases,
         .aliasCount = static_cast<int>(sizeof(kAliases) / sizeof(kAliases[0])),

--- a/magda/daw/audio/plugins/compiled/MagdaCompressorCompiledPlugin.hpp
+++ b/magda/daw/audio/plugins/compiled/MagdaCompressorCompiledPlugin.hpp
@@ -1,15 +1,9 @@
 #pragma once
 
-#include <tracktion_engine/tracktion_engine.h>
-
-#include <array>
 #include <atomic>
-#include <memory>
 #include <vector>
 
-#include "../FaustParamPool.hpp"
-#include "core/ParameterInfo.hpp"
-#include "plugins/compiled/tracktion/CompiledFaustTracktionAdapter.hpp"
+#include "plugins/compiled/MagdaCompiledEffect.hpp"
 
 class dsp;
 
@@ -32,50 +26,12 @@ namespace magda::daw::audio::compiled {
  * user's settings. Engine-specific zones (SC HPF on Clean, FBFF/Style on
  * Glue) are written only when present on each engine.
  */
-class MagdaCompressorCompiledPlugin : public te::Plugin, public ICompiledFaustPlugin {
+class MagdaCompressorCompiledPlugin : public MagdaCompiledEffect {
   public:
     static const char* xmlTypeName;
 
-    explicit MagdaCompressorCompiledPlugin(const te::PluginCreationInfo& info);
-    ~MagdaCompressorCompiledPlugin() override;
+    MagdaCompressorCompiledPlugin();
 
-    juce::String getName() const override;
-    juce::String getPluginType() override;
-    juce::String getShortName(int) override;
-    juce::String getSelectableDescription() override;
-
-    void initialise(const te::PluginInitialisationInfo& info) override;
-    void deinitialise() override;
-    void reset() override;
-    void applyToBuffer(const te::PluginRenderContext& fc) override;
-
-    bool takesMidiInput() override {
-        return false;
-    }
-    bool takesAudioInput() override {
-        return true;
-    }
-    bool isSynth() override {
-        return false;
-    }
-    bool canSidechain() override {
-        return true;
-    }
-    int getNumOutputChannelsGivenInputs(int) override {
-        return 2;
-    }
-    void getChannelNames(juce::StringArray* ins, juce::StringArray* outs) override;
-    bool producesAudioWhenNoAudioInput() override {
-        return false;
-    }
-    double getTailLength() const override {
-        return 0.0;
-    }
-
-    // Slot ordering — engine first (top-level mode switch), then the
-    // compressor surface, then engine-specific tail. DSP `[idx:N]` values
-    // mirror these (with idx 0 reserved for Engine, which lives only in the
-    // wrapper).
     static constexpr int kEngineSlot = 0;
     static constexpr int kThresholdSlot = 1;
     static constexpr int kRatioSlot = 2;
@@ -93,15 +49,10 @@ class MagdaCompressorCompiledPlugin : public te::Plugin, public ICompiledFaustPl
     static constexpr int kAutogainSlot = 14;
     static constexpr int kHostSlotCount = 15;
     static constexpr int kUseSidechainHiddenSlot = 63;
-
     enum class CompressorEngine { Clean = 0, Glue = 1 };
     static constexpr int kEngineCount = 2;
 
-    te::AutomatableParameter* getSlotParameter(int slotIndex) const;
-
-    float displayValueToNativeValue(int slotIndex, float displayValue) const;
-    float nativeValueToDisplayValue(int slotIndex, float nativeValue) const;
-
+    // Audio-thread metering taps for the transfer-curve view.
     float getInputPeakDb() const {
         return inputPeakDb_.load(std::memory_order_relaxed);
     }
@@ -118,55 +69,41 @@ class MagdaCompressorCompiledPlugin : public te::Plugin, public ICompiledFaustPl
         return usingExternalSidechain_.load(std::memory_order_relaxed);
     }
 
-    int activeEngineIndex() const;
+    juce::String devicePluginId() const override {
+        return xmlTypeName;
+    }
+    juce::String deviceName() const override {
+        return "Compressor";
+    }
+    juce::String deviceShortName() const override {
+        return "Comp";
+    }
 
-    using HostSlotInfo = CompiledHostSlotInfo;
-    const HostSlotInfo& getSlotInfo(int slotIndex) const;
-
-    // ICompiledFaustPlugin
-    int hostSlotCount() const override {
-        return kHostSlotCount;
+  protected:
+    ::dsp* createEngineDsp(int engineIndex) const override;
+    std::vector<HostSlotInfo> slotInfos() const override;
+    const char* slotIdPrefix() const override {
+        return "magda_compressor_";
     }
-    const CompiledHostSlotInfo& hostSlotInfo(int slotIndex) const override {
-        return getSlotInfo(slotIndex);
+    int engineCount() const override {
+        return kEngineCount;
     }
-    DeviceParameterHandle hostSlotParameter(int slotIndex) const override {
-        return tracktion_adapter::parameterHandle(getSlotParameter(slotIndex));
+    int engineSlot() const override {
+        return kEngineSlot;
     }
-    float displayToNormalized(int slotIndex, float displayValue) const override {
-        return displayValueToNativeValue(slotIndex, displayValue);
+    bool wantsSidechain() const override {
+        return true;
     }
-    float normalizedToDisplay(int slotIndex, float normalizedValue) const override {
-        return nativeValueToDisplayValue(slotIndex, normalizedValue);
+    int outputChannelCount() const override {
+        return 2;
     }
+    int inputChannelCount() const override {
+        return 3;  // Left, Right, and the key.
+    }
+    void beforeCompute(DeviceProcessContext& context, int engineIndex) override;
+    void afterCompute(DeviceProcessContext& context, int engineIndex) override;
 
   private:
-    void buildHostParameters();
-    void rebuildEngineState(int sampleRate);
-
-    // Per-engine state. zones_[slotIndex] is the FAUSTFLOAT* into this
-    // engine's DSP for that host slot, or null if the engine doesn't expose
-    // that slot (Glue has no SC HPF; Clean has no FBFF/Style; neither exposes
-    // Engine).
-    struct EngineState {
-        std::unique_ptr<::dsp> dsp;
-        std::array<FAUSTFLOAT*, kHostSlotCount> zones{};
-        FAUSTFLOAT* useSidechainZone = nullptr;
-        int numInputs = 0;
-        int numOutputs = 0;
-    };
-    std::array<EngineState, kEngineCount> engines_;
-    std::atomic<int> activeEngine_{0};
-
-    std::array<HostSlotInfo, kHostSlotCount> hostSlotInfo_;
-    std::array<te::AutomatableParameter::Ptr, kHostSlotCount> hostParams_;
-    std::array<juce::CachedValue<float>, kHostSlotCount> hostCached_;
-
-    juce::AudioBuffer<float> scratchIn_;
-    juce::AudioBuffer<float> scratchOut_;
-    std::vector<float*> inPtrs_;
-    std::vector<float*> outPtrs_;
-
     std::atomic<float> inputPeakDb_{-120.0f};
     std::atomic<float> keyPeakDb_{-120.0f};
     std::atomic<float> outputPeakDb_{-120.0f};

--- a/magda/daw/audio/plugins/compiled/MagdaDelayCompiledPlugin.cpp
+++ b/magda/daw/audio/plugins/compiled/MagdaDelayCompiledPlugin.cpp
@@ -1,467 +1,97 @@
 #include "plugins/compiled/MagdaDelayCompiledPlugin.hpp"
 
-#include <algorithm>
-#include <cmath>
-#include <map>
-
-#include "core/ParameterUtils.hpp"
+#include "core/ParameterInfo.hpp"
 #include "faust/dsp/dsp.h"
 #include "faust/gui/UI.h"
 #include "faust/gui/meta.h"
 #include "magda_delay.generated.cpp"
-#include "plugins/FaustMetadataParser.hpp"
-#include "plugins/FaustParamInfo.hpp"
 #include "plugins/compiled/CompiledPluginRegistry.hpp"
-#include "plugins/tracktion/TracktionDeviceAdapters.hpp"
 
 namespace magda::daw::audio::compiled {
 
 const char* MagdaDelayCompiledPlugin::xmlTypeName = "magda_delay";
 
-namespace {
-
-// idx-based harvest, identical pattern to the saturator. Same ControlMetadata
-// / parseFaustLabel helpers — keeps the harvest logic uniform across compiled
-// plugins so a future refactor can pull it into a shared file.
-struct DelayHarvest {
-    struct Control {
-        int idx = -1;
-        FaustParamSlot::Kind kind = FaustParamSlot::Kind::Continuous;
-        FAUSTFLOAT* zone = nullptr;
-        std::vector<std::pair<float, juce::String>> choices;
-        // Gate condition harvested from `[gate:N]` / `[gate:!N]` — copied
-        // through to ParameterInfo so the layout greys out cells whose
-        // enable condition is not met (Time when Sync is on, Division
-        // when Sync is off).
-        int gateSlotIndex = -1;
-        bool gateNegated = false;
-    };
-    std::vector<Control> controls;
-};
-
-class DelayHarvester : public ::UI {
-  public:
-    DelayHarvest harvest;
-
-    void openTabBox(const char*) override {}
-    void openHorizontalBox(const char*) override {}
-    void openVerticalBox(const char*) override {}
-    void closeBox() override {}
-
-    void addButton(const char* label, FAUSTFLOAT* zone) override {
-        emitControl(FaustParamSlot::Kind::Boolean, label, zone);
-    }
-    void addCheckButton(const char* label, FAUSTFLOAT* zone) override {
-        emitControl(FaustParamSlot::Kind::Boolean, label, zone);
-    }
-    void addVerticalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT, FAUSTFLOAT, FAUSTFLOAT,
-                           FAUSTFLOAT) override {
-        emitControl(FaustParamSlot::Kind::Continuous, label, zone);
-    }
-    void addHorizontalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT, FAUSTFLOAT,
-                             FAUSTFLOAT, FAUSTFLOAT) override {
-        emitControl(FaustParamSlot::Kind::Continuous, label, zone);
-    }
-    void addNumEntry(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT, FAUSTFLOAT, FAUSTFLOAT,
-                     FAUSTFLOAT) override {
-        emitControl(FaustParamSlot::Kind::Continuous, label, zone);
-    }
-    void addHorizontalBargraph(const char*, FAUSTFLOAT*, FAUSTFLOAT, FAUSTFLOAT) override {}
-    void addVerticalBargraph(const char*, FAUSTFLOAT*, FAUSTFLOAT, FAUSTFLOAT) override {}
-    void addSoundfile(const char*, const char*, Soundfile**) override {}
-
-    void declare(FAUSTFLOAT* zone, const char* key, const char* value) override {
-        if (zone == nullptr)
-            return;
-        const auto k = juce::String::fromUTF8(key != nullptr ? key : "").toLowerCase();
-        const auto v = juce::String::fromUTF8(value != nullptr ? value : "");
-        applyFaustAnnotation(k, v, pendingByZone_[zone]);
-    }
-
-  private:
-    void emitControl(FaustParamSlot::Kind kind, const char* rawLabel, FAUSTFLOAT* zone) {
-        const auto parsed =
-            parseFaustLabel(juce::String::fromUTF8(rawLabel != nullptr ? rawLabel : ""));
-        ControlMetadata merged = parsed.metadata;
-        if (zone != nullptr) {
-            if (auto it = pendingByZone_.find(zone); it != pendingByZone_.end()) {
-                mergeFaustMetadata(merged, it->second);
-                pendingByZone_.erase(it);
-            }
-        }
-
-        DelayHarvest::Control c;
-        c.idx = merged.slotIndex;
-        c.kind = merged.isChoiceStyle() ? FaustParamSlot::Kind::Discrete : kind;
-        c.zone = zone;
-        c.choices = merged.menuChoices;
-        c.gateSlotIndex = merged.gateSlotIndex;
-        c.gateNegated = merged.gateNegated;
-        harvest.controls.push_back(std::move(c));
-    }
-
-    std::map<FAUSTFLOAT*, ControlMetadata> pendingByZone_;
-};
-
-const DelayHarvest::Control* findByIdx(const DelayHarvest& h, int idx) {
-    for (const auto& c : h.controls)
-        if (c.idx == idx)
-            return &c;
-    return nullptr;
+MagdaDelayCompiledPlugin::MagdaDelayCompiledPlugin() {
+    initEffect();
 }
 
-}  // namespace
-
-MagdaDelayCompiledPlugin::MagdaDelayCompiledPlugin(const te::PluginCreationInfo& info)
-    : te::Plugin(info) {
-    dsp_ = std::make_unique<MagdaDelayDsp>();
-    constexpr int kProvisionalSampleRate = 44100;
-    rebuildEngineState(kProvisionalSampleRate);
-    buildHostParameters();
+::dsp* MagdaDelayCompiledPlugin::createEngineDsp(int) const {
+    return new MagdaDelayDsp();
 }
 
-MagdaDelayCompiledPlugin::~MagdaDelayCompiledPlugin() {
-    notifyListenersOfDeletion();
-    for (auto& p : hostParams_)
-        if (p)
-            p->detachFromCurrentValue();
-}
-
-juce::String MagdaDelayCompiledPlugin::getName() const {
-    return "Delay";
-}
-juce::String MagdaDelayCompiledPlugin::getPluginType() {
-    return xmlTypeName;
-}
-juce::String MagdaDelayCompiledPlugin::getShortName(int) {
-    return "Delay";
-}
-juce::String MagdaDelayCompiledPlugin::getSelectableDescription() {
-    return "Delay";
-}
-
-void MagdaDelayCompiledPlugin::rebuildEngineState(int sampleRate) {
-    if (!dsp_)
-        return;
-    dsp_->init(sampleRate);
-    numInputs_ = dsp_->getNumInputs();
-    numOutputs_ = dsp_->getNumOutputs();
-
-    DelayHarvester harvester;
-    dsp_->buildUserInterface(&harvester);
-
-    zones_.fill(nullptr);
-    bpmZone_ = nullptr;
-    divisionChoiceValues_.clear();
-    divisionChoiceLabels_.clear();
-
-    for (int i = 0; i < kHostSlotCount; ++i) {
-        harvestedGates_[static_cast<size_t>(i)] = {-1, false};
-        if (auto* c = findByIdx(harvester.harvest, i)) {
-            zones_[static_cast<size_t>(i)] = c->zone;
-            // Stash the harvested gate aside; buildHostParameters wipes
-            // hostSlotInfo via designated initializers, so we re-apply at
-            // the end of that function instead of here.
-            harvestedGates_[static_cast<size_t>(i)] = {c->gateSlotIndex, c->gateNegated};
-        }
-    }
-    if (auto* c = findByIdx(harvester.harvest, kBpmSlot))
-        bpmZone_ = c->zone;
-
-    if (auto* c = findByIdx(harvester.harvest, kDivisionSlot)) {
-        auto sorted = c->choices;
-        std::sort(sorted.begin(), sorted.end(),
-                  [](const auto& a, const auto& b) { return a.first < b.first; });
-        divisionChoiceValues_.reserve(sorted.size());
-        divisionChoiceLabels_.reserve(sorted.size());
-        for (const auto& choice : sorted) {
-            divisionChoiceValues_.push_back(choice.first);
-            divisionChoiceLabels_.push_back(choice.second);
-        }
-    }
-}
-
-void MagdaDelayCompiledPlugin::buildHostParameters() {
+std::vector<MagdaDelayCompiledPlugin::HostSlotInfo> MagdaDelayCompiledPlugin::slotInfos() const {
+    std::vector<HostSlotInfo> infos(kHostSlotCount);
+    // The Division choices are the dsp's own [style:menu{...}]: the labels
+    // read as musical divisions and the values are the quarter-note
+    // multipliers the zone wants, so neither list is restated here.
+    const auto divisionValues = menuValuesForIdx(kDivisionSlot);
     // Slot 0: Time (ms, 1..2000). Faust smooths internally; host slot is
     // greyed when Sync is on (gateSlotIndex below).
-    hostSlotInfo_[kTimeSlot] = {.name = "Time",
-                                .unit =
-                                    magda::technicalText(magda::TechnicalTextToken::Milliseconds),
-                                .scale = magda::ParameterScale::Linear,
-                                .minValue = 1.0f,
-                                .maxValue = 2000.0f,
-                                .defaultValue = 250.0f};
+    infos[kTimeSlot] = {.name = "Time",
+                        .unit = magda::technicalText(magda::TechnicalTextToken::Milliseconds),
+                        .scale = magda::ParameterScale::Linear,
+                        .minValue = 1.0f,
+                        .maxValue = 2000.0f,
+                        .defaultValue = 250.0f};
     // Slot 1: Division (discrete menu). Choices populated from the harvest
     // at construction; we don't hard-code names here so the [style:menu{...}]
     // in the DSP stays the source of truth.
-    hostSlotInfo_[kDivisionSlot].name = "Division";
-    hostSlotInfo_[kDivisionSlot].scale = magda::ParameterScale::Discrete;
-    hostSlotInfo_[kDivisionSlot].minValue = 0.0f;
-    hostSlotInfo_[kDivisionSlot].maxValue = 0.0f;  // filled in below from divisionChoiceValues_
-    hostSlotInfo_[kDivisionSlot].defaultValue = 0.0f;
+    infos[kDivisionSlot].name = "Division";
+    infos[kDivisionSlot].scale = magda::ParameterScale::Discrete;
+    infos[kDivisionSlot].minValue = 0.0f;
+    infos[kDivisionSlot].maxValue = 0.0f;  // filled in below from divisionValues
+    infos[kDivisionSlot].defaultValue = 0.0f;
     // Slot 2: Sync (boolean checkbox)
-    hostSlotInfo_[kSyncSlot] = {.name = "Sync",
-                                .scale = magda::ParameterScale::Discrete,
-                                .minValue = 0.0f,
-                                .maxValue = 1.0f,
-                                .defaultValue = 0.0f,
-                                .scaleAnchor = std::numeric_limits<float>::quiet_NaN(),
-                                .choices = {"Off", "On"}};
+    infos[kSyncSlot] = {.name = "Sync",
+                        .scale = magda::ParameterScale::Discrete,
+                        .minValue = 0.0f,
+                        .maxValue = 1.0f,
+                        .defaultValue = 0.0f,
+                        .scaleAnchor = std::numeric_limits<float>::quiet_NaN(),
+                        .choices = {"Off", "On"}};
     // Slot 3: Feedback (0..0.95, the DSP's safety ceiling)
-    hostSlotInfo_[kFeedbackSlot] = {.name = "Feedback",
-                                    .scale = magda::ParameterScale::Linear,
-                                    .minValue = 0.0f,
-                                    .maxValue = 0.95f,
-                                    .defaultValue = 0.45f};
+    infos[kFeedbackSlot] = {.name = "Feedback",
+                            .scale = magda::ParameterScale::Linear,
+                            .minValue = 0.0f,
+                            .maxValue = 0.95f,
+                            .defaultValue = 0.45f};
     // Slot 4: Mix (0..1)
-    hostSlotInfo_[kMixSlot] = {.name = "Mix",
-                               .scale = magda::ParameterScale::Linear,
-                               .minValue = 0.0f,
-                               .maxValue = 1.0f,
-                               .defaultValue = 0.35f};
+    infos[kMixSlot] = {.name = "Mix",
+                       .scale = magda::ParameterScale::Linear,
+                       .minValue = 0.0f,
+                       .maxValue = 1.0f,
+                       .defaultValue = 0.35f};
     // Slot 5: Tone (-1..1 tilt)
-    hostSlotInfo_[kToneSlot] = {.name = "Tone",
-                                .scale = magda::ParameterScale::Linear,
-                                .minValue = -1.0f,
-                                .maxValue = 1.0f,
-                                .defaultValue = 0.0f};
+    infos[kToneSlot] = {.name = "Tone",
+                        .scale = magda::ParameterScale::Linear,
+                        .minValue = -1.0f,
+                        .maxValue = 1.0f,
+                        .defaultValue = 0.0f};
     // Slot 6: Cross (0..1 ping-pong amount)
-    hostSlotInfo_[kCrossSlot] = {.name = "Cross",
-                                 .scale = magda::ParameterScale::Linear,
-                                 .minValue = 0.0f,
-                                 .maxValue = 1.0f,
-                                 .defaultValue = 0.0f};
+    infos[kCrossSlot] = {.name = "Cross",
+                         .scale = magda::ParameterScale::Linear,
+                         .minValue = 0.0f,
+                         .maxValue = 1.0f,
+                         .defaultValue = 0.0f};
 
     // Division choice list comes from the DSP harvest. Use the Faust-side
     // labels ("1/4", "1/8.", "1/16T") rather than stringified floats so the
     // dropdown reads as musical divisions; the underlying float values stay
-    // in divisionChoiceValues_ for the audio-side mapping in applyToBuffer.
-    if (!divisionChoiceValues_.empty()) {
-        const int n = static_cast<int>(divisionChoiceValues_.size());
-        hostSlotInfo_[kDivisionSlot].choices = divisionChoiceLabels_;
-        hostSlotInfo_[kDivisionSlot].maxValue = static_cast<float>(n - 1);
+    // in divisionValues for the audio-side mapping in applyToBuffer.
+    if (!divisionValues.empty()) {
+        const int n = static_cast<int>(divisionValues.size());
+        infos[kDivisionSlot].choices = menuLabelsForIdx(kDivisionSlot);
+        infos[kDivisionSlot].maxValue = static_cast<float>(n - 1);
         // Default to "1/4" if it's in the set (Faust value 1.0); otherwise 0.
         for (int i = 0; i < n; ++i) {
-            if (std::abs(divisionChoiceValues_[static_cast<size_t>(i)] - 1.0f) < 1e-3f) {
-                hostSlotInfo_[kDivisionSlot].defaultValue = static_cast<float>(i);
+            if (std::abs(divisionValues[static_cast<size_t>(i)] - 1.0f) < 1e-3f) {
+                infos[kDivisionSlot].defaultValue = static_cast<float>(i);
                 break;
             }
         }
     }
 
-    juce::NormalisableRange<float> normalisedRange{0.0f, 1.0f};
-    auto* undoManager = getUndoManager();
-
-    auto buildInfo = [](const HostSlotInfo& s) {
-        magda::ParameterInfo info;
-        info.minValue = s.minValue;
-        info.maxValue = s.maxValue;
-        info.defaultValue = s.defaultValue;
-        info.unit = s.unit;
-        info.scale = s.scale;
-        if (std::isfinite(s.scaleAnchor))
-            info.scaleAnchor = s.scaleAnchor;
-        info.choices = s.choices;
-        return info;
-    };
-
-    for (int i = 0; i < kHostSlotCount; ++i) {
-        const auto& slot = hostSlotInfo_[i];
-        const juce::String id = "magda_delay_" + slot.name.toLowerCase().replace(" ", "_");
-        const juce::Identifier identifier(id);
-        const auto info = buildInfo(slot);
-        const float defaultNormalized =
-            magda::ParameterUtils::realToNormalized(slot.defaultValue, info);
-        hostCached_[i].referTo(state, identifier, undoManager, defaultNormalized);
-
-        auto param = addParam(
-            id, slot.name, normalisedRange,
-            [info](float normalized) {
-                const float real = magda::ParameterUtils::normalizedToReal(normalized, info);
-                return magda::ParameterUtils::formatValue(real, info);
-            },
-            [info](const juce::String& text) {
-                auto parsed = magda::ParameterUtils::parseValue(text, info);
-                if (parsed)
-                    return magda::ParameterUtils::realToNormalized(*parsed, info);
-                return 0.0f;
-            });
-        param->attachToCurrentValue(hostCached_[i]);
-        hostParams_[i] = param;
-    }
-
-    // Re-apply the gate annotations the harvest captured. Each slot
-    // assignment above used designated initialisers that reset every
-    // field including gateSlotIndex / gateNegated, so we patch them in
-    // here from the snapshot rebuildEngineState saved.
-    for (int i = 0; i < kHostSlotCount; ++i) {
-        hostSlotInfo_[static_cast<size_t>(i)].gateSlotIndex =
-            harvestedGates_[static_cast<size_t>(i)].slotIndex;
-        hostSlotInfo_[static_cast<size_t>(i)].gateNegated =
-            harvestedGates_[static_cast<size_t>(i)].negated;
-    }
-}
-
-void MagdaDelayCompiledPlugin::initialise(const te::PluginInitialisationInfo& info) {
-    rebuildEngineState(static_cast<int>(info.sampleRate));
-    scratchIn_.setSize(numInputs_, info.blockSizeSamples, false, true, true);
-    scratchOut_.setSize(numOutputs_, info.blockSizeSamples, false, true, true);
-    inPtrs_.assign(static_cast<size_t>(numInputs_), nullptr);
-    outPtrs_.assign(static_cast<size_t>(numOutputs_), nullptr);
-}
-
-void MagdaDelayCompiledPlugin::deinitialise() {
-    scratchIn_.setSize(0, 0);
-    scratchOut_.setSize(0, 0);
-    inPtrs_.clear();
-    outPtrs_.clear();
-}
-
-void MagdaDelayCompiledPlugin::reset() {
-    if (dsp_)
-        dsp_->instanceClear();
-}
-
-void MagdaDelayCompiledPlugin::applyToBuffer(const te::PluginRenderContext& fc) {
-    if (!fc.destBuffer || fc.bufferNumSamples <= 0 || !dsp_)
-        return;
-
-    auto writeContinuous = [&](int slot) {
-        if (auto* zone = zones_[static_cast<size_t>(slot)]) {
-            const auto& s = hostSlotInfo_[static_cast<size_t>(slot)];
-            magda::ParameterInfo info;
-            info.minValue = s.minValue;
-            info.maxValue = s.maxValue;
-            info.scale = s.scale;
-            if (std::isfinite(s.scaleAnchor))
-                info.scaleAnchor = s.scaleAnchor;
-            const float norm = hostParams_[static_cast<size_t>(slot)]->getCurrentValue();
-            *zone = static_cast<FAUSTFLOAT>(magda::ParameterUtils::normalizedToReal(norm, info));
-        }
-    };
-    writeContinuous(kTimeSlot);
-    writeContinuous(kFeedbackSlot);
-    writeContinuous(kMixSlot);
-    writeContinuous(kToneSlot);
-    writeContinuous(kCrossSlot);
-
-    // Sync: 0/1 boolean. Host param is normalized 0..1 with two choices,
-    // so >= 0.5 means On.
-    if (auto* z = zones_[kSyncSlot])
-        *z = hostParams_[kSyncSlot]->getCurrentValue() >= 0.5f ? FAUSTFLOAT(1) : FAUSTFLOAT(0);
-
-    // Division: the host param picks an index 0..N-1; map to the Faust
-    // choice value via divisionChoiceValues_, same idiom the saturator
-    // uses for its mode dropdown.
-    if (auto* z = zones_[kDivisionSlot]; z && !divisionChoiceValues_.empty()) {
-        const float norm = hostParams_[kDivisionSlot]->getCurrentValue();
-        const int count = static_cast<int>(divisionChoiceValues_.size());
-        const int idx = juce::jlimit(
-            0, count - 1, static_cast<int>(std::round(norm * static_cast<float>(count - 1))));
-        *z = static_cast<FAUSTFLOAT>(divisionChoiceValues_[static_cast<size_t>(idx)]);
-    }
-
-    // Project tempo: pull the live BPM from TE's transport into the
-    // hidden BPM zone every block. Same ProjectTempo plumbing the
-    // FaustPlugin uses for interpreted DSPs — we just bypass the pool.
-    // Also publish into currentBpm_ so the UI curve view can draw a
-    // beat grid in sync mode without re-querying the tempo sequence
-    // off the message thread.
-    const double bpm = edit.tempoSequence.getBpmAt(fc.editTime.getStart());
-    currentBpm_.store(static_cast<float>(bpm), std::memory_order_relaxed);
-    if (bpmZone_)
-        *bpmZone_ = static_cast<FAUSTFLOAT>(bpm);
-
-    const int numSamples = fc.bufferNumSamples;
-    const int startSample = fc.bufferStartSample;
-    const int hostChannels = fc.destBuffer->getNumChannels();
-    if (hostChannels <= 0 || numInputs_ <= 0 || numOutputs_ <= 0)
-        return;
-
-    if (scratchIn_.getNumChannels() < numInputs_ || scratchIn_.getNumSamples() < numSamples)
-        scratchIn_.setSize(numInputs_, numSamples, false, true, true);
-    if (scratchOut_.getNumChannels() < numOutputs_ || scratchOut_.getNumSamples() < numSamples)
-        scratchOut_.setSize(numOutputs_, numSamples, false, true, true);
-    if (static_cast<int>(inPtrs_.size()) < numInputs_)
-        inPtrs_.resize(static_cast<size_t>(numInputs_), nullptr);
-    if (static_cast<int>(outPtrs_.size()) < numOutputs_)
-        outPtrs_.resize(static_cast<size_t>(numOutputs_), nullptr);
-
-    for (int ch = 0; ch < numInputs_; ++ch) {
-        float* dst = scratchIn_.getWritePointer(ch);
-        if (ch < hostChannels) {
-            const float* src = fc.destBuffer->getReadPointer(ch, startSample);
-            std::copy(src, src + numSamples, dst);
-        } else {
-            std::fill(dst, dst + numSamples, 0.0f);
-        }
-        inPtrs_[static_cast<size_t>(ch)] = dst;
-    }
-    for (int ch = 0; ch < numOutputs_; ++ch) {
-        outPtrs_[static_cast<size_t>(ch)] = (ch < hostChannels)
-                                                ? fc.destBuffer->getWritePointer(ch, startSample)
-                                                : scratchOut_.getWritePointer(ch);
-    }
-
-    dsp_->compute(numSamples, inPtrs_.data(), outPtrs_.data());
-
-    const int channelsToSanitise = std::min(hostChannels, numOutputs_);
-    for (int ch = 0; ch < channelsToSanitise; ++ch) {
-        float* out = fc.destBuffer->getWritePointer(ch, startSample);
-        for (int i = 0; i < numSamples; ++i) {
-            const float sample = out[i];
-            out[i] = std::isfinite(sample) ? juce::jlimit(-16.0f, 16.0f, sample) : 0.0f;
-        }
-    }
-}
-
-te::AutomatableParameter* MagdaDelayCompiledPlugin::getSlotParameter(int slotIndex) const {
-    if (slotIndex < 0 || slotIndex >= kHostSlotCount)
-        return nullptr;
-    return hostParams_[static_cast<size_t>(slotIndex)].get();
-}
-
-const MagdaDelayCompiledPlugin::HostSlotInfo& MagdaDelayCompiledPlugin::getSlotInfo(
-    int slotIndex) const {
-    static const HostSlotInfo kEmpty;
-    if (slotIndex < 0 || slotIndex >= kHostSlotCount)
-        return kEmpty;
-    return hostSlotInfo_[static_cast<size_t>(slotIndex)];
-}
-
-float MagdaDelayCompiledPlugin::divisionFaustValueForIndex(int index) const {
-    if (divisionChoiceValues_.empty())
-        return 1.0f;
-    const int safeIdx = juce::jlimit(0, static_cast<int>(divisionChoiceValues_.size()) - 1, index);
-    return divisionChoiceValues_[static_cast<size_t>(safeIdx)];
-}
-
-float MagdaDelayCompiledPlugin::displayValueToNativeValue(int slotIndex, float displayValue) const {
-    if (slotIndex < 0 || slotIndex >= kHostSlotCount)
-        return displayValue;
-    const auto& s = hostSlotInfo_[static_cast<size_t>(slotIndex)];
-    magda::ParameterInfo info;
-    info.minValue = s.minValue;
-    info.maxValue = s.maxValue;
-    info.scale = s.scale;
-    if (std::isfinite(s.scaleAnchor))
-        info.scaleAnchor = s.scaleAnchor;
-    info.choices = s.choices;
-    return magda::ParameterUtils::realToNormalized(displayValue, info);
-}
-
-float MagdaDelayCompiledPlugin::nativeValueToDisplayValue(int slotIndex, float nativeValue) const {
-    if (slotIndex < 0 || slotIndex >= kHostSlotCount)
-        return nativeValue;
-    const auto& s = hostSlotInfo_[static_cast<size_t>(slotIndex)];
-    magda::ParameterInfo info;
-    info.minValue = s.minValue;
-    info.maxValue = s.maxValue;
-    info.scale = s.scale;
-    if (std::isfinite(s.scaleAnchor))
-        info.scaleAnchor = s.scaleAnchor;
-    info.choices = s.choices;
-    return magda::ParameterUtils::normalizedToReal(nativeValue, info);
+    return infos;
 }
 
 constexpr AliasSpec kAliases[] = {
@@ -482,9 +112,8 @@ const CompiledPluginSpec& getMagdaDelaySpec() {
                        "Time spans 1 ms to 2 s; Sync locks to musical Division. "
                        "Feedback recirculates with Tone shaping the regen path. "
                        "Cross routes feedback across channels for ping-pong patterns.",
-        .createPlugin = [](const DevicePluginCreationContext& context) -> DevicePluginPtr {
-            return tracktion_adapter::pluginHandle(
-                new MagdaDelayCompiledPlugin(tracktion_adapter::creationInfo(context)));
+        .createDevice = [](const DevicePluginCreationContext&) -> std::unique_ptr<MagdaDevice> {
+            return std::make_unique<MagdaDelayCompiledPlugin>();
         },
         .aliasKey = "magda_delay_compiled",
         .aliases = kAliases,

--- a/magda/daw/audio/plugins/compiled/MagdaDelayCompiledPlugin.hpp
+++ b/magda/daw/audio/plugins/compiled/MagdaDelayCompiledPlugin.hpp
@@ -1,15 +1,8 @@
 #pragma once
 
-#include <tracktion_engine/tracktion_engine.h>
-
-#include <array>
-#include <atomic>
-#include <memory>
 #include <vector>
 
-#include "../FaustParamPool.hpp"
-#include "core/ParameterInfo.hpp"
-#include "plugins/compiled/tracktion/CompiledFaustTracktionAdapter.hpp"
+#include "plugins/compiled/MagdaCompiledEffect.hpp"
 
 class dsp;
 
@@ -25,40 +18,12 @@ namespace magda::daw::audio::compiled {
  * The hidden BPM slot ([idx:63]) is populated each block from TE's
  * transport so musical-division mode tracks the live tempo.
  */
-class MagdaDelayCompiledPlugin : public te::Plugin, public ICompiledFaustPlugin {
+class MagdaDelayCompiledPlugin : public MagdaCompiledEffect {
   public:
     static const char* xmlTypeName;
 
-    explicit MagdaDelayCompiledPlugin(const te::PluginCreationInfo& info);
-    ~MagdaDelayCompiledPlugin() override;
+    MagdaDelayCompiledPlugin();
 
-    juce::String getName() const override;
-    juce::String getPluginType() override;
-    juce::String getShortName(int) override;
-    juce::String getSelectableDescription() override;
-
-    void initialise(const te::PluginInitialisationInfo& info) override;
-    void deinitialise() override;
-    void reset() override;
-    void applyToBuffer(const te::PluginRenderContext& fc) override;
-
-    bool takesMidiInput() override {
-        return false;
-    }
-    bool takesAudioInput() override {
-        return true;
-    }
-    bool isSynth() override {
-        return false;
-    }
-    bool producesAudioWhenNoAudioInput() override {
-        return true;  // delay buffer keeps producing tails after dry input stops
-    }
-    double getTailLength() const override {
-        return 4.0;  // matches MAX_DELAY_SAMPLES / SR worst case
-    }
-
-    // Slot ordering matches [idx:N] pins inside magda_delay.dsp.
     static constexpr int kTimeSlot = 0;
     static constexpr int kDivisionSlot = 1;
     static constexpr int kSyncSlot = 2;
@@ -69,81 +34,30 @@ class MagdaDelayCompiledPlugin : public te::Plugin, public ICompiledFaustPlugin 
     static constexpr int kHostSlotCount = 7;
     static constexpr int kBpmSlot = 63;  // hidden, populated from TE transport
 
-    te::AutomatableParameter* getSlotParameter(int slotIndex) const;
-
-    float displayValueToNativeValue(int slotIndex, float displayValue) const;
-    float nativeValueToDisplayValue(int slotIndex, float nativeValue) const;
-
-    using HostSlotInfo = CompiledHostSlotInfo;
-    const HostSlotInfo& getSlotInfo(int slotIndex) const;
-
-    // Underlying Faust value (quarter-note multiplier) for a given Division
-    // dropdown index. Curve views use this to compute exact echo times when
-    // Sync is on — the dropdown labels ("1/4", "1/8.") aren't parseable so
-    // we can't recover the value via String::getFloatValue.
-    float divisionFaustValueForIndex(int index) const;
-
-    // Last BPM read from the edit's tempo sequence in applyToBuffer. Updated
-    // every audio block; safe to read from any thread. Lets the UI curve
-    // view draw the sync-mode beat grid against the live tempo without
-    // touching te::TempoSequence itself from the message thread.
-    float currentBpm() const {
-        return currentBpm_.load(std::memory_order_relaxed);
+    /// The Faust quarter-note multiplier behind Division choice @p index.
+    float divisionFaustValueForIndex(int index) const {
+        return menuValueForChoice(kDivisionSlot, index);
     }
 
-    // ICompiledFaustPlugin
-    int hostSlotCount() const override {
-        return kHostSlotCount;
+    juce::String devicePluginId() const override {
+        return xmlTypeName;
     }
-    const CompiledHostSlotInfo& hostSlotInfo(int slotIndex) const override {
-        return getSlotInfo(slotIndex);
+    juce::String deviceName() const override {
+        return "Delay";
     }
-    DeviceParameterHandle hostSlotParameter(int slotIndex) const override {
-        return tracktion_adapter::parameterHandle(getSlotParameter(slotIndex));
+
+  protected:
+    ::dsp* createEngineDsp(int engineIndex) const override;
+    std::vector<HostSlotInfo> slotInfos() const override;
+    const char* slotIdPrefix() const override {
+        return "magda_delay_";
     }
-    float displayToNormalized(int slotIndex, float displayValue) const override {
-        return displayValueToNativeValue(slotIndex, displayValue);
-    }
-    float normalizedToDisplay(int slotIndex, float normalizedValue) const override {
-        return nativeValueToDisplayValue(slotIndex, normalizedValue);
+    double tailSeconds() const override {
+        // Matches the dsp's MAX_DELAY_SAMPLES / SR worst case.
+        return 4.0;
     }
 
   private:
-    void buildHostParameters();
-    void rebuildEngineState(int sampleRate);
-
-    std::unique_ptr<::dsp> dsp_;
-    int numInputs_ = 0;
-    int numOutputs_ = 0;
-
-    // Faust zones harvested by [idx:N]. Mode + Division use an underlying
-    // numeric value the user picks via a menu, but here both Sync (bool)
-    // and Division (continuous menu) work via the same direct-write path.
-    std::array<FAUSTFLOAT*, kHostSlotCount> zones_{};
-    FAUSTFLOAT* bpmZone_ = nullptr;                   // [idx:63], hidden, host-driven
-    std::vector<float> divisionChoiceValues_;         // Faust-side values, used for audio writes
-    std::vector<juce::String> divisionChoiceLabels_;  // Display labels (e.g. "1/4", "1/8.")
-
-    // Gate annotations harvested from the DSP, kept aside so
-    // buildHostParameters' designated-initializer assignments don't wipe
-    // them. Indexed by host slot.
-    struct GateSpec {
-        int slotIndex = -1;
-        bool negated = false;
-    };
-    std::array<GateSpec, kHostSlotCount> harvestedGates_{};
-
-    std::array<HostSlotInfo, kHostSlotCount> hostSlotInfo_;
-    std::array<te::AutomatableParameter::Ptr, kHostSlotCount> hostParams_;
-    std::array<juce::CachedValue<float>, kHostSlotCount> hostCached_;
-
-    juce::AudioBuffer<float> scratchIn_;
-    juce::AudioBuffer<float> scratchOut_;
-    std::vector<float*> inPtrs_;
-    std::vector<float*> outPtrs_;
-
-    std::atomic<float> currentBpm_{120.0f};
-
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(MagdaDelayCompiledPlugin)
 };
 

--- a/magda/daw/audio/plugins/compiled/MagdaDelayCompiledPlugin.hpp
+++ b/magda/daw/audio/plugins/compiled/MagdaDelayCompiledPlugin.hpp
@@ -52,6 +52,11 @@ class MagdaDelayCompiledPlugin : public MagdaCompiledEffect {
     const char* slotIdPrefix() const override {
         return "magda_delay_";
     }
+    bool producesAudioWithoutInput() const override {
+        // Dry input stopping does not mean the device is done: the delay line still has up to four
+        // seconds of echoes in it, and a host that stops pumping here cuts them off.
+        return true;
+    }
     double tailSeconds() const override {
         // Matches the dsp's MAX_DELAY_SAMPLES / SR worst case.
         return 4.0;

--- a/magda/daw/audio/plugins/compiled/MagdaDimensionCompiledPlugin.cpp
+++ b/magda/daw/audio/plugins/compiled/MagdaDimensionCompiledPlugin.cpp
@@ -1,393 +1,74 @@
 #include "plugins/compiled/MagdaDimensionCompiledPlugin.hpp"
 
-#include <algorithm>
-#include <cmath>
-#include <map>
-
-#include "core/ParameterUtils.hpp"
+#include "core/ParameterInfo.hpp"
 #include "faust/dsp/dsp.h"
 #include "faust/gui/UI.h"
 #include "faust/gui/meta.h"
-#include "plugins/FaustMetadataParser.hpp"
-#include "plugins/FaustParamInfo.hpp"
-#include "plugins/compiled/CompiledPluginRegistry.hpp"
-#include "plugins/tracktion/TracktionDeviceAdapters.hpp"
-
-// Each engine's generated cpp lives in its own translation unit, so
-// co-locating the three #includes here lets us instantiate one of each
-// in this wrapper. Same trick the Reverb wrapper uses.
 #include "magda_dimension_dim.generated.cpp"
 #include "magda_dimension_haas.generated.cpp"
 #include "magda_dimension_ms.generated.cpp"
+#include "plugins/compiled/CompiledPluginRegistry.hpp"
 
 namespace magda::daw::audio::compiled {
 
 const char* MagdaDimensionCompiledPlugin::xmlTypeName = "magda_dimension";
 
-namespace {
+MagdaDimensionCompiledPlugin::MagdaDimensionCompiledPlugin() {
+    initEffect();
+}
 
-struct EngineHarvest {
-    struct Control {
-        int idx = -1;
-        FaustParamSlot::Kind kind = FaustParamSlot::Kind::Continuous;
-        FAUSTFLOAT* zone = nullptr;
-    };
-    std::vector<Control> controls;
-};
-
-class EngineHarvester : public ::UI {
-  public:
-    EngineHarvest harvest;
-
-    void openTabBox(const char*) override {}
-    void openHorizontalBox(const char*) override {}
-    void openVerticalBox(const char*) override {}
-    void closeBox() override {}
-
-    void addButton(const char* label, FAUSTFLOAT* zone) override {
-        emitControl(FaustParamSlot::Kind::Boolean, label, zone);
+::dsp* MagdaDimensionCompiledPlugin::createEngineDsp(int engineIndex) const {
+    switch (static_cast<DimensionEngine>(engineIndex)) {
+        case DimensionEngine::Dimension:
+            return new MagdaDimensionDimDsp();
+        case DimensionEngine::Haas:
+            return new MagdaDimensionHaasDsp();
+        case DimensionEngine::MidSide:
+            return new MagdaDimensionMSDsp();
     }
-    void addCheckButton(const char* label, FAUSTFLOAT* zone) override {
-        emitControl(FaustParamSlot::Kind::Boolean, label, zone);
-    }
-    void addVerticalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT, FAUSTFLOAT, FAUSTFLOAT,
-                           FAUSTFLOAT) override {
-        emitControl(FaustParamSlot::Kind::Continuous, label, zone);
-    }
-    void addHorizontalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT, FAUSTFLOAT,
-                             FAUSTFLOAT, FAUSTFLOAT) override {
-        emitControl(FaustParamSlot::Kind::Continuous, label, zone);
-    }
-    void addNumEntry(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT, FAUSTFLOAT, FAUSTFLOAT,
-                     FAUSTFLOAT) override {
-        emitControl(FaustParamSlot::Kind::Continuous, label, zone);
-    }
-    void addHorizontalBargraph(const char*, FAUSTFLOAT*, FAUSTFLOAT, FAUSTFLOAT) override {}
-    void addVerticalBargraph(const char*, FAUSTFLOAT*, FAUSTFLOAT, FAUSTFLOAT) override {}
-    void addSoundfile(const char*, const char*, Soundfile**) override {}
-
-    void declare(FAUSTFLOAT* zone, const char* key, const char* value) override {
-        if (zone == nullptr)
-            return;
-        const auto k = juce::String::fromUTF8(key != nullptr ? key : "").toLowerCase();
-        const auto v = juce::String::fromUTF8(value != nullptr ? value : "");
-        applyFaustAnnotation(k, v, pendingByZone_[zone]);
-    }
-
-  private:
-    void emitControl(FaustParamSlot::Kind kind, const char* rawLabel, FAUSTFLOAT* zone) {
-        const auto parsed =
-            parseFaustLabel(juce::String::fromUTF8(rawLabel != nullptr ? rawLabel : ""));
-        ControlMetadata merged = parsed.metadata;
-        if (zone != nullptr) {
-            if (auto it = pendingByZone_.find(zone); it != pendingByZone_.end()) {
-                mergeFaustMetadata(merged, it->second);
-                pendingByZone_.erase(it);
-            }
-        }
-
-        EngineHarvest::Control c;
-        c.idx = merged.slotIndex;
-        c.kind = merged.isChoiceStyle() ? FaustParamSlot::Kind::Discrete : kind;
-        c.zone = zone;
-        harvest.controls.push_back(std::move(c));
-    }
-
-    std::map<FAUSTFLOAT*, ControlMetadata> pendingByZone_;
-};
-
-const EngineHarvest::Control* findByIdx(const EngineHarvest& h, int idx) {
-    for (const auto& c : h.controls)
-        if (c.idx == idx)
-            return &c;
     return nullptr;
 }
 
-magda::ParameterInfo parameterInfoForSlot(const CompiledHostSlotInfo& s) {
-    magda::ParameterInfo info;
-    info.minValue = s.minValue;
-    info.maxValue = s.maxValue;
-    info.defaultValue = s.defaultValue;
-    info.unit = s.unit;
-    info.scale = s.scale;
-    if (std::isfinite(s.scaleAnchor))
-        info.scaleAnchor = s.scaleAnchor;
-    info.choices = s.choices;
-    return info;
-}
+std::vector<MagdaDimensionCompiledPlugin::HostSlotInfo> MagdaDimensionCompiledPlugin::slotInfos()
+    const {
+    std::vector<HostSlotInfo> infos(kHostSlotCount);
+    infos[kEngineSlot].name = "Engine";
+    infos[kEngineSlot].scale = magda::ParameterScale::Discrete;
+    infos[kEngineSlot].choices = {"Dimension", "Haas", "M/S"};
+    infos[kEngineSlot].minValue = 0.0f;
+    infos[kEngineSlot].maxValue = static_cast<float>(infos[kEngineSlot].choices.size() - 1);
+    infos[kEngineSlot].defaultValue = 0.0f;
 
-}  // namespace
+    infos[kAmountSlot] = {.name = "Amount",
+                          .scale = magda::ParameterScale::Linear,
+                          .minValue = 0.0f,
+                          .maxValue = 1.0f,
+                          .defaultValue = 0.5f};
+    infos[kRateSlot] = {.name = "Rate",
+                        .unit = magda::technicalText(magda::TechnicalTextToken::Hertz),
+                        .scale = magda::ParameterScale::Logarithmic,
+                        .minValue = 0.05f,
+                        .maxValue = 4.0f,
+                        .defaultValue = 0.5f,
+                        .scaleAnchor = 0.5f};
+    infos[kWidthSlot] = {.name = "Width",
+                         .scale = magda::ParameterScale::Linear,
+                         .minValue = 0.0f,
+                         .maxValue = 200.0f,
+                         .defaultValue = 100.0f};
+    infos[kMixSlot] = {.name = "Mix",
+                       .scale = magda::ParameterScale::Linear,
+                       .minValue = 0.0f,
+                       .maxValue = 1.0f,
+                       .defaultValue = 1.0f};
+    infos[kOutputSlot] = {.name = "Output",
+                          .unit = magda::technicalText(magda::TechnicalTextToken::Decibels),
+                          .scale = magda::ParameterScale::Linear,
+                          .minValue = -24.0f,
+                          .maxValue = 12.0f,
+                          .defaultValue = 0.0f};
 
-MagdaDimensionCompiledPlugin::MagdaDimensionCompiledPlugin(const te::PluginCreationInfo& info)
-    : te::Plugin(info) {
-    engines_[static_cast<size_t>(DimensionEngine::Dimension)].dsp =
-        std::make_unique<MagdaDimensionDimDsp>();
-    engines_[static_cast<size_t>(DimensionEngine::Haas)].dsp =
-        std::make_unique<MagdaDimensionHaasDsp>();
-    engines_[static_cast<size_t>(DimensionEngine::MidSide)].dsp =
-        std::make_unique<MagdaDimensionMSDsp>();
-
-    constexpr int kProvisionalSampleRate = 44100;
-    rebuildEngineState(kProvisionalSampleRate);
-    buildHostParameters();
-}
-
-MagdaDimensionCompiledPlugin::~MagdaDimensionCompiledPlugin() {
-    notifyListenersOfDeletion();
-    for (auto& p : hostParams_)
-        if (p)
-            p->detachFromCurrentValue();
-}
-
-juce::String MagdaDimensionCompiledPlugin::getName() const {
-    return "Dimension";
-}
-juce::String MagdaDimensionCompiledPlugin::getPluginType() {
-    return xmlTypeName;
-}
-juce::String MagdaDimensionCompiledPlugin::getShortName(int) {
-    return "Dim";
-}
-juce::String MagdaDimensionCompiledPlugin::getSelectableDescription() {
-    return "Dimension";
-}
-
-void MagdaDimensionCompiledPlugin::rebuildEngineState(int sampleRate) {
-    for (auto& e : engines_) {
-        if (!e.dsp)
-            continue;
-        e.dsp->init(sampleRate);
-        e.numInputs = e.dsp->getNumInputs();
-        e.numOutputs = e.dsp->getNumOutputs();
-
-        EngineHarvester harvester;
-        e.dsp->buildUserInterface(&harvester);
-
-        e.zones.fill(nullptr);
-        // Slot 0 (Engine) is wrapper-only. Slots 1..5 come from the DSP.
-        // An engine that doesn't expose a particular slot (e.g. Haas / M/S
-        // for Rate, which Faust optimises away) just leaves that zone null
-        // — the per-block write loop checks for null before assigning.
-        for (int i = 1; i < kHostSlotCount; ++i) {
-            if (auto* c = findByIdx(harvester.harvest, i))
-                e.zones[static_cast<size_t>(i)] = c->zone;
-        }
-    }
-}
-
-void MagdaDimensionCompiledPlugin::buildHostParameters() {
-    hostSlotInfo_[kEngineSlot].name = "Engine";
-    hostSlotInfo_[kEngineSlot].scale = magda::ParameterScale::Discrete;
-    hostSlotInfo_[kEngineSlot].choices = {"Dimension", "Haas", "M/S"};
-    hostSlotInfo_[kEngineSlot].minValue = 0.0f;
-    hostSlotInfo_[kEngineSlot].maxValue =
-        static_cast<float>(hostSlotInfo_[kEngineSlot].choices.size() - 1);
-    hostSlotInfo_[kEngineSlot].defaultValue = 0.0f;
-
-    hostSlotInfo_[kAmountSlot] = {.name = "Amount",
-                                  .scale = magda::ParameterScale::Linear,
-                                  .minValue = 0.0f,
-                                  .maxValue = 1.0f,
-                                  .defaultValue = 0.5f};
-    hostSlotInfo_[kRateSlot] = {.name = "Rate",
-                                .unit = magda::technicalText(magda::TechnicalTextToken::Hertz),
-                                .scale = magda::ParameterScale::Logarithmic,
-                                .minValue = 0.05f,
-                                .maxValue = 4.0f,
-                                .defaultValue = 0.5f,
-                                .scaleAnchor = 0.5f};
-    hostSlotInfo_[kWidthSlot] = {.name = "Width",
-                                 .scale = magda::ParameterScale::Linear,
-                                 .minValue = 0.0f,
-                                 .maxValue = 200.0f,
-                                 .defaultValue = 100.0f};
-    hostSlotInfo_[kMixSlot] = {.name = "Mix",
-                               .scale = magda::ParameterScale::Linear,
-                               .minValue = 0.0f,
-                               .maxValue = 1.0f,
-                               .defaultValue = 1.0f};
-    hostSlotInfo_[kOutputSlot] = {.name = "Output",
-                                  .unit = magda::technicalText(magda::TechnicalTextToken::Decibels),
-                                  .scale = magda::ParameterScale::Linear,
-                                  .minValue = -24.0f,
-                                  .maxValue = 12.0f,
-                                  .defaultValue = 0.0f};
-
-    juce::NormalisableRange<float> normalisedRange{0.0f, 1.0f};
-    auto* undoManager = getUndoManager();
-
-    for (int i = 0; i < kHostSlotCount; ++i) {
-        const auto& slot = hostSlotInfo_[i];
-        const juce::String id = "magda_dimension_" + slot.name.toLowerCase().replace(" ", "_");
-        const juce::Identifier identifier(id);
-        const auto info = parameterInfoForSlot(slot);
-        const float defaultNormalized =
-            magda::ParameterUtils::realToNormalized(slot.defaultValue, info);
-        hostCached_[i].referTo(state, identifier, undoManager, defaultNormalized);
-
-        auto param = addParam(
-            id, slot.name, normalisedRange,
-            [info](float normalized) {
-                const float real = magda::ParameterUtils::normalizedToReal(normalized, info);
-                return magda::ParameterUtils::formatValue(real, info);
-            },
-            [info](const juce::String& text) {
-                auto parsed = magda::ParameterUtils::parseValue(text, info);
-                if (parsed)
-                    return magda::ParameterUtils::realToNormalized(*parsed, info);
-                return 0.0f;
-            });
-        param->attachToCurrentValue(hostCached_[i]);
-        hostParams_[i] = param;
-    }
-}
-
-void MagdaDimensionCompiledPlugin::initialise(const te::PluginInitialisationInfo& info) {
-    rebuildEngineState(static_cast<int>(info.sampleRate));
-
-    int maxIn = 0, maxOut = 0;
-    for (const auto& e : engines_) {
-        maxIn = std::max(maxIn, e.numInputs);
-        maxOut = std::max(maxOut, e.numOutputs);
-    }
-    scratchIn_.setSize(maxIn, info.blockSizeSamples, false, true, true);
-    scratchOut_.setSize(maxOut, info.blockSizeSamples, false, true, true);
-    inPtrs_.assign(static_cast<size_t>(maxIn), nullptr);
-    outPtrs_.assign(static_cast<size_t>(maxOut), nullptr);
-}
-
-void MagdaDimensionCompiledPlugin::deinitialise() {
-    scratchIn_.setSize(0, 0);
-    scratchOut_.setSize(0, 0);
-    inPtrs_.clear();
-    outPtrs_.clear();
-}
-
-void MagdaDimensionCompiledPlugin::reset() {
-    for (auto& e : engines_)
-        if (e.dsp)
-            e.dsp->instanceClear();
-}
-
-void MagdaDimensionCompiledPlugin::applyToBuffer(const te::PluginRenderContext& fc) {
-    if (!fc.destBuffer || fc.bufferNumSamples <= 0)
-        return;
-
-    auto realForSlot = [&](int slot) -> float {
-        const auto& s = hostSlotInfo_[static_cast<size_t>(slot)];
-        const auto info = parameterInfoForSlot(s);
-        const float norm = hostParams_[static_cast<size_t>(slot)]->getCurrentValue();
-        return magda::ParameterUtils::normalizedToReal(norm, info);
-    };
-
-    const float engineNorm = hostParams_[kEngineSlot]->getCurrentValue();
-    const int engineIndex = juce::jlimit(
-        0, kEngineCount - 1,
-        static_cast<int>(std::round(engineNorm * static_cast<float>(kEngineCount - 1))));
-    activeEngine_.store(engineIndex);
-
-    // Write shared zones into ALL engines so swapping is glitchless.
-    for (int slot = 1; slot < kHostSlotCount; ++slot) {
-        const float real = realForSlot(slot);
-        for (auto& e : engines_) {
-            if (auto* zone = e.zones[static_cast<size_t>(slot)])
-                *zone = static_cast<FAUSTFLOAT>(real);
-        }
-    }
-
-    auto& active = engines_[static_cast<size_t>(engineIndex)];
-    if (!active.dsp)
-        return;
-
-    const int numSamples = fc.bufferNumSamples;
-    const int startSample = fc.bufferStartSample;
-    const int hostChannels = fc.destBuffer->getNumChannels();
-    const int numInputs = active.numInputs;
-    const int numOutputs = active.numOutputs;
-    if (hostChannels <= 0 || numInputs <= 0 || numOutputs <= 0)
-        return;
-
-    if (scratchIn_.getNumChannels() < numInputs || scratchIn_.getNumSamples() < numSamples)
-        scratchIn_.setSize(numInputs, numSamples, false, true, true);
-    if (scratchOut_.getNumChannels() < numOutputs || scratchOut_.getNumSamples() < numSamples)
-        scratchOut_.setSize(numOutputs, numSamples, false, true, true);
-    if (static_cast<int>(inPtrs_.size()) < numInputs)
-        inPtrs_.resize(static_cast<size_t>(numInputs), nullptr);
-    if (static_cast<int>(outPtrs_.size()) < numOutputs)
-        outPtrs_.resize(static_cast<size_t>(numOutputs), nullptr);
-
-    for (int ch = 0; ch < numInputs; ++ch) {
-        float* dst = scratchIn_.getWritePointer(ch);
-        if (ch < hostChannels) {
-            const float* src = fc.destBuffer->getReadPointer(ch, startSample);
-            std::copy(src, src + numSamples, dst);
-        } else {
-            std::fill(dst, dst + numSamples, 0.0f);
-        }
-        inPtrs_[static_cast<size_t>(ch)] = dst;
-    }
-    for (int ch = 0; ch < numOutputs; ++ch) {
-        outPtrs_[static_cast<size_t>(ch)] = (ch < hostChannels)
-                                                ? fc.destBuffer->getWritePointer(ch, startSample)
-                                                : scratchOut_.getWritePointer(ch);
-    }
-
-    active.dsp->compute(numSamples, inPtrs_.data(), outPtrs_.data());
-
-    // Sanitise — clamp + replace non-finite samples.
-    const int channelsToSanitise = std::min(hostChannels, numOutputs);
-    for (int ch = 0; ch < channelsToSanitise; ++ch) {
-        float* out = fc.destBuffer->getWritePointer(ch, startSample);
-        for (int i = 0; i < numSamples; ++i) {
-            const float sample = out[i];
-            out[i] = std::isfinite(sample) ? juce::jlimit(-16.0f, 16.0f, sample) : 0.0f;
-        }
-    }
-    for (int ch = numOutputs; ch < hostChannels; ++ch)
-        fc.destBuffer->clear(ch, startSample, numSamples);
-}
-
-te::AutomatableParameter* MagdaDimensionCompiledPlugin::getSlotParameter(int slotIndex) const {
-    if (slotIndex < 0 || slotIndex >= kHostSlotCount)
-        return nullptr;
-    return hostParams_[static_cast<size_t>(slotIndex)].get();
-}
-
-const MagdaDimensionCompiledPlugin::HostSlotInfo& MagdaDimensionCompiledPlugin::getSlotInfo(
-    int slotIndex) const {
-    static const HostSlotInfo kEmpty;
-    if (slotIndex < 0 || slotIndex >= kHostSlotCount)
-        return kEmpty;
-    return hostSlotInfo_[static_cast<size_t>(slotIndex)];
-}
-
-int MagdaDimensionCompiledPlugin::activeEngineIndex() const {
-    if (!hostParams_[kEngineSlot])
-        return 0;
-    const float norm = hostParams_[kEngineSlot]->getCurrentValue();
-    return juce::jlimit(0, kEngineCount - 1,
-                        static_cast<int>(std::round(norm * static_cast<float>(kEngineCount - 1))));
-}
-
-bool MagdaDimensionCompiledPlugin::isSlotHiddenForActiveEngine(int slotIndex) const {
-    return slotIndex == kRateSlot &&
-           activeEngineIndex() != static_cast<int>(DimensionEngine::Dimension);
-}
-
-float MagdaDimensionCompiledPlugin::displayValueToNativeValue(int slotIndex,
-                                                              float displayValue) const {
-    if (slotIndex < 0 || slotIndex >= kHostSlotCount)
-        return displayValue;
-    const auto info = parameterInfoForSlot(hostSlotInfo_[static_cast<size_t>(slotIndex)]);
-    return magda::ParameterUtils::realToNormalized(displayValue, info);
-}
-
-float MagdaDimensionCompiledPlugin::nativeValueToDisplayValue(int slotIndex,
-                                                              float nativeValue) const {
-    if (slotIndex < 0 || slotIndex >= kHostSlotCount)
-        return nativeValue;
-    const auto info = parameterInfoForSlot(hostSlotInfo_[static_cast<size_t>(slotIndex)]);
-    return magda::ParameterUtils::normalizedToReal(nativeValue, info);
+    return infos;
 }
 
 constexpr AliasSpec kAliases[] = {
@@ -405,9 +86,8 @@ const CompiledPluginSpec& getMagdaDimensionSpec() {
             "<b>Dimension</b>: Roland Dimension D-style anti-phase modulated delays.\n"
             "<b>Haas</b>: short fixed delay on one channel, classic psychoacoustic cue.\n"
             "<b>M/S</b>: pure mid-side side-channel gain, no time smear.",
-        .createPlugin = [](const DevicePluginCreationContext& context) -> DevicePluginPtr {
-            return tracktion_adapter::pluginHandle(
-                new MagdaDimensionCompiledPlugin(tracktion_adapter::creationInfo(context)));
+        .createDevice = [](const DevicePluginCreationContext&) -> std::unique_ptr<MagdaDevice> {
+            return std::make_unique<MagdaDimensionCompiledPlugin>();
         },
         .aliases = kAliases,
         .aliasCount = static_cast<int>(sizeof(kAliases) / sizeof(kAliases[0])),

--- a/magda/daw/audio/plugins/compiled/MagdaDimensionCompiledPlugin.hpp
+++ b/magda/daw/audio/plugins/compiled/MagdaDimensionCompiledPlugin.hpp
@@ -1,15 +1,8 @@
 #pragma once
 
-#include <tracktion_engine/tracktion_engine.h>
-
-#include <array>
-#include <atomic>
-#include <memory>
 #include <vector>
 
-#include "../FaustParamPool.hpp"
-#include "core/ParameterInfo.hpp"
-#include "plugins/compiled/tracktion/CompiledFaustTracktionAdapter.hpp"
+#include "plugins/compiled/MagdaCompiledEffect.hpp"
 
 class dsp;
 
@@ -34,47 +27,12 @@ namespace magda::daw::audio::compiled {
  * written into every engine every block so swapping engines preserves
  * the user's settings.
  */
-class MagdaDimensionCompiledPlugin : public te::Plugin, public ICompiledFaustPlugin {
+class MagdaDimensionCompiledPlugin : public MagdaCompiledEffect {
   public:
     static const char* xmlTypeName;
 
-    explicit MagdaDimensionCompiledPlugin(const te::PluginCreationInfo& info);
-    ~MagdaDimensionCompiledPlugin() override;
+    MagdaDimensionCompiledPlugin();
 
-    juce::String getName() const override;
-    juce::String getPluginType() override;
-    juce::String getShortName(int) override;
-    juce::String getSelectableDescription() override;
-
-    void initialise(const te::PluginInitialisationInfo& info) override;
-    void deinitialise() override;
-    void reset() override;
-    void applyToBuffer(const te::PluginRenderContext& fc) override;
-
-    bool takesMidiInput() override {
-        return false;
-    }
-    bool takesAudioInput() override {
-        return true;
-    }
-    bool isSynth() override {
-        return false;
-    }
-    int getNumOutputChannelsGivenInputs(int) override {
-        return 2;
-    }
-    bool producesAudioWhenNoAudioInput() override {
-        // Modulated-delay engines have a tail in the modulator state and
-        // delay lines; keep TE pumping briefly after dry input stops so
-        // the trail doesn't truncate.
-        return true;
-    }
-    double getTailLength() const override {
-        return 0.1;  // Haas at 30 ms × safety margin.
-    }
-
-    // Slot ordering — Engine first, then the shared widener surface. DSP
-    // `[idx:N]` values mirror these (idx 0 is wrapper-only).
     static constexpr int kEngineSlot = 0;
     static constexpr int kAmountSlot = 1;
     static constexpr int kRateSlot = 2;
@@ -82,64 +40,47 @@ class MagdaDimensionCompiledPlugin : public te::Plugin, public ICompiledFaustPlu
     static constexpr int kMixSlot = 4;
     static constexpr int kOutputSlot = 5;
     static constexpr int kHostSlotCount = 6;
-
     enum class DimensionEngine { Dimension = 0, Haas = 1, MidSide = 2 };
     static constexpr int kEngineCount = 3;
 
-    te::AutomatableParameter* getSlotParameter(int slotIndex) const;
+    bool isSlotHiddenForActiveEngine(int slotIndex) const override {
+        // Rate drives the Dimension engine's chorus modulator; the other two
+        // have nothing to modulate, and Faust strips the zone accordingly.
+        return slotIndex == kRateSlot &&
+               activeEngine() != static_cast<int>(DimensionEngine::Dimension);
+    }
 
-    float displayValueToNativeValue(int slotIndex, float displayValue) const;
-    float nativeValueToDisplayValue(int slotIndex, float nativeValue) const;
+    juce::String devicePluginId() const override {
+        return xmlTypeName;
+    }
+    juce::String deviceName() const override {
+        return "Dimension";
+    }
 
-    int activeEngineIndex() const;
-
-    using HostSlotInfo = CompiledHostSlotInfo;
-    const HostSlotInfo& getSlotInfo(int slotIndex) const;
-
-    // ICompiledFaustPlugin
-    int hostSlotCount() const override {
-        return kHostSlotCount;
+  protected:
+    ::dsp* createEngineDsp(int engineIndex) const override;
+    std::vector<HostSlotInfo> slotInfos() const override;
+    const char* slotIdPrefix() const override {
+        return "magda_dimension_";
     }
-    const CompiledHostSlotInfo& hostSlotInfo(int slotIndex) const override {
-        return getSlotInfo(slotIndex);
+    int engineCount() const override {
+        return kEngineCount;
     }
-    DeviceParameterHandle hostSlotParameter(int slotIndex) const override {
-        return tracktion_adapter::parameterHandle(getSlotParameter(slotIndex));
+    int engineSlot() const override {
+        return kEngineSlot;
     }
-    float displayToNormalized(int slotIndex, float displayValue) const override {
-        return displayValueToNativeValue(slotIndex, displayValue);
+    int outputChannelCount() const override {
+        return 2;
     }
-    float normalizedToDisplay(int slotIndex, float normalizedValue) const override {
-        return nativeValueToDisplayValue(slotIndex, normalizedValue);
+    bool producesAudioWithoutInput() const override {
+        return true;
     }
-    bool isSlotHiddenForActiveEngine(int slotIndex) const override;
+    double tailSeconds() const override {
+        // Haas at 30 ms, times a safety margin.
+        return 0.1;
+    }
 
   private:
-    void buildHostParameters();
-    void rebuildEngineState(int sampleRate);
-
-    // Per-engine state. zones_[slotIndex] is the FAUSTFLOAT* into this
-    // engine's DSP for that host slot, or null if the engine doesn't expose
-    // that slot (Engine slot 0 lives only in the wrapper; Rate is inert in
-    // Haas / M/S so Faust strips its zone).
-    struct EngineState {
-        std::unique_ptr<::dsp> dsp;
-        std::array<FAUSTFLOAT*, kHostSlotCount> zones{};
-        int numInputs = 0;
-        int numOutputs = 0;
-    };
-    std::array<EngineState, kEngineCount> engines_;
-    std::atomic<int> activeEngine_{0};
-
-    std::array<HostSlotInfo, kHostSlotCount> hostSlotInfo_;
-    std::array<te::AutomatableParameter::Ptr, kHostSlotCount> hostParams_;
-    std::array<juce::CachedValue<float>, kHostSlotCount> hostCached_;
-
-    juce::AudioBuffer<float> scratchIn_;
-    juce::AudioBuffer<float> scratchOut_;
-    std::vector<float*> inPtrs_;
-    std::vector<float*> outPtrs_;
-
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(MagdaDimensionCompiledPlugin)
 };
 

--- a/magda/daw/audio/plugins/compiled/MagdaEqCompiledPlugin.cpp
+++ b/magda/daw/audio/plugins/compiled/MagdaEqCompiledPlugin.cpp
@@ -3,28 +3,14 @@
 #include <algorithm>
 #include <cmath>
 
-#include "core/ParameterUtils.hpp"
+#include "core/ParameterInfo.hpp"
 #include "plugins/compiled/CompiledPluginRegistry.hpp"
-#include "plugins/tracktion/TracktionDeviceAdapters.hpp"
 
 namespace magda::daw::audio::compiled {
 
 const char* MagdaEqCompiledPlugin::xmlTypeName = "magda_eq";
 
 namespace {
-
-magda::ParameterInfo parameterInfoForSlot(const CompiledHostSlotInfo& s) {
-    magda::ParameterInfo info;
-    info.minValue = s.minValue;
-    info.maxValue = s.maxValue;
-    info.defaultValue = s.defaultValue;
-    info.unit = s.unit;
-    info.scale = s.scale;
-    if (std::isfinite(s.scaleAnchor))
-        info.scaleAnchor = s.scaleAnchor;
-    info.choices = s.choices;
-    return info;
-}
 
 // Bands default to disabled Bell filters. That keeps the inserted EQ neutral
 // and avoids spending per-sample CPU on inactive biquads.
@@ -134,189 +120,132 @@ juce::String bandDisplayPrefix(int band) {
 
 }  // namespace
 
-MagdaEqCompiledPlugin::MagdaEqCompiledPlugin(const te::PluginCreationInfo& info)
-    : te::Plugin(info) {
-    buildHostParameters();
-
-    // Persist the "collapse knobs" toggle on the plugin's state ValueTree
-    // so it survives project save/load. Defaults to collapsed (true) — the
-    // curve is the EQ's primary surface.
-    curveCollapsed_.referTo(state, "curveCollapsed", getUndoManager(), true);
+MagdaEqCompiledPlugin::MagdaEqCompiledPlugin() {
+    initEffect();
 }
 
-MagdaEqCompiledPlugin::~MagdaEqCompiledPlugin() {
-    notifyListenersOfDeletion();
-    for (auto& p : hostParams_)
-        if (p)
-            p->detachFromCurrentValue();
-}
-
-juce::String MagdaEqCompiledPlugin::getName() const {
-    return "EQ";
-}
-juce::String MagdaEqCompiledPlugin::getPluginType() {
-    return xmlTypeName;
-}
-juce::String MagdaEqCompiledPlugin::getShortName(int) {
-    return "EQ";
-}
-juce::String MagdaEqCompiledPlugin::getSelectableDescription() {
-    return "8-Band Equaliser";
-}
-
-void MagdaEqCompiledPlugin::rebuildEngineState(int sampleRate) {
-    sampleRate_.store(static_cast<double>(sampleRate), std::memory_order_relaxed);
-}
-
-void MagdaEqCompiledPlugin::buildHostParameters() {
+std::vector<MagdaEqCompiledPlugin::HostSlotInfo> MagdaEqCompiledPlugin::slotInfos() const {
+    std::vector<HostSlotInfo> infos(kHostSlotCount);
     // Per-band slots.
     for (int band = 0; band < kBandCount; ++band) {
         const auto& defaults = kBandDefaults[band];
         const juce::String prefix = bandDisplayPrefix(band);
 
         const int enabledSlot = bandSlot(band, kBandEnabledOffset);
-        hostSlotInfo_[enabledSlot] = {.name = prefix + " Enabled",
-                                      .scale = magda::ParameterScale::Boolean,
-                                      .minValue = 0.0f,
-                                      .maxValue = 1.0f,
-                                      .defaultValue = defaults.enabled};
+        infos[enabledSlot] = {.name = prefix + " Enabled",
+                              .scale = magda::ParameterScale::Boolean,
+                              .minValue = 0.0f,
+                              .maxValue = 1.0f,
+                              .defaultValue = defaults.enabled};
 
         const int typeSlot = bandSlot(band, kBandTypeOffset);
-        hostSlotInfo_[typeSlot] = {
-            .name = prefix + " Type",
-            .scale = magda::ParameterScale::Discrete,
-            .minValue = 0.0f,
-            .maxValue = static_cast<float>(kBandTypeCount - 1),
-            .defaultValue = defaults.type,
-            .choices = {"HP", "LowShelf", "Bell", "HighShelf", "LP", "Notch"}};
+        infos[typeSlot] = {.name = prefix + " Type",
+                           .scale = magda::ParameterScale::Discrete,
+                           .minValue = 0.0f,
+                           .maxValue = static_cast<float>(kBandTypeCount - 1),
+                           .defaultValue = defaults.type,
+                           .choices = {"HP", "LowShelf", "Bell", "HighShelf", "LP", "Notch"}};
 
         const int freqSlot = bandSlot(band, kBandFreqOffset);
-        hostSlotInfo_[freqSlot] = {.name = prefix + " Freq",
-                                   .unit = magda::technicalText(magda::TechnicalTextToken::Hertz),
-                                   .scale = magda::ParameterScale::Logarithmic,
-                                   .minValue = 20.0f,
-                                   .maxValue = 20000.0f,
-                                   .defaultValue = defaults.freq,
-                                   .scaleAnchor = 1000.0f};
+        infos[freqSlot] = {.name = prefix + " Freq",
+                           .unit = magda::technicalText(magda::TechnicalTextToken::Hertz),
+                           .scale = magda::ParameterScale::Logarithmic,
+                           .minValue = 20.0f,
+                           .maxValue = 20000.0f,
+                           .defaultValue = defaults.freq,
+                           .scaleAnchor = 1000.0f};
 
         const int gainSlot = bandSlot(band, kBandGainOffset);
-        hostSlotInfo_[gainSlot] = {.name = prefix + " Gain",
-                                   .unit =
-                                       magda::technicalText(magda::TechnicalTextToken::Decibels),
-                                   .scale = magda::ParameterScale::Linear,
-                                   .minValue = -24.0f,
-                                   .maxValue = 24.0f,
-                                   .defaultValue = 0.0f};
+        infos[gainSlot] = {.name = prefix + " Gain",
+                           .unit = magda::technicalText(magda::TechnicalTextToken::Decibels),
+                           .scale = magda::ParameterScale::Linear,
+                           .minValue = -24.0f,
+                           .maxValue = 24.0f,
+                           .defaultValue = 0.0f};
 
         const int qSlot = bandSlot(band, kBandQOffset);
-        hostSlotInfo_[qSlot] = {.name = prefix + " Q",
-                                .scale = magda::ParameterScale::Logarithmic,
-                                .minValue = 0.1f,
-                                .maxValue = 10.0f,
-                                .defaultValue = defaults.q,
-                                .scaleAnchor = 1.0f};
+        infos[qSlot] = {.name = prefix + " Q",
+                        .scale = magda::ParameterScale::Logarithmic,
+                        .minValue = 0.1f,
+                        .maxValue = 10.0f,
+                        .defaultValue = defaults.q,
+                        .scaleAnchor = 1.0f};
     }
 
-    hostSlotInfo_[kOutputSlot] = {.name = "Output",
-                                  .unit = magda::technicalText(magda::TechnicalTextToken::Decibels),
-                                  .scale = magda::ParameterScale::Linear,
-                                  .minValue = -24.0f,
-                                  .maxValue = 12.0f,
-                                  .defaultValue = 0.0f};
+    infos[kOutputSlot] = {.name = "Output",
+                          .unit = magda::technicalText(magda::TechnicalTextToken::Decibels),
+                          .scale = magda::ParameterScale::Linear,
+                          .minValue = -24.0f,
+                          .maxValue = 12.0f,
+                          .defaultValue = 0.0f};
 
-    juce::NormalisableRange<float> normalisedRange{0.0f, 1.0f};
-    auto* undoManager = getUndoManager();
-
-    for (int i = 0; i < kHostSlotCount; ++i) {
-        const auto& slot = hostSlotInfo_[i];
-        juce::String id;
-        if (i < kOutputSlot) {
-            const int band = i / kSlotsPerBand;
-            const int role = i % kSlotsPerBand;
-            static const char* kRoleSuffix[kSlotsPerBand] = {"enabled", "filter_type", "freq",
-                                                             "gain", "q"};
-            id = "magda_eq_" + bandIdPrefix(band) + "_" + kRoleSuffix[role];
-        } else {
-            id = "magda_eq_output";
-        }
-        const juce::Identifier identifier(id);
-        const auto info = parameterInfoForSlot(slot);
-        const float defaultNormalized =
-            magda::ParameterUtils::realToNormalized(slot.defaultValue, info);
-        hostCached_[i].referTo(state, identifier, undoManager, defaultNormalized);
-
-        auto param = addParam(
-            id, slot.name, normalisedRange,
-            [info](float normalized) {
-                const float real = magda::ParameterUtils::normalizedToReal(normalized, info);
-                return magda::ParameterUtils::formatValue(real, info);
-            },
-            [info](const juce::String& text) {
-                auto parsed = magda::ParameterUtils::parseValue(text, info);
-                if (parsed)
-                    return magda::ParameterUtils::realToNormalized(*parsed, info);
-                return 0.0f;
-            });
-        param->attachToCurrentValue(hostCached_[i]);
-        hostParams_[i] = param;
-    }
+    return infos;
 }
 
-void MagdaEqCompiledPlugin::initialise(const te::PluginInitialisationInfo& info) {
-    rebuildEngineState(static_cast<int>(info.sampleRate));
-    preTapScratch_.assign(static_cast<size_t>(juce::jmax(0, info.blockSizeSamples)), 0.0f);
-    postTapScratch_.assign(static_cast<size_t>(juce::jmax(0, info.blockSizeSamples)), 0.0f);
+juce::String MagdaEqCompiledPlugin::slotId(int slotIndex) const {
+    // Pinned rather than derived from the slot name: these ids key eight bands
+    // of saved state, and "band3_filter_type" is not what the default scheme
+    // would make of "Band 3 Type".
+    if (slotIndex < 0 || slotIndex > kOutputSlot)
+        return {};
+    if (slotIndex == kOutputSlot)
+        return "magda_eq_output";
+
+    static const char* kRoleSuffix[kSlotsPerBand] = {"enabled", "filter_type", "freq", "gain", "q"};
+    return "magda_eq_" + bandIdPrefix(slotIndex / kSlotsPerBand) + "_" +
+           kRoleSuffix[slotIndex % kSlotsPerBand];
+}
+
+void MagdaEqCompiledPlugin::flushState(juce::ValueTree& state) {
+    state.setProperty("curveCollapsed", curveCollapsed_, nullptr);
+}
+
+void MagdaEqCompiledPlugin::restoreState(const juce::ValueTree& state) {
+    curveCollapsed_ = static_cast<bool>(state.getProperty("curveCollapsed", true));
+}
+
+MagdaEqCompiledPlugin::BandSnapshot MagdaEqCompiledPlugin::getBandSnapshot(int band) const {
+    BandSnapshot snapshot;
+    if (band < 0 || band >= kBandCount)
+        return snapshot;
+
+    snapshot.enabled = slotDisplayValue(bandSlot(band, kBandEnabledOffset)) >= 0.5f;
+    const int typeIndex = juce::jlimit(
+        0, kBandTypeCount - 1,
+        static_cast<int>(std::lround(slotDisplayValue(bandSlot(band, kBandTypeOffset)))));
+    snapshot.type = static_cast<BandType>(typeIndex);
+    snapshot.freq = slotDisplayValue(bandSlot(band, kBandFreqOffset));
+    snapshot.gainDb = slotDisplayValue(bandSlot(band, kBandGainOffset));
+    snapshot.q = slotDisplayValue(bandSlot(band, kBandQOffset));
+    return snapshot;
+}
+
+void MagdaEqCompiledPlugin::onPrepare(double, int maximumBlockSize) {
+    preTapScratch_.assign(static_cast<size_t>(std::max(0, maximumBlockSize)), 0.0f);
+    postTapScratch_.assign(static_cast<size_t>(std::max(0, maximumBlockSize)), 0.0f);
     for (auto& bandStates : biquadStates_)
         bandStates.clear();
 }
 
-void MagdaEqCompiledPlugin::deinitialise() {
+void MagdaEqCompiledPlugin::onRelease() {
     preTapScratch_.clear();
     postTapScratch_.clear();
     for (auto& bandStates : biquadStates_)
         bandStates.clear();
 }
 
-void MagdaEqCompiledPlugin::reset() {
+void MagdaEqCompiledPlugin::onReset() {
     for (auto& bandStates : biquadStates_)
         for (auto& state : bandStates)
             state = {};
 }
 
-float MagdaEqCompiledPlugin::readSlotDisplayValue(int slotIndex) const {
-    if (slotIndex < 0 || slotIndex >= kHostSlotCount)
-        return 0.0f;
-
-    const auto info = parameterInfoForSlot(hostSlotInfo_[static_cast<size_t>(slotIndex)]);
-    if (const auto* param = hostParams_[static_cast<size_t>(slotIndex)].get())
-        return magda::ParameterUtils::normalizedToReal(param->getCurrentValue(), info);
-
-    return hostSlotInfo_[static_cast<size_t>(slotIndex)].defaultValue;
-}
-
-MagdaEqCompiledPlugin::BandSnapshot MagdaEqCompiledPlugin::readBandSnapshot(int band) const {
-    BandSnapshot snap;
-    if (band < 0 || band >= kBandCount)
-        return snap;
-
-    snap.enabled = readSlotDisplayValue(bandSlot(band, kBandEnabledOffset)) >= 0.5f;
-    const int typeIndex = juce::jlimit(
-        0, kBandTypeCount - 1,
-        static_cast<int>(std::round(readSlotDisplayValue(bandSlot(band, kBandTypeOffset)))));
-    snap.type = static_cast<BandType>(typeIndex);
-    snap.freq = readSlotDisplayValue(bandSlot(band, kBandFreqOffset));
-    snap.gainDb = readSlotDisplayValue(bandSlot(band, kBandGainOffset));
-    snap.q = readSlotDisplayValue(bandSlot(band, kBandQOffset));
-    return snap;
-}
-
-void MagdaEqCompiledPlugin::applyToBuffer(const te::PluginRenderContext& fc) {
-    if (!fc.destBuffer || fc.bufferNumSamples <= 0)
-        return;
-
-    const int numSamples = fc.bufferNumSamples;
-    const int startSample = fc.bufferStartSample;
-    const int hostChannels = fc.destBuffer->getNumChannels();
+void MagdaEqCompiledPlugin::processAudio(DeviceProcessContext& context) {
+    // No Faust engine: the bands are MAGDA-owned RBJ biquads so the audible
+    // response and the curve view share one piece of coefficient maths.
+    const int numSamples = context.numSamples;
+    const int startSample = context.startSample;
+    const int hostChannels = context.audio->getNumChannels();
     if (hostChannels <= 0)
         return;
 
@@ -329,98 +258,58 @@ void MagdaEqCompiledPlugin::applyToBuffer(const te::PluginRenderContext& fc) {
         if (static_cast<int>(bandStates.size()) < hostChannels)
             bandStates.resize(static_cast<size_t>(hostChannels));
 
-    const float sr = static_cast<float>(sampleRate_.load(std::memory_order_relaxed));
+    const float sampleRate = static_cast<float>(currentSampleRate());
     std::array<bool, kBandCount> bandEnabled{};
     std::array<RbjCoeffs, kBandCount> coeffs{};
     for (int band = 0; band < kBandCount; ++band) {
-        const auto snap = readBandSnapshot(band);
-        bandEnabled[static_cast<size_t>(band)] = snap.enabled;
-        if (!snap.enabled) {
+        const auto snapshot = getBandSnapshot(band);
+        bandEnabled[static_cast<size_t>(band)] = snapshot.enabled;
+        if (!snapshot.enabled) {
             auto& states = biquadStates_[static_cast<size_t>(band)];
             std::fill(states.begin(), states.end(), BiquadState{});
             continue;
         }
-        coeffs[static_cast<size_t>(band)] = makeRbj(snap.type, snap.freq, snap.gainDb, snap.q, sr);
+        coeffs[static_cast<size_t>(band)] =
+            makeRbj(snapshot.type, snapshot.freq, snapshot.gainDb, snapshot.q, sampleRate);
     }
-    const float outputGain = std::pow(10.0f, readSlotDisplayValue(kOutputSlot) / 20.0f);
+    const float outputGain = std::pow(10.0f, slotDisplayValue(kOutputSlot) / 20.0f);
 
     std::fill_n(preTapScratch_.data(), numSamples, 0.0f);
-    for (int ch = 0; ch < hostChannels; ++ch) {
-        const float* src = fc.destBuffer->getReadPointer(ch, startSample);
+    for (int channel = 0; channel < hostChannels; ++channel) {
+        const float* source = context.audio->getReadPointer(channel, startSample);
         for (int i = 0; i < numSamples; ++i)
-            preTapScratch_[static_cast<size_t>(i)] += src[i];
+            preTapScratch_[static_cast<size_t>(i)] += source[i];
     }
-    const float preInv = 1.0f / static_cast<float>(hostChannels);
+    const float channelInverse = 1.0f / static_cast<float>(hostChannels);
     for (int i = 0; i < numSamples; ++i)
-        preTapScratch_[static_cast<size_t>(i)] *= preInv;
+        preTapScratch_[static_cast<size_t>(i)] *= channelInverse;
     preSpectrumTap_.write(preTapScratch_.data(), numSamples);
 
     // Heavy boosts at high Q can rarely produce non-finite samples during a
-    // quick freq/Q sweep. Clamp+sanitise mirrors the other compiled plugins.
+    // quick freq/Q sweep, so the output goes through the same sanitising pass
+    // every compiled device applies.
     std::fill_n(postTapScratch_.data(), numSamples, 0.0f);
-    for (int ch = 0; ch < hostChannels; ++ch) {
-        float* out = fc.destBuffer->getWritePointer(ch, startSample);
+    for (int channel = 0; channel < hostChannels; ++channel) {
+        float* out = context.audio->getWritePointer(channel, startSample);
         for (int i = 0; i < numSamples; ++i) {
             float sample = out[i];
             for (int band = 0; band < kBandCount; ++band) {
                 if (!bandEnabled[static_cast<size_t>(band)])
                     continue;
-                sample =
-                    processRbj(sample, coeffs[static_cast<size_t>(band)],
-                               biquadStates_[static_cast<size_t>(band)][static_cast<size_t>(ch)]);
+                sample = processRbj(
+                    sample, coeffs[static_cast<size_t>(band)],
+                    biquadStates_[static_cast<size_t>(band)][static_cast<size_t>(channel)]);
             }
-            sample *= outputGain;
-            const float sanitized =
-                std::isfinite(sample) ? juce::jlimit(-16.0f, 16.0f, sample) : 0.0f;
+            const float sanitized = sanitise(sample * outputGain);
             out[i] = sanitized;
             postTapScratch_[static_cast<size_t>(i)] += sanitized;
         }
     }
-    const float postInv = 1.0f / static_cast<float>(hostChannels);
     for (int i = 0; i < numSamples; ++i)
-        postTapScratch_[static_cast<size_t>(i)] *= postInv;
+        postTapScratch_[static_cast<size_t>(i)] *= channelInverse;
     postSpectrumTap_.write(postTapScratch_.data(), numSamples);
 }
 
-te::AutomatableParameter* MagdaEqCompiledPlugin::getSlotParameter(int slotIndex) const {
-    if (slotIndex < 0 || slotIndex >= kHostSlotCount)
-        return nullptr;
-    return hostParams_[static_cast<size_t>(slotIndex)].get();
-}
-
-const MagdaEqCompiledPlugin::HostSlotInfo& MagdaEqCompiledPlugin::getSlotInfo(int slotIndex) const {
-    static const HostSlotInfo kEmpty;
-    if (slotIndex < 0 || slotIndex >= kHostSlotCount)
-        return kEmpty;
-    return hostSlotInfo_[static_cast<size_t>(slotIndex)];
-}
-
-float MagdaEqCompiledPlugin::displayValueToNativeValue(int slotIndex, float displayValue) const {
-    if (slotIndex < 0 || slotIndex >= kHostSlotCount)
-        return displayValue;
-    const auto info = parameterInfoForSlot(hostSlotInfo_[static_cast<size_t>(slotIndex)]);
-    return magda::ParameterUtils::realToNormalized(displayValue, info);
-}
-
-float MagdaEqCompiledPlugin::nativeValueToDisplayValue(int slotIndex, float nativeValue) const {
-    if (slotIndex < 0 || slotIndex >= kHostSlotCount)
-        return nativeValue;
-    const auto info = parameterInfoForSlot(hostSlotInfo_[static_cast<size_t>(slotIndex)]);
-    return magda::ParameterUtils::normalizedToReal(nativeValue, info);
-}
-
-MagdaEqCompiledPlugin::BandSnapshot MagdaEqCompiledPlugin::getBandSnapshot(int band) const {
-    return readBandSnapshot(band);
-}
-
-float MagdaEqCompiledPlugin::getOutputDb() const {
-    return readSlotDisplayValue(kOutputSlot);
-}
-
-namespace {
-
-// AI-chat aliases — one per slot. The slot index is what gets passed to
-// setSlotValue, so the alias just needs to point at the right host slot.
 constexpr AliasSpec kAliases[] = {
     {"band1_enabled", 0, "Band 1 Enabled"},
     {"band1_type", 1, "Band 1 Type"},
@@ -468,8 +357,6 @@ constexpr AliasSpec kAliases[] = {
 // Tracktion's retired 4-band EQ loads here; see core/LegacyDeviceAliases.hpp.
 constexpr const char* kLoadAliases[] = {"4bandEq", "eq", "equaliser"};
 
-}  // namespace
-
 const CompiledPluginSpec& getMagdaEqSpec() {
     static const CompiledPluginSpec kSpec{
         .pluginId = MagdaEqCompiledPlugin::xmlTypeName,
@@ -483,9 +370,8 @@ const CompiledPluginSpec& getMagdaEqSpec() {
                        "MAGDA-owned RBJ biquads drive audio and share coefficient math with "
                        "the curve view. "
                        "Each band exposes Freq, Gain, Q; Output trims the final sum.",
-        .createPlugin = [](const DevicePluginCreationContext& context) -> DevicePluginPtr {
-            return tracktion_adapter::pluginHandle(
-                new MagdaEqCompiledPlugin(tracktion_adapter::creationInfo(context)));
+        .createDevice = [](const DevicePluginCreationContext&) -> std::unique_ptr<MagdaDevice> {
+            return std::make_unique<MagdaEqCompiledPlugin>();
         },
         .aliases = kAliases,
         .aliasCount = static_cast<int>(sizeof(kAliases) / sizeof(kAliases[0])),

--- a/magda/daw/audio/plugins/compiled/MagdaEqCompiledPlugin.hpp
+++ b/magda/daw/audio/plugins/compiled/MagdaEqCompiledPlugin.hpp
@@ -1,15 +1,11 @@
 #pragma once
 
-#include <tracktion_engine/tracktion_engine.h>
-
 #include <array>
 #include <atomic>
-#include <memory>
 #include <vector>
 
 #include "analysis/AudioTapBuffer.hpp"
-#include "core/ParameterInfo.hpp"
-#include "plugins/compiled/tracktion/CompiledFaustTracktionAdapter.hpp"
+#include "plugins/compiled/MagdaCompiledEffect.hpp"
 
 namespace magda::daw::audio::compiled {
 
@@ -28,44 +24,16 @@ namespace magda::daw::audio::compiled {
  *   5*band + 4 → Q       (0.1..10)
  *   40         → Output  (dB, -24..+12)
  */
-class MagdaEqCompiledPlugin : public te::Plugin, public ICompiledFaustPlugin {
+class MagdaEqCompiledPlugin : public MagdaCompiledEffect {
   public:
     static const char* xmlTypeName;
 
-    explicit MagdaEqCompiledPlugin(const te::PluginCreationInfo& info);
-    ~MagdaEqCompiledPlugin() override;
-
-    juce::String getName() const override;
-    juce::String getPluginType() override;
-    juce::String getShortName(int) override;
-    juce::String getSelectableDescription() override;
-
-    void initialise(const te::PluginInitialisationInfo& info) override;
-    void deinitialise() override;
-    void reset() override;
-    void applyToBuffer(const te::PluginRenderContext& fc) override;
-
-    bool takesMidiInput() override {
-        return false;
-    }
-    bool takesAudioInput() override {
-        return true;
-    }
-    bool isSynth() override {
-        return false;
-    }
-    bool producesAudioWhenNoAudioInput() override {
-        return false;
-    }
-    double getTailLength() const override {
-        return 0.0;
-    }
+    MagdaEqCompiledPlugin();
 
     static constexpr int kBandCount = 8;
     static constexpr int kSlotsPerBand = 5;                         // Enabled, Type, Freq, Gain, Q
     static constexpr int kOutputSlot = kBandCount * kSlotsPerBand;  // 40
     static constexpr int kHostSlotCount = kOutputSlot + 1;          // 41
-
     enum class BandType {
         Highpass = 0,
         LowShelf = 1,
@@ -75,28 +43,13 @@ class MagdaEqCompiledPlugin : public te::Plugin, public ICompiledFaustPlugin {
         Notch = 5
     };
     static constexpr int kBandTypeCount = 6;
-
-    // Sub-slot offsets within a band.
     static constexpr int kBandEnabledOffset = 0;
     static constexpr int kBandTypeOffset = 1;
     static constexpr int kBandFreqOffset = 2;
     static constexpr int kBandGainOffset = 3;
     static constexpr int kBandQOffset = 4;
 
-    static int bandSlot(int band, int offset) {
-        return band * kSlotsPerBand + offset;
-    }
-
-    te::AutomatableParameter* getSlotParameter(int slotIndex) const;
-
-    float displayValueToNativeValue(int slotIndex, float displayValue) const;
-    float nativeValueToDisplayValue(int slotIndex, float nativeValue) const;
-
-    using HostSlotInfo = CompiledHostSlotInfo;
-    const HostSlotInfo& getSlotInfo(int slotIndex) const;
-
-    // Live per-band state for the curve view — these are the smoothed
-    // values currently driving the audio thread.
+    /// Live per-band state: the values currently driving the audio thread.
     struct BandSnapshot {
         bool enabled = false;
         BandType type = BandType::Bell;
@@ -105,7 +58,9 @@ class MagdaEqCompiledPlugin : public te::Plugin, public ICompiledFaustPlugin {
         float q = 1.0f;
     };
     BandSnapshot getBandSnapshot(int band) const;
-    float getOutputDb() const;
+    float getOutputDb() const {
+        return slotDisplayValue(kOutputSlot);
+    }
     const magda::daw::audio::AudioTapBuffer& getPreSpectrumTapBuffer() const {
         return preSpectrumTap_;
     }
@@ -113,36 +68,21 @@ class MagdaEqCompiledPlugin : public te::Plugin, public ICompiledFaustPlugin {
         return postSpectrumTap_;
     }
     double getSampleRate() const {
-        return sampleRate_.load(std::memory_order_relaxed);
+        return currentSampleRate();
     }
 
-    /// "Collapse knobs" toggle persisted on the plugin's state ValueTree
-    /// so the user's preferred slot layout survives project reload.
-    /// Defaults to true (curve takes the full slot body) since the curve
-    /// is the EQ's primary surface.
+    /// "Collapse knobs" toggle, persisted on the device's state so the user's
+    /// preferred slot layout survives a project reload. Defaults to true: the
+    /// curve is the EQ's primary surface.
     bool isCurveCollapsed() const {
-        return curveCollapsed_.get();
+        return curveCollapsed_;
     }
     void setCurveCollapsed(bool collapsed) {
         curveCollapsed_ = collapsed;
     }
 
-    // ICompiledFaustPlugin
-    int hostSlotCount() const override {
-        return kHostSlotCount;
-    }
-    const CompiledHostSlotInfo& hostSlotInfo(int slotIndex) const override {
-        return getSlotInfo(slotIndex);
-    }
-    DeviceParameterHandle hostSlotParameter(int slotIndex) const override {
-        return tracktion_adapter::parameterHandle(getSlotParameter(slotIndex));
-    }
-    float displayToNormalized(int slotIndex, float displayValue) const override {
-        return displayValueToNativeValue(slotIndex, displayValue);
-    }
-    float normalizedToDisplay(int slotIndex, float normalizedValue) const override {
-        return nativeValueToDisplayValue(slotIndex, normalizedValue);
-    }
+    void flushState(juce::ValueTree& state) override;
+    void restoreState(const juce::ValueTree& state) override;
 
     struct BiquadState {
         float x1 = 0.0f;
@@ -151,22 +91,35 @@ class MagdaEqCompiledPlugin : public te::Plugin, public ICompiledFaustPlugin {
         float y2 = 0.0f;
     };
 
-  private:
-    void buildHostParameters();
-    void rebuildEngineState(int sampleRate);
-    float readSlotDisplayValue(int slotIndex) const;
-    BandSnapshot readBandSnapshot(int band) const;
+    static int bandSlot(int band, int offset) {
+        return band * kSlotsPerBand + offset;
+    }
 
-    std::array<HostSlotInfo, kHostSlotCount> hostSlotInfo_;
-    std::array<te::AutomatableParameter::Ptr, kHostSlotCount> hostParams_;
-    std::array<juce::CachedValue<float>, kHostSlotCount> hostCached_;
-    juce::CachedValue<bool> curveCollapsed_;
+    juce::String devicePluginId() const override {
+        return xmlTypeName;
+    }
+    juce::String deviceName() const override {
+        return "EQ";
+    }
+
+  protected:
+    std::vector<HostSlotInfo> slotInfos() const override;
+    const char* slotIdPrefix() const override {
+        return "magda_eq_";
+    }
+    juce::String slotId(int slotIndex) const override;
+    void onPrepare(double sampleRate, int maximumBlockSize) override;
+    void onRelease() override;
+    void onReset() override;
+    void processAudio(DeviceProcessContext& context) override;
+
+  private:
+    bool curveCollapsed_ = true;
 
     std::vector<float> preTapScratch_;
     std::vector<float> postTapScratch_;
     magda::daw::audio::AudioTapBuffer preSpectrumTap_{8192};
     magda::daw::audio::AudioTapBuffer postSpectrumTap_{8192};
-    std::atomic<double> sampleRate_{44100.0};
     std::array<std::vector<BiquadState>, kBandCount> biquadStates_;
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(MagdaEqCompiledPlugin)

--- a/magda/daw/audio/plugins/compiled/MagdaFilterCompiledPlugin.cpp
+++ b/magda/daw/audio/plugins/compiled/MagdaFilterCompiledPlugin.cpp
@@ -2,28 +2,18 @@
 
 #include <algorithm>
 #include <cmath>
-#include <map>
 
-#include "core/ParameterUtils.hpp"
+#include "core/ParameterInfo.hpp"
 #include "faust/dsp/dsp.h"
 #include "faust/gui/UI.h"
 #include "faust/gui/meta.h"
-#include "plugins/FaustMetadataParser.hpp"
-#include "plugins/FaustParamInfo.hpp"
-#include "plugins/compiled/CompiledPluginRegistry.hpp"
-#include "plugins/tracktion/TracktionDeviceAdapters.hpp"
-
-// All six engine DSPs are #included into THIS translation unit only —
-// each generated `.cpp` defines a self-contained class, so co-locating
-// them lets us instantiate one of each without conflicts. The per-engine
-// wrapper TUs (MagdaSVFCompiled.cpp etc.) are removed; this file is the
-// single owner of the generated code from now on.
 #include "magda_filter_diode.generated.cpp"
 #include "magda_filter_korg35.generated.cpp"
 #include "magda_filter_ladder.generated.cpp"
 #include "magda_filter_oberheim.generated.cpp"
 #include "magda_filter_sk.generated.cpp"
 #include "magda_filter_svf.generated.cpp"
+#include "plugins/compiled/CompiledPluginRegistry.hpp"
 
 namespace magda::daw::audio::compiled {
 
@@ -31,102 +21,11 @@ const char* MagdaFilterCompiledPlugin::xmlTypeName = "magda_filter";
 
 namespace {
 
-// ============================================================================
-// HarvestUI — stripped-down version that just records each control's
-// idx, kind, zone, range, and choices. We don't need the full
-// FaustParamPool harvest because the merged plugin builds host params
-// manually; we only need to find the cutoff/res/drive/mode zones per
-// engine.
-// ============================================================================
-
-struct EngineHarvest {
-    struct Control {
-        int idx = -1;
-        FaustParamSlot::Kind kind = FaustParamSlot::Kind::Continuous;
-        FAUSTFLOAT* zone = nullptr;
-        std::vector<std::pair<float, juce::String>> choices;
-    };
-    std::vector<Control> controls;
-};
-
-class EngineHarvester : public ::UI {
-  public:
-    EngineHarvest harvest;
-
-    void openTabBox(const char*) override {}
-    void openHorizontalBox(const char*) override {}
-    void openVerticalBox(const char*) override {}
-    void closeBox() override {}
-
-    void addButton(const char* label, FAUSTFLOAT* zone) override {
-        emitControl(FaustParamSlot::Kind::Boolean, label, zone);
-    }
-    void addCheckButton(const char* label, FAUSTFLOAT* zone) override {
-        emitControl(FaustParamSlot::Kind::Boolean, label, zone);
-    }
-    void addVerticalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT, FAUSTFLOAT, FAUSTFLOAT,
-                           FAUSTFLOAT) override {
-        emitControl(FaustParamSlot::Kind::Continuous, label, zone);
-    }
-    void addHorizontalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT, FAUSTFLOAT,
-                             FAUSTFLOAT, FAUSTFLOAT) override {
-        emitControl(FaustParamSlot::Kind::Continuous, label, zone);
-    }
-    void addNumEntry(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT, FAUSTFLOAT, FAUSTFLOAT,
-                     FAUSTFLOAT) override {
-        emitControl(FaustParamSlot::Kind::Continuous, label, zone);
-    }
-    void addHorizontalBargraph(const char*, FAUSTFLOAT*, FAUSTFLOAT, FAUSTFLOAT) override {}
-    void addVerticalBargraph(const char*, FAUSTFLOAT*, FAUSTFLOAT, FAUSTFLOAT) override {}
-    void addSoundfile(const char*, const char*, Soundfile**) override {}
-
-    // Faust's compiled C++ output emits `[key:value]` annotations through
-    // per-zone `declare()` calls BEFORE the matching addControl() call —
-    // not embedded in the displayed label. We collect those declares into
-    // `pendingByZone` and merge them in when the control is emitted, so
-    // `[idx:N]` and `[style:menu{...}]` end up on the right entry.
-    void declare(FAUSTFLOAT* zone, const char* key, const char* value) override {
-        if (zone == nullptr)
-            return;
-        const auto k = juce::String::fromUTF8(key != nullptr ? key : "").toLowerCase();
-        const auto v = juce::String::fromUTF8(value != nullptr ? value : "");
-        applyFaustAnnotation(k, v, pendingByZone_[zone]);
-    }
-
-  private:
-    void emitControl(FaustParamSlot::Kind kind, const char* rawLabel, FAUSTFLOAT* zone) {
-        const auto parsed =
-            parseFaustLabel(juce::String::fromUTF8(rawLabel != nullptr ? rawLabel : ""));
-        ControlMetadata merged = parsed.metadata;
-        if (zone != nullptr) {
-            if (auto it = pendingByZone_.find(zone); it != pendingByZone_.end()) {
-                mergeFaustMetadata(merged, it->second);
-                pendingByZone_.erase(it);
-            }
-        }
-
-        EngineHarvest::Control c;
-        c.idx = merged.slotIndex;
-        c.kind = merged.isChoiceStyle() ? FaustParamSlot::Kind::Discrete : kind;
-        c.zone = zone;
-        c.choices = merged.menuChoices;
-        harvest.controls.push_back(std::move(c));
-    }
-
-    std::map<FAUSTFLOAT*, ControlMetadata> pendingByZone_;
-};
-
-// Find a control in a harvest by its idx — returns nullptr if missing.
-const EngineHarvest::Control* findByIdx(const EngineHarvest& h, int idx) {
-    for (const auto& c : h.controls) {
-        if (c.idx == idx)
-            return &c;
-    }
-    return nullptr;
-}
-
-float clampSallenKeyCutoffHz(float cutoffHz, int sampleRate, float minCutoffHz) {
-    if (sampleRate <= 0)
+/// Sallen-Key goes unstable as its cutoff approaches Nyquist, so it gets a
+/// lower ceiling than the host slot's own range. The other five take the
+/// slider's value as it stands.
+float clampSallenKeyCutoffHz(float cutoffHz, double sampleRate, float minCutoffHz) {
+    if (sampleRate <= 0.0)
         return cutoffHz;
 
     constexpr float kStableNyquistFraction = 0.84f;
@@ -138,342 +37,94 @@ float clampSallenKeyCutoffHz(float cutoffHz, int sampleRate, float minCutoffHz) 
 
 }  // namespace
 
-// ============================================================================
-// MagdaFilterCompiledPlugin
-// ============================================================================
-
-MagdaFilterCompiledPlugin::MagdaFilterCompiledPlugin(const te::PluginCreationInfo& info)
-    : te::Plugin(info) {
-    // Instantiate all six engines.
-    engines_[0].dsp = std::make_unique<MagdaSVFDsp>();
-    engines_[1].dsp = std::make_unique<MagdaLadderDsp>();
-    engines_[2].dsp = std::make_unique<MagdaKorg35Dsp>();
-    engines_[3].dsp = std::make_unique<MagdaOberheimDsp>();
-    engines_[4].dsp = std::make_unique<MagdaSallenKeyDsp>();
-    engines_[5].dsp = std::make_unique<MagdaDiodeDsp>();
-
-    constexpr int kProvisionalSampleRate = 44100;
-    rebuildEngineState(kProvisionalSampleRate);
-    buildHostParameters();
+MagdaFilterCompiledPlugin::MagdaFilterCompiledPlugin() {
+    initEffect();
 }
 
-MagdaFilterCompiledPlugin::~MagdaFilterCompiledPlugin() {
-    notifyListenersOfDeletion();
-    for (auto& p : hostParams_)
-        if (p)
-            p->detachFromCurrentValue();
-}
-
-juce::String MagdaFilterCompiledPlugin::getName() const {
-    return "Filter";
-}
-juce::String MagdaFilterCompiledPlugin::getPluginType() {
-    return xmlTypeName;
-}
-juce::String MagdaFilterCompiledPlugin::getShortName(int) {
-    return "Filter";
-}
-juce::String MagdaFilterCompiledPlugin::getSelectableDescription() {
-    return "Filter";
-}
-
-void MagdaFilterCompiledPlugin::rebuildEngineState(int sampleRate) {
-    for (size_t engineIdx = 0; engineIdx < engines_.size(); ++engineIdx) {
-        auto& e = engines_[engineIdx];
-        if (!e.dsp)
-            continue;
-        e.sampleRate = sampleRate;
-        e.dsp->init(sampleRate);
-        e.numInputs = e.dsp->getNumInputs();
-        e.numOutputs = e.dsp->getNumOutputs();
-
-        EngineHarvester harvester;
-        e.dsp->buildUserInterface(&harvester);
-
-        e.cutoffZone = nullptr;
-        e.resZone = nullptr;
-        e.driveZone = nullptr;
-        e.modeZone = nullptr;
-        e.modeChoiceValues.clear();
-
-        if (auto* c = findByIdx(harvester.harvest, 0))
-            e.cutoffZone = c->zone;
-        if (auto* c = findByIdx(harvester.harvest, 1))
-            e.resZone = c->zone;
-        if (auto* c = findByIdx(harvester.harvest, 2))
-            e.driveZone = c->zone;
-        if (auto* c = findByIdx(harvester.harvest, 3)) {
-            e.modeZone = c->zone;
-            auto sorted = c->choices;
-            std::sort(sorted.begin(), sorted.end(),
-                      [](const auto& a, const auto& b) { return a.first < b.first; });
-            e.modeChoiceValues.reserve(sorted.size());
-            for (const auto& choice : sorted)
-                e.modeChoiceValues.push_back(choice.first);
-        }
+::dsp* MagdaFilterCompiledPlugin::createEngineDsp(int engineIndex) const {
+    switch (static_cast<FilterFamily>(engineIndex)) {
+        case FilterFamily::SVF:
+            return new MagdaSVFDsp();
+        case FilterFamily::Ladder:
+            return new MagdaLadderDsp();
+        case FilterFamily::Korg35:
+            return new MagdaKorg35Dsp();
+        case FilterFamily::Oberheim:
+            return new MagdaOberheimDsp();
+        case FilterFamily::SallenKey:
+            return new MagdaSallenKeyDsp();
+        case FilterFamily::Diode:
+            return new MagdaDiodeDsp();
     }
+    return nullptr;
 }
 
-void MagdaFilterCompiledPlugin::buildHostParameters() {
+std::vector<MagdaFilterCompiledPlugin::HostSlotInfo> MagdaFilterCompiledPlugin::slotInfos() const {
+    std::vector<HostSlotInfo> infos(kHostSlotCount);
     // Slot 0: Cutoff (continuous, log, anchored at 1 kHz)
-    hostSlotInfo_[kCutoffSlot] = {.name = "Cutoff",
-                                  .unit = magda::technicalText(magda::TechnicalTextToken::Hertz),
-                                  .scale = magda::ParameterScale::Logarithmic,
-                                  .minValue = 20.0f,
-                                  .maxValue = 20000.0f,
-                                  .defaultValue = 1000.0f,
-                                  .scaleAnchor = 1000.0f};
+    infos[kCutoffSlot] = {.name = "Cutoff",
+                          .unit = magda::technicalText(magda::TechnicalTextToken::Hertz),
+                          .scale = magda::ParameterScale::Logarithmic,
+                          .minValue = 20.0f,
+                          .maxValue = 20000.0f,
+                          .defaultValue = 1000.0f,
+                          .scaleAnchor = 1000.0f};
     // Slot 1: Resonance (continuous, linear, 0..1)
-    hostSlotInfo_[kResonanceSlot] = {.name = "Resonance",
-                                     .scale = magda::ParameterScale::Linear,
-                                     .minValue = 0.0f,
-                                     .maxValue = 1.0f,
-                                     .defaultValue = 0.0f};
+    infos[kResonanceSlot] = {.name = "Resonance",
+                             .scale = magda::ParameterScale::Linear,
+                             .minValue = 0.0f,
+                             .maxValue = 1.0f,
+                             .defaultValue = 0.0f};
     // Slot 2: Drive (continuous, linear, 0..1)
-    hostSlotInfo_[kDriveSlot] = {.name = "Drive",
-                                 .scale = magda::ParameterScale::Linear,
-                                 .minValue = 0.0f,
-                                 .maxValue = 1.0f,
-                                 .defaultValue = 0.0f};
+    infos[kDriveSlot] = {.name = "Drive",
+                         .scale = magda::ParameterScale::Linear,
+                         .minValue = 0.0f,
+                         .maxValue = 1.0f,
+                         .defaultValue = 0.0f};
     // Slot 3: Engine (discrete, 6 options)
-    hostSlotInfo_[kEngineSlot].name = "Engine";
-    hostSlotInfo_[kEngineSlot].scale = magda::ParameterScale::Discrete;
-    hostSlotInfo_[kEngineSlot].choices = {"SVF",      "Ladder",     "Korg 35",
-                                          "Oberheim", "Sallen-Key", "Diode"};
-    hostSlotInfo_[kEngineSlot].minValue = 0.0f;
-    hostSlotInfo_[kEngineSlot].maxValue =
-        static_cast<float>(hostSlotInfo_[kEngineSlot].choices.size() - 1);
-    hostSlotInfo_[kEngineSlot].defaultValue = 0.0f;
+    infos[kEngineSlot].name = "Engine";
+    infos[kEngineSlot].scale = magda::ParameterScale::Discrete;
+    infos[kEngineSlot].choices = {"SVF", "Ladder", "Korg 35", "Oberheim", "Sallen-Key", "Diode"};
+    infos[kEngineSlot].minValue = 0.0f;
+    infos[kEngineSlot].maxValue = static_cast<float>(infos[kEngineSlot].choices.size() - 1);
+    infos[kEngineSlot].defaultValue = 0.0f;
     // Slot 4: Mode (discrete, 4 options) — engine-specific fallback at runtime
-    hostSlotInfo_[kModeSlot].name = "Mode";
-    hostSlotInfo_[kModeSlot].scale = magda::ParameterScale::Discrete;
-    hostSlotInfo_[kModeSlot].choices = {"LP", "BP", "HP", "Notch"};
-    hostSlotInfo_[kModeSlot].minValue = 0.0f;
-    hostSlotInfo_[kModeSlot].maxValue =
-        static_cast<float>(hostSlotInfo_[kModeSlot].choices.size() - 1);
-    hostSlotInfo_[kModeSlot].defaultValue = 0.0f;
+    infos[kModeSlot].name = "Mode";
+    infos[kModeSlot].scale = magda::ParameterScale::Discrete;
+    infos[kModeSlot].choices = {"LP", "BP", "HP", "Notch"};
+    infos[kModeSlot].minValue = 0.0f;
+    infos[kModeSlot].maxValue = static_cast<float>(infos[kModeSlot].choices.size() - 1);
+    infos[kModeSlot].defaultValue = 0.0f;
     // Slot 5: Limit blends a post-filter soft limiter into the active engine.
-    hostSlotInfo_[kLimitSlot] = {.name = "Limit",
-                                 .scale = magda::ParameterScale::Linear,
-                                 .minValue = 0.0f,
-                                 .maxValue = 1.0f,
-                                 .defaultValue = 0.0f};
+    infos[kLimitSlot] = {.name = "Limit",
+                         .scale = magda::ParameterScale::Linear,
+                         .minValue = 0.0f,
+                         .maxValue = 1.0f,
+                         .defaultValue = 0.0f};
 
-    juce::NormalisableRange<float> normalisedRange{0.0f, 1.0f};
-    auto* undoManager = getUndoManager();
+    return infos;
+}
 
-    auto buildInfo = [](const HostSlotInfo& s) {
-        magda::ParameterInfo info;
-        info.minValue = s.minValue;
-        info.maxValue = s.maxValue;
-        info.defaultValue = s.defaultValue;
-        info.unit = s.unit;
-        info.scale = s.scale;
-        if (std::isfinite(s.scaleAnchor))
-            info.scaleAnchor = s.scaleAnchor;
-        info.choices = s.choices;
-        return info;
-    };
-
-    for (int i = 0; i < kHostSlotCount; ++i) {
-        const auto& slot = hostSlotInfo_[i];
-        const juce::String id = "magda_filter_" + slot.name.toLowerCase().replace(" ", "_");
-        const juce::Identifier identifier(id);
-        const auto info = buildInfo(slot);
-        const float defaultNormalized =
-            magda::ParameterUtils::realToNormalized(slot.defaultValue, info);
-        hostCached_[i].referTo(state, identifier, undoManager, defaultNormalized);
-
-        auto param = addParam(
-            id, slot.name, normalisedRange,
-            [info](float normalized) {
-                const float real = magda::ParameterUtils::normalizedToReal(normalized, info);
-                return magda::ParameterUtils::formatValue(real, info);
-            },
-            [info](const juce::String& text) {
-                auto parsed = magda::ParameterUtils::parseValue(text, info);
-                if (parsed)
-                    return magda::ParameterUtils::realToNormalized(*parsed, info);
-                return 0.0f;
-            });
-        param->attachToCurrentValue(hostCached_[i]);
-        hostParams_[i] = param;
+int MagdaFilterCompiledPlugin::slotForDspIdx(int idx) const {
+    // The dsps number Cutoff / Resonance / Drive / Mode 0..3. The host table
+    // puts Engine between Drive and Mode, because Engine is the top-level
+    // choice and belongs next to them on the panel, and no dsp has a zone for
+    // it. Limit is wrapper-only for the same reason.
+    switch (idx) {
+        case 0:
+            return kCutoffSlot;
+        case 1:
+            return kResonanceSlot;
+        case 2:
+            return kDriveSlot;
+        case 3:
+            return kModeSlot;
+        default:
+            return -1;
     }
-}
-
-void MagdaFilterCompiledPlugin::initialise(const te::PluginInitialisationInfo& info) {
-    rebuildEngineState(static_cast<int>(info.sampleRate));
-
-    int maxIn = 0, maxOut = 0;
-    for (const auto& e : engines_) {
-        maxIn = std::max(maxIn, e.numInputs);
-        maxOut = std::max(maxOut, e.numOutputs);
-    }
-    scratchIn_.setSize(maxIn, info.blockSizeSamples, false, true, true);
-    scratchOut_.setSize(maxOut, info.blockSizeSamples, false, true, true);
-    inPtrs_.assign(static_cast<size_t>(maxIn), nullptr);
-    outPtrs_.assign(static_cast<size_t>(maxOut), nullptr);
-}
-
-void MagdaFilterCompiledPlugin::deinitialise() {
-    scratchIn_.setSize(0, 0);
-    scratchOut_.setSize(0, 0);
-    inPtrs_.clear();
-    outPtrs_.clear();
-}
-
-void MagdaFilterCompiledPlugin::reset() {
-    for (auto& e : engines_)
-        if (e.dsp)
-            e.dsp->instanceClear();
-}
-
-void MagdaFilterCompiledPlugin::applyToBuffer(const te::PluginRenderContext& fc) {
-    if (!fc.destBuffer || fc.bufferNumSamples <= 0)
-        return;
-
-    // Resolve normalized host param values once per block.
-    const float cutoffNorm = hostParams_[kCutoffSlot]->getCurrentValue();
-    const float resNorm = hostParams_[kResonanceSlot]->getCurrentValue();
-    const float driveNorm = hostParams_[kDriveSlot]->getCurrentValue();
-    const float engineNorm = hostParams_[kEngineSlot]->getCurrentValue();
-    const float modeNorm = hostParams_[kModeSlot]->getCurrentValue();
-    const float limitMix = juce::jlimit(0.0f, 1.0f, hostParams_[kLimitSlot]->getCurrentValue());
-
-    // Denormalize cutoff/res/drive into native units once and write the
-    // same value into every engine's matching zone — keeps every engine's
-    // params in sync so an engine swap preserves the user's settings.
-    const auto cutoffInfo = [this] {
-        magda::ParameterInfo i;
-        i.minValue = hostSlotInfo_[kCutoffSlot].minValue;
-        i.maxValue = hostSlotInfo_[kCutoffSlot].maxValue;
-        i.scale = hostSlotInfo_[kCutoffSlot].scale;
-        i.scaleAnchor = hostSlotInfo_[kCutoffSlot].scaleAnchor;
-        return i;
-    }();
-    const float cutoffHz = magda::ParameterUtils::normalizedToReal(cutoffNorm, cutoffInfo);
-    const float resReal = juce::jlimit(0.0f, 1.0f, resNorm);
-    const float driveReal = juce::jlimit(0.0f, 1.0f, driveNorm);
-
-    const int engineCount = static_cast<int>(engines_.size());
-    const int engineIndex = juce::jlimit(
-        0, engineCount - 1,
-        static_cast<int>(std::round(engineNorm * static_cast<float>(engineCount - 1))));
-    activeEngine_.store(engineIndex);
-
-    for (int e = 0; e < engineCount; ++e) {
-        auto& engine = engines_[e];
-        if (engine.cutoffZone) {
-            float engineCutoffHz = cutoffHz;
-            if (e == static_cast<int>(FilterFamily::SallenKey)) {
-                engineCutoffHz = clampSallenKeyCutoffHz(cutoffHz, engine.sampleRate,
-                                                        hostSlotInfo_[kCutoffSlot].minValue);
-            }
-            *engine.cutoffZone = static_cast<FAUSTFLOAT>(engineCutoffHz);
-        }
-        if (engine.resZone)
-            *engine.resZone = static_cast<FAUSTFLOAT>(resReal);
-        if (engine.driveZone)
-            *engine.driveZone = static_cast<FAUSTFLOAT>(driveReal);
-        // Mode is normalized 0..1 in the host param. Each engine has its
-        // own mode count (Korg35=2, Ladder=1, SVF=4, …); map the normalized
-        // value to this engine's local mode index and write the underlying
-        // Faust value. Same engine-aware count is used for the UI dropdown,
-        // so what the user sees and what audio does stay aligned.
-        if (engine.modeZone && !engine.modeChoiceValues.empty()) {
-            const int count = static_cast<int>(engine.modeChoiceValues.size());
-            const int idx = juce::jlimit(
-                0, count - 1,
-                static_cast<int>(std::round(modeNorm * static_cast<float>(count - 1))));
-            *engine.modeZone = static_cast<FAUSTFLOAT>(engine.modeChoiceValues[idx]);
-        }
-    }
-
-    auto& active = engines_[static_cast<size_t>(engineIndex)];
-    if (!active.dsp)
-        return;
-
-    const int numSamples = fc.bufferNumSamples;
-    const int startSample = fc.bufferStartSample;
-    const int hostChannels = fc.destBuffer->getNumChannels();
-    const int numInputs = active.numInputs;
-    const int numOutputs = active.numOutputs;
-    if (hostChannels <= 0 || numInputs <= 0 || numOutputs <= 0)
-        return;
-
-    // Make sure the scratch buffers can hold this block — and have at least
-    // as many channels as the active engine needs. `initialise()` sizes them
-    // to the max-channels-across-engines, but if a stale 0-channel buffer
-    // ever reaches us we'd otherwise call getWritePointer with an invalid
-    // channel and read garbage / silence.
-    if (scratchIn_.getNumChannels() < numInputs || scratchIn_.getNumSamples() < numSamples)
-        scratchIn_.setSize(numInputs, numSamples, false, true, true);
-    if (scratchOut_.getNumChannels() < numOutputs || scratchOut_.getNumSamples() < numSamples)
-        scratchOut_.setSize(numOutputs, numSamples, false, true, true);
-    if (static_cast<int>(inPtrs_.size()) < numInputs)
-        inPtrs_.resize(static_cast<size_t>(numInputs), nullptr);
-    if (static_cast<int>(outPtrs_.size()) < numOutputs)
-        outPtrs_.resize(static_cast<size_t>(numOutputs), nullptr);
-
-    for (int ch = 0; ch < numInputs; ++ch) {
-        float* dst = scratchIn_.getWritePointer(ch);
-        if (ch < hostChannels) {
-            const float* src = fc.destBuffer->getReadPointer(ch, startSample);
-            std::copy(src, src + numSamples, dst);
-        } else {
-            std::fill(dst, dst + numSamples, 0.0f);
-        }
-        inPtrs_[static_cast<size_t>(ch)] = dst;
-    }
-    for (int ch = 0; ch < numOutputs; ++ch) {
-        outPtrs_[static_cast<size_t>(ch)] = (ch < hostChannels)
-                                                ? fc.destBuffer->getWritePointer(ch, startSample)
-                                                : scratchOut_.getWritePointer(ch);
-    }
-
-    active.dsp->compute(numSamples, inPtrs_.data(), outPtrs_.data());
-
-    // Optional post-filter soft limiting, then sanitise output.
-    const int channelsToSanitise = std::min(hostChannels, numOutputs);
-    for (int ch = 0; ch < channelsToSanitise; ++ch) {
-        float* out = fc.destBuffer->getWritePointer(ch, startSample);
-        for (int i = 0; i < numSamples; ++i) {
-            float sample = out[i];
-            if (limitMix > 0.0f && std::isfinite(sample)) {
-                const float limited = std::tanh(sample);
-                sample += (limited - sample) * limitMix;
-            }
-            out[i] = std::isfinite(sample) ? juce::jlimit(-16.0f, 16.0f, sample) : 0.0f;
-        }
-    }
-}
-
-te::AutomatableParameter* MagdaFilterCompiledPlugin::getSlotParameter(int slotIndex) const {
-    if (slotIndex < 0 || slotIndex >= kHostSlotCount)
-        return nullptr;
-    return hostParams_[static_cast<size_t>(slotIndex)].get();
-}
-
-const MagdaFilterCompiledPlugin::HostSlotInfo& MagdaFilterCompiledPlugin::getSlotInfo(
-    int slotIndex) const {
-    static const HostSlotInfo kEmpty;
-    if (slotIndex < 0 || slotIndex >= kHostSlotCount)
-        return kEmpty;
-    return hostSlotInfo_[static_cast<size_t>(slotIndex)];
-}
-
-int MagdaFilterCompiledPlugin::activeEngineIndex() const {
-    if (!hostParams_[kEngineSlot])
-        return 0;
-    const float norm = hostParams_[kEngineSlot]->getCurrentValue();
-    return juce::jlimit(0, kEngineCount - 1,
-                        static_cast<int>(std::round(norm * static_cast<float>(kEngineCount - 1))));
 }
 
 std::vector<juce::String> MagdaFilterCompiledPlugin::modeChoicesForEngine(int engineIndex) const {
-    // Each engine's Faust source declares only the modes it can actually
-    // produce; we mirror those sets here so the host's Mode dropdown only
-    // offers options that map to a real branch in `mapModeToEngineValue`.
     switch (static_cast<FilterFamily>(engineIndex)) {
         case FilterFamily::SVF:
             return {"LP", "BP", "HP", "Notch"};
@@ -491,55 +142,31 @@ std::vector<juce::String> MagdaFilterCompiledPlugin::modeChoicesForEngine(int en
     return {"LP"};
 }
 
-float MagdaFilterCompiledPlugin::displayValueToNativeValue(int slotIndex,
-                                                           float displayValue) const {
-    if (slotIndex < 0 || slotIndex >= kHostSlotCount)
-        return displayValue;
-    // Mode's choice list is engine-dependent, so a slider position (display
-    // index 0..N-1 for the active engine's N modes) projects to normalized
-    // 0..1 using THIS engine's count, not the static hostSlotInfo. Audio
-    // side mirrors the same per-engine count in applyToBuffer.
-    if (slotIndex == kModeSlot) {
-        const auto choices = modeChoicesForEngine(activeEngineIndex());
-        const int count = static_cast<int>(choices.size());
-        if (count <= 1)
-            return 0.0f;
-        const int idx = juce::jlimit(0, count - 1, static_cast<int>(std::round(displayValue)));
-        return static_cast<float>(idx) / static_cast<float>(count - 1);
-    }
-    const auto& s = hostSlotInfo_[static_cast<size_t>(slotIndex)];
-    magda::ParameterInfo info;
-    info.minValue = s.minValue;
-    info.maxValue = s.maxValue;
-    info.scale = s.scale;
-    if (std::isfinite(s.scaleAnchor))
-        info.scaleAnchor = s.scaleAnchor;
-    info.choices = s.choices;
-    return magda::ParameterUtils::realToNormalized(displayValue, info);
+void MagdaFilterCompiledPlugin::writeExtraZones(int engineIndex) {
+    if (engineIndex != static_cast<int>(FilterFamily::SallenKey))
+        return;
+
+    if (auto* cutoff = zoneForIdx(engineIndex, 0))
+        *cutoff =
+            clampSallenKeyCutoffHz(*cutoff, currentSampleRate(), getSlotInfo(kCutoffSlot).minValue);
 }
 
-float MagdaFilterCompiledPlugin::nativeValueToDisplayValue(int slotIndex, float nativeValue) const {
-    if (slotIndex < 0 || slotIndex >= kHostSlotCount)
-        return nativeValue;
-    if (slotIndex == kModeSlot) {
-        const auto choices = modeChoicesForEngine(activeEngineIndex());
-        const int count = static_cast<int>(choices.size());
-        if (count <= 1)
-            return 0.0f;
-        const int idx =
-            juce::jlimit(0, count - 1,
-                         static_cast<int>(std::round(nativeValue * static_cast<float>(count - 1))));
-        return static_cast<float>(idx);
+void MagdaFilterCompiledPlugin::afterCompute(DeviceProcessContext& context, int engineIndex) {
+    // Limit blends a soft limiter over whatever the active engine produced. It
+    // has no zone in any dsp: resonance peaks are the thing being tamed, so it
+    // belongs after the filter rather than inside it.
+    const float limitMix = juce::jlimit(0.0f, 1.0f, getSlotParameter(kLimitSlot).currentValue());
+    if (limitMix <= 0.0f)
+        return;
+
+    const int channels = std::min(context.audio->getNumChannels(), engineOutputCount(engineIndex));
+    for (int channel = 0; channel < channels; ++channel) {
+        float* out = context.audio->getWritePointer(channel, context.startSample);
+        for (int i = 0; i < context.numSamples; ++i) {
+            const float sample = out[i];
+            out[i] = sanitise(sample + (std::tanh(sample) - sample) * limitMix);
+        }
     }
-    const auto& s = hostSlotInfo_[static_cast<size_t>(slotIndex)];
-    magda::ParameterInfo info;
-    info.minValue = s.minValue;
-    info.maxValue = s.maxValue;
-    info.scale = s.scale;
-    if (std::isfinite(s.scaleAnchor))
-        info.scaleAnchor = s.scaleAnchor;
-    info.choices = s.choices;
-    return magda::ParameterUtils::normalizedToReal(nativeValue, info);
 }
 
 constexpr AliasSpec kAliases[] = {
@@ -566,9 +193,8 @@ const CompiledPluginSpec& getMagdaFilterSpec() {
             "<warning>Warning: high resonance can create very loud peaks or "
             "self-oscillation. "
             "Keep monitoring levels conservative to protect speakers and ears.</warning>",
-        .createPlugin = [](const DevicePluginCreationContext& context) -> DevicePluginPtr {
-            return tracktion_adapter::pluginHandle(
-                new MagdaFilterCompiledPlugin(tracktion_adapter::creationInfo(context)));
+        .createDevice = [](const DevicePluginCreationContext&) -> std::unique_ptr<MagdaDevice> {
+            return std::make_unique<MagdaFilterCompiledPlugin>();
         },
         .aliases = kAliases,
         .aliasCount = static_cast<int>(sizeof(kAliases) / sizeof(kAliases[0])),

--- a/magda/daw/audio/plugins/compiled/MagdaFilterCompiledPlugin.hpp
+++ b/magda/daw/audio/plugins/compiled/MagdaFilterCompiledPlugin.hpp
@@ -1,15 +1,8 @@
 #pragma once
 
-#include <tracktion_engine/tracktion_engine.h>
-
-#include <array>
-#include <atomic>
-#include <memory>
 #include <vector>
 
-#include "../FaustParamPool.hpp"
-#include "core/ParameterInfo.hpp"
-#include "plugins/compiled/tracktion/CompiledFaustTracktionAdapter.hpp"
+#include "plugins/compiled/MagdaCompiledEffect.hpp"
 
 class dsp;
 
@@ -37,41 +30,12 @@ namespace magda::daw::audio::compiled {
  * all four (LP/BP/HP/Notch); Korg 35 LP+HP; Sallen-Key LP+BP+HP;
  * Ladder is LP-only. Unsupported modes fall back to LP for the engine.
  */
-class MagdaFilterCompiledPlugin : public te::Plugin, public ICompiledFaustPlugin {
+class MagdaFilterCompiledPlugin : public MagdaCompiledEffect {
   public:
     static const char* xmlTypeName;
 
-    explicit MagdaFilterCompiledPlugin(const te::PluginCreationInfo& info);
-    ~MagdaFilterCompiledPlugin() override;
+    MagdaFilterCompiledPlugin();
 
-    juce::String getName() const override;
-    juce::String getPluginType() override;
-    juce::String getShortName(int) override;
-    juce::String getSelectableDescription() override;
-
-    void initialise(const te::PluginInitialisationInfo& info) override;
-    void deinitialise() override;
-    void reset() override;
-    void applyToBuffer(const te::PluginRenderContext& fc) override;
-
-    bool takesMidiInput() override {
-        return false;
-    }
-    bool takesAudioInput() override {
-        return true;
-    }
-    bool isSynth() override {
-        return false;
-    }
-    bool producesAudioWhenNoAudioInput() override {
-        return false;
-    }
-    double getTailLength() const override {
-        return 0.0;
-    }
-
-    // Slot-indexed accessors for host params. Used by the curve view +
-    // processor.
     static constexpr int kCutoffSlot = 0;
     static constexpr int kResonanceSlot = 1;
     static constexpr int kDriveSlot = 2;
@@ -79,92 +43,45 @@ class MagdaFilterCompiledPlugin : public te::Plugin, public ICompiledFaustPlugin
     static constexpr int kModeSlot = 4;
     static constexpr int kLimitSlot = 5;
     static constexpr int kHostSlotCount = 6;
-
     enum class FilterFamily { SVF, Ladder, Korg35, Oberheim, SallenKey, Diode };
     static constexpr int kEngineCount = 6;
 
-    te::AutomatableParameter* getSlotParameter(int slotIndex) const;
-
-    // Convert between display value (slider Hz / index) and the te native
-    // (normalized 0..1) value for a given host slot. Mirrors the
-    // MagdaFilterCompiledPlugin API so the curve view + processor work the
-    // same way.
-    float displayValueToNativeValue(int slotIndex, float displayValue) const;
-    float nativeValueToDisplayValue(int slotIndex, float nativeValue) const;
-
-    // The host slots, exposed as ParameterInfo so the processor can
-    // populate device.parameters. Kind / range / scale baked here once at
-    // construction.
-    using HostSlotInfo = CompiledHostSlotInfo;
-    const HostSlotInfo& getSlotInfo(int slotIndex) const;
-
-    // Live engine index, derived from the host Engine param. Used by the
-    // host glue (CompiledFaustProcessor / DeviceSlotComponent) to keep the
-    // Mode slot's choice list in sync with the active engine's actual
-    // mode set (e.g. Korg 35 = LP/HP, Sallen-Key = LP/BP/HP, Ladder = LP).
-    int activeEngineIndex() const;
+    /// The modes @p engineIndex can actually produce. Each family's Faust
+    /// source declares only its own set, and the host's dropdown mirrors that
+    /// so it never offers a mode with no branch behind it.
     std::vector<juce::String> modeChoicesForEngine(int engineIndex) const;
 
-    // ICompiledFaustPlugin
-    int hostSlotCount() const override {
-        return kHostSlotCount;
-    }
-    const CompiledHostSlotInfo& hostSlotInfo(int slotIndex) const override {
-        return getSlotInfo(slotIndex);
-    }
-    DeviceParameterHandle hostSlotParameter(int slotIndex) const override {
-        return tracktion_adapter::parameterHandle(getSlotParameter(slotIndex));
-    }
-    float displayToNormalized(int slotIndex, float displayValue) const override {
-        return displayValueToNativeValue(slotIndex, displayValue);
-    }
-    float normalizedToDisplay(int slotIndex, float normalizedValue) const override {
-        return nativeValueToDisplayValue(slotIndex, normalizedValue);
-    }
     int engineAwareModeSlot() const override {
         return kModeSlot;
     }
-    int activeEngine() const override {
-        return activeEngineIndex();
-    }
     std::vector<juce::String> modeChoicesForActiveEngine() const override {
-        return modeChoicesForEngine(activeEngineIndex());
+        return modeChoicesForEngine(activeEngine());
     }
+
+    juce::String devicePluginId() const override {
+        return xmlTypeName;
+    }
+    juce::String deviceName() const override {
+        return "Filter";
+    }
+
+  protected:
+    ::dsp* createEngineDsp(int engineIndex) const override;
+    std::vector<HostSlotInfo> slotInfos() const override;
+    const char* slotIdPrefix() const override {
+        return "magda_filter_";
+    }
+    int engineCount() const override {
+        return kEngineCount;
+    }
+    int engineSlot() const override {
+        return kEngineSlot;
+    }
+    int slotForDspIdx(int idx) const override;
+    void writeExtraZones(int engineIndex) override;
+    void afterCompute(DeviceProcessContext& context, int engineIndex) override;
 
   private:
-    struct EngineDsp;
-
-    void buildHostParameters();
-    void rebuildEngineState(int sampleRate);
-    void writeSharedZones();  // cutoff/res/drive into all engines
-    void writeModeZone(int engineIndex);
-
-    // Per-engine state — the dsp + the harvested binding for cutoff /
-    // resonance / drive / mode (as float* pointers into the dsp). One
-    // entry per FilterFamily.
-    struct EngineState {
-        std::unique_ptr<::dsp> dsp;
-        FAUSTFLOAT* cutoffZone = nullptr;
-        FAUSTFLOAT* resZone = nullptr;
-        FAUSTFLOAT* driveZone = nullptr;
-        FAUSTFLOAT* modeZone = nullptr;       // null if engine has no mode
-        std::vector<float> modeChoiceValues;  // sorted underlying values for mode
-        int sampleRate = 44100;
-        int numInputs = 0;
-        int numOutputs = 0;
-    };
-    std::array<EngineState, kEngineCount> engines_;
-    std::atomic<int> activeEngine_{0};
-
-    std::array<HostSlotInfo, kHostSlotCount> hostSlotInfo_;
-    std::array<te::AutomatableParameter::Ptr, kHostSlotCount> hostParams_;
-    std::array<juce::CachedValue<float>, kHostSlotCount> hostCached_;
-
-    juce::AudioBuffer<float> scratchIn_;
-    juce::AudioBuffer<float> scratchOut_;
-    std::vector<float*> inPtrs_;
-    std::vector<float*> outPtrs_;
-
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(MagdaFilterCompiledPlugin)
 };
 

--- a/magda/daw/audio/plugins/compiled/MagdaFlangerCompiledPlugin.cpp
+++ b/magda/daw/audio/plugins/compiled/MagdaFlangerCompiledPlugin.cpp
@@ -1,440 +1,90 @@
 #include "plugins/compiled/MagdaFlangerCompiledPlugin.hpp"
 
-#include <algorithm>
-#include <cmath>
-#include <limits>
-#include <map>
-
-#include "core/ParameterUtils.hpp"
+#include "core/ParameterInfo.hpp"
 #include "faust/dsp/dsp.h"
 #include "faust/gui/UI.h"
 #include "faust/gui/meta.h"
 #include "magda_flanger.generated.cpp"
-#include "plugins/FaustMetadataParser.hpp"
-#include "plugins/FaustParamInfo.hpp"
 #include "plugins/compiled/CompiledPluginRegistry.hpp"
-#include "plugins/tracktion/TracktionDeviceAdapters.hpp"
 
 namespace magda::daw::audio::compiled {
 
 const char* MagdaFlangerCompiledPlugin::xmlTypeName = "magda_flanger";
 
-namespace {
-
-struct FlangerHarvest {
-    struct Control {
-        int idx = -1;
-        FaustParamSlot::Kind kind = FaustParamSlot::Kind::Continuous;
-        FAUSTFLOAT* zone = nullptr;
-        std::vector<std::pair<float, juce::String>> choices;
-        int gateSlotIndex = -1;
-        bool gateNegated = false;
-    };
-    std::vector<Control> controls;
-};
-
-class FlangerHarvester : public ::UI {
-  public:
-    FlangerHarvest harvest;
-
-    void openTabBox(const char*) override {}
-    void openHorizontalBox(const char*) override {}
-    void openVerticalBox(const char*) override {}
-    void closeBox() override {}
-
-    void addButton(const char* label, FAUSTFLOAT* zone) override {
-        emitControl(FaustParamSlot::Kind::Boolean, label, zone);
-    }
-    void addCheckButton(const char* label, FAUSTFLOAT* zone) override {
-        emitControl(FaustParamSlot::Kind::Boolean, label, zone);
-    }
-    void addVerticalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT, FAUSTFLOAT, FAUSTFLOAT,
-                           FAUSTFLOAT) override {
-        emitControl(FaustParamSlot::Kind::Continuous, label, zone);
-    }
-    void addHorizontalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT, FAUSTFLOAT,
-                             FAUSTFLOAT, FAUSTFLOAT) override {
-        emitControl(FaustParamSlot::Kind::Continuous, label, zone);
-    }
-    void addNumEntry(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT, FAUSTFLOAT, FAUSTFLOAT,
-                     FAUSTFLOAT) override {
-        emitControl(FaustParamSlot::Kind::Continuous, label, zone);
-    }
-    void addHorizontalBargraph(const char*, FAUSTFLOAT*, FAUSTFLOAT, FAUSTFLOAT) override {}
-    void addVerticalBargraph(const char*, FAUSTFLOAT*, FAUSTFLOAT, FAUSTFLOAT) override {}
-    void addSoundfile(const char*, const char*, Soundfile**) override {}
-
-    void declare(FAUSTFLOAT* zone, const char* key, const char* value) override {
-        if (zone == nullptr)
-            return;
-        const auto k = juce::String::fromUTF8(key != nullptr ? key : "").toLowerCase();
-        const auto v = juce::String::fromUTF8(value != nullptr ? value : "");
-        applyFaustAnnotation(k, v, pendingByZone_[zone]);
-    }
-
-  private:
-    void emitControl(FaustParamSlot::Kind kind, const char* rawLabel, FAUSTFLOAT* zone) {
-        const auto parsed =
-            parseFaustLabel(juce::String::fromUTF8(rawLabel != nullptr ? rawLabel : ""));
-        ControlMetadata merged = parsed.metadata;
-        if (zone != nullptr) {
-            if (auto it = pendingByZone_.find(zone); it != pendingByZone_.end()) {
-                mergeFaustMetadata(merged, it->second);
-                pendingByZone_.erase(it);
-            }
-        }
-
-        FlangerHarvest::Control c;
-        c.idx = merged.slotIndex;
-        c.kind = merged.isChoiceStyle() ? FaustParamSlot::Kind::Discrete : kind;
-        c.zone = zone;
-        c.choices = merged.menuChoices;
-        c.gateSlotIndex = merged.gateSlotIndex;
-        c.gateNegated = merged.gateNegated;
-        harvest.controls.push_back(std::move(c));
-    }
-
-    std::map<FAUSTFLOAT*, ControlMetadata> pendingByZone_;
-};
-
-const FlangerHarvest::Control* findByIdx(const FlangerHarvest& h, int idx) {
-    for (const auto& c : h.controls)
-        if (c.idx == idx)
-            return &c;
-    return nullptr;
+MagdaFlangerCompiledPlugin::MagdaFlangerCompiledPlugin() {
+    initEffect();
 }
 
-}  // namespace
-
-MagdaFlangerCompiledPlugin::MagdaFlangerCompiledPlugin(const te::PluginCreationInfo& info)
-    : te::Plugin(info) {
-    dsp_ = std::make_unique<MagdaFlangerDsp>();
-    constexpr int kProvisionalSampleRate = 44100;
-    rebuildEngineState(kProvisionalSampleRate);
-    buildHostParameters();
+::dsp* MagdaFlangerCompiledPlugin::createEngineDsp(int) const {
+    return new MagdaFlangerDsp();
 }
 
-MagdaFlangerCompiledPlugin::~MagdaFlangerCompiledPlugin() {
-    notifyListenersOfDeletion();
-    for (auto& p : hostParams_)
-        if (p)
-            p->detachFromCurrentValue();
-}
+std::vector<MagdaFlangerCompiledPlugin::HostSlotInfo> MagdaFlangerCompiledPlugin::slotInfos()
+    const {
+    std::vector<HostSlotInfo> infos(kHostSlotCount);
+    // The Division choices are the dsp's own [style:menu{...}]: the labels
+    // read as musical divisions and the values are the quarter-note
+    // multipliers the zone wants, so neither list is restated here.
+    const auto divisionValues = menuValuesForIdx(kDivisionSlot);
+    infos[kSyncSlot] = {.name = "Sync",
+                        .scale = magda::ParameterScale::Discrete,
+                        .minValue = 0.0f,
+                        .maxValue = 1.0f,
+                        .defaultValue = 0.0f,
+                        .scaleAnchor = std::numeric_limits<float>::quiet_NaN(),
+                        .choices = {"Off", "On"}};
 
-juce::String MagdaFlangerCompiledPlugin::getName() const {
-    return "Flanger";
-}
-juce::String MagdaFlangerCompiledPlugin::getPluginType() {
-    return xmlTypeName;
-}
-juce::String MagdaFlangerCompiledPlugin::getShortName(int) {
-    return "Flanger";
-}
-juce::String MagdaFlangerCompiledPlugin::getSelectableDescription() {
-    return "Flanger";
-}
+    infos[kRateSlot] = {.name = "Rate",
+                        .unit = magda::technicalText(magda::TechnicalTextToken::Hertz),
+                        .scale = magda::ParameterScale::Logarithmic,
+                        .minValue = 0.05f,
+                        .maxValue = 10.0f,
+                        .defaultValue = 0.5f,
+                        .scaleAnchor = 0.5f};
 
-void MagdaFlangerCompiledPlugin::rebuildEngineState(int sampleRate) {
-    if (!dsp_)
-        return;
-    dsp_->init(sampleRate);
-    numInputs_ = dsp_->getNumInputs();
-    numOutputs_ = dsp_->getNumOutputs();
+    infos[kDivisionSlot].name = "Division";
+    infos[kDivisionSlot].scale = magda::ParameterScale::Discrete;
+    infos[kDivisionSlot].minValue = 0.0f;
+    infos[kDivisionSlot].maxValue = 0.0f;
+    infos[kDivisionSlot].defaultValue = 0.0f;
 
-    FlangerHarvester harvester;
-    dsp_->buildUserInterface(&harvester);
+    infos[kDepthSlot] = {.name = "Depth",
+                         .scale = magda::ParameterScale::Linear,
+                         .minValue = 0.0f,
+                         .maxValue = 1.0f,
+                         .defaultValue = 0.5f};
 
-    zones_.fill(nullptr);
-    bpmZone_ = nullptr;
-    divisionChoiceValues_.clear();
-    divisionChoiceLabels_.clear();
+    infos[kFeedbackSlot] = {.name = "Feedback",
+                            .scale = magda::ParameterScale::Linear,
+                            .minValue = -0.95f,
+                            .maxValue = 0.95f,
+                            .defaultValue = 0.0f};
 
-    for (int i = 0; i < kHostSlotCount; ++i) {
-        harvestedGates_[static_cast<size_t>(i)] = {-1, false};
-        if (auto* c = findByIdx(harvester.harvest, i)) {
-            zones_[static_cast<size_t>(i)] = c->zone;
-            harvestedGates_[static_cast<size_t>(i)] = {c->gateSlotIndex, c->gateNegated};
-        }
-    }
-    if (auto* c = findByIdx(harvester.harvest, kBpmSlot))
-        bpmZone_ = c->zone;
+    infos[kMixSlot] = {.name = "Mix",
+                       .scale = magda::ParameterScale::Linear,
+                       .minValue = 0.0f,
+                       .maxValue = 1.0f,
+                       .defaultValue = 0.5f};
 
-    if (auto* c = findByIdx(harvester.harvest, kDivisionSlot)) {
-        auto sorted = c->choices;
-        std::sort(sorted.begin(), sorted.end(),
-                  [](const auto& a, const auto& b) { return a.first < b.first; });
-        divisionChoiceValues_.reserve(sorted.size());
-        divisionChoiceLabels_.reserve(sorted.size());
-        for (const auto& choice : sorted) {
-            divisionChoiceValues_.push_back(choice.first);
-            divisionChoiceLabels_.push_back(choice.second);
-        }
-    }
-}
+    infos[kWidthSlot] = {.name = "Width",
+                         .scale = magda::ParameterScale::Linear,
+                         .minValue = 0.0f,
+                         .maxValue = 1.0f,
+                         .defaultValue = 0.5f};
 
-void MagdaFlangerCompiledPlugin::buildHostParameters() {
-    hostSlotInfo_[kSyncSlot] = {.name = "Sync",
-                                .scale = magda::ParameterScale::Discrete,
-                                .minValue = 0.0f,
-                                .maxValue = 1.0f,
-                                .defaultValue = 0.0f,
-                                .scaleAnchor = std::numeric_limits<float>::quiet_NaN(),
-                                .choices = {"Off", "On"}};
-
-    hostSlotInfo_[kRateSlot] = {.name = "Rate",
-                                .unit = magda::technicalText(magda::TechnicalTextToken::Hertz),
-                                .scale = magda::ParameterScale::Logarithmic,
-                                .minValue = 0.05f,
-                                .maxValue = 10.0f,
-                                .defaultValue = 0.5f,
-                                .scaleAnchor = 0.5f};
-
-    hostSlotInfo_[kDivisionSlot].name = "Division";
-    hostSlotInfo_[kDivisionSlot].scale = magda::ParameterScale::Discrete;
-    hostSlotInfo_[kDivisionSlot].minValue = 0.0f;
-    hostSlotInfo_[kDivisionSlot].maxValue = 0.0f;
-    hostSlotInfo_[kDivisionSlot].defaultValue = 0.0f;
-
-    hostSlotInfo_[kDepthSlot] = {.name = "Depth",
-                                 .scale = magda::ParameterScale::Linear,
-                                 .minValue = 0.0f,
-                                 .maxValue = 1.0f,
-                                 .defaultValue = 0.5f};
-
-    hostSlotInfo_[kFeedbackSlot] = {.name = "Feedback",
-                                    .scale = magda::ParameterScale::Linear,
-                                    .minValue = -0.95f,
-                                    .maxValue = 0.95f,
-                                    .defaultValue = 0.0f};
-
-    hostSlotInfo_[kMixSlot] = {.name = "Mix",
-                               .scale = magda::ParameterScale::Linear,
-                               .minValue = 0.0f,
-                               .maxValue = 1.0f,
-                               .defaultValue = 0.5f};
-
-    hostSlotInfo_[kWidthSlot] = {.name = "Width",
-                                 .scale = magda::ParameterScale::Linear,
-                                 .minValue = 0.0f,
-                                 .maxValue = 1.0f,
-                                 .defaultValue = 0.5f};
-
-    if (!divisionChoiceValues_.empty()) {
-        const int n = static_cast<int>(divisionChoiceValues_.size());
-        hostSlotInfo_[kDivisionSlot].choices = divisionChoiceLabels_;
-        hostSlotInfo_[kDivisionSlot].maxValue = static_cast<float>(n - 1);
+    if (!divisionValues.empty()) {
+        const int n = static_cast<int>(divisionValues.size());
+        infos[kDivisionSlot].choices = menuLabelsForIdx(kDivisionSlot);
+        infos[kDivisionSlot].maxValue = static_cast<float>(n - 1);
         for (int i = 0; i < n; ++i) {
-            if (std::abs(divisionChoiceValues_[static_cast<size_t>(i)] - 1.0f) < 1e-3f) {
-                hostSlotInfo_[kDivisionSlot].defaultValue = static_cast<float>(i);
+            if (std::abs(divisionValues[static_cast<size_t>(i)] - 1.0f) < 1e-3f) {
+                infos[kDivisionSlot].defaultValue = static_cast<float>(i);
                 break;
             }
         }
     }
 
-    juce::NormalisableRange<float> normalisedRange{0.0f, 1.0f};
-    auto* undoManager = getUndoManager();
-
-    auto buildInfo = [](const HostSlotInfo& s) {
-        magda::ParameterInfo info;
-        info.minValue = s.minValue;
-        info.maxValue = s.maxValue;
-        info.defaultValue = s.defaultValue;
-        info.unit = s.unit;
-        info.scale = s.scale;
-        if (std::isfinite(s.scaleAnchor))
-            info.scaleAnchor = s.scaleAnchor;
-        info.choices = s.choices;
-        return info;
-    };
-
-    for (int i = 0; i < kHostSlotCount; ++i) {
-        const auto& slot = hostSlotInfo_[i];
-        const juce::String id = "magda_flanger_" + slot.name.toLowerCase().replace(" ", "_");
-        const juce::Identifier identifier(id);
-        const auto info = buildInfo(slot);
-        const float defaultNormalized =
-            magda::ParameterUtils::realToNormalized(slot.defaultValue, info);
-        hostCached_[i].referTo(state, identifier, undoManager, defaultNormalized);
-
-        auto param = addParam(
-            id, slot.name, normalisedRange,
-            [info](float normalized) {
-                const float real = magda::ParameterUtils::normalizedToReal(normalized, info);
-                return magda::ParameterUtils::formatValue(real, info);
-            },
-            [info](const juce::String& text) {
-                auto parsed = magda::ParameterUtils::parseValue(text, info);
-                if (parsed)
-                    return magda::ParameterUtils::realToNormalized(*parsed, info);
-                return 0.0f;
-            });
-        param->attachToCurrentValue(hostCached_[i]);
-        hostParams_[i] = param;
-    }
-
-    for (int i = 0; i < kHostSlotCount; ++i) {
-        hostSlotInfo_[static_cast<size_t>(i)].gateSlotIndex =
-            harvestedGates_[static_cast<size_t>(i)].slotIndex;
-        hostSlotInfo_[static_cast<size_t>(i)].gateNegated =
-            harvestedGates_[static_cast<size_t>(i)].negated;
-    }
-}
-
-void MagdaFlangerCompiledPlugin::initialise(const te::PluginInitialisationInfo& info) {
-    rebuildEngineState(static_cast<int>(info.sampleRate));
-    scratchIn_.setSize(numInputs_, info.blockSizeSamples, false, true, true);
-    scratchOut_.setSize(numOutputs_, info.blockSizeSamples, false, true, true);
-    inPtrs_.assign(static_cast<size_t>(numInputs_), nullptr);
-    outPtrs_.assign(static_cast<size_t>(numOutputs_), nullptr);
-}
-
-void MagdaFlangerCompiledPlugin::deinitialise() {
-    scratchIn_.setSize(0, 0);
-    scratchOut_.setSize(0, 0);
-    inPtrs_.clear();
-    outPtrs_.clear();
-}
-
-void MagdaFlangerCompiledPlugin::reset() {
-    if (dsp_)
-        dsp_->instanceClear();
-}
-
-void MagdaFlangerCompiledPlugin::applyToBuffer(const te::PluginRenderContext& fc) {
-    if (!fc.destBuffer || fc.bufferNumSamples <= 0 || !dsp_)
-        return;
-
-    if (fc.isPlaying && !wasPlaying_)
-        dsp_->instanceClear();
-    wasPlaying_ = fc.isPlaying;
-
-    auto writeContinuous = [&](int slot) {
-        if (auto* zone = zones_[static_cast<size_t>(slot)]) {
-            const auto& s = hostSlotInfo_[static_cast<size_t>(slot)];
-            magda::ParameterInfo info;
-            info.minValue = s.minValue;
-            info.maxValue = s.maxValue;
-            info.scale = s.scale;
-            if (std::isfinite(s.scaleAnchor))
-                info.scaleAnchor = s.scaleAnchor;
-            const float norm = hostParams_[static_cast<size_t>(slot)]->getCurrentValue();
-            *zone = static_cast<FAUSTFLOAT>(magda::ParameterUtils::normalizedToReal(norm, info));
-        }
-    };
-    writeContinuous(kRateSlot);
-    writeContinuous(kDepthSlot);
-    writeContinuous(kFeedbackSlot);
-    writeContinuous(kMixSlot);
-    writeContinuous(kWidthSlot);
-
-    if (auto* z = zones_[kSyncSlot])
-        *z = hostParams_[kSyncSlot]->getCurrentValue() >= 0.5f ? FAUSTFLOAT(1) : FAUSTFLOAT(0);
-
-    if (auto* z = zones_[kDivisionSlot]; z && !divisionChoiceValues_.empty()) {
-        const float norm = hostParams_[kDivisionSlot]->getCurrentValue();
-        const int count = static_cast<int>(divisionChoiceValues_.size());
-        const int idx = juce::jlimit(
-            0, count - 1, static_cast<int>(std::round(norm * static_cast<float>(count - 1))));
-        *z = static_cast<FAUSTFLOAT>(divisionChoiceValues_[static_cast<size_t>(idx)]);
-    }
-
-    const double bpm = edit.tempoSequence.getBpmAt(fc.editTime.getStart());
-    currentBpm_.store(static_cast<float>(bpm), std::memory_order_relaxed);
-    if (bpmZone_)
-        *bpmZone_ = static_cast<FAUSTFLOAT>(bpm);
-
-    const int numSamples = fc.bufferNumSamples;
-    const int startSample = fc.bufferStartSample;
-    const int hostChannels = fc.destBuffer->getNumChannels();
-    if (hostChannels <= 0 || numInputs_ <= 0 || numOutputs_ <= 0)
-        return;
-
-    if (scratchIn_.getNumChannels() < numInputs_ || scratchIn_.getNumSamples() < numSamples)
-        scratchIn_.setSize(numInputs_, numSamples, false, true, true);
-    if (scratchOut_.getNumChannels() < numOutputs_ || scratchOut_.getNumSamples() < numSamples)
-        scratchOut_.setSize(numOutputs_, numSamples, false, true, true);
-    if (static_cast<int>(inPtrs_.size()) < numInputs_)
-        inPtrs_.resize(static_cast<size_t>(numInputs_), nullptr);
-    if (static_cast<int>(outPtrs_.size()) < numOutputs_)
-        outPtrs_.resize(static_cast<size_t>(numOutputs_), nullptr);
-
-    for (int ch = 0; ch < numInputs_; ++ch) {
-        float* dst = scratchIn_.getWritePointer(ch);
-        if (ch < hostChannels) {
-            const float* src = fc.destBuffer->getReadPointer(ch, startSample);
-            std::copy(src, src + numSamples, dst);
-        } else {
-            std::fill(dst, dst + numSamples, 0.0f);
-        }
-        inPtrs_[static_cast<size_t>(ch)] = dst;
-    }
-    for (int ch = 0; ch < numOutputs_; ++ch) {
-        outPtrs_[static_cast<size_t>(ch)] = (ch < hostChannels)
-                                                ? fc.destBuffer->getWritePointer(ch, startSample)
-                                                : scratchOut_.getWritePointer(ch);
-    }
-
-    dsp_->compute(numSamples, inPtrs_.data(), outPtrs_.data());
-
-    const int channelsToSanitise = std::min(hostChannels, numOutputs_);
-    for (int ch = 0; ch < channelsToSanitise; ++ch) {
-        float* out = fc.destBuffer->getWritePointer(ch, startSample);
-        for (int i = 0; i < numSamples; ++i) {
-            const float sample = out[i];
-            out[i] = std::isfinite(sample) ? juce::jlimit(-16.0f, 16.0f, sample) : 0.0f;
-        }
-    }
-}
-
-te::AutomatableParameter* MagdaFlangerCompiledPlugin::getSlotParameter(int slotIndex) const {
-    if (slotIndex < 0 || slotIndex >= kHostSlotCount)
-        return nullptr;
-    return hostParams_[static_cast<size_t>(slotIndex)].get();
-}
-
-const MagdaFlangerCompiledPlugin::HostSlotInfo& MagdaFlangerCompiledPlugin::getSlotInfo(
-    int slotIndex) const {
-    static const HostSlotInfo kEmpty;
-    if (slotIndex < 0 || slotIndex >= kHostSlotCount)
-        return kEmpty;
-    return hostSlotInfo_[static_cast<size_t>(slotIndex)];
-}
-
-float MagdaFlangerCompiledPlugin::divisionFaustValueForIndex(int index) const {
-    if (divisionChoiceValues_.empty())
-        return 1.0f;
-    const int safeIdx = juce::jlimit(0, static_cast<int>(divisionChoiceValues_.size()) - 1, index);
-    return divisionChoiceValues_[static_cast<size_t>(safeIdx)];
-}
-
-float MagdaFlangerCompiledPlugin::displayValueToNativeValue(int slotIndex,
-                                                            float displayValue) const {
-    if (slotIndex < 0 || slotIndex >= kHostSlotCount)
-        return displayValue;
-    const auto& s = hostSlotInfo_[static_cast<size_t>(slotIndex)];
-    magda::ParameterInfo info;
-    info.minValue = s.minValue;
-    info.maxValue = s.maxValue;
-    info.scale = s.scale;
-    if (std::isfinite(s.scaleAnchor))
-        info.scaleAnchor = s.scaleAnchor;
-    info.choices = s.choices;
-    return magda::ParameterUtils::realToNormalized(displayValue, info);
-}
-
-float MagdaFlangerCompiledPlugin::nativeValueToDisplayValue(int slotIndex,
-                                                            float nativeValue) const {
-    if (slotIndex < 0 || slotIndex >= kHostSlotCount)
-        return nativeValue;
-    const auto& s = hostSlotInfo_[static_cast<size_t>(slotIndex)];
-    magda::ParameterInfo info;
-    info.minValue = s.minValue;
-    info.maxValue = s.maxValue;
-    info.scale = s.scale;
-    if (std::isfinite(s.scaleAnchor))
-        info.scaleAnchor = s.scaleAnchor;
-    info.choices = s.choices;
-    return magda::ParameterUtils::normalizedToReal(nativeValue, info);
+    return infos;
 }
 
 constexpr AliasSpec kAliases[] = {
@@ -452,9 +102,8 @@ const CompiledPluginSpec& getMagdaFlangerSpec() {
                        "comb-filter sweep. "
                        "Rate runs free in Hz or locks to tempo Division; "
                        "Depth, Feedback, Mix and Width round out the controls.",
-        .createPlugin = [](const DevicePluginCreationContext& context) -> DevicePluginPtr {
-            return tracktion_adapter::pluginHandle(
-                new MagdaFlangerCompiledPlugin(tracktion_adapter::creationInfo(context)));
+        .createDevice = [](const DevicePluginCreationContext&) -> std::unique_ptr<MagdaDevice> {
+            return std::make_unique<MagdaFlangerCompiledPlugin>();
         },
         .aliases = kAliases,
         .aliasCount = static_cast<int>(sizeof(kAliases) / sizeof(kAliases[0])),

--- a/magda/daw/audio/plugins/compiled/MagdaFlangerCompiledPlugin.hpp
+++ b/magda/daw/audio/plugins/compiled/MagdaFlangerCompiledPlugin.hpp
@@ -1,15 +1,8 @@
 #pragma once
 
-#include <tracktion_engine/tracktion_engine.h>
-
-#include <array>
-#include <atomic>
-#include <memory>
 #include <vector>
 
-#include "../FaustParamPool.hpp"
-#include "core/ParameterInfo.hpp"
-#include "plugins/compiled/tracktion/CompiledFaustTracktionAdapter.hpp"
+#include "plugins/compiled/MagdaCompiledEffect.hpp"
 
 class dsp;
 
@@ -23,40 +16,12 @@ namespace magda::daw::audio::compiled {
  * either free (Hz) or tempo-synced via the shared musical-division
  * menu. Width spreads the L/R LFO phase offset.
  */
-class MagdaFlangerCompiledPlugin : public te::Plugin, public ICompiledFaustPlugin {
+class MagdaFlangerCompiledPlugin : public MagdaCompiledEffect {
   public:
     static const char* xmlTypeName;
 
-    explicit MagdaFlangerCompiledPlugin(const te::PluginCreationInfo& info);
-    ~MagdaFlangerCompiledPlugin() override;
+    MagdaFlangerCompiledPlugin();
 
-    juce::String getName() const override;
-    juce::String getPluginType() override;
-    juce::String getShortName(int) override;
-    juce::String getSelectableDescription() override;
-
-    void initialise(const te::PluginInitialisationInfo& info) override;
-    void deinitialise() override;
-    void reset() override;
-    void applyToBuffer(const te::PluginRenderContext& fc) override;
-
-    bool takesMidiInput() override {
-        return false;
-    }
-    bool takesAudioInput() override {
-        return true;
-    }
-    bool isSynth() override {
-        return false;
-    }
-    bool producesAudioWhenNoAudioInput() override {
-        return false;
-    }
-    double getTailLength() const override {
-        return 0.05;
-    }
-
-    // Slot ordering matches [idx:N] pins inside magda_flanger.dsp.
     static constexpr int kSyncSlot = 0;
     static constexpr int kRateSlot = 1;
     static constexpr int kDivisionSlot = 2;
@@ -67,68 +32,32 @@ class MagdaFlangerCompiledPlugin : public te::Plugin, public ICompiledFaustPlugi
     static constexpr int kHostSlotCount = 7;
     static constexpr int kBpmSlot = 63;
 
-    te::AutomatableParameter* getSlotParameter(int slotIndex) const;
-
-    float displayValueToNativeValue(int slotIndex, float displayValue) const;
-    float nativeValueToDisplayValue(int slotIndex, float nativeValue) const;
-
-    using HostSlotInfo = CompiledHostSlotInfo;
-    const HostSlotInfo& getSlotInfo(int slotIndex) const;
-
-    float divisionFaustValueForIndex(int index) const;
-
-    float currentBpm() const {
-        return currentBpm_.load(std::memory_order_relaxed);
+    /// The Faust quarter-note multiplier behind Division choice @p index.
+    float divisionFaustValueForIndex(int index) const {
+        return menuValueForChoice(kDivisionSlot, index);
     }
 
-    // ICompiledFaustPlugin
-    int hostSlotCount() const override {
-        return kHostSlotCount;
+    juce::String devicePluginId() const override {
+        return xmlTypeName;
     }
-    const CompiledHostSlotInfo& hostSlotInfo(int slotIndex) const override {
-        return getSlotInfo(slotIndex);
+    juce::String deviceName() const override {
+        return "Flanger";
     }
-    DeviceParameterHandle hostSlotParameter(int slotIndex) const override {
-        return tracktion_adapter::parameterHandle(getSlotParameter(slotIndex));
+
+  protected:
+    ::dsp* createEngineDsp(int engineIndex) const override;
+    std::vector<HostSlotInfo> slotInfos() const override;
+    const char* slotIdPrefix() const override {
+        return "magda_flanger_";
     }
-    float displayToNormalized(int slotIndex, float displayValue) const override {
-        return displayValueToNativeValue(slotIndex, displayValue);
+    double tailSeconds() const override {
+        return 0.05;
     }
-    float normalizedToDisplay(int slotIndex, float normalizedValue) const override {
-        return nativeValueToDisplayValue(slotIndex, normalizedValue);
+    bool resetsOnPlayStart() const override {
+        return true;
     }
 
   private:
-    void buildHostParameters();
-    void rebuildEngineState(int sampleRate);
-
-    std::unique_ptr<::dsp> dsp_;
-    int numInputs_ = 0;
-    int numOutputs_ = 0;
-
-    std::array<FAUSTFLOAT*, kHostSlotCount> zones_{};
-    FAUSTFLOAT* bpmZone_ = nullptr;
-    std::vector<float> divisionChoiceValues_;
-    std::vector<juce::String> divisionChoiceLabels_;
-
-    struct GateSpec {
-        int slotIndex = -1;
-        bool negated = false;
-    };
-    std::array<GateSpec, kHostSlotCount> harvestedGates_{};
-
-    std::array<HostSlotInfo, kHostSlotCount> hostSlotInfo_;
-    std::array<te::AutomatableParameter::Ptr, kHostSlotCount> hostParams_;
-    std::array<juce::CachedValue<float>, kHostSlotCount> hostCached_;
-
-    juce::AudioBuffer<float> scratchIn_;
-    juce::AudioBuffer<float> scratchOut_;
-    std::vector<float*> inPtrs_;
-    std::vector<float*> outPtrs_;
-
-    std::atomic<float> currentBpm_{120.0f};
-    bool wasPlaying_ = false;
-
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(MagdaFlangerCompiledPlugin)
 };
 

--- a/magda/daw/audio/plugins/compiled/MagdaFreqShiftCompiledPlugin.cpp
+++ b/magda/daw/audio/plugins/compiled/MagdaFreqShiftCompiledPlugin.cpp
@@ -1,346 +1,53 @@
 #include "plugins/compiled/MagdaFreqShiftCompiledPlugin.hpp"
 
-#include <algorithm>
-#include <cmath>
-#include <map>
-
-#include "core/ParameterUtils.hpp"
+#include "core/ParameterInfo.hpp"
 #include "faust/dsp/dsp.h"
 #include "faust/gui/UI.h"
 #include "faust/gui/meta.h"
 #include "magda_freq_shift.generated.cpp"
-#include "plugins/FaustMetadataParser.hpp"
-#include "plugins/FaustParamInfo.hpp"
 #include "plugins/compiled/CompiledPluginRegistry.hpp"
-#include "plugins/tracktion/TracktionDeviceAdapters.hpp"
 
 namespace magda::daw::audio::compiled {
 
 const char* MagdaFreqShiftCompiledPlugin::xmlTypeName = "magda_freq_shift";
 
-namespace {
-
-struct FreqShiftHarvest {
-    struct Control {
-        int idx = -1;
-        FaustParamSlot::Kind kind = FaustParamSlot::Kind::Continuous;
-        FAUSTFLOAT* zone = nullptr;
-    };
-    std::vector<Control> controls;
-};
-
-class FreqShiftHarvester : public ::UI {
-  public:
-    FreqShiftHarvest harvest;
-
-    void openTabBox(const char*) override {}
-    void openHorizontalBox(const char*) override {}
-    void openVerticalBox(const char*) override {}
-    void closeBox() override {}
-
-    void addButton(const char* label, FAUSTFLOAT* zone) override {
-        emitControl(FaustParamSlot::Kind::Boolean, label, zone);
-    }
-    void addCheckButton(const char* label, FAUSTFLOAT* zone) override {
-        emitControl(FaustParamSlot::Kind::Boolean, label, zone);
-    }
-    void addVerticalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT, FAUSTFLOAT, FAUSTFLOAT,
-                           FAUSTFLOAT) override {
-        emitControl(FaustParamSlot::Kind::Continuous, label, zone);
-    }
-    void addHorizontalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT, FAUSTFLOAT,
-                             FAUSTFLOAT, FAUSTFLOAT) override {
-        emitControl(FaustParamSlot::Kind::Continuous, label, zone);
-    }
-    void addNumEntry(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT, FAUSTFLOAT, FAUSTFLOAT,
-                     FAUSTFLOAT) override {
-        emitControl(FaustParamSlot::Kind::Continuous, label, zone);
-    }
-    void addHorizontalBargraph(const char*, FAUSTFLOAT*, FAUSTFLOAT, FAUSTFLOAT) override {}
-    void addVerticalBargraph(const char*, FAUSTFLOAT*, FAUSTFLOAT, FAUSTFLOAT) override {}
-    void addSoundfile(const char*, const char*, Soundfile**) override {}
-
-    void declare(FAUSTFLOAT* zone, const char* key, const char* value) override {
-        if (zone == nullptr)
-            return;
-        const auto k = juce::String::fromUTF8(key != nullptr ? key : "").toLowerCase();
-        const auto v = juce::String::fromUTF8(value != nullptr ? value : "");
-        applyFaustAnnotation(k, v, pendingByZone_[zone]);
-    }
-
-  private:
-    void emitControl(FaustParamSlot::Kind kind, const char* rawLabel, FAUSTFLOAT* zone) {
-        const auto parsed =
-            parseFaustLabel(juce::String::fromUTF8(rawLabel != nullptr ? rawLabel : ""));
-        ControlMetadata merged = parsed.metadata;
-        if (zone != nullptr) {
-            if (auto it = pendingByZone_.find(zone); it != pendingByZone_.end()) {
-                mergeFaustMetadata(merged, it->second);
-                pendingByZone_.erase(it);
-            }
-        }
-
-        FreqShiftHarvest::Control c;
-        c.idx = merged.slotIndex;
-        c.kind = merged.isChoiceStyle() ? FaustParamSlot::Kind::Discrete : kind;
-        c.zone = zone;
-        harvest.controls.push_back(std::move(c));
-    }
-
-    std::map<FAUSTFLOAT*, ControlMetadata> pendingByZone_;
-};
-
-const FreqShiftHarvest::Control* findByIdx(const FreqShiftHarvest& h, int idx) {
-    for (const auto& c : h.controls)
-        if (c.idx == idx)
-            return &c;
-    return nullptr;
+MagdaFreqShiftCompiledPlugin::MagdaFreqShiftCompiledPlugin() {
+    initEffect();
 }
 
-}  // namespace
-
-MagdaFreqShiftCompiledPlugin::MagdaFreqShiftCompiledPlugin(const te::PluginCreationInfo& info)
-    : te::Plugin(info) {
-    dsp_ = std::make_unique<MagdaFreqShiftDsp>();
-    constexpr int kProvisionalSampleRate = 44100;
-    rebuildEngineState(kProvisionalSampleRate);
-    buildHostParameters();
+::dsp* MagdaFreqShiftCompiledPlugin::createEngineDsp(int) const {
+    return new MagdaFreqShiftDsp();
 }
 
-MagdaFreqShiftCompiledPlugin::~MagdaFreqShiftCompiledPlugin() {
-    notifyListenersOfDeletion();
-    for (auto& p : hostParams_)
-        if (p)
-            p->detachFromCurrentValue();
-}
+std::vector<MagdaFreqShiftCompiledPlugin::HostSlotInfo> MagdaFreqShiftCompiledPlugin::slotInfos()
+    const {
+    std::vector<HostSlotInfo> infos(kHostSlotCount);
+    infos[kShiftSlot] = {.name = "Shift",
+                         .unit = magda::technicalText(magda::TechnicalTextToken::Hertz),
+                         .scale = magda::ParameterScale::Linear,
+                         .minValue = -1000.0f,
+                         .maxValue = 1000.0f,
+                         .defaultValue = 0.0f};
 
-juce::String MagdaFreqShiftCompiledPlugin::getName() const {
-    return "Freq Shift";
-}
-juce::String MagdaFreqShiftCompiledPlugin::getPluginType() {
-    return xmlTypeName;
-}
-juce::String MagdaFreqShiftCompiledPlugin::getShortName(int) {
-    return "Freq Shift";
-}
-juce::String MagdaFreqShiftCompiledPlugin::getSelectableDescription() {
-    return "Freq Shift";
-}
+    infos[kFeedbackSlot] = {.name = "Feedback",
+                            .scale = magda::ParameterScale::Linear,
+                            .minValue = -0.9f,
+                            .maxValue = 0.9f,
+                            .defaultValue = 0.0f};
 
-void MagdaFreqShiftCompiledPlugin::rebuildEngineState(int sampleRate) {
-    if (!dsp_)
-        return;
-    dsp_->init(sampleRate);
-    numInputs_ = dsp_->getNumInputs();
-    numOutputs_ = dsp_->getNumOutputs();
+    infos[kMixSlot] = {.name = "Mix",
+                       .scale = magda::ParameterScale::Linear,
+                       .minValue = 0.0f,
+                       .maxValue = 1.0f,
+                       .defaultValue = 0.5f};
 
-    FreqShiftHarvester harvester;
-    dsp_->buildUserInterface(&harvester);
+    infos[kSpreadSlot] = {.name = "Spread",
+                          .scale = magda::ParameterScale::Linear,
+                          .minValue = 0.0f,
+                          .maxValue = 1.0f,
+                          .defaultValue = 0.0f};
 
-    zones_.fill(nullptr);
-    for (int i = 0; i < kHostSlotCount; ++i) {
-        if (auto* c = findByIdx(harvester.harvest, i))
-            zones_[static_cast<size_t>(i)] = c->zone;
-    }
-}
-
-void MagdaFreqShiftCompiledPlugin::buildHostParameters() {
-    hostSlotInfo_[kShiftSlot] = {.name = "Shift",
-                                 .unit = magda::technicalText(magda::TechnicalTextToken::Hertz),
-                                 .scale = magda::ParameterScale::Linear,
-                                 .minValue = -1000.0f,
-                                 .maxValue = 1000.0f,
-                                 .defaultValue = 0.0f};
-
-    hostSlotInfo_[kFeedbackSlot] = {.name = "Feedback",
-                                    .scale = magda::ParameterScale::Linear,
-                                    .minValue = -0.9f,
-                                    .maxValue = 0.9f,
-                                    .defaultValue = 0.0f};
-
-    hostSlotInfo_[kMixSlot] = {.name = "Mix",
-                               .scale = magda::ParameterScale::Linear,
-                               .minValue = 0.0f,
-                               .maxValue = 1.0f,
-                               .defaultValue = 0.5f};
-
-    hostSlotInfo_[kSpreadSlot] = {.name = "Spread",
-                                  .scale = magda::ParameterScale::Linear,
-                                  .minValue = 0.0f,
-                                  .maxValue = 1.0f,
-                                  .defaultValue = 0.0f};
-
-    juce::NormalisableRange<float> normalisedRange{0.0f, 1.0f};
-    auto* undoManager = getUndoManager();
-
-    auto buildInfo = [](const HostSlotInfo& s) {
-        magda::ParameterInfo info;
-        info.minValue = s.minValue;
-        info.maxValue = s.maxValue;
-        info.defaultValue = s.defaultValue;
-        info.unit = s.unit;
-        info.scale = s.scale;
-        if (std::isfinite(s.scaleAnchor))
-            info.scaleAnchor = s.scaleAnchor;
-        info.choices = s.choices;
-        return info;
-    };
-
-    for (int i = 0; i < kHostSlotCount; ++i) {
-        const auto& slot = hostSlotInfo_[i];
-        const juce::String id = "magda_freq_shift_" + slot.name.toLowerCase().replace(" ", "_");
-        const juce::Identifier identifier(id);
-        const auto info = buildInfo(slot);
-        const float defaultNormalized =
-            magda::ParameterUtils::realToNormalized(slot.defaultValue, info);
-        hostCached_[i].referTo(state, identifier, undoManager, defaultNormalized);
-
-        auto param = addParam(
-            id, slot.name, normalisedRange,
-            [info](float normalized) {
-                const float real = magda::ParameterUtils::normalizedToReal(normalized, info);
-                return magda::ParameterUtils::formatValue(real, info);
-            },
-            [info](const juce::String& text) {
-                auto parsed = magda::ParameterUtils::parseValue(text, info);
-                if (parsed)
-                    return magda::ParameterUtils::realToNormalized(*parsed, info);
-                return 0.0f;
-            });
-        param->attachToCurrentValue(hostCached_[i]);
-        hostParams_[i] = param;
-    }
-}
-
-void MagdaFreqShiftCompiledPlugin::initialise(const te::PluginInitialisationInfo& info) {
-    rebuildEngineState(static_cast<int>(info.sampleRate));
-    scratchIn_.setSize(numInputs_, info.blockSizeSamples, false, true, true);
-    scratchOut_.setSize(numOutputs_, info.blockSizeSamples, false, true, true);
-    inPtrs_.assign(static_cast<size_t>(numInputs_), nullptr);
-    outPtrs_.assign(static_cast<size_t>(numOutputs_), nullptr);
-}
-
-void MagdaFreqShiftCompiledPlugin::deinitialise() {
-    scratchIn_.setSize(0, 0);
-    scratchOut_.setSize(0, 0);
-    inPtrs_.clear();
-    outPtrs_.clear();
-}
-
-void MagdaFreqShiftCompiledPlugin::reset() {
-    if (dsp_)
-        dsp_->instanceClear();
-}
-
-void MagdaFreqShiftCompiledPlugin::applyToBuffer(const te::PluginRenderContext& fc) {
-    if (!fc.destBuffer || fc.bufferNumSamples <= 0 || !dsp_)
-        return;
-
-    if (fc.isPlaying && !wasPlaying_)
-        dsp_->instanceClear();
-    wasPlaying_ = fc.isPlaying;
-
-    auto writeSlot = [&](int slot) {
-        if (auto* zone = zones_[static_cast<size_t>(slot)]) {
-            const auto& s = hostSlotInfo_[static_cast<size_t>(slot)];
-            magda::ParameterInfo info;
-            info.minValue = s.minValue;
-            info.maxValue = s.maxValue;
-            info.scale = s.scale;
-            if (std::isfinite(s.scaleAnchor))
-                info.scaleAnchor = s.scaleAnchor;
-            const float norm = hostParams_[static_cast<size_t>(slot)]->getCurrentValue();
-            *zone = static_cast<FAUSTFLOAT>(magda::ParameterUtils::normalizedToReal(norm, info));
-        }
-    };
-    for (int i = 0; i < kHostSlotCount; ++i)
-        writeSlot(i);
-
-    const int numSamples = fc.bufferNumSamples;
-    const int startSample = fc.bufferStartSample;
-    const int hostChannels = fc.destBuffer->getNumChannels();
-    if (hostChannels <= 0 || numInputs_ <= 0 || numOutputs_ <= 0)
-        return;
-
-    if (scratchIn_.getNumChannels() < numInputs_ || scratchIn_.getNumSamples() < numSamples)
-        scratchIn_.setSize(numInputs_, numSamples, false, true, true);
-    if (scratchOut_.getNumChannels() < numOutputs_ || scratchOut_.getNumSamples() < numSamples)
-        scratchOut_.setSize(numOutputs_, numSamples, false, true, true);
-    if (static_cast<int>(inPtrs_.size()) < numInputs_)
-        inPtrs_.resize(static_cast<size_t>(numInputs_), nullptr);
-    if (static_cast<int>(outPtrs_.size()) < numOutputs_)
-        outPtrs_.resize(static_cast<size_t>(numOutputs_), nullptr);
-
-    for (int ch = 0; ch < numInputs_; ++ch) {
-        float* dst = scratchIn_.getWritePointer(ch);
-        if (ch < hostChannels) {
-            const float* src = fc.destBuffer->getReadPointer(ch, startSample);
-            std::copy(src, src + numSamples, dst);
-        } else {
-            std::fill(dst, dst + numSamples, 0.0f);
-        }
-        inPtrs_[static_cast<size_t>(ch)] = dst;
-    }
-    for (int ch = 0; ch < numOutputs_; ++ch) {
-        outPtrs_[static_cast<size_t>(ch)] = (ch < hostChannels)
-                                                ? fc.destBuffer->getWritePointer(ch, startSample)
-                                                : scratchOut_.getWritePointer(ch);
-    }
-
-    dsp_->compute(numSamples, inPtrs_.data(), outPtrs_.data());
-
-    const int channelsToSanitise = std::min(hostChannels, numOutputs_);
-    for (int ch = 0; ch < channelsToSanitise; ++ch) {
-        float* out = fc.destBuffer->getWritePointer(ch, startSample);
-        for (int i = 0; i < numSamples; ++i) {
-            const float sample = out[i];
-            out[i] = std::isfinite(sample) ? juce::jlimit(-16.0f, 16.0f, sample) : 0.0f;
-        }
-    }
-}
-
-te::AutomatableParameter* MagdaFreqShiftCompiledPlugin::getSlotParameter(int slotIndex) const {
-    if (slotIndex < 0 || slotIndex >= kHostSlotCount)
-        return nullptr;
-    return hostParams_[static_cast<size_t>(slotIndex)].get();
-}
-
-const MagdaFreqShiftCompiledPlugin::HostSlotInfo& MagdaFreqShiftCompiledPlugin::getSlotInfo(
-    int slotIndex) const {
-    static const HostSlotInfo kEmpty;
-    if (slotIndex < 0 || slotIndex >= kHostSlotCount)
-        return kEmpty;
-    return hostSlotInfo_[static_cast<size_t>(slotIndex)];
-}
-
-float MagdaFreqShiftCompiledPlugin::displayValueToNativeValue(int slotIndex,
-                                                              float displayValue) const {
-    if (slotIndex < 0 || slotIndex >= kHostSlotCount)
-        return displayValue;
-    const auto& s = hostSlotInfo_[static_cast<size_t>(slotIndex)];
-    magda::ParameterInfo info;
-    info.minValue = s.minValue;
-    info.maxValue = s.maxValue;
-    info.scale = s.scale;
-    if (std::isfinite(s.scaleAnchor))
-        info.scaleAnchor = s.scaleAnchor;
-    info.choices = s.choices;
-    return magda::ParameterUtils::realToNormalized(displayValue, info);
-}
-
-float MagdaFreqShiftCompiledPlugin::nativeValueToDisplayValue(int slotIndex,
-                                                              float nativeValue) const {
-    if (slotIndex < 0 || slotIndex >= kHostSlotCount)
-        return nativeValue;
-    const auto& s = hostSlotInfo_[static_cast<size_t>(slotIndex)];
-    magda::ParameterInfo info;
-    info.minValue = s.minValue;
-    info.maxValue = s.maxValue;
-    info.scale = s.scale;
-    if (std::isfinite(s.scaleAnchor))
-        info.scaleAnchor = s.scaleAnchor;
-    info.choices = s.choices;
-    return magda::ParameterUtils::normalizedToReal(nativeValue, info);
+    return infos;
 }
 
 constexpr AliasSpec kAliases[] = {
@@ -363,9 +70,8 @@ const CompiledPluginSpec& getMagdaFreqShiftSpec() {
                        "producing inharmonic, metallic timbres. "
                        "Feedback recirculates for resonant artefacts; "
                        "Spread detunes the channels by up to 25 Hz for chorus-style stereo.",
-        .createPlugin = [](const DevicePluginCreationContext& context) -> DevicePluginPtr {
-            return tracktion_adapter::pluginHandle(
-                new MagdaFreqShiftCompiledPlugin(tracktion_adapter::creationInfo(context)));
+        .createDevice = [](const DevicePluginCreationContext&) -> std::unique_ptr<MagdaDevice> {
+            return std::make_unique<MagdaFreqShiftCompiledPlugin>();
         },
         .aliases = kAliases,
         .aliasCount = static_cast<int>(sizeof(kAliases) / sizeof(kAliases[0])),

--- a/magda/daw/audio/plugins/compiled/MagdaFreqShiftCompiledPlugin.hpp
+++ b/magda/daw/audio/plugins/compiled/MagdaFreqShiftCompiledPlugin.hpp
@@ -1,14 +1,8 @@
 #pragma once
 
-#include <tracktion_engine/tracktion_engine.h>
-
-#include <array>
-#include <memory>
 #include <vector>
 
-#include "../FaustParamPool.hpp"
-#include "core/ParameterInfo.hpp"
-#include "plugins/compiled/tracktion/CompiledFaustTracktionAdapter.hpp"
+#include "plugins/compiled/MagdaCompiledEffect.hpp"
 
 class dsp;
 
@@ -23,92 +17,36 @@ namespace magda::daw::audio::compiled {
  * entire spectrum by a constant Hz offset (unlike ring mod, which
  * produces sum + difference sidebands).
  */
-class MagdaFreqShiftCompiledPlugin : public te::Plugin, public ICompiledFaustPlugin {
+class MagdaFreqShiftCompiledPlugin : public MagdaCompiledEffect {
   public:
     static const char* xmlTypeName;
 
-    explicit MagdaFreqShiftCompiledPlugin(const te::PluginCreationInfo& info);
-    ~MagdaFreqShiftCompiledPlugin() override;
+    MagdaFreqShiftCompiledPlugin();
 
-    juce::String getName() const override;
-    juce::String getPluginType() override;
-    juce::String getShortName(int) override;
-    juce::String getSelectableDescription() override;
-
-    void initialise(const te::PluginInitialisationInfo& info) override;
-    void deinitialise() override;
-    void reset() override;
-    void applyToBuffer(const te::PluginRenderContext& fc) override;
-
-    bool takesMidiInput() override {
-        return false;
-    }
-    bool takesAudioInput() override {
-        return true;
-    }
-    bool isSynth() override {
-        return false;
-    }
-    bool producesAudioWhenNoAudioInput() override {
-        return false;
-    }
-    double getTailLength() const override {
-        return 0.0;
-    }
-
-    // Slot ordering matches [idx:N] pins inside magda_freq_shift.dsp.
     static constexpr int kShiftSlot = 0;
     static constexpr int kFeedbackSlot = 1;
     static constexpr int kMixSlot = 2;
     static constexpr int kSpreadSlot = 3;
     static constexpr int kHostSlotCount = 4;
 
-    te::AutomatableParameter* getSlotParameter(int slotIndex) const;
+    juce::String devicePluginId() const override {
+        return xmlTypeName;
+    }
+    juce::String deviceName() const override {
+        return "Freq Shift";
+    }
 
-    float displayValueToNativeValue(int slotIndex, float displayValue) const;
-    float nativeValueToDisplayValue(int slotIndex, float nativeValue) const;
-
-    using HostSlotInfo = CompiledHostSlotInfo;
-    const HostSlotInfo& getSlotInfo(int slotIndex) const;
-
-    // ICompiledFaustPlugin
-    int hostSlotCount() const override {
-        return kHostSlotCount;
+  protected:
+    ::dsp* createEngineDsp(int engineIndex) const override;
+    std::vector<HostSlotInfo> slotInfos() const override;
+    const char* slotIdPrefix() const override {
+        return "magda_freq_shift_";
     }
-    const CompiledHostSlotInfo& hostSlotInfo(int slotIndex) const override {
-        return getSlotInfo(slotIndex);
-    }
-    DeviceParameterHandle hostSlotParameter(int slotIndex) const override {
-        return tracktion_adapter::parameterHandle(getSlotParameter(slotIndex));
-    }
-    float displayToNormalized(int slotIndex, float displayValue) const override {
-        return displayValueToNativeValue(slotIndex, displayValue);
-    }
-    float normalizedToDisplay(int slotIndex, float normalizedValue) const override {
-        return nativeValueToDisplayValue(slotIndex, normalizedValue);
+    bool resetsOnPlayStart() const override {
+        return true;
     }
 
   private:
-    void buildHostParameters();
-    void rebuildEngineState(int sampleRate);
-
-    std::unique_ptr<::dsp> dsp_;
-    int numInputs_ = 0;
-    int numOutputs_ = 0;
-
-    std::array<FAUSTFLOAT*, kHostSlotCount> zones_{};
-
-    std::array<HostSlotInfo, kHostSlotCount> hostSlotInfo_;
-    std::array<te::AutomatableParameter::Ptr, kHostSlotCount> hostParams_;
-    std::array<juce::CachedValue<float>, kHostSlotCount> hostCached_;
-
-    juce::AudioBuffer<float> scratchIn_;
-    juce::AudioBuffer<float> scratchOut_;
-    std::vector<float*> inPtrs_;
-    std::vector<float*> outPtrs_;
-
-    bool wasPlaying_ = false;
-
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(MagdaFreqShiftCompiledPlugin)
 };
 

--- a/magda/daw/audio/plugins/compiled/MagdaGateExpanderCompiledPlugin.cpp
+++ b/magda/daw/audio/plugins/compiled/MagdaGateExpanderCompiledPlugin.cpp
@@ -1,339 +1,72 @@
 #include "plugins/compiled/MagdaGateExpanderCompiledPlugin.hpp"
 
-#include <algorithm>
-#include <cmath>
-#include <map>
-
-#include "core/ParameterUtils.hpp"
+#include "core/ParameterInfo.hpp"
 #include "faust/dsp/dsp.h"
 #include "faust/gui/UI.h"
 #include "faust/gui/meta.h"
 #include "magda_gate_expander.generated.cpp"
-#include "plugins/FaustMetadataParser.hpp"
-#include "plugins/FaustParamInfo.hpp"
 #include "plugins/compiled/CompiledPluginRegistry.hpp"
-#include "plugins/tracktion/TracktionDeviceAdapters.hpp"
 
 namespace magda::daw::audio::compiled {
 
 const char* MagdaGateExpanderCompiledPlugin::xmlTypeName = "magda_gate_expander";
 
-namespace {
-
-struct GateHarvest {
-    struct Control {
-        int idx = -1;
-        FaustParamSlot::Kind kind = FaustParamSlot::Kind::Continuous;
-        FAUSTFLOAT* zone = nullptr;
-    };
-    std::vector<Control> controls;
-};
-
-class GateHarvester : public ::UI {
-  public:
-    GateHarvest harvest;
-
-    void openTabBox(const char*) override {}
-    void openHorizontalBox(const char*) override {}
-    void openVerticalBox(const char*) override {}
-    void closeBox() override {}
-
-    void addButton(const char* label, FAUSTFLOAT* zone) override {
-        emitControl(FaustParamSlot::Kind::Boolean, label, zone);
-    }
-    void addCheckButton(const char* label, FAUSTFLOAT* zone) override {
-        emitControl(FaustParamSlot::Kind::Boolean, label, zone);
-    }
-    void addVerticalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT, FAUSTFLOAT, FAUSTFLOAT,
-                           FAUSTFLOAT) override {
-        emitControl(FaustParamSlot::Kind::Continuous, label, zone);
-    }
-    void addHorizontalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT, FAUSTFLOAT,
-                             FAUSTFLOAT, FAUSTFLOAT) override {
-        emitControl(FaustParamSlot::Kind::Continuous, label, zone);
-    }
-    void addNumEntry(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT, FAUSTFLOAT, FAUSTFLOAT,
-                     FAUSTFLOAT) override {
-        emitControl(FaustParamSlot::Kind::Continuous, label, zone);
-    }
-    void addHorizontalBargraph(const char*, FAUSTFLOAT*, FAUSTFLOAT, FAUSTFLOAT) override {}
-    void addVerticalBargraph(const char*, FAUSTFLOAT*, FAUSTFLOAT, FAUSTFLOAT) override {}
-    void addSoundfile(const char*, const char*, Soundfile**) override {}
-
-    void declare(FAUSTFLOAT* zone, const char* key, const char* value) override {
-        if (zone == nullptr)
-            return;
-        const auto k = juce::String::fromUTF8(key != nullptr ? key : "").toLowerCase();
-        const auto v = juce::String::fromUTF8(value != nullptr ? value : "");
-        applyFaustAnnotation(k, v, pendingByZone_[zone]);
-    }
-
-  private:
-    void emitControl(FaustParamSlot::Kind kind, const char* rawLabel, FAUSTFLOAT* zone) {
-        const auto parsed =
-            parseFaustLabel(juce::String::fromUTF8(rawLabel != nullptr ? rawLabel : ""));
-        ControlMetadata merged = parsed.metadata;
-        if (zone != nullptr) {
-            if (auto it = pendingByZone_.find(zone); it != pendingByZone_.end()) {
-                mergeFaustMetadata(merged, it->second);
-                pendingByZone_.erase(it);
-            }
-        }
-
-        harvest.controls.push_back({merged.slotIndex,
-                                    merged.isChoiceStyle() ? FaustParamSlot::Kind::Discrete : kind,
-                                    zone});
-    }
-
-    std::map<FAUSTFLOAT*, ControlMetadata> pendingByZone_;
-};
-
-const GateHarvest::Control* findByIdx(const GateHarvest& h, int idx) {
-    for (const auto& c : h.controls)
-        if (c.idx == idx)
-            return &c;
-    return nullptr;
+MagdaGateExpanderCompiledPlugin::MagdaGateExpanderCompiledPlugin() {
+    initEffect();
 }
 
-magda::ParameterInfo parameterInfoForSlot(const CompiledHostSlotInfo& s) {
-    magda::ParameterInfo info;
-    info.minValue = s.minValue;
-    info.maxValue = s.maxValue;
-    info.defaultValue = s.defaultValue;
-    info.unit = s.unit;
-    info.scale = s.scale;
-    if (std::isfinite(s.scaleAnchor))
-        info.scaleAnchor = s.scaleAnchor;
-    info.choices = s.choices;
-    return info;
+::dsp* MagdaGateExpanderCompiledPlugin::createEngineDsp(int) const {
+    return new MagdaGateExpanderDsp();
 }
 
-}  // namespace
+std::vector<MagdaGateExpanderCompiledPlugin::HostSlotInfo>
+MagdaGateExpanderCompiledPlugin::slotInfos() const {
+    std::vector<HostSlotInfo> infos(kHostSlotCount);
+    infos[kAttackSlot] = {.name = "Attack",
+                          .unit = magda::technicalText(magda::TechnicalTextToken::Milliseconds),
+                          .scale = magda::ParameterScale::Logarithmic,
+                          .minValue = 0.1f,
+                          .maxValue = 100.0f,
+                          .defaultValue = 1.0f,
+                          .scaleAnchor = 1.0f};
+    infos[kReleaseSlot] = {.name = "Release",
+                           .unit = magda::technicalText(magda::TechnicalTextToken::Milliseconds),
+                           .scale = magda::ParameterScale::Logarithmic,
+                           .minValue = 5.0f,
+                           .maxValue = 1000.0f,
+                           .defaultValue = 120.0f,
+                           .scaleAnchor = 100.0f};
+    infos[kMixSlot] = {.name = "Mix",
+                       .scale = magda::ParameterScale::Linear,
+                       .minValue = 0.0f,
+                       .maxValue = 1.0f,
+                       .defaultValue = 1.0f};
+    infos[kOutputSlot] = {.name = "Output",
+                          .unit = magda::technicalText(magda::TechnicalTextToken::Decibels),
+                          .scale = magda::ParameterScale::Linear,
+                          .minValue = -24.0f,
+                          .maxValue = 24.0f,
+                          .defaultValue = 0.0f};
+    infos[kThresholdSlot] = {.name = "Threshold",
+                             .unit = magda::technicalText(magda::TechnicalTextToken::Decibels),
+                             .scale = magda::ParameterScale::Linear,
+                             .minValue = -80.0f,
+                             .maxValue = 0.0f,
+                             .defaultValue = -40.0f};
+    infos[kRatioSlot] = {.name = "Ratio",
+                         .scale = magda::ParameterScale::Logarithmic,
+                         .minValue = 1.0f,
+                         .maxValue = 50.0f,
+                         .defaultValue = 4.0f,
+                         .scaleAnchor = 4.0f};
+    infos[kRangeSlot] = {.name = "Range",
+                         .unit = magda::technicalText(magda::TechnicalTextToken::Decibels),
+                         .scale = magda::ParameterScale::Linear,
+                         .minValue = 0.0f,
+                         .maxValue = 80.0f,
+                         .defaultValue = 60.0f};
 
-MagdaGateExpanderCompiledPlugin::MagdaGateExpanderCompiledPlugin(const te::PluginCreationInfo& info)
-    : te::Plugin(info) {
-    dsp_ = std::make_unique<MagdaGateExpanderDsp>();
-    rebuildEngineState(44100);
-    buildHostParameters();
-}
-
-MagdaGateExpanderCompiledPlugin::~MagdaGateExpanderCompiledPlugin() {
-    notifyListenersOfDeletion();
-    for (auto& p : hostParams_)
-        if (p)
-            p->detachFromCurrentValue();
-}
-
-juce::String MagdaGateExpanderCompiledPlugin::getName() const {
-    return "Gate";
-}
-juce::String MagdaGateExpanderCompiledPlugin::getPluginType() {
-    return xmlTypeName;
-}
-juce::String MagdaGateExpanderCompiledPlugin::getShortName(int) {
-    return "Gate";
-}
-juce::String MagdaGateExpanderCompiledPlugin::getSelectableDescription() {
-    return "Gate";
-}
-
-void MagdaGateExpanderCompiledPlugin::rebuildEngineState(int sampleRate) {
-    if (!dsp_)
-        return;
-    dsp_->init(sampleRate);
-    numInputs_ = dsp_->getNumInputs();
-    numOutputs_ = dsp_->getNumOutputs();
-
-    GateHarvester harvester;
-    dsp_->buildUserInterface(&harvester);
-
-    zones_.fill(nullptr);
-    for (int i = 0; i < kHostSlotCount; ++i) {
-        if (auto* c = findByIdx(harvester.harvest, i))
-            zones_[static_cast<size_t>(i)] = c->zone;
-    }
-}
-
-void MagdaGateExpanderCompiledPlugin::buildHostParameters() {
-    hostSlotInfo_[kAttackSlot] = {.name = "Attack",
-                                  .unit =
-                                      magda::technicalText(magda::TechnicalTextToken::Milliseconds),
-                                  .scale = magda::ParameterScale::Logarithmic,
-                                  .minValue = 0.1f,
-                                  .maxValue = 100.0f,
-                                  .defaultValue = 1.0f,
-                                  .scaleAnchor = 1.0f};
-    hostSlotInfo_[kReleaseSlot] = {
-        .name = "Release",
-        .unit = magda::technicalText(magda::TechnicalTextToken::Milliseconds),
-        .scale = magda::ParameterScale::Logarithmic,
-        .minValue = 5.0f,
-        .maxValue = 1000.0f,
-        .defaultValue = 120.0f,
-        .scaleAnchor = 100.0f};
-    hostSlotInfo_[kMixSlot] = {.name = "Mix",
-                               .scale = magda::ParameterScale::Linear,
-                               .minValue = 0.0f,
-                               .maxValue = 1.0f,
-                               .defaultValue = 1.0f};
-    hostSlotInfo_[kOutputSlot] = {.name = "Output",
-                                  .unit = magda::technicalText(magda::TechnicalTextToken::Decibels),
-                                  .scale = magda::ParameterScale::Linear,
-                                  .minValue = -24.0f,
-                                  .maxValue = 24.0f,
-                                  .defaultValue = 0.0f};
-    hostSlotInfo_[kThresholdSlot] = {.name = "Threshold",
-                                     .unit =
-                                         magda::technicalText(magda::TechnicalTextToken::Decibels),
-                                     .scale = magda::ParameterScale::Linear,
-                                     .minValue = -80.0f,
-                                     .maxValue = 0.0f,
-                                     .defaultValue = -40.0f};
-    hostSlotInfo_[kRatioSlot] = {.name = "Ratio",
-                                 .scale = magda::ParameterScale::Logarithmic,
-                                 .minValue = 1.0f,
-                                 .maxValue = 50.0f,
-                                 .defaultValue = 4.0f,
-                                 .scaleAnchor = 4.0f};
-    hostSlotInfo_[kRangeSlot] = {.name = "Range",
-                                 .unit = magda::technicalText(magda::TechnicalTextToken::Decibels),
-                                 .scale = magda::ParameterScale::Linear,
-                                 .minValue = 0.0f,
-                                 .maxValue = 80.0f,
-                                 .defaultValue = 60.0f};
-
-    juce::NormalisableRange<float> normalisedRange{0.0f, 1.0f};
-    auto* undoManager = getUndoManager();
-
-    for (int i = 0; i < kHostSlotCount; ++i) {
-        const auto& slot = hostSlotInfo_[static_cast<size_t>(i)];
-        const juce::String id = "magda_gate_expander_" + slot.name.toLowerCase().replace(" ", "_");
-        const auto info = parameterInfoForSlot(slot);
-        const float defaultNormalised =
-            magda::ParameterUtils::realToNormalized(slot.defaultValue, info);
-        hostCached_[static_cast<size_t>(i)].referTo(state, juce::Identifier(id), undoManager,
-                                                    defaultNormalised);
-
-        auto param = addParam(
-            id, slot.name, normalisedRange,
-            [info](float normalised) {
-                const float real = magda::ParameterUtils::normalizedToReal(normalised, info);
-                return magda::ParameterUtils::formatValue(real, info);
-            },
-            [info](const juce::String& text) {
-                auto parsed = magda::ParameterUtils::parseValue(text, info);
-                if (parsed)
-                    return magda::ParameterUtils::realToNormalized(*parsed, info);
-                return 0.0f;
-            });
-        param->attachToCurrentValue(hostCached_[static_cast<size_t>(i)]);
-        hostParams_[static_cast<size_t>(i)] = param;
-    }
-}
-
-void MagdaGateExpanderCompiledPlugin::initialise(const te::PluginInitialisationInfo& info) {
-    rebuildEngineState(static_cast<int>(info.sampleRate));
-    scratchIn_.setSize(numInputs_, info.blockSizeSamples, false, true, true);
-    scratchOut_.setSize(numOutputs_, info.blockSizeSamples, false, true, true);
-    inPtrs_.assign(static_cast<size_t>(numInputs_), nullptr);
-    outPtrs_.assign(static_cast<size_t>(numOutputs_), nullptr);
-}
-
-void MagdaGateExpanderCompiledPlugin::deinitialise() {
-    scratchIn_.setSize(0, 0);
-    scratchOut_.setSize(0, 0);
-    inPtrs_.clear();
-    outPtrs_.clear();
-}
-
-void MagdaGateExpanderCompiledPlugin::reset() {
-    if (dsp_)
-        dsp_->instanceClear();
-}
-
-void MagdaGateExpanderCompiledPlugin::applyToBuffer(const te::PluginRenderContext& fc) {
-    if (!fc.destBuffer || fc.bufferNumSamples <= 0 || !dsp_)
-        return;
-
-    for (int slot = 0; slot < kHostSlotCount; ++slot) {
-        if (auto* zone = zones_[static_cast<size_t>(slot)]) {
-            const auto info = parameterInfoForSlot(hostSlotInfo_[static_cast<size_t>(slot)]);
-            const float norm = hostParams_[static_cast<size_t>(slot)]->getCurrentValue();
-            *zone = static_cast<FAUSTFLOAT>(magda::ParameterUtils::normalizedToReal(norm, info));
-        }
-    }
-
-    const int numSamples = fc.bufferNumSamples;
-    const int startSample = fc.bufferStartSample;
-    const int hostChannels = fc.destBuffer->getNumChannels();
-    if (hostChannels <= 0 || numInputs_ <= 0 || numOutputs_ <= 0)
-        return;
-
-    if (scratchIn_.getNumChannels() < numInputs_ || scratchIn_.getNumSamples() < numSamples)
-        scratchIn_.setSize(numInputs_, numSamples, false, true, true);
-    if (scratchOut_.getNumChannels() < numOutputs_ || scratchOut_.getNumSamples() < numSamples)
-        scratchOut_.setSize(numOutputs_, numSamples, false, true, true);
-    if (static_cast<int>(inPtrs_.size()) < numInputs_)
-        inPtrs_.resize(static_cast<size_t>(numInputs_), nullptr);
-    if (static_cast<int>(outPtrs_.size()) < numOutputs_)
-        outPtrs_.resize(static_cast<size_t>(numOutputs_), nullptr);
-
-    for (int ch = 0; ch < numInputs_; ++ch) {
-        float* dst = scratchIn_.getWritePointer(ch);
-        if (ch < hostChannels) {
-            const float* src = fc.destBuffer->getReadPointer(ch, startSample);
-            std::copy(src, src + numSamples, dst);
-        } else {
-            std::fill(dst, dst + numSamples, 0.0f);
-        }
-        inPtrs_[static_cast<size_t>(ch)] = dst;
-    }
-    for (int ch = 0; ch < numOutputs_; ++ch) {
-        outPtrs_[static_cast<size_t>(ch)] = (ch < hostChannels)
-                                                ? fc.destBuffer->getWritePointer(ch, startSample)
-                                                : scratchOut_.getWritePointer(ch);
-    }
-
-    dsp_->compute(numSamples, inPtrs_.data(), outPtrs_.data());
-
-    const int channelsToSanitise = std::min(hostChannels, numOutputs_);
-    for (int ch = 0; ch < channelsToSanitise; ++ch) {
-        float* out = fc.destBuffer->getWritePointer(ch, startSample);
-        for (int i = 0; i < numSamples; ++i) {
-            const float sample = out[i];
-            out[i] = std::isfinite(sample) ? juce::jlimit(-16.0f, 16.0f, sample) : 0.0f;
-        }
-    }
-}
-
-te::AutomatableParameter* MagdaGateExpanderCompiledPlugin::getSlotParameter(int slotIndex) const {
-    if (slotIndex < 0 || slotIndex >= kHostSlotCount)
-        return nullptr;
-    return hostParams_[static_cast<size_t>(slotIndex)].get();
-}
-
-const MagdaGateExpanderCompiledPlugin::HostSlotInfo& MagdaGateExpanderCompiledPlugin::getSlotInfo(
-    int slotIndex) const {
-    static const HostSlotInfo kEmpty;
-    if (slotIndex < 0 || slotIndex >= kHostSlotCount)
-        return kEmpty;
-    return hostSlotInfo_[static_cast<size_t>(slotIndex)];
-}
-
-float MagdaGateExpanderCompiledPlugin::displayValueToNativeValue(int slotIndex,
-                                                                 float displayValue) const {
-    if (slotIndex < 0 || slotIndex >= kHostSlotCount)
-        return displayValue;
-    return magda::ParameterUtils::realToNormalized(
-        displayValue, parameterInfoForSlot(hostSlotInfo_[static_cast<size_t>(slotIndex)]));
-}
-
-float MagdaGateExpanderCompiledPlugin::nativeValueToDisplayValue(int slotIndex,
-                                                                 float nativeValue) const {
-    if (slotIndex < 0 || slotIndex >= kHostSlotCount)
-        return nativeValue;
-    return magda::ParameterUtils::normalizedToReal(
-        nativeValue, parameterInfoForSlot(hostSlotInfo_[static_cast<size_t>(slotIndex)]));
+    return infos;
 }
 
 constexpr AliasSpec kAliases[] = {
@@ -353,9 +86,8 @@ const CompiledPluginSpec& getMagdaGateExpanderSpec() {
             "Range bounds the deepest cut. "
             "Attack and Release shape the envelope; "
             "Mix blends the gated signal back against dry for parallel gating.",
-        .createPlugin = [](const DevicePluginCreationContext& context) -> DevicePluginPtr {
-            return tracktion_adapter::pluginHandle(
-                new MagdaGateExpanderCompiledPlugin(tracktion_adapter::creationInfo(context)));
+        .createDevice = [](const DevicePluginCreationContext&) -> std::unique_ptr<MagdaDevice> {
+            return std::make_unique<MagdaGateExpanderCompiledPlugin>();
         },
         .aliases = kAliases,
         .aliasCount = static_cast<int>(sizeof(kAliases) / sizeof(kAliases[0])),

--- a/magda/daw/audio/plugins/compiled/MagdaGateExpanderCompiledPlugin.hpp
+++ b/magda/daw/audio/plugins/compiled/MagdaGateExpanderCompiledPlugin.hpp
@@ -1,51 +1,18 @@
 #pragma once
 
-#include <tracktion_engine/tracktion_engine.h>
-
-#include <array>
-#include <memory>
 #include <vector>
 
-#include "../FaustParamPool.hpp"
-#include "core/ParameterInfo.hpp"
-#include "plugins/compiled/tracktion/CompiledFaustTracktionAdapter.hpp"
+#include "plugins/compiled/MagdaCompiledEffect.hpp"
 
 class dsp;
 
 namespace magda::daw::audio::compiled {
 
-class MagdaGateExpanderCompiledPlugin : public te::Plugin, public ICompiledFaustPlugin {
+class MagdaGateExpanderCompiledPlugin : public MagdaCompiledEffect {
   public:
     static const char* xmlTypeName;
 
-    explicit MagdaGateExpanderCompiledPlugin(const te::PluginCreationInfo& info);
-    ~MagdaGateExpanderCompiledPlugin() override;
-
-    juce::String getName() const override;
-    juce::String getPluginType() override;
-    juce::String getShortName(int) override;
-    juce::String getSelectableDescription() override;
-
-    void initialise(const te::PluginInitialisationInfo& info) override;
-    void deinitialise() override;
-    void reset() override;
-    void applyToBuffer(const te::PluginRenderContext& fc) override;
-
-    bool takesMidiInput() override {
-        return false;
-    }
-    bool takesAudioInput() override {
-        return true;
-    }
-    bool isSynth() override {
-        return false;
-    }
-    bool producesAudioWhenNoAudioInput() override {
-        return false;
-    }
-    double getTailLength() const override {
-        return 0.0;
-    }
+    MagdaGateExpanderCompiledPlugin();
 
     static constexpr int kAttackSlot = 0;
     static constexpr int kReleaseSlot = 1;
@@ -56,48 +23,21 @@ class MagdaGateExpanderCompiledPlugin : public te::Plugin, public ICompiledFaust
     static constexpr int kRangeSlot = 6;
     static constexpr int kHostSlotCount = 7;
 
-    te::AutomatableParameter* getSlotParameter(int slotIndex) const;
+    juce::String devicePluginId() const override {
+        return xmlTypeName;
+    }
+    juce::String deviceName() const override {
+        return "Gate";
+    }
 
-    float displayValueToNativeValue(int slotIndex, float displayValue) const;
-    float nativeValueToDisplayValue(int slotIndex, float nativeValue) const;
-
-    using HostSlotInfo = CompiledHostSlotInfo;
-    const HostSlotInfo& getSlotInfo(int slotIndex) const;
-
-    int hostSlotCount() const override {
-        return kHostSlotCount;
-    }
-    const CompiledHostSlotInfo& hostSlotInfo(int slotIndex) const override {
-        return getSlotInfo(slotIndex);
-    }
-    DeviceParameterHandle hostSlotParameter(int slotIndex) const override {
-        return tracktion_adapter::parameterHandle(getSlotParameter(slotIndex));
-    }
-    float displayToNormalized(int slotIndex, float displayValue) const override {
-        return displayValueToNativeValue(slotIndex, displayValue);
-    }
-    float normalizedToDisplay(int slotIndex, float normalizedValue) const override {
-        return nativeValueToDisplayValue(slotIndex, normalizedValue);
+  protected:
+    ::dsp* createEngineDsp(int engineIndex) const override;
+    std::vector<HostSlotInfo> slotInfos() const override;
+    const char* slotIdPrefix() const override {
+        return "magda_gate_expander_";
     }
 
   private:
-    void buildHostParameters();
-    void rebuildEngineState(int sampleRate);
-
-    std::unique_ptr<::dsp> dsp_;
-    int numInputs_ = 0;
-    int numOutputs_ = 0;
-
-    std::array<FAUSTFLOAT*, kHostSlotCount> zones_{};
-    std::array<HostSlotInfo, kHostSlotCount> hostSlotInfo_;
-    std::array<te::AutomatableParameter::Ptr, kHostSlotCount> hostParams_;
-    std::array<juce::CachedValue<float>, kHostSlotCount> hostCached_;
-
-    juce::AudioBuffer<float> scratchIn_;
-    juce::AudioBuffer<float> scratchOut_;
-    std::vector<float*> inPtrs_;
-    std::vector<float*> outPtrs_;
-
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(MagdaGateExpanderCompiledPlugin)
 };
 

--- a/magda/daw/audio/plugins/compiled/MagdaGrainDelayCompiledPlugin.cpp
+++ b/magda/daw/audio/plugins/compiled/MagdaGrainDelayCompiledPlugin.cpp
@@ -1,440 +1,90 @@
 #include "plugins/compiled/MagdaGrainDelayCompiledPlugin.hpp"
 
-#include <algorithm>
-#include <cmath>
-#include <map>
-
-#include "core/ParameterUtils.hpp"
+#include "core/ParameterInfo.hpp"
 #include "faust/dsp/dsp.h"
 #include "faust/gui/UI.h"
 #include "faust/gui/meta.h"
 #include "magda_granular_delay.generated.cpp"
-#include "plugins/FaustMetadataParser.hpp"
-#include "plugins/FaustParamInfo.hpp"
 #include "plugins/compiled/CompiledPluginRegistry.hpp"
-#include "plugins/tracktion/TracktionDeviceAdapters.hpp"
 
 namespace magda::daw::audio::compiled {
 
 const char* MagdaGrainDelayCompiledPlugin::xmlTypeName = "magda_grain_delay";
 
-namespace {
-
-struct GrainDelayHarvest {
-    struct Control {
-        int idx = -1;
-        FaustParamSlot::Kind kind = FaustParamSlot::Kind::Continuous;
-        FAUSTFLOAT* zone = nullptr;
-        std::vector<std::pair<float, juce::String>> choices;
-        int gateSlotIndex = -1;
-        bool gateNegated = false;
-    };
-    std::vector<Control> controls;
-};
-
-class GrainDelayHarvester : public ::UI {
-  public:
-    GrainDelayHarvest harvest;
-
-    void openTabBox(const char*) override {}
-    void openHorizontalBox(const char*) override {}
-    void openVerticalBox(const char*) override {}
-    void closeBox() override {}
-
-    void addButton(const char* label, FAUSTFLOAT* zone) override {
-        emitControl(FaustParamSlot::Kind::Boolean, label, zone);
-    }
-    void addCheckButton(const char* label, FAUSTFLOAT* zone) override {
-        emitControl(FaustParamSlot::Kind::Boolean, label, zone);
-    }
-    void addVerticalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT, FAUSTFLOAT, FAUSTFLOAT,
-                           FAUSTFLOAT) override {
-        emitControl(FaustParamSlot::Kind::Continuous, label, zone);
-    }
-    void addHorizontalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT, FAUSTFLOAT,
-                             FAUSTFLOAT, FAUSTFLOAT) override {
-        emitControl(FaustParamSlot::Kind::Continuous, label, zone);
-    }
-    void addNumEntry(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT, FAUSTFLOAT, FAUSTFLOAT,
-                     FAUSTFLOAT) override {
-        emitControl(FaustParamSlot::Kind::Continuous, label, zone);
-    }
-    void addHorizontalBargraph(const char*, FAUSTFLOAT*, FAUSTFLOAT, FAUSTFLOAT) override {}
-    void addVerticalBargraph(const char*, FAUSTFLOAT*, FAUSTFLOAT, FAUSTFLOAT) override {}
-    void addSoundfile(const char*, const char*, Soundfile**) override {}
-
-    void declare(FAUSTFLOAT* zone, const char* key, const char* value) override {
-        if (zone == nullptr)
-            return;
-        const auto k = juce::String::fromUTF8(key != nullptr ? key : "").toLowerCase();
-        const auto v = juce::String::fromUTF8(value != nullptr ? value : "");
-        applyFaustAnnotation(k, v, pendingByZone_[zone]);
-    }
-
-  private:
-    void emitControl(FaustParamSlot::Kind kind, const char* rawLabel, FAUSTFLOAT* zone) {
-        const auto parsed =
-            parseFaustLabel(juce::String::fromUTF8(rawLabel != nullptr ? rawLabel : ""));
-        ControlMetadata merged = parsed.metadata;
-        if (zone != nullptr) {
-            if (auto it = pendingByZone_.find(zone); it != pendingByZone_.end()) {
-                mergeFaustMetadata(merged, it->second);
-                pendingByZone_.erase(it);
-            }
-        }
-
-        GrainDelayHarvest::Control c;
-        c.idx = merged.slotIndex;
-        c.kind = merged.isChoiceStyle() ? FaustParamSlot::Kind::Discrete : kind;
-        c.zone = zone;
-        c.choices = merged.menuChoices;
-        c.gateSlotIndex = merged.gateSlotIndex;
-        c.gateNegated = merged.gateNegated;
-        harvest.controls.push_back(std::move(c));
-    }
-
-    std::map<FAUSTFLOAT*, ControlMetadata> pendingByZone_;
-};
-
-const GrainDelayHarvest::Control* findByIdx(const GrainDelayHarvest& h, int idx) {
-    for (const auto& c : h.controls)
-        if (c.idx == idx)
-            return &c;
-    return nullptr;
+MagdaGrainDelayCompiledPlugin::MagdaGrainDelayCompiledPlugin() {
+    initEffect();
 }
 
-}  // namespace
-
-MagdaGrainDelayCompiledPlugin::MagdaGrainDelayCompiledPlugin(const te::PluginCreationInfo& info)
-    : te::Plugin(info) {
-    dsp_ = std::make_unique<MagdaGrainDelayDsp>();
-    constexpr int kProvisionalSampleRate = 44100;
-    rebuildEngineState(kProvisionalSampleRate);
-    buildHostParameters();
+::dsp* MagdaGrainDelayCompiledPlugin::createEngineDsp(int) const {
+    return new MagdaGrainDelayDsp();
 }
 
-MagdaGrainDelayCompiledPlugin::~MagdaGrainDelayCompiledPlugin() {
-    notifyListenersOfDeletion();
-    for (auto& p : hostParams_)
-        if (p)
-            p->detachFromCurrentValue();
-}
+std::vector<MagdaGrainDelayCompiledPlugin::HostSlotInfo> MagdaGrainDelayCompiledPlugin::slotInfos()
+    const {
+    std::vector<HostSlotInfo> infos(kHostSlotCount);
+    // The Division choices are the dsp's own [style:menu{...}]: the labels
+    // read as musical divisions and the values are the quarter-note
+    // multipliers the zone wants, so neither list is restated here.
+    const auto divisionValues = menuValuesForIdx(kDivisionSlot);
+    infos[kTimeSlot] = {.name = "Time",
+                        .unit = magda::technicalText(magda::TechnicalTextToken::Milliseconds),
+                        .scale = magda::ParameterScale::Linear,
+                        .minValue = 1.0f,
+                        .maxValue = 2000.0f,
+                        .defaultValue = 500.0f};
+    infos[kDivisionSlot].name = "Division";
+    infos[kDivisionSlot].scale = magda::ParameterScale::Discrete;
+    infos[kDivisionSlot].minValue = 0.0f;
+    infos[kDivisionSlot].maxValue = 0.0f;
+    infos[kDivisionSlot].defaultValue = 0.0f;
+    infos[kSyncSlot] = {.name = "Sync",
+                        .scale = magda::ParameterScale::Discrete,
+                        .minValue = 0.0f,
+                        .maxValue = 1.0f,
+                        .defaultValue = 0.0f,
+                        .scaleAnchor = std::numeric_limits<float>::quiet_NaN(),
+                        .choices = {"Off", "On"}};
+    infos[kSizeSlot] = {.name = "Size",
+                        .unit = magda::technicalText(magda::TechnicalTextToken::Milliseconds),
+                        .scale = magda::ParameterScale::Linear,
+                        .minValue = 20.0f,
+                        .maxValue = 500.0f,
+                        .defaultValue = 120.0f};
+    infos[kPitchSlot] = {.name = "Pitch",
+                         .unit = magda::technicalText(magda::TechnicalTextToken::Semitones),
+                         .scale = magda::ParameterScale::Linear,
+                         .minValue = -24.0f,
+                         .maxValue = 24.0f,
+                         .defaultValue = 0.0f};
+    infos[kSpraySlot] = {.name = "Spray",
+                         .scale = magda::ParameterScale::Linear,
+                         .minValue = 0.0f,
+                         .maxValue = 1.0f,
+                         .defaultValue = 0.0f};
+    infos[kFeedbackSlot] = {.name = "Feedback",
+                            .scale = magda::ParameterScale::Linear,
+                            .minValue = 0.0f,
+                            .maxValue = 0.95f,
+                            .defaultValue = 0.30f};
+    infos[kMixSlot] = {.name = "Mix",
+                       .scale = magda::ParameterScale::Linear,
+                       .minValue = 0.0f,
+                       .maxValue = 1.0f,
+                       .defaultValue = 0.40f};
 
-juce::String MagdaGrainDelayCompiledPlugin::getName() const {
-    return "Grain Delay";
-}
-juce::String MagdaGrainDelayCompiledPlugin::getPluginType() {
-    return xmlTypeName;
-}
-juce::String MagdaGrainDelayCompiledPlugin::getShortName(int) {
-    return "Grain Delay";
-}
-juce::String MagdaGrainDelayCompiledPlugin::getSelectableDescription() {
-    return "Grain Delay";
-}
-
-void MagdaGrainDelayCompiledPlugin::rebuildEngineState(int sampleRate) {
-    if (!dsp_)
-        return;
-    dsp_->init(sampleRate);
-    numInputs_ = dsp_->getNumInputs();
-    numOutputs_ = dsp_->getNumOutputs();
-
-    GrainDelayHarvester harvester;
-    dsp_->buildUserInterface(&harvester);
-
-    zones_.fill(nullptr);
-    bpmZone_ = nullptr;
-    divisionChoiceValues_.clear();
-    divisionChoiceLabels_.clear();
-
-    for (int i = 0; i < kHostSlotCount; ++i) {
-        harvestedGates_[static_cast<size_t>(i)] = {-1, false};
-        if (auto* c = findByIdx(harvester.harvest, i)) {
-            zones_[static_cast<size_t>(i)] = c->zone;
-            harvestedGates_[static_cast<size_t>(i)] = {c->gateSlotIndex, c->gateNegated};
-        }
-    }
-    if (auto* c = findByIdx(harvester.harvest, kBpmSlot))
-        bpmZone_ = c->zone;
-
-    if (auto* c = findByIdx(harvester.harvest, kDivisionSlot)) {
-        auto sorted = c->choices;
-        std::sort(sorted.begin(), sorted.end(),
-                  [](const auto& a, const auto& b) { return a.first < b.first; });
-        divisionChoiceValues_.reserve(sorted.size());
-        divisionChoiceLabels_.reserve(sorted.size());
-        for (const auto& choice : sorted) {
-            divisionChoiceValues_.push_back(choice.first);
-            divisionChoiceLabels_.push_back(choice.second);
-        }
-    }
-}
-
-void MagdaGrainDelayCompiledPlugin::buildHostParameters() {
-    hostSlotInfo_[kTimeSlot] = {.name = "Time",
-                                .unit =
-                                    magda::technicalText(magda::TechnicalTextToken::Milliseconds),
-                                .scale = magda::ParameterScale::Linear,
-                                .minValue = 1.0f,
-                                .maxValue = 2000.0f,
-                                .defaultValue = 500.0f};
-    hostSlotInfo_[kDivisionSlot].name = "Division";
-    hostSlotInfo_[kDivisionSlot].scale = magda::ParameterScale::Discrete;
-    hostSlotInfo_[kDivisionSlot].minValue = 0.0f;
-    hostSlotInfo_[kDivisionSlot].maxValue = 0.0f;
-    hostSlotInfo_[kDivisionSlot].defaultValue = 0.0f;
-    hostSlotInfo_[kSyncSlot] = {.name = "Sync",
-                                .scale = magda::ParameterScale::Discrete,
-                                .minValue = 0.0f,
-                                .maxValue = 1.0f,
-                                .defaultValue = 0.0f,
-                                .scaleAnchor = std::numeric_limits<float>::quiet_NaN(),
-                                .choices = {"Off", "On"}};
-    hostSlotInfo_[kSizeSlot] = {.name = "Size",
-                                .unit =
-                                    magda::technicalText(magda::TechnicalTextToken::Milliseconds),
-                                .scale = magda::ParameterScale::Linear,
-                                .minValue = 20.0f,
-                                .maxValue = 500.0f,
-                                .defaultValue = 120.0f};
-    hostSlotInfo_[kPitchSlot] = {.name = "Pitch",
-                                 .unit = magda::technicalText(magda::TechnicalTextToken::Semitones),
-                                 .scale = magda::ParameterScale::Linear,
-                                 .minValue = -24.0f,
-                                 .maxValue = 24.0f,
-                                 .defaultValue = 0.0f};
-    hostSlotInfo_[kSpraySlot] = {.name = "Spray",
-                                 .scale = magda::ParameterScale::Linear,
-                                 .minValue = 0.0f,
-                                 .maxValue = 1.0f,
-                                 .defaultValue = 0.0f};
-    hostSlotInfo_[kFeedbackSlot] = {.name = "Feedback",
-                                    .scale = magda::ParameterScale::Linear,
-                                    .minValue = 0.0f,
-                                    .maxValue = 0.95f,
-                                    .defaultValue = 0.30f};
-    hostSlotInfo_[kMixSlot] = {.name = "Mix",
-                               .scale = magda::ParameterScale::Linear,
-                               .minValue = 0.0f,
-                               .maxValue = 1.0f,
-                               .defaultValue = 0.40f};
-
-    if (!divisionChoiceValues_.empty()) {
-        const int n = static_cast<int>(divisionChoiceValues_.size());
-        hostSlotInfo_[kDivisionSlot].choices = divisionChoiceLabels_;
-        hostSlotInfo_[kDivisionSlot].maxValue = static_cast<float>(n - 1);
+    if (!divisionValues.empty()) {
+        const int n = static_cast<int>(divisionValues.size());
+        infos[kDivisionSlot].choices = menuLabelsForIdx(kDivisionSlot);
+        infos[kDivisionSlot].maxValue = static_cast<float>(n - 1);
         for (int i = 0; i < n; ++i) {
-            if (std::abs(divisionChoiceValues_[static_cast<size_t>(i)] - 1.0f) < 1e-3f) {
-                hostSlotInfo_[kDivisionSlot].defaultValue = static_cast<float>(i);
+            if (std::abs(divisionValues[static_cast<size_t>(i)] - 1.0f) < 1e-3f) {
+                infos[kDivisionSlot].defaultValue = static_cast<float>(i);
                 break;
             }
         }
     }
 
-    juce::NormalisableRange<float> normalisedRange{0.0f, 1.0f};
-    auto* undoManager = getUndoManager();
-
-    auto buildInfo = [](const HostSlotInfo& s) {
-        magda::ParameterInfo info;
-        info.minValue = s.minValue;
-        info.maxValue = s.maxValue;
-        info.defaultValue = s.defaultValue;
-        info.unit = s.unit;
-        info.scale = s.scale;
-        if (std::isfinite(s.scaleAnchor))
-            info.scaleAnchor = s.scaleAnchor;
-        info.choices = s.choices;
-        return info;
-    };
-
-    for (int i = 0; i < kHostSlotCount; ++i) {
-        const auto& slot = hostSlotInfo_[i];
-        const juce::String id = "magda_grain_delay_" + slot.name.toLowerCase().replace(" ", "_");
-        const juce::Identifier identifier(id);
-        const auto info = buildInfo(slot);
-        const float defaultNormalized =
-            magda::ParameterUtils::realToNormalized(slot.defaultValue, info);
-        hostCached_[i].referTo(state, identifier, undoManager, defaultNormalized);
-
-        auto param = addParam(
-            id, slot.name, normalisedRange,
-            [info](float normalized) {
-                const float real = magda::ParameterUtils::normalizedToReal(normalized, info);
-                return magda::ParameterUtils::formatValue(real, info);
-            },
-            [info](const juce::String& text) {
-                auto parsed = magda::ParameterUtils::parseValue(text, info);
-                if (parsed)
-                    return magda::ParameterUtils::realToNormalized(*parsed, info);
-                return 0.0f;
-            });
-        param->attachToCurrentValue(hostCached_[i]);
-        hostParams_[i] = param;
-    }
-
-    for (int i = 0; i < kHostSlotCount; ++i) {
-        hostSlotInfo_[static_cast<size_t>(i)].gateSlotIndex =
-            harvestedGates_[static_cast<size_t>(i)].slotIndex;
-        hostSlotInfo_[static_cast<size_t>(i)].gateNegated =
-            harvestedGates_[static_cast<size_t>(i)].negated;
-    }
-}
-
-void MagdaGrainDelayCompiledPlugin::initialise(const te::PluginInitialisationInfo& info) {
-    rebuildEngineState(static_cast<int>(info.sampleRate));
-    scratchIn_.setSize(numInputs_, info.blockSizeSamples, false, true, true);
-    scratchOut_.setSize(numOutputs_, info.blockSizeSamples, false, true, true);
-    inPtrs_.assign(static_cast<size_t>(numInputs_), nullptr);
-    outPtrs_.assign(static_cast<size_t>(numOutputs_), nullptr);
-}
-
-void MagdaGrainDelayCompiledPlugin::deinitialise() {
-    scratchIn_.setSize(0, 0);
-    scratchOut_.setSize(0, 0);
-    inPtrs_.clear();
-    outPtrs_.clear();
-}
-
-void MagdaGrainDelayCompiledPlugin::reset() {
-    if (dsp_)
-        dsp_->instanceClear();
-}
-
-void MagdaGrainDelayCompiledPlugin::applyToBuffer(const te::PluginRenderContext& fc) {
-    if (!fc.destBuffer || fc.bufferNumSamples <= 0 || !dsp_)
-        return;
-
-    auto writeContinuous = [&](int slot) {
-        if (auto* zone = zones_[static_cast<size_t>(slot)]) {
-            const auto& s = hostSlotInfo_[static_cast<size_t>(slot)];
-            magda::ParameterInfo info;
-            info.minValue = s.minValue;
-            info.maxValue = s.maxValue;
-            info.scale = s.scale;
-            if (std::isfinite(s.scaleAnchor))
-                info.scaleAnchor = s.scaleAnchor;
-            const float norm = hostParams_[static_cast<size_t>(slot)]->getCurrentValue();
-            *zone = static_cast<FAUSTFLOAT>(magda::ParameterUtils::normalizedToReal(norm, info));
-        }
-    };
-    writeContinuous(kTimeSlot);
-    writeContinuous(kSizeSlot);
-    writeContinuous(kPitchSlot);
-    writeContinuous(kSpraySlot);
-    writeContinuous(kFeedbackSlot);
-    writeContinuous(kMixSlot);
-
-    if (auto* z = zones_[kSyncSlot])
-        *z = hostParams_[kSyncSlot]->getCurrentValue() >= 0.5f ? FAUSTFLOAT(1) : FAUSTFLOAT(0);
-
-    if (auto* z = zones_[kDivisionSlot]; z && !divisionChoiceValues_.empty()) {
-        const float norm = hostParams_[kDivisionSlot]->getCurrentValue();
-        const int count = static_cast<int>(divisionChoiceValues_.size());
-        const int idx = juce::jlimit(
-            0, count - 1, static_cast<int>(std::round(norm * static_cast<float>(count - 1))));
-        *z = static_cast<FAUSTFLOAT>(divisionChoiceValues_[static_cast<size_t>(idx)]);
-    }
-
-    // Always read the live BPM and publish it for the UI curve view; only
-    // forward it into the Faust zone if the DSP exposed one.
-    const double bpm = edit.tempoSequence.getBpmAt(fc.editTime.getStart());
-    currentBpm_.store(static_cast<float>(bpm), std::memory_order_relaxed);
-    if (bpmZone_)
-        *bpmZone_ = static_cast<FAUSTFLOAT>(bpm);
-
-    const int numSamples = fc.bufferNumSamples;
-    const int startSample = fc.bufferStartSample;
-    const int hostChannels = fc.destBuffer->getNumChannels();
-    if (hostChannels <= 0 || numInputs_ <= 0 || numOutputs_ <= 0)
-        return;
-
-    if (scratchIn_.getNumChannels() < numInputs_ || scratchIn_.getNumSamples() < numSamples)
-        scratchIn_.setSize(numInputs_, numSamples, false, true, true);
-    if (scratchOut_.getNumChannels() < numOutputs_ || scratchOut_.getNumSamples() < numSamples)
-        scratchOut_.setSize(numOutputs_, numSamples, false, true, true);
-    if (static_cast<int>(inPtrs_.size()) < numInputs_)
-        inPtrs_.resize(static_cast<size_t>(numInputs_), nullptr);
-    if (static_cast<int>(outPtrs_.size()) < numOutputs_)
-        outPtrs_.resize(static_cast<size_t>(numOutputs_), nullptr);
-
-    for (int ch = 0; ch < numInputs_; ++ch) {
-        float* dst = scratchIn_.getWritePointer(ch);
-        if (ch < hostChannels) {
-            const float* src = fc.destBuffer->getReadPointer(ch, startSample);
-            std::copy(src, src + numSamples, dst);
-        } else {
-            std::fill(dst, dst + numSamples, 0.0f);
-        }
-        inPtrs_[static_cast<size_t>(ch)] = dst;
-    }
-    for (int ch = 0; ch < numOutputs_; ++ch) {
-        outPtrs_[static_cast<size_t>(ch)] = (ch < hostChannels)
-                                                ? fc.destBuffer->getWritePointer(ch, startSample)
-                                                : scratchOut_.getWritePointer(ch);
-    }
-
-    dsp_->compute(numSamples, inPtrs_.data(), outPtrs_.data());
-
-    const int channelsToSanitise = std::min(hostChannels, numOutputs_);
-    for (int ch = 0; ch < channelsToSanitise; ++ch) {
-        float* out = fc.destBuffer->getWritePointer(ch, startSample);
-        for (int i = 0; i < numSamples; ++i) {
-            const float sample = out[i];
-            out[i] = std::isfinite(sample) ? juce::jlimit(-16.0f, 16.0f, sample) : 0.0f;
-        }
-    }
-}
-
-te::AutomatableParameter* MagdaGrainDelayCompiledPlugin::getSlotParameter(int slotIndex) const {
-    if (slotIndex < 0 || slotIndex >= kHostSlotCount)
-        return nullptr;
-    return hostParams_[static_cast<size_t>(slotIndex)].get();
-}
-
-const MagdaGrainDelayCompiledPlugin::HostSlotInfo& MagdaGrainDelayCompiledPlugin::getSlotInfo(
-    int slotIndex) const {
-    static const HostSlotInfo kEmpty;
-    if (slotIndex < 0 || slotIndex >= kHostSlotCount)
-        return kEmpty;
-    return hostSlotInfo_[static_cast<size_t>(slotIndex)];
-}
-
-float MagdaGrainDelayCompiledPlugin::divisionFaustValueForIndex(int index) const {
-    if (divisionChoiceValues_.empty())
-        return 1.0f;
-    const int safeIdx = juce::jlimit(0, static_cast<int>(divisionChoiceValues_.size()) - 1, index);
-    return divisionChoiceValues_[static_cast<size_t>(safeIdx)];
-}
-
-float MagdaGrainDelayCompiledPlugin::displayValueToNativeValue(int slotIndex,
-                                                               float displayValue) const {
-    if (slotIndex < 0 || slotIndex >= kHostSlotCount)
-        return displayValue;
-    const auto& s = hostSlotInfo_[static_cast<size_t>(slotIndex)];
-    magda::ParameterInfo info;
-    info.minValue = s.minValue;
-    info.maxValue = s.maxValue;
-    info.scale = s.scale;
-    if (std::isfinite(s.scaleAnchor))
-        info.scaleAnchor = s.scaleAnchor;
-    info.choices = s.choices;
-    return magda::ParameterUtils::realToNormalized(displayValue, info);
-}
-
-float MagdaGrainDelayCompiledPlugin::nativeValueToDisplayValue(int slotIndex,
-                                                               float nativeValue) const {
-    if (slotIndex < 0 || slotIndex >= kHostSlotCount)
-        return nativeValue;
-    const auto& s = hostSlotInfo_[static_cast<size_t>(slotIndex)];
-    magda::ParameterInfo info;
-    info.minValue = s.minValue;
-    info.maxValue = s.maxValue;
-    info.scale = s.scale;
-    if (std::isfinite(s.scaleAnchor))
-        info.scaleAnchor = s.scaleAnchor;
-    info.choices = s.choices;
-    return magda::ParameterUtils::normalizedToReal(nativeValue, info);
+    return infos;
 }
 
 constexpr AliasSpec kAliases[] = {
@@ -454,9 +104,8 @@ const CompiledPluginSpec& getMagdaGrainDelaySpec() {
             "Pitch shifts via per-grain read-offset drift; Spray jitters the per-grain position. "
             "Time spans the base delay, locking to musical Division when Sync is on. "
             "Feedback recirculates through the grain bank; Mix blends wet against dry.",
-        .createPlugin = [](const DevicePluginCreationContext& context) -> DevicePluginPtr {
-            return tracktion_adapter::pluginHandle(
-                new MagdaGrainDelayCompiledPlugin(tracktion_adapter::creationInfo(context)));
+        .createDevice = [](const DevicePluginCreationContext&) -> std::unique_ptr<MagdaDevice> {
+            return std::make_unique<MagdaGrainDelayCompiledPlugin>();
         },
         .aliases = kAliases,
         .aliasCount = static_cast<int>(sizeof(kAliases) / sizeof(kAliases[0])),

--- a/magda/daw/audio/plugins/compiled/MagdaGrainDelayCompiledPlugin.hpp
+++ b/magda/daw/audio/plugins/compiled/MagdaGrainDelayCompiledPlugin.hpp
@@ -50,6 +50,11 @@ class MagdaGrainDelayCompiledPlugin : public MagdaCompiledEffect {
     const char* slotIdPrefix() const override {
         return "magda_grain_delay_";
     }
+    bool producesAudioWithoutInput() const override {
+        // Dry input stopping does not mean the device is done: the grain cloud still has up to four
+        // seconds of grains in it, and a host that stops pumping here cuts them off.
+        return true;
+    }
     double tailSeconds() const override {
         return 4.0;
     }

--- a/magda/daw/audio/plugins/compiled/MagdaGrainDelayCompiledPlugin.hpp
+++ b/magda/daw/audio/plugins/compiled/MagdaGrainDelayCompiledPlugin.hpp
@@ -1,15 +1,8 @@
 #pragma once
 
-#include <tracktion_engine/tracktion_engine.h>
-
-#include <array>
-#include <atomic>
-#include <memory>
 #include <vector>
 
-#include "../FaustParamPool.hpp"
-#include "core/ParameterInfo.hpp"
-#include "plugins/compiled/tracktion/CompiledFaustTracktionAdapter.hpp"
+#include "plugins/compiled/MagdaCompiledEffect.hpp"
 
 class dsp;
 
@@ -22,38 +15,11 @@ namespace magda::daw::audio::compiled {
  * the hidden BPM slot is host-written every block, and the Division menu
  * stores a display index while audio receives the Faust-side division value.
  */
-class MagdaGrainDelayCompiledPlugin : public te::Plugin, public ICompiledFaustPlugin {
+class MagdaGrainDelayCompiledPlugin : public MagdaCompiledEffect {
   public:
     static const char* xmlTypeName;
 
-    explicit MagdaGrainDelayCompiledPlugin(const te::PluginCreationInfo& info);
-    ~MagdaGrainDelayCompiledPlugin() override;
-
-    juce::String getName() const override;
-    juce::String getPluginType() override;
-    juce::String getShortName(int) override;
-    juce::String getSelectableDescription() override;
-
-    void initialise(const te::PluginInitialisationInfo& info) override;
-    void deinitialise() override;
-    void reset() override;
-    void applyToBuffer(const te::PluginRenderContext& fc) override;
-
-    bool takesMidiInput() override {
-        return false;
-    }
-    bool takesAudioInput() override {
-        return true;
-    }
-    bool isSynth() override {
-        return false;
-    }
-    bool producesAudioWhenNoAudioInput() override {
-        return true;
-    }
-    double getTailLength() const override {
-        return 4.0;
-    }
+    MagdaGrainDelayCompiledPlugin();
 
     static constexpr int kTimeSlot = 0;
     static constexpr int kDivisionSlot = 1;
@@ -66,68 +32,29 @@ class MagdaGrainDelayCompiledPlugin : public te::Plugin, public ICompiledFaustPl
     static constexpr int kHostSlotCount = 8;
     static constexpr int kBpmSlot = 63;
 
-    te::AutomatableParameter* getSlotParameter(int slotIndex) const;
-
-    float displayValueToNativeValue(int slotIndex, float displayValue) const;
-    float nativeValueToDisplayValue(int slotIndex, float nativeValue) const;
-
-    using HostSlotInfo = CompiledHostSlotInfo;
-    const HostSlotInfo& getSlotInfo(int slotIndex) const;
-
-    float divisionFaustValueForIndex(int index) const;
-
-    // Last BPM read from the edit's tempo sequence in applyToBuffer. See
-    // MagdaDelayCompiledPlugin::currentBpm() — same contract.
-    float currentBpm() const {
-        return currentBpm_.load(std::memory_order_relaxed);
+    /// The Faust quarter-note multiplier behind Division choice @p index.
+    float divisionFaustValueForIndex(int index) const {
+        return menuValueForChoice(kDivisionSlot, index);
     }
 
-    int hostSlotCount() const override {
-        return kHostSlotCount;
+    juce::String devicePluginId() const override {
+        return xmlTypeName;
     }
-    const CompiledHostSlotInfo& hostSlotInfo(int slotIndex) const override {
-        return getSlotInfo(slotIndex);
+    juce::String deviceName() const override {
+        return "Grain Delay";
     }
-    DeviceParameterHandle hostSlotParameter(int slotIndex) const override {
-        return tracktion_adapter::parameterHandle(getSlotParameter(slotIndex));
+
+  protected:
+    ::dsp* createEngineDsp(int engineIndex) const override;
+    std::vector<HostSlotInfo> slotInfos() const override;
+    const char* slotIdPrefix() const override {
+        return "magda_grain_delay_";
     }
-    float displayToNormalized(int slotIndex, float displayValue) const override {
-        return displayValueToNativeValue(slotIndex, displayValue);
-    }
-    float normalizedToDisplay(int slotIndex, float normalizedValue) const override {
-        return nativeValueToDisplayValue(slotIndex, normalizedValue);
+    double tailSeconds() const override {
+        return 4.0;
     }
 
   private:
-    void buildHostParameters();
-    void rebuildEngineState(int sampleRate);
-
-    std::unique_ptr<::dsp> dsp_;
-    int numInputs_ = 0;
-    int numOutputs_ = 0;
-
-    std::array<FAUSTFLOAT*, kHostSlotCount> zones_{};
-    FAUSTFLOAT* bpmZone_ = nullptr;
-    std::vector<float> divisionChoiceValues_;
-    std::vector<juce::String> divisionChoiceLabels_;
-
-    struct GateSpec {
-        int slotIndex = -1;
-        bool negated = false;
-    };
-    std::array<GateSpec, kHostSlotCount> harvestedGates_{};
-
-    std::array<HostSlotInfo, kHostSlotCount> hostSlotInfo_;
-    std::array<te::AutomatableParameter::Ptr, kHostSlotCount> hostParams_;
-    std::array<juce::CachedValue<float>, kHostSlotCount> hostCached_;
-
-    juce::AudioBuffer<float> scratchIn_;
-    juce::AudioBuffer<float> scratchOut_;
-    std::vector<float*> inPtrs_;
-    std::vector<float*> outPtrs_;
-
-    std::atomic<float> currentBpm_{120.0f};
-
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(MagdaGrainDelayCompiledPlugin)
 };
 

--- a/magda/daw/audio/plugins/compiled/MagdaGritCompiledPlugin.cpp
+++ b/magda/daw/audio/plugins/compiled/MagdaGritCompiledPlugin.cpp
@@ -1,370 +1,56 @@
 #include "plugins/compiled/MagdaGritCompiledPlugin.hpp"
 
-#include <algorithm>
-#include <cmath>
-#include <map>
-
-#include "core/ParameterUtils.hpp"
+#include "core/ParameterInfo.hpp"
 #include "faust/dsp/dsp.h"
 #include "faust/gui/UI.h"
 #include "faust/gui/meta.h"
 #include "magda_grit.generated.cpp"
-#include "plugins/FaustMetadataParser.hpp"
-#include "plugins/FaustParamInfo.hpp"
 #include "plugins/compiled/CompiledPluginRegistry.hpp"
-#include "plugins/tracktion/TracktionDeviceAdapters.hpp"
 
 namespace magda::daw::audio::compiled {
 
 const char* MagdaGritCompiledPlugin::xmlTypeName = "magda_grit";
 
-namespace {
-
-// idx-based harvest, identical pattern to the saturator. Same
-// ControlMetadata / parseFaustLabel helpers — keeps the harvest logic
-// uniform across compiled plugins.
-struct GritHarvest {
-    struct Control {
-        int idx = -1;
-        FaustParamSlot::Kind kind = FaustParamSlot::Kind::Continuous;
-        FAUSTFLOAT* zone = nullptr;
-        std::vector<std::pair<float, juce::String>> choices;
-    };
-    std::vector<Control> controls;
-};
-
-class GritHarvester : public ::UI {
-  public:
-    GritHarvest harvest;
-
-    void openTabBox(const char*) override {}
-    void openHorizontalBox(const char*) override {}
-    void openVerticalBox(const char*) override {}
-    void closeBox() override {}
-
-    void addButton(const char* label, FAUSTFLOAT* zone) override {
-        emitControl(FaustParamSlot::Kind::Boolean, label, zone);
-    }
-    void addCheckButton(const char* label, FAUSTFLOAT* zone) override {
-        emitControl(FaustParamSlot::Kind::Boolean, label, zone);
-    }
-    void addVerticalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT, FAUSTFLOAT, FAUSTFLOAT,
-                           FAUSTFLOAT) override {
-        emitControl(FaustParamSlot::Kind::Continuous, label, zone);
-    }
-    void addHorizontalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT, FAUSTFLOAT,
-                             FAUSTFLOAT, FAUSTFLOAT) override {
-        emitControl(FaustParamSlot::Kind::Continuous, label, zone);
-    }
-    void addNumEntry(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT, FAUSTFLOAT, FAUSTFLOAT,
-                     FAUSTFLOAT) override {
-        emitControl(FaustParamSlot::Kind::Continuous, label, zone);
-    }
-    void addHorizontalBargraph(const char*, FAUSTFLOAT*, FAUSTFLOAT, FAUSTFLOAT) override {}
-    void addVerticalBargraph(const char*, FAUSTFLOAT*, FAUSTFLOAT, FAUSTFLOAT) override {}
-    void addSoundfile(const char*, const char*, Soundfile**) override {}
-
-    void declare(FAUSTFLOAT* zone, const char* key, const char* value) override {
-        if (zone == nullptr)
-            return;
-        const auto k = juce::String::fromUTF8(key != nullptr ? key : "").toLowerCase();
-        const auto v = juce::String::fromUTF8(value != nullptr ? value : "");
-        applyFaustAnnotation(k, v, pendingByZone_[zone]);
-    }
-
-  private:
-    void emitControl(FaustParamSlot::Kind kind, const char* rawLabel, FAUSTFLOAT* zone) {
-        const auto parsed =
-            parseFaustLabel(juce::String::fromUTF8(rawLabel != nullptr ? rawLabel : ""));
-        ControlMetadata merged = parsed.metadata;
-        if (zone != nullptr) {
-            if (auto it = pendingByZone_.find(zone); it != pendingByZone_.end()) {
-                mergeFaustMetadata(merged, it->second);
-                pendingByZone_.erase(it);
-            }
-        }
-
-        GritHarvest::Control c;
-        c.idx = merged.slotIndex;
-        c.kind = merged.isChoiceStyle() ? FaustParamSlot::Kind::Discrete : kind;
-        c.zone = zone;
-        c.choices = merged.menuChoices;
-        harvest.controls.push_back(std::move(c));
-    }
-
-    std::map<FAUSTFLOAT*, ControlMetadata> pendingByZone_;
-};
-
-const GritHarvest::Control* findByIdx(const GritHarvest& h, int idx) {
-    for (const auto& c : h.controls)
-        if (c.idx == idx)
-            return &c;
-    return nullptr;
+MagdaGritCompiledPlugin::MagdaGritCompiledPlugin() {
+    initEffect();
 }
 
-}  // namespace
-
-MagdaGritCompiledPlugin::MagdaGritCompiledPlugin(const te::PluginCreationInfo& info)
-    : te::Plugin(info) {
-    dsp_ = std::make_unique<MagdaGritDsp>();
-    constexpr int kProvisionalSampleRate = 44100;
-    rebuildEngineState(kProvisionalSampleRate);
-    buildHostParameters();
+::dsp* MagdaGritCompiledPlugin::createEngineDsp(int) const {
+    return new MagdaGritDsp();
 }
 
-MagdaGritCompiledPlugin::~MagdaGritCompiledPlugin() {
-    notifyListenersOfDeletion();
-    for (auto& p : hostParams_)
-        if (p)
-            p->detachFromCurrentValue();
-}
-
-juce::String MagdaGritCompiledPlugin::getName() const {
-    return "Grit";
-}
-juce::String MagdaGritCompiledPlugin::getPluginType() {
-    return xmlTypeName;
-}
-juce::String MagdaGritCompiledPlugin::getShortName(int) {
-    return "Grit";
-}
-juce::String MagdaGritCompiledPlugin::getSelectableDescription() {
-    return "Grit";
-}
-
-void MagdaGritCompiledPlugin::rebuildEngineState(int sampleRate) {
-    if (!dsp_)
-        return;
-    dsp_->init(sampleRate);
-    numInputs_ = dsp_->getNumInputs();
-    numOutputs_ = dsp_->getNumOutputs();
-
-    GritHarvester harvester;
-    dsp_->buildUserInterface(&harvester);
-
-    zones_.fill(nullptr);
-    modeChoiceValues_.clear();
-
-    for (int i = 0; i < kHostSlotCount; ++i) {
-        if (auto* c = findByIdx(harvester.harvest, i))
-            zones_[static_cast<size_t>(i)] = c->zone;
-    }
-
-    if (auto* c = findByIdx(harvester.harvest, kModeSlot)) {
-        auto sorted = c->choices;
-        std::sort(sorted.begin(), sorted.end(),
-                  [](const auto& a, const auto& b) { return a.first < b.first; });
-        modeChoiceValues_.reserve(sorted.size());
-        for (const auto& choice : sorted)
-            modeChoiceValues_.push_back(choice.first);
-    }
-}
-
-void MagdaGritCompiledPlugin::buildHostParameters() {
+std::vector<MagdaGritCompiledPlugin::HostSlotInfo> MagdaGritCompiledPlugin::slotInfos() const {
+    std::vector<HostSlotInfo> infos(kHostSlotCount);
     // Slot 0: Frequency (log Hz, anchored at 1 kHz so the slider mid lands
     // on the most musically useful range).
-    hostSlotInfo_[kFrequencySlot] = {.name = "Frequency",
-                                     .unit = magda::technicalText(magda::TechnicalTextToken::Hertz),
-                                     .scale = magda::ParameterScale::Logarithmic,
-                                     .minValue = 20.0f,
-                                     .maxValue = 16000.0f,
-                                     .defaultValue = 1000.0f,
-                                     .scaleAnchor = 1000.0f};
+    infos[kFrequencySlot] = {.name = "Frequency",
+                             .unit = magda::technicalText(magda::TechnicalTextToken::Hertz),
+                             .scale = magda::ParameterScale::Logarithmic,
+                             .minValue = 20.0f,
+                             .maxValue = 16000.0f,
+                             .defaultValue = 1000.0f,
+                             .scaleAnchor = 1000.0f};
     // Slot 1: Width (linear 0..1; mapped inside the DSP to Q ≈ 0.5..20).
-    hostSlotInfo_[kWidthSlot] = {.name = "Width",
-                                 .scale = magda::ParameterScale::Linear,
-                                 .minValue = 0.0f,
-                                 .maxValue = 1.0f,
-                                 .defaultValue = 0.5f};
+    infos[kWidthSlot] = {.name = "Width",
+                         .scale = magda::ParameterScale::Linear,
+                         .minValue = 0.0f,
+                         .maxValue = 1.0f,
+                         .defaultValue = 0.5f};
     // Slot 2: Amount (modulation depth, 0..1).
-    hostSlotInfo_[kAmountSlot] = {.name = "Amount",
-                                  .scale = magda::ParameterScale::Linear,
-                                  .minValue = 0.0f,
-                                  .maxValue = 1.0f,
-                                  .defaultValue = 0.0f};
+    infos[kAmountSlot] = {.name = "Amount",
+                          .scale = magda::ParameterScale::Linear,
+                          .minValue = 0.0f,
+                          .maxValue = 1.0f,
+                          .defaultValue = 0.0f};
     // Slot 3: Mode (3 carrier sources).
-    hostSlotInfo_[kModeSlot].name = "Mode";
-    hostSlotInfo_[kModeSlot].scale = magda::ParameterScale::Discrete;
-    hostSlotInfo_[kModeSlot].choices = {"Noise", "Wide Noise", "Sine"};
-    hostSlotInfo_[kModeSlot].minValue = 0.0f;
-    hostSlotInfo_[kModeSlot].maxValue =
-        static_cast<float>(hostSlotInfo_[kModeSlot].choices.size() - 1);
-    hostSlotInfo_[kModeSlot].defaultValue = 0.0f;
+    infos[kModeSlot].name = "Mode";
+    infos[kModeSlot].scale = magda::ParameterScale::Discrete;
+    infos[kModeSlot].choices = {"Noise", "Wide Noise", "Sine"};
+    infos[kModeSlot].minValue = 0.0f;
+    infos[kModeSlot].maxValue = static_cast<float>(infos[kModeSlot].choices.size() - 1);
+    infos[kModeSlot].defaultValue = 0.0f;
 
-    juce::NormalisableRange<float> normalisedRange{0.0f, 1.0f};
-    auto* undoManager = getUndoManager();
-
-    auto buildInfo = [](const HostSlotInfo& s) {
-        magda::ParameterInfo info;
-        info.minValue = s.minValue;
-        info.maxValue = s.maxValue;
-        info.defaultValue = s.defaultValue;
-        info.unit = s.unit;
-        info.scale = s.scale;
-        if (std::isfinite(s.scaleAnchor))
-            info.scaleAnchor = s.scaleAnchor;
-        info.choices = s.choices;
-        return info;
-    };
-
-    for (int i = 0; i < kHostSlotCount; ++i) {
-        const auto& slot = hostSlotInfo_[i];
-        const juce::String id = "magda_grit_" + slot.name.toLowerCase().replace(" ", "_");
-        const juce::Identifier identifier(id);
-        const auto info = buildInfo(slot);
-        const float defaultNormalized =
-            magda::ParameterUtils::realToNormalized(slot.defaultValue, info);
-        hostCached_[i].referTo(state, identifier, undoManager, defaultNormalized);
-
-        auto param = addParam(
-            id, slot.name, normalisedRange,
-            [info](float normalized) {
-                const float real = magda::ParameterUtils::normalizedToReal(normalized, info);
-                return magda::ParameterUtils::formatValue(real, info);
-            },
-            [info](const juce::String& text) {
-                auto parsed = magda::ParameterUtils::parseValue(text, info);
-                if (parsed)
-                    return magda::ParameterUtils::realToNormalized(*parsed, info);
-                return 0.0f;
-            });
-        param->attachToCurrentValue(hostCached_[i]);
-        hostParams_[i] = param;
-    }
-}
-
-void MagdaGritCompiledPlugin::initialise(const te::PluginInitialisationInfo& info) {
-    rebuildEngineState(static_cast<int>(info.sampleRate));
-    scratchIn_.setSize(numInputs_, info.blockSizeSamples, false, true, true);
-    scratchOut_.setSize(numOutputs_, info.blockSizeSamples, false, true, true);
-    inPtrs_.assign(static_cast<size_t>(numInputs_), nullptr);
-    outPtrs_.assign(static_cast<size_t>(numOutputs_), nullptr);
-}
-
-void MagdaGritCompiledPlugin::deinitialise() {
-    scratchIn_.setSize(0, 0);
-    scratchOut_.setSize(0, 0);
-    inPtrs_.clear();
-    outPtrs_.clear();
-}
-
-void MagdaGritCompiledPlugin::reset() {
-    if (dsp_)
-        dsp_->instanceClear();
-}
-
-void MagdaGritCompiledPlugin::applyToBuffer(const te::PluginRenderContext& fc) {
-    if (!fc.destBuffer || fc.bufferNumSamples <= 0 || !dsp_)
-        return;
-
-    auto writeContinuous = [&](int slot) {
-        if (auto* zone = zones_[static_cast<size_t>(slot)]) {
-            const auto& s = hostSlotInfo_[static_cast<size_t>(slot)];
-            magda::ParameterInfo info;
-            info.minValue = s.minValue;
-            info.maxValue = s.maxValue;
-            info.scale = s.scale;
-            if (std::isfinite(s.scaleAnchor))
-                info.scaleAnchor = s.scaleAnchor;
-            const float norm = hostParams_[static_cast<size_t>(slot)]->getCurrentValue();
-            *zone = static_cast<FAUSTFLOAT>(magda::ParameterUtils::normalizedToReal(norm, info));
-        }
-    };
-    writeContinuous(kFrequencySlot);
-    writeContinuous(kWidthSlot);
-    writeContinuous(kAmountSlot);
-
-    if (auto* modeZone = zones_[kModeSlot]; modeZone && !modeChoiceValues_.empty()) {
-        const float norm = hostParams_[kModeSlot]->getCurrentValue();
-        const int count = static_cast<int>(modeChoiceValues_.size());
-        const int idx = juce::jlimit(
-            0, count - 1, static_cast<int>(std::round(norm * static_cast<float>(count - 1))));
-        *modeZone = static_cast<FAUSTFLOAT>(modeChoiceValues_[idx]);
-    }
-
-    const int numSamples = fc.bufferNumSamples;
-    const int startSample = fc.bufferStartSample;
-    const int hostChannels = fc.destBuffer->getNumChannels();
-    if (hostChannels <= 0 || numInputs_ <= 0 || numOutputs_ <= 0)
-        return;
-
-    if (scratchIn_.getNumChannels() < numInputs_ || scratchIn_.getNumSamples() < numSamples)
-        scratchIn_.setSize(numInputs_, numSamples, false, true, true);
-    if (scratchOut_.getNumChannels() < numOutputs_ || scratchOut_.getNumSamples() < numSamples)
-        scratchOut_.setSize(numOutputs_, numSamples, false, true, true);
-    if (static_cast<int>(inPtrs_.size()) < numInputs_)
-        inPtrs_.resize(static_cast<size_t>(numInputs_), nullptr);
-    if (static_cast<int>(outPtrs_.size()) < numOutputs_)
-        outPtrs_.resize(static_cast<size_t>(numOutputs_), nullptr);
-
-    for (int ch = 0; ch < numInputs_; ++ch) {
-        float* dst = scratchIn_.getWritePointer(ch);
-        if (ch < hostChannels) {
-            const float* src = fc.destBuffer->getReadPointer(ch, startSample);
-            std::copy(src, src + numSamples, dst);
-        } else {
-            std::fill(dst, dst + numSamples, 0.0f);
-        }
-        inPtrs_[static_cast<size_t>(ch)] = dst;
-    }
-    for (int ch = 0; ch < numOutputs_; ++ch) {
-        outPtrs_[static_cast<size_t>(ch)] = (ch < hostChannels)
-                                                ? fc.destBuffer->getWritePointer(ch, startSample)
-                                                : scratchOut_.getWritePointer(ch);
-    }
-
-    dsp_->compute(numSamples, inPtrs_.data(), outPtrs_.data());
-
-    const int channelsToSanitise = std::min(hostChannels, numOutputs_);
-    for (int ch = 0; ch < channelsToSanitise; ++ch) {
-        float* out = fc.destBuffer->getWritePointer(ch, startSample);
-        for (int i = 0; i < numSamples; ++i) {
-            const float sample = out[i];
-            out[i] = std::isfinite(sample) ? juce::jlimit(-16.0f, 16.0f, sample) : 0.0f;
-        }
-    }
-}
-
-te::AutomatableParameter* MagdaGritCompiledPlugin::getSlotParameter(int slotIndex) const {
-    if (slotIndex < 0 || slotIndex >= kHostSlotCount)
-        return nullptr;
-    return hostParams_[static_cast<size_t>(slotIndex)].get();
-}
-
-const MagdaGritCompiledPlugin::HostSlotInfo& MagdaGritCompiledPlugin::getSlotInfo(
-    int slotIndex) const {
-    static const HostSlotInfo kEmpty;
-    if (slotIndex < 0 || slotIndex >= kHostSlotCount)
-        return kEmpty;
-    return hostSlotInfo_[static_cast<size_t>(slotIndex)];
-}
-
-float MagdaGritCompiledPlugin::displayValueToNativeValue(int slotIndex, float displayValue) const {
-    if (slotIndex < 0 || slotIndex >= kHostSlotCount)
-        return displayValue;
-    const auto& s = hostSlotInfo_[static_cast<size_t>(slotIndex)];
-    magda::ParameterInfo info;
-    info.minValue = s.minValue;
-    info.maxValue = s.maxValue;
-    info.scale = s.scale;
-    if (std::isfinite(s.scaleAnchor))
-        info.scaleAnchor = s.scaleAnchor;
-    info.choices = s.choices;
-    return magda::ParameterUtils::realToNormalized(displayValue, info);
-}
-
-float MagdaGritCompiledPlugin::nativeValueToDisplayValue(int slotIndex, float nativeValue) const {
-    if (slotIndex < 0 || slotIndex >= kHostSlotCount)
-        return nativeValue;
-    const auto& s = hostSlotInfo_[static_cast<size_t>(slotIndex)];
-    magda::ParameterInfo info;
-    info.minValue = s.minValue;
-    info.maxValue = s.maxValue;
-    info.scale = s.scale;
-    if (std::isfinite(s.scaleAnchor))
-        info.scaleAnchor = s.scaleAnchor;
-    info.choices = s.choices;
-    return magda::ParameterUtils::normalizedToReal(nativeValue, info);
+    return infos;
 }
 
 constexpr AliasSpec kAliases[] = {
@@ -388,9 +74,8 @@ const CompiledPluginSpec& getMagdaGritSpec() {
             "Frequency is the carrier centre (or BPF centre in the noise modes); "
             "Width sets the bandpass Q in Noise and Wide Noise modes; it has no effect "
             "in Sine mode. Amount blends the wet against the dry.",
-        .createPlugin = [](const DevicePluginCreationContext& context) -> DevicePluginPtr {
-            return tracktion_adapter::pluginHandle(
-                new MagdaGritCompiledPlugin(tracktion_adapter::creationInfo(context)));
+        .createDevice = [](const DevicePluginCreationContext&) -> std::unique_ptr<MagdaDevice> {
+            return std::make_unique<MagdaGritCompiledPlugin>();
         },
         .aliases = kAliases,
         .aliasCount = static_cast<int>(sizeof(kAliases) / sizeof(kAliases[0])),

--- a/magda/daw/audio/plugins/compiled/MagdaGritCompiledPlugin.hpp
+++ b/magda/daw/audio/plugins/compiled/MagdaGritCompiledPlugin.hpp
@@ -1,14 +1,8 @@
 #pragma once
 
-#include <tracktion_engine/tracktion_engine.h>
-
-#include <array>
-#include <memory>
 #include <vector>
 
-#include "../FaustParamPool.hpp"
-#include "core/ParameterInfo.hpp"
-#include "plugins/compiled/tracktion/CompiledFaustTracktionAdapter.hpp"
+#include "plugins/compiled/MagdaCompiledEffect.hpp"
 
 class dsp;
 
@@ -25,94 +19,35 @@ namespace magda::daw::audio::compiled {
  * Single-engine compiled plugin — every host control maps 1:1 to a
  * Faust slot pinned by [idx:N], same harvest pattern as the saturator.
  */
-class MagdaGritCompiledPlugin : public te::Plugin, public ICompiledFaustPlugin {
+class MagdaGritCompiledPlugin : public MagdaCompiledEffect {
   public:
     static const char* xmlTypeName;
 
-    explicit MagdaGritCompiledPlugin(const te::PluginCreationInfo& info);
-    ~MagdaGritCompiledPlugin() override;
+    MagdaGritCompiledPlugin();
 
-    juce::String getName() const override;
-    juce::String getPluginType() override;
-    juce::String getShortName(int) override;
-    juce::String getSelectableDescription() override;
-
-    void initialise(const te::PluginInitialisationInfo& info) override;
-    void deinitialise() override;
-    void reset() override;
-    void applyToBuffer(const te::PluginRenderContext& fc) override;
-
-    bool takesMidiInput() override {
-        return false;
-    }
-    bool takesAudioInput() override {
-        return true;
-    }
-    bool isSynth() override {
-        return false;
-    }
-    bool producesAudioWhenNoAudioInput() override {
-        return false;
-    }
-    double getTailLength() const override {
-        return 0.0;
-    }
-
-    // Slot ordering matches the [idx:N] pins inside magda_grit.dsp.
     static constexpr int kFrequencySlot = 0;
     static constexpr int kWidthSlot = 1;
     static constexpr int kAmountSlot = 2;
     static constexpr int kModeSlot = 3;
     static constexpr int kHostSlotCount = 4;
-
     enum class Mode { Noise, WideNoise, Sine };
     static constexpr int kModeCount = 3;
 
-    te::AutomatableParameter* getSlotParameter(int slotIndex) const;
+    juce::String devicePluginId() const override {
+        return xmlTypeName;
+    }
+    juce::String deviceName() const override {
+        return "Grit";
+    }
 
-    float displayValueToNativeValue(int slotIndex, float displayValue) const;
-    float nativeValueToDisplayValue(int slotIndex, float nativeValue) const;
-
-    using HostSlotInfo = CompiledHostSlotInfo;
-    const HostSlotInfo& getSlotInfo(int slotIndex) const;
-
-    // ICompiledFaustPlugin
-    int hostSlotCount() const override {
-        return kHostSlotCount;
-    }
-    const CompiledHostSlotInfo& hostSlotInfo(int slotIndex) const override {
-        return getSlotInfo(slotIndex);
-    }
-    DeviceParameterHandle hostSlotParameter(int slotIndex) const override {
-        return tracktion_adapter::parameterHandle(getSlotParameter(slotIndex));
-    }
-    float displayToNormalized(int slotIndex, float displayValue) const override {
-        return displayValueToNativeValue(slotIndex, displayValue);
-    }
-    float normalizedToDisplay(int slotIndex, float normalizedValue) const override {
-        return nativeValueToDisplayValue(slotIndex, normalizedValue);
+  protected:
+    ::dsp* createEngineDsp(int engineIndex) const override;
+    std::vector<HostSlotInfo> slotInfos() const override;
+    const char* slotIdPrefix() const override {
+        return "magda_grit_";
     }
 
   private:
-    void buildHostParameters();
-    void rebuildEngineState(int sampleRate);
-
-    std::unique_ptr<::dsp> dsp_;
-    int numInputs_ = 0;
-    int numOutputs_ = 0;
-
-    std::array<FAUSTFLOAT*, kHostSlotCount> zones_{};
-    std::vector<float> modeChoiceValues_;
-
-    std::array<HostSlotInfo, kHostSlotCount> hostSlotInfo_;
-    std::array<te::AutomatableParameter::Ptr, kHostSlotCount> hostParams_;
-    std::array<juce::CachedValue<float>, kHostSlotCount> hostCached_;
-
-    juce::AudioBuffer<float> scratchIn_;
-    juce::AudioBuffer<float> scratchOut_;
-    std::vector<float*> inPtrs_;
-    std::vector<float*> outPtrs_;
-
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(MagdaGritCompiledPlugin)
 };
 

--- a/magda/daw/audio/plugins/compiled/MagdaLimiterCompiledPlugin.cpp
+++ b/magda/daw/audio/plugins/compiled/MagdaLimiterCompiledPlugin.cpp
@@ -3,9 +3,8 @@
 #include <algorithm>
 #include <cmath>
 
-#include "core/ParameterUtils.hpp"
+#include "core/ParameterInfo.hpp"
 #include "plugins/compiled/CompiledPluginRegistry.hpp"
-#include "plugins/tracktion/TracktionDeviceAdapters.hpp"
 
 namespace magda::daw::audio::compiled {
 
@@ -17,20 +16,44 @@ float ampToDb(float amp) {
     return 20.0f * std::log10(std::max(amp, 1.0e-6f));
 }
 
-float realForSlot(const MagdaLimiterCompiledPlugin::HostSlotInfo& s,
-                  te::AutomatableParameter* param) {
-    magda::ParameterInfo info;
-    info.minValue = s.minValue;
-    info.maxValue = s.maxValue;
-    info.scale = s.scale;
-    if (std::isfinite(s.scaleAnchor))
-        info.scaleAnchor = s.scaleAnchor;
-    info.choices = s.choices;
-    return magda::ParameterUtils::normalizedToReal(
-        param != nullptr ? param->getCurrentValue() : 0.0f, info);
+}  // namespace
+
+MagdaLimiterCompiledPlugin::MagdaLimiterCompiledPlugin() {
+    initEffect();
 }
 
-}  // namespace
+std::vector<MagdaLimiterCompiledPlugin::HostSlotInfo> MagdaLimiterCompiledPlugin::slotInfos()
+    const {
+    std::vector<HostSlotInfo> infos(kHostSlotCount);
+    infos[kThresholdSlot] = {.name = "Threshold",
+                             .unit = magda::technicalText(magda::TechnicalTextToken::Decibels),
+                             .scale = magda::ParameterScale::Linear,
+                             .minValue = -24.0f,
+                             .maxValue = 0.0f,
+                             .defaultValue = -1.0f};
+    infos[kAttackSlot] = {.name = "Attack",
+                          .unit = magda::technicalText(magda::TechnicalTextToken::Milliseconds),
+                          .scale = magda::ParameterScale::Logarithmic,
+                          .minValue = 0.1f,
+                          .maxValue = 50.0f,
+                          .defaultValue = 1.0f,
+                          .scaleAnchor = 1.0f};
+    infos[kReleaseSlot] = {.name = "Release",
+                           .unit = magda::technicalText(magda::TechnicalTextToken::Milliseconds),
+                           .scale = magda::ParameterScale::Logarithmic,
+                           .minValue = 10.0f,
+                           .maxValue = 2000.0f,
+                           .defaultValue = 200.0f,
+                           .scaleAnchor = 200.0f};
+    infos[kOutputSlot] = {.name = "Output",
+                          .unit = magda::technicalText(magda::TechnicalTextToken::Decibels),
+                          .scale = magda::ParameterScale::Linear,
+                          .minValue = -24.0f,
+                          .maxValue = 0.0f,
+                          .defaultValue = 0.0f};
+
+    return infos;
+}
 
 float MagdaLimiterDspCore::dbToGain(float db) {
     return std::pow(10.0f, db / 20.0f);
@@ -119,177 +142,35 @@ MagdaLimiterDspCore::Stats MagdaLimiterDspCore::process(juce::AudioBuffer<float>
     return stats;
 }
 
-MagdaLimiterCompiledPlugin::MagdaLimiterCompiledPlugin(const te::PluginCreationInfo& info)
-    : te::Plugin(info) {
-    limiter_.prepare(44100.0, 512, 2);
-    buildHostParameters();
+void MagdaLimiterCompiledPlugin::onPrepare(double sampleRate, int maximumBlockSize) {
+    limiter_.prepare(sampleRate, maximumBlockSize, 2);
 }
 
-MagdaLimiterCompiledPlugin::~MagdaLimiterCompiledPlugin() {
-    notifyListenersOfDeletion();
-    for (auto& p : hostParams_)
-        if (p)
-            p->detachFromCurrentValue();
+void MagdaLimiterCompiledPlugin::onRelease() {
+    limiter_.reset();
 }
 
-juce::String MagdaLimiterCompiledPlugin::getName() const {
-    return "Limiter";
-}
-juce::String MagdaLimiterCompiledPlugin::getPluginType() {
-    return xmlTypeName;
-}
-juce::String MagdaLimiterCompiledPlugin::getShortName(int) {
-    return "Limiter";
-}
-juce::String MagdaLimiterCompiledPlugin::getSelectableDescription() {
-    return "Limiter";
+void MagdaLimiterCompiledPlugin::onReset() {
+    limiter_.reset();
 }
 
-void MagdaLimiterCompiledPlugin::buildHostParameters() {
-    hostSlotInfo_[kThresholdSlot] = {.name = "Threshold",
-                                     .unit =
-                                         magda::technicalText(magda::TechnicalTextToken::Decibels),
-                                     .scale = magda::ParameterScale::Linear,
-                                     .minValue = -24.0f,
-                                     .maxValue = 0.0f,
-                                     .defaultValue = -1.0f};
-    hostSlotInfo_[kAttackSlot] = {.name = "Attack",
-                                  .unit =
-                                      magda::technicalText(magda::TechnicalTextToken::Milliseconds),
-                                  .scale = magda::ParameterScale::Logarithmic,
-                                  .minValue = 0.1f,
-                                  .maxValue = 50.0f,
-                                  .defaultValue = 1.0f,
-                                  .scaleAnchor = 1.0f};
-    hostSlotInfo_[kReleaseSlot] = {
-        .name = "Release",
-        .unit = magda::technicalText(magda::TechnicalTextToken::Milliseconds),
-        .scale = magda::ParameterScale::Logarithmic,
-        .minValue = 10.0f,
-        .maxValue = 2000.0f,
-        .defaultValue = 200.0f,
-        .scaleAnchor = 200.0f};
-    hostSlotInfo_[kOutputSlot] = {.name = "Output",
-                                  .unit = magda::technicalText(magda::TechnicalTextToken::Decibels),
-                                  .scale = magda::ParameterScale::Linear,
-                                  .minValue = -24.0f,
-                                  .maxValue = 0.0f,
-                                  .defaultValue = 0.0f};
-
-    juce::NormalisableRange<float> normalisedRange{0.0f, 1.0f};
-    auto* undoManager = getUndoManager();
-
-    auto buildInfo = [](const HostSlotInfo& s) {
-        magda::ParameterInfo info;
-        info.minValue = s.minValue;
-        info.maxValue = s.maxValue;
-        info.defaultValue = s.defaultValue;
-        info.unit = s.unit;
-        info.scale = s.scale;
-        if (std::isfinite(s.scaleAnchor))
-            info.scaleAnchor = s.scaleAnchor;
-        info.choices = s.choices;
-        return info;
+void MagdaLimiterCompiledPlugin::processAudio(DeviceProcessContext& context) {
+    // No Faust engine: the lookahead line and its gain follower are MAGDA's own,
+    // so the base's zone-writing pass has nothing to write and this is the whole
+    // block.
+    const MagdaLimiterDspCore::Settings settings{
+        .thresholdDb = slotDisplayValue(kThresholdSlot),
+        .attackMs = slotDisplayValue(kAttackSlot),
+        .releaseMs = slotDisplayValue(kReleaseSlot),
+        .outputDb = slotDisplayValue(kOutputSlot),
     };
 
-    for (int i = 0; i < kHostSlotCount; ++i) {
-        const auto& slot = hostSlotInfo_[static_cast<size_t>(i)];
-        const juce::String id = "magda_limiter_" + slot.name.toLowerCase().replace(" ", "_");
-        const juce::Identifier identifier(id);
-        const auto info = buildInfo(slot);
-        const float defaultNormalized =
-            magda::ParameterUtils::realToNormalized(slot.defaultValue, info);
-        hostCached_[static_cast<size_t>(i)].referTo(state, identifier, undoManager,
-                                                    defaultNormalized);
+    const auto stats =
+        limiter_.process(*context.audio, context.startSample, context.numSamples, settings);
 
-        auto param = addParam(
-            id, slot.name, normalisedRange,
-            [info](float normalized) {
-                const float real = magda::ParameterUtils::normalizedToReal(normalized, info);
-                return magda::ParameterUtils::formatValue(real, info);
-            },
-            [info](const juce::String& text) {
-                auto parsed = magda::ParameterUtils::parseValue(text, info);
-                if (parsed)
-                    return magda::ParameterUtils::realToNormalized(*parsed, info);
-                return 0.0f;
-            });
-        param->attachToCurrentValue(hostCached_[static_cast<size_t>(i)]);
-        hostParams_[static_cast<size_t>(i)] = param;
-    }
-}
-
-void MagdaLimiterCompiledPlugin::initialise(const te::PluginInitialisationInfo& info) {
-    limiter_.prepare(info.sampleRate, info.blockSizeSamples, 2);
-}
-
-void MagdaLimiterCompiledPlugin::deinitialise() {
-    limiter_.reset();
-}
-
-void MagdaLimiterCompiledPlugin::reset() {
-    limiter_.reset();
-}
-
-void MagdaLimiterCompiledPlugin::applyToBuffer(const te::PluginRenderContext& fc) {
-    if (!fc.destBuffer || fc.bufferNumSamples <= 0)
-        return;
-
-    MagdaLimiterDspCore::Settings settings;
-    settings.thresholdDb = realForSlot(hostSlotInfo_[kThresholdSlot], hostParams_[kThresholdSlot]);
-    settings.attackMs = realForSlot(hostSlotInfo_[kAttackSlot], hostParams_[kAttackSlot]);
-    settings.releaseMs = realForSlot(hostSlotInfo_[kReleaseSlot], hostParams_[kReleaseSlot]);
-    settings.outputDb = realForSlot(hostSlotInfo_[kOutputSlot], hostParams_[kOutputSlot]);
-
-    auto stats =
-        limiter_.process(*fc.destBuffer, fc.bufferStartSample, fc.bufferNumSamples, settings);
     inputPeakDb_.store(ampToDb(stats.inputPeak), std::memory_order_relaxed);
     outputPeakDb_.store(ampToDb(stats.outputPeak), std::memory_order_relaxed);
     gainReductionDb_.store(stats.gainReductionDb, std::memory_order_relaxed);
-}
-
-te::AutomatableParameter* MagdaLimiterCompiledPlugin::getSlotParameter(int slotIndex) const {
-    if (slotIndex < 0 || slotIndex >= kHostSlotCount)
-        return nullptr;
-    return hostParams_[static_cast<size_t>(slotIndex)].get();
-}
-
-const MagdaLimiterCompiledPlugin::HostSlotInfo& MagdaLimiterCompiledPlugin::getSlotInfo(
-    int slotIndex) const {
-    static const HostSlotInfo kEmpty;
-    if (slotIndex < 0 || slotIndex >= kHostSlotCount)
-        return kEmpty;
-    return hostSlotInfo_[static_cast<size_t>(slotIndex)];
-}
-
-float MagdaLimiterCompiledPlugin::displayValueToNativeValue(int slotIndex,
-                                                            float displayValue) const {
-    if (slotIndex < 0 || slotIndex >= kHostSlotCount)
-        return displayValue;
-    const auto& s = hostSlotInfo_[static_cast<size_t>(slotIndex)];
-    magda::ParameterInfo info;
-    info.minValue = s.minValue;
-    info.maxValue = s.maxValue;
-    info.scale = s.scale;
-    if (std::isfinite(s.scaleAnchor))
-        info.scaleAnchor = s.scaleAnchor;
-    info.choices = s.choices;
-    return magda::ParameterUtils::realToNormalized(displayValue, info);
-}
-
-float MagdaLimiterCompiledPlugin::nativeValueToDisplayValue(int slotIndex,
-                                                            float nativeValue) const {
-    if (slotIndex < 0 || slotIndex >= kHostSlotCount)
-        return nativeValue;
-    const auto& s = hostSlotInfo_[static_cast<size_t>(slotIndex)];
-    magda::ParameterInfo info;
-    info.minValue = s.minValue;
-    info.maxValue = s.maxValue;
-    info.scale = s.scale;
-    if (std::isfinite(s.scaleAnchor))
-        info.scaleAnchor = s.scaleAnchor;
-    info.choices = s.choices;
-    return magda::ParameterUtils::normalizedToReal(nativeValue, info);
 }
 
 constexpr AliasSpec kAliases[] = {
@@ -308,9 +189,8 @@ const CompiledPluginSpec& getMagdaLimiterSpec() {
                        "Threshold drives the signal into a fixed 0 dB ceiling, "
                        "Attack and Release shape gain recovery, and Output is a "
                        "post-limiter trim limited to negative gain.",
-        .createPlugin = [](const DevicePluginCreationContext& context) -> DevicePluginPtr {
-            return tracktion_adapter::pluginHandle(
-                new MagdaLimiterCompiledPlugin(tracktion_adapter::creationInfo(context)));
+        .createDevice = [](const DevicePluginCreationContext&) -> std::unique_ptr<MagdaDevice> {
+            return std::make_unique<MagdaLimiterCompiledPlugin>();
         },
         .aliases = kAliases,
         .aliasCount = static_cast<int>(sizeof(kAliases) / sizeof(kAliases[0])),

--- a/magda/daw/audio/plugins/compiled/MagdaLimiterCompiledPlugin.hpp
+++ b/magda/daw/audio/plugins/compiled/MagdaLimiterCompiledPlugin.hpp
@@ -1,13 +1,9 @@
 #pragma once
 
-#include <tracktion_engine/tracktion_engine.h>
-
-#include <array>
 #include <atomic>
 #include <vector>
 
-#include "core/ParameterInfo.hpp"
-#include "plugins/compiled/tracktion/CompiledFaustTracktionAdapter.hpp"
+#include "plugins/compiled/MagdaCompiledEffect.hpp"
 
 namespace magda::daw::audio::compiled {
 
@@ -51,38 +47,11 @@ class MagdaLimiterDspCore {
  * Output is a post-limiter trim and is restricted to negative gain, so it can
  * only reduce the emitted level after limiting.
  */
-class MagdaLimiterCompiledPlugin : public te::Plugin, public ICompiledFaustPlugin {
+class MagdaLimiterCompiledPlugin : public MagdaCompiledEffect {
   public:
     static const char* xmlTypeName;
 
-    explicit MagdaLimiterCompiledPlugin(const te::PluginCreationInfo& info);
-    ~MagdaLimiterCompiledPlugin() override;
-
-    juce::String getName() const override;
-    juce::String getPluginType() override;
-    juce::String getShortName(int) override;
-    juce::String getSelectableDescription() override;
-
-    void initialise(const te::PluginInitialisationInfo& info) override;
-    void deinitialise() override;
-    void reset() override;
-    void applyToBuffer(const te::PluginRenderContext& fc) override;
-
-    bool takesMidiInput() override {
-        return false;
-    }
-    bool takesAudioInput() override {
-        return true;
-    }
-    bool isSynth() override {
-        return false;
-    }
-    bool producesAudioWhenNoAudioInput() override {
-        return false;
-    }
-    double getTailLength() const override {
-        return 0.0;
-    }
+    MagdaLimiterCompiledPlugin();
 
     static constexpr int kThresholdSlot = 0;
     static constexpr int kAttackSlot = 1;
@@ -90,12 +59,7 @@ class MagdaLimiterCompiledPlugin : public te::Plugin, public ICompiledFaustPlugi
     static constexpr int kOutputSlot = 3;
     static constexpr int kHostSlotCount = 4;
 
-    te::AutomatableParameter* getSlotParameter(int slotIndex) const;
-
-    float displayValueToNativeValue(int slotIndex, float displayValue) const;
-    float nativeValueToDisplayValue(int slotIndex, float nativeValue) const;
-
-    // Audio-thread metering taps, read by the curve view via 33 ms timer.
+    // Audio-thread metering taps, read by the curve view on its timer.
     float getInputPeakDb() const {
         return inputPeakDb_.load(std::memory_order_relaxed);
     }
@@ -106,34 +70,25 @@ class MagdaLimiterCompiledPlugin : public te::Plugin, public ICompiledFaustPlugi
         return gainReductionDb_.load(std::memory_order_relaxed);
     }
 
-    using HostSlotInfo = CompiledHostSlotInfo;
-    const HostSlotInfo& getSlotInfo(int slotIndex) const;
+    juce::String devicePluginId() const override {
+        return xmlTypeName;
+    }
+    juce::String deviceName() const override {
+        return "Limiter";
+    }
 
-    // ICompiledFaustPlugin
-    int hostSlotCount() const override {
-        return kHostSlotCount;
+  protected:
+    std::vector<HostSlotInfo> slotInfos() const override;
+    const char* slotIdPrefix() const override {
+        return "magda_limiter_";
     }
-    const CompiledHostSlotInfo& hostSlotInfo(int slotIndex) const override {
-        return getSlotInfo(slotIndex);
-    }
-    DeviceParameterHandle hostSlotParameter(int slotIndex) const override {
-        return tracktion_adapter::parameterHandle(getSlotParameter(slotIndex));
-    }
-    float displayToNormalized(int slotIndex, float displayValue) const override {
-        return displayValueToNativeValue(slotIndex, displayValue);
-    }
-    float normalizedToDisplay(int slotIndex, float normalizedValue) const override {
-        return nativeValueToDisplayValue(slotIndex, normalizedValue);
-    }
+    void onPrepare(double sampleRate, int maximumBlockSize) override;
+    void onRelease() override;
+    void onReset() override;
+    void processAudio(DeviceProcessContext& context) override;
 
   private:
-    void buildHostParameters();
-
     MagdaLimiterDspCore limiter_;
-
-    std::array<HostSlotInfo, kHostSlotCount> hostSlotInfo_;
-    std::array<te::AutomatableParameter::Ptr, kHostSlotCount> hostParams_;
-    std::array<juce::CachedValue<float>, kHostSlotCount> hostCached_;
 
     std::atomic<float> inputPeakDb_{-120.0f};
     std::atomic<float> outputPeakDb_{-120.0f};

--- a/magda/daw/audio/plugins/compiled/MagdaModCompiledPlugin.cpp
+++ b/magda/daw/audio/plugins/compiled/MagdaModCompiledPlugin.cpp
@@ -1,464 +1,92 @@
 #include "plugins/compiled/MagdaModCompiledPlugin.hpp"
 
-#include <algorithm>
-#include <cmath>
-#include <limits>
-#include <map>
-
-#include "core/ParameterUtils.hpp"
+#include "core/ParameterInfo.hpp"
 #include "faust/dsp/dsp.h"
 #include "faust/gui/UI.h"
 #include "faust/gui/meta.h"
 #include "magda_mod.generated.cpp"
-#include "plugins/FaustMetadataParser.hpp"
-#include "plugins/FaustParamInfo.hpp"
 #include "plugins/compiled/CompiledPluginRegistry.hpp"
-#include "plugins/tracktion/TracktionDeviceAdapters.hpp"
 
 namespace magda::daw::audio::compiled {
 
 const char* MagdaModCompiledPlugin::xmlTypeName = "magda_mod";
 
-namespace {
-
-struct ModHarvest {
-    struct Control {
-        int idx = -1;
-        FaustParamSlot::Kind kind = FaustParamSlot::Kind::Continuous;
-        FAUSTFLOAT* zone = nullptr;
-        std::vector<std::pair<float, juce::String>> choices;
-        int gateSlotIndex = -1;
-        bool gateNegated = false;
-    };
-    std::vector<Control> controls;
-};
-
-class ModHarvester : public ::UI {
-  public:
-    ModHarvest harvest;
-
-    void openTabBox(const char*) override {}
-    void openHorizontalBox(const char*) override {}
-    void openVerticalBox(const char*) override {}
-    void closeBox() override {}
-
-    void addButton(const char* label, FAUSTFLOAT* zone) override {
-        emitControl(FaustParamSlot::Kind::Boolean, label, zone);
-    }
-    void addCheckButton(const char* label, FAUSTFLOAT* zone) override {
-        emitControl(FaustParamSlot::Kind::Boolean, label, zone);
-    }
-    void addVerticalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT, FAUSTFLOAT, FAUSTFLOAT,
-                           FAUSTFLOAT) override {
-        emitControl(FaustParamSlot::Kind::Continuous, label, zone);
-    }
-    void addHorizontalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT, FAUSTFLOAT,
-                             FAUSTFLOAT, FAUSTFLOAT) override {
-        emitControl(FaustParamSlot::Kind::Continuous, label, zone);
-    }
-    void addNumEntry(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT, FAUSTFLOAT, FAUSTFLOAT,
-                     FAUSTFLOAT) override {
-        emitControl(FaustParamSlot::Kind::Continuous, label, zone);
-    }
-    void addHorizontalBargraph(const char*, FAUSTFLOAT*, FAUSTFLOAT, FAUSTFLOAT) override {}
-    void addVerticalBargraph(const char*, FAUSTFLOAT*, FAUSTFLOAT, FAUSTFLOAT) override {}
-    void addSoundfile(const char*, const char*, Soundfile**) override {}
-
-    void declare(FAUSTFLOAT* zone, const char* key, const char* value) override {
-        if (zone == nullptr)
-            return;
-        const auto k = juce::String::fromUTF8(key != nullptr ? key : "").toLowerCase();
-        const auto v = juce::String::fromUTF8(value != nullptr ? value : "");
-        applyFaustAnnotation(k, v, pendingByZone_[zone]);
-    }
-
-  private:
-    void emitControl(FaustParamSlot::Kind kind, const char* rawLabel, FAUSTFLOAT* zone) {
-        const auto parsed =
-            parseFaustLabel(juce::String::fromUTF8(rawLabel != nullptr ? rawLabel : ""));
-        ControlMetadata merged = parsed.metadata;
-        if (zone != nullptr) {
-            if (auto it = pendingByZone_.find(zone); it != pendingByZone_.end()) {
-                mergeFaustMetadata(merged, it->second);
-                pendingByZone_.erase(it);
-            }
-        }
-
-        ModHarvest::Control c;
-        c.idx = merged.slotIndex;
-        c.kind = merged.isChoiceStyle() ? FaustParamSlot::Kind::Discrete : kind;
-        c.zone = zone;
-        c.choices = merged.menuChoices;
-        c.gateSlotIndex = merged.gateSlotIndex;
-        c.gateNegated = merged.gateNegated;
-        harvest.controls.push_back(std::move(c));
-    }
-
-    std::map<FAUSTFLOAT*, ControlMetadata> pendingByZone_;
-};
-
-const ModHarvest::Control* findByIdx(const ModHarvest& h, int idx) {
-    for (const auto& c : h.controls)
-        if (c.idx == idx)
-            return &c;
-    return nullptr;
+MagdaModCompiledPlugin::MagdaModCompiledPlugin() {
+    initEffect();
 }
 
-}  // namespace
-
-MagdaModCompiledPlugin::MagdaModCompiledPlugin(const te::PluginCreationInfo& info)
-    : te::Plugin(info) {
-    dsp_ = std::make_unique<MagdaModDsp>();
-    constexpr int kProvisionalSampleRate = 44100;
-    rebuildEngineState(kProvisionalSampleRate);
-    buildHostParameters();
+::dsp* MagdaModCompiledPlugin::createEngineDsp(int) const {
+    return new MagdaModDsp();
 }
 
-MagdaModCompiledPlugin::~MagdaModCompiledPlugin() {
-    notifyListenersOfDeletion();
-    for (auto& p : hostParams_)
-        if (p)
-            p->detachFromCurrentValue();
-}
-
-juce::String MagdaModCompiledPlugin::getName() const {
-    return "Mod";
-}
-juce::String MagdaModCompiledPlugin::getPluginType() {
-    return xmlTypeName;
-}
-juce::String MagdaModCompiledPlugin::getShortName(int) {
-    return "Mod";
-}
-juce::String MagdaModCompiledPlugin::getSelectableDescription() {
-    return "Mod";
-}
-
-void MagdaModCompiledPlugin::rebuildEngineState(int sampleRate) {
-    if (!dsp_)
-        return;
-    dsp_->init(sampleRate);
-    numInputs_ = dsp_->getNumInputs();
-    numOutputs_ = dsp_->getNumOutputs();
-
-    ModHarvester harvester;
-    dsp_->buildUserInterface(&harvester);
-
-    zones_.fill(nullptr);
-    bpmZone_ = nullptr;
-    divisionChoiceValues_.clear();
-    divisionChoiceLabels_.clear();
-
-    for (int i = 0; i < kHostSlotCount; ++i) {
-        harvestedGates_[static_cast<size_t>(i)] = {-1, false};
-        if (auto* c = findByIdx(harvester.harvest, i)) {
-            zones_[static_cast<size_t>(i)] = c->zone;
-            harvestedGates_[static_cast<size_t>(i)] = {c->gateSlotIndex, c->gateNegated};
-        }
-    }
-    if (auto* c = findByIdx(harvester.harvest, kBpmSlot))
-        bpmZone_ = c->zone;
-
-    if (auto* c = findByIdx(harvester.harvest, kDivisionSlot)) {
-        auto sorted = c->choices;
-        std::sort(sorted.begin(), sorted.end(),
-                  [](const auto& a, const auto& b) { return a.first < b.first; });
-        divisionChoiceValues_.reserve(sorted.size());
-        divisionChoiceLabels_.reserve(sorted.size());
-        for (const auto& choice : sorted) {
-            divisionChoiceValues_.push_back(choice.first);
-            divisionChoiceLabels_.push_back(choice.second);
-        }
-    }
-}
-
-void MagdaModCompiledPlugin::buildHostParameters() {
+std::vector<MagdaModCompiledPlugin::HostSlotInfo> MagdaModCompiledPlugin::slotInfos() const {
+    std::vector<HostSlotInfo> infos(kHostSlotCount);
+    // The Division choices are the dsp's own [style:menu{...}]: the labels
+    // read as musical divisions and the values are the quarter-note
+    // multipliers the zone wants, so neither list is restated here.
+    const auto divisionValues = menuValuesForIdx(kDivisionSlot);
     // Slot 0: Mode (Trem / Vibrato / Autopan).
-    hostSlotInfo_[kModeSlot].name = "Mode";
-    hostSlotInfo_[kModeSlot].scale = magda::ParameterScale::Discrete;
-    hostSlotInfo_[kModeSlot].choices = {"Tremolo", "Vibrato", "Autopan"};
-    hostSlotInfo_[kModeSlot].minValue = 0.0f;
-    hostSlotInfo_[kModeSlot].maxValue =
-        static_cast<float>(hostSlotInfo_[kModeSlot].choices.size() - 1);
-    hostSlotInfo_[kModeSlot].defaultValue = 0.0f;
+    infos[kModeSlot].name = "Mode";
+    infos[kModeSlot].scale = magda::ParameterScale::Discrete;
+    infos[kModeSlot].choices = {"Tremolo", "Vibrato", "Autopan"};
+    infos[kModeSlot].minValue = 0.0f;
+    infos[kModeSlot].maxValue = static_cast<float>(infos[kModeSlot].choices.size() - 1);
+    infos[kModeSlot].defaultValue = 0.0f;
 
     // Slot 1: Sync (Off / On).
-    hostSlotInfo_[kSyncSlot] = {.name = "Sync",
-                                .scale = magda::ParameterScale::Discrete,
-                                .minValue = 0.0f,
-                                .maxValue = 1.0f,
-                                .defaultValue = 0.0f,
-                                .scaleAnchor = std::numeric_limits<float>::quiet_NaN(),
-                                .choices = {"Off", "On"}};
+    infos[kSyncSlot] = {.name = "Sync",
+                        .scale = magda::ParameterScale::Discrete,
+                        .minValue = 0.0f,
+                        .maxValue = 1.0f,
+                        .defaultValue = 0.0f,
+                        .scaleAnchor = std::numeric_limits<float>::quiet_NaN(),
+                        .choices = {"Off", "On"}};
 
     // Slot 2: Rate (Hz, log).
-    hostSlotInfo_[kRateSlot] = {.name = "Rate",
-                                .unit = magda::technicalText(magda::TechnicalTextToken::Hertz),
-                                .scale = magda::ParameterScale::Logarithmic,
-                                .minValue = 0.05f,
-                                .maxValue = 20.0f,
-                                .defaultValue = 4.0f,
-                                .scaleAnchor = 4.0f};
+    infos[kRateSlot] = {.name = "Rate",
+                        .unit = magda::technicalText(magda::TechnicalTextToken::Hertz),
+                        .scale = magda::ParameterScale::Logarithmic,
+                        .minValue = 0.05f,
+                        .maxValue = 20.0f,
+                        .defaultValue = 4.0f,
+                        .scaleAnchor = 4.0f};
 
     // Slot 3: Division (populated from harvest).
-    hostSlotInfo_[kDivisionSlot].name = "Division";
-    hostSlotInfo_[kDivisionSlot].scale = magda::ParameterScale::Discrete;
-    hostSlotInfo_[kDivisionSlot].minValue = 0.0f;
-    hostSlotInfo_[kDivisionSlot].maxValue = 0.0f;
-    hostSlotInfo_[kDivisionSlot].defaultValue = 0.0f;
+    infos[kDivisionSlot].name = "Division";
+    infos[kDivisionSlot].scale = magda::ParameterScale::Discrete;
+    infos[kDivisionSlot].minValue = 0.0f;
+    infos[kDivisionSlot].maxValue = 0.0f;
+    infos[kDivisionSlot].defaultValue = 0.0f;
 
     // Slot 4: Depth.
-    hostSlotInfo_[kDepthSlot] = {.name = "Depth",
-                                 .scale = magda::ParameterScale::Linear,
-                                 .minValue = 0.0f,
-                                 .maxValue = 1.0f,
-                                 .defaultValue = 0.5f};
+    infos[kDepthSlot] = {.name = "Depth",
+                         .scale = magda::ParameterScale::Linear,
+                         .minValue = 0.0f,
+                         .maxValue = 1.0f,
+                         .defaultValue = 0.5f};
 
     // Slot 5: Shape.
-    hostSlotInfo_[kShapeSlot].name = "Shape";
-    hostSlotInfo_[kShapeSlot].scale = magda::ParameterScale::Discrete;
-    hostSlotInfo_[kShapeSlot].choices = {"Sine", "Triangle", "Square", "S&H"};
-    hostSlotInfo_[kShapeSlot].minValue = 0.0f;
-    hostSlotInfo_[kShapeSlot].maxValue =
-        static_cast<float>(hostSlotInfo_[kShapeSlot].choices.size() - 1);
-    hostSlotInfo_[kShapeSlot].defaultValue = 0.0f;
+    infos[kShapeSlot].name = "Shape";
+    infos[kShapeSlot].scale = magda::ParameterScale::Discrete;
+    infos[kShapeSlot].choices = {"Sine", "Triangle", "Square", "S&H"};
+    infos[kShapeSlot].minValue = 0.0f;
+    infos[kShapeSlot].maxValue = static_cast<float>(infos[kShapeSlot].choices.size() - 1);
+    infos[kShapeSlot].defaultValue = 0.0f;
 
-    if (!divisionChoiceValues_.empty()) {
-        const int n = static_cast<int>(divisionChoiceValues_.size());
-        hostSlotInfo_[kDivisionSlot].choices = divisionChoiceLabels_;
-        hostSlotInfo_[kDivisionSlot].maxValue = static_cast<float>(n - 1);
+    if (!divisionValues.empty()) {
+        const int n = static_cast<int>(divisionValues.size());
+        infos[kDivisionSlot].choices = menuLabelsForIdx(kDivisionSlot);
+        infos[kDivisionSlot].maxValue = static_cast<float>(n - 1);
         // Default to "1/4" (Faust value 1.0) if it's in the set.
         for (int i = 0; i < n; ++i) {
-            if (std::abs(divisionChoiceValues_[static_cast<size_t>(i)] - 1.0f) < 1e-3f) {
-                hostSlotInfo_[kDivisionSlot].defaultValue = static_cast<float>(i);
+            if (std::abs(divisionValues[static_cast<size_t>(i)] - 1.0f) < 1e-3f) {
+                infos[kDivisionSlot].defaultValue = static_cast<float>(i);
                 break;
             }
         }
     }
 
-    juce::NormalisableRange<float> normalisedRange{0.0f, 1.0f};
-    auto* undoManager = getUndoManager();
-
-    auto buildInfo = [](const HostSlotInfo& s) {
-        magda::ParameterInfo info;
-        info.minValue = s.minValue;
-        info.maxValue = s.maxValue;
-        info.defaultValue = s.defaultValue;
-        info.unit = s.unit;
-        info.scale = s.scale;
-        if (std::isfinite(s.scaleAnchor))
-            info.scaleAnchor = s.scaleAnchor;
-        info.choices = s.choices;
-        return info;
-    };
-
-    for (int i = 0; i < kHostSlotCount; ++i) {
-        const auto& slot = hostSlotInfo_[i];
-        const juce::String id = "magda_mod_" + slot.name.toLowerCase().replace(" ", "_");
-        const juce::Identifier identifier(id);
-        const auto info = buildInfo(slot);
-        const float defaultNormalized =
-            magda::ParameterUtils::realToNormalized(slot.defaultValue, info);
-        hostCached_[i].referTo(state, identifier, undoManager, defaultNormalized);
-
-        auto param = addParam(
-            id, slot.name, normalisedRange,
-            [info](float normalized) {
-                const float real = magda::ParameterUtils::normalizedToReal(normalized, info);
-                return magda::ParameterUtils::formatValue(real, info);
-            },
-            [info](const juce::String& text) {
-                auto parsed = magda::ParameterUtils::parseValue(text, info);
-                if (parsed)
-                    return magda::ParameterUtils::realToNormalized(*parsed, info);
-                return 0.0f;
-            });
-        param->attachToCurrentValue(hostCached_[i]);
-        hostParams_[i] = param;
-    }
-
-    for (int i = 0; i < kHostSlotCount; ++i) {
-        hostSlotInfo_[static_cast<size_t>(i)].gateSlotIndex =
-            harvestedGates_[static_cast<size_t>(i)].slotIndex;
-        hostSlotInfo_[static_cast<size_t>(i)].gateNegated =
-            harvestedGates_[static_cast<size_t>(i)].negated;
-    }
-}
-
-void MagdaModCompiledPlugin::initialise(const te::PluginInitialisationInfo& info) {
-    rebuildEngineState(static_cast<int>(info.sampleRate));
-    scratchIn_.setSize(numInputs_, info.blockSizeSamples, false, true, true);
-    scratchOut_.setSize(numOutputs_, info.blockSizeSamples, false, true, true);
-    inPtrs_.assign(static_cast<size_t>(numInputs_), nullptr);
-    outPtrs_.assign(static_cast<size_t>(numOutputs_), nullptr);
-}
-
-void MagdaModCompiledPlugin::deinitialise() {
-    scratchIn_.setSize(0, 0);
-    scratchOut_.setSize(0, 0);
-    inPtrs_.clear();
-    outPtrs_.clear();
-}
-
-void MagdaModCompiledPlugin::reset() {
-    if (dsp_)
-        dsp_->instanceClear();
-}
-
-void MagdaModCompiledPlugin::applyToBuffer(const te::PluginRenderContext& fc) {
-    if (!fc.destBuffer || fc.bufferNumSamples <= 0 || !dsp_)
-        return;
-
-    // Restart the LFO phase whenever transport goes from stopped to playing
-    // so the modulation is in sync with the song every time you hit play.
-    // instanceClear() also flushes the vibrato delay line; brief silence at
-    // the transport edge is the expected behaviour for a phase reset.
-    if (fc.isPlaying && !wasPlaying_)
-        dsp_->instanceClear();
-    wasPlaying_ = fc.isPlaying;
-
-    auto writeContinuous = [&](int slot) {
-        if (auto* zone = zones_[static_cast<size_t>(slot)]) {
-            const auto& s = hostSlotInfo_[static_cast<size_t>(slot)];
-            magda::ParameterInfo info;
-            info.minValue = s.minValue;
-            info.maxValue = s.maxValue;
-            info.scale = s.scale;
-            if (std::isfinite(s.scaleAnchor))
-                info.scaleAnchor = s.scaleAnchor;
-            const float norm = hostParams_[static_cast<size_t>(slot)]->getCurrentValue();
-            *zone = static_cast<FAUSTFLOAT>(magda::ParameterUtils::normalizedToReal(norm, info));
-        }
-    };
-    writeContinuous(kRateSlot);
-    writeContinuous(kDepthSlot);
-
-    // Discrete menu slots: index 0..N-1 written directly.
-    auto writeMenuIndex = [&](int slot) {
-        if (auto* z = zones_[static_cast<size_t>(slot)]) {
-            const auto& s = hostSlotInfo_[static_cast<size_t>(slot)];
-            const float norm = hostParams_[static_cast<size_t>(slot)]->getCurrentValue();
-            const int count = static_cast<int>(s.choices.size());
-            const int idx =
-                count > 1 ? juce::jlimit(
-                                0, count - 1,
-                                static_cast<int>(std::round(norm * static_cast<float>(count - 1))))
-                          : 0;
-            *z = static_cast<FAUSTFLOAT>(idx);
-        }
-    };
-    writeMenuIndex(kModeSlot);
-    writeMenuIndex(kShapeSlot);
-
-    // Sync: 0/1 boolean.
-    if (auto* z = zones_[kSyncSlot])
-        *z = hostParams_[kSyncSlot]->getCurrentValue() >= 0.5f ? FAUSTFLOAT(1) : FAUSTFLOAT(0);
-
-    // Division: map host index → Faust quarter-note multiplier.
-    if (auto* z = zones_[kDivisionSlot]; z && !divisionChoiceValues_.empty()) {
-        const float norm = hostParams_[kDivisionSlot]->getCurrentValue();
-        const int count = static_cast<int>(divisionChoiceValues_.size());
-        const int idx = juce::jlimit(
-            0, count - 1, static_cast<int>(std::round(norm * static_cast<float>(count - 1))));
-        *z = static_cast<FAUSTFLOAT>(divisionChoiceValues_[static_cast<size_t>(idx)]);
-    }
-
-    // Project tempo into the hidden BPM zone (same plumbing as the delay).
-    const double bpm = edit.tempoSequence.getBpmAt(fc.editTime.getStart());
-    currentBpm_.store(static_cast<float>(bpm), std::memory_order_relaxed);
-    if (bpmZone_)
-        *bpmZone_ = static_cast<FAUSTFLOAT>(bpm);
-
-    const int numSamples = fc.bufferNumSamples;
-    const int startSample = fc.bufferStartSample;
-    const int hostChannels = fc.destBuffer->getNumChannels();
-    if (hostChannels <= 0 || numInputs_ <= 0 || numOutputs_ <= 0)
-        return;
-
-    if (scratchIn_.getNumChannels() < numInputs_ || scratchIn_.getNumSamples() < numSamples)
-        scratchIn_.setSize(numInputs_, numSamples, false, true, true);
-    if (scratchOut_.getNumChannels() < numOutputs_ || scratchOut_.getNumSamples() < numSamples)
-        scratchOut_.setSize(numOutputs_, numSamples, false, true, true);
-    if (static_cast<int>(inPtrs_.size()) < numInputs_)
-        inPtrs_.resize(static_cast<size_t>(numInputs_), nullptr);
-    if (static_cast<int>(outPtrs_.size()) < numOutputs_)
-        outPtrs_.resize(static_cast<size_t>(numOutputs_), nullptr);
-
-    for (int ch = 0; ch < numInputs_; ++ch) {
-        float* dst = scratchIn_.getWritePointer(ch);
-        if (ch < hostChannels) {
-            const float* src = fc.destBuffer->getReadPointer(ch, startSample);
-            std::copy(src, src + numSamples, dst);
-        } else {
-            std::fill(dst, dst + numSamples, 0.0f);
-        }
-        inPtrs_[static_cast<size_t>(ch)] = dst;
-    }
-    for (int ch = 0; ch < numOutputs_; ++ch) {
-        outPtrs_[static_cast<size_t>(ch)] = (ch < hostChannels)
-                                                ? fc.destBuffer->getWritePointer(ch, startSample)
-                                                : scratchOut_.getWritePointer(ch);
-    }
-
-    dsp_->compute(numSamples, inPtrs_.data(), outPtrs_.data());
-
-    const int channelsToSanitise = std::min(hostChannels, numOutputs_);
-    for (int ch = 0; ch < channelsToSanitise; ++ch) {
-        float* out = fc.destBuffer->getWritePointer(ch, startSample);
-        for (int i = 0; i < numSamples; ++i) {
-            const float sample = out[i];
-            out[i] = std::isfinite(sample) ? juce::jlimit(-16.0f, 16.0f, sample) : 0.0f;
-        }
-    }
-}
-
-te::AutomatableParameter* MagdaModCompiledPlugin::getSlotParameter(int slotIndex) const {
-    if (slotIndex < 0 || slotIndex >= kHostSlotCount)
-        return nullptr;
-    return hostParams_[static_cast<size_t>(slotIndex)].get();
-}
-
-const MagdaModCompiledPlugin::HostSlotInfo& MagdaModCompiledPlugin::getSlotInfo(
-    int slotIndex) const {
-    static const HostSlotInfo kEmpty;
-    if (slotIndex < 0 || slotIndex >= kHostSlotCount)
-        return kEmpty;
-    return hostSlotInfo_[static_cast<size_t>(slotIndex)];
-}
-
-float MagdaModCompiledPlugin::divisionFaustValueForIndex(int index) const {
-    if (divisionChoiceValues_.empty())
-        return 1.0f;
-    const int safeIdx = juce::jlimit(0, static_cast<int>(divisionChoiceValues_.size()) - 1, index);
-    return divisionChoiceValues_[static_cast<size_t>(safeIdx)];
-}
-
-float MagdaModCompiledPlugin::displayValueToNativeValue(int slotIndex, float displayValue) const {
-    if (slotIndex < 0 || slotIndex >= kHostSlotCount)
-        return displayValue;
-    const auto& s = hostSlotInfo_[static_cast<size_t>(slotIndex)];
-    magda::ParameterInfo info;
-    info.minValue = s.minValue;
-    info.maxValue = s.maxValue;
-    info.scale = s.scale;
-    if (std::isfinite(s.scaleAnchor))
-        info.scaleAnchor = s.scaleAnchor;
-    info.choices = s.choices;
-    return magda::ParameterUtils::realToNormalized(displayValue, info);
-}
-
-float MagdaModCompiledPlugin::nativeValueToDisplayValue(int slotIndex, float nativeValue) const {
-    if (slotIndex < 0 || slotIndex >= kHostSlotCount)
-        return nativeValue;
-    const auto& s = hostSlotInfo_[static_cast<size_t>(slotIndex)];
-    magda::ParameterInfo info;
-    info.minValue = s.minValue;
-    info.maxValue = s.maxValue;
-    info.scale = s.scale;
-    if (std::isfinite(s.scaleAnchor))
-        info.scaleAnchor = s.scaleAnchor;
-    info.choices = s.choices;
-    return magda::ParameterUtils::normalizedToReal(nativeValue, info);
+    return infos;
 }
 
 constexpr AliasSpec kAliases[] = {
@@ -478,9 +106,8 @@ const CompiledPluginSpec& getMagdaModSpec() {
                        "All three mode bodies run in parallel for glitch-free switching. "
                        "LFO Shape selects Sine, Triangle, Square or Sample-and-hold; "
                        "Rate runs free in Hz or locks to tempo Division.",
-        .createPlugin = [](const DevicePluginCreationContext& context) -> DevicePluginPtr {
-            return tracktion_adapter::pluginHandle(
-                new MagdaModCompiledPlugin(tracktion_adapter::creationInfo(context)));
+        .createDevice = [](const DevicePluginCreationContext&) -> std::unique_ptr<MagdaDevice> {
+            return std::make_unique<MagdaModCompiledPlugin>();
         },
         .aliases = kAliases,
         .aliasCount = static_cast<int>(sizeof(kAliases) / sizeof(kAliases[0])),

--- a/magda/daw/audio/plugins/compiled/MagdaModCompiledPlugin.hpp
+++ b/magda/daw/audio/plugins/compiled/MagdaModCompiledPlugin.hpp
@@ -1,15 +1,8 @@
 #pragma once
 
-#include <tracktion_engine/tracktion_engine.h>
-
-#include <array>
-#include <atomic>
-#include <memory>
 #include <vector>
 
-#include "../FaustParamPool.hpp"
-#include "core/ParameterInfo.hpp"
-#include "plugins/compiled/tracktion/CompiledFaustTracktionAdapter.hpp"
+#include "plugins/compiled/MagdaCompiledEffect.hpp"
 
 class dsp;
 
@@ -23,40 +16,12 @@ namespace magda::daw::audio::compiled {
  * ([idx:63]) is populated each block from TE's transport so sync mode tracks
  * the live tempo — same plumbing the delay uses.
  */
-class MagdaModCompiledPlugin : public te::Plugin, public ICompiledFaustPlugin {
+class MagdaModCompiledPlugin : public MagdaCompiledEffect {
   public:
     static const char* xmlTypeName;
 
-    explicit MagdaModCompiledPlugin(const te::PluginCreationInfo& info);
-    ~MagdaModCompiledPlugin() override;
+    MagdaModCompiledPlugin();
 
-    juce::String getName() const override;
-    juce::String getPluginType() override;
-    juce::String getShortName(int) override;
-    juce::String getSelectableDescription() override;
-
-    void initialise(const te::PluginInitialisationInfo& info) override;
-    void deinitialise() override;
-    void reset() override;
-    void applyToBuffer(const te::PluginRenderContext& fc) override;
-
-    bool takesMidiInput() override {
-        return false;
-    }
-    bool takesAudioInput() override {
-        return true;
-    }
-    bool isSynth() override {
-        return false;
-    }
-    bool producesAudioWhenNoAudioInput() override {
-        return false;
-    }
-    double getTailLength() const override {
-        return 0.0;
-    }
-
-    // Slot ordering matches [idx:N] pins inside magda_mod.dsp.
     static constexpr int kModeSlot = 0;
     static constexpr int kSyncSlot = 1;
     static constexpr int kRateSlot = 2;
@@ -66,68 +31,29 @@ class MagdaModCompiledPlugin : public te::Plugin, public ICompiledFaustPlugin {
     static constexpr int kHostSlotCount = 6;
     static constexpr int kBpmSlot = 63;  // hidden, host-driven
 
-    te::AutomatableParameter* getSlotParameter(int slotIndex) const;
-
-    float displayValueToNativeValue(int slotIndex, float displayValue) const;
-    float nativeValueToDisplayValue(int slotIndex, float nativeValue) const;
-
-    using HostSlotInfo = CompiledHostSlotInfo;
-    const HostSlotInfo& getSlotInfo(int slotIndex) const;
-
-    float divisionFaustValueForIndex(int index) const;
-
-    float currentBpm() const {
-        return currentBpm_.load(std::memory_order_relaxed);
+    /// The Faust quarter-note multiplier behind Division choice @p index.
+    float divisionFaustValueForIndex(int index) const {
+        return menuValueForChoice(kDivisionSlot, index);
     }
 
-    // ICompiledFaustPlugin
-    int hostSlotCount() const override {
-        return kHostSlotCount;
+    juce::String devicePluginId() const override {
+        return xmlTypeName;
     }
-    const CompiledHostSlotInfo& hostSlotInfo(int slotIndex) const override {
-        return getSlotInfo(slotIndex);
+    juce::String deviceName() const override {
+        return "Mod";
     }
-    DeviceParameterHandle hostSlotParameter(int slotIndex) const override {
-        return tracktion_adapter::parameterHandle(getSlotParameter(slotIndex));
+
+  protected:
+    ::dsp* createEngineDsp(int engineIndex) const override;
+    std::vector<HostSlotInfo> slotInfos() const override;
+    const char* slotIdPrefix() const override {
+        return "magda_mod_";
     }
-    float displayToNormalized(int slotIndex, float displayValue) const override {
-        return displayValueToNativeValue(slotIndex, displayValue);
-    }
-    float normalizedToDisplay(int slotIndex, float normalizedValue) const override {
-        return nativeValueToDisplayValue(slotIndex, normalizedValue);
+    bool resetsOnPlayStart() const override {
+        return true;
     }
 
   private:
-    void buildHostParameters();
-    void rebuildEngineState(int sampleRate);
-
-    std::unique_ptr<::dsp> dsp_;
-    int numInputs_ = 0;
-    int numOutputs_ = 0;
-
-    std::array<FAUSTFLOAT*, kHostSlotCount> zones_{};
-    FAUSTFLOAT* bpmZone_ = nullptr;
-    std::vector<float> divisionChoiceValues_;
-    std::vector<juce::String> divisionChoiceLabels_;
-
-    struct GateSpec {
-        int slotIndex = -1;
-        bool negated = false;
-    };
-    std::array<GateSpec, kHostSlotCount> harvestedGates_{};
-
-    std::array<HostSlotInfo, kHostSlotCount> hostSlotInfo_;
-    std::array<te::AutomatableParameter::Ptr, kHostSlotCount> hostParams_;
-    std::array<juce::CachedValue<float>, kHostSlotCount> hostCached_;
-
-    juce::AudioBuffer<float> scratchIn_;
-    juce::AudioBuffer<float> scratchOut_;
-    std::vector<float*> inPtrs_;
-    std::vector<float*> outPtrs_;
-
-    std::atomic<float> currentBpm_{120.0f};
-    bool wasPlaying_ = false;  // audio-thread only; rising edge restarts the LFO phase
-
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(MagdaModCompiledPlugin)
 };
 

--- a/magda/daw/audio/plugins/compiled/MagdaMultibandCompiledPlugin.cpp
+++ b/magda/daw/audio/plugins/compiled/MagdaMultibandCompiledPlugin.cpp
@@ -1,11 +1,11 @@
 #include "plugins/compiled/MagdaMultibandCompiledPlugin.hpp"
 
 #include <algorithm>
+#include <array>
 #include <cmath>
 
-#include "core/ParameterUtils.hpp"
+#include "core/ParameterInfo.hpp"
 #include "plugins/compiled/CompiledPluginRegistry.hpp"
-#include "plugins/tracktion/TracktionDeviceAdapters.hpp"
 
 namespace magda::daw::audio::compiled {
 
@@ -13,23 +13,14 @@ const char* MagdaMultibandCompiledPlugin::xmlTypeName = "magda_multiband";
 
 namespace {
 
+// The property the toggle was already saved under, kept so a project written
+// before the port still finds it.
+const juce::Identifier kCurveCollapsedProperty("magda_multiband_curve_collapsed");
+
 constexpr float kMinRatio = 0.05f;
 constexpr float kMaxRatio = 100.0f;
 constexpr float kMinLevelDb = -100.0f;
 constexpr double kBiquadQ = 0.7071067811865476;
-
-magda::ParameterInfo parameterInfoForSlot(const CompiledHostSlotInfo& s) {
-    magda::ParameterInfo info;
-    info.minValue = s.minValue;
-    info.maxValue = s.maxValue;
-    info.defaultValue = s.defaultValue;
-    info.unit = s.unit;
-    info.scale = s.scale;
-    if (std::isfinite(s.scaleAnchor))
-        info.scaleAnchor = s.scaleAnchor;
-    info.choices = s.choices;
-    return info;
-}
 
 float dbToGain(float db) {
     return std::pow(10.0f, db / 20.0f);
@@ -70,6 +61,145 @@ float dynamicsGainDb(float levelDb, float lowerThresholdDb, float upperThreshold
 }
 
 }  // namespace
+
+MagdaMultibandCompiledPlugin::MagdaMultibandCompiledPlugin() {
+    initEffect();
+}
+
+std::vector<MagdaMultibandCompiledPlugin::HostSlotInfo> MagdaMultibandCompiledPlugin::slotInfos()
+    const {
+    std::vector<HostSlotInfo> infos(kHostSlotCount);
+    infos[kAmountSlot] = {.name = "Amount",
+                          .scale = magda::ParameterScale::Linear,
+                          .minValue = 0.0f,
+                          .maxValue = 1.0f,
+                          .defaultValue = 0.8f};
+    infos[kAttackSlot] = {.name = "Attack",
+                          .unit = magda::technicalText(magda::TechnicalTextToken::Milliseconds),
+                          .scale = magda::ParameterScale::Logarithmic,
+                          .minValue = 0.1f,
+                          .maxValue = 100.0f,
+                          .defaultValue = 3.0f,
+                          .scaleAnchor = 10.0f};
+    infos[kReleaseSlot] = {.name = "Release",
+                           .unit = magda::technicalText(magda::TechnicalTextToken::Milliseconds),
+                           .scale = magda::ParameterScale::Logarithmic,
+                           .minValue = 5.0f,
+                           .maxValue = 1000.0f,
+                           .defaultValue = 120.0f,
+                           .scaleAnchor = 100.0f};
+    infos[kInputSlot] = {.name = "Input",
+                         .unit = magda::technicalText(magda::TechnicalTextToken::Decibels),
+                         .scale = magda::ParameterScale::Linear,
+                         .minValue = -24.0f,
+                         .maxValue = 24.0f,
+                         .defaultValue = 0.0f};
+    infos[kOutputSlot] = {.name = "Output",
+                          .unit = magda::technicalText(magda::TechnicalTextToken::Decibels),
+                          .scale = magda::ParameterScale::Linear,
+                          .minValue = -24.0f,
+                          .maxValue = 24.0f,
+                          .defaultValue = 0.0f};
+    infos[kMixSlot] = {.name = "Mix",
+                       .scale = magda::ParameterScale::Linear,
+                       .minValue = 0.0f,
+                       .maxValue = 1.0f,
+                       .defaultValue = 1.0f};
+    auto setGain = [&infos](int slot, juce::String name) {
+        infos[slot] = {.name = std::move(name),
+                       .unit = magda::technicalText(magda::TechnicalTextToken::Decibels),
+                       .scale = magda::ParameterScale::Linear,
+                       .minValue = -24.0f,
+                       .maxValue = 24.0f,
+                       .defaultValue = 0.0f};
+    };
+    setGain(kLowInputSlot, "Low Input");
+    setGain(kMidInputSlot, "Mid Input");
+    setGain(kHighInputSlot, "High Input");
+    setGain(kLowGainSlot, "Low Output");
+    setGain(kMidGainSlot, "Mid Output");
+    setGain(kHighGainSlot, "High Output");
+
+    auto setThreshold = [&infos](int slot, juce::String name, float defaultValue) {
+        infos[slot] = {.name = std::move(name),
+                       .unit = magda::technicalText(magda::TechnicalTextToken::Decibels),
+                       .scale = magda::ParameterScale::Linear,
+                       .minValue = -80.0f,
+                       .maxValue = 0.0f,
+                       .defaultValue = defaultValue};
+    };
+    auto setRatio = [&infos](int slot, juce::String name) {
+        infos[slot] = {.name = std::move(name),
+                       .scale = magda::ParameterScale::Linear,
+                       .minValue = 0.05f,
+                       .maxValue = kMaxRatio,
+                       .defaultValue = 8.0f};
+    };
+    auto setTiming = [&infos](int attackSlot, int releaseSlot, const juce::String& bandName) {
+        infos[attackSlot] = {.name = bandName + " Attack",
+                             .unit = magda::technicalText(magda::TechnicalTextToken::Milliseconds),
+                             .scale = magda::ParameterScale::Logarithmic,
+                             .minValue = 0.1f,
+                             .maxValue = 100.0f,
+                             .defaultValue = 3.0f,
+                             .scaleAnchor = 10.0f};
+        infos[releaseSlot] = {.name = bandName + " Release",
+                              .unit = magda::technicalText(magda::TechnicalTextToken::Milliseconds),
+                              .scale = magda::ParameterScale::Logarithmic,
+                              .minValue = 5.0f,
+                              .maxValue = 1000.0f,
+                              .defaultValue = 120.0f,
+                              .scaleAnchor = 100.0f};
+    };
+    auto setBand = [&infos, setThreshold,
+                    setRatio](int lowerThresholdSlot, int upperThresholdSlot, int belowRatioSlot,
+                              int aboveRatioSlot, int rangeSlot, int limitSlot,
+                              juce::String bandName, float lowerDefault, float upperDefault) {
+        setThreshold(lowerThresholdSlot, bandName + " Lower Threshold", lowerDefault);
+        setThreshold(upperThresholdSlot, bandName + " Upper Threshold", upperDefault);
+        setRatio(belowRatioSlot, bandName + " Below Ratio");
+        setRatio(aboveRatioSlot, bandName + " Above Ratio");
+        infos[rangeSlot] = {.name = bandName + " Range",
+                            .unit = magda::technicalText(magda::TechnicalTextToken::Decibels),
+                            .scale = magda::ParameterScale::Linear,
+                            .minValue = 0.0f,
+                            .maxValue = 48.0f,
+                            .defaultValue = 24.0f};
+        infos[limitSlot] = {.name = bandName + " Limit",
+                            .unit = magda::technicalText(magda::TechnicalTextToken::Decibels),
+                            .scale = magda::ParameterScale::Linear,
+                            .minValue = -24.0f,
+                            .maxValue = 12.0f,
+                            .defaultValue = 0.0f};
+    };
+
+    setBand(kLowLowerThresholdSlot, kLowUpperThresholdSlot, kLowBelowRatioSlot, kLowAboveRatioSlot,
+            kLowRangeSlot, kLowLimitSlot, "Low", -48.0f, -24.0f);
+    setTiming(kLowAttackSlot, kLowReleaseSlot, "Low");
+    setBand(kMidLowerThresholdSlot, kMidUpperThresholdSlot, kMidBelowRatioSlot, kMidAboveRatioSlot,
+            kMidRangeSlot, kMidLimitSlot, "Mid", -48.0f, -24.0f);
+    setTiming(kMidAttackSlot, kMidReleaseSlot, "Mid");
+    setBand(kHighLowerThresholdSlot, kHighUpperThresholdSlot, kHighBelowRatioSlot,
+            kHighAboveRatioSlot, kHighRangeSlot, kHighLimitSlot, "High", -48.0f, -24.0f);
+    setTiming(kHighAttackSlot, kHighReleaseSlot, "High");
+
+    infos[kLowXoSlot] = {.name = "Low XO",
+                         .unit = magda::technicalText(magda::TechnicalTextToken::Hertz),
+                         .scale = magda::ParameterScale::Logarithmic,
+                         .minValue = 40.0f,
+                         .maxValue = 500.0f,
+                         .defaultValue = 120.0f,
+                         .scaleAnchor = 200.0f};
+    infos[kHighXoSlot] = {.name = "High XO",
+                          .unit = magda::technicalText(magda::TechnicalTextToken::Hertz),
+                          .scale = magda::ParameterScale::Logarithmic,
+                          .minValue = 500.0f,
+                          .maxValue = 8000.0f,
+                          .defaultValue = 2500.0f,
+                          .scaleAnchor = 2000.0f};
+
+    return infos;
+}
 
 void MagdaMultibandCompiledPlugin::Biquad::setLowPass(double sampleRate, double frequency) {
     frequency = juce::jlimit(10.0, sampleRate * 0.45, frequency);
@@ -147,237 +277,40 @@ void MagdaMultibandCompiledPlugin::CrossoverState::split(float input, float& low
     high = highHp2.process(highHp1.process(aboveLow));
 }
 
-MagdaMultibandCompiledPlugin::MagdaMultibandCompiledPlugin(const te::PluginCreationInfo& info)
-    : te::Plugin(info) {
-    buildHostParameters();
-    updateCrossoverCoefficients(hostSlotInfo_[kLowXoSlot].defaultValue,
-                                hostSlotInfo_[kHighXoSlot].defaultValue);
+void MagdaMultibandCompiledPlugin::flushState(juce::ValueTree& state) {
+    state.setProperty(kCurveCollapsedProperty, curveCollapsed_, nullptr);
 }
 
-MagdaMultibandCompiledPlugin::~MagdaMultibandCompiledPlugin() {
-    notifyListenersOfDeletion();
-    for (auto& p : hostParams_)
-        if (p)
-            p->detachFromCurrentValue();
+void MagdaMultibandCompiledPlugin::restoreState(const juce::ValueTree& state) {
+    curveCollapsed_ = static_cast<bool>(state.getProperty(kCurveCollapsedProperty, true));
 }
 
-juce::String MagdaMultibandCompiledPlugin::getName() const {
-    return "Multiband Dynamics";
-}
-juce::String MagdaMultibandCompiledPlugin::getPluginType() {
-    return xmlTypeName;
-}
-juce::String MagdaMultibandCompiledPlugin::getShortName(int) {
-    return "Dynamics";
-}
-juce::String MagdaMultibandCompiledPlugin::getSelectableDescription() {
-    return "Multiband Dynamics";
-}
-
-void MagdaMultibandCompiledPlugin::buildHostParameters() {
-    hostSlotInfo_[kAmountSlot] = {.name = "Amount",
-                                  .scale = magda::ParameterScale::Linear,
-                                  .minValue = 0.0f,
-                                  .maxValue = 1.0f,
-                                  .defaultValue = 0.8f};
-    hostSlotInfo_[kAttackSlot] = {.name = "Attack",
-                                  .unit =
-                                      magda::technicalText(magda::TechnicalTextToken::Milliseconds),
-                                  .scale = magda::ParameterScale::Logarithmic,
-                                  .minValue = 0.1f,
-                                  .maxValue = 100.0f,
-                                  .defaultValue = 3.0f,
-                                  .scaleAnchor = 10.0f};
-    hostSlotInfo_[kReleaseSlot] = {
-        .name = "Release",
-        .unit = magda::technicalText(magda::TechnicalTextToken::Milliseconds),
-        .scale = magda::ParameterScale::Logarithmic,
-        .minValue = 5.0f,
-        .maxValue = 1000.0f,
-        .defaultValue = 120.0f,
-        .scaleAnchor = 100.0f};
-    hostSlotInfo_[kInputSlot] = {.name = "Input",
-                                 .unit = magda::technicalText(magda::TechnicalTextToken::Decibels),
-                                 .scale = magda::ParameterScale::Linear,
-                                 .minValue = -24.0f,
-                                 .maxValue = 24.0f,
-                                 .defaultValue = 0.0f};
-    hostSlotInfo_[kOutputSlot] = {.name = "Output",
-                                  .unit = magda::technicalText(magda::TechnicalTextToken::Decibels),
-                                  .scale = magda::ParameterScale::Linear,
-                                  .minValue = -24.0f,
-                                  .maxValue = 24.0f,
-                                  .defaultValue = 0.0f};
-    hostSlotInfo_[kMixSlot] = {.name = "Mix",
-                               .scale = magda::ParameterScale::Linear,
-                               .minValue = 0.0f,
-                               .maxValue = 1.0f,
-                               .defaultValue = 1.0f};
-    auto setGain = [this](int slot, juce::String name) {
-        hostSlotInfo_[slot] = {.name = std::move(name),
-                               .unit = magda::technicalText(magda::TechnicalTextToken::Decibels),
-                               .scale = magda::ParameterScale::Linear,
-                               .minValue = -24.0f,
-                               .maxValue = 24.0f,
-                               .defaultValue = 0.0f};
-    };
-    setGain(kLowInputSlot, "Low Input");
-    setGain(kMidInputSlot, "Mid Input");
-    setGain(kHighInputSlot, "High Input");
-    setGain(kLowGainSlot, "Low Output");
-    setGain(kMidGainSlot, "Mid Output");
-    setGain(kHighGainSlot, "High Output");
-
-    auto setThreshold = [this](int slot, juce::String name, float defaultValue) {
-        hostSlotInfo_[slot] = {.name = std::move(name),
-                               .unit = magda::technicalText(magda::TechnicalTextToken::Decibels),
-                               .scale = magda::ParameterScale::Linear,
-                               .minValue = -80.0f,
-                               .maxValue = 0.0f,
-                               .defaultValue = defaultValue};
-    };
-    auto setRatio = [this](int slot, juce::String name) {
-        hostSlotInfo_[slot] = {.name = std::move(name),
-                               .scale = magda::ParameterScale::Linear,
-                               .minValue = 0.05f,
-                               .maxValue = kMaxRatio,
-                               .defaultValue = 8.0f};
-    };
-    auto setTiming = [this](int attackSlot, int releaseSlot, const juce::String& bandName) {
-        hostSlotInfo_[attackSlot] = {
-            .name = bandName + " Attack",
-            .unit = magda::technicalText(magda::TechnicalTextToken::Milliseconds),
-            .scale = magda::ParameterScale::Logarithmic,
-            .minValue = 0.1f,
-            .maxValue = 100.0f,
-            .defaultValue = 3.0f,
-            .scaleAnchor = 10.0f};
-        hostSlotInfo_[releaseSlot] = {
-            .name = bandName + " Release",
-            .unit = magda::technicalText(magda::TechnicalTextToken::Milliseconds),
-            .scale = magda::ParameterScale::Logarithmic,
-            .minValue = 5.0f,
-            .maxValue = 1000.0f,
-            .defaultValue = 120.0f,
-            .scaleAnchor = 100.0f};
-    };
-    auto setBand = [this, setThreshold,
-                    setRatio](int lowerThresholdSlot, int upperThresholdSlot, int belowRatioSlot,
-                              int aboveRatioSlot, int rangeSlot, int limitSlot,
-                              juce::String bandName, float lowerDefault, float upperDefault) {
-        setThreshold(lowerThresholdSlot, bandName + " Lower Threshold", lowerDefault);
-        setThreshold(upperThresholdSlot, bandName + " Upper Threshold", upperDefault);
-        setRatio(belowRatioSlot, bandName + " Below Ratio");
-        setRatio(aboveRatioSlot, bandName + " Above Ratio");
-        hostSlotInfo_[rangeSlot] = {.name = bandName + " Range",
-                                    .unit =
-                                        magda::technicalText(magda::TechnicalTextToken::Decibels),
-                                    .scale = magda::ParameterScale::Linear,
-                                    .minValue = 0.0f,
-                                    .maxValue = 48.0f,
-                                    .defaultValue = 24.0f};
-        hostSlotInfo_[limitSlot] = {.name = bandName + " Limit",
-                                    .unit =
-                                        magda::technicalText(magda::TechnicalTextToken::Decibels),
-                                    .scale = magda::ParameterScale::Linear,
-                                    .minValue = -24.0f,
-                                    .maxValue = 12.0f,
-                                    .defaultValue = 0.0f};
-    };
-
-    setBand(kLowLowerThresholdSlot, kLowUpperThresholdSlot, kLowBelowRatioSlot, kLowAboveRatioSlot,
-            kLowRangeSlot, kLowLimitSlot, "Low", -48.0f, -24.0f);
-    setTiming(kLowAttackSlot, kLowReleaseSlot, "Low");
-    setBand(kMidLowerThresholdSlot, kMidUpperThresholdSlot, kMidBelowRatioSlot, kMidAboveRatioSlot,
-            kMidRangeSlot, kMidLimitSlot, "Mid", -48.0f, -24.0f);
-    setTiming(kMidAttackSlot, kMidReleaseSlot, "Mid");
-    setBand(kHighLowerThresholdSlot, kHighUpperThresholdSlot, kHighBelowRatioSlot,
-            kHighAboveRatioSlot, kHighRangeSlot, kHighLimitSlot, "High", -48.0f, -24.0f);
-    setTiming(kHighAttackSlot, kHighReleaseSlot, "High");
-
-    hostSlotInfo_[kLowXoSlot] = {.name = "Low XO",
-                                 .unit = magda::technicalText(magda::TechnicalTextToken::Hertz),
-                                 .scale = magda::ParameterScale::Logarithmic,
-                                 .minValue = 40.0f,
-                                 .maxValue = 500.0f,
-                                 .defaultValue = 120.0f,
-                                 .scaleAnchor = 200.0f};
-    hostSlotInfo_[kHighXoSlot] = {.name = "High XO",
-                                  .unit = magda::technicalText(magda::TechnicalTextToken::Hertz),
-                                  .scale = magda::ParameterScale::Logarithmic,
-                                  .minValue = 500.0f,
-                                  .maxValue = 8000.0f,
-                                  .defaultValue = 2500.0f,
-                                  .scaleAnchor = 2000.0f};
-
-    curveCollapsed_.referTo(state, juce::Identifier("magda_multiband_curve_collapsed"),
-                            getUndoManager(), true);
-
-    juce::NormalisableRange<float> normalisedRange{0.0f, 1.0f};
-    auto* undoManager = getUndoManager();
-
-    for (int i = 0; i < kHostSlotCount; ++i) {
-        const auto& slot = hostSlotInfo_[i];
-        const juce::String id = "magda_multiband_" + slot.name.toLowerCase().replace(" ", "_");
-        const auto info = parameterInfoForSlot(slot);
-        const float defaultNormalized =
-            magda::ParameterUtils::realToNormalized(slot.defaultValue, info);
-        hostCached_[i].referTo(state, juce::Identifier(id), undoManager, defaultNormalized);
-
-        auto param = addParam(
-            id, slot.name, normalisedRange,
-            [info](float normalized) {
-                const float real = magda::ParameterUtils::normalizedToReal(normalized, info);
-                return magda::ParameterUtils::formatValue(real, info);
-            },
-            [info](const juce::String& text) {
-                auto parsed = magda::ParameterUtils::parseValue(text, info);
-                if (parsed)
-                    return magda::ParameterUtils::realToNormalized(*parsed, info);
-                return 0.0f;
-            });
-        param->attachToCurrentValue(hostCached_[i]);
-        hostParams_[i] = param;
-    }
-}
-
-void MagdaMultibandCompiledPlugin::initialise(const te::PluginInitialisationInfo& info) {
-    sampleRate_ = info.sampleRate > 0.0 ? info.sampleRate : 44100.0;
+void MagdaMultibandCompiledPlugin::onPrepare(double, int) {
     updateCrossoverCoefficients(slotDisplayValue(kLowXoSlot), slotDisplayValue(kHighXoSlot));
-    reset();
+    onReset();
 }
 
-void MagdaMultibandCompiledPlugin::deinitialise() {}
-
-void MagdaMultibandCompiledPlugin::reset() {
-    for (auto& c : crossovers_)
-        c.reset();
+void MagdaMultibandCompiledPlugin::onReset() {
+    for (auto& crossover : crossovers_)
+        crossover.reset();
     for (auto& channel : envelopes_)
         channel.fill(0.0f);
     for (auto& channel : gainDb_)
         channel.fill(0.0f);
 }
 
-float MagdaMultibandCompiledPlugin::slotDisplayValue(int slotIndex) const {
-    if (slotIndex < 0 || slotIndex >= kHostSlotCount)
-        return 0.0f;
-    if (auto* p = hostParams_[static_cast<size_t>(slotIndex)].get())
-        return nativeValueToDisplayValue(slotIndex, p->getCurrentValue());
-    return hostSlotInfo_[static_cast<size_t>(slotIndex)].defaultValue;
-}
-
 void MagdaMultibandCompiledPlugin::updateCrossoverCoefficients(float lowXoHz, float highXoHz) {
     lowXoHz = juce::jlimit(40.0f, 500.0f, lowXoHz);
     highXoHz = juce::jlimit(std::max(500.0f, lowXoHz + 10.0f), 8000.0f, highXoHz);
-    for (auto& c : crossovers_)
-        c.setCoefficients(sampleRate_, lowXoHz, highXoHz);
+    for (auto& crossover : crossovers_)
+        crossover.setCoefficients(currentSampleRate(), lowXoHz, highXoHz);
 }
 
-void MagdaMultibandCompiledPlugin::applyToBuffer(const te::PluginRenderContext& fc) {
-    if (!fc.destBuffer || fc.bufferNumSamples <= 0)
-        return;
+void MagdaMultibandCompiledPlugin::processAudio(DeviceProcessContext& context) {
+    // No Faust engine: the Linkwitz-Riley split and the three dynamics stages
+    // are MAGDA's own, so this is the whole block.
 
-    const int hostChannels = std::min(2, fc.destBuffer->getNumChannels());
+    const int hostChannels = std::min(2, context.audio->getNumChannels());
     if (hostChannels <= 0)
         return;
 
@@ -425,18 +358,19 @@ void MagdaMultibandCompiledPlugin::applyToBuffer(const te::PluginRenderContext& 
                                          dbToGain(slotDisplayValue(kMidGainSlot)),
                                          dbToGain(slotDisplayValue(kHighGainSlot))};
 
-    const std::array<float, 3> attackCoeffs{coefficientForMs(bandAttackMs[0], sampleRate_),
-                                            coefficientForMs(bandAttackMs[1], sampleRate_),
-                                            coefficientForMs(bandAttackMs[2], sampleRate_)};
-    const std::array<float, 3> releaseCoeffs{coefficientForMs(bandReleaseMs[0], sampleRate_),
-                                             coefficientForMs(bandReleaseMs[1], sampleRate_),
-                                             coefficientForMs(bandReleaseMs[2], sampleRate_)};
-    const float gainSmoothCoeff = coefficientForMs(5.0f, sampleRate_);
-    const int startSample = fc.bufferStartSample;
-    const int numSamples = fc.bufferNumSamples;
+    const std::array<float, 3> attackCoeffs{coefficientForMs(bandAttackMs[0], currentSampleRate()),
+                                            coefficientForMs(bandAttackMs[1], currentSampleRate()),
+                                            coefficientForMs(bandAttackMs[2], currentSampleRate())};
+    const std::array<float, 3> releaseCoeffs{
+        coefficientForMs(bandReleaseMs[0], currentSampleRate()),
+        coefficientForMs(bandReleaseMs[1], currentSampleRate()),
+        coefficientForMs(bandReleaseMs[2], currentSampleRate())};
+    const float gainSmoothCoeff = coefficientForMs(5.0f, currentSampleRate());
+    const int startSample = context.startSample;
+    const int numSamples = context.numSamples;
 
     for (int ch = 0; ch < hostChannels; ++ch) {
-        float* buffer = fc.destBuffer->getWritePointer(ch, startSample);
+        float* buffer = context.audio->getWritePointer(ch, startSample);
         auto& crossover = crossovers_[static_cast<size_t>(ch)];
         auto& env = envelopes_[static_cast<size_t>(ch)];
         auto& smoothedGainDb = gainDb_[static_cast<size_t>(ch)];
@@ -470,42 +404,12 @@ void MagdaMultibandCompiledPlugin::applyToBuffer(const te::PluginRenderContext& 
             }
 
             const float out = ((1.0f - mix) * splitDry + mix * wet) * outputGain;
-            buffer[i] = std::isfinite(out) ? juce::jlimit(-16.0f, 16.0f, out) : 0.0f;
+            buffer[i] = sanitise(out);
         }
     }
 
-    for (int ch = hostChannels; ch < fc.destBuffer->getNumChannels(); ++ch)
-        fc.destBuffer->clear(ch, startSample, numSamples);
-}
-
-te::AutomatableParameter* MagdaMultibandCompiledPlugin::getSlotParameter(int slotIndex) const {
-    if (slotIndex < 0 || slotIndex >= kHostSlotCount)
-        return nullptr;
-    return hostParams_[static_cast<size_t>(slotIndex)].get();
-}
-
-const MagdaMultibandCompiledPlugin::HostSlotInfo& MagdaMultibandCompiledPlugin::getSlotInfo(
-    int slotIndex) const {
-    static const HostSlotInfo kEmpty;
-    if (slotIndex < 0 || slotIndex >= kHostSlotCount)
-        return kEmpty;
-    return hostSlotInfo_[static_cast<size_t>(slotIndex)];
-}
-
-float MagdaMultibandCompiledPlugin::displayValueToNativeValue(int slotIndex,
-                                                              float displayValue) const {
-    if (slotIndex < 0 || slotIndex >= kHostSlotCount)
-        return displayValue;
-    const auto info = parameterInfoForSlot(hostSlotInfo_[static_cast<size_t>(slotIndex)]);
-    return magda::ParameterUtils::realToNormalized(displayValue, info);
-}
-
-float MagdaMultibandCompiledPlugin::nativeValueToDisplayValue(int slotIndex,
-                                                              float nativeValue) const {
-    if (slotIndex < 0 || slotIndex >= kHostSlotCount)
-        return nativeValue;
-    const auto info = parameterInfoForSlot(hostSlotInfo_[static_cast<size_t>(slotIndex)]);
-    return magda::ParameterUtils::normalizedToReal(nativeValue, info);
+    for (int ch = hostChannels; ch < context.audio->getNumChannels(); ++ch)
+        context.audio->clear(ch, startSample, numSamples);
 }
 
 constexpr AliasSpec kAliases[] = {
@@ -558,9 +462,8 @@ const CompiledPluginSpec& getMagdaMultibandSpec() {
             "Native 3-band dynamics processor with independent lower and upper threshold "
             "regions per band. Ratios above 1:1 compress toward the active threshold; "
             "ratios below 1:1 expand away from it.",
-        .createPlugin = [](const DevicePluginCreationContext& context) -> DevicePluginPtr {
-            return tracktion_adapter::pluginHandle(
-                new MagdaMultibandCompiledPlugin(tracktion_adapter::creationInfo(context)));
+        .createDevice = [](const DevicePluginCreationContext&) -> std::unique_ptr<MagdaDevice> {
+            return std::make_unique<MagdaMultibandCompiledPlugin>();
         },
         .aliases = kAliases,
         .aliasCount = static_cast<int>(sizeof(kAliases) / sizeof(kAliases[0])),

--- a/magda/daw/audio/plugins/compiled/MagdaMultibandCompiledPlugin.hpp
+++ b/magda/daw/audio/plugins/compiled/MagdaMultibandCompiledPlugin.hpp
@@ -1,53 +1,21 @@
 #pragma once
 
-#include <tracktion_engine/tracktion_engine.h>
-
 #include <array>
+#include <vector>
 
-#include "core/ParameterInfo.hpp"
-#include "plugins/compiled/tracktion/CompiledFaustTracktionAdapter.hpp"
+#include "plugins/compiled/MagdaCompiledEffect.hpp"
 
 namespace magda::daw::audio::compiled {
 
 /**
  * @brief Native 3-band dynamics processor with a single flexible transfer curve per band.
  */
-class MagdaMultibandCompiledPlugin : public te::Plugin, public ICompiledFaustPlugin {
+class MagdaMultibandCompiledPlugin : public MagdaCompiledEffect {
   public:
     static const char* xmlTypeName;
 
-    explicit MagdaMultibandCompiledPlugin(const te::PluginCreationInfo& info);
-    ~MagdaMultibandCompiledPlugin() override;
+    MagdaMultibandCompiledPlugin();
 
-    juce::String getName() const override;
-    juce::String getPluginType() override;
-    juce::String getShortName(int) override;
-    juce::String getSelectableDescription() override;
-
-    void initialise(const te::PluginInitialisationInfo& info) override;
-    void deinitialise() override;
-    void reset() override;
-    void applyToBuffer(const te::PluginRenderContext& fc) override;
-
-    bool takesMidiInput() override {
-        return false;
-    }
-    bool takesAudioInput() override {
-        return true;
-    }
-    bool isSynth() override {
-        return false;
-    }
-    bool producesAudioWhenNoAudioInput() override {
-        return false;
-    }
-    double getTailLength() const override {
-        return 0.0;
-    }
-
-    // Slots 0-11 are the compact grid controls.
-    // Slots 12-35 are per-band curve controls edited from the custom panel.
-    // Slots 36-37 are crossover frequencies.
     static constexpr int kAmountSlot = 0;
     static constexpr int kAttackSlot = 1;
     static constexpr int kReleaseSlot = 2;
@@ -88,43 +56,41 @@ class MagdaMultibandCompiledPlugin : public te::Plugin, public ICompiledFaustPlu
     static constexpr int kHighXoSlot = 37;
     static constexpr int kHostSlotCount = 38;
 
-    te::AutomatableParameter* getSlotParameter(int slotIndex) const;
-
-    float displayValueToNativeValue(int slotIndex, float displayValue) const;
-    float nativeValueToDisplayValue(int slotIndex, float nativeValue) const;
-
-    using HostSlotInfo = CompiledHostSlotInfo;
-    const HostSlotInfo& getSlotInfo(int slotIndex) const;
-
+    /// "Collapse knobs" toggle, persisted on the device's state so the user's
+    /// preferred slot layout survives a project reload.
     bool isCurveCollapsed() const {
-        return curveCollapsed_.get();
+        return curveCollapsed_;
     }
     void setCurveCollapsed(bool collapsed) {
         curveCollapsed_ = collapsed;
     }
 
-    // ICompiledFaustPlugin
-    int hostSlotCount() const override {
-        return kHostSlotCount;
+    void flushState(juce::ValueTree& state) override;
+    void restoreState(const juce::ValueTree& state) override;
+
+    juce::String devicePluginId() const override {
+        return xmlTypeName;
     }
-    const CompiledHostSlotInfo& hostSlotInfo(int slotIndex) const override {
-        return getSlotInfo(slotIndex);
+    juce::String deviceName() const override {
+        return "Multiband Dynamics";
     }
-    DeviceParameterHandle hostSlotParameter(int slotIndex) const override {
-        return tracktion_adapter::parameterHandle(getSlotParameter(slotIndex));
+    juce::String deviceShortName() const override {
+        return "Dynamics";
     }
-    float displayToNormalized(int slotIndex, float displayValue) const override {
-        return displayValueToNativeValue(slotIndex, displayValue);
+
+  protected:
+    std::vector<HostSlotInfo> slotInfos() const override;
+    const char* slotIdPrefix() const override {
+        return "magda_multiband_";
     }
-    float normalizedToDisplay(int slotIndex, float normalizedValue) const override {
-        return nativeValueToDisplayValue(slotIndex, normalizedValue);
+    int outputChannelCount() const override {
+        return 2;
     }
+    void onPrepare(double sampleRate, int maximumBlockSize) override;
+    void onReset() override;
+    void processAudio(DeviceProcessContext& context) override;
 
   private:
-    void buildHostParameters();
-    float slotDisplayValue(int slotIndex) const;
-    void updateCrossoverCoefficients(float lowXoHz, float highXoHz);
-
     struct Biquad {
         void setLowPass(double sampleRate, double frequency);
         void setHighPass(double sampleRate, double frequency);
@@ -146,12 +112,10 @@ class MagdaMultibandCompiledPlugin : public te::Plugin, public ICompiledFaustPlu
         Biquad highHp1, highHp2;
     };
 
-    std::array<HostSlotInfo, kHostSlotCount> hostSlotInfo_;
-    std::array<te::AutomatableParameter::Ptr, kHostSlotCount> hostParams_;
-    std::array<juce::CachedValue<float>, kHostSlotCount> hostCached_;
-    juce::CachedValue<bool> curveCollapsed_;
+    bool curveCollapsed_ = true;
 
-    double sampleRate_ = 44100.0;
+    void updateCrossoverCoefficients(float lowXoHz, float highXoHz);
+
     std::array<CrossoverState, 2> crossovers_;
     std::array<std::array<float, 3>, 2> envelopes_{};
     std::array<std::array<float, 3>, 2> gainDb_{};

--- a/magda/daw/audio/plugins/compiled/MagdaPhaserCompiledPlugin.cpp
+++ b/magda/daw/audio/plugins/compiled/MagdaPhaserCompiledPlugin.cpp
@@ -1,368 +1,80 @@
 #include "plugins/compiled/MagdaPhaserCompiledPlugin.hpp"
 
-#include <algorithm>
-#include <cmath>
-#include <map>
-
-#include "core/ParameterUtils.hpp"
+#include "core/ParameterInfo.hpp"
 #include "faust/dsp/dsp.h"
 #include "faust/gui/UI.h"
 #include "faust/gui/meta.h"
 #include "magda_phaser.generated.cpp"
-#include "plugins/FaustMetadataParser.hpp"
-#include "plugins/FaustParamInfo.hpp"
 #include "plugins/compiled/CompiledPluginRegistry.hpp"
-#include "plugins/tracktion/TracktionDeviceAdapters.hpp"
 
 namespace magda::daw::audio::compiled {
 
 const char* MagdaPhaserCompiledPlugin::xmlTypeName = "magda_phaser";
 
-namespace {
-
-struct PhaserHarvest {
-    struct Control {
-        int idx = -1;
-        FaustParamSlot::Kind kind = FaustParamSlot::Kind::Continuous;
-        FAUSTFLOAT* zone = nullptr;
-    };
-    std::vector<Control> controls;
-};
-
-class PhaserHarvester : public ::UI {
-  public:
-    PhaserHarvest harvest;
-
-    void openTabBox(const char*) override {}
-    void openHorizontalBox(const char*) override {}
-    void openVerticalBox(const char*) override {}
-    void closeBox() override {}
-
-    void addButton(const char* label, FAUSTFLOAT* zone) override {
-        emitControl(FaustParamSlot::Kind::Boolean, label, zone);
-    }
-    void addCheckButton(const char* label, FAUSTFLOAT* zone) override {
-        emitControl(FaustParamSlot::Kind::Boolean, label, zone);
-    }
-    void addVerticalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT, FAUSTFLOAT, FAUSTFLOAT,
-                           FAUSTFLOAT) override {
-        emitControl(FaustParamSlot::Kind::Continuous, label, zone);
-    }
-    void addHorizontalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT, FAUSTFLOAT,
-                             FAUSTFLOAT, FAUSTFLOAT) override {
-        emitControl(FaustParamSlot::Kind::Continuous, label, zone);
-    }
-    void addNumEntry(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT, FAUSTFLOAT, FAUSTFLOAT,
-                     FAUSTFLOAT) override {
-        emitControl(FaustParamSlot::Kind::Continuous, label, zone);
-    }
-    void addHorizontalBargraph(const char*, FAUSTFLOAT*, FAUSTFLOAT, FAUSTFLOAT) override {}
-    void addVerticalBargraph(const char*, FAUSTFLOAT*, FAUSTFLOAT, FAUSTFLOAT) override {}
-    void addSoundfile(const char*, const char*, Soundfile**) override {}
-
-    void declare(FAUSTFLOAT* zone, const char* key, const char* value) override {
-        if (zone == nullptr)
-            return;
-        const auto k = juce::String::fromUTF8(key != nullptr ? key : "").toLowerCase();
-        const auto v = juce::String::fromUTF8(value != nullptr ? value : "");
-        applyFaustAnnotation(k, v, pendingByZone_[zone]);
-    }
-
-  private:
-    void emitControl(FaustParamSlot::Kind kind, const char* rawLabel, FAUSTFLOAT* zone) {
-        const auto parsed =
-            parseFaustLabel(juce::String::fromUTF8(rawLabel != nullptr ? rawLabel : ""));
-        ControlMetadata merged = parsed.metadata;
-        if (zone != nullptr) {
-            if (auto it = pendingByZone_.find(zone); it != pendingByZone_.end()) {
-                mergeFaustMetadata(merged, it->second);
-                pendingByZone_.erase(it);
-            }
-        }
-
-        PhaserHarvest::Control c;
-        c.idx = merged.slotIndex;
-        c.kind = merged.isChoiceStyle() ? FaustParamSlot::Kind::Discrete : kind;
-        c.zone = zone;
-        harvest.controls.push_back(std::move(c));
-    }
-
-    std::map<FAUSTFLOAT*, ControlMetadata> pendingByZone_;
-};
-
-const PhaserHarvest::Control* findByIdx(const PhaserHarvest& h, int idx) {
-    for (const auto& c : h.controls)
-        if (c.idx == idx)
-            return &c;
-    return nullptr;
+MagdaPhaserCompiledPlugin::MagdaPhaserCompiledPlugin() {
+    initEffect();
 }
 
-}  // namespace
-
-MagdaPhaserCompiledPlugin::MagdaPhaserCompiledPlugin(const te::PluginCreationInfo& info)
-    : te::Plugin(info) {
-    dsp_ = std::make_unique<MagdaPhaserDsp>();
-    constexpr int kProvisionalSampleRate = 44100;
-    rebuildEngineState(kProvisionalSampleRate);
-    buildHostParameters();
+::dsp* MagdaPhaserCompiledPlugin::createEngineDsp(int) const {
+    return new MagdaPhaserDsp();
 }
 
-MagdaPhaserCompiledPlugin::~MagdaPhaserCompiledPlugin() {
-    notifyListenersOfDeletion();
-    for (auto& p : hostParams_)
-        if (p)
-            p->detachFromCurrentValue();
+std::vector<MagdaPhaserCompiledPlugin::HostSlotInfo> MagdaPhaserCompiledPlugin::slotInfos() const {
+    std::vector<HostSlotInfo> infos(kHostSlotCount);
+    infos[kRateSlot] = {.name = "Rate",
+                        .unit = magda::technicalText(magda::TechnicalTextToken::Hertz),
+                        .scale = magda::ParameterScale::Logarithmic,
+                        .minValue = 0.05f,
+                        .maxValue = 10.0f,
+                        .defaultValue = 0.5f,
+                        .scaleAnchor = 1.0f};
+    infos[kDepthSlot] = {.name = "Depth",
+                         .scale = magda::ParameterScale::Linear,
+                         .minValue = 0.0f,
+                         .maxValue = 2.0f,
+                         .defaultValue = 1.0f};
+    infos[kFeedbackSlot] = {.name = "Feedback",
+                            .scale = magda::ParameterScale::Linear,
+                            .minValue = -0.95f,
+                            .maxValue = 0.95f,
+                            .defaultValue = 0.3f};
+    infos[kStagesSlot].name = "Stages";
+    infos[kStagesSlot].scale = magda::ParameterScale::Discrete;
+    infos[kStagesSlot].choices = {"2", "4", "6", "8"};
+    infos[kStagesSlot].minValue = 0.0f;
+    infos[kStagesSlot].maxValue = static_cast<float>(infos[kStagesSlot].choices.size() - 1);
+    infos[kStagesSlot].defaultValue = 1.0f;
+    infos[kMinHzSlot] = {.name = "Min Hz",
+                         .unit = magda::technicalText(magda::TechnicalTextToken::Hertz),
+                         .scale = magda::ParameterScale::Logarithmic,
+                         .minValue = 30.0f,
+                         .maxValue = 1000.0f,
+                         .defaultValue = 100.0f,
+                         .scaleAnchor = 200.0f};
+    infos[kMaxHzSlot] = {.name = "Max Hz",
+                         .unit = magda::technicalText(magda::TechnicalTextToken::Hertz),
+                         .scale = magda::ParameterScale::Logarithmic,
+                         .minValue = 500.0f,
+                         .maxValue = 8000.0f,
+                         .defaultValue = 2000.0f,
+                         .scaleAnchor = 2000.0f};
+    infos[kMixSlot] = {.name = "Mix",
+                       .scale = magda::ParameterScale::Linear,
+                       .minValue = 0.0f,
+                       .maxValue = 1.0f,
+                       .defaultValue = 0.6f};
+
+    return infos;
 }
 
-juce::String MagdaPhaserCompiledPlugin::getName() const {
-    return "Phaser";
-}
-juce::String MagdaPhaserCompiledPlugin::getPluginType() {
-    return xmlTypeName;
-}
-juce::String MagdaPhaserCompiledPlugin::getShortName(int) {
-    return "Phaser";
-}
-juce::String MagdaPhaserCompiledPlugin::getSelectableDescription() {
-    return "Phaser";
-}
-
-void MagdaPhaserCompiledPlugin::rebuildEngineState(int sampleRate) {
-    if (!dsp_)
-        return;
-    dsp_->init(sampleRate);
-    numInputs_ = dsp_->getNumInputs();
-    numOutputs_ = dsp_->getNumOutputs();
-
-    PhaserHarvester harvester;
-    dsp_->buildUserInterface(&harvester);
-
-    zones_.fill(nullptr);
-    for (int i = 0; i < kHostSlotCount; ++i) {
-        if (auto* c = findByIdx(harvester.harvest, i))
-            zones_[static_cast<size_t>(i)] = c->zone;
-    }
-}
-
-void MagdaPhaserCompiledPlugin::buildHostParameters() {
-    hostSlotInfo_[kRateSlot] = {.name = "Rate",
-                                .unit = magda::technicalText(magda::TechnicalTextToken::Hertz),
-                                .scale = magda::ParameterScale::Logarithmic,
-                                .minValue = 0.05f,
-                                .maxValue = 10.0f,
-                                .defaultValue = 0.5f,
-                                .scaleAnchor = 1.0f};
-    hostSlotInfo_[kDepthSlot] = {.name = "Depth",
-                                 .scale = magda::ParameterScale::Linear,
-                                 .minValue = 0.0f,
-                                 .maxValue = 2.0f,
-                                 .defaultValue = 1.0f};
-    hostSlotInfo_[kFeedbackSlot] = {.name = "Feedback",
-                                    .scale = magda::ParameterScale::Linear,
-                                    .minValue = -0.95f,
-                                    .maxValue = 0.95f,
-                                    .defaultValue = 0.3f};
-    hostSlotInfo_[kStagesSlot].name = "Stages";
-    hostSlotInfo_[kStagesSlot].scale = magda::ParameterScale::Discrete;
-    hostSlotInfo_[kStagesSlot].choices = {"2", "4", "6", "8"};
-    hostSlotInfo_[kStagesSlot].minValue = 0.0f;
-    hostSlotInfo_[kStagesSlot].maxValue =
-        static_cast<float>(hostSlotInfo_[kStagesSlot].choices.size() - 1);
-    hostSlotInfo_[kStagesSlot].defaultValue = 1.0f;
-    hostSlotInfo_[kMinHzSlot] = {.name = "Min Hz",
-                                 .unit = magda::technicalText(magda::TechnicalTextToken::Hertz),
-                                 .scale = magda::ParameterScale::Logarithmic,
-                                 .minValue = 30.0f,
-                                 .maxValue = 1000.0f,
-                                 .defaultValue = 100.0f,
-                                 .scaleAnchor = 200.0f};
-    hostSlotInfo_[kMaxHzSlot] = {.name = "Max Hz",
-                                 .unit = magda::technicalText(magda::TechnicalTextToken::Hertz),
-                                 .scale = magda::ParameterScale::Logarithmic,
-                                 .minValue = 500.0f,
-                                 .maxValue = 8000.0f,
-                                 .defaultValue = 2000.0f,
-                                 .scaleAnchor = 2000.0f};
-    hostSlotInfo_[kMixSlot] = {.name = "Mix",
-                               .scale = magda::ParameterScale::Linear,
-                               .minValue = 0.0f,
-                               .maxValue = 1.0f,
-                               .defaultValue = 0.6f};
-
-    juce::NormalisableRange<float> normalisedRange{0.0f, 1.0f};
-    auto* undoManager = getUndoManager();
-
-    auto buildInfo = [](const HostSlotInfo& s) {
-        magda::ParameterInfo info;
-        info.minValue = s.minValue;
-        info.maxValue = s.maxValue;
-        info.defaultValue = s.defaultValue;
-        info.unit = s.unit;
-        info.scale = s.scale;
-        if (std::isfinite(s.scaleAnchor))
-            info.scaleAnchor = s.scaleAnchor;
-        info.choices = s.choices;
-        return info;
-    };
-
-    for (int i = 0; i < kHostSlotCount; ++i) {
-        const auto& slot = hostSlotInfo_[i];
-        const juce::String id = "magda_phaser_" + slot.name.toLowerCase().replace(" ", "_");
-        const juce::Identifier identifier(id);
-        const auto info = buildInfo(slot);
-        const float defaultNormalized =
-            magda::ParameterUtils::realToNormalized(slot.defaultValue, info);
-        hostCached_[i].referTo(state, identifier, undoManager, defaultNormalized);
-
-        auto param = addParam(
-            id, slot.name, normalisedRange,
-            [info](float normalized) {
-                const float real = magda::ParameterUtils::normalizedToReal(normalized, info);
-                return magda::ParameterUtils::formatValue(real, info);
-            },
-            [info](const juce::String& text) {
-                auto parsed = magda::ParameterUtils::parseValue(text, info);
-                if (parsed)
-                    return magda::ParameterUtils::realToNormalized(*parsed, info);
-                return 0.0f;
-            });
-        param->attachToCurrentValue(hostCached_[i]);
-        hostParams_[i] = param;
-    }
-}
-
-void MagdaPhaserCompiledPlugin::initialise(const te::PluginInitialisationInfo& info) {
-    rebuildEngineState(static_cast<int>(info.sampleRate));
-    scratchIn_.setSize(numInputs_, info.blockSizeSamples, false, true, true);
-    scratchOut_.setSize(numOutputs_, info.blockSizeSamples, false, true, true);
-    inPtrs_.assign(static_cast<size_t>(numInputs_), nullptr);
-    outPtrs_.assign(static_cast<size_t>(numOutputs_), nullptr);
-}
-
-void MagdaPhaserCompiledPlugin::deinitialise() {
-    scratchIn_.setSize(0, 0);
-    scratchOut_.setSize(0, 0);
-    inPtrs_.clear();
-    outPtrs_.clear();
-}
-
-void MagdaPhaserCompiledPlugin::reset() {
-    if (dsp_)
-        dsp_->instanceClear();
-}
-
-void MagdaPhaserCompiledPlugin::applyToBuffer(const te::PluginRenderContext& fc) {
-    if (!fc.destBuffer || fc.bufferNumSamples <= 0 || !dsp_)
-        return;
-
-    auto writeSlot = [&](int slot) {
-        if (auto* zone = zones_[static_cast<size_t>(slot)]) {
-            const auto& s = hostSlotInfo_[static_cast<size_t>(slot)];
-            magda::ParameterInfo info;
-            info.minValue = s.minValue;
-            info.maxValue = s.maxValue;
-            info.scale = s.scale;
-            if (std::isfinite(s.scaleAnchor))
-                info.scaleAnchor = s.scaleAnchor;
-            info.choices = s.choices;
-            const float norm = hostParams_[static_cast<size_t>(slot)]->getCurrentValue();
-            *zone = static_cast<FAUSTFLOAT>(magda::ParameterUtils::normalizedToReal(norm, info));
-        }
-    };
-    for (int i = 0; i < kHostSlotCount; ++i)
-        writeSlot(i);
-
-    if (auto* minHz = zones_[kMinHzSlot]; minHz != nullptr) {
-        if (auto* maxHz = zones_[kMaxHzSlot]; maxHz != nullptr) {
-            if (*minHz >= *maxHz - 1.0f)
-                *minHz = *maxHz - 1.0f;
-        }
-    }
-
-    const int numSamples = fc.bufferNumSamples;
-    const int startSample = fc.bufferStartSample;
-    const int hostChannels = fc.destBuffer->getNumChannels();
-    if (hostChannels <= 0 || numInputs_ <= 0 || numOutputs_ <= 0)
-        return;
-
-    if (scratchIn_.getNumChannels() < numInputs_ || scratchIn_.getNumSamples() < numSamples)
-        scratchIn_.setSize(numInputs_, numSamples, false, true, true);
-    if (scratchOut_.getNumChannels() < numOutputs_ || scratchOut_.getNumSamples() < numSamples)
-        scratchOut_.setSize(numOutputs_, numSamples, false, true, true);
-    if (static_cast<int>(inPtrs_.size()) < numInputs_)
-        inPtrs_.resize(static_cast<size_t>(numInputs_), nullptr);
-    if (static_cast<int>(outPtrs_.size()) < numOutputs_)
-        outPtrs_.resize(static_cast<size_t>(numOutputs_), nullptr);
-
-    for (int ch = 0; ch < numInputs_; ++ch) {
-        float* dst = scratchIn_.getWritePointer(ch);
-        if (ch < hostChannels) {
-            const float* src = fc.destBuffer->getReadPointer(ch, startSample);
-            std::copy(src, src + numSamples, dst);
-        } else {
-            std::fill(dst, dst + numSamples, 0.0f);
-        }
-        inPtrs_[static_cast<size_t>(ch)] = dst;
-    }
-    for (int ch = 0; ch < numOutputs_; ++ch) {
-        outPtrs_[static_cast<size_t>(ch)] = (ch < hostChannels)
-                                                ? fc.destBuffer->getWritePointer(ch, startSample)
-                                                : scratchOut_.getWritePointer(ch);
-    }
-
-    dsp_->compute(numSamples, inPtrs_.data(), outPtrs_.data());
-
-    const int channelsToSanitise = std::min(hostChannels, numOutputs_);
-    for (int ch = 0; ch < channelsToSanitise; ++ch) {
-        float* out = fc.destBuffer->getWritePointer(ch, startSample);
-        for (int i = 0; i < numSamples; ++i) {
-            const float sample = out[i];
-            out[i] = std::isfinite(sample) ? juce::jlimit(-16.0f, 16.0f, sample) : 0.0f;
-        }
-    }
-}
-
-te::AutomatableParameter* MagdaPhaserCompiledPlugin::getSlotParameter(int slotIndex) const {
-    if (slotIndex < 0 || slotIndex >= kHostSlotCount)
-        return nullptr;
-    return hostParams_[static_cast<size_t>(slotIndex)].get();
-}
-
-const MagdaPhaserCompiledPlugin::HostSlotInfo& MagdaPhaserCompiledPlugin::getSlotInfo(
-    int slotIndex) const {
-    static const HostSlotInfo kEmpty;
-    if (slotIndex < 0 || slotIndex >= kHostSlotCount)
-        return kEmpty;
-    return hostSlotInfo_[static_cast<size_t>(slotIndex)];
-}
-
-float MagdaPhaserCompiledPlugin::displayValueToNativeValue(int slotIndex,
-                                                           float displayValue) const {
-    if (slotIndex < 0 || slotIndex >= kHostSlotCount)
-        return displayValue;
-    const auto& s = hostSlotInfo_[static_cast<size_t>(slotIndex)];
-    magda::ParameterInfo info;
-    info.minValue = s.minValue;
-    info.maxValue = s.maxValue;
-    info.scale = s.scale;
-    if (std::isfinite(s.scaleAnchor))
-        info.scaleAnchor = s.scaleAnchor;
-    info.choices = s.choices;
-    return magda::ParameterUtils::realToNormalized(displayValue, info);
-}
-
-float MagdaPhaserCompiledPlugin::nativeValueToDisplayValue(int slotIndex, float nativeValue) const {
-    if (slotIndex < 0 || slotIndex >= kHostSlotCount)
-        return nativeValue;
-    const auto& s = hostSlotInfo_[static_cast<size_t>(slotIndex)];
-    magda::ParameterInfo info;
-    info.minValue = s.minValue;
-    info.maxValue = s.maxValue;
-    info.scale = s.scale;
-    if (std::isfinite(s.scaleAnchor))
-        info.scaleAnchor = s.scaleAnchor;
-    info.choices = s.choices;
-    return magda::ParameterUtils::normalizedToReal(nativeValue, info);
+void MagdaPhaserCompiledPlugin::writeExtraZones(int engineIndex) {
+    // The sweep's endpoints are independent parameters, so the user can put Min
+    // above Max. Keep at least a hertz between them: the dsp divides by the
+    // span, and an inverted one sweeps backwards through its own allpass chain.
+    auto* minHz = zoneForIdx(engineIndex, kMinHzSlot);
+    auto* maxHz = zoneForIdx(engineIndex, kMaxHzSlot);
+    if (minHz != nullptr && maxHz != nullptr && *minHz >= *maxHz - 1.0f)
+        *minHz = *maxHz - 1.0f;
 }
 
 constexpr AliasSpec kAliases[] = {
@@ -385,9 +97,8 @@ const CompiledPluginSpec& getMagdaPhaserSpec() {
                        "Rate and Depth drive the sweep; Feedback intensifies the resonance; "
                        "Min Hz and Max Hz bound the sweep window. "
                        "Mix blends wet against dry.",
-        .createPlugin = [](const DevicePluginCreationContext& context) -> DevicePluginPtr {
-            return tracktion_adapter::pluginHandle(
-                new MagdaPhaserCompiledPlugin(tracktion_adapter::creationInfo(context)));
+        .createDevice = [](const DevicePluginCreationContext&) -> std::unique_ptr<MagdaDevice> {
+            return std::make_unique<MagdaPhaserCompiledPlugin>();
         },
         .aliases = kAliases,
         .aliasCount = static_cast<int>(sizeof(kAliases) / sizeof(kAliases[0])),

--- a/magda/daw/audio/plugins/compiled/MagdaPhaserCompiledPlugin.hpp
+++ b/magda/daw/audio/plugins/compiled/MagdaPhaserCompiledPlugin.hpp
@@ -1,14 +1,8 @@
 #pragma once
 
-#include <tracktion_engine/tracktion_engine.h>
-
-#include <array>
-#include <memory>
 #include <vector>
 
-#include "../FaustParamPool.hpp"
-#include "core/ParameterInfo.hpp"
-#include "plugins/compiled/tracktion/CompiledFaustTracktionAdapter.hpp"
+#include "plugins/compiled/MagdaCompiledEffect.hpp"
 
 class dsp;
 
@@ -20,40 +14,12 @@ namespace magda::daw::audio::compiled {
  * Hosts magda_phaser.dsp as a native Tracktion plugin. Every host control maps
  * 1:1 to a Faust slot pinned by [idx:N].
  */
-class MagdaPhaserCompiledPlugin : public te::Plugin, public ICompiledFaustPlugin {
+class MagdaPhaserCompiledPlugin : public MagdaCompiledEffect {
   public:
     static const char* xmlTypeName;
 
-    explicit MagdaPhaserCompiledPlugin(const te::PluginCreationInfo& info);
-    ~MagdaPhaserCompiledPlugin() override;
+    MagdaPhaserCompiledPlugin();
 
-    juce::String getName() const override;
-    juce::String getPluginType() override;
-    juce::String getShortName(int) override;
-    juce::String getSelectableDescription() override;
-
-    void initialise(const te::PluginInitialisationInfo& info) override;
-    void deinitialise() override;
-    void reset() override;
-    void applyToBuffer(const te::PluginRenderContext& fc) override;
-
-    bool takesMidiInput() override {
-        return false;
-    }
-    bool takesAudioInput() override {
-        return true;
-    }
-    bool isSynth() override {
-        return false;
-    }
-    bool producesAudioWhenNoAudioInput() override {
-        return false;
-    }
-    double getTailLength() const override {
-        return 0.0;
-    }
-
-    // Slot ordering matches the [idx:N] pins inside magda_phaser.dsp.
     static constexpr int kRateSlot = 0;
     static constexpr int kDepthSlot = 1;
     static constexpr int kFeedbackSlot = 2;
@@ -63,50 +29,22 @@ class MagdaPhaserCompiledPlugin : public te::Plugin, public ICompiledFaustPlugin
     static constexpr int kMixSlot = 6;
     static constexpr int kHostSlotCount = 7;
 
-    te::AutomatableParameter* getSlotParameter(int slotIndex) const;
+    juce::String devicePluginId() const override {
+        return xmlTypeName;
+    }
+    juce::String deviceName() const override {
+        return "Phaser";
+    }
 
-    float displayValueToNativeValue(int slotIndex, float displayValue) const;
-    float nativeValueToDisplayValue(int slotIndex, float nativeValue) const;
-
-    using HostSlotInfo = CompiledHostSlotInfo;
-    const HostSlotInfo& getSlotInfo(int slotIndex) const;
-
-    // ICompiledFaustPlugin
-    int hostSlotCount() const override {
-        return kHostSlotCount;
+  protected:
+    ::dsp* createEngineDsp(int engineIndex) const override;
+    std::vector<HostSlotInfo> slotInfos() const override;
+    const char* slotIdPrefix() const override {
+        return "magda_phaser_";
     }
-    const CompiledHostSlotInfo& hostSlotInfo(int slotIndex) const override {
-        return getSlotInfo(slotIndex);
-    }
-    DeviceParameterHandle hostSlotParameter(int slotIndex) const override {
-        return tracktion_adapter::parameterHandle(getSlotParameter(slotIndex));
-    }
-    float displayToNormalized(int slotIndex, float displayValue) const override {
-        return displayValueToNativeValue(slotIndex, displayValue);
-    }
-    float normalizedToDisplay(int slotIndex, float normalizedValue) const override {
-        return nativeValueToDisplayValue(slotIndex, normalizedValue);
-    }
+    void writeExtraZones(int engineIndex) override;
 
   private:
-    void buildHostParameters();
-    void rebuildEngineState(int sampleRate);
-
-    std::unique_ptr<::dsp> dsp_;
-    int numInputs_ = 0;
-    int numOutputs_ = 0;
-
-    std::array<FAUSTFLOAT*, kHostSlotCount> zones_{};
-
-    std::array<HostSlotInfo, kHostSlotCount> hostSlotInfo_;
-    std::array<te::AutomatableParameter::Ptr, kHostSlotCount> hostParams_;
-    std::array<juce::CachedValue<float>, kHostSlotCount> hostCached_;
-
-    juce::AudioBuffer<float> scratchIn_;
-    juce::AudioBuffer<float> scratchOut_;
-    std::vector<float*> inPtrs_;
-    std::vector<float*> outPtrs_;
-
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(MagdaPhaserCompiledPlugin)
 };
 

--- a/magda/daw/audio/plugins/compiled/MagdaPitchCompiledPlugin.cpp
+++ b/magda/daw/audio/plugins/compiled/MagdaPitchCompiledPlugin.cpp
@@ -1,380 +1,75 @@
 #include "plugins/compiled/MagdaPitchCompiledPlugin.hpp"
 
-#include <algorithm>
-#include <cmath>
-#include <map>
-
-#include "core/ParameterUtils.hpp"
+#include "core/ParameterInfo.hpp"
 #include "faust/dsp/dsp.h"
 #include "faust/gui/UI.h"
 #include "faust/gui/meta.h"
 #include "magda_pitch_detuner.generated.cpp"
 #include "magda_pitch_harmonizer.generated.cpp"
 #include "magda_pitch_shifter.generated.cpp"
-#include "plugins/FaustMetadataParser.hpp"
-#include "plugins/FaustParamInfo.hpp"
 #include "plugins/compiled/CompiledPluginRegistry.hpp"
-#include "plugins/tracktion/TracktionDeviceAdapters.hpp"
 
 namespace magda::daw::audio::compiled {
 
 const char* MagdaPitchCompiledPlugin::xmlTypeName = "magda_pitch";
 
-namespace {
+MagdaPitchCompiledPlugin::MagdaPitchCompiledPlugin() {
+    initEffect();
+}
 
-struct EngineHarvest {
-    struct Control {
-        int idx = -1;
-        FaustParamSlot::Kind kind = FaustParamSlot::Kind::Continuous;
-        FAUSTFLOAT* zone = nullptr;
-    };
-    std::vector<Control> controls;
-};
-
-class EngineHarvester : public ::UI {
-  public:
-    EngineHarvest harvest;
-
-    void openTabBox(const char*) override {}
-    void openHorizontalBox(const char*) override {}
-    void openVerticalBox(const char*) override {}
-    void closeBox() override {}
-
-    void addButton(const char* label, FAUSTFLOAT* zone) override {
-        emitControl(FaustParamSlot::Kind::Boolean, label, zone);
+::dsp* MagdaPitchCompiledPlugin::createEngineDsp(int engineIndex) const {
+    switch (static_cast<PitchEngine>(engineIndex)) {
+        case PitchEngine::Shifter:
+            return new MagdaPitchShifterDsp();
+        case PitchEngine::Detuner:
+            return new MagdaPitchDetunerDsp();
+        case PitchEngine::Harmonizer:
+            return new MagdaPitchHarmonizerDsp();
     }
-    void addCheckButton(const char* label, FAUSTFLOAT* zone) override {
-        emitControl(FaustParamSlot::Kind::Boolean, label, zone);
-    }
-    void addVerticalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT, FAUSTFLOAT, FAUSTFLOAT,
-                           FAUSTFLOAT) override {
-        emitControl(FaustParamSlot::Kind::Continuous, label, zone);
-    }
-    void addHorizontalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT, FAUSTFLOAT,
-                             FAUSTFLOAT, FAUSTFLOAT) override {
-        emitControl(FaustParamSlot::Kind::Continuous, label, zone);
-    }
-    void addNumEntry(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT, FAUSTFLOAT, FAUSTFLOAT,
-                     FAUSTFLOAT) override {
-        emitControl(FaustParamSlot::Kind::Continuous, label, zone);
-    }
-    void addHorizontalBargraph(const char*, FAUSTFLOAT*, FAUSTFLOAT, FAUSTFLOAT) override {}
-    void addVerticalBargraph(const char*, FAUSTFLOAT*, FAUSTFLOAT, FAUSTFLOAT) override {}
-    void addSoundfile(const char*, const char*, Soundfile**) override {}
-
-    void declare(FAUSTFLOAT* zone, const char* key, const char* value) override {
-        if (zone == nullptr)
-            return;
-        const auto k = juce::String::fromUTF8(key != nullptr ? key : "").toLowerCase();
-        const auto v = juce::String::fromUTF8(value != nullptr ? value : "");
-        applyFaustAnnotation(k, v, pendingByZone_[zone]);
-    }
-
-  private:
-    void emitControl(FaustParamSlot::Kind kind, const char* rawLabel, FAUSTFLOAT* zone) {
-        const auto parsed =
-            parseFaustLabel(juce::String::fromUTF8(rawLabel != nullptr ? rawLabel : ""));
-        ControlMetadata merged = parsed.metadata;
-        if (zone != nullptr) {
-            if (auto it = pendingByZone_.find(zone); it != pendingByZone_.end()) {
-                mergeFaustMetadata(merged, it->second);
-                pendingByZone_.erase(it);
-            }
-        }
-
-        EngineHarvest::Control c;
-        c.idx = merged.slotIndex;
-        c.kind = merged.isChoiceStyle() ? FaustParamSlot::Kind::Discrete : kind;
-        c.zone = zone;
-        harvest.controls.push_back(std::move(c));
-    }
-
-    std::map<FAUSTFLOAT*, ControlMetadata> pendingByZone_;
-};
-
-const EngineHarvest::Control* findByIdx(const EngineHarvest& h, int idx) {
-    for (const auto& c : h.controls)
-        if (c.idx == idx)
-            return &c;
     return nullptr;
 }
 
-magda::ParameterInfo parameterInfoForSlot(const CompiledHostSlotInfo& s) {
-    magda::ParameterInfo info;
-    info.minValue = s.minValue;
-    info.maxValue = s.maxValue;
-    info.defaultValue = s.defaultValue;
-    info.unit = s.unit;
-    info.scale = s.scale;
-    if (std::isfinite(s.scaleAnchor))
-        info.scaleAnchor = s.scaleAnchor;
-    info.choices = s.choices;
-    return info;
-}
+std::vector<MagdaPitchCompiledPlugin::HostSlotInfo> MagdaPitchCompiledPlugin::slotInfos() const {
+    std::vector<HostSlotInfo> infos(kHostSlotCount);
+    infos[kEngineSlot].name = "Engine";
+    infos[kEngineSlot].scale = magda::ParameterScale::Discrete;
+    infos[kEngineSlot].choices = {"Shifter", "Detuner", "Harmonizer"};
+    infos[kEngineSlot].minValue = 0.0f;
+    infos[kEngineSlot].maxValue = static_cast<float>(infos[kEngineSlot].choices.size() - 1);
+    infos[kEngineSlot].defaultValue = 0.0f;
 
-}  // namespace
+    infos[kPitchSlot] = {.name = "Pitch",
+                         .unit = magda::technicalText(magda::TechnicalTextToken::Semitones),
+                         .scale = magda::ParameterScale::Linear,
+                         .minValue = -24.0f,
+                         .maxValue = 24.0f,
+                         .defaultValue = 0.0f};
+    infos[kFineSlot] = {.name = "Fine",
+                        .unit = "cents",
+                        .scale = magda::ParameterScale::Linear,
+                        .minValue = -100.0f,
+                        .maxValue = 100.0f,
+                        .defaultValue = 0.0f};
+    infos[kTextureSlot] = {.name = "Texture",
+                           .unit = magda::technicalText(magda::TechnicalTextToken::Milliseconds),
+                           .scale = magda::ParameterScale::Logarithmic,
+                           .minValue = 8.0f,
+                           .maxValue = 200.0f,
+                           .defaultValue = 50.0f,
+                           .scaleAnchor = 50.0f};
+    infos[kMixSlot] = {.name = "Mix",
+                       .scale = magda::ParameterScale::Linear,
+                       .minValue = 0.0f,
+                       .maxValue = 1.0f,
+                       .defaultValue = 1.0f};
+    infos[kOutputSlot] = {.name = "Output",
+                          .unit = magda::technicalText(magda::TechnicalTextToken::Decibels),
+                          .scale = magda::ParameterScale::Linear,
+                          .minValue = -24.0f,
+                          .maxValue = 12.0f,
+                          .defaultValue = 0.0f};
 
-MagdaPitchCompiledPlugin::MagdaPitchCompiledPlugin(const te::PluginCreationInfo& info)
-    : te::Plugin(info) {
-    engines_[static_cast<size_t>(PitchEngine::Shifter)].dsp =
-        std::make_unique<MagdaPitchShifterDsp>();
-    engines_[static_cast<size_t>(PitchEngine::Detuner)].dsp =
-        std::make_unique<MagdaPitchDetunerDsp>();
-    engines_[static_cast<size_t>(PitchEngine::Harmonizer)].dsp =
-        std::make_unique<MagdaPitchHarmonizerDsp>();
-
-    constexpr int kProvisionalSampleRate = 44100;
-    rebuildEngineState(kProvisionalSampleRate);
-    buildHostParameters();
-}
-
-MagdaPitchCompiledPlugin::~MagdaPitchCompiledPlugin() {
-    notifyListenersOfDeletion();
-    for (auto& p : hostParams_)
-        if (p)
-            p->detachFromCurrentValue();
-}
-
-juce::String MagdaPitchCompiledPlugin::getName() const {
-    return "Pitch";
-}
-juce::String MagdaPitchCompiledPlugin::getPluginType() {
-    return xmlTypeName;
-}
-juce::String MagdaPitchCompiledPlugin::getShortName(int) {
-    return "Pitch";
-}
-juce::String MagdaPitchCompiledPlugin::getSelectableDescription() {
-    return "Pitch";
-}
-
-void MagdaPitchCompiledPlugin::rebuildEngineState(int sampleRate) {
-    for (auto& e : engines_) {
-        if (!e.dsp)
-            continue;
-        e.dsp->init(sampleRate);
-        e.numInputs = e.dsp->getNumInputs();
-        e.numOutputs = e.dsp->getNumOutputs();
-
-        EngineHarvester harvester;
-        e.dsp->buildUserInterface(&harvester);
-
-        e.zones.fill(nullptr);
-        // Slot 0 (Engine) is wrapper-only. Slots 1..5 come from the DSP.
-        for (int i = 1; i < kHostSlotCount; ++i) {
-            if (auto* c = findByIdx(harvester.harvest, i))
-                e.zones[static_cast<size_t>(i)] = c->zone;
-        }
-    }
-}
-
-void MagdaPitchCompiledPlugin::buildHostParameters() {
-    hostSlotInfo_[kEngineSlot].name = "Engine";
-    hostSlotInfo_[kEngineSlot].scale = magda::ParameterScale::Discrete;
-    hostSlotInfo_[kEngineSlot].choices = {"Shifter", "Detuner", "Harmonizer"};
-    hostSlotInfo_[kEngineSlot].minValue = 0.0f;
-    hostSlotInfo_[kEngineSlot].maxValue =
-        static_cast<float>(hostSlotInfo_[kEngineSlot].choices.size() - 1);
-    hostSlotInfo_[kEngineSlot].defaultValue = 0.0f;
-
-    hostSlotInfo_[kPitchSlot] = {.name = "Pitch",
-                                 .unit = magda::technicalText(magda::TechnicalTextToken::Semitones),
-                                 .scale = magda::ParameterScale::Linear,
-                                 .minValue = -24.0f,
-                                 .maxValue = 24.0f,
-                                 .defaultValue = 0.0f};
-    hostSlotInfo_[kFineSlot] = {.name = "Fine",
-                                .unit = "cents",
-                                .scale = magda::ParameterScale::Linear,
-                                .minValue = -100.0f,
-                                .maxValue = 100.0f,
-                                .defaultValue = 0.0f};
-    hostSlotInfo_[kTextureSlot] = {
-        .name = "Texture",
-        .unit = magda::technicalText(magda::TechnicalTextToken::Milliseconds),
-        .scale = magda::ParameterScale::Logarithmic,
-        .minValue = 8.0f,
-        .maxValue = 200.0f,
-        .defaultValue = 50.0f,
-        .scaleAnchor = 50.0f};
-    hostSlotInfo_[kMixSlot] = {.name = "Mix",
-                               .scale = magda::ParameterScale::Linear,
-                               .minValue = 0.0f,
-                               .maxValue = 1.0f,
-                               .defaultValue = 1.0f};
-    hostSlotInfo_[kOutputSlot] = {.name = "Output",
-                                  .unit = magda::technicalText(magda::TechnicalTextToken::Decibels),
-                                  .scale = magda::ParameterScale::Linear,
-                                  .minValue = -24.0f,
-                                  .maxValue = 12.0f,
-                                  .defaultValue = 0.0f};
-
-    juce::NormalisableRange<float> normalisedRange{0.0f, 1.0f};
-    auto* undoManager = getUndoManager();
-
-    for (int i = 0; i < kHostSlotCount; ++i) {
-        const auto& slot = hostSlotInfo_[i];
-        const juce::String id = "magda_pitch_" + slot.name.toLowerCase().replace(" ", "_");
-        const juce::Identifier identifier(id);
-        const auto info = parameterInfoForSlot(slot);
-        const float defaultNormalized =
-            magda::ParameterUtils::realToNormalized(slot.defaultValue, info);
-        hostCached_[i].referTo(state, identifier, undoManager, defaultNormalized);
-
-        auto param = addParam(
-            id, slot.name, normalisedRange,
-            [info](float normalized) {
-                const float real = magda::ParameterUtils::normalizedToReal(normalized, info);
-                return magda::ParameterUtils::formatValue(real, info);
-            },
-            [info](const juce::String& text) {
-                auto parsed = magda::ParameterUtils::parseValue(text, info);
-                if (parsed)
-                    return magda::ParameterUtils::realToNormalized(*parsed, info);
-                return 0.0f;
-            });
-        param->attachToCurrentValue(hostCached_[i]);
-        hostParams_[i] = param;
-    }
-}
-
-void MagdaPitchCompiledPlugin::initialise(const te::PluginInitialisationInfo& info) {
-    rebuildEngineState(static_cast<int>(info.sampleRate));
-
-    int maxIn = 0, maxOut = 0;
-    for (const auto& e : engines_) {
-        maxIn = std::max(maxIn, e.numInputs);
-        maxOut = std::max(maxOut, e.numOutputs);
-    }
-    scratchIn_.setSize(maxIn, info.blockSizeSamples, false, true, true);
-    scratchOut_.setSize(maxOut, info.blockSizeSamples, false, true, true);
-    inPtrs_.assign(static_cast<size_t>(maxIn), nullptr);
-    outPtrs_.assign(static_cast<size_t>(maxOut), nullptr);
-}
-
-void MagdaPitchCompiledPlugin::deinitialise() {
-    scratchIn_.setSize(0, 0);
-    scratchOut_.setSize(0, 0);
-    inPtrs_.clear();
-    outPtrs_.clear();
-}
-
-void MagdaPitchCompiledPlugin::reset() {
-    for (auto& e : engines_)
-        if (e.dsp)
-            e.dsp->instanceClear();
-}
-
-void MagdaPitchCompiledPlugin::applyToBuffer(const te::PluginRenderContext& fc) {
-    if (!fc.destBuffer || fc.bufferNumSamples <= 0)
-        return;
-
-    auto realForSlot = [&](int slot) -> float {
-        const auto& s = hostSlotInfo_[static_cast<size_t>(slot)];
-        const auto info = parameterInfoForSlot(s);
-        const float norm = hostParams_[static_cast<size_t>(slot)]->getCurrentValue();
-        return magda::ParameterUtils::normalizedToReal(norm, info);
-    };
-
-    const float engineNorm = hostParams_[kEngineSlot]->getCurrentValue();
-    const int engineIndex = juce::jlimit(
-        0, kEngineCount - 1,
-        static_cast<int>(std::round(engineNorm * static_cast<float>(kEngineCount - 1))));
-    activeEngine_.store(engineIndex);
-
-    for (int slot = 1; slot < kHostSlotCount; ++slot) {
-        const float real = realForSlot(slot);
-        for (auto& e : engines_) {
-            if (auto* zone = e.zones[static_cast<size_t>(slot)])
-                *zone = static_cast<FAUSTFLOAT>(real);
-        }
-    }
-
-    auto& active = engines_[static_cast<size_t>(engineIndex)];
-    if (!active.dsp)
-        return;
-
-    const int numSamples = fc.bufferNumSamples;
-    const int startSample = fc.bufferStartSample;
-    const int hostChannels = fc.destBuffer->getNumChannels();
-    const int numInputs = active.numInputs;
-    const int numOutputs = active.numOutputs;
-    if (hostChannels <= 0 || numInputs <= 0 || numOutputs <= 0)
-        return;
-
-    if (scratchIn_.getNumChannels() < numInputs || scratchIn_.getNumSamples() < numSamples)
-        scratchIn_.setSize(numInputs, numSamples, false, true, true);
-    if (scratchOut_.getNumChannels() < numOutputs || scratchOut_.getNumSamples() < numSamples)
-        scratchOut_.setSize(numOutputs, numSamples, false, true, true);
-    if (static_cast<int>(inPtrs_.size()) < numInputs)
-        inPtrs_.resize(static_cast<size_t>(numInputs), nullptr);
-    if (static_cast<int>(outPtrs_.size()) < numOutputs)
-        outPtrs_.resize(static_cast<size_t>(numOutputs), nullptr);
-
-    for (int ch = 0; ch < numInputs; ++ch) {
-        float* dst = scratchIn_.getWritePointer(ch);
-        if (ch < hostChannels) {
-            const float* src = fc.destBuffer->getReadPointer(ch, startSample);
-            std::copy(src, src + numSamples, dst);
-        } else {
-            std::fill(dst, dst + numSamples, 0.0f);
-        }
-        inPtrs_[static_cast<size_t>(ch)] = dst;
-    }
-    for (int ch = 0; ch < numOutputs; ++ch) {
-        outPtrs_[static_cast<size_t>(ch)] = (ch < hostChannels)
-                                                ? fc.destBuffer->getWritePointer(ch, startSample)
-                                                : scratchOut_.getWritePointer(ch);
-    }
-
-    active.dsp->compute(numSamples, inPtrs_.data(), outPtrs_.data());
-
-    const int channelsToSanitise = std::min(hostChannels, numOutputs);
-    for (int ch = 0; ch < channelsToSanitise; ++ch) {
-        float* out = fc.destBuffer->getWritePointer(ch, startSample);
-        for (int i = 0; i < numSamples; ++i) {
-            const float sample = out[i];
-            out[i] = std::isfinite(sample) ? juce::jlimit(-16.0f, 16.0f, sample) : 0.0f;
-        }
-    }
-    for (int ch = numOutputs; ch < hostChannels; ++ch)
-        fc.destBuffer->clear(ch, startSample, numSamples);
-}
-
-te::AutomatableParameter* MagdaPitchCompiledPlugin::getSlotParameter(int slotIndex) const {
-    if (slotIndex < 0 || slotIndex >= kHostSlotCount)
-        return nullptr;
-    return hostParams_[static_cast<size_t>(slotIndex)].get();
-}
-
-const MagdaPitchCompiledPlugin::HostSlotInfo& MagdaPitchCompiledPlugin::getSlotInfo(
-    int slotIndex) const {
-    static const HostSlotInfo kEmpty;
-    if (slotIndex < 0 || slotIndex >= kHostSlotCount)
-        return kEmpty;
-    return hostSlotInfo_[static_cast<size_t>(slotIndex)];
-}
-
-int MagdaPitchCompiledPlugin::activeEngineIndex() const {
-    if (!hostParams_[kEngineSlot])
-        return 0;
-    const float norm = hostParams_[kEngineSlot]->getCurrentValue();
-    return juce::jlimit(0, kEngineCount - 1,
-                        static_cast<int>(std::round(norm * static_cast<float>(kEngineCount - 1))));
-}
-
-float MagdaPitchCompiledPlugin::displayValueToNativeValue(int slotIndex, float displayValue) const {
-    if (slotIndex < 0 || slotIndex >= kHostSlotCount)
-        return displayValue;
-    const auto info = parameterInfoForSlot(hostSlotInfo_[static_cast<size_t>(slotIndex)]);
-    return magda::ParameterUtils::realToNormalized(displayValue, info);
-}
-
-float MagdaPitchCompiledPlugin::nativeValueToDisplayValue(int slotIndex, float nativeValue) const {
-    if (slotIndex < 0 || slotIndex >= kHostSlotCount)
-        return nativeValue;
-    const auto info = parameterInfoForSlot(hostSlotInfo_[static_cast<size_t>(slotIndex)]);
-    return magda::ParameterUtils::normalizedToReal(nativeValue, info);
+    return infos;
 }
 
 constexpr AliasSpec kAliases[] = {
@@ -397,9 +92,8 @@ const CompiledPluginSpec& getMagdaPitchSpec() {
                        "<b>Detuner</b>: two voices hard-panned L/R for chorus-style thickening.\n"
                        "<b>Harmonizer</b>: shifted voice summed with dry at a chosen interval.\n"
                        "All three use ef.transpose; transient smear and grain are by design.",
-        .createPlugin = [](const DevicePluginCreationContext& context) -> DevicePluginPtr {
-            return tracktion_adapter::pluginHandle(
-                new MagdaPitchCompiledPlugin(tracktion_adapter::creationInfo(context)));
+        .createDevice = [](const DevicePluginCreationContext&) -> std::unique_ptr<MagdaDevice> {
+            return std::make_unique<MagdaPitchCompiledPlugin>();
         },
         .aliases = kAliases,
         .aliasCount = static_cast<int>(sizeof(kAliases) / sizeof(kAliases[0])),

--- a/magda/daw/audio/plugins/compiled/MagdaPitchCompiledPlugin.hpp
+++ b/magda/daw/audio/plugins/compiled/MagdaPitchCompiledPlugin.hpp
@@ -1,15 +1,8 @@
 #pragma once
 
-#include <tracktion_engine/tracktion_engine.h>
-
-#include <array>
-#include <atomic>
-#include <memory>
 #include <vector>
 
-#include "../FaustParamPool.hpp"
-#include "core/ParameterInfo.hpp"
-#include "plugins/compiled/tracktion/CompiledFaustTracktionAdapter.hpp"
+#include "plugins/compiled/MagdaCompiledEffect.hpp"
 
 class dsp;
 
@@ -36,43 +29,11 @@ namespace magda::daw::audio::compiled {
  * every engine every block so swapping engines preserves the user's
  * settings.
  */
-class MagdaPitchCompiledPlugin : public te::Plugin, public ICompiledFaustPlugin {
+class MagdaPitchCompiledPlugin : public MagdaCompiledEffect {
   public:
     static const char* xmlTypeName;
 
-    explicit MagdaPitchCompiledPlugin(const te::PluginCreationInfo& info);
-    ~MagdaPitchCompiledPlugin() override;
-
-    juce::String getName() const override;
-    juce::String getPluginType() override;
-    juce::String getShortName(int) override;
-    juce::String getSelectableDescription() override;
-
-    void initialise(const te::PluginInitialisationInfo& info) override;
-    void deinitialise() override;
-    void reset() override;
-    void applyToBuffer(const te::PluginRenderContext& fc) override;
-
-    bool takesMidiInput() override {
-        return false;
-    }
-    bool takesAudioInput() override {
-        return true;
-    }
-    bool isSynth() override {
-        return false;
-    }
-    int getNumOutputChannelsGivenInputs(int) override {
-        return 2;
-    }
-    bool producesAudioWhenNoAudioInput() override {
-        // The internal delay lines carry a short tail after dry input
-        // stops; let TE keep pumping so the trail doesn't clip.
-        return true;
-    }
-    double getTailLength() const override {
-        return 0.25;  // 200 ms max window + safety margin.
-    }
+    MagdaPitchCompiledPlugin();
 
     static constexpr int kEngineSlot = 0;
     static constexpr int kPitchSlot = 1;
@@ -81,61 +42,40 @@ class MagdaPitchCompiledPlugin : public te::Plugin, public ICompiledFaustPlugin 
     static constexpr int kMixSlot = 4;
     static constexpr int kOutputSlot = 5;
     static constexpr int kHostSlotCount = 6;
-
     enum class PitchEngine { Shifter = 0, Detuner = 1, Harmonizer = 2 };
     static constexpr int kEngineCount = 3;
 
-    te::AutomatableParameter* getSlotParameter(int slotIndex) const;
+    juce::String devicePluginId() const override {
+        return xmlTypeName;
+    }
+    juce::String deviceName() const override {
+        return "Pitch";
+    }
 
-    float displayValueToNativeValue(int slotIndex, float displayValue) const;
-    float nativeValueToDisplayValue(int slotIndex, float nativeValue) const;
-
-    int activeEngineIndex() const;
-
-    using HostSlotInfo = CompiledHostSlotInfo;
-    const HostSlotInfo& getSlotInfo(int slotIndex) const;
-
-    int hostSlotCount() const override {
-        return kHostSlotCount;
+  protected:
+    ::dsp* createEngineDsp(int engineIndex) const override;
+    std::vector<HostSlotInfo> slotInfos() const override;
+    const char* slotIdPrefix() const override {
+        return "magda_pitch_";
     }
-    const CompiledHostSlotInfo& hostSlotInfo(int slotIndex) const override {
-        return getSlotInfo(slotIndex);
+    int engineCount() const override {
+        return kEngineCount;
     }
-    DeviceParameterHandle hostSlotParameter(int slotIndex) const override {
-        return tracktion_adapter::parameterHandle(getSlotParameter(slotIndex));
+    int engineSlot() const override {
+        return kEngineSlot;
     }
-    float displayToNormalized(int slotIndex, float displayValue) const override {
-        return displayValueToNativeValue(slotIndex, displayValue);
+    int outputChannelCount() const override {
+        return 2;
     }
-    float normalizedToDisplay(int slotIndex, float normalizedValue) const override {
-        return nativeValueToDisplayValue(slotIndex, normalizedValue);
+    bool producesAudioWithoutInput() const override {
+        return true;
     }
-    bool isSlotHiddenForActiveEngine(int) const override {
-        return false;
+    double tailSeconds() const override {
+        // 200 ms max window, plus a safety margin.
+        return 0.25;
     }
 
   private:
-    void buildHostParameters();
-    void rebuildEngineState(int sampleRate);
-
-    struct EngineState {
-        std::unique_ptr<::dsp> dsp;
-        std::array<FAUSTFLOAT*, kHostSlotCount> zones{};
-        int numInputs = 0;
-        int numOutputs = 0;
-    };
-    std::array<EngineState, kEngineCount> engines_;
-    std::atomic<int> activeEngine_{0};
-
-    std::array<HostSlotInfo, kHostSlotCount> hostSlotInfo_;
-    std::array<te::AutomatableParameter::Ptr, kHostSlotCount> hostParams_;
-    std::array<juce::CachedValue<float>, kHostSlotCount> hostCached_;
-
-    juce::AudioBuffer<float> scratchIn_;
-    juce::AudioBuffer<float> scratchOut_;
-    std::vector<float*> inPtrs_;
-    std::vector<float*> outPtrs_;
-
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(MagdaPitchCompiledPlugin)
 };
 

--- a/magda/daw/audio/plugins/compiled/MagdaPolySynthCompiledPlugin.cpp
+++ b/magda/daw/audio/plugins/compiled/MagdaPolySynthCompiledPlugin.cpp
@@ -1,214 +1,27 @@
 #include "plugins/compiled/MagdaPolySynthCompiledPlugin.hpp"
 
-#include <algorithm>
-#include <cmath>
-#include <map>
-
-#include "core/ParameterUtils.hpp"
-#include "core/TechnicalText.hpp"
+#include "core/ParameterInfo.hpp"
 #include "faust/dsp/dsp.h"
-#include "faust/dsp/poly-dsp.h"
 #include "faust/gui/UI.h"
 #include "faust/gui/meta.h"
 #include "magda_polysynth.generated.cpp"
-#include "plugins/FaustMetadataParser.hpp"
 #include "plugins/compiled/CompiledPluginRegistry.hpp"
-#include "plugins/tracktion/TracktionDeviceAdapters.hpp"
-
-// NOTE: Faust's GUI base statics (GUI::fGuiList / gTimedZoneMap), required by
-// poly-dsp.h, are defined once in FaustPolyGuiStatics.cpp — see that file.
 
 namespace magda::daw::audio::compiled {
 
 const char* MagdaPolySynthCompiledPlugin::xmlTypeName = "magda_polysynth";
 
-namespace {
-
-// Harvest the per-voice [idx:N] zones from a mydsp_poly built with group=false.
-// That layout emits, under a "Polyphonic" tab, a shared "Voices" proxy box
-// (whose zones only propagate via the global GUI::updateAllGuis(), which we
-// avoid) followed by one "Voice<n>" box per voice carrying that voice's own
-// directly-writable zones. We keep the per-voice zones and group them by idx so
-// a single host slot can fan a write out to every voice.
-class PolyVoiceHarvester : public ::UI {
-  public:
-    // idx -> per-voice zones (encounter order).
-    std::map<int, std::vector<FAUSTFLOAT*>> zonesByIdx;
-    // Reserved controls carry no [idx]: freq/gain/gate (Faust-reserved) plus our
-    // MIDI-driven `bend`. Captured per voice (encounter order) so the wrapper can
-    // drive a single voice (mono) or fan bend across all voices.
-    std::map<juce::String, std::vector<FAUSTFLOAT*>> reservedByName;
-
-    void openTabBox(const char* label) override {
-        pushGroup(label);
-    }
-    void openHorizontalBox(const char* label) override {
-        pushGroup(label);
-    }
-    void openVerticalBox(const char* label) override {
-        pushGroup(label);
-    }
-    void closeBox() override {
-        if (!groupLabels_.empty())
-            groupLabels_.pop_back();
-    }
-
-    void addButton(const char* label, FAUSTFLOAT* zone) override {
-        emit(label, zone);
-    }
-    void addCheckButton(const char* label, FAUSTFLOAT* zone) override {
-        emit(label, zone);
-    }
-    void addVerticalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT, FAUSTFLOAT, FAUSTFLOAT,
-                           FAUSTFLOAT) override {
-        emit(label, zone);
-    }
-    void addHorizontalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT, FAUSTFLOAT,
-                             FAUSTFLOAT, FAUSTFLOAT) override {
-        emit(label, zone);
-    }
-    void addNumEntry(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT, FAUSTFLOAT, FAUSTFLOAT,
-                     FAUSTFLOAT) override {
-        emit(label, zone);
-    }
-    void addHorizontalBargraph(const char*, FAUSTFLOAT*, FAUSTFLOAT, FAUSTFLOAT) override {}
-    void addVerticalBargraph(const char*, FAUSTFLOAT*, FAUSTFLOAT, FAUSTFLOAT) override {}
-    void addSoundfile(const char*, const char*, Soundfile**) override {}
-
-    void declare(FAUSTFLOAT* zone, const char* key, const char* value) override {
-        if (zone == nullptr)
-            return;
-        const auto k = juce::String::fromUTF8(key != nullptr ? key : "").toLowerCase();
-        const auto v = juce::String::fromUTF8(value != nullptr ? value : "");
-        applyFaustAnnotation(k, v, pendingByZone_[zone]);
-    }
-
-  private:
-    void pushGroup(const char* label) {
-        groupLabels_.push_back(
-            parseFaustLabel(juce::String::fromUTF8(label != nullptr ? label : "")).cleanLabel);
-    }
-
-    // True when the nearest voice-level ancestor is the shared proxy box
-    // ("Voices"), false when it's an individual voice ("Voice1".. / "V1"..).
-    bool inProxyGroup() const {
-        for (auto it = groupLabels_.rbegin(); it != groupLabels_.rend(); ++it) {
-            if (*it == "Voices")
-                return true;
-            if (it->startsWith("Voice") || (it->length() >= 2 && (*it)[0] == 'V' &&
-                                            juce::CharacterFunctions::isDigit((*it)[1])))
-                return false;
-        }
-        return false;
-    }
-
-    void emit(const char* rawLabel, FAUSTFLOAT* zone) {
-        const auto parsed =
-            parseFaustLabel(juce::String::fromUTF8(rawLabel != nullptr ? rawLabel : ""));
-        ControlMetadata merged = parsed.metadata;
-        if (zone != nullptr) {
-            if (auto it = pendingByZone_.find(zone); it != pendingByZone_.end()) {
-                mergeFaustMetadata(merged, it->second);
-                pendingByZone_.erase(it);
-            }
-        }
-        if (zone == nullptr || inProxyGroup())
-            return;
-        if (merged.slotIndex >= 0) {
-            zonesByIdx[merged.slotIndex].push_back(zone);
-        } else {
-            const auto name = parsed.cleanLabel.toLowerCase();
-            if (name == "freq" || name == "gain" || name == "gate" || name == "bend")
-                reservedByName[name].push_back(zone);
-        }
-    }
-
-    std::vector<juce::String> groupLabels_;
-    std::map<FAUSTFLOAT*, ControlMetadata> pendingByZone_;
-};
-
-inline float midiNoteToHz(int note) {
-    return 440.0f * std::pow(2.0f, (static_cast<float>(note) - 69.0f) / 12.0f);
+MagdaPolySynthCompiledPlugin::MagdaPolySynthCompiledPlugin() {
+    initInstrument();
 }
 
-}  // namespace
-
-MagdaPolySynthCompiledPlugin::MagdaPolySynthCompiledPlugin(const te::PluginCreationInfo& info)
-    : te::Plugin(info) {
-    constexpr int kProvisionalSampleRate = 44100;
-    rebuildEngineState(kProvisionalSampleRate);
-    buildHostParameters();
+::dsp* MagdaPolySynthCompiledPlugin::createVoiceDsp() const {
+    return new MagdaPolySynthDsp();
 }
 
-MagdaPolySynthCompiledPlugin::~MagdaPolySynthCompiledPlugin() {
-    notifyListenersOfDeletion();
-    for (auto& p : hostParams_)
-        if (p)
-            p->detachFromCurrentValue();
-}
-
-juce::String MagdaPolySynthCompiledPlugin::getName() const {
-    return "Poly Synth";
-}
-juce::String MagdaPolySynthCompiledPlugin::getPluginType() {
-    return xmlTypeName;
-}
-juce::String MagdaPolySynthCompiledPlugin::getShortName(int) {
-    return "PolySynth";
-}
-juce::String MagdaPolySynthCompiledPlugin::getSelectableDescription() {
-    return "Poly Synth";
-}
-
-void MagdaPolySynthCompiledPlugin::rebuildEngineState(int sampleRate) {
-    sampleRate_ = sampleRate;
-
-    // Wrap a fresh single-voice MagdaPolySynthDsp in the poly allocator.
-    // control=true: voices are MIDI-allocated. group=false: each voice keeps its
-    // own writable zones (we fan host-macro writes out to all of them).
-    poly_ = std::make_unique<mydsp_poly>(new MagdaPolySynthDsp(), kNumVoices, /*control*/ true,
-                                         /*group*/ false);
-    poly_->init(sampleRate);
-    numOutputs_ = poly_->getNumOutputs();
-
-    // Dedicated single voice for Mono/Legato (driven directly, bypassing the
-    // poly allocator which skips idle voices).
-    monoVoice_.reset(new MagdaPolySynthDsp());
-    monoVoice_->init(sampleRate);
-
-    PolyVoiceHarvester polyH;
-    poly_->buildUserInterface(&polyH);
-    PolyVoiceHarvester monoH;
-    monoVoice_->buildUserInterface(&monoH);
-
-    for (auto& slot : voiceZonesBySlot_)
-        slot.clear();
-    monoZonesBySlot_.fill(nullptr);
-    for (int i = 0; i < kHostSlotCount; ++i) {
-        if (auto it = polyH.zonesByIdx.find(i); it != polyH.zonesByIdx.end())
-            voiceZonesBySlot_[static_cast<size_t>(i)] = it->second;
-        if (auto it = monoH.zonesByIdx.find(i); it != monoH.zonesByIdx.end() && !it->second.empty())
-            monoZonesBySlot_[static_cast<size_t>(i)] = it->second.front();
-    }
-
-    auto first = [](const std::map<juce::String, std::vector<FAUSTFLOAT*>>& m,
-                    const char* key) -> FAUSTFLOAT* {
-        auto it = m.find(key);
-        return (it != m.end() && !it->second.empty()) ? it->second.front() : nullptr;
-    };
-    voiceBendZones_.clear();
-    if (auto it = polyH.reservedByName.find("bend"); it != polyH.reservedByName.end())
-        voiceBendZones_ = it->second;
-    monoBendZone_ = first(monoH.reservedByName, "bend");
-    monoFreqZone_ = first(monoH.reservedByName, "freq");
-    monoGainZone_ = first(monoH.reservedByName, "gain");
-    monoGateZone_ = first(monoH.reservedByName, "gate");
-
-    heldNotes_.clear();
-    currentBend_ = 0.0f;
-}
-
-void MagdaPolySynthCompiledPlugin::buildHostParameters() {
+std::vector<MagdaPolySynthCompiledPlugin::HostSlotInfo> MagdaPolySynthCompiledPlugin::slotInfos()
+    const {
+    std::vector<HostSlotInfo> infos(kHostSlotCount);
     const std::vector<juce::String> waveChoices{"Sine", "Saw", "Square", "Triangle"};
 
     // Four contiguous slots per oscillator (wave / level / coarse / fine).
@@ -217,499 +30,177 @@ void MagdaPolySynthCompiledPlugin::buildHostParameters() {
         const int base = kOscBaseSlot + osc * kOscSlotCount;
         const juce::String prefix = "Osc " + juce::String(osc + 1) + " ";
 
-        hostSlotInfo_[base + 0] = {.name = prefix + "Wave",
-                                   .scale = magda::ParameterScale::Discrete,
-                                   .minValue = 0.0f,
-                                   .maxValue = static_cast<float>(waveChoices.size() - 1),
-                                   .defaultValue = 1.0f,  // Saw
-                                   .choices = waveChoices};
-        hostSlotInfo_[base + 1] = {.name = prefix + "Level",
-                                   .unit = "dB",
-                                   .scale = magda::ParameterScale::FaderDB,
-                                   .minValue = -60.0f,
-                                   .maxValue = 6.0f,
-                                   .defaultValue = (osc == 0) ? -12.0f : -60.0f};
-        hostSlotInfo_[base + 2] = {.name = prefix + "Coarse",
-                                   .unit =
-                                       magda::technicalText(magda::TechnicalTextToken::Semitones),
-                                   .scale = magda::ParameterScale::Linear,
-                                   .minValue = -24.0f,
-                                   .maxValue = 24.0f,
-                                   .defaultValue = 0.0f};
-        hostSlotInfo_[base + 3] = {.name = prefix + "Fine",
-                                   .unit = magda::technicalText(magda::TechnicalTextToken::Cents),
-                                   .scale = magda::ParameterScale::Linear,
-                                   .minValue = -100.0f,
-                                   .maxValue = 100.0f,
-                                   .defaultValue = 0.0f};
+        infos[base + 0] = {.name = prefix + "Wave",
+                           .scale = magda::ParameterScale::Discrete,
+                           .minValue = 0.0f,
+                           .maxValue = static_cast<float>(waveChoices.size() - 1),
+                           .defaultValue = 1.0f,  // Saw
+                           .choices = waveChoices};
+        infos[base + 1] = {.name = prefix + "Level",
+                           .unit = "dB",
+                           .scale = magda::ParameterScale::FaderDB,
+                           .minValue = -60.0f,
+                           .maxValue = 6.0f,
+                           .defaultValue = (osc == 0) ? -12.0f : -60.0f};
+        infos[base + 2] = {.name = prefix + "Coarse",
+                           .unit = magda::technicalText(magda::TechnicalTextToken::Semitones),
+                           .scale = magda::ParameterScale::Linear,
+                           .minValue = -24.0f,
+                           .maxValue = 24.0f,
+                           .defaultValue = 0.0f};
+        infos[base + 3] = {.name = prefix + "Fine",
+                           .unit = magda::technicalText(magda::TechnicalTextToken::Cents),
+                           .scale = magda::ParameterScale::Linear,
+                           .minValue = -100.0f,
+                           .maxValue = 100.0f,
+                           .defaultValue = 0.0f};
     }
 
-    hostSlotInfo_[kFilterTypeSlot] = {.name = "Filter Type",
-                                      .scale = magda::ParameterScale::Discrete,
-                                      .minValue = 0.0f,
-                                      .maxValue = 3.0f,
-                                      .defaultValue = 0.0f,
-                                      .choices = {"Lowpass", "Highpass", "Bandpass", "Notch"}};
-    hostSlotInfo_[kCutoffSlot] = {.name = "Cutoff",
-                                  .unit = "Hz",
-                                  .scale = magda::ParameterScale::Logarithmic,
-                                  .minValue = 50.0f,
-                                  .maxValue = 18000.0f,
-                                  .defaultValue = 3000.0f};
-    hostSlotInfo_[kResonanceSlot] = {.name = "Resonance",
-                                     .scale = magda::ParameterScale::Linear,
-                                     .minValue = 0.0f,
-                                     .maxValue = 0.95f,
-                                     .defaultValue = 0.3f};
-    hostSlotInfo_[kFilterEnvAmtSlot] = {.name = "Filter Env",
-                                        .unit = "oct",
-                                        .scale = magda::ParameterScale::Linear,
-                                        .minValue = -4.0f,
-                                        .maxValue = 4.0f,
-                                        .defaultValue = 0.0f};
+    infos[kFilterTypeSlot] = {.name = "Filter Type",
+                              .scale = magda::ParameterScale::Discrete,
+                              .minValue = 0.0f,
+                              .maxValue = 3.0f,
+                              .defaultValue = 0.0f,
+                              .choices = {"Lowpass", "Highpass", "Bandpass", "Notch"}};
+    infos[kCutoffSlot] = {.name = "Cutoff",
+                          .unit = "Hz",
+                          .scale = magda::ParameterScale::Logarithmic,
+                          .minValue = 50.0f,
+                          .maxValue = 18000.0f,
+                          .defaultValue = 3000.0f};
+    infos[kResonanceSlot] = {.name = "Resonance",
+                             .scale = magda::ParameterScale::Linear,
+                             .minValue = 0.0f,
+                             .maxValue = 0.95f,
+                             .defaultValue = 0.3f};
+    infos[kFilterEnvAmtSlot] = {.name = "Filter Env",
+                                .unit = "oct",
+                                .scale = magda::ParameterScale::Linear,
+                                .minValue = -4.0f,
+                                .maxValue = 4.0f,
+                                .defaultValue = 0.0f};
     // Envelope times are in milliseconds (the formatter shows ms below 1 s, s
     // above). The DSP divides them back to seconds.
-    hostSlotInfo_[kFilterAttackSlot] = {.name = "Filter Attack",
-                                        .unit = "ms",
-                                        .scale = magda::ParameterScale::Linear,
-                                        .minValue = 1.0f,
-                                        .maxValue = 2000.0f,
-                                        .defaultValue = 5.0f};
-    hostSlotInfo_[kFilterDecaySlot] = {.name = "Filter Decay",
-                                       .unit = "ms",
-                                       .scale = magda::ParameterScale::Linear,
-                                       .minValue = 1.0f,
-                                       .maxValue = 2000.0f,
-                                       .defaultValue = 200.0f};
-    hostSlotInfo_[kFilterSustainSlot] = {.name = "Filter Sustain",
-                                         .scale = magda::ParameterScale::Linear,
-                                         .minValue = 0.0f,
-                                         .maxValue = 1.0f,
-                                         .defaultValue = 0.7f};
-    hostSlotInfo_[kFilterReleaseSlot] = {.name = "Filter Release",
-                                         .unit = "ms",
-                                         .scale = magda::ParameterScale::Linear,
-                                         .minValue = 1.0f,
-                                         .maxValue = 4000.0f,
-                                         .defaultValue = 400.0f};
-
-    hostSlotInfo_[kAmpAttackSlot] = {.name = "Amp Attack",
-                                     .unit = "ms",
-                                     .scale = magda::ParameterScale::Linear,
-                                     .minValue = 1.0f,
-                                     .maxValue = 2000.0f,
-                                     .defaultValue = 5.0f};
-    hostSlotInfo_[kAmpDecaySlot] = {.name = "Amp Decay",
-                                    .unit = "ms",
-                                    .scale = magda::ParameterScale::Linear,
-                                    .minValue = 1.0f,
-                                    .maxValue = 2000.0f,
-                                    .defaultValue = 200.0f};
-    hostSlotInfo_[kAmpSustainSlot] = {.name = "Amp Sustain",
-                                      .scale = magda::ParameterScale::Linear,
-                                      .minValue = 0.0f,
-                                      .maxValue = 1.0f,
-                                      .defaultValue = 0.7f};
-    hostSlotInfo_[kAmpReleaseSlot] = {.name = "Amp Release",
-                                      .unit = "ms",
-                                      .scale = magda::ParameterScale::Linear,
-                                      .minValue = 1.0f,
-                                      .maxValue = 4000.0f,
-                                      .defaultValue = 400.0f};
-
-    hostSlotInfo_[kFilterDriveSlot] = {.name = "Filter Drive",
-                                       .scale = magda::ParameterScale::Linear,
-                                       .minValue = 0.0f,
-                                       .maxValue = 1.0f,
-                                       .defaultValue = 0.0f};
-
-    hostSlotInfo_[kFilterSlopeSlot] = {.name = "Filter Slope",
-                                       .scale = magda::ParameterScale::Discrete,
-                                       .minValue = 0.0f,
-                                       .maxValue = 1.0f,
-                                       .defaultValue = 0.0f,
-                                       .choices = {"12 dB", "24 dB"}};
-
-    hostSlotInfo_[kBendRangeSlot] = {.name = "Bend Range",
-                                     .unit =
-                                         magda::technicalText(magda::TechnicalTextToken::Semitones),
-                                     .scale = magda::ParameterScale::Linear,
-                                     .minValue = 0.0f,
-                                     .maxValue = 24.0f,
-                                     .defaultValue = 2.0f};
-
-    hostSlotInfo_[kVoiceModeSlot] = {.name = "Voice Mode",
-                                     .scale = magda::ParameterScale::Discrete,
-                                     .minValue = 0.0f,
-                                     .maxValue = 2.0f,
-                                     .defaultValue = 0.0f,
-                                     .choices = {"Poly", "Mono", "Legato"}};
-
-    hostSlotInfo_[kGlideSlot] = {.name = "Glide",
-                                 .unit = "ms",
+    infos[kFilterAttackSlot] = {.name = "Filter Attack",
+                                .unit = "ms",
+                                .scale = magda::ParameterScale::Linear,
+                                .minValue = 1.0f,
+                                .maxValue = 2000.0f,
+                                .defaultValue = 5.0f};
+    infos[kFilterDecaySlot] = {.name = "Filter Decay",
+                               .unit = "ms",
+                               .scale = magda::ParameterScale::Linear,
+                               .minValue = 1.0f,
+                               .maxValue = 2000.0f,
+                               .defaultValue = 200.0f};
+    infos[kFilterSustainSlot] = {.name = "Filter Sustain",
                                  .scale = magda::ParameterScale::Linear,
                                  .minValue = 0.0f,
-                                 .maxValue = 2000.0f,
-                                 .defaultValue = 0.0f};
+                                 .maxValue = 1.0f,
+                                 .defaultValue = 0.7f};
+    infos[kFilterReleaseSlot] = {.name = "Filter Release",
+                                 .unit = "ms",
+                                 .scale = magda::ParameterScale::Linear,
+                                 .minValue = 1.0f,
+                                 .maxValue = 4000.0f,
+                                 .defaultValue = 400.0f};
+
+    infos[kAmpAttackSlot] = {.name = "Amp Attack",
+                             .unit = "ms",
+                             .scale = magda::ParameterScale::Linear,
+                             .minValue = 1.0f,
+                             .maxValue = 2000.0f,
+                             .defaultValue = 5.0f};
+    infos[kAmpDecaySlot] = {.name = "Amp Decay",
+                            .unit = "ms",
+                            .scale = magda::ParameterScale::Linear,
+                            .minValue = 1.0f,
+                            .maxValue = 2000.0f,
+                            .defaultValue = 200.0f};
+    infos[kAmpSustainSlot] = {.name = "Amp Sustain",
+                              .scale = magda::ParameterScale::Linear,
+                              .minValue = 0.0f,
+                              .maxValue = 1.0f,
+                              .defaultValue = 0.7f};
+    infos[kAmpReleaseSlot] = {.name = "Amp Release",
+                              .unit = "ms",
+                              .scale = magda::ParameterScale::Linear,
+                              .minValue = 1.0f,
+                              .maxValue = 4000.0f,
+                              .defaultValue = 400.0f};
+
+    infos[kFilterDriveSlot] = {.name = "Filter Drive",
+                               .scale = magda::ParameterScale::Linear,
+                               .minValue = 0.0f,
+                               .maxValue = 1.0f,
+                               .defaultValue = 0.0f};
+
+    infos[kFilterSlopeSlot] = {.name = "Filter Slope",
+                               .scale = magda::ParameterScale::Discrete,
+                               .minValue = 0.0f,
+                               .maxValue = 1.0f,
+                               .defaultValue = 0.0f,
+                               .choices = {"12 dB", "24 dB"}};
+
+    infos[kBendRangeSlot] = {.name = "Bend Range",
+                             .unit = magda::technicalText(magda::TechnicalTextToken::Semitones),
+                             .scale = magda::ParameterScale::Linear,
+                             .minValue = 0.0f,
+                             .maxValue = 24.0f,
+                             .defaultValue = 2.0f};
+
+    infos[kVoiceModeSlot] = {.name = "Voice Mode",
+                             .scale = magda::ParameterScale::Discrete,
+                             .minValue = 0.0f,
+                             .maxValue = 2.0f,
+                             .defaultValue = 0.0f,
+                             .choices = {"Poly", "Mono", "Legato"}};
+
+    infos[kGlideSlot] = {.name = "Glide",
+                         .unit = "ms",
+                         .scale = magda::ParameterScale::Linear,
+                         .minValue = 0.0f,
+                         .maxValue = 2000.0f,
+                         .defaultValue = 0.0f};
 
     for (int osc = 0; osc < kNumOscillators; ++osc) {
-        hostSlotInfo_[kOscResetBaseSlot + osc] = {.name = "Osc " + juce::String(osc + 1) + " Reset",
-                                                  .scale = magda::ParameterScale::Discrete,
-                                                  .minValue = 0.0f,
-                                                  .maxValue = 1.0f,
-                                                  .defaultValue = 0.0f,
-                                                  .choices = {"Off", "On"}};
+        infos[kOscResetBaseSlot + osc] = {.name = "Osc " + juce::String(osc + 1) + " Reset",
+                                          .scale = magda::ParameterScale::Discrete,
+                                          .minValue = 0.0f,
+                                          .maxValue = 1.0f,
+                                          .defaultValue = 0.0f,
+                                          .choices = {"Off", "On"}};
     }
 
-    hostSlotInfo_[kVelAmpSlot] = {.name = "Vel Amp",
-                                  .scale = magda::ParameterScale::Linear,
-                                  .minValue = 0.0f,
-                                  .maxValue = 1.0f,
-                                  .defaultValue = 1.0f};
-    hostSlotInfo_[kVelFilterSlot] = {.name = "Vel Filter",
-                                     .unit = "oct",
-                                     .scale = magda::ParameterScale::Linear,
-                                     .minValue = 0.0f,
-                                     .maxValue = 6.0f,
-                                     .defaultValue = 0.0f};
+    infos[kVelAmpSlot] = {.name = "Vel Amp",
+                          .scale = magda::ParameterScale::Linear,
+                          .minValue = 0.0f,
+                          .maxValue = 1.0f,
+                          .defaultValue = 1.0f};
+    infos[kVelFilterSlot] = {.name = "Vel Filter",
+                             .unit = "oct",
+                             .scale = magda::ParameterScale::Linear,
+                             .minValue = 0.0f,
+                             .maxValue = 6.0f,
+                             .defaultValue = 0.0f};
 
     for (int osc = 0; osc < kNumOscillators; ++osc) {
-        hostSlotInfo_[kOscEnableBaseSlot + osc] = {.name =
-                                                       "Osc " + juce::String(osc + 1) + " Enable",
-                                                   .scale = magda::ParameterScale::Discrete,
-                                                   .minValue = 0.0f,
-                                                   .maxValue = 1.0f,
-                                                   .defaultValue = 1.0f,
-                                                   .choices = {"Off", "On"}};
+        infos[kOscEnableBaseSlot + osc] = {.name = "Osc " + juce::String(osc + 1) + " Enable",
+                                           .scale = magda::ParameterScale::Discrete,
+                                           .minValue = 0.0f,
+                                           .maxValue = 1.0f,
+                                           .defaultValue = 1.0f,
+                                           .choices = {"Off", "On"}};
     }
 
-    hostSlotInfo_[kOutputGainSlot] = {.name = "Output",
-                                      .unit = "dB",
-                                      .scale = magda::ParameterScale::FaderDB,
-                                      .minValue = -60.0f,
-                                      .maxValue = 6.0f,
-                                      .defaultValue = 0.0f};
+    infos[kOutputGainSlot] = {.name = "Output",
+                              .unit = "dB",
+                              .scale = magda::ParameterScale::FaderDB,
+                              .minValue = -60.0f,
+                              .maxValue = 6.0f,
+                              .defaultValue = 0.0f};
 
-    juce::NormalisableRange<float> normalisedRange{0.0f, 1.0f};
-    auto* undoManager = getUndoManager();
-
-    auto buildInfo = [](const HostSlotInfo& s) {
-        magda::ParameterInfo info;
-        info.minValue = s.minValue;
-        info.maxValue = s.maxValue;
-        info.defaultValue = s.defaultValue;
-        info.unit = s.unit;
-        info.scale = s.scale;
-        if (std::isfinite(s.scaleAnchor))
-            info.scaleAnchor = s.scaleAnchor;
-        info.choices = s.choices;
-        return info;
-    };
-
-    for (int i = 0; i < kHostSlotCount; ++i) {
-        const auto& slot = hostSlotInfo_[i];
-        const juce::String id = "magda_polysynth_" + slot.name.toLowerCase().replace(" ", "_");
-        const juce::Identifier identifier(id);
-        const auto info = buildInfo(slot);
-        const float defaultNormalized =
-            magda::ParameterUtils::realToNormalized(slot.defaultValue, info);
-        hostCached_[i].referTo(state, identifier, undoManager, defaultNormalized);
-
-        auto param = addParam(
-            id, slot.name, normalisedRange,
-            [info](float normalized) {
-                const float real = magda::ParameterUtils::normalizedToReal(normalized, info);
-                return magda::ParameterUtils::formatValue(real, info);
-            },
-            [info](const juce::String& text) {
-                auto parsed = magda::ParameterUtils::parseValue(text, info);
-                if (parsed)
-                    return magda::ParameterUtils::realToNormalized(*parsed, info);
-                return 0.0f;
-            });
-        param->attachToCurrentValue(hostCached_[i]);
-        hostParams_[i] = param;
-    }
-}
-
-void MagdaPolySynthCompiledPlugin::initialise(const te::PluginInitialisationInfo& info) {
-    rebuildEngineState(static_cast<int>(info.sampleRate));
-    scratchOut_.setSize(std::max(numOutputs_, 2), info.blockSizeSamples, false, true, true);
-    outPtrs_.assign(static_cast<size_t>(std::max(numOutputs_, 2)), nullptr);
-    heldNotes_.reserve(128);  // avoid RT allocation as notes are pressed
-}
-
-void MagdaPolySynthCompiledPlugin::deinitialise() {
-    scratchOut_.setSize(0, 0);
-    outPtrs_.clear();
-}
-
-void MagdaPolySynthCompiledPlugin::reset() {
-    // Called from the message thread (TE plugin API, resetSynthsOnTrack after a
-    // record pass). Defer the actual voice flush to the audio thread — see
-    // pendingVoiceFlush_.
-    pendingVoiceFlush_.store(true, std::memory_order_release);
-}
-
-int MagdaPolySynthCompiledPlugin::readVoiceModeIndex() const {
-    if (!hostParams_[kVoiceModeSlot])
-        return Poly;
-    const float norm = hostParams_[kVoiceModeSlot]->getCurrentValue();
-    return juce::jlimit(0, 2, static_cast<int>(std::lround(juce::jlimit(0.0f, 1.0f, norm) * 2.0f)));
-}
-
-void MagdaPolySynthCompiledPlugin::resetAllVoices() {
-    if (poly_)
-        poly_->ctrlChange(0, 123, 0);  // All Notes Off: release every poly voice
-    if (monoVoice_)
-        monoVoice_->instanceClear();
-    heldNotes_.clear();
-    if (monoGateZone_)
-        *monoGateZone_ = 0.0f;
-}
-
-void MagdaPolySynthCompiledPlugin::releasePolyVoicesForPitch(int pitch) {
-    // poly_ is always constructed as mydsp_poly in rebuildEngineState().
-    auto* impl = static_cast<mydsp_poly*>(poly_.get());
-    if (impl == nullptr)
-        return;
-
-    for (auto* voice : impl->fVoiceTable) {
-        if (voice == nullptr)
-            continue;
-        if (voice->fCurNote == pitch ||
-            (voice->fCurNote == kLegatoVoice && voice->fNextNote == pitch))
-            voice->keyOff(/*hard*/ false);
-    }
-}
-
-bool MagdaPolySynthCompiledPlugin::handleMonoNoteOn(int note, int velocity, int mode) {
-    const float g = static_cast<float>(velocity) / 127.0f;
-    const bool wasEmpty = heldNotes_.empty();
-    heldNotes_.push_back({note, g});
-    if (monoFreqZone_)
-        *monoFreqZone_ = midiNoteToHz(note);
-    if (monoGainZone_)
-        *monoGainZone_ = g;
-    if (wasEmpty) {
-        if (monoGateZone_)
-            *monoGateZone_ = 1.0f;  // gate 0 -> 1: clean attack from silence
-        return false;
-    }
-    if (mode == Mono) {
-        if (monoGateZone_)
-            *monoGateZone_ = 0.0f;  // drop; caller raises after one sample to retrigger
-        return true;
-    }
-    return false;  // Legato: change pitch only, envelope keeps running
-}
-
-void MagdaPolySynthCompiledPlugin::handleMonoNoteOff(int note) {
-    for (auto it = heldNotes_.rbegin(); it != heldNotes_.rend(); ++it) {
-        if (it->note == note) {
-            heldNotes_.erase(std::next(it).base());
-            break;
-        }
-    }
-    if (heldNotes_.empty()) {
-        if (monoGateZone_)
-            *monoGateZone_ = 0.0f;  // last note released -> envelope release
-    } else if (monoFreqZone_) {
-        *monoFreqZone_ = midiNoteToHz(heldNotes_.back().note);  // legato return to held note
-    }
-}
-
-void MagdaPolySynthCompiledPlugin::applyToBuffer(const te::PluginRenderContext& fc) {
-    if (!poly_ || !monoVoice_ || !fc.destBuffer || fc.bufferNumSamples <= 0)
-        return;
-
-    if (pendingVoiceFlush_.exchange(false, std::memory_order_acq_rel))
-        resetAllVoices();
-
-    // Stop mid-note doesn't deliver note-offs, so a sounding voice would hang
-    // gated-on. Flush every voice on the playing->stopped edge.
-    if (wasPlaying_ && !fc.isPlaying)
-        resetAllVoices();
-    wasPlaying_ = fc.isPlaying;
-
-    // Fan each host macro out to every poly voice's zone AND the mono voice's
-    // zone (RT-safe pointer writes), so both engines track the controls.
-    for (int slot = 0; slot < kHostSlotCount; ++slot) {
-        const auto& s = hostSlotInfo_[static_cast<size_t>(slot)];
-        const float norm = hostParams_[static_cast<size_t>(slot)]->getCurrentValue();
-
-        FAUSTFLOAT real;
-        if (s.scale == magda::ParameterScale::Discrete) {
-            // Discrete index = round(norm * (count - 1)); maxValue already holds
-            // count - 1, so we avoid copying the choices vector (which would
-            // allocate) onto the audio thread just to call normalizedToReal.
-            real = static_cast<FAUSTFLOAT>(std::round(juce::jlimit(0.0f, 1.0f, norm) * s.maxValue));
-        } else {
-            magda::ParameterInfo info;
-            info.minValue = s.minValue;
-            info.maxValue = s.maxValue;
-            info.scale = s.scale;
-            if (std::isfinite(s.scaleAnchor))
-                info.scaleAnchor = s.scaleAnchor;
-            real = static_cast<FAUSTFLOAT>(magda::ParameterUtils::normalizedToReal(norm, info));
-        }
-
-        // Glide is a Mono/Legato-only control: the poly voices always get 0 so
-        // reused voices never portamento from their previous note.
-        const FAUSTFLOAT polyReal = (slot == kGlideSlot) ? FAUSTFLOAT(0) : real;
-        for (FAUSTFLOAT* zone : voiceZonesBySlot_[static_cast<size_t>(slot)])
-            if (zone)
-                *zone = polyReal;
-        if (monoZonesBySlot_[static_cast<size_t>(slot)])
-            *monoZonesBySlot_[static_cast<size_t>(slot)] = real;
-    }
-
-    const int mode = readVoiceModeIndex();
-    if (mode != lastVoiceMode_) {
-        resetAllVoices();  // flush hung notes when switching Poly <-> Mono/Legato
-        lastVoiceMode_ = mode;
-    }
-
-    // Refresh live pitch-bend into every target zone (persisted across blocks; a
-    // fresh engine state or mode switch picks up the current wheel position).
-    for (FAUSTFLOAT* z : voiceBendZones_)
-        if (z)
-            *z = currentBend_;
-    if (monoBendZone_)
-        *monoBendZone_ = currentBend_;
-
-    const int n = fc.bufferNumSamples;
-    const int start = fc.bufferStartSample;
-    const int hostChannels = fc.destBuffer->getNumChannels();
-    if (hostChannels <= 0 || numOutputs_ <= 0 || scratchOut_.getNumSamples() <= 0)
-        return;
-
-    ::dsp* active =
-        (mode == Poly) ? static_cast<::dsp*>(poly_.get()) : static_cast<::dsp*>(monoVoice_.get());
-
-    outPtrs_.resize(static_cast<size_t>(numOutputs_));
-    const int scratchCh = scratchOut_.getNumChannels();
-    const int maxChunk = std::min(MIX_BUFFER_SIZE, scratchOut_.getNumSamples());
-
-    // Render [segStart, segStart+segLen) of this block from the active engine,
-    // ADDing into destBuffer. Chunked to MIX_BUFFER_SIZE (the poly mix-buffer cap).
-    auto renderSegment = [&](int segStart, int segLen) {
-        int done = 0;
-        while (done < segLen) {
-            const int chunk = std::min(segLen - done, maxChunk);
-            for (int ch = 0; ch < numOutputs_; ++ch)
-                outPtrs_[static_cast<size_t>(ch)] = scratchOut_.getWritePointer(ch % scratchCh);
-            active->compute(chunk, nullptr, outPtrs_.data());
-            for (int ch = 0; ch < hostChannels; ++ch) {
-                const int srcCh = (numOutputs_ == 1) ? 0 : (ch % numOutputs_);
-                fc.destBuffer->addFrom(ch, start + segStart + done, scratchOut_, srcCh, 0, chunk);
-            }
-            done += chunk;
-        }
-    };
-
-    // Walk MIDI in time order, rendering the audio between events so note timing
-    // (and the mono retrigger gate edge) is sample-accurate within the block.
-    int cursor = 0;
-    if (fc.bufferForMidiMessages != nullptr) {
-        for (auto& m : *fc.bufferForMidiMessages) {
-            int evSample = juce::roundToInt(m.getTimeStamp() * sampleRate_);
-            evSample = juce::jlimit(cursor, n, evSample);  // clamp + keep monotonic
-            renderSegment(cursor, evSample - cursor);
-            cursor = evSample;
-
-            if (m.isPitchWheel()) {
-                currentBend_ = (m.getPitchWheelValue() - 8192) / 8192.0f;
-                for (FAUSTFLOAT* z : voiceBendZones_)
-                    if (z)
-                        *z = currentBend_;
-                if (monoBendZone_)
-                    *monoBendZone_ = currentBend_;
-            } else if (mode == Poly) {
-                if (m.isNoteOn()) {
-                    // Release any voice still sounding this pitch before
-                    // re-triggering, so the allocator never accumulates orphan
-                    // voices that would hang (one voice per pitch).
-                    releasePolyVoicesForPitch(m.getNoteNumber());
-                    poly_->keyOn(m.getChannel(), m.getNoteNumber(), m.getVelocity());
-                } else if (m.isNoteOff()) {
-                    // Release ALL voices of this pitch (not just the oldest):
-                    // with merged duplicate streams (recorded clip + live
-                    // monitored input) note-on/off counts can be unbalanced,
-                    // and any note-off must be able to silence every voice of
-                    // its pitch so nothing stays stuck.
-                    releasePolyVoicesForPitch(m.getNoteNumber());
-                } else if (m.isController()) {
-                    poly_->ctrlChange(m.getChannel(), m.getControllerNumber(),
-                                      m.getControllerValue());
-                }
-            } else {
-                if (m.isNoteOn()) {
-                    if (handleMonoNoteOn(m.getNoteNumber(), m.getVelocity(), mode)) {
-                        // One-sample gate-low renders the falling edge; raising the
-                        // gate after it gives the rising edge that retriggers.
-                        const int low = std::min(1, n - cursor);
-                        renderSegment(cursor, low);
-                        cursor += low;
-                        if (monoGateZone_)
-                            *monoGateZone_ = 1.0f;
-                    }
-                } else if (m.isNoteOff()) {
-                    handleMonoNoteOff(m.getNoteNumber());
-                } else if (m.isController() &&
-                           (m.getControllerNumber() == 120 || m.getControllerNumber() == 123)) {
-                    heldNotes_.clear();  // all-sound/all-notes-off
-                    if (monoGateZone_)
-                        *monoGateZone_ = 0.0f;
-                }
-            }
-        }
-    }
-    renderSegment(cursor, n - cursor);
-}
-
-te::AutomatableParameter* MagdaPolySynthCompiledPlugin::getSlotParameter(int slotIndex) const {
-    if (slotIndex < 0 || slotIndex >= kHostSlotCount)
-        return nullptr;
-    return hostParams_[static_cast<size_t>(slotIndex)].get();
-}
-
-const MagdaPolySynthCompiledPlugin::HostSlotInfo& MagdaPolySynthCompiledPlugin::getSlotInfo(
-    int slotIndex) const {
-    static const HostSlotInfo kEmpty;
-    if (slotIndex < 0 || slotIndex >= kHostSlotCount)
-        return kEmpty;
-    return hostSlotInfo_[static_cast<size_t>(slotIndex)];
-}
-
-float MagdaPolySynthCompiledPlugin::displayValueToNativeValue(int slotIndex,
-                                                              float displayValue) const {
-    if (slotIndex < 0 || slotIndex >= kHostSlotCount)
-        return displayValue;
-    const auto& s = hostSlotInfo_[static_cast<size_t>(slotIndex)];
-    magda::ParameterInfo info;
-    info.minValue = s.minValue;
-    info.maxValue = s.maxValue;
-    info.scale = s.scale;
-    if (std::isfinite(s.scaleAnchor))
-        info.scaleAnchor = s.scaleAnchor;
-    info.choices = s.choices;
-    return magda::ParameterUtils::realToNormalized(displayValue, info);
-}
-
-float MagdaPolySynthCompiledPlugin::nativeValueToDisplayValue(int slotIndex,
-                                                              float nativeValue) const {
-    if (slotIndex < 0 || slotIndex >= kHostSlotCount)
-        return nativeValue;
-    const auto& s = hostSlotInfo_[static_cast<size_t>(slotIndex)];
-    magda::ParameterInfo info;
-    info.minValue = s.minValue;
-    info.maxValue = s.maxValue;
-    info.scale = s.scale;
-    if (std::isfinite(s.scaleAnchor))
-        info.scaleAnchor = s.scaleAnchor;
-    info.choices = s.choices;
-    return magda::ParameterUtils::normalizedToReal(nativeValue, info);
+    return infos;
 }
 
 const CompiledPluginSpec& getMagdaPolySynthSpec() {
@@ -720,9 +211,8 @@ const CompiledPluginSpec& getMagdaPolySynthSpec() {
         .description = "Compiled Faust polyphonic synth: four detunable oscillators "
                        "(sine/saw/square/triangle) into a multimode filter with its own "
                        "envelope, plus an ADSR amp envelope. 16-voice, MIDI-driven.",
-        .createPlugin = [](const DevicePluginCreationContext& context) -> DevicePluginPtr {
-            return tracktion_adapter::pluginHandle(
-                new MagdaPolySynthCompiledPlugin(tracktion_adapter::creationInfo(context)));
+        .createDevice = [](const DevicePluginCreationContext&) -> std::unique_ptr<MagdaDevice> {
+            return std::make_unique<MagdaPolySynthCompiledPlugin>();
         },
         .isInstrument = true,
     };

--- a/magda/daw/audio/plugins/compiled/MagdaPolySynthCompiledPlugin.hpp
+++ b/magda/daw/audio/plugins/compiled/MagdaPolySynthCompiledPlugin.hpp
@@ -1,21 +1,11 @@
 #pragma once
 
-#include <tracktion_engine/tracktion_engine.h>
-
-#include <array>
-#include <atomic>
-#include <memory>
 #include <vector>
 
-#include "../FaustParamPool.hpp"
-#include "core/ParameterInfo.hpp"
-#include "plugins/compiled/tracktion/CompiledFaustTracktionAdapter.hpp"
+#include "plugins/compiled/MagdaCompiledPolyInstrument.hpp"
 
-// mydsp_poly (Faust's polyphonic voice allocator) and the single-voice dsp are
-// forward-declared via their Faust base so the header doesn't pull in the Faust
-// SDK; the .cpp owns them.
+// The single-voice dsp is forward-declared via its Faust base; the .cpp owns it.
 class dsp;
-class dsp_poly;
 
 namespace magda::daw::audio::compiled {
 
@@ -34,46 +24,15 @@ namespace magda::daw::audio::compiled {
  *
  * First compiled instrument in MAGDA (all other compiled devices are effects).
  */
-class MagdaPolySynthCompiledPlugin : public te::Plugin, public ICompiledFaustPlugin {
+class MagdaPolySynthCompiledPlugin : public MagdaCompiledPolyInstrument {
   public:
     static const char* xmlTypeName;
 
-    explicit MagdaPolySynthCompiledPlugin(const te::PluginCreationInfo& info);
-    ~MagdaPolySynthCompiledPlugin() override;
+    MagdaPolySynthCompiledPlugin();
 
-    juce::String getName() const override;
-    juce::String getPluginType() override;
-    juce::String getShortName(int) override;
-    juce::String getSelectableDescription() override;
-
-    void initialise(const te::PluginInitialisationInfo& info) override;
-    void deinitialise() override;
-    void reset() override;
-    void applyToBuffer(const te::PluginRenderContext& fc) override;
-
-    bool takesMidiInput() override {
-        return true;
-    }
-    bool takesAudioInput() override {
-        return false;
-    }
-    bool isSynth() override {
-        return true;
-    }
-    bool producesAudioWhenNoAudioInput() override {
-        return true;
-    }
-    double getTailLength() const override {
-        return 0.0;
-    }
-
-    // Slot ordering matches the [idx:N] pins inside magda_polysynth.dsp:
-    // four contiguous slots per oscillator (wave / level / coarse / fine),
-    // then the filter section, then the amp envelope.
     static constexpr int kOscSlotCount = 4;  // slots per oscillator
     static constexpr int kNumOscillators = 4;
     static constexpr int kOscBaseSlot = 0;  // osc n -> kOscBaseSlot + 4*(n-1)
-
     static constexpr int kFilterTypeSlot = 16;
     static constexpr int kCutoffSlot = 17;
     static constexpr int kResonanceSlot = 18;
@@ -82,139 +41,58 @@ class MagdaPolySynthCompiledPlugin : public te::Plugin, public ICompiledFaustPlu
     static constexpr int kFilterDecaySlot = 21;
     static constexpr int kFilterSustainSlot = 22;
     static constexpr int kFilterReleaseSlot = 23;
-
     static constexpr int kAmpAttackSlot = 24;
     static constexpr int kAmpDecaySlot = 25;
     static constexpr int kAmpSustainSlot = 26;
     static constexpr int kAmpReleaseSlot = 27;
-
-    // Filter drive + slope (idx:28/29 in the dsp; appended after the amp
-    // envelope so the existing slot indices stay stable).
     static constexpr int kFilterDriveSlot = 28;
     static constexpr int kFilterSlopeSlot = 29;
-
-    // Performance controls (appended). Bend Range has a dsp [idx:30] zone (it
-    // scales the MIDI-driven `bend` input); Voice Mode is wrapper-only (it
-    // selects which engine renders, so it has no dsp zone - a decorative dsp
-    // control would be dead-code-eliminated by Faust).
     static constexpr int kBendRangeSlot = 30;
     static constexpr int kVoiceModeSlot = 31;
-    // Glide (portamento) has a dsp [idx:32] zone; the wrapper zeroes it on the
-    // poly voices so only the Mono/Legato voice glides.
     static constexpr int kGlideSlot = 32;
-    // Per-oscillator phase reset (restart that oscillator's phase on note-on),
-    // discrete Off/On. osc n -> kOscResetBaseSlot + (n - 1), idx 33..36.
     static constexpr int kOscResetBaseSlot = 33;
-    // Velocity routing: depth into amplitude, and octaves into the filter cutoff.
     static constexpr int kVelAmpSlot = 37;
     static constexpr int kVelFilterSlot = 38;
-    // Per-oscillator enable (mute that oscillator), discrete Off/On, default On.
-    // osc n -> kOscEnableBaseSlot + (n - 1), idx 39..42.
     static constexpr int kOscEnableBaseSlot = 39;
-    // Master output gain (dB), applied per voice after the soft-clip.
     static constexpr int kOutputGainSlot = 43;
-
     static constexpr int kHostSlotCount = 44;
-
-    enum VoiceMode { Poly = 0, Mono = 1, Legato = 2 };
-
     static constexpr int kNumVoices = 16;
 
-    te::AutomatableParameter* getSlotParameter(int slotIndex) const;
-    float displayValueToNativeValue(int slotIndex, float displayValue) const;
-    float nativeValueToDisplayValue(int slotIndex, float nativeValue) const;
+    juce::String devicePluginId() const override {
+        return xmlTypeName;
+    }
+    juce::String deviceName() const override {
+        return "Poly Synth";
+    }
 
-    using HostSlotInfo = CompiledHostSlotInfo;
-    const HostSlotInfo& getSlotInfo(int slotIndex) const;
+    // Where this synth's panel puts the controls the base would otherwise
+    // append. Gain is -1 because the dsp trims and soft-clips per voice
+    // (`outGain`, [idx:43]), so a second output stage in the wrapper would be
+    // limiting a signal that has already been limited.
+    int gainSlot() const override {
+        return -1;
+    }
+    int voiceModeSlot() const override {
+        return kVoiceModeSlot;
+    }
 
-    // ICompiledFaustPlugin
-    int hostSlotCount() const override {
-        return kHostSlotCount;
+  protected:
+    ::dsp* createVoiceDsp() const override;
+    std::vector<HostSlotInfo> slotInfos() const override;
+    const char* slotIdPrefix() const override {
+        return "magda_polysynth_";
     }
-    const CompiledHostSlotInfo& hostSlotInfo(int slotIndex) const override {
-        return getSlotInfo(slotIndex);
+    int numVoices() const override {
+        return kNumVoices;
     }
-    DeviceParameterHandle hostSlotParameter(int slotIndex) const override {
-        return tracktion_adapter::parameterHandle(getSlotParameter(slotIndex));
+    bool hasVoiceModes() const override {
+        return true;
     }
-    float displayToNormalized(int slotIndex, float displayValue) const override {
-        return displayValueToNativeValue(slotIndex, displayValue);
-    }
-    float normalizedToDisplay(int slotIndex, float normalizedValue) const override {
-        return nativeValueToDisplayValue(slotIndex, normalizedValue);
+    int glideVoiceSlot() const override {
+        return kGlideSlot;
     }
 
   private:
-    void buildHostParameters();
-    void rebuildEngineState(int sampleRate);
-
-    int readVoiceModeIndex() const;
-    // Reset both engines and the held-note stack (used on a Poly/Mono switch).
-    void resetAllVoices();
-    // Mono/Legato note handling on the dedicated single voice. handleMonoNoteOn
-    // returns true when a one-sample gate edge is needed to retrigger (Mono only).
-    bool handleMonoNoteOn(int note, int velocity, int mode);
-    void handleMonoNoteOff(int note);
-    // Releases EVERY poly voice currently sounding (or legato-targeting) the
-    // given pitch. Used both before a re-trigger (one voice per pitch) and on
-    // note-off. Unlike mydsp_poly::keyOff — which releases only the oldest
-    // matching voice and logs "Playing pitch not found" to stderr when there is
-    // none — this is a silent no-op for unmatched note-offs and self-heals
-    // orphaned voices. Duplicate on/off streams for the same pitch are
-    // legitimate (e.g. a freshly recorded clip playing back merged with the
-    // still-monitored live input that fed it), so unbalanced deliveries must
-    // never strand a sounding voice.
-    void releasePolyVoicesForPitch(int pitch);
-
-    std::unique_ptr<::dsp_poly> poly_;
-    // Dedicated single voice for Mono/Legato: the wrapper owns its freq/gate/gain
-    // zones directly (the poly engine skips idle voices, so it cannot be driven
-    // zone-only). Always allocated; only rendered when Voice Mode != Poly.
-    std::unique_ptr<::dsp> monoVoice_;
-    int numOutputs_ = 0;
-    double sampleRate_ = 44100.0;
-
-    // Per host slot: that control's zone in EVERY poly voice (group=false gives
-    // each voice its own zones). Harvested by [idx:N], skipping the proxy box.
-    std::array<std::vector<FAUSTFLOAT*>, kHostSlotCount> voiceZonesBySlot_;
-    // Same control's single zone in the mono voice (nullptr if it has none, e.g.
-    // the wrapper-only Voice Mode slot).
-    std::array<FAUSTFLOAT*, kHostSlotCount> monoZonesBySlot_{};
-
-    // MIDI-driven pitch-bend zones (no [idx]): per poly voice, and the mono voice.
-    std::vector<FAUSTFLOAT*> voiceBendZones_;
-    FAUSTFLOAT* monoBendZone_ = nullptr;
-    // Mono voice's reserved freq/gain/gate zones, driven directly from MIDI.
-    FAUSTFLOAT* monoFreqZone_ = nullptr;
-    FAUSTFLOAT* monoGainZone_ = nullptr;
-    FAUSTFLOAT* monoGateZone_ = nullptr;
-
-    // Mono/Legato held-note stack (most-recent at the back) and live bend.
-    struct HeldNote {
-        int note = 0;
-        float gain = 0.0f;
-    };
-    std::vector<HeldNote> heldNotes_;
-    // reset() may be called from the message thread (e.g. AudioBridge::
-    // resetSynthsOnTrack after a record pass) while the audio thread is inside
-    // compute()/keyOn()/keyOff(). Walking the Faust voice table from two
-    // threads is a data race, so reset() only raises this flag and the flush
-    // itself runs at the top of the next applyToBuffer() on the audio thread.
-    std::atomic<bool> pendingVoiceFlush_{false};
-    float currentBend_ = 0.0f;  // normalised [-1, 1]
-    int lastVoiceMode_ = 0;
-    // Transport play state from the previous block. On the playing->stopped edge
-    // we flush all voices: clip playback doesn't send note-offs when the user
-    // hits Stop mid-note, so the voice would stay gated on and keep sounding.
-    bool wasPlaying_ = false;
-
-    std::array<HostSlotInfo, kHostSlotCount> hostSlotInfo_;
-    std::array<te::AutomatableParameter::Ptr, kHostSlotCount> hostParams_;
-    std::array<juce::CachedValue<float>, kHostSlotCount> hostCached_;
-
-    juce::AudioBuffer<float> scratchOut_;
-    std::vector<float*> outPtrs_;
-
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(MagdaPolySynthCompiledPlugin)
 };
 

--- a/magda/daw/audio/plugins/compiled/MagdaReverbCompiledPlugin.cpp
+++ b/magda/daw/audio/plugins/compiled/MagdaReverbCompiledPlugin.cpp
@@ -1,409 +1,91 @@
 #include "plugins/compiled/MagdaReverbCompiledPlugin.hpp"
 
-#include <algorithm>
-#include <cmath>
-#include <map>
-
-#include "core/ParameterUtils.hpp"
+#include "core/ParameterInfo.hpp"
 #include "faust/dsp/dsp.h"
 #include "faust/gui/UI.h"
 #include "faust/gui/meta.h"
-#include "plugins/FaustMetadataParser.hpp"
-#include "plugins/FaustParamInfo.hpp"
-#include "plugins/compiled/CompiledPluginRegistry.hpp"
-#include "plugins/tracktion/TracktionDeviceAdapters.hpp"
-
-// All three engine DSPs are #included into THIS translation unit only —
-// each generated `.cpp` defines a self-contained class, so co-locating
-// them lets us instantiate one of each without conflicts. Mirrors the
-// MagdaFilter / MagdaCompressor wrappers.
 #include "magda_reverb_hall.generated.cpp"
 #include "magda_reverb_plate.generated.cpp"
 #include "magda_reverb_room.generated.cpp"
+#include "plugins/compiled/CompiledPluginRegistry.hpp"
 
 namespace magda::daw::audio::compiled {
 
 const char* MagdaReverbCompiledPlugin::xmlTypeName = "magda_reverb";
 
-namespace {
+MagdaReverbCompiledPlugin::MagdaReverbCompiledPlugin() {
+    initEffect();
+}
 
-// ============================================================================
-// EngineHarvester — stripped-down UI that records each control's idx,
-// kind, and zone pointer. Same shape the other multi-engine wrappers use.
-// ============================================================================
-
-struct EngineHarvest {
-    struct Control {
-        int idx = -1;
-        FaustParamSlot::Kind kind = FaustParamSlot::Kind::Continuous;
-        FAUSTFLOAT* zone = nullptr;
-    };
-    std::vector<Control> controls;
-};
-
-class EngineHarvester : public ::UI {
-  public:
-    EngineHarvest harvest;
-
-    void openTabBox(const char*) override {}
-    void openHorizontalBox(const char*) override {}
-    void openVerticalBox(const char*) override {}
-    void closeBox() override {}
-
-    void addButton(const char* label, FAUSTFLOAT* zone) override {
-        emitControl(FaustParamSlot::Kind::Boolean, label, zone);
+::dsp* MagdaReverbCompiledPlugin::createEngineDsp(int engineIndex) const {
+    switch (static_cast<ReverbEngine>(engineIndex)) {
+        case ReverbEngine::Plate:
+            return new MagdaReverbPlateDsp();
+        case ReverbEngine::Hall:
+            return new MagdaReverbHallDsp();
+        case ReverbEngine::Room:
+            return new MagdaReverbRoomDsp();
     }
-    void addCheckButton(const char* label, FAUSTFLOAT* zone) override {
-        emitControl(FaustParamSlot::Kind::Boolean, label, zone);
-    }
-    void addVerticalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT, FAUSTFLOAT, FAUSTFLOAT,
-                           FAUSTFLOAT) override {
-        emitControl(FaustParamSlot::Kind::Continuous, label, zone);
-    }
-    void addHorizontalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT, FAUSTFLOAT,
-                             FAUSTFLOAT, FAUSTFLOAT) override {
-        emitControl(FaustParamSlot::Kind::Continuous, label, zone);
-    }
-    void addNumEntry(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT, FAUSTFLOAT, FAUSTFLOAT,
-                     FAUSTFLOAT) override {
-        emitControl(FaustParamSlot::Kind::Continuous, label, zone);
-    }
-    void addHorizontalBargraph(const char*, FAUSTFLOAT*, FAUSTFLOAT, FAUSTFLOAT) override {}
-    void addVerticalBargraph(const char*, FAUSTFLOAT*, FAUSTFLOAT, FAUSTFLOAT) override {}
-    void addSoundfile(const char*, const char*, Soundfile**) override {}
-
-    void declare(FAUSTFLOAT* zone, const char* key, const char* value) override {
-        if (zone == nullptr)
-            return;
-        const auto k = juce::String::fromUTF8(key != nullptr ? key : "").toLowerCase();
-        const auto v = juce::String::fromUTF8(value != nullptr ? value : "");
-        applyFaustAnnotation(k, v, pendingByZone_[zone]);
-    }
-
-  private:
-    void emitControl(FaustParamSlot::Kind kind, const char* rawLabel, FAUSTFLOAT* zone) {
-        const auto parsed =
-            parseFaustLabel(juce::String::fromUTF8(rawLabel != nullptr ? rawLabel : ""));
-        ControlMetadata merged = parsed.metadata;
-        if (zone != nullptr) {
-            if (auto it = pendingByZone_.find(zone); it != pendingByZone_.end()) {
-                mergeFaustMetadata(merged, it->second);
-                pendingByZone_.erase(it);
-            }
-        }
-
-        EngineHarvest::Control c;
-        c.idx = merged.slotIndex;
-        c.kind = merged.isChoiceStyle() ? FaustParamSlot::Kind::Discrete : kind;
-        c.zone = zone;
-        harvest.controls.push_back(std::move(c));
-    }
-
-    std::map<FAUSTFLOAT*, ControlMetadata> pendingByZone_;
-};
-
-const EngineHarvest::Control* findByIdx(const EngineHarvest& h, int idx) {
-    for (const auto& c : h.controls)
-        if (c.idx == idx)
-            return &c;
     return nullptr;
 }
 
-magda::ParameterInfo parameterInfoForSlot(const CompiledHostSlotInfo& s) {
-    magda::ParameterInfo info;
-    info.minValue = s.minValue;
-    info.maxValue = s.maxValue;
-    info.defaultValue = s.defaultValue;
-    info.unit = s.unit;
-    info.scale = s.scale;
-    if (std::isfinite(s.scaleAnchor))
-        info.scaleAnchor = s.scaleAnchor;
-    info.choices = s.choices;
-    return info;
-}
+std::vector<MagdaReverbCompiledPlugin::HostSlotInfo> MagdaReverbCompiledPlugin::slotInfos() const {
+    std::vector<HostSlotInfo> infos(kHostSlotCount);
+    infos[kEngineSlot].name = "Engine";
+    infos[kEngineSlot].scale = magda::ParameterScale::Discrete;
+    infos[kEngineSlot].choices = {"Plate", "Hall", "Room"};
+    infos[kEngineSlot].minValue = 0.0f;
+    infos[kEngineSlot].maxValue = static_cast<float>(infos[kEngineSlot].choices.size() - 1);
+    infos[kEngineSlot].defaultValue = 0.0f;
 
-}  // namespace
+    infos[kMixSlot] = {.name = "Mix",
+                       .scale = magda::ParameterScale::Linear,
+                       .minValue = 0.0f,
+                       .maxValue = 1.0f,
+                       .defaultValue = 0.3f};
+    infos[kPredelaySlot] = {.name = "Predelay",
+                            .unit = magda::technicalText(magda::TechnicalTextToken::Milliseconds),
+                            .scale = magda::ParameterScale::Linear,
+                            .minValue = 0.0f,
+                            .maxValue = 250.0f,
+                            .defaultValue = 20.0f};
+    infos[kDecaySlot] = {.name = "Decay",
+                         .scale = magda::ParameterScale::Linear,
+                         .minValue = 0.0f,
+                         .maxValue = 100.0f,
+                         .defaultValue = 50.0f};
+    infos[kDampingSlot] = {.name = "Damping",
+                           .scale = magda::ParameterScale::Linear,
+                           .minValue = 0.0f,
+                           .maxValue = 100.0f,
+                           .defaultValue = 30.0f};
+    infos[kLowCutSlot] = {.name = "Low Cut",
+                          .unit = magda::technicalText(magda::TechnicalTextToken::Hertz),
+                          .scale = magda::ParameterScale::Logarithmic,
+                          .minValue = 20.0f,
+                          .maxValue = 500.0f,
+                          .defaultValue = 40.0f,
+                          .scaleAnchor = 80.0f};
+    infos[kHighCutSlot] = {.name = "High Cut",
+                           .unit = magda::technicalText(magda::TechnicalTextToken::Hertz),
+                           .scale = magda::ParameterScale::Logarithmic,
+                           .minValue = 1000.0f,
+                           .maxValue = 18000.0f,
+                           .defaultValue = 12000.0f,
+                           .scaleAnchor = 8000.0f};
+    infos[kWidthSlot] = {.name = "Width",
+                         .scale = magda::ParameterScale::Linear,
+                         .minValue = 0.0f,
+                         .maxValue = 200.0f,
+                         .defaultValue = 100.0f};
+    infos[kOutputSlot] = {.name = "Output",
+                          .unit = magda::technicalText(magda::TechnicalTextToken::Decibels),
+                          .scale = magda::ParameterScale::Linear,
+                          .minValue = -24.0f,
+                          .maxValue = 12.0f,
+                          .defaultValue = 0.0f};
 
-MagdaReverbCompiledPlugin::MagdaReverbCompiledPlugin(const te::PluginCreationInfo& info)
-    : te::Plugin(info) {
-    engines_[static_cast<size_t>(ReverbEngine::Plate)].dsp =
-        std::make_unique<MagdaReverbPlateDsp>();
-    engines_[static_cast<size_t>(ReverbEngine::Hall)].dsp = std::make_unique<MagdaReverbHallDsp>();
-    engines_[static_cast<size_t>(ReverbEngine::Room)].dsp = std::make_unique<MagdaReverbRoomDsp>();
-
-    constexpr int kProvisionalSampleRate = 44100;
-    rebuildEngineState(kProvisionalSampleRate);
-    buildHostParameters();
-}
-
-MagdaReverbCompiledPlugin::~MagdaReverbCompiledPlugin() {
-    notifyListenersOfDeletion();
-    for (auto& p : hostParams_)
-        if (p)
-            p->detachFromCurrentValue();
-}
-
-juce::String MagdaReverbCompiledPlugin::getName() const {
-    return "Reverb";
-}
-juce::String MagdaReverbCompiledPlugin::getPluginType() {
-    return xmlTypeName;
-}
-juce::String MagdaReverbCompiledPlugin::getShortName(int) {
-    return "Reverb";
-}
-juce::String MagdaReverbCompiledPlugin::getSelectableDescription() {
-    return "Reverb";
-}
-
-void MagdaReverbCompiledPlugin::rebuildEngineState(int sampleRate) {
-    for (auto& e : engines_) {
-        if (!e.dsp)
-            continue;
-        e.dsp->init(sampleRate);
-        e.numInputs = e.dsp->getNumInputs();
-        e.numOutputs = e.dsp->getNumOutputs();
-
-        EngineHarvester harvester;
-        e.dsp->buildUserInterface(&harvester);
-
-        e.zones.fill(nullptr);
-
-        // Slot 0 (Engine) lives only in the wrapper — no DSP zone. All
-        // other slots are looked up by their `[idx:N]` annotation, with
-        // N == host slot index. Every engine exposes every slot 1..8.
-        for (int i = 1; i < kHostSlotCount; ++i) {
-            if (auto* c = findByIdx(harvester.harvest, i))
-                e.zones[static_cast<size_t>(i)] = c->zone;
-        }
-    }
-}
-
-void MagdaReverbCompiledPlugin::buildHostParameters() {
-    hostSlotInfo_[kEngineSlot].name = "Engine";
-    hostSlotInfo_[kEngineSlot].scale = magda::ParameterScale::Discrete;
-    hostSlotInfo_[kEngineSlot].choices = {"Plate", "Hall", "Room"};
-    hostSlotInfo_[kEngineSlot].minValue = 0.0f;
-    hostSlotInfo_[kEngineSlot].maxValue =
-        static_cast<float>(hostSlotInfo_[kEngineSlot].choices.size() - 1);
-    hostSlotInfo_[kEngineSlot].defaultValue = 0.0f;
-
-    hostSlotInfo_[kMixSlot] = {.name = "Mix",
-                               .scale = magda::ParameterScale::Linear,
-                               .minValue = 0.0f,
-                               .maxValue = 1.0f,
-                               .defaultValue = 0.3f};
-    hostSlotInfo_[kPredelaySlot] = {
-        .name = "Predelay",
-        .unit = magda::technicalText(magda::TechnicalTextToken::Milliseconds),
-        .scale = magda::ParameterScale::Linear,
-        .minValue = 0.0f,
-        .maxValue = 250.0f,
-        .defaultValue = 20.0f};
-    hostSlotInfo_[kDecaySlot] = {.name = "Decay",
-                                 .scale = magda::ParameterScale::Linear,
-                                 .minValue = 0.0f,
-                                 .maxValue = 100.0f,
-                                 .defaultValue = 50.0f};
-    hostSlotInfo_[kDampingSlot] = {.name = "Damping",
-                                   .scale = magda::ParameterScale::Linear,
-                                   .minValue = 0.0f,
-                                   .maxValue = 100.0f,
-                                   .defaultValue = 30.0f};
-    hostSlotInfo_[kLowCutSlot] = {.name = "Low Cut",
-                                  .unit = magda::technicalText(magda::TechnicalTextToken::Hertz),
-                                  .scale = magda::ParameterScale::Logarithmic,
-                                  .minValue = 20.0f,
-                                  .maxValue = 500.0f,
-                                  .defaultValue = 40.0f,
-                                  .scaleAnchor = 80.0f};
-    hostSlotInfo_[kHighCutSlot] = {.name = "High Cut",
-                                   .unit = magda::technicalText(magda::TechnicalTextToken::Hertz),
-                                   .scale = magda::ParameterScale::Logarithmic,
-                                   .minValue = 1000.0f,
-                                   .maxValue = 18000.0f,
-                                   .defaultValue = 12000.0f,
-                                   .scaleAnchor = 8000.0f};
-    hostSlotInfo_[kWidthSlot] = {.name = "Width",
-                                 .scale = magda::ParameterScale::Linear,
-                                 .minValue = 0.0f,
-                                 .maxValue = 200.0f,
-                                 .defaultValue = 100.0f};
-    hostSlotInfo_[kOutputSlot] = {.name = "Output",
-                                  .unit = magda::technicalText(magda::TechnicalTextToken::Decibels),
-                                  .scale = magda::ParameterScale::Linear,
-                                  .minValue = -24.0f,
-                                  .maxValue = 12.0f,
-                                  .defaultValue = 0.0f};
-
-    juce::NormalisableRange<float> normalisedRange{0.0f, 1.0f};
-    auto* undoManager = getUndoManager();
-
-    for (int i = 0; i < kHostSlotCount; ++i) {
-        const auto& slot = hostSlotInfo_[i];
-        const juce::String id = "magda_reverb_" + slot.name.toLowerCase().replace(" ", "_");
-        const juce::Identifier identifier(id);
-        const auto info = parameterInfoForSlot(slot);
-        const float defaultNormalized =
-            magda::ParameterUtils::realToNormalized(slot.defaultValue, info);
-        hostCached_[i].referTo(state, identifier, undoManager, defaultNormalized);
-
-        auto param = addParam(
-            id, slot.name, normalisedRange,
-            [info](float normalized) {
-                const float real = magda::ParameterUtils::normalizedToReal(normalized, info);
-                return magda::ParameterUtils::formatValue(real, info);
-            },
-            [info](const juce::String& text) {
-                auto parsed = magda::ParameterUtils::parseValue(text, info);
-                if (parsed)
-                    return magda::ParameterUtils::realToNormalized(*parsed, info);
-                return 0.0f;
-            });
-        param->attachToCurrentValue(hostCached_[i]);
-        hostParams_[i] = param;
-    }
-}
-
-void MagdaReverbCompiledPlugin::initialise(const te::PluginInitialisationInfo& info) {
-    rebuildEngineState(static_cast<int>(info.sampleRate));
-
-    int maxIn = 0, maxOut = 0;
-    for (const auto& e : engines_) {
-        maxIn = std::max(maxIn, e.numInputs);
-        maxOut = std::max(maxOut, e.numOutputs);
-    }
-    scratchIn_.setSize(maxIn, info.blockSizeSamples, false, true, true);
-    scratchOut_.setSize(maxOut, info.blockSizeSamples, false, true, true);
-    inPtrs_.assign(static_cast<size_t>(maxIn), nullptr);
-    outPtrs_.assign(static_cast<size_t>(maxOut), nullptr);
-}
-
-void MagdaReverbCompiledPlugin::deinitialise() {
-    scratchIn_.setSize(0, 0);
-    scratchOut_.setSize(0, 0);
-    inPtrs_.clear();
-    outPtrs_.clear();
-}
-
-void MagdaReverbCompiledPlugin::reset() {
-    for (auto& e : engines_)
-        if (e.dsp)
-            e.dsp->instanceClear();
-}
-
-void MagdaReverbCompiledPlugin::applyToBuffer(const te::PluginRenderContext& fc) {
-    if (!fc.destBuffer || fc.bufferNumSamples <= 0)
-        return;
-
-    auto realForSlot = [&](int slot) -> float {
-        const auto& s = hostSlotInfo_[static_cast<size_t>(slot)];
-        const auto info = parameterInfoForSlot(s);
-        const float norm = hostParams_[static_cast<size_t>(slot)]->getCurrentValue();
-        return magda::ParameterUtils::normalizedToReal(norm, info);
-    };
-
-    const float engineNorm = hostParams_[kEngineSlot]->getCurrentValue();
-    const int engineIndex = juce::jlimit(
-        0, kEngineCount - 1,
-        static_cast<int>(std::round(engineNorm * static_cast<float>(kEngineCount - 1))));
-    activeEngine_.store(engineIndex);
-
-    // Write shared zones into ALL engines so an engine swap preserves the
-    // user's settings on the first sample of the new engine.
-    for (int slot = 1; slot < kHostSlotCount; ++slot) {
-        const float real = realForSlot(slot);
-        for (auto& e : engines_) {
-            if (auto* zone = e.zones[static_cast<size_t>(slot)])
-                *zone = static_cast<FAUSTFLOAT>(real);
-        }
-    }
-
-    auto& active = engines_[static_cast<size_t>(engineIndex)];
-    if (!active.dsp)
-        return;
-
-    const int numSamples = fc.bufferNumSamples;
-    const int startSample = fc.bufferStartSample;
-    const int hostChannels = fc.destBuffer->getNumChannels();
-    const int numInputs = active.numInputs;
-    const int numOutputs = active.numOutputs;
-    if (hostChannels <= 0 || numInputs <= 0 || numOutputs <= 0)
-        return;
-
-    if (scratchIn_.getNumChannels() < numInputs || scratchIn_.getNumSamples() < numSamples)
-        scratchIn_.setSize(numInputs, numSamples, false, true, true);
-    if (scratchOut_.getNumChannels() < numOutputs || scratchOut_.getNumSamples() < numSamples)
-        scratchOut_.setSize(numOutputs, numSamples, false, true, true);
-    if (static_cast<int>(inPtrs_.size()) < numInputs)
-        inPtrs_.resize(static_cast<size_t>(numInputs), nullptr);
-    if (static_cast<int>(outPtrs_.size()) < numOutputs)
-        outPtrs_.resize(static_cast<size_t>(numOutputs), nullptr);
-
-    for (int ch = 0; ch < numInputs; ++ch) {
-        float* dst = scratchIn_.getWritePointer(ch);
-        if (ch < hostChannels) {
-            const float* src = fc.destBuffer->getReadPointer(ch, startSample);
-            std::copy(src, src + numSamples, dst);
-        } else {
-            std::fill(dst, dst + numSamples, 0.0f);
-        }
-        inPtrs_[static_cast<size_t>(ch)] = dst;
-    }
-    for (int ch = 0; ch < numOutputs; ++ch) {
-        outPtrs_[static_cast<size_t>(ch)] = (ch < hostChannels)
-                                                ? fc.destBuffer->getWritePointer(ch, startSample)
-                                                : scratchOut_.getWritePointer(ch);
-    }
-
-    active.dsp->compute(numSamples, inPtrs_.data(), outPtrs_.data());
-
-    // Sanitise output — clamp and replace non-finite samples. Reverb
-    // networks can occasionally diverge if Decay is automated past safe
-    // limits or if a denormal slips through; the clamp is a safety net.
-    const int channelsToSanitise = std::min(hostChannels, numOutputs);
-    for (int ch = 0; ch < channelsToSanitise; ++ch) {
-        float* out = fc.destBuffer->getWritePointer(ch, startSample);
-        for (int i = 0; i < numSamples; ++i) {
-            const float sample = out[i];
-            out[i] = std::isfinite(sample) ? juce::jlimit(-16.0f, 16.0f, sample) : 0.0f;
-        }
-    }
-    for (int ch = numOutputs; ch < hostChannels; ++ch)
-        fc.destBuffer->clear(ch, startSample, numSamples);
-}
-
-te::AutomatableParameter* MagdaReverbCompiledPlugin::getSlotParameter(int slotIndex) const {
-    if (slotIndex < 0 || slotIndex >= kHostSlotCount)
-        return nullptr;
-    return hostParams_[static_cast<size_t>(slotIndex)].get();
-}
-
-const MagdaReverbCompiledPlugin::HostSlotInfo& MagdaReverbCompiledPlugin::getSlotInfo(
-    int slotIndex) const {
-    static const HostSlotInfo kEmpty;
-    if (slotIndex < 0 || slotIndex >= kHostSlotCount)
-        return kEmpty;
-    return hostSlotInfo_[static_cast<size_t>(slotIndex)];
-}
-
-int MagdaReverbCompiledPlugin::activeEngineIndex() const {
-    return activeEngine_.load(std::memory_order_relaxed);
-}
-
-float MagdaReverbCompiledPlugin::displayValueToNativeValue(int slotIndex,
-                                                           float displayValue) const {
-    if (slotIndex < 0 || slotIndex >= kHostSlotCount)
-        return displayValue;
-    const auto info = parameterInfoForSlot(hostSlotInfo_[static_cast<size_t>(slotIndex)]);
-    return magda::ParameterUtils::realToNormalized(displayValue, info);
-}
-
-float MagdaReverbCompiledPlugin::nativeValueToDisplayValue(int slotIndex, float nativeValue) const {
-    if (slotIndex < 0 || slotIndex >= kHostSlotCount)
-        return nativeValue;
-    const auto info = parameterInfoForSlot(hostSlotInfo_[static_cast<size_t>(slotIndex)]);
-    return magda::ParameterUtils::normalizedToReal(nativeValue, info);
+    return infos;
 }
 
 constexpr AliasSpec kAliases[] = {
@@ -424,9 +106,8 @@ const CompiledPluginSpec& getMagdaReverbSpec() {
                        "<b>Plate</b>: Dattorro diffusion network for studio-plate ambience.\n"
                        "<b>Hall</b>: Zita 8-tap FDN for smooth large-space tails.\n"
                        "<b>Room</b>: Freeverb Schroeder/Moorer network for small-space ambience.",
-        .createPlugin = [](const DevicePluginCreationContext& context) -> DevicePluginPtr {
-            return tracktion_adapter::pluginHandle(
-                new MagdaReverbCompiledPlugin(tracktion_adapter::creationInfo(context)));
+        .createDevice = [](const DevicePluginCreationContext&) -> std::unique_ptr<MagdaDevice> {
+            return std::make_unique<MagdaReverbCompiledPlugin>();
         },
         .aliases = kAliases,
         .aliasCount = static_cast<int>(sizeof(kAliases) / sizeof(kAliases[0])),

--- a/magda/daw/audio/plugins/compiled/MagdaReverbCompiledPlugin.hpp
+++ b/magda/daw/audio/plugins/compiled/MagdaReverbCompiledPlugin.hpp
@@ -1,15 +1,8 @@
 #pragma once
 
-#include <tracktion_engine/tracktion_engine.h>
-
-#include <array>
-#include <atomic>
-#include <memory>
 #include <vector>
 
-#include "../FaustParamPool.hpp"
-#include "core/ParameterInfo.hpp"
-#include "plugins/compiled/tracktion/CompiledFaustTracktionAdapter.hpp"
+#include "plugins/compiled/MagdaCompiledEffect.hpp"
 
 class dsp;
 
@@ -33,50 +26,12 @@ namespace magda::daw::audio::compiled {
  * Damping / Low Cut / High Cut / Width / Output) are written into every
  * engine every block so swapping engines preserves the user's settings.
  */
-class MagdaReverbCompiledPlugin : public te::Plugin, public ICompiledFaustPlugin {
+class MagdaReverbCompiledPlugin : public MagdaCompiledEffect {
   public:
     static const char* xmlTypeName;
 
-    explicit MagdaReverbCompiledPlugin(const te::PluginCreationInfo& info);
-    ~MagdaReverbCompiledPlugin() override;
+    MagdaReverbCompiledPlugin();
 
-    juce::String getName() const override;
-    juce::String getPluginType() override;
-    juce::String getShortName(int) override;
-    juce::String getSelectableDescription() override;
-
-    void initialise(const te::PluginInitialisationInfo& info) override;
-    void deinitialise() override;
-    void reset() override;
-    void applyToBuffer(const te::PluginRenderContext& fc) override;
-
-    bool takesMidiInput() override {
-        return false;
-    }
-    bool takesAudioInput() override {
-        return true;
-    }
-    bool isSynth() override {
-        return false;
-    }
-    int getNumOutputChannelsGivenInputs(int) override {
-        return 2;
-    }
-    bool producesAudioWhenNoAudioInput() override {
-        // True because the reverb has a tail that must keep playing after
-        // dry input stops. TE uses this to schedule processing past the
-        // last live audio sample.
-        return true;
-    }
-    double getTailLength() const override {
-        // Conservative cap covering Hall's worst case (~15s at Decay=100).
-        // TE keeps the plugin processing for this long after audio stops.
-        return 10.0;
-    }
-
-    // Slot ordering — Engine first (top-level mode switch), then the
-    // shared reverb surface. DSP `[idx:N]` values mirror these (idx 0 is
-    // wrapper-only).
     static constexpr int kEngineSlot = 0;
     static constexpr int kMixSlot = 1;
     static constexpr int kPredelaySlot = 2;
@@ -87,62 +42,41 @@ class MagdaReverbCompiledPlugin : public te::Plugin, public ICompiledFaustPlugin
     static constexpr int kWidthSlot = 7;
     static constexpr int kOutputSlot = 8;
     static constexpr int kHostSlotCount = 9;
-
     enum class ReverbEngine { Plate = 0, Hall = 1, Room = 2 };
     static constexpr int kEngineCount = 3;
 
-    te::AutomatableParameter* getSlotParameter(int slotIndex) const;
-
-    float displayValueToNativeValue(int slotIndex, float displayValue) const;
-    float nativeValueToDisplayValue(int slotIndex, float nativeValue) const;
-
-    int activeEngineIndex() const;
-
-    using HostSlotInfo = CompiledHostSlotInfo;
-    const HostSlotInfo& getSlotInfo(int slotIndex) const;
-
-    // ICompiledFaustPlugin
-    int hostSlotCount() const override {
-        return kHostSlotCount;
+    juce::String devicePluginId() const override {
+        return xmlTypeName;
     }
-    const CompiledHostSlotInfo& hostSlotInfo(int slotIndex) const override {
-        return getSlotInfo(slotIndex);
+    juce::String deviceName() const override {
+        return "Reverb";
     }
-    DeviceParameterHandle hostSlotParameter(int slotIndex) const override {
-        return tracktion_adapter::parameterHandle(getSlotParameter(slotIndex));
+
+  protected:
+    ::dsp* createEngineDsp(int engineIndex) const override;
+    std::vector<HostSlotInfo> slotInfos() const override;
+    const char* slotIdPrefix() const override {
+        return "magda_reverb_";
     }
-    float displayToNormalized(int slotIndex, float displayValue) const override {
-        return displayValueToNativeValue(slotIndex, displayValue);
+    int engineCount() const override {
+        return kEngineCount;
     }
-    float normalizedToDisplay(int slotIndex, float normalizedValue) const override {
-        return nativeValueToDisplayValue(slotIndex, normalizedValue);
+    int engineSlot() const override {
+        return kEngineSlot;
+    }
+    int outputChannelCount() const override {
+        return 2;
+    }
+    bool producesAudioWithoutInput() const override {
+        return true;
+    }
+    double tailSeconds() const override {
+        // Conservative cap covering Hall's worst case (~15s at Decay=100):
+        // the host keeps the device processing for this long after audio stops.
+        return 10.0;
     }
 
   private:
-    void buildHostParameters();
-    void rebuildEngineState(int sampleRate);
-
-    // Per-engine state. zones_[slotIndex] is the FAUSTFLOAT* into this
-    // engine's DSP for that host slot, or null if the engine doesn't
-    // expose that slot (Engine slot 0 lives only in the wrapper).
-    struct EngineState {
-        std::unique_ptr<::dsp> dsp;
-        std::array<FAUSTFLOAT*, kHostSlotCount> zones{};
-        int numInputs = 0;
-        int numOutputs = 0;
-    };
-    std::array<EngineState, kEngineCount> engines_;
-    std::atomic<int> activeEngine_{0};
-
-    std::array<HostSlotInfo, kHostSlotCount> hostSlotInfo_;
-    std::array<te::AutomatableParameter::Ptr, kHostSlotCount> hostParams_;
-    std::array<juce::CachedValue<float>, kHostSlotCount> hostCached_;
-
-    juce::AudioBuffer<float> scratchIn_;
-    juce::AudioBuffer<float> scratchOut_;
-    std::vector<float*> inPtrs_;
-    std::vector<float*> outPtrs_;
-
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(MagdaReverbCompiledPlugin)
 };
 

--- a/magda/daw/audio/plugins/compiled/MagdaRingModCompiledPlugin.cpp
+++ b/magda/daw/audio/plugins/compiled/MagdaRingModCompiledPlugin.cpp
@@ -1,458 +1,92 @@
 #include "plugins/compiled/MagdaRingModCompiledPlugin.hpp"
 
-#include <algorithm>
-#include <cmath>
-#include <limits>
-#include <map>
-
-#include "core/ParameterUtils.hpp"
+#include "core/ParameterInfo.hpp"
 #include "faust/dsp/dsp.h"
 #include "faust/gui/UI.h"
 #include "faust/gui/meta.h"
 #include "magda_ring_mod.generated.cpp"
-#include "plugins/FaustMetadataParser.hpp"
-#include "plugins/FaustParamInfo.hpp"
 #include "plugins/compiled/CompiledPluginRegistry.hpp"
-#include "plugins/tracktion/TracktionDeviceAdapters.hpp"
 
 namespace magda::daw::audio::compiled {
 
 const char* MagdaRingModCompiledPlugin::xmlTypeName = "magda_ring_mod";
 
-namespace {
-
-struct RingModHarvest {
-    struct Control {
-        int idx = -1;
-        FaustParamSlot::Kind kind = FaustParamSlot::Kind::Continuous;
-        FAUSTFLOAT* zone = nullptr;
-        std::vector<std::pair<float, juce::String>> choices;
-        int gateSlotIndex = -1;
-        bool gateNegated = false;
-    };
-    std::vector<Control> controls;
-};
-
-class RingModHarvester : public ::UI {
-  public:
-    RingModHarvest harvest;
-
-    void openTabBox(const char*) override {}
-    void openHorizontalBox(const char*) override {}
-    void openVerticalBox(const char*) override {}
-    void closeBox() override {}
-
-    void addButton(const char* label, FAUSTFLOAT* zone) override {
-        emitControl(FaustParamSlot::Kind::Boolean, label, zone);
-    }
-    void addCheckButton(const char* label, FAUSTFLOAT* zone) override {
-        emitControl(FaustParamSlot::Kind::Boolean, label, zone);
-    }
-    void addVerticalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT, FAUSTFLOAT, FAUSTFLOAT,
-                           FAUSTFLOAT) override {
-        emitControl(FaustParamSlot::Kind::Continuous, label, zone);
-    }
-    void addHorizontalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT, FAUSTFLOAT,
-                             FAUSTFLOAT, FAUSTFLOAT) override {
-        emitControl(FaustParamSlot::Kind::Continuous, label, zone);
-    }
-    void addNumEntry(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT, FAUSTFLOAT, FAUSTFLOAT,
-                     FAUSTFLOAT) override {
-        emitControl(FaustParamSlot::Kind::Continuous, label, zone);
-    }
-    void addHorizontalBargraph(const char*, FAUSTFLOAT*, FAUSTFLOAT, FAUSTFLOAT) override {}
-    void addVerticalBargraph(const char*, FAUSTFLOAT*, FAUSTFLOAT, FAUSTFLOAT) override {}
-    void addSoundfile(const char*, const char*, Soundfile**) override {}
-
-    void declare(FAUSTFLOAT* zone, const char* key, const char* value) override {
-        if (zone == nullptr)
-            return;
-        const auto k = juce::String::fromUTF8(key != nullptr ? key : "").toLowerCase();
-        const auto v = juce::String::fromUTF8(value != nullptr ? value : "");
-        applyFaustAnnotation(k, v, pendingByZone_[zone]);
-    }
-
-  private:
-    void emitControl(FaustParamSlot::Kind kind, const char* rawLabel, FAUSTFLOAT* zone) {
-        const auto parsed =
-            parseFaustLabel(juce::String::fromUTF8(rawLabel != nullptr ? rawLabel : ""));
-        ControlMetadata merged = parsed.metadata;
-        if (zone != nullptr) {
-            if (auto it = pendingByZone_.find(zone); it != pendingByZone_.end()) {
-                mergeFaustMetadata(merged, it->second);
-                pendingByZone_.erase(it);
-            }
-        }
-
-        RingModHarvest::Control c;
-        c.idx = merged.slotIndex;
-        c.kind = merged.isChoiceStyle() ? FaustParamSlot::Kind::Discrete : kind;
-        c.zone = zone;
-        c.choices = merged.menuChoices;
-        c.gateSlotIndex = merged.gateSlotIndex;
-        c.gateNegated = merged.gateNegated;
-        harvest.controls.push_back(std::move(c));
-    }
-
-    std::map<FAUSTFLOAT*, ControlMetadata> pendingByZone_;
-};
-
-const RingModHarvest::Control* findByIdx(const RingModHarvest& h, int idx) {
-    for (const auto& c : h.controls)
-        if (c.idx == idx)
-            return &c;
-    return nullptr;
+MagdaRingModCompiledPlugin::MagdaRingModCompiledPlugin() {
+    initEffect();
 }
 
-}  // namespace
-
-MagdaRingModCompiledPlugin::MagdaRingModCompiledPlugin(const te::PluginCreationInfo& info)
-    : te::Plugin(info) {
-    dsp_ = std::make_unique<MagdaRingModDsp>();
-    constexpr int kProvisionalSampleRate = 44100;
-    rebuildEngineState(kProvisionalSampleRate);
-    buildHostParameters();
+::dsp* MagdaRingModCompiledPlugin::createEngineDsp(int) const {
+    return new MagdaRingModDsp();
 }
 
-MagdaRingModCompiledPlugin::~MagdaRingModCompiledPlugin() {
-    notifyListenersOfDeletion();
-    for (auto& p : hostParams_)
-        if (p)
-            p->detachFromCurrentValue();
-}
+std::vector<MagdaRingModCompiledPlugin::HostSlotInfo> MagdaRingModCompiledPlugin::slotInfos()
+    const {
+    std::vector<HostSlotInfo> infos(kHostSlotCount);
+    // The Division choices are the dsp's own [style:menu{...}]: the labels
+    // read as musical divisions and the values are the quarter-note
+    // multipliers the zone wants, so neither list is restated here.
+    const auto divisionValues = menuValuesForIdx(kDivisionSlot);
+    infos[kSyncSlot] = {.name = "Sync",
+                        .scale = magda::ParameterScale::Discrete,
+                        .minValue = 0.0f,
+                        .maxValue = 1.0f,
+                        .defaultValue = 0.0f,
+                        .scaleAnchor = std::numeric_limits<float>::quiet_NaN(),
+                        .choices = {"Off", "On"}};
 
-juce::String MagdaRingModCompiledPlugin::getName() const {
-    return "Ring Mod";
-}
-juce::String MagdaRingModCompiledPlugin::getPluginType() {
-    return xmlTypeName;
-}
-juce::String MagdaRingModCompiledPlugin::getShortName(int) {
-    return "Ring Mod";
-}
-juce::String MagdaRingModCompiledPlugin::getSelectableDescription() {
-    return "Ring Mod";
-}
+    infos[kFrequencySlot] = {.name = "Frequency",
+                             .unit = magda::technicalText(magda::TechnicalTextToken::Hertz),
+                             .scale = magda::ParameterScale::Logarithmic,
+                             .minValue = 1.0f,
+                             .maxValue = 5000.0f,
+                             .defaultValue = 100.0f,
+                             .scaleAnchor = 200.0f};
 
-void MagdaRingModCompiledPlugin::rebuildEngineState(int sampleRate) {
-    if (!dsp_)
-        return;
-    dsp_->init(sampleRate);
-    numInputs_ = dsp_->getNumInputs();
-    numOutputs_ = dsp_->getNumOutputs();
+    infos[kDivisionSlot].name = "Division";
+    infos[kDivisionSlot].scale = magda::ParameterScale::Discrete;
+    infos[kDivisionSlot].minValue = 0.0f;
+    infos[kDivisionSlot].maxValue = 0.0f;
+    infos[kDivisionSlot].defaultValue = 0.0f;
 
-    RingModHarvester harvester;
-    dsp_->buildUserInterface(&harvester);
+    infos[kShapeSlot].name = "Shape";
+    infos[kShapeSlot].scale = magda::ParameterScale::Discrete;
+    infos[kShapeSlot].choices = {"Sine", "Triangle", "Square"};
+    infos[kShapeSlot].minValue = 0.0f;
+    infos[kShapeSlot].maxValue = static_cast<float>(infos[kShapeSlot].choices.size() - 1);
+    infos[kShapeSlot].defaultValue = 0.0f;
 
-    zones_.fill(nullptr);
-    bpmZone_ = nullptr;
-    divisionChoiceValues_.clear();
-    divisionChoiceLabels_.clear();
+    infos[kMixSlot] = {.name = "Mix",
+                       .scale = magda::ParameterScale::Linear,
+                       .minValue = 0.0f,
+                       .maxValue = 1.0f,
+                       .defaultValue = 0.5f};
 
-    for (int i = 0; i < kHostSlotCount; ++i) {
-        harvestedGates_[static_cast<size_t>(i)] = {-1, false};
-        if (auto* c = findByIdx(harvester.harvest, i)) {
-            zones_[static_cast<size_t>(i)] = c->zone;
-            harvestedGates_[static_cast<size_t>(i)] = {c->gateSlotIndex, c->gateNegated};
-        }
-    }
-    if (auto* c = findByIdx(harvester.harvest, kBpmSlot))
-        bpmZone_ = c->zone;
+    infos[kWidthSlot] = {.name = "Width",
+                         .scale = magda::ParameterScale::Linear,
+                         .minValue = 0.0f,
+                         .maxValue = 1.0f,
+                         .defaultValue = 0.5f};
 
-    if (auto* c = findByIdx(harvester.harvest, kDivisionSlot)) {
-        auto sorted = c->choices;
-        std::sort(sorted.begin(), sorted.end(),
-                  [](const auto& a, const auto& b) { return a.first < b.first; });
-        divisionChoiceValues_.reserve(sorted.size());
-        divisionChoiceLabels_.reserve(sorted.size());
-        for (const auto& choice : sorted) {
-            divisionChoiceValues_.push_back(choice.first);
-            divisionChoiceLabels_.push_back(choice.second);
-        }
-    }
-}
+    infos[kSourceSlot].name = "Source";
+    infos[kSourceSlot].scale = magda::ParameterScale::Discrete;
+    infos[kSourceSlot].choices = {"Oscillator", "Sidechain"};
+    infos[kSourceSlot].minValue = 0.0f;
+    infos[kSourceSlot].maxValue = static_cast<float>(infos[kSourceSlot].choices.size() - 1);
+    infos[kSourceSlot].defaultValue = 0.0f;
 
-void MagdaRingModCompiledPlugin::buildHostParameters() {
-    hostSlotInfo_[kSyncSlot] = {.name = "Sync",
-                                .scale = magda::ParameterScale::Discrete,
-                                .minValue = 0.0f,
-                                .maxValue = 1.0f,
-                                .defaultValue = 0.0f,
-                                .scaleAnchor = std::numeric_limits<float>::quiet_NaN(),
-                                .choices = {"Off", "On"}};
-
-    hostSlotInfo_[kFrequencySlot] = {.name = "Frequency",
-                                     .unit = magda::technicalText(magda::TechnicalTextToken::Hertz),
-                                     .scale = magda::ParameterScale::Logarithmic,
-                                     .minValue = 1.0f,
-                                     .maxValue = 5000.0f,
-                                     .defaultValue = 100.0f,
-                                     .scaleAnchor = 200.0f};
-
-    hostSlotInfo_[kDivisionSlot].name = "Division";
-    hostSlotInfo_[kDivisionSlot].scale = magda::ParameterScale::Discrete;
-    hostSlotInfo_[kDivisionSlot].minValue = 0.0f;
-    hostSlotInfo_[kDivisionSlot].maxValue = 0.0f;
-    hostSlotInfo_[kDivisionSlot].defaultValue = 0.0f;
-
-    hostSlotInfo_[kShapeSlot].name = "Shape";
-    hostSlotInfo_[kShapeSlot].scale = magda::ParameterScale::Discrete;
-    hostSlotInfo_[kShapeSlot].choices = {"Sine", "Triangle", "Square"};
-    hostSlotInfo_[kShapeSlot].minValue = 0.0f;
-    hostSlotInfo_[kShapeSlot].maxValue =
-        static_cast<float>(hostSlotInfo_[kShapeSlot].choices.size() - 1);
-    hostSlotInfo_[kShapeSlot].defaultValue = 0.0f;
-
-    hostSlotInfo_[kMixSlot] = {.name = "Mix",
-                               .scale = magda::ParameterScale::Linear,
-                               .minValue = 0.0f,
-                               .maxValue = 1.0f,
-                               .defaultValue = 0.5f};
-
-    hostSlotInfo_[kWidthSlot] = {.name = "Width",
-                                 .scale = magda::ParameterScale::Linear,
-                                 .minValue = 0.0f,
-                                 .maxValue = 1.0f,
-                                 .defaultValue = 0.5f};
-
-    hostSlotInfo_[kSourceSlot].name = "Source";
-    hostSlotInfo_[kSourceSlot].scale = magda::ParameterScale::Discrete;
-    hostSlotInfo_[kSourceSlot].choices = {"Oscillator", "Sidechain"};
-    hostSlotInfo_[kSourceSlot].minValue = 0.0f;
-    hostSlotInfo_[kSourceSlot].maxValue =
-        static_cast<float>(hostSlotInfo_[kSourceSlot].choices.size() - 1);
-    hostSlotInfo_[kSourceSlot].defaultValue = 0.0f;
-
-    if (!divisionChoiceValues_.empty()) {
-        const int n = static_cast<int>(divisionChoiceValues_.size());
-        hostSlotInfo_[kDivisionSlot].choices = divisionChoiceLabels_;
-        hostSlotInfo_[kDivisionSlot].maxValue = static_cast<float>(n - 1);
+    if (!divisionValues.empty()) {
+        const int n = static_cast<int>(divisionValues.size());
+        infos[kDivisionSlot].choices = menuLabelsForIdx(kDivisionSlot);
+        infos[kDivisionSlot].maxValue = static_cast<float>(n - 1);
         for (int i = 0; i < n; ++i) {
-            if (std::abs(divisionChoiceValues_[static_cast<size_t>(i)] - 1.0f) < 1e-3f) {
-                hostSlotInfo_[kDivisionSlot].defaultValue = static_cast<float>(i);
+            if (std::abs(divisionValues[static_cast<size_t>(i)] - 1.0f) < 1e-3f) {
+                infos[kDivisionSlot].defaultValue = static_cast<float>(i);
                 break;
             }
         }
     }
 
-    juce::NormalisableRange<float> normalisedRange{0.0f, 1.0f};
-    auto* undoManager = getUndoManager();
-
-    auto buildInfo = [](const HostSlotInfo& s) {
-        magda::ParameterInfo info;
-        info.minValue = s.minValue;
-        info.maxValue = s.maxValue;
-        info.defaultValue = s.defaultValue;
-        info.unit = s.unit;
-        info.scale = s.scale;
-        if (std::isfinite(s.scaleAnchor))
-            info.scaleAnchor = s.scaleAnchor;
-        info.choices = s.choices;
-        return info;
-    };
-
-    for (int i = 0; i < kHostSlotCount; ++i) {
-        const auto& slot = hostSlotInfo_[i];
-        const juce::String id = "magda_ring_mod_" + slot.name.toLowerCase().replace(" ", "_");
-        const juce::Identifier identifier(id);
-        const auto info = buildInfo(slot);
-        const float defaultNormalized =
-            magda::ParameterUtils::realToNormalized(slot.defaultValue, info);
-        hostCached_[i].referTo(state, identifier, undoManager, defaultNormalized);
-
-        auto param = addParam(
-            id, slot.name, normalisedRange,
-            [info](float normalized) {
-                const float real = magda::ParameterUtils::normalizedToReal(normalized, info);
-                return magda::ParameterUtils::formatValue(real, info);
-            },
-            [info](const juce::String& text) {
-                auto parsed = magda::ParameterUtils::parseValue(text, info);
-                if (parsed)
-                    return magda::ParameterUtils::realToNormalized(*parsed, info);
-                return 0.0f;
-            });
-        param->attachToCurrentValue(hostCached_[i]);
-        hostParams_[i] = param;
-    }
-
-    for (int i = 0; i < kHostSlotCount; ++i) {
-        hostSlotInfo_[static_cast<size_t>(i)].gateSlotIndex =
-            harvestedGates_[static_cast<size_t>(i)].slotIndex;
-        hostSlotInfo_[static_cast<size_t>(i)].gateNegated =
-            harvestedGates_[static_cast<size_t>(i)].negated;
-    }
-}
-
-void MagdaRingModCompiledPlugin::initialise(const te::PluginInitialisationInfo& info) {
-    rebuildEngineState(static_cast<int>(info.sampleRate));
-    scratchIn_.setSize(numInputs_, info.blockSizeSamples, false, true, true);
-    scratchOut_.setSize(numOutputs_, info.blockSizeSamples, false, true, true);
-    inPtrs_.assign(static_cast<size_t>(numInputs_), nullptr);
-    outPtrs_.assign(static_cast<size_t>(numOutputs_), nullptr);
-}
-
-void MagdaRingModCompiledPlugin::deinitialise() {
-    scratchIn_.setSize(0, 0);
-    scratchOut_.setSize(0, 0);
-    inPtrs_.clear();
-    outPtrs_.clear();
-}
-
-void MagdaRingModCompiledPlugin::reset() {
-    if (dsp_)
-        dsp_->instanceClear();
-}
-
-void MagdaRingModCompiledPlugin::applyToBuffer(const te::PluginRenderContext& fc) {
-    if (!fc.destBuffer || fc.bufferNumSamples <= 0 || !dsp_)
-        return;
-
-    if (fc.isPlaying && !wasPlaying_)
-        dsp_->instanceClear();
-    wasPlaying_ = fc.isPlaying;
-
-    auto writeContinuous = [&](int slot) {
-        if (auto* zone = zones_[static_cast<size_t>(slot)]) {
-            const auto& s = hostSlotInfo_[static_cast<size_t>(slot)];
-            magda::ParameterInfo info;
-            info.minValue = s.minValue;
-            info.maxValue = s.maxValue;
-            info.scale = s.scale;
-            if (std::isfinite(s.scaleAnchor))
-                info.scaleAnchor = s.scaleAnchor;
-            const float norm = hostParams_[static_cast<size_t>(slot)]->getCurrentValue();
-            *zone = static_cast<FAUSTFLOAT>(magda::ParameterUtils::normalizedToReal(norm, info));
-        }
-    };
-    writeContinuous(kFrequencySlot);
-    writeContinuous(kMixSlot);
-    writeContinuous(kWidthSlot);
-
-    auto writeMenuIndex = [&](int slot) {
-        if (auto* z = zones_[static_cast<size_t>(slot)]) {
-            const auto& s = hostSlotInfo_[static_cast<size_t>(slot)];
-            const float norm = hostParams_[static_cast<size_t>(slot)]->getCurrentValue();
-            const int count = static_cast<int>(s.choices.size());
-            const int idx =
-                count > 1 ? juce::jlimit(
-                                0, count - 1,
-                                static_cast<int>(std::round(norm * static_cast<float>(count - 1))))
-                          : 0;
-            *z = static_cast<FAUSTFLOAT>(idx);
-        }
-    };
-    writeMenuIndex(kShapeSlot);
-    writeMenuIndex(kSourceSlot);
-
-    if (auto* z = zones_[kSyncSlot])
-        *z = hostParams_[kSyncSlot]->getCurrentValue() >= 0.5f ? FAUSTFLOAT(1) : FAUSTFLOAT(0);
-
-    if (auto* z = zones_[kDivisionSlot]; z && !divisionChoiceValues_.empty()) {
-        const float norm = hostParams_[kDivisionSlot]->getCurrentValue();
-        const int count = static_cast<int>(divisionChoiceValues_.size());
-        const int idx = juce::jlimit(
-            0, count - 1, static_cast<int>(std::round(norm * static_cast<float>(count - 1))));
-        *z = static_cast<FAUSTFLOAT>(divisionChoiceValues_[static_cast<size_t>(idx)]);
-    }
-
-    const double bpm = edit.tempoSequence.getBpmAt(fc.editTime.getStart());
-    currentBpm_.store(static_cast<float>(bpm), std::memory_order_relaxed);
-    if (bpmZone_)
-        *bpmZone_ = static_cast<FAUSTFLOAT>(bpm);
-
-    const int numSamples = fc.bufferNumSamples;
-    const int startSample = fc.bufferStartSample;
-    const int hostChannels = fc.destBuffer->getNumChannels();
-    if (hostChannels <= 0 || numInputs_ <= 0 || numOutputs_ <= 0)
-        return;
-
-    if (scratchIn_.getNumChannels() < numInputs_ || scratchIn_.getNumSamples() < numSamples)
-        scratchIn_.setSize(numInputs_, numSamples, false, true, true);
-    if (scratchOut_.getNumChannels() < numOutputs_ || scratchOut_.getNumSamples() < numSamples)
-        scratchOut_.setSize(numOutputs_, numSamples, false, true, true);
-    if (static_cast<int>(inPtrs_.size()) < numInputs_)
-        inPtrs_.resize(static_cast<size_t>(numInputs_), nullptr);
-    if (static_cast<int>(outPtrs_.size()) < numOutputs_)
-        outPtrs_.resize(static_cast<size_t>(numOutputs_), nullptr);
-
-    for (int ch = 0; ch < numInputs_; ++ch) {
-        float* dst = scratchIn_.getWritePointer(ch);
-        if (ch < hostChannels) {
-            const float* src = fc.destBuffer->getReadPointer(ch, startSample);
-            std::copy(src, src + numSamples, dst);
-        } else {
-            std::fill(dst, dst + numSamples, 0.0f);
-        }
-        inPtrs_[static_cast<size_t>(ch)] = dst;
-    }
-    for (int ch = 0; ch < numOutputs_; ++ch) {
-        outPtrs_[static_cast<size_t>(ch)] = (ch < hostChannels)
-                                                ? fc.destBuffer->getWritePointer(ch, startSample)
-                                                : scratchOut_.getWritePointer(ch);
-    }
-
-    dsp_->compute(numSamples, inPtrs_.data(), outPtrs_.data());
-
-    const int channelsToSanitise = std::min(hostChannels, numOutputs_);
-    for (int ch = 0; ch < channelsToSanitise; ++ch) {
-        float* out = fc.destBuffer->getWritePointer(ch, startSample);
-        for (int i = 0; i < numSamples; ++i) {
-            const float sample = out[i];
-            out[i] = std::isfinite(sample) ? juce::jlimit(-16.0f, 16.0f, sample) : 0.0f;
-        }
-    }
-}
-
-te::AutomatableParameter* MagdaRingModCompiledPlugin::getSlotParameter(int slotIndex) const {
-    if (slotIndex < 0 || slotIndex >= kHostSlotCount)
-        return nullptr;
-    return hostParams_[static_cast<size_t>(slotIndex)].get();
-}
-
-const MagdaRingModCompiledPlugin::HostSlotInfo& MagdaRingModCompiledPlugin::getSlotInfo(
-    int slotIndex) const {
-    static const HostSlotInfo kEmpty;
-    if (slotIndex < 0 || slotIndex >= kHostSlotCount)
-        return kEmpty;
-    return hostSlotInfo_[static_cast<size_t>(slotIndex)];
-}
-
-float MagdaRingModCompiledPlugin::divisionFaustValueForIndex(int index) const {
-    if (divisionChoiceValues_.empty())
-        return 1.0f;
-    const int safeIdx = juce::jlimit(0, static_cast<int>(divisionChoiceValues_.size()) - 1, index);
-    return divisionChoiceValues_[static_cast<size_t>(safeIdx)];
-}
-
-float MagdaRingModCompiledPlugin::displayValueToNativeValue(int slotIndex,
-                                                            float displayValue) const {
-    if (slotIndex < 0 || slotIndex >= kHostSlotCount)
-        return displayValue;
-    const auto& s = hostSlotInfo_[static_cast<size_t>(slotIndex)];
-    magda::ParameterInfo info;
-    info.minValue = s.minValue;
-    info.maxValue = s.maxValue;
-    info.scale = s.scale;
-    if (std::isfinite(s.scaleAnchor))
-        info.scaleAnchor = s.scaleAnchor;
-    info.choices = s.choices;
-    return magda::ParameterUtils::realToNormalized(displayValue, info);
-}
-
-float MagdaRingModCompiledPlugin::nativeValueToDisplayValue(int slotIndex,
-                                                            float nativeValue) const {
-    if (slotIndex < 0 || slotIndex >= kHostSlotCount)
-        return nativeValue;
-    const auto& s = hostSlotInfo_[static_cast<size_t>(slotIndex)];
-    magda::ParameterInfo info;
-    info.minValue = s.minValue;
-    info.maxValue = s.maxValue;
-    info.scale = s.scale;
-    if (std::isfinite(s.scaleAnchor))
-        info.scaleAnchor = s.scaleAnchor;
-    info.choices = s.choices;
-    return magda::ParameterUtils::normalizedToReal(nativeValue, info);
+    return infos;
 }
 
 constexpr AliasSpec kAliases[] = {
@@ -473,9 +107,8 @@ const CompiledPluginSpec& getMagdaRingModSpec() {
             "<b>Square</b>: rich odd-harmonic spectrum, aggressive sideband stack.\n"
             "Rate runs free in Hz or locks to tempo Division. "
             "Width offsets the carrier phase per channel; Mix blends wet against dry.",
-        .createPlugin = [](const DevicePluginCreationContext& context) -> DevicePluginPtr {
-            return tracktion_adapter::pluginHandle(
-                new MagdaRingModCompiledPlugin(tracktion_adapter::creationInfo(context)));
+        .createDevice = [](const DevicePluginCreationContext&) -> std::unique_ptr<MagdaDevice> {
+            return std::make_unique<MagdaRingModCompiledPlugin>();
         },
         .aliases = kAliases,
         .aliasCount = static_cast<int>(sizeof(kAliases) / sizeof(kAliases[0])),

--- a/magda/daw/audio/plugins/compiled/MagdaRingModCompiledPlugin.hpp
+++ b/magda/daw/audio/plugins/compiled/MagdaRingModCompiledPlugin.hpp
@@ -1,15 +1,8 @@
 #pragma once
 
-#include <tracktion_engine/tracktion_engine.h>
-
-#include <array>
-#include <atomic>
-#include <memory>
 #include <vector>
 
-#include "../FaustParamPool.hpp"
-#include "core/ParameterInfo.hpp"
-#include "plugins/compiled/tracktion/CompiledFaustTracktionAdapter.hpp"
+#include "plugins/compiled/MagdaCompiledEffect.hpp"
 
 class dsp;
 
@@ -22,43 +15,12 @@ namespace magda::daw::audio::compiled {
  * 1 Hz – 5 kHz range. Low frequencies act like a tremolo; audio-rate
  * frequencies give the classic metallic-clang ring-mod timbre.
  */
-class MagdaRingModCompiledPlugin : public te::Plugin, public ICompiledFaustPlugin {
+class MagdaRingModCompiledPlugin : public MagdaCompiledEffect {
   public:
     static const char* xmlTypeName;
 
-    explicit MagdaRingModCompiledPlugin(const te::PluginCreationInfo& info);
-    ~MagdaRingModCompiledPlugin() override;
+    MagdaRingModCompiledPlugin();
 
-    juce::String getName() const override;
-    juce::String getPluginType() override;
-    juce::String getShortName(int) override;
-    juce::String getSelectableDescription() override;
-
-    void initialise(const te::PluginInitialisationInfo& info) override;
-    void deinitialise() override;
-    void reset() override;
-    void applyToBuffer(const te::PluginRenderContext& fc) override;
-
-    bool takesMidiInput() override {
-        return false;
-    }
-    bool takesAudioInput() override {
-        return true;
-    }
-    bool isSynth() override {
-        return false;
-    }
-    bool producesAudioWhenNoAudioInput() override {
-        return false;
-    }
-    bool canSidechain() override {
-        return true;  // Source=Sidechain uses input channel 3 as the carrier.
-    }
-    double getTailLength() const override {
-        return 0.0;
-    }
-
-    // Slot ordering matches [idx:N] pins inside magda_ring_mod.dsp.
     static constexpr int kSyncSlot = 0;
     static constexpr int kFrequencySlot = 1;
     static constexpr int kDivisionSlot = 2;
@@ -69,68 +31,32 @@ class MagdaRingModCompiledPlugin : public te::Plugin, public ICompiledFaustPlugi
     static constexpr int kHostSlotCount = 7;
     static constexpr int kBpmSlot = 63;
 
-    te::AutomatableParameter* getSlotParameter(int slotIndex) const;
-
-    float displayValueToNativeValue(int slotIndex, float displayValue) const;
-    float nativeValueToDisplayValue(int slotIndex, float nativeValue) const;
-
-    using HostSlotInfo = CompiledHostSlotInfo;
-    const HostSlotInfo& getSlotInfo(int slotIndex) const;
-
-    float divisionFaustValueForIndex(int index) const;
-
-    float currentBpm() const {
-        return currentBpm_.load(std::memory_order_relaxed);
+    /// The Faust quarter-note multiplier behind Division choice @p index.
+    float divisionFaustValueForIndex(int index) const {
+        return menuValueForChoice(kDivisionSlot, index);
     }
 
-    // ICompiledFaustPlugin
-    int hostSlotCount() const override {
-        return kHostSlotCount;
+    juce::String devicePluginId() const override {
+        return xmlTypeName;
     }
-    const CompiledHostSlotInfo& hostSlotInfo(int slotIndex) const override {
-        return getSlotInfo(slotIndex);
+    juce::String deviceName() const override {
+        return "Ring Mod";
     }
-    DeviceParameterHandle hostSlotParameter(int slotIndex) const override {
-        return tracktion_adapter::parameterHandle(getSlotParameter(slotIndex));
+
+  protected:
+    ::dsp* createEngineDsp(int engineIndex) const override;
+    std::vector<HostSlotInfo> slotInfos() const override;
+    const char* slotIdPrefix() const override {
+        return "magda_ring_mod_";
     }
-    float displayToNormalized(int slotIndex, float displayValue) const override {
-        return displayValueToNativeValue(slotIndex, displayValue);
+    bool wantsSidechain() const override {
+        return true;  // Source=Sidechain takes the carrier from input 3.
     }
-    float normalizedToDisplay(int slotIndex, float normalizedValue) const override {
-        return nativeValueToDisplayValue(slotIndex, normalizedValue);
+    bool resetsOnPlayStart() const override {
+        return true;
     }
 
   private:
-    void buildHostParameters();
-    void rebuildEngineState(int sampleRate);
-
-    std::unique_ptr<::dsp> dsp_;
-    int numInputs_ = 0;
-    int numOutputs_ = 0;
-
-    std::array<FAUSTFLOAT*, kHostSlotCount> zones_{};
-    FAUSTFLOAT* bpmZone_ = nullptr;
-    std::vector<float> divisionChoiceValues_;
-    std::vector<juce::String> divisionChoiceLabels_;
-
-    struct GateSpec {
-        int slotIndex = -1;
-        bool negated = false;
-    };
-    std::array<GateSpec, kHostSlotCount> harvestedGates_{};
-
-    std::array<HostSlotInfo, kHostSlotCount> hostSlotInfo_;
-    std::array<te::AutomatableParameter::Ptr, kHostSlotCount> hostParams_;
-    std::array<juce::CachedValue<float>, kHostSlotCount> hostCached_;
-
-    juce::AudioBuffer<float> scratchIn_;
-    juce::AudioBuffer<float> scratchOut_;
-    std::vector<float*> inPtrs_;
-    std::vector<float*> outPtrs_;
-
-    std::atomic<float> currentBpm_{120.0f};
-    bool wasPlaying_ = false;
-
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(MagdaRingModCompiledPlugin)
 };
 

--- a/magda/daw/audio/plugins/compiled/MagdaSaturatorCompiledPlugin.cpp
+++ b/magda/daw/audio/plugins/compiled/MagdaSaturatorCompiledPlugin.cpp
@@ -1,387 +1,64 @@
 #include "plugins/compiled/MagdaSaturatorCompiledPlugin.hpp"
 
-#include <algorithm>
-#include <cmath>
-#include <map>
-
-#include "core/ParameterUtils.hpp"
+#include "core/ParameterInfo.hpp"
 #include "faust/dsp/dsp.h"
 #include "faust/gui/UI.h"
 #include "faust/gui/meta.h"
 #include "magda_saturator.generated.cpp"
-#include "plugins/FaustMetadataParser.hpp"
-#include "plugins/FaustParamInfo.hpp"
 #include "plugins/compiled/CompiledPluginRegistry.hpp"
-#include "plugins/tracktion/TracktionDeviceAdapters.hpp"
 
 namespace magda::daw::audio::compiled {
 
 const char* MagdaSaturatorCompiledPlugin::xmlTypeName = "magda_saturator";
 
-namespace {
+MagdaSaturatorCompiledPlugin::MagdaSaturatorCompiledPlugin() {
+    initEffect();
+}
 
-// Same idx-based harvest pattern as MagdaFilterCompiledPlugin: collect every
-// control by [idx:N] and look up the host slots by their pinned indices.
-struct SaturatorHarvest {
-    struct Control {
-        int idx = -1;
-        FaustParamSlot::Kind kind = FaustParamSlot::Kind::Continuous;
-        FAUSTFLOAT* zone = nullptr;
-        std::vector<std::pair<float, juce::String>> choices;
+::dsp* MagdaSaturatorCompiledPlugin::createEngineDsp(int) const {
+    return new MagdaSaturatorDsp();
+}
+
+std::vector<MagdaSaturatorCompiledPlugin::HostSlotInfo> MagdaSaturatorCompiledPlugin::slotInfos()
+    const {
+    using magda::ParameterScale;
+    return {
+        // Drive (dB, linear). Smoothing happens inside the DSP.
+        {.name = "Drive",
+         .unit = magda::technicalText(magda::TechnicalTextToken::Decibels),
+         .scale = ParameterScale::Linear,
+         .minValue = 0.0f,
+         .maxValue = 24.0f,
+         .defaultValue = 0.0f},
+        {.name = "Mode",
+         .scale = ParameterScale::Discrete,
+         .minValue = 0.0f,
+         .maxValue = 5.0f,
+         .defaultValue = 0.0f,
+         .choices = {"Tanh", "Soft", "Hard", "Fold", "Tube", "Tape"}},
+        {.name = "Bias",
+         .scale = ParameterScale::Linear,
+         .minValue = -1.0f,
+         .maxValue = 1.0f,
+         .defaultValue = 0.0f},
+        // Bipolar tilt.
+        {.name = "Tone",
+         .scale = ParameterScale::Linear,
+         .minValue = -1.0f,
+         .maxValue = 1.0f,
+         .defaultValue = 0.0f},
+        {.name = "Mix",
+         .scale = ParameterScale::Linear,
+         .minValue = 0.0f,
+         .maxValue = 1.0f,
+         .defaultValue = 1.0f},
+        {.name = "Output",
+         .unit = magda::technicalText(magda::TechnicalTextToken::Decibels),
+         .scale = ParameterScale::Linear,
+         .minValue = -24.0f,
+         .maxValue = 6.0f,
+         .defaultValue = 0.0f},
     };
-    std::vector<Control> controls;
-};
-
-class SaturatorHarvester : public ::UI {
-  public:
-    SaturatorHarvest harvest;
-
-    void openTabBox(const char*) override {}
-    void openHorizontalBox(const char*) override {}
-    void openVerticalBox(const char*) override {}
-    void closeBox() override {}
-
-    void addButton(const char* label, FAUSTFLOAT* zone) override {
-        emitControl(FaustParamSlot::Kind::Boolean, label, zone);
-    }
-    void addCheckButton(const char* label, FAUSTFLOAT* zone) override {
-        emitControl(FaustParamSlot::Kind::Boolean, label, zone);
-    }
-    void addVerticalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT, FAUSTFLOAT, FAUSTFLOAT,
-                           FAUSTFLOAT) override {
-        emitControl(FaustParamSlot::Kind::Continuous, label, zone);
-    }
-    void addHorizontalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT, FAUSTFLOAT,
-                             FAUSTFLOAT, FAUSTFLOAT) override {
-        emitControl(FaustParamSlot::Kind::Continuous, label, zone);
-    }
-    void addNumEntry(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT, FAUSTFLOAT, FAUSTFLOAT,
-                     FAUSTFLOAT) override {
-        emitControl(FaustParamSlot::Kind::Continuous, label, zone);
-    }
-    void addHorizontalBargraph(const char*, FAUSTFLOAT*, FAUSTFLOAT, FAUSTFLOAT) override {}
-    void addVerticalBargraph(const char*, FAUSTFLOAT*, FAUSTFLOAT, FAUSTFLOAT) override {}
-    void addSoundfile(const char*, const char*, Soundfile**) override {}
-
-    void declare(FAUSTFLOAT* zone, const char* key, const char* value) override {
-        if (zone == nullptr)
-            return;
-        const auto k = juce::String::fromUTF8(key != nullptr ? key : "").toLowerCase();
-        const auto v = juce::String::fromUTF8(value != nullptr ? value : "");
-        applyFaustAnnotation(k, v, pendingByZone_[zone]);
-    }
-
-  private:
-    void emitControl(FaustParamSlot::Kind kind, const char* rawLabel, FAUSTFLOAT* zone) {
-        const auto parsed =
-            parseFaustLabel(juce::String::fromUTF8(rawLabel != nullptr ? rawLabel : ""));
-        ControlMetadata merged = parsed.metadata;
-        if (zone != nullptr) {
-            if (auto it = pendingByZone_.find(zone); it != pendingByZone_.end()) {
-                mergeFaustMetadata(merged, it->second);
-                pendingByZone_.erase(it);
-            }
-        }
-
-        SaturatorHarvest::Control c;
-        c.idx = merged.slotIndex;
-        c.kind = merged.isChoiceStyle() ? FaustParamSlot::Kind::Discrete : kind;
-        c.zone = zone;
-        c.choices = merged.menuChoices;
-        harvest.controls.push_back(std::move(c));
-    }
-
-    std::map<FAUSTFLOAT*, ControlMetadata> pendingByZone_;
-};
-
-const SaturatorHarvest::Control* findByIdx(const SaturatorHarvest& h, int idx) {
-    for (const auto& c : h.controls)
-        if (c.idx == idx)
-            return &c;
-    return nullptr;
-}
-
-}  // namespace
-
-MagdaSaturatorCompiledPlugin::MagdaSaturatorCompiledPlugin(const te::PluginCreationInfo& info)
-    : te::Plugin(info) {
-    dsp_ = std::make_unique<MagdaSaturatorDsp>();
-    constexpr int kProvisionalSampleRate = 44100;
-    rebuildEngineState(kProvisionalSampleRate);
-    buildHostParameters();
-}
-
-MagdaSaturatorCompiledPlugin::~MagdaSaturatorCompiledPlugin() {
-    notifyListenersOfDeletion();
-    for (auto& p : hostParams_)
-        if (p)
-            p->detachFromCurrentValue();
-}
-
-juce::String MagdaSaturatorCompiledPlugin::getName() const {
-    return "Saturator";
-}
-juce::String MagdaSaturatorCompiledPlugin::getPluginType() {
-    return xmlTypeName;
-}
-juce::String MagdaSaturatorCompiledPlugin::getShortName(int) {
-    return "Saturator";
-}
-juce::String MagdaSaturatorCompiledPlugin::getSelectableDescription() {
-    return "Saturator";
-}
-
-void MagdaSaturatorCompiledPlugin::rebuildEngineState(int sampleRate) {
-    if (!dsp_)
-        return;
-    dsp_->init(sampleRate);
-    numInputs_ = dsp_->getNumInputs();
-    numOutputs_ = dsp_->getNumOutputs();
-
-    SaturatorHarvester harvester;
-    dsp_->buildUserInterface(&harvester);
-
-    zones_.fill(nullptr);
-    modeChoiceValues_.clear();
-
-    for (int i = 0; i < kHostSlotCount; ++i) {
-        if (auto* c = findByIdx(harvester.harvest, i))
-            zones_[static_cast<size_t>(i)] = c->zone;
-    }
-
-    if (auto* c = findByIdx(harvester.harvest, kModeSlot)) {
-        auto sorted = c->choices;
-        std::sort(sorted.begin(), sorted.end(),
-                  [](const auto& a, const auto& b) { return a.first < b.first; });
-        modeChoiceValues_.reserve(sorted.size());
-        for (const auto& choice : sorted)
-            modeChoiceValues_.push_back(choice.first);
-    }
-}
-
-void MagdaSaturatorCompiledPlugin::buildHostParameters() {
-    // Slot 0: Drive (dB, linear, 0..24). Smoothing happens inside the DSP.
-    hostSlotInfo_[kDriveSlot] = {.name = "Drive",
-                                 .unit = magda::technicalText(magda::TechnicalTextToken::Decibels),
-                                 .scale = magda::ParameterScale::Linear,
-                                 .minValue = 0.0f,
-                                 .maxValue = 24.0f,
-                                 .defaultValue = 0.0f};
-    // Slot 1: Mode (discrete, 6 options)
-    hostSlotInfo_[kModeSlot].name = "Mode";
-    hostSlotInfo_[kModeSlot].scale = magda::ParameterScale::Discrete;
-    hostSlotInfo_[kModeSlot].choices = {"Tanh", "Soft", "Hard", "Fold", "Tube", "Tape"};
-    hostSlotInfo_[kModeSlot].minValue = 0.0f;
-    hostSlotInfo_[kModeSlot].maxValue =
-        static_cast<float>(hostSlotInfo_[kModeSlot].choices.size() - 1);
-    hostSlotInfo_[kModeSlot].defaultValue = 0.0f;
-    // Slot 2: Bias (-1..1, bipolar)
-    hostSlotInfo_[kBiasSlot] = {.name = "Bias",
-                                .scale = magda::ParameterScale::Linear,
-                                .minValue = -1.0f,
-                                .maxValue = 1.0f,
-                                .defaultValue = 0.0f};
-    // Slot 3: Tone (-1..1, bipolar tilt)
-    hostSlotInfo_[kToneSlot] = {.name = "Tone",
-                                .scale = magda::ParameterScale::Linear,
-                                .minValue = -1.0f,
-                                .maxValue = 1.0f,
-                                .defaultValue = 0.0f};
-    // Slot 4: Mix (0..1)
-    hostSlotInfo_[kMixSlot] = {.name = "Mix",
-                               .scale = magda::ParameterScale::Linear,
-                               .minValue = 0.0f,
-                               .maxValue = 1.0f,
-                               .defaultValue = 1.0f};
-    // Slot 5: Output (dB, -24..6)
-    hostSlotInfo_[kOutputSlot] = {.name = "Output",
-                                  .unit = magda::technicalText(magda::TechnicalTextToken::Decibels),
-                                  .scale = magda::ParameterScale::Linear,
-                                  .minValue = -24.0f,
-                                  .maxValue = 6.0f,
-                                  .defaultValue = 0.0f};
-
-    juce::NormalisableRange<float> normalisedRange{0.0f, 1.0f};
-    auto* undoManager = getUndoManager();
-
-    auto buildInfo = [](const HostSlotInfo& s) {
-        magda::ParameterInfo info;
-        info.minValue = s.minValue;
-        info.maxValue = s.maxValue;
-        info.defaultValue = s.defaultValue;
-        info.unit = s.unit;
-        info.scale = s.scale;
-        if (std::isfinite(s.scaleAnchor))
-            info.scaleAnchor = s.scaleAnchor;
-        info.choices = s.choices;
-        return info;
-    };
-
-    for (int i = 0; i < kHostSlotCount; ++i) {
-        const auto& slot = hostSlotInfo_[i];
-        const juce::String id = "magda_saturator_" + slot.name.toLowerCase().replace(" ", "_");
-        const juce::Identifier identifier(id);
-        const auto info = buildInfo(slot);
-        const float defaultNormalized =
-            magda::ParameterUtils::realToNormalized(slot.defaultValue, info);
-        hostCached_[i].referTo(state, identifier, undoManager, defaultNormalized);
-
-        auto param = addParam(
-            id, slot.name, normalisedRange,
-            [info](float normalized) {
-                const float real = magda::ParameterUtils::normalizedToReal(normalized, info);
-                return magda::ParameterUtils::formatValue(real, info);
-            },
-            [info](const juce::String& text) {
-                auto parsed = magda::ParameterUtils::parseValue(text, info);
-                if (parsed)
-                    return magda::ParameterUtils::realToNormalized(*parsed, info);
-                return 0.0f;
-            });
-        param->attachToCurrentValue(hostCached_[i]);
-        hostParams_[i] = param;
-    }
-}
-
-void MagdaSaturatorCompiledPlugin::initialise(const te::PluginInitialisationInfo& info) {
-    rebuildEngineState(static_cast<int>(info.sampleRate));
-    scratchIn_.setSize(numInputs_, info.blockSizeSamples, false, true, true);
-    scratchOut_.setSize(numOutputs_, info.blockSizeSamples, false, true, true);
-    inPtrs_.assign(static_cast<size_t>(numInputs_), nullptr);
-    outPtrs_.assign(static_cast<size_t>(numOutputs_), nullptr);
-}
-
-void MagdaSaturatorCompiledPlugin::deinitialise() {
-    scratchIn_.setSize(0, 0);
-    scratchOut_.setSize(0, 0);
-    inPtrs_.clear();
-    outPtrs_.clear();
-}
-
-void MagdaSaturatorCompiledPlugin::reset() {
-    if (dsp_)
-        dsp_->instanceClear();
-}
-
-void MagdaSaturatorCompiledPlugin::applyToBuffer(const te::PluginRenderContext& fc) {
-    if (!fc.destBuffer || fc.bufferNumSamples <= 0 || !dsp_)
-        return;
-
-    // Write each host param's display value into its Faust zone. For
-    // continuous params we denormalize via ParameterUtils; the discrete
-    // Mode picks the underlying Faust choice value by index.
-    auto writeContinuous = [&](int slot) {
-        if (auto* zone = zones_[static_cast<size_t>(slot)]) {
-            const auto& s = hostSlotInfo_[static_cast<size_t>(slot)];
-            magda::ParameterInfo info;
-            info.minValue = s.minValue;
-            info.maxValue = s.maxValue;
-            info.scale = s.scale;
-            if (std::isfinite(s.scaleAnchor))
-                info.scaleAnchor = s.scaleAnchor;
-            const float norm = hostParams_[static_cast<size_t>(slot)]->getCurrentValue();
-            *zone = static_cast<FAUSTFLOAT>(magda::ParameterUtils::normalizedToReal(norm, info));
-        }
-    };
-    writeContinuous(kDriveSlot);
-    writeContinuous(kBiasSlot);
-    writeContinuous(kToneSlot);
-    writeContinuous(kMixSlot);
-    writeContinuous(kOutputSlot);
-
-    if (auto* modeZone = zones_[kModeSlot]; modeZone && !modeChoiceValues_.empty()) {
-        const float norm = hostParams_[kModeSlot]->getCurrentValue();
-        const int count = static_cast<int>(modeChoiceValues_.size());
-        const int idx = juce::jlimit(
-            0, count - 1, static_cast<int>(std::round(norm * static_cast<float>(count - 1))));
-        *modeZone = static_cast<FAUSTFLOAT>(modeChoiceValues_[idx]);
-    }
-
-    const int numSamples = fc.bufferNumSamples;
-    const int startSample = fc.bufferStartSample;
-    const int hostChannels = fc.destBuffer->getNumChannels();
-    if (hostChannels <= 0 || numInputs_ <= 0 || numOutputs_ <= 0)
-        return;
-
-    if (scratchIn_.getNumChannels() < numInputs_ || scratchIn_.getNumSamples() < numSamples)
-        scratchIn_.setSize(numInputs_, numSamples, false, true, true);
-    if (scratchOut_.getNumChannels() < numOutputs_ || scratchOut_.getNumSamples() < numSamples)
-        scratchOut_.setSize(numOutputs_, numSamples, false, true, true);
-    if (static_cast<int>(inPtrs_.size()) < numInputs_)
-        inPtrs_.resize(static_cast<size_t>(numInputs_), nullptr);
-    if (static_cast<int>(outPtrs_.size()) < numOutputs_)
-        outPtrs_.resize(static_cast<size_t>(numOutputs_), nullptr);
-
-    for (int ch = 0; ch < numInputs_; ++ch) {
-        float* dst = scratchIn_.getWritePointer(ch);
-        if (ch < hostChannels) {
-            const float* src = fc.destBuffer->getReadPointer(ch, startSample);
-            std::copy(src, src + numSamples, dst);
-        } else {
-            std::fill(dst, dst + numSamples, 0.0f);
-        }
-        inPtrs_[static_cast<size_t>(ch)] = dst;
-    }
-    for (int ch = 0; ch < numOutputs_; ++ch) {
-        outPtrs_[static_cast<size_t>(ch)] = (ch < hostChannels)
-                                                ? fc.destBuffer->getWritePointer(ch, startSample)
-                                                : scratchOut_.getWritePointer(ch);
-    }
-
-    dsp_->compute(numSamples, inPtrs_.data(), outPtrs_.data());
-
-    const int channelsToSanitise = std::min(hostChannels, numOutputs_);
-    for (int ch = 0; ch < channelsToSanitise; ++ch) {
-        float* out = fc.destBuffer->getWritePointer(ch, startSample);
-        for (int i = 0; i < numSamples; ++i) {
-            const float sample = out[i];
-            out[i] = std::isfinite(sample) ? juce::jlimit(-16.0f, 16.0f, sample) : 0.0f;
-        }
-    }
-}
-
-te::AutomatableParameter* MagdaSaturatorCompiledPlugin::getSlotParameter(int slotIndex) const {
-    if (slotIndex < 0 || slotIndex >= kHostSlotCount)
-        return nullptr;
-    return hostParams_[static_cast<size_t>(slotIndex)].get();
-}
-
-const MagdaSaturatorCompiledPlugin::HostSlotInfo& MagdaSaturatorCompiledPlugin::getSlotInfo(
-    int slotIndex) const {
-    static const HostSlotInfo kEmpty;
-    if (slotIndex < 0 || slotIndex >= kHostSlotCount)
-        return kEmpty;
-    return hostSlotInfo_[static_cast<size_t>(slotIndex)];
-}
-
-float MagdaSaturatorCompiledPlugin::displayValueToNativeValue(int slotIndex,
-                                                              float displayValue) const {
-    if (slotIndex < 0 || slotIndex >= kHostSlotCount)
-        return displayValue;
-    const auto& s = hostSlotInfo_[static_cast<size_t>(slotIndex)];
-    magda::ParameterInfo info;
-    info.minValue = s.minValue;
-    info.maxValue = s.maxValue;
-    info.scale = s.scale;
-    if (std::isfinite(s.scaleAnchor))
-        info.scaleAnchor = s.scaleAnchor;
-    info.choices = s.choices;
-    return magda::ParameterUtils::realToNormalized(displayValue, info);
-}
-
-float MagdaSaturatorCompiledPlugin::nativeValueToDisplayValue(int slotIndex,
-                                                              float nativeValue) const {
-    if (slotIndex < 0 || slotIndex >= kHostSlotCount)
-        return nativeValue;
-    const auto& s = hostSlotInfo_[static_cast<size_t>(slotIndex)];
-    magda::ParameterInfo info;
-    info.minValue = s.minValue;
-    info.maxValue = s.maxValue;
-    info.scale = s.scale;
-    if (std::isfinite(s.scaleAnchor))
-        info.scaleAnchor = s.scaleAnchor;
-    info.choices = s.choices;
-    return magda::ParameterUtils::normalizedToReal(nativeValue, info);
 }
 
 constexpr AliasSpec kAliases[] = {
@@ -405,9 +82,8 @@ const CompiledPluginSpec& getMagdaSaturatorSpec() {
             "<b>Tape</b>: tanh with an odd-order compression term, tape-style headroom.\n"
             "Drive pushes the input, Bias shifts the operating point, "
             "Tone tilts the post-shape EQ, Mix blends dry.",
-        .createPlugin = [](const DevicePluginCreationContext& context) -> DevicePluginPtr {
-            return tracktion_adapter::pluginHandle(
-                new MagdaSaturatorCompiledPlugin(tracktion_adapter::creationInfo(context)));
+        .createDevice = [](const DevicePluginCreationContext&) -> std::unique_ptr<MagdaDevice> {
+            return std::make_unique<MagdaSaturatorCompiledPlugin>();
         },
         .aliases = kAliases,
         .aliasCount = static_cast<int>(sizeof(kAliases) / sizeof(kAliases[0])),

--- a/magda/daw/audio/plugins/compiled/MagdaSaturatorCompiledPlugin.hpp
+++ b/magda/daw/audio/plugins/compiled/MagdaSaturatorCompiledPlugin.hpp
@@ -1,61 +1,25 @@
 #pragma once
 
-#include <tracktion_engine/tracktion_engine.h>
-
-#include <array>
-#include <memory>
 #include <vector>
 
-#include "../FaustParamPool.hpp"
-#include "core/ParameterInfo.hpp"
-#include "plugins/compiled/tracktion/CompiledFaustTracktionAdapter.hpp"
+#include "plugins/compiled/MagdaCompiledEffect.hpp"
 
 class dsp;
 
 namespace magda::daw::audio::compiled {
 
 /**
- * @brief Compiled-Faust saturator: drive → mode → bias → tone tilt → mix.
+ * @brief Compiled-Faust waveshaper with six selectable curves.
  *
- * Single-engine compiled plugin (the multi-mode dispatch lives inside the
- * Faust DSP, not at the C++ layer). Every host-facing parameter maps
- * 1:1 to a Faust slot, harvested at construction by the same idx-based
- * scheme MagdaFilterCompiledPlugin uses.
+ * Drive pushes the input into the shape, Bias shifts its operating point,
+ * Tone tilts the post-shape EQ and Mix blends the dry signal back in.
  */
-class MagdaSaturatorCompiledPlugin : public te::Plugin, public ICompiledFaustPlugin {
+class MagdaSaturatorCompiledPlugin : public MagdaCompiledEffect {
   public:
     static const char* xmlTypeName;
 
-    explicit MagdaSaturatorCompiledPlugin(const te::PluginCreationInfo& info);
-    ~MagdaSaturatorCompiledPlugin() override;
+    MagdaSaturatorCompiledPlugin();
 
-    juce::String getName() const override;
-    juce::String getPluginType() override;
-    juce::String getShortName(int) override;
-    juce::String getSelectableDescription() override;
-
-    void initialise(const te::PluginInitialisationInfo& info) override;
-    void deinitialise() override;
-    void reset() override;
-    void applyToBuffer(const te::PluginRenderContext& fc) override;
-
-    bool takesMidiInput() override {
-        return false;
-    }
-    bool takesAudioInput() override {
-        return true;
-    }
-    bool isSynth() override {
-        return false;
-    }
-    bool producesAudioWhenNoAudioInput() override {
-        return false;
-    }
-    double getTailLength() const override {
-        return 0.0;
-    }
-
-    // Slot ordering matches the [idx:N] pins inside magda_saturator.dsp.
     static constexpr int kDriveSlot = 0;
     static constexpr int kModeSlot = 1;
     static constexpr int kBiasSlot = 2;
@@ -64,57 +28,21 @@ class MagdaSaturatorCompiledPlugin : public te::Plugin, public ICompiledFaustPlu
     static constexpr int kOutputSlot = 5;
     static constexpr int kHostSlotCount = 6;
 
-    enum class Mode { Tanh, Soft, Hard, Fold, Tube, Tape };
-    static constexpr int kModeCount = 6;
-
-    te::AutomatableParameter* getSlotParameter(int slotIndex) const;
-
-    float displayValueToNativeValue(int slotIndex, float displayValue) const;
-    float nativeValueToDisplayValue(int slotIndex, float nativeValue) const;
-
-    using HostSlotInfo = CompiledHostSlotInfo;
-    const HostSlotInfo& getSlotInfo(int slotIndex) const;
-
-    // ICompiledFaustPlugin
-    int hostSlotCount() const override {
-        return kHostSlotCount;
+    juce::String devicePluginId() const override {
+        return xmlTypeName;
     }
-    const CompiledHostSlotInfo& hostSlotInfo(int slotIndex) const override {
-        return getSlotInfo(slotIndex);
+    juce::String deviceName() const override {
+        return "Saturator";
     }
-    DeviceParameterHandle hostSlotParameter(int slotIndex) const override {
-        return tracktion_adapter::parameterHandle(getSlotParameter(slotIndex));
-    }
-    float displayToNormalized(int slotIndex, float displayValue) const override {
-        return displayValueToNativeValue(slotIndex, displayValue);
-    }
-    float normalizedToDisplay(int slotIndex, float normalizedValue) const override {
-        return nativeValueToDisplayValue(slotIndex, normalizedValue);
+
+  protected:
+    ::dsp* createEngineDsp(int engineIndex) const override;
+    std::vector<HostSlotInfo> slotInfos() const override;
+    const char* slotIdPrefix() const override {
+        return "magda_saturator_";
     }
 
   private:
-    void buildHostParameters();
-    void rebuildEngineState(int sampleRate);
-
-    std::unique_ptr<::dsp> dsp_;
-    int numInputs_ = 0;
-    int numOutputs_ = 0;
-
-    // Faust zones harvested by [idx:N] — one per host slot. Sorted choice
-    // values for the Mode discrete param so we can map slot index → underlying
-    // Faust value.
-    std::array<FAUSTFLOAT*, kHostSlotCount> zones_{};
-    std::vector<float> modeChoiceValues_;
-
-    std::array<HostSlotInfo, kHostSlotCount> hostSlotInfo_;
-    std::array<te::AutomatableParameter::Ptr, kHostSlotCount> hostParams_;
-    std::array<juce::CachedValue<float>, kHostSlotCount> hostCached_;
-
-    juce::AudioBuffer<float> scratchIn_;
-    juce::AudioBuffer<float> scratchOut_;
-    std::vector<float*> inPtrs_;
-    std::vector<float*> outPtrs_;
-
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(MagdaSaturatorCompiledPlugin)
 };
 

--- a/magda/daw/audio/plugins/compiled/MagdaUtilityCompiledPlugin.cpp
+++ b/magda/daw/audio/plugins/compiled/MagdaUtilityCompiledPlugin.cpp
@@ -3,9 +3,8 @@
 #include <algorithm>
 #include <cmath>
 
-#include "core/ParameterUtils.hpp"
+#include "core/ParameterInfo.hpp"
 #include "plugins/compiled/CompiledPluginRegistry.hpp"
-#include "plugins/tracktion/TracktionDeviceAdapters.hpp"
 
 namespace magda::daw::audio::compiled {
 
@@ -13,162 +12,82 @@ const char* MagdaUtilityCompiledPlugin::xmlTypeName = "magda_utility";
 
 namespace {
 
-magda::ParameterInfo parameterInfoForSlot(const CompiledHostSlotInfo& s) {
-    magda::ParameterInfo info;
-    info.minValue = s.minValue;
-    info.maxValue = s.maxValue;
-    info.defaultValue = s.defaultValue;
-    info.unit = s.unit;
-    info.scale = s.scale;
-    if (std::isfinite(s.scaleAnchor))
-        info.scaleAnchor = s.scaleAnchor;
-    info.choices = s.choices;
-    return info;
-}
-
-float onePoleAlpha(float cutoffHz, int sampleRate) {
-    const float sr = static_cast<float>(std::max(1, sampleRate));
+float onePoleAlpha(float cutoffHz, double sampleRate) {
+    const float sr = static_cast<float>(std::max(1.0, sampleRate));
     const float cutoff = juce::jlimit(20.0f, sr * 0.45f, cutoffHz);
     return 1.0f - std::exp(-2.0f * juce::MathConstants<float>::pi * cutoff / sr);
 }
 
-float sanitise(float sample) {
-    return std::isfinite(sample) ? juce::jlimit(-16.0f, 16.0f, sample) : 0.0f;
-}
-
 }  // namespace
 
-MagdaUtilityCompiledPlugin::MagdaUtilityCompiledPlugin(const te::PluginCreationInfo& info)
-    : te::Plugin(info) {
-    buildHostParameters();
+MagdaUtilityCompiledPlugin::MagdaUtilityCompiledPlugin() {
+    initEffect();
 }
 
-MagdaUtilityCompiledPlugin::~MagdaUtilityCompiledPlugin() {
-    notifyListenersOfDeletion();
-    for (auto& p : hostParams_)
-        if (p)
-            p->detachFromCurrentValue();
+std::vector<MagdaUtilityCompiledPlugin::HostSlotInfo> MagdaUtilityCompiledPlugin::slotInfos()
+    const {
+    std::vector<HostSlotInfo> infos(kHostSlotCount);
+    infos[kGainSlot] = {.name = "Gain",
+                        .unit = magda::technicalText(magda::TechnicalTextToken::Decibels),
+                        .scale = magda::ParameterScale::FaderDB,
+                        .minValue = -60.0f,
+                        .maxValue = 12.0f,
+                        .defaultValue = 0.0f};
+    infos[kPanSlot] = {.name = "Pan",
+                       .scale = magda::ParameterScale::Linear,
+                       .minValue = -1.0f,
+                       .maxValue = 1.0f,
+                       .defaultValue = 0.0f};
+    infos[kWidthSlot] = {.name = "Width",
+                         .unit = magda::technicalText(magda::TechnicalTextToken::Percent),
+                         .scale = magda::ParameterScale::Linear,
+                         .minValue = 0.0f,
+                         .maxValue = 200.0f,
+                         .defaultValue = 100.0f};
+    infos[kLowMonoFreqSlot] = {.name = "Low Mono Freq",
+                               .unit = magda::technicalText(magda::TechnicalTextToken::Hertz),
+                               .scale = magda::ParameterScale::Logarithmic,
+                               .minValue = 20.0f,
+                               .maxValue = 500.0f,
+                               .defaultValue = 120.0f,
+                               .scaleAnchor = 120.0f};
+    infos[kMonoSlot] = {.name = "Mono",
+                        .scale = magda::ParameterScale::Boolean,
+                        .minValue = 0.0f,
+                        .maxValue = 1.0f,
+                        .defaultValue = 0.0f};
+    infos[kLowMonoSlot] = {.name = "Low Mono",
+                           .scale = magda::ParameterScale::Boolean,
+                           .minValue = 0.0f,
+                           .maxValue = 1.0f,
+                           .defaultValue = 0.0f};
+    infos[kFlipLSlot] = {.name = "Flip L",
+                         .scale = magda::ParameterScale::Boolean,
+                         .minValue = 0.0f,
+                         .maxValue = 1.0f,
+                         .defaultValue = 0.0f};
+    infos[kFlipRSlot] = {.name = "Flip R",
+                         .scale = magda::ParameterScale::Boolean,
+                         .minValue = 0.0f,
+                         .maxValue = 1.0f,
+                         .defaultValue = 0.0f};
+
+    return infos;
 }
 
-juce::String MagdaUtilityCompiledPlugin::getName() const {
-    return "Utility";
-}
-juce::String MagdaUtilityCompiledPlugin::getPluginType() {
-    return xmlTypeName;
-}
-juce::String MagdaUtilityCompiledPlugin::getShortName(int) {
-    return "Util";
-}
-juce::String MagdaUtilityCompiledPlugin::getSelectableDescription() {
-    return "Utility";
-}
-
-void MagdaUtilityCompiledPlugin::buildHostParameters() {
-    hostSlotInfo_[kGainSlot] = {.name = "Gain",
-                                .unit = magda::technicalText(magda::TechnicalTextToken::Decibels),
-                                .scale = magda::ParameterScale::FaderDB,
-                                .minValue = -60.0f,
-                                .maxValue = 12.0f,
-                                .defaultValue = 0.0f};
-    hostSlotInfo_[kPanSlot] = {.name = "Pan",
-                               .scale = magda::ParameterScale::Linear,
-                               .minValue = -1.0f,
-                               .maxValue = 1.0f,
-                               .defaultValue = 0.0f};
-    hostSlotInfo_[kWidthSlot] = {.name = "Width",
-                                 .unit = magda::technicalText(magda::TechnicalTextToken::Percent),
-                                 .scale = magda::ParameterScale::Linear,
-                                 .minValue = 0.0f,
-                                 .maxValue = 200.0f,
-                                 .defaultValue = 100.0f};
-    hostSlotInfo_[kLowMonoFreqSlot] = {.name = "Low Mono Freq",
-                                       .unit =
-                                           magda::technicalText(magda::TechnicalTextToken::Hertz),
-                                       .scale = magda::ParameterScale::Logarithmic,
-                                       .minValue = 20.0f,
-                                       .maxValue = 500.0f,
-                                       .defaultValue = 120.0f,
-                                       .scaleAnchor = 120.0f};
-    hostSlotInfo_[kMonoSlot] = {.name = "Mono",
-                                .scale = magda::ParameterScale::Boolean,
-                                .minValue = 0.0f,
-                                .maxValue = 1.0f,
-                                .defaultValue = 0.0f};
-    hostSlotInfo_[kLowMonoSlot] = {.name = "Low Mono",
-                                   .scale = magda::ParameterScale::Boolean,
-                                   .minValue = 0.0f,
-                                   .maxValue = 1.0f,
-                                   .defaultValue = 0.0f};
-    hostSlotInfo_[kFlipLSlot] = {.name = "Flip L",
-                                 .scale = magda::ParameterScale::Boolean,
-                                 .minValue = 0.0f,
-                                 .maxValue = 1.0f,
-                                 .defaultValue = 0.0f};
-    hostSlotInfo_[kFlipRSlot] = {.name = "Flip R",
-                                 .scale = magda::ParameterScale::Boolean,
-                                 .minValue = 0.0f,
-                                 .maxValue = 1.0f,
-                                 .defaultValue = 0.0f};
-
-    juce::NormalisableRange<float> normalisedRange{0.0f, 1.0f};
-    auto* undoManager = getUndoManager();
-
-    for (int i = 0; i < kHostSlotCount; ++i) {
-        const auto& slot = hostSlotInfo_[static_cast<size_t>(i)];
-        const juce::String id = "magda_utility_" + slot.name.toLowerCase().replace(" ", "_");
-        const auto info = parameterInfoForSlot(slot);
-        const float defaultNormalised =
-            magda::ParameterUtils::realToNormalized(slot.defaultValue, info);
-        hostCached_[static_cast<size_t>(i)].referTo(state, juce::Identifier(id), undoManager,
-                                                    defaultNormalised);
-
-        auto param = addParam(
-            id, slot.name, normalisedRange,
-            [info](float normalised) {
-                const float real = magda::ParameterUtils::normalizedToReal(normalised, info);
-                return magda::ParameterUtils::formatValue(real, info);
-            },
-            [info](const juce::String& text) {
-                auto parsed = magda::ParameterUtils::parseValue(text, info);
-                if (parsed)
-                    return magda::ParameterUtils::realToNormalized(*parsed, info);
-                return 0.0f;
-            });
-        param->attachToCurrentValue(hostCached_[static_cast<size_t>(i)]);
-        hostParams_[static_cast<size_t>(i)] = param;
-    }
-}
-
-void MagdaUtilityCompiledPlugin::initialise(const te::PluginInitialisationInfo& info) {
-    sampleRate_ = std::max(1, static_cast<int>(std::round(info.sampleRate)));
-    reset();
-}
-
-void MagdaUtilityCompiledPlugin::deinitialise() {}
-
-void MagdaUtilityCompiledPlugin::reset() {
+void MagdaUtilityCompiledPlugin::onReset() {
     lowMonoLpL1_ = 0.0f;
     lowMonoLpL2_ = 0.0f;
     lowMonoLpR1_ = 0.0f;
     lowMonoLpR2_ = 0.0f;
 }
 
-float MagdaUtilityCompiledPlugin::slotDisplayValue(int slotIndex) const {
-    if (slotIndex < 0 || slotIndex >= kHostSlotCount ||
-        !hostParams_[static_cast<size_t>(slotIndex)])
-        return 0.0f;
-    const auto info = parameterInfoForSlot(hostSlotInfo_[static_cast<size_t>(slotIndex)]);
-    return magda::ParameterUtils::normalizedToReal(
-        hostParams_[static_cast<size_t>(slotIndex)]->getCurrentValue(), info);
-}
-
-void MagdaUtilityCompiledPlugin::applyToBuffer(const te::PluginRenderContext& fc) {
-    if (!fc.destBuffer || fc.bufferNumSamples <= 0)
-        return;
-
-    const int numSamples = fc.bufferNumSamples;
-    const int startSample = fc.bufferStartSample;
-    const int hostChannels = fc.destBuffer->getNumChannels();
+void MagdaUtilityCompiledPlugin::processAudio(DeviceProcessContext& context) {
+    // No Faust engine: gain, pan, M/S width and the Low Mono fold are a few
+    // lines of arithmetic each, so this is the whole block.
+    const int numSamples = context.numSamples;
+    const int startSample = context.startSample;
+    const int hostChannels = context.audio->getNumChannels();
     if (hostChannels <= 0)
         return;
 
@@ -176,17 +95,17 @@ void MagdaUtilityCompiledPlugin::applyToBuffer(const te::PluginRenderContext& fc
     const float gain = gainDb <= -59.99f ? 0.0f : juce::Decibels::decibelsToGain(gainDb);
     const float pan = juce::jlimit(-1.0f, 1.0f, slotDisplayValue(kPanSlot));
     const float width = juce::jlimit(0.0f, 200.0f, slotDisplayValue(kWidthSlot)) * 0.01f;
-    const float lowMonoFreq = slotDisplayValue(kLowMonoFreqSlot);
     const bool mono = slotDisplayValue(kMonoSlot) >= 0.5f;
     const bool lowMono = slotDisplayValue(kLowMonoSlot) >= 0.5f && !mono;
     const float flipL = slotDisplayValue(kFlipLSlot) >= 0.5f ? -1.0f : 1.0f;
     const float flipR = slotDisplayValue(kFlipRSlot) >= 0.5f ? -1.0f : 1.0f;
     const float panGainL = pan <= 0.0f ? 1.0f : 1.0f - pan;
     const float panGainR = pan >= 0.0f ? 1.0f : 1.0f + pan;
-    const float lowMonoAlpha = onePoleAlpha(lowMonoFreq, sampleRate_);
+    const float lowMonoAlpha =
+        onePoleAlpha(slotDisplayValue(kLowMonoFreqSlot), currentSampleRate());
 
-    float* left = fc.destBuffer->getWritePointer(0, startSample);
-    float* right = hostChannels > 1 ? fc.destBuffer->getWritePointer(1, startSample) : nullptr;
+    float* left = context.audio->getWritePointer(0, startSample);
+    float* right = hostChannels > 1 ? context.audio->getWritePointer(1, startSample) : nullptr;
 
     for (int i = 0; i < numSamples; ++i) {
         float l = left[i] * flipL * gain;
@@ -221,41 +140,13 @@ void MagdaUtilityCompiledPlugin::applyToBuffer(const te::PluginRenderContext& fc
             right[i] = sanitise(r);
     }
 
-    for (int ch = 2; ch < hostChannels; ++ch) {
-        float* out = fc.destBuffer->getWritePointer(ch, startSample);
+    // Anything past the stereo pair takes the gain trim and nothing else: the
+    // rest of this device is a stereo image, and there is no image to shape.
+    for (int channel = 2; channel < hostChannels; ++channel) {
+        float* out = context.audio->getWritePointer(channel, startSample);
         for (int i = 0; i < numSamples; ++i)
             out[i] = sanitise(out[i] * gain);
     }
-}
-
-te::AutomatableParameter* MagdaUtilityCompiledPlugin::getSlotParameter(int slotIndex) const {
-    if (slotIndex < 0 || slotIndex >= kHostSlotCount)
-        return nullptr;
-    return hostParams_[static_cast<size_t>(slotIndex)].get();
-}
-
-const MagdaUtilityCompiledPlugin::HostSlotInfo& MagdaUtilityCompiledPlugin::getSlotInfo(
-    int slotIndex) const {
-    static const HostSlotInfo kEmpty;
-    if (slotIndex < 0 || slotIndex >= kHostSlotCount)
-        return kEmpty;
-    return hostSlotInfo_[static_cast<size_t>(slotIndex)];
-}
-
-float MagdaUtilityCompiledPlugin::displayValueToNativeValue(int slotIndex,
-                                                            float displayValue) const {
-    if (slotIndex < 0 || slotIndex >= kHostSlotCount)
-        return displayValue;
-    return magda::ParameterUtils::realToNormalized(
-        displayValue, parameterInfoForSlot(hostSlotInfo_[static_cast<size_t>(slotIndex)]));
-}
-
-float MagdaUtilityCompiledPlugin::nativeValueToDisplayValue(int slotIndex,
-                                                            float nativeValue) const {
-    if (slotIndex < 0 || slotIndex >= kHostSlotCount)
-        return nativeValue;
-    return magda::ParameterUtils::normalizedToReal(
-        nativeValue, parameterInfoForSlot(hostSlotInfo_[static_cast<size_t>(slotIndex)]));
 }
 
 constexpr AliasSpec kUtilAliases[] = {
@@ -276,9 +167,8 @@ const CompiledPluginSpec& getMagdaUtilitySpec() {
             "Low Mono sums only the bass below the Low Mono Freq cutoff, "
             "tightening sub content while preserving stereo highs. "
             "Flip L / Flip R invert per-channel polarity for phase tweaks.",
-        .createPlugin = [](const DevicePluginCreationContext& context) -> DevicePluginPtr {
-            return tracktion_adapter::pluginHandle(
-                new MagdaUtilityCompiledPlugin(tracktion_adapter::creationInfo(context)));
+        .createDevice = [](const DevicePluginCreationContext&) -> std::unique_ptr<MagdaDevice> {
+            return std::make_unique<MagdaUtilityCompiledPlugin>();
         },
         .aliasKey = "utility",
         .aliases = kUtilAliases,

--- a/magda/daw/audio/plugins/compiled/MagdaUtilityCompiledPlugin.hpp
+++ b/magda/daw/audio/plugins/compiled/MagdaUtilityCompiledPlugin.hpp
@@ -1,46 +1,16 @@
 #pragma once
 
-#include <tracktion_engine/tracktion_engine.h>
+#include <vector>
 
-#include <array>
-
-#include "core/ParameterInfo.hpp"
-#include "plugins/compiled/tracktion/CompiledFaustTracktionAdapter.hpp"
+#include "plugins/compiled/MagdaCompiledEffect.hpp"
 
 namespace magda::daw::audio::compiled {
 
-class MagdaUtilityCompiledPlugin : public te::Plugin, public ICompiledFaustPlugin {
+class MagdaUtilityCompiledPlugin : public MagdaCompiledEffect {
   public:
     static const char* xmlTypeName;
 
-    explicit MagdaUtilityCompiledPlugin(const te::PluginCreationInfo& info);
-    ~MagdaUtilityCompiledPlugin() override;
-
-    juce::String getName() const override;
-    juce::String getPluginType() override;
-    juce::String getShortName(int) override;
-    juce::String getSelectableDescription() override;
-
-    void initialise(const te::PluginInitialisationInfo& info) override;
-    void deinitialise() override;
-    void reset() override;
-    void applyToBuffer(const te::PluginRenderContext& fc) override;
-
-    bool takesMidiInput() override {
-        return false;
-    }
-    bool takesAudioInput() override {
-        return true;
-    }
-    bool isSynth() override {
-        return false;
-    }
-    bool producesAudioWhenNoAudioInput() override {
-        return false;
-    }
-    double getTailLength() const override {
-        return 0.0;
-    }
+    MagdaUtilityCompiledPlugin();
 
     static constexpr int kGainSlot = 0;
     static constexpr int kPanSlot = 1;
@@ -52,39 +22,26 @@ class MagdaUtilityCompiledPlugin : public te::Plugin, public ICompiledFaustPlugi
     static constexpr int kFlipRSlot = 7;
     static constexpr int kHostSlotCount = 8;
 
-    te::AutomatableParameter* getSlotParameter(int slotIndex) const;
+    juce::String devicePluginId() const override {
+        return xmlTypeName;
+    }
+    juce::String deviceName() const override {
+        return "Utility";
+    }
+    juce::String deviceShortName() const override {
+        return "Util";
+    }
 
-    float displayValueToNativeValue(int slotIndex, float displayValue) const;
-    float nativeValueToDisplayValue(int slotIndex, float nativeValue) const;
-
-    using HostSlotInfo = CompiledHostSlotInfo;
-    const HostSlotInfo& getSlotInfo(int slotIndex) const;
-
-    int hostSlotCount() const override {
-        return kHostSlotCount;
+  protected:
+    std::vector<HostSlotInfo> slotInfos() const override;
+    const char* slotIdPrefix() const override {
+        return "magda_utility_";
     }
-    const CompiledHostSlotInfo& hostSlotInfo(int slotIndex) const override {
-        return getSlotInfo(slotIndex);
-    }
-    DeviceParameterHandle hostSlotParameter(int slotIndex) const override {
-        return tracktion_adapter::parameterHandle(getSlotParameter(slotIndex));
-    }
-    float displayToNormalized(int slotIndex, float displayValue) const override {
-        return displayValueToNativeValue(slotIndex, displayValue);
-    }
-    float normalizedToDisplay(int slotIndex, float normalizedValue) const override {
-        return nativeValueToDisplayValue(slotIndex, normalizedValue);
-    }
+    void onReset() override;
+    void processAudio(DeviceProcessContext& context) override;
 
   private:
-    void buildHostParameters();
-    float slotDisplayValue(int slotIndex) const;
-
-    std::array<HostSlotInfo, kHostSlotCount> hostSlotInfo_;
-    std::array<te::AutomatableParameter::Ptr, kHostSlotCount> hostParams_;
-    std::array<juce::CachedValue<float>, kHostSlotCount> hostCached_;
-
-    int sampleRate_ = 44100;
+    // One-pole state for the Low Mono crossover, audio thread only.
     float lowMonoLpL1_ = 0.0f;
     float lowMonoLpL2_ = 0.0f;
     float lowMonoLpR1_ = 0.0f;

--- a/magda/daw/audio/plugins/engine/EngineMagdaDevice.cpp
+++ b/magda/daw/audio/plugins/engine/EngineMagdaDevice.cpp
@@ -262,7 +262,9 @@ void EngineMagdaDevice::prepare(const magda::engine::RenderContext& context) {
     latencySamples_ =
         static_cast<int>(std::llround(properties_.latencySeconds * context.sampleRate));
 
-    channels_.assign(static_cast<std::size_t>(std::max(0, context.numChannels)), nullptr);
+    // Room for the device's own channels plus a sidechain key of the same
+    // width appended after them, which is how the SDK hands one over.
+    channels_.assign(static_cast<std::size_t>(std::max(0, context.numChannels) * 2), nullptr);
 
     sizeMidiScratch();
 }
@@ -320,9 +322,21 @@ void EngineMagdaDevice::process(magda::engine::DeviceBlock& block) {
     for (std::size_t channel = 0; channel < numChannels; ++channel)
         channels_[channel] = block.audio.getChannelPointer(channel);
 
+    // The key, appended after the device's own channels: the SDK hands a
+    // sidechain over as further channels of the same buffer, and the executor
+    // gives it to us as a separate block. The const_cast is safe because the
+    // contract is that a device reads its key and never writes it, and the
+    // alternative is copying the block every callback to say so in the type.
+    auto sidechainChannels = std::min(channels_.size() - numChannels,
+                                      static_cast<std::size_t>(block.sidechain.getNumChannels()));
+    for (std::size_t channel = 0; channel < sidechainChannels; ++channel)
+        channels_[numChannels + channel] =
+            const_cast<float*>(block.sidechain.getChannelPointer(channel));
+
     // Non-owning: the executor's buffer, seen through the container the SDK
     // takes. Nothing is copied and nothing is allocated.
-    juce::AudioBuffer<float> audio(channels_.data(), static_cast<int>(numChannels), numSamples);
+    juce::AudioBuffer<float> audio(channels_.data(),
+                                   static_cast<int>(numChannels + sidechainChannels), numSamples);
 
     std::optional<EngineMidiBufferView> midi;
     if (block.midiIn != nullptr || block.midiOut != nullptr) {
@@ -355,6 +369,7 @@ void EngineMagdaDevice::process(magda::engine::DeviceBlock& block) {
 
     DeviceProcessContext context{
         .audio = &audio,
+        .sidechainInputChannel = sidechainChannels > 0 ? static_cast<int>(numChannels) : -1,
         .midi = midi ? &*midi : nullptr,
         .tempoMap = tempo ? &*tempo : nullptr,
         .startSample = 0,

--- a/magda/daw/audio/plugins/engine/EngineMagdaDevice.hpp
+++ b/magda/daw/audio/plugins/engine/EngineMagdaDevice.hpp
@@ -30,13 +30,9 @@
  * once would differ from it by however much the curve moves across a block, on
  * every automated parameter, in every project.
  *
- * Three things the device SDK does not carry yet, named here rather than
+ * Two things the device SDK does not carry yet, named here rather than
  * silently dropped, because each is a divergence the day a device wants it:
  *
- * - **Sidechain audio.** DeviceProcessContext has no sidechain buffer, so
- *   DeviceBlock::sidechain stops here. No MagdaDevice reads one today (the
- *   sidechain fleet is still Tracktion-native), and the SDK has to grow the
- *   input before one can.
  * - **Further output pairs.** A MagdaDevice declares no channel layout beyond
  *   what it writes into the buffer it is handed, so DeviceBlock::extraOutputs
  *   is left cleared. Multi-out is a te::RackType wrapper in the incumbent and
@@ -46,12 +42,11 @@
  *   flag beside the events and the engine's juce::MidiBuffer does not. A device
  *   that sets it is writing to something nothing downstream reads here.
  *
- * The tempo map goes the other way. The fork's adapter passes null because
- * TempoSequence queries are not guaranteed real-time safe; the engine's map is
- * an immutable snapshot the transport already holds for the length of the
- * callback, so this passes it. Nothing reads it yet in either host, which is
- * why that is a difference in what is offered rather than a divergence in what
- * is rendered.
+ * Sidechain audio used to be a third. DeviceBlock::sidechain now reaches the
+ * device as further channels of its own buffer, after the ones it owns, with
+ * DeviceProcessContext::sidechainInputChannel saying where they start -- the
+ * layout MAGDA's compiled dynamics DSPs already read and the one the fork
+ * hands them (#2192).
  */
 
 namespace magda::daw::audio::engine_adapter {

--- a/magda/daw/audio/plugins/tracktion/TracktionMagdaDevicePlugin.cpp
+++ b/magda/daw/audio/plugins/tracktion/TracktionMagdaDevicePlugin.cpp
@@ -15,6 +15,33 @@ DeviceProperties propertiesForRequiredDevice(const std::unique_ptr<MagdaDevice>&
     return device->properties();
 }
 
+/**
+ * The edit's tempo sequence, read through the SDK's tempo contract.
+ *
+ * Queried on the audio thread, which is where the compiled devices that need a
+ * BPM have always queried it: the tempo-synced effects each called
+ * `edit.tempoSequence.getBpmAt()` from their own applyToBuffer() before they
+ * were ported (#2192). This changes who holds the reference, not when the call
+ * happens. A snapshot taken on the message thread would be the better contract
+ * and belongs with the state slice rather than with the device ports.
+ */
+class TracktionTempoMapView final : public DeviceTempoMap {
+  public:
+    explicit TracktionTempoMapView(te::TempoSequence& tempoSequence)
+        : tempoSequence_(tempoSequence) {}
+
+    double beatsAtSeconds(double seconds) const override {
+        return tempoSequence_.toBeats(tracktion::TimePosition::fromSeconds(seconds)).inBeats();
+    }
+
+    double bpmAtSeconds(double seconds) const override {
+        return tempoSequence_.getBpmAt(tracktion::TimePosition::fromSeconds(seconds));
+    }
+
+  private:
+    te::TempoSequence& tempoSequence_;
+};
+
 class TracktionMidiBufferView final : public DeviceMidiBuffer {
   public:
     explicit TracktionMidiBufferView(te::MidiMessageArray& midi) : midi_(midi) {}
@@ -121,13 +148,12 @@ void TracktionMagdaDevicePlugin::applyToBuffer(const te::PluginRenderContext& co
     if (context.bufferForMidiMessages != nullptr)
         midi.emplace(*context.bufferForMidiMessages);
 
+    TracktionTempoMapView tempoMap{edit.tempoSequence};
+
     DeviceProcessContext deviceContext{
         .audio = context.destBuffer,
         .midi = midi ? &*midi : nullptr,
-        // TempoSequence queries are not guaranteed real-time safe. Leave the
-        // optional map absent until the adapter can supply an immutable
-        // message-thread snapshot.
-        .tempoMap = nullptr,
+        .tempoMap = &tempoMap,
         .startSample = context.bufferStartSample,
         .numSamples = context.bufferNumSamples,
         .midiTimeOffsetSeconds = context.midiBufferOffset,
@@ -158,6 +184,10 @@ bool TracktionMagdaDevicePlugin::producesAudioWhenNoAudioInput() {
 
 bool TracktionMagdaDevicePlugin::canSidechain() {
     return properties_.canSidechain;
+}
+
+int TracktionMagdaDevicePlugin::getNumOutputChannelsGivenInputs(int numInputChannels) {
+    return properties_.outputChannelCount > 0 ? properties_.outputChannelCount : numInputChannels;
 }
 
 double TracktionMagdaDevicePlugin::getLatencySeconds() {

--- a/magda/daw/audio/plugins/tracktion/TracktionMagdaDevicePlugin.cpp
+++ b/magda/daw/audio/plugins/tracktion/TracktionMagdaDevicePlugin.cpp
@@ -150,8 +150,16 @@ void TracktionMagdaDevicePlugin::applyToBuffer(const te::PluginRenderContext& co
 
     TracktionTempoMapView tempoMap{edit.tempoSequence};
 
+    // The fork appends the key to the plugin's own channels, so the device's
+    // declared width is where it starts.
+    const int sidechainChannel =
+        getSidechainSourceID().isValid()
+            ? (properties_.outputChannelCount > 0 ? properties_.outputChannelCount : 2)
+            : -1;
+
     DeviceProcessContext deviceContext{
         .audio = context.destBuffer,
+        .sidechainInputChannel = sidechainChannel,
         .midi = midi ? &*midi : nullptr,
         .tempoMap = &tempoMap,
         .startSample = context.bufferStartSample,
@@ -188,6 +196,31 @@ bool TracktionMagdaDevicePlugin::canSidechain() {
 
 int TracktionMagdaDevicePlugin::getNumOutputChannelsGivenInputs(int numInputChannels) {
     return properties_.outputChannelCount > 0 ? properties_.outputChannelCount : numInputChannels;
+}
+
+void TracktionMagdaDevicePlugin::getChannelNames(juce::StringArray* inputs,
+                                                 juce::StringArray* outputs) {
+    if (properties_.inputChannelCount <= 0 && properties_.outputChannelCount <= 0) {
+        te::Plugin::getChannelNames(inputs, outputs);
+        return;
+    }
+
+    // The model counts these to decide how a device is wired, so a device that
+    // declared its widths answers for itself. Inputs past the output width are
+    // the key, which is the SDK's sidechain layout.
+    const auto name = [](int index, int mainChannels) {
+        if (index >= mainChannels)
+            return juce::String("Sidechain");
+        return juce::String(index == 0 ? "Left" : "Right");
+    };
+
+    if (inputs != nullptr)
+        for (int index = 0; index < properties_.inputChannelCount; ++index)
+            inputs->add(name(index, properties_.outputChannelCount));
+
+    if (outputs != nullptr)
+        for (int index = 0; index < properties_.outputChannelCount; ++index)
+            outputs->add(name(index, properties_.outputChannelCount));
 }
 
 double TracktionMagdaDevicePlugin::getLatencySeconds() {

--- a/magda/daw/audio/plugins/tracktion/TracktionMagdaDevicePlugin.cpp
+++ b/magda/daw/audio/plugins/tracktion/TracktionMagdaDevicePlugin.cpp
@@ -200,27 +200,32 @@ int TracktionMagdaDevicePlugin::getNumOutputChannelsGivenInputs(int numInputChan
 
 void TracktionMagdaDevicePlugin::getChannelNames(juce::StringArray* inputs,
                                                  juce::StringArray* outputs) {
-    if (properties_.inputChannelCount <= 0 && properties_.outputChannelCount <= 0) {
-        te::Plugin::getChannelNames(inputs, outputs);
-        return;
-    }
+    // The base answers first, and a declared width replaces that side and only
+    // that side. A device that names its inputs and not its outputs (or the
+    // other way round) still gets the host's answer for the half it left alone:
+    // reporting zero channels there would tell the model the device is not
+    // connected to the bus at all.
+    te::Plugin::getChannelNames(inputs, outputs);
 
-    // The model counts these to decide how a device is wired, so a device that
-    // declared its widths answers for itself. Inputs past the output width are
-    // the key, which is the SDK's sidechain layout.
-    const auto name = [](int index, int mainChannels) {
-        if (index >= mainChannels)
+    // Inputs past the output width are the key, which is the SDK's sidechain
+    // layout.
+    const auto name = [this](int index) {
+        if (properties_.outputChannelCount > 0 && index >= properties_.outputChannelCount)
             return juce::String("Sidechain");
         return juce::String(index == 0 ? "Left" : "Right");
     };
 
-    if (inputs != nullptr)
+    if (inputs != nullptr && properties_.inputChannelCount > 0) {
+        inputs->clear();
         for (int index = 0; index < properties_.inputChannelCount; ++index)
-            inputs->add(name(index, properties_.outputChannelCount));
+            inputs->add(name(index));
+    }
 
-    if (outputs != nullptr)
+    if (outputs != nullptr && properties_.outputChannelCount > 0) {
+        outputs->clear();
         for (int index = 0; index < properties_.outputChannelCount; ++index)
-            outputs->add(name(index, properties_.outputChannelCount));
+            outputs->add(name(index));
+    }
 }
 
 double TracktionMagdaDevicePlugin::getLatencySeconds() {

--- a/magda/daw/audio/plugins/tracktion/TracktionMagdaDevicePlugin.hpp
+++ b/magda/daw/audio/plugins/tracktion/TracktionMagdaDevicePlugin.hpp
@@ -41,6 +41,7 @@ class TracktionMagdaDevicePlugin final : public te::Plugin {
     bool producesAudioWhenNoAudioInput() override;
     bool canSidechain() override;
     int getNumOutputChannelsGivenInputs(int numInputChannels) override;
+    void getChannelNames(juce::StringArray* inputs, juce::StringArray* outputs) override;
     double getLatencySeconds() override;
     double getTailLength() const override;
 

--- a/magda/daw/audio/plugins/tracktion/TracktionMagdaDevicePlugin.hpp
+++ b/magda/daw/audio/plugins/tracktion/TracktionMagdaDevicePlugin.hpp
@@ -40,6 +40,7 @@ class TracktionMagdaDevicePlugin final : public te::Plugin {
     bool isSynth() override;
     bool producesAudioWhenNoAudioInput() override;
     bool canSidechain() override;
+    int getNumOutputChannelsGivenInputs(int numInputChannels) override;
     double getLatencySeconds() override;
     double getTailLength() const override;
 

--- a/magda/daw/ui/components/chain/compiled/CompiledBitcrusherEditorView.cpp
+++ b/magda/daw/ui/components/chain/compiled/CompiledBitcrusherEditorView.cpp
@@ -3,6 +3,7 @@
 #include <cmath>
 
 #include "audio/plugins/compiled/MagdaBitcrusherCompiledPlugin.hpp"
+#include "audio/plugins/tracktion/TracktionMagdaDevicePlugin.hpp"
 #include "ui/themes/DarkTheme.hpp"
 
 namespace magda::daw::ui {
@@ -39,8 +40,8 @@ void CompiledBitcrusherEditorView::setCompiledPlugin(
 }
 
 void CompiledBitcrusherEditorView::bindPlugin(te::Plugin* plugin) {
-    setCompiledPlugin(
-        dynamic_cast<magda::daw::audio::compiled::MagdaBitcrusherCompiledPlugin*>(plugin));
+    setCompiledPlugin(magda::daw::audio::tracktion_adapter::deviceFromPlugin<
+                      magda::daw::audio::compiled::MagdaBitcrusherCompiledPlugin>(plugin));
 }
 
 void CompiledBitcrusherEditorView::updateFromDevice(const magda::DeviceInfo& device) {
@@ -57,8 +58,8 @@ void CompiledBitcrusherEditorView::resampleFromDevice() {
 void CompiledBitcrusherEditorView::timerCallback() {
     if (compiledPlugin_ != nullptr) {
         auto read = [this](int slot, float fallback) {
-            if (auto* p = compiledPlugin_->getSlotParameter(slot))
-                return compiledPlugin_->nativeValueToDisplayValue(slot, p->getCurrentValue());
+            if (auto p = compiledPlugin_->getSlotParameter(slot))
+                return compiledPlugin_->nativeValueToDisplayValue(slot, p.currentValue());
             return fallback;
         };
         bits_ = read(Plugin::kBitsSlot, bits_);

--- a/magda/daw/ui/components/chain/compiled/CompiledChorusCurveView.cpp
+++ b/magda/daw/ui/components/chain/compiled/CompiledChorusCurveView.cpp
@@ -4,6 +4,7 @@
 #include <cmath>
 
 #include "audio/plugins/compiled/MagdaChorusCompiledPlugin.hpp"
+#include "audio/plugins/tracktion/TracktionMagdaDevicePlugin.hpp"
 #include "ui/themes/DarkTheme.hpp"
 
 namespace magda::daw::ui {
@@ -46,8 +47,8 @@ void CompiledChorusCurveView::setCompiledPlugin(
 }
 
 void CompiledChorusCurveView::bindPlugin(te::Plugin* plugin) {
-    setCompiledPlugin(
-        dynamic_cast<magda::daw::audio::compiled::MagdaChorusCompiledPlugin*>(plugin));
+    setCompiledPlugin(magda::daw::audio::tracktion_adapter::deviceFromPlugin<
+                      magda::daw::audio::compiled::MagdaChorusCompiledPlugin>(plugin));
 }
 
 void CompiledChorusCurveView::updateFromDevice(const magda::DeviceInfo& device) {
@@ -74,8 +75,8 @@ void CompiledChorusCurveView::timerCallback() {
     auto readPluginSlot = [this](int slot, float fallback) {
         if (compiledPlugin_ == nullptr)
             return fallback;
-        if (auto* p = compiledPlugin_->getSlotParameter(slot))
-            return compiledPlugin_->nativeValueToDisplayValue(slot, p->getCurrentValue());
+        if (auto p = compiledPlugin_->getSlotParameter(slot))
+            return compiledPlugin_->nativeValueToDisplayValue(slot, p.currentValue());
         return fallback;
     };
 
@@ -94,8 +95,8 @@ void CompiledChorusCurveView::timerCallback() {
         rateHz = readPluginSlot(Chorus::kRateSlot, rateHz);
         depth = readPluginSlot(Chorus::kDepthSlot, depth);
         width = readPluginSlot(Chorus::kWidthSlot, width);
-        if (auto* p = compiledPlugin_->getSlotParameter(Chorus::kDivisionSlot)) {
-            const float norm = p->getCurrentValue();
+        if (auto p = compiledPlugin_->getSlotParameter(Chorus::kDivisionSlot)) {
+            const float norm = p.currentValue();
             const auto& info = compiledPlugin_->getSlotInfo(Chorus::kDivisionSlot);
             const int count = static_cast<int>(info.choices.size());
             const int idx =
@@ -213,9 +214,9 @@ void CompiledChorusCurveView::paint(juce::Graphics& g) {
         if (compiledPlugin_ != nullptr) {
             const auto& info = compiledPlugin_->getSlotInfo(
                 magda::daw::audio::compiled::MagdaChorusCompiledPlugin::kDivisionSlot);
-            if (auto* p = compiledPlugin_->getSlotParameter(
+            if (auto p = compiledPlugin_->getSlotParameter(
                     magda::daw::audio::compiled::MagdaChorusCompiledPlugin::kDivisionSlot)) {
-                const float norm = p->getCurrentValue();
+                const float norm = p.currentValue();
                 const int count = static_cast<int>(info.choices.size());
                 if (count > 0) {
                     const int idx = juce::jlimit(

--- a/magda/daw/ui/components/chain/compiled/CompiledClipperCurveView.cpp
+++ b/magda/daw/ui/components/chain/compiled/CompiledClipperCurveView.cpp
@@ -4,6 +4,7 @@
 #include <cmath>
 
 #include "audio/plugins/compiled/MagdaClipperCompiledPlugin.hpp"
+#include "audio/plugins/tracktion/TracktionMagdaDevicePlugin.hpp"
 #include "ui/themes/DarkTheme.hpp"
 #include "ui/themes/FontManager.hpp"
 
@@ -88,8 +89,8 @@ void CompiledClipperCurveView::setCompiledPlugin(
 }
 
 void CompiledClipperCurveView::bindPlugin(te::Plugin* plugin) {
-    setCompiledPlugin(
-        dynamic_cast<magda::daw::audio::compiled::MagdaClipperCompiledPlugin*>(plugin));
+    setCompiledPlugin(magda::daw::audio::tracktion_adapter::deviceFromPlugin<
+                      magda::daw::audio::compiled::MagdaClipperCompiledPlugin>(plugin));
 }
 
 void CompiledClipperCurveView::updateFromDevice(const magda::DeviceInfo& device) {
@@ -104,9 +105,7 @@ void CompiledClipperCurveView::timerCallback() {
     auto readPluginSlot = [this](int slot, float fallback) {
         if (compiledPlugin_ == nullptr)
             return fallback;
-        if (auto* p = compiledPlugin_->getSlotParameter(slot))
-            return compiledPlugin_->nativeValueToDisplayValue(slot, p->getCurrentValue());
-        return fallback;
+        return compiledPlugin_->slotDisplayValue(slot);
     };
 
     float drive = driveDb_;

--- a/magda/daw/ui/components/chain/compiled/CompiledCompressorCurveView.cpp
+++ b/magda/daw/ui/components/chain/compiled/CompiledCompressorCurveView.cpp
@@ -4,6 +4,7 @@
 #include <cmath>
 
 #include "audio/plugins/compiled/MagdaCompressorCompiledPlugin.hpp"
+#include "audio/plugins/tracktion/TracktionMagdaDevicePlugin.hpp"
 #include "core/GestureRouter.hpp"
 #include "ui/themes/DarkTheme.hpp"
 #include "ui/themes/FontManager.hpp"
@@ -98,8 +99,8 @@ void CompiledCompressorCurveView::timerCallback() {
     auto readPluginSlot = [this](int slot, float fallback) {
         if (compiledPlugin_ == nullptr)
             return fallback;
-        if (auto* p = compiledPlugin_->getSlotParameter(slot))
-            return compiledPlugin_->nativeValueToDisplayValue(slot, p->getCurrentValue());
+        if (auto p = compiledPlugin_->getSlotParameter(slot))
+            return compiledPlugin_->nativeValueToDisplayValue(slot, p.currentValue());
         return fallback;
     };
 
@@ -423,8 +424,8 @@ const CompiledPresentationSpec& getMagdaCompressorPresentation() {
 }
 
 void CompiledCompressorCurveView::bindPlugin(te::Plugin* plugin) {
-    setCompiledPlugin(
-        dynamic_cast<magda::daw::audio::compiled::MagdaCompressorCompiledPlugin*>(plugin));
+    setCompiledPlugin(magda::daw::audio::tracktion_adapter::deviceFromPlugin<
+                      magda::daw::audio::compiled::MagdaCompressorCompiledPlugin>(plugin));
 }
 
 }  // namespace magda::daw::ui

--- a/magda/daw/ui/components/chain/compiled/CompiledDelayCurveView.cpp
+++ b/magda/daw/ui/components/chain/compiled/CompiledDelayCurveView.cpp
@@ -4,6 +4,7 @@
 #include <cmath>
 
 #include "audio/plugins/compiled/MagdaDelayCompiledPlugin.hpp"
+#include "audio/plugins/tracktion/TracktionMagdaDevicePlugin.hpp"
 #include "ui/themes/DarkTheme.hpp"
 
 namespace magda::daw::ui {
@@ -60,20 +61,17 @@ void CompiledDelayCurveView::timerCallback() {
     float bpm = bpm_;
 
     if (compiledPlugin_ != nullptr) {
-        if (auto* p = compiledPlugin_->getSlotParameter(Delay::kTimeSlot))
-            time =
-                compiledPlugin_->nativeValueToDisplayValue(Delay::kTimeSlot, p->getCurrentValue());
-        if (auto* p = compiledPlugin_->getSlotParameter(Delay::kFeedbackSlot))
-            fb = compiledPlugin_->nativeValueToDisplayValue(Delay::kFeedbackSlot,
-                                                            p->getCurrentValue());
-        if (auto* p = compiledPlugin_->getSlotParameter(Delay::kCrossSlot))
-            cross =
-                compiledPlugin_->nativeValueToDisplayValue(Delay::kCrossSlot, p->getCurrentValue());
-        if (auto* p = compiledPlugin_->getSlotParameter(Delay::kSyncSlot))
-            sync = p->getCurrentValue() >= 0.5f;
-        if (auto* p = compiledPlugin_->getSlotParameter(Delay::kDivisionSlot)) {
+        if (auto p = compiledPlugin_->getSlotParameter(Delay::kTimeSlot))
+            time = compiledPlugin_->nativeValueToDisplayValue(Delay::kTimeSlot, p.currentValue());
+        if (auto p = compiledPlugin_->getSlotParameter(Delay::kFeedbackSlot))
+            fb = compiledPlugin_->nativeValueToDisplayValue(Delay::kFeedbackSlot, p.currentValue());
+        if (auto p = compiledPlugin_->getSlotParameter(Delay::kCrossSlot))
+            cross = compiledPlugin_->nativeValueToDisplayValue(Delay::kCrossSlot, p.currentValue());
+        if (auto p = compiledPlugin_->getSlotParameter(Delay::kSyncSlot))
+            sync = p.currentValue() >= 0.5f;
+        if (auto p = compiledPlugin_->getSlotParameter(Delay::kDivisionSlot)) {
             divIdx = static_cast<int>(std::round(compiledPlugin_->nativeValueToDisplayValue(
-                Delay::kDivisionSlot, p->getCurrentValue())));
+                Delay::kDivisionSlot, p.currentValue())));
         }
         bpm = compiledPlugin_->currentBpm();
     } else {
@@ -238,7 +236,8 @@ const CompiledPresentationSpec& getMagdaDelayPresentation() {
 }
 
 void CompiledDelayCurveView::bindPlugin(te::Plugin* plugin) {
-    setCompiledPlugin(dynamic_cast<magda::daw::audio::compiled::MagdaDelayCompiledPlugin*>(plugin));
+    setCompiledPlugin(magda::daw::audio::tracktion_adapter::deviceFromPlugin<
+                      magda::daw::audio::compiled::MagdaDelayCompiledPlugin>(plugin));
 }
 
 }  // namespace magda::daw::ui

--- a/magda/daw/ui/components/chain/compiled/CompiledDimensionView.cpp
+++ b/magda/daw/ui/components/chain/compiled/CompiledDimensionView.cpp
@@ -3,6 +3,7 @@
 #include <cmath>
 
 #include "audio/plugins/compiled/MagdaDimensionCompiledPlugin.hpp"
+#include "audio/plugins/tracktion/TracktionMagdaDevicePlugin.hpp"
 #include "ui/themes/DarkTheme.hpp"
 
 namespace magda::daw::ui {
@@ -46,8 +47,8 @@ void CompiledDimensionView::setCompiledPlugin(
 }
 
 void CompiledDimensionView::bindPlugin(te::Plugin* plugin) {
-    setCompiledPlugin(
-        dynamic_cast<magda::daw::audio::compiled::MagdaDimensionCompiledPlugin*>(plugin));
+    setCompiledPlugin(magda::daw::audio::tracktion_adapter::deviceFromPlugin<
+                      magda::daw::audio::compiled::MagdaDimensionCompiledPlugin>(plugin));
 }
 
 void CompiledDimensionView::updateFromDevice(const magda::DeviceInfo& device) {
@@ -67,8 +68,8 @@ void CompiledDimensionView::resampleFromDevice() {
 void CompiledDimensionView::timerCallback() {
     if (compiledPlugin_ != nullptr) {
         auto read = [this](int slot, float fallback) {
-            if (auto* p = compiledPlugin_->getSlotParameter(slot))
-                return compiledPlugin_->nativeValueToDisplayValue(slot, p->getCurrentValue());
+            if (auto p = compiledPlugin_->getSlotParameter(slot))
+                return compiledPlugin_->nativeValueToDisplayValue(slot, p.currentValue());
             return fallback;
         };
         engine_ = juce::jlimit(0, Plugin::kEngineCount - 1,

--- a/magda/daw/ui/components/chain/compiled/CompiledEqCurveView.cpp
+++ b/magda/daw/ui/components/chain/compiled/CompiledEqCurveView.cpp
@@ -5,6 +5,7 @@
 
 #include "../../../utils/CurveLabelLayout.hpp"
 #include "audio/plugins/compiled/MagdaEqCompiledPlugin.hpp"
+#include "audio/plugins/tracktion/TracktionMagdaDevicePlugin.hpp"
 #include "core/GestureRouter.hpp"
 #include "ui/themes/DarkTheme.hpp"
 
@@ -266,7 +267,8 @@ void CompiledEqCurveView::setCompiledPlugin(
 }
 
 void CompiledEqCurveView::bindPlugin(te::Plugin* plugin) {
-    setCompiledPlugin(dynamic_cast<magda::daw::audio::compiled::MagdaEqCompiledPlugin*>(plugin));
+    setCompiledPlugin(magda::daw::audio::tracktion_adapter::deviceFromPlugin<
+                      magda::daw::audio::compiled::MagdaEqCompiledPlugin>(plugin));
 }
 
 void CompiledEqCurveView::updateFromDevice(const magda::DeviceInfo& device) {

--- a/magda/daw/ui/components/chain/compiled/CompiledFilterCurveView.cpp
+++ b/magda/daw/ui/components/chain/compiled/CompiledFilterCurveView.cpp
@@ -5,6 +5,7 @@
 #include <vector>
 
 #include "audio/plugins/compiled/MagdaFilterCompiledPlugin.hpp"
+#include "audio/plugins/tracktion/TracktionMagdaDevicePlugin.hpp"
 #include "core/ParameterUtils.hpp"
 #include "ui/themes/DarkTheme.hpp"
 #include "ui/themes/FontManager.hpp"
@@ -44,8 +45,8 @@ float modulatedValueForSlot(const magda::DeviceInfo& device, int slotIndex, floa
                             const ParamLinkContext* linkContext,
                             magda::daw::audio::compiled::MagdaFilterCompiledPlugin* plugin) {
     if (plugin != nullptr) {
-        if (auto* param = plugin->getSlotParameter(slotIndex))
-            return plugin->nativeValueToDisplayValue(slotIndex, param->getCurrentValue());
+        if (auto param = plugin->getSlotParameter(slotIndex))
+            return plugin->nativeValueToDisplayValue(slotIndex, param.currentValue());
     }
 
     const auto* param = paramForSlot(device, slotIndex);
@@ -429,8 +430,8 @@ const CompiledPresentationSpec& getMagdaFilterPresentation() {
 }
 
 void CompiledFilterCurveView::bindPlugin(te::Plugin* plugin) {
-    setCompiledPlugin(
-        dynamic_cast<magda::daw::audio::compiled::MagdaFilterCompiledPlugin*>(plugin));
+    setCompiledPlugin(magda::daw::audio::tracktion_adapter::deviceFromPlugin<
+                      magda::daw::audio::compiled::MagdaFilterCompiledPlugin>(plugin));
 }
 
 }  // namespace magda::daw::ui

--- a/magda/daw/ui/components/chain/compiled/CompiledFlangerCurveView.cpp
+++ b/magda/daw/ui/components/chain/compiled/CompiledFlangerCurveView.cpp
@@ -4,6 +4,7 @@
 #include <cmath>
 
 #include "audio/plugins/compiled/MagdaFlangerCompiledPlugin.hpp"
+#include "audio/plugins/tracktion/TracktionMagdaDevicePlugin.hpp"
 #include "ui/themes/DarkTheme.hpp"
 
 namespace magda::daw::ui {
@@ -58,8 +59,8 @@ void CompiledFlangerCurveView::setCompiledPlugin(
 }
 
 void CompiledFlangerCurveView::bindPlugin(te::Plugin* plugin) {
-    setCompiledPlugin(
-        dynamic_cast<magda::daw::audio::compiled::MagdaFlangerCompiledPlugin*>(plugin));
+    setCompiledPlugin(magda::daw::audio::tracktion_adapter::deviceFromPlugin<
+                      magda::daw::audio::compiled::MagdaFlangerCompiledPlugin>(plugin));
 }
 
 void CompiledFlangerCurveView::updateFromDevice(const magda::DeviceInfo& device) {
@@ -86,8 +87,8 @@ void CompiledFlangerCurveView::timerCallback() {
     auto readPluginSlot = [this](int slot, float fallback) {
         if (compiledPlugin_ == nullptr)
             return fallback;
-        if (auto* p = compiledPlugin_->getSlotParameter(slot))
-            return compiledPlugin_->nativeValueToDisplayValue(slot, p->getCurrentValue());
+        if (auto p = compiledPlugin_->getSlotParameter(slot))
+            return compiledPlugin_->nativeValueToDisplayValue(slot, p.currentValue());
         return fallback;
     };
 
@@ -107,8 +108,8 @@ void CompiledFlangerCurveView::timerCallback() {
         feedback = readPluginSlot(Flanger::kFeedbackSlot, feedback);
         mix = readPluginSlot(Flanger::kMixSlot, mix);
         width = readPluginSlot(Flanger::kWidthSlot, width);
-        if (auto* p = compiledPlugin_->getSlotParameter(Flanger::kDivisionSlot)) {
-            const float norm = p->getCurrentValue();
+        if (auto p = compiledPlugin_->getSlotParameter(Flanger::kDivisionSlot)) {
+            const float norm = p.currentValue();
             const auto& info = compiledPlugin_->getSlotInfo(Flanger::kDivisionSlot);
             const int count = static_cast<int>(info.choices.size());
             const int idx =
@@ -243,9 +244,9 @@ void CompiledFlangerCurveView::paint(juce::Graphics& g) {
         if (compiledPlugin_ != nullptr) {
             const auto& info = compiledPlugin_->getSlotInfo(
                 magda::daw::audio::compiled::MagdaFlangerCompiledPlugin::kDivisionSlot);
-            if (auto* p = compiledPlugin_->getSlotParameter(
+            if (auto p = compiledPlugin_->getSlotParameter(
                     magda::daw::audio::compiled::MagdaFlangerCompiledPlugin::kDivisionSlot)) {
-                const float norm = p->getCurrentValue();
+                const float norm = p.currentValue();
                 const int count = static_cast<int>(info.choices.size());
                 if (count > 0) {
                     const int idx = juce::jlimit(

--- a/magda/daw/ui/components/chain/compiled/CompiledFreqShiftCurveView.cpp
+++ b/magda/daw/ui/components/chain/compiled/CompiledFreqShiftCurveView.cpp
@@ -4,6 +4,7 @@
 #include <cmath>
 
 #include "audio/plugins/compiled/MagdaFreqShiftCompiledPlugin.hpp"
+#include "audio/plugins/tracktion/TracktionMagdaDevicePlugin.hpp"
 #include "ui/themes/DarkTheme.hpp"
 
 namespace magda::daw::ui {
@@ -42,8 +43,8 @@ void CompiledFreqShiftCurveView::setCompiledPlugin(
 }
 
 void CompiledFreqShiftCurveView::bindPlugin(te::Plugin* plugin) {
-    setCompiledPlugin(
-        dynamic_cast<magda::daw::audio::compiled::MagdaFreqShiftCompiledPlugin*>(plugin));
+    setCompiledPlugin(magda::daw::audio::tracktion_adapter::deviceFromPlugin<
+                      magda::daw::audio::compiled::MagdaFreqShiftCompiledPlugin>(plugin));
 }
 
 void CompiledFreqShiftCurveView::updateFromDevice(const magda::DeviceInfo& device) {
@@ -58,8 +59,8 @@ void CompiledFreqShiftCurveView::timerCallback() {
     auto readPluginSlot = [this](int slot, float fallback) {
         if (compiledPlugin_ == nullptr)
             return fallback;
-        if (auto* p = compiledPlugin_->getSlotParameter(slot))
-            return compiledPlugin_->nativeValueToDisplayValue(slot, p->getCurrentValue());
+        if (auto p = compiledPlugin_->getSlotParameter(slot))
+            return compiledPlugin_->nativeValueToDisplayValue(slot, p.currentValue());
         return fallback;
     };
 

--- a/magda/daw/ui/components/chain/compiled/CompiledGateCurveView.cpp
+++ b/magda/daw/ui/components/chain/compiled/CompiledGateCurveView.cpp
@@ -4,6 +4,7 @@
 #include <cmath>
 
 #include "audio/plugins/compiled/MagdaGateExpanderCompiledPlugin.hpp"
+#include "audio/plugins/tracktion/TracktionMagdaDevicePlugin.hpp"
 #include "core/GestureRouter.hpp"
 #include "ui/themes/DarkTheme.hpp"
 #include "ui/themes/FontManager.hpp"
@@ -58,8 +59,8 @@ void CompiledGateCurveView::timerCallback() {
     auto read = [this](int slot, float fallback) -> float {
         if (compiledPlugin_ == nullptr)
             return fallback;
-        if (auto* p = compiledPlugin_->getSlotParameter(slot))
-            return compiledPlugin_->nativeValueToDisplayValue(slot, p->getCurrentValue());
+        if (auto p = compiledPlugin_->getSlotParameter(slot))
+            return compiledPlugin_->nativeValueToDisplayValue(slot, p.currentValue());
         return fallback;
     };
 
@@ -272,8 +273,8 @@ const CompiledPresentationSpec& getMagdaGatePresentation() {
 }
 
 void CompiledGateCurveView::bindPlugin(te::Plugin* plugin) {
-    setCompiledPlugin(
-        dynamic_cast<magda::daw::audio::compiled::MagdaGateExpanderCompiledPlugin*>(plugin));
+    setCompiledPlugin(magda::daw::audio::tracktion_adapter::deviceFromPlugin<
+                      magda::daw::audio::compiled::MagdaGateExpanderCompiledPlugin>(plugin));
 }
 
 }  // namespace magda::daw::ui

--- a/magda/daw/ui/components/chain/compiled/CompiledGrainDelayCurveView.cpp
+++ b/magda/daw/ui/components/chain/compiled/CompiledGrainDelayCurveView.cpp
@@ -4,6 +4,7 @@
 #include <cmath>
 
 #include "audio/plugins/compiled/MagdaGrainDelayCompiledPlugin.hpp"
+#include "audio/plugins/tracktion/TracktionMagdaDevicePlugin.hpp"
 #include "ui/themes/DarkTheme.hpp"
 
 namespace magda::daw::ui {
@@ -59,29 +60,29 @@ void CompiledGrainDelayCurveView::timerCallback() {
     float bpm = bpm_;
 
     if (compiledPlugin_ != nullptr) {
-        if (auto* p = compiledPlugin_->getSlotParameter(GrainDelay::kTimeSlot))
-            time = compiledPlugin_->nativeValueToDisplayValue(GrainDelay::kTimeSlot,
-                                                              p->getCurrentValue());
-        if (auto* p = compiledPlugin_->getSlotParameter(GrainDelay::kSizeSlot))
-            size = compiledPlugin_->nativeValueToDisplayValue(GrainDelay::kSizeSlot,
-                                                              p->getCurrentValue());
-        if (auto* p = compiledPlugin_->getSlotParameter(GrainDelay::kPitchSlot))
+        if (auto p = compiledPlugin_->getSlotParameter(GrainDelay::kTimeSlot))
+            time =
+                compiledPlugin_->nativeValueToDisplayValue(GrainDelay::kTimeSlot, p.currentValue());
+        if (auto p = compiledPlugin_->getSlotParameter(GrainDelay::kSizeSlot))
+            size =
+                compiledPlugin_->nativeValueToDisplayValue(GrainDelay::kSizeSlot, p.currentValue());
+        if (auto p = compiledPlugin_->getSlotParameter(GrainDelay::kPitchSlot))
             pitch = compiledPlugin_->nativeValueToDisplayValue(GrainDelay::kPitchSlot,
-                                                               p->getCurrentValue());
-        if (auto* p = compiledPlugin_->getSlotParameter(GrainDelay::kSpraySlot))
+                                                               p.currentValue());
+        if (auto p = compiledPlugin_->getSlotParameter(GrainDelay::kSpraySlot))
             spray = compiledPlugin_->nativeValueToDisplayValue(GrainDelay::kSpraySlot,
-                                                               p->getCurrentValue());
-        if (auto* p = compiledPlugin_->getSlotParameter(GrainDelay::kFeedbackSlot))
+                                                               p.currentValue());
+        if (auto p = compiledPlugin_->getSlotParameter(GrainDelay::kFeedbackSlot))
             fb = compiledPlugin_->nativeValueToDisplayValue(GrainDelay::kFeedbackSlot,
-                                                            p->getCurrentValue());
-        if (auto* p = compiledPlugin_->getSlotParameter(GrainDelay::kMixSlot))
-            mix = compiledPlugin_->nativeValueToDisplayValue(GrainDelay::kMixSlot,
-                                                             p->getCurrentValue());
-        if (auto* p = compiledPlugin_->getSlotParameter(GrainDelay::kSyncSlot))
-            sync = p->getCurrentValue() >= 0.5f;
-        if (auto* p = compiledPlugin_->getSlotParameter(GrainDelay::kDivisionSlot)) {
+                                                            p.currentValue());
+        if (auto p = compiledPlugin_->getSlotParameter(GrainDelay::kMixSlot))
+            mix =
+                compiledPlugin_->nativeValueToDisplayValue(GrainDelay::kMixSlot, p.currentValue());
+        if (auto p = compiledPlugin_->getSlotParameter(GrainDelay::kSyncSlot))
+            sync = p.currentValue() >= 0.5f;
+        if (auto p = compiledPlugin_->getSlotParameter(GrainDelay::kDivisionSlot)) {
             divIdx = static_cast<int>(std::round(compiledPlugin_->nativeValueToDisplayValue(
-                GrainDelay::kDivisionSlot, p->getCurrentValue())));
+                GrainDelay::kDivisionSlot, p.currentValue())));
         }
         bpm = compiledPlugin_->currentBpm();
     } else {
@@ -284,8 +285,8 @@ const CompiledPresentationSpec& getMagdaGrainDelayPresentation() {
 }
 
 void CompiledGrainDelayCurveView::bindPlugin(te::Plugin* plugin) {
-    setCompiledPlugin(
-        dynamic_cast<magda::daw::audio::compiled::MagdaGrainDelayCompiledPlugin*>(plugin));
+    setCompiledPlugin(magda::daw::audio::tracktion_adapter::deviceFromPlugin<
+                      magda::daw::audio::compiled::MagdaGrainDelayCompiledPlugin>(plugin));
 }
 
 }  // namespace magda::daw::ui

--- a/magda/daw/ui/components/chain/compiled/CompiledGritCurveView.cpp
+++ b/magda/daw/ui/components/chain/compiled/CompiledGritCurveView.cpp
@@ -4,6 +4,7 @@
 #include <cmath>
 
 #include "audio/plugins/compiled/MagdaGritCompiledPlugin.hpp"
+#include "audio/plugins/tracktion/TracktionMagdaDevicePlugin.hpp"
 #include "ui/themes/DarkTheme.hpp"
 
 namespace magda::daw::ui {
@@ -72,18 +73,17 @@ void CompiledGritCurveView::timerCallback() {
     int mode = modeIndex_;
 
     if (compiledPlugin_ != nullptr) {
-        if (auto* p = compiledPlugin_->getSlotParameter(Grit::kFrequencySlot))
-            freq = compiledPlugin_->nativeValueToDisplayValue(Grit::kFrequencySlot,
-                                                              p->getCurrentValue());
-        if (auto* p = compiledPlugin_->getSlotParameter(Grit::kWidthSlot))
-            width =
-                compiledPlugin_->nativeValueToDisplayValue(Grit::kWidthSlot, p->getCurrentValue());
-        if (auto* p = compiledPlugin_->getSlotParameter(Grit::kAmountSlot))
+        if (auto p = compiledPlugin_->getSlotParameter(Grit::kFrequencySlot))
+            freq =
+                compiledPlugin_->nativeValueToDisplayValue(Grit::kFrequencySlot, p.currentValue());
+        if (auto p = compiledPlugin_->getSlotParameter(Grit::kWidthSlot))
+            width = compiledPlugin_->nativeValueToDisplayValue(Grit::kWidthSlot, p.currentValue());
+        if (auto p = compiledPlugin_->getSlotParameter(Grit::kAmountSlot))
             amount =
-                compiledPlugin_->nativeValueToDisplayValue(Grit::kAmountSlot, p->getCurrentValue());
-        if (auto* p = compiledPlugin_->getSlotParameter(Grit::kModeSlot)) {
+                compiledPlugin_->nativeValueToDisplayValue(Grit::kAmountSlot, p.currentValue());
+        if (auto p = compiledPlugin_->getSlotParameter(Grit::kModeSlot)) {
             mode = static_cast<int>(std::round(
-                compiledPlugin_->nativeValueToDisplayValue(Grit::kModeSlot, p->getCurrentValue())));
+                compiledPlugin_->nativeValueToDisplayValue(Grit::kModeSlot, p.currentValue())));
         }
     } else {
         freq = valueForSlot(deviceSnapshot_, Grit::kFrequencySlot, freq);
@@ -204,7 +204,8 @@ const CompiledPresentationSpec& getMagdaGritPresentation() {
 }
 
 void CompiledGritCurveView::bindPlugin(te::Plugin* plugin) {
-    setCompiledPlugin(dynamic_cast<magda::daw::audio::compiled::MagdaGritCompiledPlugin*>(plugin));
+    setCompiledPlugin(magda::daw::audio::tracktion_adapter::deviceFromPlugin<
+                      magda::daw::audio::compiled::MagdaGritCompiledPlugin>(plugin));
 }
 
 }  // namespace magda::daw::ui

--- a/magda/daw/ui/components/chain/compiled/CompiledLimiterCurveView.cpp
+++ b/magda/daw/ui/components/chain/compiled/CompiledLimiterCurveView.cpp
@@ -4,6 +4,7 @@
 #include <cmath>
 
 #include "audio/plugins/compiled/MagdaLimiterCompiledPlugin.hpp"
+#include "audio/plugins/tracktion/TracktionMagdaDevicePlugin.hpp"
 #include "ui/themes/DarkTheme.hpp"
 #include "ui/themes/FontManager.hpp"
 
@@ -47,8 +48,8 @@ void CompiledLimiterCurveView::setCompiledPlugin(
 }
 
 void CompiledLimiterCurveView::bindPlugin(te::Plugin* plugin) {
-    setCompiledPlugin(
-        dynamic_cast<magda::daw::audio::compiled::MagdaLimiterCompiledPlugin*>(plugin));
+    setCompiledPlugin(magda::daw::audio::tracktion_adapter::deviceFromPlugin<
+                      magda::daw::audio::compiled::MagdaLimiterCompiledPlugin>(plugin));
 }
 
 void CompiledLimiterCurveView::updateFromDevice(const magda::DeviceInfo& device) {
@@ -63,8 +64,8 @@ void CompiledLimiterCurveView::timerCallback() {
     auto readPluginSlot = [this](int slot, float fallback) {
         if (compiledPlugin_ == nullptr)
             return fallback;
-        if (auto* p = compiledPlugin_->getSlotParameter(slot))
-            return compiledPlugin_->nativeValueToDisplayValue(slot, p->getCurrentValue());
+        if (auto p = compiledPlugin_->getSlotParameter(slot))
+            return compiledPlugin_->nativeValueToDisplayValue(slot, p.currentValue());
         return fallback;
     };
 

--- a/magda/daw/ui/components/chain/compiled/CompiledModCurveView.cpp
+++ b/magda/daw/ui/components/chain/compiled/CompiledModCurveView.cpp
@@ -4,6 +4,7 @@
 #include <cmath>
 
 #include "audio/plugins/compiled/MagdaModCompiledPlugin.hpp"
+#include "audio/plugins/tracktion/TracktionMagdaDevicePlugin.hpp"
 #include "ui/themes/DarkTheme.hpp"
 
 namespace magda::daw::ui {
@@ -47,7 +48,8 @@ void CompiledModCurveView::setCompiledPlugin(
 }
 
 void CompiledModCurveView::bindPlugin(te::Plugin* plugin) {
-    setCompiledPlugin(dynamic_cast<magda::daw::audio::compiled::MagdaModCompiledPlugin*>(plugin));
+    setCompiledPlugin(magda::daw::audio::tracktion_adapter::deviceFromPlugin<
+                      magda::daw::audio::compiled::MagdaModCompiledPlugin>(plugin));
 }
 
 void CompiledModCurveView::updateFromDevice(const magda::DeviceInfo& device) {
@@ -92,8 +94,8 @@ void CompiledModCurveView::timerCallback() {
     auto readPluginSlot = [this](int slot, float fallback) {
         if (compiledPlugin_ == nullptr)
             return fallback;
-        if (auto* p = compiledPlugin_->getSlotParameter(slot))
-            return compiledPlugin_->nativeValueToDisplayValue(slot, p->getCurrentValue());
+        if (auto p = compiledPlugin_->getSlotParameter(slot))
+            return compiledPlugin_->nativeValueToDisplayValue(slot, p.currentValue());
         return fallback;
     };
 
@@ -113,8 +115,8 @@ void CompiledModCurveView::timerCallback() {
         depth = readPluginSlot(Mod::kDepthSlot, depth);
         // Division — the host slot stores an index into divisionChoiceValues_;
         // ask the plugin for the underlying Faust value.
-        if (auto* p = compiledPlugin_->getSlotParameter(Mod::kDivisionSlot)) {
-            const float norm = p->getCurrentValue();
+        if (auto p = compiledPlugin_->getSlotParameter(Mod::kDivisionSlot)) {
+            const float norm = p.currentValue();
             const auto& info = compiledPlugin_->getSlotInfo(Mod::kDivisionSlot);
             const int count = static_cast<int>(info.choices.size());
             const int idx =
@@ -238,9 +240,9 @@ void CompiledModCurveView::paint(juce::Graphics& g) {
         if (compiledPlugin_ != nullptr) {
             const auto& info = compiledPlugin_->getSlotInfo(
                 magda::daw::audio::compiled::MagdaModCompiledPlugin::kDivisionSlot);
-            if (auto* p = compiledPlugin_->getSlotParameter(
+            if (auto p = compiledPlugin_->getSlotParameter(
                     magda::daw::audio::compiled::MagdaModCompiledPlugin::kDivisionSlot)) {
-                const float norm = p->getCurrentValue();
+                const float norm = p.currentValue();
                 const int count = static_cast<int>(info.choices.size());
                 if (count > 0) {
                     const int idx = juce::jlimit(

--- a/magda/daw/ui/components/chain/compiled/CompiledMultibandCurveView.cpp
+++ b/magda/daw/ui/components/chain/compiled/CompiledMultibandCurveView.cpp
@@ -5,6 +5,7 @@
 
 #include "../../../utils/CurveLabelLayout.hpp"
 #include "audio/plugins/compiled/MagdaMultibandCompiledPlugin.hpp"
+#include "audio/plugins/tracktion/TracktionMagdaDevicePlugin.hpp"
 #include "core/GestureRouter.hpp"
 #include "ui/themes/DarkTheme.hpp"
 
@@ -103,8 +104,8 @@ void CompiledMultibandCurveView::timerCallback() {
     auto readSlot = [this](int slot, float fallback) {
         if (compiledPlugin_ == nullptr)
             return valueForSlot(deviceSnapshot_, slot, fallback);
-        if (auto* p = compiledPlugin_->getSlotParameter(slot))
-            return compiledPlugin_->nativeValueToDisplayValue(slot, p->getCurrentValue());
+        if (auto p = compiledPlugin_->getSlotParameter(slot))
+            return compiledPlugin_->nativeValueToDisplayValue(slot, p.currentValue());
         return fallback;
     };
 
@@ -935,8 +936,8 @@ const CompiledPresentationSpec& getMagdaMultibandPresentation() {
 }
 
 void CompiledMultibandCurveView::bindPlugin(te::Plugin* plugin) {
-    setCompiledPlugin(
-        dynamic_cast<magda::daw::audio::compiled::MagdaMultibandCompiledPlugin*>(plugin));
+    setCompiledPlugin(magda::daw::audio::tracktion_adapter::deviceFromPlugin<
+                      magda::daw::audio::compiled::MagdaMultibandCompiledPlugin>(plugin));
 }
 
 }  // namespace magda::daw::ui

--- a/magda/daw/ui/components/chain/compiled/CompiledPhaserCurveView.cpp
+++ b/magda/daw/ui/components/chain/compiled/CompiledPhaserCurveView.cpp
@@ -4,6 +4,7 @@
 #include <cmath>
 
 #include "audio/plugins/compiled/MagdaPhaserCompiledPlugin.hpp"
+#include "audio/plugins/tracktion/TracktionMagdaDevicePlugin.hpp"
 #include "ui/themes/DarkTheme.hpp"
 
 namespace magda::daw::ui {
@@ -57,8 +58,8 @@ void CompiledPhaserCurveView::setCompiledPlugin(
 }
 
 void CompiledPhaserCurveView::bindPlugin(te::Plugin* plugin) {
-    setCompiledPlugin(
-        dynamic_cast<magda::daw::audio::compiled::MagdaPhaserCompiledPlugin*>(plugin));
+    setCompiledPlugin(magda::daw::audio::tracktion_adapter::deviceFromPlugin<
+                      magda::daw::audio::compiled::MagdaPhaserCompiledPlugin>(plugin));
 }
 
 void CompiledPhaserCurveView::updateFromDevice(const magda::DeviceInfo& device) {
@@ -88,8 +89,8 @@ void CompiledPhaserCurveView::timerCallback() {
     auto readPluginSlot = [this](int slot, float fallback) {
         if (compiledPlugin_ == nullptr)
             return fallback;
-        if (auto* p = compiledPlugin_->getSlotParameter(slot))
-            return compiledPlugin_->nativeValueToDisplayValue(slot, p->getCurrentValue());
+        if (auto p = compiledPlugin_->getSlotParameter(slot))
+            return compiledPlugin_->nativeValueToDisplayValue(slot, p.currentValue());
         return fallback;
     };
 

--- a/magda/daw/ui/components/chain/compiled/CompiledPitchEditorView.cpp
+++ b/magda/daw/ui/components/chain/compiled/CompiledPitchEditorView.cpp
@@ -3,6 +3,7 @@
 #include <cmath>
 
 #include "audio/plugins/compiled/MagdaPitchCompiledPlugin.hpp"
+#include "audio/plugins/tracktion/TracktionMagdaDevicePlugin.hpp"
 #include "ui/themes/DarkTheme.hpp"
 
 namespace magda::daw::ui {
@@ -53,7 +54,8 @@ void CompiledPitchEditorView::setCompiledPlugin(
 }
 
 void CompiledPitchEditorView::bindPlugin(te::Plugin* plugin) {
-    setCompiledPlugin(dynamic_cast<magda::daw::audio::compiled::MagdaPitchCompiledPlugin*>(plugin));
+    setCompiledPlugin(magda::daw::audio::tracktion_adapter::deviceFromPlugin<
+                      magda::daw::audio::compiled::MagdaPitchCompiledPlugin>(plugin));
 }
 
 void CompiledPitchEditorView::updateFromDevice(const magda::DeviceInfo& device) {
@@ -73,8 +75,8 @@ void CompiledPitchEditorView::resampleFromDevice() {
 void CompiledPitchEditorView::timerCallback() {
     if (compiledPlugin_ != nullptr) {
         auto read = [this](int slot, float fallback) {
-            if (auto* p = compiledPlugin_->getSlotParameter(slot))
-                return compiledPlugin_->nativeValueToDisplayValue(slot, p->getCurrentValue());
+            if (auto p = compiledPlugin_->getSlotParameter(slot))
+                return compiledPlugin_->nativeValueToDisplayValue(slot, p.currentValue());
             return fallback;
         };
         engine_ = juce::jlimit(0, Plugin::kEngineCount - 1,

--- a/magda/daw/ui/components/chain/compiled/CompiledReverbCurveView.cpp
+++ b/magda/daw/ui/components/chain/compiled/CompiledReverbCurveView.cpp
@@ -4,6 +4,7 @@
 #include <cmath>
 
 #include "audio/plugins/compiled/MagdaReverbCompiledPlugin.hpp"
+#include "audio/plugins/tracktion/TracktionMagdaDevicePlugin.hpp"
 #include "ui/themes/DarkTheme.hpp"
 
 namespace magda::daw::ui {
@@ -50,8 +51,8 @@ void CompiledReverbCurveView::setCompiledPlugin(
 }
 
 void CompiledReverbCurveView::bindPlugin(te::Plugin* plugin) {
-    setCompiledPlugin(
-        dynamic_cast<magda::daw::audio::compiled::MagdaReverbCompiledPlugin*>(plugin));
+    setCompiledPlugin(magda::daw::audio::tracktion_adapter::deviceFromPlugin<
+                      magda::daw::audio::compiled::MagdaReverbCompiledPlugin>(plugin));
 }
 
 void CompiledReverbCurveView::updateFromDevice(const magda::DeviceInfo& device) {
@@ -85,8 +86,8 @@ void CompiledReverbCurveView::timerCallback() {
     }
 
     auto read = [this](int slot, float fallback) {
-        if (auto* p = compiledPlugin_->getSlotParameter(slot))
-            return compiledPlugin_->nativeValueToDisplayValue(slot, p->getCurrentValue());
+        if (auto p = compiledPlugin_->getSlotParameter(slot))
+            return compiledPlugin_->nativeValueToDisplayValue(slot, p.currentValue());
         return fallback;
     };
 

--- a/magda/daw/ui/components/chain/compiled/CompiledRingModCurveView.cpp
+++ b/magda/daw/ui/components/chain/compiled/CompiledRingModCurveView.cpp
@@ -4,6 +4,7 @@
 #include <cmath>
 
 #include "audio/plugins/compiled/MagdaRingModCompiledPlugin.hpp"
+#include "audio/plugins/tracktion/TracktionMagdaDevicePlugin.hpp"
 #include "ui/themes/DarkTheme.hpp"
 
 namespace magda::daw::ui {
@@ -57,8 +58,8 @@ void CompiledRingModCurveView::setCompiledPlugin(
 }
 
 void CompiledRingModCurveView::bindPlugin(te::Plugin* plugin) {
-    setCompiledPlugin(
-        dynamic_cast<magda::daw::audio::compiled::MagdaRingModCompiledPlugin*>(plugin));
+    setCompiledPlugin(magda::daw::audio::tracktion_adapter::deviceFromPlugin<
+                      magda::daw::audio::compiled::MagdaRingModCompiledPlugin>(plugin));
 }
 
 void CompiledRingModCurveView::updateFromDevice(const magda::DeviceInfo& device) {
@@ -85,8 +86,8 @@ void CompiledRingModCurveView::timerCallback() {
     auto readPluginSlot = [this](int slot, float fallback) {
         if (compiledPlugin_ == nullptr)
             return fallback;
-        if (auto* p = compiledPlugin_->getSlotParameter(slot))
-            return compiledPlugin_->nativeValueToDisplayValue(slot, p->getCurrentValue());
+        if (auto p = compiledPlugin_->getSlotParameter(slot))
+            return compiledPlugin_->nativeValueToDisplayValue(slot, p.currentValue());
         return fallback;
     };
 
@@ -106,8 +107,8 @@ void CompiledRingModCurveView::timerCallback() {
         mix = readPluginSlot(RM::kMixSlot, mix);
         width = readPluginSlot(RM::kWidthSlot, width);
         source = static_cast<int>(std::round(readPluginSlot(RM::kSourceSlot, source)));
-        if (auto* p = compiledPlugin_->getSlotParameter(RM::kDivisionSlot)) {
-            const float norm = p->getCurrentValue();
+        if (auto p = compiledPlugin_->getSlotParameter(RM::kDivisionSlot)) {
+            const float norm = p.currentValue();
             const auto& info = compiledPlugin_->getSlotInfo(RM::kDivisionSlot);
             const int count = static_cast<int>(info.choices.size());
             const int idx =

--- a/magda/daw/ui/components/chain/compiled/CompiledSaturatorCurveView.cpp
+++ b/magda/daw/ui/components/chain/compiled/CompiledSaturatorCurveView.cpp
@@ -4,6 +4,7 @@
 #include <cmath>
 
 #include "audio/plugins/compiled/MagdaSaturatorCompiledPlugin.hpp"
+#include "audio/plugins/tracktion/TracktionMagdaDevicePlugin.hpp"
 #include "ui/themes/DarkTheme.hpp"
 #include "ui/themes/FontManager.hpp"
 
@@ -66,19 +67,17 @@ void CompiledSaturatorCurveView::timerCallback() {
     int mode = modeIndex_;
 
     if (compiledPlugin_ != nullptr) {
-        if (auto* p = compiledPlugin_->getSlotParameter(Sat::kDriveSlot))
-            drive =
-                compiledPlugin_->nativeValueToDisplayValue(Sat::kDriveSlot, p->getCurrentValue());
-        if (auto* p = compiledPlugin_->getSlotParameter(Sat::kBiasSlot))
-            bias = compiledPlugin_->nativeValueToDisplayValue(Sat::kBiasSlot, p->getCurrentValue());
-        if (auto* p = compiledPlugin_->getSlotParameter(Sat::kOutputSlot))
-            output =
-                compiledPlugin_->nativeValueToDisplayValue(Sat::kOutputSlot, p->getCurrentValue());
-        if (auto* p = compiledPlugin_->getSlotParameter(Sat::kMixSlot))
-            mix = compiledPlugin_->nativeValueToDisplayValue(Sat::kMixSlot, p->getCurrentValue());
-        if (auto* p = compiledPlugin_->getSlotParameter(Sat::kModeSlot))
+        if (auto p = compiledPlugin_->getSlotParameter(Sat::kDriveSlot))
+            drive = compiledPlugin_->nativeValueToDisplayValue(Sat::kDriveSlot, p.currentValue());
+        if (auto p = compiledPlugin_->getSlotParameter(Sat::kBiasSlot))
+            bias = compiledPlugin_->nativeValueToDisplayValue(Sat::kBiasSlot, p.currentValue());
+        if (auto p = compiledPlugin_->getSlotParameter(Sat::kOutputSlot))
+            output = compiledPlugin_->nativeValueToDisplayValue(Sat::kOutputSlot, p.currentValue());
+        if (auto p = compiledPlugin_->getSlotParameter(Sat::kMixSlot))
+            mix = compiledPlugin_->nativeValueToDisplayValue(Sat::kMixSlot, p.currentValue());
+        if (auto p = compiledPlugin_->getSlotParameter(Sat::kModeSlot))
             mode = static_cast<int>(std::round(
-                compiledPlugin_->nativeValueToDisplayValue(Sat::kModeSlot, p->getCurrentValue())));
+                compiledPlugin_->nativeValueToDisplayValue(Sat::kModeSlot, p.currentValue())));
     } else {
         drive = valueForSlot(deviceSnapshot_, Sat::kDriveSlot, drive);
         bias = valueForSlot(deviceSnapshot_, Sat::kBiasSlot, bias);
@@ -230,8 +229,8 @@ const CompiledPresentationSpec& getMagdaSaturatorPresentation() {
 }
 
 void CompiledSaturatorCurveView::bindPlugin(te::Plugin* plugin) {
-    setCompiledPlugin(
-        dynamic_cast<magda::daw::audio::compiled::MagdaSaturatorCompiledPlugin*>(plugin));
+    setCompiledPlugin(magda::daw::audio::tracktion_adapter::deviceFromPlugin<
+                      magda::daw::audio::compiled::MagdaSaturatorCompiledPlugin>(plugin));
 }
 
 }  // namespace magda::daw::ui

--- a/magda/daw/ui/components/chain/compiled/CompiledUtilityView.cpp
+++ b/magda/daw/ui/components/chain/compiled/CompiledUtilityView.cpp
@@ -3,6 +3,7 @@
 #include <cmath>
 
 #include "audio/plugins/compiled/MagdaUtilityCompiledPlugin.hpp"
+#include "audio/plugins/tracktion/TracktionMagdaDevicePlugin.hpp"
 #include "ui/components/mixer/LevelMeterScale.hpp"
 #include "ui/themes/DarkTheme.hpp"
 #include "ui/themes/SmallButtonLookAndFeel.hpp"
@@ -166,14 +167,10 @@ void CompiledUtilityView::updateFromDevice(const magda::DeviceInfo& device,
 }
 
 void CompiledUtilityView::writeParameter(int slotIndex, float displayValue) {
-    if (compiledPlugin_ != nullptr) {
-        if (auto* param = compiledPlugin_->getSlotParameter(slotIndex)) {
-            const float normalized =
-                compiledPlugin_->displayValueToNativeValue(slotIndex, displayValue);
-            param->setParameterFromHost(normalized, juce::sendNotificationSync);
-        }
-    }
-
+    // Through the model, like every other parameter edit in the chain. The
+    // device's own value is a mirror the host pushes into before each block, so
+    // writing it here would be overwritten by the next one and would skip
+    // automation, undo and the macro links on the way (#2192).
     if (onParameterChanged)
         onParameterChanged(slotIndex, displayValue);
 }
@@ -387,8 +384,8 @@ void CompiledUtilityView::resized() {
 }
 
 void CompiledUtilityView::bindPlugin(te::Plugin* plugin) {
-    compiledPlugin_ =
-        dynamic_cast<magda::daw::audio::compiled::MagdaUtilityCompiledPlugin*>(plugin);
+    compiledPlugin_ = magda::daw::audio::tracktion_adapter::deviceFromPlugin<
+        magda::daw::audio::compiled::MagdaUtilityCompiledPlugin>(plugin);
 }
 
 const CompiledPresentationSpec& getMagdaUtilityPresentation() {

--- a/magda/daw/ui/components/chain/custom_ui/PolySynthUI.cpp
+++ b/magda/daw/ui/components/chain/custom_ui/PolySynthUI.cpp
@@ -430,8 +430,8 @@ void PolySynthUI::timerCallback() {
         return;
 
     const auto readDisplayValue = [this](int slot, float fallback) {
-        if (auto* parameter = livePlugin_->getSlotParameter(slot)) {
-            return livePlugin_->nativeValueToDisplayValue(slot, parameter->getCurrentValue());
+        if (auto parameter = livePlugin_->getSlotParameter(slot)) {
+            return livePlugin_->nativeValueToDisplayValue(slot, parameter.currentValue());
         }
         return fallback;
     };

--- a/magda/daw/ui/components/chain/slot/DeviceCustomUIManager.cpp
+++ b/magda/daw/ui/components/chain/slot/DeviceCustomUIManager.cpp
@@ -1880,7 +1880,8 @@ void DeviceCustomUIManager::refreshLivePluginBindings() {
     if (polySynthUI_ != nullptr) {
         daw::audio::compiled::MagdaPolySynthCompiledPlugin* synth = nullptr;
         if (auto plugin = getLivePlugin())
-            synth = dynamic_cast<daw::audio::compiled::MagdaPolySynthCompiledPlugin*>(plugin.get());
+            synth = daw::audio::tracktion_adapter::deviceFromPlugin<
+                daw::audio::compiled::MagdaPolySynthCompiledPlugin>(plugin.get());
         polySynthUI_->setLivePlugin(synth);
     }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -374,6 +374,11 @@ if(MAGDA_BUILD_NATIVE_ENGINE)
     list(APPEND TEST_SOURCES MgdFixtures.cpp)
     list(APPEND TEST_SOURCES test_mgd_fixture_rig.cpp)
 
+    # What the legacy projects would cost as render cases (#2081). A survey
+    # rather than a corpus: it declares no tier and asserts no residual, and
+    # reports what stands between each project and being a case.
+    list(APPEND TEST_SOURCES test_real_project_survey.cpp)
+
     # The device layer under the engine (#2174): the app's own catalogs asked
     # for a Device op's device, and a shipped device rendered through the
     # adapter. The engine's half alone -- what the two hosts do with one device

--- a/tests/MgdFixture.cpp
+++ b/tests/MgdFixture.cpp
@@ -328,6 +328,15 @@ std::string refuseIndistinguishableSources(const std::vector<juce::String>& path
     return {};
 }
 
+PooledSourcesUnwind::PooledSourcesUnwind() : held_(SourcePool::getInstance().snapshot()) {}
+
+PooledSourcesUnwind::~PooledSourcesUnwind() {
+    auto& pool = SourcePool::getInstance();
+    pool.clear();
+    for (const auto& source : held_)
+        pool.insert(source);
+}
+
 juce::File fixtureCorpusDir() {
     return juce::File(MAGDA_TEST_CORPUS_DIR);
 }

--- a/tests/MgdFixture.hpp
+++ b/tests/MgdFixture.hpp
@@ -8,6 +8,7 @@
 
 #include "NullDiffCase.hpp"
 #include "NullDiffMaterial.hpp"
+#include "core/Source.hpp"
 
 /**
  * @file MgdFixture.hpp
@@ -160,6 +161,39 @@ struct FixtureLoad {
     /// name one file twice -- a v2 table entry beside a v1 clip that migrated
     /// to the same path -- and those are one sound sharing one stand-in.
     std::map<juce::String, juce::File> written;
+};
+
+/**
+ * @brief Put the pool back the way it was found.
+ *
+ * The rig drives the app's own source install, and that install clears the pool
+ * before repopulating it: correctly, because loading a project is exactly when
+ * the previous project's sources stop being pooled. In a test binary the pool is
+ * shared with everything else in the run, so a fixture loaded there would
+ * otherwise pull the code-built corpus's sources out from under it and leave
+ * every SourceFact in it pointing at an id nobody holds.
+ *
+ * Snapshot and restore rather than clear, because clearing is what causes the
+ * problem rather than what fixes it, and `insert` preserves ids so what goes
+ * back is what was there. Ordering is not a defence: the corpus builds itself
+ * lazily and once.
+ *
+ * Here rather than in one test file because every caller of loadFixture needs
+ * it, and a correctness guard nobody can see from the function it guards is one
+ * that gets copied slightly wrong.
+ */
+class PooledSourcesUnwind {
+  public:
+    PooledSourcesUnwind();
+    ~PooledSourcesUnwind();
+
+    PooledSourcesUnwind(const PooledSourcesUnwind&) = delete;
+    PooledSourcesUnwind& operator=(const PooledSourcesUnwind&) = delete;
+    PooledSourcesUnwind(PooledSourcesUnwind&&) = delete;
+    PooledSourcesUnwind& operator=(PooledSourcesUnwind&&) = delete;
+
+  private:
+    std::vector<magda::Source> held_;
 };
 
 /**

--- a/tests/test_engine_device_layer.cpp
+++ b/tests/test_engine_device_layer.cpp
@@ -184,6 +184,21 @@ int budgetCostOf(const juce::MidiBuffer& buffer) {
     return bytes;
 }
 
+/// The slot @p device calls @p name, or -1.
+int slotNamed(const magda::daw::audio::MagdaDevice& device, const juce::String& name) {
+    for (int slot = 0; slot < device.parameterCount(); ++slot)
+        if (device.parameterInfo(slot).name == name)
+            return slot;
+    return -1;
+}
+
+/// Set a slot from its display value rather than its normalised position, so a
+/// test reads in the units the device documents.
+void setDisplayValue(magda::daw::audio::MagdaDevice& device, int slot, float displayValue) {
+    const auto info = device.parameterInfo(slot);
+    device.setParameterValue(slot, magda::ParameterUtils::realToNormalized(displayValue, info));
+}
+
 }  // namespace
 
 TEST_CASE("the engine can run every device that has moved to the SDK", "[engine][devices][2174]") {
@@ -503,4 +518,84 @@ TEST_CASE("a device may rewrite, reorder and drop long messages", "[engine][devi
     }
 
     CHECK(marks == std::vector<std::uint8_t>{0x33, 0x11});
+}
+
+TEST_CASE("one note-off releases a pitch that was pressed many times", "[engine][devices][2192]") {
+    // The mono and legato voice keeps a stack of what is held, and a note-on
+    // for a pitch already on it moves that pitch to the top rather than adding
+    // a second copy. Two things rest on that.
+    //
+    // The audible one is here: a pitch held twice would need two note-offs to
+    // be let go, and an unbalanced stream sends one. Those streams are ordinary
+    // -- a recorded clip playing back merged with the live input that fed it
+    // sends every note twice -- and the poly path has releasePolyVoicesForPitch()
+    // for exactly this. The mono path had nothing, so the note hung.
+    //
+    // The other is that the stack is then bounded by the MIDI range and can be
+    // sized once, off the audio thread, instead of growing under process().
+    // That is what the repeat count below is for: it is past any bound the
+    // stack could be given, so a stack that appended would have grown.
+    magda::DeviceInfo model;
+    model.pluginId = "magda_fm";
+
+    auto device = adapter::createEngineDevice(model);
+    REQUIRE(device != nullptr);
+
+    auto* hosted = dynamic_cast<adapter::EngineMagdaDevice*>(device.get());
+    REQUIRE(hosted != nullptr);
+    auto& sdk = hosted->device();
+
+    const int voiceModeSlot = slotNamed(sdk, "Voice Mode");
+    const int sustainSlot = slotNamed(sdk, "Amp Sustain");
+    const int releaseSlot = slotNamed(sdk, "Amp Release");
+    const int attackSlot = slotNamed(sdk, "Amp Attack");
+    REQUIRE(voiceModeSlot >= 0);
+    REQUIRE(sustainSlot >= 0);
+    REQUIRE(releaseSlot >= 0);
+    REQUIRE(attackSlot >= 0);
+
+    const auto context = contextFor();
+    device->prepare(context);
+
+    // Mono, held at full sustain so a note that never releases stays audible,
+    // with the envelope's ends short enough to settle inside a few blocks.
+    setDisplayValue(sdk, voiceModeSlot, 1.0f);  // Poly / Mono / Legato
+    setDisplayValue(sdk, sustainSlot, 1.0f);
+    setDisplayValue(sdk, attackSlot, 1.0f);
+    setDisplayValue(sdk, releaseSlot, 1.0f);
+
+    constexpr int kNote = 60;
+    constexpr int kRepeats = 400;
+
+    Block pressed(context);
+    for (int repeat = 0; repeat < kRepeats; ++repeat)
+        pressed.midi.addEvent(juce::MidiMessage::noteOn(1, kNote, 1.0f), 0);
+    auto pressedBlock = pressed.deviceBlock();
+    device->process(pressedBlock);
+
+    Block held(context);
+    auto heldBlock = held.deviceBlock();
+    device->process(heldBlock);
+    const float heldPeak = peakOf(held.buffer);
+
+    // The note has to be sounding, or the release below proves nothing.
+    REQUIRE(heldPeak > 0.0f);
+
+    Block lifted(context);
+    lifted.midi.addEvent(juce::MidiMessage::noteOff(1, kNote), 0);
+    auto liftedBlock = lifted.deviceBlock();
+    device->process(liftedBlock);
+
+    float releasedPeak = 0.0f;
+    for (int block = 0; block < 8; ++block) {
+        Block quiet(context);
+        auto quietBlock = quiet.deviceBlock();
+        device->process(quietBlock);
+        releasedPeak = peakOf(quiet.buffer);
+    }
+
+    // One note-off, four hundred note-ons: the voice is released. A stack that
+    // appended would still be holding three hundred and ninety-nine of them and
+    // sitting at full sustain here.
+    CHECK(releasedPeak < heldPeak * 0.05f);
 }

--- a/tests/test_mgd_fixture_rig.cpp
+++ b/tests/test_mgd_fixture_rig.cpp
@@ -51,22 +51,6 @@ juce::File scratch() {
 /// back is what was there. Ordering is not a defence: the corpus builds itself
 /// lazily and once, so whether it survives would depend on which test ran
 /// first.
-struct PoolUnwind {
-    PoolUnwind() : held_(SourcePool::getInstance().snapshot()) {}
-
-    ~PoolUnwind() {
-        auto& pool = SourcePool::getInstance();
-        pool.clear();
-        for (const auto& source : held_)
-            pool.insert(source);
-    }
-
-    PoolUnwind(const PoolUnwind&) = delete;
-    PoolUnwind& operator=(const PoolUnwind&) = delete;
-
-  private:
-    std::vector<Source> held_;
-};
 
 }  // namespace
 
@@ -87,7 +71,7 @@ TEST_CASE("Every fixture names a file that is there", "[nulldiff][fixture]") {
 }
 
 TEST_CASE("A fixture loads into a case", "[nulldiff][fixture]") {
-    const PoolUnwind unwind;
+    const PooledSourcesUnwind unwind;
 
     for (const auto& fixture : mgdFixtures()) {
         INFO(fixture.declaration.name);
@@ -119,7 +103,7 @@ TEST_CASE("A fixture loads into a case", "[nulldiff][fixture]") {
 }
 
 TEST_CASE("Every source reads back as what the manifest asked for", "[nulldiff][fixture]") {
-    const PoolUnwind unwind;
+    const PooledSourcesUnwind unwind;
 
     juce::AudioFormatManager formats;
     formats.registerBasicFormats();
@@ -172,7 +156,7 @@ TEST_CASE("Every source reads back as what the manifest asked for", "[nulldiff][
 }
 
 TEST_CASE("Two fixtures held at once both stay resolvable", "[nulldiff][fixture]") {
-    const PoolUnwind unwind;
+    const PooledSourcesUnwind unwind;
 
     // A Case carries source ids and nothing else, and the legs resolve them
     // through the global pool. The app's install clears that pool and resets its
@@ -243,7 +227,7 @@ TEST_CASE("Two fixtures held at once both stay resolvable", "[nulldiff][fixture]
 }
 
 TEST_CASE("A project that hosts a plugin is not a fixture here", "[nulldiff][fixture]") {
-    const PoolUnwind unwind;
+    const PooledSourcesUnwind unwind;
 
     // Half the legacy corpus hosts one, and none of it can be held to a null:
     // without the plugin installed both legs render a passthrough and agree
@@ -273,7 +257,7 @@ TEST_CASE("A project that hosts a plugin is not a fixture here", "[nulldiff][fix
 
 TEST_CASE("A source the manifest does not name fails rather than passing quietly",
           "[nulldiff][fixture]") {
-    const PoolUnwind unwind;
+    const PooledSourcesUnwind unwind;
 
     // The failure this rig is built around, provoked rather than described: drop
     // one declaration and the load has to refuse. Without the check the case
@@ -398,7 +382,7 @@ TEST_CASE("Two names the filesystem calls one file are counted, not compared",
 }
 
 TEST_CASE("Each fixture's material is its own", "[nulldiff][fixture]") {
-    const PoolUnwind unwind;
+    const PooledSourcesUnwind unwind;
 
     // Two fixtures are allowed to reference files with the same name: they are
     // different projects and nothing ties their sources together. A flat scratch
@@ -431,7 +415,7 @@ TEST_CASE("Each fixture's material is its own", "[nulldiff][fixture]") {
 }
 
 TEST_CASE("A declaration nothing claims fails too", "[nulldiff][fixture]") {
-    const PoolUnwind unwind;
+    const PooledSourcesUnwind unwind;
 
     // The other direction, and it is not symmetry for its own sake. A manifest
     // entry no source claims is a declaration that has stopped being true, which

--- a/tests/test_real_project_survey.cpp
+++ b/tests/test_real_project_survey.cpp
@@ -178,18 +178,34 @@ TEST_CASE("What the legacy projects would cost as render cases", "[nulldiff][sur
     report << "\nclean and renderable: " << juce::String(usable) << " of "
            << juce::String(static_cast<int>(rows.size())) << "\n";
 
-    // Every distinct diagnostic once, which is the list of what stands between
-    // these projects and being cases.
-    std::map<std::string, int> reasons;
+    // Every distinct reason once, against the projects it stops rather than the
+    // number of times it was said.
+    //
+    // Counted per project, and that is the correction: a project with three
+    // 4osc instances reports the same missing device three times, so tallying
+    // the diagnostics counts instances and calling the total "projects"
+    // overstates every row of the table. What decides whether a port unblocks a
+    // case is how many projects wait on it, so both are printed and the project
+    // count leads.
+    std::map<std::string, std::set<std::string>> projectsPerReason;
+    std::map<std::string, int> timesSaid;
     for (const auto& row : rows) {
-        if (!row.loaded)
-            reasons[row.refusal.substr(0, 72)]++;
-        for (const auto& diagnostic : row.diagnostics)
-            reasons[diagnostic.substr(0, 72)]++;
+        if (!row.loaded) {
+            const auto reason = row.refusal.substr(0, 72);
+            projectsPerReason[reason].insert(row.file);
+            timesSaid[reason]++;
+        }
+        for (const auto& diagnostic : row.diagnostics) {
+            const auto reason = diagnostic.substr(0, 72);
+            projectsPerReason[reason].insert(row.file);
+            timesSaid[reason]++;
+        }
     }
-    report << "\nreasons, with how many projects each covers:\n";
-    for (const auto& [reason, count] : reasons)
-        report << "  " << juce::String(count).paddedLeft(' ', 3) << "  " << juce::String(reason)
+
+    report << "\nreasons: projects stopped, times reported, reason\n";
+    for (const auto& [reason, projects] : projectsPerReason)
+        report << "  " << juce::String(static_cast<int>(projects.size())).paddedLeft(' ', 3) << "  "
+               << juce::String(timesSaid[reason]).paddedLeft(' ', 4) << "  " << juce::String(reason)
                << "\n";
 
     WARN(report.toStdString());

--- a/tests/test_real_project_survey.cpp
+++ b/tests/test_real_project_survey.cpp
@@ -1,0 +1,202 @@
+#include <catch2/catch_test_macros.hpp>
+#include <chrono>
+#include <cstdint>
+#include <map>
+#include <set>
+#include <string>
+#include <vector>
+
+#include "LegacyCorpus.hpp"
+#include "MgdFixture.hpp"
+#include "NullDiffNativeLeg.hpp"
+#include "core/SourcePool.hpp"
+#include "project/serialization/ProjectSerializer.hpp"
+
+/**
+ * @file test_real_project_survey.cpp
+ * @brief What the legacy projects would cost as render cases (#2081).
+ *
+ * #2081 asks which real projects the corpus carries and what each declares, and
+ * says the cost question is answered by measuring rather than by deciding in
+ * advance. This is the measuring. It is not the corpus: nothing here declares a
+ * tier or asserts a residual, and every project is handed the same placeholder
+ * material rather than material chosen for what its path goes through.
+ *
+ * What it reports, per project: whether the fixture rig will take it at all,
+ * what the plan compiler says about it, how many ops the plan carries, and how
+ * long one render takes. That is the table #2081 needs before anybody writes a
+ * manifest, because three of those four answers are reasons a project cannot be
+ * a case and the fourth decides where the cases run.
+ *
+ * It asserts almost nothing on purpose. A project the engine cannot yet render
+ * is a fact about #2174's device coverage, not a failure of this file, and a
+ * survey that went red every time the engine was mid-way through something
+ * would be deleted rather than read.
+ */
+
+using namespace magda;
+using namespace magda::nulldiff;
+
+namespace {
+
+juce::File scratch() {
+    auto root = juce::File::getSpecialLocation(juce::File::tempDirectory)
+                    .getChildFile("magda_real_project_survey");
+    root.createDirectory();
+    return root;
+}
+
+/// The file names a project's sources end in, read by loading it.
+///
+/// The manifest below is generated rather than written, which is the one thing
+/// a survey may do and a corpus may not: choosing material is a judgement about
+/// what stands between the two engines on that path (#2040), and generating it
+/// would be pretending to have made that judgement. Here nothing is asserted
+/// about the audio, so a placeholder is honest.
+std::vector<juce::String> sourceNamesOf(const juce::File& file) {
+    StagedProjectData staged;
+    if (!ProjectSerializer::loadAndStage(file, staged))
+        return {};
+
+    std::set<juce::String> names;
+    const auto add = [&names](const std::vector<Source>& sources) {
+        for (const auto& source : sources)
+            names.insert(source.filePath.fromLastOccurrenceOf("/", false, false)
+                             .fromLastOccurrenceOf("\\", false, false));
+    };
+    add(staged.sources);
+    add(staged.legacySources);
+
+    return {names.begin(), names.end()};
+}
+
+struct Surveyed {
+    std::string file;
+    bool loaded = false;
+    std::string refusal;
+    int tracks = 0;
+    int clips = 0;
+    int sources = 0;
+    bool rendered = false;
+    std::string renderFailure;
+    std::vector<std::string> diagnostics;
+    std::int64_t renderMs = 0;
+};
+
+Surveyed survey(const test::legacy_corpus::ProjectFixture& project) {
+    Surveyed out;
+    out.file = project.file;
+
+    // Held for the whole call: MgdFixture::file is a const char* because the
+    // corpus's own table is string literals, and a survey building one at
+    // runtime has to own the storage it points at.
+    const std::string path = std::string("legacy/projects/") + project.file;
+
+    MgdFixture fixture;
+    fixture.file = path.c_str();
+    fixture.savedBy = project.savedBy;
+    fixture.declaration.name = std::string("survey.") + project.file;
+    fixture.declaration.covers = project.covers;
+    fixture.declaration.endBeat = 16.0;
+
+    // A four-second impulse grid for every source. Long enough that nothing
+    // runs out inside sixteen beats at any tempo a project here uses.
+    MaterialSpec spec;
+    spec.kind = MaterialKind::Impulses;
+    spec.durationSeconds = 8.0;
+    spec.intervalSeconds = 0.25;
+
+    std::vector<std::string> names;
+    for (const auto& name : sourceNamesOf(fixtureCorpusDir().getChildFile(fixture.file)))
+        names.push_back(name.toStdString());
+    for (const auto& name : names)
+        fixture.sources.push_back({.fileName = name.c_str(), .material = spec, .covers = "survey"});
+
+    const auto loaded = loadFixture(fixture, scratch());
+    out.loaded = loaded.ok;
+    out.refusal = loaded.failure;
+    if (!loaded.ok)
+        return out;
+
+    out.tracks = static_cast<int>(loaded.value.tracks.size());
+    out.clips = static_cast<int>(loaded.value.clips.size());
+    out.sources = static_cast<int>(loaded.value.sources.size());
+
+    const auto started = std::chrono::steady_clock::now();
+    const auto render = renderNative(loaded.value);
+    out.renderMs = std::chrono::duration_cast<std::chrono::milliseconds>(
+                       std::chrono::steady_clock::now() - started)
+                       .count();
+
+    out.rendered = render.failure.empty();
+    out.renderFailure = render.failure;
+    out.diagnostics = render.diagnostics;
+    return out;
+}
+
+}  // namespace
+
+TEST_CASE("What the legacy projects would cost as render cases", "[nulldiff][survey]") {
+    const PooledSourcesUnwind unwind;
+
+    std::vector<Surveyed> rows;
+    for (const auto& project : test::legacy_corpus::projectFixtures())
+        rows.push_back(survey(project));
+
+    juce::String report;
+    report << "\nmagda-real-project-survey\n";
+    report << juce::String("projects=") << juce::String(static_cast<int>(rows.size())) << "\n";
+
+    auto usable = 0;
+    for (const auto& row : rows) {
+        report << juce::String(row.file).paddedRight(' ', 32) << " ";
+
+        if (!row.loaded) {
+            report << "refused: " << juce::String(row.refusal).substring(0, 96) << "\n";
+            continue;
+        }
+
+        report << "tracks=" << juce::String(row.tracks).paddedRight(' ', 3)
+               << " clips=" << juce::String(row.clips).paddedRight(' ', 4)
+               << " srcs=" << juce::String(row.sources).paddedRight(' ', 3)
+               << " render=" << juce::String(static_cast<int>(row.renderMs)).paddedLeft(' ', 5)
+               << "ms ";
+
+        if (!row.rendered) {
+            report << " FAILED: " << juce::String(row.renderFailure).substring(0, 72);
+        } else if (!row.diagnostics.empty()) {
+            report << " diagnostics=" << juce::String(static_cast<int>(row.diagnostics.size()))
+                   << ": " << juce::String(row.diagnostics.front()).substring(0, 72);
+        } else {
+            report << " clean";
+            ++usable;
+        }
+
+        report << "\n";
+    }
+
+    report << "\nclean and renderable: " << juce::String(usable) << " of "
+           << juce::String(static_cast<int>(rows.size())) << "\n";
+
+    // Every distinct diagnostic once, which is the list of what stands between
+    // these projects and being cases.
+    std::map<std::string, int> reasons;
+    for (const auto& row : rows) {
+        if (!row.loaded)
+            reasons[row.refusal.substr(0, 72)]++;
+        for (const auto& diagnostic : row.diagnostics)
+            reasons[diagnostic.substr(0, 72)]++;
+    }
+    report << "\nreasons, with how many projects each covers:\n";
+    for (const auto& [reason, count] : reasons)
+        report << "  " << juce::String(count).paddedLeft(' ', 3) << "  " << juce::String(reason)
+               << "\n";
+
+    WARN(report.toStdString());
+
+    // The survey asserts only that it ran. What it found is a fact about the
+    // engine's coverage today and belongs in the report rather than in a
+    // verdict: a file that went red every time the device layer was mid-way
+    // through something would be deleted rather than read.
+    CHECK(rows.size() == test::legacy_corpus::projectFixtures().size());
+}


### PR DESCRIPTION
Closes #2192 for the compiled-Faust slice.

#2192 measured that the native engine could not run most of the devices MAGDA
ships, and named the compiled Faust effects as the slice worth doing first: they
are the survey's blockers and they share one shape. All twenty-two of them cross
here, plus Poly Synth.

## Why they were stuck

Not because any one of them was hard. Each carried its own copy of the same six
hundred lines: an `[idx:N]` zone harvester, a normalized parameter table, a
scratch-buffer dance around `dsp::compute()`, a sanitising pass. The device's
actual identity was about forty lines of that. Porting it is one job done
twenty-two times.

`MagdaCompiledEffect` is the effect half of what `MagdaCompiledPolyInstrument`
already was for the instruments. It owns the harvest, the slot table, the
engines, the block and project tempo; a device supplies its dsp factory, its
slots and its names. The twenty-one effects are now between forty and a hundred
and fifty lines each.

Poly Synth went onto the instrument base, which had assumed the layout a struck
drum voice wants. It composes that as a default now rather than imposing it: a
device may return its whole table and say where the control slots went.

## What the SDK had to grow

Each of these is a device asking for something the contract could not say, not a
convenience:

- **Project tempo.** `DeviceProcessContext::tempoMap` was never filled in on the
  Tracktion side, so the six tempo-synced effects would have lost sync. It reads
  the edit's sequence now, on the same thread those devices already read it from.
- **Sidechain.** The engine had `DeviceBlock::sidechain` and the SDK had nowhere
  to put it. The key arrives as further channels of the device's own buffer with
  `sidechainInputChannel` saying where they start. That is the layout the
  compiled dynamics DSPs already read and the one the fork already hands them,
  so neither host copies anything to supply it.
- **Channel widths, tail and latency**, for the mono-in/stereo-out and
  reverb-tail devices.
- **A dsp-index to slot mapping**, because the Filter's table interleaves
  controls no dsp owns.

## Two regressions this branch introduced and fixed

Worth reading as part of the review rather than buried:

- Delay and Grain Delay declare four-second tails and both told the host to keep
  pumping them after dry input stopped. The port carried the tail and dropped the
  pumping, so the echoes were cut. Restored.
- Converting a slot's value went through `ParameterInfo`, which carries a
  `std::vector<juce::String>` of choices, so every discrete parameter of every
  device allocated once per block inside `process()`. The devices this base
  replaced each avoided that by hand and the base reintroduced it for all of
  them. Both bases now cache a `ParameterUtils::ParameterDomain` per slot and the
  audio thread reads it by reference.

## What this does not do

The survey still reports `clean and renderable: 2 of 22`, and that is no longer a
device fact. The dominant remaining diagnostic is
`plan: track N: output routes to missing track -2, summed into the master`, which
is the plan compiler. #2192's "done when" assumed devices were the wall. They
were, and something else is now.

Still not native, and out of this slice: `4osc` (7 projects, and #1902's v1 plan
already removes it), `drumgrid` (3), `faust` (2), `sidechain` (2), and
Tracktion's own `toneGenerator` (1).

## Verification

- Catch2: 2943 cases, 601786 assertions, 0 failures.
- JUCE target: clean. One real failure caught here mid-branch and fixed: a
  declared output width was being read as "the device answers for both sides", so
  Reverb reported zero inputs and a nested rack stopped passing audio into the
  device after it.
- Survey: every compiled device gone from the blocked table.

The first two commits are the #2081 survey this is measured with. They have no PR
of their own and are small, so they ride along rather than paying separate CI.

https://claude.ai/code/session_01EXLKj37dCPKP5neGiRvXk2
