### PR TITLE
Expose device parameter discovery and control over MCP (#2274)

### DIFF
--- a/docs/architecture/remote-api-permissions.md
+++ b/docs/architecture/remote-api-permissions.md
@@ -53,7 +53,7 @@ Five words, shared by both transports. An operation requires exactly one.
 | Scope | Covers |
 | --- | --- |
 | `read` | Every read operation, and subscribing to any topic. Every client has this — it is what being admitted means. |
-| `edit` | Project content: tempo, time signature, tracks, clips, notes, devices, racks, automation, and the user's selection. |
+| `edit` | Project content: tempo, time signature, tracks, clips, notes, devices, racks, automation, and the user's selection. Device parameter writes and opening plugin editor windows are edits too. |
 | `transport` | The timeline: play, stop, record-arm, loop, seek. |
 | `session` | Launching and stopping session clips and scenes. |
 | `hardware-midi` | Physical MIDI ports, including SysEx. |

--- a/magda/daw/api/device_api.hpp
+++ b/magda/daw/api/device_api.hpp
@@ -114,6 +114,15 @@ class DeviceApi {
      */
     virtual bool setDeviceParameter(const ChainNodePath& devicePath, int paramIndex,
                                     float value) = 0;
+
+    /**
+     * @brief Open the device's plugin editor window in the MAGDA UI.
+     *
+     * Returns whether a window is actually open afterwards — false when the
+     * path does not resolve, when no engine is running (headless), or when
+     * the device has no native editor to show.
+     */
+    virtual bool openDeviceEditor(const ChainNodePath& devicePath) = 0;
 };
 
 }  // namespace magda

--- a/magda/daw/api/device_api_live.cpp
+++ b/magda/daw/api/device_api_live.cpp
@@ -4,11 +4,13 @@
 #include <cmath>
 #include <memory>
 
+#include "../audio/AudioBridge.hpp"
 #include "../audio/plugins/InternalPluginRegistry.hpp"
 #include "../audio/plugins/compiled/CompiledPluginRegistry.hpp"
 #include "../core/TrackCommands.hpp"
 #include "../core/TrackManager.hpp"
 #include "../core/UndoManager.hpp"
+#include "../engine/AudioEngine.hpp"
 #include "plugin_api_live.hpp"
 
 namespace magda {
@@ -242,6 +244,20 @@ bool DeviceApiLive::setDeviceParameter(const ChainNodePath& devicePath, int para
 
     TrackManager::getInstance().setDeviceParameterValue(devicePath, paramIndex, value);
     return true;
+}
+
+bool DeviceApiLive::openDeviceEditor(const ChainNodePath& devicePath) {
+    if (getDevice(devicePath) == nullptr)
+        return false;
+    auto* engine = TrackManager::getInstance().getAudioEngine();
+    auto* bridge = engine != nullptr ? engine->getAudioBridge() : nullptr;
+    if (bridge == nullptr)
+        return false;
+    bridge->showPluginWindow(devicePath);
+    // showPluginWindow is best-effort — an analysis device or a plugin with no
+    // native editor shows nothing — so report what actually happened rather
+    // than that the request was heard.
+    return bridge->isPluginWindowOpen(devicePath);
 }
 
 }  // namespace magda

--- a/magda/daw/api/device_api_live.cpp
+++ b/magda/daw/api/device_api_live.cpp
@@ -7,6 +7,7 @@
 #include "../audio/AudioBridge.hpp"
 #include "../audio/plugins/InternalPluginRegistry.hpp"
 #include "../audio/plugins/compiled/CompiledPluginRegistry.hpp"
+#include "../core/ParameterUtils.hpp"
 #include "../core/TrackCommands.hpp"
 #include "../core/TrackManager.hpp"
 #include "../core/UndoManager.hpp"
@@ -165,8 +166,12 @@ std::vector<DeviceParameter> DeviceApiLive::getDeviceParameters(
     std::vector<DeviceParameter> parameters;
     parameters.reserve(device->parameters.size());
     for (const auto& info : device->parameters) {
+        // The model stores TE-native values for externals with a display-range
+        // override; this surface promises real units, so project.
         parameters.push_back({info.paramIndex, info.stableId, info.name, info.unit, info.minValue,
-                              info.maxValue, info.defaultValue, info.currentValue});
+                              info.maxValue,
+                              ParameterUtils::modelToRealValue({info.defaultValue}, info),
+                              ParameterUtils::modelToRealValue({info.currentValue}, info)});
     }
     return parameters;
 }
@@ -242,7 +247,10 @@ bool DeviceApiLive::setDeviceParameter(const ChainNodePath& devicePath, int para
     if (std::isnan(value) || value < match->minValue || value > match->maxValue)
         return false;
 
-    TrackManager::getInstance().setDeviceParameterValue(devicePath, paramIndex, value);
+    // The caller speaks display units; the model may store TE-native values
+    // (external plugin with a config display range), so convert before writing.
+    TrackManager::getInstance().setDeviceParameterValue(
+        devicePath, paramIndex, ParameterUtils::realToModelValue(value, *match));
     return true;
 }
 

--- a/magda/daw/api/device_api_live.hpp
+++ b/magda/daw/api/device_api_live.hpp
@@ -21,6 +21,7 @@ class DeviceApiLive : public DeviceApi {
     bool moveDevice(const ChainNodePath& devicePath, int toIndex) override;
     bool setDeviceBypassed(const ChainNodePath& devicePath, bool bypassed) override;
     bool setDeviceParameter(const ChainNodePath& devicePath, int paramIndex, float value) override;
+    bool openDeviceEditor(const ChainNodePath& devicePath) override;
 };
 
 }  // namespace magda

--- a/magda/daw/api/remote_api.cpp
+++ b/magda/daw/api/remote_api.cpp
@@ -329,6 +329,30 @@ const juce::var& deviceGraphSchema() {
     return value;
 }
 
+const juce::var& deviceParameterSchema() {
+    static const auto value = parseSchema(R"json({
+        "type":"object",
+        "properties":{
+            "index":{"type":"integer","minimum":0},
+            "stableId":{"type":"string"},
+            "name":{"type":"string"},
+            "unit":{"type":"string"},
+            "minValue":{"type":"number"},
+            "maxValue":{"type":"number"},
+            "defaultValue":{"type":"number"},
+            "currentValue":{"type":"number"},
+            "normalizedValue":{"type":"number","minimum":0,"maximum":1},
+            "visible":{"type":"boolean"},
+            "miniMixer":{"type":"boolean"},
+            "aiAgentEnabled":{"type":"boolean"}
+        },
+        "required":["index","stableId","name","unit","minValue","maxValue","defaultValue",
+                    "currentValue","normalizedValue","visible","miniMixer","aiAgentEnabled"],
+        "additionalProperties":false
+    })json");
+    return value;
+}
+
 const juce::var& deviceCatalogEntrySchema() {
     static const auto value = parseSchema(R"json({
         "type":"object",
@@ -1083,6 +1107,23 @@ juce::var toJson(const DeviceCatalogEntryDto& dto) {
     return object;
 }
 
+juce::var toJson(const DeviceParameterDto& dto) {
+    auto object = new juce::DynamicObject();
+    object->setProperty("index", dto.index);
+    object->setProperty("stableId", dto.stableId);
+    object->setProperty("name", dto.name);
+    object->setProperty("unit", dto.unit);
+    object->setProperty("minValue", dto.minValue);
+    object->setProperty("maxValue", dto.maxValue);
+    object->setProperty("defaultValue", dto.defaultValue);
+    object->setProperty("currentValue", dto.currentValue);
+    object->setProperty("normalizedValue", dto.normalizedValue);
+    object->setProperty("visible", dto.visible);
+    object->setProperty("miniMixer", dto.miniMixer);
+    object->setProperty("aiAgentEnabled", dto.aiAgentEnabled);
+    return object;
+}
+
 juce::var toJson(const SelectionDto& dto) {
     auto object = new juce::DynamicObject();
     object->setProperty("trackId", nullableId(dto.trackId));
@@ -1345,6 +1386,25 @@ std::optional<DeviceCatalogEntryDto> deviceCatalogEntryFromJson(const juce::var&
     return dto;
 }
 
+std::optional<DeviceParameterDto> deviceParameterFromJson(const juce::var& json, Error& error) {
+    if (!prepareDecode(json, deviceParameterSchema(), error))
+        return std::nullopt;
+    DeviceParameterDto dto;
+    dto.index = readInt(json, "index");
+    dto.stableId = json["stableId"].toString();
+    dto.name = json["name"].toString();
+    dto.unit = json["unit"].toString();
+    dto.minValue = static_cast<double>(json["minValue"]);
+    dto.maxValue = static_cast<double>(json["maxValue"]);
+    dto.defaultValue = static_cast<double>(json["defaultValue"]);
+    dto.currentValue = static_cast<double>(json["currentValue"]);
+    dto.normalizedValue = static_cast<double>(json["normalizedValue"]);
+    dto.visible = static_cast<bool>(json["visible"]);
+    dto.miniMixer = static_cast<bool>(json["miniMixer"]);
+    dto.aiAgentEnabled = static_cast<bool>(json["aiAgentEnabled"]);
+    return dto;
+}
+
 std::optional<SelectionDto> selectionFromJson(const juce::var& json, Error& error) {
     if (!prepareDecode(json, selectionSchema(), error))
         return std::nullopt;
@@ -1563,6 +1623,40 @@ OperationRegistry::OperationRegistry() {
     // its `catalogId` from — so what this lists is exactly what can be asked for.
     add("devices.catalog", "List devices that can be added, by catalogue id", OperationAccess::Read,
         &handlers::devicesCatalog, emptyObjectSchema(), arraySchema(deviceCatalogEntrySchema()));
+    // Parameter discovery and direct control (#2274). Values are real units on
+    // both sides — discovery reports what a knob shows and setParameter takes
+    // the same number back — with `normalizedValue` alongside so a client can
+    // compose with automation.addPoint's 0..1 domain.
+    add("devices.listParameters",
+        "List a device's parameters, in real units, with customization flags",
+        OperationAccess::Read, &handlers::devicesListParameters, operationInputSchema(R"json({
+            "type":"object","properties":{"devicePath":{}},
+            "required":["devicePath"],"additionalProperties":false
+        })json"),
+        arraySchema(deviceParameterSchema()));
+    operations_.back().inputSchema["properties"].getDynamicObject()->setProperty(
+        "devicePath", devicePathSchema());
+    add("devices.setParameter", "Set one device parameter, in real units", OperationAccess::Write,
+        &handlers::devicesSetParameter, operationInputSchema(R"json({
+            "type":"object",
+            "properties":{
+                "devicePath":{},
+                "parameterIndex":{"type":"integer","minimum":0},
+                "value":{"type":"number"}
+            },
+            "required":["devicePath","parameterIndex","value"],"additionalProperties":false
+        })json"),
+        deviceParameterSchema());
+    operations_.back().inputSchema["properties"].getDynamicObject()->setProperty(
+        "devicePath", devicePathSchema());
+    add("devices.openEditor", "Open a device's plugin editor window", OperationAccess::Write,
+        &handlers::devicesOpenEditor, operationInputSchema(R"json({
+            "type":"object","properties":{"devicePath":{}},
+            "required":["devicePath"],"additionalProperties":false
+        })json"),
+        okResult);
+    operations_.back().inputSchema["properties"].getDynamicObject()->setProperty(
+        "devicePath", devicePathSchema());
     add("racks.create", "Create a top-level rack", OperationAccess::Write, &handlers::racksCreate,
         operationInputSchema(R"json({
             "type":"object",
@@ -1771,6 +1865,11 @@ OperationRegistry::OperationRegistry() {
         {"racks.create", Scope::Edit},
         {"racks.remove", Scope::Edit},
         {"racks.setBypassed", Scope::Edit},
+        {"devices.setParameter", Scope::Edit},
+        // Opening a plugin editor changes no project content, but it takes
+        // over part of the user's screen — an edit-grade intrusion, not
+        // something a read-only client should reach.
+        {"devices.openEditor", Scope::Edit},
         {"selection.set", Scope::Edit},
         {"automation.createLane", Scope::Edit},
         {"automation.addPoint", Scope::Edit},

--- a/magda/daw/api/remote_api.hpp
+++ b/magda/daw/api/remote_api.hpp
@@ -202,6 +202,32 @@ struct DeviceDto {
     bool operator==(const DeviceDto&) const = default;
 };
 
+/**
+ * @brief One parameter of a live device, in real units (Hz, dB, %).
+ *
+ * `index` is the address `devices.setParameter` takes. The three booleans
+ * mirror the user's Configure Parameters customization: shown in the device
+ * UI, pinned to the mini mixer, and opted in to AI/agent control. Internal
+ * devices carry no per-parameter opt-in, so `aiAgentEnabled` is always true
+ * there; for external plugins it is exactly the subset the user ticked.
+ */
+struct DeviceParameterDto {
+    int index = -1;
+    juce::String stableId;
+    juce::String name;
+    juce::String unit;
+    double minValue = 0.0;
+    double maxValue = 1.0;
+    double defaultValue = 0.0;
+    double currentValue = 0.0;
+    double normalizedValue = 0.0;
+    bool visible = false;
+    bool miniMixer = false;
+    bool aiAgentEnabled = false;
+
+    bool operator==(const DeviceParameterDto&) const = default;
+};
+
 struct ChainDto {
     ChainId id = INVALID_CHAIN_ID;
     RackId rackId = INVALID_RACK_ID;
@@ -537,6 +563,7 @@ juce::var toJson(const ChainDto& dto);
 juce::var toJson(const RackDto& dto);
 juce::var toJson(const DeviceGraphDto& dto);
 juce::var toJson(const DeviceCatalogEntryDto& dto);
+juce::var toJson(const DeviceParameterDto& dto);
 juce::var toJson(const SelectionDto& dto);
 juce::var toJson(const TransportDto& dto);
 juce::var toJson(const SessionSlotDto& dto);
@@ -565,6 +592,7 @@ std::optional<RackDto> rackFromJson(const juce::var& json, Error& error);
 std::optional<DeviceGraphDto> deviceGraphFromJson(const juce::var& json, Error& error);
 std::optional<DeviceCatalogEntryDto> deviceCatalogEntryFromJson(const juce::var& json,
                                                                 Error& error);
+std::optional<DeviceParameterDto> deviceParameterFromJson(const juce::var& json, Error& error);
 std::optional<SelectionDto> selectionFromJson(const juce::var& json, Error& error);
 std::optional<TransportDto> transportFromJson(const juce::var& json, Error& error);
 std::optional<SessionDto> sessionFromJson(const juce::var& json, Error& error);
@@ -575,6 +603,7 @@ TrackDto makeTrackDto(const TrackInfo& track);
 ClipDto makeClipDto(const ClipInfo& clip);
 DeviceGraphDto makeDeviceGraphDto(const std::vector<TrackInfo>& tracks);
 DeviceCatalogEntryDto makeDeviceCatalogEntryDto(const DeviceCatalogEntry& entry);
+std::vector<DeviceParameterDto> makeDeviceParameterDtos(const DeviceInfo& device);
 SelectionDto makeSelectionDto(MagdaApi& api);
 TransportDto makeTransportDto(MagdaApi& api);
 SessionDto makeSessionDto(MagdaApi& api);

--- a/magda/daw/api/remote_api_projection.cpp
+++ b/magda/daw/api/remote_api_projection.cpp
@@ -4,6 +4,7 @@
 #include "../core/AutomationInfo.hpp"
 #include "../core/ClipInfo.hpp"
 #include "../core/DeviceInfo.hpp"
+#include "../core/ParameterUtils.hpp"
 #include "../core/RackInfo.hpp"
 #include "../core/TrackInfo.hpp"
 #include "../project/ProjectInfo.hpp"
@@ -336,6 +337,39 @@ DeviceCatalogEntryDto makeDeviceCatalogEntryDto(const DeviceCatalogEntry& entry)
     dto.type = deviceTypeName(entry.type);
     dto.instrument = entry.isInstrument;
     return dto;
+}
+
+std::vector<DeviceParameterDto> makeDeviceParameterDtos(const DeviceInfo& device) {
+    const auto contains = [](const std::vector<int>& positions, int position) {
+        return std::find(positions.begin(), positions.end(), position) != positions.end();
+    };
+    // The customization lists key on position in `parameters`, while the wire
+    // `index` is `paramIndex` — the address parameter writes take. The two are
+    // normally equal, but only the position indexes the user's selections.
+    std::vector<DeviceParameterDto> dtos;
+    dtos.reserve(device.parameters.size());
+    for (size_t i = 0; i < device.parameters.size(); ++i) {
+        const auto& info = device.parameters[i];
+        const auto position = static_cast<int>(i);
+        DeviceParameterDto dto;
+        dto.index = info.paramIndex >= 0 ? info.paramIndex : position;
+        dto.stableId = info.stableId;
+        dto.name = info.name;
+        dto.unit = info.unit;
+        dto.minValue = info.minValue;
+        dto.maxValue = info.maxValue;
+        dto.defaultValue = info.defaultValue;
+        dto.currentValue = info.currentValue;
+        dto.normalizedValue = ParameterUtils::realToNormalized(info.currentValue, info);
+        dto.visible = contains(device.visibleParameters, position);
+        dto.miniMixer = contains(device.miniMixerParameters, position);
+        // Configure Parameters offers the AI opt-in only for external plugins;
+        // internal devices accept agent writes on every parameter.
+        dto.aiAgentEnabled = device.format == PluginFormat::Internal ||
+                             contains(device.aiSoundDesignerParameters, position);
+        dtos.push_back(std::move(dto));
+    }
+    return dtos;
 }
 
 SelectionDto makeSelectionDto(MagdaApi& api) {

--- a/magda/daw/api/remote_api_projection.cpp
+++ b/magda/daw/api/remote_api_projection.cpp
@@ -358,9 +358,14 @@ std::vector<DeviceParameterDto> makeDeviceParameterDtos(const DeviceInfo& device
         dto.unit = info.unit;
         dto.minValue = info.minValue;
         dto.maxValue = info.maxValue;
-        dto.defaultValue = info.defaultValue;
-        dto.currentValue = info.currentValue;
-        dto.normalizedValue = ParameterUtils::realToNormalized(info.currentValue, info);
+        // currentValue/defaultValue are model values: for an external plugin
+        // whose saved config gave it a display range, they stay in TE's native
+        // domain while min/max describe real units. Project through the
+        // normalized domain so the wire always carries display units.
+        const auto normalized = ParameterUtils::modelToNormalizedValue({info.currentValue}, info);
+        dto.defaultValue = ParameterUtils::modelToRealValue({info.defaultValue}, info);
+        dto.currentValue = ParameterUtils::normalizedToReal(normalized.value, info);
+        dto.normalizedValue = normalized.value;
         dto.visible = contains(device.visibleParameters, position);
         dto.miniMixer = contains(device.miniMixerParameters, position);
         // Configure Parameters offers the AI opt-in only for external plugins;

--- a/magda/daw/api/remote_handlers.cpp
+++ b/magda/daw/api/remote_handlers.cpp
@@ -1,6 +1,7 @@
 #include "remote_handlers.hpp"
 
 #include <algorithm>
+#include <cmath>
 #include <memory>
 #include <unordered_set>
 #include <utility>
@@ -488,6 +489,85 @@ HandlerResult devicesCatalog(MagdaApi& api, const juce::var&, const RequestConte
     for (const auto& entry : api.devices().getCatalog())
         items.push_back(toJson(makeDeviceCatalogEntryDto(entry)));
     return HandlerResult::ok(toJsonArray(items));
+}
+
+HandlerResult devicesListParameters(MagdaApi& api, const juce::var& input, const RequestContext&) {
+    const auto path = toChainNodePath(devicePathFromJson(input["devicePath"]));
+    if (!path)
+        return HandlerResult::fail(ErrorCode::ValidationFailed, "devicePath does not resolve");
+    const auto* device = api.devices().getDevice(*path);
+    if (device == nullptr)
+        return HandlerResult::fail(ErrorCode::NotFound, "no device at devicePath");
+
+    std::vector<juce::var> items;
+    for (const auto& parameter : makeDeviceParameterDtos(*device))
+        items.push_back(toJson(parameter));
+    return HandlerResult::ok(toJsonArray(items));
+}
+
+HandlerResult devicesSetParameter(MagdaApi& api, const juce::var& input, const RequestContext&) {
+    const auto path = toChainNodePath(devicePathFromJson(input["devicePath"]));
+    if (!path)
+        return HandlerResult::fail(ErrorCode::ValidationFailed, "devicePath does not resolve");
+    const auto* device = api.devices().getDevice(*path);
+    if (device == nullptr)
+        return HandlerResult::fail(ErrorCode::NotFound, "no device at devicePath");
+
+    const auto parameterIndex = readInt(input, "parameterIndex", -1);
+    const auto parameters = makeDeviceParameterDtos(*device);
+    const auto named = std::find_if(parameters.begin(), parameters.end(),
+                                    [parameterIndex](const DeviceParameterDto& parameter) {
+                                        return parameter.index == parameterIndex;
+                                    });
+    if (named == parameters.end())
+        return notFound("parameter", parameterIndex);
+
+    // The same allowlist the in-app sound designer honours: the user decides
+    // per external-plugin parameter what an agent may touch, and the remote
+    // surface must not be the way around that decision.
+    if (!named->aiAgentEnabled)
+        return HandlerResult::fail(ErrorCode::PermissionDenied,
+                                   "parameter " + juce::String(parameterIndex) +
+                                       " is not enabled for AI agent control; enable it under "
+                                       "Configure Parameters");
+
+    // Reject rather than clamp, for the same reason the facade does: a clamped
+    // write reports success while setting a value the caller did not ask for.
+    const auto value = static_cast<double>(input["value"]);
+    if (!std::isfinite(value) || value < named->minValue || value > named->maxValue)
+        return HandlerResult::fail(ErrorCode::ValidationFailed,
+                                   "value " + juce::String(value) + " is outside [" +
+                                       juce::String(named->minValue) + ", " +
+                                       juce::String(named->maxValue) + "] " + named->unit);
+
+    if (!api.devices().setDeviceParameter(*path, parameterIndex, static_cast<float>(value)))
+        return HandlerResult::fail(ErrorCode::Conflict, "parameter write was rejected");
+
+    // Read the result back through the same projection listParameters uses, so
+    // the caller sees what the model now holds rather than what was sent.
+    const auto* updated = api.devices().getDevice(*path);
+    if (updated != nullptr) {
+        for (const auto& parameter : makeDeviceParameterDtos(*updated)) {
+            if (parameter.index == parameterIndex)
+                return HandlerResult::ok(toJson(parameter));
+        }
+    }
+    return HandlerResult::fail(ErrorCode::InternalError, "parameter vanished after write");
+}
+
+HandlerResult devicesOpenEditor(MagdaApi& api, const juce::var& input, const RequestContext&) {
+    const auto path = toChainNodePath(devicePathFromJson(input["devicePath"]));
+    if (!path)
+        return HandlerResult::fail(ErrorCode::ValidationFailed, "devicePath does not resolve");
+    if (api.devices().getDevice(*path) == nullptr)
+        return HandlerResult::fail(ErrorCode::NotFound, "no device at devicePath");
+
+    const bool accepted = api.devices().openDeviceEditor(*path);
+    auto* object = new juce::DynamicObject();
+    object->setProperty("accepted", accepted);
+    // A window opening (or declining to) is not project content, so the
+    // revision has nothing to record.
+    return HandlerResult::unchanged(juce::var(object));
 }
 
 HandlerResult racksCreate(MagdaApi& api, const juce::var& input, const RequestContext&) {

--- a/magda/daw/api/remote_handlers.hpp
+++ b/magda/daw/api/remote_handlers.hpp
@@ -49,6 +49,9 @@ HandlerResult clipsDelete(MagdaApi&, const juce::var&, const RequestContext&);
 // Devices and racks
 HandlerResult devicesList(MagdaApi&, const juce::var&, const RequestContext&);
 HandlerResult devicesCatalog(MagdaApi&, const juce::var&, const RequestContext&);
+HandlerResult devicesListParameters(MagdaApi&, const juce::var&, const RequestContext&);
+HandlerResult devicesSetParameter(MagdaApi&, const juce::var&, const RequestContext&);
+HandlerResult devicesOpenEditor(MagdaApi&, const juce::var&, const RequestContext&);
 HandlerResult racksCreate(MagdaApi&, const juce::var&, const RequestContext&);
 HandlerResult racksRemove(MagdaApi&, const juce::var&, const RequestContext&);
 HandlerResult racksSetBypassed(MagdaApi&, const juce::var&, const RequestContext&);

--- a/magda/daw/core/ConsoleRouting.cpp
+++ b/magda/daw/core/ConsoleRouting.cpp
@@ -152,12 +152,15 @@ const std::vector<AgentSurface>& registeredAgentSurfaces() {
          .name = "device",
          .responsibility = "Device topology, racks, presets, parameters, and sound design.",
          .promptFragments = {"Operate only on the focused device or its containing rack.",
-                             "Parameter and preset mutation are advisory until corresponding "
-                             "Remote API tools exist."},
+                             "List parameters before writing; only parameters the user enabled "
+                             "for AI control accept writes.",
+                             "Preset mutation is advisory until a corresponding Remote API tool "
+                             "exists."},
          .contextProviders = {Provider::ProjectRevision, Provider::ActiveView, Provider::Selection,
                               Provider::TrackSummaries, Provider::DeviceSummaries,
                               Provider::Conversation},
          .toolAllowlist = {"project.get", "tracks.list", "tracks.get", "devices.list",
+                           "devices.listParameters", "devices.setParameter", "devices.openEditor",
                            "racks.create", "racks.remove", "racks.setBypassed", "selection.get",
                            "selection.set"},
          .runPolicy = {.maxSteps = 8, .maxMutations = 5, .approveMutations = true},

--- a/magda/daw/core/ParameterUtils.cpp
+++ b/magda/daw/core/ParameterUtils.cpp
@@ -261,6 +261,15 @@ ParameterNormalizedValue modelToNormalizedValue(ParameterModelValue model,
     return ParameterNormalizedValue::clamped(model.value);
 }
 
+float modelToRealValue(ParameterModelValue model, const ParameterInfo& info) {
+    return normalizedToReal(modelToNormalizedValue(model, info).value, info);
+}
+
+ParameterModelValue realToModelValue(float real, const ParameterInfo& info) {
+    return normalizedToModelValue(ParameterNormalizedValue::clamped(realToNormalized(real, info)),
+                                  info);
+}
+
 float modelToTeValue(ParameterModelValue model, const ParameterInfo& info) {
     if (infoMatchesTeRange(info))
         return model.value;

--- a/magda/daw/core/ParameterUtils.hpp
+++ b/magda/daw/core/ParameterUtils.hpp
@@ -127,6 +127,22 @@ ParameterNormalizedValue modelToNormalizedValue(ParameterModelValue model,
                                                 const ParameterInfo& info);
 
 /**
+ * @brief The real/display-unit value a model value represents.
+ *
+ * Identity (up to the scale curve round trip) for parameters whose model
+ * already carries the scaled value; projects TE-native external values through
+ * the display range. This is the conversion any surface that promises real
+ * units must apply before showing `DeviceInfo::currentValue`.
+ */
+float modelToRealValue(ParameterModelValue model, const ParameterInfo& info);
+
+/**
+ * @brief Inverse of modelToRealValue(): the model value that makes the
+ *        parameter read `real` display units.
+ */
+ParameterModelValue realToModelValue(float real, const ParameterInfo& info);
+
+/**
  * @brief Convert a DeviceInfo/model value to the raw value stored by the
  *        owning Tracktion AutomatableParameter.
  *

--- a/tests/MockMagdaApi.hpp
+++ b/tests/MockMagdaApi.hpp
@@ -37,6 +37,7 @@
 #include "magda/daw/api/undo_api.hpp"
 #include "magda/daw/core/ClipInfo.hpp"
 #include "magda/daw/core/ClipTypes.hpp"
+#include "magda/daw/core/ParameterUtils.hpp"
 #include "magda/daw/core/TrackInfo.hpp"
 #include "magda/daw/core/TrackTypes.hpp"
 #include "magda/daw/core/TypeIds.hpp"
@@ -1156,8 +1157,9 @@ class MockDeviceApi : public DeviceApi {
         std::vector<DeviceParameter> parameters;
         for (const auto& info : device->parameters) {
             parameters.push_back({info.paramIndex, info.stableId, info.name, info.unit,
-                                  info.minValue, info.maxValue, info.defaultValue,
-                                  info.currentValue});
+                                  info.minValue, info.maxValue,
+                                  ParameterUtils::modelToRealValue({info.defaultValue}, info),
+                                  ParameterUtils::modelToRealValue({info.currentValue}, info)});
         }
         return parameters;
     }
@@ -1209,10 +1211,12 @@ class MockDeviceApi : public DeviceApi {
                 continue;
             if (value < info.minValue || value > info.maxValue)
                 return false;
-            // The live manager updates the model synchronously, so a test that
-            // reads the parameter back sees the written value, as a client would.
-            info.currentValue = value;
-            parameterWrites.emplace_back(devicePath, paramIndex, value);
+            // The live manager updates the model synchronously — and stores the
+            // model-domain value, which for a configured external parameter is
+            // TE-native, not the display value the caller sent.
+            const auto model = ParameterUtils::realToModelValue(value, info);
+            info.currentValue = model.value;
+            parameterWrites.emplace_back(devicePath, paramIndex, model.value);
             return true;
         }
         return false;

--- a/tests/MockMagdaApi.hpp
+++ b/tests/MockMagdaApi.hpp
@@ -1201,18 +1201,30 @@ class MockDeviceApi : public DeviceApi {
         return true;
     }
     bool setDeviceParameter(const ChainNodePath& devicePath, int paramIndex, float value) override {
-        const auto* device = getDevice(devicePath);
-        if (device == nullptr)
+        const auto it = devices.find(devicePath);
+        if (it == devices.end())
             return false;
-        for (const auto& info : device->parameters) {
+        for (auto& info : it->second.parameters) {
             if (info.paramIndex != paramIndex)
                 continue;
             if (value < info.minValue || value > info.maxValue)
                 return false;
+            // The live manager updates the model synchronously, so a test that
+            // reads the parameter back sees the written value, as a client would.
+            info.currentValue = value;
             parameterWrites.emplace_back(devicePath, paramIndex, value);
             return true;
         }
         return false;
+    }
+
+    std::vector<ChainNodePath> openedEditors;
+
+    bool openDeviceEditor(const ChainNodePath& devicePath) override {
+        if (getDevice(devicePath) == nullptr)
+            return false;
+        openedEditors.push_back(devicePath);
+        return true;
     }
 };
 

--- a/tests/remote/test_remote_api_contract.cpp
+++ b/tests/remote/test_remote_api_contract.cpp
@@ -40,6 +40,9 @@ TEST_CASE("Remote API registry is versioned, discoverable, and unique", "[remote
     REQUIRE(registry.find("system.describe") != nullptr);
     REQUIRE(registry.find("project.get") != nullptr);
     REQUIRE(registry.find("devices.list") != nullptr);
+    REQUIRE(registry.find("devices.listParameters") != nullptr);
+    REQUIRE(registry.find("devices.setParameter") != nullptr);
+    REQUIRE(registry.find("devices.openEditor") != nullptr);
     REQUIRE(registry.find("session.launchClip") != nullptr);
     REQUIRE(registry.find("automation.addPoint") != nullptr);
     REQUIRE(registry.find("does.not.exist") == nullptr);
@@ -487,6 +490,56 @@ TEST_CASE("devices.catalog lists addable devices without their file locations",
         fields.insert(property.name.toString());
     REQUIRE(fields == std::set<juce::String>{"catalogId", "name", "manufacturer", "category",
                                              "description", "format", "type", "instrument"});
+}
+
+TEST_CASE("devices.listParameters projects real units and customization flags",
+          "[remote-api][contract]") {
+    DeviceInfo device;
+    device.format = PluginFormat::VST3;
+    device.parameters.emplace_back(0, "Cutoff", "Hz", 20.0f, 20000.0f, 800.0f);
+    device.parameters.emplace_back(1, "Resonance", "%", 0.0f, 100.0f, 10.0f);
+    device.parameters[0].stableId = "cutoff";
+    device.parameters[0].currentValue = 800.0f;
+    device.parameters[1].currentValue = 25.0f;
+    device.visibleParameters = {0, 1};
+    device.miniMixerParameters = {1};
+    device.aiSoundDesignerParameters = {1};
+
+    const auto parameters = makeDeviceParameterDtos(device);
+    REQUIRE(parameters.size() == 2);
+
+    REQUIRE(parameters[0].index == 0);
+    REQUIRE(parameters[0].stableId == "cutoff");
+    REQUIRE(parameters[0].name == "Cutoff");
+    REQUIRE(parameters[0].unit == "Hz");
+    REQUIRE(parameters[0].minValue == 20.0);
+    REQUIRE(parameters[0].maxValue == 20000.0);
+    REQUIRE(parameters[0].currentValue == 800.0);
+    REQUIRE(parameters[0].visible);
+    REQUIRE_FALSE(parameters[0].miniMixer);
+
+    // The user ticked only Resonance for AI control.
+    REQUIRE_FALSE(parameters[0].aiAgentEnabled);
+    REQUIRE(parameters[1].aiAgentEnabled);
+    REQUIRE(parameters[1].miniMixer);
+    REQUIRE(std::abs(parameters[1].normalizedValue - 0.25) < 1e-6);
+
+    requireRoundTrip(parameters[0], deviceParameterFromJson);
+    requireRoundTrip(parameters[1], deviceParameterFromJson);
+}
+
+TEST_CASE("internal devices accept agent writes on every parameter", "[remote-api][contract]") {
+    // Configure Parameters offers the AI opt-in only for external plugins, so
+    // an internal device with no allowlist is fully controllable, not locked.
+    DeviceInfo device;
+    device.format = PluginFormat::Internal;
+    device.parameters.emplace_back(0, "Drive", "", 0.0f, 1.0f, 0.5f);
+    device.parameters.emplace_back(1, "Tone", "", 0.0f, 1.0f, 0.5f);
+
+    const auto parameters = makeDeviceParameterDtos(device);
+    REQUIRE(parameters.size() == 2);
+    for (const auto& parameter : parameters)
+        REQUIRE(parameter.aiAgentEnabled);
 }
 
 TEST_CASE("devices.list addresses colliding fx and post-fx device ids",

--- a/tests/remote/test_remote_api_contract.cpp
+++ b/tests/remote/test_remote_api_contract.cpp
@@ -528,6 +528,31 @@ TEST_CASE("devices.listParameters projects real units and customization flags",
     requireRoundTrip(parameters[1], deviceParameterFromJson);
 }
 
+TEST_CASE("configured external parameters project model values into display units",
+          "[remote-api][contract]") {
+    // The realistic external-override shape: the plugin's TE parameter runs
+    // 0..1 and keeps storing TE-native values, while a saved config gave the
+    // parameter a real display range. The live display provider is what marks
+    // the model as TE-native (isDisplayMappedInternalValue requires its
+    // absence), same as ExternalPluginProcessor::getParameterInfo.
+    DeviceInfo device;
+    device.format = PluginFormat::VST3;
+    ParameterInfo gain(0, "Gain", "dB", -24.0f, 24.0f, 0.0f);
+    gain.teMinValue = 0.0f;
+    gain.teMaxValue = 1.0f;
+    gain.displayText = std::make_shared<ParameterInfo::DisplayTextProvider>();
+    gain.currentValue = 0.75f;  // model / TE domain
+    gain.defaultValue = 0.5f;   // model / TE domain
+    device.parameters.push_back(gain);
+
+    const auto parameters = makeDeviceParameterDtos(device);
+    REQUIRE(parameters.size() == 1);
+    // 0.75 of a -24..24 dB range reads +12 dB, not 0.75 dB.
+    REQUIRE(std::abs(parameters[0].currentValue - 12.0) < 1e-4);
+    REQUIRE(std::abs(parameters[0].normalizedValue - 0.75) < 1e-6);
+    REQUIRE(std::abs(parameters[0].defaultValue - 0.0) < 1e-4);
+}
+
 TEST_CASE("internal devices accept agent writes on every parameter", "[remote-api][contract]") {
     // Configure Parameters offers the AI opt-in only for external plugins, so
     // an internal device with no allowlist is fully controllable, not locked.

--- a/tests/remote/test_remote_service.cpp
+++ b/tests/remote/test_remote_service.cpp
@@ -675,3 +675,129 @@ TEST_CASE("Concurrent change marks never lose the newest revision",
     // Latest-value-wins has to hold under contention, not just single-threaded.
     REQUIRE(seen[0].revision == perThread * threadCount);
 }
+
+namespace {
+
+/// An external plugin with two parameters, only the first opted in to AI
+/// control — the shape devices.setParameter's allowlist gate cares about.
+DeviceInfo makeFilterDevice() {
+    DeviceInfo device;
+    device.id = 5;
+    device.name = "Filter";
+    device.format = PluginFormat::VST3;
+    device.parameters.emplace_back(0, "Cutoff", "Hz", 20.0f, 20000.0f, 800.0f);
+    device.parameters.emplace_back(1, "Drive", "%", 0.0f, 100.0f, 0.0f);
+    device.parameters[0].currentValue = 800.0f;
+    device.aiSoundDesignerParameters = {0};
+    return device;
+}
+
+juce::var pathInput(const ChainNodePath& path) {
+    return object({{"devicePath", toJson(makeDevicePathDto(path))}});
+}
+
+}  // namespace
+
+TEST_CASE("devices.listParameters returns the device's parameters", "[remote][service][devices]") {
+    const MessageThreadRelaxation relaxation;
+    MockMagdaApi api;
+    const auto path = ChainNodePath::topLevelDevice(1, 5);
+    api.devices_.devices[path] = makeFilterDevice();
+    RemoteApiService service(api);
+
+    const auto response = run(service, "devices.listParameters", pathInput(path));
+
+    REQUIRE(response.ok);
+    const auto* items = response.result.getArray();
+    REQUIRE(items != nullptr);
+    REQUIRE(items->size() == 2);
+    REQUIRE((*items)[0]["name"].toString() == "Cutoff");
+    REQUIRE(static_cast<bool>((*items)[0]["aiAgentEnabled"]));
+    REQUIRE_FALSE(static_cast<bool>((*items)[1]["aiAgentEnabled"]));
+    // A read burns no revision.
+    REQUIRE(service.currentRevision() == INITIAL_REVISION);
+
+    const auto missing =
+        run(service, "devices.listParameters", pathInput(ChainNodePath::topLevelDevice(1, 99)));
+    REQUIRE_FALSE(missing.ok);
+    REQUIRE(errorCodeOf(missing) == "not_found");
+}
+
+TEST_CASE("devices.setParameter writes an allowed parameter and echoes the model",
+          "[remote][service][devices]") {
+    const MessageThreadRelaxation relaxation;
+    MockMagdaApi api;
+    const auto path = ChainNodePath::topLevelDevice(1, 5);
+    api.devices_.devices[path] = makeFilterDevice();
+    RemoteApiService service(api);
+
+    auto input = pathInput(path);
+    input.getDynamicObject()->setProperty("parameterIndex", 0);
+    input.getDynamicObject()->setProperty("value", 1200.0);
+    const auto response = run(service, "devices.setParameter", input);
+
+    REQUIRE(response.ok);
+    REQUIRE(static_cast<double>(response.result["currentValue"]) == 1200.0);
+    REQUIRE(api.devices_.parameterWrites.size() == 1);
+    REQUIRE(std::get<2>(api.devices_.parameterWrites.front()) == 1200.0f);
+}
+
+TEST_CASE("devices.setParameter refuses a parameter the user did not enable",
+          "[remote][service][devices]") {
+    const MessageThreadRelaxation relaxation;
+    MockMagdaApi api;
+    const auto path = ChainNodePath::topLevelDevice(1, 5);
+    api.devices_.devices[path] = makeFilterDevice();
+    RemoteApiService service(api);
+
+    // Drive exists but is not on the device's AI allowlist: the remote surface
+    // must refuse rather than bypass the in-app safeguard.
+    auto input = pathInput(path);
+    input.getDynamicObject()->setProperty("parameterIndex", 1);
+    input.getDynamicObject()->setProperty("value", 50.0);
+    const auto response = run(service, "devices.setParameter", input);
+
+    REQUIRE_FALSE(response.ok);
+    REQUIRE(errorCodeOf(response) == "permission_denied");
+    REQUIRE(api.devices_.parameterWrites.empty());
+}
+
+TEST_CASE("devices.setParameter rejects an out-of-range value rather than clamping",
+          "[remote][service][devices]") {
+    const MessageThreadRelaxation relaxation;
+    MockMagdaApi api;
+    const auto path = ChainNodePath::topLevelDevice(1, 5);
+    api.devices_.devices[path] = makeFilterDevice();
+    RemoteApiService service(api);
+
+    auto input = pathInput(path);
+    input.getDynamicObject()->setProperty("parameterIndex", 0);
+    input.getDynamicObject()->setProperty("value", 99999.0);
+    const auto response = run(service, "devices.setParameter", input);
+
+    REQUIRE_FALSE(response.ok);
+    REQUIRE(errorCodeOf(response) == "validation_failed");
+    REQUIRE(api.devices_.parameterWrites.empty());
+}
+
+TEST_CASE("devices.openEditor opens the editor without burning a revision",
+          "[remote][service][devices]") {
+    const MessageThreadRelaxation relaxation;
+    MockMagdaApi api;
+    const auto path = ChainNodePath::topLevelDevice(1, 5);
+    api.devices_.devices[path] = makeFilterDevice();
+    RemoteApiService service(api);
+
+    const auto response = run(service, "devices.openEditor", pathInput(path));
+
+    REQUIRE(response.ok);
+    REQUIRE(static_cast<bool>(response.result["accepted"]));
+    REQUIRE(api.devices_.openedEditors.size() == 1);
+    // A window is not project content; the revision must not move.
+    REQUIRE(service.currentRevision() == INITIAL_REVISION);
+
+    const auto missing =
+        run(service, "devices.openEditor", pathInput(ChainNodePath::topLevelDevice(1, 99)));
+    REQUIRE_FALSE(missing.ok);
+    REQUIRE(errorCodeOf(missing) == "not_found");
+}

--- a/tests/remote/test_remote_service.cpp
+++ b/tests/remote/test_remote_service.cpp
@@ -1,6 +1,7 @@
 #include <atomic>
 #include <catch2/catch_test_macros.hpp>
 #include <chrono>
+#include <cmath>
 #include <thread>
 #include <vector>
 
@@ -800,4 +801,35 @@ TEST_CASE("devices.openEditor opens the editor without burning a revision",
         run(service, "devices.openEditor", pathInput(ChainNodePath::topLevelDevice(1, 99)));
     REQUIRE_FALSE(missing.ok);
     REQUIRE(errorCodeOf(missing) == "not_found");
+}
+
+TEST_CASE("devices.setParameter converts display units to the model domain",
+          "[remote][service][devices]") {
+    const MessageThreadRelaxation relaxation;
+    MockMagdaApi api;
+    const auto path = ChainNodePath::topLevelDevice(1, 5);
+    DeviceInfo device;
+    device.id = 5;
+    device.format = PluginFormat::VST3;
+    ParameterInfo gain(0, "Gain", "dB", -24.0f, 24.0f, 0.0f);
+    gain.teMinValue = 0.0f;
+    gain.teMaxValue = 1.0f;
+    gain.displayText = std::make_shared<ParameterInfo::DisplayTextProvider>();
+    gain.currentValue = 0.5f;
+    device.parameters.push_back(gain);
+    device.aiSoundDesignerParameters = {0};
+    api.devices_.devices[path] = device;
+    RemoteApiService service(api);
+
+    auto input = pathInput(path);
+    input.getDynamicObject()->setProperty("parameterIndex", 0);
+    input.getDynamicObject()->setProperty("value", 12.0);
+    const auto response = run(service, "devices.setParameter", input);
+
+    REQUIRE(response.ok);
+    // The echo speaks display units; the model write is TE-native.
+    REQUIRE(std::abs(static_cast<double>(response.result["currentValue"]) - 12.0) < 1e-4);
+    REQUIRE(std::abs(static_cast<double>(response.result["normalizedValue"]) - 0.75) < 1e-6);
+    REQUIRE(api.devices_.parameterWrites.size() == 1);
+    REQUIRE(std::abs(std::get<2>(api.devices_.parameterWrites.front()) - 0.75f) < 1e-6f);
 }

--- a/tests/routing/test_console_routing.cpp
+++ b/tests/routing/test_console_routing.cpp
@@ -44,6 +44,9 @@ TEST_CASE("agent surface registry has distinct bounded capabilities", "[console_
     REQUIRE_FALSE(containsTool(automation, "session.launchClip"));
 
     REQUIRE(containsTool(device, "racks.setBypassed"));
+    REQUIRE(containsTool(device, "devices.listParameters"));
+    REQUIRE(containsTool(device, "devices.setParameter"));
+    REQUIRE(containsTool(device, "devices.openEditor"));
     REQUIRE_FALSE(containsTool(device, "tracks.update"));
 
     REQUIRE(master.runPolicy.maxMutations == 0);


### PR DESCRIPTION
Closes #2274.

Adds the three operations the issue asks for, addressed by `devicePath` like the rest of the device surface (a bare `deviceId` is ambiguous across a track's fx / post-fx sections):

- **`devices.listParameters`** (read) — every parameter in real units (`index`, `stableId`, `name`, `unit`, `minValue`/`maxValue`/`defaultValue`/`currentValue`), plus `normalizedValue` so a client can compose with `automation.addPoint`'s 0–1 domain, and the Configure Parameters customization flags: `visible`, `miniMixer`, `aiAgentEnabled`. A client can therefore both discover what `parameterIndex` means and audit how well a plugin's parameters are curated.
- **`devices.setParameter`** (write, `edit` scope) — real-unit write that rejects rather than clamps out-of-range values, and refuses (`permission_denied`) any external-plugin parameter the user has not ticked as **AI Agent** — the same allowlist the in-app sound designer honours, so MCP is not a way around it. Internal devices accept writes on every parameter (the dialog offers no AI opt-in for them). The write path goes through `TrackManager::setDeviceParameterValue`, so it reaches the engine via `setParameterFromHost` and works with modifiers active.
- **`devices.openEditor`** (write, `edit` scope) — new `DeviceApi::openDeviceEditor` over `AudioBridge::showPluginWindow`; returns `accepted` reflecting whether a window is actually open afterwards (false when headless or the device has no native editor), and does not advance the project revision.

Also updated:
- Scope policy table + `docs/architecture/remote-api-permissions.md`.
- DevicePanel agent surface: allowlists the three tools and drops the "parameter mutation is advisory" prompt fragment (preset mutation keeps its caveat).
- `MockDeviceApi`: `setDeviceParameter` now updates `currentValue` like the live manager, and records editor opens.

Tests: contract projection + round-trip (external allowlist semantics, internal always-enabled), dispatch tests for all three handlers (success, `permission_denied`, `validation_failed`, `not_found`, revision behaviour), console-routing allowlist assertions. The allowlist gate was verified negatively — removing it makes the refusal test fail.

Follow-up (agreed with @lucaromagnoli): a persisted `devices.setParameterConfig` needs the per-plugin XML store extracted out of `ParameterConfigDialog` and will be tackled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)