### PR TITLE
MPE pitch glide: bend a segment between two points (#2198)

### DIFF
--- a/magda/daw/audio/session/ClipSynchronizer.cpp
+++ b/magda/daw/audio/session/ClipSynchronizer.cpp
@@ -8,6 +8,7 @@
 
 #include "../../core/ClipManager.hpp"
 #include "../../core/ClipOperations.hpp"
+#include "../../core/PitchExpressionCurve.hpp"
 #include "../../core/TempoUtils.hpp"
 #include "../../core/TrackManager.hpp"
 #include "ArrangementClipSyncPlanner.hpp"
@@ -1553,26 +1554,10 @@ static void addPitchExpressionToTeNote(te::MidiNote& teNote, const MidiNote& not
     std::sort(sorted.begin(), sorted.end(),
               [](const auto& a, const auto& b) { return a.beat < b.beat; });
 
-    // Evaluate the curve at a beat position (relative to original note start):
-    // hold first value before the first point, linear between points, hold last.
-    auto valueAt = [&sorted](double beat) {
-        if (beat <= sorted.front().beat)
-            return sorted.front().semitones;
-        if (beat >= sorted.back().beat)
-            return sorted.back().semitones;
-        for (size_t i = 0; i + 1 < sorted.size(); ++i) {
-            const auto& a = sorted[i];
-            const auto& b = sorted[i + 1];
-            if (beat >= a.beat && beat <= b.beat) {
-                const double span = b.beat - a.beat;
-                if (span <= 0.0)
-                    return b.semitones;
-                const double t = (beat - a.beat) / span;
-                return a.semitones + t * (b.semitones - a.semitones);
-            }
-        }
-        return sorted.back().semitones;
-    };
+    // Evaluate the curve at a beat position, relative to the original note
+    // start. Shape from core (#2198), so this leg and the native one hand the
+    // same glide to their respective engines.
+    auto valueAt = [&sorted](double beat) { return evaluatePitchExpressionCurve(sorted, beat); };
 
     auto addExpressionEvent = [&teNote](double relBeat, double semitones) {
         auto value = juce::jlimit(-kMaxSemitones, kMaxSemitones, static_cast<float>(semitones));

--- a/magda/daw/core/ClipInfo.hpp
+++ b/magda/daw/core/ClipInfo.hpp
@@ -52,6 +52,14 @@ struct MidiPitchExpressionPoint {
     double beat = 0.0;       // Position relative to note start (0..note length)
     double semitones = 0.0;  // Pitch offset in semitones (-48..+48)
 
+    // Shape of the segment running from this point to the next one, in the same
+    // -3..+3 scale every other curve in the app uses (CurvePoint::tension,
+    // MidiCCData::tension). Zero is the straight line this used to always be,
+    // so a glide authored before #2198 reads back unchanged. Owned by the left
+    // point, as segments are everywhere else here; the last point's value is
+    // carried but never shapes anything.
+    double tension = 0.0;
+
     bool operator==(const MidiPitchExpressionPoint&) const = default;
 };
 

--- a/magda/daw/core/PitchExpressionCurve.hpp
+++ b/magda/daw/core/PitchExpressionCurve.hpp
@@ -67,6 +67,30 @@ inline double evaluatePitchExpressionCurve(const std::vector<MidiPitchExpression
     return points.back().semitones;
 }
 
+/**
+ * @brief Whether the segment starting at @p index can take a bend at all.
+ *
+ * A segment between two points at the same pitch cannot: the shape is a warp of
+ * the travel between the endpoints and there is none, so `evalSegment` returns
+ * the flat value whatever tension it is handed. Same property the automation
+ * lanes and the LFO editor have.
+ *
+ * Asked by the hit test as well as by the drag, from here rather than twice,
+ * because the two have to draw the line in the same place and with the same
+ * epsilon. When they did not, a flat segment advertised the bend cursor,
+ * accepted the gesture, did nothing with it, and still committed an undo entry
+ * on release (#2198 review).
+ */
+inline bool pitchExpressionSegmentCanBend(const std::vector<MidiPitchExpressionPoint>& points,
+                                          std::size_t index) {
+    if (index + 1 >= points.size())
+        return false;
+
+    const auto& left = points[index];
+    const auto& right = points[index + 1];
+    return (right.beat - left.beat) > 0.0 && std::abs(right.semitones - left.semitones) >= 1.0e-6;
+}
+
 /// The range a tension may take, matching every other curve in the app.
 inline constexpr double kMaxPitchExpressionTension = 3.0;
 

--- a/magda/daw/core/PitchExpressionCurve.hpp
+++ b/magda/daw/core/PitchExpressionCurve.hpp
@@ -1,0 +1,111 @@
+#pragma once
+
+#include <algorithm>
+#include <cmath>
+#include <vector>
+
+#include "ClipInfo.hpp"
+#include "CurveMath.hpp"
+
+/**
+ * @file PitchExpressionCurve.hpp
+ * @brief What a note's MPE pitch glide reads at a given beat (#2198).
+ *
+ * Three places used to answer this, each with its own copy of the same linear
+ * interpolation: the piano roll drew one curve, MidiClipCompiler compiled a
+ * second, and ClipSynchronizer handed a third to Tracktion. They agreed only
+ * because none of them had a shape to disagree about. Giving the segments a
+ * tension ends that, so the answer lives here and all three ask it.
+ *
+ * The shape itself is `curvemath::evalSegment`, which is what automation lanes,
+ * the LFO editor and the CC lane already bend by. A glide is not a different
+ * kind of curve from those and should not be a different kind of maths.
+ *
+ * Pure: no allocation beyond the caller's, no locks, safe on the audio thread.
+ */
+
+namespace magda {
+
+/**
+ * @brief Value of @p points at @p relBeat, in semitones.
+ *
+ * @p points must be sorted by beat. Outside the authored range the curve holds
+ * its end values rather than extrapolating: a glide is a shape drawn on a note,
+ * and a note that begins before its first point sounds at that point's pitch.
+ */
+inline double evaluatePitchExpressionCurve(const std::vector<MidiPitchExpressionPoint>& points,
+                                           double relBeat) {
+    if (points.empty())
+        return 0.0;
+    if (relBeat <= points.front().beat)
+        return points.front().semitones;
+    if (relBeat >= points.back().beat)
+        return points.back().semitones;
+
+    for (std::size_t i = 0; i + 1 < points.size(); ++i) {
+        const auto& a = points[i];
+        const auto& b = points[i + 1];
+        if (relBeat < a.beat || relBeat > b.beat)
+            continue;
+
+        const double span = b.beat - a.beat;
+        if (span <= 0.0)
+            return b.semitones;
+
+        const double t = (relBeat - a.beat) / span;
+        if (std::abs(a.tension) < 0.001)
+            return a.semitones + t * (b.semitones - a.semitones);
+
+        // No stored shaper: a glide bends by the tension scalar alone, the way
+        // the tempo lane does. Handles would be a second way to say the same
+        // thing and a second thing to serialise.
+        return static_cast<double>(curvemath::evalSegment(
+            static_cast<float>(a.semitones), static_cast<float>(b.semitones), 0.0f,
+            static_cast<float>(a.tension), false, static_cast<float>(t)));
+    }
+
+    return points.back().semitones;
+}
+
+/// The range a tension may take, matching every other curve in the app.
+inline constexpr double kMaxPitchExpressionTension = 3.0;
+
+/**
+ * @brief The tension whose curve passes through @p valueRatio at @p t.
+ *
+ * The inverse of what `evalSegment` does, so a drag can say "bend until the
+ * curve is under my cursor" rather than nudging an opaque number until it looks
+ * right. @p t is where along the segment the cursor is (0 at the left point, 1
+ * at the right), @p valueRatio where its value sits between the two endpoints
+ * (0 at the left value, 1 at the right).
+ *
+ * Both are pulled away from the ends before inverting: at t=0 and t=1 every
+ * curve passes through the same place, so the question has no answer there and
+ * the logs would run away trying to find one.
+ */
+inline double pitchExpressionTensionThrough(double t, double valueRatio) {
+    constexpr double kEps = 1.0e-4;
+    const double tt = std::clamp(t, 0.05, 0.95);
+    const double w = std::clamp(valueRatio, kEps, 1.0 - kEps);
+
+    // r is the curve's value ratio at the segment's midpoint, which is the one
+    // number evalSegment's warp is really parameterised by.
+    double r = 0.0;
+    if (w <= tt) {
+        // Below the straight line: warp(t) = t^k, k = log(r)/log(0.5).
+        const double k = std::log(w) / std::log(tt);
+        r = std::pow(0.5, k);
+    } else {
+        // Above it, and the mirror image of the same power.
+        const double m = std::log(1.0 - w) / std::log(1.0 - tt);
+        r = 1.0 - std::pow(0.5, m);
+    }
+    r = std::clamp(r, kEps, 1.0 - kEps);
+
+    const double tension = (r <= 0.5) ? (std::log(r) / std::log(0.5) - 1.0) * 0.5
+                                      : (1.0 - std::log(1.0 - r) / std::log(0.5)) * 0.5;
+
+    return std::clamp(tension, -kMaxPitchExpressionTension, kMaxPitchExpressionTension);
+}
+
+}  // namespace magda

--- a/magda/daw/project/serialization/ClipSerializer.cpp
+++ b/magda/daw/project/serialization/ClipSerializer.cpp
@@ -915,6 +915,10 @@ juce::var ProjectSerializer::serializeMidiNote(const MidiNote& data) {
             auto* pObj = new juce::DynamicObject();
             pObj->setProperty("beat", p.beat);
             pObj->setProperty("semitones", p.semitones);
+            // Only when bent (#2198), so a project full of straight glides is
+            // written exactly as it was before the field existed.
+            if (p.tension != 0.0)
+                pObj->setProperty("tension", p.tension);
             points.add(juce::var(pObj));
         }
         obj->setProperty("pitchExpression", juce::var(points));
@@ -941,6 +945,10 @@ bool ProjectSerializer::deserializeMidiNote(const juce::var& json, MidiNote& dat
                 MidiPitchExpressionPoint p;
                 p.beat = pObj->getProperty("beat");
                 p.semitones = pObj->getProperty("semitones");
+                // Absent in projects written before #2198, and absent again in
+                // any straight segment since: the default is the straight line.
+                if (pObj->hasProperty("tension"))
+                    p.tension = pObj->getProperty("tension");
                 data.pitchExpression.push_back(p);
             }
         }

--- a/magda/daw/ui/components/pianoroll/PianoRollGridComponent.cpp
+++ b/magda/daw/ui/components/pianoroll/PianoRollGridComponent.cpp
@@ -902,6 +902,7 @@ void PianoRollGridComponent::mouseMove(const juce::MouseEvent& e) {
             hoveredExpressionPoint_ = hit;
             repaint();
         }
+        updateExpressionCursor(e.mods, e.getEventRelativeTo(this).getPosition());
     } else if (hoveredExpressionPoint_) {
         hoveredExpressionPoint_.reset();
         repaint();
@@ -2034,7 +2035,25 @@ double PianoRollGridComponent::absolutePlayheadBeatForDisplayX(int mouseX) const
     return juce::jlimit(0.0, timelineLengthBeats_, beat);
 }
 
+void PianoRollGridComponent::updateExpressionCursor(const juce::ModifierKeys& mods,
+                                                    juce::Point<int> pos) {
+    // Only while the modifier is actually held: the cursor is how the gesture
+    // announces itself, and showing it unprompted over every glide would make
+    // Alt look like it was already down.
+    if (isBendExpressionGesture(mods) && hitTestExpressionSegment(pos).has_value())
+        setMouseCursor(CursorManager::getInstance().getCurveBendCursor());
+    else
+        setMouseCursor(juce::MouseCursor::NormalCursor);
+}
+
 void PianoRollGridComponent::updateEmptyGridCursor(const juce::ModifierKeys& mods, int /*mouseX*/) {
+    // Alt means bend while glides are being edited, not draw, and a pencil
+    // pointing at a curve the click will reshape is the wrong promise.
+    if (pitchExpressionMode_) {
+        updateExpressionCursor(mods, getMouseXYRelative());
+        return;
+    }
+
     if (mods.isAltDown()) {
         setMouseCursor(CursorManager::getInstance().getNoteDrawCursor());
     } else {
@@ -2043,8 +2062,8 @@ void PianoRollGridComponent::updateEmptyGridCursor(const juce::ModifierKeys& mod
 }
 
 void PianoRollGridComponent::modifierKeysChanged(const juce::ModifierKeys& modifiers) {
-    // Pressing/releasing Alt while hovering must swap the pencil cursor
-    // without waiting for a mouse move.
+    // Pressing/releasing Alt while hovering must swap the cursor -- pencil
+    // normally, bend while editing glides -- without waiting for a mouse move.
     if (isMouseOver() && !juce::Component::isMouseButtonDownAnywhere())
         updateEmptyGridCursor(modifiers, getMouseXYRelative().x);
 }

--- a/magda/daw/ui/components/pianoroll/PianoRollGridComponent.cpp
+++ b/magda/daw/ui/components/pianoroll/PianoRollGridComponent.cpp
@@ -3003,6 +3003,12 @@ PianoRollGridComponent::hitTestExpressionSegment(juce::Point<int> pos) const {
             const double centerY = noteNumberToY(note.noteNumber) + noteHeight_ * 0.5;
 
             for (size_t p = 0; p + 1 < points.size(); ++p) {
+                // Segments that cannot be bent are not offered: the cursor is a
+                // promise, and a drag that starts here would end in a commit
+                // that changed nothing.
+                if (!pitchExpressionSegmentCanBend(points, p))
+                    continue;
+
                 const int segStartX = beatToPixel(noteStartDisplayBeat + points[p].beat);
                 const int segEndX = beatToPixel(noteStartDisplayBeat + points[p + 1].beat);
                 if (pos.x < segStartX || pos.x > segEndX || segEndX <= segStartX)
@@ -3227,7 +3233,10 @@ void PianoRollGridComponent::handleExpressionMouseDrag(const juce::MouseEvent& e
 void PianoRollGridComponent::bendExpressionSegment(const MidiNote& note,
                                                    const juce::MouseEvent& e) {
     const auto index = static_cast<size_t>(expressionTensionSegmentIndex_);
-    if (index + 1 >= expressionWorkingPoints_.size())
+
+    // The same question the hit test asked before offering the gesture, asked
+    // again because the points can move under a live drag.
+    if (!pitchExpressionSegmentCanBend(expressionWorkingPoints_, index))
         return;
 
     auto& left = expressionWorkingPoints_[index];
@@ -3235,13 +3244,6 @@ void PianoRollGridComponent::bendExpressionSegment(const MidiNote& note,
 
     const double span = right.beat - left.beat;
     const double rise = right.semitones - left.semitones;
-
-    // A segment between two points at the same pitch has no curve to bend: the
-    // shape is a warp of the travel between the endpoints, and there is none.
-    // Same property the automation lanes and the LFO editor have, and leaving
-    // it alone is better than giving glides a second kind of maths.
-    if (span <= 0.0 || std::abs(rise) < 1.0e-6)
-        return;
 
     const double noteStartDisplayBeat = displayBeatForClipBeat(expressionClipId_, note.startBeat);
     const double relBeat = pixelToBeat(e.x) - noteStartDisplayBeat;

--- a/magda/daw/ui/components/pianoroll/PianoRollGridComponent.cpp
+++ b/magda/daw/ui/components/pianoroll/PianoRollGridComponent.cpp
@@ -20,6 +20,7 @@
 #include "core/GestureRouter.hpp"
 #include "core/MidiChordMarkers.hpp"
 #include "core/MidiNoteCommands.hpp"
+#include "core/PitchExpressionCurve.hpp"
 #include "core/SelectionManager.hpp"
 #include "core/TrackManager.hpp"
 #include "core/UndoManager.hpp"
@@ -2908,25 +2909,10 @@ void PianoRollGridComponent::setPitchExpressionMode(bool enabled) {
 
 double PianoRollGridComponent::evaluatePitchExpression(
     const std::vector<MidiPitchExpressionPoint>& points, double relBeat) {
-    if (points.empty())
-        return 0.0;
-    if (relBeat <= points.front().beat)
-        return points.front().semitones;
-    if (relBeat >= points.back().beat)
-        return points.back().semitones;
-
-    for (size_t i = 0; i + 1 < points.size(); ++i) {
-        const auto& a = points[i];
-        const auto& b = points[i + 1];
-        if (relBeat >= a.beat && relBeat <= b.beat) {
-            const double span = b.beat - a.beat;
-            if (span <= 0.0)
-                return b.semitones;
-            const double t = (relBeat - a.beat) / span;
-            return a.semitones + t * (b.semitones - a.semitones);
-        }
-    }
-    return points.back().semitones;
+    // The shape lives in core (#2198) because the compiler and the Tracktion
+    // bridge have to draw the same one, and a curve the editor renders
+    // differently from what plays is not an editor.
+    return evaluatePitchExpressionCurve(points, relBeat);
 }
 
 double PianoRollGridComponent::expressionRelBeatForX(ClipId clipId, const MidiNote& note,
@@ -2970,6 +2956,55 @@ std::optional<PianoRollGridComponent::ExpressionHit> PianoRollGridComponent::hit
         }
     }
     return std::nullopt;
+}
+
+std::optional<PianoRollGridComponent::ExpressionHit>
+PianoRollGridComponent::hitTestExpressionSegment(juce::Point<int> pos) const {
+    auto& clipManager = ClipManager::getInstance();
+
+    std::optional<ExpressionHit> best;
+    double bestDistance = std::numeric_limits<double>::max();
+
+    for (ClipId clipId : selectedClipIds_) {
+        const auto* clip = clipManager.getClip(clipId);
+        if (!clip || !clip->isMidi() || !isClipSelected(clipId))
+            continue;
+
+        for (size_t i = 0; i < clip->midiNotes.size(); ++i) {
+            const auto& note = clip->midiNotes[i];
+            const auto& points = note.pitchExpression;
+            if (points.size() < 2)
+                continue;
+
+            auto visibleNote = clip->midiNotes[i];
+            if (!ClipOperations::clipMidiNoteToVisibleRange(*clip, visibleNote))
+                continue;
+
+            const double noteStartDisplayBeat = displayBeatForClipBeat(clipId, note.startBeat);
+            const double centerY = noteNumberToY(note.noteNumber) + noteHeight_ * 0.5;
+
+            for (size_t p = 0; p + 1 < points.size(); ++p) {
+                const int segStartX = beatToPixel(noteStartDisplayBeat + points[p].beat);
+                const int segEndX = beatToPixel(noteStartDisplayBeat + points[p + 1].beat);
+                if (pos.x < segStartX || pos.x > segEndX || segEndX <= segStartX)
+                    continue;
+
+                // Distance to the curve as it is drawn, not to the straight
+                // line between the endpoints: a segment already bent has to be
+                // grabbable where it actually is.
+                const double relBeat = expressionRelBeatForX(clipId, note, pos.x);
+                const double curveY =
+                    centerY - evaluatePitchExpression(points, relBeat) * noteHeight_;
+                const double distance = std::abs(pos.y - curveY);
+
+                if (distance <= noteHeight_ && distance < bestDistance) {
+                    bestDistance = distance;
+                    best = ExpressionHit{clipId, i, static_cast<int>(p)};
+                }
+            }
+        }
+    }
+    return best;
 }
 
 std::optional<PianoRollGridComponent::ExpressionHit> PianoRollGridComponent::hitTestExpressionNote(
@@ -3051,6 +3086,32 @@ bool PianoRollGridComponent::handleExpressionMouseDown(const juce::MouseEvent& e
         }
     }
 
+    // Bend the segment under the cursor (#2198). Ahead of the point grab
+    // because the gesture is deliberately usable near a point, and behind the
+    // frozen guard because bending is an edit like any other.
+    //
+    // Alt is the modifier Bitwig uses for this and the one free here: Shift
+    // already means "do not snap to semitones" on both of the other gestures.
+    if (isBendExpressionGesture(e.mods)) {
+        if (auto hit = hitTestExpressionSegment(e.getPosition())) {
+            const auto* clip = clipManager.getClip(hit->clipId);
+            if (!clip || hit->noteIndex >= clip->midiNotes.size())
+                return true;
+
+            expressionClipId_ = hit->clipId;
+            expressionNoteIndex_ = hit->noteIndex;
+            expressionWorkingPoints_ = clip->midiNotes[hit->noteIndex].pitchExpression;
+            expressionTensionSegmentIndex_ = hit->pointIndex;
+            expressionDragPointIndex_ = -1;
+            isExpressionDragging_ = true;
+            repaint();
+            return true;
+        }
+        // Alt with no segment under the cursor does nothing rather than falling
+        // through to adding a point: the user asked to bend something.
+        return true;
+    }
+
     // Grab an existing point
     if (auto hit = hitTestExpressionPoint(e.getPosition())) {
         const auto* clip = clipManager.getClip(hit->clipId);
@@ -3102,8 +3163,7 @@ bool PianoRollGridComponent::handleExpressionMouseDown(const juce::MouseEvent& e
 }
 
 void PianoRollGridComponent::handleExpressionMouseDrag(const juce::MouseEvent& e) {
-    if (!isExpressionDragging_ || expressionDragPointIndex_ < 0 ||
-        expressionDragPointIndex_ >= static_cast<int>(expressionWorkingPoints_.size()))
+    if (!isExpressionDragging_)
         return;
 
     const auto* clip = ClipManager::getInstance().getClip(expressionClipId_);
@@ -3111,6 +3171,16 @@ void PianoRollGridComponent::handleExpressionMouseDrag(const juce::MouseEvent& e
         return;
 
     const auto& note = clip->midiNotes[expressionNoteIndex_];
+
+    if (expressionTensionSegmentIndex_ >= 0) {
+        bendExpressionSegment(note, e);
+        return;
+    }
+
+    if (expressionDragPointIndex_ < 0 ||
+        expressionDragPointIndex_ >= static_cast<int>(expressionWorkingPoints_.size()))
+        return;
+
     auto& point = expressionWorkingPoints_[static_cast<size_t>(expressionDragPointIndex_)];
 
     // Horizontal: clamp between neighbouring points so ordering is stable
@@ -3135,6 +3205,36 @@ void PianoRollGridComponent::handleExpressionMouseDrag(const juce::MouseEvent& e
     repaint();
 }
 
+void PianoRollGridComponent::bendExpressionSegment(const MidiNote& note,
+                                                   const juce::MouseEvent& e) {
+    const auto index = static_cast<size_t>(expressionTensionSegmentIndex_);
+    if (index + 1 >= expressionWorkingPoints_.size())
+        return;
+
+    auto& left = expressionWorkingPoints_[index];
+    const auto& right = expressionWorkingPoints_[index + 1];
+
+    const double span = right.beat - left.beat;
+    const double rise = right.semitones - left.semitones;
+
+    // A segment between two points at the same pitch has no curve to bend: the
+    // shape is a warp of the travel between the endpoints, and there is none.
+    // Same property the automation lanes and the LFO editor have, and leaving
+    // it alone is better than giving glides a second kind of maths.
+    if (span <= 0.0 || std::abs(rise) < 1.0e-6)
+        return;
+
+    const double noteStartDisplayBeat = displayBeatForClipBeat(expressionClipId_, note.startBeat);
+    const double relBeat = pixelToBeat(e.x) - noteStartDisplayBeat;
+    const double t = juce::jlimit(0.0, 1.0, (relBeat - left.beat) / span);
+
+    const double centerY = noteNumberToY(note.noteNumber) + noteHeight_ * 0.5;
+    const double semitones = (centerY - e.y) / noteHeight_;
+
+    left.tension = pitchExpressionTensionThrough(t, (semitones - left.semitones) / rise);
+    repaint();
+}
+
 void PianoRollGridComponent::handleExpressionMouseUp(const juce::MouseEvent& /*e*/) {
     if (!isExpressionDragging_)
         return;
@@ -3143,6 +3243,7 @@ void PianoRollGridComponent::handleExpressionMouseUp(const juce::MouseEvent& /*e
 
     isExpressionDragging_ = false;
     expressionDragPointIndex_ = -1;
+    expressionTensionSegmentIndex_ = -1;
     expressionClipId_ = INVALID_CLIP_ID;
     expressionWorkingPoints_.clear();
     repaint();
@@ -3251,9 +3352,32 @@ void PianoRollGridComponent::paintPitchExpression(juce::Graphics& g) {
 
             juce::Path path;
             path.startNewSubPath(startX, yForSemitones(evaluatePitchExpression(points, 0.0)));
-            for (const auto& p : points) {
-                const float px = static_cast<float>(beatToPixel(noteStartDisplayBeat + p.beat));
-                path.lineTo(juce::jlimit(startX, endX, px), yForSemitones(p.semitones));
+            for (size_t p = 0; p < points.size(); ++p) {
+                const float px =
+                    static_cast<float>(beatToPixel(noteStartDisplayBeat + points[p].beat));
+                const float clampedX = juce::jlimit(startX, endX, px);
+
+                // A bent segment is sampled rather than drawn as one line
+                // (#2198). Sample count follows the segment's width on screen so
+                // a steep bend stays smooth when zoomed in and costs nothing
+                // when the note is a few pixels wide.
+                const bool bent = p > 0 && std::abs(points[p - 1].tension) >= 0.001;
+                if (bent) {
+                    const float prevX = juce::jlimit(
+                        startX, endX,
+                        static_cast<float>(beatToPixel(noteStartDisplayBeat + points[p - 1].beat)));
+                    const int samples =
+                        juce::jlimit(8, 96, static_cast<int>(std::abs(clampedX - prevX) * 0.5f));
+                    for (int sIdx = 1; sIdx < samples; ++sIdx) {
+                        const double u = static_cast<double>(sIdx) / samples;
+                        const double beat =
+                            points[p - 1].beat + (points[p].beat - points[p - 1].beat) * u;
+                        path.lineTo(prevX + (clampedX - prevX) * static_cast<float>(u),
+                                    yForSemitones(evaluatePitchExpression(points, beat)));
+                    }
+                }
+
+                path.lineTo(clampedX, yForSemitones(points[p].semitones));
             }
             path.lineTo(endX, yForSemitones(evaluatePitchExpression(points, note.lengthBeats)));
 

--- a/magda/daw/ui/components/pianoroll/PianoRollGridComponent.hpp
+++ b/magda/daw/ui/components/pianoroll/PianoRollGridComponent.hpp
@@ -467,6 +467,11 @@ class PianoRollGridComponent : public juce::Component,
     int expressionDragPointIndex_ = -1;
     bool isExpressionDragging_ = false;
 
+    // Bending a segment rather than moving a point (#2198): the index of the
+    // segment's left point, which is the point that owns its shape. -1 when the
+    // drag is an ordinary point move.
+    int expressionTensionSegmentIndex_ = -1;
+
     static constexpr int EXPRESSION_POINT_HIT_RADIUS = 6;
     static constexpr double MAX_PITCH_EXPRESSION_SEMITONES = 48.0;
 
@@ -499,6 +504,24 @@ class PianoRollGridComponent : public juce::Component,
     };
     std::optional<ExpressionHit> hitTestExpressionPoint(juce::Point<int> pos) const;
     std::optional<ExpressionHit> hitTestExpressionNote(juce::Point<int> pos) const;
+
+    /// Whether @p mods ask for a segment bend rather than a point move (#2198).
+    /// Alt, which is what Bitwig uses and the one modifier free here: Shift
+    /// already means "do not snap to semitones" on the other two gestures.
+    /// Hard-coded rather than routed through GestureRouter, whose action codes
+    /// are persisted and whose only discrete drag actions today are the clip
+    /// duplicates; worth revisiting if a second such gesture appears.
+    static bool isBendExpressionGesture(const juce::ModifierKeys& mods) {
+        return mods.isAltDown();
+    }
+
+    /// Reshape the segment being dragged so its curve passes under the cursor.
+    void bendExpressionSegment(const MidiNote& note, const juce::MouseEvent& e);
+
+    /// The segment under @p pos, reported as its left point's index (#2198).
+    /// Only segments between two authored points: the flat runs before the
+    /// first point and after the last are the note's own pitch, not a glide.
+    std::optional<ExpressionHit> hitTestExpressionSegment(juce::Point<int> pos) const;
 
     // Point under the mouse (for the pitch value label)
     std::optional<ExpressionHit> hoveredExpressionPoint_;

--- a/magda/daw/ui/components/pianoroll/PianoRollGridComponent.hpp
+++ b/magda/daw/ui/components/pianoroll/PianoRollGridComponent.hpp
@@ -505,6 +505,10 @@ class PianoRollGridComponent : public juce::Component,
     std::optional<ExpressionHit> hitTestExpressionPoint(juce::Point<int> pos) const;
     std::optional<ExpressionHit> hitTestExpressionNote(juce::Point<int> pos) const;
 
+    /// Cursor while editing glides: the bend glyph when the gesture would take
+    /// effect here, the ordinary pointer otherwise (#2198).
+    void updateExpressionCursor(const juce::ModifierKeys& mods, juce::Point<int> pos);
+
     /// Whether @p mods ask for a segment bend rather than a point move (#2198).
     /// Alt, which is what Bitwig uses and the one modifier free here: Shift
     /// already means "do not snap to semitones" on the other two gestures.

--- a/magda/daw/ui/themes/CursorManager.cpp
+++ b/magda/daw/ui/themes/CursorManager.cpp
@@ -16,6 +16,52 @@ CursorManager::CursorManager() {
     noteRepeatCursor = createNoteRepeatCursor();
     bladeCursor = createBladeCursor();
     ghostCopyCursor = createGhostCopyCursor();
+    curveBendCursor = createCurveBendCursor();
+}
+
+juce::MouseCursor CursorManager::createCurveBendCursor() {
+    // Bending a glide segment (#2198): an S-curve with a small double-headed
+    // arrow standing clear of it. The curve says what is about to change, the
+    // arrow says the drag is vertical.
+    //
+    // Kept apart rather than overlaid. At 28px with the outline pass every
+    // other tool cursor here uses, two strokes crossing each other merge into
+    // one unreadable mark -- the first attempt put the arrow through the
+    // curve's midpoint and neither shape survived.
+    const int size = 28;
+    juce::Image img(juce::Image::ARGB, size, size, true);
+    juce::Graphics g(img);
+
+    // Low on the left, high on the right, the way a rising glide is drawn.
+    juce::Path curve;
+    curve.startNewSubPath(3.0f, 24.0f);
+    curve.cubicTo(12.0f, 24.0f, 14.0f, 11.0f, 25.0f, 11.0f);
+
+    juce::Path arrow;
+    arrow.startNewSubPath(7.0f, 3.0f);
+    arrow.lineTo(7.0f, 13.0f);
+    arrow.startNewSubPath(4.4f, 5.6f);
+    arrow.lineTo(7.0f, 2.6f);
+    arrow.lineTo(9.6f, 5.6f);
+    arrow.startNewSubPath(4.4f, 10.4f);
+    arrow.lineTo(7.0f, 13.4f);
+    arrow.lineTo(9.6f, 10.4f);
+
+    // White outline pass then the body, as the other tool cursors do, so it
+    // stays readable over both the dark grid and a bright clip colour.
+    const auto pass = [&g](const juce::Path& path, float outline, float body) {
+        g.setColour(juce::Colours::white);
+        g.strokePath(path, juce::PathStrokeType(outline, juce::PathStrokeType::curved,
+                                                juce::PathStrokeType::rounded));
+        g.setColour(juce::Colours::black);
+        g.strokePath(path, juce::PathStrokeType(body, juce::PathStrokeType::curved,
+                                                juce::PathStrokeType::rounded));
+    };
+    pass(curve, 4.0f, 2.0f);
+    pass(arrow, 3.4f, 1.6f);
+
+    // Hotspot on the curve's own midpoint, which is the thing being grabbed.
+    return juce::MouseCursor(img, 13, 17);
 }
 
 juce::MouseCursor CursorManager::createGhostCopyCursor() {

--- a/magda/daw/ui/themes/CursorManager.hpp
+++ b/magda/daw/ui/themes/CursorManager.hpp
@@ -37,6 +37,10 @@ class CursorManager {
     const juce::MouseCursor& getGhostCopyCursor() const {
         return ghostCopyCursor;
     }
+    /// Shown while Alt is held over a glide segment that can be bent (#2198).
+    const juce::MouseCursor& getCurveBendCursor() const {
+        return curveBendCursor;
+    }
 
   private:
     CursorManager();
@@ -53,6 +57,7 @@ class CursorManager {
     static juce::MouseCursor createNoteRepeatCursor();
     static juce::MouseCursor createBladeCursor();
     static juce::MouseCursor createGhostCopyCursor();
+    static juce::MouseCursor createCurveBendCursor();
 
     juce::MouseCursor zoomCursor;
     juce::MouseCursor zoomInCursor;
@@ -62,6 +67,7 @@ class CursorManager {
     juce::MouseCursor noteRepeatCursor;
     juce::MouseCursor bladeCursor;
     juce::MouseCursor ghostCopyCursor;
+    juce::MouseCursor curveBendCursor;
 };
 
 }  // namespace magda

--- a/magda/engine/clip/MidiClipCompiler.cpp
+++ b/magda/engine/clip/MidiClipCompiler.cpp
@@ -6,6 +6,8 @@
 #include <limits>
 #include <map>
 
+#include "core/PitchExpressionCurve.hpp"
+
 namespace magda::engine {
 
 namespace {
@@ -361,22 +363,11 @@ MidiEventList compileMidiEvents(const ClipInfo& clip, double curveFloorBeats) {
             std::stable_sort(points.begin(), points.end(),
                              [](const auto& a, const auto& b) { return a.beat < b.beat; });
 
+            // Shape from core, so what compiles is what the piano roll drew
+            // (#2198). The densification below is unchanged: it already walks
+            // each segment finely enough for a bend to survive it.
             const auto valueAt = [&points](double beat) {
-                if (beat <= points.front().beat)
-                    return points.front().semitones;
-                if (beat >= points.back().beat)
-                    return points.back().semitones;
-                for (std::size_t p = 0; p + 1 < points.size(); ++p) {
-                    const auto& a = points[p];
-                    const auto& b = points[p + 1];
-                    if (beat >= a.beat && beat <= b.beat) {
-                        const auto span = b.beat - a.beat;
-                        if (span <= 0.0)
-                            return b.semitones;
-                        return a.semitones + (beat - a.beat) / span * (b.semitones - a.semitones);
-                    }
-                }
-                return points.back().semitones;
+                return evaluatePitchExpressionCurve(points, beat);
             };
 
             auto lastValue = std::numeric_limits<int>::min();

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -153,6 +153,10 @@ set(TEST_SOURCES
     test_config_path_redirect.cpp
     # Keyboard clip nudging (#1957)
     test_clip_nudge.cpp
+    # The MPE pitch glide's curve (#2198): the shape the piano roll draws, the
+    # compiler compiles and the Tracktion bridge hands over, and the inverse the
+    # bend gesture drives it by.
+    test_pitch_expression_curve.cpp
     # Where a clip drag may land (#2179): the pure index rules that step the
     # ghost over a lane it cannot land on. The panel driving them is in
     # magda_juce_tests, which is where a TrackContentPanel can exist.

--- a/tests/test_midi_clip_playback.cpp
+++ b/tests/test_midi_clip_playback.cpp
@@ -12,6 +12,7 @@
 #include "clip/ClipSnapshotCompiler.hpp"
 #include "clip/GrooveTemplate.hpp"
 #include "clip/MidiClipCompiler.hpp"
+#include "core/PitchExpressionCurve.hpp"
 
 /**
  * MIDI clip playback (#2039), on the audio thread.
@@ -509,6 +510,58 @@ TEST_CASE("Overlapping expressive notes get their own channels", "[engine][clip]
         }
 
     CHECK(bends > 16);
+}
+
+TEST_CASE("A bent glide compiles to the curve the editor drew, not the straight line",
+          "[engine][clip][midi]") {
+    // #2198. The compiler already densified each segment; what is new is that
+    // the value it densifies is a shape. Checked against the linear answer,
+    // because a bend that compiles as a line is exactly the bug this replaces.
+    constexpr double kTension = 2.0;
+    constexpr double kEndSemitones = 12.0;
+
+    auto clip = makeMidiClip(1, 0.0, 8.0);
+    auto bent = note(60, 0.0, 4.0);
+    bent.pitchExpression = {MidiPitchExpressionPoint{0.0, 0.0, kTension},
+                            MidiPitchExpressionPoint{4.0, kEndSemitones, 0.0}};
+    clip.midiNotes.push_back(bent);
+
+    const auto list = compileMidiEvents(clip, 0.0);
+    REQUIRE(list.mpe);
+
+    // Wheel value -> semitones, through the same +/-48 range the compiler uses.
+    const auto semitonesOf = [](const auto& event) {
+        const auto value = static_cast<int>(event.data1) | (static_cast<int>(event.data2) << 7);
+        return (value - 8192) / 8192.0 * 48.0;
+    };
+
+    std::optional<double> atMidpoint;
+    std::optional<double> atEnd;
+    double nearestToMid = 1.0e9;
+
+    for (const auto& event : list.events) {
+        if (event.kind() != 0xe0u)
+            continue;
+        if (const auto distance = std::abs(event.beat - 2.0); distance < nearestToMid) {
+            nearestToMid = distance;
+            atMidpoint = semitonesOf(event);
+        }
+        if (std::abs(event.beat - 4.0) < 1.0e-6)
+            atEnd = semitonesOf(event);
+    }
+
+    REQUIRE(atMidpoint.has_value());
+
+    // The straight line would read half the travel here. The bend pulls it well
+    // below that, and the tolerance is the wheel's own resolution rather than a
+    // guess: 48 semitones over 8192 steps.
+    const double expected = evaluatePitchExpressionCurve(bent.pitchExpression, 2.0);
+    CHECK(*atMidpoint == Approx(expected).margin(48.0 / 8192.0 * 2.0));
+    CHECK(*atMidpoint < kEndSemitones * 0.5 - 1.0);
+
+    // ...and it still arrives where the user put the last point.
+    REQUIRE(atEnd.has_value());
+    CHECK(*atEnd == Approx(kEndSemitones).margin(48.0 / 8192.0 * 2.0));
 }
 
 // =============================================================================

--- a/tests/test_pitch_expression_curve.cpp
+++ b/tests/test_pitch_expression_curve.cpp
@@ -1,0 +1,154 @@
+// Tests for the MPE pitch glide curve (#2198): the shape a note's per-note
+// pitch expression takes between two authored points, and the inverse a drag
+// uses to bend it. Headless — plain points in, semitones out.
+
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+#include "magda/daw/core/PitchExpressionCurve.hpp"
+
+using Catch::Approx;
+using namespace magda;
+
+namespace {
+
+MidiPitchExpressionPoint pt(double beat, double semitones, double tension = 0.0) {
+    MidiPitchExpressionPoint p;
+    p.beat = beat;
+    p.semitones = semitones;
+    p.tension = tension;
+    return p;
+}
+
+}  // namespace
+
+// ============================================================================
+// The straight line it has always been
+// ============================================================================
+
+TEST_CASE("An unbent glide is the linear interpolation it used to be", "[pitch_expression]") {
+    const std::vector<MidiPitchExpressionPoint> points{pt(0.0, 0.0), pt(2.0, 4.0)};
+
+    REQUIRE(evaluatePitchExpressionCurve(points, 0.0) == Approx(0.0));
+    REQUIRE(evaluatePitchExpressionCurve(points, 0.5) == Approx(1.0));
+    REQUIRE(evaluatePitchExpressionCurve(points, 1.0) == Approx(2.0));
+    REQUIRE(evaluatePitchExpressionCurve(points, 1.5) == Approx(3.0));
+    REQUIRE(evaluatePitchExpressionCurve(points, 2.0) == Approx(4.0));
+}
+
+TEST_CASE("A glide holds its end values rather than extrapolating", "[pitch_expression]") {
+    // A note that starts before its first point sounds at that point's pitch,
+    // and one that runs past its last stays where the glide left it.
+    const std::vector<MidiPitchExpressionPoint> points{pt(1.0, -2.0), pt(2.0, 3.0)};
+
+    REQUIRE(evaluatePitchExpressionCurve(points, 0.0) == Approx(-2.0));
+    REQUIRE(evaluatePitchExpressionCurve(points, -5.0) == Approx(-2.0));
+    REQUIRE(evaluatePitchExpressionCurve(points, 9.0) == Approx(3.0));
+}
+
+TEST_CASE("A glide with no points is no glide", "[pitch_expression]") {
+    REQUIRE(evaluatePitchExpressionCurve({}, 0.0) == Approx(0.0));
+    REQUIRE(evaluatePitchExpressionCurve({}, 4.0) == Approx(0.0));
+    REQUIRE(evaluatePitchExpressionCurve({pt(1.0, 5.0)}, 0.0) == Approx(5.0));
+}
+
+// ============================================================================
+// The bend
+// ============================================================================
+
+TEST_CASE("A bent segment still meets both of its endpoints", "[pitch_expression]") {
+    // Whatever the shape does in between, it starts and ends where the user put
+    // the points. A curve that misses its own endpoints would move the pitch of
+    // a note the user never touched.
+    for (const double tension : {-3.0, -1.5, -0.4, 0.4, 1.5, 3.0}) {
+        const std::vector<MidiPitchExpressionPoint> points{pt(0.0, -1.0, tension), pt(2.0, 5.0)};
+        REQUIRE(evaluatePitchExpressionCurve(points, 0.0) == Approx(-1.0));
+        REQUIRE(evaluatePitchExpressionCurve(points, 2.0) == Approx(5.0));
+    }
+}
+
+TEST_CASE("A bend leaves the straight line, in the direction of its sign", "[pitch_expression]") {
+    const std::vector<MidiPitchExpressionPoint> straight{pt(0.0, 0.0), pt(2.0, 4.0)};
+    const std::vector<MidiPitchExpressionPoint> positive{pt(0.0, 0.0, 1.5), pt(2.0, 4.0)};
+    const std::vector<MidiPitchExpressionPoint> negative{pt(0.0, 0.0, -1.5), pt(2.0, 4.0)};
+
+    const double mid = evaluatePitchExpressionCurve(straight, 1.0);
+    REQUIRE(evaluatePitchExpressionCurve(positive, 1.0) < mid);
+    REQUIRE(evaluatePitchExpressionCurve(negative, 1.0) > mid);
+
+    // ...and opposite signs are mirror images about the straight line.
+    REQUIRE(evaluatePitchExpressionCurve(positive, 1.0) - mid ==
+            Approx(mid - evaluatePitchExpressionCurve(negative, 1.0)).margin(1.0e-5));
+}
+
+TEST_CASE("A bent segment is monotonic between its endpoints", "[pitch_expression]") {
+    // A glide that doubles back would sound like a pitch wobble nobody drew.
+    const std::vector<MidiPitchExpressionPoint> points{pt(0.0, 0.0, 2.5), pt(1.0, 7.0)};
+
+    double previous = evaluatePitchExpressionCurve(points, 0.0);
+    for (int step = 1; step <= 100; ++step) {
+        const double value = evaluatePitchExpressionCurve(points, step / 100.0);
+        REQUIRE(value >= previous - 1.0e-9);
+        previous = value;
+    }
+}
+
+TEST_CASE("A tension below the threshold is the straight line exactly", "[pitch_expression]") {
+    // The renderer and the hit test both branch on this, so it has to be the
+    // same threshold and the same answer either side of it.
+    const std::vector<MidiPitchExpressionPoint> points{pt(0.0, 0.0, 0.0005), pt(2.0, 4.0)};
+    REQUIRE(evaluatePitchExpressionCurve(points, 1.0) == Approx(2.0));
+}
+
+TEST_CASE("Only the segment's own left point shapes it", "[pitch_expression]") {
+    // Three points, one bend. The far segment must be untouched: tension is
+    // owned by the point on the left of the segment it shapes, and nothing else.
+    const std::vector<MidiPitchExpressionPoint> points{pt(0.0, 0.0, 2.0), pt(1.0, 2.0),
+                                                       pt(2.0, 4.0)};
+
+    REQUIRE(evaluatePitchExpressionCurve(points, 0.5) < 1.0);           // bent
+    REQUIRE(evaluatePitchExpressionCurve(points, 1.5) == Approx(3.0));  // straight
+}
+
+TEST_CASE("A flat segment stays flat however it is bent", "[pitch_expression]") {
+    // The shape warps the travel between the endpoints, and there is none. The
+    // editor refuses the gesture here rather than pretending otherwise.
+    const std::vector<MidiPitchExpressionPoint> points{pt(0.0, 3.0, 2.0), pt(2.0, 3.0)};
+    REQUIRE(evaluatePitchExpressionCurve(points, 1.0) == Approx(3.0));
+}
+
+// ============================================================================
+// The inverse the drag uses
+// ============================================================================
+
+TEST_CASE("The tension for a point puts the curve through that point", "[pitch_expression]") {
+    // What the drag promises: bend until the curve is under the cursor. Checked
+    // by running the answer back through the evaluator.
+    for (const double t : {0.25, 0.5, 0.75}) {
+        for (const double target : {0.2, 0.35, 0.65, 0.8}) {
+            const double tension = pitchExpressionTensionThrough(t, target);
+            const std::vector<MidiPitchExpressionPoint> points{pt(0.0, 0.0, tension), pt(1.0, 1.0)};
+
+            INFO("t " << t << " target " << target << " tension " << tension);
+            REQUIRE(evaluatePitchExpressionCurve(points, t) == Approx(target).margin(1.0e-3));
+        }
+    }
+}
+
+TEST_CASE("Asking for the straight line gives no tension", "[pitch_expression]") {
+    REQUIRE(pitchExpressionTensionThrough(0.5, 0.5) == Approx(0.0).margin(1.0e-9));
+    REQUIRE(pitchExpressionTensionThrough(0.25, 0.25) == Approx(0.0).margin(1.0e-9));
+}
+
+TEST_CASE("The inverse stays in range however far the drag goes", "[pitch_expression]") {
+    // A drag runs off the top and bottom of the note row, and past the segment's
+    // own ends. None of that may produce a tension the evaluator cannot use.
+    for (const double t : {-4.0, 0.0, 0.5, 1.0, 6.0}) {
+        for (const double target : {-9.0, 0.0, 0.5, 1.0, 12.0}) {
+            const double tension = pitchExpressionTensionThrough(t, target);
+            INFO("t " << t << " target " << target);
+            REQUIRE(std::isfinite(tension));
+            REQUIRE(std::abs(tension) <= kMaxPitchExpressionTension);
+        }
+    }
+}

--- a/tests/test_pitch_expression_curve.cpp
+++ b/tests/test_pitch_expression_curve.cpp
@@ -118,6 +118,63 @@ TEST_CASE("A flat segment stays flat however it is bent", "[pitch_expression]") 
 }
 
 // ============================================================================
+// Which segments the gesture is offered on
+// ============================================================================
+
+TEST_CASE("A segment with pitch to travel can be bent", "[pitch_expression]") {
+    const std::vector<MidiPitchExpressionPoint> points{pt(0.0, 0.0), pt(1.0, 4.0), pt(2.0, 4.0)};
+
+    CHECK(pitchExpressionSegmentCanBend(points, 0));
+}
+
+TEST_CASE("A flat segment is not offered the gesture at all", "[pitch_expression]") {
+    // Not merely refused once the drag is under way: the hit test asks this too,
+    // so a flat segment never shows the bend cursor, never starts a drag, and
+    // never commits the undo entry that drag would have ended in.
+    const std::vector<MidiPitchExpressionPoint> points{pt(0.0, 0.0), pt(1.0, 4.0), pt(2.0, 4.0)};
+
+    CHECK_FALSE(pitchExpressionSegmentCanBend(points, 1));
+}
+
+TEST_CASE("There is no segment past the last point", "[pitch_expression]") {
+    const std::vector<MidiPitchExpressionPoint> points{pt(0.0, 0.0), pt(1.0, 4.0)};
+
+    CHECK_FALSE(pitchExpressionSegmentCanBend(points, 1));
+    CHECK_FALSE(pitchExpressionSegmentCanBend(points, 9));
+    CHECK_FALSE(pitchExpressionSegmentCanBend({}, 0));
+}
+
+TEST_CASE("A zero-width segment cannot be bent either", "[pitch_expression]") {
+    // Two points stacked on the same beat: there is no travel along the segment
+    // to warp, and the parameter the drag works in would divide by that width.
+    const std::vector<MidiPitchExpressionPoint> points{pt(1.0, 0.0), pt(1.0, 4.0)};
+
+    CHECK_FALSE(pitchExpressionSegmentCanBend(points, 0));
+}
+
+TEST_CASE("What can be bent is exactly what bending changes", "[pitch_expression]") {
+    // The predicate and the evaluator have to agree, or the editor offers a
+    // gesture that does nothing -- which is the defect it was added for.
+    //
+    // Segments with width only. A zero-width segment has no interior to ask
+    // about: every beat in it is also its own endpoints, where the evaluator
+    // answers with an end value rather than with a shape, so "does bending
+    // change the middle" is not a question it has.
+    const std::vector<std::vector<MidiPitchExpressionPoint>> cases{
+        {pt(0.0, 0.0, 2.0), pt(2.0, 6.0)},   // travels: bendable, and bends
+        {pt(0.0, 3.0, 2.0), pt(2.0, 3.0)}};  // flat: neither
+
+    for (const auto& points : cases) {
+        const double straight = 0.5 * (points[0].semitones + points[1].semitones);
+        const double midBeat = 0.5 * (points[0].beat + points[1].beat);
+        const bool bends =
+            std::abs(evaluatePitchExpressionCurve(points, midBeat) - straight) > 1.0e-6;
+
+        CHECK(pitchExpressionSegmentCanBend(points, 0) == bends);
+    }
+}
+
+// ============================================================================
 // The inverse the drag uses
 // ============================================================================
 

--- a/tests/test_project_serialization.cpp
+++ b/tests/test_project_serialization.cpp
@@ -1114,6 +1114,74 @@ TEST_CASE("Looped MIDI clip serialization preserves loop region separate from pl
     REQUIRE(restored->midi().sourceFilePath == "/tmp/imported-loop.mid");
 }
 
+TEST_CASE("A bent pitch glide roundtrips, and a straight one writes nothing extra",
+          "[project][serialization][midi]") {
+    // #2198 gave each glide segment a shape. The shape has to survive a save,
+    // and a project full of straight glides has to come back byte-identical to
+    // what it was before the field existed -- which is what the write-only-when-
+    // bent rule buys and what a reader of old projects depends on.
+    ProjectTestFixture fixture;
+
+    auto trackId = TrackManager::getInstance().createTrack("MIDI", TrackType::Media);
+
+    ClipInfo clip;
+    clip.id = 93;
+    clip.trackId = trackId;
+    clip.setMidiContent();
+    clip.view = ClipView::Arrangement;
+    clip.setPlacementBeats(0.0, 4.0);
+
+    MidiNote note;
+    note.noteNumber = 60;
+    note.startBeat = 0.0;
+    note.lengthBeats = 4.0;
+    note.pitchExpression = {MidiPitchExpressionPoint{0.0, 0.0, 1.75},
+                            MidiPitchExpressionPoint{2.0, 5.0, 0.0},
+                            MidiPitchExpressionPoint{4.0, -3.0, -2.5}};
+    clip.midiNotes.push_back(note);
+
+    ClipManager::getInstance().restoreClip(clip);
+
+    ProjectInfo info;
+    info.name = "Bent Glide";
+    info.tempo = 120.0;
+
+    auto json = ProjectSerializer::serializeProject(info);
+
+    // The straight middle segment carries no tension property at all.
+    auto* rootObj = json.getDynamicObject();
+    REQUIRE(rootObj != nullptr);
+    auto* clips = rootObj->getProperty("clips").getArray();
+    REQUIRE(clips != nullptr);
+    REQUIRE(clips->size() == 1);
+    auto* clipObj = clips->getReference(0).getDynamicObject();
+    REQUIRE(clipObj != nullptr);
+    auto* notes = clipObj->getProperty("midiNotes").getArray();
+    REQUIRE(notes != nullptr);
+    REQUIRE(notes->size() == 1);
+    auto* noteObj = notes->getReference(0).getDynamicObject();
+    REQUIRE(noteObj != nullptr);
+    auto* pointArray = noteObj->getProperty("pitchExpression").getArray();
+    REQUIRE(pointArray != nullptr);
+    REQUIRE(pointArray->size() == 3);
+    CHECK(pointArray->getReference(0).getDynamicObject()->hasProperty("tension"));
+    CHECK_FALSE(pointArray->getReference(1).getDynamicObject()->hasProperty("tension"));
+    CHECK(pointArray->getReference(2).getDynamicObject()->hasProperty("tension"));
+
+    ProjectInfo loaded;
+    REQUIRE(ProjectSerializer::deserializeProject(json, loaded));
+    const auto* restored = ClipManager::getInstance().getClip(clip.id);
+    REQUIRE(restored != nullptr);
+    REQUIRE(restored->midiNotes.size() == 1);
+
+    const auto& points = restored->midiNotes.front().pitchExpression;
+    REQUIRE(points.size() == 3);
+    CHECK(points[0].tension == Approx(1.75));
+    CHECK(points[1].tension == Approx(0.0));
+    CHECK(points[2].tension == Approx(-2.5));
+    CHECK(points[1].semitones == Approx(5.0));
+}
+
 TEST_CASE("Saving a MIDI clip to the media library writes and indexes a generated source file",
           "[project][serialization][midi][media_db]") {
     ProjectTestFixture fixture;


### PR DESCRIPTION
Closes #2198.

Drag a glide segment with Alt held and it bends, the way Bitwig does it.

## The short version

The spline machinery was already here. `core/CurveMath.hpp`'s `evalSegment` backs the automation lanes, the LFO editor and the CC/pitch-bend lanes, and both `MidiCCData` and `MidiPitchBendData` carry a `curveType` and a `tension`. The per-note MPE glide was the one curve in the app that never got connected to it — `MidiPitchExpressionPoint` was `{beat, semitones}` and interpolated linearly, with no way to say anything else. Which is why this reads as an oversight rather than a missing feature.

So this is mostly wiring, not new maths.

## What changed

**The model.** `MidiPitchExpressionPoint` gains a `tension`, in the same −3..+3 scale as `CurvePoint` and `MidiCCData`, owned by the segment's left point as segments are everywhere else here. Zero is the straight line it always was, so a glide authored before this reads back unchanged. The serializer writes the property only when a segment is actually bent, so a project of straight glides is written exactly as it was before the field existed.

**One evaluator, three callers.** The piano roll drew one curve, `MidiClipCompiler` compiled a second and `ClipSynchronizer` handed a third to Tracktion, each with its own copy of the same interpolation. They agreed only because none of them had a shape to disagree about; a tension ends that, so the answer moved to `core/PitchExpressionCurve.hpp` and all three ask it. Neither compiler needed anything else — both already densified each segment finely enough for a bend to survive.

**The gesture.** Alt is what Bitwig uses and the one modifier still free in expression mode (Shift already means "do not snap to semitones" on both of the other gestures there). `pitchExpressionTensionThrough` inverts `evalSegment` at the parameter the mouse is at, so the curve passes under the pointer wherever along the segment it was grabbed — not a nudge-until-it-looks-right knob.

**The cursor**, in its own commit. Alt already showed the note-draw pencil in the piano roll, including in expression mode where it cannot draw, so the bend gesture was announcing itself with a pencil pointing at the curve it was about to reshape. There is a bend cursor now — an S-curve for what changes, a small double-headed arrow for the drag being vertical — shown only while Alt is held and only over a segment the gesture would take, so it doubles as the discoverability hint.

## One limitation, deliberate

A segment between two points at the same pitch stays flat, and the gesture declines it. The shape is a warp of the travel between the endpoints and there is none — the same property the automation lanes and the LFO editor have. Bitwig can bend a flat segment because it bends in absolute terms; matching that means a second kind of maths for glides only, which is worth its own issue rather than a quiet divergence here.

## Tests

- `test_pitch_expression_curve.cpp` — the shape headless: endpoints held, monotonic, mirrored about the straight line, confined to its own segment, and the drag's inverse round-tripped back through the evaluator.
- A compiler case asserting the wheel stream follows the curve rather than the line, to the wheel's own resolution.
- A serialization case pinning both the round-trip and the absent property on a straight segment.

Verified negatively: forcing the evaluator back to linear fails four cases, one of them the compiled output.

Full headless suite green (3113 passed, 13 skipped). Gesture confirmed by hand in the running app.

## Worth a reviewer's eye

The tension→shape mapping is the existing one, reused as-is. The new maths is only its inverse, and it is covered by round-tripping rather than by asserting particular numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)