### PR TITLE
Make Drum Grid multi-out ownership canonical and instance-local

### DIFF
--- a/magda/daw/audio/plugin_manager/PluginManagerSync.cpp
+++ b/magda/daw/audio/plugin_manager/PluginManagerSync.cpp
@@ -1724,16 +1724,13 @@ void PluginManager::syncMultiOutTrack(TrackId trackId, const TrackInfo& trackInf
             TrackManager::getInstance().getDevice(link.sourceTrackId, link.sourceDeviceId);
         device != nullptr && device->multiOut.isMultiOut && link.outputPairIndex >= 0 &&
         link.outputPairIndex < static_cast<int>(device->multiOut.outputPairs.size())) {
-        auto& outPair = device->multiOut.outputPairs[static_cast<size_t>(link.outputPairIndex)];
+        const auto& outPair =
+            device->multiOut.outputPairs[static_cast<size_t>(link.outputPairIndex)];
 
-        // Restore pair state from the existing multi-out track (needed after project load,
-        // since the async plugin callback rebuilds pairs with active=false before tracks are
-        // restored)
-        if (!outPair.active || outPair.trackId != trackId) {
-            outPair.active = true;
-            outPair.trackId = trackId;
-        }
-
+        // Nothing to repair. This track's own link is the assignment, so being
+        // here already means the pair drives it; the sync used to write that
+        // back onto the device because the device held a second copy that a
+        // project load could not populate in time (#2220).
         rackInstance = instrumentRackManager_.createOutputInstance(
             link.sourceDeviceId, link.outputPairIndex, outPair.firstPin, outPair.numChannels);
         if (rackInstance) {
@@ -3008,7 +3005,8 @@ void PluginManager::syncDrumGridMultiOutTracks(const ChainNodePath& drumGridPath
 
     // Deactivate pairs that no longer have a corresponding chain
     for (int p = 1; p < static_cast<int>(pairs.size()); ++p) {
-        if (pairs[static_cast<size_t>(p)].active && activeBuses.find(p) == activeBuses.end()) {
+        if (tm.multiOutPairIsActive(trackId, deviceId, p) &&
+            activeBuses.find(p) == activeBuses.end()) {
             tm.deactivateMultiOutPair(trackId, deviceId, p);
         }
     }
@@ -3019,7 +3017,7 @@ void PluginManager::syncDrumGridMultiOutTracks(const ChainNodePath& drumGridPath
             continue;
 
         auto& pair = pairs[static_cast<size_t>(bus)];
-        if (!pair.active) {
+        if (!tm.multiOutPairIsActive(trackId, deviceId, bus)) {
             auto childTrackId = tm.activateMultiOutPair(trackId, deviceId, bus);
 
             if (childTrackId != INVALID_TRACK_ID) {
@@ -3035,14 +3033,15 @@ void PluginManager::syncDrumGridMultiOutTracks(const ChainNodePath& drumGridPath
                 if (auto* childTrack = tm.getTrack(childTrackId))
                     syncMultiOutTrack(childTrackId, *childTrack);
             }
-        } else if (pair.trackId != INVALID_TRACK_ID) {
+        } else if (const auto childTrackId = tm.multiOutChildTrack(trackId, deviceId, bus);
+                   childTrackId != INVALID_TRACK_ID) {
             // Update name if chain name changed
             auto it = busNames.find(bus);
             if (it != busNames.end()) {
                 auto newName = drumGrid->getName() + ": " + it->second;
-                if (auto* childTrack = tm.getTrack(pair.trackId)) {
+                if (auto* childTrack = tm.getTrack(childTrackId)) {
                     if (childTrack->name != newName) {
-                        tm.setTrackName(pair.trackId, newName);
+                        tm.setTrackName(childTrackId, newName);
                         pair.name = it->second;
                     }
                 }

--- a/magda/daw/core/DeviceInfo.hpp
+++ b/magda/daw/core/DeviceInfo.hpp
@@ -102,14 +102,24 @@ enum class DeviceType { Instrument, Effect, MIDI, Analysis };
 
 /**
  * @brief Describes a single stereo output pair from a multi-output plugin
+ *
+ * Declarative content only. Whether a pair is routed anywhere, and to which
+ * track, is NOT here: that is ownership of a generated child track, which
+ * belongs to one placed instance of the device rather than to the device's
+ * description of itself. A `DeviceInfo` is copied by duplication, preset import
+ * and paste, and a copy that carried `active` and `trackId` claimed the child
+ * track of the device it was copied from, leaving the copy silent while the
+ * link still named the original (#2220).
+ *
+ * The child track's `TrackInfo::multiOutLink` is the one record. Ask
+ * `TrackManager::multiOutChildTrack()` which track a pair drives, and
+ * `TrackManager::multiOutPairIsActive()` whether it drives one at all.
  */
 struct MultiOutOutputPair {
-    int outputIndex = 0;                 // 0-based pair index (0 = main 1,2)
-    juce::String name;                   // From plugin channel names, e.g. "St.3-4"
-    bool active = false;                 // User activated this pair
-    TrackId trackId = INVALID_TRACK_ID;  // Output track created for this pair
-    int firstPin = 1;                    // 1-based rack output pin for left channel
-    int numChannels = 2;                 // 1=mono, 2=stereo
+    int outputIndex = 0;  // 0-based pair index (0 = main 1,2)
+    juce::String name;    // From plugin channel names, e.g. "St.3-4"
+    int firstPin = 1;     // 1-based rack output pin for left channel
+    int numChannels = 2;  // 1=mono, 2=stereo
 };
 
 /**

--- a/magda/daw/core/TrackManager.cpp
+++ b/magda/daw/core/TrackManager.cpp
@@ -786,6 +786,25 @@ DeviceInfo* multiOutDevice(TrackManager& tm, TrackId parentTrackId, DeviceId dev
 
 }  // namespace
 
+TrackId TrackManager::multiOutChildTrack(TrackId parentTrackId, DeviceId deviceId,
+                                         int pairIndex) const {
+    // The child tracks are asked, because they own the assignment. A device's
+    // description of its pairs says nothing about where they go, so there is no
+    // second answer that can disagree with this one (#2220).
+    if (parentTrackId == INVALID_TRACK_ID || deviceId == INVALID_DEVICE_ID || pairIndex < 0)
+        return INVALID_TRACK_ID;
+
+    for (const auto& track : tracks_) {
+        if (!track.multiOutLink)
+            continue;
+        const auto& link = *track.multiOutLink;
+        if (link.sourceTrackId == parentTrackId && link.sourceDeviceId == deviceId &&
+            link.outputPairIndex == pairIndex)
+            return track.id;
+    }
+    return INVALID_TRACK_ID;
+}
+
 TrackId TrackManager::activateMultiOutPair(TrackId parentTrackId, DeviceId deviceId,
                                            int pairIndex) {
     auto* parentTrack = getTrack(parentTrackId);
@@ -801,11 +820,13 @@ TrackId TrackManager::activateMultiOutPair(TrackId parentTrackId, DeviceId devic
     if (pairIndex < 0 || pairIndex >= static_cast<int>(device->multiOut.outputPairs.size()))
         return INVALID_TRACK_ID;
 
-    auto& pair = device->multiOut.outputPairs[static_cast<size_t>(pairIndex)];
+    const auto& pair = device->multiOut.outputPairs[static_cast<size_t>(pairIndex)];
 
-    // Already active?
-    if (pair.active && pair.trackId != INVALID_TRACK_ID)
-        return pair.trackId;
+    // Already driving a child track? Asked of the child tracks, which own the
+    // assignment, rather than of a flag on the device (#2220).
+    if (const auto existing = multiOutChildTrack(parentTrackId, deviceId, pairIndex);
+        existing != INVALID_TRACK_ID)
+        return existing;
 
     // Create the output track
     TrackId newTrackId = nextTrackId_++;
@@ -836,19 +857,8 @@ TrackId TrackManager::activateMultiOutPair(TrackId parentTrackId, DeviceId devic
         tracks_.push_back(std::move(newTrack));
     }
 
-    // Re-fetch pointers after insert (vector reallocation invalidates them).
-    // Through the same lookup as above: the flat one misses a device inside a
-    // rack, and this dereferences what it answers (#2211).
-    parentTrack = getTrack(parentTrackId);
-    device = multiOutDevice(*this, parentTrackId, deviceId);
-    if (device == nullptr || pairIndex >= static_cast<int>(device->multiOut.outputPairs.size()))
-        return INVALID_TRACK_ID;
-
-    auto& pairRef = device->multiOut.outputPairs[static_cast<size_t>(pairIndex)];
-
-    // Update the output pair state
-    pairRef.active = true;
-    pairRef.trackId = newTrackId;
+    // Nothing to write back on the device: inserting the child track with its
+    // link IS the assignment, and every reader derives from it (#2220).
 
     DBG("TrackManager: Activated multi-out pair " << pairIndex << " for device " << deviceId
                                                   << " -> track " << newTrackId);
@@ -869,22 +879,17 @@ void TrackManager::deactivateMultiOutPair(TrackId parentTrackId, DeviceId device
     if (pairIndex < 0 || pairIndex >= static_cast<int>(device->multiOut.outputPairs.size()))
         return;
 
-    auto& pair = device->multiOut.outputPairs[static_cast<size_t>(pairIndex)];
-    if (!pair.active || pair.trackId == INVALID_TRACK_ID)
+    const auto trackToRemove = multiOutChildTrack(parentTrackId, deviceId, pairIndex);
+    if (trackToRemove == INVALID_TRACK_ID)
         return;
 
-    TrackId trackToRemove = pair.trackId;
-
-    // Remove the track
+    // Removing the child track removes the assignment: the link went with it,
+    // and there is no second copy to clear (#2220).
     auto it = std::find_if(tracks_.begin(), tracks_.end(),
                            [trackToRemove](const TrackInfo& t) { return t.id == trackToRemove; });
     if (it != tracks_.end()) {
         tracks_.erase(it);
     }
-
-    // Update pair state
-    pair.active = false;
-    pair.trackId = INVALID_TRACK_ID;
 
     DBG("TrackManager: Deactivated multi-out pair " << pairIndex << " for device " << deviceId);
 
@@ -900,7 +905,7 @@ void TrackManager::deactivateAllMultiOutPairs(TrackId parentTrackId, DeviceId de
             break;
         if (i >= static_cast<int>(device->multiOut.outputPairs.size()))
             break;
-        if (device->multiOut.outputPairs[static_cast<size_t>(i)].active) {
+        if (multiOutPairIsActive(parentTrackId, deviceId, i)) {
             deactivateMultiOutPair(parentTrackId, deviceId, i);
         }
     }
@@ -1084,26 +1089,10 @@ TrackId TrackManager::duplicateTrack(TrackId trackId, bool includeDevices) {
         newTrack.auxBusIndex = nextAuxBusIndex_++;
     }
 
-    // MultiOut links and output pairs reference the original track — clear them
+    // The copy is not a child track of anything. Its devices need no such reset:
+    // a DeviceInfo no longer carries which child tracks its pairs drive, so a
+    // copy inherits no ownership to begin with (#2220).
     newTrack.multiOutLink.reset();
-
-    std::function<void(std::vector<ChainElement>&)> clearMultiOutPairs;
-    clearMultiOutPairs = [&](std::vector<ChainElement>& elements) {
-        for (auto& element : elements) {
-            if (magda::isDevice(element)) {
-                auto& device = magda::getDevice(element);
-                for (auto& pair : device.multiOut.outputPairs) {
-                    pair.active = false;
-                    pair.trackId = INVALID_TRACK_ID;
-                }
-            } else if (magda::isRack(element)) {
-                auto& rack = magda::getRack(element);
-                for (auto& chain : rack.chains)
-                    clearMultiOutPairs(chain.elements);
-            }
-        }
-    };
-    clearMultiOutPairs(newTrack.chain.fxChainElements);
 
     TrackId newId = newTrack.id;
 

--- a/magda/daw/core/TrackManager.hpp
+++ b/magda/daw/core/TrackManager.hpp
@@ -263,7 +263,26 @@ class TrackManager : public daw::audio::DeviceIdAllocator, public daw::audio::De
      */
     void previewNote(TrackId trackId, int noteNumber, int velocity, bool isNoteOn);
 
+    // ========================================================================
     // Multi-output management
+    //
+    // A pair's child track is owned by the child track: `TrackInfo::multiOutLink`
+    // names the source track, the source device and the pair, and it is the only
+    // record of the assignment. The device's `MultiOutOutputPair` carries the
+    // pair's declarative description and nothing about where it goes, so a
+    // device copied by duplication, preset import or paste cannot inherit the
+    // original's child tracks (#2220).
+    // ========================================================================
+
+    /// The child track pair @p pairIndex of @p deviceId drives, or
+    /// INVALID_TRACK_ID when it drives none.
+    TrackId multiOutChildTrack(TrackId parentTrackId, DeviceId deviceId, int pairIndex) const;
+
+    /// Whether that pair drives a child track. Derived, never stored.
+    bool multiOutPairIsActive(TrackId parentTrackId, DeviceId deviceId, int pairIndex) const {
+        return multiOutChildTrack(parentTrackId, deviceId, pairIndex) != INVALID_TRACK_ID;
+    }
+
     TrackId activateMultiOutPair(TrackId parentTrackId, DeviceId deviceId, int pairIndex);
     void deactivateMultiOutPair(TrackId parentTrackId, DeviceId deviceId, int pairIndex);
     void deactivateAllMultiOutPairs(TrackId parentTrackId, DeviceId deviceId);

--- a/magda/daw/core/TrackManagerDevices.cpp
+++ b/magda/daw/core/TrackManagerDevices.cpp
@@ -32,6 +32,41 @@ template <typename Id> bool remapId(std::map<Id, Id> const& ids, int& value) {
     return true;
 }
 
+/// Whether anything in @p element drives a multi-out child track of @p sourceTrackId.
+///
+/// The whole subtree, because a rack being moved carries its devices with it.
+/// Ownership of a generated child track belongs to the device where it stands,
+/// and the child track's link names the track it stands on, so carrying the
+/// device somewhere else would leave the link naming a track that no longer
+/// hosts it (#2220).
+bool ownsMultiOutChildTracks(const TrackManager& tm, const ChainElement& element,
+                             TrackId sourceTrackId) {
+    if (magda::isDevice(element)) {
+        const auto& device = magda::getDevice(element);
+        if (device.multiOut.isMultiOut) {
+            for (std::size_t pair = 0; pair < device.multiOut.outputPairs.size(); ++pair)
+                if (tm.multiOutPairIsActive(sourceTrackId, device.id, static_cast<int>(pair)))
+                    return true;
+        }
+
+        if (device.pads)
+            for (const auto& pad : device.pads->chains)
+                for (const auto& padElement : pad.elements)
+                    if (ownsMultiOutChildTracks(tm, padElement, sourceTrackId))
+                        return true;
+        return false;
+    }
+
+    if (!magda::isRack(element))
+        return false;
+
+    for (const auto& chain : magda::getRack(element).chains)
+        for (const auto& nested : chain.elements)
+            if (ownsMultiOutChildTracks(tm, nested, sourceTrackId))
+                return true;
+    return false;
+}
+
 bool targetPointsAtDevice(const ControlTarget& target, DeviceId deviceId) {
     return deviceId != INVALID_DEVICE_ID && target.devicePath.getDeviceId() == deviceId;
 }
@@ -689,16 +724,6 @@ static void reassignCopiedElementIds(TrackManager& tm, std::vector<ChainElement>
                 device.id = tm.allocateDeviceId();
                 remap.devices[oldId] = device.id;
 
-                // The copy owns no child tracks yet. Inheriting the source's
-                // pair state would leave the sync thinking they were already
-                // made, so it would build none and the copy's pads on a bus
-                // would be silent while the link still named the original.
-                // `duplicateTrack()` clears them for the same reason.
-                for (auto& pair : device.multiOut.outputPairs) {
-                    pair.active = false;
-                    pair.trackId = INVALID_TRACK_ID;
-                }
-
                 // A pad-per-chain device's pads are its own: their DeviceIds and
                 // the rack id derived from the owner's would otherwise key the
                 // ops of the device this was copied from, and the copy's links
@@ -798,10 +823,8 @@ bool TrackManager::moveChainElement(const ChainNodePath& sourceElementPath,
     // the top level with its routing gone. Reordering within the track's own
     // list is not a placement change and stays allowed (#2211).
     // Only reordering within the same track's own list leaves the placement
-    // alone. A track-level destination on another track moves the pair state
-    // with the device while the existing child track still links to the track
-    // it came from, so the sync finds the pair already active, makes nothing,
-    // and the pad goes quiet.
+    // alone. Anywhere else is a placement change, and two things are refused
+    // before anything is mutated rather than repaired afterwards.
     if (destinationChainPath.getType() != ChainNodeType::Track ||
         destinationChainPath.trackId != sourceElementPath.trackId) {
         const auto* moved = getDeviceInChainByPath(sourceElementPath);
@@ -834,6 +857,21 @@ bool TrackManager::moveChainElement(const ChainNodePath& sourceElementPath,
     } else {
         return false;
     }
+
+    // A device that drives child tracks cannot change placement. The child
+    // track's link names the track the device stands on, so moving it would
+    // leave that link pointing at a track no longer hosting it, and a device
+    // taken off the top level has no output instance to carry a bus at all.
+    // Refused here, before anything is mutated, rather than repaired later by
+    // engine sync: closing the pairs first is the one documented way to move a
+    // device that owns them (#2220).
+    //
+    // The whole subtree, because a rack carries its devices with it. Reordering
+    // within the track's own list is not a placement change and stays allowed.
+    const bool placementChanges = destinationChainPath.getType() != ChainNodeType::Track ||
+                                  destinationChainPath.trackId != sourceElementPath.trackId;
+    if (placementChanges && ownsMultiOutChildTracks(*this, *sourceIt, sourceElementPath.trackId))
+        return false;
 
     const bool sameContainer = sourceElements == destinationElements;
     const int sourceIndex = static_cast<int>(std::distance(sourceElements->begin(), sourceIt));

--- a/magda/daw/core/TrackManagerDevices.cpp
+++ b/magda/daw/core/TrackManagerDevices.cpp
@@ -858,6 +858,8 @@ bool TrackManager::moveChainElement(const ChainNodePath& sourceElementPath,
         return false;
     }
 
+    const bool sameContainer = sourceElements == destinationElements;
+
     // A device that drives child tracks cannot change placement. The child
     // track's link names the track the device stands on, so moving it would
     // leave that link pointing at a track no longer hosting it, and a device
@@ -866,14 +868,14 @@ bool TrackManager::moveChainElement(const ChainNodePath& sourceElementPath,
     // engine sync: closing the pairs first is the one documented way to move a
     // device that owns them (#2220).
     //
-    // The whole subtree, because a rack carries its devices with it. Reordering
-    // within the track's own list is not a placement change and stays allowed.
-    const bool placementChanges = destinationChainPath.getType() != ChainNodeType::Track ||
-                                  destinationChainPath.trackId != sourceElementPath.trackId;
-    if (placementChanges && ownsMultiOutChildTracks(*this, *sourceIt, sourceElementPath.trackId))
+    // The whole subtree, because a rack carries its devices with it. Leaving the
+    // container is the placement change; reordering inside it is not, whatever
+    // the container is. A nested multi-out device changes neither the track nor
+    // the device id its child track is keyed on by moving to another index in
+    // the chain it already lives in.
+    if (!sameContainer && ownsMultiOutChildTracks(*this, *sourceIt, sourceElementPath.trackId))
         return false;
 
-    const bool sameContainer = sourceElements == destinationElements;
     const int sourceIndex = static_cast<int>(std::distance(sourceElements->begin(), sourceIt));
     const int destinationSize = static_cast<int>(destinationElements->size());
     insertIndex = std::clamp(insertIndex, 0, destinationSize);

--- a/magda/daw/project/serialization/TrackSerializer.cpp
+++ b/magda/daw/project/serialization/TrackSerializer.cpp
@@ -509,8 +509,9 @@ juce::var ProjectSerializer::serializeDeviceInfo(const DeviceInfo& device) {
             auto* pairObj = new juce::DynamicObject();
             pairObj->setProperty("outputIndex", pair.outputIndex);
             pairObj->setProperty("name", pair.name);
-            pairObj->setProperty("active", pair.active);
-            pairObj->setProperty("trackId", pair.trackId);
+            // `active` and `trackId` are not written: which child track a pair
+            // drives is the child track's `multiOutLink`, and persisting a
+            // second copy is what let the two disagree (#2220).
             pairObj->setProperty("firstPin", pair.firstPin);
             pairObj->setProperty("numChannels", pair.numChannels);
             pairsArray.add(juce::var(pairObj));
@@ -717,8 +718,12 @@ bool ProjectSerializer::deserializeDeviceInfo(const juce::var& json, DeviceInfo&
                     MultiOutOutputPair pair;
                     pair.outputIndex = pairObj->getProperty("outputIndex");
                     pair.name = pairObj->getProperty("name").toString();
-                    pair.active = pairObj->getProperty("active");
-                    pair.trackId = pairObj->getProperty("trackId");
+                    // A project saved before the ownership flip carries `active`
+                    // and `trackId` here. Both are dropped rather than read: the
+                    // child tracks in the same project carry the links, so the
+                    // assignments come back from them, and a pair the device
+                    // claimed with no child track to match was already an
+                    // orphan (#2220).
                     if (pairObj->hasProperty("firstPin"))
                         pair.firstPin = pairObj->getProperty("firstPin");
                     if (pairObj->hasProperty("numChannels"))

--- a/magda/daw/ui/components/chain/slot/DeviceSlotMultiOutControls.cpp
+++ b/magda/daw/ui/components/chain/slot/DeviceSlotMultiOutControls.cpp
@@ -28,8 +28,9 @@ void showDeviceSlotMultiOutMenu(const magda::ChainNodePath& nodePath, magda::Dev
         if (pair.outputIndex == 0)
             continue;
 
-        menu.addItem(static_cast<int>(i + 1), pair.name, true, pair.active);
-        (pair.active ? anyActive : anyInactive) = true;
+        const bool active = tm.multiOutPairIsActive(trackId, deviceId, static_cast<int>(i));
+        menu.addItem(static_cast<int>(i + 1), pair.name, true, active);
+        (active ? anyActive : anyInactive) = true;
     }
 
     menu.addSeparator();
@@ -54,7 +55,8 @@ void showDeviceSlotMultiOutMenu(const magda::ChainNodePath& nodePath, magda::Dev
                         break;
 
                     const auto& pair = dev->multiOut.outputPairs[i];
-                    if (pair.outputIndex == 0 || pair.active)
+                    if (pair.outputIndex == 0 ||
+                        tm.multiOutPairIsActive(trackId, deviceId, static_cast<int>(i)))
                         continue;
                     tm.activateMultiOutPair(trackId, deviceId, static_cast<int>(i));
                 }
@@ -70,8 +72,7 @@ void showDeviceSlotMultiOutMenu(const magda::ChainNodePath& nodePath, magda::Dev
             if (pairIndex < 0 || pairIndex >= static_cast<int>(device->multiOut.outputPairs.size()))
                 return;
 
-            const auto& pair = device->multiOut.outputPairs[static_cast<size_t>(pairIndex)];
-            if (pair.active) {
+            if (tm.multiOutPairIsActive(trackId, deviceId, pairIndex)) {
                 tm.deactivateMultiOutPair(trackId, deviceId, pairIndex);
             } else {
                 tm.activateMultiOutPair(trackId, deviceId, pairIndex);

--- a/tests/NullDiffCorpus.cpp
+++ b/tests/NullDiffCorpus.cpp
@@ -1908,7 +1908,7 @@ std::vector<Case> buildCorpus(const juce::File& scratchDirectory) {
         // in the other, and any mixing up of the two moves both.
         auto source = instrumentTrackOn(1, 970, "Source");
         source.chain.fxChainElements.clear();
-        source.chain.fxChainElements.emplace_back(multiOutSynthDevice(970, 2));
+        source.chain.fxChainElements.emplace_back(multiOutSynthDevice(970));
         source.pan = -1.0f;
 
         TrackInfo pairTrack;

--- a/tests/NullDiffGain.hpp
+++ b/tests/NullDiffGain.hpp
@@ -172,15 +172,14 @@ inline magda::DeviceInfo synthDevice(magda::DeviceId id) {
 }
 
 /**
- * @brief The four-channel instrument, with its second pair opened by @p pairTrack.
+ * @brief The four-channel instrument, with two pairs declared.
  *
- * Two pairs declared, which is what gives the plan a port to emit and the
- * wrapper a pin to wire. The second is marked active and named its track here
- * because that is the state the app reaches after a user opens a pair; nothing
- * in either leg opens one, so a case that left it inactive would be asking the
- * engines to route a pair the model says nobody wants.
+ * Two pairs is what gives the plan a port to emit and the wrapper a pin to
+ * wire. Which of them is open is not said here: that is the child track's
+ * `multiOutLink`, and the case builds one for the second pair, which is the
+ * state the app reaches after a user opens it (#2220).
  */
-inline magda::DeviceInfo multiOutSynthDevice(magda::DeviceId id, magda::TrackId pairTrack) {
+inline magda::DeviceInfo multiOutSynthDevice(magda::DeviceId id) {
     auto device = synthDevice(id);
     device.name = "Null Diff Multi Out";
     device.pluginId = kMultiOutPluginId;
@@ -199,8 +198,6 @@ inline magda::DeviceInfo multiOutSynthDevice(magda::DeviceId id, magda::TrackId 
     second.name = "Out 3-4";
     second.firstPin = 3;
     second.numChannels = 2;
-    second.active = true;
-    second.trackId = pairTrack;
 
     device.multiOut.outputPairs.push_back(main);
     device.multiOut.outputPairs.push_back(second);

--- a/tests/test_drum_grid_pad_commands.cpp
+++ b/tests/test_drum_grid_pad_commands.cpp
@@ -970,9 +970,9 @@ TEST_CASE("A grid with a pad on a bus is not dragged to another track",
 }
 
 TEST_CASE("A copied grid owns no child tracks yet", "[drumgrid][pads][commands]") {
-    // Inheriting the source's pair state would leave the sync thinking the
-    // child tracks were already made, so it would build none for the copy and
-    // its pad on a bus would be silent while the link named the original.
+    // Ownership of a generated child track belongs to one placed instance, so a
+    // copy must not inherit it. It cannot: the assignment is the child track's
+    // own link, and a DeviceInfo carries no record of it to copy (#2220).
     resetState();
     auto& tm = TrackManager::getInstance();
 
@@ -986,9 +986,12 @@ TEST_CASE("A copied grid owns no child tracks yet", "[drumgrid][pads][commands]"
         REQUIRE(grid != nullptr);
         grid->multiOut.isMultiOut = true;
         grid->multiOut.outputPairs.resize(2);
-        grid->multiOut.outputPairs[1].active = true;
-        grid->multiOut.outputPairs[1].trackId = trackId;
     }
+
+    // A real child track, rather than a flag saying there is one.
+    const auto childTrackId = tm.activateMultiOutPair(trackId, gridId, 1);
+    REQUIRE(childTrackId != INVALID_TRACK_ID);
+    REQUIRE(tm.multiOutPairIsActive(trackId, gridId, 1));
 
     std::vector<ChainElement> copied;
     copied.push_back(makeDeviceElement(*tm.getDeviceInChainByPath(gridPath)));
@@ -996,12 +999,19 @@ TEST_CASE("A copied grid owns no child tracks yet", "[drumgrid][pads][commands]"
                                          /*reassignIds=*/true));
 
     const auto& clone = getDevice(tm.getTrack(trackId)->chain.fxChainElements[1]);
+    REQUIRE(clone.id != gridId);
     REQUIRE(clone.multiOut.outputPairs.size() == 2);
-    CHECK_FALSE(clone.multiOut.outputPairs[1].active);
-    CHECK(clone.multiOut.outputPairs[1].trackId == INVALID_TRACK_ID);
 
-    // The original keeps its own.
-    CHECK(tm.getDeviceInChainByPath(gridPath)->multiOut.outputPairs[1].active);
+    // The copy drives nothing, and the original still drives its own child.
+    CHECK_FALSE(tm.multiOutPairIsActive(trackId, clone.id, 1));
+    CHECK(tm.multiOutChildTrack(trackId, clone.id, 1) == INVALID_TRACK_ID);
+    CHECK(tm.multiOutChildTrack(trackId, gridId, 1) == childTrackId);
+
+    // And the child track still names the device it was made for.
+    const auto* child = tm.getTrack(childTrackId);
+    REQUIRE(child != nullptr);
+    REQUIRE(child->multiOutLink.has_value());
+    CHECK(child->multiOutLink->sourceDeviceId == gridId);
 }
 
 TEST_CASE("A copied link into a rack inside a pad follows the copy", "[drumgrid][pads][commands]") {

--- a/tests/test_multi_out_tracks.cpp
+++ b/tests/test_multi_out_tracks.cpp
@@ -379,3 +379,62 @@ TEST_CASE("A device driving child tracks cannot change placement",
     CHECK(tm.moveChainElement(devicePath, elsewhere, 0));
     CHECK(tm.findDevicePath(deviceId) == ChainNodePath::topLevelDevice(otherTrackId, deviceId));
 }
+
+TEST_CASE("An active multi-out device reorders inside its own nested chain",
+          "[multi_out][lifecycle][ownership]") {
+    // Reordering is not a placement change. A nested multi-out device moving to
+    // another index in the chain it already lives in changes neither the track
+    // nor the device id its child track is keyed on, so the guard above must not
+    // catch it (#2220).
+    MultiOutTestFixture fixture;
+    auto& tm = fixture.tm();
+
+    const auto trackId = tm.createTrack("Inst", TrackType::Media);
+    const auto rackId = tm.addRackToTrack(trackId, "Rack");
+    const auto chainId = tm.addChainToRack(ChainNodePath::rack(trackId, rackId));
+    const auto chainPath = ChainNodePath::chain(trackId, rackId, chainId);
+
+    DeviceInfo instrument;
+    instrument.name = "MultiOutSynth";
+    instrument.format = PluginFormat::Internal;
+    instrument.pluginId = "multisynth";
+    instrument.isInstrument = true;
+    instrument.multiOut.isMultiOut = true;
+    instrument.multiOut.totalOutputChannels = 4;
+    instrument.multiOut.outputPairs = {{0, "Main 1-2", 1, 2}, {1, "Out 3-4", 3, 2}};
+
+    const auto deviceId = tm.addDeviceToChainByPath(chainPath, instrument);
+    REQUIRE(deviceId != INVALID_DEVICE_ID);
+
+    DeviceInfo neighbour;
+    neighbour.name = "Filter";
+    neighbour.format = PluginFormat::Internal;
+    neighbour.pluginId = "magdafilter";
+    const auto neighbourId = tm.addDeviceToChainByPath(chainPath, neighbour);
+    REQUIRE(neighbourId != INVALID_DEVICE_ID);
+
+    const auto childId = tm.activateMultiOutPair(trackId, deviceId, 1);
+    REQUIRE(childId != INVALID_TRACK_ID);
+    REQUIRE(tm.multiOutPairIsActive(trackId, deviceId, 1));
+
+    // Same container, new index: allowed, and ownership is untouched.
+    REQUIRE(tm.moveChainElement(chainPath.withDevice(deviceId), chainPath, 2));
+
+    const auto* chain = tm.getChainByPath(chainPath);
+    REQUIRE(chain != nullptr);
+    REQUIRE(chain->elements.size() == 2);
+    CHECK(getDevice(chain->elements[0]).id == neighbourId);
+    CHECK(getDevice(chain->elements[1]).id == deviceId);
+
+    CHECK(tm.multiOutChildTrack(trackId, deviceId, 1) == childId);
+    const auto* child = tm.getTrack(childId);
+    REQUIRE(child != nullptr);
+    REQUIRE(child->multiOutLink.has_value());
+    CHECK(child->multiOutLink->sourceTrackId == trackId);
+    CHECK(child->multiOutLink->sourceDeviceId == deviceId);
+
+    // Leaving the container is still refused.
+    CHECK_FALSE(
+        tm.moveChainElement(chainPath.withDevice(deviceId), ChainNodePath::trackLevel(trackId), 0));
+    CHECK(tm.multiOutChildTrack(trackId, deviceId, 1) == childId);
+}

--- a/tests/test_multi_out_tracks.cpp
+++ b/tests/test_multi_out_tracks.cpp
@@ -41,9 +41,9 @@ class MultiOutTestFixture {
         instrument.multiOut.isMultiOut = true;
         instrument.multiOut.totalOutputChannels = 6;
         instrument.multiOut.outputPairs = {
-            {0, "Main 1-2", false, INVALID_TRACK_ID, 1, 2},
-            {1, "Out 3-4", false, INVALID_TRACK_ID, 3, 2},
-            {2, "Out 5-6", false, INVALID_TRACK_ID, 5, 2},
+            {0, "Main 1-2", 1, 2},
+            {1, "Out 3-4", 3, 2},
+            {2, "Out 5-6", 5, 2},
         };
 
         auto deviceId = tm().addDeviceToTrack(trackId, instrument);
@@ -174,9 +174,10 @@ TEST_CASE("Multi-out pair activation and deactivation", "[multi_out][lifecycle]"
         auto siblingId = fixture.tm().activateMultiOutPair(trackId, deviceId, 1);
         REQUIRE(siblingId != INVALID_TRACK_ID);
 
-        auto* device = fixture.tm().getDevice(trackId, deviceId);
-        REQUIRE(device->multiOut.outputPairs[1].active == true);
-        REQUIRE(device->multiOut.outputPairs[1].trackId == siblingId);
+        // Derived from the child track's own link, not from a flag the device
+        // carries (#2220).
+        REQUIRE(fixture.tm().multiOutPairIsActive(trackId, deviceId, 1));
+        REQUIRE(fixture.tm().multiOutChildTrack(trackId, deviceId, 1) == siblingId);
 
         // Multi-out track should be a top-level sibling, not a child
         auto* sibling = fixture.tm().getTrack(siblingId);
@@ -200,9 +201,8 @@ TEST_CASE("Multi-out pair activation and deactivation", "[multi_out][lifecycle]"
 
         fixture.tm().deactivateMultiOutPair(trackId, deviceId, 1);
 
-        auto* device = fixture.tm().getDevice(trackId, deviceId);
-        REQUIRE(device->multiOut.outputPairs[1].active == false);
-        REQUIRE(device->multiOut.outputPairs[1].trackId == INVALID_TRACK_ID);
+        REQUIRE_FALSE(fixture.tm().multiOutPairIsActive(trackId, deviceId, 1));
+        REQUIRE(fixture.tm().multiOutChildTrack(trackId, deviceId, 1) == INVALID_TRACK_ID);
 
         // Child track should no longer exist
         REQUIRE(fixture.tm().getTrack(childId) == nullptr);
@@ -212,4 +212,170 @@ TEST_CASE("Multi-out pair activation and deactivation", "[multi_out][lifecycle]"
         auto childId = fixture.tm().activateMultiOutPair(trackId, deviceId, 99);
         REQUIRE(childId == INVALID_TRACK_ID);
     }
+}
+
+// ============================================================================
+// Ownership is the child track's, and only the child track's (#2220)
+//
+// `active` and `trackId` used to sit on the device's output pair as well as on
+// the child track's `multiOutLink`. Two records of one fact, and a `DeviceInfo`
+// travels with duplication, preset import and paste, so a copy arrived claiming
+// the original's child track. These pin that there is one record now and that
+// every transition either keeps it consistent or leaves nothing behind.
+// ============================================================================
+
+TEST_CASE("Duplicating a track does not duplicate child-track ownership",
+          "[multi_out][lifecycle][ownership]") {
+    MultiOutTestFixture fixture;
+    auto& tm = fixture.tm();
+
+    auto [trackId, deviceId] = fixture.createMultiOutTrack();
+    const auto childId = tm.activateMultiOutPair(trackId, deviceId, 1);
+    REQUIRE(childId != INVALID_TRACK_ID);
+
+    const auto copyId = tm.duplicateTrack(trackId);
+    REQUIRE(copyId != INVALID_TRACK_ID);
+
+    const auto* copy = tm.getTrack(copyId);
+    REQUIRE(copy != nullptr);
+    REQUIRE(copy->chain.fxChainElements.size() == 1);
+    const auto copyDeviceId = getDevice(copy->chain.fxChainElements[0]).id;
+    REQUIRE(copyDeviceId != deviceId);
+
+    // The declarative description came with the copy.
+    const auto* copyDevice = tm.getDevice(copyId, copyDeviceId);
+    REQUIRE(copyDevice != nullptr);
+    CHECK(copyDevice->multiOut.isMultiOut);
+    CHECK(copyDevice->multiOut.outputPairs.size() == 3);
+    CHECK(copyDevice->multiOut.outputPairs[1].name == "Out 3-4");
+    CHECK(copyDevice->multiOut.outputPairs[1].firstPin == 3);
+
+    // The ownership did not.
+    CHECK_FALSE(tm.multiOutPairIsActive(copyId, copyDeviceId, 1));
+    CHECK(tm.multiOutChildTrack(copyId, copyDeviceId, 1) == INVALID_TRACK_ID);
+
+    // And the original still drives its own, unmoved.
+    CHECK(tm.multiOutChildTrack(trackId, deviceId, 1) == childId);
+    const auto* child = tm.getTrack(childId);
+    REQUIRE(child != nullptr);
+    REQUIRE(child->multiOutLink.has_value());
+    CHECK(child->multiOutLink->sourceTrackId == trackId);
+    CHECK(child->multiOutLink->sourceDeviceId == deviceId);
+}
+
+TEST_CASE("Removing the child track ends the assignment", "[multi_out][lifecycle][ownership]") {
+    MultiOutTestFixture fixture;
+    auto& tm = fixture.tm();
+
+    auto [trackId, deviceId] = fixture.createMultiOutTrack();
+    const auto childId = tm.activateMultiOutPair(trackId, deviceId, 1);
+    REQUIRE(childId != INVALID_TRACK_ID);
+
+    // Removed as a track, not through deactivateMultiOutPair: the record went
+    // with it, so there is no second copy left claiming a track that is gone.
+    tm.deleteTrack(childId);
+
+    CHECK(tm.getTrack(childId) == nullptr);
+    CHECK_FALSE(tm.multiOutPairIsActive(trackId, deviceId, 1));
+    CHECK(tm.multiOutChildTrack(trackId, deviceId, 1) == INVALID_TRACK_ID);
+
+    // And the pair can be opened again, onto a track of its own.
+    const auto reopened = tm.activateMultiOutPair(trackId, deviceId, 1);
+    REQUIRE(reopened != INVALID_TRACK_ID);
+    CHECK(reopened != childId);
+    CHECK(tm.multiOutChildTrack(trackId, deviceId, 1) == reopened);
+}
+
+TEST_CASE("Two pairs of one device own two different tracks", "[multi_out][lifecycle][ownership]") {
+    MultiOutTestFixture fixture;
+    auto& tm = fixture.tm();
+
+    auto [trackId, deviceId] = fixture.createMultiOutTrack();
+    const auto firstId = tm.activateMultiOutPair(trackId, deviceId, 1);
+    const auto secondId = tm.activateMultiOutPair(trackId, deviceId, 2);
+    REQUIRE(firstId != INVALID_TRACK_ID);
+    REQUIRE(secondId != INVALID_TRACK_ID);
+    REQUIRE(firstId != secondId);
+
+    CHECK(tm.multiOutChildTrack(trackId, deviceId, 1) == firstId);
+    CHECK(tm.multiOutChildTrack(trackId, deviceId, 2) == secondId);
+
+    // Closing one leaves the other alone.
+    tm.deactivateMultiOutPair(trackId, deviceId, 1);
+    CHECK(tm.multiOutChildTrack(trackId, deviceId, 1) == INVALID_TRACK_ID);
+    CHECK(tm.multiOutChildTrack(trackId, deviceId, 2) == secondId);
+}
+
+TEST_CASE("Two devices with the same pair index own different tracks",
+          "[multi_out][lifecycle][ownership]") {
+    // The record is keyed by source track, source device and pair, so two grids
+    // opening the same numbered bus cannot be confused for one another.
+    MultiOutTestFixture fixture;
+    auto& tm = fixture.tm();
+
+    auto [trackA, deviceA] = fixture.createMultiOutTrack("A");
+    auto [trackB, deviceB] = fixture.createMultiOutTrack("B");
+
+    const auto childA = tm.activateMultiOutPair(trackA, deviceA, 1);
+    const auto childB = tm.activateMultiOutPair(trackB, deviceB, 1);
+    REQUIRE(childA != INVALID_TRACK_ID);
+    REQUIRE(childB != INVALID_TRACK_ID);
+    REQUIRE(childA != childB);
+
+    CHECK(tm.multiOutChildTrack(trackA, deviceA, 1) == childA);
+    CHECK(tm.multiOutChildTrack(trackB, deviceB, 1) == childB);
+
+    // And neither answers for the other's device.
+    CHECK(tm.multiOutChildTrack(trackA, deviceB, 1) == INVALID_TRACK_ID);
+    CHECK(tm.multiOutChildTrack(trackB, deviceA, 1) == INVALID_TRACK_ID);
+}
+
+TEST_CASE("An unopened pair owns nothing", "[multi_out][lifecycle][ownership]") {
+    MultiOutTestFixture fixture;
+    auto& tm = fixture.tm();
+
+    auto [trackId, deviceId] = fixture.createMultiOutTrack();
+
+    for (int pair = 0; pair < 3; ++pair)
+        CHECK_FALSE(tm.multiOutPairIsActive(trackId, deviceId, pair));
+
+    // And an address that names nothing is answered, not guessed at.
+    CHECK(tm.multiOutChildTrack(trackId, deviceId, 99) == INVALID_TRACK_ID);
+    CHECK(tm.multiOutChildTrack(trackId, deviceId, -1) == INVALID_TRACK_ID);
+    CHECK(tm.multiOutChildTrack(INVALID_TRACK_ID, deviceId, 1) == INVALID_TRACK_ID);
+    CHECK(tm.multiOutChildTrack(trackId, INVALID_DEVICE_ID, 1) == INVALID_TRACK_ID);
+}
+
+TEST_CASE("A device driving child tracks cannot change placement",
+          "[multi_out][lifecycle][ownership]") {
+    // The child track's link names the track the device stands on, so a move
+    // would strand it. Refused before anything is mutated; closing the pairs is
+    // the documented way to move such a device (#2220).
+    MultiOutTestFixture fixture;
+    auto& tm = fixture.tm();
+
+    auto [trackId, deviceId] = fixture.createMultiOutTrack();
+    const auto otherTrackId = tm.createTrack("Other", TrackType::Media);
+    const auto childId = tm.activateMultiOutPair(trackId, deviceId, 1);
+    REQUIRE(childId != INVALID_TRACK_ID);
+
+    const auto devicePath = ChainNodePath::topLevelDevice(trackId, deviceId);
+    const auto elsewhere = ChainNodePath::trackLevel(otherTrackId);
+
+    CHECK_FALSE(tm.moveChainElement(devicePath, elsewhere, 0));
+
+    // Refused means unchanged: the device is where it was and still drives its
+    // child, which still names the track it was made against.
+    CHECK(tm.findDevicePath(deviceId) == devicePath);
+    CHECK(tm.multiOutChildTrack(trackId, deviceId, 1) == childId);
+    const auto* child = tm.getTrack(childId);
+    REQUIRE(child != nullptr);
+    REQUIRE(child->multiOutLink.has_value());
+    CHECK(child->multiOutLink->sourceTrackId == trackId);
+
+    // Closing the pair lets it move.
+    tm.deactivateMultiOutPair(trackId, deviceId, 1);
+    REQUIRE_FALSE(tm.multiOutPairIsActive(trackId, deviceId, 1));
+    CHECK(tm.moveChainElement(devicePath, elsewhere, 0));
+    CHECK(tm.findDevicePath(deviceId) == ChainNodePath::topLevelDevice(otherTrackId, deviceId));
 }

--- a/tests/test_post_fx_fader_order_juce.cpp
+++ b/tests/test_post_fx_fader_order_juce.cpp
@@ -417,8 +417,8 @@ class PostFxFaderOrderTest final : public juce::UnitTest {
         instrument.multiOut.isMultiOut = true;
         instrument.multiOut.totalOutputChannels = 4;
         instrument.multiOut.outputPairs = {
-            {0, "Main 1-2", false, INVALID_TRACK_ID, 1, 2},
-            {1, "Out 3-4", false, INVALID_TRACK_ID, 3, 2},
+            {0, "Main 1-2", 1, 2},
+            {1, "Out 3-4", 3, 2},
         };
         const auto deviceId = tm.addDeviceToTrack(sourceId, instrument);
         const auto trackId = tm.activateMultiOutPair(sourceId, deviceId, 1);


### PR DESCRIPTION
Closes #2220.

## The problem

Which child track a multi-out pair drives was recorded twice:

- `active` and `trackId` on the device's `MultiOutOutputPair`;
- `multiOutLink` on the generated child track.

The two could disagree, and the device's copy travelled with `DeviceInfo`. A grid copied by duplication, preset import or paste arrived claiming the source's child track and stayed silent while the link still named the original. Engine sync repaired part of it by writing back onto the project model.

Ownership of a generated child track belongs to one placed instance of a device. The pair's bus selection is declarative device content and is copyable; the child track it drives is not.

## The change

The child track's `multiOutLink` is the only record.

- `MultiOutOutputPair` keeps `outputIndex`, `name`, `firstPin` and `numChannels`, and says nothing about where the pair goes. A copy has no ownership to inherit, so the resets duplication and preset import performed are gone with it.
- `multiOutChildTrack()` answers which track a pair drives; `multiOutPairIsActive()` whether it drives one. Both derive from the links, keyed by source track, source device and pair index, so two devices opening the same numbered bus cannot be confused.
- The UI menu, the Drum Grid pad bus reconciliation and the activate/deactivate mutators all ask rather than read a flag. The plan compiler already built its targets from the links, which is what confirmed the direction.

## Engine sync no longer edits the model

The sync used to write `active` and `trackId` back onto the device on the grounds that a project load rebuilt pairs before the tracks were restored. A derived answer cannot get that wrong, so the repair is deleted rather than kept.

## Legacy projects

`active` and `trackId` are no longer serialized, and both are dropped when reading a project that has them. The child tracks in the same project carry the links, so the assignments come back from those; a pair the device claimed with no child track to match was already an orphan and is now correctly closed. Deterministic in one pass, with no conflict to report.

## Moving a device that owns child tracks

Refused before any mutation, across the whole moved subtree, because the links name the track the device stands on and a device off the top level has no output instance to carry a bus. Closing the pairs first is the one documented way to move it.

This generalises the existing guard, which covered only a Drum Grid with a pad on a bus and so let a plain multi-out instrument move across tracks and strand its child.

## Tests

Six new cases in `tests/test_multi_out_tracks.cpp`, plus the copy case in the pad command tests rewritten to assert the property rather than the old reset:

- duplicating a track carries the declarative pair description and no ownership, with the original still driving its own child;
- deleting the child track directly ends the assignment and the pair can be reopened onto a fresh track. This is the case the old model got wrong: nothing cleared the source device's pair, so it kept `active` with a `trackId` naming a deleted track;
- two pairs of one device own two different tracks, and closing one leaves the other;
- two devices opening the same pair index own different tracks, and neither answers for the other;
- an unopened pair owns nothing, and out-of-range or invalid addresses are answered rather than guessed at;
- a device driving child tracks cannot change placement, is unchanged by the refusal, and moves once its pairs are closed.

3045 Catch2 cases and the JUCE target pass locally.

## Next

#2221, the structural mutation boundary, is the last of the three. It wants the single ownership record this adds, to reset on clone.

https://claude.ai/code/session_0187yiSdSJPmDFZafrSfbSop
