### PR TITLE
Write a plugin's state back out, and say the rule once (#2244)

### DIFF
--- a/magda/daw/audio/AudioBridge.cpp
+++ b/magda/daw/audio/AudioBridge.cpp
@@ -804,7 +804,7 @@ juce::String AudioBridge::getVst3DeviceId(const ChainNodePath& devicePath) const
         return {};
     // Pull the current state as a .vstpreset; its header carries the 32-char
     // class id. Empty for a plugin that is not a VST3.
-    return vst3::classIdFromPreset(readVst3Preset(*pi));
+    return vst3::classIdFromPreset(readVst3Preset(*pi).preset);
 }
 
 int AudioBridge::getPluginNumPrograms(const ChainNodePath& devicePath) const {
@@ -861,7 +861,7 @@ bool AudioBridge::loadPluginPresetFile(const ChainNodePath& devicePath,
         juce::MemoryBlock raw;
         if (!presetFile.loadFileAsData(raw))
             return false;
-        applied = writeVst3Preset(*pi, raw);
+        applied = writeVst3Preset(*pi, raw) == Vst3PresetOutcome::Applied;
     } else if (extension == ".aupreset") {
         juce::MemoryBlock raw;
         if (!presetFile.loadFileAsData(raw))
@@ -886,7 +886,7 @@ bool AudioBridge::savePluginPresetFile(const ChainNodePath& devicePath,
     const auto extension = presetFile.getFileExtension().toLowerCase();
 
     if (extension == ".vstpreset") {
-        const auto preset = readVst3Preset(*pi);
+        const auto preset = readVst3Preset(*pi).preset;
         if (preset.getSize() == 0)
             return false;  // not a VST3 plugin
         presetFile.getParentDirectory().createDirectory();

--- a/magda/daw/audio/AudioBridge.cpp
+++ b/magda/daw/audio/AudioBridge.cpp
@@ -15,6 +15,7 @@
 #include "DeviceParameterDisplayTextProvider.hpp"
 #include "Vst3Preset.hpp"
 #include "modifiers/ADSRDebugLog.hpp"
+#include "plugin_manager/ExternalPluginState.hpp"
 #include "plugins/DeviceServices.hpp"
 #include "plugins/InternalPluginRegistry.hpp"
 #include "plugins/MidiInThruSync.hpp"
@@ -792,25 +793,6 @@ te::ExternalPlugin* asExternalPlugin(te::Plugin::Ptr plugin) {
     return dynamic_cast<te::ExternalPlugin*>(plugin.get());
 }
 
-// Loads / saves a .vstpreset blob via JUCE's VST3Client extension. Two-mode
-// visitor: when `dataIn` is non-empty we apply it as a preset; otherwise we
-// pull the current state into `dataOut`.
-struct Vst3PresetVisitor : juce::ExtensionsVisitor {
-    juce::MemoryBlock dataIn;
-    juce::MemoryBlock dataOut;
-    bool ok = false;
-    bool save = false;
-
-    void visitVST3Client(const VST3Client& client) override {
-        if (save) {
-            dataOut = client.getPreset();
-            ok = dataOut.getSize() > 0;
-        } else {
-            ok = client.setPreset(dataIn);
-        }
-    }
-};
-
 }  // namespace
 
 juce::String AudioBridge::getVst3DeviceId(const ChainNodePath& devicePath) const {
@@ -821,13 +803,8 @@ juce::String AudioBridge::getVst3DeviceId(const ChainNodePath& devicePath) const
     if (pi == nullptr)
         return {};
     // Pull the current state as a .vstpreset; its header carries the 32-char
-    // class id. Visitor stays empty for non-VST3 plugins.
-    Vst3PresetVisitor visitor;
-    visitor.save = true;
-    pi->getExtensions(visitor);
-    if (!visitor.ok)
-        return {};  // not a VST3 plugin
-    return vst3::classIdFromPreset(visitor.dataOut);
+    // class id. Empty for a plugin that is not a VST3.
+    return vst3::classIdFromPreset(readVst3Preset(*pi));
 }
 
 int AudioBridge::getPluginNumPrograms(const ChainNodePath& devicePath) const {
@@ -884,11 +861,7 @@ bool AudioBridge::loadPluginPresetFile(const ChainNodePath& devicePath,
         juce::MemoryBlock raw;
         if (!presetFile.loadFileAsData(raw))
             return false;
-        Vst3PresetVisitor visitor;
-        visitor.save = false;
-        visitor.dataIn = std::move(raw);
-        pi->getExtensions(visitor);
-        applied = visitor.ok;
+        applied = writeVst3Preset(*pi, raw);
     } else if (extension == ".aupreset") {
         juce::MemoryBlock raw;
         if (!presetFile.loadFileAsData(raw))
@@ -913,13 +886,11 @@ bool AudioBridge::savePluginPresetFile(const ChainNodePath& devicePath,
     const auto extension = presetFile.getFileExtension().toLowerCase();
 
     if (extension == ".vstpreset") {
-        Vst3PresetVisitor visitor;
-        visitor.save = true;
-        pi->getExtensions(visitor);
-        if (!visitor.ok)
-            return false;
+        const auto preset = readVst3Preset(*pi);
+        if (preset.getSize() == 0)
+            return false;  // not a VST3 plugin
         presetFile.getParentDirectory().createDirectory();
-        return presetFile.replaceWithData(visitor.dataOut.getData(), visitor.dataOut.getSize());
+        return presetFile.replaceWithData(preset.getData(), preset.getSize());
     }
 
     if (extension == ".aupreset") {

--- a/magda/daw/audio/plugin_manager/ExternalPluginState.cpp
+++ b/magda/daw/audio/plugin_manager/ExternalPluginState.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 
+#include "../Vst3Preset.hpp"
 #include "core/ParameterUtils.hpp"
 
 namespace magda {
@@ -25,6 +26,26 @@ const ParameterInfo* modelParameterAt(const DeviceInfo& device, int index) {
     return nullptr;
 }
 
+/// One visit to the VST3 extension, in whichever direction was asked for. The
+/// extension is the only way to ask an instance whether it is a VST3 at all:
+/// visitVST3Client() is called for one and nothing is called for anything else,
+/// so `visited` is the answer to both questions at once.
+struct Vst3PresetVisitor final : juce::ExtensionsVisitor {
+    juce::MemoryBlock preset;
+    bool writing = false;
+    bool visited = false;
+    bool accepted = false;
+
+    void visitVST3Client(const VST3Client& client) override {
+        visited = true;
+
+        if (writing)
+            accepted = client.setPreset(preset);
+        else
+            preset = client.getPreset();
+    }
+};
+
 /// The saved chunk, decoded. Empty for a device that saved none and for a
 /// string that is not base64, which is what a project truncated by a failed
 /// write looks like.
@@ -38,6 +59,18 @@ juce::MemoryBlock decodeSavedChunk(const juce::String& savedState) {
         chunk.reset();
 
     return chunk;
+}
+
+/// The saved .vstpreset, decoded. Standard base64 rather than
+/// juce::MemoryBlock's own, because this one crosses between hosts and the
+/// DAWproject writer that produced it used the standard one.
+juce::MemoryBlock decodeSavedPreset(const juce::String& savedPreset) {
+    juce::MemoryOutputStream decoded;
+
+    if (savedPreset.isEmpty() || !juce::Base64::convertFromBase64(decoded, savedPreset))
+        return {};
+
+    return decoded.getMemoryBlock();
 }
 
 }  // namespace
@@ -77,16 +110,21 @@ SavedStateOutcome applySavedPluginState(juce::AudioPluginInstance& instance,
             std::clamp(ParameterUtils::realToNormalized(info->currentValue, *info), 0.0f, 1.0f));
     }
 
+    // The portable preset is asked first, because a project only carries one
+    // until the load that consumes it: an import has a .vstpreset and no chunk,
+    // and everything saved afterwards has a chunk and no preset. A plugin that
+    // refuses it -- a VST3 that will not take that patch, or a format with no
+    // preset call at all -- falls through to the chunk rather than being left on
+    // the bare array, which is the only place the project's own record is.
+    if (const auto preset = decodeSavedPreset(device.vst3Preset); preset.getSize() > 0) {
+        if (writeVst3Preset(instance, preset))
+            return SavedStateOutcome::RestoredFromPreset;
+    }
+
     const auto chunk = decodeSavedChunk(device.pluginState);
     if (chunk.getSize() == 0)
         return SavedStateOutcome::Baseline;
 
-    // DeviceInfo::vst3Preset is deliberately not applied here. It is the
-    // portable .vstpreset a DAWproject carries, applied once on import and
-    // cleared, and its own field comment says what this relies on: interchange
-    // only, native state is pluginState. When the native engine grows an import
-    // path of its own (#2244) it belongs in this function beside the chunk,
-    // rather than in whichever engine happens to be loading the project.
     try {
         instance.setStateInformation(chunk.getData(), static_cast<int>(chunk.getSize()));
     } catch (...) {
@@ -121,6 +159,79 @@ void applyRestoredParameters(DeviceInfo& device, const std::vector<RestoredParam
                 if (info.paramIndex == parameter.paramIndex)
                     info.currentValue = ParameterUtils::normalizedToReal(
                         parameter.value, ParameterUtils::domainOf(info));
+}
+
+juce::MemoryBlock readVst3Preset(const juce::AudioPluginInstance& instance) {
+    Vst3PresetVisitor visitor;
+
+    try {
+        instance.getExtensions(visitor);
+    } catch (...) {
+        return {};
+    }
+
+    return visitor.preset;
+}
+
+bool writeVst3Preset(juce::AudioPluginInstance& instance, const juce::MemoryBlock& preset) {
+    if (preset.getSize() == 0)
+        return false;
+
+    Vst3PresetVisitor visitor;
+    visitor.writing = true;
+    visitor.preset = preset;
+
+    try {
+        instance.getExtensions(visitor);
+    } catch (...) {
+        return false;
+    }
+
+    return visitor.accepted;
+}
+
+void captureVst3Records(const juce::AudioPluginInstance& instance, DeviceInfo& device) {
+    const auto preset = readVst3Preset(instance);
+    if (preset.getSize() == 0)
+        return;
+
+    if (device.vst3ClassId.isEmpty())
+        device.vst3ClassId = vst3::classIdFromPreset(preset);
+
+    device.vst3Preset = juce::Base64::toBase64(preset.getData(), preset.getSize());
+}
+
+bool captureSavedPluginState(juce::AudioPluginInstance& instance, DeviceInfo& device) {
+    juce::MemoryBlock chunk;
+
+    // Suspended across the read, the way the fork suspends it
+    // (ExternalPlugin::flushPluginStateToValueTree). Restored either way: a
+    // plugin left suspended by its own throw would render silence for the rest
+    // of the session.
+    instance.suspendProcessing(true);
+
+    bool described = true;
+    try {
+        instance.getStateInformation(chunk);
+    } catch (...) {
+        described = false;
+    }
+
+    instance.suspendProcessing(false);
+
+    if (!described)
+        return false;
+
+    // Absent rather than empty for a plugin with nothing to say, which is what
+    // the fork writes for one: it removes the property rather than storing a
+    // zero-length chunk, and a project that stored one would come back through
+    // decodeSavedChunk() as a baseline anyway.
+    device.pluginState = chunk.getSize() > 0 ? chunk.toBase64Encoding() : juce::String();
+
+    applyRestoredParameters(device, snapshotHostParameters(instance));
+    captureVst3Records(instance, device);
+
+    return true;
 }
 
 }  // namespace magda

--- a/magda/daw/audio/plugin_manager/ExternalPluginState.cpp
+++ b/magda/daw/audio/plugin_manager/ExternalPluginState.cpp
@@ -73,6 +73,22 @@ juce::MemoryBlock decodeSavedPreset(const juce::String& savedPreset) {
     return decoded.getMemoryBlock();
 }
 
+/// Write @p read into @p device's portable records. See captureVst3Records().
+void applyVst3Records(DeviceInfo& device, const Vst3PresetRead& read) {
+    if (!read.isVst3)
+        return;
+
+    if (read.preset.getSize() == 0) {
+        device.vst3Preset = {};
+        return;
+    }
+
+    if (device.vst3ClassId.isEmpty())
+        device.vst3ClassId = vst3::classIdFromPreset(read.preset);
+
+    device.vst3Preset = juce::Base64::toBase64(read.preset.getData(), read.preset.getSize());
+}
+
 }  // namespace
 
 std::vector<juce::AudioProcessorParameter*> hostParameterOrder(
@@ -116,14 +132,34 @@ SavedStateOutcome applySavedPluginState(juce::AudioPluginInstance& instance,
     // refuses it -- a VST3 that will not take that patch, or a format with no
     // preset call at all -- falls through to the chunk rather than being left on
     // the bare array, which is the only place the project's own record is.
+    bool presetRefused = false;
+
     if (const auto preset = decodeSavedPreset(device.vst3Preset); preset.getSize() > 0) {
-        if (writeVst3Preset(instance, preset))
-            return SavedStateOutcome::RestoredFromPreset;
+        switch (writeVst3Preset(instance, preset)) {
+            case Vst3PresetOutcome::Applied:
+                return SavedStateOutcome::RestoredFromPreset;
+            case Vst3PresetOutcome::Refused:
+                presetRefused = true;
+                break;
+            case Vst3PresetOutcome::NotVst3:
+                break;
+        }
     }
 
     const auto chunk = decodeSavedChunk(device.pluginState);
-    if (chunk.getSize() == 0)
+    if (chunk.getSize() == 0) {
+        // A refusal with nothing behind it. Steinberg's loader restores the
+        // component's state before the controller's and returns false if the
+        // second fails after the first, so the plugin may be holding half the
+        // imported patch; the parameter array written above describes what the
+        // project believed and not what the instance now is. There is nothing
+        // left to make it true, so this is the same answer the chunk path gives
+        // for the same situation rather than a quieter one.
+        if (presetRefused)
+            return SavedStateOutcome::Failed;
+
         return SavedStateOutcome::Baseline;
+    }
 
     try {
         instance.setStateInformation(chunk.getData(), static_cast<int>(chunk.getSize()));
@@ -161,21 +197,26 @@ void applyRestoredParameters(DeviceInfo& device, const std::vector<RestoredParam
                         parameter.value, ParameterUtils::domainOf(info));
 }
 
-juce::MemoryBlock readVst3Preset(const juce::AudioPluginInstance& instance) {
+Vst3PresetRead readVst3Preset(const juce::AudioPluginInstance& instance) {
     Vst3PresetVisitor visitor;
 
+    // The visit is what identifies the format, and it is recorded before the
+    // plugin is asked anything: a VST3 whose getPreset() throws has still been
+    // identified as one, and the caller's answer for it is not the answer for a
+    // plugin that was never visited.
     try {
         instance.getExtensions(visitor);
     } catch (...) {
-        return {};
+        return {.preset = {}, .isVst3 = visitor.visited};
     }
 
-    return visitor.preset;
+    return {.preset = std::move(visitor.preset), .isVst3 = visitor.visited};
 }
 
-bool writeVst3Preset(juce::AudioPluginInstance& instance, const juce::MemoryBlock& preset) {
+Vst3PresetOutcome writeVst3Preset(juce::AudioPluginInstance& instance,
+                                  const juce::MemoryBlock& preset) {
     if (preset.getSize() == 0)
-        return false;
+        return Vst3PresetOutcome::NotVst3;
 
     Vst3PresetVisitor visitor;
     visitor.writing = true;
@@ -184,39 +225,46 @@ bool writeVst3Preset(juce::AudioPluginInstance& instance, const juce::MemoryBloc
     try {
         instance.getExtensions(visitor);
     } catch (...) {
-        return false;
+        // Visited and throwing is a refusal rather than a no-op, and for the
+        // same reason a refusal is: whatever the loader had done before it threw
+        // is still done.
+        return visitor.visited ? Vst3PresetOutcome::Refused : Vst3PresetOutcome::NotVst3;
     }
 
-    return visitor.accepted;
+    if (!visitor.visited)
+        return Vst3PresetOutcome::NotVst3;
+
+    return visitor.accepted ? Vst3PresetOutcome::Applied : Vst3PresetOutcome::Refused;
 }
 
 void captureVst3Records(const juce::AudioPluginInstance& instance, DeviceInfo& device) {
-    const auto preset = readVst3Preset(instance);
-    if (preset.getSize() == 0)
-        return;
-
-    if (device.vst3ClassId.isEmpty())
-        device.vst3ClassId = vst3::classIdFromPreset(preset);
-
-    device.vst3Preset = juce::Base64::toBase64(preset.getData(), preset.getSize());
+    applyVst3Records(device, readVst3Preset(instance));
 }
 
 bool captureSavedPluginState(juce::AudioPluginInstance& instance, DeviceInfo& device) {
     juce::MemoryBlock chunk;
+    std::vector<RestoredParameter> parameters;
+    Vst3PresetRead portable;
 
-    // Suspended across the read, the way the fork suspends it
-    // (ExternalPlugin::flushPluginStateToValueTree). Restored either way: a
-    // plugin left suspended by its own throw would render silence for the rest
-    // of the session.
+    // Suspended across the whole transaction, the way the fork holds its
+    // processMutex across one. Everything read here is read from a plugin that
+    // is not simultaneously processing: its chunk, the parameter values that
+    // have to agree with that chunk, and the portable preset beside them.
+    // Resuming between any two of those would let a block move the plugin
+    // underneath the rest of the read.
     instance.suspendProcessing(true);
 
     bool described = true;
     try {
         instance.getStateInformation(chunk);
+        parameters = snapshotHostParameters(instance);
+        portable = readVst3Preset(instance);
     } catch (...) {
         described = false;
     }
 
+    // Restored either way: a plugin left suspended by its own throw would render
+    // silence for the rest of the session.
     instance.suspendProcessing(false);
 
     if (!described)
@@ -228,8 +276,8 @@ bool captureSavedPluginState(juce::AudioPluginInstance& instance, DeviceInfo& de
     // decodeSavedChunk() as a baseline anyway.
     device.pluginState = chunk.getSize() > 0 ? chunk.toBase64Encoding() : juce::String();
 
-    applyRestoredParameters(device, snapshotHostParameters(instance));
-    captureVst3Records(instance, device);
+    applyRestoredParameters(device, parameters);
+    applyVst3Records(device, portable);
 
     return true;
 }

--- a/magda/daw/audio/plugin_manager/ExternalPluginState.cpp
+++ b/magda/daw/audio/plugin_manager/ExternalPluginState.cpp
@@ -241,24 +241,23 @@ void captureVst3Records(const juce::AudioPluginInstance& instance, DeviceInfo& d
     applyVst3Records(device, readVst3Preset(instance));
 }
 
-bool captureSavedPluginState(juce::AudioPluginInstance& instance, DeviceInfo& device) {
+std::optional<ExternalPluginSnapshot> captureExternalPluginState(
+    juce::AudioPluginInstance& instance) {
     juce::MemoryBlock chunk;
-    std::vector<RestoredParameter> parameters;
-    Vst3PresetRead portable;
+    ExternalPluginSnapshot snapshot;
 
-    // Suspended across the whole transaction, the way the fork holds its
-    // processMutex across one. Everything read here is read from a plugin that
-    // is not simultaneously processing: its chunk, the parameter values that
-    // have to agree with that chunk, and the portable preset beside them.
-    // Resuming between any two of those would let a block move the plugin
-    // underneath the rest of the read.
+    // Suspended across the whole read, the way the fork holds its processMutex
+    // across one. Everything here comes off a plugin that is not simultaneously
+    // processing: its chunk, the parameter values that have to agree with that
+    // chunk, and the portable preset beside them. Resuming between any two of
+    // those would let a block move the plugin underneath the rest of the read.
     instance.suspendProcessing(true);
 
     bool described = true;
     try {
         instance.getStateInformation(chunk);
-        parameters = snapshotHostParameters(instance);
-        portable = readVst3Preset(instance);
+        snapshot.parameters = snapshotHostParameters(instance);
+        snapshot.portable = readVst3Preset(instance);
     } catch (...) {
         described = false;
     }
@@ -268,18 +267,22 @@ bool captureSavedPluginState(juce::AudioPluginInstance& instance, DeviceInfo& de
     instance.suspendProcessing(false);
 
     if (!described)
-        return false;
+        return std::nullopt;
 
     // Absent rather than empty for a plugin with nothing to say, which is what
     // the fork writes for one: it removes the property rather than storing a
     // zero-length chunk, and a project that stored one would come back through
     // decodeSavedChunk() as a baseline anyway.
-    device.pluginState = chunk.getSize() > 0 ? chunk.toBase64Encoding() : juce::String();
+    if (chunk.getSize() > 0)
+        snapshot.pluginState = chunk.toBase64Encoding();
 
-    applyRestoredParameters(device, parameters);
-    applyVst3Records(device, portable);
+    return snapshot;
+}
 
-    return true;
+void applyCapturedPluginState(DeviceInfo& device, const ExternalPluginSnapshot& snapshot) {
+    device.pluginState = snapshot.pluginState;
+    applyRestoredParameters(device, snapshot.parameters);
+    applyVst3Records(device, snapshot.portable);
 }
 
 }  // namespace magda

--- a/magda/daw/audio/plugin_manager/ExternalPluginState.hpp
+++ b/magda/daw/audio/plugin_manager/ExternalPluginState.hpp
@@ -121,6 +121,12 @@ enum class SavedStateOutcome {
  * the patch, and a project holds the preset only until the first load turns it
  * into a chunk of its own.
  *
+ * A VST3 that refuses the preset falls through to the chunk, which overwrites
+ * whatever the refusal left behind. With no chunk to fall through to there is
+ * nothing left that describes the instance, and this reports Failed rather than
+ * Baseline: a refused preset is not a no-op (Vst3PresetOutcome::Refused), so the
+ * parameter array underneath it is no longer a description of the plugin.
+ *
  * A plugin's own state handler is third-party code running in-process, and a
  * corrupt chunk is exactly the input it is least likely to have been tested
  * against, so it is called inside a catch-all. What the catch-all buys is that
@@ -158,31 +164,71 @@ void applyRestoredParameters(DeviceInfo& device, const std::vector<RestoredParam
  * the format is not in the description a host holds, only in whether the
  * instance answers the VST3 extension.
  */
-juce::MemoryBlock readVst3Preset(const juce::AudioPluginInstance& instance);
+struct Vst3PresetRead {
+    /// The preset the instance wrote. Empty for a plugin of another format, and
+    /// also for a VST3 that could not write one.
+    juce::MemoryBlock preset;
+
+    /// Whether the instance answered the VST3 extension at all.
+    ///
+    /// The half that cannot be inferred from the block. An empty preset from a
+    /// VST3 is a plugin that failed to describe its patch, and an empty one from
+    /// an AU is a question that was never asked; a caller that treated them the
+    /// same would either discard an imported project's identity or keep a patch
+    /// it knows is out of date.
+    bool isVst3 = false;
+};
+
+Vst3PresetRead readVst3Preset(const juce::AudioPluginInstance& instance);
+
+/// What became of a .vstpreset handed to an instance.
+enum class Vst3PresetOutcome {
+    /// A plugin of another format. Nothing was asked of it and nothing moved.
+    NotVst3,
+
+    /// The plugin took the patch.
+    Applied,
+
+    /// A VST3 that would not take it, and which may have moved partway doing so.
+    ///
+    /// Not a no-op, which is the whole reason this is not a bool. Steinberg's
+    /// loader restores the component's state and then the controller's, and it
+    /// returns false if the second fails after the first succeeded, so a refused
+    /// preset can leave a plugin holding half of one. A caller with nothing
+    /// authoritative to apply afterwards has an instance nobody can describe.
+    Refused,
+};
 
 /**
- * @brief Hand @p preset to @p instance as a .vstpreset, and say whether it took.
+ * @brief Hand @p preset to @p instance as a .vstpreset.
  *
- * False for a non-VST3, for a preset it refuses, and for an instance that threw
- * reading it. It is the same third-party state handler applySavedPluginState()
- * guards, reached through the format's own preset call rather than through the
- * chunk.
+ * It is the same third-party state handler applySavedPluginState() guards,
+ * reached through the format's own preset call rather than through the chunk, so
+ * a throw is caught and reported as a refusal for the same reason: what the
+ * plugin holds afterwards is not knowable from here.
  */
-bool writeVst3Preset(juce::AudioPluginInstance& instance, const juce::MemoryBlock& preset);
+Vst3PresetOutcome writeVst3Preset(juce::AudioPluginInstance& instance,
+                                  const juce::MemoryBlock& preset);
 
 /**
  * @brief Refresh @p device's portable VST3 records from @p instance.
  *
  * The .vstpreset a DAWproject export writes and the class id other hosts match
- * on, both read off the live instance and neither part of native state. A
- * no-op for a plugin that is not a VST3, which leaves whatever the project
+ * on, both read off the live instance and neither part of native state.
+ *
+ * A no-op for a plugin that is not a VST3, which leaves whatever the project
  * already carried rather than clearing it: a project imported from another host
  * keeps the identity it came with even where this machine's copy cannot restate
  * it.
  *
- * The class id is written once and then left alone. It is the plugin's
- * identity, not its patch, and the one the project was authored against is
- * worth more than the one this machine happens to have installed.
+ * A VST3 that could not write one is the opposite case and is cleared. What the
+ * project is holding describes an older patch, the portable record is the
+ * overlay on the next load, and keeping it would restore that older patch over
+ * the chunk the same save just wrote.
+ *
+ * The class id survives either way. It is the plugin's identity rather than its
+ * patch, and the one the project was authored against is worth more than the
+ * one this machine happens to have installed.
  */
 void captureVst3Records(const juce::AudioPluginInstance& instance, DeviceInfo& device);
 
@@ -195,9 +241,17 @@ void captureVst3Records(const juce::AudioPluginInstance& instance, DeviceInfo& d
  * rather than empty when the plugin has nothing to say -- so a project saved
  * under either engine opens under the other.
  *
- * Message thread, and the plugin is suspended across the read the way the fork
- * suspends it: a plugin asked to describe itself mid-block is entitled to
- * answer with half of one state and half of another.
+ * Message thread, and the plugin is suspended across the whole transaction the
+ * way the fork holds its processMutex across one: a plugin asked to describe
+ * itself mid-block is entitled to answer with half of one state and half of
+ * another, and that applies to its parameter values and its portable preset as
+ * much as to its chunk.
+ *
+ * Suspension is only worth anything because the host honours it. A block that
+ * arrives while this is in flight passes its audio through rather than running
+ * the plugin (EngineExternalDevice::processPluginBlock), which is what makes
+ * suspendProcessing() wait for one already in progress rather than merely set a
+ * flag nobody reads.
  *
  * False when the plugin threw describing itself, and then @p device is left
  * exactly as it was. The two records have to agree with each other -- the array

--- a/magda/daw/audio/plugin_manager/ExternalPluginState.hpp
+++ b/magda/daw/audio/plugin_manager/ExternalPluginState.hpp
@@ -8,8 +8,8 @@
 
 /**
  * @file ExternalPluginState.hpp
- * @brief Getting a project's record of a plugin onto a live instance, once
- *        (#2243).
+ * @brief A project's record of a plugin and a live instance, in both
+ *        directions, once (#2243, #2244).
  *
  * A project stores an external plugin twice over, and the two records are not
  * the same shape. One is an array of parameter values, which is what the UI
@@ -43,6 +43,21 @@
  * parameter it is about to write is the project's own value or a stale one the
  * chunk has already corrected -- and no comparison can tell those apart from an
  * automation lane that happens to be passing through the same value.
+ *
+ * Saving is the same three records read the other way, and it is here for the
+ * same reason: a project saved while the native engine holds the instance has
+ * to be a project the incumbent can open, so what goes back into the model is
+ * what the fork's own flushPluginStateToValueTree() would have written. One
+ * definition of what a project keeps about a plugin, read and written by
+ * whichever engine happens to be holding it.
+ *
+ * There is a third record beside those two, and it belongs to neither engine:
+ * the portable .vstpreset a DAWproject carries, which is how a VST3's patch
+ * crosses between hosts that share no chunk format. It is the overlay when a
+ * project has one, because a project that has one has just been imported and
+ * has no chunk of its own yet, and it is consumed rather than kept: applying it
+ * is what turns it into native state, and a second application over a chunk
+ * written since would undo the patch it was imported to become.
  */
 
 namespace magda {
@@ -84,15 +99,27 @@ enum class SavedStateOutcome {
     /// The array, then the chunk, both applied.
     Restored,
 
+    /// The array, then the portable .vstpreset the project was imported with,
+    /// which the plugin took. The caller publishes a model with
+    /// DeviceInfo::vst3Preset cleared: it has done its one job and a project
+    /// that kept it would apply it again over whatever was saved since.
+    RestoredFromPreset,
+
     /// The plugin threw partway through reading its own state. What it holds
     /// now is not the baseline, not the chunk, and not knowable from here.
     Failed,
 };
 
 /**
- * @brief Apply what @p device saved onto @p instance: array, then chunk.
+ * @brief Apply what @p device saved onto @p instance: array, then overlay.
  *
  * Steps one and two above.
+ *
+ * The overlay is the portable .vstpreset when the project carries one and the
+ * instance is a VST3 that takes it, and the plugin's own chunk otherwise. The
+ * two are alternatives rather than a sequence: each is a complete statement of
+ * the patch, and a project holds the preset only until the first load turns it
+ * into a chunk of its own.
  *
  * A plugin's own state handler is third-party code running in-process, and a
  * corrupt chunk is exactly the input it is least likely to have been tested
@@ -123,5 +150,60 @@ std::vector<RestoredParameter> snapshotHostParameters(const juce::AudioPluginIns
  * is the only place a value like this may be written.
  */
 void applyRestoredParameters(DeviceInfo& device, const std::vector<RestoredParameter>& restored);
+
+/**
+ * @brief The .vstpreset @p instance would write, or nothing.
+ *
+ * Empty for anything that is not a live VST3, which is the only way to ask:
+ * the format is not in the description a host holds, only in whether the
+ * instance answers the VST3 extension.
+ */
+juce::MemoryBlock readVst3Preset(const juce::AudioPluginInstance& instance);
+
+/**
+ * @brief Hand @p preset to @p instance as a .vstpreset, and say whether it took.
+ *
+ * False for a non-VST3, for a preset it refuses, and for an instance that threw
+ * reading it. It is the same third-party state handler applySavedPluginState()
+ * guards, reached through the format's own preset call rather than through the
+ * chunk.
+ */
+bool writeVst3Preset(juce::AudioPluginInstance& instance, const juce::MemoryBlock& preset);
+
+/**
+ * @brief Refresh @p device's portable VST3 records from @p instance.
+ *
+ * The .vstpreset a DAWproject export writes and the class id other hosts match
+ * on, both read off the live instance and neither part of native state. A
+ * no-op for a plugin that is not a VST3, which leaves whatever the project
+ * already carried rather than clearing it: a project imported from another host
+ * keeps the identity it came with even where this machine's copy cannot restate
+ * it.
+ *
+ * The class id is written once and then left alone. It is the plugin's
+ * identity, not its patch, and the one the project was authored against is
+ * worth more than the one this machine happens to have installed.
+ */
+void captureVst3Records(const juce::AudioPluginInstance& instance, DeviceInfo& device);
+
+/**
+ * @brief Write what @p instance holds into @p device: chunk, array, VST3 records.
+ *
+ * Saving, and the mirror of applySavedPluginState(). What lands in the model is
+ * what the fork writes for the same instance -- the chunk from
+ * getStateInformation(), base64 in juce::MemoryBlock's own encoding, absent
+ * rather than empty when the plugin has nothing to say -- so a project saved
+ * under either engine opens under the other.
+ *
+ * Message thread, and the plugin is suspended across the read the way the fork
+ * suspends it: a plugin asked to describe itself mid-block is entitled to
+ * answer with half of one state and half of another.
+ *
+ * False when the plugin threw describing itself, and then @p device is left
+ * exactly as it was. The two records have to agree with each other -- the array
+ * is the baseline the chunk overlays -- so a save that can only write one of
+ * them writes neither, and the project keeps the last pair that did agree.
+ */
+bool captureSavedPluginState(juce::AudioPluginInstance& instance, DeviceInfo& device);
 
 }  // namespace magda

--- a/magda/daw/audio/plugin_manager/ExternalPluginState.hpp
+++ b/magda/daw/audio/plugin_manager/ExternalPluginState.hpp
@@ -2,6 +2,7 @@
 
 #include <juce_audio_processors/juce_audio_processors.h>
 
+#include <optional>
 #include <vector>
 
 #include "core/DeviceInfo.hpp"
@@ -233,31 +234,69 @@ Vst3PresetOutcome writeVst3Preset(juce::AudioPluginInstance& instance,
 void captureVst3Records(const juce::AudioPluginInstance& instance, DeviceInfo& device);
 
 /**
- * @brief Write what @p instance holds into @p device: chunk, array, VST3 records.
+ * @brief Everything a project keeps about a plugin, read off one in one go.
  *
- * Saving, and the mirror of applySavedPluginState(). What lands in the model is
- * what the fork writes for the same instance -- the chunk from
- * getStateInformation(), base64 in juce::MemoryBlock's own encoding, absent
- * rather than empty when the plugin has nothing to say -- so a project saved
- * under either engine opens under the other.
+ * Data, and nothing but data: no reference to the instance, no lock, nothing
+ * that has to still be alive when this is written to a model. That is what lets
+ * reading the plugin and writing the model be two separate moments, which is
+ * what the caller needs in order to check between them that the device it read
+ * is still the device it is about to write (PluginAssignments.hpp) -- and what
+ * a plugin living in another process would need in order to send one at all.
+ */
+struct ExternalPluginSnapshot {
+    /// The chunk, in the encoding DeviceInfo::pluginState holds. Empty for a
+    /// plugin with nothing to say, which the model records as absent.
+    juce::String pluginState;
+
+    /// Every parameter a project addresses, at its live value.
+    std::vector<RestoredParameter> parameters;
+
+    /// The portable VST3 records, and what the read learned about their absence.
+    Vst3PresetRead portable;
+};
+
+/**
+ * @brief Read what @p instance holds: chunk, parameter values, VST3 records.
  *
- * Message thread, and the plugin is suspended across the whole transaction the
- * way the fork holds its processMutex across one: a plugin asked to describe
- * itself mid-block is entitled to answer with half of one state and half of
- * another, and that applies to its parameter values and its portable preset as
- * much as to its chunk.
+ * Saving, and the mirror of applySavedPluginState(). What it reads is what the
+ * fork writes for the same instance -- the chunk from getStateInformation(),
+ * base64 in juce::MemoryBlock's own encoding -- so a project saved under either
+ * engine opens under the other.
+ *
+ * It reads and does not write, for the same reason the restore hands its
+ * corrections back rather than applying them: the model is the caller's, and a
+ * function holding a plugin is the wrong place to be deciding a project's
+ * contents. Symmetry aside, it is what keeps the commit a separate step the
+ * caller can refuse.
+ *
+ * Message thread, and the plugin is suspended across the whole read the way the
+ * fork holds its processMutex across one: a plugin asked to describe itself
+ * mid-block is entitled to answer with half of one state and half of another,
+ * and that applies to its parameter values and its portable preset as much as to
+ * its chunk.
  *
  * Suspension is only worth anything because the host honours it. A block that
- * arrives while this is in flight passes its audio through rather than running
- * the plugin (EngineExternalDevice::processPluginBlock), which is what makes
- * suspendProcessing() wait for one already in progress rather than merely set a
- * flag nobody reads.
+ * arrives while this is in flight passes through without touching the plugin at
+ * all, parameter writes included (EngineExternalDevice::process), which is what
+ * makes suspendProcessing() wait for one already in progress rather than merely
+ * set a flag nobody reads.
  *
- * False when the plugin threw describing itself, and then @p device is left
- * exactly as it was. The two records have to agree with each other -- the array
- * is the baseline the chunk overlays -- so a save that can only write one of
- * them writes neither, and the project keeps the last pair that did agree.
+ * Nullopt when the plugin threw describing itself. The records have to agree
+ * with each other -- the array is the baseline the chunk overlays -- so a read
+ * that can only answer part of the question answers none of it, and the project
+ * keeps the last set that did agree.
  */
-bool captureSavedPluginState(juce::AudioPluginInstance& instance, DeviceInfo& device);
+std::optional<ExternalPluginSnapshot> captureExternalPluginState(
+    juce::AudioPluginInstance& instance);
+
+/**
+ * @brief Write @p snapshot into @p device.
+ *
+ * The other half, and the only half that touches a model. Nothing here reaches
+ * a plugin, so a caller may put whatever it likes between the two: the check
+ * that the device is still the one that was read, a hop between processes, or
+ * nothing at all.
+ */
+void applyCapturedPluginState(DeviceInfo& device, const ExternalPluginSnapshot& snapshot);
 
 }  // namespace magda

--- a/magda/daw/audio/plugin_manager/ExternalPluginStateUtil.hpp
+++ b/magda/daw/audio/plugin_manager/ExternalPluginStateUtil.hpp
@@ -12,6 +12,8 @@
 #include <tracktion_engine/plugins/external/tracktion_ExternalAutomatableParameter.h>
 // clang-format on
 
+#include "ExternalPluginState.hpp"
+
 namespace magda {
 
 /**
@@ -70,12 +72,15 @@ inline void applyExternalPluginChunk(tracktion::engine::Plugin* plugin, const ju
 }
 
 /**
- * Apply a base64 .vstpreset (Steinberg preset format) to a VST3 via
- * ExtensionsVisitor::VST3Client::setPreset(), then sync TE's parameter cache.
- * Used for state imported from DAWproject, where the portable state is a
- * .vstpreset rather than MAGDA's TE chunk. Requires the instance to be live
- * (call after async load completes). Returns true if applied; no-op/false for
- * non-VST3, not-yet-live, or undecodable data.
+ * Apply a base64 .vstpreset (Steinberg preset format) to a VST3, then sync TE's
+ * parameter cache. Used for state imported from DAWproject, where the portable
+ * state is a .vstpreset rather than MAGDA's TE chunk. Requires the instance to
+ * be live (call after async load completes). Returns true if applied; no-op/false
+ * for non-VST3, not-yet-live, or undecodable data.
+ *
+ * What a .vstpreset is and how an instance takes one is engine-agnostic and
+ * stated once (ExternalPluginState.hpp); this is the incumbent's half of it,
+ * which is TE's async lifecycle and its parameter cache.
  */
 inline bool applyVst3Preset(tracktion::engine::Plugin* plugin, const juce::String& presetBase64) {
     if (presetBase64.isEmpty())
@@ -88,17 +93,7 @@ inline bool applyVst3Preset(tracktion::engine::Plugin* plugin, const juce::Strin
     if (!juce::Base64::convertFromBase64(decoded, presetBase64))
         return false;
 
-    struct ApplyVisitor : juce::ExtensionsVisitor {
-        juce::MemoryBlock data;
-        bool ok = false;
-        void visitVST3Client(const VST3Client& client) override {
-            ok = client.setPreset(data);
-        }
-    };
-    ApplyVisitor visitor;
-    visitor.data = decoded.getMemoryBlock();
-    ext->getAudioPluginInstance()->getExtensions(visitor);
-    if (!visitor.ok)
+    if (!writeVst3Preset(*ext->getAudioPluginInstance(), decoded.getMemoryBlock()))
         return false;  // not a VST3 instance / apply failed
 
     // Mirror the applied state into TE's state property so a later graph build /

--- a/magda/daw/audio/plugin_manager/ExternalPluginStateUtil.hpp
+++ b/magda/daw/audio/plugin_manager/ExternalPluginStateUtil.hpp
@@ -93,7 +93,8 @@ inline bool applyVst3Preset(tracktion::engine::Plugin* plugin, const juce::Strin
     if (!juce::Base64::convertFromBase64(decoded, presetBase64))
         return false;
 
-    if (!writeVst3Preset(*ext->getAudioPluginInstance(), decoded.getMemoryBlock()))
+    if (writeVst3Preset(*ext->getAudioPluginInstance(), decoded.getMemoryBlock()) !=
+        Vst3PresetOutcome::Applied)
         return false;  // not a VST3 instance / apply failed
 
     // Mirror the applied state into TE's state property so a later graph build /

--- a/magda/daw/audio/plugin_manager/PluginManager.cpp
+++ b/magda/daw/audio/plugin_manager/PluginManager.cpp
@@ -13,7 +13,7 @@
 #include "../PluginWindowBridge.hpp"
 #include "../TrackController.hpp"
 #include "../TracktionHelpers.hpp"
-#include "../Vst3Preset.hpp"
+#include "ExternalPluginState.hpp"
 #include "modifiers/CurveSnapshot.hpp"
 #include "modifiers/ModifierHelpers.hpp"
 #include "modifiers/ModifierSync.hpp"
@@ -137,30 +137,15 @@ void collectValidDevicePaths(const TrackInfo& track, std::set<ChainNodePath>& va
 
 // Capture the VST3 .vstpreset for a device: the class id (stable, cached once)
 // and the current preset blob (refreshed each capture, since the patch changes).
-// One getPreset() call yields both - the class id lives in the preset header.
-// These feed the portable DAWproject deviceID + <State>.
+// These feed the portable DAWproject deviceID + <State>. What they are and how
+// they are read is the same under either engine, so it is stated once
+// (ExternalPluginState.hpp) and this is the incumbent's way in.
 void captureVst3Info(DeviceInfo& devInfo, te::ExternalPlugin* ext) {
     if (ext == nullptr)
         return;
-    auto* pi = ext->getAudioPluginInstance();
-    if (pi == nullptr)
-        return;
 
-    struct PresetVisitor : juce::ExtensionsVisitor {
-        juce::MemoryBlock data;
-        void visitVST3Client(const VST3Client& client) override {
-            data = client.getPreset();
-        }
-    };
-    PresetVisitor visitor;
-    pi->getExtensions(visitor);
-
-    const auto& preset = visitor.data;
-    if (preset.getSize() == 0)
-        return;  // not a VST3 / no preset
-    if (devInfo.vst3ClassId.isEmpty())
-        devInfo.vst3ClassId = vst3::classIdFromPreset(preset);
-    devInfo.vst3Preset = juce::Base64::toBase64(preset.getData(), preset.getSize());
+    if (auto* pi = ext->getAudioPluginInstance())
+        captureVst3Records(*pi, devInfo);
 }
 
 }  // namespace

--- a/magda/daw/audio/plugins/engine/EngineDeviceFactory.cpp
+++ b/magda/daw/audio/plugins/engine/EngineDeviceFactory.cpp
@@ -100,11 +100,12 @@ ExternalDeviceResult adaptExternalPluginInstance(
     bool offlineRender) {
     instance->enableAllBuses();
 
-    // The saved array, then the chunk over it, then what that left behind. The
+    // The saved array, then the overlay over it, then what that left behind. The
     // order and the reasons are ExternalPluginState.hpp's; what matters here is
     // that all three happen before the adapter exists, so the adapter never has
-    // to reason about which of a project's two records it is looking at.
-    if (magda::applySavedPluginState(*instance, device) == magda::SavedStateOutcome::Failed)
+    // to reason about which of a project's records it is looking at.
+    const auto restoredFrom = magda::applySavedPluginState(*instance, device);
+    if (restoredFrom == magda::SavedStateOutcome::Failed)
         return {.device = {},
                 .failure = "external plugin \"" + device.name +
                            "\" failed while restoring its own saved state"};
@@ -125,6 +126,14 @@ ExternalDeviceResult adaptExternalPluginInstance(
     auto resolvedDevice = device;
     resolvedDevice.audioInputChannels = instance->getTotalNumInputChannels();
     resolvedDevice.audioOutputChannels = instance->getTotalNumOutputChannels();
+
+    // An imported .vstpreset is spent by the load that applies it. The patch is
+    // now the instance's, the next save writes it out as a chunk, and a project
+    // that kept the preset would apply it again over whatever was saved in
+    // between. Only a published resolvedDevice clears it, so a load that failed
+    // leaves the project still holding the one thing that describes its plugin.
+    if (restoredFrom == magda::SavedStateOutcome::RestoredFromPreset)
+        resolvedDevice.vst3Preset = {};
 
     // Promote only, the rule the model's other two writers follow
     // (PluginManagerSync::updateDeviceCapabilityFlags,

--- a/magda/daw/audio/plugins/engine/EngineExternalDevice.cpp
+++ b/magda/daw/audio/plugins/engine/EngineExternalDevice.cpp
@@ -372,26 +372,6 @@ void EngineExternalDevice::writeExtraOutputs(magda::engine::DeviceBlock& block,
 }
 
 void EngineExternalDevice::processPluginBlock(juce::AudioBuffer<float>& audio) {
-    // The plugin's own callback lock, and its own suspended flag. A host reading
-    // or writing this plugin's state holds one and sets the other
-    // (ExternalPluginState.hpp), and what a block may not do is run third-party
-    // DSP concurrently with a third-party state handler: the plugin is entitled
-    // to be halfway through swapping a sample or a program, and no part of that
-    // is safe to process against.
-    //
-    // Tried rather than waited on, because this is the audio thread. A block
-    // that arrives mid-transaction leaves the buffer as it was handed over,
-    // which is the passthrough the plan already gives a Device op with no
-    // instance bound, and the wet/dry mix is skipped with it: mixing a plugin's
-    // input against itself is not what a project at 40% wet asked for.
-    //
-    // The lock is the half that makes suspension mean anything. Holding it here
-    // is what makes suspendProcessing() wait for a block already in progress
-    // rather than set a flag and return while the plugin is still running.
-    const juce::ScopedTryLock guard(instance_->getCallbackLock());
-    if (!guard.isLocked() || instance_->isSuspended())
-        return;
-
     const auto numSamples = audio.getNumSamples();
 
     if (dryGain_ <= kDryLevelFloor) {
@@ -495,6 +475,31 @@ void EngineExternalDevice::processThroughScratch(magda::engine::DeviceBlock& blo
 }
 
 void EngineExternalDevice::process(magda::engine::DeviceBlock& block) {
+    // The plugin's own callback lock, and its own suspended flag. A host reading
+    // or writing this plugin's state holds one and sets the other
+    // (ExternalPluginState.hpp), and what a block may not do is touch the plugin
+    // at all while that is happening: it is entitled to be halfway through
+    // swapping a sample or a program, and neither its DSP nor its parameters are
+    // safe to reach into meanwhile.
+    //
+    // Everything plugin-facing is inside this, parameter writes included. They
+    // are the reason the gate is here rather than around the processBlock call:
+    // a capture reads the plugin's chunk and then its parameter values, and a
+    // block that moved a parameter between those two reads would produce a
+    // saved pair that disagrees with itself.
+    //
+    // Tried rather than waited on, because this is the audio thread. A block
+    // that arrives mid-transaction leaves the buffer as it was handed over,
+    // which is the passthrough the plan already gives a Device op with no
+    // instance bound.
+    //
+    // The lock is the half that makes suspension mean anything. Holding it here
+    // is what makes suspendProcessing() wait for a block already in progress
+    // rather than set a flag and return while the plugin is still running.
+    const juce::ScopedTryLock guard(instance_->getCallbackLock());
+    if (!guard.isLocked() || instance_->isSuspended())
+        return;
+
     writeParameters(block.params);
 
     const auto numSamples = static_cast<int>(block.audio.getNumSamples());

--- a/magda/daw/audio/plugins/engine/EngineExternalDevice.cpp
+++ b/magda/daw/audio/plugins/engine/EngineExternalDevice.cpp
@@ -372,6 +372,26 @@ void EngineExternalDevice::writeExtraOutputs(magda::engine::DeviceBlock& block,
 }
 
 void EngineExternalDevice::processPluginBlock(juce::AudioBuffer<float>& audio) {
+    // The plugin's own callback lock, and its own suspended flag. A host reading
+    // or writing this plugin's state holds one and sets the other
+    // (ExternalPluginState.hpp), and what a block may not do is run third-party
+    // DSP concurrently with a third-party state handler: the plugin is entitled
+    // to be halfway through swapping a sample or a program, and no part of that
+    // is safe to process against.
+    //
+    // Tried rather than waited on, because this is the audio thread. A block
+    // that arrives mid-transaction leaves the buffer as it was handed over,
+    // which is the passthrough the plan already gives a Device op with no
+    // instance bound, and the wet/dry mix is skipped with it: mixing a plugin's
+    // input against itself is not what a project at 40% wet asked for.
+    //
+    // The lock is the half that makes suspension mean anything. Holding it here
+    // is what makes suspendProcessing() wait for a block already in progress
+    // rather than set a flag and return while the plugin is still running.
+    const juce::ScopedTryLock guard(instance_->getCallbackLock());
+    if (!guard.isLocked() || instance_->isSuspended())
+        return;
+
     const auto numSamples = audio.getNumSamples();
 
     if (dryGain_ <= kDryLevelFloor) {

--- a/magda/daw/audio/plugins/engine/EngineExternalDevice.hpp
+++ b/magda/daw/audio/plugins/engine/EngineExternalDevice.hpp
@@ -124,6 +124,16 @@ class EngineExternalDevice final : public magda::engine::EngineDevice {
     void reset() override;
     void setMidiInputBoundBytes(int bytes) override;
     int latencySamples() const override;
+
+    /// One block through the plugin: its parameters written, its audio
+    /// processed, its MIDI carried.
+    ///
+    /// Does none of that while a host holds the plugin for a state read or
+    /// write, and passes the block through instead. That is the one thing in
+    /// this class which is not the fork's arrangement transcribed: the fork
+    /// waits on its own processMutex where this declines to block the audio
+    /// thread. The two can only differ while a save is in flight, and a corpus
+    /// render never takes one.
     void process(magda::engine::DeviceBlock& block) override;
 
     /// The instance this stands for. For a host that has to reach past the
@@ -139,12 +149,6 @@ class EngineExternalDevice final : public magda::engine::EngineDevice {
 
     /// The plugin over one buffer, wet/dry mixed. @p audio is the buffer the
     /// plugin processes in place, at the width it asked for.
-    ///
-    /// Leaves @p audio alone while a host holds the plugin for a state read or
-    /// write, which is the one thing in this class that is not the fork's
-    /// arrangement transcribed: the fork waits on its own processMutex where
-    /// this passes the block through rather than blocking the audio thread. The
-    /// two can only differ during a save, and a corpus render never takes one.
     void processPluginBlock(juce::AudioBuffer<float>& audio);
 
     /// The block through a buffer of the plugin's own width, for a plugin whose

--- a/magda/daw/audio/plugins/engine/EngineExternalDevice.hpp
+++ b/magda/daw/audio/plugins/engine/EngineExternalDevice.hpp
@@ -139,6 +139,12 @@ class EngineExternalDevice final : public magda::engine::EngineDevice {
 
     /// The plugin over one buffer, wet/dry mixed. @p audio is the buffer the
     /// plugin processes in place, at the width it asked for.
+    ///
+    /// Leaves @p audio alone while a host holds the plugin for a state read or
+    /// write, which is the one thing in this class that is not the fork's
+    /// arrangement transcribed: the fork waits on its own processMutex where
+    /// this passes the block through rather than blocking the audio thread. The
+    /// two can only differ during a save, and a corpus render never takes one.
     void processPluginBlock(juce::AudioBuffer<float>& audio);
 
     /// The block through a buffer of the plugin's own width, for a plugin whose

--- a/tests/engine/test_engine_external_device.cpp
+++ b/tests/engine/test_engine_external_device.cpp
@@ -11,6 +11,7 @@
 
 #include "core/ParameterInfo.hpp"
 #include "exec/EngineDevice.hpp"
+#include "magda/daw/audio/Vst3Preset.hpp"
 #include "magda/daw/audio/plugin_manager/ExternalPluginLookup.hpp"
 #include "magda/daw/audio/plugin_manager/ExternalPluginState.hpp"
 #include "magda/daw/audio/plugins/engine/EngineDeviceFactory.hpp"
@@ -81,6 +82,30 @@ class StubParameter final : public juce::AudioProcessorParameterWithID {
   private:
     float value_ = 0.0f;
 };
+
+/// The class id a stub VST3's preset header carries, which is the identity
+/// another host matches on and the one thing MAGDA reads out of the header.
+constexpr const char* kStubVst3ClassId = "0123456789ABCDEF0123456789ABCDEF";
+
+/// A .vstpreset-shaped block: Steinberg's header, then @p bytes of payload.
+///
+/// The header is what makes this a preset rather than a chunk -- the magic, the
+/// class id at offset eight, the chunk-list offset at forty -- and a stub that
+/// skipped it would let a bug that reads the wrong offset pass.
+juce::MemoryBlock vst3PresetOf(const void* payload, size_t bytes) {
+    constexpr size_t kHeaderBytes = 48;
+
+    juce::MemoryBlock preset;
+    preset.setSize(kHeaderBytes, true);
+
+    auto* header = static_cast<char*>(preset.getData());
+    std::memcpy(header, "VST3", 4);
+    std::memcpy(header + magda::vst3::kVst3PresetClassIdOffset, kStubVst3ClassId,
+                magda::vst3::kVst3PresetClassIdLength);
+
+    preset.append(payload, bytes);
+    return preset;
+}
 
 /**
  * @brief A plugin that reports what it was handed and marks what it wrote.
@@ -224,6 +249,14 @@ class StubPlugin final : public juce::AudioPluginInstance {
     };
 
     void getStateInformation(juce::MemoryBlock& destination) override {
+        if (throwsSavingState)
+            throw std::runtime_error("plugin state handler failed");
+
+        // A plugin whose whole voice is its parameters has nothing to add, and
+        // plenty of real ones are like that.
+        if (savesNothing)
+            return;
+
         const State state{.tone = tone->getValue(), .fixed = fixed->getValue()};
         destination.replaceAll(&state, sizeof(state));
     }
@@ -259,6 +292,41 @@ class StubPlugin final : public juce::AudioPluginInstance {
         }
     }
 
+    /**
+     * @brief The stub as a VST3, for the one record that is not a chunk.
+     *
+     * A portable .vstpreset is reached through the format's own client rather
+     * than through setStateInformation, and whether an instance answers this
+     * visit at all is the only way a host can ask whether it is a VST3. So the
+     * stub answers it or does not, and a test picks which.
+     *
+     * The patch it carries is the same State the chunk carries, behind a real
+     * preset header: what is being asserted is which door the host went
+     * through, not that two serialisations differ.
+     */
+    struct Vst3Extension final : juce::ExtensionsVisitor::VST3Client {
+        explicit Vst3Extension(const StubPlugin& owner) : plugin(owner) {}
+
+        Steinberg::Vst::IComponent* getIComponentPtr() const noexcept override {
+            return nullptr;
+        }
+
+        juce::MemoryBlock getPreset() const override;
+        bool setPreset(const juce::MemoryBlock& data) const override;
+
+        const StubPlugin& plugin;
+    };
+
+    void getExtensions(juce::ExtensionsVisitor& visitor) const override {
+        // Nothing is visited for a plugin of another format, which is how the
+        // host tells a VST3 from an AU without being told.
+        if (!isVst3)
+            return;
+
+        const Vst3Extension client(*this);
+        visitor.visitVST3Client(client);
+    }
+
     /// The per-channel offset the output carries, so a test can name which of
     /// the plugin's channels it is reading.
     static constexpr float kChannelMarker = 0.01f;
@@ -285,6 +353,23 @@ class StubPlugin final : public juce::AudioPluginInstance {
     /// And some get part of the way through first.
     bool mutatesBeforeThrowing = false;
 
+    /// And some throw describing themselves rather than reading a description.
+    bool throwsSavingState = false;
+
+    /// And some have nothing beyond their parameters to describe.
+    bool savesNothing = false;
+
+    /// Whether this stub is a VST3 at all (see getExtensions).
+    bool isVst3 = false;
+
+    /// Whether its VST3 client takes the preset it is handed. A real one
+    /// refuses a patch that was written for a different plugin.
+    bool acceptsPreset = true;
+
+    /// How many presets reached it, which is how a test tells the portable
+    /// record's door from the chunk's.
+    mutable int presetApplies = 0;
+
     double preparedRate = 0.0;
     int preparedBlockSize = 0;
     int prepareCount = 0;
@@ -296,6 +381,27 @@ class StubPlugin final : public juce::AudioPluginInstance {
     juce::MidiBuffer midiSeen;
     juce::AudioPlayHead::PositionInfo positionSeen;
 };
+
+juce::MemoryBlock StubPlugin::Vst3Extension::getPreset() const {
+    const State state{.tone = plugin.tone->getValue(), .fixed = plugin.fixed->getValue()};
+    return vst3PresetOf(&state, sizeof(state));
+}
+
+bool StubPlugin::Vst3Extension::setPreset(const juce::MemoryBlock& data) const {
+    if (!plugin.acceptsPreset)
+        return false;
+
+    constexpr size_t kHeaderBytes = 48;
+    if (data.getSize() != kHeaderBytes + sizeof(State))
+        return false;
+
+    State state{};
+    std::memcpy(&state, static_cast<const char*>(data.getData()) + kHeaderBytes, sizeof(state));
+    plugin.tone->setValue(state.tone);
+    plugin.fixed->setValue(state.fixed);
+    ++plugin.presetApplies;
+    return true;
+}
 
 /// A real AudioPluginFormat seam for the asynchronous factory test. The
 /// format manager still performs its normal lookup and message-thread delivery;
@@ -1407,6 +1513,270 @@ TEST_CASE("Saved state that is not a chunk this plugin understands is refused",
     REQUIRE(result.device != nullptr);
     CHECK(raw->stateRestores == 0);
     CHECK(raw->fixed->getValue() == Catch::Approx(0.0f));
+}
+
+// ============================================================================
+// The portable record: a .vstpreset a project was imported with (#2244)
+// ============================================================================
+
+TEST_CASE("An imported project's .vstpreset is the overlay", "[engine][external]") {
+    // A DAWproject carries a VST3's patch as a .vstpreset, because no other
+    // host has MAGDA's chunk format. The device it lands on therefore has a
+    // portable record and no native one, and a load that only knew about chunks
+    // would render the plugin's initialised voice.
+    auto plugin = std::make_unique<StubPlugin>(2, 2, 0);
+    auto* raw = plugin.get();
+    raw->isVst3 = true;
+
+    const StubPlugin::State imported{.tone = 0.9f, .fixed = 0.8f};
+    const auto preset = vst3PresetOf(&imported, sizeof(imported));
+
+    auto model = externalDevice();
+    model.vst3Preset = juce::Base64::toBase64(preset.getData(), preset.getSize());
+
+    const auto result = adapter::adaptExternalPluginInstance(std::move(plugin), model);
+    REQUIRE(result.device != nullptr);
+
+    // Through the format's own door, not the chunk's.
+    CHECK(raw->presetApplies == 1);
+    CHECK(raw->stateRestores == 0);
+    CHECK(raw->fixed->getValue() == Catch::Approx(0.8f));
+}
+
+TEST_CASE("An applied preset is spent rather than kept", "[engine][external]") {
+    // The patch is the instance's now, and the next save writes it out as a
+    // chunk. A project that kept the preset would apply it again on the load
+    // after that, over whatever had been saved in between.
+    auto plugin = std::make_unique<StubPlugin>(2, 2, 0);
+    plugin->isVst3 = true;
+
+    const StubPlugin::State imported{.tone = 0.9f, .fixed = 0.8f};
+    const auto preset = vst3PresetOf(&imported, sizeof(imported));
+
+    auto model = externalDevice();
+    model.vst3Preset = juce::Base64::toBase64(preset.getData(), preset.getSize());
+
+    const auto result = adapter::adaptExternalPluginInstance(std::move(plugin), model);
+    REQUIRE(result.device != nullptr);
+    REQUIRE(result.resolvedDevice.has_value());
+    CHECK(result.resolvedDevice->vst3Preset.isEmpty());
+
+    // And the model the caller was handed is the only thing that changed: a
+    // load that never got published leaves the project holding its preset.
+    CHECK(model.vst3Preset.isNotEmpty());
+}
+
+TEST_CASE("A preset the plugin refuses falls through to the chunk", "[engine][external]") {
+    // A patch written for another plugin, handed to this one. The project's own
+    // native record is right there and is the only thing that describes this
+    // device, so refusing the preset must not also discard it.
+    auto plugin = std::make_unique<StubPlugin>(2, 2, 0);
+    auto* raw = plugin.get();
+    raw->isVst3 = true;
+    raw->acceptsPreset = false;
+
+    const StubPlugin::State imported{.tone = 0.9f, .fixed = 0.8f};
+    const auto preset = vst3PresetOf(&imported, sizeof(imported));
+
+    const StubPlugin::State saved{.tone = 0.3f, .fixed = 0.2f};
+    juce::MemoryBlock chunk(&saved, sizeof(saved));
+
+    auto model = externalDevice();
+    model.vst3Preset = juce::Base64::toBase64(preset.getData(), preset.getSize());
+    model.pluginState = chunk.toBase64Encoding();
+
+    const auto result = adapter::adaptExternalPluginInstance(std::move(plugin), model);
+    REQUIRE(result.device != nullptr);
+
+    CHECK(raw->presetApplies == 0);
+    CHECK(raw->stateRestores == 1);
+    CHECK(raw->fixed->getValue() == Catch::Approx(0.2f));
+
+    // Nothing was consumed, so the project keeps the preset for a machine whose
+    // copy of the plugin does take it.
+    REQUIRE(result.resolvedDevice.has_value());
+    CHECK(result.resolvedDevice->vst3Preset.isNotEmpty());
+}
+
+TEST_CASE("A plugin that is not a VST3 never sees a preset", "[engine][external]") {
+    // Format is not something a host reads off a description here: an instance
+    // either answers the VST3 extension or it does not, and one that does not
+    // has only the chunk.
+    auto plugin = std::make_unique<StubPlugin>(2, 2, 0);
+    auto* raw = plugin.get();
+    raw->isVst3 = false;
+
+    const StubPlugin::State imported{.tone = 0.9f, .fixed = 0.8f};
+    const auto preset = vst3PresetOf(&imported, sizeof(imported));
+
+    auto model = externalDeviceSaving(1.0f, 0.7f);
+    model.vst3Preset = juce::Base64::toBase64(preset.getData(), preset.getSize());
+
+    const auto result = adapter::adaptExternalPluginInstance(std::move(plugin), model);
+    REQUIRE(result.device != nullptr);
+
+    CHECK(raw->presetApplies == 0);
+    CHECK(raw->stateRestores == 0);
+    CHECK(raw->tone->getValue() == Catch::Approx(0.7f));  // the array, and nothing over it
+}
+
+// ============================================================================
+// Saving: what a project keeps about a plugin the native engine holds (#2244)
+// ============================================================================
+
+TEST_CASE("A save writes the chunk the incumbent would have written", "[engine][external][state]") {
+    // The round trip that matters during the dual-engine release: a project
+    // saved while the native engine held the instance has to open under the
+    // fork, which means the same base64 in the same field.
+    auto plugin = std::make_unique<StubPlugin>(2, 2, 0);
+    auto* raw = plugin.get();
+    raw->tone->setValue(0.9f);
+    raw->fixed->setValue(0.8f);
+
+    auto model = externalDevice();
+    REQUIRE(magda::captureSavedPluginState(*raw, model));
+
+    // What the fork writes for the same instance: getStateInformation, in
+    // juce::MemoryBlock's own base64.
+    juce::MemoryBlock expected;
+    raw->getStateInformation(expected);
+    CHECK(model.pluginState == expected.toBase64Encoding());
+
+    // And a second instance restored from it holds what the first one held,
+    // including the parameter no host may automate.
+    auto reopened = std::make_unique<StubPlugin>(2, 2, 0);
+    auto* reopenedRaw = reopened.get();
+    const auto result = adapter::adaptExternalPluginInstance(std::move(reopened), model);
+    REQUIRE(result.device != nullptr);
+    CHECK(reopenedRaw->tone->getValue() == Catch::Approx(0.9f));
+    CHECK(reopenedRaw->fixed->getValue() == Catch::Approx(0.8f));
+}
+
+TEST_CASE("A save writes the parameter array beside the chunk", "[engine][external][state]") {
+    // The two records have to agree. The array is the baseline the chunk
+    // overlays on the next load, and it is also what the UI draws and what
+    // automation addresses, so a save that only wrote the chunk would leave the
+    // project describing the voice before the last knob move.
+    auto plugin = std::make_unique<StubPlugin>(2, 2, 0);
+    auto* raw = plugin.get();
+    raw->gain->setValue(0.6f);
+    raw->tone->setValue(0.9f);
+
+    auto model = externalDeviceSaving(0.1f, 0.2f);
+    REQUIRE(magda::captureSavedPluginState(*raw, model));
+
+    CHECK(model.parameters[0].currentValue == Catch::Approx(0.6f));
+    CHECK(model.parameters[1].currentValue == Catch::Approx(0.9f));
+}
+
+TEST_CASE("A plugin with nothing to say saves no chunk at all", "[engine][external][state]") {
+    // The fork removes the property rather than storing a zero-length chunk,
+    // and a project that stored one would come back as a baseline anyway. What
+    // matters is that a previous save's chunk does not survive the plugin
+    // ceasing to have one.
+    auto plugin = std::make_unique<StubPlugin>(2, 2, 0);
+    auto* raw = plugin.get();
+    raw->savesNothing = true;
+
+    auto model = externalDevice();
+    model.pluginState = "some earlier chunk";
+
+    REQUIRE(magda::captureSavedPluginState(*raw, model));
+    CHECK(model.pluginState.isEmpty());
+}
+
+TEST_CASE("A plugin that throws describing itself leaves the last good save",
+          "[engine][external][state]") {
+    // Neither record may be written on its own: the array is the baseline the
+    // chunk overlays, and a fresh array under a stale chunk restores the stale
+    // voice and calls it the project's. So a save that cannot write both writes
+    // neither.
+    auto plugin = std::make_unique<StubPlugin>(2, 2, 0);
+    auto* raw = plugin.get();
+    raw->gain->setValue(0.6f);
+    raw->throwsSavingState = true;
+
+    auto model = externalDeviceSaving(0.1f, 0.2f);
+    model.pluginState = "the last chunk that saved cleanly";
+
+    CHECK_FALSE(magda::captureSavedPluginState(*raw, model));
+    CHECK(model.pluginState == "the last chunk that saved cleanly");
+    CHECK(model.parameters[0].currentValue == Catch::Approx(0.1f));
+}
+
+TEST_CASE("A save is not left holding the plugin suspended", "[engine][external][state]") {
+    // The fork suspends the plugin across the read, and a plugin left suspended
+    // by its own throw would render silence for the rest of the session.
+    auto plugin = std::make_unique<StubPlugin>(2, 2, 0);
+    auto* raw = plugin.get();
+    raw->throwsSavingState = true;
+
+    auto model = externalDevice();
+    CHECK_FALSE(magda::captureSavedPluginState(*raw, model));
+    CHECK_FALSE(raw->isSuspended());
+}
+
+TEST_CASE("A save refreshes the portable VST3 records", "[engine][external][state]") {
+    // The .vstpreset a DAWproject export writes is the current patch, not the
+    // one the project was imported with, so it is read again on every save. The
+    // class id beside it is the plugin's identity rather than its patch, and is
+    // written once.
+    auto plugin = std::make_unique<StubPlugin>(2, 2, 0);
+    auto* raw = plugin.get();
+    raw->isVst3 = true;
+    raw->tone->setValue(0.9f);
+
+    auto model = externalDevice();
+    REQUIRE(magda::captureSavedPluginState(*raw, model));
+
+    CHECK(model.vst3ClassId == kStubVst3ClassId);
+    REQUIRE(model.vst3Preset.isNotEmpty());
+
+    juce::MemoryOutputStream decoded;
+    REQUIRE(juce::Base64::convertFromBase64(decoded, model.vst3Preset));
+    CHECK(magda::vst3::classIdFromPreset(decoded.getMemoryBlock()) == kStubVst3ClassId);
+}
+
+TEST_CASE("A save leaves a non-VST3 device's portable records alone", "[engine][external][state]") {
+    // An AU cannot restate the identity a project was imported with, and
+    // clearing it would lose the one thing another host matches on.
+    auto plugin = std::make_unique<StubPlugin>(2, 2, 0);
+    auto* raw = plugin.get();
+    raw->isVst3 = false;
+
+    auto model = externalDevice();
+    model.vst3ClassId = "FEDCBA9876543210FEDCBA9876543210";
+    model.vst3Preset = "what the project was imported with";
+
+    REQUIRE(magda::captureSavedPluginState(*raw, model));
+    CHECK(model.vst3ClassId == "FEDCBA9876543210FEDCBA9876543210");
+    CHECK(model.vst3Preset == "what the project was imported with");
+}
+
+TEST_CASE("A save reads the instance the adapter is holding", "[engine][external][state]") {
+    // The seam a host saves through: the adapter owns the instance, and
+    // EngineExternalDevice::instance() is how anything that is not rendering
+    // reaches it.
+    auto plugin = std::make_unique<StubPlugin>(2, 2, 0);
+    auto* raw = plugin.get();
+
+    auto model = externalDevice();
+    auto result = adapter::adaptExternalPluginInstance(std::move(plugin), model);
+    REQUIRE(result.device != nullptr);
+
+    // The patch moves after the device was built, the way a knob moved during a
+    // session does.
+    raw->tone->setValue(0.75f);
+
+    auto* external = dynamic_cast<adapter::EngineExternalDevice*>(result.device.get());
+    REQUIRE(external != nullptr);
+    REQUIRE(magda::captureSavedPluginState(external->instance(), model));
+
+    auto reopened = std::make_unique<StubPlugin>(2, 2, 0);
+    auto* reopenedRaw = reopened.get();
+    const auto reloaded = adapter::adaptExternalPluginInstance(std::move(reopened), model);
+    REQUIRE(reloaded.device != nullptr);
+    CHECK(reopenedRaw->tone->getValue() == Catch::Approx(0.75f));
 }
 
 TEST_CASE("The asynchronous entry point reports a missing plugin the same way",

--- a/tests/engine/test_engine_external_device.cpp
+++ b/tests/engine/test_engine_external_device.cpp
@@ -1713,15 +1713,29 @@ TEST_CASE("A block that arrives during a state read does not reach the plugin",
     // of its read.
     raw->suspendProcessing(true);
 
-    ParamArena arena({0.0f, 1.0f, 1.0f, 0.25f});
+    const auto gainWrites = raw->gain->writes;
+    const auto toneWrites = raw->tone->writes;
+    const auto gainBefore = raw->gain->getValue();
+
+    // Values the plugin is not already holding, so a write that got through
+    // would be a write the parameter records. Supplying what it already has
+    // would let this pass with the gate around processBlock alone, which is
+    // where the hole was: writeParameters() runs before it.
+    ParamArena arena({0.0f, 1.0f, 0.3f, 0.7f});
     Block block(context, 2);
     block.fill(0.5f);
 
     auto deviceBlock = block.deviceBlock(arena.params(context.maxBlockSize));
     result.device->process(deviceBlock);
 
-    // The plugin never saw it.
+    // Nothing plugin-facing happened. Not its DSP, and not its parameters
+    // either: a capture reads the chunk and then the parameter values, and a
+    // block that moved one between the two saves a pair that disagrees with
+    // itself.
     CHECK(raw->samplesSeen == 0);
+    CHECK(raw->gain->writes == gainWrites);
+    CHECK(raw->tone->writes == toneWrites);
+    CHECK(raw->gain->getValue() == Catch::Approx(gainBefore));
 
     // And the block came out as it went in, which is the passthrough the plan
     // already gives a Device op with no instance bound. The stub would have

--- a/tests/engine/test_engine_external_device.cpp
+++ b/tests/engine/test_engine_external_device.cpp
@@ -534,6 +534,17 @@ magda::engine::DeviceKey keyFor(const magda::DeviceInfo& device) {
     return {magda::ChainSegment::Fx, device.id};
 }
 
+/// Read a plugin and write what it holds into @p device, which is what a caller
+/// does with the two halves when it has nothing to check between them.
+bool captureInto(juce::AudioPluginInstance& instance, magda::DeviceInfo& device) {
+    const auto snapshot = magda::captureExternalPluginState(instance);
+    if (!snapshot.has_value())
+        return false;
+
+    magda::applyCapturedPluginState(device, *snapshot);
+    return true;
+}
+
 /// The device registered as live, and the request a load for it carries.
 ///
 /// Registration is the caller's job in production too: a device that becomes
@@ -1709,7 +1720,7 @@ TEST_CASE("A block that arrives during a state read does not reach the plugin",
     const auto context = contextFor();
     result.device->prepare(context);
 
-    // Suspended, the way captureSavedPluginState() suspends it for the duration
+    // Suspended, the way captureExternalPluginState() suspends it for the duration
     // of its read.
     raw->suspendProcessing(true);
 
@@ -1745,6 +1756,34 @@ TEST_CASE("A block that arrives during a state read does not reach the plugin",
     raw->suspendProcessing(false);
 }
 
+TEST_CASE("Reading a plugin does not write the project", "[engine][external][state]") {
+    // The two halves are separate so a caller can put a question between them.
+    // The one it has to ask is whether the device it read is still the device it
+    // is about to write, and a capture that wrote the model on the way past
+    // would have answered it too late. The same seam is what a plugin living in
+    // another process would need: a snapshot can cross, a plugin cannot.
+    auto plugin = std::make_unique<StubPlugin>(2, 2, 0);
+    auto* raw = plugin.get();
+    raw->gain->setValue(0.6f);
+
+    auto model = externalDeviceSaving(0.1f, 0.2f);
+    model.pluginState = "the project as it was";
+
+    const auto snapshot = magda::captureExternalPluginState(*raw);
+    REQUIRE(snapshot.has_value());
+
+    // The plugin has been read and the project has not been touched.
+    CHECK(model.pluginState == "the project as it was");
+    CHECK(model.parameters[0].currentValue == Catch::Approx(0.1f));
+
+    // And everything read is in the snapshot, waiting for a caller that wants it.
+    CHECK(snapshot->pluginState.isNotEmpty());
+
+    magda::applyCapturedPluginState(model, *snapshot);
+    CHECK(model.pluginState != "the project as it was");
+    CHECK(model.parameters[0].currentValue == Catch::Approx(0.6f));
+}
+
 TEST_CASE("A save writes the chunk the incumbent would have written", "[engine][external][state]") {
     // The round trip that matters during the dual-engine release: a project
     // saved while the native engine held the instance has to open under the
@@ -1755,7 +1794,7 @@ TEST_CASE("A save writes the chunk the incumbent would have written", "[engine][
     raw->fixed->setValue(0.8f);
 
     auto model = externalDevice();
-    REQUIRE(magda::captureSavedPluginState(*raw, model));
+    REQUIRE(captureInto(*raw, model));
 
     // What the fork writes for the same instance: getStateInformation, in
     // juce::MemoryBlock's own base64.
@@ -1784,7 +1823,7 @@ TEST_CASE("A save writes the parameter array beside the chunk", "[engine][extern
     raw->tone->setValue(0.9f);
 
     auto model = externalDeviceSaving(0.1f, 0.2f);
-    REQUIRE(magda::captureSavedPluginState(*raw, model));
+    REQUIRE(captureInto(*raw, model));
 
     CHECK(model.parameters[0].currentValue == Catch::Approx(0.6f));
     CHECK(model.parameters[1].currentValue == Catch::Approx(0.9f));
@@ -1802,7 +1841,7 @@ TEST_CASE("A plugin with nothing to say saves no chunk at all", "[engine][extern
     auto model = externalDevice();
     model.pluginState = "some earlier chunk";
 
-    REQUIRE(magda::captureSavedPluginState(*raw, model));
+    REQUIRE(captureInto(*raw, model));
     CHECK(model.pluginState.isEmpty());
 }
 
@@ -1820,7 +1859,7 @@ TEST_CASE("A plugin that throws describing itself leaves the last good save",
     auto model = externalDeviceSaving(0.1f, 0.2f);
     model.pluginState = "the last chunk that saved cleanly";
 
-    CHECK_FALSE(magda::captureSavedPluginState(*raw, model));
+    CHECK_FALSE(captureInto(*raw, model));
     CHECK(model.pluginState == "the last chunk that saved cleanly");
     CHECK(model.parameters[0].currentValue == Catch::Approx(0.1f));
 }
@@ -1833,7 +1872,7 @@ TEST_CASE("A save is not left holding the plugin suspended", "[engine][external]
     raw->throwsSavingState = true;
 
     auto model = externalDevice();
-    CHECK_FALSE(magda::captureSavedPluginState(*raw, model));
+    CHECK_FALSE(captureInto(*raw, model));
     CHECK_FALSE(raw->isSuspended());
 }
 
@@ -1848,7 +1887,7 @@ TEST_CASE("A save refreshes the portable VST3 records", "[engine][external][stat
     raw->tone->setValue(0.9f);
 
     auto model = externalDevice();
-    REQUIRE(magda::captureSavedPluginState(*raw, model));
+    REQUIRE(captureInto(*raw, model));
 
     CHECK(model.vst3ClassId == kStubVst3ClassId);
     REQUIRE(model.vst3Preset.isNotEmpty());
@@ -1875,7 +1914,7 @@ TEST_CASE("A VST3 that cannot write its patch out does not keep the old one",
     model.vst3ClassId = kStubVst3ClassId;
     model.vst3Preset = "the patch this project was imported with";
 
-    REQUIRE(magda::captureSavedPluginState(*raw, model));
+    REQUIRE(captureInto(*raw, model));
 
     CHECK(model.vst3Preset.isEmpty());
     CHECK(model.pluginState.isNotEmpty());
@@ -1896,7 +1935,7 @@ TEST_CASE("A save leaves a non-VST3 device's portable records alone", "[engine][
     model.vst3ClassId = "FEDCBA9876543210FEDCBA9876543210";
     model.vst3Preset = "what the project was imported with";
 
-    REQUIRE(magda::captureSavedPluginState(*raw, model));
+    REQUIRE(captureInto(*raw, model));
     CHECK(model.vst3ClassId == "FEDCBA9876543210FEDCBA9876543210");
     CHECK(model.vst3Preset == "what the project was imported with");
 }
@@ -1918,7 +1957,7 @@ TEST_CASE("A save reads the instance the adapter is holding", "[engine][external
 
     auto* external = dynamic_cast<adapter::EngineExternalDevice*>(result.device.get());
     REQUIRE(external != nullptr);
-    REQUIRE(magda::captureSavedPluginState(external->instance(), model));
+    REQUIRE(captureInto(external->instance(), model));
 
     auto reopened = std::make_unique<StubPlugin>(2, 2, 0);
     auto* reopenedRaw = reopened.get();

--- a/tests/engine/test_engine_external_device.cpp
+++ b/tests/engine/test_engine_external_device.cpp
@@ -359,12 +359,19 @@ class StubPlugin final : public juce::AudioPluginInstance {
     /// And some have nothing beyond their parameters to describe.
     bool savesNothing = false;
 
+    /// A VST3 that cannot write its patch out, which is the case a caller must
+    /// not read as "not a VST3".
+    bool savesNoPreset = false;
+
     /// Whether this stub is a VST3 at all (see getExtensions).
     bool isVst3 = false;
 
     /// Whether its VST3 client takes the preset it is handed. A real one
     /// refuses a patch that was written for a different plugin.
     bool acceptsPreset = true;
+
+    /// And whether it has already changed something by the time it refuses.
+    bool mutatesBeforeRefusing = false;
 
     /// How many presets reached it, which is how a test tells the portable
     /// record's door from the chunk's.
@@ -383,13 +390,24 @@ class StubPlugin final : public juce::AudioPluginInstance {
 };
 
 juce::MemoryBlock StubPlugin::Vst3Extension::getPreset() const {
+    if (plugin.savesNoPreset)
+        return {};
+
     const State state{.tone = plugin.tone->getValue(), .fixed = plugin.fixed->getValue()};
     return vst3PresetOf(&state, sizeof(state));
 }
 
 bool StubPlugin::Vst3Extension::setPreset(const juce::MemoryBlock& data) const {
-    if (!plugin.acceptsPreset)
+    if (!plugin.acceptsPreset) {
+        // Half of it, then the refusal. Steinberg's loader restores the
+        // component's state and then the controller's and returns false when the
+        // second fails after the first, so this is what a real refusal can look
+        // like from outside.
+        if (plugin.mutatesBeforeRefusing)
+            plugin.tone->setValue(0.42f);
+
         return false;
+    }
 
     constexpr size_t kHeaderBytes = 48;
     if (data.getSize() != kHeaderBytes + sizeof(State))
@@ -1566,6 +1584,57 @@ TEST_CASE("An applied preset is spent rather than kept", "[engine][external]") {
     CHECK(model.vst3Preset.isNotEmpty());
 }
 
+TEST_CASE("A refused preset with nothing behind it is not published", "[engine][external]") {
+    // Steinberg's loader restores the component's state before the controller's
+    // and returns false when the second fails after the first, so a refusal is
+    // not a no-op: the plugin can be holding half the imported patch. An import
+    // is exactly the project with no chunk to overwrite that with, and the
+    // parameter array underneath describes what the project believed rather than
+    // what the instance now is.
+    //
+    // So it is refused the same way a chunk that threw is, rather than published
+    // as a baseline nobody can describe.
+    auto plugin = std::make_unique<StubPlugin>(2, 2, 0);
+    auto* raw = plugin.get();
+    raw->isVst3 = true;
+    raw->acceptsPreset = false;
+    raw->mutatesBeforeRefusing = true;
+
+    const StubPlugin::State imported{.tone = 0.9f, .fixed = 0.8f};
+    const auto preset = vst3PresetOf(&imported, sizeof(imported));
+
+    auto model = externalDevice();
+    model.vst3Preset = juce::Base64::toBase64(preset.getData(), preset.getSize());
+
+    const auto result = adapter::adaptExternalPluginInstance(std::move(plugin), model);
+
+    CHECK(result.device == nullptr);
+    CHECK(result.failure.contains("restoring its own saved state"));
+
+    // And the value it was left on never reached the model.
+    CHECK(result.restoredParameters.empty());
+}
+
+TEST_CASE("A plugin of another format refusing nothing is still a baseline", "[engine][external]") {
+    // The other side of the case above. A project can carry a portable preset
+    // and be opened against an AU, where nothing is asked and nothing moves, and
+    // that device still has its parameter array to stand on.
+    auto plugin = std::make_unique<StubPlugin>(2, 2, 0);
+    auto* raw = plugin.get();
+    raw->isVst3 = false;
+
+    const StubPlugin::State imported{.tone = 0.9f, .fixed = 0.8f};
+    const auto preset = vst3PresetOf(&imported, sizeof(imported));
+
+    auto model = externalDeviceSaving(1.0f, 0.7f);
+    model.vst3Preset = juce::Base64::toBase64(preset.getData(), preset.getSize());
+
+    const auto result = adapter::adaptExternalPluginInstance(std::move(plugin), model);
+
+    REQUIRE(result.device != nullptr);
+    CHECK(raw->tone->getValue() == Catch::Approx(0.7f));
+}
+
 TEST_CASE("A preset the plugin refuses falls through to the chunk", "[engine][external]") {
     // A patch written for another plugin, handed to this one. The project's own
     // native record is right there and is the only thing that describes this
@@ -1623,6 +1692,44 @@ TEST_CASE("A plugin that is not a VST3 never sees a preset", "[engine][external]
 // ============================================================================
 // Saving: what a project keeps about a plugin the native engine holds (#2244)
 // ============================================================================
+
+TEST_CASE("A block that arrives during a state read does not reach the plugin",
+          "[engine][external][state]") {
+    // Suspension is worth nothing unless the host honours it. A save reads the
+    // plugin's chunk, its parameters and its preset from the message thread with
+    // the plugin suspended, and a block that ran the plugin anyway would have
+    // third-party DSP and a third-party state handler in the same instance at
+    // the same time.
+    auto plugin = std::make_unique<StubPlugin>(2, 2, 0);
+    auto* raw = plugin.get();
+
+    auto result = adapter::adaptExternalPluginInstance(std::move(plugin), externalDevice());
+    REQUIRE(result.device != nullptr);
+
+    const auto context = contextFor();
+    result.device->prepare(context);
+
+    // Suspended, the way captureSavedPluginState() suspends it for the duration
+    // of its read.
+    raw->suspendProcessing(true);
+
+    ParamArena arena({0.0f, 1.0f, 1.0f, 0.25f});
+    Block block(context, 2);
+    block.fill(0.5f);
+
+    auto deviceBlock = block.deviceBlock(arena.params(context.maxBlockSize));
+    result.device->process(deviceBlock);
+
+    // The plugin never saw it.
+    CHECK(raw->samplesSeen == 0);
+
+    // And the block came out as it went in, which is the passthrough the plan
+    // already gives a Device op with no instance bound. The stub would have
+    // added its per-channel marker had it run.
+    CHECK(block.buffer.getSample(0, 0) == Catch::Approx(0.5f));
+
+    raw->suspendProcessing(false);
+}
 
 TEST_CASE("A save writes the chunk the incumbent would have written", "[engine][external][state]") {
     // The round trip that matters during the dual-engine release: a project
@@ -1735,6 +1842,33 @@ TEST_CASE("A save refreshes the portable VST3 records", "[engine][external][stat
     juce::MemoryOutputStream decoded;
     REQUIRE(juce::Base64::convertFromBase64(decoded, model.vst3Preset));
     CHECK(magda::vst3::classIdFromPreset(decoded.getMemoryBlock()) == kStubVst3ClassId);
+}
+
+TEST_CASE("A VST3 that cannot write its patch out does not keep the old one",
+          "[engine][external][state]") {
+    // The dangerous half of the case below. An empty read from a VST3 and an
+    // empty read from an AU are the same block and are not the same event: the
+    // AU was never asked, and the VST3 failed to answer. Keeping the project's
+    // existing preset here would leave a record of an older patch beside the
+    // chunk this very save just wrote -- and the portable record is the overlay
+    // on the next load, so the older patch would win over the newer one.
+    auto plugin = std::make_unique<StubPlugin>(2, 2, 0);
+    auto* raw = plugin.get();
+    raw->isVst3 = true;
+    raw->savesNoPreset = true;
+
+    auto model = externalDevice();
+    model.vst3ClassId = kStubVst3ClassId;
+    model.vst3Preset = "the patch this project was imported with";
+
+    REQUIRE(magda::captureSavedPluginState(*raw, model));
+
+    CHECK(model.vst3Preset.isEmpty());
+    CHECK(model.pluginState.isNotEmpty());
+
+    // The identity survives. It is the plugin rather than its patch, and the one
+    // the project was authored against is the one another host matches on.
+    CHECK(model.vst3ClassId == kStubVst3ClassId);
 }
 
 TEST_CASE("A save leaves a non-VST3 device's portable records alone", "[engine][external][state]") {


### PR DESCRIPTION
Closes #2244. Slice 3 of #1893, whose other half landed in #2249.

## What was missing

A project's record of an external plugin was only readable. `applySavedPluginState()` stated the restore order in one place; saving was not stated anywhere. So a project saved while the native engine held the instance would have lost the plugin's voice on the way back to the fork, which is exactly the round trip the dual-engine release depends on.

## Saving

`captureSavedPluginState()` is the mirror of `applySavedPluginState()`, and what it writes is what `ExternalPlugin::flushPluginStateToValueTree()` writes for the same instance:

- The chunk from `getStateInformation()`, in `juce::MemoryBlock`'s own base64 rather than the standard one, because that is the encoding the field already holds and `decodeSavedChunk()` already reads.
- Absent rather than empty when the plugin has nothing to say. The fork removes the property; a stored zero-length chunk would come back as a baseline anyway, and a previous save's chunk must not survive the plugin ceasing to have one.
- The parameter array beside it, so the two records agree: the array is the baseline the chunk overlays on the next load, and it is also what the UI draws and what automation addresses.
- The portable VST3 records refreshed, which is what the incumbent does on every capture.

The plugin is suspended across the read the way the fork suspends it, and restored either way, since a plugin left suspended by its own throw would render silence for the rest of the session. A plugin that throws describing itself writes **neither** record and reports it: a fresh array under a stale chunk restores the stale voice and calls it the project's, so a save that can only write one of them writes none and the project keeps the last pair that agreed.

## The portable preset

`DeviceInfo::vst3Preset` is the .vstpreset a DAWproject carries, and until now the native engine did nothing with it -- a comment in `applySavedPluginState()` said so and pointed here. It is now the overlay when a project has one, which is what the incumbent does, and it is **consumed**: the load that applies it is what turns it into native state, and a project that kept it would apply it again over whatever had been saved since.

`adaptExternalPluginInstance()` clears it on `resolvedDevice` only, which a caller publishes solely on success -- so a load that failed leaves the project still holding the one thing that describes its plugin.

One deliberate divergence from the incumbent, stated in the header rather than left to be found: a plugin that **refuses** the preset falls through to the chunk instead of being left on the bare array. The incumbent's `else` is a consequence of TE's async lifecycle rather than a rule anyone stated, and no project carries both records unless a preset has already failed to apply once -- at which point the fork discards the project's own native record every load thereafter.

## The API, said once

#1893 asks for this to stop being an archaeology exercise. `ExternalPluginState.hpp` now states both directions and has no Tracktion dependency at all, which was the original complaint: the incumbent's sequence reaches an internal TE header that is not self-contained and has to be fenced off from `SortIncludes`.

Three copies of the VST3 `ExtensionsVisitor` become one pair of functions, `readVst3Preset()` and `writeVst3Preset()`:

- `PluginManager::captureVst3Info` keeps its name and its TE null-checks, and delegates.
- `ExternalPluginStateUtil::applyVst3Preset` keeps only what is genuinely TE's: the async guard, the state-property mirror and the parameter cache refresh.
- `AudioBridge`'s two-mode `Vst3PresetVisitor` is gone; `getVst3DeviceId`, `loadPluginPresetFile` and `savePluginPresetFile` call the shared pair.

## Tests

Twelve cases in `tests/engine/test_engine_external_device.cpp`. The stub gains a VST3 extension, because whether an instance answers that visit is the only way a host can ask what format it is, and a real `.vstpreset` header so the class id is read at the offset it actually lives at.

Restore: an imported preset is the overlay and reaches the plugin through the format's own door rather than the chunk's; an applied one is spent rather than kept; a refused one falls through to the chunk; a plugin that is not a VST3 never sees one.

Save: the chunk matches what the fork writes and a second instance restored from it holds what the first held, including the parameter no host may automate; the array is written beside it; a plugin with nothing to say saves no chunk; a plugin that throws leaves the last good save intact and is not left suspended; the portable records are refreshed for a VST3 and left alone for anything else; and a save reads the instance through `EngineExternalDevice::instance()`, which is the seam a host actually saves through.

## Verification

Full Catch2 suite passes (650,349 assertions), `make debug` builds clean, and `magda_juce_tests` passes including the real-project corpus -- the `FAIL` lines in its report are the recorded known-diff cases and are unchanged.

https://claude.ai/code/session_01Qa7GxDU184RGxo2b1Yhpa6
