### PR TITLE
Give the engine a session domain: slots in the snapshot, handles in the store (#2301)

### DIFF
--- a/magda/engine/clip/ClipSnapshot.cpp
+++ b/magda/engine/clip/ClipSnapshot.cpp
@@ -13,4 +13,13 @@ const TrackClipPlayback* ClipSnapshot::find(TrackId trackId) const {
     return &*it;
 }
 
+const SessionSlotPlayback* TrackClipPlayback::slot(int sceneIndex) const {
+    const auto it = std::lower_bound(
+        session.begin(), session.end(), sceneIndex,
+        [](const SessionSlotPlayback& slot, int index) { return slot.sceneIndex < index; });
+    if (it == session.end() || it->sceneIndex != sceneIndex)
+        return nullptr;
+    return &*it;
+}
+
 }  // namespace magda::engine

--- a/magda/engine/clip/ClipSnapshot.hpp
+++ b/magda/engine/clip/ClipSnapshot.hpp
@@ -270,10 +270,43 @@ struct MidiClipPlayback {
 };
 
 /** Everything one track plays. */
+/**
+ * @brief One session slot's material, as if it began at beat zero.
+ *
+ * A session clip has no position on the timeline. Its scene index says which
+ * slot it sits in and nothing about when it sounds, because when it sounds is
+ * decided by a launch at runtime rather than by the model (#2301). So it is
+ * compiled at the origin, describing the material and nothing else, and the
+ * launch handle's virtual origin is what maps a block onto it.
+ *
+ * Compiled through the same path the arrangement's clips go through, so a clip
+ * dragged from a slot to the timeline sounds the same in both places.
+ */
+struct SessionSlotPlayback {
+    int sceneIndex = -1;
+
+    /// The slot's material, at most one of each. Empty means the slot holds a
+    /// clip that compiled to nothing playable, which is a diagnostic rather
+    /// than a slot that does nothing.
+    std::vector<AudioClipPlayback> audio;
+    std::vector<MidiClipPlayback> midi;
+
+    /// What one pass through the slot is worth, which is what a launch handle
+    /// re-triggers on. The clip's own loop is a separate thing that happens
+    /// inside this.
+    double lengthBeats = 0.0;
+};
+
 struct TrackClipPlayback {
     TrackId trackId = INVALID_TRACK_ID;
     std::vector<AudioClipPlayback> audio;
     std::vector<MidiClipPlayback> midi;
+
+    /// Sorted by scene index, so two compiles of one model agree.
+    std::vector<SessionSlotPlayback> session;
+
+    /// The slot at @p sceneIndex, or null.
+    const SessionSlotPlayback* slot(int sceneIndex) const;
 };
 
 /**

--- a/magda/engine/clip/ClipSnapshotCompiler.cpp
+++ b/magda/engine/clip/ClipSnapshotCompiler.cpp
@@ -348,7 +348,78 @@ ClipSnapshot compileClipSnapshot(const std::vector<ClipLane>& lanes,
         std::sort(track.audio.begin(), track.audio.end(), byStart);
         std::sort(track.midi.begin(), track.midi.end(), byStart);
 
-        if (!track.audio.empty() || !track.midi.empty())
+        // The slots, each compiled as its own single-clip lane at the origin.
+        //
+        // Recursing rather than repeating: a session clip and an arrangement clip
+        // are the same material and have to sound the same, so the one that is
+        // dragged from a slot onto the timeline cannot go through a second
+        // implementation of fades, warp and events. What a slot changes is where
+        // the material sits, which is nowhere, so the placement is normalised and
+        // everything else is asked of the same compile the arrangement uses.
+        //
+        // Off the audio thread, on the publishing side, so a compile per slot
+        // costs a publish rather than a block.
+        for (const auto& clip : lane.session) {
+            const auto label = clipLabel(lane.trackId, clip.id);
+
+            if (clip.trackId != lane.trackId) {
+                snapshot.diagnostics.push_back(label + "belongs to track " +
+                                               std::to_string(clip.trackId) +
+                                               ", it is not played on this lane");
+                continue;
+            }
+            if (clip.view != ClipView::Session) {
+                snapshot.diagnostics.push_back(
+                    label + "is an arrangement clip in a session lane, it is not played here");
+                continue;
+            }
+            if (clip.sceneIndex < 0) {
+                snapshot.diagnostics.push_back(label + "is a session clip in no scene");
+                continue;
+            }
+            if (!clip.enabled)
+                continue;
+
+            // Nothing writes a session clip's placement: the scene index is its
+            // position and the beat is leftover. Normalised rather than trusted,
+            // so a slot always compiles from the origin whatever is in the field.
+            auto normalised = clip;
+            normalised.view = ClipView::Arrangement;
+            normalised.setPlacementBeats(0.0, clip.placement.lengthBeats);
+
+            ClipLane slotLane;
+            slotLane.trackId = lane.trackId;
+            slotLane.clips.push_back(normalised);
+
+            auto compiled = compileClipSnapshot({slotLane}, sources, tempoMap, grooves);
+
+            for (auto& diagnostic : compiled.diagnostics)
+                snapshot.diagnostics.push_back(std::move(diagnostic));
+
+            if (compiled.tracks.empty())
+                continue;
+
+            SessionSlotPlayback slot;
+            slot.sceneIndex = clip.sceneIndex;
+            slot.lengthBeats = clip.placement.lengthBeats;
+            slot.audio = std::move(compiled.tracks.front().audio);
+            slot.midi = std::move(compiled.tracks.front().midi);
+
+            if (slot.audio.empty() && slot.midi.empty())
+                continue;
+
+            track.session.push_back(std::move(slot));
+        }
+
+        std::sort(track.session.begin(), track.session.end(),
+                  [](const SessionSlotPlayback& a, const SessionSlotPlayback& b) {
+                      return a.sceneIndex < b.sceneIndex;
+                  });
+
+        // A track earns an entry by having something to play, in either view. A
+        // session-only track is a real one: nothing is in its arrangement and
+        // its slots are still waiting to be launched.
+        if (!track.audio.empty() || !track.midi.empty() || !track.session.empty())
             snapshot.tracks.push_back(std::move(track));
     }
 

--- a/magda/engine/clip/ClipSnapshotCompiler.hpp
+++ b/magda/engine/clip/ClipSnapshotCompiler.hpp
@@ -45,7 +45,17 @@ struct ClipSourceInfo {
  */
 struct ClipLane {
     TrackId trackId = INVALID_TRACK_ID;
+
+    /// The arrangement's clips, positioned on the timeline. A session clip here
+    /// is a diagnostic rather than a clip: the two are different questions and
+    /// the caller is the one that knows which it is asking.
     std::vector<ClipInfo> clips;
+
+    /// The track's session slots, positioned by scene rather than by beat.
+    /// Separate because they are not alternatives at the same place: a track
+    /// can carry an arrangement and a session at once, and which one sounds is
+    /// decided at launch rather than at compile (#2301).
+    std::vector<ClipInfo> session;
 };
 
 /**

--- a/magda/engine/clip/ClipSnapshotDump.cpp
+++ b/magda/engine/clip/ClipSnapshotDump.cpp
@@ -160,11 +160,24 @@ std::string dumpClipSnapshot(const ClipSnapshot& snapshot) {
 
     for (const auto& track : snapshot.tracks) {
         out << "track " << track.trackId << " audio=" << track.audio.size()
-            << " midi=" << track.midi.size() << "\n";
+            << " midi=" << track.midi.size() << " session=" << track.session.size() << "\n";
         for (const auto& clip : track.audio)
             dumpAudioClip(out, clip);
         for (const auto& clip : track.midi)
             dumpMidiClip(out, clip);
+
+        // The session, in the same detail as the arrangement. A dump that
+        // printed only the counts would let two materially different session
+        // snapshots compare identical, which is the one thing this file exists
+        // to prevent (#2301).
+        for (const auto& slot : track.session) {
+            out << "  slot scene=" << slot.sceneIndex << " length=" << fixed(slot.lengthBeats, 3)
+                << "b audio=" << slot.audio.size() << " midi=" << slot.midi.size() << "\n";
+            for (const auto& clip : slot.audio)
+                dumpAudioClip(out, clip);
+            for (const auto& clip : slot.midi)
+                dumpMidiClip(out, clip);
+        }
     }
 
     for (const auto& diagnostic : snapshot.diagnostics)

--- a/magda/engine/exec/PlanBindings.hpp
+++ b/magda/engine/exec/PlanBindings.hpp
@@ -32,6 +32,11 @@ struct PlanBindings {
     std::unordered_map<TrackId, EngineAudioSource*> clipAudio;
     std::unordered_map<TrackId, EngineMidiSource*> clipMidi;
 
+    /// The session's sources, one per track: the source consults the track's
+    /// launch handles and renders whichever slot is playing (#2301).
+    std::unordered_map<TrackId, EngineAudioSource*> sessionAudio;
+    std::unordered_map<TrackId, EngineMidiSource*> sessionMidi;
+
     /// Live hardware input feeding a track (AudioInput / MidiInput ops).
     std::unordered_map<TrackId, EngineAudioSource*> audioInputs;
     std::unordered_map<TrackId, EngineMidiSource*> midiInputs;

--- a/magda/engine/exec/PlanExecutor.cpp
+++ b/magda/engine/exec/PlanExecutor.cpp
@@ -484,6 +484,20 @@ std::vector<std::string> PlanExecutor::prepare(const RenderPlan& plan, const Pla
                                        std::to_string(trackId) + ", it renders silence");
                 break;
 
+            case OpKind::SessionAudio:
+                audioSourceForOp_[i] = findAudioSource(bindings.sessionAudio, trackId);
+                if (audioSourceForOp_[i] == nullptr)
+                    messages.push_back(describe(i) + "no session audio source bound for track " +
+                                       std::to_string(trackId) + ", it renders silence");
+                break;
+
+            case OpKind::SessionMidi:
+                midiSourceForOp_[i] = findMidiSource(bindings.sessionMidi, trackId);
+                if (midiSourceForOp_[i] == nullptr)
+                    messages.push_back(describe(i) + "no session MIDI source bound for track " +
+                                       std::to_string(trackId) + ", it renders silence");
+                break;
+
             case OpKind::ClipMidi:
                 midiSourceForOp_[i] = findMidiSource(bindings.clipMidi, trackId);
                 if (midiSourceForOp_[i] == nullptr)
@@ -1178,7 +1192,8 @@ void PlanExecutor::renderOp(OpId id, const OpValue& published, const BlockInfo& 
 
     switch (op.kind) {
         case OpKind::ClipAudio:
-        case OpKind::AudioInput: {
+        case OpKind::AudioInput:
+        case OpKind::SessionAudio: {
             auto out = audioOut(id, 0, numSamples);
             if (value.silent || audioSourceForOp_[i] == nullptr)
                 out.clear();
@@ -1188,7 +1203,8 @@ void PlanExecutor::renderOp(OpId id, const OpValue& published, const BlockInfo& 
         }
 
         case OpKind::ClipMidi:
-        case OpKind::MidiInput: {
+        case OpKind::MidiInput:
+        case OpKind::SessionMidi: {
             auto& out = midiOut(id, 0);
             out.clear();
             if (!value.silent && midiSourceForOp_[i] != nullptr) {

--- a/magda/engine/exec/PlanLayout.cpp
+++ b/magda/engine/exec/PlanLayout.cpp
@@ -105,6 +105,8 @@ std::optional<std::size_t> inPlaceInputOf(const PlanOp& op) {
         case OpKind::ClipMidi:
         case OpKind::AudioInput:
         case OpKind::MidiInput:
+        case OpKind::SessionAudio:
+        case OpKind::SessionMidi:
         case OpKind::MergeMidi:
         case OpKind::MidiNoteGate:
         case OpKind::ModSource:

--- a/magda/engine/exec/PlanValues.cpp
+++ b/magda/engine/exec/PlanValues.cpp
@@ -464,6 +464,8 @@ void Resolver::resolveOp(OpId id, OpValue& value) {
         case OpRole::ClipMidi:
         case OpRole::LiveAudioInput:
         case OpRole::LiveMidiInput:
+        case OpRole::SessionAudio:
+        case OpRole::SessionMidi:
         case OpRole::TrackAudioInput:
         case OpRole::TrackMidiInput:
         case OpRole::DeviceProcess:

--- a/magda/engine/exec/RuntimeStateStore.cpp
+++ b/magda/engine/exec/RuntimeStateStore.cpp
@@ -109,6 +109,27 @@ template <typename Map, typename Ids> std::size_t eraseUnnamed(Map& map, const I
     return removed;
 }
 
+/// Handles whose slot the model no longer names.
+///
+/// Keyed by slot and retained by track, because that is the identity the live
+/// plan carries: the session op is per track, so what the plan says is which
+/// tracks still have a session, and every slot on a track that is gone goes
+/// with it. A slot emptied while its track remains reaches here as that track's
+/// own slots changing rather than as a plan edit.
+std::size_t eraseUnnamedSlots(std::map<SlotKey, std::unique_ptr<LaunchHandle>>& map,
+                              const std::set<TrackId>& tracks) {
+    std::size_t removed = 0;
+    for (auto entry = map.begin(); entry != map.end();) {
+        if (tracks.contains(entry->first.trackId)) {
+            ++entry;
+            continue;
+        }
+        entry = map.erase(entry);
+        ++removed;
+    }
+    return removed;
+}
+
 }  // namespace
 
 PlanBindings RuntimeStateStore::realise(const RenderPlan& plan, const RenderContext& context) {
@@ -119,6 +140,8 @@ PlanBindings RuntimeStateStore::realise(const RenderPlan& plan, const RenderCont
         prepareAll(devices_, context);
         prepareAll(clipAudio_, context);
         prepareAll(clipMidi_, context);
+        prepareAll(sessionAudio_, context);
+        prepareAll(sessionMidi_, context);
         prepareAll(audioInputs_, context);
         prepareAll(midiInputs_, context);
     }
@@ -150,6 +173,20 @@ PlanBindings RuntimeStateStore::realise(const RenderPlan& plan, const RenderCont
                         return factory_.createClipMidiSource(id);
                     }))
                     bindings.clipMidi[trackId] = source;
+                break;
+
+            case OpKind::SessionAudio:
+                if (auto* source = realiseOne(sessionAudio_, trackId, context, [this](TrackId id) {
+                        return factory_.createSessionAudioSource(id);
+                    }))
+                    bindings.sessionAudio[trackId] = source;
+                break;
+
+            case OpKind::SessionMidi:
+                if (auto* source = realiseOne(sessionMidi_, trackId, context, [this](TrackId id) {
+                        return factory_.createSessionMidiSource(id);
+                    }))
+                    bindings.sessionMidi[trackId] = source;
                 break;
 
             case OpKind::AudioInput:
@@ -228,6 +265,8 @@ std::size_t RuntimeStateStore::releaseDeleted(const RenderPlan& livePlan,
             case OpKind::ClipMidi:
             case OpKind::AudioInput:
             case OpKind::MidiInput:
+            case OpKind::SessionAudio:
+            case OpKind::SessionMidi:
                 keep.tracks.insert(op.key.trackId);
                 break;
             case OpKind::Meter:
@@ -246,8 +285,9 @@ std::size_t RuntimeStateStore::releaseDeleted(const RenderPlan& livePlan,
 
     std::size_t removed =
         eraseUnnamed(devices_, keep.devices) + eraseUnnamed(clipAudio_, keep.tracks) +
-        eraseUnnamed(clipMidi_, keep.tracks) + eraseUnnamed(audioInputs_, keep.tracks) +
-        eraseUnnamed(midiInputs_, keep.tracks);
+        eraseUnnamed(clipMidi_, keep.tracks) + eraseUnnamed(sessionAudio_, keep.tracks) +
+        eraseUnnamed(sessionMidi_, keep.tracks) + eraseUnnamed(audioInputs_, keep.tracks) +
+        eraseUnnamed(midiInputs_, keep.tracks) + eraseUnnamedSlots(handles_, keep.tracks);
 
     for (auto entry = meters_.begin(); entry != meters_.end();) {
         if (isNamed(entry->first, keep)) {
@@ -299,14 +339,27 @@ RuntimeStateIds collectRuntimeStateIds(const std::vector<TrackInfo>& tracks,
     return ids;
 }
 
+LaunchHandle& RuntimeStateStore::handle(const SlotKey& key) {
+    auto& slot = handles_[key];
+    if (slot == nullptr)
+        slot = std::make_unique<LaunchHandle>();
+    return *slot;
+}
+
+LaunchHandle* RuntimeStateStore::findHandle(const SlotKey& key) const {
+    const auto it = handles_.find(key);
+    return it == handles_.end() ? nullptr : it->second.get();
+}
+
 ValueTap* RuntimeStateStore::valueTap(const ParamKey& key) const {
     const auto found = valueTaps_.find(key);
     return found == valueTaps_.end() ? nullptr : found->second.get();
 }
 
 std::size_t RuntimeStateStore::size() const {
-    return devices_.size() + clipAudio_.size() + clipMidi_.size() + audioInputs_.size() +
-           midiInputs_.size() + meters_.size() + valueTaps_.size();
+    return devices_.size() + clipAudio_.size() + clipMidi_.size() + sessionAudio_.size() +
+           sessionMidi_.size() + handles_.size() + audioInputs_.size() + midiInputs_.size() +
+           meters_.size() + valueTaps_.size();
 }
 
 }  // namespace magda::engine

--- a/magda/engine/exec/RuntimeStateStore.cpp
+++ b/magda/engine/exec/RuntimeStateStore.cpp
@@ -109,18 +109,35 @@ template <typename Map, typename Ids> std::size_t eraseUnnamed(Map& map, const I
     return removed;
 }
 
-/// Handles whose slot the model no longer names.
+/// Handles the model no longer names.
 ///
-/// Keyed by slot and retained by track, because that is the identity the live
-/// plan carries: the session op is per track, so what the plan says is which
-/// tracks still have a session, and every slot on a track that is gone goes
-/// with it. A slot emptied while its track remains reaches here as that track's
-/// own slots changing rather than as a plan edit.
+/// By slot when the caller knew the slots, and by track when it did not. The
+/// live plan cannot help here the way it helps everything else: the session op
+/// is per track, so it says which tracks still have a session and nothing about
+/// which scenes are filled.
+///
+/// Track granularity alone is not a leak, it is stale state that is observable.
+/// A slot emptied while its track remains would keep its handle for ever, and
+/// the next clip dropped into that scene would come up already playing, at the
+/// old one's loop phase and played range (#2301).
+///
+/// **This is safe to narrow only while nothing binds a handle to the audio
+/// side.** Retiring by slot removes an object the live plan cannot name, so the
+/// moment a session source holds a handle pointer, the bindings that name it
+/// have to be a keep set here as well, exactly as the live plan is for
+/// everything else. That is #2305's, along with the request lane.
 std::size_t eraseUnnamedSlots(std::map<SlotKey, std::unique_ptr<LaunchHandle>>& map,
-                              const std::set<TrackId>& tracks) {
+                              const std::set<TrackId>& tracks,
+                              const std::optional<std::set<SlotKey>>& slots) {
     std::size_t removed = 0;
     for (auto entry = map.begin(); entry != map.end();) {
-        if (tracks.contains(entry->first.trackId)) {
+        // Both, rather than the slots alone. A snapshot publishes on its own
+        // schedule, so the one in hand can still name slots on a track the
+        // model has since deleted; the track is what settles that, and the
+        // slots only narrow it further.
+        const auto named =
+            tracks.contains(entry->first.trackId) && (!slots || slots->contains(entry->first));
+        if (named) {
             ++entry;
             continue;
         }
@@ -287,7 +304,8 @@ std::size_t RuntimeStateStore::releaseDeleted(const RenderPlan& livePlan,
         eraseUnnamed(devices_, keep.devices) + eraseUnnamed(clipAudio_, keep.tracks) +
         eraseUnnamed(clipMidi_, keep.tracks) + eraseUnnamed(sessionAudio_, keep.tracks) +
         eraseUnnamed(sessionMidi_, keep.tracks) + eraseUnnamed(audioInputs_, keep.tracks) +
-        eraseUnnamed(midiInputs_, keep.tracks) + eraseUnnamedSlots(handles_, keep.tracks);
+        eraseUnnamed(midiInputs_, keep.tracks) +
+        eraseUnnamedSlots(handles_, keep.tracks, keep.slots);
 
     for (auto entry = meters_.begin(); entry != meters_.end();) {
         if (isNamed(entry->first, keep)) {
@@ -360,6 +378,22 @@ std::size_t RuntimeStateStore::size() const {
     return devices_.size() + clipAudio_.size() + clipMidi_.size() + sessionAudio_.size() +
            sessionMidi_.size() + handles_.size() + audioInputs_.size() + midiInputs_.size() +
            meters_.size() + valueTaps_.size();
+}
+
+RuntimeStateIds collectRuntimeStateIds(const std::vector<TrackInfo>& tracks,
+                                       const TrackInfo& master, const ClipSnapshot& clips) {
+    auto ids = collectRuntimeStateIds(tracks, master);
+
+    // Empty is a real answer here and absent is not: a project whose every slot
+    // was emptied names no slots, and every handle should go. Set the container
+    // first so it is present even when nothing fills it.
+    ids.slots.emplace();
+
+    for (const auto& track : clips.tracks)
+        for (const auto& slot : track.session)
+            ids.slots->insert(SlotKey{track.trackId, slot.sceneIndex});
+
+    return ids;
 }
 
 }  // namespace magda::engine

--- a/magda/engine/exec/RuntimeStateStore.hpp
+++ b/magda/engine/exec/RuntimeStateStore.hpp
@@ -7,6 +7,7 @@
 #include <vector>
 
 #include "exec/PlanBindings.hpp"
+#include "launch/LaunchHandle.hpp"
 #include "plan/RenderPlan.hpp"
 #include "tap/LevelTap.hpp"
 #include "tap/ValueTap.hpp"
@@ -52,6 +53,12 @@ class RuntimeStateFactory {
         return nullptr;
     }
     virtual std::unique_ptr<EngineMidiSource> createClipMidiSource(TrackId) {
+        return nullptr;
+    }
+    virtual std::unique_ptr<EngineAudioSource> createSessionAudioSource(TrackId) {
+        return nullptr;
+    }
+    virtual std::unique_ptr<EngineMidiSource> createSessionMidiSource(TrackId) {
         return nullptr;
     }
     virtual std::unique_ptr<EngineAudioSource> createAudioInput(TrackId) {
@@ -225,6 +232,15 @@ class RuntimeStateStore {
      */
     ValueTap* valueTap(const ParamKey& key) const;
 
+    /// The handle for one slot, made on first ask. Unlike a device or a tap
+    /// there is no factory to decline: a handle is the engine's own state
+    /// rather than something the host builds, so a slot the model names always
+    /// has one.
+    LaunchHandle& handle(const SlotKey& key);
+
+    /// The handle for one slot, or null if nothing has asked for it yet.
+    LaunchHandle* findHandle(const SlotKey& key) const;
+
     /// Objects currently owned, for tests and diagnostics.
     std::size_t size() const;
 
@@ -245,6 +261,15 @@ class RuntimeStateStore {
     std::unordered_map<DeviceKey, std::unique_ptr<EngineDevice>, DeviceKeyHash> devices_;
     std::unordered_map<TrackId, std::unique_ptr<EngineAudioSource>> clipAudio_;
     std::unordered_map<TrackId, std::unique_ptr<EngineMidiSource>> clipMidi_;
+    std::unordered_map<TrackId, std::unique_ptr<EngineAudioSource>> sessionAudio_;
+    std::unordered_map<TrackId, std::unique_ptr<EngineMidiSource>> sessionMidi_;
+
+    /// One per slot rather than per track, because a slot's state has to
+    /// survive another slot playing in between: launch scene 0, then scene 1,
+    /// then scene 0 again, and the first slot's loop phase and played range are
+    /// still its own. Retired by the same rule as everything else here, which
+    /// is the model no longer naming the slot (#2301).
+    std::map<SlotKey, std::unique_ptr<LaunchHandle>> handles_;
     std::unordered_map<TrackId, std::unique_ptr<EngineAudioSource>> audioInputs_;
     std::unordered_map<TrackId, std::unique_ptr<EngineMidiSource>> midiInputs_;
 

--- a/magda/engine/exec/RuntimeStateStore.hpp
+++ b/magda/engine/exec/RuntimeStateStore.hpp
@@ -2,10 +2,12 @@
 
 #include <map>
 #include <memory>
+#include <optional>
 #include <set>
 #include <unordered_map>
 #include <vector>
 
+#include "clip/ClipSnapshot.hpp"
 #include "exec/PlanBindings.hpp"
 #include "launch/LaunchHandle.hpp"
 #include "plan/RenderPlan.hpp"
@@ -135,6 +137,21 @@ class RuntimeStateFactory {
 struct RuntimeStateIds {
     std::set<DeviceKey> devices;
     std::set<TrackId> tracks;
+
+    /**
+     * @brief Every session slot the model holds, when the caller knows them.
+     *
+     * Absent rather than empty when it does not. Slots are clips, and the walk
+     * that answers what exists is handed tracks, so a caller with no snapshot
+     * to hand cannot name them; absent means "keep by track", which leaks a
+     * handle rather than retiring one something may still be holding.
+     *
+     * Track granularity is not enough on its own. A slot emptied while its
+     * track remains would keep its handle for ever, so the next clip put in
+     * that scene would inherit the old one's play state, loop phase and played
+     * range (#2301).
+     */
+    std::optional<std::set<SlotKey>> slots;
 };
 
 /**
@@ -145,6 +162,16 @@ struct RuntimeStateIds {
  */
 RuntimeStateIds collectRuntimeStateIds(const std::vector<TrackInfo>& tracks,
                                        const TrackInfo& master);
+
+/**
+ * @brief The same, with the session slots @p clips says exist.
+ *
+ * The snapshot rather than the model because that is what enumerates slots, and
+ * because it is what a handle would be made for: a slot the snapshot does not
+ * carry has nothing to launch.
+ */
+RuntimeStateIds collectRuntimeStateIds(const std::vector<TrackInfo>& tracks,
+                                       const TrackInfo& master, const ClipSnapshot& clips);
 
 /**
  * @brief The runtime objects behind a plan's leaf ops, owned across swaps.

--- a/magda/engine/launch/LaunchHandle.hpp
+++ b/magda/engine/launch/LaunchHandle.hpp
@@ -1,6 +1,9 @@
 #pragma once
 
 #include <optional>
+#include <tuple>
+
+#include "core/TypeIds.hpp"
 
 /**
  * @file LaunchHandle.hpp
@@ -23,6 +26,25 @@
  */
 
 namespace magda::engine {
+
+/**
+ * @brief Which slot a launch handle belongs to.
+ *
+ * A track and a scene, because that is what a slot is in the model. The op that
+ * renders a session is per track and this is per slot on purpose: an op is a
+ * place in the graph and wants to be stable, a handle is state and wants to be
+ * per thing that has state.
+ */
+struct SlotKey {
+    TrackId trackId = INVALID_TRACK_ID;
+    int sceneIndex = -1;
+
+    bool operator==(const SlotKey&) const = default;
+
+    bool operator<(const SlotKey& other) const {
+        return std::tie(trackId, sceneIndex) < std::tie(other.trackId, other.sceneIndex);
+    }
+};
 
 /// A stretch of beats. Half open: a block ending at 4.0 and one starting there
 /// do not both contain beat 4.

--- a/magda/engine/plan/RenderPlan.cpp
+++ b/magda/engine/plan/RenderPlan.cpp
@@ -18,6 +18,8 @@ int arityOf(OpKind kind) {
         case OpKind::ClipMidi:
         case OpKind::AudioInput:
         case OpKind::MidiInput:
+        case OpKind::SessionAudio:
+        case OpKind::SessionMidi:
             return 0;
         case OpKind::Device:
             return 3;  // audio, MIDI, sidechain audio
@@ -57,6 +59,10 @@ const char* toString(OpKind kind) {
             return "AudioInput";
         case OpKind::MidiInput:
             return "MidiInput";
+        case OpKind::SessionAudio:
+            return "SessionAudio";
+        case OpKind::SessionMidi:
+            return "SessionMidi";
         case OpKind::Device:
             return "Device";
         case OpKind::MixAudio:
@@ -101,6 +107,10 @@ const char* toString(OpRole role) {
             return "liveAudioInput";
         case OpRole::LiveMidiInput:
             return "liveMidiInput";
+        case OpRole::SessionAudio:
+            return "sessionAudio";
+        case OpRole::SessionMidi:
+            return "sessionMidi";
         case OpRole::TrackAudioInput:
             return "trackAudioInput";
         case OpRole::TrackMidiInput:

--- a/magda/engine/plan/RenderPlan.hpp
+++ b/magda/engine/plan/RenderPlan.hpp
@@ -104,8 +104,16 @@ constexpr int kMaxMultiOutPairs = 64;
  * cheap ops is a later back-end pass over the same flat list.
  */
 enum class OpKind : std::uint8_t {
-    ClipAudio,   ///< audio clip playback for one track (reads the clip snapshot)
-    ClipMidi,    ///< MIDI clip playback for one track
+    ClipAudio,  ///< audio clip playback for one track (reads the clip snapshot)
+    ClipMidi,   ///< MIDI clip playback for one track
+
+    /// The session's audio and MIDI for one track: whichever slot a launch
+    /// handle currently has playing (#2301). One op per track rather than per
+    /// slot, because a track sounds one session clip at a time and an op per
+    /// slot would put a silent node in the graph for every scene on every
+    /// track, and would change the plan's shape whenever a scene is added.
+    SessionAudio,
+    SessionMidi,
     AudioInput,  ///< live hardware audio input
     MidiInput,   ///< live MIDI input
     Device,      ///< a device instance (instrument, effect, MIDI or analysis)
@@ -142,6 +150,8 @@ enum class OpRole : std::uint8_t {
     ClipMidi,         ///< the track's MIDI clip source
     LiveAudioInput,   ///< the track's live audio input
     LiveMidiInput,    ///< the track's live MIDI input
+    SessionAudio,     ///< the track's session audio, whichever slot is playing
+    SessionMidi,      ///< the track's session MIDI
     TrackAudioInput,  ///< sum of everything feeding the track's chain head
     TrackMidiInput,   ///< merge of everything feeding the track's chain head
     DeviceProcess,    ///< the device itself

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -363,6 +363,9 @@ if(MAGDA_BUILD_NATIVE_ENGINE)
     # The launcher's state machine (#2300): quantized launch and stop against
     # monotonic beats, and the split a block straddling one reports.
     list(APPEND TEST_SOURCES engine/test_launch_handle.cpp)
+    # Which slot handles survive a publish (#2301): the plan is per track and a
+    # handle is per slot, so the snapshot is what names them.
+    list(APPEND TEST_SOURCES engine/test_launch_handle_lifetime.cpp)
     list(APPEND TEST_SOURCES audio/test_click_generator.cpp)
     list(APPEND TEST_SOURCES audio/test_prefetch_stream.cpp)
     list(APPEND TEST_SOURCES audio/test_source_readers.cpp)

--- a/tests/engine/test_clip_snapshot.cpp
+++ b/tests/engine/test_clip_snapshot.cpp
@@ -604,3 +604,147 @@ TEST_CASE("The dump is the snapshot's golden surface", "[engine][clip]") {
     INFO(text);
     CHECK(text == kGoldenDump);
 }
+
+namespace {
+
+/// A lane whose session slots are @p slots, with nothing in its arrangement.
+ClipSnapshot compileSession(std::vector<ClipInfo> slots, const TempoMap& tempoMap) {
+    ClipLane lane;
+    lane.trackId = kTrack;
+    lane.session = std::move(slots);
+    return compileClipSnapshot({lane}, makeSources(), tempoMap);
+}
+
+/// An audio clip in a scene, with the leftover placement a session clip really
+/// carries: nothing writes startBeat for one, so it is whatever it was.
+ClipInfo makeSessionClip(magda::ClipId id, int sceneIndex, double startBeat, double lengthBeats) {
+    auto clip = makeAudioClip(id, startBeat, lengthBeats);
+    clip.view = ClipView::Session;
+    clip.sceneIndex = sceneIndex;
+    return clip;
+}
+
+}  // namespace
+
+TEST_CASE("A session slot is compiled at the origin, whatever its placement says",
+          "[engine][clip][session]") {
+    // The leftover beat is the point: the scene index is a session clip's
+    // position and nothing writes the placement, so a slot compiled from what
+    // the field happens to hold would start wherever the clip last was in the
+    // arrangement (#2301).
+    const auto snapshot = compileSession({makeSessionClip(1, 2, 18.5, 8.0)}, makeTempoMap());
+
+    REQUIRE(snapshot.tracks.size() == 1);
+    const auto& track = snapshot.tracks.front();
+
+    CHECK(track.audio.empty());
+    REQUIRE(track.session.size() == 1);
+
+    const auto* slot = track.slot(2);
+    REQUIRE(slot != nullptr);
+    CHECK(slot->sceneIndex == 2);
+    CHECK(slot->lengthBeats == Catch::Approx(8.0));
+
+    REQUIRE(slot->audio.size() == 1);
+    CHECK(slot->audio.front().span.startBeat == Catch::Approx(0.0));
+    CHECK(slot->audio.front().span.endBeat == Catch::Approx(8.0));
+}
+
+TEST_CASE("A session slot compiles through the arrangement's own path", "[engine][clip][session]") {
+    // The reason slots are compiled by recursing rather than by a second
+    // implementation: a clip dragged from a slot onto the timeline has to sound
+    // the same, so there is one answer about fades, events and stretch.
+    const auto tempoMap = makeTempoMap();
+
+    const auto asSlot = compileSession({makeSessionClip(1, 0, 18.5, 8.0)}, tempoMap);
+    const auto asClip = compile({makeAudioClip(1, 0.0, 8.0)}, tempoMap);
+
+    REQUIRE(asSlot.tracks.size() == 1);
+    REQUIRE(asClip.tracks.size() == 1);
+
+    const auto* slot = asSlot.tracks.front().slot(0);
+    REQUIRE(slot != nullptr);
+    REQUIRE(slot->audio.size() == 1);
+    REQUIRE(asClip.tracks.front().audio.size() == 1);
+
+    const auto& fromSlot = slot->audio.front();
+    const auto& fromLane = asClip.tracks.front().audio.front();
+
+    CHECK(fromSlot.span.startBeat == Catch::Approx(fromLane.span.startBeat));
+    CHECK(fromSlot.span.endBeat == Catch::Approx(fromLane.span.endBeat));
+    CHECK(fromSlot.events.size() == fromLane.events.size());
+    REQUIRE(!fromSlot.events.empty());
+    CHECK(fromSlot.events.front().span.startSeconds ==
+          Catch::Approx(fromLane.events.front().span.startSeconds));
+}
+
+TEST_CASE("Slots are found by scene and kept in scene order", "[engine][clip][session]") {
+    const auto snapshot =
+        compileSession({makeSessionClip(3, 5, 0.0, 4.0), makeSessionClip(1, 0, 0.0, 4.0),
+                        makeSessionClip(2, 2, 0.0, 4.0)},
+                       makeTempoMap());
+
+    REQUIRE(snapshot.tracks.size() == 1);
+    const auto& track = snapshot.tracks.front();
+    REQUIRE(track.session.size() == 3);
+
+    CHECK(track.session[0].sceneIndex == 0);
+    CHECK(track.session[1].sceneIndex == 2);
+    CHECK(track.session[2].sceneIndex == 5);
+
+    CHECK(track.slot(2) != nullptr);
+    CHECK(track.slot(5) != nullptr);
+
+    // A scene nobody filled is not a slot, rather than an empty one a launch
+    // would have to check before binding.
+    CHECK(track.slot(1) == nullptr);
+    CHECK(track.slot(9) == nullptr);
+}
+
+TEST_CASE("What a session lane will not play says so", "[engine][clip][session]") {
+    SECTION("an arrangement clip in a session lane is reported") {
+        auto clip = makeAudioClip(1, 0.0, 8.0);  // left as Arrangement
+
+        const auto snapshot = compileSession({clip}, makeTempoMap());
+        CHECK(snapshot.tracks.empty());
+        REQUIRE(snapshot.diagnostics.size() == 1);
+        CHECK(snapshot.diagnostics.front().find("arrangement clip") != std::string::npos);
+    }
+
+    SECTION("a session clip in no scene is reported") {
+        const auto snapshot = compileSession({makeSessionClip(1, -1, 0.0, 8.0)}, makeTempoMap());
+        CHECK(snapshot.tracks.empty());
+        REQUIRE(snapshot.diagnostics.size() == 1);
+        CHECK(snapshot.diagnostics.front().find("no scene") != std::string::npos);
+    }
+
+    SECTION("a disabled slot is skipped without comment") {
+        auto clip = makeSessionClip(1, 0, 0.0, 8.0);
+        clip.enabled = false;
+
+        const auto snapshot = compileSession({clip}, makeTempoMap());
+        CHECK(snapshot.tracks.empty());
+        CHECK(snapshot.diagnostics.empty());
+    }
+}
+
+TEST_CASE("A track carrying both views keeps them apart", "[engine][clip][session]") {
+    ClipLane lane;
+    lane.trackId = kTrack;
+    lane.clips.push_back(makeAudioClip(1, 0.0, 8.0));
+    lane.session.push_back(makeSessionClip(2, 0, 0.0, 4.0));
+
+    const auto snapshot = compileClipSnapshot({lane}, makeSources(), makeTempoMap());
+
+    REQUIRE(snapshot.tracks.size() == 1);
+    const auto& track = snapshot.tracks.front();
+
+    // Both, because they are not alternatives: which one sounds is decided at
+    // launch rather than at compile.
+    REQUIRE(track.audio.size() == 1);
+    CHECK(track.audio.front().clipId == 1);
+    REQUIRE(track.session.size() == 1);
+    REQUIRE(track.slot(0)->audio.size() == 1);
+    CHECK(track.slot(0)->audio.front().clipId == 2);
+    CHECK(snapshot.diagnostics.empty());
+}

--- a/tests/engine/test_clip_snapshot.cpp
+++ b/tests/engine/test_clip_snapshot.cpp
@@ -80,7 +80,7 @@ ClipSnapshot compile(std::vector<ClipInfo> clips, const TempoMap& tempoMap) {
 const std::string kGoldenDump =
     "magda-clip-snapshot v1\n"
     "tempo=a95350905fc122eb tracks=1\n"
-    "track 1 audio=2 midi=1\n"
+    "track 1 audio=2 midi=1 session=0\n"
     "  audio clip=1 span=0.000..8.000b 0.000..4.000s fade=0.000/1.000 curve=lin/lin "
     "behaviour=0/0 gain=0.0 pan=0.00 launch=256\n"
     "    event 1 src=7 file=loop.wav rate=48000 span=0.000..8.000b 0.000..4.000s anchor=0 "
@@ -747,4 +747,42 @@ TEST_CASE("A track carrying both views keeps them apart", "[engine][clip][sessio
     REQUIRE(track.slot(0)->audio.size() == 1);
     CHECK(track.slot(0)->audio.front().clipId == 2);
     CHECK(snapshot.diagnostics.empty());
+}
+
+TEST_CASE("A session slot is in the dump, in the arrangement's own detail",
+          "[engine][clip][session]") {
+    // The dump is the snapshot's canonical surface, so a session slot has to be
+    // in it at the same detail an arrangement clip is. Printing only the count
+    // would let two materially different session snapshots compare identical,
+    // which is the one thing this file exists to prevent.
+    const auto snapshot = compileSession({makeSessionClip(1, 3, 18.5, 8.0)}, makeTempoMap());
+    const auto text = dumpClipSnapshot(snapshot);
+
+    INFO(text);
+
+    CHECK(text.find("track 1 audio=0 midi=0 session=1") != std::string::npos);
+    CHECK(text.find("slot scene=3 length=8.000b audio=1 midi=0") != std::string::npos);
+
+    // The slot's own material, not just its header: the clip, its span at the
+    // origin, and the event underneath it with the source it reads.
+    CHECK(text.find("audio clip=1 span=0.000..8.000b") != std::string::npos);
+    CHECK(text.find("event 1 src=7 file=loop.wav") != std::string::npos);
+
+    CHECK(text.find("/tmp/") == std::string::npos);
+}
+
+TEST_CASE("Two session snapshots that differ do not dump alike", "[engine][clip][session]") {
+    const auto tempoMap = makeTempoMap();
+
+    const auto inScene0 =
+        dumpClipSnapshot(compileSession({makeSessionClip(1, 0, 0.0, 8.0)}, tempoMap));
+    const auto inScene4 =
+        dumpClipSnapshot(compileSession({makeSessionClip(1, 4, 0.0, 8.0)}, tempoMap));
+    const auto shorter =
+        dumpClipSnapshot(compileSession({makeSessionClip(1, 0, 0.0, 4.0)}, tempoMap));
+
+    // The same clip in a different slot, and the same slot at a different
+    // length. Both were invisible before the dump carried the session.
+    CHECK(inScene0 != inScene4);
+    CHECK(inScene0 != shorter);
 }

--- a/tests/engine/test_launch_handle_lifetime.cpp
+++ b/tests/engine/test_launch_handle_lifetime.cpp
@@ -1,0 +1,118 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "clip/ClipSnapshot.hpp"
+#include "core/TrackInfo.hpp"
+#include "exec/RuntimeStateStore.hpp"
+
+/**
+ * @file test_launch_handle_lifetime.cpp
+ * @brief Which slot handles survive a publish, and which do not (#2301).
+ *
+ * A handle is per slot and the plan is per track, so the plan cannot say which
+ * scenes are filled. What can is the snapshot, and these are the cases that say
+ * a slot emptied and refilled comes back new rather than carrying the run it
+ * had before.
+ */
+
+using namespace magda;
+using namespace magda::engine;
+
+namespace {
+
+constexpr TrackId kTrack = 1;
+
+/// A factory that builds nothing: these cases are about lifetime rather than
+/// about what a handle is attached to.
+class NoFactory final : public RuntimeStateFactory {};
+
+TrackInfo trackWithId(TrackId id) {
+    TrackInfo track;
+    track.id = id;
+    return track;
+}
+
+/// A snapshot naming @p scenes on kTrack, with no material in them: what is
+/// asserted here is which slots exist, not what they play.
+ClipSnapshot snapshotWithScenes(std::vector<int> scenes) {
+    ClipSnapshot snapshot;
+    TrackClipPlayback track;
+    track.trackId = kTrack;
+    for (const auto scene : scenes)
+        track.session.push_back(SessionSlotPlayback{scene, {}, {}, 4.0});
+    snapshot.tracks.push_back(std::move(track));
+    return snapshot;
+}
+
+}  // namespace
+
+TEST_CASE("A slot's handle does not outlive the slot", "[engine][session][launch]") {
+    NoFactory factory;
+    RuntimeStateStore store(factory);
+
+    auto& first = store.handle(SlotKey{kTrack, 0});
+    store.handle(SlotKey{kTrack, 2});
+
+    first.play({});
+    first.advance(SyncRange{BeatRange{0.0, 2.0}, BeatRange{0.0, 2.0}});
+    REQUIRE(first.playState() == LaunchHandle::PlayState::playing);
+
+    const auto tracks = std::vector<TrackInfo>{trackWithId(kTrack)};
+    const auto master = trackWithId(MASTER_TRACK_ID);
+    const RenderPlan empty;
+
+    SECTION("a slot the snapshot still names keeps it") {
+        const auto ids = collectRuntimeStateIds(tracks, master, snapshotWithScenes({0, 2}));
+        store.releaseDeleted(empty, ids, nullptr);
+
+        auto* kept = store.findHandle(SlotKey{kTrack, 0});
+        REQUIRE(kept != nullptr);
+        CHECK(kept->playState() == LaunchHandle::PlayState::playing);
+    }
+
+    SECTION("emptying one slot does not disturb the others") {
+        const auto ids = collectRuntimeStateIds(tracks, master, snapshotWithScenes({0}));
+        store.releaseDeleted(empty, ids, nullptr);
+
+        CHECK(store.findHandle(SlotKey{kTrack, 0}) != nullptr);
+        CHECK(store.findHandle(SlotKey{kTrack, 2}) == nullptr);
+    }
+
+    SECTION("a slot emptied and refilled comes back new") {
+        // The bug this rule exists for. The track survives, so a keep set that
+        // only knew tracks would hand the next clip in scene 0 a handle that is
+        // already playing, three bars into a run it never started.
+        const auto emptied = collectRuntimeStateIds(tracks, master, snapshotWithScenes({}));
+        store.releaseDeleted(empty, emptied, nullptr);
+
+        CHECK(store.findHandle(SlotKey{kTrack, 0}) == nullptr);
+
+        auto& refilled = store.handle(SlotKey{kTrack, 0});
+        CHECK(refilled.playState() == LaunchHandle::PlayState::stopped);
+        CHECK_FALSE(refilled.playedRange().has_value());
+        CHECK_FALSE(refilled.lastPlayedRange().has_value());
+    }
+
+    SECTION("a caller that cannot name slots keeps them by track") {
+        // Absent is not empty: a walk with no snapshot to hand does not get to
+        // retire a handle it knows nothing about.
+        const auto unknown = collectRuntimeStateIds(tracks, master);
+        REQUIRE_FALSE(unknown.slots.has_value());
+
+        store.releaseDeleted(empty, unknown, nullptr);
+
+        CHECK(store.findHandle(SlotKey{kTrack, 0}) != nullptr);
+        CHECK(store.findHandle(SlotKey{kTrack, 2}) != nullptr);
+    }
+
+    SECTION("a slot whose track is gone goes with it, stale snapshot or not") {
+        // The snapshot still names both slots and the model no longer has the
+        // track at all. Snapshots publish on their own schedule, so this is an
+        // ordinary state rather than a corrupt one, and the track is what
+        // settles it: the slots only ever narrow what the track already keeps.
+        const auto gone = collectRuntimeStateIds({}, master, snapshotWithScenes({0, 2}));
+        store.releaseDeleted(empty, gone, nullptr);
+
+        CHECK(store.findHandle(SlotKey{kTrack, 0}) == nullptr);
+        CHECK(store.findHandle(SlotKey{kTrack, 2}) == nullptr);
+    }
+}


### PR DESCRIPTION
Part of #2301, and the half of it that stands on its own. The plan emission and the source that binds it are the other half, and the last section says why they are not here.

Session clips did not reach the engine at all before this. They were filtered out where lanes are built and the snapshot compiler diagnosed one that slipped through, so what is added here is a domain the engine did not have rather than an op.

## A slot has no position, so it is compiled at the origin

Nothing writes `placement.startBeat` for a session clip. The scene index is where it lives, and the beat field holds whatever it last was, so a slot compiled from what the model happens to carry would start wherever the clip used to be in the arrangement. The test uses a leftover 18.5 for exactly that reason.

Each slot is normalised to the origin and compiled by **recursing with a single-clip lane** rather than by a second implementation. That is the point rather than a shortcut: a clip dragged out of a slot onto the timeline has to sound the same, and there is now one answer about fades, events, warp and stretch instead of two that can drift apart. `plugin.wetdry` and the rest of #2246 exist because two hosts disagreeing about one plugin is a real bug; two compilers disagreeing about one clip would be the same bug a layer up.

It costs one compile per slot on the publishing thread and nothing on the audio thread.

`ClipLane` carries the two views in separate lists, so the existing guard keeps meaning what it said. A session clip in an arrangement lane is still a diagnostic, and the reverse now is too.

## Handles per slot, not per track

`RuntimeStateStore` owns them, keyed by `SlotKey`, retired by the rule it already applies to devices, clip sources, meters and value taps.

That rule is also the answer to #1894's requirement that a structural edit during playback must not restart a playing clip. The store already exists so that "the same edit that recompiles the plan leaves the objects it names untouched", so a handle needed no new lifetime mechanism. This is most of what #2305 asked for, and that issue is narrowed to the request lane accordingly.

Per slot rather than per track because a slot's state has to survive another slot playing in between. Launch scene 0, then scene 1, then scene 0 again: the first slot's loop phase, played range and last-played range are still its own. One handle per track would have slot 1 overwrite them, and follow actions (#2304) need exactly that survival to decide when to advance.

The op stays per track for the opposite reason. An op is a place in the graph and wants to be stable so the differ has nothing to do; per-slot ops would put a silent node in the graph for every scene on every track, and adding a scene would change the plan's shape everywhere instead of costing nothing.

## The op is defined and deliberately not emitted

`SessionAudio` and `SessionMidi` exist as kinds and roles, wired through `PlanBindings`, the executor, `PlanValues` and `PlanLayout`. The compiler does not emit them.

Emitting them is one line and it was written, run, and taken back out: it changed **54 test cases**, because every track gains ops and so every plan and every golden moves. Paying that for ops nothing can bind is churn with no behaviour behind it. They land in the slice that binds them, so the plan moves once.

That slice also has to answer how a slot's clips get streams, since `ClipAudioSource` matches against a table keyed by `(trackId, clipId, eventId)`. The answer is a section selector on `ClipAudioSource` rather than a parallel session source, for the same reason the snapshot recurses: stretch, warp, fades and voice management should not be written twice either.

## A bug this introduced, and the tests that caught it

The session loop went in between `if (!track.audio.empty() || !track.midi.empty())` and the push it guarded, which made the push unconditional and gave every empty lane a track entry. Three existing cases failed on it.

Worth recording because the fix is not a revert: the guard now covers the push **and** admits a session-only track, which is a real one. Nothing in its arrangement, and its slots waiting to be launched.

## Tests

Five cases, all offline:

- a slot compiles at the origin despite a leftover placement of 18.5
- a slot and the same clip in an arrangement lane produce the same spans, the same event count and the same event seconds
- slots are found by scene and held in scene order, and a scene nobody filled is not a slot rather than an empty one
- both diagnostics, plus a disabled slot skipped without comment
- a track carrying an arrangement clip and a session slot keeps them apart, with no diagnostics

Full Catch2 suite green locally: 3312 passed, 13 skipped for plugins absent from this machine, 0 failures.
