### PR TITLE
Compile a Drum Grid's pads instead of stopping at it (#2200)

### DIFF
--- a/magda/daw/audio/plugin_manager/PluginManager.cpp
+++ b/magda/daw/audio/plugin_manager/PluginManager.cpp
@@ -14,6 +14,7 @@
 #include "../TrackController.hpp"
 #include "../TracktionHelpers.hpp"
 #include "../Vst3Preset.hpp"
+#include "../plugins/DrumGridPadParameters.hpp"
 #include "modifiers/CurveSnapshot.hpp"
 #include "modifiers/ModifierHelpers.hpp"
 #include "modifiers/ModifierSync.hpp"
@@ -456,6 +457,8 @@ void PluginManager::captureAllPluginStates() {
             // keyable: a Drum Grid allocates a pad plugin's DeviceId when it
             // restores it, so the ids exist here and not at load (#2192).
             refreshPadRack(*devInfo);
+            if (auto* drumGrid = dynamic_cast<daw::audio::DrumGridPlugin*>(sd.plugin.get()))
+                daw::audio::populatePadDeviceParameters(*devInfo, *drumGrid);
             captureVst3Info(*devInfo, capturedExt);
             if (sd.processor != nullptr)
                 sd.processor->populateParameters(*devInfo);
@@ -494,6 +497,8 @@ void PluginManager::capturePluginState(const ChainNodePath& devicePath) {
 
     devInfo->pluginState = stateStr;
     refreshPadRack(*devInfo);
+    if (auto* drumGrid = dynamic_cast<daw::audio::DrumGridPlugin*>(plugin))
+        daw::audio::populatePadDeviceParameters(*devInfo, *drumGrid);
     captureVst3Info(*devInfo, capturedExt);
     if (it->second.processor)
         it->second.processor->populateParameters(*devInfo);

--- a/magda/daw/audio/plugins/DrumGridPadParameters.cpp
+++ b/magda/daw/audio/plugins/DrumGridPadParameters.cpp
@@ -1,0 +1,62 @@
+#include "plugins/DrumGridPadParameters.hpp"
+
+#include "core/DeviceInfo.hpp"
+#include "core/RackInfo.hpp"
+#include "plugins/DrumGridPlugin.hpp"
+#include "processors/ParameterInfoBuilder.hpp"
+
+namespace magda::daw::audio {
+
+namespace {
+
+void fillFrom(DeviceInfo& device, te::Plugin& plugin) {
+    device.parameters.clear();
+
+    const auto params = plugin.getAutomatableParameters();
+    for (int i = 0; i < params.size(); ++i)
+        if (params[i] != nullptr)
+            device.parameters.push_back(makeInfoFromTeParam(i, params[i]));
+}
+
+/// The pad chain the model holds for @p chainIndex, or null.
+///
+/// Matched on the chain id rather than on position, because the projection
+/// carries the device's own chain index as the id and a pad that could not be
+/// compiled is not in the model at all.
+ChainInfo* findPad(RackInfo& pads, int chainIndex) {
+    for (auto& pad : pads.chains)
+        if (pad.id == chainIndex)
+            return &pad;
+    return nullptr;
+}
+
+}  // namespace
+
+void populatePadDeviceParameters(DeviceInfo& device, DrumGridPlugin& plugin) {
+    if (!device.padRack)
+        return;
+
+    auto& pads = *device.padRack.get();
+
+    for (const auto& chain : plugin.getChains()) {
+        if (chain == nullptr)
+            continue;
+
+        auto* pad = findPad(pads, chain->index);
+        if (pad == nullptr)
+            continue;
+
+        // Position within the pad, which is the order both the device and the
+        // projection keep them in.
+        std::size_t slot = 0;
+        for (auto& element : pad->elements) {
+            if (!magda::isDevice(element))
+                continue;
+            if (slot < chain->plugins.size() && chain->plugins[slot] != nullptr)
+                fillFrom(magda::getDevice(element), *chain->plugins[slot]);
+            ++slot;
+        }
+    }
+}
+
+}  // namespace magda::daw::audio

--- a/magda/daw/audio/plugins/DrumGridPadParameters.cpp
+++ b/magda/daw/audio/plugins/DrumGridPadParameters.cpp
@@ -37,6 +37,19 @@ ChainInfo* findPad(RackInfo& pads, int chainIndex) {
     return nullptr;
 }
 
+/// The live plugin carrying @p deviceId, or null.
+///
+/// The Drum Grid stamps the id onto a pad plugin's state when it creates or
+/// restores it, and the projection reads that same property, so this is the one
+/// thing the two sides are guaranteed to agree on.
+te::Plugin::Ptr findPluginById(DrumGridPlugin& grid, const DrumGridPlugin::Chain& chain,
+                               DeviceId deviceId) {
+    for (int i = 0; i < static_cast<int>(chain.plugins.size()); ++i)
+        if (grid.getPluginDeviceId(chain.index, i) == deviceId)
+            return chain.plugins[static_cast<std::size_t>(i)];
+    return {};
+}
+
 }  // namespace
 
 void populatePadDeviceParameters(DeviceInfo& device, DrumGridPlugin& plugin) {
@@ -53,15 +66,21 @@ void populatePadDeviceParameters(DeviceInfo& device, DrumGridPlugin& plugin) {
         if (pad == nullptr)
             continue;
 
-        // Position within the pad, which is the order both the device and the
-        // projection keep them in.
-        std::size_t slot = 0;
+        // By DeviceId, not by position. A plugin the engine could not create is
+        // left out of the chain while its node stays in the state the projection
+        // reads, so one missing plugin would shift every match after it: a valid
+        // plugin's parameters onto the device that failed, and the valid device
+        // left at its defaults.
         for (auto& element : pad->elements) {
             if (!magda::isDevice(element))
                 continue;
-            if (slot < chain->plugins.size() && chain->plugins[slot] != nullptr)
-                fillFrom(magda::getDevice(element), chain->plugins[slot]);
-            ++slot;
+
+            auto& padDevice = magda::getDevice(element);
+            if (padDevice.id == INVALID_DEVICE_ID)
+                continue;
+
+            if (auto live = findPluginById(plugin, *chain, padDevice.id))
+                fillFrom(padDevice, live);
         }
     }
 }

--- a/magda/daw/audio/plugins/DrumGridPadParameters.cpp
+++ b/magda/daw/audio/plugins/DrumGridPadParameters.cpp
@@ -3,19 +3,26 @@
 #include "core/DeviceInfo.hpp"
 #include "core/RackInfo.hpp"
 #include "plugins/DrumGridPlugin.hpp"
-#include "processors/ParameterInfoBuilder.hpp"
+#include "processors/DeviceProcessorFactory.hpp"
+#include "processors/base/DeviceProcessor.hpp"
 
 namespace magda::daw::audio {
 
 namespace {
 
-void fillFrom(DeviceInfo& device, te::Plugin& plugin) {
+/// Through the device's own processor, which is how every other device in the
+/// model gets its parameters.
+///
+/// Not from the Tracktion parameters directly: a device behind the SDK exposes
+/// those normalized, so reading them would record a kick's 220 Hz pitch as 0.17
+/// with a 0 to 1 range. The native engine takes the model's metadata at face
+/// value, so it would then render 0.17 Hz clamped to the parameter's minimum.
+/// The processor is what knows the real range.
+void fillFrom(DeviceInfo& device, te::Plugin::Ptr plugin) {
     device.parameters.clear();
 
-    const auto params = plugin.getAutomatableParameters();
-    for (int i = 0; i < params.size(); ++i)
-        if (params[i] != nullptr)
-            device.parameters.push_back(makeInfoFromTeParam(i, params[i]));
+    if (auto processor = createDeviceProcessorForPlugin(device.id, plugin, device.pluginId))
+        processor->populateParameters(device);
 }
 
 /// The pad chain the model holds for @p chainIndex, or null.
@@ -53,7 +60,7 @@ void populatePadDeviceParameters(DeviceInfo& device, DrumGridPlugin& plugin) {
             if (!magda::isDevice(element))
                 continue;
             if (slot < chain->plugins.size() && chain->plugins[slot] != nullptr)
-                fillFrom(magda::getDevice(element), *chain->plugins[slot]);
+                fillFrom(magda::getDevice(element), chain->plugins[slot]);
             ++slot;
         }
     }

--- a/magda/daw/audio/plugins/DrumGridPadParameters.hpp
+++ b/magda/daw/audio/plugins/DrumGridPadParameters.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+namespace magda {
+struct DeviceInfo;
+}
+
+namespace magda::daw::audio {
+
+class DrumGridPlugin;
+
+/**
+ * Fill the parameters of the devices projected from @p plugin's pads (#2200).
+ *
+ * The pads reach the model as a projection of the device's saved state, which
+ * carries a plugin's parameter values but not its names, ranges or count: only
+ * the plugin answers those. Without them the parameter table allocates no window
+ * for a pad's device, and a native-capable plugin inside a pad runs at its
+ * defaults rather than at what the project saved, because the engine's factory
+ * restores everything EXCEPT parameters and expects the table to supply them.
+ *
+ * Called where the pads are projected from a live device, which is the same
+ * point their DeviceIds and instrument flags arrive at.
+ */
+void populatePadDeviceParameters(DeviceInfo& device, DrumGridPlugin& plugin);
+
+}  // namespace magda::daw::audio

--- a/magda/daw/audio/processors/internal/MidiDeviceProcessors.cpp
+++ b/magda/daw/audio/processors/internal/MidiDeviceProcessors.cpp
@@ -90,6 +90,14 @@ DrumGridProcessor::DrumGridProcessor(DeviceId deviceId, te::Plugin::Ptr plugin)
 void DrumGridProcessor::customiseParameterInfo(int index, ParameterInfo& info) const {
     // Pan params (odd indices) are bipolar
     info.bipolarModulation = (index % 2 == 1);
+
+    // The id the pad's parameter was registered under, carried through so a
+    // consumer can find a pad's level or pan by name. The plan compiler binds a
+    // pad's fader with it (#2200), which is what lets a lane or a macro over the
+    // pad's level reach the fader rather than stopping at the device.
+    const auto params = getAutomatableParameters();
+    if (index >= 0 && index < params.size() && params[index] != nullptr)
+        info.stableId = params[index]->paramID;
 }
 
 }  // namespace magda

--- a/magda/daw/audio/racks/RackSyncManager.cpp
+++ b/magda/daw/audio/racks/RackSyncManager.cpp
@@ -1,6 +1,7 @@
 #include "racks/RackSyncManager.hpp"
 
 #include "../../core/DrumGridPads.hpp"
+#include "../plugins/DrumGridPadParameters.hpp"
 #include "TracktionHelpers.hpp"
 #include "core/ChainRoutingModel.hpp"
 #include "core/TrackManager.hpp"
@@ -525,6 +526,8 @@ void RackSyncManager::capturePluginStates(SyncedRack& synced) {
         devInfo->pluginState = stateStr;
         // As on a track: pads follow the state they live in (#2192).
         refreshPadRack(*devInfo);
+        if (auto* drumGrid = dynamic_cast<daw::audio::DrumGridPlugin*>(plugin.get()))
+            daw::audio::populatePadDeviceParameters(*devInfo, *drumGrid);
         pluginManager_.refreshDeviceParameters(devicePath);
     }
 }

--- a/magda/daw/core/DrumGridPads.cpp
+++ b/magda/daw/core/DrumGridPads.cpp
@@ -214,6 +214,10 @@ RackId padRackIdFor(DeviceId deviceId) {
     return -(deviceId + 2);
 }
 
+bool isPadRackId(RackId rackId) {
+    return rackId < INVALID_RACK_ID;
+}
+
 bool isPadRackDevice(const juce::String& pluginId) {
     return pluginId == kDrumGridId;
 }

--- a/magda/daw/core/DrumGridPads.cpp
+++ b/magda/daw/core/DrumGridPads.cpp
@@ -200,6 +200,10 @@ std::unique_ptr<RackInfo> rackFromRoot(const ds::Node& root) {
 
 }  // namespace
 
+RackId padRackIdFor(DeviceId deviceId) {
+    return -(deviceId + 2);
+}
+
 bool isPadRackDevice(const juce::String& pluginId) {
     return pluginId == kDrumGridId;
 }
@@ -231,6 +235,8 @@ void refreshPadRack(DeviceInfo& device) {
     }
 
     device.padRack.reset(readPadRack(device.pluginId, device.pluginState));
+    if (device.padRack)
+        device.padRack->id = padRackIdFor(device.id);
 }
 
 }  // namespace magda

--- a/magda/daw/core/DrumGridPads.cpp
+++ b/magda/daw/core/DrumGridPads.cpp
@@ -45,6 +45,11 @@ const juce::Identifier kPluginIsInstrument("magdaIsInstrument");
 /// instead of ChainInfo's default, which means "every note".
 constexpr int kFallbackNote = 60;
 
+/// The note the grid's first pad answers to, and how many pads it has. The
+/// device's own, and what turns a pad's bottom note into its parameter slot.
+constexpr int kPadBaseNote = 24;
+constexpr int kMaxPads = 64;
+
 /// One pad's device.
 ///
 /// The plan keys an op on the DeviceId and routes on the instrument, MIDI and
@@ -199,6 +204,11 @@ std::unique_ptr<RackInfo> rackFromRoot(const ds::Node& root) {
 }
 
 }  // namespace
+
+int padParameterSlot(const ChainInfo& pad) {
+    const auto slot = pad.lowNote - kPadBaseNote;
+    return slot >= 0 && slot < kMaxPads ? slot : -1;
+}
 
 RackId padRackIdFor(DeviceId deviceId) {
     return -(deviceId + 2);

--- a/magda/daw/core/DrumGridPads.hpp
+++ b/magda/daw/core/DrumGridPads.hpp
@@ -4,6 +4,8 @@
 
 #include <memory>
 
+#include "TypeIds.hpp"
+
 namespace magda {
 
 struct DeviceInfo;
@@ -34,5 +36,12 @@ void refreshPadRack(DeviceInfo& device);
 
 /// True when devices of this type keep their chains as pads.
 bool isPadRackDevice(const juce::String& pluginId);
+
+/// The RackId a pad rack owned by `deviceId` carries.
+///
+/// Negative, and never INVALID_RACK_ID. Rack ids the app allocates start at 1,
+/// so the negative space is free and a pad rack can be keyed and looked up like
+/// any other rack without an allocator that does not reach here.
+RackId padRackIdFor(DeviceId deviceId);
 
 }  // namespace magda

--- a/magda/daw/core/DrumGridPads.hpp
+++ b/magda/daw/core/DrumGridPads.hpp
@@ -8,6 +8,7 @@
 
 namespace magda {
 
+struct ChainInfo;
 struct DeviceInfo;
 struct RackInfo;
 
@@ -36,6 +37,15 @@ void refreshPadRack(DeviceInfo& device);
 
 /// True when devices of this type keep their chains as pads.
 bool isPadRackDevice(const juce::String& pluginId);
+
+/// The parameter slot a pad's level and pan live in, or -1 when the pad's range
+/// starts outside the grid.
+///
+/// A Drum Grid registers padLevelN and padPanN for a fixed N per pad and reaches
+/// them by the pad's bottom note, not by the order its chains were made: a pad
+/// added first can hold chain 0 and still drive slot 17. Anything binding a pad
+/// to those parameters has to ask the same question the device does.
+int padParameterSlot(const ChainInfo& pad);
 
 /// The RackId a pad rack owned by `deviceId` carries.
 ///

--- a/magda/daw/core/DrumGridPads.hpp
+++ b/magda/daw/core/DrumGridPads.hpp
@@ -47,6 +47,9 @@ bool isPadRackDevice(const juce::String& pluginId);
 /// to those parameters has to ask the same question the device does.
 int padParameterSlot(const ChainInfo& pad);
 
+/// True when @p rackId names a pad rack rather than one the app allocated.
+bool isPadRackId(RackId rackId);
+
 /// The RackId a pad rack owned by `deviceId` carries.
 ///
 /// Negative, and never INVALID_RACK_ID. Rack ids the app allocates start at 1,

--- a/magda/engine/exec/PlanExecutor.cpp
+++ b/magda/engine/exec/PlanExecutor.cpp
@@ -360,6 +360,21 @@ std::vector<std::string> PlanExecutor::prepare(const RenderPlan& plan, const Pla
                 mixerParamForOp_[i].gain = params->find(key);
                 key.kind = ParamKey::Kind::TrackPan;
                 mixerParamForOp_[i].pan = params->find(key);
+            } else if (op.kind == OpKind::Fader && op.key.role == OpRole::RackChainFader &&
+                       op.padLevelParam >= 0) {
+                // The exception to the line above: a Drum Grid's pad level and
+                // pan are real parameters of the device that owns the pad, so a
+                // lane over them has to reach this fader. Read through the
+                // owner's window, which is indexed by the device's own
+                // parameter index.
+                const auto window = params->windowFor(op.key.deviceKey());
+                const auto slot = [&](int index) {
+                    return index >= 0 && index < window.count
+                               ? static_cast<ParamId>(window.first + index)
+                               : INVALID_PARAM_ID;
+                };
+                mixerParamForOp_[i].gain = slot(op.padLevelParam);
+                mixerParamForOp_[i].pan = slot(op.padPanParam);
             } else if (op.kind == OpKind::SendTap) {
                 key.kind = ParamKey::Kind::SendLevel;
                 key.index = op.key.index;

--- a/magda/engine/exec/PlanValues.cpp
+++ b/magda/engine/exec/PlanValues.cpp
@@ -5,6 +5,7 @@
 #include <set>
 #include <unordered_map>
 
+#include "core/DrumGridPads.hpp"
 #include "core/RackInfo.hpp"
 #include "core/TrackInfo.hpp"
 #include "param/ParamTableCompiler.hpp"
@@ -108,12 +109,21 @@ const DeviceInfo* findDeviceIn(const std::vector<PostFxChainElement>& elements, 
 
 /// Whether a rack chain is in the mix. Solo is relative to its siblings, which
 /// is why chain activity cannot be answered from the chain alone.
+///
+/// A pad rack counts solo only on pads that have something to run. That is the
+/// Drum Grid's own rule, and it matters because removing a pad's last plugin
+/// leaves the chain behind: an empty soloed pad would otherwise silence every
+/// populated pad beside it, where the device plays them.
 bool isChainActive(const RackInfo& rack, const ChainInfo& chain) {
     if (chain.muted)
         return false;
-    const auto anySolo =
-        std::ranges::any_of(rack.chains, [](const ChainInfo& c) { return c.solo; });
-    return !anySolo || chain.solo;
+
+    const auto counts = [pads = isPadRackId(rack.id)](const ChainInfo& c) {
+        return c.solo && (!pads || !c.elements.empty());
+    };
+
+    const auto anySolo = std::ranges::any_of(rack.chains, counts);
+    return !anySolo || counts(chain);
 }
 
 class Resolver {

--- a/magda/engine/exec/PlanValues.cpp
+++ b/magda/engine/exec/PlanValues.cpp
@@ -71,10 +71,18 @@ const RackInfo* findRackIn(const RackInfo& rack, RackId rackId) {
 }
 
 const RackInfo* findRackIn(const std::vector<ChainElement>& elements, RackId rackId) {
-    for (const auto& element : elements)
-        if (isRack(element))
+    for (const auto& element : elements) {
+        if (isRack(element)) {
             if (const auto* found = findRackIn(getRack(element), rackId))
                 return found;
+            continue;
+        }
+        // A pad rack hangs off its device rather than sitting in the chain, and
+        // its chains carry mute, solo and a fader like any other's.
+        if (const auto& device = getDevice(element); device.padRack)
+            if (const auto* found = findRackIn(*device.padRack.get(), rackId))
+                return found;
+    }
     return nullptr;
 }
 

--- a/magda/engine/exec/PlanValues.cpp
+++ b/magda/engine/exec/PlanValues.cpp
@@ -178,8 +178,22 @@ class Resolver {
     /// outer chain disconnected.
     void collectSilencedRacks(const std::vector<ChainElement>& elements, bool insideInactiveChain) {
         for (const auto& element : elements) {
-            if (!isRack(element))
+            if (!isRack(element)) {
+                // A pad rack hangs off its device rather than sitting in the
+                // chain, and an inactive chain silences its pads the same way it
+                // silences a nested rack's chains. Without this a Drum Grid in a
+                // muted chain keeps its pad devices running behind a silent
+                // fader, advancing tails and publishing meters.
+                if (const auto& device = getDevice(element); device.padRack) {
+                    const auto& pads = *device.padRack.get();
+                    if (insideInactiveChain)
+                        silencedRacks_.insert(pads.id);
+                    for (const auto& pad : pads.chains)
+                        collectSilencedRacks(pad.elements,
+                                             insideInactiveChain || !isChainActive(pads, pad));
+                }
                 continue;
+            }
 
             const auto& rack = getRack(element);
             if (insideInactiveChain)

--- a/magda/engine/exec/RuntimeStateStore.cpp
+++ b/magda/engine/exec/RuntimeStateStore.cpp
@@ -49,7 +49,17 @@ void collectDeviceIds(const std::vector<ChainElement>& elements, ChainSegment se
                       std::set<DeviceKey>& out) {
     for (const auto& element : elements) {
         if (isDevice(element)) {
-            out.emplace(segment, getDevice(element).id);
+            const auto& device = getDevice(element);
+            out.emplace(segment, device.id);
+
+            // A pad rack's devices are the user's the same way a nested rack's
+            // are. Bypass and chain power take their ops out of the plan, and a
+            // device named by neither the plan nor this set has its runtime
+            // released: re-enabling would rebuild the plugins and lose their
+            // tails and state.
+            if (device.padRack)
+                for (const auto& pad : device.padRack->chains)
+                    collectDeviceIds(pad.elements, segment, out);
         } else if (isRack(element)) {
             for (const auto& chain : getRack(element).chains)
                 collectDeviceIds(chain.elements, segment, out);

--- a/magda/engine/param/ParamTableCompiler.cpp
+++ b/magda/engine/param/ParamTableCompiler.cpp
@@ -540,6 +540,12 @@ void Builder::walkElements(const std::vector<magda::ChainElement>& elements, mag
             node.device = &device;
             node.sidechainSource = sidechainSourceOf(device.sidechain);
             nodes_.push_back(node);
+
+            // A pad rack's chains hold devices like any other rack's, and the
+            // plan compiles them, so their parameters, macros and mods need
+            // addresses or nothing consumes them.
+            if (device.padRack)
+                walkRack(*device.padRack.get(), trackId);
         } else if (magda::isRack(element)) {
             walkRack(magda::getRack(element), trackId);
         }

--- a/magda/engine/param/ParamTableCompiler.cpp
+++ b/magda/engine/param/ParamTableCompiler.cpp
@@ -544,8 +544,17 @@ void Builder::walkElements(const std::vector<magda::ChainElement>& elements, mag
             // A pad rack's chains hold devices like any other rack's, and the
             // plan compiles them, so their parameters, macros and mods need
             // addresses or nothing consumes them.
+            //
+            // Addressed under the owning device's id, not the pad rack's. A
+            // stored link to a pad device names the Drum Grid there -- see the
+            // chainDevice path syncDrumGridPadPlugins and the ADSR macro links
+            // are built with -- and ParamKey carries the rack id, so addressing
+            // these under the pad rack's own synthetic id would put them where
+            // no link can find them. The rack itself gets no node: it is
+            // synthesized, so it owns no macros or modifiers to address.
             if (device.padRack)
-                walkRack(*device.padRack.get(), trackId);
+                for (const auto& pad : device.padRack->chains)
+                    walkElements(pad.elements, trackId, device.id);
         } else if (magda::isRack(element)) {
             walkRack(magda::getRack(element), trackId);
         }

--- a/magda/engine/plan/PlanCompiler.cpp
+++ b/magda/engine/plan/PlanCompiler.cpp
@@ -953,6 +953,14 @@ ChainSignal Compiler::emitRack(const RackInfo& rack, const ChainSite& site, Chai
     return out;
 }
 
+/// The index of the parameter @p device declares under @p stableId, or -1.
+int deviceParamIndex(const DeviceInfo& device, const std::string& stableId) {
+    const auto found = std::ranges::find_if(device.parameters, [&](const ParameterInfo& param) {
+        return param.stableId.toStdString() == stableId;
+    });
+    return found == device.parameters.end() ? -1 : found->paramIndex;
+}
+
 /// A pad-per-chain device, expanded the way a rack is.
 ///
 /// The device itself never becomes an op. Its pads are chains, and each one is
@@ -1010,11 +1018,23 @@ ChainSignal Compiler::emitPadRack(const DeviceInfo& device, const ChainSite& sit
         // past it the way it flows past an instrument.
         const auto padOut = emitElements(pad.elements, padSite, ChainSignal{noInput(), padMidi});
 
-        const OpKey faderKey{site.trackId,           pads.id, pad.id,      INVALID_DEVICE_ID,
+        // Keyed with the device that owns the pad, so the executor can reach its
+        // parameters. A rack's own chain faders carry no device id, so the two
+        // never collide.
+        const OpKey faderKey{site.trackId,           pads.id, pad.id,      device.id,
                              OpRole::RackChainFader, 0,       site.segment};
         const auto faderOp = addOp(OpKind::Fader, faderKey,
                                    alignInputs(faderKey, OpKind::Fader, {padOut.audio, noInput()}),
                                    {SignalKind::Audio});
+
+        // A pad's level and pan are the Drum Grid's own parameters, so a lane, a
+        // macro or a modifier over them has to reach this fader. Found by stable
+        // id rather than by arithmetic over the pad index, so a device that lays
+        // its pads out differently still resolves.
+        auto& fader = plan_.ops[static_cast<std::size_t>(faderOp)];
+        fader.padLevelParam = deviceParamIndex(device, "padLevel" + std::to_string(pad.id));
+        fader.padPanParam = deviceParamIndex(device, "padPan" + std::to_string(pad.id));
+
         busAudio[pad.outputIndex].push_back(PortRef{faderOp, 0});
     }
 

--- a/magda/engine/plan/PlanCompiler.cpp
+++ b/magda/engine/plan/PlanCompiler.cpp
@@ -237,6 +237,7 @@ class Compiler {
                              ChainSignal signal);
     ChainSignal emitDevice(const DeviceInfo& device, const ChainSite& site, ChainSignal signal);
     ChainSignal emitRack(const RackInfo& rack, const ChainSite& site, ChainSignal signal);
+    ChainSignal emitPadRack(const DeviceInfo& device, const ChainSite& site, ChainSignal signal);
 
     /// Delta solo: @p wet minus @p dry, which is what the device or rack the
     /// key names added to the signal. Both sides go through alignInputs, so
@@ -952,6 +953,91 @@ ChainSignal Compiler::emitRack(const RackInfo& rack, const ChainSite& site, Chai
     return out;
 }
 
+/// A pad-per-chain device, expanded the way a rack is.
+///
+/// The device itself never becomes an op. Its pads are chains, and each one is
+/// an instrument chain: it reads no audio, takes the notes its range claims, and
+/// what it makes is summed with its siblings and injected into the bus. That is
+/// what lets a Drum Grid render under an engine that cannot host one.
+ChainSignal Compiler::emitPadRack(const DeviceInfo& device, const ChainSite& site,
+                                  ChainSignal signal) {
+    const auto& pads = *device.padRack.get();
+
+    if (device.bypassed)
+        return signal;
+
+    std::vector<PortRef> padAudio;
+
+    for (const auto& pad : pads.chains) {
+        if (pad.bypassed)
+            continue;
+
+        const ChainSite padSite{site.trackId, pads.id, pad.id, site.segment};
+
+        // The pad's own notes, transposed onto its root. A pad with no range
+        // takes everything, which is what a plain parallel chain does.
+        PortRef padMidi = signal.midi;
+        if (padMidi.valid() && !pad.answersToEveryNote()) {
+            const OpKey gateKey{site.trackId,        pads.id, pad.id,      device.id,
+                                OpRole::PadNoteGate, 0,       site.segment};
+            const auto gateOp = addOp(OpKind::MidiNoteGate, gateKey, {padMidi}, {SignalKind::Midi});
+            auto& gate = plan_.ops[static_cast<std::size_t>(gateOp)];
+            gate.noteGateLow = static_cast<std::uint8_t>(std::clamp(pad.lowNote, 0, 127));
+            gate.noteGateHigh = static_cast<std::uint8_t>(std::clamp(pad.highNote, 0, 127));
+            gate.noteGateTranspose =
+                static_cast<std::int8_t>(std::clamp(pad.rootNote - pad.lowNote, -127, 127));
+            padMidi = PortRef{gateOp, 0};
+        }
+
+        // A pad plugin's DeviceId arrives when the Drum Grid restores it, so a
+        // project that has not been opened since carries none. Two such devices
+        // in one pad would key the same op, and a plan that does not validate
+        // costs the whole project rather than the pad.
+        const auto unkeyable = std::ranges::find_if(pad.elements, [](const ChainElement& element) {
+            return isDevice(element) && getDevice(element).id == INVALID_DEVICE_ID;
+        });
+        if (unkeyable != pad.elements.end()) {
+            diagnose("device " + std::to_string(device.id) + " on track " +
+                     std::to_string(site.trackId) + " pad " + std::to_string(pad.id) +
+                     ": a plugin has no device id, so the pad is not compiled");
+            continue;
+        }
+
+        // No audio in: a pad generates rather than processes, so the bus flows
+        // past it the way it flows past an instrument.
+        const auto padOut = emitElements(pad.elements, padSite, ChainSignal{noInput(), padMidi});
+
+        const OpKey faderKey{site.trackId,           pads.id, pad.id,      INVALID_DEVICE_ID,
+                             OpRole::RackChainFader, 0,       site.segment};
+        const auto faderOp = addOp(OpKind::Fader, faderKey,
+                                   alignInputs(faderKey, OpKind::Fader, {padOut.audio, noInput()}),
+                                   {SignalKind::Audio});
+        padAudio.push_back(PortRef{faderOp, 0});
+    }
+
+    if (padAudio.empty())
+        return signal;
+
+    // No device id, the way a rack's own mix carries none. The inject below is
+    // the same location and differs only in role, and the latency delays that
+    // land on a mix's inputs keep the id but not the role, so sharing it would
+    // key one mix's delays onto the other's.
+    const OpKey mixKey{site.trackId,    pads.id, INVALID_CHAIN_ID, INVALID_DEVICE_ID,
+                       OpRole::RackMix, 0,       site.segment};
+    const auto mixed = emitMix(mixKey, padAudio);
+
+    ChainSignal out = signal;
+    if (signal.audio.valid()) {
+        const OpKey injectKey{site.trackId,         pads.id, INVALID_CHAIN_ID, device.id,
+                              OpRole::DeviceInject, 0,       site.segment};
+        out.audio = emitMix(injectKey, {signal.audio, mixed});
+    } else {
+        out.audio = mixed;
+    }
+
+    return out;
+}
+
 ChainSignal Compiler::emitElements(const std::vector<ChainElement>& elements, const ChainSite& site,
                                    ChainSignal signal) {
     // Only the track's own list, and only while a trigger tap is still wanted.
@@ -967,7 +1053,8 @@ ChainSignal Compiler::emitElements(const std::vector<ChainElement>& elements, co
         if (isDevice(element)) {
             const auto& device = getDevice(element);
             endsTheSearch = !device.bypassed && device.isInstrument;
-            signal = emitDevice(device, site, signal);
+            signal = device.padRack ? emitPadRack(device, site, signal)
+                                    : emitDevice(device, site, signal);
         } else if (isRack(element)) {
             const auto& rack = getRack(element);
             endsTheSearch = !rack.bypassed && rackHasInstrument(rack, nesting_);

--- a/magda/engine/plan/PlanCompiler.cpp
+++ b/magda/engine/plan/PlanCompiler.cpp
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "core/ChainRoutingModel.hpp"
+#include "core/DrumGridPads.hpp"
 #include "core/RackInfo.hpp"
 #include "core/TrackChain.hpp"
 #include "core/TrackInfo.hpp"
@@ -1028,12 +1029,18 @@ ChainSignal Compiler::emitPadRack(const DeviceInfo& device, const ChainSite& sit
                                    {SignalKind::Audio});
 
         // A pad's level and pan are the Drum Grid's own parameters, so a lane, a
-        // macro or a modifier over them has to reach this fader. Found by stable
-        // id rather than by arithmetic over the pad index, so a device that lays
-        // its pads out differently still resolves.
-        auto& fader = plan_.ops[static_cast<std::size_t>(faderOp)];
-        fader.padLevelParam = deviceParamIndex(device, "padLevel" + std::to_string(pad.id));
-        fader.padPanParam = deviceParamIndex(device, "padPan" + std::to_string(pad.id));
+        // macro or a modifier over them has to reach this fader.
+        //
+        // By the pad's slot, which is its bottom note, and NOT by its chain id:
+        // the device reaches these parameters the same way, and the two differ
+        // whenever pads were not made in note order. Resolved by stable id from
+        // there, so a device that declares none binds nothing and keeps the
+        // published value.
+        if (const auto slot = padParameterSlot(pad); slot >= 0) {
+            auto& fader = plan_.ops[static_cast<std::size_t>(faderOp)];
+            fader.padLevelParam = deviceParamIndex(device, "padLevel" + std::to_string(slot));
+            fader.padPanParam = deviceParamIndex(device, "padPan" + std::to_string(slot));
+        }
 
         busAudio[pad.outputIndex].push_back(PortRef{faderOp, 0});
     }

--- a/magda/engine/plan/PlanCompiler.cpp
+++ b/magda/engine/plan/PlanCompiler.cpp
@@ -957,8 +957,8 @@ ChainSignal Compiler::emitRack(const RackInfo& rack, const ChainSite& site, Chai
 ///
 /// The device itself never becomes an op. Its pads are chains, and each one is
 /// an instrument chain: it reads no audio, takes the notes its range claims, and
-/// what it makes is summed with its siblings and injected into the bus. That is
-/// what lets a Drum Grid render under an engine that cannot host one.
+/// what it makes is summed with its siblings. That is what lets a Drum Grid
+/// render under an engine that cannot host one.
 ChainSignal Compiler::emitPadRack(const DeviceInfo& device, const ChainSite& site,
                                   ChainSignal signal) {
     const auto& pads = *device.padRack.get();
@@ -966,13 +966,30 @@ ChainSignal Compiler::emitPadRack(const DeviceInfo& device, const ChainSite& sit
     if (device.bypassed)
         return signal;
 
-    std::vector<PortRef> padAudio;
+    // Keyed by the bus each pad plays out of. Bus 0 is the device's own output
+    // and flows on down the chain; the rest are output pairs a multi-out track
+    // reads, the way an instrument's further pairs are.
+    std::map<int, std::vector<PortRef>> busAudio;
 
     for (const auto& pad : pads.chains) {
         if (pad.bypassed)
             continue;
 
         const ChainSite padSite{site.trackId, pads.id, pad.id, site.segment};
+
+        // A pad plugin's DeviceId arrives when the Drum Grid restores it, so a
+        // project that has not been opened since carries none. Two such devices
+        // in one pad would key the same op, and a plan that does not validate
+        // costs the whole project rather than the pad.
+        const auto unkeyable = std::ranges::find_if(pad.elements, [](const ChainElement& element) {
+            return isDevice(element) && getDevice(element).id == INVALID_DEVICE_ID;
+        });
+        if (unkeyable != pad.elements.end()) {
+            diagnose("device " + std::to_string(device.id) + " on track " +
+                     std::to_string(site.trackId) + " pad " + std::to_string(pad.id) +
+                     ": a plugin has no device id, so the pad is not compiled");
+            continue;
+        }
 
         // The pad's own notes, transposed onto its root. A pad with no range
         // takes everything, which is what a plain parallel chain does.
@@ -989,20 +1006,6 @@ ChainSignal Compiler::emitPadRack(const DeviceInfo& device, const ChainSite& sit
             padMidi = PortRef{gateOp, 0};
         }
 
-        // A pad plugin's DeviceId arrives when the Drum Grid restores it, so a
-        // project that has not been opened since carries none. Two such devices
-        // in one pad would key the same op, and a plan that does not validate
-        // costs the whole project rather than the pad.
-        const auto unkeyable = std::ranges::find_if(pad.elements, [](const ChainElement& element) {
-            return isDevice(element) && getDevice(element).id == INVALID_DEVICE_ID;
-        });
-        if (unkeyable != pad.elements.end()) {
-            diagnose("device " + std::to_string(device.id) + " on track " +
-                     std::to_string(site.trackId) + " pad " + std::to_string(pad.id) +
-                     ": a plugin has no device id, so the pad is not compiled");
-            continue;
-        }
-
         // No audio in: a pad generates rather than processes, so the bus flows
         // past it the way it flows past an instrument.
         const auto padOut = emitElements(pad.elements, padSite, ChainSignal{noInput(), padMidi});
@@ -1012,27 +1015,69 @@ ChainSignal Compiler::emitPadRack(const DeviceInfo& device, const ChainSite& sit
         const auto faderOp = addOp(OpKind::Fader, faderKey,
                                    alignInputs(faderKey, OpKind::Fader, {padOut.audio, noInput()}),
                                    {SignalKind::Audio});
-        padAudio.push_back(PortRef{faderOp, 0});
+        busAudio[pad.outputIndex].push_back(PortRef{faderOp, 0});
     }
 
-    if (padAudio.empty())
+    // The pairs a multi-out track claimed from this device, the same map an
+    // instrument's further outputs are read through.
+    const auto targets = multiOutTargets_.find({site.trackId, device.id});
+
+    for (const auto& [bus, audio] : busAudio) {
+        if (bus == 0 || audio.empty())
+            continue;
+
+        // Mixed per bus, and keyed on the bus so two of them are two ops.
+        const OpKey busKey{site.trackId,    pads.id, INVALID_CHAIN_ID, INVALID_DEVICE_ID,
+                           OpRole::RackMix, bus,     site.segment};
+        const auto mixed = emitMix(busKey, audio);
+
+        const auto* claimed = targets == multiOutTargets_.end() ? nullptr : &targets->second;
+        const auto target =
+            claimed == nullptr ? std::map<int, TrackId>::const_iterator{} : claimed->find(bus);
+        if (claimed == nullptr || target == claimed->end()) {
+            // No track opened this pair, which is what the current engine does
+            // with a pin no RackInstance was made for. Reported rather than
+            // folded into the main mix: the model says these pads play
+            // somewhere else, and mixing them into the device's own output
+            // would render a project nobody saved.
+            diagnose("device " + std::to_string(device.id) + " on track " +
+                     std::to_string(site.trackId) + ": bus " + std::to_string(bus) +
+                     " reaches no track, the pads on it are silent");
+            continue;
+        }
+
+        pendingInputs_[target->second].push_back(mixed);
+    }
+
+    const auto main = busAudio.find(0);
+    if (main == busAudio.end() || main->second.empty())
         return signal;
 
-    // No device id, the way a rack's own mix carries none. The inject below is
-    // the same location and differs only in role, and the latency delays that
-    // land on a mix's inputs keep the id but not the role, so sharing it would
-    // key one mix's delays onto the other's.
     const OpKey mixKey{site.trackId,    pads.id, INVALID_CHAIN_ID, INVALID_DEVICE_ID,
                        OpRole::RackMix, 0,       site.segment};
-    const auto mixed = emitMix(mixKey, padAudio);
+    auto wet = emitMix(mixKey, main->second);
+
+    // The device's own slot controls. An expanded Drum Grid is still a device in
+    // the chain, so the gain and meter its slot carries have to sit where every
+    // other instrument's do: on what the device made, before it reaches the bus.
+    // Keyed where the device is, not where its pads are: these belong to the
+    // Drum Grid's own slot, and the value layer resolves a device id against the
+    // chain the device sits in.
+    OpKey slotKey{site.trackId,       site.rackId, site.chainId, device.id,
+                  OpRole::DeviceGain, 0,           site.segment};
+    wet = PortRef{addOp(OpKind::Gain, slotKey, {wet}, {SignalKind::Audio}), 0};
+
+    if (options_.deviceMeters) {
+        slotKey.role = OpRole::DeviceMeter;
+        wet = PortRef{addOp(OpKind::Meter, slotKey, {wet}, {SignalKind::Audio}), 0};
+    }
 
     ChainSignal out = signal;
     if (signal.audio.valid()) {
-        const OpKey injectKey{site.trackId,         pads.id, INVALID_CHAIN_ID, device.id,
-                              OpRole::DeviceInject, 0,       site.segment};
-        out.audio = emitMix(injectKey, {signal.audio, mixed});
+        slotKey.role = OpRole::DeviceInject;
+        out.audio = emitMix(slotKey, {signal.audio, wet});
     } else {
-        out.audio = mixed;
+        out.audio = wet;
     }
 
     return out;

--- a/magda/engine/plan/RenderPlan.hpp
+++ b/magda/engine/plan/RenderPlan.hpp
@@ -374,6 +374,17 @@ struct PlanOp {
     std::uint8_t noteGateLow = 0;
     std::uint8_t noteGateHigh = 127;
     std::int8_t noteGateTranspose = 0;
+
+    /// A pad fader's level and pan, as parameter indices of the device that
+    /// owns the pad (OpKey::deviceId).
+    ///
+    /// A rack chain's fader is not addressable in the model and keeps whatever
+    /// the value table published. A Drum Grid's pads are the exception: their
+    /// level and pan are real automatable parameters of the Drum Grid, so a lane,
+    /// a macro or a modifier can play over them and the fader has to read the
+    /// table like a track's does. -1 for every other fader.
+    int padLevelParam = -1;
+    int padPanParam = -1;
 };
 
 /**

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -304,6 +304,7 @@ if(MAGDA_BUILD_NATIVE_ENGINE)
     list(APPEND TEST_SOURCES test_plan_layout.cpp)
     # The note-range gate a pad chain needs (#2200).
     list(APPEND TEST_SOURCES test_plan_note_gate.cpp)
+    list(APPEND TEST_SOURCES test_plan_pad_rack.cpp)
     list(APPEND TEST_SOURCES test_plan_diff.cpp)
     # Rack nesting, recursion and op-key identity (#2137). Reaches the parameter
     # table as well as the plan, because the nearest-scope rule the two resolve

--- a/tests/test_drum_grid_serialization_juce.cpp
+++ b/tests/test_drum_grid_serialization_juce.cpp
@@ -825,6 +825,86 @@ class DrumGridPadChainSerializationTest final : public juce::UnitTest {
         expect(sawRealRange,
                "A compiled pad voice must report at least one parameter in real units");
 
+        runPadPluginMatching();
+    }
+
+    /// Pad plugins are matched by DeviceId, not by position (#2200).
+    ///
+    /// A plugin the engine could not create is left out of the chain while its
+    /// node stays in the saved state the projection reads. Matching by position
+    /// would then shift every device after it, handing a valid plugin's
+    /// parameters to the device that failed and leaving the valid one at its
+    /// defaults.
+    void runPadPluginMatching() {
+        beginTest("Pad plugins are matched by device id, not by position");
+
+        auto& wrapper = magda::test::getSharedEngine();
+        auto edit = te::test_utilities::createTestEdit(*wrapper.getEngine(), 1);
+        expect(edit != nullptr, "Test edit must be created");
+        if (!edit)
+            return;
+
+        auto plugin = createCustomPlugin(*edit, DrumGridPlugin::xmlTypeName);
+        auto* drumGrid = dynamic_cast<DrumGridPlugin*>(plugin.get());
+        expect(drumGrid != nullptr, "DrumGrid plugin must be created");
+        if (drumGrid == nullptr)
+            return;
+
+        constexpr int padIndex = 2;
+        drumGrid->loadInternalPluginToPad(padIndex, "magda_kick");
+
+        auto* chain = drumGrid->getChainForNote(DrumGridPlugin::baseNote + padIndex);
+        expect(chain != nullptr, "Pad chain must exist");
+        if (chain == nullptr || chain->plugins.empty())
+            return;
+
+        const auto liveId = drumGrid->getPluginDeviceId(chain->index, 0);
+        expect(liveId != magda::INVALID_DEVICE_ID, "The pad's plugin must carry a device id");
+
+        magda::DeviceInfo device;
+        device.id = 7;
+        device.pluginId = DrumGridPlugin::xmlTypeName;
+        device.pluginState =
+            magda::daw::audio::tracktion_adapter::captureInternalDeviceState(*plugin, {});
+
+        magda::refreshPadRack(device);
+        expect(static_cast<bool>(device.padRack), "The projection must find the pads");
+        if (!device.padRack)
+            return;
+
+        // A device the live chain has no plugin for, standing where one that
+        // failed to create would: ahead of the real one, so a positional match
+        // would hand it the kick's parameters.
+        for (auto& pad : device.padRack->chains) {
+            if (pad.elements.empty())
+                continue;
+
+            magda::DeviceInfo missing;
+            missing.id = 9999;
+            missing.pluginId = "magda_kick";
+            pad.elements.insert(pad.elements.begin(), missing);
+            break;
+        }
+
+        magda::daw::audio::populatePadDeviceParameters(device, *drumGrid);
+
+        for (const auto& pad : device.padRack->chains) {
+            for (const auto& element : pad.elements) {
+                if (!magda::isDevice(element))
+                    continue;
+
+                const auto& padDevice = magda::getDevice(element);
+                if (padDevice.id == 9999)
+                    expect(padDevice.parameters.empty(),
+                           "A device with no live plugin must get no parameters");
+                else if (padDevice.id == liveId)
+                    expect(!padDevice.parameters.empty(),
+                           "The device the live plugin belongs to must still get its parameters");
+            }
+        }
+
+        juce::MessageManager::getInstance()->runDispatchLoopUntil(50);
+
         juce::MessageManager::getInstance()->runDispatchLoopUntil(50);
     }
 };

--- a/tests/test_drum_grid_serialization_juce.cpp
+++ b/tests/test_drum_grid_serialization_juce.cpp
@@ -5,9 +5,13 @@
 #include "SharedTestEngine.hpp"
 #include "magda/daw/audio/AudioBridge.hpp"
 #include "magda/daw/audio/TracktionHelpers.hpp"
+#include "magda/daw/audio/plugins/DrumGridPadParameters.hpp"
 #include "magda/daw/audio/plugins/DrumGridPlugin.hpp"
 #include "magda/daw/audio/plugins/MagdaSamplerPlugin.hpp"
+#include "magda/daw/audio/plugins/tracktion/TracktionDeviceStateBridge.hpp"
 #include "magda/daw/core/ClipManager.hpp"
+#include "magda/daw/core/DrumGridPads.hpp"
+#include "magda/daw/core/RackInfo.hpp"
 #include "magda/daw/core/TrackManager.hpp"
 #include "magda/daw/project/ProjectManager.hpp"
 #include "magda/daw/project/serialization/ProjectSerializer.hpp"
@@ -730,6 +734,74 @@ class DrumGridPadChainSerializationTest final : public juce::UnitTest {
         cm.clearAllClips();
         tm.clearAllTracks();
         tm.setAudioEngine(nullptr);
+        juce::MessageManager::getInstance()->runDispatchLoopUntil(50);
+
+        runPadParameterProjection();
+    }
+
+    /// A pad's device carries the plugin's parameters (#2200).
+    ///
+    /// The projection reads a Drum Grid's pads out of its saved state, which
+    /// holds a plugin's parameter values but not their names, ranges or count:
+    /// only the plugin answers those. Without them the parameter table allocates
+    /// no window for a pad's device, and the engine's factory restores
+    /// everything EXCEPT parameters, so a native-capable plugin in a pad would
+    /// run at its defaults rather than at what the project saved.
+    void runPadParameterProjection() {
+        beginTest("A pad's device carries its plugin's parameters");
+
+        auto& wrapper = magda::test::getSharedEngine();
+        auto edit = te::test_utilities::createTestEdit(*wrapper.getEngine(), 1);
+        expect(edit != nullptr, "Test edit must be created");
+        if (!edit)
+            return;
+
+        auto plugin = createCustomPlugin(*edit, DrumGridPlugin::xmlTypeName);
+        auto* drumGrid = dynamic_cast<DrumGridPlugin*>(plugin.get());
+        expect(drumGrid != nullptr, "DrumGrid plugin must be created");
+        if (drumGrid == nullptr)
+            return;
+
+        constexpr int padIndex = 3;
+        drumGrid->loadInternalPluginToPad(padIndex, "magda_kick");
+
+        magda::DeviceInfo device;
+        device.id = 7;
+        device.pluginId = DrumGridPlugin::xmlTypeName;
+        device.pluginState =
+            magda::daw::audio::tracktion_adapter::captureInternalDeviceState(*plugin, {});
+
+        magda::refreshPadRack(device);
+        expect(static_cast<bool>(device.padRack), "The projection must find the pads");
+        if (!device.padRack)
+            return;
+
+        // The projection alone leaves them empty: the values are in the state,
+        // the parameters are not.
+        for (const auto& pad : device.padRack->chains)
+            for (const auto& element : pad.elements)
+                if (magda::isDevice(element))
+                    expect(magda::getDevice(element).parameters.empty(),
+                           "The projection must not invent parameters");
+
+        magda::daw::audio::populatePadDeviceParameters(device, *drumGrid);
+
+        int padDevices = 0;
+        int withParameters = 0;
+        for (const auto& pad : device.padRack->chains) {
+            for (const auto& element : pad.elements) {
+                if (!magda::isDevice(element))
+                    continue;
+                ++padDevices;
+                if (!magda::getDevice(element).parameters.empty())
+                    ++withParameters;
+            }
+        }
+
+        expect(padDevices > 0, "The pad must project a device");
+        expectEquals(withParameters, padDevices,
+                     "Every pad device must carry its plugin's parameters");
+
         juce::MessageManager::getInstance()->runDispatchLoopUntil(50);
     }
 };

--- a/tests/test_drum_grid_serialization_juce.cpp
+++ b/tests/test_drum_grid_serialization_juce.cpp
@@ -802,6 +802,29 @@ class DrumGridPadChainSerializationTest final : public juce::UnitTest {
         expectEquals(withParameters, padDevices,
                      "Every pad device must carry its plugin's parameters");
 
+        // And carry them in real units. A device behind the SDK exposes its
+        // Tracktion parameters normalized, so reading those directly would
+        // record every parameter as 0 to 1 and the native engine, which takes
+        // this metadata at face value, would render a kick's pitch as a fraction
+        // of a Hz clamped to the parameter's minimum.
+        bool sawRealRange = false;
+        for (const auto& pad : device.padRack->chains) {
+            for (const auto& element : pad.elements) {
+                if (!magda::isDevice(element))
+                    continue;
+                for (const auto& param : magda::getDevice(element).parameters) {
+                    if (param.maxValue > 1.01f) {
+                        sawRealRange = true;
+                        expect(param.currentValue >= param.minValue &&
+                                   param.currentValue <= param.maxValue,
+                               "A parameter's value must sit inside its own range");
+                    }
+                }
+            }
+        }
+        expect(sawRealRange,
+               "A compiled pad voice must report at least one parameter in real units");
+
         juce::MessageManager::getInstance()->runDispatchLoopUntil(50);
     }
 };

--- a/tests/test_plan_pad_rack.cpp
+++ b/tests/test_plan_pad_rack.cpp
@@ -1,0 +1,221 @@
+#include <catch2/catch_test_macros.hpp>
+#include <string>
+#include <vector>
+
+#include "core/DrumGridPads.hpp"
+#include "core/RackInfo.hpp"
+#include "core/TrackInfo.hpp"
+#include "plan/PlanCompiler.hpp"
+#include "plan/PlanDump.hpp"
+#include "plan/RenderPlan.hpp"
+
+// Compiling a pad-per-chain device (#2200). The device never becomes an op:
+// its pads are instrument chains, each gated to the notes its range claims.
+
+using namespace magda;
+using magda::engine::OpKind;
+using magda::engine::OpRole;
+using magda::engine::RenderPlan;
+
+namespace {
+
+TrackInfo makeTrack(TrackId id) {
+    TrackInfo track;
+    track.id = id;
+    track.name = "Track " + juce::String(id);
+    track.audioOutputDevice = "master";
+    return track;
+}
+
+TrackInfo makeMaster() {
+    auto master = makeTrack(MASTER_TRACK_ID);
+    master.type = TrackType::Master;
+    master.audioOutputDevice = {};
+    return master;
+}
+
+DeviceInfo makePadInstrument(DeviceId id) {
+    DeviceInfo device;
+    device.id = id;
+    device.name = "Sampler " + juce::String(id);
+    device.pluginId = "magdasampler";
+    device.isInstrument = true;
+    device.deviceType = DeviceType::Instrument;
+    device.format = PluginFormat::Internal;
+    device.audioOutputChannels = 2;
+    return device;
+}
+
+ChainInfo makePad(ChainId id, int lowNote, int highNote, int rootNote, DeviceId deviceId) {
+    ChainInfo pad;
+    pad.id = id;
+    pad.name = "Pad " + juce::String(id);
+    pad.lowNote = lowNote;
+    pad.highNote = highNote;
+    pad.rootNote = rootNote;
+    pad.elements.push_back(makePadInstrument(deviceId));
+    return pad;
+}
+
+/// A Drum Grid with two pads, as the projection produces one.
+DeviceInfo makeDrumGrid(DeviceId id, std::vector<ChainInfo> pads) {
+    DeviceInfo drumGrid;
+    drumGrid.id = id;
+    drumGrid.name = "Drum Grid";
+    drumGrid.pluginId = "drumgrid";
+    drumGrid.isInstrument = true;
+    drumGrid.deviceType = DeviceType::Instrument;
+    drumGrid.format = PluginFormat::Internal;
+
+    auto rack = std::make_unique<RackInfo>();
+    rack->id = padRackIdFor(id);
+    rack->chains = std::move(pads);
+    drumGrid.padRack.reset(std::move(rack));
+
+    return drumGrid;
+}
+
+RenderPlan compileWith(DeviceInfo drumGrid) {
+    auto track = makeTrack(1);
+    track.chain.fxChainElements.push_back(std::move(drumGrid));
+    return magda::engine::compileRenderPlan({track}, makeMaster(), {});
+}
+
+std::vector<const magda::engine::PlanOp*> opsOfKind(const RenderPlan& plan, OpKind kind) {
+    std::vector<const magda::engine::PlanOp*> found;
+    for (const auto& op : plan.ops)
+        if (op.kind == kind)
+            found.push_back(&op);
+    return found;
+}
+
+}  // namespace
+
+TEST_CASE("A pad rack compiles to a well formed plan", "[engine][plan][padrack]") {
+    const auto plan =
+        compileWith(makeDrumGrid(10, {makePad(0, 36, 36, 60, 101), makePad(1, 38, 40, 60, 102)}));
+
+    const auto problems = magda::engine::validatePlan(plan);
+    for (const auto& problem : problems)
+        UNSCOPED_INFO("validate: " << problem);
+    CHECK(problems.empty());
+
+    for (const auto& diagnostic : plan.diagnostics)
+        UNSCOPED_INFO("diagnostic: " << diagnostic);
+}
+
+TEST_CASE("Each pad gets its own note gate", "[engine][plan][padrack]") {
+    const auto plan =
+        compileWith(makeDrumGrid(10, {makePad(0, 36, 36, 60, 101), makePad(1, 38, 40, 60, 102)}));
+
+    const auto gates = opsOfKind(plan, OpKind::MidiNoteGate);
+    REQUIRE(gates.size() == 2);
+
+    CHECK(gates[0]->noteGateLow == 36);
+    CHECK(gates[0]->noteGateHigh == 36);
+    CHECK(gates[0]->noteGateTranspose == 24);
+
+    CHECK(gates[1]->noteGateLow == 38);
+    CHECK(gates[1]->noteGateHigh == 40);
+    CHECK(gates[1]->noteGateTranspose == 22);
+
+    // Keyed apart, or the differ carries one pad into the other.
+    CHECK_FALSE(gates[0]->key == gates[1]->key);
+}
+
+TEST_CASE("A Drum Grid itself is never a device op", "[engine][plan][padrack]") {
+    const auto plan =
+        compileWith(makeDrumGrid(10, {makePad(0, 36, 36, 60, 101), makePad(1, 38, 40, 60, 102)}));
+
+    for (const auto* op : opsOfKind(plan, OpKind::Device))
+        CHECK(op->key.deviceId != 10);
+
+    // The pads' own devices are what run.
+    std::vector<DeviceId> deviceIds;
+    for (const auto* op : opsOfKind(plan, OpKind::Device))
+        deviceIds.push_back(op->key.deviceId);
+    CHECK(std::find(deviceIds.begin(), deviceIds.end(), 101) != deviceIds.end());
+    CHECK(std::find(deviceIds.begin(), deviceIds.end(), 102) != deviceIds.end());
+}
+
+TEST_CASE("A pad that answers to every note needs no gate", "[engine][plan][padrack]") {
+    auto pad = makePad(0, 0, -1, 0, 101);
+    REQUIRE(pad.answersToEveryNote());
+
+    const auto plan = compileWith(makeDrumGrid(10, {std::move(pad)}));
+    CHECK(opsOfKind(plan, OpKind::MidiNoteGate).empty());
+}
+
+TEST_CASE("A bypassed Drum Grid passes the chain through", "[engine][plan][padrack]") {
+    auto drumGrid = makeDrumGrid(10, {makePad(0, 36, 36, 60, 101)});
+    drumGrid.bypassed = true;
+
+    const auto plan = compileWith(std::move(drumGrid));
+    CHECK(opsOfKind(plan, OpKind::MidiNoteGate).empty());
+    for (const auto* op : opsOfKind(plan, OpKind::Device))
+        CHECK(op->key.deviceId != 101);
+}
+
+TEST_CASE("A bypassed pad is left out of the mix", "[engine][plan][padrack]") {
+    auto quiet = makePad(1, 38, 40, 60, 102);
+    quiet.bypassed = true;
+
+    const auto plan =
+        compileWith(makeDrumGrid(10, {makePad(0, 36, 36, 60, 101), std::move(quiet)}));
+
+    REQUIRE(opsOfKind(plan, OpKind::MidiNoteGate).size() == 1);
+    for (const auto* op : opsOfKind(plan, OpKind::Device))
+        CHECK(op->key.deviceId != 102);
+}
+
+TEST_CASE("A Drum Grid inside a rack compiles", "[engine][plan][padrack]") {
+    // 1.0.0-drumgrid-rack.mgd's shape: the pad rack is nested in a user rack, so
+    // the pad ops carry the pad rack's id while the chain around them carries
+    // the outer rack's.
+    auto chain = ChainInfo{};
+    chain.id = 1;
+    chain.elements.push_back(
+        makeDrumGrid(10, {makePad(0, 36, 36, 60, 101), makePad(1, 38, 40, 60, 102)}));
+
+    auto rack = std::make_unique<RackInfo>();
+    rack->id = 1;
+    rack->chains.push_back(std::move(chain));
+
+    auto track = makeTrack(1);
+    track.chain.fxChainElements.push_back(std::move(rack));
+
+    const auto plan = magda::engine::compileRenderPlan({track}, makeMaster(), {});
+
+    const auto problems = magda::engine::validatePlan(plan);
+    for (const auto& problem : problems)
+        UNSCOPED_INFO("validate: " << problem);
+    CHECK(problems.empty());
+
+    CHECK(opsOfKind(plan, OpKind::MidiNoteGate).size() == 2);
+}
+
+TEST_CASE("A pad device with no id is reported, not compiled to a broken plan",
+          "[engine][plan][padrack]") {
+    // Both corpus projects are old enough that their pad plugins carry no
+    // DeviceId: a Drum Grid allocates one when it restores a plugin, so they
+    // arrive on capture and not at load. Two such devices in one pad would key
+    // the same op, and a malformed plan costs the whole project rather than the
+    // pad.
+    auto pad = makePad(0, 36, 36, 60, INVALID_DEVICE_ID);
+    auto effect = makePadInstrument(INVALID_DEVICE_ID);
+    effect.isInstrument = false;
+    effect.deviceType = DeviceType::Effect;
+    pad.elements.push_back(std::move(effect));
+
+    const auto plan = compileWith(makeDrumGrid(10, {std::move(pad)}));
+
+    const auto problems = magda::engine::validatePlan(plan);
+    for (const auto& problem : problems)
+        UNSCOPED_INFO("validate: " << problem);
+    CHECK(problems.empty());
+
+    const auto said = std::ranges::any_of(plan.diagnostics, [](const std::string& diagnostic) {
+        return diagnostic.find("no device id") != std::string::npos;
+    });
+    CHECK(said);
+}

--- a/tests/test_plan_pad_rack.cpp
+++ b/tests/test_plan_pad_rack.cpp
@@ -45,6 +45,11 @@ DeviceInfo makePadInstrument(DeviceId id) {
     device.deviceType = DeviceType::Instrument;
     device.format = PluginFormat::Internal;
     device.audioOutputChannels = 2;
+    // What capture puts there. The projection reads a pad's parameter VALUES out
+    // of the saved state but not their names, ranges or count, so a pad device
+    // reaches the compiler with parameters only once the Drum Grid has been in
+    // hand (populatePadDeviceParameters). Without them the table allocates no
+    // window and the device runs at its defaults.
     device.parameters.push_back(ParameterInfo(0, "Level", "", 0.0f, 1.0f, 0.5f));
     return device;
 }

--- a/tests/test_plan_pad_rack.cpp
+++ b/tests/test_plan_pad_rack.cpp
@@ -5,6 +5,7 @@
 #include "core/DrumGridPads.hpp"
 #include "core/RackInfo.hpp"
 #include "core/TrackInfo.hpp"
+#include "param/ParamTableCompiler.hpp"
 #include "plan/PlanCompiler.hpp"
 #include "plan/PlanDump.hpp"
 #include "plan/RenderPlan.hpp"
@@ -43,6 +44,7 @@ DeviceInfo makePadInstrument(DeviceId id) {
     device.deviceType = DeviceType::Instrument;
     device.format = PluginFormat::Internal;
     device.audioOutputChannels = 2;
+    device.parameters.push_back(ParameterInfo(0, "Level", "", 0.0f, 1.0f, 0.5f));
     return device;
 }
 
@@ -218,4 +220,63 @@ TEST_CASE("A pad device with no id is reported, not compiled to a broken plan",
         return diagnostic.find("no device id") != std::string::npos;
     });
     CHECK(said);
+}
+
+TEST_CASE("A pad's mix keeps the Drum Grid's slot gain and meter", "[engine][plan][padrack]") {
+    // An expanded Drum Grid is still a device in the chain: what it made has to
+    // pass its slot's gain and meter before it reaches the bus, the way every
+    // other instrument's output does.
+    const auto plan = compileWith(makeDrumGrid(10, {makePad(0, 36, 36, 60, 101)}));
+
+    const auto gains = opsOfKind(plan, OpKind::Gain);
+    const auto slotGain = std::ranges::find_if(gains, [](const magda::engine::PlanOp* op) {
+        return op->key.role == OpRole::DeviceGain && op->key.deviceId == 10;
+    });
+    REQUIRE(slotGain != gains.end());
+
+    const auto meters = opsOfKind(plan, OpKind::Meter);
+    CHECK(std::ranges::any_of(meters, [](const magda::engine::PlanOp* op) {
+        return op->key.role == OpRole::DeviceMeter && op->key.deviceId == 10;
+    }));
+}
+
+TEST_CASE("Pads on an unclaimed bus are reported, not folded into the main mix",
+          "[engine][plan][padrack]") {
+    // The model says these pads play somewhere else. Mixing them into the
+    // device's own output would render a project nobody saved.
+    auto aux = makePad(1, 38, 40, 60, 102);
+    aux.outputIndex = 2;
+
+    const auto plan = compileWith(makeDrumGrid(10, {makePad(0, 36, 36, 60, 101), std::move(aux)}));
+
+    CHECK(std::ranges::any_of(plan.diagnostics, [](const std::string& diagnostic) {
+        return diagnostic.find("bus 2 reaches no track") != std::string::npos;
+    }));
+
+    // The main mix takes one pad, not both.
+    const auto mixes = opsOfKind(plan, OpKind::MixAudio);
+    const auto mainMix = std::ranges::find_if(mixes, [](const magda::engine::PlanOp* op) {
+        return op->key.role == OpRole::RackMix && op->key.index == 0;
+    });
+    if (mainMix != mixes.end())
+        CHECK((*mainMix)->inputs.size() == 1);
+}
+
+TEST_CASE("A pad's devices reach the parameter table", "[engine][plan][padrack]") {
+    // Without the pad-rack walk, a pad device's parameters, macros and mods have
+    // no address and nothing consumes them.
+    auto track = makeTrack(1);
+    track.chain.fxChainElements.push_back(
+        makeDrumGrid(10, {makePad(0, 36, 36, 60, 101), makePad(1, 38, 40, 60, 102)}));
+
+    const auto plan = magda::engine::compileRenderPlan({track}, makeMaster(), {});
+    const auto table = magda::engine::compileParamTable(plan, {track}, makeMaster());
+
+    const auto addressed = [&](DeviceId deviceId) {
+        return std::ranges::any_of(table.keys, [deviceId](const magda::engine::ParamKey& key) {
+            return key.device.deviceId == deviceId;
+        });
+    };
+    CHECK(addressed(101));
+    CHECK(addressed(102));
 }

--- a/tests/test_plan_pad_rack.cpp
+++ b/tests/test_plan_pad_rack.cpp
@@ -2,11 +2,13 @@
 #include <string>
 #include <vector>
 
+#include "core/ControlTarget.hpp"
 #include "core/DrumGridPads.hpp"
 #include "core/RackInfo.hpp"
 #include "core/TrackInfo.hpp"
 #include "exec/PlanValues.hpp"
 #include "exec/RuntimeStateStore.hpp"
+#include "param/ParamKey.hpp"
 #include "param/ParamTableCompiler.hpp"
 #include "plan/PlanCompiler.hpp"
 #include "plan/PlanDump.hpp"
@@ -436,4 +438,44 @@ TEST_CASE("A populated soloed pad still silences its siblings", "[engine][plan][
         else if (op.key.chainId == 1)
             CHECK_FALSE(values.ops[i].silent);
     }
+}
+
+TEST_CASE("A macro on a pad device's parameter resolves", "[engine][plan][padrack]") {
+    // A stored link to a pad device names the Drum Grid in the rack slot of its
+    // path (the chainDevice path syncDrumGridPadPlugins and the ADSR macro links
+    // are built with). ParamKey carries the rack id, so addressing pad devices
+    // under the pad rack's own synthetic id would put them where no link can
+    // find them, and every macro, mod and lane on a pad would silently do
+    // nothing.
+    constexpr DeviceId kDrumGrid = 10;
+    constexpr DeviceId kPadDevice = 101;
+    constexpr ChainId kPad = 0;
+
+    auto drumGrid = makeDrumGrid(kDrumGrid, {makePad(kPad, 36, 36, 60, kPadDevice)});
+
+    magda::MacroLink link;
+    link.target = magda::ControlTarget::pluginParam(
+        magda::ChainNodePath::chainDevice(1, kDrumGrid, kPad, kPadDevice), 0);
+    link.amount = 1.0f;
+    drumGrid.macros[0].links.push_back(link);
+
+    auto track = makeTrack(1);
+    track.chain.fxChainElements.push_back(std::move(drumGrid));
+
+    const auto plan = magda::engine::compileRenderPlan({track}, makeMaster(), {});
+    const auto table = magda::engine::compileParamTable(plan, {track}, makeMaster());
+
+    for (const auto& diagnostic : table.diagnostics)
+        UNSCOPED_INFO("param table: " << diagnostic);
+
+    const auto unresolved =
+        std::ranges::any_of(table.diagnostics, [](const std::string& diagnostic) {
+            return diagnostic.find("which the project does not have") != std::string::npos;
+        });
+    CHECK_FALSE(unresolved);
+
+    // And the address the link names is one the table actually carries.
+    const auto key = magda::engine::paramKeyFor(link.target);
+    REQUIRE(key.has_value());
+    CHECK(table.find(*key) != magda::engine::INVALID_PARAM_ID);
 }

--- a/tests/test_plan_pad_rack.cpp
+++ b/tests/test_plan_pad_rack.cpp
@@ -5,6 +5,7 @@
 #include "core/DrumGridPads.hpp"
 #include "core/RackInfo.hpp"
 #include "core/TrackInfo.hpp"
+#include "exec/RuntimeStateStore.hpp"
 #include "param/ParamTableCompiler.hpp"
 #include "plan/PlanCompiler.hpp"
 #include "plan/PlanDump.hpp"
@@ -279,4 +280,74 @@ TEST_CASE("A pad's devices reach the parameter table", "[engine][plan][padrack]"
     };
     CHECK(addressed(101));
     CHECK(addressed(102));
+}
+
+TEST_CASE("A bypassed Drum Grid keeps its pad devices' runtimes", "[engine][plan][padrack]") {
+    // Bypass takes the pad Device ops out of the plan. If the model id set does
+    // not name the pad devices either, their runtimes are released and
+    // re-enabling rebuilds the plugins, losing their tails and state.
+    auto drumGrid = makeDrumGrid(10, {makePad(0, 36, 36, 60, 101), makePad(1, 38, 40, 60, 102)});
+    drumGrid.bypassed = true;
+
+    auto track = makeTrack(1);
+    track.chain.fxChainElements.push_back(std::move(drumGrid));
+
+    const auto ids = magda::engine::collectRuntimeStateIds({track}, makeMaster());
+
+    const auto named = [&](DeviceId deviceId) {
+        return ids.devices.contains(magda::engine::DeviceKey{ChainSegment::Fx, deviceId});
+    };
+    CHECK(named(10));
+    CHECK(named(101));
+    CHECK(named(102));
+}
+
+TEST_CASE("A pad fader is bound to the Drum Grid's own level and pan parameters",
+          "[engine][plan][padrack]") {
+    // A rack chain's fader keeps whatever the value table published, because a
+    // rack chain is not addressable in the model. A Drum Grid's pads are the
+    // exception: their level and pan are real parameters of the Drum Grid, so a
+    // lane, a macro or a modifier over them has to reach the fader.
+    auto drumGrid = makeDrumGrid(10, {makePad(0, 36, 36, 60, 101), makePad(1, 38, 40, 60, 102)});
+    const auto padParam = [](int index, const char* stableId, float min, float max) {
+        ParameterInfo param(index, stableId, "", min, max, 0.0f);
+        param.stableId = stableId;
+        return param;
+    };
+    drumGrid.parameters.push_back(padParam(0, "padLevel0", -60.0f, 12.0f));
+    drumGrid.parameters.push_back(padParam(1, "padPan0", -1.0f, 1.0f));
+    drumGrid.parameters.push_back(padParam(2, "padLevel1", -60.0f, 12.0f));
+    drumGrid.parameters.push_back(padParam(3, "padPan1", -1.0f, 1.0f));
+
+    const auto plan = compileWith(std::move(drumGrid));
+
+    const auto faders = opsOfKind(plan, OpKind::Fader);
+    std::vector<const magda::engine::PlanOp*> padFaders;
+    for (const auto* op : faders)
+        if (op->key.role == OpRole::RackChainFader)
+            padFaders.push_back(op);
+
+    REQUIRE(padFaders.size() == 2);
+
+    // Keyed to the owning device, which is how the executor reaches its window.
+    CHECK(padFaders[0]->key.deviceId == 10);
+    CHECK(padFaders[1]->key.deviceId == 10);
+
+    CHECK(padFaders[0]->padLevelParam == 0);
+    CHECK(padFaders[0]->padPanParam == 1);
+    CHECK(padFaders[1]->padLevelParam == 2);
+    CHECK(padFaders[1]->padPanParam == 3);
+}
+
+TEST_CASE("A pad fader on a device with no pad parameters binds nothing",
+          "[engine][plan][padrack]") {
+    // Resolved by stable id, so a device that declares none simply keeps the
+    // published value rather than reading whatever sits at that index.
+    const auto plan = compileWith(makeDrumGrid(10, {makePad(0, 36, 36, 60, 101)}));
+
+    for (const auto* op : opsOfKind(plan, OpKind::Fader))
+        if (op->key.role == OpRole::RackChainFader) {
+            CHECK(op->padLevelParam == -1);
+            CHECK(op->padPanParam == -1);
+        }
 }

--- a/tests/test_plan_pad_rack.cpp
+++ b/tests/test_plan_pad_rack.cpp
@@ -5,6 +5,7 @@
 #include "core/DrumGridPads.hpp"
 #include "core/RackInfo.hpp"
 #include "core/TrackInfo.hpp"
+#include "exec/PlanValues.hpp"
 #include "exec/RuntimeStateStore.hpp"
 #include "param/ParamTableCompiler.hpp"
 #include "plan/PlanCompiler.hpp"
@@ -376,4 +377,63 @@ TEST_CASE("A pad fader on a device with no pad parameters binds nothing",
             CHECK(op->padLevelParam == -1);
             CHECK(op->padPanParam == -1);
         }
+}
+
+TEST_CASE("An empty soloed pad does not silence the populated ones", "[engine][plan][padrack]") {
+    // Removing a pad's last plugin leaves the chain behind. The Drum Grid counts
+    // solo only on pads that have something to run, so an empty soloed pad plays
+    // every populated pad beside it; treating it as a solo would silence them.
+    auto empty = makePad(1, 38, 40, 60, 102);
+    empty.elements.clear();
+    empty.solo = true;
+
+    auto drumGrid = makeDrumGrid(10, {makePad(0, 36, 36, 60, 101), std::move(empty)});
+
+    auto track = makeTrack(1);
+    track.chain.fxChainElements.push_back(std::move(drumGrid));
+
+    const auto plan = magda::engine::compileRenderPlan({track}, makeMaster(), {});
+
+    magda::engine::PlanValues values;
+    magda::engine::resolvePlanValues(plan, {track}, makeMaster(), values);
+
+    bool sawPopulatedPad = false;
+    for (std::size_t i = 0; i < plan.ops.size(); ++i) {
+        const auto& op = plan.ops[i];
+        if (op.kind != OpKind::Fader || op.key.role != OpRole::RackChainFader)
+            continue;
+        if (op.key.chainId != 0)
+            continue;
+
+        sawPopulatedPad = true;
+        CHECK_FALSE(values.ops[i].silent);
+    }
+
+    CHECK(sawPopulatedPad);
+}
+
+TEST_CASE("A populated soloed pad still silences its siblings", "[engine][plan][padrack]") {
+    auto soloed = makePad(1, 38, 40, 60, 102);
+    soloed.solo = true;
+
+    auto drumGrid = makeDrumGrid(10, {makePad(0, 36, 36, 60, 101), std::move(soloed)});
+
+    auto track = makeTrack(1);
+    track.chain.fxChainElements.push_back(std::move(drumGrid));
+
+    const auto plan = magda::engine::compileRenderPlan({track}, makeMaster(), {});
+
+    magda::engine::PlanValues values;
+    magda::engine::resolvePlanValues(plan, {track}, makeMaster(), values);
+
+    for (std::size_t i = 0; i < plan.ops.size(); ++i) {
+        const auto& op = plan.ops[i];
+        if (op.kind != OpKind::Fader || op.key.role != OpRole::RackChainFader)
+            continue;
+
+        if (op.key.chainId == 0)
+            CHECK(values.ops[i].silent);
+        else if (op.key.chainId == 1)
+            CHECK_FALSE(values.ops[i].silent);
+    }
 }

--- a/tests/test_plan_pad_rack.cpp
+++ b/tests/test_plan_pad_rack.cpp
@@ -302,41 +302,62 @@ TEST_CASE("A bypassed Drum Grid keeps its pad devices' runtimes", "[engine][plan
     CHECK(named(102));
 }
 
-TEST_CASE("A pad fader is bound to the Drum Grid's own level and pan parameters",
-          "[engine][plan][padrack]") {
-    // A rack chain's fader keeps whatever the value table published, because a
-    // rack chain is not addressable in the model. A Drum Grid's pads are the
-    // exception: their level and pan are real parameters of the Drum Grid, so a
-    // lane, a macro or a modifier over them has to reach the fader.
-    auto drumGrid = makeDrumGrid(10, {makePad(0, 36, 36, 60, 101), makePad(1, 38, 40, 60, 102)});
+TEST_CASE("A pad fader binds by the pad's slot, not by its chain id", "[engine][plan][padrack]") {
+    // A Drum Grid reaches padLevelN and padPanN by the pad's bottom note, not by
+    // the order its chains were made, so the two differ whenever pads were not
+    // added in note order. Binding by chain id would have this pad, which sits
+    // at slot 13, reading slot 0's level.
+    //
+    // Pad 0 here is chain id 0 at note 24, which is slot 0 -- the case where the
+    // two agree, and the one that hid this.
+    auto drumGrid = makeDrumGrid(10, {makePad(0, 24, 24, 60, 101), makePad(1, 37, 37, 60, 102)});
+
     const auto padParam = [](int index, const char* stableId, float min, float max) {
         ParameterInfo param(index, stableId, "", min, max, 0.0f);
         param.stableId = stableId;
         return param;
     };
-    drumGrid.parameters.push_back(padParam(0, "padLevel0", -60.0f, 12.0f));
-    drumGrid.parameters.push_back(padParam(1, "padPan0", -1.0f, 1.0f));
-    drumGrid.parameters.push_back(padParam(2, "padLevel1", -60.0f, 12.0f));
-    drumGrid.parameters.push_back(padParam(3, "padPan1", -1.0f, 1.0f));
+    // The device declares a fixed pair per pad, in slot order.
+    for (int slot = 0; slot < 20; ++slot) {
+        drumGrid.parameters.push_back(
+            padParam(slot * 2, ("padLevel" + std::to_string(slot)).c_str(), -60.0f, 12.0f));
+        drumGrid.parameters.push_back(
+            padParam(slot * 2 + 1, ("padPan" + std::to_string(slot)).c_str(), -1.0f, 1.0f));
+    }
 
     const auto plan = compileWith(std::move(drumGrid));
 
-    const auto faders = opsOfKind(plan, OpKind::Fader);
     std::vector<const magda::engine::PlanOp*> padFaders;
-    for (const auto* op : faders)
+    for (const auto* op : opsOfKind(plan, OpKind::Fader))
         if (op->key.role == OpRole::RackChainFader)
             padFaders.push_back(op);
 
     REQUIRE(padFaders.size() == 2);
-
-    // Keyed to the owning device, which is how the executor reaches its window.
     CHECK(padFaders[0]->key.deviceId == 10);
-    CHECK(padFaders[1]->key.deviceId == 10);
 
+    // Note 24 is slot 0: parameters 0 and 1.
     CHECK(padFaders[0]->padLevelParam == 0);
     CHECK(padFaders[0]->padPanParam == 1);
-    CHECK(padFaders[1]->padLevelParam == 2);
-    CHECK(padFaders[1]->padPanParam == 3);
+
+    // Note 37 is slot 13, whatever its chain id: parameters 26 and 27. Chain id
+    // 1 would have read 2 and 3.
+    CHECK(padFaders[1]->padLevelParam == 26);
+    CHECK(padFaders[1]->padPanParam == 27);
+}
+
+TEST_CASE("A pad whose range starts below the grid binds nothing", "[engine][plan][padrack]") {
+    // No slot to read, so the fader keeps the published value rather than
+    // reading whichever parameter a negative index landed on.
+    auto drumGrid = makeDrumGrid(10, {makePad(0, 12, 12, 60, 101)});
+    ParameterInfo level(0, "padLevel0", "", -60.0f, 12.0f, 0.0f);
+    level.stableId = "padLevel0";
+    drumGrid.parameters.push_back(level);
+
+    const auto plan = compileWith(std::move(drumGrid));
+
+    for (const auto* op : opsOfKind(plan, OpKind::Fader))
+        if (op->key.role == OpRole::RackChainFader)
+            CHECK(op->padLevelParam == -1);
 }
 
 TEST_CASE("A pad fader on a device with no pad parameters binds nothing",


### PR DESCRIPTION
Closes #2200. The last of three steps: #2199 put a Drum Grid's pads in the model,
#2201 gave the plan a note gate, and this expands one into the other. A Drum Grid
renders under an engine that cannot host one.

## What it does

The device never becomes an op. Its pads are chains and each is an instrument
chain: it reads no audio, takes the notes its range claims through a
`MidiNoteGate`, and what it makes is summed with its siblings and injected into
the bus the way an instrument's output is.

A pad that answers to every note gets no gate at all, because a chain that takes
everything is what a plain parallel rack chain already is.

## A pad rack is a rack

It carries a `RackId` of its own, negative and derived from the device that owns
it. Rack ids the app allocates start at 1, so the negative space is free and
nothing has to reach an allocator that does not exist at projection time.

That is what keeps this from being a special case: the value layer's rack lookup
descends into a device's pads as well as a chain's racks, so a pad's mute, solo
and fader resolve through the same code every other chain uses.

## Two things only real projects found

**The rack mix and the inject collided.** They sat at one location and differed
only in role. The latency delays that land on a mix's inputs keep the id but not
the role, so one mix's delays keyed onto the other's and the plan did not
validate. The mix carries no device id now, which is what a rack's own mix
already does.

**Pads with no DeviceId.** A pad plugin's id arrives when the Drum Grid restores
that plugin, so a project not opened since carries none, and both corpus projects
are that old. Two such devices in one pad key the same op. The pad is now
reported and left out rather than compiled: a plan that does not validate costs
the whole project, where a diagnostic costs the pad.

Worth a decision, and the reason I am flagging it rather than burying it: those
pads only compile once a project has been opened and re-saved. If that is not
acceptable, the fix is resolving ids at load rather than at capture, which is its
own change.

## Survey

Clean and renderable: **six of twenty-two to seven**. `drumgrid` leaves the
blocked-device table entirely.

- `0.4.8-drumgrid.mgd`: clean.
- `1.0.0-drumgrid-rack.mgd`: from a refused plan to a render with a diagnostic
  naming the pad it could not key.

What blocks the rest is `4osc` on seven projects, which #1902 removes.

## Coverage

Eight cases: a well formed plan, a gate per pad with the right range and
transposition, the Drum Grid never appearing as a device op, a full-range pad
needing no gate, a bypassed device and a bypassed pad, a Drum Grid nested inside
a user rack (`1.0.0-drumgrid-rack.mgd`'s shape), and the unkeyable pad above.

## Not here

Parity. The Tracktion leg still gates internally in `DrumGridPlugin::applyToBuffer`,
so the two legs now reach the same result by different routes and null-diff over a
Drum Grid is the next thing to establish.

## Verification

Catch2 2980 cases / 602671 assertions green, re-run against the committed state
after clang-format.

https://claude.ai/code/session_0187yiSdSJPmDFZafrSfbSop
