### PR TITLE
Unify agent and MCP access to MagdaApi (#2295, #2296, #2297)

### DIFF
--- a/docs/architecture/remote-api-permissions.md
+++ b/docs/architecture/remote-api-permissions.md
@@ -53,10 +53,10 @@ Five words, shared by both transports. An operation requires exactly one.
 | Scope | Covers |
 | --- | --- |
 | `read` | Every read operation, and subscribing to any topic. Every client has this — it is what being admitted means. |
-| `edit` | Project content: tempo, time signature, tracks, clips, notes, devices, racks, automation, and the user's selection. Device parameter writes and opening plugin editor windows are edits too. |
+| `edit` | Project content: tempo, time signature, tracks, clips, notes, devices, racks, grooves, automation, and the user's selection. Device parameter writes, focused-macro writes, and opening plugin editor windows are edits too. |
 | `transport` | The timeline: play, stop, record-arm, loop, seek. |
 | `session` | Launching and stopping session clips and scenes. |
-| `hardware-midi` | Physical MIDI ports, including SysEx. |
+| `hardware-midi` | Physical MIDI ports: `midi.send` and `midi.sendSysEx`. |
 
 The split is by what a user would regret, not by which manager the code calls.
 Driving the transport is separate from editing because a remote that only starts
@@ -68,13 +68,14 @@ changes no project content and does not move the playhead.
 user is looking at and what their next keystroke acts on, which is not something
 a read-only client should reach.
 
-**`hardware-midi` has no operations yet.** The registry exposes no hardware MIDI
-surface. The scope is declared now because grants are persisted: a word invented
-later would read as "not granted" on every existing client — the correct answer,
-but only if the word already exists when those grants are written. It also gives
-the settings UI a stable place to show the permission before there is anything
-behind it. When a MIDI-out or SysEx operation lands, it declares this scope and
-the enforcement already works.
+**`hardware-midi` gates `midi.send` and `midi.sendSysEx`** (#2297). The scope
+was declared before any operation required it, because grants are persisted: a
+word invented later would read as "not granted" on every existing client — the
+correct answer, but only if the word already exists when those grants are
+written. That bet paid out exactly as designed: when these operations landed,
+every existing grant read as "not granted" and the enforcement already worked.
+`midi.listOutputPorts` is a plain read — port names reveal hardware, not
+project content, and a client that may send needs to know where.
 
 ### Where the mapping lives
 

--- a/magda/agents/CMakeLists.txt
+++ b/magda/agents/CMakeLists.txt
@@ -14,6 +14,10 @@ set(AGENTS_SOURCES
     agent_runtime.cpp
     fast_inference_policy.hpp
     fast_inference_policy.cpp
+    agent_tool_bridge.hpp
+    agent_tool_bridge.cpp
+    llm_tool_model.hpp
+    llm_tool_model.cpp
     console_agent_orchestrator.hpp
     console_agent_orchestrator.cpp
     instruction_executor.hpp

--- a/magda/agents/agent_tool_bridge.cpp
+++ b/magda/agents/agent_tool_bridge.cpp
@@ -59,7 +59,10 @@ remote::ScopeSet agentScopesForSurface(const AgentSurface& surface) {
 
 RemoteAgentToolExecutor::RemoteAgentToolExecutor(remote::RemoteApiService& service,
                                                  const AgentSurface& surface)
-    : service_(service), surface_(surface), scopes_(agentScopesForSurface(surface)) {}
+    : service_(service),
+      surface_(surface),
+      scopes_(agentScopesForSurface(surface)),
+      runNamespace_(juce::Uuid().toDashedString()) {}
 
 ToolResult RemoteAgentToolExecutor::execute(const ToolExecutionRequest& request,
                                             const CancellationToken& cancellation) {
@@ -88,7 +91,7 @@ ToolResult RemoteAgentToolExecutor::execute(const ToolExecutionRequest& request,
     context.clientId = "agent:" + juce::String(surface_.name);
     context.clientName = "magda-agent";
     context.transport = "in-app";
-    context.requestId = request.call.id;
+    context.requestId = runNamespace_ + "/" + request.call.id;
     // The runtime threads the revision it last observed; passing it through
     // gives agent writes the same optimistic concurrency a remote client gets.
     // Zero means the run has observed nothing yet and expects nothing.

--- a/magda/agents/agent_tool_bridge.cpp
+++ b/magda/agents/agent_tool_bridge.cpp
@@ -1,0 +1,152 @@
+#include "agent_tool_bridge.hpp"
+
+#include <algorithm>
+#include <chrono>
+#include <memory>
+
+#include "../daw/api/remote_service.hpp"
+
+namespace magda::agent {
+namespace {
+
+const remote::OperationDescriptor* resolvableOperation(const std::string& name) {
+    const auto* operation = remote::OperationRegistry::instance().find(juce::String(name));
+    if (operation == nullptr) {
+        juce::Logger::writeToLog("Agent surface allowlist names an unknown operation: " + name);
+        jassertfalse;
+        return nullptr;
+    }
+    // Transport-scoped operations (subscriptions) are per-connection state and
+    // an in-process agent has no connection; a surface listing one would hand
+    // the model a tool nothing can execute.
+    if (operation->transportScoped) {
+        juce::Logger::writeToLog("Agent surface allowlist names a transport-scoped operation: " +
+                                 name);
+        jassertfalse;
+        return nullptr;
+    }
+    return operation;
+}
+
+}  // namespace
+
+std::vector<ToolDefinition> agentToolsForSurface(const AgentSurface& surface) {
+    std::vector<ToolDefinition> tools;
+    tools.reserve(surface.toolAllowlist.size());
+    for (const auto& name : surface.toolAllowlist) {
+        const auto* operation = resolvableOperation(name);
+        if (operation == nullptr)
+            continue;
+        tools.push_back({.name = operation->name,
+                         .description = operation->summary,
+                         .inputSchema = operation->inputSchema.clone(),
+                         .access = operation->access == remote::OperationAccess::Write
+                                       ? ToolAccess::Mutation
+                                       : ToolAccess::Read});
+    }
+    return tools;
+}
+
+remote::ScopeSet agentScopesForSurface(const AgentSurface& surface) {
+    remote::ScopeSet scopes{remote::Scope::Read};
+    for (const auto& name : surface.toolAllowlist) {
+        const auto* operation = resolvableOperation(name);
+        if (operation != nullptr)
+            scopes.add(operation->requiredScope);
+    }
+    return scopes;
+}
+
+RemoteAgentToolExecutor::RemoteAgentToolExecutor(remote::RemoteApiService& service,
+                                                 const AgentSurface& surface)
+    : service_(service), surface_(surface), scopes_(agentScopesForSurface(surface)) {}
+
+ToolResult RemoteAgentToolExecutor::execute(const ToolExecutionRequest& request,
+                                            const CancellationToken& cancellation) {
+    const auto failure = [&](juce::String code, juce::String message,
+                             juce::var details = {}) -> ToolResult {
+        return {.callId = request.call.id,
+                .toolName = request.call.name,
+                .success = false,
+                .content = {},
+                .error = ToolError{.code = std::move(code),
+                                   .message = std::move(message),
+                                   .details = std::move(details)},
+                // The current revision, never something older: the runtime
+                // treats a regressed revision as a broken executor.
+                .projectRevision = service_.currentRevision(),
+                .mutated = false};
+    };
+
+    const bool allowed = std::find(surface_.toolAllowlist.begin(), surface_.toolAllowlist.end(),
+                                   request.call.name.toStdString()) != surface_.toolAllowlist.end();
+    if (!allowed)
+        return failure("tool_not_allowed", "Operation '" + request.call.name + "' is not in the " +
+                                               surface_.name + " surface's allowlist");
+
+    remote::RequestContext context;
+    context.clientId = "agent:" + juce::String(surface_.name);
+    context.clientName = "magda-agent";
+    context.transport = "in-app";
+    context.requestId = request.call.id;
+    // The runtime threads the revision it last observed; passing it through
+    // gives agent writes the same optimistic concurrency a remote client gets.
+    // Zero means the run has observed nothing yet and expects nothing.
+    if (request.expectedRevision != 0)
+        context.expectedRevision = request.expectedRevision;
+    context.scopes = scopes_;
+    context.deadline = request.deadline;
+
+    const auto revisionBefore = service_.currentRevision();
+
+    // The service runs the completion inline when this is already the message
+    // thread (or there is none), and posts it to the message thread otherwise —
+    // so one dispatch-and-wait covers every calling context, and the inline
+    // cases signal before the first wait. Shared state keeps the completion
+    // valid even if this thread abandons the wait at the deadline.
+    struct Pending {
+        juce::WaitableEvent done;
+        remote::Response response;
+    };
+    auto pending = std::make_shared<Pending>();
+    service_.dispatch(request.call.name, request.call.arguments, context,
+                      [pending](remote::Response completed) {
+                          pending->response = std::move(completed);
+                          pending->done.signal();
+                      });
+
+    constexpr int pollMs = 50;
+    while (!pending->done.wait(pollMs)) {
+        if (cancellation.isCancellationRequested())
+            return failure("cancelled", "Run cancelled while the operation was in flight");
+        if (std::chrono::steady_clock::now() >= request.deadline)
+            return failure("time_limit", "Operation did not complete before the deadline");
+    }
+    const remote::Response response = std::move(pending->response);
+
+    if (!response.ok) {
+        juce::var details;
+        if (!response.error.issues.empty()) {
+            juce::Array<juce::var> issues;
+            for (const auto& issue : response.error.issues) {
+                auto* entry = new juce::DynamicObject();
+                entry->setProperty("path", issue.path);
+                entry->setProperty("code", issue.code);
+                entry->setProperty("message", issue.message);
+                issues.add(entry);
+            }
+            details = issues;
+        }
+        return failure(remote::toString(response.error.code), response.error.message, details);
+    }
+
+    return {.callId = request.call.id,
+            .toolName = request.call.name,
+            .success = true,
+            .content = response.result,
+            .error = {},
+            .projectRevision = response.revision,
+            .mutated = response.revision != revisionBefore};
+}
+
+}  // namespace magda::agent

--- a/magda/agents/agent_tool_bridge.hpp
+++ b/magda/agents/agent_tool_bridge.hpp
@@ -1,0 +1,83 @@
+#pragma once
+
+#include <vector>
+
+#include "../daw/api/remote_scopes.hpp"
+#include "../daw/core/ConsoleRouting.hpp"
+#include "agent_runtime.hpp"
+
+namespace magda::remote {
+class RemoteApiService;
+}
+
+namespace magda::agent {
+
+/**
+ * @brief The bridge `agent_runtime.hpp` demands: agents act through the same
+ *        operation contract as every remote client (#2295).
+ *
+ * `ToolExecutor`'s contract says production adapters must delegate to
+ * `RemoteApiService`, and until this existed the only implementation was a test
+ * fake — in-app agents held a raw `MagdaApi&` and bypassed validation, scopes,
+ * and the audit log entirely. This file is the missing production half:
+ *
+ * - `agentToolsForSurface` turns a `ConsoleRouting` surface allowlist into the
+ *   tool set an `AgentDefinition` carries, resolved against
+ *   `remote::OperationRegistry`. The allowlist stops being prompt metadata and
+ *   becomes the agent's actual capability boundary: the runtime refuses calls
+ *   outside its definition, so a surface's agent structurally cannot reach an
+ *   operation the surface does not declare.
+ * - `RemoteAgentToolExecutor` executes each call through the service, which is
+ *   where schema validation, scope enforcement, revision tracking, undo
+ *   grouping, and the audit record already live — once, for every caller.
+ */
+
+/**
+ * @brief The surface's allowlist as executable tool definitions.
+ *
+ * One `ToolDefinition` per allowlisted operation, carrying the registry's
+ * summary and input schema so the model sees the same contract an MCP client
+ * does. Transport-scoped operations and names the registry does not know are
+ * skipped and logged — `invalidSurfaceTools` exists to keep the lists in sync,
+ * and a test pins every registered surface to resolve completely.
+ */
+std::vector<ToolDefinition> agentToolsForSurface(const AgentSurface& surface);
+
+/**
+ * @brief The scopes the surface's allowlist requires, plus `read`.
+ *
+ * Computed from the resolved operations' `requiredScope` rather than granted
+ * wholesale, so a surface whose allowlist holds no session operation cannot
+ * launch clips even if a handler is misrouted.
+ */
+remote::ScopeSet agentScopesForSurface(const AgentSurface& surface);
+
+/**
+ * @brief `ToolExecutor` over `RemoteApiService`.
+ *
+ * Threading follows the service's rules: the service runs the completion
+ * inline when called on the message thread (or when there is none), and posts
+ * it back to the message thread when called from an agent worker thread — so
+ * this dispatches and waits in every calling context, honouring the request
+ * deadline and the cancellation token.
+ *
+ * Enforces the surface allowlist a second time at dispatch, independently of
+ * the definition the runtime checked — a definition built by hand with an
+ * extra tool still cannot reach past the surface.
+ */
+class RemoteAgentToolExecutor : public ToolExecutor {
+  public:
+    RemoteAgentToolExecutor(remote::RemoteApiService& service, const AgentSurface& surface);
+
+    ToolResult execute(const ToolExecutionRequest& request,
+                       const CancellationToken& cancellation) override;
+
+  private:
+    remote::RemoteApiService& service_;
+    /// Points into `registeredAgentSurfaces()`, whose storage lives for the
+    /// process, so holding a reference is safe.
+    const AgentSurface& surface_;
+    remote::ScopeSet scopes_;
+};
+
+}  // namespace magda::agent

--- a/magda/agents/agent_tool_bridge.hpp
+++ b/magda/agents/agent_tool_bridge.hpp
@@ -78,6 +78,11 @@ class RemoteAgentToolExecutor : public ToolExecutor {
     /// process, so holding a reference is safe.
     const AgentSurface& surface_;
     remote::ScopeSet scopes_;
+    /// Unique per executor, and an executor lives for one agent run. Tool-call
+    /// ids are provider-generated and repeat across runs ("call_0"), while the
+    /// service caches writes by clientId + requestId — without this namespace a
+    /// later run's write could be answered from an earlier run's cache.
+    juce::String runNamespace_;
 };
 
 }  // namespace magda::agent

--- a/magda/agents/llm_tool_model.cpp
+++ b/magda/agents/llm_tool_model.cpp
@@ -1,0 +1,102 @@
+#include "llm_tool_model.hpp"
+
+namespace magda::agent {
+namespace {
+
+llm::Message toLlmMessage(const ConversationTurn& turn) {
+    llm::Message message;
+    switch (turn.role) {
+        case ConversationRole::User:
+            message.role = "user";
+            message.content = turn.text;
+            break;
+        case ConversationRole::Assistant:
+            message.role = "assistant";
+            message.content = turn.text;
+            for (const auto& call : turn.toolCalls) {
+                llm::ToolCall llmCall;
+                llmCall.id = call.id;
+                llmCall.name = call.name;
+                llmCall.arguments = call.arguments;
+                message.toolCalls.push_back(std::move(llmCall));
+            }
+            break;
+        case ConversationRole::Tool: {
+            message.role = "tool";
+            if (turn.toolResult.has_value()) {
+                const auto& result = *turn.toolResult;
+                const bool isError = result.error.has_value();
+                message.toolResults.emplace_back(
+                    result.callId, result.toolName,
+                    isError ? juce::var(result.error->code + ": " + result.error->message)
+                            : result.content,
+                    isError, isError ? result.error->message : juce::String());
+            }
+            break;
+        }
+    }
+    return message;
+}
+
+}  // namespace
+
+LlmToolModel::LlmToolModel(llm::LLMClient& client, float temperature)
+    : client_(client), temperature_(temperature) {}
+
+ModelResponse LlmToolModel::generate(const ModelRequest& request,
+                                     const CancellationToken& cancellation) {
+    if (cancellation.isCancellationRequested())
+        return {.success = false, .error = "cancelled"};
+
+    llm::Request llmRequest;
+    llmRequest.systemPrompt = request.systemPrompt;
+    if (!request.baselineContext.isVoid()) {
+        llmRequest.systemPrompt +=
+            "\n\n[Context]\n" + juce::JSON::toString(request.baselineContext, true);
+    }
+    llmRequest.temperature = temperature_;
+
+    llmRequest.tools.reserve(request.tools.size());
+    for (const auto& tool : request.tools) {
+        auto* annotations = new juce::DynamicObject();
+        annotations->setProperty("readOnlyHint", tool.access == ToolAccess::Read);
+        llmRequest.tools.emplace_back(tool.name, tool.description, tool.inputSchema.clone(),
+                                      juce::var(annotations));
+    }
+
+    // The runtime appends the user turn to the conversation; providers want the
+    // current user turn separated out, so a trailing user turn becomes
+    // `userMessage` and everything before it becomes history. Mid-run
+    // iterations end on tool results instead, which stay in `messages` as the
+    // pending turns the provider reads.
+    auto conversation = request.conversation;
+    if (!conversation.empty() && conversation.back().role == ConversationRole::User) {
+        llmRequest.userMessage = conversation.back().text;
+        conversation.pop_back();
+    }
+    llmRequest.messages.reserve(conversation.size());
+    for (const auto& turn : conversation)
+        llmRequest.messages.push_back(toLlmMessage(turn));
+
+    const auto response = client_.sendRequest(llmRequest);
+    if (cancellation.isCancellationRequested())
+        return {.success = false, .error = "cancelled"};
+
+    ModelResponse mapped;
+    mapped.success = response.success;
+    mapped.error = response.error;
+    mapped.text = response.text;
+    for (const auto& call : response.toolCalls) {
+        // A call whose arguments failed to parse keeps its name and a void
+        // payload: dispatch-side schema validation turns that into an error
+        // the model can read and correct, which beats repairing JSON here.
+        mapped.toolCalls.push_back({.id = call.id, .name = call.name, .arguments = call.arguments});
+    }
+    if (response.totalTokens >= 0)
+        mapped.tokensUsed = static_cast<std::size_t>(response.totalTokens);
+    else if (response.outputTokens >= 0)
+        mapped.tokensUsed = static_cast<std::size_t>(response.outputTokens);
+    return mapped;
+}
+
+}  // namespace magda::agent

--- a/magda/agents/llm_tool_model.hpp
+++ b/magda/agents/llm_tool_model.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <juce_llm/juce_llm.h>
+
+#include "agent_runtime.hpp"
+
+namespace magda::agent {
+
+/**
+ * @brief `agent::Model` over an `llm::LLMClient`, via native tool calling.
+ *
+ * The provider-neutral surface juce_llm already carries — `Request::tools`,
+ * `Response::toolCalls`, tool-result conversation turns — mapped onto the
+ * runtime's types, so one adapter serves every configured provider (#2295).
+ * No DSL, no grammar: the model calls the same named operations an MCP client
+ * calls, and malformed arguments come back to it as the dispatcher's
+ * validation errors rather than being repaired here.
+ */
+class LlmToolModel : public Model {
+  public:
+    explicit LlmToolModel(llm::LLMClient& client, float temperature = 0.1f);
+
+    ModelResponse generate(const ModelRequest& request,
+                           const CancellationToken& cancellation) override;
+
+  private:
+    llm::LLMClient& client_;
+    float temperature_;
+};
+
+}  // namespace magda::agent

--- a/magda/daw/api/device_api.hpp
+++ b/magda/daw/api/device_api.hpp
@@ -143,6 +143,11 @@ class DeviceApi {
      * Values outside the parameter's range are rejected rather than clamped: a
      * silently clamped write reports success while doing something the caller
      * did not ask for.
+     *
+     * External-plugin parameters the user has not opted in under Configure
+     * Parameters are rejected: this facade is the programmatic surface, and
+     * the per-parameter opt-in is enforced here so no consumer routes around
+     * it. Internal devices accept writes on every parameter.
      */
     virtual bool setDeviceParameter(const ChainNodePath& devicePath, int paramIndex,
                                     float value) = 0;

--- a/magda/daw/api/device_api_live.cpp
+++ b/magda/daw/api/device_api_live.cpp
@@ -248,6 +248,18 @@ bool DeviceApiLive::setDeviceParameter(const ChainNodePath& devicePath, int para
     if (std::isnan(value) || value < match->minValue || value > match->maxValue)
         return false;
 
+    // The user's per-parameter opt-in (Configure Parameters) gates programmatic
+    // writes to external plugins; internal devices accept writes on every
+    // parameter. Enforced here so every facade consumer — agents, remote, Lua,
+    // OSC, CLI — sees the same policy, not just the MCP handler (#2296). The
+    // opt-in list keys on position in `parameters`, not on paramIndex.
+    if (device->format != PluginFormat::Internal) {
+        const auto position = static_cast<int>(match - device->parameters.begin());
+        const auto& allowed = device->aiSoundDesignerParameters;
+        if (std::find(allowed.begin(), allowed.end(), position) == allowed.end())
+            return false;
+    }
+
     // The caller speaks display units; the model may store TE-native values
     // (external plugin with a config display range), so convert before writing.
     TrackManager::getInstance().setDeviceParameterValue(

--- a/magda/daw/api/remote_api.cpp
+++ b/magda/daw/api/remote_api.cpp
@@ -1576,6 +1576,27 @@ OperationRegistry::OperationRegistry() {
             "required":["trackId"],"additionalProperties":false
         })json"),
         okResult);
+    add("tracks.group", "Group tracks under a new group track", OperationAccess::Write,
+        &handlers::tracksGroup, operationInputSchema(R"json({
+            "type":"object",
+            "properties":{
+                "trackIds":{"type":"array","minItems":1,
+                            "items":{"type":"integer","minimum":0}},
+                "name":{"type":"string"}
+            },
+            "required":["trackIds","name"],"additionalProperties":false
+        })json"),
+        idResult);
+    add("tracks.move", "Move a track to a one-based position in the track list",
+        OperationAccess::Write, &handlers::tracksMove, operationInputSchema(R"json({
+            "type":"object",
+            "properties":{
+                "trackId":{"type":"integer","minimum":0},
+                "position":{"type":"integer","minimum":1}
+            },
+            "required":["trackId","position"],"additionalProperties":false
+        })json"),
+        okResult);
 
     add("clips.list", "List clips with optional track and view filters", OperationAccess::Read,
         &handlers::clipsList, operationInputSchema(R"json({
@@ -1626,6 +1647,53 @@ OperationRegistry::OperationRegistry() {
             "required":["clipId"],"additionalProperties":false
         })json"),
         okResult);
+    add("clips.update", "Update clip name, enabled state, or groove template assignment",
+        OperationAccess::Write, &handlers::clipsUpdate, operationInputSchema(R"json({
+            "type":"object",
+            "properties":{
+                "clipId":{"type":"integer","minimum":0},
+                "name":{"type":"string"},
+                "enabled":{"type":"boolean"},
+                "grooveTemplate":{"type":"string"}
+            },
+            "required":["clipId"],"additionalProperties":false
+        })json"),
+        clipSchema());
+    add("clips.transpose", "Transpose every note in a MIDI clip by semitones",
+        OperationAccess::Write, &handlers::clipsTranspose, operationInputSchema(R"json({
+            "type":"object",
+            "properties":{
+                "clipId":{"type":"integer","minimum":0},
+                "semitones":{"type":"integer","minimum":-127,"maximum":127}
+            },
+            "required":["clipId","semitones"],"additionalProperties":false
+        })json"),
+        clipSchema());
+    add("clips.quantize",
+        "Quantize a MIDI clip's notes to a beat grid; all notes when noteIndices is absent",
+        OperationAccess::Write, &handlers::clipsQuantize, operationInputSchema(R"json({
+            "type":"object",
+            "properties":{
+                "clipId":{"type":"integer","minimum":0},
+                "gridResolution":{"type":"number","exclusiveMinimum":0,"maximum":16},
+                "noteIndices":{"type":"array","items":{"type":"integer","minimum":0}},
+                "mode":{"type":"string","enum":["start","length","start_and_length"]}
+            },
+            "required":["clipId","gridResolution"],"additionalProperties":false
+        })json"),
+        clipSchema());
+    add("clips.sliceNotes",
+        "Slice a MIDI clip's notes into equal subdivisions; all notes when noteIndices is absent",
+        OperationAccess::Write, &handlers::clipsSliceNotes, operationInputSchema(R"json({
+            "type":"object",
+            "properties":{
+                "clipId":{"type":"integer","minimum":0},
+                "subdivisions":{"type":"integer","minimum":2,"maximum":64},
+                "noteIndices":{"type":"array","items":{"type":"integer","minimum":0}}
+            },
+            "required":["clipId","subdivisions"],"additionalProperties":false
+        })json"),
+        clipSchema());
 
     add("devices.list", "List safe device and rack graph metadata", OperationAccess::Read,
         &handlers::devicesList, operationInputSchema(R"json({
@@ -1881,6 +1949,95 @@ OperationRegistry::OperationRegistry() {
         })json"),
         automationLaneSchema());
 
+    const auto stringArraySchema = arraySchema(parseSchema(R"json({"type":"string"})json"));
+    add("grooves.list", "List groove template names", OperationAccess::Read, &handlers::groovesList,
+        emptyObjectSchema(), stringArraySchema);
+    add("grooves.upsert",
+        "Create or replace a groove template; latenessProportions is one entry per grid slot, "
+        "-1..1 of the slot length",
+        OperationAccess::Write, &handlers::groovesUpsert, operationInputSchema(R"json({
+            "type":"object",
+            "properties":{
+                "name":{"type":"string","minLength":1},
+                "notesPerBeat":{"type":"integer","minimum":1,"maximum":16},
+                "parameterized":{"type":"boolean"},
+                "latenessProportions":{"type":"array","minItems":1,
+                                       "items":{"type":"number","minimum":-1,"maximum":1}}
+            },
+            "required":["name","notesPerBeat","latenessProportions"],
+            "additionalProperties":false
+        })json"),
+        okResult);
+
+    // The focused device's macro page — the same surface controller scripts
+    // drive. Reads answer safely with hasFocus=false when nothing is focused.
+    const auto focusedSchema = parseSchema(R"json({
+        "type":"object",
+        "properties":{
+            "hasFocus":{"type":"boolean"},
+            "name":{"type":"string"},
+            "macros":{"type":"array","items":{
+                "type":"object",
+                "properties":{
+                    "index":{"type":"integer"},
+                    "name":{"type":"string"},
+                    "value":{"type":"number"}
+                },
+                "required":["index","name","value"],
+                "additionalProperties":false
+            }}
+        },
+        "required":["hasFocus","name","macros"],
+        "additionalProperties":false
+    })json");
+    add("focused.get", "Get the focused device or rack and its macro page", OperationAccess::Read,
+        &handlers::focusedGet, emptyObjectSchema(), focusedSchema);
+    add("focused.setMacro", "Write a normalized value to a macro on the focused device",
+        OperationAccess::Write, &handlers::focusedSetMacro, operationInputSchema(R"json({
+            "type":"object",
+            "properties":{
+                "index":{"type":"integer","minimum":0,"maximum":15},
+                "value":{"type":"number","minimum":0,"maximum":1}
+            },
+            "required":["index","value"],"additionalProperties":false
+        })json"),
+        focusedSchema);
+    add("focused.cycleDevice", "Move device focus to the previous or next top-level chain node",
+        OperationAccess::Write, &handlers::focusedCycleDevice, operationInputSchema(R"json({
+            "type":"object",
+            "properties":{"direction":{"type":"integer","enum":[-1,1]}},
+            "required":["direction"],"additionalProperties":false
+        })json"),
+        focusedSchema);
+
+    // Hardware MIDI out — the first operations behind the `hardware-midi`
+    // scope, which was declared ahead of them (#1860) precisely so existing
+    // grants read as "not granted" when these landed.
+    add("midi.listOutputPorts", "List available MIDI output port names", OperationAccess::Read,
+        &handlers::midiListOutputPorts, emptyObjectSchema(), stringArraySchema);
+    add("midi.send", "Send one channel message to a MIDI output, as status-first raw bytes",
+        OperationAccess::Write, &handlers::midiSend, operationInputSchema(R"json({
+            "type":"object",
+            "properties":{
+                "port":{"type":"string","minLength":1},
+                "bytes":{"type":"array","minItems":1,"maxItems":3,
+                         "items":{"type":"integer","minimum":0,"maximum":255}}
+            },
+            "required":["port","bytes"],"additionalProperties":false
+        })json"),
+        okResult);
+    add("midi.sendSysEx", "Send a SysEx payload to a MIDI output; F0/F7 framing is added",
+        OperationAccess::Write, &handlers::midiSendSysEx, operationInputSchema(R"json({
+            "type":"object",
+            "properties":{
+                "port":{"type":"string","minLength":1},
+                "bytes":{"type":"array","minItems":1,"maxItems":4096,
+                         "items":{"type":"integer","minimum":0,"maximum":127}}
+            },
+            "required":["port","bytes"],"additionalProperties":false
+        })json"),
+        okResult);
+
     // -----------------------------------------------------------------------
     // Subscriptions (#1857)
     //
@@ -1944,9 +2101,20 @@ OperationRegistry::OperationRegistry() {
         {"tracks.create", Scope::Edit},
         {"tracks.update", Scope::Edit},
         {"tracks.delete", Scope::Edit},
+        {"tracks.group", Scope::Edit},
+        {"tracks.move", Scope::Edit},
         {"clips.createMidi", Scope::Edit},
         {"clips.addMidiNote", Scope::Edit},
         {"clips.delete", Scope::Edit},
+        {"clips.update", Scope::Edit},
+        {"clips.transpose", Scope::Edit},
+        {"clips.quantize", Scope::Edit},
+        {"clips.sliceNotes", Scope::Edit},
+        {"grooves.upsert", Scope::Edit},
+        // Focused-macro writes edit device state; cycling focus changes what
+        // the user is looking at, the same reasoning as selection.set.
+        {"focused.setMacro", Scope::Edit},
+        {"focused.cycleDevice", Scope::Edit},
         {"racks.create", Scope::Edit},
         {"racks.remove", Scope::Edit},
         {"racks.setBypassed", Scope::Edit},
@@ -1982,6 +2150,11 @@ OperationRegistry::OperationRegistry() {
         {"session.stopTrack", Scope::Session},
         {"session.stopAll", Scope::Session},
         {"session.launchScene", Scope::Session},
+
+        // Physical MIDI ports. The scope existed before any operation did
+        // (#1860); these are the operations it was declared for.
+        {"midi.send", Scope::HardwareMidi},
+        {"midi.sendSysEx", Scope::HardwareMidi},
     };
 
     for (const auto& [name, scope] : kWriteScopes) {

--- a/magda/daw/api/remote_handlers.cpp
+++ b/magda/daw/api/remote_handlers.cpp
@@ -12,6 +12,7 @@
 #include "../core/AutomationTypes.hpp"
 #include "../core/ClipCommands.hpp"
 #include "../core/ClipInfo.hpp"
+#include "../core/ClipPropertyCommands.hpp"
 #include "../core/ControlTarget.hpp"
 #include "../core/DeviceInfo.hpp"
 #include "../core/MidiNoteCommands.hpp"
@@ -24,7 +25,10 @@
 #include "automation_api.hpp"
 #include "clip_api.hpp"
 #include "device_api.hpp"
+#include "focused_api.hpp"
+#include "groove_api.hpp"
 #include "magda_api.hpp"
+#include "midi_api.hpp"
 #include "project_api.hpp"
 #include "selection_api.hpp"
 #include "session_api.hpp"
@@ -1083,6 +1087,317 @@ HandlerResult automationClearLane(MagdaApi& api, const juce::var& input, const R
     if (cleared == nullptr)
         return notFound("automation lane", laneId);
     return HandlerResult::ok(toJson(makeAutomationLaneDto(*cleared)));
+}
+
+// ===========================================================================
+// Clip content editing (#2297)
+// ===========================================================================
+
+namespace {
+
+/// Note indices for a clip-scoped note operation: the given list validated
+/// against the clip, or every note when the field is absent. Nullopt with
+/// `error` set when an index names nothing.
+std::optional<std::vector<size_t>> resolveNoteIndices(const ClipInfo& clip, const juce::var& input,
+                                                      juce::String& error) {
+    std::vector<size_t> indices;
+    if (!has(input, "noteIndices")) {
+        indices.resize(clip.midiNotes.size());
+        for (size_t i = 0; i < indices.size(); ++i)
+            indices[i] = i;
+        return indices;
+    }
+    for (const auto& item : *input["noteIndices"].getArray()) {
+        const auto index = static_cast<int>(item);
+        if (index < 0 || static_cast<size_t>(index) >= clip.midiNotes.size()) {
+            error = "noteIndices names unknown note " + juce::String(index);
+            return std::nullopt;
+        }
+        indices.push_back(static_cast<size_t>(index));
+    }
+    return indices;
+}
+
+/// The clip named by `clipId`, required to be MIDI. Sets `failure` when it is
+/// missing or not MIDI.
+const ClipInfo* midiClipOrFail(MagdaApi& api, ClipId clipId, HandlerResult& failure) {
+    const auto* clip = api.clips().getClip(clipId);
+    if (clip == nullptr) {
+        failure = notFound("clip", clipId);
+        return nullptr;
+    }
+    if (!clip->isMidi()) {
+        failure = HandlerResult::fail(ErrorCode::Conflict,
+                                      "clip " + juce::String(clipId) + " is not MIDI");
+        return nullptr;
+    }
+    return clip;
+}
+
+}  // namespace
+
+HandlerResult clipsUpdate(MagdaApi& api, const juce::var& input, const RequestContext&) {
+    const auto clipId = static_cast<ClipId>(static_cast<int>(input["clipId"]));
+    const auto* current = api.clips().getClip(clipId);
+    if (current == nullptr)
+        return notFound("clip", clipId);
+
+    // A patch, not a replace, following tracks.update: absent fields leave the
+    // current value alone, and a patch restating current state mutates nothing.
+    bool mutated = false;
+
+    if (has(input, "name") && current->name != input["name"].toString()) {
+        runCommand<SetClipNameCommand>(api, clipId, input["name"].toString());
+        mutated = true;
+    }
+    if (has(input, "enabled") && current->enabled != readBool(input, "enabled")) {
+        const bool enabled = readBool(input, "enabled");
+        runCommand<SetClipPropertyCommand>(
+            api, clipId, enabled ? juce::String("Enable Clip") : juce::String("Disable Clip"),
+            [enabled](auto& manager, ClipId id) { manager.setClipEnabled(id, enabled); });
+        mutated = true;
+    }
+    if (has(input, "grooveTemplate")) {
+        const auto templateName = input["grooveTemplate"].toString();
+        // An empty name clears the assignment; anything else must name a
+        // template that exists, or the clip would carry a groove that grooves
+        // nothing.
+        if (templateName.isNotEmpty() && !api.grooves().getTemplateNames().contains(templateName)) {
+            return HandlerResult::fail(ErrorCode::NotFound,
+                                       "groove template '" + templateName + "' not found");
+        }
+        if (current->grooveTemplate != templateName) {
+            runCommand<SetClipGrooveTemplateCommand>(api, clipId, templateName);
+            mutated = true;
+        }
+    }
+
+    const auto* updated = api.clips().getClip(clipId);
+    if (updated == nullptr)
+        return notFound("clip", clipId);
+    auto payload = toJson(makeClipDto(*updated));
+    return mutated ? HandlerResult::ok(std::move(payload))
+                   : HandlerResult::unchanged(std::move(payload));
+}
+
+HandlerResult clipsTranspose(MagdaApi& api, const juce::var& input, const RequestContext&) {
+    const auto clipId = static_cast<ClipId>(static_cast<int>(input["clipId"]));
+    HandlerResult failure = HandlerResult::fail(ErrorCode::InternalError, "unreachable");
+    const auto* clip = midiClipOrFail(api, clipId, failure);
+    if (clip == nullptr)
+        return failure;
+    if (clip->midiNotes.empty())
+        return HandlerResult::unchanged(toJson(makeClipDto(*clip)));
+
+    if (!api.clips().transposeMidiClip(clipId, static_cast<int>(input["semitones"])))
+        return HandlerResult::fail(ErrorCode::Conflict, "transpose was rejected");
+    const auto* updated = api.clips().getClip(clipId);
+    if (updated == nullptr)
+        return notFound("clip", clipId);
+    return HandlerResult::ok(toJson(makeClipDto(*updated)));
+}
+
+HandlerResult clipsQuantize(MagdaApi& api, const juce::var& input, const RequestContext&) {
+    const auto clipId = static_cast<ClipId>(static_cast<int>(input["clipId"]));
+    HandlerResult failure = HandlerResult::fail(ErrorCode::InternalError, "unreachable");
+    const auto* clip = midiClipOrFail(api, clipId, failure);
+    if (clip == nullptr)
+        return failure;
+
+    juce::String indexError;
+    const auto indices = resolveNoteIndices(*clip, input, indexError);
+    if (!indices)
+        return HandlerResult::fail(ErrorCode::ValidationFailed, indexError);
+    if (indices->empty())
+        return HandlerResult::unchanged(toJson(makeClipDto(*clip)));
+
+    auto mode = MidiNoteQuantizeMode::StartAndLength;
+    if (has(input, "mode")) {
+        const auto name = input["mode"].toString();
+        if (name == "start")
+            mode = MidiNoteQuantizeMode::StartOnly;
+        else if (name == "length")
+            mode = MidiNoteQuantizeMode::LengthOnly;
+    }
+
+    if (!api.clips().quantizeMidiNotes(clipId, *indices,
+                                       static_cast<double>(input["gridResolution"]), mode))
+        return HandlerResult::fail(ErrorCode::Conflict, "quantize was rejected");
+    const auto* updated = api.clips().getClip(clipId);
+    if (updated == nullptr)
+        return notFound("clip", clipId);
+    return HandlerResult::ok(toJson(makeClipDto(*updated)));
+}
+
+HandlerResult clipsSliceNotes(MagdaApi& api, const juce::var& input, const RequestContext&) {
+    const auto clipId = static_cast<ClipId>(static_cast<int>(input["clipId"]));
+    HandlerResult failure = HandlerResult::fail(ErrorCode::InternalError, "unreachable");
+    const auto* clip = midiClipOrFail(api, clipId, failure);
+    if (clip == nullptr)
+        return failure;
+
+    juce::String indexError;
+    const auto indices = resolveNoteIndices(*clip, input, indexError);
+    if (!indices)
+        return HandlerResult::fail(ErrorCode::ValidationFailed, indexError);
+    if (indices->empty())
+        return HandlerResult::unchanged(toJson(makeClipDto(*clip)));
+
+    if (!api.clips().sliceMidiNotes(clipId, *indices, static_cast<int>(input["subdivisions"])))
+        return HandlerResult::fail(ErrorCode::Conflict, "slice was rejected");
+    const auto* updated = api.clips().getClip(clipId);
+    if (updated == nullptr)
+        return notFound("clip", clipId);
+    return HandlerResult::ok(toJson(makeClipDto(*updated)));
+}
+
+// ===========================================================================
+// Track grouping and ordering (#2297)
+// ===========================================================================
+
+HandlerResult tracksGroup(MagdaApi& api, const juce::var& input, const RequestContext&) {
+    std::vector<TrackId> trackIds;
+    for (const auto& item : *input["trackIds"].getArray()) {
+        const auto trackId = static_cast<TrackId>(static_cast<int>(item));
+        if (api.tracks().getTrack(trackId) == nullptr)
+            return notFound("track", trackId);
+        trackIds.push_back(trackId);
+    }
+
+    const auto groupId = api.tracks().groupTracks(trackIds, input["name"].toString());
+    if (groupId == INVALID_TRACK_ID)
+        return HandlerResult::fail(ErrorCode::Conflict, "grouping was rejected");
+    return HandlerResult::ok(idResult(groupId));
+}
+
+HandlerResult tracksMove(MagdaApi& api, const juce::var& input, const RequestContext&) {
+    const auto trackId = static_cast<TrackId>(static_cast<int>(input["trackId"]));
+    if (api.tracks().getTrack(trackId) == nullptr)
+        return notFound("track", trackId);
+    api.tracks().moveTrackToPosition(trackId, static_cast<int>(input["position"]));
+    return HandlerResult::ok(acceptedResult());
+}
+
+// ===========================================================================
+// Grooves (#2297)
+// ===========================================================================
+
+HandlerResult groovesList(MagdaApi& api, const juce::var&, const RequestContext&) {
+    std::vector<juce::var> items;
+    for (const auto& name : api.grooves().getTemplateNames())
+        items.push_back(name);
+    return HandlerResult::ok(toJsonArray(items));
+}
+
+HandlerResult groovesUpsert(MagdaApi& api, const juce::var& input, const RequestContext&) {
+    std::vector<float> lateness;
+    for (const auto& item : *input["latenessProportions"].getArray())
+        lateness.push_back(static_cast<float>(static_cast<double>(item)));
+
+    if (!api.grooves().upsertTemplate(input["name"].toString(),
+                                      static_cast<int>(input["notesPerBeat"]),
+                                      readBool(input, "parameterized", true), lateness))
+        return HandlerResult::fail(ErrorCode::Conflict, "groove template was rejected");
+    return HandlerResult::ok(acceptedResult());
+}
+
+// ===========================================================================
+// Focused device macros (#2297)
+// ===========================================================================
+
+namespace {
+
+constexpr int FOCUSED_MACRO_COUNT = 16;
+
+juce::var focusedResult(MagdaApi& api) {
+    auto& focused = api.focused();
+    auto* result = new juce::DynamicObject();
+    const bool hasFocus = focused.hasFocus();
+    result->setProperty("hasFocus", hasFocus);
+    result->setProperty("name", focused.getFocusedName());
+    juce::Array<juce::var> macros;
+    if (hasFocus) {
+        for (int i = 0; i < FOCUSED_MACRO_COUNT; ++i) {
+            auto* macro = new juce::DynamicObject();
+            macro->setProperty("index", i);
+            macro->setProperty("name", focused.getMacroName(i));
+            macro->setProperty("value", focused.getMacroValue(i));
+            macros.add(macro);
+        }
+    }
+    result->setProperty("macros", macros);
+    return result;
+}
+
+}  // namespace
+
+HandlerResult focusedGet(MagdaApi& api, const juce::var&, const RequestContext&) {
+    return HandlerResult::ok(focusedResult(api));
+}
+
+HandlerResult focusedSetMacro(MagdaApi& api, const juce::var& input, const RequestContext&) {
+    // setMacroValue is a silent no-op without focus; refusing is the honest
+    // answer over a wire where the caller cannot see the panel.
+    if (!api.focused().hasFocus())
+        return HandlerResult::fail(ErrorCode::Conflict, "no device or rack is focused");
+    api.focused().setMacroValue(static_cast<int>(input["index"]),
+                                static_cast<float>(static_cast<double>(input["value"])));
+    return HandlerResult::ok(focusedResult(api));
+}
+
+HandlerResult focusedCycleDevice(MagdaApi& api, const juce::var& input, const RequestContext&) {
+    api.focused().cycleDevice(static_cast<int>(input["direction"]));
+    return HandlerResult::ok(focusedResult(api));
+}
+
+// ===========================================================================
+// Hardware MIDI out (#2297) — the first operations behind `hardware-midi`
+// ===========================================================================
+
+namespace {
+
+std::vector<juce::uint8> readByteArray(const juce::var& value) {
+    std::vector<juce::uint8> bytes;
+    for (const auto& item : *value.getArray())
+        bytes.push_back(static_cast<juce::uint8>(static_cast<int>(item)));
+    return bytes;
+}
+
+}  // namespace
+
+HandlerResult midiListOutputPorts(MagdaApi& api, const juce::var&, const RequestContext&) {
+    std::vector<juce::var> items;
+    for (const auto& name : api.midi().getOutputPortNames())
+        items.push_back(name);
+    return HandlerResult::ok(toJsonArray(items));
+}
+
+HandlerResult midiSend(MagdaApi& api, const juce::var& input, const RequestContext&) {
+    const auto bytes = readByteArray(input["bytes"]);
+    // A channel message only: the schema caps the length at 3 and the status
+    // byte range excludes SysEx framing, but the length still has to match what
+    // the status byte promises — juce::MidiMessage asserts on malformed data
+    // rather than rejecting it.
+    const int expected = juce::MidiMessage::getMessageLengthFromFirstByte(bytes.front());
+    if (static_cast<int>(bytes.size()) != expected)
+        return HandlerResult::fail(ErrorCode::ValidationFailed,
+                                   "status byte " + juce::String(bytes.front()) + " expects " +
+                                       juce::String(expected) + " bytes, got " +
+                                       juce::String(static_cast<int>(bytes.size())));
+
+    const juce::MidiMessage message(bytes.data(), static_cast<int>(bytes.size()));
+    if (!api.midi().sendMidi(input["port"].toString(), message))
+        return HandlerResult::fail(ErrorCode::NotFound, "MIDI output '" + input["port"].toString() +
+                                                            "' cannot be opened");
+    return HandlerResult::ok(acceptedResult());
+}
+
+HandlerResult midiSendSysEx(MagdaApi& api, const juce::var& input, const RequestContext&) {
+    const auto bytes = readByteArray(input["bytes"]);
+    if (!api.midi().sendSysEx(input["port"].toString(), bytes.data(), bytes.size()))
+        return HandlerResult::fail(ErrorCode::NotFound, "MIDI output '" + input["port"].toString() +
+                                                            "' cannot be opened");
+    return HandlerResult::ok(acceptedResult());
 }
 
 }  // namespace magda::remote::handlers

--- a/magda/daw/api/remote_handlers.cpp
+++ b/magda/daw/api/remote_handlers.cpp
@@ -582,9 +582,10 @@ HandlerResult devicesSetParameter(MagdaApi& api, const juce::var& input, const R
     if (named == parameters.end())
         return notFound("parameter", parameterIndex);
 
-    // The same allowlist the in-app sound designer honours: the user decides
-    // per external-plugin parameter what an agent may touch, and the remote
-    // surface must not be the way around that decision.
+    // DeviceApi::setDeviceParameter enforces the user's per-parameter opt-in
+    // for every facade consumer; this pre-check only exists to classify the
+    // refusal as PermissionDenied with a useful message, which the facade's
+    // bare bool cannot convey (#2296).
     if (!named->aiAgentEnabled)
         return HandlerResult::fail(ErrorCode::PermissionDenied,
                                    "parameter " + juce::String(parameterIndex) +

--- a/magda/daw/api/remote_handlers.cpp
+++ b/magda/daw/api/remote_handlers.cpp
@@ -1142,6 +1142,19 @@ HandlerResult clipsUpdate(MagdaApi& api, const juce::var& input, const RequestCo
     if (current == nullptr)
         return notFound("clip", clipId);
 
+    // Validate the whole patch before mutating anything: a failed handler does
+    // not roll back the compound, so refusing the groove after applying an
+    // earlier field would leave the rename in place while reporting failure.
+    // An empty name clears the assignment; anything else must name a template
+    // that exists, or the clip would carry a groove that grooves nothing.
+    if (has(input, "grooveTemplate")) {
+        const auto templateName = input["grooveTemplate"].toString();
+        if (templateName.isNotEmpty() && !api.grooves().getTemplateNames().contains(templateName)) {
+            return HandlerResult::fail(ErrorCode::NotFound,
+                                       "groove template '" + templateName + "' not found");
+        }
+    }
+
     // A patch, not a replace, following tracks.update: absent fields leave the
     // current value alone, and a patch restating current state mutates nothing.
     bool mutated = false;
@@ -1157,19 +1170,10 @@ HandlerResult clipsUpdate(MagdaApi& api, const juce::var& input, const RequestCo
             [enabled](auto& manager, ClipId id) { manager.setClipEnabled(id, enabled); });
         mutated = true;
     }
-    if (has(input, "grooveTemplate")) {
-        const auto templateName = input["grooveTemplate"].toString();
-        // An empty name clears the assignment; anything else must name a
-        // template that exists, or the clip would carry a groove that grooves
-        // nothing.
-        if (templateName.isNotEmpty() && !api.grooves().getTemplateNames().contains(templateName)) {
-            return HandlerResult::fail(ErrorCode::NotFound,
-                                       "groove template '" + templateName + "' not found");
-        }
-        if (current->grooveTemplate != templateName) {
-            runCommand<SetClipGrooveTemplateCommand>(api, clipId, templateName);
-            mutated = true;
-        }
+    if (has(input, "grooveTemplate") &&
+        current->grooveTemplate != input["grooveTemplate"].toString()) {
+        runCommand<SetClipGrooveTemplateCommand>(api, clipId, input["grooveTemplate"].toString());
+        mutated = true;
     }
 
     const auto* updated = api.clips().getClip(clipId);
@@ -1264,7 +1268,12 @@ HandlerResult tracksGroup(MagdaApi& api, const juce::var& input, const RequestCo
         trackIds.push_back(trackId);
     }
 
-    const auto groupId = api.tracks().groupTracks(trackIds, input["name"].toString());
+    // Through a command, not TrackApi::groupTracks: the facade setter mutates
+    // the manager directly, so the dispatcher's compound would close empty and
+    // the grouping could never be undone.
+    const auto groupId = runCommandAndRead<GroupTracksCommand>(
+        api, [](const GroupTracksCommand& command) { return command.getCreatedGroupId(); },
+        std::move(trackIds), input["name"].toString());
     if (groupId == INVALID_TRACK_ID)
         return HandlerResult::fail(ErrorCode::Conflict, "grouping was rejected");
     return HandlerResult::ok(idResult(groupId));
@@ -1274,7 +1283,7 @@ HandlerResult tracksMove(MagdaApi& api, const juce::var& input, const RequestCon
     const auto trackId = static_cast<TrackId>(static_cast<int>(input["trackId"]));
     if (api.tracks().getTrack(trackId) == nullptr)
         return notFound("track", trackId);
-    api.tracks().moveTrackToPosition(trackId, static_cast<int>(input["position"]));
+    runCommand<MoveTrackCommand>(api, trackId, static_cast<int>(input["position"]));
     return HandlerResult::ok(acceptedResult());
 }
 
@@ -1389,7 +1398,9 @@ HandlerResult midiSend(MagdaApi& api, const juce::var& input, const RequestConte
     if (!api.midi().sendMidi(input["port"].toString(), message))
         return HandlerResult::fail(ErrorCode::NotFound, "MIDI output '" + input["port"].toString() +
                                                             "' cannot be opened");
-    return HandlerResult::ok(acceptedResult());
+    // Delivered to hardware, but no project state changed: `unchanged` keeps
+    // the revision still, the undo stack clean, and change feeds quiet.
+    return HandlerResult::unchanged(acceptedResult());
 }
 
 HandlerResult midiSendSysEx(MagdaApi& api, const juce::var& input, const RequestContext&) {
@@ -1397,7 +1408,7 @@ HandlerResult midiSendSysEx(MagdaApi& api, const juce::var& input, const Request
     if (!api.midi().sendSysEx(input["port"].toString(), bytes.data(), bytes.size()))
         return HandlerResult::fail(ErrorCode::NotFound, "MIDI output '" + input["port"].toString() +
                                                             "' cannot be opened");
-    return HandlerResult::ok(acceptedResult());
+    return HandlerResult::unchanged(acceptedResult());
 }
 
 }  // namespace magda::remote::handlers

--- a/magda/daw/api/remote_handlers.hpp
+++ b/magda/daw/api/remote_handlers.hpp
@@ -38,6 +38,8 @@ HandlerResult tracksGet(MagdaApi&, const juce::var&, const RequestContext&);
 HandlerResult tracksCreate(MagdaApi&, const juce::var&, const RequestContext&);
 HandlerResult tracksUpdate(MagdaApi&, const juce::var&, const RequestContext&);
 HandlerResult tracksDelete(MagdaApi&, const juce::var&, const RequestContext&);
+HandlerResult tracksGroup(MagdaApi&, const juce::var&, const RequestContext&);
+HandlerResult tracksMove(MagdaApi&, const juce::var&, const RequestContext&);
 
 // Clips
 HandlerResult clipsList(MagdaApi&, const juce::var&, const RequestContext&);
@@ -45,6 +47,10 @@ HandlerResult clipsGet(MagdaApi&, const juce::var&, const RequestContext&);
 HandlerResult clipsCreateMidi(MagdaApi&, const juce::var&, const RequestContext&);
 HandlerResult clipsAddMidiNote(MagdaApi&, const juce::var&, const RequestContext&);
 HandlerResult clipsDelete(MagdaApi&, const juce::var&, const RequestContext&);
+HandlerResult clipsUpdate(MagdaApi&, const juce::var&, const RequestContext&);
+HandlerResult clipsTranspose(MagdaApi&, const juce::var&, const RequestContext&);
+HandlerResult clipsQuantize(MagdaApi&, const juce::var&, const RequestContext&);
+HandlerResult clipsSliceNotes(MagdaApi&, const juce::var&, const RequestContext&);
 
 // Devices and racks
 HandlerResult devicesList(MagdaApi&, const juce::var&, const RequestContext&);
@@ -87,6 +93,20 @@ HandlerResult automationGetLane(MagdaApi&, const juce::var&, const RequestContex
 HandlerResult automationCreateLane(MagdaApi&, const juce::var&, const RequestContext&);
 HandlerResult automationAddPoint(MagdaApi&, const juce::var&, const RequestContext&);
 HandlerResult automationClearLane(MagdaApi&, const juce::var&, const RequestContext&);
+
+// Grooves
+HandlerResult groovesList(MagdaApi&, const juce::var&, const RequestContext&);
+HandlerResult groovesUpsert(MagdaApi&, const juce::var&, const RequestContext&);
+
+// Focused device macros
+HandlerResult focusedGet(MagdaApi&, const juce::var&, const RequestContext&);
+HandlerResult focusedSetMacro(MagdaApi&, const juce::var&, const RequestContext&);
+HandlerResult focusedCycleDevice(MagdaApi&, const juce::var&, const RequestContext&);
+
+// Hardware MIDI out
+HandlerResult midiListOutputPorts(MagdaApi&, const juce::var&, const RequestContext&);
+HandlerResult midiSend(MagdaApi&, const juce::var&, const RequestContext&);
+HandlerResult midiSendSysEx(MagdaApi&, const juce::var&, const RequestContext&);
 
 }  // namespace remote::handlers
 }  // namespace magda

--- a/magda/daw/core/Config.cpp
+++ b/magda/daw/core/Config.cpp
@@ -187,6 +187,7 @@ void Config::save() {
     {
         auto* aiObj = new juce::DynamicObject();
         aiObj->setProperty("preset", toJuceString(aiPreset));
+        aiObj->setProperty("toolLoop", agentToolLoopEnabled);
 
         auto* agentsObj = new juce::DynamicObject();
         for (const auto& [role, profile] : agentInferenceConfigs) {
@@ -578,6 +579,8 @@ void Config::load() {
         auto aiVar = obj->getProperty("ai");
         if (auto* aiObj = aiVar.getDynamicObject()) {
             aiPreset = aiObj->getProperty("preset").toString().toStdString();
+            if (aiObj->hasProperty("toolLoop"))
+                agentToolLoopEnabled = static_cast<bool>(aiObj->getProperty("toolLoop"));
             auto agentsVar = aiObj->getProperty("agents");
             if (auto* agentsObj = agentsVar.getDynamicObject()) {
                 bool jsonHadController = false;

--- a/magda/daw/core/Config.hpp
+++ b/magda/daw/core/Config.hpp
@@ -884,6 +884,19 @@ class Config {
         agentInferenceConfigs[agentRole] = config;
     }
 
+    /**
+     * Whether console agents run the tool-calling loop (AgentRuntime over
+     * RemoteApiService, #2295) instead of the DSL/IR workflows. Off by
+     * default: the tool loop needs a provider with native tool calling, and
+     * the DSL paths stay the shipped behaviour until it has soaked.
+     */
+    bool getAgentToolLoopEnabled() const {
+        return agentToolLoopEnabled;
+    }
+    void setAgentToolLoopEnabled(bool enabled) {
+        agentToolLoopEnabled = enabled;
+    }
+
     // Temporary backend-specific bridge for existing LLM agents and settings
     // UI. These are not role APIs; callers configuring an agent should use
     // the inference-profile methods above.
@@ -1600,6 +1613,7 @@ class Config {
 
     // AI settings
     std::string aiPreset = "local_embedded";
+    bool agentToolLoopEnabled = false;
     std::map<std::string, AgentInferenceConfig> agentInferenceConfigs = {
         {"command", {"llm", {"llama_local", "", "", ""}}},
         {"music", {"llm", {"llama_local", "", "", ""}}},

--- a/magda/daw/ui/panels/content/AIChatConsoleContent.cpp
+++ b/magda/daw/ui/panels/content/AIChatConsoleContent.cpp
@@ -4,10 +4,12 @@
 #include <atomic>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <set>
 #include <string>
 #include <thread>
 
+#include "../../../../agents/agent_tool_bridge.hpp"
 #include "../../../../agents/automation_agent.hpp"
 #include "../../../../agents/command_agent.hpp"
 #include "../../../../agents/console_agent_orchestrator.hpp"
@@ -19,11 +21,14 @@
 #include "../../../../agents/internal_plugins.hpp"
 #include "../../../../agents/llama_model_manager.hpp"
 #include "../../../../agents/llm_presets.hpp"
+#include "../../../../agents/llm_tool_model.hpp"
 #include "../../../../agents/midi_context.hpp"
 #include "../../../../agents/mixing_agent.hpp"
 #include "../../../../agents/music_agent.hpp"
 #include "../../../../agents/theme_agent.hpp"
 #include "../../../api/magda_api_live.hpp"
+#include "../../../api/remote_api_host.hpp"
+#include "../../../api/remote_service.hpp"
 #include "../../../audio/analysis/OfflineMixAnalysis.hpp"
 #include "../../../core/AppPaths.hpp"
 #include "../../../core/ClipManager.hpp"
@@ -65,6 +70,93 @@ namespace {
 // next to isDrummerTrack().
 juce::String formatClipAsDrummerContext(magda::ClipId clipId);
 juce::String formatSelectedClipsAsDrummerContext();
+
+/**
+ * The tool-calling console path (#2295): the surface's agent runs the bounded
+ * observe-act runtime, and every call executes through RemoteApiService — the
+ * same schema validation, scope enforcement, revision tracking, and audit an
+ * MCP client gets, with the ConsoleRouting allowlist as its tool set.
+ *
+ * Preflight rather than commitment: returns nullopt when the loop is switched
+ * off in config, no remote host exists, or the configured provider cannot
+ * carry tool calls — and the caller falls through to the DSL workflows. Once
+ * the run starts, its outcome is the response, success or not: mutations have
+ * gone through the service, so falling back to a second execution path would
+ * apply the request twice.
+ */
+std::optional<std::string> runAgentToolLoop(magda::AgentSurfaceId surfaceId,
+                                            const std::string& message,
+                                            const std::string& priorConversation,
+                                            const magda::agent::CancellationToken& cancellation) {
+    auto& config = magda::Config::getInstance();
+    if (!config.getAgentToolLoopEnabled())
+        return std::nullopt;
+    // Read from the request thread: safe because the host outlives every
+    // console request thread — it is created at startup and destroyed at
+    // shutdown, after this panel (and its RequestThread) are gone.
+    auto* host = magda::remote::activeHost();
+    if (host == nullptr)
+        return std::nullopt;
+
+    const auto llmConfig = config.getAgentLLMConfig(magda::role::COMMAND);
+    // The on-device command model is an intent tagger, not a tool-calling
+    // model; the DSL path is the one that knows how to drive it.
+    if (llmConfig.provider == magda::provider::FAST_INFERENCE)
+        return std::nullopt;
+    auto client = magda::createLLMClient(llmConfig, "tool-loop");
+    if (client == nullptr)
+        return std::nullopt;
+
+    const auto& surface = magda::agentSurface(surfaceId);
+    auto tools = magda::agent::agentToolsForSurface(surface);
+    if (tools.empty())
+        return std::nullopt;
+
+    magda::agent::LlmToolModel model(*client);
+    magda::agent::RemoteAgentToolExecutor executor(host->service(), surface);
+    // Approving here matches what the DSL executors do today — they apply
+    // mutations without a per-step prompt. The hook is the seam where a real
+    // approval UI lands; the surface's `approveMutations` policy is what it
+    // will read.
+    magda::agent::AgentRuntime runtime(model, executor, [](const magda::agent::ApprovalRequest&) {
+        return magda::agent::ApprovalDecision{};
+    });
+
+    magda::agent::AgentDefinition definition;
+    definition.id = "console-" + juce::String(surface.name);
+    definition.systemPrompt = "You are MAGDA's " + juce::String(surface.name) + " agent. " +
+                              juce::String(surface.responsibility);
+    for (const auto& fragment : surface.promptFragments)
+        definition.systemPrompt += "\n" + juce::String(fragment);
+    definition.systemPrompt +=
+        "\nAct by calling tools; inspect state before mutating it. When the work is done, "
+        "reply with a short summary and no further tool calls.";
+    definition.tools = std::move(tools);
+    definition.budget.maxSteps = surface.runPolicy.maxSteps;
+    definition.budget.maxMutations = surface.runPolicy.maxMutations;
+
+    magda::agent::AgentRunInput input;
+    input.userMessage = priorConversation.empty()
+                            ? juce::String(message)
+                            : juce::String(priorConversation) + "\nUser request: " + message;
+    input.projectRevision = host->service().currentRevision();
+
+    const auto result = runtime.run(definition, input, cancellation);
+
+    std::string response = result.finalText.toStdString();
+    if (result.state != magda::agent::RunState::Completed) {
+        if (!response.empty())
+            response += "\n";
+        response += "[agent stopped: " + std::string(magda::agent::toString(result.reason));
+        if (result.detail.isNotEmpty())
+            response += ": " + result.detail.toStdString();
+        response += "]";
+    }
+    if (result.mutations > 0)
+        response += "\n[" + std::to_string(result.mutations) + " change(s) applied in " +
+                    std::to_string(result.steps) + " step(s)]";
+    return response;
+}
 }  // namespace
 
 // ============================================================================
@@ -667,29 +759,41 @@ void AIChatConsoleContent::RequestThread::run() {
 
     auto agentStart = std::chrono::steady_clock::now();
 
-    magda::agent::ConsoleRunRequest request{
-        .surface = surfaceDecision.surface,
-        .userMessage = message,
-        .priorConversation = priorContext,
-        .midiContext = midiContext_.toStdString(),
-        .drummerContext = drummerContext_.toStdString(),
-        .reviseTargetClipId = reviseTargetClipId_,
-    };
-    auto output = owner_.agentOrchestrator_->run(
-        request,
-        [&](const magda::agent::ConsoleRunEvent& event) {
-            if (event.type == magda::agent::ConsoleRunEventType::Token)
-                onToken(event.text);
-        },
-        magda::agent::CancellationToken([this] { return threadShouldExit(); }));
-    if (output.cancelled || threadShouldExit())
-        return;
-    dslCode = std::move(output.dslCode);
-    musicInstructions = std::move(output.musicInstructions);
-    musicDescription = std::move(output.musicDescription);
-    autoInstructions = std::move(output.automationInstructions);
-    mixAnalysis = std::move(output.prose);
-    error = std::move(output.error);
+    // Tool-calling path first (#2295): when enabled, the agent acts through
+    // RemoteApiService with the surface allowlist as its tool set, and its
+    // summary flows through the same prose channel the mix agent uses. A
+    // nullopt is a preflight refusal, and the DSL workflows below run instead.
+    if (auto toolLoopResponse = runAgentToolLoop(
+            surfaceDecision.surface, message, priorContext,
+            magda::agent::CancellationToken([this] { return threadShouldExit(); }))) {
+        if (threadShouldExit())
+            return;
+        mixAnalysis = std::move(*toolLoopResponse);
+    } else {
+        magda::agent::ConsoleRunRequest request{
+            .surface = surfaceDecision.surface,
+            .userMessage = message,
+            .priorConversation = priorContext,
+            .midiContext = midiContext_.toStdString(),
+            .drummerContext = drummerContext_.toStdString(),
+            .reviseTargetClipId = reviseTargetClipId_,
+        };
+        auto output = owner_.agentOrchestrator_->run(
+            request,
+            [&](const magda::agent::ConsoleRunEvent& event) {
+                if (event.type == magda::agent::ConsoleRunEventType::Token)
+                    onToken(event.text);
+            },
+            magda::agent::CancellationToken([this] { return threadShouldExit(); }));
+        if (output.cancelled || threadShouldExit())
+            return;
+        dslCode = std::move(output.dslCode);
+        musicInstructions = std::move(output.musicInstructions);
+        musicDescription = std::move(output.musicDescription);
+        autoInstructions = std::move(output.automationInstructions);
+        mixAnalysis = std::move(output.prose);
+        error = std::move(output.error);
+    }
 
     agentMs =
         std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - agentStart)

--- a/magda/daw/ui/panels/content/AIChatConsoleContent.cpp
+++ b/magda/daw/ui/panels/content/AIChatConsoleContent.cpp
@@ -100,8 +100,12 @@ std::optional<std::string> runAgentToolLoop(magda::AgentSurfaceId surfaceId,
 
     const auto llmConfig = config.getAgentLLMConfig(magda::role::COMMAND);
     // The on-device command model is an intent tagger, not a tool-calling
-    // model; the DSL path is the one that knows how to drive it.
-    if (llmConfig.provider == magda::provider::FAST_INFERENCE)
+    // model; the DSL path is the one that knows how to drive it. The embedded
+    // llama client likewise refuses any request that carries tools, so
+    // starting the loop with it could only end in a model error — preflight
+    // both and let the DSL workflows take the request instead.
+    if (llmConfig.provider == magda::provider::FAST_INFERENCE ||
+        llmConfig.provider == magda::provider::LLAMA_LOCAL)
         return std::nullopt;
     auto client = magda::createLLMClient(llmConfig, "tool-loop");
     if (client == nullptr)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -175,6 +175,7 @@ set(TEST_SOURCES
     routing/test_console_routing.cpp
     agents/test_conversation_store.cpp
     agents/test_agent_runtime.cpp
+    agents/test_agent_tool_bridge.cpp
     agents/test_console_agent_orchestrator.cpp
     midi/test_midi_context.cpp
     agents/test_llama_model_manager.cpp

--- a/tests/agents/test_agent_tool_bridge.cpp
+++ b/tests/agents/test_agent_tool_bridge.cpp
@@ -1,0 +1,382 @@
+#include <catch2/catch_test_macros.hpp>
+#include <chrono>
+#include <functional>
+#include <vector>
+
+#include "MockMagdaApi.hpp"
+#include "RemoteTestScopes.hpp"
+#include "magda/agents/agent_tool_bridge.hpp"
+#include "magda/daw/api/remote_service.hpp"
+
+using namespace magda;
+using namespace magda::agent;
+using magda::test::MockMagdaApi;
+
+namespace {
+
+/// The bridge reads live model state through the service, which asserts the
+/// message thread; the Catch2 runner has none, the same accommodation the
+/// remote service tests make.
+struct MessageThreadRelaxation {
+    remote::ScopedMessageThreadAssertionDisabler disabler;
+};
+
+juce::var object(std::initializer_list<std::pair<const char*, juce::var>> fields) {
+    auto* result = new juce::DynamicObject();
+    for (const auto& [key, value] : fields)
+        result->setProperty(key, value);
+    return result;
+}
+
+ToolExecutionRequest requestFor(juce::String id, juce::String name, juce::var arguments,
+                                std::uint64_t expectedRevision = 0) {
+    return {
+        .call = {.id = std::move(id), .name = std::move(name), .arguments = std::move(arguments)},
+        .expectedRevision = expectedRevision,
+        .permissions = {},
+        .deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5)};
+}
+
+class ScriptedModel final : public Model {
+  public:
+    std::function<ModelResponse(const ModelRequest&, const CancellationToken&)> handler;
+
+    ModelResponse generate(const ModelRequest& request,
+                           const CancellationToken& cancellation) override {
+        return handler(request, cancellation);
+    }
+};
+
+}  // namespace
+
+// ===========================================================================
+// Surface tool sets
+// ===========================================================================
+
+TEST_CASE("Every surface allowlist resolves completely against the registry",
+          "[agent-bridge][surfaces]") {
+    // The production form of `invalidSurfaceTools`: a surface naming an
+    // operation the registry does not carry would hand its model a tool
+    // nothing can execute, and this is where that becomes a red build instead
+    // of a runtime log line.
+    for (const auto& surface : registeredAgentSurfaces()) {
+        INFO("surface: " << surface.name);
+        REQUIRE(agentToolsForSurface(surface).size() == surface.toolAllowlist.size());
+    }
+
+    std::vector<std::string> operationNames;
+    for (const auto& operation : remote::OperationRegistry::instance().operations())
+        operationNames.push_back(operation.name.toStdString());
+    REQUIRE(invalidSurfaceTools(operationNames).empty());
+}
+
+TEST_CASE("Tool definitions carry the registry's contract", "[agent-bridge][surfaces]") {
+    const auto tools = agentToolsForSurface(agentSurface(AgentSurfaceId::Arrangement));
+
+    const auto find = [&](const char* name) -> const ToolDefinition* {
+        for (const auto& tool : tools)
+            if (tool.name == name)
+                return &tool;
+        return nullptr;
+    };
+
+    const auto* list = find("tracks.list");
+    REQUIRE(list != nullptr);
+    REQUIRE(list->access == ToolAccess::Read);
+    REQUIRE(list->description.isNotEmpty());
+
+    const auto* create = find("tracks.create");
+    REQUIRE(create != nullptr);
+    REQUIRE(create->access == ToolAccess::Mutation);
+    // The model sees the same input schema an MCP client is validated against.
+    REQUIRE(create->inputSchema["properties"]["name"].isObject());
+}
+
+TEST_CASE("A surface is granted only the scopes its allowlist needs", "[agent-bridge][surfaces]") {
+    const auto pianoRoll = agentScopesForSurface(agentSurface(AgentSurfaceId::PianoRoll));
+    REQUIRE(pianoRoll.has(remote::Scope::Read));
+    REQUIRE(pianoRoll.has(remote::Scope::Edit));
+    REQUIRE_FALSE(pianoRoll.has(remote::Scope::Session));
+    REQUIRE_FALSE(pianoRoll.has(remote::Scope::Transport));
+    REQUIRE_FALSE(pianoRoll.has(remote::Scope::HardwareMidi));
+
+    const auto session = agentScopesForSurface(agentSurface(AgentSurfaceId::Session));
+    REQUIRE(session.has(remote::Scope::Session));
+    REQUIRE(session.has(remote::Scope::Transport));
+    REQUIRE_FALSE(session.has(remote::Scope::HardwareMidi));
+}
+
+// ===========================================================================
+// RemoteAgentToolExecutor
+// ===========================================================================
+
+TEST_CASE("The executor runs an allowlisted read through the service", "[agent-bridge][executor]") {
+    const MessageThreadRelaxation relaxation;
+    MockMagdaApi api;
+    api.tracks_.createTrack("Drums", TrackType::Media);
+    remote::RemoteApiService service(api);
+    RemoteAgentToolExecutor executor(service, agentSurface(AgentSurfaceId::Arrangement));
+
+    const auto result = executor.execute(requestFor("call-1", "tracks.list", object({})), {});
+
+    REQUIRE(result.success);
+    REQUIRE(result.callId == "call-1");
+    REQUIRE_FALSE(result.mutated);
+    REQUIRE(result.projectRevision == remote::INITIAL_REVISION);
+    const auto* items = result.content.getArray();
+    REQUIRE(items != nullptr);
+    REQUIRE(items->size() == 1);
+}
+
+TEST_CASE("The executor's write mutates and reports the new revision", "[agent-bridge][executor]") {
+    const MessageThreadRelaxation relaxation;
+    MockMagdaApi api;
+    remote::RemoteApiService service(api);
+    RemoteAgentToolExecutor executor(service, agentSurface(AgentSurfaceId::Arrangement));
+
+    const auto result =
+        executor.execute(requestFor("call-1", "project.setTempo", object({{"tempo", 132.0}})), {});
+
+    REQUIRE(result.success);
+    REQUIRE(result.mutated);
+    REQUIRE(result.projectRevision == remote::INITIAL_REVISION + 1);
+    REQUIRE(api.project_.info.tempo == 132.0);
+}
+
+TEST_CASE("The executor refuses a call outside the surface allowlist", "[agent-bridge][executor]") {
+    const MessageThreadRelaxation relaxation;
+    MockMagdaApi api;
+    remote::RemoteApiService service(api);
+    // The piano-roll surface carries no device operations at all.
+    RemoteAgentToolExecutor executor(service, agentSurface(AgentSurfaceId::PianoRoll));
+
+    const auto result =
+        executor.execute(requestFor("call-1", "devices.setParameter", object({})), {});
+
+    REQUIRE_FALSE(result.success);
+    REQUIRE(result.error.has_value());
+    REQUIRE(result.error->code == "tool_not_allowed");
+    REQUIRE(service.currentRevision() == remote::INITIAL_REVISION);
+}
+
+TEST_CASE("A service refusal comes back as the dispatcher's error code",
+          "[agent-bridge][executor]") {
+    const MessageThreadRelaxation relaxation;
+    MockMagdaApi api;
+    remote::RemoteApiService service(api);
+    RemoteAgentToolExecutor executor(service, agentSurface(AgentSurfaceId::Arrangement));
+
+    const auto result =
+        executor.execute(requestFor("call-1", "tracks.get", object({{"trackId", 9999}})), {});
+
+    REQUIRE_FALSE(result.success);
+    REQUIRE(result.error.has_value());
+    REQUIRE(result.error->code == "not_found");
+    // Failures still report the current revision; anything older reads to the
+    // runtime as a broken executor.
+    REQUIRE(result.projectRevision == service.currentRevision());
+}
+
+// ===========================================================================
+// The loop end to end: runtime + bridge + service
+// ===========================================================================
+
+TEST_CASE("An agent run reads, writes, and completes through the service",
+          "[agent-bridge][runtime]") {
+    const MessageThreadRelaxation relaxation;
+    MockMagdaApi api;
+    remote::RemoteApiService service(api);
+    const auto& surface = agentSurface(AgentSurfaceId::Arrangement);
+    RemoteAgentToolExecutor executor(service, surface);
+
+    ScriptedModel model;
+    int step = 0;
+    model.handler = [&](const ModelRequest&, const CancellationToken&) -> ModelResponse {
+        ++step;
+        if (step == 1)
+            return {.success = true,
+                    .toolCalls = {{.id = "c1",
+                                   .name = "project.setTempo",
+                                   .arguments = object({{"tempo", 132.0}})}}};
+        return {.success = true, .text = "Tempo set to 132."};
+    };
+
+    AgentDefinition definition{.id = "console-arrangement",
+                               .systemPrompt = "Act via tools.",
+                               .tools = agentToolsForSurface(surface)};
+    definition.budget.maxSteps = 4;
+
+    AgentRuntime runtime(model, executor);
+    const auto result = runtime.run(definition, {.userMessage = "set the tempo to 132"});
+
+    REQUIRE(result.state == RunState::Completed);
+    REQUIRE(result.finalText == "Tempo set to 132.");
+    REQUIRE(result.mutations == 1);
+    REQUIRE(result.finalRevision == remote::INITIAL_REVISION + 1);
+    REQUIRE(api.project_.info.tempo == 132.0);
+}
+
+TEST_CASE("A model calling past its definition is refused without touching the service",
+          "[agent-bridge][runtime]") {
+    const MessageThreadRelaxation relaxation;
+    MockMagdaApi api;
+    remote::RemoteApiService service(api);
+    const auto& surface = agentSurface(AgentSurfaceId::PianoRoll);
+    RemoteAgentToolExecutor executor(service, surface);
+
+    ScriptedModel model;
+    int step = 0;
+    model.handler = [&](const ModelRequest& request, const CancellationToken&) -> ModelResponse {
+        ++step;
+        if (step == 1)
+            return {.success = true,
+                    .toolCalls = {
+                        {.id = "c1", .name = "devices.setParameter", .arguments = object({})}}};
+        // The refusal reaches the model as a tool error it can read.
+        const auto& lastTurn = request.conversation.back();
+        REQUIRE(lastTurn.role == ConversationRole::Tool);
+        REQUIRE(lastTurn.toolResult.has_value());
+        REQUIRE(lastTurn.toolResult->error.has_value());
+        REQUIRE(lastTurn.toolResult->error->code == "tool_not_allowed");
+        return {.success = true, .text = "That tool is not available here."};
+    };
+
+    AgentDefinition definition{.id = "console-piano-roll",
+                               .systemPrompt = "Act via tools.",
+                               .tools = agentToolsForSurface(surface)};
+    definition.budget.maxSteps = 4;
+
+    AgentRuntime runtime(model, executor);
+    const auto result = runtime.run(definition, {.userMessage = "tweak the filter"});
+
+    REQUIRE(result.state == RunState::Completed);
+    REQUIRE(api.devices_.parameterWrites.empty());
+    REQUIRE(service.currentRevision() == remote::INITIAL_REVISION);
+}
+
+// ===========================================================================
+// LlmToolModel: runtime types <-> juce_llm types
+// ===========================================================================
+
+#include "magda/agents/llm_tool_model.hpp"
+
+namespace {
+
+/// Captures the mapped llm::Request and answers with a scripted llm::Response.
+class CapturingLlmClient final : public llm::LLMClient {
+  public:
+    CapturingLlmClient() : llm::LLMClient(llm::ProviderConfig{}) {}
+
+    mutable std::vector<llm::Request> requests;
+    llm::Response scripted;
+
+    llm::Response sendRequest(const llm::Request& request) const override {
+        requests.push_back(request);
+        return scripted;
+    }
+
+    juce::String getName() const override {
+        return "capturing";
+    }
+    juce::String buildRequestBody(const llm::Request&) const override {
+        return {};
+    }
+    juce::String getEndpointUrl() const override {
+        return {};
+    }
+    juce::StringPairArray getHeaders() const override {
+        return {};
+    }
+    llm::Response parseResponseBody(const juce::String&) const override {
+        return {};
+    }
+};
+
+}  // namespace
+
+TEST_CASE("LlmToolModel maps the runtime conversation onto the provider surface",
+          "[agent-bridge][llm-model]") {
+    CapturingLlmClient client;
+    client.scripted.success = true;
+    client.scripted.text = "done";
+    llm::ToolCall scriptedCall;
+    scriptedCall.id = "c9";
+    scriptedCall.name = "tracks.list";
+    scriptedCall.arguments = object({});
+    client.scripted.toolCalls.push_back(scriptedCall);
+    client.scripted.totalTokens = 321;
+
+    LlmToolModel model(client);
+
+    ModelRequest request;
+    request.systemPrompt = "Be the arrangement agent.";
+    request.tools = {{.name = "tracks.list",
+                      .description = "List tracks",
+                      .inputSchema = object({}),
+                      .access = ToolAccess::Read}};
+    // A completed earlier iteration: assistant tool call, its result, then the
+    // current user turn the provider wants separated out.
+    ConversationTurn assistant{.role = ConversationRole::Assistant, .text = "checking"};
+    assistant.toolCalls.push_back({.id = "c1", .name = "tracks.list", .arguments = object({})});
+    ConversationTurn toolTurn{.role = ConversationRole::Tool};
+    toolTurn.toolResult = ToolResult{.callId = "c1",
+                                     .toolName = "tracks.list",
+                                     .success = true,
+                                     .content = object({{"ok", true}})};
+    request.conversation = {ConversationTurn{.role = ConversationRole::User, .text = "hi"},
+                            assistant, toolTurn,
+                            ConversationTurn{.role = ConversationRole::User, .text = "and now?"}};
+
+    const auto response = model.generate(request, {});
+
+    REQUIRE(client.requests.size() == 1);
+    const auto& mapped = client.requests.front();
+    REQUIRE(mapped.systemPrompt == "Be the arrangement agent.");
+    REQUIRE(mapped.tools.size() == 1);
+    REQUIRE(mapped.tools.front().name == "tracks.list");
+    REQUIRE(static_cast<bool>(mapped.tools.front().annotations["readOnlyHint"]));
+    // The trailing user turn became the current message; history kept the rest.
+    REQUIRE(mapped.userMessage == "and now?");
+    REQUIRE(mapped.messages.size() == 3);
+    REQUIRE(mapped.messages[0].role == "user");
+    REQUIRE(mapped.messages[1].role == "assistant");
+    REQUIRE(mapped.messages[1].toolCalls.size() == 1);
+    REQUIRE(mapped.messages[2].role == "tool");
+    REQUIRE(mapped.messages[2].toolResults.size() == 1);
+    REQUIRE(mapped.messages[2].toolResults.front().callId == "c1");
+    REQUIRE_FALSE(mapped.messages[2].toolResults.front().isError);
+
+    // The provider's answer came back in runtime terms.
+    REQUIRE(response.success);
+    REQUIRE(response.text == "done");
+    REQUIRE(response.toolCalls.size() == 1);
+    REQUIRE(response.toolCalls.front().id == "c9");
+    REQUIRE(response.tokensUsed == 321);
+}
+
+TEST_CASE("LlmToolModel surfaces tool errors as error results", "[agent-bridge][llm-model]") {
+    CapturingLlmClient client;
+    client.scripted.success = true;
+    client.scripted.text = "understood";
+
+    LlmToolModel model(client);
+
+    ModelRequest request;
+    ConversationTurn toolTurn{.role = ConversationRole::Tool};
+    toolTurn.toolResult =
+        ToolResult{.callId = "c1",
+                   .toolName = "tracks.get",
+                   .success = false,
+                   .error = ToolError{.code = "not_found", .message = "track 9 not found"}};
+    request.conversation = {toolTurn};
+
+    model.generate(request, {});
+
+    REQUIRE(client.requests.size() == 1);
+    const auto& mapped = client.requests.front();
+    REQUIRE(mapped.userMessage.isEmpty());
+    REQUIRE(mapped.messages.size() == 1);
+    REQUIRE(mapped.messages[0].toolResults.size() == 1);
+    REQUIRE(mapped.messages[0].toolResults.front().isError);
+    REQUIRE(mapped.messages[0].toolResults.front().error == "track 9 not found");
+}

--- a/tests/agents/test_agent_tool_bridge.cpp
+++ b/tests/agents/test_agent_tool_bridge.cpp
@@ -143,6 +143,31 @@ TEST_CASE("The executor's write mutates and reports the new revision", "[agent-b
     REQUIRE(api.project_.info.tempo == 132.0);
 }
 
+TEST_CASE("A reused tool-call id in a later run is not answered from cache",
+          "[agent-bridge][executor]") {
+    const MessageThreadRelaxation relaxation;
+    MockMagdaApi api;
+    remote::RemoteApiService service(api);
+    const auto& surface = agentSurface(AgentSurfaceId::Arrangement);
+
+    // Providers number tool calls per response, so two runs both open with
+    // "call_0". The service caches writes by clientId + requestId, and the
+    // surface's clientId never changes — only the executor's per-run namespace
+    // keeps the second write from replaying the first one's cached response.
+    RemoteAgentToolExecutor firstRun(service, surface);
+    const auto first =
+        firstRun.execute(requestFor("call_0", "project.setTempo", object({{"tempo", 120.0}})), {});
+    REQUIRE(first.success);
+    REQUIRE(api.project_.info.tempo == 120.0);
+
+    RemoteAgentToolExecutor secondRun(service, surface);
+    const auto second =
+        secondRun.execute(requestFor("call_0", "project.setTempo", object({{"tempo", 132.0}})), {});
+    REQUIRE(second.success);
+    REQUIRE(api.project_.info.tempo == 132.0);
+    REQUIRE(second.projectRevision == remote::INITIAL_REVISION + 2);
+}
+
 TEST_CASE("The executor refuses a call outside the surface allowlist", "[agent-bridge][executor]") {
     const MessageThreadRelaxation relaxation;
     MockMagdaApi api;

--- a/tests/devices/test_device_api.cpp
+++ b/tests/devices/test_device_api.cpp
@@ -481,6 +481,8 @@ TEST_CASE("Parameter writes are range-checked rather than clamped", "[device-api
     DeviceInfo device;
     device.name = "Filter";
     device.pluginId = "test_filter";
+    // Internal, so the external-plugin opt-in gate stays out of this test's way.
+    device.format = PluginFormat::Internal;
     ParameterInfo cutoff;
     cutoff.paramIndex = 0;
     cutoff.name = "Cutoff";
@@ -507,6 +509,40 @@ TEST_CASE("Parameter writes are range-checked rather than clamped", "[device-api
 
     SECTION("unknown device is refused") {
         REQUIRE_FALSE(devices.setDeviceParameter(ChainNodePath{}, 0, 100.0f));
+    }
+
+    tracks.clearAllTracks();
+}
+
+TEST_CASE("External-plugin parameter writes require the user's opt-in", "[device-api][mutation]") {
+    auto& tracks = TrackManager::getInstance();
+    const auto trackId = freshTrack("Synth");
+
+    DeviceInfo device;
+    device.name = "External synth";
+    device.pluginId = "external_synth";
+    device.format = PluginFormat::VST3;
+    for (int i = 0; i < 2; ++i) {
+        ParameterInfo param;
+        param.paramIndex = i;
+        param.name = "Param " + juce::String(i);
+        param.minValue = 0.0f;
+        param.maxValue = 1.0f;
+        device.parameters.push_back(param);
+    }
+    // The user opted in only the first parameter under Configure Parameters.
+    device.aiSoundDesignerParameters = {0};
+    const auto deviceId = tracks.addDeviceToTrack(trackId, device);
+    const auto path = tracks.findDevicePath(deviceId);
+
+    DeviceApiLive devices;
+
+    SECTION("an opted-in parameter accepts the write") {
+        REQUIRE(devices.setDeviceParameter(path, 0, 0.5f));
+    }
+
+    SECTION("a parameter the user did not opt in is refused") {
+        REQUIRE_FALSE(devices.setDeviceParameter(path, 1, 0.5f));
     }
 
     tracks.clearAllTracks();

--- a/tests/remote/test_remote_permission_conformance.cpp
+++ b/tests/remote/test_remote_permission_conformance.cpp
@@ -104,6 +104,15 @@ std::vector<Vector> vectors() {
 
         {"selection is an edit", "selection.set", emptyObject(), read, false},
         {"automation is an edit", "automation.listLanes", emptyObject(), read, true},
+
+        {"hardware MIDI is refused without its scope", "midi.send",
+         object({{"port", "conformance-port"},
+                 {"bytes", juce::var(juce::Array<juce::var>{0x90, 60, 100})}}),
+         ScopeSet{Scope::Read, Scope::Edit}, false},
+        {"hardware MIDI is allowed with it", "midi.send",
+         object({{"port", "conformance-port"},
+                 {"bytes", juce::var(juce::Array<juce::var>{0x90, 60, 100})}}),
+         ScopeSet{Scope::Read, Scope::HardwareMidi}, true},
     };
 }
 

--- a/tests/remote/test_remote_service.cpp
+++ b/tests/remote/test_remote_service.cpp
@@ -1075,6 +1075,26 @@ TEST_CASE("clips.update refuses a groove template that does not exist",
     REQUIRE(api.undo_.executeCalls == 0);
 }
 
+TEST_CASE("clips.update with an unknown groove applies none of the patch",
+          "[remote][service][clips]") {
+    const MessageThreadRelaxation relaxation;
+    MockMagdaApi api;
+    seedMidiClip(api, 7);
+    RemoteApiService service(api);
+
+    // The rename is valid on its own; the groove is not. A failed handler does
+    // not roll back the compound, so the groove has to be refused before the
+    // rename runs — otherwise the request fails after changing the project.
+    const auto response =
+        run(service, "clips.update",
+            object({{"clipId", 7}, {"name", "Hook"}, {"grooveTemplate", "No Such Groove"}}));
+
+    REQUIRE_FALSE(response.ok);
+    REQUIRE(errorCodeOf(response) == "not_found");
+    REQUIRE(api.undo_.executeCalls == 0);
+    REQUIRE(service.currentRevision() == INITIAL_REVISION);
+}
+
 TEST_CASE("clips.transpose shifts every note and echoes the clip", "[remote][service][clips]") {
     const MessageThreadRelaxation relaxation;
     MockMagdaApi api;
@@ -1158,7 +1178,7 @@ TEST_CASE("Note operations refuse a clip that is not MIDI", "[remote][service][c
     REQUIRE(errorCodeOf(response) == "conflict");
 }
 
-TEST_CASE("tracks.group groups existing tracks under a new id", "[remote][service][tracks]") {
+TEST_CASE("tracks.group goes through the undo stack, not the facade", "[remote][service][tracks]") {
     const MessageThreadRelaxation relaxation;
     MockMagdaApi api;
     api.tracks_.createTrack("Drums", TrackType::Media);
@@ -1167,22 +1187,25 @@ TEST_CASE("tracks.group groups existing tracks under a new id", "[remote][servic
     const auto second = api.tracks_.tracks[1].id;
     RemoteApiService service(api);
 
-    const auto response =
-        run(service, "tracks.group",
-            object({{"trackIds", integerArray({static_cast<int>(first), static_cast<int>(second)})},
-                    {"name", "Rhythm"}}));
+    run(service, "tracks.group",
+        object({{"trackIds", integerArray({static_cast<int>(first), static_cast<int>(second)})},
+                {"name", "Rhythm"}}));
 
-    REQUIRE(response.ok);
-    REQUIRE(static_cast<int>(response.result["id"]) != INVALID_TRACK_ID);
-    REQUIRE(api.tracks_.groupWrites.size() == 1);
+    // One command enqueued and no direct facade write: the grouping lands on
+    // the undo stack. The stub retains commands without executing them (they
+    // act on the real singletons), so the created id — and the success path —
+    // are asserted where the singletons are live, in the WebSocket live suite.
+    REQUIRE(api.undo_.executeCalls == 1);
+    REQUIRE(api.tracks_.groupWrites.empty());
 
     const auto missing = run(service, "tracks.group",
                              object({{"trackIds", integerArray({9999})}, {"name", "Ghost"}}));
     REQUIRE_FALSE(missing.ok);
     REQUIRE(errorCodeOf(missing) == "not_found");
+    REQUIRE(api.undo_.executeCalls == 1);
 }
 
-TEST_CASE("tracks.move repositions a track", "[remote][service][tracks]") {
+TEST_CASE("tracks.move goes through the undo stack, not the facade", "[remote][service][tracks]") {
     const MessageThreadRelaxation relaxation;
     MockMagdaApi api;
     api.tracks_.createTrack("Drums", TrackType::Media);
@@ -1193,7 +1216,8 @@ TEST_CASE("tracks.move repositions a track", "[remote][service][tracks]") {
         run(service, "tracks.move", object({{"trackId", static_cast<int>(id)}, {"position", 1}}));
 
     REQUIRE(response.ok);
-    REQUIRE(api.tracks_.moveWrites.size() == 1);
+    REQUIRE(api.undo_.executeCalls == 1);
+    REQUIRE(api.tracks_.moveWrites.empty());
 }
 
 TEST_CASE("grooves.upsert then grooves.list round-trips the template name",
@@ -1274,6 +1298,10 @@ TEST_CASE("midi.send delivers a channel message to the named port", "[remote][se
     REQUIRE(api.midi_.sends.size() == 1);
     REQUIRE(api.midi_.sends.front().port == "Launchkey");
     REQUIRE(api.midi_.sends.front().msg.isNoteOn());
+    // Hardware delivery is not a project mutation: no revision bump, no undo
+    // step.
+    REQUIRE(service.currentRevision() == INITIAL_REVISION);
+    REQUIRE(api.undo_.executeCalls == 0);
 }
 
 TEST_CASE("midi.send refuses a length that contradicts the status byte",
@@ -1307,4 +1335,6 @@ TEST_CASE("midi.sendSysEx delivers the unframed payload", "[remote][service][mid
     REQUIRE(response.ok);
     REQUIRE(api.midi_.sends.size() == 1);
     REQUIRE(api.midi_.sends.front().msg.isSysEx());
+    REQUIRE(service.currentRevision() == INITIAL_REVISION);
+    REQUIRE(api.undo_.executeCalls == 0);
 }

--- a/tests/remote/test_remote_service.cpp
+++ b/tests/remote/test_remote_service.cpp
@@ -992,3 +992,319 @@ TEST_CASE("devices.setParameterConfig applies detection overrides", "[remote][se
     REQUIRE(errorCodeOf(refused) == "validation_failed");
     REQUIRE(api.devices_.configUpdates.size() == 1);
 }
+
+// ===========================================================================
+// Content operations (#2297): clips.update / transpose / quantize / sliceNotes,
+// tracks.group / move, grooves, focused macros, hardware MIDI out
+// ===========================================================================
+
+namespace {
+
+/// A MIDI clip with two notes, seeded into the mock under `clipId`.
+void seedMidiClip(MockMagdaApi& api, ClipId clipId) {
+    ClipInfo clip;
+    clip.id = clipId;
+    clip.name = "Riff";
+    MidiNote first;
+    first.startBeat = 0.1;
+    first.noteNumber = 60;
+    first.lengthBeats = 0.9;
+    MidiNote second;
+    second.startBeat = 1.6;
+    second.noteNumber = 64;
+    second.lengthBeats = 1.0;
+    clip.midiNotes = {first, second};
+    api.clips_.clips[clipId] = clip;
+}
+
+juce::var integerArray(std::initializer_list<int> values) {
+    juce::Array<juce::var> array;
+    for (const auto value : values)
+        array.add(value);
+    return array;
+}
+
+}  // namespace
+
+TEST_CASE("clips.update patches name, enabled, and groove as one undo step",
+          "[remote][service][clips]") {
+    const MessageThreadRelaxation relaxation;
+    MockMagdaApi api;
+    seedMidiClip(api, 7);
+    api.grooves_.names.add("Swing 16");
+    RemoteApiService service(api);
+
+    const auto response = run(
+        service, "clips.update",
+        object(
+            {{"clipId", 7}, {"name", "Hook"}, {"enabled", false}, {"grooveTemplate", "Swing 16"}}));
+
+    REQUIRE(response.ok);
+    // Three field changes, three commands, one compound for the request.
+    REQUIRE(api.undo_.executeCalls == 3);
+    REQUIRE(api.undo_.maxCompoundDepth == 1);
+    REQUIRE(service.currentRevision() == INITIAL_REVISION + 1);
+}
+
+TEST_CASE("clips.update restating current state mutates nothing", "[remote][service][clips]") {
+    const MessageThreadRelaxation relaxation;
+    MockMagdaApi api;
+    seedMidiClip(api, 7);
+    RemoteApiService service(api);
+
+    const auto response = run(service, "clips.update", object({{"clipId", 7}, {"name", "Riff"}}));
+
+    REQUIRE(response.ok);
+    REQUIRE(api.undo_.executeCalls == 0);
+    // A no-op patch must not advance the revision.
+    REQUIRE(service.currentRevision() == INITIAL_REVISION);
+}
+
+TEST_CASE("clips.update refuses a groove template that does not exist",
+          "[remote][service][clips]") {
+    const MessageThreadRelaxation relaxation;
+    MockMagdaApi api;
+    seedMidiClip(api, 7);
+    RemoteApiService service(api);
+
+    const auto response =
+        run(service, "clips.update", object({{"clipId", 7}, {"grooveTemplate", "No Such Groove"}}));
+
+    REQUIRE_FALSE(response.ok);
+    REQUIRE(errorCodeOf(response) == "not_found");
+    REQUIRE(api.undo_.executeCalls == 0);
+}
+
+TEST_CASE("clips.transpose shifts every note and echoes the clip", "[remote][service][clips]") {
+    const MessageThreadRelaxation relaxation;
+    MockMagdaApi api;
+    seedMidiClip(api, 7);
+    RemoteApiService service(api);
+
+    const auto response =
+        run(service, "clips.transpose", object({{"clipId", 7}, {"semitones", 5}}));
+
+    REQUIRE(response.ok);
+    const auto* notes = response.result["notes"].getArray();
+    REQUIRE(notes != nullptr);
+    REQUIRE(static_cast<int>((*notes)[0]["note"]) == 65);
+    REQUIRE(static_cast<int>((*notes)[1]["note"]) == 69);
+}
+
+TEST_CASE("clips.quantize defaults to every note and snaps to the grid",
+          "[remote][service][clips]") {
+    const MessageThreadRelaxation relaxation;
+    MockMagdaApi api;
+    seedMidiClip(api, 7);
+    RemoteApiService service(api);
+
+    const auto response =
+        run(service, "clips.quantize", object({{"clipId", 7}, {"gridResolution", 0.5}}));
+
+    REQUIRE(response.ok);
+    REQUIRE(api.clips_.quantizeCalls.size() == 1);
+    REQUIRE(api.clips_.quantizeCalls.front().noteIndices == std::vector<size_t>{0, 1});
+    const auto* notes = response.result["notes"].getArray();
+    REQUIRE(notes != nullptr);
+    REQUIRE(static_cast<double>((*notes)[0]["startBeat"]) == 0.0);
+    REQUIRE(static_cast<double>((*notes)[1]["startBeat"]) == 1.5);
+}
+
+TEST_CASE("clips.quantize refuses an index that names no note", "[remote][service][clips]") {
+    const MessageThreadRelaxation relaxation;
+    MockMagdaApi api;
+    seedMidiClip(api, 7);
+    RemoteApiService service(api);
+
+    const auto response = run(
+        service, "clips.quantize",
+        object({{"clipId", 7}, {"gridResolution", 0.5}, {"noteIndices", integerArray({0, 9})}}));
+
+    REQUIRE_FALSE(response.ok);
+    REQUIRE(errorCodeOf(response) == "validation_failed");
+    REQUIRE(api.clips_.quantizeCalls.empty());
+}
+
+TEST_CASE("clips.sliceNotes subdivides the addressed notes", "[remote][service][clips]") {
+    const MessageThreadRelaxation relaxation;
+    MockMagdaApi api;
+    seedMidiClip(api, 7);
+    RemoteApiService service(api);
+
+    const auto response =
+        run(service, "clips.sliceNotes",
+            object({{"clipId", 7}, {"subdivisions", 2}, {"noteIndices", integerArray({1})}}));
+
+    REQUIRE(response.ok);
+    const auto* notes = response.result["notes"].getArray();
+    REQUIRE(notes != nullptr);
+    // One untouched note plus one sliced into two.
+    REQUIRE(notes->size() == 3);
+}
+
+TEST_CASE("Note operations refuse a clip that is not MIDI", "[remote][service][clips]") {
+    const MessageThreadRelaxation relaxation;
+    MockMagdaApi api;
+    ClipInfo audio;
+    audio.id = 9;
+    audio.content = AudioClipModel{};
+    api.clips_.clips[9] = audio;
+    RemoteApiService service(api);
+
+    const auto response =
+        run(service, "clips.transpose", object({{"clipId", 9}, {"semitones", 2}}));
+
+    REQUIRE_FALSE(response.ok);
+    REQUIRE(errorCodeOf(response) == "conflict");
+}
+
+TEST_CASE("tracks.group groups existing tracks under a new id", "[remote][service][tracks]") {
+    const MessageThreadRelaxation relaxation;
+    MockMagdaApi api;
+    api.tracks_.createTrack("Drums", TrackType::Media);
+    api.tracks_.createTrack("Bass", TrackType::Media);
+    const auto first = api.tracks_.tracks[0].id;
+    const auto second = api.tracks_.tracks[1].id;
+    RemoteApiService service(api);
+
+    const auto response =
+        run(service, "tracks.group",
+            object({{"trackIds", integerArray({static_cast<int>(first), static_cast<int>(second)})},
+                    {"name", "Rhythm"}}));
+
+    REQUIRE(response.ok);
+    REQUIRE(static_cast<int>(response.result["id"]) != INVALID_TRACK_ID);
+    REQUIRE(api.tracks_.groupWrites.size() == 1);
+
+    const auto missing = run(service, "tracks.group",
+                             object({{"trackIds", integerArray({9999})}, {"name", "Ghost"}}));
+    REQUIRE_FALSE(missing.ok);
+    REQUIRE(errorCodeOf(missing) == "not_found");
+}
+
+TEST_CASE("tracks.move repositions a track", "[remote][service][tracks]") {
+    const MessageThreadRelaxation relaxation;
+    MockMagdaApi api;
+    api.tracks_.createTrack("Drums", TrackType::Media);
+    const auto id = api.tracks_.tracks[0].id;
+    RemoteApiService service(api);
+
+    const auto response =
+        run(service, "tracks.move", object({{"trackId", static_cast<int>(id)}, {"position", 1}}));
+
+    REQUIRE(response.ok);
+    REQUIRE(api.tracks_.moveWrites.size() == 1);
+}
+
+TEST_CASE("grooves.upsert then grooves.list round-trips the template name",
+          "[remote][service][grooves]") {
+    const MessageThreadRelaxation relaxation;
+    MockMagdaApi api;
+    RemoteApiService service(api);
+
+    juce::Array<juce::var> lateness;
+    lateness.add(0.0);
+    lateness.add(0.25);
+    const auto upsert = run(service, "grooves.upsert",
+                            object({{"name", "Swing 8"},
+                                    {"notesPerBeat", 2},
+                                    {"latenessProportions", juce::var(lateness)}}));
+    REQUIRE(upsert.ok);
+
+    const auto list = run(service, "grooves.list", emptyInput());
+    REQUIRE(list.ok);
+    const auto* names = list.result.getArray();
+    REQUIRE(names != nullptr);
+    REQUIRE(names->size() == 1);
+    REQUIRE((*names)[0].toString() == "Swing 8");
+}
+
+TEST_CASE("focused.get answers safely with nothing focused", "[remote][service][focused]") {
+    const MessageThreadRelaxation relaxation;
+    MockMagdaApi api;
+    RemoteApiService service(api);
+
+    const auto response = run(service, "focused.get", emptyInput());
+
+    REQUIRE(response.ok);
+    REQUIRE_FALSE(static_cast<bool>(response.result["hasFocus"]));
+    REQUIRE(response.result["macros"].getArray()->isEmpty());
+}
+
+TEST_CASE("focused.setMacro writes the focused device's macro", "[remote][service][focused]") {
+    const MessageThreadRelaxation relaxation;
+    MockMagdaApi api;
+    api.focused_.focused = true;
+    api.focused_.focusedName = "Poly Synth";
+    api.focused_.macroNames = {"Cutoff"};
+    api.focused_.macroValues = {0.25f};
+    RemoteApiService service(api);
+
+    const auto response = run(service, "focused.setMacro", object({{"index", 0}, {"value", 0.75}}));
+
+    REQUIRE(response.ok);
+    REQUIRE(api.focused_.macroWrites.size() == 1);
+    REQUIRE(api.focused_.macroWrites.front().idx == 0);
+    REQUIRE(api.focused_.macroWrites.front().value == 0.75f);
+    REQUIRE(response.result["name"].toString() == "Poly Synth");
+}
+
+TEST_CASE("focused.setMacro refuses when nothing is focused", "[remote][service][focused]") {
+    const MessageThreadRelaxation relaxation;
+    MockMagdaApi api;
+    RemoteApiService service(api);
+
+    const auto response = run(service, "focused.setMacro", object({{"index", 0}, {"value", 0.5}}));
+
+    REQUIRE_FALSE(response.ok);
+    REQUIRE(errorCodeOf(response) == "conflict");
+    REQUIRE(api.focused_.macroWrites.empty());
+}
+
+TEST_CASE("midi.send delivers a channel message to the named port", "[remote][service][midi]") {
+    const MessageThreadRelaxation relaxation;
+    MockMagdaApi api;
+    RemoteApiService service(api);
+
+    const auto response =
+        run(service, "midi.send",
+            object({{"port", "Launchkey"}, {"bytes", integerArray({0x90, 60, 100})}}));
+
+    REQUIRE(response.ok);
+    REQUIRE(api.midi_.sends.size() == 1);
+    REQUIRE(api.midi_.sends.front().port == "Launchkey");
+    REQUIRE(api.midi_.sends.front().msg.isNoteOn());
+}
+
+TEST_CASE("midi.send refuses a length that contradicts the status byte",
+          "[remote][service][midi]") {
+    const MessageThreadRelaxation relaxation;
+    MockMagdaApi api;
+    RemoteApiService service(api);
+
+    // A note-on promises three bytes; sending two would make MidiMessage
+    // assert rather than refuse.
+    const auto response = run(service, "midi.send",
+                              object({{"port", "Launchkey"}, {"bytes", integerArray({0x90, 60})}}));
+
+    REQUIRE_FALSE(response.ok);
+    REQUIRE(errorCodeOf(response) == "validation_failed");
+    REQUIRE(api.midi_.sends.empty());
+}
+
+TEST_CASE("midi.sendSysEx delivers the unframed payload", "[remote][service][midi]") {
+    const MessageThreadRelaxation relaxation;
+    MockMagdaApi api;
+    api.midi_.outputPortNames = {"Launchkey"};
+    RemoteApiService service(api);
+
+    const auto ports = run(service, "midi.listOutputPorts", emptyInput());
+    REQUIRE(ports.ok);
+    REQUIRE(ports.result.getArray()->size() == 1);
+
+    const auto response = run(service, "midi.sendSysEx",
+                              object({{"port", "Launchkey"}, {"bytes", integerArray({1, 2, 3})}}));
+    REQUIRE(response.ok);
+    REQUIRE(api.midi_.sends.size() == 1);
+    REQUIRE(api.midi_.sends.front().msg.isSysEx());
+}

--- a/tests/remote/test_remote_websocket_live_juce.cpp
+++ b/tests/remote/test_remote_websocket_live_juce.cpp
@@ -128,6 +128,52 @@ class RemoteWebSocketLiveTest final : public juce::UnitTest {
             expect(TrackManager::getInstance().getTracks().size() == 1);
         }
 
+        beginTest("A grouping over the wire is one undoable step");
+        {
+            Fixture fixture;
+            const auto first = static_cast<int>(fixture.exchange(requestJson(
+                "tracks.create", object({{"name", "Drums"}, {"type", "audio"}})))["result"]["id"]);
+            const auto second = static_cast<int>(fixture.exchange(requestJson(
+                "tracks.create", object({{"name", "Bass"}, {"type", "audio"}})))["result"]["id"]);
+
+            juce::Array<juce::var> ids;
+            ids.add(first);
+            ids.add(second);
+            const auto reply = fixture.exchange(requestJson(
+                "tracks.group", object({{"trackIds", juce::var(ids)}, {"name", "Rhythm"}})));
+
+            expect(reply["error"].isVoid());
+            const auto groupId = static_cast<int>(reply["result"]["id"]);
+            expect(TrackManager::getInstance().getTrack(groupId) != nullptr);
+
+            // The grouping went through a command inside the request's
+            // compound; a handler that wrote through the facade would leave
+            // the compound empty and this undo with nothing to revert.
+            expect(UndoManager::getInstance().undo());
+            expect(TrackManager::getInstance().getTrack(groupId) == nullptr);
+            expect(TrackManager::getInstance().getTopLevelTracks().size() == 2);
+        }
+
+        beginTest("A move over the wire is one undoable step");
+        {
+            Fixture fixture;
+            const auto first = static_cast<int>(fixture.exchange(requestJson(
+                "tracks.create", object({{"name", "Drums"}, {"type", "audio"}})))["result"]["id"]);
+            const auto second = static_cast<int>(fixture.exchange(requestJson(
+                "tracks.create", object({{"name", "Bass"}, {"type", "audio"}})))["result"]["id"]);
+
+            const auto reply = fixture.exchange(
+                requestJson("tracks.move", object({{"trackId", second}, {"position", 1}})));
+
+            expect(reply["error"].isVoid());
+            auto order = TrackManager::getInstance().getTopLevelTracks();
+            expect(order.size() == 2 && static_cast<int>(order[0]) == second);
+
+            expect(UndoManager::getInstance().undo());
+            order = TrackManager::getInstance().getTopLevelTracks();
+            expect(order.size() == 2 && static_cast<int>(order[0]) == first);
+        }
+
         beginTest("An edit made in the UI is visible to the next request");
         {
             Fixture fixture;


### PR DESCRIPTION
Closes #2295, closes #2296, closes #2297.

One PR for the three issues from the agent/MCP access audit: in-app agents and remote clients acted on the same `MagdaApi` instance through different layers, with different capabilities and different safeguards. Three commits, one per issue.

## #2296 — the parameter opt-in gate moved into DeviceApi

The per-parameter AI opt-in was checked only in the MCP handler, so any facade consumer (agents, Lua, OSC, CLI) bypassed it. The gate now lives in `DeviceApiLive::setDeviceParameter`; the handler keeps a pre-check solely to classify the refusal as `PermissionDenied` with a useful message. Negative-verified: the new opt-in test fails with the gate reverted.

## #2297 — 14 new remote operations

Closing the widest capability gaps between the DSL and the registry:

- `clips.update` / `clips.transpose` / `clips.quantize` / `clips.sliceNotes`
- `tracks.group` / `tracks.move`
- `grooves.list` / `grooves.upsert`
- `focused.get` / `focused.setMacro` / `focused.cycleDevice`
- `midi.listOutputPorts` / `midi.send` / `midi.sendSysEx` — the **first operations behind the `hardware-midi` scope**, which #1860 declared ahead of time for exactly this moment

Scope policy table, permissions doc, service tests, and cross-transport conformance vectors updated. Deliberately not added: `AliasApi` (registry references, not remotable as-is), `PluginApi`'s sequencer/Faust appliers (sibling of #2294's device-surface work), and DSL sugar verbs like `addChord` (composable client-side from `clips.addMidiNote`).

## #2295 — agents routed through RemoteApiService

The production half the agent runtime (#1863) was missing:

- **`magda/agents/agent_tool_bridge`** — `agentToolsForSurface()` resolves each `ConsoleRouting` allowlist against `OperationRegistry` into the agent's tool set; `agentScopesForSurface()` grants only what the allowlist needs; `RemoteAgentToolExecutor` executes every call through `RemoteApiService`, so agent actions get schema validation, scope enforcement, optimistic concurrency, undo grouping, and the audit log — same as an MCP client. The allowlists are now enforced at execution time (definition membership in the runtime + an independent executor check), pinned by a test that resolves every registered surface against the live registry.
- **`magda/agents/llm_tool_model`** — `agent::Model` over `llm::LLMClient` using juce_llm's native tool-calling surface; one adapter for all configured providers.
- **Console wiring** — an opt-in tool-loop path in `AIChatConsoleContent` (`Config` `ai.toolLoop`, default **off**): when enabled, the surface's agent runs `AgentRuntime` end to end; preflight failure (flag off, no remote host, provider without tool calling) falls through to the existing DSL workflows unchanged. Off by default because the loop needs live-LLM soak time; the DSL paths remain the shipped behaviour. The approval hook is in place and currently auto-approves, matching what the DSL executors do today — a per-step approval UI is the follow-up that reads `AgentRunPolicy.approveMutations`.

## Testing

- Full unit suite: 3321 cases pass.
- New: 21 test cases across `[device-api]` gate, `[remote][service]` content ops, conformance vectors for `hardware-midi`, and `[agent-bridge]` (surface resolution, executor enforcement, end-to-end runtime run, LLM mapping).

Note: overlaps with #2293 only in `tests/remote/test_remote_service.cpp` (both append test cases); everything else merges cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VMjNEtqw2WxSK3evwdeXZG