### PR TITLE
Teach the plan to gate MIDI by note range (#2200)

### DIFF
--- a/magda/engine/exec/PlanExecutor.cpp
+++ b/magda/engine/exec/PlanExecutor.cpp
@@ -1266,6 +1266,52 @@ void PlanExecutor::renderOp(OpId id, const OpValue& published, const BlockInfo& 
             break;
         }
 
+        case OpKind::MidiNoteGate: {
+            // A pad answers to a contiguous range of notes and plays them from
+            // its own root, so a sampler mapped at C0 sounds from whichever pad
+            // triggered it. Both halves are here because they are one decision:
+            // an event is either this pad's, in which case it arrives
+            // transposed, or it is not and this pad never sees it.
+            auto& out = midiOut(id, 0);
+            out.clear();
+
+            if (value.silent)
+                break;
+
+            const int low = op.noteGateLow;
+            const int high = op.noteGateHigh;
+            const int transpose = op.noteGateTranspose;
+
+            for (const auto metadata : midiIn(op.inputs[0])) {
+                auto message = metadata.getMessage();
+
+                // Everything that is not a note carries no pitch to gate on and
+                // is the chain's business as much as any pad's: a sustain pedal
+                // or a pitch bend reaches every pad, which is what the current
+                // engine does with them too.
+                if (!message.isNoteOnOrOff() && !message.isAftertouch()) {
+                    out.addEvent(message, metadata.samplePosition);
+                    continue;
+                }
+
+                const int note = message.getNoteNumber();
+                if (note < low || note > high)
+                    continue;
+
+                // Clamped rather than dropped. A transposed note past the end of
+                // the keyboard is a pad configured to play higher than MIDI
+                // goes, and the note it asked for is the nearest one that
+                // exists; dropping it would leave a pad that triggers nothing
+                // and looks broken.
+                message.setNoteNumber(std::clamp(note + transpose, 0, 127));
+                out.addEvent(message, metadata.samplePosition);
+            }
+
+            if (auto* tap = midiTapForOp_[i]; tap != nullptr)
+                tap->write(out, block);
+            break;
+        }
+
         case OpKind::Device: {
             auto audio = audioOut(id, 0, numSamples);
             const auto producesMidi =

--- a/magda/engine/exec/PlanLayout.cpp
+++ b/magda/engine/exec/PlanLayout.cpp
@@ -106,6 +106,8 @@ std::optional<std::size_t> inPlaceInputOf(const PlanOp& op) {
         case OpKind::AudioInput:
         case OpKind::MidiInput:
         case OpKind::MergeMidi:
+        case OpKind::MidiNoteGate:
+        case OpKind::ModSource:
         case OpKind::Output:
             return std::nullopt;
     }

--- a/magda/engine/exec/PlanValues.cpp
+++ b/magda/engine/exec/PlanValues.cpp
@@ -457,6 +457,12 @@ void Resolver::resolveOp(OpId id, OpValue& value) {
         case OpRole::DeviceProcess:
         case OpRole::DeviceMeter:
         case OpRole::ChainMidiMerge:
+        // A note gate's range and transposition are topology, compiled into the
+        // op. What it does read from here is the silence the block above sets
+        // for a chain taken out of the mix, so a muted pad passes no notes
+        // rather than passing them to a silenced fader.
+        case OpRole::PadNoteGate:
+        case OpRole::DeviceInject:
         case OpRole::RackMix:
         case OpRole::RackMidiMix:
         case OpRole::TrackMeter:

--- a/magda/engine/plan/RenderPlan.cpp
+++ b/magda/engine/plan/RenderPlan.cpp
@@ -35,6 +35,7 @@ int arityOf(OpKind kind) {
         case OpKind::SendTap:
         case OpKind::Meter:
         case OpKind::Output:
+        case OpKind::MidiNoteGate:
             return 1;
         case OpKind::ModSource:
             return 2;  // the source's audio at this tap's point, the source's MIDI
@@ -58,6 +59,8 @@ const char* toString(OpKind kind) {
             return "MixAudio";
         case OpKind::MergeMidi:
             return "MergeMidi";
+        case OpKind::MidiNoteGate:
+            return "MidiNoteGate";
         case OpKind::Subtract:
             return "Subtract";
         case OpKind::Delay:
@@ -106,6 +109,8 @@ const char* toString(OpRole role) {
             return "deviceMeter";
         case OpRole::ChainMidiMerge:
             return "chainMidiMerge";
+        case OpRole::PadNoteGate:
+            return "padNoteGate";
         case OpRole::RackChainFader:
             return "rackChainFader";
         case OpRole::RackMix:
@@ -392,7 +397,7 @@ std::vector<std::string> validatePlan(const RenderPlan& plan) {
             }
             // A delay carries whatever reaches it, so its own output port is
             // what its input has to agree with.
-            const bool midiSlot = op.kind == OpKind::MergeMidi ||
+            const bool midiSlot = op.kind == OpKind::MergeMidi || op.kind == OpKind::MidiNoteGate ||
                                   ((op.kind == OpKind::Device || op.kind == OpKind::Fader ||
                                     op.kind == OpKind::ModSource) &&
                                    slot == 1);

--- a/magda/engine/plan/RenderPlan.hpp
+++ b/magda/engine/plan/RenderPlan.hpp
@@ -111,15 +111,16 @@ enum class OpKind : std::uint8_t {
     Device,      ///< a device instance (instrument, effect, MIDI or analysis)
     MixAudio,   ///< ordered sum of audio inputs (summing order is compiled, never scheduling order)
     MergeMidi,  ///< ordered merge of MIDI inputs
-    Subtract,   ///< one audio input minus another: what a delta solo hears
-    Delay,      ///< latency compensation on one edge; the sample count is bound at prepare time
-    Crossfade,  ///< an edge as it was and as it is, ramped from one to the other
-    Gain,       ///< scalar gain
-    Fader,      ///< volume + pan, and the MIDI its stage passes on
-    SendTap,    ///< pre/post-fader tap feeding another track
-    Meter,      ///< level tap read by the UI
-    ModSource,  ///< a track's signal as the modulation system reads it
-    Output,     ///< hardware output
+    MidiNoteGate,  ///< passes a note range through, transposed onto a root
+    Subtract,      ///< one audio input minus another: what a delta solo hears
+    Delay,         ///< latency compensation on one edge; the sample count is bound at prepare time
+    Crossfade,     ///< an edge as it was and as it is, ramped from one to the other
+    Gain,          ///< scalar gain
+    Fader,         ///< volume + pan, and the MIDI its stage passes on
+    SendTap,       ///< pre/post-fader tap feeding another track
+    Meter,         ///< level tap read by the UI
+    ModSource,     ///< a track's signal as the modulation system reads it
+    Output,        ///< hardware output
 };
 
 /**
@@ -142,6 +143,7 @@ enum class OpRole : std::uint8_t {
     DeviceGain,       ///< the device slot's gain trim
     DeviceMeter,      ///< the device slot's level tap
     ChainMidiMerge,   ///< raw chain MIDI merged with a device's MIDI output
+    PadNoteGate,      ///< one pad chain's note range and transposition
     RackChainFader,   ///< one rack chain's volume + pan
     RackMix,          ///< sum of a rack's chains
     RackMidiMix,      ///< merge of a rack's chain MIDI outputs
@@ -359,6 +361,19 @@ struct PlanOp {
     /// wires pin 1 and leaves pin 2 unconnected. It is not a downmix. Zero for
     /// every other op kind, and for a device not connected to the bus at all.
     std::uint8_t audioInputChannels = 0;
+
+    /// The notes a MidiNoteGate passes, inclusive, and the semitone shift it
+    /// applies to what it passes.
+    ///
+    /// Topology rather than a value: a note range is not something a mixer move
+    /// can touch, so it belongs here beside audioInputChannels rather than in
+    /// the value table, and editing a pad's range recompiles the way adding a
+    /// device does. `noteGateTranspose` is `rootNote - lowNote`, resolved at
+    /// compile time so the audio thread adds one number instead of doing the
+    /// arithmetic per event. Zero for every other op kind.
+    std::uint8_t noteGateLow = 0;
+    std::uint8_t noteGateHigh = 127;
+    std::int8_t noteGateTranspose = 0;
 };
 
 /**

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -299,6 +299,8 @@ if(MAGDA_BUILD_NATIVE_ENGINE)
     list(APPEND TEST_SOURCES test_render_plan_executor.cpp)
     list(APPEND TEST_SOURCES test_parallel_executor.cpp)
     list(APPEND TEST_SOURCES test_plan_layout.cpp)
+    # The note-range gate a pad chain needs (#2200).
+    list(APPEND TEST_SOURCES test_plan_note_gate.cpp)
     list(APPEND TEST_SOURCES test_plan_diff.cpp)
     # Rack nesting, recursion and op-key identity (#2137). Reaches the parameter
     # table as well as the plan, because the nearest-scope rule the two resolve

--- a/tests/test_plan_note_gate.cpp
+++ b/tests/test_plan_note_gate.cpp
@@ -1,0 +1,211 @@
+#include <catch2/catch_test_macros.hpp>
+#include <vector>
+
+#include "exec/PlanExecutor.hpp"
+#include "exec/PlanValues.hpp"
+#include "plan/RenderPlan.hpp"
+
+// The MidiNoteGate op (#2200).
+//
+// A pad answers to a contiguous range of notes and plays them from its own
+// root, so a sampler mapped at C0 sounds from whichever pad triggered it. The
+// op is what the plan needs before a Drum Grid can be expanded like a rack.
+
+using magda::engine::BlockInfo;
+using magda::engine::DeviceBlock;
+using magda::engine::DeviceKey;
+using magda::engine::EngineDevice;
+using magda::engine::EngineMidiSource;
+using magda::engine::OpKind;
+using magda::engine::PlanBindings;
+using magda::engine::PlanExecutor;
+using magda::engine::PlanValues;
+using magda::engine::PortRef;
+using magda::engine::RenderContext;
+using magda::engine::RenderPlan;
+using magda::engine::SignalKind;
+
+namespace {
+
+constexpr int kBlockSize = 64;
+
+/// Emits one message per note it is given, all at sample zero.
+class NoteSource final : public EngineMidiSource {
+  public:
+    explicit NoteSource(std::vector<juce::MidiMessage> messages) : messages_(std::move(messages)) {}
+
+    void render(const BlockInfo&, juce::MidiBuffer& out) override {
+        for (const auto& message : messages_)
+            out.addEvent(message, 0);
+    }
+
+  private:
+    std::vector<juce::MidiMessage> messages_;
+};
+
+/// Records every message that reaches it.
+class MidiCapture final : public EngineDevice {
+  public:
+    void process(DeviceBlock& block) override {
+        block.audio.clear();
+        if (block.midiIn == nullptr)
+            return;
+        for (const auto metadata : *block.midiIn)
+            seen.push_back(metadata.getMessage());
+    }
+
+    std::vector<int> noteOnNumbers() const {
+        std::vector<int> notes;
+        for (const auto& message : seen)
+            if (message.isNoteOn())
+                notes.push_back(message.getNoteNumber());
+        return notes;
+    }
+
+    std::vector<juce::MidiMessage> seen;
+};
+
+/// MidiInput -> MidiNoteGate -> Device, which is the shape a pad chain has.
+struct GateHarness {
+    RenderPlan plan;
+    PlanExecutor executor;
+    PlanBindings bindings;
+    NoteSource source;
+    MidiCapture capture;
+
+    GateHarness(std::vector<juce::MidiMessage> messages, int low, int high, int transpose)
+        : source(std::move(messages)) {
+        magda::engine::PlanOp input;
+        input.kind = OpKind::MidiInput;
+        input.key.trackId = 1;
+        input.key.role = magda::engine::OpRole::LiveMidiInput;
+        input.outputs = {SignalKind::Midi};
+        plan.ops.push_back(input);
+
+        magda::engine::PlanOp gate;
+        gate.kind = OpKind::MidiNoteGate;
+        gate.key.trackId = 1;
+        gate.key.rackId = 5;
+        gate.key.chainId = 2;
+        gate.key.role = magda::engine::OpRole::PadNoteGate;
+        gate.inputs = {PortRef{0, 0}};
+        gate.outputs = {SignalKind::Midi};
+        gate.noteGateLow = static_cast<std::uint8_t>(low);
+        gate.noteGateHigh = static_cast<std::uint8_t>(high);
+        gate.noteGateTranspose = static_cast<std::int8_t>(transpose);
+        plan.ops.push_back(gate);
+
+        magda::engine::PlanOp device;
+        device.kind = OpKind::Device;
+        device.key.trackId = 1;
+        device.key.rackId = 5;
+        device.key.chainId = 2;
+        device.key.deviceId = 9;
+        device.key.role = magda::engine::OpRole::DeviceProcess;
+        device.inputs = {PortRef{}, PortRef{1, 0}, PortRef{}};
+        device.outputs = {SignalKind::Audio};
+        plan.ops.push_back(device);
+
+        magda::engine::PlanOp out;
+        out.kind = OpKind::Output;
+        out.key.trackId = 1;
+        out.key.role = magda::engine::OpRole::HardwareOutput;
+        out.inputs = {PortRef{2, 0}};
+        plan.ops.push_back(out);
+
+        plan.outputOps = {3};
+        magda::engine::bakeScheduling(plan);
+
+        bindings.midiInputs[1] = &source;
+        bindings.devices[DeviceKey{9}] = &capture;
+    }
+
+    void render() {
+        const auto messages =
+            executor.prepare(plan, bindings, RenderContext{44100.0, kBlockSize, 2});
+        for (const auto& message : messages)
+            UNSCOPED_INFO("prepare: " << message);
+        REQUIRE(messages.empty());
+        REQUIRE(executor.isPrepared());
+
+        juce::AudioBuffer<float> output(2, kBlockSize);
+        output.clear();
+        BlockInfo block;
+        block.numSamples = kBlockSize;
+        executor.process(PlanValues{}, block, output);
+    }
+};
+
+juce::MidiMessage noteOn(int note) {
+    return juce::MidiMessage::noteOn(1, note, 1.0f);
+}
+
+}  // namespace
+
+TEST_CASE("A note gate passes only the notes in its range", "[engine][exec][notegate]") {
+    GateHarness harness({noteOn(35), noteOn(36), noteOn(38), noteOn(39), noteOn(40)}, 36, 39, 0);
+    harness.render();
+
+    CHECK(harness.capture.noteOnNumbers() == std::vector<int>{36, 38, 39});
+}
+
+TEST_CASE("A note gate transposes what it passes onto its root", "[engine][exec][notegate]") {
+    // A pad taking 38..40 whose sampler is mapped at 60: the range is moved so
+    // the bottom of it plays the root.
+    GateHarness harness({noteOn(38), noteOn(39), noteOn(40)}, 38, 40, 60 - 38);
+    harness.render();
+
+    CHECK(harness.capture.noteOnNumbers() == std::vector<int>{60, 61, 62});
+}
+
+TEST_CASE("A note gate with no transposition leaves pitch alone", "[engine][exec][notegate]") {
+    GateHarness harness({noteOn(36), noteOn(37)}, 0, 127, 0);
+    harness.render();
+
+    CHECK(harness.capture.noteOnNumbers() == std::vector<int>{36, 37});
+}
+
+TEST_CASE("A note gate clamps a transposition past the end of the keyboard",
+          "[engine][exec][notegate]") {
+    // A pad configured to play higher than MIDI goes. The nearest note that
+    // exists is what it asked for; dropping it would leave a pad that triggers
+    // nothing and looks broken.
+    GateHarness harness({noteOn(120), noteOn(127)}, 120, 127, 20);
+    harness.render();
+
+    CHECK(harness.capture.noteOnNumbers() == std::vector<int>{127, 127});
+}
+
+TEST_CASE("A note gate passes note-offs so a gated note can end", "[engine][exec][notegate]") {
+    GateHarness harness({noteOn(38), juce::MidiMessage::noteOff(1, 38)}, 38, 38, 2);
+    harness.render();
+
+    REQUIRE(harness.capture.seen.size() == 2);
+    CHECK(harness.capture.seen[0].isNoteOn());
+    CHECK(harness.capture.seen[0].getNoteNumber() == 40);
+    CHECK(harness.capture.seen[1].isNoteOff());
+
+    // The off has to follow the on, or the note it ends is a different one and
+    // the pad hangs.
+    CHECK(harness.capture.seen[1].getNoteNumber() == 40);
+}
+
+TEST_CASE("A note gate lets non-note messages through untouched", "[engine][exec][notegate]") {
+    // A sustain pedal or a pitch bend carries no pitch to gate on and is the
+    // chain's business as much as any pad's.
+    GateHarness harness({juce::MidiMessage::controllerEvent(1, 64, 127),
+                         juce::MidiMessage::pitchWheel(1, 4096), noteOn(20)},
+                        36, 39, 0);
+    harness.render();
+
+    REQUIRE(harness.capture.seen.size() == 2);
+    CHECK(harness.capture.seen[0].isController());
+    CHECK(harness.capture.seen[1].isPitchWheel());
+}
+
+TEST_CASE("A note gate is a MidiNoteGate in a plan dump", "[engine][exec][notegate]") {
+    CHECK(std::string(magda::engine::toString(OpKind::MidiNoteGate)) == "MidiNoteGate");
+    CHECK(std::string(magda::engine::toString(magda::engine::OpRole::PadNoteGate)) ==
+          "padNoteGate");
+    CHECK(magda::engine::arityOf(OpKind::MidiNoteGate) == 1);
+}


### PR DESCRIPTION
Closes the vocabulary half of #2200. Independent of #2199 and based on
`dev/0.20.0` rather than stacked on it: the op is plan vocabulary and needs no
pads to exist.

## What was missing

A pad answers to a contiguous range of notes and plays them from its own root:

```
note in [lowNote, highNote]  ->  rootNote + (note - lowNote)
```

That is what makes a sampler mapped at C0 sound from whichever pad triggered it,
and it is the only thing a pad has that a plain parallel rack chain does not.
`OpKind` had nothing that could express it, so the plan could hold a Drum Grid's
pads and still not compile them: there was nothing to put between a pad chain's
MIDI input and its devices.

## Decisions worth reviewing

**Gate and transpose are one op, not two.** They are one decision: an event is
either this pad's, in which case it arrives transposed, or it is not and this pad
never sees it. Two ops would put 128 in the plan for a full Drum Grid instead of
64, and sixty-four pads makes that count real.

**The range is topology, not a value.** It lives on `PlanOp` beside
`audioInputChannels` rather than in the value table. The table is for what a
mixer move can touch; a note range is not that, and editing one recompiles the
way adding a device does. What the op *does* read from the table is the silence a
chain taken out of the mix already sets, so a muted pad passes no notes rather
than passing them into a silenced fader.

**`noteGateTranspose` is `rootNote - lowNote`, resolved at compile time**, so the
audio thread adds one number per event instead of doing the arithmetic.

## Three behaviours, all tested

- **A message with no pitch passes through untouched.** A sustain pedal or a
  pitch bend is the chain's business as much as any pad's, and the current engine
  hands those to every pad too.
- **A note-off is gated and transposed exactly like its note-on.** Otherwise the
  note it ends is a different one and the pad hangs.
- **A transposition past the end of the keyboard clamps rather than drops.** That
  is a pad configured to play higher than MIDI goes, and the note it asked for is
  the nearest one that exists; dropping it would leave a pad that triggers nothing
  and looks broken.

## Two switch gaps closed on the way

Adding the kind surfaced two enumerators that had never been listed:
`PlanLayout`'s in-place table had no `ModSource`, and `PlanValues`' role switch
had no `DeviceInject`. Both already fell through to the right answer; both now say
so rather than warning.

## What is deliberately not here

The compiler does not emit this yet. That needs a Drum Grid's pads in the model,
which is #2199, and it is the commit that actually moves the survey number. This
PR is the vocabulary it will emit into.

Parity is also still open: once the compiler emits the gate, the Tracktion leg has
to agree with it for null-diff, and today `DrumGridPlugin::applyToBuffer` does the
gating internally, so the two legs reach the same result by different routes.
Nothing in this PR changes either leg's output, because nothing emits the op.

## Verification

Catch2 2952 cases / 601909 assertions green, re-run against the committed state
after clang-format.

https://claude.ai/code/session_0187yiSdSJPmDFZafrSfbSop
