### PR TITLE
One descent through the chain tree, and the four defects the sweep found (#2204)

### DIFF
--- a/magda/agents/dsl_interpreter.cpp
+++ b/magda/agents/dsl_interpreter.cpp
@@ -17,6 +17,7 @@
 #include "../daw/api/track_api.hpp"
 #include "../daw/api/undo_api.hpp"
 #include "../daw/audio/AudioThumbnailManager.hpp"
+#include "../daw/core/ChainWalk.hpp"
 #include "../daw/core/ClipManager.hpp"
 #include "../daw/core/ClipPropertyCommands.hpp"
 #include "../daw/core/DeviceInfo.hpp"
@@ -1965,34 +1966,15 @@ struct DeviceAtPath {
     ChainNodePath path;
 };
 
-void collectRackDevices(const RackInfo& rack, const ChainNodePath& rackPath,
-                        std::vector<DeviceAtPath>& devices) {
-    for (const auto& chain : rack.chains) {
-        const auto chainPath = rackPath.withChain(chain.id);
-        for (const auto& element : chain.elements) {
-            if (isDevice(element)) {
-                const auto& device = getDevice(element);
-                devices.push_back({&device, chainPath.withDevice(device.id)});
-            } else {
-                const auto& nestedRack = getRack(element);
-                const auto nestedPath = chainPath.withRack(nestedRack.id);
-                collectRackDevices(nestedRack, nestedPath, devices);
-            }
-        }
-    }
-}
-
 std::vector<DeviceAtPath> collectTrackDevices(const TrackInfo& track) {
     std::vector<DeviceAtPath> devices;
-    for (const auto& element : track.chain.fxChainElements) {
-        if (isDevice(element)) {
-            const auto& device = getDevice(element);
-            devices.push_back({&device, ChainNodePath::topLevelDevice(track.id, device.id)});
-        } else {
-            const auto& rack = getRack(element);
-            collectRackDevices(rack, ChainNodePath::rack(track.id, rack.id), devices);
-        }
-    }
+    // Pads skipped: the DSL addresses a track's own devices, and a pad device
+    // is reached through its grid rather than named beside it (#2204).
+    chain_walk::forEachDevice(track.chain.fxChainElements, ChainNodePath::trackLevel(track.id),
+                              chain_walk::Pads::Skip,
+                              [&devices](const DeviceInfo& device, const ChainNodePath& path) {
+                                  devices.push_back({&device, path});
+                              });
     for (const auto& element : track.chain.postFxChainElements) {
         devices.push_back(
             {&element.device, ChainNodePath::postFxDevice(track.id, element.device.id)});
@@ -2003,6 +1985,7 @@ std::vector<DeviceAtPath> collectTrackDevices(const TrackInfo& track) {
     }
     return devices;
 }
+
 }  // namespace
 
 void Interpreter::setContextEnabled(bool enabled) {

--- a/magda/daw/core/ChainNodePath.hpp
+++ b/magda/daw/core/ChainNodePath.hpp
@@ -314,7 +314,15 @@ struct ChainNodePath {
     // back as the track, and undo left it standing (#2229).
     ChainNodePath extendedWith(ChainPathStep step) const {
         ChainNodePath p = *this;
+        // Both of the step-free representations are dropped, not just the
+        // track-level flag. A path carrying a step and one of these says where
+        // it points twice, `getType()` picks between them by precedence, and
+        // the accessors then disagree with each other -- which is exactly the
+        // shape `parseChainNodePath()` refuses to load as corrupt. #2230
+        // cleared `isTrackLevel` here and left `topLevelDeviceId`, so the
+        // invariant held for one of the two (#2204).
         p.isTrackLevel = false;
+        p.topLevelDeviceId = INVALID_DEVICE_ID;
         p.steps.push_back(step);
         return p;
     }

--- a/magda/daw/core/ChainWalk.hpp
+++ b/magda/daw/core/ChainWalk.hpp
@@ -120,11 +120,32 @@ bool forEachNode(Elements& elements, const ChainNodePath& parentPath, Pads pads,
             }
 
             if (pads == Pads::Enter && device.pads) {
-                for (auto& pad : device.pads->chains) {
-                    const auto padPath =
-                        ChainNodePath::padChain(parentPath.trackId, device.id, pad.id);
-                    if (!forEachNode(pad.elements, padPath, pads, onDevice, onRack))
-                        return false;
+                // The pad rack is a rack, and a walk that only descended into
+                // its chains would hand a rack visitor every rack but this one
+                // -- the silent kind of miss this file exists to stop. It
+                // carries mute, solo and a fader like any other, which is what
+                // `PlanValues` looks it up for.
+                //
+                // Addressed by the owning device's path, because a bare
+                // `PadRack` step is not a valid address on its own:
+                // `parseChainNodePath()` refuses one, and every pad API takes
+                // the grid's path and builds the rest from it.
+                if (onRack(*device.pads.get(), devicePath) == Descend::Into) {
+                    struct PadExit {
+                        OnRackExit& run;
+                        std::remove_reference_t<decltype(*device.pads.get())>& rack;
+                        const ChainNodePath& path;
+                        ~PadExit() {
+                            run(rack, path);
+                        }
+                    } padExit{onRackExit, *device.pads.get(), devicePath};
+
+                    for (auto& pad : device.pads->chains) {
+                        const auto padPath =
+                            ChainNodePath::padChain(parentPath.trackId, device.id, pad.id);
+                        if (!forEachNode(pad.elements, padPath, pads, onDevice, onRack, onRackExit))
+                            return false;
+                    }
                 }
             }
             continue;
@@ -213,6 +234,43 @@ void forEachChain(Elements& elements, const ChainNodePath& parentPath, Pads pads
             forEachChain(chain.elements, chainPath, pads, visit);
         }
     }
+}
+
+/// The first device @p match accepts, or null.
+///
+/// A search rather than a sweep, so it stops where it finds. Several of the
+/// walks this replaces were searches written as their own recursion.
+template <typename Elements, typename Match>
+auto* findDevice(Elements& elements, const ChainNodePath& parentPath, Pads pads, Match&& match) {
+    using Device = std::remove_reference_t<decltype(getDevice(*elements.begin()))>;
+    Device* found = nullptr;
+    forEachDevice(elements, parentPath, pads,
+                  [&found, &match](Device& device, const ChainNodePath& path) {
+                      if (!match(device, path))
+                          return true;
+                      found = &device;
+                      return false;
+                  });
+    return found;
+}
+
+/// The first rack @p match accepts, or null. Pad racks included when asked for,
+/// addressed by their owning device's path.
+template <typename Elements, typename Match>
+auto* findRack(Elements& elements, const ChainNodePath& parentPath, Pads pads, Match&& match) {
+    using Rack = std::remove_reference_t<decltype(getRack(*elements.begin()))>;
+    Rack* found = nullptr;
+    forEachNode(
+        elements, parentPath, pads,
+        [&found](auto&, const ChainNodePath&) { return found == nullptr; },
+        [&found, &match](Rack& rack, const ChainNodePath& path) {
+            if (found != nullptr)
+                return Descend::Skip;
+            if (match(rack, path))
+                found = &rack;
+            return found != nullptr ? Descend::Skip : Descend::Into;
+        });
+    return found;
 }
 
 }  // namespace magda::chain_walk

--- a/magda/daw/core/ChainWalk.hpp
+++ b/magda/daw/core/ChainWalk.hpp
@@ -138,13 +138,19 @@ bool forEachNode(Elements& elements, const ChainNodePath& parentPath, Pads pads,
                 // `PadRack` step is not a valid address on its own:
                 // `parseChainNodePath()` refuses one, and every pad API takes
                 // the grid's path and builds the rest from it.
+                // The alias is hoisted and the member is not called `rack`:
+                // naming a member after an enclosing variable and typing it
+                // `decltype(that variable)` changes the meaning of the name
+                // inside the class, which GCC rejects where clang does not.
+                using PadRackRef = std::remove_reference_t<decltype(*device.pads.get())>;
+
                 if (onRack(*device.pads.get(), devicePath) == Descend::Into) {
                     struct PadExit {
                         OnRackExit& run;
-                        std::remove_reference_t<decltype(*device.pads.get())>& rack;
+                        PadRackRef& target;
                         const ChainNodePath& path;
                         ~PadExit() {
-                            run(rack, path);
+                            run(target, path);
                         }
                     } padExit{onRackExit, *device.pads.get(), devicePath};
 
@@ -167,12 +173,13 @@ bool forEachNode(Elements& elements, const ChainNodePath& parentPath, Pads pads,
         if (onRack(rack, rackPath) == Descend::Skip)
             continue;
 
+        using RackRef = std::remove_reference_t<decltype(rack)>;
         struct Exit {
             OnRackExit& run;
-            decltype(rack)& rack;
+            RackRef& target;
             const ChainNodePath& path;
             ~Exit() {
-                run(rack, path);
+                run(target, path);
             }
         } exit{onRackExit, rack, rackPath};
 

--- a/magda/daw/core/ChainWalk.hpp
+++ b/magda/daw/core/ChainWalk.hpp
@@ -52,8 +52,16 @@ enum class Pads { Skip, Enter };
 /// `topLevelDeviceId` rather than in a step, and `withDevice()` would build the
 /// other spelling.
 inline ChainNodePath deviceIn(const ChainNodePath& parentPath, DeviceId deviceId) {
-    return parentPath.isTrackLevel ? ChainNodePath::topLevelDevice(parentPath.trackId, deviceId)
-                                   : parentPath.withDevice(deviceId);
+    // On the absence of steps rather than on `isTrackLevel`. The two agree for
+    // a path built by `trackLevel()`, and only one of them survives a round
+    // trip: `parentChain()` returns the track's own list with no steps and the
+    // flag unset, so keying on the flag would spell a device in it the other
+    // way and `deviceIn(path.parentChain(), id) == path` would not hold.
+    //
+    // A stepless chain path is the track's own FX list and nothing else: the
+    // flat sections carry a Segment step and a pad chain carries two.
+    return parentPath.steps.empty() ? ChainNodePath::topLevelDevice(parentPath.trackId, deviceId)
+                                    : parentPath.withDevice(deviceId);
 }
 
 /// The address of a rack directly inside @p parentPath.

--- a/magda/daw/core/ChainWalk.hpp
+++ b/magda/daw/core/ChainWalk.hpp
@@ -1,0 +1,218 @@
+#pragma once
+
+#include <type_traits>
+#include <vector>
+
+#include "ChainNodePath.hpp"
+#include "RackInfo.hpp"
+
+/**
+ * @file
+ * @brief The one descent through a track's chain tree (#2204).
+ *
+ * "The devices in this chain" was implemented separately in a dozen places
+ * under a dozen names, so adding a container to the model meant finding each
+ * one by hand, with no compiler error and no test that caught a miss. Every
+ * finding on #2200 was a walk that had not been updated, and each was a silent
+ * wrong render rather than a failure.
+ *
+ * Two things come with the descent, and they are the reason it is worth
+ * sharing rather than just repeating:
+ *
+ * **The path.** A top-level device is addressed by `topLevelDevice()`, which
+ * puts the id in its own field rather than in a step, so a walk that reaches
+ * for `withDevice()` at the top level builds a path that names the same device
+ * and does not compare equal to the one everything else stored. Six sites
+ * carried the `isTrackLevel` ternary for this by hand.
+ *
+ * **The pads.** A pad-per-chain device owns chains of its own (#2207), so a
+ * device is not always a leaf. Whether to descend into them is a real question
+ * with different right answers -- a plan expands them, gain staging does not --
+ * so it is asked explicitly rather than defaulted, and the answer is visible at
+ * the call site.
+ *
+ * Not everything should be here. `PlanCompiler::emitElements()` and
+ * `ParamTableCompiler::walkElements()` thread state through the descent -- a
+ * signal, a nesting stack -- and are compilations rather than traversals. They
+ * opt out, and say so where they do.
+ */
+
+namespace magda::chain_walk {
+
+/// Whether a device's own pad chains are part of the walk.
+///
+/// `Skip` is right whenever the thing being collected is something a pad device
+/// cannot own or cannot answer for; `Enter` whenever a pad device counts as one
+/// of the user's devices. Neither is a safe default, hence no default.
+enum class Pads { Skip, Enter };
+
+/// The address of a device directly inside @p parentPath.
+///
+/// The whole reason this is a function: at the top level a device's id lives in
+/// `topLevelDeviceId` rather than in a step, and `withDevice()` would build the
+/// other spelling.
+inline ChainNodePath deviceIn(const ChainNodePath& parentPath, DeviceId deviceId) {
+    return parentPath.isTrackLevel ? ChainNodePath::topLevelDevice(parentPath.trackId, deviceId)
+                                   : parentPath.withDevice(deviceId);
+}
+
+/// The address of a rack directly inside @p parentPath.
+///
+/// `withRack()` already answers this correctly at every depth, because
+/// extending clears the track-level flag (#2230). Here for symmetry with
+/// `deviceIn()`, so a caller never has to know that only one of the two needed
+/// the special case.
+inline ChainNodePath rackIn(const ChainNodePath& parentPath, RackId rackId) {
+    return parentPath.withRack(rackId);
+}
+
+/// Whether a rack's contents are part of the walk.
+///
+/// Returned by a rack visitor to prune: the parameter table stops at a rack
+/// already open above it, because a second instance claims every address the
+/// first one has.
+enum class Descend { Into, Skip };
+
+/// The id a device's macros, modifiers and links are addressed under.
+///
+/// The innermost rack it stands in, or the Drum Grid whose pad holds it -- a
+/// stored link to a pad device names the grid, not the synthetic pad rack. The
+/// plan, the parameter table and the runtime store each derived this from their
+/// own walk; deriving it once is what makes a disagreement between them
+/// impossible rather than untested (#2204).
+inline RackId owningRackId(const ChainNodePath& path) {
+    for (auto it = path.steps.rbegin(); it != path.steps.rend(); ++it)
+        if (it->type == ChainStepType::Rack || it->type == ChainStepType::PadRack)
+            return it->id;
+    return INVALID_RACK_ID;
+}
+
+/// The one descent. Devices and racks in a single pre-order pass, each with its
+/// address, depth-first in element order.
+///
+/// @p onDevice is called with `(device, devicePath)`; returning `bool` prunes
+/// the whole walk on `false`, and a `void` visitor always continues.
+/// @p onRack is called with `(rack, rackPath)` before the rack's chains and
+/// returns `Descend`, so a visitor can skip a subtree without stopping.
+/// @p onRackExit is called with the same arguments once the rack's chains are
+/// done, for a visitor keeping a stack of what is open around it.
+///
+/// The exit is run from a destructor rather than after the loop, so a walk that
+/// prunes on the way out still unwinds: `RackNesting` refuses a rack that is
+/// already open, and one left open by an early return would refuse every later
+/// sibling that reuses the id.
+///
+/// A device's pads come after the device and before whatever stands next to it,
+/// the way a rack's chains do.
+template <typename Elements, typename OnDevice, typename OnRack, typename OnRackExit>
+bool forEachNode(Elements& elements, const ChainNodePath& parentPath, Pads pads,
+                 OnDevice&& onDevice, OnRack&& onRack, OnRackExit&& onRackExit) {
+    for (auto& element : elements) {
+        if (isDevice(element)) {
+            auto& device = getDevice(element);
+            const auto devicePath = deviceIn(parentPath, device.id);
+
+            if constexpr (std::is_same_v<decltype(onDevice(device, devicePath)), bool>) {
+                if (!onDevice(device, devicePath))
+                    return false;
+            } else {
+                onDevice(device, devicePath);
+            }
+
+            if (pads == Pads::Enter && device.pads) {
+                for (auto& pad : device.pads->chains) {
+                    const auto padPath =
+                        ChainNodePath::padChain(parentPath.trackId, device.id, pad.id);
+                    if (!forEachNode(pad.elements, padPath, pads, onDevice, onRack))
+                        return false;
+                }
+            }
+            continue;
+        }
+
+        if (!isRack(element))
+            continue;
+
+        auto& rack = getRack(element);
+        const auto rackPath = rackIn(parentPath, rack.id);
+        if (onRack(rack, rackPath) == Descend::Skip)
+            continue;
+
+        struct Exit {
+            OnRackExit& run;
+            decltype(rack)& rack;
+            const ChainNodePath& path;
+            ~Exit() {
+                run(rack, path);
+            }
+        } exit{onRackExit, rack, rackPath};
+
+        for (auto& chain : rack.chains)
+            if (!forEachNode(chain.elements, rackPath.withChain(chain.id), pads, onDevice, onRack,
+                             onRackExit))
+                return false;
+    }
+
+    return true;
+}
+
+/// The three-argument form, for a walk with nothing to unwind.
+template <typename Elements, typename OnDevice, typename OnRack>
+bool forEachNode(Elements& elements, const ChainNodePath& parentPath, Pads pads,
+                 OnDevice&& onDevice, OnRack&& onRack) {
+    return forEachNode(elements, parentPath, pads, onDevice, onRack,
+                       [](auto&, const ChainNodePath&) {});
+}
+
+/// Every device, with its address. The common face of the walk.
+template <typename Elements, typename Visit>
+bool forEachDevice(Elements& elements, const ChainNodePath& parentPath, Pads pads, Visit&& visit) {
+    return forEachNode(elements, parentPath, pads, visit,
+                       [](auto&, const ChainNodePath&) { return Descend::Into; });
+}
+
+/// Every rack, outermost first, with its address.
+template <typename Elements, typename Visit>
+void forEachRack(Elements& elements, const ChainNodePath& parentPath, Pads pads, Visit&& visit) {
+    forEachNode(
+        elements, parentPath, pads, [](auto&, const ChainNodePath&) {},
+        [&visit](auto& rack, const ChainNodePath& rackPath) {
+            visit(rack, rackPath);
+            return Descend::Into;
+        });
+}
+
+/// Every chain with its address: a rack's chains, and a pad-per-chain device's
+/// pads when asked for.
+template <typename Elements, typename Visit>
+void forEachChain(Elements& elements, const ChainNodePath& parentPath, Pads pads, Visit&& visit) {
+    for (auto& element : elements) {
+        if (isDevice(element)) {
+            if (pads == Pads::Enter) {
+                auto& device = getDevice(element);
+                if (device.pads) {
+                    for (auto& pad : device.pads->chains) {
+                        const auto padPath =
+                            ChainNodePath::padChain(parentPath.trackId, device.id, pad.id);
+                        visit(pad, padPath);
+                        forEachChain(pad.elements, padPath, pads, visit);
+                    }
+                }
+            }
+            continue;
+        }
+
+        if (!isRack(element))
+            continue;
+
+        auto& rack = getRack(element);
+        const auto rackPath = rackIn(parentPath, rack.id);
+        for (auto& chain : rack.chains) {
+            const auto chainPath = rackPath.withChain(chain.id);
+            visit(chain, chainPath);
+            forEachChain(chain.elements, chainPath, pads, visit);
+        }
+    }
+}
+
+}  // namespace magda::chain_walk

--- a/magda/daw/core/DeviceParamMigrations.cpp
+++ b/magda/daw/core/DeviceParamMigrations.cpp
@@ -7,6 +7,7 @@
 #include <set>
 
 #include "AutomationInfo.hpp"
+#include "ChainWalk.hpp"
 #include "TrackInfo.hpp"
 
 namespace magda::device_param_migrations {
@@ -139,40 +140,20 @@ using MigrationsById = std::map<DeviceId, const ParamIndexMigration*>;
 /// A device and the path saved links address it by.
 using DeviceAtPath = std::pair<ChainNodePath, DeviceInfo*>;
 
-void collectElements(std::vector<ChainElement>& elements, const ChainNodePath& parentPath,
-                     TrackId trackId, std::vector<DeviceAtPath>& out);
-
-void collectRack(RackInfo& rack, const ChainNodePath& rackPath, TrackId trackId,
-                 std::vector<DeviceAtPath>& out) {
-    for (auto& chain : rack.chains)
-        collectElements(chain.elements, rackPath.withChain(chain.id), trackId, out);
-}
-
-void collectElements(std::vector<ChainElement>& elements, const ChainNodePath& parentPath,
-                     TrackId trackId, std::vector<DeviceAtPath>& out) {
-    for (auto& element : elements) {
-        if (isDevice(element)) {
-            auto& device = getDevice(element);
-            // A top-level device on a track keeps the legacy flat path shape,
-            // which is what the control graph stored for it.
-            out.emplace_back(parentPath.isTrackLevel
-                                 ? ChainNodePath::topLevelDevice(trackId, device.id)
-                                 : parentPath.withDevice(device.id),
-                             &device);
-        } else if (isRack(element)) {
-            auto& rack = getRack(element);
-            const auto rackPath = parentPath.isTrackLevel ? ChainNodePath::rack(trackId, rack.id)
-                                                          : parentPath.withRack(rack.id);
-            collectRack(rack, rackPath, trackId, out);
-        }
-    }
-}
-
 /// Every device on a track, each with the path its links address it by.
 std::vector<DeviceAtPath> devicesInTrack(TrackInfo& track) {
     std::vector<DeviceAtPath> devices;
-    collectElements(track.chain.fxChainElements, ChainNodePath::trackLevel(track.id), track.id,
-                    devices);
+    // Pads skipped: these migrations rewrite parameters saved against a
+    // DeviceInfo in the chain model, and the Drum Grid covers its own retired
+    // nested plugins through adoptRetiredNestedPluginTree.
+    //
+    // The walk spells a top-level device the flat way the control graph stored
+    // it, which this had to remember for itself (#2204).
+    chain_walk::forEachDevice(track.chain.fxChainElements, ChainNodePath::trackLevel(track.id),
+                              chain_walk::Pads::Skip,
+                              [&devices](DeviceInfo& device, const ChainNodePath& path) {
+                                  devices.emplace_back(path, &device);
+                              });
     for (auto& element : track.chain.postFxChainElements)
         devices.emplace_back(ChainNodePath::postFxDevice(track.id, element.device.id),
                              &element.device);

--- a/magda/daw/core/GainStagingManager.cpp
+++ b/magda/daw/core/GainStagingManager.cpp
@@ -9,6 +9,7 @@
 #include "../audio/AudioBridge.hpp"
 #include "../audio/DeviceMeteringManager.hpp"
 #include "../engine/AudioEngine.hpp"
+#include "ChainWalk.hpp"
 #include "DeviceInfo.hpp"
 #include "RackInfo.hpp"
 #include "TrackInfo.hpp"
@@ -21,18 +22,6 @@ namespace {
 
 float linearToDb(float linear) {
     return juce::Decibels::gainToDecibels(linear, kGainStageSilenceDb);
-}
-
-void collectChainDeviceIds(const std::vector<ChainElement>& elements, std::vector<DeviceId>& out) {
-    for (const auto& element : elements) {
-        if (isDevice(element)) {
-            out.push_back(getDevice(element).id);
-        } else if (isRack(element)) {
-            const auto& rack = getRack(element);
-            for (const auto& chain : rack.chains)
-                collectChainDeviceIds(chain.elements, out);
-        }
-    }
 }
 
 struct CascadeSuggestion {
@@ -365,14 +354,18 @@ void GainStagingManager::buildStagedDeviceList(TrackId trackId) {
     if (track == nullptr)
         return;
 
-    // Main FX chain (device/rack tree) in signal order.
-    std::vector<DeviceId> fxIds;
-    collectChainDeviceIds(track->chain.fxChainElements, fxIds);
-    for (auto deviceId : fxIds) {
-        auto path = tm.findDevicePath(deviceId);
-        if (path.isValid())
-            staged_.push_back({deviceId, path});
-    }
+    // Main FX chain (device/rack tree) in signal order. Pads skipped: gain
+    // staging works on a track's chain, and a pad's level is the grid's
+    // business rather than a stage in the cascade (#2204).
+    //
+    // The walk hands back the address it built, so there is no findDevicePath()
+    // search per device to undo the descent that just passed the device.
+    chain_walk::forEachDevice(track->chain.fxChainElements, ChainNodePath::trackLevel(trackId),
+                              chain_walk::Pads::Skip,
+                              [this](const DeviceInfo& device, const ChainNodePath& path) {
+                                  if (path.isValid())
+                                      staged_.push_back({device.id, path});
+                              });
 
     // Post-FX stage (flat, devices only).
     for (const auto& element : track->chain.postFxChainElements) {

--- a/magda/daw/core/LegacyDeviceAliases.cpp
+++ b/magda/daw/core/LegacyDeviceAliases.cpp
@@ -10,6 +10,7 @@
 #include <span>
 
 #include "AutomationInfo.hpp"
+#include "ChainWalk.hpp"
 #include "DeviceInfo.hpp"
 #include "DeviceState.hpp"
 #include "TrackInfo.hpp"
@@ -631,39 +632,40 @@ void pruneLinks(MacroArray& macros, ModArray& mods, const std::set<ChainNodePath
         });
 }
 
-void collectChainElements(std::vector<ChainElement>& elements, const ChainNodePath& parentPath,
-                          TrackId trackId, std::set<ChainNodePath>& migratedPaths);
+/// Migrate every device on the track, and drop the links each rack held to one
+/// that lost them, innermost rack first.
+///
+/// A rack prunes against what migrated inside it rather than against the whole
+/// track: a link is the rack's own, and a device elsewhere losing its links is
+/// none of its business. That scoping is a stack of sets pushed and popped
+/// around the descent, which is what the walk's rack exit is for -- and it runs
+/// from a destructor, so the stack stays balanced (#2204).
+void migrateTrackDevices(std::vector<ChainElement>& elements, const ChainNodePath& trackPath,
+                         std::set<ChainNodePath>& migratedPaths) {
+    std::vector<std::set<ChainNodePath>> scopes;
+    scopes.emplace_back();
 
-void collectRack(RackInfo& rack, const ChainNodePath& rackPath, TrackId trackId,
-                 std::set<ChainNodePath>& migratedPaths) {
-    std::set<ChainNodePath> rackMigrated;
-    for (auto& chain : rack.chains)
-        collectChainElements(chain.elements, rackPath.withChain(chain.id), trackId, rackMigrated);
+    // Pads skipped: a pad device has no legacy alias to migrate, and the Drum
+    // Grid covers its own retired nested plugins through
+    // adoptRetiredNestedPluginTree.
+    chain_walk::forEachNode(
+        elements, trackPath, chain_walk::Pads::Skip,
+        [&scopes](DeviceInfo& device, const ChainNodePath& path) {
+            if (migrateDevice(device) == MigrationResult::MigratedDroppingLinks)
+                scopes.back().insert(path);
+        },
+        [&scopes](RackInfo&, const ChainNodePath&) {
+            scopes.emplace_back();
+            return chain_walk::Descend::Into;
+        },
+        [&scopes](RackInfo& rack, const ChainNodePath&) {
+            auto rackMigrated = std::move(scopes.back());
+            scopes.pop_back();
+            pruneLinks(rack.macros, rack.mods, rackMigrated);
+            scopes.back().merge(rackMigrated);
+        });
 
-    pruneLinks(rack.macros, rack.mods, rackMigrated);
-    migratedPaths.insert(rackMigrated.begin(), rackMigrated.end());
-}
-
-void collectChainElements(std::vector<ChainElement>& elements, const ChainNodePath& parentPath,
-                          TrackId trackId, std::set<ChainNodePath>& migratedPaths) {
-    for (auto& element : elements) {
-        if (isDevice(element)) {
-            auto& device = getDevice(element);
-            if (migrateDevice(device) != MigrationResult::MigratedDroppingLinks)
-                continue;
-
-            // A top-level device on a track keeps the legacy flat path shape,
-            // which is what the control graph stored for it.
-            migratedPaths.insert(parentPath.isTrackLevel
-                                     ? ChainNodePath::topLevelDevice(trackId, device.id)
-                                     : parentPath.withDevice(device.id));
-        } else if (isRack(element)) {
-            auto& rack = getRack(element);
-            const auto rackPath = parentPath.isTrackLevel ? ChainNodePath::rack(trackId, rack.id)
-                                                          : parentPath.withRack(rack.id);
-            collectRack(rack, rackPath, trackId, migratedPaths);
-        }
-    }
+    migratedPaths.merge(scopes.back());
 }
 
 // A preset carries no surrounding project, and its device ids are unique
@@ -769,8 +771,8 @@ bool migrateRetiredDevice(DeviceInfo& device) {
 std::vector<ChainNodePath> migrateRetiredDevicesInTrack(TrackInfo& track) {
     std::set<ChainNodePath> migratedPaths;
 
-    collectChainElements(track.chain.fxChainElements, ChainNodePath::trackLevel(track.id), track.id,
-                         migratedPaths);
+    migrateTrackDevices(track.chain.fxChainElements, ChainNodePath::trackLevel(track.id),
+                        migratedPaths);
 
     for (auto& element : track.chain.postFxChainElements)
         if (migrateDevice(element.device) == MigrationResult::MigratedDroppingLinks)

--- a/magda/daw/core/TrackManager.cpp
+++ b/magda/daw/core/TrackManager.cpp
@@ -186,37 +186,28 @@ void scanEmbeddedDeviceIds(const juce::String& pluginState, int& maxDeviceId) {
         scanEmbeddedDeviceIds(state, maxDeviceId);
 }
 
+/// Point a duplicated track's links at the copy, and strip the runtime state
+/// its devices carried over.
+///
+/// The walk addresses everything, including a device's pads: they are chains it
+/// owns, their devices carry state to strip, and the address it builds is
+/// stamped into any mod link that carries none of its own. This built pad
+/// addresses as `Rack(deviceId) > Chain(padId)`, the untyped spelling #2219
+/// removed, so a duplicated pad device's self-targeted modifier named a rack
+/// step holding a DeviceId -- which resolves down the rack walk that no pad
+/// answers to (#2204).
 void remapDuplicatedElements(std::vector<ChainElement>& elements, const ChainNodePath& parentPath,
                              const DuplicateIdRemap& remap) {
-    for (auto& element : elements) {
-        if (magda::isDevice(element)) {
-            auto& device = magda::getDevice(element);
-            auto devicePath = parentPath;
-            if (parentPath.isTrackLevel) {
-                devicePath = ChainNodePath::topLevelDevice(remap.newTrackId, device.id);
-            } else {
-                devicePath = parentPath.withDevice(device.id);
-            }
+    chain_walk::forEachNode(
+        elements, parentPath, chain_walk::Pads::Enter,
+        [&remap](DeviceInfo& device, const ChainNodePath& devicePath) {
             remapDuplicatedLinks(device.macros, device.mods, devicePath, remap);
             device.pluginState = stripDuplicateRuntimePluginState(device.pluginState);
-
-            // A device's pads are chains it owns, so they are walked like a
-            // rack's: their devices carry state to strip, and the grid's links
-            // into them were remapped by the call above (#2207).
-            if (device.pads) {
-                const auto padsPath = devicePath.parentChain().withRack(device.id);
-                for (auto& pad : device.pads->chains)
-                    remapDuplicatedElements(pad.elements, padsPath.withChain(pad.id), remap);
-            }
-        } else if (magda::isRack(element)) {
-            auto& rack = magda::getRack(element);
-            auto rackPath = parentPath.isTrackLevel ? ChainNodePath::rack(remap.newTrackId, rack.id)
-                                                    : parentPath.withRack(rack.id);
+        },
+        [&remap](RackInfo& rack, const ChainNodePath& rackPath) {
             remapDuplicatedLinks(rack.macros, rack.mods, rackPath, remap);
-            for (auto& chain : rack.chains)
-                remapDuplicatedElements(chain.elements, rackPath.withChain(chain.id), remap);
-        }
-    }
+            return chain_walk::Descend::Into;
+        });
 }
 
 void setChainElementsBypassed(std::vector<ChainElement>& elements, const ChainNodePath& parentPath,

--- a/magda/daw/core/TrackManager.cpp
+++ b/magda/daw/core/TrackManager.cpp
@@ -10,6 +10,7 @@
 #include "../audio/TracktionHelpers.hpp"
 #include "../audio/plugins/SidechainTriggerBus.hpp"
 #include "../engine/AudioEngine.hpp"
+#include "ChainWalk.hpp"
 #include "ClipManager.hpp"
 #include "Config.hpp"
 #include "DeviceState.hpp"
@@ -218,51 +219,20 @@ void remapDuplicatedElements(std::vector<ChainElement>& elements, const ChainNod
     }
 }
 
-ChainNodePath childDevicePath(const ChainNodePath& parentPath, DeviceId deviceId) {
-    return parentPath.isTrackLevel ? ChainNodePath::topLevelDevice(parentPath.trackId, deviceId)
-                                   : parentPath.withDevice(deviceId);
-}
-
-ChainNodePath childRackPath(const ChainNodePath& parentPath, RackId rackId) {
-    return parentPath.isTrackLevel ? ChainNodePath::rack(parentPath.trackId, rackId)
-                                   : parentPath.withRack(rackId);
-}
-
-// Collect the device paths of every device in the given chain tree (racks
-// recursed), without mutating anything. Path construction mirrors
-// setChainElementsBypassed below.
-void collectChainDevicePaths(const std::vector<ChainElement>& elements,
-                             const ChainNodePath& parentPath,
-                             std::vector<ChainNodePath>& outDevices) {
-    for (const auto& element : elements) {
-        if (magda::isDevice(element)) {
-            outDevices.push_back(childDevicePath(parentPath, magda::getDevice(element).id));
-            continue;
-        }
-        const auto& rack = magda::getRack(element);
-        const auto rackPath = childRackPath(parentPath, rack.id);
-        for (const auto& chain : rack.chains)
-            collectChainDevicePaths(chain.elements, rackPath.withChain(chain.id), outDevices);
-    }
-}
-
 void setChainElementsBypassed(std::vector<ChainElement>& elements, const ChainNodePath& parentPath,
                               bool bypassed, std::vector<ChainNodePath>& affectedDevices) {
-    for (auto& element : elements) {
-        if (magda::isDevice(element)) {
-            auto& device = magda::getDevice(element);
+    // Racks and devices are two walks rather than one that visits both, which
+    // costs a second descent and buys the two orders being independent: the
+    // devices come out in signal order for the caller to announce.
+    chain_walk::forEachRack(
+        elements, parentPath, chain_walk::Pads::Skip,
+        [bypassed](RackInfo& rack, const ChainNodePath&) { rack.bypassed = bypassed; });
+    chain_walk::forEachDevice(
+        elements, parentPath, chain_walk::Pads::Skip,
+        [bypassed, &affectedDevices](DeviceInfo& device, const ChainNodePath& path) {
             device.bypassed = bypassed;
-            affectedDevices.push_back(childDevicePath(parentPath, device.id));
-            continue;
-        }
-
-        auto& rack = magda::getRack(element);
-        rack.bypassed = bypassed;
-        const auto rackPath = childRackPath(parentPath, rack.id);
-        for (auto& chain : rack.chains)
-            setChainElementsBypassed(chain.elements, rackPath.withChain(chain.id), bypassed,
-                                     affectedDevices);
-    }
+            affectedDevices.push_back(path);
+        });
 }
 
 void enforcePostFxAnalysisDeviceOrder(std::vector<PostFxChainElement>& elements) {
@@ -2428,11 +2398,11 @@ void TrackManager::setChainEnabled(TrackId trackId, bool enabled) {
     // regular device sync path (AudioBridge::devicePropertyChanged applies the
     // chain gate on top of each device's own bypassed flag). The flags
     // themselves are untouched, so per-device bypass survives an off/on cycle.
-    std::vector<ChainNodePath> devicePaths;
-    collectChainDevicePaths(track->chain.fxChainElements, ChainNodePath::trackLevel(trackId),
-                            devicePaths);
-    for (const auto& devicePath : devicePaths)
-        notifyDevicePropertyChanged(devicePath);
+    chain_walk::forEachDevice(track->chain.fxChainElements, ChainNodePath::trackLevel(trackId),
+                              chain_walk::Pads::Skip,
+                              [this](const DeviceInfo&, const ChainNodePath& devicePath) {
+                                  notifyDevicePropertyChanged(devicePath);
+                              });
     notifyTrackDevicesChanged(trackId);
 }
 

--- a/magda/daw/core/TrackManagerDevices.cpp
+++ b/magda/daw/core/TrackManagerDevices.cpp
@@ -681,24 +681,34 @@ static void collectMovedDevicePaths(const ChainElement& element, const ChainNode
                               });
 }
 
+/// Point every link @p elements OWNS at where the moved devices now are.
+///
+/// Pads entered: a pad device owns macros and mods like any other, and a
+/// modifier on one pointing at its own parameter is the ordinary case. This
+/// descended only through racks, so such a link went on naming the track its
+/// grid came from (#2204).
 static void retargetLinksInElements(std::vector<ChainElement>& elements,
+                                    const ChainNodePath& parentPath,
                                     const DevicePathMap& movedPaths) {
-    for (auto& element : elements) {
-        if (magda::isDevice(element)) {
-            auto& device = magda::getDevice(element);
+    // The real parent, not the track: these run over a nested chain's elements
+    // as well as a track's own list, and a walk told the wrong parent spells
+    // every device in it as top-level. Nothing here reads the address it
+    // builds, which is exactly why passing the wrong one would sit unnoticed.
+    chain_walk::forEachNode(
+        elements, parentPath, chain_walk::Pads::Enter,
+        [&movedPaths](DeviceInfo& device, const ChainNodePath&) {
             retargetMovedLinks(device.macros, device.mods, movedPaths);
-        } else if (magda::isRack(element)) {
-            auto& rack = magda::getRack(element);
+        },
+        [&movedPaths](RackInfo& rack, const ChainNodePath&) {
             retargetMovedLinks(rack.macros, rack.mods, movedPaths);
-            for (auto& chain : rack.chains)
-                retargetLinksInElements(chain.elements, movedPaths);
-        }
-    }
+            return chain_walk::Descend::Into;
+        });
 }
 
 static void retargetMovedLinksInTrack(TrackInfo& track, const DevicePathMap& movedPaths) {
     retargetMovedLinks(track.macros, track.mods, movedPaths);
-    retargetLinksInElements(track.chain.fxChainElements, movedPaths);
+    retargetLinksInElements(track.chain.fxChainElements, ChainNodePath::trackLevel(track.id),
+                            movedPaths);
 }
 
 static bool targetPointsAtMovedDevice(const ControlTarget& target,
@@ -728,24 +738,28 @@ static void removeMovedTargets(MacroArray& macros, ModArray& mods,
     }
 }
 
+/// Drop every link @p elements owns to a device that has left the track.
+///
+/// The mirror of the above, and it skipped pads the same way: a pad device
+/// staying put kept a link to something no longer on its track (#2204).
 static void removeMovedTargetsInElements(std::vector<ChainElement>& elements,
+                                         const ChainNodePath& parentPath,
                                          const DevicePathMap& movedPaths) {
-    for (auto& element : elements) {
-        if (magda::isDevice(element)) {
-            auto& device = magda::getDevice(element);
+    chain_walk::forEachNode(
+        elements, parentPath, chain_walk::Pads::Enter,
+        [&movedPaths](DeviceInfo& device, const ChainNodePath&) {
             removeMovedTargets(device.macros, device.mods, movedPaths);
-        } else if (magda::isRack(element)) {
-            auto& rack = magda::getRack(element);
+        },
+        [&movedPaths](RackInfo& rack, const ChainNodePath&) {
             removeMovedTargets(rack.macros, rack.mods, movedPaths);
-            for (auto& chain : rack.chains)
-                removeMovedTargetsInElements(chain.elements, movedPaths);
-        }
-    }
+            return chain_walk::Descend::Into;
+        });
 }
 
 static void removeMovedTargetsInTrack(TrackInfo& track, const DevicePathMap& movedPaths) {
     removeMovedTargets(track.macros, track.mods, movedPaths);
-    removeMovedTargetsInElements(track.chain.fxChainElements, movedPaths);
+    removeMovedTargetsInElements(track.chain.fxChainElements, ChainNodePath::trackLevel(track.id),
+                                 movedPaths);
 }
 
 static ChainNodePath getInsertedElementPath(const ChainNodePath& destinationChainPath,
@@ -973,7 +987,7 @@ bool TrackManager::moveChainElement(const ChainNodePath& sourceElementPath,
         if (auto* track = getTrack(destinationChainPath.trackId))
             retargetMovedLinksInTrack(*track, movedPaths);
     } else {
-        retargetLinksInElements(*destinationElements, movedPaths);
+        retargetLinksInElements(*destinationElements, destinationChainPath, movedPaths);
         if (auto* sourceTrack = getTrack(sourceElementPath.trackId))
             removeMovedTargetsInTrack(*sourceTrack, movedPaths);
     }

--- a/magda/daw/core/TrackManagerDevices.cpp
+++ b/magda/daw/core/TrackManagerDevices.cpp
@@ -1,12 +1,14 @@
 #include <algorithm>
 #include <map>
 #include <set>
+#include <span>
 
 #include "../audio/AudioBridge.hpp"
 #include "../audio/TracktionHelpers.hpp"
 #include "../audio/plugin_manager/ExternalPluginStateUtil.hpp"
 #include "../audio/plugins/tracktion/TracktionDeviceStateBridge.hpp"
 #include "../engine/AudioEngine.hpp"
+#include "ChainWalk.hpp"
 #include "DeviceState.hpp"
 #include "DrumGridPads.hpp"
 #include "PluginPreferences.hpp"
@@ -251,21 +253,16 @@ void remapPresetLinksRecursive(std::vector<ChainElement>& elements, const Preset
     }
 }
 
-void collectDeviceIdMatches(std::vector<ChainElement>& elements, DeviceId deviceId,
+void collectDeviceIdMatches(std::vector<ChainElement>& elements, TrackId trackId, DeviceId deviceId,
                             std::vector<DeviceInfo*>& matches) {
-    for (auto& element : elements) {
-        if (magda::isDevice(element)) {
-            auto& device = magda::getDevice(element);
-            if (device.id == deviceId)
-                matches.push_back(&device);
-            continue;
-        }
-
-        if (magda::isRack(element)) {
-            for (auto& chain : magda::getRack(element).chains)
-                collectDeviceIdMatches(chain.elements, deviceId, matches);
-        }
-    }
+    // Pads entered: this asks whether a bare device id names exactly one
+    // device, and a pad device is one. Skipping them would answer "unique" for
+    // an id that two devices hold.
+    chain_walk::forEachDevice(elements, ChainNodePath::trackLevel(trackId), chain_walk::Pads::Enter,
+                              [deviceId, &matches](DeviceInfo& device, const ChainNodePath&) {
+                                  if (device.id == deviceId)
+                                      matches.push_back(&device);
+                              });
 }
 
 void collectDeviceIdMatches(std::vector<PostFxChainElement>& elements, DeviceId deviceId,
@@ -278,12 +275,12 @@ void collectDeviceIdMatches(std::vector<PostFxChainElement>& elements, DeviceId 
 DeviceInfo* findUniqueBareDeviceIdMatch(TrackInfo& masterTrack, std::vector<TrackInfo>& tracks,
                                         DeviceId deviceId) {
     std::vector<DeviceInfo*> matches;
-    collectDeviceIdMatches(masterTrack.chain.fxChainElements, deviceId, matches);
+    collectDeviceIdMatches(masterTrack.chain.fxChainElements, masterTrack.id, deviceId, matches);
     collectDeviceIdMatches(masterTrack.chain.postFxChainElements, deviceId, matches);
     collectDeviceIdMatches(masterTrack.chain.mixerAnalysisElements, deviceId, matches);
 
     for (auto& track : tracks) {
-        collectDeviceIdMatches(track.chain.fxChainElements, deviceId, matches);
+        collectDeviceIdMatches(track.chain.fxChainElements, track.id, deviceId, matches);
         collectDeviceIdMatches(track.chain.postFxChainElements, deviceId, matches);
         collectDeviceIdMatches(track.chain.mixerAnalysisElements, deviceId, matches);
     }
@@ -664,27 +661,24 @@ static void retargetMovedLinks(MacroArray& macros, ModArray& mods,
     }
 }
 
+/// Where every device under @p element now lives, keyed by id, for the links
+/// naming them to be retargeted onto.
+///
+/// Pads entered: a Drum Grid carries its pad devices with it. This stopped at
+/// the grid, so moving one to another track left every link into its pads
+/// holding the path it had on the track it came from -- a device id that
+/// `retargetMovedTarget` never found, so the whole address survived unchanged
+/// (#2204).
 static void collectMovedDevicePaths(const ChainElement& element, const ChainNodePath& elementPath,
                                     DevicePathMap& movedPaths) {
-    if (magda::isDevice(element)) {
-        movedPaths[magda::getDevice(element).id] = elementPath;
-        return;
-    }
+    const std::span<const ChainElement> subtree{&element, 1};
+    const auto parentPath =
+        magda::isDevice(element) ? elementPath.parentChain() : elementPath.parent();
 
-    const auto& rack = magda::getRack(element);
-    auto rackPath = elementPath;
-    for (const auto& chain : rack.chains) {
-        auto chainPath = rackPath.withChain(chain.id);
-        for (const auto& child : chain.elements) {
-            if (magda::isDevice(child)) {
-                collectMovedDevicePaths(child, chainPath.withDevice(magda::getDevice(child).id),
-                                        movedPaths);
-            } else if (magda::isRack(child)) {
-                collectMovedDevicePaths(child, chainPath.withRack(magda::getRack(child).id),
-                                        movedPaths);
-            }
-        }
-    }
+    chain_walk::forEachDevice(subtree, parentPath, chain_walk::Pads::Enter,
+                              [&movedPaths](const DeviceInfo& device, const ChainNodePath& path) {
+                                  movedPaths[device.id] = path;
+                              });
 }
 
 static void retargetLinksInElements(std::vector<ChainElement>& elements,

--- a/magda/engine/exec/PlanValues.cpp
+++ b/magda/engine/exec/PlanValues.cpp
@@ -5,6 +5,7 @@
 #include <set>
 #include <unordered_map>
 
+#include "core/ChainWalk.hpp"
 #include "core/DrumGridPads.hpp"
 #include "core/RackInfo.hpp"
 #include "core/TrackInfo.hpp"
@@ -59,33 +60,6 @@ float faderPositionToGain(float position) {
 /// compiler reports routing cycles, and mute inheritance is not the place to
 /// discover one.
 constexpr int kMaxTrackWalk = 64;
-
-const RackInfo* findRackIn(const std::vector<ChainElement>& elements, RackId rackId);
-
-const RackInfo* findRackIn(const RackInfo& rack, RackId rackId) {
-    if (rack.id == rackId)
-        return &rack;
-    for (const auto& chain : rack.chains)
-        if (const auto* found = findRackIn(chain.elements, rackId))
-            return found;
-    return nullptr;
-}
-
-const RackInfo* findRackIn(const std::vector<ChainElement>& elements, RackId rackId) {
-    for (const auto& element : elements) {
-        if (isRack(element)) {
-            if (const auto* found = findRackIn(getRack(element), rackId))
-                return found;
-            continue;
-        }
-        // A pad rack hangs off its device rather than sitting in the chain, and
-        // its chains carry mute, solo and a fader like any other's.
-        if (const auto& device = getDevice(element); device.pads)
-            if (const auto* found = findRackIn(*device.pads.get(), rackId))
-                return found;
-    }
-    return nullptr;
-}
 
 const ChainInfo* findChain(const RackInfo& rack, ChainId chainId) {
     const auto found = std::ranges::find_if(
@@ -153,8 +127,14 @@ class Resolver {
     }
 
     /// The rack an op's key names, wherever it is nested.
+    ///
+    /// Pads entered: a pad rack hangs off its device rather than sitting in the
+    /// chain, and its chains carry mute, solo and a fader like any other's.
     const RackInfo* findRack(const TrackInfo& track, RackId rackId) const {
-        return findRackIn(track.chain.fxChainElements, rackId);
+        return chain_walk::findRack(
+            track.chain.fxChainElements, ChainNodePath::trackLevel(track.id),
+            chain_walk::Pads::Enter,
+            [rackId](const RackInfo& rack, const ChainNodePath&) { return rack.id == rackId; });
     }
 
     /// The device an op's key names: a track-level device sits in one of the

--- a/magda/engine/exec/RuntimeStateStore.cpp
+++ b/magda/engine/exec/RuntimeStateStore.cpp
@@ -2,6 +2,7 @@
 
 #include <set>
 
+#include "core/ChainWalk.hpp"
 #include "core/RackInfo.hpp"
 #include "core/TrackInfo.hpp"
 #include "param/ParamTable.hpp"
@@ -36,35 +37,22 @@ template <typename Map> void prepareAll(Map& map, const RenderContext& context) 
         object->prepare(context);
 }
 
-void collectDeviceIds(const std::vector<ChainElement>& elements, ChainSegment segment,
-                      std::set<DeviceKey>& out);
-
 void collectDeviceIds(const std::vector<PostFxChainElement>& elements, ChainSegment segment,
                       std::set<DeviceKey>& out) {
     for (const auto& element : elements)
         out.emplace(segment, element.device.id);
 }
 
-void collectDeviceIds(const std::vector<ChainElement>& elements, ChainSegment segment,
-                      std::set<DeviceKey>& out) {
-    for (const auto& element : elements) {
-        if (isDevice(element)) {
-            const auto& device = getDevice(element);
-            out.emplace(segment, device.id);
-
-            // A pad rack's devices are the user's the same way a nested rack's
-            // are. Bypass and chain power take their ops out of the plan, and a
-            // device named by neither the plan nor this set has its runtime
-            // released: re-enabling would rebuild the plugins and lose their
-            // tails and state.
-            if (device.pads)
-                for (const auto& pad : device.pads->chains)
-                    collectDeviceIds(pad.elements, segment, out);
-        } else if (isRack(element)) {
-            for (const auto& chain : getRack(element).chains)
-                collectDeviceIds(chain.elements, segment, out);
-        }
-    }
+void collectDeviceIds(const std::vector<ChainElement>& elements, TrackId trackId,
+                      ChainSegment segment, std::set<DeviceKey>& out) {
+    // Pads entered: a pad rack's devices are the user's the same way a nested
+    // rack's are. Bypass and chain power take their ops out of the plan, and a
+    // device named by neither the plan nor this set has its runtime released:
+    // re-enabling would rebuild the plugins and lose their tails and state.
+    chain_walk::forEachDevice(elements, ChainNodePath::trackLevel(trackId), chain_walk::Pads::Enter,
+                              [segment, &out](const DeviceInfo& device, const ChainNodePath&) {
+                                  out.emplace(segment, device.id);
+                              });
 }
 
 /// Whether a Meter op's key still names something the model holds. A meter at a
@@ -298,7 +286,7 @@ RuntimeStateIds collectRuntimeStateIds(const std::vector<TrackInfo>& tracks,
         ids.tracks.insert(track.id);
         // Every section, and bypass is not consulted anywhere here: a bypassed
         // device is still a device the user owns.
-        collectDeviceIds(track.chain.fxChainElements, ChainSegment::Fx, ids.devices);
+        collectDeviceIds(track.chain.fxChainElements, track.id, ChainSegment::Fx, ids.devices);
         collectDeviceIds(track.chain.postFxChainElements, ChainSegment::PostFx, ids.devices);
         collectDeviceIds(track.chain.mixerAnalysisElements, ChainSegment::MixerAnalysis,
                          ids.devices);

--- a/magda/engine/param/ParamTableCompiler.cpp
+++ b/magda/engine/param/ParamTableCompiler.cpp
@@ -5,6 +5,7 @@
 #include <set>
 
 #include "core/AutomationCurve.hpp"
+#include "core/ChainWalk.hpp"
 #include "core/ClipLaneFlattener.hpp"
 #include "core/RackInfo.hpp"
 #include "core/TrackInfo.hpp"
@@ -261,9 +262,6 @@ class Builder {
     ParamId add(const ParamKey& key, const ParamSpec& spec, float base);
 
     void walkTrack(const magda::TrackInfo& track);
-    void walkRack(const magda::RackInfo& rack, magda::TrackId trackId);
-    void walkElements(const std::vector<magda::ChainElement>& elements, magda::TrackId trackId,
-                      magda::RackId rackId);
     void walkFlat(const std::vector<magda::PostFxChainElement>& elements, magda::TrackId trackId,
                   ChainSegment segment);
 
@@ -525,42 +523,6 @@ void Builder::allocateDevice(const Node& node) {
         table_.deviceWindows.emplace(scope.device, ParamTable::DeviceWindow{first, highest + 1});
 }
 
-void Builder::walkElements(const std::vector<magda::ChainElement>& elements, magda::TrackId trackId,
-                           magda::RackId rackId) {
-    for (const auto& element : elements) {
-        if (magda::isDevice(element)) {
-            const auto& device = magda::getDevice(element);
-            Node node;
-            node.scope.scope = ParamKey::Scope::Device;
-            node.scope.trackId = trackId;
-            node.scope.rackId = rackId;
-            node.scope.device = DeviceKey{ChainSegment::Fx, device.id};
-            node.macros = &device.macros;
-            node.mods = &device.mods;
-            node.device = &device;
-            node.sidechainSource = sidechainSourceOf(device.sidechain);
-            nodes_.push_back(node);
-
-            // A pad rack's chains hold devices like any other rack's, and the
-            // plan compiles them, so their parameters, macros and mods need
-            // addresses or nothing consumes them.
-            //
-            // Addressed under the owning device's id, not the pad rack's. A
-            // stored link to a pad device names the Drum Grid there -- see the
-            // chainDevice path syncDrumGridPadPlugins and the ADSR macro links
-            // are built with -- and ParamKey carries the rack id, so addressing
-            // these under the pad rack's own synthetic id would put them where
-            // no link can find them. The rack itself gets no node: it is
-            // synthesized, so it owns no macros or modifiers to address.
-            if (device.pads)
-                for (const auto& pad : device.pads->chains)
-                    walkElements(pad.elements, trackId, device.id);
-        } else if (magda::isRack(element)) {
-            walkRack(magda::getRack(element), trackId);
-        }
-    }
-}
-
 void Builder::walkFlat(const std::vector<magda::PostFxChainElement>& elements,
                        magda::TrackId trackId, ChainSegment segment) {
     for (const auto& element : elements) {
@@ -574,31 +536,6 @@ void Builder::walkFlat(const std::vector<magda::PostFxChainElement>& elements,
         node.sidechainSource = sidechainSourceOf(element.device.sidechain);
         nodes_.push_back(node);
     }
-}
-
-void Builder::walkRack(const magda::RackInfo& rack, magda::TrackId trackId) {
-    // The same instance the plan compiler passes over. Walking it would report
-    // every address in the subtree as claimed twice, with nothing naming the
-    // cause.
-    if (nesting_.encloses(rack.id)) {
-        diagnose(nesting_.cycle(rack.id) +
-                 ", its parameters and everything under it are not carried");
-        return;
-    }
-
-    const RackNesting::Scope scope{nesting_, rack.id};
-
-    Node node;
-    node.scope.scope = ParamKey::Scope::Rack;
-    node.scope.trackId = trackId;
-    node.scope.rackId = rack.id;
-    node.macros = &rack.macros;
-    node.mods = &rack.mods;
-    node.sidechainSource = sidechainSourceOf(rack.sidechain);
-    nodes_.push_back(node);
-
-    for (const auto& chain : rack.chains)
-        walkElements(chain.elements, trackId, rack.id);
 }
 
 /// The mixer values a track has, allocated only when something reaches them: a
@@ -648,7 +585,56 @@ void Builder::walkTrack(const magda::TrackInfo& track) {
     node.track = &track;
     nodes_.push_back(node);
 
-    walkElements(track.chain.fxChainElements, track.id, INVALID_RACK_ID);
+    // Pads entered: a pad rack's chains hold devices like any other rack's, and
+    // the plan compiles them, so their parameters, macros and mods need
+    // addresses or nothing consumes them.
+    //
+    // A device's own id comes from the walk's `owningRackId`, which answers the
+    // Drum Grid for a pad device rather than the synthetic pad rack: a stored
+    // link to one names the grid -- see the chainDevice path
+    // syncDrumGridPadPlugins and the ADSR macro links are built with -- and
+    // ParamKey carries the rack id, so addressing these under the pad rack's
+    // own id would put them where no link can find them. The pad rack itself
+    // gets no node: it is synthesized, so it owns no macros or modifiers.
+    chain_walk::forEachNode(
+        track.chain.fxChainElements, magda::ChainNodePath::trackLevel(track.id),
+        chain_walk::Pads::Enter,
+        [this, &track](const magda::DeviceInfo& device, const magda::ChainNodePath& path) {
+            Node deviceNode;
+            deviceNode.scope.scope = ParamKey::Scope::Device;
+            deviceNode.scope.trackId = track.id;
+            deviceNode.scope.rackId = chain_walk::owningRackId(path);
+            deviceNode.scope.device = DeviceKey{ChainSegment::Fx, device.id};
+            deviceNode.macros = &device.macros;
+            deviceNode.mods = &device.mods;
+            deviceNode.device = &device;
+            deviceNode.sidechainSource = sidechainSourceOf(device.sidechain);
+            nodes_.push_back(deviceNode);
+        },
+        [this, &track](const magda::RackInfo& rack, const magda::ChainNodePath&) {
+            // The same instance the plan compiler passes over. Walking it would
+            // report every address in the subtree as claimed twice, with
+            // nothing naming the cause.
+            if (nesting_.encloses(rack.id)) {
+                diagnose(nesting_.cycle(rack.id) +
+                         ", its parameters and everything under it are not carried");
+                return chain_walk::Descend::Skip;
+            }
+            nesting_.open(rack.id);
+
+            Node rackNode;
+            rackNode.scope.scope = ParamKey::Scope::Rack;
+            rackNode.scope.trackId = track.id;
+            rackNode.scope.rackId = rack.id;
+            rackNode.macros = &rack.macros;
+            rackNode.mods = &rack.mods;
+            rackNode.sidechainSource = sidechainSourceOf(rack.sidechain);
+            nodes_.push_back(rackNode);
+            return chain_walk::Descend::Into;
+        },
+        [this](const magda::RackInfo& rack, const magda::ChainNodePath&) {
+            nesting_.close(rack.id);
+        });
     walkFlat(track.chain.postFxChainElements, track.id, ChainSegment::PostFx);
     walkFlat(track.chain.mixerAnalysisElements, track.id, ChainSegment::MixerAnalysis);
 }

--- a/magda/engine/plan/RackNesting.cpp
+++ b/magda/engine/plan/RackNesting.cpp
@@ -17,12 +17,25 @@ std::string RackNesting::cycle(RackId rack) const {
     return "rack " + std::to_string(rack) + " contains itself: " + path;
 }
 
-RackNesting::Scope::Scope(RackNesting& nesting, RackId rack) : nesting_(nesting) {
-    nesting_.open_.push_back(rack);
+void RackNesting::open(RackId rack) {
+    open_.push_back(rack);
+}
+
+void RackNesting::close(RackId rack) {
+    // By identity rather than by position: a caller closing something other
+    // than the innermost open rack has lost track of its own descent, and
+    // popping regardless would hide that and leave the stack wrong from there
+    // on.
+    if (!open_.empty() && open_.back() == rack)
+        open_.pop_back();
+}
+
+RackNesting::Scope::Scope(RackNesting& nesting, RackId rack) : nesting_(nesting), rack_(rack) {
+    nesting_.open(rack);
 }
 
 RackNesting::Scope::~Scope() {
-    nesting_.open_.pop_back();
+    nesting_.close(rack_);
 }
 
 }  // namespace magda::engine

--- a/magda/engine/plan/RackNesting.hpp
+++ b/magda/engine/plan/RackNesting.hpp
@@ -40,6 +40,18 @@ class RackNesting {
      */
     std::string cycle(RackId rack) const;
 
+    /**
+     * @brief Open @p rack, and close the innermost open one.
+     *
+     * The pair, for a walk that owns the descent and unwinds the pair itself:
+     * `chain_walk::forEachNode()` runs its rack exit from a destructor, so an
+     * early return out of the descent still closes what it opened. Anything
+     * descending under its own control wants `Scope` below instead, which
+     * cannot be got wrong (#2204).
+     */
+    void open(RackId rack);
+    void close(RackId rack);
+
     /// Opens a rack instance for as long as this lives. A guard rather than a
     /// push and a pop, because every walk that descends has somewhere it
     /// returns early from.
@@ -55,6 +67,7 @@ class RackNesting {
 
       private:
         RackNesting& nesting_;
+        RackId rack_;
     };
 
   private:

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -38,6 +38,7 @@ set(TEST_SOURCES
     test_drum_grid_pad_commands.cpp
     test_pad_path_types.cpp
     test_structural_undo_roundtrip.cpp
+    test_chain_walk.cpp
     test_structural_matrix.cpp
     test_drum_grid_pads.cpp
     test_drum_grid_pads_corpus.cpp

--- a/tests/test_chain_walk.cpp
+++ b/tests/test_chain_walk.cpp
@@ -1,0 +1,200 @@
+#include <catch2/catch_test_macros.hpp>
+#include <string>
+
+#include "magda/daw/core/ChainWalk.hpp"
+#include "magda/daw/core/DrumGridPads.hpp"
+#include "magda/daw/core/TrackManager.hpp"
+
+using namespace magda;
+
+// The one descent, and the order it goes in (#2204).
+//
+// A dozen walks each implemented this, and a consumer that swapped to the
+// shared one would change behaviour if the order moved: the gain-staging
+// cascade reads its devices in signal order, and the bypass sweep announces
+// the paths it touched in the order it touched them. So the order is asserted
+// rather than left to whatever the recursion happens to do.
+
+namespace {
+
+DeviceInfo effect(const juce::String& name) {
+    DeviceInfo device;
+    device.name = name;
+    device.pluginId = "delay";
+    device.format = PluginFormat::Internal;
+    return device;
+}
+
+DeviceInfo drumGrid(const juce::String& name) {
+    DeviceInfo device;
+    device.name = name;
+    device.pluginId = "drumgrid";
+    device.format = PluginFormat::Internal;
+    device.isInstrument = true;
+    device.deviceType = DeviceType::Instrument;
+    return device;
+}
+
+/// The names the walk visited, in order, comma-separated.
+std::string order(const std::vector<juce::String>& names) {
+    juce::String joined;
+    for (const auto& name : names)
+        joined += (joined.isEmpty() ? "" : ",") + name;
+    return joined.toStdString();
+}
+
+}  // namespace
+
+TEST_CASE("The device walk is depth-first in element order", "[chain-walk]") {
+    auto& tm = TrackManager::getInstance();
+    tm.clearAllTracks();
+
+    // Track: A, Rack[ chain1: B, Rack[ chain: C ]; chain2: D ], E
+    const auto trackId = tm.createTrack("Track");
+    tm.addDeviceToTrack(trackId, effect("A"));
+    const auto rackId = tm.addRackToTrack(trackId, "Outer");
+    tm.addDeviceToTrack(trackId, effect("E"));
+
+    const auto rackPath = ChainNodePath::rack(trackId, rackId);
+    const auto chainOne = tm.addChainToRack(rackPath);
+    const auto chainTwo = tm.addChainToRack(rackPath);
+    tm.addDeviceToChainByPath(rackPath.withChain(chainOne), effect("B"));
+    const auto innerId = tm.addRackToChainByPath(rackPath.withChain(chainOne), "Inner");
+    const auto innerPath = rackPath.withChain(chainOne).withRack(innerId);
+    tm.addDeviceToChainByPath(innerPath.withChain(tm.addChainToRack(innerPath)), effect("C"));
+    tm.addDeviceToChainByPath(rackPath.withChain(chainTwo), effect("D"));
+
+    const auto* track = tm.getTrack(trackId);
+    REQUIRE(track != nullptr);
+
+    std::vector<juce::String> visited;
+    chain_walk::forEachDevice(track->chain.fxChainElements, ChainNodePath::trackLevel(trackId),
+                              chain_walk::Pads::Skip,
+                              [&visited](const DeviceInfo& device, const ChainNodePath&) {
+                                  visited.push_back(device.name);
+                              });
+
+    // Depth-first and pre-order: the rack's contents come between the elements
+    // standing either side of it, and the nested rack's device comes before the
+    // outer rack's second chain.
+    CHECK(order(visited) == "A,B,C,D,E");
+
+    tm.clearAllTracks();
+}
+
+TEST_CASE("The device walk spells a top-level device the way everything else stores it",
+          "[chain-walk]") {
+    // The reason the walk builds the path rather than the caller: at the top
+    // level a device's id lives in `topLevelDeviceId` rather than in a step, so
+    // `withDevice()` would name the same device with a path that compares equal
+    // to nothing the model holds.
+    auto& tm = TrackManager::getInstance();
+    tm.clearAllTracks();
+
+    const auto trackId = tm.createTrack("Track");
+    const auto topId = tm.addDeviceToTrack(trackId, effect("Top"));
+    const auto rackId = tm.addRackToTrack(trackId, "Rack");
+    const auto rackPath = ChainNodePath::rack(trackId, rackId);
+    const auto chainId = tm.addChainToRack(rackPath);
+    const auto nestedId = tm.addDeviceToChainByPath(rackPath.withChain(chainId), effect("Nested"));
+
+    const auto* track = tm.getTrack(trackId);
+    REQUIRE(track != nullptr);
+
+    std::vector<ChainNodePath> paths;
+    chain_walk::forEachDevice(
+        track->chain.fxChainElements, ChainNodePath::trackLevel(trackId), chain_walk::Pads::Skip,
+        [&paths](const DeviceInfo&, const ChainNodePath& path) { paths.push_back(path); });
+
+    REQUIRE(paths.size() == 2);
+    CHECK(paths[0] == ChainNodePath::topLevelDevice(trackId, topId));
+    CHECK(paths[1] == rackPath.withChain(chainId).withDevice(nestedId));
+
+    // The other spelling names the same device and is a different path, which
+    // is the trap the walk exists to close.
+    CHECK_FALSE(paths[0] == ChainNodePath::trackLevel(trackId).withDevice(topId));
+
+    tm.clearAllTracks();
+}
+
+TEST_CASE("A device's pads are walked after it, and only when asked for", "[chain-walk]") {
+    auto& tm = TrackManager::getInstance();
+    tm.clearAllTracks();
+
+    const auto trackId = tm.createTrack("Track");
+    const auto gridId = tm.addDeviceToTrack(trackId, drumGrid("Grid"));
+    tm.addDeviceToTrack(trackId, effect("After"));
+
+    const auto gridPath = ChainNodePath::topLevelDevice(trackId, gridId);
+    const auto padChainId = tm.ensurePad(gridPath, 0);
+    REQUIRE(padChainId != INVALID_CHAIN_ID);
+    REQUIRE(tm.addDeviceToPad(gridPath, padChainId, effect("OnPad")) != INVALID_DEVICE_ID);
+
+    const auto* track = tm.getTrack(trackId);
+    REQUIRE(track != nullptr);
+
+    auto walk = [&](chain_walk::Pads pads) {
+        std::vector<juce::String> visited;
+        chain_walk::forEachDevice(track->chain.fxChainElements, ChainNodePath::trackLevel(trackId),
+                                  pads, [&visited](const DeviceInfo& device, const ChainNodePath&) {
+                                      visited.push_back(device.name);
+                                  });
+        return order(visited);
+    };
+
+    // A device is not a leaf when it owns pads, and its pads come after it and
+    // before whatever stands next to it, like a rack's chains do.
+    CHECK(walk(chain_walk::Pads::Enter) == "Grid,OnPad,After");
+    CHECK(walk(chain_walk::Pads::Skip) == "Grid,After");
+
+    tm.clearAllTracks();
+}
+
+TEST_CASE("A pad device is addressed off the track by its grid's id", "[chain-walk]") {
+    auto& tm = TrackManager::getInstance();
+    tm.clearAllTracks();
+
+    const auto trackId = tm.createTrack("Track");
+    const auto gridId = tm.addDeviceToTrack(trackId, drumGrid("Grid"));
+    const auto gridPath = ChainNodePath::topLevelDevice(trackId, gridId);
+    const auto padChainId = tm.ensurePad(gridPath, 0);
+    const auto padDeviceId = tm.addDeviceToPad(gridPath, padChainId, effect("OnPad"));
+    REQUIRE(padDeviceId != INVALID_DEVICE_ID);
+
+    const auto* track = tm.getTrack(trackId);
+    REQUIRE(track != nullptr);
+
+    std::vector<ChainNodePath> paths;
+    chain_walk::forEachDevice(
+        track->chain.fxChainElements, ChainNodePath::trackLevel(trackId), chain_walk::Pads::Enter,
+        [&paths](const DeviceInfo&, const ChainNodePath& path) { paths.push_back(path); });
+
+    REQUIRE(paths.size() == 2);
+    CHECK(paths[1] == ChainNodePath::padChain(trackId, gridId, padChainId).withDevice(padDeviceId));
+
+    tm.clearAllTracks();
+}
+
+TEST_CASE("The rack walk is outermost first and can prune", "[chain-walk]") {
+    auto& tm = TrackManager::getInstance();
+    tm.clearAllTracks();
+
+    const auto trackId = tm.createTrack("Track");
+    const auto outerId = tm.addRackToTrack(trackId, "Outer");
+    const auto outerPath = ChainNodePath::rack(trackId, outerId);
+    const auto chainId = tm.addChainToRack(outerPath);
+    const auto innerId = tm.addRackToChainByPath(outerPath.withChain(chainId), "Inner");
+    REQUIRE(innerId != INVALID_RACK_ID);
+
+    const auto* track = tm.getTrack(trackId);
+    REQUIRE(track != nullptr);
+
+    std::vector<juce::String> visited;
+    chain_walk::forEachRack(
+        track->chain.fxChainElements, ChainNodePath::trackLevel(trackId), chain_walk::Pads::Skip,
+        [&visited](const RackInfo& rack, const ChainNodePath&) { visited.push_back(rack.name); });
+
+    CHECK(order(visited) == "Outer,Inner");
+
+    tm.clearAllTracks();
+}

--- a/tests/test_chain_walk.cpp
+++ b/tests/test_chain_walk.cpp
@@ -367,3 +367,80 @@ TEST_CASE("Duplicating a track addresses the copy's pads the typed way", "[chain
 
     tm.clearAllTracks();
 }
+
+TEST_CASE("A moved grid's pad device keeps its own links pointing at itself",
+          "[chain-walk][links]") {
+    // The links a moved device OWNS are retargeted onto its new address, by a
+    // second descent over what arrived. That one skipped pads too, so a
+    // modifier on a pad device pointing at its own parameter went on naming the
+    // track the grid came from (#2204).
+    auto& tm = TrackManager::getInstance();
+    tm.clearAllTracks();
+
+    const auto source = tm.createTrack("Source");
+    const auto destination = tm.createTrack("Destination");
+
+    const auto gridId = tm.addDeviceToTrack(source, drumGrid("Grid"));
+    const auto gridPath = ChainNodePath::topLevelDevice(source, gridId);
+    const auto padChainId = tm.ensurePad(gridPath, 0);
+    const auto padDeviceId = tm.addDeviceToPad(gridPath, padChainId, effect("OnPad"));
+    REQUIRE(padDeviceId != INVALID_DEVICE_ID);
+
+    const auto before = ChainNodePath::padChain(source, gridId, padChainId).withDevice(padDeviceId);
+    auto* padDevice = tm.getDeviceInChainByPath(before);
+    REQUIRE(padDevice != nullptr);
+    padDevice->mods.push_back(ModInfo(0));
+    padDevice->mods.back().links.push_back(
+        ModLink{ControlTarget::pluginParam(before, 0), 1.0f, true});
+
+    REQUIRE(tm.moveChainElement(gridPath, ChainNodePath::trackLevel(destination), 0));
+
+    const auto after =
+        ChainNodePath::padChain(destination, gridId, padChainId).withDevice(padDeviceId);
+    const auto* moved = tm.getDeviceInChainByPath(after);
+    REQUIRE(moved != nullptr);
+    REQUIRE_FALSE(moved->mods.empty());
+    REQUIRE_FALSE(moved->mods.front().links.empty());
+
+    CHECK(moved->mods.front().links.front().target.devicePath == after);
+
+    tm.clearAllTracks();
+}
+
+TEST_CASE("A pad device left behind loses its link to a device that moved away",
+          "[chain-walk][links]") {
+    // The mirror: the source track drops links naming a device that left, by a
+    // descent that also skipped pads. A pad device staying put kept a link to
+    // something no longer on its track.
+    auto& tm = TrackManager::getInstance();
+    tm.clearAllTracks();
+
+    const auto source = tm.createTrack("Source");
+    const auto destination = tm.createTrack("Destination");
+
+    const auto gridId = tm.addDeviceToTrack(source, drumGrid("Stays"));
+    const auto gridPath = ChainNodePath::topLevelDevice(source, gridId);
+    const auto padChainId = tm.ensurePad(gridPath, 0);
+    const auto padDeviceId = tm.addDeviceToPad(gridPath, padChainId, effect("OnPad"));
+    REQUIRE(padDeviceId != INVALID_DEVICE_ID);
+
+    const auto leavingId = tm.addDeviceToTrack(source, effect("Leaves"));
+    const auto leavingPath = ChainNodePath::topLevelDevice(source, leavingId);
+
+    const auto padDevicePath =
+        ChainNodePath::padChain(source, gridId, padChainId).withDevice(padDeviceId);
+    auto* padDevice = tm.getDeviceInChainByPath(padDevicePath);
+    REQUIRE(padDevice != nullptr);
+    padDevice->mods.push_back(ModInfo(0));
+    padDevice->mods.back().links.push_back(
+        ModLink{ControlTarget::pluginParam(leavingPath, 0), 1.0f, true});
+
+    REQUIRE(tm.moveChainElement(leavingPath, ChainNodePath::trackLevel(destination), 0));
+
+    const auto* stayed = tm.getDeviceInChainByPath(padDevicePath);
+    REQUIRE(stayed != nullptr);
+    REQUIRE_FALSE(stayed->mods.empty());
+    CHECK(stayed->mods.front().links.empty());
+
+    tm.clearAllTracks();
+}

--- a/tests/test_chain_walk.cpp
+++ b/tests/test_chain_walk.cpp
@@ -2,7 +2,10 @@
 #include <string>
 
 #include "magda/daw/core/ChainWalk.hpp"
+#include "magda/daw/core/ControlTarget.hpp"
 #include "magda/daw/core/DrumGridPads.hpp"
+#include "magda/daw/core/MacroInfo.hpp"
+#include "magda/daw/core/ModInfo.hpp"
 #include "magda/daw/core/TrackManager.hpp"
 
 using namespace magda;
@@ -115,6 +118,22 @@ TEST_CASE("The device walk spells a top-level device the way everything else sto
     CHECK_FALSE(paths[0] == ChainNodePath::trackLevel(trackId).withDevice(topId));
 
     tm.clearAllTracks();
+}
+
+TEST_CASE("A device's address survives a round trip through its parent", "[chain-walk]") {
+    // deviceIn() has to agree with parentChain() about how the track's own list
+    // is spelled, or a caller that has a device path, takes its parent and asks
+    // for the device back gets a different path naming the same device.
+    // parentChain() leaves isTrackLevel unset, so keying on that flag broke
+    // exactly this (#2204).
+    const auto topLevel = ChainNodePath::topLevelDevice(7, 3);
+    CHECK(chain_walk::deviceIn(topLevel.parentChain(), 3) == topLevel);
+
+    const auto nested = ChainNodePath::rack(7, 1).withChain(2).withDevice(3);
+    CHECK(chain_walk::deviceIn(nested.parentChain(), 3) == nested);
+
+    const auto onPad = ChainNodePath::padChain(7, 3, 4).withDevice(5);
+    CHECK(chain_walk::deviceIn(onPad.parentChain(), 5) == onPad);
 }
 
 TEST_CASE("A device's pads are walked after it, and only when asked for", "[chain-walk]") {
@@ -241,6 +260,110 @@ TEST_CASE("The rack walk is outermost first and can prune", "[chain-walk]") {
         [&visited](const RackInfo& rack, const ChainNodePath&) { visited.push_back(rack.name); });
 
     CHECK(order(visited) == "Outer,Inner");
+
+    tm.clearAllTracks();
+}
+
+// ============================================================================
+// What the descent covering pads is worth, at the two places it did not.
+//
+// Each becomes wrong the moment a pad device owns the thing being collected,
+// and nothing says so -- the trap #2204 describes. Both were found by putting
+// the walks named in that issue onto one descent and asking each what it does
+// about pads.
+// ============================================================================
+
+TEST_CASE("Moving a Drum Grid off a track drops that track's links into its pads",
+          "[chain-walk][links]") {
+    // A move looks every device it carried up in a map the descent built, and
+    // for a cross-track move drops the source track's links to them: a track
+    // macro cannot reach into another track. That descent stopped at the grid,
+    // so a link into one of its pads was never in the map and survived,
+    // pointing at a device the track no longer holds.
+    auto& tm = TrackManager::getInstance();
+    tm.clearAllTracks();
+
+    const auto source = tm.createTrack("Source");
+    const auto destination = tm.createTrack("Destination");
+
+    const auto gridId = tm.addDeviceToTrack(source, drumGrid("Grid"));
+    const auto gridPath = ChainNodePath::topLevelDevice(source, gridId);
+    const auto padChainId = tm.ensurePad(gridPath, 0);
+    REQUIRE(padChainId != INVALID_CHAIN_ID);
+    const auto padDeviceId = tm.addDeviceToPad(gridPath, padChainId, effect("OnPad"));
+    REQUIRE(padDeviceId != INVALID_DEVICE_ID);
+
+    const auto padDevicePath =
+        ChainNodePath::padChain(source, gridId, padChainId).withDevice(padDeviceId);
+
+    // A track macro driving a parameter of the device on the pad.
+    auto* sourceTrack = tm.getTrack(source);
+    REQUIRE(sourceTrack != nullptr);
+    sourceTrack->macros[0].links.push_back(
+        MacroLink{ControlTarget::pluginParam(padDevicePath, 0), 1.0f, true});
+
+    REQUIRE(tm.getTrack(source)->macros[0].links.size() == 1);
+    REQUIRE(tm.moveChainElement(gridPath, ChainNodePath::trackLevel(destination), 0));
+
+    CHECK(tm.getTrack(source)->macros[0].links.empty());
+
+    // And the grid really did move, so the link had nothing left to name.
+    CHECK(tm.getDeviceInChainByPath(
+              ChainNodePath::padChain(destination, gridId, padChainId).withDevice(padDeviceId)) !=
+          nullptr);
+
+    tm.clearAllTracks();
+}
+
+TEST_CASE("Duplicating a track addresses the copy's pads the typed way", "[chain-walk][links]") {
+    // The duplicate remaps every link it copies onto the new track's ids, and
+    // built a pad address as `Rack(deviceId) > Chain(padId)` -- the untyped
+    // spelling #2219 removed. A rack step carrying a DeviceId resolves down the
+    // rack walk, which no pad answers to, so the link named nothing.
+    auto& tm = TrackManager::getInstance();
+    tm.clearAllTracks();
+
+    const auto source = tm.createTrack("Source");
+    const auto gridId = tm.addDeviceToTrack(source, drumGrid("Grid"));
+    const auto gridPath = ChainNodePath::topLevelDevice(source, gridId);
+    const auto padChainId = tm.ensurePad(gridPath, 0);
+    const auto padDeviceId = tm.addDeviceToPad(gridPath, padChainId, effect("OnPad"));
+    REQUIRE(padDeviceId != INVALID_DEVICE_ID);
+
+    auto* padDevice = tm.getDeviceInChainByPath(
+        ChainNodePath::padChain(source, gridId, padChainId).withDevice(padDeviceId));
+    REQUIRE(padDevice != nullptr);
+    // A mod link with no path of its own: the remap stamps the owner's address
+    // into it, which is the one place the pad address the duplicate builds is
+    // actually consumed. A link that already carries a path is remapped by id
+    // instead and never sees it.
+    // A device starts with no modifiers (`createDefaultMods(0)`), so one is
+    // added before it can carry a link.
+    padDevice->mods.push_back(ModInfo(0));
+    padDevice->mods.back().links.push_back(
+        ModLink{ControlTarget::modParam(ChainNodePath{}, 0, 0), 1.0f, true});
+
+    const auto copy = tm.duplicateTrack(source);
+    REQUIRE(copy != INVALID_TRACK_ID);
+
+    // Whatever ids the copy got, the link its pad device holds has to name
+    // something the model can resolve.
+    const auto* copyTrack = tm.getTrack(copy);
+    REQUIRE(copyTrack != nullptr);
+    REQUIRE(copyTrack->chain.fxChainElements.size() == 1);
+    const auto& copiedGrid = getDevice(copyTrack->chain.fxChainElements.front());
+    REQUIRE(copiedGrid.pads);
+    REQUIRE_FALSE(copiedGrid.pads->chains.empty());
+
+    const auto& copiedPad = copiedGrid.pads->chains.front();
+    REQUIRE_FALSE(copiedPad.elements.empty());
+    const auto& copiedPadDevice = getDevice(copiedPad.elements.front());
+    REQUIRE_FALSE(copiedPadDevice.mods.empty());
+    REQUIRE_FALSE(copiedPadDevice.mods.front().links.empty());
+
+    const auto& target = copiedPadDevice.mods.front().links.front().target.devicePath;
+    CHECK(target.isPadOwned());
+    CHECK(tm.getDeviceInChainByPath(target) != nullptr);
 
     tm.clearAllTracks();
 }

--- a/tests/test_chain_walk.cpp
+++ b/tests/test_chain_walk.cpp
@@ -175,6 +175,52 @@ TEST_CASE("A pad device is addressed off the track by its grid's id", "[chain-wa
     tm.clearAllTracks();
 }
 
+TEST_CASE("A pad rack is a rack the walk yields", "[chain-walk]") {
+    // A pad rack is a RackInfo hanging off a device rather than sitting in the
+    // chain as an element, so a walk that only descended into its chains would
+    // hand a rack visitor every rack but this one. It carries mute, solo and a
+    // fader like any other, which is what PlanValues looks it up for, and a
+    // consumer migrating to the walk would have lost it silently (#2204).
+    auto& tm = TrackManager::getInstance();
+    tm.clearAllTracks();
+
+    const auto trackId = tm.createTrack("Track");
+    tm.addRackToTrack(trackId, "Ordinary");
+    const auto gridId = tm.addDeviceToTrack(trackId, drumGrid("Grid"));
+    const auto gridPath = ChainNodePath::topLevelDevice(trackId, gridId);
+    REQUIRE(tm.ensurePad(gridPath, 0) != INVALID_CHAIN_ID);
+
+    const auto* track = tm.getTrack(trackId);
+    REQUIRE(track != nullptr);
+
+    auto walk = [&](chain_walk::Pads pads) {
+        std::vector<juce::String> visited;
+        chain_walk::forEachRack(track->chain.fxChainElements, ChainNodePath::trackLevel(trackId),
+                                pads, [&visited](const RackInfo& rack, const ChainNodePath&) {
+                                    visited.push_back(rack.name);
+                                });
+        return visited;
+    };
+
+    const auto entered = walk(chain_walk::Pads::Enter);
+    REQUIRE(entered.size() == 2);
+    CHECK(entered[0] == "Ordinary");
+    CHECK(isPadRackId(tm.getPads(gridPath)->id));
+
+    CHECK(walk(chain_walk::Pads::Skip).size() == 1);
+
+    // Addressed by the owning device's path: a bare PadRack step is not a valid
+    // address, and every pad API takes the grid's path and builds the rest.
+    std::vector<ChainNodePath> rackPaths;
+    chain_walk::forEachRack(
+        track->chain.fxChainElements, ChainNodePath::trackLevel(trackId), chain_walk::Pads::Enter,
+        [&rackPaths](const RackInfo&, const ChainNodePath& path) { rackPaths.push_back(path); });
+    REQUIRE(rackPaths.size() == 2);
+    CHECK(rackPaths[1] == gridPath);
+
+    tm.clearAllTracks();
+}
+
 TEST_CASE("The rack walk is outermost first and can prune", "[chain-walk]") {
     auto& tm = TrackManager::getInstance();
     tm.clearAllTracks();


### PR DESCRIPTION
Closes #2204.

"The devices in this chain" was implemented separately in a dozen places under a dozen names. Adding a container to the model meant finding each one by hand, with no compiler error and no test that caught a miss: every finding on #2200 was a walk that had not been updated, and each was a silent wrong render rather than a failure.

`ChainWalk.hpp` is one recursion with three faces. `forEachNode` visits devices and racks in a single pre-order pass; `forEachDevice` and `forEachRack` are the common cases; `findDevice` and `findRack` stop where they find, because several of these were searches rather than sweeps.

Two things come with the descent, and they are why it is worth sharing rather than repeating.

**The path.** A top-level device is addressed by `topLevelDevice()`, which puts the id in its own field rather than in a step, so a walk reaching for `withDevice()` at the top level builds a path naming the same device that compares equal to nothing the model holds. Six sites carried an `isTrackLevel` ternary by hand for this.

**The pads.** A pad-per-chain device owns chains of its own (#2207), so a device is not always a leaf. Whether to descend is a real question with different right answers per caller -- the plan expands them, gain staging does not -- so `Pads::Skip` / `Pads::Enter` is asked explicitly and has no default.

`owningRackId()` is the identity half of the issue: the innermost rack a device stands in, or the Drum Grid whose pad holds it. The plan, the parameter table and the runtime store each derived this from their own walk.

## The list, reclassified

Eleven walks are on the shared descent. The issue's dozen turns out to include four that should not be:

**Not chain walks.** `DawProjectXmlAdapter::collectExportableDevices` deliberately does not descend -- "Racks (parallel routing) are intentionally not descended into" -- and is a flat scan of the top level. `ModulationBakeAction::collectFromScope` iterates a `ModArray` for one already-known scope.

**Folds, not traversals, and they opt out with the reason written down.** `PlanCompiler::emitElements` threads a `ChainSignal` in and returns one, and its descent is conditional on routing: an aux-routed chain is diagnosed and skipped. `PlanValues::collectSilencedRacks` inherits an `insideInactiveChain` decided per chain on the way down.

`ParamTableCompiler` is the one that had to move for the abstraction to be worth having -- it produced two of the four #2200 findings. Its cycle guard prunes through `Descend::Skip`, and the walk runs its rack exit from a destructor so a prune still unwinds `RackNesting` rather than leaving a rack open to refuse its own later siblings. `RackNesting` grew `open`/`close` beside `Scope` for that, and `close` matches by identity rather than popping blindly.

## What the sweep found

Four defects, none visible from inside any single walk. Each is the shape the issue predicts: wrong the moment a pad device owns the thing being collected, with nothing to say so.

**A grid moved to another track left the old track's links into its pads dangling.** A move looks every device it carried up in a map the descent built, and drops the source track's links to them, because a track macro cannot reach into another track. The descent stopped at the grid, so a pad device was never in the map. Only a cross-track move can do this: a pad address is rooted at the track and names the grid by `DeviceId`, so a same-track move leaves it unchanged.

**A duplicated track built pad addresses as `Rack(deviceId) > Chain(padId)`,** the untyped spelling #2219 removed. It is consumed only for a mod link carrying no path of its own, which the remap stamps the owner's address into, so a duplicated pad device's self-targeted modifier named a rack step holding a `DeviceId` -- resolving down a rack walk no pad answers to.

**`findUniqueBareDeviceIdMatch` could answer "unique" for an id two devices hold,** because its walk skipped pads. It enters them now. A semantics change rather than a refactor.

**A pad rack is a rack the walk was not yielding.** It is a `RackInfo` hanging off a device rather than a chain element, so `forEachRack` handed a visitor every rack but that one -- a consumer migrating would have lost pad racks silently, which is the failure mode this file exists to stop. `PlanValues` looks one up for its mute, solo and fader. It is visited under `Pads::Enter` now, addressed by the owning device's path, because a bare `PadRack` step is not a valid address: `parseChainNodePath()` refuses one.

Two more found by using the new API rather than reading it. `deviceIn()` keyed on `isTrackLevel`, but `parentChain()` returns the track's own list with that flag unset, so `deviceIn(path.parentChain(), id) == path` did not hold for a top-level device and the first caller needing it would have built the other spelling silently; it keys on the absence of steps now. And `extendedWith()` cleared `isTrackLevel` but not `topLevelDeviceId`, so extending a top-level-device path built the multi-representation shape `parseChainNodePath()` refuses to load as corrupt -- #2230 fixed one of the two.

## Also settled

The issue's part 3 asks to decide what a pad's model is. #2207 already settled it in favour of the model: `DeviceInfo::padRack` is gone, `DeviceInfo::pads` is authoritative, and nothing reads pads back out of the plugin, so the two-copies problem that section describes no longer exists.

## Testing

Eleven cases in `test_chain_walk.cpp`. The order is pinned rather than trusted to the recursion -- a tree of `A, Rack[chain1: B, Rack[C]; chain2: D], E` visits `A,B,C,D,E`, and a grid with a pad device visits `Grid,OnPad,After` under `Pads::Enter` -- because the gain-staging cascade reads its devices in signal order and the bypass sweep announces paths in the order it touched them. The spellings are pinned too: a top-level device comes out the way everything else stores it and explicitly not the other way, a pad device is addressed off the track by its grid, and a device's address survives a round trip through its parent at all three depths. Two more cover the move and duplicate defects.

Full Catch2 suite green (627,485 assertions, 3,099 cases) and `magda_juce_tests` green.

https://claude.ai/code/session_0187yiSdSJPmDFZafrSfbSop
