### PR TITLE
Read a Drum Grid's pads into the model (#2192)

### DIFF
--- a/magda/daw/audio/plugin_manager/PluginManager.cpp
+++ b/magda/daw/audio/plugin_manager/PluginManager.cpp
@@ -452,9 +452,9 @@ void PluginManager::captureAllPluginStates() {
 
             // Always overwrite pluginState (even if empty) to avoid stale state.
             devInfo->pluginState = stateStr;
-            // A pad-per-chain device's pads follow its state. This is where they
-            // become keyable: a Drum Grid allocates a DeviceId per pad plugin
-            // when it restores one, so the ids exist here and not at load (#2192).
+            // Pads follow the state they live in. Also where they become
+            // keyable: a Drum Grid allocates a pad plugin's DeviceId when it
+            // restores it, so the ids exist here and not at load (#2192).
             refreshPadRack(*devInfo);
             captureVst3Info(*devInfo, capturedExt);
             if (sd.processor != nullptr)

--- a/magda/daw/audio/plugin_manager/PluginManager.cpp
+++ b/magda/daw/audio/plugin_manager/PluginManager.cpp
@@ -5,6 +5,7 @@
 #include <unordered_set>
 #include <vector>
 
+#include "../../core/DrumGridPads.hpp"
 #include "../../core/RackInfo.hpp"
 #include "../../core/TrackManager.hpp"
 #include "../../core/aliases/AutoAliasGenerator.hpp"
@@ -451,6 +452,10 @@ void PluginManager::captureAllPluginStates() {
 
             // Always overwrite pluginState (even if empty) to avoid stale state.
             devInfo->pluginState = stateStr;
+            // A pad-per-chain device's pads follow its state. This is where they
+            // become keyable: a Drum Grid allocates a DeviceId per pad plugin
+            // when it restores one, so the ids exist here and not at load (#2192).
+            refreshPadRack(*devInfo);
             captureVst3Info(*devInfo, capturedExt);
             if (sd.processor != nullptr)
                 sd.processor->populateParameters(*devInfo);
@@ -488,6 +493,7 @@ void PluginManager::capturePluginState(const ChainNodePath& devicePath) {
     }
 
     devInfo->pluginState = stateStr;
+    refreshPadRack(*devInfo);
     captureVst3Info(*devInfo, capturedExt);
     if (it->second.processor)
         it->second.processor->populateParameters(*devInfo);

--- a/magda/daw/audio/plugins/DrumGridPlugin.cpp
+++ b/magda/daw/audio/plugins/DrumGridPlugin.cpp
@@ -59,6 +59,7 @@ const juce::Identifier DrumGridPlugin::busOutputId("busOutput");
 const juce::Identifier DrumGridPlugin::mixerExpandedId("mixerExpanded");
 const juce::Identifier DrumGridPlugin::multiOutEnabledId("multiOutEnabled");
 const juce::Identifier DrumGridPlugin::pluginDeviceIdProp("magdaDeviceId");
+const juce::Identifier DrumGridPlugin::pluginIsInstrumentProp("magdaIsInstrument");
 
 //==============================================================================
 DrumGridPlugin::DrumGridPlugin(const te::PluginCreationInfo& info,
@@ -600,6 +601,7 @@ void DrumGridPlugin::installSinglePadPlugin(Chain& chain, te::Plugin::Ptr plugin
 
     // Assign a stable DeviceId for macro/mod linking.
     plugin->state.setProperty(pluginDeviceIdProp, deviceIdAllocator_.allocateDeviceId(), nullptr);
+    plugin->state.setProperty(pluginIsInstrumentProp, plugin->isSynth(), nullptr);
 
     // Initialise BEFORE the plugin can become visible to the audio thread.
     initialisePluginIfNeeded(*plugin, sampleRate_, blockSize_);
@@ -766,6 +768,7 @@ void DrumGridPlugin::addPluginToChain(int chainIndex, const juce::PluginDescript
 
     // Assign a stable DeviceId for macro/mod linking
     plugin->state.setProperty(pluginDeviceIdProp, deviceIdAllocator_.allocateDeviceId(), nullptr);
+    plugin->state.setProperty(pluginIsInstrumentProp, plugin->isSynth(), nullptr);
 
     auto chainTree = findChainTree(chainIndex);
     if (chainTree.isValid()) {
@@ -814,6 +817,7 @@ void DrumGridPlugin::addInternalPluginToChain(int chainIndex, const juce::String
 
     // Assign a stable DeviceId for macro/mod linking
     plugin->state.setProperty(pluginDeviceIdProp, deviceIdAllocator_.allocateDeviceId(), nullptr);
+    plugin->state.setProperty(pluginIsInstrumentProp, plugin->isSynth(), nullptr);
 
     auto chainTree = findChainTree(chainIndex);
     if (chainTree.isValid()) {
@@ -1191,6 +1195,10 @@ void DrumGridPlugin::restorePluginStateFromValueTree(const juce::ValueTree& v) {
                     int restoredId = pluginState.getProperty(pluginDeviceIdProp);
                     deviceIdAllocator_.ensureDeviceIdAbove(restoredId);
                 }
+
+                // Written every time, not only when absent: a saved flag can
+                // describe a plugin that has since been swapped.
+                pluginState.setProperty(pluginIsInstrumentProp, plugin->isSynth(), nullptr);
 
                 chain->plugins.push_back(plugin);
 

--- a/magda/daw/audio/plugins/DrumGridPlugin.hpp
+++ b/magda/daw/audio/plugins/DrumGridPlugin.hpp
@@ -343,6 +343,11 @@ class DrumGridPlugin : public te::Plugin, private juce::Timer {
     static const juce::Identifier mixerExpandedId;
     static const juce::Identifier multiOutEnabledId;
     static const juce::Identifier pluginDeviceIdProp;
+    /// Whether a pad's plugin is an instrument, as the plugin itself answers.
+    /// Saved because nothing outside the engine can ask an external plugin, and
+    /// position does not answer it: an effect can be inserted at index 0, and
+    /// plugins can be moved and removed (#2192).
+    static const juce::Identifier pluginIsInstrumentProp;
 
     Chain* findChainForNote(int midiNote);
     Chain* findOrCreateChainForPad(int padIndex);

--- a/magda/daw/audio/racks/RackSyncManager.cpp
+++ b/magda/daw/audio/racks/RackSyncManager.cpp
@@ -523,8 +523,7 @@ void RackSyncManager::capturePluginStates(SyncedRack& synced) {
         }
 
         devInfo->pluginState = stateStr;
-        // Pads follow the state they live in, for a Drum Grid inside a rack the
-        // same as one on a track (#2192).
+        // As on a track: pads follow the state they live in (#2192).
         refreshPadRack(*devInfo);
         pluginManager_.refreshDeviceParameters(devicePath);
     }

--- a/magda/daw/audio/racks/RackSyncManager.cpp
+++ b/magda/daw/audio/racks/RackSyncManager.cpp
@@ -1,5 +1,6 @@
 #include "racks/RackSyncManager.hpp"
 
+#include "../../core/DrumGridPads.hpp"
 #include "TracktionHelpers.hpp"
 #include "core/ChainRoutingModel.hpp"
 #include "core/TrackManager.hpp"
@@ -522,6 +523,9 @@ void RackSyncManager::capturePluginStates(SyncedRack& synced) {
         }
 
         devInfo->pluginState = stateStr;
+        // Pads follow the state they live in, for a Drum Grid inside a rack the
+        // same as one on a track (#2192).
+        refreshPadRack(*devInfo);
         pluginManager_.refreshDeviceParameters(devicePath);
     }
 }

--- a/magda/daw/core/CMakeLists.txt
+++ b/magda/daw/core/CMakeLists.txt
@@ -7,6 +7,7 @@ target_sources(magda_daw PRIVATE
     AppPaths.cpp
     ChainNodePath.cpp
     DeviceInfo.cpp
+    DrumGridPads.cpp
     ControlTarget.cpp
     MixerStripOrder.cpp
     UIScale.cpp

--- a/magda/daw/core/DrumGridPads.cpp
+++ b/magda/daw/core/DrumGridPads.cpp
@@ -11,9 +11,8 @@ namespace {
 
 namespace ds = device_state;
 
-/// What a Drum Grid calls its own state. These are the device's property names,
-/// not the engine's: they are the same in a v2 document and in the pre-v2 XML
-/// because the bridge carries a nested tree's properties across unchanged.
+/// A Drum Grid's own property names. The same in a v2 document and in pre-v2
+/// XML: the bridge carries a nested tree's properties across unchanged.
 constexpr const char* kDrumGridId = "drumgrid";
 const juce::Identifier kChain("CHAIN");
 const juce::Identifier kPlugin("PLUGIN");
@@ -29,48 +28,36 @@ const juce::Identifier kPadSolo("padSolo");
 const juce::Identifier kPadBypassed("padBypassed");
 const juce::Identifier kBusOutput("busOutput");
 const juce::Identifier kType("type");
-/// Tracktion saves every external plugin under one type name and keeps the real
-/// identity in these. `format` is the plugin format ("VST3", "AudioUnit"), NOT
-/// what `type` says.
+/// Tracktion saves every external plugin under one `type`, with the real
+/// identity in these. `format` is the plugin format ("VST3", "AudioUnit").
 const juce::Identifier kExternalName("name");
 const juce::Identifier kManufacturer("manufacturer");
 const juce::Identifier kFormat("format");
 const juce::Identifier kFilename("filename");
 const juce::Identifier kEnabled("enabled");
-/// The DeviceId a Drum Grid allocated for a pad's plugin and saved with it.
-/// TrackManager's id allocator already reads this same property out of pad
-/// state so a newly created device cannot be given an id a pad is using.
+/// The DeviceId a Drum Grid allocated for a pad's plugin. TrackManager's id
+/// allocator reads the same property, so ids cannot be handed out twice.
 const juce::Identifier kPluginDeviceId("magdaDeviceId");
+/// Whether a pad's plugin is an instrument, as the plugin itself answered.
+const juce::Identifier kPluginIsInstrument("magdaIsInstrument");
 
-/// A Drum Grid writes 60 for a chain whose note range it has not been told, so
-/// that is what an absent range reads as rather than ChainInfo's own default.
-/// A pad always has a range: the middle-C fallback is the device's, and keeping
-/// it here means a chain restored from state never claims the whole keyboard by
-/// accident.
+/// What a Drum Grid writes for a chain whose note range it was not told. Used
+/// instead of ChainInfo's default, which means "every note".
 constexpr int kFallbackNote = 60;
 
-/// One pad's device, carrying what the compiler needs to key and bind it.
+/// One pad's device.
 ///
-/// A projected device is a real device or it is useless. The plan keys an op on
-/// the DeviceId (`OpKey`), and routes on whether the device is an instrument,
-/// consumes MIDI or is bypassed, so a device projected with those left at their
-/// defaults would give every pad the same key and route none of them: sixty-four
-/// ops that collide and a Drum Grid that still does not render.
-///
-/// None of it is invented. The DeviceId is the one the Drum Grid allocated and
-/// saved with the pad, which is why the id allocator has to read the same
-/// property; the rest comes from the plugin registry, which is where a device's
-/// identity lives for every other device in the model too.
-DeviceInfo deviceFromNode(const ds::Node& node, bool isPadInstrumentSlot) {
+/// The plan keys an op on the DeviceId and routes on the instrument, MIDI and
+/// bypass flags, so all of them have to be real: left at their defaults, every
+/// pad keys the same op and none of them route.
+DeviceInfo deviceFromNode(const ds::Node& node) {
     DeviceInfo device;
 
     const auto savedType = node.props[kType].toString();
     device.pluginId = savedType;
     device.name = savedType;
 
-    // A pad saved by an older build can name a device by a load alias rather
-    // than the id it has now, so the alias-aware lookup goes first and the
-    // canonical id is taken from whatever it resolves to.
+    // Alias-aware first, so a pad saved under a retired device name resolves.
     const auto* spec = daw::audio::findInternalPluginSpecForLoadType(savedType);
     if (spec == nullptr)
         spec = daw::audio::findInternalPluginSpec(savedType);
@@ -83,17 +70,13 @@ DeviceInfo deviceFromNode(const ds::Node& node, bool isPadInstrumentSlot) {
         device.isInstrument = spec->isInstrument;
         device.deviceType = spec->isInstrument ? DeviceType::Instrument : DeviceType::Effect;
 
-        // Without this the device keeps PluginFormat's VST3 default and every
-        // path that asks reads an internal device as an external one: it would
-        // claim a floating editor window it does not have, and the creation
-        // paths would try to instantiate it from external identifiers it has
-        // never had.
+        // Left at PluginFormat's VST3 default, an internal device is read as
+        // external: it claims an editor window it has not got, and creation
+        // tries to instantiate it from identifiers it has never had.
         device.format = PluginFormat::Internal;
     } else {
-        // No spec means an external plugin. Tracktion saves all of them under
-        // one type name, so `type` identifies nothing on its own and the real
-        // identity is in the properties beside it: a pad holding Kick 2 would
-        // otherwise project as an effect called "vst".
+        // No spec means an external plugin, whose `type` is the same string for
+        // all of them. The identity is in the properties beside it.
         const auto externalName = node.props[kExternalName].toString();
         if (externalName.isNotEmpty())
             device.name = externalName;
@@ -102,39 +85,36 @@ DeviceInfo deviceFromNode(const ds::Node& node, bool isPadInstrumentSlot) {
         device.fileOrIdentifier = node.props[kFilename].toString();
         device.format = pluginFormatFromName(node.props[kFormat].toString());
 
-        // The path, not the type name. JUCE's identifier string is what the app
-        // uses for a scanned plugin and it cannot be rebuilt from what is saved
-        // here, so the file is the honest identifier; leaving the type name in
-        // place would key every external pad plugin in the project the same.
-        // uniqueId stays empty on purpose: the `uniqueId` saved here is
-        // Tracktion's own hash, not the JUCE identifier DeviceInfo::uniqueId
-        // means, and putting one where the other is expected would send every
-        // capability lookup to the wrong entry.
+        // The file, because JUCE's identifier string cannot be rebuilt from
+        // what is saved here and the shared `type` would key every external pad
+        // plugin alike. uniqueId stays empty: the saved `uniqueId` is
+        // Tracktion's hash, not the JUCE identifier DeviceInfo::uniqueId means,
+        // and capability lookups key on that field.
         if (device.fileOrIdentifier.isNotEmpty())
             device.pluginId = device.fileOrIdentifier;
 
-        // Nothing saved says whether an external plugin is an instrument, and
-        // the scan is not available here. The pad's own shape is: a Drum Grid
-        // loads a pad's instrument into the first slot and adds FX after it, so
-        // the first plugin in a pad chain is the instrument. Without this a pad
-        // whose instrument is external routes no MIDI and the pad is silent.
-        if (isPadInstrumentSlot) {
+        // Only the plugin can answer this, so the Drum Grid asks it and saves
+        // the answer. Position does not answer it: an effect can be inserted at
+        // index 0, and plugins can be moved and removed.
+        //
+        // Absent means a pad this build has not restored yet, and is left false
+        // rather than guessed: the flag drives MIDI consumption and the
+        // instrument injector, so a wrong answer misroutes the pad.
+        const auto* savedIsInstrument = node.props.getVarPointer(kPluginIsInstrument);
+        if (savedIsInstrument != nullptr && static_cast<bool>(*savedIsInstrument)) {
             device.isInstrument = true;
             device.deviceType = DeviceType::Instrument;
         }
     }
 
-    // The id the pad was saved with. A pad whose state predates it is left
-    // invalid rather than given a made-up one: the compiler reports a device it
-    // cannot key, which is a diagnosis, where a minted id would collide with a
-    // real device and be a silent wrong render.
+    // Left invalid when the state predates it. A minted id would collide with a
+    // real device and render the wrong thing silently.
     const auto* savedId = node.props.getVarPointer(kPluginDeviceId);
     if (savedId != nullptr)
         device.id = static_cast<DeviceId>(static_cast<int>(*savedId));
 
     // The engine's `enabled` is MAGDA's `bypassed`. The bridge strips it at the
-    // root because DeviceInfo owns that fact there; on a nested pad plugin it
-    // survives, and this is the DeviceInfo that owns it.
+    // root, where DeviceInfo already owns it, but keeps it on a nested plugin.
     const auto* enabled = node.props.getVarPointer(kEnabled);
     if (enabled != nullptr)
         device.bypassed = !static_cast<bool>(*enabled);
@@ -144,8 +124,8 @@ DeviceInfo deviceFromNode(const ds::Node& node, bool isPadInstrumentSlot) {
     doc.root = node;
     device.pluginState = ds::encode(doc);
 
-    // Fills the MIDI and audio capabilities the router asks about from the same
-    // cache every other device in the model is filled from.
+    // The MIDI and audio capabilities the router asks about, from the cache
+    // every other device is filled from.
     applyCachedCapabilitiesToDevice(device);
 
     return device;
@@ -182,21 +162,15 @@ ChainInfo chainFromNode(const ds::Node& node) {
     chain.bypassed = boolProp(node, kPadBypassed, false);
     chain.outputIndex = intProp(node, kBusOutput, 0);
 
-    bool firstPlugin = true;
-    for (const auto& child : node.children) {
-        if (child.type != kPlugin.toString())
-            continue;
-        chain.elements.push_back(deviceFromNode(child, firstPlugin));
-        firstPlugin = false;
-    }
+    for (const auto& child : node.children)
+        if (child.type == kPlugin.toString())
+            chain.elements.push_back(deviceFromNode(child));
 
     return chain;
 }
 
-/// The pre-v2 shape, read through the same code by turning the XML back into
-/// document nodes. A legacy tree carries engine ids and engine children that a
-/// document does not, and none of them are read here, so nothing has to strip
-/// them.
+/// Pre-v2 state, turned back into document nodes so one reader handles both.
+/// The engine ids and children a legacy tree carries are simply not read.
 ds::Node nodeFromXml(const juce::XmlElement& xml) {
     ds::Node node;
     node.type = xml.getTagName();
@@ -238,9 +212,8 @@ std::unique_ptr<RackInfo> readPadRack(const juce::String& pluginId,
     if (const auto doc = ds::decode(pluginState))
         return rackFromRoot(doc->root);
 
-    // Not a document this build reads. Only pre-v2 engine XML is worth trying:
-    // anything else, a newer schema included, has to be left alone rather than
-    // guessed at.
+    // Anything else, a newer schema included, is left alone rather than guessed
+    // at.
     if (!ds::looksLikeLegacyEngineState(pluginState))
         return nullptr;
 

--- a/magda/daw/core/DrumGridPads.cpp
+++ b/magda/daw/core/DrumGridPads.cpp
@@ -1,7 +1,9 @@
 #include "DrumGridPads.hpp"
 
 #include "DeviceState.hpp"
+#include "PluginCapabilities.hpp"
 #include "RackInfo.hpp"
+#include "audio/plugins/InternalPluginRegistry.hpp"
 
 namespace magda {
 
@@ -27,6 +29,11 @@ const juce::Identifier kPadSolo("padSolo");
 const juce::Identifier kPadBypassed("padBypassed");
 const juce::Identifier kBusOutput("busOutput");
 const juce::Identifier kType("type");
+const juce::Identifier kEnabled("enabled");
+/// The DeviceId a Drum Grid allocated for a pad's plugin and saved with it.
+/// TrackManager's id allocator already reads this same property out of pad
+/// state so a newly created device cannot be given an id a pad is using.
+const juce::Identifier kPluginDeviceId("magdaDeviceId");
 
 /// A Drum Grid writes 60 for a chain whose note range it has not been told, so
 /// that is what an absent range reads as rather than ChainInfo's own default.
@@ -35,21 +42,64 @@ const juce::Identifier kType("type");
 /// accident.
 constexpr int kFallbackNote = 60;
 
-/// One pad's device, as far as the model needs it here.
+/// One pad's device, carrying what the compiler needs to key and bind it.
 ///
-/// A pad's plugin keeps its own state as the node it was saved as, re-encoded
-/// so it reads exactly like any other device's. What it is NOT given is a
-/// DeviceId: ids are allocated by the app against a project, and a projection
-/// that minted its own would collide with them.
+/// A projected device is a real device or it is useless. The plan keys an op on
+/// the DeviceId (`OpKey`), and routes on whether the device is an instrument,
+/// consumes MIDI or is bypassed, so a device projected with those left at their
+/// defaults would give every pad the same key and route none of them: sixty-four
+/// ops that collide and a Drum Grid that still does not render.
+///
+/// None of it is invented. The DeviceId is the one the Drum Grid allocated and
+/// saved with the pad, which is why the id allocator has to read the same
+/// property; the rest comes from the plugin registry, which is where a device's
+/// identity lives for every other device in the model too.
 DeviceInfo deviceFromNode(const ds::Node& node) {
     DeviceInfo device;
-    device.pluginId = node.props[kType].toString();
-    device.name = device.pluginId;
+
+    const auto savedType = node.props[kType].toString();
+    device.pluginId = savedType;
+    device.name = savedType;
+
+    // A pad saved by an older build can name a device by a load alias rather
+    // than the id it has now, so the alias-aware lookup goes first and the
+    // canonical id is taken from whatever it resolves to.
+    const auto* spec = daw::audio::findInternalPluginSpecForLoadType(savedType);
+    if (spec == nullptr)
+        spec = daw::audio::findInternalPluginSpec(savedType);
+
+    if (spec != nullptr) {
+        if (spec->pluginId != nullptr)
+            device.pluginId = spec->pluginId;
+        if (spec->displayName != nullptr)
+            device.name = spec->displayName;
+        device.isInstrument = spec->isInstrument;
+        device.deviceType = spec->isInstrument ? DeviceType::Instrument : DeviceType::Effect;
+    }
+
+    // The id the pad was saved with. A pad whose state predates it is left
+    // invalid rather than given a made-up one: the compiler reports a device it
+    // cannot key, which is a diagnosis, where a minted id would collide with a
+    // real device and be a silent wrong render.
+    const auto* savedId = node.props.getVarPointer(kPluginDeviceId);
+    if (savedId != nullptr)
+        device.id = static_cast<DeviceId>(static_cast<int>(*savedId));
+
+    // The engine's `enabled` is MAGDA's `bypassed`. The bridge strips it at the
+    // root because DeviceInfo owns that fact there; on a nested pad plugin it
+    // survives, and this is the DeviceInfo that owns it.
+    const auto* enabled = node.props.getVarPointer(kEnabled);
+    if (enabled != nullptr)
+        device.bypassed = !static_cast<bool>(*enabled);
 
     ds::Doc doc;
     doc.deviceType = device.pluginId;
     doc.root = node;
     device.pluginState = ds::encode(doc);
+
+    // Fills the MIDI and audio capabilities the router asks about from the same
+    // cache every other device in the model is filled from.
+    applyCachedCapabilitiesToDevice(device);
 
     return device;
 }

--- a/magda/daw/core/DrumGridPads.cpp
+++ b/magda/daw/core/DrumGridPads.cpp
@@ -1,0 +1,162 @@
+#include "DrumGridPads.hpp"
+
+#include "DeviceState.hpp"
+#include "RackInfo.hpp"
+
+namespace magda {
+
+namespace {
+
+namespace ds = device_state;
+
+/// What a Drum Grid calls its own state. These are the device's property names,
+/// not the engine's: they are the same in a v2 document and in the pre-v2 XML
+/// because the bridge carries a nested tree's properties across unchanged.
+constexpr const char* kDrumGridId = "drumgrid";
+const juce::Identifier kChain("CHAIN");
+const juce::Identifier kPlugin("PLUGIN");
+const juce::Identifier kIndex("index");
+const juce::Identifier kName("name");
+const juce::Identifier kLowNote("lowNote");
+const juce::Identifier kHighNote("highNote");
+const juce::Identifier kRootNote("rootNote");
+const juce::Identifier kPadLevel("padLevel");
+const juce::Identifier kPadPan("padPan");
+const juce::Identifier kPadMute("padMute");
+const juce::Identifier kPadSolo("padSolo");
+const juce::Identifier kPadBypassed("padBypassed");
+const juce::Identifier kBusOutput("busOutput");
+const juce::Identifier kType("type");
+
+/// A Drum Grid writes 60 for a chain whose note range it has not been told, so
+/// that is what an absent range reads as rather than ChainInfo's own default.
+/// A pad always has a range: the middle-C fallback is the device's, and keeping
+/// it here means a chain restored from state never claims the whole keyboard by
+/// accident.
+constexpr int kFallbackNote = 60;
+
+/// One pad's device, as far as the model needs it here.
+///
+/// A pad's plugin keeps its own state as the node it was saved as, re-encoded
+/// so it reads exactly like any other device's. What it is NOT given is a
+/// DeviceId: ids are allocated by the app against a project, and a projection
+/// that minted its own would collide with them.
+DeviceInfo deviceFromNode(const ds::Node& node) {
+    DeviceInfo device;
+    device.pluginId = node.props[kType].toString();
+    device.name = device.pluginId;
+
+    ds::Doc doc;
+    doc.deviceType = device.pluginId;
+    doc.root = node;
+    device.pluginState = ds::encode(doc);
+
+    return device;
+}
+
+int intProp(const ds::Node& node, const juce::Identifier& id, int fallback) {
+    const auto value = node.props[id];
+    return value.isVoid() ? fallback : static_cast<int>(value);
+}
+
+float floatProp(const ds::Node& node, const juce::Identifier& id, float fallback) {
+    const auto value = node.props[id];
+    return value.isVoid() ? fallback : static_cast<float>(value);
+}
+
+bool boolProp(const ds::Node& node, const juce::Identifier& id, bool fallback) {
+    const auto value = node.props[id];
+    return value.isVoid() ? fallback : static_cast<bool>(value);
+}
+
+ChainInfo chainFromNode(const ds::Node& node) {
+    ChainInfo chain;
+    chain.id = intProp(node, kIndex, 0);
+    chain.name = node.props[kName].toString();
+
+    chain.lowNote = intProp(node, kLowNote, kFallbackNote);
+    chain.highNote = intProp(node, kHighNote, kFallbackNote);
+    chain.rootNote = intProp(node, kRootNote, kFallbackNote);
+
+    chain.volume = floatProp(node, kPadLevel, 0.0f);
+    chain.pan = floatProp(node, kPadPan, 0.0f);
+    chain.muted = boolProp(node, kPadMute, false);
+    chain.solo = boolProp(node, kPadSolo, false);
+    chain.bypassed = boolProp(node, kPadBypassed, false);
+    chain.outputIndex = intProp(node, kBusOutput, 0);
+
+    for (const auto& child : node.children)
+        if (child.type == kPlugin.toString())
+            chain.elements.push_back(deviceFromNode(child));
+
+    return chain;
+}
+
+/// The pre-v2 shape, read through the same code by turning the XML back into
+/// document nodes. A legacy tree carries engine ids and engine children that a
+/// document does not, and none of them are read here, so nothing has to strip
+/// them.
+ds::Node nodeFromXml(const juce::XmlElement& xml) {
+    ds::Node node;
+    node.type = xml.getTagName();
+
+    for (int i = 0; i < xml.getNumAttributes(); ++i)
+        node.props.set(xml.getAttributeName(i), xml.getAttributeValue(i));
+
+    for (auto* child : xml.getChildIterator())
+        if (child != nullptr)
+            node.children.push_back(nodeFromXml(*child));
+
+    return node;
+}
+
+std::unique_ptr<RackInfo> rackFromRoot(const ds::Node& root) {
+    auto rack = std::make_unique<RackInfo>();
+
+    for (const auto& child : root.children)
+        if (child.type == kChain.toString())
+            rack->chains.push_back(chainFromNode(child));
+
+    if (rack->chains.empty())
+        return nullptr;
+
+    return rack;
+}
+
+}  // namespace
+
+bool isPadRackDevice(const juce::String& pluginId) {
+    return pluginId == kDrumGridId;
+}
+
+std::unique_ptr<RackInfo> readPadRack(const juce::String& pluginId,
+                                      const juce::String& pluginState) {
+    if (!isPadRackDevice(pluginId) || pluginState.isEmpty())
+        return nullptr;
+
+    if (const auto doc = ds::decode(pluginState))
+        return rackFromRoot(doc->root);
+
+    // Not a document this build reads. Only pre-v2 engine XML is worth trying:
+    // anything else, a newer schema included, has to be left alone rather than
+    // guessed at.
+    if (!ds::looksLikeLegacyEngineState(pluginState))
+        return nullptr;
+
+    const auto xml = juce::parseXML(pluginState);
+    if (xml == nullptr)
+        return nullptr;
+
+    return rackFromRoot(nodeFromXml(*xml));
+}
+
+void refreshPadRack(DeviceInfo& device) {
+    if (!isPadRackDevice(device.pluginId)) {
+        device.padRack.reset(nullptr);
+        return;
+    }
+
+    device.padRack.reset(readPadRack(device.pluginId, device.pluginState));
+}
+
+}  // namespace magda

--- a/magda/daw/core/DrumGridPads.cpp
+++ b/magda/daw/core/DrumGridPads.cpp
@@ -29,6 +29,13 @@ const juce::Identifier kPadSolo("padSolo");
 const juce::Identifier kPadBypassed("padBypassed");
 const juce::Identifier kBusOutput("busOutput");
 const juce::Identifier kType("type");
+/// Tracktion saves every external plugin under one type name and keeps the real
+/// identity in these. `format` is the plugin format ("VST3", "AudioUnit"), NOT
+/// what `type` says.
+const juce::Identifier kExternalName("name");
+const juce::Identifier kManufacturer("manufacturer");
+const juce::Identifier kFormat("format");
+const juce::Identifier kFilename("filename");
 const juce::Identifier kEnabled("enabled");
 /// The DeviceId a Drum Grid allocated for a pad's plugin and saved with it.
 /// TrackManager's id allocator already reads this same property out of pad
@@ -54,7 +61,7 @@ constexpr int kFallbackNote = 60;
 /// saved with the pad, which is why the id allocator has to read the same
 /// property; the rest comes from the plugin registry, which is where a device's
 /// identity lives for every other device in the model too.
-DeviceInfo deviceFromNode(const ds::Node& node) {
+DeviceInfo deviceFromNode(const ds::Node& node, bool isPadInstrumentSlot) {
     DeviceInfo device;
 
     const auto savedType = node.props[kType].toString();
@@ -75,6 +82,46 @@ DeviceInfo deviceFromNode(const ds::Node& node) {
             device.name = spec->displayName;
         device.isInstrument = spec->isInstrument;
         device.deviceType = spec->isInstrument ? DeviceType::Instrument : DeviceType::Effect;
+
+        // Without this the device keeps PluginFormat's VST3 default and every
+        // path that asks reads an internal device as an external one: it would
+        // claim a floating editor window it does not have, and the creation
+        // paths would try to instantiate it from external identifiers it has
+        // never had.
+        device.format = PluginFormat::Internal;
+    } else {
+        // No spec means an external plugin. Tracktion saves all of them under
+        // one type name, so `type` identifies nothing on its own and the real
+        // identity is in the properties beside it: a pad holding Kick 2 would
+        // otherwise project as an effect called "vst".
+        const auto externalName = node.props[kExternalName].toString();
+        if (externalName.isNotEmpty())
+            device.name = externalName;
+
+        device.manufacturer = node.props[kManufacturer].toString();
+        device.fileOrIdentifier = node.props[kFilename].toString();
+        device.format = pluginFormatFromName(node.props[kFormat].toString());
+
+        // The path, not the type name. JUCE's identifier string is what the app
+        // uses for a scanned plugin and it cannot be rebuilt from what is saved
+        // here, so the file is the honest identifier; leaving the type name in
+        // place would key every external pad plugin in the project the same.
+        // uniqueId stays empty on purpose: the `uniqueId` saved here is
+        // Tracktion's own hash, not the JUCE identifier DeviceInfo::uniqueId
+        // means, and putting one where the other is expected would send every
+        // capability lookup to the wrong entry.
+        if (device.fileOrIdentifier.isNotEmpty())
+            device.pluginId = device.fileOrIdentifier;
+
+        // Nothing saved says whether an external plugin is an instrument, and
+        // the scan is not available here. The pad's own shape is: a Drum Grid
+        // loads a pad's instrument into the first slot and adds FX after it, so
+        // the first plugin in a pad chain is the instrument. Without this a pad
+        // whose instrument is external routes no MIDI and the pad is silent.
+        if (isPadInstrumentSlot) {
+            device.isInstrument = true;
+            device.deviceType = DeviceType::Instrument;
+        }
     }
 
     // The id the pad was saved with. A pad whose state predates it is left
@@ -135,9 +182,13 @@ ChainInfo chainFromNode(const ds::Node& node) {
     chain.bypassed = boolProp(node, kPadBypassed, false);
     chain.outputIndex = intProp(node, kBusOutput, 0);
 
-    for (const auto& child : node.children)
-        if (child.type == kPlugin.toString())
-            chain.elements.push_back(deviceFromNode(child));
+    bool firstPlugin = true;
+    for (const auto& child : node.children) {
+        if (child.type != kPlugin.toString())
+            continue;
+        chain.elements.push_back(deviceFromNode(child, firstPlugin));
+        firstPlugin = false;
+    }
 
     return chain;
 }

--- a/magda/daw/core/DrumGridPads.hpp
+++ b/magda/daw/core/DrumGridPads.hpp
@@ -10,36 +10,26 @@ struct DeviceInfo;
 struct RackInfo;
 
 /**
- * Reading a pad-per-chain device's pads out of its saved state (#2192).
+ * A pad-per-chain device's pads, read out of its saved state as chains (#2192).
  *
- * A Drum Grid's pads are saved inside the device's own state rather than in the
- * chain model, so nothing outside the device could see them: the plan compiler
- * could not expand a Drum Grid the way it expands a rack, and the whole device
- * stopped at a Device op that no native engine could bind.
+ * A Drum Grid saves its pads inside its own device state, so the plan compiler
+ * cannot expand one the way it expands a rack. The state is already engine
+ * neutral; what it is not is typed, so this turns its property bag into the
+ * chains the compiler wants.
  *
- * The pads are not engine XML any more. A v2 device state document is
- * MAGDA-defined and engine-neutral, and its `root` is where a device's
- * non-parameter state lives -- drum-pad chains included. What is missing is not
- * neutral storage but a typed view: `root` is a property bag, and the compiler
- * wants chains. That is what this produces.
- *
- * It is a projection, not a second copy. Nothing here is serialized separately,
- * so a project file keeps one set of pads and no existing project changes shape.
+ * A projection, not a second copy: nothing here is serialized separately and no
+ * project file changes shape.
  */
 
 /// The pads saved for `pluginId` in `pluginState`, as a rack of chains.
 ///
-/// Null when the device is not a pad-per-chain device, when it has no pads
-/// saved, and when the state cannot be read. Reads both a v2 document and the
-/// pre-v2 engine XML, because projects on disk still carry either.
+/// Null for a device that is not pad-per-chain, one with no pads saved, and
+/// state that cannot be read. Handles both a v2 document and pre-v2 engine XML.
 std::unique_ptr<RackInfo> readPadRack(const juce::String& pluginId,
                                       const juce::String& pluginState);
 
-/// Point `device.padRack` at whatever `device.pluginState` currently holds.
-///
-/// Clears it for a device with no pads, so a device that loses them does not
-/// keep a stale set. Cheap enough to call on any device: it does no parsing at
-/// all unless the id is one that has pads.
+/// Point `device.padRack` at whatever `device.pluginState` currently holds,
+/// clearing it for a device with no pads. Parses nothing unless the id has pads.
 void refreshPadRack(DeviceInfo& device);
 
 /// True when devices of this type keep their chains as pads.

--- a/magda/daw/core/DrumGridPads.hpp
+++ b/magda/daw/core/DrumGridPads.hpp
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <juce_core/juce_core.h>
+
+#include <memory>
+
+namespace magda {
+
+struct DeviceInfo;
+struct RackInfo;
+
+/**
+ * Reading a pad-per-chain device's pads out of its saved state (#2192).
+ *
+ * A Drum Grid's pads are saved inside the device's own state rather than in the
+ * chain model, so nothing outside the device could see them: the plan compiler
+ * could not expand a Drum Grid the way it expands a rack, and the whole device
+ * stopped at a Device op that no native engine could bind.
+ *
+ * The pads are not engine XML any more. A v2 device state document is
+ * MAGDA-defined and engine-neutral, and its `root` is where a device's
+ * non-parameter state lives -- drum-pad chains included. What is missing is not
+ * neutral storage but a typed view: `root` is a property bag, and the compiler
+ * wants chains. That is what this produces.
+ *
+ * It is a projection, not a second copy. Nothing here is serialized separately,
+ * so a project file keeps one set of pads and no existing project changes shape.
+ */
+
+/// The pads saved for `pluginId` in `pluginState`, as a rack of chains.
+///
+/// Null when the device is not a pad-per-chain device, when it has no pads
+/// saved, and when the state cannot be read. Reads both a v2 document and the
+/// pre-v2 engine XML, because projects on disk still carry either.
+std::unique_ptr<RackInfo> readPadRack(const juce::String& pluginId,
+                                      const juce::String& pluginState);
+
+/// Point `device.padRack` at whatever `device.pluginState` currently holds.
+///
+/// Clears it for a device with no pads, so a device that loses them does not
+/// keep a stale set. Cheap enough to call on any device: it does no parsing at
+/// all unless the id is one that has pads.
+void refreshPadRack(DeviceInfo& device);
+
+/// True when devices of this type keep their chains as pads.
+bool isPadRackDevice(const juce::String& pluginId);
+
+}  // namespace magda

--- a/magda/daw/core/RackInfo.hpp
+++ b/magda/daw/core/RackInfo.hpp
@@ -108,6 +108,9 @@ struct ChainInfo {
           bypassed(other.bypassed),
           volume(other.volume),
           pan(other.pan),
+          lowNote(other.lowNote),
+          highNote(other.highNote),
+          rootNote(other.rootNote),
           expanded(other.expanded) {
         elements.reserve(other.elements.size());
         for (const auto& element : other.elements) {
@@ -126,6 +129,9 @@ struct ChainInfo {
             bypassed = other.bypassed;
             volume = other.volume;
             pan = other.pan;
+            lowNote = other.lowNote;
+            highNote = other.highNote;
+            rootNote = other.rootNote;
             expanded = other.expanded;
             elements.clear();
             elements.reserve(other.elements.size());

--- a/magda/daw/project/serialization/TrackSerializer.cpp
+++ b/magda/daw/project/serialization/TrackSerializer.cpp
@@ -2,6 +2,7 @@
 
 #include "../../audio/plugins/InternalPluginRegistry.hpp"
 #include "../../core/DeviceParamMigrations.hpp"
+#include "../../core/DrumGridPads.hpp"
 #include "../../core/PluginCapabilities.hpp"
 #include "../../core/ViewModeState.hpp"
 #include "ProjectSerializer.hpp"
@@ -752,6 +753,11 @@ bool ProjectSerializer::deserializeDeviceInfo(const juce::var& json, DeviceInfo&
     // Plugin native state
     if (obj->hasProperty("pluginState"))
         outDevice.pluginState = obj->getProperty("pluginState").toString();
+
+    // A pad-per-chain device keeps its pads inside that state. Project the
+    // model's view of them now the state is in hand, so the compiler can expand
+    // a Drum Grid rather than stopping at it (#2192).
+    refreshPadRack(outDevice);
 
     // Per-instance drum kit rows
     auto kitVar = obj->getProperty("kitRows");

--- a/magda/daw/project/serialization/TrackSerializer.cpp
+++ b/magda/daw/project/serialization/TrackSerializer.cpp
@@ -754,9 +754,7 @@ bool ProjectSerializer::deserializeDeviceInfo(const juce::var& json, DeviceInfo&
     if (obj->hasProperty("pluginState"))
         outDevice.pluginState = obj->getProperty("pluginState").toString();
 
-    // A pad-per-chain device keeps its pads inside that state. Project the
-    // model's view of them now the state is in hand, so the compiler can expand
-    // a Drum Grid rather than stopping at it (#2192).
+    // A pad-per-chain device keeps its pads inside that state (#2192).
     refreshPadRack(outDevice);
 
     // Per-instance drum kit rows

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -34,6 +34,7 @@ set(TEST_SOURCES
     test_control_target.cpp
     test_tempo_sequence_ripple_math.cpp
     test_chain_fingerprint.cpp
+    test_chain_info_copy.cpp
     test_chain_routing_model.cpp
     test_post_fx_chain.cpp
     test_group_tracks_and_macros.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -35,6 +35,8 @@ set(TEST_SOURCES
     test_tempo_sequence_ripple_math.cpp
     test_chain_fingerprint.cpp
     test_chain_info_copy.cpp
+    test_drum_grid_pads.cpp
+    test_drum_grid_pads_corpus.cpp
     test_chain_routing_model.cpp
     test_post_fx_chain.cpp
     test_group_tracks_and_macros.cpp

--- a/tests/test_chain_info_copy.cpp
+++ b/tests/test_chain_info_copy.cpp
@@ -1,0 +1,102 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "magda/daw/core/RackInfo.hpp"
+
+// ChainInfo copies through hand-written operations, because a chain element can
+// be a nested rack held by unique_ptr and that has to be deep copied. Every
+// other field has to be listed by hand there, and one that is forgotten is lost
+// silently on the first copy rather than failing to build.
+//
+// The note range was forgotten exactly that way when pads arrived (#2192): a
+// DeviceInfo is copied by value all over the app, so every pad in a copied
+// padRack came back answering to every note instead of its own.
+//
+// This sets every field to something that is not its default and copies both
+// ways. A field added to ChainInfo and not to the copy operations fails here.
+
+namespace {
+
+magda::ChainInfo makeFullyPopulatedChain() {
+    magda::ChainInfo chain;
+    chain.id = 42;
+    chain.name = "Snare";
+    chain.outputIndex = 3;
+    chain.muted = true;
+    chain.solo = true;
+    chain.bypassed = true;
+    chain.volume = -6.0f;
+    chain.pan = -0.5f;
+    chain.lowNote = 38;
+    chain.highNote = 40;
+    chain.rootNote = 39;
+    chain.expanded = false;
+
+    magda::DeviceInfo device;
+    device.id = 7;
+    device.name = "Sampler";
+    chain.elements.push_back(device);
+
+    auto nested = std::make_unique<magda::RackInfo>();
+    nested->id = 5;
+    nested->name = "Pad FX";
+    chain.elements.push_back(std::move(nested));
+
+    return chain;
+}
+
+void requireCarriesEverything(const magda::ChainInfo& copy) {
+    CHECK(copy.id == 42);
+    CHECK(copy.name == "Snare");
+    CHECK(copy.outputIndex == 3);
+    CHECK(copy.muted);
+    CHECK(copy.solo);
+    CHECK(copy.bypassed);
+    CHECK(copy.volume == -6.0f);
+    CHECK(copy.pan == -0.5f);
+    CHECK(copy.lowNote == 38);
+    CHECK(copy.highNote == 40);
+    CHECK(copy.rootNote == 39);
+    CHECK_FALSE(copy.expanded);
+    CHECK_FALSE(copy.answersToEveryNote());
+
+    REQUIRE(copy.elements.size() == 2);
+    REQUIRE(magda::isDevice(copy.elements[0]));
+    CHECK(magda::getDevice(copy.elements[0]).id == 7);
+    REQUIRE(magda::isRack(copy.elements[1]));
+    CHECK(magda::getRack(copy.elements[1]).id == 5);
+}
+
+}  // namespace
+
+TEST_CASE("ChainInfo copy construction carries every field", "[chain][rack]") {
+    const auto original = makeFullyPopulatedChain();
+    const magda::ChainInfo copy(original);
+    requireCarriesEverything(copy);
+}
+
+TEST_CASE("ChainInfo copy assignment carries every field", "[chain][rack]") {
+    const auto original = makeFullyPopulatedChain();
+    magda::ChainInfo copy;
+    copy = original;
+    requireCarriesEverything(copy);
+}
+
+TEST_CASE("ChainInfo copies the nested rack rather than sharing it", "[chain][rack]") {
+    const auto original = makeFullyPopulatedChain();
+    magda::ChainInfo copy(original);
+
+    REQUIRE(magda::isRack(copy.elements[1]));
+    REQUIRE(magda::isRack(original.elements[1]));
+    CHECK(&magda::getRack(copy.elements[1]) != &magda::getRack(original.elements[1]));
+
+    magda::getRack(copy.elements[1]).name = "Changed";
+    CHECK(magda::getRack(original.elements[1]).name == "Pad FX");
+}
+
+TEST_CASE("A chain with no note range answers to every note", "[chain][rack]") {
+    const magda::ChainInfo plain;
+    CHECK(plain.answersToEveryNote());
+
+    const magda::ChainInfo copy(plain);
+    CHECK(copy.answersToEveryNote());
+}

--- a/tests/test_chain_info_copy.cpp
+++ b/tests/test_chain_info_copy.cpp
@@ -2,17 +2,13 @@
 
 #include "magda/daw/core/RackInfo.hpp"
 
-// ChainInfo copies through hand-written operations, because a chain element can
-// be a nested rack held by unique_ptr and that has to be deep copied. Every
-// other field has to be listed by hand there, and one that is forgotten is lost
-// silently on the first copy rather than failing to build.
+// ChainInfo's copy operations are hand written, because a chain element can be a
+// nested rack held by unique_ptr. Every other field is listed by hand there, and
+// a forgotten one is lost silently rather than failing to build: the note range
+// was, when pads arrived (#2192).
 //
-// The note range was forgotten exactly that way when pads arrived (#2192): a
-// DeviceInfo is copied by value all over the app, so every pad in a copied
-// padRack came back answering to every note instead of its own.
-//
-// This sets every field to something that is not its default and copies both
-// ways. A field added to ChainInfo and not to the copy operations fails here.
+// Every field is set to something that is not its default and copied both ways,
+// so the next field forgotten there fails here.
 
 namespace {
 

--- a/tests/test_drum_grid_pads.cpp
+++ b/tests/test_drum_grid_pads.cpp
@@ -1,0 +1,152 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "magda/daw/core/DeviceInfo.hpp"
+#include "magda/daw/core/DeviceState.hpp"
+#include "magda/daw/core/DrumGridPads.hpp"
+#include "magda/daw/core/RackInfo.hpp"
+
+// Reading a Drum Grid's pads out of its saved state into the model (#2192).
+//
+// Both shapes a project on disk can carry are covered: the v2 device state
+// document this build writes, and the pre-v2 engine XML that older projects
+// still hold.
+
+namespace {
+
+namespace ds = magda::device_state;
+
+ds::Node padNode(int index, int lowNote, int highNote, int rootNote) {
+    ds::Node node;
+    node.type = "CHAIN";
+    node.props.set("index", index);
+    node.props.set("name", "Pad " + juce::String(index));
+    node.props.set("lowNote", lowNote);
+    node.props.set("highNote", highNote);
+    node.props.set("rootNote", rootNote);
+    node.props.set("padLevel", -3.0f);
+    node.props.set("padPan", 0.25f);
+    node.props.set("padMute", true);
+    node.props.set("padSolo", false);
+    node.props.set("padBypassed", true);
+    node.props.set("busOutput", 2);
+
+    ds::Node plugin;
+    plugin.type = "PLUGIN";
+    plugin.props.set("type", "magdasampler");
+    node.children.push_back(plugin);
+
+    return node;
+}
+
+juce::String encodedDrumGridWithPads() {
+    ds::Doc doc;
+    doc.deviceType = "drumgrid";
+    doc.root.type = "PLUGIN";
+    doc.root.children.push_back(padNode(0, 36, 36, 36));
+    doc.root.children.push_back(padNode(1, 38, 40, 39));
+    return ds::encode(doc);
+}
+
+}  // namespace
+
+TEST_CASE("A Drum Grid's pads are read out of a v2 document", "[drumgrid][pads]") {
+    const auto rack = magda::readPadRack("drumgrid", encodedDrumGridWithPads());
+
+    REQUIRE(rack != nullptr);
+    REQUIRE(rack->chains.size() == 2);
+
+    const auto& second = rack->chains[1];
+    CHECK(second.name == "Pad 1");
+    CHECK(second.lowNote == 38);
+    CHECK(second.highNote == 40);
+    CHECK(second.rootNote == 39);
+    CHECK_FALSE(second.answersToEveryNote());
+
+    CHECK(second.volume == -3.0f);
+    CHECK(second.pan == 0.25f);
+    CHECK(second.muted);
+    CHECK_FALSE(second.solo);
+    CHECK(second.bypassed);
+    CHECK(second.outputIndex == 2);
+
+    REQUIRE(second.elements.size() == 1);
+    REQUIRE(magda::isDevice(second.elements[0]));
+    CHECK(magda::getDevice(second.elements[0]).pluginId == "magdasampler");
+}
+
+TEST_CASE("A Drum Grid's pads are read out of pre-v2 engine XML", "[drumgrid][pads]") {
+    const juce::String legacy = R"(<PLUGIN type="drumgrid" id="1234">
+  <CHAIN index="0" name="Kick" lowNote="36" highNote="36" rootNote="36"
+         padLevel="-6.0" padPan="-0.5" padMute="0" padSolo="1"
+         padBypassed="0" busOutput="1">
+    <PLUGIN type="magdasampler" id="5678"/>
+  </CHAIN>
+</PLUGIN>)";
+
+    const auto rack = magda::readPadRack("drumgrid", legacy);
+
+    REQUIRE(rack != nullptr);
+    REQUIRE(rack->chains.size() == 1);
+
+    const auto& pad = rack->chains[0];
+    CHECK(pad.name == "Kick");
+    CHECK(pad.lowNote == 36);
+    CHECK(pad.highNote == 36);
+    CHECK(pad.rootNote == 36);
+    CHECK(pad.volume == -6.0f);
+    CHECK(pad.pan == -0.5f);
+    CHECK_FALSE(pad.muted);
+    CHECK(pad.solo);
+    CHECK(pad.outputIndex == 1);
+
+    REQUIRE(pad.elements.size() == 1);
+    CHECK(magda::getDevice(pad.elements[0]).pluginId == "magdasampler");
+}
+
+TEST_CASE("A device that is not a Drum Grid has no pads", "[drumgrid][pads]") {
+    CHECK(magda::readPadRack("magda_reverb", encodedDrumGridWithPads()) == nullptr);
+    CHECK(magda::readPadRack("drumgrid", "") == nullptr);
+    CHECK(magda::readPadRack("drumgrid", "not a document at all") == nullptr);
+    CHECK_FALSE(magda::isPadRackDevice("magda_reverb"));
+    CHECK(magda::isPadRackDevice("drumgrid"));
+}
+
+TEST_CASE("A Drum Grid with no chains saved yields no pad rack", "[drumgrid][pads]") {
+    ds::Doc doc;
+    doc.deviceType = "drumgrid";
+    doc.root.type = "PLUGIN";
+    CHECK(magda::readPadRack("drumgrid", ds::encode(doc)) == nullptr);
+}
+
+TEST_CASE("refreshPadRack projects and clears a device's pads", "[drumgrid][pads]") {
+    magda::DeviceInfo device;
+    device.pluginId = "drumgrid";
+    device.pluginState = encodedDrumGridWithPads();
+
+    magda::refreshPadRack(device);
+    REQUIRE(static_cast<bool>(device.padRack));
+    CHECK(device.padRack->chains.size() == 2);
+
+    // A device that stops being a Drum Grid must not keep the pads it had.
+    device.pluginId = "magda_reverb";
+    magda::refreshPadRack(device);
+    CHECK_FALSE(static_cast<bool>(device.padRack));
+}
+
+TEST_CASE("A copied device does not share its pads", "[drumgrid][pads]") {
+    magda::DeviceInfo device;
+    device.pluginId = "drumgrid";
+    device.pluginState = encodedDrumGridWithPads();
+    magda::refreshPadRack(device);
+
+    magda::DeviceInfo copy = device;
+    REQUIRE(static_cast<bool>(copy.padRack));
+    CHECK(copy.padRack.get() != device.padRack.get());
+
+    // The note range has to survive the copy: a pad that came back answering to
+    // every note would silently claim the whole keyboard.
+    REQUIRE(copy.padRack->chains.size() == 2);
+    CHECK(copy.padRack->chains[1].lowNote == 38);
+    CHECK(copy.padRack->chains[1].highNote == 40);
+    CHECK_FALSE(copy.padRack->chains[1].answersToEveryNote());
+}

--- a/tests/test_drum_grid_pads.cpp
+++ b/tests/test_drum_grid_pads.cpp
@@ -194,3 +194,90 @@ TEST_CASE("A copied device does not share its pads", "[drumgrid][pads]") {
     CHECK(copy.padRack->chains[1].highNote == 40);
     CHECK_FALSE(copy.padRack->chains[1].answersToEveryNote());
 }
+
+TEST_CASE("A projected internal pad device is internal", "[drumgrid][pads]") {
+    const auto rack = magda::readPadRack("drumgrid", encodedDrumGridWithPads());
+    REQUIRE(rack != nullptr);
+
+    const auto& device = magda::getDevice(rack->chains[0].elements[0]);
+
+    // Left at PluginFormat's VST3 default, an internal device claims a floating
+    // editor window it does not have and the creation paths try to instantiate
+    // it from external identifiers it has never had.
+    CHECK(device.format == magda::PluginFormat::Internal);
+    CHECK_FALSE(device.hasEditorWindow());
+    CHECK(device.getFormatString() == "Internal");
+}
+
+TEST_CASE("An external pad plugin keeps its real identity", "[drumgrid][pads]") {
+    ds::Doc doc;
+    doc.deviceType = "drumgrid";
+    doc.root.type = "PLUGIN";
+
+    auto pad = padNode(0, 36, 36, 36);
+    pad.children.clear();
+
+    // What Tracktion actually saves: one type name for every external plugin,
+    // with the format and the identity in the properties beside it.
+    ds::Node external;
+    external.type = "PLUGIN";
+    external.props.set("type", "vst");
+    external.props.set("name", "Kick 2");
+    external.props.set("manufacturer", "Sonic Academy");
+    external.props.set("format", "VST3");
+    external.props.set("filename", "/Plug-Ins/VST3/Kick 2.vst3");
+    external.props.set("uniqueId", "db742358");
+    external.props.set("magdaDeviceId", 1020);
+    pad.children.push_back(external);
+    doc.root.children.push_back(pad);
+
+    const auto rack = magda::readPadRack("drumgrid", ds::encode(doc));
+    REQUIRE(rack != nullptr);
+    REQUIRE(rack->chains[0].elements.size() == 1);
+
+    const auto& device = magda::getDevice(rack->chains[0].elements[0]);
+    CHECK(device.name == "Kick 2");
+    CHECK(device.manufacturer == "Sonic Academy");
+    CHECK(device.format == magda::PluginFormat::VST3);
+    CHECK(device.fileOrIdentifier == "/Plug-Ins/VST3/Kick 2.vst3");
+    CHECK(device.id == 1020);
+
+    // The type name identifies nothing: every external plugin in the project
+    // carries the same one.
+    CHECK(device.pluginId != "vst");
+    CHECK(device.pluginId.isNotEmpty());
+
+    // Tracktion's own hash is not the JUCE identifier DeviceInfo::uniqueId
+    // means, so it must not be copied into it.
+    CHECK(device.uniqueId != "db742358");
+
+    // A pad's first plugin is its instrument. Without this the pad routes no
+    // MIDI and is silent.
+    CHECK(device.isInstrument);
+    CHECK(device.deviceType == magda::DeviceType::Instrument);
+}
+
+TEST_CASE("An external effect after a pad's instrument is not an instrument", "[drumgrid][pads]") {
+    ds::Doc doc;
+    doc.deviceType = "drumgrid";
+    doc.root.type = "PLUGIN";
+
+    auto pad = padNode(0, 36, 36, 36);
+    ds::Node fx;
+    fx.type = "PLUGIN";
+    fx.props.set("type", "vst");
+    fx.props.set("name", "Pro-Q 4");
+    fx.props.set("format", "VST3");
+    fx.props.set("filename", "/Plug-Ins/VST3/FabFilter Pro-Q 4.vst3");
+    pad.children.push_back(fx);
+    doc.root.children.push_back(pad);
+
+    const auto rack = magda::readPadRack("drumgrid", ds::encode(doc));
+    REQUIRE(rack != nullptr);
+    REQUIRE(rack->chains[0].elements.size() == 2);
+
+    const auto& effect = magda::getDevice(rack->chains[0].elements[1]);
+    CHECK(effect.name == "Pro-Q 4");
+    CHECK_FALSE(effect.isInstrument);
+    CHECK(effect.deviceType == magda::DeviceType::Effect);
+}

--- a/tests/test_drum_grid_pads.cpp
+++ b/tests/test_drum_grid_pads.cpp
@@ -1,4 +1,5 @@
 #include <catch2/catch_test_macros.hpp>
+#include <set>
 
 #include "magda/daw/core/DeviceInfo.hpp"
 #include "magda/daw/core/DeviceState.hpp"
@@ -33,6 +34,8 @@ ds::Node padNode(int index, int lowNote, int highNote, int rootNote) {
     ds::Node plugin;
     plugin.type = "PLUGIN";
     plugin.props.set("type", "magdasampler");
+    plugin.props.set("magdaDeviceId", 900 + index);
+    plugin.props.set("enabled", false);
     node.children.push_back(plugin);
 
     return node;
@@ -71,7 +74,48 @@ TEST_CASE("A Drum Grid's pads are read out of a v2 document", "[drumgrid][pads]"
 
     REQUIRE(second.elements.size() == 1);
     REQUIRE(magda::isDevice(second.elements[0]));
-    CHECK(magda::getDevice(second.elements[0]).pluginId == "magdasampler");
+
+    // A projected device has to be a real one. The plan keys an op on the
+    // DeviceId and routes on the instrument flag, so a pad device that kept the
+    // defaults would collide with every other pad and route nowhere.
+    const auto& padDevice = magda::getDevice(second.elements[0]);
+    CHECK(padDevice.pluginId == "magdasampler");
+    CHECK(padDevice.id == 901);
+    CHECK(padDevice.isInstrument);
+    CHECK(padDevice.deviceType == magda::DeviceType::Instrument);
+    CHECK(padDevice.bypassed);
+    CHECK(padDevice.name == "Sampler");
+}
+
+TEST_CASE("Each pad's device keeps its own id", "[drumgrid][pads]") {
+    const auto rack = magda::readPadRack("drumgrid", encodedDrumGridWithPads());
+    REQUIRE(rack != nullptr);
+    REQUIRE(rack->chains.size() == 2);
+
+    std::set<magda::DeviceId> ids;
+    for (const auto& chain : rack->chains) {
+        REQUIRE(chain.elements.size() == 1);
+        ids.insert(magda::getDevice(chain.elements[0]).id);
+    }
+
+    CHECK(ids.size() == 2);
+    CHECK(ids.count(magda::INVALID_DEVICE_ID) == 0);
+}
+
+TEST_CASE("A pad device saved with no id stays invalid rather than inventing one",
+          "[drumgrid][pads]") {
+    ds::Doc doc;
+    doc.deviceType = "drumgrid";
+    doc.root.type = "PLUGIN";
+
+    auto pad = padNode(0, 36, 36, 36);
+    pad.children[0].props.remove("magdaDeviceId");
+    doc.root.children.push_back(pad);
+
+    const auto rack = magda::readPadRack("drumgrid", ds::encode(doc));
+    REQUIRE(rack != nullptr);
+    REQUIRE(rack->chains[0].elements.size() == 1);
+    CHECK(magda::getDevice(rack->chains[0].elements[0]).id == magda::INVALID_DEVICE_ID);
 }
 
 TEST_CASE("A Drum Grid's pads are read out of pre-v2 engine XML", "[drumgrid][pads]") {

--- a/tests/test_drum_grid_pads.cpp
+++ b/tests/test_drum_grid_pads.cpp
@@ -228,6 +228,7 @@ TEST_CASE("An external pad plugin keeps its real identity", "[drumgrid][pads]") 
     external.props.set("filename", "/Plug-Ins/VST3/Kick 2.vst3");
     external.props.set("uniqueId", "db742358");
     external.props.set("magdaDeviceId", 1020);
+    external.props.set("magdaIsInstrument", true);
     pad.children.push_back(external);
     doc.root.children.push_back(pad);
 
@@ -251,13 +252,11 @@ TEST_CASE("An external pad plugin keeps its real identity", "[drumgrid][pads]") 
     // means, so it must not be copied into it.
     CHECK(device.uniqueId != "db742358");
 
-    // A pad's first plugin is its instrument. Without this the pad routes no
-    // MIDI and is silent.
     CHECK(device.isInstrument);
     CHECK(device.deviceType == magda::DeviceType::Instrument);
 }
 
-TEST_CASE("An external effect after a pad's instrument is not an instrument", "[drumgrid][pads]") {
+TEST_CASE("An external effect in a pad is not an instrument", "[drumgrid][pads]") {
     ds::Doc doc;
     doc.deviceType = "drumgrid";
     doc.root.type = "PLUGIN";
@@ -280,4 +279,74 @@ TEST_CASE("An external effect after a pad's instrument is not an instrument", "[
     CHECK(effect.name == "Pro-Q 4");
     CHECK_FALSE(effect.isInstrument);
     CHECK(effect.deviceType == magda::DeviceType::Effect);
+}
+
+TEST_CASE("A pad's instrument is found by its flag, not its position", "[drumgrid][pads]") {
+    // The model lets an effect be inserted at index 0, and lets plugins be moved
+    // and removed. Reading position as the instrument would have this EQ
+    // consuming the pad's MIDI and the sampler under it treated as an effect.
+    ds::Doc doc;
+    doc.deviceType = "drumgrid";
+    doc.root.type = "PLUGIN";
+
+    auto pad = padNode(0, 36, 36, 36);
+    pad.children.clear();
+
+    ds::Node effect;
+    effect.type = "PLUGIN";
+    effect.props.set("type", "vst");
+    effect.props.set("name", "Pro-Q 4");
+    effect.props.set("format", "VST3");
+    effect.props.set("filename", "/Plug-Ins/VST3/Pro-Q 4.vst3");
+    effect.props.set("magdaIsInstrument", false);
+    pad.children.push_back(effect);
+
+    ds::Node instrument;
+    instrument.type = "PLUGIN";
+    instrument.props.set("type", "vst");
+    instrument.props.set("name", "Kick 2");
+    instrument.props.set("format", "VST3");
+    instrument.props.set("filename", "/Plug-Ins/VST3/Kick 2.vst3");
+    instrument.props.set("magdaIsInstrument", true);
+    pad.children.push_back(instrument);
+
+    doc.root.children.push_back(pad);
+
+    const auto rack = magda::readPadRack("drumgrid", ds::encode(doc));
+    REQUIRE(rack != nullptr);
+    REQUIRE(rack->chains[0].elements.size() == 2);
+
+    const auto& first = magda::getDevice(rack->chains[0].elements[0]);
+    CHECK(first.name == "Pro-Q 4");
+    CHECK_FALSE(first.isInstrument);
+    CHECK(first.deviceType == magda::DeviceType::Effect);
+
+    const auto& second = magda::getDevice(rack->chains[0].elements[1]);
+    CHECK(second.name == "Kick 2");
+    CHECK(second.isInstrument);
+    CHECK(second.deviceType == magda::DeviceType::Instrument);
+}
+
+TEST_CASE("An external pad plugin with no saved flag is not called an instrument",
+          "[drumgrid][pads]") {
+    // A wrong answer misroutes the pad; a missing one is a device the compiler
+    // can report.
+    ds::Doc doc;
+    doc.deviceType = "drumgrid";
+    doc.root.type = "PLUGIN";
+
+    auto pad = padNode(0, 36, 36, 36);
+    pad.children.clear();
+
+    ds::Node unknown;
+    unknown.type = "PLUGIN";
+    unknown.props.set("type", "vst");
+    unknown.props.set("name", "Kick 2");
+    unknown.props.set("filename", "/Plug-Ins/VST3/Kick 2.vst3");
+    pad.children.push_back(unknown);
+    doc.root.children.push_back(pad);
+
+    const auto rack = magda::readPadRack("drumgrid", ds::encode(doc));
+    REQUIRE(rack != nullptr);
+    CHECK_FALSE(magda::getDevice(rack->chains[0].elements[0]).isInstrument);
 }

--- a/tests/test_drum_grid_pads_corpus.cpp
+++ b/tests/test_drum_grid_pads_corpus.cpp
@@ -8,12 +8,9 @@
 #include "magda/daw/core/TrackInfo.hpp"
 #include "magda/daw/project/serialization/ProjectSerializer.hpp"
 
-// The pad projection against real files (#2192).
-//
-// The synthetic cases in test_drum_grid_pads.cpp fix the shape; these fix the
-// fact that released builds actually wrote that shape. Two projects in the
-// legacy corpus carry a Drum Grid, saved four minor versions apart, and one of
-// them has it inside a rack.
+// The pad projection against real files (#2192). test_drum_grid_pads.cpp fixes
+// the shape; these fix that released builds actually wrote it. Two corpus
+// projects carry a Drum Grid, four minor versions apart, one of them racked.
 
 namespace {
 
@@ -99,13 +96,13 @@ void requirePadsAreReal(const magda::DeviceInfo& drumGrid) {
                 CHECK(device.fileOrIdentifier.isNotEmpty());
         }
 
-        // A pad makes sound through its first plugin, so that one has to arrive
-        // as an instrument whether it is one of MAGDA's or a scanned plugin.
-        if (!pad.elements.empty()) {
-            const auto& first = magda::getDevice(pad.elements[0]);
-            INFO("pad instrument " << first.name);
-            CHECK(first.isInstrument);
-        }
+        // At most one instrument per pad. Position does not decide which, so
+        // two would mean the flag is being read off the wrong thing.
+        int instruments = 0;
+        for (const auto& element : pad.elements)
+            if (magda::getDevice(element).isInstrument)
+                ++instruments;
+        CHECK(instruments <= 1);
     }
 
     // A DeviceId is not a load-time fact for these files. A Drum Grid allocates

--- a/tests/test_drum_grid_pads_corpus.cpp
+++ b/tests/test_drum_grid_pads_corpus.cpp
@@ -2,6 +2,7 @@
 #include <set>
 
 #include "LegacyCorpus.hpp"
+#include "magda/daw/audio/plugins/InternalPluginRegistry.hpp"
 #include "magda/daw/core/DrumGridPads.hpp"
 #include "magda/daw/core/RackInfo.hpp"
 #include "magda/daw/core/TrackInfo.hpp"
@@ -76,8 +77,34 @@ void requirePadsAreReal(const magda::DeviceInfo& drumGrid) {
         for (const auto& element : pad.elements) {
             REQUIRE(magda::isDevice(element));
             const auto& device = magda::getDevice(element);
-            INFO("pad device " << device.pluginId);
+            INFO("pad device " << device.name << " / " << device.pluginId);
             CHECK(device.pluginId.isNotEmpty());
+
+            // Non-empty is not enough, and checking only that is what let the
+            // real external plugins in this corpus project through as an effect
+            // called "vst". Tracktion saves every external plugin under that one
+            // type name, so it identifies nothing and must never survive as
+            // either the id or the display name.
+            CHECK(device.pluginId != "vst");
+            CHECK(device.name != "vst");
+            CHECK(device.name.isNotEmpty());
+
+            // Internal and external are the two cases, and each has to come out
+            // as itself: an internal device left on PluginFormat's VST3 default
+            // claims an editor window it has not got, and an external one needs
+            // the file it was loaded from.
+            if (magda::daw::audio::findInternalPluginSpec(device.pluginId) != nullptr)
+                CHECK(device.format == magda::PluginFormat::Internal);
+            else
+                CHECK(device.fileOrIdentifier.isNotEmpty());
+        }
+
+        // A pad makes sound through its first plugin, so that one has to arrive
+        // as an instrument whether it is one of MAGDA's or a scanned plugin.
+        if (!pad.elements.empty()) {
+            const auto& first = magda::getDevice(pad.elements[0]);
+            INFO("pad instrument " << first.name);
+            CHECK(first.isInstrument);
         }
     }
 

--- a/tests/test_drum_grid_pads_corpus.cpp
+++ b/tests/test_drum_grid_pads_corpus.cpp
@@ -1,0 +1,100 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "LegacyCorpus.hpp"
+#include "magda/daw/core/DrumGridPads.hpp"
+#include "magda/daw/core/RackInfo.hpp"
+#include "magda/daw/core/TrackInfo.hpp"
+#include "magda/daw/project/serialization/ProjectSerializer.hpp"
+
+// The pad projection against real files (#2192).
+//
+// The synthetic cases in test_drum_grid_pads.cpp fix the shape; these fix the
+// fact that released builds actually wrote that shape. Two projects in the
+// legacy corpus carry a Drum Grid, saved four minor versions apart, and one of
+// them has it inside a rack.
+
+namespace {
+
+void collectDrumGrids(const std::vector<magda::ChainElement>& elements,
+                      std::vector<const magda::DeviceInfo*>& out) {
+    for (const auto& element : elements) {
+        if (magda::isDevice(element)) {
+            const auto& device = magda::getDevice(element);
+            if (magda::isPadRackDevice(device.pluginId))
+                out.push_back(&device);
+            continue;
+        }
+
+        for (const auto& chain : magda::getRack(element).chains)
+            collectDrumGrids(chain.elements, out);
+    }
+}
+
+std::vector<const magda::DeviceInfo*> drumGridsIn(const magda::StagedProjectData& staged) {
+    std::vector<const magda::DeviceInfo*> out;
+    for (const auto& track : staged.tracks) {
+        collectDrumGrids(track.chain.fxChainElements, out);
+
+        // Post-FX is a flat list of devices rather than the element tree, and a
+        // Drum Grid is an instrument so it never sits there. Checked anyway, so
+        // this counts every Drum Grid a project has rather than most of them.
+        for (const auto& element : track.chain.postFxChainElements)
+            if (magda::isPadRackDevice(element.device.pluginId))
+                out.push_back(&element.device);
+    }
+    return out;
+}
+
+magda::StagedProjectData loadCorpusProject(const char* file) {
+    const auto path = magda::test::legacy_corpus::projectsDir().getChildFile(file);
+    REQUIRE(path.existsAsFile());
+
+    magda::StagedProjectData staged;
+    REQUIRE(magda::ProjectSerializer::loadAndStage(path, staged));
+    return staged;
+}
+
+void requirePadsAreReal(const magda::DeviceInfo& drumGrid) {
+    INFO("drum grid device " << drumGrid.name);
+    REQUIRE(static_cast<bool>(drumGrid.padRack));
+    REQUIRE_FALSE(drumGrid.padRack->chains.empty());
+
+    for (const auto& pad : drumGrid.padRack->chains) {
+        INFO("pad " << pad.name);
+        // A pad answers to a real range. The whole point of the projection is
+        // that the compiler can key a chain by pitch, so a pad that came back
+        // taking every note would be the projection silently not working.
+        CHECK_FALSE(pad.answersToEveryNote());
+        CHECK(pad.lowNote >= 0);
+        CHECK(pad.lowNote <= 127);
+        CHECK(pad.highNote >= pad.lowNote);
+        CHECK(pad.highNote <= 127);
+        CHECK(pad.rootNote >= 0);
+        CHECK(pad.rootNote <= 127);
+    }
+}
+
+}  // namespace
+
+TEST_CASE("A 0.4.8 project's Drum Grid pads reach the model", "[drumgrid][pads][corpus]") {
+    const auto staged = loadCorpusProject("0.4.8-drumgrid.mgd");
+    const auto drumGrids = drumGridsIn(staged);
+
+    REQUIRE_FALSE(drumGrids.empty());
+    for (const auto* drumGrid : drumGrids)
+        requirePadsAreReal(*drumGrid);
+}
+
+TEST_CASE("A 1.0.0 project's racked Drum Grid pads reach the model", "[drumgrid][pads][corpus]") {
+    const auto staged = loadCorpusProject("1.0.0-drumgrid-rack.mgd");
+    const auto drumGrids = drumGridsIn(staged);
+
+    REQUIRE_FALSE(drumGrids.empty());
+    for (const auto* drumGrid : drumGrids)
+        requirePadsAreReal(*drumGrid);
+}
+
+TEST_CASE("A project with no Drum Grid has no pad racks", "[drumgrid][pads][corpus]") {
+    const auto staged = loadCorpusProject("0.16.0-reverse.mgd");
+    CHECK(drumGridsIn(staged).empty());
+}

--- a/tests/test_drum_grid_pads_corpus.cpp
+++ b/tests/test_drum_grid_pads_corpus.cpp
@@ -1,4 +1,5 @@
 #include <catch2/catch_test_macros.hpp>
+#include <set>
 
 #include "LegacyCorpus.hpp"
 #include "magda/daw/core/DrumGridPads.hpp"
@@ -71,7 +72,33 @@ void requirePadsAreReal(const magda::DeviceInfo& drumGrid) {
         CHECK(pad.highNote <= 127);
         CHECK(pad.rootNote >= 0);
         CHECK(pad.rootNote <= 127);
+
+        for (const auto& element : pad.elements) {
+            REQUIRE(magda::isDevice(element));
+            const auto& device = magda::getDevice(element);
+            INFO("pad device " << device.pluginId);
+            CHECK(device.pluginId.isNotEmpty());
+        }
     }
+
+    // A DeviceId is not a load-time fact for these files. A Drum Grid allocates
+    // one per pad plugin when it restores it, so a project saved before that
+    // plugin was ever instantiated carries none, and both corpus projects are
+    // that old. What load must guarantee is that the ids it DOES find are
+    // distinct: an id read from the file and duplicated across pads would key
+    // two ops the same and bind one pad's parameters to another's.
+    std::set<magda::DeviceId> ids;
+    int withIds = 0;
+    for (const auto& pad : drumGrid.padRack->chains) {
+        for (const auto& element : pad.elements) {
+            const auto id = magda::getDevice(element).id;
+            if (id == magda::INVALID_DEVICE_ID)
+                continue;
+            ++withIds;
+            ids.insert(id);
+        }
+    }
+    CHECK(static_cast<int>(ids.size()) == withIds);
 }
 
 }  // namespace


### PR DESCRIPTION
Follows #2196, which landed `padRack` with somewhere to put a Drum Grid's pads and
nothing writing it. This writes it.

## A bug in the groundwork, first

`ChainInfo` copies through hand-written operations, because a chain element can be
a nested rack held by `unique_ptr` and that has to be deep copied. Every other
field is listed by hand there, and the note range that arrived with pads was not.

Nothing had noticed because nothing wrote `padRack` yet. It would have gone wrong
the moment something did: a `DeviceInfo` is copied by value throughout the app, so
every pad came back holding the defaults, which `answersToEveryNote()` reads as a
chain that takes everything. Sixty-four pads each claiming the whole keyboard,
which is the failure that looks like working code.

The test sets every field to something that is not its default and copies both
ways, so the next field added and forgotten there fails rather than going missing.
Confirmed to fail without the fix.

## Reading the pads

The pads were never the thing that had to move. A v2 device state document is
already MAGDA-defined and engine-neutral, and its `root` is where a device's
non-parameter state lives, drum-pad chains included. What was missing was a typed
view: `root` is a property bag and the compiler wants chains.

So `padRack` is a projection, not a second copy. Nothing is serialized separately,
a project file keeps one set of pads, and no project on disk changes shape.

Both saved shapes are read. A v2 document goes straight through; pre-v2 engine XML
is turned back into document nodes and read by the same code, so the two paths
cannot drift. Anything else, a newer schema included, is left alone rather than
guessed at.

## What review caught

A pad device was projected with a plugin id and a name and nothing else, which is
not enough to compile or bind one. The plan keys an op on the `DeviceId` and routes
on whether a device is an instrument, consumes MIDI or is bypassed, and
`OpKey::deviceKey()` is what the value layer binds parameters through. Sixty-four
pads projected with those at their defaults would key one op between them and bind
every pad's parameters to the same device.

None of what replaced it is invented. The `DeviceId` is the one the Drum Grid
allocated and saved with the pad, which is why the id allocator reads the same
property. The instrument flag, device type and canonical id come from the plugin
registry, through the alias-aware lookup so a pad saved under a retired name still
resolves. The engine's `enabled` is MAGDA's `bypassed`, which survives on a nested
pad plugin because the bridge only strips it at the root. The MIDI and audio
capabilities come from the cache every other device is filled from.

A pad whose state carries no id keeps `INVALID_DEVICE_ID` rather than being given a
made-up one. A minted id would collide with a real device and render the wrong
thing silently; an invalid one is a device the compiler can report.

## What the corpus tests then found

That case is not hypothetical. I asserted real files carry pad device ids and they
do not: three pad devices in `1.0.0-drumgrid-rack.mgd` collapsed to one id, and one
pad holds a VST.

A Drum Grid allocates a pad plugin's `DeviceId` when it restores that plugin, so a
project saved before the plugin was ever instantiated carries none, and both corpus
projects are that old. The projection is therefore refreshed on capture as well as
on load, where the ids do exist -- through the rack path too, since one of those two
projects has its Drum Grid inside a rack. Load-time tests assert only what load can
guarantee: that the ids it does find are distinct.

## Coverage

Twice over. The synthetic cases fix the shape, both saved formats included. The
corpus cases fix the fact that released builds wrote it, against the two real
projects that carry a Drum Grid, saved four minor versions apart, one racked.

## What is next, and why it is not here

Teaching `PlanCompiler` to expand pads needs a note-range gate and transpose:
notes in `[low, high]`, remapped to `root + (note - low)`. `OpKind` has no such op.
The whole list is ClipAudio, ClipMidi, AudioInput, MidiInput, Device, MixAudio,
MergeMidi, Subtract, Delay, Crossfade, Gain, Fader, SendTap, Meter, ModSource,
Output.

Adding one touches the plan vocabulary, the native executor, the TE leg for
null-diff parity and the differ. That is its own unit of work rather than an
addition to this one, and it is what actually moves the survey number.

## Verification

Catch2 2960 cases / 602794 assertions green, re-run against the committed state
after clang-format.

https://claude.ai/code/session_0187yiSdSJPmDFZafrSfbSop
