### PR TITLE
Host external plugins in the null-diff native leg, and the master chain (#2175)

### DIFF
--- a/magda/daw/audio/plugins/engine/EngineDeviceFactory.cpp
+++ b/magda/daw/audio/plugins/engine/EngineDeviceFactory.cpp
@@ -202,7 +202,13 @@ ExternalPluginResolution resolveEngineExternalPlugin(const magda::DeviceInfo& de
     ExternalPluginResolution resolved{.planDevice = device};
 
     if (services.formats == nullptr || services.knownPlugins == nullptr) {
-        resolved.failure = "no plugin formats or scan results were given to the engine";
+        // Named, like every other failure here. A caller collecting these has a
+        // project's worth of devices and needs to know which one it is holding,
+        // and "no plugin formats" on its own reads as one global complaint
+        // rather than one per plugin the render went without.
+        resolved.failure = "external plugin \"" + device.name +
+                           "\" cannot be resolved: no plugin formats or scan results were given "
+                           "to the engine";
         return resolved;
     }
 

--- a/tests/MgdFixture.cpp
+++ b/tests/MgdFixture.cpp
@@ -5,6 +5,7 @@
 #include <map>
 #include <set>
 
+#include "core/ChainWalk.hpp"
 #include "core/SourcePool.hpp"
 #include "project/serialization/ProjectSerializer.hpp"
 
@@ -191,23 +192,33 @@ std::string writeAndRepoint(const std::vector<Source*>& sources, const Declarati
 }
 
 /// Every device anywhere in a track's chain, racks and flat sections included.
-void everyDevice(const std::vector<ChainElement>& elements, std::vector<const DeviceInfo*>& out) {
-    for (const auto& element : elements) {
-        if (magda::isDevice(element)) {
-            out.push_back(&magda::getDevice(element));
-        } else if (magda::isRack(element)) {
-            for (const auto& chain : magda::getRack(element).chains)
-                everyDevice(chain.elements, out);
-        }
-    }
+/// Every device under @p elements, pads included.
+///
+/// The model's own walk rather than one written here, and entered with
+/// Pads::Enter: a Drum Grid's pads are chains of devices, so a walk that stopped
+/// at the grid would call a project full of hosted plugins an internal one. The
+/// refusal below is the whole point of this walk, and a walk that cannot see
+/// half a project cannot refuse on its behalf.
+void everyDevice(const std::vector<ChainElement>& elements, TrackId trackId,
+                 std::vector<const DeviceInfo*>& out) {
+    magda::chain_walk::forEachDevice(
+        elements, magda::ChainNodePath::trackLevel(trackId), magda::chain_walk::Pads::Enter,
+        [&out](const DeviceInfo& device, const ChainNodePath&) { out.push_back(&device); });
 }
 
 void everyDevice(const TrackInfo& track, std::vector<const DeviceInfo*>& out) {
-    everyDevice(track.chain.fxChainElements, out);
+    everyDevice(track.chain.fxChainElements, track.id, out);
+
+    // Flat stages: no racks, but a device there can still carry pads.
     for (const auto* section :
          {&track.chain.postFxChainElements, &track.chain.mixerAnalysisElements})
-        for (const auto& element : *section)
+        for (const auto& element : *section) {
             out.push_back(&element.device);
+
+            if (element.device.pads)
+                for (const auto& pad : element.device.pads->chains)
+                    everyDevice(pad.elements, track.id, out);
+        }
 }
 
 /**

--- a/tests/MgdFixtures.cpp
+++ b/tests/MgdFixtures.cpp
@@ -147,6 +147,23 @@ std::vector<MgdFixture> build() {
         fixture.declaration = declarationFor(
             "project.v1bounces", "two v1 audio clips with their sources inline, at 120", 0.0, 16.0);
 
+        // The grid's pads, said out loud rather than substituted in silence.
+        //
+        // A Drum Grid fills every pad with a magdasampler when it restores
+        // (DrumGridPads.cpp), and that device has not moved to the SDK, so the
+        // native engine cannot build one (#2271). Until #2175 the harness never
+        // looked inside a pad and the substitution was invisible; it looks now,
+        // so the gap is named here.
+        //
+        // Declared rather than skipped, because the grid on this project's third
+        // track has nothing to play and the two v1 audio clips are what the
+        // fixture exists for. Declaring it keeps those live and asserts the gap
+        // in both directions: the day the sampler runs natively (#2271), this
+        // line fails and comes out.
+        fixture.declaration.expectedDiagnostics = {
+            "no native device for magdasampler",
+        };
+
         // Impulses on both: neither clip is stretched -- the source's own bpm is
         // the project's -- so where each sample lands is the whole assertion.
         //

--- a/tests/NullDiffCorpus.cpp
+++ b/tests/NullDiffCorpus.cpp
@@ -6,6 +6,7 @@
 #include "NullDiffCase.hpp"
 #include "NullDiffGain.hpp"
 #include "NullDiffMaterial.hpp"
+#include "core/ChainWalk.hpp"
 #include "core/DeviceInfo.hpp"
 #include "core/SourcePool.hpp"
 #include "core/TimeStretchModes.hpp"
@@ -2141,38 +2142,42 @@ std::vector<Case> buildCorpus(const juce::File& scratchDirectory) {
 std::vector<std::string> externalDevicesIn(const Case& value) {
     std::vector<std::string> external;
 
-    // Recursive, because a rack is a chain of chains and a plugin four levels
-    // down frames its own work exactly like one at the top. A walk that stopped
-    // at the first level would report a rack full of plugins as an internal
-    // project and hold it to bit identity, which is the one way this can be
-    // wrong in the direction nobody notices: the gate would fail, and the
+    // The model's own walk, because a rack is a chain of chains and a plugin four
+    // levels down frames its own work exactly like one at the top. A walk that
+    // stopped at the first level would report a rack full of plugins as an
+    // internal project and hold it to bit identity, which is the one way this
+    // can be wrong in the direction nobody notices: the gate would fail, and the
     // failure would name no cause.
-    const std::function<void(const std::vector<ChainElement>&)> walk =
-        [&](const std::vector<ChainElement>& elements) {
-            for (const auto& element : elements) {
-                if (isDevice(element)) {
-                    const auto& device = getDevice(element);
-                    if (device.format != PluginFormat::Internal)
-                        external.push_back(device.name.toStdString());
-                    continue;
-                }
-
-                for (const auto& chain : getRack(element).chains)
-                    walk(chain.elements);
-            }
-        };
+    //
+    // Pads::Enter for the same reason one level further in. A Drum Grid's pads
+    // are chains of devices, and a kit built out of hosted plugins is a project
+    // this would otherwise call internal.
+    const auto walk = [&external](const std::vector<ChainElement>& elements, TrackId trackId) {
+        chain_walk::forEachDevice(elements, ChainNodePath::trackLevel(trackId),
+                                  chain_walk::Pads::Enter,
+                                  [&external](const DeviceInfo& device, const ChainNodePath&) {
+                                      if (device.format != PluginFormat::Internal)
+                                          external.push_back(device.name.toStdString());
+                                  });
+    };
 
     // The post-FX stage and the mixer rail's analysis devices are as much of the
     // project as the insert chain is, and a plugin in either one reaches the
     // render the same way.
     const auto walkTrack = [&](const TrackInfo& track) {
-        walk(track.chain.fxChainElements);
+        walk(track.chain.fxChainElements, track.id);
 
+        // Flat stages: no racks, but a device there can still carry pads.
         for (const auto* stage :
              {&track.chain.postFxChainElements, &track.chain.mixerAnalysisElements})
-            for (const auto& element : *stage)
+            for (const auto& element : *stage) {
                 if (element.device.format != PluginFormat::Internal)
                     external.push_back(element.device.name.toStdString());
+
+                if (element.device.pads)
+                    for (const auto& pad : element.device.pads->chains)
+                        walk(pad.elements, track.id);
+            }
     };
 
     for (const auto& track : value.tracks)

--- a/tests/NullDiffNativeLeg.cpp
+++ b/tests/NullDiffNativeLeg.cpp
@@ -18,6 +18,7 @@
 #include "exec/PlanExecutor.hpp"
 #include "exec/PlanValues.hpp"
 #include "io/PrefetchThread.hpp"
+#include "magda/daw/audio/plugin_manager/ExternalPluginState.hpp"
 #include "magda/daw/audio/plugins/engine/EngineDeviceFactory.hpp"
 #include "plan/PlanCompiler.hpp"
 #include "transport/TempoMap.hpp"
@@ -25,6 +26,8 @@
 namespace magda::nulldiff {
 
 using namespace magda::engine;
+
+namespace adapter = ::magda::daw::audio::engine_adapter;
 
 namespace {
 
@@ -186,30 +189,78 @@ class ImpulseSynthDevice final : public EngineDevice {
 /// segment and not across them (#1899), so a map keyed by the number alone
 /// would let a post-FX device stand in for the FX device with the same one.
 /// OpKey::deviceKey() carries the segment for that reason; this has to match.
-void collectDevices(const std::vector<magda::ChainElement>& elements,
-                    std::map<DeviceKey, const magda::DeviceInfo*>& out) {
-    for (const auto& element : elements) {
+void collectDevices(std::vector<magda::ChainElement>& elements,
+                    std::map<DeviceKey, magda::DeviceInfo*>& out) {
+    for (auto& element : elements) {
         if (magda::isDevice(element)) {
-            const auto& device = magda::getDevice(element);
+            auto& device = magda::getDevice(element);
             out[DeviceKey{ChainSegment::Fx, device.id}] = &device;
         } else if (magda::isRack(element)) {
             // A rack's chains sit in the segment the rack itself does.
-            for (const auto& chain : magda::getRack(element).chains)
+            for (auto& chain : magda::getRack(element).chains)
                 collectDevices(chain.elements, out);
         }
     }
 }
 
-std::map<DeviceKey, const magda::DeviceInfo*> devicesIn(const Case& value) {
-    std::map<DeviceKey, const magda::DeviceInfo*> devices;
-    for (const auto& track : value.tracks) {
+/// Every device the plan can emit an op for, by the key the op carries.
+///
+/// The master's chain is walked with the rest. It is as much of the project as
+/// any track's, the compiler emits Device ops for it, and a master left out of
+/// this map is a master limiter that silently becomes a stand-in: the case
+/// still renders, still compares, and is measuring a project without its
+/// master chain in it.
+std::map<DeviceKey, magda::DeviceInfo*> devicesIn(std::vector<TrackInfo>& tracks,
+                                                  TrackInfo& master) {
+    std::map<DeviceKey, magda::DeviceInfo*> devices;
+
+    const auto collectTrack = [&devices](TrackInfo& track) {
         collectDevices(track.chain.fxChainElements, devices);
-        for (const auto& element : track.chain.postFxChainElements)
+        for (auto& element : track.chain.postFxChainElements)
             devices[DeviceKey{ChainSegment::PostFx, element.device.id}] = &element.device;
-        for (const auto& element : track.chain.mixerAnalysisElements)
+        for (auto& element : track.chain.mixerAnalysisElements)
             devices[DeviceKey{ChainSegment::MixerAnalysis, element.device.id}] = &element.device;
-    }
+    };
+
+    for (auto& track : tracks)
+        collectTrack(track);
+
+    collectTrack(master);
     return devices;
+}
+
+/// Whether @p device is a plugin somebody else shipped, which is the one kind
+/// this leg cannot build from a catalog and has to find on the machine.
+bool isExternalDevice(const magda::DeviceInfo& device) {
+    return device.format != magda::PluginFormat::Internal;
+}
+
+/**
+ * @brief Correct every external device against the scan, before the plan reads it.
+ *
+ * The plan is compiled from the model, and for an external plugin two of the
+ * things it compiles from are the project's guesses rather than facts: the
+ * effect/instrument role, which decides whether the device is routed MIDI at
+ * all, and the cached capability flags. A project imported from another host
+ * carries whatever that host said, and #2252's whole point is that resolution
+ * is entitled to correct it.
+ *
+ * So resolution happens here, once, against a copy of the model, and both the
+ * plan and the device creation below read the corrected one. A failure is left
+ * alone rather than reported: the creation below asks the same question and
+ * reports the same answer, and one diagnostic per absent plugin is what a
+ * reader wants.
+ */
+void resolveExternalDevices(std::vector<TrackInfo>& tracks, TrackInfo& master,
+                            const adapter::ExternalPluginServices& services) {
+    for (auto& [key, device] : devicesIn(tracks, master)) {
+        if (!isExternalDevice(*device))
+            continue;
+
+        auto resolved = adapter::resolveEngineExternalPlugin(*device, services);
+        if (resolved)
+            *device = std::move(resolved.planDevice);
+    }
 }
 
 engine::TempoMap tempoMapFor(const Case& value) {
@@ -273,7 +324,7 @@ class BufferSink final : public OfflineRenderSink {
 
 }  // namespace
 
-NativeRender renderNative(const Case& value) {
+NativeRender renderNative(const Case& value, const InstalledPlugins& installed) {
     NativeRender result;
 
     const RenderContext context{value.sampleRate, value.blockSize, value.channels};
@@ -327,9 +378,23 @@ NativeRender renderNative(const Case& value) {
 
     // --- the plan ------------------------------------------------------------
 
+    // The scan an external plugin is resolved against, and the settings one is
+    // instantiated at. Both legs read the same scan; a leg that was handed none
+    // resolves nothing and says so per device below.
+    const adapter::ExternalPluginServices services{
+        .formats = installed.formats, .knownPlugins = installed.knownPlugins, .context = context};
+
+    // The model the plan and the devices are both built from, corrected against
+    // the scan first. Resolution may change the role an external device is
+    // compiled with, and a plan compiled from the project's own guess would
+    // route MIDI to the wrong places before any plugin was created.
+    auto tracks = value.tracks;
+    auto master = value.master;
+    resolveExternalDevices(tracks, master, services);
+
     CompileOptions options;
     options.deviceMeters = false;
-    const auto plan = compileRenderPlan(value.tracks, value.master, options);
+    const auto plan = compileRenderPlan(tracks, master, options);
     for (const auto& diagnostic : plan.diagnostics)
         result.diagnostics.push_back("plan: " + diagnostic);
 
@@ -358,14 +423,14 @@ NativeRender renderNative(const Case& value) {
     std::vector<std::unique_ptr<GainDevice>> gains;
     std::vector<std::unique_ptr<ImpulseSynthDevice>> synths;
 
-    const auto modelDevices = devicesIn(value);
+    const auto modelDevices = devicesIn(tracks, master);
 
     // The tracks the corpus compares MIDI for, which is the same question the
     // incumbent asks when it decides where to put a capture. Asked once, of the
     // model, through the compiler's own predicate, rather than inferred from the
     // graph afterwards.
     std::set<TrackId> midiTracks;
-    for (const auto& track : value.tracks)
+    for (const auto& track : tracks)
         if (chainConsumesMidi(track))
             midiTracks.insert(track.id);
 
@@ -405,7 +470,7 @@ NativeRender renderNative(const Case& value) {
                 // is built by the factory below, which is what makes a corpus
                 // case able to contain one (#2174).
                 const auto found = modelDevices.find(op.key.deviceKey());
-                const auto* model = found == modelDevices.end() ? nullptr : found->second;
+                auto* model = found == modelDevices.end() ? nullptr : found->second;
 
                 if (model != nullptr && isImpulseSynthDevice(*model)) {
                     auto device = std::make_unique<ImpulseSynthDevice>();
@@ -423,14 +488,44 @@ NativeRender renderNative(const Case& value) {
                     break;
                 }
 
-                if (model != nullptr) {
+                if (model != nullptr && isExternalDevice(*model)) {
+                    // A plugin somebody else shipped, loaded from the machine
+                    // rather than built from a catalog. Blocking, because this
+                    // leg is an offline render with nothing to do until the
+                    // plugin is there.
+                    auto external = adapter::createEngineExternalDevice(*model, services,
+                                                                        /*offlineRender=*/true);
+
+                    if (external.device != nullptr) {
+                        // What the restore left behind, written back into the
+                        // model before the parameter table is resolved from it.
+                        // The chunk wins over the project's saved array, and the
+                        // table is what the plan writes onto the device every
+                        // block: a model left holding the stale array would put
+                        // it back on the first one (ExternalPluginState.hpp).
+                        magda::applyRestoredParameters(*model, external.restoredParameters);
+
+                        external.device->prepare(context);
+                        bindings.devices[op.key.deviceKey()] = external.device.get();
+                        hosted.push_back(std::move(external.device));
+                        break;
+                    }
+
+                    // Said out loud, always. A plugin this machine does not
+                    // have is not a quieter project, it is a different one, and
+                    // a case that compared anyway would be passing by having
+                    // tested less than it claims. The runner turns any
+                    // diagnostic the case did not declare into unmeasurable,
+                    // which is the same treatment a proxy that never arrived
+                    // already gets (#2175).
+                    result.diagnostics.push_back("devices: " + external.failure.toStdString());
+                } else if (model != nullptr) {
                     // Built for an offline render, because that is what this
                     // leg is and what the other leg's Renderer tells its own
                     // devices. A device that skips live-only work has to skip
                     // it on both sides or the corpus is comparing two different
                     // decisions about the same block.
-                    if (auto device = ::magda::daw::audio::engine_adapter::createEngineDevice(
-                            *model, /*offlineRender=*/true)) {
+                    if (auto device = adapter::createEngineDevice(*model, /*offlineRender=*/true)) {
                         device->prepare(context);
                         bindings.devices[op.key.deviceKey()] = device.get();
                         hosted.push_back(std::move(device));
@@ -449,7 +544,7 @@ NativeRender renderNative(const Case& value) {
                     // capture there rather than a plugin -- and reporting those
                     // would make every such case unmeasurable over an asymmetry
                     // that does not exist.
-                    if (::magda::daw::audio::engine_adapter::isRegisteredDevice(model->pluginId))
+                    if (adapter::isRegisteredDevice(model->pluginId))
                         result.diagnostics.push_back("devices: no native device for " +
                                                      model->pluginId.toStdString());
                 }
@@ -484,8 +579,8 @@ NativeRender renderNative(const Case& value) {
     // The op values and the parameter table together, out of one call, so the
     // two cannot be published out of step (#2117).
     PlanValues values;
-    for (const auto& diagnostic : resolvePlanValues(plan, value.tracks, value.master, values,
-                                                    value.lanes, value.automationClips))
+    for (const auto& diagnostic :
+         resolvePlanValues(plan, tracks, master, values, value.lanes, value.automationClips))
         result.diagnostics.push_back("values: " + diagnostic);
 
     // What the table could not honour: a link naming something the project does

--- a/tests/NullDiffNativeLeg.cpp
+++ b/tests/NullDiffNativeLeg.cpp
@@ -20,6 +20,7 @@
 #include "io/PrefetchThread.hpp"
 #include "magda/daw/audio/plugin_manager/ExternalPluginState.hpp"
 #include "magda/daw/audio/plugins/engine/EngineDeviceFactory.hpp"
+#include "magda/daw/core/ChainWalk.hpp"
 #include "plan/PlanCompiler.hpp"
 #include "transport/TempoMap.hpp"
 
@@ -183,23 +184,46 @@ class ImpulseSynthDevice final : public EngineDevice {
     }
 };
 
-/// Every device the case declares, by the identity the plan addresses it with.
+/// Every device in @p elements and everything nested inside them, keyed in
+/// @p segment.
 ///
 /// Keyed by DeviceKey and not by DeviceId: an id is unique within a chain
 /// segment and not across them (#1899), so a map keyed by the number alone
 /// would let a post-FX device stand in for the FX device with the same one.
 /// OpKey::deviceKey() carries the segment for that reason; this has to match.
+///
+/// The walk is the model's own (ChainWalk.hpp) rather than one written here,
+/// entered with Pads::Enter. A Drum Grid's pads are chains of devices and
+/// PlanCompiler::emitPadRack() emits an op for each of them, so a walk that
+/// stopped at the grid would leave every plugin in every pad looked up and not
+/// found -- bound to a stand-in, never resolved, and reported as nothing. Two
+/// definitions of "every device in a project" is exactly the disagreement that
+/// file exists to prevent.
 void collectDevices(std::vector<magda::ChainElement>& elements,
+                    const magda::ChainNodePath& parentPath, ChainSegment segment,
                     std::map<DeviceKey, magda::DeviceInfo*>& out) {
+    magda::chain_walk::forEachDevice(
+        elements, parentPath, magda::chain_walk::Pads::Enter,
+        [&out, segment](magda::DeviceInfo& device, const magda::ChainNodePath&) {
+            out[DeviceKey{segment, device.id}] = &device;
+        });
+}
+
+/// The same for a flat stage, whose elements are devices rather than a tree.
+///
+/// Flat means no racks; it does not mean no pads, so a device that carries them
+/// is descended into the same way.
+void collectFlatDevices(std::vector<magda::PostFxChainElement>& elements,
+                        const magda::ChainNodePath& parentPath, ChainSegment segment,
+                        std::map<DeviceKey, magda::DeviceInfo*>& out) {
     for (auto& element : elements) {
-        if (magda::isDevice(element)) {
-            auto& device = magda::getDevice(element);
-            out[DeviceKey{ChainSegment::Fx, device.id}] = &device;
-        } else if (magda::isRack(element)) {
-            // A rack's chains sit in the segment the rack itself does.
-            for (auto& chain : magda::getRack(element).chains)
-                collectDevices(chain.elements, out);
-        }
+        out[DeviceKey{segment, element.device.id}] = &element.device;
+
+        if (!element.device.pads)
+            continue;
+
+        for (auto& pad : element.device.pads->chains)
+            collectDevices(pad.elements, parentPath, segment, out);
     }
 }
 
@@ -215,11 +239,12 @@ std::map<DeviceKey, magda::DeviceInfo*> devicesIn(std::vector<TrackInfo>& tracks
     std::map<DeviceKey, magda::DeviceInfo*> devices;
 
     const auto collectTrack = [&devices](TrackInfo& track) {
-        collectDevices(track.chain.fxChainElements, devices);
-        for (auto& element : track.chain.postFxChainElements)
-            devices[DeviceKey{ChainSegment::PostFx, element.device.id}] = &element.device;
-        for (auto& element : track.chain.mixerAnalysisElements)
-            devices[DeviceKey{ChainSegment::MixerAnalysis, element.device.id}] = &element.device;
+        const auto trackPath = magda::ChainNodePath::trackLevel(track.id);
+        collectDevices(track.chain.fxChainElements, trackPath, ChainSegment::Fx, devices);
+        collectFlatDevices(track.chain.postFxChainElements, trackPath, ChainSegment::PostFx,
+                           devices);
+        collectFlatDevices(track.chain.mixerAnalysisElements, trackPath,
+                           ChainSegment::MixerAnalysis, devices);
     };
 
     for (auto& track : tracks)
@@ -261,6 +286,71 @@ void resolveExternalDevices(std::vector<TrackInfo>& tracks, TrackInfo& master,
         if (resolved)
             *device = std::move(resolved.planDevice);
     }
+}
+
+/// The keys of the Device ops @p plan emits, which is which of a project's
+/// devices actually render.
+std::set<DeviceKey> deviceKeysIn(const RenderPlan& plan) {
+    std::set<DeviceKey> keys;
+
+    for (const auto& op : plan.ops)
+        if (op.kind == OpKind::Device)
+            keys.insert(op.key.deviceKey());
+
+    return keys;
+}
+
+/**
+ * @brief Create every external plugin the plan reaches, before the plan is final.
+ *
+ * Scan metadata is not the whole answer about an external device. A plugin's own
+ * saved state is allowed to change its topology -- a sampler whose patch turns
+ * its drum outs on, a compressor whose patch enables its sidechain, an
+ * instrument that is stereo for one program and mono for another -- and
+ * adaptExternalPluginInstance() reads the live bus counts and MIDI capabilities
+ * back only after the chunk has been applied, which is why it hands a
+ * resolvedDevice back at all.
+ *
+ * Those facts have to reach the model before PlanCompiler freezes port widths
+ * and MIDI edges from it. So the instances are made here, their corrections
+ * written into @p tracks and @p master, and the plan compiled from the result;
+ * the same instances are then bound, rather than a second set made from the
+ * corrected model.
+ *
+ * @p reached is the first compile's answer to which devices render, and it is
+ * all the first compile is used for. A device on a bypassed chain is not
+ * instantiated and not reported, because a project does not go without a plugin
+ * it was never going to run.
+ */
+std::map<DeviceKey, adapter::ExternalDeviceResult> createExternalDevices(
+    std::vector<TrackInfo>& tracks, TrackInfo& master, const std::set<DeviceKey>& reached,
+    const adapter::ExternalPluginServices& services) {
+    std::map<DeviceKey, adapter::ExternalDeviceResult> created;
+
+    for (auto& [key, device] : devicesIn(tracks, master)) {
+        if (!isExternalDevice(*device) || !reached.contains(key))
+            continue;
+
+        // Built for an offline render, which is what this leg is; see the
+        // binding loop for why that matters on both sides.
+        auto result = adapter::createEngineExternalDevice(*device, services,
+                                                          /*offlineRender=*/true);
+
+        if (result.device != nullptr) {
+            // The live topology first, then what the restore left behind on top
+            // of it. Both are read from this model by what comes next: the
+            // compiler for the widths and the roles, the value layer for the
+            // parameters.
+            if (result.resolvedDevice.has_value())
+                *device = *result.resolvedDevice;
+
+            magda::applyRestoredParameters(*device, result.restoredParameters);
+        }
+
+        created.emplace(key, std::move(result));
+    }
+
+    return created;
 }
 
 engine::TempoMap tempoMapFor(const Case& value) {
@@ -394,6 +484,17 @@ NativeRender renderNative(const Case& value, const InstalledPlugins& installed) 
 
     CompileOptions options;
     options.deviceMeters = false;
+
+    // Compiled twice, and the first one is thrown away. Its only job is to say
+    // which devices this project actually renders, so that the plugins can be
+    // made -- and a plugin's own state is entitled to change the topology the
+    // second compile reads (createExternalDevices).
+    //
+    // A project with no external device compiles the same plan both times, which
+    // is every case in the code-built corpus.
+    auto externals = createExternalDevices(
+        tracks, master, deviceKeysIn(compileRenderPlan(tracks, master, options)), services);
+
     const auto plan = compileRenderPlan(tracks, master, options);
     for (const auto& diagnostic : plan.diagnostics)
         result.diagnostics.push_back("plan: " + diagnostic);
@@ -489,25 +590,17 @@ NativeRender renderNative(const Case& value, const InstalledPlugins& installed) 
                 }
 
                 if (model != nullptr && isExternalDevice(*model)) {
-                    // A plugin somebody else shipped, loaded from the machine
-                    // rather than built from a catalog. Blocking, because this
-                    // leg is an offline render with nothing to do until the
-                    // plugin is there.
-                    auto external = adapter::createEngineExternalDevice(*model, services,
-                                                                        /*offlineRender=*/true);
+                    // Already made, above, because the plan was compiled from
+                    // what the instance turned out to be rather than from what
+                    // the project guessed. This binds that instance; a second
+                    // one made here would be a second plugin, at its own state,
+                    // for a plan describing the first.
+                    const auto made = externals.find(op.key.deviceKey());
 
-                    if (external.device != nullptr) {
-                        // What the restore left behind, written back into the
-                        // model before the parameter table is resolved from it.
-                        // The chunk wins over the project's saved array, and the
-                        // table is what the plan writes onto the device every
-                        // block: a model left holding the stale array would put
-                        // it back on the first one (ExternalPluginState.hpp).
-                        magda::applyRestoredParameters(*model, external.restoredParameters);
-
-                        external.device->prepare(context);
-                        bindings.devices[op.key.deviceKey()] = external.device.get();
-                        hosted.push_back(std::move(external.device));
+                    if (made != externals.end() && made->second.device != nullptr) {
+                        made->second.device->prepare(context);
+                        bindings.devices[op.key.deviceKey()] = made->second.device.get();
+                        hosted.push_back(std::move(made->second.device));
                         break;
                     }
 
@@ -518,7 +611,15 @@ NativeRender renderNative(const Case& value, const InstalledPlugins& installed) 
                     // diagnostic the case did not declare into unmeasurable,
                     // which is the same treatment a proxy that never arrived
                     // already gets (#2175).
-                    result.diagnostics.push_back("devices: " + external.failure.toStdString());
+                    //
+                    // An op with nothing made for it at all is a device the
+                    // first compile did not reach and the second did, which is
+                    // the plan changing shape around the corrected topology.
+                    result.diagnostics.push_back(
+                        "devices: " + (made != externals.end()
+                                           ? made->second.failure.toStdString()
+                                           : "external plugin \"" + model->name.toStdString() +
+                                                 "\" was not reached by the first compile"));
                 } else if (model != nullptr) {
                     // Built for an offline render, because that is what this
                     // leg is and what the other leg's Renderer tells its own
@@ -659,6 +760,16 @@ NativeRender renderNative(const Case& value, const InstalledPlugins& installed) 
     // time rather than as one track's timeline followed by another's.
     std::stable_sort(result.midi.begin(), result.midi.end(),
                      [](const MidiEvent& a, const MidiEvent& b) { return a.sample < b.sample; });
+
+    // One sentence, however many devices said it. A Drum Grid has a pad per
+    // note and every pad holds the same sampler, so a device the engine cannot
+    // build is a diagnostic repeated sixteen times that says nothing the first
+    // one did not. Repetition also has to be counted by anything declaring the
+    // diagnostic it expects (NullDiffCase::expectedDiagnostics), which would
+    // make a case's declaration depend on how many pads a grid happens to have.
+    std::stable_sort(result.diagnostics.begin(), result.diagnostics.end());
+    result.diagnostics.erase(std::unique(result.diagnostics.begin(), result.diagnostics.end()),
+                             result.diagnostics.end());
 
     return result;
 }

--- a/tests/NullDiffNativeLeg.hpp
+++ b/tests/NullDiffNativeLeg.hpp
@@ -29,7 +29,37 @@
  * stand-in for a device neither engine runs (#2174).
  */
 
+namespace juce {
+class AudioPluginFormatManager;
+class KnownPluginList;
+}  // namespace juce
+
 namespace magda::nulldiff {
+
+/**
+ * @brief The machine's plugin scan, for a case whose project hosts one.
+ *
+ * The engine does not go looking for plugins and could not: which plugin a
+ * project meant is answered against a scan, and the scan belongs to the host.
+ * So the leg is handed one rather than finding one, and the corpus hands it the
+ * same list the incumbent leg resolves against -- two legs reading one scan,
+ * because a corpus where each engine found its own copy of a plugin would be
+ * comparing two projects.
+ *
+ * Absent is the normal case and not an error: the code-built corpus hosts no
+ * plugins, and a machine with no scan has none to host. What it must not be is
+ * silent -- a project rendered without its plugin is a different project, so a
+ * case that names one and cannot have it is reported unmeasurable rather than
+ * compared (#2175).
+ */
+struct InstalledPlugins {
+    juce::AudioPluginFormatManager* formats = nullptr;
+    const juce::KnownPluginList* knownPlugins = nullptr;
+
+    bool available() const {
+        return formats != nullptr && knownPlugins != nullptr;
+    }
+};
 
 struct NativeRender {
     juce::AudioBuffer<float> audio;
@@ -75,6 +105,10 @@ struct NativeRender {
 };
 
 /// Render @p value through the native engine, over its own beat range.
-NativeRender renderNative(const Case& value);
+///
+/// @p installed is the scan an external plugin is resolved against. A case
+/// whose project names one without it renders nothing for that device and says
+/// so in the diagnostics.
+NativeRender renderNative(const Case& value, const InstalledPlugins& installed = {});
 
 }  // namespace magda::nulldiff

--- a/tests/NullDiffRunner.cpp
+++ b/tests/NullDiffRunner.cpp
@@ -11,9 +11,32 @@
 #include "AssertionWatch.hpp"
 #include "NullDiffNativeLeg.hpp"
 #include "NullDiffTeLeg.hpp"
+#include "SharedTestEngine.hpp"
 
 namespace magda::nulldiff {
 namespace {
+
+/**
+ * @brief The one scan both legs resolve a project's plugins against.
+ *
+ * The incumbent leg resolves against the engine's own KnownPluginList, because
+ * that is what the app does. The native leg is handed the same one rather than
+ * a list of its own: two legs that each found their own copy of a plugin would
+ * be rendering two projects and calling the difference an engine bug.
+ *
+ * It is whatever this machine has scanned, which is the point. A developer's
+ * machine has the plugins the corpus projects were authored with and measures
+ * them; a runner that has none reports every case that names one as
+ * unmeasurable, which is the honest answer rather than a green one (#2175).
+ */
+InstalledPlugins installedPlugins() {
+    auto* engine = magda::test::getSharedEngine().getEngine();
+    if (engine == nullptr)
+        return {};
+
+    auto& plugins = engine->getPluginManager();
+    return {.formats = &plugins.pluginFormatManager, .knownPlugins = &plugins.knownPluginList};
+}
 
 /// The largest magnitude anywhere in @p buffer, which is all the silence guard
 /// below needs: it asks whether a render happened, not how loud it was.
@@ -200,7 +223,7 @@ CaseReport runCase(const Case& value, const RunnerLog& log) {
     report.tier = value.tier;
     report.environment = value.environment();
 
-    const auto native = renderNative(value);
+    const auto native = renderNative(value, installedPlugins());
     const auto incumbent = renderIncumbent(value);
 
     // A leg that could not render is never reported as a residual.

--- a/tests/engine/test_engine_external_device.cpp
+++ b/tests/engine/test_engine_external_device.cpp
@@ -858,6 +858,10 @@ TEST_CASE("A host that gave the engine no formats is told so", "[engine][externa
 
     CHECK(result.device == nullptr);
     CHECK(result.failure.contains("no plugin formats"));
+
+    // And which plugin went without, because a caller collecting these has a
+    // project's worth of them.
+    CHECK(result.failure.contains(externalDevice().name));
 }
 
 TEST_CASE("Resolution returns planning facts without rewriting the saved assignment",

--- a/tests/engine/test_null_diff_block_size.cpp
+++ b/tests/engine/test_null_diff_block_size.cpp
@@ -163,6 +163,31 @@ struct GateResult {
     }
 };
 
+/// What the engine could not do in @p rendered, beyond what @p value declared.
+///
+/// The same rule the runner applies, and this file needs it more than the runner
+/// does: the runner compares a native render against the incumbent, where a
+/// device the engine did not build shows up as a residual. This compares native
+/// renders against each other, and a passthrough substituted for a plugin is
+/// perfectly block-size invariant. Checking only `failure` would certify exactly
+/// that -- a project held to bit identity across every size without the plugin
+/// ever having run.
+std::string undeclaredDiagnostic(const Case& value, const NativeRender& rendered) {
+    auto diagnostics = rendered.diagnostics;
+
+    for (const auto& expected : value.expectedDiagnostics) {
+        const auto found =
+            std::find_if(diagnostics.begin(), diagnostics.end(), [&](const std::string& reported) {
+                return reported.find(expected) != std::string::npos;
+            });
+
+        if (found != diagnostics.end())
+            diagnostics.erase(found);
+    }
+
+    return diagnostics.empty() ? std::string{} : diagnostics.front();
+}
+
 GateResult gate(const Case& value) {
     GateResult result;
 
@@ -189,6 +214,12 @@ GateResult gate(const Case& value) {
         return result;
     }
 
+    if (const auto refused = undeclaredDiagnostic(value, rendered); !refused.empty()) {
+        result.unmeasurable = "at " + std::to_string(kReferenceBlockSize) +
+                              ", the engine could not honour the case: " + refused;
+        return result;
+    }
+
     // The same project, the same size, the second time. Held to the same bit
     // identity the rungs are, and for a stronger reason: a render that is not a
     // function of the timeline is not a function of anything the rest of this
@@ -198,6 +229,13 @@ GateResult gate(const Case& value) {
         if (!again.failure.empty()) {
             result.unmeasurable =
                 "at " + std::to_string(kReferenceBlockSize) + ", rendered again: " + again.failure;
+            return result;
+        }
+
+        if (const auto refused = undeclaredDiagnostic(value, again); !refused.empty()) {
+            result.unmeasurable =
+                "at " + std::to_string(kReferenceBlockSize) +
+                ", rendered again, the engine could not honour the case: " + refused;
             return result;
         }
 
@@ -221,6 +259,12 @@ GateResult gate(const Case& value) {
 
         if (!second.failure.empty()) {
             result.unmeasurable = "at " + std::to_string(blockSize) + ": " + second.failure;
+            return result;
+        }
+
+        if (const auto refused = undeclaredDiagnostic(value, second); !refused.empty()) {
+            result.unmeasurable = "at " + std::to_string(blockSize) +
+                                  ", the engine could not honour the case: " + refused;
             return result;
         }
 
@@ -551,6 +595,41 @@ TEST_CASE("An epsilon is bought by a plugin, not declared", "[nulldiff][blocksiz
         const auto external = externalDevicesIn(value);
         REQUIRE(external.size() == 1);
         CHECK(external.front() == "Nested");
+    }
+
+    SECTION("a plugin inside a Drum Grid pad counts") {
+        // The same miss one level further in. A pad is a chain of devices, so a
+        // kit built out of hosted plugins is a project this would otherwise call
+        // internal and hold to bit identity -- and every one of those plugins
+        // frames its own work, which is exactly what the epsilon exists for.
+        auto value = projectWith(PluginFormat::Internal);
+
+        DeviceInfo grid;
+        grid.id = 904;
+        grid.name = "Drum Grid";
+        grid.deviceType = DeviceType::Instrument;
+        grid.isInstrument = true;
+        grid.format = PluginFormat::Internal;
+
+        auto pads = std::make_unique<RackInfo>();
+        pads->id = 1;
+        {
+            ChainInfo pad;
+            pad.id = 1;
+            DeviceInfo sampler;
+            sampler.id = 905;
+            sampler.name = "Padded";
+            sampler.format = PluginFormat::VST3;
+            pad.elements.emplace_back(std::move(sampler));
+            pads->chains.push_back(std::move(pad));
+        }
+        grid.pads.reset(std::move(pads));
+
+        value.tracks.front().chain.fxChainElements.emplace_back(std::move(grid));
+
+        const auto external = externalDevicesIn(value);
+        REQUIRE(external.size() == 1);
+        CHECK(external.front() == "Padded");
     }
 
     SECTION("a plugin in the post-FX stage counts too") {

--- a/tests/engine/test_null_diff_native_leg.cpp
+++ b/tests/engine/test_null_diff_native_leg.cpp
@@ -4,6 +4,7 @@
 #include <set>
 #include <string>
 
+#include "NullDiffGain.hpp"
 #include "NullDiffNativeLeg.hpp"
 
 /**
@@ -257,4 +258,156 @@ TEST_CASE("An eligible track with nothing to play is still captured", "[nulldiff
     // has, and its being empty is what says nothing was invented to fill it.
     REQUIRE(rendered.midiByTrack.count(2) == 1);
     CHECK(rendered.midiByTrack.at(2).empty());
+}
+
+namespace {
+
+/// A master track with nothing on its chain.
+///
+/// Built by hand rather than defaulted: a Case's master carries the id and the
+/// type the compiler looks for, and one that carried neither would be a
+/// different bug from the one each case below is about.
+TrackInfo bareMaster() {
+    TrackInfo master;
+    master.id = MASTER_TRACK_ID;
+    master.type = TrackType::Master;
+    master.name = "Master";
+    return master;
+}
+
+/// The same, with @p device on its insert chain.
+///
+/// Moved in one at a time. A ChainElement holds a unique_ptr for the rack case,
+/// so a braced list of them would copy and does not compile.
+TrackInfo masterWith(DeviceInfo device) {
+    auto master = bareMaster();
+    master.chain.fxChainElements.emplace_back(std::move(device));
+    return master;
+}
+
+/// An instrument track that plays one note, so a case has something audible to
+/// send through whatever is downstream of it.
+TrackInfo impulseTrack(TrackId trackId, DeviceId deviceId) {
+    TrackInfo track;
+    track.id = trackId;
+    track.type = TrackType::Media;
+    track.name = "Instrument";
+    track.audioOutputDevice = "master";
+    track.chain.fxChainElements.emplace_back(synthDevice(deviceId));
+    return track;
+}
+
+ClipInfo oneNoteClip(ClipId clipId, TrackId trackId) {
+    ClipInfo clip;
+    clip.id = clipId;
+    clip.trackId = trackId;
+    clip.name = "midi";
+    clip.view = ClipView::Arrangement;
+    clip.setMidiContent();
+    clip.setPlacementBeats(0.0, 4.0);
+    clip.deriveTimesFromBeats(120.0);
+
+    MidiNote note;
+    note.noteNumber = 60;
+    note.velocity = 100;
+    note.startBeat = 0.0;
+    note.lengthBeats = 1.0;
+    clip.midiNotes.push_back(note);
+    return clip;
+}
+
+/// One note into one instrument, with @p device on the master chain.
+Case throughMaster(const char* name, DeviceInfo device) {
+    Case value;
+    value.name = name;
+    value.covers = "the master chain's own devices";
+    value.endBeat = 4.0;
+    value.tracks.push_back(impulseTrack(1, 900));
+    value.master = masterWith(std::move(device));
+    value.clips.push_back(oneNoteClip(1, 1));
+    return value;
+}
+
+}  // namespace
+
+TEST_CASE("A device on the master chain is the one that renders", "[nulldiff][native]") {
+    // The master's chain is as much of the project as any track's, and the
+    // compiler emits Device ops for it. A leg that collected only the tracks'
+    // devices left every one of them looked up and not found, which binds the
+    // stand-in: the case still renders, still compares, and is measuring a
+    // project with no master chain in it.
+    //
+    // A gain of zero is what makes that visible. Bound, it silences the render;
+    // as a stand-in it passes the signal through and the case cannot tell the
+    // difference between a master device that worked and one that was never
+    // there.
+    const auto silenced = renderNative(throughMaster("master.silenced", gainDevice(901, 0.0f)));
+    REQUIRE(silenced.failure.empty());
+    CHECK(silenced.diagnostics.empty());
+    CHECK(peakOf(silenced.audio) == 0.0);
+
+    // The control, so the assertion above is about the master device rather
+    // than about a case that renders nothing either way.
+    const auto passed = renderNative(throughMaster("master.passed", gainDevice(901, 1.0f)));
+    REQUIRE(passed.failure.empty());
+    CHECK(peakOf(passed.audio) > 0.0);
+}
+
+TEST_CASE("A plugin the machine does not have is said out loud", "[nulldiff][native]") {
+    // The rule #2175 turns on: a project rendered without its plugin is not
+    // that project, and a case that compared anyway would pass by having tested
+    // less than it claims. The runner makes any diagnostic a case did not
+    // declare unmeasurable, so what this leg owes is to report one.
+    //
+    // Rendered with no scan at all, which is what a machine that has never
+    // scanned looks like and what every CI runner looks like.
+    Case value;
+    value.name = "external.absent";
+    value.covers = "a project naming a plugin this machine cannot resolve";
+    value.endBeat = 4.0;
+
+    TrackInfo track;
+    track.id = 1;
+    track.type = TrackType::Media;
+    track.name = "Hosting";
+    track.audioOutputDevice = "master";
+
+    DeviceInfo plugin;
+    plugin.id = 910;
+    plugin.name = "Something Nobody Has";
+    plugin.deviceType = DeviceType::Effect;
+    plugin.format = PluginFormat::VST3;
+    track.chain.fxChainElements.emplace_back(std::move(plugin));
+
+    value.tracks.push_back(std::move(track));
+    value.master = bareMaster();
+
+    const auto rendered = renderNative(value);
+
+    // It still renders. The stand-in is bound because the executor refuses an
+    // unbound Device op, and a leg that failed outright would report the case
+    // as a broken harness rather than as a project it could not measure.
+    REQUIRE(rendered.failure.empty());
+
+    REQUIRE_FALSE(rendered.diagnostics.empty());
+    const auto reported = rendered.diagnostics.front();
+    CHECK(reported.find("Something Nobody Has") != std::string::npos);
+}
+
+TEST_CASE("A plugin on the master chain is reported too", "[nulldiff][native]") {
+    // The two halves of this change meet here: a master device is looked up at
+    // all, and an external one that cannot be resolved says so. A master bus
+    // limiter is where a real project puts a plugin, and it is the case the old
+    // lookup would have dropped in silence.
+    DeviceInfo plugin;
+    plugin.id = 911;
+    plugin.name = "Master Bus Limiter";
+    plugin.deviceType = DeviceType::Effect;
+    plugin.format = PluginFormat::VST3;
+
+    const auto rendered = renderNative(throughMaster("external.master", std::move(plugin)));
+
+    REQUIRE(rendered.failure.empty());
+    REQUIRE_FALSE(rendered.diagnostics.empty());
+    CHECK(rendered.diagnostics.front().find("Master Bus Limiter") != std::string::npos);
 }

--- a/tests/engine/test_null_diff_native_leg.cpp
+++ b/tests/engine/test_null_diff_native_leg.cpp
@@ -394,6 +394,93 @@ TEST_CASE("A plugin the machine does not have is said out loud", "[nulldiff][nat
     CHECK(reported.find("Something Nobody Has") != std::string::npos);
 }
 
+TEST_CASE("A plugin inside a Drum Grid pad is reported", "[nulldiff][native]") {
+    // A pad is a chain of devices and PlanCompiler::emitPadRack() emits a Device
+    // op for each one in it, so a walk that stopped at the grid would leave every
+    // plugin in every pad looked up and not found: bound to a stand-in, never
+    // resolved, and reported as nothing. A drum kit built out of hosted plugins
+    // is a normal project, and it is the shape where the miss is invisible.
+    DeviceInfo grid;
+    grid.id = 920;
+    grid.name = "Drum Grid";
+    grid.deviceType = DeviceType::Instrument;
+    grid.isInstrument = true;
+    grid.canReceiveMidi = true;
+    grid.format = PluginFormat::Internal;
+    grid.pluginId = "magda_drum_grid";
+
+    auto rack = std::make_unique<RackInfo>();
+    rack->id = 1;
+
+    ChainInfo pad;
+    pad.id = 1;
+
+    DeviceInfo padPlugin;
+    padPlugin.id = 921;
+    padPlugin.name = "Kick Plugin Nobody Has";
+    padPlugin.deviceType = DeviceType::Instrument;
+    padPlugin.isInstrument = true;
+    padPlugin.format = PluginFormat::VST3;
+    pad.elements.emplace_back(std::move(padPlugin));
+
+    rack->chains.push_back(std::move(pad));
+    grid.pads.reset(std::move(rack));
+
+    TrackInfo track;
+    track.id = 1;
+    track.type = TrackType::Media;
+    track.name = "Drums";
+    track.audioOutputDevice = "master";
+    track.chain.fxChainElements.emplace_back(std::move(grid));
+
+    Case value;
+    value.name = "external.pad";
+    value.covers = "a plugin hosted inside a Drum Grid pad";
+    value.endBeat = 4.0;
+    value.tracks.push_back(std::move(track));
+    value.master = bareMaster();
+    value.clips.push_back(oneNoteClip(1, 1));
+
+    const auto rendered = renderNative(value);
+    REQUIRE(rendered.failure.empty());
+
+    REQUIRE_FALSE(rendered.diagnostics.empty());
+    const auto named = std::any_of(
+        rendered.diagnostics.begin(), rendered.diagnostics.end(), [](const std::string& reported) {
+            return reported.find("Kick Plugin Nobody Has") != std::string::npos;
+        });
+    CHECK(named);
+}
+
+TEST_CASE("A plugin the plan never reaches is not reported", "[nulldiff][native]") {
+    // A project does not go without a plugin it was never going to run. A
+    // bypassed device is not compiled, so no op names it and nothing is missing;
+    // reporting one would make a case unmeasurable over a plugin that would not
+    // have been heard either way.
+    //
+    // What holds that today is that the diagnostics are written while walking
+    // the plan's ops rather than the model's devices, and this exists to keep it
+    // that way: collecting devices from the model is what the pad case above
+    // asks for, and the obvious next step from there is to report from the same
+    // walk, which would fail here.
+    DeviceInfo plugin;
+    plugin.id = 930;
+    plugin.name = "Bypassed Plugin Nobody Has";
+    plugin.deviceType = DeviceType::Effect;
+    plugin.format = PluginFormat::VST3;
+    plugin.bypassed = true;
+
+    auto value = throughMaster("external.bypassed", std::move(plugin));
+
+    const auto rendered = renderNative(value);
+    REQUIRE(rendered.failure.empty());
+    CHECK(rendered.diagnostics.empty());
+
+    // And the render still happened, so this is not a case that reported
+    // nothing by doing nothing.
+    CHECK(peakOf(rendered.audio) > 0.0);
+}
+
 TEST_CASE("A plugin on the master chain is reported too", "[nulldiff][native]") {
     // The two halves of this change meet here: a master device is looked up at
     // all, and an external one that cannot be resolved says so. A master bus

--- a/tests/engine/test_real_project_corpus_juce.cpp
+++ b/tests/engine/test_real_project_corpus_juce.cpp
@@ -175,6 +175,15 @@ class RealProjectCorpusTests : public juce::UnitTest {
             // stretch cases went through and is a measurement rather than a
             // guess.
             //
+            // Its numbers moved when the master chain started rendering
+            // (#2175): this project carries a limiter there, and until then the
+            // corpus was comparing the incumbent's limited render against an
+            // unlimited native one. The envelopes correlate at 0.417 now where
+            // they correlated at 0.442 before, which is the comparison getting
+            // honest rather than worse -- and whoever calibrates the shift
+            // should expect to find two mechanisms in here rather than one, the
+            // stretch priming and whatever the two limiters do differently.
+            //
             // project.faust is the third, and it is skipped in this binary
             // rather than calibrated here; see the list above.
             "project.demo",


### PR DESCRIPTION
Part of #2175, and the step it opens with. Sits on top of the external plugin slices (#2241, #2243, #2244).

## What the leg was doing

`NullDiffNativeLeg` bound a Device op through `createEngineDevice()`, which asks the two internal catalogs. An external plugin is in neither, so a project hosting one rendered a passthrough where the incumbent rendered the plugin -- and said nothing about it, because the diagnostic beside that path only fires for a `pluginId` some catalog knows. "Nothing hosts VST3 in the engine" was true when #2175 was written and stopped being true with #2249; what was left was the leg asking.

## The wiring

The blocking entry point, which is the one written for a render with nothing to do until the plugin is there. The scan comes from the runner and is the shared engine's own `KnownPluginList`: both legs resolve against one list, because two legs that each found their own copy of a plugin would be rendering two projects and calling the difference an engine bug. On a machine with no scan there is nothing to find, which is the case every CI runner is in.

Two orderings that matter, and neither is incidental:

- **Resolution runs before the plan is compiled**, against a copy of the model. For an external plugin the effect/instrument role the plan compiles from is the project's guess rather than a fact -- an imported project carries whatever the exporting host said, which is the correction #2252 exists for -- and a plan compiled from the guess routes MIDI to the wrong places before any plugin is created.
- **`restoredParameters` is written back into that copy before `resolvePlanValues`.** The chunk wins over the project's saved array, and the parameter table is what the plan writes onto the device every block, so a model left holding the stale array would put it back on the first one.

## A plugin this machine does not have

Now reported rather than passed through. The runner already turns a diagnostic the case did not declare into unmeasurable, which is the treatment #2175 asks for and the same one a proxy that never arrived already gets. The render still completes and the stand-in is still bound, because the executor refuses an unbound Device op and a leg that failed outright would report a broken harness rather than a project it could not measure.

`resolveEngineExternalPlugin`'s no-scan failure now names the device. It was the one failure sentence in that file that did not, against `ExternalDeviceResult`'s own promise that a failure says which plugin and what went wrong, and a caller collecting these holds a project's worth of them.

## The master chain, which is a real bug

`devicesIn()` collected the tracks' devices and not the master's. Every Device op the compiler emits for the master chain was therefore looked up, not found, and bound to the stand-in -- silently, since the "no native device for" diagnostic sits behind a model the lookup did not have.

`project.demo` carries a limiter there. The corpus has been comparing the incumbent's limited render against an unlimited native one.

**Measured rather than assumed.** On `dev/0.20.0` the demo reports envelope correlation **0.442** and shift 5400; with this change, **0.417** and shift -3832. That number got slightly worse, and it is the comparison getting honest: the limiter now renders on both legs and the two evidently disagree. `project.fmchain` and `project.sidechain` are unchanged to the decimal (5.4/21.9 and 3.6/16.5 dB), which fits -- neither has a master device. The demo stays under calibration for its own declared reason, and its calibration note now says what moved and that its shift has two mechanisms behind it rather than one.

## Tests

Three in `test_null_diff_native_leg.cpp`, in the model-only target:

- A gain of zero on the master silences the render, with a unity control beside it so the assertion is about the master device rather than about a case that renders nothing either way. Bound it silences; as a stand-in it passes signal, which is the difference the old lookup could not tell.
- A project naming a plugin this machine cannot resolve renders, and names it in the diagnostics.
- The same for a plugin on the master chain, where the two halves of this change meet -- a master bus limiter is where a real project puts one.

Plus the no-scan failure naming its device, in `test_engine_external_device.cpp`.

## Verification

Full Catch2 suite passes (650,288 assertions) and the whole JUCE suite passes including the real-project corpus, with no case changing pass/fail state.

## Still open on #2175

The plugin-version field on `Case`'s environment block, and the corpus projects that carry real VST3 state.

https://claude.ai/code/session_01Qa7GxDU184RGxo2b1Yhpa6
