### PR TITLE
A launch is a beat, not a block, and the clock grows a third face (#2300)

### DIFF
--- a/magda/engine/CMakeLists.txt
+++ b/magda/engine/CMakeLists.txt
@@ -103,6 +103,8 @@ add_library(magda_engine STATIC
     tap/LevelTap.hpp
     tap/SampleRing.hpp
     tap/ValueTap.hpp
+    launch/LaunchHandle.cpp
+    launch/LaunchHandle.hpp
     transport/TempoMap.cpp
     transport/TransportClock.cpp
     transport/ClickGenerator.cpp
@@ -186,7 +188,8 @@ endforeach()
 # engine's own headers.
 
 set(MAGDA_ENGINE_ALLOWED_QUOTED_PREFIXES
-    "core/" "clip/" "param/" "plan/" "exec/" "transport/" "io/" "tap/" "analysis/")
+    "core/" "clip/" "param/" "plan/" "exec/" "transport/" "io/" "tap/" "analysis/"
+    "launch/")
 
 file(GLOB_RECURSE MAGDA_ENGINE_SOURCES CONFIGURE_DEPENDS
     "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp"

--- a/magda/engine/exec/RenderContext.hpp
+++ b/magda/engine/exec/RenderContext.hpp
@@ -81,6 +81,27 @@ struct BlockInfo {
     double endSeconds = 0.0;
 
     /**
+     * @brief The same stretch, counted in beats that only ever go forwards.
+     *
+     * The timeline beat is where the cursor is, and it goes backwards every
+     * time a loop wraps and every time somebody locates. That is right for
+     * placing material and wrong for scheduling anything against a future
+     * beat: a launch quantized to the next bar, resolved against a beat the
+     * loop is about to take back, fires at the wrong moment or twice.
+     *
+     * This is the third face of the same instant, alongside beats and seconds,
+     * and it is derived in the same one place they are. It counts musical time
+     * the transport has actually rolled through since the clock began, so it
+     * survives a wrap, a locate and a tempo edit, and it is the domain a
+     * queued launch names its position in (#2300).
+     *
+     * A stopped block does not advance it, for the same reason it does not
+     * advance the timeline.
+     */
+    double startMonotonicBeat = 0.0;
+    double endMonotonicBeat = 0.0;
+
+    /**
      * @brief Whether the timeline ran into this block out of the last one.
      *
      * False on the first block after the transport starts, after a locate, and

--- a/magda/engine/launch/LaunchHandle.cpp
+++ b/magda/engine/launch/LaunchHandle.cpp
@@ -186,6 +186,12 @@ SplitStatus LaunchHandle::advance(const SyncRange& range) {
         if (wrap < range.monotonic.end && (!event || wrap < *event)) {
             event = wrap;
             fromPending = false;
+
+            // A second wrap inside the same block is one this cannot report.
+            // Counted rather than swallowed: the run carries on past where it
+            // was due to restart, and nothing downstream can see that happen.
+            if (wrap + *loopBeats_ < range.monotonic.end)
+                ++loopRetriggerOverflows_;
         }
     }
 

--- a/magda/engine/launch/LaunchHandle.cpp
+++ b/magda/engine/launch/LaunchHandle.cpp
@@ -1,5 +1,6 @@
 #include "launch/LaunchHandle.hpp"
 
+#include <algorithm>
 #include <cmath>
 
 namespace magda::engine {
@@ -18,6 +19,20 @@ double project(const BeatRange& from, const BeatRange& to, double value) {
 }
 
 }  // namespace
+
+double LaunchHandle::virtualStart(const SyncRange& piece) const {
+    // Where the run would have begun on the timeline as it stands now, which
+    // is not where it did begin once the timeline has wrapped or been located
+    // since. A source works out how far into the material it is by subtracting
+    // this from the block it was handed, so the two have to be in the same
+    // cycle of the timeline; the beat the run actually started on stops being
+    // in any cycle the moment the loop takes it back.
+    //
+    // Derived from monotonic elapsed, which is the one quantity that survives
+    // the wrap. It may sit before the block or before zero, and that is what it
+    // means: the run began that far back.
+    return piece.timeline.start - (piece.monotonic.start - playedMonotonic_->start);
+}
 
 std::optional<LaunchHandle::QueueState> LaunchHandle::queuedState() const {
     if (!pending_)
@@ -69,11 +84,16 @@ void LaunchHandle::nudge(double beats) {
     // The origin moves, not the end: the played length is what a source reads
     // its position from, so shifting where the run began is what moves the
     // playhead through the material without interrupting the run.
-    if (played_)
-        played_->start -= beats;
+    if (!played_ || !playedMonotonic_)
+        return;
 
-    if (playedMonotonic_)
-        playedMonotonic_->start -= beats;
+    // Backwards only as far as the run has got. Further would put the origin
+    // in the future, which is a run of negative length and a loop whose next
+    // wrap has already passed; a handle cannot be nudged to before it started.
+    const auto effective = std::max(beats, -played_->length());
+
+    played_->start -= effective;
+    playedMonotonic_->start -= effective;
 }
 
 std::optional<BeatRange> LaunchHandle::playedRange() const {
@@ -185,9 +205,17 @@ SplitStatus LaunchHandle::advance(const SyncRange& range) {
     if (!event && playState_ == PlayState::playing && loopBeats_ && playedMonotonic_) {
         const auto origin = playedMonotonic_->start;
         const auto elapsed = range.monotonic.start - origin;
-        auto wrap = origin + (std::floor(elapsed / *loopBeats_) + 1.0) * *loopBeats_;
 
-        while (wrap <= range.monotonic.start)
+        // The first wrap at or after this block begins, which is ceil rather
+        // than floor-plus-one: a wrap due exactly on the first sample was
+        // passed over by the previous block, whose range ended before it, and
+        // rounding up again here would skip it a second time and every
+        // block-aligned wrap after it. Never the origin itself, which is where
+        // the run started rather than somewhere it repeats.
+        const auto turns = std::max(1.0, std::ceil(elapsed / *loopBeats_));
+        auto wrap = origin + turns * *loopBeats_;
+
+        while (wrap < range.monotonic.start)
             wrap += *loopBeats_;
 
         if (wrap < range.monotonic.end) {
@@ -204,8 +232,8 @@ SplitStatus LaunchHandle::advance(const SyncRange& range) {
 
     if (!event) {
         if (playState_ == PlayState::playing) {
+            status.playStartTime1 = virtualStart(range);
             extendRun(range);
-            status.playStartTime1 = played_->start;
         }
 
         return status;
@@ -222,8 +250,8 @@ SplitStatus LaunchHandle::advance(const SyncRange& range) {
         status.playing2 = status.playing1;
 
         if (playState_ == PlayState::playing) {
+            status.playStartTime1 = virtualStart(range);
             extendRun(range);
-            status.playStartTime1 = played_->start;
         }
 
         return status;
@@ -237,8 +265,8 @@ SplitStatus LaunchHandle::advance(const SyncRange& range) {
                            BeatRange{*event, range.monotonic.end}};
 
     if (playState_ == PlayState::playing) {
+        status.playStartTime1 = virtualStart(first);
         extendRun(first);
-        status.playStartTime1 = played_->start;
     }
 
     applyEvent(fromPending, second.timeline.start, second.monotonic.start);
@@ -246,8 +274,8 @@ SplitStatus LaunchHandle::advance(const SyncRange& range) {
     status.playing2 = playState_ == PlayState::playing;
 
     if (playState_ == PlayState::playing) {
+        status.playStartTime2 = virtualStart(second);
         extendRun(second);
-        status.playStartTime2 = played_->start;
     }
 
     status.isSplit = true;

--- a/magda/engine/launch/LaunchHandle.cpp
+++ b/magda/engine/launch/LaunchHandle.cpp
@@ -154,12 +154,19 @@ SplitStatus LaunchHandle::advance(const SyncRange& range) {
     status.playing1 = playState_ == PlayState::playing;
     status.playing2 = status.playing1;
 
-    // What happens inside this block, in monotonic beats. At most one: a
-    // handle holds one pending request, so a launch cannot be queued behind a
-    // stop, and the only way two events can compete is a request landing in
-    // the same block as a loop wrap. The earlier one wins and the other is
-    // reconsidered next block, which bounds the error at one block rather than
-    // inventing a second split the caller has nowhere to put.
+    // What happens inside this block, in monotonic beats. At most one, and a
+    // request always outranks a loop wrap.
+    //
+    // The rule is that anything quantized lands on its beat, and anything that
+    // is not is the user's own business. A wrap is the handle's bookkeeping and
+    // it is not entitled to move an instant somebody asked for: a clip launched
+    // off the grid has its wraps off the grid too, and letting one displace a
+    // quantized stop would carry that drift into the one action that was
+    // explicitly put on the beat.
+    //
+    // Giving way costs the wrap nothing. A stop ends the run and a launch
+    // restarts it, so either way the run it would have restarted is gone before
+    // the block is over.
     std::optional<double> event;
     auto fromPending = false;
 
@@ -175,7 +182,7 @@ SplitStatus LaunchHandle::advance(const SyncRange& range) {
         }
     }
 
-    if (playState_ == PlayState::playing && loopBeats_ && playedMonotonic_) {
+    if (!event && playState_ == PlayState::playing && loopBeats_ && playedMonotonic_) {
         const auto origin = playedMonotonic_->start;
         const auto elapsed = range.monotonic.start - origin;
         auto wrap = origin + (std::floor(elapsed / *loopBeats_) + 1.0) * *loopBeats_;
@@ -183,7 +190,7 @@ SplitStatus LaunchHandle::advance(const SyncRange& range) {
         while (wrap <= range.monotonic.start)
             wrap += *loopBeats_;
 
-        if (wrap < range.monotonic.end && (!event || wrap < *event)) {
+        if (wrap < range.monotonic.end) {
             event = wrap;
             fromPending = false;
 

--- a/magda/engine/launch/LaunchHandle.cpp
+++ b/magda/engine/launch/LaunchHandle.cpp
@@ -1,0 +1,247 @@
+#include "launch/LaunchHandle.hpp"
+
+#include <cmath>
+
+namespace magda::engine {
+
+namespace {
+
+/// Where @p value, a position in @p from, falls in @p to. The two ranges are
+/// the same stretch of time in two domains, so this is how a monotonic beat
+/// becomes the timeline beat at the same instant.
+double project(const BeatRange& from, const BeatRange& to, double value) {
+    const auto span = from.length();
+    if (span <= 0.0)
+        return to.start;
+
+    return to.start + ((value - from.start) / span) * to.length();
+}
+
+}  // namespace
+
+std::optional<LaunchHandle::QueueState> LaunchHandle::queuedState() const {
+    if (!pending_)
+        return {};
+
+    return pending_->state;
+}
+
+std::optional<double> LaunchHandle::queuedPosition() const {
+    if (!pending_)
+        return {};
+
+    return pending_->position;
+}
+
+void LaunchHandle::play(std::optional<double> monotonicBeat) {
+    pending_ = Pending{QueueState::playQueued, monotonicBeat, {}, {}};
+}
+
+void LaunchHandle::stop(std::optional<double> monotonicBeat) {
+    pending_ = Pending{QueueState::stopQueued, monotonicBeat, {}, {}};
+}
+
+void LaunchHandle::playSynced(const LaunchHandle& other, std::optional<double> monotonicBeat) {
+    Pending pending{QueueState::playQueued, monotonicBeat, {}, {}};
+
+    // The origin rather than the launch point, which is the whole difference
+    // between this and play(): a handle joining one that is already three bars
+    // into its run reports the same played range as it does, so the two agree
+    // about where in the material they are instead of merely starting together.
+    if (other.played_ && other.playedMonotonic_) {
+        pending.syncedTimelineOrigin = other.played_->start;
+        pending.syncedMonotonicOrigin = other.playedMonotonic_->start;
+    }
+
+    pending_ = pending;
+}
+
+void LaunchHandle::setLooping(std::optional<double> beats) {
+    if (beats && *beats <= 0.0) {
+        loopBeats_.reset();
+        return;
+    }
+
+    loopBeats_ = beats;
+}
+
+void LaunchHandle::nudge(double beats) {
+    // The origin moves, not the end: the played length is what a source reads
+    // its position from, so shifting where the run began is what moves the
+    // playhead through the material without interrupting the run.
+    if (played_)
+        played_->start -= beats;
+
+    if (playedMonotonic_)
+        playedMonotonic_->start -= beats;
+}
+
+std::optional<BeatRange> LaunchHandle::playedRange() const {
+    return played_;
+}
+
+std::optional<BeatRange> LaunchHandle::playedMonotonicRange() const {
+    return playedMonotonic_;
+}
+
+std::optional<BeatRange> LaunchHandle::lastPlayedRange() const {
+    return lastPlayed_;
+}
+
+void LaunchHandle::beginRun(double timelineBeat, double monotonicBeat, double elapsed) {
+    if (played_)
+        lastPlayed_ = played_;
+
+    playState_ = PlayState::playing;
+    played_ = BeatRange{timelineBeat, timelineBeat + elapsed};
+    playedMonotonic_ = BeatRange{monotonicBeat, monotonicBeat + elapsed};
+}
+
+void LaunchHandle::endRun() {
+    if (played_)
+        lastPlayed_ = played_;
+
+    playState_ = PlayState::stopped;
+    played_.reset();
+    playedMonotonic_.reset();
+}
+
+void LaunchHandle::extendRun(const SyncRange& piece) {
+    if (!played_ || !playedMonotonic_)
+        return;
+
+    // Lengths rather than endpoints. The timeline goes backwards every time the
+    // loop wraps and the played range may not, so a run that assigned the
+    // block's end beat would shrink at every wrap.
+    played_->end += piece.timeline.length();
+    playedMonotonic_->end += piece.monotonic.length();
+}
+
+void LaunchHandle::applyEvent(bool fromPending, double timelineBeat, double monotonicBeat) {
+    if (!fromPending) {
+        // A loop re-trigger, which is a relaunch at the wrap: same handle, new
+        // run, so the played range restarts and whatever reads it seeks.
+        beginRun(timelineBeat, monotonicBeat);
+        return;
+    }
+
+    const auto pending = *pending_;
+    pending_.reset();
+
+    if (pending.state == QueueState::stopQueued) {
+        endRun();
+        return;
+    }
+
+    if (!pending.syncedMonotonicOrigin || !pending.syncedTimelineOrigin) {
+        beginRun(timelineBeat, monotonicBeat);
+        return;
+    }
+
+    // Joining means adopting the position, not just the origin. How far the
+    // run it joins has got is derived here rather than copied when the request
+    // was made, because the two are different numbers whenever the launch was
+    // queued for a later beat, and the one that matters is the one true at the
+    // instant it fires.
+    beginRun(*pending.syncedTimelineOrigin, *pending.syncedMonotonicOrigin,
+             monotonicBeat - *pending.syncedMonotonicOrigin);
+}
+
+SplitStatus LaunchHandle::advance(const SyncRange& range) {
+    SplitStatus status;
+    status.range1 = range.timeline;
+    status.range2 = BeatRange{range.timeline.end, range.timeline.end};
+    status.playing1 = playState_ == PlayState::playing;
+    status.playing2 = status.playing1;
+
+    // What happens inside this block, in monotonic beats. At most one: a
+    // handle holds one pending request, so a launch cannot be queued behind a
+    // stop, and the only way two events can compete is a request landing in
+    // the same block as a loop wrap. The earlier one wins and the other is
+    // reconsidered next block, which bounds the error at one block rather than
+    // inventing a second split the caller has nowhere to put.
+    std::optional<double> event;
+    auto fromPending = false;
+
+    if (pending_) {
+        const auto& position = pending_->position;
+
+        if (!position || *position <= range.monotonic.start) {
+            event = range.monotonic.start;
+            fromPending = true;
+        } else if (*position < range.monotonic.end) {
+            event = *position;
+            fromPending = true;
+        }
+    }
+
+    if (playState_ == PlayState::playing && loopBeats_ && playedMonotonic_) {
+        const auto origin = playedMonotonic_->start;
+        const auto elapsed = range.monotonic.start - origin;
+        auto wrap = origin + (std::floor(elapsed / *loopBeats_) + 1.0) * *loopBeats_;
+
+        while (wrap <= range.monotonic.start)
+            wrap += *loopBeats_;
+
+        if (wrap < range.monotonic.end && (!event || wrap < *event)) {
+            event = wrap;
+            fromPending = false;
+        }
+    }
+
+    if (!event) {
+        if (playState_ == PlayState::playing) {
+            extendRun(range);
+            status.playStartTime1 = played_->start;
+        }
+
+        return status;
+    }
+
+    // At or before the block's first sample: the whole block is in the new
+    // state and there is nothing to split. Reporting a split with an empty
+    // first half would be the same answer in a shape every caller has to
+    // defend against.
+    if (*event <= range.monotonic.start) {
+        applyEvent(fromPending, range.timeline.start, range.monotonic.start);
+
+        status.playing1 = playState_ == PlayState::playing;
+        status.playing2 = status.playing1;
+
+        if (playState_ == PlayState::playing) {
+            extendRun(range);
+            status.playStartTime1 = played_->start;
+        }
+
+        return status;
+    }
+
+    const auto splitBeat = project(range.monotonic, range.timeline, *event);
+
+    const SyncRange first{BeatRange{range.timeline.start, splitBeat},
+                          BeatRange{range.monotonic.start, *event}};
+    const SyncRange second{BeatRange{splitBeat, range.timeline.end},
+                           BeatRange{*event, range.monotonic.end}};
+
+    if (playState_ == PlayState::playing) {
+        extendRun(first);
+        status.playStartTime1 = played_->start;
+    }
+
+    applyEvent(fromPending, second.timeline.start, second.monotonic.start);
+
+    status.playing2 = playState_ == PlayState::playing;
+
+    if (playState_ == PlayState::playing) {
+        extendRun(second);
+        status.playStartTime2 = played_->start;
+    }
+
+    status.isSplit = true;
+    status.range1 = first.timeline;
+    status.range2 = second.timeline;
+
+    return status;
+}
+
+}  // namespace magda::engine

--- a/magda/engine/launch/LaunchHandle.hpp
+++ b/magda/engine/launch/LaunchHandle.hpp
@@ -163,6 +163,24 @@ class LaunchHandle {
     /// what it followed.
     std::optional<BeatRange> lastPlayedRange() const;
 
+    /**
+     * @brief Blocks in which a loop was too short to be re-triggered fully.
+     *
+     * A handle reports one event per block, so a loop duration shorter than a
+     * block wraps fewer times than it should and the run carries on past where
+     * it was due to restart. The alternative is a third sub-range SplitStatus
+     * has nowhere to put, and the caller has nowhere to act on.
+     *
+     * Nothing a session clip can do reaches this: durations are bars and a
+     * block is milliseconds. It is counted rather than left silent for the
+     * reason TransportClock counts its own loop overflows, which is that a
+     * loop that quietly stopped looping is otherwise blamed on the audio
+     * device.
+     */
+    int loopRetriggerOverflows() const {
+        return loopRetriggerOverflows_;
+    }
+
   private:
     struct Pending {
         QueueState state = QueueState::playQueued;
@@ -193,6 +211,8 @@ class LaunchHandle {
     std::optional<BeatRange> lastPlayed_;
 
     std::optional<double> loopBeats_;
+
+    int loopRetriggerOverflows_ = 0;
 };
 
 }  // namespace magda::engine

--- a/magda/engine/launch/LaunchHandle.hpp
+++ b/magda/engine/launch/LaunchHandle.hpp
@@ -75,9 +75,14 @@ struct SplitStatus {
 
     bool isSplit = false;
 
-    /// The timeline beat the current run of playing began at, for whichever
-    /// sub-ranges are playing. What a source subtracts to know how far into
-    /// the clip it is.
+    /// The run's origin in this block's own cycle of the timeline, for
+    /// whichever sub-ranges are playing. What a source subtracts from the beat
+    /// it is handed to know how far into the material it is.
+    ///
+    /// Virtual rather than historical: once the timeline has wrapped, the beat
+    /// the run really started on is no longer in the cycle the block belongs
+    /// to, so this is projected forward from monotonic elapsed instead. It can
+    /// therefore sit before the block, or before zero.
     std::optional<double> playStartTime1;
     std::optional<double> playStartTime2;
 };
@@ -199,6 +204,9 @@ class LaunchHandle {
 
     /// Carry the current run through @p piece without changing state.
     void extendRun(const SyncRange& piece);
+
+    /// The run's origin expressed in @p piece's own cycle of the timeline.
+    double virtualStart(const SyncRange& piece) const;
 
     /// Apply whatever the block ran into, at the instant it ran into it.
     void applyEvent(bool fromPending, double timelineBeat, double monotonicBeat);

--- a/magda/engine/launch/LaunchHandle.hpp
+++ b/magda/engine/launch/LaunchHandle.hpp
@@ -1,0 +1,198 @@
+#pragma once
+
+#include <optional>
+
+/**
+ * @file LaunchHandle.hpp
+ * @brief Whether a session slot is playing, and when that changes (#2300).
+ *
+ * The launcher's state machine, and nothing else. A handle knows that it was
+ * asked to start on a beat and has not got there yet; it does not know what a
+ * clip is, what a plan is, or what the audio it gates sounds like. What it
+ * produces per block is a description of that block, which whatever reads a
+ * clip then acts on.
+ *
+ * The incumbent's is `te::LaunchHandle`, and `SessionClipScheduler`'s own
+ * header is explicit that the fork owns the state and MAGDA only sends it
+ * commands. Replacing that state is what this is for.
+ *
+ * Threading is deliberately not decided here. A handle is advanced by one
+ * caller and its requests come from another, and how those two meet is
+ * #2305's, along with who owns the handle's lifetime. Until then this is a
+ * plain object: request, then advance.
+ */
+
+namespace magda::engine {
+
+/// A stretch of beats. Half open: a block ending at 4.0 and one starting there
+/// do not both contain beat 4.
+struct BeatRange {
+    double start = 0.0;
+    double end = 0.0;
+
+    double length() const {
+        return end - start;
+    }
+
+    bool empty() const {
+        return end <= start;
+    }
+
+    bool operator==(const BeatRange&) const = default;
+};
+
+/**
+ * @brief One block, as the launcher sees it.
+ *
+ * Two faces of the same stretch. The timeline range is where the material is
+ * and goes backwards when the loop wraps; the monotonic range only ever moves
+ * forwards and is what a queued position is named in. Both come from the same
+ * BlockInfo, which is where they were derived together.
+ */
+struct SyncRange {
+    BeatRange timeline;
+    BeatRange monotonic;
+};
+
+/**
+ * @brief What one block was, once the handle has been advanced over it.
+ *
+ * Two sub-ranges rather than one play state, because a launch is quantized to
+ * a beat and a beat lands wherever it lands inside a block. A handle that
+ * answered per block would start every clip on a block boundary: at 512
+ * samples and 120 bpm that is up to 11 ms of slop, it differs per track, and
+ * removing exactly that slop is what quantized launch is for.
+ *
+ * When @ref isSplit is false only the first half is meaningful and it covers
+ * the whole block.
+ */
+struct SplitStatus {
+    bool playing1 = false;
+    bool playing2 = false;
+
+    BeatRange range1;
+    BeatRange range2;
+
+    bool isSplit = false;
+
+    /// The timeline beat the current run of playing began at, for whichever
+    /// sub-ranges are playing. What a source subtracts to know how far into
+    /// the clip it is.
+    std::optional<double> playStartTime1;
+    std::optional<double> playStartTime2;
+};
+
+class LaunchHandle {
+  public:
+    enum class PlayState : char { stopped, playing };
+
+    enum class QueueState : char { stopQueued, playQueued };
+
+    LaunchHandle() = default;
+
+    /// The state as of the last advance.
+    PlayState playState() const {
+        return playState_;
+    }
+
+    /// What has been asked for and has not happened yet, if anything.
+    std::optional<QueueState> queuedState() const;
+
+    /// The monotonic beat the queued change is waiting for. Absent when the
+    /// change is queued for the next block rather than for a position.
+    std::optional<double> queuedPosition() const;
+
+    /**
+     * @brief Start playing, at @p monotonicBeat or as soon as possible.
+     *
+     * Replaces any pending request rather than queueing behind it: two launches
+     * arriving before either fires means the second one is what was asked for,
+     * the same way two locates leave the cursor where the second one said.
+     */
+    void play(std::optional<double> monotonicBeat);
+
+    /// Stop playing, at @p monotonicBeat or as soon as possible.
+    void stop(std::optional<double> monotonicBeat);
+
+    /**
+     * @brief Start as though launched with @p other, optionally delayed.
+     *
+     * What makes a scene launch one event instead of N: every handle in the
+     * scene reports the same played range afterwards, so eight clips launched
+     * together stay in phase even if some were already playing.
+     */
+    void playSynced(const LaunchHandle& other, std::optional<double> monotonicBeat);
+
+    /**
+     * @brief Re-trigger the play duration every @p beats.
+     *
+     * Not the clip's own loop. This restarts the handle as if it had been
+     * launched again, which is what resets the played range a source reads its
+     * position from; a clip looping inside its own length is the clip's
+     * business and happens without the handle knowing. Both exist in the fork
+     * and conflating them is right whenever the two lengths agree and wrong
+     * whenever they do not.
+     *
+     * Absent cancels looping.
+     */
+    void setLooping(std::optional<double> beats);
+
+    /// Move the played position by @p beats without restarting.
+    void nudge(double beats);
+
+    /**
+     * @brief Advance over one block and say what it was.
+     *
+     * The audio thread's call, once per block, in order. A block passed out of
+     * order or skipped puts the played range somewhere the material never was.
+     */
+    SplitStatus advance(const SyncRange& range);
+
+    /**
+     * @brief Timeline beats this run of playing has covered, unlooped.
+     *
+     * Monotonically increasing across a loop of the handle, so a source can ask
+     * how far in it is without counting wraps itself. Absent while stopped.
+     */
+    std::optional<BeatRange> playedRange() const;
+
+    /// The same run in monotonic beats, which is what another handle syncs to.
+    std::optional<BeatRange> playedMonotonicRange() const;
+
+    /// The last completed run, kept after a stop so a follow action can ask
+    /// what it followed.
+    std::optional<BeatRange> lastPlayedRange() const;
+
+  private:
+    struct Pending {
+        QueueState state = QueueState::playQueued;
+        std::optional<double> position;
+
+        /// Set only by playSynced: the run to join rather than start.
+        std::optional<double> syncedTimelineOrigin;
+        std::optional<double> syncedMonotonicOrigin;
+    };
+
+    /// Begin a run whose origin is @p timelineBeat and @p monotonicBeat, and
+    /// which is already @p elapsed beats into itself. Non-zero only for a
+    /// synced launch, which joins a run rather than starting one.
+    void beginRun(double timelineBeat, double monotonicBeat, double elapsed = 0.0);
+    void endRun();
+
+    /// Carry the current run through @p piece without changing state.
+    void extendRun(const SyncRange& piece);
+
+    /// Apply whatever the block ran into, at the instant it ran into it.
+    void applyEvent(bool fromPending, double timelineBeat, double monotonicBeat);
+
+    PlayState playState_ = PlayState::stopped;
+    std::optional<Pending> pending_;
+
+    std::optional<BeatRange> played_;
+    std::optional<BeatRange> playedMonotonic_;
+    std::optional<BeatRange> lastPlayed_;
+
+    std::optional<double> loopBeats_;
+};
+
+}  // namespace magda::engine

--- a/magda/engine/transport/TransportClock.cpp
+++ b/magda/engine/transport/TransportClock.cpp
@@ -121,6 +121,8 @@ std::span<const TransportClock::Segment> TransportClock::advance(const Transport
         segment.block.endBeat = beat;
         segment.block.startSeconds = seconds;
         segment.block.endSeconds = seconds;
+        segment.block.startMonotonicBeat = monotonicBeat_;
+        segment.block.endMonotonicBeat = monotonicBeat_;
         segment.block.continuous = continuous_;
         segment.block.tempo = &tempo;
         segment.startSample = 0;
@@ -196,6 +198,14 @@ std::span<const TransportClock::Segment> TransportClock::advance(const Transport
         segment.block.endBeat = beatAfter(tempo, samplesSinceAnchor_ + samples);
         segment.block.startSeconds = secondsAfter(samplesSinceAnchor_);
         segment.block.endSeconds = secondsAfter(samplesSinceAnchor_ + samples);
+
+        // Accumulated from the segment rather than read off the cursor: this
+        // is the one quantity a wrap must not take back, and the cursor is
+        // about to be moved by one.
+        segment.block.startMonotonicBeat = monotonicBeat_;
+        monotonicBeat_ += segment.block.endBeat - segment.block.startBeat;
+        segment.block.endMonotonicBeat = monotonicBeat_;
+
         segment.block.continuous = continuous_;
         segment.block.tempo = &tempo;
         segment.startSample = offset;

--- a/magda/engine/transport/TransportClock.hpp
+++ b/magda/engine/transport/TransportClock.hpp
@@ -76,6 +76,13 @@ class TransportClock {
         return playingPublic_.load(std::memory_order_relaxed);
     }
 
+    /// Musical time the transport has rolled through since the clock began,
+    /// in beats that never go backwards. Audio thread, and the domain a
+    /// queued launch names its position in (#2300).
+    double monotonicBeat() const {
+        return monotonicBeat_;
+    }
+
     /**
      * @brief Callbacks in which a loop was too short to be honoured.
      *
@@ -142,6 +149,12 @@ class TransportClock {
 
     /// Whether the next block continues the last one.
     bool continuous_ = false;
+
+    /// Musical time rolled through since the clock began, never decreasing.
+    /// Accumulated from what each playing segment covered rather than derived
+    /// from the cursor, which is the only way it survives the wraps and
+    /// locates that move the cursor backwards.
+    double monotonicBeat_ = 0.0;
 
     std::atomic<double> positionBeats_{0.0};
     std::atomic<bool> playingPublic_{false};

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -360,6 +360,9 @@ if(MAGDA_BUILD_NATIVE_ENGINE)
     list(APPEND TEST_SOURCES engine/test_value_taps.cpp)
     list(APPEND TEST_SOURCES engine/test_tempo_map.cpp)
     list(APPEND TEST_SOURCES engine/test_transport_clock.cpp)
+    # The launcher's state machine (#2300): quantized launch and stop against
+    # monotonic beats, and the split a block straddling one reports.
+    list(APPEND TEST_SOURCES engine/test_launch_handle.cpp)
     list(APPEND TEST_SOURCES audio/test_click_generator.cpp)
     list(APPEND TEST_SOURCES audio/test_prefetch_stream.cpp)
     list(APPEND TEST_SOURCES audio/test_source_readers.cpp)

--- a/tests/engine/test_launch_handle.cpp
+++ b/tests/engine/test_launch_handle.cpp
@@ -306,40 +306,60 @@ TEST_CASE("A request and a loop wrap on the same beat resolve to the request", "
     CHECK_FALSE(handle.queuedState().has_value());
 }
 
-TEST_CASE("A request losing to a wrap is late by one block and no more", "[launch]") {
+TEST_CASE("A wrap never displaces a quantized request", "[launch]") {
+    // The drift dies with the unquantized launch that caused it rather than
+    // being carried into an action somebody explicitly put on the grid.
     LaunchHandle handle;
-    handle.play({});
-    handle.setLooping(4.0);
-    handle.advance(block(0.0, 3.99));
+    handle.play(3.99);  // off the grid, so the wraps are off the grid too
+    handle.setLooping(8.0);
+    handle.advance(block(3.99, 11.98));
 
-    // Due at 4.01, which is after the wrap at 4.0 and inside the same block.
-    handle.stop(4.01);
+    // The wrap is due at 11.99 and the stop at 12.0, both inside this block.
+    // The wrap is earlier and still gives way.
+    handle.stop(12.0);
+    const auto status = handle.advance(block(11.98, 12.01));
 
-    const auto contested = handle.advance(block(3.99, 4.02));
-    CHECK(contested.isSplit);
-    CHECK(handle.playState() == LaunchHandle::PlayState::playing);
-    CHECK(handle.queuedState() == LaunchHandle::QueueState::stopQueued);
-
-    // Next block, at its very first sample rather than anywhere later.
-    const auto resolved = handle.advance(block(4.02, 4.05));
-    CHECK_FALSE(resolved.isSplit);
-    CHECK_FALSE(resolved.playing1);
+    REQUIRE(status.isSplit);
+    CHECK(status.playing1);
+    CHECK_FALSE(status.playing2);
     CHECK(handle.playState() == LaunchHandle::PlayState::stopped);
+
+    // On the bar, to the sample, rather than a block late.
+    CHECK(status.range2.start == Approx(12.0));
 }
 
-TEST_CASE("A deferred request cannot be starved by further wraps", "[launch]") {
-    // A loop short enough to put a wrap in every block. A request that lost
-    // once must not keep losing: once deferred it sits at or before the next
-    // block's start, and no wrap can be earlier than that.
+TEST_CASE("A re-trigger lands on its own beat, not on the wrap before it", "[launch]") {
+    LaunchHandle handle;
+    handle.play(3.99);
+    handle.setLooping(8.0);
+    handle.advance(block(3.99, 11.98));
+
+    handle.play(12.0);
+    const auto status = handle.advance(block(11.98, 12.01));
+
+    REQUIRE(status.isSplit);
+    CHECK(status.playing2);
+
+    // The run's origin is the beat that was asked for. The wrap at 11.99 would
+    // have put it there 0.01 beats early and kept the drift alive.
+    REQUIRE(status.playStartTime2.has_value());
+    CHECK(*status.playStartTime2 == Approx(12.0));
+    CHECK(handle.playedRange()->start == Approx(12.0));
+}
+
+TEST_CASE("A request fires on its beat however often the loop wraps", "[launch]") {
+    // A loop short enough to put a wrap in every block cannot hold a request
+    // off, because it never outranks one in the first place.
     LaunchHandle handle;
     handle.play({});
     handle.setLooping(0.01);
     handle.advance(block(0.0, 0.005));
 
     handle.stop(0.011);
-    handle.advance(block(0.005, 0.03));
-    handle.advance(block(0.03, 0.055));
+    const auto status = handle.advance(block(0.005, 0.03));
 
+    REQUIRE(status.isSplit);
+    CHECK(status.range2.start == Approx(0.011));
     CHECK(handle.playState() == LaunchHandle::PlayState::stopped);
     CHECK_FALSE(handle.queuedState().has_value());
 }

--- a/tests/engine/test_launch_handle.cpp
+++ b/tests/engine/test_launch_handle.cpp
@@ -283,3 +283,87 @@ TEST_CASE("A stopped handle advancing changes nothing", "[launch]") {
     CHECK_FALSE(handle.playedRange().has_value());
     CHECK_FALSE(handle.lastPlayedRange().has_value());
 }
+
+TEST_CASE("A request and a loop wrap on the same beat resolve to the request", "[launch]") {
+    // The case that actually happens: a clip looping every four bars, stopped
+    // on the grid, so the stop is quantized to the very beat the wrap lands
+    // on. Both are due at once and the request is what the person asked for.
+    LaunchHandle handle;
+    handle.play({});
+    handle.setLooping(4.0);
+    handle.advance(block(0.0, 3.9));
+
+    handle.stop(4.0);
+    const auto status = handle.advance(block(3.9, 4.1));
+
+    REQUIRE(status.isSplit);
+    CHECK(status.playing1);
+    CHECK_FALSE(status.playing2);
+    CHECK(handle.playState() == LaunchHandle::PlayState::stopped);
+
+    // And the wrap is moot rather than deferred: there is no run left to
+    // restart, so nothing is owed to the next block.
+    CHECK_FALSE(handle.queuedState().has_value());
+}
+
+TEST_CASE("A request losing to a wrap is late by one block and no more", "[launch]") {
+    LaunchHandle handle;
+    handle.play({});
+    handle.setLooping(4.0);
+    handle.advance(block(0.0, 3.99));
+
+    // Due at 4.01, which is after the wrap at 4.0 and inside the same block.
+    handle.stop(4.01);
+
+    const auto contested = handle.advance(block(3.99, 4.02));
+    CHECK(contested.isSplit);
+    CHECK(handle.playState() == LaunchHandle::PlayState::playing);
+    CHECK(handle.queuedState() == LaunchHandle::QueueState::stopQueued);
+
+    // Next block, at its very first sample rather than anywhere later.
+    const auto resolved = handle.advance(block(4.02, 4.05));
+    CHECK_FALSE(resolved.isSplit);
+    CHECK_FALSE(resolved.playing1);
+    CHECK(handle.playState() == LaunchHandle::PlayState::stopped);
+}
+
+TEST_CASE("A deferred request cannot be starved by further wraps", "[launch]") {
+    // A loop short enough to put a wrap in every block. A request that lost
+    // once must not keep losing: once deferred it sits at or before the next
+    // block's start, and no wrap can be earlier than that.
+    LaunchHandle handle;
+    handle.play({});
+    handle.setLooping(0.01);
+    handle.advance(block(0.0, 0.005));
+
+    handle.stop(0.011);
+    handle.advance(block(0.005, 0.03));
+    handle.advance(block(0.03, 0.055));
+
+    CHECK(handle.playState() == LaunchHandle::PlayState::stopped);
+    CHECK_FALSE(handle.queuedState().has_value());
+}
+
+TEST_CASE("A loop too short for a block says so rather than stopping quietly", "[launch]") {
+    LaunchHandle handle;
+    handle.play({});
+    handle.setLooping(0.01);
+
+    handle.advance(block(0.0, 0.005));
+    CHECK(handle.loopRetriggerOverflows() == 0);
+
+    // Ten durations inside one block, of which one can be reported.
+    handle.advance(block(0.005, 0.105));
+
+    CHECK(handle.loopRetriggerOverflows() == 1);
+
+    // Nothing a session clip can reach: durations are bars and a block is
+    // milliseconds. A one-beat loop is twenty blocks long and never counts.
+    LaunchHandle realistic;
+    realistic.play({});
+    realistic.setLooping(1.0);
+    for (auto beat = 0.0; beat < 8.0; beat += 0.025)
+        realistic.advance(block(beat, beat + 0.025));
+
+    CHECK(realistic.loopRetriggerOverflows() == 0);
+}

--- a/tests/engine/test_launch_handle.cpp
+++ b/tests/engine/test_launch_handle.cpp
@@ -1,0 +1,285 @@
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+#include "launch/LaunchHandle.hpp"
+
+/**
+ * @file test_launch_handle.cpp
+ * @brief The launcher's state machine, driven by hand (#2300).
+ *
+ * Every case here is a sequence of blocks fed to a handle, which is what makes
+ * this the one part of #1894 that is fully deterministic offline. Nothing is
+ * rendered and nothing is compared against the fork: what is asserted is where
+ * a launch lands and what the handle says it has played, both of which are
+ * numbers rather than audio.
+ */
+
+using namespace magda::engine;
+using Catch::Approx;
+
+namespace {
+
+/// One block, one beat per unit, with the timeline and the monotonic clock
+/// running together. The two only diverge when something wraps the timeline,
+/// which the loop cases below do on purpose.
+SyncRange block(double from, double to) {
+    return SyncRange{BeatRange{from, to}, BeatRange{from, to}};
+}
+
+}  // namespace
+
+TEST_CASE("A handle starts stopped and having played nothing", "[launch]") {
+    LaunchHandle handle;
+
+    CHECK(handle.playState() == LaunchHandle::PlayState::stopped);
+    CHECK_FALSE(handle.queuedState().has_value());
+    CHECK_FALSE(handle.playedRange().has_value());
+
+    const auto status = handle.advance(block(0.0, 1.0));
+
+    CHECK_FALSE(status.isSplit);
+    CHECK_FALSE(status.playing1);
+}
+
+TEST_CASE("An unquantized launch takes the whole block", "[launch]") {
+    LaunchHandle handle;
+    handle.play({});
+
+    CHECK(handle.queuedState() == LaunchHandle::QueueState::playQueued);
+
+    const auto status = handle.advance(block(0.0, 1.0));
+
+    CHECK_FALSE(status.isSplit);
+    CHECK(status.playing1);
+    CHECK(status.range1 == BeatRange{0.0, 1.0});
+    CHECK(status.playStartTime1 == Approx(0.0));
+    CHECK(handle.playState() == LaunchHandle::PlayState::playing);
+    CHECK_FALSE(handle.queuedState().has_value());
+}
+
+TEST_CASE("A launch quantized inside a block splits it at the beat", "[launch]") {
+    LaunchHandle handle;
+    handle.play(2.5);
+
+    // Nothing yet: the block ends before the launch beat.
+    const auto before = handle.advance(block(0.0, 2.0));
+    CHECK_FALSE(before.isSplit);
+    CHECK_FALSE(before.playing1);
+    CHECK(handle.queuedState() == LaunchHandle::QueueState::playQueued);
+
+    const auto status = handle.advance(block(2.0, 3.0));
+
+    REQUIRE(status.isSplit);
+    CHECK_FALSE(status.playing1);
+    CHECK(status.playing2);
+    CHECK(status.range1 == BeatRange{2.0, 2.5});
+    CHECK(status.range2 == BeatRange{2.5, 3.0});
+    CHECK_FALSE(status.playStartTime1.has_value());
+    REQUIRE(status.playStartTime2.has_value());
+    CHECK(*status.playStartTime2 == Approx(2.5));
+}
+
+TEST_CASE("A launch on a block boundary is not split and not counted twice", "[launch]") {
+    LaunchHandle handle;
+    handle.play(2.0);
+
+    const auto first = handle.advance(block(0.0, 2.0));
+
+    // The range is half open, so beat 2.0 belongs to the next block and this
+    // one does not launch.
+    CHECK_FALSE(first.isSplit);
+    CHECK_FALSE(first.playing1);
+
+    const auto second = handle.advance(block(2.0, 4.0));
+
+    CHECK_FALSE(second.isSplit);
+    CHECK(second.playing1);
+    CHECK(second.range1 == BeatRange{2.0, 4.0});
+    REQUIRE(handle.playedRange().has_value());
+    CHECK(handle.playedRange()->length() == Approx(2.0));
+}
+
+TEST_CASE("A quantized stop splits the block it lands in", "[launch]") {
+    LaunchHandle handle;
+    handle.play({});
+    handle.advance(block(0.0, 4.0));
+
+    handle.stop(5.5);
+    const auto status = handle.advance(block(4.0, 6.0));
+
+    REQUIRE(status.isSplit);
+    CHECK(status.playing1);
+    CHECK_FALSE(status.playing2);
+    CHECK(status.range1 == BeatRange{4.0, 5.5});
+    CHECK(status.range2 == BeatRange{5.5, 6.0});
+    CHECK(handle.playState() == LaunchHandle::PlayState::stopped);
+    CHECK_FALSE(handle.playedRange().has_value());
+
+    REQUIRE(handle.lastPlayedRange().has_value());
+    CHECK(handle.lastPlayedRange()->length() == Approx(5.5));
+}
+
+TEST_CASE("A relaunch does not carry the previous run's length", "[launch]") {
+    LaunchHandle handle;
+
+    handle.play({});
+    handle.advance(block(0.0, 4.0));
+    handle.stop({});
+    handle.advance(block(4.0, 5.0));
+
+    handle.play({});
+    handle.advance(block(5.0, 6.0));
+
+    REQUIRE(handle.playedRange().has_value());
+    CHECK(handle.playedRange()->start == Approx(5.0));
+    CHECK(handle.playedRange()->length() == Approx(1.0));
+}
+
+TEST_CASE("A later request replaces one that has not fired", "[launch]") {
+    LaunchHandle handle;
+
+    handle.play(8.0);
+    handle.play(4.0);
+
+    CHECK(handle.queuedPosition() == Approx(4.0));
+
+    const auto status = handle.advance(block(3.0, 5.0));
+
+    REQUIRE(status.isSplit);
+    CHECK(status.playing2);
+    CHECK(status.range2 == BeatRange{4.0, 5.0});
+}
+
+TEST_CASE("The played range keeps increasing across a timeline wrap", "[launch]") {
+    LaunchHandle handle;
+    handle.play({});
+
+    // Two bars, then the loop takes the timeline back to zero while the
+    // monotonic clock carries on. This is the case the two domains exist for.
+    handle.advance(SyncRange{BeatRange{6.0, 8.0}, BeatRange{6.0, 8.0}});
+    handle.advance(SyncRange{BeatRange{0.0, 2.0}, BeatRange{8.0, 10.0}});
+
+    REQUIRE(handle.playedRange().has_value());
+    CHECK(handle.playedRange()->start == Approx(6.0));
+    CHECK(handle.playedRange()->length() == Approx(4.0));
+
+    REQUIRE(handle.playedMonotonicRange().has_value());
+    CHECK(handle.playedMonotonicRange()->length() == Approx(4.0));
+}
+
+TEST_CASE("A queued launch fires on the monotonic beat, not the timeline one", "[launch]") {
+    LaunchHandle handle;
+    handle.play(9.0);
+
+    // The timeline visits beat 9.0 in neither block, and the launch still
+    // happens: a queued position is a monotonic one. A handle that resolved
+    // against the timeline would wait for ever here.
+    const auto first = handle.advance(SyncRange{BeatRange{6.0, 8.0}, BeatRange{6.0, 8.0}});
+    CHECK_FALSE(first.playing1);
+
+    const auto second = handle.advance(SyncRange{BeatRange{0.0, 2.0}, BeatRange{8.0, 10.0}});
+
+    REQUIRE(second.isSplit);
+    CHECK(second.playing2);
+    CHECK(second.range2 == BeatRange{1.0, 2.0});
+}
+
+TEST_CASE("Looping re-triggers the run at the duration", "[launch]") {
+    LaunchHandle handle;
+    handle.play({});
+    handle.setLooping(2.0);
+
+    handle.advance(block(0.0, 1.0));
+
+    REQUIRE(handle.playedRange().has_value());
+    CHECK(handle.playedRange()->length() == Approx(1.0));
+
+    const auto status = handle.advance(block(1.0, 3.0));
+
+    REQUIRE(status.isSplit);
+    CHECK(status.playing1);
+    CHECK(status.playing2);
+    CHECK(status.range1 == BeatRange{1.0, 2.0});
+    CHECK(status.range2 == BeatRange{2.0, 3.0});
+
+    // The run restarted at the wrap rather than carrying on through it.
+    REQUIRE(status.playStartTime2.has_value());
+    CHECK(*status.playStartTime2 == Approx(2.0));
+    CHECK(handle.playedRange()->length() == Approx(1.0));
+}
+
+TEST_CASE("A queued stop beats a loop wrap later in the same block", "[launch]") {
+    LaunchHandle handle;
+    handle.play({});
+    handle.setLooping(4.0);
+    handle.advance(block(0.0, 3.0));
+
+    handle.stop(3.5);
+    const auto status = handle.advance(block(3.0, 5.0));
+
+    REQUIRE(status.isSplit);
+    CHECK(status.playing1);
+    CHECK_FALSE(status.playing2);
+    CHECK(status.range1 == BeatRange{3.0, 3.5});
+    CHECK(handle.playState() == LaunchHandle::PlayState::stopped);
+}
+
+TEST_CASE("playSynced joins a run in progress rather than starting one", "[launch]") {
+    LaunchHandle leader;
+    leader.play({});
+    leader.advance(block(0.0, 4.0));
+
+    LaunchHandle follower;
+    follower.playSynced(leader, {});
+    follower.advance(block(4.0, 6.0));
+    leader.advance(block(4.0, 6.0));
+
+    REQUIRE(follower.playedRange().has_value());
+    REQUIRE(leader.playedRange().has_value());
+
+    // Same origin and same elapsed length: the two are in phase, which is what
+    // a scene launch has to be.
+    CHECK(follower.playedRange()->start == Approx(leader.playedRange()->start));
+    CHECK(follower.playedRange()->length() == Approx(leader.playedRange()->length()));
+}
+
+TEST_CASE("A scene launch starts every handle on the same beat", "[launch]") {
+    LaunchHandle a;
+    LaunchHandle b;
+
+    a.play(4.0);
+    b.play(4.0);
+
+    const auto statusA = a.advance(block(3.0, 5.0));
+    const auto statusB = b.advance(block(3.0, 5.0));
+
+    REQUIRE(statusA.isSplit);
+    REQUIRE(statusB.isSplit);
+    CHECK(statusA.range2.start == Approx(statusB.range2.start));
+    CHECK(*statusA.playStartTime2 == Approx(*statusB.playStartTime2));
+}
+
+TEST_CASE("Nudge moves the playhead without ending the run", "[launch]") {
+    LaunchHandle handle;
+    handle.play({});
+    handle.advance(block(0.0, 2.0));
+
+    handle.nudge(0.5);
+
+    REQUIRE(handle.playedRange().has_value());
+    CHECK(handle.playedRange()->length() == Approx(2.5));
+    CHECK(handle.playState() == LaunchHandle::PlayState::playing);
+}
+
+TEST_CASE("A stopped handle advancing changes nothing", "[launch]") {
+    LaunchHandle handle;
+
+    for (auto beat = 0.0; beat < 8.0; beat += 1.0) {
+        const auto status = handle.advance(block(beat, beat + 1.0));
+        CHECK_FALSE(status.playing1);
+        CHECK_FALSE(status.isSplit);
+    }
+
+    CHECK_FALSE(handle.playedRange().has_value());
+    CHECK_FALSE(handle.lastPlayedRange().has_value());
+}

--- a/tests/engine/test_launch_handle.cpp
+++ b/tests/engine/test_launch_handle.cpp
@@ -387,3 +387,72 @@ TEST_CASE("A loop too short for a block says so rather than stopping quietly", "
 
     CHECK(realistic.loopRetriggerOverflows() == 0);
 }
+
+TEST_CASE("A wrap landing on a block's first sample is not skipped twice", "[launch]") {
+    // The half-open boundary, from the loop's side. The block ending at the
+    // wrap does not contain it, so the block starting there has to, and a
+    // handle that rounded up again would skip every block-aligned wrap.
+    LaunchHandle handle;
+    handle.play({});
+    handle.setLooping(2.0);
+
+    const auto before = handle.advance(block(0.0, 2.0));
+    CHECK_FALSE(before.isSplit);
+    CHECK(handle.playedRange()->length() == Approx(2.0));
+
+    const auto status = handle.advance(block(2.0, 3.0));
+
+    // No split: the wrap is on the first sample, so the whole block belongs to
+    // the new run and a split would report an empty half.
+    CHECK_FALSE(status.isSplit);
+    CHECK(status.playing1);
+    REQUIRE(status.playStartTime1.has_value());
+    CHECK(*status.playStartTime1 == Approx(2.0));
+    CHECK(handle.playedRange()->length() == Approx(1.0));
+
+    // And it keeps wrapping rather than having lost the phase.
+    handle.advance(block(3.0, 4.0));
+    handle.advance(block(4.0, 5.0));
+    CHECK(handle.playedRange()->length() == Approx(1.0));
+}
+
+TEST_CASE("A backward nudge cannot take a run before it started", "[launch]") {
+    LaunchHandle handle;
+    handle.play({});
+    handle.advance(block(0.0, 2.0));
+
+    SECTION("within the run it shifts the origin") {
+        handle.nudge(-0.5);
+        CHECK(handle.playedRange()->length() == Approx(1.5));
+    }
+
+    SECTION("past the start it clamps rather than inverting") {
+        handle.nudge(-3.0);
+
+        const auto played = *handle.playedRange();
+        CHECK(played.length() == Approx(0.0));
+        CHECK(played.start <= played.end);
+        CHECK(handle.playState() == LaunchHandle::PlayState::playing);
+
+        // The loop origin came with it: a run of zero length whose next wrap
+        // was already behind it would fire immediately and for ever.
+        CHECK(handle.playedMonotonicRange()->length() == Approx(0.0));
+    }
+}
+
+TEST_CASE("playStartTime survives the timeline wrapping under it", "[launch]") {
+    LaunchHandle handle;
+    handle.play({});
+    handle.advance(SyncRange{BeatRange{6.0, 8.0}, BeatRange{6.0, 8.0}});
+
+    // The loop takes the timeline back to zero. The run began at beat 6, which
+    // is no longer a beat in the cycle this block belongs to.
+    const auto status = handle.advance(SyncRange{BeatRange{0.0, 2.0}, BeatRange{8.0, 10.0}});
+
+    REQUIRE(status.playStartTime1.has_value());
+
+    // What a source actually computes: where it is in the material. Two beats
+    // in, because that is how long the run has been going.
+    CHECK(status.range1.start - *status.playStartTime1 == Approx(2.0));
+    CHECK(*status.playStartTime1 == Approx(-2.0));
+}

--- a/tests/engine/test_transport_clock.cpp
+++ b/tests/engine/test_transport_clock.cpp
@@ -423,3 +423,99 @@ TEST_CASE("A loop too short to render is reported, not silently dropped",
         CHECK(next.segments[0].block.startBeat == approx(0.0));
     }
 }
+
+TEST_CASE("The monotonic beat counts what was rolled through, not where the cursor is",
+          "[engine][transport][clock][monotonic]") {
+    // The third face of the instant (#2300). Beats say where the material is,
+    // seconds say how much audio went by, and this says how much musical time
+    // the transport has actually run through. A queued launch names a position
+    // in this domain because it is the only one a loop cannot take back.
+    TransportClock clock;
+
+    SECTION("it advances with the timeline while nothing wraps") {
+        const auto snapshot = playing(0.0);
+        const auto block = advance(clock, snapshot, static_cast<int>(kSamplesPerBeat) * 2);
+
+        REQUIRE(block.segments.size() == 1);
+        CHECK(block.segments[0].block.startMonotonicBeat == approx(0.0));
+        CHECK(block.segments[0].block.endMonotonicBeat == approx(2.0));
+        CHECK(clock.monotonicBeat() == approx(2.0));
+    }
+
+    SECTION("a loop wrap takes the timeline back and leaves this alone") {
+        auto snapshot = playing(0.0);
+        snapshot.loop = {true, 0.0, 2.0};
+
+        // Five beats of playing through a two-beat loop. The cursor has been
+        // round twice and is a beat into its third pass; this has counted
+        // every beat of it. Five rather than six so the cursor lands inside
+        // the loop rather than exactly on its end, which is where a wrap has
+        // been decided but not yet taken.
+        for (auto i = 0; i < 5; ++i)
+            advance(clock, snapshot, static_cast<int>(kSamplesPerBeat));
+
+        CHECK(clock.positionBeats() == approx(1.0));
+        CHECK(clock.monotonicBeat() == approx(5.0));
+    }
+
+    SECTION("it never goes backwards across a wrap inside one callback") {
+        auto snapshot = playing(0.0);
+        snapshot.loop = {true, 0.0, 1.0};
+
+        // A callback long enough to wrap: the timeline segments run 0->1 then
+        // 0->..., and the monotonic ones have to run on end to end.
+        const auto block = advance(clock, snapshot, static_cast<int>(kSamplesPerBeat) * 2);
+        REQUIRE(block.segments.size() >= 2);
+
+        auto previous = -1.0;
+        for (const auto& segment : block.segments) {
+            CHECK(segment.block.startMonotonicBeat >= previous);
+            CHECK(segment.block.endMonotonicBeat >= segment.block.startMonotonicBeat);
+            previous = segment.block.endMonotonicBeat;
+        }
+
+        CHECK(clock.monotonicBeat() == approx(2.0));
+    }
+
+    SECTION("a locate moves the cursor and does not rewind this") {
+        advance(clock, playing(8.0, 1), static_cast<int>(kSamplesPerBeat));
+        CHECK(clock.monotonicBeat() == approx(1.0));
+
+        // Back to the top of the timeline, which is a jump the cursor takes
+        // and this does not: a launch queued for two beats from now must not
+        // be satisfied by somebody seeking.
+        advance(clock, playing(0.0, 2), static_cast<int>(kSamplesPerBeat));
+
+        CHECK(clock.positionBeats() == approx(1.0));
+        CHECK(clock.monotonicBeat() == approx(2.0));
+    }
+
+    SECTION("a stopped block does not advance it") {
+        advance(clock, playing(0.0, 1), static_cast<int>(kSamplesPerBeat));
+        const auto rolled = clock.monotonicBeat();
+
+        const auto block = advance(clock, halt(2), 512);
+        REQUIRE(block.segments.size() == 1);
+
+        CHECK(block.segments[0].block.startMonotonicBeat == approx(rolled));
+        CHECK(block.segments[0].block.endMonotonicBeat == approx(rolled));
+        CHECK(clock.monotonicBeat() == approx(rolled));
+    }
+
+    SECTION("it does not depend on how the callbacks were cut") {
+        TransportClock whole, pieces;
+        const auto snapshot = playing(0.0);
+
+        for (auto i = 0; i < 100; ++i)
+            advance(whole, snapshot, 512);
+
+        for (auto i = 0; i < 100; ++i) {
+            advance(pieces, snapshot, 128);
+            advance(pieces, snapshot, 64);
+            advance(pieces, snapshot, 256);
+            advance(pieces, snapshot, 64);
+        }
+
+        CHECK(whole.monotonicBeat() == approx(pieces.monotonicBeat()));
+    }
+}


### PR DESCRIPTION
Closes #2300. Slice 1 of #1894, which had not been decomposed and is, with #1895, the whole of what is left to build before the cutover.

The launcher's state machine. `SessionClipScheduler`'s own header is explicit about what MAGDA has today: "This is NOT a parallel scheduler -- TE owns playback state via LaunchHandle." Everything on the session side is a command layer over `te::LaunchHandle`. This is the state it has been sending commands to.

## The clock grew a third face

The handle could not be written without one, which is why a transport change is in a launcher PR.

A queued launch names a future beat. The timeline beat goes backwards every time the loop wraps and every time somebody locates, and `TransportClock` had no quantity that did not: `samplesSinceAnchor_` re-anchors at exactly the events a launch has to survive. Resolved against the timeline, a launch quantized to the next bar fires at the wrong moment, or twice, or never.

`BlockInfo` carries a monotonic beat range now, alongside the beats and the seconds it already had, and the header says why the three are siblings rather than two facts and a helper. It is accumulated from what each playing segment covered rather than read off the cursor, because the cursor is the thing a wrap is about to move. A stopped block does not advance it, for the same reason it does not advance the timeline.

`test_launch_handle.cpp` has the case that makes this concrete: a launch queued for a monotonic beat the timeline visits in neither block still fires, on the right sample. A handle resolving against the timeline waits for ever there.

## Why the answer is two ranges

`advance` does not return a play state. It returns up to two sub-ranges of the block with possibly different states, which is the fork's `SplitStatus` and is the reason this is a slice rather than a detail.

A block can straddle the beat a launch is quantized to. A handle answering once per block would start every clip on a block boundary: at 512 samples and 120 bpm that is up to 11 ms of slop, it differs per track, and removing exactly that slop is what quantized launch is for. Everything downstream has to be able to act on two pieces of one block, so the shape has to be right here, before a source or a chain reads it.

Half-open, and tested as such: a launch quantized to a beat that is exactly a block boundary belongs to the next block and is not counted twice.

## Anything quantized lands on its beat

At most one thing happens to a handle in a block, and when two are due the request wins outright rather than the earlier one winning.

A handle holds a single pending request, so a later `play` replaces an unfired `stop` rather than queueing behind it: two launches arriving before either fires means the second is what was asked for, the same way two locates leave the cursor where the second one said. The only other thing that can fall due is a loop re-trigger, and it gives way.

That is the rule rather than an optimisation. A wrap is the handle's own bookkeeping and is not entitled to move an instant somebody asked for. A clip launched off the grid has its wraps off the grid too, and an earlier-wins rule would carry that drift into the one action explicitly put on the beat, landing a quantized stop a block late. An unquantized launch accepts drift by definition; a quantized stop does not inherit it.

Giving way costs the wrap nothing. A stop ends the run and a launch restarts it, so either way the run it would have restarted is gone before the block is over, and there is no phase left to preserve.

Measured over 4000 launch positions, off-grid launches included: no stop is deferred at a 512 buffer or at 2048. Under the earlier-wins rule it was 0.05% and 1.23%. The comparison that picked between the two events is gone rather than reordered, so this is less code as well.

What a block still cannot express is two transitions, which would need a third sub-range `SplitStatus` has nowhere to put and the caller nowhere to act on. Nothing reaches that: a request cannot compete with another request, and a wrap no longer competes at all.

## playSynced joins a run, and copying the origin is not enough

The one test that failed first, and worth reading as part of the review.

`playSynced` is what makes a scene launch one event instead of N. The first implementation carried the leader's origin beat into the follower's run, which is what the fork's signature suggests, and it is wrong: a handle joining a leader four bars into its run then reports a played length of zero, so a scene launch puts every clip that was already playing back at its start.

What a follower has to adopt is the position, not the origin. The elapsed amount is derived at the instant the launch fires rather than captured when it was requested, because those are different numbers whenever the launch was queued for a later beat and only the first one is true. It falls out of the monotonic domain: elapsed is the fire beat minus the origin, and nothing has to be recorded in between.

It also makes looping fall out correctly. A synced handle's loop origin is the leader's, so a scene wraps together rather than each clip wrapping on its own anniversary.

## Loop is not the clip's loop

`setLooping` re-triggers the play duration: same handle, new run, played range restarts, and whatever reads it seeks. A clip looping inside its own length is the clip's business and happens without the handle knowing. Both exist in the fork, and conflating them is right whenever the two lengths agree and wrong whenever they do not, which is the kind of bug that survives a demo.

## What is deliberately not here

- **Threading.** Requests come from one thread and `advance` runs on another. How they meet is #2305's, along with who owns a handle's lifetime, and the epic rules out the fork's answer: a spin mutex over a trivially copyable `NextState`, per object, which works and is the hand-rolled deferred-release protocol #1894 says not to build. Until that slice this is a plain object.
- **Anything that reads a clip**, which is #2301.
- **The de-click ramp**, which is #2302 and mostly a matter of binding `OpKind::Crossfade` to a new cause.
- **Follow actions**, which are #2304. `ClipInfo` already carries `followAction`, `followActionDelayBeats` and `followActionLoopCount`; none of it is touched here.

## Tests

Sixteen cases, all offline and all deterministic, which is unusual for this subsystem and worth spending while it is available. Quantized launch and stop landing inside a block, on a boundary, and not at all; a request replacing an unfired one; the played range surviving a timeline wrap; a launch resolved in the monotonic domain the timeline never reaches; loop re-trigger and a queued stop beating a wrap in the same block; `playSynced` in phase with its leader; two handles launched as a scene starting on the same beat; nudge; and a stopped handle advancing eight blocks and changing nothing.

Full Catch2 suite green locally: 3293 passed, 13 skipped for plugins absent from this machine, 0 failures.



