### PR TITLE
Accept both spellings of a top-level device in engine lookups (#2288)

### DIFF
--- a/magda/daw/audio/AudioBridge.cpp
+++ b/magda/daw/audio/AudioBridge.cpp
@@ -569,6 +569,10 @@ void AudioBridge::deviceParameterChanged(const ChainNodePath& devicePath, int pa
     // A single device parameter changed - sync only that parameter to processor
     auto* processor = getDeviceProcessor(devicePath);
     if (!processor) {
+        // The model updated and the caller was told ok, but nothing reached
+        // the engine. Say so rather than dropping the write silently (#2288).
+        DBG("AudioBridge: dropping parameter change for device " << devicePath.getDeviceId()
+                                                                 << " - no processor");
         return;
     }
 

--- a/magda/daw/audio/plugin_manager/PluginManager.cpp
+++ b/magda/daw/audio/plugin_manager/PluginManager.cpp
@@ -165,12 +165,14 @@ PluginManager::PluginManager(te::Engine& engine, te::Edit& edit, TrackController
 
 PluginManager::SyncedDeviceMap::iterator PluginManager::findSyncedDevice(
     const ChainNodePath& devicePath) {
-    return syncedDevices_.find(devicePath);
+    // Entries are keyed by the canonical spelling; the model layer accepts
+    // both spellings of a top-level device, so lookups must too (#2288).
+    return syncedDevices_.find(devicePath.normalized());
 }
 
 PluginManager::SyncedDeviceMap::const_iterator PluginManager::findSyncedDevice(
     const ChainNodePath& devicePath) const {
-    return syncedDevices_.find(devicePath);
+    return syncedDevices_.find(devicePath.normalized());
 }
 
 void PluginManager::prepareForChainElementMove(const ChainNodePath& sourceElementPath,
@@ -231,7 +233,15 @@ te::Plugin::Ptr PluginManager::getPlugin(const ChainNodePath& devicePath) const 
 DeviceProcessor* PluginManager::getDeviceProcessor(const ChainNodePath& devicePath) const {
     juce::ScopedLock lock(pluginLock_);
     auto it = findSyncedDevice(devicePath);
-    return it != syncedDevices_.end() ? it->second.processor.get() : nullptr;
+    if (it == syncedDevices_.end())
+        return nullptr;
+    if (it->second.processor == nullptr) {
+        // The entry exists but async load failed or is still pending: every
+        // host parameter write to this device is currently being dropped.
+        DBG("PluginManager: device " << devicePath.getDeviceId()
+                                     << " has no processor (load failed or pending)");
+    }
+    return it->second.processor.get();
 }
 
 DeviceId PluginManager::getDeviceIdForPlugin(te::Plugin* plugin) const {

--- a/magda/daw/core/ChainNodePath.hpp
+++ b/magda/daw/core/ChainNodePath.hpp
@@ -343,6 +343,21 @@ struct ChainNodePath {
         return extendedWith({ChainStepType::Device, d});
     }
 
+    /**
+     * @brief The canonical spelling of this address.
+     *
+     * A top-level FX device can be written two ways — `topLevelDeviceId` on
+     * the root, or a single Device step — and the model layer accepts both.
+     * Map keys must not: this collapses the step spelling onto the
+     * `topLevelDevice` form and leaves every other path untouched.
+     */
+    ChainNodePath normalized() const {
+        if (topLevelDeviceId == INVALID_DEVICE_ID && !isTrackLevel && steps.size() == 1 &&
+            steps.front().type == ChainStepType::Device)
+            return topLevelDevice(trackId, steps.front().id);
+        return *this;
+    }
+
     // Get the parent path (without the last step)
     ChainNodePath parent() const {
         ChainNodePath p = *this;

--- a/tests/devices/test_chain_node_path_drag.cpp
+++ b/tests/devices/test_chain_node_path_drag.cpp
@@ -110,3 +110,23 @@ TEST_CASE("An invalid path is never handed to a drop handler", "[ui][drag][chain
 
     REQUIRE_FALSE(readChainNodePathFromDragInfo(*info.getDynamicObject()).has_value());
 }
+
+TEST_CASE("normalized collapses the step spelling of a top-level device", "[chain][path]") {
+    // The model accepts both spellings of a top-level FX device; map keys are
+    // canonical. normalized() is what lets an engine lookup accept either.
+    magda::ChainNodePath stepSpelling;
+    stepSpelling.trackId = 3;
+    stepSpelling.steps.push_back({magda::ChainStepType::Device, 7});
+
+    REQUIRE(stepSpelling.normalized() == magda::ChainNodePath::topLevelDevice(3, 7));
+
+    // Canonical, nested, sectioned, and track-level paths pass through.
+    const auto canonical = magda::ChainNodePath::topLevelDevice(3, 7);
+    REQUIRE(canonical.normalized() == canonical);
+    const auto nested = magda::ChainNodePath::chainDevice(3, 1, 2, 7);
+    REQUIRE(nested.normalized() == nested);
+    const auto postFx = magda::ChainNodePath::postFxDevice(3, 7);
+    REQUIRE(postFx.normalized() == postFx);
+    const auto track = magda::ChainNodePath::trackLevel(3);
+    REQUIRE(track.normalized() == track);
+}


### PR DESCRIPTION
Closes #2288. Stacked on #2290.

`TrackManager::getDeviceInChainByPath` accepts a top-level FX device as either `topLevelDeviceId=N` or `steps=[{device,N}]`, but `PluginManager::syncedDevices_` keys only the first spelling, and `getDeviceProcessor` was a strict map lookup. A host parameter write addressed with the step spelling therefore validated, mutated the model, and echoed success while `AudioBridge::deviceParameterChanged` silently dropped it.

- New `ChainNodePath::normalized()` collapses the step spelling onto the canonical `topLevelDevice` form (identity for canonical, nested, sectioned, and track-level paths — unit-tested).
- `PluginManager::findSyncedDevice` normalizes before lookup, so `getPlugin`, `getDeviceProcessor`, and every other consumer accept either spelling uniformly.
- The two silent-drop sites now log, distinguishing "no map entry" from "entry whose async plugin load failed and never produced a processor" — the second reachable case from the issue.

Not included: propagating a "consumed by engine" signal into the `devices.setParameter` response — left open on the issue as a possible follow-up, since it changes the operation's success semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)