### PR TITLE
Give a projected pad device its plugin's channel counts (#2205)

### DIFF
--- a/magda/daw/audio/TracktionHelpers.hpp
+++ b/magda/daw/audio/TracktionHelpers.hpp
@@ -3,9 +3,35 @@
 #include <juce_data_structures/juce_data_structures.h>
 #include <tracktion_engine/tracktion_engine.h>
 
+#include "../core/DeviceInfo.hpp"
+
 namespace magda {
 
 namespace te = tracktion;
+
+/** Point a device's channel counts at what the live plugin reports.
+
+    The widths the chain model compiles against, asked the way the incumbent's
+    chain wiring asks them. The model is told once and keeps the answer while
+    the current engine asks again on every rewire, so a wrong answer here lasts
+    the rest of the session.
+
+    What we distrust is a missing instance, not an empty answer: a
+    te::ExternalPlugin fills neither array while it has no AudioPluginInstance,
+    and storing 0 and 0 would leave a working device connected to no audio. An
+    empty answer from a plugin that HAS its instance is correct, and belongs to
+    MIDI-only plugins such as te::MidiPatchBay, which the current engine gives
+    no audio for exactly that reason. */
+inline void applyLiveChannelCounts(DeviceInfo& device, te::Plugin& plugin) {
+    const auto* external = dynamic_cast<const te::ExternalPlugin*>(&plugin);
+    if (external != nullptr && external->getAudioPluginInstance() == nullptr)
+        return;
+
+    juce::StringArray inputs, outputs;
+    plugin.getChannelNames(&inputs, &outputs);
+    device.audioInputChannels = inputs.size();
+    device.audioOutputChannels = outputs.size();
+}
 
 /** Recursively strip TE-internal `id` properties from a ValueTree.
     Used when duplicating plugin state to prevent copied objects from

--- a/magda/daw/audio/plugin_manager/PluginManagerSync.cpp
+++ b/magda/daw/audio/plugin_manager/PluginManagerSync.cpp
@@ -133,26 +133,9 @@ void updateDeviceCapabilityFlags(DeviceInfo& device, te::Plugin& plugin) {
         device.canReceiveMidi = true;
     device.producesMidi = snapshot.hasMidiOutput;
 
-    // The channel counts the chain model compiles against, asked the way the
-    // incumbent's chain wiring asks them.
-    //
-    // Only asked of a plugin that can answer. te::ExternalPlugin fills neither
-    // array while it has no AudioPluginInstance, so one still loading reports
-    // 0 and 0. Storing that would leave a working device connected to no audio
-    // for the rest of the session, because the model is told once and keeps
-    // it, while the current engine asks again on every rewire.
-    //
-    // What we distrust is a missing instance, not an empty answer. 0 and 0 is
-    // correct for a MIDI-only plugin such as te::MidiPatchBay, and the current
-    // engine gives those no audio because that is what they report. Only an
-    // external plugin can be missing its instance.
-    const auto* external = dynamic_cast<const te::ExternalPlugin*>(&plugin);
-    if (external == nullptr || external->getAudioPluginInstance() != nullptr) {
-        juce::StringArray audioInputs, audioOutputs;
-        plugin.getChannelNames(&audioInputs, &audioOutputs);
-        device.audioInputChannels = audioInputs.size();
-        device.audioOutputChannels = audioOutputs.size();
-    }
+    // The channel counts the chain model compiles against. Shared with the Drum
+    // Grid's pad projection, which has to ask the same question the same way.
+    applyLiveChannelCounts(device, plugin);
 }
 
 // Faust's processor owns a dynamic canSidechain flag, while the generic

--- a/magda/daw/audio/plugins/DrumGridPadParameters.cpp
+++ b/magda/daw/audio/plugins/DrumGridPadParameters.cpp
@@ -1,5 +1,6 @@
 #include "plugins/DrumGridPadParameters.hpp"
 
+#include "TracktionHelpers.hpp"
 #include "core/DeviceInfo.hpp"
 #include "core/RackInfo.hpp"
 #include "plugins/DrumGridPlugin.hpp"
@@ -18,11 +19,19 @@ namespace {
 /// with a 0 to 1 range. The native engine takes the model's metadata at face
 /// value, so it would then render 0.17 Hz clamped to the parameter's minimum.
 /// The processor is what knows the real range.
+///
+/// The channel counts come from the same plugin, because nothing else can say
+/// them: the saved state does not record a width, and the plan compiler sizes a
+/// device's output with what the model holds. Left at the DeviceInfo default a
+/// mono pad voice is compiled as though it were stereo.
 void fillFrom(DeviceInfo& device, te::Plugin::Ptr plugin) {
     device.parameters.clear();
 
     if (auto processor = createDeviceProcessorForPlugin(device.id, plugin, device.pluginId))
         processor->populateParameters(device);
+
+    if (plugin != nullptr)
+        applyLiveChannelCounts(device, *plugin);
 }
 
 /// The pad chain the model holds for @p chainIndex, or null.

--- a/magda/daw/audio/plugins/DrumGridPadParameters.hpp
+++ b/magda/daw/audio/plugins/DrumGridPadParameters.hpp
@@ -9,7 +9,8 @@ namespace magda::daw::audio {
 class DrumGridPlugin;
 
 /**
- * Fill the parameters of the devices projected from @p plugin's pads (#2200).
+ * Fill what only the live plugin can answer on the devices projected from
+ * @p plugin's pads: their parameters (#2200) and their channel counts (#2205).
  *
  * The pads reach the model as a projection of the device's saved state, which
  * carries a plugin's parameter values but not its names, ranges or count: only
@@ -17,6 +18,11 @@ class DrumGridPlugin;
  * for a pad's device, and a native-capable plugin inside a pad runs at its
  * defaults rather than at what the project saved, because the engine's factory
  * restores everything EXCEPT parameters and expects the table to supply them.
+ *
+ * The channel counts are the same story: the state records no width, and the
+ * plan compiler sizes a device's ports with what the model holds, so a mono pad
+ * voice left at DeviceInfo's stereo default is compiled as though it were
+ * stereo.
  *
  * Called where the pads are projected from a live device, which is the same
  * point their DeviceIds and instrument flags arrive at.

--- a/magda/daw/core/DrumGridPads.hpp
+++ b/magda/daw/core/DrumGridPads.hpp
@@ -41,7 +41,9 @@ struct RackInfo;
  * Carried, out of the live grid: `parameters`, refilled by
  * `populatePadDeviceParameters()` (#2200) because only the plugin knows a
  * parameter's name and range, along with the `wrapperParameters` and `meters`
- * that same processor call fills.
+ * that same processor call fills, and `audioInputChannels` and
+ * `audioOutputChannels`, which the plugin is asked for in the same pass (#2205)
+ * because the plan compiler sizes a device's ports with them.
  *
  * Absent because a pad device cannot own it: `macros`, `mods`, `sidechain`,
  * `multiOut`, `deltaSolo`, `midiInThru`, `kitRows`, `gainValue` and `gainDb`.
@@ -50,10 +52,11 @@ struct RackInfo;
  * Drum Grid's state. The grid's own macros are unaffected, because they sit on
  * the grid's `DeviceInfo` and merely target a pad device's parameters.
  *
- * Absent because the saved state does not say: `audioInputChannels`,
- * `audioOutputChannels`, `canSidechain`, `uniqueId`, `vst3ClassId` and
- * `vst3Preset`. Only the live plugin answers these, and the live pass asks it
- * for parameters alone.
+ * Absent because the saved state does not say: `canSidechain`, `uniqueId`,
+ * `vst3ClassId` and `vst3Preset`. Only the live plugin answers these, and it is
+ * not asked. Anything else that only a live plugin can answer belongs in the
+ * pass above, which is where the channel counts had to go: left at the stereo
+ * default they had every mono pad voice compiled as though it were stereo.
  *
  * Absent because it is UI or session state a pad has no surface for:
  * `expanded`, `modPanelOpen`, `gainPanelOpen`, `paramPanelOpen`, `aiPanelOpen`,
@@ -61,13 +64,6 @@ struct RackInfo;
  * `miniMixerParameters`, `aiSoundDesignerParameters`, `aiSoundDesignerPrompt`,
  * `browserCategoryOverride`, `currentParameterPage`, `loadState`, and `padRack`
  * itself, since a pad holds no pads.
- *
- * `audioOutputChannels` is the nearest one to mattering: the plan compiler
- * clamps a device's output width with it, so a mono pad voice is compiled as
- * though it were stereo. The state cannot answer it, so closing it means asking
- * the live grid for channel counts where it already asks for parameters, or
- * making pads first-class chains (#2204), which removes the projection and this
- * list with it.
  *
  * Carrying a new field is never enough on its own: every walk that collects it
  * has to descend into `padRack` too (`ModSources`, `SidechainTraversal`, the

--- a/magda/daw/core/DrumGridPads.hpp
+++ b/magda/daw/core/DrumGridPads.hpp
@@ -24,6 +24,60 @@ struct RackInfo;
  * project file changes shape.
  */
 
+/**
+ * What a projected pad device carries, and what it does not (#2205).
+ *
+ * A pad's plugin has no `DeviceInfo` outside this projection, so what the
+ * projection fills is the whole of it. It is also thrown away and rebuilt from
+ * `pluginState` on every capture, so a field written onto a projected device
+ * from anywhere else is gone by the next one. That leaves two sources, and this
+ * is all of both.
+ *
+ * Carried, out of the saved state: `pluginId`, `name`, `manufacturer`,
+ * `format`, `fileOrIdentifier`, `isInstrument`, `deviceType`, `id`, `bypassed`
+ * and `pluginState`, plus the MIDI capability flags `canReceiveMidi` and
+ * `producesMidi`, which come from the capability cache keyed on that identity.
+ *
+ * Carried, out of the live grid: `parameters`, refilled by
+ * `populatePadDeviceParameters()` (#2200) because only the plugin knows a
+ * parameter's name and range, along with the `wrapperParameters` and `meters`
+ * that same processor call fills.
+ *
+ * Absent because a pad device cannot own it: `macros`, `mods`, `sidechain`,
+ * `multiOut`, `deltaSolo`, `midiInThru`, `kitRows`, `gainValue` and `gainDb`.
+ * Every one of them is written through a path that reaches a device in the
+ * chain model, and a pad plugin is not in the chain model: it lives inside the
+ * Drum Grid's state. The grid's own macros are unaffected, because they sit on
+ * the grid's `DeviceInfo` and merely target a pad device's parameters.
+ *
+ * Absent because the saved state does not say: `audioInputChannels`,
+ * `audioOutputChannels`, `canSidechain`, `uniqueId`, `vst3ClassId` and
+ * `vst3Preset`. Only the live plugin answers these, and the live pass asks it
+ * for parameters alone.
+ *
+ * Absent because it is UI or session state a pad has no surface for:
+ * `expanded`, `modPanelOpen`, `gainPanelOpen`, `paramPanelOpen`, `aiPanelOpen`,
+ * `aiPanelOutput`, `aiConversation`, `visibleParameters`,
+ * `miniMixerParameters`, `aiSoundDesignerParameters`, `aiSoundDesignerPrompt`,
+ * `browserCategoryOverride`, `currentParameterPage`, `loadState`, and `padRack`
+ * itself, since a pad holds no pads.
+ *
+ * `audioOutputChannels` is the nearest one to mattering: the plan compiler
+ * clamps a device's output width with it, so a mono pad voice is compiled as
+ * though it were stereo. The state cannot answer it, so closing it means asking
+ * the live grid for channel counts where it already asks for parameters, or
+ * making pads first-class chains (#2204), which removes the projection and this
+ * list with it.
+ *
+ * Carrying a new field is never enough on its own: every walk that collects it
+ * has to descend into `padRack` too (`ModSources`, `SidechainTraversal`, the
+ * macro and modifier syncs). Miss one and the field is carried but never read,
+ * which looks exactly like it working.
+ *
+ * test_drum_grid_pads.cpp classifies every `DeviceInfo` field against the lists
+ * above, and fails when `DeviceInfo` grows one they do not name.
+ */
+
 /// The pads saved for `pluginId` in `pluginState`, as a rack of chains.
 ///
 /// Null for a device that is not pad-per-chain, one with no pads saved, and

--- a/tests/test_drum_grid_pads.cpp
+++ b/tests/test_drum_grid_pads.cpp
@@ -404,6 +404,8 @@ constexpr FieldContract kPadDeviceContract[] = {
     {"parameters", Carriage::FromLiveGrid},
     {"wrapperParameters", Carriage::FromLiveGrid},
     {"meters", Carriage::FromLiveGrid},
+    {"audioInputChannels", Carriage::FromLiveGrid},
+    {"audioOutputChannels", Carriage::FromLiveGrid},
 
     {"macros", Carriage::CannotOwn},
     {"mods", Carriage::CannotOwn},
@@ -415,8 +417,6 @@ constexpr FieldContract kPadDeviceContract[] = {
     {"gainValue", Carriage::CannotOwn},
     {"gainDb", Carriage::CannotOwn},
 
-    {"audioInputChannels", Carriage::StateSilent},
-    {"audioOutputChannels", Carriage::StateSilent},
     {"canSidechain", Carriage::StateSilent},
     {"uniqueId", Carriage::StateSilent},
     {"vst3ClassId", Carriage::StateSilent},

--- a/tests/test_drum_grid_pads.cpp
+++ b/tests/test_drum_grid_pads.cpp
@@ -1,5 +1,11 @@
+#include <algorithm>
 #include <catch2/catch_test_macros.hpp>
+#include <cctype>
+#include <cstring>
+#include <iterator>
 #include <set>
+#include <string>
+#include <vector>
 
 #include "magda/daw/core/DeviceInfo.hpp"
 #include "magda/daw/core/DeviceState.hpp"
@@ -349,4 +355,361 @@ TEST_CASE("An external pad plugin with no saved flag is not called an instrument
     const auto rack = magda::readPadRack("drumgrid", ds::encode(doc));
     REQUIRE(rack != nullptr);
     CHECK_FALSE(magda::getDevice(rack->chains[0].elements[0]).isInstrument);
+}
+
+// The projection's field contract (#2205).
+//
+// A pad plugin has no DeviceInfo anywhere but this projection, so the fields
+// `deviceFromNode()` fills are the whole of what a pad device is. Nothing in
+// the type system says which those are: add a field to DeviceInfo and it simply
+// arrives on a projected pad device at its default, and whatever was attached
+// to it does nothing, with no crash and no diagnostic to say so.
+//
+// So the contract is written out in DrumGridPads.hpp and classified here.
+// Reading DeviceInfo's members out of the header is unusual and is the point:
+// the fact being checked is which fields exist, which no runtime value reports.
+
+namespace {
+
+/// Where a projected pad device's value for a field comes from, or why it has
+/// none. The reasons are the ones DrumGridPads.hpp gives.
+enum class Carriage {
+    FromState,     ///< Read out of the Drum Grid's saved state.
+    FromLiveGrid,  ///< Refilled from the live plugin by populatePadDeviceParameters().
+    CannotOwn,     ///< Written only through a path that reaches the chain model.
+    StateSilent,   ///< Only the live plugin could answer it, and it is not asked.
+    UiOnly,        ///< UI or session state a pad device has no surface for.
+};
+
+struct FieldContract {
+    const char* field;
+    Carriage carriage;
+};
+
+/// Every field of DeviceInfo, and what a projected pad device does with it.
+constexpr FieldContract kPadDeviceContract[] = {
+    {"id", Carriage::FromState},
+    {"name", Carriage::FromState},
+    {"pluginId", Carriage::FromState},
+    {"manufacturer", Carriage::FromState},
+    {"format", Carriage::FromState},
+    {"isInstrument", Carriage::FromState},
+    {"deviceType", Carriage::FromState},
+    {"fileOrIdentifier", Carriage::FromState},
+    {"bypassed", Carriage::FromState},
+    {"pluginState", Carriage::FromState},
+    {"canReceiveMidi", Carriage::FromState},
+    {"producesMidi", Carriage::FromState},
+
+    {"parameters", Carriage::FromLiveGrid},
+    {"wrapperParameters", Carriage::FromLiveGrid},
+    {"meters", Carriage::FromLiveGrid},
+
+    {"macros", Carriage::CannotOwn},
+    {"mods", Carriage::CannotOwn},
+    {"sidechain", Carriage::CannotOwn},
+    {"multiOut", Carriage::CannotOwn},
+    {"deltaSolo", Carriage::CannotOwn},
+    {"midiInThru", Carriage::CannotOwn},
+    {"kitRows", Carriage::CannotOwn},
+    {"gainValue", Carriage::CannotOwn},
+    {"gainDb", Carriage::CannotOwn},
+
+    {"audioInputChannels", Carriage::StateSilent},
+    {"audioOutputChannels", Carriage::StateSilent},
+    {"canSidechain", Carriage::StateSilent},
+    {"uniqueId", Carriage::StateSilent},
+    {"vst3ClassId", Carriage::StateSilent},
+    {"vst3Preset", Carriage::StateSilent},
+
+    {"browserCategoryOverride", Carriage::UiOnly},
+    {"expanded", Carriage::UiOnly},
+    {"modPanelOpen", Carriage::UiOnly},
+    {"gainPanelOpen", Carriage::UiOnly},
+    {"paramPanelOpen", Carriage::UiOnly},
+    {"aiPanelOpen", Carriage::UiOnly},
+    {"aiPanelOutput", Carriage::UiOnly},
+    {"aiConversation", Carriage::UiOnly},
+    {"visibleParameters", Carriage::UiOnly},
+    {"miniMixerParameters", Carriage::UiOnly},
+    {"aiSoundDesignerParameters", Carriage::UiOnly},
+    {"aiSoundDesignerPrompt", Carriage::UiOnly},
+    {"currentParameterPage", Carriage::UiOnly},
+    {"loadState", Carriage::UiOnly},
+    {"padRack", Carriage::UiOnly},
+};
+
+/// The source with its comments, string and character literals removed, so a
+/// brace or a semicolon inside one cannot be read as structure.
+std::string withoutCommentsAndLiterals(const std::string& text) {
+    const auto starts = [&text](std::size_t at, const char* token) {
+        return text.compare(at, std::strlen(token), token) == 0;
+    };
+
+    std::string out;
+    out.reserve(text.size());
+
+    for (std::size_t i = 0; i < text.size();) {
+        if (starts(i, "//")) {
+            while (i < text.size() && text[i] != '\n')
+                ++i;
+        } else if (starts(i, "/*")) {
+            i += 2;
+            while (i < text.size() && !starts(i, "*/"))
+                ++i;
+            i = std::min(i + 2, text.size());
+        } else if (text[i] == '"' || text[i] == '\'') {
+            const auto quote = text[i++];
+            while (i < text.size() && text[i] != quote)
+                i += text[i] == '\\' ? 2 : 1;
+            ++i;
+        } else {
+            out += text[i++];
+        }
+    }
+
+    return out;
+}
+
+/// The declared name in `juce::String name` or `int channels = 2`: the last
+/// identifier before the initialiser, whatever the type in front of it is.
+std::string lastIdentifier(const std::string& declarator) {
+    std::string current, last;
+
+    for (const auto c : declarator) {
+        if (std::isalnum(static_cast<unsigned char>(c)) != 0 || c == '_') {
+            current += c;
+            continue;
+        }
+        if (!current.empty())
+            last = current;
+        current.clear();
+    }
+
+    return current.empty() ? last : current;
+}
+
+/// Every data member declared directly in `struct name`, in declaration order.
+///
+/// Member functions are not members here, and neither is anything a body
+/// contains: only the depth the struct's own declarations sit at is read.
+std::vector<std::string> fieldsOfStruct(const std::string& source, const std::string& name) {
+    std::vector<std::string> fields;
+    const auto declaration = "struct " + name;
+
+    // Past any forward declaration: the body is the one an opening brace
+    // follows.
+    std::size_t body = std::string::npos;
+    for (auto at = source.find(declaration); at != std::string::npos;
+         at = source.find(declaration, at + 1)) {
+        auto after = at + declaration.size();
+        while (after < source.size() &&
+               std::isspace(static_cast<unsigned char>(source[after])) != 0)
+            ++after;
+        if (after < source.size() && source[after] == '{') {
+            body = after;
+            break;
+        }
+    }
+
+    if (body == std::string::npos)
+        return fields;
+
+    int depth = 0;
+    std::string statement, beforeBrace;
+
+    for (auto i = body; i < source.size(); ++i) {
+        const auto c = source[i];
+
+        if (c == '{') {
+            if (depth == 1)
+                beforeBrace = statement;
+            ++depth;
+            continue;
+        }
+
+        if (c == '}') {
+            if (--depth == 0)
+                break;
+            // A brace after a member function's parameter list opens its body,
+            // and the declaration ends with it. Anywhere else it is a member's
+            // initialiser, and the declaration runs on to its semicolon.
+            if (depth == 1)
+                statement =
+                    beforeBrace.find('(') == std::string::npos ? beforeBrace : std::string();
+            continue;
+        }
+
+        if (depth != 1)
+            continue;
+
+        if (c != ';') {
+            statement += c;
+            continue;
+        }
+
+        const auto declarator = statement.substr(0, statement.find('='));
+        statement.clear();
+
+        // A '(' ahead of any initialiser makes it a function declaration.
+        if (declarator.find('(') != std::string::npos)
+            continue;
+
+        if (auto field = lastIdentifier(declarator); !field.empty())
+            fields.push_back(std::move(field));
+    }
+
+    return fields;
+}
+
+std::string headerText(const juce::String& path) {
+    const auto file = juce::File(MAGDA_REPO_ROOT).getChildFile(path);
+    REQUIRE(file.existsAsFile());
+    return file.loadFileAsString().toStdString();
+}
+
+/// The stretch of the contract in DrumGridPads.hpp that lists one carriage's
+/// fields: from the sentence introducing it to whatever comes next.
+std::string contractSection(const std::string& header, Carriage carriage) {
+    // In the order the header states them, so each section ends where the next
+    // begins and the last one runs to the end of the block.
+    constexpr struct {
+        Carriage carriage;
+        const char* opening;
+    } kSections[] = {
+        {Carriage::FromState, "Carried, out of the saved state:"},
+        {Carriage::FromLiveGrid, "Carried, out of the live grid:"},
+        {Carriage::CannotOwn, "Absent because a pad device cannot own it:"},
+        {Carriage::StateSilent, "Absent because the saved state does not say:"},
+        {Carriage::UiOnly, "Absent because it is UI or session state"},
+    };
+
+    for (std::size_t i = 0; i < std::size(kSections); ++i) {
+        if (kSections[i].carriage != carriage)
+            continue;
+
+        const auto from = header.find(kSections[i].opening);
+        if (from == std::string::npos)
+            return {};
+
+        const auto to = i + 1 < std::size(kSections) ? header.find(kSections[i + 1].opening, from)
+                                                     : header.find("*/", from);
+        return header.substr(from, to == std::string::npos ? std::string::npos : to - from);
+    }
+
+    return {};
+}
+
+bool classified(const std::string& field) {
+    return std::any_of(std::begin(kPadDeviceContract), std::end(kPadDeviceContract),
+                       [&field](const FieldContract& entry) { return field == entry.field; });
+}
+
+}  // namespace
+
+TEST_CASE("Every DeviceInfo field is classified by the pad projection's contract",
+          "[drumgrid][pads][contract]") {
+    const auto fields = fieldsOfStruct(
+        withoutCommentsAndLiterals(headerText("magda/daw/core/DeviceInfo.hpp")), "DeviceInfo");
+
+    // If this trips, the scanner stopped finding the struct rather than the
+    // struct losing its fields.
+    REQUIRE(fields.size() > 20);
+
+    std::vector<std::string> unclassified;
+    for (const auto& field : fields)
+        if (!classified(field))
+            unclassified.push_back(field);
+
+    if (!unclassified.empty()) {
+        std::string report =
+            "DeviceInfo has fields the Drum Grid pad projection has not been taught about:\n";
+        for (const auto& field : unclassified)
+            report += "  " + field + "\n";
+        report +=
+            "\nDecide whether a projected pad device carries each one, say so in the contract "
+            "in DrumGridPads.hpp, and add it to kPadDeviceContract. Carrying one also means "
+            "teaching every walk that collects it to descend into padRack.";
+        UNSCOPED_INFO(report);
+    }
+    CHECK(unclassified.empty());
+
+    std::vector<std::string> stale;
+    for (const auto& entry : kPadDeviceContract)
+        if (std::find(fields.begin(), fields.end(), entry.field) == fields.end())
+            stale.push_back(entry.field);
+
+    if (!stale.empty()) {
+        std::string report =
+            "The pad projection's contract names fields DeviceInfo no longer has:\n";
+        for (const auto& field : stale)
+            report += "  " + field + "\n";
+        UNSCOPED_INFO(report);
+    }
+    CHECK(stale.empty());
+}
+
+TEST_CASE("The contract in DrumGridPads.hpp names every field where it classifies it",
+          "[drumgrid][pads][contract]") {
+    // The table above is what fails the build; the header is where someone
+    // reads why. A field classified in one and missing from the other leaves
+    // the reason unwritten, which is the state this contract exists to end.
+    const auto header = headerText("magda/daw/core/DrumGridPads.hpp");
+
+    std::vector<std::string> undocumented;
+    for (const auto& entry : kPadDeviceContract) {
+        const auto section = contractSection(header, entry.carriage);
+        if (section.find("`" + std::string(entry.field) + "`") == std::string::npos)
+            undocumented.push_back(entry.field);
+    }
+
+    if (!undocumented.empty()) {
+        std::string report =
+            "Fields the table classifies that the matching paragraph of DrumGridPads.hpp does "
+            "not name:\n";
+        for (const auto& field : undocumented)
+            report += "  " + field + "\n";
+        UNSCOPED_INFO(report);
+    }
+    CHECK(undocumented.empty());
+}
+
+TEST_CASE("The field scanner reads declarations and not bodies", "[drumgrid][pads][contract]") {
+    // Without this the guard above is worth nothing: a scanner that counted a
+    // member function's locals would demand they be classified, and one that
+    // stopped at the first function body would never see the fields after it.
+    const std::string source = R"(
+struct DeviceInfo {
+    int declared = 0;
+    juce::String name;  // int inAComment;
+    std::vector<int> braceInitialised{};
+    MacroArray macros = createDefaultMacros();
+
+    int findParameterByIndex(int index) {
+        int local = 0;
+        return local;
+    }
+
+    juce::String getFormatString() const { return "}; int inALiteral;"; }
+
+    int afterABody = 1;
+};
+)";
+
+    const auto fields = fieldsOfStruct(withoutCommentsAndLiterals(source), "DeviceInfo");
+    CHECK(fields ==
+          std::vector<std::string>{"declared", "name", "braceInitialised", "macros", "afterABody"});
+}
+
+TEST_CASE("The field scanner skips a forward declaration", "[drumgrid][pads][contract]") {
+    const std::string source = R"(
+struct DeviceInfo;
+struct Other { int notMine = 0; };
+struct DeviceInfo {
+    int mine = 0;
+};
+)";
+
+    CHECK(fieldsOfStruct(withoutCommentsAndLiterals(source), "DeviceInfo") ==
+          std::vector<std::string>{"mine"});
 }

--- a/tests/test_drum_grid_serialization_juce.cpp
+++ b/tests/test_drum_grid_serialization_juce.cpp
@@ -1,6 +1,9 @@
 #include <juce_core/juce_core.h>
 #include <tracktion_engine/tracktion_engine.h>
 
+#include <algorithm>
+#include <vector>
+
 #include "JuceTestStateGuard.hpp"
 #include "SharedTestEngine.hpp"
 #include "magda/daw/audio/AudioBridge.hpp"
@@ -904,6 +907,119 @@ class DrumGridPadChainSerializationTest final : public juce::UnitTest {
         }
 
         juce::MessageManager::getInstance()->runDispatchLoopUntil(50);
+
+        runPadChannelCounts();
+    }
+
+    /// A pad's device carries its plugin's channel counts (#2205).
+    ///
+    /// The plan compiler sizes a device's ports with them and the saved state
+    /// records no width, so a pad device left at DeviceInfo's stereo default
+    /// has the engine reading channels the device never wrote and missing the
+    /// ones it did: a sidechaining FX in a pad is fed two inputs where it
+    /// declares three, and a mono voice would be summed as though it were
+    /// stereo.
+    void runPadChannelCounts() {
+        beginTest("A pad's device carries its plugin's channel counts");
+
+        auto& wrapper = magda::test::getSharedEngine();
+        auto edit = te::test_utilities::createTestEdit(*wrapper.getEngine(), 1);
+        expect(edit != nullptr, "Test edit must be created");
+        if (!edit)
+            return;
+
+        auto plugin = createCustomPlugin(*edit, DrumGridPlugin::xmlTypeName);
+        auto* drumGrid = dynamic_cast<DrumGridPlugin*>(plugin.get());
+        expect(drumGrid != nullptr, "DrumGrid plugin must be created");
+        if (drumGrid == nullptr)
+            return;
+
+        // A voice and an FX whose width is not the default, so a projection
+        // that carried nothing would still be wrong about one of them.
+        constexpr int padIndex = 3;
+        drumGrid->loadInternalPluginToPad(padIndex, "magda_kick");
+
+        auto* chain = drumGrid->getChainForNote(DrumGridPlugin::baseNote + padIndex);
+        expect(chain != nullptr, "The kick pad chain must exist");
+        if (chain == nullptr)
+            return;
+        drumGrid->addInternalPluginToChain(chain->index, "magda_compressor");
+
+        magda::DeviceInfo device;
+        device.id = 7;
+        device.pluginId = DrumGridPlugin::xmlTypeName;
+        device.pluginState =
+            magda::daw::audio::tracktion_adapter::captureInternalDeviceState(*plugin, {});
+
+        magda::refreshPadRack(device);
+        expect(static_cast<bool>(device.padRack), "The projection must find the pads");
+        if (!device.padRack)
+            return;
+
+        // What the live plugins answer, read through the grid rather than
+        // through the projection, so the two sides are compared and not one of
+        // them with itself.
+        struct LiveWidths {
+            magda::DeviceId id = magda::INVALID_DEVICE_ID;
+            int inputs = 0;
+            int outputs = 0;
+        };
+        std::vector<LiveWidths> live;
+
+        for (const auto& padChain : drumGrid->getChains()) {
+            if (padChain == nullptr)
+                continue;
+
+            for (int i = 0; i < static_cast<int>(padChain->plugins.size()); ++i) {
+                const auto& padPlugin = padChain->plugins[static_cast<std::size_t>(i)];
+                if (padPlugin == nullptr)
+                    continue;
+
+                juce::StringArray inputs, outputs;
+                padPlugin->getChannelNames(&inputs, &outputs);
+                live.push_back({drumGrid->getPluginDeviceId(padChain->index, i), inputs.size(),
+                                outputs.size()});
+            }
+        }
+
+        expectEquals(static_cast<int>(live.size()), 2, "The pad must hold the voice and the FX");
+
+        // Otherwise the comparison below passes on a projection that carries
+        // nothing, because every width would happen to be the default.
+        const auto defaults = magda::DeviceInfo{};
+        expect(std::any_of(live.begin(), live.end(),
+                           [&defaults](const LiveWidths& widths) {
+                               return widths.inputs != defaults.audioInputChannels ||
+                                      widths.outputs != defaults.audioOutputChannels;
+                           }),
+               "One of the pad's plugins must report a width DeviceInfo does not default to");
+
+        magda::daw::audio::populatePadDeviceParameters(device, *drumGrid);
+
+        int checked = 0;
+        for (const auto& pad : device.padRack->chains) {
+            for (const auto& element : pad.elements) {
+                if (!magda::isDevice(element))
+                    continue;
+
+                const auto& padDevice = magda::getDevice(element);
+                const auto found =
+                    std::find_if(live.begin(), live.end(), [&padDevice](const LiveWidths& widths) {
+                        return widths.id == padDevice.id;
+                    });
+                if (found == live.end())
+                    continue;
+
+                ++checked;
+                expectEquals(padDevice.audioInputChannels, found->inputs,
+                             "A pad device's input width must be its plugin's");
+                expectEquals(padDevice.audioOutputChannels, found->outputs,
+                             "A pad device's output width must be its plugin's");
+            }
+        }
+
+        expectEquals(checked, static_cast<int>(live.size()),
+                     "Every live pad plugin must reach a projected device");
 
         juce::MessageManager::getInstance()->runDispatchLoopUntil(50);
     }


### PR DESCRIPTION
Closes #2205.

## The bug

`PlanCompiler` sizes a device's ports with `audioInputChannels` and
`audioOutputChannels`. Nothing ever set them on a pad device: a Drum Grid's pads
reach the model as a projection of the grid's saved state, and the state records
no width, so every pad plugin was compiled at `DeviceInfo`'s stereo default. A
sidechaining FX in a pad declares three inputs and was wired two, dropping the
key channel; a mono voice would be read as stereo.

`populatePadDeviceParameters()` already walks the live pad plugins for what only
they can answer, so it now asks them for their channel counts in the same pass.
The question and its one guard, a `te::ExternalPlugin` with no
`AudioPluginInstance` yet (which reports 0 and 0 and would leave a working
device connected to no audio), move into `applyLiveChannelCounts()`, shared with
`PluginManagerSync` so the two cannot drift on how the model is told a device's
width.

## The contract

The bug existed because nothing said what a projected pad device carries.
`deviceFromNode()` fills a `DeviceInfo` field by field, a pad plugin has no
`DeviceInfo` anywhere else, and a field nobody thought about simply arrives at
its default: no crash, no diagnostic, just a device rendering without the thing
you attached to it.

`DrumGridPads.hpp` now states it. Twelve fields come out of the saved state,
five out of the live grid, and each of the remaining twenty-eight is absent for
one of three reasons: a pad device cannot own it (`macros`, `mods`, `sidechain`,
`multiOut`, `deltaSolo`, `midiInThru`, `kitRows`, the gain pair), the saved
state does not say and nothing asks (`canSidechain`, `uniqueId`, the VST3 preset
fields), or it is UI state a pad has no surface for. It also records that
carrying a new field means teaching every walk that collects it to descend into
`padRack`.

`test_drum_grid_pads.cpp` reads `DeviceInfo`'s members out of the header and
classifies all forty-five against a table, so a new field fails the test until
someone decides what a pad does with it, and a field `DeviceInfo` no longer has
fails it too. A second test checks each field is named in the paragraph whose
reason the table claims for it, so the prose and the table cannot drift apart.
Two scanner self-tests cover member function bodies, brace initialisers,
literals and forward declarations. Scanning a header from a test is unusual and
is the point: which fields exist is not something any runtime value reports.

## Verification

The JUCE test loads a kick and a compressor into one pad and compares the
projected devices against what the live plugins report, having first checked
that one of those widths is not what `DeviceInfo` defaults to, so it cannot pass
on a projection that carries nothing. Reverting the fix makes it fail with
`Expected value: 3, Actual value: 2` on the compressor's inputs.

Both branches of the contract guard were exercised by hand: adding a field to
`DeviceInfo` reports it as unclassified, and renaming `midiInThru` trips the
unclassified and the stale branch together.

Full Catch2 suite: 2981 passed, 13 skipped, 0 failed. Full JUCE suite: all
passed.

https://claude.ai/code/session_0187yiSdSJPmDFZafrSfbSop