### PR TITLE
Own plugin-assignment identity at runtime, not in DeviceInfo (#2261)

### DIFF
--- a/magda/daw/audio/CMakeLists.txt
+++ b/magda/daw/audio/CMakeLists.txt
@@ -309,6 +309,8 @@ set(_magda_engine_device_adapter_sources
     "${CMAKE_CURRENT_SOURCE_DIR}/plugins/engine/EngineExternalDevice.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/plugins/engine/EngineMagdaDevice.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/plugins/engine/EngineMagdaDevice.hpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/plugins/engine/PluginAssignments.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/plugins/engine/PluginAssignments.hpp"
 )
 list(REMOVE_ITEM _magda_device_pack_sources ${_magda_engine_device_adapter_sources})
 

--- a/magda/daw/audio/plugins/engine/EngineDeviceFactory.cpp
+++ b/magda/daw/audio/plugins/engine/EngineDeviceFactory.cpp
@@ -318,6 +318,19 @@ ExternalPluginResolution createEngineExternalDeviceAsync(
                                      .resolvedIsInstrument = resolved.description.isInstrument},
          currentDevice = std::move(currentDevice), offlineRender, completed = std::move(completed)](
             std::unique_ptr<juce::AudioPluginInstance> instance, const juce::String& error) {
+            // The lifetime gate, before anything is called rather than after.
+            // This lambda is stored by JUCE and run a turn or more later, and
+            // `completed` is the runtime's own: it publishes the device into the
+            // project and reports the failures. A runtime that is gone has
+            // nowhere to publish and nobody to tell, so calling it at all is the
+            // use-after-free -- refusing inside it would already be too late.
+            //
+            // Deliberately not isStillWanted(): a device deleted while its
+            // runtime lives is a load to refuse *and say so about*, because
+            // something is still waiting to hear it.
+            if (!requested.assignment.runtimeIsAlive())
+                return;
+
             completed(completeExternalPluginLoad(std::move(instance), error, requested,
                                                  currentDevice, offlineRender));
         });

--- a/magda/daw/audio/plugins/engine/EngineDeviceFactory.cpp
+++ b/magda/daw/audio/plugins/engine/EngineDeviceFactory.cpp
@@ -255,27 +255,38 @@ ExternalDeviceResult createEngineExternalDevice(const magda::DeviceInfo& device,
 ExternalDeviceResult completeExternalPluginLoad(std::unique_ptr<juce::AudioPluginInstance> instance,
                                                 const juce::String& error,
                                                 const RequestedPlugin& requested,
+                                                const PluginAssignments& assignments,
                                                 const CurrentDeviceLookup& currentDevice,
                                                 bool offlineRender) {
-    // The model first, before anything is done with the instance. Everything
+    const auto& requestedName = requested.displayName;
+
+    // The identity boundary, and the first thing asked. Scan metadata may have
+    // changed in every field while the plugin loaded, including the role the
+    // plan compiles from; those are facts learned about this assignment, not
+    // about another one, so none of them is consulted here. What decides is
+    // whether the runtime still holds the very assignment the load was started
+    // against, which no copy of the model can carry and no unregistered device
+    // can claim.
+    if (!assignments.accepts(requested.assignment)) {
+        // Which of the two it was, for a person reading the log: a key nothing
+        // holds any more is a device that went away, and a key held under a
+        // different assignment is a slot that is now asking for something else.
+        const auto replaced = static_cast<bool>(assignments.current(requested.assignment.key));
+        return {.device = {},
+                .failure =
+                    replaced
+                        ? "the device changed plugin while \"" + requestedName + "\" was loading"
+                        : "the device was removed while \"" + requestedName + "\" was loading"};
+    }
+
+    // Then the model, before anything is done with the instance. Everything
     // below restores from it, and it is a different object from the one the
     // load was requested with: seconds have passed.
-    const auto* device = currentDevice ? currentDevice(requested.deviceId) : nullptr;
-
-    const auto& requestedName = requested.displayName;
+    const auto* device = currentDevice ? currentDevice(requested.assignment.key) : nullptr;
 
     if (device == nullptr)
         return {.device = {},
                 .failure = "the device was removed while \"" + requestedName + "\" was loading"};
-
-    // This is the identity boundary. Scan metadata may have changed in every
-    // field while the plugin loaded, including the role the plan compiles from;
-    // those are facts learned about this assignment, not another assignment.
-    // A replacement DeviceInfo carries a newly authored generation even when
-    // it is another variant in the same bundle or has the same display name.
-    if (device->pluginAssignmentGeneration != requested.assignmentGeneration)
-        return {.device = {},
-                .failure = "the device changed plugin while \"" + requestedName + "\" was loading"};
 
     if (instance == nullptr)
         return {.device = {},
@@ -288,8 +299,10 @@ ExternalDeviceResult completeExternalPluginLoad(std::unique_ptr<juce::AudioPlugi
 }
 
 ExternalPluginResolution createEngineExternalDeviceAsync(
-    const magda::DeviceInfo& device, const ExternalPluginServices& services, bool offlineRender,
-    CurrentDeviceLookup currentDevice, std::function<void(ExternalDeviceResult)> completed) {
+    const magda::DeviceInfo& device, magda::engine::DeviceKey key,
+    const ExternalPluginServices& services, bool offlineRender,
+    const PluginAssignments& assignments, CurrentDeviceLookup currentDevice,
+    std::function<void(ExternalDeviceResult)> completed) {
     jassert(completed != nullptr);
     jassert(currentDevice != nullptr);
 
@@ -301,13 +314,13 @@ ExternalPluginResolution createEngineExternalDeviceAsync(
 
     services.formats->createPluginInstanceAsync(
         resolved.description, services.context.sampleRate, services.context.maxBlockSize,
-        [requested = RequestedPlugin{.deviceId = device.id,
-                                     .assignmentGeneration = device.pluginAssignmentGeneration,
+        [requested = RequestedPlugin{.assignment = assignments.request(key),
                                      .displayName = device.name,
                                      .resolvedIsInstrument = resolved.description.isInstrument},
-         currentDevice = std::move(currentDevice), offlineRender, completed = std::move(completed)](
-            std::unique_ptr<juce::AudioPluginInstance> instance, const juce::String& error) {
-            completed(completeExternalPluginLoad(std::move(instance), error, requested,
+         &assignments, currentDevice = std::move(currentDevice), offlineRender,
+         completed = std::move(completed)](std::unique_ptr<juce::AudioPluginInstance> instance,
+                                           const juce::String& error) {
+            completed(completeExternalPluginLoad(std::move(instance), error, requested, assignments,
                                                  currentDevice, offlineRender));
         });
 

--- a/magda/daw/audio/plugins/engine/EngineDeviceFactory.cpp
+++ b/magda/daw/audio/plugins/engine/EngineDeviceFactory.cpp
@@ -255,7 +255,6 @@ ExternalDeviceResult createEngineExternalDevice(const magda::DeviceInfo& device,
 ExternalDeviceResult completeExternalPluginLoad(std::unique_ptr<juce::AudioPluginInstance> instance,
                                                 const juce::String& error,
                                                 const RequestedPlugin& requested,
-                                                const PluginAssignments& assignments,
                                                 const CurrentDeviceLookup& currentDevice,
                                                 bool offlineRender) {
     const auto& requestedName = requested.displayName;
@@ -267,14 +266,14 @@ ExternalDeviceResult completeExternalPluginLoad(std::unique_ptr<juce::AudioPlugi
     // whether the runtime still holds the very assignment the load was started
     // against, which no copy of the model can carry and no unregistered device
     // can claim.
-    if (!assignments.accepts(requested.assignment)) {
-        // Which of the two it was, for a person reading the log: a key nothing
-        // holds any more is a device that went away, and a key held under a
-        // different assignment is a slot that is now asking for something else.
-        const auto replaced = static_cast<bool>(assignments.current(requested.assignment.key));
+    if (!requested.assignment.isStillWanted()) {
+        // Which of the two it was, for a person reading the log: a key held
+        // under a different assignment is a slot now asking for something else,
+        // and anything else -- a released key, a runtime that is gone, a
+        // registration nobody made -- is a device there is no longer one of.
         return {.device = {},
                 .failure =
-                    replaced
+                    requested.assignment.keyWasReassigned()
                         ? "the device changed plugin while \"" + requestedName + "\" was loading"
                         : "the device was removed while \"" + requestedName + "\" was loading"};
     }
@@ -317,10 +316,9 @@ ExternalPluginResolution createEngineExternalDeviceAsync(
         [requested = RequestedPlugin{.assignment = assignments.request(key),
                                      .displayName = device.name,
                                      .resolvedIsInstrument = resolved.description.isInstrument},
-         &assignments, currentDevice = std::move(currentDevice), offlineRender,
-         completed = std::move(completed)](std::unique_ptr<juce::AudioPluginInstance> instance,
-                                           const juce::String& error) {
-            completed(completeExternalPluginLoad(std::move(instance), error, requested, assignments,
+         currentDevice = std::move(currentDevice), offlineRender, completed = std::move(completed)](
+            std::unique_ptr<juce::AudioPluginInstance> instance, const juce::String& error) {
+            completed(completeExternalPluginLoad(std::move(instance), error, requested,
                                                  currentDevice, offlineRender));
         });
 

--- a/magda/daw/audio/plugins/engine/EngineDeviceFactory.hpp
+++ b/magda/daw/audio/plugins/engine/EngineDeviceFactory.hpp
@@ -9,8 +9,10 @@
 #include "core/DeviceInfo.hpp"
 #include "exec/EngineDevice.hpp"
 #include "exec/RenderContext.hpp"
+#include "plan/RenderPlan.hpp"
 #include "plugin_manager/ExternalPluginLookup.hpp"
 #include "plugin_manager/ExternalPluginState.hpp"
+#include "plugins/engine/PluginAssignments.hpp"
 
 /**
  * @file EngineDeviceFactory.hpp
@@ -217,24 +219,28 @@ ExternalDeviceResult createEngineExternalDevice(const magda::DeviceInfo& device,
  * So the model is read at completion rather than captured at request. Null
  * means the device is gone, and the load is abandoned rather than completed
  * against a project that no longer has it.
+ *
+ * Keyed on engine::DeviceKey, not on a bare DeviceId: DeviceId is allocated per
+ * section, so the main FX, post-FX and mixer-analysis sections can each hold the
+ * same integer and a bare one names up to three devices.
  */
-using CurrentDeviceLookup = std::function<const magda::DeviceInfo*(magda::DeviceId deviceId)>;
+using CurrentDeviceLookup = std::function<const magda::DeviceInfo*(magda::engine::DeviceKey)>;
 
 /**
  * @brief What an asynchronous load remembers about what it asked for.
  *
- * The device id and assignment generation are the stable question the loader
- * is answering. Saved plugin metadata is not: resolving a moved plugin or an
- * imported DAWproject legitimately corrects it before this request completes.
+ * The assignment is the stable question the loader is answering, and it is a
+ * weak reference to something the runtime owns rather than anything read off
+ * the model (PluginAssignments.hpp). Saved plugin metadata is not part of the
+ * question: resolving a moved plugin or an imported DAWproject legitimately
+ * corrects it before this request completes.
  *
- * Only the stable assignment token decides whether the answer is still wanted.
  * The display name makes an abandoned/failing request intelligible, and the
  * resolved role is the one installed fact completion still needs. The full
  * PluginDescription is deliberately not retained.
  */
 struct RequestedPlugin {
-    magda::DeviceId deviceId = magda::INVALID_DEVICE_ID;
-    std::uint64_t assignmentGeneration = 0;
+    LoadRequest assignment;
     juce::String displayName;
     bool resolvedIsInstrument = false;
 };
@@ -246,13 +252,21 @@ struct RequestedPlugin {
  * calls it directly. @p error is what the loader reported, used only when @p
  * instance is null.
  *
- * It resolves @p currentDevice by the captured id first. A device that has gone,
- * or whose assignment generation changed, is a load whose answer arrived too
- * late to be useful. Mutable plugin metadata is deliberately not compared.
+ * @p assignments is asked first, and it is the identity boundary: the load is
+ * completed only onto the assignment it was requested for. A device that was
+ * deleted, had its plugin replaced, was duplicated or pasted from, or whose id
+ * was handed out again after the project was cleared, no longer holds that
+ * assignment. Nor does one that was never registered, which is why a forgotten
+ * registration refuses the load instead of accepting it. Mutable plugin
+ * metadata is deliberately not compared.
+ *
+ * @p currentDevice then supplies the model to restore from, read now rather
+ * than captured when the load was requested.
  */
 ExternalDeviceResult completeExternalPluginLoad(std::unique_ptr<juce::AudioPluginInstance> instance,
                                                 const juce::String& error,
                                                 const RequestedPlugin& requested,
+                                                const PluginAssignments& assignments,
                                                 const CurrentDeviceLookup& currentDevice,
                                                 bool offlineRender = false);
 
@@ -274,10 +288,18 @@ ExternalDeviceResult completeExternalPluginLoad(std::unique_ptr<juce::AudioPlugi
  * The saved @p device is read once to work out which plugin to load.
  * @p currentDevice is read again at completion, to work out what to restore
  * onto it; see CurrentDeviceLookup for why those are two different questions.
+ *
+ * @p key says which live device this is being loaded for, and @p assignments is
+ * asked for the assignment that key holds now. It has to outlive the load,
+ * which it does by construction: it is owned by whatever runs the plugins, and
+ * a load with nothing to complete onto is a load nothing is waiting for. A key
+ * with no assignment yields a request that completion refuses.
  */
 ExternalPluginResolution createEngineExternalDeviceAsync(
-    const magda::DeviceInfo& device, const ExternalPluginServices& services, bool offlineRender,
-    CurrentDeviceLookup currentDevice, std::function<void(ExternalDeviceResult)> completed);
+    const magda::DeviceInfo& device, magda::engine::DeviceKey key,
+    const ExternalPluginServices& services, bool offlineRender,
+    const PluginAssignments& assignments, CurrentDeviceLookup currentDevice,
+    std::function<void(ExternalDeviceResult)> completed);
 
 /**
  * @brief Whether the scan knows the plugin @p device names.

--- a/magda/daw/audio/plugins/engine/EngineDeviceFactory.hpp
+++ b/magda/daw/audio/plugins/engine/EngineDeviceFactory.hpp
@@ -252,13 +252,18 @@ struct RequestedPlugin {
  * calls it directly. @p error is what the loader reported, used only when @p
  * instance is null.
  *
- * @p assignments is asked first, and it is the identity boundary: the load is
- * completed only onto the assignment it was requested for. A device that was
- * deleted, had its plugin replaced, was duplicated or pasted from, or whose id
- * was handed out again after the project was cleared, no longer holds that
- * assignment. Nor does one that was never registered, which is why a forgotten
- * registration refuses the load instead of accepting it. Mutable plugin
+ * The requested assignment is asked first, and it is the identity boundary: the
+ * load is completed only onto the assignment it was requested for. A device
+ * that was deleted, had its plugin replaced, was duplicated or pasted from, or
+ * whose id was handed out again after the project was cleared, no longer holds
+ * that assignment. Nor does one that was never registered, which is why a
+ * forgotten registration refuses the load instead of accepting it, nor one
+ * whose whole runtime went away while the plugin loaded. Mutable plugin
  * metadata is deliberately not compared.
+ *
+ * Nothing but @p requested is needed for that, which is why it is a value:
+ * a completion arriving after the runtime is gone answers from weak references
+ * that have expired, rather than by reaching into it.
  *
  * @p currentDevice then supplies the model to restore from, read now rather
  * than captured when the load was requested.
@@ -266,7 +271,6 @@ struct RequestedPlugin {
 ExternalDeviceResult completeExternalPluginLoad(std::unique_ptr<juce::AudioPluginInstance> instance,
                                                 const juce::String& error,
                                                 const RequestedPlugin& requested,
-                                                const PluginAssignments& assignments,
                                                 const CurrentDeviceLookup& currentDevice,
                                                 bool offlineRender = false);
 
@@ -290,10 +294,11 @@ ExternalDeviceResult completeExternalPluginLoad(std::unique_ptr<juce::AudioPlugi
  * onto it; see CurrentDeviceLookup for why those are two different questions.
  *
  * @p key says which live device this is being loaded for, and @p assignments is
- * asked for the assignment that key holds now. It has to outlive the load,
- * which it does by construction: it is owned by whatever runs the plugins, and
- * a load with nothing to complete onto is a load nothing is waiting for. A key
- * with no assignment yields a request that completion refuses.
+ * read once, here, for the assignment that key holds now. It is not captured:
+ * the request that comes out of it is self-contained and holds weak references,
+ * so a runtime destroyed while a plugin is still loading is a load that expires
+ * rather than a dangling one. A key with no assignment yields a request that
+ * completion refuses.
  */
 ExternalPluginResolution createEngineExternalDeviceAsync(
     const magda::DeviceInfo& device, magda::engine::DeviceKey key,

--- a/magda/daw/audio/plugins/engine/EngineDeviceFactory.hpp
+++ b/magda/daw/audio/plugins/engine/EngineDeviceFactory.hpp
@@ -299,6 +299,13 @@ ExternalDeviceResult completeExternalPluginLoad(std::unique_ptr<juce::AudioPlugi
  * so a runtime destroyed while a plugin is still loading is a load that expires
  * rather than a dangling one. A key with no assignment yields a request that
  * completion refuses.
+ *
+ * That expiry also gates @p completed. It is the runtime's own callback -- it
+ * publishes the device into the project and reports the failures -- so if the
+ * runtime that owns @p assignments is destroyed before the plugin arrives, it
+ * is not called at all. A caller therefore does not have to make its completion
+ * survive its own destruction; it has to keep the assignments alive for exactly
+ * as long as it wants to hear about loads, which is the same thing said once.
  */
 ExternalPluginResolution createEngineExternalDeviceAsync(
     const magda::DeviceInfo& device, magda::engine::DeviceKey key,

--- a/magda/daw/audio/plugins/engine/PluginAssignments.cpp
+++ b/magda/daw/audio/plugins/engine/PluginAssignments.cpp
@@ -34,6 +34,10 @@ bool LoadRequest::keyWasReassigned() const {
     return now != nullptr && now != handle.lock();
 }
 
+bool LoadRequest::runtimeIsAlive() const {
+    return !table.expired();
+}
+
 PluginAssignments::PluginAssignments() : table_(std::make_shared<AssignmentTable>()) {}
 
 ActiveAssignment PluginAssignments::ensureAssignment(magda::engine::DeviceKey key) {

--- a/magda/daw/audio/plugins/engine/PluginAssignments.cpp
+++ b/magda/daw/audio/plugins/engine/PluginAssignments.cpp
@@ -5,46 +5,73 @@
 
 namespace magda::daw::audio::engine_adapter {
 
-ActiveAssignment PluginAssignments::assign(magda::engine::DeviceKey key) {
+std::shared_ptr<const AssignmentHandle> AssignmentTable::find(magda::engine::DeviceKey key) const {
+    const auto it = byKey_.find(key);
+    return it != byKey_.end() ? it->second : nullptr;
+}
+
+bool LoadRequest::isStillWanted() const {
+    const auto live = table.lock();
+    if (live == nullptr)
+        return false;
+
+    const auto held = handle.lock();
+    if (held == nullptr)
+        return false;
+
+    // Locking is not enough on its own. A caller holding the ActiveAssignment
+    // it was handed keeps the handle alive past the release, so the table is
+    // what decides: this key must still be this assignment.
+    return live->find(key) == held;
+}
+
+bool LoadRequest::keyWasReassigned() const {
+    const auto live = table.lock();
+    if (live == nullptr)
+        return false;
+
+    const auto now = live->find(key);
+    return now != nullptr && now != handle.lock();
+}
+
+PluginAssignments::PluginAssignments() : table_(std::make_shared<AssignmentTable>()) {}
+
+ActiveAssignment PluginAssignments::ensureAssignment(magda::engine::DeviceKey key) {
+    if (auto held = table_->find(key); held != nullptr)
+        return {.key = key, .handle = std::move(held)};
+
+    return replaceAssignment(key);
+}
+
+ActiveAssignment PluginAssignments::replaceAssignment(magda::engine::DeviceKey key) {
     // Assigned rather than merged: a key that already had a handle is being
     // reused, and the previous assignment's requests must expire.
     auto handle = std::make_shared<const AssignmentHandle>();
-    live_[key] = handle;
+    table_->byKey_[key] = handle;
     return {.key = key, .handle = std::move(handle)};
 }
 
 ActiveAssignment PluginAssignments::current(magda::engine::DeviceKey key) const {
-    const auto it = live_.find(key);
-    if (it == live_.end())
+    auto held = table_->find(key);
+    if (held == nullptr)
         return {};
-    return {.key = key, .handle = it->second};
+    return {.key = key, .handle = std::move(held)};
 }
 
 LoadRequest PluginAssignments::request(magda::engine::DeviceKey key) const {
-    const auto it = live_.find(key);
-    if (it == live_.end())
-        return {.key = key, .handle = {}};
-    return {.key = key, .handle = it->second};
+    return {.key = key, .handle = table_->find(key), .table = table_};
 }
 
 void PluginAssignments::release(magda::engine::DeviceKey key) {
-    live_.erase(key);
+    table_->byKey_.erase(key);
 }
 
 void PluginAssignments::releaseAll() {
-    live_.clear();
+    table_->byKey_.clear();
 }
 
-bool PluginAssignments::accepts(const LoadRequest& request) const {
-    const auto held = request.handle.lock();
-    if (held == nullptr)
-        return false;
-
-    // Locking alone is not enough. A caller holding the ActiveAssignment it was
-    // handed keeps the handle alive past the release, so the live set is what
-    // decides: this key must still be this assignment.
-    const auto it = live_.find(request.key);
-    return it != live_.end() && it->second == held;
+std::size_t PluginAssignments::size() const {
+    return table_->byKey_.size();
 }
 
 }  // namespace magda::daw::audio::engine_adapter

--- a/magda/daw/audio/plugins/engine/PluginAssignments.cpp
+++ b/magda/daw/audio/plugins/engine/PluginAssignments.cpp
@@ -1,0 +1,50 @@
+#include "plugins/engine/PluginAssignments.hpp"
+
+#include <memory>
+#include <utility>
+
+namespace magda::daw::audio::engine_adapter {
+
+ActiveAssignment PluginAssignments::assign(magda::engine::DeviceKey key) {
+    // Assigned rather than merged: a key that already had a handle is being
+    // reused, and the previous assignment's requests must expire.
+    auto handle = std::make_shared<const AssignmentHandle>();
+    live_[key] = handle;
+    return {.key = key, .handle = std::move(handle)};
+}
+
+ActiveAssignment PluginAssignments::current(magda::engine::DeviceKey key) const {
+    const auto it = live_.find(key);
+    if (it == live_.end())
+        return {};
+    return {.key = key, .handle = it->second};
+}
+
+LoadRequest PluginAssignments::request(magda::engine::DeviceKey key) const {
+    const auto it = live_.find(key);
+    if (it == live_.end())
+        return {.key = key, .handle = {}};
+    return {.key = key, .handle = it->second};
+}
+
+void PluginAssignments::release(magda::engine::DeviceKey key) {
+    live_.erase(key);
+}
+
+void PluginAssignments::releaseAll() {
+    live_.clear();
+}
+
+bool PluginAssignments::accepts(const LoadRequest& request) const {
+    const auto held = request.handle.lock();
+    if (held == nullptr)
+        return false;
+
+    // Locking alone is not enough. A caller holding the ActiveAssignment it was
+    // handed keeps the handle alive past the release, so the live set is what
+    // decides: this key must still be this assignment.
+    const auto it = live_.find(request.key);
+    return it != live_.end() && it->second == held;
+}
+
+}  // namespace magda::daw::audio::engine_adapter

--- a/magda/daw/audio/plugins/engine/PluginAssignments.hpp
+++ b/magda/daw/audio/plugins/engine/PluginAssignments.hpp
@@ -121,6 +121,18 @@ struct LoadRequest {
      * for accepting anything.
      */
     bool keyWasReassigned() const;
+
+    /**
+     * @brief Whether the runtime that owns this assignment is still there.
+     *
+     * A different question from isStillWanted(), and the one a caller asks
+     * before *reporting* rather than before accepting. A device deleted while
+     * its runtime lives is a load to refuse and say so about, because something
+     * is waiting to hear it. A runtime that is gone is not: there is nothing to
+     * publish onto and nobody to tell, and a completion callback made by that
+     * runtime is exactly the thing that must not be called now.
+     */
+    bool runtimeIsAlive() const;
 };
 
 /**

--- a/magda/daw/audio/plugins/engine/PluginAssignments.hpp
+++ b/magda/daw/audio/plugins/engine/PluginAssignments.hpp
@@ -1,0 +1,139 @@
+#pragma once
+
+#include <cstddef>
+#include <memory>
+#include <unordered_map>
+
+#include "plan/RenderPlan.hpp"
+
+/**
+ * @file PluginAssignments.hpp
+ * @brief Who a plugin is being loaded for, owned at runtime (#2261).
+ *
+ * An asynchronous plugin load takes seconds, and the answer has to be refused
+ * when it comes back for a device that is no longer asking. Mutable plugin
+ * metadata cannot decide that: resolution deliberately tolerates a moved file,
+ * a renamed plugin, a missing vendor and an unreliable imported role, so a
+ * comparison of names or paths finds a legitimate correction indistinguishable
+ * from a swap. The question needs an identity nothing about the plugin can
+ * change.
+ *
+ * That identity used to live in the model, as a counter on DeviceInfo minted by
+ * whichever call site remembered to. It could not hold: DeviceInfo is a value,
+ * and C++ copying cannot tell a snapshot from an undo record from a browser
+ * template from a duplicate from a paste from a new live placement. The
+ * invariant survived only as a habit, missed sites were found one at a time,
+ * and a missed one failed the wrong way -- the copy kept the token, so a stale
+ * load was *accepted* and one plugin's state was restored onto another.
+ *
+ * So identity is owned here instead, by whoever runs the plugins, and it is a
+ * pointer rather than a number. A device that becomes live gets a handle; the
+ * request holds a weak reference to it; completion is accepted only if this
+ * still holds that same handle for that same key. Nothing in the model carries
+ * it, so no copy, re-key or serialization path can get it wrong, and a device
+ * that was never registered has no handle to lend -- which rejects its load
+ * rather than accepting it.
+ *
+ * Message thread only. Registration happens as devices are placed, and JUCE
+ * calls an asynchronous load back on the message thread, so both ends of the
+ * question are already there.
+ */
+
+namespace magda::daw::audio::engine_adapter {
+
+/**
+ * @brief The identity of one live plugin assignment.
+ *
+ * Deliberately empty: it is identified by its address and by nothing else, so
+ * there is no field a copy could carry and no value a caller could forge. Held
+ * by shared_ptr so a request can hold a weak reference that expires on its own
+ * when the assignment ends.
+ */
+struct AssignmentHandle {};
+
+/** A device that is live now, and the handle standing for its assignment. */
+struct ActiveAssignment {
+    magda::engine::DeviceKey key;
+    std::shared_ptr<const AssignmentHandle> handle;
+
+    /// Whether this names an assignment at all. False for the empty value a
+    /// lookup returns when nothing is registered.
+    explicit operator bool() const {
+        return handle != nullptr;
+    }
+};
+
+/**
+ * @brief What an asynchronous load remembers about who it is loading for.
+ *
+ * Weak on purpose. A load in flight must not keep an assignment alive, because
+ * an assignment outliving its device is exactly the state in which a stale load
+ * would be accepted. An expired handle is the answer "no longer wanted", and it
+ * is also what an unregistered device hands out, so forgetting to register
+ * fails closed.
+ */
+struct LoadRequest {
+    magda::engine::DeviceKey key;
+    std::weak_ptr<const AssignmentHandle> handle;
+};
+
+/**
+ * @brief The live set of plugin assignments, and the arbiter of stale loads.
+ *
+ * Keyed on engine::DeviceKey rather than a bare DeviceId: DeviceId is allocated
+ * per section, so the main FX, post-FX and mixer-analysis sections can each hold
+ * the same integer, and a device in one section must not be able to accept a
+ * load requested for a device in another.
+ */
+class PluginAssignments {
+  public:
+    /**
+     * @brief A device is live under @p key, as a new assignment.
+     *
+     * Any handle already held for @p key is dropped, which expires every
+     * request outstanding against it. That is what covers a slot whose plugin
+     * was replaced and an id handed out again after the project was cleared:
+     * both are a new assignment on a key that had one, and neither can be told
+     * from the other by anything in the model.
+     */
+    ActiveAssignment assign(magda::engine::DeviceKey key);
+
+    /** The assignment held for @p key, or an empty one when there is none. */
+    ActiveAssignment current(magda::engine::DeviceKey key) const;
+
+    /**
+     * @brief What to remember when starting a load for @p key.
+     *
+     * An unregistered key yields an already-expired request, so a load started
+     * without one is refused at completion.
+     */
+    LoadRequest request(magda::engine::DeviceKey key) const;
+
+    /** The device is gone, or its plugin is being replaced by nothing. */
+    void release(magda::engine::DeviceKey key);
+
+    /** Every assignment ends: the project was closed or cleared. */
+    void releaseAll();
+
+    /**
+     * @brief Whether a load answering @p request is still wanted.
+     *
+     * True only when this still holds, for @p request's key, the very handle
+     * the request was made against. Both halves matter: the weak reference can
+     * still be locked by a caller holding the ActiveAssignment it was given,
+     * and a key can be live again under a different assignment.
+     */
+    bool accepts(const LoadRequest& request) const;
+
+    /** How many assignments are live. For tests and diagnostics. */
+    std::size_t size() const {
+        return live_.size();
+    }
+
+  private:
+    std::unordered_map<magda::engine::DeviceKey, std::shared_ptr<const AssignmentHandle>,
+                       magda::engine::DeviceKeyHash>
+        live_;
+};
+
+}  // namespace magda::daw::audio::engine_adapter

--- a/magda/daw/audio/plugins/engine/PluginAssignments.hpp
+++ b/magda/daw/audio/plugins/engine/PluginAssignments.hpp
@@ -28,11 +28,11 @@
  *
  * So identity is owned here instead, by whoever runs the plugins, and it is a
  * pointer rather than a number. A device that becomes live gets a handle; the
- * request holds a weak reference to it; completion is accepted only if this
- * still holds that same handle for that same key. Nothing in the model carries
- * it, so no copy, re-key or serialization path can get it wrong, and a device
- * that was never registered has no handle to lend -- which rejects its load
- * rather than accepting it.
+ * request holds a weak reference to it, and to the table it lives in; a load is
+ * accepted only if that table still holds that same handle for that same key.
+ * Nothing in the model carries it, so no copy, re-key or serialization path can
+ * get it wrong, and a device that was never registered has no handle to lend --
+ * which rejects its load rather than accepting it.
  *
  * Message thread only. Registration happens as devices are placed, and JUCE
  * calls an asynchronous load back on the message thread, so both ends of the
@@ -51,6 +51,27 @@ namespace magda::daw::audio::engine_adapter {
  */
 struct AssignmentHandle {};
 
+/**
+ * @brief The live set, held apart from the object that manages it.
+ *
+ * A load in flight outlives things. The project can be closed and the runtime
+ * that owns the assignments destroyed while a plugin is still loading, and the
+ * completion that arrives afterwards still has to answer -- so it cannot answer
+ * by dereferencing the owner. It holds a weak reference to this instead, and a
+ * table that is gone is a load nobody is waiting for.
+ */
+class AssignmentTable {
+  public:
+    /** The handle held for @p key, or null when nothing is. */
+    std::shared_ptr<const AssignmentHandle> find(magda::engine::DeviceKey key) const;
+
+  private:
+    friend class PluginAssignments;
+    std::unordered_map<magda::engine::DeviceKey, std::shared_ptr<const AssignmentHandle>,
+                       magda::engine::DeviceKeyHash>
+        byKey_;
+};
+
 /** A device that is live now, and the handle standing for its assignment. */
 struct ActiveAssignment {
     magda::engine::DeviceKey key;
@@ -66,15 +87,40 @@ struct ActiveAssignment {
 /**
  * @brief What an asynchronous load remembers about who it is loading for.
  *
- * Weak on purpose. A load in flight must not keep an assignment alive, because
- * an assignment outliving its device is exactly the state in which a stale load
- * would be accepted. An expired handle is the answer "no longer wanted", and it
- * is also what an unregistered device hands out, so forgetting to register
- * fails closed.
+ * Weak at both ends, and for the same reason. A load must not keep an
+ * assignment alive, because an assignment outliving its device is exactly the
+ * state in which a stale load would be accepted; and it must not keep the table
+ * alive either, because the runtime that owns it may be gone by the time the
+ * plugin arrives. Either reference expiring is the answer "no longer wanted",
+ * and an unregistered device hands out an already-expired handle, so forgetting
+ * to register fails closed.
+ *
+ * Self-contained on purpose: completion needs nothing but this to decide, so
+ * nothing about the runtime has to be captured by an asynchronous callback.
  */
 struct LoadRequest {
     magda::engine::DeviceKey key;
     std::weak_ptr<const AssignmentHandle> handle;
+    std::weak_ptr<const AssignmentTable> table;
+
+    /**
+     * @brief Whether a load answering this is still wanted.
+     *
+     * True only when the table is still there and still holds, for this key,
+     * the very handle the request was made against. Every part matters: the
+     * weak handle can still be locked by a caller holding the ActiveAssignment
+     * it was given, and a key can be live again under a different assignment.
+     */
+    bool isStillWanted() const;
+
+    /**
+     * @brief Whether the key is live again under a different assignment.
+     *
+     * Only for telling a person which of the two happened: a slot now asking
+     * for a different plugin, against a device that went away. Never the basis
+     * for accepting anything.
+     */
+    bool keyWasReassigned() const;
 };
 
 /**
@@ -84,19 +130,40 @@ struct LoadRequest {
  * per section, so the main FX, post-FX and mixer-analysis sections can each hold
  * the same integer, and a device in one section must not be able to accept a
  * load requested for a device in another.
+ *
+ * Move-only. The table is shared with the loads in flight against it, never
+ * with a second manager.
  */
 class PluginAssignments {
   public:
+    PluginAssignments();
+
+    PluginAssignments(const PluginAssignments&) = delete;
+    PluginAssignments& operator=(const PluginAssignments&) = delete;
+    PluginAssignments(PluginAssignments&&) noexcept = default;
+    PluginAssignments& operator=(PluginAssignments&&) noexcept = default;
+    ~PluginAssignments() = default;
+
     /**
-     * @brief A device is live under @p key, as a new assignment.
+     * @brief @p key is live and keeps whatever assignment it already has.
      *
-     * Any handle already held for @p key is dropped, which expires every
-     * request outstanding against it. That is what covers a slot whose plugin
-     * was replaced and an id handed out again after the project was cleared:
-     * both are a new assignment on a key that had one, and neither can be told
-     * from the other by anything in the model.
+     * What ordinary registration is: a plan prepared again, a device re-visited
+     * as the project is walked, a slot confirmed to still be there. None of
+     * those is a new assignment, and minting one would expire a load that is
+     * still wanted -- repeatedly, for anything that re-registers on a timer or
+     * on every recompile.
      */
-    ActiveAssignment assign(magda::engine::DeviceKey key);
+    ActiveAssignment ensureAssignment(magda::engine::DeviceKey key);
+
+    /**
+     * @brief @p key is live as a *new* assignment, whatever it held before.
+     *
+     * What a slot asking for a different plugin is, and what a placement is: a
+     * duplicate, a paste, a preset import, an undo reinsertion, or an id handed
+     * out again after the project was cleared. Any handle already held for @p
+     * key is dropped, which expires every request outstanding against it.
+     */
+    ActiveAssignment replaceAssignment(magda::engine::DeviceKey key);
 
     /** The assignment held for @p key, or an empty one when there is none. */
     ActiveAssignment current(magda::engine::DeviceKey key) const;
@@ -115,25 +182,11 @@ class PluginAssignments {
     /** Every assignment ends: the project was closed or cleared. */
     void releaseAll();
 
-    /**
-     * @brief Whether a load answering @p request is still wanted.
-     *
-     * True only when this still holds, for @p request's key, the very handle
-     * the request was made against. Both halves matter: the weak reference can
-     * still be locked by a caller holding the ActiveAssignment it was given,
-     * and a key can be live again under a different assignment.
-     */
-    bool accepts(const LoadRequest& request) const;
-
     /** How many assignments are live. For tests and diagnostics. */
-    std::size_t size() const {
-        return live_.size();
-    }
+    std::size_t size() const;
 
   private:
-    std::unordered_map<magda::engine::DeviceKey, std::shared_ptr<const AssignmentHandle>,
-                       magda::engine::DeviceKeyHash>
-        live_;
+    std::shared_ptr<AssignmentTable> table_;
 };
 
 }  // namespace magda::daw::audio::engine_adapter

--- a/magda/daw/core/DeviceInfo.cpp
+++ b/magda/daw/core/DeviceInfo.cpp
@@ -1,15 +1,8 @@
 #include "DeviceInfo.hpp"
 
-#include <atomic>
-
 #include "RackInfo.hpp"
 
 namespace magda {
-
-std::uint64_t nextPluginAssignmentGeneration() {
-    static std::atomic<std::uint64_t> generation{0};
-    return generation.fetch_add(1, std::memory_order_relaxed) + 1;
-}
 
 // Out of line because RackInfo is only complete once RackInfo.hpp has been
 // seen, and RackInfo.hpp includes DeviceInfo.hpp, so the header cannot see it.

--- a/magda/daw/core/DeviceInfo.hpp
+++ b/magda/daw/core/DeviceInfo.hpp
@@ -2,7 +2,6 @@
 
 #include <juce_core/juce_core.h>
 
-#include <cstdint>
 #include <memory>
 #include <optional>
 
@@ -15,18 +14,6 @@
 namespace magda {
 
 struct RackInfo;
-
-/**
- * @brief A process-local serial number for a newly authored plugin assignment.
- *
- * This is deliberately not project data. A project load authors fresh live
- * assignments, while copies of those DeviceInfo values carry the same number.
- * The distinction is what an asynchronous plugin load needs: metadata and
- * state edits copy or mutate the current assignment, while replacing a slot
- * with a newly constructed DeviceInfo carries a different number even when
- * both plugins have ambiguous or temporarily incomplete saved metadata.
- */
-std::uint64_t nextPluginAssignmentGeneration();
 
 /**
  * @brief Value-semantic owner for a device's pad chains.
@@ -208,22 +195,12 @@ struct MeterInfo {
 struct DeviceInfo {
     DeviceId id = INVALID_DEVICE_ID;
 
-    // Runtime identity of the plugin assignment in this slot. Copies preserve
-    // it; a newly constructed replacement gets another monotonically increasing
-    // value. Scan enrichment, parameter edits and preset restores must not
-    // change it. Transient by design: serializers neither read nor write it.
-    std::uint64_t pluginAssignmentGeneration = nextPluginAssignmentGeneration();
-
-    /**
-     * Mark this slot as asking for a different plugin.
-     *
-     * Copies deliberately keep their token, because most copies are snapshots
-     * of the same assignment. Every path that authors a replacement from a
-     * copy or mutates plugin identity in place must come through here.
-     */
-    void beginNewPluginAssignment() {
-        pluginAssignmentGeneration = nextPluginAssignmentGeneration();
-    }
+    // No runtime lifetime identity lives here. Which live assignment a slot
+    // holds is owned by the runtime that runs the plugins, and is a handle
+    // rather than a value (PluginAssignments.hpp): a value type cannot tell a
+    // snapshot from an undo record from a browser template from a duplicate
+    // from a new live placement, because every one of those is the same copy
+    // (#2261).
 
     juce::String name;  // Display name (e.g., "Pro-Q 3")
 

--- a/magda/daw/core/DrumGridPads.cpp
+++ b/magda/daw/core/DrumGridPads.cpp
@@ -226,7 +226,6 @@ DeviceInfo deviceFromNode(const ds::Node& node) {
     // the only reason it had to read a nested plugin tree at all (#2207).
     if (const auto successor = legacy_devices::retiredDeviceSuccessor(savedType);
         successor.isNotEmpty()) {
-        device.beginNewPluginAssignment();
         for (const auto& slot :
              legacy_devices::convertRetiredDeviceState(savedType, [&node](const char* property) {
                  return node.props[juce::Identifier(property)];

--- a/magda/daw/core/LegacyDeviceAliases.cpp
+++ b/magda/daw/core/LegacyDeviceAliases.cpp
@@ -558,8 +558,6 @@ MigrationResult migrateDevice(DeviceInfo& device) {
     if (retired == nullptr)
         return MigrationResult::NotRetired;
 
-    device.beginNewPluginAssignment();
-
     const auto converted = convertSlots(
         *retired, [&device](int legacyIndex) { return retiredValue(device, legacyIndex); });
 

--- a/magda/daw/core/TrackManager.cpp
+++ b/magda/daw/core/TrackManager.cpp
@@ -1087,17 +1087,10 @@ TrackId TrackManager::duplicateTrack(TrackId trackId, bool includeDevices) {
     // DeviceId counter, so the copied devices must be re-stamped with fresh ids
     // from the right counter (sharing ids = sharing audio-engine plugin slots).
     // Empty when !includeDevices, so these loops are no-ops in that case.
-    // Each is a distinct live assignment for the same reason reassignChainElementIds
-    // mints one, and these two counters are section-local, so a copied device
-    // can otherwise land on an id another section is already using.
-    for (auto& element : newTrack.chain.postFxChainElements) {
-        element.device.beginNewPluginAssignment();
+    for (auto& element : newTrack.chain.postFxChainElements)
         element.device.id = nextPostFxDeviceId_++;
-    }
-    for (auto& element : newTrack.chain.mixerAnalysisElements) {
-        element.device.beginNewPluginAssignment();
+    for (auto& element : newTrack.chain.mixerAnalysisElements)
         element.device.id = nextMixerAnalysisDeviceId_++;
-    }
 
     // Log all device IDs after reassignment
     DBG("duplicateTrack: original trackId=" << trackId << " -> newTrackId=" << newTrack.id);
@@ -2124,7 +2117,7 @@ DeviceId TrackManager::addDeviceToTrack(TrackId trackId, const DeviceInfo& devic
             DBG("Cannot add MIDI generator to master track");
             return INVALID_DEVICE_ID;
         }
-        DeviceInfo newDevice = prepareNewDevice(device);
+        DeviceInfo newDevice = prepareNewDevice(trackId, device);
         seedSidechainModIfMissing(newDevice, ChainNodePath::topLevelDevice(trackId, newDevice.id));
         track->chain.fxChainElements.push_back(makeDeviceElement(newDevice));
         notifyTrackDevicesChanged(trackId);
@@ -2151,7 +2144,7 @@ DeviceId TrackManager::addDeviceToTrack(TrackId trackId, const DeviceInfo& devic
             DBG("Cannot add MIDI generator to master track");
             return INVALID_DEVICE_ID;
         }
-        DeviceInfo newDevice = prepareNewDevice(device);
+        DeviceInfo newDevice = prepareNewDevice(trackId, device);
         seedSidechainModIfMissing(newDevice, ChainNodePath::topLevelDevice(trackId, newDevice.id));
 
         // Clamp insert index to valid range
@@ -2219,7 +2212,6 @@ DeviceId TrackManager::addDeviceToPostFx(TrackId trackId, const DeviceInfo& devi
     }
 
     DeviceInfo newDevice = device;
-    newDevice.beginNewPluginAssignment();
     newDevice.id = nextPostFxDeviceId_++;
     applyCachedCapabilitiesToDevice(newDevice);
     if (daw::audio::isInternalAnalysisPlugin(newDevice.pluginId))
@@ -2285,7 +2277,6 @@ DeviceId TrackManager::addDeviceToMixerAnalysis(TrackId trackId, const DeviceInf
     }
 
     DeviceInfo newDevice = device;
-    newDevice.beginNewPluginAssignment();
     newDevice.id = nextMixerAnalysisDeviceId_++;
     applyCachedCapabilitiesToDevice(newDevice);
     if (daw::audio::isInternalAnalysisPlugin(newDevice.pluginId))
@@ -3509,43 +3500,6 @@ void TrackManager::notifyDeviceAdded(const ChainNodePath& devicePath, const Devi
         if (listeners_[i])
             listeners_[i]->deviceAdded(devicePath, device);
     }
-}
-
-DeviceInfo TrackManager::prepareNewDevice(const DeviceInfo& device) {
-    DeviceInfo newDevice = device;
-    newDevice.beginNewPluginAssignment();
-    newDevice.id = nextFxDeviceId_++;
-    rekeyPads(newDevice);
-    applyCachedCapabilitiesToDevice(newDevice);
-    stampDefaultKitIfMissing(newDevice);
-    if (daw::audio::isInternalAnalysisPlugin(newDevice.pluginId))
-        newDevice.deviceType = DeviceType::Analysis;
-    return newDevice;
-}
-
-void TrackManager::rekeyPads(DeviceInfo& device, ChainIdRemap* remap) {
-    if (!device.pads)
-        return;
-
-    // Both the pad rack's id and its devices' are DeviceIds in disguise, so a
-    // copied Drum Grid that kept them would key the ops of the one it was
-    // copied from: the plan would emit two devices onto one op and the executor
-    // would run whichever it saw last (#2207).
-    stampPadRackId(device);
-
-    // A pad holds chain elements like any other chain, nested racks included,
-    // so the same recursive walk re-keys them. A shallow pass over the direct
-    // pad devices left everything inside a pad's rack carrying the source's
-    // DeviceIds and assignment tokens, so a copied grid shared ops with the one
-    // it came from and a late async load could complete onto the copy.
-    //
-    // Reported so a caller that also rewrites paths can follow the pad
-    // contents, which is what keeps a macro or a mod on the grid pointing at
-    // the pad it was linked to.
-    ChainIdRemap discarded;
-    auto& target = remap != nullptr ? *remap : discarded;
-    for (auto& pad : device.pads->chains)
-        reassignChainElementIds(pad.elements, target);
 }
 
 void TrackManager::notifyDeviceModifiersChanged(TrackId trackId) {

--- a/magda/daw/core/TrackManager.hpp
+++ b/magda/daw/core/TrackManager.hpp
@@ -539,21 +539,26 @@ class TrackManager : public daw::audio::DeviceIdAllocator, public daw::audio::De
     static void seedSidechainModIfMissing(DeviceInfo& dev, const ChainNodePath& devicePath);
 
     // Common prep for the FX-chain and rack-chain add paths: assign a fresh
-    // DeviceId from nextFxDeviceId_, stamp the default kit, and tag analysis
-    // devices. Returns the prepared copy; callers insert it, then fire
-    // notifyDeviceAdded. Centralised so these steps can't drift per call site.
-    // Post-fx and mixer-analysis keep their own ID spaces (nextPostFxDeviceId_,
-    // nextMixerAnalysisDeviceId_) and so do their own prep.
-    DeviceInfo prepareNewDevice(const DeviceInfo& device);
+    // DeviceId from nextFxDeviceId_, re-key and retarget its pads, stamp the
+    // default kit, and tag analysis devices. Returns the prepared copy; callers
+    // insert it into @p trackId, then fire notifyDeviceAdded. Centralised so
+    // these steps can't drift per call site. Post-fx and mixer-analysis keep
+    // their own ID spaces (nextPostFxDeviceId_, nextMixerAnalysisDeviceId_) and
+    // so do their own prep.
+    //
+    // The track is taken because a pad path is rooted at one: a link inside a
+    // Drum Grid's pads names the track the grid is on, and the copy is about to
+    // be on a different one.
+    DeviceInfo prepareNewDevice(TrackId trackId, const DeviceInfo& device);
 
     // Re-derive a pad-per-chain device's rack id and re-key its pad devices,
     // for a copy that arrived carrying the ids of the device it came from.
     // Both ids are DeviceIds in disguise, so a copy that kept them would key
     // the original's ops (#2207). A pad's contents are chain elements like any
     // other, nested racks included, so the whole subtree is re-keyed rather
-    // than the direct pad devices alone. `remap`, when given, collects the
-    // old-to-new ids so a caller that also rewrites paths can follow them.
-    void rekeyPads(DeviceInfo& device, ChainIdRemap* remap = nullptr);
+    // than the direct pad devices alone. `remap` collects the old-to-new ids so
+    // the caller can follow the paths that named them.
+    void rekeyPads(DeviceInfo& device, ChainIdRemap& remap);
 
     // The pad chain answering to a pad, mutable. Private because a pad property
     // is set through the setters above, which notify.

--- a/magda/daw/core/TrackManagerDevices.cpp
+++ b/magda/daw/core/TrackManagerDevices.cpp
@@ -257,11 +257,14 @@ void remapPresetLinksRecursive(std::vector<ChainElement>& elements, const Preset
             if (state == PresetState::Strip)
                 device.pluginState = stripPresetRuntimePluginState(device.pluginState);
 
-            // A pad device is an ordinary DeviceInfo and owns macros and mods
-            // like any other, so a copy's have to be retargeted too (#2211).
+            // The pad rack, as a rack. A pad device is an ordinary DeviceInfo
+            // and owns macros and mods like any other, so a copy's have to be
+            // retargeted too (#2211) -- and so does the pad rack itself, which
+            // is a RackInfo with macros and mods of its own that a pad path
+            // resolves to and the modulation surfaces compile from. Descending
+            // straight into its chains walked past those (#2261).
             if (device.pads)
-                for (auto& pad : device.pads->chains)
-                    remapPresetLinksRecursive(pad.elements, remap, state);
+                remapRackPresetLinks(*device.pads.get(), remap, state);
         } else if (magda::isRack(element)) {
             remapRackPresetLinks(magda::getRack(element), remap, state);
         }
@@ -270,11 +273,11 @@ void remapPresetLinksRecursive(std::vector<ChainElement>& elements, const Preset
 
 /// Follow a re-keyed Drum Grid's pads with everything that addressed them.
 ///
-/// @p ids is what `rekeyPads()` moved, the grid's own id included. Both ends of
-/// a pad link need it: the grid's macros and mods point down into the pads, and
-/// a pad device's own macros and mods point at their siblings. A link out of the
-/// subtree names an id this does not hold and is left alone, which is what
-/// `remapPresetPath()` does with an unmapped id.
+/// @p ids is what `rekeyPads()` moved, the grid's own id included. Every end of
+/// a pad link needs it: the grid's macros and mods point down into the pads,
+/// the pad rack's own point at what it holds, and a pad device's point at its
+/// siblings. A link out of the subtree names an id this does not hold and is
+/// left alone, which is what `remapPresetPath()` does with an unmapped id.
 void retargetPadLinks(DeviceInfo& device, TrackId trackId, const ChainIdRemap& ids) {
     if (!device.pads)
         return;
@@ -286,8 +289,7 @@ void retargetPadLinks(DeviceInfo& device, TrackId trackId, const ChainIdRemap& i
     remap.chains = ids.chains;
 
     remapPresetLinks(device.macros, device.mods, remap);
-    for (auto& pad : device.pads->chains)
-        remapPresetLinksRecursive(pad.elements, remap, PresetState::Keep);
+    remapRackPresetLinks(*device.pads.get(), remap, PresetState::Keep);
 }
 
 void collectDeviceIdMatches(std::vector<ChainElement>& elements, TrackId trackId, DeviceId deviceId,

--- a/magda/daw/core/TrackManagerDevices.cpp
+++ b/magda/daw/core/TrackManagerDevices.cpp
@@ -6,11 +6,13 @@
 #include "../audio/AudioBridge.hpp"
 #include "../audio/TracktionHelpers.hpp"
 #include "../audio/plugin_manager/ExternalPluginStateUtil.hpp"
+#include "../audio/plugins/InternalPluginRegistry.hpp"
 #include "../audio/plugins/tracktion/TracktionDeviceStateBridge.hpp"
 #include "../engine/AudioEngine.hpp"
 #include "ChainWalk.hpp"
 #include "DeviceState.hpp"
 #include "DrumGridPads.hpp"
+#include "PluginCapabilities.hpp"
 #include "PluginPreferences.hpp"
 #include "RackInfo.hpp"
 #include "TrackManager.hpp"
@@ -227,30 +229,65 @@ juce::String stripPresetRuntimePluginState(const juce::String& pluginState) {
     return pluginState;
 }
 
-void remapPresetLinksRecursive(std::vector<ChainElement>& elements, const PresetIdRemap& remap);
+/// Whether a re-keyed subtree's saved plugin state is a preset's or a project's.
+///
+/// A preset carries state captured against another project's engine, so the
+/// runtime ids in it name plugin instances that are not this project's. A
+/// subtree being re-keyed in place -- a Drum Grid getting its own DeviceId as it
+/// is placed -- carries no such thing, and rewriting its state would be a change
+/// nobody asked for.
+enum class PresetState { Strip, Keep };
 
-void remapRackPresetLinks(RackInfo& rack, const PresetIdRemap& remap) {
+void remapPresetLinksRecursive(std::vector<ChainElement>& elements, const PresetIdRemap& remap,
+                               PresetState state = PresetState::Strip);
+
+void remapRackPresetLinks(RackInfo& rack, const PresetIdRemap& remap,
+                          PresetState state = PresetState::Strip) {
     remapPresetLinks(rack.macros, rack.mods, remap);
     for (auto& chain : rack.chains)
-        remapPresetLinksRecursive(chain.elements, remap);
+        remapPresetLinksRecursive(chain.elements, remap, state);
 }
 
-void remapPresetLinksRecursive(std::vector<ChainElement>& elements, const PresetIdRemap& remap) {
+void remapPresetLinksRecursive(std::vector<ChainElement>& elements, const PresetIdRemap& remap,
+                               PresetState state) {
     for (auto& element : elements) {
         if (magda::isDevice(element)) {
             auto& device = magda::getDevice(element);
             remapPresetLinks(device.macros, device.mods, remap);
-            device.pluginState = stripPresetRuntimePluginState(device.pluginState);
+            if (state == PresetState::Strip)
+                device.pluginState = stripPresetRuntimePluginState(device.pluginState);
 
             // A pad device is an ordinary DeviceInfo and owns macros and mods
             // like any other, so a copy's have to be retargeted too (#2211).
             if (device.pads)
                 for (auto& pad : device.pads->chains)
-                    remapPresetLinksRecursive(pad.elements, remap);
+                    remapPresetLinksRecursive(pad.elements, remap, state);
         } else if (magda::isRack(element)) {
-            remapRackPresetLinks(magda::getRack(element), remap);
+            remapRackPresetLinks(magda::getRack(element), remap, state);
         }
     }
+}
+
+/// Follow a re-keyed Drum Grid's pads with everything that addressed them.
+///
+/// @p ids is what `rekeyPads()` moved, the grid's own id included. Both ends of
+/// a pad link need it: the grid's macros and mods point down into the pads, and
+/// a pad device's own macros and mods point at their siblings. A link out of the
+/// subtree names an id this does not hold and is left alone, which is what
+/// `remapPresetPath()` does with an unmapped id.
+void retargetPadLinks(DeviceInfo& device, TrackId trackId, const ChainIdRemap& ids) {
+    if (!device.pads)
+        return;
+
+    PresetIdRemap remap;
+    remap.trackId = trackId;
+    remap.devices = ids.devices;
+    remap.racks = ids.racks;
+    remap.chains = ids.chains;
+
+    remapPresetLinks(device.macros, device.mods, remap);
+    for (auto& pad : device.pads->chains)
+        remapPresetLinksRecursive(pad.elements, remap, PresetState::Keep);
 }
 
 void collectDeviceIdMatches(std::vector<ChainElement>& elements, TrackId trackId, DeviceId deviceId,
@@ -360,7 +397,7 @@ DeviceId TrackManager::addDeviceToChain(TrackId trackId, RackId rackId, ChainId 
         }
     }
     if (auto* chain = getChain(trackId, rackId, chainId)) {
-        DeviceInfo newDevice = prepareNewDevice(device);
+        DeviceInfo newDevice = prepareNewDevice(trackId, device);
         seedSidechainModIfMissing(
             newDevice, ChainNodePath::chainDevice(trackId, rackId, chainId, newDevice.id));
         chain->elements.push_back(makeDeviceElement(newDevice));
@@ -415,7 +452,7 @@ DeviceId TrackManager::addDeviceToChainByPath(const ChainNodePath& chainPath,
         }
 
         // Add the device
-        DeviceInfo newDevice = prepareNewDevice(device);
+        DeviceInfo newDevice = prepareNewDevice(chainPath.trackId, device);
         seedSidechainModIfMissing(newDevice, chainPath.withDevice(newDevice.id));
         chain->elements.push_back(makeDeviceElement(newDevice));
         notifyTrackDevicesChanged(chainPath.trackId);
@@ -469,7 +506,7 @@ DeviceId TrackManager::addDeviceToChainByPath(const ChainNodePath& chainPath,
         }
 
         // Add the device at the specified index
-        DeviceInfo newDevice = prepareNewDevice(device);
+        DeviceInfo newDevice = prepareNewDevice(chainPath.trackId, device);
         seedSidechainModIfMissing(newDevice, chainPath.withDevice(newDevice.id));
 
         // Clamp insert index to valid range
@@ -1932,19 +1969,54 @@ bool TrackManager::applyDevicePreset(const ChainNodePath& devicePath,
     return true;
 }
 
+DeviceInfo TrackManager::prepareNewDevice(TrackId trackId, const DeviceInfo& device) {
+    DeviceInfo newDevice = device;
+    newDevice.id = nextFxDeviceId_++;
+
+    // The grid's own id is in the map because a pad path names the grid rather
+    // than a route to it: every link into these pads carries the old DeviceId
+    // in its PadRack step, and the ones the grid's own macros and mods hold
+    // carry it in `topLevelDeviceId` as well.
+    ChainIdRemap ids;
+    ids.devices[device.id] = newDevice.id;
+    rekeyPads(newDevice, ids);
+    retargetPadLinks(newDevice, trackId, ids);
+
+    applyCachedCapabilitiesToDevice(newDevice);
+    stampDefaultKitIfMissing(newDevice);
+    if (daw::audio::isInternalAnalysisPlugin(newDevice.pluginId))
+        newDevice.deviceType = DeviceType::Analysis;
+    return newDevice;
+}
+
+void TrackManager::rekeyPads(DeviceInfo& device, ChainIdRemap& remap) {
+    if (!device.pads)
+        return;
+
+    // Both the pad rack's id and its devices' are DeviceIds in disguise, so a
+    // copied Drum Grid that kept them would key the ops of the one it was
+    // copied from: the plan would emit two devices onto one op and the executor
+    // would run whichever it saw last (#2207).
+    stampPadRackId(device);
+
+    // A pad holds chain elements like any other chain, nested racks included,
+    // so the same recursive walk re-keys them. A shallow pass over the direct
+    // pad devices left everything inside a pad's rack carrying the source's
+    // DeviceIds, so a copied grid shared ops with the one it came from.
+    //
+    // Reported rather than discarded: the ids this moves are the ones a macro
+    // or a mod addressing anything in the pad subtree was pointing at, and a
+    // link left on the old address resolves to nothing.
+    for (auto& pad : device.pads->chains)
+        reassignChainElementIds(pad.elements, remap);
+}
+
 void TrackManager::reassignChainElementIds(std::vector<ChainElement>& elements,
                                            ChainIdRemap& remap) {
     for (auto& element : elements) {
         if (magda::isDevice(element)) {
             auto& device = magda::getDevice(element);
             const auto oldDeviceId = device.id;
-
-            // A re-keyed element is a distinct live assignment, not a snapshot
-            // of the one it was copied from: it gets its own plugin instance,
-            // and DeviceIds are reused after clearAllTracks(). Without a fresh
-            // token an async load requested by the original would match the
-            // copy and restore one plugin's state onto another.
-            device.beginNewPluginAssignment();
             device.id = allocateDeviceId();
             remap.devices[oldDeviceId] = device.id;
 

--- a/magda/daw/core/TrackManagerPads.cpp
+++ b/magda/daw/core/TrackManagerPads.cpp
@@ -112,7 +112,7 @@ DeviceId TrackManager::addDeviceToPad(const ChainNodePath& gridPath, ChainId pad
         track != nullptr && !track->canHostInstrument() && device.isInstrument)
         return INVALID_DEVICE_ID;
 
-    auto newDevice = prepareNewDevice(device);
+    auto newDevice = prepareNewDevice(gridPath.trackId, device);
     const auto devicePath = padChainPath(gridPath, padChainId).withDevice(newDevice.id);
     seedSidechainModIfMissing(newDevice, devicePath);
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -417,6 +417,10 @@ if(MAGDA_BUILD_NATIVE_ENGINE)
     # corpus (#2175), where both engines run the same one.
     list(APPEND TEST_SOURCES engine/test_engine_external_device.cpp)
 
+    # Who an asynchronous plugin load belongs to (#2261): the runtime-owned
+    # assignment the adapter above checks before it completes one.
+    list(APPEND TEST_SOURCES engine/test_plugin_assignments.cpp)
+
     # The block-size invariance gate (#2078). Model-only for the same reason the
     # native leg is: the claim is the native engine's alone, and the incumbent
     # owes nobody block-size invariance. In CI rather than in a nightly, because

--- a/tests/controllers/test_legacy_device_aliases.cpp
+++ b/tests/controllers/test_legacy_device_aliases.cpp
@@ -75,7 +75,6 @@ TEST_CASE("Retired Tracktion devices resolve to their successor by every stored 
 
 TEST_CASE("Migrating a retired device rewrites its identity", "[devices][legacy][aliases]") {
     auto device = retiredDevice("reverb", {param(0, 0.5f)});
-    const auto retiredGeneration = device.pluginAssignmentGeneration;
     device.name = "Reverb";  // still the stock name
     device.pluginState = "<PLUGIN type=\"reverb\"/>";
     device.visibleParameters = {0, 1, 2};
@@ -84,16 +83,13 @@ TEST_CASE("Migrating a retired device rewrites its identity", "[devices][legacy]
 
     CHECK(device.pluginId == "magda_reverb");
     CHECK(device.uniqueId == "magda_reverb");
-    CHECK(device.pluginAssignmentGeneration > retiredGeneration);
     CHECK(device.name == "Reverb");
     // State and index lists described a plugin that no longer exists.
     CHECK(device.pluginState.isEmpty());
     CHECK(device.visibleParameters.empty());
 
     // Idempotent: a second pass finds nothing to do.
-    const auto successorGeneration = device.pluginAssignmentGeneration;
     CHECK_FALSE(legacy_devices::migrateRetiredDevice(device));
-    CHECK(device.pluginAssignmentGeneration == successorGeneration);
 }
 
 TEST_CASE("Migration keeps a user-renamed device's name", "[devices][legacy][aliases]") {

--- a/tests/devices/test_device_api.cpp
+++ b/tests/devices/test_device_api.cpp
@@ -248,6 +248,14 @@ TEST_CASE("A grid's links follow its pads when the grid is placed", "[device-api
     intoPad.amount = 1.0f;
     grid.macros.front().links.push_back(intoPad);
 
+    // The pad rack owns macros and mods of its own -- it is a RackInfo, a pad
+    // path resolves to it, and the modulation surfaces read its macros like any
+    // other rack's. A walk that descended straight into its chains left these
+    // behind.
+    if (pads.macros.empty())
+        pads.macros.emplace_back(0);
+    pads.macros.front().links.push_back(intoPad);
+
     const auto gridId = tracks.addDeviceToTrack(trackId, grid);
     REQUIRE(gridId != INVALID_DEVICE_ID);
     REQUIRE(gridId != kGridId);
@@ -272,6 +280,10 @@ TEST_CASE("A grid's links follow its pads when the grid is placed", "[device-api
 
     REQUIRE_FALSE(livePadDevice.macros.front().links.empty());
     CHECK(livePadDevice.macros.front().links.front().target.devicePath == livePadDevicePath);
+
+    REQUIRE_FALSE(live->pads->macros.empty());
+    REQUIRE_FALSE(live->pads->macros.front().links.empty());
+    CHECK(live->pads->macros.front().links.front().target.devicePath == livePadDevicePath);
 }
 
 TEST_CASE("Device parameters are reported in real units", "[device-api][inspection]") {

--- a/tests/devices/test_device_api.cpp
+++ b/tests/devices/test_device_api.cpp
@@ -77,37 +77,31 @@ TEST_CASE("Live device lookup rejects paths that address nothing", "[device-api]
     REQUIRE(devices.getDeviceParameters(missing).empty());
 }
 
-TEST_CASE("Each device added from a reusable template gets a fresh plugin assignment token",
+TEST_CASE("Each device added from a reusable template gets an id of its own",
           "[device-api][inspection]") {
+    // A browser entry is a template added over and over. Each placement is its
+    // own device: it runs its own plugin instance and keys its own op.
     auto& tracks = TrackManager::getInstance();
     const auto trackId = freshTrack("Track");
 
     DeviceInfo browserTemplate;
     browserTemplate.name = "Reusable effect";
     browserTemplate.pluginId = "template-effect";
-    const auto templateGeneration = browserTemplate.pluginAssignmentGeneration;
 
     const auto firstId = tracks.addDeviceToTrack(trackId, browserTemplate);
     const auto secondId = tracks.addDeviceToTrack(trackId, browserTemplate);
     REQUIRE(firstId != INVALID_DEVICE_ID);
     REQUIRE(secondId != INVALID_DEVICE_ID);
+    CHECK(firstId != secondId);
 
-    const auto* first = tracks.getDevice(trackId, firstId);
-    const auto* second = tracks.getDevice(trackId, secondId);
-    REQUIRE(first != nullptr);
-    REQUIRE(second != nullptr);
-    CHECK(first->pluginAssignmentGeneration != templateGeneration);
-    CHECK(second->pluginAssignmentGeneration != templateGeneration);
-    CHECK(first->pluginAssignmentGeneration != second->pluginAssignmentGeneration);
+    CHECK(tracks.getDevice(trackId, firstId) != nullptr);
+    CHECK(tracks.getDevice(trackId, secondId) != nullptr);
 }
 
-TEST_CASE("Devices sharing a DeviceId across sections still hold distinct assignment tokens",
-          "[device-api][inspection]") {
-    // The three sections keep independent DeviceId counters that all start at
-    // 1, so a top-level, a post-FX and a mixer-analysis device can carry the
-    // same bare id. The assignment token is what tells an arriving async load
-    // which of them it was asked for, and completeExternalPluginLoad accepts a
-    // matching (id, token) pair as proof the load is still wanted.
+TEST_CASE("The three sections hand out the same DeviceId", "[device-api][inspection]") {
+    // Not an accident to be fixed: the counters are section-local by design,
+    // and this is why runtime ownership keys on engine::DeviceKey rather than
+    // on a bare id, and why findUniqueBareDeviceIdMatch has to exist (#2261).
     auto& tracks = TrackManager::getInstance();
     const auto trackId = freshTrack("Track");
 
@@ -115,38 +109,20 @@ TEST_CASE("Devices sharing a DeviceId across sections still hold distinct assign
     effect.name = "Reusable effect";
     effect.pluginId = "template-effect";
 
-    const auto topLevelId = tracks.addDeviceToTrack(trackId, effect);
-    const auto postFxId = tracks.addDeviceToPostFx(trackId, effect);
-    REQUIRE(topLevelId != INVALID_DEVICE_ID);
-    REQUIRE(postFxId != INVALID_DEVICE_ID);
-
-    const auto* topLevel = tracks.getDevice(trackId, topLevelId);
-    REQUIRE(topLevel != nullptr);
-
-    const auto& postFx = tracks.getPostFxChainElements(trackId);
-    REQUIRE(postFx.size() == 1);
-
-    CHECK(postFx.front().device.pluginAssignmentGeneration != topLevel->pluginAssignmentGeneration);
-    CHECK(postFx.front().device.pluginAssignmentGeneration != effect.pluginAssignmentGeneration);
-}
-
-TEST_CASE("A mixer-analysis device gets its own assignment token", "[device-api][inspection]") {
-    auto& tracks = TrackManager::getInstance();
-    const auto trackId = freshTrack("Track");
-
     DeviceInfo analysis;
     analysis.name = "Reusable analyser";
     analysis.pluginId = "template-analyser";
 
-    REQUIRE(tracks.addDeviceToMixerAnalysis(trackId, analysis) != INVALID_DEVICE_ID);
+    const auto topLevelId = tracks.addDeviceToTrack(trackId, effect);
+    const auto postFxId = tracks.addDeviceToPostFx(trackId, effect);
+    const auto analysisId = tracks.addDeviceToMixerAnalysis(trackId, analysis);
 
-    const auto& elements = tracks.getMixerAnalysisElements(trackId);
-    REQUIRE(elements.size() == 1);
-    CHECK(elements.front().device.pluginAssignmentGeneration !=
-          analysis.pluginAssignmentGeneration);
+    REQUIRE(topLevelId != INVALID_DEVICE_ID);
+    CHECK(postFxId == topLevelId);
+    CHECK(analysisId == topLevelId);
 }
 
-TEST_CASE("A duplicated track's devices are distinct assignments from the originals",
+TEST_CASE("A duplicated track's devices are re-keyed away from the originals",
           "[device-api][inspection]") {
     auto& tracks = TrackManager::getInstance();
     const auto trackId = freshTrack("Track");
@@ -159,34 +135,28 @@ TEST_CASE("A duplicated track's devices are distinct assignments from the origin
     REQUIRE(sourceId != INVALID_DEVICE_ID);
     REQUIRE(tracks.addDeviceToPostFx(trackId, effect) != INVALID_DEVICE_ID);
 
-    const auto* source = tracks.getDevice(trackId, sourceId);
-    REQUIRE(source != nullptr);
-    const auto sourceGeneration = source->pluginAssignmentGeneration;
-    const auto sourcePostFxGeneration =
-        tracks.getPostFxChainElements(trackId).front().device.pluginAssignmentGeneration;
+    const auto sourcePostFxId = tracks.getPostFxChainElements(trackId).front().device.id;
 
     const auto copyId = tracks.duplicateTrack(trackId);
     REQUIRE(copyId != INVALID_TRACK_ID);
 
-    // The copy runs its own plugin instances, and DeviceIds are handed out
-    // again after clearAllTracks(), so a shared token would let a load the
-    // original requested complete onto the copy.
+    // The copy runs its own plugin instances, so sharing an id would mean
+    // sharing an op and, once the native engine binds them, a plugin.
     const auto& copiedTopLevel = tracks.getChainElements(copyId);
     REQUIRE_FALSE(copiedTopLevel.empty());
     REQUIRE(magda::isDevice(copiedTopLevel.front()));
-    CHECK(magda::getDevice(copiedTopLevel.front()).pluginAssignmentGeneration != sourceGeneration);
+    CHECK(magda::getDevice(copiedTopLevel.front()).id != sourceId);
 
     const auto& copiedPostFx = tracks.getPostFxChainElements(copyId);
     REQUIRE(copiedPostFx.size() == 1);
-    CHECK(copiedPostFx.front().device.pluginAssignmentGeneration != sourcePostFxGeneration);
+    CHECK(copiedPostFx.front().device.id != sourcePostFxId);
 }
 
 TEST_CASE("A pad's nested rack is re-keyed along with the pad itself", "[device-api][inspection]") {
     // Pads hold chain elements like any other chain, so a pre-populated Drum
     // Grid can arrive with a rack inside a pad. A walk that stopped at the
     // direct pad devices left everything under that rack carrying the source's
-    // DeviceIds -- keying the original's ops -- and its assignment tokens, so a
-    // late async load could complete onto the copy.
+    // DeviceIds, keying the original's ops.
     auto& tracks = TrackManager::getInstance();
     const auto trackId = freshTrack("Track");
 
@@ -194,7 +164,6 @@ TEST_CASE("A pad's nested rack is re-keyed along with the pad itself", "[device-
     nested.name = "Nested effect";
     nested.pluginId = "template-effect";
     nested.id = 4242;
-    const auto nestedGeneration = nested.pluginAssignmentGeneration;
 
     auto rack = std::make_unique<RackInfo>();
     rack->id = 9911;
@@ -232,7 +201,77 @@ TEST_CASE("A pad's nested rack is re-keyed along with the pad itself", "[device-
 
     const auto& liveNested = magda::getDevice(nestedElements.front());
     CHECK(liveNested.id != 4242);
-    CHECK(liveNested.pluginAssignmentGeneration != nestedGeneration);
+}
+
+TEST_CASE("A grid's links follow its pads when the grid is placed", "[device-api][inspection]") {
+    // A pre-populated Drum Grid arrives with links already pointing into its
+    // pads: the grid's own macro drives a pad device's parameter, and that pad
+    // device's macro drives the same one. Placing it re-keys the whole pad
+    // subtree, and a link left on the old address resolves to nothing -- the
+    // macro is still there, still says it is linked, and moves nothing.
+    auto& tracks = TrackManager::getInstance();
+    const auto trackId = freshTrack("Track");
+
+    constexpr DeviceId kGridId = 7000;
+    constexpr DeviceId kPadDeviceId = 7001;
+    constexpr ChainId kPadChainId = 1;
+
+    DeviceInfo padDevice;
+    padDevice.name = "Pad effect";
+    padDevice.pluginId = "template-effect";
+    padDevice.id = kPadDeviceId;
+
+    const auto sourcePadDevicePath =
+        ChainNodePath::padChain(trackId, kGridId, kPadChainId).withDevice(kPadDeviceId);
+
+    // The pad device's own macro, pointing at itself: a link that lives inside
+    // the subtree and names an id the re-key moves.
+    MacroLink self;
+    self.target.devicePath = sourcePadDevicePath;
+    self.target.paramIndex = 3;
+    self.amount = 1.0f;
+    padDevice.macros.front().links.push_back(self);
+
+    DeviceInfo grid;
+    grid.name = "Grid";
+    grid.pluginId = "drumgrid";
+    grid.id = kGridId;
+    auto& pads = magda::ensurePads(grid);
+    auto& pad = magda::ensurePadChain(pads, 0);
+    pad.id = kPadChainId;
+    pad.elements.push_back(ChainElement{padDevice});
+
+    // The grid's macro, pointing down into the pad.
+    MacroLink intoPad;
+    intoPad.target.devicePath = sourcePadDevicePath;
+    intoPad.target.paramIndex = 3;
+    intoPad.amount = 1.0f;
+    grid.macros.front().links.push_back(intoPad);
+
+    const auto gridId = tracks.addDeviceToTrack(trackId, grid);
+    REQUIRE(gridId != INVALID_DEVICE_ID);
+    REQUIRE(gridId != kGridId);
+
+    const auto* live = tracks.getDevice(trackId, gridId);
+    REQUIRE(live != nullptr);
+    REQUIRE(static_cast<bool>(live->pads));
+    REQUIRE(live->pads->chains.size() == 1);
+
+    const auto& liveElements = live->pads->chains.front().elements;
+    REQUIRE(liveElements.size() == 1);
+    REQUIRE(magda::isDevice(liveElements.front()));
+    const auto& livePadDevice = magda::getDevice(liveElements.front());
+    REQUIRE(livePadDevice.id != kPadDeviceId);
+
+    const auto livePadDevicePath =
+        ChainNodePath::padChain(trackId, gridId, live->pads->chains.front().id)
+            .withDevice(livePadDevice.id);
+
+    REQUIRE_FALSE(live->macros.front().links.empty());
+    CHECK(live->macros.front().links.front().target.devicePath == livePadDevicePath);
+
+    REQUIRE_FALSE(livePadDevice.macros.front().links.empty());
+    CHECK(livePadDevice.macros.front().links.front().target.devicePath == livePadDevicePath);
 }
 
 TEST_CASE("Device parameters are reported in real units", "[device-api][inspection]") {

--- a/tests/devices/test_external_plugin_lookup.cpp
+++ b/tests/devices/test_external_plugin_lookup.cpp
@@ -144,22 +144,6 @@ TEST_CASE("A project from another host resolves by name and format", "[plugins][
     CHECK(match.description.manufacturerName == "Xfer Records");
 }
 
-TEST_CASE("Plugin assignment generations survive snapshots and explicitly change for replacements",
-          "[plugins][lookup]") {
-    auto assignment = saved("Kontakt", "NI", "/Library/Kontakt.vst3", true);
-    const auto copy = assignment;
-    const auto originalGeneration = assignment.pluginAssignmentGeneration;
-
-    // Production replacement paths mutate an existing DeviceInfo or copy a
-    // browser template, so replacement identity is authored explicitly rather
-    // than inferred from C++ object construction.
-    assignment.beginNewPluginAssignment();
-    assignment.isInstrument = false;
-
-    CHECK(copy.pluginAssignmentGeneration == originalGeneration);
-    CHECK(assignment.pluginAssignmentGeneration > originalGeneration);
-}
-
 TEST_CASE("The format is part of the last pass", "[plugins][lookup]") {
     // Same name, different format. An AU is not a substitute for the VST3 a
     // project saved: the two have different parameter lists and different

--- a/tests/engine/test_engine_external_device.cpp
+++ b/tests/engine/test_engine_external_device.cpp
@@ -419,8 +419,7 @@ adapter::RequestedPlugin requestFor(
     const std::optional<juce::PluginDescription>& resolved = std::nullopt) {
     const auto description = resolved.value_or(descriptionFor(device));
     const auto key = keyFor(device);
-    if (!assignments.current(key))
-        assignments.assign(key);
+    assignments.ensureAssignment(key);
     return {.assignment = assignments.request(key),
             .displayName = device.name,
             .resolvedIsInstrument = description.isInstrument};
@@ -1428,7 +1427,7 @@ TEST_CASE("The asynchronous entry point reports a missing plugin the same way",
         .formats = &formats, .knownPlugins = &empty, .context = contextFor()};
 
     adapter::PluginAssignments assignments;
-    assignments.assign(keyFor(missing));
+    assignments.ensureAssignment(keyFor(missing));
 
     bool called = false;
     adapter::ExternalDeviceResult delivered;
@@ -1477,7 +1476,7 @@ TEST_CASE("The asynchronous entry point resolves once and completes an installed
         .formats = &formats, .knownPlugins = &known, .context = contextFor()};
 
     adapter::PluginAssignments assignments;
-    assignments.assign(keyFor(model));
+    assignments.ensureAssignment(keyFor(model));
 
     bool called = false;
     adapter::ExternalDeviceResult delivered;
@@ -1532,9 +1531,8 @@ TEST_CASE("A load that finishes late restores from the model as it is now", "[en
     // assignment, so nothing about the assignment changes.
     model.parameters[1].currentValue = 0.6f;
 
-    const auto result =
-        adapter::completeExternalPluginLoad(std::move(plugin), {}, requested, assignments,
-                                            [&](magda::engine::DeviceKey) { return &model; });
+    const auto result = adapter::completeExternalPluginLoad(
+        std::move(plugin), {}, requested, [&](magda::engine::DeviceKey) { return &model; });
 
     REQUIRE(result.device != nullptr);
     CHECK(raw->tone->getValue() == Catch::Approx(0.6f));
@@ -1561,9 +1559,8 @@ TEST_CASE("State applied while a plugin loads is the state that gets restored",
     const juce::MemoryBlock chunk(&preset, sizeof(preset));
     model.pluginState = chunk.toBase64Encoding();
 
-    const auto result =
-        adapter::completeExternalPluginLoad(std::move(plugin), {}, requested, assignments,
-                                            [&](magda::engine::DeviceKey) { return &model; });
+    const auto result = adapter::completeExternalPluginLoad(
+        std::move(plugin), {}, requested, [&](magda::engine::DeviceKey) { return &model; });
 
     REQUIRE(result.device != nullptr);
     CHECK(raw->stateRestores == 1);
@@ -1582,7 +1579,7 @@ TEST_CASE("A device deleted while its plugin loaded is not completed", "[engine]
     assignments.release(keyFor(device));
 
     const auto result = adapter::completeExternalPluginLoad(
-        std::move(plugin), {}, requested, assignments,
+        std::move(plugin), {}, requested,
         [](magda::engine::DeviceKey) -> const magda::DeviceInfo* { return nullptr; });
 
     CHECK(result.device == nullptr);
@@ -1602,13 +1599,12 @@ TEST_CASE("A device that changed plugin while loading is not completed", "[engin
 
     // The slot keeps its id and is assigned again: a new assignment on a key
     // that had one.
-    assignments.assign(keyFor(model));
+    assignments.replaceAssignment(keyFor(model));
     model.name = "Something Else";
     model.fileOrIdentifier = "/Library/SomethingElse.vst3";
 
-    const auto result =
-        adapter::completeExternalPluginLoad(std::move(plugin), {}, requested, assignments,
-                                            [&](magda::engine::DeviceKey) { return &model; });
+    const auto result = adapter::completeExternalPluginLoad(
+        std::move(plugin), {}, requested, [&](magda::engine::DeviceKey) { return &model; });
 
     CHECK(result.device == nullptr);
     CHECK(result.failure.contains("changed plugin"));
@@ -1619,9 +1615,9 @@ TEST_CASE("A load that failed reports the loader's reason", "[engine][external]"
     adapter::PluginAssignments assignments;
     const auto requested = requestFor(assignments, model);
 
-    const auto result = adapter::completeExternalPluginLoad(
-        nullptr, "the file was not there", requested, assignments,
-        [&](magda::engine::DeviceKey) { return &model; });
+    const auto result =
+        adapter::completeExternalPluginLoad(nullptr, "the file was not there", requested,
+                                            [&](magda::engine::DeviceKey) { return &model; });
 
     CHECK(result.device == nullptr);
     CHECK(result.failure.contains("the file was not there"));
@@ -1653,9 +1649,8 @@ TEST_CASE("A scanned plugin's own identifier is not read as a change", "[engine]
     auto plugin = std::make_unique<StubPlugin>(2, 2, 0);
     auto* raw = plugin.get();
 
-    const auto result =
-        adapter::completeExternalPluginLoad(std::move(plugin), {}, requested, assignments,
-                                            [&](magda::engine::DeviceKey) { return &model; });
+    const auto result = adapter::completeExternalPluginLoad(
+        std::move(plugin), {}, requested, [&](magda::engine::DeviceKey) { return &model; });
 
     REQUIRE(result.device != nullptr);
     CHECK(result.failure.isEmpty());
@@ -1688,9 +1683,8 @@ TEST_CASE("Resolved metadata gained while loading does not change the assignment
     model.uniqueId = "VST3-Serum-1234abcd-4d617373";
 
     auto plugin = std::make_unique<StubPlugin>(2, 2, 0);
-    const auto result =
-        adapter::completeExternalPluginLoad(std::move(plugin), {}, requested, assignments,
-                                            [&](magda::engine::DeviceKey) { return &model; });
+    const auto result = adapter::completeExternalPluginLoad(
+        std::move(plugin), {}, requested, [&](magda::engine::DeviceKey) { return &model; });
 
     REQUIRE(result.device != nullptr);
     CHECK(result.failure.isEmpty());
@@ -1710,13 +1704,12 @@ TEST_CASE("An imported device swapped to the other half of its bundle is a chang
     adapter::PluginAssignments assignments;
     const auto requested = requestFor(assignments, model);
 
-    assignments.assign(keyFor(model));
+    assignments.replaceAssignment(keyFor(model));
     model.isInstrument = true;
 
     auto plugin = std::make_unique<StubPlugin>(2, 2, 0);
-    const auto result =
-        adapter::completeExternalPluginLoad(std::move(plugin), {}, requested, assignments,
-                                            [&](magda::engine::DeviceKey) { return &model; });
+    const auto result = adapter::completeExternalPluginLoad(
+        std::move(plugin), {}, requested, [&](magda::engine::DeviceKey) { return &model; });
 
     CHECK(result.device == nullptr);
     CHECK(result.failure.contains("changed plugin"));
@@ -1735,14 +1728,13 @@ TEST_CASE("An imported device swapped to another vendor's plugin is a change",
     adapter::PluginAssignments assignments;
     const auto requested = requestFor(assignments, model);
 
-    assignments.assign(keyFor(model));
+    assignments.replaceAssignment(keyFor(model));
     model.manufacturer = "Another";
     model.fileOrIdentifier = "/Another/Saturator.vst3";
 
     auto plugin = std::make_unique<StubPlugin>(2, 2, 0);
-    const auto result =
-        adapter::completeExternalPluginLoad(std::move(plugin), {}, requested, assignments,
-                                            [&](magda::engine::DeviceKey) { return &model; });
+    const auto result = adapter::completeExternalPluginLoad(
+        std::move(plugin), {}, requested, [&](magda::engine::DeviceKey) { return &model; });
 
     CHECK(result.device == nullptr);
     CHECK(result.failure.contains("changed plugin"));
@@ -1760,15 +1752,14 @@ TEST_CASE("A duplicate cannot accept the load its source asked for", "[engine][e
 
     auto copy = source;  // duplicate, paste, preset import, undo reinsertion
     copy.id = 2;
-    assignments.assign(keyFor(copy));
+    assignments.replaceAssignment(keyFor(copy));
 
     // The load arrives while only the copy is still in the project.
     assignments.release(keyFor(source));
 
     auto plugin = std::make_unique<StubPlugin>(2, 2, 0);
-    const auto result =
-        adapter::completeExternalPluginLoad(std::move(plugin), {}, requested, assignments,
-                                            [&](magda::engine::DeviceKey) { return &copy; });
+    const auto result = adapter::completeExternalPluginLoad(
+        std::move(plugin), {}, requested, [&](magda::engine::DeviceKey) { return &copy; });
 
     CHECK(result.device == nullptr);
     CHECK(result.failure.contains("removed while"));
@@ -1781,7 +1772,7 @@ TEST_CASE("A device in another section cannot accept the load", "[engine][extern
     model.id = 1;
 
     adapter::PluginAssignments assignments;
-    assignments.assign({magda::ChainSegment::PostFx, model.id});
+    assignments.replaceAssignment({magda::ChainSegment::PostFx, model.id});
 
     const adapter::RequestedPlugin requested{
         .assignment = assignments.request({magda::ChainSegment::PostFx, model.id}),
@@ -1790,12 +1781,11 @@ TEST_CASE("A device in another section cannot accept the load", "[engine][extern
 
     // The main-FX device with the same integer is the one still live.
     assignments.release({magda::ChainSegment::PostFx, model.id});
-    assignments.assign({magda::ChainSegment::Fx, model.id});
+    assignments.replaceAssignment({magda::ChainSegment::Fx, model.id});
 
     auto plugin = std::make_unique<StubPlugin>(2, 2, 0);
-    const auto result =
-        adapter::completeExternalPluginLoad(std::move(plugin), {}, requested, assignments,
-                                            [&](magda::engine::DeviceKey) { return &model; });
+    const auto result = adapter::completeExternalPluginLoad(
+        std::move(plugin), {}, requested, [&](magda::engine::DeviceKey) { return &model; });
 
     CHECK(result.device == nullptr);
     // "removed", not "changed plugin": the live main-FX device is a different
@@ -1814,11 +1804,57 @@ TEST_CASE("A load nobody registered is refused rather than completed", "[engine]
                                              .resolvedIsInstrument = false};
 
     auto plugin = std::make_unique<StubPlugin>(2, 2, 0);
-    const auto result =
-        adapter::completeExternalPluginLoad(std::move(plugin), {}, requested, assignments,
-                                            [&](magda::engine::DeviceKey) { return &model; });
+    const auto result = adapter::completeExternalPluginLoad(
+        std::move(plugin), {}, requested, [&](magda::engine::DeviceKey) { return &model; });
 
     CHECK(result.device == nullptr);
     CHECK(result.failure.isNotEmpty());
     CHECK(result.restoredParameters.empty());
+}
+
+TEST_CASE("A load outliving the runtime that started it is refused", "[engine][external]") {
+    // The project was closed while a plugin was still loading, and the thing
+    // that owned the assignments went with it. The completion still arrives,
+    // and it has to answer without reaching into any of that.
+    auto model = externalDeviceSaving(1.0f, 0.5f);
+
+    adapter::RequestedPlugin requested;
+    {
+        adapter::PluginAssignments assignments;
+        requested = requestFor(assignments, model);
+        REQUIRE(requested.assignment.isStillWanted());
+    }
+
+    CHECK_FALSE(requested.assignment.isStillWanted());
+
+    auto plugin = std::make_unique<StubPlugin>(2, 2, 0);
+    const auto result = adapter::completeExternalPluginLoad(
+        std::move(plugin), {}, requested, [&](magda::engine::DeviceKey) { return &model; });
+
+    CHECK(result.device == nullptr);
+    CHECK(result.failure.contains("removed while"));
+}
+
+TEST_CASE("Registering a device that is already live does not expire its load",
+          "[engine][external]") {
+    // Ordinary registration: a plan prepared again, the project walked again.
+    // Minting a new assignment for that would abandon a load that is still
+    // wanted, over and over for anything that re-registers on every recompile.
+    auto model = externalDeviceSaving(1.0f, 0.5f);
+
+    adapter::PluginAssignments assignments;
+    const auto requested = requestFor(assignments, model);
+
+    for (int again = 0; again < 3; ++again)
+        assignments.ensureAssignment(keyFor(model));
+
+    auto plugin = std::make_unique<StubPlugin>(2, 2, 0);
+    auto* raw = plugin.get();
+
+    const auto result = adapter::completeExternalPluginLoad(
+        std::move(plugin), {}, requested, [&](magda::engine::DeviceKey) { return &model; });
+
+    REQUIRE(result.device != nullptr);
+    CHECK(result.failure.isEmpty());
+    CHECK(raw->tone->getValue() == Catch::Approx(0.5f));
 }

--- a/tests/engine/test_engine_external_device.cpp
+++ b/tests/engine/test_engine_external_device.cpp
@@ -15,6 +15,7 @@
 #include "magda/daw/audio/plugin_manager/ExternalPluginState.hpp"
 #include "magda/daw/audio/plugins/engine/EngineDeviceFactory.hpp"
 #include "magda/daw/audio/plugins/engine/EngineExternalDevice.hpp"
+#include "magda/daw/audio/plugins/engine/PluginAssignments.hpp"
 #include "param/ParamBlock.hpp"
 #include "transport/TempoMap.hpp"
 
@@ -404,12 +405,23 @@ juce::PluginDescription descriptionFor(const magda::DeviceInfo& device) {
     return description;
 }
 
+/// The key a device holds while these tests keep it in the main FX section.
+magda::engine::DeviceKey keyFor(const magda::DeviceInfo& device) {
+    return {magda::ChainSegment::Fx, device.id};
+}
+
+/// The device registered as live, and the request a load for it carries.
+///
+/// Registration is the caller's job in production too: a device that becomes
+/// live is assigned a handle, and nothing about the DeviceInfo grants one.
 adapter::RequestedPlugin requestFor(
-    const magda::DeviceInfo& device,
+    adapter::PluginAssignments& assignments, const magda::DeviceInfo& device,
     const std::optional<juce::PluginDescription>& resolved = std::nullopt) {
     const auto description = resolved.value_or(descriptionFor(device));
-    return {.deviceId = device.id,
-            .assignmentGeneration = device.pluginAssignmentGeneration,
+    const auto key = keyFor(device);
+    if (!assignments.current(key))
+        assignments.assign(key);
+    return {.assignment = assignments.request(key),
             .displayName = device.name,
             .resolvedIsInstrument = description.isInstrument};
 }
@@ -859,7 +871,6 @@ TEST_CASE("Resolution returns planning facts without rewriting the saved assignm
     model.fileOrIdentifier = "/Library/Stub.vst3";
     model.audioInputChannels = 2;
     model.audioOutputChannels = 2;
-    const auto generation = model.pluginAssignmentGeneration;
 
     auto installed = descriptionFor(model);
     installed.name = "Scanner's canonical name";
@@ -888,7 +899,6 @@ TEST_CASE("Resolution returns planning facts without rewriting the saved assignm
     CHECK(model.deviceType == magda::DeviceType::Effect);
     CHECK(model.audioInputChannels == 2);
     CHECK(model.audioOutputChannels == 2);
-    CHECK(model.pluginAssignmentGeneration == generation);
 
     // The transient copy carries only the role needed for placement validation
     // and plan compilation. Zero/default scan buses are not treated as live.
@@ -1417,10 +1427,14 @@ TEST_CASE("The asynchronous entry point reports a missing plugin the same way",
     const adapter::ExternalPluginServices services{
         .formats = &formats, .knownPlugins = &empty, .context = contextFor()};
 
+    adapter::PluginAssignments assignments;
+    assignments.assign(keyFor(missing));
+
     bool called = false;
     adapter::ExternalDeviceResult delivered;
     adapter::createEngineExternalDeviceAsync(
-        missing, services, false, [&](magda::DeviceId) { return &missing; },
+        missing, keyFor(missing), services, false, assignments,
+        [&](magda::engine::DeviceKey) { return &missing; },
         [&](adapter::ExternalDeviceResult result) {
             called = true;
             delivered = std::move(result);
@@ -1443,7 +1457,6 @@ TEST_CASE("The asynchronous entry point resolves once and completes an installed
     model.deviceType = magda::DeviceType::Effect;
     model.audioInputChannels = 1;
     model.audioOutputChannels = 1;
-    const auto generation = model.pluginAssignmentGeneration;
 
     auto installed = descriptionFor(model);
     installed.name = "Installed Stub";
@@ -1463,10 +1476,14 @@ TEST_CASE("The asynchronous entry point resolves once and completes an installed
     const adapter::ExternalPluginServices services{
         .formats = &formats, .knownPlugins = &known, .context = contextFor()};
 
+    adapter::PluginAssignments assignments;
+    assignments.assign(keyFor(model));
+
     bool called = false;
     adapter::ExternalDeviceResult delivered;
     const auto resolved = adapter::createEngineExternalDeviceAsync(
-        model, services, false, [&](magda::DeviceId) { return &model; },
+        model, keyFor(model), services, false, assignments,
+        [&](magda::engine::DeviceKey) { return &model; },
         [&](adapter::ExternalDeviceResult result) {
             called = true;
             delivered = std::move(result);
@@ -1484,7 +1501,6 @@ TEST_CASE("The asynchronous entry point resolves once and completes an installed
     CHECK(model.deviceType == magda::DeviceType::Effect);
     CHECK(model.audioInputChannels == 1);
     CHECK(model.audioOutputChannels == 1);
-    CHECK(model.pluginAssignmentGeneration == generation);
 
     for (int attempts = 0; !called && attempts < 100; ++attempts)
         juce::MessageManager::getInstance()->runDispatchLoopUntil(10);
@@ -1509,13 +1525,16 @@ TEST_CASE("A load that finishes late restores from the model as it is now", "[en
     auto* raw = plugin.get();
 
     auto model = externalDeviceSaving(1.0f, 0.25f);
-    const auto requested = requestFor(model);
+    adapter::PluginAssignments assignments;
+    const auto requested = requestFor(assignments, model);
 
-    // The edit, made while the plugin was loading.
+    // The edit, made while the plugin was loading. It is an edit to this
+    // assignment, so nothing about the assignment changes.
     model.parameters[1].currentValue = 0.6f;
 
-    const auto result = adapter::completeExternalPluginLoad(
-        std::move(plugin), {}, requested, [&](magda::DeviceId) { return &model; });
+    const auto result =
+        adapter::completeExternalPluginLoad(std::move(plugin), {}, requested, assignments,
+                                            [&](magda::engine::DeviceKey) { return &model; });
 
     REQUIRE(result.device != nullptr);
     CHECK(raw->tone->getValue() == Catch::Approx(0.6f));
@@ -1533,7 +1552,8 @@ TEST_CASE("State applied while a plugin loads is the state that gets restored",
     auto* raw = plugin.get();
 
     auto model = externalDeviceSaving(1.0f, 0.25f);
-    const auto requested = requestFor(model);
+    adapter::PluginAssignments assignments;
+    const auto requested = requestFor(assignments, model);
 
     // A preset selected after the load began. Its chunk is the current model's
     // authority at completion, not the empty state on the request-time copy.
@@ -1541,8 +1561,9 @@ TEST_CASE("State applied while a plugin loads is the state that gets restored",
     const juce::MemoryBlock chunk(&preset, sizeof(preset));
     model.pluginState = chunk.toBase64Encoding();
 
-    const auto result = adapter::completeExternalPluginLoad(
-        std::move(plugin), {}, requested, [&](magda::DeviceId) { return &model; });
+    const auto result =
+        adapter::completeExternalPluginLoad(std::move(plugin), {}, requested, assignments,
+                                            [&](magda::engine::DeviceKey) { return &model; });
 
     REQUIRE(result.device != nullptr);
     CHECK(raw->stateRestores == 1);
@@ -1554,10 +1575,15 @@ TEST_CASE("A device deleted while its plugin loaded is not completed", "[engine]
     auto plugin = std::make_unique<StubPlugin>(2, 2, 0);
 
     const auto device = externalDevice();
-    const auto requested = requestFor(device);
+    adapter::PluginAssignments assignments;
+    const auto requested = requestFor(assignments, device);
+
+    // Deletion releases the assignment, which is what expires the request.
+    assignments.release(keyFor(device));
+
     const auto result = adapter::completeExternalPluginLoad(
-        std::move(plugin), {}, requested,
-        [](magda::DeviceId) -> const magda::DeviceInfo* { return nullptr; });
+        std::move(plugin), {}, requested, assignments,
+        [](magda::engine::DeviceKey) -> const magda::DeviceInfo* { return nullptr; });
 
     CHECK(result.device == nullptr);
     CHECK(result.failure.contains("removed while"));
@@ -1571,14 +1597,18 @@ TEST_CASE("A device that changed plugin while loading is not completed", "[engin
     auto model = externalDevice();
     model.name = "Massive X";
     model.fileOrIdentifier = "/Library/MassiveX.vst3";
-    const auto requested = requestFor(model);
+    adapter::PluginAssignments assignments;
+    const auto requested = requestFor(assignments, model);
 
-    model.beginNewPluginAssignment();
+    // The slot keeps its id and is assigned again: a new assignment on a key
+    // that had one.
+    assignments.assign(keyFor(model));
     model.name = "Something Else";
     model.fileOrIdentifier = "/Library/SomethingElse.vst3";
 
-    const auto result = adapter::completeExternalPluginLoad(
-        std::move(plugin), {}, requested, [&](magda::DeviceId) { return &model; });
+    const auto result =
+        adapter::completeExternalPluginLoad(std::move(plugin), {}, requested, assignments,
+                                            [&](magda::engine::DeviceKey) { return &model; });
 
     CHECK(result.device == nullptr);
     CHECK(result.failure.contains("changed plugin"));
@@ -1586,10 +1616,12 @@ TEST_CASE("A device that changed plugin while loading is not completed", "[engin
 
 TEST_CASE("A load that failed reports the loader's reason", "[engine][external]") {
     auto model = externalDevice();
-    const auto requested = requestFor(model);
+    adapter::PluginAssignments assignments;
+    const auto requested = requestFor(assignments, model);
 
     const auto result = adapter::completeExternalPluginLoad(
-        nullptr, "the file was not there", requested, [&](magda::DeviceId) { return &model; });
+        nullptr, "the file was not there", requested, assignments,
+        [&](magda::engine::DeviceKey) { return &model; });
 
     CHECK(result.device == nullptr);
     CHECK(result.failure.contains("the file was not there"));
@@ -1615,13 +1647,15 @@ TEST_CASE("A scanned plugin's own identifier is not read as a change", "[engine]
     model.fileOrIdentifier = scanned.fileOrIdentifier;
     model.uniqueId = scanned.createIdentifierString();
 
-    const auto requested = requestFor(model, scanned);
+    adapter::PluginAssignments assignments;
+    const auto requested = requestFor(assignments, model, scanned);
 
     auto plugin = std::make_unique<StubPlugin>(2, 2, 0);
     auto* raw = plugin.get();
 
-    const auto result = adapter::completeExternalPluginLoad(
-        std::move(plugin), {}, requested, [&](magda::DeviceId) { return &model; });
+    const auto result =
+        adapter::completeExternalPluginLoad(std::move(plugin), {}, requested, assignments,
+                                            [&](magda::engine::DeviceKey) { return &model; });
 
     REQUIRE(result.device != nullptr);
     CHECK(result.failure.isEmpty());
@@ -1644,7 +1678,8 @@ TEST_CASE("Resolved metadata gained while loading does not change the assignment
     resolved.fileOrIdentifier = "/Library/Serum.vst3";
     resolved.isInstrument = true;
     resolved.uniqueId = 0x53657275;
-    const auto requested = requestFor(model, resolved);
+    adapter::PluginAssignments assignments;
+    const auto requested = requestFor(assignments, model, resolved);
 
     model.manufacturer = "Xfer Records";
     model.fileOrIdentifier = "/Library/Serum.vst3";
@@ -1653,8 +1688,9 @@ TEST_CASE("Resolved metadata gained while loading does not change the assignment
     model.uniqueId = "VST3-Serum-1234abcd-4d617373";
 
     auto plugin = std::make_unique<StubPlugin>(2, 2, 0);
-    const auto result = adapter::completeExternalPluginLoad(
-        std::move(plugin), {}, requested, [&](magda::DeviceId) { return &model; });
+    const auto result =
+        adapter::completeExternalPluginLoad(std::move(plugin), {}, requested, assignments,
+                                            [&](magda::engine::DeviceKey) { return &model; });
 
     REQUIRE(result.device != nullptr);
     CHECK(result.failure.isEmpty());
@@ -1662,8 +1698,8 @@ TEST_CASE("Resolved metadata gained while loading does not change the assignment
 
 TEST_CASE("An imported device swapped to the other half of its bundle is a change",
           "[engine][external]") {
-    // The generation distinguishes two assignments even where JUCE's compact
-    // identifier and all bundle-level metadata do not.
+    // The assignment distinguishes the two even where JUCE's compact identifier
+    // and all bundle-level metadata do not.
     auto model = externalDeviceSaving(1.0f, 0.5f);
     model.name = "Kontakt";
     model.manufacturer = "NI";
@@ -1671,14 +1707,16 @@ TEST_CASE("An imported device swapped to the other half of its bundle is a chang
     model.isInstrument = false;
     model.uniqueId = {};  // imported: nothing scanned it
 
-    const auto requested = requestFor(model);
+    adapter::PluginAssignments assignments;
+    const auto requested = requestFor(assignments, model);
 
-    model.beginNewPluginAssignment();
+    assignments.assign(keyFor(model));
     model.isInstrument = true;
 
     auto plugin = std::make_unique<StubPlugin>(2, 2, 0);
-    const auto result = adapter::completeExternalPluginLoad(
-        std::move(plugin), {}, requested, [&](magda::DeviceId) { return &model; });
+    const auto result =
+        adapter::completeExternalPluginLoad(std::move(plugin), {}, requested, assignments,
+                                            [&](magda::engine::DeviceKey) { return &model; });
 
     CHECK(result.device == nullptr);
     CHECK(result.failure.contains("changed plugin"));
@@ -1694,16 +1732,93 @@ TEST_CASE("An imported device swapped to another vendor's plugin is a change",
     model.fileOrIdentifier = "/Library/Saturator.vst3";
     model.uniqueId = {};
 
-    const auto requested = requestFor(model);
+    adapter::PluginAssignments assignments;
+    const auto requested = requestFor(assignments, model);
 
-    model.beginNewPluginAssignment();
+    assignments.assign(keyFor(model));
     model.manufacturer = "Another";
     model.fileOrIdentifier = "/Another/Saturator.vst3";
 
     auto plugin = std::make_unique<StubPlugin>(2, 2, 0);
-    const auto result = adapter::completeExternalPluginLoad(
-        std::move(plugin), {}, requested, [&](magda::DeviceId) { return &model; });
+    const auto result =
+        adapter::completeExternalPluginLoad(std::move(plugin), {}, requested, assignments,
+                                            [&](magda::engine::DeviceKey) { return &model; });
 
     CHECK(result.device == nullptr);
     CHECK(result.failure.contains("changed plugin"));
+}
+
+TEST_CASE("A duplicate cannot accept the load its source asked for", "[engine][external]") {
+    // The copy is a different device with an id of its own, and there is
+    // nothing in the DeviceInfo it was copied from that could have made it look
+    // like the original. It is registered as the placement it is.
+    auto source = externalDeviceSaving(1.0f, 0.5f);
+    source.id = 1;
+
+    adapter::PluginAssignments assignments;
+    const auto requested = requestFor(assignments, source);
+
+    auto copy = source;  // duplicate, paste, preset import, undo reinsertion
+    copy.id = 2;
+    assignments.assign(keyFor(copy));
+
+    // The load arrives while only the copy is still in the project.
+    assignments.release(keyFor(source));
+
+    auto plugin = std::make_unique<StubPlugin>(2, 2, 0);
+    const auto result =
+        adapter::completeExternalPluginLoad(std::move(plugin), {}, requested, assignments,
+                                            [&](magda::engine::DeviceKey) { return &copy; });
+
+    CHECK(result.device == nullptr);
+    CHECK(result.failure.contains("removed while"));
+}
+
+TEST_CASE("A device in another section cannot accept the load", "[engine][external]") {
+    // DeviceId is allocated per section, so the post-FX device below is also
+    // device 1. A bare id would have named both.
+    auto model = externalDeviceSaving(1.0f, 0.5f);
+    model.id = 1;
+
+    adapter::PluginAssignments assignments;
+    assignments.assign({magda::ChainSegment::PostFx, model.id});
+
+    const adapter::RequestedPlugin requested{
+        .assignment = assignments.request({magda::ChainSegment::PostFx, model.id}),
+        .displayName = model.name,
+        .resolvedIsInstrument = false};
+
+    // The main-FX device with the same integer is the one still live.
+    assignments.release({magda::ChainSegment::PostFx, model.id});
+    assignments.assign({magda::ChainSegment::Fx, model.id});
+
+    auto plugin = std::make_unique<StubPlugin>(2, 2, 0);
+    const auto result =
+        adapter::completeExternalPluginLoad(std::move(plugin), {}, requested, assignments,
+                                            [&](magda::engine::DeviceKey) { return &model; });
+
+    CHECK(result.device == nullptr);
+    // "removed", not "changed plugin": the live main-FX device is a different
+    // key, so it was not offered as a stand-in for the one that went away.
+    CHECK(result.failure.contains("removed while"));
+}
+
+TEST_CASE("A load nobody registered is refused rather than completed", "[engine][external]") {
+    // The failure direction. The device is in the model and the plugin loaded
+    // fine; what is missing is the registration, and the answer is no.
+    auto model = externalDeviceSaving(1.0f, 0.5f);
+
+    const adapter::PluginAssignments assignments;
+    const adapter::RequestedPlugin requested{.assignment = assignments.request(keyFor(model)),
+                                             .displayName = model.name,
+                                             .resolvedIsInstrument = false};
+
+    auto plugin = std::make_unique<StubPlugin>(2, 2, 0);
+    const auto result =
+        adapter::completeExternalPluginLoad(std::move(plugin), {}, requested, assignments,
+                                            [&](magda::engine::DeviceKey) { return &model; });
+
+    CHECK(result.device == nullptr);
+    CHECK(result.failure.isNotEmpty());
+    CHECK(result.restoredParameters.empty());
 }

--- a/tests/engine/test_engine_external_device.cpp
+++ b/tests/engine/test_engine_external_device.cpp
@@ -1858,3 +1858,51 @@ TEST_CASE("Registering a device that is already live does not expire its load",
     CHECK(result.failure.isEmpty());
     CHECK(raw->tone->getValue() == Catch::Approx(0.5f));
 }
+
+TEST_CASE("A runtime torn down before dispatch is never called back", "[engine][external]") {
+    // The other half of the shutdown case, through the entry point a session
+    // actually uses. JUCE stores the completion and runs it a turn or more
+    // later, and in production that callback is the runtime's own -- it
+    // publishes the device into the project. So the load must be dropped
+    // before it is invoked, not refused inside it.
+    juce::ScopedJuceInitialiser_GUI juce;
+
+    auto model = externalDevice();
+    model.name = "My Stub";
+    model.fileOrIdentifier = "stub.plugin";
+
+    auto installed = descriptionFor(model);
+    installed.name = "Installed Stub";
+    installed.pluginFormatName = "StubFormat";
+    installed.fileOrIdentifier = model.fileOrIdentifier;
+
+    juce::KnownPluginList known;
+    known.addType(installed);
+    juce::AudioPluginFormatManager formats;
+    formats.addFormat(std::make_unique<StubFormat>());
+
+    const adapter::ExternalPluginServices services{
+        .formats = &formats, .knownPlugins = &known, .context = contextFor()};
+
+    bool called = false;
+    {
+        adapter::PluginAssignments assignments;
+        assignments.ensureAssignment(keyFor(model));
+
+        const auto resolved = adapter::createEngineExternalDeviceAsync(
+            model, keyFor(model), services, false, assignments,
+            [&](magda::engine::DeviceKey) { return &model; },
+            [&](adapter::ExternalDeviceResult) { called = true; });
+
+        REQUIRE(resolved);
+        // Nothing has dispatched yet: the creation is queued, not done.
+        REQUIRE_FALSE(called);
+    }
+
+    // The project closed. Everything the completion would have published into
+    // is gone, and the plugin only arrives now.
+    for (int attempts = 0; attempts < 20; ++attempts)
+        juce::MessageManager::getInstance()->runDispatchLoopUntil(10);
+
+    CHECK_FALSE(called);
+}

--- a/tests/engine/test_plugin_assignments.cpp
+++ b/tests/engine/test_plugin_assignments.cpp
@@ -33,25 +33,41 @@ magda::engine::DeviceKey mixerAnalysis(magda::DeviceId id) {
 
 TEST_CASE("A load completes onto the assignment it was requested for", "[plugins][assignments]") {
     adapter::PluginAssignments assignments;
-    assignments.assign(fx(1));
+    assignments.replaceAssignment(fx(1));
 
     const auto request = assignments.request(fx(1));
-    CHECK(assignments.accepts(request));
+    CHECK(request.isStillWanted());
 
     // Nothing about the assignment changes because the device was edited,
     // enriched by a scan, restored from a preset or recompiled into a plan:
     // none of those touch the coordinator, so the load is still wanted.
-    CHECK(assignments.accepts(request));
+    CHECK(request.isStillWanted());
+}
+
+TEST_CASE("Registering a live device again keeps its assignment", "[plugins][assignments]") {
+    // The distinction the API has to encode. Ordinary registration -- a plan
+    // prepared again, a project walked again -- is not a new assignment, and a
+    // caller should not have to remember to check before asking.
+    adapter::PluginAssignments assignments;
+    const auto first = assignments.ensureAssignment(fx(1));
+    const auto request = assignments.request(fx(1));
+
+    const auto again = assignments.ensureAssignment(fx(1));
+
+    CHECK(again.handle == first.handle);
+    CHECK(request.isStillWanted());
+    CHECK(assignments.size() == 1);
 }
 
 TEST_CASE("A deleted device cannot accept the load it asked for", "[plugins][assignments]") {
     adapter::PluginAssignments assignments;
-    assignments.assign(fx(1));
+    assignments.replaceAssignment(fx(1));
 
     const auto request = assignments.request(fx(1));
     assignments.release(fx(1));
 
-    CHECK_FALSE(assignments.accepts(request));
+    CHECK_FALSE(request.isStillWanted());
+    CHECK_FALSE(request.keyWasReassigned());
     CHECK_FALSE(static_cast<bool>(assignments.current(fx(1))));
 }
 
@@ -61,28 +77,29 @@ TEST_CASE("A replaced plugin cannot accept the load its predecessor asked for",
     // asking for. Metadata cannot tell this from a moved file or a corrected
     // vendor, which is the whole reason identity is not read off the model.
     adapter::PluginAssignments assignments;
-    assignments.assign(fx(1));
+    assignments.ensureAssignment(fx(1));
     const auto request = assignments.request(fx(1));
 
-    assignments.assign(fx(1));
+    assignments.replaceAssignment(fx(1));
 
-    CHECK_FALSE(assignments.accepts(request));
-    CHECK(assignments.accepts(assignments.request(fx(1))));
+    CHECK_FALSE(request.isStillWanted());
+    CHECK(request.keyWasReassigned());
+    CHECK(assignments.request(fx(1)).isStillWanted());
 }
 
 TEST_CASE("An id handed out again is a different assignment", "[plugins][assignments]") {
     // What clearAllTracks() does: DeviceId counters restart, so the next
     // project's device 1 is not the one a load is still in flight for.
     adapter::PluginAssignments assignments;
-    assignments.assign(fx(1));
+    assignments.replaceAssignment(fx(1));
     const auto request = assignments.request(fx(1));
 
     assignments.releaseAll();
     CHECK(assignments.size() == 0);
 
-    assignments.assign(fx(1));
+    assignments.ensureAssignment(fx(1));
 
-    CHECK_FALSE(assignments.accepts(request));
+    CHECK_FALSE(request.isStillWanted());
 }
 
 TEST_CASE("A copy of a live device is not the device it was copied from",
@@ -93,32 +110,38 @@ TEST_CASE("A copy of a live device is not the device it was copied from",
     // nothing it could have inherited, because assignment identity is not in
     // the value that was copied.
     adapter::PluginAssignments assignments;
-    assignments.assign(fx(1));
+    assignments.replaceAssignment(fx(1));
     const auto sourceRequest = assignments.request(fx(1));
 
-    assignments.assign(fx(2));
+    assignments.replaceAssignment(fx(2));
 
-    CHECK_FALSE(assignments.accepts({.key = fx(2), .handle = sourceRequest.handle}));
-    CHECK(assignments.accepts(sourceRequest));
+    const adapter::LoadRequest ontoTheCopy{
+        .key = fx(2), .handle = sourceRequest.handle, .table = sourceRequest.table};
+    CHECK_FALSE(ontoTheCopy.isStillWanted());
+    CHECK(sourceRequest.isStillWanted());
 }
 
 TEST_CASE("Sections holding the same DeviceId hold different assignments",
           "[plugins][assignments]") {
     // DeviceId is allocated per section, so all three of these are device 1.
     adapter::PluginAssignments assignments;
-    assignments.assign(fx(1));
-    assignments.assign(postFx(1));
-    assignments.assign(mixerAnalysis(1));
+    assignments.replaceAssignment(fx(1));
+    assignments.replaceAssignment(postFx(1));
+    assignments.replaceAssignment(mixerAnalysis(1));
 
     const auto request = assignments.request(fx(1));
 
-    CHECK_FALSE(assignments.accepts({.key = postFx(1), .handle = request.handle}));
-    CHECK_FALSE(assignments.accepts({.key = mixerAnalysis(1), .handle = request.handle}));
+    CHECK_FALSE(
+        adapter::LoadRequest{.key = postFx(1), .handle = request.handle, .table = request.table}
+            .isStillWanted());
+    CHECK_FALSE(adapter::LoadRequest{
+        .key = mixerAnalysis(1), .handle = request.handle, .table = request.table}
+                    .isStillWanted());
 
     // Releasing one leaves the other two alone.
     assignments.release(fx(1));
     CHECK(assignments.size() == 2);
-    CHECK(assignments.accepts(assignments.request(postFx(1))));
+    CHECK(assignments.request(postFx(1)).isStillWanted());
 }
 
 TEST_CASE("A device that was never registered has no load to accept", "[plugins][assignments]") {
@@ -129,7 +152,8 @@ TEST_CASE("A device that was never registered has no load to accept", "[plugins]
 
     const auto request = assignments.request(fx(7));
     CHECK(request.handle.expired());
-    CHECK_FALSE(assignments.accepts(request));
+    CHECK_FALSE(request.isStillWanted());
+    CHECK_FALSE(request.keyWasReassigned());
 }
 
 TEST_CASE("A handle held past its release does not revive the assignment",
@@ -137,19 +161,39 @@ TEST_CASE("A handle held past its release does not revive the assignment",
     // The caller keeps the ActiveAssignment it was handed, so the weak
     // reference still locks. The live set is what decides.
     adapter::PluginAssignments assignments;
-    const auto held = assignments.assign(fx(1));
+    const auto held = assignments.replaceAssignment(fx(1));
     REQUIRE(static_cast<bool>(held));
 
     const auto request = assignments.request(fx(1));
     assignments.release(fx(1));
 
     REQUIRE_FALSE(request.handle.expired());
-    CHECK_FALSE(assignments.accepts(request));
+    CHECK_FALSE(request.isStillWanted());
+}
+
+TEST_CASE("A request outliving the whole runtime is refused", "[plugins][assignments]") {
+    // The project was closed while a plugin was loading. The completion still
+    // arrives, and it must answer from what it holds rather than by reaching
+    // into a destroyed registry.
+    adapter::LoadRequest request;
+    adapter::ActiveAssignment held;
+    {
+        adapter::PluginAssignments assignments;
+        held = assignments.replaceAssignment(fx(1));
+        request = assignments.request(fx(1));
+        REQUIRE(request.isStillWanted());
+    }
+
+    // The handle itself is still alive, held by the caller. The table is not.
+    REQUIRE_FALSE(request.handle.expired());
+    CHECK(request.table.expired());
+    CHECK_FALSE(request.isStillWanted());
+    CHECK_FALSE(request.keyWasReassigned());
 }
 
 TEST_CASE("A default-constructed request is refused", "[plugins][assignments]") {
     adapter::PluginAssignments assignments;
-    assignments.assign(fx(magda::INVALID_DEVICE_ID));
+    assignments.replaceAssignment(fx(magda::INVALID_DEVICE_ID));
 
-    CHECK_FALSE(assignments.accepts({}));
+    CHECK_FALSE(adapter::LoadRequest{}.isStillWanted());
 }

--- a/tests/engine/test_plugin_assignments.cpp
+++ b/tests/engine/test_plugin_assignments.cpp
@@ -1,0 +1,155 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "magda/daw/audio/plugins/engine/PluginAssignments.hpp"
+
+/**
+ * @file test_plugin_assignments.cpp
+ * @brief Who a plugin load belongs to, decided at runtime (#2261).
+ *
+ * The identity these tests are about used to be a counter on DeviceInfo, minted
+ * by whichever call site remembered to. What is asserted here is the property
+ * that replaced it: nothing in the model carries assignment identity, so no
+ * copy of a device can inherit one, and a device nobody registered has none to
+ * lend. Every case below is stated as what a load is allowed to complete onto.
+ */
+
+namespace adapter = magda::daw::audio::engine_adapter;
+
+namespace {
+
+magda::engine::DeviceKey fx(magda::DeviceId id) {
+    return {magda::ChainSegment::Fx, id};
+}
+
+magda::engine::DeviceKey postFx(magda::DeviceId id) {
+    return {magda::ChainSegment::PostFx, id};
+}
+
+magda::engine::DeviceKey mixerAnalysis(magda::DeviceId id) {
+    return {magda::ChainSegment::MixerAnalysis, id};
+}
+
+}  // namespace
+
+TEST_CASE("A load completes onto the assignment it was requested for", "[plugins][assignments]") {
+    adapter::PluginAssignments assignments;
+    assignments.assign(fx(1));
+
+    const auto request = assignments.request(fx(1));
+    CHECK(assignments.accepts(request));
+
+    // Nothing about the assignment changes because the device was edited,
+    // enriched by a scan, restored from a preset or recompiled into a plan:
+    // none of those touch the coordinator, so the load is still wanted.
+    CHECK(assignments.accepts(request));
+}
+
+TEST_CASE("A deleted device cannot accept the load it asked for", "[plugins][assignments]") {
+    adapter::PluginAssignments assignments;
+    assignments.assign(fx(1));
+
+    const auto request = assignments.request(fx(1));
+    assignments.release(fx(1));
+
+    CHECK_FALSE(assignments.accepts(request));
+    CHECK_FALSE(static_cast<bool>(assignments.current(fx(1))));
+}
+
+TEST_CASE("A replaced plugin cannot accept the load its predecessor asked for",
+          "[plugins][assignments]") {
+    // The slot survives and keeps its id: what changed is which plugin it is
+    // asking for. Metadata cannot tell this from a moved file or a corrected
+    // vendor, which is the whole reason identity is not read off the model.
+    adapter::PluginAssignments assignments;
+    assignments.assign(fx(1));
+    const auto request = assignments.request(fx(1));
+
+    assignments.assign(fx(1));
+
+    CHECK_FALSE(assignments.accepts(request));
+    CHECK(assignments.accepts(assignments.request(fx(1))));
+}
+
+TEST_CASE("An id handed out again is a different assignment", "[plugins][assignments]") {
+    // What clearAllTracks() does: DeviceId counters restart, so the next
+    // project's device 1 is not the one a load is still in flight for.
+    adapter::PluginAssignments assignments;
+    assignments.assign(fx(1));
+    const auto request = assignments.request(fx(1));
+
+    assignments.releaseAll();
+    CHECK(assignments.size() == 0);
+
+    assignments.assign(fx(1));
+
+    CHECK_FALSE(assignments.accepts(request));
+}
+
+TEST_CASE("A copy of a live device is not the device it was copied from",
+          "[plugins][assignments]") {
+    // Duplicate, paste, preset import and undo reinsertion all end at the same
+    // shape: a second device that came from the first and is placed under an id
+    // of its own. It is registered like any other placement, and there is
+    // nothing it could have inherited, because assignment identity is not in
+    // the value that was copied.
+    adapter::PluginAssignments assignments;
+    assignments.assign(fx(1));
+    const auto sourceRequest = assignments.request(fx(1));
+
+    assignments.assign(fx(2));
+
+    CHECK_FALSE(assignments.accepts({.key = fx(2), .handle = sourceRequest.handle}));
+    CHECK(assignments.accepts(sourceRequest));
+}
+
+TEST_CASE("Sections holding the same DeviceId hold different assignments",
+          "[plugins][assignments]") {
+    // DeviceId is allocated per section, so all three of these are device 1.
+    adapter::PluginAssignments assignments;
+    assignments.assign(fx(1));
+    assignments.assign(postFx(1));
+    assignments.assign(mixerAnalysis(1));
+
+    const auto request = assignments.request(fx(1));
+
+    CHECK_FALSE(assignments.accepts({.key = postFx(1), .handle = request.handle}));
+    CHECK_FALSE(assignments.accepts({.key = mixerAnalysis(1), .handle = request.handle}));
+
+    // Releasing one leaves the other two alone.
+    assignments.release(fx(1));
+    CHECK(assignments.size() == 2);
+    CHECK(assignments.accepts(assignments.request(postFx(1))));
+}
+
+TEST_CASE("A device that was never registered has no load to accept", "[plugins][assignments]") {
+    // The failure direction that matters. A forgotten registration yields an
+    // expired request, so the load is refused; the token it replaced would have
+    // been carried by a copy and the load accepted.
+    adapter::PluginAssignments assignments;
+
+    const auto request = assignments.request(fx(7));
+    CHECK(request.handle.expired());
+    CHECK_FALSE(assignments.accepts(request));
+}
+
+TEST_CASE("A handle held past its release does not revive the assignment",
+          "[plugins][assignments]") {
+    // The caller keeps the ActiveAssignment it was handed, so the weak
+    // reference still locks. The live set is what decides.
+    adapter::PluginAssignments assignments;
+    const auto held = assignments.assign(fx(1));
+    REQUIRE(static_cast<bool>(held));
+
+    const auto request = assignments.request(fx(1));
+    assignments.release(fx(1));
+
+    REQUIRE_FALSE(request.handle.expired());
+    CHECK_FALSE(assignments.accepts(request));
+}
+
+TEST_CASE("A default-constructed request is refused", "[plugins][assignments]") {
+    adapter::PluginAssignments assignments;
+    assignments.assign(fx(magda::INVALID_DEVICE_ID));
+
+    CHECK_FALSE(assignments.accepts({}));
+}


### PR DESCRIPTION
Closes #2261. Follow-up to #2252/#2255.

## The problem with where the identity lived

#2255 put assignment identity on `DeviceInfo` as `pluginAssignmentGeneration`: a process-local counter minted in a default member initializer, preserved by copy, and re-minted by an explicit `beginNewPluginAssignment()` at every site that turns a copy into a live device.

That placement could not hold. `DeviceInfo` is value-semantic, and C++ copying cannot distinguish a snapshot from an undo record from a browser template from a duplicate from a paste from a preset import from a new live placement -- all of them are the same copy. The invariant lived only in whoever remembered to call the minting function, review found missed sites one round at a time, and a missed one failed in the unsafe direction: the copy kept the token, so the completion guard *accepted* a stale load and restored one plugin's state onto another.

## What replaces it

`magda/daw/audio/plugins/engine/PluginAssignments.hpp` -- a coordinator owning the live set, keyed on `engine::DeviceKey`:

- `AssignmentHandle` is empty on purpose: identified by its address and by nothing else, so there is no field a copy could carry and no value a caller could forge.
- A device that becomes live gets a `shared_ptr` handle; a load holds a `weak_ptr` to it, so a load in flight never keeps an assignment alive.
- `accepts()` requires both that the weak reference locks **and** that the set still holds that same handle for that key. Locking alone is not enough: a caller holding the `ActiveAssignment` it was handed keeps the handle alive past the release, so the live set is what decides.

Deletion, replacement, duplication, paste, preset import, undo reinsertion and an id handed out again after `clearAllTracks()` are now one shape: a key that is no longer this assignment. A device that was never registered has no handle to lend, so a **forgotten registration refuses the load** instead of accepting it.

`DeviceInfo::pluginAssignmentGeneration` and `beginNewPluginAssignment()` are gone, along with all eight mint sites. No copy, re-key or serialization path touches async load identity.

## Also in scope

`CurrentDeviceLookup` now keys on `engine::DeviceKey` rather than a bare `DeviceId`. `DeviceId` is allocated per section, so main FX, post-FX and mixer-analysis can each hold the same integer and a bare one names up to three devices.

## Separately: pad link retargeting

Independent of the identity work and pre-dating #2252. `prepareNewDevice` re-keyed a Drum Grid's pads and discarded the resulting map, so macros and modulators addressing anything in that pad subtree kept their old `ChainNodePath` and stopped resolving -- the macro is still there, still says it is linked, and moves nothing.

The map is now seeded with the grid's own old `DeviceId` (which is what a pad path names, in its `PadRack` step) and both the grid's own links and the pad subtree's are retargeted through it. `remapPresetLinksRecursive` gained a `PresetState` flag so the add path follows links without also rewriting saved plugin state, which is preset-only behaviour.

## Acceptance criteria

- [x] Every acceptance criterion of #2252 still holds
- [x] `DeviceInfo` carries no runtime lifetime identity
- [x] No copy, re-key or serialization path knows about async load identity
- [x] A duplicated, pasted, preset-imported or undo-reinserted device cannot accept a load requested for the device it came from
- [x] A device whose id is reused after `clearAllTracks()` cannot accept a load requested for its predecessor
- [x] A device in one section cannot accept a load requested for the same `DeviceId` in another
- [x] A forgotten registration rejects the load rather than accepting it
- [x] `CurrentDeviceLookup` keys on `engine::DeviceKey`
- [x] Pad link retargeting fixed on its own

Production wiring of `createEngineExternalDeviceAsync()` was blocked on this and is now unblocked; it is not done here.

## Tests

New `tests/test_plugin_assignments.cpp` covers the coordinator directly (9 cases). `tests/test_engine_external_device.cpp` gains three adapter-level cases: a duplicate refusing its source's load, a section collision refusing with "removed" rather than standing in, and an unregistered device refusing a load that otherwise succeeded. `tests/test_device_api.cpp` gains a case for the pad link retarget -- verified to fail without the fix.

- `magda_tests`: 3210 cases, 0 failures
- `magda_juce_tests`: all suites `0 failed`

https://claude.ai/code/session_01Qa7GxDU184RGxo2b1Yhpa6