### PR TITLE
Faust device submissions from magda.land

### DIFF
--- a/.github/ISSUE_TEMPLATE/faust-device.yml
+++ b/.github/ISSUE_TEMPLATE/faust-device.yml
@@ -1,0 +1,51 @@
+# A device shared from magda.land/community/devices.
+#
+# This exists for its `labels:` line. The submission page could put the whole
+# issue in a link, but GitHub only honours a `labels=` query parameter for
+# people who already have permission to label -- "you must have the proper
+# permissions for any action to use the equivalent query parameter" -- so a
+# contributor's submission would arrive bare and stay unpublished. A template
+# carries its labels itself, for whoever opens it.
+#
+# The fields are prefilled from the page by query parameter, one per field id:
+#   ?template=faust-device.yml&title=...&source=...&notes=...
+#
+# `render: faust` is what puts the source in a fenced block, which is what the
+# gallery reads it back out of. Everything else about the device -- its name,
+# its author, what it does -- is read from the DSP's own `declare` lines, so
+# the file stays the single source of truth and there is nothing to keep in
+# step with it.
+name: Share a Faust device
+description: A device you wrote, to be listed on magda.land for anyone to play and download
+title: "Faust device: "
+labels: ["faust-device"]
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Devices are usually sent from
+        [magda.land/community/devices](https://magda.land/community/devices/),
+        which compiles yours in your browser first and fills this in for you.
+        You can also paste one here directly.
+
+        Give the DSP a `declare name`, `declare author` and
+        `declare description` — that is where the listing gets its title, your
+        credit, and the text under it.
+
+  - type: textarea
+    id: source
+    attributes:
+      label: The device
+      description: The whole .dsp file.
+      render: faust
+    validations:
+      required: true
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: Anything worth saying about it
+      description: Optional. What it is for, what to turn first, what it was modelled on.
+    validations:
+      required: false

--- a/.github/workflows/faust-device-published.yml
+++ b/.github/workflows/faust-device-published.yml
@@ -1,0 +1,56 @@
+# Label and close a shared Faust device.
+#
+# magda.land/community/devices hands a contributor a prefilled issue rather
+# than uploading anything: GitHub is the identity and the store. The gallery
+# lists every issue carrying `faust-device`, open or closed, so the label is
+# what publishes a device and removing it is what takes one down.
+#
+# The prefilled link asks for that label, but GitHub only honours `labels=` for
+# people with triage rights on the repo -- so a contributor's submission always
+# arrives bare, and without this it would sit unpublished until someone noticed
+# it. This applies the label on their behalf, which means devices publish on
+# submission and come down afterwards if they need to, rather than waiting on a
+# review before they appear.
+#
+# The guard is the body contract the submission form writes: the title it uses
+# and the ```faust fence the gallery parses. An issue that does not match is
+# left entirely alone, so this cannot fire on an ordinary bug report.
+#
+# Once labelled, the issue itself has nothing outstanding on it, so it closes
+# and says where the device went.
+name: Faust device published
+
+on:
+  issues:
+    types: [opened, labeled]
+
+permissions:
+  issues: write
+
+jobs:
+  publish:
+    if: >-
+      (github.event.action == 'opened' &&
+       startsWith(github.event.issue.title, 'Faust device:') &&
+       contains(github.event.issue.body, '```faust')) ||
+      (github.event.action == 'labeled' &&
+       github.event.label.name == 'faust-device' &&
+       github.event.issue.state == 'open')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Publish it, say where it went, and close it
+        env:
+          GH_TOKEN: ${{ github.token }}
+          NUMBER: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          # Adding a label already present is not an error, so the two events
+          # take the same path rather than needing to know which one ran.
+          gh issue edit "$NUMBER" --repo "$REPO" --add-label faust-device
+
+          gh issue comment "$NUMBER" --repo "$REPO" --body \
+            'Published — this device is now on [magda.land/community/devices](https://magda.land/community/devices/), where anyone can play it in their browser and download the `.dsp`.
+
+          Closing, because the label is what keeps it listed: it stays on that page whether this issue is open or closed. Comment here if something needs changing, and removing the `faust-device` label takes it back down.'
+
+          gh issue close "$NUMBER" --repo "$REPO" --reason completed


### PR DESCRIPTION
Two files in `.github/`, no code. They are what makes
[magda.land/community/devices](https://magda.land/community/devices/) work —
see Conceptual-Machines/magda-cloud#80.

Someone writes a device, the site compiles it in their browser with the same
libfaust that builds our shipped devices, and if it works they share it. The
share is an issue here: GitHub is the identity and the store, so the site keeps
no accounts and has no write endpoint to abuse. The gallery lists every issue
carrying `faust-device`, open or closed, and reads the name, the author and the
description out of the DSP's own `declare` lines.

**`ISSUE_TEMPLATE/faust-device.yml`** exists for its `labels:` line. The site
could put the whole issue in a link, but GitHub honours a `labels=` query
parameter only for people who already have permission to label — *"you must have
the proper permissions for any action to use the equivalent query parameter"* —
and drops it silently otherwise. So a contributor's submission would arrive bare
and sit unpublished. A template carries its own labels, for whoever opens it.
`render: faust` is what puts the source in a fenced block for the gallery to
read back.

**`workflows/faust-device-published.yml`** labels anything that still arrives
bare, comments where the device went, and closes it. Guarded on the title prefix
plus the presence of a ```` ```faust ```` fence, so it cannot fire on an ordinary
issue — verified against a submission, a manual label, a bug report and an
unrelated label.

Note this means devices publish on submission, with the label removal as the
takedown, rather than a review before they appear.

The `faust-device` label already exists on this repo.

Co-authored-by: CM Claude