### PR TITLE
Make redo of a paste and a wrap reproduce the model they made

### DIFF
--- a/magda/daw/core/TrackCommands.cpp
+++ b/magda/daw/core/TrackCommands.cpp
@@ -570,10 +570,18 @@ PasteChainElementsCommand::PasteChainElementsCommand(const ChainNodePath& destin
 
 void PasteChainElementsCommand::execute() {
     auto& tm = TrackManager::getInstance();
-    auto elements = deepCopyChainElements(templateElements_);
+    const bool replaying = !materialised_.empty();
+
+    // A redo replays what the first run produced, ids and all. Re-copying the
+    // template would re-key it, giving every pasted device a fresh id and
+    // orphaning the links, automation lanes and aliases made against the first
+    // paste -- the same reason the removal commands restore under the id the
+    // device had (#2221).
+    auto elements =
+        replaying ? deepCopyChainElements(materialised_) : deepCopyChainElements(templateElements_);
     const int requestedIndex = insertIndex_;
     executed_ = tm.insertChainElementsByPath(destinationChainPath_, std::move(elements),
-                                             requestedIndex, true);
+                                             requestedIndex, !replaying);
     insertedPaths_.clear();
     if (!executed_)
         return;
@@ -607,6 +615,9 @@ void PasteChainElementsCommand::execute() {
         } else if (isRack(element)) {
             insertedPaths_.push_back(destinationChainPath_.withRack(getRack(element).id));
         }
+
+        if (!replaying)
+            materialised_.push_back(deepCopyElement(element));
     }
 }
 
@@ -653,7 +664,11 @@ void WrapChainElementsInRackCommand::execute() {
         return;
     }
 
-    rackId_ = tm.wrapChainElementsInRack(sourceElementPaths_, rackName_);
+    // A redo reuses the ids the first run allocated, so undo followed by redo
+    // leaves the rack with the identity it had rather than a fresh one (#2221).
+    const auto newRackId =
+        tm.wrapChainElementsInRack(sourceElementPaths_, rackName_, rackId_, chainId_);
+    rackId_ = newRackId;
     executed_ = rackId_ != INVALID_RACK_ID;
 
     if (executed_) {

--- a/magda/daw/core/TrackCommands.cpp
+++ b/magda/daw/core/TrackCommands.cpp
@@ -1,5 +1,6 @@
 #include "TrackCommands.hpp"
 
+#include <algorithm>
 #include <limits>
 
 #include "../audio/AudioBridge.hpp"
@@ -579,7 +580,25 @@ void PasteChainElementsCommand::execute() {
     // device had (#2221).
     auto elements =
         replaying ? deepCopyChainElements(materialised_) : deepCopyChainElements(templateElements_);
-    const int requestedIndex = insertIndex_;
+    const int elementCount = static_cast<int>(elements.size());
+
+    // The index the insert will actually use, taken against the destination as
+    // it is NOW. `insertChainElementsByPath()` clamps against the pre-insertion
+    // size, so reading it back afterwards against the larger list would start
+    // the bookkeeping past what was inserted: a stale or out-of-range index
+    // recorded some of the pasted elements, or none, and undo then left them
+    // behind while redo pasted another copy (#2221).
+    const auto* destinationBefore =
+        destinationChainPath_.steps.empty() ? nullptr : tm.getChainByPath(destinationChainPath_);
+    const auto* trackBefore = tm.getTrack(destinationChainPath_.trackId);
+    const int destinationSizeBefore =
+        destinationChainPath_.steps.empty()
+            ? (trackBefore != nullptr ? static_cast<int>(trackBefore->chain.fxChainElements.size())
+                                      : 0)
+            : (destinationBefore != nullptr ? static_cast<int>(destinationBefore->elements.size())
+                                            : 0);
+    const int requestedIndex = std::clamp(insertIndex_, 0, destinationSizeBefore);
+
     executed_ = tm.insertChainElementsByPath(destinationChainPath_, std::move(elements),
                                              requestedIndex, !replaying);
     insertedPaths_.clear();
@@ -601,9 +620,10 @@ void PasteChainElementsCommand::execute() {
     const auto& destinationElements = destinationChainPath_.steps.empty()
                                           ? track->chain.fxChainElements
                                           : destinationChain->elements;
-    const int start = std::clamp(requestedIndex, 0, static_cast<int>(destinationElements.size()));
-    for (int i = 0; i < static_cast<int>(templateElements_.size()) &&
-                    start + i < static_cast<int>(destinationElements.size());
+    // `requestedIndex` is already the effective one, so the inserted elements are
+    // exactly [start, start + elementCount).
+    const int start = requestedIndex;
+    for (int i = 0; i < elementCount && start + i < static_cast<int>(destinationElements.size());
          ++i) {
         const auto& element = destinationElements[static_cast<size_t>(start + i)];
         if (isDevice(element)) {
@@ -649,6 +669,7 @@ void WrapChainElementsInRackCommand::execute() {
 
     sourceChainPath_ = parentChainOf(sourceElementPaths_.front());
     sourceIndex_ = std::numeric_limits<int>::max();
+    sourceIndices_.clear();
     for (const auto& path : sourceElementPaths_) {
         if (parentChainOf(path) != sourceChainPath_) {
             executed_ = false;
@@ -656,9 +677,14 @@ void WrapChainElementsInRackCommand::execute() {
         }
 
         const int index = tm.getChainElementIndex(path);
-        if (index >= 0)
+        if (index >= 0) {
             sourceIndex_ = std::min(sourceIndex_, index);
+            sourceIndices_.push_back(index);
+        }
     }
+    // Ascending, which is the order the wrap itself puts them in the rack, so an
+    // index and a child line up.
+    std::sort(sourceIndices_.begin(), sourceIndices_.end());
     if (sourceIndex_ == std::numeric_limits<int>::max()) {
         executed_ = false;
         return;
@@ -697,9 +723,23 @@ void WrapChainElementsInRackCommand::undo() {
             childPaths.push_back(chainPath.withRack(getRack(element).id));
     }
 
-    int insertIndex = sourceIndex_;
-    for (const auto& childPath : childPaths)
-        tm.moveChainElement(childPath, sourceChainPath_, insertIndex++);
+    // Each child goes back to the index it came from, not to a run starting at
+    // the lowest one: a selection can have gaps, and closing them reorders the
+    // chain (#2221).
+    //
+    // The rack is still standing while they move, occupying one slot at
+    // `rackIndex`, so a child whose home is past it aims one higher and lands
+    // right when the rack goes. `rackIndex` rises as children are put in front
+    // of it.
+    int rackIndex = sourceIndex_;
+    for (std::size_t i = 0; i < childPaths.size(); ++i) {
+        const int home =
+            i < sourceIndices_.size() ? sourceIndices_[i] : sourceIndex_ + static_cast<int>(i);
+        const int target = home <= rackIndex ? home : home + 1;
+        tm.moveChainElement(childPaths[i], sourceChainPath_, target);
+        if (target <= rackIndex)
+            ++rackIndex;
+    }
 
     tm.removeRackFromChainByPath(rackPath);
 }

--- a/magda/daw/core/TrackCommands.hpp
+++ b/magda/daw/core/TrackCommands.hpp
@@ -247,6 +247,12 @@ class WrapChainElementsInRackCommand : public UndoableCommand {
     RackId rackId_ = INVALID_RACK_ID;
     ChainId chainId_ = INVALID_CHAIN_ID;
     int sourceIndex_ = -1;
+    /// Where each wrapped element stood, ascending.
+    ///
+    /// A selection need not be contiguous. Remembering only the lowest index and
+    /// reinserting everything from there closed the gaps, so wrapping the first
+    /// and third of three and undoing reordered the chain (#2221).
+    std::vector<int> sourceIndices_;
     bool executed_ = false;
 };
 

--- a/magda/daw/core/TrackCommands.hpp
+++ b/magda/daw/core/TrackCommands.hpp
@@ -213,6 +213,13 @@ class PasteChainElementsCommand : public UndoableCommand {
   private:
     ChainNodePath destinationChainPath_;
     std::vector<ChainElement> templateElements_;
+    /// What the first execute actually produced, ids included.
+    ///
+    /// A redo replays this rather than re-copying the template: the template is
+    /// re-keyed on the way in, so re-deriving it would give every pasted device
+    /// a fresh id and orphan the links, automation lanes and aliases made
+    /// against the first paste (#2221).
+    std::vector<ChainElement> materialised_;
     std::vector<ChainNodePath> insertedPaths_;
     int insertIndex_ = 0;
     bool executed_ = false;

--- a/magda/daw/core/TrackManager.hpp
+++ b/magda/daw/core/TrackManager.hpp
@@ -712,8 +712,17 @@ class TrackManager : public daw::audio::DeviceIdAllocator, public daw::audio::De
     bool insertChainElementsByPath(const ChainNodePath& destinationChainPath,
                                    std::vector<ChainElement> elements, int insertIndex,
                                    bool reassignIds = true);
+    /// Wrap @p paths in a new rack.
+    ///
+    /// @p presetRackId and @p presetChainId let a redo reuse the ids its first
+    /// run allocated. Re-deriving them would give the rack a different identity
+    /// each time, so every link, automation lane and alias naming it would be
+    /// orphaned by an undo followed by a redo -- the same reason the removal
+    /// commands restore a device under the id it had (#2221).
     RackId wrapChainElementsInRack(const std::vector<ChainNodePath>& paths,
-                                   const juce::String& rackName = "Rack");
+                                   const juce::String& rackName = "Rack",
+                                   RackId presetRackId = INVALID_RACK_ID,
+                                   ChainId presetChainId = INVALID_CHAIN_ID);
     int getChainElementIndex(const ChainNodePath& elementPath);
     DeviceInfo* getDeviceInChain(TrackId trackId, RackId rackId, ChainId chainId,
                                  DeviceId deviceId);

--- a/magda/daw/core/TrackManagerDevices.cpp
+++ b/magda/daw/core/TrackManagerDevices.cpp
@@ -1067,7 +1067,8 @@ bool TrackManager::insertChainElementsByPath(const ChainNodePath& destinationCha
 }
 
 RackId TrackManager::wrapChainElementsInRack(const std::vector<ChainNodePath>& paths,
-                                             const juce::String& rackName) {
+                                             const juce::String& rackName, RackId presetRackId,
+                                             ChainId presetChainId) {
     if (paths.empty())
         return INVALID_RACK_ID;
 
@@ -1102,10 +1103,12 @@ RackId TrackManager::wrapChainElementsInRack(const std::vector<ChainNodePath>& p
                      [](const auto& a, const auto& b) { return a.first < b.first; });
 
     RackInfo rack;
-    rack.id = allocateRackId();
+    // A redo passes the ids its first run allocated, so the rack keeps the
+    // identity every link naming it was made against (#2221).
+    rack.id = presetRackId != INVALID_RACK_ID ? presetRackId : allocateRackId();
     rack.name = rackName.isEmpty() ? "Rack" : rackName;
     ChainInfo chain;
-    chain.id = allocateChainId();
+    chain.id = presetChainId != INVALID_CHAIN_ID ? presetChainId : allocateChainId();
     chain.name = "Chain 1";
 
     if (audioEngine_) {

--- a/magda/daw/project/serialization/ProjectSerializer.hpp
+++ b/magda/daw/project/serialization/ProjectSerializer.hpp
@@ -145,6 +145,17 @@ class ProjectSerializer {
     // the track and clip managers standing up around it, which buys nothing.
     // ========================================================================
 
+    /**
+     * @brief Serialize one track, its chain included.
+     *
+     * Public for the same reason `serializeClipInfo` is: it is a pure function
+     * of the value it is given, and the serialized form is the only way to state
+     * that a structural edit and its undo left the model where they found it
+     * (#2221).
+     */
+    static juce::var serializeTrackInfo(const TrackInfo& track);
+    static bool deserializeTrackInfo(const juce::var& json, TrackInfo& outTrack);
+
     static juce::var serializeClipInfo(const ClipInfo& clip);
 
     /// Provisional id for a v1 source staged rather than pooled. Negative so
@@ -277,9 +288,6 @@ class ProjectSerializer {
     // ========================================================================
     // Track serialization helpers
     // ========================================================================
-
-    static juce::var serializeTrackInfo(const TrackInfo& track);
-    static bool deserializeTrackInfo(const juce::var& json, TrackInfo& outTrack);
 
     // serializeChainElement / DeviceInfo / RackInfo / ChainInfo are declared
     // public above so PresetManager can use them.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -37,6 +37,7 @@ set(TEST_SOURCES
     test_chain_info_copy.cpp
     test_drum_grid_pad_commands.cpp
     test_pad_path_types.cpp
+    test_structural_undo_roundtrip.cpp
     test_drum_grid_pads.cpp
     test_drum_grid_pads_corpus.cpp
     test_chain_routing_model.cpp

--- a/tests/test_structural_undo_roundtrip.cpp
+++ b/tests/test_structural_undo_roundtrip.cpp
@@ -1,0 +1,185 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "magda/daw/core/ClipManager.hpp"
+#include "magda/daw/core/DrumGridPads.hpp"
+#include "magda/daw/core/RackInfo.hpp"
+#include "magda/daw/core/SelectionManager.hpp"
+#include "magda/daw/core/TrackCommands.hpp"
+#include "magda/daw/core/TrackManager.hpp"
+#include "magda/daw/core/UndoManager.hpp"
+#include "magda/daw/project/serialization/ProjectSerializer.hpp"
+
+using namespace magda;
+
+// Undo of a structural edit restores the serialized model exactly (#2221).
+//
+// Move, paste, wrap and remove each save and restore their own idea of what
+// they changed. The property that matters is not that they save something, but
+// that what comes back serializes to the same bytes: an id allocated on the way
+// out, a link retargeted and not put back, a notification without a matching
+// mutation are all invisible to a test that only checks the device is present
+// again. Comparing the serialized track is what catches them.
+
+namespace {
+
+void resetState() {
+    ClipManager::getInstance().clearAllClips();
+    TrackManager::getInstance().clearAllTracks();
+    SelectionManager::getInstance().clearSelection();
+    UndoManager::getInstance().clearHistory();
+}
+
+/// Every track, serialized, in order. The comparison subject.
+juce::String snapshot() {
+    juce::Array<juce::var> tracks;
+    for (const auto& track : TrackManager::getInstance().getTracks())
+        tracks.add(ProjectSerializer::serializeTrackInfo(track));
+    return juce::JSON::toString(juce::var(tracks), false);
+}
+
+DeviceInfo effect(const juce::String& name) {
+    DeviceInfo device;
+    device.name = name;
+    device.pluginId = "delay";
+    device.format = PluginFormat::Internal;
+    return device;
+}
+
+DeviceInfo drumGrid() {
+    DeviceInfo device;
+    device.name = "Drum Grid";
+    device.pluginId = "drumgrid";
+    device.format = PluginFormat::Internal;
+    device.isInstrument = true;
+    device.deviceType = DeviceType::Instrument;
+    return device;
+}
+
+/// Run @p command through the undo stack and assert the round trip.
+///
+/// Undo must restore the bytes the model had before, and redo must reproduce
+/// the bytes it had after, so the operation is a single reversible step rather
+/// than one that merely ends up somewhere plausible.
+void requireUndoRoundTrip(std::unique_ptr<UndoableCommand> command) {
+    auto& undo = UndoManager::getInstance();
+
+    const auto before = snapshot();
+    undo.executeCommand(std::move(command));
+    const auto after = snapshot();
+    REQUIRE(before != after);  // The operation did something to compare.
+
+    REQUIRE(undo.undo());
+    CHECK(snapshot() == before);
+
+    REQUIRE(undo.redo());
+    CHECK(snapshot() == after);
+}
+
+}  // namespace
+
+TEST_CASE("Undoing a move restores the serialized model", "[structural][undo][roundtrip]") {
+    resetState();
+    auto& tm = TrackManager::getInstance();
+
+    const auto trackId = tm.createTrack("Track");
+    const auto first = tm.addDeviceToTrack(trackId, effect("First"));
+    tm.addDeviceToTrack(trackId, effect("Second"));
+    tm.addDeviceToTrack(trackId, effect("Third"));
+
+    requireUndoRoundTrip(std::make_unique<MoveChainElementCommand>(
+        ChainNodePath::topLevelDevice(trackId, first), ChainNodePath::trackLevel(trackId), 3));
+}
+
+TEST_CASE("Undoing a move into a rack chain restores the serialized model",
+          "[structural][undo][roundtrip]") {
+    resetState();
+    auto& tm = TrackManager::getInstance();
+
+    const auto trackId = tm.createTrack("Track");
+    const auto deviceId = tm.addDeviceToTrack(trackId, effect("Mover"));
+    const auto rackId = tm.addRackToTrack(trackId, "Rack");
+    const auto chainId = tm.addChainToRack(ChainNodePath::rack(trackId, rackId));
+
+    requireUndoRoundTrip(std::make_unique<MoveChainElementCommand>(
+        ChainNodePath::topLevelDevice(trackId, deviceId),
+        ChainNodePath::chain(trackId, rackId, chainId), 0));
+}
+
+TEST_CASE("Undoing a cross-track move restores the serialized model",
+          "[structural][undo][roundtrip]") {
+    resetState();
+    auto& tm = TrackManager::getInstance();
+
+    const auto source = tm.createTrack("Source");
+    const auto destination = tm.createTrack("Destination");
+    const auto deviceId = tm.addDeviceToTrack(source, effect("Mover"));
+    tm.addDeviceToTrack(destination, effect("Resident"));
+
+    requireUndoRoundTrip(
+        std::make_unique<MoveChainElementCommand>(ChainNodePath::topLevelDevice(source, deviceId),
+                                                  ChainNodePath::trackLevel(destination), 0));
+}
+
+TEST_CASE("Undoing a paste restores the serialized model", "[structural][undo][roundtrip]") {
+    resetState();
+    auto& tm = TrackManager::getInstance();
+
+    const auto trackId = tm.createTrack("Track");
+    tm.addDeviceToTrack(trackId, effect("Resident"));
+
+    std::vector<ChainElement> pasted;
+    pasted.push_back(makeDeviceElement(effect("Pasted")));
+
+    requireUndoRoundTrip(std::make_unique<PasteChainElementsCommand>(
+        ChainNodePath::trackLevel(trackId), std::move(pasted), 1));
+}
+
+TEST_CASE("Undoing a wrap restores the serialized model", "[structural][undo][roundtrip]") {
+    resetState();
+    auto& tm = TrackManager::getInstance();
+
+    const auto trackId = tm.createTrack("Track");
+    const auto first = tm.addDeviceToTrack(trackId, effect("First"));
+    const auto second = tm.addDeviceToTrack(trackId, effect("Second"));
+
+    requireUndoRoundTrip(std::make_unique<WrapChainElementsInRackCommand>(
+        std::vector<ChainNodePath>{ChainNodePath::topLevelDevice(trackId, first),
+                                   ChainNodePath::topLevelDevice(trackId, second)},
+        "Wrapper"));
+}
+
+TEST_CASE("Undoing a device removal restores the serialized model",
+          "[structural][undo][roundtrip]") {
+    resetState();
+    auto& tm = TrackManager::getInstance();
+
+    const auto trackId = tm.createTrack("Track");
+    tm.addDeviceToTrack(trackId, effect("Keeper"));
+    const auto doomed = tm.addDeviceToTrack(trackId, effect("Doomed"));
+    tm.addDeviceToTrack(trackId, effect("Other"));
+
+    requireUndoRoundTrip(std::make_unique<RemoveDeviceByPathCommand>(
+        ChainNodePath::topLevelDevice(trackId, doomed)));
+}
+
+TEST_CASE("Undoing the removal of a routed grid restores the serialized model",
+          "[structural][undo][roundtrip][pads]") {
+    resetState();
+    auto& tm = TrackManager::getInstance();
+
+    const auto trackId = tm.createTrack("Drums");
+    const auto gridId = tm.addDeviceToTrack(trackId, drumGrid());
+    const auto gridPath = ChainNodePath::topLevelDevice(trackId, gridId);
+
+    DeviceInfo voice;
+    voice.name = "Kick";
+    voice.pluginId = "magdasampler";
+    voice.format = PluginFormat::Internal;
+    voice.isInstrument = true;
+    voice.deviceType = DeviceType::Instrument;
+    REQUIRE(tm.setPadDevice(gridPath, 0, voice) != INVALID_DEVICE_ID);
+    REQUIRE(tm.setPadOutput(gridPath, 0, 1));
+
+    UndoManager::getInstance().clearHistory();
+    requireUndoRoundTrip(std::make_unique<RemoveDeviceByPathCommand>(gridPath));
+}

--- a/tests/test_structural_undo_roundtrip.cpp
+++ b/tests/test_structural_undo_roundtrip.cpp
@@ -134,6 +134,26 @@ TEST_CASE("Undoing a paste restores the serialized model", "[structural][undo][r
         ChainNodePath::trackLevel(trackId), std::move(pasted), 1));
 }
 
+TEST_CASE("Undoing a paste at an out-of-range index restores the serialized model",
+          "[structural][undo][roundtrip]") {
+    // The insert clamps the requested index against the destination as it was.
+    // Bookkeeping that read the index back against the larger list started past
+    // what had been inserted, so undo left pasted elements behind and redo
+    // pasted another copy on top.
+    resetState();
+    auto& tm = TrackManager::getInstance();
+
+    const auto trackId = tm.createTrack("Track");
+    tm.addDeviceToTrack(trackId, effect("Resident"));
+
+    std::vector<ChainElement> pasted;
+    pasted.push_back(makeDeviceElement(effect("First")));
+    pasted.push_back(makeDeviceElement(effect("Second")));
+
+    requireUndoRoundTrip(std::make_unique<PasteChainElementsCommand>(
+        ChainNodePath::trackLevel(trackId), std::move(pasted), 99));
+}
+
 TEST_CASE("Undoing a wrap restores the serialized model", "[structural][undo][roundtrip]") {
     resetState();
     auto& tm = TrackManager::getInstance();
@@ -145,6 +165,26 @@ TEST_CASE("Undoing a wrap restores the serialized model", "[structural][undo][ro
     requireUndoRoundTrip(std::make_unique<WrapChainElementsInRackCommand>(
         std::vector<ChainNodePath>{ChainNodePath::topLevelDevice(trackId, first),
                                    ChainNodePath::topLevelDevice(trackId, second)},
+        "Wrapper"));
+}
+
+TEST_CASE("Undoing a wrap of a noncontiguous selection restores the serialized model",
+          "[structural][undo][roundtrip]") {
+    // The context menu accepts an arbitrary multi-selection. Reinserting every
+    // wrapped element in one run from the lowest index closes the gaps between
+    // them, which reorders the chain and so changes what it sounds like.
+    resetState();
+    auto& tm = TrackManager::getInstance();
+
+    const auto trackId = tm.createTrack("Track");
+    const auto first = tm.addDeviceToTrack(trackId, effect("First"));
+    tm.addDeviceToTrack(trackId, effect("Gap"));
+    const auto third = tm.addDeviceToTrack(trackId, effect("Third"));
+    tm.addDeviceToTrack(trackId, effect("Fourth"));
+
+    requireUndoRoundTrip(std::make_unique<WrapChainElementsInRackCommand>(
+        std::vector<ChainNodePath>{ChainNodePath::topLevelDevice(trackId, first),
+                                   ChainNodePath::topLevelDevice(trackId, third)},
         "Wrapper"));
 }
 


### PR DESCRIPTION
Third step of #2221. The harness is as much the deliverable as the two fixes it found.

## The harness

`tests/test_structural_undo_roundtrip.cpp` snapshots every track through `serializeTrackInfo()`, runs one structural command through the undo stack, and requires that **undo restores the bytes it started from** and **redo reproduces the bytes it made**.

That is a sharper question than the tests we had. "The device is back" cannot tell a restored model from a merely plausible one: an id allocated on the way out, a link retargeted and not put back, a notification with no matching mutation are all invisible to it. Comparing the serialized track is not.

Seven operations covered: move within a list, move into a rack chain, cross-track move, paste, wrap, device removal, and removal of a Drum Grid with a routed pad.

## What it found

Five passed. Paste and wrap both failed, on the redo.

**Paste** re-copied `templateElements_` on every execute and inserted it with ids reassigned, so a redo gave each pasted device a fresh id.

**Wrap** called `wrapChainElementsInRack()` again, which allocated a fresh rack id and chain id.

In both cases undo followed by redo left the model holding elements that no earlier link, automation lane or alias could name. That is exactly the failure the removal commands already guard against, and say so in their comments: "undo would restore it under a different id and orphan every automation lane, macro link, and alias that targeted it." Paste and wrap had the same problem and no test that could see it.

## The fixes

Paste records what its first run actually produced, ids and all, and replays that with re-keying off. The template is still what a first execute copies.

Wrap passes the ids its first run allocated back into `wrapChainElementsInRack()`, which uses them when given them and allocates otherwise. Same shape as the removal commands preserving a DeviceId.

`serializeTrackInfo()` is now public, for the same reason `serializeClipInfo()` already is: it is a pure function of the value it is given, and the serialized form is the only way to state this property.

## Not changed, and why

Two of the issue's criteria were already met and I am not touching them:

- **Engine sync does not mutate the project model.** The only `TrackManager` write left in `PluginManagerSync` is `setEnabled` on a plugin, which is runtime state. The structural repair went with #2224.
- **`moveChainElement` emits two notifications**, but for two different tracks on a cross-track move. That is correct rather than partial; "notify once" means once per affected track.

3062 Catch2 cases and the JUCE target pass locally.

## What is left on #2221

The remaining criterion is the transition matrix: active multi-out grids moved or copied among top-level tracks, rack chains, pad chains and nested racks, as a systematic sweep rather than the individual cases the last three PRs added. Worth doing once this is in, and it may be worth closing the issue and filing that separately, since the three structural halves it asked for are now done.

https://claude.ai/code/session_0187yiSdSJPmDFZafrSfbSop
