### PR TITLE
Route track outputs to hardware wave output devices (#2264)

### DIFF
--- a/magda/daw/audio/AudioBridge.cpp
+++ b/magda/daw/audio/AudioBridge.cpp
@@ -1435,6 +1435,18 @@ juce::BigInteger AudioBridge::getEnabledOutputChannels() const {
     return enabled;
 }
 
+std::map<int, juce::String> AudioBridge::getOutputDeviceNamesByChannel() const {
+    std::map<int, juce::String> result;
+    auto& dm = engine_.getDeviceManager();
+    for (auto* dev : dm.getWaveOutputDevices()) {
+        if (dev->isEnabled()) {
+            for (const auto& ch : dev->getChannels())
+                result[ch.indexInDevice] = dev->getName();
+        }
+    }
+    return result;
+}
+
 void AudioBridge::setTrackAudioOutput(TrackId trackId, const juce::String& destination) {
     trackController_.setTrackAudioOutput(trackId, destination);
 }

--- a/magda/daw/audio/AudioBridge.hpp
+++ b/magda/daw/audio/AudioBridge.hpp
@@ -695,6 +695,9 @@ class AudioBridge : public TrackManagerListener, public ClipManagerListener, pub
      */
     juce::BigInteger getEnabledOutputChannels() const;
 
+    /** Map from hardware channel index to TE WaveOutputDevice name (e.g. "Out 1 + 2"). */
+    std::map<int, juce::String> getOutputDeviceNamesByChannel() const;
+
     /**
      * @brief Set audio output destination for a track
      * @param trackId The MAGDA track ID

--- a/magda/daw/audio/TrackController.cpp
+++ b/magda/daw/audio/TrackController.cpp
@@ -289,8 +289,12 @@ void TrackController::setTrackAudioOutput(TrackId trackId, const juce::String& d
             track->getOutput().setOutputToDefaultDevice(false);
         }
     } else {
-        // Route to specific output device
-        track->getOutput().setOutputToDeviceID(destination);
+        // Route to specific output device. "stereo:" marks a pair selection in
+        // the UI; both forms resolve to the same TE wave output device.
+        auto resolvedName = destination.startsWith("stereo:")
+                                ? destination.fromFirstOccurrenceOf("stereo:", false, false)
+                                : destination;
+        track->getOutput().setOutputToDeviceID(resolvedName);
     }
 }
 

--- a/magda/daw/ui/components/mixer/RoutingSyncHelper.hpp
+++ b/magda/daw/ui/components/mixer/RoutingSyncHelper.hpp
@@ -139,9 +139,14 @@ inline void populateAudioInputOptions(RoutingSelector* selector, juce::AudioIODe
 inline void populateAudioOutputOptions(RoutingSelector* selector, TrackId currentTrackId,
                                        juce::AudioIODevice* device,
                                        std::map<int, TrackId>& outTrackMapping,
-                                       juce::BigInteger enabledOutputChannels = {}) {
+                                       juce::BigInteger enabledOutputChannels = {},
+                                       std::map<int, juce::String>* outChannelMapping = nullptr,
+                                       const std::map<int, juce::String>& teDeviceNames = {}) {
     if (!selector)
         return;
+
+    if (outChannelMapping)
+        outChannelMapping->clear();
 
     std::vector<RoutingSelector::RoutingOption> options;
     options.push_back({1, technicalText(TechnicalTextToken::Master)});
@@ -237,13 +242,25 @@ inline void populateAudioOutputOptions(RoutingSelector* selector, TrackId curren
                 }
             }
 
+            // Helper: get the TE device name for a channel index, fall back to "Out N"
+            auto getDeviceName = [&](int channelIndex) -> juce::String {
+                auto it = teDeviceNames.find(channelIndex);
+                if (it != teDeviceNames.end())
+                    return it->second;
+                return "Out " + juce::String(channelIndex + 1);
+            };
+
             int id = 10;
             for (int i = 0; i < activeIndices.size(); i += 2) {
                 if (i + 1 < activeIndices.size()) {
                     int ch1 = activeIndices[i] + 1;
                     int ch2 = activeIndices[i + 1] + 1;
                     juce::String pairName = juce::String(ch1) + "-" + juce::String(ch2);
-                    options.push_back({id++, pairName});
+                    options.push_back({id, pairName});
+                    // Use actual TE device name for routing
+                    if (outChannelMapping)
+                        (*outChannelMapping)[id] = "stereo:" + getDeviceName(activeIndices[i]);
+                    ++id;
                 }
             }
 
@@ -254,7 +271,10 @@ inline void populateAudioOutputOptions(RoutingSelector* selector, TrackId curren
             id = 100;
             for (int i = 0; i < activeIndices.size(); ++i) {
                 int channelNum = activeIndices[i] + 1;
-                options.push_back({id++, juce::String(channelNum) + " (mono)"});
+                options.push_back({id, juce::String(channelNum) + " (mono)"});
+                if (outChannelMapping)
+                    (*outChannelMapping)[id] = getDeviceName(activeIndices[i]);
+                ++id;
             }
         }
     }
@@ -403,7 +423,9 @@ inline void syncSelectorsFromTrack(
     juce::BigInteger enabledOutputChannels = {},
     std::map<int, juce::String>* inputChannelMapping = nullptr,
     const std::map<int, juce::String>& teDeviceNames = {},
-    std::map<int, TrackId>* midiInputTrackMapping = nullptr) {
+    std::map<int, TrackId>* midiInputTrackMapping = nullptr,
+    std::map<int, juce::String>* outputChannelMapping = nullptr,
+    const std::map<int, juce::String>& teOutputDeviceNames = {}) {
     bool hasAudioInput = !track.audioInputDevice.isEmpty();
     bool hasMidiInput = !track.midiInputDevice.isEmpty();
 
@@ -494,7 +516,8 @@ inline void syncSelectorsFromTrack(
     // Update Audio Output selector
     if (audioOutSelector) {
         populateAudioOutputOptions(audioOutSelector, currentTrackId, device, outputTrackMapping,
-                                   enabledOutputChannels);
+                                   enabledOutputChannels, outputChannelMapping,
+                                   teOutputDeviceNames);
         juce::String currentAudioOutput = track.audioOutputDevice;
         if (currentAudioOutput.isEmpty()) {
             audioOutSelector->setSelectedId(2);  // "None"
@@ -517,6 +540,20 @@ inline void syncSelectorsFromTrack(
             }
             audioOutSelector->setEnabled(true);
         } else {
+            // Hardware output device — find the option whose mapped device
+            // string matches so the dropdown doesn't snap back to Master
+            if (outputChannelMapping) {
+                int optionId = -1;
+                for (const auto& [oid, name] : *outputChannelMapping) {
+                    if (name == currentAudioOutput) {
+                        optionId = oid;
+                        break;
+                    }
+                }
+                if (optionId > 0) {
+                    audioOutSelector->setSelectedId(optionId);
+                }
+            }
             audioOutSelector->setEnabled(true);
         }
     }

--- a/magda/daw/ui/components/mixer/RoutingSyncHelper.hpp
+++ b/magda/daw/ui/components/mixer/RoutingSyncHelper.hpp
@@ -233,8 +233,6 @@ inline void populateAudioOutputOptions(RoutingSelector* selector, TrackId curren
         int numActiveChannels = activeOutputChannels.countNumberOfSetBits();
 
         if (numActiveChannels > 0) {
-            options.push_back({0, "", true});
-
             juce::Array<int> activeIndices;
             for (int i = 0; i < activeOutputChannels.getHighestBit() + 1; ++i) {
                 if (activeOutputChannels[i]) {
@@ -242,38 +240,69 @@ inline void populateAudioOutputOptions(RoutingSelector* selector, TrackId curren
                 }
             }
 
-            // Helper: get the TE device name for a channel index, fall back to "Out N"
-            auto getDeviceName = [&](int channelIndex) -> juce::String {
-                auto it = teDeviceNames.find(channelIndex);
-                if (it != teDeviceNames.end())
-                    return it->second;
-                return "Out " + juce::String(channelIndex + 1);
+            // Group channels into the wave devices they belong to: consecutive
+            // active channels sharing a TE device name form one device (a
+            // stereo pair or a mono channel). Only whole devices are offered —
+            // TE routes a track output to a device, not to a channel inside
+            // one, so a "mono" option only exists where a mono device does.
+            struct DeviceGroup {
+                juce::String name;
+                juce::Array<int> channels;
             };
-
-            int id = 10;
-            for (int i = 0; i < activeIndices.size(); i += 2) {
-                if (i + 1 < activeIndices.size()) {
-                    int ch1 = activeIndices[i] + 1;
-                    int ch2 = activeIndices[i + 1] + 1;
-                    juce::String pairName = juce::String(ch1) + "-" + juce::String(ch2);
-                    options.push_back({id, pairName});
-                    // Use actual TE device name for routing
-                    if (outChannelMapping)
-                        (*outChannelMapping)[id] = "stereo:" + getDeviceName(activeIndices[i]);
-                    ++id;
+            std::vector<DeviceGroup> groups;
+            if (!teDeviceNames.empty()) {
+                for (int idx : activeIndices) {
+                    auto it = teDeviceNames.find(idx);
+                    juce::String name =
+                        it != teDeviceNames.end() ? it->second : "Out " + juce::String(idx + 1);
+                    if (!groups.empty() && groups.back().name == name &&
+                        groups.back().channels.size() < 2)
+                        groups.back().channels.add(idx);
+                    else
+                        groups.push_back({name, {idx}});
+                }
+            } else {
+                // No TE device names available: assume the default stereo pairing
+                for (int i = 0; i < activeIndices.size(); ++i) {
+                    juce::String name = "Out " + juce::String(activeIndices[i] + 1);
+                    if (i + 1 < activeIndices.size()) {
+                        groups.push_back({name, {activeIndices[i], activeIndices[i + 1]}});
+                        ++i;
+                    } else {
+                        groups.push_back({name, {activeIndices[i]}});
+                    }
                 }
             }
 
-            if (activeIndices.size() > 1) {
+            options.push_back({0, "", true});
+
+            int stereoCount = 0, monoCount = 0;
+            for (const auto& g : groups)
+                (g.channels.size() == 2 ? stereoCount : monoCount)++;
+
+            int id = 10;
+            for (const auto& g : groups) {
+                if (g.channels.size() != 2)
+                    continue;
+                juce::String pairName =
+                    juce::String(g.channels[0] + 1) + "-" + juce::String(g.channels[1] + 1);
+                options.push_back({id, pairName});
+                if (outChannelMapping)
+                    (*outChannelMapping)[id] = "stereo:" + g.name;
+                ++id;
+            }
+
+            if (stereoCount > 0 && monoCount > 0) {
                 options.push_back({0, "", true});
             }
 
             id = 100;
-            for (int i = 0; i < activeIndices.size(); ++i) {
-                int channelNum = activeIndices[i] + 1;
-                options.push_back({id, juce::String(channelNum) + " (mono)"});
+            for (const auto& g : groups) {
+                if (g.channels.size() != 1)
+                    continue;
+                options.push_back({id, juce::String(g.channels[0] + 1) + " (mono)"});
                 if (outChannelMapping)
-                    (*outChannelMapping)[id] = getDeviceName(activeIndices[i]);
+                    (*outChannelMapping)[id] = g.name;
                 ++id;
             }
         }

--- a/magda/daw/ui/components/tracks/TrackHeadersPanel.cpp
+++ b/magda/daw/ui/components/tracks/TrackHeadersPanel.cpp
@@ -642,11 +642,14 @@ void TrackHeadersPanel::populateAudioOutputOptions(RoutingSelector* selector,
     if (!deviceManager)
         return;
     juce::BigInteger enabledOutputChannels;
-    if (auto* bridge = audioEngine_->getAudioBridge())
+    std::map<int, juce::String> teOutputDeviceNames;
+    if (auto* bridge = audioEngine_->getAudioBridge()) {
         enabledOutputChannels = bridge->getEnabledOutputChannels();
-    RoutingSyncHelper::populateAudioOutputOptions(selector, currentTrackId,
-                                                  deviceManager->getCurrentAudioDevice(),
-                                                  outputTrackMapping_, enabledOutputChannels);
+        teOutputDeviceNames = bridge->getOutputDeviceNamesByChannel();
+    }
+    RoutingSyncHelper::populateAudioOutputOptions(
+        selector, currentTrackId, deviceManager->getCurrentAudioDevice(), outputTrackMapping_,
+        enabledOutputChannels, &outputChannelMapping_, teOutputDeviceNames);
 }
 
 void TrackHeadersPanel::populateMidiInputOptions(RoutingSelector* selector, TrackId trackId) {
@@ -819,8 +822,9 @@ void TrackHeadersPanel::setupRoutingCallbacks(TrackHeader& header, TrackId track
 
     // Capture outputTrackMapping_ by value so each header has its own snapshot
     // (the shared member is rebuilt per-header in populateAudioOutputOptions)
-    header.outputSelector->onSelectionChanged = [trackId,
-                                                 mapping = outputTrackMapping_](int selectedId) {
+    header.outputSelector->onSelectionChanged = [trackId, mapping = outputTrackMapping_,
+                                                 channelMapping =
+                                                     outputChannelMapping_](int selectedId) {
         if (selectedId == 1) {
             // Master
             TrackManager::getInstance().setTrackAudioOutput(trackId, "master");
@@ -835,9 +839,10 @@ void TrackHeadersPanel::setupRoutingCallbacks(TrackHeader& header, TrackId track
                     trackId, "track:" + juce::String(it->second));
             }
         } else if (selectedId >= 10) {
-            // Hardware output device (existing behavior — use device ID)
-            // For now, hardware channels route via device ID
-            TrackManager::getInstance().setTrackAudioOutput(trackId, "master");
+            // Hardware output — route to the mapped wave output device
+            auto it = channelMapping.find(selectedId);
+            TrackManager::getInstance().setTrackAudioOutput(
+                trackId, it != channelMapping.end() ? it->second : "master");
         }
     };
 
@@ -1160,17 +1165,19 @@ void TrackHeadersPanel::updateRoutingSelectorFromTrack(TrackHeader& header,
     auto* deviceManager = audioEngine_->getDeviceManager();
     auto* device = deviceManager ? deviceManager->getCurrentAudioDevice() : nullptr;
     juce::BigInteger enabledIn, enabledOut;
-    std::map<int, juce::String> teInputDeviceNames;
+    std::map<int, juce::String> teInputDeviceNames, teOutputDeviceNames;
     if (auto* bridge = audioEngine_->getAudioBridge()) {
         enabledIn = bridge->getEnabledInputChannels();
         enabledOut = bridge->getEnabledOutputChannels();
         teInputDeviceNames = bridge->getInputDeviceNamesByChannel();
+        teOutputDeviceNames = bridge->getOutputDeviceNamesByChannel();
     }
     RoutingSyncHelper::syncSelectorsFromTrack(
         *track, header.audioInputSelector.get(), header.inputSelector.get(),
         header.outputSelector.get(), header.midiOutputSelector.get(), audioEngine_->getMidiBridge(),
         device, header.trackId, outputTrackMapping_, midiOutputTrackMapping_, &inputTrackMapping_,
-        enabledIn, enabledOut, &inputChannelMapping_, teInputDeviceNames, &midiInputTrackMapping_);
+        enabledIn, enabledOut, &inputChannelMapping_, teInputDeviceNames, &midiInputTrackMapping_,
+        &outputChannelMapping_, teOutputDeviceNames);
 }
 
 void TrackHeadersPanel::paint(juce::Graphics& g) {

--- a/magda/daw/ui/components/tracks/TrackHeadersPanel.cpp
+++ b/magda/daw/ui/components/tracks/TrackHeadersPanel.cpp
@@ -822,9 +822,8 @@ void TrackHeadersPanel::setupRoutingCallbacks(TrackHeader& header, TrackId track
 
     // Capture outputTrackMapping_ by value so each header has its own snapshot
     // (the shared member is rebuilt per-header in populateAudioOutputOptions)
-    header.outputSelector->onSelectionChanged = [trackId, mapping = outputTrackMapping_,
-                                                 channelMapping =
-                                                     outputChannelMapping_](int selectedId) {
+    header.outputSelector->onSelectionChanged = [this, trackId,
+                                                 mapping = outputTrackMapping_](int selectedId) {
         if (selectedId == 1) {
             // Master
             TrackManager::getInstance().setTrackAudioOutput(trackId, "master");
@@ -839,10 +838,14 @@ void TrackHeadersPanel::setupRoutingCallbacks(TrackHeader& header, TrackId track
                     trackId, "track:" + juce::String(it->second));
             }
         } else if (selectedId >= 10) {
-            // Hardware output — route to the mapped wave output device
-            auto it = channelMapping.find(selectedId);
-            TrackManager::getInstance().setTrackAudioOutput(
-                trackId, it != channelMapping.end() ? it->second : "master");
+            // Hardware output — route to the mapped wave output device. Read
+            // the shared member (rebuilt whenever options are, and identical
+            // for every header) and copy the string — setTrackAudioOutput can
+            // trigger a re-population that invalidates the iterator.
+            auto it = outputChannelMapping_.find(selectedId);
+            juce::String dest =
+                it != outputChannelMapping_.end() ? it->second : juce::String("master");
+            TrackManager::getInstance().setTrackAudioOutput(trackId, dest);
         }
     };
 

--- a/magda/daw/ui/components/tracks/TrackHeadersPanel.hpp
+++ b/magda/daw/ui/components/tracks/TrackHeadersPanel.hpp
@@ -317,6 +317,7 @@ class TrackHeadersPanel : public juce::Component,
     std::map<int, TrackId> inputTrackMapping_;
     std::map<int, TrackId> midiInputTrackMapping_;
     std::map<int, juce::String> inputChannelMapping_;
+    std::map<int, juce::String> outputChannelMapping_;
 
     // Flip name-label text colour on the near-white selected fill
     void updateHeaderSelectionColours();

--- a/magda/daw/ui/panels/content/inspector/TrackInspector.cpp
+++ b/magda/daw/ui/panels/content/inspector/TrackInspector.cpp
@@ -1783,8 +1783,13 @@ void TrackInspector::populateRoutingSelectors() {
                     selectedTrackId_, "track:" + juce::String(it->second));
             }
         } else if (selectedId >= 10) {
-            // Hardware output
-            magda::TrackManager::getInstance().setTrackAudioOutput(selectedTrackId_, "master");
+            // Hardware output — route to the mapped wave output device.
+            // Copy the string — the map can be repopulated during setTrackAudioOutput
+            // (via notifyTrackPropertyChanged → updateRoutingSelectorsFromTrack)
+            auto it = outputChannelMapping_.find(selectedId);
+            juce::String dest =
+                it != outputChannelMapping_.end() ? it->second : juce::String("master");
+            magda::TrackManager::getInstance().setTrackAudioOutput(selectedTrackId_, dest);
         }
     };
 
@@ -1847,11 +1852,14 @@ void TrackInspector::populateAudioOutputOptions() {
     if (!deviceManager)
         return;
     juce::BigInteger enabledOutputChannels;
-    if (auto* bridge = audioEngine_->getAudioBridge())
+    std::map<int, juce::String> teOutputDeviceNames;
+    if (auto* bridge = audioEngine_->getAudioBridge()) {
         enabledOutputChannels = bridge->getEnabledOutputChannels();
+        teOutputDeviceNames = bridge->getOutputDeviceNamesByChannel();
+    }
     magda::RoutingSyncHelper::populateAudioOutputOptions(
         outputSelector_.get(), selectedTrackId_, deviceManager->getCurrentAudioDevice(),
-        outputTrackMapping_, enabledOutputChannels);
+        outputTrackMapping_, enabledOutputChannels, &outputChannelMapping_, teOutputDeviceNames);
 }
 
 void TrackInspector::populateMidiInputOptions() {
@@ -1884,17 +1892,19 @@ void TrackInspector::updateRoutingSelectorsFromTrack() {
     auto* deviceManager = audioEngine_->getDeviceManager();
     auto* device = deviceManager ? deviceManager->getCurrentAudioDevice() : nullptr;
     juce::BigInteger enabledIn, enabledOut;
-    std::map<int, juce::String> teInputDeviceNames;
+    std::map<int, juce::String> teInputDeviceNames, teOutputDeviceNames;
     if (auto* bridge = audioEngine_->getAudioBridge()) {
         enabledIn = bridge->getEnabledInputChannels();
         enabledOut = bridge->getEnabledOutputChannels();
         teInputDeviceNames = bridge->getInputDeviceNamesByChannel();
+        teOutputDeviceNames = bridge->getOutputDeviceNamesByChannel();
     }
     magda::RoutingSyncHelper::syncSelectorsFromTrack(
         *track, audioInputSelector_.get(), inputSelector_.get(), outputSelector_.get(),
         midiOutputSelector_.get(), audioEngine_->getMidiBridge(), device, selectedTrackId_,
         outputTrackMapping_, midiOutputTrackMapping_, &inputTrackMapping_, enabledIn, enabledOut,
-        &inputChannelMapping_, teInputDeviceNames, &midiInputTrackMapping_);
+        &inputChannelMapping_, teInputDeviceNames, &midiInputTrackMapping_, &outputChannelMapping_,
+        teOutputDeviceNames);
 }
 
 }  // namespace magda::daw::ui

--- a/magda/daw/ui/panels/content/inspector/TrackInspector.hpp
+++ b/magda/daw/ui/panels/content/inspector/TrackInspector.hpp
@@ -168,6 +168,7 @@ class TrackInspector : public BaseInspector,
     std::map<int, magda::TrackId> inputTrackMapping_;
     std::map<int, magda::TrackId> midiInputTrackMapping_;
     std::map<int, juce::String> inputChannelMapping_;
+    std::map<int, juce::String> outputChannelMapping_;
 
     // MIDI device change detection
     size_t lastMidiInputCount_ = 0;

--- a/magda/daw/ui/views/MixerView.cpp
+++ b/magda/daw/ui/views/MixerView.cpp
@@ -387,17 +387,19 @@ void MixerView::ChannelStrip::updateFromTrack(const TrackInfo& track, bool syncM
             auto* device = deviceManager ? deviceManager->getCurrentAudioDevice() : nullptr;
             auto* midiBridge = audioEngine_->getMidiBridge();
             juce::BigInteger enabledIn, enabledOut;
-            std::map<int, juce::String> teInputDeviceNames;
+            std::map<int, juce::String> teInputDeviceNames, teOutputDeviceNames;
             if (auto* bridge = audioEngine_->getAudioBridge()) {
                 enabledIn = bridge->getEnabledInputChannels();
                 enabledOut = bridge->getEnabledOutputChannels();
                 teInputDeviceNames = bridge->getInputDeviceNamesByChannel();
+                teOutputDeviceNames = bridge->getOutputDeviceNamesByChannel();
             }
             RoutingSyncHelper::syncSelectorsFromTrack(
                 track, audioInSelector.get(), midiInSelector.get(), audioOutSelector.get(),
                 midiOutSelector.get(), midiBridge, device, trackId_, outputTrackMapping_,
                 midiOutputTrackMapping_, &inputTrackMapping_, enabledIn, enabledOut, nullptr,
-                teInputDeviceNames, &midiInputTrackMapping_);
+                teInputDeviceNames, &midiInputTrackMapping_, &outputChannelMapping_,
+                teOutputDeviceNames);
         }
     }
 
@@ -773,19 +775,20 @@ void MixerView::ChannelStrip::setupControls() {
             auto* midiBridge = audioEngine_->getMidiBridge();
 
             juce::BigInteger enabledInputChannels, enabledOutputChannels;
-            std::map<int, juce::String> teInputDeviceNames;
+            std::map<int, juce::String> teInputDeviceNames, teOutputDeviceNames;
             if (auto* bridge = audioEngine_->getAudioBridge()) {
                 enabledInputChannels = bridge->getEnabledInputChannels();
                 enabledOutputChannels = bridge->getEnabledOutputChannels();
                 teInputDeviceNames = bridge->getInputDeviceNamesByChannel();
+                teOutputDeviceNames = bridge->getOutputDeviceNamesByChannel();
             }
 
             RoutingSyncHelper::populateAudioInputOptions(audioInSelector.get(), device, trackId_,
                                                          &inputTrackMapping_, enabledInputChannels,
                                                          nullptr, teInputDeviceNames);
-            RoutingSyncHelper::populateAudioOutputOptions(audioOutSelector.get(), trackId_, device,
-                                                          outputTrackMapping_,
-                                                          enabledOutputChannels);
+            RoutingSyncHelper::populateAudioOutputOptions(
+                audioOutSelector.get(), trackId_, device, outputTrackMapping_,
+                enabledOutputChannels, &outputChannelMapping_, teOutputDeviceNames);
             RoutingSyncHelper::populateMidiInputOptions(midiInSelector.get(), midiBridge, trackId_,
                                                         &midiInputTrackMapping_);
             RoutingSyncHelper::populateMidiOutputOptions(midiOutSelector.get(), midiBridge,
@@ -916,7 +919,12 @@ void MixerView::ChannelStrip::setupRoutingCallbacks() {
                     trackId_, "track:" + juce::String(it->second));
             }
         } else if (selectedId >= 10) {
-            TrackManager::getInstance().setTrackAudioOutput(trackId_, "master");
+            // Copy the string — the map can be repopulated during
+            // setTrackAudioOutput (change notification re-syncs selectors)
+            auto it = outputChannelMapping_.find(selectedId);
+            juce::String dest =
+                it != outputChannelMapping_.end() ? it->second : juce::String("master");
+            TrackManager::getInstance().setTrackAudioOutput(trackId_, dest);
         }
     };
 

--- a/magda/daw/ui/views/MixerView.hpp
+++ b/magda/daw/ui/views/MixerView.hpp
@@ -275,6 +275,7 @@ class MixerView : public juce::Component,
         // Routing option-to-track mappings (rebuilt when options are populated)
         std::map<int, TrackId> outputTrackMapping_;
         std::map<int, TrackId> midiOutputTrackMapping_;
+        std::map<int, juce::String> outputChannelMapping_;
         std::map<int, TrackId> inputTrackMapping_;
         std::map<int, TrackId> midiInputTrackMapping_;
 

--- a/magda/daw/ui/views/SessionView.cpp
+++ b/magda/daw/ui/views/SessionView.cpp
@@ -931,18 +931,20 @@ class SessionView::MiniIOStrip : public juce::Component {
         auto* midiBridge = audioEngine_ ? audioEngine_->getMidiBridge() : nullptr;
 
         juce::BigInteger enabledInputChannels, enabledOutputChannels;
-        std::map<int, juce::String> teInputDeviceNames;
+        std::map<int, juce::String> teInputDeviceNames, teOutputDeviceNames;
         if (auto* bridge = audioEngine_->getAudioBridge()) {
             enabledInputChannels = bridge->getEnabledInputChannels();
             enabledOutputChannels = bridge->getEnabledOutputChannels();
             teInputDeviceNames = bridge->getInputDeviceNamesByChannel();
+            teOutputDeviceNames = bridge->getOutputDeviceNamesByChannel();
         }
 
         RoutingSyncHelper::syncSelectorsFromTrack(
             *track, audioInSelector_.get(), midiInSelector_.get(), audioOutSelector_.get(),
             midiOutSelector_.get(), midiBridge, device, trackId_, outputTrackMapping_,
             midiOutputTrackMapping_, &inputTrackMapping_, enabledInputChannels,
-            enabledOutputChannels, nullptr, teInputDeviceNames, &midiInputTrackMapping_);
+            enabledOutputChannels, nullptr, teInputDeviceNames, &midiInputTrackMapping_,
+            &outputChannelMapping_, teOutputDeviceNames);
     }
 
     TrackId getTrackId() const {
@@ -960,6 +962,7 @@ class SessionView::MiniIOStrip : public juce::Component {
     std::map<int, TrackId> midiInputTrackMapping_;
     std::map<int, TrackId> outputTrackMapping_;
     std::map<int, TrackId> midiOutputTrackMapping_;
+    std::map<int, juce::String> outputChannelMapping_;
 
     void populateOptions() {
         if (!audioEngine_)
@@ -970,18 +973,20 @@ class SessionView::MiniIOStrip : public juce::Component {
         auto* midiBridge = audioEngine_->getMidiBridge();
 
         juce::BigInteger enabledInputChannels, enabledOutputChannels;
-        std::map<int, juce::String> teInputDeviceNames;
+        std::map<int, juce::String> teInputDeviceNames, teOutputDeviceNames;
         if (auto* bridge = audioEngine_->getAudioBridge()) {
             enabledInputChannels = bridge->getEnabledInputChannels();
             enabledOutputChannels = bridge->getEnabledOutputChannels();
             teInputDeviceNames = bridge->getInputDeviceNamesByChannel();
+            teOutputDeviceNames = bridge->getOutputDeviceNamesByChannel();
         }
 
         RoutingSyncHelper::populateAudioInputOptions(audioInSelector_.get(), device, trackId_,
                                                      &inputTrackMapping_, enabledInputChannels,
                                                      nullptr, teInputDeviceNames);
         RoutingSyncHelper::populateAudioOutputOptions(audioOutSelector_.get(), trackId_, device,
-                                                      outputTrackMapping_, enabledOutputChannels);
+                                                      outputTrackMapping_, enabledOutputChannels,
+                                                      &outputChannelMapping_, teOutputDeviceNames);
         RoutingSyncHelper::populateMidiInputOptions(midiInSelector_.get(), midiBridge, trackId_,
                                                     &midiInputTrackMapping_);
         RoutingSyncHelper::populateMidiOutputOptions(midiOutSelector_.get(), midiBridge,
@@ -1091,7 +1096,12 @@ class SessionView::MiniIOStrip : public juce::Component {
                     TrackManager::getInstance().setTrackAudioOutput(
                         trackId_, "track:" + juce::String(it->second));
             } else if (selectedId >= 10) {
-                TrackManager::getInstance().setTrackAudioOutput(trackId_, "master");
+                // Copy the string — the map can be repopulated during
+                // setTrackAudioOutput (change notification re-syncs selectors)
+                auto it = outputChannelMapping_.find(selectedId);
+                juce::String dest =
+                    it != outputChannelMapping_.end() ? it->second : juce::String("master");
+                TrackManager::getInstance().setTrackAudioOutput(trackId_, dest);
             }
         };
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -569,6 +569,9 @@ target_sources(magda_juce_tests PRIVATE
     ui/test_transport_seek_juce.cpp
     midi/test_session_slot_recording_juce.cpp
     routing/test_input_monitor_track_routing_juce.cpp
+    # Hardware output selections must reach the TE wave output devices (#2264)
+    routing/test_hardware_output_routing_juce.cpp
+    ../magda/daw/ui/components/mixer/RoutingSelector.cpp
     controllers/test_controller_track_level_write_juce.cpp
     # OSC control surfaces (issue #1757): a live receive thread and real packets
     controllers/test_osc_service_juce.cpp

--- a/tests/routing/test_hardware_output_routing_juce.cpp
+++ b/tests/routing/test_hardware_output_routing_juce.cpp
@@ -105,44 +105,60 @@ class HardwareOutputRoutingTest final : public juce::UnitTest {
     void testOptionToDeviceMapping() {
         beginTest("populateAudioOutputOptions maps option IDs to wave output devices");
 
-        StubAudioIODevice device(4);
+        StubAudioIODevice device(5);
         RoutingSelector selector(RoutingSelector::Type::AudioOut);
         std::map<int, TrackId> trackMapping;
         std::map<int, juce::String> channelMapping;
         juce::BigInteger enabled;
-        enabled.setRange(0, 4, true);
+        enabled.setRange(0, 5, true);
+        // Two stereo-pair devices plus a trailing mono device
         const std::map<int, juce::String> teNames = {
-            {0, "Out 1 + 2"}, {1, "Out 1 + 2"}, {2, "Out 3 + 4"}, {3, "Out 3 + 4"}};
+            {0, "Out 1 + 2"}, {1, "Out 1 + 2"}, {2, "Out 3 + 4"}, {3, "Out 3 + 4"}, {4, "Out 5"}};
 
         RoutingSyncHelper::populateAudioOutputOptions(
             &selector, INVALID_TRACK_ID, &device, trackMapping, enabled, &channelMapping, teNames);
 
-        // Stereo pairs (ID 10+) carry the pair marker; monos (ID 100+) the bare name
+        // Stereo pairs (ID 10+) carry the pair marker; the mono device (ID
+        // 100+) the bare name. Channels inside a pair get no mono option — TE
+        // routes a track output to a whole wave device only.
         expectEquals(channelMapping[10], juce::String("stereo:Out 1 + 2"));
         expectEquals(channelMapping[11], juce::String("stereo:Out 3 + 4"));
-        expectEquals(channelMapping[100], juce::String("Out 1 + 2"));
-        expectEquals(channelMapping[102], juce::String("Out 3 + 4"));
+        expectEquals(channelMapping[100], juce::String("Out 5"));
+        expectEquals(static_cast<int>(channelMapping.size()), 3);
 
-        // Without TE device names the mapping falls back to positional names
+        // Distinct mono devices must stay distinguishable in the model
+        std::map<int, juce::String> monoMapping;
+        juce::BigInteger twoChannels;
+        twoChannels.setRange(0, 2, true);
+        const std::map<int, juce::String> monoNames = {{0, "Main L"}, {1, "Main R"}};
+        RoutingSyncHelper::populateAudioOutputOptions(&selector, INVALID_TRACK_ID, &device,
+                                                      trackMapping, twoChannels, &monoMapping,
+                                                      monoNames);
+        expectEquals(monoMapping[100], juce::String("Main L"));
+        expectEquals(monoMapping[101], juce::String("Main R"));
+        expectEquals(static_cast<int>(monoMapping.size()), 2);
+
+        // Without TE device names the mapping falls back to positional pairing
         std::map<int, juce::String> fallbackMapping;
         RoutingSyncHelper::populateAudioOutputOptions(&selector, INVALID_TRACK_ID, &device,
                                                       trackMapping, enabled, &fallbackMapping);
         expectEquals(fallbackMapping[10], juce::String("stereo:Out 1"));
-        expectEquals(fallbackMapping[101], juce::String("Out 2"));
+        expectEquals(fallbackMapping[11], juce::String("stereo:Out 3"));
+        expectEquals(fallbackMapping[100], juce::String("Out 5"));
     }
 
     void testSelectorRoundTrip() {
         beginTest("syncSelectorsFromTrack re-selects a stored hardware destination");
 
-        StubAudioIODevice device(4);
+        StubAudioIODevice device(5);
         RoutingSelector selector(RoutingSelector::Type::AudioOut);
         std::map<int, TrackId> outputTrackMapping;
         std::map<int, TrackId> midiOutputTrackMapping;
         std::map<int, juce::String> channelMapping;
         juce::BigInteger enabled;
-        enabled.setRange(0, 4, true);
+        enabled.setRange(0, 5, true);
         const std::map<int, juce::String> teNames = {
-            {0, "Out 1 + 2"}, {1, "Out 1 + 2"}, {2, "Out 3 + 4"}, {3, "Out 3 + 4"}};
+            {0, "Out 1 + 2"}, {1, "Out 1 + 2"}, {2, "Out 3 + 4"}, {3, "Out 3 + 4"}, {4, "Out 5"}};
 
         TrackInfo track;
         track.audioOutputDevice = "stereo:Out 3 + 4";
@@ -155,7 +171,7 @@ class HardwareOutputRoutingTest final : public juce::UnitTest {
         // The dropdown must land on the second stereo pair, not snap back to Master
         expectEquals(selector.getSelectedId(), 11);
 
-        track.audioOutputDevice = "Out 1 + 2";  // mono/bare device selection
+        track.audioOutputDevice = "Out 5";  // mono device selection
         RoutingSyncHelper::syncSelectorsFromTrack(
             track, nullptr, nullptr, &selector, nullptr, nullptr, &device, INVALID_TRACK_ID,
             outputTrackMapping, midiOutputTrackMapping, nullptr, {}, enabled, nullptr, {}, nullptr,

--- a/tests/routing/test_hardware_output_routing_juce.cpp
+++ b/tests/routing/test_hardware_output_routing_juce.cpp
@@ -1,0 +1,196 @@
+// Regression tests for #2264: every hardware output selection in the track
+// output dropdowns routed straight back to master because the UI had no
+// option-ID -> wave-output-device mapping. These cover the three pieces of the
+// fix: populateAudioOutputOptions emitting the mapping, syncSelectorsFromTrack
+// re-selecting a stored hardware destination (no snap-back to Master), and
+// TrackController resolving the "stereo:" pair marker to the TE device.
+
+#include <juce_audio_devices/juce_audio_devices.h>
+#include <juce_core/juce_core.h>
+
+#include "JuceTestStateGuard.hpp"
+#include "SharedTestEngine.hpp"
+#include "magda/daw/audio/AudioBridge.hpp"
+#include "magda/daw/core/TrackManager.hpp"
+#include "magda/daw/engine/TracktionEngineWrapper.hpp"
+#include "magda/daw/ui/components/mixer/RoutingSyncHelper.hpp"
+
+using namespace magda;
+
+namespace {
+
+// Minimal stand-in so populateAudioOutputOptions sees "a device is active";
+// channel layout comes from the enabledOutputChannels mask the tests pass.
+class StubAudioIODevice final : public juce::AudioIODevice {
+  public:
+    explicit StubAudioIODevice(int numOutputs)
+        : juce::AudioIODevice("Stub Device", "Stub"), numOutputs_(numOutputs) {}
+
+    juce::StringArray getOutputChannelNames() override {
+        juce::StringArray names;
+        for (int i = 0; i < numOutputs_; ++i)
+            names.add("Out " + juce::String(i + 1));
+        return names;
+    }
+    juce::StringArray getInputChannelNames() override {
+        return {};
+    }
+    juce::Array<double> getAvailableSampleRates() override {
+        return {44100.0};
+    }
+    juce::Array<int> getAvailableBufferSizes() override {
+        return {512};
+    }
+    int getDefaultBufferSize() override {
+        return 512;
+    }
+    juce::String open(const juce::BigInteger&, const juce::BigInteger&, double, int) override {
+        return {};
+    }
+    void close() override {}
+    bool isOpen() override {
+        return false;
+    }
+    void start(juce::AudioIODeviceCallback*) override {}
+    void stop() override {}
+    bool isPlaying() override {
+        return false;
+    }
+    juce::String getLastError() override {
+        return {};
+    }
+    int getCurrentBufferSizeSamples() override {
+        return 512;
+    }
+    double getCurrentSampleRate() override {
+        return 44100.0;
+    }
+    int getCurrentBitDepth() override {
+        return 24;
+    }
+    juce::BigInteger getActiveOutputChannels() const override {
+        juce::BigInteger b;
+        b.setRange(0, numOutputs_, true);
+        return b;
+    }
+    juce::BigInteger getActiveInputChannels() const override {
+        return {};
+    }
+    int getOutputLatencyInSamples() override {
+        return 0;
+    }
+    int getInputLatencyInSamples() override {
+        return 0;
+    }
+
+  private:
+    int numOutputs_;
+};
+
+}  // namespace
+
+class HardwareOutputRoutingTest final : public juce::UnitTest {
+  public:
+    HardwareOutputRoutingTest() : juce::UnitTest("Hardware Output Routing Tests", "magda") {}
+
+    void runTest() override {
+        magda::test::runWithCleanJuceState([this] {
+            testOptionToDeviceMapping();
+            testSelectorRoundTrip();
+            testControllerResolvesStereoMarker();
+        });
+    }
+
+  private:
+    void testOptionToDeviceMapping() {
+        beginTest("populateAudioOutputOptions maps option IDs to wave output devices");
+
+        StubAudioIODevice device(4);
+        RoutingSelector selector(RoutingSelector::Type::AudioOut);
+        std::map<int, TrackId> trackMapping;
+        std::map<int, juce::String> channelMapping;
+        juce::BigInteger enabled;
+        enabled.setRange(0, 4, true);
+        const std::map<int, juce::String> teNames = {
+            {0, "Out 1 + 2"}, {1, "Out 1 + 2"}, {2, "Out 3 + 4"}, {3, "Out 3 + 4"}};
+
+        RoutingSyncHelper::populateAudioOutputOptions(
+            &selector, INVALID_TRACK_ID, &device, trackMapping, enabled, &channelMapping, teNames);
+
+        // Stereo pairs (ID 10+) carry the pair marker; monos (ID 100+) the bare name
+        expectEquals(channelMapping[10], juce::String("stereo:Out 1 + 2"));
+        expectEquals(channelMapping[11], juce::String("stereo:Out 3 + 4"));
+        expectEquals(channelMapping[100], juce::String("Out 1 + 2"));
+        expectEquals(channelMapping[102], juce::String("Out 3 + 4"));
+
+        // Without TE device names the mapping falls back to positional names
+        std::map<int, juce::String> fallbackMapping;
+        RoutingSyncHelper::populateAudioOutputOptions(&selector, INVALID_TRACK_ID, &device,
+                                                      trackMapping, enabled, &fallbackMapping);
+        expectEquals(fallbackMapping[10], juce::String("stereo:Out 1"));
+        expectEquals(fallbackMapping[101], juce::String("Out 2"));
+    }
+
+    void testSelectorRoundTrip() {
+        beginTest("syncSelectorsFromTrack re-selects a stored hardware destination");
+
+        StubAudioIODevice device(4);
+        RoutingSelector selector(RoutingSelector::Type::AudioOut);
+        std::map<int, TrackId> outputTrackMapping;
+        std::map<int, TrackId> midiOutputTrackMapping;
+        std::map<int, juce::String> channelMapping;
+        juce::BigInteger enabled;
+        enabled.setRange(0, 4, true);
+        const std::map<int, juce::String> teNames = {
+            {0, "Out 1 + 2"}, {1, "Out 1 + 2"}, {2, "Out 3 + 4"}, {3, "Out 3 + 4"}};
+
+        TrackInfo track;
+        track.audioOutputDevice = "stereo:Out 3 + 4";
+
+        RoutingSyncHelper::syncSelectorsFromTrack(
+            track, nullptr, nullptr, &selector, nullptr, nullptr, &device, INVALID_TRACK_ID,
+            outputTrackMapping, midiOutputTrackMapping, nullptr, {}, enabled, nullptr, {}, nullptr,
+            &channelMapping, teNames);
+
+        // The dropdown must land on the second stereo pair, not snap back to Master
+        expectEquals(selector.getSelectedId(), 11);
+
+        track.audioOutputDevice = "Out 1 + 2";  // mono/bare device selection
+        RoutingSyncHelper::syncSelectorsFromTrack(
+            track, nullptr, nullptr, &selector, nullptr, nullptr, &device, INVALID_TRACK_ID,
+            outputTrackMapping, midiOutputTrackMapping, nullptr, {}, enabled, nullptr, {}, nullptr,
+            &channelMapping, teNames);
+        expectEquals(selector.getSelectedId(), 100);
+    }
+
+    void testControllerResolvesStereoMarker() {
+        beginTest("TrackController strips the stereo: marker before routing to TE");
+
+        auto& wrapper = magda::test::getSharedEngine();
+        auto* bridge = wrapper.getAudioBridge();
+        expect(bridge != nullptr, "AudioBridge must exist");
+        if (bridge == nullptr)
+            return;
+
+        auto& tm = TrackManager::getInstance();
+        const auto trackId = tm.createTrack("HW Out");
+        bridge->createAudioTrack(trackId, "HW Out");
+
+        bridge->setTrackAudioOutput(trackId, "stereo:Speakers L + R");
+        expectEquals(bridge->getTrackAudioOutput(trackId), juce::String("Speakers L + R"));
+
+        // If real wave output devices exist, a pair selection must resolve to one
+        const auto outputNames = bridge->getOutputDeviceNamesByChannel();
+        if (!outputNames.empty()) {
+            const auto deviceName = outputNames.begin()->second;
+            bridge->setTrackAudioOutput(trackId, "stereo:" + deviceName);
+            expectEquals(bridge->getTrackAudioOutput(trackId), deviceName);
+        }
+
+        // And master must still round-trip as the default output
+        bridge->setTrackAudioOutput(trackId, "master");
+        expectEquals(bridge->getTrackAudioOutput(trackId), juce::String("master"));
+    }
+};
+
+static HardwareOutputRoutingTest hardwareOutputRoutingTest;


### PR DESCRIPTION
Closes #2264.

Hardware entries in the track output dropdowns were stubbed: every selection ≥ ID 10 mapped back to `"master"` in all four handlers, so on multi-out interfaces (e.g. the reporter's NI Audio8 DJ) audio only ever left through the master pair. The TE backend already supported device routing; the UI just never passed the destination through.

## Changes

- `RoutingSyncHelper::populateAudioOutputOptions` emits an option-ID → wave-output-device mapping, mirroring the input path: stereo pairs (ID 10+) as `"stereo:<device>"`, monos (ID 100+) as the bare device name, "Out N" fallback when TE names are unavailable.
- The four selection handlers (TrackHeadersPanel, SessionView, MixerView, TrackInspector) pass the mapped device string to `setTrackAudioOutput` instead of `"master"`. Handlers that read the shared mapping inside the callback copy the string first, since the map is rebuilt when the change notification re-syncs selectors.
- `syncSelectorsFromTrack` re-selects the stored hardware destination so the dropdown doesn't snap back to Master.
- `TrackController::setTrackAudioOutput` strips the `stereo:` marker before `setOutputToDeviceID`; `getTrackAudioOutput` round-trips the bare name.
- New `AudioBridge::getOutputDeviceNamesByChannel()`, mirroring the input-side helper.

## Engine-agnosticism (#1882)

The stored representation stays a plain device string in `TrackInfo.audioOutputDevice`; the native engine's `parseTrackRoute` already classifies it as `External`, so nothing TE-shaped reaches the model layer. TE-specific surface is confined to the bridge layer (`stereo:` strip + device-name lookup). Caveat: the native engine's PlanCompiler currently sends every External output route to the default output, so under it these selections are stored but not yet honored — tracked in #2272.

## Testing

- New `tests/routing/test_hardware_output_routing_juce.cpp`: mapping emission (TE names + fallback), selector round-trip for pair and mono selections, `stereo:` stripping through a real TE track, master round-trip.
- Verified negatively: with the sync re-selection and marker strip reverted, 4 assertions fail exactly as the bug predicts.
- Full debug build, new suite, and `[routing]` catch2 tests (135 assertions) all pass.

Out of scope (per issue): crash when toggling output configuration repeatedly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)