### PR TITLE
Collapse four chain re-key walkers into one, and fix the two that skipped pads

### DIFF
--- a/magda/daw/core/ChainIdRemap.hpp
+++ b/magda/daw/core/ChainIdRemap.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <map>
+
+#include "TypeIds.hpp"
+
+namespace magda {
+
+/**
+ * @brief What one re-keyed chain subtree's ids were moved to.
+ *
+ * Filled by `TrackManager::reassignChainElementIds()`, and read by everything
+ * that has to follow the subtree's internal references afterwards: macro and
+ * mod link targets, automation lane targets, and the addresses stored inside
+ * the subtree itself.
+ *
+ * `racks` carries two kinds of key. An allocated rack's id is one. The other is
+ * the synthetic negative id a pad rack holds (`padRackIdFor()`), which moves
+ * with the DeviceId it is derived from; a link naming a pad rack is remapped
+ * through this map like any other.
+ */
+struct ChainIdRemap {
+    std::map<DeviceId, DeviceId> devices;
+    std::map<RackId, RackId> racks;
+    std::map<ChainId, ChainId> chains;
+};
+
+}  // namespace magda

--- a/magda/daw/core/TrackManager.cpp
+++ b/magda/daw/core/TrackManager.cpp
@@ -997,54 +997,15 @@ TrackId TrackManager::duplicateTrack(TrackId trackId, bool includeDevices) {
     remap.oldTrackId = trackId;
     remap.newTrackId = newTrack.id;
 
-    std::function<void(std::vector<ChainElement>&)> reassignIds;
-    reassignIds = [&](std::vector<ChainElement>& elements) {
-        for (auto& element : elements) {
-            if (magda::isDevice(element)) {
-                auto& device = magda::getDevice(element);
-                const auto oldDeviceId = device.id;
-                device.id = nextFxDeviceId_++;
-                remap.devices[oldDeviceId] = device.id;
-
-                // The pads a device owns are keyed on its id too, so they are
-                // re-keyed with it: left alone, the duplicate's pad devices
-                // would share the original's runtime, and its pad rack id would
-                // no longer be the one derived from its device id, which is how
-                // every pad path is built (#2207).
-                if (device.pads) {
-                    // The synthetic negative id is what `RackInfo::id` holds and
-                    // is safe in the shared rack map. The grid's own DeviceId,
-                    // which is what a pad path spells its owner step with, moves
-                    // with the devices map above instead -- a PadRack step says
-                    // it is a DeviceId, so nothing has to keep a second map to
-                    // tell it apart from a rack sharing the number (#2219).
-                    remap.racks[padRackIdFor(oldDeviceId)] = padRackIdFor(device.id);
-
-                    stampPadRackId(device);
-
-                    // A pad's own elements are re-keyed by the ordinary walk:
-                    // the devices on it land in `remap.devices` like any other,
-                    // and its chain id is rack-local and stays as it is, which
-                    // is what keeps a macro, a mod or an automation lane naming
-                    // one still naming it.
-                    for (auto& pad : device.pads->chains)
-                        reassignIds(pad.elements);
-                }
-            } else if (magda::isRack(element)) {
-                auto& rack = magda::getRack(element);
-                const auto oldRackId = rack.id;
-                rack.id = nextRackId_++;
-                remap.racks[oldRackId] = rack.id;
-                for (auto& chain : rack.chains) {
-                    const auto oldChainId = chain.id;
-                    chain.id = nextChainId_++;
-                    remap.chains[oldChainId] = chain.id;
-                    reassignIds(chain.elements);
-                }
-            }
-        }
-    };
-    reassignIds(newTrack.chain.fxChainElements);
+    // The shared walk. The duplicate's devices, racks, chains and pads all get
+    // fresh ids: left alone, the copy's pad devices would share the original's
+    // runtime, and its pad rack id would no longer be the one derived from its
+    // device id, which is how every pad path is built (#2207, #2221).
+    ChainIdRemap ids;
+    reassignChainElementIds(newTrack.chain.fxChainElements, ids);
+    remap.devices = std::move(ids.devices);
+    remap.racks = std::move(ids.racks);
+    remap.chains = std::move(ids.chains);
     remapDuplicatedLinks(newTrack.macros, newTrack.mods, ChainNodePath::trackLevel(newTrack.id),
                          remap);
     remapDuplicatedElements(newTrack.chain.fxChainElements, ChainNodePath::trackLevel(newTrack.id),

--- a/magda/daw/core/TrackManager.hpp
+++ b/magda/daw/core/TrackManager.hpp
@@ -8,6 +8,7 @@
 #include <mutex>
 #include <vector>
 
+#include "ChainIdRemap.hpp"
 #include "ChainNode.hpp"
 #include "SelectionManager.hpp"
 #include "TrackInfo.hpp"
@@ -264,6 +265,25 @@ class TrackManager : public daw::audio::DeviceIdAllocator, public daw::audio::De
     void previewNote(TrackId trackId, int noteNumber, int velocity, bool isNoteOn);
 
     // ========================================================================
+    // ========================================================================
+    // Structural re-keying (#2221)
+    // ========================================================================
+
+    /// Give every device, rack and chain in @p elements a fresh id, recording
+    /// what moved where in @p remap.
+    ///
+    /// The one recursive re-key. Duplication, preset import, rack presets and
+    /// chain presets each grew their own, and they drifted: two of the four did
+    /// not descend into a device's pads, so a preset carrying a Drum Grid
+    /// brought the preset's pad DeviceIds into a live project, and only one of
+    /// the four recorded the synthetic pad rack id so a link naming it could be
+    /// followed. Anything with the same job calls this instead of writing a
+    /// fifth (#2221).
+    ///
+    /// Ids only. Links inside the subtree are followed afterwards from @p remap,
+    /// because who owns them differs by caller.
+    void reassignChainElementIds(std::vector<ChainElement>& elements, ChainIdRemap& remap);
+
     // Multi-output management
     //
     // A pair's child track is owned by the child track: `TrackInfo::multiOutLink`

--- a/magda/daw/core/TrackManagerDevices.cpp
+++ b/magda/daw/core/TrackManagerDevices.cpp
@@ -715,48 +715,15 @@ static void reassignCopiedElementIds(TrackManager& tm, std::vector<ChainElement>
     PresetIdRemap remap;
     remap.trackId = targetTrackId;
 
-    std::function<void(std::vector<ChainElement>&)> reassignIds;
-    reassignIds = [&](std::vector<ChainElement>& items) {
-        for (auto& element : items) {
-            if (magda::isDevice(element)) {
-                auto& device = magda::getDevice(element);
-                const auto oldId = device.id;
-                device.id = tm.allocateDeviceId();
-                remap.devices[oldId] = device.id;
+    // The shared walk: fresh ids for every device, rack and chain, pads
+    // included, with the synthetic pad rack id recorded so a link naming one can
+    // be followed (#2221).
+    ChainIdRemap ids;
+    tm.reassignChainElementIds(elements, ids);
+    remap.devices = std::move(ids.devices);
+    remap.racks = std::move(ids.racks);
+    remap.chains = std::move(ids.chains);
 
-                // A pad-per-chain device's pads are its own: their DeviceIds and
-                // the rack id derived from the owner's would otherwise key the
-                // ops of the device this was copied from, and the copy's links
-                // would still name the original's pads. Pad chain ids are
-                // rack-local and stay as they are, which is what keeps a macro,
-                // a mod or an automation lane naming one still naming it.
-                if (device.pads) {
-                    stampPadRackId(device);
-
-                    // A pad's own elements are re-keyed by the ordinary walk:
-                    // the devices on it land in `remap.devices` like any other,
-                    // and its chain id is rack-local and stays as it is, which
-                    // is what keeps a macro, a mod or an automation lane naming
-                    // one still naming it.
-                    for (auto& pad : device.pads->chains)
-                        reassignIds(pad.elements);
-                }
-            } else if (magda::isRack(element)) {
-                auto& rack = magda::getRack(element);
-                const auto oldRackId = rack.id;
-                rack.id = tm.allocateRackId();
-                remap.racks[oldRackId] = rack.id;
-                for (auto& chain : rack.chains) {
-                    const auto oldChainId = chain.id;
-                    chain.id = tm.allocateChainId();
-                    remap.chains[oldChainId] = chain.id;
-                    reassignIds(chain.elements);
-                }
-            }
-        }
-    };
-
-    reassignIds(elements);
     remapPresetLinksRecursive(elements, remap);
 }
 
@@ -1799,6 +1766,53 @@ bool TrackManager::applyDevicePreset(const ChainNodePath& devicePath,
     return true;
 }
 
+void TrackManager::reassignChainElementIds(std::vector<ChainElement>& elements,
+                                           ChainIdRemap& remap) {
+    for (auto& element : elements) {
+        if (magda::isDevice(element)) {
+            auto& device = magda::getDevice(element);
+            const auto oldDeviceId = device.id;
+            device.id = allocateDeviceId();
+            remap.devices[oldDeviceId] = device.id;
+
+            if (!device.pads)
+                continue;
+
+            // A device's pads are a rack it owns, and their contents are chain
+            // elements like any other, so they are re-keyed by the same walk.
+            // Two of the four walkers this replaces stopped at the device and
+            // left a preset's pad DeviceIds in a live project.
+            //
+            // The pad rack's own id is derived from the device's, so it moves
+            // with it. Recorded, because a stored link can name it and there is
+            // otherwise nothing to follow it by.
+            remap.racks[padRackIdFor(oldDeviceId)] = padRackIdFor(device.id);
+            stampPadRackId(device);
+
+            // Pad chain ids are rack-local and stay as they are, which is what
+            // keeps a link naming a pad still naming it.
+            for (auto& pad : device.pads->chains)
+                reassignChainElementIds(pad.elements, remap);
+            continue;
+        }
+
+        if (!magda::isRack(element))
+            continue;
+
+        auto& rack = magda::getRack(element);
+        const auto oldRackId = rack.id;
+        rack.id = allocateRackId();
+        remap.racks[oldRackId] = rack.id;
+
+        for (auto& chain : rack.chains) {
+            const auto oldChainId = chain.id;
+            chain.id = allocateChainId();
+            remap.chains[oldChainId] = chain.id;
+            reassignChainElementIds(chain.elements, remap);
+        }
+    }
+}
+
 bool TrackManager::applyRackPreset(const ChainNodePath& rackPath, const RackInfo& presetRack) {
     auto* live = getRackByPath(rackPath);
     if (!live) {
@@ -1816,37 +1830,21 @@ bool TrackManager::applyRackPreset(const ChainNodePath& rackPath, const RackInfo
     remap.racks[presetRack.id] = preservedId;
 
     // Reassign every chain / device / nested-rack id under this rack so the
-    // freshly-loaded subtree doesn't collide with other live elements'
-    // runtime IDs. Macros and mods are indexed within their parent and don't
-    // need reassignment. Mirrors the recursive walk in duplicateTrack.
-    std::function<void(std::vector<ChainElement>&)> reassignIds;
-    reassignIds = [&](std::vector<ChainElement>& elements) {
-        for (auto& element : elements) {
-            if (magda::isDevice(element)) {
-                auto& device = magda::getDevice(element);
-                const auto oldId = device.id;
-                device.id = nextFxDeviceId_++;
-                remap.devices[oldId] = device.id;
-            } else if (magda::isRack(element)) {
-                auto& nested = magda::getRack(element);
-                const auto oldRackId = nested.id;
-                nested.id = nextRackId_++;
-                remap.racks[oldRackId] = nested.id;
-                for (auto& chain : nested.chains) {
-                    const auto oldChainId = chain.id;
-                    chain.id = nextChainId_++;
-                    remap.chains[oldChainId] = chain.id;
-                    reassignIds(chain.elements);
-                }
-            }
-        }
-    };
+    // freshly-loaded subtree doesn't collide with other live elements' runtime
+    // IDs. Macros and mods are indexed within their parent and don't need
+    // reassignment. Through the shared walk, which descends into a device's
+    // pads: this one used not to, so a rack preset holding a Drum Grid brought
+    // the preset's pad DeviceIds in with it (#2221).
+    ChainIdRemap ids;
     for (auto& chain : live->chains) {
         const auto oldChainId = chain.id;
-        chain.id = nextChainId_++;
-        remap.chains[oldChainId] = chain.id;
-        reassignIds(chain.elements);
+        chain.id = allocateChainId();
+        ids.chains[oldChainId] = chain.id;
+        reassignChainElementIds(chain.elements, ids);
     }
+    remap.devices.merge(ids.devices);
+    remap.racks.merge(ids.racks);
+    remap.chains.merge(ids.chains);
     remapRackPresetLinks(*live, remap);
 
     // Trigger a full track resync — AudioBridge::trackDevicesChanged tears
@@ -1862,33 +1860,15 @@ bool TrackManager::applyChainPreset(TrackId trackId, std::vector<ChainElement> p
     }
 
     // Reassign every chain / device / nested-rack id in the preset so they
-    // don't collide with other live elements' runtime IDs. Same recursive
-    // walk applyRackPreset uses.
+    // don't collide with other live elements' runtime IDs, through the shared
+    // walk. This one used not to descend into a device's pads either (#2221).
     PresetIdRemap remap;
     remap.trackId = trackId;
-    std::function<void(std::vector<ChainElement>&)> reassignIds;
-    reassignIds = [&](std::vector<ChainElement>& elements) {
-        for (auto& element : elements) {
-            if (magda::isDevice(element)) {
-                auto& device = magda::getDevice(element);
-                const auto oldId = device.id;
-                device.id = nextFxDeviceId_++;
-                remap.devices[oldId] = device.id;
-            } else if (magda::isRack(element)) {
-                auto& nested = magda::getRack(element);
-                const auto oldRackId = nested.id;
-                nested.id = nextRackId_++;
-                remap.racks[oldRackId] = nested.id;
-                for (auto& chain : nested.chains) {
-                    const auto oldChainId = chain.id;
-                    chain.id = nextChainId_++;
-                    remap.chains[oldChainId] = chain.id;
-                    reassignIds(chain.elements);
-                }
-            }
-        }
-    };
-    reassignIds(presetElements);
+    ChainIdRemap ids;
+    reassignChainElementIds(presetElements, ids);
+    remap.devices = std::move(ids.devices);
+    remap.racks = std::move(ids.racks);
+    remap.chains = std::move(ids.chains);
     remapPresetLinksRecursive(presetElements, remap);
 
     track->chain.fxChainElements = std::move(presetElements);

--- a/tests/test_rack_audio.cpp
+++ b/tests/test_rack_audio.cpp
@@ -2,6 +2,7 @@
 
 #include <catch2/catch_test_macros.hpp>
 
+#include "../magda/daw/core/DrumGridPads.hpp"
 #include "../magda/daw/core/RackInfo.hpp"
 #include "../magda/daw/core/TrackManager.hpp"
 
@@ -517,4 +518,131 @@ TEST_CASE("Rack audio sync: recursive device search", "[rack_audio][recursive_se
         REQUIRE(isDevice(track->chain.fxChainElements[0]));
         REQUIRE(isRack(track->chain.fxChainElements[1]));
     }
+}
+
+// ============================================================================
+// One recursive re-key (#2221)
+//
+// Duplication, preset import, rack presets and chain presets each grew their
+// own, and two of the four stopped at the device rather than descending into
+// the pads it owns. A preset carrying a Drum Grid therefore brought the
+// preset's pad DeviceIds into a live project, where they collide with whatever
+// already holds them, and left the pad rack id derived from the id the grid had
+// in the preset rather than the one it has now.
+// ============================================================================
+
+namespace {
+
+/// A Drum Grid carrying one pad device, both under ids the caller chooses.
+DeviceInfo presetGridWithPad(DeviceId gridId, DeviceId padDeviceId) {
+    DeviceInfo grid;
+    grid.id = gridId;
+    grid.name = "Drum Grid";
+    grid.pluginId = "drumgrid";
+    grid.format = PluginFormat::Internal;
+    grid.isInstrument = true;
+    grid.deviceType = DeviceType::Instrument;
+
+    auto& pads = ensurePads(grid);
+    ChainInfo pad;
+    pad.id = 1;
+
+    DeviceInfo voice;
+    voice.id = padDeviceId;
+    voice.name = "Kick";
+    voice.pluginId = "magdasampler";
+    voice.format = PluginFormat::Internal;
+    voice.isInstrument = true;
+    voice.deviceType = DeviceType::Instrument;
+    pad.elements.push_back(makeDeviceElement(voice));
+
+    pads.chains.push_back(std::move(pad));
+    stampPadRackId(grid);
+    return grid;
+}
+
+}  // namespace
+
+TEST_CASE("A rack preset re-keys the pads of a device it carries",
+          "[rack_audio][rack_presets][pads]") {
+    RackAudioTestFixture fixture;
+    auto& tm = fixture.tm();
+
+    const auto trackId = tm.createTrack("Rack Preset Target");
+    const auto liveRackId = tm.addRackToTrack(trackId, "Live Rack");
+    const auto liveRackPath = ChainNodePath::rack(trackId, liveRackId);
+
+    // A live device whose id the preset's pad device also claims, so leaving the
+    // pad un-keyed puts two devices in one project under one id.
+    DeviceInfo occupant;
+    occupant.name = "Delay";
+    occupant.pluginId = "delay";
+    occupant.format = PluginFormat::Internal;
+    const auto occupantId = tm.addDeviceToTrack(trackId, occupant);
+    REQUIRE(occupantId != INVALID_DEVICE_ID);
+
+    RackInfo presetRack;
+    presetRack.id = 90;
+    presetRack.name = "Preset Rack";
+    ChainInfo presetChain;
+    presetChain.id = 91;
+    presetChain.elements.push_back(makeDeviceElement(presetGridWithPad(92, occupantId)));
+    presetRack.chains.push_back(std::move(presetChain));
+
+    REQUIRE(tm.applyRackPreset(liveRackPath, presetRack));
+
+    auto* liveRack = tm.getRackByPath(liveRackPath);
+    REQUIRE(liveRack != nullptr);
+    REQUIRE(liveRack->chains.size() == 1);
+    REQUIRE(liveRack->chains[0].elements.size() == 1);
+
+    const auto& grid = getDevice(liveRack->chains[0].elements[0]);
+    REQUIRE(static_cast<bool>(grid.pads));
+    REQUIRE(grid.pads->chains.size() == 1);
+    REQUIRE(grid.pads->chains[0].elements.size() == 1);
+    const auto& padDevice = getDevice(grid.pads->chains[0].elements[0]);
+
+    // The grid got a fresh id, and so did the device on its pad.
+    CHECK(grid.id != 92);
+    CHECK(padDevice.id != occupantId);
+    CHECK(padDevice.id != grid.id);
+
+    // And the pad rack id follows the id the grid has now, which is what every
+    // pad path is built from.
+    CHECK(grid.pads->id == padRackIdFor(grid.id));
+}
+
+TEST_CASE("A chain preset re-keys the pads of a device it carries",
+          "[rack_audio][track_presets][pads]") {
+    RackAudioTestFixture fixture;
+    auto& tm = fixture.tm();
+
+    const auto trackId = tm.createTrack("Chain Preset Target");
+
+    DeviceInfo occupant;
+    occupant.name = "Delay";
+    occupant.pluginId = "delay";
+    occupant.format = PluginFormat::Internal;
+    const auto occupantId = tm.addDeviceToTrack(trackId, occupant);
+    REQUIRE(occupantId != INVALID_DEVICE_ID);
+
+    std::vector<ChainElement> presetElements;
+    presetElements.push_back(makeDeviceElement(presetGridWithPad(200, occupantId)));
+
+    REQUIRE(tm.applyChainPreset(trackId, std::move(presetElements)));
+
+    auto* track = tm.getTrack(trackId);
+    REQUIRE(track != nullptr);
+    REQUIRE(track->chain.fxChainElements.size() == 1);
+
+    const auto& grid = getDevice(track->chain.fxChainElements[0]);
+    REQUIRE(static_cast<bool>(grid.pads));
+    REQUIRE(grid.pads->chains.size() == 1);
+    REQUIRE(grid.pads->chains[0].elements.size() == 1);
+    const auto& padDevice = getDevice(grid.pads->chains[0].elements[0]);
+
+    CHECK(grid.id != 200);
+    CHECK(padDevice.id != occupantId);
+    CHECK(padDevice.id != grid.id);
+    CHECK(grid.pads->id == padRackIdFor(grid.id));
 }


### PR DESCRIPTION
First step of #2221, which stays open: one canonical clone before one preflight and one commit. Two live bugs fall out of it.

## What was there

Duplication, preset import, rack presets and chain presets each carried their own recursive re-key of a chain subtree. Four walkers, same job, allocating from the same three counters, and they had drifted:

| walker | descends into pads | records the synthetic pad rack id |
| --- | --- | --- |
| `duplicateTrack` | yes | yes |
| preset import (copy/paste) | yes | no |
| `applyRackPreset` | **no** | no |
| `applyChainPreset` | **no** | no |

The rack-preset one is commented "Mirrors the recursive walk in duplicateTrack". It does not.

## The two bugs

**A preset carrying a Drum Grid brought the preset's pad DeviceIds into the live project.** They collide with whatever already holds them, and the pad rack id stayed derived from the id the grid had in the preset rather than the one it has now, which is what every pad path is built from. A Drum Grid in a rack chain is ordinary, so both preset paths reach it.

**A link naming a pad rack survived a track duplication but not a preset import.** Only duplication recorded `padRackIdFor(old) -> padRackIdFor(new)`; the synthetic negative id a pad rack holds is what a stored link to one carries, and nothing else follows it.

## The change

`TrackManager::reassignChainElementIds()` is the one walk, and all four call it. It descends into a device's pads, records the synthetic rack id, and leaves pad chain ids alone because they are rack-local, which is what keeps a macro, a mod or an automation lane naming a pad still naming it.

`ChainIdRemap` carries what moved where. The two preset remap structs and the duplication one take their maps from it rather than filling their own: link retargeting stays per-caller, because who owns the links to follow afterwards genuinely differs (a track's macros, a rack's, a loose fragment's).

Nothing else moved. This is the id half; placement validation and the notification boundary are the next two steps on the issue.

## Tests

Two new cases in `tests/test_rack_audio.cpp`: a rack preset and a chain preset, each carrying a Drum Grid whose pad device claims the id of a device already live on the track. Both assert the grid, its pad device and the pad rack id all come back re-keyed.

I ran both against the previous walkers first and confirmed they fail there.

3048 Catch2 cases and the JUCE target pass locally.

## Still to come on #2221

- one preflight: placement validation is spread over five sites with four predicates (`canHostInstrument` at five call sites, `anyPadOnABus` at three, plus `chainPathContainsRack`, `elementContainsInstrument` and the multi-out ownership guard), and each command picks its own subset;
- one commit: preflight the whole subtree and destination, build the transformed value, apply and notify once with a single undo boundary.

https://claude.ai/code/session_0187yiSdSJPmDFZafrSfbSop
