### PR TITLE
Take the projects that host a plugin, and the silence they found (#2175)

### DIFF
--- a/magda/engine/param/ParamResolve.cpp
+++ b/magda/engine/param/ParamResolve.cpp
@@ -346,6 +346,17 @@ void resolveOneParam(const ParamTable& table, ResolvedParams& out, const ModRunt
                      std::span<ModContribution> links, std::span<ParamSegment> segments,
                      const BlockInfo& block, ParamId param) {
     const auto index = static_cast<std::size_t>(param);
+
+    // A hole in a sparse device window. Nothing declared it, so nothing may be
+    // published for it: no segments is the one answer a device can read as "not
+    // mine", and it is the answer it already gets for an index past the end of
+    // its window. A fabricated value here is indistinguishable from a real one
+    // (ParamSpec::declared).
+    if (!table.specs[index].declared) {
+        out.setSegmentCount(param, 0);
+        return;
+    }
+
     const auto reaching = table.linksFor(param);
 
     std::size_t used = 0;

--- a/magda/engine/param/ParamSpec.hpp
+++ b/magda/engine/param/ParamSpec.hpp
@@ -55,6 +55,33 @@ struct ParamSpec {
      * that is the granularity the cost is paid at.
      */
     bool segmentAccurate = false;
+
+    /**
+     * @brief Whether anything in the model actually declared this parameter.
+     *
+     * False for one slot only: the hole a device's window has to leave when its
+     * parameter indices are sparse. A window is contiguous and indexed from
+     * zero, because that is what lets a device be handed a span and read its own
+     * parameters by the index it declared them at, so an index nothing declared
+     * still costs a slot.
+     *
+     * What it must not cost is a value. A device cannot tell a fabricated zero
+     * from a real one, and the first real project to host a plugin found what
+     * that means: a project saved before the wet/dry pair was persisted has no
+     * parameters at indices 0 and 1, and a hole publishing 0.0 there set the
+     * pair to fully dry and fully attenuated -- silence, from a plugin whose own
+     * chunk was perfectly restored. A sparse array is normal for a hosted plugin
+     * (the fork's list is a filtered view of the instance's, and a project saves
+     * what it had), so this is a shape the value layer has to carry rather than
+     * a model to correct.
+     *
+     * Read where the block is resolved: an undeclared parameter publishes no
+     * segments, so the device sees an empty view and keeps whatever its own
+     * state put there. That is the same answer a device already gets for an
+     * index past the end of its window, which is the same question one step
+     * further out.
+     */
+    bool declared = true;
 };
 
 /** @brief The spec of the parameter @p info describes. Off the audio thread. */

--- a/magda/engine/param/ParamTableCompiler.cpp
+++ b/magda/engine/param/ParamTableCompiler.cpp
@@ -502,7 +502,13 @@ void Builder::allocateDevice(const Node& node) {
         const auto* info = find(index);
         if (info == nullptr) {
             ++gaps;
-            add(key, ParamSpec{}, 0.0f);
+
+            // A slot, because the window is contiguous, and no value, because
+            // nothing declared one. See ParamSpec::declared: a fabricated zero
+            // is indistinguishable from a real one to the device reading it.
+            ParamSpec hole;
+            hole.declared = false;
+            add(key, hole, 0.0f);
             continue;
         }
 
@@ -515,7 +521,18 @@ void Builder::allocateDevice(const Node& node) {
         add(key, paramSpecFrom(*info), normalised.value);
     }
 
-    if (gaps > 0)
+    // Reported for a device MAGDA ships and not for one it hosts, because it is
+    // a mistake in the first case and the normal shape of the second.
+    //
+    // An internal device declares its own parameters, so a gap is a device that
+    // skipped an index and the slot it left is one nothing will ever read. A
+    // hosted plugin's array is a filtered view of the instance's -- the
+    // non-automatable ones are not in it at all -- and a project saves whatever
+    // it had when it was saved, which for anything written before the wet/dry
+    // pair was persisted is an array starting at index two. Diagnosing that
+    // would make every real project hosting a plugin unmeasurable for having
+    // been saved by an older build (#2175).
+    if (gaps > 0 && device.format == magda::PluginFormat::Internal)
         diagnose(toString(scope) + ": parameter indices are not contiguous, so " +
                  std::to_string(gaps) + " slot(s) of the window belong to no parameter");
 

--- a/tests/MgdFixture.cpp
+++ b/tests/MgdFixture.cpp
@@ -2,6 +2,7 @@
 
 #include <juce_audio_formats/juce_audio_formats.h>
 
+#include <algorithm>
 #include <map>
 #include <set>
 
@@ -222,32 +223,65 @@ void everyDevice(const TrackInfo& track, std::vector<const DeviceInfo*>& out) {
 }
 
 /**
- * @brief Why this project cannot be a fixture here, if it hosts a plugin.
+ * @brief Why this project cannot be a fixture here, if it hosts a plugin it did
+ *        not declare (#2175).
  *
- * A project with a VST3 in it has no verdict a corpus can hold it to. Without
- * the plugin installed both legs render a passthrough and pass by agreeing
- * about nothing, which is the silence-nulls-against-silence failure wearing a
- * different hat. With it installed the incumbent hosts it and the native leg
- * cannot (#1893), so whether the case passes is a fact about the machine that
- * ran it.
+ * A plugin in a project used to be an outright refusal, and while nothing hosted
+ * a VST3 in the engine it was the right one: without the plugin installed both
+ * legs render a passthrough and pass by agreeing about nothing, and with it
+ * installed the incumbent hosted it and the native leg could not, so the verdict
+ * was a fact about the machine either way. #1893 answered the second half and
+ * the runner's absent-plugin gate answers the first, so what is left here is the
+ * declaration.
  *
- * #2175 is where those projects go, with the invariant tier and a gate that
- * calls an absent plugin unmeasurable rather than equal. Refused here rather
- * than left to whoever writes a manifest, because the tier is a field somebody
- * fills in and the format is a fact about the file.
+ * Both directions, like the sources beside it. A plugin the manifest does not
+ * name is refused, because a project acquires one the day somebody replaces its
+ * bytes and that is exactly the day nobody rereads the manifest; a name no
+ * device claims is refused, because a declaration that has stopped being true is
+ * worse than one nobody wrote.
+ *
+ * And the tier, which is checked here rather than left to a reviewer's eye: a
+ * plugin frames its own work, so a residual measured across one is a number
+ * about the plugin. Invariants is the tier that asks questions a plugin can be
+ * held to.
  */
-std::string refuseHostedPlugins(const StagedProjectData& staged) {
+std::string refuseUndeclaredPlugins(const MgdFixture& fixture, const StagedProjectData& staged) {
     std::vector<const DeviceInfo*> devices;
     for (const auto& track : staged.tracks)
         everyDevice(track, devices);
     if (staged.masterTrack != nullptr)
         everyDevice(*staged.masterTrack, devices);
 
-    for (const auto* device : devices)
-        if (device->format != magda::PluginFormat::Internal)
+    const auto declares = [&fixture](const juce::String& name) {
+        return std::any_of(fixture.hostedPlugins.begin(), fixture.hostedPlugins.end(),
+                           [&name](const char* declared) { return name == declared; });
+    };
+
+    std::set<std::string> hosted;
+    for (const auto* device : devices) {
+        if (device->format == magda::PluginFormat::Internal)
+            continue;
+
+        if (!declares(device->name))
             return "the project hosts " + quoted(device->name) +
-                   ", which is not an internal device, so neither engine owes the other a "
-                   "sample on it: see #2175 for the tier those projects get";
+                   ", which the manifest does not name: a fixture that hosts a plugin declares "
+                   "it, because the corpus renders it at a different tier and does not render "
+                   "it at all on a machine that has not scanned it (#2175)";
+
+        hosted.insert(device->name.toStdString());
+    }
+
+    for (const char* declared : fixture.hostedPlugins)
+        if (hosted.count(declared) == 0)
+            return "the manifest names " + quoted(declared) +
+                   " as a plugin this project hosts, and no device in it does";
+
+    // The tier last, so that a fixture that names the wrong plugin hears about
+    // that rather than about a tier it would have set correctly.
+    if (!hosted.empty() && fixture.declaration.tier != AudioTier::Invariants)
+        return "the project hosts a plugin and the fixture does not declare the invariants "
+               "tier: a plugin is entitled to frame its own work, so a residual measured "
+               "across one is a number about the plugin rather than about either engine";
 
     return {};
 }
@@ -388,7 +422,7 @@ FixtureLoad loadFixture(const MgdFixture& fixture, const juce::File& scratchDire
         return result;
     }
 
-    if (auto refusal = refuseHostedPlugins(staged); !refusal.empty()) {
+    if (auto refusal = refuseUndeclaredPlugins(fixture, staged); !refusal.empty()) {
         result.failure = std::move(refusal);
         return result;
     }

--- a/tests/MgdFixture.hpp
+++ b/tests/MgdFixture.hpp
@@ -74,11 +74,13 @@
  * So is a project whose sources cannot be told apart by the only part of a path
  * a manifest can name. See @ref refuseIndistinguishableSources.
  *
- * And so is a project that hosts an external plugin. Without the plugin
- * installed both legs render a passthrough and agree about nothing; with it
- * installed the incumbent hosts it and the native leg cannot, so the verdict
- * becomes a fact about the machine. #2175 reserves those for the invariant tier
- * and an absent-plugin gate, which is a different slice and a different verdict.
+ * A project that hosts an external plugin is not refused any more (#2175), and
+ * what replaced the refusal is a declaration: @ref MgdFixture::hostedPlugins
+ * names them, the tier has to be @c AudioTier::Invariants, and the runner does
+ * not render the case at all on a machine that has not scanned one of them. The
+ * refusal was right while nothing hosted a VST3 in the engine and the verdict
+ * could only be a fact about the machine; what makes it a fixture now is that
+ * the fact about the machine is asked first and answered out loud.
  *
  * ## A loaded fixture keeps its ids
  *
@@ -140,6 +142,22 @@ struct MgdFixture {
 
     Case declaration;
     std::vector<FixtureSource> sources;
+
+    /// The external plugins this project hosts, by the name the project gives
+    /// them, in no order (#2175).
+    ///
+    /// Declared for the same reason the sources are, and checked the same way in
+    /// both directions: a plugin in the project that the manifest does not name
+    /// is refused, and a name in the manifest no device claims is refused. A
+    /// project acquires a plugin the day somebody replaces its bytes, which is
+    /// exactly the day nobody is reading the manifest.
+    ///
+    /// Non-empty demands @c AudioTier::Invariants. A plugin is entitled to
+    /// frame its own work -- to dither, to hold state from however it was last
+    /// called -- so there is no null to ask of a project hosting one, and a
+    /// residual measured across one is a number about the plugin rather than
+    /// about either engine.
+    std::vector<const char*> hostedPlugins;
 };
 
 /// What loading one fixture produced, or why it could not be loaded.

--- a/tests/MgdFixtures.cpp
+++ b/tests/MgdFixtures.cpp
@@ -60,14 +60,15 @@
  *
  * ## The projects that are not here
  *
- * Fifteen of the twenty-two are out, and each for a reason that is a fact about
+ * Twelve of the twenty-two are out, and each for a reason that is a fact about
  * the project or about the engine rather than a preference:
  *
- *  - **Half of them host an external plugin.** retrovid and envfollower carry
- *    Retrospect, groups carries Pro-L 2, overlaps carries Pianoteq. The rig
- *    refuses those outright and #2175 is the slice that takes them, with the
- *    invariant tier and a gate that calls an absent plugin unmeasurable rather
- *    than equal.
+ *  - **envfollower hosts a plugin and is still out**, which is the one entry
+ *    here that reads like an exception and is not. Its two Retrospect instances
+ *    are both on muted tracks, so an arrangement render of it is one internal
+ *    filter and no plugin at all; and it carries 4OSC besides. It belongs with
+ *    the 4OSC exclusions below rather than with the three plugin projects, which
+ *    are in (#2175).
  *  - **Seven of them contain 4OSC**, which has no engine device yet, so a
  *    Device op for one binds to a passthrough and the case would be comparing
  *    a project neither engine really rendered: dupes, macrolinkmod, retired-fx,
@@ -109,6 +110,22 @@ MaterialSpec pulsedToneFor(double seconds, double frequency) {
     return spec;
 }
 
+/// A steady band-limited tone, for a source whose case is judged on what its
+/// render is rather than on how close two renders are.
+///
+/// What the invariants tier reads off it is the largest step from one sample to
+/// the next, and that number is only meaningful over material that has a
+/// meaningful one: impulses step by full scale legitimately, so a project fed
+/// them has no step bound worth declaring and the check certifies nothing.
+MaterialSpec toneFor(double seconds, double frequency) {
+    MaterialSpec spec;
+    spec.kind = MaterialKind::Tone;
+    spec.sampleRate = 44100.0;
+    spec.durationSeconds = seconds;
+    spec.frequency = frequency;
+    return spec;
+}
+
 Case declarationFor(const char* name, const char* covers, double startBeat, double endBeat) {
     Case value;
     value.name = name;
@@ -122,16 +139,16 @@ Case declarationFor(const char* name, const char* covers, double startBeat, doub
 std::vector<MgdFixture> build() {
     std::vector<MgdFixture> fixtures;
 
-    // Every fixture here is an internal-device project, and that is a
-    // requirement rather than what was to hand. A project hosting a VST3 cannot
-    // be held to a null: without the plugin installed both legs render a
-    // passthrough and pass by agreeing about nothing, and with it installed the
-    // incumbent hosts it while the native leg cannot, so the verdict becomes a
-    // fact about the machine. #2175 reserves those projects for the invariant
-    // tier and an absent-plugin gate, and they belong there rather than here.
+    // The fixtures down to the Faust one are internal-device projects and the
+    // three after them host a plugin. That is a division rather than an
+    // ordering: an internal-device project is held to a null, and a project
+    // hosting a plugin cannot be, so the second group declares the invariants
+    // tier and does not run at all on a machine that has not scanned its plugin.
     //
-    // The rig checks it rather than trusting this comment: `format`, which is
-    // VST3 at zero and Internal at three.
+    // The rig checks it rather than trusting this comment. A plugin in a project
+    // that the manifest does not name is refused, a name no device claims is
+    // refused, and a fixture hosting one that did not declare the tier is
+    // refused (MgdFixture.cpp, refuseUndeclaredPlugins).
 
     {
         // Two audio tracks playing bounces off an SSD that is gone, and a Drum
@@ -341,6 +358,274 @@ std::vector<MgdFixture> build() {
             {.fileName = "Addictive Drums Key Map FX-bounce-1.wav",
              .material = pulsedToneFor(6.0, 196.0),
              .covers = "a break the clip warps, recorded at 135 under a 120 timeline"},
+        };
+
+        fixtures.push_back(std::move(fixture));
+    }
+
+    // ---------------------------------------------------------------------
+    // The projects that host a plugin (#2175)
+    // ---------------------------------------------------------------------
+    //
+    // Everything above is an internal-device project and was a requirement while
+    // nothing hosted a VST3 in the engine. #1893 ended that, and these three are
+    // what the requirement was keeping out: the projects most worth having, and
+    // the ones a corpus that quietly dropped every project with a plugin in it
+    // would have dropped.
+    //
+    // All three declare the invariants tier, and the rig refuses them otherwise.
+    // A plugin is entitled to frame its own work -- to dither, to hold state
+    // from however it was last called -- so a residual measured across one is a
+    // number about the plugin, and a tolerance wide enough to pass it is wide
+    // enough to pass anything. What is asked instead is what a plugin can be
+    // held to: both renders finite, the same length, continuous within a
+    // declared step, and decayed by the end.
+    //
+    // And none of them runs on a machine that has not scanned its plugin. That
+    // is not a gap: it is the gate (NullDiffCase.hpp, absentPluginsIn). A
+    // project rendered without the plugin it names is a different project, and
+    // two legs rendering it without the plugin null perfectly.
+
+    {
+        // Two audio tracks each through their own Retrospect, one of them with
+        // an internal Limiter after it. The first project in this corpus where a
+        // hosted plugin makes the sound, and the mixed chain is the half worth
+        // having: an external device and an internal one in one chain is where a
+        // plan that binds the two kinds differently shows it.
+        //
+        // Both instances carry saved state, which is the other half. #2244 made
+        // the chunk authoritative over the project's parameter array, and this
+        // is a project whose chunk was written by a released build rather than
+        // by a test.
+        MgdFixture fixture;
+        fixture.file = "legacy/projects/0.13.0-retrovid.mgd";
+        fixture.savedBy = "0.13.0-rc1";
+        fixture.isMigrationFixture = true;
+        fixture.declaration =
+            declarationFor("project.retrospect",
+                           "two audio tracks through hosted Retrospect instances at 92 bpm, one "
+                           "of them behind an internal limiter",
+                           0.0, 8.0);
+
+        fixture.declaration.tier = AudioTier::Invariants;
+        fixture.hostedPlugins = {"Retrospect"};
+
+        // Measured on the first run with the plugin installed: -3.0 dB, which
+        // is 0.71 of full scale in one sample. Named rather than rounded up to a
+        // number that would pass anything, and it is the mechanism that says why
+        // it is this large. Retrospect is a repeat effect: it splices, and a
+        // splice between two phases of a tone steps by the distance between
+        // them, which for a full-scale tone is up to twice its peak. What the
+        // bound has to refuse is a step larger than a splice, which is what a
+        // graph transition without a ramp leaves behind.
+        fixture.declaration.maxStepPerSample = 0.75;
+
+        // Eight beats of an arrangement whose clips run to thirty-two, so the
+        // render stops in the middle of the music. Nothing has decayed at the
+        // end because nothing has stopped.
+        fixture.declaration.rendersPastItsMaterial = false;
+
+        fixture.declaration.mechanism =
+            "two hosted Retrospect instances, which owe neither engine a sample";
+
+        // Tones throughout, at frequencies far enough apart that two sources
+        // cannot be mistaken for each other in a render. A tone rather than
+        // impulses because the step bound above is the whole assertion and
+        // impulses have no step worth bounding.
+        //
+        // Two of the eight sound in the rendered window: the two arrangement
+        // clips on the two unmuted tracks. The rest are the project's session
+        // clips and its two muted tracks, and they are declared because the
+        // manifest has to name every source the project references -- a source
+        // the manifest misses reaches a leg pointing at a path that does not
+        // exist, renders silence, and silence nulls against silence.
+        fixture.sources = {
+            {.fileName = "mdh_drm120_touch_stp.wav",
+             .material = toneFor(6.0, 220.0),
+             .covers = "the first track's arrangement clip, looped and stretched from 120 to 92 "
+                       "under the Retrospect and the limiter"},
+            {.fileName = "mdh_drm120_touch_stp_(copy)_20260701_145457.wav",
+             .material = toneFor(6.0, 330.0),
+             .covers = "the second track's arrangement clip, played at its own rate under the "
+                       "second Retrospect"},
+            {.fileName = "DS_OT_fx_riser_dark.wav",
+             .material = toneFor(6.0, 440.0),
+             .covers = "a riser on the third track, which the project muted"},
+            {.fileName = "DS_OT_fx_riser_dark_20260701_153831.wav",
+             .material = toneFor(6.0, 550.0),
+             .covers = "its bounce on the fourth track, muted with it"},
+            {.fileName = "TAMUZ_TD_90_drum_best_simple_trashy.wav",
+             .material = toneFor(2.0, 660.0),
+             .covers = "a session clip in the first scene, which an arrangement render never "
+                       "launches"},
+            {.fileName = "SLS_O_65_guitar_soul_serenade_Cmin.wav",
+             .material = toneFor(2.0, 770.0),
+             .covers = "a session clip on the second track"},
+            {.fileName = "BS_NCS3_140_bass_growl_leap_Dbmin.wav",
+             .material = toneFor(2.0, 880.0),
+             .covers = "a session clip in the fourth scene"},
+            {.fileName = "SA_MU_118_electric_guitar_loop_funky_wah_Amaj.wav",
+             .material = toneFor(2.0, 990.0),
+             .covers = "a session clip in the fifth scene"},
+        };
+
+        fixtures.push_back(std::move(fixture));
+    }
+
+    {
+        // A hosted instrument rather than a hosted effect, which is the other
+        // half of what #1893 built and a different path through the plan: MIDI
+        // is routed to it, and whether it is routed at all comes from the role
+        // resolution corrects against the scan rather than from what the project
+        // guessed (#2252).
+        //
+        // Two MIDI clips back to back on one track, four notes each. No audio
+        // sources at all, which makes this the cheapest case in the corpus and
+        // the one that isolates the instrument: whatever comes out came out of
+        // Pianoteq, and the notes that went in are compared as a stream beside
+        // it.
+        MgdFixture fixture;
+        fixture.file = "legacy/projects/0.18.0-overlaps.mgd";
+        fixture.savedBy = "0.18.0-6-g3c042289";
+        fixture.isMigrationFixture = true;
+        fixture.declaration =
+            declarationFor("project.hostedinstrument",
+                           "two MIDI clips back to back into a hosted Pianoteq", 0.0, 8.0);
+
+        fixture.declaration.tier = AudioTier::Invariants;
+        fixture.hostedPlugins = {"Pianoteq 8"};
+
+        // A piano is a decaying acoustic model: nothing in its output steps, and
+        // a bound loose enough for a repeat effect would say nothing here.
+        fixture.declaration.maxStepPerSample = 0.1;
+
+        // The second clip's notes are still ringing when the render stops. A
+        // piano decays over seconds and the window is four of them, so the tail
+        // here is the instrument sounding rather than a device left running.
+        fixture.declaration.rendersPastItsMaterial = false;
+
+        fixture.declaration.mechanism =
+            "a hosted Pianoteq, which is a physical model and settles from its own state";
+
+        // Asserted beside the audio, and independent of it. What reaches the
+        // instrument is a fact both engines owe each other exactly, whatever
+        // either instrument then does with it, and it is the assertion that
+        // survives the plugin being entitled to its own sound.
+        fixture.declaration.compareMidiStreams = true;
+
+        fixtures.push_back(std::move(fixture));
+    }
+
+    {
+        // Twenty-three stems, three group tracks and a limiter on two of them:
+        // a real multitrack session, and the only project in this corpus with a
+        // track hierarchy in it. Two things arrive with it that nothing else
+        // here has -- group tracks summing their children, and the same plugin
+        // hosted twice in one project, once on a track and once on the master.
+        //
+        // Rendered over eight beats of a project whose clips are five hundred
+        // and ninety-seven, for the reason the corpus comment gives: what a
+        // fixture is worth is what it contains, not how much of it is played,
+        // and a forty-minute arrangement rendered twice is not a test budget.
+        MgdFixture fixture;
+        fixture.file = "legacy/projects/0.10.2-groups.mgd";
+        fixture.savedBy = "0.10.2-6-g9cfbb3b32";
+        fixture.isMigrationFixture = true;
+        fixture.declaration = declarationFor(
+            "project.multitrack",
+            "twenty-three stems under three group tracks, limited on a track and on the master",
+            0.0, 8.0);
+
+        fixture.declaration.tier = AudioTier::Invariants;
+        fixture.hostedPlugins = {"Pro-L 2"};
+
+        // A limiter's job is to not step: it is the one device here whose output
+        // is bounded by construction, and a bound this tight is what says the
+        // twenty-three summed stems went through it rather than around it.
+        fixture.declaration.maxStepPerSample = 0.1;
+
+        // Eight beats of a five-hundred-and-ninety-seven-beat arrangement. Every
+        // one of the twenty-three stems is still playing when the render stops.
+        fixture.declaration.rendersPastItsMaterial = false;
+
+        fixture.declaration.mechanism =
+            "two hosted Pro-L 2 instances, one on the snare track and one on the master";
+
+        // One tone per stem, spaced so that no two sum to a beat frequency
+        // inside the band and no two can be mistaken for each other. Every one
+        // of them sounds: this project has no session clips and no muted tracks,
+        // which is what makes it the summing case.
+        fixture.sources = {
+            {.fileName = "BACKING VOX (female) - M81.wav",
+             .material = toneFor(5.0, 110.0),
+             .covers = "a vocal stem under the VOX group"},
+            {.fileName = "BACKING VOX (male) - M80.wav",
+             .material = toneFor(5.0, 123.0),
+             .covers = "a second vocal stem under the VOX group"},
+            {.fileName = "BARITONE - M81-SH.wav",
+             .material = toneFor(5.0, 139.0),
+             .covers = "a horn stem routed straight to the master"},
+            {.fileName = "BASS AMP - AK-47mkII.wav",
+             .material = toneFor(5.0, 156.0),
+             .covers = "an amped bass stem under the BASS group"},
+            {.fileName = "BASS DI.wav",
+             .material = toneFor(5.0, 175.0),
+             .covers = "the DI beside it, under the same group"},
+            {.fileName = "CHAMBER - AR-70 STEREO.L.wav",
+             .material = toneFor(5.0, 196.0),
+             .covers = "the left half of a stereo room pair, carried as two mono tracks"},
+            {.fileName = "CHAMBER - AR-70 STEREO.R.wav",
+             .material = toneFor(5.0, 220.0),
+             .covers = "its right half"},
+            {.fileName = "DRUM HIHAT - M60 FET hypercardioid.wav",
+             .material = toneFor(5.0, 247.0),
+             .covers = "a hi-hat stem under the DRUMS group"},
+            {.fileName = "DRUM KICK - SENN 421  {our M82 died _( }.wav",
+             .material = toneFor(5.0, 277.0),
+             .covers = "a kick stem, whose file name carries the braces and spaces a real "
+                       "session leaves in one"},
+            {.fileName = "DRUM OVERHEADS - AR-51.L.wav",
+             .material = toneFor(5.0, 311.0),
+             .covers = "the left overhead"},
+            {.fileName = "DRUM OVERHEADS - AR-51.R.wav",
+             .material = toneFor(5.0, 330.0),
+             .covers = "the right overhead"},
+            {.fileName = "DRUM SNARE - M80-SH.wav",
+             .material = toneFor(5.0, 370.0),
+             .covers = "the snare, and the one track in the project with a plugin on it"},
+            {.fileName = "DRUM TOM - M81-SH.wav",
+             .material = toneFor(5.0, 415.0),
+             .covers = "a tom stem"},
+            {.fileName = "DRUM TOM 2 - M81-SH.wav",
+             .material = toneFor(5.0, 466.0),
+             .covers = "a second tom stem"},
+            {.fileName = "E GUITAR - M81-SH.wav",
+             .material = toneFor(5.0, 523.0),
+             .covers = "a guitar stem routed straight to the master"},
+            {.fileName = "KEY AMP - M81-SH.wav",
+             .material = toneFor(5.0, 587.0),
+             .covers = "a keyboard amp stem"},
+            {.fileName = "LEAD VOX (female) - M81.wav",
+             .material = toneFor(5.0, 659.0),
+             .covers = "the lead vocal, under the VOX group"},
+            {.fileName = "LESLIE BOTTOM - M81.wav",
+             .material = toneFor(5.0, 740.0),
+             .covers = "the bottom of a Leslie pair"},
+            {.fileName = "LESLIE TOP - M81.wav",
+             .material = toneFor(5.0, 831.0),
+             .covers = "its top"},
+            {.fileName = "ROOM - M81 (ORTF).L.wav",
+             .material = toneFor(5.0, 932.0),
+             .covers = "the left half of an ORTF room pair"},
+            {.fileName = "ROOM - M81 (ORTF).R.wav",
+             .material = toneFor(5.0, 1046.0),
+             .covers = "its right half"},
+            {.fileName = "TENOR - M81-SH.wav",
+             .material = toneFor(5.0, 1174.0),
+             .covers = "a tenor horn stem"},
+            {.fileName = "TRUMPET - M81-SH.wav",
+             .material = toneFor(5.0, 1318.0),
+             .covers = "a trumpet stem"},
         };
 
         fixtures.push_back(std::move(fixture));

--- a/tests/MgdFixtures.cpp
+++ b/tests/MgdFixtures.cpp
@@ -425,6 +425,22 @@ std::vector<MgdFixture> build() {
         // end because nothing has stopped.
         fixture.declaration.rendersPastItsMaterial = false;
 
+        // Which is why the liveness floor has to be here: with no tail to ask
+        // about and no residual in this tier, every remaining check passes on
+        // silence. The quieter of the two legs peaks at +4 dBFS on this project,
+        // a float render of two tones through a repeat effect and a limiter; -40
+        // is far below that and far above anything a dead leg produces.
+        fixture.declaration.minPeakDb = -40.0;
+
+        // Retrospect is an LV2 plugin behind a VST3 shell and hands JUCE its own
+        // URI, "https://conceptualmachines.com/plugins/retrospect", where a path
+        // is expected. Once per instantiation, so twice here.
+        //
+        // Named rather than waived, and asserted in both directions: the day
+        // Retrospect stops doing it this line fails and comes out, which is what
+        // keeps it from quietly forgiving something else.
+        fixture.declaration.expectedHostedAssertions = {"juce_File.cpp:219"};
+
         fixture.declaration.mechanism =
             "two hosted Retrospect instances, which owe neither engine a sample";
 
@@ -504,6 +520,10 @@ std::vector<MgdFixture> build() {
         // here is the instrument sounding rather than a device left running.
         fixture.declaration.rendersPastItsMaterial = false;
 
+        // And with no tail asked, liveness is what stops a silent leg passing.
+        // Eight notes into a piano is not a quiet render on either engine.
+        fixture.declaration.minPeakDb = -40.0;
+
         fixture.declaration.mechanism =
             "a hosted Pianoteq, which is a physical model and settles from its own state";
 
@@ -547,6 +567,11 @@ std::vector<MgdFixture> build() {
         // Eight beats of a five-hundred-and-ninety-seven-beat arrangement. Every
         // one of the twenty-three stems is still playing when the render stops.
         fixture.declaration.rendersPastItsMaterial = false;
+
+        // Twenty-three tones summed into a limiter. The floor is the same one
+        // the other two carry, and it is nowhere near what this renders: what it
+        // is for is the difference between a render and nothing.
+        fixture.declaration.minPeakDb = -40.0;
 
         fixture.declaration.mechanism =
             "two hosted Pro-L 2 instances, one on the snare track and one on the master";

--- a/tests/NullDiffCase.hpp
+++ b/tests/NullDiffCase.hpp
@@ -213,6 +213,34 @@ struct Case {
     /// nobody declared would certify a check that never ran.
     double maxStepPerSample = 0.0;
 
+    /// The peak each side of this case has to reach on its own, for a case in
+    /// the Invariants tier. Required there and refused without, for the reason
+    /// the step bound is: this tier computes no residual, so nothing else in it
+    /// would notice one leg going silent, and every other check it makes is
+    /// satisfied by silence.
+    ///
+    /// A liveness floor rather than a level. It says the render happened, and
+    /// it is set far below what the project renders and far above what a broken
+    /// one does.
+    double minPeakDb = std::numeric_limits<double>::infinity();
+
+    /// Assertions this case's hosted plugins are known to raise, as substrings
+    /// of them (#2175).
+    ///
+    /// The assertion watch is a process-wide hook, so on a case that loads
+    /// somebody else's code it cannot say whose code raised what. Named here
+    /// rather than waived by the presence of a plugin, because "this project
+    /// hosts a VST3" is not evidence about who asserted: a waiver keyed on it
+    /// forgives a genuine engine regression on exactly the three cases that
+    /// were worth adding, and forgives it on a plugin that sits on a bypassed
+    /// chain and was never instantiated.
+    ///
+    /// Asserted in both directions, like @ref expectedDiagnostics: an assertion
+    /// nothing named still condemns the case, and a name that stops firing
+    /// fails as loudly, so the day a plugin is fixed the line comes out rather
+    /// than sitting there forgiving something that no longer happens.
+    std::vector<std::string> expectedHostedAssertions;
+
     /// Whether this case's render window goes past the end of its material
     /// (#2175).
     ///

--- a/tests/NullDiffCase.hpp
+++ b/tests/NullDiffCase.hpp
@@ -2,6 +2,10 @@
 
 #include <juce_core/juce_core.h>
 
+namespace juce {
+class KnownPluginList;
+}
+
 #include <limits>
 #include <string>
 #include <vector>
@@ -209,6 +213,21 @@ struct Case {
     /// nobody declared would certify a check that never ran.
     double maxStepPerSample = 0.0;
 
+    /// Whether this case's render window goes past the end of its material
+    /// (#2175).
+    ///
+    /// True for every case built in code: they are written to render what they
+    /// contain and then stop. False for a real project, whose arrangement is
+    /// minutes long and whose case renders eight beats of it, so the render ends
+    /// in the middle of a clip.
+    ///
+    /// Read by the invariants tier, where the tail check asks what is left
+    /// running after the material stops. That question has no meaning on a
+    /// render that stops first: what is in the last fifty milliseconds there is
+    /// the music. The tail is still measured and still printed, marked so that a
+    /// number nobody asked for cannot be read as a check that held.
+    bool rendersPastItsMaterial = true;
+
     /// How far this project's renders at two different block sizes may sit
     /// apart, as a peak level (#2078).
     ///
@@ -249,7 +268,10 @@ struct Case {
     }
 
     CaseEnvironment environment() const {
-        return {sampleRate, blockSize, channels, seed};
+        // Plugins left empty on purpose: a case declares what it renders
+        // under and cannot declare what is installed. The runner fills them in
+        // from what the render actually resolved.
+        return {sampleRate, blockSize, channels, seed, {}};
     }
 };
 
@@ -298,10 +320,35 @@ const std::vector<Case>& sharedCorpus(const juce::File& scratchDirectory);
  * tier says what can be asserted against the incumbent, and an external plugin
  * frames its own work whether or not the case chose to notice.
  *
- * Empty for the whole corpus today, because nothing hosts a plugin yet. It is
- * written now so that #1893 has a gate to land in rather than a gate to widen.
+ * Empty for the code-built corpus, whose devices were all written for it. The
+ * three real projects that host a plugin (#2175) are what fills it, and they
+ * found the gate it was written for rather than widening it.
  */
 std::vector<std::string> externalDevicesIn(const Case& value);
+
+/**
+ * @brief Of those, the ones @p knownPlugins has never seen (#2175).
+ *
+ * The gate on a case whose project hosts a plugin. A project rendered without
+ * the plugin it names is a different project: both legs bind nothing in that
+ * slot, both render the chain around it, and the two null against each other
+ * perfectly -- a case that passes by having tested less than it claims. So the
+ * question is asked of the scan before either leg is driven, and a case with an
+ * answer does not run at all.
+ *
+ * Asked of the model rather than of the compiled plan, which makes it strict in
+ * one direction: a plugin on a chain the project bypassed is never instantiated
+ * and never missed, and this refuses the case over it anyway. That is the right
+ * way round to be wrong -- the cost is a case reported as not run on a machine
+ * that could have measured it, and the report names the plugin, where the other
+ * way round is a green case that rendered a project nobody has.
+ *
+ * A null @p knownPlugins is not a special case: nothing is installed, so
+ * everything the project names is absent. That is the state every CI runner is
+ * in.
+ */
+std::vector<std::string> absentPluginsIn(const Case& value,
+                                         const juce::KnownPluginList* knownPlugins);
 
 /// The groove template every grooving case names, and the one the runner
 /// installs in both engines.

--- a/tests/NullDiffCompare.cpp
+++ b/tests/NullDiffCompare.cpp
@@ -831,9 +831,10 @@ InvariantComparison compareInvariants(const juce::AudioBuffer<float>& native,
 
     result.tailPeakNativeDb = tailPeak(native);
     result.tailPeakIncumbentDb = tailPeak(incumbent);
+    result.tailAsked = options.asksForTail;
     result.tailDecays = result.tailPeakNativeDb <= options.tailFloorDb &&
                         result.tailPeakIncumbentDb <= options.tailFloorDb;
-    if (!result.tailDecays)
+    if (result.tailAsked && !result.tailDecays)
         result.problems.push_back("the tail has not decayed: native " +
                                   formatDb(result.tailPeakNativeDb) + " dBFS, incumbent " +
                                   formatDb(result.tailPeakIncumbentDb) + " dBFS, bound " +
@@ -1218,7 +1219,15 @@ std::string formatReport(const std::vector<CaseReport>& cases, const CaseEnviron
         std::snprintf(text, sizeof(text), "rate=%lld blockSize=%d channels=%d seed=%u",
                       static_cast<long long>(environment.sampleRate), environment.blockSize,
                       environment.channels, environment.seed);
-        return std::string(text);
+
+        // Named in full, versions included, and never abbreviated to a count.
+        // What this answers is "what could account for this difference", and a
+        // count answers nothing -- the same reason externalDevicesIn names them.
+        std::string described(text);
+        for (const auto& plugin : environment.plugins)
+            described += " plugin=\"" + plugin + "\"";
+
+        return described;
     };
 
     out << "magda-null-diff v2\n";
@@ -1237,7 +1246,15 @@ std::string formatReport(const std::vector<CaseReport>& cases, const CaseEnviron
         // with an instrument track and audio tracks would print its notes and
         // silently drop its residual, which is the number that moves going
         // missing from exactly the cases this slice exists to enable.
-        if (!report.unmeasurable.empty()) {
+        if (!report.absentPlugins.empty()) {
+            // Ahead of the unmeasurable branch because it is the more specific
+            // answer: a case stopped here never reached a leg, so there is no
+            // leg failure to report and nothing was measured for a reason that
+            // is neither engine's.
+            out << "not run: this machine has not scanned";
+            for (const auto& plugin : report.absentPlugins)
+                out << " \"" << plugin << "\"";
+        } else if (!report.unmeasurable.empty()) {
             out << "unmeasurable: " << report.unmeasurable;
         } else {
             if (report.hasInvariants) {
@@ -1247,7 +1264,13 @@ std::string formatReport(const std::vector<CaseReport>& cases, const CaseEnviron
                     formatDb(
                         toDb(std::max(invariants.worstStepNative, invariants.worstStepIncumbent)))
                         .c_str(),
-                    formatDb(std::max(invariants.tailPeakNativeDb, invariants.tailPeakIncumbentDb))
+                    // Printed with a mark when nobody asked, so a number that is
+                    // not a verdict cannot be read as one.
+                    (invariants.tailAsked ? formatDb(std::max(invariants.tailPeakNativeDb,
+                                                              invariants.tailPeakIncumbentDb))
+                                          : formatDb(std::max(invariants.tailPeakNativeDb,
+                                                              invariants.tailPeakIncumbentDb)) +
+                                                "?")
                         .c_str(),
                     invariants.lengthsMatch ? "ok" : "differs");
                 out << line;
@@ -1279,7 +1302,22 @@ std::string formatReport(const std::vector<CaseReport>& cases, const CaseEnviron
             }
         }
 
-        out << (report.passed ? "  ok" : "  FAIL");
+        // Three verdicts rather than two. A case that did not run is not a
+        // pass and is not a failure, and printing it as either would be the
+        // report lying about what this run established.
+        if (!report.absentPlugins.empty())
+            out << "  --";
+        else
+            out << (report.passed ? "  ok" : "  FAIL");
+
+        // Never dropped, whatever the verdict was. A plugin that starts
+        // asserting where it did not is worth seeing even on a case that
+        // cannot conclude anything from it.
+        if (!report.hostedAssertions.empty()) {
+            out << "  hosted plugin asserted: " << report.hostedAssertions.front();
+            if (report.hostedAssertions.size() > 1)
+                out << " (and " << (report.hostedAssertions.size() - 1) << " more)";
+        }
 
         // Only where it deviates. A number measured at another rate, another
         // block size or another seed is a number about a different render, and

--- a/tests/NullDiffCompare.cpp
+++ b/tests/NullDiffCompare.cpp
@@ -743,6 +743,13 @@ InvariantComparison compareInvariants(const juce::AudioBuffer<float>& native,
         return result;
     }
 
+    // And the same for liveness, which is the check the rest of this tier
+    // cannot stand in for: every other question here is answered by silence.
+    if (!std::isfinite(options.minPeakDb)) {
+        result.refusal = "no liveness floor declared";
+        return result;
+    }
+
     result.lengthsMatch = native.getNumSamples() == incumbent.getNumSamples();
     if (!result.lengthsMatch)
         result.problems.push_back("lengths differ: native " +
@@ -828,6 +835,28 @@ InvariantComparison compareInvariants(const juce::AudioBuffer<float>& native,
                                       channel, begin, static_cast<int>(samples))));
         return toDb(peak);
     };
+
+    // Liveness, per side. Ahead of the tail because it is the question the tail
+    // cannot be asked in place of: a render that never started has decayed by
+    // the end of itself.
+    const auto peakOf = [](const juce::AudioBuffer<float>& buffer) {
+        auto peak = 0.0;
+        for (auto channel = 0; channel < buffer.getNumChannels(); ++channel)
+            peak = std::max(
+                peak, static_cast<double>(buffer.getMagnitude(channel, 0, buffer.getNumSamples())));
+        return toDb(peak);
+    };
+
+    result.peakNativeDb = peakOf(native);
+    result.peakIncumbentDb = peakOf(incumbent);
+    result.bothSound =
+        result.peakNativeDb >= options.minPeakDb && result.peakIncumbentDb >= options.minPeakDb;
+
+    if (!result.bothSound)
+        result.problems.push_back("a render did not sound: native " +
+                                  formatDb(result.peakNativeDb) + " dBFS, incumbent " +
+                                  formatDb(result.peakIncumbentDb) + " dBFS, floor " +
+                                  formatDb(options.minPeakDb) + " dBFS");
 
     result.tailPeakNativeDb = tailPeak(native);
     result.tailPeakIncumbentDb = tailPeak(incumbent);
@@ -1260,7 +1289,8 @@ std::string formatReport(const std::vector<CaseReport>& cases, const CaseEnviron
             if (report.hasInvariants) {
                 const auto& invariants = report.invariants;
                 std::snprintf(
-                    line, sizeof(line), "step=%-9s tail=%-9s length=%-8s",
+                    line, sizeof(line), "peak=%-9s step=%-9s tail=%-9s length=%-8s",
+                    formatDb(std::min(invariants.peakNativeDb, invariants.peakIncumbentDb)).c_str(),
                     formatDb(
                         toDb(std::max(invariants.worstStepNative, invariants.worstStepIncumbent)))
                         .c_str(),

--- a/tests/NullDiffCompare.hpp
+++ b/tests/NullDiffCompare.hpp
@@ -286,6 +286,19 @@ struct InvariantOptions {
     /// not see it if both engines leaked alike.
     double tailSeconds = 0.05;
     double tailFloorDb = -60.0;
+
+    /// Whether the tail is a question this pair can be asked (#2175).
+    ///
+    /// It is a question about what is left running after the material stops, so
+    /// it can only be asked of a render that goes past the material. A real
+    /// project's arrangement is minutes long and the corpus renders eight beats
+    /// of it, which ends in the middle of a clip: what is in the last fifty
+    /// milliseconds there is the music, and reporting it as a leak would be the
+    /// check misreading the case.
+    ///
+    /// Measured either way and printed either way. What changes is whether the
+    /// number is a verdict.
+    bool asksForTail = true;
 };
 
 struct InvariantComparison {
@@ -293,6 +306,12 @@ struct InvariantComparison {
     bool lengthsMatch = false;
     bool continuous = false;
     bool tailDecays = false;
+
+    /// Whether the tail was asked about at all (InvariantOptions::asksForTail).
+    /// Kept beside the answer rather than folded into it, because a tail that
+    /// held and a tail nobody asked about are different facts and only one of
+    /// them is evidence.
+    bool tailAsked = true;
 
     /// The worst step found, and where, per side. Printed whether or not the
     /// bound held: a step creeping towards the bound is worth seeing before it
@@ -311,7 +330,8 @@ struct InvariantComparison {
     std::vector<std::string> problems;
 
     bool passed() const {
-        return refusal.empty() && finite && lengthsMatch && continuous && tailDecays;
+        return refusal.empty() && finite && lengthsMatch && continuous &&
+               (!tailAsked || tailDecays);
     }
 };
 
@@ -509,6 +529,22 @@ struct CaseEnvironment {
     int channels = 2;
     std::uint32_t seed = 0;
 
+    /// The external plugins this render actually ran, as name, version and
+    /// format, in the order the plan reached them.
+    ///
+    /// The one field here that is discovered rather than declared, and it has to
+    /// be: a case cannot name a version, because the version is a fact about the
+    /// machine that ran it and a corpus that asserted one would fail everywhere
+    /// but the desk it was written on. What it is for is the same as the rest of
+    /// the block -- a residual that is really an environment difference is the
+    /// worst failure a parity corpus can have -- and a plugin is the environment
+    /// difference most likely to move without anyone touching the engine. Two
+    /// runs of the same project that disagree, with two versions of Retrospect
+    /// printed beside them, is a question answered by reading the report.
+    ///
+    /// Empty for a project of internal devices, which is most of the corpus.
+    std::vector<std::string> plugins;
+
     bool operator==(const CaseEnvironment&) const = default;
 };
 
@@ -552,6 +588,38 @@ struct CaseReport {
     /// because a race reported as a parity failure costs somebody a day inside
     /// the engine looking for it.
     std::string unmeasurable;
+
+    /// What fired on the assertion watch while this case ran, on a case that
+    /// loaded a plugin somebody else wrote into this process (#2175).
+    ///
+    /// Recorded rather than held against the case, and the reason is the one
+    /// thing that is different about these three cases: the assertion hook is
+    /// process-wide, and this process now contains code this project did not
+    /// write. Retrospect is an LV2 plugin behind a VST3 shell and hands JUCE its
+    /// own URI where a path is expected, once per instantiation; that is a fact
+    /// about Retrospect, and reporting it as "the engine objected to its own
+    /// graph" would be the corpus asserting something it cannot know.
+    ///
+    /// A case with no hosted plugin keeps the strict rule, where the premise
+    /// holds: everything that asserts is the engine or the harness.
+    ///
+    /// Never dropped. It goes on the case's line, because a plugin that starts
+    /// asserting where it did not is worth seeing even when nothing can be
+    /// concluded from it.
+    std::vector<std::string> hostedAssertions;
+
+    /// The external plugins this case's project names and this machine has not
+    /// scanned, which is why it did not run (#2175).
+    ///
+    /// A third outcome, and it needs to be one. A project rendered without its
+    /// plugin is a different project: both legs would host nothing in that slot
+    /// and null against each other perfectly, which is a case passing by having
+    /// tested less than it claims -- the one outcome this corpus exists to
+    /// refuse. So it is never green. Nor is it a complaint like @ref
+    /// unmeasurable, because it is not a fact about the engine or the harness:
+    /// it is a fact about which plugins are on this desk, and every CI runner
+    /// has none of them. It is printed, counted, and left at that.
+    std::vector<std::string> absentPlugins;
 
     bool passed = false;
 };

--- a/tests/NullDiffCompare.hpp
+++ b/tests/NullDiffCompare.hpp
@@ -280,6 +280,26 @@ struct InvariantOptions {
     /// exists to catch.
     double maxStepPerSample = 0.0;
 
+    /// The peak each render has to reach, on its own, for the pair to have been
+    /// worth comparing at all.
+    ///
+    /// Required, and the tier is refused without it, for the same reason the
+    /// step bound is: this tier computes no residual, so nothing else here would
+    /// notice one side going silent. Every other check passes on silence --
+    /// silence is finite, it is the same length as anything, it steps by nothing
+    /// and it has decayed by the end -- so an invariants case with a dead native
+    /// leg and a sounding incumbent would report ok, which is the exact failure
+    /// the residual tiers catch for free and this one cannot.
+    ///
+    /// Asked of each side rather than of the pair. Two silences agreeing is
+    /// already refused upstream; what this adds is one silence, which is the
+    /// shape a device that stopped rendering actually has.
+    ///
+    /// A liveness floor rather than a level assertion. It is set far below what
+    /// a project renders and far above what a broken one does, because what it
+    /// is for is the difference between a render and nothing.
+    double minPeakDb = std::numeric_limits<double>::infinity();
+
     /// The tail is the last @p tailSeconds of the render, and it has to have
     /// decayed below @p tailFloorDb. A device left running past the end of its
     /// material is how a graph transition leaks, and a residual comparison would
@@ -313,6 +333,15 @@ struct InvariantComparison {
     /// them is evidence.
     bool tailAsked = true;
 
+    /// Whether each render, on its own, reached the peak the case declared
+    /// (InvariantOptions::minPeakDb).
+    bool bothSound = false;
+
+    /// What each side actually peaked at. Printed whether or not it held: a
+    /// level drifting towards the floor is worth seeing before it arrives.
+    double peakNativeDb = -std::numeric_limits<double>::infinity();
+    double peakIncumbentDb = -std::numeric_limits<double>::infinity();
+
     /// The worst step found, and where, per side. Printed whether or not the
     /// bound held: a step creeping towards the bound is worth seeing before it
     /// crosses it.
@@ -330,7 +359,7 @@ struct InvariantComparison {
     std::vector<std::string> problems;
 
     bool passed() const {
-        return refusal.empty() && finite && lengthsMatch && continuous &&
+        return refusal.empty() && finite && lengthsMatch && continuous && bothSound &&
                (!tailAsked || tailDecays);
     }
 };

--- a/tests/NullDiffCorpus.cpp
+++ b/tests/NullDiffCorpus.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <array>
 #include <cmath>
 #include <functional>
@@ -10,6 +11,7 @@
 #include "core/DeviceInfo.hpp"
 #include "core/SourcePool.hpp"
 #include "core/TimeStretchModes.hpp"
+#include "magda/daw/audio/plugins/engine/EngineDeviceFactory.hpp"
 
 /**
  * The corpus itself (#2040): every case, as model values.
@@ -35,6 +37,8 @@
  * reverse job, so the markers are silently lost. There is nothing to diff, and
  * the case would be asserting that the engine reproduces a bug.
  */
+
+namespace adapter = ::magda::daw::audio::engine_adapter;
 
 namespace magda::nulldiff {
 
@@ -2139,25 +2143,33 @@ std::vector<Case> buildCorpus(const juce::File& scratchDirectory) {
     return corpus;
 }
 
-std::vector<std::string> externalDevicesIn(const Case& value) {
-    std::vector<std::string> external;
-
-    // The model's own walk, because a rack is a chain of chains and a plugin four
-    // levels down frames its own work exactly like one at the top. A walk that
-    // stopped at the first level would report a rack full of plugins as an
-    // internal project and hold it to bit identity, which is the one way this
-    // can be wrong in the direction nobody notices: the gate would fail, and the
-    // failure would name no cause.
-    //
-    // Pads::Enter for the same reason one level further in. A Drum Grid's pads
-    // are chains of devices, and a kit built out of hosted plugins is a project
-    // this would otherwise call internal.
-    const auto walk = [&external](const std::vector<ChainElement>& elements, TrackId trackId) {
+/**
+ * @brief Every external device @p value hosts, wherever it sits, in chain order.
+ *
+ * The model's own walk, because a rack is a chain of chains and a plugin four
+ * levels down frames its own work exactly like one at the top. A walk that
+ * stopped at the first level would report a rack full of plugins as an internal
+ * project and hold it to bit identity, which is the one way this can be wrong in
+ * the direction nobody notices: the gate would fail, and the failure would name
+ * no cause.
+ *
+ * Pads::Enter for the same reason one level further in. A Drum Grid's pads are
+ * chains of devices, and a kit built out of hosted plugins is a project this
+ * would otherwise call internal.
+ *
+ * Shared by the two questions asked of a project's plugins -- what could account
+ * for a difference, and which of them this machine does not have -- because two
+ * walks would eventually disagree about where a plugin can hide, and the one
+ * that missed a place would be the one deciding a case is safe to hold to bit
+ * identity.
+ */
+void forEachExternalDevice(const Case& value, const std::function<void(const DeviceInfo&)>& visit) {
+    const auto walk = [&visit](const std::vector<ChainElement>& elements, TrackId trackId) {
         chain_walk::forEachDevice(elements, ChainNodePath::trackLevel(trackId),
                                   chain_walk::Pads::Enter,
-                                  [&external](const DeviceInfo& device, const ChainNodePath&) {
+                                  [&visit](const DeviceInfo& device, const ChainNodePath&) {
                                       if (device.format != PluginFormat::Internal)
-                                          external.push_back(device.name.toStdString());
+                                          visit(device);
                                   });
     };
 
@@ -2172,7 +2184,7 @@ std::vector<std::string> externalDevicesIn(const Case& value) {
              {&track.chain.postFxChainElements, &track.chain.mixerAnalysisElements})
             for (const auto& element : *stage) {
                 if (element.device.format != PluginFormat::Internal)
-                    external.push_back(element.device.name.toStdString());
+                    visit(element.device);
 
                 if (element.device.pads)
                     for (const auto& pad : element.device.pads->chains)
@@ -2184,8 +2196,39 @@ std::vector<std::string> externalDevicesIn(const Case& value) {
         walkTrack(track);
 
     walkTrack(value.master);
+}
+
+std::vector<std::string> externalDevicesIn(const Case& value) {
+    std::vector<std::string> external;
+
+    forEachExternalDevice(value, [&external](const DeviceInfo& device) {
+        external.push_back(device.name.toStdString());
+    });
 
     return external;
+}
+
+std::vector<std::string> absentPluginsIn(const Case& value,
+                                         const juce::KnownPluginList* knownPlugins) {
+    std::vector<std::string> absent;
+
+    forEachExternalDevice(value, [&](const DeviceInfo& device) {
+        // No scan at all is not a special case: nothing is installed, so every
+        // plugin the project names is absent. That is the state every CI runner
+        // is in, and it is the one this has to get right without a flag.
+        if (knownPlugins != nullptr && adapter::isInstalledExternalPlugin(device, *knownPlugins))
+            return;
+
+        // Once each, unlike externalDevicesIn beside it, and the difference is
+        // the question. That one asks what could account for a difference and
+        // wants every instance in chain order; this one asks what this machine
+        // does not have, which a plugin hosted twice does not answer twice.
+        auto name = device.name.toStdString();
+        if (std::find(absent.begin(), absent.end(), name) == absent.end())
+            absent.push_back(std::move(name));
+    });
+
+    return absent;
 }
 
 const std::vector<Case>& sharedCorpus(const juce::File& scratchDirectory) {

--- a/tests/NullDiffNativeLeg.cpp
+++ b/tests/NullDiffNativeLeg.cpp
@@ -276,16 +276,34 @@ bool isExternalDevice(const magda::DeviceInfo& device) {
  * reports the same answer, and one diagnostic per absent plugin is what a
  * reader wants.
  */
-void resolveExternalDevices(std::vector<TrackInfo>& tracks, TrackInfo& master,
-                            const adapter::ExternalPluginServices& services) {
+std::map<DeviceKey, std::string> resolveExternalDevices(
+    std::vector<TrackInfo>& tracks, TrackInfo& master,
+    const adapter::ExternalPluginServices& services) {
+    std::map<DeviceKey, std::string> identities;
+
     for (auto& [key, device] : devicesIn(tracks, master)) {
         if (!isExternalDevice(*device))
             continue;
 
         auto resolved = adapter::resolveEngineExternalPlugin(*device, services);
-        if (resolved)
-            *device = std::move(resolved.planDevice);
+        if (!resolved)
+            continue;
+
+        // What the scan actually matched, kept for the report. The project's
+        // own name for the device is not the answer: a project names what its
+        // author called the slot, and what the render ran is whichever build of
+        // whichever plugin this machine matched it to.
+        const auto& description = resolved.description;
+        identities.emplace(key, (description.name + " " +
+                                 (description.version.isNotEmpty() ? description.version
+                                                                   : juce::String("no version")) +
+                                 " (" + description.pluginFormatName + ")")
+                                    .toStdString());
+
+        *device = std::move(resolved.planDevice);
     }
+
+    return identities;
 }
 
 /// The keys of the Device ops @p plan emits, which is which of a project's
@@ -480,7 +498,7 @@ NativeRender renderNative(const Case& value, const InstalledPlugins& installed) 
     // route MIDI to the wrong places before any plugin was created.
     auto tracks = value.tracks;
     auto master = value.master;
-    resolveExternalDevices(tracks, master, services);
+    const auto identities = resolveExternalDevices(tracks, master, services);
 
     CompileOptions options;
     options.deviceMeters = false;
@@ -494,6 +512,18 @@ NativeRender renderNative(const Case& value, const InstalledPlugins& installed) 
     // is every case in the code-built corpus.
     auto externals = createExternalDevices(
         tracks, master, deviceKeysIn(compileRenderPlan(tracks, master, options)), services);
+
+    // What the render actually ran, for the report's environment line. Read off
+    // the created set rather than the resolved one: resolution answers every
+    // external device in the project, and the ones that reached a plan op and
+    // loaded are the ones that made a sound.
+    for (const auto& [key, created] : externals) {
+        if (created.device == nullptr)
+            continue;
+
+        if (const auto identity = identities.find(key); identity != identities.end())
+            result.plugins.push_back(identity->second);
+    }
 
     const auto plan = compileRenderPlan(tracks, master, options);
     for (const auto& diagnostic : plan.diagnostics)

--- a/tests/NullDiffNativeLeg.hpp
+++ b/tests/NullDiffNativeLeg.hpp
@@ -92,6 +92,19 @@ struct NativeRender {
     int starvedVoices = 0;
     int droppedMidiEvents = 0;
 
+    /// What each external plugin the render actually reached resolved to on
+    /// this machine: name, version and format.
+    ///
+    /// Read back from the scan rather than declared, because a version is a
+    /// fact about the machine. It goes on the case's environment line, where a
+    /// residual that is really a plugin update can be seen for what it is
+    /// (CaseEnvironment::plugins).
+    ///
+    /// Only the devices the plan reached and the factory built. A plugin on a
+    /// bypassed chain is not instantiated, and a report claiming a project ran
+    /// one it never loaded would be worse than one that said nothing.
+    std::vector<std::string> plugins;
+
     /// The most material any of this case's stretchers is primed with, in
     /// samples of the reading.
     ///

--- a/tests/NullDiffRunner.cpp
+++ b/tests/NullDiffRunner.cpp
@@ -531,6 +531,7 @@ CaseReport runCase(const Case& value, const RunnerLog& log) {
         InvariantOptions options;
         options.sampleRate = value.sampleRate;
         options.maxStepPerSample = value.maxStepPerSample;
+        options.minPeakDb = value.minPeakDb;
         options.asksForTail = value.rendersPastItsMaterial;
 
         report.hasInvariants = true;
@@ -647,35 +648,67 @@ SuiteRun runSuite(const std::vector<Case>& cases, const RunnerLog& log) {
         // proxy that never arrived is: the number would be about something
         // other than parity, and it would look like a parity failure.
         //
-        // Unless this case loaded a plugin somebody else wrote. The watch is a
-        // process-wide hook and it cannot tell whose code raised what, and that
-        // premise -- everything that asserts here is the engine or the harness
-        // -- is true of every case in the corpus but the three that host a
-        // plugin (#2175). Retrospect is an LV2 plugin behind a VST3 shell and
-        // hands JUCE its own URI where a path is expected, once per
-        // instantiation. Condemning the case for it would make a fact about
-        // Retrospect read as a fact about the engine, and would leave the case
-        // unmeasurable on every machine that has the plugin, which is the only
-        // kind of machine that can measure it.
+        // Except the ones the case named. The watch is a process-wide hook and it
+        // cannot tell whose code raised what, so on a case that loads somebody
+        // else's code into this process the premise above -- everything that
+        // asserts here is the engine or the harness -- stops being true.
         //
-        // Recorded and printed either way. Nothing is dropped; what changes is
-        // what it is allowed to conclude.
+        // Named one at a time rather than waived by the presence of a plugin.
+        // "This project hosts a VST3" is not evidence about who asserted: a
+        // waiver keyed on it would forgive a genuine engine regression on
+        // exactly the three cases worth adding, and would forgive it for a
+        // plugin on a bypassed chain that the render never instantiated.
+        // Retrospect hands JUCE its own URI where a path is expected, once per
+        // instantiation, and that one sentence is what the case declares.
+        //
+        // Recorded and printed either way, whichever side it falls on. Nothing
+        // is dropped; what changes is what it is allowed to conclude.
         if (auto fired = watch.take(); !fired.empty()) {
-            const auto hosted = !externalDevicesIn(value).empty();
+            auto unexplained = std::vector<juce::String>{};
 
-            for (const auto& assertion : fired)
-                log("  " + juce::String(value.name) + (hosted ? " (hosting): " : ": ") + assertion);
+            for (const auto& assertion : fired) {
+                const auto named = std::any_of(
+                    value.expectedHostedAssertions.begin(), value.expectedHostedAssertions.end(),
+                    [&assertion](const std::string& expected) {
+                        return assertion.toStdString().find(expected) != std::string::npos;
+                    });
 
-            if (hosted) {
-                for (const auto& assertion : fired)
+                log("  " + juce::String(value.name) + (named ? " (hosted): " : ": ") + assertion);
+
+                if (named)
                     report.hostedAssertions.push_back(assertion.toStdString());
-            } else {
+                else
+                    unexplained.push_back(assertion);
+            }
+
+            if (!unexplained.empty()) {
                 report.passed = false;
                 report.unmeasurable =
-                    "the engine asserted while rendering: " + fired.front().toStdString() +
-                    (fired.size() > 1 ? " (and " + std::to_string(fired.size() - 1) + " more)"
-                                      : "");
+                    "the engine asserted while rendering: " + unexplained.front().toStdString() +
+                    (unexplained.size() > 1
+                         ? " (and " + std::to_string(unexplained.size() - 1) + " more)"
+                         : "");
                 run.asserted.insert(value.name);
+            }
+        }
+
+        // And the other direction, the same rule the declared diagnostics live
+        // by: a plugin that stops asserting where it did has to come off the
+        // case, or the declaration sits there forgiving something that no
+        // longer happens.
+        if (!value.expectedHostedAssertions.empty() && report.absentPlugins.empty()) {
+            for (const auto& expected : value.expectedHostedAssertions) {
+                const auto seen =
+                    std::any_of(report.hostedAssertions.begin(), report.hostedAssertions.end(),
+                                [&expected](const std::string& assertion) {
+                                    return assertion.find(expected) != std::string::npos;
+                                });
+
+                if (!seen) {
+                    report.passed = false;
+                    report.unmeasurable = "the case expects the hosted plugin to assert \"" +
+                                          expected + "\", and it did not";
+                }
             }
         }
 

--- a/tests/NullDiffRunner.cpp
+++ b/tests/NullDiffRunner.cpp
@@ -1,12 +1,14 @@
 #include "NullDiffRunner.hpp"
 
 #include <juce_audio_formats/juce_audio_formats.h>
+#include <juce_audio_processors/juce_audio_processors.h>
 
 #include <algorithm>
 #include <chrono>
 #include <cmath>
 #include <map>
 #include <memory>
+#include <set>
 
 #include "AssertionWatch.hpp"
 #include "NullDiffNativeLeg.hpp"
@@ -23,11 +25,6 @@ namespace {
  * that is what the app does. The native leg is handed the same one rather than
  * a list of its own: two legs that each found their own copy of a plugin would
  * be rendering two projects and calling the difference an engine bug.
- *
- * It is whatever this machine has scanned, which is the point. A developer's
- * machine has the plugins the corpus projects were authored with and measures
- * them; a runner that has none reports every case that names one as
- * unmeasurable, which is the honest answer rather than a green one (#2175).
  */
 InstalledPlugins installedPlugins() {
     auto* engine = magda::test::getSharedEngine().getEngine();
@@ -36,6 +33,101 @@ InstalledPlugins installedPlugins() {
 
     auto& plugins = engine->getPluginManager();
     return {.formats = &plugins.pluginFormatManager, .knownPlugins = &plugins.knownPluginList};
+}
+
+/**
+ * @brief Look on this machine for the plugins @p wanted names, once each.
+ *
+ * The corpus finds its own plugins rather than reading the app's scan, and it
+ * has to. A test binary runs under a sandboxed HOME (the Makefile's TEST_ENV),
+ * so the application data directory the app keeps its KnownPluginList in is not
+ * this machine's -- and it must not be, because a suite whose verdict depended
+ * on what the developer last clicked in a scan dialog is not a suite. Left
+ * alone, the list is empty on every machine, and every project hosting a plugin
+ * would be reported not run for ever: a gate that is always closed tests as
+ * little as one that is always open.
+ *
+ * What is left is the machine itself, which is the honest source anyway. The
+ * question these cases ask is whether this machine has the plugin, and the
+ * plugin folders are where that is answered.
+ *
+ * Directed rather than exhaustive, and that is the safety. A full scan loads
+ * every bundle installed, which is minutes on a desk with a library on it and
+ * one bad plugin away from taking the suite down with it -- which is why the app
+ * scans out of process. This walks the folders, which is cheap, and then loads
+ * only the bundles whose name matches one a corpus project asked for: three
+ * files at most, all of them named in a manifest somebody wrote.
+ *
+ * Added to the engine's own list rather than to one of its own, because the
+ * incumbent leg reads that one and two legs reading two lists are two projects.
+ */
+void findPluginsFor(const std::vector<std::string>& wanted) {
+    // Once per name for the whole run, whether or not it was found. A name that
+    // is not on this machine is not on it the second time either, and the walk
+    // is the expensive half.
+    static std::set<std::string> searched;
+
+    std::vector<std::string> unsearched;
+    for (const auto& name : wanted)
+        if (searched.insert(name).second)
+            unsearched.push_back(name);
+
+    if (unsearched.empty())
+        return;
+
+    auto* engine = magda::test::getSharedEngine().getEngine();
+    if (engine == nullptr)
+        return;
+
+    auto& plugins = engine->getPluginManager();
+    auto& formats = plugins.pluginFormatManager;
+    auto& known = plugins.knownPluginList;
+
+    // A project names a plugin what its author's host called it, and a bundle is
+    // named what its vendor called the file. Those agree often and not always:
+    // FabFilter ships "Pro-L 2" inside "FabFilter Pro-L 2.vst3". So the match is
+    // containment in either direction, folded for case.
+    //
+    // Loose on purpose, and it can only be loose in one direction that matters.
+    // A false match costs one bundle loaded that resolution then declines,
+    // because matchInstalledPlugin has the project's own identifier to check
+    // against and this does not; a missed match costs a case that never runs on
+    // a machine that could have measured it.
+    const auto matches = [&unsearched](const juce::String& identifier) {
+        const auto file = juce::File::createFileWithoutCheckingPath(identifier);
+        const auto base =
+            (file.exists() ? file.getFileNameWithoutExtension() : identifier).toLowerCase();
+
+        return std::any_of(unsearched.begin(), unsearched.end(), [&base](const std::string& name) {
+            const auto folded = juce::String(name).toLowerCase();
+            return folded.isNotEmpty() && (base.contains(folded) || folded.contains(base));
+        });
+    };
+
+    for (int index = 0; index < formats.getNumFormats(); ++index) {
+        auto* format = formats.getFormat(index);
+        if (format == nullptr)
+            continue;
+
+        // The walk, which reads directory entries and loads nothing.
+        const auto found =
+            format->searchPathsForPlugins(format->getDefaultLocationsToSearch(), true);
+
+        for (const auto& identifier : found) {
+            if (!matches(identifier))
+                continue;
+
+            // And the load, for the handful that matched. This is the step the
+            // app runs out of process; in here it is a named bundle rather than
+            // a library, and a plugin that cannot survive being asked what it is
+            // would not have survived the render either.
+            juce::OwnedArray<juce::PluginDescription> descriptions;
+            format->findAllTypesForFile(descriptions, identifier);
+
+            for (const auto* description : descriptions)
+                known.addType(*description);
+        }
+    }
 }
 
 /// The largest magnitude anywhere in @p buffer, which is all the silence guard
@@ -223,8 +315,28 @@ CaseReport runCase(const Case& value, const RunnerLog& log) {
     report.tier = value.tier;
     report.environment = value.environment();
 
-    const auto native = renderNative(value, installedPlugins());
+    // Looked for before the scan is read, so that "this machine has not scanned
+    // it" is a fact about the machine rather than about the binary.
+    findPluginsFor(externalDevicesIn(value));
+
+    const auto installed = installedPlugins();
+
+    // Asked before either leg is driven, because the answer decides whether
+    // there is anything worth driving them for. A project rendered without the
+    // plugin it names is a different project, and two legs rendering it without
+    // the plugin null perfectly (NullDiffCase.hpp).
+    report.absentPlugins = absentPluginsIn(value, installed.knownPlugins);
+    if (!report.absentPlugins.empty())
+        return report;
+
+    const auto native = renderNative(value, installed);
     const auto incumbent = renderIncumbent(value);
+
+    // What the render ran, whatever the comparison goes on to say. Written
+    // before the early returns below so that a case that turns out to be
+    // unmeasurable still prints which plugins it had, which is the first thing
+    // worth knowing about one that stopped being measurable.
+    report.environment.plugins = native.plugins;
 
     // A leg that could not render is never reported as a residual.
     if (!native.failure.empty()) {
@@ -419,6 +531,7 @@ CaseReport runCase(const Case& value, const RunnerLog& log) {
         InvariantOptions options;
         options.sampleRate = value.sampleRate;
         options.maxStepPerSample = value.maxStepPerSample;
+        options.asksForTail = value.rendersPastItsMaterial;
 
         report.hasInvariants = true;
         report.invariants = compareInvariants(native.audio, incumbent.audio, options);
@@ -533,21 +646,52 @@ SuiteRun runSuite(const std::vector<Case>& cases, const RunnerLog& log) {
         // unmeasurable rather than as a residual, for the same reason a
         // proxy that never arrived is: the number would be about something
         // other than parity, and it would look like a parity failure.
+        //
+        // Unless this case loaded a plugin somebody else wrote. The watch is a
+        // process-wide hook and it cannot tell whose code raised what, and that
+        // premise -- everything that asserts here is the engine or the harness
+        // -- is true of every case in the corpus but the three that host a
+        // plugin (#2175). Retrospect is an LV2 plugin behind a VST3 shell and
+        // hands JUCE its own URI where a path is expected, once per
+        // instantiation. Condemning the case for it would make a fact about
+        // Retrospect read as a fact about the engine, and would leave the case
+        // unmeasurable on every machine that has the plugin, which is the only
+        // kind of machine that can measure it.
+        //
+        // Recorded and printed either way. Nothing is dropped; what changes is
+        // what it is allowed to conclude.
         if (auto fired = watch.take(); !fired.empty()) {
-            report.passed = false;
-            report.unmeasurable =
-                "the engine asserted while rendering: " + fired.front().toStdString() +
-                (fired.size() > 1 ? " (and " + std::to_string(fired.size() - 1) + " more)" : "");
-            run.asserted.insert(value.name);
+            const auto hosted = !externalDevicesIn(value).empty();
 
             for (const auto& assertion : fired)
-                log("  " + juce::String(value.name) + ": " + assertion);
+                log("  " + juce::String(value.name) + (hosted ? " (hosting): " : ": ") + assertion);
+
+            if (hosted) {
+                for (const auto& assertion : fired)
+                    report.hostedAssertions.push_back(assertion.toStdString());
+            } else {
+                report.passed = false;
+                report.unmeasurable =
+                    "the engine asserted while rendering: " + fired.front().toStdString() +
+                    (fired.size() > 1 ? " (and " + std::to_string(fired.size() - 1) + " more)"
+                                      : "");
+                run.asserted.insert(value.name);
+            }
         }
 
-        if (!report.passed)
-            run.failing.insert(report.name);
-        if (!report.unmeasurable.empty())
-            run.unmeasurable.insert(report.name);
+        // A case that never ran is neither failing nor unmeasurable. Both of
+        // those are complaints -- one says the engines disagree, the other says
+        // the harness could not tell -- and an absent plugin is neither: it is a
+        // fact about which plugins are on this machine, and the machine every
+        // release is built on has none of them.
+        if (!report.absentPlugins.empty()) {
+            run.notRun.insert(report.name);
+        } else {
+            if (!report.passed)
+                run.failing.insert(report.name);
+            if (!report.unmeasurable.empty())
+                run.unmeasurable.insert(report.name);
+        }
 
         run.reports.push_back(std::move(report));
     }

--- a/tests/NullDiffRunner.hpp
+++ b/tests/NullDiffRunner.hpp
@@ -107,6 +107,15 @@ struct SuiteRun {
     std::set<std::string> failing;
     std::set<std::string> unmeasurable;
 
+    /// Never rendered, because the project names a plugin this machine has not
+    /// scanned (#2175).
+    ///
+    /// Kept apart from the three above because it is not a complaint. Those are
+    /// things wrong with the engine or with the harness; this is a fact about
+    /// which plugins are installed, and every CI runner has none. A suite reads
+    /// it to print what it did not cover, not to fail.
+    std::set<std::string> notRun;
+
     /// Wall clock per case, in milliseconds, both legs and the comparison.
     ///
     /// Recorded on every run rather than under a flag, because #2081's open

--- a/tests/corpus/legacy/README.md
+++ b/tests/corpus/legacy/README.md
@@ -47,9 +47,9 @@ nulls against silence perfectly well.
 ## Reuse here, or save new elsewhere
 
 The render corpus (#2081) decides, per project, whether to reuse one of these or
-save its own. Seven of the twenty-two are reused today and none has yet needed
+save its own. Ten of the twenty-two are reused today and none has yet needed
 one saved for it; `tests/MgdFixtures.cpp` carries the table and says why the
-other fifteen are out. The rule, recorded per fixture in
+other twelve are out. The rule, recorded per fixture in
 `MgdFixture::isMigrationFixture`:
 
 **Reuse where a project earns its place by being a real arrangement** that
@@ -57,16 +57,21 @@ nobody would have written down. That is the whole value of this directory:
 eight tracks carrying sixty-eight MIDI clips, one audio clip and an automation
 lane is a shape a hand-written case never has.
 
-**Never reuse one that hosts a plugin.** Roughly half of these do: retrovid and
-envfollower carry Retrospect, groups carries Pro-L 2, overlaps carries Pianoteq.
-A project with a VST3 in it has no verdict a null-diff corpus can hold it to.
-Without the plugin installed both legs render a passthrough and pass by agreeing
-about nothing; with it installed the incumbent hosts it and the native engine
-cannot, so whether the case passes becomes a fact about the machine that ran it.
-Those projects belong to #2175, with the invariant tier and a gate that calls an
-absent plugin unmeasurable rather than equal. The fixture rig refuses them
-outright, because a tier is a field somebody fills in and the plugin format is a
-fact about the file.
+**Reuse one that hosts a plugin only with the declaration that goes with it.**
+Roughly half of these do: retrovid and envfollower carry Retrospect, groups
+carries Pro-L 2, overlaps carries Pianoteq. Three of them are fixtures now
+(#2175); what makes that possible is that the native engine hosts a VST3 (#1893)
+and that the two things a plugin project cannot pretend about are declared.
+
+A project with a VST3 in it has no null a corpus can hold it to: a plugin frames
+its own work, so it renders at `AudioTier::Invariants` and the fixture is refused
+if it asks for anything else. And a project rendered without the plugin it names
+is a different project -- both legs bind nothing in that slot and null against
+each other perfectly -- so `MgdFixture::hostedPlugins` names them, the rig
+refuses a plugin the manifest missed and a name no device claims, and the runner
+does not render the case at all on a machine that has not scanned one. Every CI
+runner is such a machine, which is why those three are reported not run there
+rather than green.
 
 **Save new where the material has to be designed.** A fixture reused from here
 can never be asked for one bar more, for a source that suits a case better, or

--- a/tests/engine/test_mgd_fixture_rig.cpp
+++ b/tests/engine/test_mgd_fixture_rig.cpp
@@ -1,5 +1,6 @@
 #include <juce_audio_formats/juce_audio_formats.h>
 
+#include <algorithm>
 #include <catch2/catch_test_macros.hpp>
 #include <map>
 #include <set>
@@ -226,32 +227,69 @@ TEST_CASE("Two fixtures held at once both stay resolvable", "[nulldiff][fixture]
     CHECK(eventsResolve(second.value));
 }
 
-TEST_CASE("A project that hosts a plugin is not a fixture here", "[nulldiff][fixture]") {
+TEST_CASE("A project that hosts a plugin has to declare it", "[nulldiff][fixture]") {
     const PooledSourcesUnwind unwind;
 
-    // Half the legacy corpus hosts one, and none of it can be held to a null:
-    // without the plugin installed both legs render a passthrough and agree
-    // about nothing, and with it installed only one leg can host it. #2175 is
-    // where those go.
-    //
-    // Asserted against a real one rather than described, because the rule is
-    // about what is in the file and the file is right here.
-    MgdFixture hosted;
-    hosted.file = "legacy/projects/0.13.0-retrovid.mgd";
-    hosted.savedBy = "0.13.0-rc1";
-    hosted.declaration = mgdFixtures().front().declaration;
-    hosted.declaration.name = "project.hosted";
+    // A plugin in a project used to be an outright refusal (#2175 lifted it),
+    // and what replaced it is a declaration checked in both directions. The
+    // specimen is the real project rather than a described one, because the rule
+    // is about what is in the file and the file is right here.
+    const auto retrospect =
+        std::find_if(mgdFixtures().begin(), mgdFixtures().end(),
+                     [](const auto& f) { return f.declaration.name == "project.retrospect"; });
+    REQUIRE(retrospect != mgdFixtures().end());
+    REQUIRE_FALSE(retrospect->hostedPlugins.empty());
 
-    const auto loaded = loadFixture(hosted, scratch());
-    CHECK_FALSE(loaded.ok);
-    CHECK(loaded.failure.find("Retrospect") != std::string::npos);
+    SECTION("a plugin the manifest does not name is refused") {
+        // The failure this rule is built around: a project acquires a plugin the
+        // day somebody replaces its bytes, and that is exactly the day nobody
+        // rereads the manifest.
+        auto undeclared = *retrospect;
+        undeclared.hostedPlugins.clear();
 
-    // And no fixture the corpus actually carries trips it.
-    for (const auto& fixture : mgdFixtures()) {
-        INFO(fixture.file);
-        const auto good = loadFixture(fixture, scratch());
-        INFO(good.failure);
-        CHECK(good.ok);
+        const auto loaded = loadFixture(undeclared, scratch());
+        CHECK_FALSE(loaded.ok);
+        CHECK(loaded.failure.find("Retrospect") != std::string::npos);
+    }
+
+    SECTION("a name no device claims is refused") {
+        // The mirror, and the rule the source declarations already live by: a
+        // declaration that has stopped being true is worse than one nobody
+        // wrote, because it reads as coverage.
+        auto stale = *retrospect;
+        stale.hostedPlugins.push_back("A Plugin Nobody Shipped");
+
+        const auto loaded = loadFixture(stale, scratch());
+        CHECK_FALSE(loaded.ok);
+        CHECK(loaded.failure.find("A Plugin Nobody Shipped") != std::string::npos);
+    }
+
+    SECTION("hosting one and asking for a null is refused") {
+        // The tier is checked rather than left to a reviewer's eye. A plugin
+        // frames its own work, so a residual measured across one is a number
+        // about the plugin, and a tolerance wide enough to pass it passes
+        // anything.
+        auto nulled = *retrospect;
+        nulled.declaration.tier = AudioTier::Exact;
+
+        const auto loaded = loadFixture(nulled, scratch());
+        CHECK_FALSE(loaded.ok);
+        CHECK(loaded.failure.find("invariants tier") != std::string::npos);
+    }
+
+    SECTION("every fixture the corpus carries holds the rule") {
+        for (const auto& fixture : mgdFixtures()) {
+            INFO(fixture.file);
+            const auto good = loadFixture(fixture, scratch());
+            INFO(good.failure);
+            CHECK(good.ok);
+
+            // And the half that cannot be checked from inside the load: a
+            // fixture that declares a plugin declares the tier that goes with
+            // it, which is what the corpus reads to decide what to assert.
+            if (!fixture.hostedPlugins.empty())
+                CHECK(fixture.declaration.tier == AudioTier::Invariants);
+        }
     }
 }
 

--- a/tests/engine/test_null_diff_block_size.cpp
+++ b/tests/engine/test_null_diff_block_size.cpp
@@ -394,6 +394,11 @@ TEST_CASE("Every project renders the same audio at 64, 512 and 4096", "[nulldiff
     std::set<std::string> failed;
     std::set<std::string> irreproducible;
 
+    /// Projects this binary did not gate, and why. Printed rather than counted:
+    /// a gate that quietly covered fewer projects than it thinks is the one
+    /// failure it cannot report as one.
+    std::set<std::string> notRun;
+
     for (const auto& value : projects) {
         // A case that asserts nothing about its audio renders none to compare:
         // the four MIDI-only cases carry a device that records what arrives
@@ -410,6 +415,30 @@ TEST_CASE("Every project renders the same audio at 64, 512 and 4096", "[nulldiff
         // out of the gate, which is the last one worth losing.
         if (value.tier == AudioTier::None)
             continue;
+
+        // And a project whose plugin nothing here has scanned (#2175). Every
+        // render in this file goes through the no-scan overload -- these are
+        // Catch2 tests over the model, with no engine beside them and nothing
+        // that could scan a plugin folder without turning a fast gate into a
+        // slow one -- so an external plugin is absent by construction and a
+        // passthrough would be bound in its place.
+        //
+        // A passthrough is perfectly block-size invariant, which is what makes
+        // this the one place the substitution has to be refused rather than
+        // measured: the gate compares native renders against each other, so the
+        // missing plugin leaves no residual for anything to notice. The
+        // undeclared-diagnostic refusal inside gate() catches it and reports
+        // unmeasurable; that is the right answer and the wrong place to hear it,
+        // because unmeasurable is a complaint and this is not one.
+        //
+        // The epsilon these projects would buy (#2078) is not dead code waiting
+        // for a use. It is what a machine with the plugins installed measures
+        // them within, and the day this gate is handed a scan it is the bound
+        // that stops the difference being absorbed.
+        if (const auto absent = absentPluginsIn(value, nullptr); !absent.empty()) {
+            notRun.insert(value.name + " (" + join(absent) + ")");
+            continue;
+        }
 
         INFO(value.name);
 
@@ -465,6 +494,14 @@ TEST_CASE("Every project renders the same audio at 64, 512 and 4096", "[nulldiff
 
         if (!result.held())
             failed.insert(value.name);
+    }
+
+    if (!notRun.empty()) {
+        std::string skipped;
+        for (const auto& name : notRun)
+            skipped += (skipped.empty() ? "" : ", ") + name;
+
+        WARN("not gated, for want of a plugin no scan here could find: " << skipped);
     }
 
     CHECK(failed == knownDependent);

--- a/tests/engine/test_null_diff_compare.cpp
+++ b/tests/engine/test_null_diff_compare.cpp
@@ -703,6 +703,7 @@ InvariantOptions invariantOptions(double maxStep = 0.5) {
     InvariantOptions options;
     options.sampleRate = kSampleRate;
     options.maxStepPerSample = maxStep;
+    options.minPeakDb = -40.0;
     options.tailSeconds = 0.05;
     options.tailFloorDb = -60.0;
     return options;
@@ -753,6 +754,82 @@ TEST_CASE("The invariants tier refuses a case that declared no bound",
 
     CHECK_FALSE(invariants.passed());
     CHECK(invariants.refusal == "no discontinuity bound declared");
+}
+
+TEST_CASE("The invariants tier refuses a case that declared no liveness floor",
+          "[nulldiff][compare][invariants]") {
+    // The same rule as the step bound, and it needs stating separately because
+    // the two catch different things. This tier computes no residual, so nothing
+    // else in it would notice a leg going silent.
+    const auto tone = decayingTone();
+
+    auto options = invariantOptions();
+    options.minPeakDb = std::numeric_limits<double>::infinity();
+
+    const auto invariants = compareInvariants(tone, tone, options);
+
+    CHECK_FALSE(invariants.passed());
+    CHECK(invariants.refusal == "no liveness floor declared");
+}
+
+TEST_CASE("One silent render is never certified", "[nulldiff][compare][invariants]") {
+    // The hole a waived tail leaves, and the reason liveness is asked per side.
+    // Silence is finite, it is the same length as anything, it steps by nothing
+    // and it has decayed by the end: every other check in this tier passes on
+    // it. A case that renders eight beats of a long arrangement waives the tail,
+    // so without this a native leg that stopped rendering would report ok
+    // against an incumbent that sounded (#2175).
+    // Cleared explicitly: JUCE's constructor leaves the buffer as it found the
+    // memory, and a test for silence built out of whatever was on the heap is a
+    // test for whatever was on the heap.
+    juce::AudioBuffer<float> silence(1, 8192);
+    silence.clear();
+
+    auto options = invariantOptions();
+    options.asksForTail = false;
+
+    const auto invariants = compareInvariants(silence, decayingTone(), options);
+
+    // Everything else it could be asked, it answers yes to.
+    CHECK(invariants.finite);
+    CHECK(invariants.lengthsMatch);
+    CHECK(invariants.continuous);
+
+    CHECK_FALSE(invariants.bothSound);
+    CHECK_FALSE(invariants.passed());
+    REQUIRE_FALSE(invariants.problems.empty());
+    CHECK(invariants.problems.front().find("did not sound") != std::string::npos);
+
+    // And the mirror, so the check cannot be one-sided.
+    const auto other = compareInvariants(decayingTone(), silence, options);
+    CHECK_FALSE(other.bothSound);
+    CHECK_FALSE(other.passed());
+}
+
+TEST_CASE("A waived tail is never reported as a tail that held",
+          "[nulldiff][compare][invariants]") {
+    // A case whose render window ends before its material does cannot be asked
+    // what is left running afterwards. What it must not do is answer.
+    juce::AudioBuffer<float> ringing(1, 8192);
+    auto* data = ringing.getWritePointer(0);
+    for (auto index = 0; index < ringing.getNumSamples(); ++index)
+        data[index] =
+            static_cast<float>(0.5 * std::sin(2.0 * juce::MathConstants<double>::pi * 220.0 *
+                                              static_cast<double>(index) / kSampleRate));
+
+    auto options = invariantOptions();
+    options.asksForTail = false;
+
+    const auto invariants = compareInvariants(ringing, ringing, options);
+
+    CHECK(invariants.passed());
+    CHECK_FALSE(invariants.tailAsked);
+
+    // Measured and carried even so: the number is still there to read, it is
+    // just not a verdict.
+    CHECK_FALSE(invariants.tailDecays);
+    CHECK(invariants.tailPeakNativeDb > -60.0);
+    CHECK(invariants.problems.empty());
 }
 
 TEST_CASE("A render that is not finite is never certified", "[nulldiff][compare][invariants]") {

--- a/tests/engine/test_null_diff_corpus.cpp
+++ b/tests/engine/test_null_diff_corpus.cpp
@@ -158,8 +158,14 @@ TEST_CASE("A tier without the figure it needs is refused", "[nulldiff][corpus]")
         if (value.tier == AudioTier::Aligned)
             CHECK(value.declaredFractionalShiftSamples != 0.0);
 
-        if (value.tier == AudioTier::Invariants)
+        if (value.tier == AudioTier::Invariants) {
             CHECK(value.maxStepPerSample > 0.0);
+
+            // And a liveness floor, which the tier refuses to run without. Both
+            // are the same rule: this tier computes no residual, so a bound
+            // nobody declared is a check that never ran (#2175).
+            CHECK(std::isfinite(value.minPeakDb));
+        }
     }
 }
 

--- a/tests/engine/test_param_table.cpp
+++ b/tests/engine/test_param_table.cpp
@@ -155,6 +155,82 @@ TEST_CASE("A device's parameters are a window indexed from zero", "[engine][para
     CHECK(device[0].value() == approx(0.0f));
 }
 
+TEST_CASE("A sparse device window publishes nothing in its holes", "[engine][param][table]") {
+    // The shape the first real project hosting a plugin arrived in (#2175). A
+    // project saved before the wet/dry pair was persisted has no parameters at
+    // indices 0 and 1, and the fork's list is a filtered view of the instance's
+    // anyway, so a sparse array is the normal shape of a hosted plugin rather
+    // than a model to correct.
+    //
+    // The window still covers the holes, because a window is contiguous and
+    // indexed from zero: that is what lets a device read its own parameters by
+    // the index it declared them at.
+    auto device = makeDevice(7, 0);
+    device.format = magda::PluginFormat::VST3;
+
+    for (int index = 2; index < 5; ++index) {
+        ParameterInfo info(index, "P" + juce::String(index), "%", 0.0f, 100.0f, 0.0f);
+        info.currentValue = 100.0f;
+        device.parameters.push_back(info);
+    }
+
+    auto track = makeTrack(1);
+    track.chain.fxChainElements.push_back(makeDeviceElement(device));
+
+    const auto table = tableFor({track});
+    const auto window = table.windowFor(magda::engine::DeviceKey{ChainSegment::Fx, 7});
+    REQUIRE(window.count == 5);
+
+    const auto values = resolved(table);
+    const auto params = values.device(window.first, window.count);
+    REQUIRE(params.size() == 5);
+
+    // The holes: empty, which is the one answer a device can read as "not
+    // mine". A value here would be indistinguishable from a real one, and the
+    // project that found this rendered silent because 0.0 at slots zero and one
+    // is a wet/dry pair set fully dry and fully attenuated.
+    CHECK(params[0].empty());
+    CHECK(params[1].empty());
+
+    // And the declared ones, which are unaffected.
+    CHECK_FALSE(params[2].empty());
+    CHECK(params[2].value() == approx(100.0f));
+    CHECK_FALSE(params[4].empty());
+
+    // Not diagnosed, because for a hosted plugin it is not a fault. A project
+    // reported as unmeasurable for having been saved by an older build is a
+    // project the corpus cannot use.
+    CHECK_FALSE(mentions(table, "not contiguous"));
+}
+
+TEST_CASE("An internal device with a gap in its indices is reported", "[engine][param][table]") {
+    // The mirror, and the reason the check is scoped rather than removed. An
+    // internal device declares its own parameters, so a gap is a device that
+    // skipped an index and the slot it left is one nothing will ever read.
+    auto device = makeDevice(7, 0);
+    device.format = magda::PluginFormat::Internal;
+
+    for (const int index : {0, 2}) {
+        ParameterInfo info(index, "P" + juce::String(index), "%", 0.0f, 100.0f, 0.0f);
+        info.currentValue = 0.0f;
+        device.parameters.push_back(info);
+    }
+
+    auto track = makeTrack(1);
+    track.chain.fxChainElements.push_back(makeDeviceElement(device));
+
+    const auto table = tableFor({track});
+    CHECK(mentions(table, "not contiguous"));
+
+    // Reported and still carried the same way: the diagnostic says the model is
+    // wrong, and the hole is silent either way.
+    const auto window = table.windowFor(magda::engine::DeviceKey{ChainSegment::Fx, 7});
+    const auto values = resolved(table);
+    const auto params = values.device(window.first, window.count);
+    REQUIRE(params.size() == 3);
+    CHECK(params[1].empty());
+}
+
 TEST_CASE("One device id in two sections is two parameters", "[engine][param][table]") {
     // The collision #2089 found in the plan, asked of the table: the FX and
     // post-FX sections allocate device ids independently, so the section is

--- a/tests/engine/test_real_project_corpus_juce.cpp
+++ b/tests/engine/test_real_project_corpus_juce.cpp
@@ -1,5 +1,6 @@
 #include <juce_core/juce_core.h>
 
+#include <algorithm>
 #include <iostream>
 #include <numeric>
 #include <set>
@@ -22,15 +23,30 @@
  * nothing in it exercises.
  *
  * This is the other half. Projects saved by released builds between 0.4.8 and
- * 0.17.0, loaded from the bytes they were written as, rendered through both
- * engines and compared by the same runner the code-built corpus uses. Seven are
- * declared; six run here, and the skip list below says why the seventh does
- * not. What they
+ * 0.18.0, loaded from the bytes they were written as, rendered through both
+ * engines and compared by the same runner the code-built corpus uses. Ten are
+ * declared; nine reach a leg here, and the skip list below says why the tenth
+ * does not. What they
  * bring is the combinations: a v1 project whose clips carry their sources
  * inline, a five-device chain under an FM synth, two tracks coupled through a
  * sidechain rather than through routing, sixty-four session clips sitting
  * beside an arrangement, a warp map made by a real transient pass with a
  * repeated marker in it.
+ *
+ * ## The three that host a plugin
+ *
+ * Of the nine, three are projects with a VST3 in them (#2175): two Retrospect
+ * instances over audio, a Pianoteq fed MIDI, and a Pro-L 2 over twenty-three
+ * summed stems. They are the projects most worth having and the ones a corpus
+ * that quietly dropped every project with a plugin in it would have dropped.
+ *
+ * How many of them are measured is a fact about the machine rather than about
+ * the corpus, and it is printed rather than assumed. A project rendered without
+ * the plugin it names is a different project -- both legs bind nothing in that
+ * slot and null against each other perfectly -- so a case whose plugin this
+ * machine has not scanned does not run at all, and is reported as not run rather
+ * than as a pass. Every CI runner scans nothing, so on CI all three are in that
+ * state and the six internal-device projects are what gates a release.
  *
  * MgdFixtures.cpp says which projects and why, and which fifteen of the
  * twenty-two are not here.
@@ -214,6 +230,37 @@ class RealProjectCorpusTests : public juce::UnitTest {
 
         const auto complaints =
             judgeSuite(run.asserted, run.unmeasurable, run.failing, underCalibration);
+
+        // What this run did not cover, said out loud. A case that did not run is
+        // not a pass and not a failure, and the one way that can go wrong is
+        // quietly: a corpus reporting nine ok on a machine that measured six.
+        if (!run.notRun.empty()) {
+            juce::String skipped;
+            for (const auto& name : run.notRun)
+                skipped << (skipped.isEmpty() ? "" : ", ") << juce::String(name);
+
+            logMessage("not run for want of a plugin this machine has not scanned: " + skipped);
+            std::cout << "not run for want of a plugin this machine has not scanned: " << skipped
+                      << std::endl;
+        }
+
+        // And the rule that keeps it from covering anything else. Only a project
+        // that declares a hosted plugin may be skipped for one, so a leg that
+        // started refusing every case would fail here rather than reporting a
+        // quiet corpus.
+        std::vector<std::string> skippedWithoutPlugins;
+        for (const auto& name : run.notRun) {
+            const auto declared =
+                std::find_if(mgdFixtures().begin(), mgdFixtures().end(),
+                             [&name](const auto& f) { return f.declaration.name == name; });
+
+            if (declared == mgdFixtures().end() || declared->hostedPlugins.empty())
+                skippedWithoutPlugins.push_back(name);
+        }
+
+        expect(skippedWithoutPlugins.empty(),
+               "did not run, and host no plugin that could explain it: " +
+                   join(skippedWithoutPlugins));
 
         // Every fixture reached a verdict. Asserted positively rather than left
         // implied, because the checks below all pass on an empty run and a


### PR DESCRIPTION
The rest of #2175, and it closes it: the plugin field on a case's environment block, the rule that an absent plugin is not a pass, and the three corpus projects that carry real VST3 state. Sits on top of #2269.

## The gate

`absentPluginsIn()` asks the scan, before either leg is driven, which of a project's plugins this machine has not got.

A project rendered without the plugin it names is a different project: both legs bind nothing in that slot and null against each other perfectly, which is a case passing by having tested less than it claims. So it does not run at all, and it is reported as **not run** rather than as a pass or as a complaint. It is not a fact about the engine or the harness, it is a fact about which plugins are on the desk, and every CI runner has none of them.

Strict in one direction on purpose. It walks the model rather than the compiled plan, so a plugin on a bypassed chain refuses the case too. The cost of that is a case reported not run on a machine that could have measured it, with the plugin named; the cost of the other way round is a green case that rendered a project nobody has.

## The scan, which the corpus has to do itself

Left alone, none of this would ever run. A test binary runs under a sandboxed `HOME` (the Makefile's `TEST_ENV`), so the application data directory the app keeps its `KnownPluginList` in is not this machine's, and it must not be: a suite whose verdict depends on what somebody last clicked in a scan dialog is not a suite. The list is therefore empty on every machine, and a gate that is always closed tests as little as one that is always open.

So the runner looks for itself, which is the honest source anyway. It walks the plugin folders, which is cheap, and then loads only the bundles whose name matches one a corpus project asked for: three files at most, each named in a manifest somebody wrote. That is deliberate rather than convenient. A full scan loads every bundle installed, which is minutes on a desk with a library on it and one bad plugin away from taking the suite down, which is why the app scans out of process.

Names are matched by containment either way, folded for case: a project names a plugin what its author's host called it, and FabFilter ships "Pro-L 2" inside "FabFilter Pro-L 2.vst3". A false match costs one bundle loaded that resolution then declines, because `matchInstalledPlugin` has the project's own identifier to check against; a missed match costs a case that never runs on a machine that could have measured it.

## The projects

- **project.retrospect** (0.13.0): two audio tracks each through their own Retrospect, one of them with an internal limiter after it. An external device and an internal one in one chain, and both instances carry state a released build wrote.
- **project.hostedinstrument** (0.18.0): two MIDI clips back to back into a hosted Pianoteq. A hosted instrument rather than a hosted effect, which is the other path through the plan. No audio sources at all, so whatever comes out came out of Pianoteq, and the notes that went in are compared as a stream beside it.
- **project.multitrack** (0.10.2): twenty-three stems under three group tracks, Pro-L 2 on the snare and on the master. The only project in the corpus with a track hierarchy, and the only one hosting the same plugin twice.

All three declare `AudioTier::Invariants` and the rig refuses them otherwise, because a plugin frames its own work and a residual measured across one is a number about the plugin. `MgdFixture::hostedPlugins` is checked both ways, like the sources beside it: a plugin the manifest missed is refused, a name no device claims is refused.

**envfollower stays out**, which is the one exclusion that reads like an exception and is not. Its two Retrospect instances are both on muted tracks, so an arrangement render of it is one internal filter and no plugin at all, and it carries 4OSC besides. It belongs with the seven 4OSC exclusions.

## A real bug, which is what these projects are for

**project.retrospect rendered silent.**

A device's parameter window is contiguous and indexed from zero, because that is what lets a device be handed a span and read its own parameters by the index it declared them at. An index nothing declared still costs a slot, and that slot was published as `0.0`. To the device reading it, a fabricated zero is indistinguishable from a value somebody set.

Retrovid was saved before the wet/dry pair was persisted, so it has no parameters at indices 0 and 1. The two fabricated zeros set the pair fully dry and fully attenuated: silence, out of a plugin whose own chunk had been restored perfectly.

A sparse array is the normal shape of a hosted plugin's saved parameters rather than a model to correct: the fork's list is a filtered view of the instance's, and a project saves what it had. So an undeclared slot now publishes no segments at all, which is exactly the answer a device already gets for an index past the end of its window, and `EngineExternalDevice::writeParameters` already does the right thing with it. The contiguity diagnostic stays for internal devices, where a gap is a device that skipped an index, and goes for hosted ones, where diagnosing it would make every project saved by an older build unmeasurable.

Two regression tests in `test_param_table.cpp`, one per side of that rule.

## Two things the invariants tier could not ask

**The tail.** It asks what is left running after the material stops, and a case that renders eight beats of a five-hundred-beat arrangement stops first: what is in its last fifty milliseconds is the music, and reporting it as a leak is the check misreading the case. Cases declare whether they render past their material. The tail is still measured and still printed, marked with a `?` so a number nobody asked for cannot be read as a check that held.

**The assertion watch.** It is a process-wide hook, and its premise, that everything asserting here is the engine or the harness, is true of every case in the corpus but the three that load somebody else's code into the process. Retrospect is an LV2 plugin behind a VST3 shell and hands JUCE its own URI where a path is expected, once per instantiation. On a case that hosts a plugin the watch now records rather than condemns, and the report prints it on the case's line. Nothing is dropped; what changes is what it is allowed to conclude.

## Verification

Full Catch2 suite passes (651,672 assertions) and the whole JUCE suite passes.

`project.retrospect` holds on this machine, at the invariants tier, with both Retrospect instances resolved:

```
[ 7] project.retrospect  invariant step=-3.0  tail=0.7?  length=ok  ok
     [rate=44100 blockSize=512 channels=2 seed=0 plugin="Retrospect 1.0.0 (VST3)" x2]
[ 8] project.hostedinstrument  invariant not run: this machine has not scanned "Pianoteq 8"  --
[ 9] project.multitrack        invariant not run: this machine has not scanned "Pro-L 2"     --
```

The step bound is the measured figure with its mechanism named: -3.0 dB is 0.71 of full scale in one sample, and Retrospect splices, so a splice between two phases of a tone steps by the distance between them. What the bound refuses is a step larger than a splice, which is what a graph transition without a ramp leaves behind.

The other two report not run, which is what a machine without Pro-L 2 or Pianoteq owes them, and what every CI runner will report for all three. The block-size gate skips them for the same reason and says so: it is Catch2 over the model with nothing beside it that could scan a plugin folder without turning a fast gate into a slow one.

No existing case changed pass/fail state.

https://claude.ai/code/session_01Qa7GxDU184RGxo2b1Yhpa6