### PR TITLE
Retry rate-limited requests in the MCP bridge with bounded backoff (#2287)

### DIFF
--- a/magda/mcp_bridge/main.cpp
+++ b/magda/mcp_bridge/main.cpp
@@ -32,6 +32,7 @@
 
 #include <algorithm>
 #include <atomic>
+#include <chrono>
 #include <cstdlib>
 #include <iostream>
 #include <map>
@@ -363,6 +364,19 @@ class Bridge {
         }
 
         auto result = client->Post(endpoint.path, headers, body, "application/json");
+
+        // The endpoint admits requests from a token bucket, so a legitimate
+        // burst — an agent sweeping a dozen parameters — sees HTTP 429 partway
+        // through. That refusal is retryable by construction (tokens return
+        // with wall-clock, ~50/s), and most stdio hosts treat any error as
+        // terminal, so absorb it here with a bounded backoff. The bound keeps a
+        // genuinely saturated server visible instead of hidden forever.
+        for (int delayMs = 100;
+             result && result->status == httplib::StatusCode::TooManyRequests_429 && delayMs <= 800;
+             delayMs *= 2) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(delayMs));
+            result = client->Post(endpoint.path, headers, body, "application/json");
+        }
 
         if (!result) {
             // Connection refused or reset: MAGDA is gone or was restarted. Worth

--- a/tests/remote/test_remote_mcp_bridge.cpp
+++ b/tests/remote/test_remote_mcp_bridge.cpp
@@ -361,6 +361,37 @@ TEST_CASE("A legacy session survives MAGDA restarting under it", "[remote][mcp-b
     dataDir.deleteRecursively();
 }
 
+TEST_CASE("The bridge absorbs rate-limit refusals with backoff", "[remote][mcp-bridge]") {
+    // The endpoint's token bucket refuses a burst partway through (burst =
+    // maxConcurrentRequests). A stdio host treats errors as terminal, so the
+    // bridge retries 429s itself; every call in a modest burst must answer.
+    const MessageThreadRelaxation relaxation;
+    MockMagdaApi api;
+    RemoteApiService service(api);
+
+    auto options = serverOptions();
+    options.maxConcurrentRequests = 2;    // burst of 2 tokens
+    options.maxRequestsPerSecond = 20.0;  // one token back every 50ms
+    RemoteMcpServer server(service, options);
+    REQUIRE(server.start());
+
+    juce::TemporaryFile scratch;
+    const auto dataDir = scratch.getFile().getSiblingFile("magda-bridge-rate-limit");
+    writeRecord(dataDir, server.boundPort(), kToken);
+    BridgeProcess bridge(dataDir);
+
+    for (int id = 1; id <= 8; ++id) {
+        bridge.send(request(id, "ping", modernParams()));
+        const auto response = bridge.receive();
+        INFO("request " << id);
+        REQUIRE(response.getDynamicObject() != nullptr);
+        REQUIRE(static_cast<int>(response["id"]) == id);
+        REQUIRE(response["error"].isVoid());
+    }
+
+    dataDir.deleteRecursively();
+}
+
 TEST_CASE("With no MAGDA running, the bridge says so rather than hanging", "[remote][mcp-bridge]") {
     juce::TemporaryFile scratch;
     const auto dataDir = scratch.getFile().getSiblingFile("magda-bridge-empty");


### PR DESCRIPTION
Closes #2287. Stacked on #2291.

Root cause (details on the issue): the MCP server's token bucket has burst capacity `maxConcurrentRequests` (8) with 50/s refill, so a fresh session's `initialize` + `initialized` + 6 tool calls exhaust the burst and the 7th tool call gets HTTP 429 — a structured refusal, but one most stdio MCP hosts surface as a terminal error.

Fix at the bridge, per the issue's option 2: `magda-mcp` retries 429s with bounded exponential backoff (100/200/400/800 ms). Bursts from agent workflows are absorbed transparently; a genuinely saturated server still surfaces after ~1.5s of refusals. The server-side bound is unchanged.

Regression test runs the real bridge binary against a server configured with a burst of 2 and 20/s refill, and requires all 8 rapid sequential calls to answer without error. Verified negatively: disabling the retry loop fails the test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)