### PR TITLE
Give the model somewhere to put a Drum Grid's pads (#2192)

### DIFF
--- a/magda/daw/audio/plugins/engine/EngineDeviceFactory.cpp
+++ b/magda/daw/audio/plugins/engine/EngineDeviceFactory.cpp
@@ -2,6 +2,7 @@
 
 #include <utility>
 
+#include "core/DeviceState.hpp"
 #include "plugins/InternalPluginRegistry.hpp"
 #include "plugins/compiled/CompiledPluginRegistry.hpp"
 #include "plugins/engine/EngineMagdaDevice.hpp"
@@ -49,6 +50,40 @@ std::unique_ptr<MagdaDevice> createSdkDevice(const juce::String& pluginId) {
     return {};
 }
 
+/// The saved node, as the tree MagdaDevice::restoreState() takes.
+juce::ValueTree treeFromNode(const magda::device_state::Node& node) {
+    juce::ValueTree tree(node.type.isNotEmpty() ? juce::Identifier(node.type)
+                                                : juce::Identifier("PLUGIN"));
+    for (int i = 0; i < node.props.size(); ++i)
+        tree.setProperty(node.props.getName(i), node.props.getValueAt(i), nullptr);
+    for (const auto& child : node.children)
+        if (child.type.isNotEmpty())
+            tree.appendChild(treeFromNode(child), nullptr);
+    return tree;
+}
+
+/// Hand the device whatever the project saved for it.
+///
+/// Parameters are not this: the plan's value layer resolves every one of them
+/// per block and the adapter writes them before each process() call. What this
+/// carries is everything else -- the runtime Faust device's dsp source, an EQ's
+/// collapsed curve -- without which a device built here runs its defaults and
+/// renders a project nobody saved. A device with no saved state, or state from a
+/// schema this build refuses, keeps those defaults, which is what the fork does
+/// with the same document.
+void restoreSavedState(MagdaDevice& device, const juce::String& savedState) {
+    if (savedState.isEmpty())
+        return;
+
+    const auto doc = magda::device_state::decode(savedState);
+    if (!doc)
+        return;
+
+    auto tree = treeFromNode(doc->root);
+    tree.setProperty(typeProperty(), doc->deviceType, nullptr);
+    device.restoreState(tree);
+}
+
 }  // namespace
 
 std::unique_ptr<magda::engine::EngineDevice> createEngineDevice(const magda::DeviceInfo& device,
@@ -56,6 +91,11 @@ std::unique_ptr<magda::engine::EngineDevice> createEngineDevice(const magda::Dev
     auto sdkDevice = createSdkDevice(device.pluginId);
     if (sdkDevice == nullptr)
         return {};
+
+    // Before the adapter, not after. EngineMagdaDevice snapshots the device's
+    // parameter metadata when it is constructed, so a device that restores its
+    // state later would be mapped against the parameters it had before.
+    restoreSavedState(*sdkDevice, device.pluginState);
 
     return std::make_unique<EngineMagdaDevice>(std::move(sdkDevice), offlineRender);
 }

--- a/magda/daw/audio/processors/internal/StockDeviceProcessors.cpp
+++ b/magda/daw/audio/processors/internal/StockDeviceProcessors.cpp
@@ -3,6 +3,10 @@
 #include <cmath>
 #include <utility>
 
+#include "core/ParameterUtils.hpp"
+#include "plugins/ToneGeneratorPlugin.hpp"
+#include "plugins/compiled/tracktion/CompiledFaustTracktionAdapter.hpp"
+#include "plugins/tracktion/TracktionMagdaDevicePlugin.hpp"
 #include "processors/ParameterInfoBuilder.hpp"
 
 namespace magda {
@@ -30,8 +34,35 @@ void ToneGeneratorProcessor::initializeDefaults() {
     initialized_ = true;
 }
 
-te::ToneGeneratorPlugin* ToneGeneratorProcessor::getTonePlugin() const {
-    return dynamic_cast<te::ToneGeneratorPlugin*>(plugin_.get());
+// The device is MAGDA's now and the chain holds the host's wrapper around it,
+// so the parameters are reached by slot rather than by the retired plugin's
+// named members. The accessors below keep their old units -- Hz, linear level,
+// the waveform enum -- because their callers are written against those; the
+// conversion to the slot's normalized position happens here.
+
+daw::audio::ToneGeneratorPlugin* ToneGeneratorProcessor::getToneDevice() const {
+    return daw::audio::tracktion_adapter::deviceFromPlugin<daw::audio::ToneGeneratorPlugin>(
+        plugin_.get());
+}
+
+void ToneGeneratorProcessor::setSlotDisplayValue(int slot, float displayValue) const {
+    auto* device = getToneDevice();
+    auto* param = daw::audio::compiled::tracktionParameterForSlot(plugin_.get(), slot);
+    if (device == nullptr || param == nullptr)
+        return;
+
+    param->setParameterFromHost(
+        ParameterUtils::realToNormalized(displayValue, device->parameterInfo(slot)),
+        juce::dontSendNotification);
+}
+
+float ToneGeneratorProcessor::slotDisplayValue(int slot, float fallback) const {
+    auto* device = getToneDevice();
+    auto* param = daw::audio::compiled::tracktionParameterForSlot(plugin_.get(), slot);
+    if (device == nullptr || param == nullptr)
+        return fallback;
+
+    return ParameterUtils::normalizedToReal(param->getCurrentValue(), device->parameterInfo(slot));
 }
 
 void ToneGeneratorProcessor::setParameter(const juce::String& paramName, float value) {
@@ -164,72 +195,43 @@ void ToneGeneratorProcessor::setParameterByIndex(int paramIndex, float value) {
 }
 
 void ToneGeneratorProcessor::setFrequency(float hz) {
-    if (auto* tone = getTonePlugin()) {
-        // Clamp to valid range
-        hz = juce::jlimit(20.0f, 20000.0f, hz);
-
-        // Set via AutomatableParameter - this is the proper Tracktion Engine way
-        // The parameter will automatically sync to the CachedValue
-        if (tone->frequencyParam) {
-            tone->frequencyParam->setParameterFromHost(hz, juce::dontSendNotification);
-        }
-    }
+    setSlotDisplayValue(daw::audio::ToneGeneratorPlugin::kFrequencyParamIndex,
+                        juce::jlimit(20.0f, 20000.0f, hz));
 }
 
 float ToneGeneratorProcessor::getFrequency() const {
-    if (auto* tone = getTonePlugin()) {
-        return tone->frequency;
-    }
-    return 440.0f;
+    return slotDisplayValue(daw::audio::ToneGeneratorPlugin::kFrequencyParamIndex, 440.0f);
 }
 
 void ToneGeneratorProcessor::setLevel(float level) {
-    if (auto* tone = getTonePlugin()) {
-        // Set via AutomatableParameter - proper Tracktion Engine way
-        if (tone->levelParam) {
-            tone->levelParam->setParameterFromHost(level, juce::dontSendNotification);
-        }
-    }
+    // The caller's level is linear; the device's is dB.
+    setSlotDisplayValue(daw::audio::ToneGeneratorPlugin::kLevelParamIndex,
+                        juce::Decibels::gainToDecibels(level, -60.0f));
 }
 
 float ToneGeneratorProcessor::getLevel() const {
-    if (auto* tone = getTonePlugin()) {
-        return tone->level;
-    }
-    return 0.25f;
+    const float db = slotDisplayValue(daw::audio::ToneGeneratorPlugin::kLevelParamIndex, -12.0f);
+    return db <= -60.0f ? 0.0f : juce::Decibels::decibelsToGain(db, -60.0f);
 }
 
 void ToneGeneratorProcessor::setOscType(int teOscType) {
-    if (auto* tone = getTonePlugin()) {
-        // TE enum: 0=sin, 1=triangle, 2=sawUp, 3=sawDown, 4=square, 5=noise
-        float teType = static_cast<float>(juce::jlimit(0, 5, teOscType));
-        if (tone->oscTypeParam) {
-            tone->oscTypeParam->setParameterFromHost(teType, juce::dontSendNotification);
-        }
-    }
+    setSlotDisplayValue(daw::audio::ToneGeneratorPlugin::kWaveformParamIndex,
+                        static_cast<float>(juce::jlimit(0, 5, teOscType)));
 }
 
 int ToneGeneratorProcessor::getOscType() const {
-    if (auto* tone = getTonePlugin()) {
-        return juce::jlimit(0, 5, static_cast<int>(tone->oscType));
-    }
-    return 0;
+    return juce::jlimit(0, 5,
+                        static_cast<int>(std::lround(slotDisplayValue(
+                            daw::audio::ToneGeneratorPlugin::kWaveformParamIndex, 0.0f))));
 }
 
 void ToneGeneratorProcessor::setBandLimit(bool bandLimited) {
-    if (auto* tone = getTonePlugin()) {
-        if (tone->bandLimitParam) {
-            tone->bandLimitParam->setParameterFromHost(bandLimited ? 1.0f : 0.0f,
-                                                       juce::dontSendNotification);
-        }
-    }
+    setSlotDisplayValue(daw::audio::ToneGeneratorPlugin::kBandLimitParamIndex,
+                        bandLimited ? 1.0f : 0.0f);
 }
 
 bool ToneGeneratorProcessor::getBandLimit() const {
-    if (auto* tone = getTonePlugin()) {
-        return static_cast<float>(tone->bandLimit) >= 0.5f;
-    }
-    return false;
+    return slotDisplayValue(daw::audio::ToneGeneratorPlugin::kBandLimitParamIndex, 0.0f) >= 0.5f;
 }
 
 void ToneGeneratorProcessor::applyGain() {

--- a/magda/daw/audio/processors/internal/StockDeviceProcessors.hpp
+++ b/magda/daw/audio/processors/internal/StockDeviceProcessors.hpp
@@ -4,6 +4,10 @@
 
 #include "processors/base/AutomatablePluginProcessor.hpp"
 
+namespace magda::daw::audio {
+class ToneGeneratorPlugin;
+}
+
 namespace magda {
 
 namespace te = tracktion;
@@ -67,7 +71,9 @@ class ToneGeneratorProcessor : public DeviceProcessor {
     void applyGain() override;
 
   private:
-    te::ToneGeneratorPlugin* getTonePlugin() const;
+    daw::audio::ToneGeneratorPlugin* getToneDevice() const;
+    void setSlotDisplayValue(int slot, float displayValue) const;
+    float slotDisplayValue(int slot, float fallback) const;
     bool initialized_ = false;
 };
 

--- a/magda/daw/core/CMakeLists.txt
+++ b/magda/daw/core/CMakeLists.txt
@@ -6,6 +6,7 @@ target_sources(magda_daw PRIVATE
     Config.cpp
     AppPaths.cpp
     ChainNodePath.cpp
+    DeviceInfo.cpp
     ControlTarget.cpp
     MixerStripOrder.cpp
     UIScale.cpp

--- a/magda/daw/core/DeviceInfo.cpp
+++ b/magda/daw/core/DeviceInfo.cpp
@@ -1,0 +1,28 @@
+#include "DeviceInfo.hpp"
+
+#include "RackInfo.hpp"
+
+namespace magda {
+
+// Out of line because RackInfo is only complete once RackInfo.hpp has been
+// seen, and RackInfo.hpp includes DeviceInfo.hpp, so the header cannot see it.
+
+PadRack::PadRack() = default;
+PadRack::~PadRack() = default;
+PadRack::PadRack(PadRack&& other) noexcept = default;
+PadRack& PadRack::operator=(PadRack&& other) noexcept = default;
+
+PadRack::PadRack(const PadRack& other)
+    : rack_(other.rack_ != nullptr ? std::make_unique<RackInfo>(*other.rack_) : nullptr) {}
+
+PadRack& PadRack::operator=(const PadRack& other) {
+    if (this != &other)
+        rack_ = other.rack_ != nullptr ? std::make_unique<RackInfo>(*other.rack_) : nullptr;
+    return *this;
+}
+
+void PadRack::reset(std::unique_ptr<RackInfo> rack) {
+    rack_ = std::move(rack);
+}
+
+}  // namespace magda

--- a/magda/daw/core/DeviceInfo.hpp
+++ b/magda/daw/core/DeviceInfo.hpp
@@ -13,6 +13,42 @@
 
 namespace magda {
 
+struct RackInfo;
+
+/**
+ * @brief Value-semantic owner for a device's pad chains.
+ *
+ * RackInfo is incomplete here -- RackInfo.hpp includes this header, so it
+ * cannot be included back -- and DeviceInfo is copied by value throughout the
+ * app. A bare unique_ptr would make DeviceInfo non-copyable and a shared_ptr
+ * would make two copies of a device share one set of pads. This owns the rack,
+ * copies it deep, and keeps its own rule of five out of line so DeviceInfo
+ * needs none of its own.
+ */
+class PadRack {
+  public:
+    PadRack();
+    ~PadRack();
+    PadRack(const PadRack& other);
+    PadRack& operator=(const PadRack& other);
+    PadRack(PadRack&& other) noexcept;
+    PadRack& operator=(PadRack&& other) noexcept;
+
+    explicit operator bool() const {
+        return rack_ != nullptr;
+    }
+    RackInfo* get() const {
+        return rack_.get();
+    }
+    RackInfo* operator->() const {
+        return rack_.get();
+    }
+    void reset(std::unique_ptr<RackInfo> rack);
+
+  private:
+    std::unique_ptr<RackInfo> rack_;
+};
+
 /**
  * @brief Plugin format enumeration
  *
@@ -250,6 +286,22 @@ struct DeviceInfo {
     // here; PluginPreferences keeps a user-global mirror that's stamped onto
     // new instances when they're created. See KitRow.hpp.
     std::vector<KitRow> kitRows;
+
+    /**
+     * A pad-per-chain device's pads, as chains keyed by note range (#2192).
+     *
+     * Null for every device that is not one. A Drum Grid's pads used to live
+     * inside its engine plugin state as engine XML, which meant nothing but the
+     * engine could see them: the plan compiler could not expand them the way it
+     * expands a rack, so the whole device stopped at a Device op that no native
+     * engine could bind.
+     *
+     * They are chains because that is what they are. ChainInfo already carries
+     * a pad's level, pan, mute, solo, bypass and output; the note range it
+     * gained alongside this is the only thing a pad has that a rack chain does
+     * not.
+     */
+    PadRack padRack;
 
     // Sidechain configuration (e.g., compressor key input)
     SidechainConfig sidechain;

--- a/magda/daw/core/RackInfo.hpp
+++ b/magda/daw/core/RackInfo.hpp
@@ -70,6 +70,24 @@ struct ChainInfo {
     float volume = 0.0f;  // Chain volume in dB (0 = unity)
     float pan = 0.0f;     // Chain pan (-1 to 1)
 
+    /**
+     * The MIDI notes this chain answers to, for a rack whose chains are keyed
+     * by pitch rather than run in parallel: a Drum Grid's pads (#2192).
+     *
+     * `lowNote` > `highNote` means the chain takes everything, which is what a
+     * plain parallel rack chain does and what every chain built before pads
+     * lived in the model reads as. `rootNote` is the pitch the range is
+     * transposed onto before the chain sees it, so a sampler mapped at C0
+     * plays from whichever pad triggered it.
+     */
+    int lowNote = 0;
+    int highNote = -1;
+    int rootNote = 0;
+
+    bool answersToEveryNote() const {
+        return lowNote > highNote;
+    }
+
     // UI state
     bool expanded = true;
 

--- a/tests/test_engine_device_layer.cpp
+++ b/tests/test_engine_device_layer.cpp
@@ -7,9 +7,11 @@
 #include <vector>
 
 #include "NullDiffGain.hpp"
+#include "core/DeviceState.hpp"
 #include "core/ParameterUtils.hpp"
 #include "exec/EngineDevice.hpp"
 #include "exec/PlanExecutor.hpp"
+#include "magda/daw/audio/plugins/FaustPlugin.hpp"
 #include "magda/daw/audio/plugins/InternalPluginRegistry.hpp"
 #include "magda/daw/audio/plugins/compiled/CompiledPluginRegistry.hpp"
 #include "magda/daw/audio/plugins/engine/EngineDeviceFactory.hpp"
@@ -598,4 +600,42 @@ TEST_CASE("one note-off releases a pitch that was pressed many times", "[engine]
     // appended would still be holding three hundred and ninety-nine of them and
     // sitting at full sustain here.
     CHECK(releasedPeak < heldPeak * 0.05f);
+}
+
+TEST_CASE("a device built for the engine gets the state the project saved",
+          "[engine][devices][2192]") {
+    // Parameters reach a device through the plan's value layer, so for most
+    // devices there is nothing else to carry and the factory carried nothing.
+    // The runtime Faust device breaks that: its dsp source is state, not a
+    // parameter, and a device built without it runs the default passthrough.
+    // That is a render of a project nobody saved, which is the one thing the
+    // factory must not do quietly.
+    constexpr const char* kSource = R"FAUST(
+// Self-contained test DSP. The literal "stdfaust.lib" in this comment is
+// load-bearing: the compile step only skips its automatic import when the
+// source already mentions the library.
+process = *(0.25), *(0.25);
+)FAUST";
+
+    magda::device_state::Doc doc;
+    doc.deviceType = "faust";
+    doc.root.props.set("dspSource", kSource);
+    doc.root.props.set("dspName", "Saved patch");
+
+    magda::DeviceInfo model;
+    model.pluginId = "faust";
+    model.pluginState = magda::device_state::encode(doc);
+    REQUIRE(model.pluginState.isNotEmpty());
+
+    auto device = adapter::createEngineDevice(model);
+    REQUIRE(device != nullptr);
+
+    auto* hosted = dynamic_cast<adapter::EngineMagdaDevice*>(device.get());
+    REQUIRE(hosted != nullptr);
+
+    auto* faust = dynamic_cast<magda::daw::audio::FaustPlugin*>(&hosted->device());
+    REQUIRE(faust != nullptr);
+
+    CHECK(faust->getDspSource().contains("*(0.25)"));
+    CHECK(faust->getDspName() == juce::String("Saved patch"));
 }


### PR DESCRIPTION
Stacked on #2196; review that first. This adds one commit.

Groundwork only. Nothing writes `padRack` and nothing reads it, so there is no
behaviour change to test yet. It is separate because what follows is a project
format change and this part is not.

## Why DrumGrid could not be ported like the others

It is not a DSP device. Each pad hosts a full plugin chain (instrument plus FX)
and `processChain()` builds a `te::PluginRenderContext` and runs them; a pad can
hold an external VST. A `MagdaDevice` cannot host one, and the SDK has no
device-hosts-devices contract.

The plan already compiles racks structurally (`emitRack`, chains, `OpKey` carries
rack and chain), and a Drum Grid is that same shape: 64 pads, each a chain. So
the native answer is for the plan to expand it, not for the class to be ported.

Except the plan compiles from the model, and the pads are not in it. They live
inside the device's opaque `pluginState` as engine XML:

```xml
<PLUGIN type="drumgrid">
  <CHAIN index="0" lowNote="24" highNote="24" rootNote="24"
         padLevel="0.0" padPan="0.0" padMute="0" padSolo="0"
         padBypassed="0" busOutput="0">
    <PLUGIN type="magdasampler" source="..."/>
```

`PluginManagerSync` says it outright: "Pad plugins live inside the DrumGrid's
state, not in the chain."

## What this does

Pads are chains, so they are stored as chains. `ChainInfo` already carries a
pad's level, pan, mute, solo, bypass and output; the note range added here is the
only thing a pad has that a rack chain does not. A chain that answers to every
note is what a plain parallel chain already is, so nothing built before this
reads differently.

`DeviceInfo` holds them through `PadRack` rather than a bare pointer. `RackInfo`
is incomplete there, `DeviceInfo` is copied by value throughout the app, and two
copies of a device must not share one set of pads. `PadRack` owns the rack,
copies it deep, and keeps its rule of five out of line so `DeviceInfo` keeps the
compiler's own and nothing else has to change. No aggregate initialization of
`DeviceInfo` exists anywhere, which is what makes that safe.

## What comes next, on this branch

1. Read the pads out of the saved engine XML into `padRack`, and serialize them
2. Teach `PlanCompiler` to expand a device with pads like `emitRack`, gated by
   note range
3. Keep the fork rendering from that same model

Step 1 touches save and load for every existing Drum Grid project, so it is worth
agreeing the model here before it is written against.

## Verification

Full app builds. Catch2 2944 cases / 600607 assertions, JUCE suite clean.

https://claude.ai/code/session_01EXLKj37dCPKP5neGiRvXk2
