### PR TITLE
Step a clip drag over a lane it cannot land on (#2179)

### DIFF
--- a/magda/daw/ui/components/clips/ClipComponent.cpp
+++ b/magda/daw/ui/components/clips/ClipComponent.cpp
@@ -1666,6 +1666,13 @@ void ClipComponent::mouseDown(const juce::MouseEvent& e) {
     dragStartTrackId_ = clip->trackId;
     dragStartAudioOffset_ = magda::audioEventRef(*clip).anchorSeconds();
 
+    // Which lanes this drag may land on (#2179), worked out once here rather
+    // than per frame. A multi-clip drag replaces it in startMultiClipDrag with
+    // the whole selection's answer; this covers the single-clip case, which is
+    // the panel's only way to know a drag has begun.
+    if (parentPanel_)
+        parentPanel_->beginClipDragTargets({clipId_}, clipId_);
+
     // Cache file duration for resize clamping
     dragStartFileDuration_ = 0.0;
     if (clip->isAudio() && magda::audioEventRef(*clip).sourceFilePath().isNotEmpty()) {
@@ -2008,7 +2015,8 @@ void ClipComponent::mouseDrag(const juce::MouseEvent& e) {
                     int ghostH = getHeight();
                     const int localY =
                         e.getScreenPosition().y - parentPanel_->getScreenBounds().getPosition().y;
-                    const int trackIndex = parentPanel_->getTrackIndexAtY(localY);
+                    const int trackIndex = parentPanel_->clipDragTargetLane(
+                        dragStartTrackId_, parentPanel_->clipDragSlotDelta(localY));
                     if (trackIndex >= 0) {
                         ghostY = parentPanel_->getTrackYPosition(trackIndex);
                         ghostH = parentPanel_->getTrackTotalHeight(trackIndex);
@@ -2027,32 +2035,29 @@ void ClipComponent::mouseDrag(const juce::MouseEvent& e) {
                 int newWidth = static_cast<int>(std::round(lengthBeats * pixelsPerBeat));
                 setBounds(newX, getY(), juce::jmax(10, newWidth), getHeight());
 
-                // Show ghost on target track when dragging across tracks
+                // Show ghost on the track the drop will actually use, which is
+                // the nearest lane that can hold this clip rather than whichever
+                // one the pointer is over (#2179). Resolved through the panel so
+                // the ghost and the mouseUp commit cannot disagree.
                 auto screenPos = e.getScreenPosition();
                 auto parentPos = parentPanel_->getScreenBounds().getPosition();
                 int localY = screenPos.y - parentPos.y;
-                int trackIndex = parentPanel_->getTrackIndexAtY(localY);
+                const int slotDelta = parentPanel_->clipDragSlotDelta(localY);
+                const int trackIndex =
+                    parentPanel_->clipDragTargetLane(dragStartTrackId_, slotDelta);
 
-                if (trackIndex >= 0) {
-                    auto visibleTracks = TrackManager::getInstance().getVisibleTracks(
-                        ViewModeController::getInstance().getViewMode());
-
-                    if (trackIndex < static_cast<int>(visibleTracks.size()) &&
-                        visibleTracks[trackIndex] != dragStartTrackId_) {
-                        // Over a different track — show ghost
-                        int targetY = parentPanel_->getTrackYPosition(trackIndex);
-                        int targetH = parentPanel_->getTrackTotalHeight(trackIndex);
-                        const auto* clip = getClipInfo();
-                        juce::Rectangle<int> ghostBounds(newX, targetY, juce::jmax(10, newWidth),
-                                                         targetH);
-                        parentPanel_->setClipGhost(clipId_, ghostBounds,
-                                                   clip ? clip->colour : juce::Colours::grey);
-                    } else {
-                        // Back on source track — clear ghost
-                        parentPanel_->clearClipGhost(clipId_);
-                    }
+                if (trackIndex >= 0 && parentPanel_->clipDragTargetTrackId(
+                                           dragStartTrackId_, slotDelta) != dragStartTrackId_) {
+                    // Landing somewhere else — show ghost
+                    int targetY = parentPanel_->getTrackYPosition(trackIndex);
+                    int targetH = parentPanel_->getTrackTotalHeight(trackIndex);
+                    const auto* clip = getClipInfo();
+                    juce::Rectangle<int> ghostBounds(newX, targetY, juce::jmax(10, newWidth),
+                                                     targetH);
+                    parentPanel_->setClipGhost(clipId_, ghostBounds,
+                                               clip ? clip->colour : juce::Colours::grey);
                 } else {
-                    // Outside any track — clear ghost
+                    // Staying on the source track — no ghost to draw
                     parentPanel_->clearClipGhost(clipId_);
                 }
             }
@@ -2549,22 +2554,19 @@ void ClipComponent::mouseUp(const juce::MouseEvent& e) {
                 }
                 finalStartTime = juce::jmax(0.0, finalStartTime);
 
-                // Determine target track
+                // Determine target track — the same resolution the ghost used,
+                // so the lane under the ghost at the moment of release is the
+                // lane the clip lands on (#2179).
                 TrackId targetTrackId = dragStartTrackId_;
                 if (parentPanel_) {
                     auto screenPos = e.getScreenPosition();
                     auto parentPos = parentPanel_->getScreenBounds().getPosition();
                     int localY = screenPos.y - parentPos.y;
-                    int trackIndex = parentPanel_->getTrackIndexAtY(localY);
-
-                    if (trackIndex >= 0) {
-                        auto visibleTracks = TrackManager::getInstance().getVisibleTracks(
-                            ViewModeController::getInstance().getViewMode());
-
-                        if (trackIndex < static_cast<int>(visibleTracks.size())) {
-                            targetTrackId = visibleTracks[trackIndex];
-                        }
-                    }
+                    targetTrackId = parentPanel_->clipDragTargetTrackId(
+                        dragStartTrackId_, parentPanel_->clipDragSlotDelta(localY));
+                    // Nothing below reads them, and the commit can destroy this
+                    // component before any later exit could clear them.
+                    parentPanel_->endClipDragTargets();
                 }
 
                 if (isDuplicating_) {

--- a/magda/daw/ui/components/tracks/TrackContentPanel.hpp
+++ b/magda/daw/ui/components/tracks/TrackContentPanel.hpp
@@ -145,6 +145,13 @@ class TrackContentPanel : public juce::Component,
     // Get track index at Y position (for drag-drop)
     int getTrackIndexAtY(int y) const;
 
+    /// The arrangement's lanes in display order. The index space every track
+    /// index in this class is expressed in, exposed so a caller can turn one
+    /// back into the track it names.
+    const std::vector<TrackId>& getVisibleTrackIds() const {
+        return visibleTrackIds_;
+    }
+
     // Automation lane management
     void showAutomationLane(TrackId trackId, AutomationLaneId laneId);
     void hideAutomationLane(TrackId trackId, AutomationLaneId laneId);
@@ -216,6 +223,35 @@ class TrackContentPanel : public juce::Component,
     void updateMultiClipDrag(const juce::Point<int>& currentPos);
     void finishMultiClipDrag();
 
+    // ------------------------------------------------------------------
+    // Clip drag destinations (#2179)
+    //
+    // One resolution of pointer Y to a landing lane, shared by the ghost and
+    // the commit, because a ghost that lands where the commit refuses is the
+    // bug this exists to end. Public for ClipComponent, which drives the
+    // single-clip drag and has to ask the same question the panel's own
+    // multi-clip drag asks.
+    //
+    // The set of lanes that can hold the selection is fixed for the length of
+    // the gesture -- the selection does not change mid-drag -- so it is
+    // computed once at drag start and every frame after that is a lookup.
+    // ------------------------------------------------------------------
+
+    /// Work out which lanes can hold @p movingClips, measured from @p anchorClipId.
+    void beginClipDragTargets(const std::vector<ClipId>& movingClips, ClipId anchorClipId);
+
+    /// Forget them. Safe to call when no drag is in progress.
+    void endClipDragTargets();
+
+    /// How many usable lanes the selection has travelled for a pointer at @p pointerY.
+    int clipDragSlotDelta(int pointerY) const;
+
+    /// Lane a clip from @p originalTrackId lands on; -1 when it cannot move.
+    int clipDragTargetLane(TrackId originalTrackId, int slotDelta) const;
+
+    /// The same destination as a track; @p originalTrackId when it cannot move.
+    TrackId clipDragTargetTrackId(TrackId originalTrackId, int slotDelta) const;
+
     // Lower-zone time selection: a ClipComponent hands its lower-half gestures
     // back to the panel so the existing time-selection machinery runs over the
     // clip (the panel's own mouse handlers are private). Events must already be
@@ -255,6 +291,11 @@ class TrackContentPanel : public juce::Component,
                       const juce::Colour& colour);
     void clearClipGhost(ClipId clipId);
     void clearAllClipGhosts();
+
+    /// Where @p clipId's ghost is being drawn, or an empty rectangle if it has
+    /// none. The preview a drag is showing, so a test can ask whether it agrees
+    /// with where the release actually puts the clip (#2179).
+    juce::Rectangle<int> getClipGhostBounds(ClipId clipId) const;
 
     TimelineController* getTimelineController() const {
         return timelineController;
@@ -477,9 +518,23 @@ class TrackContentPanel : public juce::Component,
     double multiClipDragStartTime_ = 0.0;
     double multiClipDragDeltaTime_ =
         0.0;  // Stored during drag, used at commit — no pixel round-trip
-    int multiClipDragAnchorTrackIndex_ = -1;  // Anchor clip's track index at drag start
-    int multiClipDragTrackDelta_ =
-        0;  // Track index offset, stored during drag — no pixel round-trip
+    // Offset in usable-lane slots rather than in raw track indices (#2179):
+    // one delta has to mean the same travel for every clip in the selection,
+    // and a lane the selection cannot land on is not travel. Stored during the
+    // drag and reused at commit — no pixel round-trip.
+    int multiClipDragSlotDelta_ = 0;
+
+    // Lanes this drag may land on, in display order, fixed at drag start.
+    // Empty means vertical movement is pinned: nothing in the stack can hold
+    // what is being dragged, which needs no case of its own.
+    std::vector<TrackId> clipDragHostTrackIds_;
+    std::vector<int> clipDragHostLanes_;  // their indices into visibleTrackIds_
+    int clipDragAnchorSlot_ = -1;         // where the gesture started, in slots
+    int clipDragMinSlot_ = 0;             // topmost and bottommost slots the
+    int clipDragMaxSlot_ = 0;             // selection occupies, for block clamping
+
+    /// Slot @p trackId occupies in the current drag's host set; -1 if it has none.
+    int clipDragSlotOfTrack(TrackId trackId) const;
 
     // Multi-clip Alt+drag duplicate state
     bool isMultiClipDuplicating_ = false;

--- a/magda/daw/ui/components/tracks/TrackContentPanel.hpp
+++ b/magda/daw/ui/components/tracks/TrackContentPanel.hpp
@@ -536,6 +536,11 @@ class TrackContentPanel : public juce::Component,
     /// Slot @p trackId occupies in the current drag's host set; -1 if it has none.
     int clipDragSlotOfTrack(TrackId trackId) const;
 
+    /// The row @p pointerY falls in, counting a track's automation lanes as part
+    /// of that track's row and clamping to the ends of the stack. -1 only when
+    /// there are no rows at all.
+    int clipDragRowAtY(int pointerY) const;
+
     // Multi-clip Alt+drag duplicate state
     bool isMultiClipDuplicating_ = false;
     bool isMultiClipGhosting_ = false;  // the copies join their sources' link groups

--- a/magda/daw/ui/components/tracks/TrackContentPanelClipDrag.cpp
+++ b/magda/daw/ui/components/tracks/TrackContentPanelClipDrag.cpp
@@ -4,6 +4,7 @@
 #include <algorithm>
 #include <limits>
 
+#include "../../interaction/ClipDragTargets.hpp"
 #include "../../interaction/ClipNudge.hpp"
 #include "../clips/ClipComponent.hpp"
 #include "TrackContentPanel.hpp"
@@ -37,6 +38,22 @@ double clipTimelineLengthBeats(const ClipInfo& clip, double bpm) {
         return clip.placement.lengthBeats;
     const double resolvedBpm = isValidBpm(bpm) ? bpm : DEFAULT_BPM;
     return clip.getTimelineLength(resolvedBpm) * resolvedBpm / 60.0;
+}
+
+// Tracks a move may put this selection on, which is the same question a file
+// drop, a keyboard nudge and a clip drag ask, of the same table
+// (TrackTypes.hpp).
+//
+// Asked with the selection in hand rather than of the track alone, because a
+// lane can accept one kind and not another: a multi-out lane takes MIDI, whose
+// notes play the parent instrument, and has nothing to do with audio. A mixed
+// selection therefore needs a track that accepts every kind in it, since a move
+// carries the selection as one block and cannot leave half of it behind.
+bool canHostClips(const TrackInfo& track, const std::vector<const ClipInfo*>& moving) {
+    for (const auto* clip : moving)
+        if (clip == nullptr || !trackAcceptsClip(track, *clip))
+            return false;
+    return !moving.empty();
 }
 
 }  // namespace
@@ -114,6 +131,130 @@ ClipComponent* TrackContentPanel::getClipComponentAt(int x, int y) const {
 }
 
 // ============================================================================
+// Clip Drag Destinations (#2179)
+// ============================================================================
+
+void TrackContentPanel::beginClipDragTargets(const std::vector<ClipId>& movingClips,
+                                             ClipId anchorClipId) {
+    endClipDragTargets();
+
+    auto& clipManager = ClipManager::getInstance();
+    auto& trackManager = TrackManager::getInstance();
+
+    // The clips themselves rather than their kinds: a chord lane takes a MIDI
+    // clip that is already a progression and not one that merely could have
+    // been, and a kind cannot tell those apart.
+    std::vector<const ClipInfo*> moving;
+    moving.reserve(movingClips.size());
+    for (const ClipId clipId : movingClips)
+        if (const auto* clip = clipManager.getClip(clipId))
+            moving.push_back(clip);
+    if (moving.empty())
+        return;
+
+    // Frozen tracks are excluded as destinations for the same reason they are
+    // refused as sources: dropping a clip into a frozen track's lane would put
+    // the model out of step with its rendered audio. Skipped rather than
+    // refused, so a frozen lane does not wall off the tracks below it -- which
+    // is the whole argument of this feature, applied to the one lane that had
+    // it written down first (nudgeSelectedClipsToAdjacentTrack).
+    for (int lane = 0; lane < static_cast<int>(visibleTrackIds_.size()); ++lane) {
+        const TrackId trackId = visibleTrackIds_[static_cast<size_t>(lane)];
+        const auto* track = trackManager.getTrack(trackId);
+        if (track == nullptr || track->frozen || !canHostClips(*track, moving))
+            continue;
+        clipDragHostLanes_.push_back(lane);
+        clipDragHostTrackIds_.push_back(trackId);
+    }
+
+    // Every clip in the selection needs a slot of its own, because the delta is
+    // measured from where each one starts. A selection with a clip on a lane
+    // that is not in the set cannot be given one consistently, so the drag
+    // keeps its vertical position instead of moving part of the selection.
+    int minSlot = std::numeric_limits<int>::max();
+    int maxSlot = std::numeric_limits<int>::min();
+    for (const auto* clip : moving) {
+        const int slot = clipDragSlotOfTrack(clip->trackId);
+        if (slot < 0) {
+            endClipDragTargets();
+            return;
+        }
+        minSlot = std::min(minSlot, slot);
+        maxSlot = std::max(maxSlot, slot);
+    }
+
+    clipDragMinSlot_ = minSlot;
+    clipDragMaxSlot_ = maxSlot;
+
+    // Measured from the anchor clip's own lane rather than from the pointer's,
+    // so a grab a pixel over a lane boundary does not start the gesture with a
+    // delta already in it.
+    const auto* anchor = clipManager.getClip(anchorClipId);
+    clipDragAnchorSlot_ = anchor != nullptr ? clipDragSlotOfTrack(anchor->trackId) : minSlot;
+    if (clipDragAnchorSlot_ < 0)
+        clipDragAnchorSlot_ = minSlot;
+}
+
+void TrackContentPanel::endClipDragTargets() {
+    clipDragHostTrackIds_.clear();
+    clipDragHostLanes_.clear();
+    clipDragAnchorSlot_ = -1;
+    clipDragMinSlot_ = 0;
+    clipDragMaxSlot_ = 0;
+}
+
+int TrackContentPanel::clipDragSlotOfTrack(TrackId trackId) const {
+    const auto it = std::find(clipDragHostTrackIds_.begin(), clipDragHostTrackIds_.end(), trackId);
+    if (it == clipDragHostTrackIds_.end())
+        return -1;
+    return static_cast<int>(std::distance(clipDragHostTrackIds_.begin(), it));
+}
+
+int TrackContentPanel::clipDragSlotDelta(int pointerY) const {
+    if (clipDragAnchorSlot_ < 0)
+        return 0;
+
+    // Outside the lanes entirely, the pointer counts as being at whichever end
+    // it left through: dragging off the top of the arrangement keeps travelling
+    // upwards rather than stalling on the last lane the pointer was over.
+    int lane = getTrackIndexAtY(pointerY);
+    if (lane < 0)
+        lane = pointerY <= 0 ? 0 : static_cast<int>(visibleTrackIds_.size()) - 1;
+
+    const int slot = interaction::nearestHostSlot(clipDragHostLanes_, lane);
+    if (slot < 0)
+        return 0;
+
+    return interaction::blockSlotDelta(slot - clipDragAnchorSlot_, clipDragMinSlot_,
+                                       clipDragMaxSlot_,
+                                       static_cast<int>(clipDragHostLanes_.size()));
+}
+
+int TrackContentPanel::clipDragTargetLane(TrackId originalTrackId, int slotDelta) const {
+    const int slot = clipDragSlotOfTrack(originalTrackId);
+    if (slot < 0)
+        return -1;
+
+    const int target = slot + slotDelta;
+    if (target < 0 || target >= static_cast<int>(clipDragHostLanes_.size()))
+        return -1;
+
+    return clipDragHostLanes_[static_cast<size_t>(target)];
+}
+
+TrackId TrackContentPanel::clipDragTargetTrackId(TrackId originalTrackId, int slotDelta) const {
+    const int slot = clipDragSlotOfTrack(originalTrackId);
+    if (slot < 0)
+        return originalTrackId;
+
+    const int target = slot + slotDelta;
+    if (target < 0 || target >= static_cast<int>(clipDragHostTrackIds_.size()))
+        return originalTrackId;
+
+    return clipDragHostTrackIds_[static_cast<size_t>(target)];
+}
+
+// ============================================================================
 // Multi-Clip Drag
 // ============================================================================
 
@@ -140,14 +281,15 @@ void TrackContentPanel::startMultiClipDrag(ClipId anchorClipId, const juce::Poin
     anchorClipId_ = anchorClipId;
     multiClipDragStartPos_ = startPos;
     multiClipDragDeltaTime_ = 0.0;
-    multiClipDragTrackDelta_ = 0;
+    multiClipDragSlotDelta_ = 0;
 
     // Get the anchor clip's start time and track index
     const auto* anchorClip = ClipManager::getInstance().getClip(anchorClipId);
     if (anchorClip) {
         multiClipDragStartTime_ = clipTimelineStart(*anchorClip, tempoBPM);
     }
-    multiClipDragAnchorTrackIndex_ = getTrackIndexAtY(startPos.y);
+    beginClipDragTargets(std::vector<ClipId>(selectedClips.begin(), selectedClips.end()),
+                         anchorClipId);
 
     // Store original positions of all selected clips
     multiClipDragInfos_.clear();
@@ -204,27 +346,27 @@ void TrackContentPanel::updateMultiClipDrag(const juce::Point<int>& currentPos) 
     multiClipDragDeltaTime_ =
         actualDeltaTime;  // Store for finishMultiClipDrag — no pixel round-trip
 
-    // Compute vertical (cross-track) delta from mouse Y
-    int currentTrackIndex = getTrackIndexAtY(currentPos.y);
-    if (currentTrackIndex < 0) {
-        // Mouse is outside track lanes — clamp based on direction
-        if (currentPos.y <= 0)
-            currentTrackIndex = 0;
-        else
-            currentTrackIndex = static_cast<int>(visibleTrackIds_.size()) - 1;
-    }
-    if (currentTrackIndex >= 0 && multiClipDragAnchorTrackIndex_ >= 0) {
-        multiClipDragTrackDelta_ = currentTrackIndex - multiClipDragAnchorTrackIndex_;
-    }
+    // Vertical travel, counted in lanes that can hold the selection rather than
+    // in lanes: a lane the drag cannot land on is stepped over, so it is not
+    // travel, and the same delta then means the same thing for every clip in
+    // the selection however the refusing lanes are distributed between them.
+    multiClipDragSlotDelta_ = clipDragSlotDelta(currentPos.y);
 
-    int numTracks = static_cast<int>(visibleTrackIds_.size());
+    // The ghost is drawn where the commit will put the clip, from the same
+    // resolution of the same pointer position, because a ghost that lands where
+    // the commit refuses is the defect this replaced. A clip with nowhere to go
+    // stays on its own lane.
+    const auto ghostLaneFor = [this](TrackId originalTrackId, int originalLane) {
+        const int lane = clipDragTargetLane(originalTrackId, multiClipDragSlotDelta_);
+        return lane >= 0 ? lane : originalLane;
+    };
 
     if (isMultiClipDuplicating_) {
         // Copy-on-drag: show ghosts at NEW positions, keep originals in place
         for (const auto& dragInfo : multiClipDragInfos_) {
             double newStartTime = juce::jmax(0.0, dragInfo.originalStartTime + actualDeltaTime);
-            int targetTrackIdx = juce::jlimit(
-                0, numTracks - 1, dragInfo.originalTrackIndex + multiClipDragTrackDelta_);
+            const int targetTrackIdx =
+                ghostLaneFor(dragInfo.originalTrackId, dragInfo.originalTrackIndex);
 
             const auto* clip = ClipManager::getInstance().getClip(dragInfo.clipId);
             if (clip) {
@@ -238,12 +380,12 @@ void TrackContentPanel::updateMultiClipDrag(const juce::Point<int>& currentPos) 
                              clip->colour);
             }
         }
-    } else if (multiClipDragTrackDelta_ != 0) {
+    } else if (multiClipDragSlotDelta_ != 0) {
         // Cross-track move: show ghosts on target track, keep originals in place
         for (const auto& dragInfo : multiClipDragInfos_) {
             double newStartTime = juce::jmax(0.0, dragInfo.originalStartTime + actualDeltaTime);
-            int targetTrackIdx = juce::jlimit(
-                0, numTracks - 1, dragInfo.originalTrackIndex + multiClipDragTrackDelta_);
+            const int targetTrackIdx =
+                ghostLaneFor(dragInfo.originalTrackId, dragInfo.originalTrackIndex);
             const auto* clip = ClipManager::getInstance().getClip(dragInfo.clipId);
             if (clip) {
                 int ghostX = beatsToPixel(newStartTime * tempoBPM / 60.0);
@@ -284,10 +426,9 @@ void TrackContentPanel::finishMultiClipDrag() {
 
     // Use the deltas stored during updateMultiClipDrag — never re-derive from pixels
     double actualDeltaTime = multiClipDragDeltaTime_;
-    int trackDelta = multiClipDragTrackDelta_;
-    int numTracks = static_cast<int>(visibleTrackIds_.size());
+    int slotDelta = multiClipDragSlotDelta_;
 
-    bool hasTrackChange = trackDelta != 0;
+    bool hasTrackChange = slotDelta != 0;
     bool isCompound = multiClipDragInfos_.size() > 1 || hasTrackChange;
     std::unordered_set<ClipId> duplicatedClipIds;
 
@@ -301,9 +442,7 @@ void TrackContentPanel::finishMultiClipDrag() {
         std::vector<std::unique_ptr<DuplicateClipCommand>> commands;
         for (const auto& dragInfo : multiClipDragInfos_) {
             double newStartTime = juce::jmax(0.0, dragInfo.originalStartTime + actualDeltaTime);
-            int targetIdx =
-                juce::jlimit(0, numTracks - 1, dragInfo.originalTrackIndex + trackDelta);
-            TrackId targetTrackId = visibleTrackIds_[static_cast<size_t>(targetIdx)];
+            TrackId targetTrackId = clipDragTargetTrackId(dragInfo.originalTrackId, slotDelta);
             const double bpm = getTempo();
             auto cmd = std::make_unique<DuplicateClipCommand>(
                 dragInfo.clipId, BeatPosition{newStartTime * bpm / 60.0}, targetTrackId, bpm, -1,
@@ -337,9 +476,7 @@ void TrackContentPanel::finishMultiClipDrag() {
             UndoManager::getInstance().executeCommand(std::move(cmd));
 
             // Move to new track if needed
-            int targetIdx =
-                juce::jlimit(0, numTracks - 1, dragInfo.originalTrackIndex + trackDelta);
-            TrackId targetTrackId = visibleTrackIds_[static_cast<size_t>(targetIdx)];
+            TrackId targetTrackId = clipDragTargetTrackId(dragInfo.originalTrackId, slotDelta);
             if (targetTrackId != dragInfo.originalTrackId) {
                 // Asked before the command is built, not because the command
                 // would let it through -- it refuses the same targets -- but
@@ -368,8 +505,8 @@ void TrackContentPanel::finishMultiClipDrag() {
     anchorClipId_ = INVALID_CLIP_ID;
     multiClipDragInfos_.clear();
     multiClipDuplicateIds_.clear();
-    multiClipDragAnchorTrackIndex_ = -1;
-    multiClipDragTrackDelta_ = 0;
+    multiClipDragSlotDelta_ = 0;
+    endClipDragTargets();
 
     // Refresh positions from ClipManager
     updateClipComponentPositions();
@@ -403,8 +540,8 @@ void TrackContentPanel::cancelMultiClipDrag() {
     anchorClipId_ = INVALID_CLIP_ID;
     multiClipDragInfos_.clear();
     multiClipDuplicateIds_.clear();
-    multiClipDragAnchorTrackIndex_ = -1;
-    multiClipDragTrackDelta_ = 0;
+    multiClipDragSlotDelta_ = 0;
+    endClipDragTargets();
 }
 
 // ============================================================================
@@ -412,21 +549,6 @@ void TrackContentPanel::cancelMultiClipDrag() {
 // ============================================================================
 
 namespace {
-
-// Tracks a nudge may move this selection onto, which is the same question a
-// file drop and a clip drag ask, of the same table (TrackTypes.hpp).
-//
-// Asked with the selection in hand rather than of the track alone, because a
-// lane can accept one kind and not another: a multi-out lane takes MIDI, whose
-// notes play the parent instrument, and has nothing to do with audio. A mixed
-// selection therefore needs a track that accepts every kind in it, since a
-// nudge moves the selection as one block and cannot leave half of it behind.
-bool canHostNudgedClips(const TrackInfo& track, const std::vector<const ClipInfo*>& moving) {
-    for (const auto* clip : moving)
-        if (clip == nullptr || !trackAcceptsClip(track, *clip))
-            return false;
-    return !moving.empty();
-}
 
 // The clips a nudge acts on: the arrangement half of the selection. Session
 // clips live in a scene grid, not on the timeline, and are left alone even
@@ -570,7 +692,7 @@ bool TrackContentPanel::nudgeSelectedClipsToAdjacentTrack(int direction) {
     std::vector<TrackId> hostTrackIds;
     for (TrackId trackId : visibleTrackIds_) {
         const auto* track = trackManager.getTrack(trackId);
-        if (track != nullptr && canHostNudgedClips(*track, moving) && !track->frozen)
+        if (track != nullptr && canHostClips(*track, moving) && !track->frozen)
             hostTrackIds.push_back(trackId);
     }
     if (hostTrackIds.size() < 2)
@@ -848,6 +970,13 @@ void TrackContentPanel::clearAllClipGhosts() {
         clipGhosts_.clear();
         repaintVisible();
     }
+}
+
+juce::Rectangle<int> TrackContentPanel::getClipGhostBounds(ClipId clipId) const {
+    for (const auto& ghost : clipGhosts_)
+        if (ghost.clipId == clipId)
+            return ghost.bounds;
+    return {};
 }
 
 void TrackContentPanel::paintClipGhosts(juce::Graphics& g) {

--- a/magda/daw/ui/components/tracks/TrackContentPanelClipDrag.cpp
+++ b/magda/daw/ui/components/tracks/TrackContentPanelClipDrag.cpp
@@ -210,16 +210,41 @@ int TrackContentPanel::clipDragSlotOfTrack(TrackId trackId) const {
     return static_cast<int>(std::distance(clipDragHostTrackIds_.begin(), it));
 }
 
+int TrackContentPanel::clipDragRowAtY(int pointerY) const {
+    if (trackLanes.empty())
+        return -1;
+    if (pointerY < 0)
+        return 0;
+
+    // getTrackIndexAtY answers with the track's own lane area and nothing else,
+    // so it says -1 both for a pointer below the arrangement and for one inside
+    // a track's automation lanes. A drag has to tell those apart: the second is
+    // a gap in the middle of the stack, and reading it as "below everything"
+    // would send the ghost to the bottom of the arrangement from a position the
+    // user is holding halfway up it. An automation lane belongs to the track it
+    // was opened under, so the row it falls in is that track's.
+    int currentY = 0;
+    for (size_t row = 0; row < trackLanes.size(); ++row) {
+        const int rowHeight = getTrackTotalHeight(static_cast<int>(row));
+        if (pointerY < currentY + rowHeight)
+            return static_cast<int>(row);
+        currentY += rowHeight;
+    }
+
+    // Genuinely past the end of the stack.
+    return static_cast<int>(trackLanes.size()) - 1;
+}
+
 int TrackContentPanel::clipDragSlotDelta(int pointerY) const {
     if (clipDragAnchorSlot_ < 0)
         return 0;
 
-    // Outside the lanes entirely, the pointer counts as being at whichever end
-    // it left through: dragging off the top of the arrangement keeps travelling
-    // upwards rather than stalling on the last lane the pointer was over.
-    int lane = getTrackIndexAtY(pointerY);
+    // Off either end of the arrangement the pointer counts as being at whichever
+    // end it left through, so a drag dragged past the top keeps travelling
+    // upwards rather than stalling on the last lane it was over.
+    const int lane = clipDragRowAtY(pointerY);
     if (lane < 0)
-        lane = pointerY <= 0 ? 0 : static_cast<int>(visibleTrackIds_.size()) - 1;
+        return 0;
 
     const int slot = interaction::nearestHostSlot(clipDragHostLanes_, lane);
     if (slot < 0)

--- a/magda/daw/ui/interaction/ClipDragTargets.hpp
+++ b/magda/daw/ui/interaction/ClipDragTargets.hpp
@@ -1,0 +1,72 @@
+#pragma once
+
+#include <algorithm>
+#include <vector>
+
+namespace magda::interaction {
+
+// ============================================================================
+// CLIP DRAG TARGETS (#2179)
+//
+// Where a clip drag may land. The mouse counterpart of ClipNudge: the pointer
+// moves over every lane in the stack, and only some of them can hold what is
+// being dragged, so the destination is resolved in the index space of the
+// lanes that can rather than in raw lane indices.
+//
+// Working in that space is what lets the ghost step over a refusing lane the
+// way the nudge already steps over one, and it is also what keeps a multi-clip
+// selection together: one delta in slot space moves every clip past the same
+// number of usable lanes, where one delta in lane space would move clips that
+// started either side of a refusing lane by different amounts.
+//
+// "Lane" here is an index into the visible track list; "slot" is an index into
+// the subset of those lanes that accept the whole selection. Plain integers in,
+// plain integers out — no components, no singletons — so the rules are
+// headless-testable (tests/test_clip_drag_targets.cpp).
+// ============================================================================
+
+/**
+ * @brief Slot whose lane is nearest to @p lane; -1 when there are no slots.
+ *
+ * @p hostLanes must be ascending. A pointer sitting on a refusing lane resolves
+ * to whichever usable lane is closest, which is what makes the ghost jump past
+ * the refusal instead of stopping on it. Exactly between two, the upper lane
+ * wins — arbitrary, but it has to be decided somewhere or the ghost flickers
+ * between them on a pixel of mouse noise.
+ */
+inline int nearestHostSlot(const std::vector<int>& hostLanes, int lane) {
+    if (hostLanes.empty())
+        return -1;
+
+    // Ascending, so the first lane at or past the pointer and the one before it
+    // are the only two candidates.
+    const auto at = std::lower_bound(hostLanes.begin(), hostLanes.end(), lane);
+    if (at == hostLanes.begin())
+        return 0;
+    if (at == hostLanes.end())
+        return static_cast<int>(hostLanes.size()) - 1;
+
+    const auto below = at - 1;
+    const int distanceAbove = *at - lane;
+    const int distanceBelow = lane - *below;
+    return static_cast<int>(
+        std::distance(hostLanes.begin(), distanceAbove < distanceBelow ? at : below));
+}
+
+/**
+ * @brief The part of @p rawDelta the whole selection can take.
+ *
+ * A drag is continuous, so a selection that reaches the end of the stack slides
+ * up against it rather than refusing the way a keypress does. Trimmed as a
+ * block rather than per clip: clamping each clip to the last slot on its own
+ * would pile the selection onto one lane and flatten a vertical spread that
+ * only undo could restore.
+ */
+inline int blockSlotDelta(int rawDelta, int minSlot, int maxSlot, int slotCount) {
+    if (slotCount <= 0 || minSlot < 0 || maxSlot >= slotCount || minSlot > maxSlot)
+        return 0;
+
+    return std::clamp(rawDelta, -minSlot, slotCount - 1 - maxSlot);
+}
+
+}  // namespace magda::interaction

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -153,6 +153,10 @@ set(TEST_SOURCES
     test_config_path_redirect.cpp
     # Keyboard clip nudging (#1957)
     test_clip_nudge.cpp
+    # Where a clip drag may land (#2179): the pure index rules that step the
+    # ghost over a lane it cannot land on. The panel driving them is in
+    # magda_juce_tests, which is where a TrackContentPanel can exist.
+    test_clip_drag_targets.cpp
     test_mono_note_processor.cpp
     test_sends_and_track_deletion.cpp
     # Internal track-to-track routing (issue #1690)
@@ -574,6 +578,7 @@ target_sources(magda_juce_tests PRIVATE
     test_multi_clip_resize_preview_juce.cpp
     test_clip_paint_juce.cpp
     test_clip_nudge_juce.cpp
+    test_clip_drag_targets_juce.cpp
     # A .mid dropped on the chord track arrives as chords
     test_chord_track_file_drop_juce.cpp
     # Files dropped straight onto a Drum Grid track (#2172)

--- a/tests/test_clip_drag_targets.cpp
+++ b/tests/test_clip_drag_targets.cpp
@@ -1,0 +1,87 @@
+// Tests for the clip-drag destination model (#2179): the pure rules that turn a
+// pointer position into a lane the drag can actually land on. Everything here
+// runs headless on plain integers; the panel driving them is covered in
+// test_clip_drag_targets_juce.cpp.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "magda/daw/ui/interaction/ClipDragTargets.hpp"
+
+using namespace magda::interaction;
+
+// ============================================================================
+// Resolving a pointer lane to a usable one
+// ============================================================================
+
+TEST_CASE("A pointer over a usable lane resolves to that lane", "[clip_drag_targets]") {
+    const std::vector<int> hostLanes{0, 1, 2, 3};
+    REQUIRE(nearestHostSlot(hostLanes, 0) == 0);
+    REQUIRE(nearestHostSlot(hostLanes, 2) == 2);
+    REQUIRE(nearestHostSlot(hostLanes, 3) == 3);
+}
+
+TEST_CASE("A pointer over a refusing lane resolves past it", "[clip_drag_targets]") {
+    // Lane 1 refuses — a chord track between two media tracks.
+    const std::vector<int> hostLanes{0, 2};
+
+    // Exactly between the two, so the tie-break decides: the upper lane.
+    REQUIRE(nearestHostSlot(hostLanes, 1) == 0);
+
+    // With two refusing lanes in the middle there is no tie, and the pointer
+    // resolves to whichever side it is closer to. This is the step-over: the
+    // ghost never sits on lane 1 or 2, it jumps from lane 0 to lane 3.
+    const std::vector<int> acrossTwo{0, 3};
+    REQUIRE(nearestHostSlot(acrossTwo, 1) == 0);
+    REQUIRE(nearestHostSlot(acrossTwo, 2) == 1);
+}
+
+TEST_CASE("A pointer past either end resolves to the end lane", "[clip_drag_targets]") {
+    const std::vector<int> hostLanes{2, 4};
+    REQUIRE(nearestHostSlot(hostLanes, 0) == 0);
+    REQUIRE(nearestHostSlot(hostLanes, 1) == 0);
+    REQUIRE(nearestHostSlot(hostLanes, 9) == 1);
+}
+
+TEST_CASE("No usable lane has no answer", "[clip_drag_targets]") {
+    // Dragging audio in a project whose only other track is the chord track.
+    // The caller reads -1 as "stay where you are"; it needs no case of its own.
+    REQUIRE(nearestHostSlot({}, 0) == -1);
+    REQUIRE(nearestHostSlot({}, 7) == -1);
+}
+
+// ============================================================================
+// Trimming the delta the selection takes
+// ============================================================================
+
+TEST_CASE("A delta inside the stack is taken whole", "[clip_drag_targets]") {
+    REQUIRE(blockSlotDelta(2, 0, 1, 5) == 2);
+    REQUIRE(blockSlotDelta(-1, 2, 3, 5) == -1);
+    REQUIRE(blockSlotDelta(0, 0, 0, 1) == 0);
+}
+
+TEST_CASE("A selection reaching the end of the stack slides against it", "[clip_drag_targets]") {
+    // Slots 0..3 occupied by clips on 0 and 1: the block can travel two slots
+    // down before its lower clip is on the last one, and no further.
+    REQUIRE(blockSlotDelta(9, 0, 1, 4) == 2);
+    REQUIRE(blockSlotDelta(-9, 0, 1, 4) == 0);
+
+    // ...and the mirror, with the block sitting at the bottom.
+    REQUIRE(blockSlotDelta(-9, 2, 3, 4) == -2);
+    REQUIRE(blockSlotDelta(9, 2, 3, 4) == 0);
+}
+
+TEST_CASE("The selection keeps its spread rather than piling up", "[clip_drag_targets]") {
+    // Two clips three slots apart in a stack of five. Dragged hard downwards
+    // the pair moves as one and stops with the lower clip on the last slot —
+    // the delta the *block* can take, not the delta each clip could take on its
+    // own, which would put both of them on the same lane and flatten a spread
+    // only undo could restore.
+    REQUIRE(blockSlotDelta(4, 0, 3, 5) == 1);
+}
+
+TEST_CASE("A degenerate stack yields no movement", "[clip_drag_targets]") {
+    REQUIRE(blockSlotDelta(1, 0, 0, 0) == 0);   // no usable lanes at all
+    REQUIRE(blockSlotDelta(1, 0, 3, 3) == 0);   // a slot outside the stack
+    REQUIRE(blockSlotDelta(1, -1, 1, 3) == 0);  // ...or below it
+    REQUIRE(blockSlotDelta(1, 2, 1, 3) == 0);   // min above max
+}

--- a/tests/test_clip_drag_targets_juce.cpp
+++ b/tests/test_clip_drag_targets_juce.cpp
@@ -1,0 +1,284 @@
+#include <juce_gui_basics/juce_gui_basics.h>
+
+#include "JuceTestStateGuard.hpp"
+#include "magda/daw/core/ClipManager.hpp"
+#include "magda/daw/core/SelectionManager.hpp"
+#include "magda/daw/core/TrackManager.hpp"
+#include "magda/daw/core/UndoManager.hpp"
+#include "magda/daw/ui/components/tracks/TrackContentPanel.hpp"
+#include "magda/daw/ui/state/TimelineController.hpp"
+#include "magda/daw/ui/state/TimelineEvents.hpp"
+
+/**
+ * Clip drag destinations (#2179)
+ *
+ * A clip dragged over a lane that cannot hold it used to follow the pointer
+ * onto that lane, show a ghost there and be declined on release: the gesture
+ * said yes for as long as it lasted and said no at the only moment the user
+ * could no longer change their mind.
+ *
+ * What is pinned here is that the drag steps over such a lane the way the
+ * keyboard nudge already does, and -- the part that made the old behaviour a
+ * bug rather than a preference -- that the preview and the release agree. The
+ * pure index rules underneath are covered headless in
+ * test_clip_drag_targets.cpp; this drives the panel's real drag entry points
+ * over a stack with a refusing lane in the middle of it.
+ */
+
+using namespace magda;
+
+namespace {
+
+constexpr double testTempoBPM = 120.0;
+constexpr double testZoomPixelsPerBeat = 40.0;
+
+TrackId trackOf(ClipId clipId) {
+    const auto* clip = ClipManager::getInstance().getClip(clipId);
+    return clip ? clip->trackId : INVALID_TRACK_ID;
+}
+
+// Media / Chord / Media / Media, so a plain MIDI clip on the top track has a
+// lane it cannot land on directly beneath it and two it can below that. The
+// chord track takes progressions only, and a clip created here has no chord
+// annotations, so it is refused with the clip in hand rather than by kind.
+struct DragFixture {
+    TimelineController controller;
+    TrackContentPanel panel;
+    TrackId topTrack = INVALID_TRACK_ID;
+    TrackId chordTrack = INVALID_TRACK_ID;
+    TrackId middleTrack = INVALID_TRACK_ID;
+    TrackId bottomTrack = INVALID_TRACK_ID;
+
+    DragFixture() {
+        auto& trackManager = TrackManager::getInstance();
+        topTrack = trackManager.createTrack("Top", TrackType::Media);
+        chordTrack = trackManager.createTrack("Chords", TrackType::Chord);
+        middleTrack = trackManager.createTrack("Middle", TrackType::Media);
+        bottomTrack = trackManager.createTrack("Bottom", TrackType::Media);
+
+        panel.setSize(2000, 600);
+        panel.setTempo(testTempoBPM);
+        panel.setZoom(testZoomPixelsPerBeat);
+        panel.setController(&controller);
+        controller.dispatch(SetSnapEnabledEvent{false});
+    }
+
+    ClipId addClip(TrackId trackId, double startBeats, double lengthBeats = 4.0) {
+        return ClipManager::getInstance().createMidiClipBeats(trackId, startBeats, lengthBeats,
+                                                              ClipView::Arrangement);
+    }
+
+    /// A pointer position in the middle of a lane, which is where a user
+    /// dragging onto that lane leaves the mouse.
+    int centreOfLane(int lane) const {
+        return panel.getTrackYPosition(lane) + panel.getTrackTotalHeight(lane) / 2;
+    }
+
+    // Asked of the panel rather than assumed from creation order: display
+    // order is the panel's to decide, and a test that hard-codes it is testing
+    // its own arithmetic.
+    TrackId trackIdAtLane(int lane) const {
+        const auto& lanes = panel.getVisibleTrackIds();
+        return (lane >= 0 && lane < static_cast<int>(lanes.size()))
+                   ? lanes[static_cast<size_t>(lane)]
+                   : INVALID_TRACK_ID;
+    }
+
+    int laneOf(TrackId trackId) const {
+        const auto& lanes = panel.getVisibleTrackIds();
+        for (int lane = 0; lane < static_cast<int>(lanes.size()); ++lane)
+            if (lanes[static_cast<size_t>(lane)] == trackId)
+                return lane;
+        return -1;
+    }
+};
+
+}  // namespace
+
+class ClipDragTargetsJuceTest final : public juce::UnitTest {
+  public:
+    ClipDragTargetsJuceTest() : juce::UnitTest("Clip Drag Targets Tests", "magda") {}
+
+    void runTest() override {
+        testDragStepsOverARefusingLane();
+        testPreviewAndReleaseAgree();
+        testSelectionKeepsItsSpreadAcrossARefusingLane();
+        testDragPinsWhenNoLaneAccepts();
+        testFrozenLanesAreSteppedOver();
+    }
+
+  private:
+    // The ghost the drag is showing, expressed as the lane it sits on, which is
+    // the thing the user is reading off the screen.
+    int ghostLane(const DragFixture& f, ClipId clipId) {
+        const auto bounds = f.panel.getClipGhostBounds(clipId);
+        if (bounds.isEmpty())
+            return -1;
+        return f.panel.getTrackIndexAtY(bounds.getCentreY());
+    }
+
+    void testDragStepsOverARefusingLane() {
+        beginTest("A drag onto a lane that cannot hold the clip lands past it");
+
+        magda::test::runWithCleanJuceState([this] {
+            DragFixture f;
+            const ClipId clip = f.addClip(f.topTrack, 0.0);
+            SelectionManager::getInstance().selectClip(clip);
+
+            // The premise, asserted rather than assumed: a refusing lane with a
+            // usable one either side of it. Without this the case degenerates
+            // into clamping at the end of the stack, which is a different rule
+            // and would pass while testing nothing.
+            expect(f.laneOf(f.topTrack) < f.laneOf(f.chordTrack) &&
+                       f.laneOf(f.chordTrack) < f.laneOf(f.middleTrack),
+                   "the chord lane should sit between the two media lanes, got " +
+                       juce::String(f.laneOf(f.topTrack)) + "/" +
+                       juce::String(f.laneOf(f.chordTrack)) + "/" +
+                       juce::String(f.laneOf(f.middleTrack)));
+
+            // The panel resolves the destination for both the ghost and the
+            // commit; a single-clip drag asks it exactly this way.
+            f.panel.beginClipDragTargets({clip}, clip);
+
+            // Pointer on the chord lane, which cannot hold a plain MIDI clip.
+            const int delta = f.panel.clipDragSlotDelta(f.centreOfLane(f.laneOf(f.chordTrack)));
+            const TrackId target = f.panel.clipDragTargetTrackId(f.topTrack, delta);
+            expect(target != f.chordTrack, "the chord track must never be a destination");
+            expect(target == f.topTrack,
+                   "halfway onto the refusing lane the clip stays on its own track");
+
+            // Pointer on the lane below it: the usable lane the step-over reaches.
+            const int pastDelta =
+                f.panel.clipDragSlotDelta(f.centreOfLane(f.laneOf(f.middleTrack)));
+            expect(f.panel.clipDragTargetTrackId(f.topTrack, pastDelta) == f.middleTrack,
+                   "the drag should reach the track below the chord track");
+        });
+    }
+
+    void testPreviewAndReleaseAgree() {
+        beginTest("The lane the ghost sits on at release is the lane the clip lands on");
+
+        // Every lane in the stack, including the refusing one, because the
+        // disagreement this replaced only appeared over that lane. Each pass
+        // gets its own clean state: sharing one would stack a second set of
+        // tracks under the first and leave the lane indices meaning something
+        // else on every iteration after the first.
+        for (int lane = 0; lane < 4; ++lane) {
+            magda::test::runWithCleanJuceState([this, lane] {
+                DragFixture f;
+                expect(static_cast<int>(f.panel.getVisibleTrackIds().size()) == 4,
+                       "the fixture should be four lanes, got " +
+                           juce::String(static_cast<int>(f.panel.getVisibleTrackIds().size())));
+
+                const ClipId clip = f.addClip(f.topTrack, 0.0);
+                const ClipId partner = f.addClip(f.middleTrack, 32.0);
+                SelectionManager::getInstance().selectClips({clip, partner});
+
+                f.panel.startMultiClipDrag(clip, {100, f.centreOfLane(f.laneOf(f.topTrack))});
+                f.panel.updateMultiClipDrag({100, f.centreOfLane(lane)});
+
+                const int previewLane = ghostLane(f, clip);
+                f.panel.finishMultiClipDrag();
+
+                const TrackId landed = trackOf(clip);
+                if (previewLane < 0) {
+                    expect(landed == f.topTrack,
+                           "no ghost means the clip did not move, lane " + juce::String(lane));
+                } else {
+                    expect(f.trackIdAtLane(previewLane) == landed,
+                           "ghost lane " + juce::String(previewLane) +
+                               " disagreed with the committed track, pointer on lane " +
+                               juce::String(lane));
+                }
+                expect(landed != f.chordTrack,
+                       "a plain MIDI clip must never land on the chord track");
+            });
+        }
+    }
+
+    void testSelectionKeepsItsSpreadAcrossARefusingLane() {
+        beginTest("A selection either side of a refusing lane keeps its spread");
+
+        magda::test::runWithCleanJuceState([this] {
+            DragFixture f;
+            // Two clips two usable lanes apart: top and middle, with the chord
+            // lane between them. A delta in raw lane indices would move them by
+            // different amounts once one has stepped over and the other has not.
+            const ClipId upper = f.addClip(f.topTrack, 0.0);
+            const ClipId lower = f.addClip(f.middleTrack, 32.0);
+            SelectionManager::getInstance().selectClips({upper, lower});
+
+            f.panel.startMultiClipDrag(upper, {100, f.centreOfLane(f.laneOf(f.topTrack))});
+            f.panel.updateMultiClipDrag({100, f.centreOfLane(f.laneOf(f.middleTrack))});
+            f.panel.finishMultiClipDrag();
+
+            // One usable lane down for both: top -> middle, middle -> bottom.
+            // The pair is now against the end of the stack, which is what stops
+            // it, and neither clip has been pulled onto the other's lane.
+            expect(trackOf(upper) == f.middleTrack, "the upper clip should move one usable lane");
+            expect(trackOf(lower) == f.bottomTrack, "the lower clip should move with it");
+        });
+    }
+
+    void testDragPinsWhenNoLaneAccepts() {
+        beginTest("A drag with nowhere to go keeps its vertical position");
+
+        magda::test::runWithCleanJuceState([this] {
+            auto& trackManager = TrackManager::getInstance();
+            TimelineController controller;
+            TrackContentPanel panel;
+            const TrackId media = trackManager.createTrack("Only", TrackType::Media);
+            trackManager.createTrack("Chords", TrackType::Chord);
+            panel.setSize(2000, 600);
+            panel.setTempo(testTempoBPM);
+            panel.setZoom(testZoomPixelsPerBeat);
+            panel.setController(&controller);
+
+            const ClipId clip = ClipManager::getInstance().createMidiClipBeats(
+                media, 0.0, 4.0, ClipView::Arrangement);
+            SelectionManager::getInstance().selectClip(clip);
+            panel.beginClipDragTargets({clip}, clip);
+
+            // Anywhere in the stack, and off the bottom of it: the only other
+            // lane refuses the clip, so vertical movement has nothing to offer.
+            for (int y : {0, 40, 200, 5000}) {
+                const int delta = panel.clipDragSlotDelta(y);
+                expect(panel.clipDragTargetTrackId(media, delta) == media,
+                       "the clip should stay on its own track at y=" + juce::String(y));
+            }
+        });
+    }
+
+    void testFrozenLanesAreSteppedOver() {
+        beginTest("A frozen lane is stepped over rather than dropped into");
+
+        magda::test::runWithCleanJuceState([this] {
+            DragFixture f;
+            auto& trackManager = TrackManager::getInstance();
+            if (auto* track = trackManager.getTrack(f.middleTrack))
+                track->frozen = true;
+
+            const ClipId clip = f.addClip(f.topTrack, 0.0);
+            SelectionManager::getInstance().selectClip(clip);
+            f.panel.beginClipDragTargets({clip}, clip);
+
+            // Lanes 1 and 2 both refuse now — the chord track by type, the
+            // middle track by being rendered to audio — so the drag reaches
+            // the bottom track or stays put, never either of them.
+            for (int lane = 1; lane < 4; ++lane) {
+                const int delta = f.panel.clipDragSlotDelta(f.centreOfLane(lane));
+                const TrackId target = f.panel.clipDragTargetTrackId(f.topTrack, delta);
+                expect(target == f.topTrack || target == f.bottomTrack,
+                       "a frozen or refusing lane must not be a destination, pointer on lane " +
+                           juce::String(lane));
+            }
+
+            // ...and it does reach past both of them.
+            const int delta = f.panel.clipDragSlotDelta(f.centreOfLane(3));
+            expect(f.panel.clipDragTargetTrackId(f.topTrack, delta) == f.bottomTrack,
+                   "the drag should reach the bottom track");
+        });
+    }
+};
+
+static ClipDragTargetsJuceTest clipDragTargetsJuceTest;

--- a/tests/test_clip_drag_targets_juce.cpp
+++ b/tests/test_clip_drag_targets_juce.cpp
@@ -1,6 +1,7 @@
 #include <juce_gui_basics/juce_gui_basics.h>
 
 #include "JuceTestStateGuard.hpp"
+#include "magda/daw/core/AutomationManager.hpp"
 #include "magda/daw/core/ClipManager.hpp"
 #include "magda/daw/core/SelectionManager.hpp"
 #include "magda/daw/core/TrackManager.hpp"
@@ -63,6 +64,19 @@ struct DragFixture {
         controller.dispatch(SetSnapEnabledEvent{false});
     }
 
+    /// Open an automation lane under @p trackId, so its row is taller than its
+    /// track and there is a band of Y inside the stack that is not any track's
+    /// own lane area.
+    AutomationLaneId showAutomationLaneOn(TrackId trackId) {
+        AutomationTarget target;
+        target.kind = ControlTarget::Kind::TrackVolume;
+        target.devicePath = ChainNodePath::trackLevel(trackId);
+        const auto laneId =
+            AutomationManager::getInstance().createLane(target, AutomationLaneType::Absolute);
+        AutomationManager::getInstance().setLaneVisible(laneId, true);
+        return laneId;
+    }
+
     ClipId addClip(TrackId trackId, double startBeats, double lengthBeats = 4.0) {
         return ClipManager::getInstance().createMidiClipBeats(trackId, startBeats, lengthBeats,
                                                               ClipView::Arrangement);
@@ -105,6 +119,7 @@ class ClipDragTargetsJuceTest final : public juce::UnitTest {
         testSelectionKeepsItsSpreadAcrossARefusingLane();
         testDragPinsWhenNoLaneAccepts();
         testFrozenLanesAreSteppedOver();
+        testAnAutomationLaneBelongsToItsOwnTrack();
     }
 
   private:
@@ -277,6 +292,49 @@ class ClipDragTargetsJuceTest final : public juce::UnitTest {
             const int delta = f.panel.clipDragSlotDelta(f.centreOfLane(3));
             expect(f.panel.clipDragTargetTrackId(f.topTrack, delta) == f.bottomTrack,
                    "the drag should reach the bottom track");
+        });
+    }
+
+    // getTrackIndexAtY answers -1 both for a pointer below the arrangement and
+    // for one inside a track's automation lanes, and a drag that reads the
+    // second as the first sends the ghost to the bottom of the stack from a
+    // position the user is holding halfway up it.
+    void testAnAutomationLaneBelongsToItsOwnTrack() {
+        beginTest("A pointer over an automation lane resolves to the track above it");
+
+        magda::test::runWithCleanJuceState([this] {
+            DragFixture f;
+            f.showAutomationLaneOn(f.topTrack);
+
+            // The automation band is whatever part of the top track's row no
+            // track's own lane area claims. Found by probing rather than
+            // computed, so the test does not have to know how the row is laid
+            // out -- only that a gap exists inside the stack.
+            const int topLane = f.laneOf(f.topTrack);
+            const int rowStart = f.panel.getTrackYPosition(topLane);
+            const int rowEnd = rowStart + f.panel.getTrackTotalHeight(topLane);
+            int automationY = -1;
+            for (int y = rowStart; y < rowEnd; ++y)
+                if (f.panel.getTrackIndexAtY(y) < 0) {
+                    automationY = y;
+                    break;
+                }
+
+            expect(automationY >= 0,
+                   "the fixture needs a visible automation lane to have a gap at all");
+            expect(automationY > rowStart && automationY < rowEnd,
+                   "the gap should be inside the top track's row, not past the stack");
+            if (automationY < 0)
+                return;
+
+            const ClipId clip = f.addClip(f.middleTrack, 0.0);
+            SelectionManager::getInstance().selectClip(clip);
+            f.panel.beginClipDragTargets({clip}, clip);
+
+            const int delta = f.panel.clipDragSlotDelta(automationY);
+            expect(f.panel.clipDragTargetTrackId(f.middleTrack, delta) == f.topTrack,
+                   "an automation lane belongs to the track it was opened under, "
+                   "not to the bottom of the arrangement");
         });
     }
 };


### PR DESCRIPTION
Closes #2179.

A clip dragged over a track that cannot hold it followed the pointer onto that track, showed a ghost there, and was declined on release. The outcome was right and the affordance was not: the gesture said yes for as long as it lasted and said no at the only moment the user could no longer change their mind.

#2177 gave every path that places a clip one rule to ask and applied it to the file drop, the keyboard nudge and `MoveClipToTrackCommand` itself. The drag was left showing the old answer, which made it the third path holding its own opinion.

## What it does now

The ghost steps over such a lane, the way vertical nudging already does, and for the reason this repo had already written down beside the nudge: a lane that stops the ghost dead is a lane you cannot drag a clip past. Frozen tracks are skipped as drag destinations here too, so the two paths answer alike.

**One resolution, both ends.** `ClipDragTargets.hpp` holds the rules as plain integers — `nearestHostSlot` picks the closest lane that can hold the selection, `blockSlotDelta` trims the travel so a selection reaching the end of the stack slides against it rather than refusing the way a keypress does. The panel wraps them in `beginClipDragTargets` / `clipDragSlotDelta` / `clipDragTargetTrackId`, and the ghost, the alt-drag copy's ghost and the mouseUp commit all go through those. `ClipComponent` no longer resolves pointer Y itself. A ghost that lands where the commit refuses is not fixed by fixing both — it is fixed by there being one.

**The part that is not bookkeeping.** A multi-clip drag carries a single delta, and a delta in raw lane indices does not survive lanes being skipped: clips starting either side of a refusing lane travel different distances and the selection pulls apart. The delta now counts lanes that can hold the selection rather than lanes — the treatment the nudge already gave it — and is clamped as a block, so a selection against the end of the stack keeps its spread instead of piling onto one lane where only undo could recover it.

Where nothing in the stack accepts the selection (audio in a project whose only other track is the chord track), vertical movement pins and horizontal is unaffected. That falls out of the set being empty rather than needing a case of its own.

`canHostNudgedClips` becomes the shared `canHostClips`: the drag and the nudge ask one question of one table.

Out of scope as the issue specified: converting a clip on drag, and marking the refusing lane.

## Tests

- `test_clip_drag_targets.cpp` — the index rules, headless.
- `test_clip_drag_targets_juce.cpp` — the panel's real drag entry points over a Media/Chord/Media/Media stack, including the case the issue asked for: the lane the ghost sits on at the moment of release is the lane the clip ends up on, checked at every lane including the refusing one.

Verified negatively: reverting the acceptance filter reproduces the original defect down to its symptom, `ghost lane 1 disagreed with the committed track`.

Full headless suite green (3099 passed, 13 skipped). Clip Nudge, Chord Track File Drop, Multi Clip Resize Preview, Arrangement Row Alignment, Clip painting and ClipInspector all still green.

## Worth a reviewer's eye

Two accessors are new on `TrackContentPanel`. `getClipGhostBounds` exists so the preview is observable at all — without it the agreement between preview and release can only be assumed, not asserted. `getVisibleTrackIds` turns a lane index back into the track it names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)