### PR TITLE
Make every chain-view deletion undoable, and stop a property edit freeing its own component (#2232)

### DIFF
--- a/magda/daw/core/ChainNodePath.hpp
+++ b/magda/daw/core/ChainNodePath.hpp
@@ -266,6 +266,24 @@ struct ChainNodePath {
         return p;
     }
 
+    // The track's post-fader FX list itself, as a container: Track >
+    // Segment(PostFx). What an insert into that list is addressed by, the way a
+    // chain path addresses an insert into a chain (#2232).
+    static ChainNodePath postFxSection(TrackId track) {
+        ChainNodePath p;
+        p.trackId = track;
+        p.steps.push_back({ChainStepType::Segment, static_cast<int>(ChainSegment::PostFx)});
+        return p;
+    }
+
+    // The rail-managed mixer-analysis section itself, as a container.
+    static ChainNodePath mixerAnalysisSection(TrackId track) {
+        ChainNodePath p;
+        p.trackId = track;
+        p.steps.push_back({ChainStepType::Segment, static_cast<int>(ChainSegment::MixerAnalysis)});
+        return p;
+    }
+
     // A device in the track's post-fader FX list. Flat by construction:
     //   Track > Segment(PostFx) > Device
     static ChainNodePath postFxDevice(TrackId track, DeviceId device) {

--- a/magda/daw/core/SelectionManager.cpp
+++ b/magda/daw/core/SelectionManager.cpp
@@ -926,6 +926,26 @@ void SelectionManager::clearSelectionForDeletedChainNode(const ChainNodePath& de
             shouldClear = deviceSelection_.trackId == deletedPath.trackId &&
                           deviceSelection_.deviceId == deletedPath.getDeviceId();
             break;
+        case SelectionType::MultiChainNode: {
+            // Drop the members that went and keep the rest. This had no case at
+            // all, so a Cmd-selected set holding one node inside a removed
+            // subtree kept that path in `selectedChainNodes_` and every
+            // multi-node operation ran against freed model (#2232). Clearing
+            // the whole set instead would take the survivors with it, which is
+            // not what deleting one of several selected nodes means.
+            std::vector<ChainNodePath> survivors;
+            survivors.reserve(selectedChainNodes_.size());
+            for (const auto& path : selectedChainNodes_)
+                if (!pointsAtDeletedNode(path))
+                    survivors.push_back(path);
+
+            // Re-selecting is the whole bookkeeping: it collapses back to
+            // ChainNode at one member, clears at none, moves the primary off a
+            // node that has gone, and notifies.
+            if (survivors.size() != selectedChainNodes_.size())
+                selectChainNodes(survivors);
+            return;
+        }
         default:
             break;
     }

--- a/magda/daw/core/TrackCommands.cpp
+++ b/magda/daw/core/TrackCommands.cpp
@@ -386,69 +386,6 @@ void AddDeviceToTrackCommand::undo() {
 }
 
 // ============================================================================
-// RemoveDeviceFromTrackCommand
-// ============================================================================
-
-RemoveDeviceFromTrackCommand::RemoveDeviceFromTrackCommand(TrackId trackId, DeviceId deviceId)
-    : trackId_(trackId), deviceId_(deviceId) {}
-
-void RemoveDeviceFromTrackCommand::execute() {
-    auto& tm = TrackManager::getInstance();
-
-    // Flush the plugin's live state into DeviceInfo before capturing
-    if (auto* engine = tm.getAudioEngine()) {
-        if (auto* bridge = engine->getAudioBridge()) {
-            DBG("UNDO: Capturing plugin state for device " << deviceId_);
-            bridge->getPluginManager().capturePluginState(
-                ChainNodePath::topLevelDevice(trackId_, deviceId_));
-        } else {
-            DBG("UNDO: WARNING - no AudioBridge, cannot capture plugin state");
-        }
-    } else {
-        DBG("UNDO: WARNING - no AudioEngine, cannot capture plugin state");
-    }
-
-    // Save the device info and position before removing
-    const auto& elements = tm.getChainElements(trackId_);
-    for (int i = 0; i < static_cast<int>(elements.size()); ++i) {
-        if (isDevice(elements[i]) && getDevice(elements[i]).id == deviceId_) {
-            savedDevice_ = getDevice(elements[i]);
-            savedIndex_ = i;
-            break;
-        }
-    }
-
-    if (savedIndex_ < 0)
-        return;
-
-    DBG("UNDO: Captured device state, pluginState length=" << savedDevice_.pluginState.length());
-
-    tm.removeDeviceFromTrack(trackId_, deviceId_);
-    executed_ = true;
-    DBG("UNDO: Removed device " << savedDevice_.name << " (id=" << deviceId_ << ") from track "
-                                << trackId_ << " at index " << savedIndex_);
-}
-
-void RemoveDeviceFromTrackCommand::undo() {
-    if (!executed_)
-        return;
-
-    DBG("UNDO: Restoring device " << savedDevice_.name << " (id=" << deviceId_
-                                  << "), pluginState length=" << savedDevice_.pluginState.length());
-    auto& tm = TrackManager::getInstance();
-    // Re-insert with ids preserved. addDeviceToTrack runs the device through
-    // prepareNewDevice, which stamps a fresh DeviceId, so undo would restore it
-    // under a different id and orphan every automation lane, macro link, and
-    // alias that targeted it. ChainElement is move-only, hence the push_back.
-    std::vector<ChainElement> elements;
-    elements.push_back(makeDeviceElement(savedDevice_));
-    tm.insertChainElementsByPath(ChainNodePath::topLevelDevice(trackId_, deviceId_).parentChain(),
-                                 std::move(elements), savedIndex_, /*reassignIds=*/false);
-    DBG("UNDO: Restored device " << savedDevice_.name << " (id=" << deviceId_ << ") to track "
-                                 << trackId_ << " at index " << savedIndex_);
-}
-
-// ============================================================================
 // MoveChainElementCommand
 // ============================================================================
 

--- a/magda/daw/core/TrackCommands.cpp
+++ b/magda/daw/core/TrackCommands.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <functional>
 #include <limits>
+#include <ranges>
 
 #include "../audio/AudioBridge.hpp"
 #include "../engine/AudioEngine.hpp"
@@ -957,6 +958,28 @@ void capturePluginStateAt(const ChainNodePath& devicePath) {
     }
 }
 
+/// Flush every live plugin under @p chainPath into the model before it is taken
+/// out, so an undo restores the subtree as it sounded rather than as it was
+/// assembled. A Drum Grid's pads ride along in its own state (#2207), so the
+/// grid device itself is the whole capture for them.
+void capturePluginStatesUnder(const std::vector<ChainElement>& elements,
+                              const ChainNodePath& chainPath) {
+    for (const auto& element : elements) {
+        if (isDevice(element)) {
+            capturePluginStateAt(chainPath.withDevice(magda::getDevice(element).id));
+            continue;
+        }
+
+        if (!isRack(element))
+            continue;
+
+        const auto& rack = magda::getRack(element);
+        const auto rackPath = chainPath.withRack(rack.id);
+        for (const auto& chain : rack.chains)
+            capturePluginStatesUnder(chain.elements, rackPath.withChain(chain.id));
+    }
+}
+
 }  // namespace
 
 AddDeviceByPathCommand::AddDeviceByPathCommand(const ChainNodePath& parentPath,
@@ -1024,6 +1047,17 @@ void RemoveDeviceByPathCommand::undo() {
     if (!executed_)
         return;
 
+    auto& tm = TrackManager::getInstance();
+
+    // The two flat sections hold bare devices in their own list, which the
+    // chain-element insert cannot address.
+    if (devicePath_.isPostFx() || devicePath_.isMixerAnalysis()) {
+        tm.insertFlatSectionDeviceByPath(devicePath_, savedDevice_, savedIndex_);
+        DBG("UNDO: Restored flat-section device " << savedDevice_.name << " at index "
+                                                  << savedIndex_);
+        return;
+    }
+
     // Re-insert with ids preserved. The ordinary add path runs the device
     // through prepareNewDevice, which stamps a fresh DeviceId — undo would then
     // restore the device under a different id, leaving every automation lane,
@@ -1032,11 +1066,105 @@ void RemoveDeviceByPathCommand::undo() {
     // from an initializer list.
     std::vector<ChainElement> elements;
     elements.push_back(makeDeviceElement(savedDevice_));
-    TrackManager::getInstance().insertChainElementsByPath(parentPath_, std::move(elements),
-                                                          savedIndex_, /*reassignIds=*/false);
+    tm.insertChainElementsByPath(parentPath_, std::move(elements), savedIndex_,
+                                 /*reassignIds=*/false);
 
     DBG("UNDO: Restored device " << savedDevice_.name << " (id=" << savedDevice_.id << ") at index "
                                  << savedIndex_);
+}
+
+RemoveRackByPathCommand::RemoveRackByPathCommand(const ChainNodePath& rackPath)
+    : rackPath_(rackPath), parentPath_(rackPath.parentChain()) {}
+
+void RemoveRackByPathCommand::execute() {
+    auto& tm = TrackManager::getInstance();
+
+    const auto* rack = tm.getRackByPath(rackPath_);
+    if (rack == nullptr)
+        return;
+
+    // The whole subtree, not the rack's own properties: every device under it
+    // goes with it, and each one's plugin holds state the model has not seen
+    // since it was last written.
+    for (const auto& chain : rack->chains)
+        capturePluginStatesUnder(chain.elements, rackPath_.withChain(chain.id));
+
+    // Capturing writes into the model, which can reallocate the container the
+    // rack lives in, so the pointer is taken again rather than reused.
+    rack = tm.getRackByPath(rackPath_);
+    if (rack == nullptr)
+        return;
+
+    savedIndex_ = tm.getChainElementIndex(rackPath_);
+    if (savedIndex_ < 0)
+        return;
+
+    savedRack_ = *rack;
+    tm.removeRackFromChainByPath(rackPath_);
+    executed_ = true;
+    DBG("UNDO: Removed rack " << savedRack_.name << " (id=" << savedRack_.id << ") at index "
+                              << savedIndex_);
+}
+
+void RemoveRackByPathCommand::undo() {
+    if (!executed_)
+        return;
+
+    // Copied rather than moved from: a redo runs execute() again, and the second
+    // removal has to have something to save. Restored with `reassignIds=false`
+    // for the reason the device command gives -- fresh ids would orphan every
+    // automation lane, macro link and alias naming what was in here.
+    std::vector<ChainElement> elements;
+    elements.push_back(makeRackElement(savedRack_));
+    TrackManager::getInstance().insertChainElementsByPath(parentPath_, std::move(elements),
+                                                          savedIndex_, /*reassignIds=*/false);
+
+    DBG("UNDO: Restored rack " << savedRack_.name << " (id=" << savedRack_.id << ") at index "
+                               << savedIndex_);
+}
+
+RemoveChainByPathCommand::RemoveChainByPathCommand(const ChainNodePath& chainPath)
+    : chainPath_(chainPath), rackPath_(chainPath.parent()) {}
+
+void RemoveChainByPathCommand::execute() {
+    auto& tm = TrackManager::getInstance();
+
+    const auto* rack = tm.getRackByPath(rackPath_);
+    if (rack == nullptr)
+        return;
+
+    const auto chainId = chainPath_.steps.empty() ? INVALID_CHAIN_ID : chainPath_.steps.back().id;
+    const auto found = std::ranges::find_if(
+        rack->chains, [chainId](const ChainInfo& chain) { return chain.id == chainId; });
+    if (found == rack->chains.end())
+        return;
+
+    capturePluginStatesUnder(found->elements, chainPath_);
+
+    rack = tm.getRackByPath(rackPath_);
+    if (rack == nullptr)
+        return;
+
+    const auto refound = std::ranges::find_if(
+        rack->chains, [chainId](const ChainInfo& chain) { return chain.id == chainId; });
+    if (refound == rack->chains.end())
+        return;
+
+    savedIndex_ = static_cast<int>(std::distance(rack->chains.begin(), refound));
+    savedChain_ = *refound;
+    tm.removeChainByPath(chainPath_);
+    executed_ = true;
+    DBG("UNDO: Removed chain " << savedChain_.name << " (id=" << savedChain_.id << ") at index "
+                               << savedIndex_);
+}
+
+void RemoveChainByPathCommand::undo() {
+    if (!executed_)
+        return;
+
+    TrackManager::getInstance().insertChainIntoRackByPath(rackPath_, savedChain_, savedIndex_);
+    DBG("UNDO: Restored chain " << savedChain_.name << " (id=" << savedChain_.id << ") at index "
+                                << savedIndex_);
 }
 
 }  // namespace magda

--- a/magda/daw/core/TrackCommands.cpp
+++ b/magda/daw/core/TrackCommands.cpp
@@ -926,7 +926,40 @@ AddDeviceByPathCommand::AddDeviceByPathCommand(const ChainNodePath& parentPath,
 void AddDeviceByPathCommand::execute() {
     auto& tm = TrackManager::getInstance();
 
-    if (parentPath_.getType() == ChainNodeType::Track) {
+    // A redo puts back what the first run made rather than adding again. Every
+    // add path stamps a fresh DeviceId, so a second run would hand the device a
+    // different identity and orphan every automation lane, macro link and alias
+    // named against the first one -- the reason paste and wrap replay what they
+    // materialised (#2228, #2232).
+    if (executed_ && createdDevicePath_.isValid()) {
+        if (createdDevicePath_.isPostFx() || createdDevicePath_.isMixerAnalysis()) {
+            tm.insertFlatSectionDeviceByPath(createdDevicePath_, materialised_, insertIndex_);
+            return;
+        }
+
+        std::vector<ChainElement> elements;
+        elements.push_back(makeDeviceElement(materialised_));
+        tm.insertChainElementsByPath(createdDevicePath_.parentChain(), std::move(elements),
+                                     insertIndex_, /*reassignIds=*/false);
+        return;
+    }
+
+    const bool postFx = parentPath_.isPostFx();
+    if (postFx || parentPath_.isMixerAnalysis()) {
+        // The two flat sections hold bare devices in their own list; neither of
+        // the chain adds can reach one, so adding an analyzer stayed off the
+        // undo stack entirely.
+        if (postFx)
+            createdDeviceId_ =
+                insertIndex_ >= 0 ? tm.addDeviceToPostFx(parentPath_.trackId, device_, insertIndex_)
+                                  : tm.addDeviceToPostFx(parentPath_.trackId, device_);
+        else
+            createdDeviceId_ = tm.addDeviceToMixerAnalysis(parentPath_.trackId, device_);
+        if (createdDeviceId_ != INVALID_DEVICE_ID)
+            createdDevicePath_ =
+                postFx ? ChainNodePath::postFxDevice(parentPath_.trackId, createdDeviceId_)
+                       : ChainNodePath::mixerAnalysisDevice(parentPath_.trackId, createdDeviceId_);
+    } else if (parentPath_.getType() == ChainNodeType::Track) {
         createdDeviceId_ = insertIndex_ >= 0
                                ? tm.addDeviceToTrack(parentPath_.trackId, device_, insertIndex_)
                                : tm.addDeviceToTrack(parentPath_.trackId, device_);
@@ -942,6 +975,13 @@ void AddDeviceByPathCommand::execute() {
     }
 
     executed_ = createdDeviceId_ != INVALID_DEVICE_ID;
+    if (executed_) {
+        // Where it actually landed, so a redo restores that index rather than
+        // the -1 that meant "append".
+        insertIndex_ = tm.getChainElementIndex(createdDevicePath_);
+        if (const auto* added = tm.getDeviceInChainByPath(createdDevicePath_))
+            materialised_ = *added;
+    }
     DBG("UNDO: Added device by path " << parentPath_.toString() << " (deviceId=" << createdDeviceId_
                                       << ")");
 }

--- a/magda/daw/core/TrackCommands.hpp
+++ b/magda/daw/core/TrackCommands.hpp
@@ -421,4 +421,66 @@ class RemoveDeviceByPathCommand : public UndoableCommand {
     bool executed_ = false;
 };
 
+/**
+ * @brief Remove a rack addressed by path, restoring the whole subtree on undo.
+ *
+ * The chain view used to call `removeRackFromChainByPath()` straight off the
+ * model, so deleting a rack -- with every device, nested rack, macro and mod it
+ * held -- could not be undone at all. It was the one operation the structural
+ * matrix had to exclude by name rather than assert (#2232).
+ *
+ * Captures the live plugin state of every device beneath the rack first, so
+ * undo restores them as they sounded, and restores under the ids they had so
+ * the links naming them still resolve.
+ */
+class RemoveRackByPathCommand : public UndoableCommand {
+  public:
+    explicit RemoveRackByPathCommand(const ChainNodePath& rackPath);
+
+    void execute() override;
+    void undo() override;
+    juce::String getDescription() const override {
+        return "Remove Rack";
+    }
+
+    bool didRemove() const {
+        return executed_;
+    }
+
+  private:
+    ChainNodePath rackPath_;
+    ChainNodePath parentPath_;
+    RackInfo savedRack_;
+    int savedIndex_ = -1;
+    bool executed_ = false;
+};
+
+/**
+ * @brief Remove one chain from a rack, restoring it in place on undo.
+ *
+ * Same gap as the rack above, one level down: the chain row's X went straight
+ * to `removeChainByPath()`, and a chain carries devices (#2232).
+ */
+class RemoveChainByPathCommand : public UndoableCommand {
+  public:
+    explicit RemoveChainByPathCommand(const ChainNodePath& chainPath);
+
+    void execute() override;
+    void undo() override;
+    juce::String getDescription() const override {
+        return "Remove Chain";
+    }
+
+    bool didRemove() const {
+        return executed_;
+    }
+
+  private:
+    ChainNodePath chainPath_;
+    ChainNodePath rackPath_;
+    ChainInfo savedChain_;
+    int savedIndex_ = -1;
+    bool executed_ = false;
+};
+
 }  // namespace magda

--- a/magda/daw/core/TrackCommands.hpp
+++ b/magda/daw/core/TrackCommands.hpp
@@ -340,8 +340,9 @@ class CreateTrackWithDeviceCommand : public UndoableCommand {
  *
  * The track-level `AddDeviceToTrackCommand` above cannot reach into a rack, and
  * a `(trackId, rackId, chainId)` triple stops at one level of nesting. This
- * takes the parent path — track-level for the main FX chain, or a chain path at
- * any depth — so anything the model can express is reachable.
+ * takes the parent path — track-level for the main FX chain, a chain path at
+ * any depth, or one of the two flat sections — so anything the model can
+ * express is reachable (#2232).
  */
 class AddDeviceByPathCommand : public UndoableCommand {
   public:
@@ -369,6 +370,12 @@ class AddDeviceByPathCommand : public UndoableCommand {
     int insertIndex_ = -1;
     DeviceId createdDeviceId_ = INVALID_DEVICE_ID;
     ChainNodePath createdDevicePath_;
+    /// What the first run actually made, replayed by a redo rather than added
+    /// again. The add path stamps a fresh DeviceId, so re-adding would give the
+    /// device a different identity each time round the stack and orphan
+    /// everything named against the first one -- the reason paste and wrap
+    /// replay what they materialised (#2228).
+    DeviceInfo materialised_;
     bool executed_ = false;
 };
 

--- a/magda/daw/core/TrackCommands.hpp
+++ b/magda/daw/core/TrackCommands.hpp
@@ -141,27 +141,6 @@ class AddDeviceToTrackCommand : public UndoableCommand {
 };
 
 /**
- * @brief Command for removing a device from a track (undoable)
- */
-class RemoveDeviceFromTrackCommand : public UndoableCommand {
-  public:
-    RemoveDeviceFromTrackCommand(TrackId trackId, DeviceId deviceId);
-
-    void execute() override;
-    void undo() override;
-    juce::String getDescription() const override {
-        return "Remove Device from Track";
-    }
-
-  private:
-    TrackId trackId_;
-    DeviceId deviceId_;
-    DeviceInfo savedDevice_;
-    int savedIndex_ = -1;
-    bool executed_ = false;
-};
-
-/**
  * @brief Command for moving a chain element within/between track and rack chains.
  */
 class MoveChainElementCommand : public UndoableCommand {

--- a/magda/daw/core/TrackManager.cpp
+++ b/magda/daw/core/TrackManager.cpp
@@ -2499,6 +2499,33 @@ RackId TrackManager::addRackToTrack(TrackId trackId, const juce::String& name) {
     return INVALID_RACK_ID;
 }
 
+void TrackManager::clearSelectionsUnderChain(const std::vector<ChainElement>& elements,
+                                             const ChainNodePath& chainPath) {
+    auto& selection = SelectionManager::getInstance();
+    for (const auto& element : elements) {
+        if (magda::isDevice(element)) {
+            selection.clearSelectionForDeletedChainNode(
+                chainPath.withDevice(magda::getDevice(element).id));
+            continue;
+        }
+
+        if (magda::isRack(element)) {
+            const auto& rack = magda::getRack(element);
+            clearSelectionsUnderRack(rack, chainPath.withRack(rack.id));
+        }
+    }
+}
+
+void TrackManager::clearSelectionsUnderRack(const RackInfo& rack, const ChainNodePath& rackPath) {
+    auto& selection = SelectionManager::getInstance();
+    for (const auto& chain : rack.chains) {
+        const auto chainPath = rackPath.withChain(chain.id);
+        clearSelectionsUnderChain(chain.elements, chainPath);
+        selection.clearSelectionForDeletedChainNode(chainPath);
+    }
+    selection.clearSelectionForDeletedChainNode(rackPath);
+}
+
 void TrackManager::removeRackFromTrack(TrackId trackId, RackId rackId) {
     if (auto* track = getTrack(trackId)) {
         auto& elements = track->chain.fxChainElements;
@@ -2508,6 +2535,7 @@ void TrackManager::removeRackFromTrack(TrackId trackId, RackId rackId) {
         if (it != elements.end()) {
             DBG("Removed rack: " << magda::getRack(*it).name << " (id=" << rackId << ") from track "
                                  << trackId);
+            clearSelectionsUnderRack(magda::getRack(*it), ChainNodePath::rack(trackId, rackId));
             elements.erase(it);
             notifyTrackDevicesChanged(trackId);
         }
@@ -2792,6 +2820,9 @@ void TrackManager::removeChainFromRack(TrackId trackId, RackId rackId, ChainId c
                                [chainId](const ChainInfo& c) { return c.id == chainId; });
         if (it != chains.end()) {
             DBG("Removed chain: " << it->name << " (id=" << chainId << ") from rack " << rackId);
+            const auto chainPath = ChainNodePath::rack(trackId, rackId).withChain(chainId);
+            clearSelectionsUnderChain(it->elements, chainPath);
+            SelectionManager::getInstance().clearSelectionForDeletedChainNode(chainPath);
             chains.erase(it);
             notifyTrackDevicesChanged(trackId);
         }
@@ -2828,12 +2859,26 @@ void TrackManager::removeChainByPath(const ChainNodePath& chainPath) {
                                [chainId](const ChainInfo& c) { return c.id == chainId; });
         if (it != chains.end()) {
             DBG("Removed chain via path: " << it->name << " (id=" << chainId << ")");
+            clearSelectionsUnderChain(it->elements, chainPath);
+            SelectionManager::getInstance().clearSelectionForDeletedChainNode(chainPath);
             chains.erase(it);
             notifyTrackDevicesChanged(chainPath.trackId);
         }
     } else {
         DBG("removeChainByPath FAILED - rack not found via path!");
     }
+}
+
+bool TrackManager::insertChainIntoRackByPath(const ChainNodePath& rackPath, ChainInfo chain,
+                                             int index) {
+    auto* rack = getRackByPath(rackPath);
+    if (rack == nullptr || chain.id == INVALID_CHAIN_ID)
+        return false;
+
+    index = std::clamp(index, 0, static_cast<int>(rack->chains.size()));
+    rack->chains.insert(rack->chains.begin() + index, std::move(chain));
+    notifyTrackDevicesChanged(rackPath.trackId);
+    return true;
 }
 
 ChainInfo* TrackManager::getChainByPath(const ChainNodePath& chainPath) {

--- a/magda/daw/core/TrackManager.cpp
+++ b/magda/daw/core/TrackManager.cpp
@@ -2348,8 +2348,8 @@ void TrackManager::removeDeviceFromTrack(TrackId trackId, DeviceId deviceId) {
         if (it != elements.end()) {
             DBG("Removed device: " << magda::getDevice(*it).name << " (id=" << deviceId
                                    << ") from track " << trackId);
-            SelectionManager::getInstance().clearSelectionForDeletedChainNode(
-                ChainNodePath::topLevelDevice(trackId, deviceId));
+            clearSelectionsUnderDevice(magda::getDevice(*it),
+                                       ChainNodePath::topLevelDevice(trackId, deviceId));
             elements.erase(it);
             notifyTrackDevicesChanged(trackId);
             return;
@@ -2499,13 +2499,33 @@ RackId TrackManager::addRackToTrack(TrackId trackId, const juce::String& name) {
     return INVALID_RACK_ID;
 }
 
+void TrackManager::clearSelectionsUnderDevice(const DeviceInfo& device,
+                                              const ChainNodePath& devicePath) {
+    SelectionManager::getInstance().clearSelectionForDeletedChainNode(devicePath);
+
+    // A device is not always a leaf: a pad-per-chain device owns chains of its
+    // own (#2207), and they are addressed off the track by the device's id
+    // rather than through whatever the device itself stands in, so neither the
+    // grid's path nor its DeviceId matches anything under it. A selected pad
+    // chain, or a device on one, would survive the erase pointing at freed
+    // model (#2232).
+    const auto* pads = device.pads.get();
+    if (pads == nullptr)
+        return;
+
+    for (const auto& pad : pads->chains) {
+        const auto padPath = ChainNodePath::padChain(devicePath.trackId, device.id, pad.id);
+        clearSelectionsUnderChain(pad.elements, padPath);
+        SelectionManager::getInstance().clearSelectionForDeletedChainNode(padPath);
+    }
+}
+
 void TrackManager::clearSelectionsUnderChain(const std::vector<ChainElement>& elements,
                                              const ChainNodePath& chainPath) {
-    auto& selection = SelectionManager::getInstance();
     for (const auto& element : elements) {
         if (magda::isDevice(element)) {
-            selection.clearSelectionForDeletedChainNode(
-                chainPath.withDevice(magda::getDevice(element).id));
+            const auto& device = magda::getDevice(element);
+            clearSelectionsUnderDevice(device, chainPath.withDevice(device.id));
             continue;
         }
 

--- a/magda/daw/core/TrackManager.hpp
+++ b/magda/daw/core/TrackManager.hpp
@@ -722,6 +722,15 @@ class TrackManager : public daw::audio::DeviceIdAllocator, public daw::audio::De
     ChainId addChainToRack(const ChainNodePath& rackPath, const juce::String& name = "Chain");
     void removeChainFromRack(TrackId trackId, RackId rackId, ChainId chainId);
     void removeChainByPath(const ChainNodePath& chainPath);  // Path-based removal for nested chains
+    /// Put @p chain back into the rack at @p rackPath, at @p index, under the id
+    /// it already carries.
+    ///
+    /// `addChainToRack()` appends and stamps a fresh ChainId, so it cannot undo
+    /// a removal: the chain would come back last and under a different identity
+    /// from the one every link, lane and alias naming it was made against, the
+    /// same reason the device and rack removals restore ids rather than
+    /// reallocate them (#2232).
+    bool insertChainIntoRackByPath(const ChainNodePath& rackPath, ChainInfo chain, int index);
     ChainInfo* getChain(TrackId trackId, RackId rackId, ChainId chainId);
     const ChainInfo* getChain(TrackId trackId, RackId rackId, ChainId chainId) const;
     ChainInfo* getChainByPath(const ChainNodePath& chainPath);  // Nested-chain lookup
@@ -785,6 +794,16 @@ class TrackManager : public daw::audio::DeviceIdAllocator, public daw::audio::De
     bool insertChainElementsByPath(const ChainNodePath& destinationChainPath,
                                    std::vector<ChainElement> elements, int insertIndex,
                                    bool reassignIds = true);
+    /// Put @p device back into the flat section @p devicePath addresses, at
+    /// @p index, under the id it already carries.
+    ///
+    /// `addDeviceToPostFx()` and `addDeviceToMixerAnalysis()` stamp a fresh
+    /// DeviceId and re-run the section's admission rules, so neither can undo a
+    /// removal: the device would come back under an identity no existing link
+    /// names. The chain tree has `insertChainElementsByPath(reassignIds=false)`
+    /// for this; the flat sections had nothing (#2232).
+    bool insertFlatSectionDeviceByPath(const ChainNodePath& devicePath, DeviceInfo device,
+                                       int index);
     /// Wrap @p paths in a new rack.
     ///
     /// @p presetRackId and @p presetChainId let a redo reuse the ids its first
@@ -920,8 +939,6 @@ class TrackManager : public daw::audio::DeviceIdAllocator, public daw::audio::De
     RackId addRackToChain(TrackId trackId, RackId parentRackId, ChainId chainId,
                           const juce::String& name = "Rack");
     RackId addRackToChainByPath(const ChainNodePath& chainPath, const juce::String& name = "Rack");
-    void removeRackFromChain(TrackId trackId, RackId parentRackId, ChainId chainId,
-                             RackId nestedRackId);
     void removeRackFromChainByPath(const ChainNodePath& rackPath);
 
     // ========================================================================
@@ -1206,6 +1223,16 @@ class TrackManager : public daw::audio::DeviceIdAllocator, public daw::audio::De
     // reach in and mutate macros/mods without going through the setter
     // notification path.
     ChainNode resolveChainNode(const ChainNodePath& path);
+
+    // Drop any selection standing on something that is about to be erased.
+    //
+    // `SelectionManager::clearSelectionForDeletedChainNode()` matches an exact
+    // path or a device id rather than an ancestor, so removing a container
+    // leaves a selection below it pointing at freed model. Every removal of a
+    // subtree goes through these two, which walk it (#2232).
+    static void clearSelectionsUnderChain(const std::vector<ChainElement>& elements,
+                                          const ChainNodePath& chainPath);
+    static void clearSelectionsUnderRack(const RackInfo& rack, const ChainNodePath& rackPath);
 
     std::vector<TrackInfo> tracks_;
     std::vector<TrackManagerListener*> listeners_;

--- a/magda/daw/core/TrackManager.hpp
+++ b/magda/daw/core/TrackManager.hpp
@@ -1230,6 +1230,8 @@ class TrackManager : public daw::audio::DeviceIdAllocator, public daw::audio::De
     // path or a device id rather than an ancestor, so removing a container
     // leaves a selection below it pointing at freed model. Every removal of a
     // subtree goes through these two, which walk it (#2232).
+    static void clearSelectionsUnderDevice(const DeviceInfo& device,
+                                           const ChainNodePath& devicePath);
     static void clearSelectionsUnderChain(const std::vector<ChainElement>& elements,
                                           const ChainNodePath& chainPath);
     static void clearSelectionsUnderRack(const RackInfo& rack, const ChainNodePath& rackPath);

--- a/magda/daw/core/TrackManagerDevices.cpp
+++ b/magda/daw/core/TrackManagerDevices.cpp
@@ -1037,6 +1037,23 @@ std::vector<ChainElement> TrackManager::copyChainElements(
     return copied;
 }
 
+bool TrackManager::insertFlatSectionDeviceByPath(const ChainNodePath& devicePath, DeviceInfo device,
+                                                 int index) {
+    auto* track = getTrack(devicePath.trackId);
+    if (track == nullptr || device.id == INVALID_DEVICE_ID)
+        return false;
+
+    const bool postFx = devicePath.isPostFx();
+    if (!postFx && !devicePath.isMixerAnalysis())
+        return false;
+
+    auto& section = postFx ? track->chain.postFxChainElements : track->chain.mixerAnalysisElements;
+    index = std::clamp(index, 0, static_cast<int>(section.size()));
+    section.insert(section.begin() + index, PostFxChainElement{std::move(device)});
+    notifyTrackDevicesChanged(devicePath.trackId);
+    return true;
+}
+
 bool TrackManager::insertChainElementsByPath(const ChainNodePath& destinationChainPath,
                                              std::vector<ChainElement> elements, int insertIndex,
                                              bool reassignIds) {
@@ -1144,6 +1161,26 @@ RackId TrackManager::wrapChainElementsInRack(const std::vector<ChainNodePath>& p
 }
 
 int TrackManager::getChainElementIndex(const ChainNodePath& elementPath) {
+    // The two flat sections hold bare devices rather than chain elements, so
+    // the container lookup below has no answer for them. Without this a removal
+    // command could not record where a post-fader device stood and stopped
+    // before removing it, which is why the structural matrix recorded every
+    // flat-section removal as refused (#2232).
+    if (elementPath.isPostFx() || elementPath.isMixerAnalysis()) {
+        auto* track = getTrack(elementPath.trackId);
+        if (track == nullptr)
+            return -1;
+
+        const auto& section = elementPath.isPostFx() ? track->chain.postFxChainElements
+                                                     : track->chain.mixerAnalysisElements;
+        const auto deviceId = elementPath.getDeviceId();
+        for (int i = 0; i < static_cast<int>(section.size()); ++i) {
+            if (section[static_cast<size_t>(i)].device.id == deviceId)
+                return i;
+        }
+        return -1;
+    }
+
     ChainNodePath containerPath;
     containerPath.trackId = elementPath.trackId;
 
@@ -2292,28 +2329,8 @@ RackId TrackManager::addRackToChainByPath(const ChainNodePath& chainPath,
     return INVALID_RACK_ID;
 }
 
-void TrackManager::removeRackFromChain(TrackId trackId, RackId parentRackId, ChainId chainId,
-                                       RackId nestedRackId) {
-    if (auto* chain = getChain(trackId, parentRackId, chainId)) {
-        auto& elements = chain->elements;
-        for (auto it = elements.begin(); it != elements.end(); ++it) {
-            if (magda::isRack(*it)) {
-                if (magda::getRack(*it).id == nestedRackId) {
-                    elements.erase(it);
-                    notifyTrackDevicesChanged(trackId);
-                    return;
-                }
-            }
-        }
-    } else {
-    }
-}
-
 void TrackManager::removeRackFromChainByPath(const ChainNodePath& rackPath) {
     // rackPath ends with a Rack step - we need to find the parent chain and remove this rack
-    for (size_t i = 0; i < rackPath.steps.size(); ++i) {
-    }
-
     if (rackPath.steps.size() == 1 && rackPath.steps.back().type == ChainStepType::Rack) {
         removeRackFromTrack(rackPath.trackId, rackPath.steps.back().id);
         return;
@@ -2342,15 +2359,13 @@ void TrackManager::removeRackFromChainByPath(const ChainNodePath& rackPath) {
     if (auto* chain = getChainFromPath(*this, chainPath)) {
         auto& elements = chain->elements;
         for (auto it = elements.begin(); it != elements.end(); ++it) {
-            if (magda::isRack(*it)) {
-                if (magda::getRack(*it).id == rackId) {
-                    elements.erase(it);
-                    notifyTrackDevicesChanged(rackPath.trackId);
-                    return;
-                }
+            if (magda::isRack(*it) && magda::getRack(*it).id == rackId) {
+                clearSelectionsUnderRack(magda::getRack(*it), rackPath);
+                elements.erase(it);
+                notifyTrackDevicesChanged(rackPath.trackId);
+                return;
             }
         }
-    } else {
     }
 }
 

--- a/magda/daw/core/TrackManagerDevices.cpp
+++ b/magda/daw/core/TrackManagerDevices.cpp
@@ -496,7 +496,8 @@ void TrackManager::removeDeviceFromChain(TrackId trackId, RackId rackId, ChainId
             return magda::isDevice(e) && magda::getDevice(e).id == deviceId;
         });
         if (it != elements.end()) {
-            SelectionManager::getInstance().clearSelectionForDeletedChainNode(
+            clearSelectionsUnderDevice(
+                magda::getDevice(*it),
                 ChainNodePath::chainDevice(trackId, rackId, chainId, deviceId));
             elements.erase(it);
             notifyTrackDevicesChanged(trackId);
@@ -1223,7 +1224,7 @@ void TrackManager::removeDeviceFromChainByPath(const ChainNodePath& devicePath) 
         auto it = std::find_if(elements.begin(), elements.end(),
                                [id](const PostFxChainElement& e) { return e.device.id == id; });
         if (it != elements.end()) {
-            SelectionManager::getInstance().clearSelectionForDeletedChainNode(devicePath);
+            clearSelectionsUnderDevice(it->device, devicePath);
             elements.erase(it);
             notifyTrackDevicesChanged(devicePath.trackId);
         }
@@ -1253,7 +1254,7 @@ void TrackManager::removeDeviceFromChainByPath(const ChainNodePath& devicePath) 
                 return magda::isDevice(e) && magda::getDevice(e).id == devicePath.topLevelDeviceId;
             });
         if (it != elements.end()) {
-            SelectionManager::getInstance().clearSelectionForDeletedChainNode(devicePath);
+            clearSelectionsUnderDevice(magda::getDevice(*it), devicePath);
             elements.erase(it);
             notifyTrackDevicesChanged(devicePath.trackId);
         }
@@ -1284,7 +1285,7 @@ void TrackManager::removeDeviceFromChainByPath(const ChainNodePath& devicePath) 
             return magda::isDevice(e) && magda::getDevice(e).id == deviceId;
         });
         if (it != elements.end()) {
-            SelectionManager::getInstance().clearSelectionForDeletedChainNode(devicePath);
+            clearSelectionsUnderDevice(magda::getDevice(*it), devicePath);
             elements.erase(it);
             notifyTrackDevicesChanged(devicePath.trackId);
         }

--- a/magda/daw/core/TrackManagerPads.cpp
+++ b/magda/daw/core/TrackManagerPads.cpp
@@ -24,40 +24,6 @@ namespace magda {
 // inspect the model or count steps (#2219).
 // ============================================================================
 
-namespace {
-
-/// Drop any selection standing on something inside @p chainPath before it goes.
-///
-/// Every node under it, not only the devices it holds directly: a pad's chain
-/// takes racks like any other chain, and `clearSelectionForDeletedChainNode()`
-/// matches an exact path or a device id rather than an ancestor, so a selection
-/// below a nested rack would survive the erase pointing at freed model (#2211).
-void clearSelectionsUnder(const std::vector<ChainElement>& elements,
-                          const ChainNodePath& chainPath) {
-    auto& selection = SelectionManager::getInstance();
-    for (const auto& element : elements) {
-        if (magda::isDevice(element)) {
-            selection.clearSelectionForDeletedChainNode(
-                chainPath.withDevice(magda::getDevice(element).id));
-            continue;
-        }
-
-        if (!magda::isRack(element))
-            continue;
-
-        const auto& rack = magda::getRack(element);
-        const auto rackPath = chainPath.withRack(rack.id);
-        for (const auto& chain : rack.chains) {
-            const auto nested = rackPath.withChain(chain.id);
-            clearSelectionsUnder(chain.elements, nested);
-            selection.clearSelectionForDeletedChainNode(nested);
-        }
-        selection.clearSelectionForDeletedChainNode(rackPath);
-    }
-}
-
-}  // namespace
-
 ChainNodePath TrackManager::padChainPath(const ChainNodePath& gridPath, ChainId padChainId) {
     // Flat, and named by the DEVICE's own id: `PadRack(gridDeviceId) >
     // PadChain(pad)`, whatever the grid itself is nested in.
@@ -250,7 +216,7 @@ DeviceId TrackManager::setPadDevice(const ChainNodePath& gridPath, int padIndex,
     // Dropping an instrument on a pad replaces the pad, effects and all: that
     // is what the pad's slot means. Selections pointing into what is going away
     // are cleared first, the same as any other device removal.
-    clearSelectionsUnder(pad->elements, padChainPath(gridPath, padChainId));
+    clearSelectionsUnderChain(pad->elements, padChainPath(gridPath, padChainId));
     pad->elements.clear();
 
     // Named after what is on it, which is what the grid shows on the pad.
@@ -276,7 +242,7 @@ void TrackManager::clearPad(const ChainNodePath& gridPath, int padIndex) {
         return;
 
     const auto chainPath = padChainPath(gridPath, pad->id);
-    clearSelectionsUnder(pad->elements, chainPath);
+    clearSelectionsUnderChain(pad->elements, chainPath);
     SelectionManager::getInstance().clearSelectionForDeletedChainNode(chainPath);
 
     std::erase_if(pads->chains, [id = pad->id](const ChainInfo& chain) { return chain.id == id; });
@@ -486,7 +452,7 @@ void TrackManager::removePadChain(const ChainNodePath& gridPath, ChainId padChai
         return;
 
     const auto chainPath = padChainPath(gridPath, padChainId);
-    clearSelectionsUnder(found->elements, chainPath);
+    clearSelectionsUnderChain(found->elements, chainPath);
     SelectionManager::getInstance().clearSelectionForDeletedChainNode(chainPath);
 
     pads->chains.erase(found);

--- a/magda/daw/ui/components/chain/ChainRowComponent.cpp
+++ b/magda/daw/ui/components/chain/ChainRowComponent.cpp
@@ -7,6 +7,7 @@
 #include "../../utils/SelectionPolicy.hpp"
 #include "RackComponent.hpp"
 #include "core/SelectionManager.hpp"
+#include "core/TrackCommands.hpp"
 #include "ui/themes/DarkTheme.hpp"
 #include "ui/themes/FontManager.hpp"
 #include "ui/themes/SmallButtonLookAndFeel.hpp"
@@ -389,13 +390,16 @@ void ChainRowComponent::onBypassClicked() {
 }
 
 void ChainRowComponent::onDeleteClicked() {
-    // Use path-based removal to support nested chains
-    if (nodePath_.isValid()) {
-        magda::TrackManager::getInstance().removeChainByPath(nodePath_);
-    } else {
-        // Fallback to flat ID removal for top-level chains
-        magda::TrackManager::getInstance().removeChainFromRack(trackId_, rackId_, chainId_);
-    }
+    // Deferred and undoable: the removal notifies synchronously and the rebuild
+    // it triggers destroys this row while its own click is still on the stack,
+    // and a chain carries every device in it (#2232).
+    const auto chainPath = nodePath_.isValid()
+                               ? nodePath_
+                               : magda::ChainNodePath::rack(trackId_, rackId_).withChain(chainId_);
+    juce::MessageManager::callAsync([chainPath]() {
+        magda::UndoManager::getInstance().executeCommand(
+            std::make_unique<magda::RemoveChainByPathCommand>(chainPath));
+    });
 }
 
 }  // namespace magda::daw::ui

--- a/magda/daw/ui/components/chain/DeviceSlotComponent.cpp
+++ b/magda/daw/ui/components/chain/DeviceSlotComponent.cpp
@@ -184,14 +184,11 @@ DeviceSlotComponent::DeviceSlotComponent(const magda::DeviceInfo& device) : devi
         auto callback = onDeviceDeleted;
         detachInlineUiFromLivePlugin();
         juce::MessageManager::callAsync([pathToDelete, callback]() {
-            // Top-level devices use undoable command; nested devices fall back to direct removal
-            if (pathToDelete.topLevelDeviceId != magda::INVALID_DEVICE_ID) {
-                magda::UndoManager::getInstance().executeCommand(
-                    std::make_unique<magda::RemoveDeviceFromTrackCommand>(
-                        pathToDelete.trackId, pathToDelete.topLevelDeviceId));
-            } else {
-                magda::TrackManager::getInstance().removeDeviceFromChainByPath(pathToDelete);
-            }
+            // Every depth through the same undoable command. A nested device
+            // used to fall back to a direct model call, so deleting one out of
+            // a rack chain could not be undone (#2232).
+            magda::UndoManager::getInstance().executeCommand(
+                std::make_unique<magda::RemoveDeviceByPathCommand>(pathToDelete));
             if (callback) {
                 callback();
             }

--- a/magda/daw/ui/components/chain/RackComponent.cpp
+++ b/magda/daw/ui/components/chain/RackComponent.cpp
@@ -16,21 +16,34 @@
 
 namespace magda::daw::ui {
 
+namespace {
+
+/// Delete the rack at @p rackPath, undoably and after this component has gone.
+///
+/// Deferred because removing the rack notifies synchronously, and the rebuild
+/// that follows destroys the button whose click is still on the stack; the path
+/// is taken by value for the same reason. Both constructors below share this,
+/// so the top-level and nested X do the same thing (#2232).
+void requestRackDeletion(magda::ChainNodePath rackPath) {
+    juce::MessageManager::callAsync([rackPath]() {
+        magda::UndoManager::getInstance().executeCommand(
+            std::make_unique<magda::RemoveRackByPathCommand>(rackPath));
+    });
+}
+
+}  // namespace
+
 // Constructor for top-level rack (in track)
 RackComponent::RackComponent(magda::TrackId trackId, const magda::RackInfo& rack)
     : rackPath_(magda::ChainNodePath::rack(trackId, rack.id)), trackId_(trackId), rackId_(rack.id) {
-    onDeleteClicked = [this]() {
-        magda::TrackManager::getInstance().removeRackFromTrack(trackId_, rackId_);
-    };
+    onDeleteClicked = [this]() { requestRackDeletion(rackPath_); };
     initializeCommon(rack);
 }
 
 // Constructor for nested rack (in chain) - with full path context
 RackComponent::RackComponent(const magda::ChainNodePath& rackPath, const magda::RackInfo& rack)
     : rackPath_(rackPath), trackId_(rackPath.trackId), rackId_(rack.id) {
-    onDeleteClicked = [this]() {
-        magda::TrackManager::getInstance().removeRackFromChainByPath(rackPath_);
-    };
+    onDeleteClicked = [this]() { requestRackDeletion(rackPath_); };
     initializeCommon(rack);
 }
 

--- a/magda/daw/ui/components/chain/slot/DeviceSlotAnalyzerContextActions.cpp
+++ b/magda/daw/ui/components/chain/slot/DeviceSlotAnalyzerContextActions.cpp
@@ -90,13 +90,13 @@ void showDeviceSlotContextMenu(juce::Component& owner, const magda::ChainNodePat
                     std::make_unique<magda::WrapChainElementsInRackCommand>(selectedPaths));
             } else if (result == 100) {
                 juce::MessageManager::callAsync([path, callback]() {
-                    if (path.topLevelDeviceId != magda::INVALID_DEVICE_ID) {
-                        magda::UndoManager::getInstance().executeCommand(
-                            std::make_unique<magda::RemoveDeviceFromTrackCommand>(
-                                path.trackId, path.topLevelDeviceId));
-                    } else {
-                        magda::TrackManager::getInstance().removeDeviceFromChainByPath(path);
-                    }
+                    // Every depth through the same undoable command, the way
+                    // the slot's own X does. This used to fall through to a
+                    // direct model call for anything but a top-level device,
+                    // so right-click Delete on a nested, post-fader or
+                    // mixer-analysis device could not be undone (#2232).
+                    magda::UndoManager::getInstance().executeCommand(
+                        std::make_unique<magda::RemoveDeviceByPathCommand>(path));
                     if (callback)
                         callback();
                 });

--- a/magda/daw/ui/panels/content/PostFxPanelContent.cpp
+++ b/magda/daw/ui/panels/content/PostFxPanelContent.cpp
@@ -4,6 +4,8 @@
 
 #include "PluginBrowserContent.hpp"
 #include "core/ChainNodePath.hpp"
+#include "core/TrackCommands.hpp"
+#include "core/UndoManager.hpp"
 #include "engine/AudioEngine.hpp"
 #include "ui/components/chain/DeviceSlotComponent.hpp"
 #include "ui/components/chain/NodeComponent.hpp"
@@ -109,8 +111,10 @@ class PostFxPanelContent::Container : public juce::Component, public juce::DragA
                 auto device = PostFxPanelContent::deviceInfoFromDragObject(*obj);
                 // Post-fx never holds instruments (addDeviceToPostFx also guards).
                 if (!device.isInstrument) {
-                    magda::TrackManager::getInstance().addDeviceToPostFx(owner_.trackId_, device,
-                                                                         insertIndex);
+                    magda::UndoManager::getInstance().executeCommand(
+                        std::make_unique<magda::AddDeviceByPathCommand>(
+                            magda::ChainNodePath::postFxSection(owner_.trackId_), device,
+                            insertIndex));
                 }
             }
         }
@@ -516,7 +520,9 @@ void PostFxPanelContent::showAddDeviceMenu() {
             return;
         }
 
-        magda::TrackManager::getInstance().addDeviceToPostFx(trackId, device);
+        magda::UndoManager::getInstance().executeCommand(
+            std::make_unique<magda::AddDeviceByPathCommand>(
+                magda::ChainNodePath::postFxSection(trackId), device));
     });
 }
 

--- a/magda/daw/ui/panels/content/TrackChainContent.cpp
+++ b/magda/daw/ui/panels/content/TrackChainContent.cpp
@@ -2663,28 +2663,59 @@ void TrackChainContent::hideHeaderControls() {
 }
 
 void TrackChainContent::rebuildNodeComponents() {
-    // Save node states (collapsed, expanded chains) BEFORE clearing components
+    // Save node states (collapsed, expanded chains) BEFORE anything is dropped
     saveNodeStates();
 
-    // Clear existing components
-    unfocusAllComponents();
-    nodeComponents_.clear();
-
     if (selectedTrackId_ == magda::INVALID_TRACK_ID) {
+        unfocusAllComponents();
+        nodeComponents_.clear();
         return;
     }
 
     const auto& elements = magda::TrackManager::getInstance().getChainElements(selectedTrackId_);
 
-    // Create a component for each chain element
-    for (size_t i = 0; i < elements.size(); ++i) {
-        const auto& element = elements[i];
+    // Reuse the component already standing for an element, keyed by its id, and
+    // build only what is new. This used to clear the whole vector and construct
+    // every node again, so a control that wrote a device property destroyed the
+    // component tree it was inside before its own callback returned: fifty-odd
+    // TrackManager setters announce `trackDevicesChanged`, and most of them have
+    // a control behind them. `ChainPanel::rebuildElementSlots()` has always done
+    // it this way (#2214).
+    //
+    // Element ids are unique across the project, so a component never survives
+    // into a track it does not belong to: switching tracks finds no match and
+    // builds afresh.
+    std::vector<std::unique_ptr<NodeComponent>> newNodes;
 
+    auto takeExisting = [this](auto predicate) -> std::unique_ptr<NodeComponent> {
+        for (size_t i = 0; i < nodeComponents_.size(); ++i) {
+            if (predicate(nodeComponents_[i].get())) {
+                auto found = std::move(nodeComponents_[i]);
+                nodeComponents_.erase(nodeComponents_.begin() + static_cast<long>(i));
+                return found;
+            }
+        }
+        return nullptr;
+    };
+
+    for (const auto& element : elements) {
         if (magda::isDevice(element)) {
-            // Create device slot component
             const auto& device = magda::getDevice(element);
+            const auto devicePath =
+                magda::ChainNodePath::topLevelDevice(selectedTrackId_, device.id);
+
+            if (auto existing = takeExisting([&device](NodeComponent* node) {
+                    auto* slot = dynamic_cast<DeviceSlotComponent*>(node);
+                    return slot != nullptr && slot->getDeviceId() == device.id;
+                })) {
+                static_cast<DeviceSlotComponent*>(existing.get())->updateFromDevice(device);
+                existing->setNodePath(devicePath);
+                newNodes.push_back(std::move(existing));
+                continue;
+            }
+
             auto slot = std::make_unique<DeviceSlotComponent>(device);
-            slot->setNodePath(magda::ChainNodePath::topLevelDevice(selectedTrackId_, device.id));
+            slot->setNodePath(devicePath);
 
             // Wire up device-specific callbacks
             slot->onDeviceLayoutChanged = [this]() {
@@ -2692,48 +2723,25 @@ void TrackChainContent::rebuildNodeComponents() {
                 repaint();
             };
 
-            // Wire up drag-to-reorder callbacks
-            slot->onDragStart = [this](NodeComponent* node, const juce::MouseEvent&) {
-                draggedNode_ = node;
-                dragOriginalIndex_ = findNodeIndex(node);
-                dragInsertIndex_ = dragOriginalIndex_;
-                // Capture ghost image and make original semi-transparent
-                dragGhostImage_ = node->createComponentSnapshot(node->getLocalBounds());
-                node->setAlpha(0.4f);
-                startTimerHz(10);  // Start timer to detect stale drag state
-                // Re-layout to add left padding for drop indicator
-                resized();
-            };
-
-            slot->onDragMove = [this](NodeComponent*, const juce::MouseEvent& e) {
-                auto pos = e.getEventRelativeTo(chainContainer_.get()).getPosition();
-                dragInsertIndex_ = calculateInsertIndex(pos.x);
-                dragMousePos_ = pos;
-                chainContainer_->repaint();
-            };
-
-            slot->onDragEnd = [this](NodeComponent* node, const juce::MouseEvent&) {
-                // Restore alpha and clear ghost
-                node->setAlpha(1.0f);
-                dragGhostImage_ = juce::Image();
-                stopTimer();
-
-                draggedNode_ = nullptr;
-                dragOriginalIndex_ = -1;
-                dragInsertIndex_ = -1;
-
-                resized();
-                chainContainer_->repaint();
-            };
-
             chainContainer_->addAndMakeVisible(*slot);
-            nodeComponents_.push_back(std::move(slot));
+            newNodes.push_back(std::move(slot));
 
         } else if (magda::isRack(element)) {
-            // Create rack component
             const auto& rack = magda::getRack(element);
+            const auto rackPath = magda::ChainNodePath::rack(selectedTrackId_, rack.id);
+
+            if (auto existing = takeExisting([&rack](NodeComponent* node) {
+                    auto* rackComp = dynamic_cast<RackComponent*>(node);
+                    return rackComp != nullptr && rackComp->getRackId() == rack.id;
+                })) {
+                static_cast<RackComponent*>(existing.get())->updateFromRack(rack);
+                existing->setNodePath(rackPath);
+                newNodes.push_back(std::move(existing));
+                continue;
+            }
+
             auto rackComp = std::make_unique<RackComponent>(selectedTrackId_, rack);
-            rackComp->setNodePath(magda::ChainNodePath::rack(selectedTrackId_, rack.id));
+            rackComp->setNodePath(rackPath);
 
             // Wire up callbacks
             rackComp->onSelected = [this]() { selectedDeviceId_ = magda::INVALID_DEVICE_ID; };
@@ -2755,42 +2763,61 @@ void TrackChainContent::rebuildNodeComponents() {
                 }
             };
 
-            // Wire up drag-to-reorder callbacks
-            rackComp->onDragStart = [this](NodeComponent* node, const juce::MouseEvent&) {
-                draggedNode_ = node;
-                dragOriginalIndex_ = findNodeIndex(node);
-                dragInsertIndex_ = dragOriginalIndex_;
-                // Capture ghost image and make original semi-transparent
-                dragGhostImage_ = node->createComponentSnapshot(node->getLocalBounds());
-                node->setAlpha(0.4f);
-                startTimerHz(10);  // Start timer to detect stale drag state
-                // Re-layout to add left padding for drop indicator
-                resized();
-            };
-
-            rackComp->onDragMove = [this](NodeComponent*, const juce::MouseEvent& e) {
-                auto pos = e.getEventRelativeTo(chainContainer_.get()).getPosition();
-                dragInsertIndex_ = calculateInsertIndex(pos.x);
-                dragMousePos_ = pos;
-                chainContainer_->repaint();
-            };
-
-            rackComp->onDragEnd = [this](NodeComponent* node, const juce::MouseEvent&) {
-                // Restore alpha and clear ghost
-                node->setAlpha(1.0f);
-                dragGhostImage_ = juce::Image();
-                stopTimer();
-
-                draggedNode_ = nullptr;
-                dragOriginalIndex_ = -1;
-                dragInsertIndex_ = -1;
-                resized();
-                chainContainer_->repaint();
-            };
-
             chainContainer_->addAndMakeVisible(*rackComp);
-            nodeComponents_.push_back(std::move(rackComp));
+            newNodes.push_back(std::move(rackComp));
         }
+    }
+
+    // Whatever is left in nodeComponents_ stands for an element that has gone,
+    // and is about to be destroyed, so drop the focus first.
+    if (!nodeComponents_.empty())
+        unfocusAllComponents();
+    nodeComponents_ = std::move(newNodes);
+
+    // Drag-to-reorder is the same on both kinds, so it is wired once here
+    // rather than twice above. A SafePointer because a drop calls back into a
+    // move, which rebuilds and can take this panel with it.
+    auto safeThis = juce::Component::SafePointer<TrackChainContent>(this);
+    for (auto& node : nodeComponents_) {
+        node->onDragStart = [safeThis](NodeComponent* dragged, const juce::MouseEvent&) {
+            if (safeThis == nullptr)
+                return;
+            safeThis->draggedNode_ = dragged;
+            safeThis->dragOriginalIndex_ = safeThis->findNodeIndex(dragged);
+            safeThis->dragInsertIndex_ = safeThis->dragOriginalIndex_;
+            // Capture ghost image and make original semi-transparent
+            safeThis->dragGhostImage_ = dragged->createComponentSnapshot(dragged->getLocalBounds());
+            dragged->setAlpha(0.4f);
+            safeThis->startTimerHz(10);  // Start timer to detect stale drag state
+            // Re-layout to add left padding for drop indicator
+            safeThis->resized();
+        };
+
+        node->onDragMove = [safeThis](NodeComponent*, const juce::MouseEvent& e) {
+            if (safeThis == nullptr)
+                return;
+            auto pos = e.getEventRelativeTo(safeThis->chainContainer_.get()).getPosition();
+            safeThis->dragInsertIndex_ = safeThis->calculateInsertIndex(pos.x);
+            safeThis->dragMousePos_ = pos;
+            safeThis->chainContainer_->repaint();
+        };
+
+        node->onDragEnd = [safeThis](NodeComponent* dragged, const juce::MouseEvent&) {
+            if (safeThis == nullptr)
+                return;
+
+            // Restore alpha and clear ghost
+            dragged->setAlpha(1.0f);
+            safeThis->dragGhostImage_ = juce::Image();
+            safeThis->stopTimer();
+
+            safeThis->draggedNode_ = nullptr;
+            safeThis->dragOriginalIndex_ = -1;
+            safeThis->dragInsertIndex_ = -1;
+
+            safeThis->resized();
+            safeThis->chainContainer_->repaint();
+        };
     }
 
     // Set frozen + chain-power state on all nodes. Chain power off greys the

--- a/magda/daw/ui/panels/content/TrackChainContent.cpp
+++ b/magda/daw/ui/panels/content/TrackChainContent.cpp
@@ -2029,7 +2029,11 @@ void TrackChainContent::togglePostFxAnalysisDevice(const juce::String& pluginId,
         device.pluginId = pluginId;
         device.deviceType = magda::DeviceType::Analysis;
         device.format = magda::PluginFormat::Internal;
-        tm.addDeviceToPostFx(selectedTrackId_, device);
+        // Both directions on the stack. Only the removal being undoable would
+        // mean Cmd+Z after turning a toggle on undid something else entirely.
+        magda::UndoManager::getInstance().executeCommand(
+            std::make_unique<magda::AddDeviceByPathCommand>(
+                magda::ChainNodePath::postFxSection(selectedTrackId_), device));
         // Reveal the panel so the analyzer you just added is visible.
         if (onPostFxPanelToggled)
             onPostFxPanelToggled(true);

--- a/magda/daw/ui/panels/content/TrackChainContent.cpp
+++ b/magda/daw/ui/panels/content/TrackChainContent.cpp
@@ -2016,8 +2016,12 @@ void TrackChainContent::togglePostFxAnalysisDevice(const juce::String& pluginId,
     auto& tm = magda::TrackManager::getInstance();
     const magda::DeviceId existing = tm.findPostFxDevice(selectedTrackId_, pluginId);
     if (existing != magda::INVALID_DEVICE_ID) {
-        tm.removeDeviceFromChainByPath(
-            magda::ChainNodePath::postFxDevice(selectedTrackId_, existing));
+        // Through the command, like the slot's X and the context menu: turning
+        // the header toggle off is the third way to delete an analyzer, and it
+        // was the one that still went straight to the model (#2232).
+        magda::UndoManager::getInstance().executeCommand(
+            std::make_unique<magda::RemoveDeviceByPathCommand>(
+                magda::ChainNodePath::postFxDevice(selectedTrackId_, existing)));
     } else {
         magda::DeviceInfo device;
         device.name = displayName;

--- a/tests/test_device_api.cpp
+++ b/tests/test_device_api.cpp
@@ -222,31 +222,6 @@ TEST_CASE("Undoing a removal restores the device under its original id",
     tracks.clearAllTracks();
 }
 
-TEST_CASE("The track-level remove command also preserves the device id",
-          "[device-api][mutation][undo]") {
-    // RemoveDeviceFromTrackCommand is what the UI runs when a device is deleted
-    // from a track, and it had the same id-reassigning undo.
-    auto& tracks = TrackManager::getInstance();
-    const auto trackId = freshTrack("Bass");
-
-    DeviceInfo device;
-    device.name = "Filter";
-    device.pluginId = "test_filter";
-    const auto deviceId = tracks.addDeviceToTrack(trackId, device);
-    REQUIRE(deviceId != INVALID_DEVICE_ID);
-    const auto path = tracks.findDevicePath(deviceId);
-
-    auto& undo = UndoManager::getInstance();
-    undo.executeCommand(std::make_unique<RemoveDeviceFromTrackCommand>(trackId, deviceId));
-    REQUIRE(tracks.getChainElements(trackId).empty());
-
-    undo.undo();
-    REQUIRE(tracks.getChainElements(trackId).size() == 1);
-    REQUIRE(tracks.findDevicePath(deviceId) == path);
-
-    tracks.clearAllTracks();
-}
-
 TEST_CASE("Undo restores a device to its original position", "[device-api][mutation][undo]") {
     auto& tracks = TrackManager::getInstance();
     const auto trackId = freshTrack("Bass");

--- a/tests/test_structural_matrix.cpp
+++ b/tests/test_structural_matrix.cpp
@@ -194,9 +194,10 @@ Disposition expectedOutcome(Operation operation, Subject subject, Container sour
             return Disposition::Applied;
 
         case Operation::Remove:
-            // A flat section is not a chain, so the element index the removal
-            // records has no answer there and it stops before mutating.
-            return isFlatSection(source) ? Disposition::Refused : Disposition::Applied;
+            // Every container, the two flat sections included: they hold bare
+            // devices rather than chain elements, and the removal now records
+            // and restores a position in that list too (#2232).
+            return Disposition::Applied;
 
         case Operation::Wrap:
             if (isFlatSection(source))
@@ -315,14 +316,6 @@ void requireEveryAxisCovered(const Ledger& ledger, const std::vector<Subject>& e
 
 std::vector<Subject> everySubject() {
     return {kSubjects.begin(), kSubjects.end()};
-}
-
-std::vector<Subject> everySubjectExcept(Subject omitted) {
-    std::vector<Subject> subjects;
-    for (auto subject : kSubjects)
-        if (subject != omitted)
-            subjects.push_back(subject);
-    return subjects;
 }
 
 // ============================================================================
@@ -927,18 +920,20 @@ TEST_CASE("Every removal across the container matrix is refused or reversible",
                 ledger.exclude(cell, reason);
                 continue;
             }
-            if (subject == Subject::Rack) {
-                ledger.exclude(cell, "no undoable command removes a rack: the chain view calls "
-                                     "removeRackFromChainByPath() directly");
-                continue;
-            }
-
             auto world = buildWorld(container);
             const auto subjectPath = placeSubject(subject, world.host, container);
+            // A rack is taken out by its own command: the model call the two
+            // share erases a whole subtree, and only one of the two knows how
+            // to put a subtree back (#2232).
+            auto command = subject == Subject::Rack
+                               ? std::unique_ptr<UndoableCommand>(
+                                     std::make_unique<RemoveRackByPathCommand>(subjectPath))
+                               : std::unique_ptr<UndoableCommand>(
+                                     std::make_unique<RemoveDeviceByPathCommand>(subjectPath));
             requireCell(
                 cell,
                 expectedOutcome(Operation::Remove, subject, container, container, TrackRole::Host),
-                std::make_unique<RemoveDeviceByPathCommand>(subjectPath));
+                std::move(command));
 
             ++ledger.ran;
             ledger.sourcesCovered.insert(container);
@@ -947,7 +942,7 @@ TEST_CASE("Every removal across the container matrix is refused or reversible",
         }
     }
 
-    requireEveryAxisCovered(ledger, everySubjectExcept(Subject::Rack));
+    requireEveryAxisCovered(ledger, everySubject());
     WARN(ledger.report().toStdString());
     resetState();
 }

--- a/tests/test_structural_undo_roundtrip.cpp
+++ b/tests/test_structural_undo_roundtrip.cpp
@@ -462,6 +462,68 @@ TEST_CASE("Undoing a post-fader device removal puts it back at its index",
         std::make_unique<RemoveDeviceByPathCommand>(ChainNodePath::postFxDevice(trackId, middle)));
 }
 
+TEST_CASE("Adding a post-fader device is reversible and replays the same device",
+          "[structural][undo][roundtrip]") {
+    // Adding to a flat section was not on the undo stack at all: neither chain
+    // add can reach one, so the header analyzer toggle, the post-fx panel drop
+    // and its plus menu all wrote straight to the model. Turning a toggle on
+    // and pressing Cmd+Z undid whatever came before it (#2232).
+    resetState();
+    auto& tm = TrackManager::getInstance();
+
+    const auto trackId = tm.createTrack("Track");
+    tm.addDeviceToPostFx(trackId, effect("Resident"));
+
+    requireUndoRoundTrip(std::make_unique<AddDeviceByPathCommand>(
+        ChainNodePath::postFxSection(trackId), effect("Analyzer")));
+}
+
+TEST_CASE("Adding a mixer-analysis device is reversible", "[structural][undo][roundtrip]") {
+    resetState();
+    auto& tm = TrackManager::getInstance();
+
+    const auto trackId = tm.createTrack("Track");
+
+    requireUndoRoundTrip(std::make_unique<AddDeviceByPathCommand>(
+        ChainNodePath::mixerAnalysisSection(trackId), effect("Scope")));
+}
+
+TEST_CASE("Redoing an add puts back the device it made, not another one",
+          "[structural][undo][roundtrip]") {
+    // Every add path stamps a fresh DeviceId. A redo that added again gave the
+    // device a different identity each time round the stack, orphaning every
+    // link named against the first one -- the defect #2228 fixed for paste and
+    // wrap, still standing on the add. The round trip catches it: the redone
+    // model has to serialize to the bytes the first run made, id included.
+    resetState();
+    auto& tm = TrackManager::getInstance();
+
+    const auto trackId = tm.createTrack("Track");
+    const auto rackId = tm.addRackToTrack(trackId, "Rack");
+    const auto rackPath = ChainNodePath::rack(trackId, rackId);
+    const auto chainId = tm.addChainToRack(rackPath);
+    tm.addDeviceToChainByPath(rackPath.withChain(chainId), effect("Resident"));
+
+    requireUndoRoundTrip(
+        std::make_unique<AddDeviceByPathCommand>(rackPath.withChain(chainId), effect("Added")));
+}
+
+TEST_CASE("Adding a device to the middle of a chain is redone at the same index",
+          "[structural][undo][roundtrip]") {
+    // An add that named no index appended, and a redo that re-derived it would
+    // append again -- right only because it happened to be last. This one is
+    // placed, so the index has to be recorded rather than recomputed.
+    resetState();
+    auto& tm = TrackManager::getInstance();
+
+    const auto trackId = tm.createTrack("Track");
+    tm.addDeviceToTrack(trackId, effect("First"));
+    tm.addDeviceToTrack(trackId, effect("Last"));
+
+    requireUndoRoundTrip(std::make_unique<AddDeviceByPathCommand>(
+        ChainNodePath::trackLevel(trackId), effect("Middle"), 1));
+}
+
 TEST_CASE("Removing a rack prunes a multi-node selection rather than clearing it",
           "[structural][selection]") {
     // `clearSelectionForDeletedChainNode()` had no MultiChainNode case at all,

--- a/tests/test_structural_undo_roundtrip.cpp
+++ b/tests/test_structural_undo_roundtrip.cpp
@@ -462,6 +462,68 @@ TEST_CASE("Undoing a post-fader device removal puts it back at its index",
         std::make_unique<RemoveDeviceByPathCommand>(ChainNodePath::postFxDevice(trackId, middle)));
 }
 
+TEST_CASE("Removing a rack drops a selection standing on a pad inside it",
+          "[structural][selection]") {
+    // A device is not always a leaf. A Drum Grid's pads are chains on the
+    // device (#2207), addressed off the track by the grid's own DeviceId --
+    // `PadRack(grid) > PadChain(pad)` -- so neither the grid's path nor its
+    // DeviceId matches anything under it, and the subtree walk stopped at the
+    // grid. A pad selected when the rack around it went kept pointing into the
+    // erased subtree (#2232).
+    resetState();
+    auto& tm = TrackManager::getInstance();
+    auto& selection = SelectionManager::getInstance();
+
+    const auto trackId = tm.createTrack("Track");
+    const auto rackId = tm.addRackToTrack(trackId, "Rack");
+    const auto rackPath = ChainNodePath::rack(trackId, rackId);
+    const auto chainId = tm.addChainToRack(rackPath);
+    const auto gridId = tm.addDeviceToChainByPath(rackPath.withChain(chainId), drumGrid());
+
+    const auto gridPath = rackPath.withChain(chainId).withDevice(gridId);
+    const auto padChainId = tm.ensurePad(gridPath, 0);
+    REQUIRE(padChainId != INVALID_CHAIN_ID);
+
+    const auto padPath = TrackManager::padChainPath(gridPath, padChainId);
+    selection.selectChainNode(padPath);
+    REQUIRE(selection.getSelectedChainNode() == padPath);
+
+    UndoManager::getInstance().executeCommand(std::make_unique<RemoveRackByPathCommand>(rackPath));
+
+    CHECK_FALSE(selection.getSelectedChainNode().isValid());
+}
+
+TEST_CASE("Removing a Drum Grid drops a selection standing on one of its pads",
+          "[structural][selection]") {
+    // The same leaf assumption on the direct route: deleting the grid itself
+    // cleared only the grid's own path.
+    resetState();
+    auto& tm = TrackManager::getInstance();
+    auto& selection = SelectionManager::getInstance();
+
+    const auto trackId = tm.createTrack("Track");
+    const auto gridId = tm.addDeviceToTrack(trackId, drumGrid());
+    const auto gridPath = ChainNodePath::topLevelDevice(trackId, gridId);
+
+    const auto padChainId = tm.ensurePad(gridPath, 0);
+    REQUIRE(padChainId != INVALID_CHAIN_ID);
+    const auto padDeviceId = tm.addDeviceToPad(gridPath, padChainId, effect("Pad FX"));
+    REQUIRE(padDeviceId != INVALID_DEVICE_ID);
+
+    // The device on the pad, not the pad itself: it is a step deeper again, and
+    // its DeviceId is not the grid's, so nothing about the grid's own path
+    // reaches it.
+    const auto padDevicePath =
+        TrackManager::padChainPath(gridPath, padChainId).withDevice(padDeviceId);
+    selection.selectChainNode(padDevicePath);
+    REQUIRE(selection.getSelectedChainNode() == padDevicePath);
+
+    UndoManager::getInstance().executeCommand(
+        std::make_unique<RemoveDeviceByPathCommand>(gridPath));
+
+    CHECK_FALSE(selection.getSelectedChainNode().isValid());
+}
+
 TEST_CASE("Removing a rack drops a selection standing inside it", "[structural][selection]") {
     // `clearSelectionForDeletedChainNode()` matches an exact path or a device
     // id, never an ancestor, so removing a container left a selection below it

--- a/tests/test_structural_undo_roundtrip.cpp
+++ b/tests/test_structural_undo_roundtrip.cpp
@@ -462,6 +462,62 @@ TEST_CASE("Undoing a post-fader device removal puts it back at its index",
         std::make_unique<RemoveDeviceByPathCommand>(ChainNodePath::postFxDevice(trackId, middle)));
 }
 
+TEST_CASE("Removing a rack prunes a multi-node selection rather than clearing it",
+          "[structural][selection]") {
+    // `clearSelectionForDeletedChainNode()` had no MultiChainNode case at all,
+    // so a Cmd-selected set holding one node inside a removed subtree kept that
+    // path and every multi-node operation ran against freed model. The members
+    // that did not go have to survive: dropping the whole set is a different
+    // and equally wrong answer (#2232).
+    resetState();
+    auto& tm = TrackManager::getInstance();
+    auto& selection = SelectionManager::getInstance();
+
+    const auto trackId = tm.createTrack("Track");
+    const auto keptId = tm.addDeviceToTrack(trackId, effect("Kept"));
+    const auto rackId = tm.addRackToTrack(trackId, "Doomed");
+    const auto rackPath = ChainNodePath::rack(trackId, rackId);
+    const auto chainId = tm.addChainToRack(rackPath);
+    const auto doomedId = tm.addDeviceToChainByPath(rackPath.withChain(chainId), effect("Doomed"));
+
+    const auto keptPath = ChainNodePath::topLevelDevice(trackId, keptId);
+    const auto doomedPath = rackPath.withChain(chainId).withDevice(doomedId);
+    selection.selectChainNodes({keptPath, doomedPath});
+    REQUIRE(selection.getSelectedChainNodes().size() == 2);
+
+    UndoManager::getInstance().executeCommand(std::make_unique<RemoveRackByPathCommand>(rackPath));
+
+    const auto remaining = selection.getSelectedChainNodes();
+    REQUIRE(remaining.size() == 1);
+    CHECK(remaining.front() == keptPath);
+    // One member left, so it is an ordinary single selection again, and the
+    // primary has moved off the node that went.
+    CHECK(selection.getSelectedChainNode() == keptPath);
+}
+
+TEST_CASE("Removing a rack clears a multi-node selection that was entirely inside it",
+          "[structural][selection]") {
+    resetState();
+    auto& tm = TrackManager::getInstance();
+    auto& selection = SelectionManager::getInstance();
+
+    const auto trackId = tm.createTrack("Track");
+    const auto rackId = tm.addRackToTrack(trackId, "Doomed");
+    const auto rackPath = ChainNodePath::rack(trackId, rackId);
+    const auto chainId = tm.addChainToRack(rackPath);
+    const auto chainPath = rackPath.withChain(chainId);
+    const auto firstId = tm.addDeviceToChainByPath(chainPath, effect("First"));
+    const auto secondId = tm.addDeviceToChainByPath(chainPath, effect("Second"));
+
+    selection.selectChainNodes({chainPath.withDevice(firstId), chainPath.withDevice(secondId)});
+    REQUIRE(selection.getSelectedChainNodes().size() == 2);
+
+    UndoManager::getInstance().executeCommand(std::make_unique<RemoveRackByPathCommand>(rackPath));
+
+    CHECK(selection.getSelectedChainNodes().empty());
+    CHECK_FALSE(selection.getSelectedChainNode().isValid());
+}
+
 TEST_CASE("Removing a rack drops a selection standing on a pad inside it",
           "[structural][selection]") {
     // A device is not always a leaf. A Drum Grid's pads are chains on the

--- a/tests/test_structural_undo_roundtrip.cpp
+++ b/tests/test_structural_undo_roundtrip.cpp
@@ -395,3 +395,93 @@ TEST_CASE("Undoing a track deletion puts back the routing it swept up",
     UndoManager::getInstance().clearHistory();
     requireUndoRoundTrip(std::make_unique<DeleteTrackCommand>(auxId));
 }
+
+TEST_CASE("Undoing a rack removal brings back everything that was inside it",
+          "[structural][undo][roundtrip]") {
+    // Nothing undid a rack removal at all: the chain view called
+    // removeRackFromChainByPath() straight off the model, so deleting a rack
+    // took its chains, its devices and their links with it for good. It was the
+    // one operation the transition matrix had to exclude by name (#2232).
+    resetState();
+    auto& tm = TrackManager::getInstance();
+
+    const auto trackId = tm.createTrack("Track");
+    tm.addDeviceToTrack(trackId, effect("Before"));
+    const auto rackId = tm.addRackToTrack(trackId, "Doomed");
+    tm.addDeviceToTrack(trackId, effect("After"));
+
+    const auto rackPath = ChainNodePath::rack(trackId, rackId);
+    const auto firstChain = tm.addChainToRack(rackPath);
+    const auto secondChain = tm.addChainToRack(rackPath);
+    tm.addDeviceToChainByPath(rackPath.withChain(firstChain), effect("In Chain One"));
+    tm.addDeviceToChainByPath(rackPath.withChain(secondChain), effect("In Chain Two"));
+
+    // A rack inside the rack, so the restore has to carry a subtree rather than
+    // a flat list of devices.
+    const auto nestedId = tm.addRackToChainByPath(rackPath.withChain(firstChain), "Nested");
+    const auto nestedPath = rackPath.withChain(firstChain).withRack(nestedId);
+    tm.addDeviceToChainByPath(nestedPath.withChain(tm.addChainToRack(nestedPath)), effect("Deep"));
+
+    requireUndoRoundTrip(std::make_unique<RemoveRackByPathCommand>(rackPath));
+}
+
+TEST_CASE("Undoing a chain removal puts the chain back among its siblings",
+          "[structural][undo][roundtrip]") {
+    // Same gap one level down, and with the same trap the track restores had:
+    // an append puts a middle chain back last, which reorders the rack.
+    resetState();
+    auto& tm = TrackManager::getInstance();
+
+    const auto trackId = tm.createTrack("Track");
+    const auto rackId = tm.addRackToTrack(trackId, "Rack");
+    const auto rackPath = ChainNodePath::rack(trackId, rackId);
+
+    tm.addDeviceToChainByPath(rackPath.withChain(tm.addChainToRack(rackPath)), effect("First"));
+    const auto middle = tm.addChainToRack(rackPath);
+    tm.addDeviceToChainByPath(rackPath.withChain(middle), effect("Middle"));
+    tm.addDeviceToChainByPath(rackPath.withChain(tm.addChainToRack(rackPath)), effect("Last"));
+
+    requireUndoRoundTrip(std::make_unique<RemoveChainByPathCommand>(rackPath.withChain(middle)));
+}
+
+TEST_CASE("Undoing a post-fader device removal puts it back at its index",
+          "[structural][undo][roundtrip]") {
+    // The flat sections hold bare devices rather than chain elements, so the
+    // index lookup the removal records had no answer for them and the command
+    // stopped before mutating: deleting a post-fader device from the UI worked
+    // only because the UI was not going through the command (#2232).
+    resetState();
+    auto& tm = TrackManager::getInstance();
+
+    const auto trackId = tm.createTrack("Track");
+    tm.addDeviceToPostFx(trackId, effect("First"));
+    const auto middle = tm.addDeviceToPostFx(trackId, effect("Middle"));
+    tm.addDeviceToPostFx(trackId, effect("Last"));
+
+    requireUndoRoundTrip(
+        std::make_unique<RemoveDeviceByPathCommand>(ChainNodePath::postFxDevice(trackId, middle)));
+}
+
+TEST_CASE("Removing a rack drops a selection standing inside it", "[structural][selection]") {
+    // `clearSelectionForDeletedChainNode()` matches an exact path or a device
+    // id, never an ancestor, so removing a container left a selection below it
+    // pointing at model that had just been freed. The pad removals walked the
+    // subtree for this reason; the rack and chain removals did not (#2232).
+    resetState();
+    auto& tm = TrackManager::getInstance();
+    auto& selection = SelectionManager::getInstance();
+
+    const auto trackId = tm.createTrack("Track");
+    const auto rackId = tm.addRackToTrack(trackId, "Rack");
+    const auto rackPath = ChainNodePath::rack(trackId, rackId);
+    const auto chainId = tm.addChainToRack(rackPath);
+    const auto deviceId = tm.addDeviceToChainByPath(rackPath.withChain(chainId), effect("Buried"));
+
+    const auto devicePath = rackPath.withChain(chainId).withDevice(deviceId);
+    selection.selectChainNode(devicePath);
+    REQUIRE(selection.getSelectedChainNode() == devicePath);
+
+    UndoManager::getInstance().executeCommand(std::make_unique<RemoveRackByPathCommand>(rackPath));
+
+    CHECK_FALSE(selection.getSelectedChainNode().isValid());
+}


### PR DESCRIPTION
Closes #2232 and #2214.

#2230 left one thing standing: no undoable command removed a rack, so the removal matrix excluded that column by name. Writing the issue for it turned up that the rack was one of four. The chain view deleted straight off `TrackManager`, with no command in between, at every depth it can delete.

| deleted | went to |
| --- | --- |
| a rack at the top level | `removeRackFromTrack()` |
| a rack nested in a chain | `removeRackFromChainByPath()` |
| a chain in a rack | `removeChainByPath()` |
| a device inside a rack chain | `removeDeviceFromChainByPath()` |

The last one is the sharpest, because half of it was already right: `DeviceSlotComponent` routed a top-level device through a command and fell through to a direct call for a nested one, so whether Cmd+Z brought a device back depended on how deep it stood.

## The removals

`RemoveRackByPathCommand` and `RemoveChainByPathCommand` save the subtree and restore it under the ids it had. Fresh ids would orphan every automation lane, macro link and alias naming what was inside, which is the reason the device removal already preserved them. Both capture the live plugin state of every device beneath them before it goes, so an undo restores the subtree as it sounded rather than as it was assembled; a Drum Grid's pads ride along in its own state, so the grid device is the whole capture for them.

The nested-device delete now goes through the `RemoveDeviceByPathCommand` that was already there. All three deletes are posted rather than run inline: the removal notifies synchronously and the rebuild that follows destroys the button whose click is still on the stack.

## Two things that went with them

**Selection was left standing on freed model.** `clearSelectionForDeletedChainNode()` matches an exact path or a device id, never an ancestor, so removing a container never cleared a selection below it. The pad removals walked the subtree for exactly this reason (#2211); the walk is now shared by the pad, rack and chain removals rather than living in the pads file.

**The two flat sections could not be restored at all.** `getChainElementIndex()` had no answer for a post-fader or mixer-analysis path, so `RemoveDeviceByPathCommand` stopped before mutating -- which is why the matrix recorded every flat-section removal as refused. Both sections now answer it, with an id-preserving insert to put a device back where it stood. Deleting a post-fader device works today only because the UI is not going through the command.

Also removes `removeRackFromChain()`, a triple-form API with no callers.

## The component the edit was made from (#2214)

`TrackChainContent::rebuildNodeComponents()` cleared a vector of owning pointers and built every node again. `TrackManager` notifies synchronously, so a control that wrote a device property tore down the component tree it was inside before its own callback returned: `ChainRowComponent::onMuteClicked()` kept looping over its edit targets after the first write had freed `this`, and `RackComponent`'s bypass returned into the button plumbing of a freed node. Fifty-odd `TrackManager` setters announce `trackDevicesChanged`, and most of the property ones have a control behind them.

The notification cannot be dropped, because `AudioBridge` runs `syncTrackPlugins` on it. So the rebuild reuses the component standing for each element, keyed by its id, and builds only what is new, the way `ChainPanel::rebuildElementSlots()` and `RackComponent::rebuildChainRows()` already did. Element ids are unique across the project, so switching tracks finds no match and builds afresh rather than carrying a component into a track it does not belong to.

Drag-to-reorder was wired twice, identically, once per element kind. It is wired once now over the finished list, through a SafePointer rather than a raw `this`: a drop calls back into a move, which rebuilds and can take the panel with it.

## Testing

The removal matrix loses its `Subject::Rack` exclusion and flips the flat-section expectation from refused to applied: 23 cells run where 19 did, and no removal is excluded now for want of a command. Four named cases in `test_structural_undo_roundtrip.cpp` carry the specific defects -- a rack with nested racks under it, a chain restored among its siblings, a post-fader device restored at its index, and a selection buried inside a removed rack.

Full Catch2 suite green (627,478 assertions, 3,083 cases) and `magda_juce_tests` green.

## Not covered by a test

The #2214 change has none. I wrote a component-identity test -- hold the node pointers across a property write, require them to still be there -- and pulled it: `TrackChainContent` and the whole chain UI are scoped to `magda_daw_app` rather than `libmagda_daw` on purpose ("the magda_daw library only picks up the few UI components that tests link against"), so it does not link, and making it link means dragging every custom device UI into the juce test binary -- on the job #2231 is about. Its verification is the app.

The pad-edit posting #2213 added stays for now. #2214 says it can come back out once this lands, but confirming that needs the GUI, and a one-turn deferral of an undoable edit costs nothing.

https://claude.ai/code/session_0187yiSdSJPmDFZafrSfbSop
