### PR TITLE
Give pad-owned chains explicit path step types

### DIFF
--- a/magda/daw/api/remote_api.cpp
+++ b/magda/daw/api/remote_api.cpp
@@ -224,7 +224,7 @@ const juce::var& devicePathSchema() {
             "steps":{"type":"array","items":{
                 "type":"object",
                 "properties":{
-                    "type":{"type":"string","enum":["rack","chain","device"]},
+                    "type":{"type":"string","enum":["rack","chain","device","pad_rack","pad_chain"]},
                     "id":{"type":"integer","minimum":0}
                 },
                 "required":["type","id"],

--- a/magda/daw/api/remote_api_projection.cpp
+++ b/magda/daw/api/remote_api_projection.cpp
@@ -450,6 +450,15 @@ DevicePathDto makeDevicePathDto(const ChainNodePath& path) {
             case ChainStepType::Device:
                 dto.steps.push_back({"device", step.id});
                 break;
+            case ChainStepType::PadRack:
+                // The id is the owning Drum Grid's DeviceId, not a RackId; the
+                // public step type says so rather than leaving a client to
+                // guess from position (#2219).
+                dto.steps.push_back({"pad_rack", step.id});
+                break;
+            case ChainStepType::PadChain:
+                dto.steps.push_back({"pad_chain", step.id});
+                break;
             case ChainStepType::Segment:
                 // Non-leading segments are not produced by any factory; drop
                 // rather than emit a step type the public contract lacks.
@@ -482,6 +491,10 @@ std::optional<ChainNodePath> toChainNodePath(const DevicePathDto& dto) {
             path.steps.push_back({ChainStepType::Chain, step.id});
         else if (step.type == "device")
             path.steps.push_back({ChainStepType::Device, step.id});
+        else if (step.type == "pad_rack")
+            path.steps.push_back({ChainStepType::PadRack, step.id});
+        else if (step.type == "pad_chain")
+            path.steps.push_back({ChainStepType::PadChain, step.id});
         else
             return std::nullopt;
     }

--- a/magda/daw/core/CMakeLists.txt
+++ b/magda/daw/core/CMakeLists.txt
@@ -52,6 +52,7 @@ target_sources(magda_daw PRIVATE
     DeviceCatalogMetadata.cpp
     LegacyDeviceAliases.cpp
     DeviceParamMigrations.cpp
+    PadPathMigration.cpp
     PluginPreferences.cpp
     PluginCapabilities.cpp
     PluginPresetScanner.cpp

--- a/magda/daw/core/ChainNodePath.cpp
+++ b/magda/daw/core/ChainNodePath.cpp
@@ -88,7 +88,7 @@ bool fromVar(const juce::var& v, ChainNodePath& out) {
             if (!readRequiredInt(*stepObj, "type", rawType))
                 return false;
             if (rawType < static_cast<int>(ChainStepType::Rack) ||
-                rawType > static_cast<int>(ChainStepType::Segment))
+                rawType > static_cast<int>(ChainStepType::PadChain))
                 return false;
 
             ChainPathStep step;
@@ -105,6 +105,19 @@ bool fromVar(const juce::var& v, ChainNodePath& out) {
                     step.id > static_cast<int>(ChainSegment::MixerAnalysis))
                     return false;
             }
+
+            // The pad steps come as a leading pair. A pad path names its owning
+            // grid by DeviceId rather than by a route to it, so PadRack is always
+            // step 0 and PadChain always step 1; accepting either anywhere else
+            // would readmit exactly the ambiguity the types exist to remove.
+            if (step.type == ChainStepType::PadRack && i != 0)
+                return false;
+            if (step.type == ChainStepType::PadChain &&
+                (i != 1 || path.steps.front().type != ChainStepType::PadRack))
+                return false;
+            if (i == 1 && path.steps.front().type == ChainStepType::PadRack &&
+                step.type != ChainStepType::PadChain)
+                return false;
 
             path.steps.push_back(step);
         }

--- a/magda/daw/core/ChainNodePath.cpp
+++ b/magda/daw/core/ChainNodePath.cpp
@@ -123,6 +123,14 @@ bool fromVar(const juce::var& v, ChainNodePath& out) {
         }
     }
 
+    // A PadRack with nothing after it is not an address. The pair is the whole
+    // point: alone, the step names the pad rack, which nothing resolves, and
+    // getType() would report the path as an ordinary Rack whose id is a
+    // DeviceId, which is the ambiguity the types exist to remove. The in-loop
+    // checks cannot catch it, because there is no second step to check.
+    if (!path.steps.empty() && path.steps.back().type == ChainStepType::PadRack)
+        return false;
+
     if (obj->hasProperty("isTrackLevel")) {
         const auto flag = obj->getProperty("isTrackLevel");
         if (!flag.isBool())

--- a/magda/daw/core/ChainNodePath.hpp
+++ b/magda/daw/core/ChainNodePath.hpp
@@ -11,22 +11,44 @@ namespace magda {
 /**
  * @brief Type of element in a chain path step
  *
- * Segment is appended last so the persisted integer values of Rack/Chain/
- * Device (serialized in automation targets) stay stable.
+ * New values are appended so the persisted integer values of the existing ones
+ * (serialized in automation targets) stay stable. Never renumber.
+ *
+ * `PadRack` and `PadChain` address the pad rack a Drum Grid owns. They exist so
+ * an owner id in a path says what it is: a `PadRack` step carries the owning
+ * grid's DeviceId, where a `Rack` step carries a RackId. Rack ids and device ids
+ * come out of counters that both start at 1, so without the distinction `Rack(1)`
+ * is as much rack 1 as it is Drum Grid 1's pads, and generic resolvers and
+ * remappers had to guess from the path's shape (#2219).
  */
-enum class ChainStepType { Rack, Chain, Device, Segment };
+enum class ChainStepType { Rack, Chain, Device, Segment, PadRack, PadChain };
 
 /**
  * @brief A single step in a chain node path
  */
 struct ChainPathStep {
     ChainStepType type;
-    int id;  // RackId, ChainId, or DeviceId depending on type
+    // RackId, ChainId or DeviceId depending on type. A PadRack step carries the
+    // owning device's DeviceId; a PadChain step carries a rack-local ChainId.
+    int id;
 
     bool operator==(const ChainPathStep& other) const {
         return type == other.type && id == other.id;
     }
 };
+
+/// True for the two step types that name the rack a chain belongs to: an
+/// allocated `Rack`, or the `PadRack` a Drum Grid owns. Use this wherever the
+/// question is "which rack encloses this?"; use an explicit `== Rack` only
+/// where the answer has to be a real RackId.
+inline bool isRackStep(ChainStepType type) {
+    return type == ChainStepType::Rack || type == ChainStepType::PadRack;
+}
+
+/// True for the two step types that name a chain. Both carry a ChainId.
+inline bool isChainStep(ChainStepType type) {
+    return type == ChainStepType::Chain || type == ChainStepType::PadChain;
+}
 
 /**
  * @brief Type of the selected chain node (derived from path)
@@ -72,8 +94,10 @@ struct ChainNodePath {
 
         switch (steps.back().type) {
             case ChainStepType::Rack:
+            case ChainStepType::PadRack:
                 return ChainNodeType::Rack;
             case ChainStepType::Chain:
+            case ChainStepType::PadChain:
                 return ChainNodeType::Chain;
             case ChainStepType::Device:
                 return ChainNodeType::Device;
@@ -92,6 +116,29 @@ struct ChainNodePath {
     bool isPostFx() const {
         return !steps.empty() && steps.front().type == ChainStepType::Segment &&
                steps.front().id == static_cast<int>(ChainSegment::PostFx);
+    }
+
+    // True when this path descends into the pad rack a Drum Grid owns.
+    //
+    // A pad path is rooted at the track whatever the grid is nested in, because
+    // `PadRack` names the grid by its DeviceId rather than by a route to it, so
+    // the pad steps are always the first two.
+    bool isPadOwned() const {
+        return !steps.empty() && steps.front().type == ChainStepType::PadRack;
+    }
+
+    // The DeviceId of the Drum Grid owning this path's pads, or INVALID_DEVICE_ID
+    // when the path is not pad-owned.
+    DeviceId getPadOwnerDeviceId() const {
+        return isPadOwned() ? steps.front().id : INVALID_DEVICE_ID;
+    }
+
+    // The pad chain this path descends through, or INVALID_CHAIN_ID when the
+    // path is not pad-owned.
+    ChainId getPadChainId() const {
+        if (steps.size() > 1 && isPadOwned() && steps[1].type == ChainStepType::PadChain)
+            return steps[1].id;
+        return INVALID_CHAIN_ID;
     }
 
     bool isMixerAnalysis() const {
@@ -142,8 +189,11 @@ struct ChainNodePath {
         return INVALID_RACK_ID;
     }
 
+    // Both Chain and PadChain steps carry a ChainId: a pad chain is an ordinary
+    // chain of the rack its grid owns. Only the *owner* spelling differs, which
+    // is what getRackIdAt() stays strict about.
     ChainId getChainIdAt(size_t index) const {
-        if (index < steps.size() && steps[index].type == ChainStepType::Chain)
+        if (index < steps.size() && isChainStep(steps[index].type))
             return steps[index].id;
         return INVALID_CHAIN_ID;
     }
@@ -205,6 +255,17 @@ struct ChainNodePath {
         return p;
     }
 
+    // A pad chain of the Drum Grid @p owner. Flat by construction and rooted at
+    // the track, whatever the grid itself is nested in:
+    //   Track > PadRack(ownerDeviceId) > PadChain(padChainId)
+    static ChainNodePath padChain(TrackId track, DeviceId owner, ChainId padChainId) {
+        ChainNodePath p;
+        p.trackId = track;
+        p.steps.push_back({ChainStepType::PadRack, owner});
+        p.steps.push_back({ChainStepType::PadChain, padChainId});
+        return p;
+    }
+
     // A device in the track's post-fader FX list. Flat by construction:
     //   Track > Segment(PostFx) > Device
     static ChainNodePath postFxDevice(TrackId track, DeviceId device) {
@@ -235,6 +296,12 @@ struct ChainNodePath {
     ChainNodePath withChain(ChainId c) const {
         ChainNodePath p = *this;
         p.steps.push_back({ChainStepType::Chain, c});
+        return p;
+    }
+
+    ChainNodePath withPadChain(ChainId c) const {
+        ChainNodePath p = *this;
+        p.steps.push_back({ChainStepType::PadChain, c});
         return p;
     }
 
@@ -287,6 +354,12 @@ struct ChainNodePath {
                     break;
                 case ChainStepType::Device:
                     result += " > Device[" + juce::String(step.id) + "]";
+                    break;
+                case ChainStepType::PadRack:
+                    result += " > PadRack[" + juce::String(step.id) + "]";
+                    break;
+                case ChainStepType::PadChain:
+                    result += " > PadChain[" + juce::String(step.id) + "]";
                     break;
                 case ChainStepType::Segment: {
                     auto seg = static_cast<ChainSegment>(step.id);

--- a/magda/daw/core/PadPathMigration.cpp
+++ b/magda/daw/core/PadPathMigration.cpp
@@ -1,8 +1,7 @@
 #include "PadPathMigration.hpp"
 
 #include <functional>
-#include <map>
-#include <set>
+#include <vector>
 
 #include "AutomationInfo.hpp"
 #include "ChainNodePath.hpp"
@@ -11,87 +10,168 @@
 
 namespace magda::pad_paths {
 
+namespace {
+
+/// Follow @p path from @p index through @p elements, the ordinary way.
+///
+/// True only when every remaining step resolves. The tie-break this migration
+/// reproduces is the resolver's, and the resolver gave the rack route priority
+/// only when the WHOLE route came out somewhere: `getDeviceInChainByPath()`
+/// walked the rack tree, searched the chain it landed in for the leaf device,
+/// and fell through to the pad route when that search failed. Matching only the
+/// leading pair would keep an address untyped whose leaf lives on a pad, and
+/// duplication would then move its owner id through the racks map (#2219).
+bool resolvesOrdinary(const std::vector<ChainElement>& elements, const ChainNodePath& path,
+                      std::size_t index) {
+    if (index >= path.steps.size())
+        return true;  // Every step accounted for.
+
+    const auto& step = path.steps[index];
+
+    if (step.type == ChainStepType::Device) {
+        if (index + 1 != path.steps.size())
+            return false;  // A Device step is a leaf.
+        for (const auto& element : elements)
+            if (isDevice(element) && getDevice(element).id == step.id)
+                return true;
+        return false;
+    }
+
+    if (step.type != ChainStepType::Rack)
+        return false;
+
+    for (const auto& element : elements) {
+        if (!isRack(element) || getRack(element).id != step.id)
+            continue;
+
+        // A bare Rack step is a rack-scoped address and resolves here.
+        if (index + 1 == path.steps.size())
+            return true;
+        if (path.steps[index + 1].type != ChainStepType::Chain)
+            return false;
+
+        for (const auto& chain : getRack(element).chains)
+            if (chain.id == path.steps[index + 1].id)
+                return resolvesOrdinary(chain.elements, path, index + 2);
+        return false;
+    }
+    return false;
+}
+
+/// The device @p deviceId names, searched for its pads rather than itself.
+///
+/// A grid can sit anywhere a device can, so this descends the way the resolver's
+/// own `findPadOwner` does.
+const DeviceInfo* findPadOwner(const std::vector<ChainElement>& elements, DeviceId deviceId) {
+    for (const auto& element : elements) {
+        if (isDevice(element)) {
+            const auto& device = getDevice(element);
+            if (device.id == deviceId)
+                return device.pads ? &device : nullptr;
+
+            if (device.pads)
+                for (const auto& pad : device.pads->chains)
+                    if (const auto* found = findPadOwner(pad.elements, deviceId))
+                        return found;
+            continue;
+        }
+
+        if (isRack(element))
+            for (const auto& chain : getRack(element).chains)
+                if (const auto* found = findPadOwner(chain.elements, deviceId))
+                    return found;
+    }
+    return nullptr;
+}
+
+/// True when @p path resolves as a pad address: `Rack(gridDeviceId) >
+/// Chain(pad)` and then an ordinary route through the pad's own elements.
+bool resolvesAsPad(const TrackInfo& track, const ChainNodePath& path) {
+    if (path.steps.size() < 2 || path.steps[0].type != ChainStepType::Rack ||
+        path.steps[1].type != ChainStepType::Chain)
+        return false;
+
+    const auto* owner = findPadOwner(track.chain.fxChainElements, path.steps[0].id);
+    if (owner == nullptr)
+        return false;
+
+    for (const auto& pad : owner->pads->chains)
+        if (pad.id == path.steps[1].id)
+            return resolvesOrdinary(pad.elements, path, 2);
+
+    return false;
+}
+
+void collectLinks(MacroArray& macros, ModArray& mods, std::vector<ChainNodePath*>& out) {
+    for (auto& macro : macros)
+        for (auto& link : macro.links)
+            out.push_back(&link.target.devicePath);
+    for (auto& mod : mods)
+        for (auto& link : mod.links)
+            out.push_back(&link.target.devicePath);
+}
+
+/// Every stored address on @p track: the links a track, a rack, a device or a
+/// pad device owns, wherever it sits.
+void collectTrackPaths(TrackInfo& track, std::vector<ChainNodePath*>& out) {
+    collectLinks(track.macros, track.mods, out);
+
+    std::function<void(std::vector<ChainElement>&)> walk =
+        [&](std::vector<ChainElement>& elements) {
+            for (auto& element : elements) {
+                if (isRack(element)) {
+                    auto& rack = getRack(element);
+                    collectLinks(rack.macros, rack.mods, out);
+                    for (auto& chain : rack.chains)
+                        walk(chain.elements);
+                    continue;
+                }
+
+                auto& device = getDevice(element);
+                collectLinks(device.macros, device.mods, out);
+                if (device.pads)
+                    for (auto& pad : device.pads->chains)
+                        walk(pad.elements);
+            }
+        };
+
+    walk(track.chain.fxChainElements);
+    for (auto& element : track.chain.postFxChainElements)
+        collectLinks(element.device.macros, element.device.mods, out);
+    for (auto& element : track.chain.mixerAnalysisElements)
+        collectLinks(element.device.macros, element.device.mods, out);
+}
+
+}  // namespace
+
 void migrateLegacyPadPaths(std::vector<TrackInfo>& tracks, TrackInfo* masterTrack,
                            std::vector<AutomationLaneInfo>& lanes) {
-    struct TrackAddressing {
-        std::map<DeviceId, std::set<ChainId>> padChains;    // grid device id -> its pad chain ids
-        std::map<RackId, std::set<ChainId>> topLevelRacks;  // rack id -> its chain ids
+    const auto migrateTrack = [&lanes](TrackInfo& track) {
         std::vector<ChainNodePath*> paths;
-    };
-
-    const auto collectLinks = [](MacroArray& macros, ModArray& mods,
-                                 std::vector<ChainNodePath*>& out) {
-        for (auto& macro : macros)
-            for (auto& link : macro.links)
-                out.push_back(&link.target.devicePath);
-        for (auto& mod : mods)
-            for (auto& link : mod.links)
-                out.push_back(&link.target.devicePath);
-    };
-
-    const auto survey = [&](TrackInfo& track, TrackAddressing& addressing) {
-        collectLinks(track.macros, track.mods, addressing.paths);
-
-        std::function<void(std::vector<ChainElement>&, bool)> walk =
-            [&](std::vector<ChainElement>& elements, bool topLevel) {
-                for (auto& element : elements) {
-                    if (isRack(element)) {
-                        auto& rack = getRack(element);
-                        collectLinks(rack.macros, rack.mods, addressing.paths);
-                        for (auto& chain : rack.chains) {
-                            if (topLevel)
-                                addressing.topLevelRacks[rack.id].insert(chain.id);
-                            walk(chain.elements, false);
-                        }
-                        continue;
-                    }
-
-                    auto& device = getDevice(element);
-                    collectLinks(device.macros, device.mods, addressing.paths);
-                    if (!device.pads)
-                        continue;
-
-                    for (auto& pad : device.pads->chains) {
-                        addressing.padChains[device.id].insert(pad.id);
-                        walk(pad.elements, false);
-                    }
-                }
-            };
-
-        walk(track.chain.fxChainElements, true);
-        for (auto& element : track.chain.postFxChainElements)
-            collectLinks(element.device.macros, element.device.mods, addressing.paths);
-        for (auto& element : track.chain.mixerAnalysisElements)
-            collectLinks(element.device.macros, element.device.mods, addressing.paths);
-    };
-
-    const auto retype = [](const TrackAddressing& addressing, ChainNodePath& path) {
-        if (path.steps.size() < 2 || path.steps[0].type != ChainStepType::Rack ||
-            path.steps[1].type != ChainStepType::Chain)
-            return;
-
-        const auto rack = addressing.topLevelRacks.find(path.steps[0].id);
-        if (rack != addressing.topLevelRacks.end() && rack->second.contains(path.steps[1].id))
-            return;  // An allocated rack accounts for it, exactly as it used to.
-
-        const auto pads = addressing.padChains.find(path.steps[0].id);
-        if (pads == addressing.padChains.end() || !pads->second.contains(path.steps[1].id))
-            return;
-
-        path.steps[0].type = ChainStepType::PadRack;
-        path.steps[1].type = ChainStepType::PadChain;
-    };
-
-    const auto migrateTrack = [&](TrackInfo& track) {
-        TrackAddressing addressing;
-        survey(track, addressing);
+        collectTrackPaths(track, paths);
 
         for (auto& lane : lanes)
             if (lane.target.devicePath.trackId == track.id)
-                addressing.paths.push_back(&lane.target.devicePath);
+                paths.push_back(&lane.target.devicePath);
 
-        for (auto* path : addressing.paths)
-            retype(addressing, *path);
+        for (auto* path : paths) {
+            if (path->steps.size() < 2 || path->steps[0].type != ChainStepType::Rack ||
+                path->steps[1].type != ChainStepType::Chain)
+                continue;
+
+            // The rack route first and whole, then the pad route: the order the
+            // untyped spelling was always resolved in. An address the rack tree
+            // answers completely stays a rack address even when a pad shares its
+            // prefix; only one the rack tree cannot answer and a pad can is
+            // retyped.
+            if (resolvesOrdinary(track.chain.fxChainElements, *path, 0))
+                continue;
+            if (!resolvesAsPad(track, *path))
+                continue;
+
+            path->steps[0].type = ChainStepType::PadRack;
+            path->steps[1].type = ChainStepType::PadChain;
+        }
     };
 
     for (auto& track : tracks)

--- a/magda/daw/core/PadPathMigration.cpp
+++ b/magda/daw/core/PadPathMigration.cpp
@@ -1,0 +1,103 @@
+#include "PadPathMigration.hpp"
+
+#include <functional>
+#include <map>
+#include <set>
+
+#include "AutomationInfo.hpp"
+#include "ChainNodePath.hpp"
+#include "RackInfo.hpp"
+#include "TrackInfo.hpp"
+
+namespace magda::pad_paths {
+
+void migrateLegacyPadPaths(std::vector<TrackInfo>& tracks, TrackInfo* masterTrack,
+                           std::vector<AutomationLaneInfo>& lanes) {
+    struct TrackAddressing {
+        std::map<DeviceId, std::set<ChainId>> padChains;    // grid device id -> its pad chain ids
+        std::map<RackId, std::set<ChainId>> topLevelRacks;  // rack id -> its chain ids
+        std::vector<ChainNodePath*> paths;
+    };
+
+    const auto collectLinks = [](MacroArray& macros, ModArray& mods,
+                                 std::vector<ChainNodePath*>& out) {
+        for (auto& macro : macros)
+            for (auto& link : macro.links)
+                out.push_back(&link.target.devicePath);
+        for (auto& mod : mods)
+            for (auto& link : mod.links)
+                out.push_back(&link.target.devicePath);
+    };
+
+    const auto survey = [&](TrackInfo& track, TrackAddressing& addressing) {
+        collectLinks(track.macros, track.mods, addressing.paths);
+
+        std::function<void(std::vector<ChainElement>&, bool)> walk =
+            [&](std::vector<ChainElement>& elements, bool topLevel) {
+                for (auto& element : elements) {
+                    if (isRack(element)) {
+                        auto& rack = getRack(element);
+                        collectLinks(rack.macros, rack.mods, addressing.paths);
+                        for (auto& chain : rack.chains) {
+                            if (topLevel)
+                                addressing.topLevelRacks[rack.id].insert(chain.id);
+                            walk(chain.elements, false);
+                        }
+                        continue;
+                    }
+
+                    auto& device = getDevice(element);
+                    collectLinks(device.macros, device.mods, addressing.paths);
+                    if (!device.pads)
+                        continue;
+
+                    for (auto& pad : device.pads->chains) {
+                        addressing.padChains[device.id].insert(pad.id);
+                        walk(pad.elements, false);
+                    }
+                }
+            };
+
+        walk(track.chain.fxChainElements, true);
+        for (auto& element : track.chain.postFxChainElements)
+            collectLinks(element.device.macros, element.device.mods, addressing.paths);
+        for (auto& element : track.chain.mixerAnalysisElements)
+            collectLinks(element.device.macros, element.device.mods, addressing.paths);
+    };
+
+    const auto retype = [](const TrackAddressing& addressing, ChainNodePath& path) {
+        if (path.steps.size() < 2 || path.steps[0].type != ChainStepType::Rack ||
+            path.steps[1].type != ChainStepType::Chain)
+            return;
+
+        const auto rack = addressing.topLevelRacks.find(path.steps[0].id);
+        if (rack != addressing.topLevelRacks.end() && rack->second.contains(path.steps[1].id))
+            return;  // An allocated rack accounts for it, exactly as it used to.
+
+        const auto pads = addressing.padChains.find(path.steps[0].id);
+        if (pads == addressing.padChains.end() || !pads->second.contains(path.steps[1].id))
+            return;
+
+        path.steps[0].type = ChainStepType::PadRack;
+        path.steps[1].type = ChainStepType::PadChain;
+    };
+
+    const auto migrateTrack = [&](TrackInfo& track) {
+        TrackAddressing addressing;
+        survey(track, addressing);
+
+        for (auto& lane : lanes)
+            if (lane.target.devicePath.trackId == track.id)
+                addressing.paths.push_back(&lane.target.devicePath);
+
+        for (auto* path : addressing.paths)
+            retype(addressing, *path);
+    };
+
+    for (auto& track : tracks)
+        migrateTrack(track);
+    if (masterTrack != nullptr)
+        migrateTrack(*masterTrack);
+}
+
+}  // namespace magda::pad_paths

--- a/magda/daw/core/PadPathMigration.hpp
+++ b/magda/daw/core/PadPathMigration.hpp
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <vector>
+
+namespace magda {
+
+struct TrackInfo;
+struct AutomationLaneInfo;
+
+/**
+ * Load-time migration of pad addresses saved before pad ownership was a step
+ * type (#2219).
+ *
+ * A pad device's address has always named its owning Drum Grid by that device's
+ * own id. Before `ChainStepType::PadRack` and `ChainStepType::PadChain` existed
+ * it was spelled `Rack(gridDeviceId) > Chain(pad)`, which is character for
+ * character how an allocated rack of the same number is spelled. Rack ids and
+ * device ids come out of counters that both start at 1, so a stored link could
+ * only be resolved by trying the ordinary rack route first and the pad route
+ * second, and every remapper had to recognise pads by the shape of the path.
+ *
+ * The migration keeps that resolution order as its tie-break and then writes
+ * the answer down, so a project resolves exactly as it did before and leaves
+ * the ambiguity behind the next time it is saved.
+ */
+namespace pad_paths {
+
+/**
+ * @brief Retype every legacy pad address in a staged project.
+ *
+ * A leading `Rack > Chain` pair is retyped only when no top-level rack of the
+ * track can account for it and a pad-owning device on that track can. Anything
+ * past the pair is an ordinary route through the pad chain's own elements and
+ * was never ambiguous, so it is left alone.
+ *
+ * Runs after pad device ids are allocated, because a pad chain is matched by
+ * the id of the device that owns it.
+ */
+void migrateLegacyPadPaths(std::vector<TrackInfo>& tracks, TrackInfo* masterTrack,
+                           std::vector<AutomationLaneInfo>& lanes);
+
+}  // namespace pad_paths
+
+}  // namespace magda

--- a/magda/daw/core/TrackCommands.cpp
+++ b/magda/daw/core/TrackCommands.cpp
@@ -582,12 +582,17 @@ void PasteChainElementsCommand::execute() {
     if (!track)
         return;
 
-    const auto& destinationElements =
-        destinationChainPath_.steps.empty()
-            ? track->chain.fxChainElements
-            : tm.getChain(destinationChainPath_.trackId, destinationChainPath_.getRackId(),
-                          destinationChainPath_.getChainId())
-                  ->elements;
+    // By path rather than by extracted ids: the destination can be nested to any
+    // depth, and it can be a pad chain, whose owner step is a DeviceId that no
+    // rack lookup answers to (#2219).
+    const auto* destinationChain =
+        destinationChainPath_.steps.empty() ? nullptr : tm.getChainByPath(destinationChainPath_);
+    if (!destinationChainPath_.steps.empty() && destinationChain == nullptr)
+        return;
+
+    const auto& destinationElements = destinationChainPath_.steps.empty()
+                                          ? track->chain.fxChainElements
+                                          : destinationChain->elements;
     const int start = std::clamp(requestedIndex, 0, static_cast<int>(destinationElements.size()));
     for (int i = 0; i < static_cast<int>(templateElements_.size()) &&
                     start + i < static_cast<int>(destinationElements.size());

--- a/magda/daw/core/TrackManager.cpp
+++ b/magda/daw/core/TrackManager.cpp
@@ -25,23 +25,12 @@ namespace magda {
 
 namespace {
 
-/// What one pad-per-chain device's pads were re-keyed to.
-struct DuplicatePadRemap {
-    DeviceId newOwnerId = INVALID_DEVICE_ID;
-    std::map<DeviceId, DeviceId> devices;  ///< old pad DeviceId -> new
-    /// The owner's pad chain ids. Unchanged by duplication, and what tells a
-    /// pad prefix from a rack that merely shares the owner's number.
-    std::set<ChainId> chains;
-};
-
 struct DuplicateIdRemap {
     TrackId oldTrackId = INVALID_TRACK_ID;
     TrackId newTrackId = INVALID_TRACK_ID;
     std::map<DeviceId, DeviceId> devices;
     std::map<RackId, RackId> racks;
     std::map<ChainId, ChainId> chains;
-    /// Keyed by the OLD DeviceId of the device that owns the pads.
-    std::map<DeviceId, DuplicatePadRemap> pads;
 };
 
 template <typename Id> bool remapDuplicateId(const std::map<Id, Id>& ids, int& value) {
@@ -52,76 +41,8 @@ template <typename Id> bool remapDuplicateId(const std::map<Id, Id>& ids, int& v
     return true;
 }
 
-/// Rewrite @p path if it addresses a pad device, and say whether it did.
-///
-/// A pad device's address is `Rack(gridDeviceId) > Chain(pad) > Device(pad
-/// device)`. None of its three steps may go through the ordinary maps:
-///
-///  - The rack step is a DeviceId, and rack ids come out of a counter that also
-///    starts at 1, so `remap.racks` would send it to whatever rack shares the
-///    number.
-///  - The chain step is a pad chain id, rack-local and untouched by
-///    duplication, so `remap.chains` would move it for the same reason.
-///
-/// Both ends are matched before either is rewritten, so a link that merely
-/// passes through a rack numbered like a grid is left to the ordinary remap
-/// (#2207).
-bool remapDuplicatedPadPath(ChainNodePath& path, const DuplicateIdRemap& remap) {
-    if (path.steps.size() < 3 || path.steps[0].type != ChainStepType::Rack ||
-        path.steps[1].type != ChainStepType::Chain)
-        return false;
-
-    const auto owner = remap.pads.find(path.steps[0].id);
-    if (owner == remap.pads.end())
-        return false;
-
-    // A pad device, named directly by the pad's chain.
-    if (path.steps.size() == 3 && path.steps[2].type == ChainStepType::Device) {
-        const auto device = owner->second.devices.find(path.steps[2].id);
-        if (device == owner->second.devices.end())
-            return false;
-
-        path.trackId = remap.newTrackId;
-        path.steps[0].id = owner->second.newOwnerId;
-        path.steps[2].id = device->second;
-        return true;
-    }
-
-    // Or something further down, inside a rack the pad's chain holds. The
-    // prefix is still the pad's; what follows is an ordinary route and moves
-    // with the ordinary maps.
-    if (!owner->second.chains.contains(path.steps[1].id))
-        return false;
-
-    path.trackId = remap.newTrackId;
-    path.steps[0].id = owner->second.newOwnerId;
-
-    for (std::size_t index = 2; index < path.steps.size(); ++index) {
-        auto& step = path.steps[index];
-        switch (step.type) {
-            case ChainStepType::Rack:
-                remapDuplicateId(remap.racks, step.id);
-                break;
-            case ChainStepType::Chain:
-                remapDuplicateId(remap.chains, step.id);
-                break;
-            case ChainStepType::Device:
-                remapDuplicateId(remap.devices, step.id);
-                break;
-            case ChainStepType::Segment:
-                break;
-        }
-    }
-    return true;
-}
-
 void remapDuplicatedPath(ChainNodePath& path, const DuplicateIdRemap& remap) {
     if (!path.isValid())
-        return;
-
-    // Pads first, and nothing else runs for one: every step of a pad path would
-    // be moved by the wrong map.
-    if (remapDuplicatedPadPath(path, remap))
         return;
 
     bool touched = false;
@@ -144,6 +65,15 @@ void remapDuplicatedPath(ChainNodePath& path, const DuplicateIdRemap& remap) {
             case ChainStepType::Device:
                 touched = remapDuplicateId(remap.devices, step.id) || touched;
                 break;
+            case ChainStepType::PadRack:
+                // A PadRack step carries the owning grid's DeviceId, so it moves
+                // with the devices map like any other device id. Saying so in
+                // the type is what removed the shape-matching pad remapper this
+                // used to need (#2219).
+                touched = remapDuplicateId(remap.devices, step.id) || touched;
+                break;
+            case ChainStepType::PadChain:
+                break;  // Pad chain ids are rack-local and survive duplication
             case ChainStepType::Segment:
                 break;  // Segment steps carry no remappable ID
         }
@@ -1077,40 +1007,23 @@ TrackId TrackManager::duplicateTrack(TrackId trackId, bool includeDevices) {
                 // no longer be the one derived from its device id, which is how
                 // every pad path is built (#2207).
                 if (device.pads) {
-                    // The synthetic negative id is safe in the shared rack map;
-                    // the grid's own DeviceId, which is what a pad path actually
-                    // spells its rack step with, is not. That one is recorded as
-                    // a pad remap so `remapDuplicatedPadPath` can rewrite a whole
-                    // pad path at once, wherever the link that carries it lives:
-                    // on the grid, on a rack, or on the track (#2207).
+                    // The synthetic negative id is what `RackInfo::id` holds and
+                    // is safe in the shared rack map. The grid's own DeviceId,
+                    // which is what a pad path spells its owner step with, moves
+                    // with the devices map above instead -- a PadRack step says
+                    // it is a DeviceId, so nothing has to keep a second map to
+                    // tell it apart from a rack sharing the number (#2219).
                     remap.racks[padRackIdFor(oldDeviceId)] = padRackIdFor(device.id);
 
                     stampPadRackId(device);
 
-                    DuplicatePadRemap pads;
-                    pads.newOwnerId = device.id;
-
-                    for (auto& pad : device.pads->chains) {
-                        pads.chains.insert(pad.id);
-
-                        // The devices directly on the pad are the ones a pad
-                        // path names, so their old ids are noted before the walk
-                        // replaces them. Anything deeper is inside an ordinary
-                        // rack and moves with the ordinary maps, which is why
-                        // the walk runs over the whole chain rather than only
-                        // its devices.
-                        std::vector<DeviceId> padDeviceIds;
-                        for (const auto& padElement : pad.elements)
-                            if (magda::isDevice(padElement))
-                                padDeviceIds.push_back(magda::getDevice(padElement).id);
-
+                    // A pad's own elements are re-keyed by the ordinary walk:
+                    // the devices on it land in `remap.devices` like any other,
+                    // and its chain id is rack-local and stays as it is, which
+                    // is what keeps a macro, a mod or an automation lane naming
+                    // one still naming it.
+                    for (auto& pad : device.pads->chains)
                         reassignIds(pad.elements);
-
-                        for (const auto padDeviceId : padDeviceIds)
-                            pads.devices[padDeviceId] = remap.devices[padDeviceId];
-                    }
-
-                    remap.pads[oldDeviceId] = std::move(pads);
                 }
             } else if (magda::isRack(element)) {
                 auto& rack = magda::getRack(element);
@@ -2679,6 +2592,12 @@ RackInfo* TrackManager::getRackByPath(const ChainNodePath& rackPath) {
         const bool isLast = index + 1 == rackPath.steps.size();
 
         switch (step.type) {
+            // A PadRack names a device rather than a chain element, so
+            // `findRackAmong` will not find it and this returns null, which is
+            // what a Rack step carrying a grid's id did before the pad types
+            // existed. Pads are reached through `getPads()` and
+            // `getDeviceInPadByPath()` instead (#2219).
+            case ChainStepType::PadRack:
             case ChainStepType::Rack: {
                 // Valid at track level, or immediately inside a chain. A Rack
                 // straight after a Rack is the sideways move above.
@@ -2696,6 +2615,7 @@ RackInfo* TrackManager::getRackByPath(const ChainNodePath& rackPath) {
                 currentChain = nullptr;  // Reset chain context
                 break;
             }
+            case ChainStepType::PadChain:
             case ChainStepType::Chain: {
                 // Only ever directly inside a rack. A Chain after a Chain would
                 // hop between siblings.
@@ -2811,6 +2731,11 @@ void TrackManager::removeChainByPath(const ChainNodePath& chainPath) {
 }
 
 ChainInfo* TrackManager::getChainByPath(const ChainNodePath& chainPath) {
+    // A pad chain hangs off a device rather than off a rack in the chain tree,
+    // and its typed address says so, so it needs no walk (#2219).
+    if (chainPath.isPadOwned())
+        return getChainInPadByPath(chainPath);
+
     if (chainPath.steps.empty() || chainPath.steps.back().type != ChainStepType::Chain)
         return nullptr;
 
@@ -3023,10 +2948,12 @@ TrackManager::ResolvedPath TrackManager::resolvePath(const ChainNodePath& path) 
         const auto& step = path.steps[i];
 
         switch (step.type) {
+            case ChainStepType::PadRack:
             case ChainStepType::Rack: {
                 // A top-level rack lives in the track's own list, a nested one
-                // in the chain the previous step reached; either way a device's
-                // pads answer to a Rack step too (#2207).
+                // in the chain the previous step reached. A PadRack names a
+                // device, so it finds nothing here and contributes no name,
+                // exactly as the untyped spelling did (#2219).
                 const auto& elements =
                     currentChain != nullptr ? currentChain->elements : track->chain.fxChainElements;
                 if (const auto* found = findRackAmong(elements, step.id)) {
@@ -3036,6 +2963,7 @@ TrackManager::ResolvedPath TrackManager::resolvePath(const ChainNodePath& path) 
                 }
                 break;
             }
+            case ChainStepType::PadChain:
             case ChainStepType::Chain: {
                 if (currentRack != nullptr) {
                     for (const auto& chain : currentRack->chains) {

--- a/magda/daw/core/TrackManager.hpp
+++ b/magda/daw/core/TrackManager.hpp
@@ -466,6 +466,12 @@ class TrackManager : public daw::audio::DeviceIdAllocator, public daw::audio::De
     /// through the generic lookup like any other device path (#2211).
     DeviceInfo* getDeviceInPadByPath(const ChainNodePath& devicePath);
 
+    /// The pad chain @p chainPath names, or null when it names none.
+    ///
+    /// `getChainByPath()` dispatches to this for a pad-owned address, so a pad
+    /// chain is looked up through the generic call like any other chain (#2219).
+    ChainInfo* getChainInPadByPath(const ChainNodePath& chainPath);
+
     /// Replace those pads wholesale. Undo's counterpart to every pad edit
     /// below, which is why it lives with them rather than on the command
     /// (`EditPadsCommand`, #2211).

--- a/magda/daw/core/TrackManagerDevices.cpp
+++ b/magda/daw/core/TrackManagerDevices.cpp
@@ -1258,11 +1258,19 @@ DeviceInfo* TrackManager::getDeviceInPadByPath(const ChainNodePath& devicePath) 
 }
 
 ChainInfo* TrackManager::getChainInPadByPath(const ChainNodePath& chainPath) {
-    // `PadRack(gridDeviceId) > PadChain(pad)` and nothing after it: a pad chain
-    // is the whole of a pad-owned address, and anything deeper names something
-    // inside the chain rather than the chain (#2219).
-    if (chainPath.steps.size() != 2 || !chainPath.isPadOwned() ||
+    // `PadRack(gridDeviceId) > PadChain(pad)` and then ordinary `Rack > Chain`
+    // pairs: a pad's chain holds racks like any other chain does, and their
+    // chains are addressable. Stopping at the pad chain would leave
+    // `getElementContainerForChainPath()` unable to name them, so copy, move,
+    // remove, wrap, insert and paste could not act on anything inside a rack
+    // nested under a pad even though device lookup resolves the same route
+    // (#2219).
+    if (!chainPath.isPadOwned() || chainPath.steps.size() < 2 ||
         chainPath.getPadChainId() == INVALID_CHAIN_ID)
+        return nullptr;
+
+    // The tail is whole pairs, and the address ends on the chain it names.
+    if ((chainPath.steps.size() - 2) % 2 != 0)
         return nullptr;
 
     auto* track = getTrack(chainPath.trackId);
@@ -1273,11 +1281,40 @@ ChainInfo* TrackManager::getChainInPadByPath(const ChainNodePath& chainPath) {
     if (owner == nullptr)
         return nullptr;
 
-    for (auto& pad : owner->pads->chains)
-        if (pad.id == chainPath.getPadChainId())
-            return &pad;
+    ChainInfo* current = nullptr;
+    for (auto& pad : owner->pads->chains) {
+        if (pad.id == chainPath.getPadChainId()) {
+            current = &pad;
+            break;
+        }
+    }
+    if (current == nullptr)
+        return nullptr;
 
-    return nullptr;
+    for (std::size_t index = 2; index < chainPath.steps.size(); index += 2) {
+        const auto& rackStep = chainPath.steps[index];
+        const auto& chainStep = chainPath.steps[index + 1];
+        if (rackStep.type != ChainStepType::Rack || chainStep.type != ChainStepType::Chain)
+            return nullptr;
+
+        ChainInfo* next = nullptr;
+        for (auto& element : current->elements) {
+            if (!magda::isRack(element) || magda::getRack(element).id != rackStep.id)
+                continue;
+            for (auto& chain : magda::getRack(element).chains) {
+                if (chain.id == chainStep.id) {
+                    next = &chain;
+                    break;
+                }
+            }
+            break;
+        }
+        if (next == nullptr)
+            return nullptr;
+        current = next;
+    }
+
+    return current;
 }
 
 const DeviceInfo* TrackManager::getDeviceInChainByPath(const ChainNodePath& devicePath) const {

--- a/magda/daw/core/TrackManagerDevices.cpp
+++ b/magda/daw/core/TrackManagerDevices.cpp
@@ -17,21 +17,11 @@ namespace magda {
 
 namespace {
 
-struct PresetPadRemap {
-    DeviceId newOwnerId = INVALID_DEVICE_ID;
-    std::map<DeviceId, DeviceId> devices;
-    /// The owner's pad chain ids. Unchanged by copying, and what tells a pad
-    /// prefix from a rack that merely shares the owner's number.
-    std::set<ChainId> chains;
-};
-
 struct PresetIdRemap {
     TrackId trackId = INVALID_TRACK_ID;
     std::map<DeviceId, DeviceId> devices;
     std::map<RackId, RackId> racks;
     std::map<ChainId, ChainId> chains;
-    /// Keyed by the OLD DeviceId of the device that owns the pads.
-    std::map<DeviceId, PresetPadRemap> pads;
 };
 
 template <typename Id> bool remapId(std::map<Id, Id> const& ids, int& value) {
@@ -39,65 +29,6 @@ template <typename Id> bool remapId(std::map<Id, Id> const& ids, int& value) {
     if (it == ids.end())
         return false;
     value = it->second;
-    return true;
-}
-
-/// Rewrite @p path if it addresses a pad device, and say whether it did.
-///
-/// The same shape `remapDuplicatedPadPath()` handles for a duplicated track,
-/// and for the same reason: a pad device's address is
-/// `Rack(gridDeviceId) > Chain(pad) > Device(padDevice)`, and none of its steps
-/// may go through the ordinary maps. The rack step is a DeviceId, and rack ids
-/// come out of a counter that also starts at 1; the chain step is a pad chain
-/// id, rack-local and untouched by copying. Both ends are matched before either
-/// is rewritten, so a link merely passing through a rack numbered like a grid
-/// is left to the ordinary remap (#2211).
-bool remapPresetPadPath(ChainNodePath& path, const PresetIdRemap& remap) {
-    if (path.steps.size() < 3 || path.steps[0].type != ChainStepType::Rack ||
-        path.steps[1].type != ChainStepType::Chain)
-        return false;
-
-    const auto owner = remap.pads.find(path.steps[0].id);
-    if (owner == remap.pads.end())
-        return false;
-
-    // A pad device, named directly by the pad's chain.
-    if (path.steps.size() == 3 && path.steps[2].type == ChainStepType::Device) {
-        const auto device = owner->second.devices.find(path.steps[2].id);
-        if (device == owner->second.devices.end())
-            return false;
-
-        path.trackId = remap.trackId;
-        path.steps[0].id = owner->second.newOwnerId;
-        path.steps[2].id = device->second;
-        return true;
-    }
-
-    // Or something further down, inside a rack the pad's chain holds. The
-    // prefix is still the pad's and still has to come from the pad map; what
-    // follows is an ordinary route and was re-keyed with the ordinary ones.
-    if (!owner->second.chains.contains(path.steps[1].id))
-        return false;
-
-    path.trackId = remap.trackId;
-    path.steps[0].id = owner->second.newOwnerId;
-
-    for (std::size_t index = 2; index < path.steps.size(); ++index) {
-        auto& step = path.steps[index];
-        switch (step.type) {
-            case ChainStepType::Rack:
-                remapId(remap.racks, step.id);
-                break;
-            case ChainStepType::Chain:
-                remapId(remap.chains, step.id);
-                break;
-            case ChainStepType::Device:
-                remapId(remap.devices, step.id);
-                break;
-            case ChainStepType::Segment:
-                break;
-        }
-    }
     return true;
 }
 
@@ -127,11 +58,6 @@ void retargetPresetLinks(MacroArray& macros, ModArray& mods, DeviceId presetDevi
 void remapPresetPath(ChainNodePath& path, const PresetIdRemap& remap) {
     bool touched = false;
 
-    // Pads first, and nothing else runs for one: every step of a pad path would
-    // be moved by the wrong map.
-    if (remapPresetPadPath(path, remap))
-        return;
-
     if (path.isTrackLevel) {
         path.trackId = remap.trackId;
         return;
@@ -151,6 +77,15 @@ void remapPresetPath(ChainNodePath& path, const PresetIdRemap& remap) {
             case ChainStepType::Device:
                 touched = remapId(remap.devices, step.id) || touched;
                 break;
+            case ChainStepType::PadRack:
+                // A PadRack step carries the owning grid's DeviceId, so it moves
+                // with the devices map like any other device id. Saying so in
+                // the type is what removed the shape-matching pad remapper this
+                // used to need (#2219).
+                touched = remapId(remap.devices, step.id) || touched;
+                break;
+            case ChainStepType::PadChain:
+                break;  // Pad chain ids are rack-local and survive the copy
             case ChainStepType::Segment:
                 break;  // Segment steps carry no remappable ID
         }
@@ -772,26 +707,14 @@ static void reassignCopiedElementIds(TrackManager& tm, std::vector<ChainElement>
                 // a mod or an automation lane naming one still naming it.
                 if (device.pads) {
                     stampPadRackId(device);
-                    auto& padRemap = remap.pads[oldId];
-                    padRemap.newOwnerId = device.id;
 
-                    for (auto& pad : device.pads->chains) {
-                        padRemap.chains.insert(pad.id);
-
-                        // The devices directly on the pad are the ones a pad
-                        // path names, so their old ids are noted before the walk
-                        // replaces them. Anything deeper is inside an ordinary
-                        // rack and goes through the ordinary maps.
-                        std::vector<DeviceId> padDeviceIds;
-                        for (const auto& padElement : pad.elements)
-                            if (magda::isDevice(padElement))
-                                padDeviceIds.push_back(magda::getDevice(padElement).id);
-
+                    // A pad's own elements are re-keyed by the ordinary walk:
+                    // the devices on it land in `remap.devices` like any other,
+                    // and its chain id is rack-local and stays as it is, which
+                    // is what keeps a macro, a mod or an automation lane naming
+                    // one still naming it.
+                    for (auto& pad : device.pads->chains)
                         reassignIds(pad.elements);
-
-                        for (const auto padDeviceId : padDeviceIds)
-                            padRemap.devices[padDeviceId] = remap.devices[padDeviceId];
-                    }
                 }
             } else if (magda::isRack(element)) {
                 auto& rack = magda::getRack(element);
@@ -1272,6 +1195,12 @@ DeviceInfo* TrackManager::getDeviceInChainByPath(const ChainNodePath& devicePath
         return nullptr;
     }
 
+    // A typed pad address says outright that its owner step is a DeviceId, so
+    // it goes straight to the pad route rather than walking a rack tree that
+    // cannot contain it (#2219).
+    if (devicePath.isPadOwned())
+        return getDeviceInPadByPath(devicePath);
+
     // Otherwise, device is inside a chain
     if (auto* chain = getChainFromPath(*this, chainPath)) {
         for (auto& element : chain->elements) {
@@ -1281,28 +1210,36 @@ DeviceInfo* TrackManager::getDeviceInChainByPath(const ChainNodePath& devicePath
         }
     }
 
+    // Last: an untyped pad address from a project saved before the pad step
+    // types. Ordering is the tie-break, as it always was.
     return getDeviceInPadByPath(devicePath);
 }
 
 DeviceInfo* TrackManager::getDeviceInPadByPath(const ChainNodePath& devicePath) {
-    // A pad device's chain is not in the rack tree. Its address spells the Rack
-    // step with the owning device's id, and a pad rack is `DeviceInfo::pads`
-    // rather than a chain element, so `getRackByPath()` cannot follow it and
-    // was never meant to (#2207).
+    // A pad device's chain is not in the rack tree. Its address names the
+    // owning device by that device's own id, and a pad rack is
+    // `DeviceInfo::pads` rather than a chain element, so `getRackByPath()`
+    // cannot follow it and was never meant to (#2207).
     //
-    // Tried only after the ordinary route has failed, so an allocated rack that
-    // shares the number resolves exactly as it did before. That ordering is
-    // what makes this unambiguous rather than a guess: every device in the
-    // Rack > Chain > Device space comes out of one counter, so the leaf id
-    // names one device in the whole project, and whichever route reaches it
-    // reaches the same one (#2211).
-    // `Rack(gridDeviceId) > Chain(pad)` is the synthetic prefix; everything past
-    // it is an ordinary route, because a pad's chain holds racks like any other
+    // `PadRack(gridDeviceId) > PadChain(pad)` is the prefix; everything past it
+    // is an ordinary route, because a pad's chain holds racks like any other
     // chain does and every walk that reaches a pad recurses through them.
+    //
+    // Two spellings are accepted. The typed one is what `padChainPath()` builds
+    // and what `getDeviceInChainByPath()` dispatches on directly, because the
+    // types say the leading id is a DeviceId and no allocated rack can be
+    // confused with it. The untyped `Rack > Chain` one is what projects saved
+    // before the pad step types carry; `migrateStagedPadPaths()` retypes those
+    // on load, and until a project is re-saved this still resolves them, tried
+    // only after the ordinary rack route has failed so an allocated rack
+    // sharing the number wins exactly as it used to (#2219).
     if (devicePath.steps.size() < 3)
         return nullptr;
-    if (devicePath.steps[0].type != ChainStepType::Rack ||
-        devicePath.steps[1].type != ChainStepType::Chain)
+    const bool typed = devicePath.steps[0].type == ChainStepType::PadRack &&
+                       devicePath.steps[1].type == ChainStepType::PadChain;
+    const bool legacy = devicePath.steps[0].type == ChainStepType::Rack &&
+                        devicePath.steps[1].type == ChainStepType::Chain;
+    if (!typed && !legacy)
         return nullptr;
 
     auto* track = getTrack(devicePath.trackId);
@@ -1316,6 +1253,29 @@ DeviceInfo* TrackManager::getDeviceInPadByPath(const ChainNodePath& devicePath) 
     for (auto& pad : owner->pads->chains)
         if (pad.id == devicePath.steps[1].id)
             return followChainSteps(pad.elements, devicePath, 2);
+
+    return nullptr;
+}
+
+ChainInfo* TrackManager::getChainInPadByPath(const ChainNodePath& chainPath) {
+    // `PadRack(gridDeviceId) > PadChain(pad)` and nothing after it: a pad chain
+    // is the whole of a pad-owned address, and anything deeper names something
+    // inside the chain rather than the chain (#2219).
+    if (chainPath.steps.size() != 2 || !chainPath.isPadOwned() ||
+        chainPath.getPadChainId() == INVALID_CHAIN_ID)
+        return nullptr;
+
+    auto* track = getTrack(chainPath.trackId);
+    if (track == nullptr)
+        return nullptr;
+
+    auto* owner = findPadOwner(track->chain.fxChainElements, chainPath.getPadOwnerDeviceId());
+    if (owner == nullptr)
+        return nullptr;
+
+    for (auto& pad : owner->pads->chains)
+        if (pad.id == chainPath.getPadChainId())
+            return &pad;
 
     return nullptr;
 }

--- a/magda/daw/core/TrackManagerPads.cpp
+++ b/magda/daw/core/TrackManagerPads.cpp
@@ -17,12 +17,11 @@ namespace magda {
 // path and takes `DeviceInfo::pads`.
 //
 // Never through a Rack step. A pad's engine address spells the rack component
-// with the grid's own DeviceId (`padChainPath`), and rack ids and device ids
-// come out of counters that both start at 1, so `Rack(1)` is as much rack 1 as
-// it is Drum Grid 1's pads. Resolving a pad edit that way would send it to an
-// unrelated rack whenever the two numbers met. The address is kept for what it
-// has always been used for, an exact-match key and a stored link target, and
-// the model is reached the unambiguous way.
+// with the grid's own DeviceId, under the distinct `PadRack`/`PadChain` step
+// types (`padChainPath`). Rack ids and device ids come out of counters that
+// both start at 1, so an untyped `Rack(1)` would be as much rack 1 as it is
+// Drum Grid 1's pads; the types keep the two apart without anyone having to
+// inspect the model or count steps (#2219).
 // ============================================================================
 
 namespace {
@@ -60,26 +59,23 @@ void clearSelectionsUnder(const std::vector<ChainElement>& elements,
 }  // namespace
 
 ChainNodePath TrackManager::padChainPath(const ChainNodePath& gridPath, ChainId padChainId) {
-    // Flat, and named by the DEVICE's own id: `Rack(gridDeviceId) > Chain(pad)`,
-    // whatever the grid itself is nested in.
+    // Flat, and named by the DEVICE's own id: `PadRack(gridDeviceId) >
+    // PadChain(pad)`, whatever the grid itself is nested in.
     //
-    // This is the shape a pad device's address has always had, and three other
-    // things build or store it: the ADSR macro links the slicer generates
-    // (ClipCommands), the addresses the native parameter table compiles
-    // (ParamTableCompiler), and every link a project has already saved. A
-    // plugin lookup is an exact path match, so a different spelling here would
-    // leave all of them pointing at nothing (#2207).
+    // The step types say which id is which, so a resolver or a remapper never
+    // has to infer pad ownership from the path's shape and can never confuse a
+    // grid's DeviceId with the RackId of an allocated rack sharing the number
+    // (#2219).
     //
     // The synthetic negative id is still what `RackInfo::id` holds, because the
     // plan keys its ops on it and `isPadRackId()` is how the executor tells a
     // pad rack from an allocated one.
     //
     // `getRackByPath()` does not resolve this: a pad rack is a field on a
-    // device rather than a chain element, and the Rack step here carries the
-    // device's id rather than the rack's. `getDeviceInChainByPath()` follows it
-    // through `getDeviceInPadByPath()`, tried after the ordinary rack route so
-    // an allocated rack sharing the number is unaffected (#2211).
-    return ChainNodePath::chain(gridPath.trackId, gridPath.getDeviceId(), padChainId);
+    // device rather than a chain element. `getDeviceInChainByPath()` follows it
+    // through `getDeviceInPadByPath()`, which now dispatches on the step type
+    // rather than trying the pad route as a fallback.
+    return ChainNodePath::padChain(gridPath.trackId, gridPath.getDeviceId(), padChainId);
 }
 
 RackInfo* TrackManager::getPads(const ChainNodePath& gridPath) {

--- a/magda/daw/core/aliases/ChainContext.cpp
+++ b/magda/daw/core/aliases/ChainContext.cpp
@@ -63,7 +63,7 @@ ChainNodePath DefaultChainContext::focusedMacroOwner() const {
             return path;
         case ChainNodeType::Chain: {
             for (int i = static_cast<int>(path.steps.size()) - 1; i >= 0; --i) {
-                if (path.steps[i].type == ChainStepType::Rack) {
+                if (isRackStep(path.steps[i].type)) {
                     ChainNodePath rackPath;
                     rackPath.trackId = path.trackId;
                     rackPath.steps.assign(path.steps.begin(), path.steps.begin() + i + 1);

--- a/magda/daw/project/serialization/ProjectSerializer.cpp
+++ b/magda/daw/project/serialization/ProjectSerializer.cpp
@@ -4,6 +4,8 @@
 
 #include <algorithm>
 #include <functional>
+#include <map>
+#include <set>
 #include <unordered_set>
 
 #include "../../core/AutomationManager.hpp"
@@ -11,6 +13,7 @@
 #include "../../core/DeviceParamMigrations.hpp"
 #include "../../core/DrumGridPads.hpp"
 #include "../../core/LegacyDeviceAliases.hpp"
+#include "../../core/PadPathMigration.hpp"
 #include "../../core/SelectionManager.hpp"
 #include "../../core/TrackManager.hpp"
 #include "../../core/ViewModeState.hpp"
@@ -367,6 +370,12 @@ bool ProjectSerializer::loadAndStage(const juce::File& file, StagedProjectData& 
         // a Drum Grid with no pads at all (#2207).
         allocateStagedPadDeviceIds(outData.tracks, outData.masterTrack.get());
 
+        // Then the pad addresses saved before pad ownership was a step type.
+        // After the id allocation above, because a pad chain is matched by the
+        // id of the device that owns it (#2219).
+        pad_paths::migrateLegacyPadPaths(outData.tracks, outData.masterTrack.get(),
+                                         outData.automationLanes);
+
         // Parameter aliases (UserProject layer -- opaque pass-through to AliasRegistry)
         if (obj->hasProperty("paramAliases"))
             outData.info.paramAliases = obj->getProperty("paramAliases");
@@ -678,6 +687,10 @@ bool ProjectSerializer::deserializeProject(const juce::var& json, ProjectInfo& o
     device_param_migrations::applyParamIndexMigrations(
         stagedTracks, hasMasterTrack ? &stagedMasterTrack : nullptr, stagedAutomation,
         stagedAutomationClips);
+
+    // Then the pad addresses saved before pad ownership was a step type (#2219).
+    pad_paths::migrateLegacyPadPaths(stagedTracks, hasMasterTrack ? &stagedMasterTrack : nullptr,
+                                     stagedAutomation);
 
     // Stage 2: All components validated successfully - now commit to managers atomically
     installStagedSources(stagedSources, stagedLegacySources, stagedClips);

--- a/magda/daw/ui/components/chain/ChainPanel.cpp
+++ b/magda/daw/ui/components/chain/ChainPanel.cpp
@@ -497,9 +497,9 @@ void ChainPanel::showChain(const magda::ChainNodePath& chainPath) {
     // The path should end with a Chain step
     if (!chainPath.steps.empty()) {
         for (const auto& step : chainPath.steps) {
-            if (step.type == magda::ChainStepType::Rack) {
+            if (magda::isRackStep(step.type)) {
                 rackId_ = step.id;
-            } else if (step.type == magda::ChainStepType::Chain) {
+            } else if (magda::isChainStep(step.type)) {
                 chainId_ = step.id;
             }
         }

--- a/magda/daw/ui/components/chain/modulation/ModulationOwnerPath.hpp
+++ b/magda/daw/ui/components/chain/modulation/ModulationOwnerPath.hpp
@@ -9,7 +9,7 @@ inline magda::ChainNodePath nearestRackPathForDevicePath(const magda::ChainNodeP
     rackPath.trackId = devicePath.trackId;
     int rackStepIndex = -1;
     for (int i = 0; i < static_cast<int>(devicePath.steps.size()); ++i) {
-        if (devicePath.steps[static_cast<size_t>(i)].type == magda::ChainStepType::Rack)
+        if (magda::isRackStep(devicePath.steps[static_cast<size_t>(i)].type))
             rackStepIndex = i;
     }
     if (rackStepIndex >= 0) {

--- a/magda/daw/ui/components/chain/params/ModulationBakeAction.cpp
+++ b/magda/daw/ui/components/chain/params/ModulationBakeAction.cpp
@@ -17,7 +17,7 @@ magda::ChainNodePath enclosingRackPath(const magda::ChainNodePath& devicePath) {
     auto path = devicePath;
     path.isTrackLevel = false;
     path.topLevelDeviceId = magda::INVALID_DEVICE_ID;
-    while (!path.steps.empty() && path.steps.back().type != magda::ChainStepType::Rack)
+    while (!path.steps.empty() && !magda::isRackStep(path.steps.back().type))
         path.steps.pop_back();
     return path;
 }

--- a/magda/engine/param/ParamKey.cpp
+++ b/magda/engine/param/ParamKey.cpp
@@ -20,7 +20,7 @@ ChainSegment segmentOf(const magda::ChainNodePath& path) {
 /// at rack scope.
 RackId lastRackOf(const magda::ChainNodePath& path) {
     for (auto step = path.steps.rbegin(); step != path.steps.rend(); ++step)
-        if (step->type == magda::ChainStepType::Rack)
+        if (magda::isRackStep(step->type))
             return step->id;
     return INVALID_RACK_ID;
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -36,6 +36,7 @@ set(TEST_SOURCES
     test_chain_fingerprint.cpp
     test_chain_info_copy.cpp
     test_drum_grid_pad_commands.cpp
+    test_pad_path_types.cpp
     test_drum_grid_pads.cpp
     test_drum_grid_pads_corpus.cpp
     test_chain_routing_model.cpp

--- a/tests/test_pad_path_types.cpp
+++ b/tests/test_pad_path_types.cpp
@@ -190,6 +190,58 @@ TEST_CASE("A rack nested inside a pad chain resolves through the typed prefix",
     CHECK(resolved->id == kNested);
 }
 
+TEST_CASE("A chain inside a rack nested under a pad is addressable", "[drumgrid][pads][path]") {
+    // `getElementContainerForChainPath()` delegates to the pad chain lookup, so
+    // stopping at the pad chain would leave copy, move, remove, wrap, insert and
+    // paste unable to name anything inside a rack nested under a pad, even
+    // though the device lookup resolves the same route.
+    resetState();
+    auto& tm = TrackManager::getInstance();
+
+    const auto trackId = tm.createTrack("Drums");
+    const auto gridId = tm.addDeviceToTrack(trackId, drumGridDevice());
+    const auto gridPath = ChainNodePath::topLevelDevice(trackId, gridId);
+    REQUIRE(tm.setPadDevice(gridPath, 0, padVoice("Kick")) != INVALID_DEVICE_ID);
+
+    auto* pad = tm.getPad(gridPath, 0);
+    REQUIRE(pad != nullptr);
+    const auto padChainId = pad->id;
+
+    constexpr DeviceId kNested = 5150;
+    RackInfo inner;
+    inner.id = 91;
+    inner.name = "Pad Rack";
+    ChainInfo innerChain;
+    innerChain.id = 6;
+    innerChain.name = "Inner";
+    auto nested = padVoice("Nested");
+    nested.id = kNested;
+    innerChain.elements.push_back(makeDeviceElement(nested));
+    inner.chains.push_back(std::move(innerChain));
+    tm.getPadChain(gridPath, padChainId)->elements.push_back(makeRackElement(std::move(inner)));
+
+    const auto padChainPath = TrackManager::padChainPath(gridPath, padChainId);
+
+    // The pad chain itself.
+    const auto* root = tm.getChainByPath(padChainPath);
+    REQUIRE(root != nullptr);
+    CHECK(root->id == padChainId);
+
+    // And the chain of the rack it holds, through the same generic call.
+    const auto nestedChainPath = padChainPath.withRack(91).withChain(6);
+    const auto* nestedChain = tm.getChainByPath(nestedChainPath);
+    REQUIRE(nestedChain != nullptr);
+    CHECK(nestedChain->id == 6);
+    CHECK(nestedChain->name == "Inner");
+    REQUIRE(nestedChain->elements.size() == 1);
+    CHECK(getDevice(nestedChain->elements[0]).id == kNested);
+
+    // A rack id that names nothing under the pad resolves to nothing.
+    CHECK(tm.getChainByPath(padChainPath.withRack(92).withChain(6)) == nullptr);
+    // And so does a half pair.
+    CHECK(tm.getChainByPath(padChainPath.withRack(91)) == nullptr);
+}
+
 TEST_CASE("A pad address is answered only by the track it names",
           "[drumgrid][pads][path][master]") {
     // The pad route reaches the model through `getTrack()`, and

--- a/tests/test_pad_path_types.cpp
+++ b/tests/test_pad_path_types.cpp
@@ -361,6 +361,11 @@ TEST_CASE("Misplaced pad steps are rejected rather than loaded",
     // And a PadRack is always followed by one.
     CHECK_FALSE(fromVar(encode({{ChainStepType::PadRack, 1}, {ChainStepType::Chain, 1}}), out));
 
+    // Including when the input simply ends: a lone PadRack has no second step
+    // for the checks above to reject, and getType() would report it as an
+    // ordinary Rack whose id is really a DeviceId.
+    CHECK_FALSE(fromVar(encode({{ChainStepType::PadRack, 1}}), out));
+
     // The well-formed pair loads.
     CHECK(fromVar(encode({{ChainStepType::PadRack, 1}, {ChainStepType::PadChain, 1}}), out));
     CHECK(out.isPadOwned());

--- a/tests/test_pad_path_types.cpp
+++ b/tests/test_pad_path_types.cpp
@@ -352,6 +352,61 @@ TEST_CASE("A project saved before the pad step types still resolves and is retyp
     CHECK(migrated.isPadOwned());
 }
 
+TEST_CASE("A load retypes an address a rack answers only the prefix of",
+          "[drumgrid][pads][path][migration]") {
+    // The tie-break is the whole route, not the leading pair. A rack and a grid
+    // can share both leading numbers while the leaf device exists only on the
+    // pad, and the old resolver walked the rack tree, failed to find the leaf in
+    // the chain it landed in, and fell through to the pad route. Left untyped,
+    // duplication would move the owner id through the racks map and break the
+    // link.
+    resetState();
+    auto& tm = TrackManager::getInstance();
+
+    const auto trackId = tm.createTrack("Drums");
+    const auto rackId = tm.addRackToTrack(trackId, "FX Rack");
+    const auto rackChainId = tm.addChainToRack(ChainNodePath::rack(trackId, rackId));
+    const auto gridId = tm.addDeviceToTrack(trackId, drumGridDevice());
+    REQUIRE(rackId == gridId);
+
+    const auto gridPath = ChainNodePath::topLevelDevice(trackId, gridId);
+    const auto voiceId = tm.setPadDevice(gridPath, 0, padVoice("Kick"));
+    REQUIRE(voiceId != INVALID_DEVICE_ID);
+
+    auto* pad = tm.getPad(gridPath, 0);
+    REQUIRE(pad != nullptr);
+    tm.getPadChain(gridPath, pad->id)->id = rackChainId;
+
+    // The rack chain exists and shares both numbers, but holds nothing, so the
+    // leaf is answered only by the pad.
+    const auto* rackChain = tm.getChain(trackId, rackId, rackChainId);
+    REQUIRE(rackChain != nullptr);
+    REQUIRE(rackChain->elements.empty());
+
+    const auto typed = TrackManager::padChainPath(gridPath, rackChainId).withDevice(voiceId);
+    const auto legacy = asLegacySpelling(typed);
+
+    // Untyped, it already resolves through the pad, which is what the migration
+    // has to agree with.
+    const auto* resolved = tm.getDeviceInChainByPath(legacy);
+    REQUIRE(resolved != nullptr);
+    CHECK(resolved->id == voiceId);
+
+    auto* track = tm.getTrack(trackId);
+    REQUIRE(track != nullptr);
+    MacroLink link;
+    link.target = ControlTarget::pluginParam(legacy, 0);
+    track->macros[0].links.push_back(link);
+
+    std::vector<TrackInfo> tracks{*track};
+    std::vector<AutomationLaneInfo> lanes;
+    pad_paths::migrateLegacyPadPaths(tracks, nullptr, lanes);
+
+    const auto& migrated = tracks[0].macros[0].links[0].target.devicePath;
+    CHECK(migrated == typed);
+    CHECK(migrated.isPadOwned());
+}
+
 TEST_CASE("A load leaves an address an allocated rack can account for alone",
           "[drumgrid][pads][path][migration]") {
     // The tie-break the untyped spelling had: the ordinary rack route was tried

--- a/tests/test_pad_path_types.cpp
+++ b/tests/test_pad_path_types.cpp
@@ -1,0 +1,395 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "magda/daw/core/AutomationInfo.hpp"
+#include "magda/daw/core/ChainNodePath.hpp"
+#include "magda/daw/core/ClipManager.hpp"
+#include "magda/daw/core/ControlTarget.hpp"
+#include "magda/daw/core/MacroInfo.hpp"
+#include "magda/daw/core/PadPathMigration.hpp"
+#include "magda/daw/core/RackInfo.hpp"
+#include "magda/daw/core/SelectionManager.hpp"
+#include "magda/daw/core/TrackManager.hpp"
+#include "magda/daw/core/UndoManager.hpp"
+
+using namespace magda;
+
+// Typed pad path steps (#2219).
+//
+// A pad device's address names its owning Drum Grid by that device's own id.
+// Spelled as an ordinary `Rack > Chain` pair it was indistinguishable from a
+// route through an allocated rack that happened to share the number, so every
+// resolver and remapper recognised pads by the shape of the path and by trying
+// the routes in a fixed order. `PadRack` and `PadChain` say which id is which,
+// and these pin that the answer no longer depends on either.
+
+namespace {
+
+void resetState() {
+    ClipManager::getInstance().clearAllClips();
+    TrackManager::getInstance().clearAllTracks();
+    SelectionManager::getInstance().clearSelection();
+    UndoManager::getInstance().clearHistory();
+}
+
+DeviceInfo drumGridDevice() {
+    DeviceInfo device;
+    device.name = "Drum Grid";
+    device.pluginId = "drumgrid";
+    device.format = PluginFormat::Internal;
+    device.isInstrument = true;
+    device.deviceType = DeviceType::Instrument;
+    return device;
+}
+
+DeviceInfo padVoice(const juce::String& name) {
+    DeviceInfo device;
+    device.name = name;
+    device.pluginId = "magdasampler";
+    device.format = PluginFormat::Internal;
+    device.isInstrument = true;
+    device.deviceType = DeviceType::Instrument;
+    return device;
+}
+
+/// The untyped spelling a project saved before the pad step types existed.
+ChainNodePath asLegacySpelling(ChainNodePath path) {
+    REQUIRE(path.isPadOwned());
+    path.steps[0].type = ChainStepType::Rack;
+    path.steps[1].type = ChainStepType::Chain;
+    return path;
+}
+
+}  // namespace
+
+TEST_CASE("A pad path says which of its ids is a device and which is a chain",
+          "[drumgrid][pads][path]") {
+    resetState();
+    auto& tm = TrackManager::getInstance();
+
+    const auto trackId = tm.createTrack("Drums");
+    const auto gridId = tm.addDeviceToTrack(trackId, drumGridDevice());
+    const auto gridPath = ChainNodePath::topLevelDevice(trackId, gridId);
+    REQUIRE(tm.setPadDevice(gridPath, 0, padVoice("Kick")) != INVALID_DEVICE_ID);
+
+    const auto* pad = tm.getPad(gridPath, 0);
+    REQUIRE(pad != nullptr);
+
+    const auto padPath = TrackManager::padChainPath(gridPath, pad->id);
+    REQUIRE(padPath.steps.size() == 2);
+    CHECK(padPath.steps[0].type == ChainStepType::PadRack);
+    CHECK(padPath.steps[1].type == ChainStepType::PadChain);
+
+    CHECK(padPath.isPadOwned());
+    CHECK(padPath.getPadOwnerDeviceId() == gridId);
+    CHECK(padPath.getPadChainId() == pad->id);
+
+    // The owner id is a DeviceId, so the rack accessor must not hand it back.
+    CHECK(padPath.getRackIdAt(0) == INVALID_RACK_ID);
+    // The pad chain id is an ordinary ChainId and the chain accessor does.
+    CHECK(padPath.getChainIdAt(1) == pad->id);
+
+    // An ordinary rack path is not pad-owned whatever its numbers.
+    const auto rackPath = ChainNodePath::chain(trackId, 1, 1);
+    CHECK_FALSE(rackPath.isPadOwned());
+    CHECK(rackPath.getPadOwnerDeviceId() == INVALID_DEVICE_ID);
+    CHECK(rackPath.getPadChainId() == INVALID_CHAIN_ID);
+}
+
+TEST_CASE("A pad and a rack sharing both numbers resolve to their own devices",
+          "[drumgrid][pads][path]") {
+    // The collision the untyped spelling invited, made total: the rack's id
+    // equals the grid's DeviceId AND the rack chain's id equals the pad chain's,
+    // so the two addresses were the same sequence of numbers. Resolution used to
+    // depend on which route was tried first; now the step types decide.
+    resetState();
+    auto& tm = TrackManager::getInstance();
+
+    const auto trackId = tm.createTrack("Drums");
+    const auto rackId = tm.addRackToTrack(trackId, "FX Rack");
+    const auto rackChainId = tm.addChainToRack(ChainNodePath::rack(trackId, rackId));
+    const auto gridId = tm.addDeviceToTrack(trackId, drumGridDevice());
+    REQUIRE(rackId == gridId);  // both counters start at 1
+
+    const auto gridPath = ChainNodePath::topLevelDevice(trackId, gridId);
+    const auto padVoiceId = tm.setPadDevice(gridPath, 0, padVoice("Kick"));
+    REQUIRE(padVoiceId != INVALID_DEVICE_ID);
+
+    auto* pad = tm.getPad(gridPath, 0);
+    REQUIRE(pad != nullptr);
+
+    // Force the chain ids together too, so nothing but the types tells them
+    // apart. The pad chain id is rack-local, so this is a legal value for it.
+    tm.getPadChain(gridPath, pad->id)->id = rackChainId;
+    const auto padChainId = rackChainId;
+
+    const auto rackDeviceId = tm.addDeviceToChainByPath(
+        ChainNodePath::chain(trackId, rackId, rackChainId), padVoice("Rack Device"));
+    REQUIRE(rackDeviceId != INVALID_DEVICE_ID);
+
+    const auto padDevicePath =
+        TrackManager::padChainPath(gridPath, padChainId).withDevice(padVoiceId);
+    const auto rackDevicePath =
+        ChainNodePath::chainDevice(trackId, rackId, rackChainId, rackDeviceId);
+
+    // Identical id sequences, different step types.
+    REQUIRE(padDevicePath.steps[0].id == rackDevicePath.steps[0].id);
+    REQUIRE(padDevicePath.steps[1].id == rackDevicePath.steps[1].id);
+
+    const auto* onPad = tm.getDeviceInChainByPath(padDevicePath);
+    REQUIRE(onPad != nullptr);
+    CHECK(onPad->id == padVoiceId);
+    CHECK(onPad->name == "Kick");
+
+    const auto* onRack = tm.getDeviceInChainByPath(rackDevicePath);
+    REQUIRE(onRack != nullptr);
+    CHECK(onRack->id == rackDeviceId);
+    CHECK(onRack->name == "Rack Device");
+}
+
+TEST_CASE("A rack nested inside a pad chain resolves through the typed prefix",
+          "[drumgrid][pads][path]") {
+    resetState();
+    auto& tm = TrackManager::getInstance();
+
+    const auto trackId = tm.createTrack("Drums");
+    const auto gridId = tm.addDeviceToTrack(trackId, drumGridDevice());
+    const auto gridPath = ChainNodePath::topLevelDevice(trackId, gridId);
+    REQUIRE(tm.setPadDevice(gridPath, 1, padVoice("Tom")) != INVALID_DEVICE_ID);
+
+    auto* pad = tm.getPad(gridPath, 1);
+    REQUIRE(pad != nullptr);
+    const auto padChainId = pad->id;
+
+    // Built on the model directly: no pad command makes one today.
+    constexpr DeviceId kNested = 4242;
+    RackInfo inner;
+    inner.id = 77;
+    inner.name = "Pad Rack";
+    ChainInfo innerChain;
+    innerChain.id = 3;
+    auto nested = padVoice("Nested");
+    nested.id = kNested;
+    innerChain.elements.push_back(makeDeviceElement(nested));
+    inner.chains.push_back(std::move(innerChain));
+    tm.getPadChain(gridPath, padChainId)->elements.push_back(makeRackElement(std::move(inner)));
+
+    const auto path = tm.findDevicePath(kNested);
+    REQUIRE(path.isValid());
+
+    // The pad pair leads and stays typed; the tail is an ordinary route.
+    REQUIRE(path.steps.size() == 5);
+    CHECK(path.steps[0].type == ChainStepType::PadRack);
+    CHECK(path.steps[1].type == ChainStepType::PadChain);
+    CHECK(path.steps[2].type == ChainStepType::Rack);
+    CHECK(path.steps[3].type == ChainStepType::Chain);
+    CHECK(path.steps[4].type == ChainStepType::Device);
+    CHECK(path.getRackIdAt(2) == 77);
+
+    const auto* resolved = tm.getDeviceInChainByPath(path);
+    REQUIRE(resolved != nullptr);
+    CHECK(resolved->id == kNested);
+}
+
+TEST_CASE("A pad address is answered only by the track it names",
+          "[drumgrid][pads][path][master]") {
+    // The pad route reaches the model through `getTrack()`, and
+    // `getTrack(MASTER_TRACK_ID)` returns a real track rather than null, so the
+    // scoping has to come from the lookup rather than from the track missing.
+    resetState();
+    auto& tm = TrackManager::getInstance();
+
+    const auto trackId = tm.createTrack("Drums");
+    const auto gridId = tm.addDeviceToTrack(trackId, drumGridDevice());
+    const auto gridPath = ChainNodePath::topLevelDevice(trackId, gridId);
+    const auto voiceId = tm.setPadDevice(gridPath, 0, padVoice("Kick"));
+    REQUIRE(voiceId != INVALID_DEVICE_ID);
+
+    auto* pad = tm.getPad(gridPath, 0);
+    REQUIRE(pad != nullptr);
+
+    const auto padDevicePath = TrackManager::padChainPath(gridPath, pad->id).withDevice(voiceId);
+    REQUIRE(tm.getDeviceInChainByPath(padDevicePath) != nullptr);
+
+    // The master track exists and owns no such grid, so the same steps under it
+    // name nothing.
+    REQUIRE(tm.getTrack(MASTER_TRACK_ID) != nullptr);
+    auto onMaster = padDevicePath;
+    onMaster.trackId = MASTER_TRACK_ID;
+    CHECK(tm.getDeviceInChainByPath(onMaster) == nullptr);
+
+    // And so does a second media track that has no grid of its own.
+    const auto otherTrackId = tm.createTrack("Other");
+    auto onOther = padDevicePath;
+    onOther.trackId = otherTrackId;
+    CHECK(tm.getDeviceInChainByPath(onOther) == nullptr);
+}
+
+TEST_CASE("Duplicating a track re-points a pad link at the copy's own pad device",
+          "[drumgrid][pads][path][duplicate]") {
+    resetState();
+    auto& tm = TrackManager::getInstance();
+
+    const auto trackId = tm.createTrack("Drums");
+    const auto gridId = tm.addDeviceToTrack(trackId, drumGridDevice());
+    const auto gridPath = ChainNodePath::topLevelDevice(trackId, gridId);
+    const auto voiceId = tm.setPadDevice(gridPath, 0, padVoice("Kick"));
+    REQUIRE(voiceId != INVALID_DEVICE_ID);
+
+    auto* pad = tm.getPad(gridPath, 0);
+    REQUIRE(pad != nullptr);
+    const auto padChainId = pad->id;
+
+    // A track macro pointing into the pad: the link a duplication has to move.
+    const auto padDevicePath = TrackManager::padChainPath(gridPath, padChainId).withDevice(voiceId);
+    {
+        auto* track = tm.getTrack(trackId);
+        REQUIRE(track != nullptr);
+        MacroLink link;
+        link.target = ControlTarget::pluginParam(padDevicePath, 0);
+        track->macros[0].links.push_back(link);
+    }
+
+    const auto cloneTrackId = tm.duplicateTrack(trackId);
+    REQUIRE(cloneTrackId != INVALID_TRACK_ID);
+
+    const auto* clone = tm.getTrack(cloneTrackId);
+    REQUIRE(clone != nullptr);
+    REQUIRE(clone->macros[0].links.size() == 1);
+    const auto& moved = clone->macros[0].links[0].target.devicePath;
+
+    // Still a pad address, and now the copy's own.
+    CHECK(moved.isPadOwned());
+    CHECK(moved.trackId == cloneTrackId);
+    CHECK(moved.getPadOwnerDeviceId() != gridId);
+    CHECK(moved.getPadChainId() == padChainId);  // rack-local, unchanged by the copy
+    CHECK(moved.getDeviceId() != voiceId);
+
+    const auto* resolved = tm.getDeviceInChainByPath(moved);
+    REQUIRE(resolved != nullptr);
+    CHECK(resolved->name == "Kick");
+
+    // And the original still names its own.
+    const auto* original = tm.getDeviceInChainByPath(padDevicePath);
+    REQUIRE(original != nullptr);
+    CHECK(original->id == voiceId);
+}
+
+TEST_CASE("A pad path survives a serialization round trip",
+          "[drumgrid][pads][path][serialization]") {
+    auto path = ChainNodePath::padChain(3, 9, 5).withRack(77).withChain(2).withDevice(41);
+
+    ChainNodePath restored;
+    REQUIRE(fromVar(toVar(path), restored));
+    CHECK(restored == path);
+    CHECK(restored.isPadOwned());
+    CHECK(restored.getPadOwnerDeviceId() == 9);
+    CHECK(restored.getPadChainId() == 5);
+    CHECK(restored.getDeviceId() == 41);
+}
+
+TEST_CASE("Misplaced pad steps are rejected rather than loaded",
+          "[drumgrid][pads][path][serialization]") {
+    const auto encode = [](const std::vector<ChainPathStep>& steps) {
+        ChainNodePath path;
+        path.trackId = 1;
+        path.steps = steps;
+        return toVar(path);
+    };
+
+    ChainNodePath out;
+
+    // PadRack is only ever the leading step.
+    CHECK_FALSE(fromVar(
+        encode({{ChainStepType::Rack, 1}, {ChainStepType::Chain, 1}, {ChainStepType::PadRack, 2}}),
+        out));
+
+    // PadChain only ever follows a PadRack.
+    CHECK_FALSE(fromVar(encode({{ChainStepType::Rack, 1}, {ChainStepType::PadChain, 1}}), out));
+
+    // And a PadRack is always followed by one.
+    CHECK_FALSE(fromVar(encode({{ChainStepType::PadRack, 1}, {ChainStepType::Chain, 1}}), out));
+
+    // The well-formed pair loads.
+    CHECK(fromVar(encode({{ChainStepType::PadRack, 1}, {ChainStepType::PadChain, 1}}), out));
+    CHECK(out.isPadOwned());
+}
+
+TEST_CASE("A project saved before the pad step types still resolves and is retyped on load",
+          "[drumgrid][pads][path][migration]") {
+    resetState();
+    auto& tm = TrackManager::getInstance();
+
+    const auto trackId = tm.createTrack("Drums");
+    const auto gridId = tm.addDeviceToTrack(trackId, drumGridDevice());
+    const auto gridPath = ChainNodePath::topLevelDevice(trackId, gridId);
+    const auto voiceId = tm.setPadDevice(gridPath, 0, padVoice("Kick"));
+    REQUIRE(voiceId != INVALID_DEVICE_ID);
+
+    auto* pad = tm.getPad(gridPath, 0);
+    REQUIRE(pad != nullptr);
+
+    const auto typed = TrackManager::padChainPath(gridPath, pad->id).withDevice(voiceId);
+    const auto legacy = asLegacySpelling(typed);
+
+    // Untyped, it still resolves: the pad route is tried after the ordinary one.
+    const auto* resolved = tm.getDeviceInChainByPath(legacy);
+    REQUIRE(resolved != nullptr);
+    CHECK(resolved->id == voiceId);
+
+    // And a load retypes it.
+    auto* track = tm.getTrack(trackId);
+    REQUIRE(track != nullptr);
+    MacroLink link;
+    link.target = ControlTarget::pluginParam(legacy, 0);
+    track->macros[0].links.push_back(link);
+
+    std::vector<TrackInfo> tracks{*track};
+    std::vector<AutomationLaneInfo> lanes;
+    pad_paths::migrateLegacyPadPaths(tracks, nullptr, lanes);
+
+    const auto& migrated = tracks[0].macros[0].links[0].target.devicePath;
+    CHECK(migrated == typed);
+    CHECK(migrated.isPadOwned());
+}
+
+TEST_CASE("A load leaves an address an allocated rack can account for alone",
+          "[drumgrid][pads][path][migration]") {
+    // The tie-break the untyped spelling had: the ordinary rack route was tried
+    // first, so a path a real rack can answer stays a rack path even when a pad
+    // could answer it too.
+    resetState();
+    auto& tm = TrackManager::getInstance();
+
+    const auto trackId = tm.createTrack("Drums");
+    const auto rackId = tm.addRackToTrack(trackId, "FX Rack");
+    const auto rackChainId = tm.addChainToRack(ChainNodePath::rack(trackId, rackId));
+    const auto gridId = tm.addDeviceToTrack(trackId, drumGridDevice());
+    REQUIRE(rackId == gridId);
+
+    const auto gridPath = ChainNodePath::topLevelDevice(trackId, gridId);
+    REQUIRE(tm.setPadDevice(gridPath, 0, padVoice("Kick")) != INVALID_DEVICE_ID);
+    auto* pad = tm.getPad(gridPath, 0);
+    REQUIRE(pad != nullptr);
+    tm.getPadChain(gridPath, pad->id)->id = rackChainId;
+
+    const auto rackDeviceId = tm.addDeviceToChainByPath(
+        ChainNodePath::chain(trackId, rackId, rackChainId), padVoice("Rack Device"));
+    REQUIRE(rackDeviceId != INVALID_DEVICE_ID);
+
+    const auto rackDevicePath =
+        ChainNodePath::chainDevice(trackId, rackId, rackChainId, rackDeviceId);
+
+    auto* track = tm.getTrack(trackId);
+    REQUIRE(track != nullptr);
+    MacroLink link;
+    link.target = ControlTarget::pluginParam(rackDevicePath, 0);
+    track->macros[0].links.push_back(link);
+
+    std::vector<TrackInfo> tracks{*track};
+    std::vector<AutomationLaneInfo> lanes;
+    pad_paths::migrateLegacyPadPaths(tracks, nullptr, lanes);
+
+    const auto& untouched = tracks[0].macros[0].links[0].target.devicePath;
+    CHECK(untouched == rackDevicePath);
+    CHECK_FALSE(untouched.isPadOwned());
+}

--- a/tests/test_remote_api_contract.cpp
+++ b/tests/test_remote_api_contract.cpp
@@ -614,6 +614,36 @@ TEST_CASE("Device paths round-trip through nested racks and chains",
         REQUIRE(toChainNodePath(dto) == path);
     }
 
+    SECTION("pad-owned steps") {
+        // A pad address names its owning Drum Grid by that device's own id, and
+        // the two step names say so rather than leaving a client to infer
+        // ownership from position.
+        const auto path = ChainNodePath::padChain(2, 9, 5).withDevice(6);
+        const auto dto = makeDevicePathDto(path);
+        REQUIRE(dto.steps.size() == 3);
+        REQUIRE(dto.steps[0].type == "pad_rack");
+        REQUIRE(dto.steps[0].id == 9);
+        REQUIRE(dto.steps[1].type == "pad_chain");
+        REQUIRE(dto.steps[1].id == 5);
+        REQUIRE(toChainNodePath(dto) == path);
+
+        // Including through a rack nested inside the pad chain.
+        const auto nested =
+            ChainNodePath::padChain(2, 9, 5).withRack(7).withChain(8).withDevice(10);
+        REQUIRE(toChainNodePath(makeDevicePathDto(nested)) == nested);
+
+        // And the published schema admits what the projection emits, so the
+        // output does not violate the contract and a client can send the same
+        // address back.
+        const auto* get = OperationRegistry::instance().find("devices.list");
+        REQUIRE(get != nullptr);
+        const DeviceGraphDto graph{{{6, 2, std::nullopt, std::nullopt, dto, "Kick", "instrument",
+                                     "internal", true, false, 0.0}},
+                                   {},
+                                   {}};
+        REQUIRE(validateJson(toJson(graph), get->outputSchema).empty());
+    }
+
     SECTION("unknown section and step types are rejected, not guessed") {
         auto dto = makeDevicePathDto(ChainNodePath::chainDevice(2, 4, 5, 6));
         dto.section = "not_a_section";


### PR DESCRIPTION
Closes #2219.

Based on `fix/2211-pad-ownership-followups` (#2213), which merges first. `padChainPath()` only exists on that branch, so this cannot sit on main until it lands.

## The problem

A pad device's address names its owning Drum Grid by that device's own id. Spelled as an ordinary `Rack > Chain` pair it was character for character how an allocated rack of the same number is spelled, and rack ids and device ids come out of counters that both start at 1. Every resolver and remapper therefore recognised pads by the shape of the path and by trying the routes in a fixed order.

## The change

`ChainStepType` gains `PadRack` and `PadChain`, appended so the persisted integer values of the existing steps stay stable. `padChainPath()` builds the typed form and the types decide from there:

- `getDeviceInChainByPath()` dispatches a pad-owned address straight to the pad route rather than walking a rack tree that cannot contain it.
- `getChainByPath()` gains the same dispatch through a new `getChainInPadByPath()`, so a pad chain is looked up through the generic call like any other chain.
- The shape-matching pad remappers in the track-duplication and preset-import paths are **removed rather than extended**. A `PadRack` step carries a DeviceId, so it moves with the ordinary devices map like any other device id; a `PadChain` step is rack-local and stays put. The pad-local id maps they needed (`DuplicatePadRemap`, `PresetPadRemap`) go with them.
- `isRackStep()` / `isChainStep()` cover the walkers that ask which rack encloses a node, so a pad path still answers them. `getRackIdAt()` stays strict, because a pad owner id is not a RackId, which turns the old silent collisions in the rack macro and modifier lookups into a clean miss.
- The remote API projects the two steps as `pad_rack` / `pad_chain`, so an external client is not left inferring ownership from position.

## Legacy projects

`pad_paths::migrateLegacyPadPaths()` retypes saved addresses on load, in its own unit beside `LegacyDeviceAliases` and `DeviceParamMigrations`. It keeps the old try-rack-then-pad order as its tie-break: a prefix a top-level rack of the track can account for is left alone, and only one a pad-owning device can account for is retyped. A project resolves exactly as it did before and leaves the ambiguity behind the next time it is saved. Until then, untyped addresses still resolve, tried after the ordinary rack route as they always were.

`fromVar` validates the pair structurally: `PadRack` only leads, `PadChain` only follows it, so the ambiguity cannot be readmitted through a hand-written file.

## Also fixed

`PasteChainElementsCommand` looked its destination chain up with `getChain(trackId, path.getRackId(), path.getChainId())` and dereferenced the result unchecked. That is a null dereference for any destination those two accessors cannot name, which now includes pad chains, and it was already wrong for a destination nested deeper than one rack. It goes through `getChainByPath()` with a guard.

## Tests

New `tests/test_pad_path_types.cpp`:

- total id collision: the rack's id equals the grid's DeviceId **and** the rack chain's id equals the pad chain's, so the two addresses are the same sequence of numbers and only the step types tell them apart. Both resolve to their own device.
- a rack nested inside a pad chain resolves, with the typed pair leading and an ordinary route as the tail.
- a pad address is answered only by the track it names, checked against the master track, which `getTrack()` returns a live track for.
- duplicating a track re-points a pad link at the copy's own pad device and leaves the original naming its own.
- serialization round trip, and rejection of misplaced pad steps.
- both migration directions: a legacy address gets retyped, and one an allocated rack can account for alone is left as it is.

Full Catch2 suite (3037 cases) and the JUCE target both pass locally.

## Follow-ups

#2220 (canonical multi-out ownership) and #2221 (one structural mutation boundary) land after this, in that order.

https://claude.ai/code/session_0187yiSdSJPmDFZafrSfbSop

