### PR TITLE
Host an external plugin under a Device op, and find the one a project meant (#2241, #2243)

### DIFF
--- a/magda/daw/audio/CMakeLists.txt
+++ b/magda/daw/audio/CMakeLists.txt
@@ -305,6 +305,8 @@ list(REMOVE_ITEM _magda_device_pack_sources ${_magda_tracktion_device_adapter_so
 set(_magda_engine_device_adapter_sources
     "${CMAKE_CURRENT_SOURCE_DIR}/plugins/engine/EngineDeviceFactory.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/plugins/engine/EngineDeviceFactory.hpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/plugins/engine/EngineExternalDevice.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/plugins/engine/EngineExternalDevice.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/plugins/engine/EngineMagdaDevice.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/plugins/engine/EngineMagdaDevice.hpp"
 )

--- a/magda/daw/audio/CMakeLists.txt
+++ b/magda/daw/audio/CMakeLists.txt
@@ -471,6 +471,11 @@ target_sources(magda_daw PRIVATE
     # resolves it at the final link the way it resolves findCompiledPluginSpec.
     plugin_manager/ExternalPluginLookup.cpp
     plugin_manager/ExternalPluginLookup.hpp
+    # A project's record of a plugin onto a live instance: array, then chunk,
+    # then what that left behind, for whoever owns the model (#2243). Same
+    # arrangement as the lookup above -- one answer, both engines.
+    plugin_manager/ExternalPluginState.cpp
+    plugin_manager/ExternalPluginState.hpp
     plugin_manager/PluginManagerMacros.cpp
     plugin_manager/PluginManagerModifiers.cpp
     plugin_manager/PluginManagerSidechain.cpp

--- a/magda/daw/audio/CMakeLists.txt
+++ b/magda/daw/audio/CMakeLists.txt
@@ -466,6 +466,11 @@ target_sources(magda_daw PRIVATE
     TrackController.cpp
     plugin_manager/PluginManager.cpp
     plugin_manager/PluginManagerSync.cpp
+    # Which installed plugin a saved device meant (#2243). One answer, asked by
+    # the sync path here and by the native engine's device factory, which
+    # resolves it at the final link the way it resolves findCompiledPluginSpec.
+    plugin_manager/ExternalPluginLookup.cpp
+    plugin_manager/ExternalPluginLookup.hpp
     plugin_manager/PluginManagerMacros.cpp
     plugin_manager/PluginManagerModifiers.cpp
     plugin_manager/PluginManagerSidechain.cpp

--- a/magda/daw/audio/plugin_manager/ExternalPluginLookup.cpp
+++ b/magda/daw/audio/plugin_manager/ExternalPluginLookup.cpp
@@ -41,31 +41,39 @@ ExternalPluginMatch matchInstalledPlugin(const DeviceInfo& device,
                                          const juce::KnownPluginList& knownPlugins) {
     const auto saved = describeSavedPlugin(device);
 
-    // The four passes, as predicates over one list. Written this way rather
-    // than as four loops because what matters about them is the order, and the
-    // order is invisible when it is four hundred lines of the same loop.
+    // The passes, as predicates over one list. Written this way rather than as
+    // five loops because what matters about them is the order, and the order is
+    // invisible when it is four hundred lines of the same loop.
     //
-    // The two file passes ask nothing when the device saved no file, because an
-    // empty path matches every description that also has none and that is a
-    // match on the absence of evidence. The app guarded this at its call sites
-    // by declining to search at all; the guard belongs to the pass that needs
-    // it, so the other two still answer.
+    // A pass asks nothing when the device saved nothing for it to ask with. An
+    // empty path matches every description that also has none, and an empty
+    // name matches every plugin with no name: both are matches on the absence
+    // of evidence, and they would resolve a device that saved neither to
+    // whichever scanned plugin happens to be missing the same field.
     const auto hasFile = device.fileOrIdentifier.isNotEmpty();
+    const auto hasName = device.name.isNotEmpty();
+    const auto hasIdentity = device.uniqueId.isNotEmpty();
 
-    const std::array<std::function<bool(const juce::PluginDescription&)>, 4> passes{
+    const std::array<std::function<bool(const juce::PluginDescription&)>, 5> passes{
+        [&](const juce::PluginDescription& known) {
+            return hasIdentity && known.createIdentifierString() == device.uniqueId;
+        },
         [&](const juce::PluginDescription& known) {
             return hasFile && known.fileOrIdentifier == device.fileOrIdentifier &&
                    known.isInstrument == device.isInstrument;
         },
         [&](const juce::PluginDescription& known) {
-            return known.name == device.name && known.manufacturerName == device.manufacturer &&
+            return hasName && known.name == device.name &&
+                   known.manufacturerName == device.manufacturer &&
+                   known.pluginFormatName == saved.pluginFormatName &&
                    known.isInstrument == device.isInstrument;
         },
         [&](const juce::PluginDescription& known) {
             return hasFile && known.fileOrIdentifier == device.fileOrIdentifier;
         },
         [&](const juce::PluginDescription& known) {
-            return known.name == device.name && known.pluginFormatName == saved.pluginFormatName;
+            return hasName && known.name == device.name &&
+                   known.pluginFormatName == saved.pluginFormatName;
         },
     };
 

--- a/magda/daw/audio/plugin_manager/ExternalPluginLookup.cpp
+++ b/magda/daw/audio/plugin_manager/ExternalPluginLookup.cpp
@@ -1,0 +1,80 @@
+#include "ExternalPluginLookup.hpp"
+
+#include <array>
+#include <functional>
+
+namespace magda {
+
+namespace {
+
+/// JUCE's own name for a format, which is what a PluginDescription carries and
+/// what the scan wrote. Empty for an internal device, which has no format and
+/// never reaches this file.
+juce::String formatNameOf(PluginFormat format) {
+    switch (format) {
+        case PluginFormat::VST3:
+            return "VST3";
+        case PluginFormat::AU:
+            return "AudioUnit";
+        case PluginFormat::LV2:
+            return "LV2";
+        case PluginFormat::Internal:
+            break;
+    }
+
+    return {};
+}
+
+}  // namespace
+
+juce::PluginDescription describeSavedPlugin(const DeviceInfo& device) {
+    juce::PluginDescription description;
+    description.name = device.name;
+    description.manufacturerName = device.manufacturer;
+    description.fileOrIdentifier = device.fileOrIdentifier;
+    description.isInstrument = device.isInstrument;
+    description.pluginFormatName = formatNameOf(device.format);
+    return description;
+}
+
+ExternalPluginMatch matchInstalledPlugin(const DeviceInfo& device,
+                                         const juce::KnownPluginList& knownPlugins) {
+    const auto saved = describeSavedPlugin(device);
+
+    // The four passes, as predicates over one list. Written this way rather
+    // than as four loops because what matters about them is the order, and the
+    // order is invisible when it is four hundred lines of the same loop.
+    //
+    // The two file passes ask nothing when the device saved no file, because an
+    // empty path matches every description that also has none and that is a
+    // match on the absence of evidence. The app guarded this at its call sites
+    // by declining to search at all; the guard belongs to the pass that needs
+    // it, so the other two still answer.
+    const auto hasFile = device.fileOrIdentifier.isNotEmpty();
+
+    const std::array<std::function<bool(const juce::PluginDescription&)>, 4> passes{
+        [&](const juce::PluginDescription& known) {
+            return hasFile && known.fileOrIdentifier == device.fileOrIdentifier &&
+                   known.isInstrument == device.isInstrument;
+        },
+        [&](const juce::PluginDescription& known) {
+            return known.name == device.name && known.manufacturerName == device.manufacturer &&
+                   known.isInstrument == device.isInstrument;
+        },
+        [&](const juce::PluginDescription& known) {
+            return hasFile && known.fileOrIdentifier == device.fileOrIdentifier;
+        },
+        [&](const juce::PluginDescription& known) {
+            return known.name == device.name && known.pluginFormatName == saved.pluginFormatName;
+        },
+    };
+
+    for (const auto& matches : passes)
+        for (const auto& known : knownPlugins.getTypes())
+            if (matches(known))
+                return {.description = known, .found = true};
+
+    return {.description = saved, .found = false};
+}
+
+}  // namespace magda

--- a/magda/daw/audio/plugin_manager/ExternalPluginLookup.cpp
+++ b/magda/daw/audio/plugin_manager/ExternalPluginLookup.cpp
@@ -37,6 +37,11 @@ juce::PluginDescription describeSavedPlugin(const DeviceInfo& device) {
     return description;
 }
 
+SavedPluginIdentity savedPluginIdentity(const DeviceInfo& device) {
+    return {.identifier = device.uniqueId,
+            .fields = describeSavedPlugin(device).createIdentifierString()};
+}
+
 ExternalPluginMatch matchInstalledPlugin(const DeviceInfo& device,
                                          const juce::KnownPluginList& knownPlugins) {
     const auto saved = describeSavedPlugin(device);

--- a/magda/daw/audio/plugin_manager/ExternalPluginLookup.cpp
+++ b/magda/daw/audio/plugin_manager/ExternalPluginLookup.cpp
@@ -39,7 +39,11 @@ juce::PluginDescription describeSavedPlugin(const DeviceInfo& device) {
 
 SavedPluginIdentity savedPluginIdentity(const DeviceInfo& device) {
     return {.identifier = device.uniqueId,
-            .fields = describeSavedPlugin(device).createIdentifierString()};
+            .name = device.name,
+            .manufacturer = device.manufacturer,
+            .fileOrIdentifier = device.fileOrIdentifier,
+            .format = device.format,
+            .isInstrument = device.isInstrument};
 }
 
 ExternalPluginMatch matchInstalledPlugin(const DeviceInfo& device,

--- a/magda/daw/audio/plugin_manager/ExternalPluginLookup.hpp
+++ b/magda/daw/audio/plugin_manager/ExternalPluginLookup.hpp
@@ -91,18 +91,26 @@ ExternalPluginMatch matchInstalledPlugin(const DeviceInfo& device,
  *
  * Two forms, because a project may carry either. @ref identifier is JUCE's own
  * identifier string, which is what DeviceInfo::uniqueId holds for a device
- * added from the browser; @ref fields is the saved name, format and file, which
- * is all an imported project has.
+ * added from the browser. The fields beside it are what an imported project has
+ * instead, and they are compared as themselves rather than through
+ * PluginDescription::createIdentifierString().
  *
- * Both are needed and neither replaces the other. The identifier contains the
- * plugin's numeric uid, which a description reconstructed from saved fields
- * does not have: comparing one against the other is comparing a real uid
- * against a zero, and it never matches. So a comparison has to be told which
- * form it is looking at, which is what this type is for.
+ * Not through that string for two reasons. It contains the plugin's numeric
+ * uid, which a description rebuilt from saved fields does not have, so
+ * comparing a rebuilt one against a scanned one never matches. And it encodes
+ * only the format, the name and a hash of the file: not the vendor, and not
+ * whether the plugin is an instrument. A bundle shipping an effect and an
+ * instrument of the same name out of one file -- the case the lookup's own
+ * first pass exists for -- produces one string for both.
  */
 struct SavedPluginIdentity {
     juce::String identifier;
-    juce::String fields;
+
+    juce::String name;
+    juce::String manufacturer;
+    juce::String fileOrIdentifier;
+    PluginFormat format = PluginFormat::VST3;
+    bool isInstrument = false;
 
     /**
      * @brief Whether @p other names the same plugin.
@@ -117,7 +125,9 @@ struct SavedPluginIdentity {
         if (identifier.isNotEmpty() && other.identifier.isNotEmpty())
             return identifier == other.identifier;
 
-        return fields == other.fields;
+        return name == other.name && manufacturer == other.manufacturer &&
+               fileOrIdentifier == other.fileOrIdentifier && format == other.format &&
+               isInstrument == other.isInstrument;
     }
 };
 

--- a/magda/daw/audio/plugin_manager/ExternalPluginLookup.hpp
+++ b/magda/daw/audio/plugin_manager/ExternalPluginLookup.hpp
@@ -52,20 +52,36 @@ struct ExternalPluginMatch {
 juce::PluginDescription describeSavedPlugin(const DeviceInfo& device);
 
 /**
- * @brief The installed plugin @p device names, searched for in four passes.
+ * @brief The installed plugin @p device names, searched for in five passes.
  *
  * In order, each stricter than the one after it:
  *
- * 1. The file it was loaded from, and the instrument flag agreeing. The flag is
+ * 1. JUCE's own identifier, which is what DeviceInfo::uniqueId holds
+ *    (PluginDescription::createIdentifierString). Exact identity, and it is
+ *    first because nothing below it can tell two plugins apart that a bundle
+ *    ships out of one file with one role: a shell format's dozen effects share
+ *    a path, and the pass below would return whichever of them the scan listed
+ *    first.
+ * 2. The file it was loaded from, and the instrument flag agreeing. The flag is
  *    checked here because a plugin often ships an effect and an instrument out
  *    of one file, and loading the wrong one is silent.
- * 2. Name, vendor and the instrument flag. What answers when the plugin moved.
- * 3. The file alone. What answers when a plugin was renamed in place.
- * 4. Name and format alone. What answers for a project that came from another
+ * 3. Name, vendor, format and the instrument flag. What answers when the plugin
+ *    moved. The format is required because a machine commonly has the same
+ *    plugin twice, as an AU and as a VST3, with the same name, vendor and role:
+ *    the two have different parameter layouts and different state, so
+ *    substituting one for the other loads a plugin and renders a different
+ *    project.
+ * 4. The file alone. What answers when a plugin was renamed in place.
+ * 5. Name and format alone. What answers for a project that came from another
  *    host: a DAWproject carries the plugin's name and its class id but neither
  *    our file path nor, reliably, its role -- Bitwig exports Serum, an
  *    instrument, as an audio effect -- so neither the vendor nor the flag can
  *    be required by the pass that has to resolve it.
+ *
+ * A pass that has nothing to ask with asks nothing: a device that saved no file
+ * skips the file passes, one with no name skips the name passes, one with no
+ * identifier skips the first. An empty field matching an empty field is a match
+ * on the absence of evidence.
  */
 ExternalPluginMatch matchInstalledPlugin(const DeviceInfo& device,
                                          const juce::KnownPluginList& knownPlugins);

--- a/magda/daw/audio/plugin_manager/ExternalPluginLookup.hpp
+++ b/magda/daw/audio/plugin_manager/ExternalPluginLookup.hpp
@@ -1,0 +1,73 @@
+#pragma once
+
+#include <juce_audio_processors/juce_audio_processors.h>
+
+#include "core/DeviceInfo.hpp"
+
+/**
+ * @file ExternalPluginLookup.hpp
+ * @brief Which installed plugin a saved device meant (#2243).
+ *
+ * A project stores what it can about an external plugin: the name it had, its
+ * vendor, the file it was loaded from, whether it was an instrument. What it
+ * cannot store is the plugin, so opening the project means finding that plugin
+ * again among whatever this machine has installed, which is not the machine
+ * that saved it.
+ *
+ * The passes below are that search, and none of them is incidental. Each was
+ * added for a project that would otherwise have loaded nothing or, worse,
+ * loaded the wrong plugin: an effect where an instrument was saved, a plugin of
+ * the same name from another vendor, a plugin whose installer moved it between
+ * versions.
+ *
+ * It lives here, in one function, because there is one answer to it. The two
+ * engines cannot each have an opinion about which plugin a project meant, and
+ * before this the app itself had two: the track path tried the file path on its
+ * own after the vendor pass and the rack path did not, so a plugin that had
+ * both moved and been renamed resolved on a track and not inside a rack.
+ */
+
+namespace magda {
+
+/**
+ * @brief What the search found, and whether it found anything.
+ *
+ * @ref description is the installed plugin when @ref found is true, and the
+ * saved fields as a description when it is false. The second is not a
+ * placeholder: a host is free to try to load it anyway, which is what lets a
+ * plugin resolve through a format's own lookup when the scan is out of date,
+ * and it is what the app has always done.
+ */
+struct ExternalPluginMatch {
+    juce::PluginDescription description;
+    bool found = false;
+};
+
+/**
+ * @brief The description @p device carries, before anything installed is asked.
+ *
+ * Name, vendor, file and instrument flag as saved, with the format named the
+ * way JUCE names it. This is the query; matchInstalledPlugin() is the search.
+ */
+juce::PluginDescription describeSavedPlugin(const DeviceInfo& device);
+
+/**
+ * @brief The installed plugin @p device names, searched for in four passes.
+ *
+ * In order, each stricter than the one after it:
+ *
+ * 1. The file it was loaded from, and the instrument flag agreeing. The flag is
+ *    checked here because a plugin often ships an effect and an instrument out
+ *    of one file, and loading the wrong one is silent.
+ * 2. Name, vendor and the instrument flag. What answers when the plugin moved.
+ * 3. The file alone. What answers when a plugin was renamed in place.
+ * 4. Name and format alone. What answers for a project that came from another
+ *    host: a DAWproject carries the plugin's name and its class id but neither
+ *    our file path nor, reliably, its role -- Bitwig exports Serum, an
+ *    instrument, as an audio effect -- so neither the vendor nor the flag can
+ *    be required by the pass that has to resolve it.
+ */
+ExternalPluginMatch matchInstalledPlugin(const DeviceInfo& device,
+                                         const juce::KnownPluginList& knownPlugins);
+
+}  // namespace magda

--- a/magda/daw/audio/plugin_manager/ExternalPluginLookup.hpp
+++ b/magda/daw/audio/plugin_manager/ExternalPluginLookup.hpp
@@ -86,4 +86,42 @@ juce::PluginDescription describeSavedPlugin(const DeviceInfo& device);
 ExternalPluginMatch matchInstalledPlugin(const DeviceInfo& device,
                                          const juce::KnownPluginList& knownPlugins);
 
+/**
+ * @brief How a device says which plugin it is, as the model records it.
+ *
+ * Two forms, because a project may carry either. @ref identifier is JUCE's own
+ * identifier string, which is what DeviceInfo::uniqueId holds for a device
+ * added from the browser; @ref fields is the saved name, format and file, which
+ * is all an imported project has.
+ *
+ * Both are needed and neither replaces the other. The identifier contains the
+ * plugin's numeric uid, which a description reconstructed from saved fields
+ * does not have: comparing one against the other is comparing a real uid
+ * against a zero, and it never matches. So a comparison has to be told which
+ * form it is looking at, which is what this type is for.
+ */
+struct SavedPluginIdentity {
+    juce::String identifier;
+    juce::String fields;
+
+    /**
+     * @brief Whether @p other names the same plugin.
+     *
+     * By identifier when both have one, which is exact. By the saved fields
+     * otherwise, which is what an imported device has and what a device that
+     * has only just been resolved has: a device that gains a scanned identifier
+     * has not changed plugin, and a comparison that read that as a change would
+     * refuse an answer it should have taken.
+     */
+    bool namesSamePluginAs(const SavedPluginIdentity& other) const {
+        if (identifier.isNotEmpty() && other.identifier.isNotEmpty())
+            return identifier == other.identifier;
+
+        return fields == other.fields;
+    }
+};
+
+/** What @p device records about which plugin it names. */
+SavedPluginIdentity savedPluginIdentity(const DeviceInfo& device);
+
 }  // namespace magda

--- a/magda/daw/audio/plugin_manager/ExternalPluginState.cpp
+++ b/magda/daw/audio/plugin_manager/ExternalPluginState.cpp
@@ -56,7 +56,8 @@ std::vector<juce::AudioProcessorParameter*> hostParameterOrder(
     return order;
 }
 
-bool applySavedPluginState(juce::AudioPluginInstance& instance, const DeviceInfo& device) {
+SavedStateOutcome applySavedPluginState(juce::AudioPluginInstance& instance,
+                                        const DeviceInfo& device) {
     const auto order = hostParameterOrder(instance);
 
     // The array first. A parameter the model does not describe keeps whatever
@@ -78,7 +79,7 @@ bool applySavedPluginState(juce::AudioPluginInstance& instance, const DeviceInfo
 
     const auto chunk = decodeSavedChunk(device.pluginState);
     if (chunk.getSize() == 0)
-        return false;
+        return SavedStateOutcome::Baseline;
 
     // DeviceInfo::vst3Preset is deliberately not applied here. It is the
     // portable .vstpreset a DAWproject carries, applied once on import and
@@ -89,13 +90,15 @@ bool applySavedPluginState(juce::AudioPluginInstance& instance, const DeviceInfo
     try {
         instance.setStateInformation(chunk.getData(), static_cast<int>(chunk.getSize()));
     } catch (...) {
-        // Third-party code, handed the input it is least likely to have been
-        // tested against. The baseline above is still standing, which is where
-        // a plugin that refuses a chunk quietly leaves things anyway.
-        return false;
+        // The host survives, which is all a catch-all can promise. What the
+        // plugin holds now is whatever it had managed to do before it threw:
+        // half a preset, a program it switched, a sample it swapped. Writing
+        // the parameter array again would put the parameters back and none of
+        // the rest, so this says so rather than pretending otherwise.
+        return SavedStateOutcome::Failed;
     }
 
-    return true;
+    return SavedStateOutcome::Restored;
 }
 
 std::vector<RestoredParameter> snapshotHostParameters(const juce::AudioPluginInstance& instance) {

--- a/magda/daw/audio/plugin_manager/ExternalPluginState.cpp
+++ b/magda/daw/audio/plugin_manager/ExternalPluginState.cpp
@@ -1,0 +1,123 @@
+#include "ExternalPluginState.hpp"
+
+#include <algorithm>
+
+#include "core/ParameterUtils.hpp"
+
+namespace magda {
+
+namespace {
+
+/// The slots the host puts in front of a plugin's own: dry, then wet.
+constexpr int kWrapperParameterCount = 2;
+
+/// The model's record of the parameter at @p index, or none.
+///
+/// Both buckets, because MAGDA splits the incumbent's one list in two: the
+/// plugin's parameters and the wrapper pair it never declared. Both carry the
+/// index a project addresses them by.
+const ParameterInfo* modelParameterAt(const DeviceInfo& device, int index) {
+    for (const auto* bucket : {&device.parameters, &device.wrapperParameters})
+        for (const auto& info : *bucket)
+            if (info.paramIndex == index)
+                return &info;
+
+    return nullptr;
+}
+
+/// The saved chunk, decoded. Empty for a device that saved none and for a
+/// string that is not base64, which is what a project truncated by a failed
+/// write looks like.
+juce::MemoryBlock decodeSavedChunk(const juce::String& savedState) {
+    juce::MemoryBlock chunk;
+
+    if (savedState.isEmpty())
+        return chunk;
+
+    if (!chunk.fromBase64Encoding(savedState))
+        chunk.reset();
+
+    return chunk;
+}
+
+}  // namespace
+
+std::vector<juce::AudioProcessorParameter*> hostParameterOrder(
+    const juce::AudioPluginInstance& instance) {
+    std::vector<juce::AudioProcessorParameter*> order;
+
+    // The wrapper pair, which nothing on the plugin stands behind.
+    order.resize(kWrapperParameterCount, nullptr);
+
+    for (auto* parameter : instance.getParameters())
+        if (parameter != nullptr && parameter->isAutomatable())
+            order.push_back(parameter);
+
+    return order;
+}
+
+bool applySavedPluginState(juce::AudioPluginInstance& instance, const DeviceInfo& device) {
+    const auto order = hostParameterOrder(instance);
+
+    // The array first. A parameter the model does not describe keeps whatever
+    // the plugin was built with: the project has nothing to say about it, which
+    // is what a plugin that has gained a parameter since the project was saved
+    // looks like.
+    for (int index = 0; index < static_cast<int>(order.size()); ++index) {
+        auto* parameter = order[static_cast<std::size_t>(index)];
+        if (parameter == nullptr)
+            continue;
+
+        const auto* info = modelParameterAt(device, index);
+        if (info == nullptr)
+            continue;
+
+        parameter->setValue(
+            std::clamp(ParameterUtils::realToNormalized(info->currentValue, *info), 0.0f, 1.0f));
+    }
+
+    const auto chunk = decodeSavedChunk(device.pluginState);
+    if (chunk.getSize() == 0)
+        return false;
+
+    // DeviceInfo::vst3Preset is deliberately not applied here. It is the
+    // portable .vstpreset a DAWproject carries, applied once on import and
+    // cleared, and its own field comment says what this relies on: interchange
+    // only, native state is pluginState. When the native engine grows an import
+    // path of its own (#2244) it belongs in this function beside the chunk,
+    // rather than in whichever engine happens to be loading the project.
+    try {
+        instance.setStateInformation(chunk.getData(), static_cast<int>(chunk.getSize()));
+    } catch (...) {
+        // Third-party code, handed the input it is least likely to have been
+        // tested against. The baseline above is still standing, which is where
+        // a plugin that refuses a chunk quietly leaves things anyway.
+        return false;
+    }
+
+    return true;
+}
+
+std::vector<RestoredParameter> snapshotHostParameters(const juce::AudioPluginInstance& instance) {
+    const auto order = hostParameterOrder(instance);
+
+    std::vector<RestoredParameter> restored;
+    restored.reserve(order.size());
+
+    for (int index = 0; index < static_cast<int>(order.size()); ++index)
+        if (auto* parameter = order[static_cast<std::size_t>(index)]; parameter != nullptr)
+            restored.push_back({.paramIndex = index, .value = parameter->getValue()});
+
+    return restored;
+}
+
+void applyRestoredParameters(DeviceInfo& device, const std::vector<RestoredParameter>& restored) {
+    for (const auto& parameter : restored)
+        for (auto* bucket : {&device.parameters, &device.wrapperParameters})
+            for (auto& info : *bucket)
+                if (info.paramIndex == parameter.paramIndex)
+                    info.currentValue = ParameterUtils::normalizedToReal(
+                        parameter.value, ParameterUtils::domainOf(info));
+}
+
+}  // namespace magda

--- a/magda/daw/audio/plugin_manager/ExternalPluginState.hpp
+++ b/magda/daw/audio/plugin_manager/ExternalPluginState.hpp
@@ -1,0 +1,109 @@
+#pragma once
+
+#include <juce_audio_processors/juce_audio_processors.h>
+
+#include <vector>
+
+#include "core/DeviceInfo.hpp"
+
+/**
+ * @file ExternalPluginState.hpp
+ * @brief Getting a project's record of a plugin onto a live instance, once
+ *        (#2243).
+ *
+ * A project stores an external plugin twice over, and the two records are not
+ * the same shape. One is an array of parameter values, which is what the UI
+ * draws, what automation addresses and what a preset browser can read. The
+ * other is the chunk the plugin itself wrote, which is fuller: it carries the
+ * current program, a sampler's loaded samples and key mappings, and every value
+ * the plugin never exposed as a parameter at all.
+ *
+ * Neither is redundant and the order between them is load-bearing, so it lives
+ * here rather than in whichever engine happens to be loading the project. The
+ * incumbent's sequence, which this is:
+ *
+ * 1. **The parameter array, as a baseline.** It is what a project has for a
+ *    plugin with no chunk -- one that stores nothing, or whose chunk this build
+ *    of it refuses -- and skipping it leaves such a plugin on its factory
+ *    defaults with the project's own values unused in the model.
+ * 2. **The chunk, over the top.** Where the two disagree the chunk is right and
+ *    the array is stale, which is what every project saved by a MAGDA old
+ *    enough to have written a stale array looks like
+ *    (test_external_plugin_state_restore_juce.cpp).
+ * 3. **A snapshot of what the plugin now holds**, handed back to whoever owns
+ *    the model. That is the step the fork spends `valueChangedByPlugin` on, and
+ *    the reason it exists is the same here: after a restore the model's array
+ *    and the live plugin can disagree, and everything downstream -- an
+ *    automation lane's base value, a knob's position, the values a render
+ *    writes every block -- reads the model. Correcting it is the host's job and
+ *    the message thread's; what this returns is what to correct it to.
+ *
+ * The third step is what keeps the engine out of the guessing business. Without
+ * it a device would have to work out, from the numbers alone, whether a
+ * parameter it is about to write is the project's own value or a stale one the
+ * chunk has already corrected -- and no comparison can tell those apart from an
+ * automation lane that happens to be passing through the same value.
+ */
+
+namespace magda {
+
+/**
+ * @brief The plugin's parameters in the order a project's indices address them.
+ *
+ * Index zero is the slot-level dry level and index one the wet level, both
+ * null: they are the host's own numbers, the plugin has never heard of them,
+ * and no chunk carries them. From two on it is the plugin's own parameters, in
+ * plugin order, skipping any it says are not automatable.
+ *
+ * That shape is not a choice. It is the list the incumbent builds
+ * (ExternalPlugin::buildParameterList) and therefore what MAGDA saved in
+ * ParameterInfo::paramIndex, so anything reading a project's parameter values
+ * back onto a live plugin has to reproduce it. One definition, because two
+ * would eventually differ by one and put a project's cutoff on its resonance.
+ */
+std::vector<juce::AudioProcessorParameter*> hostParameterOrder(
+    const juce::AudioPluginInstance& instance);
+
+/** One parameter's live value, addressed the way a project addresses it. */
+struct RestoredParameter {
+    int paramIndex = 0;
+
+    /// Normalised, which is the unit an external plugin's parameters are in on
+    /// both sides of this: what the plugin takes, and what the model stores.
+    float value = 0.0f;
+};
+
+/**
+ * @brief Apply what @p device saved onto @p instance: array, then chunk.
+ *
+ * Steps one and two above. Returns whether the chunk was applied, which is
+ * false for a device that saved none and for one whose saved state this build
+ * of the plugin could not read.
+ *
+ * A plugin's own state handler is third-party code running in-process, and a
+ * corrupt chunk is exactly the input it is least likely to have been tested
+ * against, so it is called inside a catch-all. A plugin that throws leaves the
+ * baseline standing, which is the same place a plugin that refuses the chunk
+ * quietly leaves it.
+ */
+bool applySavedPluginState(juce::AudioPluginInstance& instance, const DeviceInfo& device);
+
+/**
+ * @brief What @p instance holds now, for the model to record.
+ *
+ * Step three. Every parameter a project addresses, at its live value, in the
+ * order hostParameterOrder() defines. The wrapper pair is not in it: nothing
+ * on the plugin holds those, so there is nothing to read back.
+ */
+std::vector<RestoredParameter> snapshotHostParameters(const juce::AudioPluginInstance& instance);
+
+/**
+ * @brief Write @p restored into @p device's own parameter records.
+ *
+ * The other half of step three, for a host that keeps its model in a DeviceInfo
+ * rather than somewhere of its own. Off the audio thread, on the model, which
+ * is the only place a value like this may be written.
+ */
+void applyRestoredParameters(DeviceInfo& device, const std::vector<RestoredParameter>& restored);
+
+}  // namespace magda

--- a/magda/daw/audio/plugin_manager/ExternalPluginState.hpp
+++ b/magda/daw/audio/plugin_manager/ExternalPluginState.hpp
@@ -73,20 +73,38 @@ struct RestoredParameter {
     float value = 0.0f;
 };
 
+/** How far applySavedPluginState() got. */
+enum class SavedStateOutcome {
+    /// The parameter array is on the instance and no chunk went over it: the
+    /// device saved none, or what it saved was not decodable. A plugin that
+    /// takes a chunk and quietly ignores it lands here too, because from
+    /// outside it is the same thing.
+    Baseline,
+
+    /// The array, then the chunk, both applied.
+    Restored,
+
+    /// The plugin threw partway through reading its own state. What it holds
+    /// now is not the baseline, not the chunk, and not knowable from here.
+    Failed,
+};
+
 /**
  * @brief Apply what @p device saved onto @p instance: array, then chunk.
  *
- * Steps one and two above. Returns whether the chunk was applied, which is
- * false for a device that saved none and for one whose saved state this build
- * of the plugin could not read.
+ * Steps one and two above.
  *
  * A plugin's own state handler is third-party code running in-process, and a
  * corrupt chunk is exactly the input it is least likely to have been tested
- * against, so it is called inside a catch-all. A plugin that throws leaves the
- * baseline standing, which is the same place a plugin that refuses the chunk
- * quietly leaves it.
+ * against, so it is called inside a catch-all. What the catch-all buys is that
+ * the host survives, and nothing more: a plugin is free to have loaded half a
+ * preset, switched program and swapped a sample before it threw, and no
+ * sequence of parameter writes puts any of that back. So a throw is reported as
+ * a failure rather than smoothed over, and the caller's business is to discard
+ * the instance rather than to publish one whose state nobody can describe.
  */
-bool applySavedPluginState(juce::AudioPluginInstance& instance, const DeviceInfo& device);
+SavedStateOutcome applySavedPluginState(juce::AudioPluginInstance& instance,
+                                        const DeviceInfo& device);
 
 /**
  * @brief What @p instance holds now, for the model to record.

--- a/magda/daw/audio/plugin_manager/PluginManagerSync.cpp
+++ b/magda/daw/audio/plugin_manager/PluginManagerSync.cpp
@@ -13,6 +13,7 @@
 #include "../PluginWindowBridge.hpp"
 #include "../TrackController.hpp"
 #include "../TracktionHelpers.hpp"
+#include "ExternalPluginLookup.hpp"
 #include "ExternalPluginStateUtil.hpp"
 #include "PluginManager.hpp"
 #include "modifiers/CurveSnapshot.hpp"
@@ -2142,66 +2143,12 @@ te::Plugin::Ptr PluginManager::createPluginOnly(TrackId trackId, const DeviceInf
             }
         }
     } else {
-        // External plugin — same lookup logic as loadDeviceAsPlugin but without track insertion
+        // External plugin. Which installed plugin the saved device meant is one
+        // question with one answer (ExternalPluginLookup.hpp), asked here, by
+        // the track path below, and by the native engine's device factory.
         if (device.uniqueId.isNotEmpty() || device.fileOrIdentifier.isNotEmpty()) {
-            juce::PluginDescription desc;
-            desc.name = device.name;
-            desc.manufacturerName = device.manufacturer;
-            desc.fileOrIdentifier = device.fileOrIdentifier;
-            desc.isInstrument = device.isInstrument;
-
-            switch (device.format) {
-                case PluginFormat::VST3:
-                    desc.pluginFormatName = "VST3";
-                    break;
-                case PluginFormat::AU:
-                    desc.pluginFormatName = "AudioUnit";
-                    break;
-                case PluginFormat::LV2:
-                    desc.pluginFormatName = "LV2";
-                    break;
-                default:
-                    break;
-            }
-
-            // Try to find a matching plugin in KnownPluginList
-            auto& knownPlugins = engine_.getPluginManager().knownPluginList;
-            bool found = false;
-
-            for (const auto& knownDesc : knownPlugins.getTypes()) {
-                if (knownDesc.fileOrIdentifier == device.fileOrIdentifier &&
-                    knownDesc.isInstrument == device.isInstrument) {
-                    desc = knownDesc;
-                    found = true;
-                    break;
-                }
-            }
-
-            if (!found) {
-                for (const auto& knownDesc : knownPlugins.getTypes()) {
-                    if (knownDesc.name == device.name &&
-                        knownDesc.manufacturerName == device.manufacturer &&
-                        knownDesc.isInstrument == device.isInstrument) {
-                        desc = knownDesc;
-                        found = true;
-                        break;
-                    }
-                }
-            }
-
-            // Final pass: by name + format only (other hosts' deviceRole is
-            // unreliable, so isInstrument can't be required); resolves an imported
-            // plugin to the installed one by name.
-            if (!found) {
-                for (const auto& knownDesc : knownPlugins.getTypes()) {
-                    if (knownDesc.name == device.name &&
-                        knownDesc.pluginFormatName == desc.pluginFormatName) {
-                        desc = knownDesc;
-                        found = true;
-                        break;
-                    }
-                }
-            }
+            auto desc = matchInstalledPlugin(device, engine_.getPluginManager().knownPluginList)
+                            .description;
 
             // Apply TE bug workaround (same as loadExternalPlugin)
             juce::PluginDescription descCopy = desc;
@@ -2343,94 +2290,13 @@ te::Plugin::Ptr PluginManager::loadDeviceAsPlugin(const ChainNodePath& devicePat
             }
         }
     } else {
-        // External plugin - find matching description from KnownPluginList
+        // External plugin. The same lookup the rack path above asks, and the one
+        // the native engine asks (ExternalPluginLookup.hpp).
         if (device.uniqueId.isNotEmpty() || device.fileOrIdentifier.isNotEmpty()) {
-            // Build PluginDescription from DeviceInfo
-            juce::PluginDescription desc;
-            desc.name = device.name;
-            desc.manufacturerName = device.manufacturer;
-            desc.fileOrIdentifier = device.fileOrIdentifier;
-            desc.isInstrument = device.isInstrument;
-
-            // Set format
-            switch (device.format) {
-                case PluginFormat::VST3:
-                    desc.pluginFormatName = "VST3";
-                    break;
-                case PluginFormat::AU:
-                    desc.pluginFormatName = "AudioUnit";
-                    break;
-                case PluginFormat::LV2:
-                    desc.pluginFormatName = "LV2";
-                    break;
-                default:
-                    break;
-            }
-
-            // Try to find a matching plugin in KnownPluginList
-
-            auto& knownPlugins = engine_.getPluginManager().knownPluginList;
-
-            // Debug: dump all plugins that match the name (case insensitive)
-            for (const auto& kd : knownPlugins.getTypes()) {
-                if (kd.name.containsIgnoreCase(device.name) ||
-                    device.name.containsIgnoreCase(kd.name.toStdString())) {
-                }
-            }
-            bool found = false;
-            for (const auto& knownDesc : knownPlugins.getTypes()) {
-                // Match by fileOrIdentifier (most specific) BUT also check isInstrument
-                // to avoid loading FX when instrument is requested
-                if (knownDesc.fileOrIdentifier == device.fileOrIdentifier &&
-                    knownDesc.isInstrument == device.isInstrument) {
-                    desc = knownDesc;
-                    found = true;
-                    break;
-                }
-            }
-
-            // Second pass: match by name, manufacturer, AND isInstrument flag
-            if (!found) {
-                for (const auto& knownDesc : knownPlugins.getTypes()) {
-                    if (knownDesc.name == device.name &&
-                        knownDesc.manufacturerName == device.manufacturer &&
-                        knownDesc.isInstrument == device.isInstrument) {
-                        desc = knownDesc;
-                        found = true;
-                        break;
-                    }
-                }
-            }
-
-            // Third pass: match by fileOrIdentifier only (fallback)
-            if (!found) {
-                for (const auto& knownDesc : knownPlugins.getTypes()) {
-                    if (knownDesc.fileOrIdentifier == device.fileOrIdentifier) {
-                        desc = knownDesc;
-                        found = true;
-                        break;
-                    }
-                }
-            }
-
-            // Final pass: match by name + format + isInstrument, ignoring vendor
-            // and file path. DAWproject from other hosts (Bitwig) carries the
-            // plugin name and the VST3 class id, but not MAGDA's file path or the
-            // vendor, so the earlier passes can't resolve it; the name is the only
-            // portable handle to the installed plugin.
-            // Final pass: match by name + format only. Other hosts' deviceRole is
-            // unreliable (Bitwig exports Serum, an instrument, as "audioFX"), so we
-            // can't require isInstrument to agree; the name is the portable handle.
-            if (!found) {
-                for (const auto& knownDesc : knownPlugins.getTypes()) {
-                    if (knownDesc.name == device.name &&
-                        knownDesc.pluginFormatName == desc.pluginFormatName) {
-                        desc = knownDesc;
-                        found = true;
-                        break;
-                    }
-                }
-            }
+            const auto match =
+                matchInstalledPlugin(device, engine_.getPluginManager().knownPluginList);
+            auto desc = match.description;
+            const bool found = match.found;
 
             // Adopt the resolved plugin's instrument classification (the imported
             // deviceRole may be wrong), so MAGDA wraps/routes it correctly. A

--- a/magda/daw/audio/plugin_manager/PluginManagerSync.cpp
+++ b/magda/daw/audio/plugin_manager/PluginManagerSync.cpp
@@ -2146,7 +2146,13 @@ te::Plugin::Ptr PluginManager::createPluginOnly(TrackId trackId, const DeviceInf
         // External plugin. Which installed plugin the saved device meant is one
         // question with one answer (ExternalPluginLookup.hpp), asked here, by
         // the track path below, and by the native engine's device factory.
-        if (device.uniqueId.isNotEmpty() || device.fileOrIdentifier.isNotEmpty()) {
+        //
+        // Asked for every external device rather than only for one that saved
+        // an id or a file. The lookup resolves an imported project by name and
+        // format, which is the case a device with neither of those is, and the
+        // guard that used to stand here meant the pass written for that case
+        // could never run.
+        {
             auto desc = matchInstalledPlugin(device, engine_.getPluginManager().knownPluginList)
                             .description;
 
@@ -2291,8 +2297,10 @@ te::Plugin::Ptr PluginManager::loadDeviceAsPlugin(const ChainNodePath& devicePat
         }
     } else {
         // External plugin. The same lookup the rack path above asks, and the one
-        // the native engine asks (ExternalPluginLookup.hpp).
-        if (device.uniqueId.isNotEmpty() || device.fileOrIdentifier.isNotEmpty()) {
+        // the native engine asks (ExternalPluginLookup.hpp), for every external
+        // device rather than only one that saved an id or a file: see the note
+        // on the rack path.
+        {
             const auto match =
                 matchInstalledPlugin(device, engine_.getPluginManager().knownPluginList);
             auto desc = match.description;
@@ -2348,7 +2356,6 @@ te::Plugin::Ptr PluginManager::loadDeviceAsPlugin(const ChainNodePath& devicePat
                 }
                 return nullptr;  // Don't proceed with a failed plugin
             }
-        } else {
         }
     }
 

--- a/magda/daw/audio/plugins/engine/EngineDeviceFactory.cpp
+++ b/magda/daw/audio/plugins/engine/EngineDeviceFactory.cpp
@@ -4,6 +4,7 @@
 
 #include "core/DeviceState.hpp"
 #include "plugin_manager/ExternalPluginLookup.hpp"
+#include "plugin_manager/ExternalPluginState.hpp"
 #include "plugins/InternalPluginRegistry.hpp"
 #include "plugins/compiled/CompiledPluginRegistry.hpp"
 #include "plugins/engine/EngineExternalDevice.hpp"
@@ -86,45 +87,6 @@ void restoreSavedState(MagdaDevice& device, const juce::String& savedState) {
     device.restoreState(tree);
 }
 
-/**
- * @brief The plugin's own state, as the project saved it.
- *
- * Base64 of what getStateInformation wrote, which is the one thing MAGDA
- * persists for an external plugin and the only thing that carries what a
- * parameter array cannot: the current program, a sampler's loaded samples and
- * key mappings, and every value the plugin never exposed as a parameter. A
- * plugin created without it renders its initialised voice, which is a different
- * project rather than a quieter one.
- *
- * DeviceInfo::vst3Preset is not this and is not applied here. It is the
- * portable .vstpreset a DAWproject carries, applied once on import and cleared
- * (PluginManagerSync), and the field's own comment says what this file relies
- * on: interchange only, native state is pluginState.
- *
- * What happens afterwards is the same rule the fork reaches by another route.
- * The fork applies the saved parameter array, overlays the chunk, then
- * refreshes its own parameter cache from the plugin, so nothing writes the
- * array back and the chunk wins. Here the chunk is applied at creation and the
- * adapter declines to write a parameter that is still sitting where the project
- * said it sits (EngineExternalDevice::writeParameters), which comes to the same
- * thing without the engine writing to the model from a render.
- *
- * That the two saved records can disagree at all is not hypothetical: every
- * project written by a MAGDA old enough to have saved a stale array beside a
- * good chunk is this case, which is what
- * test_external_plugin_state_restore_juce.cpp was written for.
- */
-void restoreSavedChunk(juce::AudioPluginInstance& instance, const juce::String& savedState) {
-    if (savedState.isEmpty())
-        return;
-
-    juce::MemoryBlock chunk;
-    if (!chunk.fromBase64Encoding(savedState) || chunk.getSize() == 0)
-        return;
-
-    instance.setStateInformation(chunk.getData(), static_cast<int>(chunk.getSize()));
-}
-
 }  // namespace
 
 /// enableAllBuses first, at the same point the fork does it
@@ -137,15 +99,17 @@ ExternalDeviceResult adaptExternalPluginInstance(
     bool offlineRender) {
     instance->enableAllBuses();
 
-    // Before the adapter, not after, and for the same reason the internal path
-    // restores before wrapping: the adapter reads the plugin's parameter list
-    // when it is constructed, and a plugin that changes which parameters it has
-    // when its state is applied would be mapped against the ones it had first.
-    restoreSavedChunk(*instance, device.pluginState);
+    // The saved array, then the chunk over it, then what that left behind. The
+    // order and the reasons are ExternalPluginState.hpp's; what matters here is
+    // that all three happen before the adapter exists, so the adapter never has
+    // to reason about which of a project's two records it is looking at.
+    magda::applySavedPluginState(*instance, device);
+    auto restored = magda::snapshotHostParameters(*instance);
 
     return {.device =
                 std::make_unique<EngineExternalDevice>(std::move(instance), device, offlineRender),
-            .failure = {}};
+            .failure = {},
+            .restoredParameters = std::move(restored)};
 }
 
 namespace {

--- a/magda/daw/audio/plugins/engine/EngineDeviceFactory.cpp
+++ b/magda/daw/audio/plugins/engine/EngineDeviceFactory.cpp
@@ -206,7 +206,7 @@ ExternalDeviceResult createEngineExternalDevice(const magda::DeviceInfo& device,
 
 ExternalDeviceResult completeExternalPluginLoad(std::unique_ptr<juce::AudioPluginInstance> instance,
                                                 const juce::String& error,
-                                                const juce::PluginDescription& requested,
+                                                const RequestedPlugin& requested,
                                                 const CurrentDeviceLookup& currentDevice,
                                                 bool offlineRender) {
     // The model first, before anything is done with the instance. Everything
@@ -226,8 +226,12 @@ ExternalDeviceResult completeExternalPluginLoad(std::unique_ptr<juce::AudioPlugi
     // And it has to still be the same plugin. A device whose plugin was
     // replaced while this one loaded is not waiting for this answer, and
     // restoring onto it would put one plugin's saved patch on another.
-    if (magda::describeSavedPlugin(*device).createIdentifierString() !=
-        requested.createIdentifierString())
+    //
+    // The model's identity on both sides. The scanned description's identifier
+    // carries the plugin's numeric uid and a device's saved fields do not, so
+    // comparing this against that would find every unchanged plugin changed and
+    // refuse every load there is.
+    if (!magda::savedPluginIdentity(*device).namesSamePluginAs(requested.identity))
         return {.device = {},
                 .failure =
                     "the device changed plugin while \"" + requested.name + "\" was loading"};
@@ -253,9 +257,10 @@ void createEngineExternalDeviceAsync(const magda::DeviceInfo& device,
     // to move on: see CurrentDeviceLookup.
     services.formats->createPluginInstanceAsync(
         resolved.description, services.context.sampleRate, services.context.maxBlockSize,
-        [requested = resolved.description, currentDevice = std::move(currentDevice), offlineRender,
-         completed = std::move(completed)](std::unique_ptr<juce::AudioPluginInstance> instance,
-                                           const juce::String& error) {
+        [requested = RequestedPlugin{.identity = magda::savedPluginIdentity(device),
+                                     .name = resolved.description.name},
+         currentDevice = std::move(currentDevice), offlineRender, completed = std::move(completed)](
+            std::unique_ptr<juce::AudioPluginInstance> instance, const juce::String& error) {
             completed(completeExternalPluginLoad(std::move(instance), error, requested,
                                                  currentDevice, offlineRender));
         });

--- a/magda/daw/audio/plugins/engine/EngineDeviceFactory.cpp
+++ b/magda/daw/audio/plugins/engine/EngineDeviceFactory.cpp
@@ -86,21 +86,69 @@ void restoreSavedState(MagdaDevice& device, const juce::String& savedState) {
     device.restoreState(tree);
 }
 
-/// The adapter over an instance the format manager just handed back.
-///
+/**
+ * @brief The plugin's own state, as the project saved it.
+ *
+ * Base64 of what getStateInformation wrote, which is the one thing MAGDA
+ * persists for an external plugin and the only thing that carries what a
+ * parameter array cannot: the current program, a sampler's loaded samples and
+ * key mappings, and every value the plugin never exposed as a parameter. A
+ * plugin created without it renders its initialised voice, which is a different
+ * project rather than a quieter one.
+ *
+ * DeviceInfo::vst3Preset is not this and is not applied here. It is the
+ * portable .vstpreset a DAWproject carries, applied once on import and cleared
+ * (PluginManagerSync), and the field's own comment says what this file relies
+ * on: interchange only, native state is pluginState.
+ *
+ * What happens afterwards is worth stating, because it is the native engine's
+ * answer to the precedence the fork spends three steps on. The fork applies the
+ * saved parameter array, overlays the chunk, then refreshes its parameter cache
+ * from the plugin so the chunk wins. Here the chunk is applied at creation and
+ * the plan writes every parameter it knows about before each block, so for an
+ * automatable parameter the model is authoritative and for everything else the
+ * chunk is. Those agree in a project MAGDA saved, because the app writes the
+ * refreshed values back into the model; where they disagree -- a chunk written
+ * by another version of the plugin -- the model wins for the parameters it has.
+ * Whether that is the right way round for a dual-engine release is #2244's
+ * question, and it is a question about which number to keep rather than about
+ * whether the patch loads.
+ */
+void restoreSavedChunk(juce::AudioPluginInstance& instance, const juce::String& savedState) {
+    if (savedState.isEmpty())
+        return;
+
+    juce::MemoryBlock chunk;
+    if (!chunk.fromBase64Encoding(savedState) || chunk.getSize() == 0)
+        return;
+
+    instance.setStateInformation(chunk.getData(), static_cast<int>(chunk.getSize()));
+}
+
+}  // namespace
+
 /// enableAllBuses first, at the same point the fork does it
 /// (completePluginInstanceCreation) and for the same reason: a plugin whose
 /// sidechain or second output bus is disabled reports channels it does not
 /// have, and everything downstream -- the adapter's own channel adaptation, the
 /// plan's declared widths -- is read off those numbers.
-ExternalDeviceResult adaptInstance(std::unique_ptr<juce::AudioPluginInstance> instance,
-                                   const magda::DeviceInfo& device, bool offlineRender) {
+ExternalDeviceResult adaptExternalPluginInstance(
+    std::unique_ptr<juce::AudioPluginInstance> instance, const magda::DeviceInfo& device,
+    bool offlineRender) {
     instance->enableAllBuses();
+
+    // Before the adapter, not after, and for the same reason the internal path
+    // restores before wrapping: the adapter reads the plugin's parameter list
+    // when it is constructed, and a plugin that changes which parameters it has
+    // when its state is applied would be mapped against the ones it had first.
+    restoreSavedChunk(*instance, device.pluginState);
 
     return {.device =
                 std::make_unique<EngineExternalDevice>(std::move(instance), device, offlineRender),
             .failure = {}};
 }
+
+namespace {
 
 /// Why a plugin nobody could find is missing, said once so both entry points
 /// say it the same way.
@@ -189,7 +237,7 @@ ExternalDeviceResult createEngineExternalDevice(const magda::DeviceInfo& device,
                 .failure = "external plugin \"" + device.name + "\" could not be loaded: " +
                            (error.isNotEmpty() ? error : "no reason given")};
 
-    return adaptInstance(std::move(instance), device, offlineRender);
+    return adaptExternalPluginInstance(std::move(instance), device, offlineRender);
 }
 
 void createEngineExternalDeviceAsync(const magda::DeviceInfo& device,
@@ -219,7 +267,7 @@ void createEngineExternalDeviceAsync(const magda::DeviceInfo& device,
                 return;
             }
 
-            completed(adaptInstance(std::move(instance), saved, offlineRender));
+            completed(adaptExternalPluginInstance(std::move(instance), saved, offlineRender));
         });
 }
 

--- a/magda/daw/audio/plugins/engine/EngineDeviceFactory.cpp
+++ b/magda/daw/audio/plugins/engine/EngineDeviceFactory.cpp
@@ -204,10 +204,43 @@ ExternalDeviceResult createEngineExternalDevice(const magda::DeviceInfo& device,
     return adaptExternalPluginInstance(std::move(instance), device, offlineRender);
 }
 
+ExternalDeviceResult completeExternalPluginLoad(std::unique_ptr<juce::AudioPluginInstance> instance,
+                                                const juce::String& error,
+                                                const juce::PluginDescription& requested,
+                                                const CurrentDeviceLookup& currentDevice,
+                                                bool offlineRender) {
+    // The model first, before anything is done with the instance. Everything
+    // below restores from it, and it is a different object from the one the
+    // load was requested with: seconds have passed.
+    const auto* device = currentDevice ? currentDevice() : nullptr;
+
+    if (device == nullptr)
+        return {.device = {},
+                .failure = "the device was removed while \"" + requested.name + "\" was loading"};
+
+    if (instance == nullptr)
+        return {.device = {},
+                .failure = "external plugin \"" + device->name + "\" could not be loaded: " +
+                           (error.isNotEmpty() ? error : "no reason given")};
+
+    // And it has to still be the same plugin. A device whose plugin was
+    // replaced while this one loaded is not waiting for this answer, and
+    // restoring onto it would put one plugin's saved patch on another.
+    if (magda::describeSavedPlugin(*device).createIdentifierString() !=
+        requested.createIdentifierString())
+        return {.device = {},
+                .failure =
+                    "the device changed plugin while \"" + requested.name + "\" was loading"};
+
+    return adaptExternalPluginInstance(std::move(instance), *device, offlineRender);
+}
+
 void createEngineExternalDeviceAsync(const magda::DeviceInfo& device,
                                      const ExternalPluginServices& services, bool offlineRender,
+                                     CurrentDeviceLookup currentDevice,
                                      std::function<void(ExternalDeviceResult)> completed) {
     jassert(completed != nullptr);
+    jassert(currentDevice != nullptr);
 
     const auto resolved = resolvePlugin(device, services);
     if (resolved.failure.isNotEmpty()) {
@@ -215,23 +248,16 @@ void createEngineExternalDeviceAsync(const magda::DeviceInfo& device,
         return;
     }
 
-    // The device is copied into the callback rather than captured by reference.
-    // What it is read for is its parameter metadata, and the model it came from
-    // is free to be edited, moved or deleted while a plugin loads: that is what
-    // taking seconds means.
+    // Nothing of the model is captured here. What the callback needs from it is
+    // read when the callback runs, because by then the project has had seconds
+    // to move on: see CurrentDeviceLookup.
     services.formats->createPluginInstanceAsync(
         resolved.description, services.context.sampleRate, services.context.maxBlockSize,
-        [saved = device, offlineRender, completed = std::move(completed)](
-            std::unique_ptr<juce::AudioPluginInstance> instance, const juce::String& error) {
-            if (instance == nullptr) {
-                completed({.device = {},
-                           .failure = "external plugin \"" + saved.name +
-                                      "\" could not be loaded: " +
-                                      (error.isNotEmpty() ? error : "no reason given")});
-                return;
-            }
-
-            completed(adaptExternalPluginInstance(std::move(instance), saved, offlineRender));
+        [requested = resolved.description, currentDevice = std::move(currentDevice), offlineRender,
+         completed = std::move(completed)](std::unique_ptr<juce::AudioPluginInstance> instance,
+                                           const juce::String& error) {
+            completed(completeExternalPluginLoad(std::move(instance), error, requested,
+                                                 currentDevice, offlineRender));
         });
 }
 

--- a/magda/daw/audio/plugins/engine/EngineDeviceFactory.cpp
+++ b/magda/daw/audio/plugins/engine/EngineDeviceFactory.cpp
@@ -103,7 +103,11 @@ ExternalDeviceResult adaptExternalPluginInstance(
     // order and the reasons are ExternalPluginState.hpp's; what matters here is
     // that all three happen before the adapter exists, so the adapter never has
     // to reason about which of a project's two records it is looking at.
-    magda::applySavedPluginState(*instance, device);
+    if (magda::applySavedPluginState(*instance, device) == magda::SavedStateOutcome::Failed)
+        return {.device = {},
+                .failure = "external plugin \"" + device.name +
+                           "\" failed while restoring its own saved state"};
+
     auto restored = magda::snapshotHostParameters(*instance);
 
     return {.device =

--- a/magda/daw/audio/plugins/engine/EngineDeviceFactory.cpp
+++ b/magda/daw/audio/plugins/engine/EngineDeviceFactory.cpp
@@ -101,18 +101,18 @@ void restoreSavedState(MagdaDevice& device, const juce::String& savedState) {
  * (PluginManagerSync), and the field's own comment says what this file relies
  * on: interchange only, native state is pluginState.
  *
- * What happens afterwards is worth stating, because it is the native engine's
- * answer to the precedence the fork spends three steps on. The fork applies the
- * saved parameter array, overlays the chunk, then refreshes its parameter cache
- * from the plugin so the chunk wins. Here the chunk is applied at creation and
- * the plan writes every parameter it knows about before each block, so for an
- * automatable parameter the model is authoritative and for everything else the
- * chunk is. Those agree in a project MAGDA saved, because the app writes the
- * refreshed values back into the model; where they disagree -- a chunk written
- * by another version of the plugin -- the model wins for the parameters it has.
- * Whether that is the right way round for a dual-engine release is #2244's
- * question, and it is a question about which number to keep rather than about
- * whether the patch loads.
+ * What happens afterwards is the same rule the fork reaches by another route.
+ * The fork applies the saved parameter array, overlays the chunk, then
+ * refreshes its own parameter cache from the plugin, so nothing writes the
+ * array back and the chunk wins. Here the chunk is applied at creation and the
+ * adapter declines to write a parameter that is still sitting where the project
+ * said it sits (EngineExternalDevice::writeParameters), which comes to the same
+ * thing without the engine writing to the model from a render.
+ *
+ * That the two saved records can disagree at all is not hypothetical: every
+ * project written by a MAGDA old enough to have saved a stale array beside a
+ * good chunk is this case, which is what
+ * test_external_plugin_state_restore_juce.cpp was written for.
  */
 void restoreSavedChunk(juce::AudioPluginInstance& instance, const juce::String& savedState) {
     if (savedState.isEmpty())

--- a/magda/daw/audio/plugins/engine/EngineDeviceFactory.cpp
+++ b/magda/daw/audio/plugins/engine/EngineDeviceFactory.cpp
@@ -3,8 +3,10 @@
 #include <utility>
 
 #include "core/DeviceState.hpp"
+#include "plugin_manager/ExternalPluginLookup.hpp"
 #include "plugins/InternalPluginRegistry.hpp"
 #include "plugins/compiled/CompiledPluginRegistry.hpp"
+#include "plugins/engine/EngineExternalDevice.hpp"
 #include "plugins/engine/EngineMagdaDevice.hpp"
 
 namespace magda::daw::audio::engine_adapter {
@@ -84,6 +86,57 @@ void restoreSavedState(MagdaDevice& device, const juce::String& savedState) {
     device.restoreState(tree);
 }
 
+/// The adapter over an instance the format manager just handed back.
+///
+/// enableAllBuses first, at the same point the fork does it
+/// (completePluginInstanceCreation) and for the same reason: a plugin whose
+/// sidechain or second output bus is disabled reports channels it does not
+/// have, and everything downstream -- the adapter's own channel adaptation, the
+/// plan's declared widths -- is read off those numbers.
+ExternalDeviceResult adaptInstance(std::unique_ptr<juce::AudioPluginInstance> instance,
+                                   const magda::DeviceInfo& device, bool offlineRender) {
+    instance->enableAllBuses();
+
+    return {.device =
+                std::make_unique<EngineExternalDevice>(std::move(instance), device, offlineRender),
+            .failure = {}};
+}
+
+/// Why a plugin nobody could find is missing, said once so both entry points
+/// say it the same way.
+juce::String describeMissingPlugin(const magda::DeviceInfo& device) {
+    return "external plugin \"" + device.name + "\" (" + device.getFormatString() +
+           ") is not installed on this machine";
+}
+
+/// What the two entry points check before either asks a format manager for
+/// anything: the services are complete, and the scan knows the plugin.
+///
+/// Returns the description to load, or the reason there is not one.
+struct ResolvedPlugin {
+    juce::PluginDescription description;
+    juce::String failure;
+};
+
+ResolvedPlugin resolvePlugin(const magda::DeviceInfo& device,
+                             const ExternalPluginServices& services) {
+    if (services.formats == nullptr || services.knownPlugins == nullptr)
+        return {.description = {},
+                .failure = "no plugin formats or scan results were given to the engine"};
+
+    const auto match = magda::matchInstalledPlugin(device, *services.knownPlugins);
+
+    // Unfound is refused rather than attempted. The app tries the saved
+    // description anyway and lets the format's own lookup have a go, which is
+    // right for a session where a user is watching and can be told; a render is
+    // not that, and a plugin resolved by a route nothing recorded is the kind
+    // of difference a null-diff corpus cannot attribute afterwards.
+    if (!match.found)
+        return {.description = {}, .failure = describeMissingPlugin(device)};
+
+    return {.description = match.description, .failure = {}};
+}
+
 }  // namespace
 
 std::unique_ptr<magda::engine::EngineDevice> createEngineDevice(const magda::DeviceInfo& device,
@@ -113,6 +166,61 @@ bool canCreateEngineDevice(const juce::String& pluginId) {
 bool isRegisteredDevice(const juce::String& pluginId) {
     return findInternalPluginSpec(pluginId) != nullptr ||
            compiled::findCompiledPluginSpec(pluginId) != nullptr;
+}
+
+bool isInstalledExternalPlugin(const magda::DeviceInfo& device,
+                               const juce::KnownPluginList& knownPlugins) {
+    return magda::matchInstalledPlugin(device, knownPlugins).found;
+}
+
+ExternalDeviceResult createEngineExternalDevice(const magda::DeviceInfo& device,
+                                                const ExternalPluginServices& services,
+                                                bool offlineRender) {
+    const auto resolved = resolvePlugin(device, services);
+    if (resolved.failure.isNotEmpty())
+        return {.device = {}, .failure = resolved.failure};
+
+    juce::String error;
+    auto instance = services.formats->createPluginInstance(
+        resolved.description, services.context.sampleRate, services.context.maxBlockSize, error);
+
+    if (instance == nullptr)
+        return {.device = {},
+                .failure = "external plugin \"" + device.name + "\" could not be loaded: " +
+                           (error.isNotEmpty() ? error : "no reason given")};
+
+    return adaptInstance(std::move(instance), device, offlineRender);
+}
+
+void createEngineExternalDeviceAsync(const magda::DeviceInfo& device,
+                                     const ExternalPluginServices& services, bool offlineRender,
+                                     std::function<void(ExternalDeviceResult)> completed) {
+    jassert(completed != nullptr);
+
+    const auto resolved = resolvePlugin(device, services);
+    if (resolved.failure.isNotEmpty()) {
+        completed({.device = {}, .failure = resolved.failure});
+        return;
+    }
+
+    // The device is copied into the callback rather than captured by reference.
+    // What it is read for is its parameter metadata, and the model it came from
+    // is free to be edited, moved or deleted while a plugin loads: that is what
+    // taking seconds means.
+    services.formats->createPluginInstanceAsync(
+        resolved.description, services.context.sampleRate, services.context.maxBlockSize,
+        [saved = device, offlineRender, completed = std::move(completed)](
+            std::unique_ptr<juce::AudioPluginInstance> instance, const juce::String& error) {
+            if (instance == nullptr) {
+                completed({.device = {},
+                           .failure = "external plugin \"" + saved.name +
+                                      "\" could not be loaded: " +
+                                      (error.isNotEmpty() ? error : "no reason given")});
+                return;
+            }
+
+            completed(adaptInstance(std::move(instance), saved, offlineRender));
+        });
 }
 
 }  // namespace magda::daw::audio::engine_adapter

--- a/magda/daw/audio/plugins/engine/EngineDeviceFactory.hpp
+++ b/magda/daw/audio/plugins/engine/EngineDeviceFactory.hpp
@@ -172,7 +172,41 @@ ExternalDeviceResult createEngineExternalDevice(const magda::DeviceInfo& device,
                                                 bool offlineRender = false);
 
 /**
- * @brief The same, without waiting for it.
+ * @brief What the model says about this device now, asked on the message thread.
+ *
+ * A plugin takes seconds to load and a project does not stop while it does. By
+ * the time one arrives its device may have been edited, had a preset applied,
+ * or been deleted, and the restoration is about to write the model's parameter
+ * values onto the instance and hand corrected ones back. Doing that from a copy
+ * taken when the load was requested would quietly undo whatever happened in
+ * between.
+ *
+ * So the model is read at completion rather than captured at request. Null
+ * means the device is gone, and the load is abandoned rather than completed
+ * against a project that no longer has it.
+ */
+using CurrentDeviceLookup = std::function<const magda::DeviceInfo*()>;
+
+/**
+ * @brief The end of an asynchronous load, once the instance exists.
+ *
+ * The seam the callback below ends at, and a host with a loader of its own
+ * calls it directly. @p error is what the loader reported, used only when @p
+ * instance is null.
+ *
+ * It resolves @p currentDevice first: a device that has gone, or that now names
+ * a different plugin from the one that was asked for, is a load whose answer
+ * arrived too late to be useful, and completing it would put a stale patch on a
+ * device somebody has since changed.
+ */
+ExternalDeviceResult completeExternalPluginLoad(std::unique_ptr<juce::AudioPluginInstance> instance,
+                                                const juce::String& error,
+                                                const juce::PluginDescription& requested,
+                                                const CurrentDeviceLookup& currentDevice,
+                                                bool offlineRender = false);
+
+/**
+ * @brief The same as createEngineExternalDevice, without waiting for it.
  *
  * @p completed runs on the message thread when the plugin is ready or has
  * failed. Until then the plan has no device bound for that op, which the
@@ -180,9 +214,14 @@ ExternalDeviceResult createEngineExternalDevice(const magda::DeviceInfo& device,
  * through and says so in the diagnostics. Completion is therefore a re-prepare
  * rather than a hand-off -- bindings are resolved when a plan is prepared, so a
  * device that arrives later is published and the plan prepared again.
+ *
+ * @p device is read once, now, to work out which plugin to load.
+ * @p currentDevice is read again at completion, to work out what to restore
+ * onto it; see CurrentDeviceLookup for why those are two different questions.
  */
 void createEngineExternalDeviceAsync(const magda::DeviceInfo& device,
                                      const ExternalPluginServices& services, bool offlineRender,
+                                     CurrentDeviceLookup currentDevice,
                                      std::function<void(ExternalDeviceResult)> completed);
 
 /**

--- a/magda/daw/audio/plugins/engine/EngineDeviceFactory.hpp
+++ b/magda/daw/audio/plugins/engine/EngineDeviceFactory.hpp
@@ -1,9 +1,13 @@
 #pragma once
 
+#include <juce_audio_processors/juce_audio_processors.h>
+
+#include <functional>
 #include <memory>
 
 #include "core/DeviceInfo.hpp"
 #include "exec/EngineDevice.hpp"
+#include "exec/RenderContext.hpp"
 
 /**
  * @file EngineDeviceFactory.hpp
@@ -28,6 +32,13 @@
  * by the first sample. What is not carried yet is the rest of a device's state
  * -- what MagdaDevice::restoreState() takes -- which is the pluginState v2
  * contract (#1887) and belongs with the state slice rather than with this one.
+ *
+ * The second half of the file is the same job for a plugin MAGDA did not write
+ * (#2243). It is a different job in one respect that shapes everything below:
+ * an internal device is a class this build contains and either exists or does
+ * not, while an external plugin is a file on a machine that may have moved,
+ * been upgraded, or never been installed. So creating one can fail for reasons
+ * worth telling a user about, and it returns why rather than a null.
  */
 
 namespace magda::daw::audio::engine_adapter {
@@ -69,5 +80,78 @@ bool canCreateEngineDevice(const juce::String& pluginId);
  * signal through is a render of a different project.
  */
 bool isRegisteredDevice(const juce::String& pluginId);
+
+/**
+ * @brief What a host hands over before the engine can make an external plugin.
+ *
+ * Two things the engine has no way to own: the formats this build can load, and
+ * what the last scan found installed. Both are the app's, and both are plain
+ * JUCE rather than anything of the incumbent engine's, which is what lets the
+ * native engine ask for them without reaching into it.
+ *
+ * The render context is here because a plugin is told the rate and block size
+ * as it is created, before anything prepares it. It is prepared again by the
+ * adapter, so this is not the authority on either number -- it is what a plugin
+ * that allocates at construction has to go on.
+ */
+struct ExternalPluginServices {
+    juce::AudioPluginFormatManager* formats = nullptr;
+    const juce::KnownPluginList* knownPlugins = nullptr;
+    magda::engine::RenderContext context{};
+};
+
+/**
+ * @brief An external device, or why there is not one.
+ *
+ * Exactly one of the two is set. The failure is a sentence for a person: which
+ * plugin, and what went wrong finding or loading it. A caller that has nowhere
+ * to put it may drop it; a caller rendering a corpus case prints it, because a
+ * project rendered without its plugin is a render of a different project.
+ */
+struct ExternalDeviceResult {
+    std::unique_ptr<magda::engine::EngineDevice> device;
+    juce::String failure;
+};
+
+/**
+ * @brief The external plugin @p device names, created and ready to bind.
+ *
+ * Blocking: it resolves the description, loads the plugin and returns. What
+ * that suits is a render waiting for the answer -- an offline bounce, a corpus
+ * case -- where there is nothing to do until the plugin is there.
+ *
+ * A session opening a project wants the asynchronous form below instead, since
+ * a plugin can take seconds to load and a project with forty of them would
+ * otherwise open in a minute.
+ */
+ExternalDeviceResult createEngineExternalDevice(const magda::DeviceInfo& device,
+                                                const ExternalPluginServices& services,
+                                                bool offlineRender = false);
+
+/**
+ * @brief The same, without waiting for it.
+ *
+ * @p completed runs on the message thread when the plugin is ready or has
+ * failed. Until then the plan has no device bound for that op, which the
+ * executor already handles the way the incumbent does: the op passes its audio
+ * through and says so in the diagnostics. Completion is therefore a re-prepare
+ * rather than a hand-off -- bindings are resolved when a plan is prepared, so a
+ * device that arrives later is published and the plan prepared again.
+ */
+void createEngineExternalDeviceAsync(const magda::DeviceInfo& device,
+                                     const ExternalPluginServices& services, bool offlineRender,
+                                     std::function<void(ExternalDeviceResult)> completed);
+
+/**
+ * @brief Whether the scan knows the plugin @p device names.
+ *
+ * The question a report asks before it renders: a project whose plugin is not
+ * installed on this machine renders without it in both engines, and that is
+ * worth saying once rather than being read off a residual afterwards. True does
+ * not promise the plugin will load -- a scanned plugin can still fail to
+ * instantiate -- only that there is one to try.
+ */
+bool isInstalledExternalPlugin(const magda::DeviceInfo& device,
+                               const juce::KnownPluginList& knownPlugins);
 
 }  // namespace magda::daw::audio::engine_adapter

--- a/magda/daw/audio/plugins/engine/EngineDeviceFactory.hpp
+++ b/magda/daw/audio/plugins/engine/EngineDeviceFactory.hpp
@@ -8,6 +8,7 @@
 #include "core/DeviceInfo.hpp"
 #include "exec/EngineDevice.hpp"
 #include "exec/RenderContext.hpp"
+#include "plugin_manager/ExternalPluginState.hpp"
 
 /**
  * @file EngineDeviceFactory.hpp
@@ -41,11 +42,11 @@
  * worth telling a user about, and it returns why rather than a null.
  *
  * An external plugin's saved state does travel, unlike an internal device's:
- * MAGDA persists the plugin's own chunk and it is applied before the adapter
- * takes the instance. What that leaves for the state slice (#2244) is the other
- * direction -- writing the chunk back out of an instance the native engine
- * holds, so a project round-trips between the two engines during the
- * dual-engine release.
+ * MAGDA persists the plugin's own chunk, and the adapter applies it along with
+ * the saved parameter array it overlays (EngineExternalDevice::applySavedState).
+ * What that leaves for the state slice (#2244) is the other direction --
+ * writing the chunk back out of an instance the native engine holds, so a
+ * project round-trips between the two engines during the dual-engine release.
  */
 
 namespace magda::daw::audio::engine_adapter {
@@ -118,15 +119,38 @@ struct ExternalPluginServices {
 struct ExternalDeviceResult {
     std::unique_ptr<magda::engine::EngineDevice> device;
     juce::String failure;
+
+    /**
+     * @brief What the plugin holds now, for the caller to write into its model.
+     *
+     * Restoring a plugin is not only something done to the plugin: a project's
+     * saved parameter array and the chunk beside it can disagree, the chunk
+     * wins, and everything downstream reads the model rather than the plugin.
+     * An automation lane's base value, a knob's position, and the values a
+     * render writes every block all come from there, so a model left holding
+     * the stale array would put them back on the next block.
+     *
+     * The engine does not correct the model itself and could not: the model is
+     * the one authority and this is a render path. So the correction is handed
+     * back, and applying it is the caller's, on the message thread
+     * (magda::applyRestoredParameters). A caller that already knows its model
+     * agrees with the plugin -- a project saved by a build that refreshed it --
+     * applies the same values it already had.
+     *
+     * Empty when nothing was created.
+     */
+    std::vector<magda::RestoredParameter> restoredParameters;
 };
 
 /**
  * @brief The adapter over an instance the host made itself.
  *
  * What both entry points below end at, and the seam for a host that creates its
- * plugins some other way. It enables the instance's buses and applies the
- * project's saved state before the adapter takes it, because the adapter reads
- * the plugin's parameter list when it is constructed.
+ * plugins some other way. One transaction: the instance's buses are enabled,
+ * which has to happen before anything reads its channel counts; the project's
+ * saved parameter array and its chunk are applied in that order; and what the
+ * plugin holds afterwards comes back in the result for the caller to write into
+ * its model (ExternalPluginState.hpp).
  */
 ExternalDeviceResult adaptExternalPluginInstance(
     std::unique_ptr<juce::AudioPluginInstance> instance, const magda::DeviceInfo& device,

--- a/magda/daw/audio/plugins/engine/EngineDeviceFactory.hpp
+++ b/magda/daw/audio/plugins/engine/EngineDeviceFactory.hpp
@@ -39,6 +39,13 @@
  * not, while an external plugin is a file on a machine that may have moved,
  * been upgraded, or never been installed. So creating one can fail for reasons
  * worth telling a user about, and it returns why rather than a null.
+ *
+ * An external plugin's saved state does travel, unlike an internal device's:
+ * MAGDA persists the plugin's own chunk and it is applied before the adapter
+ * takes the instance. What that leaves for the state slice (#2244) is the other
+ * direction -- writing the chunk back out of an instance the native engine
+ * holds, so a project round-trips between the two engines during the
+ * dual-engine release.
  */
 
 namespace magda::daw::audio::engine_adapter {
@@ -112,6 +119,18 @@ struct ExternalDeviceResult {
     std::unique_ptr<magda::engine::EngineDevice> device;
     juce::String failure;
 };
+
+/**
+ * @brief The adapter over an instance the host made itself.
+ *
+ * What both entry points below end at, and the seam for a host that creates its
+ * plugins some other way. It enables the instance's buses and applies the
+ * project's saved state before the adapter takes it, because the adapter reads
+ * the plugin's parameter list when it is constructed.
+ */
+ExternalDeviceResult adaptExternalPluginInstance(
+    std::unique_ptr<juce::AudioPluginInstance> instance, const magda::DeviceInfo& device,
+    bool offlineRender = false);
 
 /**
  * @brief The external plugin @p device names, created and ready to bind.

--- a/magda/daw/audio/plugins/engine/EngineDeviceFactory.hpp
+++ b/magda/daw/audio/plugins/engine/EngineDeviceFactory.hpp
@@ -8,6 +8,7 @@
 #include "core/DeviceInfo.hpp"
 #include "exec/EngineDevice.hpp"
 #include "exec/RenderContext.hpp"
+#include "plugin_manager/ExternalPluginLookup.hpp"
 #include "plugin_manager/ExternalPluginState.hpp"
 
 /**
@@ -188,6 +189,22 @@ ExternalDeviceResult createEngineExternalDevice(const magda::DeviceInfo& device,
 using CurrentDeviceLookup = std::function<const magda::DeviceInfo*()>;
 
 /**
+ * @brief What an asynchronous load remembers about what it asked for.
+ *
+ * The identity is the model's, taken when the load was requested, so that
+ * comparing it with the model's identity at completion compares like with like.
+ * Not the scanned description's identifier: that carries the plugin's numeric
+ * uid, a device's saved fields do not, and comparing the two would call every
+ * unchanged plugin a change.
+ */
+struct RequestedPlugin {
+    magda::SavedPluginIdentity identity;
+
+    /// For the messages, which name a plugin rather than an identifier.
+    juce::String name;
+};
+
+/**
  * @brief The end of an asynchronous load, once the instance exists.
  *
  * The seam the callback below ends at, and a host with a loader of its own
@@ -201,7 +218,7 @@ using CurrentDeviceLookup = std::function<const magda::DeviceInfo*()>;
  */
 ExternalDeviceResult completeExternalPluginLoad(std::unique_ptr<juce::AudioPluginInstance> instance,
                                                 const juce::String& error,
-                                                const juce::PluginDescription& requested,
+                                                const RequestedPlugin& requested,
                                                 const CurrentDeviceLookup& currentDevice,
                                                 bool offlineRender = false);
 

--- a/magda/daw/audio/plugins/engine/EngineExternalDevice.cpp
+++ b/magda/daw/audio/plugins/engine/EngineExternalDevice.cpp
@@ -159,8 +159,6 @@ EngineExternalDevice::~EngineExternalDevice() {
 }
 
 void EngineExternalDevice::prepare(const magda::engine::RenderContext& context) {
-    sampleRate_ = context.sampleRate;
-
     // Before prepareToPlay, because it is what a plugin reads when it decides
     // how much work a block is worth: an oversampling saturator sizes its
     // filters here.
@@ -168,8 +166,21 @@ void EngineExternalDevice::prepare(const magda::engine::RenderContext& context) 
     instance_->setPlayHead(playHead_.get());
 
     instance_->setRateAndBufferSizeDetails(context.sampleRate, context.maxBlockSize);
-    instance_->prepareToPlay(context.sampleRate, context.maxBlockSize);
+
+    // Prepared once, and again only when the rate or the block size actually
+    // moved. This is the fork's rule and its comment is worth carrying with it:
+    // it used to call releaseResources() before re-preparing, and with VST3
+    // that shuts down the MIDI input buses with no way to get them back, which
+    // breaks every synth. So a device the store retains across a re-prepare at
+    // the same settings is left alone rather than torn down and rebuilt.
+    if (!prepared_ || context.sampleRate != sampleRate_ ||
+        context.maxBlockSize != preparedBlockSize_) {
+        instance_->prepareToPlay(context.sampleRate, context.maxBlockSize);
+    }
+
     prepared_ = true;
+    preparedBlockSize_ = context.maxBlockSize;
+    sampleRate_ = context.sampleRate;
 
     latencySamples_ = instance_->getLatencySamples();
 
@@ -187,6 +198,14 @@ void EngineExternalDevice::prepare(const magda::engine::RenderContext& context) 
     // The fork's width, verbatim: a plugin is processed at its own channel
     // count whatever the chain around it is, and never at none.
     processChannels_ = std::max({1, totalInputs, totalOutputs});
+
+    // What the plugin actually writes, which is not the same number and is the
+    // one the chain has to be filled from. A plugin with more inputs than
+    // outputs -- a stereo-in mono-out utility, anything with a sidechain -- is
+    // processed at the wider count, and the channels past its outputs still
+    // hold what was copied in. Reading those back as output hands the chain its
+    // own input, or a sidechain key, in place of the second half of a signal.
+    outputChannels_ = std::max(1, totalOutputs);
 
     // Wide enough for either path: the block's channels when the plugin's width
     // already matches, the plugin's when it does not.
@@ -375,13 +394,19 @@ void EngineExternalDevice::processThroughScratch(magda::engine::DeviceBlock& blo
     for (int channel = 0; channel < destChannels; ++channel) {
         auto* destination = block.audio.getChannelPointer(static_cast<std::size_t>(channel));
 
-        if (channel < processChannels_)
+        if (channel < outputChannels_)
             juce::FloatVectorOperations::copy(destination, audio.getReadPointer(channel),
                                               numSamples);
         else if (channel < 2)
             // A mono plugin in a stereo chain: its one output goes to both
             // sides, so what follows it has two channels to read rather than a
             // silent right.
+            //
+            // Bounded by the plugin's output count and not by the width it was
+            // processed at. Those differ for anything with more inputs than
+            // outputs, and there the channels between the two hold input rather
+            // than answer: a sidechain key, or the right half of a signal the
+            // plugin summed to mono.
             juce::FloatVectorOperations::copy(destination, audio.getReadPointer(0), numSamples);
         else
             juce::FloatVectorOperations::clear(destination, numSamples);
@@ -401,10 +426,17 @@ void EngineExternalDevice::process(magda::engine::DeviceBlock& block) {
     else
         midi_.clear();
 
-    if (destChannels == processChannels_ && sidechainInputChannels_ == 0) {
-        // The plugin's width and the block's already agree, so it processes the
-        // executor's own buffer and nothing is copied. The fork's fast path,
-        // and the one almost every plugin in a stereo chain takes.
+    if (destChannels == processChannels_ && sidechainInputChannels_ == 0 &&
+        outputChannels_ >= destChannels) {
+        // The plugin's width and the block's already agree and it writes every
+        // channel the slot will be read at, so it processes the executor's own
+        // buffer and nothing is copied. The fork's fast path, and the one
+        // almost every plugin in a stereo chain takes.
+        //
+        // The output count is part of the test rather than a detail: a
+        // stereo-in mono-out plugin matches the first half of it and leaves the
+        // right channel holding the input it was handed, which is not silence
+        // and is not its answer.
         for (int channel = 0; channel < destChannels; ++channel)
             channels_[static_cast<std::size_t>(channel)] =
                 block.audio.getChannelPointer(static_cast<std::size_t>(channel));

--- a/magda/daw/audio/plugins/engine/EngineExternalDevice.cpp
+++ b/magda/daw/audio/plugins/engine/EngineExternalDevice.cpp
@@ -136,6 +136,18 @@ EngineExternalDevice::EngineExternalDevice(std::unique_ptr<juce::AudioPluginInst
     parameters_.push_back({nullptr, magda::WrapperRole::DryGain, modelParameterAt(device, 0)});
     parameters_.push_back({nullptr, magda::WrapperRole::WetGain, modelParameterAt(device, 1)});
 
+    // The pairs past the main one, in the plan's own order: extraOutputs[k] is
+    // pair k + 1. Read from the model rather than from the instance's bus
+    // layout, because it is the model the plan compiled its ports from -- the
+    // two agree, and where they do not it is the plan that decided how many
+    // ports there are.
+    const auto& pairs = device.multiOut.outputPairs;
+    for (std::size_t pair = 1; pair < pairs.size(); ++pair) {
+        const auto& declared = pairs[pair];
+        extraOutputPairs_.push_back({.firstChannel = std::max(0, declared.firstPin - 1),
+                                     .numChannels = std::max(0, declared.numChannels)});
+    }
+
     int slot = kWrapperParameterCount;
     for (auto* parameter : instance_->getParameters()) {
         if (parameter == nullptr || !parameter->isAutomatable())
@@ -311,6 +323,35 @@ void EngineExternalDevice::writeMidiOut(juce::MidiBuffer& out, int numSamples) c
     }
 }
 
+void EngineExternalDevice::writeExtraOutputs(magda::engine::DeviceBlock& block,
+                                             const juce::AudioBuffer<float>& processed,
+                                             int numSamples) const {
+    const auto pairs = std::min(block.extraOutputs.size(), extraOutputPairs_.size());
+
+    for (std::size_t pair = 0; pair < pairs; ++pair) {
+        auto& destination = block.extraOutputs[pair];
+        const auto& source = extraOutputPairs_[pair];
+        const auto channels =
+            std::min(static_cast<int>(destination.getNumChannels()), source.numChannels);
+
+        for (int channel = 0; channel < channels; ++channel) {
+            const auto from = source.firstChannel + channel;
+
+            // A pair whose channels the plugin does not have is left as it
+            // arrived, which is cleared. That is a model that recorded more
+            // pairs than this build of the plugin reports, and silence is the
+            // honest answer: the alternative is handing a track whatever
+            // happened to be in the buffer at that index.
+            if (from >= outputChannels_ || from >= processed.getNumChannels())
+                break;
+
+            juce::FloatVectorOperations::copy(
+                destination.getChannelPointer(static_cast<std::size_t>(channel)),
+                processed.getReadPointer(from), numSamples);
+        }
+    }
+}
+
 void EngineExternalDevice::processPluginBlock(juce::AudioBuffer<float>& audio) {
     const auto numSamples = audio.getNumSamples();
 
@@ -390,6 +431,7 @@ void EngineExternalDevice::processThroughScratch(magda::engine::DeviceBlock& blo
     }
 
     processPluginBlock(audio);
+    writeExtraOutputs(block, audio, numSamples);
 
     for (int channel = 0; channel < destChannels; ++channel) {
         auto* destination = block.audio.getChannelPointer(static_cast<std::size_t>(channel));
@@ -427,7 +469,7 @@ void EngineExternalDevice::process(magda::engine::DeviceBlock& block) {
         midi_.clear();
 
     if (destChannels == processChannels_ && sidechainInputChannels_ == 0 &&
-        outputChannels_ >= destChannels) {
+        outputChannels_ >= destChannels && block.extraOutputs.empty()) {
         // The plugin's width and the block's already agree and it writes every
         // channel the slot will be read at, so it processes the executor's own
         // buffer and nothing is copied. The fork's fast path, and the one
@@ -437,6 +479,11 @@ void EngineExternalDevice::process(magda::engine::DeviceBlock& block) {
         // stereo-in mono-out plugin matches the first half of it and leaves the
         // right channel holding the input it was handed, which is not silence
         // and is not its answer.
+        //
+        // A multi-out instrument is out of it entirely: its further pairs live
+        // in the channels past the ones the chain reads, and processing in
+        // place into the chain's own two would leave nowhere for them to be
+        // written.
         for (int channel = 0; channel < destChannels; ++channel)
             channels_[static_cast<std::size_t>(channel)] =
                 block.audio.getChannelPointer(static_cast<std::size_t>(channel));

--- a/magda/daw/audio/plugins/engine/EngineExternalDevice.cpp
+++ b/magda/daw/audio/plugins/engine/EngineExternalDevice.cpp
@@ -6,6 +6,7 @@
 #include <utility>
 
 #include "core/ParameterUtils.hpp"
+#include "plugin_manager/ExternalPluginState.hpp"
 
 namespace magda::daw::audio::engine_adapter {
 
@@ -135,14 +136,7 @@ EngineExternalDevice::EngineExternalDevice(std::unique_ptr<juce::AudioPluginInst
     // lands on.
     const auto mappingFor = [](juce::AudioProcessorParameter* parameter, magda::WrapperRole role,
                                std::optional<magda::ParameterInfo> info) {
-        // Where the model says the parameter sits, in the units the plan will
-        // resolve it in, so writeParameters() can tell "still where the project
-        // left it" from "something moved it" without converting twice.
-        const auto base =
-            info ? magda::ParameterUtils::realToNormalized(info->currentValue, *info) : 0.0f;
-
-        return ParameterMapping{
-            .parameter = parameter, .role = role, .info = std::move(info), .base = base};
+        return ParameterMapping{.parameter = parameter, .role = role, .info = std::move(info)};
     };
 
     parameters_.push_back(
@@ -162,15 +156,10 @@ EngineExternalDevice::EngineExternalDevice(std::unique_ptr<juce::AudioPluginInst
                                      .numChannels = std::max(0, declared.numChannels)});
     }
 
-    int slot = kWrapperParameterCount;
-    for (auto* parameter : instance_->getParameters()) {
-        if (parameter == nullptr || !parameter->isAutomatable())
-            continue;
-
-        parameters_.push_back(
-            mappingFor(parameter, magda::WrapperRole::None, modelParameterAt(device, slot)));
-        ++slot;
-    }
+    const auto order = magda::hostParameterOrder(*instance_);
+    for (int slot = kWrapperParameterCount; slot < static_cast<int>(order.size()); ++slot)
+        parameters_.push_back(mappingFor(order[static_cast<std::size_t>(slot)],
+                                         magda::WrapperRole::None, modelParameterAt(device, slot)));
 }
 
 EngineExternalDevice::~EngineExternalDevice() {
@@ -267,7 +256,7 @@ int EngineExternalDevice::latencySamples() const {
 
 void EngineExternalDevice::writeParameters(const magda::engine::DeviceParams& params) {
     for (int slot = 0; slot < static_cast<int>(parameters_.size()); ++slot) {
-        auto& mapping = parameters_[static_cast<std::size_t>(slot)];
+        const auto& mapping = parameters_[static_cast<std::size_t>(slot)];
         const auto values = params[slot];
 
         // A slot the table does not carry is one nothing resolved: a project
@@ -301,29 +290,16 @@ void EngineExternalDevice::writeParameters(const magda::engine::DeviceParams& pa
                 if (mapping.parameter == nullptr)
                     break;
 
-                // A parameter still sitting where the project said it sits is
-                // not written at all, and the plugin keeps what its own state
-                // gave it. That is the fork's answer to a project whose saved
-                // parameter array disagrees with its chunk, which is every
-                // project written by a MAGDA old enough to have saved a stale
-                // array: the fork refreshes its cache from the plugin after the
-                // restore precisely so that nothing writes the array back
-                // afterwards. Writing it here would undo the chunk on the first
-                // block and render the initialised voice.
-                //
-                // Anything that moves the value off that position -- an
-                // automation lane, a macro, a modifier, a host edit -- is a
-                // write, and it stays a write from then on. Latched rather than
-                // compared each block, because a lane that returns to the
-                // saved position later has still taken the parameter away from
-                // the plugin's own state, and stopping there would leave it
-                // wherever the last write put it.
-                if (!mapping.moved) {
-                    if (juce::approximatelyEqual(normalised, mapping.base))
-                        break;
-
-                    mapping.moved = true;
-                }
+                // What the plan resolved, with nothing read into it. Whether
+                // this value came from the project's array, a lane, a macro or
+                // a knob somebody just turned is the model's business, and the
+                // one case where the model could hold something the plugin has
+                // already corrected -- a stale array beside a good chunk -- is
+                // settled before this device exists, by the restoration handing
+                // the corrected values back to whoever owns the model
+                // (ExternalPluginState.hpp). A device that tried to work that
+                // out from the numbers could not: no comparison tells a stale
+                // value apart from a lane passing through the same one.
 
                 // Only on a change, which is the fork's rule rather than a
                 // saving: a plugin is entitled to treat every write as a

--- a/magda/daw/audio/plugins/engine/EngineExternalDevice.cpp
+++ b/magda/daw/audio/plugins/engine/EngineExternalDevice.cpp
@@ -133,8 +133,22 @@ EngineExternalDevice::EngineExternalDevice(std::unique_ptr<juce::AudioPluginInst
     // the plugin's parameter array with two added -- it is a filtered view of
     // it, and the filter is what decides which slot a project's saved value
     // lands on.
-    parameters_.push_back({nullptr, magda::WrapperRole::DryGain, modelParameterAt(device, 0)});
-    parameters_.push_back({nullptr, magda::WrapperRole::WetGain, modelParameterAt(device, 1)});
+    const auto mappingFor = [](juce::AudioProcessorParameter* parameter, magda::WrapperRole role,
+                               std::optional<magda::ParameterInfo> info) {
+        // Where the model says the parameter sits, in the units the plan will
+        // resolve it in, so writeParameters() can tell "still where the project
+        // left it" from "something moved it" without converting twice.
+        const auto base =
+            info ? magda::ParameterUtils::realToNormalized(info->currentValue, *info) : 0.0f;
+
+        return ParameterMapping{
+            .parameter = parameter, .role = role, .info = std::move(info), .base = base};
+    };
+
+    parameters_.push_back(
+        mappingFor(nullptr, magda::WrapperRole::DryGain, modelParameterAt(device, 0)));
+    parameters_.push_back(
+        mappingFor(nullptr, magda::WrapperRole::WetGain, modelParameterAt(device, 1)));
 
     // The pairs past the main one, in the plan's own order: extraOutputs[k] is
     // pair k + 1. Read from the model rather than from the instance's bus
@@ -154,7 +168,7 @@ EngineExternalDevice::EngineExternalDevice(std::unique_ptr<juce::AudioPluginInst
             continue;
 
         parameters_.push_back(
-            {parameter, magda::WrapperRole::None, modelParameterAt(device, slot)});
+            mappingFor(parameter, magda::WrapperRole::None, modelParameterAt(device, slot)));
         ++slot;
     }
 }
@@ -253,7 +267,7 @@ int EngineExternalDevice::latencySamples() const {
 
 void EngineExternalDevice::writeParameters(const magda::engine::DeviceParams& params) {
     for (int slot = 0; slot < static_cast<int>(parameters_.size()); ++slot) {
-        const auto& mapping = parameters_[static_cast<std::size_t>(slot)];
+        auto& mapping = parameters_[static_cast<std::size_t>(slot)];
         const auto values = params[slot];
 
         // A slot the table does not carry is one nothing resolved: a project
@@ -274,6 +288,8 @@ void EngineExternalDevice::writeParameters(const magda::engine::DeviceParams& pa
 
         switch (mapping.role) {
             case magda::WrapperRole::DryGain:
+                // The wrapper pair is the host's own number and no chunk can
+                // carry it, so it is always taken from the model.
                 dryGain_ = normalised;
                 break;
 
@@ -282,11 +298,38 @@ void EngineExternalDevice::writeParameters(const magda::engine::DeviceParams& pa
                 break;
 
             default:
+                if (mapping.parameter == nullptr)
+                    break;
+
+                // A parameter still sitting where the project said it sits is
+                // not written at all, and the plugin keeps what its own state
+                // gave it. That is the fork's answer to a project whose saved
+                // parameter array disagrees with its chunk, which is every
+                // project written by a MAGDA old enough to have saved a stale
+                // array: the fork refreshes its cache from the plugin after the
+                // restore precisely so that nothing writes the array back
+                // afterwards. Writing it here would undo the chunk on the first
+                // block and render the initialised voice.
+                //
+                // Anything that moves the value off that position -- an
+                // automation lane, a macro, a modifier, a host edit -- is a
+                // write, and it stays a write from then on. Latched rather than
+                // compared each block, because a lane that returns to the
+                // saved position later has still taken the parameter away from
+                // the plugin's own state, and stopping there would leave it
+                // wherever the last write put it.
+                if (!mapping.moved) {
+                    if (juce::approximatelyEqual(normalised, mapping.base))
+                        break;
+
+                    mapping.moved = true;
+                }
+
                 // Only on a change, which is the fork's rule rather than a
                 // saving: a plugin is entitled to treat every write as a
                 // gesture, and one that rebuilds a filter or repaints an editor
                 // on each would do it every block on a parameter nobody moved.
-                if (mapping.parameter != nullptr && mapping.parameter->getValue() != normalised)
+                if (mapping.parameter->getValue() != normalised)
                     mapping.parameter->setValue(normalised);
                 break;
         }

--- a/magda/daw/audio/plugins/engine/EngineExternalDevice.cpp
+++ b/magda/daw/audio/plugins/engine/EngineExternalDevice.cpp
@@ -1,0 +1,422 @@
+#include "plugins/engine/EngineExternalDevice.hpp"
+
+#include <algorithm>
+#include <atomic>
+#include <cmath>
+#include <utility>
+
+#include "core/ParameterUtils.hpp"
+
+namespace magda::daw::audio::engine_adapter {
+
+namespace {
+
+/// What an encoded event costs before its own bytes. Derived from the engine's
+/// own cost model, the same way EngineMagdaDevice derives it, so the two cannot
+/// drift apart.
+constexpr int kMidiEventOverheadBytes =
+    magda::engine::kMidiShortMessageBytes - 3;  // a short message is three bytes of data
+
+/// Below this the fork treats the dry level as off and skips the mix entirely,
+/// which is what makes the common case one processBlock and no copy.
+constexpr float kDryLevelFloor = 0.00004f;
+
+/// Above this the fork treats the wet level as unity and skips the gain pass.
+constexpr float kWetLevelCeiling = 0.999f;
+
+/// The parameter slots the fork puts in front of a plugin's own: dry, then wet.
+constexpr int kWrapperParameterCount = 2;
+
+/// The model's description of the parameter at plan slot @p index, or none.
+///
+/// Both buckets, because MAGDA splits the fork's one list in two: the plugin's
+/// parameters and the wrapper pair it never declared. Both carry the fork's
+/// index in paramIndex, which is what the plan addresses them by, so the split
+/// is a UI concern and this is the one place that has to put them back together.
+std::optional<magda::ParameterInfo> modelParameterAt(const magda::DeviceInfo& device, int index) {
+    for (const auto* bucket : {&device.parameters, &device.wrapperParameters})
+        for (const auto& info : *bucket)
+            if (info.paramIndex == index)
+                return info;
+
+    return std::nullopt;
+}
+
+}  // namespace
+
+/**
+ * @brief Where the transport is, as a plugin asks for it.
+ *
+ * A block's own description, published for the plugin to read during the call.
+ * Held in atomics rather than as a pointer to the block, for the fork's own
+ * reason: a plugin is entitled to ask on the message thread, hours after the
+ * block that produced the answer, and some do. The worst that can do here is
+ * report a stale position, which is what the fork does too.
+ */
+class EngineExternalDevice::PlayHead final : public juce::AudioPlayHead {
+  public:
+    void setBlock(const magda::engine::BlockInfo& block, double sampleRate) {
+        playing_.store(block.playing, std::memory_order_relaxed);
+        timeSeconds_.store(block.startSeconds, std::memory_order_relaxed);
+        timeSamples_.store(static_cast<std::int64_t>(std::llround(block.startSeconds * sampleRate)),
+                           std::memory_order_relaxed);
+        ppqPosition_.store(block.startBeat, std::memory_order_relaxed);
+
+        if (block.tempo == nullptr) {
+            // A caller assembling a block by hand: the defaults are what the
+            // transport would have published, and the bar grid is the one the
+            // engine's own default map has.
+            bpm_.store(kDefaultBpm, std::memory_order_relaxed);
+            numerator_.store(4, std::memory_order_relaxed);
+            denominator_.store(4, std::memory_order_relaxed);
+            ppqOfBarStart_.store(std::floor(block.startBeat / 4.0) * 4.0,
+                                 std::memory_order_relaxed);
+            return;
+        }
+
+        bpm_.store(block.tempo->bpmAt(block.startBeat), std::memory_order_relaxed);
+
+        const auto position = block.tempo->barsAndBeatsAt(block.startBeat);
+        numerator_.store(position.numerator, std::memory_order_relaxed);
+        denominator_.store(position.denominator, std::memory_order_relaxed);
+
+        // PPQ counts quarter notes and the position inside a bar is counted in
+        // the signature's own beats, so the two part company anywhere the
+        // denominator is not four: three eighths into a 6/8 bar is one and a
+        // half quarter notes, not three.
+        const auto quartersPerBeat = 4.0 / std::max(1, position.denominator);
+        ppqOfBarStart_.store(block.startBeat - (position.beat * quartersPerBeat),
+                             std::memory_order_relaxed);
+    }
+
+    juce::Optional<PositionInfo> getPosition() const override {
+        PositionInfo result;
+
+        result.setIsPlaying(playing_.load(std::memory_order_relaxed));
+        result.setTimeInSeconds(timeSeconds_.load(std::memory_order_relaxed));
+        result.setTimeInSamples(timeSamples_.load(std::memory_order_relaxed));
+        result.setBpm(bpm_.load(std::memory_order_relaxed));
+        result.setTimeSignature(
+            TimeSignature{.numerator = numerator_.load(std::memory_order_relaxed),
+                          .denominator = denominator_.load(std::memory_order_relaxed)});
+
+        const auto barStart = ppqOfBarStart_.load(std::memory_order_relaxed);
+        result.setPpqPositionOfLastBarStart(barStart);
+        result.setPpqPosition(std::max(barStart, ppqPosition_.load(std::memory_order_relaxed)));
+
+        return result;
+    }
+
+  private:
+    static constexpr double kDefaultBpm = 120.0;
+
+    std::atomic<bool> playing_{false};
+    std::atomic<double> timeSeconds_{0.0};
+    std::atomic<std::int64_t> timeSamples_{0};
+    std::atomic<double> ppqPosition_{0.0};
+    std::atomic<double> ppqOfBarStart_{0.0};
+    std::atomic<double> bpm_{kDefaultBpm};
+    std::atomic<int> numerator_{4};
+    std::atomic<int> denominator_{4};
+};
+
+EngineExternalDevice::EngineExternalDevice(std::unique_ptr<juce::AudioPluginInstance> instance,
+                                           const magda::DeviceInfo& device, bool offlineRender)
+    : instance_(std::move(instance)),
+      playHead_(std::make_unique<PlayHead>()),
+      offlineRender_(offlineRender) {
+    jassert(instance_ != nullptr);
+
+    // The fork's list, rebuilt: the wrapper pair first, then the plugin's own
+    // automatable parameters in plugin order. A parameter the plugin says is
+    // not automatable is not in the list at all, which is why this cannot be
+    // the plugin's parameter array with two added -- it is a filtered view of
+    // it, and the filter is what decides which slot a project's saved value
+    // lands on.
+    parameters_.push_back({nullptr, magda::WrapperRole::DryGain, modelParameterAt(device, 0)});
+    parameters_.push_back({nullptr, magda::WrapperRole::WetGain, modelParameterAt(device, 1)});
+
+    int slot = kWrapperParameterCount;
+    for (auto* parameter : instance_->getParameters()) {
+        if (parameter == nullptr || !parameter->isAutomatable())
+            continue;
+
+        parameters_.push_back(
+            {parameter, magda::WrapperRole::None, modelParameterAt(device, slot)});
+        ++slot;
+    }
+}
+
+EngineExternalDevice::~EngineExternalDevice() {
+    // The playhead outlives nothing: the instance is told to forget it before
+    // either is destroyed, because JUCE leaves the pointer where it was and a
+    // plugin asking after the fact would read freed memory. The fork does the
+    // same thing in the same order (deinitialise: "must be done first").
+    instance_->setPlayHead(nullptr);
+
+    if (prepared_)
+        instance_->releaseResources();
+}
+
+void EngineExternalDevice::prepare(const magda::engine::RenderContext& context) {
+    sampleRate_ = context.sampleRate;
+
+    // Before prepareToPlay, because it is what a plugin reads when it decides
+    // how much work a block is worth: an oversampling saturator sizes its
+    // filters here.
+    instance_->setNonRealtime(offlineRender_);
+    instance_->setPlayHead(playHead_.get());
+
+    instance_->setRateAndBufferSizeDetails(context.sampleRate, context.maxBlockSize);
+    instance_->prepareToPlay(context.sampleRate, context.maxBlockSize);
+    prepared_ = true;
+
+    latencySamples_ = instance_->getLatencySamples();
+
+    const auto totalInputs = instance_->getTotalNumInputChannels();
+    const auto totalOutputs = instance_->getTotalNumOutputChannels();
+
+    // The main bus is what the chain feeds; anything after it is where a
+    // sidechain key goes, which is how every dynamics plugin takes one. A
+    // plugin with no bus layout at all reports its channels only in total, and
+    // then all of them are the main bus.
+    const auto* mainBus = instance_->getBus(true, 0);
+    mainInputChannels_ = mainBus != nullptr ? mainBus->getNumberOfChannels() : totalInputs;
+    sidechainInputChannels_ = std::max(0, totalInputs - mainInputChannels_);
+
+    // The fork's width, verbatim: a plugin is processed at its own channel
+    // count whatever the chain around it is, and never at none.
+    processChannels_ = std::max({1, totalInputs, totalOutputs});
+
+    // Wide enough for either path: the block's channels when the plugin's width
+    // already matches, the plugin's when it does not.
+    channels_.assign(static_cast<std::size_t>(std::max(processChannels_, context.numChannels)),
+                     nullptr);
+
+    scratch_.setSize(processChannels_, context.maxBlockSize, false, true, false);
+    dryScratch_.setSize(std::max(processChannels_, context.numChannels), context.maxBlockSize,
+                        false, true, false);
+
+    // What comes in, plus room for a plugin that answers with more than it was
+    // given. Both are the port's own budget, which is the only figure either
+    // side of this is sized from.
+    midi_.ensureSize(static_cast<std::size_t>(midiInputBoundBytes_) +
+                     magda::engine::kMaxMidiBytesPerPort);
+}
+
+void EngineExternalDevice::reset() {
+    instance_->reset();
+}
+
+void EngineExternalDevice::setMidiInputBoundBytes(int bytes) {
+    midiInputBoundBytes_ = bytes;
+
+    if (prepared_)
+        midi_.ensureSize(static_cast<std::size_t>(midiInputBoundBytes_) +
+                         magda::engine::kMaxMidiBytesPerPort);
+}
+
+int EngineExternalDevice::latencySamples() const {
+    return latencySamples_;
+}
+
+void EngineExternalDevice::writeParameters(const magda::engine::DeviceParams& params) {
+    for (int slot = 0; slot < static_cast<int>(parameters_.size()); ++slot) {
+        const auto& mapping = parameters_[static_cast<std::size_t>(slot)];
+        const auto values = params[slot];
+
+        // A slot the table does not carry is one nothing resolved: a project
+        // that saved fewer parameters than this build of the plugin has, or a
+        // wrapper pair a project never wrote. The plugin keeps whatever its own
+        // state put there, which for the pair is fully wet.
+        if (values.empty())
+            continue;
+
+        // Through the model's own inverse rather than as a raw number. An
+        // external parameter's units are already normalised, so this is the
+        // identity for almost all of them, and the almost is the point: it is
+        // the same conversion the value went into the table through, and
+        // ParameterUtils is the only thing that knows where it is not.
+        const auto normalised =
+            mapping.info ? magda::ParameterUtils::realToNormalized(values.value(), *mapping.info)
+                         : std::clamp(values.value(), 0.0f, 1.0f);
+
+        switch (mapping.role) {
+            case magda::WrapperRole::DryGain:
+                dryGain_ = normalised;
+                break;
+
+            case magda::WrapperRole::WetGain:
+                wetGain_ = normalised;
+                break;
+
+            default:
+                // Only on a change, which is the fork's rule rather than a
+                // saving: a plugin is entitled to treat every write as a
+                // gesture, and one that rebuilds a filter or repaints an editor
+                // on each would do it every block on a parameter nobody moved.
+                if (mapping.parameter != nullptr && mapping.parameter->getValue() != normalised)
+                    mapping.parameter->setValue(normalised);
+                break;
+        }
+    }
+}
+
+void EngineExternalDevice::readMidiIn(const juce::MidiBuffer& in) {
+    midi_.clear();
+
+    for (const auto metadata : in)
+        midi_.addEvent(metadata.data, metadata.numBytes, metadata.samplePosition);
+}
+
+void EngineExternalDevice::writeMidiOut(juce::MidiBuffer& out, int numSamples) const {
+    // Whatever the plugin left in the buffer, which for most plugins is what
+    // went in. That is the fork's behaviour and not an accident of it: JUCE
+    // hands a plugin one buffer for both directions, the fork writes back what
+    // is in it afterwards, and a chain that wanted the raw input as well asks
+    // the plan for it (DeviceInfo::midiInThru) rather than asking the plugin.
+    //
+    // Counted in bytes against the port's budget, like every other producer.
+    int bytesWritten = 0;
+
+    for (const auto metadata : midi_) {
+        const auto cost = kMidiEventOverheadBytes + metadata.numBytes;
+        if (bytesWritten + cost > magda::engine::kMaxMidiBytesPerPort) {
+            jassertfalse;  // a plugin past the port's budget
+            break;
+        }
+
+        bytesWritten += cost;
+        out.addEvent(metadata.data, metadata.numBytes,
+                     std::clamp(metadata.samplePosition, 0, std::max(0, numSamples - 1)));
+    }
+}
+
+void EngineExternalDevice::processPluginBlock(juce::AudioBuffer<float>& audio) {
+    const auto numSamples = audio.getNumSamples();
+
+    if (dryGain_ <= kDryLevelFloor) {
+        instance_->processBlock(audio, midi_);
+
+        if (wetGain_ < kWetLevelCeiling)
+            audio.applyGain(0, numSamples, wetGain_);
+
+        return;
+    }
+
+    const auto numChannels = audio.getNumChannels();
+
+    for (int channel = 0; channel < numChannels; ++channel)
+        dryScratch_.copyFrom(channel, 0, audio, channel, 0, numSamples);
+
+    instance_->processBlock(audio, midi_);
+
+    if (wetGain_ < kWetLevelCeiling)
+        audio.applyGain(0, numSamples, wetGain_);
+
+    for (int channel = 0; channel < numChannels; ++channel)
+        audio.addFrom(channel, 0, dryScratch_.getReadPointer(channel), numSamples, dryGain_);
+}
+
+/// The plugin's own buffer, filled from the block, processed, and copied back.
+///
+/// The path taken whenever the plugin's width and the chain's differ, or the
+/// plugin has a sidechain bus to fill: both need a buffer that is not the
+/// executor's, since the executor's is exactly the chain's width and carries no
+/// key.
+void EngineExternalDevice::processThroughScratch(magda::engine::DeviceBlock& block, int numSamples,
+                                                 int destChannels) {
+    juce::AudioBuffer<float> audio(scratch_.getArrayOfWritePointers(), processChannels_, 0,
+                                   numSamples);
+
+    for (int channel = 0; channel < processChannels_; ++channel) {
+        if (channel < destChannels)
+            juce::FloatVectorOperations::copy(
+                audio.getWritePointer(channel),
+                block.audio.getChannelPointer(static_cast<std::size_t>(channel)), numSamples);
+        else
+            audio.clear(channel, 0, numSamples);
+    }
+
+    // The fork's two bridging rules, against the plugin's main bus rather than
+    // against its total input count. They mean the same thing: the fork's
+    // buffer already has the sidechain channels appended by the rack around it,
+    // so its total is this main count wherever these two cases can fire, and
+    // naming the main bus is what keeps a mono plugin with a mono key out of
+    // the stereo branch.
+    if (destChannels == 1 && mainInputChannels_ == 2) {
+        // Mono in, stereo wanted: duplicate rather than leave a silent side.
+        audio.copyFrom(1, 0, audio, 0, 0, numSamples);
+    } else if (destChannels == 2 && mainInputChannels_ == 1) {
+        // Stereo in, mono wanted: the average, which is the sum at half gain
+        // and not the left channel.
+        audio.addFrom(0, 0, block.audio.getChannelPointer(1), numSamples);
+        audio.applyGain(0, 0, numSamples, 0.5f);
+    }
+
+    const auto sidechainChannels =
+        std::min(sidechainInputChannels_, static_cast<int>(block.sidechain.getNumChannels()));
+
+    for (int channel = 0; channel < sidechainInputChannels_; ++channel) {
+        const auto destination = mainInputChannels_ + channel;
+        if (destination >= processChannels_)
+            break;
+
+        if (channel < sidechainChannels)
+            juce::FloatVectorOperations::copy(
+                audio.getWritePointer(destination),
+                block.sidechain.getChannelPointer(static_cast<std::size_t>(channel)), numSamples);
+        else
+            audio.clear(destination, 0, numSamples);
+    }
+
+    processPluginBlock(audio);
+
+    for (int channel = 0; channel < destChannels; ++channel) {
+        auto* destination = block.audio.getChannelPointer(static_cast<std::size_t>(channel));
+
+        if (channel < processChannels_)
+            juce::FloatVectorOperations::copy(destination, audio.getReadPointer(channel),
+                                              numSamples);
+        else if (channel < 2)
+            // A mono plugin in a stereo chain: its one output goes to both
+            // sides, so what follows it has two channels to read rather than a
+            // silent right.
+            juce::FloatVectorOperations::copy(destination, audio.getReadPointer(0), numSamples);
+        else
+            juce::FloatVectorOperations::clear(destination, numSamples);
+    }
+}
+
+void EngineExternalDevice::process(magda::engine::DeviceBlock& block) {
+    writeParameters(block.params);
+
+    const auto numSamples = static_cast<int>(block.audio.getNumSamples());
+    const auto destChannels = static_cast<int>(block.audio.getNumChannels());
+
+    playHead_->setBlock(block.block, sampleRate_);
+
+    if (block.midiIn != nullptr)
+        readMidiIn(*block.midiIn);
+    else
+        midi_.clear();
+
+    if (destChannels == processChannels_ && sidechainInputChannels_ == 0) {
+        // The plugin's width and the block's already agree, so it processes the
+        // executor's own buffer and nothing is copied. The fork's fast path,
+        // and the one almost every plugin in a stereo chain takes.
+        for (int channel = 0; channel < destChannels; ++channel)
+            channels_[static_cast<std::size_t>(channel)] =
+                block.audio.getChannelPointer(static_cast<std::size_t>(channel));
+
+        juce::AudioBuffer<float> audio(channels_.data(), destChannels, numSamples);
+        processPluginBlock(audio);
+    } else {
+        processThroughScratch(block, numSamples, destChannels);
+    }
+
+    if (block.midiOut != nullptr)
+        writeMidiOut(*block.midiOut, numSamples);
+}
+
+}  // namespace magda::daw::audio::engine_adapter

--- a/magda/daw/audio/plugins/engine/EngineExternalDevice.hpp
+++ b/magda/daw/audio/plugins/engine/EngineExternalDevice.hpp
@@ -169,6 +169,11 @@ class EngineExternalDevice final : public magda::engine::EngineDevice {
     /// chain's: max(max(1, inputs), outputs).
     int processChannels_ = 0;
 
+    /// How many of those channels the plugin writes. Not the same number
+    /// whenever it has more inputs than outputs, and it is this one the chain
+    /// is filled from: the channels between the two carry input.
+    int outputChannels_ = 0;
+
     /// Input channels on the plugin's main bus, and how many it has after them.
     /// The second is where a sidechain key lands, which is how every dynamics
     /// plugin takes one.
@@ -187,6 +192,11 @@ class EngineExternalDevice final : public magda::engine::EngineDevice {
     juce::MidiBuffer midi_;
 
     double sampleRate_ = 44100.0;
+
+    /// What the instance was last prepared at, so a second prepare at the same
+    /// settings does not prepare it again. See prepare().
+    int preparedBlockSize_ = 0;
+
     int latencySamples_ = 0;
     int midiInputBoundBytes_ = magda::engine::kMaxMidiBytesPerPort;
     bool offlineRender_ = false;

--- a/magda/daw/audio/plugins/engine/EngineExternalDevice.hpp
+++ b/magda/daw/audio/plugins/engine/EngineExternalDevice.hpp
@@ -1,0 +1,196 @@
+#pragma once
+
+#include <juce_audio_processors/juce_audio_processors.h>
+
+#include <memory>
+#include <optional>
+#include <vector>
+
+#include "core/DeviceInfo.hpp"
+#include "core/ParameterInfo.hpp"
+#include "exec/EngineDevice.hpp"
+
+/**
+ * @file EngineExternalDevice.hpp
+ * @brief A VST3, AU or LV2 plugin, as the native engine's executor sees it
+ *        (#2241).
+ *
+ * The third adapter, and the one with no MAGDA device behind it. EngineMagdaDevice
+ * hosts a device this repository wrote and can ask anything of; this hosts a
+ * binary somebody else shipped, whose only contract is juce::AudioPluginInstance.
+ * What it owes the corpus is the same thing: given one project, render what the
+ * fork renders.
+ *
+ * That makes this file a transcription rather than a design. Everything it does
+ * between receiving a block and handing it back is what te::ExternalPlugin does
+ * with the same block, in the same order, because a difference here is a
+ * difference in every project that hosts a plugin and there is no third opinion
+ * to appeal to. Each piece is written out below beside the fork's own reason for
+ * it, so that the day the fork changes one, the divergence is a diff rather than
+ * an archaeology exercise:
+ *
+ * - **Channel adaptation.** A plugin is processed at
+ *   `max(max(1, inputs), outputs)` channels whatever the chain around it is, and
+ *   a mismatch between that and the block is bridged by the fork's own rules: a
+ *   mono block feeding a stereo input duplicates, a stereo block feeding a mono
+ *   input averages at half gain, and a mono output is spread back over a stereo
+ *   block so the next device has two channels to read.
+ * - **Wet/dry.** The fork gives every external plugin a slot-level dry/wet pair
+ *   the plugin never declared, defaulting to fully wet, and mixes with it after
+ *   processing. MAGDA persists both (DeviceInfo::wrapperParameters), so a
+ *   project can carry a plugin that is 40% wet and the two engines have to agree
+ *   about what that means.
+ * - **Parameter identity.** The fork's automatable list is dry, then wet, then
+ *   the plugin's own automatable parameters in plugin order. Those positions are
+ *   what MAGDA saved as ParameterInfo::paramIndex and what the plan's value
+ *   layer resolves against, so the mapping back onto the live instance has to
+ *   reproduce that list rather than invent one.
+ * - **Latency.** Read once from the instance after prepareToPlay and reported to
+ *   the executor, which compensates it the same way it compensates any device.
+ * - **The playhead.** A plugin asks where the transport is, and a tempo-synced
+ *   delay that is told nothing renders a different project. The block already
+ *   carries the answer.
+ *
+ * Three differences are known and named here rather than found later:
+ *
+ * - **The all-notes-off flag.** The fork's MIDI container carries one beside the
+ *   events, and turns it into per-channel note-offs, sustain-pedal releases and
+ *   an MPE reset before the plugin sees the block. juce::MidiBuffer has no such
+ *   flag, so the engine has nowhere to read it from; the same gap
+ *   EngineMagdaDevice declares, and it closes in one place for both of them.
+ * - **Denormal sanitising.** The fork clamps a plugin's output on Intel when the
+ *   CPU's denormal flag was raised during the call. The native engine has no
+ *   denormal handling at all yet, anywhere, so this adapter is not the place to
+ *   add one: it is an executor-wide question (#2240) and it is a no-op on Apple
+ *   silicon either way.
+ * - **The transport's own state.** The fork's playhead reports whether the edit
+ *   is recording and where its loop points are. A device under the plan is
+ *   handed a stretch of timeline and not a transport, so those two fields are
+ *   left unset until the recording and launcher subsystems give the block
+ *   something to read them off (#1894, #1895).
+ */
+
+namespace magda::daw::audio::engine_adapter {
+
+/**
+ * @brief One external plugin instance bound to one Device op.
+ *
+ * Owns the instance. Everything the audio thread touches is sized in prepare():
+ * the channel pointer array, the processing scratch, the dry copy the wet/dry
+ * mix reads, and the MIDI buffer.
+ *
+ * The instance arrives already created and already told what it is: buses
+ * enabled, saved state applied. Instantiation is a message-thread job with a
+ * plugin format manager behind it, and it is not this class's (see
+ * EngineDeviceFactory.hpp).
+ */
+class EngineExternalDevice final : public magda::engine::EngineDevice {
+  public:
+    /**
+     * @brief Binds @p instance, whose parameters @p device describes.
+     *
+     * @p device is read for its parameter metadata and nothing else: the value
+     * the plan resolves for a slot is in that parameter's own units, and its
+     * ParameterInfo is what converts it back to the normalised position the
+     * plugin takes. The mapping from a slot to a live parameter comes from the
+     * instance rather than from the model, because that is where the fork's
+     * comes from and a stale model would otherwise write a project's values
+     * onto whatever the plugin's parameters are called this version.
+     *
+     * @p offlineRender says which kind of render this instance is being built
+     * for. It is the flag the fork sets on every external plugin before a
+     * bounce and clears afterwards, and a plugin is entitled to behave
+     * differently under it: an analogue-modelled saturator may oversample where
+     * it would not in a callback.
+     */
+    EngineExternalDevice(std::unique_ptr<juce::AudioPluginInstance> instance,
+                         const magda::DeviceInfo& device, bool offlineRender);
+    ~EngineExternalDevice() override;
+
+    void prepare(const magda::engine::RenderContext& context) override;
+    void reset() override;
+    void setMidiInputBoundBytes(int bytes) override;
+    int latencySamples() const override;
+    void process(magda::engine::DeviceBlock& block) override;
+
+    /// The instance this stands for. For a host that has to reach past the
+    /// adapter -- an editor window, a state save -- never for rendering.
+    juce::AudioPluginInstance& instance() const {
+        return *instance_;
+    }
+
+  private:
+    class PlayHead;
+
+    void writeParameters(const magda::engine::DeviceParams& params);
+
+    /// The plugin over one buffer, wet/dry mixed. @p audio is the buffer the
+    /// plugin processes in place, at the width it asked for.
+    void processPluginBlock(juce::AudioBuffer<float>& audio);
+
+    /// The block through a buffer of the plugin's own width, for a plugin whose
+    /// width is not the chain's or which has a sidechain bus to fill.
+    void processThroughScratch(magda::engine::DeviceBlock& block, int numSamples, int destChannels);
+
+    void readMidiIn(const juce::MidiBuffer& in);
+    void writeMidiOut(juce::MidiBuffer& out, int numSamples) const;
+
+    std::unique_ptr<juce::AudioPluginInstance> instance_;
+    std::unique_ptr<PlayHead> playHead_;
+
+    /**
+     * @brief What the plan's parameter slot at this index addresses.
+     *
+     * Indexed by plan slot, which is the fork's automatable-parameter index:
+     * zero is the dry level, one is the wet level, and the rest are the
+     * plugin's automatable parameters in plugin order. A slot with no live
+     * parameter behind it -- a project saved against a plugin that has since
+     * dropped one -- carries a null and is skipped, which leaves the plugin
+     * wherever its own state put it.
+     */
+    struct ParameterMapping {
+        juce::AudioProcessorParameter* parameter = nullptr;
+        magda::WrapperRole role = magda::WrapperRole::None;
+
+        /// The model's description of this parameter, or none. What it is for
+        /// is the conversion out of the plan's units, which is the same
+        /// conversion the value went in through.
+        std::optional<magda::ParameterInfo> info;
+    };
+
+    std::vector<ParameterMapping> parameters_;
+
+    /// The wet/dry pair, held rather than written through: they are the host's
+    /// own numbers and the plugin has never heard of them.
+    float dryGain_ = 0.0f;
+    float wetGain_ = 1.0f;
+
+    /// The width the plugin is processed at, which is its own rather than the
+    /// chain's: max(max(1, inputs), outputs).
+    int processChannels_ = 0;
+
+    /// Input channels on the plugin's main bus, and how many it has after them.
+    /// The second is where a sidechain key lands, which is how every dynamics
+    /// plugin takes one.
+    int mainInputChannels_ = 0;
+    int sidechainInputChannels_ = 0;
+
+    /// Non-owning view over the block, for the case where the plugin's width
+    /// and the block's already agree and nothing needs copying.
+    std::vector<float*> channels_;
+
+    /// The plugin's buffer when they do not agree, and the dry copy the mix
+    /// reads. Both sized in prepare() and never resized on the audio thread.
+    juce::AudioBuffer<float> scratch_;
+    juce::AudioBuffer<float> dryScratch_;
+
+    juce::MidiBuffer midi_;
+
+    double sampleRate_ = 44100.0;
+    int latencySamples_ = 0;
+    int midiInputBoundBytes_ = magda::engine::kMaxMidiBytesPerPort;
+    bool offlineRender_ = false;
+    bool prepared_ = false;
+};
+
+}  // namespace magda::daw::audio::engine_adapter

--- a/magda/daw/audio/plugins/engine/EngineExternalDevice.hpp
+++ b/magda/daw/audio/plugins/engine/EngineExternalDevice.hpp
@@ -45,13 +45,13 @@
  *   what MAGDA saved as ParameterInfo::paramIndex and what the plan's value
  *   layer resolves against, so the mapping back onto the live instance has to
  *   reproduce that list rather than invent one.
- * - **Which of the two saved records wins.** A project saves a plugin twice: as
- *   the chunk the plugin wrote, and as an array of parameter values. Where they
- *   disagree the fork lets the chunk win -- it applies the array, overlays the
- *   chunk, then refreshes its own cache from the plugin so nothing writes the
- *   array back afterwards -- and a project saved by an older build of MAGDA is
- *   exactly where they disagree. So a parameter nothing has moved is not
- *   written at all here, and the plugin keeps what its state gave it.
+ * - **Which of the two saved records wins** is settled before this class
+ *   exists. A project saves a plugin twice, as a chunk and as an array of
+ *   parameter values, and where they disagree the chunk is right; the
+ *   restoration applies both in that order and hands the corrected values back
+ *   for the model to record (ExternalPluginState.hpp). By the time a device is
+ *   rendering, the model is the answer and this writes what the plan resolves
+ *   from it.
  * - **Further output pairs.** A multi-out sampler's drum outs are the channels
  *   past its main pair, and the plan opens a port for each one the model
  *   recorded. They are copied out by the same mapping the current engine wires
@@ -91,9 +91,10 @@ namespace magda::daw::audio::engine_adapter {
  * the channel pointer array, the processing scratch, the dry copy the wet/dry
  * mix reads, and the MIDI buffer.
  *
- * The instance arrives already created and already told what it is: buses
- * enabled, saved state applied. Instantiation is a message-thread job with a
- * plugin format manager behind it, and it is not this class's (see
+ * The instance arrives created and with its buses enabled; what the project
+ * saved for it is applied here, because the order of that is bound up with the
+ * parameter list this class builds. Instantiation itself is a message-thread
+ * job with a plugin format manager behind it, and it is not this class's (see
  * EngineDeviceFactory.hpp).
  */
 class EngineExternalDevice final : public magda::engine::EngineDevice {
@@ -173,13 +174,6 @@ class EngineExternalDevice final : public magda::engine::EngineDevice {
         /// is the conversion out of the plan's units, which is the same
         /// conversion the value went in through.
         std::optional<magda::ParameterInfo> info;
-
-        /// Where the model says this parameter sits, normalised: the knob
-        /// position a project saved, before automation or a modifier moves it.
-        float base = 0.0f;
-
-        /// Whether anything has moved it off that. See writeParameters().
-        bool moved = false;
     };
 
     std::vector<ParameterMapping> parameters_;

--- a/magda/daw/audio/plugins/engine/EngineExternalDevice.hpp
+++ b/magda/daw/audio/plugins/engine/EngineExternalDevice.hpp
@@ -45,6 +45,13 @@
  *   what MAGDA saved as ParameterInfo::paramIndex and what the plan's value
  *   layer resolves against, so the mapping back onto the live instance has to
  *   reproduce that list rather than invent one.
+ * - **Which of the two saved records wins.** A project saves a plugin twice: as
+ *   the chunk the plugin wrote, and as an array of parameter values. Where they
+ *   disagree the fork lets the chunk win -- it applies the array, overlays the
+ *   chunk, then refreshes its own cache from the plugin so nothing writes the
+ *   array back afterwards -- and a project saved by an older build of MAGDA is
+ *   exactly where they disagree. So a parameter nothing has moved is not
+ *   written at all here, and the plugin keeps what its state gave it.
  * - **Further output pairs.** A multi-out sampler's drum outs are the channels
  *   past its main pair, and the plan opens a port for each one the model
  *   recorded. They are copied out by the same mapping the current engine wires
@@ -166,6 +173,13 @@ class EngineExternalDevice final : public magda::engine::EngineDevice {
         /// is the conversion out of the plan's units, which is the same
         /// conversion the value went in through.
         std::optional<magda::ParameterInfo> info;
+
+        /// Where the model says this parameter sits, normalised: the knob
+        /// position a project saved, before automation or a modifier moves it.
+        float base = 0.0f;
+
+        /// Whether anything has moved it off that. See writeParameters().
+        bool moved = false;
     };
 
     std::vector<ParameterMapping> parameters_;

--- a/magda/daw/audio/plugins/engine/EngineExternalDevice.hpp
+++ b/magda/daw/audio/plugins/engine/EngineExternalDevice.hpp
@@ -45,6 +45,11 @@
  *   what MAGDA saved as ParameterInfo::paramIndex and what the plan's value
  *   layer resolves against, so the mapping back onto the live instance has to
  *   reproduce that list rather than invent one.
+ * - **Further output pairs.** A multi-out sampler's drum outs are the channels
+ *   past its main pair, and the plan opens a port for each one the model
+ *   recorded. They are copied out by the same mapping the current engine wires
+ *   its rack pins by, rather than by a second guess at how a plugin lays its
+ *   outputs out.
  * - **Latency.** Read once from the instance after prepareToPlay and reported to
  *   the executor, which compensates it the same way it compensates any device.
  * - **The playhead.** A plugin asks where the transport is, and a tempo-synced
@@ -135,6 +140,11 @@ class EngineExternalDevice final : public magda::engine::EngineDevice {
     void readMidiIn(const juce::MidiBuffer& in);
     void writeMidiOut(juce::MidiBuffer& out, int numSamples) const;
 
+    /// The plugin's further output pairs, onto the ports the plan opened for
+    /// them. @p processed is the buffer the plugin just wrote, at its own width.
+    void writeExtraOutputs(magda::engine::DeviceBlock& block,
+                           const juce::AudioBuffer<float>& processed, int numSamples) const;
+
     std::unique_ptr<juce::AudioPluginInstance> instance_;
     std::unique_ptr<PlayHead> playHead_;
 
@@ -173,6 +183,26 @@ class EngineExternalDevice final : public magda::engine::EngineDevice {
     /// whenever it has more inputs than outputs, and it is this one the chain
     /// is filled from: the channels between the two carry input.
     int outputChannels_ = 0;
+
+    /**
+     * @brief Where each further output pair starts in the plugin's own output.
+     *
+     * Entry k is the pair the plan's `extraOutputs[k]` stands for, which is
+     * pair k + 1: pair 0 is the main output and is the buffer the chain carries
+     * on from. The channel it starts at is what the model recorded when it read
+     * the plugin's output buses (MultiOutOutputPair::firstPin, one-based), so
+     * this is the same mapping the current engine wires its rack pins by rather
+     * than a second guess at how a plugin lays its outputs out.
+     *
+     * Empty for every plugin that is not multi-out, which is almost all of
+     * them.
+     */
+    struct OutputPair {
+        int firstChannel = 0;
+        int numChannels = 0;
+    };
+
+    std::vector<OutputPair> extraOutputPairs_;
 
     /// Input channels on the plugin's main bus, and how many it has after them.
     /// The second is where a sidechain key lands, which is how every dynamics

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -63,6 +63,7 @@ set(TEST_SOURCES
     test_plugin_preferences.cpp
     test_plugin_browser_metadata_merge.cpp
     test_plugin_metadata_store.cpp
+    test_external_plugin_lookup.cpp
     test_prune_missing_plugins.cpp
     test_known_plugin_list_duplicates.cpp
     test_device_parameter_pagination.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -402,6 +402,12 @@ if(MAGDA_BUILD_NATIVE_ENGINE)
     # is the corpus's question, in magda_juce_tests.
     list(APPEND TEST_SOURCES test_engine_device_layer.cpp)
 
+    # An external plugin under a Device op (#2241): the adapter over
+    # juce::AudioPluginInstance, against a plugin written in the test rather
+    # than one that happens to be installed. What a real plugin is for is the
+    # corpus (#2175), where both engines run the same one.
+    list(APPEND TEST_SOURCES test_engine_external_device.cpp)
+
     # The block-size invariance gate (#2078). Model-only for the same reason the
     # native leg is: the claim is the native engine's alone, and the incumbent
     # owes nobody block-size invariance. In CI rather than in a nightly, because

--- a/tests/test_engine_external_device.cpp
+++ b/tests/test_engine_external_device.cpp
@@ -2,6 +2,7 @@
 
 #include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
+#include <cstring>
 #include <memory>
 #include <vector>
 
@@ -111,7 +112,9 @@ class StubPlugin final : public juce::AudioPluginInstance {
         gain = gainParameter.get();
         addHostedParameter(std::move(gainParameter));
 
-        addHostedParameter(std::make_unique<StubParameter>("fixed", "Fixed", 0.0f, false));
+        auto fixedParameter = std::make_unique<StubParameter>("fixed", "Fixed", 0.0f, false);
+        fixed = fixedParameter.get();
+        addHostedParameter(std::move(fixedParameter));
 
         auto toneParameter = std::make_unique<StubParameter>("tone", "Tone", 0.25f, true);
         tone = toneParameter.get();
@@ -207,9 +210,28 @@ class StubPlugin final : public juce::AudioPluginInstance {
 
     void changeProgramName(int, const juce::String&) override {}
 
-    void getStateInformation(juce::MemoryBlock&) override {}
+    /// The state a real plugin carries and a parameter array cannot: here, the
+    /// values of both parameters, including the one no host may automate.
+    struct State {
+        float tone = 0.0f;
+        float fixed = 0.0f;
+    };
 
-    void setStateInformation(const void*, int) override {}
+    void getStateInformation(juce::MemoryBlock& destination) override {
+        const State state{.tone = tone->getValue(), .fixed = fixed->getValue()};
+        destination.replaceAll(&state, sizeof(state));
+    }
+
+    void setStateInformation(const void* data, int size) override {
+        if (size != static_cast<int>(sizeof(State)))
+            return;
+
+        State state{};
+        std::memcpy(&state, data, sizeof(state));
+        tone->setValue(state.tone);
+        fixed->setValue(state.fixed);
+        ++stateRestores;
+    }
 
     /// The per-channel offset the output carries, so a test can name which of
     /// the plugin's channels it is reading.
@@ -217,6 +239,9 @@ class StubPlugin final : public juce::AudioPluginInstance {
 
     StubParameter* gain = nullptr;
     StubParameter* tone = nullptr;
+    StubParameter* fixed = nullptr;
+
+    int stateRestores = 0;
 
     bool emitsMidi = false;
 
@@ -871,4 +896,66 @@ TEST_CASE("A pair the plugin does not have stays silent", "[engine][external]") 
     CHECK(pairBuffers[0].getSample(0, 0) == Catch::Approx(3 * StubPlugin::kChannelMarker));
     CHECK(pairBuffers[1].getSample(0, 0) == Catch::Approx(0.0f));
     CHECK(pairBuffers[1].getSample(1, 0) == Catch::Approx(0.0f));
+}
+
+TEST_CASE("A project's saved plugin state reaches the plugin", "[engine][external]") {
+    // The chunk carries what the parameter array cannot. Here that is the value
+    // of a parameter no host may automate, which stands for a sampler's loaded
+    // samples and a synth's current program: a plugin created without the chunk
+    // renders its initialised voice, which is a different project rather than a
+    // quieter one.
+    auto plugin = std::make_unique<StubPlugin>(2, 2, 0);
+    auto* raw = plugin.get();
+
+    const StubPlugin::State saved{.tone = 0.9f, .fixed = 0.8f};
+    juce::MemoryBlock chunk(&saved, sizeof(saved));
+
+    auto model = externalDevice();
+    model.pluginState = chunk.toBase64Encoding();
+
+    const auto result = adapter::adaptExternalPluginInstance(std::move(plugin), model);
+    REQUIRE(result.device != nullptr);
+    CHECK(raw->stateRestores == 1);
+    CHECK(raw->fixed->getValue() == Catch::Approx(0.8f));
+
+    result.device->prepare(contextFor());
+
+    // The plan writes the parameters it knows about before every block, so an
+    // automatable value comes from the model and everything else stays as the
+    // chunk left it. That is the native engine's answer to the precedence the
+    // fork spends three steps on, and the two agree for a project MAGDA saved.
+    ParamArena arena({0.0f, 1.0f, 1.0f, 0.4f});
+    Block block(contextFor(), 2);
+    auto deviceBlock = block.deviceBlock(arena.params(contextFor().maxBlockSize));
+    result.device->process(deviceBlock);
+
+    CHECK(raw->tone->getValue() == Catch::Approx(0.4f));
+    CHECK(raw->fixed->getValue() == Catch::Approx(0.8f));
+}
+
+TEST_CASE("A device with no saved state keeps the plugin's defaults", "[engine][external]") {
+    auto plugin = std::make_unique<StubPlugin>(2, 2, 0);
+    auto* raw = plugin.get();
+
+    const auto result = adapter::adaptExternalPluginInstance(std::move(plugin), externalDevice());
+
+    REQUIRE(result.device != nullptr);
+    CHECK(raw->stateRestores == 0);
+}
+
+TEST_CASE("Saved state that is not a chunk this plugin understands is refused",
+          "[engine][external]") {
+    // A chunk written by another plugin, or by another version of this one. The
+    // plugin is handed it and declines; what it must not do is take half of it.
+    auto plugin = std::make_unique<StubPlugin>(2, 2, 0);
+    auto* raw = plugin.get();
+
+    auto model = externalDevice();
+    model.pluginState = "not base64 at all !!";
+
+    const auto result = adapter::adaptExternalPluginInstance(std::move(plugin), model);
+
+    REQUIRE(result.device != nullptr);
+    CHECK(raw->stateRestores == 0);
+    CHECK(raw->fixed->getValue() == Catch::Approx(0.0f));
 }

--- a/tests/test_engine_external_device.cpp
+++ b/tests/test_engine_external_device.cpp
@@ -1331,3 +1331,57 @@ TEST_CASE("A device that gained a scanned identifier has not changed plugin",
     REQUIRE(result.device != nullptr);
     CHECK(result.failure.isEmpty());
 }
+
+TEST_CASE("An imported device swapped to the other half of its bundle is a change",
+          "[engine][external]") {
+    // A bundle shipping an effect and an instrument of the same name out of one
+    // file is the case the lookup's first pass exists for, and it is the case
+    // JUCE's identifier string cannot see: that string carries the format, the
+    // name and a hash of the file, and neither the vendor nor the role. An
+    // imported device has no saved identifier to fall back on, so swapping to
+    // the other variant while a load is in flight has to be caught by the
+    // fields themselves.
+    auto model = externalDeviceSaving(1.0f, 0.5f);
+    model.name = "Kontakt";
+    model.manufacturer = "NI";
+    model.fileOrIdentifier = "/Library/Kontakt.vst3";
+    model.isInstrument = false;
+    model.uniqueId = {};  // imported: nothing scanned it
+
+    const adapter::RequestedPlugin requested{.identity = magda::savedPluginIdentity(model),
+                                             .name = model.name};
+
+    // The swap: the instrument out of the same bundle.
+    model.isInstrument = true;
+
+    auto plugin = std::make_unique<StubPlugin>(2, 2, 0);
+    const auto result = adapter::completeExternalPluginLoad(std::move(plugin), {}, requested,
+                                                            [&]() { return &model; });
+
+    CHECK(result.device == nullptr);
+    CHECK(result.failure.contains("changed plugin"));
+}
+
+TEST_CASE("An imported device swapped to another vendor's plugin is a change",
+          "[engine][external]") {
+    // The same gap, from the other side: the identifier string leaves the
+    // vendor out too, so two plugins of one name shipped by different vendors
+    // are one identity to it.
+    auto model = externalDeviceSaving(1.0f, 0.5f);
+    model.name = "Saturator";
+    model.manufacturer = "One";
+    model.fileOrIdentifier = "/Library/Saturator.vst3";
+    model.uniqueId = {};
+
+    const adapter::RequestedPlugin requested{.identity = magda::savedPluginIdentity(model),
+                                             .name = model.name};
+
+    model.manufacturer = "Another";
+
+    auto plugin = std::make_unique<StubPlugin>(2, 2, 0);
+    const auto result = adapter::completeExternalPluginLoad(std::move(plugin), {}, requested,
+                                                            [&]() { return &model; });
+
+    CHECK(result.device == nullptr);
+    CHECK(result.failure.contains("changed plugin"));
+}

--- a/tests/test_engine_external_device.cpp
+++ b/tests/test_engine_external_device.cpp
@@ -290,6 +290,16 @@ magda::DeviceInfo externalDevice() {
     return device;
 }
 
+/// The same device, with the knob positions a project saved for the plugin's
+/// two parameters. What the plan resolves for an untouched parameter is this,
+/// which is what tells "the project left it here" from "something moved it".
+magda::DeviceInfo externalDeviceSaving(float gain, float tone) {
+    auto device = externalDevice();
+    device.parameters[0].currentValue = gain;
+    device.parameters[1].currentValue = tone;
+    return device;
+}
+
 /**
  * @brief One block, and the parameter values the plan resolved for it.
  *
@@ -917,20 +927,81 @@ TEST_CASE("A project's saved plugin state reaches the plugin", "[engine][externa
     REQUIRE(result.device != nullptr);
     CHECK(raw->stateRestores == 1);
     CHECK(raw->fixed->getValue() == Catch::Approx(0.8f));
+}
 
-    result.device->prepare(contextFor());
+TEST_CASE("A stale saved parameter array does not overwrite the chunk", "[engine][external]") {
+    // Every project MAGDA saved before the restore was fixed has this shape:
+    // the chunk holds the voice the user heard, and the parameter array beside
+    // it holds the defaults the host had read at construction. The incumbent
+    // lets the chunk win -- it refreshes its own parameter cache from the
+    // plugin after the restore so nothing writes the array back -- and
+    // test_external_plugin_state_restore_juce.cpp is what pins that. A device
+    // that wrote the array on its first block would undo the restore and render
+    // the initialised voice.
+    auto plugin = std::make_unique<StubPlugin>(2, 2, 0);
+    auto* raw = plugin.get();
 
-    // The plan writes the parameters it knows about before every block, so an
-    // automatable value comes from the model and everything else stays as the
-    // chunk left it. That is the native engine's answer to the precedence the
-    // fork spends three steps on, and the two agree for a project MAGDA saved.
-    ParamArena arena({0.0f, 1.0f, 1.0f, 0.4f});
-    Block block(contextFor(), 2);
-    auto deviceBlock = block.deviceBlock(arena.params(contextFor().maxBlockSize));
+    const StubPlugin::State chunkVoice{.tone = 0.9f, .fixed = 0.8f};
+    juce::MemoryBlock chunk(&chunkVoice, sizeof(chunkVoice));
+
+    auto model = externalDeviceSaving(1.0f, 0.25f);  // stale: the chunk says 0.9
+    model.pluginState = chunk.toBase64Encoding();
+
+    const auto result = adapter::adaptExternalPluginInstance(std::move(plugin), model);
+    REQUIRE(result.device != nullptr);
+
+    const auto context = contextFor();
+    result.device->prepare(context);
+
+    // Counted from here: restoring the chunk is itself a write, and what this
+    // is about is whether the block adds one.
+    const auto writesAfterRestore = raw->tone->writes;
+
+    // The plan resolves the stale value, because that is what the model holds.
+    ParamArena arena({0.0f, 1.0f, 1.0f, 0.25f});
+    Block block(context, 2);
+    auto deviceBlock = block.deviceBlock(arena.params(context.maxBlockSize));
     result.device->process(deviceBlock);
 
-    CHECK(raw->tone->getValue() == Catch::Approx(0.4f));
-    CHECK(raw->fixed->getValue() == Catch::Approx(0.8f));
+    CHECK(raw->tone->getValue() == Catch::Approx(0.9f));
+    CHECK(raw->tone->writes == writesAfterRestore);
+}
+
+TEST_CASE("Automation still moves a parameter the chunk set", "[engine][external]") {
+    // The other half of the rule. Leaving a parameter alone is for one that is
+    // still where the project put it; a lane, a macro or a modifier moving it
+    // is a write, and the plugin's own state has no say after that.
+    auto plugin = std::make_unique<StubPlugin>(2, 2, 0);
+    auto* raw = plugin.get();
+
+    const StubPlugin::State chunkVoice{.tone = 0.9f, .fixed = 0.8f};
+    juce::MemoryBlock chunk(&chunkVoice, sizeof(chunkVoice));
+
+    auto model = externalDeviceSaving(1.0f, 0.25f);
+    model.pluginState = chunk.toBase64Encoding();
+
+    const auto result = adapter::adaptExternalPluginInstance(std::move(plugin), model);
+    REQUIRE(result.device != nullptr);
+
+    const auto context = contextFor();
+    result.device->prepare(context);
+    Block block(context, 2);
+
+    // A lane holding the parameter somewhere else.
+    ParamArena automated({0.0f, 1.0f, 1.0f, 0.5f});
+    auto moved = block.deviceBlock(automated.params(context.maxBlockSize));
+    result.device->process(moved);
+
+    CHECK(raw->tone->getValue() == Catch::Approx(0.5f));
+
+    // And back to where the project saved it, which is a position the lane
+    // passes through rather than a parameter nobody has touched: it must arrive
+    // there rather than stay at 0.5.
+    ParamArena returned({0.0f, 1.0f, 1.0f, 0.25f});
+    auto back = block.deviceBlock(returned.params(context.maxBlockSize));
+    result.device->process(back);
+
+    CHECK(raw->tone->getValue() == Catch::Approx(0.25f));
 }
 
 TEST_CASE("A device with no saved state keeps the plugin's defaults", "[engine][external]") {

--- a/tests/test_engine_external_device.cpp
+++ b/tests/test_engine_external_device.cpp
@@ -10,6 +10,7 @@
 
 #include "core/ParameterInfo.hpp"
 #include "exec/EngineDevice.hpp"
+#include "magda/daw/audio/plugin_manager/ExternalPluginLookup.hpp"
 #include "magda/daw/audio/plugin_manager/ExternalPluginState.hpp"
 #include "magda/daw/audio/plugins/engine/EngineDeviceFactory.hpp"
 #include "magda/daw/audio/plugins/engine/EngineExternalDevice.hpp"
@@ -1146,14 +1147,86 @@ TEST_CASE("The asynchronous entry point reports a missing plugin the same way",
 
     bool called = false;
     adapter::ExternalDeviceResult delivered;
-    adapter::createEngineExternalDeviceAsync(missing, services, false,
-                                             [&](adapter::ExternalDeviceResult result) {
-                                                 called = true;
-                                                 delivered = std::move(result);
-                                             });
+    adapter::createEngineExternalDeviceAsync(
+        missing, services, false, [&]() { return &missing; },
+        [&](adapter::ExternalDeviceResult result) {
+            called = true;
+            delivered = std::move(result);
+        });
 
     REQUIRE(called);
     CHECK(delivered.device == nullptr);
     CHECK(delivered.failure.contains("Massive X"));
     CHECK(delivered.restoredParameters.empty());
+}
+
+TEST_CASE("A load that finishes late restores from the model as it is now", "[engine][external]") {
+    // A plugin takes seconds to load and a project does not stop while it does.
+    // If the user turns a knob or applies a preset in the meantime, completing
+    // the load from the values the request was made with would put them back,
+    // and the caller would then be handed those as the values to write into the
+    // model: the edit undone twice over.
+    auto plugin = std::make_unique<StubPlugin>(2, 2, 0);
+    auto* raw = plugin.get();
+
+    auto model = externalDeviceSaving(1.0f, 0.25f);
+    const auto requested = magda::describeSavedPlugin(model);
+
+    // The edit, made while the plugin was loading.
+    model.parameters[1].currentValue = 0.6f;
+
+    const auto result = adapter::completeExternalPluginLoad(std::move(plugin), {}, requested,
+                                                            [&]() { return &model; });
+
+    REQUIRE(result.device != nullptr);
+    CHECK(raw->tone->getValue() == Catch::Approx(0.6f));
+
+    const auto tone =
+        std::find_if(result.restoredParameters.begin(), result.restoredParameters.end(),
+                     [](const magda::RestoredParameter& p) { return p.paramIndex == 3; });
+    REQUIRE(tone != result.restoredParameters.end());
+    CHECK(tone->value == Catch::Approx(0.6f));
+}
+
+TEST_CASE("A device deleted while its plugin loaded is not completed", "[engine][external]") {
+    auto plugin = std::make_unique<StubPlugin>(2, 2, 0);
+
+    const auto requested = magda::describeSavedPlugin(externalDevice());
+    const auto result = adapter::completeExternalPluginLoad(
+        std::move(plugin), {}, requested, []() -> const magda::DeviceInfo* { return nullptr; });
+
+    CHECK(result.device == nullptr);
+    CHECK(result.failure.contains("removed while"));
+}
+
+TEST_CASE("A device that changed plugin while loading is not completed", "[engine][external]") {
+    // The answer arrived for a question the device is no longer asking.
+    // Restoring here would put one plugin's saved patch onto another.
+    auto plugin = std::make_unique<StubPlugin>(2, 2, 0);
+
+    auto model = externalDevice();
+    model.name = "Something Else";
+    model.fileOrIdentifier = "/Library/SomethingElse.vst3";
+
+    auto requestedDevice = externalDevice();
+    requestedDevice.name = "Massive X";
+    requestedDevice.fileOrIdentifier = "/Library/MassiveX.vst3";
+    const auto requested = magda::describeSavedPlugin(requestedDevice);
+
+    const auto result = adapter::completeExternalPluginLoad(std::move(plugin), {}, requested,
+                                                            [&]() { return &model; });
+
+    CHECK(result.device == nullptr);
+    CHECK(result.failure.contains("changed plugin"));
+}
+
+TEST_CASE("A load that failed reports the loader's reason", "[engine][external]") {
+    auto model = externalDevice();
+    const auto requested = magda::describeSavedPlugin(model);
+
+    const auto result = adapter::completeExternalPluginLoad(nullptr, "the file was not there",
+                                                            requested, [&]() { return &model; });
+
+    CHECK(result.device == nullptr);
+    CHECK(result.failure.contains("the file was not there"));
 }

--- a/tests/test_engine_external_device.cpp
+++ b/tests/test_engine_external_device.cpp
@@ -227,8 +227,14 @@ class StubPlugin final : public juce::AudioPluginInstance {
     }
 
     void setStateInformation(const void* data, int size) override {
-        if (throwsOnState)
+        if (throwsOnState) {
+            // Half of a restore, then the throw. A plugin that got this far has
+            // changed things no parameter write puts back.
+            if (mutatesBeforeThrowing)
+                tone->setValue(0.42f);
+
             throw std::runtime_error("plugin state handler failed");
+        }
 
         if (size != static_cast<int>(sizeof(State)))
             return;
@@ -254,6 +260,9 @@ class StubPlugin final : public juce::AudioPluginInstance {
 
     /// Third-party code handed a chunk it cannot read. Some throw.
     bool throwsOnState = false;
+
+    /// And some get part of the way through first.
+    bool mutatesBeforeThrowing = false;
 
     double preparedRate = 0.0;
     int preparedBlockSize = 0;
@@ -1044,13 +1053,20 @@ TEST_CASE("A chunk the plugin declines leaves the baseline standing", "[engine][
     CHECK(raw->tone->getValue() == Catch::Approx(0.7f));
 }
 
-TEST_CASE("A plugin that throws restoring its state does not take the host with it",
-          "[engine][external]") {
+TEST_CASE("A plugin that throws restoring its state is not published", "[engine][external]") {
     // A plugin's state handler is third-party code, and a corrupt chunk is the
-    // input it is least likely to have been tested against.
+    // input it is least likely to have been tested against. Catching the throw
+    // keeps the host alive and tells us nothing about the plugin: it may have
+    // loaded half a preset, switched program and swapped a sample first, and no
+    // amount of writing parameters puts any of that back.
+    //
+    // So the instance is dropped rather than published. What must not happen is
+    // the third step running over it, because that would hand the caller a half
+    // restored plugin's values as the ones to write into the project.
     auto plugin = std::make_unique<StubPlugin>(2, 2, 0);
     auto* raw = plugin.get();
     raw->throwsOnState = true;
+    raw->mutatesBeforeThrowing = true;
 
     const StubPlugin::State chunkVoice{.tone = 0.9f, .fixed = 0.8f};
     juce::MemoryBlock chunk(&chunkVoice, sizeof(chunkVoice));
@@ -1060,8 +1076,32 @@ TEST_CASE("A plugin that throws restoring its state does not take the host with 
 
     const auto result = adapter::adaptExternalPluginInstance(std::move(plugin), model);
 
-    REQUIRE(result.device != nullptr);
-    CHECK(raw->tone->getValue() == Catch::Approx(0.7f));
+    CHECK(result.device == nullptr);
+    CHECK(result.failure.contains("failed while restoring"));
+    CHECK(result.restoredParameters.empty());
+}
+
+TEST_CASE("The value a half restored plugin was left on never reaches the model",
+          "[engine][external]") {
+    // The same case, said from the model's side, which is where the damage
+    // would be: a snapshot of a plugin that threw partway would be written into
+    // the project as the corrected values and saved over the real ones.
+    auto plugin = std::make_unique<StubPlugin>(2, 2, 0);
+    auto* raw = plugin.get();
+    raw->throwsOnState = true;
+    raw->mutatesBeforeThrowing = true;
+
+    const StubPlugin::State chunkVoice{.tone = 0.9f, .fixed = 0.8f};
+    juce::MemoryBlock chunk(&chunkVoice, sizeof(chunkVoice));
+
+    auto model = externalDeviceSaving(1.0f, 0.7f);
+    model.pluginState = chunk.toBase64Encoding();
+
+    const auto result = adapter::adaptExternalPluginInstance(std::move(plugin), model);
+    magda::applyRestoredParameters(model, result.restoredParameters);
+
+    // 0.42 is where the plugin was left. The project still says 0.7.
+    CHECK(model.parameters[1].currentValue == Catch::Approx(0.7f));
 }
 
 TEST_CASE("Automation moves a parameter the chunk set", "[engine][external]") {

--- a/tests/test_engine_external_device.cpp
+++ b/tests/test_engine_external_device.cpp
@@ -1126,3 +1126,34 @@ TEST_CASE("Saved state that is not a chunk this plugin understands is refused",
     CHECK(raw->stateRestores == 0);
     CHECK(raw->fixed->getValue() == Catch::Approx(0.0f));
 }
+
+TEST_CASE("The asynchronous entry point reports a missing plugin the same way",
+          "[engine][external]") {
+    // Both entry points end at the same transaction, which is what the cases
+    // above drive; what is its own here is that a failure reaches the caller
+    // through the callback rather than through a return value, so a session
+    // that asked for a plugin it does not have is told rather than left
+    // waiting.
+    juce::KnownPluginList empty;
+    juce::AudioPluginFormatManager formats;
+
+    magda::DeviceInfo missing = externalDevice();
+    missing.name = "Massive X";
+    missing.fileOrIdentifier = "/Library/MassiveX.vst3";
+
+    const adapter::ExternalPluginServices services{
+        .formats = &formats, .knownPlugins = &empty, .context = contextFor()};
+
+    bool called = false;
+    adapter::ExternalDeviceResult delivered;
+    adapter::createEngineExternalDeviceAsync(missing, services, false,
+                                             [&](adapter::ExternalDeviceResult result) {
+                                                 called = true;
+                                                 delivered = std::move(result);
+                                             });
+
+    REQUIRE(called);
+    CHECK(delivered.device == nullptr);
+    CHECK(delivered.failure.contains("Massive X"));
+    CHECK(delivered.restoredParameters.empty());
+}

--- a/tests/test_engine_external_device.cpp
+++ b/tests/test_engine_external_device.cpp
@@ -1170,7 +1170,8 @@ TEST_CASE("A load that finishes late restores from the model as it is now", "[en
     auto* raw = plugin.get();
 
     auto model = externalDeviceSaving(1.0f, 0.25f);
-    const auto requested = magda::describeSavedPlugin(model);
+    const adapter::RequestedPlugin requested{.identity = magda::savedPluginIdentity(model),
+                                             .name = model.name};
 
     // The edit, made while the plugin was loading.
     model.parameters[1].currentValue = 0.6f;
@@ -1191,7 +1192,9 @@ TEST_CASE("A load that finishes late restores from the model as it is now", "[en
 TEST_CASE("A device deleted while its plugin loaded is not completed", "[engine][external]") {
     auto plugin = std::make_unique<StubPlugin>(2, 2, 0);
 
-    const auto requested = magda::describeSavedPlugin(externalDevice());
+    const auto device = externalDevice();
+    const adapter::RequestedPlugin requested{.identity = magda::savedPluginIdentity(device),
+                                             .name = device.name};
     const auto result = adapter::completeExternalPluginLoad(
         std::move(plugin), {}, requested, []() -> const magda::DeviceInfo* { return nullptr; });
 
@@ -1211,7 +1214,8 @@ TEST_CASE("A device that changed plugin while loading is not completed", "[engin
     auto requestedDevice = externalDevice();
     requestedDevice.name = "Massive X";
     requestedDevice.fileOrIdentifier = "/Library/MassiveX.vst3";
-    const auto requested = magda::describeSavedPlugin(requestedDevice);
+    const adapter::RequestedPlugin requested{
+        .identity = magda::savedPluginIdentity(requestedDevice), .name = requestedDevice.name};
 
     const auto result = adapter::completeExternalPluginLoad(std::move(plugin), {}, requested,
                                                             [&]() { return &model; });
@@ -1222,11 +1226,68 @@ TEST_CASE("A device that changed plugin while loading is not completed", "[engin
 
 TEST_CASE("A load that failed reports the loader's reason", "[engine][external]") {
     auto model = externalDevice();
-    const auto requested = magda::describeSavedPlugin(model);
+    const adapter::RequestedPlugin requested{.identity = magda::savedPluginIdentity(model),
+                                             .name = model.name};
 
     const auto result = adapter::completeExternalPluginLoad(nullptr, "the file was not there",
                                                             requested, [&]() { return &model; });
 
     CHECK(result.device == nullptr);
     CHECK(result.failure.contains("the file was not there"));
+}
+
+TEST_CASE("A scanned plugin's own identifier is not read as a change", "[engine][external]") {
+    // The identity a project saves for a device added from the browser is
+    // JUCE's identifier string for the scanned plugin, and that string carries
+    // the plugin's numeric uid. A description rebuilt from the device's saved
+    // name, format and file has no uid to put in it, so comparing one form
+    // against the other finds every unchanged plugin changed -- and refuses
+    // every load that ever succeeds.
+    juce::PluginDescription scanned;
+    scanned.name = "Massive X";
+    scanned.manufacturerName = "NI";
+    scanned.fileOrIdentifier = "/Library/MassiveX.vst3";
+    scanned.pluginFormatName = "VST3";
+    scanned.uniqueId = 0x4d617373;  // what a scan reports and a rebuild cannot
+
+    auto model = externalDeviceSaving(1.0f, 0.5f);
+    model.name = scanned.name;
+    model.manufacturer = scanned.manufacturerName;
+    model.fileOrIdentifier = scanned.fileOrIdentifier;
+    model.uniqueId = scanned.createIdentifierString();
+
+    const adapter::RequestedPlugin requested{.identity = magda::savedPluginIdentity(model),
+                                             .name = scanned.name};
+
+    auto plugin = std::make_unique<StubPlugin>(2, 2, 0);
+    auto* raw = plugin.get();
+
+    const auto result = adapter::completeExternalPluginLoad(std::move(plugin), {}, requested,
+                                                            [&]() { return &model; });
+
+    REQUIRE(result.device != nullptr);
+    CHECK(result.failure.isEmpty());
+    CHECK(raw->tone->getValue() == Catch::Approx(0.5f));
+}
+
+TEST_CASE("A device that gained a scanned identifier has not changed plugin",
+          "[engine][external]") {
+    // An imported project has no identifier until something resolves it. The
+    // device gaining one while its plugin loaded is not a change of plugin, and
+    // a comparison that read it as one would throw away a good load.
+    auto model = externalDeviceSaving(1.0f, 0.5f);
+    model.name = "Massive X";
+    model.fileOrIdentifier = "/Library/MassiveX.vst3";
+
+    const adapter::RequestedPlugin requested{.identity = magda::savedPluginIdentity(model),
+                                             .name = model.name};
+
+    model.uniqueId = "VST3-Massive X-1234abcd-4d617373";
+
+    auto plugin = std::make_unique<StubPlugin>(2, 2, 0);
+    const auto result = adapter::completeExternalPluginLoad(std::move(plugin), {}, requested,
+                                                            [&]() { return &model; });
+
+    REQUIRE(result.device != nullptr);
+    CHECK(result.failure.isEmpty());
 }

--- a/tests/test_engine_external_device.cpp
+++ b/tests/test_engine_external_device.cpp
@@ -144,8 +144,14 @@ class StubPlugin final : public juce::AudioPluginInstance {
             if (auto position = head->getPosition())
                 positionSeen = *position;
 
+        // Only the channels it has outputs for, which is what a real plugin
+        // does: JUCE hands it a buffer as wide as its inputs or its outputs,
+        // whichever is more, and a mono-out plugin leaves everything past its
+        // one output holding the input it was given.
+        const auto written = std::min(buffer.getNumChannels(), getTotalNumOutputChannels());
+
         const auto level = gain->getValue();
-        for (int channel = 0; channel < buffer.getNumChannels(); ++channel) {
+        for (int channel = 0; channel < written; ++channel) {
             auto* samples = buffer.getWritePointer(channel);
             const auto marker = static_cast<float>(channel + 1) * kChannelMarker;
 
@@ -678,4 +684,85 @@ TEST_CASE("A host that gave the engine no formats is told so", "[engine][externa
 
     CHECK(result.device == nullptr);
     CHECK(result.failure.contains("no plugin formats"));
+}
+
+TEST_CASE("A plugin with more inputs than outputs fills the slot from its outputs",
+          "[engine][external]") {
+    // Stereo in, mono out, and a mono sidechain after them: processed at three
+    // channels, of which the plugin writes one. The two channels past its
+    // output hold what was copied in -- the right half of the input, and the
+    // key -- and reading those back as output hands the chain its own input in
+    // place of an answer.
+    auto plugin = std::make_unique<StubPlugin>(2, 1, 1);
+    auto* raw = plugin.get();
+
+    adapter::EngineExternalDevice device(std::move(plugin), externalDevice(), false);
+    const auto context = contextFor();
+    device.prepare(context);
+
+    ParamArena arena({0.0f, 1.0f, 1.0f, 0.0f});
+    Block block(context, 2);
+    juce::FloatVectorOperations::fill(block.buffer.getWritePointer(0), 1.0f,
+                                      block.buffer.getNumSamples());
+    juce::FloatVectorOperations::fill(block.buffer.getWritePointer(1), -1.0f,
+                                      block.buffer.getNumSamples());
+
+    juce::AudioBuffer<float> key(1, context.maxBlockSize);
+    juce::FloatVectorOperations::fill(key.getWritePointer(0), 0.5f, key.getNumSamples());
+
+    auto deviceBlock = block.deviceBlock(arena.params(context.maxBlockSize));
+    deviceBlock.sidechain = juce::dsp::AudioBlock<const float>(key);
+    device.process(deviceBlock);
+
+    REQUIRE(raw->channelsSeen == 3);
+
+    // The one output, on both sides. Not the input's right channel and not the
+    // key, which are what channels one and two of the plugin's buffer hold.
+    const auto expected = 1.0f + StubPlugin::kChannelMarker;
+    CHECK(block.buffer.getSample(0, 0) == Catch::Approx(expected));
+    CHECK(block.buffer.getSample(1, 0) == Catch::Approx(expected));
+}
+
+TEST_CASE("A stereo-in mono-out plugin does not leave its input in the right channel",
+          "[engine][external]") {
+    // The same rule where the widths happen to agree: two channels in, one
+    // written, and the block is two channels wide. Taking the fast path here
+    // would leave the input sitting in the right channel, which is neither
+    // silence nor the plugin's answer.
+    auto plugin = std::make_unique<StubPlugin>(2, 1, 0);
+
+    adapter::EngineExternalDevice device(std::move(plugin), externalDevice(), false);
+    const auto context = contextFor();
+    device.prepare(context);
+
+    ParamArena arena({0.0f, 1.0f, 1.0f, 0.0f});
+    Block block(context, 2);
+    block.fill(0.5f);
+
+    auto deviceBlock = block.deviceBlock(arena.params(context.maxBlockSize));
+    device.process(deviceBlock);
+
+    const auto expected = 0.5f + StubPlugin::kChannelMarker;
+    CHECK(block.buffer.getSample(0, 0) == Catch::Approx(expected));
+    CHECK(block.buffer.getSample(1, 0) == Catch::Approx(expected));
+}
+
+TEST_CASE("A second prepare at the same settings does not prepare the plugin again",
+          "[engine][external]") {
+    auto plugin = std::make_unique<StubPlugin>();
+    auto* raw = plugin.get();
+
+    adapter::EngineExternalDevice device(std::move(plugin), externalDevice(), false);
+    device.prepare(contextFor());
+    device.prepare(contextFor());
+
+    // Once. The fork does not release a plugin's resources before re-preparing
+    // it -- with VST3 that shuts down the MIDI input buses for good -- so a
+    // device retained across a re-prepare at settings that did not move is left
+    // alone rather than torn down and rebuilt.
+    CHECK(raw->prepareCount == 1);
+
+    device.prepare(contextFor(2, 128));
+    CHECK(raw->prepareCount == 2);
+    CHECK(raw->preparedBlockSize == 128);
 }

--- a/tests/test_engine_external_device.cpp
+++ b/tests/test_engine_external_device.cpp
@@ -7,6 +7,7 @@
 
 #include "core/ParameterInfo.hpp"
 #include "exec/EngineDevice.hpp"
+#include "magda/daw/audio/plugins/engine/EngineDeviceFactory.hpp"
 #include "magda/daw/audio/plugins/engine/EngineExternalDevice.hpp"
 #include "param/ParamBlock.hpp"
 #include "transport/TempoMap.hpp"
@@ -649,4 +650,32 @@ TEST_CASE("A parameter the table does not carry is left where it was", "[engine]
 
     CHECK(raw->gain->getValue() == Catch::Approx(0.4f));
     CHECK(raw->tone->getValue() == Catch::Approx(0.9f));
+}
+
+TEST_CASE("A plugin the scan never saw is refused with a reason", "[engine][external]") {
+    juce::KnownPluginList empty;
+    juce::AudioPluginFormatManager formats;
+
+    magda::DeviceInfo missing = externalDevice();
+    missing.name = "Massive X";
+    missing.fileOrIdentifier = "/Library/MassiveX.vst3";
+
+    const adapter::ExternalPluginServices services{
+        .formats = &formats, .knownPlugins = &empty, .context = contextFor()};
+
+    const auto result = adapter::createEngineExternalDevice(missing, services);
+
+    CHECK(result.device == nullptr);
+    CHECK(result.failure.contains("Massive X"));
+    CHECK(result.failure.contains("not installed"));
+    CHECK_FALSE(adapter::isInstalledExternalPlugin(missing, empty));
+}
+
+TEST_CASE("A host that gave the engine no formats is told so", "[engine][external]") {
+    const adapter::ExternalPluginServices nothing{};
+
+    const auto result = adapter::createEngineExternalDevice(externalDevice(), nothing);
+
+    CHECK(result.device == nullptr);
+    CHECK(result.failure.contains("no plugin formats"));
 }

--- a/tests/test_engine_external_device.cpp
+++ b/tests/test_engine_external_device.cpp
@@ -1,0 +1,652 @@
+#include <juce_audio_processors/juce_audio_processors.h>
+
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <memory>
+#include <vector>
+
+#include "core/ParameterInfo.hpp"
+#include "exec/EngineDevice.hpp"
+#include "magda/daw/audio/plugins/engine/EngineExternalDevice.hpp"
+#include "param/ParamBlock.hpp"
+#include "transport/TempoMap.hpp"
+
+/**
+ * @file test_engine_external_device.cpp
+ * @brief An external plugin under the native engine's Device op (#2241).
+ *
+ * The adapter's half of external plugin hosting, tested against a plugin
+ * written here rather than against one that happens to be installed. That is
+ * not a convenience: the assertions below are about what the host does with a
+ * plugin -- which channels it hands it, which parameter a project's saved value
+ * lands on, what it does with the wet/dry pair the plugin never declared -- and
+ * a real plugin answers none of those questions any better than a stub that
+ * reports exactly what it was given. What a real plugin is for is the corpus,
+ * where the two engines run the same one (#2175).
+ *
+ * The stub is deliberately awkward in the ways real plugins are: a
+ * non-automatable parameter in the middle of its list, a mono bus, a sidechain
+ * bus, latency it reports rather than hides.
+ */
+
+namespace {
+
+namespace adapter = magda::daw::audio::engine_adapter;
+
+/**
+ * @brief One parameter of the stub, automatable or not.
+ *
+ * The non-automatable one is what makes the slot numbering below worth
+ * asserting: the fork's list skips it, so every parameter after it sits one slot
+ * lower than its position in the plugin's own array. Real plugins are full of
+ * them -- a bypass switch, a program selector, a meter reported as a parameter.
+ */
+class StubParameter final : public juce::AudioProcessorParameterWithID {
+  public:
+    StubParameter(const juce::String& id, const juce::String& name, float initial, bool automatable)
+        : juce::AudioProcessorParameterWithID(
+              juce::ParameterID{id, 1}, name,
+              juce::AudioProcessorParameterWithIDAttributes().withAutomatable(automatable)),
+          value_(initial) {}
+
+    float getValue() const override {
+        return value_;
+    }
+
+    void setValue(float newValue) override {
+        value_ = newValue;
+        ++writes;
+    }
+
+    float getDefaultValue() const override {
+        return 0.0f;
+    }
+
+    float getValueForText(const juce::String& text) const override {
+        return text.getFloatValue();
+    }
+
+    /// How many times the host wrote this parameter, which is how a test sees
+    /// that an unchanged value is not written again.
+    int writes = 0;
+
+  private:
+    float value_ = 0.0f;
+};
+
+/**
+ * @brief A plugin that reports what it was handed and marks what it wrote.
+ *
+ * Its output is the input at the gain its first parameter says, plus a
+ * per-channel marker, so a test can tell which of its channels ended up where
+ * without inferring it from a level.
+ */
+class StubPlugin final : public juce::AudioPluginInstance {
+  public:
+    static juce::AudioChannelSet setFor(int channels) {
+        return channels == 1 ? juce::AudioChannelSet::mono() : juce::AudioChannelSet::stereo();
+    }
+
+    static BusesProperties busesFor(int inputs, int outputs, int sidechain) {
+        auto buses = BusesProperties()
+                         .withInput("Input", setFor(inputs), true)
+                         .withOutput("Output", setFor(outputs), true);
+
+        if (sidechain > 0)
+            buses = buses.withInput("Sidechain", setFor(sidechain), true);
+
+        return buses;
+    }
+
+    StubPlugin(int inputs, int outputs, int sidechain)
+        : AudioPluginInstance(busesFor(inputs, outputs, sidechain)) {
+        auto gainParameter = std::make_unique<StubParameter>("gain", "Gain", 1.0f, true);
+        gain = gainParameter.get();
+        addHostedParameter(std::move(gainParameter));
+
+        addHostedParameter(std::make_unique<StubParameter>("fixed", "Fixed", 0.0f, false));
+
+        auto toneParameter = std::make_unique<StubParameter>("tone", "Tone", 0.25f, true);
+        tone = toneParameter.get();
+        addHostedParameter(std::move(toneParameter));
+    }
+
+    StubPlugin() : StubPlugin(2, 2, 0) {}
+
+    const juce::String getName() const override {
+        return "Stub";
+    }
+
+    void fillInPluginDescription(juce::PluginDescription& description) const override {
+        description.name = "Stub";
+        description.pluginFormatName = "VST3";
+        description.manufacturerName = "MAGDA";
+    }
+
+    void prepareToPlay(double rate, int blockSize) override {
+        preparedRate = rate;
+        preparedBlockSize = blockSize;
+        ++prepareCount;
+        nonRealtimeAtPrepare = isNonRealtime();
+    }
+
+    void releaseResources() override {}
+
+    void processBlock(juce::AudioBuffer<float>& buffer, juce::MidiBuffer& midi) override {
+        channelsSeen = buffer.getNumChannels();
+        samplesSeen = buffer.getNumSamples();
+        inputSeen.makeCopyOf(buffer);
+        midiSeen.clear();
+        midiSeen.addEvents(midi, 0, buffer.getNumSamples(), 0);
+
+        if (auto* head = getPlayHead())
+            if (auto position = head->getPosition())
+                positionSeen = *position;
+
+        const auto level = gain->getValue();
+        for (int channel = 0; channel < buffer.getNumChannels(); ++channel) {
+            auto* samples = buffer.getWritePointer(channel);
+            const auto marker = static_cast<float>(channel + 1) * kChannelMarker;
+
+            for (int sample = 0; sample < buffer.getNumSamples(); ++sample)
+                samples[sample] = (samples[sample] * level) + marker;
+        }
+
+        if (emitsMidi) {
+            midi.clear();
+            midi.addEvent(juce::MidiMessage::noteOn(1, 64, 1.0f), 0);
+        }
+    }
+
+    double getTailLengthSeconds() const override {
+        return 0.0;
+    }
+
+    bool acceptsMidi() const override {
+        return true;
+    }
+
+    bool producesMidi() const override {
+        return emitsMidi;
+    }
+
+    juce::AudioProcessorEditor* createEditor() override {
+        return nullptr;
+    }
+
+    bool hasEditor() const override {
+        return false;
+    }
+
+    int getNumPrograms() override {
+        return 1;
+    }
+
+    int getCurrentProgram() override {
+        return 0;
+    }
+
+    void setCurrentProgram(int) override {}
+
+    const juce::String getProgramName(int) override {
+        return {};
+    }
+
+    void changeProgramName(int, const juce::String&) override {}
+
+    void getStateInformation(juce::MemoryBlock&) override {}
+
+    void setStateInformation(const void*, int) override {}
+
+    /// The per-channel offset the output carries, so a test can name which of
+    /// the plugin's channels it is reading.
+    static constexpr float kChannelMarker = 0.01f;
+
+    StubParameter* gain = nullptr;
+    StubParameter* tone = nullptr;
+
+    bool emitsMidi = false;
+
+    double preparedRate = 0.0;
+    int preparedBlockSize = 0;
+    int prepareCount = 0;
+    bool nonRealtimeAtPrepare = false;
+
+    int channelsSeen = 0;
+    int samplesSeen = 0;
+    juce::AudioBuffer<float> inputSeen;
+    juce::MidiBuffer midiSeen;
+    juce::AudioPlayHead::PositionInfo positionSeen;
+};
+
+magda::engine::RenderContext contextFor(int channels = 2, int blockSize = 64) {
+    return {.sampleRate = 48000.0, .maxBlockSize = blockSize, .numChannels = channels};
+}
+
+/// A device whose parameters are the fork's list: the wrapper pair at zero and
+/// one, then the plugin's automatable parameters.
+magda::DeviceInfo externalDevice() {
+    magda::DeviceInfo device;
+    device.id = 7;
+    device.name = "Stub";
+    device.format = magda::PluginFormat::VST3;
+
+    const auto normalised = [](int index, const juce::String& name) {
+        magda::ParameterInfo info;
+        info.paramIndex = index;
+        info.name = name;
+        info.minValue = 0.0f;
+        info.maxValue = 1.0f;
+        info.currentValue = 0.0f;
+        return info;
+    };
+
+    auto dry = normalised(0, "Dry Level");
+    dry.wrapperRole = magda::WrapperRole::DryGain;
+    auto wet = normalised(1, "Wet Level");
+    wet.wrapperRole = magda::WrapperRole::WetGain;
+
+    device.wrapperParameters = {dry, wet};
+    device.parameters = {normalised(2, "Gain"), normalised(3, "Tone")};
+
+    return device;
+}
+
+/**
+ * @brief One block, and the parameter values the plan resolved for it.
+ *
+ * The table is built by hand rather than compiled, because what is being
+ * asserted is what the adapter does with a resolved value and not how it came
+ * to be resolved. The values are held as the flat arena DeviceParams reads,
+ * one segment per parameter.
+ */
+class ParamArena {
+  public:
+    explicit ParamArena(const std::vector<float>& values) {
+        for (const auto value : values) {
+            segments_.push_back({.startSample = 0, .startValue = value, .endValue = value});
+            counts_.push_back(1);
+            domains_.push_back(
+                {.scale = magda::ParameterScale::Linear, .minValue = 0.0f, .maxValue = 1.0f});
+        }
+    }
+
+    magda::engine::DeviceParams params(int numSamples) const {
+        return {segments_, counts_, domains_, 1, numSamples};
+    }
+
+  private:
+    std::vector<magda::engine::ParamSegment> segments_;
+    std::vector<int> counts_;
+    std::vector<magda::ParameterUtils::ParameterDomain> domains_;
+};
+
+/// A block of audio, its MIDI ports, and the description of where it is.
+struct Block {
+    Block(const magda::engine::RenderContext& context, int channels)
+        : buffer(channels, context.maxBlockSize) {
+        buffer.clear();
+        info.numSamples = context.maxBlockSize;
+        info.playing = true;
+        info.endSeconds = context.maxBlockSize / context.sampleRate;
+        info.endBeat = info.endSeconds * 2.0;
+    }
+
+    void fill(float value) {
+        for (int channel = 0; channel < buffer.getNumChannels(); ++channel)
+            juce::FloatVectorOperations::fill(buffer.getWritePointer(channel), value,
+                                              buffer.getNumSamples());
+    }
+
+    magda::engine::DeviceBlock deviceBlock(const magda::engine::DeviceParams& params) {
+        magda::engine::DeviceBlock block;
+        block.audio = juce::dsp::AudioBlock<float>(buffer);
+        block.params = params;
+        block.block = info;
+        return block;
+    }
+
+    juce::AudioBuffer<float> buffer;
+    magda::engine::BlockInfo info;
+};
+
+}  // namespace
+
+TEST_CASE("External device reports the instance's latency", "[engine][external]") {
+    auto plugin = std::make_unique<StubPlugin>();
+    plugin->setLatencySamples(128);
+    auto* raw = plugin.get();
+
+    adapter::EngineExternalDevice device(std::move(plugin), externalDevice(), false);
+    device.prepare(contextFor());
+
+    CHECK(device.latencySamples() == 128);
+    CHECK(raw->preparedRate == 48000.0);
+    CHECK(raw->preparedBlockSize == 64);
+    CHECK(raw->prepareCount == 1);
+}
+
+TEST_CASE("A bounce tells the plugin it is not realtime", "[engine][external]") {
+    auto live = std::make_unique<StubPlugin>();
+    auto* liveRaw = live.get();
+    adapter::EngineExternalDevice liveDevice(std::move(live), externalDevice(), false);
+    liveDevice.prepare(contextFor());
+
+    auto offline = std::make_unique<StubPlugin>();
+    auto* offlineRaw = offline.get();
+    adapter::EngineExternalDevice offlineDevice(std::move(offline), externalDevice(), true);
+    offlineDevice.prepare(contextFor());
+
+    CHECK_FALSE(liveRaw->nonRealtimeAtPrepare);
+    CHECK(offlineRaw->nonRealtimeAtPrepare);
+}
+
+TEST_CASE("A plan slot addresses the fork's parameter, not the plugin's", "[engine][external]") {
+    auto plugin = std::make_unique<StubPlugin>();
+    auto* raw = plugin.get();
+
+    adapter::EngineExternalDevice device(std::move(plugin), externalDevice(), false);
+    const auto context = contextFor();
+    device.prepare(context);
+
+    // Slot two is the plugin's first automatable parameter and slot three is
+    // its second: the non-automatable one between them is not in the fork's
+    // list, so it takes no slot.
+    ParamArena arena({0.0f, 1.0f, 0.75f, 0.5f});
+    Block block(context, 2);
+    auto deviceBlock = block.deviceBlock(arena.params(context.maxBlockSize));
+    device.process(deviceBlock);
+
+    CHECK(raw->gain->getValue() == Catch::Approx(0.75f));
+    CHECK(raw->tone->getValue() == Catch::Approx(0.5f));
+}
+
+TEST_CASE("A stereo plugin processes the block in place", "[engine][external]") {
+    auto plugin = std::make_unique<StubPlugin>();
+    auto* raw = plugin.get();
+
+    adapter::EngineExternalDevice device(std::move(plugin), externalDevice(), false);
+    const auto context = contextFor();
+    device.prepare(context);
+
+    ParamArena arena({0.0f, 1.0f, 1.0f, 0.0f});
+    Block block(context, 2);
+    block.fill(0.5f);
+
+    auto deviceBlock = block.deviceBlock(arena.params(context.maxBlockSize));
+    device.process(deviceBlock);
+
+    CHECK(raw->channelsSeen == 2);
+    CHECK(raw->inputSeen.getSample(0, 0) == Catch::Approx(0.5f));
+
+    // Its own output, marked per channel: nothing between the plugin and the
+    // block to lose a channel in.
+    CHECK(block.buffer.getSample(0, 0) == Catch::Approx(0.5f + StubPlugin::kChannelMarker));
+    CHECK(block.buffer.getSample(1, 0) == Catch::Approx(0.5f + (2 * StubPlugin::kChannelMarker)));
+}
+
+TEST_CASE("A mono plugin is fed the average and answers on both sides", "[engine][external]") {
+    auto plugin = std::make_unique<StubPlugin>(1, 1, 0);
+    auto* raw = plugin.get();
+
+    adapter::EngineExternalDevice device(std::move(plugin), externalDevice(), false);
+    const auto context = contextFor();
+    device.prepare(context);
+
+    ParamArena arena({0.0f, 1.0f, 1.0f, 0.0f});
+    Block block(context, 2);
+    juce::FloatVectorOperations::fill(block.buffer.getWritePointer(0), 1.0f,
+                                      block.buffer.getNumSamples());
+    juce::FloatVectorOperations::fill(block.buffer.getWritePointer(1), 0.0f,
+                                      block.buffer.getNumSamples());
+
+    auto deviceBlock = block.deviceBlock(arena.params(context.maxBlockSize));
+    device.process(deviceBlock);
+
+    // The average of one and nothing, which is the fork's rule and not the left
+    // channel.
+    CHECK(raw->channelsSeen == 1);
+    CHECK(raw->inputSeen.getSample(0, 0) == Catch::Approx(0.5f));
+
+    // One output channel spread over both sides, so what follows reads two.
+    const auto expected = 0.5f + StubPlugin::kChannelMarker;
+    CHECK(block.buffer.getSample(0, 0) == Catch::Approx(expected));
+    CHECK(block.buffer.getSample(1, 0) == Catch::Approx(expected));
+}
+
+TEST_CASE("A stereo plugin in a mono slot is handed the channel twice", "[engine][external]") {
+    auto plugin = std::make_unique<StubPlugin>(2, 2, 0);
+    auto* raw = plugin.get();
+
+    adapter::EngineExternalDevice device(std::move(plugin), externalDevice(), false);
+    const auto context = contextFor(1);
+    device.prepare(context);
+
+    ParamArena arena({0.0f, 1.0f, 1.0f, 0.0f});
+    Block block(context, 1);
+    block.fill(0.25f);
+
+    auto deviceBlock = block.deviceBlock(arena.params(context.maxBlockSize));
+    device.process(deviceBlock);
+
+    CHECK(raw->channelsSeen == 2);
+    CHECK(raw->inputSeen.getSample(0, 0) == Catch::Approx(0.25f));
+    CHECK(raw->inputSeen.getSample(1, 0) == Catch::Approx(0.25f));
+
+    // The slot is one channel wide, so only the plugin's first comes back.
+    CHECK(block.buffer.getNumChannels() == 1);
+    CHECK(block.buffer.getSample(0, 0) == Catch::Approx(0.25f + StubPlugin::kChannelMarker));
+}
+
+TEST_CASE("A sidechain key lands on the bus after the plugin's own", "[engine][external]") {
+    auto plugin = std::make_unique<StubPlugin>(2, 2, 2);
+    auto* raw = plugin.get();
+
+    adapter::EngineExternalDevice device(std::move(plugin), externalDevice(), false);
+    const auto context = contextFor();
+    device.prepare(context);
+
+    ParamArena arena({0.0f, 1.0f, 1.0f, 0.0f});
+    Block block(context, 2);
+    block.fill(0.5f);
+
+    juce::AudioBuffer<float> key(2, context.maxBlockSize);
+    for (int channel = 0; channel < key.getNumChannels(); ++channel)
+        juce::FloatVectorOperations::fill(key.getWritePointer(channel), -0.75f,
+                                          key.getNumSamples());
+
+    auto deviceBlock = block.deviceBlock(arena.params(context.maxBlockSize));
+    deviceBlock.sidechain = juce::dsp::AudioBlock<const float>(key);
+    device.process(deviceBlock);
+
+    REQUIRE(raw->channelsSeen == 4);
+    CHECK(raw->inputSeen.getSample(0, 0) == Catch::Approx(0.5f));
+    CHECK(raw->inputSeen.getSample(2, 0) == Catch::Approx(-0.75f));
+    CHECK(raw->inputSeen.getSample(3, 0) == Catch::Approx(-0.75f));
+
+    // Only the plugin's own pair comes back to the chain.
+    CHECK(block.buffer.getSample(0, 0) == Catch::Approx(0.5f + StubPlugin::kChannelMarker));
+}
+
+TEST_CASE("An unconnected sidechain is silence rather than the last block's key",
+          "[engine][external]") {
+    auto plugin = std::make_unique<StubPlugin>(2, 2, 2);
+    auto* raw = plugin.get();
+
+    adapter::EngineExternalDevice device(std::move(plugin), externalDevice(), false);
+    const auto context = contextFor();
+    device.prepare(context);
+
+    ParamArena arena({0.0f, 1.0f, 1.0f, 0.0f});
+    Block block(context, 2);
+    block.fill(0.5f);
+
+    auto deviceBlock = block.deviceBlock(arena.params(context.maxBlockSize));
+    device.process(deviceBlock);
+
+    REQUIRE(raw->channelsSeen == 4);
+    CHECK(raw->inputSeen.getSample(2, 0) == Catch::Approx(0.0f));
+    CHECK(raw->inputSeen.getSample(3, 0) == Catch::Approx(0.0f));
+}
+
+TEST_CASE("The wrapper pair mixes the plugin against what it was handed", "[engine][external]") {
+    auto plugin = std::make_unique<StubPlugin>();
+
+    adapter::EngineExternalDevice device(std::move(plugin), externalDevice(), false);
+    const auto context = contextFor();
+    device.prepare(context);
+
+    // Half dry, half wet, and a plugin that halves what it is given: the output
+    // is half the input plus half of the plugin's answer.
+    ParamArena arena({0.5f, 0.5f, 0.5f, 0.0f});
+    Block block(context, 2);
+    block.fill(1.0f);
+
+    auto deviceBlock = block.deviceBlock(arena.params(context.maxBlockSize));
+    device.process(deviceBlock);
+
+    const auto wet = ((1.0f * 0.5f) + StubPlugin::kChannelMarker) * 0.5f;
+    CHECK(block.buffer.getSample(0, 0) == Catch::Approx(wet + (1.0f * 0.5f)));
+}
+
+TEST_CASE("A fully dry slot still runs the plugin", "[engine][external]") {
+    auto plugin = std::make_unique<StubPlugin>();
+    auto* raw = plugin.get();
+
+    adapter::EngineExternalDevice device(std::move(plugin), externalDevice(), false);
+    const auto context = contextFor();
+    device.prepare(context);
+
+    ParamArena arena({1.0f, 0.0f, 1.0f, 0.0f});
+    Block block(context, 2);
+    block.fill(0.25f);
+
+    auto deviceBlock = block.deviceBlock(arena.params(context.maxBlockSize));
+    device.process(deviceBlock);
+
+    // The plugin ran -- its tail keeps building even at no wet level, which is
+    // what makes a wet-level automation lane usable at all.
+    CHECK(raw->channelsSeen == 2);
+    CHECK(block.buffer.getSample(0, 0) == Catch::Approx(0.25f));
+}
+
+TEST_CASE("MIDI reaches the plugin and what it answers reaches the port", "[engine][external]") {
+    auto plugin = std::make_unique<StubPlugin>();
+    auto* raw = plugin.get();
+    raw->emitsMidi = true;
+
+    adapter::EngineExternalDevice device(std::move(plugin), externalDevice(), false);
+    const auto context = contextFor();
+    device.prepare(context);
+
+    ParamArena arena({0.0f, 1.0f, 1.0f, 0.0f});
+    Block block(context, 2);
+
+    juce::MidiBuffer in;
+    in.addEvent(juce::MidiMessage::noteOn(1, 60, 0.8f), 12);
+    juce::MidiBuffer out;
+
+    auto deviceBlock = block.deviceBlock(arena.params(context.maxBlockSize));
+    deviceBlock.midiIn = &in;
+    deviceBlock.midiOut = &out;
+    device.process(deviceBlock);
+
+    REQUIRE(raw->midiSeen.getNumEvents() == 1);
+    for (const auto event : raw->midiSeen) {
+        CHECK(event.getMessage().isNoteOn());
+        CHECK(event.getMessage().getNoteNumber() == 60);
+        CHECK(event.samplePosition == 12);
+    }
+
+    REQUIRE(out.getNumEvents() == 1);
+    for (const auto event : out)
+        CHECK(event.getMessage().getNoteNumber() == 64);
+}
+
+TEST_CASE("The plugin is told where the transport is", "[engine][external]") {
+    auto plugin = std::make_unique<StubPlugin>();
+    auto* raw = plugin.get();
+
+    adapter::EngineExternalDevice device(std::move(plugin), externalDevice(), false);
+    const auto context = contextFor();
+    device.prepare(context);
+
+    const magda::engine::TempoMap tempo({{.startBeat = 0.0, .bpm = 90.0}},
+                                        {{.startBeat = 0.0, .numerator = 3, .denominator = 4}});
+
+    ParamArena arena({0.0f, 1.0f, 1.0f, 0.0f});
+    Block block(context, 2);
+    block.info.startBeat = 7.0;  // the second beat of the third bar, in 3/4
+    block.info.endBeat = 7.5;
+    block.info.startSeconds = tempo.beatToTime(7.0);
+    block.info.endSeconds = tempo.beatToTime(7.5);
+    block.info.tempo = &tempo;
+
+    auto deviceBlock = block.deviceBlock(arena.params(context.maxBlockSize));
+    device.process(deviceBlock);
+
+    const auto& position = raw->positionSeen;
+    REQUIRE(position.getBpm().hasValue());
+    CHECK(*position.getBpm() == Catch::Approx(90.0));
+    CHECK(position.getIsPlaying());
+    REQUIRE(position.getPpqPosition().hasValue());
+    CHECK(*position.getPpqPosition() == Catch::Approx(7.0));
+    REQUIRE(position.getPpqPositionOfLastBarStart().hasValue());
+    CHECK(*position.getPpqPositionOfLastBarStart() == Catch::Approx(6.0));
+    REQUIRE(position.getTimeSignature().hasValue());
+    CHECK(position.getTimeSignature()->numerator == 3);
+    CHECK(position.getTimeSignature()->denominator == 4);
+    REQUIRE(position.getTimeInSeconds().hasValue());
+    CHECK(*position.getTimeInSeconds() == Catch::Approx(tempo.beatToTime(7.0)));
+}
+
+TEST_CASE("A parameter that did not move is not written again", "[engine][external]") {
+    auto plugin = std::make_unique<StubPlugin>();
+    auto* raw = plugin.get();
+
+    adapter::EngineExternalDevice device(std::move(plugin), externalDevice(), false);
+    const auto context = contextFor();
+    device.prepare(context);
+
+    ParamArena held({0.0f, 1.0f, 0.6f, 0.0f});
+    Block block(context, 2);
+
+    for (int pass = 0; pass < 3; ++pass) {
+        auto deviceBlock = block.deviceBlock(held.params(context.maxBlockSize));
+        device.process(deviceBlock);
+    }
+
+    // Once, on the block that moved it. The fork writes a plugin parameter only
+    // when the value differs from what the plugin already reports, because a
+    // plugin is entitled to treat every write as a gesture: one that rebuilds a
+    // filter or repaints an editor on each would do it every block on a
+    // parameter nobody touched.
+    CHECK(raw->gain->writes == 1);
+
+    ParamArena moved({0.0f, 1.0f, 0.7f, 0.0f});
+    auto movedBlock = block.deviceBlock(moved.params(context.maxBlockSize));
+    device.process(movedBlock);
+
+    CHECK(raw->gain->writes == 2);
+}
+
+TEST_CASE("A parameter the table does not carry is left where it was", "[engine][external]") {
+    auto plugin = std::make_unique<StubPlugin>();
+    auto* raw = plugin.get();
+    raw->tone->setValue(0.9f);
+
+    adapter::EngineExternalDevice device(std::move(plugin), externalDevice(), false);
+    const auto context = contextFor();
+    device.prepare(context);
+
+    // A window that stops before the tone parameter: a project saved against a
+    // build of the plugin that did not have it.
+    ParamArena arena({0.0f, 1.0f, 0.4f});
+    Block block(context, 2);
+
+    auto deviceBlock = block.deviceBlock(arena.params(context.maxBlockSize));
+    device.process(deviceBlock);
+
+    CHECK(raw->gain->getValue() == Catch::Approx(0.4f));
+    CHECK(raw->tone->getValue() == Catch::Approx(0.9f));
+}

--- a/tests/test_engine_external_device.cpp
+++ b/tests/test_engine_external_device.cpp
@@ -88,7 +88,7 @@ class StubPlugin final : public juce::AudioPluginInstance {
         return channels == 1 ? juce::AudioChannelSet::mono() : juce::AudioChannelSet::stereo();
     }
 
-    static BusesProperties busesFor(int inputs, int outputs, int sidechain) {
+    static BusesProperties busesFor(int inputs, int outputs, int sidechain, int extraPairs) {
         auto buses = BusesProperties()
                          .withInput("Input", setFor(inputs), true)
                          .withOutput("Output", setFor(outputs), true);
@@ -96,11 +96,17 @@ class StubPlugin final : public juce::AudioPluginInstance {
         if (sidechain > 0)
             buses = buses.withInput("Sidechain", setFor(sidechain), true);
 
+        // Further stereo output buses, the way a multi-out sampler reports its
+        // drum outs: one bus each, after the main one.
+        for (int pair = 0; pair < extraPairs; ++pair)
+            buses = buses.withOutput("Out " + juce::String(pair + 2),
+                                     juce::AudioChannelSet::stereo(), true);
+
         return buses;
     }
 
-    StubPlugin(int inputs, int outputs, int sidechain)
-        : AudioPluginInstance(busesFor(inputs, outputs, sidechain)) {
+    StubPlugin(int inputs, int outputs, int sidechain, int extraPairs = 0)
+        : AudioPluginInstance(busesFor(inputs, outputs, sidechain, extraPairs)) {
         auto gainParameter = std::make_unique<StubParameter>("gain", "Gain", 1.0f, true);
         gain = gainParameter.get();
         addHostedParameter(std::move(gainParameter));
@@ -765,4 +771,104 @@ TEST_CASE("A second prepare at the same settings does not prepare the plugin aga
     device.prepare(contextFor(2, 128));
     CHECK(raw->prepareCount == 2);
     CHECK(raw->preparedBlockSize == 128);
+}
+
+TEST_CASE("A multi-out plugin's further pairs reach the ports opened for them",
+          "[engine][external]") {
+    // Three drum outs past the main pair, which is what a multi-out sampler on
+    // a MultiOut track is. The plan opens a port for each and the executor
+    // hands over a cleared block for it; a device that writes only the main
+    // pair leaves every one of those tracks silent.
+    auto plugin = std::make_unique<StubPlugin>(2, 2, 0, 3);
+    auto* raw = plugin.get();
+
+    auto model = externalDevice();
+    model.multiOut.isMultiOut = true;
+    model.multiOut.totalOutputChannels = 8;
+    for (int pair = 0; pair < 4; ++pair)
+        model.multiOut.outputPairs.push_back({.outputIndex = pair,
+                                              .name = "Out " + juce::String(pair + 1),
+                                              .firstPin = (pair * 2) + 1,
+                                              .numChannels = 2});
+
+    adapter::EngineExternalDevice device(std::move(plugin), model, false);
+    const auto context = contextFor();
+    device.prepare(context);
+
+    ParamArena arena({0.0f, 1.0f, 1.0f, 0.0f});
+    Block block(context, 2);
+    block.fill(0.25f);
+
+    // One block per pair past the main one, cleared, exactly as the executor
+    // hands them over.
+    std::vector<juce::AudioBuffer<float>> pairBuffers;
+    std::vector<juce::dsp::AudioBlock<float>> pairs;
+    pairBuffers.reserve(3);
+    for (int pair = 0; pair < 3; ++pair) {
+        pairBuffers.emplace_back(2, context.maxBlockSize);
+        pairBuffers.back().clear();
+    }
+    for (auto& buffer : pairBuffers)
+        pairs.emplace_back(buffer);
+
+    auto deviceBlock = block.deviceBlock(arena.params(context.maxBlockSize));
+    deviceBlock.extraOutputs = {pairs.data(), pairs.size()};
+    device.process(deviceBlock);
+
+    REQUIRE(raw->channelsSeen == 8);
+
+    // The main pair still goes to the chain, and each further pair carries the
+    // plugin's own channels for it: pair one is channels two and three.
+    CHECK(block.buffer.getSample(0, 0) == Catch::Approx(0.25f + StubPlugin::kChannelMarker));
+
+    for (int pair = 0; pair < 3; ++pair) {
+        const auto firstChannel = (pair + 1) * 2;
+        for (int channel = 0; channel < 2; ++channel) {
+            const auto expected =
+                static_cast<float>(firstChannel + channel + 1) * StubPlugin::kChannelMarker;
+            CHECK(pairBuffers[static_cast<std::size_t>(pair)].getSample(channel, 0) ==
+                  Catch::Approx(expected));
+        }
+    }
+}
+
+TEST_CASE("A pair the plugin does not have stays silent", "[engine][external]") {
+    // A model that recorded four pairs against a build of the plugin that has
+    // two. The block for the pair with nothing behind it arrives cleared and
+    // has to stay that way rather than being handed whatever sits at that index.
+    auto plugin = std::make_unique<StubPlugin>(2, 2, 0, 1);
+
+    auto model = externalDevice();
+    model.multiOut.isMultiOut = true;
+    for (int pair = 0; pair < 3; ++pair)
+        model.multiOut.outputPairs.push_back(
+            {.outputIndex = pair, .name = "Out", .firstPin = (pair * 2) + 1, .numChannels = 2});
+
+    adapter::EngineExternalDevice device(std::move(plugin), model, false);
+    const auto context = contextFor();
+    device.prepare(context);
+
+    ParamArena arena({0.0f, 1.0f, 1.0f, 0.0f});
+    Block block(context, 2);
+    block.fill(0.25f);
+
+    std::vector<juce::AudioBuffer<float>> pairBuffers;
+    std::vector<juce::dsp::AudioBlock<float>> pairs;
+    pairBuffers.reserve(2);
+    for (int pair = 0; pair < 2; ++pair) {
+        pairBuffers.emplace_back(2, context.maxBlockSize);
+        pairBuffers.back().clear();
+    }
+    for (auto& buffer : pairBuffers)
+        pairs.emplace_back(buffer);
+
+    auto deviceBlock = block.deviceBlock(arena.params(context.maxBlockSize));
+    deviceBlock.extraOutputs = {pairs.data(), pairs.size()};
+    device.process(deviceBlock);
+
+    // Pair one is the plugin's second bus and carries audio; pair two has no
+    // channels behind it.
+    CHECK(pairBuffers[0].getSample(0, 0) == Catch::Approx(3 * StubPlugin::kChannelMarker));
+    CHECK(pairBuffers[1].getSample(0, 0) == Catch::Approx(0.0f));
+    CHECK(pairBuffers[1].getSample(1, 0) == Catch::Approx(0.0f));
 }

--- a/tests/test_engine_external_device.cpp
+++ b/tests/test_engine_external_device.cpp
@@ -1,13 +1,16 @@
 #include <juce_audio_processors/juce_audio_processors.h>
 
+#include <algorithm>
 #include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <cstring>
 #include <memory>
+#include <stdexcept>
 #include <vector>
 
 #include "core/ParameterInfo.hpp"
 #include "exec/EngineDevice.hpp"
+#include "magda/daw/audio/plugin_manager/ExternalPluginState.hpp"
 #include "magda/daw/audio/plugins/engine/EngineDeviceFactory.hpp"
 #include "magda/daw/audio/plugins/engine/EngineExternalDevice.hpp"
 #include "param/ParamBlock.hpp"
@@ -223,6 +226,9 @@ class StubPlugin final : public juce::AudioPluginInstance {
     }
 
     void setStateInformation(const void* data, int size) override {
+        if (throwsOnState)
+            throw std::runtime_error("plugin state handler failed");
+
         if (size != static_cast<int>(sizeof(State)))
             return;
 
@@ -244,6 +250,9 @@ class StubPlugin final : public juce::AudioPluginInstance {
     int stateRestores = 0;
 
     bool emitsMidi = false;
+
+    /// Third-party code handed a chunk it cannot read. Some throw.
+    bool throwsOnState = false;
 
     double preparedRate = 0.0;
     int preparedBlockSize = 0;
@@ -659,6 +668,10 @@ TEST_CASE("A parameter that did not move is not written again", "[engine][extern
     ParamArena held({0.0f, 1.0f, 0.6f, 0.0f});
     Block block(context, 2);
 
+    // From here: applying the project's saved parameter array is itself a
+    // write, and what this is about is how many the blocks add.
+    const auto writesAfterConstruction = raw->gain->writes;
+
     for (int pass = 0; pass < 3; ++pass) {
         auto deviceBlock = block.deviceBlock(held.params(context.maxBlockSize));
         device.process(deviceBlock);
@@ -669,13 +682,13 @@ TEST_CASE("A parameter that did not move is not written again", "[engine][extern
     // plugin is entitled to treat every write as a gesture: one that rebuilds a
     // filter or repaints an editor on each would do it every block on a
     // parameter nobody touched.
-    CHECK(raw->gain->writes == 1);
+    CHECK(raw->gain->writes == writesAfterConstruction + 1);
 
     ParamArena moved({0.0f, 1.0f, 0.7f, 0.0f});
     auto movedBlock = block.deviceBlock(moved.params(context.maxBlockSize));
     device.process(movedBlock);
 
-    CHECK(raw->gain->writes == 2);
+    CHECK(raw->gain->writes == writesAfterConstruction + 2);
 }
 
 TEST_CASE("A parameter the table does not carry is left where it was", "[engine][external]") {
@@ -683,12 +696,16 @@ TEST_CASE("A parameter the table does not carry is left where it was", "[engine]
     auto* raw = plugin.get();
     raw->tone->setValue(0.9f);
 
-    adapter::EngineExternalDevice device(std::move(plugin), externalDevice(), false);
+    // A project saved against a build of the plugin that did not have the tone
+    // parameter: the model does not describe it, so nothing seeds it and the
+    // plan's window stops before it.
+    auto model = externalDevice();
+    model.parameters.pop_back();
+
+    adapter::EngineExternalDevice device(std::move(plugin), model, false);
     const auto context = contextFor();
     device.prepare(context);
 
-    // A window that stops before the tone parameter: a project saved against a
-    // build of the plugin that did not have it.
     ParamArena arena({0.0f, 1.0f, 0.4f});
     Block block(context, 2);
 
@@ -929,15 +946,17 @@ TEST_CASE("A project's saved plugin state reaches the plugin", "[engine][externa
     CHECK(raw->fixed->getValue() == Catch::Approx(0.8f));
 }
 
-TEST_CASE("A stale saved parameter array does not overwrite the chunk", "[engine][external]") {
+TEST_CASE("A stale saved parameter array is corrected rather than replayed", "[engine][external]") {
     // Every project MAGDA saved before the restore was fixed has this shape:
     // the chunk holds the voice the user heard, and the parameter array beside
-    // it holds the defaults the host had read at construction. The incumbent
-    // lets the chunk win -- it refreshes its own parameter cache from the
-    // plugin after the restore so nothing writes the array back -- and
-    // test_external_plugin_state_restore_juce.cpp is what pins that. A device
-    // that wrote the array on its first block would undo the restore and render
-    // the initialised voice.
+    // it holds the defaults the host read at construction. The incumbent lets
+    // the chunk win and test_external_plugin_state_restore_juce.cpp pins that.
+    //
+    // Under the native engine the plan writes every parameter it resolves
+    // before each block, and it resolves them from the model. So the chunk
+    // winning on the instance is not enough on its own: what the restoration
+    // leaves behind has to reach the model, or the next block puts the stale
+    // value back. That correction is what the result carries.
     auto plugin = std::make_unique<StubPlugin>(2, 2, 0);
     auto* raw = plugin.get();
 
@@ -947,30 +966,107 @@ TEST_CASE("A stale saved parameter array does not overwrite the chunk", "[engine
     auto model = externalDeviceSaving(1.0f, 0.25f);  // stale: the chunk says 0.9
     model.pluginState = chunk.toBase64Encoding();
 
-    const auto result = adapter::adaptExternalPluginInstance(std::move(plugin), model);
+    auto result = adapter::adaptExternalPluginInstance(std::move(plugin), model);
     REQUIRE(result.device != nullptr);
+
+    // The chunk won on the instance.
+    CHECK(raw->tone->getValue() == Catch::Approx(0.9f));
+    CHECK(raw->fixed->getValue() == Catch::Approx(0.8f));
+
+    // And the correction came back, addressed the way the project addresses it.
+    const auto tone =
+        std::find_if(result.restoredParameters.begin(), result.restoredParameters.end(),
+                     [](const magda::RestoredParameter& p) { return p.paramIndex == 3; });
+    REQUIRE(tone != result.restoredParameters.end());
+    CHECK(tone->value == Catch::Approx(0.9f));
+
+    // Applied by the host, on the model, which is the only place it may be
+    // written. From here the plan resolves the chunk's value and every block
+    // asserts it rather than fighting it.
+    magda::applyRestoredParameters(model, result.restoredParameters);
+    CHECK(model.parameters[1].currentValue == Catch::Approx(0.9f));
 
     const auto context = contextFor();
     result.device->prepare(context);
 
-    // Counted from here: restoring the chunk is itself a write, and what this
-    // is about is whether the block adds one.
-    const auto writesAfterRestore = raw->tone->writes;
-
-    // The plan resolves the stale value, because that is what the model holds.
-    ParamArena arena({0.0f, 1.0f, 1.0f, 0.25f});
+    ParamArena arena({0.0f, 1.0f, 1.0f, 0.9f});
     Block block(context, 2);
     auto deviceBlock = block.deviceBlock(arena.params(context.maxBlockSize));
     result.device->process(deviceBlock);
 
     CHECK(raw->tone->getValue() == Catch::Approx(0.9f));
-    CHECK(raw->tone->writes == writesAfterRestore);
 }
 
-TEST_CASE("Automation still moves a parameter the chunk set", "[engine][external]") {
-    // The other half of the rule. Leaving a parameter alone is for one that is
-    // still where the project put it; a lane, a macro or a modifier moving it
-    // is a write, and the plugin's own state has no say after that.
+TEST_CASE("With no chunk the saved parameter array is what the plugin gets", "[engine][external]") {
+    // The baseline is not a formality. A plugin that stores nothing, or whose
+    // chunk this build refuses, has only the array, and skipping it would leave
+    // it on its factory defaults with the project's own values unused.
+    auto plugin = std::make_unique<StubPlugin>(2, 2, 0);
+    auto* raw = plugin.get();
+    REQUIRE(raw->tone->getValue() == Catch::Approx(0.25f));  // the plugin's own default
+
+    const auto result =
+        adapter::adaptExternalPluginInstance(std::move(plugin), externalDeviceSaving(1.0f, 0.7f));
+
+    REQUIRE(result.device != nullptr);
+    CHECK(raw->tone->getValue() == Catch::Approx(0.7f));
+    CHECK(raw->stateRestores == 0);
+}
+
+TEST_CASE("A chunk that is not base64 leaves the baseline standing", "[engine][external]") {
+    auto plugin = std::make_unique<StubPlugin>(2, 2, 0);
+    auto* raw = plugin.get();
+
+    auto model = externalDeviceSaving(1.0f, 0.7f);
+    model.pluginState = "not base64 at all !!";
+
+    const auto result = adapter::adaptExternalPluginInstance(std::move(plugin), model);
+
+    REQUIRE(result.device != nullptr);
+    CHECK(raw->stateRestores == 0);
+    CHECK(raw->tone->getValue() == Catch::Approx(0.7f));
+}
+
+TEST_CASE("A chunk the plugin declines leaves the baseline standing", "[engine][external]") {
+    // Valid base64 of something this build of the plugin cannot read, which is
+    // what a chunk written by another version of it looks like.
+    auto plugin = std::make_unique<StubPlugin>(2, 2, 0);
+    auto* raw = plugin.get();
+
+    auto model = externalDeviceSaving(1.0f, 0.7f);
+    const juce::MemoryBlock nonsense("wrong size entirely", 19);
+    model.pluginState = nonsense.toBase64Encoding();
+
+    const auto result = adapter::adaptExternalPluginInstance(std::move(plugin), model);
+
+    REQUIRE(result.device != nullptr);
+    CHECK(raw->tone->getValue() == Catch::Approx(0.7f));
+}
+
+TEST_CASE("A plugin that throws restoring its state does not take the host with it",
+          "[engine][external]") {
+    // A plugin's state handler is third-party code, and a corrupt chunk is the
+    // input it is least likely to have been tested against.
+    auto plugin = std::make_unique<StubPlugin>(2, 2, 0);
+    auto* raw = plugin.get();
+    raw->throwsOnState = true;
+
+    const StubPlugin::State chunkVoice{.tone = 0.9f, .fixed = 0.8f};
+    juce::MemoryBlock chunk(&chunkVoice, sizeof(chunkVoice));
+
+    auto model = externalDeviceSaving(1.0f, 0.7f);
+    model.pluginState = chunk.toBase64Encoding();
+
+    const auto result = adapter::adaptExternalPluginInstance(std::move(plugin), model);
+
+    REQUIRE(result.device != nullptr);
+    CHECK(raw->tone->getValue() == Catch::Approx(0.7f));
+}
+
+TEST_CASE("Automation moves a parameter the chunk set", "[engine][external]") {
+    // A lane, a macro or a modifier takes the parameter away from whatever the
+    // plugin's state left there, and keeps it: a value the lane passes through
+    // on its way back is still the lane's, not the plugin's.
     auto plugin = std::make_unique<StubPlugin>(2, 2, 0);
     auto* raw = plugin.get();
 

--- a/tests/test_external_plugin_lookup.cpp
+++ b/tests/test_external_plugin_lookup.cpp
@@ -51,7 +51,29 @@ void fill(juce::KnownPluginList& list, const std::vector<juce::PluginDescription
 
 }  // namespace
 
-TEST_CASE("The file and the instrument flag together are the first answer", "[plugins][lookup]") {
+TEST_CASE("JUCE's own identifier is the first answer", "[plugins][lookup]") {
+    // A bundle shipping several effects out of one file, which is what a shell
+    // format is. Every one of them has the same path and the same role, so the
+    // file pass returns whichever the scan listed first; only the identifier
+    // tells them apart, and it is what the project saved.
+    // The decoy is added last, which puts it first: KnownPluginList::addType
+    // inserts at the front. So the file pass below, which cannot tell these two
+    // apart, returns the decoy.
+    juce::KnownPluginList list;
+    const auto wanted = installed("Shell Reverb", "Vendor", "/Library/Shell.vst3", false);
+    const auto decoy = installed("Shell Delay", "Vendor", "/Library/Shell.vst3", false);
+    fill(list, {wanted, decoy});
+
+    auto device = saved("Shell Reverb", "Vendor", "/Library/Shell.vst3", false);
+    device.uniqueId = wanted.createIdentifierString();
+
+    const auto match = magda::matchInstalledPlugin(device, list);
+
+    REQUIRE(match.found);
+    CHECK(match.description.name == "Shell Reverb");
+}
+
+TEST_CASE("The file and the instrument flag together are the second answer", "[plugins][lookup]") {
     // One file, two plugins out of it: the effect and the instrument. This is
     // the case the flag is in the first pass for, and loading the other one is
     // silent rather than an error.
@@ -75,6 +97,22 @@ TEST_CASE("A plugin that moved is found by name and vendor", "[plugins][lookup]"
 
     REQUIRE(match.found);
     CHECK(match.description.fileOrIdentifier == "/new/Pro-Q 3.vst3");
+}
+
+TEST_CASE("A moved plugin is not resolved to the same plugin in another format",
+          "[plugins][lookup]") {
+    // The common macOS case: the same plugin installed twice, as an AU and as a
+    // VST3, with the same name, vendor and role. The saved VST3 has moved, so
+    // the file pass cannot answer, and without the format in the vendor pass
+    // the AU wins by being there. It is not a substitute: its parameter layout
+    // and its state are its own, so the project would load and be wrong.
+    juce::KnownPluginList list;
+    fill(list, {installed("Pro-Q 3", "FabFilter", "/Library/ProQ.component", false, "AudioUnit")});
+
+    const auto match =
+        magda::matchInstalledPlugin(saved("Pro-Q 3", "FabFilter", "/old/ProQ.vst3", false), list);
+
+    CHECK_FALSE(match.found);
 }
 
 TEST_CASE("A plugin renamed in place is found by its file alone", "[plugins][lookup]") {
@@ -114,6 +152,19 @@ TEST_CASE("The format is part of the last pass", "[plugins][lookup]") {
     fill(list, {installed("Serum", "Xfer Records", "/Library/Serum.component", true, "AudioUnit")});
 
     const auto match = magda::matchInstalledPlugin(saved("Serum", "", "", true), list);
+
+    CHECK_FALSE(match.found);
+}
+
+TEST_CASE("A saved device with no name matches nothing by name", "[plugins][lookup]") {
+    // The other half of the same rule as the file guard below. A device with
+    // neither a name nor a file reaches the app's lookup now that the call
+    // sites no longer refuse to search, and it must not resolve to whichever
+    // scanned plugin happens to have an empty name.
+    juce::KnownPluginList list;
+    fill(list, {installed("", "", "/Library/Nameless.vst3", false)});
+
+    const auto match = magda::matchInstalledPlugin(saved("", "", "", false), list);
 
     CHECK_FALSE(match.found);
 }

--- a/tests/test_external_plugin_lookup.cpp
+++ b/tests/test_external_plugin_lookup.cpp
@@ -1,0 +1,158 @@
+#include <juce_audio_processors/juce_audio_processors.h>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "magda/daw/audio/plugin_manager/ExternalPluginLookup.hpp"
+
+/**
+ * @file test_external_plugin_lookup.cpp
+ * @brief Which installed plugin a saved device meant (#2243).
+ *
+ * The four passes, each shown resolving the case it was added for and shown not
+ * resolving the case the pass before it owns. The order is the whole content of
+ * this function: every pass matches things the next one also matches, so a test
+ * that only checked "it finds something" would pass with them in any order and
+ * would let the wrong plugin load.
+ */
+
+namespace {
+
+juce::PluginDescription installed(const juce::String& name, const juce::String& vendor,
+                                  const juce::String& file, bool isInstrument,
+                                  const juce::String& format = "VST3") {
+    juce::PluginDescription description;
+    description.name = name;
+    description.manufacturerName = vendor;
+    description.fileOrIdentifier = file;
+    description.isInstrument = isInstrument;
+    description.pluginFormatName = format;
+    description.uniqueId = name.hashCode() + (isInstrument ? 1 : 0);
+    return description;
+}
+
+magda::DeviceInfo saved(const juce::String& name, const juce::String& vendor,
+                        const juce::String& file, bool isInstrument,
+                        magda::PluginFormat format = magda::PluginFormat::VST3) {
+    magda::DeviceInfo device;
+    device.name = name;
+    device.manufacturer = vendor;
+    device.fileOrIdentifier = file;
+    device.isInstrument = isInstrument;
+    device.format = format;
+    return device;
+}
+
+/// juce::KnownPluginList cannot be copied or moved, so it is filled in place
+/// rather than returned.
+void fill(juce::KnownPluginList& list, const std::vector<juce::PluginDescription>& descriptions) {
+    for (const auto& description : descriptions)
+        list.addType(description);
+}
+
+}  // namespace
+
+TEST_CASE("The file and the instrument flag together are the first answer", "[plugins][lookup]") {
+    // One file, two plugins out of it: the effect and the instrument. This is
+    // the case the flag is in the first pass for, and loading the other one is
+    // silent rather than an error.
+    juce::KnownPluginList list;
+    fill(list, {installed("Kontakt", "NI", "/Library/Kontakt.vst3", false),
+                installed("Kontakt", "NI", "/Library/Kontakt.vst3", true)});
+
+    const auto match =
+        magda::matchInstalledPlugin(saved("Kontakt", "NI", "/Library/Kontakt.vst3", true), list);
+
+    REQUIRE(match.found);
+    CHECK(match.description.isInstrument);
+}
+
+TEST_CASE("A plugin that moved is found by name and vendor", "[plugins][lookup]") {
+    juce::KnownPluginList list;
+    fill(list, {installed("Pro-Q 3", "FabFilter", "/new/Pro-Q 3.vst3", false)});
+
+    const auto match = magda::matchInstalledPlugin(
+        saved("Pro-Q 3", "FabFilter", "/old/Pro-Q 3.vst3", false), list);
+
+    REQUIRE(match.found);
+    CHECK(match.description.fileOrIdentifier == "/new/Pro-Q 3.vst3");
+}
+
+TEST_CASE("A plugin renamed in place is found by its file alone", "[plugins][lookup]") {
+    // The pass the rack path did not have before this was one function: a
+    // plugin that was renamed by its vendor resolved on a track and not inside
+    // a rack, in the same project, on the same machine.
+    juce::KnownPluginList list;
+    fill(list, {installed("Pro-Q 4", "FabFilter", "/Library/ProQ.vst3", false)});
+
+    const auto match = magda::matchInstalledPlugin(
+        saved("Pro-Q 3", "FabFilter", "/Library/ProQ.vst3", false), list);
+
+    REQUIRE(match.found);
+    CHECK(match.description.name == "Pro-Q 4");
+}
+
+TEST_CASE("A project from another host resolves by name and format", "[plugins][lookup]") {
+    // A DAWproject carries the name and the class id and neither our file path
+    // nor a reliable role: Bitwig exports Serum, an instrument, as an audio
+    // effect. So this pass can require neither the vendor nor the flag.
+    juce::KnownPluginList list;
+    fill(list, {installed("Serum", "Xfer Records", "/Library/Serum.vst3", true)});
+
+    auto imported = saved("Serum", "", "", false);
+    const auto match = magda::matchInstalledPlugin(imported, list);
+
+    REQUIRE(match.found);
+    CHECK(match.description.isInstrument);
+    CHECK(match.description.manufacturerName == "Xfer Records");
+}
+
+TEST_CASE("The format is part of the last pass", "[plugins][lookup]") {
+    // Same name, different format. An AU is not a substitute for the VST3 a
+    // project saved: the two have different parameter lists and different
+    // state, so the project would load and be wrong.
+    juce::KnownPluginList list;
+    fill(list, {installed("Serum", "Xfer Records", "/Library/Serum.component", true, "AudioUnit")});
+
+    const auto match = magda::matchInstalledPlugin(saved("Serum", "", "", true), list);
+
+    CHECK_FALSE(match.found);
+}
+
+TEST_CASE("A saved device with no file does not match a description with none",
+          "[plugins][lookup]") {
+    // Both file passes ask nothing here. An empty path equalling an empty path
+    // is a match on the absence of evidence, and it would resolve every device
+    // that saved no file to whichever scanned plugin happens to have none.
+    juce::KnownPluginList list;
+    fill(list, {installed("Something Else", "Vendor", "", false)});
+
+    const auto match = magda::matchInstalledPlugin(saved("Pro-Q 3", "FabFilter", "", false), list);
+
+    CHECK_FALSE(match.found);
+}
+
+TEST_CASE("An unfound plugin comes back as what the project saved", "[plugins][lookup]") {
+    juce::KnownPluginList list;
+    fill(list, {installed("Pro-Q 3", "FabFilter", "/Library/ProQ.vst3", false)});
+
+    const auto match =
+        magda::matchInstalledPlugin(saved("Massive X", "NI", "/Library/MassiveX.vst3", true), list);
+
+    REQUIRE_FALSE(match.found);
+
+    // Not empty: the saved fields, as a description. A session is free to try
+    // to load it and let the format's own lookup have a go, which is what the
+    // app does and what lets a plugin resolve when the scan is out of date.
+    CHECK(match.description.name == "Massive X");
+    CHECK(match.description.fileOrIdentifier == "/Library/MassiveX.vst3");
+    CHECK(match.description.pluginFormatName == "VST3");
+}
+
+TEST_CASE("An empty list finds nothing and says so", "[plugins][lookup]") {
+    const juce::KnownPluginList empty;
+
+    const auto match = magda::matchInstalledPlugin(
+        saved("Pro-Q 3", "FabFilter", "/Library/ProQ.vst3", false), empty);
+
+    CHECK_FALSE(match.found);
+}


### PR DESCRIPTION
Closes #2241. Closes #2243.

The first two slices of external plugin hosting (#1893): a plugin runs under a Device op, and the
engine can find and load one.

## The adapter (#2241)

`EngineExternalDevice` is the third device adapter and the one with no MAGDA device behind it.
EngineMagdaDevice hosts something this repository wrote and can ask anything of; this hosts a binary
somebody else shipped whose only contract is `juce::AudioPluginInstance`. So it is a transcription
of `te::ExternalPlugin` rather than a design, and each piece is written out beside the fork's own
reason for it, because a difference here is a difference in every project that hosts a plugin:

- **Channel adaptation** at `max(max(1, inputs), outputs)`, whatever the chain around it is, with
  the fork's bridging rules on either side: a mono block into a stereo input duplicates, a stereo
  block into a mono input averages at half gain, a mono output is spread back over a stereo slot so
  the next device has two channels to read.
- **The wet/dry pair** the fork gives every external plugin and the plugin never declared. MAGDA
  persists both (`DeviceInfo::wrapperParameters`), so a project can carry a plugin at 40% wet and
  the two engines have to agree what that means. Fully dry still runs the plugin, which is what
  makes a wet-level automation lane usable at all.
- **Parameter identity.** The fork's automatable list is dry, wet, then the plugin's automatable
  parameters in plugin order, and those positions are what a project saved as
  `ParameterInfo::paramIndex`. The mapping is rebuilt from the live instance rather than from the
  model, because that is where the fork's comes from: a project saved against another build of the
  plugin would otherwise write its values onto whatever the parameters are called now. A parameter
  is written only when the value differs from what the plugin reports, which is also the fork's
  rule -- a plugin is entitled to treat every write as a gesture.
- **Latency** read once after prepareToPlay and reported into the executor's PDC.
- **A playhead**, because a tempo-synced delay that is told nothing renders a different project.
  Position, bar start, signature and bpm come off the block's own tempo map.
- **Sidechain audio** as the channels after the plugin's own bus, and `setNonRealtime` for a bounce,
  which the fork sets and clears around a render.

Three differences are named in the header rather than left to be found: the all-notes-off flag
`juce::MidiBuffer` has nowhere to carry (the gap EngineMagdaDevice already declares), the transport
state a device under the plan is not handed (#1894, #1895), and denormal handling (#2240, below).

## Instantiation, and one answer to which plugin a project meant (#2243)

The search for the installed plugin a saved device names was written twice in `PluginManagerSync`,
and the two copies had drifted. The track path tried the file path on its own after the vendor pass;
the rack path did not. **A plugin renamed in place by its vendor therefore resolved on a track and
not inside a rack, in the same project, on the same machine.** They are one function now
(`ExternalPluginLookup.hpp`) with the four passes in one place and their order tested, because the
order is the whole content of the search: every pass matches things the later ones also match, so a
test that only asked whether something was found would pass with them in any order and let the wrong
plugin load.

The lifted version also declines to match on an empty file path, which both copies would have done
had their callers not guarded the whole search. An empty path equalling an empty path is a match on
the absence of evidence; the guard belongs to the two passes that need it rather than to the call
site, so the other two still answer for a device that saved no file. A dead debug loop that walked
every scanned plugin on every load, with an empty body, goes with them.

Loading is the engine's half: a blocking create for a render that is waiting for the answer, an
async one for a session that is not, `enableAllBuses` at the point the fork does it, and a failure
that comes back as a sentence rather than a null. **Refusing a plugin the scan does not know is
deliberate and differs from the app**, which tries the saved description anyway and lets the format's
own lookup have a go. That is right where a user is watching and can be told, and wrong for a
render: a plugin resolved by a route nothing recorded is a difference no corpus can attribute
afterwards.

## The finding worth its own issue

**The native engine has no denormal handling anywhere** (#2240). No `ScopedNoDenormals` around a
render, and nothing sanitising what an op wrote, where the fork has both halves: flush-to-zero
around the callback, and every plugin's output passed through `zeroDenormalisedValuesIfNeeded`. It
is `#if JUCE_INTEL` in the fork, so there is nothing to diverge from on Apple silicon today, and it
is an executor-wide decision rather than this adapter's -- the second half in particular (clamping a
plugin's output to a magnitude of 100) is a policy worth deciding rather than transcribing.

## Testing

Against a plugin written in the test rather than one that happens to be installed. What is asserted
is what the host does with a plugin -- which channels it hands it, which slot a saved value lands
on, what the wrapper pair means -- and a stub that reports exactly what it was given answers those
better than a real plugin does. The stub is deliberately awkward in the ways real plugins are: a
non-automatable parameter in the middle of its list, mono and stereo buses, a sidechain, latency it
reports. A real plugin under both engines is the corpus's job (#2175).

The lookup's tests show each pass resolving the case it was added for and not resolving the case the
pass before it owns.

## Verification

`magda_tests` 3114 passed, 13 skipped. `magda_juce_tests` all passed. `make debug` clean.

https://claude.ai/code/session_01Qa7GxDU184RGxo2b1Yhpa6
