### PR TITLE
Finish the Drum Grid pad ownership flip (#2211)

### DIFF
--- a/magda/daw/audio/plugin_manager/PluginManagerSync.cpp
+++ b/magda/daw/audio/plugin_manager/PluginManagerSync.cpp
@@ -2971,7 +2971,11 @@ void PluginManager::syncDrumGridMultiOutTracks(const ChainNodePath& drumGridPath
     const auto trackId = drumGridPath.trackId;
     const auto deviceId = drumGridPath.getDeviceId();
     auto& tm = TrackManager::getInstance();
-    auto* devInfo = tm.getDevice(trackId, deviceId);
+
+    // By path, not by (track, device): the flat lookup misses a grid nested in
+    // a rack, which is a placement the model supports and the pad bus selector
+    // can now reach (#2211).
+    auto* devInfo = tm.getDeviceInChainByPath(drumGridPath);
     if (!devInfo || !devInfo->multiOut.isMultiOut)
         return;
 

--- a/magda/daw/audio/plugin_manager/PluginManagerSync.cpp
+++ b/magda/daw/audio/plugin_manager/PluginManagerSync.cpp
@@ -2979,6 +2979,18 @@ void PluginManager::syncDrumGridMultiOutTracks(const ChainNodePath& drumGridPath
     if (!devInfo || !devInfo->multiOut.isMultiOut)
         return;
 
+    // A grid can arrive here in a placement where buses do not work: wrapping a
+    // top-level one in a rack moves it and keeps its pads, and a project can be
+    // loaded already like that. Nothing carries a bus off a nested grid, so a
+    // pad left on one would simply go silent, and any child track it had made
+    // would linger with nothing feeding it. Put the pads back on the grid's own
+    // mix and take the children down.
+    if (!tm.padBusesAvailable(drumGridPath)) {
+        tm.resetPadBuses(drumGridPath);
+        tm.deactivateAllMultiOutPairs(trackId, deviceId);
+        return;
+    }
+
     auto& pairs = devInfo->multiOut.outputPairs;
     const auto& chains = drumGrid->getChains();
 

--- a/magda/daw/audio/plugins/DrumGridPlugin.cpp
+++ b/magda/daw/audio/plugins/DrumGridPlugin.cpp
@@ -41,13 +41,11 @@ const juce::Identifier DrumGridPlugin::padSoloId("padSolo");
 const juce::Identifier DrumGridPlugin::padBypassedId("padBypassed");
 const juce::Identifier DrumGridPlugin::busOutputId("busOutput");
 const juce::Identifier DrumGridPlugin::mixerExpandedId("mixerExpanded");
-const juce::Identifier DrumGridPlugin::multiOutEnabledId("multiOutEnabled");
 const juce::Identifier DrumGridPlugin::pluginDeviceIdProp("magdaDeviceId");
 
 //==============================================================================
 DrumGridPlugin::DrumGridPlugin(const te::PluginCreationInfo& info) : Plugin(info) {
     mixerExpanded_.referTo(state, mixerExpandedId, getUndoManager(), false);
-    multiOutEnabled_.referTo(state, multiOutEnabledId, getUndoManager(), false);
 
     // Register AutomatableParameters for all 64 pads (fixed slots for stable macro/mod indexing)
     for (int i = 0; i < maxPads; ++i) {
@@ -751,7 +749,6 @@ void DrumGridPlugin::restorePluginStateFromValueTree(const juce::ValueTree& v) {
     }
 
     mixerExpanded_.forceUpdateOfCachedValue();
-    multiOutEnabled_.forceUpdateOfCachedValue();
 }
 
 void DrumGridPlugin::syncParamFromChain(const Chain& chain) {

--- a/magda/daw/audio/plugins/DrumGridPlugin.hpp
+++ b/magda/daw/audio/plugins/DrumGridPlugin.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <vector>
 
+#include "core/DrumGridPads.hpp"
 #include "plugins/DeviceServices.hpp"
 
 namespace magda {
@@ -47,8 +48,11 @@ class DrumGridPlugin : public te::Plugin, private juce::Timer {
     static const char* xmlTypeName;
 
     static constexpr int maxPads = 64;
-    static constexpr int baseNote = 24;       // Pad 0 = MIDI note 24 (C0)
-    static constexpr int maxBusOutputs = 32;  // TE RackType max is 64 audio pins = 32 stereo pairs
+    static constexpr int baseNote = 24;  // Pad 0 = MIDI note 24 (C0)
+    // The model's own count, so the plan and the live plugin route from the
+    // same set of buses (magda::kPadBusCount). TE's RackType carries 64 audio
+    // pins, which is 32 stereo pairs.
+    static constexpr int maxBusOutputs = magda::kPadBusCount;
 
     /**
      * @brief Per-pad output gains for a given level and pan position.

--- a/magda/daw/audio/plugins/DrumGridPlugin.hpp
+++ b/magda/daw/audio/plugins/DrumGridPlugin.hpp
@@ -198,13 +198,11 @@ class DrumGridPlugin : public te::Plugin, private juce::Timer {
         mixerExpanded_ = expanded;
     }
 
-    // Multi-out mode toggle (persisted in ValueTree). A pad's bus is
-    // `ChainInfo::outputIndex` and is assigned in the model like every other
-    // pad property; this is the grid's own switch, not a pad's (#2207).
-    bool isMultiOutEnabled() const {
-        return multiOutEnabled_.get();
-    }
-
+    // A pad's bus is `ChainInfo::outputIndex`, assigned in the model like every
+    // other pad property, and the device sync turns a pad on a bus into a
+    // multi-out child track. There is no second switch in front of that: the
+    // `multiOutEnabled` flag that used to be here gated `assignBusOutputs()`,
+    // which #2207 removed, and nothing ever wrote or read either (#2211).
     int getNumOutputChannels() const {
         return maxBusOutputs * 2;
     }
@@ -340,7 +338,6 @@ class DrumGridPlugin : public te::Plugin, private juce::Timer {
     std::array<ChainMeterData, maxPads> chainMeters_{};
     std::array<std::array<ChainMeterData, maxFxPerChain>, maxPads> pluginMeters_{};
     juce::CachedValue<bool> mixerExpanded_;
-    juce::CachedValue<bool> multiOutEnabled_;
 
     // Audio processing state
     te::MidiMessageArray chainMidi_;
@@ -367,7 +364,6 @@ class DrumGridPlugin : public te::Plugin, private juce::Timer {
     static const juce::Identifier padBypassedId;
     static const juce::Identifier busOutputId;
     static const juce::Identifier mixerExpandedId;
-    static const juce::Identifier multiOutEnabledId;
     /// The model DeviceId of the pad device a plugin was built for, stamped by
     /// the sync. The mirror carries no other model state: everything else is
     /// read from the `RackInfo` each pass (#2207).

--- a/magda/daw/core/CMakeLists.txt
+++ b/magda/daw/core/CMakeLists.txt
@@ -39,6 +39,7 @@ target_sources(magda_daw PRIVATE
     ClipPropertyCommands.cpp
     WarpMarkerCommands.cpp
     TrackCommands.cpp
+    PadCommands.cpp
     TrackPropertyCommands.cpp
     AutomationCommands.cpp
     ClipLaneFlattener.cpp
@@ -110,6 +111,7 @@ target_sources(magda_daw PRIVATE
     ClipPropertyCommands.hpp
     WarpMarkerCommands.hpp
     TrackCommands.hpp
+    PadCommands.hpp
     TrackPropertyCommands.hpp
     AutomationCommands.hpp
     MidiNoteCommands.hpp

--- a/magda/daw/core/DrumGridPads.cpp
+++ b/magda/daw/core/DrumGridPads.cpp
@@ -331,6 +331,14 @@ int padParameterSlot(const ChainInfo& pad) {
     return slot >= 0 && slot < kPadCount ? slot : -1;
 }
 
+bool anyPadOnABus(const DeviceInfo& device) {
+    if (!device.pads)
+        return false;
+
+    return std::ranges::any_of(device.pads->chains,
+                               [](const ChainInfo& pad) { return pad.outputIndex != 0; });
+}
+
 RackId padRackIdFor(DeviceId deviceId) {
     return -(deviceId + 2);
 }

--- a/magda/daw/core/DrumGridPads.hpp
+++ b/magda/daw/core/DrumGridPads.hpp
@@ -33,6 +33,15 @@ struct RackInfo;
 constexpr int kPadCount = 64;
 constexpr int kPadBaseNote = 24;
 
+/// How many outputs a pad can be sent to: 0 is the grid's own mix, 1 upwards
+/// are multi-out buses. `DrumGridPlugin::maxBusOutputs` is the same number,
+/// from the same limit (a TE RackType carries 64 audio pins, so 32 stereo
+/// pairs). Here as well because the model is what the plan compiler routes
+/// from, and the two engines have to agree on which buses exist: the live
+/// plugin clamps what it is given, and the plan takes the model's value as it
+/// finds it, so an out-of-range one reaches no track and silences its pads.
+constexpr int kPadBusCount = 32;
+
 /// True when devices of this type keep their chains as pads.
 bool isPadRackDevice(const juce::String& pluginId);
 
@@ -61,6 +70,15 @@ int padNoteFor(int padIndex);
 /// added first can hold chain 0 and still drive slot 17. Anything binding a pad
 /// to those parameters has to ask the same question the device does.
 int padParameterSlot(const ChainInfo& pad);
+
+/// True when any of @p device's pads plays out of a multi-out bus rather than
+/// the device's own mix.
+///
+/// Asked before a structural move that would take the device somewhere buses do
+/// not work. Refusing the move is what keeps the assignment: normalising it
+/// afterwards would be undone by nothing, because the move is one undoable step
+/// and the normalisation would not be part of it (#2211).
+bool anyPadOnABus(const DeviceInfo& device);
 
 /// Point `device.pads->id` at whatever `device.id` currently is. No-op for a
 /// device with no pads.

--- a/magda/daw/core/PadCommands.cpp
+++ b/magda/daw/core/PadCommands.cpp
@@ -35,11 +35,8 @@ PadRack snapshotPads(const ChainNodePath& gridPath) {
 }  // namespace
 
 EditPadsCommand::EditPadsCommand(const ChainNodePath& gridPath, juce::String description,
-                                 std::function<void()> edit, juce::String mergeKey)
-    : gridPath_(gridPath),
-      description_(std::move(description)),
-      edit_(std::move(edit)),
-      mergeKey_(std::move(mergeKey)) {}
+                                 std::function<void()> edit)
+    : gridPath_(gridPath), description_(std::move(description)), edit_(std::move(edit)) {}
 
 void EditPadsCommand::execute() {
     auto& tm = TrackManager::getInstance();
@@ -74,27 +71,69 @@ void EditPadsCommand::undo() {
     TrackManager::getInstance().setPads(gridPath_, padsBefore_);
 }
 
-bool EditPadsCommand::canMergeWith(const UndoableCommand* other) const {
-    if (mergeKey_.isEmpty())
-        return false;
-
-    const auto* otherEdit = dynamic_cast<const EditPadsCommand*>(other);
-    return otherEdit != nullptr && otherEdit->gridPath_ == gridPath_ &&
-           otherEdit->mergeKey_ == mergeKey_;
-}
-
-void EditPadsCommand::mergeWith(const UndoableCommand* other) {
-    // The later state is where redo lands; the state to come back to stays the
-    // one this command was made against, which is the point of merging. The
-    // other command has already run by the time this is called.
-    if (const auto* otherEdit = dynamic_cast<const EditPadsCommand*>(other))
-        padsAfter_ = otherEdit->padsAfter_;
-}
-
 void editPads(const ChainNodePath& gridPath, const juce::String& description,
-              std::function<void()> edit, const juce::String& mergeKey) {
+              std::function<void()> edit) {
     UndoManager::getInstance().executeCommand(
-        std::make_unique<EditPadsCommand>(gridPath, description, std::move(edit), mergeKey));
+        std::make_unique<EditPadsCommand>(gridPath, description, std::move(edit)));
+}
+
+// ============================================================================
+// SetPadFaderCommand
+// ============================================================================
+
+SetPadFaderCommand::SetPadFaderCommand(const ChainNodePath& gridPath, int padIndex, Target target,
+                                       float value, int gesture)
+    : gridPath_(gridPath),
+      padIndex_(padIndex),
+      target_(target),
+      newValue_(value),
+      gesture_(gesture) {
+    if (const auto* pad = TrackManager::getInstance().getPad(gridPath_, padIndex_)) {
+        oldValue_ = target_ == Target::Volume ? pad->volume : pad->pan;
+        valid_ = true;
+    }
+}
+
+void SetPadFaderCommand::apply(float value) const {
+    auto& tm = TrackManager::getInstance();
+    if (target_ == Target::Volume)
+        tm.setPadVolume(gridPath_, padIndex_, value);
+    else
+        tm.setPadPan(gridPath_, padIndex_, value);
+}
+
+void SetPadFaderCommand::execute() {
+    if (valid_)
+        apply(newValue_);
+}
+
+void SetPadFaderCommand::undo() {
+    if (valid_)
+        apply(oldValue_);
+}
+
+juce::String SetPadFaderCommand::getDescription() const {
+    return target_ == Target::Volume ? "Set Pad Level" : "Set Pad Pan";
+}
+
+bool SetPadFaderCommand::canMergeWith(const UndoableCommand* other) const {
+    const auto* otherFader = dynamic_cast<const SetPadFaderCommand*>(other);
+    return otherFader != nullptr && otherFader->gridPath_ == gridPath_ &&
+           otherFader->padIndex_ == padIndex_ && otherFader->target_ == target_ &&
+           otherFader->gesture_ == gesture_;
+}
+
+void SetPadFaderCommand::mergeWith(const UndoableCommand* other) {
+    // The value to redo to moves on; the one to come back to stays where the
+    // gesture started, which is the point of merging.
+    if (const auto* otherFader = dynamic_cast<const SetPadFaderCommand*>(other))
+        newValue_ = otherFader->newValue_;
+}
+
+void setPadFader(const ChainNodePath& gridPath, int padIndex, SetPadFaderCommand::Target target,
+                 float value, int gesture) {
+    UndoManager::getInstance().executeCommand(
+        std::make_unique<SetPadFaderCommand>(gridPath, padIndex, target, value, gesture));
 }
 
 }  // namespace magda

--- a/magda/daw/core/PadCommands.cpp
+++ b/magda/daw/core/PadCommands.cpp
@@ -1,0 +1,63 @@
+#include "PadCommands.hpp"
+
+#include <memory>
+#include <utility>
+
+#include "RackInfo.hpp"
+
+namespace magda {
+
+EditPadsCommand::EditPadsCommand(const ChainNodePath& gridPath, juce::String description,
+                                 std::function<void()> edit, juce::String mergeKey)
+    : gridPath_(gridPath),
+      description_(std::move(description)),
+      edit_(std::move(edit)),
+      mergeKey_(std::move(mergeKey)) {}
+
+void EditPadsCommand::execute() {
+    if (!edit_)
+        return;
+
+    auto& tm = TrackManager::getInstance();
+
+    // Taken before the edit and only on the first run: redo re-runs the edit,
+    // so the state to come back to is the one this command was made against.
+    if (!executed_) {
+        if (const auto* pads = tm.getPads(gridPath_))
+            padsBefore_.reset(std::make_unique<RackInfo>(*pads));
+    }
+
+    edit_();
+    executed_ = true;
+}
+
+void EditPadsCommand::undo() {
+    if (!executed_)
+        return;
+
+    TrackManager::getInstance().setPads(gridPath_, padsBefore_);
+}
+
+bool EditPadsCommand::canMergeWith(const UndoableCommand* other) const {
+    if (mergeKey_.isEmpty())
+        return false;
+
+    const auto* otherEdit = dynamic_cast<const EditPadsCommand*>(other);
+    return otherEdit != nullptr && otherEdit->gridPath_ == gridPath_ &&
+           otherEdit->mergeKey_ == mergeKey_;
+}
+
+void EditPadsCommand::mergeWith(const UndoableCommand* other) {
+    // The later edit is what redo replays; the state to come back to stays the
+    // one this command was made against, which is the point of merging.
+    if (const auto* otherEdit = dynamic_cast<const EditPadsCommand*>(other))
+        edit_ = otherEdit->edit_;
+}
+
+void editPads(const ChainNodePath& gridPath, const juce::String& description,
+              std::function<void()> edit, const juce::String& mergeKey) {
+    UndoManager::getInstance().executeCommand(
+        std::make_unique<EditPadsCommand>(gridPath, description, std::move(edit), mergeKey));
+}
+
+}  // namespace magda

--- a/magda/daw/core/PadCommands.cpp
+++ b/magda/daw/core/PadCommands.cpp
@@ -3,9 +3,36 @@
 #include <memory>
 #include <utility>
 
+#include "../audio/AudioBridge.hpp"
+#include "../engine/AudioEngine.hpp"
 #include "RackInfo.hpp"
 
 namespace magda {
+
+namespace {
+
+/// Flush the grid's live plugins into the model before it is snapshotted.
+///
+/// A pad plugin's patch reaches `DeviceInfo` only when the Drum Grid's state is
+/// captured (`PluginManager::captureDrumGridPads`), and the ordinary sync does
+/// not do it. Without this, undoing the removal of a pad whose sampler had been
+/// edited since it was added restores the sampler as it was added, not as it
+/// sounded. `RemoveDeviceByPathCommand` captures for the same reason.
+void capturePadPluginStates(const ChainNodePath& gridPath) {
+    auto& tm = TrackManager::getInstance();
+    if (auto* engine = tm.getAudioEngine())
+        if (auto* bridge = engine->getAudioBridge())
+            bridge->getPluginManager().capturePluginState(gridPath);
+}
+
+PadRack snapshotPads(const ChainNodePath& gridPath) {
+    PadRack pads;
+    if (const auto* live = TrackManager::getInstance().getPads(gridPath))
+        pads.reset(std::make_unique<RackInfo>(*live));
+    return pads;
+}
+
+}  // namespace
 
 EditPadsCommand::EditPadsCommand(const ChainNodePath& gridPath, juce::String description,
                                  std::function<void()> edit, juce::String mergeKey)
@@ -15,19 +42,28 @@ EditPadsCommand::EditPadsCommand(const ChainNodePath& gridPath, juce::String des
       mergeKey_(std::move(mergeKey)) {}
 
 void EditPadsCommand::execute() {
+    auto& tm = TrackManager::getInstance();
+
+    // Redo restores the after-state rather than replaying the edit. Replaying
+    // would run `addDeviceToPad()` again, and that allocates a fresh DeviceId
+    // every time: the pad device would come back under a new id while every
+    // later command in the redo chain still named the old one, and each of them
+    // would silently do nothing. Restoring the snapshot brings the ids back
+    // with it.
+    if (executed_) {
+        tm.setPads(gridPath_, padsAfter_);
+        return;
+    }
+
     if (!edit_)
         return;
 
-    auto& tm = TrackManager::getInstance();
-
-    // Taken before the edit and only on the first run: redo re-runs the edit,
-    // so the state to come back to is the one this command was made against.
-    if (!executed_) {
-        if (const auto* pads = tm.getPads(gridPath_))
-            padsBefore_.reset(std::make_unique<RackInfo>(*pads));
-    }
+    capturePadPluginStates(gridPath_);
+    padsBefore_ = snapshotPads(gridPath_);
 
     edit_();
+
+    padsAfter_ = snapshotPads(gridPath_);
     executed_ = true;
 }
 
@@ -48,10 +84,11 @@ bool EditPadsCommand::canMergeWith(const UndoableCommand* other) const {
 }
 
 void EditPadsCommand::mergeWith(const UndoableCommand* other) {
-    // The later edit is what redo replays; the state to come back to stays the
-    // one this command was made against, which is the point of merging.
+    // The later state is where redo lands; the state to come back to stays the
+    // one this command was made against, which is the point of merging. The
+    // other command has already run by the time this is called.
     if (const auto* otherEdit = dynamic_cast<const EditPadsCommand*>(other))
-        edit_ = otherEdit->edit_;
+        padsAfter_ = otherEdit->padsAfter_;
 }
 
 void editPads(const ChainNodePath& gridPath, const juce::String& description,

--- a/magda/daw/core/PadCommands.hpp
+++ b/magda/daw/core/PadCommands.hpp
@@ -25,14 +25,19 @@ namespace magda {
  * and clearing one erases it. Recording those as per-op inverses would be a
  * second description of what each edit does, free to disagree with the first.
  *
- * Redo re-runs the edit rather than restoring the after-state, so an edit that
- * allocates ids (a device added to a pad) hands out the same ones it would have
- * on a fresh run.
+ * The state is taken after the grid's live plugins have been captured into the
+ * model, so undoing the removal of a pad restores it as it sounded rather than
+ * as it was added.
+ *
+ * Both sides are snapshots. Redo restores the after-state rather than replaying
+ * the edit, because `addDeviceToPad()` allocates a fresh DeviceId on every run:
+ * a replayed add would bring the device back under a new id and leave every
+ * later command in the redo chain naming the old one.
  */
 class EditPadsCommand : public UndoableCommand {
   public:
-    /// @p edit runs against the live model, addressed by @p gridPath. It is
-    /// held for redo, so it must be repeatable.
+    /// @p edit runs against the live model, addressed by @p gridPath. It runs
+    /// once: redo restores the snapshot it produced.
     ///
     /// @p mergeKey coalesces: two consecutive edits carrying the same non-empty
     /// key on the same grid collapse into one undo step, so a fader drag is one
@@ -56,6 +61,7 @@ class EditPadsCommand : public UndoableCommand {
     std::function<void()> edit_;
     juce::String mergeKey_;
     PadRack padsBefore_;
+    PadRack padsAfter_;
     bool executed_ = false;
 };
 

--- a/magda/daw/core/PadCommands.hpp
+++ b/magda/daw/core/PadCommands.hpp
@@ -38,13 +38,8 @@ class EditPadsCommand : public UndoableCommand {
   public:
     /// @p edit runs against the live model, addressed by @p gridPath. It runs
     /// once: redo restores the snapshot it produced.
-    ///
-    /// @p mergeKey coalesces: two consecutive edits carrying the same non-empty
-    /// key on the same grid collapse into one undo step, so a fader drag is one
-    /// step back to where it started rather than one per mouse move. Empty
-    /// never merges.
     EditPadsCommand(const ChainNodePath& gridPath, juce::String description,
-                    std::function<void()> edit, juce::String mergeKey = {});
+                    std::function<void()> edit);
 
     void execute() override;
     void undo() override;
@@ -52,14 +47,10 @@ class EditPadsCommand : public UndoableCommand {
         return description_;
     }
 
-    bool canMergeWith(const UndoableCommand* other) const override;
-    void mergeWith(const UndoableCommand* other) override;
-
   private:
     ChainNodePath gridPath_;
     juce::String description_;
     std::function<void()> edit_;
-    juce::String mergeKey_;
     PadRack padsBefore_;
     PadRack padsAfter_;
     bool executed_ = false;
@@ -67,6 +58,54 @@ class EditPadsCommand : public UndoableCommand {
 
 /// Run @p edit as one undoable step on @p gridPath's pads.
 void editPads(const ChainNodePath& gridPath, const juce::String& description,
-              std::function<void()> edit, const juce::String& mergeKey = {});
+              std::function<void()> edit);
+
+/**
+ * @brief A pad's fader or pan, undone by putting the old value back (#2211).
+ *
+ * Separate from `EditPadsCommand` because a fader ticks and the sound has to
+ * follow the mouse, so this is the one pad edit that cannot wait for the drag
+ * to end. Taking a pad-rack snapshot per mouse move would mean flushing every
+ * pad plugin's live state into the model to make the snapshot honest and then
+ * deep-copying the whole rack, which is the right price for a structural edit
+ * and far too much for a mouse move.
+ *
+ * One value in, one value out, which is the shape `SetTrackVolumeCommand`
+ * already has for a track's fader.
+ */
+class SetPadFaderCommand : public UndoableCommand {
+  public:
+    enum class Target { Volume, Pan };
+
+    /// @p gesture bounds the merging. Two edits coalesce only while they carry
+    /// the same one, so a drag is a single undo step and the next drag on the
+    /// same fader is another. `UndoManager` merges adjacent commands with no
+    /// timeout of its own, so without this one Undo would walk back every
+    /// gesture since something else last intervened.
+    SetPadFaderCommand(const ChainNodePath& gridPath, int padIndex, Target target, float value,
+                       int gesture);
+
+    void execute() override;
+    void undo() override;
+    juce::String getDescription() const override;
+
+    bool canMergeWith(const UndoableCommand* other) const override;
+    void mergeWith(const UndoableCommand* other) override;
+
+  private:
+    void apply(float value) const;
+
+    ChainNodePath gridPath_;
+    int padIndex_ = -1;
+    Target target_ = Target::Volume;
+    float oldValue_ = 0.0f;
+    float newValue_ = 0.0f;
+    int gesture_ = 0;
+    bool valid_ = false;
+};
+
+/// Set a pad's fader or pan as one undoable step, coalescing within @p gesture.
+void setPadFader(const ChainNodePath& gridPath, int padIndex, SetPadFaderCommand::Target target,
+                 float value, int gesture);
 
 }  // namespace magda

--- a/magda/daw/core/PadCommands.hpp
+++ b/magda/daw/core/PadCommands.hpp
@@ -1,0 +1,66 @@
+#pragma once
+
+#include <functional>
+
+#include "DeviceInfo.hpp"
+#include "TrackManager.hpp"
+#include "UndoManager.hpp"
+
+namespace magda {
+
+/**
+ * @brief Any edit to a pad-per-chain device's pads, made undoable (#2211).
+ *
+ * The per-op commands in TrackCommands.cpp cannot serve a pad. A pad's address
+ * spells its Rack step with the grid's own DeviceId, and rack ids and device
+ * ids come out of counters that both start at 1, so `AddDeviceByPathCommand`
+ * and friends would resolve a pad edit onto whichever rack happened to share
+ * the number. Every pad edit therefore goes through `TrackManager`'s pad calls,
+ * which reach the model through the owning device instead (#2207).
+ *
+ * The undo state is the whole of `DeviceInfo::pads`. That is one field on one
+ * device, deep-copied by `PadRack`, and it is the only snapshot that stays
+ * correct for the edits that touch more than one pad at a time: a swap trades
+ * two chains' note ranges, dropping an instrument replaces a pad's whole chain,
+ * and clearing one erases it. Recording those as per-op inverses would be a
+ * second description of what each edit does, free to disagree with the first.
+ *
+ * Redo re-runs the edit rather than restoring the after-state, so an edit that
+ * allocates ids (a device added to a pad) hands out the same ones it would have
+ * on a fresh run.
+ */
+class EditPadsCommand : public UndoableCommand {
+  public:
+    /// @p edit runs against the live model, addressed by @p gridPath. It is
+    /// held for redo, so it must be repeatable.
+    ///
+    /// @p mergeKey coalesces: two consecutive edits carrying the same non-empty
+    /// key on the same grid collapse into one undo step, so a fader drag is one
+    /// step back to where it started rather than one per mouse move. Empty
+    /// never merges.
+    EditPadsCommand(const ChainNodePath& gridPath, juce::String description,
+                    std::function<void()> edit, juce::String mergeKey = {});
+
+    void execute() override;
+    void undo() override;
+    juce::String getDescription() const override {
+        return description_;
+    }
+
+    bool canMergeWith(const UndoableCommand* other) const override;
+    void mergeWith(const UndoableCommand* other) override;
+
+  private:
+    ChainNodePath gridPath_;
+    juce::String description_;
+    std::function<void()> edit_;
+    juce::String mergeKey_;
+    PadRack padsBefore_;
+    bool executed_ = false;
+};
+
+/// Run @p edit as one undoable step on @p gridPath's pads.
+void editPads(const ChainNodePath& gridPath, const juce::String& description,
+              std::function<void()> edit, const juce::String& mergeKey = {});
+
+}  // namespace magda

--- a/magda/daw/core/TrackManager.cpp
+++ b/magda/daw/core/TrackManager.cpp
@@ -803,6 +803,25 @@ void TrackManager::deleteTrack(TrackId trackId) {
 // Multi-Output Management
 // =============================================================================
 
+namespace {
+
+/// The multi-out device @p deviceId names, wherever it sits on @p parentTrackId.
+///
+/// `getDevice(trackId, deviceId)` walks the track's flat lists only, so a
+/// multi-out instrument inside a rack chain answered nothing and its pairs
+/// could never be activated. A Drum Grid reaches this on any pad given a bus,
+/// and nesting one in a rack is explicitly supported (#2211).
+DeviceInfo* multiOutDevice(TrackManager& tm, TrackId parentTrackId, DeviceId deviceId) {
+    if (auto* device = tm.getDevice(parentTrackId, deviceId))
+        return device;
+
+    const auto path = tm.findDevicePath(deviceId);
+    return path.isValid() && path.trackId == parentTrackId ? tm.getDeviceInChainByPath(path)
+                                                           : nullptr;
+}
+
+}  // namespace
+
 TrackId TrackManager::activateMultiOutPair(TrackId parentTrackId, DeviceId deviceId,
                                            int pairIndex) {
     auto* parentTrack = getTrack(parentTrackId);
@@ -810,7 +829,7 @@ TrackId TrackManager::activateMultiOutPair(TrackId parentTrackId, DeviceId devic
         return INVALID_TRACK_ID;
 
     // Find the device
-    DeviceInfo* device = getDevice(parentTrackId, deviceId);
+    DeviceInfo* device = multiOutDevice(*this, parentTrackId, deviceId);
     if (!device || !device->multiOut.isMultiOut)
         return INVALID_TRACK_ID;
 
@@ -874,7 +893,7 @@ void TrackManager::deactivateMultiOutPair(TrackId parentTrackId, DeviceId device
     if (!parentTrack)
         return;
 
-    DeviceInfo* device = getDevice(parentTrackId, deviceId);
+    DeviceInfo* device = multiOutDevice(*this, parentTrackId, deviceId);
     if (!device || !device->multiOut.isMultiOut)
         return;
 
@@ -907,7 +926,7 @@ void TrackManager::deactivateAllMultiOutPairs(TrackId parentTrackId, DeviceId de
     // Re-fetch device pointer each iteration since deactivateMultiOutPair
     // calls tracks_.erase() which can invalidate pointers
     for (int i = 0;; ++i) {
-        DeviceInfo* device = getDevice(parentTrackId, deviceId);
+        DeviceInfo* device = multiOutDevice(*this, parentTrackId, deviceId);
         if (!device || !device->multiOut.isMultiOut)
             break;
         if (i >= static_cast<int>(device->multiOut.outputPairs.size()))

--- a/magda/daw/core/TrackManager.cpp
+++ b/magda/daw/core/TrackManager.cpp
@@ -872,9 +872,14 @@ TrackId TrackManager::activateMultiOutPair(TrackId parentTrackId, DeviceId devic
         tracks_.push_back(std::move(newTrack));
     }
 
-    // Re-fetch pointers after insert (vector reallocation invalidates them)
+    // Re-fetch pointers after insert (vector reallocation invalidates them).
+    // Through the same lookup as above: the flat one misses a device inside a
+    // rack, and this dereferences what it answers (#2211).
     parentTrack = getTrack(parentTrackId);
-    device = getDevice(parentTrackId, deviceId);
+    device = multiOutDevice(*this, parentTrackId, deviceId);
+    if (device == nullptr || pairIndex >= static_cast<int>(device->multiOut.outputPairs.size()))
+        return INVALID_TRACK_ID;
+
     auto& pairRef = device->multiOut.outputPairs[static_cast<size_t>(pairIndex)];
 
     // Update the output pair state

--- a/magda/daw/core/TrackManager.cpp
+++ b/magda/daw/core/TrackManager.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <map>
+#include <set>
 #include <unordered_set>
 
 #include "../audio/AudioBridge.hpp"
@@ -28,6 +29,9 @@ namespace {
 struct DuplicatePadRemap {
     DeviceId newOwnerId = INVALID_DEVICE_ID;
     std::map<DeviceId, DeviceId> devices;  ///< old pad DeviceId -> new
+    /// The owner's pad chain ids. Unchanged by duplication, and what tells a
+    /// pad prefix from a rack that merely shares the owner's number.
+    std::set<ChainId> chains;
 };
 
 struct DuplicateIdRemap {
@@ -39,6 +43,14 @@ struct DuplicateIdRemap {
     /// Keyed by the OLD DeviceId of the device that owns the pads.
     std::map<DeviceId, DuplicatePadRemap> pads;
 };
+
+template <typename Id> bool remapDuplicateId(const std::map<Id, Id>& ids, int& value) {
+    auto it = ids.find(value);
+    if (it == ids.end())
+        return false;
+    value = it->second;
+    return true;
+}
 
 /// Rewrite @p path if it addresses a pad device, and say whether it did.
 ///
@@ -55,29 +67,51 @@ struct DuplicateIdRemap {
 /// passes through a rack numbered like a grid is left to the ordinary remap
 /// (#2207).
 bool remapDuplicatedPadPath(ChainNodePath& path, const DuplicateIdRemap& remap) {
-    if (path.steps.size() != 3 || path.steps[0].type != ChainStepType::Rack ||
-        path.steps[1].type != ChainStepType::Chain || path.steps[2].type != ChainStepType::Device)
+    if (path.steps.size() < 3 || path.steps[0].type != ChainStepType::Rack ||
+        path.steps[1].type != ChainStepType::Chain)
         return false;
 
     const auto owner = remap.pads.find(path.steps[0].id);
     if (owner == remap.pads.end())
         return false;
 
-    const auto device = owner->second.devices.find(path.steps[2].id);
-    if (device == owner->second.devices.end())
+    // A pad device, named directly by the pad's chain.
+    if (path.steps.size() == 3 && path.steps[2].type == ChainStepType::Device) {
+        const auto device = owner->second.devices.find(path.steps[2].id);
+        if (device == owner->second.devices.end())
+            return false;
+
+        path.trackId = remap.newTrackId;
+        path.steps[0].id = owner->second.newOwnerId;
+        path.steps[2].id = device->second;
+        return true;
+    }
+
+    // Or something further down, inside a rack the pad's chain holds. The
+    // prefix is still the pad's; what follows is an ordinary route and moves
+    // with the ordinary maps.
+    if (!owner->second.chains.contains(path.steps[1].id))
         return false;
 
     path.trackId = remap.newTrackId;
     path.steps[0].id = owner->second.newOwnerId;
-    path.steps[2].id = device->second;
-    return true;
-}
 
-template <typename Id> bool remapDuplicateId(const std::map<Id, Id>& ids, int& value) {
-    auto it = ids.find(value);
-    if (it == ids.end())
-        return false;
-    value = it->second;
+    for (std::size_t index = 2; index < path.steps.size(); ++index) {
+        auto& step = path.steps[index];
+        switch (step.type) {
+            case ChainStepType::Rack:
+                remapDuplicateId(remap.racks, step.id);
+                break;
+            case ChainStepType::Chain:
+                remapDuplicateId(remap.chains, step.id);
+                break;
+            case ChainStepType::Device:
+                remapDuplicateId(remap.devices, step.id);
+                break;
+            case ChainStepType::Segment:
+                break;
+        }
+    }
     return true;
 }
 
@@ -1051,9 +1085,31 @@ TrackId TrackManager::duplicateTrack(TrackId trackId, bool includeDevices) {
                     // on the grid, on a rack, or on the track (#2207).
                     remap.racks[padRackIdFor(oldDeviceId)] = padRackIdFor(device.id);
 
+                    stampPadRackId(device);
+
                     DuplicatePadRemap pads;
                     pads.newOwnerId = device.id;
-                    rekeyPads(device, &pads.devices);
+
+                    for (auto& pad : device.pads->chains) {
+                        pads.chains.insert(pad.id);
+
+                        // The devices directly on the pad are the ones a pad
+                        // path names, so their old ids are noted before the walk
+                        // replaces them. Anything deeper is inside an ordinary
+                        // rack and moves with the ordinary maps, which is why
+                        // the walk runs over the whole chain rather than only
+                        // its devices.
+                        std::vector<DeviceId> padDeviceIds;
+                        for (const auto& padElement : pad.elements)
+                            if (magda::isDevice(padElement))
+                                padDeviceIds.push_back(magda::getDevice(padElement).id);
+
+                        reassignIds(pad.elements);
+
+                        for (const auto padDeviceId : padDeviceIds)
+                            pads.devices[padDeviceId] = remap.devices[padDeviceId];
+                    }
+
                     remap.pads[oldDeviceId] = std::move(pads);
                 }
             } else if (magda::isRack(element)) {

--- a/magda/daw/core/TrackManager.hpp
+++ b/magda/daw/core/TrackManager.hpp
@@ -460,6 +460,11 @@ class TrackManager : public daw::audio::DeviceIdAllocator, public daw::audio::De
     RackInfo* getPads(const ChainNodePath& gridPath);
     const RackInfo* getPads(const ChainNodePath& gridPath) const;
 
+    /// Replace those pads wholesale. Undo's counterpart to every pad edit
+    /// below, which is why it lives with them rather than on the command
+    /// (`EditPadsCommand`, #2211).
+    void setPads(const ChainNodePath& gridPath, const PadRack& pads);
+
     /// The pad chain answering to pad @p padIndex, or null.
     const ChainInfo* getPad(const ChainNodePath& gridPath, int padIndex) const;
 
@@ -491,6 +496,17 @@ class TrackManager : public daw::audio::DeviceIdAllocator, public daw::audio::De
     void setPadMuted(const ChainNodePath& gridPath, int padIndex, bool muted);
     void setPadSolo(const ChainNodePath& gridPath, int padIndex, bool solo);
     void setPadBypassed(const ChainNodePath& gridPath, int padIndex, bool bypassed);
+
+    /// Which output a pad plays out of: 0 is the grid's own mix, 1+ a multi-out
+    /// bus. `ChainInfo::outputIndex`, the same field a rack chain routes with.
+    void setPadOutput(const ChainNodePath& gridPath, int padIndex, int outputIndex);
+
+    /// The notes a pad answers to, and the one its sampler is rooted on.
+    ///
+    /// A pad is keyed by pitch, so this is the one pad property with no rack
+    /// equivalent: a plain chain answers to everything.
+    void setPadNoteRange(const ChainNodePath& gridPath, int padIndex, int lowNote, int highNote,
+                         int rootNote);
 
     /// The pad chain answering to pad @p padIndex, made if it is not there yet.
     /// INVALID_CHAIN_ID when the device does not keep its chains as pads.

--- a/magda/daw/core/TrackManager.hpp
+++ b/magda/daw/core/TrackManager.hpp
@@ -460,6 +460,12 @@ class TrackManager : public daw::audio::DeviceIdAllocator, public daw::audio::De
     RackInfo* getPads(const ChainNodePath& gridPath);
     const RackInfo* getPads(const ChainNodePath& gridPath) const;
 
+    /// The pad device @p devicePath names, or null when it names none.
+    ///
+    /// `getDeviceInChainByPath()` falls back to this, so a pad path resolves
+    /// through the generic lookup like any other device path (#2211).
+    DeviceInfo* getDeviceInPadByPath(const ChainNodePath& devicePath);
+
     /// Replace those pads wholesale. Undo's counterpart to every pad edit
     /// below, which is why it lives with them rather than on the command
     /// (`EditPadsCommand`, #2211).

--- a/magda/daw/core/TrackManager.hpp
+++ b/magda/daw/core/TrackManager.hpp
@@ -516,6 +516,15 @@ class TrackManager : public daw::audio::DeviceIdAllocator, public daw::audio::De
     /// Whether a bus can be assigned to @p gridPath's pads at all.
     bool padBusesAvailable(const ChainNodePath& gridPath) const;
 
+    /// Put every pad back on the grid's own mix. True when any of them moved.
+    ///
+    /// A grid can cross into a placement where buses do not work after the
+    /// assignment was made -- `wrapDeviceInRack()` moves it into a rack and
+    /// keeps its pads -- and a project can be loaded already in that state. The
+    /// device sync calls this so a pad never stays pointed at a bus nothing
+    /// carries (#2211).
+    bool resetPadBuses(const ChainNodePath& gridPath);
+
     /// Whether @p padIndex's chain could take this range: inside the grid's own
     /// notes, and clear of every other pad chain's. Asked before the edit so a
     /// refused range does not become an undo step that changed nothing.

--- a/magda/daw/core/TrackManager.hpp
+++ b/magda/daw/core/TrackManager.hpp
@@ -511,8 +511,23 @@ class TrackManager : public daw::audio::DeviceIdAllocator, public daw::audio::De
     ///
     /// A pad is keyed by pitch, so this is the one pad property with no rack
     /// equivalent: a plain chain answers to everything.
-    void setPadNoteRange(const ChainNodePath& gridPath, int padIndex, int lowNote, int highNote,
+    ///
+    /// Refused, and false, when the range would reach a note another pad chain
+    /// already answers to. A note has one owner: the grid plays every chain
+    /// whose range covers an incoming note, and the rows, the faders and the
+    /// switches all address a pad by finding the chain covering its note, so a
+    /// second claimant would leave a row editing a chain other than the one it
+    /// shows (#2211).
+    bool setPadNoteRange(const ChainNodePath& gridPath, int padIndex, int lowNote, int highNote,
                          int rootNote);
+
+    /// Take a pad chain off the grid by id, whatever range it answers to.
+    ///
+    /// `clearPad()` is the pad's own delete and leaves a chain shared with
+    /// neighbouring pads alone. This is the chain's: a row stands for a chain,
+    /// so its delete has to be able to remove one that answers to more than a
+    /// single note.
+    void removePadChain(const ChainNodePath& gridPath, ChainId padChainId);
 
     /// The pad chain answering to pad @p padIndex, made if it is not there yet.
     /// INVALID_CHAIN_ID when the device does not keep its chains as pads.

--- a/magda/daw/core/TrackManager.hpp
+++ b/magda/daw/core/TrackManager.hpp
@@ -505,7 +505,22 @@ class TrackManager : public daw::audio::DeviceIdAllocator, public daw::audio::De
 
     /// Which output a pad plays out of: 0 is the grid's own mix, 1+ a multi-out
     /// bus. `ChainInfo::outputIndex`, the same field a rack chain routes with.
-    void setPadOutput(const ChainNodePath& gridPath, int padIndex, int outputIndex);
+    ///
+    /// False, and refused, for a bus on a grid that is not a top-level device.
+    /// A multi-out child track is fed by an output instance the instrument rack
+    /// manager makes for a wrapped top-level instrument; a grid inside a MAGDA
+    /// rack is loaded by RackSyncManager and has no such entry, so the bus
+    /// would name a track nothing reaches (#2211).
+    bool setPadOutput(const ChainNodePath& gridPath, int padIndex, int outputIndex);
+
+    /// Whether a bus can be assigned to @p gridPath's pads at all.
+    bool padBusesAvailable(const ChainNodePath& gridPath) const;
+
+    /// Whether @p padIndex's chain could take this range: inside the grid's own
+    /// notes, and clear of every other pad chain's. Asked before the edit so a
+    /// refused range does not become an undo step that changed nothing.
+    bool padNoteRangeIsFree(const ChainNodePath& gridPath, int padIndex, int lowNote,
+                            int highNote) const;
 
     /// The notes a pad answers to, and the one its sampler is rooted on.
     ///

--- a/magda/daw/core/TrackManagerDevices.cpp
+++ b/magda/daw/core/TrackManagerDevices.cpp
@@ -7,6 +7,7 @@
 #include "../audio/plugins/tracktion/TracktionDeviceStateBridge.hpp"
 #include "../engine/AudioEngine.hpp"
 #include "DeviceState.hpp"
+#include "DrumGridPads.hpp"
 #include "PluginPreferences.hpp"
 #include "RackInfo.hpp"
 #include "TrackManager.hpp"
@@ -895,6 +896,12 @@ RackId TrackManager::wrapChainElementsInRack(const std::vector<ChainNodePath>& p
     std::vector<std::pair<int, ChainNodePath>> orderedPaths;
     for (const auto& path : paths) {
         if (!path.isValid() || getParentChainPathForElementPath(path) != sourceChainPath)
+            return INVALID_RACK_ID;
+
+        // Same refusal as the single-device wrap: a pad on a bus would lose its
+        // routing to a clean-up the undo of this move does not cover (#2211).
+        if (const auto* device = getDeviceInChainByPath(path);
+            device != nullptr && anyPadOnABus(*device))
             return INVALID_RACK_ID;
 
         const int index = getChainElementIndex(path);
@@ -1827,6 +1834,14 @@ RackId TrackManager::wrapDeviceInRack(TrackId trackId, DeviceId deviceId,
         return magda::isDevice(e) && magda::getDevice(e).id == deviceId;
     });
     if (it == elements.end())
+        return INVALID_RACK_ID;
+
+    // Refused while a pad is on a bus. Nothing carries a bus off a device inside
+    // a rack, so the move would have to put every pad back on the main mix and
+    // take its child tracks down -- and that clean-up would not be part of the
+    // undoable step the move is, so undoing it would return the device to the
+    // top level with its routing gone for good (#2211).
+    if (anyPadOnABus(magda::getDevice(*it)))
         return INVALID_RACK_ID;
 
     int insertIndex = static_cast<int>(std::distance(elements.begin(), it));

--- a/magda/daw/core/TrackManagerDevices.cpp
+++ b/magda/daw/core/TrackManagerDevices.cpp
@@ -184,6 +184,43 @@ DeviceInfo* findUniqueBareDeviceIdMatch(TrackInfo& masterTrack, std::vector<Trac
     return matches.size() == 1 ? matches.front() : nullptr;
 }
 
+/// Follow @p path from @p index inside @p elements, ending on its Device step.
+///
+/// The ordinary `Rack > Chain > ... > Device` alternation, walked from wherever
+/// the caller has already got to. A pad's chain holds elements like any other,
+/// racks included, so the tail of a pad device's address is an ordinary route.
+DeviceInfo* followChainSteps(std::vector<ChainElement>& elements, const ChainNodePath& path,
+                             std::size_t index) {
+    if (index >= path.steps.size())
+        return nullptr;
+
+    const auto& step = path.steps[index];
+
+    if (step.type == ChainStepType::Device) {
+        // A Device step is a leaf: anything after it describes no route.
+        if (index + 1 != path.steps.size())
+            return nullptr;
+        for (auto& element : elements)
+            if (magda::isDevice(element) && magda::getDevice(element).id == step.id)
+                return &magda::getDevice(element);
+        return nullptr;
+    }
+
+    if (step.type != ChainStepType::Rack || index + 1 >= path.steps.size() ||
+        path.steps[index + 1].type != ChainStepType::Chain)
+        return nullptr;
+
+    for (auto& element : elements) {
+        if (!magda::isRack(element) || magda::getRack(element).id != step.id)
+            continue;
+        for (auto& chain : magda::getRack(element).chains)
+            if (chain.id == path.steps[index + 1].id)
+                return followChainSteps(chain.elements, path, index + 2);
+        return nullptr;
+    }
+    return nullptr;
+}
+
 /// The device @p deviceId names, searched for its pads rather than itself.
 ///
 /// A grid can sit anywhere a device can, including inside a rack chain, so the
@@ -1113,11 +1150,13 @@ DeviceInfo* TrackManager::getDeviceInPadByPath(const ChainNodePath& devicePath) 
     // Rack > Chain > Device space comes out of one counter, so the leaf id
     // names one device in the whole project, and whichever route reaches it
     // reaches the same one (#2211).
-    if (devicePath.steps.size() != 3)
+    // `Rack(gridDeviceId) > Chain(pad)` is the synthetic prefix; everything past
+    // it is an ordinary route, because a pad's chain holds racks like any other
+    // chain does and every walk that reaches a pad recurses through them.
+    if (devicePath.steps.size() < 3)
         return nullptr;
     if (devicePath.steps[0].type != ChainStepType::Rack ||
-        devicePath.steps[1].type != ChainStepType::Chain ||
-        devicePath.steps[2].type != ChainStepType::Device)
+        devicePath.steps[1].type != ChainStepType::Chain)
         return nullptr;
 
     auto* track = getTrack(devicePath.trackId);
@@ -1128,14 +1167,10 @@ DeviceInfo* TrackManager::getDeviceInPadByPath(const ChainNodePath& devicePath) 
     if (owner == nullptr)
         return nullptr;
 
-    for (auto& pad : owner->pads->chains) {
-        if (pad.id != devicePath.steps[1].id)
-            continue;
-        for (auto& element : pad.elements)
-            if (magda::isDevice(element) && magda::getDevice(element).id == devicePath.steps[2].id)
-                return &magda::getDevice(element);
-        return nullptr;
-    }
+    for (auto& pad : owner->pads->chains)
+        if (pad.id == devicePath.steps[1].id)
+            return followChainSteps(pad.elements, devicePath, 2);
+
     return nullptr;
 }
 

--- a/magda/daw/core/TrackManagerDevices.cpp
+++ b/magda/daw/core/TrackManagerDevices.cpp
@@ -1284,30 +1284,77 @@ void TrackManager::setDeviceKitRows(TrackId trackId, DeviceId deviceId,
     mirrorKitToPreferences(*device);
 }
 
-ChainNodePath TrackManager::findDevicePath(DeviceId deviceId) const {
-    // Search all tracks for a device by ID and return its full path
-    for (const auto& track : tracks_) {
-        for (const auto& element : track.chain.fxChainElements) {
-            if (magda::isDevice(element) && magda::getDevice(element).id == deviceId)
-                return ChainNodePath::topLevelDevice(track.id, deviceId);
-            if (magda::isRack(element)) {
-                const auto& rack = magda::getRack(element);
-                for (const auto& chain : rack.chains) {
-                    for (const auto& chainElement : chain.elements) {
-                        if (magda::isDevice(chainElement) &&
-                            magda::getDevice(chainElement).id == deviceId)
-                            return ChainNodePath::chainDevice(track.id, rack.id, chain.id,
-                                                              deviceId);
-                    }
-                }
-            }
+namespace {
+
+/// The path @p parentChain gives a device it directly holds.
+///
+/// A track's own FX list is not a chain and its devices are addressed as
+/// top-level ones, which is the same split `AddDeviceByPathCommand` makes.
+ChainNodePath devicePathUnder(const ChainNodePath& parentChain, DeviceId deviceId) {
+    return parentChain.getType() == ChainNodeType::Track
+               ? ChainNodePath::topLevelDevice(parentChain.trackId, deviceId)
+               : parentChain.withDevice(deviceId);
+}
+
+/// The path addressing @p deviceId somewhere under @p parentChain, or an
+/// invalid path when it is not there.
+///
+/// Descends into a rack's chains and into a pad-per-chain device's pads. A pad
+/// device is an ordinary DeviceInfo since #2207, so anything that starts from a
+/// DeviceId and needs a path -- alias generation, automation targets, link
+/// repair -- has to be able to reach one (#2211).
+ChainNodePath findDeviceUnder(const std::vector<ChainElement>& elements,
+                              const ChainNodePath& parentChain, DeviceId deviceId) {
+    for (const auto& element : elements) {
+        if (magda::isDevice(element)) {
+            const auto& device = magda::getDevice(element);
+            if (device.id == deviceId)
+                return devicePathUnder(parentChain, deviceId);
+
+            if (!device.pads)
+                continue;
+
+            // A pad's address spells its rack step with the grid's own
+            // DeviceId: what padChainPath() builds, and what every link a
+            // project has saved to a pad device carries.
+            const auto gridPath = devicePathUnder(parentChain, device.id);
+            for (const auto& pad : device.pads->chains)
+                if (auto found = findDeviceUnder(
+                        pad.elements, TrackManager::padChainPath(gridPath, pad.id), deviceId);
+                    found.isValid())
+                    return found;
+            continue;
+        }
+
+        if (magda::isRack(element)) {
+            const auto& rack = magda::getRack(element);
+            const auto rackPath = parentChain.getType() == ChainNodeType::Track
+                                      ? ChainNodePath::rack(parentChain.trackId, rack.id)
+                                      : parentChain.withRack(rack.id);
+            for (const auto& chain : rack.chains)
+                if (auto found =
+                        findDeviceUnder(chain.elements, rackPath.withChain(chain.id), deviceId);
+                    found.isValid())
+                    return found;
         }
     }
-    // Also check master track
-    for (const auto& element : masterTrack_.chain.fxChainElements) {
-        if (magda::isDevice(element) && magda::getDevice(element).id == deviceId)
-            return ChainNodePath::topLevelDevice(MASTER_TRACK_ID, deviceId);
-    }
+    return {};
+}
+
+}  // namespace
+
+ChainNodePath TrackManager::findDevicePath(DeviceId deviceId) const {
+    for (const auto& track : tracks_)
+        if (auto found = findDeviceUnder(track.chain.fxChainElements,
+                                         ChainNodePath::trackLevel(track.id), deviceId);
+            found.isValid())
+            return found;
+
+    if (auto found = findDeviceUnder(masterTrack_.chain.fxChainElements,
+                                     ChainNodePath::trackLevel(MASTER_TRACK_ID), deviceId);
+        found.isValid())
+        return found;
+
     return {};  // Not found — returns invalid path
 }
 

--- a/magda/daw/core/TrackManagerDevices.cpp
+++ b/magda/daw/core/TrackManagerDevices.cpp
@@ -16,12 +16,48 @@ namespace magda {
 
 namespace {
 
+struct PresetPadRemap {
+    DeviceId newOwnerId = INVALID_DEVICE_ID;
+    std::map<DeviceId, DeviceId> devices;
+};
+
 struct PresetIdRemap {
     TrackId trackId = INVALID_TRACK_ID;
     std::map<DeviceId, DeviceId> devices;
     std::map<RackId, RackId> racks;
     std::map<ChainId, ChainId> chains;
+    /// Keyed by the OLD DeviceId of the device that owns the pads.
+    std::map<DeviceId, PresetPadRemap> pads;
 };
+
+/// Rewrite @p path if it addresses a pad device, and say whether it did.
+///
+/// The same shape `remapDuplicatedPadPath()` handles for a duplicated track,
+/// and for the same reason: a pad device's address is
+/// `Rack(gridDeviceId) > Chain(pad) > Device(padDevice)`, and none of its steps
+/// may go through the ordinary maps. The rack step is a DeviceId, and rack ids
+/// come out of a counter that also starts at 1; the chain step is a pad chain
+/// id, rack-local and untouched by copying. Both ends are matched before either
+/// is rewritten, so a link merely passing through a rack numbered like a grid
+/// is left to the ordinary remap (#2211).
+bool remapPresetPadPath(ChainNodePath& path, const PresetIdRemap& remap) {
+    if (path.steps.size() != 3 || path.steps[0].type != ChainStepType::Rack ||
+        path.steps[1].type != ChainStepType::Chain || path.steps[2].type != ChainStepType::Device)
+        return false;
+
+    const auto owner = remap.pads.find(path.steps[0].id);
+    if (owner == remap.pads.end())
+        return false;
+
+    const auto device = owner->second.devices.find(path.steps[2].id);
+    if (device == owner->second.devices.end())
+        return false;
+
+    path.trackId = remap.trackId;
+    path.steps[0].id = owner->second.newOwnerId;
+    path.steps[2].id = device->second;
+    return true;
+}
 
 bool targetPointsAtDevice(const ControlTarget& target, DeviceId deviceId) {
     return deviceId != INVALID_DEVICE_ID && target.devicePath.getDeviceId() == deviceId;
@@ -56,6 +92,11 @@ template <typename Id> bool remapId(std::map<Id, Id> const& ids, int& value) {
 
 void remapPresetPath(ChainNodePath& path, const PresetIdRemap& remap) {
     bool touched = false;
+
+    // Pads first, and nothing else runs for one: every step of a pad path would
+    // be moved by the wrong map.
+    if (remapPresetPadPath(path, remap))
+        return;
 
     if (path.isTrackLevel) {
         path.trackId = remap.trackId;
@@ -139,6 +180,12 @@ void remapPresetLinksRecursive(std::vector<ChainElement>& elements, const Preset
             auto& device = magda::getDevice(element);
             remapPresetLinks(device.macros, device.mods, remap);
             device.pluginState = stripPresetRuntimePluginState(device.pluginState);
+
+            // A pad device is an ordinary DeviceInfo and owns macros and mods
+            // like any other, so a copy's have to be retargeted too (#2211).
+            if (device.pads)
+                for (auto& pad : device.pads->chains)
+                    remapPresetLinksRecursive(pad.elements, remap);
         } else if (magda::isRack(element)) {
             remapRackPresetLinks(magda::getRack(element), remap);
         }
@@ -672,6 +719,34 @@ static void reassignCopiedElementIds(TrackManager& tm, std::vector<ChainElement>
                 const auto oldId = device.id;
                 device.id = tm.allocateDeviceId();
                 remap.devices[oldId] = device.id;
+
+                // A pad-per-chain device's pads are its own: their DeviceIds and
+                // the rack id derived from the owner's would otherwise key the
+                // ops of the device this was copied from, and the copy's links
+                // would still name the original's pads. Pad chain ids are
+                // rack-local and stay as they are, which is what keeps a macro,
+                // a mod or an automation lane naming one still naming it.
+                if (device.pads) {
+                    stampPadRackId(device);
+                    auto& padRemap = remap.pads[oldId];
+                    padRemap.newOwnerId = device.id;
+
+                    for (auto& pad : device.pads->chains) {
+                        // The devices directly on the pad are the ones a pad
+                        // path names, so their old ids are noted before the walk
+                        // replaces them. Anything deeper is inside an ordinary
+                        // rack and goes through the ordinary maps.
+                        std::vector<DeviceId> padDeviceIds;
+                        for (const auto& padElement : pad.elements)
+                            if (magda::isDevice(padElement))
+                                padDeviceIds.push_back(magda::getDevice(padElement).id);
+
+                        reassignIds(pad.elements);
+
+                        for (const auto padDeviceId : padDeviceIds)
+                            padRemap.devices[padDeviceId] = remap.devices[padDeviceId];
+                    }
+                }
             } else if (magda::isRack(element)) {
                 auto& rack = magda::getRack(element);
                 const auto oldRackId = rack.id;
@@ -745,6 +820,18 @@ bool TrackManager::moveChainElement(const ChainNodePath& sourceElementPath,
     if (sourceType == ChainStepType::Rack &&
         chainPathContainsRack(destinationChainPath, sourceElementPath)) {
         return false;
+    }
+
+    // Refused for the same reason a wrap is: dropping a grid into a rack takes
+    // it somewhere no bus is carried, so the move would have to put every pad
+    // back on the main mix and take its child tracks down, and that clean-up is
+    // not part of the undoable step the move is. Undo would return the grid to
+    // the top level with its routing gone. Reordering within the track's own
+    // list is not a placement change and stays allowed (#2211).
+    if (destinationChainPath.getType() != ChainNodeType::Track) {
+        const auto* moved = getDeviceInChainByPath(sourceElementPath);
+        if (moved != nullptr && anyPadOnABus(*moved))
+            return false;
     }
 
     auto* sourceElements = getElementContainerForChainPath(*this, sourceChainPath);

--- a/magda/daw/core/TrackManagerDevices.cpp
+++ b/magda/daw/core/TrackManagerDevices.cpp
@@ -184,6 +184,27 @@ DeviceInfo* findUniqueBareDeviceIdMatch(TrackInfo& masterTrack, std::vector<Trac
     return matches.size() == 1 ? matches.front() : nullptr;
 }
 
+/// The device @p deviceId names, searched for its pads rather than itself.
+///
+/// A grid can sit anywhere a device can, including inside a rack chain, so the
+/// search descends the same way `findDeviceUnder` does.
+DeviceInfo* findPadOwner(std::vector<ChainElement>& elements, DeviceId deviceId) {
+    for (auto& element : elements) {
+        if (magda::isDevice(element)) {
+            auto& device = magda::getDevice(element);
+            if (device.id == deviceId)
+                return device.pads ? &device : nullptr;
+            continue;
+        }
+
+        if (magda::isRack(element))
+            for (auto& chain : magda::getRack(element).chains)
+                if (auto* found = findPadOwner(chain.elements, deviceId))
+                    return found;
+    }
+    return nullptr;
+}
+
 }  // namespace
 
 // ============================================================================
@@ -1075,6 +1096,45 @@ DeviceInfo* TrackManager::getDeviceInChainByPath(const ChainNodePath& devicePath
                 return &magda::getDevice(element);
             }
         }
+    }
+
+    return getDeviceInPadByPath(devicePath);
+}
+
+DeviceInfo* TrackManager::getDeviceInPadByPath(const ChainNodePath& devicePath) {
+    // A pad device's chain is not in the rack tree. Its address spells the Rack
+    // step with the owning device's id, and a pad rack is `DeviceInfo::pads`
+    // rather than a chain element, so `getRackByPath()` cannot follow it and
+    // was never meant to (#2207).
+    //
+    // Tried only after the ordinary route has failed, so an allocated rack that
+    // shares the number resolves exactly as it did before. That ordering is
+    // what makes this unambiguous rather than a guess: every device in the
+    // Rack > Chain > Device space comes out of one counter, so the leaf id
+    // names one device in the whole project, and whichever route reaches it
+    // reaches the same one (#2211).
+    if (devicePath.steps.size() != 3)
+        return nullptr;
+    if (devicePath.steps[0].type != ChainStepType::Rack ||
+        devicePath.steps[1].type != ChainStepType::Chain ||
+        devicePath.steps[2].type != ChainStepType::Device)
+        return nullptr;
+
+    auto* track = getTrack(devicePath.trackId);
+    if (track == nullptr)
+        return nullptr;
+
+    auto* owner = findPadOwner(track->chain.fxChainElements, devicePath.steps[0].id);
+    if (owner == nullptr)
+        return nullptr;
+
+    for (auto& pad : owner->pads->chains) {
+        if (pad.id != devicePath.steps[1].id)
+            continue;
+        for (auto& element : pad.elements)
+            if (magda::isDevice(element) && magda::getDevice(element).id == devicePath.steps[2].id)
+                return &magda::getDevice(element);
+        return nullptr;
     }
     return nullptr;
 }

--- a/magda/daw/core/TrackManagerDevices.cpp
+++ b/magda/daw/core/TrackManagerDevices.cpp
@@ -1,5 +1,6 @@
 #include <algorithm>
 #include <map>
+#include <set>
 
 #include "../audio/AudioBridge.hpp"
 #include "../audio/TracktionHelpers.hpp"
@@ -19,6 +20,9 @@ namespace {
 struct PresetPadRemap {
     DeviceId newOwnerId = INVALID_DEVICE_ID;
     std::map<DeviceId, DeviceId> devices;
+    /// The owner's pad chain ids. Unchanged by copying, and what tells a pad
+    /// prefix from a rack that merely shares the owner's number.
+    std::set<ChainId> chains;
 };
 
 struct PresetIdRemap {
@@ -29,6 +33,14 @@ struct PresetIdRemap {
     /// Keyed by the OLD DeviceId of the device that owns the pads.
     std::map<DeviceId, PresetPadRemap> pads;
 };
+
+template <typename Id> bool remapId(std::map<Id, Id> const& ids, int& value) {
+    auto it = ids.find(value);
+    if (it == ids.end())
+        return false;
+    value = it->second;
+    return true;
+}
 
 /// Rewrite @p path if it addresses a pad device, and say whether it did.
 ///
@@ -41,21 +53,51 @@ struct PresetIdRemap {
 /// is rewritten, so a link merely passing through a rack numbered like a grid
 /// is left to the ordinary remap (#2211).
 bool remapPresetPadPath(ChainNodePath& path, const PresetIdRemap& remap) {
-    if (path.steps.size() != 3 || path.steps[0].type != ChainStepType::Rack ||
-        path.steps[1].type != ChainStepType::Chain || path.steps[2].type != ChainStepType::Device)
+    if (path.steps.size() < 3 || path.steps[0].type != ChainStepType::Rack ||
+        path.steps[1].type != ChainStepType::Chain)
         return false;
 
     const auto owner = remap.pads.find(path.steps[0].id);
     if (owner == remap.pads.end())
         return false;
 
-    const auto device = owner->second.devices.find(path.steps[2].id);
-    if (device == owner->second.devices.end())
+    // A pad device, named directly by the pad's chain.
+    if (path.steps.size() == 3 && path.steps[2].type == ChainStepType::Device) {
+        const auto device = owner->second.devices.find(path.steps[2].id);
+        if (device == owner->second.devices.end())
+            return false;
+
+        path.trackId = remap.trackId;
+        path.steps[0].id = owner->second.newOwnerId;
+        path.steps[2].id = device->second;
+        return true;
+    }
+
+    // Or something further down, inside a rack the pad's chain holds. The
+    // prefix is still the pad's and still has to come from the pad map; what
+    // follows is an ordinary route and was re-keyed with the ordinary ones.
+    if (!owner->second.chains.contains(path.steps[1].id))
         return false;
 
     path.trackId = remap.trackId;
     path.steps[0].id = owner->second.newOwnerId;
-    path.steps[2].id = device->second;
+
+    for (std::size_t index = 2; index < path.steps.size(); ++index) {
+        auto& step = path.steps[index];
+        switch (step.type) {
+            case ChainStepType::Rack:
+                remapId(remap.racks, step.id);
+                break;
+            case ChainStepType::Chain:
+                remapId(remap.chains, step.id);
+                break;
+            case ChainStepType::Device:
+                remapId(remap.devices, step.id);
+                break;
+            case ChainStepType::Segment:
+                break;
+        }
+    }
     return true;
 }
 
@@ -80,14 +122,6 @@ void retargetPresetLinks(MacroArray& macros, ModArray& mods, DeviceId presetDevi
         for (auto& link : mod.links)
             retargetPresetLink(link.target, presetDeviceId, liveDevicePath);
     }
-}
-
-template <typename Id> bool remapId(std::map<Id, Id> const& ids, int& value) {
-    auto it = ids.find(value);
-    if (it == ids.end())
-        return false;
-    value = it->second;
-    return true;
 }
 
 void remapPresetPath(ChainNodePath& path, const PresetIdRemap& remap) {
@@ -720,6 +754,16 @@ static void reassignCopiedElementIds(TrackManager& tm, std::vector<ChainElement>
                 device.id = tm.allocateDeviceId();
                 remap.devices[oldId] = device.id;
 
+                // The copy owns no child tracks yet. Inheriting the source's
+                // pair state would leave the sync thinking they were already
+                // made, so it would build none and the copy's pads on a bus
+                // would be silent while the link still named the original.
+                // `duplicateTrack()` clears them for the same reason.
+                for (auto& pair : device.multiOut.outputPairs) {
+                    pair.active = false;
+                    pair.trackId = INVALID_TRACK_ID;
+                }
+
                 // A pad-per-chain device's pads are its own: their DeviceIds and
                 // the rack id derived from the owner's would otherwise key the
                 // ops of the device this was copied from, and the copy's links
@@ -732,6 +776,8 @@ static void reassignCopiedElementIds(TrackManager& tm, std::vector<ChainElement>
                     padRemap.newOwnerId = device.id;
 
                     for (auto& pad : device.pads->chains) {
+                        padRemap.chains.insert(pad.id);
+
                         // The devices directly on the pad are the ones a pad
                         // path names, so their old ids are noted before the walk
                         // replaces them. Anything deeper is inside an ordinary
@@ -828,7 +874,13 @@ bool TrackManager::moveChainElement(const ChainNodePath& sourceElementPath,
     // not part of the undoable step the move is. Undo would return the grid to
     // the top level with its routing gone. Reordering within the track's own
     // list is not a placement change and stays allowed (#2211).
-    if (destinationChainPath.getType() != ChainNodeType::Track) {
+    // Only reordering within the same track's own list leaves the placement
+    // alone. A track-level destination on another track moves the pair state
+    // with the device while the existing child track still links to the track
+    // it came from, so the sync finds the pair already active, makes nothing,
+    // and the pad goes quiet.
+    if (destinationChainPath.getType() != ChainNodeType::Track ||
+        destinationChainPath.trackId != sourceElementPath.trackId) {
         const auto* moved = getDeviceInChainByPath(sourceElementPath);
         if (moved != nullptr && anyPadOnABus(*moved))
             return false;

--- a/magda/daw/core/TrackManagerPads.cpp
+++ b/magda/daw/core/TrackManagerPads.cpp
@@ -347,22 +347,59 @@ void TrackManager::setPadOutput(const ChainNodePath& gridPath, int padIndex, int
     notifyTrackDevicesChanged(gridPath.trackId);
 }
 
-void TrackManager::setPadNoteRange(const ChainNodePath& gridPath, int padIndex, int lowNote,
+bool TrackManager::setPadNoteRange(const ChainNodePath& gridPath, int padIndex, int lowNote,
                                    int highNote, int rootNote) {
-    auto* pad = mutablePad(gridPath, padIndex);
+    auto* pads = getPads(gridPath);
+    if (pads == nullptr)
+        return false;
+
+    auto* pad = findPadChain(*pads, padIndex);
     if (pad == nullptr)
-        return;
+        return false;
 
     const auto low = juce::jlimit(0, 127, std::min(lowNote, highNote));
     const auto high = juce::jlimit(0, 127, std::max(lowNote, highNote));
     const auto root = juce::jlimit(0, 127, rootNote);
 
     if (pad->lowNote == low && pad->highNote == high && pad->rootNote == root)
-        return;
+        return true;
+
+    // One note, one owner. Every chain whose range covers an incoming note
+    // plays it, so an overlap layers two sounds the UI has no way to tell
+    // apart: the rows show the last chain to claim a note and the setters
+    // reach the first, so a row would edit a chain other than the one it
+    // shows. Refused rather than silently normalised, so the slider snaps
+    // back to what the model kept.
+    for (const auto& other : pads->chains)
+        if (other.id != pad->id && !other.answersToEveryNote() && low <= other.highNote &&
+            high >= other.lowNote)
+            return false;
 
     pad->lowNote = low;
     pad->highNote = high;
     pad->rootNote = root;
+    notifyTrackDevicesChanged(gridPath.trackId);
+    return true;
+}
+
+void TrackManager::removePadChain(const ChainNodePath& gridPath, ChainId padChainId) {
+    auto* pads = getPads(gridPath);
+    if (pads == nullptr)
+        return;
+
+    const auto found = std::ranges::find_if(
+        pads->chains, [padChainId](const ChainInfo& chain) { return chain.id == padChainId; });
+    if (found == pads->chains.end())
+        return;
+
+    const auto chainPath = padChainPath(gridPath, padChainId);
+    for (const auto& element : found->elements)
+        if (magda::isDevice(element))
+            SelectionManager::getInstance().clearSelectionForDeletedChainNode(
+                chainPath.withDevice(magda::getDevice(element).id));
+    SelectionManager::getInstance().clearSelectionForDeletedChainNode(chainPath);
+
+    pads->chains.erase(found);
     notifyTrackDevicesChanged(gridPath.trackId);
 }
 

--- a/magda/daw/core/TrackManagerPads.cpp
+++ b/magda/daw/core/TrackManagerPads.cpp
@@ -343,6 +343,25 @@ bool TrackManager::padBusesAvailable(const ChainNodePath& gridPath) const {
     return gridPath.getType() == ChainNodeType::TopLevelDevice;
 }
 
+bool TrackManager::resetPadBuses(const ChainNodePath& gridPath) {
+    auto* pads = getPads(gridPath);
+    if (pads == nullptr)
+        return false;
+
+    bool moved = false;
+    for (auto& pad : pads->chains) {
+        if (pad.outputIndex == 0)
+            continue;
+        pad.outputIndex = 0;
+        moved = true;
+    }
+
+    if (moved)
+        notifyTrackDevicesChanged(gridPath.trackId);
+
+    return moved;
+}
+
 bool TrackManager::setPadOutput(const ChainNodePath& gridPath, int padIndex, int outputIndex) {
     if (outputIndex != 0 && !padBusesAvailable(gridPath))
         return false;

--- a/magda/daw/core/TrackManagerPads.cpp
+++ b/magda/daw/core/TrackManagerPads.cpp
@@ -334,10 +334,24 @@ void TrackManager::setPadBypassed(const ChainNodePath& gridPath, int padIndex, b
     }
 }
 
-void TrackManager::setPadOutput(const ChainNodePath& gridPath, int padIndex, int outputIndex) {
+bool TrackManager::padBusesAvailable(const ChainNodePath& gridPath) const {
+    // A multi-out child track is fed by the output instance
+    // InstrumentRackManager makes when it wraps a top-level instrument. A grid
+    // inside a MAGDA rack is loaded by RackSyncManager instead and has no entry
+    // there, so nothing would carry a bus off it: the pads on that bus would
+    // simply go silent. Refused until that route exists (#2211).
+    return gridPath.getType() == ChainNodeType::TopLevelDevice;
+}
+
+bool TrackManager::setPadOutput(const ChainNodePath& gridPath, int padIndex, int outputIndex) {
+    if (outputIndex != 0 && !padBusesAvailable(gridPath))
+        return false;
+
     auto* pad = mutablePad(gridPath, padIndex);
-    if (pad == nullptr || pad->outputIndex == outputIndex)
-        return;
+    if (pad == nullptr)
+        return false;
+    if (pad->outputIndex == outputIndex)
+        return true;
 
     pad->outputIndex = outputIndex;
 
@@ -345,6 +359,40 @@ void TrackManager::setPadOutput(const ChainNodePath& gridPath, int padIndex, int
     // whether the grid needs a multi-out child track for it, and that is
     // settled by the device sync (PluginManager::syncDrumGridMultiOutTracks).
     notifyTrackDevicesChanged(gridPath.trackId);
+    return true;
+}
+
+bool TrackManager::padNoteRangeIsFree(const ChainNodePath& gridPath, int padIndex, int lowNote,
+                                      int highNote) const {
+    const auto* pads = getPads(gridPath);
+    if (pads == nullptr)
+        return false;
+
+    const auto* pad = findPadChain(*pads, padIndex);
+    if (pad == nullptr)
+        return false;
+
+    const auto low = juce::jlimit(0, 127, std::min(lowNote, highNote));
+    const auto high = juce::jlimit(0, 127, std::max(lowNote, highNote));
+
+    // Reachable. The grid shows kPadCount pads from kPadBaseNote, and its rows
+    // are built from those notes: a chain moved clear of them keeps playing and
+    // disappears from the UI, with no way left to edit or delete it.
+    if (high < kPadBaseNote || low > kPadBaseNote + kPadCount - 1)
+        return false;
+
+    // One note, one owner. Every chain whose range covers an incoming note
+    // plays it, so an overlap layers two sounds the UI has no way to tell
+    // apart: the rows show the last chain to claim a note and the setters
+    // reach the first, so a row would edit a chain other than the one it
+    // shows. Refused rather than silently normalised, so the row snaps back
+    // to what the model kept.
+    for (const auto& other : pads->chains)
+        if (other.id != pad->id && !other.answersToEveryNote() && low <= other.highNote &&
+            high >= other.lowNote)
+            return false;
+
+    return true;
 }
 
 bool TrackManager::setPadNoteRange(const ChainNodePath& gridPath, int padIndex, int lowNote,
@@ -364,16 +412,8 @@ bool TrackManager::setPadNoteRange(const ChainNodePath& gridPath, int padIndex, 
     if (pad->lowNote == low && pad->highNote == high && pad->rootNote == root)
         return true;
 
-    // One note, one owner. Every chain whose range covers an incoming note
-    // plays it, so an overlap layers two sounds the UI has no way to tell
-    // apart: the rows show the last chain to claim a note and the setters
-    // reach the first, so a row would edit a chain other than the one it
-    // shows. Refused rather than silently normalised, so the slider snaps
-    // back to what the model kept.
-    for (const auto& other : pads->chains)
-        if (other.id != pad->id && !other.answersToEveryNote() && low <= other.highNote &&
-            high >= other.lowNote)
-            return false;
+    if (!padNoteRangeIsFree(gridPath, padIndex, low, high))
+        return false;
 
     pad->lowNote = low;
     pad->highNote = high;

--- a/magda/daw/core/TrackManagerPads.cpp
+++ b/magda/daw/core/TrackManagerPads.cpp
@@ -51,6 +51,22 @@ const RackInfo* TrackManager::getPads(const ChainNodePath& gridPath) const {
     return const_cast<TrackManager*>(this)->getPads(gridPath);
 }
 
+void TrackManager::setPads(const ChainNodePath& gridPath, const PadRack& pads) {
+    auto* device = getDeviceInChainByPath(gridPath);
+    if (device == nullptr)
+        return;
+
+    device->pads = pads;
+
+    // The rack carries the device's id, and a restored copy has to carry the
+    // id the device has now rather than the one it had when the snapshot was
+    // taken -- a device restored by an undo of its own removal comes back under
+    // the same id, but nothing here depends on that being true.
+    stampPadRackId(*device);
+
+    notifyTrackDevicesChanged(gridPath.trackId);
+}
+
 ChainInfo* TrackManager::getPadChain(const ChainNodePath& gridPath, ChainId padChainId) {
     auto* pads = getPads(gridPath);
     if (pads == nullptr)
@@ -310,6 +326,38 @@ void TrackManager::setPadBypassed(const ChainNodePath& gridPath, int padIndex, b
         pad->bypassed = bypassed;
         notifyTrackDevicesChanged(gridPath.trackId);
     }
+}
+
+void TrackManager::setPadOutput(const ChainNodePath& gridPath, int padIndex, int outputIndex) {
+    auto* pad = mutablePad(gridPath, padIndex);
+    if (pad == nullptr || pad->outputIndex == outputIndex)
+        return;
+
+    pad->outputIndex = outputIndex;
+
+    // trackDevicesChanged, not trackPropertyChanged: a pad's bus decides
+    // whether the grid needs a multi-out child track for it, and that is
+    // settled by the device sync (PluginManager::syncDrumGridMultiOutTracks).
+    notifyTrackDevicesChanged(gridPath.trackId);
+}
+
+void TrackManager::setPadNoteRange(const ChainNodePath& gridPath, int padIndex, int lowNote,
+                                   int highNote, int rootNote) {
+    auto* pad = mutablePad(gridPath, padIndex);
+    if (pad == nullptr)
+        return;
+
+    const auto low = juce::jlimit(0, 127, std::min(lowNote, highNote));
+    const auto high = juce::jlimit(0, 127, std::max(lowNote, highNote));
+    const auto root = juce::jlimit(0, 127, rootNote);
+
+    if (pad->lowNote == low && pad->highNote == high && pad->rootNote == root)
+        return;
+
+    pad->lowNote = low;
+    pad->highNote = high;
+    pad->rootNote = root;
+    notifyTrackDevicesChanged(gridPath.trackId);
 }
 
 ChainInfo* TrackManager::mutablePad(const ChainNodePath& gridPath, int padIndex) {

--- a/magda/daw/core/TrackManagerPads.cpp
+++ b/magda/daw/core/TrackManagerPads.cpp
@@ -25,6 +25,40 @@ namespace magda {
 // the model is reached the unambiguous way.
 // ============================================================================
 
+namespace {
+
+/// Drop any selection standing on something inside @p chainPath before it goes.
+///
+/// Every node under it, not only the devices it holds directly: a pad's chain
+/// takes racks like any other chain, and `clearSelectionForDeletedChainNode()`
+/// matches an exact path or a device id rather than an ancestor, so a selection
+/// below a nested rack would survive the erase pointing at freed model (#2211).
+void clearSelectionsUnder(const std::vector<ChainElement>& elements,
+                          const ChainNodePath& chainPath) {
+    auto& selection = SelectionManager::getInstance();
+    for (const auto& element : elements) {
+        if (magda::isDevice(element)) {
+            selection.clearSelectionForDeletedChainNode(
+                chainPath.withDevice(magda::getDevice(element).id));
+            continue;
+        }
+
+        if (!magda::isRack(element))
+            continue;
+
+        const auto& rack = magda::getRack(element);
+        const auto rackPath = chainPath.withRack(rack.id);
+        for (const auto& chain : rack.chains) {
+            const auto nested = rackPath.withChain(chain.id);
+            clearSelectionsUnder(chain.elements, nested);
+            selection.clearSelectionForDeletedChainNode(nested);
+        }
+        selection.clearSelectionForDeletedChainNode(rackPath);
+    }
+}
+
+}  // namespace
+
 ChainNodePath TrackManager::padChainPath(const ChainNodePath& gridPath, ChainId padChainId) {
     // Flat, and named by the DEVICE's own id: `Rack(gridDeviceId) > Chain(pad)`,
     // whatever the grid itself is nested in.
@@ -220,11 +254,7 @@ DeviceId TrackManager::setPadDevice(const ChainNodePath& gridPath, int padIndex,
     // Dropping an instrument on a pad replaces the pad, effects and all: that
     // is what the pad's slot means. Selections pointing into what is going away
     // are cleared first, the same as any other device removal.
-    const auto chainPath = padChainPath(gridPath, padChainId);
-    for (const auto& element : pad->elements)
-        if (magda::isDevice(element))
-            SelectionManager::getInstance().clearSelectionForDeletedChainNode(
-                chainPath.withDevice(magda::getDevice(element).id));
+    clearSelectionsUnder(pad->elements, padChainPath(gridPath, padChainId));
     pad->elements.clear();
 
     // Named after what is on it, which is what the grid shows on the pad.
@@ -250,10 +280,7 @@ void TrackManager::clearPad(const ChainNodePath& gridPath, int padIndex) {
         return;
 
     const auto chainPath = padChainPath(gridPath, pad->id);
-    for (const auto& element : pad->elements)
-        if (magda::isDevice(element))
-            SelectionManager::getInstance().clearSelectionForDeletedChainNode(
-                chainPath.withDevice(magda::getDevice(element).id));
+    clearSelectionsUnder(pad->elements, chainPath);
     SelectionManager::getInstance().clearSelectionForDeletedChainNode(chainPath);
 
     std::erase_if(pads->chains, [id = pad->id](const ChainInfo& chain) { return chain.id == id; });
@@ -363,6 +390,13 @@ bool TrackManager::resetPadBuses(const ChainNodePath& gridPath) {
 }
 
 bool TrackManager::setPadOutput(const ChainNodePath& gridPath, int padIndex, int outputIndex) {
+    // The bus has to be one that exists. The live plugin clamps what it is
+    // given and the plan compiler takes the model's value as it finds it, so an
+    // out-of-range index makes the two engines disagree: the plan reports a bus
+    // that reaches no track and the pads on it go silent (#2211).
+    if (outputIndex < 0 || outputIndex >= kPadBusCount)
+        return false;
+
     if (outputIndex != 0 && !padBusesAvailable(gridPath))
         return false;
 
@@ -394,10 +428,14 @@ bool TrackManager::padNoteRangeIsFree(const ChainNodePath& gridPath, int padInde
     const auto low = juce::jlimit(0, 127, std::min(lowNote, highNote));
     const auto high = juce::jlimit(0, 127, std::max(lowNote, highNote));
 
-    // Reachable. The grid shows kPadCount pads from kPadBaseNote, and its rows
-    // are built from those notes: a chain moved clear of them keeps playing and
-    // disappears from the UI, with no way left to edit or delete it.
-    if (high < kPadBaseNote || low > kPadBaseNote + kPadCount - 1)
+    // Reachable, at both ends. The grid shows kPadCount pads from kPadBaseNote
+    // and builds its rows from those notes, so a chain reaching outside them
+    // keeps playing and cannot be seen; and `padParameterSlot()` takes the pad's
+    // slot from its bottom note, so a low end below the grid returns -1 and the
+    // plan stops binding the chain's fader and pan to the grid's parameters.
+    // The endpoint sliders offer only these notes, so this is also what keeps
+    // the row's reading of a range honest.
+    if (low < kPadBaseNote || high > kPadBaseNote + kPadCount - 1)
         return false;
 
     // One note, one owner. Every chain whose range covers an incoming note
@@ -452,10 +490,7 @@ void TrackManager::removePadChain(const ChainNodePath& gridPath, ChainId padChai
         return;
 
     const auto chainPath = padChainPath(gridPath, padChainId);
-    for (const auto& element : found->elements)
-        if (magda::isDevice(element))
-            SelectionManager::getInstance().clearSelectionForDeletedChainNode(
-                chainPath.withDevice(magda::getDevice(element).id));
+    clearSelectionsUnder(found->elements, chainPath);
     SelectionManager::getInstance().clearSelectionForDeletedChainNode(chainPath);
 
     pads->chains.erase(found);

--- a/magda/daw/core/TrackManagerPads.cpp
+++ b/magda/daw/core/TrackManagerPads.cpp
@@ -38,7 +38,13 @@ ChainNodePath TrackManager::padChainPath(const ChainNodePath& gridPath, ChainId 
     //
     // The synthetic negative id is still what `RackInfo::id` holds, because the
     // plan keys its ops on it and `isPadRackId()` is how the executor tells a
-    // pad rack from an allocated one. `getRackByPath()` resolves either.
+    // pad rack from an allocated one.
+    //
+    // `getRackByPath()` does not resolve this: a pad rack is a field on a
+    // device rather than a chain element, and the Rack step here carries the
+    // device's id rather than the rack's. `getDeviceInChainByPath()` follows it
+    // through `getDeviceInPadByPath()`, tried after the ordinary rack route so
+    // an allocated rack sharing the number is unaffected (#2211).
     return ChainNodePath::chain(gridPath.trackId, gridPath.getDeviceId(), padChainId);
 }
 

--- a/magda/daw/project/serialization/TrackSerializer.cpp
+++ b/magda/daw/project/serialization/TrackSerializer.cpp
@@ -965,7 +965,13 @@ bool ProjectSerializer::deserializeChainInfo(const juce::var& json, ChainInfo& o
 
     outChain.id = obj->getProperty("id");
     outChain.name = obj->getProperty("name").toString();
-    outChain.outputIndex = obj->getProperty("outputIndex");
+
+    // Normalised on the way in, not trusted. A pad's bus is what the plan
+    // compiler routes from, and it silences a pad on a bus that reaches no
+    // track rather than folding it into the device's mix, so a saved value
+    // outside the range the buses exist in would lose the audio (#2211).
+    outChain.outputIndex =
+        juce::jlimit(0, kPadBusCount - 1, static_cast<int>(obj->getProperty("outputIndex")));
     outChain.muted = obj->getProperty("muted");
     outChain.solo = obj->getProperty("solo");
     outChain.bypassed = obj->getProperty("bypassed");

--- a/magda/daw/ui/components/chain/drum_grid/DrumGridUI.cpp
+++ b/magda/daw/ui/components/chain/drum_grid/DrumGridUI.cpp
@@ -532,6 +532,8 @@ void DrumGridUI::setSelectedPad(int padIndex) {
         row->setSelected(rowChainIdx >= 0 && rowChainIdx == selectedChainIdx);
     }
 
+    refreshRangeRows();
+
     // Scroll chains viewport to show the selected row
     for (auto& row : chainRows_) {
         if (row->isSelected()) {
@@ -781,6 +783,21 @@ void DrumGridUI::resized() {
             row->setBounds(0, y, containerWidth, PadChainRowComponent::ROW_HEIGHT);
             chainsContainer_.addAndMakeVisible(*row);
             y += PadChainRowComponent::ROW_HEIGHT + 2;
+
+            // The selected chain's key range sits directly under it. The
+            // others are built but never laid out, so they stay out of the
+            // container's children.
+            if (!row->isSelected())
+                continue;
+
+            for (auto& rangeRow : rangeRows_) {
+                if (rangeRow->getPadIndex() != row->getPadIndex())
+                    continue;
+                rangeRow->setBounds(0, y, containerWidth, PadChainRangeRowComponent::ROW_HEIGHT);
+                chainsContainer_.addAndMakeVisible(*rangeRow);
+                y += PadChainRangeRowComponent::ROW_HEIGHT + 2;
+                break;
+            }
         }
         chainsContainer_.setSize(containerWidth, juce::jmax(y, chainsArea.getHeight()));
     } else {
@@ -934,6 +951,7 @@ void DrumGridUI::itemDropped(const SourceDetails& details) {
 
 void DrumGridUI::rebuildChainRows() {
     chainRows_.clear();
+    rangeRows_.clear();
     chainsContainer_.removeAllChildren();
 
     // Build rows from padInfos — one row per pad that has a chain
@@ -1011,12 +1029,40 @@ void DrumGridUI::rebuildChainRows() {
 
         row->setSelected(i == selectedPad_);
         chainRows_.push_back(std::move(row));
+
+        // --- Key range row ---
+        //
+        // One per chain, laid out only under the selected one. A pad is keyed
+        // by pitch, so its range has to be editable somewhere, and showing a
+        // row for every chain would double the panel for a field most pads
+        // never move off their own note. Built here rather than on selection
+        // because selection is changed from a row's own mouseUp: rebuilding
+        // there would destroy the component mid-callback.
+        auto rangeRow = std::make_unique<PadChainRangeRowComponent>(i);
+        rangeRow->setSelected(true);
+        rangeRow->onRangeChanged = [this](int padIndex, int low, int high, int root) {
+            if (onPadRangeChanged)
+                onPadRangeChanged(padIndex, low, high, root);
+        };
+        rangeRows_.push_back(std::move(rangeRow));
     }
+
+    refreshRangeRows();
 
     resized();
     repaint();
     if (onLayoutChanged)
         onLayoutChanged();
+}
+
+void DrumGridUI::refreshRangeRows() {
+    if (!getNoteRange)
+        return;
+
+    for (auto& rangeRow : rangeRows_) {
+        const auto [lowNote, highNote, rootNote] = getNoteRange(rangeRow->getPadIndex());
+        rangeRow->updateFromChain("Range", lowNote, highNote, rootNote);
+    }
 }
 
 void DrumGridUI::showPadContextMenu(int padIndex, juce::Point<int> screenPos) {

--- a/magda/daw/ui/components/chain/drum_grid/DrumGridUI.cpp
+++ b/magda/daw/ui/components/chain/drum_grid/DrumGridUI.cpp
@@ -261,6 +261,7 @@ DrumGridUI::DrumGridUI() {
         if (onPadLevelChanged)
             onPadLevelChanged(selectedPad_, static_cast<float>(value));
     };
+    levelSlider_.onDragEnd = [this]() { ++faderGesture_; };
     addAndMakeVisible(levelSlider_);
 
     // Pan slider (-1 to +1)
@@ -288,6 +289,7 @@ DrumGridUI::DrumGridUI() {
         if (onPadPanChanged)
             onPadPanChanged(selectedPad_, static_cast<float>(value));
     };
+    panSlider_.onDragEnd = [this]() { ++faderGesture_; };
     addAndMakeVisible(panSlider_);
 
     // Mute/Solo buttons
@@ -992,6 +994,7 @@ void DrumGridUI::rebuildChainRows() {
             if (onPadPanChanged)
                 onPadPanChanged(padIndex, val);
         };
+        row->onFaderGestureEnd = [this]() { ++faderGesture_; };
         row->onMuteChanged = [this](int padIndex, bool val) {
             padInfos_[static_cast<size_t>(padIndex)].mute = val;
             if (onPadMuteChanged)

--- a/magda/daw/ui/components/chain/drum_grid/DrumGridUI.cpp
+++ b/magda/daw/ui/components/chain/drum_grid/DrumGridUI.cpp
@@ -262,8 +262,13 @@ DrumGridUI::DrumGridUI() {
     levelSlider_.onValueChanged = [this](double value) {
         if (onPadLevelChanged)
             onPadLevelChanged(selectedPad_, static_cast<float>(value));
+        // A typed value or a reset has no drag to end, so it closes its own
+        // gesture here. Without this, two typed values on the same fader keep
+        // the same token and fold into one undo step (#2211).
+        if (!levelSlider_.isBeingDragged())
+            endFaderGesture();
     };
-    levelSlider_.onDragEnd = [this]() { faderGesture_ = nextFaderGesture_.fetch_add(1); };
+    levelSlider_.onDragEnd = [this]() { endFaderGesture(); };
     addAndMakeVisible(levelSlider_);
 
     // Pan slider (-1 to +1)
@@ -290,8 +295,10 @@ DrumGridUI::DrumGridUI() {
     panSlider_.onValueChanged = [this](double value) {
         if (onPadPanChanged)
             onPadPanChanged(selectedPad_, static_cast<float>(value));
+        if (!panSlider_.isBeingDragged())
+            endFaderGesture();
     };
-    panSlider_.onDragEnd = [this]() { faderGesture_ = nextFaderGesture_.fetch_add(1); };
+    panSlider_.onDragEnd = [this]() { endFaderGesture(); };
     addAndMakeVisible(panSlider_);
 
     // Mute/Solo buttons
@@ -996,7 +1003,7 @@ void DrumGridUI::rebuildChainRows() {
             if (onPadPanChanged)
                 onPadPanChanged(padIndex, val);
         };
-        row->onFaderGestureEnd = [this]() { faderGesture_ = nextFaderGesture_.fetch_add(1); };
+        row->onFaderGestureEnd = [this]() { endFaderGesture(); };
         row->onMuteChanged = [this](int padIndex, bool val) {
             padInfos_[static_cast<size_t>(padIndex)].mute = val;
             if (onPadMuteChanged)
@@ -1032,7 +1039,13 @@ void DrumGridUI::rebuildChainRows() {
                 onPadOutputChanged(padIndex, busIndex);
         };
 
-        row->setSelected(i == selectedPad_);
+        // By chain, the same comparison setSelectedPad() makes. A row is named
+        // by the lowest pad its chain covers, so selecting any other note of a
+        // ranged chain left the next rebuild unselecting its only row, and the
+        // range editor under it went unlaid out (#2211).
+        row->setSelected(info.chainIndex >= 0 &&
+                         info.chainIndex ==
+                             padInfos_[static_cast<size_t>(selectedPad_)].chainIndex);
         chainRows_.push_back(std::move(row));
 
         // --- Key range row ---
@@ -1058,6 +1071,10 @@ void DrumGridUI::rebuildChainRows() {
     repaint();
     if (onLayoutChanged)
         onLayoutChanged();
+}
+
+void DrumGridUI::endFaderGesture() {
+    faderGesture_ = nextFaderGesture_.fetch_add(1);
 }
 
 void DrumGridUI::refreshRangeRows() {

--- a/magda/daw/ui/components/chain/drum_grid/DrumGridUI.cpp
+++ b/magda/daw/ui/components/chain/drum_grid/DrumGridUI.cpp
@@ -18,6 +18,8 @@ namespace te = tracktion::engine;
 
 namespace magda::daw::ui {
 
+std::atomic<int> DrumGridUI::nextFaderGesture_{0};
+
 // =============================================================================
 // PadButton
 // =============================================================================
@@ -261,7 +263,7 @@ DrumGridUI::DrumGridUI() {
         if (onPadLevelChanged)
             onPadLevelChanged(selectedPad_, static_cast<float>(value));
     };
-    levelSlider_.onDragEnd = [this]() { ++faderGesture_; };
+    levelSlider_.onDragEnd = [this]() { faderGesture_ = nextFaderGesture_.fetch_add(1); };
     addAndMakeVisible(levelSlider_);
 
     // Pan slider (-1 to +1)
@@ -289,7 +291,7 @@ DrumGridUI::DrumGridUI() {
         if (onPadPanChanged)
             onPadPanChanged(selectedPad_, static_cast<float>(value));
     };
-    panSlider_.onDragEnd = [this]() { ++faderGesture_; };
+    panSlider_.onDragEnd = [this]() { faderGesture_ = nextFaderGesture_.fetch_add(1); };
     addAndMakeVisible(panSlider_);
 
     // Mute/Solo buttons
@@ -994,7 +996,7 @@ void DrumGridUI::rebuildChainRows() {
             if (onPadPanChanged)
                 onPadPanChanged(padIndex, val);
         };
-        row->onFaderGestureEnd = [this]() { ++faderGesture_; };
+        row->onFaderGestureEnd = [this]() { faderGesture_ = nextFaderGesture_.fetch_add(1); };
         row->onMuteChanged = [this](int padIndex, bool val) {
             padInfos_[static_cast<size_t>(padIndex)].mute = val;
             if (onPadMuteChanged)

--- a/magda/daw/ui/components/chain/drum_grid/DrumGridUI.hpp
+++ b/magda/daw/ui/components/chain/drum_grid/DrumGridUI.hpp
@@ -328,6 +328,9 @@ class DrumGridUI : public juce::Component,
     //==============================================================================
     void setDetailCollapsed(bool collapsed);
     void refreshPadButtons();
+
+    /// Close the current fader gesture, so the next edit is a new undo step.
+    void endFaderGesture();
     void refreshDetailPanel();
     void goToPrevPage();
     void goToNextPage();

--- a/magda/daw/ui/components/chain/drum_grid/DrumGridUI.hpp
+++ b/magda/daw/ui/components/chain/drum_grid/DrumGridUI.hpp
@@ -96,6 +96,13 @@ class DrumGridUI : public juce::Component,
     /** Called when pad pan changes. (padIndex, pan -1..1) */
     std::function<void(int, float)> onPadPanChanged;
 
+    /** Which fader drag the level and pan callbacks currently belong to.
+        Bumped when a drag ends, so consecutive gestures on the same fader are
+        separate undo steps rather than one merged run (#2211). */
+    int getFaderGesture() const {
+        return faderGesture_;
+    }
+
     /** Called when pad mute changes. (padIndex, muted) */
     std::function<void(int, bool)> onPadMuteChanged;
 
@@ -238,6 +245,7 @@ class DrumGridUI : public juce::Component,
     };
 
     std::array<PadInfo, kTotalPads> padInfos_;
+    int faderGesture_ = 0;
     int selectedPad_ = 0;
     int currentPage_ = 0;
 

--- a/magda/daw/ui/components/chain/drum_grid/DrumGridUI.hpp
+++ b/magda/daw/ui/components/chain/drum_grid/DrumGridUI.hpp
@@ -4,6 +4,7 @@
 #include <juce_gui_basics/juce_gui_basics.h>
 
 #include <array>
+#include <atomic>
 #include <functional>
 #include <memory>
 
@@ -157,6 +158,10 @@ class DrumGridUI : public juce::Component,
     /** Rebuild visible chain rows from padInfos_. */
     void rebuildChainRows();
 
+    /** Re-read the key range rows from the model. Called after an edit the
+        model refused, so the row shows the range it actually kept (#2211). */
+    void refreshRangeRows();
+
     /** Show or hide the chains panel. */
     void setChainsPanelVisible(bool visible);
 
@@ -245,7 +250,15 @@ class DrumGridUI : public juce::Component,
     };
 
     std::array<PadInfo, kTotalPads> padInfos_;
-    int faderGesture_ = 0;
+
+    // Process-wide and monotonic. A token local to one DrumGridUI restarts at
+    // zero every time the component is rebuilt -- reopening the device UI,
+    // switching tracks -- and none of that is an undoable action, so the last
+    // fader command can still be on top of the undo stack when the first drag
+    // in the new UI arrives. Reusing the token would fold two sessions into
+    // one step (#2211).
+    static std::atomic<int> nextFaderGesture_;
+    int faderGesture_ = nextFaderGesture_.fetch_add(1);
     int selectedPad_ = 0;
     int currentPage_ = 0;
 
@@ -315,7 +328,6 @@ class DrumGridUI : public juce::Component,
     //==============================================================================
     void setDetailCollapsed(bool collapsed);
     void refreshPadButtons();
-    void refreshRangeRows();
     void refreshDetailPanel();
     void goToPrevPage();
     void goToNextPage();

--- a/magda/daw/ui/components/chain/drum_grid/DrumGridUI.hpp
+++ b/magda/daw/ui/components/chain/drum_grid/DrumGridUI.hpp
@@ -9,6 +9,7 @@
 
 #include "custom_ui/SamplerUI.hpp"
 #include "drum_grid/PadChainPanel.hpp"
+#include "drum_grid/PadChainRangeRowComponent.hpp"
 #include "drum_grid/PadChainRowComponent.hpp"
 #include "params/ParamSlotComponent.hpp"
 #include "ui/components/common/SvgButton.hpp"
@@ -283,6 +284,10 @@ class DrumGridUI : public juce::Component,
     juce::Viewport chainsViewport_;
     juce::Component chainsContainer_;
     std::vector<std::unique_ptr<PadChainRowComponent>> chainRows_;
+    // One per chain row, laid out only under the selected one. Built with the
+    // rows rather than on selection: selection changes from a row's own
+    // mouseUp, and rebuilding there would free the component mid-callback.
+    std::vector<std::unique_ptr<PadChainRangeRowComponent>> rangeRows_;
     std::unique_ptr<magda::SvgButton> chainsToggleButton_;
 
     // Paint rects (set in resized, used in paint)
@@ -302,6 +307,7 @@ class DrumGridUI : public juce::Component,
     //==============================================================================
     void setDetailCollapsed(bool collapsed);
     void refreshPadButtons();
+    void refreshRangeRows();
     void refreshDetailPanel();
     void goToPrevPage();
     void goToNextPage();

--- a/magda/daw/ui/components/chain/drum_grid/PadChainPanel.cpp
+++ b/magda/daw/ui/components/chain/drum_grid/PadChainPanel.cpp
@@ -3,6 +3,7 @@
 #include <tracktion_engine/tracktion_engine.h>
 
 #include "audio/plugins/MagdaSamplerPlugin.hpp"
+#include "core/TrackManager.hpp"
 #include "ui/themes/DarkTheme.hpp"
 #include "ui/themes/FontManager.hpp"
 #include "ui/themes/SmallButtonLookAndFeel.hpp"
@@ -122,7 +123,15 @@ void PadChainPanel::updateLinkContext() {
 
 void PadChainPanel::applyLinkContextToSlot(PadDeviceSlot& slot, const PluginSlotInfo& info) {
     if (info.deviceId != magda::INVALID_DEVICE_ID) {
-        auto pluginPath = magda::ChainNodePath::topLevelDevice(devicePath_.trackId, info.deviceId);
+        // The address the pad device actually has, asked of the model rather
+        // than manufactured. ParamTableCompiler keys a pad device under the
+        // owning grid's DeviceId, and so does every link a project has saved,
+        // so a link made from a top-level path would name a parameter the
+        // table does not carry (#2211). The manufactured path is kept as the
+        // fallback for a slot whose device is not in the model yet.
+        auto pluginPath = magda::TrackManager::getInstance().findDevicePath(info.deviceId);
+        if (!pluginPath.isValid())
+            pluginPath = magda::ChainNodePath::topLevelDevice(devicePath_.trackId, info.deviceId);
         DBG("[PadChainLink] apply pad=" << currentPadIndex_ << " pluginDevice=" << info.deviceId
                                         << " sampler=" << yesNo(info.isSampler)
                                         << " target=" << linkPathString(pluginPath)

--- a/magda/daw/ui/components/chain/drum_grid/PadChainRangeRowComponent.cpp
+++ b/magda/daw/ui/components/chain/drum_grid/PadChainRangeRowComponent.cpp
@@ -36,9 +36,26 @@ PadChainRangeRowComponent::PadChainRangeRowComponent(int padIndex) : padIndex_(p
     setupNoteSlider(highNoteSlider_);
     setupNoteSlider(rootNoteSlider_);
 
-    lowNoteSlider_.onValueChanged = [this](double) { fireRangeChanged(); };
-    highNoteSlider_.onValueChanged = [this](double) { fireRangeChanged(); };
-    rootNoteSlider_.onValueChanged = [this](double) { fireRangeChanged(); };
+    // Committed when the drag ends, not on every update. A pad's note range is
+    // model state, and writing it notifies trackDevicesChanged, which rebuilds
+    // the track's chain components: this row and this slider among them.
+    // Firing per update would free the slider before its own mouseUp and cut
+    // the drag off after the first delta (#2211). A typed or clicked value
+    // still commits at once, because that is not a drag.
+    const auto commitIfSettled = [this](TextSlider& slider) {
+        return [this, &slider](double) {
+            if (!slider.isBeingDragged())
+                fireRangeChanged();
+        };
+    };
+
+    lowNoteSlider_.onValueChanged = commitIfSettled(lowNoteSlider_);
+    highNoteSlider_.onValueChanged = commitIfSettled(highNoteSlider_);
+    rootNoteSlider_.onValueChanged = commitIfSettled(rootNoteSlider_);
+
+    lowNoteSlider_.onDragEnd = [this]() { fireRangeChanged(); };
+    highNoteSlider_.onDragEnd = [this]() { fireRangeChanged(); };
+    rootNoteSlider_.onDragEnd = [this]() { fireRangeChanged(); };
 }
 
 PadChainRangeRowComponent::~PadChainRangeRowComponent() = default;

--- a/magda/daw/ui/components/chain/drum_grid/PadChainRangeRowComponent.cpp
+++ b/magda/daw/ui/components/chain/drum_grid/PadChainRangeRowComponent.cpp
@@ -17,13 +17,8 @@ PadChainRangeRowComponent::PadChainRangeRowComponent(int padIndex) : padIndex_(p
     addAndMakeVisible(nameLabel_);
 
     // Helper to set up a note slider (0-127, displayed as note names)
-    // Only the notes the grid shows. A chain retuned clear of them keeps
-    // playing and disappears from the rows, with no way left to edit or delete
-    // it; the model refuses such a range, and the slider does not offer it
-    // (#2211).
-    auto setupNoteSlider = [this](TextSlider& slider) {
-        slider.setRange(static_cast<double>(kPadBaseNote),
-                        static_cast<double>(kPadBaseNote + kPadCount - 1), 1.0);
+    auto setupNoteSlider = [this](TextSlider& slider, int minNote, int maxNote) {
+        slider.setRange(static_cast<double>(minNote), static_cast<double>(maxNote), 1.0);
         slider.setValue(static_cast<double>(kPadBaseNote), juce::dontSendNotification);
         slider.setShowFillIndicator(false);
         slider.setValueFormatter([](double v) { return midiNoteToName(static_cast<int>(v)); });
@@ -38,9 +33,17 @@ PadChainRangeRowComponent::PadChainRangeRowComponent(int padIndex) : padIndex_(p
         addAndMakeVisible(slider);
     };
 
-    setupNoteSlider(lowNoteSlider_);
-    setupNoteSlider(highNoteSlider_);
-    setupNoteSlider(rootNoteSlider_);
+    // The endpoints reach only the notes the grid shows: a chain retuned clear
+    // of them keeps playing and disappears from the rows, with no way left to
+    // edit or delete it, and the model refuses such a range (#2211).
+    setupNoteSlider(lowNoteSlider_, kPadBaseNote, kPadBaseNote + kPadCount - 1);
+    setupNoteSlider(highNoteSlider_, kPadBaseNote, kPadBaseNote + kPadCount - 1);
+
+    // The root is not an endpoint. It is the pitch the range is transposed onto
+    // before the chain sees it (DrumGridPlugin::processChain), so it decides
+    // nothing about reachability and keeps the whole MIDI range: a sample whose
+    // natural pitch sits outside the displayed pads is a valid mapping.
+    setupNoteSlider(rootNoteSlider_, 0, 127);
 
     // Committed when the drag ends, not on every update. A pad's note range is
     // model state, and writing it notifies trackDevicesChanged, which rebuilds

--- a/magda/daw/ui/components/chain/drum_grid/PadChainRangeRowComponent.cpp
+++ b/magda/daw/ui/components/chain/drum_grid/PadChainRangeRowComponent.cpp
@@ -2,6 +2,7 @@
 
 #include <juce_audio_basics/juce_audio_basics.h>
 
+#include "core/DrumGridPads.hpp"
 #include "ui/themes/DarkTheme.hpp"
 #include "ui/themes/FontManager.hpp"
 
@@ -16,9 +17,14 @@ PadChainRangeRowComponent::PadChainRangeRowComponent(int padIndex) : padIndex_(p
     addAndMakeVisible(nameLabel_);
 
     // Helper to set up a note slider (0-127, displayed as note names)
+    // Only the notes the grid shows. A chain retuned clear of them keeps
+    // playing and disappears from the rows, with no way left to edit or delete
+    // it; the model refuses such a range, and the slider does not offer it
+    // (#2211).
     auto setupNoteSlider = [this](TextSlider& slider) {
-        slider.setRange(0.0, 127.0, 1.0);
-        slider.setValue(60.0, juce::dontSendNotification);
+        slider.setRange(static_cast<double>(kPadBaseNote),
+                        static_cast<double>(kPadBaseNote + kPadCount - 1), 1.0);
+        slider.setValue(static_cast<double>(kPadBaseNote), juce::dontSendNotification);
         slider.setShowFillIndicator(false);
         slider.setValueFormatter([](double v) { return midiNoteToName(static_cast<int>(v)); });
         slider.setValueParser([](const juce::String& text) {

--- a/magda/daw/ui/components/chain/drum_grid/PadChainRowComponent.cpp
+++ b/magda/daw/ui/components/chain/drum_grid/PadChainRowComponent.cpp
@@ -24,6 +24,10 @@ PadChainRowComponent::PadChainRowComponent(int padIndex) : padIndex_(padIndex) {
     levelSlider_.onValueChanged = [this](double value) {
         if (onLevelChanged)
             onLevelChanged(padIndex_, static_cast<float>(value));
+        // A typed value or a reset has no drag to end, so it closes its own
+        // gesture here (#2211).
+        if (!levelSlider_.isBeingDragged() && onFaderGestureEnd)
+            onFaderGestureEnd();
     };
     // The fader writes the model as it moves, so the sound follows the mouse.
     // The drag's end is reported separately: it closes the undo step the moves
@@ -41,6 +45,8 @@ PadChainRowComponent::PadChainRowComponent(int padIndex) : padIndex_(padIndex) {
     panSlider_.onValueChanged = [this](double value) {
         if (onPanChanged)
             onPanChanged(padIndex_, static_cast<float>(value));
+        if (!panSlider_.isBeingDragged() && onFaderGestureEnd)
+            onFaderGestureEnd();
     };
     panSlider_.onDragEnd = [this]() {
         if (onFaderGestureEnd)

--- a/magda/daw/ui/components/chain/drum_grid/PadChainRowComponent.cpp
+++ b/magda/daw/ui/components/chain/drum_grid/PadChainRowComponent.cpp
@@ -25,6 +25,13 @@ PadChainRowComponent::PadChainRowComponent(int padIndex) : padIndex_(padIndex) {
         if (onLevelChanged)
             onLevelChanged(padIndex_, static_cast<float>(value));
     };
+    // The fader writes the model as it moves, so the sound follows the mouse.
+    // The drag's end is reported separately: it closes the undo step the moves
+    // coalesce into (#2211).
+    levelSlider_.onDragEnd = [this]() {
+        if (onFaderGestureEnd)
+            onFaderGestureEnd();
+    };
     addAndMakeVisible(levelSlider_);
 
     // Pan text slider (L/C/R format)
@@ -34,6 +41,10 @@ PadChainRowComponent::PadChainRowComponent(int padIndex) : padIndex_(padIndex) {
     panSlider_.onValueChanged = [this](double value) {
         if (onPanChanged)
             onPanChanged(padIndex_, static_cast<float>(value));
+    };
+    panSlider_.onDragEnd = [this]() {
+        if (onFaderGestureEnd)
+            onFaderGestureEnd();
     };
     addAndMakeVisible(panSlider_);
 

--- a/magda/daw/ui/components/chain/drum_grid/PadChainRowComponent.hpp
+++ b/magda/daw/ui/components/chain/drum_grid/PadChainRowComponent.hpp
@@ -43,6 +43,9 @@ class PadChainRowComponent : public juce::Component {
     std::function<void(int padIndex)> onClicked;
     std::function<void(int padIndex, float)> onLevelChanged;
     std::function<void(int padIndex, float)> onPanChanged;
+    /// A level or pan drag has ended. What follows belongs to a new gesture,
+    /// and so to a new undo step (#2211).
+    std::function<void()> onFaderGestureEnd;
     std::function<void(int padIndex, bool)> onMuteChanged;
     std::function<void(int padIndex, bool)> onSoloChanged;
     std::function<void(int padIndex)> onDeleteClicked;

--- a/magda/daw/ui/components/chain/drum_grid/PadDeviceSlot.cpp
+++ b/magda/daw/ui/components/chain/drum_grid/PadDeviceSlot.cpp
@@ -90,10 +90,21 @@ PadDeviceSlot::PadDeviceSlot() {
     gainSlider_.setRange(-60.0, 12.0, 0.1);
     gainSlider_.setValue(0.0, juce::dontSendNotification);
     gainSlider_.setShowFillIndicator(false);
-    gainSlider_.onValueChanged = [this](double value) {
+    // Committed when the drag ends, not on every update. A pad device's gain is
+    // model state, and writing it notifies trackDevicesChanged, which rebuilds
+    // the track's chain components: this slot and this slider among them.
+    // Firing per update would free the slider before its own mouseUp and cut
+    // the drag off after the first delta (#2211). The readout still tracks the
+    // mouse; only the model write waits.
+    const auto commitGain = [this]() {
         if (onGainDbChanged)
-            onGainDbChanged(static_cast<float>(value));
+            onGainDbChanged(static_cast<float>(gainSlider_.getValue()));
     };
+    gainSlider_.onValueChanged = [this, commitGain](double) {
+        if (!gainSlider_.isBeingDragged())
+            commitGain();
+    };
+    gainSlider_.onDragEnd = commitGain;
     addAndMakeVisible(gainSlider_);
 
     // Level meter (right edge of content area)

--- a/magda/daw/ui/components/chain/slot/DeviceCustomUIManager.cpp
+++ b/magda/daw/ui/components/chain/slot/DeviceCustomUIManager.cpp
@@ -1247,7 +1247,7 @@ bool DeviceCustomUIManager::createDrumGridUI(const magda::DeviceInfo& device,
         if (auto* chain = dg->getChainForNote(midiNote)) {
             drumGridUI_->updatePadInfo(padIndex, getChainDisplayName(*chain), chain->mute.get(),
                                        chain->solo.get(), chain->level.get(), chain->pan.get(),
-                                       chain->index, chain->bypassed.get());
+                                       chain->index, chain->bypassed.get(), chain->busOutput.get());
         } else {
             drumGridUI_->updatePadInfo(padIndex, "", false, false, 0.0f, 0.0f, -1);
         }
@@ -1359,8 +1359,19 @@ bool DeviceCustomUIManager::createDrumGridUI(const magda::DeviceInfo& device,
         return {pad->lowNote, pad->highNote, pad->rootNote};
     };
 
-    drumGridUI_->onPadRangeChanged = [postPadEdit](int padIndex, int lowNote, int highNote,
-                                                   int rootNote) {
+    drumGridUI_->onPadRangeChanged = [this, postPadEdit, gridPath](int padIndex, int lowNote,
+                                                                   int highNote, int rootNote) {
+        // A range has to stay inside the grid's own notes and clear of every
+        // other pad's. Asked before the edit, so a refused range snaps the row
+        // back rather than leaving it showing something the model never took,
+        // and does not become an undo step that changed nothing.
+        if (!magda::TrackManager::getInstance().padNoteRangeIsFree(gridPath(), padIndex, lowNote,
+                                                                   highNote)) {
+            if (drumGridUI_ != nullptr)
+                drumGridUI_->refreshRangeRows();
+            return;
+        }
+
         postPadEdit("Set Pad Key Range",
                     [padIndex, lowNote, highNote, rootNote](const magda::ChainNodePath& grid) {
                         magda::TrackManager::getInstance().setPadNoteRange(grid, padIndex, lowNote,
@@ -2359,7 +2370,7 @@ void DeviceCustomUIManager::update(const magda::DeviceInfo& device) {
                         drumGridUI_->updatePadInfo(padIdx, displayName, chain->mute.get(),
                                                    chain->solo.get(), chain->level.get(),
                                                    chain->pan.get(), chain->index,
-                                                   chain->bypassed.get());
+                                                   chain->bypassed.get(), chain->busOutput.get());
                     }
                 }
             }

--- a/magda/daw/ui/components/chain/slot/DeviceCustomUIManager.cpp
+++ b/magda/daw/ui/components/chain/slot/DeviceCustomUIManager.cpp
@@ -1182,21 +1182,26 @@ bool DeviceCustomUIManager::createDrumGridUI(const magda::DeviceInfo& device,
         return devicePath_;
     };
 
-    // One undoable pad edit, run now. `EditPadsCommand` snapshots the grid's
-    // pad rack, so any edit -- one pad's switch, two pads trading places, a
-    // whole chain replaced -- comes back in one step (#2211).
-    auto padEdit = [gridPath](const juce::String& description,
-                              std::function<void(const magda::ChainNodePath&)> edit,
-                              const juce::String& mergeKey = {}) {
+    // A pad's fader, run now: the sound has to follow the mouse, and a fader
+    // notifies trackPropertyChanged, which by design does not rebuild the chain
+    // components. `SetPadFaderCommand` stores the one value it changed rather
+    // than snapshotting the pad rack, which is what makes it cheap enough to
+    // run per mouse move, and coalesces within a drag (#2211).
+    auto padFader = [this, gridPath](int padIndex, magda::SetPadFaderCommand::Target target,
+                                     float value) {
         const auto grid = gridPath();
-        if (!grid.isValid())
+        if (!grid.isValid() || drumGridUI_ == nullptr)
             return;
-        magda::editPads(
-            grid, description, [grid, edit = std::move(edit)]() { edit(grid); }, mergeKey);
+        magda::setPadFader(grid, padIndex, target, value, drumGridUI_->getFaderGesture());
     };
 
-    // The same, posted rather than run now, and with a follow-up that runs only
-    // if there is still a UI to run it on.
+    // One undoable pad edit, posted rather than run now, with a follow-up that
+    // runs only if there is still a UI to run it on.
+    //
+    // `EditPadsCommand` snapshots the grid's pad rack, so any edit -- one pad's
+    // switch, two pads trading places, a whole chain replaced -- comes back in
+    // one step. Everything reaching it is one command per click or per gesture,
+    // so the snapshot is never taken per mouse move (#2211).
     //
     // Every pad edit but a fader notifies trackDevicesChanged, and the track's
     // chain rebuild that follows destroys this slot, this UI, and the row whose
@@ -1205,17 +1210,15 @@ bool DeviceCustomUIManager::createDrumGridUI(const magda::DeviceInfo& device,
     // resolver reads this manager and the rebuild may have taken it by then.
     auto postPadEdit = [this, gridPath](const juce::String& description,
                                         std::function<void(const magda::ChainNodePath&)> edit,
-                                        std::function<void()> then = {},
-                                        const juce::String& mergeKey = {}) {
+                                        std::function<void()> then = {}) {
         const auto grid = gridPath();
         if (!grid.isValid())
             return;
 
         juce::MessageManager::callAsync(
             [safeUi = juce::Component::SafePointer<DrumGridUI>(drumGridUI_.get()), grid,
-             description, mergeKey, edit = std::move(edit), then = std::move(then)]() {
-                magda::editPads(
-                    grid, description, [grid, edit]() { edit(grid); }, mergeKey);
+             description, edit = std::move(edit), then = std::move(then)]() {
+                magda::editPads(grid, description, [grid, edit]() { edit(grid); });
                 if (then && safeUi != nullptr)
                     then();
             });
@@ -1292,7 +1295,9 @@ bool DeviceCustomUIManager::createDrumGridUI(const magda::DeviceInfo& device,
         postPadEdit(
             "Clear Pad",
             [padIndex](const magda::ChainNodePath& grid) {
-                magda::TrackManager::getInstance().clearPad(grid, padIndex);
+                auto& tm = magda::TrackManager::getInstance();
+                if (const auto* pad = tm.getPad(grid, padIndex))
+                    tm.removePadChain(grid, pad->id);
             },
             [this, padIndex]() {
                 drumGridUI_->updatePadInfo(padIndex, "", false, false, 0.0f, 0.0f, -1);
@@ -1305,22 +1310,12 @@ bool DeviceCustomUIManager::createDrumGridUI(const magda::DeviceInfo& device,
     // The faders are run now, not posted: they notify trackPropertyChanged,
     // which by design does not rebuild the chain, and a fader wants the sound
     // to move under the mouse. They coalesce into one undo step per drag.
-    drumGridUI_->onPadLevelChanged = [padEdit](int padIndex, float levelDb) {
-        padEdit(
-            "Set Pad Level",
-            [padIndex, levelDb](const magda::ChainNodePath& grid) {
-                magda::TrackManager::getInstance().setPadVolume(grid, padIndex, levelDb);
-            },
-            "padLevel:" + juce::String(padIndex));
+    drumGridUI_->onPadLevelChanged = [padFader](int padIndex, float levelDb) {
+        padFader(padIndex, magda::SetPadFaderCommand::Target::Volume, levelDb);
     };
 
-    drumGridUI_->onPadPanChanged = [padEdit](int padIndex, float pan) {
-        padEdit(
-            "Set Pad Pan",
-            [padIndex, pan](const magda::ChainNodePath& grid) {
-                magda::TrackManager::getInstance().setPadPan(grid, padIndex, pan);
-            },
-            "padPan:" + juce::String(padIndex));
+    drumGridUI_->onPadPanChanged = [padFader](int padIndex, float pan) {
+        padFader(padIndex, magda::SetPadFaderCommand::Target::Pan, pan);
     };
 
     drumGridUI_->onPadMuteChanged = [postPadEdit](int padIndex, bool muted) {
@@ -1434,12 +1429,17 @@ bool DeviceCustomUIManager::createDrumGridUI(const magda::DeviceInfo& device,
             cb.onLayoutChanged();
     };
 
-    // Delete from chain row — same as clear
+    // Delete from a chain row removes the chain the row stands for, whatever
+    // range it answers to. `clearPad()` is the pad's own delete and refuses a
+    // chain shared with its neighbours, which after a range edit would leave a
+    // widened chain with no way off the grid at all (#2211).
     drumGridUI_->onPadDeleteRequested = [this, postPadEdit](int padIndex) {
         postPadEdit(
-            "Clear Pad",
+            "Delete Pad Chain",
             [padIndex](const magda::ChainNodePath& grid) {
-                magda::TrackManager::getInstance().clearPad(grid, padIndex);
+                auto& tm = magda::TrackManager::getInstance();
+                if (const auto* pad = tm.getPad(grid, padIndex))
+                    tm.removePadChain(grid, pad->id);
             },
             [this, padIndex]() {
                 drumGridUI_->updatePadInfo(padIndex, "", false, false, 0.0f, 0.0f, -1);
@@ -1645,13 +1645,11 @@ bool DeviceCustomUIManager::createDrumGridUI(const magda::DeviceInfo& device,
                 };
                 info.onGainDbChanged = [postPadEdit, padChainId,
                                         deviceId = info.deviceId](float gainDb) {
-                    postPadEdit(
-                        "Set Pad Device Gain",
-                        [padChainId, deviceId, gainDb](const magda::ChainNodePath& grid) {
-                            magda::TrackManager::getInstance().setPadDeviceGainDb(grid, padChainId,
-                                                                                  deviceId, gainDb);
-                        },
-                        {}, "padDeviceGain:" + juce::String(deviceId));
+                    postPadEdit("Set Pad Device Gain",
+                                [padChainId, deviceId, gainDb](const magda::ChainNodePath& grid) {
+                                    magda::TrackManager::getInstance().setPadDeviceGainDb(
+                                        grid, padChainId, deviceId, gainDb);
+                                });
                 };
             }
 

--- a/magda/daw/ui/components/chain/slot/DeviceCustomUIManager.cpp
+++ b/magda/daw/ui/components/chain/slot/DeviceCustomUIManager.cpp
@@ -10,6 +10,7 @@
 #include <mutex>
 #include <optional>
 #include <thread>
+#include <tuple>
 
 #include "audio/AudioBridge.hpp"
 #include "audio/plugins/ArpeggiatorPlugin.hpp"
@@ -35,6 +36,7 @@
 #include "compiled/CompiledPluginPresentation.hpp"
 #include "core/DrumGridPads.hpp"
 #include "core/MidiFileWriter.hpp"
+#include "core/PadCommands.hpp"
 #include "core/SelectionManager.hpp"
 #include "core/TrackManager.hpp"
 #include "custom_ui/ArpeggiatorUI.hpp"
@@ -1180,15 +1182,43 @@ bool DeviceCustomUIManager::createDrumGridUI(const magda::DeviceInfo& device,
         return devicePath_;
     };
 
-    // The chain id behind a pad, or INVALID_CHAIN_ID when the pad is empty.
-    // Pad edits take the grid's path and this, never a rack path: a pad's rack
-    // component is the grid's DeviceId and would be ambiguous with a real rack
-    // (#2207).
-    auto padChainId = [gridPath](int padIndex) -> magda::ChainId {
-        auto& tm = magda::TrackManager::getInstance();
-        if (const auto* pad = tm.getPad(gridPath(), padIndex))
-            return pad->id;
-        return magda::INVALID_CHAIN_ID;
+    // One undoable pad edit, run now. `EditPadsCommand` snapshots the grid's
+    // pad rack, so any edit -- one pad's switch, two pads trading places, a
+    // whole chain replaced -- comes back in one step (#2211).
+    auto padEdit = [gridPath](const juce::String& description,
+                              std::function<void(const magda::ChainNodePath&)> edit,
+                              const juce::String& mergeKey = {}) {
+        const auto grid = gridPath();
+        if (!grid.isValid())
+            return;
+        magda::editPads(
+            grid, description, [grid, edit = std::move(edit)]() { edit(grid); }, mergeKey);
+    };
+
+    // The same, posted rather than run now, and with a follow-up that runs only
+    // if there is still a UI to run it on.
+    //
+    // Every pad edit but a fader notifies trackDevicesChanged, and the track's
+    // chain rebuild that follows destroys this slot, this UI, and the row whose
+    // button is still on the stack. Posting lets the gesture finish first. The
+    // grid's path is resolved here rather than inside the post, because the
+    // resolver reads this manager and the rebuild may have taken it by then.
+    auto postPadEdit = [this, gridPath](const juce::String& description,
+                                        std::function<void(const magda::ChainNodePath&)> edit,
+                                        std::function<void()> then = {},
+                                        const juce::String& mergeKey = {}) {
+        const auto grid = gridPath();
+        if (!grid.isValid())
+            return;
+
+        juce::MessageManager::callAsync(
+            [safeUi = juce::Component::SafePointer<DrumGridUI>(drumGridUI_.get()), grid,
+             description, mergeKey, edit = std::move(edit), then = std::move(then)]() {
+                magda::editPads(
+                    grid, description, [grid, edit]() { edit(grid); }, mergeKey);
+                if (then && safeUi != nullptr)
+                    then();
+            });
     };
 
     // Helper to get display name for first plugin in chain
@@ -1222,87 +1252,155 @@ bool DeviceCustomUIManager::createDrumGridUI(const magda::DeviceInfo& device,
 
     // Loading a sample onto a pad is a model edit: it puts a sampler device on
     // the pad's chain, rooted on the pad's note. The plugin follows by sync.
-    auto loadSampleToPad = [gridPath](int padIndex, const juce::File& file) {
-        magda::TrackManager::getInstance().setPadDevice(
-            gridPath(), padIndex,
-            magda::padSamplerDevice(file.getFullPathName(), magda::padNoteFor(padIndex)));
+    auto loadSampleToPad = [postPadEdit, getDrumGrid, updatePadFromChain](int padIndex,
+                                                                          const juce::File& file) {
+        postPadEdit(
+            "Load Pad Sample",
+            [padIndex, file](const magda::ChainNodePath& grid) {
+                magda::TrackManager::getInstance().setPadDevice(
+                    grid, padIndex,
+                    magda::padSamplerDevice(file.getFullPathName(), magda::padNoteFor(padIndex)));
+            },
+            [padIndex, getDrumGrid, updatePadFromChain]() {
+                if (auto* dg = getDrumGrid())
+                    updatePadFromChain(dg, padIndex);
+            });
     };
 
     // Sample drop callback
-    drumGridUI_->onSampleDropped = [getDrumGrid, updatePadFromChain,
-                                    loadSampleToPad](int padIndex, const juce::File& file) {
+    drumGridUI_->onSampleDropped = [loadSampleToPad](int padIndex, const juce::File& file) {
         loadSampleToPad(padIndex, file);
-        if (auto* dg = getDrumGrid())
-            updatePadFromChain(dg, padIndex);
     };
 
     // Load button callback (file chooser)
-    drumGridUI_->onLoadRequested = [this, getDrumGrid, updatePadFromChain,
-                                    loadSampleToPad](int padIndex) {
+    drumGridUI_->onLoadRequested = [this, loadSampleToPad](int padIndex) {
         auto chooser = std::make_shared<juce::FileChooser>("Load Sample", juce::File(),
                                                            "*.wav;*.aif;*.aiff;*.flac;*.ogg;*.mp3");
         chooser->launchAsync(juce::FileBrowserComponent::openMode |
                                  juce::FileBrowserComponent::canSelectFiles,
-                             [this, padIndex, chooser, getDrumGrid, updatePadFromChain,
-                              loadSampleToPad](const juce::FileChooser&) {
+                             [this, padIndex, chooser, loadSampleToPad](const juce::FileChooser&) {
                                  if (!drumGridUI_)
                                      return;
                                  auto result = chooser->getResult();
-                                 if (result.existsAsFile()) {
+                                 if (result.existsAsFile())
                                      loadSampleToPad(padIndex, result);
-                                     if (auto* dg = getDrumGrid())
-                                         updatePadFromChain(dg, padIndex);
-                                 }
                              });
     };
 
     // Clear callback
-    drumGridUI_->onClearRequested = [this, gridPath](int padIndex) {
-        magda::TrackManager::getInstance().clearPad(gridPath(), padIndex);
-        drumGridUI_->updatePadInfo(padIndex, "", false, false, 0.0f, 0.0f, -1);
+    drumGridUI_->onClearRequested = [this, postPadEdit](int padIndex) {
+        postPadEdit(
+            "Clear Pad",
+            [padIndex](const magda::ChainNodePath& grid) {
+                magda::TrackManager::getInstance().clearPad(grid, padIndex);
+            },
+            [this, padIndex]() {
+                drumGridUI_->updatePadInfo(padIndex, "", false, false, 0.0f, 0.0f, -1);
+            });
     };
 
     // A pad's fader, pan and switches are its chain's, so they are set the way
     // any other chain's are.
-    drumGridUI_->onPadLevelChanged = [gridPath](int padIndex, float levelDb) {
-        magda::TrackManager::getInstance().setPadVolume(gridPath(), padIndex, levelDb);
+    //
+    // The faders are run now, not posted: they notify trackPropertyChanged,
+    // which by design does not rebuild the chain, and a fader wants the sound
+    // to move under the mouse. They coalesce into one undo step per drag.
+    drumGridUI_->onPadLevelChanged = [padEdit](int padIndex, float levelDb) {
+        padEdit(
+            "Set Pad Level",
+            [padIndex, levelDb](const magda::ChainNodePath& grid) {
+                magda::TrackManager::getInstance().setPadVolume(grid, padIndex, levelDb);
+            },
+            "padLevel:" + juce::String(padIndex));
     };
 
-    drumGridUI_->onPadPanChanged = [gridPath](int padIndex, float pan) {
-        magda::TrackManager::getInstance().setPadPan(gridPath(), padIndex, pan);
+    drumGridUI_->onPadPanChanged = [padEdit](int padIndex, float pan) {
+        padEdit(
+            "Set Pad Pan",
+            [padIndex, pan](const magda::ChainNodePath& grid) {
+                magda::TrackManager::getInstance().setPadPan(grid, padIndex, pan);
+            },
+            "padPan:" + juce::String(padIndex));
     };
 
-    drumGridUI_->onPadMuteChanged = [gridPath](int padIndex, bool muted) {
-        magda::TrackManager::getInstance().setPadMuted(gridPath(), padIndex, muted);
+    drumGridUI_->onPadMuteChanged = [postPadEdit](int padIndex, bool muted) {
+        postPadEdit(muted ? "Mute Pad" : "Unmute Pad",
+                    [padIndex, muted](const magda::ChainNodePath& grid) {
+                        magda::TrackManager::getInstance().setPadMuted(grid, padIndex, muted);
+                    });
     };
 
-    drumGridUI_->onPadSoloChanged = [gridPath](int padIndex, bool soloed) {
-        magda::TrackManager::getInstance().setPadSolo(gridPath(), padIndex, soloed);
+    drumGridUI_->onPadSoloChanged = [postPadEdit](int padIndex, bool soloed) {
+        postPadEdit(soloed ? "Solo Pad" : "Unsolo Pad",
+                    [padIndex, soloed](const magda::ChainNodePath& grid) {
+                        magda::TrackManager::getInstance().setPadSolo(grid, padIndex, soloed);
+                    });
     };
 
-    drumGridUI_->onPadBypassChanged = [gridPath](int padIndex, bool bypassed) {
-        magda::TrackManager::getInstance().setPadBypassed(gridPath(), padIndex, bypassed);
+    drumGridUI_->onPadBypassChanged = [postPadEdit](int padIndex, bool bypassed) {
+        postPadEdit(bypassed ? "Disable Pad" : "Enable Pad",
+                    [padIndex, bypassed](const magda::ChainNodePath& grid) {
+                        magda::TrackManager::getInstance().setPadBypassed(grid, padIndex, bypassed);
+                    });
+    };
+
+    // The pad's output bus. `ChainInfo::outputIndex` is model state, and the
+    // device sync turns a pad on a bus into a multi-out child track, so the row
+    // selector only ever had to write the model (#2211).
+    drumGridUI_->onPadOutputChanged = [postPadEdit](int padIndex, int busIndex) {
+        postPadEdit("Set Pad Output", [padIndex, busIndex](const magda::ChainNodePath& grid) {
+            magda::TrackManager::getInstance().setPadOutput(grid, padIndex, busIndex);
+        });
+    };
+
+    // The notes a pad answers to. A pad that answers to everything is a chain
+    // built before pads were keyed by pitch; it reads as the pad's own note so
+    // the row shows the range the grid actually plays it at.
+    drumGridUI_->getNoteRange = [gridPath](int padIndex) -> std::tuple<int, int, int> {
+        const int note = magda::padNoteFor(padIndex);
+        const auto* pad = magda::TrackManager::getInstance().getPad(gridPath(), padIndex);
+        if (pad == nullptr || pad->answersToEveryNote())
+            return {note, note, note};
+        return {pad->lowNote, pad->highNote, pad->rootNote};
+    };
+
+    drumGridUI_->onPadRangeChanged = [postPadEdit](int padIndex, int lowNote, int highNote,
+                                                   int rootNote) {
+        postPadEdit("Set Pad Key Range",
+                    [padIndex, lowNote, highNote, rootNote](const magda::ChainNodePath& grid) {
+                        magda::TrackManager::getInstance().setPadNoteRange(grid, padIndex, lowNote,
+                                                                           highNote, rootNote);
+                    });
     };
 
     // Plugin drag and drop onto pads: an instrument replaces the pad
-    drumGridUI_->onPluginDropped = [getDrumGrid, updatePadFromChain, gridPath,
+    drumGridUI_->onPluginDropped = [postPadEdit, getDrumGrid, updatePadFromChain,
                                     loadSampleToPad](int padIndex, const juce::DynamicObject& obj) {
         auto& tm = magda::TrackManager::getInstance();
 
         bool isExternal = obj.getProperty("isExternal");
         juce::String uniqueId = obj.getProperty("uniqueId").toString();
 
+        const auto refreshPad = [padIndex, getDrumGrid, updatePadFromChain]() {
+            if (auto* dg = getDrumGrid())
+                updatePadFromChain(dg, padIndex);
+        };
+
         // Handle internal plugins (MagdaSampler, etc.)
         if (!isExternal) {
             if (isInstrumentDrop(obj) && !isDrumGridPluginId(uniqueId)) {
-                if (uniqueId.equalsIgnoreCase(daw::audio::MagdaSamplerPlugin::xmlTypeName))
+                if (uniqueId.equalsIgnoreCase(daw::audio::MagdaSamplerPlugin::xmlTypeName)) {
                     loadSampleToPad(padIndex, juce::File());
-                else
-                    tm.setPadDevice(
-                        gridPath(), padIndex,
-                        internalPadDevice(uniqueId, obj.getProperty("name").toString()));
-                if (auto* dg = getDrumGrid())
-                    updatePadFromChain(dg, padIndex);
+                } else {
+                    postPadEdit(
+                        "Set Pad Instrument",
+                        [padIndex,
+                         device = internalPadDevice(uniqueId, obj.getProperty("name").toString())](
+                            const magda::ChainNodePath& grid) {
+                            magda::TrackManager::getInstance().setPadDevice(grid, padIndex, device);
+                        },
+                        refreshPad);
+                }
             }
             return;
         }
@@ -1316,11 +1414,14 @@ bool DeviceCustomUIManager::createDrumGridUI(const magda::DeviceInfo& device,
 
         for (const auto& desc : audioEngine->getKnownPluginTypes()) {
             if (pluginDescriptionMatchesDrop(desc, fileOrId, uniqueId)) {
-                if (desc.isInstrument) {
-                    tm.setPadDevice(gridPath(), padIndex, externalPadDevice(desc));
-                    if (auto* dg = getDrumGrid())
-                        updatePadFromChain(dg, padIndex);
-                }
+                if (desc.isInstrument)
+                    postPadEdit(
+                        "Set Pad Instrument",
+                        [padIndex,
+                         device = externalPadDevice(desc)](const magda::ChainNodePath& grid) {
+                            magda::TrackManager::getInstance().setPadDevice(grid, padIndex, device);
+                        },
+                        refreshPad);
                 return;
             }
         }
@@ -1334,9 +1435,15 @@ bool DeviceCustomUIManager::createDrumGridUI(const magda::DeviceInfo& device,
     };
 
     // Delete from chain row — same as clear
-    drumGridUI_->onPadDeleteRequested = [this, gridPath](int padIndex) {
-        magda::TrackManager::getInstance().clearPad(gridPath(), padIndex);
-        drumGridUI_->updatePadInfo(padIndex, "", false, false, 0.0f, 0.0f, -1);
+    drumGridUI_->onPadDeleteRequested = [this, postPadEdit](int padIndex) {
+        postPadEdit(
+            "Clear Pad",
+            [padIndex](const magda::ChainNodePath& grid) {
+                magda::TrackManager::getInstance().clearPad(grid, padIndex);
+            },
+            [this, padIndex]() {
+                drumGridUI_->updatePadInfo(padIndex, "", false, false, 0.0f, 0.0f, -1);
+            });
     };
 
     drumGridUI_->onAnalyzePadRoleRequested = [this, cb = callbacks, getDrumGrid](int padIndex) {
@@ -1429,14 +1536,20 @@ bool DeviceCustomUIManager::createDrumGridUI(const magda::DeviceInfo& device,
     };
 
     // Pad swap via drag-and-drop
-    drumGridUI_->onPadsSwapped = [this, getDrumGrid, updatePadFromChain, gridPath](int srcPad,
-                                                                                   int dstPad) {
-        magda::TrackManager::getInstance().swapPads(gridPath(), srcPad, dstPad);
-        if (auto* dg = getDrumGrid()) {
-            updatePadFromChain(dg, srcPad);
-            updatePadFromChain(dg, dstPad);
-        }
-        drumGridUI_->rebuildChainRows();
+    drumGridUI_->onPadsSwapped = [this, postPadEdit, getDrumGrid, updatePadFromChain](int srcPad,
+                                                                                      int dstPad) {
+        postPadEdit(
+            "Swap Pads",
+            [srcPad, dstPad](const magda::ChainNodePath& grid) {
+                magda::TrackManager::getInstance().swapPads(grid, srcPad, dstPad);
+            },
+            [this, srcPad, dstPad, getDrumGrid, updatePadFromChain]() {
+                if (auto* dg = getDrumGrid()) {
+                    updatePadFromChain(dg, srcPad);
+                    updatePadFromChain(dg, dstPad);
+                }
+                drumGridUI_->rebuildChainRows();
+            });
     };
 
     // Set plugin pointer for trigger polling
@@ -1464,8 +1577,8 @@ bool DeviceCustomUIManager::createDrumGridUI(const magda::DeviceInfo& device,
     auto& padChain = drumGridUI_->getPadChainPanel();
 
     // Provide plugin slot info for each pad (via its chain)
-    padChain.getPluginSlots =
-        [getDrumGrid, gridPath](int padIndex) -> std::vector<PadChainPanel::PluginSlotInfo> {
+    padChain.getPluginSlots = [getDrumGrid, gridPath, postPadEdit](
+                                  int padIndex) -> std::vector<PadChainPanel::PluginSlotInfo> {
         std::vector<PadChainPanel::PluginSlotInfo> result;
         auto* dg = getDrumGrid();
         if (!dg)
@@ -1505,6 +1618,16 @@ bool DeviceCustomUIManager::createDrumGridUI(const magda::DeviceInfo& device,
             info.isSampler = dynamic_cast<daw::audio::MagdaSamplerPlugin*>(plugin.get()) != nullptr;
             info.name = info.device.name.isNotEmpty() ? info.device.name : plugin->getName();
 
+            // A pad plugin runs inside the grid, not on the track's graph, so
+            // it has no DeviceMeteringManager tap of its own. The grid meters
+            // each one as it processes it and the slot drains that (#2211).
+            info.getMeterLevels = [getDrumGrid, chainIndex = chain->index,
+                                   pluginIndex]() -> std::pair<float, float> {
+                auto* grid = getDrumGrid();
+                return grid != nullptr ? grid->consumeChainPluginPeak(chainIndex, pluginIndex)
+                                       : std::pair<float, float>{0.0f, 0.0f};
+            };
+
             if (const auto* device = modelDevice(info.deviceId)) {
                 info.bypassed = device->bypassed;
                 info.gainDb = device->gainDb;
@@ -1512,13 +1635,23 @@ bool DeviceCustomUIManager::createDrumGridUI(const magda::DeviceInfo& device,
             }
 
             if (padChainId != magda::INVALID_CHAIN_ID) {
-                info.onPowerChanged = [grid, padChainId, deviceId = info.deviceId](bool powered) {
-                    magda::TrackManager::getInstance().setPadDeviceBypassed(grid, padChainId,
-                                                                            deviceId, !powered);
+                info.onPowerChanged = [postPadEdit, padChainId,
+                                       deviceId = info.deviceId](bool powered) {
+                    postPadEdit(powered ? "Enable Pad Device" : "Disable Pad Device",
+                                [padChainId, deviceId, powered](const magda::ChainNodePath& grid) {
+                                    magda::TrackManager::getInstance().setPadDeviceBypassed(
+                                        grid, padChainId, deviceId, !powered);
+                                });
                 };
-                info.onGainDbChanged = [grid, padChainId, deviceId = info.deviceId](float gainDb) {
-                    magda::TrackManager::getInstance().setPadDeviceGainDb(grid, padChainId,
-                                                                          deviceId, gainDb);
+                info.onGainDbChanged = [postPadEdit, padChainId,
+                                        deviceId = info.deviceId](float gainDb) {
+                    postPadEdit(
+                        "Set Pad Device Gain",
+                        [padChainId, deviceId, gainDb](const magda::ChainNodePath& grid) {
+                            magda::TrackManager::getInstance().setPadDeviceGainDb(grid, padChainId,
+                                                                                  deviceId, gainDb);
+                        },
+                        {}, "padDeviceGain:" + juce::String(deviceId));
                 };
             }
 
@@ -1530,110 +1663,118 @@ bool DeviceCustomUIManager::createDrumGridUI(const magda::DeviceInfo& device,
     // Adding a device to a pad's chain. An instrument replaces the pad; an
     // effect joins the chain behind it. Both are chain edits on the model: the
     // pad is a chain, so the ordinary add is the one that runs (#2207).
-    auto addToPad = [this, getDrumGrid, updatePadFromChain,
-                     gridPath](int padIndex, const magda::DeviceInfo& device, int insertIdx) {
-        auto& tm = magda::TrackManager::getInstance();
-        const auto grid = gridPath();
+    auto addToPad = [this, postPadEdit, getDrumGrid, updatePadFromChain](
+                        int padIndex, const magda::DeviceInfo& device, int insertIdx) {
+        postPadEdit(
+            device.isInstrument ? "Set Pad Instrument" : "Add Pad Device",
+            [padIndex, device, insertIdx](const magda::ChainNodePath& grid) {
+                auto& tm = magda::TrackManager::getInstance();
+                if (device.isInstrument) {
+                    tm.setPadDevice(grid, padIndex, device);
+                    return;
+                }
 
-        if (device.isInstrument) {
-            tm.setPadDevice(grid, padIndex, device);
-            if (auto* dg = getDrumGrid())
-                updatePadFromChain(dg, padIndex);
-        } else {
-            const auto chainId = tm.ensurePad(grid, padIndex);
-            if (chainId == INVALID_CHAIN_ID)
-                return;
-            tm.addDeviceToPad(grid, chainId, device, insertIdx);
-        }
-
-        drumGridUI_->getPadChainPanel().refresh();
+                const auto chainId = tm.ensurePad(grid, padIndex);
+                if (chainId == INVALID_CHAIN_ID)
+                    return;
+                tm.addDeviceToPad(grid, chainId, device, insertIdx);
+            },
+            [this, padIndex, isInstrument = device.isInstrument, getDrumGrid,
+             updatePadFromChain]() {
+                if (isInstrument)
+                    if (auto* dg = getDrumGrid())
+                        updatePadFromChain(dg, padIndex);
+                drumGridUI_->getPadChainPanel().refresh();
+            });
     };
 
     // FX plugin drop onto chain area
-    padChain.onPluginDropped = [addToPad, loadSampleToPad, getDrumGrid, updatePadFromChain](
-                                   int padIndex, const juce::DynamicObject& obj, int insertIdx) {
-        bool isExternal = obj.getProperty("isExternal");
-        juce::String uniqueId = obj.getProperty("uniqueId").toString();
+    padChain.onPluginDropped =
+        [addToPad, loadSampleToPad](int padIndex, const juce::DynamicObject& obj, int insertIdx) {
+            bool isExternal = obj.getProperty("isExternal");
+            juce::String uniqueId = obj.getProperty("uniqueId").toString();
 
-        if (!isExternal) {
-            if (!isDrumGridPluginId(uniqueId) && !isMidiFxDrop(obj)) {
-                if (uniqueId.equalsIgnoreCase(daw::audio::MagdaSamplerPlugin::xmlTypeName)) {
-                    loadSampleToPad(padIndex, juce::File());
-                    if (auto* dg = getDrumGrid())
-                        updatePadFromChain(dg, padIndex);
-                } else {
-                    addToPad(padIndex,
-                             internalPadDevice(uniqueId, obj.getProperty("name").toString()),
-                             insertIdx);
+            if (!isExternal) {
+                if (!isDrumGridPluginId(uniqueId) && !isMidiFxDrop(obj)) {
+                    if (uniqueId.equalsIgnoreCase(daw::audio::MagdaSamplerPlugin::xmlTypeName)) {
+                        loadSampleToPad(padIndex, juce::File());
+                    } else {
+                        addToPad(padIndex,
+                                 internalPadDevice(uniqueId, obj.getProperty("name").toString()),
+                                 insertIdx);
+                    }
                 }
-            }
-            return;
-        }
-
-        // External plugin: look it up in KnownPluginList
-        juce::String fileOrId = obj.getProperty("fileOrIdentifier").toString();
-
-        auto* audioEngine = magda::TrackManager::getInstance().getAudioEngine();
-        if (!audioEngine)
-            return;
-        for (const auto& desc : audioEngine->getKnownPluginTypes()) {
-            if (pluginDescriptionMatchesDrop(desc, fileOrId, uniqueId)) {
-                if (isMidiFxPlugin(desc))
-                    return;
-                addToPad(padIndex, externalPadDevice(desc), insertIdx);
                 return;
             }
-        }
-    };
+
+            // External plugin: look it up in KnownPluginList
+            juce::String fileOrId = obj.getProperty("fileOrIdentifier").toString();
+
+            auto* audioEngine = magda::TrackManager::getInstance().getAudioEngine();
+            if (!audioEngine)
+                return;
+            for (const auto& desc : audioEngine->getKnownPluginTypes()) {
+                if (pluginDescriptionMatchesDrop(desc, fileOrId, uniqueId)) {
+                    if (isMidiFxPlugin(desc))
+                        return;
+                    addToPad(padIndex, externalPadDevice(desc), insertIdx);
+                    return;
+                }
+            }
+        };
 
     // Remove plugin from chain
-    padChain.onPluginRemoved = [getDrumGrid, updatePadFromChain, gridPath](int padIndex,
-                                                                           int pluginIndex) {
-        auto& tm = magda::TrackManager::getInstance();
-        const auto grid = gridPath();
-        const auto* pad = tm.getPad(grid, padIndex);
-        if (pad == nullptr)
-            return;
+    padChain.onPluginRemoved = [postPadEdit, getDrumGrid, updatePadFromChain](int padIndex,
+                                                                              int pluginIndex) {
+        postPadEdit(
+            "Remove Pad Device",
+            [padIndex, pluginIndex](const magda::ChainNodePath& grid) {
+                auto& tm = magda::TrackManager::getInstance();
+                const auto* pad = tm.getPad(grid, padIndex);
+                if (pad == nullptr)
+                    return;
 
-        const auto devices = pad->getDevices();
-        if (pluginIndex < 0 || pluginIndex >= static_cast<int>(devices.size()))
-            return;
+                const auto devices = pad->getDevices();
+                if (pluginIndex < 0 || pluginIndex >= static_cast<int>(devices.size()))
+                    return;
 
-        tm.removeDeviceFromPad(grid, pad->id, devices[static_cast<size_t>(pluginIndex)]->id);
-        if (auto* dg = getDrumGrid())
-            updatePadFromChain(dg, padIndex);
+                tm.removeDeviceFromPad(grid, pad->id,
+                                       devices[static_cast<size_t>(pluginIndex)]->id);
+            },
+            [padIndex, getDrumGrid, updatePadFromChain]() {
+                if (auto* dg = getDrumGrid())
+                    updatePadFromChain(dg, padIndex);
+            });
     };
 
     // Reorder plugins in chain
-    padChain.onPluginMoved = [gridPath, padChainId](int padIndex, int fromIdx, int toIdx) {
-        magda::TrackManager::getInstance().moveDeviceInPad(gridPath(), padChainId(padIndex),
-                                                           fromIdx, toIdx);
+    padChain.onPluginMoved = [postPadEdit](int padIndex, int fromIdx, int toIdx) {
+        postPadEdit("Reorder Pad Devices",
+                    [padIndex, fromIdx, toIdx](const magda::ChainNodePath& grid) {
+                        auto& tm = magda::TrackManager::getInstance();
+                        const auto* pad = tm.getPad(grid, padIndex);
+                        if (pad == nullptr)
+                            return;
+                        tm.moveDeviceInPad(grid, pad->id, fromIdx, toIdx);
+                    });
     };
 
     // Forward sample operations from PadDeviceSlot -> the model
-    padChain.onSampleDropped = [getDrumGrid, updatePadFromChain,
-                                loadSampleToPad](int padIndex, const juce::File& file) {
+    padChain.onSampleDropped = [loadSampleToPad](int padIndex, const juce::File& file) {
         loadSampleToPad(padIndex, file);
-        if (auto* dg = getDrumGrid())
-            updatePadFromChain(dg, padIndex);
     };
 
-    padChain.onLoadSampleRequested = [this, getDrumGrid, updatePadFromChain,
-                                      loadSampleToPad](int padIndex) {
+    padChain.onLoadSampleRequested = [this, loadSampleToPad](int padIndex) {
         auto chooser = std::make_shared<juce::FileChooser>("Load Sample", juce::File(),
                                                            "*.wav;*.aif;*.aiff;*.flac;*.ogg;*.mp3");
         chooser->launchAsync(juce::FileBrowserComponent::openMode |
                                  juce::FileBrowserComponent::canSelectFiles,
-                             [this, padIndex, chooser, getDrumGrid, updatePadFromChain,
-                              loadSampleToPad](const juce::FileChooser&) {
+                             [this, padIndex, chooser, loadSampleToPad](const juce::FileChooser&) {
                                  if (!drumGridUI_)
                                      return;
                                  auto result = chooser->getResult();
-                                 if (result.existsAsFile()) {
+                                 if (result.existsAsFile())
                                      loadSampleToPad(padIndex, result);
-                                     if (auto* dg = getDrumGrid())
-                                         updatePadFromChain(dg, padIndex);
-                                 }
                              });
     };
 

--- a/magda/daw/ui/components/chain/slot/DeviceCustomUIManager.cpp
+++ b/magda/daw/ui/components/chain/slot/DeviceCustomUIManager.cpp
@@ -1342,7 +1342,18 @@ bool DeviceCustomUIManager::createDrumGridUI(const magda::DeviceInfo& device,
     // The pad's output bus. `ChainInfo::outputIndex` is model state, and the
     // device sync turns a pad on a bus into a multi-out child track, so the row
     // selector only ever had to write the model (#2211).
-    drumGridUI_->onPadOutputChanged = [postPadEdit](int padIndex, int busIndex) {
+    drumGridUI_->onPadOutputChanged = [this, postPadEdit, gridPath](int padIndex, int busIndex) {
+        // Refused for a grid inside a rack: nothing carries a bus off one, so
+        // the pads on it would go silent. Asked before the edit, the same way a
+        // range is, so a refusal snaps the row back to Main rather than leaving
+        // it showing a bus the model never took, and does not become an undo
+        // step that changed nothing.
+        if (busIndex != 0 && !magda::TrackManager::getInstance().padBusesAvailable(gridPath())) {
+            if (drumGridUI_ != nullptr)
+                drumGridUI_->rebuildChainRows();
+            return;
+        }
+
         postPadEdit("Set Pad Output", [padIndex, busIndex](const magda::ChainNodePath& grid) {
             magda::TrackManager::getInstance().setPadOutput(grid, padIndex, busIndex);
         });

--- a/magda/engine/param/ModSources.cpp
+++ b/magda/engine/param/ModSources.cpp
@@ -14,6 +14,21 @@ void collectModulationTaps(const std::vector<magda::ChainElement>& elements,
             const auto source = sidechainSourceOf(device.sidechain);
             collectModulationTaps(device.mods, source, ownTrack, out);
             collectNoteSources(device.mods, source, ownTrack, notes);
+
+            // A pad-per-chain device's pads hold devices like any other rack's
+            // chains, and each of those is an ordinary DeviceInfo that can own
+            // macros and modifiers since #2207. Not collecting them dropped
+            // nothing while a pad device had no DeviceInfo at all; now it
+            // would drop a modifier the parameter table has an address for
+            // (#2211).
+            //
+            // Under `ownTrack`, not the grid's sidechain source: a device
+            // inside a rack hears its own sidechain and the rack's is the
+            // rack's, which is the rule the chain descent below follows. The
+            // pad rack itself is synthesized and owns no modifiers.
+            if (device.pads)
+                for (const auto& pad : device.pads->chains)
+                    collectModulationTaps(pad.elements, ownTrack, out, notes, nesting);
         } else if (magda::isRack(element)) {
             const auto& rack = magda::getRack(element);
 

--- a/tests/test_drum_grid_pad_commands.cpp
+++ b/tests/test_drum_grid_pad_commands.cpp
@@ -760,6 +760,64 @@ TEST_CASE("A pad's range cannot reach a note another pad already answers to",
     CHECK(tm.getPad(gridPath, 0)->highNote == note + 1);
 }
 
+TEST_CASE("A pad's range has to stay inside the notes the grid shows",
+          "[drumgrid][pads][commands]") {
+    // The grid shows kPadCount pads from kPadBaseNote and builds its rows from
+    // those notes. A chain retuned clear of them keeps playing and disappears
+    // from the UI, with no way left to edit or delete it.
+    resetState();
+    auto& tm = TrackManager::getInstance();
+
+    const auto trackId = tm.createTrack("Drums");
+    const auto gridId = tm.addDeviceToTrack(trackId, drumGridDevice());
+    const auto gridPath = ChainNodePath::topLevelDevice(trackId, gridId);
+
+    REQUIRE(tm.setPadDevice(gridPath, 0, padVoice("Kick")) != INVALID_DEVICE_ID);
+    const auto note = padNoteFor(0);
+
+    CHECK_FALSE(tm.padNoteRangeIsFree(gridPath, 0, 0, kPadBaseNote - 1));
+    CHECK_FALSE(tm.setPadNoteRange(gridPath, 0, 0, kPadBaseNote - 1, 0));
+    CHECK(tm.getPad(gridPath, 0)->lowNote == note);
+
+    const auto lastNote = padNoteFor(kPadCount - 1);
+    CHECK_FALSE(tm.setPadNoteRange(gridPath, 0, lastNote + 1, 127, lastNote + 1));
+    CHECK(tm.getPad(gridPath, 0)->lowNote == note);
+}
+
+TEST_CASE("A pad on a grid inside a rack cannot be put on a bus", "[drumgrid][pads][commands]") {
+    // A multi-out child track is fed by the output instance InstrumentRackManager
+    // makes when it wraps a top-level instrument. A grid inside a MAGDA rack is
+    // loaded by RackSyncManager and has no entry there, so a bus would name a
+    // track nothing reaches and the pads on it would go silent.
+    resetState();
+    auto& tm = TrackManager::getInstance();
+
+    const auto trackId = tm.createTrack("Drums");
+    const auto rackId = tm.addRackToTrack(trackId, "Rack");
+    const auto rackChainId = tm.addChainToRack(ChainNodePath::rack(trackId, rackId));
+    const auto rackChainPath = ChainNodePath::chain(trackId, rackId, rackChainId);
+    const auto nestedGridId = tm.addDeviceToChainByPath(rackChainPath, drumGridDevice());
+    REQUIRE(nestedGridId != INVALID_DEVICE_ID);
+
+    const auto nestedGridPath = rackChainPath.withDevice(nestedGridId);
+    REQUIRE(tm.setPadDevice(nestedGridPath, 0, padVoice("Kick")) != INVALID_DEVICE_ID);
+
+    CHECK_FALSE(tm.padBusesAvailable(nestedGridPath));
+    CHECK_FALSE(tm.setPadOutput(nestedGridPath, 0, 1));
+    CHECK(tm.getPad(nestedGridPath, 0)->outputIndex == 0);
+
+    // Back to the grid's own mix is always allowed, nested or not.
+    CHECK(tm.setPadOutput(nestedGridPath, 0, 0));
+
+    // A top-level grid takes one.
+    const auto gridId = tm.addDeviceToTrack(trackId, drumGridDevice());
+    const auto gridPath = ChainNodePath::topLevelDevice(trackId, gridId);
+    REQUIRE(tm.setPadDevice(gridPath, 0, padVoice("Snare")) != INVALID_DEVICE_ID);
+    CHECK(tm.padBusesAvailable(gridPath));
+    CHECK(tm.setPadOutput(gridPath, 0, 2));
+    CHECK(tm.getPad(gridPath, 0)->outputIndex == 2);
+}
+
 TEST_CASE("A pad chain answering to more than one note can still be deleted",
           "[drumgrid][pads][commands]") {
     // clearPad() is the pad's own delete and leaves a chain shared with its

--- a/tests/test_drum_grid_pad_commands.cpp
+++ b/tests/test_drum_grid_pad_commands.cpp
@@ -818,6 +818,43 @@ TEST_CASE("A pad on a grid inside a rack cannot be put on a bus", "[drumgrid][pa
     CHECK(tm.getPad(gridPath, 0)->outputIndex == 2);
 }
 
+TEST_CASE("Pads are put back on the main mix when their grid stops being top level",
+          "[drumgrid][pads][commands]") {
+    // padBusesAvailable only guards a new assignment. A grid can cross into a
+    // placement where buses do not work after one was made -- wrapping it in a
+    // rack moves it and keeps its pads -- and a project can be loaded already
+    // like that, leaving a pad pointed at a bus nothing carries.
+    resetState();
+    auto& tm = TrackManager::getInstance();
+
+    const auto trackId = tm.createTrack("Drums");
+    const auto gridId = tm.addDeviceToTrack(trackId, drumGridDevice());
+    const auto gridPath = ChainNodePath::topLevelDevice(trackId, gridId);
+
+    REQUIRE(tm.setPadDevice(gridPath, 0, padVoice("Kick")) != INVALID_DEVICE_ID);
+    REQUIRE(tm.setPadDevice(gridPath, 1, padVoice("Snare")) != INVALID_DEVICE_ID);
+    REQUIRE(tm.setPadOutput(gridPath, 0, 1));
+    REQUIRE(tm.setPadOutput(gridPath, 1, 2));
+
+    // Wrapping keeps the pads and their buses, and the grid is no longer a
+    // top-level device.
+    const auto rackId = tm.wrapDeviceInRack(trackId, gridId);
+    REQUIRE(rackId != INVALID_RACK_ID);
+
+    const auto nestedGridPath = tm.findDevicePath(gridId);
+    REQUIRE(nestedGridPath.isValid());
+    REQUIRE_FALSE(tm.padBusesAvailable(nestedGridPath));
+    REQUIRE(tm.getPad(nestedGridPath, 0)->outputIndex == 1);
+
+    // What the device sync does about it.
+    CHECK(tm.resetPadBuses(nestedGridPath));
+    CHECK(tm.getPad(nestedGridPath, 0)->outputIndex == 0);
+    CHECK(tm.getPad(nestedGridPath, 1)->outputIndex == 0);
+
+    // And it says so only when something actually moved.
+    CHECK_FALSE(tm.resetPadBuses(nestedGridPath));
+}
+
 TEST_CASE("A pad chain answering to more than one note can still be deleted",
           "[drumgrid][pads][commands]") {
     // clearPad() is the pad's own delete and leaves a chain shared with its

--- a/tests/test_drum_grid_pad_commands.cpp
+++ b/tests/test_drum_grid_pad_commands.cpp
@@ -646,6 +646,51 @@ TEST_CASE("A pad device resolves through the generic path lookup", "[drumgrid][p
           nullptr);
 }
 
+TEST_CASE("A device inside a rack inside a pad resolves too", "[drumgrid][pads][commands]") {
+    // A pad's chain holds elements like any other chain, racks included, and
+    // every walk that reaches a pad recurses through them. The synthetic
+    // prefix is the pad's; the rest of the address is an ordinary route.
+    resetState();
+    auto& tm = TrackManager::getInstance();
+
+    const auto trackId = tm.createTrack("Drums");
+    const auto gridId = tm.addDeviceToTrack(trackId, drumGridDevice());
+    const auto gridPath = ChainNodePath::topLevelDevice(trackId, gridId);
+
+    constexpr int padIndex = 1;
+    REQUIRE(tm.setPadDevice(gridPath, padIndex, padVoice("Tom")) != INVALID_DEVICE_ID);
+
+    auto* pad = tm.getPad(gridPath, padIndex);
+    REQUIRE(pad != nullptr);
+    const auto padChainId = pad->id;
+
+    // Built on the model directly: no pad command makes one today, and the
+    // point is that the address resolves wherever the model can express it.
+    constexpr DeviceId kNested = 4242;
+    RackInfo inner;
+    inner.id = 77;
+    inner.name = "Pad Rack";
+    ChainInfo innerChain;
+    innerChain.id = 3;
+    auto nested = padVoice("Nested");
+    nested.id = kNested;
+    innerChain.elements.push_back(makeDeviceElement(nested));
+    inner.chains.push_back(std::move(innerChain));
+    tm.getPadChain(gridPath, padChainId)->elements.push_back(makeRackElement(std::move(inner)));
+
+    const auto path = tm.findDevicePath(kNested);
+    REQUIRE(path.isValid());
+    CHECK(path == TrackManager::padChainPath(gridPath, padChainId)
+                      .withRack(77)
+                      .withChain(3)
+                      .withDevice(kNested));
+
+    const auto* resolved = tm.getDeviceInChainByPath(path);
+    REQUIRE(resolved != nullptr);
+    CHECK(resolved->id == kNested);
+    CHECK(resolved->name == "Nested");
+}
+
 TEST_CASE("A dragged pad fader is one undo step, not one per move",
           "[drumgrid][pads][commands][undo]") {
     resetState();

--- a/tests/test_drum_grid_pad_commands.cpp
+++ b/tests/test_drum_grid_pad_commands.cpp
@@ -5,9 +5,11 @@
 #include "magda/daw/core/ControlTarget.hpp"
 #include "magda/daw/core/DrumGridPads.hpp"
 #include "magda/daw/core/MacroInfo.hpp"
+#include "magda/daw/core/PadCommands.hpp"
 #include "magda/daw/core/RackInfo.hpp"
 #include "magda/daw/core/SelectionManager.hpp"
 #include "magda/daw/core/TrackManager.hpp"
+#include "magda/daw/core/UndoManager.hpp"
 
 using namespace magda;
 
@@ -26,6 +28,7 @@ void resetState() {
     ClipManager::getInstance().clearAllClips();
     TrackManager::getInstance().clearAllTracks();
     SelectionManager::getInstance().clearSelection();
+    UndoManager::getInstance().clearHistory();
 }
 
 DeviceInfo drumGridDevice() {
@@ -470,4 +473,159 @@ TEST_CASE("A pad device's power is model state", "[drumgrid][pads][commands]") {
 
     tm.setPadDeviceBypassed(gridPath, pad->id, voiceId, false);
     CHECK_FALSE(getDevice(tm.getPad(gridPath, padIndex)->elements[0]).bypassed);
+}
+
+// ============================================================================
+// #2211 -- what the pad flip left unfinished
+// ============================================================================
+
+TEST_CASE("A pad device is found by id like any other device", "[drumgrid][pads][commands]") {
+    resetState();
+    auto& tm = TrackManager::getInstance();
+
+    const auto trackId = tm.createTrack("Drums");
+    const auto rackId = tm.addRackToTrack(trackId, "FX Rack");
+    const auto rackChainId = tm.addChainToRack(ChainNodePath::rack(trackId, rackId));
+    const auto gridId = tm.addDeviceToTrack(trackId, drumGridDevice());
+    const auto gridPath = ChainNodePath::topLevelDevice(trackId, gridId);
+
+    constexpr int padIndex = 3;
+    const auto voiceId = tm.setPadDevice(gridPath, padIndex, padVoice("Snare"));
+    REQUIRE(voiceId != INVALID_DEVICE_ID);
+    const auto* pad = tm.getPad(gridPath, padIndex);
+    REQUIRE(pad != nullptr);
+
+    // The address a stored link carries: the grid's own DeviceId in the rack
+    // step, then the pad chain, then the device.
+    CHECK(tm.findDevicePath(voiceId) ==
+          TrackManager::padChainPath(gridPath, pad->id).withDevice(voiceId));
+
+    // The devices it could already find still resolve the same way.
+    CHECK(tm.findDevicePath(gridId) == gridPath);
+
+    const auto rackDeviceId = tm.addDeviceToChainByPath(
+        ChainNodePath::chain(trackId, rackId, rackChainId), padVoice("Rack Voice"));
+    REQUIRE(rackDeviceId != INVALID_DEVICE_ID);
+    CHECK(tm.findDevicePath(rackDeviceId) ==
+          ChainNodePath::chainDevice(trackId, rackId, rackChainId, rackDeviceId));
+}
+
+TEST_CASE("A pad's output bus and key range are model state", "[drumgrid][pads][commands]") {
+    resetState();
+    auto& tm = TrackManager::getInstance();
+
+    const auto trackId = tm.createTrack("Drums");
+    const auto gridId = tm.addDeviceToTrack(trackId, drumGridDevice());
+    const auto gridPath = ChainNodePath::topLevelDevice(trackId, gridId);
+
+    constexpr int padIndex = 5;
+    REQUIRE(tm.setPadDevice(gridPath, padIndex, padVoice("Clap")) != INVALID_DEVICE_ID);
+
+    tm.setPadOutput(gridPath, padIndex, 2);
+    CHECK(tm.getPad(gridPath, padIndex)->outputIndex == 2);
+
+    // A range arrives low-first whichever way round the sliders were dragged.
+    // Widened over the two notes above it, the pad still answers to its own.
+    const auto note = padNoteFor(padIndex);
+    tm.setPadNoteRange(gridPath, padIndex, note + 2, note, note + 1);
+    const auto* pad = tm.getPad(gridPath, padIndex);
+    REQUIRE(pad != nullptr);
+    CHECK(pad->lowNote == note);
+    CHECK(pad->highNote == note + 2);
+    CHECK(pad->rootNote == note + 1);
+
+    // Clamped to what MIDI can spell.
+    tm.setPadNoteRange(gridPath, padIndex, -5, 300, 400);
+    pad = tm.getPad(gridPath, padIndex);
+    REQUIRE(pad != nullptr);
+    CHECK(pad->lowNote == 0);
+    CHECK(pad->highNote == 127);
+    CHECK(pad->rootNote == 127);
+}
+
+TEST_CASE("A pad moved off its own note stops being that pad", "[drumgrid][pads][commands]") {
+    // The pad is the note, which is what `swapPads` trades. Retuning a chain
+    // clear of the note it was on hands its sound to whichever pad the new
+    // range covers, and leaves the old one empty.
+    resetState();
+    auto& tm = TrackManager::getInstance();
+
+    const auto trackId = tm.createTrack("Drums");
+    const auto gridId = tm.addDeviceToTrack(trackId, drumGridDevice());
+    const auto gridPath = ChainNodePath::topLevelDevice(trackId, gridId);
+
+    constexpr int padIndex = 5;
+    constexpr int movedTo = 9;
+    REQUIRE(tm.setPadDevice(gridPath, padIndex, padVoice("Clap")) != INVALID_DEVICE_ID);
+
+    const auto note = padNoteFor(movedTo);
+    tm.setPadNoteRange(gridPath, padIndex, note, note, note);
+
+    CHECK(tm.getPad(gridPath, padIndex) == nullptr);
+    REQUIRE(tm.getPad(gridPath, movedTo) != nullptr);
+    CHECK(tm.getPad(gridPath, movedTo)->elements.size() == 1);
+}
+
+TEST_CASE("A pad edit is one undo step", "[drumgrid][pads][commands][undo]") {
+    resetState();
+    auto& tm = TrackManager::getInstance();
+    auto& undo = UndoManager::getInstance();
+
+    const auto trackId = tm.createTrack("Drums");
+    const auto gridId = tm.addDeviceToTrack(trackId, drumGridDevice());
+    const auto gridPath = ChainNodePath::topLevelDevice(trackId, gridId);
+
+    constexpr int padIndex = 0;
+    editPads(gridPath, "Set Pad Instrument", [gridPath]() {
+        TrackManager::getInstance().setPadDevice(gridPath, padIndex, padVoice("Kick"));
+    });
+    REQUIRE(tm.getPad(gridPath, padIndex) != nullptr);
+    REQUIRE(tm.getPad(gridPath, padIndex)->elements.size() == 1);
+
+    editPads(gridPath, "Mute Pad",
+             [gridPath]() { TrackManager::getInstance().setPadMuted(gridPath, padIndex, true); });
+    CHECK(tm.getPad(gridPath, padIndex)->muted);
+
+    REQUIRE(undo.undo());
+    CHECK_FALSE(tm.getPad(gridPath, padIndex)->muted);
+
+    // The pad itself goes back, devices and all: the snapshot is the whole rack.
+    REQUIRE(undo.undo());
+    CHECK(tm.getPad(gridPath, padIndex) == nullptr);
+
+    // And redo re-runs the edit rather than restoring a saved after-state.
+    REQUIRE(undo.redo());
+    REQUIRE(tm.getPad(gridPath, padIndex) != nullptr);
+    CHECK(tm.getPad(gridPath, padIndex)->elements.size() == 1);
+}
+
+TEST_CASE("A dragged pad fader is one undo step, not one per move",
+          "[drumgrid][pads][commands][undo]") {
+    resetState();
+    auto& tm = TrackManager::getInstance();
+    auto& undo = UndoManager::getInstance();
+
+    const auto trackId = tm.createTrack("Drums");
+    const auto gridId = tm.addDeviceToTrack(trackId, drumGridDevice());
+    const auto gridPath = ChainNodePath::topLevelDevice(trackId, gridId);
+
+    constexpr int padIndex = 0;
+    editPads(gridPath, "Set Pad Instrument", [gridPath]() {
+        TrackManager::getInstance().setPadDevice(gridPath, padIndex, padVoice("Kick"));
+    });
+
+    for (float db : {-1.0f, -2.0f, -3.0f, -4.0f})
+        editPads(
+            gridPath, "Set Pad Level",
+            [gridPath, db]() { TrackManager::getInstance().setPadVolume(gridPath, padIndex, db); },
+            "padLevel:0");
+
+    CHECK(tm.getPad(gridPath, padIndex)->volume == -4.0f);
+
+    // One step back to where the drag started, not four.
+    REQUIRE(undo.undo());
+    CHECK(tm.getPad(gridPath, padIndex)->volume == 0.0f);
+
+    // A different pad's fader is its own step.
+    CHECK(tm.getPad(gridPath, padIndex) != nullptr);
 }

--- a/tests/test_drum_grid_pad_commands.cpp
+++ b/tests/test_drum_grid_pad_commands.cpp
@@ -581,6 +581,7 @@ TEST_CASE("A pad edit is one undo step", "[drumgrid][pads][commands][undo]") {
     });
     REQUIRE(tm.getPad(gridPath, padIndex) != nullptr);
     REQUIRE(tm.getPad(gridPath, padIndex)->elements.size() == 1);
+    const auto voiceId = getDevice(tm.getPad(gridPath, padIndex)->elements[0]).id;
 
     editPads(gridPath, "Mute Pad",
              [gridPath]() { TrackManager::getInstance().setPadMuted(gridPath, padIndex, true); });
@@ -593,10 +594,56 @@ TEST_CASE("A pad edit is one undo step", "[drumgrid][pads][commands][undo]") {
     REQUIRE(undo.undo());
     CHECK(tm.getPad(gridPath, padIndex) == nullptr);
 
-    // And redo re-runs the edit rather than restoring a saved after-state.
+    // Redo restores the snapshot rather than replaying the edit. Replaying an
+    // add allocates a fresh DeviceId, and the mute behind it in the redo chain
+    // still names the one the first run handed out.
     REQUIRE(undo.redo());
     REQUIRE(tm.getPad(gridPath, padIndex) != nullptr);
-    CHECK(tm.getPad(gridPath, padIndex)->elements.size() == 1);
+    REQUIRE(tm.getPad(gridPath, padIndex)->elements.size() == 1);
+    CHECK(getDevice(tm.getPad(gridPath, padIndex)->elements[0]).id == voiceId);
+
+    REQUIRE(undo.redo());
+    CHECK(tm.getPad(gridPath, padIndex)->muted);
+    CHECK(getDevice(tm.getPad(gridPath, padIndex)->elements[0]).id == voiceId);
+}
+
+TEST_CASE("A pad device resolves through the generic path lookup", "[drumgrid][pads][commands]") {
+    // findDevicePath() answering with a pad address is only worth anything if
+    // the address can then be dereferenced: alias generation, automation
+    // targets and link repair all go id -> path -> DeviceInfo.
+    resetState();
+    auto& tm = TrackManager::getInstance();
+
+    const auto trackId = tm.createTrack("Drums");
+    const auto rackId = tm.addRackToTrack(trackId, "FX Rack");
+    const auto rackChainId = tm.addChainToRack(ChainNodePath::rack(trackId, rackId));
+    const auto gridId = tm.addDeviceToTrack(trackId, drumGridDevice());
+    const auto gridPath = ChainNodePath::topLevelDevice(trackId, gridId);
+
+    constexpr int padIndex = 2;
+    const auto voiceId = tm.setPadDevice(gridPath, padIndex, padVoice("Hat"));
+    REQUIRE(voiceId != INVALID_DEVICE_ID);
+
+    const auto padDevicePath = tm.findDevicePath(voiceId);
+    REQUIRE(padDevicePath.isValid());
+
+    const auto* resolved = tm.getDeviceInChainByPath(padDevicePath);
+    REQUIRE(resolved != nullptr);
+    CHECK(resolved->id == voiceId);
+    CHECK(resolved->name == "Hat");
+
+    // The rack sharing the grid's number still resolves the ordinary way; a pad
+    // path is only tried once that has failed.
+    const auto rackDeviceId = tm.addDeviceToChainByPath(
+        ChainNodePath::chain(trackId, rackId, rackChainId), padVoice("Rack Voice"));
+    const auto* rackResolved = tm.getDeviceInChainByPath(
+        ChainNodePath::chainDevice(trackId, rackId, rackChainId, rackDeviceId));
+    REQUIRE(rackResolved != nullptr);
+    CHECK(rackResolved->id == rackDeviceId);
+
+    // A path naming a device that is in neither place still answers nothing.
+    CHECK(tm.getDeviceInChainByPath(ChainNodePath::chainDevice(trackId, gridId, 0, 9999)) ==
+          nullptr);
 }
 
 TEST_CASE("A dragged pad fader is one undo step, not one per move",

--- a/tests/test_drum_grid_pad_commands.cpp
+++ b/tests/test_drum_grid_pad_commands.cpp
@@ -706,18 +706,85 @@ TEST_CASE("A dragged pad fader is one undo step, not one per move",
         TrackManager::getInstance().setPadDevice(gridPath, padIndex, padVoice("Kick"));
     });
 
+    using Target = SetPadFaderCommand::Target;
+
     for (float db : {-1.0f, -2.0f, -3.0f, -4.0f})
-        editPads(
-            gridPath, "Set Pad Level",
-            [gridPath, db]() { TrackManager::getInstance().setPadVolume(gridPath, padIndex, db); },
-            "padLevel:0");
+        setPadFader(gridPath, padIndex, Target::Volume, db, /*gesture=*/1);
 
     CHECK(tm.getPad(gridPath, padIndex)->volume == -4.0f);
 
-    // One step back to where the drag started, not four.
+    // The next drag is a new gesture, so it does not fold into the last one.
+    // UndoManager merges adjacent commands with no timeout of its own, so
+    // without the gesture one Undo would walk back both drags.
+    setPadFader(gridPath, padIndex, Target::Volume, -8.0f, /*gesture=*/2);
+
+    REQUIRE(undo.undo());
+    CHECK(tm.getPad(gridPath, padIndex)->volume == -4.0f);
+
+    // One step back to where the first drag started, not four.
     REQUIRE(undo.undo());
     CHECK(tm.getPad(gridPath, padIndex)->volume == 0.0f);
 
-    // A different pad's fader is its own step.
-    CHECK(tm.getPad(gridPath, padIndex) != nullptr);
+    // And pan is its own step, not the level's.
+    setPadFader(gridPath, padIndex, Target::Pan, -0.5f, /*gesture=*/3);
+    setPadFader(gridPath, padIndex, Target::Volume, -2.0f, /*gesture=*/3);
+    REQUIRE(undo.undo());
+    CHECK(tm.getPad(gridPath, padIndex)->volume == 0.0f);
+    CHECK(tm.getPad(gridPath, padIndex)->pan == -0.5f);
+}
+
+TEST_CASE("A pad's range cannot reach a note another pad already answers to",
+          "[drumgrid][pads][commands]") {
+    // Every chain whose range covers an incoming note plays it, and every row,
+    // fader and switch addresses a pad by finding the chain covering its note.
+    // A second claimant would leave a row editing a chain other than the one it
+    // shows, so the range is refused instead.
+    resetState();
+    auto& tm = TrackManager::getInstance();
+
+    const auto trackId = tm.createTrack("Drums");
+    const auto gridId = tm.addDeviceToTrack(trackId, drumGridDevice());
+    const auto gridPath = ChainNodePath::topLevelDevice(trackId, gridId);
+
+    REQUIRE(tm.setPadDevice(gridPath, 0, padVoice("Kick")) != INVALID_DEVICE_ID);
+    REQUIRE(tm.setPadDevice(gridPath, 2, padVoice("Snare")) != INVALID_DEVICE_ID);
+
+    const auto note = padNoteFor(0);
+
+    // Up to, but not into, pad 2.
+    CHECK(tm.setPadNoteRange(gridPath, 0, note, note + 1, note));
+    CHECK(tm.getPad(gridPath, 0)->highNote == note + 1);
+
+    // One note further would reach pad 2's, and is refused whole.
+    CHECK_FALSE(tm.setPadNoteRange(gridPath, 0, note, note + 2, note));
+    CHECK(tm.getPad(gridPath, 0)->highNote == note + 1);
+}
+
+TEST_CASE("A pad chain answering to more than one note can still be deleted",
+          "[drumgrid][pads][commands]") {
+    // clearPad() is the pad's own delete and leaves a chain shared with its
+    // neighbours alone, which after a range edit left a widened chain with no
+    // way off the grid at all.
+    resetState();
+    auto& tm = TrackManager::getInstance();
+
+    const auto trackId = tm.createTrack("Drums");
+    const auto gridId = tm.addDeviceToTrack(trackId, drumGridDevice());
+    const auto gridPath = ChainNodePath::topLevelDevice(trackId, gridId);
+
+    REQUIRE(tm.setPadDevice(gridPath, 0, padVoice("Kick")) != INVALID_DEVICE_ID);
+    const auto note = padNoteFor(0);
+    REQUIRE(tm.setPadNoteRange(gridPath, 0, note, note + 2, note));
+
+    const auto padChainId = tm.getPad(gridPath, 0)->id;
+
+    // The pad's own clear refuses it: the chain is its neighbours' sound too.
+    tm.clearPad(gridPath, 0);
+    CHECK(tm.getPad(gridPath, 0) != nullptr);
+
+    // The chain's delete takes it.
+    tm.removePadChain(gridPath, padChainId);
+    CHECK(tm.getPad(gridPath, 0) == nullptr);
+    CHECK(tm.getPad(gridPath, 1) == nullptr);
+    CHECK(tm.getPad(gridPath, 2) == nullptr);
 }

--- a/tests/test_drum_grid_pad_commands.cpp
+++ b/tests/test_drum_grid_pad_commands.cpp
@@ -534,13 +534,17 @@ TEST_CASE("A pad's output bus and key range are model state", "[drumgrid][pads][
     CHECK(pad->highNote == note + 2);
     CHECK(pad->rootNote == note + 1);
 
-    // Clamped to what MIDI can spell.
-    tm.setPadNoteRange(gridPath, padIndex, -5, 300, 400);
+    // A range spanning everything MIDI can spell reaches outside the grid at
+    // both ends, and is refused whole rather than clamped into it.
+    CHECK_FALSE(tm.setPadNoteRange(gridPath, padIndex, -5, 300, 400));
     pad = tm.getPad(gridPath, padIndex);
     REQUIRE(pad != nullptr);
-    CHECK(pad->lowNote == 0);
-    CHECK(pad->highNote == 127);
-    CHECK(pad->rootNote == 127);
+    CHECK(pad->lowNote == note);
+    CHECK(pad->highNote == note + 2);
+
+    // The root is clamped rather than refused: it is not an endpoint.
+    CHECK(tm.setPadNoteRange(gridPath, padIndex, note, note + 2, 400));
+    CHECK(tm.getPad(gridPath, padIndex)->rootNote == 127);
 }
 
 TEST_CASE("A pad moved off its own note stops being that pad", "[drumgrid][pads][commands]") {
@@ -782,6 +786,19 @@ TEST_CASE("A pad's range has to stay inside the notes the grid shows",
     const auto lastNote = padNoteFor(kPadCount - 1);
     CHECK_FALSE(tm.setPadNoteRange(gridPath, 0, lastNote + 1, 127, lastNote + 1));
     CHECK(tm.getPad(gridPath, 0)->lowNote == note);
+
+    // Both ends, not merely an overlap. A low end below the grid makes
+    // padParameterSlot() answer -1, and the plan stops binding the chain's
+    // fader and pan to the grid's parameters.
+    CHECK_FALSE(tm.setPadNoteRange(gridPath, 0, 0, note, 0));
+    CHECK_FALSE(tm.setPadNoteRange(gridPath, 0, note, 127, note));
+    CHECK(tm.getPad(gridPath, 0)->lowNote == note);
+    CHECK(tm.getPad(gridPath, 0)->highNote == note);
+
+    // The root is not an endpoint: it is the transposition target, and a sample
+    // whose natural pitch sits outside the displayed pads is a valid mapping.
+    CHECK(tm.setPadNoteRange(gridPath, 0, note, note, 127));
+    CHECK(tm.getPad(gridPath, 0)->rootNote == 127);
 }
 
 TEST_CASE("A pad on a grid inside a rack cannot be put on a bus", "[drumgrid][pads][commands]") {
@@ -818,12 +835,11 @@ TEST_CASE("A pad on a grid inside a rack cannot be put on a bus", "[drumgrid][pa
     CHECK(tm.getPad(gridPath, 0)->outputIndex == 2);
 }
 
-TEST_CASE("Pads are put back on the main mix when their grid stops being top level",
-          "[drumgrid][pads][commands]") {
-    // padBusesAvailable only guards a new assignment. A grid can cross into a
-    // placement where buses do not work after one was made -- wrapping it in a
-    // rack moves it and keeps its pads -- and a project can be loaded already
-    // like that, leaving a pad pointed at a bus nothing carries.
+TEST_CASE("A grid with a pad on a bus is not wrapped into a rack", "[drumgrid][pads][commands]") {
+    // Wrapping would take the grid somewhere no bus is carried, so the move
+    // would have to put every pad back on the main mix. That clean-up is not
+    // part of the undoable step the move is, so undoing the wrap would return
+    // the grid to the top level with its routing gone. Refused instead.
     resetState();
     auto& tm = TrackManager::getInstance();
 
@@ -832,27 +848,68 @@ TEST_CASE("Pads are put back on the main mix when their grid stops being top lev
     const auto gridPath = ChainNodePath::topLevelDevice(trackId, gridId);
 
     REQUIRE(tm.setPadDevice(gridPath, 0, padVoice("Kick")) != INVALID_DEVICE_ID);
-    REQUIRE(tm.setPadDevice(gridPath, 1, padVoice("Snare")) != INVALID_DEVICE_ID);
     REQUIRE(tm.setPadOutput(gridPath, 0, 1));
-    REQUIRE(tm.setPadOutput(gridPath, 1, 2));
 
-    // Wrapping keeps the pads and their buses, and the grid is no longer a
-    // top-level device.
-    const auto rackId = tm.wrapDeviceInRack(trackId, gridId);
-    REQUIRE(rackId != INVALID_RACK_ID);
+    CHECK(tm.wrapDeviceInRack(trackId, gridId) == INVALID_RACK_ID);
+    CHECK(tm.findDevicePath(gridId) == gridPath);
+    CHECK(tm.getPad(gridPath, 0)->outputIndex == 1);
 
-    const auto nestedGridPath = tm.findDevicePath(gridId);
-    REQUIRE(nestedGridPath.isValid());
-    REQUIRE_FALSE(tm.padBusesAvailable(nestedGridPath));
-    REQUIRE(tm.getPad(nestedGridPath, 0)->outputIndex == 1);
+    // Back on the main mix, it wraps like any other device.
+    REQUIRE(tm.setPadOutput(gridPath, 0, 0));
+    CHECK(tm.wrapDeviceInRack(trackId, gridId) != INVALID_RACK_ID);
+}
 
-    // What the device sync does about it.
-    CHECK(tm.resetPadBuses(nestedGridPath));
-    CHECK(tm.getPad(nestedGridPath, 0)->outputIndex == 0);
-    CHECK(tm.getPad(nestedGridPath, 1)->outputIndex == 0);
+TEST_CASE("Pads on a grid that is already nested are put back on the main mix",
+          "[drumgrid][pads][commands]") {
+    // A project can be loaded with a nested grid whose pads are on buses, from
+    // before the wrap was refused or by hand. Nothing carries a bus off one, so
+    // the device sync puts them back rather than leaving them silent.
+    resetState();
+    auto& tm = TrackManager::getInstance();
+
+    const auto trackId = tm.createTrack("Drums");
+    const auto rackId = tm.addRackToTrack(trackId, "Rack");
+    const auto rackChainId = tm.addChainToRack(ChainNodePath::rack(trackId, rackId));
+    const auto rackChainPath = ChainNodePath::chain(trackId, rackId, rackChainId);
+    const auto gridId = tm.addDeviceToChainByPath(rackChainPath, drumGridDevice());
+    const auto gridPath = rackChainPath.withDevice(gridId);
+
+    REQUIRE(tm.setPadDevice(gridPath, 0, padVoice("Kick")) != INVALID_DEVICE_ID);
+    REQUIRE(tm.setPadDevice(gridPath, 1, padVoice("Snare")) != INVALID_DEVICE_ID);
+
+    // Straight onto the model, the way a loaded project arrives: the setter
+    // refuses a bus here.
+    REQUIRE_FALSE(tm.setPadOutput(gridPath, 0, 1));
+    tm.getPadChain(gridPath, tm.getPad(gridPath, 0)->id)->outputIndex = 1;
+    tm.getPadChain(gridPath, tm.getPad(gridPath, 1)->id)->outputIndex = 2;
+
+    CHECK(tm.resetPadBuses(gridPath));
+    CHECK(tm.getPad(gridPath, 0)->outputIndex == 0);
+    CHECK(tm.getPad(gridPath, 1)->outputIndex == 0);
 
     // And it says so only when something actually moved.
-    CHECK_FALSE(tm.resetPadBuses(nestedGridPath));
+    CHECK_FALSE(tm.resetPadBuses(gridPath));
+}
+
+TEST_CASE("A pad's bus has to name one the plan can route", "[drumgrid][pads][commands]") {
+    // The live plugin clamps what it is given and the plan compiler takes the
+    // model's value as it finds it, so an out-of-range index makes the two
+    // disagree: the plan reports a bus that reaches no track and silences the
+    // pads on it rather than folding them into the device's own mix.
+    resetState();
+    auto& tm = TrackManager::getInstance();
+
+    const auto trackId = tm.createTrack("Drums");
+    const auto gridId = tm.addDeviceToTrack(trackId, drumGridDevice());
+    const auto gridPath = ChainNodePath::topLevelDevice(trackId, gridId);
+    REQUIRE(tm.setPadDevice(gridPath, 0, padVoice("Kick")) != INVALID_DEVICE_ID);
+
+    CHECK_FALSE(tm.setPadOutput(gridPath, 0, -1));
+    CHECK_FALSE(tm.setPadOutput(gridPath, 0, kPadBusCount));
+    CHECK(tm.getPad(gridPath, 0)->outputIndex == 0);
+
+    CHECK(tm.setPadOutput(gridPath, 0, kPadBusCount - 1));
+    CHECK(tm.getPad(gridPath, 0)->outputIndex == kPadBusCount - 1);
 }
 
 TEST_CASE("A pad chain answering to more than one note can still be deleted",

--- a/tests/test_drum_grid_pad_commands.cpp
+++ b/tests/test_drum_grid_pad_commands.cpp
@@ -859,6 +859,92 @@ TEST_CASE("A grid with a pad on a bus is not wrapped into a rack", "[drumgrid][p
     CHECK(tm.wrapDeviceInRack(trackId, gridId) != INVALID_RACK_ID);
 }
 
+TEST_CASE("A grid with a pad on a bus is not dragged into a rack", "[drumgrid][pads][commands]") {
+    // The drag-and-drop path is a move, not a wrap, and reaches neither wrap
+    // API. Undo of a move puts the already-reset grid back at the top level,
+    // which is the routing loss the wrap refusal exists to prevent.
+    resetState();
+    auto& tm = TrackManager::getInstance();
+
+    const auto trackId = tm.createTrack("Drums");
+    const auto rackId = tm.addRackToTrack(trackId, "Rack");
+    const auto rackChainId = tm.addChainToRack(ChainNodePath::rack(trackId, rackId));
+    const auto rackChainPath = ChainNodePath::chain(trackId, rackId, rackChainId);
+    const auto gridId = tm.addDeviceToTrack(trackId, drumGridDevice());
+    const auto gridPath = ChainNodePath::topLevelDevice(trackId, gridId);
+
+    REQUIRE(tm.setPadDevice(gridPath, 0, padVoice("Kick")) != INVALID_DEVICE_ID);
+    REQUIRE(tm.setPadOutput(gridPath, 0, 1));
+
+    CHECK_FALSE(tm.moveChainElement(gridPath, rackChainPath, 0));
+    CHECK(tm.findDevicePath(gridId) == gridPath);
+
+    // Reordering inside the track's own list is not a placement change.
+    CHECK(tm.moveChainElement(gridPath, ChainNodePath::trackLevel(trackId), 0));
+
+    // And once the pad is back on the main mix it moves like anything else.
+    REQUIRE(tm.setPadOutput(tm.findDevicePath(gridId), 0, 0));
+    CHECK(tm.moveChainElement(tm.findDevicePath(gridId), rackChainPath, 0));
+}
+
+TEST_CASE("A copied Drum Grid's pads get ids of their own", "[drumgrid][pads][commands]") {
+    // The copy path allocates a new id for the outer grid. Without descending
+    // into its pads the clone kept every pad DeviceId from the source, so the
+    // plan would emit two devices onto one op and findDevicePath() would answer
+    // whichever copy it met first.
+    resetState();
+    auto& tm = TrackManager::getInstance();
+
+    const auto trackId = tm.createTrack("Drums");
+    const auto gridId = tm.addDeviceToTrack(trackId, drumGridDevice());
+    const auto gridPath = ChainNodePath::topLevelDevice(trackId, gridId);
+    const auto voiceId = tm.setPadDevice(gridPath, 0, padVoice("Kick"));
+    REQUIRE(voiceId != INVALID_DEVICE_ID);
+    const auto padChainId = tm.getPad(gridPath, 0)->id;
+
+    // A macro on the grid pointing at its own pad device: what the copy has to
+    // carry across to the copy's pad rather than leave on the original's.
+    {
+        auto* grid = tm.getDeviceInChainByPath(gridPath);
+        REQUIRE(grid != nullptr);
+        MacroLink link;
+        link.target = ControlTarget::pluginParam(
+            TrackManager::padChainPath(gridPath, padChainId).withDevice(voiceId), 0);
+        link.amount = 1.0f;
+        grid->macros[0].links.push_back(link);
+    }
+
+    std::vector<ChainElement> copied;
+    copied.push_back(makeDeviceElement(*tm.getDeviceInChainByPath(gridPath)));
+    REQUIRE(tm.insertChainElementsByPath(ChainNodePath::trackLevel(trackId), std::move(copied), 1,
+                                         /*reassignIds=*/true));
+
+    const auto* track = tm.getTrack(trackId);
+    REQUIRE(track != nullptr);
+    REQUIRE(track->chain.fxChainElements.size() == 2);
+
+    const auto& clone = getDevice(track->chain.fxChainElements[1]);
+    CHECK(clone.id != gridId);
+    REQUIRE(clone.pads);
+    REQUIRE(clone.pads->chains.size() == 1);
+
+    const auto& clonedVoice = getDevice(clone.pads->chains[0].elements[0]);
+    CHECK(clonedVoice.id != voiceId);
+
+    // The pad rack carries the clone's own id, and the copied macro names the
+    // clone's pad rather than the original's.
+    CHECK(clone.pads->id == padRackIdFor(clone.id));
+    const auto clonePath = ChainNodePath::topLevelDevice(trackId, clone.id);
+    CHECK(
+        clone.macros[0].links[0].target.devicePath ==
+        TrackManager::padChainPath(clonePath, clone.pads->chains[0].id).withDevice(clonedVoice.id));
+
+    // And each id now resolves to its own copy.
+    CHECK(tm.findDevicePath(voiceId) ==
+          TrackManager::padChainPath(gridPath, padChainId).withDevice(voiceId));
+    CHECK(tm.findDevicePath(clonedVoice.id).getDeviceId() == clonedVoice.id);
+}
+
 TEST_CASE("Pads on a grid that is already nested are put back on the main mix",
           "[drumgrid][pads][commands]") {
     // A project can be loaded with a nested grid whose pads are on buses, from

--- a/tests/test_drum_grid_pad_commands.cpp
+++ b/tests/test_drum_grid_pad_commands.cpp
@@ -945,6 +945,129 @@ TEST_CASE("A copied Drum Grid's pads get ids of their own", "[drumgrid][pads][co
     CHECK(tm.findDevicePath(clonedVoice.id).getDeviceId() == clonedVoice.id);
 }
 
+TEST_CASE("A grid with a pad on a bus is not dragged to another track",
+          "[drumgrid][pads][commands]") {
+    // A track-level destination on another track is still a placement change:
+    // the pair state moves with the device while the child track it made still
+    // links to the track it came from, so the sync finds the pair active, makes
+    // nothing, and the pad goes quiet.
+    resetState();
+    auto& tm = TrackManager::getInstance();
+
+    const auto trackId = tm.createTrack("Drums");
+    const auto otherTrackId = tm.createTrack("Other");
+    const auto gridId = tm.addDeviceToTrack(trackId, drumGridDevice());
+    const auto gridPath = ChainNodePath::topLevelDevice(trackId, gridId);
+
+    REQUIRE(tm.setPadDevice(gridPath, 0, padVoice("Kick")) != INVALID_DEVICE_ID);
+    REQUIRE(tm.setPadOutput(gridPath, 0, 1));
+
+    CHECK_FALSE(tm.moveChainElement(gridPath, ChainNodePath::trackLevel(otherTrackId), 0));
+    CHECK(tm.findDevicePath(gridId) == gridPath);
+
+    REQUIRE(tm.setPadOutput(gridPath, 0, 0));
+    CHECK(tm.moveChainElement(gridPath, ChainNodePath::trackLevel(otherTrackId), 0));
+}
+
+TEST_CASE("A copied grid owns no child tracks yet", "[drumgrid][pads][commands]") {
+    // Inheriting the source's pair state would leave the sync thinking the
+    // child tracks were already made, so it would build none for the copy and
+    // its pad on a bus would be silent while the link named the original.
+    resetState();
+    auto& tm = TrackManager::getInstance();
+
+    const auto trackId = tm.createTrack("Drums");
+    const auto gridId = tm.addDeviceToTrack(trackId, drumGridDevice());
+    const auto gridPath = ChainNodePath::topLevelDevice(trackId, gridId);
+    REQUIRE(tm.setPadDevice(gridPath, 0, padVoice("Kick")) != INVALID_DEVICE_ID);
+
+    {
+        auto* grid = tm.getDeviceInChainByPath(gridPath);
+        REQUIRE(grid != nullptr);
+        grid->multiOut.isMultiOut = true;
+        grid->multiOut.outputPairs.resize(2);
+        grid->multiOut.outputPairs[1].active = true;
+        grid->multiOut.outputPairs[1].trackId = trackId;
+    }
+
+    std::vector<ChainElement> copied;
+    copied.push_back(makeDeviceElement(*tm.getDeviceInChainByPath(gridPath)));
+    REQUIRE(tm.insertChainElementsByPath(ChainNodePath::trackLevel(trackId), std::move(copied), 1,
+                                         /*reassignIds=*/true));
+
+    const auto& clone = getDevice(tm.getTrack(trackId)->chain.fxChainElements[1]);
+    REQUIRE(clone.multiOut.outputPairs.size() == 2);
+    CHECK_FALSE(clone.multiOut.outputPairs[1].active);
+    CHECK(clone.multiOut.outputPairs[1].trackId == INVALID_TRACK_ID);
+
+    // The original keeps its own.
+    CHECK(tm.getDeviceInChainByPath(gridPath)->multiOut.outputPairs[1].active);
+}
+
+TEST_CASE("A copied link into a rack inside a pad follows the copy", "[drumgrid][pads][commands]") {
+    // A pad's chain holds racks like any other, so a link can name something
+    // deeper than the pad's own devices. Its prefix is still the pad's and has
+    // to come from the pad remap; what follows moves with the ordinary maps.
+    resetState();
+    auto& tm = TrackManager::getInstance();
+
+    const auto trackId = tm.createTrack("Drums");
+    const auto gridId = tm.addDeviceToTrack(trackId, drumGridDevice());
+    const auto gridPath = ChainNodePath::topLevelDevice(trackId, gridId);
+    REQUIRE(tm.setPadDevice(gridPath, 0, padVoice("Kick")) != INVALID_DEVICE_ID);
+
+    const auto padChainId = tm.getPad(gridPath, 0)->id;
+    constexpr RackId kInnerRack = 77;
+    constexpr ChainId kInnerChain = 3;
+    constexpr DeviceId kNested = 4242;
+
+    {
+        RackInfo inner;
+        inner.id = kInnerRack;
+        ChainInfo innerChain;
+        innerChain.id = kInnerChain;
+        auto nested = padVoice("Nested");
+        nested.id = kNested;
+        innerChain.elements.push_back(makeDeviceElement(nested));
+        inner.chains.push_back(std::move(innerChain));
+        tm.getPadChain(gridPath, padChainId)->elements.push_back(makeRackElement(std::move(inner)));
+
+        auto* grid = tm.getDeviceInChainByPath(gridPath);
+        REQUIRE(grid != nullptr);
+        MacroLink link;
+        link.target = ControlTarget::pluginParam(TrackManager::padChainPath(gridPath, padChainId)
+                                                     .withRack(kInnerRack)
+                                                     .withChain(kInnerChain)
+                                                     .withDevice(kNested),
+                                                 0);
+        link.amount = 1.0f;
+        grid->macros[0].links.push_back(link);
+    }
+
+    std::vector<ChainElement> copied;
+    copied.push_back(makeDeviceElement(*tm.getDeviceInChainByPath(gridPath)));
+    REQUIRE(tm.insertChainElementsByPath(ChainNodePath::trackLevel(trackId), std::move(copied), 1,
+                                         /*reassignIds=*/true));
+
+    const auto& clone = getDevice(tm.getTrack(trackId)->chain.fxChainElements[1]);
+    const auto& clonedRack = getRack(clone.pads->chains[0].elements[1]);
+    const auto& clonedNested = getDevice(clonedRack.chains[0].elements[0]);
+
+    // Every id moved, and the link names the copy's own.
+    CHECK(clonedRack.id != kInnerRack);
+    CHECK(clonedNested.id != kNested);
+    CHECK(clone.macros[0].links[0].target.devicePath ==
+          TrackManager::padChainPath(ChainNodePath::topLevelDevice(trackId, clone.id),
+                                     clone.pads->chains[0].id)
+              .withRack(clonedRack.id)
+              .withChain(clonedRack.chains[0].id)
+              .withDevice(clonedNested.id));
+
+    // And both copies resolve to their own nested device.
+    CHECK(tm.getDeviceInChainByPath(clone.macros[0].links[0].target.devicePath) != nullptr);
+    CHECK(tm.findDevicePath(kNested).getDeviceId() == kNested);
+}
+
 TEST_CASE("Pads on a grid that is already nested are put back on the main mix",
           "[drumgrid][pads][commands]") {
     // A project can be loaded with a nested grid whose pads are on buses, from

--- a/tests/test_plan_pad_rack.cpp
+++ b/tests/test_plan_pad_rack.cpp
@@ -8,6 +8,7 @@
 #include "core/TrackInfo.hpp"
 #include "exec/PlanValues.hpp"
 #include "exec/RuntimeStateStore.hpp"
+#include "param/ModSources.hpp"
 #include "param/ParamKey.hpp"
 #include "param/ParamTableCompiler.hpp"
 #include "plan/PlanCompiler.hpp"
@@ -478,4 +479,33 @@ TEST_CASE("A macro on a pad device's parameter resolves", "[engine][plan][padrac
     const auto key = magda::engine::paramKeyFor(link.target);
     REQUIRE(key.has_value());
     CHECK(table.find(*key) != magda::engine::INVALID_PARAM_ID);
+}
+
+TEST_CASE("A modifier on a pad device is collected as a modulation source",
+          "[engine][plan][padrack]") {
+    // A pad device is an ordinary DeviceInfo since #2207, so it can own a
+    // modifier. Before #2211 the collection walk stopped at the Drum Grid, so
+    // the plan carried no edge for one and the tap it reads was never emitted
+    // (#2204: the same question answered by a dozen separate walks).
+    constexpr DeviceId kDrumGrid = 10;
+    constexpr DeviceId kPadDevice = 101;
+
+    auto drumGrid = makeDrumGrid(kDrumGrid, {makePad(0, 36, 36, 60, kPadDevice)});
+
+    magda::ModInfo follower;
+    follower.id = 1;
+    follower.name = "Follower";
+    follower.type = magda::ModType::Follower;
+    follower.enabled = true;
+    follower.tapPoint = magda::ModTapPoint::PostFader;
+    getDevice(drumGrid.pads->chains[0].elements[0]).mods.push_back(follower);
+
+    auto track = makeTrack(1);
+    track.chain.fxChainElements.push_back(std::move(drumGrid));
+
+    std::set<magda::engine::ModTap> taps;
+    std::set<TrackId> notes;
+    magda::engine::collectModulationTaps(track, taps, notes);
+
+    CHECK(taps.contains(magda::engine::ModTap{track.id, magda::ModTapPoint::PostFader}));
 }


### PR DESCRIPTION
Closes #2211.

#2207 gave a Drum Grid's pads to the model. This is the work that audit found unfinished: items 2 through 7 (item 1 shipped on #2208, item 6 was noted rather than a task).

## Found by a pad device's id (item 2)

`findDevicePath()` descends into `DeviceInfo::pads`, so a pad device resolves to the address every stored link to one already carries: `Rack(gridDeviceId) > Chain(pad) > Device(padDevice)`.

Rewriting it as one recursion also closed two gaps it already had: it went only one rack level deep, and it never looked in the master track's racks at all.

## Collected as a modulation source (item 7)

`ModSources` walks a pad's elements the way it walks a rack chain's. A pad device can own macros and mods since #2207 and nothing read them, so the plan carried no edge for a modifier the parameter table has an address for.

Under the pad's own track, not the grid's sidechain source: a device inside a rack hears its own sidechain, and the rack's is the rack's.

## Undoable (item 3)

`EditPadsCommand` snapshots the grid's whole pad rack. That is one field on one `DeviceInfo`, and it is the only snapshot that stays correct for the edits that touch more than one pad at a time: a swap, a replace, a clear. The per-op commands in `TrackCommands.cpp` cannot serve a pad, because a pad path's Rack step spells a DeviceId and would resolve onto whichever rack shares the number.

Redo re-runs the edit rather than restoring an after-state, so an edit that allocates ids hands out the ones a fresh run would. A `mergeKey` coalesces a fader drag into one step.

### A use-after-free the flip introduced

Every pad edit in the UI is now posted rather than called inline. Since #2207 a pad edit writes the model and notifies `trackDevicesChanged`; `TrackChainContent::trackDevicesChanged` calls `rebuildNodeComponents()`, which clears `nodeComponents_` synchronously and owns the slots by `unique_ptr`. That freed the device slot, the pad UI inside it and the row whose button was still on the stack. Before #2207 these callbacks wrote the plugin's `CachedValue` directly and notified nothing, so there was nothing to tear down.

Posting lets the gesture finish first. The faders stay inline: they notify `trackPropertyChanged`, which by design does not rebuild.

The general shape is untouched. Any UI callback that writes a device property firing `trackDevicesChanged` has the same exposure, because that handler rebuilds every node component. Only the pad path is closed here.

## Controls wired to nothing (item 4)

- `onPadOutputChanged` writes `ChainInfo::outputIndex` through a new `TrackManager::setPadOutput`.
- `getNoteRange` / `onPadRangeChanged` read and write a pad's note range through a new `TrackManager::setPadNoteRange`, and `PadChainRangeRowComponent` is built for every chain row and laid out under the selected one. Built with the rows rather than on selection, because selection changes from a row's own `mouseUp`.
- A pad slot's meters drain the grid's own per-plugin peaks. A pad plugin runs inside the grid, so it has no `DeviceMeteringManager` tap of its own.

## Multi-out (item 5)

Wiring the bus selector makes the machinery live: the engine already routes a pad's bus, `PluginManager` already creates the child track for it, and the device slot's multi-out button already opens the pairs.

`DrumGridPlugin::multiOutEnabled` is deleted. It gated `assignBusOutputs()`, which #2207 removed, and nothing ever wrote or read either. This is the "delete the machinery" half of item 5 applied to the one piece nothing reads; the issue's out-of-scope note was about where `mixerExpanded` and `multiOutEnabled` live, not about keeping a flag with no readers.

## Seeing it in the app

Open a track with a Drum Grid and expand the device slot. The chains panel on the right lists one row per loaded pad; selecting a row now shows a second row under it with Low, High and Root note fields. The bus button on a pad row (Main / B1 / B2 ...) now sticks and creates the multi-out child track. Pad slot meters in the detail panel move while a pad plays. Ctrl+Z steps back through pad edits.

## Tests

Six new cases: pad lookup by id, output bus, key range clamping and low-first ordering, a pad retuned off its own note, undo/redo of a pad edit, fader coalescing, and the modulation-source descent. The `ModSources` one was checked against the unpatched walk and fails there.

3014 Catch2 cases and the full JUCE suite pass locally.

https://claude.ai/code/session_0187yiSdSJPmDFZafrSfbSop


