### PR TITLE
Report scale and choices in devices.listParameters (#2286)

### DIFF
--- a/magda/daw/api/remote_api.cpp
+++ b/magda/daw/api/remote_api.cpp
@@ -4,6 +4,7 @@
 #include <cmath>
 #include <limits>
 
+#include "../core/PluginParameterConfigStore.hpp"
 #include "remote_handlers.hpp"
 
 namespace magda::remote {
@@ -1122,7 +1123,7 @@ juce::var toJson(const DeviceParameterDto& dto) {
     object->setProperty("defaultValue", dto.defaultValue);
     object->setProperty("currentValue", dto.currentValue);
     object->setProperty("normalizedValue", dto.normalizedValue);
-    object->setProperty("scale", dto.scale);
+    object->setProperty("scale", PluginParameterConfigStore::scaleToString(dto.scale));
     juce::Array<juce::var> choices;
     for (const auto& choice : dto.choices)
         choices.add(choice);
@@ -1408,7 +1409,7 @@ std::optional<DeviceParameterDto> deviceParameterFromJson(const juce::var& json,
     dto.defaultValue = static_cast<double>(json["defaultValue"]);
     dto.currentValue = static_cast<double>(json["currentValue"]);
     dto.normalizedValue = static_cast<double>(json["normalizedValue"]);
-    dto.scale = json["scale"].toString();
+    dto.scale = PluginParameterConfigStore::scaleFromString(json["scale"].toString());
     if (const auto* choices = json["choices"].getArray()) {
         for (const auto& choice : *choices)
             dto.choices.push_back(choice.toString());

--- a/magda/daw/api/remote_api.cpp
+++ b/magda/daw/api/remote_api.cpp
@@ -342,12 +342,16 @@ const juce::var& deviceParameterSchema() {
             "defaultValue":{"type":"number"},
             "currentValue":{"type":"number"},
             "normalizedValue":{"type":"number","minimum":0,"maximum":1},
+            "scale":{"type":"string",
+                     "enum":["linear","logarithmic","exponential","discrete","boolean","fader_db"]},
+            "choices":{"type":"array","items":{"type":"string"}},
             "visible":{"type":"boolean"},
             "miniMixer":{"type":"boolean"},
             "aiAgentEnabled":{"type":"boolean"}
         },
         "required":["index","stableId","name","unit","minValue","maxValue","defaultValue",
-                    "currentValue","normalizedValue","visible","miniMixer","aiAgentEnabled"],
+                    "currentValue","normalizedValue","scale","choices","visible","miniMixer",
+                    "aiAgentEnabled"],
         "additionalProperties":false
     })json");
     return value;
@@ -1118,6 +1122,11 @@ juce::var toJson(const DeviceParameterDto& dto) {
     object->setProperty("defaultValue", dto.defaultValue);
     object->setProperty("currentValue", dto.currentValue);
     object->setProperty("normalizedValue", dto.normalizedValue);
+    object->setProperty("scale", dto.scale);
+    juce::Array<juce::var> choices;
+    for (const auto& choice : dto.choices)
+        choices.add(choice);
+    object->setProperty("choices", choices);
     object->setProperty("visible", dto.visible);
     object->setProperty("miniMixer", dto.miniMixer);
     object->setProperty("aiAgentEnabled", dto.aiAgentEnabled);
@@ -1399,6 +1408,11 @@ std::optional<DeviceParameterDto> deviceParameterFromJson(const juce::var& json,
     dto.defaultValue = static_cast<double>(json["defaultValue"]);
     dto.currentValue = static_cast<double>(json["currentValue"]);
     dto.normalizedValue = static_cast<double>(json["normalizedValue"]);
+    dto.scale = json["scale"].toString();
+    if (const auto* choices = json["choices"].getArray()) {
+        for (const auto& choice : *choices)
+            dto.choices.push_back(choice.toString());
+    }
     dto.visible = static_cast<bool>(json["visible"]);
     dto.miniMixer = static_cast<bool>(json["miniMixer"]);
     dto.aiAgentEnabled = static_cast<bool>(json["aiAgentEnabled"]);

--- a/magda/daw/api/remote_api.hpp
+++ b/magda/daw/api/remote_api.hpp
@@ -10,6 +10,7 @@
 
 #include "../core/ChainNodePath.hpp"
 #include "../core/ClipTypes.hpp"
+#include "../core/ParameterInfo.hpp"
 #include "../core/TypeIds.hpp"
 #include "remote_scopes.hpp"
 
@@ -221,8 +222,7 @@ struct DeviceParameterDto {
     double defaultValue = 0.0;
     double currentValue = 0.0;
     double normalizedValue = 0.0;
-    juce::String
-        scale;  // "linear" | "logarithmic" | "exponential" | "discrete" | "boolean" | "fader_db"
+    ParameterScale scale = ParameterScale::Linear;  // serialized as the store's wire strings
     std::vector<juce::String> choices;  // labels for discrete parameters; empty otherwise
     bool visible = false;
     bool miniMixer = false;

--- a/magda/daw/api/remote_api.hpp
+++ b/magda/daw/api/remote_api.hpp
@@ -221,6 +221,9 @@ struct DeviceParameterDto {
     double defaultValue = 0.0;
     double currentValue = 0.0;
     double normalizedValue = 0.0;
+    juce::String
+        scale;  // "linear" | "logarithmic" | "exponential" | "discrete" | "boolean" | "fader_db"
+    std::vector<juce::String> choices;  // labels for discrete parameters; empty otherwise
     bool visible = false;
     bool miniMixer = false;
     bool aiAgentEnabled = false;

--- a/magda/daw/api/remote_api_projection.cpp
+++ b/magda/daw/api/remote_api_projection.cpp
@@ -367,7 +367,7 @@ std::vector<DeviceParameterDto> makeDeviceParameterDtos(const DeviceInfo& device
         dto.defaultValue = ParameterUtils::modelToRealValue({info.defaultValue}, info);
         dto.currentValue = ParameterUtils::normalizedToReal(normalized.value, info);
         dto.normalizedValue = normalized.value;
-        dto.scale = PluginParameterConfigStore::scaleToString(info.scale);
+        dto.scale = info.scale;
         dto.choices = info.choices;
         dto.visible = contains(device.visibleParameters, position);
         dto.miniMixer = contains(device.miniMixerParameters, position);

--- a/magda/daw/api/remote_api_projection.cpp
+++ b/magda/daw/api/remote_api_projection.cpp
@@ -5,6 +5,7 @@
 #include "../core/ClipInfo.hpp"
 #include "../core/DeviceInfo.hpp"
 #include "../core/ParameterUtils.hpp"
+#include "../core/PluginParameterConfigStore.hpp"
 #include "../core/RackInfo.hpp"
 #include "../core/TrackInfo.hpp"
 #include "../project/ProjectInfo.hpp"
@@ -366,6 +367,8 @@ std::vector<DeviceParameterDto> makeDeviceParameterDtos(const DeviceInfo& device
         dto.defaultValue = ParameterUtils::modelToRealValue({info.defaultValue}, info);
         dto.currentValue = ParameterUtils::normalizedToReal(normalized.value, info);
         dto.normalizedValue = normalized.value;
+        dto.scale = PluginParameterConfigStore::scaleToString(info.scale);
+        dto.choices = info.choices;
         dto.visible = contains(device.visibleParameters, position);
         dto.miniMixer = contains(device.miniMixerParameters, position);
         // Configure Parameters offers the AI opt-in only for external plugins;

--- a/magda/daw/core/PluginParameterConfigStore.cpp
+++ b/magda/daw/core/PluginParameterConfigStore.cpp
@@ -10,38 +10,6 @@
 namespace magda::PluginParameterConfigStore {
 namespace {
 
-juce::String scaleToXmlString(ParameterScale scale) {
-    switch (scale) {
-        case ParameterScale::Linear:
-            return "linear";
-        case ParameterScale::Logarithmic:
-            return "logarithmic";
-        case ParameterScale::Exponential:
-            return "exponential";
-        case ParameterScale::Discrete:
-            return "discrete";
-        case ParameterScale::Boolean:
-            return "boolean";
-        case ParameterScale::FaderDB:
-            return "fader_db";
-    }
-    return "linear";
-}
-
-ParameterScale xmlStringToScale(const juce::String& str) {
-    if (str == "logarithmic")
-        return ParameterScale::Logarithmic;
-    if (str == "exponential")
-        return ParameterScale::Exponential;
-    if (str == "discrete")
-        return ParameterScale::Discrete;
-    if (str == "boolean")
-        return ParameterScale::Boolean;
-    if (str == "fader_db")
-        return ParameterScale::FaderDB;
-    return ParameterScale::Linear;
-}
-
 /// The id a live device's config is filed under. Older devices carry only a
 /// pluginId, so it is the fallback rather than an error.
 juce::String configIdFor(const DeviceInfo& device) {
@@ -78,6 +46,38 @@ bool refreshFlatParameterConfig(const juce::String& uniqueId,
 
 }  // namespace
 
+juce::String scaleToString(ParameterScale scale) {
+    switch (scale) {
+        case ParameterScale::Linear:
+            return "linear";
+        case ParameterScale::Logarithmic:
+            return "logarithmic";
+        case ParameterScale::Exponential:
+            return "exponential";
+        case ParameterScale::Discrete:
+            return "discrete";
+        case ParameterScale::Boolean:
+            return "boolean";
+        case ParameterScale::FaderDB:
+            return "fader_db";
+    }
+    return "linear";
+}
+
+ParameterScale scaleFromString(const juce::String& name) {
+    if (name == "logarithmic")
+        return ParameterScale::Logarithmic;
+    if (name == "exponential")
+        return ParameterScale::Exponential;
+    if (name == "discrete")
+        return ParameterScale::Discrete;
+    if (name == "boolean")
+        return ParameterScale::Boolean;
+    if (name == "fader_db")
+        return ParameterScale::FaderDB;
+    return ParameterScale::Linear;
+}
+
 juce::File configFileFor(const juce::String& uniqueId) {
     return paths::pluginConfigsDir().getChildFile(uniqueId.replaceCharacters(":/\\,; ", "______") +
                                                   ".xml");
@@ -113,7 +113,7 @@ std::optional<PluginParameterConfig> load(const juce::String& uniqueId) {
             if (paramElem->hasAttribute("unit"))
                 entry.unit = paramElem->getStringAttribute("unit");
             if (paramElem->hasAttribute("scale"))
-                entry.scale = xmlStringToScale(paramElem->getStringAttribute("scale"));
+                entry.scale = scaleFromString(paramElem->getStringAttribute("scale"));
             if (paramElem->hasAttribute("min"))
                 entry.rangeMin = static_cast<float>(paramElem->getDoubleAttribute("min"));
             if (paramElem->hasAttribute("max"))
@@ -172,7 +172,7 @@ bool save(const juce::String& uniqueId, const PluginParameterConfig& config) {
         if (entry.unit)
             paramElem->setAttribute("unit", *entry.unit);
         if (entry.scale)
-            paramElem->setAttribute("scale", scaleToXmlString(*entry.scale));
+            paramElem->setAttribute("scale", scaleToString(*entry.scale));
         if (entry.rangeMin)
             paramElem->setAttribute("min", static_cast<double>(*entry.rangeMin));
         if (entry.rangeMax)

--- a/magda/daw/core/PluginParameterConfigStore.hpp
+++ b/magda/daw/core/PluginParameterConfigStore.hpp
@@ -52,6 +52,12 @@ struct PluginParameterConfig {
  */
 namespace PluginParameterConfigStore {
 
+/// The wire/XML name of a parameter scale ("linear", "logarithmic",
+/// "exponential", "discrete", "boolean", "fader_db"). One owner for the
+/// vocabulary shared by the config XML and the remote API.
+juce::String scaleToString(ParameterScale scale);
+ParameterScale scaleFromString(const juce::String& name);
+
 /// The config file for `uniqueId`, whether or not it exists yet.
 juce::File configFileFor(const juce::String& uniqueId);
 

--- a/tests/remote/test_remote_api_contract.cpp
+++ b/tests/remote/test_remote_api_contract.cpp
@@ -529,10 +529,10 @@ TEST_CASE("devices.listParameters projects real units and customization flags",
     REQUIRE(std::abs(parameters[1].normalizedValue - 0.25) < 1e-6);
 
     // A discrete parameter is interpretable, not just a number in a range.
-    REQUIRE(parameters[0].scale == "logarithmic");
-    REQUIRE(parameters[1].scale == "linear");
+    REQUIRE(parameters[0].scale == ParameterScale::Logarithmic);
+    REQUIRE(parameters[1].scale == ParameterScale::Linear);
     REQUIRE(parameters[1].choices.empty());
-    REQUIRE(parameters[2].scale == "discrete");
+    REQUIRE(parameters[2].scale == ParameterScale::Discrete);
     REQUIRE(parameters[2].choices == std::vector<juce::String>{"LP", "BP", "HP"});
 
     requireRoundTrip(parameters[0], deviceParameterFromJson);

--- a/tests/remote/test_remote_api_contract.cpp
+++ b/tests/remote/test_remote_api_contract.cpp
@@ -497,17 +497,20 @@ TEST_CASE("devices.listParameters projects real units and customization flags",
           "[remote-api][contract]") {
     DeviceInfo device;
     device.format = PluginFormat::VST3;
-    device.parameters.emplace_back(0, "Cutoff", "Hz", 20.0f, 20000.0f, 800.0f);
+    device.parameters.emplace_back(0, "Cutoff", "Hz", 20.0f, 20000.0f, 800.0f,
+                                   ParameterScale::Logarithmic);
     device.parameters.emplace_back(1, "Resonance", "%", 0.0f, 100.0f, 10.0f);
+    device.parameters.emplace_back(2, "Mode", "", 0.0f, 2.0f, 0.0f, ParameterScale::Discrete);
     device.parameters[0].stableId = "cutoff";
     device.parameters[0].currentValue = 800.0f;
     device.parameters[1].currentValue = 25.0f;
+    device.parameters[2].choices = {"LP", "BP", "HP"};
     device.visibleParameters = {0, 1};
     device.miniMixerParameters = {1};
     device.aiSoundDesignerParameters = {1};
 
     const auto parameters = makeDeviceParameterDtos(device);
-    REQUIRE(parameters.size() == 2);
+    REQUIRE(parameters.size() == 3);
 
     REQUIRE(parameters[0].index == 0);
     REQUIRE(parameters[0].stableId == "cutoff");
@@ -525,8 +528,16 @@ TEST_CASE("devices.listParameters projects real units and customization flags",
     REQUIRE(parameters[1].miniMixer);
     REQUIRE(std::abs(parameters[1].normalizedValue - 0.25) < 1e-6);
 
+    // A discrete parameter is interpretable, not just a number in a range.
+    REQUIRE(parameters[0].scale == "logarithmic");
+    REQUIRE(parameters[1].scale == "linear");
+    REQUIRE(parameters[1].choices.empty());
+    REQUIRE(parameters[2].scale == "discrete");
+    REQUIRE(parameters[2].choices == std::vector<juce::String>{"LP", "BP", "HP"});
+
     requireRoundTrip(parameters[0], deviceParameterFromJson);
     requireRoundTrip(parameters[1], deviceParameterFromJson);
+    requireRoundTrip(parameters[2], deviceParameterFromJson);
 }
 
 TEST_CASE("configured external parameters project model values into display units",


### PR DESCRIPTION
Closes #2286.

Adds `scale` (linear / logarithmic / exponential / discrete / boolean / fader_db) and `choices` (labels, empty for continuous parameters) to `DeviceParameterDto`, its schema, JSON codecs, and the projection. The scale↔string mapping moves from `PluginParameterConfigStore`'s anonymous namespace to its public API (`scaleToString` / `scaleFromString`) so the config XML and the remote wire share one vocabulary owner.

Live motivation from the #2274 test session: Surge XT's "A Filter 1 Type" reported `0..1, no unit`, forcing a client to set 0.5 blind instead of asking for a filter model by name.

Contract test extended with a discrete parameter (choices + scale asserted, round-tripped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)