### PR TITLE
Use stable assignment tokens for async external-plugin loading (#2252)

### DIFF
--- a/magda/daw/audio/plugin_manager/ExternalPluginLookup.cpp
+++ b/magda/daw/audio/plugin_manager/ExternalPluginLookup.cpp
@@ -37,13 +37,19 @@ juce::PluginDescription describeSavedPlugin(const DeviceInfo& device) {
     return description;
 }
 
-SavedPluginIdentity savedPluginIdentity(const DeviceInfo& device) {
-    return {.identifier = device.uniqueId,
-            .name = device.name,
-            .manufacturer = device.manufacturer,
-            .fileOrIdentifier = device.fileOrIdentifier,
-            .format = device.format,
-            .isInstrument = device.isInstrument};
+void applyResolvedPluginDescription(DeviceInfo& device,
+                                    const juce::PluginDescription& description) {
+    device.name = description.name;
+    device.pluginId = description.createIdentifierString();
+    device.manufacturer = description.manufacturerName;
+    device.format = pluginFormatFromName(description.pluginFormatName);
+    device.isInstrument = description.isInstrument;
+    if (device.deviceType != DeviceType::MIDI)
+        device.deviceType = description.isInstrument ? DeviceType::Instrument : DeviceType::Effect;
+    device.uniqueId = description.createIdentifierString();
+    device.fileOrIdentifier = description.fileOrIdentifier;
+    device.audioInputChannels = description.numInputChannels;
+    device.audioOutputChannels = description.numOutputChannels;
 }
 
 ExternalPluginMatch matchInstalledPlugin(const DeviceInfo& device,

--- a/magda/daw/audio/plugin_manager/ExternalPluginLookup.cpp
+++ b/magda/daw/audio/plugin_manager/ExternalPluginLookup.cpp
@@ -37,21 +37,6 @@ juce::PluginDescription describeSavedPlugin(const DeviceInfo& device) {
     return description;
 }
 
-void applyResolvedPluginDescription(DeviceInfo& device,
-                                    const juce::PluginDescription& description) {
-    device.name = description.name;
-    device.pluginId = description.createIdentifierString();
-    device.manufacturer = description.manufacturerName;
-    device.format = pluginFormatFromName(description.pluginFormatName);
-    device.isInstrument = description.isInstrument;
-    if (device.deviceType != DeviceType::MIDI)
-        device.deviceType = description.isInstrument ? DeviceType::Instrument : DeviceType::Effect;
-    device.uniqueId = description.createIdentifierString();
-    device.fileOrIdentifier = description.fileOrIdentifier;
-    device.audioInputChannels = description.numInputChannels;
-    device.audioOutputChannels = description.numOutputChannels;
-}
-
 ExternalPluginMatch matchInstalledPlugin(const DeviceInfo& device,
                                          const juce::KnownPluginList& knownPlugins) {
     const auto saved = describeSavedPlugin(device);

--- a/magda/daw/audio/plugin_manager/ExternalPluginLookup.hpp
+++ b/magda/daw/audio/plugin_manager/ExternalPluginLookup.hpp
@@ -86,19 +86,4 @@ juce::PluginDescription describeSavedPlugin(const DeviceInfo& device);
 ExternalPluginMatch matchInstalledPlugin(const DeviceInfo& device,
                                          const juce::KnownPluginList& knownPlugins);
 
-/**
- * @brief Enrich @p device with facts from the exact installed plugin selected.
- *
- * Resolution is also metadata discovery. An imported DAWproject may have no
- * vendor or path and may call an instrument an effect; a plugin may have moved
- * since the project was saved. The native plan must see the installed role and
- * channel topology before it compiles, otherwise the successfully resolved
- * instrument receives no MIDI or a device is wired at the wrong width.
- *
- * This does not author a new plugin assignment and therefore deliberately does
- * not change DeviceInfo::pluginAssignmentGeneration. It only replaces mutable
- * saved/scan facts for the assignment already in the slot.
- */
-void applyResolvedPluginDescription(DeviceInfo& device, const juce::PluginDescription& description);
-
 }  // namespace magda

--- a/magda/daw/audio/plugin_manager/ExternalPluginLookup.hpp
+++ b/magda/daw/audio/plugin_manager/ExternalPluginLookup.hpp
@@ -87,51 +87,18 @@ ExternalPluginMatch matchInstalledPlugin(const DeviceInfo& device,
                                          const juce::KnownPluginList& knownPlugins);
 
 /**
- * @brief How a device says which plugin it is, as the model records it.
+ * @brief Enrich @p device with facts from the exact installed plugin selected.
  *
- * Two forms, because a project may carry either. @ref identifier is JUCE's own
- * identifier string, which is what DeviceInfo::uniqueId holds for a device
- * added from the browser. The fields beside it are what an imported project has
- * instead, and they are compared as themselves rather than through
- * PluginDescription::createIdentifierString().
+ * Resolution is also metadata discovery. An imported DAWproject may have no
+ * vendor or path and may call an instrument an effect; a plugin may have moved
+ * since the project was saved. The native plan must see the installed role and
+ * channel topology before it compiles, otherwise the successfully resolved
+ * instrument receives no MIDI or a device is wired at the wrong width.
  *
- * Not through that string for two reasons. It contains the plugin's numeric
- * uid, which a description rebuilt from saved fields does not have, so
- * comparing a rebuilt one against a scanned one never matches. And it encodes
- * only the format, the name and a hash of the file: not the vendor, and not
- * whether the plugin is an instrument. A bundle shipping an effect and an
- * instrument of the same name out of one file -- the case the lookup's own
- * first pass exists for -- produces one string for both.
+ * This does not author a new plugin assignment and therefore deliberately does
+ * not change DeviceInfo::pluginAssignmentGeneration. It only replaces mutable
+ * saved/scan facts for the assignment already in the slot.
  */
-struct SavedPluginIdentity {
-    juce::String identifier;
-
-    juce::String name;
-    juce::String manufacturer;
-    juce::String fileOrIdentifier;
-    PluginFormat format = PluginFormat::VST3;
-    bool isInstrument = false;
-
-    /**
-     * @brief Whether @p other names the same plugin.
-     *
-     * By identifier when both have one, which is exact. By the saved fields
-     * otherwise, which is what an imported device has and what a device that
-     * has only just been resolved has: a device that gains a scanned identifier
-     * has not changed plugin, and a comparison that read that as a change would
-     * refuse an answer it should have taken.
-     */
-    bool namesSamePluginAs(const SavedPluginIdentity& other) const {
-        if (identifier.isNotEmpty() && other.identifier.isNotEmpty())
-            return identifier == other.identifier;
-
-        return name == other.name && manufacturer == other.manufacturer &&
-               fileOrIdentifier == other.fileOrIdentifier && format == other.format &&
-               isInstrument == other.isInstrument;
-    }
-};
-
-/** What @p device records about which plugin it names. */
-SavedPluginIdentity savedPluginIdentity(const DeviceInfo& device);
+void applyResolvedPluginDescription(DeviceInfo& device, const juce::PluginDescription& description);
 
 }  // namespace magda

--- a/magda/daw/audio/plugins/engine/EngineDeviceFactory.cpp
+++ b/magda/daw/audio/plugins/engine/EngineDeviceFactory.cpp
@@ -100,15 +100,6 @@ ExternalDeviceResult adaptExternalPluginInstance(
     bool offlineRender) {
     instance->enableAllBuses();
 
-    // Scan descriptions report the format's default buses, not the instance
-    // after the host has enabled its sidechains and extra outputs. These are
-    // the only channel counts safe to compile a live plan from.
-    auto resolvedDevice = device;
-    resolvedDevice.audioInputChannels = instance->getTotalNumInputChannels();
-    resolvedDevice.audioOutputChannels = instance->getTotalNumOutputChannels();
-    resolvedDevice.canReceiveMidi = !resolvedDevice.isInstrument && instance->acceptsMidi();
-    resolvedDevice.producesMidi = instance->producesMidi() || instance->isMidiEffect();
-
     // The saved array, then the chunk over it, then what that left behind. The
     // order and the reasons are ExternalPluginState.hpp's; what matters here is
     // that all three happen before the adapter exists, so the adapter never has
@@ -117,6 +108,33 @@ ExternalDeviceResult adaptExternalPluginInstance(
         return {.device = {},
                 .failure = "external plugin \"" + device.name +
                            "\" failed while restoring its own saved state"};
+
+    // Buses again, and the widths only now. setStateInformation is free to
+    // change a plugin's bus layout -- an instrument the patch switches to
+    // multi-out, a compressor whose sidechain the patch turns on -- so widths
+    // read before the chunk was applied describe a layout the instance no
+    // longer has, while EngineExternalDevice::prepare() goes on to process the
+    // one it does. Re-enabling keeps the all-buses policy the first call
+    // establishes: a chunk that disabled one would otherwise leave the device
+    // reporting channels the rest of the chain is wired for.
+    instance->enableAllBuses();
+
+    // Scan descriptions report the format's default buses, not the instance
+    // after the host has enabled its sidechains and extra outputs. These are
+    // the only channel counts safe to compile a live plan from.
+    auto resolvedDevice = device;
+    resolvedDevice.audioInputChannels = instance->getTotalNumInputChannels();
+    resolvedDevice.audioOutputChannels = instance->getTotalNumOutputChannels();
+
+    // Promote only, the rule the model's other two writers follow
+    // (PluginManagerSync::updateDeviceCapabilityFlags,
+    // applyCachedCapabilitiesToDevice). A raw AudioProcessor::acceptsMidi() is
+    // narrower than what the incumbent engine asks -- it takes MIDI input for
+    // plugins whose processor does not advertise it -- so assigning it here
+    // clears a saved true and PlanCompiler stops routing MIDI to the device.
+    if (!resolvedDevice.isInstrument && (instance->acceptsMidi() || instance->isMidiEffect()))
+        resolvedDevice.canReceiveMidi = true;
+    resolvedDevice.producesMidi = instance->producesMidi() || instance->isMidiEffect();
 
     auto restored = magda::snapshotHostParameters(*instance);
 

--- a/magda/daw/audio/plugins/engine/EngineDeviceFactory.cpp
+++ b/magda/daw/audio/plugins/engine/EngineDeviceFactory.cpp
@@ -216,34 +216,33 @@ ExternalDeviceResult completeExternalPluginLoad(std::unique_ptr<juce::AudioPlugi
     // The model first, before anything is done with the instance. Everything
     // below restores from it, and it is a different object from the one the
     // load was requested with: seconds have passed.
-    const auto* device = currentDevice ? currentDevice() : nullptr;
+    const auto* device = currentDevice ? currentDevice(requested.deviceId) : nullptr;
+
+    const auto& requestedName = requested.resolvedIdentity.name;
 
     if (device == nullptr)
         return {.device = {},
-                .failure = "the device was removed while \"" + requested.name + "\" was loading"};
+                .failure = "the device was removed while \"" + requestedName + "\" was loading"};
+
+    // This is the identity boundary. Scan metadata may have changed in every
+    // field while the plugin loaded, including the role the plan compiles from;
+    // those are facts learned about this assignment, not another assignment.
+    // A replacement DeviceInfo carries a newly authored generation even when
+    // it is another variant in the same bundle or has the same display name.
+    if (device->id != requested.deviceId ||
+        device->pluginAssignmentGeneration != requested.assignmentGeneration)
+        return {.device = {},
+                .failure = "the device changed plugin while \"" + requestedName + "\" was loading"};
 
     if (instance == nullptr)
         return {.device = {},
                 .failure = "external plugin \"" + device->name + "\" could not be loaded: " +
                            (error.isNotEmpty() ? error : "no reason given")};
 
-    // And it has to still be the same plugin. A device whose plugin was
-    // replaced while this one loaded is not waiting for this answer, and
-    // restoring onto it would put one plugin's saved patch on another.
-    //
-    // The model's identity on both sides. The scanned description's identifier
-    // carries the plugin's numeric uid and a device's saved fields do not, so
-    // comparing this against that would find every unchanged plugin changed and
-    // refuse every load there is.
-    if (!magda::savedPluginIdentity(*device).namesSamePluginAs(requested.identity))
-        return {.device = {},
-                .failure =
-                    "the device changed plugin while \"" + requested.name + "\" was loading"};
-
     return adaptExternalPluginInstance(std::move(instance), *device, offlineRender);
 }
 
-void createEngineExternalDeviceAsync(const magda::DeviceInfo& device,
+void createEngineExternalDeviceAsync(magda::DeviceInfo& device,
                                      const ExternalPluginServices& services, bool offlineRender,
                                      CurrentDeviceLookup currentDevice,
                                      std::function<void(ExternalDeviceResult)> completed) {
@@ -256,13 +255,18 @@ void createEngineExternalDeviceAsync(const magda::DeviceInfo& device,
         return;
     }
 
-    // Nothing of the model is captured here. What the callback needs from it is
-    // read when the callback runs, because by then the project has had seconds
-    // to move on: see CurrentDeviceLookup.
+    // This is synchronous on purpose. A caller compiles the native plan after
+    // starting the loads, while their instances are still in flight; it needs
+    // the resolved instrument role and channel topology now, not at completion.
+    // These are corrected facts about the existing assignment, so its stable
+    // generation is preserved.
+    magda::applyResolvedPluginDescription(device, resolved.description);
+
     services.formats->createPluginInstanceAsync(
         resolved.description, services.context.sampleRate, services.context.maxBlockSize,
-        [requested = RequestedPlugin{.identity = magda::savedPluginIdentity(device),
-                                     .name = resolved.description.name},
+        [requested = RequestedPlugin{.deviceId = device.id,
+                                     .assignmentGeneration = device.pluginAssignmentGeneration,
+                                     .resolvedIdentity = resolved.description},
          currentDevice = std::move(currentDevice), offlineRender, completed = std::move(completed)](
             std::unique_ptr<juce::AudioPluginInstance> instance, const juce::String& error) {
             completed(completeExternalPluginLoad(std::move(instance), error, requested,

--- a/magda/daw/audio/plugins/engine/EngineDeviceFactory.cpp
+++ b/magda/daw/audio/plugins/engine/EngineDeviceFactory.cpp
@@ -3,6 +3,7 @@
 #include <utility>
 
 #include "core/DeviceState.hpp"
+#include "core/PluginCapabilities.hpp"
 #include "plugin_manager/ExternalPluginLookup.hpp"
 #include "plugin_manager/ExternalPluginState.hpp"
 #include "plugins/InternalPluginRegistry.hpp"
@@ -99,6 +100,15 @@ ExternalDeviceResult adaptExternalPluginInstance(
     bool offlineRender) {
     instance->enableAllBuses();
 
+    // Scan descriptions report the format's default buses, not the instance
+    // after the host has enabled its sidechains and extra outputs. These are
+    // the only channel counts safe to compile a live plan from.
+    auto resolvedDevice = device;
+    resolvedDevice.audioInputChannels = instance->getTotalNumInputChannels();
+    resolvedDevice.audioOutputChannels = instance->getTotalNumOutputChannels();
+    resolvedDevice.canReceiveMidi = !resolvedDevice.isInstrument && instance->acceptsMidi();
+    resolvedDevice.producesMidi = instance->producesMidi() || instance->isMidiEffect();
+
     // The saved array, then the chunk over it, then what that left behind. The
     // order and the reasons are ExternalPluginState.hpp's; what matters here is
     // that all three happen before the adapter exists, so the adapter never has
@@ -110,10 +120,11 @@ ExternalDeviceResult adaptExternalPluginInstance(
 
     auto restored = magda::snapshotHostParameters(*instance);
 
-    return {.device =
-                std::make_unique<EngineExternalDevice>(std::move(instance), device, offlineRender),
+    return {.device = std::make_unique<EngineExternalDevice>(std::move(instance), resolvedDevice,
+                                                             offlineRender),
             .failure = {},
-            .restoredParameters = std::move(restored)};
+            .restoredParameters = std::move(restored),
+            .resolvedDevice = std::move(resolvedDevice)};
 }
 
 namespace {
@@ -125,32 +136,16 @@ juce::String describeMissingPlugin(const magda::DeviceInfo& device) {
            ") is not installed on this machine";
 }
 
-/// What the two entry points check before either asks a format manager for
-/// anything: the services are complete, and the scan knows the plugin.
-///
-/// Returns the description to load, or the reason there is not one.
-struct ResolvedPlugin {
-    juce::PluginDescription description;
-    juce::String failure;
-};
+/// Apply only a role JUCE's installed description can author. MIDI and Analysis
+/// are explicit MAGDA roles, and replacing either with Effect/Instrument would
+/// change the plan rather than enrich it.
+void applyInstalledRole(magda::DeviceInfo& device, bool isInstrument) {
+    if (device.deviceType == magda::DeviceType::MIDI ||
+        device.deviceType == magda::DeviceType::Analysis)
+        return;
 
-ResolvedPlugin resolvePlugin(const magda::DeviceInfo& device,
-                             const ExternalPluginServices& services) {
-    if (services.formats == nullptr || services.knownPlugins == nullptr)
-        return {.description = {},
-                .failure = "no plugin formats or scan results were given to the engine"};
-
-    const auto match = magda::matchInstalledPlugin(device, *services.knownPlugins);
-
-    // Unfound is refused rather than attempted. The app tries the saved
-    // description anyway and lets the format's own lookup have a go, which is
-    // right for a session where a user is watching and can be told; a render is
-    // not that, and a plugin resolved by a route nothing recorded is the kind
-    // of difference a null-diff corpus cannot attribute afterwards.
-    if (!match.found)
-        return {.description = {}, .failure = describeMissingPlugin(device)};
-
-    return {.description = match.description, .failure = {}};
+    device.isInstrument = isInstrument;
+    device.deviceType = isInstrument ? magda::DeviceType::Instrument : magda::DeviceType::Effect;
 }
 
 }  // namespace
@@ -184,6 +179,37 @@ bool isRegisteredDevice(const juce::String& pluginId) {
            compiled::findCompiledPluginSpec(pluginId) != nullptr;
 }
 
+ExternalPluginResolution resolveEngineExternalPlugin(const magda::DeviceInfo& device,
+                                                     const ExternalPluginServices& services) {
+    ExternalPluginResolution resolved{.planDevice = device};
+
+    if (services.formats == nullptr || services.knownPlugins == nullptr) {
+        resolved.failure = "no plugin formats or scan results were given to the engine";
+        return resolved;
+    }
+
+    const auto match = magda::matchInstalledPlugin(device, *services.knownPlugins);
+
+    // Unfound is refused rather than attempted. The app tries the saved
+    // description anyway and lets the format's own lookup have a go, which is
+    // right for a session where a user is watching and can be told; a render is
+    // not that, and a plugin resolved by a route nothing recorded is the kind
+    // of difference a null-diff corpus cannot attribute afterwards.
+    if (!match.found) {
+        resolved.failure = describeMissingPlugin(device);
+        return resolved;
+    }
+
+    resolved.description = match.description;
+    applyInstalledRole(resolved.planDevice, match.description.isInstrument);
+
+    // Keep the project's identity and preference key. The capability cache is
+    // nevertheless queried with the exact installed identity resolution found.
+    const auto resolvedIdentifier = match.description.createIdentifierString();
+    magda::applyCachedCapabilitiesToDevice(resolved.planDevice, resolvedIdentifier);
+    return resolved;
+}
+
 bool isInstalledExternalPlugin(const magda::DeviceInfo& device,
                                const juce::KnownPluginList& knownPlugins) {
     return magda::matchInstalledPlugin(device, knownPlugins).found;
@@ -192,7 +218,7 @@ bool isInstalledExternalPlugin(const magda::DeviceInfo& device,
 ExternalDeviceResult createEngineExternalDevice(const magda::DeviceInfo& device,
                                                 const ExternalPluginServices& services,
                                                 bool offlineRender) {
-    const auto resolved = resolvePlugin(device, services);
+    const auto resolved = resolveEngineExternalPlugin(device, services);
     if (resolved.failure.isNotEmpty())
         return {.device = {}, .failure = resolved.failure};
 
@@ -205,7 +231,7 @@ ExternalDeviceResult createEngineExternalDevice(const magda::DeviceInfo& device,
                 .failure = "external plugin \"" + device.name + "\" could not be loaded: " +
                            (error.isNotEmpty() ? error : "no reason given")};
 
-    return adaptExternalPluginInstance(std::move(instance), device, offlineRender);
+    return adaptExternalPluginInstance(std::move(instance), resolved.planDevice, offlineRender);
 }
 
 ExternalDeviceResult completeExternalPluginLoad(std::unique_ptr<juce::AudioPluginInstance> instance,
@@ -218,7 +244,7 @@ ExternalDeviceResult completeExternalPluginLoad(std::unique_ptr<juce::AudioPlugi
     // load was requested with: seconds have passed.
     const auto* device = currentDevice ? currentDevice(requested.deviceId) : nullptr;
 
-    const auto& requestedName = requested.resolvedIdentity.name;
+    const auto& requestedName = requested.displayName;
 
     if (device == nullptr)
         return {.device = {},
@@ -229,8 +255,7 @@ ExternalDeviceResult completeExternalPluginLoad(std::unique_ptr<juce::AudioPlugi
     // those are facts learned about this assignment, not another assignment.
     // A replacement DeviceInfo carries a newly authored generation even when
     // it is another variant in the same bundle or has the same display name.
-    if (device->id != requested.deviceId ||
-        device->pluginAssignmentGeneration != requested.assignmentGeneration)
+    if (device->pluginAssignmentGeneration != requested.assignmentGeneration)
         return {.device = {},
                 .failure = "the device changed plugin while \"" + requestedName + "\" was loading"};
 
@@ -239,39 +264,36 @@ ExternalDeviceResult completeExternalPluginLoad(std::unique_ptr<juce::AudioPlugi
                 .failure = "external plugin \"" + device->name + "\" could not be loaded: " +
                            (error.isNotEmpty() ? error : "no reason given")};
 
-    return adaptExternalPluginInstance(std::move(instance), *device, offlineRender);
+    auto resolvedDevice = *device;
+    applyInstalledRole(resolvedDevice, requested.resolvedIsInstrument);
+    return adaptExternalPluginInstance(std::move(instance), resolvedDevice, offlineRender);
 }
 
-void createEngineExternalDeviceAsync(magda::DeviceInfo& device,
-                                     const ExternalPluginServices& services, bool offlineRender,
-                                     CurrentDeviceLookup currentDevice,
-                                     std::function<void(ExternalDeviceResult)> completed) {
+ExternalPluginResolution createEngineExternalDeviceAsync(
+    const magda::DeviceInfo& device, const ExternalPluginServices& services, bool offlineRender,
+    CurrentDeviceLookup currentDevice, std::function<void(ExternalDeviceResult)> completed) {
     jassert(completed != nullptr);
     jassert(currentDevice != nullptr);
 
-    const auto resolved = resolvePlugin(device, services);
+    auto resolved = resolveEngineExternalPlugin(device, services);
     if (resolved.failure.isNotEmpty()) {
         completed({.device = {}, .failure = resolved.failure});
-        return;
+        return resolved;
     }
-
-    // This is synchronous on purpose. A caller compiles the native plan after
-    // starting the loads, while their instances are still in flight; it needs
-    // the resolved instrument role and channel topology now, not at completion.
-    // These are corrected facts about the existing assignment, so its stable
-    // generation is preserved.
-    magda::applyResolvedPluginDescription(device, resolved.description);
 
     services.formats->createPluginInstanceAsync(
         resolved.description, services.context.sampleRate, services.context.maxBlockSize,
         [requested = RequestedPlugin{.deviceId = device.id,
                                      .assignmentGeneration = device.pluginAssignmentGeneration,
-                                     .resolvedIdentity = resolved.description},
+                                     .displayName = device.name,
+                                     .resolvedIsInstrument = resolved.description.isInstrument},
          currentDevice = std::move(currentDevice), offlineRender, completed = std::move(completed)](
             std::unique_ptr<juce::AudioPluginInstance> instance, const juce::String& error) {
             completed(completeExternalPluginLoad(std::move(instance), error, requested,
                                                  currentDevice, offlineRender));
         });
+
+    return resolved;
 }
 
 }  // namespace magda::daw::audio::engine_adapter

--- a/magda/daw/audio/plugins/engine/EngineDeviceFactory.hpp
+++ b/magda/daw/audio/plugins/engine/EngineDeviceFactory.hpp
@@ -186,22 +186,24 @@ ExternalDeviceResult createEngineExternalDevice(const magda::DeviceInfo& device,
  * means the device is gone, and the load is abandoned rather than completed
  * against a project that no longer has it.
  */
-using CurrentDeviceLookup = std::function<const magda::DeviceInfo*()>;
+using CurrentDeviceLookup = std::function<const magda::DeviceInfo*(magda::DeviceId deviceId)>;
 
 /**
  * @brief What an asynchronous load remembers about what it asked for.
  *
- * The identity is the model's, taken when the load was requested, so that
- * comparing it with the model's identity at completion compares like with like.
- * Not the scanned description's identifier: that carries the plugin's numeric
- * uid, a device's saved fields do not, and comparing the two would call every
- * unchanged plugin a change.
+ * The device id and assignment generation are the stable question the loader
+ * is answering. Saved plugin metadata is not: resolving a moved plugin or an
+ * imported DAWproject legitimately corrects it before this request completes.
+ *
+ * @ref resolvedIdentity is the exact installed description handed to JUCE. It
+ * is retained so the request records the precise variant that is in flight;
+ * completion does not try to re-resolve mutable model fields and infer whether
+ * they still mean it. The assignment generation answers that directly.
  */
 struct RequestedPlugin {
-    magda::SavedPluginIdentity identity;
-
-    /// For the messages, which name a plugin rather than an identifier.
-    juce::String name;
+    magda::DeviceId deviceId = magda::INVALID_DEVICE_ID;
+    std::uint64_t assignmentGeneration = 0;
+    juce::PluginDescription resolvedIdentity;
 };
 
 /**
@@ -211,10 +213,9 @@ struct RequestedPlugin {
  * calls it directly. @p error is what the loader reported, used only when @p
  * instance is null.
  *
- * It resolves @p currentDevice first: a device that has gone, or that now names
- * a different plugin from the one that was asked for, is a load whose answer
- * arrived too late to be useful, and completing it would put a stale patch on a
- * device somebody has since changed.
+ * It resolves @p currentDevice by the captured id first. A device that has gone,
+ * or whose assignment generation changed, is a load whose answer arrived too
+ * late to be useful. Mutable plugin metadata is deliberately not compared.
  */
 ExternalDeviceResult completeExternalPluginLoad(std::unique_ptr<juce::AudioPluginInstance> instance,
                                                 const juce::String& error,
@@ -232,11 +233,16 @@ ExternalDeviceResult completeExternalPluginLoad(std::unique_ptr<juce::AudioPlugi
  * rather than a hand-off -- bindings are resolved when a plan is prepared, so a
  * device that arrives later is published and the plan prepared again.
  *
- * @p device is read once, now, to work out which plugin to load.
+ * @p device is resolved and enriched synchronously before this function
+ * returns, so its installed role and channel capabilities are visible to a
+ * plan compiled while the plugin instance is still loading. That enrichment
+ * preserves its assignment generation.
+ *
+ * The enriched @p device is read once to work out which plugin to load.
  * @p currentDevice is read again at completion, to work out what to restore
  * onto it; see CurrentDeviceLookup for why those are two different questions.
  */
-void createEngineExternalDeviceAsync(const magda::DeviceInfo& device,
+void createEngineExternalDeviceAsync(magda::DeviceInfo& device,
                                      const ExternalPluginServices& services, bool offlineRender,
                                      CurrentDeviceLookup currentDevice,
                                      std::function<void(ExternalDeviceResult)> completed);

--- a/magda/daw/audio/plugins/engine/EngineDeviceFactory.hpp
+++ b/magda/daw/audio/plugins/engine/EngineDeviceFactory.hpp
@@ -4,6 +4,7 @@
 
 #include <functional>
 #include <memory>
+#include <optional>
 
 #include "core/DeviceInfo.hpp"
 #include "exec/EngineDevice.hpp"
@@ -110,6 +111,30 @@ struct ExternalPluginServices {
 };
 
 /**
+ * @brief The exact installed plugin and the model facts safe to compile from.
+ *
+ * @ref planDevice is a transient copy. Resolution may correct the ordinary
+ * effect/instrument role and apply capabilities cached under the installed
+ * plugin's exact identifier, but it never rekeys or mutates the persistent
+ * model. Display names, user preferences, explicit MIDI/Analysis roles and
+ * saved channel widths remain the project's. Live channel topology is only
+ * known after JUCE has instantiated the plugin and enabled all of its buses.
+ */
+struct ExternalPluginResolution {
+    magda::DeviceInfo planDevice;
+    juce::PluginDescription description;
+    juce::String failure;
+
+    explicit operator bool() const {
+        return failure.isEmpty();
+    }
+};
+
+/** Resolve once for both plan compilation and plugin creation. */
+ExternalPluginResolution resolveEngineExternalPlugin(const magda::DeviceInfo& device,
+                                                     const ExternalPluginServices& services);
+
+/**
  * @brief An external device, or why there is not one.
  *
  * Exactly one of the two is set. The failure is a sentence for a person: which
@@ -141,6 +166,13 @@ struct ExternalDeviceResult {
      * Empty when nothing was created.
      */
     std::vector<magda::RestoredParameter> restoredParameters;
+
+    /**
+     * The current assignment enriched from the live instance after all buses
+     * were enabled. A caller may validate and publish this only on success;
+     * failures leave the persistent model exactly as it was.
+     */
+    std::optional<magda::DeviceInfo> resolvedDevice;
 };
 
 /**
@@ -195,15 +227,16 @@ using CurrentDeviceLookup = std::function<const magda::DeviceInfo*(magda::Device
  * is answering. Saved plugin metadata is not: resolving a moved plugin or an
  * imported DAWproject legitimately corrects it before this request completes.
  *
- * @ref resolvedIdentity is the exact installed description handed to JUCE. It
- * is retained so the request records the precise variant that is in flight;
- * completion does not try to re-resolve mutable model fields and infer whether
- * they still mean it. The assignment generation answers that directly.
+ * Only the stable assignment token decides whether the answer is still wanted.
+ * The display name makes an abandoned/failing request intelligible, and the
+ * resolved role is the one installed fact completion still needs. The full
+ * PluginDescription is deliberately not retained.
  */
 struct RequestedPlugin {
     magda::DeviceId deviceId = magda::INVALID_DEVICE_ID;
     std::uint64_t assignmentGeneration = 0;
-    juce::PluginDescription resolvedIdentity;
+    juce::String displayName;
+    bool resolvedIsInstrument = false;
 };
 
 /**
@@ -233,19 +266,18 @@ ExternalDeviceResult completeExternalPluginLoad(std::unique_ptr<juce::AudioPlugi
  * rather than a hand-off -- bindings are resolved when a plan is prepared, so a
  * device that arrives later is published and the plan prepared again.
  *
- * @p device is resolved and enriched synchronously before this function
- * returns, so its installed role and channel capabilities are visible to a
- * plan compiled while the plugin instance is still loading. That enrichment
- * preserves its assignment generation.
+ * The returned resolution carries the installed role and cached capabilities
+ * a plan compiled while the instance loads must use. The persistent @p device
+ * is never changed here; only a successful result carries live facts suitable
+ * for validation and publication.
  *
- * The enriched @p device is read once to work out which plugin to load.
+ * The saved @p device is read once to work out which plugin to load.
  * @p currentDevice is read again at completion, to work out what to restore
  * onto it; see CurrentDeviceLookup for why those are two different questions.
  */
-void createEngineExternalDeviceAsync(magda::DeviceInfo& device,
-                                     const ExternalPluginServices& services, bool offlineRender,
-                                     CurrentDeviceLookup currentDevice,
-                                     std::function<void(ExternalDeviceResult)> completed);
+ExternalPluginResolution createEngineExternalDeviceAsync(
+    const magda::DeviceInfo& device, const ExternalPluginServices& services, bool offlineRender,
+    CurrentDeviceLookup currentDevice, std::function<void(ExternalDeviceResult)> completed);
 
 /**
  * @brief Whether the scan knows the plugin @p device names.

--- a/magda/daw/core/DeviceInfo.cpp
+++ b/magda/daw/core/DeviceInfo.cpp
@@ -1,8 +1,15 @@
 #include "DeviceInfo.hpp"
 
+#include <atomic>
+
 #include "RackInfo.hpp"
 
 namespace magda {
+
+std::uint64_t nextPluginAssignmentGeneration() {
+    static std::atomic<std::uint64_t> generation{0};
+    return generation.fetch_add(1, std::memory_order_relaxed) + 1;
+}
 
 // Out of line because RackInfo is only complete once RackInfo.hpp has been
 // seen, and RackInfo.hpp includes DeviceInfo.hpp, so the header cannot see it.

--- a/magda/daw/core/DeviceInfo.hpp
+++ b/magda/daw/core/DeviceInfo.hpp
@@ -2,6 +2,7 @@
 
 #include <juce_core/juce_core.h>
 
+#include <cstdint>
 #include <memory>
 #include <optional>
 
@@ -14,6 +15,18 @@
 namespace magda {
 
 struct RackInfo;
+
+/**
+ * @brief A process-local serial number for a newly authored plugin assignment.
+ *
+ * This is deliberately not project data. A project load authors fresh live
+ * assignments, while copies of those DeviceInfo values carry the same number.
+ * The distinction is what an asynchronous plugin load needs: metadata and
+ * state edits copy or mutate the current assignment, while replacing a slot
+ * with a newly constructed DeviceInfo carries a different number even when
+ * both plugins have ambiguous or temporarily incomplete saved metadata.
+ */
+std::uint64_t nextPluginAssignmentGeneration();
 
 /**
  * @brief Value-semantic owner for a device's pad chains.
@@ -194,6 +207,13 @@ struct MeterInfo {
  */
 struct DeviceInfo {
     DeviceId id = INVALID_DEVICE_ID;
+
+    // Runtime identity of the plugin assignment in this slot. Copies preserve
+    // it; a newly constructed replacement gets another monotonically increasing
+    // value. Scan enrichment, parameter edits and preset restores must not
+    // change it. Transient by design: serializers neither read nor write it.
+    std::uint64_t pluginAssignmentGeneration = nextPluginAssignmentGeneration();
+
     juce::String name;  // Display name (e.g., "Pro-Q 3")
 
     // MAGDA's loader/model id for this device. For internal devices this is

--- a/magda/daw/core/DeviceInfo.hpp
+++ b/magda/daw/core/DeviceInfo.hpp
@@ -214,6 +214,17 @@ struct DeviceInfo {
     // change it. Transient by design: serializers neither read nor write it.
     std::uint64_t pluginAssignmentGeneration = nextPluginAssignmentGeneration();
 
+    /**
+     * Mark this slot as asking for a different plugin.
+     *
+     * Copies deliberately keep their token, because most copies are snapshots
+     * of the same assignment. Every path that authors a replacement from a
+     * copy or mutates plugin identity in place must come through here.
+     */
+    void beginNewPluginAssignment() {
+        pluginAssignmentGeneration = nextPluginAssignmentGeneration();
+    }
+
     juce::String name;  // Display name (e.g., "Pro-Q 3")
 
     // MAGDA's loader/model id for this device. For internal devices this is

--- a/magda/daw/core/DrumGridPads.cpp
+++ b/magda/daw/core/DrumGridPads.cpp
@@ -226,6 +226,7 @@ DeviceInfo deviceFromNode(const ds::Node& node) {
     // the only reason it had to read a nested plugin tree at all (#2207).
     if (const auto successor = legacy_devices::retiredDeviceSuccessor(savedType);
         successor.isNotEmpty()) {
+        device.beginNewPluginAssignment();
         for (const auto& slot :
              legacy_devices::convertRetiredDeviceState(savedType, [&node](const char* property) {
                  return node.props[juce::Identifier(property)];

--- a/magda/daw/core/LegacyDeviceAliases.cpp
+++ b/magda/daw/core/LegacyDeviceAliases.cpp
@@ -558,6 +558,8 @@ MigrationResult migrateDevice(DeviceInfo& device) {
     if (retired == nullptr)
         return MigrationResult::NotRetired;
 
+    device.beginNewPluginAssignment();
+
     const auto converted = convertSlots(
         *retired, [&device](int legacyIndex) { return retiredValue(device, legacyIndex); });
 

--- a/magda/daw/core/PluginCapabilities.cpp
+++ b/magda/daw/core/PluginCapabilities.cpp
@@ -277,9 +277,20 @@ void applyCachedCapabilitiesToDevice(DeviceInfo& device, const juce::String& plu
     if (!snapshot)
         return;
 
+    // These two are not written the same way, and the difference is the one
+    // PluginManagerSync::updateDeviceCapabilityFlags makes from the same
+    // snapshot. Two paths writing one model field by different rules would
+    // flip it on alternate loads.
+    //
+    // canReceiveMidi promotes only. A project's saved true can be true for
+    // reasons one scan of the installed plugin cannot see -- a MIDI-typed
+    // device, a plugin whose MIDI input the incumbent engine takes even though
+    // its AudioProcessor does not advertise it -- and PlanCompiler gates MIDI
+    // delivery on it, so assigning a scan's false over the model is a device
+    // that silently stops receiving MIDI.
     device.producesMidi = snapshot->hasMidiOutput;
-    if (!device.isInstrument)
-        device.canReceiveMidi = snapshot->hasMidiInput;
+    if (!device.isInstrument && snapshot->hasMidiInput)
+        device.canReceiveMidi = true;
 }
 
 }  // namespace magda

--- a/magda/daw/core/PluginCapabilities.cpp
+++ b/magda/daw/core/PluginCapabilities.cpp
@@ -269,14 +269,17 @@ bool supportsSidechainRoutingMenu(const DeviceInfo& device) {
 }
 
 void applyCachedCapabilitiesToDevice(DeviceInfo& device) {
-    const auto identifier = PluginCapabilityCache::identifierForDevice(device);
-    auto snapshot = PluginCapabilityCache::getInstance().find(identifier);
+    applyCachedCapabilitiesToDevice(device, PluginCapabilityCache::identifierForDevice(device));
+}
+
+void applyCachedCapabilitiesToDevice(DeviceInfo& device, const juce::String& pluginIdentifier) {
+    auto snapshot = PluginCapabilityCache::getInstance().find(pluginIdentifier);
     if (!snapshot)
         return;
 
     device.producesMidi = snapshot->hasMidiOutput;
-    if (!device.isInstrument && snapshot->hasMidiInput)
-        device.canReceiveMidi = true;
+    if (!device.isInstrument)
+        device.canReceiveMidi = snapshot->hasMidiInput;
 }
 
 }  // namespace magda

--- a/magda/daw/core/PluginCapabilities.hpp
+++ b/magda/daw/core/PluginCapabilities.hpp
@@ -86,5 +86,6 @@ bool supportsExternalMidiInputRouting(const DeviceInfo& device);
 bool supportsMidiSidechainSource(const DeviceInfo& device);
 bool supportsSidechainRoutingMenu(const DeviceInfo& device);
 void applyCachedCapabilitiesToDevice(DeviceInfo& device);
+void applyCachedCapabilitiesToDevice(DeviceInfo& device, const juce::String& pluginIdentifier);
 
 }  // namespace magda

--- a/magda/daw/core/TrackManager.cpp
+++ b/magda/daw/core/TrackManager.cpp
@@ -3504,6 +3504,7 @@ void TrackManager::notifyDeviceAdded(const ChainNodePath& devicePath, const Devi
 
 DeviceInfo TrackManager::prepareNewDevice(const DeviceInfo& device) {
     DeviceInfo newDevice = device;
+    newDevice.beginNewPluginAssignment();
     newDevice.id = nextFxDeviceId_++;
     rekeyPads(newDevice);
     applyCachedCapabilitiesToDevice(newDevice);
@@ -3530,6 +3531,7 @@ void TrackManager::rekeyPads(DeviceInfo& device, std::map<DeviceId, DeviceId>* r
 
             auto& padDevice = magda::getDevice(element);
             const auto oldId = padDevice.id;
+            padDevice.beginNewPluginAssignment();
             padDevice.id = allocateDeviceId();
 
             // Reported so a caller that also rewrites paths can follow the pad

--- a/magda/daw/core/TrackManager.cpp
+++ b/magda/daw/core/TrackManager.cpp
@@ -3523,7 +3523,7 @@ DeviceInfo TrackManager::prepareNewDevice(const DeviceInfo& device) {
     return newDevice;
 }
 
-void TrackManager::rekeyPads(DeviceInfo& device, std::map<DeviceId, DeviceId>* remap) {
+void TrackManager::rekeyPads(DeviceInfo& device, ChainIdRemap* remap) {
     if (!device.pads)
         return;
 
@@ -3533,23 +3533,19 @@ void TrackManager::rekeyPads(DeviceInfo& device, std::map<DeviceId, DeviceId>* r
     // would run whichever it saw last (#2207).
     stampPadRackId(device);
 
-    for (auto& pad : device.pads->chains) {
-        for (auto& element : pad.elements) {
-            if (!magda::isDevice(element))
-                continue;
-
-            auto& padDevice = magda::getDevice(element);
-            const auto oldId = padDevice.id;
-            padDevice.beginNewPluginAssignment();
-            padDevice.id = allocateDeviceId();
-
-            // Reported so a caller that also rewrites paths can follow the pad
-            // devices, which is what keeps a macro or a mod on the grid pointing
-            // at the pad it was linked to.
-            if (remap != nullptr && oldId != INVALID_DEVICE_ID)
-                (*remap)[oldId] = padDevice.id;
-        }
-    }
+    // A pad holds chain elements like any other chain, nested racks included,
+    // so the same recursive walk re-keys them. A shallow pass over the direct
+    // pad devices left everything inside a pad's rack carrying the source's
+    // DeviceIds and assignment tokens, so a copied grid shared ops with the one
+    // it came from and a late async load could complete onto the copy.
+    //
+    // Reported so a caller that also rewrites paths can follow the pad
+    // contents, which is what keeps a macro or a mod on the grid pointing at
+    // the pad it was linked to.
+    ChainIdRemap discarded;
+    auto& target = remap != nullptr ? *remap : discarded;
+    for (auto& pad : device.pads->chains)
+        reassignChainElementIds(pad.elements, target);
 }
 
 void TrackManager::notifyDeviceModifiersChanged(TrackId trackId) {

--- a/magda/daw/core/TrackManager.cpp
+++ b/magda/daw/core/TrackManager.cpp
@@ -1087,10 +1087,17 @@ TrackId TrackManager::duplicateTrack(TrackId trackId, bool includeDevices) {
     // DeviceId counter, so the copied devices must be re-stamped with fresh ids
     // from the right counter (sharing ids = sharing audio-engine plugin slots).
     // Empty when !includeDevices, so these loops are no-ops in that case.
-    for (auto& element : newTrack.chain.postFxChainElements)
+    // Each is a distinct live assignment for the same reason reassignChainElementIds
+    // mints one, and these two counters are section-local, so a copied device
+    // can otherwise land on an id another section is already using.
+    for (auto& element : newTrack.chain.postFxChainElements) {
+        element.device.beginNewPluginAssignment();
         element.device.id = nextPostFxDeviceId_++;
-    for (auto& element : newTrack.chain.mixerAnalysisElements)
+    }
+    for (auto& element : newTrack.chain.mixerAnalysisElements) {
+        element.device.beginNewPluginAssignment();
         element.device.id = nextMixerAnalysisDeviceId_++;
+    }
 
     // Log all device IDs after reassignment
     DBG("duplicateTrack: original trackId=" << trackId << " -> newTrackId=" << newTrack.id);
@@ -2212,6 +2219,7 @@ DeviceId TrackManager::addDeviceToPostFx(TrackId trackId, const DeviceInfo& devi
     }
 
     DeviceInfo newDevice = device;
+    newDevice.beginNewPluginAssignment();
     newDevice.id = nextPostFxDeviceId_++;
     applyCachedCapabilitiesToDevice(newDevice);
     if (daw::audio::isInternalAnalysisPlugin(newDevice.pluginId))
@@ -2277,6 +2285,7 @@ DeviceId TrackManager::addDeviceToMixerAnalysis(TrackId trackId, const DeviceInf
     }
 
     DeviceInfo newDevice = device;
+    newDevice.beginNewPluginAssignment();
     newDevice.id = nextMixerAnalysisDeviceId_++;
     applyCachedCapabilitiesToDevice(newDevice);
     if (daw::audio::isInternalAnalysisPlugin(newDevice.pluginId))

--- a/magda/daw/core/TrackManager.hpp
+++ b/magda/daw/core/TrackManager.hpp
@@ -549,10 +549,11 @@ class TrackManager : public daw::audio::DeviceIdAllocator, public daw::audio::De
     // Re-derive a pad-per-chain device's rack id and re-key its pad devices,
     // for a copy that arrived carrying the ids of the device it came from.
     // Both ids are DeviceIds in disguise, so a copy that kept them would key
-    // the original's ops (#2207). `remap`, when given, collects the pad
-    // devices' old-to-new ids so a caller that also rewrites paths can follow
-    // them.
-    void rekeyPads(DeviceInfo& device, std::map<DeviceId, DeviceId>* remap = nullptr);
+    // the original's ops (#2207). A pad's contents are chain elements like any
+    // other, nested racks included, so the whole subtree is re-keyed rather
+    // than the direct pad devices alone. `remap`, when given, collects the
+    // old-to-new ids so a caller that also rewrites paths can follow them.
+    void rekeyPads(DeviceInfo& device, ChainIdRemap* remap = nullptr);
 
     // The pad chain answering to a pad, mutable. Private because a pad property
     // is set through the setters above, which notify.

--- a/magda/daw/core/TrackManagerDevices.cpp
+++ b/magda/daw/core/TrackManagerDevices.cpp
@@ -1938,6 +1938,13 @@ void TrackManager::reassignChainElementIds(std::vector<ChainElement>& elements,
         if (magda::isDevice(element)) {
             auto& device = magda::getDevice(element);
             const auto oldDeviceId = device.id;
+
+            // A re-keyed element is a distinct live assignment, not a snapshot
+            // of the one it was copied from: it gets its own plugin instance,
+            // and DeviceIds are reused after clearAllTracks(). Without a fresh
+            // token an async load requested by the original would match the
+            // copy and restore one plugin's state onto another.
+            device.beginNewPluginAssignment();
             device.id = allocateDeviceId();
             remap.devices[oldDeviceId] = device.id;
 

--- a/tests/test_device_api.cpp
+++ b/tests/test_device_api.cpp
@@ -4,6 +4,7 @@
 #include <set>
 
 #include "magda/daw/api/device_api_live.hpp"
+#include "magda/daw/core/DrumGridPads.hpp"
 #include "magda/daw/core/TrackCommands.hpp"
 #include "magda/daw/core/TrackManager.hpp"
 #include "magda/daw/core/UndoManager.hpp"
@@ -178,6 +179,60 @@ TEST_CASE("A duplicated track's devices are distinct assignments from the origin
     const auto& copiedPostFx = tracks.getPostFxChainElements(copyId);
     REQUIRE(copiedPostFx.size() == 1);
     CHECK(copiedPostFx.front().device.pluginAssignmentGeneration != sourcePostFxGeneration);
+}
+
+TEST_CASE("A pad's nested rack is re-keyed along with the pad itself", "[device-api][inspection]") {
+    // Pads hold chain elements like any other chain, so a pre-populated Drum
+    // Grid can arrive with a rack inside a pad. A walk that stopped at the
+    // direct pad devices left everything under that rack carrying the source's
+    // DeviceIds -- keying the original's ops -- and its assignment tokens, so a
+    // late async load could complete onto the copy.
+    auto& tracks = TrackManager::getInstance();
+    const auto trackId = freshTrack("Track");
+
+    DeviceInfo nested;
+    nested.name = "Nested effect";
+    nested.pluginId = "template-effect";
+    nested.id = 4242;
+    const auto nestedGeneration = nested.pluginAssignmentGeneration;
+
+    auto rack = std::make_unique<RackInfo>();
+    rack->id = 9911;
+    ChainInfo rackChain;
+    rackChain.id = 8811;
+    rackChain.elements.push_back(ChainElement{nested});
+    rack->chains.push_back(std::move(rackChain));
+
+    DeviceInfo grid;
+    grid.name = "Grid";
+    grid.pluginId = "drumgrid";
+    auto& pads = magda::ensurePads(grid);
+    magda::ensurePadChain(pads, 0).elements.push_back(ChainElement{std::move(rack)});
+
+    const auto gridId = tracks.addDeviceToTrack(trackId, grid);
+    REQUIRE(gridId != INVALID_DEVICE_ID);
+
+    const auto* live = tracks.getDevice(trackId, gridId);
+    REQUIRE(live != nullptr);
+    REQUIRE(static_cast<bool>(live->pads));
+    REQUIRE(live->pads->chains.size() == 1);
+
+    const auto& padElements = live->pads->chains.front().elements;
+    REQUIRE(padElements.size() == 1);
+    REQUIRE(magda::isRack(padElements.front()));
+
+    const auto& liveRack = magda::getRack(padElements.front());
+    CHECK(liveRack.id != 9911);
+    REQUIRE(liveRack.chains.size() == 1);
+    CHECK(liveRack.chains.front().id != 8811);
+
+    const auto& nestedElements = liveRack.chains.front().elements;
+    REQUIRE(nestedElements.size() == 1);
+    REQUIRE(magda::isDevice(nestedElements.front()));
+
+    const auto& liveNested = magda::getDevice(nestedElements.front());
+    CHECK(liveNested.id != 4242);
+    CHECK(liveNested.pluginAssignmentGeneration != nestedGeneration);
 }
 
 TEST_CASE("Device parameters are reported in real units", "[device-api][inspection]") {

--- a/tests/test_device_api.cpp
+++ b/tests/test_device_api.cpp
@@ -76,6 +76,30 @@ TEST_CASE("Live device lookup rejects paths that address nothing", "[device-api]
     REQUIRE(devices.getDeviceParameters(missing).empty());
 }
 
+TEST_CASE("Each device added from a reusable template gets a fresh plugin assignment token",
+          "[device-api][inspection]") {
+    auto& tracks = TrackManager::getInstance();
+    const auto trackId = freshTrack("Track");
+
+    DeviceInfo browserTemplate;
+    browserTemplate.name = "Reusable effect";
+    browserTemplate.pluginId = "template-effect";
+    const auto templateGeneration = browserTemplate.pluginAssignmentGeneration;
+
+    const auto firstId = tracks.addDeviceToTrack(trackId, browserTemplate);
+    const auto secondId = tracks.addDeviceToTrack(trackId, browserTemplate);
+    REQUIRE(firstId != INVALID_DEVICE_ID);
+    REQUIRE(secondId != INVALID_DEVICE_ID);
+
+    const auto* first = tracks.getDevice(trackId, firstId);
+    const auto* second = tracks.getDevice(trackId, secondId);
+    REQUIRE(first != nullptr);
+    REQUIRE(second != nullptr);
+    CHECK(first->pluginAssignmentGeneration != templateGeneration);
+    CHECK(second->pluginAssignmentGeneration != templateGeneration);
+    CHECK(first->pluginAssignmentGeneration != second->pluginAssignmentGeneration);
+}
+
 TEST_CASE("Device parameters are reported in real units", "[device-api][inspection]") {
     auto& tracks = TrackManager::getInstance();
     tracks.clearAllTracks();

--- a/tests/test_device_api.cpp
+++ b/tests/test_device_api.cpp
@@ -100,6 +100,86 @@ TEST_CASE("Each device added from a reusable template gets a fresh plugin assign
     CHECK(first->pluginAssignmentGeneration != second->pluginAssignmentGeneration);
 }
 
+TEST_CASE("Devices sharing a DeviceId across sections still hold distinct assignment tokens",
+          "[device-api][inspection]") {
+    // The three sections keep independent DeviceId counters that all start at
+    // 1, so a top-level, a post-FX and a mixer-analysis device can carry the
+    // same bare id. The assignment token is what tells an arriving async load
+    // which of them it was asked for, and completeExternalPluginLoad accepts a
+    // matching (id, token) pair as proof the load is still wanted.
+    auto& tracks = TrackManager::getInstance();
+    const auto trackId = freshTrack("Track");
+
+    DeviceInfo effect;
+    effect.name = "Reusable effect";
+    effect.pluginId = "template-effect";
+
+    const auto topLevelId = tracks.addDeviceToTrack(trackId, effect);
+    const auto postFxId = tracks.addDeviceToPostFx(trackId, effect);
+    REQUIRE(topLevelId != INVALID_DEVICE_ID);
+    REQUIRE(postFxId != INVALID_DEVICE_ID);
+
+    const auto* topLevel = tracks.getDevice(trackId, topLevelId);
+    REQUIRE(topLevel != nullptr);
+
+    const auto& postFx = tracks.getPostFxChainElements(trackId);
+    REQUIRE(postFx.size() == 1);
+
+    CHECK(postFx.front().device.pluginAssignmentGeneration != topLevel->pluginAssignmentGeneration);
+    CHECK(postFx.front().device.pluginAssignmentGeneration != effect.pluginAssignmentGeneration);
+}
+
+TEST_CASE("A mixer-analysis device gets its own assignment token", "[device-api][inspection]") {
+    auto& tracks = TrackManager::getInstance();
+    const auto trackId = freshTrack("Track");
+
+    DeviceInfo analysis;
+    analysis.name = "Reusable analyser";
+    analysis.pluginId = "template-analyser";
+
+    REQUIRE(tracks.addDeviceToMixerAnalysis(trackId, analysis) != INVALID_DEVICE_ID);
+
+    const auto& elements = tracks.getMixerAnalysisElements(trackId);
+    REQUIRE(elements.size() == 1);
+    CHECK(elements.front().device.pluginAssignmentGeneration !=
+          analysis.pluginAssignmentGeneration);
+}
+
+TEST_CASE("A duplicated track's devices are distinct assignments from the originals",
+          "[device-api][inspection]") {
+    auto& tracks = TrackManager::getInstance();
+    const auto trackId = freshTrack("Track");
+
+    DeviceInfo effect;
+    effect.name = "Reusable effect";
+    effect.pluginId = "template-effect";
+
+    const auto sourceId = tracks.addDeviceToTrack(trackId, effect);
+    REQUIRE(sourceId != INVALID_DEVICE_ID);
+    REQUIRE(tracks.addDeviceToPostFx(trackId, effect) != INVALID_DEVICE_ID);
+
+    const auto* source = tracks.getDevice(trackId, sourceId);
+    REQUIRE(source != nullptr);
+    const auto sourceGeneration = source->pluginAssignmentGeneration;
+    const auto sourcePostFxGeneration =
+        tracks.getPostFxChainElements(trackId).front().device.pluginAssignmentGeneration;
+
+    const auto copyId = tracks.duplicateTrack(trackId);
+    REQUIRE(copyId != INVALID_TRACK_ID);
+
+    // The copy runs its own plugin instances, and DeviceIds are handed out
+    // again after clearAllTracks(), so a shared token would let a load the
+    // original requested complete onto the copy.
+    const auto& copiedTopLevel = tracks.getChainElements(copyId);
+    REQUIRE_FALSE(copiedTopLevel.empty());
+    REQUIRE(magda::isDevice(copiedTopLevel.front()));
+    CHECK(magda::getDevice(copiedTopLevel.front()).pluginAssignmentGeneration != sourceGeneration);
+
+    const auto& copiedPostFx = tracks.getPostFxChainElements(copyId);
+    REQUIRE(copiedPostFx.size() == 1);
+    CHECK(copiedPostFx.front().device.pluginAssignmentGeneration != sourcePostFxGeneration);
+}
+
 TEST_CASE("Device parameters are reported in real units", "[device-api][inspection]") {
     auto& tracks = TrackManager::getInstance();
     tracks.clearAllTracks();

--- a/tests/test_engine_external_device.cpp
+++ b/tests/test_engine_external_device.cpp
@@ -184,7 +184,7 @@ class StubPlugin final : public juce::AudioPluginInstance {
     }
 
     bool acceptsMidi() const override {
-        return true;
+        return takesMidi;
     }
 
     bool producesMidi() const override {
@@ -245,6 +245,17 @@ class StubPlugin final : public juce::AudioPluginInstance {
         tone->setValue(state.tone);
         fixed->setValue(state.fixed);
         ++stateRestores;
+
+        // A patch that changes the plugin's own topology, which real ones do:
+        // a sampler whose preset turns its drum outs on, an instrument that
+        // goes stereo for one program and mono for another. Anything that read
+        // the width before the chunk was applied is now describing a layout
+        // this instance no longer has.
+        if (widensOutputOnState) {
+            auto layout = getBusesLayout();
+            layout.outputBuses.getReference(0) = juce::AudioChannelSet::stereo();
+            setBusesLayout(layout);
+        }
     }
 
     /// The per-channel offset the output carries, so a test can name which of
@@ -258,6 +269,14 @@ class StubPlugin final : public juce::AudioPluginInstance {
     int stateRestores = 0;
 
     bool emitsMidi = false;
+
+    /// Whether the processor advertises MIDI input at all. A real plugin can
+    /// say no here while the incumbent engine still takes MIDI input for it.
+    bool takesMidi = true;
+
+    /// Whether restoring the chunk widens the main output bus (see
+    /// setStateInformation).
+    bool widensOutputOnState = false;
 
     /// Third-party code handed a chunk it cannot read. Some throw.
     bool throwsOnState = false;
@@ -1307,6 +1326,61 @@ TEST_CASE("Successful adaptation reports live buses and MIDI capabilities", "[en
     // Publication belongs to the caller and only happens after success.
     CHECK(model.audioInputChannels == 9);
     CHECK(model.audioOutputChannels == 9);
+}
+
+TEST_CASE("A plugin that does not advertise MIDI input cannot clear the project's flag",
+          "[engine][external]") {
+    // The incumbent engine takes MIDI input for plugins whose AudioProcessor
+    // says no, so the model's true is evidence the instance does not have.
+    // Assigning over it would leave PlanCompiler routing no MIDI to a device
+    // that had been receiving it.
+    auto plugin = std::make_unique<StubPlugin>(2, 2, 0);
+    plugin->takesMidi = false;
+
+    auto model = externalDevice();
+    model.canReceiveMidi = true;
+
+    const auto result = adapter::adaptExternalPluginInstance(std::move(plugin), model);
+
+    REQUIRE(result.device != nullptr);
+    REQUIRE(result.resolvedDevice.has_value());
+    CHECK(result.resolvedDevice->canReceiveMidi);
+}
+
+TEST_CASE("An instrument keeps its MIDI flag off however the instance answers",
+          "[engine][external]") {
+    auto plugin = std::make_unique<StubPlugin>(2, 2, 0);
+    auto model = externalDevice();
+    model.isInstrument = true;
+
+    const auto result = adapter::adaptExternalPluginInstance(std::move(plugin), model);
+
+    REQUIRE(result.resolvedDevice.has_value());
+    CHECK_FALSE(result.resolvedDevice->canReceiveMidi);
+}
+
+TEST_CASE("Channel widths are read after the plugin's own state is restored",
+          "[engine][external]") {
+    // A chunk is free to change the layout it is restored into. The widths the
+    // plan compiles from have to be the ones the instance ends up with, since
+    // EngineExternalDevice::prepare() goes on to process that layout.
+    auto plugin = std::make_unique<StubPlugin>(2, 1, 0);
+    plugin->widensOutputOnState = true;
+    auto* raw = plugin.get();
+
+    const StubPlugin::State saved{.tone = 0.5f, .fixed = 0.5f};
+    juce::MemoryBlock chunk(&saved, sizeof(saved));
+
+    auto model = externalDevice();
+    model.pluginState = chunk.toBase64Encoding();
+
+    const auto result = adapter::adaptExternalPluginInstance(std::move(plugin), model);
+
+    REQUIRE(result.device != nullptr);
+    REQUIRE(result.resolvedDevice.has_value());
+    CHECK(raw->stateRestores == 1);
+    CHECK(raw->getTotalNumOutputChannels() == 2);
+    CHECK(result.resolvedDevice->audioOutputChannels == 2);
 }
 
 TEST_CASE("Saved state that is not a chunk this plugin understands is refused",

--- a/tests/test_engine_external_device.cpp
+++ b/tests/test_engine_external_device.cpp
@@ -277,6 +277,65 @@ class StubPlugin final : public juce::AudioPluginInstance {
     juce::AudioPlayHead::PositionInfo positionSeen;
 };
 
+/// A real AudioPluginFormat seam for the asynchronous factory test. The
+/// format manager still performs its normal lookup and message-thread delivery;
+/// only the binary behind the description is local to the test.
+class StubFormat final : public juce::AudioPluginFormat {
+  public:
+    juce::String getName() const override {
+        return "StubFormat";
+    }
+
+    void findAllTypesForFile(juce::OwnedArray<juce::PluginDescription>&,
+                             const juce::String&) override {}
+
+    bool fileMightContainThisPluginType(const juce::String&) override {
+        return true;
+    }
+
+    juce::String getNameOfPluginFromIdentifier(const juce::String&) override {
+        return "Stub";
+    }
+
+    bool pluginNeedsRescanning(const juce::PluginDescription&) override {
+        return false;
+    }
+
+    bool doesPluginStillExist(const juce::PluginDescription&) override {
+        return true;
+    }
+
+    bool canScanForPlugins() const override {
+        return false;
+    }
+
+    bool isTrivialToScan() const override {
+        return true;
+    }
+
+    juce::StringArray searchPathsForPlugins(const juce::FileSearchPath&, bool, bool) override {
+        return {};
+    }
+
+    juce::FileSearchPath getDefaultLocationsToSearch() override {
+        return {};
+    }
+
+    bool requiresUnblockedMessageThreadDuringCreation(
+        const juce::PluginDescription&) const override {
+        return false;
+    }
+
+    juce::PluginDescription requested;
+
+  private:
+    void createPluginInstance(const juce::PluginDescription& description, double, int,
+                              PluginCreationCallback callback) override {
+        requested = description;
+        callback(std::make_unique<StubPlugin>(2, 2, 0), {});
+    }
+};
+
 magda::engine::RenderContext contextFor(int channels = 2, int blockSize = 64) {
     return {.sampleRate = 48000.0, .maxBlockSize = blockSize, .numChannels = channels};
 }
@@ -329,9 +388,11 @@ juce::PluginDescription descriptionFor(const magda::DeviceInfo& device) {
 adapter::RequestedPlugin requestFor(
     const magda::DeviceInfo& device,
     const std::optional<juce::PluginDescription>& resolved = std::nullopt) {
+    const auto description = resolved.value_or(descriptionFor(device));
     return {.deviceId = device.id,
             .assignmentGeneration = device.pluginAssignmentGeneration,
-            .resolvedIdentity = resolved.value_or(descriptionFor(device))};
+            .displayName = device.name,
+            .resolvedIsInstrument = description.isInstrument};
 }
 
 /**
@@ -769,6 +830,66 @@ TEST_CASE("A host that gave the engine no formats is told so", "[engine][externa
     CHECK(result.failure.contains("no plugin formats"));
 }
 
+TEST_CASE("Resolution returns planning facts without rewriting the saved assignment",
+          "[engine][external]") {
+    auto model = externalDevice();
+    model.name = "My imported synth";  // user/import display label
+    model.pluginId = "saved-plugin-key";
+    model.uniqueId = "saved-preference-key";
+    model.manufacturer = "Saved vendor";
+    model.fileOrIdentifier = "/Library/Stub.vst3";
+    model.audioInputChannels = 2;
+    model.audioOutputChannels = 2;
+    const auto generation = model.pluginAssignmentGeneration;
+
+    auto installed = descriptionFor(model);
+    installed.name = "Scanner's canonical name";
+    installed.manufacturerName = "Installed vendor";
+    installed.pluginFormatName = "UnknownFutureFormat";
+    installed.isInstrument = true;
+    installed.numInputChannels = 0;
+    installed.numOutputChannels = 0;
+
+    juce::KnownPluginList known;
+    known.addType(installed);
+    juce::AudioPluginFormatManager formats;
+    const adapter::ExternalPluginServices services{
+        .formats = &formats, .knownPlugins = &known, .context = contextFor()};
+
+    const auto resolved = adapter::resolveEngineExternalPlugin(model, services);
+    REQUIRE(resolved);
+
+    // The persistent assignment is untouched, including preference keys,
+    // display text, placement role and widths last observed from a live host.
+    CHECK(model.name == "My imported synth");
+    CHECK(model.pluginId == "saved-plugin-key");
+    CHECK(model.uniqueId == "saved-preference-key");
+    CHECK(model.manufacturer == "Saved vendor");
+    CHECK_FALSE(model.isInstrument);
+    CHECK(model.deviceType == magda::DeviceType::Effect);
+    CHECK(model.audioInputChannels == 2);
+    CHECK(model.audioOutputChannels == 2);
+    CHECK(model.pluginAssignmentGeneration == generation);
+
+    // The transient copy carries only the role needed for placement validation
+    // and plan compilation. Zero/default scan buses are not treated as live.
+    CHECK(resolved.planDevice.name == model.name);
+    CHECK(resolved.planDevice.pluginId == model.pluginId);
+    CHECK(resolved.planDevice.uniqueId == model.uniqueId);
+    CHECK(resolved.planDevice.format == model.format);
+    CHECK(resolved.planDevice.isInstrument);
+    CHECK(resolved.planDevice.deviceType == magda::DeviceType::Instrument);
+    CHECK(resolved.planDevice.audioInputChannels == 2);
+    CHECK(resolved.planDevice.audioOutputChannels == 2);
+
+    auto analysis = model;
+    analysis.deviceType = magda::DeviceType::Analysis;
+    const auto resolvedAnalysis = adapter::resolveEngineExternalPlugin(analysis, services);
+    REQUIRE(resolvedAnalysis);
+    CHECK(resolvedAnalysis.planDevice.deviceType == magda::DeviceType::Analysis);
+    CHECK_FALSE(resolvedAnalysis.planDevice.isInstrument);
+}
+
 TEST_CASE("A plugin with more inputs than outputs fills the slot from its outputs",
           "[engine][external]") {
     // Stereo in, mono out, and a mono sidechain after them: processed at three
@@ -1166,6 +1287,28 @@ TEST_CASE("A device with no saved state keeps the plugin's defaults", "[engine][
     CHECK(raw->stateRestores == 0);
 }
 
+TEST_CASE("Successful adaptation reports live buses and MIDI capabilities", "[engine][external]") {
+    auto plugin = std::make_unique<StubPlugin>(2, 2, 1, 2);
+    plugin->emitsMidi = true;
+
+    auto model = externalDevice();
+    model.audioInputChannels = 9;
+    model.audioOutputChannels = 9;
+
+    const auto result = adapter::adaptExternalPluginInstance(std::move(plugin), model);
+
+    REQUIRE(result.device != nullptr);
+    REQUIRE(result.resolvedDevice.has_value());
+    CHECK(result.resolvedDevice->audioInputChannels == 3);
+    CHECK(result.resolvedDevice->audioOutputChannels == 6);
+    CHECK(result.resolvedDevice->canReceiveMidi);
+    CHECK(result.resolvedDevice->producesMidi);
+
+    // Publication belongs to the caller and only happens after success.
+    CHECK(model.audioInputChannels == 9);
+    CHECK(model.audioOutputChannels == 9);
+}
+
 TEST_CASE("Saved state that is not a chunk this plugin understands is refused",
           "[engine][external]") {
     // A chunk written by another plugin, or by another version of this one. The
@@ -1213,6 +1356,73 @@ TEST_CASE("The asynchronous entry point reports a missing plugin the same way",
     CHECK(delivered.device == nullptr);
     CHECK(delivered.failure.contains("Massive X"));
     CHECK(delivered.restoredParameters.empty());
+}
+
+TEST_CASE("The asynchronous entry point resolves once and completes an installed plugin",
+          "[engine][external]") {
+    juce::ScopedJuceInitialiser_GUI juce;
+
+    auto model = externalDevice();
+    model.name = "My Stub";
+    model.fileOrIdentifier = "stub.plugin";
+    model.isInstrument = false;
+    model.deviceType = magda::DeviceType::Effect;
+    model.audioInputChannels = 1;
+    model.audioOutputChannels = 1;
+    const auto generation = model.pluginAssignmentGeneration;
+
+    auto installed = descriptionFor(model);
+    installed.name = "Installed Stub";
+    installed.pluginFormatName = "StubFormat";
+    installed.fileOrIdentifier = model.fileOrIdentifier;
+    installed.isInstrument = true;
+    installed.numInputChannels = 0;
+    installed.numOutputChannels = 0;
+
+    juce::KnownPluginList known;
+    known.addType(installed);
+    juce::AudioPluginFormatManager formats;
+    auto stubFormat = std::make_unique<StubFormat>();
+    auto* rawFormat = stubFormat.get();
+    formats.addFormat(std::move(stubFormat));
+
+    const adapter::ExternalPluginServices services{
+        .formats = &formats, .knownPlugins = &known, .context = contextFor()};
+
+    bool called = false;
+    adapter::ExternalDeviceResult delivered;
+    const auto resolved = adapter::createEngineExternalDeviceAsync(
+        model, services, false, [&](magda::DeviceId) { return &model; },
+        [&](adapter::ExternalDeviceResult result) {
+            called = true;
+            delivered = std::move(result);
+        });
+
+    REQUIRE(resolved);
+    CHECK(resolved.planDevice.isInstrument);
+    CHECK(resolved.planDevice.deviceType == magda::DeviceType::Instrument);
+    CHECK(resolved.planDevice.audioInputChannels == 1);
+    CHECK(resolved.planDevice.audioOutputChannels == 1);
+
+    // Starting the request does not rewrite a placed model or publish scan bus
+    // defaults before JUCE has made an instance.
+    CHECK_FALSE(model.isInstrument);
+    CHECK(model.deviceType == magda::DeviceType::Effect);
+    CHECK(model.audioInputChannels == 1);
+    CHECK(model.audioOutputChannels == 1);
+    CHECK(model.pluginAssignmentGeneration == generation);
+
+    for (int attempts = 0; !called && attempts < 100; ++attempts)
+        juce::MessageManager::getInstance()->runDispatchLoopUntil(10);
+
+    REQUIRE(called);
+    REQUIRE(delivered.device != nullptr);
+    REQUIRE(delivered.resolvedDevice.has_value());
+    CHECK(delivered.resolvedDevice->isInstrument);
+    CHECK(delivered.resolvedDevice->deviceType == magda::DeviceType::Instrument);
+    CHECK(delivered.resolvedDevice->audioInputChannels == 2);
+    CHECK(delivered.resolvedDevice->audioOutputChannels == 2);
+    CHECK(rawFormat->requested.createIdentifierString() == installed.createIdentifierString());
 }
 
 TEST_CASE("A load that finishes late restores from the model as it is now", "[engine][external]") {
@@ -1285,17 +1495,13 @@ TEST_CASE("A device that changed plugin while loading is not completed", "[engin
     auto plugin = std::make_unique<StubPlugin>(2, 2, 0);
 
     auto model = externalDevice();
-    auto requestedDevice = model;
-    requestedDevice.name = "Massive X";
-    requestedDevice.fileOrIdentifier = "/Library/MassiveX.vst3";
-    model = requestedDevice;
+    model.name = "Massive X";
+    model.fileOrIdentifier = "/Library/MassiveX.vst3";
     const auto requested = requestFor(model);
 
-    auto replacement = externalDevice();
-    replacement.id = model.id;
-    replacement.name = "Something Else";
-    replacement.fileOrIdentifier = "/Library/SomethingElse.vst3";
-    model = std::move(replacement);
+    model.beginNewPluginAssignment();
+    model.name = "Something Else";
+    model.fileOrIdentifier = "/Library/SomethingElse.vst3";
 
     const auto result = adapter::completeExternalPluginLoad(
         std::move(plugin), {}, requested, [&](magda::DeviceId) { return &model; });
@@ -1393,14 +1599,8 @@ TEST_CASE("An imported device swapped to the other half of its bundle is a chang
 
     const auto requested = requestFor(model);
 
-    auto replacement = externalDeviceSaving(1.0f, 0.5f);
-    replacement.id = model.id;
-    replacement.name = model.name;
-    replacement.manufacturer = model.manufacturer;
-    replacement.fileOrIdentifier = model.fileOrIdentifier;
-    replacement.isInstrument = true;
-    replacement.uniqueId = {};
-    model = std::move(replacement);
+    model.beginNewPluginAssignment();
+    model.isInstrument = true;
 
     auto plugin = std::make_unique<StubPlugin>(2, 2, 0);
     const auto result = adapter::completeExternalPluginLoad(
@@ -1422,13 +1622,9 @@ TEST_CASE("An imported device swapped to another vendor's plugin is a change",
 
     const auto requested = requestFor(model);
 
-    auto replacement = externalDeviceSaving(1.0f, 0.5f);
-    replacement.id = model.id;
-    replacement.name = model.name;
-    replacement.manufacturer = "Another";
-    replacement.fileOrIdentifier = "/Another/Saturator.vst3";
-    replacement.uniqueId = {};
-    model = std::move(replacement);
+    model.beginNewPluginAssignment();
+    model.manufacturer = "Another";
+    model.fileOrIdentifier = "/Another/Saturator.vst3";
 
     auto plugin = std::make_unique<StubPlugin>(2, 2, 0);
     const auto result = adapter::completeExternalPluginLoad(

--- a/tests/test_engine_external_device.cpp
+++ b/tests/test_engine_external_device.cpp
@@ -5,6 +5,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <cstring>
 #include <memory>
+#include <optional>
 #include <stdexcept>
 #include <vector>
 
@@ -317,6 +318,20 @@ magda::DeviceInfo externalDeviceSaving(float gain, float tone) {
     device.parameters[0].currentValue = gain;
     device.parameters[1].currentValue = tone;
     return device;
+}
+
+juce::PluginDescription descriptionFor(const magda::DeviceInfo& device) {
+    auto description = magda::describeSavedPlugin(device);
+    description.uniqueId = device.name.hashCode();
+    return description;
+}
+
+adapter::RequestedPlugin requestFor(
+    const magda::DeviceInfo& device,
+    const std::optional<juce::PluginDescription>& resolved = std::nullopt) {
+    return {.deviceId = device.id,
+            .assignmentGeneration = device.pluginAssignmentGeneration,
+            .resolvedIdentity = resolved.value_or(descriptionFor(device))};
 }
 
 /**
@@ -1188,7 +1203,7 @@ TEST_CASE("The asynchronous entry point reports a missing plugin the same way",
     bool called = false;
     adapter::ExternalDeviceResult delivered;
     adapter::createEngineExternalDeviceAsync(
-        missing, services, false, [&]() { return &missing; },
+        missing, services, false, [&](magda::DeviceId) { return &missing; },
         [&](adapter::ExternalDeviceResult result) {
             called = true;
             delivered = std::move(result);
@@ -1210,14 +1225,13 @@ TEST_CASE("A load that finishes late restores from the model as it is now", "[en
     auto* raw = plugin.get();
 
     auto model = externalDeviceSaving(1.0f, 0.25f);
-    const adapter::RequestedPlugin requested{.identity = magda::savedPluginIdentity(model),
-                                             .name = model.name};
+    const auto requested = requestFor(model);
 
     // The edit, made while the plugin was loading.
     model.parameters[1].currentValue = 0.6f;
 
-    const auto result = adapter::completeExternalPluginLoad(std::move(plugin), {}, requested,
-                                                            [&]() { return &model; });
+    const auto result = adapter::completeExternalPluginLoad(
+        std::move(plugin), {}, requested, [&](magda::DeviceId) { return &model; });
 
     REQUIRE(result.device != nullptr);
     CHECK(raw->tone->getValue() == Catch::Approx(0.6f));
@@ -1229,14 +1243,37 @@ TEST_CASE("A load that finishes late restores from the model as it is now", "[en
     CHECK(tone->value == Catch::Approx(0.6f));
 }
 
+TEST_CASE("State applied while a plugin loads is the state that gets restored",
+          "[engine][external]") {
+    auto plugin = std::make_unique<StubPlugin>(2, 2, 0);
+    auto* raw = plugin.get();
+
+    auto model = externalDeviceSaving(1.0f, 0.25f);
+    const auto requested = requestFor(model);
+
+    // A preset selected after the load began. Its chunk is the current model's
+    // authority at completion, not the empty state on the request-time copy.
+    const StubPlugin::State preset{.tone = 0.8f, .fixed = 0.7f};
+    const juce::MemoryBlock chunk(&preset, sizeof(preset));
+    model.pluginState = chunk.toBase64Encoding();
+
+    const auto result = adapter::completeExternalPluginLoad(
+        std::move(plugin), {}, requested, [&](magda::DeviceId) { return &model; });
+
+    REQUIRE(result.device != nullptr);
+    CHECK(raw->stateRestores == 1);
+    CHECK(raw->tone->getValue() == Catch::Approx(0.8f));
+    CHECK(raw->fixed->getValue() == Catch::Approx(0.7f));
+}
+
 TEST_CASE("A device deleted while its plugin loaded is not completed", "[engine][external]") {
     auto plugin = std::make_unique<StubPlugin>(2, 2, 0);
 
     const auto device = externalDevice();
-    const adapter::RequestedPlugin requested{.identity = magda::savedPluginIdentity(device),
-                                             .name = device.name};
+    const auto requested = requestFor(device);
     const auto result = adapter::completeExternalPluginLoad(
-        std::move(plugin), {}, requested, []() -> const magda::DeviceInfo* { return nullptr; });
+        std::move(plugin), {}, requested,
+        [](magda::DeviceId) -> const magda::DeviceInfo* { return nullptr; });
 
     CHECK(result.device == nullptr);
     CHECK(result.failure.contains("removed while"));
@@ -1248,17 +1285,20 @@ TEST_CASE("A device that changed plugin while loading is not completed", "[engin
     auto plugin = std::make_unique<StubPlugin>(2, 2, 0);
 
     auto model = externalDevice();
-    model.name = "Something Else";
-    model.fileOrIdentifier = "/Library/SomethingElse.vst3";
-
-    auto requestedDevice = externalDevice();
+    auto requestedDevice = model;
     requestedDevice.name = "Massive X";
     requestedDevice.fileOrIdentifier = "/Library/MassiveX.vst3";
-    const adapter::RequestedPlugin requested{
-        .identity = magda::savedPluginIdentity(requestedDevice), .name = requestedDevice.name};
+    model = requestedDevice;
+    const auto requested = requestFor(model);
 
-    const auto result = adapter::completeExternalPluginLoad(std::move(plugin), {}, requested,
-                                                            [&]() { return &model; });
+    auto replacement = externalDevice();
+    replacement.id = model.id;
+    replacement.name = "Something Else";
+    replacement.fileOrIdentifier = "/Library/SomethingElse.vst3";
+    model = std::move(replacement);
+
+    const auto result = adapter::completeExternalPluginLoad(
+        std::move(plugin), {}, requested, [&](magda::DeviceId) { return &model; });
 
     CHECK(result.device == nullptr);
     CHECK(result.failure.contains("changed plugin"));
@@ -1266,11 +1306,10 @@ TEST_CASE("A device that changed plugin while loading is not completed", "[engin
 
 TEST_CASE("A load that failed reports the loader's reason", "[engine][external]") {
     auto model = externalDevice();
-    const adapter::RequestedPlugin requested{.identity = magda::savedPluginIdentity(model),
-                                             .name = model.name};
+    const auto requested = requestFor(model);
 
-    const auto result = adapter::completeExternalPluginLoad(nullptr, "the file was not there",
-                                                            requested, [&]() { return &model; });
+    const auto result = adapter::completeExternalPluginLoad(
+        nullptr, "the file was not there", requested, [&](magda::DeviceId) { return &model; });
 
     CHECK(result.device == nullptr);
     CHECK(result.failure.contains("the file was not there"));
@@ -1296,37 +1335,46 @@ TEST_CASE("A scanned plugin's own identifier is not read as a change", "[engine]
     model.fileOrIdentifier = scanned.fileOrIdentifier;
     model.uniqueId = scanned.createIdentifierString();
 
-    const adapter::RequestedPlugin requested{.identity = magda::savedPluginIdentity(model),
-                                             .name = scanned.name};
+    const auto requested = requestFor(model, scanned);
 
     auto plugin = std::make_unique<StubPlugin>(2, 2, 0);
     auto* raw = plugin.get();
 
-    const auto result = adapter::completeExternalPluginLoad(std::move(plugin), {}, requested,
-                                                            [&]() { return &model; });
+    const auto result = adapter::completeExternalPluginLoad(
+        std::move(plugin), {}, requested, [&](magda::DeviceId) { return &model; });
 
     REQUIRE(result.device != nullptr);
     CHECK(result.failure.isEmpty());
     CHECK(raw->tone->getValue() == Catch::Approx(0.5f));
 }
 
-TEST_CASE("A device that gained a scanned identifier has not changed plugin",
+TEST_CASE("Resolved metadata gained while loading does not change the assignment",
           "[engine][external]") {
-    // An imported project has no identifier until something resolves it. The
-    // device gaining one while its plugin loaded is not a change of plugin, and
-    // a comparison that read it as one would throw away a good load.
+    // Resolution may correct every mutable identity-looking field. They are
+    // newly learned facts about this assignment, not the identity boundary.
     auto model = externalDeviceSaving(1.0f, 0.5f);
-    model.name = "Massive X";
-    model.fileOrIdentifier = "/Library/MassiveX.vst3";
+    model.name = "Serum";
+    model.manufacturer = {};
+    model.fileOrIdentifier = "/old/Serum.vst3";
+    model.isInstrument = false;  // DAWproject role was wrong
+    model.uniqueId = {};
 
-    const adapter::RequestedPlugin requested{.identity = magda::savedPluginIdentity(model),
-                                             .name = model.name};
+    auto resolved = descriptionFor(model);
+    resolved.manufacturerName = "Xfer Records";
+    resolved.fileOrIdentifier = "/Library/Serum.vst3";
+    resolved.isInstrument = true;
+    resolved.uniqueId = 0x53657275;
+    const auto requested = requestFor(model, resolved);
 
-    model.uniqueId = "VST3-Massive X-1234abcd-4d617373";
+    model.manufacturer = "Xfer Records";
+    model.fileOrIdentifier = "/Library/Serum.vst3";
+    model.isInstrument = true;
+    model.deviceType = magda::DeviceType::Instrument;
+    model.uniqueId = "VST3-Serum-1234abcd-4d617373";
 
     auto plugin = std::make_unique<StubPlugin>(2, 2, 0);
-    const auto result = adapter::completeExternalPluginLoad(std::move(plugin), {}, requested,
-                                                            [&]() { return &model; });
+    const auto result = adapter::completeExternalPluginLoad(
+        std::move(plugin), {}, requested, [&](magda::DeviceId) { return &model; });
 
     REQUIRE(result.device != nullptr);
     CHECK(result.failure.isEmpty());
@@ -1334,13 +1382,8 @@ TEST_CASE("A device that gained a scanned identifier has not changed plugin",
 
 TEST_CASE("An imported device swapped to the other half of its bundle is a change",
           "[engine][external]") {
-    // A bundle shipping an effect and an instrument of the same name out of one
-    // file is the case the lookup's first pass exists for, and it is the case
-    // JUCE's identifier string cannot see: that string carries the format, the
-    // name and a hash of the file, and neither the vendor nor the role. An
-    // imported device has no saved identifier to fall back on, so swapping to
-    // the other variant while a load is in flight has to be caught by the
-    // fields themselves.
+    // The generation distinguishes two assignments even where JUCE's compact
+    // identifier and all bundle-level metadata do not.
     auto model = externalDeviceSaving(1.0f, 0.5f);
     model.name = "Kontakt";
     model.manufacturer = "NI";
@@ -1348,15 +1391,20 @@ TEST_CASE("An imported device swapped to the other half of its bundle is a chang
     model.isInstrument = false;
     model.uniqueId = {};  // imported: nothing scanned it
 
-    const adapter::RequestedPlugin requested{.identity = magda::savedPluginIdentity(model),
-                                             .name = model.name};
+    const auto requested = requestFor(model);
 
-    // The swap: the instrument out of the same bundle.
-    model.isInstrument = true;
+    auto replacement = externalDeviceSaving(1.0f, 0.5f);
+    replacement.id = model.id;
+    replacement.name = model.name;
+    replacement.manufacturer = model.manufacturer;
+    replacement.fileOrIdentifier = model.fileOrIdentifier;
+    replacement.isInstrument = true;
+    replacement.uniqueId = {};
+    model = std::move(replacement);
 
     auto plugin = std::make_unique<StubPlugin>(2, 2, 0);
-    const auto result = adapter::completeExternalPluginLoad(std::move(plugin), {}, requested,
-                                                            [&]() { return &model; });
+    const auto result = adapter::completeExternalPluginLoad(
+        std::move(plugin), {}, requested, [&](magda::DeviceId) { return &model; });
 
     CHECK(result.device == nullptr);
     CHECK(result.failure.contains("changed plugin"));
@@ -1364,23 +1412,27 @@ TEST_CASE("An imported device swapped to the other half of its bundle is a chang
 
 TEST_CASE("An imported device swapped to another vendor's plugin is a change",
           "[engine][external]") {
-    // The same gap, from the other side: the identifier string leaves the
-    // vendor out too, so two plugins of one name shipped by different vendors
-    // are one identity to it.
+    // The same gap from the other side: display metadata is not asked to carry
+    // request lifetime identity.
     auto model = externalDeviceSaving(1.0f, 0.5f);
     model.name = "Saturator";
     model.manufacturer = "One";
     model.fileOrIdentifier = "/Library/Saturator.vst3";
     model.uniqueId = {};
 
-    const adapter::RequestedPlugin requested{.identity = magda::savedPluginIdentity(model),
-                                             .name = model.name};
+    const auto requested = requestFor(model);
 
-    model.manufacturer = "Another";
+    auto replacement = externalDeviceSaving(1.0f, 0.5f);
+    replacement.id = model.id;
+    replacement.name = model.name;
+    replacement.manufacturer = "Another";
+    replacement.fileOrIdentifier = "/Another/Saturator.vst3";
+    replacement.uniqueId = {};
+    model = std::move(replacement);
 
     auto plugin = std::make_unique<StubPlugin>(2, 2, 0);
-    const auto result = adapter::completeExternalPluginLoad(std::move(plugin), {}, requested,
-                                                            [&]() { return &model; });
+    const auto result = adapter::completeExternalPluginLoad(
+        std::move(plugin), {}, requested, [&](magda::DeviceId) { return &model; });
 
     CHECK(result.device == nullptr);
     CHECK(result.failure.contains("changed plugin"));

--- a/tests/test_external_plugin_lookup.cpp
+++ b/tests/test_external_plugin_lookup.cpp
@@ -144,37 +144,20 @@ TEST_CASE("A project from another host resolves by name and format", "[plugins][
     CHECK(match.description.manufacturerName == "Xfer Records");
 }
 
-TEST_CASE("Resolved scan facts enrich the assignment without replacing it", "[plugins][lookup]") {
-    auto device = saved("Serum", "", "/old/Serum.vst3", false);
-    device.deviceType = magda::DeviceType::Effect;
-    const auto generation = device.pluginAssignmentGeneration;
-
-    auto description = installed("Serum", "Xfer Records", "/Library/Serum.vst3", true);
-    description.numInputChannels = 0;
-    description.numOutputChannels = 8;
-
-    magda::applyResolvedPluginDescription(device, description);
-
-    CHECK(device.pluginAssignmentGeneration == generation);
-    CHECK(device.name == "Serum");
-    CHECK(device.pluginId == description.createIdentifierString());
-    CHECK(device.uniqueId == description.createIdentifierString());
-    CHECK(device.manufacturer == "Xfer Records");
-    CHECK(device.fileOrIdentifier == "/Library/Serum.vst3");
-    CHECK(device.isInstrument);
-    CHECK(device.deviceType == magda::DeviceType::Instrument);
-    CHECK(device.audioInputChannels == 0);
-    CHECK(device.audioOutputChannels == 8);
-}
-
-TEST_CASE("Plugin assignment generations survive copies and change for replacements",
+TEST_CASE("Plugin assignment generations survive snapshots and explicitly change for replacements",
           "[plugins][lookup]") {
-    const auto assignment = saved("Kontakt", "NI", "/Library/Kontakt.vst3", true);
+    auto assignment = saved("Kontakt", "NI", "/Library/Kontakt.vst3", true);
     const auto copy = assignment;
-    const auto replacement = saved("Kontakt", "NI", "/Library/Kontakt.vst3", false);
+    const auto originalGeneration = assignment.pluginAssignmentGeneration;
 
-    CHECK(copy.pluginAssignmentGeneration == assignment.pluginAssignmentGeneration);
-    CHECK(replacement.pluginAssignmentGeneration > assignment.pluginAssignmentGeneration);
+    // Production replacement paths mutate an existing DeviceInfo or copy a
+    // browser template, so replacement identity is authored explicitly rather
+    // than inferred from C++ object construction.
+    assignment.beginNewPluginAssignment();
+    assignment.isInstrument = false;
+
+    CHECK(copy.pluginAssignmentGeneration == originalGeneration);
+    CHECK(assignment.pluginAssignmentGeneration > originalGeneration);
 }
 
 TEST_CASE("The format is part of the last pass", "[plugins][lookup]") {

--- a/tests/test_external_plugin_lookup.cpp
+++ b/tests/test_external_plugin_lookup.cpp
@@ -144,6 +144,39 @@ TEST_CASE("A project from another host resolves by name and format", "[plugins][
     CHECK(match.description.manufacturerName == "Xfer Records");
 }
 
+TEST_CASE("Resolved scan facts enrich the assignment without replacing it", "[plugins][lookup]") {
+    auto device = saved("Serum", "", "/old/Serum.vst3", false);
+    device.deviceType = magda::DeviceType::Effect;
+    const auto generation = device.pluginAssignmentGeneration;
+
+    auto description = installed("Serum", "Xfer Records", "/Library/Serum.vst3", true);
+    description.numInputChannels = 0;
+    description.numOutputChannels = 8;
+
+    magda::applyResolvedPluginDescription(device, description);
+
+    CHECK(device.pluginAssignmentGeneration == generation);
+    CHECK(device.name == "Serum");
+    CHECK(device.pluginId == description.createIdentifierString());
+    CHECK(device.uniqueId == description.createIdentifierString());
+    CHECK(device.manufacturer == "Xfer Records");
+    CHECK(device.fileOrIdentifier == "/Library/Serum.vst3");
+    CHECK(device.isInstrument);
+    CHECK(device.deviceType == magda::DeviceType::Instrument);
+    CHECK(device.audioInputChannels == 0);
+    CHECK(device.audioOutputChannels == 8);
+}
+
+TEST_CASE("Plugin assignment generations survive copies and change for replacements",
+          "[plugins][lookup]") {
+    const auto assignment = saved("Kontakt", "NI", "/Library/Kontakt.vst3", true);
+    const auto copy = assignment;
+    const auto replacement = saved("Kontakt", "NI", "/Library/Kontakt.vst3", false);
+
+    CHECK(copy.pluginAssignmentGeneration == assignment.pluginAssignmentGeneration);
+    CHECK(replacement.pluginAssignmentGeneration > assignment.pluginAssignmentGeneration);
+}
+
 TEST_CASE("The format is part of the last pass", "[plugins][lookup]") {
     // Same name, different format. An AU is not a substitute for the VST3 a
     // project saved: the two have different parameter lists and different

--- a/tests/test_legacy_device_aliases.cpp
+++ b/tests/test_legacy_device_aliases.cpp
@@ -75,6 +75,7 @@ TEST_CASE("Retired Tracktion devices resolve to their successor by every stored 
 
 TEST_CASE("Migrating a retired device rewrites its identity", "[devices][legacy][aliases]") {
     auto device = retiredDevice("reverb", {param(0, 0.5f)});
+    const auto retiredGeneration = device.pluginAssignmentGeneration;
     device.name = "Reverb";  // still the stock name
     device.pluginState = "<PLUGIN type=\"reverb\"/>";
     device.visibleParameters = {0, 1, 2};
@@ -83,13 +84,16 @@ TEST_CASE("Migrating a retired device rewrites its identity", "[devices][legacy]
 
     CHECK(device.pluginId == "magda_reverb");
     CHECK(device.uniqueId == "magda_reverb");
+    CHECK(device.pluginAssignmentGeneration > retiredGeneration);
     CHECK(device.name == "Reverb");
     // State and index lists described a plugin that no longer exists.
     CHECK(device.pluginState.isEmpty());
     CHECK(device.visibleParameters.empty());
 
     // Idempotent: a second pass finds nothing to do.
+    const auto successorGeneration = device.pluginAssignmentGeneration;
     CHECK_FALSE(legacy_devices::migrateRetiredDevice(device));
+    CHECK(device.pluginAssignmentGeneration == successorGeneration);
 }
 
 TEST_CASE("Migration keeps a user-renamed device's name", "[devices][legacy][aliases]") {


### PR DESCRIPTION
## Summary

- give each live plugin assignment a transient, monotonically generated token that survives model copies but changes for replacement devices
- apply the exact resolved plugin metadata, role, and channel topology before native plan compilation
- complete async loads only when the captured device ID and assignment token still match, while restoring parameters and plugin state from the current model
- cover metadata enrichment, incorrect imported instrument roles, same-bundle variants, same-name plugins from different vendors, deletion, and in-flight parameter/state edits

## Tests

- cmake --build cmake-build-debug --target magda_tests -j8
- magda_tests [engine][external] — 41 cases, 137 assertions
- magda_tests [plugins][lookup] — 13 cases, 32 assertions
- magda_tests [engine][plan][compiler] — 55 cases, 431 assertions
- magda_tests [project][serialization][device] — 6 cases, 56 assertions

Closes #2252