### PR TITLE
Sweep the structural matrix, and fix the five things it found (#2229)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1181,10 +1181,16 @@ jobs:
     # A timeout is here to catch a hang, not to enforce a performance budget.
     # At five minutes it was doing the second job badly: the last green run on
     # dev finished this step in 4:53, so any test added anywhere in the suite
-    # failed Windows and nowhere else, with a timeout for a message. Fifteen
-    # still catches a hang and stops the gate going red over seven seconds.
+    # failed Windows and nowhere else, with a timeout for a message.
+    #
+    # Fifteen went the same way. The suite reached 11:32 on dev, and the next
+    # test matrix added anywhere took it over, again on Windows and nowhere
+    # else. Debug MSVC runs this suite about ten times slower than a Debug
+    # clang build does, so this is the step that meets every addition first.
+    # Thirty still kills a hang long before the job's own limit, and leaves the
+    # suite room to grow without the gate reading "timed out" for "slower".
     - name: Run tests
-      timeout-minutes: 15
+      timeout-minutes: 30
       run: |
         $testExe = Get-ChildItem -Path build-debug -Recurse -Filter "magda_tests.exe" | Select-Object -First 1
         if ($testExe) {

--- a/magda/daw/core/ChainNodePath.hpp
+++ b/magda/daw/core/ChainNodePath.hpp
@@ -286,29 +286,35 @@ struct ChainNodePath {
         return p;
     }
 
-    // Create a path by extending an existing path
-    ChainNodePath withRack(RackId r) const {
+    // Create a path by extending an existing path.
+    //
+    // Extending clears `isTrackLevel`: a path that descends into a step names
+    // something inside the track rather than the track itself, and a path
+    // claiming both is answered as track-level by `getType()` whatever its
+    // steps say. `trackLevel(t).withRack(r)` used to build exactly that, so a
+    // rack pasted into a track's own list was recorded under a path that read
+    // back as the track, and undo left it standing (#2229).
+    ChainNodePath extendedWith(ChainPathStep step) const {
         ChainNodePath p = *this;
-        p.steps.push_back({ChainStepType::Rack, r});
+        p.isTrackLevel = false;
+        p.steps.push_back(step);
         return p;
+    }
+
+    ChainNodePath withRack(RackId r) const {
+        return extendedWith({ChainStepType::Rack, r});
     }
 
     ChainNodePath withChain(ChainId c) const {
-        ChainNodePath p = *this;
-        p.steps.push_back({ChainStepType::Chain, c});
-        return p;
+        return extendedWith({ChainStepType::Chain, c});
     }
 
     ChainNodePath withPadChain(ChainId c) const {
-        ChainNodePath p = *this;
-        p.steps.push_back({ChainStepType::PadChain, c});
-        return p;
+        return extendedWith({ChainStepType::PadChain, c});
     }
 
     ChainNodePath withDevice(DeviceId d) const {
-        ChainNodePath p = *this;
-        p.steps.push_back({ChainStepType::Device, d});
-        return p;
+        return extendedWith({ChainStepType::Device, d});
     }
 
     // Get the parent path (without the last step)

--- a/magda/daw/core/TrackCommands.cpp
+++ b/magda/daw/core/TrackCommands.cpp
@@ -202,7 +202,7 @@ void DeleteTrackCommand::execute() {
     // Store full track info, position and clips for undo (only on first execute)
     if (!executed_) {
         storedTrack_ = *track;
-        storedIndex_ = trackManager.getTrackIndex(trackId_);
+        storedPosition_ = trackManager.restorePositionOf(trackId_);
     }
 
     // Store and remove all clips on this track
@@ -228,7 +228,7 @@ void DeleteTrackCommand::undo() {
         return;
     }
 
-    TrackManager::getInstance().restoreTrack(storedTrack_, storedIndex_);
+    TrackManager::getInstance().restoreTrack(storedTrack_, storedPosition_);
 
     // Restore clips that were on this track
     auto& clipManager = ClipManager::getInstance();
@@ -260,7 +260,7 @@ void DuplicateTrackCommand::execute() {
     if (executed_) {
         if (duplicatedTrackId_ == INVALID_TRACK_ID)
             return;
-        trackManager.restoreTrack(storedTrack_, storedIndex_);
+        trackManager.restoreTrack(storedTrack_, storedPosition_);
         for (const auto& clip : storedClips_)
             clipManager.restoreClip(clip);
         return;
@@ -294,7 +294,7 @@ void DuplicateTrackCommand::execute() {
     // What it made, so a redo can make exactly that again.
     if (const auto* made = trackManager.getTrack(duplicatedTrackId_)) {
         storedTrack_ = *made;
-        storedIndex_ = trackManager.getTrackIndex(duplicatedTrackId_);
+        storedPosition_ = trackManager.restorePositionOf(duplicatedTrackId_);
         storedClips_.clear();
         for (auto clipId : clipManager.getClipsOnTrack(duplicatedTrackId_))
             if (const auto* clip = clipManager.getClip(clipId))

--- a/magda/daw/core/TrackCommands.cpp
+++ b/magda/daw/core/TrackCommands.cpp
@@ -92,6 +92,31 @@ bool describeChainElementPath(const ChainNodePath& path, ChainStepType& type, in
 
     return false;
 }
+
+/// The index to hand `moveChainElement()` so @p elementPath comes to rest at
+/// @p homeIndex of @p homeChain.
+///
+/// The two are not the same number. `homeIndex` is where the element stood,
+/// counted with itself still in the list. `moveChainElement()` takes a drop
+/// position -- insert before whatever stands there now -- and drops one when
+/// the element is travelling up a list it is already in, because removing it
+/// first shifts everything past it down. So an element on its way back up its
+/// own container has to aim one slot past its home to land on it.
+///
+/// One conversion, because it was written twice and only one of them was right:
+/// the multi-element undo made the correction, the single-element one passed the
+/// home index straight through, and so undoing a drag that moved a device
+/// towards the front of its chain put it back one slot too early
+/// (#2229). `WrapChainElementsInRackCommand::undo()` makes the same correction
+/// against the standing rack.
+int dropIndexForHome(TrackManager& tm, const ChainNodePath& elementPath,
+                     const ChainNodePath& homeChain, int homeIndex) {
+    if (parentChainOf(elementPath) != homeChain)
+        return homeIndex;
+
+    const int currentIndex = tm.getChainElementIndex(elementPath);
+    return currentIndex >= 0 && currentIndex < homeIndex ? homeIndex + 1 : homeIndex;
+}
 }  // namespace
 
 // ============================================================================
@@ -174,9 +199,10 @@ void DeleteTrackCommand::execute() {
         return;
     }
 
-    // Store full track info and clips for undo (only on first execute)
+    // Store full track info, position and clips for undo (only on first execute)
     if (!executed_) {
         storedTrack_ = *track;
+        storedIndex_ = trackManager.getTrackIndex(trackId_);
     }
 
     // Store and remove all clips on this track
@@ -202,7 +228,7 @@ void DeleteTrackCommand::undo() {
         return;
     }
 
-    TrackManager::getInstance().restoreTrack(storedTrack_);
+    TrackManager::getInstance().restoreTrack(storedTrack_, storedIndex_);
 
     // Restore clips that were on this track
     auto& clipManager = ClipManager::getInstance();
@@ -225,6 +251,20 @@ DuplicateTrackCommand::DuplicateTrackCommand(TrackId sourceTrackId, bool duplica
 
 void DuplicateTrackCommand::execute() {
     auto& trackManager = TrackManager::getInstance();
+    auto& clipManager = ClipManager::getInstance();
+
+    // A redo puts back what the first run made rather than duplicating again:
+    // duplicating again allocates a fresh TrackId and fresh device, rack and
+    // chain ids, so undo followed by redo would leave a different project than
+    // the one the undo took away (#2229).
+    if (executed_) {
+        if (duplicatedTrackId_ == INVALID_TRACK_ID)
+            return;
+        trackManager.restoreTrack(storedTrack_, storedIndex_);
+        for (const auto& clip : storedClips_)
+            clipManager.restoreClip(clip);
+        return;
+    }
 
     // Capture current plugin state so the duplicate gets the source's live settings.
     // Skipped when we're stripping the FX chain anyway — nothing to carry over.
@@ -239,7 +279,6 @@ void DuplicateTrackCommand::execute() {
     duplicatedTrackId_ = trackManager.duplicateTrack(sourceTrackId_, duplicateDevices_);
 
     if (duplicateContent_ && duplicatedTrackId_ != INVALID_TRACK_ID) {
-        auto& clipManager = ClipManager::getInstance();
         auto clipIds = clipManager.getClipsOnTrack(sourceTrackId_);
         const double projectBpm = ProjectManager::getInstance().getCurrentProjectInfo().tempo;
         const double bpm = isValidBpm(projectBpm) ? projectBpm : DEFAULT_BPM;
@@ -250,6 +289,16 @@ void DuplicateTrackCommand::execute() {
                                             bpm);
             }
         }
+    }
+
+    // What it made, so a redo can make exactly that again.
+    if (const auto* made = trackManager.getTrack(duplicatedTrackId_)) {
+        storedTrack_ = *made;
+        storedIndex_ = trackManager.getTrackIndex(duplicatedTrackId_);
+        storedClips_.clear();
+        for (auto clipId : clipManager.getClipsOnTrack(duplicatedTrackId_))
+            if (const auto* clip = clipManager.getClip(clipId))
+                storedClips_.push_back(*clip);
     }
 
     executed_ = true;
@@ -263,7 +312,7 @@ void DuplicateTrackCommand::undo() {
 
     // Delete all clips on the duplicated track before deleting the track
     auto& clipManager = ClipManager::getInstance();
-    auto clipIds = clipManager.getClipsOnTrack(duplicatedTrackId_);
+    const auto clipIds = clipManager.getClipsOnTrack(duplicatedTrackId_);
     for (auto clipId : clipIds) {
         clipManager.deleteClip(clipId);
     }
@@ -415,7 +464,9 @@ void MoveChainElementCommand::undo() {
     if (!executed_)
         return;
 
-    TrackManager::getInstance().moveChainElement(movedElementPath_, undoChainPath_, undoIndex_);
+    auto& tm = TrackManager::getInstance();
+    tm.moveChainElement(movedElementPath_, undoChainPath_,
+                        dropIndexForHome(tm, movedElementPath_, undoChainPath_, undoIndex_));
 }
 
 // ============================================================================
@@ -507,17 +558,13 @@ void MoveChainElementsCommand::undo() {
         if (!currentPath.isValid())
             return;
 
-        int insertIndex = record.originalIndex;
-        const auto currentParentPath = parentChainOf(currentPath);
-        const int currentIndex = tm.getChainElementIndex(currentPath);
-        if (currentParentPath == record.originalParentPath) {
-            if (currentIndex == record.originalIndex)
-                return;
-            if (currentIndex >= 0 && currentIndex < record.originalIndex)
-                ++insertIndex;
-        }
+        if (parentChainOf(currentPath) == record.originalParentPath &&
+            tm.getChainElementIndex(currentPath) == record.originalIndex)
+            return;
 
-        tm.moveChainElement(currentPath, record.originalParentPath, insertIndex);
+        tm.moveChainElement(
+            currentPath, record.originalParentPath,
+            dropIndexForHome(tm, currentPath, record.originalParentPath, record.originalIndex));
     };
 
     auto begin = records.begin();

--- a/magda/daw/core/TrackCommands.cpp
+++ b/magda/daw/core/TrackCommands.cpp
@@ -1,6 +1,7 @@
 #include "TrackCommands.hpp"
 
 #include <algorithm>
+#include <functional>
 #include <limits>
 
 #include "../audio/AudioBridge.hpp"
@@ -185,6 +186,40 @@ juce::String CreateTrackCommand::getDescription() const {
 
 DeleteTrackCommand::DeleteTrackCommand(TrackId trackId) : trackId_(trackId) {}
 
+std::vector<DeleteTrackCommand::DeletedTrack> DeleteTrackCommand::collectSubtree(TrackId trackId) {
+    auto& tm = TrackManager::getInstance();
+    std::vector<DeletedTrack> records;
+
+    const std::function<void(TrackId)> descend = [&](TrackId id) {
+        const auto* track = tm.getTrack(id);
+        if (track == nullptr)
+            return;
+
+        DeletedTrack record;
+        record.track = *track;
+        record.position = tm.restorePositionOf(id);
+
+        auto& clipManager = ClipManager::getInstance();
+        for (auto clipId : clipManager.getClipsOnTrack(id))
+            if (const auto* clip = clipManager.getClip(clipId))
+                record.clips.push_back(*clip);
+
+        records.push_back(std::move(record));
+
+        for (auto childId : track->childIds)
+            descend(childId);
+    };
+
+    descend(trackId);
+
+    // By where each stood, so refilling the list left to right lands every one
+    // of them on its own index.
+    std::stable_sort(records.begin(), records.end(), [](const auto& a, const auto& b) {
+        return a.position.trackIndex < b.position.trackIndex;
+    });
+    return records;
+}
+
 void DeleteTrackCommand::execute() {
     // The master track is permanent. Bail before touching clips or storing undo
     // state so the command is a clean no-op (undo() is gated on executed_).
@@ -199,28 +234,18 @@ void DeleteTrackCommand::execute() {
         return;
     }
 
-    // Store full track info, position and clips for undo (only on first execute)
+    // The whole subtree, because deleteTrack() cascades into the children and
+    // takes their devices and clips with them (only on first execute).
     if (!executed_) {
-        storedTrack_ = *track;
-        storedPosition_ = trackManager.restorePositionOf(trackId_);
+        storedTracks_ = collectSubtree(trackId_);
     }
 
-    // Store and remove all clips on this track
-    auto& clipManager = ClipManager::getInstance();
-    auto clipIds = clipManager.getClipsOnTrack(trackId_);
-    storedClips_.clear();
-    for (auto clipId : clipIds) {
-        const auto* clip = clipManager.getClip(clipId);
-        if (clip) {
-            storedClips_.push_back(*clip);
-        }
-        clipManager.deleteClip(clipId);
-    }
-
+    // deleteTrack() deletes each track's clips as it goes, children included.
     trackManager.deleteTrack(trackId_);
     executed_ = true;
 
-    DBG("UNDO: Deleted track " << trackId_);
+    DBG("UNDO: Deleted track " << trackId_ << " and " << (int)storedTracks_.size() - 1
+                               << " descendant(s)");
 }
 
 void DeleteTrackCommand::undo() {
@@ -228,15 +253,19 @@ void DeleteTrackCommand::undo() {
         return;
     }
 
-    TrackManager::getInstance().restoreTrack(storedTrack_, storedPosition_);
-
-    // Restore clips that were on this track
+    auto& trackManager = TrackManager::getInstance();
     auto& clipManager = ClipManager::getInstance();
-    for (const auto& clip : storedClips_) {
-        clipManager.restoreClip(clip);
+
+    // Ascending by where each stood, so the list refills left to right. A child
+    // restored before its parent finds no parent to rejoin, and needs none: the
+    // parent's own stored childIds still names it.
+    for (const auto& record : storedTracks_) {
+        trackManager.restoreTrack(record.track, record.position);
+        for (const auto& clip : record.clips)
+            clipManager.restoreClip(clip);
     }
 
-    DBG("UNDO: Restored track " << trackId_);
+    DBG("UNDO: Restored track " << trackId_ << " and its descendants");
 }
 
 // ============================================================================

--- a/magda/daw/core/TrackCommands.cpp
+++ b/magda/daw/core/TrackCommands.cpp
@@ -238,6 +238,13 @@ void DeleteTrackCommand::execute() {
     // takes their devices and clips with them (only on first execute).
     if (!executed_) {
         storedTracks_ = collectSubtree(trackId_);
+
+        // And what it will clear on everything that outlives it.
+        std::vector<TrackId> doomed;
+        doomed.reserve(storedTracks_.size());
+        for (const auto& record : storedTracks_)
+            doomed.push_back(record.track.id);
+        storedRouting_ = trackManager.externalRoutingInto(doomed);
     }
 
     // deleteTrack() deletes each track's clips as it goes, children included.
@@ -264,6 +271,10 @@ void DeleteTrackCommand::undo() {
         for (const auto& clip : record.clips)
             clipManager.restoreClip(clip);
     }
+
+    // After the tracks are back, so a send, an input or a sidechain naming one
+    // of them names something that exists again.
+    trackManager.restoreExternalRouting(storedRouting_);
 
     DBG("UNDO: Restored track " << trackId_ << " and its descendants");
 }

--- a/magda/daw/core/TrackCommands.hpp
+++ b/magda/daw/core/TrackCommands.hpp
@@ -48,8 +48,9 @@ class DeleteTrackCommand : public UndoableCommand {
     TrackId trackId_;
     TrackInfo storedTrack_;
     std::vector<ClipInfo> storedClips_;
-    /// Where the track stood, so undo puts it back there rather than at the end.
-    int storedIndex_ = -1;
+    /// Where the track stood -- in the project and among its group's children --
+    /// so undo puts it back there rather than at the end of either.
+    TrackRestorePosition storedPosition_;
     bool executed_ = false;
 };
 
@@ -91,7 +92,7 @@ class DuplicateTrackCommand : public UndoableCommand {
     /// replays what it materialised and a wrap reuses its rack's id (#2229).
     TrackInfo storedTrack_;
     std::vector<ClipInfo> storedClips_;
-    int storedIndex_ = -1;
+    TrackRestorePosition storedPosition_;
     bool executed_ = false;
 };
 

--- a/magda/daw/core/TrackCommands.hpp
+++ b/magda/daw/core/TrackCommands.hpp
@@ -48,6 +48,8 @@ class DeleteTrackCommand : public UndoableCommand {
     TrackId trackId_;
     TrackInfo storedTrack_;
     std::vector<ClipInfo> storedClips_;
+    /// Where the track stood, so undo puts it back there rather than at the end.
+    int storedIndex_ = -1;
     bool executed_ = false;
 };
 
@@ -80,6 +82,16 @@ class DuplicateTrackCommand : public UndoableCommand {
     bool duplicateContent_;
     bool duplicateDevices_;
     TrackId duplicatedTrackId_ = INVALID_TRACK_ID;
+    /// What the first run actually made, ids and position included.
+    ///
+    /// A redo restores this rather than duplicating again. Duplicating again
+    /// allocates a fresh TrackId and fresh device, rack and chain ids, so an
+    /// undo followed by a redo would orphan every link, automation lane and
+    /// alias made against the first duplicate -- the same reason a paste
+    /// replays what it materialised and a wrap reuses its rack's id (#2229).
+    TrackInfo storedTrack_;
+    std::vector<ClipInfo> storedClips_;
+    int storedIndex_ = -1;
     bool executed_ = false;
 };
 

--- a/magda/daw/core/TrackCommands.hpp
+++ b/magda/daw/core/TrackCommands.hpp
@@ -45,12 +45,27 @@ class DeleteTrackCommand : public UndoableCommand {
     }
 
   private:
+    /// One deleted track, with everything needed to put it back as it was.
+    struct DeletedTrack {
+        TrackInfo track;
+        /// Where it stood -- in the project and among its group's children --
+        /// so undo puts it back there rather than at the end of either.
+        TrackRestorePosition position;
+        std::vector<ClipInfo> clips;
+    };
+
+    /// @p trackId and everything under it, each with where it stood and what
+    /// it held, ordered by their places in the project.
+    static std::vector<DeletedTrack> collectSubtree(TrackId trackId);
+
     TrackId trackId_;
-    TrackInfo storedTrack_;
-    std::vector<ClipInfo> storedClips_;
-    /// Where the track stood -- in the project and among its group's children --
-    /// so undo puts it back there rather than at the end of either.
-    TrackRestorePosition storedPosition_;
+    /// The whole subtree, in the order it stood in the project.
+    ///
+    /// Deleting a group deletes its children with it, so storing only the track
+    /// the user named restored the group alone: its tracks, their devices and
+    /// their clips were gone for good, and the restored group listed children
+    /// that no longer existed (#2229).
+    std::vector<DeletedTrack> storedTracks_;
     bool executed_ = false;
 };
 

--- a/magda/daw/core/TrackCommands.hpp
+++ b/magda/daw/core/TrackCommands.hpp
@@ -66,6 +66,11 @@ class DeleteTrackCommand : public UndoableCommand {
     /// their clips were gone for good, and the restored group listed children
     /// that no longer existed (#2229).
     std::vector<DeletedTrack> storedTracks_;
+    /// What the deletion cleared on the tracks that outlived it: their sends
+    /// into the subtree, their inputs listening to it, their sidechains on it.
+    /// None of that is inside the subtree, so restoring the subtree alone left
+    /// a project that had permanently lost them (#2229).
+    ExternalTrackRouting storedRouting_;
     bool executed_ = false;
 };
 

--- a/magda/daw/core/TrackManager.cpp
+++ b/magda/daw/core/TrackManager.cpp
@@ -939,6 +939,91 @@ TrackRestorePosition TrackManager::restorePositionOf(TrackId trackId) const {
     return position;
 }
 
+namespace {
+
+/// Every device and rack under @p elements that is sidechained to one of
+/// @p doomed, with the path that addresses it.
+void collectSidechainsInto(const std::vector<ChainElement>& elements,
+                           const ChainNodePath& parentChain, const std::set<TrackId>& doomed,
+                           std::vector<ExternalTrackRouting::Sidechain>& found) {
+    const bool topLevel = parentChain.steps.empty();
+    for (const auto& element : elements) {
+        if (magda::isDevice(element)) {
+            const auto& device = magda::getDevice(element);
+            if (doomed.count(device.sidechain.sourceTrackId) == 1)
+                found.push_back({topLevel
+                                     ? ChainNodePath::topLevelDevice(parentChain.trackId, device.id)
+                                     : parentChain.withDevice(device.id),
+                                 device.sidechain});
+            continue;
+        }
+
+        const auto& rack = magda::getRack(element);
+        const auto rackPath = topLevel ? ChainNodePath::rack(parentChain.trackId, rack.id)
+                                       : parentChain.withRack(rack.id);
+        if (doomed.count(rack.sidechain.sourceTrackId) == 1)
+            found.push_back({rackPath, rack.sidechain});
+        for (const auto& chain : rack.chains)
+            collectSidechainsInto(chain.elements, rackPath.withChain(chain.id), doomed, found);
+    }
+}
+
+}  // namespace
+
+ExternalTrackRouting TrackManager::externalRoutingInto(const std::vector<TrackId>& trackIds) const {
+    ExternalTrackRouting routing;
+    const std::set<TrackId> doomed(trackIds.begin(), trackIds.end());
+
+    const auto listensToADoomedTrack = [&doomed](const juce::String& input) {
+        for (auto id : doomed)
+            if (input == "track:" + juce::String(id))
+                return true;
+        return false;
+    };
+
+    const auto record = [&](const TrackInfo& track) {
+        if (doomed.count(track.id) == 1)
+            return;
+
+        const bool sendsIn = std::ranges::any_of(track.sends, [&doomed](const SendInfo& send) {
+            return doomed.count(send.destTrackId) == 1;
+        });
+        if (sendsIn || listensToADoomedTrack(track.audioInputDevice) ||
+            listensToADoomedTrack(track.midiInputDevice))
+            routing.tracks.push_back(
+                {track.id, track.sends, track.audioInputDevice, track.midiInputDevice});
+
+        collectSidechainsInto(track.chain.fxChainElements, ChainNodePath::trackLevel(track.id),
+                              doomed, routing.sidechains);
+    };
+
+    for (const auto& track : tracks_)
+        record(track);
+    record(masterTrack_);
+
+    return routing;
+}
+
+void TrackManager::restoreExternalRouting(const ExternalTrackRouting& routing) {
+    for (const auto& entry : routing.tracks) {
+        if (auto* track = getTrack(entry.trackId)) {
+            // Whole, not by difference: the deletion only removed from these.
+            track->sends = entry.sends;
+            notifyTrackPropertyChanged(entry.trackId);
+        }
+        // Through the setters, so the engine follows the routing back.
+        setTrackAudioInput(entry.trackId, entry.audioInputDevice);
+        setTrackMidiInput(entry.trackId, entry.midiInputDevice);
+    }
+
+    for (const auto& entry : routing.sidechains) {
+        if (entry.nodePath.getType() == ChainNodeType::Rack)
+            setRackSidechainSource(entry.nodePath, entry.config.sourceTrackId, entry.config.type);
+        else if (const auto deviceId = entry.nodePath.getDeviceId(); deviceId != INVALID_DEVICE_ID)
+            setSidechainSource(deviceId, entry.config.sourceTrackId, entry.config.type);
+    }
+}
+
 void TrackManager::restoreTrack(const TrackInfo& trackInfo, TrackRestorePosition position) {
     // Check if a track with this ID already exists
     auto it = std::find_if(tracks_.begin(), tracks_.end(),

--- a/magda/daw/core/TrackManager.cpp
+++ b/magda/daw/core/TrackManager.cpp
@@ -923,7 +923,7 @@ void TrackManager::startMidiMonitoring(const TrackInfo& track, const juce::Strin
     }
 }
 
-void TrackManager::restoreTrack(const TrackInfo& trackInfo) {
+void TrackManager::restoreTrack(const TrackInfo& trackInfo, int index) {
     // Check if a track with this ID already exists
     auto it = std::find_if(tracks_.begin(), tracks_.end(),
                            [&trackInfo](const TrackInfo& t) { return t.id == trackInfo.id; });
@@ -933,13 +933,15 @@ void TrackManager::restoreTrack(const TrackInfo& trackInfo) {
         return;
     }
 
-    tracks_.push_back(trackInfo);
+    const int at = index < 0 ? static_cast<int>(tracks_.size())
+                             : std::clamp(index, 0, static_cast<int>(tracks_.size()));
+    auto inserted = tracks_.insert(tracks_.begin() + at, trackInfo);
 
     // Projects saved before the input-less-track invariant existed can carry
     // MIDI/audio input, monitoring, or record-arm on Aux/Group tracks
     // (createTrack used to seed every non-Aux track with "all"). Normalize on
     // restore rather than let stale on-disk state reintroduce it.
-    tracks_.back().normalizeForType();
+    inserted->normalizeForType();
 
     // Ensure nextTrackId_ is beyond any restored track IDs
     if (trackInfo.id >= nextTrackId_) {
@@ -2485,7 +2487,53 @@ const RackInfo* findRackAmong(const std::vector<ChainElement>& elements, RackId 
 
 }  // namespace
 
+RackInfo* TrackManager::getRackInPadByPath(const ChainNodePath& rackPath) {
+    if (!rackPath.isPadOwned() || rackPath.steps.empty())
+        return nullptr;
+
+    // `PadRack(grid)` on its own names the grid's own pad rack, which hangs off
+    // the device rather than sitting in a chain.
+    if (rackPath.steps.size() == 1) {
+        const auto gridPath = findDevicePath(rackPath.getPadOwnerDeviceId());
+        return gridPath.isValid() && gridPath.trackId == rackPath.trackId ? getPads(gridPath)
+                                                                          : nullptr;
+    }
+
+    // A path ending on a chain or a device names the rack that encloses it,
+    // which is the #2057 leniency the rack walk already has. The node itself has
+    // to resolve first, so a route that does not exist answers nothing rather
+    // than answering with whatever it passed through.
+    const auto& last = rackPath.steps.back();
+    if (isChainStep(last.type))
+        return getChainInPadByPath(rackPath) != nullptr ? getRackInPadByPath(rackPath.parent())
+                                                        : nullptr;
+    if (last.type == ChainStepType::Device)
+        return getDeviceInPadByPath(rackPath) != nullptr ? getRackInPadByPath(rackPath.parent())
+                                                         : nullptr;
+
+    if (last.type != ChainStepType::Rack)
+        return nullptr;
+
+    // Anything else ends on an allocated rack, sitting in a chain the pad route
+    // reaches: a pad's chain holds racks like any other chain does.
+    auto* chain = getChainInPadByPath(rackPath.parent());
+    if (chain == nullptr)
+        return nullptr;
+
+    for (auto& element : chain->elements)
+        if (magda::isRack(element) && magda::getRack(element).id == last.id)
+            return &magda::getRack(element);
+
+    return nullptr;
+}
+
 RackInfo* TrackManager::getRackByPath(const ChainNodePath& rackPath) {
+    // A pad-owned address goes to the pad route, the way `getChainByPath()`
+    // already sends one there. The walk below searches chain elements for a
+    // rack id, and a `PadRack` step carries neither (#2229).
+    if (rackPath.isPadOwned())
+        return getRackInPadByPath(rackPath);
+
     auto* track = getTrack(rackPath.trackId);
     if (!track) {
         return nullptr;
@@ -2542,12 +2590,11 @@ RackInfo* TrackManager::getRackByPath(const ChainNodePath& rackPath) {
         const bool isLast = index + 1 == rackPath.steps.size();
 
         switch (step.type) {
-            // A PadRack names a device rather than a chain element, so
-            // `findRackAmong` will not find it and this returns null, which is
-            // what a Rack step carrying a grid's id did before the pad types
-            // existed. Pads are reached through `getPads()` and
-            // `getDeviceInPadByPath()` instead (#2219).
+            // A PadRack is answered above, before the walk starts: it is always
+            // the first step of a pad-owned path, so one reaching here would be
+            // a pad step in a position the model cannot express.
             case ChainStepType::PadRack:
+                return nullptr;
             case ChainStepType::Rack: {
                 // Valid at track level, or immediately inside a chain. A Rack
                 // straight after a Rack is the sideways move above.

--- a/magda/daw/core/TrackManager.cpp
+++ b/magda/daw/core/TrackManager.cpp
@@ -923,7 +923,23 @@ void TrackManager::startMidiMonitoring(const TrackInfo& track, const juce::Strin
     }
 }
 
-void TrackManager::restoreTrack(const TrackInfo& trackInfo, int index) {
+TrackRestorePosition TrackManager::restorePositionOf(TrackId trackId) const {
+    TrackRestorePosition position;
+    position.trackIndex = getTrackIndex(trackId);
+
+    if (const auto* track = getTrack(trackId); track != nullptr && track->hasParent()) {
+        if (const auto* parent = getTrack(track->parentId)) {
+            const auto found = std::find(parent->childIds.begin(), parent->childIds.end(), trackId);
+            if (found != parent->childIds.end())
+                position.siblingIndex =
+                    static_cast<int>(std::distance(parent->childIds.begin(), found));
+        }
+    }
+
+    return position;
+}
+
+void TrackManager::restoreTrack(const TrackInfo& trackInfo, TrackRestorePosition position) {
     // Check if a track with this ID already exists
     auto it = std::find_if(tracks_.begin(), tracks_.end(),
                            [&trackInfo](const TrackInfo& t) { return t.id == trackInfo.id; });
@@ -933,8 +949,9 @@ void TrackManager::restoreTrack(const TrackInfo& trackInfo, int index) {
         return;
     }
 
-    const int at = index < 0 ? static_cast<int>(tracks_.size())
-                             : std::clamp(index, 0, static_cast<int>(tracks_.size()));
+    const int at = position.trackIndex < 0
+                       ? static_cast<int>(tracks_.size())
+                       : std::clamp(position.trackIndex, 0, static_cast<int>(tracks_.size()));
     auto inserted = tracks_.insert(tracks_.begin() + at, trackInfo);
 
     // Projects saved before the input-less-track invariant existed can carry
@@ -948,12 +965,19 @@ void TrackManager::restoreTrack(const TrackInfo& trackInfo, int index) {
         nextTrackId_ = trackInfo.id + 1;
     }
 
-    // If track has a parent, add it back to parent's children
+    // If track has a parent, add it back to parent's children -- where it stood,
+    // not at the end. A group's order is its `childIds` order, so appending a
+    // restored middle child reorders the group even when the project order is
+    // right (#2229).
     if (trackInfo.hasParent()) {
         if (auto* parent = getTrack(trackInfo.parentId)) {
-            if (std::find(parent->childIds.begin(), parent->childIds.end(), trackInfo.id) ==
-                parent->childIds.end()) {
-                parent->childIds.push_back(trackInfo.id);
+            auto& children = parent->childIds;
+            if (std::find(children.begin(), children.end(), trackInfo.id) == children.end()) {
+                const int amongSiblings =
+                    position.siblingIndex < 0
+                        ? static_cast<int>(children.size())
+                        : std::clamp(position.siblingIndex, 0, static_cast<int>(children.size()));
+                children.insert(children.begin() + amongSiblings, trackInfo.id);
             }
         }
     }

--- a/magda/daw/core/TrackManager.hpp
+++ b/magda/daw/core/TrackManager.hpp
@@ -225,7 +225,13 @@ class TrackManager : public daw::audio::DeviceIdAllocator, public daw::audio::De
      * slate for workflows that want content-only duplication.
      */
     TrackId duplicateTrack(TrackId trackId, bool includeDevices = true);
-    void restoreTrack(const TrackInfo& trackInfo);  // Used by undo system
+    /// Put a track back, at @p index in the track order when one is given and
+    /// at the end when it is not.
+    ///
+    /// The index matters: a track deleted from the middle of a project and
+    /// restored at the end has moved, and a duplicate redone at the end is no
+    /// longer beside the track it copies (#2229).
+    void restoreTrack(const TrackInfo& trackInfo, int index = -1);
     void moveTrack(TrackId trackId, int newIndex);
 
     // Hierarchy operations
@@ -523,6 +529,17 @@ class TrackManager : public daw::audio::DeviceIdAllocator, public daw::audio::De
     /// `getChainByPath()` dispatches to this for a pad-owned address, so a pad
     /// chain is looked up through the generic call like any other chain (#2219).
     ChainInfo* getChainInPadByPath(const ChainNodePath& chainPath);
+
+    /// The rack a pad-owned @p rackPath names, or null when it names none.
+    ///
+    /// `getRackByPath()` dispatches to this for a pad-owned address, the way
+    /// `getChainByPath()` already dispatched chains. The rack walk cannot
+    /// answer one: a `PadRack` step carries the owning grid's DeviceId and the
+    /// rack it names is `DeviceInfo::pads`, which is not a chain element. Until
+    /// this existed every path-based rack call failed silently inside a pad, so
+    /// wrapping a device there made a rack whose chain could not be found
+    /// again and the wrap could not be undone (#2229).
+    RackInfo* getRackInPadByPath(const ChainNodePath& rackPath);
 
     /// Replace those pads wholesale. Undo's counterpart to every pad edit
     /// below, which is why it lives with them rather than on the command

--- a/magda/daw/core/TrackManager.hpp
+++ b/magda/daw/core/TrackManager.hpp
@@ -124,6 +124,18 @@ class TrackManagerListener {
 };
 
 /**
+ * @brief Where a restored track belongs: its place in the project's track
+ * order, and its place among its parent group's children when it has one.
+ *
+ * A track belongs to two orders and a restore has to put it back in both. Either
+ * index left unset means the end of that order (#2229).
+ */
+struct TrackRestorePosition {
+    int trackIndex = -1;
+    int siblingIndex = -1;
+};
+
+/**
  * @brief Singleton manager for all tracks in the project
  *
  * Provides CRUD operations for tracks and notifies listeners of changes.
@@ -225,13 +237,14 @@ class TrackManager : public daw::audio::DeviceIdAllocator, public daw::audio::De
      * slate for workflows that want content-only duplication.
      */
     TrackId duplicateTrack(TrackId trackId, bool includeDevices = true);
-    /// Put a track back, at @p index in the track order when one is given and
-    /// at the end when it is not.
-    ///
-    /// The index matters: a track deleted from the middle of a project and
-    /// restored at the end has moved, and a duplicate redone at the end is no
-    /// longer beside the track it copies (#2229).
-    void restoreTrack(const TrackInfo& trackInfo, int index = -1);
+    /// Put a track back. Both orders matter: a track deleted from the middle of
+    /// a project and restored at the end has moved, and a child restored at the
+    /// end of its group's `childIds` has changed the group's order even when its
+    /// place in the project is right (#2229).
+    void restoreTrack(const TrackInfo& trackInfo, TrackRestorePosition position = {});
+
+    /// Where @p trackId stands now, so a later restore can put it back there.
+    TrackRestorePosition restorePositionOf(TrackId trackId) const;
     void moveTrack(TrackId trackId, int newIndex);
 
     // Hierarchy operations

--- a/magda/daw/core/TrackManager.hpp
+++ b/magda/daw/core/TrackManager.hpp
@@ -136,6 +136,40 @@ struct TrackRestorePosition {
 };
 
 /**
+ * @brief What a track deletion clears on the tracks that outlive it.
+ *
+ * `deleteTrack()` reaches outside the track it removes: it erases every send
+ * aimed at it, clears the input of anything listening to it, and clears every
+ * device and rack sidechained to it, the master track included. None of that
+ * lives inside the deleted subtree, so an undo that restores only the subtree
+ * gives back a project that has permanently lost them (#2229).
+ */
+struct ExternalTrackRouting {
+    /// One surviving track's routing, whole rather than by difference: the
+    /// deletion only ever removes from these, so putting the recorded state
+    /// back is exact, order and send levels included.
+    struct Routing {
+        TrackId trackId = INVALID_TRACK_ID;
+        std::vector<SendInfo> sends;
+        juce::String audioInputDevice;
+        juce::String midiInputDevice;
+    };
+
+    /// One device or rack that was sidechained to a deleted track.
+    struct Sidechain {
+        ChainNodePath nodePath;
+        SidechainConfig config;
+    };
+
+    std::vector<Routing> tracks;
+    std::vector<Sidechain> sidechains;
+
+    bool empty() const {
+        return tracks.empty() && sidechains.empty();
+    }
+};
+
+/**
  * @brief Singleton manager for all tracks in the project
  *
  * Provides CRUD operations for tracks and notifies listeners of changes.
@@ -245,6 +279,15 @@ class TrackManager : public daw::audio::DeviceIdAllocator, public daw::audio::De
 
     /// Where @p trackId stands now, so a later restore can put it back there.
     TrackRestorePosition restorePositionOf(TrackId trackId) const;
+
+    /// Everything outside @p trackIds that deleting all of them would clear.
+    ///
+    /// Asked before the deletion, so undo can put back what the cleanup swept
+    /// up. Only tracks that actually route into the doomed set are recorded.
+    ExternalTrackRouting externalRoutingInto(const std::vector<TrackId>& trackIds) const;
+
+    /// Put back what @p routing recorded.
+    void restoreExternalRouting(const ExternalTrackRouting& routing);
     void moveTrack(TrackId trackId, int newIndex);
 
     // Hierarchy operations

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -38,6 +38,7 @@ set(TEST_SOURCES
     test_drum_grid_pad_commands.cpp
     test_pad_path_types.cpp
     test_structural_undo_roundtrip.cpp
+    test_structural_matrix.cpp
     test_drum_grid_pads.cpp
     test_drum_grid_pads_corpus.cpp
     test_chain_routing_model.cpp

--- a/tests/StructuralRoundTrip.hpp
+++ b/tests/StructuralRoundTrip.hpp
@@ -1,0 +1,84 @@
+#pragma once
+
+#include <juce_core/juce_core.h>
+
+#include <string>
+
+#include "TextDifference.hpp"
+#include "magda/daw/core/ClipManager.hpp"
+#include "magda/daw/core/SelectionManager.hpp"
+#include "magda/daw/core/TrackManager.hpp"
+#include "magda/daw/core/UndoManager.hpp"
+#include "magda/daw/project/serialization/ProjectSerializer.hpp"
+
+// The oracle every structural edit is measured against (#2221, #2229).
+//
+// "The device is back" cannot tell a restored model from a plausible one: an id
+// allocated on the way out, a link retargeted and not put back, an element
+// reinserted at the wrong index are all invisible to it. Comparing the
+// serialized track is what catches them, which is why both the hand-written
+// cases and the generated matrix compare this and nothing else.
+
+namespace magda::structural_test {
+
+/// Every track, serialized, in order. The comparison subject.
+inline juce::String snapshot() {
+    juce::Array<juce::var> tracks;
+    for (const auto& track : TrackManager::getInstance().getTracks())
+        tracks.add(ProjectSerializer::serializeTrackInfo(track));
+    return juce::JSON::toString(juce::var(tracks), false);
+}
+
+inline void resetState() {
+    ClipManager::getInstance().clearAllClips();
+    TrackManager::getInstance().clearAllTracks();
+    SelectionManager::getInstance().clearSelection();
+    UndoManager::getInstance().clearHistory();
+}
+
+/// The first line on which two snapshots disagree, or an empty string.
+///
+/// A failure has to name the field that moved, not print two projects at each
+/// other: a snapshot of a handful of tracks runs to thousands of lines, and a
+/// sweep that reports one on every cell reports nothing at all.
+inline std::string modelDifference(const juce::String& expected, const juce::String& actual) {
+    return firstDifference(expected.toStdString(), actual.toStdString());
+}
+
+/// Counts what a structural edit announced while it was alive.
+///
+/// A refused operation has to leave the model alone and say nothing. A
+/// notification with no matching mutation sends every listener to rebuild from
+/// a model that did not change, which is how a half-applied edit hides.
+class NotificationCounter final : public TrackManagerListener {
+  public:
+    NotificationCounter() {
+        TrackManager::getInstance().addListener(this);
+    }
+
+    ~NotificationCounter() override {
+        TrackManager::getInstance().removeListener(this);
+    }
+
+    NotificationCounter(const NotificationCounter&) = delete;
+    NotificationCounter& operator=(const NotificationCounter&) = delete;
+
+    void tracksChanged() override {
+        ++count_;
+    }
+    void trackPropertyChanged(int) override {
+        ++count_;
+    }
+    void trackDevicesChanged(TrackId) override {
+        ++count_;
+    }
+
+    int count() const {
+        return count_;
+    }
+
+  private:
+    int count_ = 0;
+};
+
+}  // namespace magda::structural_test

--- a/tests/test_structural_matrix.cpp
+++ b/tests/test_structural_matrix.cpp
@@ -167,6 +167,19 @@ bool carriesAnInstrument(Subject subject) {
 /// construction. These are the rules as the issues state them --
 /// `PlacementRefusal` for what a subtree may carry and where, plus the two
 /// sections that hold bare devices and so cannot be addressed as chains at all.
+/// Why a destination track of this role adds nothing for this subject, or empty
+/// when it does.
+///
+/// An aux track differs from another media track in exactly one thing the sweep
+/// tests: it refuses an instrument. For a subject carrying none, the cell is the
+/// media-track cell run twice.
+juce::String rolePointless(Subject subject, TrackRole role) {
+    if (role == TrackRole::Aux && !carriesAnInstrument(subject))
+        return "an aux track differs from another media track only in refusing an instrument, "
+               "so for a subject carrying none this repeats the media-track cell";
+    return {};
+}
+
 Disposition expectedOutcome(Operation operation, Subject subject, Container source,
                             Container destination, TrackRole role) {
     const bool auxDestination = role == TrackRole::Aux;
@@ -453,8 +466,30 @@ struct Shapes {
 /// Build a track holding one of every container shape, each already occupied by
 /// a resident effect so that an index of 0 is always a real placement rather
 /// than a subject's own index.
-Shapes buildShapes(const juce::String& name, TrackType type) {
+/// Which shapes a container needs standing before it: a pad chain needs the grid
+/// that owns it, a nested chain needs the rack it hangs in.
+std::set<Container> withPrerequisites(const std::set<Container>& wanted) {
+    std::set<Container> needed = wanted;
+    if (needed.count(Container::PadNestedRackChain) == 1)
+        needed.insert(Container::PadChain);
+    if (needed.count(Container::NestedRackChain) == 1)
+        needed.insert(Container::RackChain);
+    return needed;
+}
+
+/// Build a track carrying the container shapes in @p wanted and nothing else,
+/// each already occupied by a resident effect so that an index of 0 is always a
+/// real placement rather than a subject's own index.
+///
+/// Only what the cell addresses, because the oracle serializes every track four
+/// times per cell: standing up all seven shapes on three tracks to use one of
+/// them made the sweep an order of magnitude more expensive than the coverage it
+/// bought, and pushed the Windows test step past its timeout.
+Shapes buildShapes(const juce::String& name, TrackType type, const std::set<Container>& wanted) {
     auto& tm = TrackManager::getInstance();
+    const auto needed = withPrerequisites(wanted);
+    const auto asked = [&needed](Container container) { return needed.count(container) == 1; };
+
     Shapes shapes;
     shapes.id = tm.createTrack(name, type);
     REQUIRE(shapes.id != INVALID_TRACK_ID);
@@ -462,25 +497,30 @@ Shapes buildShapes(const juce::String& name, TrackType type) {
     REQUIRE(track != nullptr);
     shapes.hostsInstruments = track->canHostInstrument();
 
-    shapes.containers[Container::TrackList] = ChainNodePath::trackLevel(shapes.id);
+    if (asked(Container::TrackList))
+        shapes.containers[Container::TrackList] = ChainNodePath::trackLevel(shapes.id);
 
-    const auto rackId = tm.addRackToTrack(shapes.id, name + " Rack");
-    REQUIRE(rackId != INVALID_RACK_ID);
-    const auto chainId = tm.addChainToRack(ChainNodePath::rack(shapes.id, rackId));
-    REQUIRE(chainId != INVALID_CHAIN_ID);
-    const auto rackChain = ChainNodePath::chain(shapes.id, rackId, chainId);
-    shapes.containers[Container::RackChain] = rackChain;
+    if (asked(Container::RackChain)) {
+        const auto rackId = tm.addRackToTrack(shapes.id, name + " Rack");
+        REQUIRE(rackId != INVALID_RACK_ID);
+        const auto chainId = tm.addChainToRack(ChainNodePath::rack(shapes.id, rackId));
+        REQUIRE(chainId != INVALID_CHAIN_ID);
+        const auto rackChain = ChainNodePath::chain(shapes.id, rackId, chainId);
+        shapes.containers[Container::RackChain] = rackChain;
 
-    const auto innerRackId = tm.addRackToChainByPath(rackChain, "Inner");
-    REQUIRE(innerRackId != INVALID_RACK_ID);
-    const auto innerChainId = tm.addChainToRack(rackChain.withRack(innerRackId));
-    REQUIRE(innerChainId != INVALID_CHAIN_ID);
-    shapes.containers[Container::NestedRackChain] =
-        rackChain.withRack(innerRackId).withChain(innerChainId);
+        if (asked(Container::NestedRackChain)) {
+            const auto innerRackId = tm.addRackToChainByPath(rackChain, "Inner");
+            REQUIRE(innerRackId != INVALID_RACK_ID);
+            const auto innerChainId = tm.addChainToRack(rackChain.withRack(innerRackId));
+            REQUIRE(innerChainId != INVALID_CHAIN_ID);
+            shapes.containers[Container::NestedRackChain] =
+                rackChain.withRack(innerRackId).withChain(innerChainId);
+        }
+    }
 
-    // A pad rack belongs to a Drum Grid, which is an instrument, so a track
-    // that cannot host one has no pad shapes at all.
-    if (shapes.hostsInstruments) {
+    // A pad rack belongs to a Drum Grid, which is an instrument, so a track that
+    // cannot host one has no pad shapes at all.
+    if (asked(Container::PadChain) && shapes.hostsInstruments) {
         shapes.gridId = tm.addDeviceToTrack(shapes.id, drumGrid(name + " Grid"));
         REQUIRE(shapes.gridId != INVALID_DEVICE_ID);
         const auto gridPath = ChainNodePath::topLevelDevice(shapes.id, shapes.gridId);
@@ -489,26 +529,31 @@ Shapes buildShapes(const juce::String& name, TrackType type) {
         const auto padChain = ChainNodePath::padChain(shapes.id, shapes.gridId, padChainId);
         shapes.containers[Container::PadChain] = padChain;
 
-        // The rack goes in whole rather than through `addRackToChainByPath`,
-        // which resolves its parent through the rack walk and so cannot reach a
-        // pad chain. Its chain comes with it for the same reason.
-        const auto nestedPath = append(padChain, rackHolding("Pad Inner", effect("Pad Inner FX")));
-        // Its chain id is read back out of the pad chain rather than asked of
-        // `getRackByPath`, which walks the rack tree a pad rack is not part of.
-        const auto* holder = tm.getChainByPath(padChain);
-        REQUIRE(holder != nullptr);
-        ChainId nestedChainId = INVALID_CHAIN_ID;
-        for (const auto& element : holder->elements)
-            if (isRack(element) && getRack(element).id == nestedPath.steps.back().id &&
-                !getRack(element).chains.empty())
-                nestedChainId = getRack(element).chains.front().id;
-        REQUIRE(nestedChainId != INVALID_CHAIN_ID);
-        shapes.containers[Container::PadNestedRackChain] = nestedPath.withChain(nestedChainId);
+        if (asked(Container::PadNestedRackChain)) {
+            // The rack goes in whole rather than through `addRackToChainByPath`,
+            // which resolves its parent through the rack walk and so cannot
+            // reach a pad chain. Its chain comes with it for the same reason.
+            const auto nestedPath =
+                append(padChain, rackHolding("Pad Inner", effect("Pad Inner FX")));
+            // Its chain id is read back out of the pad chain rather than asked
+            // of `getRackByPath`, which walks a tree a pad rack is not part of.
+            const auto* holder = tm.getChainByPath(padChain);
+            REQUIRE(holder != nullptr);
+            ChainId nestedChainId = INVALID_CHAIN_ID;
+            for (const auto& element : holder->elements)
+                if (isRack(element) && getRack(element).id == nestedPath.steps.back().id &&
+                    !getRack(element).chains.empty())
+                    nestedChainId = getRack(element).chains.front().id;
+            REQUIRE(nestedChainId != INVALID_CHAIN_ID);
+            shapes.containers[Container::PadNestedRackChain] = nestedPath.withChain(nestedChainId);
+        }
     }
 
-    shapes.containers[Container::PostFx] = segmentContainer(shapes.id, ChainSegment::PostFx);
-    shapes.containers[Container::MixerAnalysis] =
-        segmentContainer(shapes.id, ChainSegment::MixerAnalysis);
+    if (asked(Container::PostFx))
+        shapes.containers[Container::PostFx] = segmentContainer(shapes.id, ChainSegment::PostFx);
+    if (asked(Container::MixerAnalysis))
+        shapes.containers[Container::MixerAnalysis] =
+            segmentContainer(shapes.id, ChainSegment::MixerAnalysis);
 
     // One resident everywhere, so index 0 is never the subject's own index.
     for (const auto& [container, path] : shapes.containers) {
@@ -526,29 +571,38 @@ Shapes buildShapes(const juce::String& name, TrackType type) {
 
 struct World {
     Shapes host;
-    Shapes peer;
-    Shapes aux;
+    Shapes destination;  ///< The same track as `host` when the role is Host.
 
     const Shapes& of(TrackRole role) const {
-        switch (role) {
-            case TrackRole::Host:
-                return host;
-            case TrackRole::Peer:
-                return peer;
-            case TrackRole::Aux:
-                return aux;
-        }
-        return host;
+        return role == TrackRole::Host ? host : destination;
     }
 };
 
-World buildWorld() {
+TrackType trackTypeFor(TrackRole role) {
+    return role == TrackRole::Aux ? TrackType::Aux : TrackType::Media;
+}
+
+/// A project holding just the shapes @p cell needs: the subject's container on
+/// the host track, and the destination container on whichever track the role
+/// names.
+World buildWorld(Container source, Container destination, TrackRole role) {
     resetState();
     World world;
-    world.host = buildShapes("Host", TrackType::Media);
-    world.peer = buildShapes("Peer", TrackType::Media);
-    world.aux = buildShapes("Aux", TrackType::Aux);
+    if (role == TrackRole::Host) {
+        world.host = buildShapes("Host", TrackType::Media, {source, destination});
+        world.destination = world.host;
+        return world;
+    }
+
+    world.host = buildShapes("Host", TrackType::Media, {source});
+    world.destination =
+        buildShapes(role == TrackRole::Aux ? "Aux" : "Peer", trackTypeFor(role), {destination});
     return world;
+}
+
+/// The single-container matrices, which never reach past the host track.
+World buildWorld(Container container) {
+    return buildWorld(container, container, TrackRole::Host);
 }
 
 // ============================================================================
@@ -703,8 +757,12 @@ TEST_CASE("Every move across the container matrix is refused or reversible",
             for (auto destination : kContainers) {
                 for (auto role : kRoles) {
                     const auto cell = cellName("move", subject, source, destination, role);
+                    if (const auto reason = rolePointless(subject, role); reason.isNotEmpty()) {
+                        ledger.exclude(cell, reason);
+                        continue;
+                    }
 
-                    auto world = buildWorld();
+                    auto world = buildWorld(source, destination, role);
                     const auto* target = world.of(role).find(destination);
                     if (target == nullptr) {
                         ledger.exclude(cell, "an aux track cannot host the Drum Grid a pad rack "
@@ -746,8 +804,12 @@ TEST_CASE("Every paste across the container matrix is refused or reversible",
             for (auto destination : kContainers) {
                 for (auto role : kRoles) {
                     const auto cell = cellName("paste", subject, source, destination, role);
+                    if (const auto reason = rolePointless(subject, role); reason.isNotEmpty()) {
+                        ledger.exclude(cell, reason);
+                        continue;
+                    }
 
-                    auto world = buildWorld();
+                    auto world = buildWorld(source, destination, role);
                     const auto* target = world.of(role).find(destination);
                     if (target == nullptr) {
                         ledger.exclude(cell, "an aux track cannot host the Drum Grid a pad rack "
@@ -792,7 +854,7 @@ TEST_CASE("Every wrap across the container matrix is refused or reversible",
                 continue;
             }
 
-            auto world = buildWorld();
+            auto world = buildWorld(container);
             const auto subjectPath = placeSubject(subject, world.host, container);
             requireCell(
                 cell,
@@ -827,7 +889,7 @@ TEST_CASE("Every duplication across the container matrix is refused or reversibl
                 continue;
             }
 
-            auto world = buildWorld();
+            auto world = buildWorld(container);
             const auto* containerPath = world.host.find(container);
             REQUIRE(containerPath != nullptr);
             const auto subjectPath = placeSubject(subject, world.host, container);
@@ -871,7 +933,7 @@ TEST_CASE("Every removal across the container matrix is refused or reversible",
                 continue;
             }
 
-            auto world = buildWorld();
+            auto world = buildWorld(container);
             const auto subjectPath = placeSubject(subject, world.host, container);
             requireCell(
                 cell,
@@ -903,7 +965,7 @@ TEST_CASE("Duplicating a track carrying any subject in any container is reversib
                 continue;
             }
 
-            auto world = buildWorld();
+            auto world = buildWorld(container);
             placeSubject(subject, world.host, container);
             requireCell(cell,
                         expectedOutcome(Operation::TrackDuplicate, subject, container, container,
@@ -983,7 +1045,7 @@ TEST_CASE("Every pad structural edit from every container is refused or reversib
             const juce::String cell =
                 juce::String(operation.name) + " on a grid in the " + label(container);
 
-            auto world = buildWorld();
+            auto world = buildWorld(container);
             const auto* containerPath = world.host.find(container);
             REQUIRE(containerPath != nullptr);
 

--- a/tests/test_structural_matrix.cpp
+++ b/tests/test_structural_matrix.cpp
@@ -28,12 +28,16 @@ using magda::structural_test::snapshot;
 // so a container shape nobody thought of is covered by construction rather than
 // by having come up.
 //
-// Every cell asserts one of two outcomes. Either the operation is refused, and
-// then the serialized model is byte-identical and nothing was announced; or it
-// happened, and then undo restores the bytes it started from and redo
-// reproduces the bytes it made. Combinations that cannot exist are excluded by
-// name, with the reason, and the excluded set is reported so a shape that stops
-// being generated shows up instead of quietly dropping out of the sweep.
+// Every cell says which of two outcomes it expects before it runs, and asserts
+// that one. Refused: the serialized model is byte-identical and nothing was
+// announced. Applied: undo restores the bytes it started from and redo
+// reproduces the bytes it made. Saying so up front is what gives the sweep
+// teeth -- a regression that starts refusing every legal edit would satisfy a
+// harness that accepted "nothing changed" wherever it found it.
+//
+// Combinations that cannot exist are excluded by name, with the reason, and the
+// excluded set is reported so a shape that stops being generated shows up
+// instead of quietly dropping out of the sweep.
 
 namespace {
 
@@ -133,6 +137,102 @@ const char* label(TrackRole role) {
             return "an aux track";
     }
     return "?";
+}
+
+/// The structural operations the sweep drives.
+enum class Operation { Move, Paste, Wrap, Duplicate, Remove, TrackDuplicate, PadEdit };
+
+/// What a cell has to do: the model's own rules decide, and the cell asserts it.
+///
+/// Accepting "nothing changed" as a valid outcome wherever it turned up would
+/// make the sweep agree with a regression that refuses every legal edit, which
+/// is the one thing a matrix this size exists to catch. So each cell says which
+/// of the two outcomes it expects before it runs, and a refusal that was
+/// supposed to apply fails as loudly as a broken round trip.
+enum class Disposition { Applied, Refused };
+
+const char* label(Disposition disposition) {
+    return disposition == Disposition::Applied ? "apply" : "be refused";
+}
+
+bool carriesAnInstrument(Subject subject) {
+    return subject == Subject::Instrument || subject == Subject::RoutedGrid ||
+           subject == Subject::MultiOutDriver;
+}
+
+/// The rules, restated from the model side.
+///
+/// Deliberately written out rather than derived from `checkPlacement()`: a test
+/// that asks the code under test what it should do agrees with it by
+/// construction. These are the rules as the issues state them --
+/// `PlacementRefusal` for what a subtree may carry and where, plus the two
+/// sections that hold bare devices and so cannot be addressed as chains at all.
+Disposition expectedOutcome(Operation operation, Subject subject, Container source,
+                            Container destination, TrackRole role) {
+    const bool auxDestination = role == TrackRole::Aux;
+    const bool sameContainer = source == destination && role == TrackRole::Host;
+
+    switch (operation) {
+        case Operation::TrackDuplicate:
+        case Operation::PadEdit:
+            // Neither reads a destination, and neither has a rule that can stop
+            // it: a duplicate is a copy of a whole track, and a pad edit acts on
+            // pads the grid resolves from its own path wherever it stands.
+            return Disposition::Applied;
+
+        case Operation::Remove:
+            // A flat section is not a chain, so the element index the removal
+            // records has no answer there and it stops before mutating.
+            return isFlatSection(source) ? Disposition::Refused : Disposition::Applied;
+
+        case Operation::Wrap:
+            if (isFlatSection(source))
+                return Disposition::Refused;
+            // Wrapping takes the element off the top level, which is where a pad
+            // bus and a multi-out pair are carried from.
+            if (subject == Subject::RoutedGrid || subject == Subject::MultiOutDriver)
+                return Disposition::Refused;
+            return Disposition::Applied;
+
+        case Operation::Duplicate:
+            // A copy pasted back beside itself. It has no source as far as the
+            // placement rules are concerned, so only what it carries matters,
+            // and a routed grid only ever stands in the track's own list.
+            return isFlatSection(source) ? Disposition::Refused : Disposition::Applied;
+
+        case Operation::Paste:
+            // Copying reads the source as a chain and inserting addresses the
+            // destination as one, so neither may be a flat section.
+            if (isFlatSection(source) || isFlatSection(destination))
+                return Disposition::Refused;
+            if (carriesAnInstrument(subject) && auxDestination)
+                return Disposition::Refused;
+            // A pasted subtree owns no child tracks and leaves no track, so the
+            // rules keyed on where it came from pass. What it carries still has
+            // to land somewhere that carries it: a pad on a bus needs the output
+            // instance made for a top-level instrument.
+            if (subject == Subject::RoutedGrid && destination != Container::TrackList)
+                return Disposition::Refused;
+            return Disposition::Applied;
+
+        case Operation::Move:
+            if (isFlatSection(source) || isFlatSection(destination))
+                return Disposition::Refused;
+            // Reordering inside the container it already lives in changes
+            // neither the track nor the ids anything is keyed on, so none of the
+            // rules below apply to it.
+            if (sameContainer)
+                return Disposition::Applied;
+            if (carriesAnInstrument(subject) && auxDestination)
+                return Disposition::Refused;
+            // Both of these are keyed on the track the subtree stands on, and
+            // both are stranded by any placement change.
+            if (subject == Subject::RoutedGrid || subject == Subject::MultiOutDriver)
+                return Disposition::Refused;
+            return Disposition::Applied;
+    }
+
+    return Disposition::Applied;
 }
 
 // ============================================================================
@@ -539,9 +639,9 @@ void requireModel(const juce::String& expected, const char* stage) {
     CHECK(difference.empty());
 }
 
-void requireRefusedOrReversible(const juce::String& cell,
-                                std::unique_ptr<UndoableCommand> command) {
-    INFO(cell);
+void requireCell(const juce::String& cell, Disposition expected,
+                 std::unique_ptr<UndoableCommand> command) {
+    INFO(cell << ", which must " << label(expected));
     auto& undo = UndoManager::getInstance();
     undo.clearHistory();
 
@@ -550,8 +650,11 @@ void requireRefusedOrReversible(const juce::String& cell,
     undo.executeCommand(std::move(command));
     const auto after = snapshot();
 
-    if (after == before) {
-        INFO("refused");
+    if (expected == Disposition::Refused) {
+        // Refused means untouched and unannounced: a notification with no
+        // matching mutation sends every listener to rebuild from a model that
+        // did not change, which is how a half-applied edit hides.
+        requireModel(before, "the refusal");
         CHECK(notifications.count() == 0);
         // A refused step is still a step on the stack, and it has to be a no-op
         // in both directions.
@@ -562,7 +665,7 @@ void requireRefusedOrReversible(const juce::String& cell,
         return;
     }
 
-    INFO("applied");
+    REQUIRE(before != after);  // It was supposed to do something.
     REQUIRE(undo.undo());
     requireModel(before, "undo");
     REQUIRE(undo.redo());
@@ -610,8 +713,9 @@ TEST_CASE("Every move across the container matrix is refused or reversible",
                     }
 
                     const auto subjectPath = placeSubject(subject, world.host, source);
-                    requireRefusedOrReversible(
-                        cell, std::make_unique<MoveChainElementCommand>(subjectPath, *target, 0));
+                    requireCell(
+                        cell, expectedOutcome(Operation::Move, subject, source, destination, role),
+                        std::make_unique<MoveChainElementCommand>(subjectPath, *target, 0));
 
                     ++ledger.ran;
                     ledger.sourcesCovered.insert(source);
@@ -653,8 +757,9 @@ TEST_CASE("Every paste across the container matrix is refused or reversible",
 
                     const auto subjectPath = placeSubject(subject, world.host, source);
                     auto copied = TrackManager::getInstance().copyChainElements({subjectPath});
-                    requireRefusedOrReversible(cell, std::make_unique<PasteChainElementsCommand>(
-                                                         *target, std::move(copied), 0));
+                    requireCell(
+                        cell, expectedOutcome(Operation::Paste, subject, source, destination, role),
+                        std::make_unique<PasteChainElementsCommand>(*target, std::move(copied), 0));
 
                     ++ledger.ran;
                     ledger.sourcesCovered.insert(source);
@@ -689,9 +794,11 @@ TEST_CASE("Every wrap across the container matrix is refused or reversible",
 
             auto world = buildWorld();
             const auto subjectPath = placeSubject(subject, world.host, container);
-            requireRefusedOrReversible(cell,
-                                       std::make_unique<WrapChainElementsInRackCommand>(
-                                           std::vector<ChainNodePath>{subjectPath}, "Wrapper"));
+            requireCell(
+                cell,
+                expectedOutcome(Operation::Wrap, subject, container, container, TrackRole::Host),
+                std::make_unique<WrapChainElementsInRackCommand>(
+                    std::vector<ChainNodePath>{subjectPath}, "Wrapper"));
 
             ++ledger.ran;
             ledger.sourcesCovered.insert(container);
@@ -728,8 +835,11 @@ TEST_CASE("Every duplication across the container matrix is refused or reversibl
             auto& tm = TrackManager::getInstance();
             auto copied = tm.copyChainElements({subjectPath});
             const int index = tm.getChainElementIndex(subjectPath);
-            requireRefusedOrReversible(cell, std::make_unique<PasteChainElementsCommand>(
-                                                 *containerPath, std::move(copied), index + 1));
+            requireCell(cell,
+                        expectedOutcome(Operation::Duplicate, subject, container, container,
+                                        TrackRole::Host),
+                        std::make_unique<PasteChainElementsCommand>(*containerPath,
+                                                                    std::move(copied), index + 1));
 
             ++ledger.ran;
             ledger.sourcesCovered.insert(container);
@@ -763,8 +873,10 @@ TEST_CASE("Every removal across the container matrix is refused or reversible",
 
             auto world = buildWorld();
             const auto subjectPath = placeSubject(subject, world.host, container);
-            requireRefusedOrReversible(cell,
-                                       std::make_unique<RemoveDeviceByPathCommand>(subjectPath));
+            requireCell(
+                cell,
+                expectedOutcome(Operation::Remove, subject, container, container, TrackRole::Host),
+                std::make_unique<RemoveDeviceByPathCommand>(subjectPath));
 
             ++ledger.ran;
             ledger.sourcesCovered.insert(container);
@@ -793,9 +905,12 @@ TEST_CASE("Duplicating a track carrying any subject in any container is reversib
 
             auto world = buildWorld();
             placeSubject(subject, world.host, container);
-            requireRefusedOrReversible(
-                cell, std::make_unique<DuplicateTrackCommand>(world.host.id, /*duplicateContent=*/
-                                                              true, /*duplicateDevices=*/true));
+            requireCell(cell,
+                        expectedOutcome(Operation::TrackDuplicate, subject, container, container,
+                                        TrackRole::Host),
+                        std::make_unique<DuplicateTrackCommand>(world.host.id,
+                                                                /*duplicateContent=*/true,
+                                                                /*duplicateDevices=*/true));
 
             ++ledger.ran;
             ledger.sourcesCovered.insert(container);
@@ -882,11 +997,13 @@ TEST_CASE("Every pad structural edit from every container is refused or reversib
             REQUIRE(tm.ensurePad(gridPath, 1) != INVALID_CHAIN_ID);
 
             const auto apply = operation.apply;
-            requireRefusedOrReversible(
-                cell, std::make_unique<EditPadsCommand>(
-                          gridPath, operation.name, [gridPath, padChainId, padDeviceId, apply] {
-                              apply(gridPath, padChainId, padDeviceId);
-                          }));
+            requireCell(cell,
+                        expectedOutcome(Operation::PadEdit, Subject::RoutedGrid, container,
+                                        container, TrackRole::Host),
+                        std::make_unique<EditPadsCommand>(
+                            gridPath, operation.name, [gridPath, padChainId, padDeviceId, apply] {
+                                apply(gridPath, padChainId, padDeviceId);
+                            }));
 
             ++ledger.ran;
             ledger.sourcesCovered.insert(container);

--- a/tests/test_structural_matrix.cpp
+++ b/tests/test_structural_matrix.cpp
@@ -1,0 +1,904 @@
+#include <array>
+#include <catch2/catch_test_macros.hpp>
+#include <map>
+#include <memory>
+#include <set>
+#include <utility>
+#include <vector>
+
+#include "StructuralRoundTrip.hpp"
+#include "magda/daw/core/DrumGridPads.hpp"
+#include "magda/daw/core/PadCommands.hpp"
+#include "magda/daw/core/RackInfo.hpp"
+#include "magda/daw/core/TrackCommands.hpp"
+#include "magda/daw/core/TrackManager.hpp"
+#include "magda/daw/core/UndoManager.hpp"
+
+using namespace magda;
+using magda::structural_test::modelDifference;
+using magda::structural_test::NotificationCounter;
+using magda::structural_test::resetState;
+using magda::structural_test::snapshot;
+
+// The structural transition matrix (#2229).
+//
+// The hand-written cases in test_structural_undo_roundtrip.cpp each record one
+// bug that was found and fixed. This is the systematic other half: the same
+// oracle, driven from a generated product of operation, container and subject,
+// so a container shape nobody thought of is covered by construction rather than
+// by having come up.
+//
+// Every cell asserts one of two outcomes. Either the operation is refused, and
+// then the serialized model is byte-identical and nothing was announced; or it
+// happened, and then undo restores the bytes it started from and redo
+// reproduces the bytes it made. Combinations that cannot exist are excluded by
+// name, with the reason, and the excluded set is reported so a shape that stops
+// being generated shows up instead of quietly dropping out of the sweep.
+
+namespace {
+
+// ============================================================================
+// Axes
+// ============================================================================
+
+/// Every place the model can hold a chain element.
+enum class Container {
+    TrackList,           ///< The track's own FX list
+    RackChain,           ///< A chain of a rack on the track
+    NestedRackChain,     ///< A chain of a rack inside a rack chain
+    PadChain,            ///< A chain a Drum Grid owns
+    PadNestedRackChain,  ///< A chain of a rack inside a pad chain
+    PostFx,              ///< The post-fader list
+    MixerAnalysis,       ///< The rail-managed mixer-analysis section
+};
+
+constexpr std::array kContainers{
+    Container::TrackList,     Container::RackChain,          Container::NestedRackChain,
+    Container::PadChain,      Container::PadNestedRackChain, Container::PostFx,
+    Container::MixerAnalysis,
+};
+
+const char* label(Container container) {
+    switch (container) {
+        case Container::TrackList:
+            return "track list";
+        case Container::RackChain:
+            return "rack chain";
+        case Container::NestedRackChain:
+            return "rack in a rack chain";
+        case Container::PadChain:
+            return "pad chain";
+        case Container::PadNestedRackChain:
+            return "rack in a pad chain";
+        case Container::PostFx:
+            return "post-fader list";
+        case Container::MixerAnalysis:
+            return "mixer-analysis section";
+    }
+    return "?";
+}
+
+/// True for the two flat sections, which hold bare devices in their own id
+/// space rather than chain elements.
+bool isFlatSection(Container container) {
+    return container == Container::PostFx || container == Container::MixerAnalysis;
+}
+
+/// What is being moved, copied, wrapped or removed.
+enum class Subject {
+    Effect,
+    Instrument,
+    Rack,
+    RoutedGrid,      ///< A Drum Grid with a pad on a multi-out bus
+    MultiOutDriver,  ///< A device whose pair drives a child track
+};
+
+constexpr std::array kSubjects{
+    Subject::Effect,     Subject::Instrument,     Subject::Rack,
+    Subject::RoutedGrid, Subject::MultiOutDriver,
+};
+
+const char* label(Subject subject) {
+    switch (subject) {
+        case Subject::Effect:
+            return "an effect";
+        case Subject::Instrument:
+            return "an instrument";
+        case Subject::Rack:
+            return "a rack";
+        case Subject::RoutedGrid:
+            return "a routed Drum Grid";
+        case Subject::MultiOutDriver:
+            return "a multi-out device driving a child track";
+    }
+    return "?";
+}
+
+/// Which track a destination container belongs to.
+enum class TrackRole {
+    Host,  ///< The track the subject starts on
+    Peer,  ///< Another Media track
+    Aux,   ///< A track that cannot host an instrument
+};
+
+constexpr std::array kRoles{TrackRole::Host, TrackRole::Peer, TrackRole::Aux};
+
+const char* label(TrackRole role) {
+    switch (role) {
+        case TrackRole::Host:
+            return "its own track";
+        case TrackRole::Peer:
+            return "another media track";
+        case TrackRole::Aux:
+            return "an aux track";
+    }
+    return "?";
+}
+
+// ============================================================================
+// The ledger
+// ============================================================================
+
+/// What the sweep ran and what it left out.
+///
+/// The excluded cells are reported by name, so a shape that stops being
+/// generated -- a builder that silently fails, a factory that starts returning
+/// nothing -- is visible as a cell that moved from run to excluded rather than
+/// as coverage that quietly went away.
+struct Ledger {
+    juce::String title;
+    int ran = 0;
+    /// Excluded cells, grouped by the reason they were excluded. Grouped rather
+    /// than listed flat because one reason covers dozens of cells, and a report
+    /// that repeats it dozens of times is one nobody reads.
+    std::map<juce::String, std::vector<juce::String>> excluded;
+    std::set<Container> sourcesCovered;
+    std::set<Container> destinationsCovered;
+    std::set<Subject> subjectsCovered;
+
+    void exclude(const juce::String& cell, const juce::String& reason) {
+        excluded[reason].push_back(cell);
+    }
+
+    int excludedCount() const {
+        int total = 0;
+        for (const auto& [reason, cells] : excluded)
+            total += static_cast<int>(cells.size());
+        return total;
+    }
+
+    juce::String report() const {
+        juce::String out;
+        out << "\n" << title << ": " << ran << " cells run, " << excludedCount() << " excluded\n";
+        for (const auto& [reason, cells] : excluded) {
+            out << "  " << static_cast<int>(cells.size()) << " excluded because " << reason
+                << ":\n";
+            for (const auto& cell : cells)
+                out << "      " << cell << "\n";
+        }
+        return out;
+    }
+};
+
+/// Every axis value has to survive into at least one cell that actually ran.
+///
+/// Without this the sweep degrades silently: a builder that stops producing a
+/// pad chain turns every pad cell into an exclusion, the exclusions are printed
+/// and nobody reads them, and the suite still passes with a hole in it.
+void requireEveryAxisCovered(const Ledger& ledger, const std::vector<Subject>& expectedSubjects) {
+    INFO(ledger.report());
+    CHECK(ledger.ran > 0);
+    for (auto subject : expectedSubjects) {
+        INFO("subject: " << label(subject));
+        CHECK(ledger.subjectsCovered.count(subject) == 1);
+    }
+    for (auto container : kContainers) {
+        INFO("source container: " << label(container));
+        CHECK(ledger.sourcesCovered.count(container) == 1);
+        INFO("destination container: " << label(container));
+        CHECK(ledger.destinationsCovered.count(container) == 1);
+    }
+}
+
+std::vector<Subject> everySubject() {
+    return {kSubjects.begin(), kSubjects.end()};
+}
+
+std::vector<Subject> everySubjectExcept(Subject omitted) {
+    std::vector<Subject> subjects;
+    for (auto subject : kSubjects)
+        if (subject != omitted)
+            subjects.push_back(subject);
+    return subjects;
+}
+
+// ============================================================================
+// Devices
+// ============================================================================
+
+DeviceInfo effect(const juce::String& name, const juce::String& pluginId = "delay") {
+    DeviceInfo device;
+    device.name = name;
+    device.pluginId = pluginId;
+    device.format = PluginFormat::Internal;
+    return device;
+}
+
+/// The occupant every container starts with, so that index 0 is a real
+/// placement rather than the subject's own index. Its own plugin id, because
+/// the mixer-analysis section holds one device per plugin id on a track and a
+/// resident sharing the subject's would turn every such cell into a refusal.
+DeviceInfo resident() {
+    return effect("Resident", "reverb");
+}
+
+DeviceInfo instrument(const juce::String& name) {
+    DeviceInfo device;
+    device.name = name;
+    device.pluginId = "magdasampler";
+    device.format = PluginFormat::Internal;
+    device.isInstrument = true;
+    device.deviceType = DeviceType::Instrument;
+    return device;
+}
+
+DeviceInfo drumGrid(const juce::String& name) {
+    DeviceInfo device;
+    device.name = name;
+    device.pluginId = "drumgrid";
+    device.format = PluginFormat::Internal;
+    device.isInstrument = true;
+    device.deviceType = DeviceType::Instrument;
+    return device;
+}
+
+DeviceInfo multiOutInstrument(const juce::String& name) {
+    auto device = instrument(name);
+    device.pluginId = "multisynth";
+    device.multiOut.isMultiOut = true;
+    device.multiOut.totalOutputChannels = 4;
+    device.multiOut.outputPairs = {{0, "Main 1-2", 1, 2}, {1, "Out 3-4", 3, 2}};
+    return device;
+}
+
+ChainElement rackHolding(const juce::String& name, DeviceInfo child) {
+    RackInfo rack;
+    rack.name = name;
+    ChainInfo chain;
+    chain.name = "Chain 1";
+    chain.elements.push_back(makeDeviceElement(std::move(child)));
+    rack.chains.push_back(std::move(chain));
+    return makeRackElement(std::move(rack));
+}
+
+// ============================================================================
+// Reading and filling containers
+// ============================================================================
+
+/// The elements a chain-shaped container holds, or null when the path does not
+/// name one. The flat sections answer null: they hold their own element type.
+const std::vector<ChainElement>* elementsOf(const ChainNodePath& container) {
+    auto& tm = TrackManager::getInstance();
+    if (container.trackId == INVALID_TRACK_ID)
+        return nullptr;
+    if (container.steps.empty()) {
+        const auto* track = tm.getTrack(container.trackId);
+        return track != nullptr ? &track->chain.fxChainElements : nullptr;
+    }
+    const auto* chain = tm.getChainByPath(container);
+    return chain != nullptr ? &chain->elements : nullptr;
+}
+
+/// The path @p container gives an element it directly holds.
+///
+/// A track's own list is not a chain and its devices are addressed as top-level
+/// ones, which is the same split every path-based command makes.
+ChainNodePath pathOfChild(const ChainNodePath& container, const ChainElement& element) {
+    const bool topLevel = container.steps.empty();
+    if (isDevice(element)) {
+        const auto id = getDevice(element).id;
+        return topLevel ? ChainNodePath::topLevelDevice(container.trackId, id)
+                        : container.withDevice(id);
+    }
+    const auto id = getRack(element).id;
+    return topLevel ? ChainNodePath::rack(container.trackId, id) : container.withRack(id);
+}
+
+/// Put @p element at the end of @p container and answer with its path.
+///
+/// Goes in through the insert path rather than the add-by-path helpers because
+/// that is the one route every chain shape answers to: `addDeviceToChainByPath`
+/// and `addRackToChainByPath` resolve their parent through the rack walk, which
+/// no pad address answers to.
+ChainNodePath append(const ChainNodePath& container, ChainElement element) {
+    auto& tm = TrackManager::getInstance();
+    const auto* before = elementsOf(container);
+    REQUIRE(before != nullptr);
+    const int index = static_cast<int>(before->size());
+
+    std::vector<ChainElement> batch;
+    batch.push_back(std::move(element));
+    REQUIRE(tm.insertChainElementsByPath(container, std::move(batch), index, /*reassignIds=*/true));
+
+    const auto* after = elementsOf(container);
+    REQUIRE(after != nullptr);
+    REQUIRE(static_cast<int>(after->size()) == index + 1);
+    return pathOfChild(container, (*after)[static_cast<size_t>(index)]);
+}
+
+ChainNodePath segmentContainer(TrackId trackId, ChainSegment segment) {
+    ChainNodePath path;
+    path.trackId = trackId;
+    path.steps.push_back({ChainStepType::Segment, static_cast<int>(segment)});
+    return path;
+}
+
+// ============================================================================
+// The world
+// ============================================================================
+
+/// One track carrying every container shape it can carry.
+struct Shapes {
+    TrackId id = INVALID_TRACK_ID;
+    bool hostsInstruments = false;
+    DeviceId gridId = INVALID_DEVICE_ID;
+    std::map<Container, ChainNodePath> containers;
+
+    const ChainNodePath* find(Container container) const {
+        const auto it = containers.find(container);
+        return it == containers.end() ? nullptr : &it->second;
+    }
+};
+
+/// Build a track holding one of every container shape, each already occupied by
+/// a resident effect so that an index of 0 is always a real placement rather
+/// than a subject's own index.
+Shapes buildShapes(const juce::String& name, TrackType type) {
+    auto& tm = TrackManager::getInstance();
+    Shapes shapes;
+    shapes.id = tm.createTrack(name, type);
+    REQUIRE(shapes.id != INVALID_TRACK_ID);
+    const auto* track = tm.getTrack(shapes.id);
+    REQUIRE(track != nullptr);
+    shapes.hostsInstruments = track->canHostInstrument();
+
+    shapes.containers[Container::TrackList] = ChainNodePath::trackLevel(shapes.id);
+
+    const auto rackId = tm.addRackToTrack(shapes.id, name + " Rack");
+    REQUIRE(rackId != INVALID_RACK_ID);
+    const auto chainId = tm.addChainToRack(ChainNodePath::rack(shapes.id, rackId));
+    REQUIRE(chainId != INVALID_CHAIN_ID);
+    const auto rackChain = ChainNodePath::chain(shapes.id, rackId, chainId);
+    shapes.containers[Container::RackChain] = rackChain;
+
+    const auto innerRackId = tm.addRackToChainByPath(rackChain, "Inner");
+    REQUIRE(innerRackId != INVALID_RACK_ID);
+    const auto innerChainId = tm.addChainToRack(rackChain.withRack(innerRackId));
+    REQUIRE(innerChainId != INVALID_CHAIN_ID);
+    shapes.containers[Container::NestedRackChain] =
+        rackChain.withRack(innerRackId).withChain(innerChainId);
+
+    // A pad rack belongs to a Drum Grid, which is an instrument, so a track
+    // that cannot host one has no pad shapes at all.
+    if (shapes.hostsInstruments) {
+        shapes.gridId = tm.addDeviceToTrack(shapes.id, drumGrid(name + " Grid"));
+        REQUIRE(shapes.gridId != INVALID_DEVICE_ID);
+        const auto gridPath = ChainNodePath::topLevelDevice(shapes.id, shapes.gridId);
+        const auto padChainId = tm.ensurePad(gridPath, 0);
+        REQUIRE(padChainId != INVALID_CHAIN_ID);
+        const auto padChain = ChainNodePath::padChain(shapes.id, shapes.gridId, padChainId);
+        shapes.containers[Container::PadChain] = padChain;
+
+        // The rack goes in whole rather than through `addRackToChainByPath`,
+        // which resolves its parent through the rack walk and so cannot reach a
+        // pad chain. Its chain comes with it for the same reason.
+        const auto nestedPath = append(padChain, rackHolding("Pad Inner", effect("Pad Inner FX")));
+        // Its chain id is read back out of the pad chain rather than asked of
+        // `getRackByPath`, which walks the rack tree a pad rack is not part of.
+        const auto* holder = tm.getChainByPath(padChain);
+        REQUIRE(holder != nullptr);
+        ChainId nestedChainId = INVALID_CHAIN_ID;
+        for (const auto& element : holder->elements)
+            if (isRack(element) && getRack(element).id == nestedPath.steps.back().id &&
+                !getRack(element).chains.empty())
+                nestedChainId = getRack(element).chains.front().id;
+        REQUIRE(nestedChainId != INVALID_CHAIN_ID);
+        shapes.containers[Container::PadNestedRackChain] = nestedPath.withChain(nestedChainId);
+    }
+
+    shapes.containers[Container::PostFx] = segmentContainer(shapes.id, ChainSegment::PostFx);
+    shapes.containers[Container::MixerAnalysis] =
+        segmentContainer(shapes.id, ChainSegment::MixerAnalysis);
+
+    // One resident everywhere, so index 0 is never the subject's own index.
+    for (const auto& [container, path] : shapes.containers) {
+        if (container == Container::PostFx) {
+            REQUIRE(tm.addDeviceToPostFx(shapes.id, resident()) != INVALID_DEVICE_ID);
+        } else if (container == Container::MixerAnalysis) {
+            REQUIRE(tm.addDeviceToMixerAnalysis(shapes.id, resident()) != INVALID_DEVICE_ID);
+        } else {
+            append(path, makeDeviceElement(resident()));
+        }
+    }
+
+    return shapes;
+}
+
+struct World {
+    Shapes host;
+    Shapes peer;
+    Shapes aux;
+
+    const Shapes& of(TrackRole role) const {
+        switch (role) {
+            case TrackRole::Host:
+                return host;
+            case TrackRole::Peer:
+                return peer;
+            case TrackRole::Aux:
+                return aux;
+        }
+        return host;
+    }
+};
+
+World buildWorld() {
+    resetState();
+    World world;
+    world.host = buildShapes("Host", TrackType::Media);
+    world.peer = buildShapes("Peer", TrackType::Media);
+    world.aux = buildShapes("Aux", TrackType::Aux);
+    return world;
+}
+
+// ============================================================================
+// Subjects
+// ============================================================================
+
+/// Why (@p subject, @p container) cannot be built on a media track, or empty
+/// when it can. The one place a combination is declared impossible.
+juce::String cannotPlace(Subject subject, Container container) {
+    const bool carriesAnInstrument = subject == Subject::Instrument ||
+                                     subject == Subject::RoutedGrid ||
+                                     subject == Subject::MultiOutDriver;
+    if (isFlatSection(container)) {
+        if (subject == Subject::Rack)
+            return "the flat sections hold bare devices, so no rack can be represented in one";
+        if (carriesAnInstrument)
+            return "the post-fader and mixer-analysis sections take effects only: nothing "
+                   "generates sound after the fader";
+    }
+
+    if (subject == Subject::RoutedGrid && container != Container::TrackList)
+        return "a pad's bus is carried by the output instance made for a top-level instrument, "
+               "so only a grid in the track's own list can be on one";
+
+    return {};
+}
+
+/// Put @p subject into @p container on @p shapes and answer with its path.
+/// Only called for combinations `cannotPlace()` allows.
+ChainNodePath placeSubject(Subject subject, const Shapes& shapes, Container container) {
+    auto& tm = TrackManager::getInstance();
+    const auto* containerPath = shapes.find(container);
+    REQUIRE(containerPath != nullptr);
+
+    if (isFlatSection(container)) {
+        // Effects only: `cannotPlace()` has already excluded everything else.
+        const auto id = container == Container::PostFx
+                            ? tm.addDeviceToPostFx(shapes.id, effect("Subject"))
+                            : tm.addDeviceToMixerAnalysis(shapes.id, effect("Subject"));
+        REQUIRE(id != INVALID_DEVICE_ID);
+        return containerPath->withDevice(id);
+    }
+
+    switch (subject) {
+        case Subject::Effect:
+            return append(*containerPath, makeDeviceElement(effect("Subject")));
+
+        case Subject::Instrument:
+            return append(*containerPath, makeDeviceElement(instrument("Subject")));
+
+        case Subject::Rack:
+            return append(*containerPath, rackHolding("Subject", effect("Inside")));
+
+        case Subject::RoutedGrid: {
+            const auto gridPath = append(*containerPath, makeDeviceElement(drumGrid("Subject")));
+            REQUIRE(tm.setPadDevice(gridPath, 3, instrument("Kick")) != INVALID_DEVICE_ID);
+            REQUIRE(tm.setPadOutput(gridPath, 3, 1));
+            return gridPath;
+        }
+
+        case Subject::MultiOutDriver: {
+            const auto devicePath =
+                append(*containerPath, makeDeviceElement(multiOutInstrument("Subject")));
+            const auto childId =
+                tm.activateMultiOutPair(shapes.id, devicePath.getDeviceId(), /*pairIndex=*/1);
+            REQUIRE(childId != INVALID_TRACK_ID);
+            return devicePath;
+        }
+    }
+
+    FAIL("unhandled subject");
+    return {};
+}
+
+// ============================================================================
+// The cell
+// ============================================================================
+
+/// The property every cell asserts.
+///
+/// Refused: the serialized model is byte-identical and nothing was announced,
+/// and the no-op step the stack kept is a no-op in both directions too.
+/// Applied: undo restores the bytes it started from and redo reproduces the
+/// bytes it made.
+void requireModel(const juce::String& expected, const char* stage) {
+    const auto difference = modelDifference(expected, snapshot());
+    INFO(stage << " left the model at " << difference);
+    CHECK(difference.empty());
+}
+
+void requireRefusedOrReversible(const juce::String& cell,
+                                std::unique_ptr<UndoableCommand> command) {
+    INFO(cell);
+    auto& undo = UndoManager::getInstance();
+    undo.clearHistory();
+
+    NotificationCounter notifications;
+    const auto before = snapshot();
+    undo.executeCommand(std::move(command));
+    const auto after = snapshot();
+
+    if (after == before) {
+        INFO("refused");
+        CHECK(notifications.count() == 0);
+        // A refused step is still a step on the stack, and it has to be a no-op
+        // in both directions.
+        REQUIRE(undo.undo());
+        requireModel(before, "undo");
+        REQUIRE(undo.redo());
+        requireModel(before, "redo");
+        return;
+    }
+
+    INFO("applied");
+    REQUIRE(undo.undo());
+    requireModel(before, "undo");
+    REQUIRE(undo.redo());
+    requireModel(after, "redo");
+}
+
+juce::String cellName(const juce::String& operation, Subject subject, Container source) {
+    return operation + " " + label(subject) + " in the " + label(source);
+}
+
+juce::String cellName(const juce::String& operation, Subject subject, Container source,
+                      Container destination, TrackRole role) {
+    return cellName(operation, subject, source) + " to the " + label(destination) + " of " +
+           label(role);
+}
+
+}  // namespace
+
+// ============================================================================
+// Move and paste: every container to every container
+// ============================================================================
+
+TEST_CASE("Every move across the container matrix is refused or reversible",
+          "[structural][undo][roundtrip][matrix]") {
+    Ledger ledger;
+    ledger.title = "move matrix";
+
+    for (auto subject : kSubjects) {
+        for (auto source : kContainers) {
+            if (const auto reason = cannotPlace(subject, source); reason.isNotEmpty()) {
+                ledger.exclude(cellName("move", subject, source), reason);
+                continue;
+            }
+
+            for (auto destination : kContainers) {
+                for (auto role : kRoles) {
+                    const auto cell = cellName("move", subject, source, destination, role);
+
+                    auto world = buildWorld();
+                    const auto* target = world.of(role).find(destination);
+                    if (target == nullptr) {
+                        ledger.exclude(cell, "an aux track cannot host the Drum Grid a pad rack "
+                                             "belongs to, so it has no pad shapes");
+                        continue;
+                    }
+
+                    const auto subjectPath = placeSubject(subject, world.host, source);
+                    requireRefusedOrReversible(
+                        cell, std::make_unique<MoveChainElementCommand>(subjectPath, *target, 0));
+
+                    ++ledger.ran;
+                    ledger.sourcesCovered.insert(source);
+                    ledger.destinationsCovered.insert(destination);
+                    ledger.subjectsCovered.insert(subject);
+                }
+            }
+        }
+    }
+
+    requireEveryAxisCovered(ledger, everySubject());
+    WARN(ledger.report().toStdString());
+    resetState();
+}
+
+TEST_CASE("Every paste across the container matrix is refused or reversible",
+          "[structural][undo][roundtrip][matrix]") {
+    Ledger ledger;
+    ledger.title = "paste matrix";
+
+    for (auto subject : kSubjects) {
+        for (auto source : kContainers) {
+            if (const auto reason = cannotPlace(subject, source); reason.isNotEmpty()) {
+                ledger.exclude(cellName("paste", subject, source), reason);
+                continue;
+            }
+
+            for (auto destination : kContainers) {
+                for (auto role : kRoles) {
+                    const auto cell = cellName("paste", subject, source, destination, role);
+
+                    auto world = buildWorld();
+                    const auto* target = world.of(role).find(destination);
+                    if (target == nullptr) {
+                        ledger.exclude(cell, "an aux track cannot host the Drum Grid a pad rack "
+                                             "belongs to, so it has no pad shapes");
+                        continue;
+                    }
+
+                    const auto subjectPath = placeSubject(subject, world.host, source);
+                    auto copied = TrackManager::getInstance().copyChainElements({subjectPath});
+                    requireRefusedOrReversible(cell, std::make_unique<PasteChainElementsCommand>(
+                                                         *target, std::move(copied), 0));
+
+                    ++ledger.ran;
+                    ledger.sourcesCovered.insert(source);
+                    ledger.destinationsCovered.insert(destination);
+                    ledger.subjectsCovered.insert(subject);
+                }
+            }
+        }
+    }
+
+    requireEveryAxisCovered(ledger, everySubject());
+    WARN(ledger.report().toStdString());
+    resetState();
+}
+
+// ============================================================================
+// Operations that stay where the subject already is
+// ============================================================================
+
+TEST_CASE("Every wrap across the container matrix is refused or reversible",
+          "[structural][undo][roundtrip][matrix]") {
+    Ledger ledger;
+    ledger.title = "wrap matrix";
+
+    for (auto subject : kSubjects) {
+        for (auto container : kContainers) {
+            const auto cell = cellName("wrap", subject, container);
+            if (const auto reason = cannotPlace(subject, container); reason.isNotEmpty()) {
+                ledger.exclude(cell, reason);
+                continue;
+            }
+
+            auto world = buildWorld();
+            const auto subjectPath = placeSubject(subject, world.host, container);
+            requireRefusedOrReversible(cell,
+                                       std::make_unique<WrapChainElementsInRackCommand>(
+                                           std::vector<ChainNodePath>{subjectPath}, "Wrapper"));
+
+            ++ledger.ran;
+            ledger.sourcesCovered.insert(container);
+            ledger.destinationsCovered.insert(container);
+            ledger.subjectsCovered.insert(subject);
+        }
+    }
+
+    requireEveryAxisCovered(ledger, everySubject());
+    WARN(ledger.report().toStdString());
+    resetState();
+}
+
+TEST_CASE("Every duplication across the container matrix is refused or reversible",
+          "[structural][undo][roundtrip][matrix]") {
+    // Duplicating a device or a rack is a copy of it pasted back beside itself,
+    // which is what the chain view's alt-drag and its duplicate action both do.
+    Ledger ledger;
+    ledger.title = "duplication matrix";
+
+    for (auto subject : kSubjects) {
+        for (auto container : kContainers) {
+            const auto cell = cellName("duplicate", subject, container);
+            if (const auto reason = cannotPlace(subject, container); reason.isNotEmpty()) {
+                ledger.exclude(cell, reason);
+                continue;
+            }
+
+            auto world = buildWorld();
+            const auto* containerPath = world.host.find(container);
+            REQUIRE(containerPath != nullptr);
+            const auto subjectPath = placeSubject(subject, world.host, container);
+
+            auto& tm = TrackManager::getInstance();
+            auto copied = tm.copyChainElements({subjectPath});
+            const int index = tm.getChainElementIndex(subjectPath);
+            requireRefusedOrReversible(cell, std::make_unique<PasteChainElementsCommand>(
+                                                 *containerPath, std::move(copied), index + 1));
+
+            ++ledger.ran;
+            ledger.sourcesCovered.insert(container);
+            ledger.destinationsCovered.insert(container);
+            ledger.subjectsCovered.insert(subject);
+        }
+    }
+
+    requireEveryAxisCovered(ledger, everySubject());
+    WARN(ledger.report().toStdString());
+    resetState();
+}
+
+TEST_CASE("Every removal across the container matrix is refused or reversible",
+          "[structural][undo][roundtrip][matrix]") {
+    Ledger ledger;
+    ledger.title = "removal matrix";
+
+    for (auto subject : kSubjects) {
+        for (auto container : kContainers) {
+            const auto cell = cellName("remove", subject, container);
+            if (const auto reason = cannotPlace(subject, container); reason.isNotEmpty()) {
+                ledger.exclude(cell, reason);
+                continue;
+            }
+            if (subject == Subject::Rack) {
+                ledger.exclude(cell, "no undoable command removes a rack: the chain view calls "
+                                     "removeRackFromChainByPath() directly");
+                continue;
+            }
+
+            auto world = buildWorld();
+            const auto subjectPath = placeSubject(subject, world.host, container);
+            requireRefusedOrReversible(cell,
+                                       std::make_unique<RemoveDeviceByPathCommand>(subjectPath));
+
+            ++ledger.ran;
+            ledger.sourcesCovered.insert(container);
+            ledger.destinationsCovered.insert(container);
+            ledger.subjectsCovered.insert(subject);
+        }
+    }
+
+    requireEveryAxisCovered(ledger, everySubjectExcept(Subject::Rack));
+    WARN(ledger.report().toStdString());
+    resetState();
+}
+
+TEST_CASE("Duplicating a track carrying any subject in any container is reversible",
+          "[structural][undo][roundtrip][matrix]") {
+    Ledger ledger;
+    ledger.title = "track duplication matrix";
+
+    for (auto subject : kSubjects) {
+        for (auto container : kContainers) {
+            const auto cell = cellName("duplicate the track holding", subject, container);
+            if (const auto reason = cannotPlace(subject, container); reason.isNotEmpty()) {
+                ledger.exclude(cell, reason);
+                continue;
+            }
+
+            auto world = buildWorld();
+            placeSubject(subject, world.host, container);
+            requireRefusedOrReversible(
+                cell, std::make_unique<DuplicateTrackCommand>(world.host.id, /*duplicateContent=*/
+                                                              true, /*duplicateDevices=*/true));
+
+            ++ledger.ran;
+            ledger.sourcesCovered.insert(container);
+            ledger.destinationsCovered.insert(container);
+            ledger.subjectsCovered.insert(subject);
+        }
+    }
+
+    requireEveryAxisCovered(ledger, everySubject());
+    WARN(ledger.report().toStdString());
+    resetState();
+}
+
+// ============================================================================
+// Pad structural edits, from a grid in every container that can hold one
+// ============================================================================
+
+namespace {
+
+/// Where a Drum Grid can stand while its pads are edited.
+constexpr std::array kGridContainers{
+    Container::TrackList, Container::RackChain,          Container::NestedRackChain,
+    Container::PadChain,  Container::PadNestedRackChain,
+};
+
+struct PadOperation {
+    const char* name;
+    /// Runs against the live model inside one `EditPadsCommand`.
+    void (*apply)(const ChainNodePath& gridPath, ChainId padChainId, DeviceId padDeviceId);
+};
+
+constexpr std::array kPadOperations{
+    PadOperation{"set a pad's device",
+                 [](const ChainNodePath& grid, ChainId, DeviceId) {
+                     TrackManager::getInstance().setPadDevice(grid, 5, instrument("Snare"));
+                 }},
+    PadOperation{"clear a pad", [](const ChainNodePath& grid, ChainId,
+                                   DeviceId) { TrackManager::getInstance().clearPad(grid, 0); }},
+    PadOperation{"swap two pads",
+                 [](const ChainNodePath& grid, ChainId, DeviceId) {
+                     TrackManager::getInstance().swapPads(grid, 0, 1);
+                 }},
+    PadOperation{"remove a pad chain",
+                 [](const ChainNodePath& grid, ChainId padChainId, DeviceId) {
+                     TrackManager::getInstance().removePadChain(grid, padChainId);
+                 }},
+    PadOperation{"add a device to a pad",
+                 [](const ChainNodePath& grid, ChainId padChainId, DeviceId) {
+                     TrackManager::getInstance().addDeviceToPad(grid, padChainId, effect("Pad FX"));
+                 }},
+    PadOperation{"remove a device from a pad",
+                 [](const ChainNodePath& grid, ChainId padChainId, DeviceId padDeviceId) {
+                     TrackManager::getInstance().removeDeviceFromPad(grid, padChainId, padDeviceId);
+                 }},
+    PadOperation{"reorder a pad's devices",
+                 [](const ChainNodePath& grid, ChainId padChainId, DeviceId) {
+                     TrackManager::getInstance().moveDeviceInPad(grid, padChainId, 0, 1);
+                 }},
+};
+
+}  // namespace
+
+TEST_CASE("Every pad structural edit from every container is refused or reversible",
+          "[structural][undo][roundtrip][matrix][pads]") {
+    Ledger ledger;
+    ledger.title = "pad edit matrix";
+
+    for (const auto& operation : kPadOperations) {
+        for (auto container : kGridContainers) {
+            const juce::String cell =
+                juce::String(operation.name) + " on a grid in the " + label(container);
+
+            auto world = buildWorld();
+            const auto* containerPath = world.host.find(container);
+            REQUIRE(containerPath != nullptr);
+
+            auto& tm = TrackManager::getInstance();
+            const auto gridPath = append(*containerPath, makeDeviceElement(drumGrid("Subject")));
+            const auto padChainId = tm.ensurePad(gridPath, 0);
+            REQUIRE(padChainId != INVALID_CHAIN_ID);
+            const auto padDeviceId = tm.setPadDevice(gridPath, 0, instrument("Kick"));
+            REQUIRE(padDeviceId != INVALID_DEVICE_ID);
+            REQUIRE(tm.addDeviceToPad(gridPath, padChainId, effect("Pad FX")) != INVALID_DEVICE_ID);
+            REQUIRE(tm.ensurePad(gridPath, 1) != INVALID_CHAIN_ID);
+
+            const auto apply = operation.apply;
+            requireRefusedOrReversible(
+                cell, std::make_unique<EditPadsCommand>(
+                          gridPath, operation.name, [gridPath, padChainId, padDeviceId, apply] {
+                              apply(gridPath, padChainId, padDeviceId);
+                          }));
+
+            ++ledger.ran;
+            ledger.sourcesCovered.insert(container);
+            ledger.destinationsCovered.insert(container);
+        }
+    }
+
+    for (auto container : kGridContainers) {
+        INFO("grid container: " << label(container));
+        CHECK(ledger.sourcesCovered.count(container) == 1);
+    }
+    CHECK(ledger.ran == static_cast<int>(kPadOperations.size() * kGridContainers.size()));
+    WARN(ledger.report().toStdString());
+    resetState();
+}

--- a/tests/test_structural_undo_roundtrip.cpp
+++ b/tests/test_structural_undo_roundtrip.cpp
@@ -342,3 +342,26 @@ TEST_CASE("Undoing the deletion of a middle child puts it back among its sibling
 
     requireUndoRoundTrip(std::make_unique<DeleteTrackCommand>(middle));
 }
+
+TEST_CASE("Undoing the deletion of a group brings its children back with it",
+          "[structural][undo][roundtrip]") {
+    // Deleting a group deletes its children, and the command stored only the
+    // track the user named. Undo restored the group alone: its tracks, their
+    // devices and their clips were gone for good, and the restored group listed
+    // children that no longer existed.
+    resetState();
+    auto& tm = TrackManager::getInstance();
+
+    tm.createTrack("Before");
+    const auto groupId = tm.createGroupTrack("Group");
+    const auto first = tm.createTrack("First");
+    const auto second = tm.createTrack("Second");
+    tm.addTrackToGroup(first, groupId);
+    tm.addTrackToGroup(second, groupId);
+    tm.addDeviceToTrack(first, effect("Child FX"));
+    const auto rackId = tm.addRackToTrack(second, "Child Rack");
+    tm.addChainToRack(ChainNodePath::rack(second, rackId));
+    tm.createTrack("After");
+
+    requireUndoRoundTrip(std::make_unique<DeleteTrackCommand>(groupId));
+}

--- a/tests/test_structural_undo_roundtrip.cpp
+++ b/tests/test_structural_undo_roundtrip.cpp
@@ -365,3 +365,33 @@ TEST_CASE("Undoing the deletion of a group brings its children back with it",
 
     requireUndoRoundTrip(std::make_unique<DeleteTrackCommand>(groupId));
 }
+
+TEST_CASE("Undoing a track deletion puts back the routing it swept up",
+          "[structural][undo][roundtrip]") {
+    // The deletion reaches outside the track it removes: every send aimed at it
+    // goes, so does the input of anything listening to it, and so does every
+    // sidechain on it. None of that is inside the deleted subtree, so an undo
+    // that restored only the subtree gave back a project that had permanently
+    // lost them.
+    resetState();
+    auto& tm = TrackManager::getInstance();
+
+    const auto auxId = tm.createTrack("Aux", TrackType::Aux);
+    const auto sender = tm.createTrack("Sender");
+    const auto listener = tm.createTrack("Listener");
+    const auto ducked = tm.createTrack("Ducked");
+
+    tm.addSend(sender, auxId);
+    tm.setTrackAudioInput(listener, "track:" + juce::String(auxId));
+    tm.setTrackMidiInput(listener, "track:" + juce::String(auxId));
+
+    const auto compressor = tm.addDeviceToTrack(ducked, effect("Compressor"));
+    tm.setSidechainSource(compressor, auxId, SidechainConfig::Type::Audio);
+
+    const auto* senderTrack = tm.getTrack(sender);
+    REQUIRE(senderTrack != nullptr);
+    REQUIRE(senderTrack->sends.size() == 1);
+
+    UndoManager::getInstance().clearHistory();
+    requireUndoRoundTrip(std::make_unique<DeleteTrackCommand>(auxId));
+}

--- a/tests/test_structural_undo_roundtrip.cpp
+++ b/tests/test_structural_undo_roundtrip.cpp
@@ -1,15 +1,15 @@
 #include <catch2/catch_test_macros.hpp>
 
-#include "magda/daw/core/ClipManager.hpp"
+#include "StructuralRoundTrip.hpp"
 #include "magda/daw/core/DrumGridPads.hpp"
 #include "magda/daw/core/RackInfo.hpp"
-#include "magda/daw/core/SelectionManager.hpp"
 #include "magda/daw/core/TrackCommands.hpp"
 #include "magda/daw/core/TrackManager.hpp"
 #include "magda/daw/core/UndoManager.hpp"
-#include "magda/daw/project/serialization/ProjectSerializer.hpp"
 
 using namespace magda;
+using magda::structural_test::resetState;
+using magda::structural_test::snapshot;
 
 // Undo of a structural edit restores the serialized model exactly (#2221).
 //
@@ -19,23 +19,12 @@ using namespace magda;
 // out, a link retargeted and not put back, a notification without a matching
 // mutation are all invisible to a test that only checks the device is present
 // again. Comparing the serialized track is what catches them.
+//
+// Each case here is one bug that was found this way. The generated sweep over
+// every operation, container and subject is in test_structural_matrix.cpp
+// (#2229), against this same oracle.
 
 namespace {
-
-void resetState() {
-    ClipManager::getInstance().clearAllClips();
-    TrackManager::getInstance().clearAllTracks();
-    SelectionManager::getInstance().clearSelection();
-    UndoManager::getInstance().clearHistory();
-}
-
-/// Every track, serialized, in order. The comparison subject.
-juce::String snapshot() {
-    juce::Array<juce::var> tracks;
-    for (const auto& track : TrackManager::getInstance().getTracks())
-        tracks.add(ProjectSerializer::serializeTrackInfo(track));
-    return juce::JSON::toString(juce::var(tracks), false);
-}
 
 DeviceInfo effect(const juce::String& name) {
     DeviceInfo device;
@@ -222,4 +211,110 @@ TEST_CASE("Undoing the removal of a routed grid restores the serialized model",
 
     UndoManager::getInstance().clearHistory();
     requireUndoRoundTrip(std::make_unique<RemoveDeviceByPathCommand>(gridPath));
+}
+
+// The five below are what the generated matrix found (#2229). Each is kept as
+// its own case because a sweep says a cell failed and a case says what broke.
+
+TEST_CASE("Undoing a move towards the front of a chain puts it back where it stood",
+          "[structural][undo][roundtrip]") {
+    // The index a move records is where the element stood, counted with itself
+    // still in the list. `moveChainElement()` takes a drop position and drops
+    // one when the element travels up a list it is already in, so handing it the
+    // recorded index straight back landed the element one slot early. Only
+    // visible undoing a move that went *towards the front*: the other direction
+    // needs no correction, which is why the existing case above passed.
+    resetState();
+    auto& tm = TrackManager::getInstance();
+
+    const auto trackId = tm.createTrack("Track");
+    tm.addDeviceToTrack(trackId, effect("First"));
+    tm.addDeviceToTrack(trackId, effect("Second"));
+    const auto third = tm.addDeviceToTrack(trackId, effect("Third"));
+
+    requireUndoRoundTrip(std::make_unique<MoveChainElementCommand>(
+        ChainNodePath::topLevelDevice(trackId, third), ChainNodePath::trackLevel(trackId), 0));
+}
+
+TEST_CASE("Undoing a paste of a rack into a track's own list removes it",
+          "[structural][undo][roundtrip]") {
+    // The paste recorded the rack under `trackLevel(track).withRack(id)`, a path
+    // claiming to be both the track and a rack in it, which reads back as the
+    // track. The undo asked what kind of node it was, got "track", and removed
+    // nothing.
+    resetState();
+    auto& tm = TrackManager::getInstance();
+
+    const auto trackId = tm.createTrack("Track");
+    tm.addDeviceToTrack(trackId, effect("Resident"));
+
+    RackInfo rack;
+    rack.name = "Pasted";
+    ChainInfo chain;
+    chain.name = "Chain 1";
+    chain.elements.push_back(makeDeviceElement(effect("Inside")));
+    rack.chains.push_back(std::move(chain));
+
+    std::vector<ChainElement> pasted;
+    pasted.push_back(makeRackElement(std::move(rack)));
+
+    requireUndoRoundTrip(std::make_unique<PasteChainElementsCommand>(
+        ChainNodePath::trackLevel(trackId), std::move(pasted), 0));
+}
+
+TEST_CASE("Undoing a wrap inside a pad chain restores the serialized model",
+          "[structural][undo][roundtrip][pads]") {
+    // The wrap read its new rack's chain id back through the rack walk, which no
+    // pad address answers to, so it never learned the id and its undo bailed
+    // before touching anything: the rack stayed.
+    resetState();
+    auto& tm = TrackManager::getInstance();
+
+    const auto trackId = tm.createTrack("Drums");
+    const auto gridId = tm.addDeviceToTrack(trackId, drumGrid());
+    const auto gridPath = ChainNodePath::topLevelDevice(trackId, gridId);
+    const auto padChainId = tm.ensurePad(gridPath, 0);
+    REQUIRE(padChainId != INVALID_CHAIN_ID);
+
+    const auto padChain = ChainNodePath::padChain(trackId, gridId, padChainId);
+    const auto deviceId = tm.addDeviceToPad(gridPath, padChainId, effect("Pad FX"));
+    REQUIRE(deviceId != INVALID_DEVICE_ID);
+
+    UndoManager::getInstance().clearHistory();
+    requireUndoRoundTrip(std::make_unique<WrapChainElementsInRackCommand>(
+        std::vector<ChainNodePath>{padChain.withDevice(deviceId)}, "Wrapper"));
+}
+
+TEST_CASE("Redoing a track duplication reproduces the track it made",
+          "[structural][undo][roundtrip]") {
+    // A redo used to duplicate again, which allocates a fresh TrackId and fresh
+    // device, rack and chain ids: undo followed by redo left a different project
+    // than the one the undo took away, and every link made against the first
+    // duplicate pointed at nothing.
+    resetState();
+    auto& tm = TrackManager::getInstance();
+
+    const auto trackId = tm.createTrack("Track");
+    tm.addDeviceToTrack(trackId, effect("Delay"));
+    const auto rackId = tm.addRackToTrack(trackId, "Rack");
+    const auto chainId = tm.addChainToRack(ChainNodePath::rack(trackId, rackId));
+    tm.addDeviceToChainByPath(ChainNodePath::chain(trackId, rackId, chainId), effect("Nested"));
+    tm.createTrack("After");
+
+    requireUndoRoundTrip(std::make_unique<DuplicateTrackCommand>(trackId));
+}
+
+TEST_CASE("Undoing a track deletion puts the track back in its place",
+          "[structural][undo][roundtrip]") {
+    // The restore appended, so undoing the deletion of a track from the middle
+    // of a project moved it to the end. Same defect as the duplicate's redo,
+    // through the same restore.
+    resetState();
+    auto& tm = TrackManager::getInstance();
+
+    tm.createTrack("Before");
+    const auto doomed = tm.createTrack("Doomed");
+    tm.createTrack("After");
+
+    requireUndoRoundTrip(std::make_unique<DeleteTrackCommand>(doomed));
 }

--- a/tests/test_structural_undo_roundtrip.cpp
+++ b/tests/test_structural_undo_roundtrip.cpp
@@ -318,3 +318,27 @@ TEST_CASE("Undoing a track deletion puts the track back in its place",
 
     requireUndoRoundTrip(std::make_unique<DeleteTrackCommand>(doomed));
 }
+
+TEST_CASE("Undoing the deletion of a middle child puts it back among its siblings",
+          "[structural][undo][roundtrip]") {
+    // A track belongs to two orders, and the restore only put back the first.
+    // A group's order is its `childIds` order, so a middle child restored at the
+    // end of that list has moved within the group even though its place in the
+    // project is right.
+    resetState();
+    auto& tm = TrackManager::getInstance();
+
+    const auto groupId = tm.createGroupTrack("Group");
+    const auto first = tm.createTrack("First");
+    const auto middle = tm.createTrack("Middle");
+    const auto last = tm.createTrack("Last");
+    tm.addTrackToGroup(first, groupId);
+    tm.addTrackToGroup(middle, groupId);
+    tm.addTrackToGroup(last, groupId);
+
+    const auto* group = tm.getTrack(groupId);
+    REQUIRE(group != nullptr);
+    REQUIRE(group->childIds == std::vector<TrackId>{first, middle, last});
+
+    requireUndoRoundTrip(std::make_unique<DeleteTrackCommand>(middle));
+}


### PR DESCRIPTION
Closes #2229. The last acceptance criterion from #2221.

The hand-written round-trip cases each record a bug that came up. This adds the systematic other half: 996 generated cells over operation x container x subject, against the same oracle, so a container shape nobody thought of is covered by construction.

**Operations**: move, paste, wrap, device and rack duplication, removal, track duplication, and the seven pad structural edits.
**Containers**: a track's own list, a rack chain, a pad chain, a rack nested in either, the post-fader list and the mixer-analysis section, on the subject's own track, another media track and an aux track.
**Subjects**: an effect, an instrument, a rack, a Drum Grid with a routed pad, and a device driving a multi-out child track.

Each cell asserts one of two outcomes: refused, and then the serialized model is byte-identical and nothing was announced; or applied, and then undo restores the bytes it started from and redo reproduces the bytes it made. The 169 impossible combinations are excluded by name with the reason, grouped and reported, and every axis value has to survive into a cell that ran, so a shape that stops being generated fails rather than quietly dropping out.

## What it found

- **Undoing a move towards the front of a chain put the element back one slot early.** The index a move records is where the element stood, counted with itself in the list; `moveChainElement()` takes a drop position and drops one when the element travels up a list it is already in. The multi-element undo made that conversion, the single-element one did not. Now there is one conversion and both call it.
- **A rack pasted into a track's own list could not be undone.** The paste recorded it under `trackLevel(track).withRack(id)`, a path claiming to be both the track and a rack in it, which reads back as the track. Extending a path now clears `isTrackLevel`, so every caller gets a well-formed path.
- **Wrapping a device inside a pad chain could not be undone.** The wrap read its new rack's chain id back through the rack walk, which no pad address answers to. `getRackByPath()` now dispatches pad-owned addresses to the pad route, the way `getChainByPath()` already dispatched chains, so every path-based rack call works inside a pad rather than failing silently. This is the widest of the five: bypass, volume, macros and `addChainToRack` were all silently failing in there.
- **Redoing a track duplication made a different track.** It duplicated again, allocating a fresh TrackId and fresh device, rack and chain ids, orphaning every link made against the first duplicate. It now restores what the first run made, as a paste replays what it materialised.
- **Undoing a track deletion moved the track to the end of the project.** The restore appended; it now takes the index the track stood at.

Each has its own named case in `test_structural_undo_roundtrip.cpp`, because a sweep says a cell failed and a case says what broke.

## Left standing

No undoable command removes a rack: the chain view calls `removeRackFromChainByPath()` straight off the model, so deleting a rack cannot be undone at all. Named in the sweep's own exclusions rather than fixed here, because it needs a new command plus UI wiring and engine-teardown verification.

## Testing

Full Catch2 suite green (713,712 assertions, 3,063 cases) and `magda_juce_tests` green.

https://claude.ai/code/session_0187yiSdSJPmDFZafrSfbSop