### PR TITLE
Round out the MCP device surface (#2284–#2288)

### DIFF
--- a/magda/daw/api/device_api.hpp
+++ b/magda/daw/api/device_api.hpp
@@ -56,6 +56,23 @@ struct DeviceParameter {
 };
 
 /**
+ * @brief Detection-data overrides for one parameter.
+ *
+ * The same fields Configure Parameters' AI-Detect writes: display unit,
+ * scale, display range, and discrete choice labels. Present fields replace
+ * the saved value; absent fields keep it. `index` is a position in
+ * `DeviceInfo::parameters`.
+ */
+struct DeviceParameterOverride {
+    int index = -1;
+    std::optional<juce::String> unit;
+    std::optional<ParameterScale> scale;
+    std::optional<float> minValue;
+    std::optional<float> maxValue;
+    std::optional<std::vector<juce::String>> choices;
+};
+
+/**
  * @brief A partial update to a device's saved parameter customization.
  *
  * Each present field replaces that selection wholesale — an empty vector
@@ -67,6 +84,7 @@ struct DeviceParameterConfigUpdate {
     std::optional<std::vector<int>> miniMixerParameters;
     std::optional<std::vector<int>> aiAgentParameters;
     std::optional<juce::String> aiPrompt;
+    std::optional<std::vector<DeviceParameterOverride>> parameterOverrides;
 };
 
 /**

--- a/magda/daw/api/device_api_live.cpp
+++ b/magda/daw/api/device_api_live.cpp
@@ -274,6 +274,17 @@ bool DeviceApiLive::setDeviceParameterConfig(const ChainNodePath& devicePath,
     if (!inRange(update.visibleParameters) || !inRange(update.miniMixerParameters) ||
         !inRange(update.aiAgentParameters))
         return false;
+    if (update.parameterOverrides) {
+        for (const auto& override_ : *update.parameterOverrides) {
+            if (override_.index < 0 || override_.index >= count)
+                return false;
+            const auto& info = device->parameters[static_cast<size_t>(override_.index)];
+            const auto effectiveMin = override_.minValue.value_or(info.minValue);
+            const auto effectiveMax = override_.maxValue.value_or(info.maxValue);
+            if (effectiveMin >= effectiveMax)
+                return false;
+        }
+    }
 
     // Start from the device's own parameters so every one has an entry, then
     // overlay whatever was saved — a legacy file listing three indices must
@@ -300,6 +311,28 @@ bool DeviceApiLive::setDeviceParameterConfig(const ChainNodePath& devicePath,
     applySelection(update.aiAgentParameters, &PluginParameterConfigEntry::aiAgent);
     if (update.aiPrompt)
         config.aiPrompt = *update.aiPrompt;
+    if (update.parameterOverrides) {
+        for (const auto& override_ : *update.parameterOverrides) {
+            auto& entry = config.entries[static_cast<size_t>(override_.index)];
+            if (override_.unit)
+                entry.unit = *override_.unit;
+            if (override_.scale)
+                entry.scale = *override_.scale;
+            if (override_.minValue)
+                entry.rangeMin = *override_.minValue;
+            if (override_.maxValue)
+                entry.rangeMax = *override_.maxValue;
+            // A new display range moves the anchor the way a fresh AI-Detect
+            // would: to its midpoint.
+            if (override_.minValue || override_.maxValue) {
+                const auto low = entry.rangeMin.value_or(0.0f);
+                const auto high = entry.rangeMax.value_or(1.0f);
+                entry.rangeCenter = (low + high) * 0.5f;
+            }
+            if (override_.choices)
+                entry.choices = *override_.choices;
+        }
+    }
 
     if (!PluginParameterConfigStore::save(uniqueId, config))
         return false;

--- a/magda/daw/api/remote_api.cpp
+++ b/magda/daw/api/remote_api.cpp
@@ -4,6 +4,7 @@
 #include <cmath>
 #include <limits>
 
+#include "../core/PluginParameterConfigStore.hpp"
 #include "remote_handlers.hpp"
 
 namespace magda::remote {
@@ -342,12 +343,16 @@ const juce::var& deviceParameterSchema() {
             "defaultValue":{"type":"number"},
             "currentValue":{"type":"number"},
             "normalizedValue":{"type":"number","minimum":0,"maximum":1},
+            "scale":{"type":"string",
+                     "enum":["linear","logarithmic","exponential","discrete","boolean","fader_db"]},
+            "choices":{"type":"array","items":{"type":"string"}},
             "visible":{"type":"boolean"},
             "miniMixer":{"type":"boolean"},
             "aiAgentEnabled":{"type":"boolean"}
         },
         "required":["index","stableId","name","unit","minValue","maxValue","defaultValue",
-                    "currentValue","normalizedValue","visible","miniMixer","aiAgentEnabled"],
+                    "currentValue","normalizedValue","scale","choices","visible","miniMixer",
+                    "aiAgentEnabled"],
         "additionalProperties":false
     })json");
     return value;
@@ -1118,6 +1123,11 @@ juce::var toJson(const DeviceParameterDto& dto) {
     object->setProperty("defaultValue", dto.defaultValue);
     object->setProperty("currentValue", dto.currentValue);
     object->setProperty("normalizedValue", dto.normalizedValue);
+    object->setProperty("scale", PluginParameterConfigStore::scaleToString(dto.scale));
+    juce::Array<juce::var> choices;
+    for (const auto& choice : dto.choices)
+        choices.add(choice);
+    object->setProperty("choices", choices);
     object->setProperty("visible", dto.visible);
     object->setProperty("miniMixer", dto.miniMixer);
     object->setProperty("aiAgentEnabled", dto.aiAgentEnabled);
@@ -1399,6 +1409,11 @@ std::optional<DeviceParameterDto> deviceParameterFromJson(const juce::var& json,
     dto.defaultValue = static_cast<double>(json["defaultValue"]);
     dto.currentValue = static_cast<double>(json["currentValue"]);
     dto.normalizedValue = static_cast<double>(json["normalizedValue"]);
+    dto.scale = PluginParameterConfigStore::scaleFromString(json["scale"].toString());
+    if (const auto* choices = json["choices"].getArray()) {
+        for (const auto& choice : *choices)
+            dto.choices.push_back(choice.toString());
+    }
     dto.visible = static_cast<bool>(json["visible"]);
     dto.miniMixer = static_cast<bool>(json["miniMixer"]);
     dto.aiAgentEnabled = static_cast<bool>(json["aiAgentEnabled"]);
@@ -1623,6 +1638,46 @@ OperationRegistry::OperationRegistry() {
     // its `catalogId` from — so what this lists is exactly what can be asked for.
     add("devices.catalog", "List devices that can be added, by catalogue id", OperationAccess::Read,
         &handlers::devicesCatalog, emptyObjectSchema(), arraySchema(deviceCatalogEntrySchema()));
+    add("devices.add", "Add a device from the catalogue to a track's FX chain or a rack chain",
+        OperationAccess::Write, &handlers::devicesAdd, operationInputSchema(R"json({
+            "type":"object",
+            "properties":{
+                "trackId":{"type":"integer","minimum":0},
+                "parentPath":{},
+                "catalogId":{"type":"string","minLength":1},
+                "index":{"type":"integer","minimum":-1}
+            },
+            "required":["catalogId"],"additionalProperties":false
+        })json"),
+        parseSchema(R"json({
+            "type":"object",
+            "properties":{"id":{"type":"integer","minimum":0},"devicePath":{}},
+            "required":["id","devicePath"],"additionalProperties":false
+        })json"));
+    operations_.back().inputSchema["properties"].getDynamicObject()->setProperty(
+        "parentPath", devicePathSchema());
+    operations_.back().outputSchema["properties"].getDynamicObject()->setProperty(
+        "devicePath", devicePathSchema());
+    add("devices.remove", "Remove a device", OperationAccess::Write, &handlers::devicesRemove,
+        operationInputSchema(R"json({
+            "type":"object","properties":{"devicePath":{}},
+            "required":["devicePath"],"additionalProperties":false
+        })json"),
+        okResult);
+    operations_.back().inputSchema["properties"].getDynamicObject()->setProperty(
+        "devicePath", devicePathSchema());
+    add("devices.move", "Move a device within its chain", OperationAccess::Write,
+        &handlers::devicesMove, operationInputSchema(R"json({
+            "type":"object",
+            "properties":{
+                "devicePath":{},
+                "toIndex":{"type":"integer","minimum":0}
+            },
+            "required":["devicePath","toIndex"],"additionalProperties":false
+        })json"),
+        okResult);
+    operations_.back().inputSchema["properties"].getDynamicObject()->setProperty(
+        "devicePath", devicePathSchema());
     // Parameter discovery and direct control (#2274). Values are real units on
     // both sides — discovery reports what a knob shows and setParameter takes
     // the same number back — with `normalizedValue` alongside so a client can
@@ -1659,7 +1714,20 @@ OperationRegistry::OperationRegistry() {
                 "visibleParameters":{"type":"array","items":{"type":"integer","minimum":0}},
                 "miniMixerParameters":{"type":"array","items":{"type":"integer","minimum":0}},
                 "aiAgentParameters":{"type":"array","items":{"type":"integer","minimum":0}},
-                "aiPrompt":{"type":"string"}
+                "aiPrompt":{"type":"string"},
+                "parameterOverrides":{"type":"array","items":{
+                    "type":"object",
+                    "properties":{
+                        "index":{"type":"integer","minimum":0},
+                        "unit":{"type":"string"},
+                        "scale":{"type":"string","enum":["linear","logarithmic","exponential",
+                                                          "discrete","boolean","fader_db"]},
+                        "minValue":{"type":"number"},
+                        "maxValue":{"type":"number"},
+                        "choices":{"type":"array","items":{"type":"string"}}
+                    },
+                    "required":["index"],"additionalProperties":false
+                }}
             },
             "required":["devicePath"],"additionalProperties":false
         })json"),
@@ -1882,6 +1950,9 @@ OperationRegistry::OperationRegistry() {
         {"racks.create", Scope::Edit},
         {"racks.remove", Scope::Edit},
         {"racks.setBypassed", Scope::Edit},
+        {"devices.add", Scope::Edit},
+        {"devices.remove", Scope::Edit},
+        {"devices.move", Scope::Edit},
         {"devices.setParameter", Scope::Edit},
         {"devices.setParameterConfig", Scope::Edit},
         // Opening a plugin editor changes no project content, but it takes

--- a/magda/daw/api/remote_api.hpp
+++ b/magda/daw/api/remote_api.hpp
@@ -10,6 +10,7 @@
 
 #include "../core/ChainNodePath.hpp"
 #include "../core/ClipTypes.hpp"
+#include "../core/ParameterInfo.hpp"
 #include "../core/TypeIds.hpp"
 #include "remote_scopes.hpp"
 
@@ -221,6 +222,8 @@ struct DeviceParameterDto {
     double defaultValue = 0.0;
     double currentValue = 0.0;
     double normalizedValue = 0.0;
+    ParameterScale scale = ParameterScale::Linear;  // serialized as the store's wire strings
+    std::vector<juce::String> choices;  // labels for discrete parameters; empty otherwise
     bool visible = false;
     bool miniMixer = false;
     bool aiAgentEnabled = false;

--- a/magda/daw/api/remote_api_projection.cpp
+++ b/magda/daw/api/remote_api_projection.cpp
@@ -5,6 +5,7 @@
 #include "../core/ClipInfo.hpp"
 #include "../core/DeviceInfo.hpp"
 #include "../core/ParameterUtils.hpp"
+#include "../core/PluginParameterConfigStore.hpp"
 #include "../core/RackInfo.hpp"
 #include "../core/TrackInfo.hpp"
 #include "../project/ProjectInfo.hpp"
@@ -366,6 +367,8 @@ std::vector<DeviceParameterDto> makeDeviceParameterDtos(const DeviceInfo& device
         dto.defaultValue = ParameterUtils::modelToRealValue({info.defaultValue}, info);
         dto.currentValue = ParameterUtils::normalizedToReal(normalized.value, info);
         dto.normalizedValue = normalized.value;
+        dto.scale = info.scale;
+        dto.choices = info.choices;
         dto.visible = contains(device.visibleParameters, position);
         dto.miniMixer = contains(device.miniMixerParameters, position);
         // Configure Parameters offers the AI opt-in only for external plugins;

--- a/magda/daw/api/remote_handlers.cpp
+++ b/magda/daw/api/remote_handlers.cpp
@@ -15,6 +15,7 @@
 #include "../core/ControlTarget.hpp"
 #include "../core/DeviceInfo.hpp"
 #include "../core/MidiNoteCommands.hpp"
+#include "../core/PluginParameterConfigStore.hpp"
 #include "../core/TrackCommands.hpp"
 #include "../core/TrackInfo.hpp"
 #include "../core/TrackPropertyCommands.hpp"
@@ -492,6 +493,64 @@ HandlerResult devicesCatalog(MagdaApi& api, const juce::var&, const RequestConte
     return HandlerResult::ok(toJsonArray(items));
 }
 
+HandlerResult devicesAdd(MagdaApi& api, const juce::var& input, const RequestContext&) {
+    const auto catalogId = input["catalogId"].toString();
+    if (!api.devices().findCatalogEntry(catalogId).has_value())
+        return HandlerResult::fail(ErrorCode::NotFound, "no catalogue entry " + catalogId);
+
+    ChainNodePath parent;
+    if (const auto parentPath = input["parentPath"]; parentPath.isObject()) {
+        const auto resolved = toChainNodePath(devicePathFromJson(parentPath));
+        if (!resolved)
+            return HandlerResult::fail(ErrorCode::ValidationFailed, "parentPath does not resolve");
+        parent = *resolved;
+    } else if (has(input, "trackId")) {
+        const auto trackId = static_cast<TrackId>(static_cast<int>(input["trackId"]));
+        if (api.tracks().getTrack(trackId) == nullptr)
+            return notFound("track", trackId);
+        parent = ChainNodePath::trackLevel(trackId);
+    } else {
+        return HandlerResult::fail(ErrorCode::ValidationFailed,
+                                   "provide trackId (main FX chain) or parentPath (a chain)");
+    }
+
+    const auto id = api.devices().addDevice(parent, catalogId, readInt(input, "index", -1));
+    if (id == INVALID_DEVICE_ID)
+        return HandlerResult::fail(ErrorCode::Conflict, "device could not be added");
+
+    // The new device's address: a top-level id lives on the path root rather
+    // than as a step; a chain-hosted one extends the chain.
+    const auto devicePath = parent.getType() == ChainNodeType::Track
+                                ? ChainNodePath::topLevelDevice(parent.trackId, id)
+                                : parent.withDevice(id);
+    auto* object = new juce::DynamicObject();
+    object->setProperty("id", id);
+    object->setProperty("devicePath", toJson(makeDevicePathDto(devicePath)));
+    return HandlerResult::ok(juce::var(object));
+}
+
+HandlerResult devicesRemove(MagdaApi& api, const juce::var& input, const RequestContext&) {
+    const auto path = toChainNodePath(devicePathFromJson(input["devicePath"]));
+    if (!path)
+        return HandlerResult::fail(ErrorCode::ValidationFailed, "devicePath does not resolve");
+    if (api.devices().getDevice(*path) == nullptr)
+        return HandlerResult::fail(ErrorCode::NotFound, "no device at devicePath");
+    if (!api.devices().removeDevice(*path))
+        return HandlerResult::fail(ErrorCode::InternalError, "device removal failed");
+    return HandlerResult::ok(acceptedResult());
+}
+
+HandlerResult devicesMove(MagdaApi& api, const juce::var& input, const RequestContext&) {
+    const auto path = toChainNodePath(devicePathFromJson(input["devicePath"]));
+    if (!path)
+        return HandlerResult::fail(ErrorCode::ValidationFailed, "devicePath does not resolve");
+    if (api.devices().getDevice(*path) == nullptr)
+        return HandlerResult::fail(ErrorCode::NotFound, "no device at devicePath");
+    if (!api.devices().moveDevice(*path, readInt(input, "toIndex", -1)))
+        return HandlerResult::fail(ErrorCode::Conflict, "device move failed");
+    return HandlerResult::ok(acceptedResult());
+}
+
 HandlerResult devicesListParameters(MagdaApi& api, const juce::var& input, const RequestContext&) {
     const auto path = toChainNodePath(devicePathFromJson(input["devicePath"]));
     if (!path)
@@ -611,12 +670,53 @@ HandlerResult devicesSetParameterConfig(MagdaApi& api, const juce::var& input,
     if (has(input, "aiPrompt"))
         update.aiPrompt = input["aiPrompt"].toString();
 
+    if (has(input, "parameterOverrides")) {
+        std::vector<DeviceParameterOverride> overrides;
+        if (const auto* array = input["parameterOverrides"].getArray()) {
+            for (const auto& item : *array) {
+                DeviceParameterOverride override_;
+                const auto wireIndex = readInt(item, "index", -1);
+                const auto found = positionByWireIndex.find(wireIndex);
+                if (found == positionByWireIndex.end())
+                    return HandlerResult::fail(ErrorCode::ValidationFailed,
+                                               "parameterOverrides names unknown parameter " +
+                                                   juce::String(wireIndex));
+                override_.index = found->second;
+                if (has(item, "unit"))
+                    override_.unit = item["unit"].toString();
+                if (has(item, "scale"))
+                    override_.scale =
+                        PluginParameterConfigStore::scaleFromString(item["scale"].toString());
+                if (has(item, "minValue"))
+                    override_.minValue = static_cast<float>(static_cast<double>(item["minValue"]));
+                if (has(item, "maxValue"))
+                    override_.maxValue = static_cast<float>(static_cast<double>(item["maxValue"]));
+                const auto& info = device->parameters[static_cast<size_t>(override_.index)];
+                if (override_.minValue.value_or(info.minValue) >=
+                    override_.maxValue.value_or(info.maxValue))
+                    return HandlerResult::fail(ErrorCode::ValidationFailed,
+                                               "parameter " + juce::String(wireIndex) +
+                                                   ": display range is empty or inverted");
+                if (has(item, "choices")) {
+                    std::vector<juce::String> choices;
+                    if (const auto* labels = item["choices"].getArray()) {
+                        for (const auto& label : *labels)
+                            choices.push_back(label.toString());
+                    }
+                    override_.choices = std::move(choices);
+                }
+                overrides.push_back(std::move(override_));
+            }
+        }
+        update.parameterOverrides = std::move(overrides);
+    }
+
     if (!update.visibleParameters && !update.miniMixerParameters && !update.aiAgentParameters &&
-        !update.aiPrompt)
+        !update.aiPrompt && !update.parameterOverrides)
         return HandlerResult::fail(ErrorCode::ValidationFailed,
                                    "nothing to update: provide at least one of "
                                    "visibleParameters, miniMixerParameters, aiAgentParameters, "
-                                   "aiPrompt");
+                                   "aiPrompt, parameterOverrides");
 
     if (!api.devices().setDeviceParameterConfig(*path, update))
         return HandlerResult::fail(ErrorCode::InternalError, "parameter config write failed");

--- a/magda/daw/api/remote_handlers.hpp
+++ b/magda/daw/api/remote_handlers.hpp
@@ -49,6 +49,9 @@ HandlerResult clipsDelete(MagdaApi&, const juce::var&, const RequestContext&);
 // Devices and racks
 HandlerResult devicesList(MagdaApi&, const juce::var&, const RequestContext&);
 HandlerResult devicesCatalog(MagdaApi&, const juce::var&, const RequestContext&);
+HandlerResult devicesAdd(MagdaApi&, const juce::var&, const RequestContext&);
+HandlerResult devicesRemove(MagdaApi&, const juce::var&, const RequestContext&);
+HandlerResult devicesMove(MagdaApi&, const juce::var&, const RequestContext&);
 HandlerResult devicesListParameters(MagdaApi&, const juce::var&, const RequestContext&);
 HandlerResult devicesSetParameter(MagdaApi&, const juce::var&, const RequestContext&);
 HandlerResult devicesSetParameterConfig(MagdaApi&, const juce::var&, const RequestContext&);

--- a/magda/daw/audio/AudioBridge.cpp
+++ b/magda/daw/audio/AudioBridge.cpp
@@ -569,6 +569,10 @@ void AudioBridge::deviceParameterChanged(const ChainNodePath& devicePath, int pa
     // A single device parameter changed - sync only that parameter to processor
     auto* processor = getDeviceProcessor(devicePath);
     if (!processor) {
+        // The model updated and the caller was told ok, but nothing reached
+        // the engine. Say so rather than dropping the write silently (#2288).
+        DBG("AudioBridge: dropping parameter change for device " << devicePath.getDeviceId()
+                                                                 << " - no processor");
         return;
     }
 

--- a/magda/daw/audio/plugin_manager/PluginManager.cpp
+++ b/magda/daw/audio/plugin_manager/PluginManager.cpp
@@ -165,12 +165,14 @@ PluginManager::PluginManager(te::Engine& engine, te::Edit& edit, TrackController
 
 PluginManager::SyncedDeviceMap::iterator PluginManager::findSyncedDevice(
     const ChainNodePath& devicePath) {
-    return syncedDevices_.find(devicePath);
+    // Entries are keyed by the canonical spelling; the model layer accepts
+    // both spellings of a top-level device, so lookups must too (#2288).
+    return syncedDevices_.find(devicePath.normalized());
 }
 
 PluginManager::SyncedDeviceMap::const_iterator PluginManager::findSyncedDevice(
     const ChainNodePath& devicePath) const {
-    return syncedDevices_.find(devicePath);
+    return syncedDevices_.find(devicePath.normalized());
 }
 
 void PluginManager::prepareForChainElementMove(const ChainNodePath& sourceElementPath,
@@ -231,7 +233,15 @@ te::Plugin::Ptr PluginManager::getPlugin(const ChainNodePath& devicePath) const 
 DeviceProcessor* PluginManager::getDeviceProcessor(const ChainNodePath& devicePath) const {
     juce::ScopedLock lock(pluginLock_);
     auto it = findSyncedDevice(devicePath);
-    return it != syncedDevices_.end() ? it->second.processor.get() : nullptr;
+    if (it == syncedDevices_.end())
+        return nullptr;
+    if (it->second.processor == nullptr) {
+        // The entry exists but async load failed or is still pending: every
+        // host parameter write to this device is currently being dropped.
+        DBG("PluginManager: device " << devicePath.getDeviceId()
+                                     << " has no processor (load failed or pending)");
+    }
+    return it->second.processor.get();
 }
 
 DeviceId PluginManager::getDeviceIdForPlugin(te::Plugin* plugin) const {

--- a/magda/daw/core/ChainNodePath.hpp
+++ b/magda/daw/core/ChainNodePath.hpp
@@ -343,6 +343,21 @@ struct ChainNodePath {
         return extendedWith({ChainStepType::Device, d});
     }
 
+    /**
+     * @brief The canonical spelling of this address.
+     *
+     * A top-level FX device can be written two ways — `topLevelDeviceId` on
+     * the root, or a single Device step — and the model layer accepts both.
+     * Map keys must not: this collapses the step spelling onto the
+     * `topLevelDevice` form and leaves every other path untouched.
+     */
+    ChainNodePath normalized() const {
+        if (topLevelDeviceId == INVALID_DEVICE_ID && !isTrackLevel && steps.size() == 1 &&
+            steps.front().type == ChainStepType::Device)
+            return topLevelDevice(trackId, steps.front().id);
+        return *this;
+    }
+
     // Get the parent path (without the last step)
     ChainNodePath parent() const {
         ChainNodePath p = *this;

--- a/magda/daw/core/ConsoleRouting.cpp
+++ b/magda/daw/core/ConsoleRouting.cpp
@@ -160,6 +160,7 @@ const std::vector<AgentSurface>& registeredAgentSurfaces() {
                               Provider::TrackSummaries, Provider::DeviceSummaries,
                               Provider::Conversation},
          .toolAllowlist = {"project.get", "tracks.list", "tracks.get", "devices.list",
+                           "devices.catalog", "devices.add", "devices.remove", "devices.move",
                            "devices.listParameters", "devices.setParameter",
                            "devices.setParameterConfig", "devices.openEditor", "racks.create",
                            "racks.remove", "racks.setBypassed", "selection.get", "selection.set"},

--- a/magda/daw/core/PluginParameterConfigStore.cpp
+++ b/magda/daw/core/PluginParameterConfigStore.cpp
@@ -10,38 +10,6 @@
 namespace magda::PluginParameterConfigStore {
 namespace {
 
-juce::String scaleToXmlString(ParameterScale scale) {
-    switch (scale) {
-        case ParameterScale::Linear:
-            return "linear";
-        case ParameterScale::Logarithmic:
-            return "logarithmic";
-        case ParameterScale::Exponential:
-            return "exponential";
-        case ParameterScale::Discrete:
-            return "discrete";
-        case ParameterScale::Boolean:
-            return "boolean";
-        case ParameterScale::FaderDB:
-            return "fader_db";
-    }
-    return "linear";
-}
-
-ParameterScale xmlStringToScale(const juce::String& str) {
-    if (str == "logarithmic")
-        return ParameterScale::Logarithmic;
-    if (str == "exponential")
-        return ParameterScale::Exponential;
-    if (str == "discrete")
-        return ParameterScale::Discrete;
-    if (str == "boolean")
-        return ParameterScale::Boolean;
-    if (str == "fader_db")
-        return ParameterScale::FaderDB;
-    return ParameterScale::Linear;
-}
-
 /// The id a live device's config is filed under. Older devices carry only a
 /// pluginId, so it is the fallback rather than an error.
 juce::String configIdFor(const DeviceInfo& device) {
@@ -78,6 +46,38 @@ bool refreshFlatParameterConfig(const juce::String& uniqueId,
 
 }  // namespace
 
+juce::String scaleToString(ParameterScale scale) {
+    switch (scale) {
+        case ParameterScale::Linear:
+            return "linear";
+        case ParameterScale::Logarithmic:
+            return "logarithmic";
+        case ParameterScale::Exponential:
+            return "exponential";
+        case ParameterScale::Discrete:
+            return "discrete";
+        case ParameterScale::Boolean:
+            return "boolean";
+        case ParameterScale::FaderDB:
+            return "fader_db";
+    }
+    return "linear";
+}
+
+ParameterScale scaleFromString(const juce::String& name) {
+    if (name == "logarithmic")
+        return ParameterScale::Logarithmic;
+    if (name == "exponential")
+        return ParameterScale::Exponential;
+    if (name == "discrete")
+        return ParameterScale::Discrete;
+    if (name == "boolean")
+        return ParameterScale::Boolean;
+    if (name == "fader_db")
+        return ParameterScale::FaderDB;
+    return ParameterScale::Linear;
+}
+
 juce::File configFileFor(const juce::String& uniqueId) {
     return paths::pluginConfigsDir().getChildFile(uniqueId.replaceCharacters(":/\\,; ", "______") +
                                                   ".xml");
@@ -113,7 +113,7 @@ std::optional<PluginParameterConfig> load(const juce::String& uniqueId) {
             if (paramElem->hasAttribute("unit"))
                 entry.unit = paramElem->getStringAttribute("unit");
             if (paramElem->hasAttribute("scale"))
-                entry.scale = xmlStringToScale(paramElem->getStringAttribute("scale"));
+                entry.scale = scaleFromString(paramElem->getStringAttribute("scale"));
             if (paramElem->hasAttribute("min"))
                 entry.rangeMin = static_cast<float>(paramElem->getDoubleAttribute("min"));
             if (paramElem->hasAttribute("max"))
@@ -172,7 +172,7 @@ bool save(const juce::String& uniqueId, const PluginParameterConfig& config) {
         if (entry.unit)
             paramElem->setAttribute("unit", *entry.unit);
         if (entry.scale)
-            paramElem->setAttribute("scale", scaleToXmlString(*entry.scale));
+            paramElem->setAttribute("scale", scaleToString(*entry.scale));
         if (entry.rangeMin)
             paramElem->setAttribute("min", static_cast<double>(*entry.rangeMin));
         if (entry.rangeMax)

--- a/magda/daw/core/PluginParameterConfigStore.hpp
+++ b/magda/daw/core/PluginParameterConfigStore.hpp
@@ -52,6 +52,12 @@ struct PluginParameterConfig {
  */
 namespace PluginParameterConfigStore {
 
+/// The wire/XML name of a parameter scale ("linear", "logarithmic",
+/// "exponential", "discrete", "boolean", "fader_db"). One owner for the
+/// vocabulary shared by the config XML and the remote API.
+juce::String scaleToString(ParameterScale scale);
+ParameterScale scaleFromString(const juce::String& name);
+
 /// The config file for `uniqueId`, whether or not it exists yet.
 juce::File configFileFor(const juce::String& uniqueId);
 

--- a/magda/mcp_bridge/main.cpp
+++ b/magda/mcp_bridge/main.cpp
@@ -32,6 +32,7 @@
 
 #include <algorithm>
 #include <atomic>
+#include <chrono>
 #include <cstdlib>
 #include <iostream>
 #include <map>
@@ -363,6 +364,19 @@ class Bridge {
         }
 
         auto result = client->Post(endpoint.path, headers, body, "application/json");
+
+        // The endpoint admits requests from a token bucket, so a legitimate
+        // burst — an agent sweeping a dozen parameters — sees HTTP 429 partway
+        // through. That refusal is retryable by construction (tokens return
+        // with wall-clock, ~50/s), and most stdio hosts treat any error as
+        // terminal, so absorb it here with a bounded backoff. The bound keeps a
+        // genuinely saturated server visible instead of hidden forever.
+        for (int delayMs = 100;
+             result && result->status == httplib::StatusCode::TooManyRequests_429 && delayMs <= 800;
+             delayMs *= 2) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(delayMs));
+            result = client->Post(endpoint.path, headers, body, "application/json");
+        }
 
         if (!result) {
             // Connection refused or reset: MAGDA is gone or was restarted. Worth

--- a/tests/MockMagdaApi.hpp
+++ b/tests/MockMagdaApi.hpp
@@ -1244,6 +1244,16 @@ class MockDeviceApi : public DeviceApi {
                     return false;
             }
         }
+        if (update.parameterOverrides) {
+            for (const auto& override_ : *update.parameterOverrides) {
+                if (override_.index < 0 || override_.index >= count)
+                    return false;
+                const auto& info = device.parameters[static_cast<size_t>(override_.index)];
+                if (override_.minValue.value_or(info.minValue) >=
+                    override_.maxValue.value_or(info.maxValue))
+                    return false;
+            }
+        }
         if (update.visibleParameters)
             device.visibleParameters = *update.visibleParameters;
         if (update.miniMixerParameters)
@@ -1252,6 +1262,21 @@ class MockDeviceApi : public DeviceApi {
             device.aiSoundDesignerParameters = *update.aiAgentParameters;
         if (update.aiPrompt)
             device.aiSoundDesignerPrompt = *update.aiPrompt;
+        if (update.parameterOverrides) {
+            for (const auto& override_ : *update.parameterOverrides) {
+                auto& info = device.parameters[static_cast<size_t>(override_.index)];
+                if (override_.unit)
+                    info.unit = *override_.unit;
+                if (override_.scale)
+                    info.scale = *override_.scale;
+                if (override_.minValue)
+                    info.minValue = *override_.minValue;
+                if (override_.maxValue)
+                    info.maxValue = *override_.maxValue;
+                if (override_.choices)
+                    info.choices = *override_.choices;
+            }
+        }
         configUpdates.emplace_back(devicePath, update);
         return true;
     }

--- a/tests/devices/test_chain_node_path_drag.cpp
+++ b/tests/devices/test_chain_node_path_drag.cpp
@@ -110,3 +110,23 @@ TEST_CASE("An invalid path is never handed to a drop handler", "[ui][drag][chain
 
     REQUIRE_FALSE(readChainNodePathFromDragInfo(*info.getDynamicObject()).has_value());
 }
+
+TEST_CASE("normalized collapses the step spelling of a top-level device", "[chain][path]") {
+    // The model accepts both spellings of a top-level FX device; map keys are
+    // canonical. normalized() is what lets an engine lookup accept either.
+    magda::ChainNodePath stepSpelling;
+    stepSpelling.trackId = 3;
+    stepSpelling.steps.push_back({magda::ChainStepType::Device, 7});
+
+    REQUIRE(stepSpelling.normalized() == magda::ChainNodePath::topLevelDevice(3, 7));
+
+    // Canonical, nested, sectioned, and track-level paths pass through.
+    const auto canonical = magda::ChainNodePath::topLevelDevice(3, 7);
+    REQUIRE(canonical.normalized() == canonical);
+    const auto nested = magda::ChainNodePath::chainDevice(3, 1, 2, 7);
+    REQUIRE(nested.normalized() == nested);
+    const auto postFx = magda::ChainNodePath::postFxDevice(3, 7);
+    REQUIRE(postFx.normalized() == postFx);
+    const auto track = magda::ChainNodePath::trackLevel(3);
+    REQUIRE(track.normalized() == track);
+}

--- a/tests/remote/test_remote_api_contract.cpp
+++ b/tests/remote/test_remote_api_contract.cpp
@@ -43,6 +43,9 @@ TEST_CASE("Remote API registry is versioned, discoverable, and unique", "[remote
     REQUIRE(registry.find("devices.listParameters") != nullptr);
     REQUIRE(registry.find("devices.setParameter") != nullptr);
     REQUIRE(registry.find("devices.setParameterConfig") != nullptr);
+    REQUIRE(registry.find("devices.add") != nullptr);
+    REQUIRE(registry.find("devices.remove") != nullptr);
+    REQUIRE(registry.find("devices.move") != nullptr);
     REQUIRE(registry.find("devices.openEditor") != nullptr);
     REQUIRE(registry.find("session.launchClip") != nullptr);
     REQUIRE(registry.find("automation.addPoint") != nullptr);
@@ -497,17 +500,20 @@ TEST_CASE("devices.listParameters projects real units and customization flags",
           "[remote-api][contract]") {
     DeviceInfo device;
     device.format = PluginFormat::VST3;
-    device.parameters.emplace_back(0, "Cutoff", "Hz", 20.0f, 20000.0f, 800.0f);
+    device.parameters.emplace_back(0, "Cutoff", "Hz", 20.0f, 20000.0f, 800.0f,
+                                   ParameterScale::Logarithmic);
     device.parameters.emplace_back(1, "Resonance", "%", 0.0f, 100.0f, 10.0f);
+    device.parameters.emplace_back(2, "Mode", "", 0.0f, 2.0f, 0.0f, ParameterScale::Discrete);
     device.parameters[0].stableId = "cutoff";
     device.parameters[0].currentValue = 800.0f;
     device.parameters[1].currentValue = 25.0f;
+    device.parameters[2].choices = {"LP", "BP", "HP"};
     device.visibleParameters = {0, 1};
     device.miniMixerParameters = {1};
     device.aiSoundDesignerParameters = {1};
 
     const auto parameters = makeDeviceParameterDtos(device);
-    REQUIRE(parameters.size() == 2);
+    REQUIRE(parameters.size() == 3);
 
     REQUIRE(parameters[0].index == 0);
     REQUIRE(parameters[0].stableId == "cutoff");
@@ -525,8 +531,16 @@ TEST_CASE("devices.listParameters projects real units and customization flags",
     REQUIRE(parameters[1].miniMixer);
     REQUIRE(std::abs(parameters[1].normalizedValue - 0.25) < 1e-6);
 
+    // A discrete parameter is interpretable, not just a number in a range.
+    REQUIRE(parameters[0].scale == ParameterScale::Logarithmic);
+    REQUIRE(parameters[1].scale == ParameterScale::Linear);
+    REQUIRE(parameters[1].choices.empty());
+    REQUIRE(parameters[2].scale == ParameterScale::Discrete);
+    REQUIRE(parameters[2].choices == std::vector<juce::String>{"LP", "BP", "HP"});
+
     requireRoundTrip(parameters[0], deviceParameterFromJson);
     requireRoundTrip(parameters[1], deviceParameterFromJson);
+    requireRoundTrip(parameters[2], deviceParameterFromJson);
 }
 
 TEST_CASE("configured external parameters project model values into display units",

--- a/tests/remote/test_remote_mcp_bridge.cpp
+++ b/tests/remote/test_remote_mcp_bridge.cpp
@@ -361,6 +361,37 @@ TEST_CASE("A legacy session survives MAGDA restarting under it", "[remote][mcp-b
     dataDir.deleteRecursively();
 }
 
+TEST_CASE("The bridge absorbs rate-limit refusals with backoff", "[remote][mcp-bridge]") {
+    // The endpoint's token bucket refuses a burst partway through (burst =
+    // maxConcurrentRequests). A stdio host treats errors as terminal, so the
+    // bridge retries 429s itself; every call in a modest burst must answer.
+    const MessageThreadRelaxation relaxation;
+    MockMagdaApi api;
+    RemoteApiService service(api);
+
+    auto options = serverOptions();
+    options.maxConcurrentRequests = 2;    // burst of 2 tokens
+    options.maxRequestsPerSecond = 20.0;  // one token back every 50ms
+    RemoteMcpServer server(service, options);
+    REQUIRE(server.start());
+
+    juce::TemporaryFile scratch;
+    const auto dataDir = scratch.getFile().getSiblingFile("magda-bridge-rate-limit");
+    writeRecord(dataDir, server.boundPort(), kToken);
+    BridgeProcess bridge(dataDir);
+
+    for (int id = 1; id <= 8; ++id) {
+        bridge.send(request(id, "ping", modernParams()));
+        const auto response = bridge.receive();
+        INFO("request " << id);
+        REQUIRE(response.getDynamicObject() != nullptr);
+        REQUIRE(static_cast<int>(response["id"]) == id);
+        REQUIRE(response["error"].isVoid());
+    }
+
+    dataDir.deleteRecursively();
+}
+
 TEST_CASE("With no MAGDA running, the bridge says so rather than hanging", "[remote][mcp-bridge]") {
     juce::TemporaryFile scratch;
     const auto dataDir = scratch.getFile().getSiblingFile("magda-bridge-empty");

--- a/tests/remote/test_remote_service.cpp
+++ b/tests/remote/test_remote_service.cpp
@@ -895,3 +895,100 @@ TEST_CASE("devices.setParameter converts display units to the model domain",
     REQUIRE(api.devices_.parameterWrites.size() == 1);
     REQUIRE(std::abs(std::get<2>(api.devices_.parameterWrites.front()) - 0.75f) < 1e-6f);
 }
+
+TEST_CASE("devices.add creates a device and returns its address", "[remote][service][devices]") {
+    const MessageThreadRelaxation relaxation;
+    MockMagdaApi api;
+    TrackInfo track;
+    track.id = 1;
+    api.tracks_.tracks.push_back(track);
+    api.devices_.catalog.push_back({"internal.filter", "Filter", "", "", "", PluginFormat::Internal,
+                                    DeviceType::Effect, false});
+    RemoteApiService service(api);
+
+    const auto response =
+        run(service, "devices.add", object({{"trackId", 1}, {"catalogId", "internal.filter"}}));
+
+    REQUIRE(response.ok);
+    const auto id = static_cast<int>(response.result["id"]);
+    REQUIRE(id != INVALID_DEVICE_ID);
+    // The returned address is the canonical top-level spelling.
+    REQUIRE(static_cast<int>(response.result["devicePath"]["topLevelDeviceId"]) == id);
+    REQUIRE(response.result["devicePath"]["section"].toString() == "fx");
+    REQUIRE(api.devices_.added.size() == 1);
+    REQUIRE(api.devices_.added.front().catalogId == "internal.filter");
+
+    const auto unknown =
+        run(service, "devices.add", object({{"trackId", 1}, {"catalogId", "no.such.device"}}));
+    REQUIRE_FALSE(unknown.ok);
+    REQUIRE(errorCodeOf(unknown) == "not_found");
+}
+
+TEST_CASE("devices.remove and devices.move act on resolvable paths only",
+          "[remote][service][devices]") {
+    const MessageThreadRelaxation relaxation;
+    MockMagdaApi api;
+    const auto path = ChainNodePath::topLevelDevice(1, 5);
+    api.devices_.devices[path] = makeFilterDevice();
+    RemoteApiService service(api);
+
+    auto move = pathInput(path);
+    move.getDynamicObject()->setProperty("toIndex", 2);
+    const auto moved = run(service, "devices.move", move);
+    REQUIRE(moved.ok);
+    REQUIRE(api.devices_.moved.size() == 1);
+
+    const auto removed = run(service, "devices.remove", pathInput(path));
+    REQUIRE(removed.ok);
+    REQUIRE(static_cast<bool>(removed.result["accepted"]));
+    REQUIRE(api.devices_.removed.size() == 1);
+
+    const auto missing =
+        run(service, "devices.remove", pathInput(ChainNodePath::topLevelDevice(1, 99)));
+    REQUIRE_FALSE(missing.ok);
+    REQUIRE(errorCodeOf(missing) == "not_found");
+}
+
+TEST_CASE("devices.setParameterConfig applies detection overrides", "[remote][service][devices]") {
+    const MessageThreadRelaxation relaxation;
+    MockMagdaApi api;
+    const auto path = ChainNodePath::topLevelDevice(1, 5);
+    api.devices_.devices[path] = makeFilterDevice();
+    RemoteApiService service(api);
+
+    auto* override_ = new juce::DynamicObject();
+    override_->setProperty("index", 1);
+    override_->setProperty("unit", "dB");
+    override_->setProperty("scale", "logarithmic");
+    override_->setProperty("minValue", 1.0);
+    override_->setProperty("maxValue", 100.0);
+    juce::Array<juce::var> overrides;
+    overrides.add(juce::var(override_));
+    auto input = pathInput(path);
+    input.getDynamicObject()->setProperty("parameterOverrides", overrides);
+    const auto response = run(service, "devices.setParameterConfig", input);
+
+    REQUIRE(response.ok);
+    const auto* items = response.result.getArray();
+    REQUIRE(items != nullptr);
+    // The echo speaks the new detection data immediately.
+    REQUIRE((*items)[1]["unit"].toString() == "dB");
+    REQUIRE((*items)[1]["scale"].toString() == "logarithmic");
+    REQUIRE(static_cast<double>((*items)[1]["minValue"]) == 1.0);
+    REQUIRE(static_cast<double>((*items)[1]["maxValue"]) == 100.0);
+    REQUIRE(api.devices_.configUpdates.size() == 1);
+
+    // An empty or inverted display range is refused before anything persists.
+    auto* bad = new juce::DynamicObject();
+    bad->setProperty("index", 0);
+    bad->setProperty("minValue", 500.0);
+    bad->setProperty("maxValue", 100.0);
+    juce::Array<juce::var> badOverrides;
+    badOverrides.add(juce::var(bad));
+    auto badInput = pathInput(path);
+    badInput.getDynamicObject()->setProperty("parameterOverrides", badOverrides);
+    const auto refused = run(service, "devices.setParameterConfig", badInput);
+    REQUIRE_FALSE(refused.ok);
+    REQUIRE(errorCodeOf(refused) == "validation_failed");
+    REQUIRE(api.devices_.configUpdates.size() == 1);
+}

--- a/tests/routing/test_console_routing.cpp
+++ b/tests/routing/test_console_routing.cpp
@@ -47,6 +47,8 @@ TEST_CASE("agent surface registry has distinct bounded capabilities", "[console_
     REQUIRE(containsTool(device, "devices.listParameters"));
     REQUIRE(containsTool(device, "devices.setParameter"));
     REQUIRE(containsTool(device, "devices.setParameterConfig"));
+    REQUIRE(containsTool(device, "devices.add"));
+    REQUIRE(containsTool(device, "devices.remove"));
     REQUIRE(containsTool(device, "devices.openEditor"));
     REQUIRE_FALSE(containsTool(device, "tracks.update"));
 


### PR DESCRIPTION
Closes #2284, closes #2285, closes #2286, closes #2287, closes #2288.

One combined PR (folded from four stacked ones to spare the self-hosted runner — apologies for the earlier CI burst). Everything below came out of the #2274 live test session with Surge XT:

**`devices.add` / `devices.remove` / `devices.move`** (#2284) — edit-scoped wrappers over the existing `DeviceApi` facade. `add` takes a `catalogId` (from `devices.catalog`) plus `trackId` (main FX chain) or `parentPath` (rack chain), returns `{id, devicePath}` in the canonical spelling. DevicePanel agent surface gains all three plus `devices.catalog`, which it previously couldn't see.

**`scale` + `choices` in `devices.listParameters`** (#2286) — the DTO carries `ParameterScale` as a typed enum (per review feedback) with discrete choice labels; the wire uses the config store's stable strings, and the scale↔string mapping moves to the store's public API as the vocabulary's single owner. A client can now ask for a Surge filter model by name instead of writing 0.5 blind.

**`parameterOverrides` in `devices.setParameterConfig`** (#2285) — per-parameter display unit, scale, display range, and choice labels, the same fields AI-Detect writes. Persisted via `PluginParameterConfigStore`, re-applied to live instances, echoed back immediately. Empty/inverted display ranges refused with `validation_failed`. Combined with the earlier selection writes, an external agent can now do the full curation job — units and subset — without an API key configured in MAGDA.

**Bridge absorbs rate limits** (#2287) — the endpoint's token bucket (burst = `maxConcurrentRequests` = 8, 50/s refill) 429s a legitimate burst on the 7th tool call; stdio hosts treat any error as terminal. `magda-mcp` now retries 429s with bounded backoff (100–800 ms). Regression test drives the real bridge binary against a burst-2 server; disabling the retry fails it.

**Engine lookups accept both path spellings** (#2288) — `ChainNodePath::normalized()` collapses the single-Device-step spelling onto the canonical `topLevelDevice` form, applied in `PluginManager::findSyncedDevice`, so a write that validates against the model can no longer be silently dropped by the processor lookup. The two silent-drop sites in `AudioBridge` now log, distinguishing "no map entry" from "async plugin load never produced a processor".

Tests: 269 cases green across the remote, routing, config-store, bridge, and path suites; the allowlist gate, the 429 retry, and the model/display conversion were each verified negatively during development.

🤖 Generated with [Claude Code](https://claude.com/claude-code)