### PR TITLE
Ask one placement question instead of four subsets of it

### DIFF
--- a/magda/daw/core/CMakeLists.txt
+++ b/magda/daw/core/CMakeLists.txt
@@ -53,6 +53,7 @@ target_sources(magda_daw PRIVATE
     LegacyDeviceAliases.cpp
     DeviceParamMigrations.cpp
     PadPathMigration.cpp
+    ChainPlacement.cpp
     PluginPreferences.cpp
     PluginCapabilities.cpp
     PluginPresetScanner.cpp

--- a/magda/daw/core/ChainPlacement.cpp
+++ b/magda/daw/core/ChainPlacement.cpp
@@ -1,0 +1,21 @@
+#include "ChainPlacement.hpp"
+
+namespace magda {
+
+const char* describe(PlacementRefusal refusal) {
+    switch (refusal) {
+        case PlacementRefusal::Allowed:
+            return "allowed";
+        case PlacementRefusal::DestinationCannotHostInstrument:
+            return "the destination track cannot host an instrument";
+        case PlacementRefusal::DestinationInsideSource:
+            return "the destination is inside the rack being moved";
+        case PlacementRefusal::PadOnABus:
+            return "a pad is routed to a bus the destination does not carry";
+        case PlacementRefusal::OwnsMultiOutChildTracks:
+            return "the device drives multi-out child tracks of its current track";
+    }
+    return "refused";
+}
+
+}  // namespace magda

--- a/magda/daw/core/ChainPlacement.hpp
+++ b/magda/daw/core/ChainPlacement.hpp
@@ -1,0 +1,44 @@
+#pragma once
+
+#include "ChainNodePath.hpp"
+#include "RackInfo.hpp"  // ChainElement is a variant alias, not a forward-declarable type
+
+namespace magda {
+
+/**
+ * @brief Why a structural edit was refused, or `Allowed`.
+ *
+ * One answer for every operation that puts a subtree somewhere: move, paste,
+ * wrap, unwrap and duplication all ask the same question and used to answer it
+ * with their own subset of the rules. `wrapDeviceInRack()` checked whether a pad
+ * was on a bus but not whether the device drove a multi-out child track, so
+ * wrapping a multi-out instrument into a rack stranded the child track that a
+ * move of the same device refuses to strand (#2221).
+ */
+enum class PlacementRefusal {
+    Allowed,
+    DestinationCannotHostInstrument,  ///< An aux or group track, and the subtree has an instrument
+    DestinationInsideSource,          ///< A rack being put inside one of its own chains
+    PadOnABus,                        ///< A Drum Grid pad routed to a bus no destination carries
+    OwnsMultiOutChildTracks,          ///< A device whose pairs drive child tracks of its own track
+};
+
+/**
+ * @brief What is being placed, and where.
+ *
+ * `leavesItsContainer` is the difference between a placement change and a
+ * reorder. Reordering inside the container a subtree already lives in changes
+ * neither the track nor the ids anything is keyed on, so the rules that exist to
+ * protect those do not apply to it.
+ */
+struct PlacementRequest {
+    const ChainElement* subtree = nullptr;  ///< The element being placed
+    ChainNodePath sourcePath;               ///< Where it is now, addressed
+    ChainNodePath destination;              ///< The chain it is going into
+    bool leavesItsContainer = true;
+};
+
+/// A one-line reason for @p refusal, for logs and diagnostics.
+const char* describe(PlacementRefusal refusal);
+
+}  // namespace magda

--- a/magda/daw/core/ChainPlacement.hpp
+++ b/magda/daw/core/ChainPlacement.hpp
@@ -33,9 +33,18 @@ enum class PlacementRefusal {
  */
 struct PlacementRequest {
     const ChainElement* subtree = nullptr;  ///< The element being placed
-    ChainNodePath sourcePath;               ///< Where it is now, addressed
-    ChainNodePath destination;              ///< The chain it is going into
+    /// Where it is now. Empty for a source-less reconstruction: a paste, or an
+    /// undo restoring a device that was deleted. Such a subtree owns no child
+    /// tracks and is leaving no track, so the rules keyed on where it came from
+    /// do not apply to it.
+    ChainNodePath sourcePath;
+    ChainNodePath destination;  ///< The chain it is going into
     bool leavesItsContainer = true;
+    /// Whether it lands directly in a track's own list, which is where the
+    /// output instance that carries a multi-out bus is made. False for a rack
+    /// chain, a pad chain, and for a wrap, whose destination is a rack that does
+    /// not exist yet and so cannot be described by a path.
+    bool destinationIsTrackTopLevel = false;
 };
 
 /// A one-line reason for @p refusal, for logs and diagnostics.

--- a/magda/daw/core/TrackManager.hpp
+++ b/magda/daw/core/TrackManager.hpp
@@ -10,6 +10,7 @@
 
 #include "ChainIdRemap.hpp"
 #include "ChainNode.hpp"
+#include "ChainPlacement.hpp"
 #include "SelectionManager.hpp"
 #include "TrackInfo.hpp"
 #include "TrackTypes.hpp"
@@ -268,6 +269,18 @@ class TrackManager : public daw::audio::DeviceIdAllocator, public daw::audio::De
     // ========================================================================
     // Structural re-keying (#2221)
     // ========================================================================
+
+    /// Whether @p request may be carried out, and why not when it may not.
+    ///
+    /// The one placement question. Move, paste, wrap, unwrap and duplication all
+    /// ask it, and used to answer it with their own subset of the rules: the
+    /// move path checked four, wrap checked one, insert checked none. Every rule
+    /// examines the complete subtree and is independent of whether the
+    /// destination is a track's own list, a rack chain or a pad chain (#2221).
+    ///
+    /// Asked before anything is mutated. A refused operation leaves the model
+    /// as it was and notifies nothing.
+    PlacementRefusal checkPlacement(const PlacementRequest& request) const;
 
     /// Give every device, rack and chain in @p elements a fresh id, recording
     /// what moved where in @p remap.

--- a/magda/daw/core/TrackManagerDevices.cpp
+++ b/magda/daw/core/TrackManagerDevices.cpp
@@ -830,11 +830,22 @@ PlacementRefusal TrackManager::checkPlacement(const PlacementRequest& request) c
     }
 
     // A pad on a bus is carried by the output instance made for a top-level
-    // instrument. Nowhere else carries one, so the move would have to put every
-    // pad back on the main mix and take its child tracks down, and that clean-up
-    // is not part of the undoable step (#2211).
-    if (anyPadOnABusInSubtree(*request.subtree))
-        return PlacementRefusal::PadOnABus;
+    // instrument. Nowhere else carries one, so a destination that is not a
+    // track's own list would silently drop the routing, and leaving the track
+    // the buses were realised on would leave its child tracks behind. Neither
+    // clean-up is part of the undoable step (#2211).
+    //
+    // A source-less reconstruction is neither: a paste, or an undo putting a
+    // deleted device back, owns no child tracks and leaves no track. Refusing it
+    // would have made undoing the deletion of a routed grid restore nothing at
+    // all, silently, because the callers discard the result (#2221).
+    if (anyPadOnABusInSubtree(*request.subtree)) {
+        const bool hasSource = request.sourcePath.trackId != INVALID_TRACK_ID;
+        const bool leavesItsTrack =
+            hasSource && request.destination.trackId != request.sourcePath.trackId;
+        if (!request.destinationIsTrackTopLevel || leavesItsTrack)
+            return PlacementRefusal::PadOnABus;
+    }
 
     // And the same for a multi-out pair: the child track's link names the track
     // the device stands on, so moving it strands the link, and a device off the
@@ -897,8 +908,8 @@ bool TrackManager::moveChainElement(const ChainNodePath& sourceElementPath,
     const bool sameContainer = sourceElements == destinationElements;
 
     // One question, asked before anything is mutated (#2221).
-    if (checkPlacement({&*sourceIt, sourceElementPath, destinationChainPath, !sameContainer}) !=
-        PlacementRefusal::Allowed)
+    if (checkPlacement({&*sourceIt, sourceElementPath, destinationChainPath, !sameContainer,
+                        destinationChainPath.steps.empty()}) != PlacementRefusal::Allowed)
         return false;
 
     const int sourceIndex = static_cast<int>(std::distance(sourceElements->begin(), sourceIt));
@@ -1004,7 +1015,9 @@ bool TrackManager::insertChainElementsByPath(const ChainNodePath& destinationCha
     // the rules keyed on where they came from pass and the ones about what is
     // being placed still apply (#2221).
     for (const auto& element : elements) {
-        if (checkPlacement({&element, {}, destinationChainPath, true}) != PlacementRefusal::Allowed)
+        if (checkPlacement(
+                {&element, {}, destinationChainPath, true, destinationChainPath.steps.empty()}) !=
+            PlacementRefusal::Allowed)
             return false;
     }
 
@@ -1039,8 +1052,8 @@ RackId TrackManager::wrapChainElementsInRack(const std::vector<ChainNodePath>& p
         // whether a pad was on a bus, so wrapping a multi-out instrument
         // stranded the child tracks a move of it refuses to strand (#2221).
         if (const auto* element = findChainElement(*this, path);
-            element != nullptr &&
-            checkPlacement({element, path, sourceChainPath, true}) != PlacementRefusal::Allowed)
+            element != nullptr && checkPlacement({element, path, sourceChainPath, true, false}) !=
+                                      PlacementRefusal::Allowed)
             return INVALID_RACK_ID;
 
         const int index = getChainElementIndex(path);
@@ -2068,7 +2081,8 @@ RackId TrackManager::wrapDeviceInRack(TrackId trackId, DeviceId deviceId,
     // on a bus, so wrapping a multi-out instrument stranded the child tracks a
     // move of it refuses to strand (#2211, #2221).
     if (checkPlacement({&*it, ChainNodePath::topLevelDevice(trackId, deviceId),
-                        ChainNodePath::trackLevel(trackId), true}) != PlacementRefusal::Allowed)
+                        ChainNodePath::trackLevel(trackId), true, false}) !=
+        PlacementRefusal::Allowed)
         return INVALID_RACK_ID;
 
     int insertIndex = static_cast<int>(std::distance(elements.begin(), it));
@@ -2121,7 +2135,7 @@ RackId TrackManager::wrapDeviceInRackByPath(const ChainNodePath& devicePath,
     // A nested device can drive multi-out child tracks too, and wrapping moves
     // it into a container it was not in, so this is a placement change like any
     // other and was going round the boundary (#2221).
-    if (checkPlacement({&*it, devicePath, chainPath, true}) != PlacementRefusal::Allowed)
+    if (checkPlacement({&*it, devicePath, chainPath, true, false}) != PlacementRefusal::Allowed)
         return INVALID_RACK_ID;
 
     int insertIndex = static_cast<int>(std::distance(elements.begin(), it));

--- a/magda/daw/core/TrackManagerDevices.cpp
+++ b/magda/daw/core/TrackManagerDevices.cpp
@@ -2117,6 +2117,13 @@ RackId TrackManager::wrapDeviceInRackByPath(const ChainNodePath& devicePath,
     if (it == elements.end())
         return INVALID_RACK_ID;
 
+    // The same question the top-level branch asks through `wrapDeviceInRack()`.
+    // A nested device can drive multi-out child tracks too, and wrapping moves
+    // it into a container it was not in, so this is a placement change like any
+    // other and was going round the boundary (#2221).
+    if (checkPlacement({&*it, devicePath, chainPath, true}) != PlacementRefusal::Allowed)
+        return INVALID_RACK_ID;
+
     int insertIndex = static_cast<int>(std::distance(elements.begin(), it));
 
     // Extract the device

--- a/magda/daw/core/TrackManagerDevices.cpp
+++ b/magda/daw/core/TrackManagerDevices.cpp
@@ -60,6 +60,33 @@ bool anyPadOnABusInSubtree(const ChainElement& element) {
     return false;
 }
 
+/// Whether anything strictly BELOW @p element has a Drum Grid pad routed to a bus.
+///
+/// The distinction the destination rule needs. Only the root of a subtree lands
+/// where the caller says it lands; anything below it stays nested inside the
+/// root wherever that is, so it can never be the top-level instrument whose
+/// output instance carries a bus (#2221).
+bool anyPadOnABusBelowRoot(const ChainElement& element) {
+    if (magda::isDevice(element)) {
+        const auto& device = magda::getDevice(element);
+        if (device.pads)
+            for (const auto& pad : device.pads->chains)
+                for (const auto& padElement : pad.elements)
+                    if (anyPadOnABusInSubtree(padElement))
+                        return true;
+        return false;
+    }
+
+    if (!magda::isRack(element))
+        return false;
+
+    for (const auto& chain : magda::getRack(element).chains)
+        for (const auto& nested : chain.elements)
+            if (anyPadOnABusInSubtree(nested))
+                return true;
+    return false;
+}
+
 /// Whether anything in @p element drives a multi-out child track of @p sourceTrackId.
 ///
 /// The whole subtree, because a rack being moved carries its devices with it.
@@ -839,7 +866,14 @@ PlacementRefusal TrackManager::checkPlacement(const PlacementRequest& request) c
     // deleted device back, owns no child tracks and leaves no track. Refusing it
     // would have made undoing the deletion of a routed grid restore nothing at
     // all, silently, because the callers discard the result (#2221).
-    if (anyPadOnABusInSubtree(*request.subtree)) {
+    //
+    // Only the root lands where the caller says it lands. A routed grid deeper
+    // in the subtree stays nested inside that root wherever it goes, so it can
+    // never be the top-level instrument its bus needs, whatever the destination.
+    if (anyPadOnABusBelowRoot(*request.subtree))
+        return PlacementRefusal::PadOnABus;
+
+    if (magda::isDevice(*request.subtree) && anyPadOnABus(magda::getDevice(*request.subtree))) {
         const bool hasSource = request.sourcePath.trackId != INVALID_TRACK_ID;
         const bool leavesItsTrack =
             hasSource && request.destination.trackId != request.sourcePath.trackId;

--- a/magda/daw/core/TrackManagerDevices.cpp
+++ b/magda/daw/core/TrackManagerDevices.cpp
@@ -32,6 +32,34 @@ template <typename Id> bool remapId(std::map<Id, Id> const& ids, int& value) {
     return true;
 }
 
+/// Whether anything in @p element has a Drum Grid pad routed to a bus.
+///
+/// The whole subtree, because a rack being moved carries its devices with it.
+/// The single-device callers this replaces looked only at the element itself.
+bool anyPadOnABusInSubtree(const ChainElement& element) {
+    if (magda::isDevice(element)) {
+        const auto& device = magda::getDevice(element);
+        if (anyPadOnABus(device))
+            return true;
+
+        if (device.pads)
+            for (const auto& pad : device.pads->chains)
+                for (const auto& padElement : pad.elements)
+                    if (anyPadOnABusInSubtree(padElement))
+                        return true;
+        return false;
+    }
+
+    if (!magda::isRack(element))
+        return false;
+
+    for (const auto& chain : magda::getRack(element).chains)
+        for (const auto& nested : chain.elements)
+            if (anyPadOnABusInSubtree(nested))
+                return true;
+    return false;
+}
+
 /// Whether anything in @p element drives a multi-out child track of @p sourceTrackId.
 ///
 /// The whole subtree, because a rack being moved carries its devices with it.
@@ -752,6 +780,71 @@ static bool elementContainsInstrument(const ChainElement& element) {
     return false;
 }
 
+/// The chain element @p path addresses, device or rack, or null.
+const ChainElement* findChainElement(TrackManager& tm, const ChainNodePath& path) {
+    const auto parentPath = getParentChainPathForElementPath(path);
+    const auto* elements = getElementContainerForChainPath(tm, parentPath);
+    if (elements == nullptr)
+        return nullptr;
+
+    const auto type = path.topLevelDeviceId != INVALID_DEVICE_ID
+                          ? ChainStepType::Device
+                          : (!path.steps.empty() ? path.steps.back().type : ChainStepType::Device);
+    const auto id = path.topLevelDeviceId != INVALID_DEVICE_ID
+                        ? path.topLevelDeviceId
+                        : (!path.steps.empty() ? path.steps.back().id : INVALID_DEVICE_ID);
+
+    for (const auto& element : *elements) {
+        if (type == ChainStepType::Device) {
+            if (magda::isDevice(element) && magda::getDevice(element).id == id)
+                return &element;
+            continue;
+        }
+        if (magda::isRack(element) && magda::getRack(element).id == id)
+            return &element;
+    }
+    return nullptr;
+}
+
+PlacementRefusal TrackManager::checkPlacement(const PlacementRequest& request) const {
+    if (request.subtree == nullptr)
+        return PlacementRefusal::Allowed;
+
+    // Reordering inside the container a subtree already lives in changes neither
+    // the track nor the ids anything is keyed on, so the rules below, which all
+    // exist to protect one of those, do not apply to it.
+    if (!request.leavesItsContainer)
+        return PlacementRefusal::Allowed;
+
+    // A rack cannot be put inside one of its own chains.
+    if (chainPathContainsRack(request.destination, request.sourcePath))
+        return PlacementRefusal::DestinationInsideSource;
+
+    // The destination track has to be able to hold what is coming. Asked of the
+    // whole subtree, because a rack carries its devices with it.
+    if (const auto* destinationTrack = getTrack(request.destination.trackId)) {
+        if (!destinationTrack->canHostInstrument() && elementContainsInstrument(*request.subtree))
+            return PlacementRefusal::DestinationCannotHostInstrument;
+    } else {
+        return PlacementRefusal::DestinationCannotHostInstrument;
+    }
+
+    // A pad on a bus is carried by the output instance made for a top-level
+    // instrument. Nowhere else carries one, so the move would have to put every
+    // pad back on the main mix and take its child tracks down, and that clean-up
+    // is not part of the undoable step (#2211).
+    if (anyPadOnABusInSubtree(*request.subtree))
+        return PlacementRefusal::PadOnABus;
+
+    // And the same for a multi-out pair: the child track's link names the track
+    // the device stands on, so moving it strands the link, and a device off the
+    // top level has no output instance to carry a bus at all (#2220).
+    if (ownsMultiOutChildTracks(*this, *request.subtree, request.sourcePath.trackId))
+        return PlacementRefusal::OwnsMultiOutChildTracks;
+
+    return PlacementRefusal::Allowed;
+}
+
 bool TrackManager::moveChainElement(const ChainNodePath& sourceElementPath,
                                     const ChainNodePath& destinationChainPath, int insertIndex) {
     if (sourceElementPath.trackId == INVALID_TRACK_ID ||
@@ -778,27 +871,12 @@ bool TrackManager::moveChainElement(const ChainNodePath& sourceElementPath,
         return false;
     }
 
-    if (sourceType == ChainStepType::Rack &&
-        chainPathContainsRack(destinationChainPath, sourceElementPath)) {
-        return false;
-    }
-
     // Refused for the same reason a wrap is: dropping a grid into a rack takes
     // it somewhere no bus is carried, so the move would have to put every pad
     // back on the main mix and take its child tracks down, and that clean-up is
     // not part of the undoable step the move is. Undo would return the grid to
     // the top level with its routing gone. Reordering within the track's own
     // list is not a placement change and stays allowed (#2211).
-    // Only reordering within the same track's own list leaves the placement
-    // alone. Anywhere else is a placement change, and two things are refused
-    // before anything is mutated rather than repaired afterwards.
-    if (destinationChainPath.getType() != ChainNodeType::Track ||
-        destinationChainPath.trackId != sourceElementPath.trackId) {
-        const auto* moved = getDeviceInChainByPath(sourceElementPath);
-        if (moved != nullptr && anyPadOnABus(*moved))
-            return false;
-    }
-
     auto* sourceElements = getElementContainerForChainPath(*this, sourceChainPath);
     auto* destinationElements = getElementContainerForChainPath(*this, destinationChainPath);
     if (sourceElements == nullptr || destinationElements == nullptr) {
@@ -816,31 +894,11 @@ bool TrackManager::moveChainElement(const ChainNodePath& sourceElementPath,
         return false;
     }
 
-    if (auto* destinationTrack = getTrack(destinationChainPath.trackId)) {
-        const bool destinationCannotHostInstruments = !destinationTrack->canHostInstrument();
-        if (destinationCannotHostInstruments && elementContainsInstrument(*sourceIt)) {
-            return false;
-        }
-    } else {
-        return false;
-    }
-
     const bool sameContainer = sourceElements == destinationElements;
 
-    // A device that drives child tracks cannot change placement. The child
-    // track's link names the track the device stands on, so moving it would
-    // leave that link pointing at a track no longer hosting it, and a device
-    // taken off the top level has no output instance to carry a bus at all.
-    // Refused here, before anything is mutated, rather than repaired later by
-    // engine sync: closing the pairs first is the one documented way to move a
-    // device that owns them (#2220).
-    //
-    // The whole subtree, because a rack carries its devices with it. Leaving the
-    // container is the placement change; reordering inside it is not, whatever
-    // the container is. A nested multi-out device changes neither the track nor
-    // the device id its child track is keyed on by moving to another index in
-    // the chain it already lives in.
-    if (!sameContainer && ownsMultiOutChildTracks(*this, *sourceIt, sourceElementPath.trackId))
+    // One question, asked before anything is mutated (#2221).
+    if (checkPlacement({&*sourceIt, sourceElementPath, destinationChainPath, !sameContainer}) !=
+        PlacementRefusal::Allowed)
         return false;
 
     const int sourceIndex = static_cast<int>(std::distance(sourceElements->begin(), sourceIt));
@@ -941,6 +999,15 @@ bool TrackManager::insertChainElementsByPath(const ChainNodePath& destinationCha
     if (destinationElements == nullptr || elements.empty())
         return false;
 
+    // This asked nothing before, so a paste could put an instrument on a track
+    // that cannot host one. There is no source: the elements are arriving, so
+    // the rules keyed on where they came from pass and the ones about what is
+    // being placed still apply (#2221).
+    for (const auto& element : elements) {
+        if (checkPlacement({&element, {}, destinationChainPath, true}) != PlacementRefusal::Allowed)
+            return false;
+    }
+
     if (reassignIds)
         reassignCopiedElementIds(*this, elements, destinationChainPath.trackId);
 
@@ -967,10 +1034,13 @@ RackId TrackManager::wrapChainElementsInRack(const std::vector<ChainNodePath>& p
         if (!path.isValid() || getParentChainPathForElementPath(path) != sourceChainPath)
             return INVALID_RACK_ID;
 
-        // Same refusal as the single-device wrap: a pad on a bus would lose its
-        // routing to a clean-up the undo of this move does not cover (#2211).
-        if (const auto* device = getDeviceInChainByPath(path);
-            device != nullptr && anyPadOnABus(*device))
+        // Wrapping takes an element off the top level, which is a placement
+        // change like any other. Asked the same way: this used to check only
+        // whether a pad was on a bus, so wrapping a multi-out instrument
+        // stranded the child tracks a move of it refuses to strand (#2221).
+        if (const auto* element = findChainElement(*this, path);
+            element != nullptr &&
+            checkPlacement({element, path, sourceChainPath, true}) != PlacementRefusal::Allowed)
             return INVALID_RACK_ID;
 
         const int index = getChainElementIndex(path);
@@ -1992,12 +2062,13 @@ RackId TrackManager::wrapDeviceInRack(TrackId trackId, DeviceId deviceId,
     if (it == elements.end())
         return INVALID_RACK_ID;
 
-    // Refused while a pad is on a bus. Nothing carries a bus off a device inside
-    // a rack, so the move would have to put every pad back on the main mix and
-    // take its child tracks down -- and that clean-up would not be part of the
-    // undoable step the move is, so undoing it would return the device to the
-    // top level with its routing gone for good (#2211).
-    if (anyPadOnABus(magda::getDevice(*it)))
+    // Wrapping takes the device off the top level, where the output instance
+    // that carries a bus is made, so it is a placement change and asks the same
+    // question every other one does. This used to check only whether a pad was
+    // on a bus, so wrapping a multi-out instrument stranded the child tracks a
+    // move of it refuses to strand (#2211, #2221).
+    if (checkPlacement({&*it, ChainNodePath::topLevelDevice(trackId, deviceId),
+                        ChainNodePath::trackLevel(trackId), true}) != PlacementRefusal::Allowed)
         return INVALID_RACK_ID;
 
     int insertIndex = static_cast<int>(std::distance(elements.begin(), it));

--- a/tests/test_drum_grid_pad_commands.cpp
+++ b/tests/test_drum_grid_pad_commands.cpp
@@ -1235,3 +1235,41 @@ TEST_CASE("A routed grid pastes at track level but not into a rack",
     REQUIRE(static_cast<bool>(clone.pads));
     CHECK(clone.pads->chains[0].outputIndex == 1);
 }
+
+TEST_CASE("A rack carrying a routed grid is refused even at track level",
+          "[drumgrid][pads][commands][placement]") {
+    // The destination rule speaks for the subtree root only. A rack landing in
+    // the track's own list is top-level, but the grid inside it is not, so its
+    // bus has no output instance to be carried by and sync would drop the
+    // routing silently (#2221).
+    resetState();
+    auto& tm = TrackManager::getInstance();
+
+    const auto trackId = tm.createTrack("Drums");
+    const auto gridId = tm.addDeviceToTrack(trackId, drumGridDevice());
+    const auto gridPath = ChainNodePath::topLevelDevice(trackId, gridId);
+    REQUIRE(tm.setPadDevice(gridPath, 0, padVoice("Kick")) != INVALID_DEVICE_ID);
+    REQUIRE(tm.setPadOutput(gridPath, 0, 1));
+
+    // A rack holding a copy of the routed grid, built on the model directly:
+    // no command makes one, and the point is what the rule says about it.
+    RackInfo carrier;
+    carrier.id = 500;
+    carrier.name = "Carrier";
+    ChainInfo carrierChain;
+    carrierChain.id = 501;
+    carrierChain.elements.push_back(makeDeviceElement(*tm.getDeviceInChainByPath(gridPath)));
+    carrier.chains.push_back(std::move(carrierChain));
+
+    std::vector<ChainElement> pasted;
+    pasted.push_back(makeRackElement(std::move(carrier)));
+
+    CHECK_FALSE(tm.insertChainElementsByPath(ChainNodePath::trackLevel(trackId), std::move(pasted),
+                                             1, /*reassignIds=*/true));
+
+    // Nothing landed: the grid is still the track's only element.
+    const auto& elements = tm.getTrack(trackId)->chain.fxChainElements;
+    REQUIRE(elements.size() == 1);
+    CHECK(isDevice(elements[0]));
+    CHECK(getDevice(elements[0]).id == gridId);
+}

--- a/tests/test_drum_grid_pad_commands.cpp
+++ b/tests/test_drum_grid_pad_commands.cpp
@@ -8,6 +8,7 @@
 #include "magda/daw/core/PadCommands.hpp"
 #include "magda/daw/core/RackInfo.hpp"
 #include "magda/daw/core/SelectionManager.hpp"
+#include "magda/daw/core/TrackCommands.hpp"
 #include "magda/daw/core/TrackManager.hpp"
 #include "magda/daw/core/UndoManager.hpp"
 
@@ -1158,4 +1159,79 @@ TEST_CASE("A pad chain answering to more than one note can still be deleted",
     CHECK(tm.getPad(gridPath, 0) == nullptr);
     CHECK(tm.getPad(gridPath, 1) == nullptr);
     CHECK(tm.getPad(gridPath, 2) == nullptr);
+}
+
+TEST_CASE("A routed grid is restored by undoing its deletion",
+          "[drumgrid][pads][commands][undo][placement]") {
+    // The remove commands put the device back through
+    // `insertChainElementsByPath()`, and discard the result. A placement rule
+    // that refused a source-less reconstruction would therefore make undo
+    // restore nothing at all, silently (#2221).
+    resetState();
+    auto& tm = TrackManager::getInstance();
+
+    const auto trackId = tm.createTrack("Drums");
+    const auto gridId = tm.addDeviceToTrack(trackId, drumGridDevice());
+    const auto gridPath = ChainNodePath::topLevelDevice(trackId, gridId);
+    REQUIRE(tm.setPadDevice(gridPath, 0, padVoice("Kick")) != INVALID_DEVICE_ID);
+
+    // A pad on a bus, which only a top-level grid may have.
+    REQUIRE(tm.padBusesAvailable(gridPath));
+    REQUIRE(tm.setPadOutput(gridPath, 0, 1));
+    REQUIRE(tm.getPad(gridPath, 0)->outputIndex == 1);
+
+    auto& undo = UndoManager::getInstance();
+    undo.executeCommand(std::make_unique<RemoveDeviceByPathCommand>(gridPath));
+    REQUIRE(tm.getDeviceInChainByPath(gridPath) == nullptr);
+
+    REQUIRE(undo.undo());
+
+    const auto* restored = tm.getDeviceInChainByPath(gridPath);
+    REQUIRE(restored != nullptr);
+    CHECK(restored->id == gridId);
+
+    // With its routing intact, which is the whole reason ids are preserved.
+    const auto* pad = tm.getPad(gridPath, 0);
+    REQUIRE(pad != nullptr);
+    CHECK(pad->outputIndex == 1);
+}
+
+TEST_CASE("A routed grid pastes at track level but not into a rack",
+          "[drumgrid][pads][commands][placement]") {
+    // A copy keeps each pad's outputIndex, and owns no child tracks. A track's
+    // own list can carry its buses; a rack chain cannot (#2221).
+    resetState();
+    auto& tm = TrackManager::getInstance();
+
+    const auto trackId = tm.createTrack("Drums");
+    const auto gridId = tm.addDeviceToTrack(trackId, drumGridDevice());
+    const auto gridPath = ChainNodePath::topLevelDevice(trackId, gridId);
+    REQUIRE(tm.setPadDevice(gridPath, 0, padVoice("Kick")) != INVALID_DEVICE_ID);
+    REQUIRE(tm.setPadOutput(gridPath, 0, 1));
+
+    const auto rackId = tm.addRackToTrack(trackId, "FX Rack");
+    const auto rackChainId = tm.addChainToRack(ChainNodePath::rack(trackId, rackId));
+    const auto rackChainPath = ChainNodePath::chain(trackId, rackId, rackChainId);
+
+    const auto copyOfGrid = [&] {
+        std::vector<ChainElement> elements;
+        elements.push_back(makeDeviceElement(*tm.getDeviceInChainByPath(gridPath)));
+        return elements;
+    };
+
+    // A rack chain carries no bus off the grid, so it is refused and nothing
+    // lands there.
+    CHECK_FALSE(tm.insertChainElementsByPath(rackChainPath, copyOfGrid(), 0,
+                                             /*reassignIds=*/true));
+    CHECK(tm.getChainByPath(rackChainPath)->elements.empty());
+
+    // The track's own list carries them, so the paste is allowed.
+    REQUIRE(tm.insertChainElementsByPath(ChainNodePath::trackLevel(trackId), copyOfGrid(), 1,
+                                         /*reassignIds=*/true));
+    const auto& elements = tm.getTrack(trackId)->chain.fxChainElements;
+    REQUIRE(elements.size() == 3);  // grid, the copy, rack
+    const auto& clone = getDevice(elements[1]);
+    CHECK(clone.id != gridId);
+    REQUIRE(static_cast<bool>(clone.pads));
+    CHECK(clone.pads->chains[0].outputIndex == 1);
 }

--- a/tests/test_multi_out_tracks.cpp
+++ b/tests/test_multi_out_tracks.cpp
@@ -529,3 +529,48 @@ TEST_CASE("An instrument cannot be pasted onto a track that cannot host one",
                                        /*reassignIds=*/true));
     CHECK(tm.getTrack(auxId)->chain.fxChainElements.size() == 1);
 }
+
+TEST_CASE("Wrapping a nested device that drives child tracks is refused",
+          "[multi_out][lifecycle][ownership][placement]") {
+    // `wrapDeviceInRackByPath()` delegates its top-level case to
+    // `wrapDeviceInRack()`, but its nested branch extracted and wrapped the
+    // device on its own and so went round the placement boundary (#2221).
+    MultiOutTestFixture fixture;
+    auto& tm = fixture.tm();
+
+    const auto trackId = tm.createTrack("Inst", TrackType::Media);
+    const auto rackId = tm.addRackToTrack(trackId, "Rack");
+    const auto chainId = tm.addChainToRack(ChainNodePath::rack(trackId, rackId));
+    const auto chainPath = ChainNodePath::chain(trackId, rackId, chainId);
+
+    DeviceInfo instrument;
+    instrument.name = "MultiOutSynth";
+    instrument.format = PluginFormat::Internal;
+    instrument.pluginId = "multisynth";
+    instrument.isInstrument = true;
+    instrument.multiOut.isMultiOut = true;
+    instrument.multiOut.totalOutputChannels = 4;
+    instrument.multiOut.outputPairs = {{0, "Main 1-2", 1, 2}, {1, "Out 3-4", 3, 2}};
+
+    const auto deviceId = tm.addDeviceToChainByPath(chainPath, instrument);
+    REQUIRE(deviceId != INVALID_DEVICE_ID);
+
+    const auto childId = tm.activateMultiOutPair(trackId, deviceId, 1);
+    REQUIRE(childId != INVALID_TRACK_ID);
+
+    const auto devicePath = chainPath.withDevice(deviceId);
+    CHECK(tm.wrapDeviceInRackByPath(devicePath, "Wrapper") == INVALID_RACK_ID);
+
+    // Refused means unchanged: still directly in its chain, still driving its
+    // child track.
+    CHECK(tm.findDevicePath(deviceId) == devicePath);
+    const auto* chain = tm.getChainByPath(chainPath);
+    REQUIRE(chain != nullptr);
+    REQUIRE(chain->elements.size() == 1);
+    CHECK(isDevice(chain->elements[0]));
+    CHECK(tm.multiOutChildTrack(trackId, deviceId, 1) == childId);
+
+    // Closing the pair lets it wrap.
+    tm.deactivateMultiOutPair(trackId, deviceId, 1);
+    CHECK(tm.wrapDeviceInRackByPath(devicePath, "Wrapper") != INVALID_RACK_ID);
+}

--- a/tests/test_multi_out_tracks.cpp
+++ b/tests/test_multi_out_tracks.cpp
@@ -438,3 +438,94 @@ TEST_CASE("An active multi-out device reorders inside its own nested chain",
         tm.moveChainElement(chainPath.withDevice(deviceId), ChainNodePath::trackLevel(trackId), 0));
     CHECK(tm.multiOutChildTrack(trackId, deviceId, 1) == childId);
 }
+
+TEST_CASE("Wrapping a device that drives child tracks is refused",
+          "[multi_out][lifecycle][ownership][placement]") {
+    // Wrapping takes the device off the top level, where the output instance
+    // that carries a bus is made, so it strands the child track exactly as a
+    // move would. Wrap used to ask only whether a pad was on a bus, which a
+    // plain multi-out instrument never trips (#2221).
+    MultiOutTestFixture fixture;
+    auto& tm = fixture.tm();
+
+    auto [trackId, deviceId] = fixture.createMultiOutTrack();
+    const auto childId = tm.activateMultiOutPair(trackId, deviceId, 1);
+    REQUIRE(childId != INVALID_TRACK_ID);
+
+    CHECK(tm.wrapDeviceInRack(trackId, deviceId) == INVALID_RACK_ID);
+
+    // Refused means unchanged.
+    CHECK(tm.findDevicePath(deviceId) == ChainNodePath::topLevelDevice(trackId, deviceId));
+    CHECK(tm.multiOutChildTrack(trackId, deviceId, 1) == childId);
+
+    // Closing the pair lets it wrap.
+    tm.deactivateMultiOutPair(trackId, deviceId, 1);
+    CHECK(tm.wrapDeviceInRack(trackId, deviceId) != INVALID_RACK_ID);
+}
+
+TEST_CASE("Wrapping a selection containing such a device is refused",
+          "[multi_out][lifecycle][ownership][placement]") {
+    MultiOutTestFixture fixture;
+    auto& tm = fixture.tm();
+
+    auto [trackId, deviceId] = fixture.createMultiOutTrack();
+
+    DeviceInfo neighbour;
+    neighbour.name = "Delay";
+    neighbour.pluginId = "delay";
+    neighbour.format = PluginFormat::Internal;
+    const auto neighbourId = tm.addDeviceToTrack(trackId, neighbour);
+    REQUIRE(neighbourId != INVALID_DEVICE_ID);
+
+    const auto childId = tm.activateMultiOutPair(trackId, deviceId, 1);
+    REQUIRE(childId != INVALID_TRACK_ID);
+
+    const std::vector<ChainNodePath> selection{ChainNodePath::topLevelDevice(trackId, deviceId),
+                                               ChainNodePath::topLevelDevice(trackId, neighbourId)};
+
+    CHECK(tm.wrapChainElementsInRack(selection, "Rack") == INVALID_RACK_ID);
+
+    // Neither device moved, and the ownership stands.
+    CHECK(tm.findDevicePath(deviceId) == ChainNodePath::topLevelDevice(trackId, deviceId));
+    CHECK(tm.findDevicePath(neighbourId) == ChainNodePath::topLevelDevice(trackId, neighbourId));
+    CHECK(tm.multiOutChildTrack(trackId, deviceId, 1) == childId);
+}
+
+TEST_CASE("An instrument cannot be pasted onto a track that cannot host one",
+          "[multi_out][placement]") {
+    // insertChainElementsByPath asked nothing before, so paste could put an
+    // instrument where the move path refuses to put one (#2221).
+    MultiOutTestFixture fixture;
+    auto& tm = fixture.tm();
+
+    const auto auxId = tm.createTrack("Aux", TrackType::Aux);
+    REQUIRE(auxId != INVALID_TRACK_ID);
+    const auto* aux = tm.getTrack(auxId);
+    REQUIRE(aux != nullptr);
+    REQUIRE_FALSE(aux->canHostInstrument());
+
+    DeviceInfo instrument;
+    instrument.name = "MultiOutSynth";
+    instrument.pluginId = "multisynth";
+    instrument.format = PluginFormat::Internal;
+    instrument.isInstrument = true;
+
+    std::vector<ChainElement> pasted;
+    pasted.push_back(makeDeviceElement(instrument));
+
+    CHECK_FALSE(tm.insertChainElementsByPath(ChainNodePath::trackLevel(auxId), std::move(pasted), 0,
+                                             /*reassignIds=*/true));
+    CHECK(tm.getTrack(auxId)->chain.fxChainElements.empty());
+
+    // An effect is fine.
+    DeviceInfo effect;
+    effect.name = "Delay";
+    effect.pluginId = "delay";
+    effect.format = PluginFormat::Internal;
+
+    std::vector<ChainElement> effectPaste;
+    effectPaste.push_back(makeDeviceElement(effect));
+    CHECK(tm.insertChainElementsByPath(ChainNodePath::trackLevel(auxId), std::move(effectPaste), 0,
+                                       /*reassignIds=*/true));
+    CHECK(tm.getTrack(auxId)->chain.fxChainElements.size() == 1);
+}


### PR DESCRIPTION
Second step of #2221, which stays open for the third. Two more live bugs fall out of it.

## What was there

Move, paste and wrap each decided for themselves whether a subtree could go where it was being put, and each picked a different subset of the rules:

| operation | destination can host | pad on a bus | drives child tracks | rack inside itself |
| --- | --- | --- | --- | --- |
| `moveChainElement` | yes | the element only | yes | yes |
| `wrapDeviceInRack` | no | the element only | **no** | n/a |
| `wrapChainElementsInRack` | no | each element | **no** | n/a |
| `insertChainElementsByPath` | **no** | **no** | **no** | n/a |

## The two bugs

**Wrapping a device that drives multi-out child tracks was allowed.** Wrapping takes it off the top level, where the output instance that carries a bus is made, so it strands the child track exactly as a move would, and a move of the same device is refused. Wrap only ever asked about pads, which a plain multi-out instrument never trips.

**Pasting an instrument onto a track that cannot host one was allowed**, because `insertChainElementsByPath()` asked nothing.

## The change

`TrackManager::checkPlacement()` is the question. It takes what is being placed, where it is now, where it is going, and whether it leaves its container at all, and returns a typed `PlacementRefusal` rather than a bool so a caller can say why. Every rule examines the complete subtree, and none of them care whether the destination is a track's own list, a rack chain or a pad chain.

Move, paste, and both wrap paths call it. The rules themselves are unchanged apart from one widening: pad-on-a-bus is now subtree-wide, where the callers it replaces looked only at the element itself. That is not reachable today, because a grid inside a rack cannot put a pad on a bus in the first place, but the rule now says what it means rather than what happened to be enough.

Reordering inside the container a subtree already lives in is not a placement change and skips all of it, which is the distinction the multi-out guard learned in #2224.

## Tests

Three new cases: wrapping a device with an open multi-out pair, wrapping a selection containing one, and pasting an instrument onto an aux track. Each also checks the refusal left the model unchanged, and the first checks it wraps once the pair is closed.

I ran all three against the previous code first and confirmed they fail there.

3051 Catch2 cases and the JUCE target pass locally.

## Still to come on #2221

One commit boundary: preflight the whole subtree and destination, build the transformed value, then apply and notify once with a single undo boundary. That is the last of the three.

https://claude.ai/code/session_0187yiSdSJPmDFZafrSfbSop
