### PR TITLE
The corpus hosts a plugin, and two hosts stop disagreeing about it (#2246)

### DIFF
--- a/magda/engine/exec/OfflineRender.cpp
+++ b/magda/engine/exec/OfflineRender.cpp
@@ -218,11 +218,19 @@ OfflineRenderResult renderOffline(PlanExecutor& executor, const PlanValues& valu
     // same request a moment later.
     clock.advance(snapshot, context.sampleRate, 0);
 
-    // The latency goes on whichever span is last, so that the samples it flushes
+    // A request with nothing in it renders nothing, latency or not. The flush
+    // below exists to push the last of a range through the graph, and a range
+    // with no samples in it has nothing to push: rendering it anyway would run
+    // every bound device and ask the caller whether to continue, for blocks the
+    // sink is never handed, so an empty request could come back cancelled or
+    // leave a delay line holding something.
+    const auto flushSamples = rangeSamples > 0 || tailSamples > 0 ? latencySamples : 0;
+
+    // The flush goes on whichever span is last, so that the samples it produces
     // are the continuation of what came before them: with a tail, the graph is
     // still ringing out with the transport stopped, and without one the sources
     // play on past the range while the kept window ends where it was asked to.
-    renderSpan(rangeSamples + (tailSamples > 0 ? 0 : latencySamples));
+    renderSpan(rangeSamples + (tailSamples > 0 ? 0 : flushSamples));
 
     if (result.cancelled || tailSamples <= 0)
         return result;
@@ -241,7 +249,7 @@ OfflineRenderResult renderOffline(PlanExecutor& executor, const PlanValues& valu
     snapshot.request.playing = false;
     snapshot.request.locate = false;
 
-    renderSpan(tailSamples + latencySamples);
+    renderSpan(tailSamples + flushSamples);
 
     return result;
 }

--- a/magda/engine/exec/OfflineRender.cpp
+++ b/magda/engine/exec/OfflineRender.cpp
@@ -15,6 +15,79 @@ std::int64_t samplesBetween(double startSeconds, double endSeconds, double sampl
     return static_cast<std::int64_t>(std::llround((endSeconds - startSeconds) * sampleRate));
 }
 
+/**
+ * @brief A sink with the plan's own latency taken off the front (#2246).
+ *
+ * A prepared plan's output is however far behind the timeline the devices on
+ * its longest path report between them, and during playback that is the whole
+ * point: the graph is aligned with itself and the interface's own buffer is
+ * what the listener hears it through. A file has no such excuse. A bounce whose
+ * first sample is not the range's first sample is a bounce that drifts against
+ * every other bounce of the same project, and against the project itself the
+ * moment it is imported back in.
+ *
+ * So the render pulls the plan's latency in extra samples at the end and this
+ * drops the same number off the front. What the sink receives is exactly the
+ * range it asked for, at the position it asked for it, with nothing lost:
+ * material still inside a delay line when the range ends comes out during those
+ * extra samples rather than being cut off.
+ *
+ * Nothing at all when the plan reports no latency, which is every project
+ * without a latency-reporting plugin in it.
+ */
+class LatencyTrimmedSink final : public OfflineRenderSink {
+  public:
+    LatencyTrimmedSink(OfflineRenderSink& target, int latencySamples)
+        : target_(target), remaining_(latencySamples) {}
+
+    void write(const juce::AudioBuffer<float>& block, int numSamples) override {
+        if (remaining_ <= 0) {
+            forward(block, numSamples);
+            return;
+        }
+
+        if (remaining_ >= numSamples) {
+            remaining_ -= numSamples;
+            return;
+        }
+
+        // The block the trim ends inside, handed on as the part of itself that
+        // is past it. A view rather than a copy: the sink's contract already
+        // says the buffer is the renderer's and is reused, so a sink that wants
+        // to keep these samples was going to copy them anyway.
+        const auto skipped = remaining_;
+        remaining_ = 0;
+
+        juce::AudioBuffer<float> rest(const_cast<float* const*>(block.getArrayOfReadPointers()),
+                                      block.getNumChannels(), skipped, numSamples - skipped);
+        forward(rest, numSamples - skipped);
+    }
+
+    /// What the sink behind this one actually received. The result reports
+    /// these rather than what the render pulled: a caller writing a file is
+    /// owed the length of the file, and the samples that went into the trim
+    /// never reached it.
+    std::int64_t forwardedSamples() const {
+        return forwardedSamples_;
+    }
+
+    int forwardedBlocks() const {
+        return forwardedBlocks_;
+    }
+
+  private:
+    void forward(const juce::AudioBuffer<float>& block, int numSamples) {
+        target_.write(block, numSamples);
+        forwardedSamples_ += numSamples;
+        ++forwardedBlocks_;
+    }
+
+    OfflineRenderSink& target_;
+    int remaining_ = 0;
+    std::int64_t forwardedSamples_ = 0;
+    int forwardedBlocks_ = 0;
+};
+
 }  // namespace
 
 OfflineRenderResult renderOffline(PlanExecutor& executor, const PlanValues& values,
@@ -53,6 +126,14 @@ OfflineRenderResult renderOffline(PlanExecutor& executor, const PlanValues& valu
         request.tailSeconds > 0.0
             ? static_cast<std::int64_t>(std::llround(request.tailSeconds * context.sampleRate))
             : 0;
+
+    // What the plan is behind by, and therefore what has to come off the front
+    // of the file and be pulled in at the end of it. Asked of the executor
+    // rather than recomputed, because it is the number the same executor
+    // aligned its own graph with.
+    const auto latencySamples = std::max(0, executor.latencySamples());
+
+    LatencyTrimmedSink trimmed(sink, latencySamples);
 
     juce::AudioBuffer<float> buffer(context.numChannels, blockSize);
 
@@ -118,10 +199,12 @@ OfflineRenderResult renderOffline(PlanExecutor& executor, const PlanValues& valu
                 executor.process(values, segment.block, piece);
             }
 
-            sink.write(buffer, numSamples);
+            trimmed.write(buffer, numSamples);
 
-            result.samplesRendered += numSamples;
-            ++result.blocksRendered;
+            // Assigned rather than accumulated, because what the result reports
+            // is what the sink received and the trim is between the two.
+            result.samplesRendered = trimmed.forwardedSamples();
+            result.blocksRendered = trimmed.forwardedBlocks();
             samples -= numSamples;
         }
     };
@@ -135,7 +218,11 @@ OfflineRenderResult renderOffline(PlanExecutor& executor, const PlanValues& valu
     // same request a moment later.
     clock.advance(snapshot, context.sampleRate, 0);
 
-    renderSpan(rangeSamples);
+    // The latency goes on whichever span is last, so that the samples it flushes
+    // are the continuation of what came before them: with a tail, the graph is
+    // still ringing out with the transport stopped, and without one the sources
+    // play on past the range while the kept window ends where it was asked to.
+    renderSpan(rangeSamples + (tailSamples > 0 ? 0 : latencySamples));
 
     if (result.cancelled || tailSamples <= 0)
         return result;
@@ -154,7 +241,7 @@ OfflineRenderResult renderOffline(PlanExecutor& executor, const PlanValues& valu
     snapshot.request.playing = false;
     snapshot.request.locate = false;
 
-    renderSpan(tailSamples);
+    renderSpan(tailSamples + latencySamples);
 
     return result;
 }

--- a/magda/engine/plan/PlanCompiler.cpp
+++ b/magda/engine/plan/PlanCompiler.cpp
@@ -805,10 +805,30 @@ ChainSignal Compiler::emitDevice(const DeviceInfo& device, const ChainSite& site
     // narrowing it would narrow the chain rather than the device.
     const bool transparent = isTransparentTap(device);
     const bool injector = !transparent && node.injectsAudio();
-    const auto inputWidth = transparent ? 2
-                            : injector  ? 0
-                                        : std::clamp(device.audioInputChannels, 0, 2);
-    const auto outputWidth = transparent ? 2 : std::clamp(device.audioOutputChannels, 0, 2);
+
+    // An external plugin is handed the bus and adapts its own channels, and
+    // that is not a width the plan gets an opinion about (#2246).
+    //
+    // The adaptation is arithmetic rather than routing, and it is the fork's:
+    // a stereo bus into a mono plugin is averaged, a mono bus into a stereo one
+    // is duplicated, and a mono plugin's output is spread back over both sides.
+    // EngineExternalDevice reproduces every step of it, because every project
+    // hosting a plugin that is not stereo was mixed against it.
+    //
+    // Narrowing the port first defeats that. The device would be handed the
+    // left channel of the bus and the average would never be taken -- the
+    // arithmetic would still be in the adapter, unreachable, and a mono plugin
+    // would render one side of a project the fork renders both sides of.
+    const bool adaptsItsOwnChannels = device.format != PluginFormat::Internal;
+
+    // The injector test still comes first: an instrument reads no bus in either
+    // engine, and being external does not give it one to adapt.
+    const auto inputWidth = transparent            ? 2
+                            : injector             ? 0
+                            : adaptsItsOwnChannels ? 2
+                                                   : std::clamp(device.audioInputChannels, 0, 2);
+    const auto outputWidth =
+        transparent || adaptsItsOwnChannels ? 2 : std::clamp(device.audioOutputChannels, 0, 2);
 
     std::vector<PortDesc> outputs{
         PortDesc{SignalKind::Audio, static_cast<std::uint8_t>(outputWidth)}};

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -383,6 +383,7 @@ if(MAGDA_BUILD_NATIVE_ENGINE)
     list(APPEND TEST_SOURCES NullDiffMaterial.cpp)
     list(APPEND TEST_SOURCES NullDiffCompare.cpp)
     list(APPEND TEST_SOURCES NullDiffCorpus.cpp)
+    list(APPEND TEST_SOURCES NullDiffHostedPlugin.cpp)
     list(APPEND TEST_SOURCES NullDiffNativeLeg.cpp)
     list(APPEND TEST_SOURCES engine/test_null_diff_compare.cpp)
     list(APPEND TEST_SOURCES engine/test_null_diff_corpus.cpp)
@@ -701,6 +702,7 @@ if(MAGDA_BUILD_NATIVE_ENGINE)
         NullDiffMaterial.cpp
         NullDiffCompare.cpp
         NullDiffCorpus.cpp
+        NullDiffHostedPlugin.cpp
         NullDiffNativeLeg.cpp
         NullDiffTeLeg.cpp
         NullDiffRunner.cpp

--- a/tests/DawProjectRoundTrip.cpp
+++ b/tests/DawProjectRoundTrip.cpp
@@ -1,6 +1,7 @@
 #include "DawProjectRoundTrip.hpp"
 
 #include <algorithm>
+#include <deque>
 #include <functional>
 #include <map>
 #include <optional>
@@ -400,8 +401,13 @@ Loss multiOutRouting() {
             }};
 }
 
-/// Every top-level device of @p track, paired with the one of the same name on
-/// @p source. What the two device-level losses below both need.
+/// Every top-level device of @p track, paired with the one it went out as.
+/// What the two device-level losses below both need.
+///
+/// By id, which is exact and which these can rely on: the trip has already put
+/// the surviving devices back onto the ids they went out under, by portable
+/// identity and occurrence, before any loss is restored. Pairing by name here
+/// would reintroduce the ambiguity that mapping exists to avoid.
 void forEachPairedDevice(TrackInfo& track, const TrackInfo& source,
                          const std::function<void(DeviceInfo&, const DeviceInfo&)>& visit) {
     for (auto& element : track.chain.fxChainElements) {
@@ -411,7 +417,7 @@ void forEachPairedDevice(TrackInfo& track, const TrackInfo& source,
         auto& device = getDevice(element);
 
         for (const auto& candidate : source.chain.fxChainElements) {
-            if (!isDevice(candidate) || getDevice(candidate).name != device.name)
+            if (!isDevice(candidate) || getDevice(candidate).id != device.id)
                 continue;
 
             visit(device, getDevice(candidate));
@@ -442,6 +448,52 @@ Loss deviceSidechain() {
                                     return;
 
                                 device.sidechain = saved.sidechain;
+                                restored = true;
+                            });
+                    }
+
+                return restored;
+            }};
+}
+
+/// The dry and wet levels in front of a hosted plugin, which are the host's own
+/// numbers and not the plugin's (#2246).
+Loss deviceWrapperMix() {
+    return {.field = "DeviceInfo::wrapperParameters",
+            .reason = "the pair of levels in front of an external plugin belongs to the host "
+                      "rather than to the plugin: the fork injects it, MAGDA persists it, and "
+                      "the plugin has never heard of it. DAWproject carries a device as an "
+                      "identity and a blob of its own state, and neither has anywhere to put a "
+                      "number the plugin did not author. It comes back empty, which the engine "
+                      "reads as the pair's own default of fully wet -- so a project saved at "
+                      "40% wet returns as one that is not",
+            .restore = [](Case& imported, const Case& original) {
+                const auto sameMix = [](const DeviceInfo& device, const DeviceInfo& saved) {
+                    if (device.wrapperParameters.size() != saved.wrapperParameters.size())
+                        return false;
+
+                    for (std::size_t index = 0; index < saved.wrapperParameters.size(); ++index)
+                        if (device.wrapperParameters[index].currentValue !=
+                            saved.wrapperParameters[index].currentValue)
+                            return false;
+
+                    return true;
+                };
+
+                bool restored = false;
+
+                for (auto& track : imported.tracks)
+                    for (const auto& source : original.tracks) {
+                        if (source.name != track.name)
+                            continue;
+
+                        forEachPairedDevice(
+                            track, source,
+                            [&restored, &sameMix](DeviceInfo& device, const DeviceInfo& saved) {
+                                if (sameMix(device, saved))
+                                    return;
+
+                                device.wrapperParameters = saved.wrapperParameters;
                                 restored = true;
                             });
                     }
@@ -536,6 +588,8 @@ const std::map<std::string, std::vector<Loss>>& lossTable() {
         // there is no chain to put a device back into once the container it
         // sat in has no representation.
         {"plugin.narrow.slot", {internalDevices()}},
+        {"plugin.wetdry", {deviceWrapperMix()}},
+        {"plugin.wetdry.dry", {deviceWrapperMix()}},
         {"plugin.sidechain", {deviceSidechain()}},
         {"plugin.instrument.midiout", {deviceMidiPorts()}},
         {"multiout.pair", {internalDevices(), multiOutRouting()}},
@@ -831,6 +885,43 @@ bool takeClips(ProjectDocument& imported, const std::map<TrackId, TrackId>& trac
 }
 
 /**
+ * @brief The identity the format carries for a device, on either side of the
+ *        trip (#2246).
+ *
+ * The same preference the exporter writes its `deviceID` from -- a VST3's class
+ * id, then JUCE's own identifier string, then the file it was loaded from --
+ * which is what makes it comparable across the trip: the importer puts that one
+ * attribute back into all three fields, so a device asked this question before
+ * and after answers with the same string.
+ *
+ * Deliberately not the display name. A name is what a user typed and what a
+ * browser showed; two instances of one plugin on one chain share it, and a
+ * mapping keyed on it would have to refuse a project that is perfectly ordinary.
+ *
+ * Empty for a device the format could not identify at all, which is a device it
+ * did not carry either: nothing comes back for it, and the chain it sat in is
+ * restored from the original as a declared loss.
+ */
+juce::String portableIdentity(const DeviceInfo& device) {
+    if (device.vst3ClassId.isNotEmpty())
+        return device.vst3ClassId;
+    if (device.uniqueId.isNotEmpty())
+        return device.uniqueId;
+    return device.fileOrIdentifier;
+}
+
+/// Every top-level device of @p elements, in chain order.
+std::vector<const DeviceInfo*> topLevelDevices(const std::vector<ChainElement>& elements) {
+    std::vector<const DeviceInfo*> devices;
+
+    for (const auto& element : elements)
+        if (isDevice(element))
+            devices.push_back(&getDevice(element));
+
+    return devices;
+}
+
+/**
  * @brief Put the devices that came back onto the ids they went out under
  *        (#2246).
  *
@@ -842,12 +933,24 @@ bool takeClips(ProjectDocument& imported, const std::map<TrackId, TrackId>& trac
  * case of internal devices does, would put the exported plugin back too and
  * stop comparing what the format actually carried.
  *
+ * Matched by portable identity and occurrence rather than by name. Two copies of
+ * one plugin on one chain is an ordinary project, and a mapping that refused it
+ * would be writing a harness limitation into what the corpus is allowed to
+ * contain: so the nth device carrying an identity takes the id of the nth device
+ * that went out carrying it, in chain order, and the name is only ever printed.
+ *
+ * That keeps a reorder visible, which is the property this could have lost. Two
+ * instances of one plugin swapped are the same project and compile to the same
+ * plan; two different devices swapped keep their own ids and compile to a plan
+ * whose ops are in the other order, which the dump comparison reads straight
+ * off.
+ *
  * Unlike a track or a clip, a device that did not come back is not a refusal
  * here. Most of them do not: MAGDA's own devices and its racks have no
  * representation at all, and that is declared as a loss and restored from the
- * original. What is refused is a device that came back under a name nothing
- * went out under, or two under one name, which are the two ways a mapping could
- * quietly put one device's id on another.
+ * original. What is refused is a device that came back carrying an identity
+ * nothing went out under, or a further copy of one, which are the two ways a
+ * mapping could quietly put one device's id on another.
  *
  * Top-level chain devices only. It is where the corpus's hosted plugins sit,
  * and the sections the format has no shape for arrive empty rather than
@@ -855,27 +958,30 @@ bool takeClips(ProjectDocument& imported, const std::map<TrackId, TrackId>& trac
  */
 bool mapDeviceIds(Case& value, const Case& original, std::string& refusal) {
     const auto mapTrack = [&refusal](TrackInfo& track, const TrackInfo& source) {
-        std::map<juce::String, DeviceId> byName;
-        for (const auto& element : source.chain.fxChainElements)
-            if (isDevice(element) &&
-                !byName.emplace(getDevice(element).name, getDevice(element).id).second) {
-                refusal = "two of this case's devices on track '" + source.name.toStdString() +
-                          "' share a name, so ids cannot be mapped back";
-                return false;
-            }
-
-        NameClaims<DeviceId> claims("device", std::move(byName));
+        // The ids that went out, per identity, in chain order. A deque because
+        // matching is first come first served: the second instance of a plugin
+        // to come back is the second that went out.
+        std::map<juce::String, std::deque<DeviceId>> byIdentity;
+        for (const auto* device : topLevelDevices(source.chain.fxChainElements))
+            byIdentity[portableIdentity(*device)].push_back(device->id);
 
         for (auto& element : track.chain.fxChainElements) {
             if (!isDevice(element))
                 continue;
 
             auto& device = getDevice(element);
-            const auto id = claims.claim(device.name, refusal);
-            if (!id.has_value())
-                return false;
+            const auto identity = portableIdentity(device);
 
-            device.id = *id;
+            const auto found = byIdentity.find(identity);
+            if (found == byIdentity.end() || found->second.empty()) {
+                refusal = "a device came back on track '" + track.name.toStdString() + "' as '" +
+                          device.name.toStdString() + "' (" + identity.toStdString() +
+                          "), which nothing went out as";
+                return false;
+            }
+
+            device.id = found->second.front();
+            found->second.pop_front();
         }
 
         return true;

--- a/tests/DawProjectRoundTrip.cpp
+++ b/tests/DawProjectRoundTrip.cpp
@@ -1,6 +1,7 @@
 #include "DawProjectRoundTrip.hpp"
 
 #include <algorithm>
+#include <functional>
 #include <map>
 #include <optional>
 #include <set>
@@ -399,6 +400,88 @@ Loss multiOutRouting() {
             }};
 }
 
+/// Every top-level device of @p track, paired with the one of the same name on
+/// @p source. What the two device-level losses below both need.
+void forEachPairedDevice(TrackInfo& track, const TrackInfo& source,
+                         const std::function<void(DeviceInfo&, const DeviceInfo&)>& visit) {
+    for (auto& element : track.chain.fxChainElements) {
+        if (!isDevice(element))
+            continue;
+
+        auto& device = getDevice(element);
+
+        for (const auto& candidate : source.chain.fxChainElements) {
+            if (!isDevice(candidate) || getDevice(candidate).name != device.name)
+                continue;
+
+            visit(device, getDevice(candidate));
+            break;
+        }
+    }
+}
+
+/// A device's key input, which is a relationship rather than a property (#2246).
+Loss deviceSidechain() {
+    return {.field = "DeviceInfo::sidechain",
+            .reason = "DAWproject has no cross-track key routing. A device arrives as a plugin "
+                      "identity and a state blob, and which track feeds its sidechain is neither "
+                      "of those: it is a reference from a device to a track, which the format "
+                      "has nowhere to put. It comes back unrouted",
+            .restore = [](Case& imported, const Case& original) {
+                bool restored = false;
+
+                for (auto& track : imported.tracks)
+                    for (const auto& source : original.tracks) {
+                        if (source.name != track.name)
+                            continue;
+
+                        forEachPairedDevice(
+                            track, source,
+                            [&restored](DeviceInfo& device, const DeviceInfo& saved) {
+                                if (device.sidechain.isActive() == saved.sidechain.isActive())
+                                    return;
+
+                                device.sidechain = saved.sidechain;
+                                restored = true;
+                            });
+                    }
+
+                return restored;
+            }};
+}
+
+/// What a device's MIDI ports do, which is read off a live plugin (#2246).
+Loss deviceMidiPorts() {
+    return {.field = "DeviceInfo::producesMidi, DeviceInfo::midiInThru",
+            .reason = "a device's MIDI capabilities are what the live plugin reported and what "
+                      "the user chose to do with them, and the format carries neither: it names "
+                      "a plugin and hands over its state. They come back at the defaults, which "
+                      "is a plugin that emits no MIDI and a chain that passes its own through",
+            .restore = [](Case& imported, const Case& original) {
+                bool restored = false;
+
+                for (auto& track : imported.tracks)
+                    for (const auto& source : original.tracks) {
+                        if (source.name != track.name)
+                            continue;
+
+                        forEachPairedDevice(
+                            track, source,
+                            [&restored](DeviceInfo& device, const DeviceInfo& saved) {
+                                if (device.producesMidi == saved.producesMidi &&
+                                    device.midiInThru == saved.midiInThru)
+                                    return;
+
+                                device.producesMidi = saved.producesMidi;
+                                device.midiInThru = saved.midiInThru;
+                                restored = true;
+                            });
+                    }
+
+                return restored;
+            }};
+}
+
 const std::map<std::string, std::vector<Loss>>& lossTable() {
     static const std::map<std::string, std::vector<Loss>> table{
         {"fades.curves", {fades()}},
@@ -448,6 +531,13 @@ const std::map<std::string, std::vector<Loss>>& lossTable() {
         {"rack.aux", {internalDevices()}},
         {"rack.mono", {internalDevices()}},
         {"rack.instrument", {internalDevices()}},
+        // The one hosted case with a rack in it (#2246). The rack goes the way
+        // every other rack goes, and it takes the plugin inside it along:
+        // there is no chain to put a device back into once the container it
+        // sat in has no representation.
+        {"plugin.narrow.slot", {internalDevices()}},
+        {"plugin.sidechain", {deviceSidechain()}},
+        {"plugin.instrument.midiout", {deviceMidiPorts()}},
         {"multiout.pair", {internalDevices(), multiOutRouting()}},
         {"project.mixed", {internalDevices()}},
         {"midi.notes", {internalDevices()}},
@@ -740,6 +830,74 @@ bool takeClips(ProjectDocument& imported, const std::map<TrackId, TrackId>& trac
     return claims.allClaimed(refusal);
 }
 
+/**
+ * @brief Put the devices that came back onto the ids they went out under
+ *        (#2246).
+ *
+ * The same rule tracks and clips live by, applied one level further in, and it
+ * arrived with the first case whose device survives the trip: a hosted plugin
+ * is carried by the format, so a case with one compiles a plan whose ops are
+ * keyed on a device id the importer chose. That is a renumbering rather than a
+ * loss, and the difference matters -- restoring the chain wholesale, the way a
+ * case of internal devices does, would put the exported plugin back too and
+ * stop comparing what the format actually carried.
+ *
+ * Unlike a track or a clip, a device that did not come back is not a refusal
+ * here. Most of them do not: MAGDA's own devices and its racks have no
+ * representation at all, and that is declared as a loss and restored from the
+ * original. What is refused is a device that came back under a name nothing
+ * went out under, or two under one name, which are the two ways a mapping could
+ * quietly put one device's id on another.
+ *
+ * Top-level chain devices only. It is where the corpus's hosted plugins sit,
+ * and the sections the format has no shape for arrive empty rather than
+ * renumbered.
+ */
+bool mapDeviceIds(Case& value, const Case& original, std::string& refusal) {
+    const auto mapTrack = [&refusal](TrackInfo& track, const TrackInfo& source) {
+        std::map<juce::String, DeviceId> byName;
+        for (const auto& element : source.chain.fxChainElements)
+            if (isDevice(element) &&
+                !byName.emplace(getDevice(element).name, getDevice(element).id).second) {
+                refusal = "two of this case's devices on track '" + source.name.toStdString() +
+                          "' share a name, so ids cannot be mapped back";
+                return false;
+            }
+
+        NameClaims<DeviceId> claims("device", std::move(byName));
+
+        for (auto& element : track.chain.fxChainElements) {
+            if (!isDevice(element))
+                continue;
+
+            auto& device = getDevice(element);
+            const auto id = claims.claim(device.name, refusal);
+            if (!id.has_value())
+                return false;
+
+            device.id = *id;
+        }
+
+        return true;
+    };
+
+    for (auto& track : value.tracks) {
+        const auto source =
+            std::find_if(original.tracks.begin(), original.tracks.end(),
+                         [&track](const TrackInfo& candidate) { return candidate.id == track.id; });
+
+        if (source == original.tracks.end()) {
+            refusal = "a track came back that nothing went out as";
+            return false;
+        }
+
+        if (!mapTrack(track, *source))
+            return false;
+    }
+
+    return mapTrack(value.master, original.master);
+}
+
 }  // namespace
 
 RoundTrip exportAndReimport(const Case& original, const juce::File& scratchDirectory) {
@@ -788,6 +946,9 @@ RoundTrip exportAndReimport(const Case& original, const juce::File& scratchDirec
     if (!takeTracks(imported, trackIds, result.value, result.refusal))
         return result;
     if (!takeClips(imported, trackIds, original, result.value, result.refusal))
+        return result;
+
+    if (!mapDeviceIds(result.value, original, result.refusal))
         return result;
 
     result.value.sources = pooledSourcesFor(result.value.clips, media, result.refusal);

--- a/tests/NullDiffCorpus.cpp
+++ b/tests/NullDiffCorpus.cpp
@@ -6,6 +6,7 @@
 
 #include "NullDiffCase.hpp"
 #include "NullDiffGain.hpp"
+#include "NullDiffHostedPlugin.hpp"
 #include "NullDiffMaterial.hpp"
 #include "core/ChainWalk.hpp"
 #include "core/DeviceInfo.hpp"
@@ -2136,6 +2137,257 @@ std::vector<Case> buildCorpus(const juce::File& scratchDirectory) {
         value.mechanism =
             "the fork's arranger path drops midiOffset on an unlooped clip while its session "
             "path applies it; the engine applies it either way";
+
+        corpus.push_back(std::move(value));
+    }
+
+    // --- external plugins ------------------------------------------------------
+    //
+    // The first cases in the corpus that host a plugin rather than run a device
+    // written for them (#2246). What each one asserts is a number the host
+    // chose: how a mix the plugin never declared is applied, which channels a
+    // narrow plugin is handed, where a reported latency is taken out again,
+    // which bus a key arrives on, what a plugin is told about the transport, and
+    // what an instrument's MIDI does on the way in and on the way out.
+    //
+    // They are held to the ordinary floor rather than given the epsilon a
+    // project hosting a plugin may declare (#2078). The plugin is ours and does
+    // nothing that depends on how a render was framed (NullDiffHostedPlugin.hpp),
+    // so there is nothing here to attribute a difference to, and a case that
+    // took the allowance anyway would be spending it on the host.
+
+    {
+        // The pair the fork gives every external plugin and the plugin never
+        // asked for. Dry six tenths against wet four, over a plugin that
+        // inverts, so what the render carries is a fifth of the material and
+        // the arithmetic is the whole signal rather than a level somebody has
+        // to measure.
+        auto track = plainTrack();
+        auto device = hostedDevice(970, HostedRole::Polarity);
+        setHostedMix(device, 0.6f, 0.4f);
+        track.chain.fxChainElements.emplace_back(std::move(device));
+
+        auto value = newCase("plugin.wetdry", "the wrapper pair at a value a project saves",
+                             std::move(track));
+        value.endBeat = 8.0;
+
+        const auto source = writeSource(scratchDirectory, "pluginwetdry", impulses());
+        value.sources.push_back(source);
+        value.clips.push_back(audioClip(330, 0.0, 8.0, source));
+
+        corpus.push_back(std::move(value));
+    }
+
+    {
+        // Fully dry, which both engines still run the plugin for. The claim is
+        // that the slot is transparent and not that the plugin was skipped: the
+        // fork's own dry path takes the input around a plugin it nevertheless
+        // called, and the engine reproduces that including the threshold below
+        // which it stops mixing at all (EngineExternalDevice.cpp).
+        auto track = plainTrack();
+        auto device = hostedDevice(971, HostedRole::Polarity);
+        setHostedMix(device, 1.0f, 0.0f);
+        track.chain.fxChainElements.emplace_back(std::move(device));
+
+        auto value =
+            newCase("plugin.wetdry.dry", "a fully dry slot in front of a plugin that still runs",
+                    std::move(track));
+        value.endBeat = 8.0;
+
+        const auto source = writeSource(scratchDirectory, "plugindry", impulses());
+        value.sources.push_back(source);
+        value.clips.push_back(audioClip(331, 0.0, 8.0, source));
+
+        corpus.push_back(std::move(value));
+    }
+
+    {
+        // A one-channel plugin on a stereo track: the host folds the bus into
+        // it and spreads what comes back. Two-channel noise, and stated rather
+        // than left to the default for the reason rack.mono states it -- a fold
+        // of two identical channels is the identity whichever way it is done, so
+        // a case playing a mono file would null green over a host reading the
+        // wrong side.
+        auto track = plainTrack();
+        track.chain.fxChainElements.emplace_back(hostedDevice(972, HostedRole::Narrow));
+
+        auto value = newCase("plugin.mono", "a mono plugin folded into and out of a stereo chain",
+                             std::move(track));
+        value.endBeat = 8.0;
+
+        auto material = noise();
+        material.channels = 2;
+        value.seed = material.seed;
+
+        const auto source = writeSource(scratchDirectory, "pluginmono", material);
+        value.sources.push_back(source);
+        value.clips.push_back(audioClip(332, 0.0, 8.0, source));
+
+        corpus.push_back(std::move(value));
+    }
+
+    {
+        // And the adaptation the other way round: a stereo plugin in a slot one
+        // channel wide, which is what the corpus's own mono device leaves behind
+        // it inside a rack chain. The host has one channel and a plugin that
+        // wants two, and what it does with the second is arithmetic in both
+        // engines.
+        ChainInfo chain;
+        chain.id = 1;
+        chain.name = "Narrowed";
+        chain.elements.emplace_back(monoGainDevice(973, 1.0f));
+        chain.elements.emplace_back(hostedDevice(974, HostedRole::Polarity));
+
+        std::vector<ChainInfo> chains;
+        chains.push_back(std::move(chain));
+
+        auto value = newRackCase(
+            "plugin.narrow.slot", "a stereo plugin in a mono slot",
+            rackTrack(kTrack, "Narrow slot", rackOf(720, "Narrowed", std::move(chains))));
+
+        auto material = noise();
+        material.channels = 2;
+        value.seed = material.seed;
+
+        const auto source = writeSource(scratchDirectory, "pluginnarrowslot", material);
+        value.sources.push_back(source);
+        value.clips.push_back(audioClip(333, 0.0, 8.0, source));
+
+        corpus.push_back(std::move(value));
+    }
+
+    {
+        // A plugin reporting latency, against a track without one. Both tracks
+        // play the same impulses, so a compensation that worked puts one impulse
+        // per interval where two would otherwise sit 333 samples apart, and the
+        // second track's fader keeps the two halves separable if it did not.
+        //
+        // The figure is deliberately awkward (NullDiffHostedPlugin.hpp): a
+        // compensation that is only right on block boundaries is wrong here at
+        // every size the invariance gate renders at.
+        //
+        // The clips start a beat in, and that is this case's one concession to
+        // the incumbent. A render of a project whose plugin reports latency
+        // comes back from the fork with its first 333 samples missing -- the
+        // impulse at beat zero is simply not in the file, while every impulse
+        // after it sits at its own sample. The engine loses nothing there: the
+        // offline render pulls the plan's latency in extra samples at the end
+        // and drops the same number off the front, so the file starts where the
+        // range does and the material still inside the delay line comes out
+        // (OfflineRender.cpp). Starting a beat in keeps that difference out of
+        // a case about alignment, which is what this one is for.
+        auto delayed = mixTrack(1, "Through the plugin");
+        delayed.chain.fxChainElements.emplace_back(hostedDevice(975, HostedRole::Latency));
+
+        auto direct = mixTrack(2, "Direct");
+        direct.volume = 0.5f;
+
+        auto value = newMixCase("plugin.latency", "a plugin's reported latency, taken back out",
+                                {std::move(delayed), std::move(direct)});
+
+        const auto source = writeSource(scratchDirectory, "pluginlatency", impulses());
+        value.sources.push_back(source);
+        value.clips.push_back(audioClipOn(1, 334, 1.0, 7.0, source));
+        value.clips.push_back(audioClipOn(2, 335, 1.0, 7.0, source));
+
+        corpus.push_back(std::move(value));
+    }
+
+    {
+        // A sidechained plugin, which returns its key instead of its input. That
+        // is what makes the case readable rather than a level to be trusted: a
+        // host that wired nothing renders silence on this track, one that wired
+        // the main input renders this track's own impulses, and only the host
+        // that put the key on the bus after the plugin's own renders the other
+        // track's.
+        //
+        // The two tracks play different intervals for the same reason.
+        auto keyed = mixTrack(1, "Keyed");
+        auto device = hostedDevice(976, HostedRole::Key);
+        device.sidechain.type = SidechainConfig::Type::Audio;
+        device.sidechain.sourceTrackId = 2;
+        keyed.chain.fxChainElements.emplace_back(std::move(device));
+
+        auto value = newMixCase("plugin.sidechain", "a key on the bus after the plugin's own",
+                                {std::move(keyed), mixTrack(2, "Key source")});
+
+        const auto keyedSource = writeSource(scratchDirectory, "pluginkeyed", impulses(0.375));
+        const auto keySource = writeSource(scratchDirectory, "pluginkey", impulses(0.25));
+        value.sources.push_back(keyedSource);
+        value.sources.push_back(keySource);
+        value.clips.push_back(audioClipOn(1, 336, 0.0, 8.0, keyedSource));
+        value.clips.push_back(audioClipOn(2, 337, 0.0, 8.0, keySource));
+
+        corpus.push_back(std::move(value));
+    }
+
+    {
+        // What a plugin cannot work out for itself. This one discards its input
+        // and renders a sine locked to the bar from the position the host
+        // published, so a host that reported the wrong place renders the right
+        // shape at the wrong phase, and one that published nothing renders
+        // silence.
+        //
+        // The clip is there to give both engines a track with something on it
+        // rather than to be heard: the plugin overwrites whatever it is handed.
+        auto track = plainTrack();
+        track.chain.fxChainElements.emplace_back(hostedDevice(977, HostedRole::Transport));
+
+        auto value =
+            newCase("plugin.transport", "the position a plugin is told it is at", std::move(track));
+        value.endBeat = 8.0;
+
+        const auto source = writeSource(scratchDirectory, "plugintransport", impulses());
+        value.sources.push_back(source);
+        value.clips.push_back(audioClip(338, 0.0, 8.0, source));
+
+        corpus.push_back(std::move(value));
+    }
+
+    {
+        // MIDI into a hosted instrument. One sample at the note's own velocity
+        // on every note-on, which says both that the MIDI arrived and where it
+        // landed, and nothing between the two engines interpolates it.
+        auto track = plainTrack();
+        track.chain.fxChainElements.emplace_back(hostedDevice(978, HostedRole::Instrument));
+
+        auto value =
+            newCase("plugin.instrument", "MIDI into a hosted instrument", std::move(track));
+        value.endBeat = 8.0;
+
+        auto clip = midiClip(339, 0.0, 8.0);
+        for (auto index = 0; index < 8; ++index)
+            clip.midiNotes.push_back(note(60 + index, static_cast<double>(index), 0.5, 127));
+        value.clips.push_back(std::move(clip));
+
+        corpus.push_back(std::move(value));
+    }
+
+    {
+        // And MIDI out of one. The instrument answers every note-on with its own
+        // an octave up at half the velocity, the device behind it renders what it
+        // receives as impulses at a quarter of that, and the chain's raw input is
+        // held back so the second device can only be hearing the first.
+        //
+        // Three levels in one render, and they are what the case reads: the
+        // instrument's own impulse at full scale, the echo's at an eighth of it,
+        // and nothing at all where a host dropped the plugin's MIDI on the way to
+        // the next device.
+        auto track = plainTrack();
+        auto relay = hostedDevice(979, HostedRole::InstrumentMidiOut);
+        relay.midiInThru = false;
+        track.chain.fxChainElements.emplace_back(std::move(relay));
+        track.chain.fxChainElements.emplace_back(hostedDevice(980, HostedRole::Echo));
+
+        auto value =
+            newCase("plugin.instrument.midiout",
+                    "an instrument's MIDI output reaching the device behind it", std::move(track));
+        value.endBeat = 8.0;
+
+        auto clip = midiClip(340, 0.0, 8.0);
+        for (auto index = 0; index < 8; ++index)
+            clip.midiNotes.push_back(note(60 + index, static_cast<double>(index), 0.5, 127));
+        value.clips.push_back(std::move(clip));
 
         corpus.push_back(std::move(value));
     }

--- a/tests/NullDiffHostedPlugin.cpp
+++ b/tests/NullDiffHostedPlugin.cpp
@@ -1,0 +1,572 @@
+#include "NullDiffHostedPlugin.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <memory>
+#include <vector>
+
+namespace magda::nulldiff {
+
+namespace {
+
+/// A note-on with a velocity of zero is a note-off, which is the one thing a
+/// device counting note-ons has to know about MIDI.
+bool isNoteOn(const juce::MidiMessage& message) {
+    return message.isNoteOn();
+}
+
+/// What each role is called, which is what a project saves and what the scan
+/// holds. One name per role, because a project names a plugin rather than a
+/// mode.
+const char* roleName(HostedRole role) {
+    switch (role) {
+        case HostedRole::Polarity:
+            return "Null Diff Polarity";
+        case HostedRole::Narrow:
+            return "Null Diff Narrow";
+        case HostedRole::Latency:
+            return "Null Diff Latency";
+        case HostedRole::Key:
+            return "Null Diff Key";
+        case HostedRole::Transport:
+            return "Null Diff Transport";
+        case HostedRole::Instrument:
+            return "Null Diff Voice";
+        case HostedRole::InstrumentMidiOut:
+            return "Null Diff Relay";
+        case HostedRole::Echo:
+            return "Null Diff Echo";
+    }
+
+    return "Null Diff";
+}
+
+/// The identifier a scan would have recorded. A path shape rather than a real
+/// path: nothing opens it, and the lookup's file passes compare it as a string.
+juce::String roleIdentifier(HostedRole role) {
+    return juce::String("nulldiff://") + roleName(role);
+}
+
+/// The number a description carries as its own identity. Stable across runs and
+/// distinct per role, since two roles sharing one would resolve to whichever the
+/// list held first.
+int roleUid(HostedRole role) {
+    return 0x4E44'0000 + static_cast<int>(role);
+}
+
+bool roleIsInstrument(HostedRole role) {
+    return role == HostedRole::Instrument || role == HostedRole::InstrumentMidiOut;
+}
+
+bool roleAcceptsMidi(HostedRole role) {
+    return roleIsInstrument(role) || role == HostedRole::Echo;
+}
+
+bool roleProducesMidi(HostedRole role) {
+    return role == HostedRole::InstrumentMidiOut;
+}
+
+/// How many channels of chain audio the plugin reads, and how many it writes.
+/// An instrument reads none: both engines route audio around one rather than
+/// into it.
+int roleInputChannels(HostedRole role) {
+    switch (role) {
+        case HostedRole::Narrow:
+            return 1;
+        case HostedRole::Instrument:
+        case HostedRole::InstrumentMidiOut:
+            return 0;
+        default:
+            return 2;
+    }
+}
+
+int roleOutputChannels(HostedRole role) {
+    return role == HostedRole::Narrow ? 1 : 2;
+}
+
+/**
+ * @brief The plugin itself: one class, one behaviour per role.
+ *
+ * Everything it does is a function of the block it was handed and the position
+ * it was told about, with one exception that is state by definition -- the
+ * delay line the latency role reports. Nothing else accumulates, so the same
+ * timeline renders the same samples at every block size, and a case built on it
+ * can be held to bit identity across the sizes the invariance gate renders at
+ * (#2078) rather than buying the epsilon a project hosting a plugin is entitled
+ * to.
+ */
+class HostedPlugin final : public juce::AudioPluginInstance {
+  public:
+    explicit HostedPlugin(HostedRole role)
+        : juce::AudioPluginInstance(busesFor(role)), role_(role) {
+        if (role_ == HostedRole::Latency)
+            setLatencySamples(kHostedLatencySamples);
+    }
+
+    const juce::String getName() const override {
+        return roleName(role_);
+    }
+
+    void fillInPluginDescription(juce::PluginDescription& description) const override {
+        description = hostedDescription(role_);
+    }
+
+    void prepareToPlay(double sampleRate, int maximumExpectedSamplesPerBlock) override {
+        sampleRate_ = sampleRate > 0.0 ? sampleRate : 44100.0;
+        juce::ignoreUnused(maximumExpectedSamplesPerBlock);
+
+        // Cleared rather than resized-and-kept: a render is entitled to start
+        // from silence, and a delay line carrying the last case's tail would
+        // put one case's material into another's first thirty samples.
+        delay_.assign(static_cast<std::size_t>(std::max(1, kHostedLatencySamples)) * 2, 0.0f);
+        delayWritePosition_ = 0;
+
+        if (role_ == HostedRole::Latency)
+            setLatencySamples(kHostedLatencySamples);
+    }
+
+    void releaseResources() override {}
+
+    bool isBusesLayoutSupported(const BusesLayout& layouts) const override {
+        const auto width = [](const juce::AudioChannelSet& set) { return set.size(); };
+
+        if (width(layouts.getMainOutputChannelSet()) != roleOutputChannels(role_))
+            return false;
+
+        if (roleIsInstrument(role_))
+            return layouts.inputBuses.isEmpty();
+
+        if (width(layouts.getMainInputChannelSet()) != roleInputChannels(role_))
+            return false;
+
+        if (role_ == HostedRole::Key)
+            return layouts.inputBuses.size() == 2 && width(layouts.getChannelSet(true, 1)) == 2;
+
+        return layouts.inputBuses.size() == 1;
+    }
+
+    void processBlock(juce::AudioBuffer<float>& buffer, juce::MidiBuffer& midi) override {
+        const auto numSamples = buffer.getNumSamples();
+
+        switch (role_) {
+            case HostedRole::Polarity:
+                for (int channel = 0; channel < roleOutputChannels(role_); ++channel)
+                    if (channel < buffer.getNumChannels())
+                        buffer.applyGain(channel, 0, numSamples, -1.0f);
+                break;
+
+            case HostedRole::Narrow:
+                // Identity. What a mono case measures is the fold and the
+                // spread the host puts either side of this call.
+                break;
+
+            case HostedRole::Latency:
+                processDelay(buffer);
+                break;
+
+            case HostedRole::Key:
+                processKey(buffer);
+                break;
+
+            case HostedRole::Transport:
+                processTransport(buffer);
+                break;
+
+            case HostedRole::Instrument:
+            case HostedRole::InstrumentMidiOut:
+                processVoice(buffer, midi);
+                break;
+
+            case HostedRole::Echo:
+                processEcho(buffer, midi);
+                break;
+        }
+    }
+
+    double getTailLengthSeconds() const override {
+        return 0.0;
+    }
+
+    bool acceptsMidi() const override {
+        return roleAcceptsMidi(role_);
+    }
+
+    bool producesMidi() const override {
+        return roleProducesMidi(role_);
+    }
+
+    bool isMidiEffect() const override {
+        return false;
+    }
+
+    juce::AudioProcessorEditor* createEditor() override {
+        return nullptr;
+    }
+
+    bool hasEditor() const override {
+        return false;
+    }
+
+    int getNumPrograms() override {
+        return 1;
+    }
+
+    int getCurrentProgram() override {
+        return 0;
+    }
+
+    void setCurrentProgram(int) override {}
+
+    const juce::String getProgramName(int) override {
+        return "Default";
+    }
+
+    void changeProgramName(int, const juce::String&) override {}
+
+    /// No state of its own, and it says so by writing nothing.
+    ///
+    /// A plugin with a chunk would put the restore contract (#2244) in the
+    /// middle of every case here, and what these cases are about is the block.
+    /// What that contract does is asserted where it belongs, against a stub
+    /// written for it (test_engine_external_device.cpp).
+    void getStateInformation(juce::MemoryBlock& destination) override {
+        destination.reset();
+    }
+
+    void setStateInformation(const void*, int) override {}
+
+  private:
+    void processDelay(juce::AudioBuffer<float>& buffer) {
+        const auto numSamples = buffer.getNumSamples();
+        const auto length = kHostedLatencySamples;
+        const auto channels = std::min(buffer.getNumChannels(), 2);
+
+        for (int sample = 0; sample < numSamples; ++sample) {
+            const auto slot = static_cast<std::size_t>(delayWritePosition_);
+
+            for (int channel = 0; channel < channels; ++channel) {
+                auto& stored = delay_[(slot * 2) + static_cast<std::size_t>(channel)];
+                const auto input = buffer.getSample(channel, sample);
+                buffer.setSample(channel, sample, stored);
+                stored = input;
+            }
+
+            delayWritePosition_ = (delayWritePosition_ + 1) % length;
+        }
+    }
+
+    void processKey(juce::AudioBuffer<float>& buffer) {
+        auto output = getBusBuffer(buffer, false, 0);
+
+        if (getBusCount(true) < 2 || !getBus(true, 1)->isEnabled()) {
+            // A key bus the host did not give us. Silence rather than the main
+            // input, so a case reads it as the key never arriving instead of as
+            // the plugin having been bypassed.
+            output.clear();
+            return;
+        }
+
+        const auto key = getBusBuffer(buffer, true, 1);
+
+        for (int channel = 0; channel < output.getNumChannels(); ++channel) {
+            const auto source = std::min(channel, key.getNumChannels() - 1);
+            if (source < 0) {
+                output.clear(channel, 0, output.getNumSamples());
+                continue;
+            }
+
+            output.copyFrom(channel, 0, key, source, 0, output.getNumSamples());
+        }
+    }
+
+    void processTransport(juce::AudioBuffer<float>& buffer) {
+        const auto numSamples = buffer.getNumSamples();
+
+        auto* playHead = getPlayHead();
+        const auto position = playHead != nullptr
+                                  ? playHead->getPosition()
+                                  : juce::Optional<juce::AudioPlayHead::PositionInfo>{};
+
+        if (!position.hasValue()) {
+            // Nothing to render from. Silence is the right answer and a loud
+            // one: a leg that told the plugin nothing renders nothing, and the
+            // case fails against the leg that did.
+            buffer.clear();
+            return;
+        }
+
+        const auto ppq = position->getPpqPosition().orFallback(0.0);
+        const auto bpm = position->getBpm().orFallback(120.0);
+        const auto perSample = bpm / 60.0 / sampleRate_;
+
+        for (int sample = 0; sample < numSamples; ++sample) {
+            const auto beats = ppq + perSample * static_cast<double>(sample);
+            const auto value = static_cast<float>(
+                kHostedTransportLevel *
+                std::sin(2.0 * juce::MathConstants<double>::pi * beats / kHostedTransportBeats));
+
+            for (int channel = 0; channel < buffer.getNumChannels(); ++channel)
+                buffer.setSample(channel, sample, value);
+        }
+    }
+
+    void processVoice(juce::AudioBuffer<float>& buffer, juce::MidiBuffer& midi) {
+        const auto numSamples = buffer.getNumSamples();
+        buffer.clear();
+
+        juce::MidiBuffer produced;
+
+        for (const auto metadata : midi) {
+            const auto message = metadata.getMessage();
+            if (!isNoteOn(message))
+                continue;
+
+            const auto sample = std::clamp(metadata.samplePosition, 0, std::max(0, numSamples - 1));
+            const auto level = static_cast<float>(message.getVelocity()) / 127.0f;
+
+            for (int channel = 0; channel < buffer.getNumChannels(); ++channel)
+                buffer.addSample(channel, sample, level);
+
+            if (role_ == HostedRole::InstrumentMidiOut) {
+                // An octave up at half the velocity, so what reaches the next
+                // device is this plugin's own message and could not be the raw
+                // input wearing its name.
+                produced.addEvent(
+                    juce::MidiMessage::noteOn(message.getChannel(), message.getNoteNumber() + 12,
+                                              static_cast<juce::uint8>(message.getVelocity() / 2)),
+                    sample);
+            }
+        }
+
+        // What the plugin says, rather than what it was handed. A plugin that
+        // left its input in the buffer would be a passthrough claiming to be a
+        // source, and the case behind it could not tell the two apart.
+        midi.swapWith(produced);
+    }
+
+    void processEcho(juce::AudioBuffer<float>& buffer, juce::MidiBuffer& midi) {
+        const auto numSamples = buffer.getNumSamples();
+
+        for (const auto metadata : midi) {
+            const auto message = metadata.getMessage();
+            if (!isNoteOn(message))
+                continue;
+
+            const auto sample = std::clamp(metadata.samplePosition, 0, std::max(0, numSamples - 1));
+            const auto level =
+                kHostedEchoScale * static_cast<float>(message.getVelocity()) / 127.0f;
+
+            for (int channel = 0; channel < buffer.getNumChannels(); ++channel)
+                buffer.addSample(channel, sample, level);
+        }
+    }
+
+    /// The buses each role declares.
+    ///
+    /// A member because BusesProperties is the processor's own type, and a
+    /// static one because the constructor passes it to the base before there is
+    /// an instance to ask.
+    static BusesProperties busesFor(HostedRole role) {
+        const auto main = juce::AudioChannelSet::stereo();
+        const auto mono = juce::AudioChannelSet::mono();
+
+        switch (role) {
+            case HostedRole::Narrow:
+                return BusesProperties().withInput("In", mono, true).withOutput("Out", mono, true);
+
+            case HostedRole::Key:
+                // The sidechain is a second input bus, which is what makes the
+                // fork call the plugin sidechainable at all: Plugin::canSidechain
+                // asks whether it has more input channels than a track has.
+                return BusesProperties()
+                    .withInput("In", main, true)
+                    .withInput("Sidechain", main, true)
+                    .withOutput("Out", main, true);
+
+            case HostedRole::Instrument:
+            case HostedRole::InstrumentMidiOut:
+                return BusesProperties().withOutput("Out", main, true);
+
+            default:
+                return BusesProperties().withInput("In", main, true).withOutput("Out", main, true);
+        }
+    }
+
+    HostedRole role_;
+    double sampleRate_ = 44100.0;
+    std::vector<float> delay_;
+    int delayWritePosition_ = 0;
+};
+
+/**
+ * @brief The format that makes those instances, as far as either engine knows.
+ *
+ * It scans nothing and finds nothing on disk, which is the whole point: what it
+ * publishes is in the binary, so a case that hosts one of these runs on a
+ * machine with no plugins installed and on CI, where every real plugin is
+ * absent.
+ *
+ * Creation is synchronous, and it says so. The fork asks a format whether it
+ * needs an unblocked message thread and takes the async path when it does
+ * (ExternalPlugin::requiresAsyncInstantiation), which would leave a leg
+ * rendering a project whose plugins had not arrived yet.
+ */
+class HostedFormat final : public juce::AudioPluginFormat {
+  public:
+    juce::String getName() const override {
+        return kHostedFormatName;
+    }
+
+    void findAllTypesForFile(juce::OwnedArray<juce::PluginDescription>& results,
+                             const juce::String& fileOrIdentifier) override {
+        for (const auto role : kHostedRoles) {
+            auto description = hostedDescription(role);
+            if (description.fileOrIdentifier == fileOrIdentifier)
+                results.add(new juce::PluginDescription(description));
+        }
+    }
+
+    bool fileMightContainThisPluginType(const juce::String& fileOrIdentifier) override {
+        return fileOrIdentifier.startsWith("nulldiff://");
+    }
+
+    juce::String getNameOfPluginFromIdentifier(const juce::String& fileOrIdentifier) override {
+        return fileOrIdentifier.fromLastOccurrenceOf("/", false, false);
+    }
+
+    bool pluginNeedsRescanning(const juce::PluginDescription&) override {
+        return false;
+    }
+
+    bool doesPluginStillExist(const juce::PluginDescription&) override {
+        return true;
+    }
+
+    bool canScanForPlugins() const override {
+        return false;
+    }
+
+    bool isTrivialToScan() const override {
+        return true;
+    }
+
+    juce::StringArray searchPathsForPlugins(const juce::FileSearchPath&, bool, bool) override {
+        return {};
+    }
+
+    juce::FileSearchPath getDefaultLocationsToSearch() override {
+        return {};
+    }
+
+    bool requiresUnblockedMessageThreadDuringCreation(
+        const juce::PluginDescription&) const override {
+        return false;
+    }
+
+  private:
+    void createPluginInstance(const juce::PluginDescription& description, double initialSampleRate,
+                              int initialBufferSize, PluginCreationCallback callback) override {
+        for (const auto role : kHostedRoles) {
+            if (hostedDescription(role).uniqueId != description.uniqueId)
+                continue;
+
+            auto instance = std::make_unique<HostedPlugin>(role);
+            instance->setRateAndBufferSizeDetails(initialSampleRate, initialBufferSize);
+            callback(std::move(instance), {});
+            return;
+        }
+
+        callback(nullptr, "no null-diff plugin with that identity: " + description.name);
+    }
+};
+
+}  // namespace
+
+juce::PluginDescription hostedDescription(HostedRole role) {
+    juce::PluginDescription description;
+    description.name = roleName(role);
+    description.descriptiveName = description.name;
+    description.pluginFormatName = kHostedFormatName;
+    description.category = roleIsInstrument(role) ? "Synth" : "Effect";
+    description.manufacturerName = kHostedManufacturer;
+    description.version = "1.0.0";
+    description.fileOrIdentifier = roleIdentifier(role);
+    description.isInstrument = roleIsInstrument(role);
+    description.numInputChannels = roleInputChannels(role) + (role == HostedRole::Key ? 2 : 0);
+    description.numOutputChannels = roleOutputChannels(role);
+    description.uniqueId = roleUid(role);
+    description.deprecatedUid = 0;
+    return description;
+}
+
+magda::DeviceInfo hostedDevice(magda::DeviceId id, HostedRole role) {
+    const auto description = hostedDescription(role);
+
+    magda::DeviceInfo device;
+    device.id = id;
+    device.name = description.name;
+    device.pluginId = description.createIdentifierString();
+    device.manufacturer = description.manufacturerName;
+
+    // The format enum has three values and none of them is this one. What it
+    // costs is nothing: the enum decides which name the lookup's format-matching
+    // passes compare, and a device carrying an identifier never reaches them
+    // (ExternalPluginLookup.hpp). What it must not be is Internal, which is what
+    // both the plan and the block-size gate read to tell a hosted plugin from a
+    // device MAGDA wrote.
+    device.format = magda::PluginFormat::VST3;
+    device.uniqueId = description.createIdentifierString();
+    device.fileOrIdentifier = description.fileOrIdentifier;
+
+    device.isInstrument = description.isInstrument;
+    device.deviceType =
+        description.isInstrument ? magda::DeviceType::Instrument : magda::DeviceType::Effect;
+    device.canReceiveMidi = roleAcceptsMidi(role);
+    device.producesMidi = roleProducesMidi(role);
+    device.canSidechain = role == HostedRole::Key;
+    device.audioInputChannels = roleInputChannels(role);
+    device.audioOutputChannels = roleOutputChannels(role);
+
+    return device;
+}
+
+void setHostedMix(magda::DeviceInfo& device, float dry, float wet) {
+    const auto level = [](int index, const char* name, magda::WrapperRole role, float value) {
+        magda::ParameterInfo info;
+        info.paramIndex = index;
+        info.stableId = name;
+        info.name = name;
+        info.minValue = 0.0f;
+        info.maxValue = 1.0f;
+        info.defaultValue = index == 0 ? 0.0f : 1.0f;
+        info.currentValue = value;
+        info.teMinValue = 0.0f;
+        info.teMaxValue = 1.0f;
+        info.scale = magda::ParameterScale::Linear;
+        info.wrapperRole = role;
+        return info;
+    };
+
+    device.wrapperParameters.clear();
+    device.wrapperParameters.push_back(level(0, "Dry Level", magda::WrapperRole::DryGain, dry));
+    device.wrapperParameters.push_back(level(1, "Wet Level", magda::WrapperRole::WetGain, wet));
+}
+
+void installHostedPlugins(juce::AudioPluginFormatManager& formats,
+                          juce::KnownPluginList& knownPlugins) {
+    auto alreadyRegistered = false;
+    for (auto* format : formats.getFormats())
+        if (format != nullptr && format->getName() == kHostedFormatName)
+            alreadyRegistered = true;
+
+    if (!alreadyRegistered)
+        formats.addFormat(std::make_unique<HostedFormat>());
+
+    // addType replaces an entry with the same identifier rather than adding a
+    // second, so this is idempotent on its own.
+    for (const auto role : kHostedRoles)
+        knownPlugins.addType(hostedDescription(role));
+}
+
+}  // namespace magda::nulldiff

--- a/tests/NullDiffHostedPlugin.hpp
+++ b/tests/NullDiffHostedPlugin.hpp
@@ -1,0 +1,241 @@
+#pragma once
+
+#include <juce_audio_processors/juce_audio_processors.h>
+
+#include "core/DeviceInfo.hpp"
+#include "core/TypeIds.hpp"
+
+/**
+ * @file NullDiffHostedPlugin.hpp
+ * @brief The plugin the corpus hosts, and the model device that names it
+ *        (#2246).
+ *
+ * Every other device in the corpus is written twice: once as a te::Plugin for
+ * the incumbent leg and once as an SDK device for the native one, from a
+ * contract that says what the two owe each other (NullDiffGain.hpp). An
+ * external plugin is the one device that cannot be written twice, and that is
+ * the whole reason these cases exist. Neither engine wrote it, neither can ask
+ * anything of it, and both are reduced to handing it blocks and taking back
+ * what it returns -- so what the two hosts do around the plugin is the entire
+ * difference between them, and it is what a case here measures.
+ *
+ * One implementation, two hosts. The instance below is created through the
+ * ordinary path in both legs: a format registered with the engine's own
+ * juce::AudioPluginFormatManager, a description in the same
+ * juce::KnownPluginList both legs resolve against, and from there
+ * te::ExternalPlugin on one side and EngineExternalDevice on the other. Nothing
+ * in either engine knows this plugin is ours.
+ *
+ * It is in the binary rather than on the machine, and that is not a shortcut
+ * around #2175. The two questions are different. A real project hosting a real
+ * plugin asks whether this machine's Pro-Q renders the same under both engines,
+ * and it can only be asked where that plugin is installed. These ask what the
+ * host does: which channels a mono plugin is handed, what the wrapper pair
+ * means, where a sidechain key lands, what a plugin is told about the
+ * transport. Every one of those is an assertion about a number the host chose,
+ * and a plugin that reports exactly what it was given answers it on every
+ * machine, CI included, where a real plugin answers it nowhere.
+ *
+ * What each role does is chosen so the answer is readable off the render rather
+ * than inferred from it: the polarity plugin makes the wrapper pair's
+ * arithmetic the whole signal, the key plugin returns its sidechain instead of
+ * its input so a render of the wrong bus is silence, and the transport plugin
+ * renders where it thinks it is.
+ */
+
+namespace magda::nulldiff {
+
+/**
+ * @brief What a hosted plugin does with a block.
+ *
+ * One class implements all of them and one description is published per role,
+ * because a project names a plugin rather than a mode: a case that had to
+ * configure the plugin after creating it would be testing a path no project
+ * has.
+ */
+enum class HostedRole {
+    /// Stereo in, stereo out, output is the input inverted.
+    ///
+    /// The wrapper pair's own material. Dry plus wet of an inverted signal is
+    /// `(dry - wet)` times the input, so a mix the host got wrong is a level
+    /// nobody has to squint at, and a fully wet slot is full scale rather than
+    /// something that looks like the input.
+    Polarity,
+
+    /// One channel in, one channel out, output is the input.
+    ///
+    /// Identity on purpose. What a mono case measures is the fold and the
+    /// spread the host puts either side of the plugin, and a plugin that also
+    /// changed the signal would put a second arithmetic in the residual.
+    Narrow,
+
+    /// Stereo in, stereo out, delayed by @ref kHostedLatencySamples and
+    /// reporting exactly that.
+    ///
+    /// A pure delay, so what it renders is a function of the timeline and
+    /// nothing else, and the case is about the compensation rather than about
+    /// the plugin.
+    Latency,
+
+    /// Stereo main input, stereo sidechain input, stereo out; the output is the
+    /// sidechain.
+    ///
+    /// Returning the key rather than processing with it is what makes the case
+    /// legible: a host that wired the key to the wrong channels renders the
+    /// main input, and one that wired nothing renders silence. A compressor
+    /// would render a difference in level that a reader has to trust somebody
+    /// measured.
+    Key,
+
+    /// Stereo in, stereo out; the input is discarded and a sine locked to the
+    /// bar is written in its place.
+    ///
+    /// The one thing a plugin cannot work out for itself. Computed per sample
+    /// from the position the host published for the block, so it is continuous
+    /// across block boundaries and a host that framed the render differently
+    /// still owes the same samples -- and a host reporting the wrong position
+    /// renders the right shape at the wrong phase, which is loud.
+    Transport,
+
+    /// An instrument: no audio input, stereo out, one sample at
+    /// `velocity / 127` on every note-on.
+    ///
+    /// The same law the corpus's own impulse synth runs (NullDiffGain.hpp), for
+    /// the same reason: an impulse at the note's own sample says both that the
+    /// MIDI arrived and where, and nothing between the two engines interpolates
+    /// it.
+    Instrument,
+
+    /// The same instrument, which also writes every note-on it received to its
+    /// MIDI output.
+    ///
+    /// What a project does with that is @ref Echo below. Kept apart from
+    /// @ref Instrument rather than made a property of it, because a plugin that
+    /// produces MIDI is a different device to both engines -- it is what
+    /// DeviceInfo::producesMidi says and what midiInThru is about -- and a case
+    /// about an instrument's audio should not quietly be a case about its MIDI.
+    InstrumentMidiOut,
+
+    /// A stereo effect that accepts MIDI and adds an impulse at
+    /// @ref kHostedEchoScale of the velocity for every note-on it receives.
+    ///
+    /// It exists to hear what the plugin in front of it said. Behind an
+    /// @ref InstrumentMidiOut it renders the instrument's MIDI output as audio,
+    /// at a level nothing else in the render uses, so a host that dropped the
+    /// plugin's MIDI on the way to the next device renders the instrument alone
+    /// and the case says so.
+    Echo,
+};
+
+/// Every role, for the places that publish or enumerate all of them.
+inline constexpr HostedRole kHostedRoles[]{
+    HostedRole::Polarity,  HostedRole::Narrow,     HostedRole::Latency,           HostedRole::Key,
+    HostedRole::Transport, HostedRole::Instrument, HostedRole::InstrumentMidiOut, HostedRole::Echo,
+};
+
+/// What @ref HostedRole::Latency reports and delays by.
+///
+/// Not a power of two and not a multiple of any block size the corpus renders
+/// at, so a compensation that happened to be right only on aligned boundaries
+/// is wrong here.
+inline constexpr int kHostedLatencySamples = 333;
+
+/// The bar the transport plugin's sine is locked to, in quarter notes.
+inline constexpr double kHostedTransportBeats = 4.0;
+
+/// Its level. Below full scale so a host that summed it with something else
+/// does not clip the comparison.
+inline constexpr float kHostedTransportLevel = 0.5f;
+
+/// What @ref HostedRole::Echo renders, relative to the velocity it received.
+///
+/// A quarter, which is not what any instrument here renders, so the two are
+/// separable in one buffer.
+inline constexpr float kHostedEchoScale = 0.25f;
+
+/// The vendor every description carries. A vendor of our own rather than a
+/// plausible one, so nothing on a developer's machine can be confused for it.
+inline constexpr const char* kHostedManufacturer = "MAGDA Null Diff";
+
+/// The format's name, which is what a description carries and what the format
+/// manager dispatches on.
+///
+/// Its own name rather than "VST3". Two formats answering to one name are told
+/// apart only by which of them claims a file, which would make every creation
+/// in the binary depend on the real VST3 format declining a path that is not a
+/// bundle. The lookup a project resolves through does not need the name to
+/// agree: a device saved with an identifier matches on identity, which is the
+/// first pass and the exact one (ExternalPluginLookup.hpp).
+inline constexpr const char* kHostedFormatName = "Null Diff";
+
+/// The description @p role publishes, as the scan would hold it.
+juce::PluginDescription hostedDescription(HostedRole role);
+
+/**
+ * @brief The model device naming that plugin, as a project would save it.
+ *
+ * `uniqueId` is the description's own identifier string, which is what makes
+ * the device resolve by identity rather than by name: it is the first pass of
+ * the lookup and the only one that cannot return a different plugin
+ * (ExternalPluginLookup.hpp).
+ *
+ * The channel counts and the MIDI flags are the plugin's own, declared here as
+ * well because the plan reads them off the model while the incumbent reads them
+ * off the live instance. Both have to say the same thing or a case measures the
+ * disagreement between two declarations rather than what the engines do
+ * (NullDiffGain.hpp).
+ */
+magda::DeviceInfo hostedDevice(magda::DeviceId id, HostedRole role);
+
+/**
+ * @brief Put the wrapper pair on @p device at the levels a project saved.
+ *
+ * The fork gives every external plugin a dry level and a wet level the plugin
+ * never declared, at slots zero and one in front of its own parameters, and
+ * MAGDA persists both (DeviceInfo::wrapperParameters). A device that leaves
+ * them off is a device at the pair's own default, which is fully wet: the
+ * absence is a value, so a case that wants one says so.
+ */
+void setHostedMix(magda::DeviceInfo& device, float dry, float wet);
+
+/**
+ * @brief Register the format and its descriptions, once per manager.
+ *
+ * Both legs are handed the same two objects for the reason the corpus already
+ * hands them one scan: two legs that each found their own copy of a plugin
+ * would be rendering two projects and calling the difference an engine bug.
+ *
+ * Idempotent, because the runner calls it per case and the tests that build
+ * their own scan build one per project. A second call adds neither a second
+ * format nor a second description.
+ */
+void installHostedPlugins(juce::AudioPluginFormatManager& formats,
+                          juce::KnownPluginList& knownPlugins);
+
+/**
+ * @brief A scan holding the corpus's own plugins and nothing else.
+ *
+ * For the tests that drive the native leg on their own, where there is no
+ * engine to borrow a format manager from and no reason to want one: these
+ * plugins are in the binary, so a manager and a list built here hold exactly
+ * what the runner's engine-owned pair holds.
+ *
+ * A local rather than a static, and the reason is JUCE's own bookkeeping: a
+ * format manager that outlives main() is reported as a leaked
+ * AudioPluginFormat, which is a real complaint about a real object and would
+ * arrive in every future run of a binary that owns one, having nothing to do
+ * with what it was measuring. Building one costs a format and its descriptions.
+ *
+ * A real project's plugin is still absent from it, still skipped by whatever
+ * asks, and still named when it is.
+ */
+struct HostedScan {
+    HostedScan() {
+        installHostedPlugins(formats, knownPlugins);
+    }
+
+    juce::AudioPluginFormatManager formats;
+    juce::KnownPluginList knownPlugins;
+};
+
+}  // namespace magda::nulldiff

--- a/tests/NullDiffRunner.cpp
+++ b/tests/NullDiffRunner.cpp
@@ -11,12 +11,34 @@
 #include <set>
 
 #include "AssertionWatch.hpp"
+#include "NullDiffHostedPlugin.hpp"
 #include "NullDiffNativeLeg.hpp"
 #include "NullDiffTeLeg.hpp"
 #include "SharedTestEngine.hpp"
 
 namespace magda::nulldiff {
 namespace {
+
+/**
+ * @brief Put the corpus's own plugins where a project can find them (#2246).
+ *
+ * They are in this binary rather than on this machine, so there is nothing to
+ * search for and nothing that can be missing: the format is registered with the
+ * engine's own manager and the descriptions go into the engine's own scan, which
+ * is the list both legs already resolve against.
+ *
+ * Called per case and idempotent, because the alternative is a static
+ * initialiser that would have to run before the engine it registers with
+ * exists.
+ */
+void installCorpusPlugins() {
+    auto* engine = magda::test::getSharedEngine().getEngine();
+    if (engine == nullptr)
+        return;
+
+    auto& plugins = engine->getPluginManager();
+    installHostedPlugins(plugins.pluginFormatManager, plugins.knownPluginList);
+}
 
 /**
  * @brief The one scan both legs resolve a project's plugins against.
@@ -314,6 +336,12 @@ CaseReport runCase(const Case& value, const RunnerLog& log) {
     report.name = value.name;
     report.tier = value.tier;
     report.environment = value.environment();
+
+    // The corpus's own plugins first, which are a fact about the binary, then
+    // whatever this machine has: a case naming one of ours must not depend on a
+    // folder walk, and a case naming a real plugin must not be answered by one
+    // of ours.
+    installCorpusPlugins();
 
     // Looked for before the scan is read, so that "this machine has not scanned
     // it" is a fact about the machine rather than about the binary.

--- a/tests/PlanGoldenFixtures.cpp
+++ b/tests/PlanGoldenFixtures.cpp
@@ -40,6 +40,13 @@ DeviceInfo effect(DeviceId id) {
     device.id = id;
     device.name = "Effect " + juce::String(id);
     device.deviceType = DeviceType::Effect;
+
+    // What it is, rather than what the struct defaults to. DeviceInfo::format
+    // starts at VST3, and every device in these fixtures stands for one MAGDA
+    // runs: an external plugin is handed the bus and adapts its own channels,
+    // so a fixture about declared widths has to be a device that declares them
+    // (#2246).
+    device.format = PluginFormat::Internal;
     return device;
 }
 
@@ -63,6 +70,7 @@ DeviceInfo instrument(DeviceId id) {
     device.deviceType = DeviceType::Instrument;
     device.isInstrument = true;
     device.canReceiveMidi = true;
+    device.format = PluginFormat::Internal;
     return device;
 }
 

--- a/tests/engine/test_dawproject_round_trip.cpp
+++ b/tests/engine/test_dawproject_round_trip.cpp
@@ -7,6 +7,7 @@
 
 #include "DawProjectRoundTrip.hpp"
 #include "NullDiffCompare.hpp"
+#include "NullDiffHostedPlugin.hpp"
 #include "NullDiffNativeLeg.hpp"
 #include "TextDifference.hpp"
 #include "plan/PlanCompiler.hpp"
@@ -182,9 +183,18 @@ bool midiHolds(const NativeRender& before, const NativeRender& after) {
 
 /// The two models render the same samples, and send the same MIDI where the
 /// case captures any.
+///
+/// Both renders are handed the corpus's own plugins (#2246). Without them a case
+/// that hosts one binds a passthrough on both sides, reports the same missing
+/// plugin twice, and nulls against itself: a round trip certified for a project
+/// whose plugin never ran, which is exactly the shape of pass this file exists
+/// to refuse elsewhere.
 bool renderHolds(const Case& value, const Case& imported) {
-    const auto before = renderNative(value);
-    const auto after = renderNative(imported);
+    HostedScan scan;
+    const InstalledPlugins installed{.formats = &scan.formats, .knownPlugins = &scan.knownPlugins};
+
+    const auto before = renderNative(value, installed);
+    const auto after = renderNative(imported, installed);
 
     {
         INFO("the original would not render: " << before.failure);

--- a/tests/engine/test_null_diff_block_size.cpp
+++ b/tests/engine/test_null_diff_block_size.cpp
@@ -10,6 +10,7 @@
 
 #include "MgdFixture.hpp"
 #include "NullDiffCompare.hpp"
+#include "NullDiffHostedPlugin.hpp"
 #include "NullDiffNativeLeg.hpp"
 
 /**
@@ -74,10 +75,12 @@
  * project with no plugin in it, which is the one way this tier could be turned
  * into a way to make a failing case pass.
  *
- * The corpus hosts no plugin today, so every case here is held to bit identity
- * and the external path is exercised by the hand-built cases at the bottom.
- * That is deliberate: #1893 brings the first plugin, and it should find a gate
- * to land in rather than a gate to widen.
+ * The corpus hosts plugins now (#2246), and they landed in the gate rather than
+ * widening it: every one of those cases is still held to bit identity, because
+ * the plugin they host is the corpus's own and does nothing that depends on how
+ * a render was framed (NullDiffHostedPlugin.hpp). The epsilon stays where it
+ * was written for -- a real plugin in a real project, which owes nobody a
+ * sample -- and the cases that could have claimed it do not.
  *
  * One value is refused rather than judged, in both places it could arrive: an
  * epsilon of positive infinity. It is not finite, so a rule written as "does
@@ -121,6 +124,16 @@ constexpr std::array<int, 3> kOtherBlockSizes{64, 96, 4096};
 /// that differed audibly. A second comparator would have been a second thing to
 /// keep honest.
 constexpr double kBitIdenticalDb = -std::numeric_limits<double>::infinity();
+
+/// The corpus's own plugins, as an installed scan (NullDiffHostedPlugin.hpp).
+///
+/// It is what makes a case that hosts one measurable here rather than reported
+/// as not gated: they are in the binary, where a real plugin would need the
+/// folder walk that turns a fast gate into a slow one. So a real project's
+/// plugin is absent by construction, skipped below, and named when it is.
+InstalledPlugins installedFrom(HostedScan& scan) {
+    return {.formats = &scan.formats, .knownPlugins = &scan.knownPlugins};
+}
 
 std::string join(const std::vector<std::string>& parts) {
     std::string joined;
@@ -191,6 +204,8 @@ std::string undeclaredDiagnostic(const Case& value, const NativeRender& rendered
 GateResult gate(const Case& value) {
     GateResult result;
 
+    HostedScan scan;
+
     const auto external = externalDevicesIn(value);
     const auto allowed = external.empty() ? kBitIdenticalDb : value.blockSizeEpsilonDb;
 
@@ -207,7 +222,7 @@ GateResult gate(const Case& value) {
 
     auto reference = value;
     reference.blockSize = kReferenceBlockSize;
-    const auto rendered = renderNative(reference);
+    const auto rendered = renderNative(reference, installedFrom(scan));
 
     if (!rendered.failure.empty()) {
         result.unmeasurable = "at " + std::to_string(kReferenceBlockSize) + ": " + rendered.failure;
@@ -225,7 +240,7 @@ GateResult gate(const Case& value) {
     // function of the timeline is not a function of anything the rest of this
     // file is asking about.
     {
-        const auto again = renderNative(reference);
+        const auto again = renderNative(reference, installedFrom(scan));
         if (!again.failure.empty()) {
             result.unmeasurable =
                 "at " + std::to_string(kReferenceBlockSize) + ", rendered again: " + again.failure;
@@ -255,7 +270,7 @@ GateResult gate(const Case& value) {
     for (const auto blockSize : kOtherBlockSizes) {
         auto other = value;
         other.blockSize = blockSize;
-        const auto second = renderNative(other);
+        const auto second = renderNative(other, installedFrom(scan));
 
         if (!second.failure.empty()) {
             result.unmeasurable = "at " + std::to_string(blockSize) + ": " + second.failure;
@@ -347,11 +362,11 @@ TEST_CASE("Every project renders the same audio at 64, 512 and 4096", "[nulldiff
     // Four real projects are on it, and they arrived together with the projects
     // themselves (#2081). What they have in common is the one thing no case
     // above them has: a device MAGDA ships. The code-built corpus contains four
-    // devices and all four were written for it -- a gain, a mono gain, an
-    // impulse synth and a multi-out (NullDiffGain.hpp) -- so until a real
-    // project was gated, this claim had never been asked of a Poly Synth, an FM
-    // synth, a Drum Grid, a reverb, a limiter, a Clouds, a sidechain or a Faust
-    // device.
+    // devices written for it -- a gain, a mono gain, an impulse synth and a
+    // multi-out (NullDiffGain.hpp) -- and, since #2246, a hosted plugin also
+    // written for it. So until a real project was gated, this claim had never
+    // been asked of a Poly Synth, an FM synth, a Drum Grid, a reverb, a limiter,
+    // a Clouds, a sidechain or a Faust device.
     //
     // What was measured, at 64, 96 and 4096 against 512:
     //
@@ -385,6 +400,8 @@ TEST_CASE("Every project renders the same audio at 64, 512 and 4096", "[nulldiff
     // depend on is the block size and not the process's history.
     const std::set<std::string> knownIrreproducible{};
 
+    HostedScan scan;
+
     std::vector<std::string> refusals;
     const auto projects = everyProject(refusals);
 
@@ -416,12 +433,11 @@ TEST_CASE("Every project renders the same audio at 64, 512 and 4096", "[nulldiff
         if (value.tier == AudioTier::None)
             continue;
 
-        // And a project whose plugin nothing here has scanned (#2175). Every
-        // render in this file goes through the no-scan overload -- these are
-        // Catch2 tests over the model, with no engine beside them and nothing
-        // that could scan a plugin folder without turning a fast gate into a
-        // slow one -- so an external plugin is absent by construction and a
-        // passthrough would be bound in its place.
+        // And a project whose plugin nothing here has (#2175). The scan this
+        // file renders through holds the corpus's own plugins and nothing else:
+        // they are in the binary, where a real plugin would need the folder walk
+        // that turns a fast gate into a slow one. So a real project's plugin is
+        // absent by construction and a passthrough would be bound in its place.
         //
         // A passthrough is perfectly block-size invariant, which is what makes
         // this the one place the substitution has to be refused rather than
@@ -433,9 +449,11 @@ TEST_CASE("Every project renders the same audio at 64, 512 and 4096", "[nulldiff
         //
         // The epsilon these projects would buy (#2078) is not dead code waiting
         // for a use. It is what a machine with the plugins installed measures
-        // them within, and the day this gate is handed a scan it is the bound
-        // that stops the difference being absorbed.
-        if (const auto absent = absentPluginsIn(value, nullptr); !absent.empty()) {
+        // them within, and it is the bound that stops the difference being
+        // absorbed on the day one of them is gated here. The corpus's own
+        // hosted cases do not take it and do not need it: they get through this
+        // gate on bit identity like everything else (#2246).
+        if (const auto absent = absentPluginsIn(value, &scan.knownPlugins); !absent.empty()) {
             notRun.insert(value.name + " (" + join(absent) + ")");
             continue;
         }

--- a/tests/engine/test_null_diff_corpus.cpp
+++ b/tests/engine/test_null_diff_corpus.cpp
@@ -36,7 +36,7 @@ juce::File scratch() {
 TEST_CASE("The corpus builds and covers what the slice claims", "[nulldiff][corpus]") {
     const auto corpus = sharedCorpus(scratch());
 
-    REQUIRE(corpus.size() == 55);
+    REQUIRE(corpus.size() == 64);
 
     std::set<std::string> names;
     for (const auto& value : corpus)
@@ -98,7 +98,16 @@ TEST_CASE("The corpus builds and covers what the slice claims", "[nulldiff][corp
                                  "midi.cc",
                                  "midi.mpe",
                                  "midi.fold",
-                                 "midi.offset"})
+                                 "midi.offset",
+                                 "plugin.wetdry",
+                                 "plugin.wetdry.dry",
+                                 "plugin.mono",
+                                 "plugin.narrow.slot",
+                                 "plugin.latency",
+                                 "plugin.sidechain",
+                                 "plugin.transport",
+                                 "plugin.instrument",
+                                 "plugin.instrument.midiout"})
         CHECK(names.count(expected) == 1);
 }
 

--- a/tests/engine/test_null_diff_native_leg.cpp
+++ b/tests/engine/test_null_diff_native_leg.cpp
@@ -5,6 +5,7 @@
 #include <string>
 
 #include "NullDiffGain.hpp"
+#include "NullDiffHostedPlugin.hpp"
 #include "NullDiffNativeLeg.hpp"
 
 /**
@@ -42,10 +43,18 @@ double peakOf(const juce::AudioBuffer<float>& buffer) {
 }  // namespace
 
 TEST_CASE("Every case renders through the native engine", "[nulldiff][native]") {
+    // The corpus's own plugins, which are in this binary rather than on this
+    // machine (#2246). Without them a case that hosts one renders a passthrough
+    // and says so in the diagnostics, which is the right answer to the wrong
+    // question: what this file asks is whether the leg renders the corpus, and
+    // the corpus includes the projects it brought a plugin for.
+    HostedScan scan;
+    const InstalledPlugins installed{.formats = &scan.formats, .knownPlugins = &scan.knownPlugins};
+
     for (const auto& value : sharedCorpus(scratch())) {
         INFO(value.name);
 
-        const auto rendered = renderNative(value);
+        const auto rendered = renderNative(value, installed);
 
         CHECK(rendered.failure.empty());
 

--- a/tests/engine/test_offline_render.cpp
+++ b/tests/engine/test_offline_render.cpp
@@ -139,6 +139,8 @@ class LatentDevice final : public EngineDevice {
     }
 
     void process(DeviceBlock& block) override {
+        ++blocksProcessed;
+
         const auto channels = std::min(static_cast<int>(block.audio.getNumChannels()), channels_);
 
         for (auto sample = 0; sample < block.block.numSamples; ++sample) {

--- a/tests/engine/test_offline_render.cpp
+++ b/tests/engine/test_offline_render.cpp
@@ -116,6 +116,52 @@ class DecayDevice final : public EngineDevice {
     float level_ = 0.0f;
 };
 
+/// A pure delay that reports exactly what it delays by (#2246).
+///
+/// The one device shape that can say whether a render was compensated: what
+/// comes out is what went in, moved, so a render that took the latency back out
+/// is sample for sample the render of the same project without it, and one that
+/// did not is that render late.
+class LatentDevice final : public EngineDevice {
+  public:
+    explicit LatentDevice(int latencySamples) : latency_(latencySamples) {}
+
+    int latencySamples() const override {
+        return latency_;
+    }
+
+    void prepare(const RenderContext& context) override {
+        delay_.assign(static_cast<std::size_t>(std::max(1, latency_)) *
+                          static_cast<std::size_t>(std::max(1, context.numChannels)),
+                      0.0f);
+        channels_ = std::max(1, context.numChannels);
+        position_ = 0;
+    }
+
+    void process(DeviceBlock& block) override {
+        const auto channels = std::min(static_cast<int>(block.audio.getNumChannels()), channels_);
+
+        for (auto sample = 0; sample < block.block.numSamples; ++sample) {
+            for (auto channel = 0; channel < channels; ++channel) {
+                auto& stored = delay_[(static_cast<std::size_t>(position_) *
+                                       static_cast<std::size_t>(channels_)) +
+                                      static_cast<std::size_t>(channel)];
+                const auto input = block.audio.getSample(channel, sample);
+                block.audio.setSample(channel, sample, stored);
+                stored = input;
+            }
+
+            position_ = (position_ + 1) % std::max(1, latency_);
+        }
+    }
+
+  private:
+    int latency_ = 0;
+    int channels_ = 2;
+    int position_ = 0;
+    std::vector<float> delay_;
+};
+
 /// Everything a render produced, as one stream per channel, so two renders are
 /// comparable sample for sample however they were cut into blocks.
 class CollectingSink final : public OfflineRenderSink {
@@ -455,4 +501,66 @@ TEST_CASE("An offline render's block size is held to what the plan was prepared 
     // Cut to the prepared size rather than asserted against: the caller's block
     // size is a batching hint and the render is the same audio either way.
     CHECK(result.blocksRendered == static_cast<int>((result.samplesRendered + 127) / 128));
+}
+
+TEST_CASE("A render takes the plan's own latency back out", "[engine][offline]") {
+    // What a bounce owes: its first sample is the range's first sample. A plan
+    // whose devices report latency is that far behind the timeline, which is
+    // right during playback and wrong in a file -- a bounce that starts late
+    // drifts against every other bounce of the same project, and against the
+    // project itself the moment it is imported back in.
+    //
+    // Asserted as an identity rather than as an offset. A pure delay that is
+    // compensated renders what the same project renders without it, so the
+    // reference here is that project: nothing about the expected samples has to
+    // be written down, and a compensation that is off by one fails as loudly as
+    // one that is missing.
+    constexpr int kLatency = 333;
+
+    std::vector<float> reference;
+    {
+        Harness harness;
+        REQUIRE(harness.prepare(512).empty());
+
+        CollectingSink sink;
+        REQUIRE_FALSE(harness.render({0.0, 4.0, 0.0, 512}, sink).refused);
+        reference = sink.samples;
+    }
+
+    Harness harness(true);
+    harness.context = RenderContext{kSampleRate, 512, 2};
+
+    harness.source = std::make_unique<TimelineRamp>();
+    harness.source->prepare(harness.context);
+    harness.bindings.clipAudio[1] = harness.source.get();
+
+    LatentDevice latent(kLatency);
+    latent.prepare(harness.context);
+
+    for (const auto& op : harness.plan.ops)
+        if (op.kind == magda::engine::OpKind::Device)
+            harness.bindings.devices[op.key.deviceKey()] = &latent;
+
+    harness.valueMessages = magda::engine::resolvePlanValues(harness.plan, harness.tracks,
+                                                             harness.master, harness.values);
+    REQUIRE(harness.executor.prepare(harness.plan, harness.bindings, harness.context).empty());
+    REQUIRE(harness.executor.latencySamples() == kLatency);
+
+    CollectingSink sink;
+    const auto result = harness.render({0.0, 4.0, 0.0, 512}, sink);
+
+    CHECK_FALSE(result.refused);
+
+    // The same length as the range asked for, so the extra samples the render
+    // pulled to flush the delay went to the trim rather than into the file, and
+    // what the result reports is what the sink was handed.
+    CHECK(sink.samples.size() == reference.size());
+    CHECK(result.samplesRendered == static_cast<std::int64_t>(sink.samples.size()));
+    CHECK(result.blocksRendered == sink.blocks);
+
+    REQUIRE(sink.samples.size() == reference.size());
+    for (std::size_t sample = 0; sample < reference.size(); ++sample) {
+        INFO("sample " << sample);
+        REQUIRE(sink.samples[sample] == approx(reference[sample]));
+    }
 }

--- a/tests/engine/test_offline_render.cpp
+++ b/tests/engine/test_offline_render.cpp
@@ -155,6 +155,10 @@ class LatentDevice final : public EngineDevice {
         }
     }
 
+    /// Blocks it was handed, which is how a render that produced nothing for the
+    /// sink can still be caught having run the graph.
+    int blocksProcessed = 0;
+
   private:
     int latency_ = 0;
     int channels_ = 2;
@@ -233,6 +237,28 @@ struct Harness {
     std::vector<std::unique_ptr<DecayDevice>> devices;
     DecayDevice* decay = nullptr;
 };
+
+/// A harness whose one device is @p latent, prepared and ready to render.
+///
+/// The plain Harness binds its own decaying device to every Device op, which is
+/// the wrong shape for a latency question: what these tests need is a device
+/// that reports one and delays by exactly it.
+void bindLatentDevice(Harness& harness, LatentDevice& latent) {
+    harness.context = RenderContext{kSampleRate, 512, 2};
+
+    harness.source = std::make_unique<TimelineRamp>();
+    harness.source->prepare(harness.context);
+    harness.bindings.clipAudio[1] = harness.source.get();
+
+    latent.prepare(harness.context);
+
+    for (const auto& op : harness.plan.ops)
+        if (op.kind == magda::engine::OpKind::Device)
+            harness.bindings.devices[op.key.deviceKey()] = &latent;
+
+    harness.valueMessages = magda::engine::resolvePlanValues(harness.plan, harness.tracks,
+                                                             harness.master, harness.values);
+}
 
 Catch::Approx approx(float value) {
     return Catch::Approx(value).margin(1e-6);
@@ -528,21 +554,9 @@ TEST_CASE("A render takes the plan's own latency back out", "[engine][offline]")
     }
 
     Harness harness(true);
-    harness.context = RenderContext{kSampleRate, 512, 2};
-
-    harness.source = std::make_unique<TimelineRamp>();
-    harness.source->prepare(harness.context);
-    harness.bindings.clipAudio[1] = harness.source.get();
-
     LatentDevice latent(kLatency);
-    latent.prepare(harness.context);
+    bindLatentDevice(harness, latent);
 
-    for (const auto& op : harness.plan.ops)
-        if (op.kind == magda::engine::OpKind::Device)
-            harness.bindings.devices[op.key.deviceKey()] = &latent;
-
-    harness.valueMessages = magda::engine::resolvePlanValues(harness.plan, harness.tracks,
-                                                             harness.master, harness.values);
     REQUIRE(harness.executor.prepare(harness.plan, harness.bindings, harness.context).empty());
     REQUIRE(harness.executor.latencySamples() == kLatency);
 
@@ -563,4 +577,28 @@ TEST_CASE("A render takes the plan's own latency back out", "[engine][offline]")
         INFO("sample " << sample);
         REQUIRE(sink.samples[sample] == approx(reference[sample]));
     }
+}
+
+TEST_CASE("An empty range renders nothing through a plan that reports latency",
+          "[engine][offline]") {
+    // The flush that takes a plan's latency back out is for pushing the last of
+    // a range through the graph, and a range with no samples in it has nothing
+    // to push. Rendering it anyway would run every bound device for blocks the
+    // sink is never handed, which is a side effect an empty request is not
+    // supposed to have: a device left holding something, and a caller that can
+    // be asked whether to continue a render that produced nothing.
+    Harness harness(true);
+    LatentDevice latent(333);
+    bindLatentDevice(harness, latent);
+
+    REQUIRE(harness.executor.prepare(harness.plan, harness.bindings, harness.context).empty());
+    REQUIRE(harness.executor.latencySamples() == 333);
+
+    CollectingSink sink;
+    const auto result = harness.render({4.0, 4.0, 0.0, 512}, sink);
+
+    CHECK_FALSE(result.refused);
+    CHECK(result.samplesRendered == 0);
+    CHECK(sink.blocks == 0);
+    CHECK(latent.blocksProcessed == 0);
 }

--- a/tests/engine/test_render_plan_compiler.cpp
+++ b/tests/engine/test_render_plan_compiler.cpp
@@ -38,6 +38,12 @@ DeviceInfo makeEffect(DeviceId id) {
     device.id = id;
     device.name = "Effect " + juce::String(id);
     device.deviceType = DeviceType::Effect;
+
+    // What it is, rather than what the struct defaults to. DeviceInfo::format
+    // starts at VST3, and these stand for devices MAGDA runs: an external
+    // plugin is handed the bus and adapts its own channels, so the width rules
+    // below are asked of a device that has declared what it reads (#2246).
+    device.format = PluginFormat::Internal;
     return device;
 }
 
@@ -48,6 +54,7 @@ DeviceInfo makeInstrument(DeviceId id) {
     device.deviceType = DeviceType::Instrument;
     device.isInstrument = true;
     device.canReceiveMidi = true;
+    device.format = PluginFormat::Internal;
     return device;
 }
 
@@ -328,6 +335,27 @@ TEST_CASE("A device's channel counts reach the ports it is compiled to",
         // on both sides, not a narrower chain.
         CHECK(inputOp(plan, opsWithRole(plan, OpRole::TrackFader).front(), 0) ==
               deviceOutput(plan, 7));
+    }
+
+    SECTION("an external plugin is handed the bus whatever it declares") {
+        // The one device the plan has no opinion about (#2246). A hosted plugin
+        // that reports one channel is still given both, because the fold and the
+        // spread either side of it are the fork's own arithmetic and the adapter
+        // reproduces them (EngineExternalDevice.cpp). Narrowing the port first
+        // would hand it the left channel and take the average nowhere.
+        auto hosted = makeMonoEffect(7);
+        hosted.format = PluginFormat::VST3;
+
+        std::vector<TrackInfo> tracks{makeTrack(1)};
+        tracks[0].chain.fxChainElements.push_back(makeDeviceElement(hosted));
+
+        const auto plan =
+            magda::engine::compileRenderPlan(tracks, makeMaster(), withoutDeviceMeters());
+        requireWellFormed(plan);
+
+        const auto widths = widthsOf(plan, 7);
+        CHECK(widths.in == 2);
+        CHECK(widths.out == 2);
     }
 
     SECTION("a device wider than the bus is clamped to it") {

--- a/tests/engine/test_render_plan_executor.cpp
+++ b/tests/engine/test_render_plan_executor.cpp
@@ -78,6 +78,12 @@ DeviceInfo makeEffect(DeviceId id) {
     device.id = id;
     device.name = "Effect " + juce::String(id);
     device.deviceType = DeviceType::Effect;
+
+    // What it is, rather than what the struct defaults to. DeviceInfo::format
+    // starts at VST3, and these stand for devices MAGDA runs: an external
+    // plugin is handed the bus and adapts its own channels, so the width rules
+    // below are asked of a device that has declared what it reads (#2246).
+    device.format = PluginFormat::Internal;
     return device;
 }
 
@@ -88,6 +94,7 @@ DeviceInfo makeInstrument(DeviceId id) {
     device.deviceType = DeviceType::Instrument;
     device.isInstrument = true;
     device.canReceiveMidi = true;
+    device.format = PluginFormat::Internal;
     return device;
 }
 


### PR DESCRIPTION
Slice 5 of #1893, and the last of it. Every other device in the corpus is written twice, once for each leg, from a contract that says what the two owe each other. An external plugin is the one device that cannot be written twice, and that is the whole reason these cases exist: neither engine wrote it and neither can ask it anything, so what the two hosts do around it is the entire difference between them.

## One implementation, two hosts

`NullDiffHostedPlugin` is a `juce::AudioPluginInstance` behind a `juce::AudioPluginFormat`, registered with the engine's own format manager and listed in the same `KnownPluginList` both legs resolve against. It arrives as a `te::ExternalPlugin` on one side and an `EngineExternalDevice` on the other, by the ordinary path, and nothing in either engine knows the plugin is ours.

It is in the binary rather than on the machine, and that is not a shortcut around #2175. The two questions are different. A real project hosting a real plugin asks whether this machine's Pro-Q renders the same under both engines, and it can only be asked where that plugin is installed. These ask what the host does -- which channels a narrow plugin is handed, what the wrapper pair means, where a key lands, what a plugin is told about the transport. Every one of those is an assertion about a number the host chose, and a plugin that reports exactly what it was given answers it on CI, where every real plugin is absent.

Each role is shaped so the answer is readable off the render rather than inferred from it: the polarity plugin makes the wrapper pair's arithmetic the whole signal, the key plugin returns its sidechain instead of its input so a render of the wrong bus is silence, and the transport plugin renders where it thinks it is.

## The nine cases

| case | what it pins |
| --- | --- |
| `plugin.wetdry` | the wrapper pair at dry 0.6 / wet 0.4 over an inverting plugin |
| `plugin.wetdry.dry` | a fully dry slot in front of a plugin that still runs |
| `plugin.mono` | a mono plugin folded into and out of a stereo chain |
| `plugin.narrow.slot` | a stereo plugin in a mono slot |
| `plugin.latency` | a reported latency, taken back out, against a track without one |
| `plugin.sidechain` | a key on the bus after the plugin's own |
| `plugin.transport` | the position a plugin is told it is at |
| `plugin.instrument` | MIDI into a hosted instrument |
| `plugin.instrument.midiout` | an instrument's MIDI output reaching the device behind it |

All nine null exactly (peak `-inf`), and all nine hold **bit identity** through the block-size gate (#2078) rather than taking the epsilon a project hosting a plugin may declare. The plugin is ours and nothing it does depends on how a render was framed, so there is nothing here to attribute a difference to and the cases do not spend the allowance on the host.

## Two of them found bugs

**A mono plugin was handed one side of the bus.** The fork averages a stereo bus into a mono plugin and spreads the result back over both sides, and `EngineExternalDevice` transcribes every step of that -- but the plan narrowed the port to one channel first, so the device got the left channel and the average was never taken. The arithmetic was in the adapter, unreachable. Measured before the fix: a peak residual of -6.0 dB, which is exactly `|L - R| / 2` on the case's two-channel noise.

`PlanCompiler` now leaves an external plugin's widths at the bus. The adaptation is the adapter's, it is arithmetic rather than routing, and every project hosting a plugin that is not stereo was mixed against the fork's version of it.

**A render came back late by the plugin's latency.** A plan whose devices report latency is that far behind the timeline, which is right during playback and wrong in a file: the whole render sat 333 samples late, so a bounce would drift against every other bounce of the same project, and against the project itself the moment it is imported back in.

`renderOffline` pulls the plan's latency in extra samples at the end and drops the same number off the front, so the file starts where the range does and material still inside a delay line when the range ends comes out rather than being cut off. `OfflineRenderResult` now reports what the sink received rather than what the render pulled.

The incumbent compensates by losing its first 333 samples instead -- the impulse at beat zero is simply not in its file, while every impulse after it sits at its own sample. That is why the case's clips start a beat in, and the case says so where it does it: it is about alignment, and the fork's own head loss is not what it is measuring.

## What the corpus's own plugins changed around them

- The block-size gate and the native-leg test build a scan of their own instead of reporting these cases as not gated for want of a plugin no scan here could find. A real project's plugin is still absent, still skipped, still named.
- The DAWproject round trip maps **device** ids back by name, the way it already maps tracks and clips. The comment that said this would be needed "the day a case carries a VST3" was right; this is that day. It also declares two losses the format really has: a device's sidechain source, which is a reference from a device to a track, and what its MIDI ports do, which is a capability read off a live plugin.
- The plan goldens and the compiler and executor tests now say `Internal` on the devices they stand up. `DeviceInfo::format` starts at VST3, and a fixture about declared widths has to be a device that declares them -- the same correction #2174 made in the corpus.

## Tests

- `tests/NullDiffHostedPlugin.{hpp,cpp}`: the plugin, its format and the model device that names it.
- The nine `plugin.*` cases in the corpus, through both legs, the block-size gate and the DAWproject round trip.
- `test_render_plan_compiler.cpp`: an external plugin is handed the bus whatever it declares.
- `test_offline_render.cpp`: a compensated pure delay renders what the same project renders without it, asserted as an identity rather than as an offset.

## Verification

Full Catch2 suite passes (740,358 assertions), the whole JUCE suite passes, and the app builds.

https://claude.ai/code/session_01Qa7GxDU184RGxo2b1Yhpa6
