### PR TITLE
Expose device add, remove, and move over MCP (#2284)

### DIFF
--- a/magda/daw/api/remote_api.cpp
+++ b/magda/daw/api/remote_api.cpp
@@ -1637,6 +1637,46 @@ OperationRegistry::OperationRegistry() {
     // its `catalogId` from — so what this lists is exactly what can be asked for.
     add("devices.catalog", "List devices that can be added, by catalogue id", OperationAccess::Read,
         &handlers::devicesCatalog, emptyObjectSchema(), arraySchema(deviceCatalogEntrySchema()));
+    add("devices.add", "Add a device from the catalogue to a track's FX chain or a rack chain",
+        OperationAccess::Write, &handlers::devicesAdd, operationInputSchema(R"json({
+            "type":"object",
+            "properties":{
+                "trackId":{"type":"integer","minimum":0},
+                "parentPath":{},
+                "catalogId":{"type":"string","minLength":1},
+                "index":{"type":"integer","minimum":-1}
+            },
+            "required":["catalogId"],"additionalProperties":false
+        })json"),
+        parseSchema(R"json({
+            "type":"object",
+            "properties":{"id":{"type":"integer","minimum":0},"devicePath":{}},
+            "required":["id","devicePath"],"additionalProperties":false
+        })json"));
+    operations_.back().inputSchema["properties"].getDynamicObject()->setProperty(
+        "parentPath", devicePathSchema());
+    operations_.back().outputSchema["properties"].getDynamicObject()->setProperty(
+        "devicePath", devicePathSchema());
+    add("devices.remove", "Remove a device", OperationAccess::Write, &handlers::devicesRemove,
+        operationInputSchema(R"json({
+            "type":"object","properties":{"devicePath":{}},
+            "required":["devicePath"],"additionalProperties":false
+        })json"),
+        okResult);
+    operations_.back().inputSchema["properties"].getDynamicObject()->setProperty(
+        "devicePath", devicePathSchema());
+    add("devices.move", "Move a device within its chain", OperationAccess::Write,
+        &handlers::devicesMove, operationInputSchema(R"json({
+            "type":"object",
+            "properties":{
+                "devicePath":{},
+                "toIndex":{"type":"integer","minimum":0}
+            },
+            "required":["devicePath","toIndex"],"additionalProperties":false
+        })json"),
+        okResult);
+    operations_.back().inputSchema["properties"].getDynamicObject()->setProperty(
+        "devicePath", devicePathSchema());
     // Parameter discovery and direct control (#2274). Values are real units on
     // both sides — discovery reports what a knob shows and setParameter takes
     // the same number back — with `normalizedValue` alongside so a client can
@@ -1896,6 +1936,9 @@ OperationRegistry::OperationRegistry() {
         {"racks.create", Scope::Edit},
         {"racks.remove", Scope::Edit},
         {"racks.setBypassed", Scope::Edit},
+        {"devices.add", Scope::Edit},
+        {"devices.remove", Scope::Edit},
+        {"devices.move", Scope::Edit},
         {"devices.setParameter", Scope::Edit},
         {"devices.setParameterConfig", Scope::Edit},
         // Opening a plugin editor changes no project content, but it takes

--- a/magda/daw/api/remote_handlers.cpp
+++ b/magda/daw/api/remote_handlers.cpp
@@ -492,6 +492,64 @@ HandlerResult devicesCatalog(MagdaApi& api, const juce::var&, const RequestConte
     return HandlerResult::ok(toJsonArray(items));
 }
 
+HandlerResult devicesAdd(MagdaApi& api, const juce::var& input, const RequestContext&) {
+    const auto catalogId = input["catalogId"].toString();
+    if (!api.devices().findCatalogEntry(catalogId).has_value())
+        return HandlerResult::fail(ErrorCode::NotFound, "no catalogue entry " + catalogId);
+
+    ChainNodePath parent;
+    if (const auto parentPath = input["parentPath"]; parentPath.isObject()) {
+        const auto resolved = toChainNodePath(devicePathFromJson(parentPath));
+        if (!resolved)
+            return HandlerResult::fail(ErrorCode::ValidationFailed, "parentPath does not resolve");
+        parent = *resolved;
+    } else if (has(input, "trackId")) {
+        const auto trackId = static_cast<TrackId>(static_cast<int>(input["trackId"]));
+        if (api.tracks().getTrack(trackId) == nullptr)
+            return notFound("track", trackId);
+        parent = ChainNodePath::trackLevel(trackId);
+    } else {
+        return HandlerResult::fail(ErrorCode::ValidationFailed,
+                                   "provide trackId (main FX chain) or parentPath (a chain)");
+    }
+
+    const auto id = api.devices().addDevice(parent, catalogId, readInt(input, "index", -1));
+    if (id == INVALID_DEVICE_ID)
+        return HandlerResult::fail(ErrorCode::Conflict, "device could not be added");
+
+    // The new device's address: a top-level id lives on the path root rather
+    // than as a step; a chain-hosted one extends the chain.
+    const auto devicePath = parent.getType() == ChainNodeType::Track
+                                ? ChainNodePath::topLevelDevice(parent.trackId, id)
+                                : parent.withDevice(id);
+    auto* object = new juce::DynamicObject();
+    object->setProperty("id", id);
+    object->setProperty("devicePath", toJson(makeDevicePathDto(devicePath)));
+    return HandlerResult::ok(juce::var(object));
+}
+
+HandlerResult devicesRemove(MagdaApi& api, const juce::var& input, const RequestContext&) {
+    const auto path = toChainNodePath(devicePathFromJson(input["devicePath"]));
+    if (!path)
+        return HandlerResult::fail(ErrorCode::ValidationFailed, "devicePath does not resolve");
+    if (api.devices().getDevice(*path) == nullptr)
+        return HandlerResult::fail(ErrorCode::NotFound, "no device at devicePath");
+    if (!api.devices().removeDevice(*path))
+        return HandlerResult::fail(ErrorCode::InternalError, "device removal failed");
+    return HandlerResult::ok(acceptedResult());
+}
+
+HandlerResult devicesMove(MagdaApi& api, const juce::var& input, const RequestContext&) {
+    const auto path = toChainNodePath(devicePathFromJson(input["devicePath"]));
+    if (!path)
+        return HandlerResult::fail(ErrorCode::ValidationFailed, "devicePath does not resolve");
+    if (api.devices().getDevice(*path) == nullptr)
+        return HandlerResult::fail(ErrorCode::NotFound, "no device at devicePath");
+    if (!api.devices().moveDevice(*path, readInt(input, "toIndex", -1)))
+        return HandlerResult::fail(ErrorCode::Conflict, "device move failed");
+    return HandlerResult::ok(acceptedResult());
+}
+
 HandlerResult devicesListParameters(MagdaApi& api, const juce::var& input, const RequestContext&) {
     const auto path = toChainNodePath(devicePathFromJson(input["devicePath"]));
     if (!path)

--- a/magda/daw/api/remote_handlers.hpp
+++ b/magda/daw/api/remote_handlers.hpp
@@ -49,6 +49,9 @@ HandlerResult clipsDelete(MagdaApi&, const juce::var&, const RequestContext&);
 // Devices and racks
 HandlerResult devicesList(MagdaApi&, const juce::var&, const RequestContext&);
 HandlerResult devicesCatalog(MagdaApi&, const juce::var&, const RequestContext&);
+HandlerResult devicesAdd(MagdaApi&, const juce::var&, const RequestContext&);
+HandlerResult devicesRemove(MagdaApi&, const juce::var&, const RequestContext&);
+HandlerResult devicesMove(MagdaApi&, const juce::var&, const RequestContext&);
 HandlerResult devicesListParameters(MagdaApi&, const juce::var&, const RequestContext&);
 HandlerResult devicesSetParameter(MagdaApi&, const juce::var&, const RequestContext&);
 HandlerResult devicesSetParameterConfig(MagdaApi&, const juce::var&, const RequestContext&);

--- a/magda/daw/core/ConsoleRouting.cpp
+++ b/magda/daw/core/ConsoleRouting.cpp
@@ -160,6 +160,7 @@ const std::vector<AgentSurface>& registeredAgentSurfaces() {
                               Provider::TrackSummaries, Provider::DeviceSummaries,
                               Provider::Conversation},
          .toolAllowlist = {"project.get", "tracks.list", "tracks.get", "devices.list",
+                           "devices.catalog", "devices.add", "devices.remove", "devices.move",
                            "devices.listParameters", "devices.setParameter",
                            "devices.setParameterConfig", "devices.openEditor", "racks.create",
                            "racks.remove", "racks.setBypassed", "selection.get", "selection.set"},

--- a/tests/remote/test_remote_api_contract.cpp
+++ b/tests/remote/test_remote_api_contract.cpp
@@ -43,6 +43,9 @@ TEST_CASE("Remote API registry is versioned, discoverable, and unique", "[remote
     REQUIRE(registry.find("devices.listParameters") != nullptr);
     REQUIRE(registry.find("devices.setParameter") != nullptr);
     REQUIRE(registry.find("devices.setParameterConfig") != nullptr);
+    REQUIRE(registry.find("devices.add") != nullptr);
+    REQUIRE(registry.find("devices.remove") != nullptr);
+    REQUIRE(registry.find("devices.move") != nullptr);
     REQUIRE(registry.find("devices.openEditor") != nullptr);
     REQUIRE(registry.find("session.launchClip") != nullptr);
     REQUIRE(registry.find("automation.addPoint") != nullptr);

--- a/tests/remote/test_remote_service.cpp
+++ b/tests/remote/test_remote_service.cpp
@@ -895,3 +895,56 @@ TEST_CASE("devices.setParameter converts display units to the model domain",
     REQUIRE(api.devices_.parameterWrites.size() == 1);
     REQUIRE(std::abs(std::get<2>(api.devices_.parameterWrites.front()) - 0.75f) < 1e-6f);
 }
+
+TEST_CASE("devices.add creates a device and returns its address", "[remote][service][devices]") {
+    const MessageThreadRelaxation relaxation;
+    MockMagdaApi api;
+    TrackInfo track;
+    track.id = 1;
+    api.tracks_.tracks.push_back(track);
+    api.devices_.catalog.push_back({"internal.filter", "Filter", "", "", "", PluginFormat::Internal,
+                                    DeviceType::Effect, false});
+    RemoteApiService service(api);
+
+    const auto response =
+        run(service, "devices.add", object({{"trackId", 1}, {"catalogId", "internal.filter"}}));
+
+    REQUIRE(response.ok);
+    const auto id = static_cast<int>(response.result["id"]);
+    REQUIRE(id != INVALID_DEVICE_ID);
+    // The returned address is the canonical top-level spelling.
+    REQUIRE(static_cast<int>(response.result["devicePath"]["topLevelDeviceId"]) == id);
+    REQUIRE(response.result["devicePath"]["section"].toString() == "fx");
+    REQUIRE(api.devices_.added.size() == 1);
+    REQUIRE(api.devices_.added.front().catalogId == "internal.filter");
+
+    const auto unknown =
+        run(service, "devices.add", object({{"trackId", 1}, {"catalogId", "no.such.device"}}));
+    REQUIRE_FALSE(unknown.ok);
+    REQUIRE(errorCodeOf(unknown) == "not_found");
+}
+
+TEST_CASE("devices.remove and devices.move act on resolvable paths only",
+          "[remote][service][devices]") {
+    const MessageThreadRelaxation relaxation;
+    MockMagdaApi api;
+    const auto path = ChainNodePath::topLevelDevice(1, 5);
+    api.devices_.devices[path] = makeFilterDevice();
+    RemoteApiService service(api);
+
+    auto move = pathInput(path);
+    move.getDynamicObject()->setProperty("toIndex", 2);
+    const auto moved = run(service, "devices.move", move);
+    REQUIRE(moved.ok);
+    REQUIRE(api.devices_.moved.size() == 1);
+
+    const auto removed = run(service, "devices.remove", pathInput(path));
+    REQUIRE(removed.ok);
+    REQUIRE(static_cast<bool>(removed.result["accepted"]));
+    REQUIRE(api.devices_.removed.size() == 1);
+
+    const auto missing =
+        run(service, "devices.remove", pathInput(ChainNodePath::topLevelDevice(1, 99)));
+    REQUIRE_FALSE(missing.ok);
+    REQUIRE(errorCodeOf(missing) == "not_found");
+}

--- a/tests/routing/test_console_routing.cpp
+++ b/tests/routing/test_console_routing.cpp
@@ -47,6 +47,8 @@ TEST_CASE("agent surface registry has distinct bounded capabilities", "[console_
     REQUIRE(containsTool(device, "devices.listParameters"));
     REQUIRE(containsTool(device, "devices.setParameter"));
     REQUIRE(containsTool(device, "devices.setParameterConfig"));
+    REQUIRE(containsTool(device, "devices.add"));
+    REQUIRE(containsTool(device, "devices.remove"));
     REQUIRE(containsTool(device, "devices.openEditor"));
     REQUIRE_FALSE(containsTool(device, "tracks.update"));
 


### PR DESCRIPTION
Closes #2284. Stacked on #2289.

- **`devices.add`** (write, edit): `{catalogId, trackId | parentPath, index?}` → `{id, devicePath}`. The catalogue id comes from `devices.catalog`; `trackId` targets the main FX chain, `parentPath` a rack chain at any depth. The returned `devicePath` is the canonical spelling (top-level id on the path root, chain-hosted as a device step) so the client can immediately address the new device.
- **`devices.remove`** (write, edit): `{devicePath}` → `{accepted}`.
- **`devices.move`** (write, edit): `{devicePath, toIndex}` → `{accepted}`.

All three are thin handlers over the pre-existing `DeviceApi::addDevice` / `removeDevice` / `moveDevice`, which were implemented (live + mock, undoable commands) but never registered. The DevicePanel agent surface allowlists them plus `devices.catalog` — previously it had no way to discover what could be added.

Motivation from the #2274 live session: deleting and recreating a Surge XT instance over MCP was impossible; the user had to do it in the UI.

Dispatch tests cover create-with-address, unknown catalogue id, move/remove success, and unresolvable-path refusal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)