### PR TITLE
A device answers for its plugin, and hands out no pointer to it (#2270)

### DIFF
--- a/magda/daw/audio/CMakeLists.txt
+++ b/magda/daw/audio/CMakeLists.txt
@@ -305,6 +305,8 @@ list(REMOVE_ITEM _magda_device_pack_sources ${_magda_tracktion_device_adapter_so
 set(_magda_engine_device_adapter_sources
     "${CMAKE_CURRENT_SOURCE_DIR}/plugins/engine/EngineDeviceFactory.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/plugins/engine/EngineDeviceFactory.hpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/plugins/engine/DeviceControl.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/plugins/engine/DeviceControl.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/plugins/engine/EngineExternalDevice.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/plugins/engine/EngineExternalDevice.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/plugins/engine/EngineMagdaDevice.cpp"

--- a/magda/daw/audio/CMakeLists.txt
+++ b/magda/daw/audio/CMakeLists.txt
@@ -305,6 +305,8 @@ list(REMOVE_ITEM _magda_device_pack_sources ${_magda_tracktion_device_adapter_so
 set(_magda_engine_device_adapter_sources
     "${CMAKE_CURRENT_SOURCE_DIR}/plugins/engine/EngineDeviceFactory.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/plugins/engine/EngineDeviceFactory.hpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/plugins/engine/ControlExecutor.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/plugins/engine/ControlExecutor.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/plugins/engine/DeviceControl.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/plugins/engine/DeviceControl.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/plugins/engine/EngineExternalDevice.cpp"

--- a/magda/daw/audio/plugins/engine/ControlExecutor.cpp
+++ b/magda/daw/audio/plugins/engine/ControlExecutor.cpp
@@ -1,0 +1,91 @@
+#include "ControlExecutor.hpp"
+
+#include <utility>
+
+namespace magda::daw::audio::engine_adapter {
+
+void MessageThreadControlExecutor::run(Work work) {
+    if (!work)
+        return;
+
+    if (isCurrent()) {
+        work();
+        return;
+    }
+
+    juce::MessageManager::callAsync(std::move(work));
+}
+
+bool MessageThreadControlExecutor::isCurrent() const {
+    return juce::MessageManager::existsAndIsCurrentThread();
+}
+
+SerialControlThread::SerialControlThread() : thread_([this] { loop(); }) {}
+
+SerialControlThread::~SerialControlThread() {
+    {
+        const std::lock_guard<std::mutex> held(lock_);
+        stopping_ = true;
+
+        // Dropped rather than drained. Work that has not started is work whose
+        // answer nobody is left to receive: this executor is destroyed before
+        // the devices its work would reach, and running it now would be
+        // reaching for plugins that are about to go.
+        queued_.clear();
+    }
+
+    wake_.notify_all();
+
+    if (thread_.joinable())
+        thread_.join();
+}
+
+void SerialControlThread::run(Work work) {
+    if (!work)
+        return;
+
+    // Already here: run it now rather than queue it behind ourselves, which is
+    // what an operation asked for from inside another one would otherwise wait
+    // forever for.
+    if (isCurrent()) {
+        work();
+        return;
+    }
+
+    {
+        const std::lock_guard<std::mutex> held(lock_);
+        if (stopping_)
+            return;
+
+        queued_.push_back(std::move(work));
+    }
+
+    wake_.notify_one();
+}
+
+bool SerialControlThread::isCurrent() const {
+    return std::this_thread::get_id() == thread_.get_id();
+}
+
+void SerialControlThread::loop() {
+    for (;;) {
+        Work work;
+
+        {
+            std::unique_lock<std::mutex> held(lock_);
+            wake_.wait(held, [this] { return stopping_ || !queued_.empty(); });
+
+            if (stopping_)
+                return;
+
+            work = std::move(queued_.front());
+            queued_.pop_front();
+        }
+
+        // Outside the lock, because the work is what takes the time and because
+        // it is entitled to queue more of itself.
+        work();
+    }
+}
+
+}  // namespace magda::daw::audio::engine_adapter

--- a/magda/daw/audio/plugins/engine/ControlExecutor.cpp
+++ b/magda/daw/audio/plugins/engine/ControlExecutor.cpp
@@ -1,9 +1,18 @@
 #include "ControlExecutor.hpp"
 
 #include <utility>
-#include <vector>
 
 namespace magda::daw::audio::engine_adapter {
+
+MessageThreadControlExecutor::MessageThreadControlExecutor()
+    : posted_(std::make_shared<Posted>()) {}
+
+MessageThreadControlExecutor::~MessageThreadControlExecutor() {
+    // Everything still in flight becomes a cancellation. It arrives on the
+    // message thread like every other answer, which is what keeps a caller from
+    // having to ask which thread it is on before it can act on one.
+    posted_->cancelled = true;
+}
 
 bool MessageThreadControlExecutor::run(Work work) {
     if (!work)
@@ -12,8 +21,13 @@ bool MessageThreadControlExecutor::run(Work work) {
     // Posted even from the message thread itself. Running it here would let a
     // nested operation into a plugin the outer one has open, and would put it
     // ahead of everything already waiting (ControlExecutor.hpp).
-    return juce::MessageManager::callAsync(
-        [work = std::move(work)]() mutable { work(ExecutionState::Ran); });
+    //
+    // The flag travels with the post rather than being read off this object: by
+    // the time it arrives, this executor may be gone, and what the call needs
+    // to know is whether it still means anything rather than who it came from.
+    return juce::MessageManager::callAsync([work = std::move(work), posted = posted_]() mutable {
+        work(posted->cancelled ? ExecutionState::Cancelled : ExecutionState::Ran);
+    });
 }
 
 bool MessageThreadControlExecutor::isCurrent() const {
@@ -27,58 +41,56 @@ SerialControlThread::SerialControlThread() : shared_(std::make_shared<Shared>())
         for (;;) {
             Work work;
 
+            auto state = ExecutionState::Ran;
+
             {
                 std::unique_lock<std::mutex> held(shared->lock);
                 shared->wake.wait(
                     held, [&shared] { return shared->stopping || !shared->queued.empty(); });
 
-                // Stopping wins over what is left: whatever is still queued has
-                // already been cancelled by the destructor, and running it now
-                // would be reaching for devices that are going away.
-                if (shared->stopping)
-                    return;
+                if (shared->stopping) {
+                    // Drained rather than abandoned, and drained here rather
+                    // than by whoever is destroying the executor: an answer owed
+                    // on this thread is owed on this thread whichever of the two
+                    // answers it turns out to be.
+                    if (shared->queued.empty())
+                        return;
+
+                    state = ExecutionState::Cancelled;
+                }
 
                 work = std::move(shared->queued.front());
                 shared->queued.pop_front();
             }
 
             // Outside the lock, because the work is what takes the time and
-            // because it is entitled to queue more of itself.
-            work(ExecutionState::Ran);
+            // because it is entitled to queue more of itself -- which run()
+            // refuses once stopping, so a drain cannot feed itself.
+            work(state);
         }
     });
 }
 
 SerialControlThread::~SerialControlThread() {
-    std::deque<Work> abandoned;
-
     {
         const std::lock_guard<std::mutex> held(shared_->lock);
         shared_->stopping = true;
-        abandoned.swap(shared_->queued);
     }
 
     shared_->wake.notify_all();
-
-    // Answered rather than dropped. Every one of these is an operation somebody
-    // is still waiting on, and an executor that let them go would leave a
-    // promise of exactly one answer unkept by whoever made it.
-    //
-    // Before the wait below, so that a caller destroying this executor knows
-    // that when the destructor returns, every operation it accepted has been
-    // accounted for.
-    for (auto& work : abandoned)
-        work(ExecutionState::Cancelled);
 
     if (thread_.get_id() == std::this_thread::get_id()) {
         // Destroyed by its own work, which is what a completion that closes the
         // project it belongs to looks like from here. A thread cannot wait for
         // itself, so it is let go instead: the loop's own copy of the shared
-        // state keeps it alive, and the loop stops the moment this work returns.
+        // state keeps it alive, and it drains what is left as cancellations and
+        // stops the moment this work returns.
         thread_.detach();
         return;
     }
 
+    // Waited for, so that a destroyed executor has accounted for everything it
+    // accepted: the worker answers what is left before it stops.
     if (thread_.joinable())
         thread_.join();
 }

--- a/magda/daw/audio/plugins/engine/ControlExecutor.cpp
+++ b/magda/daw/audio/plugins/engine/ControlExecutor.cpp
@@ -1,91 +1,108 @@
 #include "ControlExecutor.hpp"
 
 #include <utility>
+#include <vector>
 
 namespace magda::daw::audio::engine_adapter {
 
-void MessageThreadControlExecutor::run(Work work) {
+bool MessageThreadControlExecutor::run(Work work) {
     if (!work)
-        return;
+        return false;
 
-    if (isCurrent()) {
-        work();
-        return;
-    }
-
-    juce::MessageManager::callAsync(std::move(work));
+    // Posted even from the message thread itself. Running it here would let a
+    // nested operation into a plugin the outer one has open, and would put it
+    // ahead of everything already waiting (ControlExecutor.hpp).
+    return juce::MessageManager::callAsync(
+        [work = std::move(work)]() mutable { work(ExecutionState::Ran); });
 }
 
 bool MessageThreadControlExecutor::isCurrent() const {
     return juce::MessageManager::existsAndIsCurrentThread();
 }
 
-SerialControlThread::SerialControlThread() : thread_([this] { loop(); }) {}
+SerialControlThread::SerialControlThread() : shared_(std::make_shared<Shared>()) {
+    // The worker holds the state as well, so that this object can be destroyed
+    // by work running on the worker without taking the worker's world with it.
+    thread_ = std::thread([shared = shared_] {
+        for (;;) {
+            Work work;
+
+            {
+                std::unique_lock<std::mutex> held(shared->lock);
+                shared->wake.wait(
+                    held, [&shared] { return shared->stopping || !shared->queued.empty(); });
+
+                // Stopping wins over what is left: whatever is still queued has
+                // already been cancelled by the destructor, and running it now
+                // would be reaching for devices that are going away.
+                if (shared->stopping)
+                    return;
+
+                work = std::move(shared->queued.front());
+                shared->queued.pop_front();
+            }
+
+            // Outside the lock, because the work is what takes the time and
+            // because it is entitled to queue more of itself.
+            work(ExecutionState::Ran);
+        }
+    });
+}
 
 SerialControlThread::~SerialControlThread() {
-    {
-        const std::lock_guard<std::mutex> held(lock_);
-        stopping_ = true;
+    std::deque<Work> abandoned;
 
-        // Dropped rather than drained. Work that has not started is work whose
-        // answer nobody is left to receive: this executor is destroyed before
-        // the devices its work would reach, and running it now would be
-        // reaching for plugins that are about to go.
-        queued_.clear();
+    {
+        const std::lock_guard<std::mutex> held(shared_->lock);
+        shared_->stopping = true;
+        abandoned.swap(shared_->queued);
     }
 
-    wake_.notify_all();
+    shared_->wake.notify_all();
+
+    // Answered rather than dropped. Every one of these is an operation somebody
+    // is still waiting on, and an executor that let them go would leave a
+    // promise of exactly one answer unkept by whoever made it.
+    //
+    // Before the wait below, so that a caller destroying this executor knows
+    // that when the destructor returns, every operation it accepted has been
+    // accounted for.
+    for (auto& work : abandoned)
+        work(ExecutionState::Cancelled);
+
+    if (thread_.get_id() == std::this_thread::get_id()) {
+        // Destroyed by its own work, which is what a completion that closes the
+        // project it belongs to looks like from here. A thread cannot wait for
+        // itself, so it is let go instead: the loop's own copy of the shared
+        // state keeps it alive, and the loop stops the moment this work returns.
+        thread_.detach();
+        return;
+    }
 
     if (thread_.joinable())
         thread_.join();
 }
 
-void SerialControlThread::run(Work work) {
+bool SerialControlThread::run(Work work) {
     if (!work)
-        return;
-
-    // Already here: run it now rather than queue it behind ourselves, which is
-    // what an operation asked for from inside another one would otherwise wait
-    // forever for.
-    if (isCurrent()) {
-        work();
-        return;
-    }
+        return false;
 
     {
-        const std::lock_guard<std::mutex> held(lock_);
-        if (stopping_)
-            return;
+        const std::lock_guard<std::mutex> held(shared_->lock);
+        if (shared_->stopping)
+            return false;
 
-        queued_.push_back(std::move(work));
+        // Queued even when the caller is the worker itself. See the header: a
+        // nested operation run inline is a second transaction inside the first.
+        shared_->queued.push_back(std::move(work));
     }
 
-    wake_.notify_one();
+    shared_->wake.notify_one();
+    return true;
 }
 
 bool SerialControlThread::isCurrent() const {
     return std::this_thread::get_id() == thread_.get_id();
-}
-
-void SerialControlThread::loop() {
-    for (;;) {
-        Work work;
-
-        {
-            std::unique_lock<std::mutex> held(lock_);
-            wake_.wait(held, [this] { return stopping_ || !queued_.empty(); });
-
-            if (stopping_)
-                return;
-
-            work = std::move(queued_.front());
-            queued_.pop_front();
-        }
-
-        // Outside the lock, because the work is what takes the time and because
-        // it is entitled to queue more of itself.
-        work();
-    }
 }
 
 }  // namespace magda::daw::audio::engine_adapter

--- a/magda/daw/audio/plugins/engine/ControlExecutor.hpp
+++ b/magda/daw/audio/plugins/engine/ControlExecutor.hpp
@@ -1,0 +1,131 @@
+#pragma once
+
+#include <juce_events/juce_events.h>
+
+#include <condition_variable>
+#include <deque>
+#include <functional>
+#include <mutex>
+#include <thread>
+
+/**
+ * @file ControlExecutor.hpp
+ * @brief The one thread everything that is not a block runs on (#2270).
+ *
+ * A device has two sides. The audio side is a block arriving on whatever thread
+ * the host renders from, and it is already serialised by being one callback.
+ * The control side -- reading a plugin's state, loading a preset, changing a
+ * program, opening an editor -- is not serialised by anything unless something
+ * says so, and the plugin underneath it is entitled to assume it is: every one
+ * of those operations suspends the plugin, does something to it, and resumes
+ * it, so two of them overlapping means the first to finish resumes a plugin the
+ * second is still working on.
+ *
+ * A host with a GUI already has an answer, and it is the message thread. The
+ * mistake worth naming is treating the absence of one as an absence of the
+ * question: a headless host has whatever threads it has, and "no message
+ * manager" is not permission for all of them to reach a plugin at once. So the
+ * control side has an execution context of its own, explicitly, and both kinds
+ * of host name one rather than one kind going without.
+ *
+ * ## What this is for
+ *
+ * Every control operation on a device runs here, and every answer to one is
+ * delivered here. That is what makes an out-of-process implementation an
+ * add-on: its request goes out from this thread and its reply is marshalled
+ * back onto the same one, so a caller writing a project's model in a callback
+ * is on the thread it was always on, whichever process answered.
+ *
+ * The capture is the first of those operations (DeviceControl.hpp). Presets,
+ * programs and editor windows are the same shape and belong here as they
+ * arrive, rather than each finding its own thread and its own convention.
+ *
+ * The asynchronous load is the one control operation that predates this and
+ * still has a contract of its own: it completes on the message thread, which is
+ * where JUCE hands a plugin over. It is not wrong, and it is the next thing to
+ * join, so that a host with plugins in another process has one thread its
+ * device operations happen on rather than two.
+ */
+
+namespace magda::daw::audio::engine_adapter {
+
+/**
+ * @brief Where a device's control operations run.
+ *
+ * Serial: one piece of work at a time, in the order it was given. That is the
+ * whole contract, and it is what the plugins underneath are entitled to.
+ */
+class ControlExecutor {
+  public:
+    virtual ~ControlExecutor() = default;
+
+    ControlExecutor() = default;
+    ControlExecutor(const ControlExecutor&) = delete;
+    ControlExecutor& operator=(const ControlExecutor&) = delete;
+    ControlExecutor(ControlExecutor&&) = delete;
+    ControlExecutor& operator=(ControlExecutor&&) = delete;
+
+    using Work = std::function<void()>;
+
+    /**
+     * @brief Run @p work on this executor.
+     *
+     * Immediately when the caller is already on it, which is what keeps an
+     * operation asked for from inside another one from waiting on a thread it
+     * is standing on; queued otherwise.
+     */
+    virtual void run(Work work) = 0;
+
+    /// Whether the calling thread is this executor's own.
+    virtual bool isCurrent() const = 0;
+};
+
+/**
+ * @brief The executor for a host that has a message thread.
+ *
+ * Which is every host with a window in it. Control work belongs on the message
+ * thread there for reasons older than this file: it is the thread a plugin's
+ * editor lives on, the one its own host callbacks expect, and the one the model
+ * a callback writes into is edited from.
+ */
+class MessageThreadControlExecutor final : public ControlExecutor {
+  public:
+    void run(Work work) override;
+    bool isCurrent() const override;
+};
+
+/**
+ * @brief The executor for a host that has no message thread.
+ *
+ * An offline render, a command-line tool, a test binary. It owns a thread and
+ * runs what it is given on that one, in order, which is the same guarantee the
+ * message thread gives an application and the reason a headless host is not
+ * left deciding per call site.
+ *
+ * Work queued but not yet run is dropped when this is destroyed. That is the
+ * ordering rule it exists under and the reason it is safe: an executor is
+ * destroyed before the devices whose plugins its work would have reached, so
+ * work that has not started must not start, and whoever was waiting for the
+ * answer is the thing being torn down.
+ */
+class SerialControlThread final : public ControlExecutor {
+  public:
+    SerialControlThread();
+    ~SerialControlThread() override;
+
+    void run(Work work) override;
+    bool isCurrent() const override;
+
+  private:
+    void loop();
+
+    std::mutex lock_;
+    std::condition_variable wake_;
+    std::deque<Work> queued_;
+    bool stopping_ = false;
+
+    /// Last, so the thread starts once everything it reads is built.
+    std::thread thread_;
+};
+
+}  // namespace magda::daw::audio::engine_adapter

--- a/magda/daw/audio/plugins/engine/ControlExecutor.hpp
+++ b/magda/daw/audio/plugins/engine/ControlExecutor.hpp
@@ -5,6 +5,7 @@
 #include <condition_variable>
 #include <deque>
 #include <functional>
+#include <memory>
 #include <mutex>
 #include <thread>
 
@@ -28,6 +29,37 @@
  * control side has an execution context of its own, explicitly, and both kinds
  * of host name one rather than one kind going without.
  *
+ * ## One at a time, and that includes nesting
+ *
+ * Work is queued, always, including work asked for from the executor itself.
+ * Running a nested piece inline would be the very failure this exists to
+ * prevent: an operation that has suspended a plugin and asks for another would
+ * have the second run inside it, resume the plugin, and let audio back in
+ * halfway through the first. It would also jump the queue past work already
+ * waiting.
+ *
+ * So run() is fire and forget in every case, and composition is by callback:
+ * an operation that needs another does it from its own completion, which by
+ * then has ended.
+ *
+ * ## What happens to work that was accepted
+ *
+ * Accepted work is always called exactly once, and told which of the two it is:
+ * it either ran, or it was cancelled because the executor went away before its
+ * turn. That is what lets a caller above this keep a promise of its own -- a
+ * capture owes its answer exactly once, and an executor that quietly dropped
+ * queued work would leave callers waiting for an answer nobody was left to
+ * send.
+ *
+ * Cancelled work runs on whichever thread destroys the executor and must touch
+ * nothing but its own reporting. A cancellation is not a late chance to reach a
+ * plugin: the reason there is one is that the plugins are going away.
+ *
+ * Submission itself can fail, and says so rather than pretending: an executor
+ * that has stopped accepts nothing, and a message loop that is shutting down
+ * refuses a post. A caller that is refused has been told nothing will run, and
+ * answers for the operation itself.
+ *
  * ## What this is for
  *
  * Every control operation on a device runs here, and every answer to one is
@@ -49,11 +81,23 @@
 
 namespace magda::daw::audio::engine_adapter {
 
+/// Which of the two things happened to a piece of accepted work.
+enum class ExecutionState {
+    /// Its turn came and this is it, on the executor's own thread.
+    Ran,
+
+    /// The executor went away first. Report and return: the devices this would
+    /// have reached are going away too, and this is not running on the control
+    /// thread.
+    Cancelled,
+};
+
 /**
  * @brief Where a device's control operations run.
  *
- * Serial: one piece of work at a time, in the order it was given. That is the
- * whole contract, and it is what the plugins underneath are entitled to.
+ * Serial: one piece of work at a time, in the order it was accepted, nesting
+ * included. That is the whole contract, and it is what the plugins underneath
+ * are entitled to.
  */
 class ControlExecutor {
   public:
@@ -65,16 +109,21 @@ class ControlExecutor {
     ControlExecutor(ControlExecutor&&) = delete;
     ControlExecutor& operator=(ControlExecutor&&) = delete;
 
-    using Work = std::function<void()>;
+    using Work = std::function<void(ExecutionState)>;
 
     /**
-     * @brief Run @p work on this executor.
+     * @brief Queue @p work, to run on this executor in the order it arrived.
      *
-     * Immediately when the caller is already on it, which is what keeps an
-     * operation asked for from inside another one from waiting on a thread it
-     * is standing on; queued otherwise.
+     * Never immediate, including when the caller is already on the executor.
+     * See the file comment: an operation that ran nested work inline would be
+     * letting a second transaction into a plugin the first has open.
+     *
+     * @return whether it was accepted. Accepted work is called exactly once,
+     *         with Ran or with Cancelled. A refusal means nothing will run it
+     *         and nothing will call it, so whatever the caller owed for it is
+     *         still owed.
      */
-    virtual void run(Work work) = 0;
+    virtual bool run(Work work) = 0;
 
     /// Whether the calling thread is this executor's own.
     virtual bool isCurrent() const = 0;
@@ -87,10 +136,15 @@ class ControlExecutor {
  * thread there for reasons older than this file: it is the thread a plugin's
  * editor lives on, the one its own host callbacks expect, and the one the model
  * a callback writes into is edited from.
+ *
+ * The one guarantee it cannot make is the one JUCE does not: a message posted
+ * and then abandoned because the loop itself was torn down is a call that never
+ * arrives. That is process teardown rather than a plane closing, and it is
+ * stated here rather than papered over.
  */
 class MessageThreadControlExecutor final : public ControlExecutor {
   public:
-    void run(Work work) override;
+    bool run(Work work) override;
     bool isCurrent() const override;
 };
 
@@ -102,29 +156,39 @@ class MessageThreadControlExecutor final : public ControlExecutor {
  * message thread gives an application and the reason a headless host is not
  * left deciding per call site.
  *
- * Work queued but not yet run is dropped when this is destroyed. That is the
- * ordering rule it exists under and the reason it is safe: an executor is
- * destroyed before the devices whose plugins its work would have reached, so
- * work that has not started must not start, and whoever was waiting for the
- * answer is the thing being torn down.
+ * Work still queued when this is destroyed is cancelled rather than dropped, so
+ * every accepted operation is still answered once. Cancellation runs on the
+ * thread doing the destroying, before it waits for the worker.
+ *
+ * ## Being destroyed by its own work
+ *
+ * A completion running here is entitled to close the thing that owns this
+ * executor -- a project closing from a callback is an ordinary outcome -- and
+ * that makes the last reference fall on the executor's own thread. So the state
+ * the worker touches is held apart from this object and outlives it, and a
+ * destructor that finds itself on the worker detaches rather than joining: a
+ * thread cannot wait for itself, and a worker whose state is still alive can be
+ * left to finish the block it is in and stop.
  */
 class SerialControlThread final : public ControlExecutor {
   public:
     SerialControlThread();
     ~SerialControlThread() override;
 
-    void run(Work work) override;
+    bool run(Work work) override;
     bool isCurrent() const override;
 
   private:
-    void loop();
+    /// Everything the worker touches, owned by the worker as much as by the
+    /// executor, so that either can be the last to let go.
+    struct Shared {
+        std::mutex lock;
+        std::condition_variable wake;
+        std::deque<Work> queued;
+        bool stopping = false;
+    };
 
-    std::mutex lock_;
-    std::condition_variable wake_;
-    std::deque<Work> queued_;
-    bool stopping_ = false;
-
-    /// Last, so the thread starts once everything it reads is built.
+    std::shared_ptr<Shared> shared_;
     std::thread thread_;
 };
 

--- a/magda/daw/audio/plugins/engine/ControlExecutor.hpp
+++ b/magda/daw/audio/plugins/engine/ControlExecutor.hpp
@@ -2,6 +2,7 @@
 
 #include <juce_events/juce_events.h>
 
+#include <atomic>
 #include <condition_variable>
 #include <deque>
 #include <functional>
@@ -44,21 +45,33 @@
  *
  * ## What happens to work that was accepted
  *
- * Accepted work is always called exactly once, and told which of the two it is:
- * it either ran, or it was cancelled because the executor went away before its
- * turn. That is what lets a caller above this keep a promise of its own -- a
- * capture owes its answer exactly once, and an executor that quietly dropped
- * queued work would leave callers waiting for an answer nobody was left to
- * send.
+ * Accepted work is called exactly once, on the executor, and told which of the
+ * two it is: it either ran, or it was cancelled because the executor is going
+ * away before its turn came. Both arrive on the executor's own thread, which is
+ * the whole point of having one -- a caller writing a project's model in a
+ * completion is entitled to be on the same thread whichever of the two it got,
+ * and an answer that arrived somewhere else would put an isCurrent() check and
+ * a hop of its own into every consumer.
  *
- * Cancelled work runs on whichever thread destroys the executor and must touch
- * nothing but its own reporting. A cancellation is not a late chance to reach a
- * plugin: the reason there is one is that the plugins are going away.
+ * A cancellation is not a late chance to reach a plugin. The devices are going
+ * away; what it is for is letting whoever was waiting stop waiting.
  *
  * Submission itself can fail, and says so rather than pretending: an executor
- * that has stopped accepts nothing, and a message loop that is shutting down
- * refuses a post. A caller that is refused has been told nothing will run, and
- * answers for the operation itself.
+ * that has stopped accepts nothing. A caller that is refused has been told,
+ * synchronously, that nothing will run and nothing will be called -- so
+ * whatever it owed for that operation is still its own to answer, on its own
+ * thread, without a callback arriving from somewhere unexpected to say so.
+ *
+ * ## The one edge the guarantee is scoped to
+ *
+ * "Exactly once, on the executor" holds for as long as the executor has a
+ * context to run on. A SerialControlThread owns its thread and therefore owns
+ * the guarantee outright. A MessageThreadControlExecutor borrows the host's
+ * message loop: work it posted is cancelled on that loop when the executor is
+ * destroyed, but a loop torn down under a posted call takes the call with it,
+ * and nothing in this file can be standing on a thread that no longer exists.
+ * That is process teardown rather than a project closing, and it is written
+ * here rather than left as a surprise.
  *
  * ## What this is for
  *
@@ -118,10 +131,12 @@ class ControlExecutor {
      * See the file comment: an operation that ran nested work inline would be
      * letting a second transaction into a plugin the first has open.
      *
-     * @return whether it was accepted. Accepted work is called exactly once,
-     *         with Ran or with Cancelled. A refusal means nothing will run it
-     *         and nothing will call it, so whatever the caller owed for it is
-     *         still owed.
+     * @return whether it was accepted. Accepted work is called exactly once and
+     *         on this executor, with Ran or with Cancelled, scoped as the file
+     *         comment scopes it. A refusal means nothing will run it and
+     *         nothing will call it, so whatever the caller owed for it is still
+     *         owed -- and is owed on the caller's own thread, which is where it
+     *         has just been told.
      */
     virtual bool run(Work work) = 0;
 
@@ -137,15 +152,32 @@ class ControlExecutor {
  * editor lives on, the one its own host callbacks expect, and the one the model
  * a callback writes into is edited from.
  *
- * The one guarantee it cannot make is the one JUCE does not: a message posted
- * and then abandoned because the loop itself was torn down is a call that never
- * arrives. That is process teardown rather than a plane closing, and it is
- * stated here rather than papered over.
+ * Work it has posted and this executor has not outlived is cancelled rather
+ * than left to run against a plane that is gone: the post still arrives on the
+ * message thread and is told it was cancelled, which keeps the answer on the
+ * executor in both cases.
+ *
+ * The loop is the host's rather than this object's, which is where the base
+ * guarantee is scoped rather than kept: a message loop torn down under a posted
+ * call takes the call with it, and there is no thread left to say so on.
  */
 class MessageThreadControlExecutor final : public ControlExecutor {
   public:
+    MessageThreadControlExecutor();
+    ~MessageThreadControlExecutor() override;
+
     bool run(Work work) override;
     bool isCurrent() const override;
+
+  private:
+    /// Shared with every post this executor has made, so that destroying it
+    /// turns them all into cancellations rather than calls into a plane that
+    /// has gone.
+    struct Posted {
+        std::atomic<bool> cancelled{false};
+    };
+
+    std::shared_ptr<Posted> posted_;
 };
 
 /**
@@ -157,8 +189,11 @@ class MessageThreadControlExecutor final : public ControlExecutor {
  * left deciding per call site.
  *
  * Work still queued when this is destroyed is cancelled rather than dropped, so
- * every accepted operation is still answered once. Cancellation runs on the
- * thread doing the destroying, before it waits for the worker.
+ * every accepted operation is still answered once -- and answered on the worker
+ * itself, which drains what is left as cancellations before it stops. The
+ * destructor waits for that, so an executor that has been destroyed has
+ * accounted for everything it accepted, on the one thread it promised to
+ * account for it on.
  *
  * ## Being destroyed by its own work
  *

--- a/magda/daw/audio/plugins/engine/DeviceControl.cpp
+++ b/magda/daw/audio/plugins/engine/DeviceControl.cpp
@@ -47,8 +47,10 @@ DeviceControlPlane::DeviceControlPlane(std::shared_ptr<ControlExecutor> executor
 }
 
 LocalDeviceControlPlane::LocalDeviceControlPlane(std::shared_ptr<ControlExecutor> executor,
-                                                 DeviceLookup devices)
-    : DeviceControlPlane(std::move(executor)), devices_(std::move(devices)) {}
+                                                 std::weak_ptr<void> lifeline, DeviceLookup devices)
+    : DeviceControlPlane(std::move(executor)),
+      lifeline_(std::move(lifeline)),
+      devices_(std::move(devices)) {}
 
 void LocalDeviceControlPlane::captureState(magda::engine::DeviceKey key,
                                            CaptureCallback completed) {
@@ -66,10 +68,29 @@ void LocalDeviceControlPlane::captureState(magda::engine::DeviceKey key,
     // being inside one plugin at once, and one serial executor is what makes
     // that impossible for every control operation rather than for this one.
     //
-    // The lookup is copied rather than reached for through `this`: work outlives
-    // the call that queued it, and a plane destroyed in between would otherwise
-    // be read from a thread that is still running.
-    executor()->run([devices = devices_, key, completed = std::move(completed)]() mutable {
+    // Nothing about the plane is captured. The work outlives the call that
+    // queued it, so it carries what it needs by value: the lookup, and the weak
+    // lifeline that says whether the runtime the lookup reads is still there.
+    const auto accepted = executor()->run([lifeline = lifeline_, devices = devices_, key,
+                                           completed](ExecutionState state) mutable {
+        if (state == ExecutionState::Cancelled) {
+            // Owed an answer even here, and owed the truth about it: this is
+            // not the control thread and the devices are going away, so nothing
+            // is looked up and nothing is read.
+            completed(CaptureOutcome::failed("the control plane closed before this capture ran"));
+            return;
+        }
+
+        // Held for the length of the operation rather than checked at the start
+        // of it. A runtime that expires between the check and the lookup is the
+        // same dangling pointer as one that expired before either.
+        const auto alive = lifeline.lock();
+        if (!alive) {
+            completed(CaptureOutcome::failed("the runtime that owned " + describeKey(key) +
+                                             " is gone, so nothing was read"));
+            return;
+        }
+
         if (!devices) {
             completed(
                 CaptureOutcome::failed("this control plane was given no way to find a device"));
@@ -95,6 +116,13 @@ void LocalDeviceControlPlane::captureState(magda::engine::DeviceKey key,
 
         completed(CaptureOutcome::taken(std::move(*snapshot)));
     });
+
+    // Refused, which is a plane already shutting down: nothing will run the
+    // work and nothing will call the callback, so the promise of exactly one
+    // answer is this call's to keep. The one answer that does not arrive on the
+    // executor, because by now there is not one to arrive on.
+    if (!accepted)
+        completed(CaptureOutcome::failed("the control plane is closing and took no capture"));
 }
 
 bool commitCapturedState(const AssignmentRequest& request,

--- a/magda/daw/audio/plugins/engine/DeviceControl.cpp
+++ b/magda/daw/audio/plugins/engine/DeviceControl.cpp
@@ -85,7 +85,11 @@ bool LocalDeviceControlPlane::captureState(magda::engine::DeviceKey key,
             return;
         }
 
-        auto* device = registry->find(key);
+        // The lease, held for the rest of this operation. What it is worth is
+        // that the device cannot go while the capture is reading it: not when
+        // the chain it sits in is edited, and not when whatever owns it lets
+        // go. The registry being alive was never enough to promise that.
+        const auto device = registry->find(key);
         if (device == nullptr) {
             // Named rather than reported as an empty state. A key with nothing
             // bound to it is a slot whose plugin has not arrived or has gone,

--- a/magda/daw/audio/plugins/engine/DeviceControl.cpp
+++ b/magda/daw/audio/plugins/engine/DeviceControl.cpp
@@ -47,20 +47,13 @@ DeviceControlPlane::DeviceControlPlane(std::shared_ptr<ControlExecutor> executor
 }
 
 LocalDeviceControlPlane::LocalDeviceControlPlane(std::shared_ptr<ControlExecutor> executor,
-                                                 std::weak_ptr<void> lifeline, DeviceLookup devices)
-    : DeviceControlPlane(std::move(executor)),
-      lifeline_(std::move(lifeline)),
-      devices_(std::move(devices)) {}
+                                                 std::weak_ptr<const DeviceRegistry> devices)
+    : DeviceControlPlane(std::move(executor)), devices_(std::move(devices)) {}
 
-void LocalDeviceControlPlane::captureState(magda::engine::DeviceKey key,
+bool LocalDeviceControlPlane::captureState(magda::engine::DeviceKey key,
                                            CaptureCallback completed) {
-    if (!completed)
-        return;
-
-    if (executor() == nullptr) {
-        completed(CaptureOutcome::failed("this control plane has no executor to run on"));
-        return;
-    }
+    if (!completed || executor() == nullptr)
+        return false;
 
     // Everything past here runs on the executor: the lookup, the plugin's own
     // state read, and the answer. Nothing checks which thread asked, because
@@ -69,35 +62,30 @@ void LocalDeviceControlPlane::captureState(magda::engine::DeviceKey key,
     // that impossible for every control operation rather than for this one.
     //
     // Nothing about the plane is captured. The work outlives the call that
-    // queued it, so it carries what it needs by value: the lookup, and the weak
-    // lifeline that says whether the runtime the lookup reads is still there.
-    const auto accepted = executor()->run([lifeline = lifeline_, devices = devices_, key,
-                                           completed](ExecutionState state) mutable {
+    // queued it, so it carries what it needs by value: the weak registry, which
+    // is the devices and their owner in one reference rather than a token
+    // standing beside them.
+    return executor()->run([devices = devices_, key, completed](ExecutionState state) mutable {
         if (state == ExecutionState::Cancelled) {
-            // Owed an answer even here, and owed the truth about it: this is
-            // not the control thread and the devices are going away, so nothing
-            // is looked up and nothing is read.
+            // Still on the executor, which is what a cancellation is worth: the
+            // caller is told where it was expecting to be told, and the devices
+            // are not reached for on the way.
             completed(CaptureOutcome::failed("the control plane closed before this capture ran"));
             return;
         }
 
         // Held for the length of the operation rather than checked at the start
-        // of it. A runtime that expires between the check and the lookup is the
-        // same dangling pointer as one that expired before either.
-        const auto alive = lifeline.lock();
-        if (!alive) {
+        // of it, and it is the registry itself rather than a token beside it:
+        // what keeps a device alive is the thing that owns it, so locking that
+        // is what makes the pointer below safe to use until this returns.
+        const auto registry = devices.lock();
+        if (!registry) {
             completed(CaptureOutcome::failed("the runtime that owned " + describeKey(key) +
                                              " is gone, so nothing was read"));
             return;
         }
 
-        if (!devices) {
-            completed(
-                CaptureOutcome::failed("this control plane was given no way to find a device"));
-            return;
-        }
-
-        auto* device = devices(key);
+        auto* device = registry->find(key);
         if (device == nullptr) {
             // Named rather than reported as an empty state. A key with nothing
             // bound to it is a slot whose plugin has not arrived or has gone,
@@ -116,13 +104,6 @@ void LocalDeviceControlPlane::captureState(magda::engine::DeviceKey key,
 
         completed(CaptureOutcome::taken(std::move(*snapshot)));
     });
-
-    // Refused, which is a plane already shutting down: nothing will run the
-    // work and nothing will call the callback, so the promise of exactly one
-    // answer is this call's to keep. The one answer that does not arrive on the
-    // executor, because by now there is not one to arrive on.
-    if (!accepted)
-        completed(CaptureOutcome::failed("the control plane is closing and took no capture"));
 }
 
 bool commitCapturedState(const AssignmentRequest& request,

--- a/magda/daw/audio/plugins/engine/DeviceControl.cpp
+++ b/magda/daw/audio/plugins/engine/DeviceControl.cpp
@@ -39,59 +39,62 @@ const magda::ExternalPluginSnapshot& CaptureOutcome::snapshot() const {
     return *snapshot_;
 }
 
-LocalDeviceControlPlane::LocalDeviceControlPlane(DeviceLookup devices)
-    : devices_(std::move(devices)) {}
+DeviceControlPlane::DeviceControlPlane(std::shared_ptr<ControlExecutor> executor)
+    : executor_(std::move(executor)) {
+    // A plane with nowhere to run its work would answer nothing and say nothing
+    // about why, which is the one failure this whole file is arranged against.
+    jassert(executor_ != nullptr);
+}
+
+LocalDeviceControlPlane::LocalDeviceControlPlane(std::shared_ptr<ControlExecutor> executor,
+                                                 DeviceLookup devices)
+    : DeviceControlPlane(std::move(executor)), devices_(std::move(devices)) {}
 
 void LocalDeviceControlPlane::captureState(magda::engine::DeviceKey key,
                                            CaptureCallback completed) {
     if (!completed)
         return;
 
-    // The precondition, enforced rather than documented. Everything below this
-    // line reaches into a plugin: the lookup finds the device, the device
-    // suspends the instance and asks it to describe itself, and none of that is
-    // a worker thread's to do. Refused rather than marshalled, because a save
-    // asked for from the wrong thread is a caller to fix and not a call to
-    // rescue -- and because a remote implementation would answer the same way
-    // rather than quietly acquiring a thread to hop from.
+    if (executor() == nullptr) {
+        completed(CaptureOutcome::failed("this control plane has no executor to run on"));
+        return;
+    }
+
+    // Everything past here runs on the executor: the lookup, the plugin's own
+    // state read, and the answer. Nothing checks which thread asked, because
+    // asking is allowed from any of them -- what is not allowed is two of these
+    // being inside one plugin at once, and one serial executor is what makes
+    // that impossible for every control operation rather than for this one.
     //
-    // Asked as "is there a message thread, and is this it" rather than as "is
-    // this the message thread", because those differ where the engine is
-    // supposed to work: a headless render has no message manager at all, so
-    // there is no thread to be off, and a check that refused there would refuse
-    // every offline host on the grounds that it is not an application.
-    if (auto* messages = juce::MessageManager::getInstanceWithoutCreating();
-        messages != nullptr && !messages->isThisTheMessageThread()) {
-        JUCE_ASSERT_MESSAGE_THREAD
-        completed(CaptureOutcome::failed("a capture was asked for off the message thread"));
-        return;
-    }
+    // The lookup is copied rather than reached for through `this`: work outlives
+    // the call that queued it, and a plane destroyed in between would otherwise
+    // be read from a thread that is still running.
+    executor()->run([devices = devices_, key, completed = std::move(completed)]() mutable {
+        if (!devices) {
+            completed(
+                CaptureOutcome::failed("this control plane was given no way to find a device"));
+            return;
+        }
 
-    if (!devices_) {
-        completed(CaptureOutcome::failed("this control plane was given no way to find a device"));
-        return;
-    }
+        auto* device = devices(key);
+        if (device == nullptr) {
+            // Named rather than reported as an empty state. A key with nothing
+            // bound to it is a slot whose plugin has not arrived or has gone,
+            // and a caller told "no state" would write that absence into the
+            // project.
+            completed(CaptureOutcome::failed("no plugin is bound for " + describeKey(key)));
+            return;
+        }
 
-    auto* device = devices_(key);
-    if (device == nullptr) {
-        // Named rather than reported as an empty state. A key with nothing
-        // bound to it is a slot whose plugin has not arrived or has gone, and a
-        // caller told "no state" would write that absence into the project.
-        completed(CaptureOutcome::failed("no plugin is bound for " + describeKey(key)));
-        return;
-    }
+        auto snapshot = device->captureState();
+        if (!snapshot.has_value()) {
+            completed(CaptureOutcome::failed("the plugin bound for " + describeKey(key) +
+                                             " could not describe itself"));
+            return;
+        }
 
-    auto snapshot = device->captureState();
-    if (!snapshot.has_value()) {
-        completed(CaptureOutcome::failed("the plugin bound for " + describeKey(key) +
-                                         " could not describe itself"));
-        return;
-    }
-
-    // Called before returning, because the plugin is right here. Through the
-    // callback all the same: a caller that only worked when the answer arrived
-    // synchronously would be a caller that only works in this process.
-    completed(CaptureOutcome::taken(std::move(*snapshot)));
+        completed(CaptureOutcome::taken(std::move(*snapshot)));
+    });
 }
 
 bool commitCapturedState(const AssignmentRequest& request,

--- a/magda/daw/audio/plugins/engine/DeviceControl.cpp
+++ b/magda/daw/audio/plugins/engine/DeviceControl.cpp
@@ -16,6 +16,29 @@ juce::String describeKey(magda::engine::DeviceKey key) {
 
 }  // namespace
 
+CaptureOutcome CaptureOutcome::taken(magda::ExternalPluginSnapshot snapshot) {
+    CaptureOutcome outcome;
+    outcome.snapshot_ = std::move(snapshot);
+    return outcome;
+}
+
+CaptureOutcome CaptureOutcome::failed(juce::String reason) {
+    CaptureOutcome outcome;
+
+    // A failure always says something. One that did not would reach a person as
+    // a save that did not happen and no reason it did not, which is the same
+    // thing as saying nothing at all.
+    outcome.failure_ = reason.isNotEmpty()
+                           ? std::move(reason)
+                           : juce::String("the capture failed for no stated reason");
+    return outcome;
+}
+
+const magda::ExternalPluginSnapshot& CaptureOutcome::snapshot() const {
+    jassert(ok());
+    return *snapshot_;
+}
+
 LocalDeviceControlPlane::LocalDeviceControlPlane(DeviceLookup devices)
     : devices_(std::move(devices)) {}
 
@@ -24,9 +47,28 @@ void LocalDeviceControlPlane::captureState(magda::engine::DeviceKey key,
     if (!completed)
         return;
 
+    // The precondition, enforced rather than documented. Everything below this
+    // line reaches into a plugin: the lookup finds the device, the device
+    // suspends the instance and asks it to describe itself, and none of that is
+    // a worker thread's to do. Refused rather than marshalled, because a save
+    // asked for from the wrong thread is a caller to fix and not a call to
+    // rescue -- and because a remote implementation would answer the same way
+    // rather than quietly acquiring a thread to hop from.
+    //
+    // Asked as "is there a message thread, and is this it" rather than as "is
+    // this the message thread", because those differ where the engine is
+    // supposed to work: a headless render has no message manager at all, so
+    // there is no thread to be off, and a check that refused there would refuse
+    // every offline host on the grounds that it is not an application.
+    if (auto* messages = juce::MessageManager::getInstanceWithoutCreating();
+        messages != nullptr && !messages->isThisTheMessageThread()) {
+        JUCE_ASSERT_MESSAGE_THREAD
+        completed(CaptureOutcome::failed("a capture was asked for off the message thread"));
+        return;
+    }
+
     if (!devices_) {
-        completed({.snapshot = std::nullopt,
-                   .failure = "this control plane was given no way to find a device"});
+        completed(CaptureOutcome::failed("this control plane was given no way to find a device"));
         return;
     }
 
@@ -35,27 +77,26 @@ void LocalDeviceControlPlane::captureState(magda::engine::DeviceKey key,
         // Named rather than reported as an empty state. A key with nothing
         // bound to it is a slot whose plugin has not arrived or has gone, and a
         // caller told "no state" would write that absence into the project.
-        completed(
-            {.snapshot = std::nullopt, .failure = "no plugin is bound for " + describeKey(key)});
+        completed(CaptureOutcome::failed("no plugin is bound for " + describeKey(key)));
         return;
     }
 
     auto snapshot = device->captureState();
     if (!snapshot.has_value()) {
-        completed(
-            {.snapshot = std::nullopt,
-             .failure = "the plugin bound for " + describeKey(key) + " could not describe itself"});
+        completed(CaptureOutcome::failed("the plugin bound for " + describeKey(key) +
+                                         " could not describe itself"));
         return;
     }
 
     // Called before returning, because the plugin is right here. Through the
     // callback all the same: a caller that only worked when the answer arrived
     // synchronously would be a caller that only works in this process.
-    completed({.snapshot = std::move(snapshot), .failure = {}});
+    completed(CaptureOutcome::taken(std::move(*snapshot)));
 }
 
 bool commitCapturedState(const AssignmentRequest& request,
-                         const magda::ExternalPluginSnapshot& snapshot, magda::DeviceInfo& device) {
+                         const magda::ExternalPluginSnapshot& snapshot,
+                         const MutableDeviceLookup& device) {
     // The same question the other direction asks of a plugin that has finished
     // loading, and the same answer: a snapshot is only worth writing down onto
     // the assignment it was read from. A key that is live again under a
@@ -63,7 +104,16 @@ bool commitCapturedState(const AssignmentRequest& request,
     if (!request.isStillWanted())
         return false;
 
-    magda::applyCapturedPluginState(device, snapshot);
+    if (!device)
+        return false;
+
+    // Resolved from the token's own key, so the thing that was validated and
+    // the thing that is written are the same device by construction.
+    auto* target = device(request.key);
+    if (target == nullptr)
+        return false;
+
+    magda::applyCapturedPluginState(*target, snapshot);
     return true;
 }
 

--- a/magda/daw/audio/plugins/engine/DeviceControl.cpp
+++ b/magda/daw/audio/plugins/engine/DeviceControl.cpp
@@ -1,0 +1,70 @@
+#include "DeviceControl.hpp"
+
+#include <utility>
+
+#include "EngineExternalDevice.hpp"
+
+namespace magda::daw::audio::engine_adapter {
+
+namespace {
+
+/// Which device a key names, said the way a person reads it.
+juce::String describeKey(magda::engine::DeviceKey key) {
+    return "device " + juce::String(static_cast<int>(key.deviceId)) + " in section " +
+           juce::String(static_cast<int>(key.segment));
+}
+
+}  // namespace
+
+LocalDeviceControlPlane::LocalDeviceControlPlane(DeviceLookup devices)
+    : devices_(std::move(devices)) {}
+
+void LocalDeviceControlPlane::captureState(magda::engine::DeviceKey key,
+                                           CaptureCallback completed) {
+    if (!completed)
+        return;
+
+    if (!devices_) {
+        completed({.snapshot = std::nullopt,
+                   .failure = "this control plane was given no way to find a device"});
+        return;
+    }
+
+    auto* device = devices_(key);
+    if (device == nullptr) {
+        // Named rather than reported as an empty state. A key with nothing
+        // bound to it is a slot whose plugin has not arrived or has gone, and a
+        // caller told "no state" would write that absence into the project.
+        completed(
+            {.snapshot = std::nullopt, .failure = "no plugin is bound for " + describeKey(key)});
+        return;
+    }
+
+    auto snapshot = device->captureState();
+    if (!snapshot.has_value()) {
+        completed(
+            {.snapshot = std::nullopt,
+             .failure = "the plugin bound for " + describeKey(key) + " could not describe itself"});
+        return;
+    }
+
+    // Called before returning, because the plugin is right here. Through the
+    // callback all the same: a caller that only worked when the answer arrived
+    // synchronously would be a caller that only works in this process.
+    completed({.snapshot = std::move(snapshot), .failure = {}});
+}
+
+bool commitCapturedState(const AssignmentRequest& request,
+                         const magda::ExternalPluginSnapshot& snapshot, magda::DeviceInfo& device) {
+    // The same question the other direction asks of a plugin that has finished
+    // loading, and the same answer: a snapshot is only worth writing down onto
+    // the assignment it was read from. A key that is live again under a
+    // different assignment is not that, and neither is a runtime that has gone.
+    if (!request.isStillWanted())
+        return false;
+
+    magda::applyCapturedPluginState(device, snapshot);
+    return true;
+}
+
+}  // namespace magda::daw::audio::engine_adapter

--- a/magda/daw/audio/plugins/engine/DeviceControl.hpp
+++ b/magda/daw/audio/plugins/engine/DeviceControl.hpp
@@ -197,16 +197,19 @@ class DeviceControlPlane {
  * @brief The devices a plane can reach, owned by whoever runs them (#2270).
  *
  * A plane's work runs later than the call that queued it, so between the two a
- * project can be closed. What it needs at that moment is not a token beside a
- * lookup -- keeping one alive says nothing about what the other captured -- but
- * the thing that owns the devices, held weakly and locked before it is asked.
+ * project can be closed and a device can be taken out of the chain it was in.
+ * Two lifetimes, and both have to be answered where the answer cannot be
+ * forgotten.
  *
- * So the lookup is a type rather than a function, and the plane holds a weak
- * reference to it. Locking it is what keeps the devices alive for the length of
- * the operation, and failing to lock it is the answer that there is nothing
- * left to ask. The relationship is the type's rather than a caller's to
- * maintain: there is no way to hand over a lease that has nothing to do with
- * the devices it is supposed to be keeping.
+ * The registry answers the first: the plane holds it weakly, locks it before it
+ * asks anything, and a registry that will not lock is a runtime that has gone.
+ * The lease answers the second: what comes back from find() carries the device
+ * rather than pointing at it, so a device removed or destroyed while a capture
+ * is reading it is a device the capture is still holding.
+ *
+ * Neither is a caller's to remember. A token beside a lookup was the version
+ * that could be got wrong -- keeping one alive says nothing about what the
+ * other captured -- and the types say it now instead.
  *
  * The same shape the load path already has for the same problem, where an
  * assignment is held weakly and a completion that finds it gone is refused
@@ -223,14 +226,24 @@ class DeviceRegistry {
     DeviceRegistry& operator=(DeviceRegistry&&) = delete;
 
     /**
-     * @brief The device at @p key, or null.
+     * @brief A lease on the device at @p key, or nothing.
      *
-     * Null for a key nothing is bound to, which includes one whose plugin has
-     * not finished loading. Called on the control executor, with the registry
-     * held alive for the length of the operation, so what it returns is safe to
-     * use until that operation ends.
+     * A lease rather than a pointer, and that is the whole of what this
+     * interface is for. Holding the registry alive says only that the registry
+     * is alive: a device can be taken out of it, or destroyed by whatever owns
+     * it, while the registry itself carries on -- and a capture that had a bare
+     * pointer would be reading a plugin that had gone. So the lifetime comes
+     * back with the answer, and the operation holds it until it is finished.
+     *
+     * Which means a runtime owns its external devices by shared_ptr. That is
+     * the cost of this, and it is the smaller half of the bill: the alternative
+     * is every control operation reasoning about what else might be removing a
+     * device while it works.
+     *
+     * Empty for a key nothing is bound to, which includes one whose plugin has
+     * not finished loading. Called on the control executor.
      */
-    virtual EngineExternalDevice* find(magda::engine::DeviceKey key) const = 0;
+    virtual std::shared_ptr<EngineExternalDevice> find(magda::engine::DeviceKey key) const = 0;
 };
 
 /**

--- a/magda/daw/audio/plugins/engine/DeviceControl.hpp
+++ b/magda/daw/audio/plugins/engine/DeviceControl.hpp
@@ -149,16 +149,29 @@ class DeviceControlPlane {
     /**
      * @brief Ask the device at @p key what its plugin holds.
      *
-     * Asked from any thread. The work runs on the executor and @p completed is
-     * called there, exactly once, with a snapshot or with a reason there is
-     * none -- so a caller writing a project's model in that callback is on the
-     * thread it is entitled to write one from, whichever thread asked and
-     * whichever process answered.
+     * Asked from any thread, answered on the executor, always later than this
+     * returns. A caller writing a project's model in that callback is therefore
+     * on the thread it is entitled to write one from, whichever thread asked
+     * and whichever process answered.
      *
-     * It may be called before this returns, which is what a caller already on
-     * the executor gets: the plugin is right here and there is nothing to wait
-     * for. A caller that assumed otherwise would be assuming something only
-     * that case happens to make true.
+     * @p completed is called exactly once. Three things can happen to it:
+     *
+     * - the capture ran, and it carries a snapshot or a reason there is none;
+     * - the plane's executor went away before its turn, and it carries that as
+     *   a failure, on whichever thread destroyed the executor;
+     * - the executor would not take the work at all, which is a plane already
+     *   shutting down, and the failure is delivered on the calling thread
+     *   because there is no longer an executor to deliver it on.
+     *
+     * The last is the only answer that does not arrive on the executor, and it
+     * is the one case where there is none to arrive on. It is stated rather
+     * than left to be discovered, because a caller that writes a model in this
+     * callback has to know the one occasion it is not being handed the thread
+     * for it.
+     *
+     * The callback outlives the call. Whatever it captures must still be there
+     * when it runs, or must be held weakly and checked -- the plane keeps its
+     * own end of that with @p lifeline and cannot keep the caller's.
      */
     virtual void captureState(magda::engine::DeviceKey key, CaptureCallback completed) = 0;
 
@@ -194,11 +207,31 @@ class LocalDeviceControlPlane final : public DeviceControlPlane {
     /// answers from the same thread its runtime is edited from.
     using DeviceLookup = std::function<EngineExternalDevice*(magda::engine::DeviceKey)>;
 
-    LocalDeviceControlPlane(std::shared_ptr<ControlExecutor> executor, DeviceLookup devices);
+    /**
+     * @brief The plane for plugins in this process.
+     *
+     * @p lifeline is what the lookup belongs to: the runtime that owns the
+     * devices, held weakly. Work is queued and runs later, so between the two
+     * the project can be closed -- and a lookup is a function over a runtime,
+     * so calling one whose runtime has gone is reaching into a deleted object
+     * rather than being told there is no device.
+     *
+     * Locked on the executor for the length of the operation, which is more
+     * than a check: it is what stops the runtime being destroyed halfway
+     * through a capture rather than only before one. An expired lifeline is a
+     * failure with a reason, and the lookup is never called.
+     *
+     * The same shape the load path uses for the same problem, where an
+     * assignment is held weakly and a completion that finds it gone is refused
+     * (PluginAssignments.hpp).
+     */
+    LocalDeviceControlPlane(std::shared_ptr<ControlExecutor> executor, std::weak_ptr<void> lifeline,
+                            DeviceLookup devices);
 
     void captureState(magda::engine::DeviceKey key, CaptureCallback completed) override;
 
   private:
+    std::weak_ptr<void> lifeline_;
     DeviceLookup devices_;
 };
 

--- a/magda/daw/audio/plugins/engine/DeviceControl.hpp
+++ b/magda/daw/audio/plugins/engine/DeviceControl.hpp
@@ -3,8 +3,10 @@
 #include <juce_core/juce_core.h>
 
 #include <functional>
+#include <memory>
 #include <optional>
 
+#include "ControlExecutor.hpp"
 #include "PluginAssignments.hpp"
 #include "plan/RenderPlan.hpp"
 #include "plugin_manager/ExternalPluginState.hpp"
@@ -39,9 +41,22 @@
  * Keyed by magda::engine::DeviceKey, which is the identity the plan and the
  * assignment table already use, rather than by a reference to a live object.
  * Asynchronous and fallible, because a remote implementation has IPC, a
- * timeout, and a device that can go away mid-call; a local one answers
- * immediately and still answers through the callback, so a caller written
- * against this works either way.
+ * timeout, and a device that can go away mid-call.
+ *
+ * ## Where it all runs
+ *
+ * On the plane's ControlExecutor, which is the part that has to be explicit
+ * rather than assumed (ControlExecutor.hpp). Every operation runs there and
+ * every answer is delivered there: a caller may ask from any thread, and what
+ * it gets back arrives on the one thread the control side of a device is
+ * allowed to be on.
+ *
+ * That is what serialises these. Reading a plugin's state suspends it and
+ * resumes it afterwards, so two operations overlapping would have the first to
+ * finish resuming a plugin the second is still inside -- and neither the
+ * endpoint nor the device can prevent it by checking a thread, because a
+ * headless host has whatever threads it has. One executor answers it for every
+ * operation at once, including the ones that are not written yet.
  *
  * Nothing here reaches a model. A capture comes back as data, the caller checks
  * that the assignment it was read from still holds, and only then is it written
@@ -116,33 +131,45 @@ class CaptureOutcome {
  */
 class DeviceControlPlane {
   public:
+    /// @p executor is where this plane's work runs and its answers arrive. Held
+    /// by shared_ptr because a remote implementation's reply comes back long
+    /// after the call that sent it.
+    explicit DeviceControlPlane(std::shared_ptr<ControlExecutor> executor);
+
     virtual ~DeviceControlPlane() = default;
 
-    /// What a capture is answered with, on the message thread.
+    DeviceControlPlane(const DeviceControlPlane&) = delete;
+    DeviceControlPlane& operator=(const DeviceControlPlane&) = delete;
+    DeviceControlPlane(DeviceControlPlane&&) = delete;
+    DeviceControlPlane& operator=(DeviceControlPlane&&) = delete;
+
+    /// What a capture is answered with, on this plane's executor.
     using CaptureCallback = std::function<void(CaptureOutcome)>;
 
     /**
      * @brief Ask the device at @p key what its plugin holds.
      *
-     * Asked on the message thread, and that is a precondition rather than a
-     * convenience: a plugin's state is read with the plugin suspended, on the
-     * thread the host is allowed to talk to it from, and a save dispatched from
-     * a worker would be reaching into somebody else's code from the wrong one.
-     * An implementation is required to refuse rather than to marshal, so that
-     * a caller on the wrong thread is a finding here and not a rare crash in a
-     * plugin later.
+     * Asked from any thread. The work runs on the executor and @p completed is
+     * called there, exactly once, with a snapshot or with a reason there is
+     * none -- so a caller writing a project's model in that callback is on the
+     * thread it is entitled to write one from, whichever thread asked and
+     * whichever process answered.
      *
-     * A host with no message thread at all -- an offline render, a test binary,
-     * anything headless -- has nothing to be off, and is not refused. What is
-     * refused is a caller that had one and was not on it.
-     *
-     * @p completed is called exactly once, on the message thread, with a
-     * snapshot or with a reason there is none. It may be called before this
-     * returns -- a local plane has the plugin right here -- and a caller that
-     * assumed otherwise would be assuming something only the local case
-     * happens to make true.
+     * It may be called before this returns, which is what a caller already on
+     * the executor gets: the plugin is right here and there is nothing to wait
+     * for. A caller that assumed otherwise would be assuming something only
+     * that case happens to make true.
      */
     virtual void captureState(magda::engine::DeviceKey key, CaptureCallback completed) = 0;
+
+    /// Where this plane's work runs, for a host that has something else to put
+    /// on the same thread.
+    const std::shared_ptr<ControlExecutor>& executor() const {
+        return executor_;
+    }
+
+  private:
+    std::shared_ptr<ControlExecutor> executor_;
 };
 
 /**
@@ -162,9 +189,12 @@ class LocalDeviceControlPlane final : public DeviceControlPlane {
   public:
     /// The device at a key, or null. Null for a key nothing is bound to, which
     /// includes one whose plugin has not finished loading.
+    ///
+    /// Called on the executor, like everything else here, so a host writing one
+    /// answers from the same thread its runtime is edited from.
     using DeviceLookup = std::function<EngineExternalDevice*(magda::engine::DeviceKey)>;
 
-    explicit LocalDeviceControlPlane(DeviceLookup devices);
+    LocalDeviceControlPlane(std::shared_ptr<ControlExecutor> executor, DeviceLookup devices);
 
     void captureState(magda::engine::DeviceKey key, CaptureCallback completed) override;
 

--- a/magda/daw/audio/plugins/engine/DeviceControl.hpp
+++ b/magda/daw/audio/plugins/engine/DeviceControl.hpp
@@ -63,21 +63,47 @@ namespace magda::daw::audio::engine_adapter {
 class EngineExternalDevice;
 
 /**
- * @brief What a capture came back with.
+ * @brief What a capture came back with: a snapshot, or a reason there is none.
  *
- * One of the two, never both and never neither: a snapshot the caller may write
- * down, or a reason it has nothing to write. A failure is a string rather than
- * an enumeration because every one of them is something to tell a person and
- * nothing to branch on -- there is no device here, this plugin would not
- * describe itself, the answer did not come back in time.
+ * Exactly one of the two, and the type is what says so rather than a sentence
+ * in a comment. That matters most at the boundary this is being built for: an
+ * out-of-process implementation decodes one of these from bytes, and an
+ * aggregate that permitted both or neither would leave every decoder
+ * reconstructing an invariant nothing enforced -- with the both-present case
+ * reading as success and carrying a reason nobody would look at.
+ *
+ * A failure is a string rather than an enumeration because every one of them is
+ * something to tell a person and nothing to branch on: there is no device here,
+ * this plugin would not describe itself, the answer did not come back in time.
+ * A failure with nothing to say is refused the same way an empty snapshot is,
+ * and gets a generic reason instead of an empty one.
  */
-struct CaptureOutcome {
-    std::optional<magda::ExternalPluginSnapshot> snapshot;
-    juce::String failure;
+class CaptureOutcome {
+  public:
+    /// What the plugin held.
+    static CaptureOutcome taken(magda::ExternalPluginSnapshot snapshot);
+
+    /// Why it did not.
+    static CaptureOutcome failed(juce::String reason);
 
     bool ok() const {
-        return snapshot.has_value();
+        return snapshot_.has_value();
     }
+
+    /// The snapshot. Only when ok(); a caller that asks otherwise is asking for
+    /// state that was never read.
+    const magda::ExternalPluginSnapshot& snapshot() const;
+
+    /// Why there is none. Empty when ok().
+    const juce::String& failure() const {
+        return failure_;
+    }
+
+  private:
+    CaptureOutcome() = default;
+
+    std::optional<magda::ExternalPluginSnapshot> snapshot_;
+    juce::String failure_;
 };
 
 /**
@@ -97,6 +123,18 @@ class DeviceControlPlane {
 
     /**
      * @brief Ask the device at @p key what its plugin holds.
+     *
+     * Asked on the message thread, and that is a precondition rather than a
+     * convenience: a plugin's state is read with the plugin suspended, on the
+     * thread the host is allowed to talk to it from, and a save dispatched from
+     * a worker would be reaching into somebody else's code from the wrong one.
+     * An implementation is required to refuse rather than to marshal, so that
+     * a caller on the wrong thread is a finding here and not a rare crash in a
+     * plugin later.
+     *
+     * A host with no message thread at all -- an offline render, a test binary,
+     * anything headless -- has nothing to be off, and is not refused. What is
+     * refused is a caller that had one and was not on it.
      *
      * @p completed is called exactly once, on the message thread, with a
      * snapshot or with a reason there is none. It may be called before this
@@ -135,8 +173,20 @@ class LocalDeviceControlPlane final : public DeviceControlPlane {
 };
 
 /**
- * @brief Write @p snapshot into @p device, if it is still the device it was
- *        read from.
+ * @brief The device a key names now, to write onto.
+ *
+ * The same question CurrentDeviceLookup asks on the load path, asked for
+ * writing rather than for reading, and asked at the same moment: at completion
+ * rather than when the operation started. A model captured when the capture was
+ * requested would be a model whatever happened since has already left behind.
+ *
+ * Null for a key whose device is gone, which is a commit that does not happen.
+ */
+using MutableDeviceLookup = std::function<magda::DeviceInfo*(magda::engine::DeviceKey)>;
+
+/**
+ * @brief Write @p snapshot onto the device @p request was made for, if that is
+ *        still the device it was read from.
  *
  * The commit half, and the reason a capture is two steps with only data
  * between them. A snapshot is read from a plugin at one moment and written into
@@ -144,6 +194,13 @@ class LocalDeviceControlPlane final : public DeviceControlPlane {
  * plugin, or emptied, or the whole runtime can have gone: writing it down then
  * would put one plugin's patch onto another's device, which is the failure the
  * assignment table exists to make impossible.
+ *
+ * The device is resolved here, from @p request's own key through @p device,
+ * rather than passed in beside the token. A caller that handed over both would
+ * be free to hand over a model the token says nothing about -- the check would
+ * pass, the write would land somewhere else, and the boundary would be a
+ * gesture. Validating one thing and writing another is the failure this exists
+ * to prevent, so only one of them is the caller's to choose.
  *
  * @p request is what PluginAssignments::request() returned for the key when the
  * capture was asked for. Checked rather than trusted, and checked here rather
@@ -153,6 +210,7 @@ class LocalDeviceControlPlane final : public DeviceControlPlane {
  * @return whether anything was written.
  */
 bool commitCapturedState(const AssignmentRequest& request,
-                         const magda::ExternalPluginSnapshot& snapshot, magda::DeviceInfo& device);
+                         const magda::ExternalPluginSnapshot& snapshot,
+                         const MutableDeviceLookup& device);
 
 }  // namespace magda::daw::audio::engine_adapter

--- a/magda/daw/audio/plugins/engine/DeviceControl.hpp
+++ b/magda/daw/audio/plugins/engine/DeviceControl.hpp
@@ -152,28 +152,27 @@ class DeviceControlPlane {
      * Asked from any thread, answered on the executor, always later than this
      * returns. A caller writing a project's model in that callback is therefore
      * on the thread it is entitled to write one from, whichever thread asked
-     * and whichever process answered.
+     * and whichever process answered -- and it is never handed that callback
+     * anywhere else, which is what keeps an isCurrent() check and a hop of its
+     * own out of every consumer.
      *
-     * @p completed is called exactly once. Three things can happen to it:
+     * @return whether the request was accepted. False is a plane that is
+     *         closing: nothing will run and @p completed will not be called, so
+     *         the caller still owes whatever it owed and has been told so here,
+     *         synchronously, rather than by a callback arriving from a thread
+     *         it was not expecting one on.
      *
-     * - the capture ran, and it carries a snapshot or a reason there is none;
-     * - the plane's executor went away before its turn, and it carries that as
-     *   a failure, on whichever thread destroyed the executor;
-     * - the executor would not take the work at all, which is a plane already
-     *   shutting down, and the failure is delivered on the calling thread
-     *   because there is no longer an executor to deliver it on.
-     *
-     * The last is the only answer that does not arrive on the executor, and it
-     * is the one case where there is none to arrive on. It is stated rather
-     * than left to be discovered, because a caller that writes a model in this
-     * callback has to know the one occasion it is not being handed the thread
-     * for it.
+     * An accepted request calls @p completed exactly once, on the executor,
+     * either with what the capture found or with a failure saying the plane
+     * closed before its turn came. The one thing that can take an accepted
+     * request away without a word is the host's message loop being torn down
+     * under it, which is process teardown (ControlExecutor.hpp).
      *
      * The callback outlives the call. Whatever it captures must still be there
      * when it runs, or must be held weakly and checked -- the plane keeps its
-     * own end of that with @p lifeline and cannot keep the caller's.
+     * own end of that with the registry below and cannot keep the caller's.
      */
-    virtual void captureState(magda::engine::DeviceKey key, CaptureCallback completed) = 0;
+    virtual bool captureState(magda::engine::DeviceKey key, CaptureCallback completed) = 0;
 
     /// Where this plane's work runs, for a host that has something else to put
     /// on the same thread.
@@ -186,53 +185,71 @@ class DeviceControlPlane {
 };
 
 /**
+ * @brief A registry that finds nothing is a failure, not an empty snapshot.
+ *
+ * Worth saying where the two meet: a slot with no plugin in it and a plugin
+ * that would not describe itself are different findings, and a caller told the
+ * second when the first happened would write a project's plugin state away as
+ * absent.
+ */
+
+/**
+ * @brief The devices a plane can reach, owned by whoever runs them (#2270).
+ *
+ * A plane's work runs later than the call that queued it, so between the two a
+ * project can be closed. What it needs at that moment is not a token beside a
+ * lookup -- keeping one alive says nothing about what the other captured -- but
+ * the thing that owns the devices, held weakly and locked before it is asked.
+ *
+ * So the lookup is a type rather than a function, and the plane holds a weak
+ * reference to it. Locking it is what keeps the devices alive for the length of
+ * the operation, and failing to lock it is the answer that there is nothing
+ * left to ask. The relationship is the type's rather than a caller's to
+ * maintain: there is no way to hand over a lease that has nothing to do with
+ * the devices it is supposed to be keeping.
+ *
+ * The same shape the load path already has for the same problem, where an
+ * assignment is held weakly and a completion that finds it gone is refused
+ * (PluginAssignments.hpp).
+ */
+class DeviceRegistry {
+  public:
+    virtual ~DeviceRegistry() = default;
+
+    DeviceRegistry() = default;
+    DeviceRegistry(const DeviceRegistry&) = delete;
+    DeviceRegistry& operator=(const DeviceRegistry&) = delete;
+    DeviceRegistry(DeviceRegistry&&) = delete;
+    DeviceRegistry& operator=(DeviceRegistry&&) = delete;
+
+    /**
+     * @brief The device at @p key, or null.
+     *
+     * Null for a key nothing is bound to, which includes one whose plugin has
+     * not finished loading. Called on the control executor, with the registry
+     * held alive for the length of the operation, so what it returns is safe to
+     * use until that operation ends.
+     */
+    virtual EngineExternalDevice* find(magda::engine::DeviceKey key) const = 0;
+};
+
+/**
  * @brief The plane for plugins running in this process.
  *
- * It owns nothing. Which device is at a key is the runtime's business, so the
- * lookup is handed in: the same arrangement the load path already has with
- * CurrentDeviceLookup, and what keeps this from becoming a second registry
- * disagreeing with the first.
- *
- * A lookup that returns nothing is a failure rather than an empty snapshot. The
- * two are different findings -- a slot with no plugin in it, against a plugin
- * that would not describe itself -- and a caller told the second when the first
- * happened would write a project's plugin state away as absent.
+ * It owns nothing: which device is at a key is the runtime's business, and the
+ * runtime's registry is held weakly so that a project closing between a request
+ * and its turn is a failure with a reason rather than a dereference of
+ * something that has gone.
  */
 class LocalDeviceControlPlane final : public DeviceControlPlane {
   public:
-    /// The device at a key, or null. Null for a key nothing is bound to, which
-    /// includes one whose plugin has not finished loading.
-    ///
-    /// Called on the executor, like everything else here, so a host writing one
-    /// answers from the same thread its runtime is edited from.
-    using DeviceLookup = std::function<EngineExternalDevice*(magda::engine::DeviceKey)>;
+    LocalDeviceControlPlane(std::shared_ptr<ControlExecutor> executor,
+                            std::weak_ptr<const DeviceRegistry> devices);
 
-    /**
-     * @brief The plane for plugins in this process.
-     *
-     * @p lifeline is what the lookup belongs to: the runtime that owns the
-     * devices, held weakly. Work is queued and runs later, so between the two
-     * the project can be closed -- and a lookup is a function over a runtime,
-     * so calling one whose runtime has gone is reaching into a deleted object
-     * rather than being told there is no device.
-     *
-     * Locked on the executor for the length of the operation, which is more
-     * than a check: it is what stops the runtime being destroyed halfway
-     * through a capture rather than only before one. An expired lifeline is a
-     * failure with a reason, and the lookup is never called.
-     *
-     * The same shape the load path uses for the same problem, where an
-     * assignment is held weakly and a completion that finds it gone is refused
-     * (PluginAssignments.hpp).
-     */
-    LocalDeviceControlPlane(std::shared_ptr<ControlExecutor> executor, std::weak_ptr<void> lifeline,
-                            DeviceLookup devices);
-
-    void captureState(magda::engine::DeviceKey key, CaptureCallback completed) override;
+    bool captureState(magda::engine::DeviceKey key, CaptureCallback completed) override;
 
   private:
-    std::weak_ptr<void> lifeline_;
-    DeviceLookup devices_;
+    std::weak_ptr<const DeviceRegistry> devices_;
 };
 
 /**

--- a/magda/daw/audio/plugins/engine/DeviceControl.hpp
+++ b/magda/daw/audio/plugins/engine/DeviceControl.hpp
@@ -1,0 +1,158 @@
+#pragma once
+
+#include <juce_core/juce_core.h>
+
+#include <functional>
+#include <optional>
+
+#include "PluginAssignments.hpp"
+#include "plan/RenderPlan.hpp"
+#include "plugin_manager/ExternalPluginState.hpp"
+
+/**
+ * @file DeviceControl.hpp
+ * @brief Everything that is not rendering, addressed the way rendering is
+ *        (#2270).
+ *
+ * #1893 asks for one thing beyond parity: the device op contract is
+ * location-transparent from day one, so that running a plugin in another
+ * process later is an add-on rather than a rework. The realtime half already
+ * honours it -- magda::engine::EngineDevice says nothing about where a device
+ * lives, and EngineExternalDevice is one implementation of it -- and the
+ * control half did not. Editor windows and state captures reached the plugin by
+ * asking the adapter for its juce::AudioPluginInstance, which is the one thing
+ * a plugin in another process cannot hand over.
+ *
+ * ## Why it is an endpoint rather than an accessor
+ *
+ * A pointer to an instance is not only unavailable across a process boundary;
+ * it is also how the serialisation rule lost its owner. Reading a plugin's
+ * state and rendering through it must not overlap, and that rule needs one
+ * object that can enforce it. Two races in the #2268 review were the same shape
+ * twice: an operation reached the plugin from the control side while the audio
+ * side was reaching it too, and neither side owned the rule. Behind an endpoint
+ * the question does not arise -- the object that owns the instance is the only
+ * thing that can touch it, from either side.
+ *
+ * ## The shape
+ *
+ * Keyed by magda::engine::DeviceKey, which is the identity the plan and the
+ * assignment table already use, rather than by a reference to a live object.
+ * Asynchronous and fallible, because a remote implementation has IPC, a
+ * timeout, and a device that can go away mid-call; a local one answers
+ * immediately and still answers through the callback, so a caller written
+ * against this works either way.
+ *
+ * Nothing here reaches a model. A capture comes back as data, the caller checks
+ * that the assignment it was read from still holds, and only then is it written
+ * down -- the same boundary completeExternalPluginLoad() applies to the other
+ * direction, and for the same reason: between asking and answering, a slot can
+ * have been given a different plugin, or none.
+ *
+ * ## What is not here yet
+ *
+ * The editor window. It is the other caller that reaches for an instance, and
+ * it does not exist on this path yet: MAGDA's plugin windows are still the
+ * fork's. It belongs here when it arrives -- an editor is a control-plane
+ * request like any other -- and this file is where it goes rather than a second
+ * accessor next to it.
+ */
+
+namespace magda::daw::audio::engine_adapter {
+
+class EngineExternalDevice;
+
+/**
+ * @brief What a capture came back with.
+ *
+ * One of the two, never both and never neither: a snapshot the caller may write
+ * down, or a reason it has nothing to write. A failure is a string rather than
+ * an enumeration because every one of them is something to tell a person and
+ * nothing to branch on -- there is no device here, this plugin would not
+ * describe itself, the answer did not come back in time.
+ */
+struct CaptureOutcome {
+    std::optional<magda::ExternalPluginSnapshot> snapshot;
+    juce::String failure;
+
+    bool ok() const {
+        return snapshot.has_value();
+    }
+};
+
+/**
+ * @brief Where a host asks a device for anything that is not a block.
+ *
+ * One implementation runs the plugin in this process and answers out of its own
+ * table; another asks a process that is not this one. Which of them a host
+ * holds is the whole of the difference between an in-process plugin and a
+ * sandboxed one, and nothing above this has to know which it is (#1899).
+ */
+class DeviceControlPlane {
+  public:
+    virtual ~DeviceControlPlane() = default;
+
+    /// What a capture is answered with, on the message thread.
+    using CaptureCallback = std::function<void(CaptureOutcome)>;
+
+    /**
+     * @brief Ask the device at @p key what its plugin holds.
+     *
+     * @p completed is called exactly once, on the message thread, with a
+     * snapshot or with a reason there is none. It may be called before this
+     * returns -- a local plane has the plugin right here -- and a caller that
+     * assumed otherwise would be assuming something only the local case
+     * happens to make true.
+     */
+    virtual void captureState(magda::engine::DeviceKey key, CaptureCallback completed) = 0;
+};
+
+/**
+ * @brief The plane for plugins running in this process.
+ *
+ * It owns nothing. Which device is at a key is the runtime's business, so the
+ * lookup is handed in: the same arrangement the load path already has with
+ * CurrentDeviceLookup, and what keeps this from becoming a second registry
+ * disagreeing with the first.
+ *
+ * A lookup that returns nothing is a failure rather than an empty snapshot. The
+ * two are different findings -- a slot with no plugin in it, against a plugin
+ * that would not describe itself -- and a caller told the second when the first
+ * happened would write a project's plugin state away as absent.
+ */
+class LocalDeviceControlPlane final : public DeviceControlPlane {
+  public:
+    /// The device at a key, or null. Null for a key nothing is bound to, which
+    /// includes one whose plugin has not finished loading.
+    using DeviceLookup = std::function<EngineExternalDevice*(magda::engine::DeviceKey)>;
+
+    explicit LocalDeviceControlPlane(DeviceLookup devices);
+
+    void captureState(magda::engine::DeviceKey key, CaptureCallback completed) override;
+
+  private:
+    DeviceLookup devices_;
+};
+
+/**
+ * @brief Write @p snapshot into @p device, if it is still the device it was
+ *        read from.
+ *
+ * The commit half, and the reason a capture is two steps with only data
+ * between them. A snapshot is read from a plugin at one moment and written into
+ * a project at another, and in between a slot can have been given a different
+ * plugin, or emptied, or the whole runtime can have gone: writing it down then
+ * would put one plugin's patch onto another's device, which is the failure the
+ * assignment table exists to make impossible.
+ *
+ * @p request is what PluginAssignments::request() returned for the key when the
+ * capture was asked for. Checked rather than trusted, and checked here rather
+ * than at each call site, so the rule has one owner in this direction as it
+ * does in the other (completeExternalPluginLoad).
+ *
+ * @return whether anything was written.
+ */
+bool commitCapturedState(const AssignmentRequest& request,
+                         const magda::ExternalPluginSnapshot& snapshot, magda::DeviceInfo& device);
+
+}  // namespace magda::daw::audio::engine_adapter

--- a/magda/daw/audio/plugins/engine/EngineDeviceFactory.hpp
+++ b/magda/daw/audio/plugins/engine/EngineDeviceFactory.hpp
@@ -240,7 +240,7 @@ using CurrentDeviceLookup = std::function<const magda::DeviceInfo*(magda::engine
  * PluginDescription is deliberately not retained.
  */
 struct RequestedPlugin {
-    LoadRequest assignment;
+    AssignmentRequest assignment;
     juce::String displayName;
     bool resolvedIsInstrument = false;
 };

--- a/magda/daw/audio/plugins/engine/EngineExternalDevice.cpp
+++ b/magda/daw/audio/plugins/engine/EngineExternalDevice.cpp
@@ -542,4 +542,14 @@ void EngineExternalDevice::process(magda::engine::DeviceBlock& block) {
         writeMidiOut(*block.midiOut, numSamples);
 }
 
+std::optional<magda::ExternalPluginSnapshot> EngineExternalDevice::captureState() {
+    // The read itself is engine-agnostic and stated once: what a plugin holds,
+    // in the encoding a project keeps it in, with the plugin suspended across
+    // the whole of it (ExternalPluginState.hpp). What this adds is the only
+    // thing that could not live there -- that nothing else can reach the
+    // instance to do it, so the suspension the read asks for is a suspension
+    // this device's own process() is already honouring.
+    return magda::captureExternalPluginState(*instance_);
+}
+
 }  // namespace magda::daw::audio::engine_adapter

--- a/magda/daw/audio/plugins/engine/EngineExternalDevice.hpp
+++ b/magda/daw/audio/plugins/engine/EngineExternalDevice.hpp
@@ -148,9 +148,22 @@ class EngineExternalDevice final : public magda::engine::EngineDevice {
      * promise the two are serialised. A caller handed the instance instead
      * would be holding half of a rule and no way to keep it.
      *
-     * Message thread. Nullopt when the plugin threw describing itself, which is
-     * a plugin whose records would not agree with each other
-     * (ExternalPluginState.hpp).
+     * Nullopt when the plugin threw describing itself, which is a plugin whose
+     * records would not agree with each other (ExternalPluginState.hpp).
+     *
+     * Called on the control executor, which is where every control operation on
+     * a device runs and what serialises them against each other
+     * (ControlExecutor.hpp). It matters here more than it looks: the read
+     * suspends the plugin and resumes it afterwards, so two overlapping readers
+     * would have the first to finish resuming the plugin underneath the second
+     * and letting a block back in mid-capture. This device does not check --
+     * a lock here would be a second answer to a question the executor already
+     * answers for the editor and the preset load as well.
+     *
+     * The audio thread is not party to any of it. process() is gated by the
+     * plugin's own callback lock and its suspended flag, which it tries rather
+     * than waits on, so a capture in flight costs a block its passthrough and
+     * never the deadline.
      *
      * It reads and does not write. What to do with a snapshot -- and whether
      * the device it was read from is still the device the model means -- is the

--- a/magda/daw/audio/plugins/engine/EngineExternalDevice.hpp
+++ b/magda/daw/audio/plugins/engine/EngineExternalDevice.hpp
@@ -9,6 +9,7 @@
 #include "core/DeviceInfo.hpp"
 #include "core/ParameterInfo.hpp"
 #include "exec/EngineDevice.hpp"
+#include "plugin_manager/ExternalPluginState.hpp"
 
 /**
  * @file EngineExternalDevice.hpp
@@ -136,11 +137,26 @@ class EngineExternalDevice final : public magda::engine::EngineDevice {
     /// render never takes one.
     void process(magda::engine::DeviceBlock& block) override;
 
-    /// The instance this stands for. For a host that has to reach past the
-    /// adapter -- an editor window, a state save -- never for rendering.
-    juce::AudioPluginInstance& instance() const {
-        return *instance_;
-    }
+    /**
+     * @brief What the plugin holds now: chunk, parameter values, VST3 records.
+     *
+     * The control half of this device, and the reason it is here rather than
+     * anywhere with a pointer to the instance (#2270). Reading a plugin and
+     * rendering through it are two things that must not overlap, and the rule
+     * saying so has to have one owner: this object holds the instance, honours
+     * the suspension in process(), and is therefore the only thing that can
+     * promise the two are serialised. A caller handed the instance instead
+     * would be holding half of a rule and no way to keep it.
+     *
+     * Message thread. Nullopt when the plugin threw describing itself, which is
+     * a plugin whose records would not agree with each other
+     * (ExternalPluginState.hpp).
+     *
+     * It reads and does not write. What to do with a snapshot -- and whether
+     * the device it was read from is still the device the model means -- is the
+     * caller's, over in the control plane (DeviceControl.hpp).
+     */
+    std::optional<magda::ExternalPluginSnapshot> captureState();
 
   private:
     class PlayHead;

--- a/magda/daw/audio/plugins/engine/PluginAssignments.cpp
+++ b/magda/daw/audio/plugins/engine/PluginAssignments.cpp
@@ -10,7 +10,7 @@ std::shared_ptr<const AssignmentHandle> AssignmentTable::find(magda::engine::Dev
     return it != byKey_.end() ? it->second : nullptr;
 }
 
-bool LoadRequest::isStillWanted() const {
+bool AssignmentRequest::isStillWanted() const {
     const auto live = table.lock();
     if (live == nullptr)
         return false;
@@ -25,7 +25,7 @@ bool LoadRequest::isStillWanted() const {
     return live->find(key) == held;
 }
 
-bool LoadRequest::keyWasReassigned() const {
+bool AssignmentRequest::keyWasReassigned() const {
     const auto live = table.lock();
     if (live == nullptr)
         return false;
@@ -34,7 +34,7 @@ bool LoadRequest::keyWasReassigned() const {
     return now != nullptr && now != handle.lock();
 }
 
-bool LoadRequest::runtimeIsAlive() const {
+bool AssignmentRequest::runtimeIsAlive() const {
     return !table.expired();
 }
 
@@ -62,7 +62,7 @@ ActiveAssignment PluginAssignments::current(magda::engine::DeviceKey key) const 
     return {.key = key, .handle = std::move(held)};
 }
 
-LoadRequest PluginAssignments::request(magda::engine::DeviceKey key) const {
+AssignmentRequest PluginAssignments::request(magda::engine::DeviceKey key) const {
     return {.key = key, .handle = table_->find(key), .table = table_};
 }
 

--- a/magda/daw/audio/plugins/engine/PluginAssignments.hpp
+++ b/magda/daw/audio/plugins/engine/PluginAssignments.hpp
@@ -85,20 +85,27 @@ struct ActiveAssignment {
 };
 
 /**
- * @brief What an asynchronous load remembers about who it is loading for.
+ * @brief What an asynchronous operation remembers about the device it is for.
  *
- * Weak at both ends, and for the same reason. A load must not keep an
+ * Both directions carry one. A load is answered by a plugin arriving and asks
+ * whether the slot that wanted it still does; a state capture is answered by a
+ * snapshot arriving and asks the same thing before writing it into a project
+ * (DeviceControl.hpp). It is the same question either way -- is this still the
+ * assignment the operation was started against -- so it is one type, and the
+ * check is one function rather than a convention each caller reimplements.
+ *
+ * Weak at both ends, and for the same reason. An operation must not keep an
  * assignment alive, because an assignment outliving its device is exactly the
- * state in which a stale load would be accepted; and it must not keep the table
- * alive either, because the runtime that owns it may be gone by the time the
- * plugin arrives. Either reference expiring is the answer "no longer wanted",
- * and an unregistered device hands out an already-expired handle, so forgetting
- * to register fails closed.
+ * state in which a stale answer would be accepted; and it must not keep the
+ * table alive either, because the runtime that owns it may be gone by the time
+ * the answer arrives. Either reference expiring is the answer "no longer
+ * wanted", and an unregistered device hands out an already-expired handle, so
+ * forgetting to register fails closed.
  *
  * Self-contained on purpose: completion needs nothing but this to decide, so
  * nothing about the runtime has to be captured by an asynchronous callback.
  */
-struct LoadRequest {
+struct AssignmentRequest {
     magda::engine::DeviceKey key;
     std::weak_ptr<const AssignmentHandle> handle;
     std::weak_ptr<const AssignmentTable> table;
@@ -186,7 +193,7 @@ class PluginAssignments {
      * An unregistered key yields an already-expired request, so a load started
      * without one is refused at completion.
      */
-    LoadRequest request(magda::engine::DeviceKey key) const;
+    AssignmentRequest request(magda::engine::DeviceKey key) const;
 
     /** The device is gone, or its plugin is being replaced by nothing. */
     void release(magda::engine::DeviceKey key);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -422,6 +422,7 @@ if(MAGDA_BUILD_NATIVE_ENGINE)
     # Who an asynchronous plugin load belongs to (#2261): the runtime-owned
     # assignment the adapter above checks before it completes one.
     list(APPEND TEST_SOURCES engine/test_plugin_assignments.cpp)
+    list(APPEND TEST_SOURCES engine/test_control_executor.cpp)
 
     # The block-size invariance gate (#2078). Model-only for the same reason the
     # native leg is: the claim is the native engine's alone, and the incumbent

--- a/tests/engine/test_control_executor.cpp
+++ b/tests/engine/test_control_executor.cpp
@@ -136,39 +136,33 @@ TEST_CASE("Work that never ran is cancelled rather than dropped", "[engine][cont
     // The promise a caller above this makes is exactly one answer, and an
     // executor that let queued work go would leave that promise unkept by
     // whoever made it: a capture waiting for a snapshot nobody is left to send.
-    // So accepted work is always called, and told which of the two it is.
-    std::promise<void> holdingOn;
-    std::shared_future<void> release = holdingOn.get_future();
-    std::promise<void> started;
-    auto running = started.get_future();
+    // So accepted work is always called, on this executor, and told which of the
+    // two it is.
+    //
+    // Destroyed from inside its own work, which is the one ordering a test can
+    // pin without a sleep in it: the destructor runs while the worker is here,
+    // so the item queued below is still queued when it does, and the drain that
+    // follows is on this thread rather than a race with it.
+    auto executor = std::make_shared<adapter::SerialControlThread>();
 
     std::promise<ExecutionState> abandoned;
     auto answered = abandoned.get_future();
 
-    auto executor = std::make_unique<adapter::SerialControlThread>();
+    REQUIRE(executor->run([executor, &abandoned](ExecutionState) mutable {
+        // Queued while the executor is still taking work, and never reached:
+        // what follows stops it.
+        CHECK(executor->run([&abandoned](ExecutionState state) { abandoned.set_value(state); }));
 
-    // Holds the worker, so what follows is still queued when the executor is
-    // destroyed.
-    REQUIRE(executor->run([&started, release](ExecutionState) {
-        started.set_value();
-        release.wait();
+        // The last reference, dropped here. The destructor runs on this thread,
+        // marks the executor stopping, and leaves the worker to answer what is
+        // left once this returns.
+        executor.reset();
     }));
 
-    running.wait();
-
-    REQUIRE(executor->run([&abandoned](ExecutionState state) { abandoned.set_value(state); }));
-
-    // Destroyed from another thread, because the destructor waits for a worker
-    // this test is deliberately holding. Nothing here is a race: the destructor
-    // answers the queue before it starts waiting, so the cancellation below
-    // arrives while the first piece of work is still standing still.
-    std::thread destroyer([&executor] { executor.reset(); });
+    executor.reset();
 
     REQUIRE(answered.wait_for(std::chrono::seconds(2)) == std::future_status::ready);
     CHECK(answered.get() == ExecutionState::Cancelled);
-
-    holdingOn.set_value();
-    destroyer.join();
 }
 
 TEST_CASE("An executor destroyed by its own work does not wait for itself", "[engine][control]") {

--- a/tests/engine/test_control_executor.cpp
+++ b/tests/engine/test_control_executor.cpp
@@ -1,5 +1,7 @@
 #include <atomic>
 #include <catch2/catch_test_macros.hpp>
+#include <chrono>
+#include <future>
 #include <memory>
 #include <thread>
 #include <vector>
@@ -25,49 +27,51 @@
 
 namespace adapter = magda::daw::audio::engine_adapter;
 
+using adapter::ExecutionState;
+
 TEST_CASE("A serial executor runs its work on one thread, in order", "[engine][control]") {
     adapter::SerialControlThread executor;
 
     std::vector<int> order;
     std::vector<std::thread::id> threads;
-    std::atomic<int> done{0};
 
     // Queued from several threads at once, which is the case a headless host
     // presents: nothing about who asks says anything about who runs it.
     std::vector<std::thread> askers;
     for (int index = 0; index < 4; ++index)
-        askers.emplace_back([&executor, &order, &threads, &done, index] {
+        askers.emplace_back([&executor, &order, &threads, index] {
             for (int item = 0; item < 8; ++item)
-                executor.run([&order, &threads, &done, index] {
+                CHECK(executor.run([&order, &threads, index](ExecutionState state) {
+                    if (state != ExecutionState::Ran)
+                        return;
+
                     // No lock: the claim is that this only ever runs on one
                     // thread, so a second one writing here would be the finding
                     // rather than a reason to synchronise.
                     order.push_back(index);
                     threads.push_back(std::this_thread::get_id());
-                    ++done;
-                });
+                }));
         });
 
     for (auto& asker : askers)
         asker.join();
 
-    // Drained by asking for one more thing and waiting for it: work is run in
-    // the order it was accepted, so anything queued before this has run by the
-    // time this has.
-    std::atomic<bool> drained{false};
-    executor.run([&drained] { drained = true; });
-    while (!drained)
-        std::this_thread::yield();
+    // Drained by asking for one more thing and waiting for it: work runs in the
+    // order it was accepted, so anything queued before this has run by the time
+    // this has.
+    std::promise<void> drained;
+    auto emptied = drained.get_future();
+    REQUIRE(executor.run([&drained](ExecutionState) { drained.set_value(); }));
+    emptied.wait();
 
-    CHECK(done == 32);
     REQUIRE(order.size() == 32);
     REQUIRE(threads.size() == 32);
 
     for (const auto& thread : threads)
         CHECK(thread == threads.front());
 
-    // Each asker's own items kept their order, which is what "serial" is worth:
-    // interleaving between askers is fine and reordering within one is not.
+    // Each asker's own items all arrived. Interleaving between askers is fine
+    // and losing one is not.
     for (int index = 0; index < 4; ++index) {
         auto seen = 0;
         for (const auto item : order)
@@ -78,50 +82,117 @@ TEST_CASE("A serial executor runs its work on one thread, in order", "[engine][c
     }
 }
 
-TEST_CASE("Work asked for from the executor runs before the ask returns", "[engine][control]") {
-    // What keeps one control operation asking for another from waiting on a
-    // thread it is standing on. A capture that loaded a preset, or an editor
-    // that saved state on the way down, would otherwise queue behind itself and
-    // never be reached.
+TEST_CASE("Work asked for from the executor is queued behind what asked for it",
+          "[engine][control]") {
+    // The half that makes "one at a time" mean anything. An operation that has
+    // suspended a plugin and asks for another must not have the second run
+    // inside it: that second one would resume the plugin and let audio back in
+    // halfway through the first, which is the failure this executor exists to
+    // remove rather than to relocate.
     adapter::SerialControlThread executor;
 
     std::atomic<bool> nested{false};
-    std::atomic<bool> nestedRanFirst{false};
-    std::atomic<bool> finished{false};
+    std::atomic<bool> nestedRanInside{false};
+    std::promise<void> outerDone;
+    auto outerFinished = outerDone.get_future();
 
-    executor.run([&executor, &nested, &nestedRanFirst, &finished] {
-        executor.run([&nested] { nested = true; });
+    REQUIRE(executor.run([&](ExecutionState) {
+        CHECK(executor.run([&nested](ExecutionState) { nested = true; }));
 
-        // Read immediately after the inner ask returned: if it had been queued
-        // rather than run, nothing would have happened yet.
-        nestedRanFirst = nested.load();
-        finished = true;
-    });
+        // Read after the inner ask returned and before this one ends: nothing
+        // may have happened yet, because the queue is behind us.
+        nestedRanInside = nested.load();
+        outerDone.set_value();
+    }));
 
-    while (!finished)
-        std::this_thread::yield();
+    outerFinished.wait();
+    CHECK_FALSE(nestedRanInside);
 
+    std::promise<void> after;
+    auto arrived = after.get_future();
+    REQUIRE(executor.run([&after](ExecutionState) { after.set_value(); }));
+    arrived.wait();
+
+    // And it did run, in its turn, which is the other half: queued is not
+    // dropped.
     CHECK(nested);
-    CHECK(nestedRanFirst);
 }
 
 TEST_CASE("An executor knows whether this is its own thread", "[engine][control]") {
-    // What lets an implementation tell "run it now" from "queue it", and what a
-    // caller checks when it wants to know where its answer arrived.
     adapter::SerialControlThread executor;
 
     CHECK_FALSE(executor.isCurrent());
 
-    std::atomic<bool> insideSaysYes{false};
-    std::atomic<bool> finished{false};
+    std::promise<bool> inside;
+    auto answered = inside.get_future();
 
-    executor.run([&executor, &insideSaysYes, &finished] {
-        insideSaysYes = executor.isCurrent();
-        finished = true;
-    });
+    REQUIRE(executor.run(
+        [&executor, &inside](ExecutionState) { inside.set_value(executor.isCurrent()); }));
 
-    while (!finished)
-        std::this_thread::yield();
+    CHECK(answered.get());
+}
 
-    CHECK(insideSaysYes);
+TEST_CASE("Work that never ran is cancelled rather than dropped", "[engine][control]") {
+    // The promise a caller above this makes is exactly one answer, and an
+    // executor that let queued work go would leave that promise unkept by
+    // whoever made it: a capture waiting for a snapshot nobody is left to send.
+    // So accepted work is always called, and told which of the two it is.
+    std::promise<void> holdingOn;
+    std::shared_future<void> release = holdingOn.get_future();
+    std::promise<void> started;
+    auto running = started.get_future();
+
+    std::promise<ExecutionState> abandoned;
+    auto answered = abandoned.get_future();
+
+    auto executor = std::make_unique<adapter::SerialControlThread>();
+
+    // Holds the worker, so what follows is still queued when the executor is
+    // destroyed.
+    REQUIRE(executor->run([&started, release](ExecutionState) {
+        started.set_value();
+        release.wait();
+    }));
+
+    running.wait();
+
+    REQUIRE(executor->run([&abandoned](ExecutionState state) { abandoned.set_value(state); }));
+
+    // Destroyed from another thread, because the destructor waits for a worker
+    // this test is deliberately holding. Nothing here is a race: the destructor
+    // answers the queue before it starts waiting, so the cancellation below
+    // arrives while the first piece of work is still standing still.
+    std::thread destroyer([&executor] { executor.reset(); });
+
+    REQUIRE(answered.wait_for(std::chrono::seconds(2)) == std::future_status::ready);
+    CHECK(answered.get() == ExecutionState::Cancelled);
+
+    holdingOn.set_value();
+    destroyer.join();
+}
+
+TEST_CASE("An executor destroyed by its own work does not wait for itself", "[engine][control]") {
+    // A completion is entitled to close the thing that owns the executor -- a
+    // project closing from a callback is an ordinary outcome -- and that puts
+    // the last reference on the executor's own thread. A thread cannot wait for
+    // itself, so this test is one the binary either survives or does not.
+    auto executor = std::make_shared<adapter::SerialControlThread>();
+
+    std::promise<void> ran;
+    auto finished = ran.get_future();
+
+    REQUIRE(executor->run([executor, &ran](ExecutionState) mutable {
+        // The work holds the only other reference. Dropping the outer one here
+        // leaves this lambda owning the executor, and the lambda is destroyed
+        // on the executor's own thread once this returns.
+        ran.set_value();
+        executor.reset();
+    }));
+
+    executor.reset();
+    finished.wait();
+
+    // Nothing to assert but arriving here: a self-join would have taken the
+    // process with it.
+    SUCCEED();
 }

--- a/tests/engine/test_control_executor.cpp
+++ b/tests/engine/test_control_executor.cpp
@@ -1,0 +1,127 @@
+#include <atomic>
+#include <catch2/catch_test_macros.hpp>
+#include <memory>
+#include <thread>
+#include <vector>
+
+#include "magda/daw/audio/plugins/engine/ControlExecutor.hpp"
+
+/**
+ * @file test_control_executor.cpp
+ * @brief The one thread a device's control operations run on (#2270).
+ *
+ * What the endpoint above it rests on, and the reason it is a type rather than
+ * a convention: reading a plugin's state, loading a preset and opening an
+ * editor each suspend the plugin and resume it, so two of them overlapping
+ * means the first to finish resumes a plugin the second is still inside. A host
+ * with a window has the message thread to answer that. A headless one has
+ * whatever threads it has, which is exactly why it needs an executor of its own
+ * rather than permission for all of them.
+ *
+ * The message-thread implementation is not tested here, and deliberately: it is
+ * two calls into juce::MessageManager, and this target has no message thread to
+ * put it on. What is tested is the one that had to be written.
+ */
+
+namespace adapter = magda::daw::audio::engine_adapter;
+
+TEST_CASE("A serial executor runs its work on one thread, in order", "[engine][control]") {
+    adapter::SerialControlThread executor;
+
+    std::vector<int> order;
+    std::vector<std::thread::id> threads;
+    std::atomic<int> done{0};
+
+    // Queued from several threads at once, which is the case a headless host
+    // presents: nothing about who asks says anything about who runs it.
+    std::vector<std::thread> askers;
+    for (int index = 0; index < 4; ++index)
+        askers.emplace_back([&executor, &order, &threads, &done, index] {
+            for (int item = 0; item < 8; ++item)
+                executor.run([&order, &threads, &done, index] {
+                    // No lock: the claim is that this only ever runs on one
+                    // thread, so a second one writing here would be the finding
+                    // rather than a reason to synchronise.
+                    order.push_back(index);
+                    threads.push_back(std::this_thread::get_id());
+                    ++done;
+                });
+        });
+
+    for (auto& asker : askers)
+        asker.join();
+
+    // Drained by asking for one more thing and waiting for it: work is run in
+    // the order it was accepted, so anything queued before this has run by the
+    // time this has.
+    std::atomic<bool> drained{false};
+    executor.run([&drained] { drained = true; });
+    while (!drained)
+        std::this_thread::yield();
+
+    CHECK(done == 32);
+    REQUIRE(order.size() == 32);
+    REQUIRE(threads.size() == 32);
+
+    for (const auto& thread : threads)
+        CHECK(thread == threads.front());
+
+    // Each asker's own items kept their order, which is what "serial" is worth:
+    // interleaving between askers is fine and reordering within one is not.
+    for (int index = 0; index < 4; ++index) {
+        auto seen = 0;
+        for (const auto item : order)
+            if (item == index)
+                ++seen;
+
+        CHECK(seen == 8);
+    }
+}
+
+TEST_CASE("Work asked for from the executor runs before the ask returns", "[engine][control]") {
+    // What keeps one control operation asking for another from waiting on a
+    // thread it is standing on. A capture that loaded a preset, or an editor
+    // that saved state on the way down, would otherwise queue behind itself and
+    // never be reached.
+    adapter::SerialControlThread executor;
+
+    std::atomic<bool> nested{false};
+    std::atomic<bool> nestedRanFirst{false};
+    std::atomic<bool> finished{false};
+
+    executor.run([&executor, &nested, &nestedRanFirst, &finished] {
+        executor.run([&nested] { nested = true; });
+
+        // Read immediately after the inner ask returned: if it had been queued
+        // rather than run, nothing would have happened yet.
+        nestedRanFirst = nested.load();
+        finished = true;
+    });
+
+    while (!finished)
+        std::this_thread::yield();
+
+    CHECK(nested);
+    CHECK(nestedRanFirst);
+}
+
+TEST_CASE("An executor knows whether this is its own thread", "[engine][control]") {
+    // What lets an implementation tell "run it now" from "queue it", and what a
+    // caller checks when it wants to know where its answer arrived.
+    adapter::SerialControlThread executor;
+
+    CHECK_FALSE(executor.isCurrent());
+
+    std::atomic<bool> insideSaysYes{false};
+    std::atomic<bool> finished{false};
+
+    executor.run([&executor, &insideSaysYes, &finished] {
+        insideSaysYes = executor.isCurrent();
+        finished = true;
+    });
+
+    while (!finished)
+        std::this_thread::yield();
+
+    CHECK(insideSaysYes);
+}

--- a/tests/engine/test_engine_external_device.cpp
+++ b/tests/engine/test_engine_external_device.cpp
@@ -1,9 +1,13 @@
 #include <juce_audio_processors/juce_audio_processors.h>
 
 #include <algorithm>
+#include <atomic>
 #include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
+#include <chrono>
 #include <cstring>
+#include <functional>
+#include <future>
 #include <memory>
 #include <optional>
 #include <stdexcept>
@@ -251,6 +255,11 @@ class StubPlugin final : public juce::AudioPluginInstance {
     };
 
     void getStateInformation(juce::MemoryBlock& destination) override {
+        // What a real plugin spends time doing here, and what a test needs in
+        // order to see two readers inside it at once if anything let them be.
+        if (whileDescribingItself)
+            whileDescribingItself();
+
         if (throwsSavingState)
             throw std::runtime_error("plugin state handler failed");
 
@@ -357,6 +366,10 @@ class StubPlugin final : public juce::AudioPluginInstance {
 
     /// And some throw describing themselves rather than reading a description.
     bool throwsSavingState = false;
+
+    /// Run inside getStateInformation, for a test that has something to observe
+    /// about when a read is in progress.
+    std::function<void()> whileDescribingItself;
 
     /// And some have nothing beyond their parameters to describe.
     bool savesNothing = false;
@@ -489,35 +502,22 @@ magda::engine::RenderContext contextFor(int channels = 2, int blockSize = 64) {
 /// A device whose parameters are the fork's list: the wrapper pair at zero and
 /// one, then the plugin's automatable parameters.
 /**
- * @brief A message manager for the length of one test, where the binary has
- *        none (#2270).
+ * @brief Ask @p plane for a capture and wait for the answer (#2270).
  *
- * This target is headless: nothing here has a message thread, which is the
- * state the control plane is required not to refuse. The one case that is about
- * being on the wrong thread needs a right one to exist first, and it must not
- * leave it behind -- a manager that outlives the test is reported as a leaked
- * object by whatever runs next, which is a complaint about this file rather
- * than about the run.
- *
- * Only deleted if it was made here. A manager another test created is that
- * test's, and deleting it would be answering a leak with a dangling singleton.
+ * Every answer arrives on the plane's executor, which is not this thread, so a
+ * test that read its result straight after the call would be reading it before
+ * it was written. Waiting for it here is what a host with something else to do
+ * would not have to do, and what a test that has nothing else to do must.
  */
-struct ScopedMessageThread {
-    ScopedMessageThread() : mine_(juce::MessageManager::getInstanceWithoutCreating() == nullptr) {
-        juce::MessageManager::getInstance();
-    }
+adapter::CaptureOutcome capture(adapter::DeviceControlPlane& plane, magda::engine::DeviceKey key) {
+    std::promise<adapter::CaptureOutcome> answer;
+    auto answered = answer.get_future();
 
-    ~ScopedMessageThread() {
-        if (mine_)
-            juce::MessageManager::deleteInstance();
-    }
+    plane.captureState(
+        key, [&answer](adapter::CaptureOutcome outcome) { answer.set_value(std::move(outcome)); });
 
-    ScopedMessageThread(const ScopedMessageThread&) = delete;
-    ScopedMessageThread& operator=(const ScopedMessageThread&) = delete;
-
-  private:
-    bool mine_ = false;
-};
+    return answered.get();
+}
 
 magda::DeviceInfo externalDevice() {
     magda::DeviceInfo device;
@@ -2532,20 +2532,14 @@ TEST_CASE("A capture through the control plane answers with what the plugin hold
 
     const magda::engine::DeviceKey key{magda::ChainSegment::Fx, model.id};
     adapter::LocalDeviceControlPlane plane(
+        std::make_shared<adapter::SerialControlThread>(),
         [&](magda::engine::DeviceKey asked) { return asked == key ? external : nullptr; });
 
-    std::optional<adapter::CaptureOutcome> answered;
-    plane.captureState(
-        key, [&answered](adapter::CaptureOutcome outcome) { answered = std::move(outcome); });
+    const auto answered = capture(plane, key);
+    REQUIRE(answered.ok());
+    CHECK(answered.failure().isEmpty());
 
-    // Answered before the call returned, because this plugin is in this
-    // process. Through the callback all the same, which is the half that will
-    // still be true when it is not.
-    REQUIRE(answered.has_value());
-    REQUIRE(answered->ok());
-    CHECK(answered->failure().isEmpty());
-
-    magda::applyCapturedPluginState(model, answered->snapshot());
+    magda::applyCapturedPluginState(model, answered.snapshot());
     CHECK(model.parameters[1].currentValue == Catch::Approx(0.4f));
 }
 
@@ -2556,20 +2550,16 @@ TEST_CASE("A key with no device bound is a failure rather than an empty state",
     // caller told the second would write that nothing into the project and lose
     // the patch the slot is about to load.
     adapter::LocalDeviceControlPlane plane(
+        std::make_shared<adapter::SerialControlThread>(),
         [](magda::engine::DeviceKey) -> adapter::EngineExternalDevice* { return nullptr; });
 
-    std::optional<adapter::CaptureOutcome> answered;
-    plane.captureState(
-        {magda::ChainSegment::PostFx, 12},
-        [&answered](adapter::CaptureOutcome outcome) { answered = std::move(outcome); });
-
-    REQUIRE(answered.has_value());
-    CHECK_FALSE(answered->ok());
-    CHECK(answered->failure().contains("no plugin is bound"));
+    const auto answered = capture(plane, {magda::ChainSegment::PostFx, 12});
+    CHECK_FALSE(answered.ok());
+    CHECK(answered.failure().contains("no plugin is bound"));
 
     // And it says which slot, because a host with a project's worth of devices
     // is holding a failure that has to name one of them.
-    CHECK(answered->failure().contains("12"));
+    CHECK(answered.failure().contains("12"));
 }
 
 TEST_CASE("A plugin that will not describe itself is a failure with a reason",
@@ -2586,16 +2576,12 @@ TEST_CASE("A plugin that will not describe itself is a failure with a reason",
     REQUIRE(external != nullptr);
 
     adapter::LocalDeviceControlPlane plane(
+        std::make_shared<adapter::SerialControlThread>(),
         [external](magda::engine::DeviceKey) { return external; });
 
-    std::optional<adapter::CaptureOutcome> answered;
-    plane.captureState(
-        {magda::ChainSegment::Fx, model.id},
-        [&answered](adapter::CaptureOutcome outcome) { answered = std::move(outcome); });
-
-    REQUIRE(answered.has_value());
-    CHECK_FALSE(answered->ok());
-    CHECK(answered->failure().contains("could not describe itself"));
+    const auto answered = capture(plane, {magda::ChainSegment::Fx, model.id});
+    CHECK_FALSE(answered.ok());
+    CHECK(answered.failure().contains("could not describe itself"));
 }
 
 TEST_CASE("A snapshot is written onto the assignment it was read from",
@@ -2695,22 +2681,12 @@ TEST_CASE("A snapshot is written onto the device its own token names",
     CHECK(somewhereElse.pluginState.isEmpty());
 }
 
-TEST_CASE("A capture asked for off the message thread is refused", "[engine][external][control]") {
-    // The precondition the endpoint states, enforced where it can be. Everything
-    // past it reaches into somebody else's code: a plugin suspended and asked to
-    // describe itself is a message-thread transaction in every host there is,
-    // and a save dispatched from a worker would be doing it from the wrong one.
-    //
-    // Refused rather than marshalled, and refused before the lookup runs: the
-    // finding is the caller's thread, and a plane that went looking for a device
-    // first would report whichever complaint it met on the way.
-    //
-    // A message manager has to exist for there to be a wrong thread at all. A
-    // headless host has none and is not refused, which is the case every other
-    // test in this file runs under, so this one makes the manager and holds the
-    // message thread on the thread it is running on.
-    const ScopedMessageThread messageThread;
-
+TEST_CASE("A capture runs and answers on the plane's executor", "[engine][external][control]") {
+    // Asked from any thread, run on one. That is the whole of the execution
+    // contract: a caller does not have to be anywhere in particular, and what
+    // it gets back arrives on the thread the control side of a device is
+    // allowed to be on -- which is where it is entitled to write a project's
+    // model from, whichever thread asked and whichever process answered.
     auto plugin = std::make_unique<StubPlugin>(2, 2, 0);
     auto model = externalDevice();
     auto result = adapter::adaptExternalPluginInstance(std::move(plugin), model);
@@ -2719,24 +2695,112 @@ TEST_CASE("A capture asked for off the message thread is refused", "[engine][ext
     auto* external = dynamic_cast<adapter::EngineExternalDevice*>(result.device.get());
     REQUIRE(external != nullptr);
 
-    bool lookedForADevice = false;
-    adapter::LocalDeviceControlPlane plane([&](magda::engine::DeviceKey) {
-        lookedForADevice = true;
-        return external;
+    auto executor = std::make_shared<adapter::SerialControlThread>();
+    adapter::LocalDeviceControlPlane plane(
+        executor, [external](magda::engine::DeviceKey) { return external; });
+
+    std::promise<bool> onTheExecutor;
+    auto answered = onTheExecutor.get_future();
+
+    // Asked from a thread that is neither the executor's nor this one, which is
+    // the case the endpoint used to refuse and now simply serves.
+    std::thread worker([&] {
+        plane.captureState({magda::ChainSegment::Fx, model.id},
+                           [&executor, &onTheExecutor](adapter::CaptureOutcome outcome) {
+                               onTheExecutor.set_value(outcome.ok() && executor->isCurrent());
+                           });
     });
-
-    std::optional<adapter::CaptureOutcome> answered;
-    const auto ask = [&] {
-        plane.captureState(
-            {magda::ChainSegment::Fx, model.id},
-            [&answered](adapter::CaptureOutcome outcome) { answered = std::move(outcome); });
-    };
-
-    std::thread worker(ask);
     worker.join();
 
-    REQUIRE(answered.has_value());
-    CHECK_FALSE(answered->ok());
-    CHECK(answered->failure().contains("off the message thread"));
-    CHECK_FALSE(lookedForADevice);
+    CHECK(answered.get());
+}
+
+TEST_CASE("A capture asked for on the executor answers before it returns",
+          "[engine][external][control]") {
+    // The other half of the same contract, and the one a host actually meets: a
+    // save runs on the control thread, so the plugin is right here and there is
+    // nothing to wait for. A caller that assumed this of every capture would be
+    // assuming something only this case makes true, which is why the interface
+    // says so rather than leaving it to be discovered.
+    auto plugin = std::make_unique<StubPlugin>(2, 2, 0);
+    auto model = externalDevice();
+    auto result = adapter::adaptExternalPluginInstance(std::move(plugin), model);
+    REQUIRE(result.device != nullptr);
+
+    auto* external = dynamic_cast<adapter::EngineExternalDevice*>(result.device.get());
+    REQUIRE(external != nullptr);
+
+    auto executor = std::make_shared<adapter::SerialControlThread>();
+    adapter::LocalDeviceControlPlane plane(
+        executor, [external](magda::engine::DeviceKey) { return external; });
+
+    std::promise<bool> done;
+    auto finished = done.get_future();
+
+    executor->run([&] {
+        bool answeredInline = false;
+        plane.captureState(
+            {magda::ChainSegment::Fx, model.id},
+            [&answeredInline](adapter::CaptureOutcome outcome) { answeredInline = outcome.ok(); });
+
+        // Set after captureState returned, from the same call: if the answer
+        // had been queued behind this work rather than run inside it, nothing
+        // would have been written yet.
+        done.set_value(answeredInline);
+    });
+
+    CHECK(finished.get());
+}
+
+TEST_CASE("Two captures of one device do not overlap", "[engine][external][control]") {
+    // The rule the executor exists for. A capture suspends the plugin and
+    // resumes it afterwards, so two of them overlapping would have the first to
+    // finish resuming it while the second was still reading -- and the next
+    // block let straight back into a plugin halfway through describing itself.
+    //
+    // A headless host has whatever threads it has, and four of them ask at once
+    // here. What makes that safe is not a thread check but the executor: one
+    // piece of control work at a time, for every operation and not only this
+    // one. The stub counts how many readers are inside it at once.
+    auto plugin = std::make_unique<StubPlugin>(2, 2, 0);
+    auto* raw = plugin.get();
+
+    auto model = externalDevice();
+    auto result = adapter::adaptExternalPluginInstance(std::move(plugin), model);
+    REQUIRE(result.device != nullptr);
+
+    auto* external = dynamic_cast<adapter::EngineExternalDevice*>(result.device.get());
+    REQUIRE(external != nullptr);
+
+    std::atomic<int> inside{0};
+    std::atomic<int> mostAtOnce{0};
+    raw->whileDescribingItself = [&inside, &mostAtOnce] {
+        const auto now = ++inside;
+        auto highest = mostAtOnce.load();
+        while (now > highest && !mostAtOnce.compare_exchange_weak(highest, now)) {
+        }
+
+        // Long enough that a second reader arriving unserialised would be seen
+        // rather than missed by luck.
+        std::this_thread::sleep_for(std::chrono::milliseconds(2));
+        --inside;
+    };
+
+    adapter::LocalDeviceControlPlane plane(
+        std::make_shared<adapter::SerialControlThread>(),
+        [external](magda::engine::DeviceKey) { return external; });
+
+    std::atomic<int> taken{0};
+    std::vector<std::thread> askers;
+    for (int index = 0; index < 4; ++index)
+        askers.emplace_back([&plane, &taken, &model] {
+            if (capture(plane, {magda::ChainSegment::Fx, model.id}).ok())
+                ++taken;
+        });
+
+    for (auto& asker : askers)
+        asker.join();
+
+    CHECK(taken == 4);
+    CHECK(mostAtOnce == 1);
 }

--- a/tests/engine/test_engine_external_device.cpp
+++ b/tests/engine/test_engine_external_device.cpp
@@ -2531,8 +2531,9 @@ TEST_CASE("A capture through the control plane answers with what the plugin hold
     REQUIRE(external != nullptr);
 
     const magda::engine::DeviceKey key{magda::ChainSegment::Fx, model.id};
+    const auto runtime = std::make_shared<int>(0);
     adapter::LocalDeviceControlPlane plane(
-        std::make_shared<adapter::SerialControlThread>(),
+        std::make_shared<adapter::SerialControlThread>(), runtime,
         [&](magda::engine::DeviceKey asked) { return asked == key ? external : nullptr; });
 
     const auto answered = capture(plane, key);
@@ -2549,8 +2550,9 @@ TEST_CASE("A key with no device bound is a failure rather than an empty state",
     // plugin has not arrived, against a plugin that answered with nothing. A
     // caller told the second would write that nothing into the project and lose
     // the patch the slot is about to load.
+    const auto runtime = std::make_shared<int>(0);
     adapter::LocalDeviceControlPlane plane(
-        std::make_shared<adapter::SerialControlThread>(),
+        std::make_shared<adapter::SerialControlThread>(), runtime,
         [](magda::engine::DeviceKey) -> adapter::EngineExternalDevice* { return nullptr; });
 
     const auto answered = capture(plane, {magda::ChainSegment::PostFx, 12});
@@ -2575,8 +2577,9 @@ TEST_CASE("A plugin that will not describe itself is a failure with a reason",
     auto* external = dynamic_cast<adapter::EngineExternalDevice*>(result.device.get());
     REQUIRE(external != nullptr);
 
+    const auto runtime = std::make_shared<int>(0);
     adapter::LocalDeviceControlPlane plane(
-        std::make_shared<adapter::SerialControlThread>(),
+        std::make_shared<adapter::SerialControlThread>(), runtime,
         [external](magda::engine::DeviceKey) { return external; });
 
     const auto answered = capture(plane, {magda::ChainSegment::Fx, model.id});
@@ -2696,8 +2699,9 @@ TEST_CASE("A capture runs and answers on the plane's executor", "[engine][extern
     REQUIRE(external != nullptr);
 
     auto executor = std::make_shared<adapter::SerialControlThread>();
+    const auto runtime = std::make_shared<int>(0);
     adapter::LocalDeviceControlPlane plane(
-        executor, [external](magda::engine::DeviceKey) { return external; });
+        executor, runtime, [external](magda::engine::DeviceKey) { return external; });
 
     std::promise<bool> onTheExecutor;
     auto answered = onTheExecutor.get_future();
@@ -2715,13 +2719,13 @@ TEST_CASE("A capture runs and answers on the plane's executor", "[engine][extern
     CHECK(answered.get());
 }
 
-TEST_CASE("A capture asked for on the executor answers before it returns",
+TEST_CASE("A capture asked for on the executor is queued behind what asked for it",
           "[engine][external][control]") {
-    // The other half of the same contract, and the one a host actually meets: a
-    // save runs on the control thread, so the plugin is right here and there is
-    // nothing to wait for. A caller that assumed this of every capture would be
-    // assuming something only this case makes true, which is why the interface
-    // says so rather than leaving it to be discovered.
+    // Never inline, and that is the rule rather than a missed optimisation: an
+    // operation that has suspended a plugin and asks for a capture must not
+    // have the capture run inside it. It would resume the plugin and let audio
+    // back in halfway through the first transaction, which is what the executor
+    // is for (ControlExecutor.hpp).
     auto plugin = std::make_unique<StubPlugin>(2, 2, 0);
     auto model = externalDevice();
     auto result = adapter::adaptExternalPluginInstance(std::move(plugin), model);
@@ -2731,25 +2735,90 @@ TEST_CASE("A capture asked for on the executor answers before it returns",
     REQUIRE(external != nullptr);
 
     auto executor = std::make_shared<adapter::SerialControlThread>();
+    const auto runtime = std::make_shared<int>(0);
     adapter::LocalDeviceControlPlane plane(
-        executor, [external](magda::engine::DeviceKey) { return external; });
+        executor, runtime, [external](magda::engine::DeviceKey) { return external; });
 
-    std::promise<bool> done;
-    auto finished = done.get_future();
+    std::atomic<bool> answered{false};
+    std::promise<bool> answeredInside;
+    auto asked = answeredInside.get_future();
 
-    executor->run([&] {
-        bool answeredInline = false;
+    executor->run([&](adapter::ExecutionState) {
         plane.captureState(
             {magda::ChainSegment::Fx, model.id},
-            [&answeredInline](adapter::CaptureOutcome outcome) { answeredInline = outcome.ok(); });
+            [&answered](adapter::CaptureOutcome outcome) { answered = outcome.ok(); });
 
-        // Set after captureState returned, from the same call: if the answer
-        // had been queued behind this work rather than run inside it, nothing
-        // would have been written yet.
-        done.set_value(answeredInline);
+        // Read after captureState returned and while this work is still the one
+        // running: an answer here would be a second transaction inside this one.
+        answeredInside.set_value(answered.load());
     });
 
-    CHECK(finished.get());
+    CHECK_FALSE(asked.get());
+
+    // And it arrives in its turn, which is the other half.
+    std::promise<void> drained;
+    auto emptied = drained.get_future();
+    executor->run([&drained](adapter::ExecutionState) { drained.set_value(); });
+    emptied.wait();
+
+    CHECK(answered);
+}
+
+TEST_CASE("A capture queued before its runtime went is answered rather than run",
+          "[engine][external][control]") {
+    // The hazard of being genuinely asynchronous. Between queueing a capture
+    // and running it, the project can close -- and the lookup a plane was given
+    // is a function over the runtime that owned those devices, so calling it
+    // then is reaching into something that has been deleted rather than being
+    // told there is no device.
+    //
+    // So the work carries a weak lifeline, takes it before it looks anything
+    // up, and answers rather than reaching. The same shape the asynchronous
+    // load path uses for the same problem (PluginAssignments.hpp).
+    auto plugin = std::make_unique<StubPlugin>(2, 2, 0);
+    auto model = externalDevice();
+    auto result = adapter::adaptExternalPluginInstance(std::move(plugin), model);
+    REQUIRE(result.device != nullptr);
+
+    auto* external = dynamic_cast<adapter::EngineExternalDevice*>(result.device.get());
+    REQUIRE(external != nullptr);
+
+    auto executor = std::make_shared<adapter::SerialControlThread>();
+    auto runtime = std::make_shared<int>(0);
+
+    std::atomic<bool> lookedUp{false};
+    adapter::LocalDeviceControlPlane plane(executor, runtime,
+                                           [external, &lookedUp](magda::engine::DeviceKey) {
+                                               lookedUp = true;
+                                               return external;
+                                           });
+
+    // The worker is held while the capture is queued behind it, so the project
+    // can be closed in between the way it would be by a person doing it.
+    std::promise<void> holdingOn;
+    std::shared_future<void> release = holdingOn.get_future();
+    std::promise<void> started;
+    auto running = started.get_future();
+
+    executor->run([&started, release](adapter::ExecutionState) {
+        started.set_value();
+        release.wait();
+    });
+    running.wait();
+
+    std::promise<adapter::CaptureOutcome> answered;
+    auto answer = answered.get_future();
+    plane.captureState(
+        {magda::ChainSegment::Fx, model.id},
+        [&answered](adapter::CaptureOutcome outcome) { answered.set_value(std::move(outcome)); });
+
+    runtime.reset();
+    holdingOn.set_value();
+
+    const auto outcome = answer.get();
+    CHECK_FALSE(outcome.ok());
+    CHECK(outcome.failure().contains("is gone"));
+    CHECK_FALSE(lookedUp);
 }
 
 TEST_CASE("Two captures of one device do not overlap", "[engine][external][control]") {
@@ -2786,8 +2855,9 @@ TEST_CASE("Two captures of one device do not overlap", "[engine][external][contr
         --inside;
     };
 
+    const auto runtime = std::make_shared<int>(0);
     adapter::LocalDeviceControlPlane plane(
-        std::make_shared<adapter::SerialControlThread>(),
+        std::make_shared<adapter::SerialControlThread>(), runtime,
         [external](magda::engine::DeviceKey) { return external; });
 
     std::atomic<int> taken{0};

--- a/tests/engine/test_engine_external_device.cpp
+++ b/tests/engine/test_engine_external_device.cpp
@@ -519,6 +519,41 @@ adapter::CaptureOutcome capture(adapter::DeviceControlPlane& plane, magda::engin
     return answered.get();
 }
 
+/// A registry over one device, which is what a runtime hands a plane (#2270).
+///
+/// Owned by the test the way a runtime owns its own: what keeps the device
+/// reachable is this object being alive, so dropping it is how a test closes a
+/// project.
+class OneDeviceRegistry final : public adapter::DeviceRegistry {
+  public:
+    /// @p asked counts the lookups, for the cases about whether there should
+    /// have been one. It belongs to the test rather than to this object,
+    /// because the case that cares is the one where this object is gone.
+    OneDeviceRegistry(magda::engine::DeviceKey key, adapter::EngineExternalDevice* device,
+                      std::atomic<int>* asked = nullptr)
+        : key_(key), device_(device), asked_(asked) {}
+
+    adapter::EngineExternalDevice* find(magda::engine::DeviceKey key) const override {
+        if (asked_ != nullptr)
+            ++(*asked_);
+
+        return key == key_ ? device_ : nullptr;
+    }
+
+  private:
+    magda::engine::DeviceKey key_;
+    adapter::EngineExternalDevice* device_ = nullptr;
+    std::atomic<int>* asked_ = nullptr;
+};
+
+/// A registry with nothing in it.
+class EmptyRegistry final : public adapter::DeviceRegistry {
+  public:
+    adapter::EngineExternalDevice* find(magda::engine::DeviceKey) const override {
+        return nullptr;
+    }
+};
+
 magda::DeviceInfo externalDevice() {
     magda::DeviceInfo device;
     device.id = 7;
@@ -2531,10 +2566,9 @@ TEST_CASE("A capture through the control plane answers with what the plugin hold
     REQUIRE(external != nullptr);
 
     const magda::engine::DeviceKey key{magda::ChainSegment::Fx, model.id};
-    const auto runtime = std::make_shared<int>(0);
-    adapter::LocalDeviceControlPlane plane(
-        std::make_shared<adapter::SerialControlThread>(), runtime,
-        [&](magda::engine::DeviceKey asked) { return asked == key ? external : nullptr; });
+    const auto registry = std::make_shared<const OneDeviceRegistry>(key, external);
+    adapter::LocalDeviceControlPlane plane(std::make_shared<adapter::SerialControlThread>(),
+                                           registry);
 
     const auto answered = capture(plane, key);
     REQUIRE(answered.ok());
@@ -2550,10 +2584,9 @@ TEST_CASE("A key with no device bound is a failure rather than an empty state",
     // plugin has not arrived, against a plugin that answered with nothing. A
     // caller told the second would write that nothing into the project and lose
     // the patch the slot is about to load.
-    const auto runtime = std::make_shared<int>(0);
-    adapter::LocalDeviceControlPlane plane(
-        std::make_shared<adapter::SerialControlThread>(), runtime,
-        [](magda::engine::DeviceKey) -> adapter::EngineExternalDevice* { return nullptr; });
+    const auto registry = std::make_shared<const EmptyRegistry>();
+    adapter::LocalDeviceControlPlane plane(std::make_shared<adapter::SerialControlThread>(),
+                                           registry);
 
     const auto answered = capture(plane, {magda::ChainSegment::PostFx, 12});
     CHECK_FALSE(answered.ok());
@@ -2577,10 +2610,10 @@ TEST_CASE("A plugin that will not describe itself is a failure with a reason",
     auto* external = dynamic_cast<adapter::EngineExternalDevice*>(result.device.get());
     REQUIRE(external != nullptr);
 
-    const auto runtime = std::make_shared<int>(0);
-    adapter::LocalDeviceControlPlane plane(
-        std::make_shared<adapter::SerialControlThread>(), runtime,
-        [external](magda::engine::DeviceKey) { return external; });
+    const auto registry = std::make_shared<const OneDeviceRegistry>(
+        magda::engine::DeviceKey{magda::ChainSegment::Fx, model.id}, external);
+    adapter::LocalDeviceControlPlane plane(std::make_shared<adapter::SerialControlThread>(),
+                                           registry);
 
     const auto answered = capture(plane, {magda::ChainSegment::Fx, model.id});
     CHECK_FALSE(answered.ok());
@@ -2699,9 +2732,9 @@ TEST_CASE("A capture runs and answers on the plane's executor", "[engine][extern
     REQUIRE(external != nullptr);
 
     auto executor = std::make_shared<adapter::SerialControlThread>();
-    const auto runtime = std::make_shared<int>(0);
-    adapter::LocalDeviceControlPlane plane(
-        executor, runtime, [external](magda::engine::DeviceKey) { return external; });
+    const auto registry = std::make_shared<const OneDeviceRegistry>(
+        magda::engine::DeviceKey{magda::ChainSegment::Fx, model.id}, external);
+    adapter::LocalDeviceControlPlane plane(executor, registry);
 
     std::promise<bool> onTheExecutor;
     auto answered = onTheExecutor.get_future();
@@ -2735,9 +2768,9 @@ TEST_CASE("A capture asked for on the executor is queued behind what asked for i
     REQUIRE(external != nullptr);
 
     auto executor = std::make_shared<adapter::SerialControlThread>();
-    const auto runtime = std::make_shared<int>(0);
-    adapter::LocalDeviceControlPlane plane(
-        executor, runtime, [external](magda::engine::DeviceKey) { return external; });
+    const auto registry = std::make_shared<const OneDeviceRegistry>(
+        magda::engine::DeviceKey{magda::ChainSegment::Fx, model.id}, external);
+    adapter::LocalDeviceControlPlane plane(executor, registry);
 
     std::atomic<bool> answered{false};
     std::promise<bool> answeredInside;
@@ -2764,17 +2797,18 @@ TEST_CASE("A capture asked for on the executor is queued behind what asked for i
     CHECK(answered);
 }
 
-TEST_CASE("A capture queued before its runtime went is answered rather than run",
+TEST_CASE("A capture queued before its registry went is answered rather than run",
           "[engine][external][control]") {
     // The hazard of being genuinely asynchronous. Between queueing a capture
-    // and running it, the project can close -- and the lookup a plane was given
-    // is a function over the runtime that owned those devices, so calling it
-    // then is reaching into something that has been deleted rather than being
-    // told there is no device.
+    // and running it, the project can close -- and what finds a device is a
+    // registry the runtime owns, so asking one whose runtime has gone is
+    // reaching into something that has been deleted rather than being told
+    // there is no device.
     //
-    // So the work carries a weak lifeline, takes it before it looks anything
-    // up, and answers rather than reaching. The same shape the asynchronous
-    // load path uses for the same problem (PluginAssignments.hpp).
+    // So the plane holds the registry weakly and takes it before it asks
+    // anything, which is the relationship a token standing beside a lookup
+    // could not have had. The same shape the asynchronous load path uses for
+    // the same problem (PluginAssignments.hpp).
     auto plugin = std::make_unique<StubPlugin>(2, 2, 0);
     auto model = externalDevice();
     auto result = adapter::adaptExternalPluginInstance(std::move(plugin), model);
@@ -2784,41 +2818,40 @@ TEST_CASE("A capture queued before its runtime went is answered rather than run"
     REQUIRE(external != nullptr);
 
     auto executor = std::make_shared<adapter::SerialControlThread>();
-    auto runtime = std::make_shared<int>(0);
+    // Counted outside the registry, because the point of this case is that the
+    // registry is gone by the time the question is asked.
+    std::atomic<int> asked{0};
+    auto registry = std::make_shared<const OneDeviceRegistry>(
+        magda::engine::DeviceKey{magda::ChainSegment::Fx, model.id}, external, &asked);
 
-    std::atomic<bool> lookedUp{false};
-    adapter::LocalDeviceControlPlane plane(executor, runtime,
-                                           [external, &lookedUp](magda::engine::DeviceKey) {
-                                               lookedUp = true;
-                                               return external;
-                                           });
+    adapter::LocalDeviceControlPlane plane(executor, registry);
 
     // The worker is held while the capture is queued behind it, so the project
-    // can be closed in between the way it would be by a person doing it.
+    // can be closed in between the way a person would close it.
     std::promise<void> holdingOn;
     std::shared_future<void> release = holdingOn.get_future();
     std::promise<void> started;
     auto running = started.get_future();
 
-    executor->run([&started, release](adapter::ExecutionState) {
+    REQUIRE(executor->run([&started, release](adapter::ExecutionState) {
         started.set_value();
         release.wait();
-    });
+    }));
     running.wait();
 
     std::promise<adapter::CaptureOutcome> answered;
     auto answer = answered.get_future();
-    plane.captureState(
+    REQUIRE(plane.captureState(
         {magda::ChainSegment::Fx, model.id},
-        [&answered](adapter::CaptureOutcome outcome) { answered.set_value(std::move(outcome)); });
+        [&answered](adapter::CaptureOutcome outcome) { answered.set_value(std::move(outcome)); }));
 
-    runtime.reset();
+    registry.reset();
     holdingOn.set_value();
 
     const auto outcome = answer.get();
     CHECK_FALSE(outcome.ok());
     CHECK(outcome.failure().contains("is gone"));
-    CHECK_FALSE(lookedUp);
+    CHECK(asked == 0);
 }
 
 TEST_CASE("Two captures of one device do not overlap", "[engine][external][control]") {
@@ -2855,10 +2888,10 @@ TEST_CASE("Two captures of one device do not overlap", "[engine][external][contr
         --inside;
     };
 
-    const auto runtime = std::make_shared<int>(0);
-    adapter::LocalDeviceControlPlane plane(
-        std::make_shared<adapter::SerialControlThread>(), runtime,
-        [external](magda::engine::DeviceKey) { return external; });
+    const auto registry = std::make_shared<const OneDeviceRegistry>(
+        magda::engine::DeviceKey{magda::ChainSegment::Fx, model.id}, external);
+    adapter::LocalDeviceControlPlane plane(std::make_shared<adapter::SerialControlThread>(),
+                                           registry);
 
     std::atomic<int> taken{0};
     std::vector<std::thread> askers;

--- a/tests/engine/test_engine_external_device.cpp
+++ b/tests/engine/test_engine_external_device.cpp
@@ -14,6 +14,7 @@
 #include "magda/daw/audio/Vst3Preset.hpp"
 #include "magda/daw/audio/plugin_manager/ExternalPluginLookup.hpp"
 #include "magda/daw/audio/plugin_manager/ExternalPluginState.hpp"
+#include "magda/daw/audio/plugins/engine/DeviceControl.hpp"
 #include "magda/daw/audio/plugins/engine/EngineDeviceFactory.hpp"
 #include "magda/daw/audio/plugins/engine/EngineExternalDevice.hpp"
 #include "magda/daw/audio/plugins/engine/PluginAssignments.hpp"
@@ -1944,10 +1945,11 @@ TEST_CASE("A save leaves a non-VST3 device's portable records alone", "[engine][
     CHECK(model.vst3Preset == "what the project was imported with");
 }
 
-TEST_CASE("A save reads the instance the adapter is holding", "[engine][external][state]") {
-    // The seam a host saves through: the adapter owns the instance, and
-    // EngineExternalDevice::instance() is how anything that is not rendering
-    // reaches it.
+TEST_CASE("A save reads the plugin through the device that owns it", "[engine][external][state]") {
+    // The seam a host saves through (#2270). The adapter owns the instance and
+    // nothing else can reach it: a save asks the device for what its plugin
+    // holds, which is what makes the read and the blocks around it two things
+    // one object is serialising rather than two callers observing a convention.
     auto plugin = std::make_unique<StubPlugin>(2, 2, 0);
     auto* raw = plugin.get();
 
@@ -1961,7 +1963,10 @@ TEST_CASE("A save reads the instance the adapter is holding", "[engine][external
 
     auto* external = dynamic_cast<adapter::EngineExternalDevice*>(result.device.get());
     REQUIRE(external != nullptr);
-    REQUIRE(captureInto(external->instance(), model));
+
+    const auto snapshot = external->captureState();
+    REQUIRE(snapshot.has_value());
+    magda::applyCapturedPluginState(model, *snapshot);
 
     auto reopened = std::make_unique<StubPlugin>(2, 2, 0);
     auto* reopenedRaw = reopened.get();
@@ -2466,4 +2471,157 @@ TEST_CASE("A runtime torn down before dispatch is never called back", "[engine][
         juce::MessageManager::getInstance()->runDispatchLoopUntil(10);
 
     CHECK_FALSE(called);
+}
+
+// =============================================================================
+// The control plane (#2270)
+// =============================================================================
+
+TEST_CASE("A capture through the control plane answers with what the plugin holds",
+          "[engine][external][control]") {
+    // The endpoint a host asks rather than the instance it used to be handed.
+    // What it answers with is data: a snapshot that outlives the call, which is
+    // what lets the caller check between reading and writing, and what a plugin
+    // in another process could send back at all.
+    auto plugin = std::make_unique<StubPlugin>(2, 2, 0);
+    auto* raw = plugin.get();
+
+    auto model = externalDevice();
+    auto result = adapter::adaptExternalPluginInstance(std::move(plugin), model);
+    REQUIRE(result.device != nullptr);
+
+    // Moved after the device was built, the way a knob moved during a session
+    // is: what a capture is for is the difference between what the project
+    // holds and what the plugin holds now.
+    raw->tone->setValue(0.4f);
+
+    auto* external = dynamic_cast<adapter::EngineExternalDevice*>(result.device.get());
+    REQUIRE(external != nullptr);
+
+    const magda::engine::DeviceKey key{magda::ChainSegment::Fx, model.id};
+    adapter::LocalDeviceControlPlane plane(
+        [&](magda::engine::DeviceKey asked) { return asked == key ? external : nullptr; });
+
+    std::optional<adapter::CaptureOutcome> answered;
+    plane.captureState(
+        key, [&answered](adapter::CaptureOutcome outcome) { answered = std::move(outcome); });
+
+    // Answered before the call returned, because this plugin is in this
+    // process. Through the callback all the same, which is the half that will
+    // still be true when it is not.
+    REQUIRE(answered.has_value());
+    REQUIRE(answered->ok());
+    CHECK(answered->failure.isEmpty());
+
+    magda::applyCapturedPluginState(model, *answered->snapshot);
+    CHECK(model.parameters[1].currentValue == Catch::Approx(0.4f));
+}
+
+TEST_CASE("A key with no device bound is a failure rather than an empty state",
+          "[engine][external][control]") {
+    // The two are different findings and one reads like the other: a slot whose
+    // plugin has not arrived, against a plugin that answered with nothing. A
+    // caller told the second would write that nothing into the project and lose
+    // the patch the slot is about to load.
+    adapter::LocalDeviceControlPlane plane(
+        [](magda::engine::DeviceKey) -> adapter::EngineExternalDevice* { return nullptr; });
+
+    std::optional<adapter::CaptureOutcome> answered;
+    plane.captureState(
+        {magda::ChainSegment::PostFx, 12},
+        [&answered](adapter::CaptureOutcome outcome) { answered = std::move(outcome); });
+
+    REQUIRE(answered.has_value());
+    CHECK_FALSE(answered->ok());
+    CHECK(answered->failure.contains("no plugin is bound"));
+
+    // And it says which slot, because a host with a project's worth of devices
+    // is holding a failure that has to name one of them.
+    CHECK(answered->failure.contains("12"));
+}
+
+TEST_CASE("A plugin that will not describe itself is a failure with a reason",
+          "[engine][external][control]") {
+    auto plugin = std::make_unique<StubPlugin>(2, 2, 0);
+    auto* raw = plugin.get();
+    raw->throwsSavingState = true;
+
+    auto model = externalDevice();
+    auto result = adapter::adaptExternalPluginInstance(std::move(plugin), model);
+    REQUIRE(result.device != nullptr);
+
+    auto* external = dynamic_cast<adapter::EngineExternalDevice*>(result.device.get());
+    REQUIRE(external != nullptr);
+
+    adapter::LocalDeviceControlPlane plane(
+        [external](magda::engine::DeviceKey) { return external; });
+
+    std::optional<adapter::CaptureOutcome> answered;
+    plane.captureState(
+        {magda::ChainSegment::Fx, model.id},
+        [&answered](adapter::CaptureOutcome outcome) { answered = std::move(outcome); });
+
+    REQUIRE(answered.has_value());
+    CHECK_FALSE(answered->ok());
+    CHECK(answered->failure.contains("could not describe itself"));
+}
+
+TEST_CASE("A snapshot is written onto the assignment it was read from",
+          "[engine][external][control]") {
+    adapter::PluginAssignments assignments;
+    const magda::engine::DeviceKey key{magda::ChainSegment::Fx, 7};
+    assignments.replaceAssignment(key);
+
+    const auto request = assignments.request(key);
+
+    magda::ExternalPluginSnapshot snapshot;
+    snapshot.pluginState = "what the plugin was holding";
+
+    auto model = externalDevice();
+    CHECK(adapter::commitCapturedState(request, snapshot, model));
+    CHECK(model.pluginState == "what the plugin was holding");
+}
+
+TEST_CASE("A snapshot read from an assignment that has been replaced is not written",
+          "[engine][external][control]") {
+    // The reason a capture is two steps with only data between them. Between
+    // asking a plugin what it holds and writing that down, the slot can have
+    // been given a different plugin -- and the patch of the one that answered
+    // would land on the one that did not.
+    adapter::PluginAssignments assignments;
+    const magda::engine::DeviceKey key{magda::ChainSegment::Fx, 7};
+    assignments.replaceAssignment(key);
+
+    const auto request = assignments.request(key);
+    assignments.replaceAssignment(key);
+
+    magda::ExternalPluginSnapshot snapshot;
+    snapshot.pluginState = "the plugin that used to be in this slot";
+
+    auto model = externalDevice();
+    model.pluginState = "what the slot holds now";
+
+    CHECK_FALSE(adapter::commitCapturedState(request, snapshot, model));
+    CHECK(model.pluginState == "what the slot holds now");
+}
+
+TEST_CASE("A snapshot outliving the runtime that read it is not written",
+          "[engine][external][control]") {
+    // The other way a commit arrives too late, and the one an out-of-process
+    // capture will meet first: the project was closed while the answer was in
+    // flight. There is nothing to write onto and nobody waiting to hear it.
+    adapter::AssignmentRequest request;
+    {
+        adapter::PluginAssignments assignments;
+        assignments.replaceAssignment({magda::ChainSegment::Fx, 7});
+        request = assignments.request({magda::ChainSegment::Fx, 7});
+        CHECK(request.isStillWanted());
+    }
+
+    magda::ExternalPluginSnapshot snapshot;
+    snapshot.pluginState = "read before the project closed";
+
+    auto model = externalDevice();
+    CHECK_FALSE(adapter::commitCapturedState(request, snapshot, model));
+    CHECK(model.pluginState.isEmpty());
 }

--- a/tests/engine/test_engine_external_device.cpp
+++ b/tests/engine/test_engine_external_device.cpp
@@ -521,38 +521,63 @@ adapter::CaptureOutcome capture(adapter::DeviceControlPlane& plane, magda::engin
 
 /// A registry over one device, which is what a runtime hands a plane (#2270).
 ///
-/// Owned by the test the way a runtime owns its own: what keeps the device
-/// reachable is this object being alive, so dropping it is how a test closes a
-/// project.
+/// It owns the device, the way a runtime owns the ones it runs, and hands out a
+/// lease rather than a pointer: what keeps a device alive through a capture is
+/// the lease, so this can let go of its own copy mid-operation and the capture
+/// carries on with the plugin it was already reading.
 class OneDeviceRegistry final : public adapter::DeviceRegistry {
   public:
     /// @p asked counts the lookups, for the cases about whether there should
     /// have been one. It belongs to the test rather than to this object,
     /// because the case that cares is the one where this object is gone.
-    OneDeviceRegistry(magda::engine::DeviceKey key, adapter::EngineExternalDevice* device,
+    OneDeviceRegistry(magda::engine::DeviceKey key,
+                      std::shared_ptr<adapter::EngineExternalDevice> device,
                       std::atomic<int>* asked = nullptr)
-        : key_(key), device_(device), asked_(asked) {}
+        : key_(key), device_(std::move(device)), asked_(asked) {}
 
-    adapter::EngineExternalDevice* find(magda::engine::DeviceKey key) const override {
+    std::shared_ptr<adapter::EngineExternalDevice> find(
+        magda::engine::DeviceKey key) const override {
         if (asked_ != nullptr)
             ++(*asked_);
 
         return key == key_ ? device_ : nullptr;
     }
 
+    /// Let go of the device while keeping the registry, which is the state a
+    /// chain edit leaves behind: the runtime is still there and the device is
+    /// not its any more.
+    void release() {
+        device_.reset();
+    }
+
   private:
     magda::engine::DeviceKey key_;
-    adapter::EngineExternalDevice* device_ = nullptr;
+    std::shared_ptr<adapter::EngineExternalDevice> device_;
     std::atomic<int>* asked_ = nullptr;
 };
 
 /// A registry with nothing in it.
 class EmptyRegistry final : public adapter::DeviceRegistry {
   public:
-    adapter::EngineExternalDevice* find(magda::engine::DeviceKey) const override {
+    std::shared_ptr<adapter::EngineExternalDevice> find(magda::engine::DeviceKey) const override {
         return nullptr;
     }
 };
+
+/// The device an adaptation produced, owned the way a runtime owns one.
+///
+/// The factory hands back the base type by unique_ptr, and what a registry
+/// lends out is a lease on the external device underneath it, so the cast and
+/// the change of ownership happen once here rather than in every case.
+std::shared_ptr<adapter::EngineExternalDevice> ownedExternalDevice(
+    adapter::ExternalDeviceResult& result) {
+    auto* external = dynamic_cast<adapter::EngineExternalDevice*>(result.device.get());
+    if (external == nullptr)
+        return nullptr;
+
+    result.device.release();
+    return std::shared_ptr<adapter::EngineExternalDevice>(external);
+}
 
 magda::DeviceInfo externalDevice() {
     magda::DeviceInfo device;
@@ -2562,7 +2587,7 @@ TEST_CASE("A capture through the control plane answers with what the plugin hold
     // holds and what the plugin holds now.
     raw->tone->setValue(0.4f);
 
-    auto* external = dynamic_cast<adapter::EngineExternalDevice*>(result.device.get());
+    const auto external = ownedExternalDevice(result);
     REQUIRE(external != nullptr);
 
     const magda::engine::DeviceKey key{magda::ChainSegment::Fx, model.id};
@@ -2607,7 +2632,7 @@ TEST_CASE("A plugin that will not describe itself is a failure with a reason",
     auto result = adapter::adaptExternalPluginInstance(std::move(plugin), model);
     REQUIRE(result.device != nullptr);
 
-    auto* external = dynamic_cast<adapter::EngineExternalDevice*>(result.device.get());
+    const auto external = ownedExternalDevice(result);
     REQUIRE(external != nullptr);
 
     const auto registry = std::make_shared<const OneDeviceRegistry>(
@@ -2728,7 +2753,7 @@ TEST_CASE("A capture runs and answers on the plane's executor", "[engine][extern
     auto result = adapter::adaptExternalPluginInstance(std::move(plugin), model);
     REQUIRE(result.device != nullptr);
 
-    auto* external = dynamic_cast<adapter::EngineExternalDevice*>(result.device.get());
+    const auto external = ownedExternalDevice(result);
     REQUIRE(external != nullptr);
 
     auto executor = std::make_shared<adapter::SerialControlThread>();
@@ -2764,7 +2789,7 @@ TEST_CASE("A capture asked for on the executor is queued behind what asked for i
     auto result = adapter::adaptExternalPluginInstance(std::move(plugin), model);
     REQUIRE(result.device != nullptr);
 
-    auto* external = dynamic_cast<adapter::EngineExternalDevice*>(result.device.get());
+    const auto external = ownedExternalDevice(result);
     REQUIRE(external != nullptr);
 
     auto executor = std::make_shared<adapter::SerialControlThread>();
@@ -2797,6 +2822,52 @@ TEST_CASE("A capture asked for on the executor is queued behind what asked for i
     CHECK(answered);
 }
 
+TEST_CASE("A device let go of mid-capture is still the one being read",
+          "[engine][external][control]") {
+    // What the lease is for, and what holding the registry alive never proved.
+    // A registry can carry on while a device leaves it -- a chain edited, a
+    // slot emptied -- and a capture that had been handed a bare pointer would
+    // be reading a plugin that had gone. So find() hands over the device rather
+    // than pointing at it, and the operation holds it until it is finished.
+    auto plugin = std::make_unique<StubPlugin>(2, 2, 0);
+    auto* raw = plugin.get();
+
+    auto model = externalDevice();
+    auto result = adapter::adaptExternalPluginInstance(std::move(plugin), model);
+    REQUIRE(result.device != nullptr);
+
+    auto external = ownedExternalDevice(result);
+    REQUIRE(external != nullptr);
+
+    const magda::engine::DeviceKey key{magda::ChainSegment::Fx, model.id};
+    auto registry = std::make_shared<OneDeviceRegistry>(key, external);
+
+    // From here the registry is the only owner, so what happens next is the
+    // device being destroyed rather than merely unregistered.
+    std::weak_ptr<adapter::EngineExternalDevice> watch = external;
+    external.reset();
+
+    // Let go of halfway through describing itself, which is the moment a bare
+    // pointer would become stale in.
+    raw->whileDescribingItself = [&registry] { registry->release(); };
+
+    auto executor = std::make_shared<adapter::SerialControlThread>();
+    adapter::LocalDeviceControlPlane plane(executor, registry);
+
+    const auto answered = capture(plane, key);
+    CHECK(answered.ok());
+
+    // And once the operation is over, so is the lease. Drained by asking for
+    // one more thing, because the work holding it is destroyed at the end of
+    // its own turn rather than when its callback fired.
+    std::promise<void> drained;
+    auto emptied = drained.get_future();
+    REQUIRE(executor->run([&drained](adapter::ExecutionState) { drained.set_value(); }));
+    emptied.wait();
+
+    CHECK(watch.expired());
+}
+
 TEST_CASE("A capture queued before its registry went is answered rather than run",
           "[engine][external][control]") {
     // The hazard of being genuinely asynchronous. Between queueing a capture
@@ -2814,7 +2885,7 @@ TEST_CASE("A capture queued before its registry went is answered rather than run
     auto result = adapter::adaptExternalPluginInstance(std::move(plugin), model);
     REQUIRE(result.device != nullptr);
 
-    auto* external = dynamic_cast<adapter::EngineExternalDevice*>(result.device.get());
+    const auto external = ownedExternalDevice(result);
     REQUIRE(external != nullptr);
 
     auto executor = std::make_shared<adapter::SerialControlThread>();
@@ -2871,7 +2942,7 @@ TEST_CASE("Two captures of one device do not overlap", "[engine][external][contr
     auto result = adapter::adaptExternalPluginInstance(std::move(plugin), model);
     REQUIRE(result.device != nullptr);
 
-    auto* external = dynamic_cast<adapter::EngineExternalDevice*>(result.device.get());
+    const auto external = ownedExternalDevice(result);
     REQUIRE(external != nullptr);
 
     std::atomic<int> inside{0};

--- a/tests/engine/test_engine_external_device.cpp
+++ b/tests/engine/test_engine_external_device.cpp
@@ -7,6 +7,7 @@
 #include <memory>
 #include <optional>
 #include <stdexcept>
+#include <thread>
 #include <vector>
 
 #include "core/ParameterInfo.hpp"
@@ -487,6 +488,37 @@ magda::engine::RenderContext contextFor(int channels = 2, int blockSize = 64) {
 
 /// A device whose parameters are the fork's list: the wrapper pair at zero and
 /// one, then the plugin's automatable parameters.
+/**
+ * @brief A message manager for the length of one test, where the binary has
+ *        none (#2270).
+ *
+ * This target is headless: nothing here has a message thread, which is the
+ * state the control plane is required not to refuse. The one case that is about
+ * being on the wrong thread needs a right one to exist first, and it must not
+ * leave it behind -- a manager that outlives the test is reported as a leaked
+ * object by whatever runs next, which is a complaint about this file rather
+ * than about the run.
+ *
+ * Only deleted if it was made here. A manager another test created is that
+ * test's, and deleting it would be answering a leak with a dangling singleton.
+ */
+struct ScopedMessageThread {
+    ScopedMessageThread() : mine_(juce::MessageManager::getInstanceWithoutCreating() == nullptr) {
+        juce::MessageManager::getInstance();
+    }
+
+    ~ScopedMessageThread() {
+        if (mine_)
+            juce::MessageManager::deleteInstance();
+    }
+
+    ScopedMessageThread(const ScopedMessageThread&) = delete;
+    ScopedMessageThread& operator=(const ScopedMessageThread&) = delete;
+
+  private:
+    bool mine_ = false;
+};
+
 magda::DeviceInfo externalDevice() {
     magda::DeviceInfo device;
     device.id = 7;
@@ -2511,9 +2543,9 @@ TEST_CASE("A capture through the control plane answers with what the plugin hold
     // still be true when it is not.
     REQUIRE(answered.has_value());
     REQUIRE(answered->ok());
-    CHECK(answered->failure.isEmpty());
+    CHECK(answered->failure().isEmpty());
 
-    magda::applyCapturedPluginState(model, *answered->snapshot);
+    magda::applyCapturedPluginState(model, answered->snapshot());
     CHECK(model.parameters[1].currentValue == Catch::Approx(0.4f));
 }
 
@@ -2533,11 +2565,11 @@ TEST_CASE("A key with no device bound is a failure rather than an empty state",
 
     REQUIRE(answered.has_value());
     CHECK_FALSE(answered->ok());
-    CHECK(answered->failure.contains("no plugin is bound"));
+    CHECK(answered->failure().contains("no plugin is bound"));
 
     // And it says which slot, because a host with a project's worth of devices
     // is holding a failure that has to name one of them.
-    CHECK(answered->failure.contains("12"));
+    CHECK(answered->failure().contains("12"));
 }
 
 TEST_CASE("A plugin that will not describe itself is a failure with a reason",
@@ -2563,7 +2595,7 @@ TEST_CASE("A plugin that will not describe itself is a failure with a reason",
 
     REQUIRE(answered.has_value());
     CHECK_FALSE(answered->ok());
-    CHECK(answered->failure.contains("could not describe itself"));
+    CHECK(answered->failure().contains("could not describe itself"));
 }
 
 TEST_CASE("A snapshot is written onto the assignment it was read from",
@@ -2578,7 +2610,9 @@ TEST_CASE("A snapshot is written onto the assignment it was read from",
     snapshot.pluginState = "what the plugin was holding";
 
     auto model = externalDevice();
-    CHECK(adapter::commitCapturedState(request, snapshot, model));
+    CHECK(adapter::commitCapturedState(request, snapshot, [&model](magda::engine::DeviceKey asked) {
+        return asked.deviceId == model.id ? &model : nullptr;
+    }));
     CHECK(model.pluginState == "what the plugin was holding");
 }
 
@@ -2601,7 +2635,8 @@ TEST_CASE("A snapshot read from an assignment that has been replaced is not writ
     auto model = externalDevice();
     model.pluginState = "what the slot holds now";
 
-    CHECK_FALSE(adapter::commitCapturedState(request, snapshot, model));
+    CHECK_FALSE(adapter::commitCapturedState(
+        request, snapshot, [&model](magda::engine::DeviceKey) { return &model; }));
     CHECK(model.pluginState == "what the slot holds now");
 }
 
@@ -2622,6 +2657,86 @@ TEST_CASE("A snapshot outliving the runtime that read it is not written",
     snapshot.pluginState = "read before the project closed";
 
     auto model = externalDevice();
-    CHECK_FALSE(adapter::commitCapturedState(request, snapshot, model));
+    CHECK_FALSE(adapter::commitCapturedState(
+        request, snapshot, [&model](magda::engine::DeviceKey) { return &model; }));
     CHECK(model.pluginState.isEmpty());
+}
+
+TEST_CASE("A snapshot is written onto the device its own token names",
+          "[engine][external][control]") {
+    // The half a token check does not do on its own. Validating one device and
+    // writing another would pass every test above it and still put one plugin's
+    // patch onto another's slot, so the device is resolved here from the
+    // request's own key rather than handed in beside it: what was checked and
+    // what is written are the same device by construction.
+    adapter::PluginAssignments assignments;
+    const magda::engine::DeviceKey key{magda::ChainSegment::Fx, 7};
+    assignments.replaceAssignment(key);
+
+    const auto request = assignments.request(key);
+
+    magda::ExternalPluginSnapshot snapshot;
+    snapshot.pluginState = "what the plugin was holding";
+
+    auto onTheSlot = externalDevice();
+    auto somewhereElse = externalDevice();
+    somewhereElse.id = 9;
+
+    std::vector<magda::engine::DeviceKey> asked;
+    CHECK(adapter::commitCapturedState(
+        request, snapshot, [&](magda::engine::DeviceKey key) -> magda::DeviceInfo* {
+            asked.push_back(key);
+            return key.deviceId == onTheSlot.id ? &onTheSlot : &somewhereElse;
+        }));
+
+    REQUIRE(asked.size() == 1);
+    CHECK(asked.front() == key);
+    CHECK(onTheSlot.pluginState == "what the plugin was holding");
+    CHECK(somewhereElse.pluginState.isEmpty());
+}
+
+TEST_CASE("A capture asked for off the message thread is refused", "[engine][external][control]") {
+    // The precondition the endpoint states, enforced where it can be. Everything
+    // past it reaches into somebody else's code: a plugin suspended and asked to
+    // describe itself is a message-thread transaction in every host there is,
+    // and a save dispatched from a worker would be doing it from the wrong one.
+    //
+    // Refused rather than marshalled, and refused before the lookup runs: the
+    // finding is the caller's thread, and a plane that went looking for a device
+    // first would report whichever complaint it met on the way.
+    //
+    // A message manager has to exist for there to be a wrong thread at all. A
+    // headless host has none and is not refused, which is the case every other
+    // test in this file runs under, so this one makes the manager and holds the
+    // message thread on the thread it is running on.
+    const ScopedMessageThread messageThread;
+
+    auto plugin = std::make_unique<StubPlugin>(2, 2, 0);
+    auto model = externalDevice();
+    auto result = adapter::adaptExternalPluginInstance(std::move(plugin), model);
+    REQUIRE(result.device != nullptr);
+
+    auto* external = dynamic_cast<adapter::EngineExternalDevice*>(result.device.get());
+    REQUIRE(external != nullptr);
+
+    bool lookedForADevice = false;
+    adapter::LocalDeviceControlPlane plane([&](magda::engine::DeviceKey) {
+        lookedForADevice = true;
+        return external;
+    });
+
+    std::optional<adapter::CaptureOutcome> answered;
+    const auto ask = [&] {
+        plane.captureState(
+            {magda::ChainSegment::Fx, model.id},
+            [&answered](adapter::CaptureOutcome outcome) { answered = std::move(outcome); });
+    };
+
+    std::thread worker(ask);
+    worker.join();
+
+    REQUIRE(answered.has_value());
+    CHECK_FALSE(answered->ok());
+    CHECK(answered->failure().contains("off the message thread"));
+    CHECK_FALSE(lookedForADevice);
 }

--- a/tests/engine/test_plugin_assignments.cpp
+++ b/tests/engine/test_plugin_assignments.cpp
@@ -115,7 +115,7 @@ TEST_CASE("A copy of a live device is not the device it was copied from",
 
     assignments.replaceAssignment(fx(2));
 
-    const adapter::LoadRequest ontoTheCopy{
+    const adapter::AssignmentRequest ontoTheCopy{
         .key = fx(2), .handle = sourceRequest.handle, .table = sourceRequest.table};
     CHECK_FALSE(ontoTheCopy.isStillWanted());
     CHECK(sourceRequest.isStillWanted());
@@ -131,10 +131,10 @@ TEST_CASE("Sections holding the same DeviceId hold different assignments",
 
     const auto request = assignments.request(fx(1));
 
-    CHECK_FALSE(
-        adapter::LoadRequest{.key = postFx(1), .handle = request.handle, .table = request.table}
-            .isStillWanted());
-    CHECK_FALSE(adapter::LoadRequest{
+    CHECK_FALSE(adapter::AssignmentRequest{
+        .key = postFx(1), .handle = request.handle, .table = request.table}
+                    .isStillWanted());
+    CHECK_FALSE(adapter::AssignmentRequest{
         .key = mixerAnalysis(1), .handle = request.handle, .table = request.table}
                     .isStillWanted());
 
@@ -175,7 +175,7 @@ TEST_CASE("A request outliving the whole runtime is refused", "[plugins][assignm
     // The project was closed while a plugin was loading. The completion still
     // arrives, and it must answer from what it holds rather than by reaching
     // into a destroyed registry.
-    adapter::LoadRequest request;
+    adapter::AssignmentRequest request;
     adapter::ActiveAssignment held;
     {
         adapter::PluginAssignments assignments;
@@ -195,5 +195,5 @@ TEST_CASE("A default-constructed request is refused", "[plugins][assignments]") 
     adapter::PluginAssignments assignments;
     assignments.replaceAssignment(fx(magda::INVALID_DEVICE_ID));
 
-    CHECK_FALSE(adapter::LoadRequest{}.isStillWanted());
+    CHECK_FALSE(adapter::AssignmentRequest{}.isStillWanted());
 }


### PR DESCRIPTION
Part of #1893, and the prerequisite that makes #1899 an add-on rather than a rewrite.

#1893 asks for one thing beyond parity: the device op contract is location-transparent from day one, so running a plugin in another process later is not a rework. The realtime half honoured it already — `magda::engine::EngineDevice` says nothing about where a device lives. The control half did not: everything that was not rendering reached the plugin through `EngineExternalDevice::instance()`, and a `juce::AudioPluginInstance&` is the one thing a plugin in another process cannot hand over.

It is also how the serialisation rule lost its owner. The two races found in the #2268 review were the same shape twice — an operation reaching the plugin from the control side while the audio side was reaching it too, with the policy spread across two APIs that do not know about each other.

## The device answers, and hands out no pointer

`EngineExternalDevice::captureState()` reads what the plugin holds; `instance()` is gone. The read itself is unchanged and still stated once in `ExternalPluginState.hpp` — what changes is that only the object holding the instance can perform it, and that object is the one already honouring the suspension inside `process()`. There is nothing left for a caller to remember.

## The endpoint

`DeviceControl.hpp`:

```cpp
class DeviceControlPlane {
    using CaptureCallback = std::function<void(CaptureOutcome)>;
    virtual void captureState(magda::engine::DeviceKey key, CaptureCallback completed) = 0;
};
```

Keyed by `DeviceKey`, which is the identity the plan and `PluginAssignments` already use, rather than by a reference to a live object. Asynchronous and fallible, because a remote implementation has IPC, a timeout and a device that can go away mid-call.

`LocalDeviceControlPlane` answers before it returns — the plugin is right here — and answers through the callback all the same: a caller that only worked when the answer arrived synchronously would only work in this process. It owns nothing; which device sits at a key is the runtime's business, so the lookup is handed in, the same arrangement the load path has with `CurrentDeviceLookup`.

A key with nothing bound is a **failure with a reason**, not an empty snapshot. Those are different findings — a slot whose plugin has not arrived, against a plugin that answered with nothing — and a host told the second when the first happened writes that absence into the project and loses the patch the slot is about to load.

## The commit

`commitCapturedState()` writes a snapshot onto a device only while the assignment it was read from still holds — the same boundary `completeExternalPluginLoad()` applies to the other direction, and for the same reason: between asking and answering, a slot can have been given a different plugin, or emptied, or the whole runtime can have gone.

The token both directions carry is therefore no longer called `LoadRequest`. It is an **`AssignmentRequest`**: one type, one check, rather than a convention each call site reimplements.

## What is deliberately not here

The editor window is the other caller that reaches for an instance. It does not exist on this path yet — MAGDA's plugin windows are still the fork's — and the header says where it goes when it arrives, which is behind this endpoint rather than a second accessor beside it.

## Tests

Six cases in `test_engine_external_device.cpp`: a capture through the plane answers with what the plugin holds; a key with nothing bound is a named failure; a plugin that will not describe itself is another; a snapshot is written onto the assignment it was read from, is refused when that assignment has been replaced, and is refused when the runtime that read it is gone. The existing save case now reads through the device rather than through its instance.

## Verification

Full Catch2 suite passes (740,373 assertions), the whole JUCE suite passes, and the app builds.

https://claude.ai/code/session_01Qa7GxDU184RGxo2b1Yhpa6
