### PR TITLE
Make the model the sole authority for internal-device parameters (#2317)

### DIFF
--- a/magda/daw/audio/CMakeLists.txt
+++ b/magda/daw/audio/CMakeLists.txt
@@ -276,6 +276,8 @@ set(_magda_device_sdk_sources
     "${CMAKE_CURRENT_SOURCE_DIR}/plugins/DeviceServices.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/plugins/DeviceSessionKey.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/plugins/IFaustEditorModel.hpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/plugins/DeviceStateHydration.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/plugins/DeviceStateHydration.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/plugins/InternalPluginRegistry.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/plugins/InternalPluginRegistry.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/plugins/MagdaDevice.hpp"

--- a/magda/daw/audio/plugin_manager/PluginManager.cpp
+++ b/magda/daw/audio/plugin_manager/PluginManager.cpp
@@ -455,7 +455,7 @@ void PluginManager::captureAllPluginStates() {
             // Model-first: save never copies an internal device's parameter
             // values back off the engine (#2317).
             if (sd.processor != nullptr)
-                sd.processor->populateParametersModelFirst(*devInfo);
+                sd.processor->populateParameters(*devInfo, DeviceProcessor::ValueSource::Model);
         }
     }
 
@@ -494,7 +494,7 @@ void PluginManager::capturePluginState(const ChainNodePath& devicePath) {
         captureDrumGridPads(devicePath, *drumGrid);
     captureVst3Info(*devInfo, capturedExt);
     if (it->second.processor)
-        it->second.processor->populateParametersModelFirst(*devInfo);
+        it->second.processor->populateParameters(*devInfo, DeviceProcessor::ValueSource::Model);
 }
 
 void PluginManager::removeDrumGridPadDevicesLocked(const ChainNodePath& drumGridPath) {

--- a/magda/daw/audio/plugin_manager/PluginManager.cpp
+++ b/magda/daw/audio/plugin_manager/PluginManager.cpp
@@ -452,8 +452,10 @@ void PluginManager::captureAllPluginStates() {
             if (auto* drumGrid = dynamic_cast<daw::audio::DrumGridPlugin*>(sd.plugin.get()))
                 captureDrumGridPads(devicePath, *drumGrid);
             captureVst3Info(*devInfo, capturedExt);
+            // Model-first: save never copies an internal device's parameter
+            // values back off the engine (#2317).
             if (sd.processor != nullptr)
-                sd.processor->populateParameters(*devInfo);
+                sd.processor->populateParametersModelFirst(*devInfo);
         }
     }
 
@@ -492,7 +494,7 @@ void PluginManager::capturePluginState(const ChainNodePath& devicePath) {
         captureDrumGridPads(devicePath, *drumGrid);
     captureVst3Info(*devInfo, capturedExt);
     if (it->second.processor)
-        it->second.processor->populateParameters(*devInfo);
+        it->second.processor->populateParametersModelFirst(*devInfo);
 }
 
 void PluginManager::removeDrumGridPadDevicesLocked(const ChainNodePath& drumGridPath) {
@@ -583,10 +585,8 @@ void PluginManager::restorePluginState(const ChainNodePath& devicePath, te::Plug
     } else if (plugin != nullptr) {
         namespace ta = daw::audio::tracktion_adapter;
         auto savedState = ta::devicePluginTreeFromState(devInfo->pluginState);
-        if (savedState.isValid()) {
+        if (savedState.isValid())
             plugin->restorePluginStateFromValueTree(savedState);
-            ta::applyDeviceStateParameters(*plugin, devInfo->pluginState);
-        }
     }
 }
 

--- a/magda/daw/audio/plugin_manager/PluginManagerSync.cpp
+++ b/magda/daw/audio/plugin_manager/PluginManagerSync.cpp
@@ -1319,7 +1319,7 @@ void PluginManager::pollAsyncPluginLoad(const ChainNodePath& devicePath, te::Plu
             // Populate parameters on the DeviceInfo
             if (processor) {
                 if (auto* devInfo = getDeviceInfoForPath(devicePath)) {
-                    processor->populateParameters(*devInfo);
+                    processor->populateParameters(*devInfo, DeviceProcessor::ValueSource::Engine);
 
                     updateDeviceCapabilityFlags(*devInfo, *plugin);
                     AutoAliasGenerator::regenerateForDevice(devicePath);
@@ -2227,7 +2227,7 @@ void PluginManager::registerRackPluginProcessor(const ChainNodePath& devicePath,
         // per-param displayText, etc.). Model-first: an internal device's
         // restored values stay the model's, never read back off the engine.
         if (canonical != nullptr)
-            processor->populateParametersModelFirst(*canonical);
+            processor->populateParameters(*canonical, DeviceProcessor::ValueSource::Model);
         AutoAliasGenerator::regenerateForDevice(devicePath);
 
         juce::ScopedLock lock(pluginLock_);
@@ -2253,7 +2253,7 @@ void PluginManager::refreshDeviceParameters(const ChainNodePath& devicePath) {
 
     DeviceId sidechainToClear = INVALID_DEVICE_ID;
     if (auto* devInfo = TrackManager::getInstance().getDeviceInChainByPath(devicePath)) {
-        processor->populateParametersModelFirst(*devInfo);
+        processor->populateParameters(*devInfo, DeviceProcessor::ValueSource::Model);
         sidechainToClear = clearStaleFaustAudioSidechain(*devInfo, plugin.get());
     }
     if (sidechainToClear != INVALID_DEVICE_ID)
@@ -2390,7 +2390,7 @@ te::Plugin::Ptr PluginManager::loadDeviceAsPlugin(const ChainNodePath& devicePat
             // DeviceInfo (see comment in registerRackPluginProcessor).
             DeviceId sidechainToClear = INVALID_DEVICE_ID;
             if (auto* devInfo = TrackManager::getInstance().getDeviceInChainByPath(devicePath)) {
-                processor->populateParametersModelFirst(*devInfo);
+                processor->populateParameters(*devInfo, DeviceProcessor::ValueSource::Model);
                 sidechainToClear = clearStaleFaustAudioSidechain(*devInfo, plugin.get());
             }
 
@@ -2818,7 +2818,8 @@ void PluginManager::captureDrumGridPads(const ChainNodePath& drumGridPath,
                         TrackManager::padChainPath(drumGridPath, chain->index).withDevice(deviceId);
                     if (auto padIt = findSyncedDevice(padPath);
                         padIt != syncedDevices_.end() && padIt->second.processor != nullptr)
-                        padIt->second.processor->populateParametersModelFirst(padDevice);
+                        padIt->second.processor->populateParameters(
+                            padDevice, DeviceProcessor::ValueSource::Model);
                 }
                 break;
             }

--- a/magda/daw/audio/plugin_manager/PluginManagerSync.cpp
+++ b/magda/daw/audio/plugin_manager/PluginManagerSync.cpp
@@ -285,13 +285,10 @@ bool savedPluginStateMatchesRequestedType(const juce::ValueTree& savedState,
 // leaving just the baseline.
 void restoreDeviceStateWithChunkOverlay(DeviceProcessor& processor, const te::Plugin::Ptr& plugin,
                                         const DeviceInfo& device) {
-    // Internal devices: seat the v2 document's frozen parameter values first, so
-    // a device state that arrived without a matching DeviceInfo::parameters array
-    // (a preset, an imported chain) still restores. syncFromDeviceInfo then has
-    // the last word, keeping the model the authority for anything it does carry.
-    if (plugin != nullptr && device.format == PluginFormat::Internal)
-        daw::audio::tracktion_adapter::applyDeviceStateParameters(*plugin, device.pluginState);
-
+    // Internal devices restore their parameters from DeviceInfo::parameters
+    // alone (#2317): a document that arrived without a matching array (an old
+    // preset, an imported chain) had it hydrated at load by the model-side
+    // migration, so there is no second record to seat first.
     processor.syncFromDeviceInfo(device);
     // DAWproject-imported VST3s carry their state as a .vstpreset (vst3Preset)
     // rather than MAGDA's TE chunk; apply it as the authoritative overlay too.
@@ -2143,10 +2140,8 @@ te::Plugin::Ptr PluginManager::createPluginOnly(TrackId trackId, const DeviceInf
         // with its sample and one inside a rack came back empty.
         if (plugin != nullptr && ps.isNotEmpty()) {
             namespace ta = daw::audio::tracktion_adapter;
-            if (auto savedState = ta::devicePluginTreeFromState(ps); savedState.isValid()) {
+            if (auto savedState = ta::devicePluginTreeFromState(ps); savedState.isValid())
                 plugin->restorePluginStateFromValueTree(savedState);
-                ta::applyDeviceStateParameters(*plugin, ps);
-            }
         }
     } else {
         // External plugin. Which installed plugin the saved device meant is one
@@ -2229,9 +2224,10 @@ void PluginManager::registerRackPluginProcessor(const ChainNodePath& devicePath,
         // Populate processor-owned fields directly into the canonical
         // DeviceInfo. Snapshotting into a temp and copying only `.parameters`
         // back loses any other processor-populated field (wrapperParameters,
-        // per-param displayText, etc.).
+        // per-param displayText, etc.). Model-first: an internal device's
+        // restored values stay the model's, never read back off the engine.
         if (canonical != nullptr)
-            processor->populateParameters(*canonical);
+            processor->populateParametersModelFirst(*canonical);
         AutoAliasGenerator::regenerateForDevice(devicePath);
 
         juce::ScopedLock lock(pluginLock_);
@@ -2257,7 +2253,7 @@ void PluginManager::refreshDeviceParameters(const ChainNodePath& devicePath) {
 
     DeviceId sidechainToClear = INVALID_DEVICE_ID;
     if (auto* devInfo = TrackManager::getInstance().getDeviceInChainByPath(devicePath)) {
-        processor->populateParameters(*devInfo);
+        processor->populateParametersModelFirst(*devInfo);
         sidechainToClear = clearStaleFaustAudioSidechain(*devInfo, plugin.get());
     }
     if (sidechainToClear != INVALID_DEVICE_ID)
@@ -2394,7 +2390,7 @@ te::Plugin::Ptr PluginManager::loadDeviceAsPlugin(const ChainNodePath& devicePat
             // DeviceInfo (see comment in registerRackPluginProcessor).
             DeviceId sidechainToClear = INVALID_DEVICE_ID;
             if (auto* devInfo = TrackManager::getInstance().getDeviceInChainByPath(devicePath)) {
-                processor->populateParameters(*devInfo);
+                processor->populateParametersModelFirst(*devInfo);
                 sidechainToClear = clearStaleFaustAudioSidechain(*devInfo, plugin.get());
             }
 
@@ -2627,11 +2623,8 @@ te::Plugin::Ptr PluginManager::createInternalPlugin(const juce::String& xmlTypeN
         auto savedState =
             daw::audio::tracktion_adapter::devicePluginTreeFromState(savedPluginState);
         if (savedState.isValid() && savedPluginStateMatchesRequestedType(savedState, xmlTypeName)) {
-            if (auto plugin = edit_.getPluginCache().createNewPlugin(savedState)) {
-                daw::audio::tracktion_adapter::applyDeviceStateParameters(*plugin,
-                                                                          savedPluginState);
+            if (auto plugin = edit_.getPluginCache().createNewPlugin(savedState))
                 return plugin;
-            }
         }
     }
 
@@ -2815,17 +2808,17 @@ void PluginManager::captureDrumGridPads(const ChainNodePath& drumGridPath,
                             *plugin, padDevice.pluginState);
                 }
 
-                // And its parameters, as every other captured device gets. The
-                // model's values are seated back onto the plugin when it is
-                // rebuilt, so leaving them at what creation reported would put
-                // the defaults over what the patch just saved.
+                // And its parameter METADATA, as every other captured device
+                // gets - model-first, so an internal pad's values are never
+                // read back off the engine at save (#2317). An external pad
+                // still mirrors its chunk.
                 {
                     juce::ScopedLock lock(pluginLock_);
                     const auto padPath =
                         TrackManager::padChainPath(drumGridPath, chain->index).withDevice(deviceId);
                     if (auto padIt = findSyncedDevice(padPath);
                         padIt != syncedDevices_.end() && padIt->second.processor != nullptr)
-                        padIt->second.processor->populateParameters(padDevice);
+                        padIt->second.processor->populateParametersModelFirst(padDevice);
                 }
                 break;
             }

--- a/magda/daw/audio/plugins/ArpeggiatorPlugin.cpp
+++ b/magda/daw/audio/plugins/ArpeggiatorPlugin.cpp
@@ -8,14 +8,10 @@ namespace magda::daw::audio {
 
 const char* ArpeggiatorPlugin::xmlTypeName = "arpeggiator";
 
-// ValueTree property IDs for the non-parameter settings. The spellings are the
-// retired host-native plugin's, so saved projects keep them.
-namespace ArpIDs {
-static const juce::Identifier rampCycles("arpRampCycles");
-static const juce::Identifier quantize("arpQuantize");
-static const juce::Identifier quantizeSub("arpQuantizeSub");
-static const juce::Identifier hardAngle("arpHardAngle");
-}  // namespace ArpIDs
+const juce::Identifier ArpeggiatorPlugin::SettingIDs::rampCycles("arpRampCycles");
+const juce::Identifier ArpeggiatorPlugin::SettingIDs::quantize("arpQuantize");
+const juce::Identifier ArpeggiatorPlugin::SettingIDs::quantizeSub("arpQuantizeSub");
+const juce::Identifier ArpeggiatorPlugin::SettingIDs::hardAngle("arpHardAngle");
 
 namespace {
 
@@ -179,20 +175,21 @@ void ArpeggiatorPlugin::reset() {
 }
 
 void ArpeggiatorPlugin::flushState(juce::ValueTree& state) {
-    state.setProperty(ArpIDs::rampCycles, rampCycles.load(std::memory_order_relaxed), nullptr);
-    state.setProperty(ArpIDs::quantize, quantize.load(std::memory_order_relaxed), nullptr);
-    state.setProperty(ArpIDs::quantizeSub, quantizeSub.load(std::memory_order_relaxed), nullptr);
-    state.setProperty(ArpIDs::hardAngle, hardAngle.load(std::memory_order_relaxed), nullptr);
+    state.setProperty(SettingIDs::rampCycles, rampCycles.load(std::memory_order_relaxed), nullptr);
+    state.setProperty(SettingIDs::quantize, quantize.load(std::memory_order_relaxed), nullptr);
+    state.setProperty(SettingIDs::quantizeSub, quantizeSub.load(std::memory_order_relaxed),
+                      nullptr);
+    state.setProperty(SettingIDs::hardAngle, hardAngle.load(std::memory_order_relaxed), nullptr);
 }
 
 void ArpeggiatorPlugin::restoreState(const juce::ValueTree& state) {
-    if (const auto* value = state.getPropertyPointer(ArpIDs::rampCycles))
+    if (const auto* value = state.getPropertyPointer(SettingIDs::rampCycles))
         rampCycles.store(static_cast<int>(*value), std::memory_order_relaxed);
-    if (const auto* value = state.getPropertyPointer(ArpIDs::quantize))
+    if (const auto* value = state.getPropertyPointer(SettingIDs::quantize))
         quantize.store(static_cast<float>(*value), std::memory_order_relaxed);
-    if (const auto* value = state.getPropertyPointer(ArpIDs::quantizeSub))
+    if (const auto* value = state.getPropertyPointer(SettingIDs::quantizeSub))
         quantizeSub.store(static_cast<int>(*value), std::memory_order_relaxed);
-    if (const auto* value = state.getPropertyPointer(ArpIDs::hardAngle))
+    if (const auto* value = state.getPropertyPointer(SettingIDs::hardAngle))
         hardAngle.store(static_cast<bool>(*value), std::memory_order_relaxed);
 }
 

--- a/magda/daw/audio/plugins/ArpeggiatorPlugin.hpp
+++ b/magda/daw/audio/plugins/ArpeggiatorPlugin.hpp
@@ -85,8 +85,20 @@ class ArpeggiatorPlugin : public MidiMagdaDevice {
     void flushState(juce::ValueTree& state) override;
     void restoreState(const juce::ValueTree& state) override;
 
-    // --- Non-parameter settings (persisted device state, written by the UI) ---
-    // Atomics: the faceplate writes on the message thread while process() reads.
+    // ValueTree property ids for the non-parameter settings below. The
+    // spellings are the retired host-native plugin's, so saved projects keep
+    // them. Public because the faceplate's settings edits travel as model
+    // document patches in this vocabulary (#2317), not as writes to the
+    // atomics.
+    struct SettingIDs {
+        static const juce::Identifier rampCycles;
+        static const juce::Identifier quantize;
+        static const juce::Identifier quantizeSub;
+        static const juce::Identifier hardAngle;
+    };
+
+    // --- Non-parameter settings (persisted device state) ---
+    // Atomics: restoreState() writes on the message thread while process() reads.
     std::atomic<int> rampCycles{1};      // 1-8: curve repetitions within one arp cycle
     std::atomic<float> quantize{0.0f};   // 0..1: pull warped steps toward a regular grid
     std::atomic<int> quantizeSub{16};    // grid subdivisions for quantize

--- a/magda/daw/audio/plugins/BaseDevicePack.cpp
+++ b/magda/daw/audio/plugins/BaseDevicePack.cpp
@@ -133,10 +133,7 @@ te::Plugin::Ptr restoreSavedPlugin(te::Edit& edit, const juce::String& savedPlug
         return {};
     }
 
-    auto plugin = edit.getPluginCache().createNewPlugin(savedState);
-    if (plugin != nullptr)
-        tracktion_adapter::applyDeviceStateParameters(*plugin, savedPluginState);
-    return plugin;
+    return edit.getPluginCache().createNewPlugin(savedState);
 }
 
 DevicePluginPtr createTracktionPlugin(const InternalPluginSpec& spec, DeviceSessionKey sessionKey,

--- a/magda/daw/audio/plugins/DeviceStateHydration.cpp
+++ b/magda/daw/audio/plugins/DeviceStateHydration.cpp
@@ -5,6 +5,7 @@
 #include <memory>
 
 #include "core/ChainWalk.hpp"
+#include "core/DeviceParamMigrations.hpp"
 #include "core/DeviceState.hpp"
 #include "core/ParameterUtils.hpp"
 #include "core/TrackInfo.hpp"
@@ -147,8 +148,32 @@ bool hydrateParametersFromDeviceState(DeviceInfo& device, const Provenance& prov
     if (!doc || doc->params.empty())
         return false;
 
+    // A record saved against a parameter order this build has since renumbered
+    // is identified by ITS length, not the model array's - the model array is
+    // exactly what an old preset or imported chain does not have. Remap the
+    // frozen indices first, or every old index would be read as a current one
+    // and land on the wrong slot (the pre-Enabled EQ, the 7-slot limiter).
+    // Dropped indices are dropped for the same reason the project-level pass
+    // drops them: re-pointing a value at a neighbour is corruption.
+    auto savedParams = doc->params;
+    const auto* migration = device_param_migrations::findMigrationForSavedCount(
+        device.pluginId, static_cast<int>(savedParams.size()));
+    if (migration != nullptr) {
+        std::vector<ds::ParamValue> remapped;
+        remapped.reserve(savedParams.size());
+        for (auto saved : savedParams) {
+            const auto newIndex =
+                device_param_migrations::migratedParamIndex(*migration, saved.index);
+            if (!newIndex.has_value())
+                continue;
+            saved.index = *newIndex;
+            remapped.push_back(std::move(saved));
+        }
+        savedParams = std::move(remapped);
+    }
+
     std::vector<const ds::ParamValue*> missing;
-    for (const auto& saved : doc->params)
+    for (const auto& saved : savedParams)
         if (saved.index >= 0 && !modelCarries(device, saved))
             missing.push_back(&saved);
     if (missing.empty())
@@ -184,6 +209,33 @@ bool hydrateParametersFromDeviceState(DeviceInfo& device, const Provenance& prov
         }
         // A normalised value without slot metadata is meaningless and is
         // dropped: there is no device to run it on either.
+    }
+
+    // Parameters the migrated order ADDED, seeded so the device keeps doing
+    // what the old one did (an old EQ's bands were always running; today they
+    // default off). Seed values are display-domain by contract
+    // (DeviceParamMigrations.hpp), whatever domain the record itself used.
+    if (migration != nullptr) {
+        for (const auto& seed : migration->seeded) {
+            if (device.findParameterByIndex(seed.index) != nullptr)
+                continue;
+            if (metadata != nullptr && seed.index < metadata->parameterCount()) {
+                auto info = metadata->parameterInfo(seed.index);
+                info.paramIndex = seed.index;
+                info.currentValue = seed.value;
+                device.parameters.push_back(std::move(info));
+            } else {
+                ParameterInfo info;
+                info.paramIndex = seed.index;
+                info.name = seed.name != nullptr ? juce::String(seed.name) : juce::String();
+                info.minValue = std::min(0.0f, seed.value);
+                info.maxValue = std::max(1.0f, seed.value);
+                info.defaultValue = seed.value;
+                info.currentValue = seed.value;
+                device.parameters.push_back(std::move(info));
+            }
+            added = true;
+        }
     }
 
     // A fully hydrated array keeps the device's own display order; entries

--- a/magda/daw/audio/plugins/DeviceStateHydration.cpp
+++ b/magda/daw/audio/plugins/DeviceStateHydration.cpp
@@ -71,19 +71,6 @@ ParamDomain resolveDomain(const DeviceInfo& device, const ds::Doc& doc,
     return ParamDomain::Display;
 }
 
-/// The saved root as the tree `MagdaDevice::restoreState()` takes - same shape
-/// the native engine's device factory builds (`EngineDeviceFactory.cpp`).
-juce::ValueTree treeFromNode(const ds::Node& node) {
-    juce::ValueTree tree(node.type.isNotEmpty() ? juce::Identifier(node.type)
-                                                : juce::Identifier("PLUGIN"));
-    for (int i = 0; i < node.props.size(); ++i)
-        tree.setProperty(node.props.getName(i), node.props.getValueAt(i), nullptr);
-    for (const auto& child : node.children)
-        if (child.type.isNotEmpty())
-            tree.appendChild(treeFromNode(child), nullptr);
-    return tree;
-}
-
 /// A throwaway SDK device for the parameter metadata a normalised value needs
 /// to become a display one. Restored from the document's own root first, for
 /// the devices whose parameter set depends on it (the runtime Faust device
@@ -106,7 +93,7 @@ std::unique_ptr<MagdaDevice> metadataDevice(const juce::String& pluginId, const 
 
     auto device = create();
     if (device != nullptr) {
-        auto tree = treeFromNode(doc.root);
+        auto tree = ds::toValueTree(doc.root);
         tree.setProperty(juce::Identifier("type"), doc.deviceType, nullptr);
         device->restoreState(tree);
     }

--- a/magda/daw/audio/plugins/DeviceStateHydration.cpp
+++ b/magda/daw/audio/plugins/DeviceStateHydration.cpp
@@ -1,0 +1,245 @@
+#include "plugins/DeviceStateHydration.hpp"
+
+#include <algorithm>
+#include <array>
+#include <memory>
+
+#include "core/ChainWalk.hpp"
+#include "core/DeviceState.hpp"
+#include "core/ParameterUtils.hpp"
+#include "core/TrackInfo.hpp"
+#include "plugins/DevicePluginHandle.hpp"
+#include "plugins/InternalPluginRegistry.hpp"
+#include "plugins/MagdaDevice.hpp"
+#include "plugins/compiled/CompiledPluginRegistry.hpp"
+
+namespace magda::daw::audio::device_state_hydration {
+
+namespace {
+
+namespace ds = magda::device_state;
+
+/// The domain a pre-#2317 document's parameter record used.
+enum class ParamDomain { Display, Normalized };
+
+/// Devices that were already behind `TracktionMagdaDevicePlugin` before the
+/// `paramsAreDisplayDomain` marker existed. Their unmarked documents have TWO
+/// eras: 0.19 captures from the retired host-native plugins hold display
+/// values, later captures from the wrapper hold normalised slots. Everything
+/// wrapped since the marker always writes it, so an unmarked document for any
+/// other device predates its wrapper and can only be display-domain.
+bool wrappedBeforeDomainMarker(const juce::String& deviceType) {
+    static constexpr std::array<const char*, 5> kPreMarkerWrapped{
+        "toneGenerator", "sidechain", "faust-fx", "oscilloscope", "spectrumanalyzer",
+    };
+    return std::any_of(kPreMarkerWrapped.begin(), kPreMarkerWrapped.end(),
+                       [&deviceType](const char* id) { return deviceType == id; });
+}
+
+/// Released-state-first fallback for a two-era document with no provenance:
+/// any value outside [0, 1] can only be display-domain (a 0.19 sidechain
+/// document always carries one - its release defaults to 15 ms). The residue -
+/// every value inside the unit interval - is read as normalised, which is
+/// exact for slots whose display range IS the unit interval and correct for
+/// wrapper-era captures of the rest.
+bool anyValueOutsideUnitInterval(const ds::Doc& doc) {
+    return std::any_of(doc.params.begin(), doc.params.end(), [](const ds::ParamValue& saved) {
+        return saved.value < -1.0e-4f || saved.value > 1.0f + 1.0e-4f;
+    });
+}
+
+ParamDomain resolveDomain(const DeviceInfo& device, const ds::Doc& doc,
+                          const Provenance& provenance) {
+    if (doc.paramsAreDisplayDomain)
+        return ParamDomain::Display;
+
+    // The compiled Faust pack's parameters were always normalised slots, and
+    // so were its documents, in every era.
+    if (compiled::findCompiledPluginSpec(device.pluginId) != nullptr)
+        return ParamDomain::Normalized;
+
+    if (wrappedBeforeDomainMarker(device.pluginId)) {
+        if (provenance.savedBeforeWrapperCutover)
+            return ParamDomain::Display;
+        return anyValueOutsideUnitInterval(doc) ? ParamDomain::Display : ParamDomain::Normalized;
+    }
+
+    // Every other unmarked document was captured from a plugin whose
+    // parameters ran in their own display range: either the device has never
+    // been wrapped, or it crossed after the marker existed and the document
+    // predates the crossing.
+    return ParamDomain::Display;
+}
+
+/// The saved root as the tree `MagdaDevice::restoreState()` takes - same shape
+/// the native engine's device factory builds (`EngineDeviceFactory.cpp`).
+juce::ValueTree treeFromNode(const ds::Node& node) {
+    juce::ValueTree tree(node.type.isNotEmpty() ? juce::Identifier(node.type)
+                                                : juce::Identifier("PLUGIN"));
+    for (int i = 0; i < node.props.size(); ++i)
+        tree.setProperty(node.props.getName(i), node.props.getValueAt(i), nullptr);
+    for (const auto& child : node.children)
+        if (child.type.isNotEmpty())
+            tree.appendChild(treeFromNode(child), nullptr);
+    return tree;
+}
+
+/// A throwaway SDK device for the parameter metadata a normalised value needs
+/// to become a display one. Restored from the document's own root first, for
+/// the devices whose parameter set depends on it (the runtime Faust device
+/// reads its slots out of its dsp source). Null for a device that has not
+/// crossed to MagdaDevice, whose documents were never normalised.
+std::unique_ptr<MagdaDevice> metadataDevice(const juce::String& pluginId, const ds::Doc& doc) {
+    auto create = [&pluginId]() -> std::unique_ptr<MagdaDevice> {
+        juce::ValueTree state{juce::Identifier("PLUGIN")};
+        state.setProperty(juce::Identifier("type"), pluginId, nullptr);
+        const DevicePluginCreationContext context{
+            .sessionKey = {}, .state = std::move(state), .isNewPlugin = true};
+        if (const auto* spec = findInternalPluginSpec(pluginId);
+            spec != nullptr && spec->createDevice != nullptr)
+            return spec->createDevice(context);
+        if (const auto* spec = compiled::findCompiledPluginSpec(pluginId);
+            spec != nullptr && spec->createDevice != nullptr)
+            return spec->createDevice(context);
+        return {};
+    };
+
+    auto device = create();
+    if (device != nullptr) {
+        auto tree = treeFromNode(doc.root);
+        tree.setProperty(juce::Identifier("type"), doc.deviceType, nullptr);
+        device->restoreState(tree);
+    }
+    return device;
+}
+
+/// Whether the model already carries the saved parameter, by frozen index
+/// first and stable id as the re-seat fallback (`DeviceParamSchema.hpp`).
+bool modelCarries(const DeviceInfo& device, const ds::ParamValue& saved) {
+    if (device.findParameterByIndex(saved.index) != nullptr)
+        return true;
+    if (saved.id.isEmpty())
+        return false;
+    return std::any_of(device.parameters.begin(), device.parameters.end(),
+                       [&saved](const ParameterInfo& p) { return p.stableId == saved.id; });
+}
+
+/// A hydrated entry for a device without SDK metadata: value and identity only,
+/// with a range wide enough to hold the value. The device's processor fills in
+/// the real metadata at registration, preserving this value.
+ParameterInfo minimalEntry(const ds::ParamValue& saved) {
+    ParameterInfo info;
+    info.paramIndex = saved.index;
+    info.stableId = saved.id;
+    info.name = saved.id;
+    info.minValue = std::min(0.0f, saved.value);
+    info.maxValue = std::max(1.0f, saved.value);
+    info.defaultValue = saved.value;
+    info.currentValue = saved.value;
+    return info;
+}
+
+}  // namespace
+
+Provenance provenanceFromMagdaVersion(const juce::String& version) {
+    const auto trimmed = version.trim();
+    const int major = trimmed.upToFirstOccurrenceOf(".", false, false).getIntValue();
+    const auto rest = trimmed.fromFirstOccurrenceOf(".", false, false);
+    const int minor = rest.upToFirstOccurrenceOf(".", false, false).getIntValue();
+
+    // Unparseable reads as 0.0: no build old enough to write no version at all
+    // postdates the cutover.
+    return {.savedBeforeWrapperCutover = major == 0 && minor < 20};
+}
+
+bool hydrateParametersFromDeviceState(DeviceInfo& device, const Provenance& provenance) {
+    if (device.format != PluginFormat::Internal || device.pluginState.isEmpty())
+        return false;
+
+    const auto doc = ds::decode(device.pluginState);
+    if (!doc || doc->params.empty())
+        return false;
+
+    std::vector<const ds::ParamValue*> missing;
+    for (const auto& saved : doc->params)
+        if (saved.index >= 0 && !modelCarries(device, saved))
+            missing.push_back(&saved);
+    if (missing.empty())
+        return false;
+
+    const bool arrayWasEmpty = device.parameters.empty();
+    const auto domain = resolveDomain(device, *doc, provenance);
+
+    // Real slot metadata whenever the device has an SDK factory, whatever the
+    // domain: the plan's value layer converts through the MODEL's ParameterInfo
+    // ranges, so a made-up range would corrupt a headless native render before
+    // any live processor could refresh it. The minimal fallback is reserved for
+    // devices without a factory - exactly the ones the native engine refuses to
+    // build, so nothing downstream converts through the placeholder.
+    const auto metadata = metadataDevice(device.pluginId, *doc);
+
+    bool added = false;
+    for (const auto* saved : missing) {
+        const bool haveSlot = metadata != nullptr && saved->index < metadata->parameterCount();
+        if (haveSlot) {
+            auto info = metadata->parameterInfo(saved->index);
+            info.paramIndex = saved->index;
+            if (info.stableId.isEmpty())
+                info.stableId = saved->id;
+            info.currentValue = domain == ParamDomain::Normalized
+                                    ? ParameterUtils::normalizedToReal(saved->value, info)
+                                    : saved->value;
+            device.parameters.push_back(std::move(info));
+            added = true;
+        } else if (domain == ParamDomain::Display) {
+            device.parameters.push_back(minimalEntry(*saved));
+            added = true;
+        }
+        // A normalised value without slot metadata is meaningless and is
+        // dropped: there is no device to run it on either.
+    }
+
+    // A fully hydrated array keeps the device's own display order; entries
+    // appended to a partial one land at the end, which only affects display
+    // order and only until the processor next refreshes the metadata.
+    if (added && arrayWasEmpty)
+        std::stable_sort(device.parameters.begin(), device.parameters.end(),
+                         [](const ParameterInfo& a, const ParameterInfo& b) {
+                             return a.paramIndex < b.paramIndex;
+                         });
+
+    return added;
+}
+
+void hydrateChainElements(std::vector<ChainElement>& elements, const Provenance& provenance) {
+    chain_walk::forEachDevice(elements, ChainNodePath{}, chain_walk::Pads::Enter,
+                              [&provenance](DeviceInfo& device, const ChainNodePath&) {
+                                  hydrateParametersFromDeviceState(device, provenance);
+                                  return true;
+                              });
+}
+
+void hydrateRack(RackInfo& rack, const Provenance& provenance) {
+    for (auto& chain : rack.chains)
+        hydrateChainElements(chain.elements, provenance);
+}
+
+void hydrateStagedProject(std::vector<TrackInfo>& tracks, TrackInfo* masterTrack,
+                          const juce::String& magdaVersion) {
+    const auto provenance = provenanceFromMagdaVersion(magdaVersion);
+
+    auto hydrateTrack = [&provenance](TrackInfo& track) {
+        hydrateChainElements(track.chain.fxChainElements, provenance);
+        for (auto& element : track.chain.postFxChainElements)
+            hydrateParametersFromDeviceState(element.device, provenance);
+        for (auto& element : track.chain.mixerAnalysisElements)
+            hydrateParametersFromDeviceState(element.device, provenance);
+    };
+
+    for (auto& track : tracks)
+        hydrateTrack(track);
+    if (masterTrack != nullptr)
+        hydrateTrack(*masterTrack);
+}
+
+}  // namespace magda::daw::audio::device_state_hydration

--- a/magda/daw/audio/plugins/DeviceStateHydration.hpp
+++ b/magda/daw/audio/plugins/DeviceStateHydration.hpp
@@ -1,0 +1,72 @@
+#pragma once
+
+#include <juce_core/juce_core.h>
+
+#include <vector>
+
+#include "core/DeviceInfo.hpp"
+#include "core/RackInfo.hpp"
+
+namespace magda {
+struct TrackInfo;
+}
+
+namespace magda::daw::audio::device_state_hydration {
+
+/**
+ * One-time load migration for the retired dual parameter authority (#2317).
+ *
+ * `DeviceInfo::parameters` is the sole persisted authority for an internal
+ * device's automatable parameters, in the device's DISPLAY domain. Documents
+ * written since #2317 carry no parameter record at all. Documents written
+ * before it duplicate the parameters as `Doc::params`, in a domain that
+ * depends on which build captured them; this module is the one place that
+ * still knows that chronology, and it applies it exactly once - at load,
+ * before either engine projection is constructed.
+ *
+ * Hydration never overwrites a parameter the model already carries: the model
+ * array is the authority and the duplicate record is only consulted for
+ * entries the array is missing (a state-only device preset, an imported
+ * chain, a hand-edited file). The duplicate itself is not deleted here; it
+ * disappears the next time the device is captured, because capture no longer
+ * writes one.
+ */
+
+/// What the container that carried the saved state says about the build that
+/// wrote it. Documents predating the `paramsAreDisplayDomain` marker cannot
+/// say on their own which domain they used; the container sometimes can.
+struct Provenance {
+    /// True when the container is known to have been written before the
+    /// wrapper cutover (a project whose `magdaVersion` is older than 0.20).
+    /// An unmarked document from such a container can only hold values in the
+    /// capturing plugin's display range.
+    bool savedBeforeWrapperCutover = false;
+};
+
+/// Provenance from a container's saved MAGDA version string ("0.19.2").
+/// Unparseable or missing versions are read as old: every build that wrote a
+/// version at all predates the cutover or wrote the marker.
+Provenance provenanceFromMagdaVersion(const juce::String& version);
+
+/// Hydrate `device.parameters` entries missing from the model out of the
+/// pre-#2317 duplicate parameter record in `device.pluginState`, converting to
+/// the display domain. No-op for external devices, empty or unreadable state,
+/// documents without a parameter record, and parameters the model already
+/// carries. Returns true when the device was changed.
+bool hydrateParametersFromDeviceState(DeviceInfo& device, const Provenance& provenance = {});
+
+/// Every internal device in a chain-element list (racks and pad chains
+/// included), for presets and imported chains. RackInfo overload for rack
+/// presets.
+void hydrateChainElements(std::vector<ChainElement>& elements, const Provenance& provenance = {});
+void hydrateRack(RackInfo& rack, const Provenance& provenance = {});
+
+/// Every internal device staged for a project load, with provenance from the
+/// file's `magdaVersion`. Belongs at the end of the load-time migration chain:
+/// after the retired-device aliases (so ids are canonical) and the param-index
+/// migrations (so the array hydration merges against is current), before any
+/// engine projection exists.
+void hydrateStagedProject(std::vector<TrackInfo>& tracks, TrackInfo* masterTrack,
+                          const juce::String& magdaVersion);
+
+}  // namespace magda::daw::audio::device_state_hydration

--- a/magda/daw/audio/plugins/MagdaConvolutionPlugin.cpp
+++ b/magda/daw/audio/plugins/MagdaConvolutionPlugin.cpp
@@ -8,15 +8,12 @@
 
 namespace magda::daw::audio {
 
-namespace {
+const juce::Identifier MagdaConvolutionPlugin::StateIDs::name("name");
+const juce::Identifier MagdaConvolutionPlugin::StateIDs::normalise("normalise");
+const juce::Identifier MagdaConvolutionPlugin::StateIDs::trimSilence("trimSilence");
+const juce::Identifier MagdaConvolutionPlugin::StateIDs::irFileData("irFileData");
 
-// The device's own state property names. `irFileData`, `name`, `normalise` and
-// `trimSilence` deliberately match the retired Tracktion device's, which is how
-// a migrated project keeps its impulse response (core/LegacyDeviceAliases.cpp).
-const juce::Identifier kNameProp("name");
-const juce::Identifier kNormaliseProp("normalise");
-const juce::Identifier kTrimSilenceProp("trimSilence");
-const juce::Identifier kIrFileDataProp("irFileData");
+namespace {
 
 constexpr float kMinFrequency = 10.0f;
 constexpr float kMaxFrequency = 20000.0f;
@@ -165,7 +162,8 @@ bool MagdaConvolutionPlugin::loadImpulseResponse(const juce::File& file) {
     return loadImpulseResponse(fileData.getData(), fileData.getSize());
 }
 
-bool MagdaConvolutionPlugin::loadImpulseResponse(const void* sourceData, size_t sourceDataSize) {
+bool MagdaConvolutionPlugin::encodeImpulseResponse(const void* sourceData, size_t sourceDataSize,
+                                                   juce::MemoryBlock& outEncoded) {
     if (sourceData == nullptr || sourceDataSize == 0)
         return false;
 
@@ -197,6 +195,15 @@ bool MagdaConvolutionPlugin::loadImpulseResponse(const void* sourceData, size_t 
         return false;
 
     writer.reset();  // flush before the block is moved into the device state
+
+    outEncoded = std::move(encoded);
+    return true;
+}
+
+bool MagdaConvolutionPlugin::loadImpulseResponse(const void* sourceData, size_t sourceDataSize) {
+    juce::MemoryBlock encoded;
+    if (!encodeImpulseResponse(sourceData, sourceDataSize, encoded))
+        return false;
 
     irData_ = std::move(encoded);
     loadImpulseResponseFromData();
@@ -315,27 +322,27 @@ void MagdaConvolutionPlugin::process(DeviceProcessContext& context) {
 
 //==============================================================================
 void MagdaConvolutionPlugin::flushState(juce::ValueTree& state) {
-    state.setProperty(kNameProp, irName_, nullptr);
-    state.setProperty(kNormaliseProp, normalise_, nullptr);
-    state.setProperty(kTrimSilenceProp, trimSilence_, nullptr);
+    state.setProperty(StateIDs::name, irName_, nullptr);
+    state.setProperty(StateIDs::normalise, normalise_, nullptr);
+    state.setProperty(StateIDs::trimSilence, trimSilence_, nullptr);
 
     // Only written when the device holds an IR. A device with none leaves the
     // property alone rather than removing it: the retired device stored the
     // blob directly on this tree, and state written there behind the device's
     // back (tests do; a failed decode could) must survive a flush.
     if (irData_.getSize() > 0)
-        state.setProperty(kIrFileDataProp, juce::var(irData_), nullptr);
+        state.setProperty(StateIDs::irFileData, juce::var(irData_), nullptr);
 }
 
 void MagdaConvolutionPlugin::restoreState(const juce::ValueTree& state) {
-    if (const auto* name = state.getPropertyPointer(kNameProp))
+    if (const auto* name = state.getPropertyPointer(StateIDs::name))
         irName_ = name->toString();
-    if (const auto* normalise = state.getPropertyPointer(kNormaliseProp))
+    if (const auto* normalise = state.getPropertyPointer(StateIDs::normalise))
         normalise_ = static_cast<bool>(*normalise);
-    if (const auto* trimSilence = state.getPropertyPointer(kTrimSilenceProp))
+    if (const auto* trimSilence = state.getPropertyPointer(StateIDs::trimSilence))
         trimSilence_ = static_cast<bool>(*trimSilence);
 
-    if (const auto* irFileData = state.getProperty(kIrFileDataProp).getBinaryData()) {
+    if (const auto* irFileData = state.getProperty(StateIDs::irFileData).getBinaryData()) {
         irData_ = *irFileData;
         loadImpulseResponseFromData();
     }

--- a/magda/daw/audio/plugins/MagdaConvolutionPlugin.cpp
+++ b/magda/daw/audio/plugins/MagdaConvolutionPlugin.cpp
@@ -326,12 +326,15 @@ void MagdaConvolutionPlugin::flushState(juce::ValueTree& state) {
     state.setProperty(StateIDs::normalise, normalise_, nullptr);
     state.setProperty(StateIDs::trimSilence, trimSilence_, nullptr);
 
-    // Only written when the device holds an IR. A device with none leaves the
-    // property alone rather than removing it: the retired device stored the
-    // blob directly on this tree, and state written there behind the device's
-    // back (tests do; a failed decode could) must survive a flush.
+    // The property tracks the device exactly: written when it holds an IR,
+    // REMOVED when it does not. Leaving a stale blob on the engine tree would
+    // let a capture write an un-loaded IR back into the model after an undo
+    // (#2317 review). restoreState() now owns the absent-means-none contract,
+    // so nothing legitimate parks state here behind the device's back.
     if (irData_.getSize() > 0)
         state.setProperty(StateIDs::irFileData, juce::var(irData_), nullptr);
+    else
+        state.removeProperty(StateIDs::irFileData, nullptr);
 }
 
 void MagdaConvolutionPlugin::restoreState(const juce::ValueTree& state) {
@@ -342,15 +345,34 @@ void MagdaConvolutionPlugin::restoreState(const juce::ValueTree& state) {
     if (const auto* trimSilence = state.getPropertyPointer(StateIDs::trimSilence))
         trimSilence_ = static_cast<bool>(*trimSilence);
 
+    // The document is the whole authored state, so no `irFileData` MEANS no
+    // impulse response - restoring a document saved before the first IR load
+    // (an undo of that load, a preset with none) has to unload the current
+    // one, or the model says "no IR" while playback keeps convolving with it
+    // (#2317 review). An empty blob reads the same way.
     if (const auto* irFileData = state.getProperty(StateIDs::irFileData).getBinaryData()) {
         irData_ = *irFileData;
-        loadImpulseResponseFromData();
+    } else {
+        irData_ = {};
+        if (!state.hasProperty(StateIDs::name))
+            irName_.clear();
     }
+    loadImpulseResponseFromData();
 }
 
 void MagdaConvolutionPlugin::loadImpulseResponseFromData() {
     if (irData_.getSize() == 0) {
         irLengthSeconds_.store(0.0, std::memory_order_relaxed);
+        // dsp::Convolution has no unload, but a single-sample unit impulse IS
+        // the identity: loading it returns the stage to the pass-through a
+        // fresh convolution gives, so "no IR" sounds the same whether the
+        // device never loaded one or just un-loaded it (#2317 review).
+        juce::AudioBuffer<float> dirac(1, 1);
+        dirac.setSample(0, 0, 1.0f);
+        chain_.get<kConvolution>().loadImpulseResponse(
+            std::move(dirac), sampleRate_ > 0.0 ? sampleRate_ : 44100.0,
+            juce::dsp::Convolution::Stereo::no, juce::dsp::Convolution::Trim::no,
+            juce::dsp::Convolution::Normalise::no);
         return;
     }
 

--- a/magda/daw/audio/plugins/MagdaConvolutionPlugin.hpp
+++ b/magda/daw/audio/plugins/MagdaConvolutionPlugin.hpp
@@ -46,6 +46,17 @@ class MagdaConvolutionPlugin : public MagdaDevice {
     MagdaConvolutionPlugin();
     ~MagdaConvolutionPlugin() override;
 
+    // The device's own state property names. The spellings deliberately match
+    // the retired Tracktion device's, which is how a migrated project keeps
+    // its impulse response (core/LegacyDeviceAliases.cpp). Public because an
+    // IR load travels as a model document patch in this vocabulary (#2317).
+    struct StateIDs {
+        static const juce::Identifier name;
+        static const juce::Identifier normalise;
+        static const juce::Identifier trimSilence;
+        static const juce::Identifier irFileData;
+    };
+
     //==============================================================================
     /// FROZEN parameter order - the compatibility surface saved links address.
     enum ParamIndex {
@@ -68,6 +79,13 @@ class MagdaConvolutionPlugin : public MagdaDevice {
         @return false when the file cannot be read or encoded.
     */
     bool loadImpulseResponse(const juce::File&);
+
+    /// Parse @p sourceData as audio and re-encode it as the FLAC blob the
+    /// state document stores. Pure: touches no device. The model-first IR
+    /// load (#2317) encodes here and writes the result into the document; the
+    /// projection then decodes it in restoreState().
+    static bool encodeImpulseResponse(const void* sourceData, size_t sourceDataSize,
+                                      juce::MemoryBlock& outEncoded);
 
     /** Loads an impulse response from an encoded audio file held in memory. */
     bool loadImpulseResponse(const void* sourceData, size_t sourceDataSize);

--- a/magda/daw/audio/plugins/engine/EngineDeviceFactory.cpp
+++ b/magda/daw/audio/plugins/engine/EngineDeviceFactory.cpp
@@ -54,18 +54,6 @@ std::unique_ptr<MagdaDevice> createSdkDevice(const juce::String& pluginId) {
     return {};
 }
 
-/// The saved node, as the tree MagdaDevice::restoreState() takes.
-juce::ValueTree treeFromNode(const magda::device_state::Node& node) {
-    juce::ValueTree tree(node.type.isNotEmpty() ? juce::Identifier(node.type)
-                                                : juce::Identifier("PLUGIN"));
-    for (int i = 0; i < node.props.size(); ++i)
-        tree.setProperty(node.props.getName(i), node.props.getValueAt(i), nullptr);
-    for (const auto& child : node.children)
-        if (child.type.isNotEmpty())
-            tree.appendChild(treeFromNode(child), nullptr);
-    return tree;
-}
-
 /// Hand the device whatever the project saved for it.
 ///
 /// Parameters are not this: the plan's value layer resolves every one of them
@@ -83,7 +71,7 @@ void restoreSavedState(MagdaDevice& device, const juce::String& savedState) {
     if (!doc)
         return;
 
-    auto tree = treeFromNode(doc->root);
+    auto tree = magda::device_state::toValueTree(doc->root);
     tree.setProperty(typeProperty(), doc->deviceType, nullptr);
     device.restoreState(tree);
 }

--- a/magda/daw/audio/plugins/tracktion/TracktionDeviceStateBridge.cpp
+++ b/magda/daw/audio/plugins/tracktion/TracktionDeviceStateBridge.cpp
@@ -6,7 +6,6 @@
 #include "TracktionHelpers.hpp"
 #include "core/DeviceState.hpp"
 #include "core/LegacyDeviceAliases.hpp"
-#include "core/ParameterUtils.hpp"
 #include "plugins/InternalPluginRegistry.hpp"
 #include "plugins/compiled/CompiledFaustInterface.hpp"
 #include "plugins/compiled/tracktion/CompiledFaustTracktionAdapter.hpp"
@@ -138,39 +137,6 @@ juce::ValueTree legacyPluginTree(const juce::String& savedState) {
 
 }  // namespace
 
-/// The device behind the host adapter, when @p plugin is an internal-registry
-/// device that has crossed to MagdaDevice. Null for legacy plugins and for the
-/// compiled pack (whose parameters were always normalised, docs included).
-///
-/// Documents for these devices carry parameter values in the DEVICE'S DISPLAY
-/// DOMAIN, declared by the document's `paramsDomain` marker. The wrapper's
-/// parameters are normalised [0,1] slots, so capture and apply convert at this
-/// boundary.
-const MagdaDevice* displayDomainDeviceFor(te::Plugin& plugin, const juce::String& deviceType) {
-    auto* adapter = dynamic_cast<TracktionMagdaDevicePlugin*>(&plugin);
-    if (adapter == nullptr || findInternalPluginSpec(deviceType) == nullptr)
-        return nullptr;
-    return &adapter->device();
-}
-
-/// Whether an UNMARKED document for @p deviceType holds display-domain values.
-///
-/// A document without the `paramsDomain` marker predates it, so its values are
-/// in whatever range the capturing parameter ran in. For the devices that
-/// crossed to the wrapper in #2312 that can only be the retired plugin's
-/// display range - they were never behind the wrapper before the marker
-/// existed. For everything that was already wrapped on the target branch (Test
-/// Tone, Sidechain, the runtime Faust device, the analyzers) an unmarked
-/// document is normalised and must apply raw.
-bool unmarkedDocIsDisplayDomain(const juce::String& deviceType) {
-    static constexpr const char* kPortedWithMarker[] = {
-        "magda_rings",       "magda_elements", "magda_clouds",
-        "magda_convolution", "magda_strum",    "arpeggiator",
-    };
-    return std::any_of(std::begin(kPortedWithMarker), std::end(kPortedWithMarker),
-                       [&deviceType](const char* id) { return deviceType == id; });
-}
-
 juce::String captureInternalDeviceState(te::Plugin& plugin, const juce::String& existingState) {
     // State from a newer schema was refused at load, so the live plugin holds
     // defaults rather than what the project actually says. Capturing over it
@@ -187,7 +153,6 @@ juce::String captureInternalDeviceState(te::Plugin& plugin, const juce::String& 
     doc.deviceType = canonicalDeviceType(plugin.state.getProperty(te::IDs::type).toString());
 
     const auto& params = plugin.getAutomatableParameters();
-    doc.params.reserve(static_cast<size_t>(params.size()));
 
     // Three Tracktion parameters store under a property spelled differently
     // from their paramID; the spellings are frozen because released TE projects
@@ -199,20 +164,15 @@ juce::String captureInternalDeviceState(te::Plugin& plugin, const juce::String& 
         {"damping", "damp"},             // Reverb
     };
 
+    // The document carries NO parameter values (#2317): `DeviceInfo::parameters`
+    // is the sole persisted authority for automatable parameters, in the
+    // device's display domain. The live parameter list is still walked so the
+    // engine's per-parameter properties are filtered out of the root below -
+    // they are exactly the engine-shaped state the document exists to exclude.
     juce::StringArray parameterProperties;
-    const auto* displayDevice = displayDomainDeviceFor(plugin, doc.deviceType);
-    doc.paramsAreDisplayDomain = displayDevice != nullptr;
-
-    for (int i = 0; i < params.size(); ++i) {
-        auto* param = params[i];
+    for (auto* param : params) {
         if (param == nullptr)
             continue;
-        // Base value, never the modulated value: a modulated read would bake the
-        // current LFO position into the saved patch.
-        float value = param->getCurrentBaseValue();
-        if (displayDevice != nullptr)
-            value = ParameterUtils::normalizedToReal(value, displayDevice->parameterInfo(i));
-        doc.params.push_back({i, param->paramID, value});
         parameterProperties.add(param->paramID);
         for (const auto& [paramID, property] : kParamPropertySpellings)
             if (param->paramID == paramID)
@@ -241,66 +201,6 @@ juce::ValueTree devicePluginTreeFromState(const juce::String& savedState) {
     applyNode(doc->root, tree);
     adoptCanonicalPluginType(tree);
     return tree;
-}
-
-void applyDeviceStateParameters(te::Plugin& plugin, const juce::String& savedState) {
-    const auto doc = ds::decode(savedState);
-    if (!doc || doc->params.empty())
-        return;
-
-    const auto& params = plugin.getAutomatableParameters();
-    const auto* displayDevice = displayDomainDeviceFor(plugin, doc->deviceType);
-
-    bool convertFromDisplay = false;
-    if (displayDevice != nullptr) {
-        if (doc->paramsAreDisplayDomain || unmarkedDocIsDisplayDomain(doc->deviceType)) {
-            convertFromDisplay = true;
-        } else {
-            // Devices that were already wrapped before the marker existed have
-            // TWO unmarked eras: 0.19 documents captured from the host-native
-            // plugins hold display values, target-branch documents captured
-            // from the wrapper hold normalised ones. No provenance survives in
-            // the document, but the values discriminate safely in one
-            // direction: anything outside [0, 1] can only be display-domain.
-            // A 0.19 sidechain document always carries one (its release
-            // defaults to 15 ms). The residue - a document whose every value
-            // sits inside [0, 1] - is read as normalised, which is exact for
-            // slots whose display range IS the unit interval and the
-            // target-branch form for the rest.
-            for (const auto& saved : doc->params) {
-                if (saved.value < -1.0e-4f || saved.value > 1.0f + 1.0e-4f) {
-                    convertFromDisplay = true;
-                    break;
-                }
-            }
-        }
-    }
-
-    for (const auto& saved : doc->params) {
-        te::AutomatableParameter* param = nullptr;
-
-        // Frozen index first; the stable id re-seats a value if a device ever
-        // has to renumber (see DeviceParamSchema.hpp).
-        if (saved.index >= 0 && saved.index < params.size())
-            if (auto* candidate = params[saved.index];
-                candidate != nullptr && (saved.id.isEmpty() || candidate->paramID == saved.id))
-                param = candidate;
-
-        if (param == nullptr && saved.id.isNotEmpty())
-            for (auto* candidate : params)
-                if (candidate != nullptr && candidate->paramID == saved.id) {
-                    param = candidate;
-                    break;
-                }
-
-        if (param != nullptr) {
-            float value = saved.value;
-            if (convertFromDisplay)
-                value = ParameterUtils::realToNormalized(
-                    value, displayDevice->parameterInfo(params.indexOf(param)));
-            param->setParameterFromHost(value, juce::sendNotificationSync);
-        }
-    }
 }
 
 std::vector<magda::legacy_devices::RetiredSlotValue> adoptRetiredNestedPluginTree(

--- a/magda/daw/audio/plugins/tracktion/TracktionDeviceStateBridge.hpp
+++ b/magda/daw/audio/plugins/tracktion/TracktionDeviceStateBridge.hpp
@@ -23,8 +23,11 @@ namespace te = tracktion::engine;
  * process / frozen flags, editor window bounds, modifier assignments, macro and
  * sidechain wiring). MAGDA already owns all of those in `DeviceInfo`, and
  * keeping them would put engine chrome back into user files. What survives is
- * the device's own property/child vocabulary plus its parameter values keyed by
- * frozen index.
+ * the device's own property/child vocabulary ONLY: since #2317 automatable
+ * parameter values are not captured at all, because `DeviceInfo::parameters`
+ * is their sole persisted authority (display domain). Documents from older
+ * builds that do carry a `params` record are consumed once at load by the
+ * model-side migration (`core/DeviceStateHydration.hpp`), never here.
  */
 
 /// Capture a live internal device as a v2 document (JSON text). Empty when the
@@ -42,11 +45,6 @@ juce::String captureInternalDeviceState(te::Plugin& plugin, const juce::String& 
 /// saved state. Accepts v2 JSON and legacy (v1) engine XML; returns an invalid
 /// tree when `savedState` is empty or unusable.
 juce::ValueTree devicePluginTreeFromState(const juce::String& savedState);
-
-/// Apply a v2 document's frozen parameter values on top of an already
-/// constructed plugin. No-op for legacy state, which carries no separate
-/// parameter record.
-void applyDeviceStateParameters(te::Plugin& plugin, const juce::String& savedState);
 
 /**
  * @brief Rewrite a nested retired-device plugin tree onto its compiled

--- a/magda/daw/audio/processors/CompiledFaustProcessor.cpp
+++ b/magda/daw/audio/processors/CompiledFaustProcessor.cpp
@@ -64,7 +64,7 @@ ParameterInfo CompiledFaustProcessor::getParameterInfo(int index) const {
     return info;
 }
 
-void CompiledFaustProcessor::populateParameters(DeviceInfo& info) const {
+void CompiledFaustProcessor::populateParametersFromEngine(DeviceInfo& info) const {
     info.parameters.clear();
     const auto* host = compiledDevice(plugin_.get());
     if (host == nullptr)

--- a/magda/daw/audio/processors/CompiledFaustProcessor.hpp
+++ b/magda/daw/audio/processors/CompiledFaustProcessor.hpp
@@ -17,7 +17,7 @@ class CompiledFaustProcessor : public DeviceProcessor {
 
     int getParameterCount() const override;
     ParameterInfo getParameterInfo(int index) const override;
-    void populateParameters(DeviceInfo& info) const override;
+    void populateParametersFromEngine(DeviceInfo& info) const override;
     void setParameterByIndex(int paramIndex, float value) override;
     float getParameterByIndex(int paramIndex) const;
 };

--- a/magda/daw/audio/processors/base/DeviceProcessor.cpp
+++ b/magda/daw/audio/processors/base/DeviceProcessor.cpp
@@ -94,6 +94,35 @@ bool DeviceProcessor::isDeltaSolo() const {
     return plugin_ && plugin_->isDeltaSoloEnabled();
 }
 
+void DeviceProcessor::populateParametersModelFirst(DeviceInfo& info) const {
+    if (info.format != PluginFormat::Internal) {
+        populateParameters(info);
+        return;
+    }
+
+    const auto model = std::move(info.parameters);
+    populateParameters(info);
+
+    auto sameParameter = [](const ParameterInfo& kept, const ParameterInfo& fresh) {
+        if (kept.paramIndex != fresh.paramIndex)
+            return false;
+        // A minimal hydrated entry (value and saved id only, named after that
+        // id) has no metadata to compare; its frozen index is all it has.
+        if (kept.name == kept.stableId)
+            return true;
+        if (kept.stableId.isNotEmpty() && fresh.stableId.isNotEmpty())
+            return kept.stableId == fresh.stableId;
+        return kept.name == fresh.name;
+    };
+
+    for (auto& fresh : info.parameters)
+        for (const auto& kept : model)
+            if (sameParameter(kept, fresh)) {
+                fresh.currentValue = kept.currentValue;
+                break;
+            }
+}
+
 void DeviceProcessor::syncFromDeviceInfo(const DeviceInfo& info) {
     setGainDb(info.gainDb);
     setBypassed(info.bypassed);

--- a/magda/daw/audio/processors/base/DeviceProcessor.cpp
+++ b/magda/daw/audio/processors/base/DeviceProcessor.cpp
@@ -45,7 +45,7 @@ juce::String DeviceProcessor::formatParameterValue(int index, float normalizedVa
     return cachedParams_[index]->valueToString(normalizedValue);
 }
 
-void DeviceProcessor::populateParameters(DeviceInfo& info) const {
+void DeviceProcessor::populateParametersFromEngine(DeviceInfo& info) const {
     info.parameters.clear();
     int count = getParameterCount();
     for (int i = 0; i < count; ++i) {
@@ -94,14 +94,14 @@ bool DeviceProcessor::isDeltaSolo() const {
     return plugin_ && plugin_->isDeltaSoloEnabled();
 }
 
-void DeviceProcessor::populateParametersModelFirst(DeviceInfo& info) const {
-    if (info.format != PluginFormat::Internal) {
-        populateParameters(info);
+void DeviceProcessor::populateParameters(DeviceInfo& info, ValueSource source) const {
+    if (source == ValueSource::Engine || info.format != PluginFormat::Internal) {
+        populateParametersFromEngine(info);
         return;
     }
 
     const auto model = std::move(info.parameters);
-    populateParameters(info);
+    populateParametersFromEngine(info);
 
     auto sameParameter = [](const ParameterInfo& kept, const ParameterInfo& fresh) {
         if (kept.paramIndex != fresh.paramIndex)

--- a/magda/daw/audio/processors/base/DeviceProcessor.hpp
+++ b/magda/daw/audio/processors/base/DeviceProcessor.hpp
@@ -38,20 +38,33 @@ class DeviceProcessor {
     virtual int getParameterCount() const;
     virtual ParameterInfo getParameterInfo(int index) const;
     virtual juce::String formatParameterValue(int index, float normalizedValue) const;
-    virtual void populateParameters(DeviceInfo& info) const;
+    /**
+     * Where an internal device's parameter VALUES come from when `info` is
+     * (re)populated. Mandatory at every call site, because which way values
+     * flow is exactly the decision #2317 exists to make explicit.
+     */
+    enum class ValueSource {
+        /// Values are read off the live plugin along with the metadata. For
+        /// seeding a brand-new device, and the only correct source for an
+        /// external plugin whose chunk is authoritative.
+        Engine,
+        /// The model is the authority (#2317): an entry `info` already carried
+        /// keeps its `currentValue` when the refreshed entry still names the
+        /// same parameter (same frozen index, same identity); only entries the
+        /// model lacked - a new device, a parameter added by an update, a
+        /// Faust recompile that changed what a slot means - take the engine's
+        /// value. An EXTERNAL device passing through here still reads Engine:
+        /// its chunk is authoritative and the model array mirrors it.
+        Model
+    };
 
     /**
-     * Refresh `info`'s parameters from this processor WITHOUT copying values
-     * back from the engine (#2317). For an internal device the model is the
-     * authority for parameter values: an entry the model already carried keeps
-     * its `currentValue` when the refreshed entry still names the same
-     * parameter (same frozen index, same identity), and only entries the model
-     * lacked - a new device, a parameter added by an update, a Faust recompile
-     * that changed what a slot means - take the processor's value. External
-     * devices get the plain copy-back: their chunk is authoritative and the
-     * model array mirrors it.
+     * Refresh `info`'s parameter list (metadata and values) from this
+     * processor, with `source` deciding whether the engine's values may
+     * overwrite the model's. The per-processor engine read is the protected
+     * `populateParametersFromEngine()` hook.
      */
-    void populateParametersModelFirst(DeviceInfo& info) const;
+    void populateParameters(DeviceInfo& info, ValueSource source) const;
     virtual void setParameterByIndex(int paramIndex, float value);
     void setParameterByIndex(int paramIndex, ParameterModelValue value);
 
@@ -74,6 +87,11 @@ class DeviceProcessor {
     virtual void syncToDeviceInfo(DeviceInfo& info) const;
 
   protected:
+    /// Read the full parameter list - metadata AND current values - off the
+    /// live plugin into `info.parameters`. Never call directly from outside:
+    /// the public populateParameters() applies the ValueSource policy on top.
+    virtual void populateParametersFromEngine(DeviceInfo& info) const;
+
     DeviceId deviceId_;
     te::Plugin::Ptr plugin_;
 

--- a/magda/daw/audio/processors/base/DeviceProcessor.hpp
+++ b/magda/daw/audio/processors/base/DeviceProcessor.hpp
@@ -39,6 +39,19 @@ class DeviceProcessor {
     virtual ParameterInfo getParameterInfo(int index) const;
     virtual juce::String formatParameterValue(int index, float normalizedValue) const;
     virtual void populateParameters(DeviceInfo& info) const;
+
+    /**
+     * Refresh `info`'s parameters from this processor WITHOUT copying values
+     * back from the engine (#2317). For an internal device the model is the
+     * authority for parameter values: an entry the model already carried keeps
+     * its `currentValue` when the refreshed entry still names the same
+     * parameter (same frozen index, same identity), and only entries the model
+     * lacked - a new device, a parameter added by an update, a Faust recompile
+     * that changed what a slot means - take the processor's value. External
+     * devices get the plain copy-back: their chunk is authoritative and the
+     * model array mirrors it.
+     */
+    void populateParametersModelFirst(DeviceInfo& info) const;
     virtual void setParameterByIndex(int paramIndex, float value);
     void setParameterByIndex(int paramIndex, ParameterModelValue value);
 

--- a/magda/daw/audio/processors/base/MagdaDeviceProcessor.cpp
+++ b/magda/daw/audio/processors/base/MagdaDeviceProcessor.cpp
@@ -52,7 +52,7 @@ ParameterInfo MagdaDeviceProcessor::getParameterInfo(int index) const {
     return info;
 }
 
-void MagdaDeviceProcessor::populateParameters(DeviceInfo& info) const {
+void MagdaDeviceProcessor::populateParametersFromEngine(DeviceInfo& info) const {
     info.parameters.clear();
     const int count = getParameterCount();
     for (int index = 0; index < count; ++index)

--- a/magda/daw/audio/processors/base/MagdaDeviceProcessor.hpp
+++ b/magda/daw/audio/processors/base/MagdaDeviceProcessor.hpp
@@ -24,7 +24,7 @@ class MagdaDeviceProcessor : public DeviceProcessor {
 
     int getParameterCount() const override;
     ParameterInfo getParameterInfo(int index) const override;
-    void populateParameters(DeviceInfo& info) const override;
+    void populateParametersFromEngine(DeviceInfo& info) const override;
     void setParameterByIndex(int paramIndex, float value) override;
     float getParameterByIndex(int paramIndex) const;
 };

--- a/magda/daw/audio/processors/external/ExternalPluginProcessor.cpp
+++ b/magda/daw/audio/processors/external/ExternalPluginProcessor.cpp
@@ -92,7 +92,7 @@ ParameterInfo ExternalPluginProcessor::getParameterInfo(int index) const {
     return info;
 }
 
-void ExternalPluginProcessor::populateParameters(DeviceInfo& info) const {
+void ExternalPluginProcessor::populateParametersFromEngine(DeviceInfo& info) const {
     info.parameters.clear();
     info.wrapperParameters.clear();
 

--- a/magda/daw/audio/processors/external/ExternalPluginProcessor.hpp
+++ b/magda/daw/audio/processors/external/ExternalPluginProcessor.hpp
@@ -25,7 +25,7 @@ class ExternalPluginProcessor : public DeviceProcessor, public te::AutomatablePa
     std::vector<juce::String> getParameterNames() const override;
     int getParameterCount() const override;
     ParameterInfo getParameterInfo(int index) const override;
-    void populateParameters(DeviceInfo& info) const override;
+    void populateParametersFromEngine(DeviceInfo& info) const override;
 
     void syncFromDeviceInfo(const DeviceInfo& info) override;
 

--- a/magda/daw/audio/processors/internal/NativeDeviceProcessors.cpp
+++ b/magda/daw/audio/processors/internal/NativeDeviceProcessors.cpp
@@ -139,7 +139,7 @@ ParameterInfo FaustProcessor::getParameterInfo(int index) const {
     return daw::audio::paramInfoFromSlot(faust->getPool().slot(index));
 }
 
-void FaustProcessor::populateParameters(DeviceInfo& info) const {
+void FaustProcessor::populateParametersFromEngine(DeviceInfo& info) const {
     info.parameters.clear();
     auto* faust =
         daw::audio::tracktion_adapter::deviceFromPlugin<daw::audio::FaustPlugin>(plugin_.get());
@@ -228,7 +228,7 @@ ParameterInfo FaustInstrumentProcessor::getParameterInfo(int index) const {
     return daw::audio::paramInfoFromSlot(faust->getPool().slot(index));
 }
 
-void FaustInstrumentProcessor::populateParameters(DeviceInfo& info) const {
+void FaustInstrumentProcessor::populateParametersFromEngine(DeviceInfo& info) const {
     info.parameters.clear();
     auto* faust = dynamic_cast<daw::audio::FaustInstrumentPlugin*>(plugin_.get());
     if (faust == nullptr)

--- a/magda/daw/audio/processors/internal/NativeDeviceProcessors.hpp
+++ b/magda/daw/audio/processors/internal/NativeDeviceProcessors.hpp
@@ -129,7 +129,7 @@ class FaustProcessor : public DeviceProcessor {
 
     int getParameterCount() const override;
     ParameterInfo getParameterInfo(int index) const override;
-    void populateParameters(DeviceInfo& info) const override;
+    void populateParametersFromEngine(DeviceInfo& info) const override;
 
     void setParameterByIndex(int paramIndex, float value) override;
     float getParameterByIndex(int paramIndex) const;
@@ -147,7 +147,7 @@ class FaustInstrumentProcessor : public DeviceProcessor {
 
     int getParameterCount() const override;
     ParameterInfo getParameterInfo(int index) const override;
-    void populateParameters(DeviceInfo& info) const override;
+    void populateParametersFromEngine(DeviceInfo& info) const override;
 
     void setParameterByIndex(int paramIndex, float value) override;
     float getParameterByIndex(int paramIndex) const;

--- a/magda/daw/audio/processors/internal/StockDeviceProcessors.cpp
+++ b/magda/daw/audio/processors/internal/StockDeviceProcessors.cpp
@@ -293,7 +293,7 @@ ParameterInfo UtilityProcessor::getParameterInfo(int index) const {
     return info;
 }
 
-void UtilityProcessor::populateParameters(DeviceInfo& info) const {
+void UtilityProcessor::populateParametersFromEngine(DeviceInfo& info) const {
     info.parameters.clear();
     for (int i = 0; i < getParameterCount(); ++i) {
         info.parameters.push_back(getParameterInfo(i));

--- a/magda/daw/audio/processors/internal/StockDeviceProcessors.hpp
+++ b/magda/daw/audio/processors/internal/StockDeviceProcessors.hpp
@@ -91,7 +91,7 @@ class UtilityProcessor : public DeviceProcessor {
 
     int getParameterCount() const override;
     ParameterInfo getParameterInfo(int index) const override;
-    void populateParameters(DeviceInfo& info) const override;
+    void populateParametersFromEngine(DeviceInfo& info) const override;
 
     void setParameterByIndex(int paramIndex, float value) override;
     float getParameterByIndex(int paramIndex) const;

--- a/magda/daw/core/CMakeLists.txt
+++ b/magda/daw/core/CMakeLists.txt
@@ -39,6 +39,7 @@ target_sources(magda_daw PRIVATE
     UndoManager.cpp
     ClipPropertyCommands.cpp
     WarpMarkerCommands.cpp
+    DeviceStateCommands.cpp
     TrackCommands.cpp
     PadCommands.cpp
     TrackPropertyCommands.cpp

--- a/magda/daw/core/DeviceParamMigrations.cpp
+++ b/magda/daw/core/DeviceParamMigrations.cpp
@@ -270,15 +270,22 @@ const MigrationTable& shippedMigrations() {
     return table();
 }
 
-const ParamIndexMigration* findMigration(const DeviceInfo& device, const MigrationTable& table) {
+const ParamIndexMigration* findMigrationForSavedCount(const juce::String& deviceType,
+                                                      int savedParamCount,
+                                                      const MigrationTable& table) {
     for (const auto& migration : table) {
-        if (device.pluginId != migration.deviceType)
+        if (deviceType != migration.deviceType)
             continue;
-        if (static_cast<int>(device.parameters.size()) != migration.savedParamCount)
+        if (savedParamCount != migration.savedParamCount)
             continue;  // a different order, or already migrated
         return &migration;
     }
     return nullptr;
+}
+
+const ParamIndexMigration* findMigration(const DeviceInfo& device, const MigrationTable& table) {
+    return findMigrationForSavedCount(device.pluginId, static_cast<int>(device.parameters.size()),
+                                      table);
 }
 
 std::optional<int> migratedParamIndex(const ParamIndexMigration& migration, int savedIndex) {

--- a/magda/daw/core/DeviceParamMigrations.hpp
+++ b/magda/daw/core/DeviceParamMigrations.hpp
@@ -94,6 +94,20 @@ inline const ParamIndexMigration* findMigration(const DeviceInfo& device) {
     return findMigration(device, shippedMigrations());
 }
 
+/// The migration that applies to a saved parameter record carrying
+/// @p savedParamCount entries for @p deviceType, or null. For state that
+/// arrives WITHOUT a model parameter array - an old preset's document, an
+/// imported chain - where the count identifying the saved order is the
+/// record's own length rather than `DeviceInfo::parameters.size()`.
+const ParamIndexMigration* findMigrationForSavedCount(const juce::String& deviceType,
+                                                      int savedParamCount,
+                                                      const MigrationTable& table);
+
+inline const ParamIndexMigration* findMigrationForSavedCount(const juce::String& deviceType,
+                                                             int savedParamCount) {
+    return findMigrationForSavedCount(deviceType, savedParamCount, shippedMigrations());
+}
+
 /**
  * The index `savedIndex` becomes under `migration`.
  *

--- a/magda/daw/core/DeviceState.cpp
+++ b/magda/daw/core/DeviceState.cpp
@@ -234,4 +234,15 @@ void forEachNode(const Node& root, const std::function<void(const Node&)>& visit
         forEachNode(child, visit);
 }
 
+juce::ValueTree toValueTree(const Node& node) {
+    juce::ValueTree tree(node.type.isNotEmpty() ? juce::Identifier(node.type)
+                                                : juce::Identifier("PLUGIN"));
+    for (int i = 0; i < node.props.size(); ++i)
+        tree.setProperty(node.props.getName(i), node.props.getValueAt(i), nullptr);
+    for (const auto& child : node.children)
+        if (child.type.isNotEmpty())
+            tree.appendChild(toValueTree(child), nullptr);
+    return tree;
+}
+
 }  // namespace magda::device_state

--- a/magda/daw/core/DeviceState.hpp
+++ b/magda/daw/core/DeviceState.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <juce_core/juce_core.h>
+#include <juce_data_structures/juce_data_structures.h>
 
 #include <functional>
 #include <optional>
@@ -123,5 +124,15 @@ bool isFutureDeviceState(const juce::String& text);
 
 /// Depth-first walk over `root` and all descendants, root first.
 void forEachNode(const Node& root, const std::function<void(const Node&)>& visit);
+
+/**
+ * A node as the plain ValueTree `MagdaDevice::restoreState()` takes. The
+ * document root has no element name of its own, so it (and any nameless
+ * descendant's shell) becomes "PLUGIN"; nameless children are skipped, the
+ * same rule `decode` applies on the way in. Every consumer of a document -
+ * the native engine's device factory, the load-time hydration - builds the
+ * restore tree through here, so a device sees one shape whoever asks.
+ */
+juce::ValueTree toValueTree(const Node& node);
 
 }  // namespace magda::device_state

--- a/magda/daw/core/DeviceState.hpp
+++ b/magda/daw/core/DeviceState.hpp
@@ -18,19 +18,22 @@ namespace magda::device_state {
  * into MAGDA's own format, so the engine could not be replaced without
  * rewriting every user file.
  *
- * v2 is a MAGDA-defined document with three parts:
+ * v2 is a MAGDA-defined document with two parts:
  *
  *  - `deviceType` — MAGDA's canonical device id (`DeviceInfo::pluginId`), not an
  *    engine plugin type name.
- *  - `params` — the device's automatable parameters, keyed by the FROZEN
- *    `paramIndex` for that device type. This is the same index the persisted
- *    automation / macro / mod graph is stored against (`ControlTarget::PluginParam`),
- *    so it is a compatibility surface: see `DeviceParamSchema.hpp`. Each entry also
- *    carries the parameter's stable string id so a value can be re-seated if a
- *    device ever has to renumber.
  *  - `root` — everything that is not a parameter (sample paths, DSP source,
  *    sequencer steps, drum-pad chains, ...) as a plain name/value tree under the
  *    device's own property names. No engine ids, no engine container tags.
+ *
+ * Automatable parameter values are NOT part of the document (#2317):
+ * `DeviceInfo::parameters` is their sole persisted authority, in the device's
+ * display domain, keyed by the frozen `paramIndex` (`DeviceParamSchema.hpp`).
+ * Documents written before #2317 duplicated them as `params`; that record is
+ * still decoded, but only the load-time migration
+ * (`audio/plugins/DeviceStateHydration.hpp`) consumes it - once, to fill model
+ * entries the file is missing - and encode drops it when a build writes the
+ * document back.
  *
  * The document is engine-neutral by construction: nothing here knows what a
  * `te::Plugin` is. The engine adapter converts between a live device and this
@@ -46,10 +49,11 @@ namespace magda::device_state {
 inline constexpr int kSchemaVersion = 2;
 
 /**
- * One automatable parameter value, keyed by its frozen index.
+ * One automatable parameter value from a pre-#2317 document, keyed by its
+ * frozen index. Read for the load-time hydration only; never written again.
  *
- * `index` is authoritative for restore; `id` is a self-describing fallback and
- * the value the frozen-schema check compares against.
+ * `index` is authoritative; `id` is a self-describing fallback and the value
+ * the frozen-schema check compares against.
  */
 struct ParamValue {
     int index = -1;
@@ -72,11 +76,13 @@ struct Node {
 struct Doc {
     int version = kSchemaVersion;
     juce::String deviceType;
+    /// Pre-#2317 duplicate parameter record. Decoded for the load-time
+    /// hydration; empty in every document this build writes (encode skips it).
     std::vector<ParamValue> params;
     /// Whether `params` values are in the device's DISPLAY domain rather than
-    /// the capturing parameter's own range. Set by captures taken from devices
-    /// behind the host adapter since #2312; readers that predate the field
-    /// ignore it, which is safe because absence is meaningful (see the bridge).
+    /// the capturing parameter's own range. Written by captures taken from
+    /// devices behind the host adapter between #2312 and #2317; an unmarked
+    /// record's domain is resolved by the hydration's chronology rules.
     bool paramsAreDisplayDomain = false;
     Node root;
 };

--- a/magda/daw/core/DeviceStateCommands.cpp
+++ b/magda/daw/core/DeviceStateCommands.cpp
@@ -1,5 +1,6 @@
 #include "DeviceStateCommands.hpp"
 
+#include "DeviceState.hpp"
 #include "ProjectManager.hpp"
 #include "TrackManager.hpp"
 
@@ -16,7 +17,17 @@ juce::String LoadImpulseResponseCommand::getDescription() const {
 
 bool LoadImpulseResponseCommand::canExecute() const {
     const auto* device = TrackManager::getInstance().getDeviceInChainByPath(devicePath_);
-    return device != nullptr && irData_.getSize() > 0;
+    if (device == nullptr || irData_.getSize() == 0)
+        return false;
+
+    // The same preconditions updateDeviceAuthoredState() enforces, checked
+    // here so a refused edit is refused BEFORE SnapshotCommand marks the
+    // command executed and the UndoManager records a dirty no-op undo step.
+    // The device id is a literal for the same layering reason as the property
+    // names below: core must not include a concrete device header.
+    if (device->format != PluginFormat::Internal || device->pluginId != "magda_convolution")
+        return false;
+    return !device_state::isFutureDeviceState(device->pluginState);
 }
 
 juce::String LoadImpulseResponseCommand::captureState() {

--- a/magda/daw/core/DeviceStateCommands.cpp
+++ b/magda/daw/core/DeviceStateCommands.cpp
@@ -1,0 +1,49 @@
+#include "DeviceStateCommands.hpp"
+
+#include "ProjectManager.hpp"
+#include "TrackManager.hpp"
+
+namespace magda {
+
+LoadImpulseResponseCommand::LoadImpulseResponseCommand(const ChainNodePath& devicePath,
+                                                       const juce::String& irName,
+                                                       juce::MemoryBlock irData)
+    : devicePath_(devicePath), irName_(irName), irData_(std::move(irData)) {}
+
+juce::String LoadImpulseResponseCommand::getDescription() const {
+    return "Load Impulse Response";
+}
+
+bool LoadImpulseResponseCommand::canExecute() const {
+    const auto* device = TrackManager::getInstance().getDeviceInChainByPath(devicePath_);
+    return device != nullptr && irData_.getSize() > 0;
+}
+
+juce::String LoadImpulseResponseCommand::captureState() {
+    const auto* device = TrackManager::getInstance().getDeviceInChainByPath(devicePath_);
+    return device != nullptr ? device->pluginState : juce::String();
+}
+
+void LoadImpulseResponseCommand::restoreState(const juce::String& state) {
+    TrackManager::getInstance().setDeviceAuthoredState(devicePath_, state);
+    ProjectManager::getInstance().markDirty();
+}
+
+void LoadImpulseResponseCommand::performAction() {
+    // The convolution device's own state property names
+    // (MagdaConvolutionPlugin::StateIDs). Spelled out here because core must
+    // not include a concrete device header; the spellings are a frozen
+    // persistence surface either way - they are the retired Tracktion
+    // device's, and saved projects carry them.
+    static const juce::Identifier irNameProp("name");
+    static const juce::Identifier irFileDataProp("irFileData");
+
+    TrackManager::getInstance().updateDeviceAuthoredState(
+        devicePath_, [this](device_state::Doc& doc) {
+            doc.root.props.set(irNameProp, irName_);
+            doc.root.props.set(irFileDataProp, juce::var(irData_));
+        });
+    ProjectManager::getInstance().markDirty();
+}
+
+}  // namespace magda

--- a/magda/daw/core/DeviceStateCommands.hpp
+++ b/magda/daw/core/DeviceStateCommands.hpp
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <juce_core/juce_core.h>
+
+#include "ChainNodePath.hpp"
+#include "CommandPattern.hpp"
+
+namespace magda {
+
+/**
+ * @brief Undoable authored-state edits on an internal device's state document.
+ *
+ * The model owns a device's authored state (`DeviceInfo::pluginState`, the v2
+ * document) and the engines are projections of it (#2317). An edit is a patch
+ * applied to the document through TrackManager::updateDeviceAuthoredState;
+ * undo puts the whole previous document back. The engine is never asked what
+ * it currently holds - the snapshot IS the model's document, so undo works
+ * whether or not a live plugin exists.
+ */
+
+/**
+ * @brief Load an impulse response into a convolution device.
+ *
+ * The file's bytes and display name are written into the device's state
+ * document, and the projection reloads the live convolution from them - the
+ * same route a project load takes. Undo restores the previous document (and
+ * with it the previous IR, when there was one).
+ */
+class LoadImpulseResponseCommand : public SnapshotCommand<juce::String> {
+  public:
+    LoadImpulseResponseCommand(const ChainNodePath& devicePath, const juce::String& irName,
+                               juce::MemoryBlock irData);
+
+    juce::String getDescription() const override;
+    bool canExecute() const override;
+
+  protected:
+    juce::String captureState() override;
+    void restoreState(const juce::String& state) override;
+    void performAction() override;
+
+  private:
+    ChainNodePath devicePath_;
+    juce::String irName_;
+    juce::MemoryBlock irData_;
+};
+
+}  // namespace magda

--- a/magda/daw/core/PresetManager.cpp
+++ b/magda/daw/core/PresetManager.cpp
@@ -2,6 +2,7 @@
 
 #include <filesystem>
 
+#include "../audio/plugins/DeviceStateHydration.hpp"
 #include "../media_db/MediaDbContext.hpp"
 #include "../media_db/PresetDbIndexer.hpp"
 #include "../project/serialization/ProjectSerializer.hpp"
@@ -146,9 +147,12 @@ bool writePresetFile(const juce::File& target, const juce::String& kind, const j
     return true;
 }
 
-// Parse a preset file, validate the envelope, and return the payload.
+// Parse a preset file, validate the envelope, and return the payload. The
+// envelope's magdaVersion travels out so a load can resolve the domain of a
+// pre-#2317 parameter record by the build that wrote it.
 bool readPresetFile(const juce::File& source, const juce::String& expectedKind,
-                    juce::var& outPayload, juce::String& outError) {
+                    juce::var& outPayload, juce::String& outError,
+                    juce::String* outVersion = nullptr) {
     if (!source.existsAsFile()) {
         outError = "Preset file not found: " + source.getFullPathName();
         return false;
@@ -169,6 +173,8 @@ bool readPresetFile(const juce::File& source, const juce::String& expectedKind,
     }
 
     outPayload = obj->getProperty("payload");
+    if (outVersion != nullptr)
+        *outVersion = obj->getProperty("magdaVersion").toString();
     return true;
 }
 
@@ -238,7 +244,8 @@ bool PresetManager::loadChainPreset(const juce::String& presetName,
     auto source =
         getChainsDirectory().getChildFile(sanitizeRelativePath(presetName) + kPresetExtension);
     juce::var payload;
-    if (!readPresetFile(source, kKindChain, payload, lastError_))
+    juce::String savedVersion;
+    if (!readPresetFile(source, kKindChain, payload, lastError_, &savedVersion))
         return false;
 
     if (!payload.isObject()) {
@@ -264,6 +271,9 @@ bool PresetManager::loadChainPreset(const juce::String& presetName,
     }
     legacy_devices::migrateRetiredDevicesInChain(outChainElements);
     device_param_migrations::migrateChainPreset(outChainElements);
+    namespace hydration = daw::audio::device_state_hydration;
+    hydration::hydrateChainElements(outChainElements,
+                                    hydration::provenanceFromMagdaVersion(savedVersion));
     return true;
 }
 
@@ -344,7 +354,8 @@ bool PresetManager::loadRackPreset(const juce::String& presetName, RackInfo& out
     auto source =
         getRacksDirectory().getChildFile(sanitizeRelativePath(presetName) + kPresetExtension);
     juce::var payload;
-    if (!readPresetFile(source, kKindRack, payload, lastError_))
+    juce::String savedVersion;
+    if (!readPresetFile(source, kKindRack, payload, lastError_, &savedVersion))
         return false;
 
     if (!ProjectSerializer::deserializeRackInfo(payload, outRack)) {
@@ -353,6 +364,8 @@ bool PresetManager::loadRackPreset(const juce::String& presetName, RackInfo& out
     }
     legacy_devices::migrateRetiredDevicesInRack(outRack);
     device_param_migrations::migrateRackPreset(outRack);
+    namespace hydration = daw::audio::device_state_hydration;
+    hydration::hydrateRack(outRack, hydration::provenanceFromMagdaVersion(savedVersion));
     return true;
 }
 
@@ -400,7 +413,8 @@ bool PresetManager::loadDevicePreset(const juce::String& pluginFolder,
     auto source = getDevicePluginDirectory(pluginFolder)
                       .getChildFile(sanitizeRelativePath(presetRelativePath) + kPresetExtension);
     juce::var payload;
-    if (!readPresetFile(source, kKindDevice, payload, lastError_))
+    juce::String savedVersion;
+    if (!readPresetFile(source, kKindDevice, payload, lastError_, &savedVersion))
         return false;
 
     if (!ProjectSerializer::deserializeDeviceInfo(payload, outDevice)) {
@@ -409,6 +423,9 @@ bool PresetManager::loadDevicePreset(const juce::String& pluginFolder,
     }
     legacy_devices::migrateRetiredDevice(outDevice);
     device_param_migrations::migrateDevicePreset(outDevice);
+    namespace hydration = daw::audio::device_state_hydration;
+    hydration::hydrateParametersFromDeviceState(
+        outDevice, hydration::provenanceFromMagdaVersion(savedVersion));
     return true;
 }
 

--- a/magda/daw/core/TrackManager.hpp
+++ b/magda/daw/core/TrackManager.hpp
@@ -3,6 +3,7 @@
 #include <array>
 #include <atomic>
 #include <cstdint>
+#include <functional>
 #include <map>
 #include <memory>
 #include <mutex>
@@ -11,6 +12,7 @@
 #include "ChainIdRemap.hpp"
 #include "ChainNode.hpp"
 #include "ChainPlacement.hpp"
+#include "DeviceState.hpp"
 #include "SelectionManager.hpp"
 #include "TrackInfo.hpp"
 #include "TrackTypes.hpp"
@@ -885,6 +887,32 @@ class TrackManager : public daw::audio::DeviceIdAllocator, public daw::audio::De
      * plugin identity doesn't match the live device.
      */
     bool applyDevicePreset(const ChainNodePath& devicePath, const DeviceInfo& presetDevice);
+
+    /**
+     * @brief Edit an internal device's authored (non-parameter) state on the
+     *        model, then project it into the running engine (#2317).
+     *
+     * The one write direction for authored state: @p patch edits the device's
+     * state document (`device_state::Doc`) IN THE MODEL - decoded from
+     * `DeviceInfo::pluginState`, or a fresh document when the device has none
+     * - and the result is encoded back and pushed into the live plugin, never
+     * the other way around. Never touches `Doc::params`, which no longer
+     * exists in new documents; parameters go through setDeviceParameterValue.
+     *
+     * Returns false if the path doesn't resolve to an internal device or the
+     * saved state is from a future schema (which must not be edited blind).
+     */
+    bool updateDeviceAuthoredState(const ChainNodePath& devicePath,
+                                   const std::function<void(device_state::Doc&)>& patch);
+
+    /**
+     * @brief Replace an internal device's saved state document verbatim and
+     *        project it into the running engine.
+     *
+     * The undo half of updateDeviceAuthoredState: a command snapshots
+     * `DeviceInfo::pluginState`, and this puts a snapshot back.
+     */
+    bool setDeviceAuthoredState(const ChainNodePath& devicePath, const juce::String& docText);
 
     /**
      * @brief Apply a loaded rack preset to a live rack at the given path.

--- a/magda/daw/core/TrackManagerDevices.cpp
+++ b/magda/daw/core/TrackManagerDevices.cpp
@@ -1897,6 +1897,62 @@ void TrackManager::setDeviceParameterValue(const ChainNodePath& devicePath, int 
     }
 }
 
+namespace {
+
+/// Push an internal device's state document into its running plugin, if it has
+/// one. The projection direction: the model already holds the document, the
+/// engine adapter is told to match it.
+void projectAuthoredStateToEngine(AudioEngine* audioEngine, const ChainNodePath& devicePath,
+                                  const juce::String& docText) {
+    if (audioEngine == nullptr)
+        return;
+    auto* bridge = audioEngine->getAudioBridge();
+    if (bridge == nullptr)
+        return;
+    auto plugin = bridge->getPlugin(devicePath);
+    if (plugin == nullptr)
+        return;
+
+    namespace ta = daw::audio::tracktion_adapter;
+    if (auto tree = ta::devicePluginTreeFromState(docText); tree.isValid())
+        plugin->restorePluginStateFromValueTree(tree);
+}
+
+}  // namespace
+
+bool TrackManager::updateDeviceAuthoredState(const ChainNodePath& devicePath,
+                                             const std::function<void(device_state::Doc&)>& patch) {
+    auto* device = getDeviceInChainByPath(devicePath);
+    if (device == nullptr || device->format != PluginFormat::Internal)
+        return false;
+    if (device_state::isFutureDeviceState(device->pluginState))
+        return false;
+
+    device_state::Doc doc;
+    if (auto decoded = device_state::decode(device->pluginState))
+        doc = std::move(*decoded);
+    doc.deviceType = device->pluginId;
+
+    patch(doc);
+
+    device->pluginState = device_state::encode(doc);
+    projectAuthoredStateToEngine(audioEngine_, devicePath, device->pluginState);
+    notifyDevicePropertyChanged(devicePath);
+    return true;
+}
+
+bool TrackManager::setDeviceAuthoredState(const ChainNodePath& devicePath,
+                                          const juce::String& docText) {
+    auto* device = getDeviceInChainByPath(devicePath);
+    if (device == nullptr || device->format != PluginFormat::Internal)
+        return false;
+
+    device->pluginState = docText;
+    projectAuthoredStateToEngine(audioEngine_, devicePath, device->pluginState);
+    notifyDevicePropertyChanged(devicePath);
+    return true;
+}
+
 bool TrackManager::applyDevicePreset(const ChainNodePath& devicePath,
                                      const DeviceInfo& presetDevice) {
     auto* live = getDeviceInChainByPath(devicePath);
@@ -1948,10 +2004,8 @@ bool TrackManager::applyDevicePreset(const ChainNodePath& devicePath,
                 } else {
                     namespace ta = daw::audio::tracktion_adapter;
                     auto savedState = ta::devicePluginTreeFromState(live->pluginState);
-                    if (savedState.isValid()) {
+                    if (savedState.isValid())
                         plugin->restorePluginStateFromValueTree(savedState);
-                        ta::applyDeviceStateParameters(*plugin, live->pluginState);
-                    }
                 }
             }
         }

--- a/magda/daw/core/TrackManagerDevices.cpp
+++ b/magda/daw/core/TrackManagerDevices.cpp
@@ -1964,8 +1964,25 @@ bool TrackManager::setDeviceAuthoredState(const ChainNodePath& devicePath,
     auto* device = getDeviceInChainByPath(devicePath);
     if (device == nullptr || device->format != PluginFormat::Internal)
         return false;
+    // Same contract as updateDeviceAuthoredState: state this build cannot read
+    // must not be replaced blind.
+    if (device_state::isFutureDeviceState(device->pluginState))
+        return false;
 
-    device->pluginState = docText;
+    // Canonicalize at the WRITE BOUNDARY, not per mutation path: a snapshot
+    // taken from a pre-#2317 document still carries the retired parameter
+    // record, and an undo that put it back verbatim would recreate the second
+    // authority the edit itself just eliminated. Anything decode refuses -
+    // legacy engine XML, an empty string - passes through unchanged; only a
+    // readable v2 document is stripped.
+    auto canonical = docText;
+    if (auto decoded = device_state::decode(docText)) {
+        decoded->params.clear();
+        decoded->paramsAreDisplayDomain = false;
+        canonical = device_state::encode(*decoded);
+    }
+
+    device->pluginState = canonical;
     projectAuthoredStateToEngine(audioEngine_, devicePath, device->pluginState, device->pluginId);
     notifyDevicePropertyChanged(devicePath);
     return true;

--- a/magda/daw/core/TrackManagerDevices.cpp
+++ b/magda/daw/core/TrackManagerDevices.cpp
@@ -1999,7 +1999,7 @@ bool TrackManager::applyDevicePreset(const ChainNodePath& devicePath,
                     if (live->pluginState.isNotEmpty()) {
                         applyExternalPluginChunk(plugin.get(), live->pluginState);
                         if (auto* proc = bridge->getDeviceProcessor(devicePath))
-                            proc->populateParameters(*live);
+                            proc->populateParameters(*live, DeviceProcessor::ValueSource::Engine);
                     }
                 } else {
                     namespace ta = daw::audio::tracktion_adapter;

--- a/magda/daw/core/TrackManagerDevices.cpp
+++ b/magda/daw/core/TrackManagerDevices.cpp
@@ -1903,7 +1903,7 @@ namespace {
 /// one. The projection direction: the model already holds the document, the
 /// engine adapter is told to match it.
 void projectAuthoredStateToEngine(AudioEngine* audioEngine, const ChainNodePath& devicePath,
-                                  const juce::String& docText) {
+                                  const juce::String& docText, const juce::String& deviceType) {
     if (audioEngine == nullptr)
         return;
     auto* bridge = audioEngine->getAudioBridge();
@@ -1914,8 +1914,16 @@ void projectAuthoredStateToEngine(AudioEngine* audioEngine, const ChainNodePath&
         return;
 
     namespace ta = daw::audio::tracktion_adapter;
-    if (auto tree = ta::devicePluginTreeFromState(docText); tree.isValid())
-        plugin->restorePluginStateFromValueTree(tree);
+    auto tree = ta::devicePluginTreeFromState(docText);
+    if (!tree.isValid()) {
+        // An empty snapshot is still a state: "nothing authored". Project a
+        // bare typed tree so a device whose contract reads absence as none (a
+        // convolution's impulse response) actually unloads, rather than the
+        // model saying the edit was undone while the engine keeps playing it.
+        tree = juce::ValueTree(tracktion::engine::IDs::PLUGIN);
+        tree.setProperty(tracktion::engine::IDs::type, deviceType, nullptr);
+    }
+    plugin->restorePluginStateFromValueTree(tree);
 }
 
 }  // namespace
@@ -1933,10 +1941,20 @@ bool TrackManager::updateDeviceAuthoredState(const ChainNodePath& devicePath,
         doc = std::move(*decoded);
     doc.deviceType = device->pluginId;
 
+    // A pre-#2317 document still carries the retired duplicate parameter
+    // record, and encode() writes whatever is in `params`. The record was
+    // consumed by the load-time hydration; writing it back here would leave a
+    // second persisted authority alive in every path that never passes through
+    // a Tracktion capture (preset saves, native-only sessions), free to
+    // hydrate stale values on the next load. This edit is the moment the
+    // document goes canonical.
+    doc.params.clear();
+    doc.paramsAreDisplayDomain = false;
+
     patch(doc);
 
     device->pluginState = device_state::encode(doc);
-    projectAuthoredStateToEngine(audioEngine_, devicePath, device->pluginState);
+    projectAuthoredStateToEngine(audioEngine_, devicePath, device->pluginState, device->pluginId);
     notifyDevicePropertyChanged(devicePath);
     return true;
 }
@@ -1948,7 +1966,7 @@ bool TrackManager::setDeviceAuthoredState(const ChainNodePath& devicePath,
         return false;
 
     device->pluginState = docText;
-    projectAuthoredStateToEngine(audioEngine_, devicePath, device->pluginState);
+    projectAuthoredStateToEngine(audioEngine_, devicePath, device->pluginState, device->pluginId);
     notifyDevicePropertyChanged(devicePath);
     return true;
 }

--- a/magda/daw/project/serialization/ProjectSerializer.cpp
+++ b/magda/daw/project/serialization/ProjectSerializer.cpp
@@ -8,6 +8,7 @@
 #include <set>
 #include <unordered_set>
 
+#include "../../audio/plugins/DeviceStateHydration.hpp"
 #include "../../core/AutomationManager.hpp"
 #include "../../core/ClipManager.hpp"
 #include "../../core/DeviceParamMigrations.hpp"
@@ -395,6 +396,13 @@ bool ProjectSerializer::loadAndStage(const juce::File& file, StagedProjectData& 
         pad_paths::migrateLegacyPadPaths(outData.tracks, outData.masterTrack.get(),
                                          outData.automationLanes);
 
+        // Then the retired duplicate parameter record (#2317): hydrate what
+        // the model's parameter array is missing out of the old document's
+        // `params`, once, before either engine projection is built. After the
+        // aliases and index migrations so ids and indices are current.
+        daw::audio::device_state_hydration::hydrateStagedProject(
+            outData.tracks, outData.masterTrack.get(), outData.info.version);
+
         // Parameter aliases (UserProject layer -- opaque pass-through to AliasRegistry)
         if (obj->hasProperty("paramAliases"))
             outData.info.paramAliases = obj->getProperty("paramAliases");
@@ -724,6 +732,10 @@ bool ProjectSerializer::deserializeProject(const juce::var& json, ProjectInfo& o
     // Then the pad addresses saved before pad ownership was a step type (#2219).
     pad_paths::migrateLegacyPadPaths(stagedTracks, hasMasterTrack ? &stagedMasterTrack : nullptr,
                                      stagedAutomation);
+
+    // Then the retired duplicate parameter record (#2317), same as loadAndStage.
+    daw::audio::device_state_hydration::hydrateStagedProject(
+        stagedTracks, hasMasterTrack ? &stagedMasterTrack : nullptr, outInfo.version);
 
     // Stage 2: All components validated successfully - now commit to managers atomically
     installStagedSources(stagedSources, stagedLegacySources, stagedClips);

--- a/magda/daw/ui/components/chain/custom_ui/ArpeggiatorUI.cpp
+++ b/magda/daw/ui/components/chain/custom_ui/ArpeggiatorUI.cpp
@@ -122,12 +122,7 @@ ArpeggiatorUI::ArpeggiatorUI() {
     setupSlider(cyclesSlider_, 1.0, 8.0, 1.0);
     cyclesSlider_.setValueFormatter([](double v) { return juce::String(juce::roundToInt(v)); });
     cyclesSlider_.setValueParser([](const juce::String& t) { return t.getDoubleValue(); });
-    cyclesSlider_.onValueChanged = [this](double value) {
-        if (plugin_) {
-            plugin_->rampCycles.store(juce::roundToInt(value), std::memory_order_relaxed);
-            settingsEdited();
-        }
-    };
+    cyclesSlider_.onValueChanged = [this](double) { settingsEdited(); };
 
     setupLabel(quantizeLabel_, "Q");
     setupSlider(quantizeSlider_, 0.0, 1.0, 0.01);
@@ -135,30 +130,18 @@ ArpeggiatorUI::ArpeggiatorUI() {
         [](double v) { return juce::String(juce::roundToInt(v * 100.0)) + "%"; });
     quantizeSlider_.setValueParser(
         [](const juce::String& t) { return t.trimCharactersAtEnd("%").getDoubleValue() / 100.0; });
-    quantizeSlider_.onValueChanged = [this](double value) {
-        if (plugin_) {
-            plugin_->quantize.store(static_cast<float>(value), std::memory_order_relaxed);
-            settingsEdited();
-        }
-    };
+    quantizeSlider_.onValueChanged = [this](double) { settingsEdited(); };
 
     setupLabel(quantizeSubLabel_, "SUB");
     setupSlider(quantizeSubSlider_, 16, 512, 16);
     quantizeSubSlider_.setValueFormatter(
         [](double v) { return juce::String(juce::roundToInt(v)); });
     quantizeSubSlider_.setValueParser([](const juce::String& t) { return t.getDoubleValue(); });
-    quantizeSubSlider_.onValueChanged = [this](double value) {
-        if (plugin_) {
-            plugin_->quantizeSub.store(juce::roundToInt(value), std::memory_order_relaxed);
-            settingsEdited();
-        }
-    };
+    quantizeSubSlider_.onValueChanged = [this](double) { settingsEdited(); };
 
     rampCurveDisplay_.onHardAngleChanged = [this](bool hardAngle) {
-        if (plugin_) {
-            plugin_->hardAngle.store(hardAngle, std::memory_order_relaxed);
-            settingsEdited();
-        }
+        hardAngle_ = hardAngle;
+        settingsEdited();
     };
 
     setupLabel(velModeLabel_, "VEL MODE");
@@ -198,8 +181,19 @@ void ArpeggiatorUI::sendChange(int paramIndex, float value) {
 }
 
 void ArpeggiatorUI::settingsEdited() {
-    if (onSettingsEdited)
-        onSettingsEdited();
+    if (!onSettingsEdited)
+        return;
+
+    // The full settings set, from the controls, in the device's own state
+    // vocabulary. The owner patches these onto the model's document; the
+    // device itself is updated by the projection, not by this UI.
+    using IDs = daw::audio::ArpeggiatorPlugin::SettingIDs;
+    juce::NamedValueSet settings;
+    settings.set(IDs::rampCycles, juce::roundToInt(cyclesSlider_.getValue()));
+    settings.set(IDs::quantize, static_cast<float>(quantizeSlider_.getValue()));
+    settings.set(IDs::quantizeSub, juce::roundToInt(quantizeSubSlider_.getValue()));
+    settings.set(IDs::hardAngle, hardAngle_);
+    onSettingsEdited(settings);
 }
 
 void ArpeggiatorUI::setArpeggiator(daw::audio::ArpeggiatorPlugin* device) {
@@ -223,7 +217,8 @@ void ArpeggiatorUI::syncSettingsFromDevice() {
     quantizeSubSlider_.setValue(
         static_cast<double>(plugin_->quantizeSub.load(std::memory_order_relaxed)),
         juce::dontSendNotification);
-    rampCurveDisplay_.setHardAngle(plugin_->hardAngle.load(std::memory_order_relaxed));
+    hardAngle_ = plugin_->hardAngle.load(std::memory_order_relaxed);
+    rampCurveDisplay_.setHardAngle(hardAngle_);
 }
 
 void ArpeggiatorUI::updateFromParameters(const std::vector<magda::ParameterInfo>& params) {

--- a/magda/daw/ui/components/chain/custom_ui/ArpeggiatorUI.hpp
+++ b/magda/daw/ui/components/chain/custom_ui/ArpeggiatorUI.hpp
@@ -17,8 +17,8 @@ namespace magda::daw::ui {
  * The Arpeggiator is a MagdaDevice (#2299), so this UI is written against the
  * model: slot values arrive through updateFromParameters(), slot edits leave
  * through onParameterChanged. The device pointer stays for what is not a slot -
- * the ramp-cycles / quantize / hard-angle settings the faceplate writes
- * directly, and the play-step atomics the sweep animation reads.
+ * the ramp-cycles / quantize / hard-angle settings it publishes as model
+ * document patches, and the play-step atomics the sweep animation reads.
  */
 class ArpeggiatorUI : public juce::Component, private juce::Timer {
   public:
@@ -30,11 +30,12 @@ class ArpeggiatorUI : public juce::Component, private juce::Timer {
 
     std::function<void(int paramIndex, float value)> onParameterChanged;
 
-    /// Fired after a non-slot setting (ramp cycles, quantize, subdivision,
-    /// hard angle) is written to the device, so the owner can capture the
-    /// device state into the model: the write alone reaches only the live
-    /// wrapper instance, not the project or the native engine.
-    std::function<void()> onSettingsEdited;
+    /// Fired when a non-slot setting (ramp cycles, quantize, subdivision,
+    /// hard angle) is edited, carrying ALL the settings as properties in the
+    /// device's own state vocabulary (ArpeggiatorPlugin::SettingIDs). The UI
+    /// does not write the device: the owner patches the model's state
+    /// document, and the projection updates the live device (#2317).
+    std::function<void(const juce::NamedValueSet&)> onSettingsEdited;
 
     std::vector<LinkableTextSlider*> getLinkableSliders();
 
@@ -43,6 +44,9 @@ class ArpeggiatorUI : public juce::Component, private juce::Timer {
     void resized() override;
 
   private:
+    // Mirror of the curve display's hard-angle toggle, so settingsEdited() can
+    // publish the full settings set from the controls alone.
+    bool hardAngle_ = false;
     daw::audio::ArpeggiatorPlugin* plugin_ = nullptr;
 
     // Left column

--- a/magda/daw/ui/components/chain/slot/DeviceCustomUIManager.cpp
+++ b/magda/daw/ui/components/chain/slot/DeviceCustomUIManager.cpp
@@ -34,6 +34,7 @@
 #include "audio/processors/DeviceProcessorFactory.hpp"
 #include "audio/processors/base/DeviceProcessor.hpp"
 #include "compiled/CompiledPluginPresentation.hpp"
+#include "core/DeviceStateCommands.hpp"
 #include "core/DrumGridPads.hpp"
 #include "core/MidiFileWriter.hpp"
 #include "core/PadCommands.hpp"
@@ -938,19 +939,19 @@ bool DeviceCustomUIManager::createMidiUtilityUI(const magda::DeviceInfo& device,
     if (device.pluginId.containsIgnoreCase(daw::audio::ArpeggiatorPlugin::xmlTypeName)) {
         arpeggiatorUI_ = std::make_unique<ArpeggiatorUI>();
         forwardParameterChanges(*arpeggiatorUI_, callbacks);
-        // Non-slot settings live in the device state, so an edit has to be
-        // captured into the model: that is what persists it, dirties the
-        // project, and hands the native engine's device the new values.
-        arpeggiatorUI_->onSettingsEdited = [this] {
-            auto* audioEngine = magda::TrackManager::getInstance().getAudioEngine();
-            auto* bridge = audioEngine != nullptr ? audioEngine->getAudioBridge() : nullptr;
-            if (bridge != nullptr) {
-                bridge->getPluginManager().capturePluginState(devicePath_);
-                // The capture is the model update - DeviceInfo.pluginState is
-                // what autosave writes and what the engine's device factory
-                // builds from - so the edit also has to dirty the project.
+        // Non-slot settings are authored state: the edit patches the MODEL's
+        // state document, and the projection updates the live device (#2317).
+        // The model is what autosave writes and what both engines build from,
+        // so the edit also dirties the project.
+        arpeggiatorUI_->onSettingsEdited = [this](const juce::NamedValueSet& settings) {
+            auto& tm = magda::TrackManager::getInstance();
+            const bool changed = tm.updateDeviceAuthoredState(
+                devicePath_, [&settings](magda::device_state::Doc& doc) {
+                    for (int i = 0; i < settings.size(); ++i)
+                        doc.root.props.set(settings.getName(i), settings.getValueAt(i));
+                });
+            if (changed)
                 ProjectManager::getInstance().markDirty();
-            }
         };
         parent.addAndMakeVisible(*arpeggiatorUI_);
         if (auto plugin = getLivePlugin()) {
@@ -1986,38 +1987,30 @@ bool DeviceCustomUIManager::executeImpulseResponseLoadCommand(const juce::var& a
         return false;
     }
 
-    auto* audioEngine = magda::TrackManager::getInstance().getAudioEngine();
-    if (audioEngine == nullptr) {
-        DBG("IR load: no audio engine");
-        return false;
-    }
-    auto* bridge = audioEngine->getAudioBridge();
-    if (bridge == nullptr) {
-        DBG("IR load: no audio bridge");
-        return false;
-    }
-    auto plugin = getLivePlugin();
-    if (!plugin) {
-        DBG("IR load: no plugin found for device " << devicePath_.getDeviceId());
-        return false;
-    }
-    auto* ir = daw::audio::tracktion_adapter::deviceFromPlugin<daw::audio::MagdaConvolutionPlugin>(
-        plugin.get());
-    if (ir == nullptr) {
-        DBG("IR load: plugin is not a convolution device, type: " << plugin->getName());
-        return false;
-    }
-    if (!ir->loadImpulseResponse(file)) {
-        DBG("IR load: loadImpulseResponse returned false for: " << file.getFullPathName());
+    juce::MemoryBlock raw;
+    if (!file.loadFileAsData(raw)) {
+        DBG("IR load: could not read: " << file.getFullPathName());
         return false;
     }
 
-    ir->setIrName(file.getFileNameWithoutExtension());
+    // Encode up front so an unreadable file is refused before anything is
+    // committed. The command then writes the blob into the MODEL's state
+    // document and the projection reloads the live convolution from it -
+    // the same route a project load takes (#2317). Undoable: the previous
+    // document, previous IR included, comes back as one snapshot.
+    juce::MemoryBlock encoded;
+    if (!daw::audio::MagdaConvolutionPlugin::encodeImpulseResponse(raw.getData(), raw.getSize(),
+                                                                   encoded)) {
+        DBG("IR load: not readable as audio: " << file.getFullPathName());
+        return false;
+    }
+
+    magda::UndoManager::getInstance().executeCommand(
+        std::make_unique<magda::LoadImpulseResponseCommand>(
+            devicePath_, file.getFileNameWithoutExtension(), std::move(encoded)));
+
     if (impulseResponseUI_ != nullptr)
         impulseResponseUI_->setIRName(file.getFileNameWithoutExtension());
-
-    // Capture plugin state so the IR persists in the project.
-    bridge->getPluginManager().capturePluginState(devicePath_);
     return true;
 }
 

--- a/magda/daw/ui/components/chain/slot/DeviceCustomUIManager.cpp
+++ b/magda/daw/ui/components/chain/slot/DeviceCustomUIManager.cpp
@@ -2005,9 +2005,16 @@ bool DeviceCustomUIManager::executeImpulseResponseLoadCommand(const juce::var& a
         return false;
     }
 
-    magda::UndoManager::getInstance().executeCommand(
-        std::make_unique<magda::LoadImpulseResponseCommand>(
-            devicePath_, file.getFileNameWithoutExtension(), std::move(encoded)));
+    auto command = std::make_unique<magda::LoadImpulseResponseCommand>(
+        devicePath_, file.getFileNameWithoutExtension(), std::move(encoded));
+    // Refused BEFORE it reaches the UndoManager: executeCommand records even a
+    // command whose execute() declines, which would leave a no-op undo step
+    // and a false success here.
+    if (!command->canExecute()) {
+        DBG("IR load: refused (future-schema state or not a convolution device)");
+        return false;
+    }
+    magda::UndoManager::getInstance().executeCommand(std::move(command));
 
     if (impulseResponseUI_ != nullptr)
         impulseResponseUI_->setIRName(file.getFileNameWithoutExtension());

--- a/magda/daw/ui/components/chain/slot/DeviceCustomUIManager.cpp
+++ b/magda/daw/ui/components/chain/slot/DeviceCustomUIManager.cpp
@@ -413,7 +413,7 @@ magda::DeviceInfo projectPadPluginDevice(magda::DeviceId deviceId,
     }
 
     if (auto processor = magda::createDeviceProcessorForPlugin(device.id, plugin, device.pluginId))
-        processor->populateParameters(device);
+        processor->populateParameters(device, magda::DeviceProcessor::ValueSource::Engine);
 
     return device;
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -51,6 +51,7 @@ set(TEST_SOURCES
     project/test_update_checker.cpp
     devices/test_plugin_loading.cpp
     devices/test_plugin_format.cpp
+    devices/test_device_authored_state.cpp
     devices/test_device_state_hydration.cpp
     devices/test_internal_plugin_registry.cpp
     # Engine-neutral internal device state schema v2 (issue #1887)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -51,6 +51,7 @@ set(TEST_SOURCES
     project/test_update_checker.cpp
     devices/test_plugin_loading.cpp
     devices/test_plugin_format.cpp
+    devices/test_device_state_hydration.cpp
     devices/test_internal_plugin_registry.cpp
     # Engine-neutral internal device state schema v2 (issue #1887)
     devices/test_device_state_codec.cpp

--- a/tests/PadSyncTestSupport.hpp
+++ b/tests/PadSyncTestSupport.hpp
@@ -48,10 +48,8 @@ inline daw::audio::DrumGridPlugin::PadPluginFactory padPluginFactory(
         // every internal device: a sampler is built fresh and reads its sample
         // path out of the tree it is restored with.
         if (plugin != nullptr && device.pluginState.isNotEmpty()) {
-            if (auto saved = ta::devicePluginTreeFromState(device.pluginState); saved.isValid()) {
+            if (auto saved = ta::devicePluginTreeFromState(device.pluginState); saved.isValid())
                 plugin->restorePluginStateFromValueTree(saved);
-                ta::applyDeviceStateParameters(*plugin, device.pluginState);
-            }
         }
 
         return plugin;

--- a/tests/devices/test_convolution_device_juce.cpp
+++ b/tests/devices/test_convolution_device_juce.cpp
@@ -280,11 +280,14 @@ class ConvolutionDeviceTest final : public juce::UnitTest {
         expect(doc->root.props["irFileData"].getBinaryData() != nullptr,
                "the captured state lost the impulse response");
 
+        // #2317: the document is authored state only; the low-cut travels in
+        // DeviceInfo::parameters, not here.
+        expect(doc->params.empty(), "capture wrote a duplicate parameter record");
+
         // What loading a project does: rebuild the plugin from the document.
         auto tree = ta::devicePluginTreeFromState(captured);
         expect(tree.isValid());
         auto restoredHolder = edit.getPluginCache().createNewPlugin(tree);
-        ta::applyDeviceStateParameters(*restoredHolder, captured);
 
         auto* restored = ta::deviceFromPlugin<audio::MagdaConvolutionPlugin>(restoredHolder.get());
         expect(restored != nullptr);
@@ -294,6 +297,10 @@ class ConvolutionDeviceTest final : public juce::UnitTest {
         expectEquals(restored->irName(), juce::String("Test Space"));
         expect(!restored->normalise(), "the normalise flag did not round-trip");
         expect(!restored->trimSilence());
+        // The parameter restores from the model array, the way a project load
+        // seats it (syncFromDeviceInfo), not from the document.
+        setSlotDisplayValue(*restoredHolder, *restored, audio::MagdaConvolutionPlugin::kLowCut,
+                            180.0f);
         expectWithinAbsoluteError(
             slotDisplayValue(*restoredHolder, *restored, audio::MagdaConvolutionPlugin::kLowCut),
             180.0f, 0.5f);

--- a/tests/devices/test_convolution_device_juce.cpp
+++ b/tests/devices/test_convolution_device_juce.cpp
@@ -132,6 +132,7 @@ class ConvolutionDeviceTest final : public juce::UnitTest {
         testLoadedImpulseResponseConvolves(*edit);
         testTrimSilenceReachesTheDsp(*edit);
         testImpulseResponseSurvivesSaveAndReload(*edit);
+        testRestoringAStatelessDocumentUnloadsTheImpulseResponse(*edit);
         testDryPassesThroughUntouched(*edit);
     }
 
@@ -313,6 +314,52 @@ class ConvolutionDeviceTest final : public juce::UnitTest {
                      "the reloaded device is not convolving with the saved IR");
 
         restoredHolder->deleteFromParent();
+    }
+
+    // Undoing the FIRST IR load restores a document with no `irFileData`.
+    // Absence means none (#2317 review): the device must unload - stop
+    // convolving, drop the name, and stop writing the blob back on the next
+    // flush, or capture would resurrect the "undone" IR into the model.
+    void testRestoringAStatelessDocumentUnloadsTheImpulseResponse(te::Edit& edit) {
+        beginTest("Restoring a document without an IR unloads the device");
+
+        auto irFile = writeDelayImpulseResponse();
+
+        te::Plugin::Ptr holder;
+        auto* convolution = createConvolution(edit, holder);
+        expect(convolution != nullptr);
+        if (convolution == nullptr)
+            return;
+
+        expect(convolution->loadImpulseResponse(irFile));
+        convolution->setIrName("Doomed");
+        irFile.deleteFile();
+        expect(convolution->irName() == "Doomed");
+
+        // What setDeviceAuthoredState projects for an empty snapshot: a bare
+        // typed tree, nothing authored.
+        juce::ValueTree bare(te::IDs::PLUGIN);
+        bare.setProperty(te::IDs::type, audio::MagdaConvolutionPlugin::xmlTypeName, nullptr);
+        convolution->restoreState(bare);
+
+        expect(convolution->irName().isEmpty(), "the un-loaded IR kept its name");
+        expectWithinAbsoluteError(convolution->properties().tailLengthSeconds, 0.0, 1.0e-9,
+                                  "the un-loaded IR still reports a tail");
+
+        // A capture after the unload must not resurrect the blob.
+        juce::ValueTree flushed(te::IDs::PLUGIN);
+        convolution->flushState(flushed);
+        expect(!flushed.hasProperty(te::IDs::irFileData),
+               "flush wrote an impulse response the device no longer holds");
+
+        // And the unloaded device passes signal instead of convolving.
+        setSlotDisplayValue(*holder, *convolution, audio::MagdaConvolutionPlugin::kMix, 1.0f);
+        prepareForRender(*holder);
+        const auto rendered = renderImpulse(*holder);
+        expectEquals(peakIndex(rendered), 0,
+                     "the un-loaded device is still convolving with the old IR");
+
+        holder->deleteFromParent();
     }
 
     void testDryPassesThroughUntouched(te::Edit& edit) {

--- a/tests/devices/test_device_authored_state.cpp
+++ b/tests/devices/test_device_authored_state.cpp
@@ -66,6 +66,62 @@ TEST_CASE("An authored-state edit never re-encodes the retired parameter record"
     TrackManager::getInstance().clearAllTracks();
 }
 
+TEST_CASE("Undoing an authored-state command cannot resurrect the retired record",
+          "[device-authored-state]") {
+    // The command snapshots DeviceInfo::pluginState verbatim, and a device
+    // that has not been saved since #2317 still holds a document WITH the
+    // retired `params`. The canonicalization therefore lives at the write
+    // boundary (setDeviceAuthoredState), not in the forward edit alone:
+    // execute -> undo must leave a canonical document, not the pre-#2317 one.
+    ds::Doc oldDoc;
+    oldDoc.deviceType = "magda_convolution";
+    oldDoc.params.push_back({0, "gain", 0.5f});
+    oldDoc.root.props.set(juce::Identifier("normalise"), true);
+
+    const auto path = addInternalDevice("magda_convolution", ds::encode(oldDoc));
+
+    juce::MemoryBlock blob;
+    blob.append("notrealaudio", 12);
+    LoadImpulseResponseCommand command(path, "Test IR", std::move(blob));
+    REQUIRE(command.canExecute());
+    command.execute();
+    REQUIRE(command.wasExecuted());
+
+    auto& tracks = TrackManager::getInstance();
+    const auto* device = tracks.getDeviceInChainByPath(path);
+    REQUIRE(device != nullptr);
+    {
+        const auto written = ds::decode(device->pluginState);
+        REQUIRE(written.has_value());
+        CHECK(written->params.empty());
+        CHECK(written->root.props.contains(juce::Identifier("irFileData")));
+    }
+
+    command.undo();
+    {
+        const auto restored = ds::decode(device->pluginState);
+        REQUIRE(restored.has_value());
+        CHECK(restored->params.empty());
+        CHECK_FALSE(restored->root.props.contains(juce::Identifier("irFileData")));
+        // The authored state itself came back with the snapshot.
+        CHECK(static_cast<bool>(restored->root.props[juce::Identifier("normalise")]));
+    }
+
+    tracks.clearAllTracks();
+}
+
+TEST_CASE("Snapshot replacement passes through what decode refuses", "[device-authored-state]") {
+    // Legacy engine XML is not a v2 document; a snapshot of it restores
+    // verbatim rather than being mangled into one.
+    const juce::String legacyXml = "<PLUGIN type=\"arpeggiator\" arpQuantizeSub=\"8\"/>";
+    const auto path = addInternalDevice("arpeggiator", {});
+    REQUIRE(TrackManager::getInstance().setDeviceAuthoredState(path, legacyXml));
+    const auto* device = TrackManager::getInstance().getDeviceInChainByPath(path);
+    REQUIRE(device != nullptr);
+    CHECK(device->pluginState == legacyXml);
+    TrackManager::getInstance().clearAllTracks();
+}
+
 TEST_CASE("Authored-state edits refuse what they cannot read", "[device-authored-state]") {
     const juce::String futureDoc =
         "{\"schema\": 99, \"device\": \"arpeggiator\", \"somethingNewer\": true}";

--- a/tests/devices/test_device_authored_state.cpp
+++ b/tests/devices/test_device_authored_state.cpp
@@ -1,0 +1,100 @@
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+#include "../../magda/daw/core/DeviceState.hpp"
+#include "../../magda/daw/core/DeviceStateCommands.hpp"
+#include "../../magda/daw/core/TrackManager.hpp"
+#include "../../magda/daw/core/UndoManager.hpp"
+
+using namespace magda;
+namespace ds = magda::device_state;
+
+// ============================================================================
+// #2317 — authored-state edits on the model. No live engine in this binary:
+// TrackManager has no audio engine, so the projection is skipped and what is
+// under test is exactly the model-side contract.
+// ============================================================================
+
+namespace {
+
+ChainNodePath addInternalDevice(const juce::String& pluginId, const juce::String& pluginState) {
+    auto& tracks = TrackManager::getInstance();
+    tracks.clearAllTracks();
+    UndoManager::getInstance().clearHistory();
+    const auto trackId = tracks.createTrack("Authored", TrackType::Media);
+
+    DeviceInfo device;
+    device.name = pluginId;
+    device.pluginId = pluginId;
+    device.format = PluginFormat::Internal;
+    device.pluginState = pluginState;
+    const auto deviceId = tracks.addDeviceToTrack(trackId, device);
+    REQUIRE(deviceId != INVALID_DEVICE_ID);
+    return ChainNodePath::topLevelDevice(trackId, deviceId);
+}
+
+}  // namespace
+
+TEST_CASE("An authored-state edit never re-encodes the retired parameter record",
+          "[device-authored-state]") {
+    // A pre-#2317 document still carrying its duplicate `params`. The edit is
+    // the moment the document goes canonical: hydration consumed the record at
+    // load, and writing it back would leave a second persisted authority alive
+    // in every path that never passes through a Tracktion capture.
+    ds::Doc oldDoc;
+    oldDoc.deviceType = "arpeggiator";
+    oldDoc.paramsAreDisplayDomain = true;
+    oldDoc.params.push_back({0, "pattern", 2.0f});
+    oldDoc.params.push_back({3, "gate", 0.8f});
+    oldDoc.root.props.set(juce::Identifier("arpQuantizeSub"), 16);
+
+    const auto path = addInternalDevice("arpeggiator", ds::encode(oldDoc));
+
+    static const juce::Identifier quantizeSub("arpQuantizeSub");
+    REQUIRE(TrackManager::getInstance().updateDeviceAuthoredState(
+        path, [](ds::Doc& doc) { doc.root.props.set(quantizeSub, 8); }));
+
+    const auto* device = TrackManager::getInstance().getDeviceInChainByPath(path);
+    REQUIRE(device != nullptr);
+    const auto written = ds::decode(device->pluginState);
+    REQUIRE(written.has_value());
+    CHECK(written->params.empty());
+    CHECK_FALSE(written->paramsAreDisplayDomain);
+    CHECK(static_cast<int>(written->root.props[quantizeSub]) == 8);
+    CHECK(written->deviceType == "arpeggiator");
+
+    TrackManager::getInstance().clearAllTracks();
+}
+
+TEST_CASE("Authored-state edits refuse what they cannot read", "[device-authored-state]") {
+    const juce::String futureDoc =
+        "{\"schema\": 99, \"device\": \"arpeggiator\", \"somethingNewer\": true}";
+
+    SECTION("updateDeviceAuthoredState leaves a future-schema document untouched") {
+        const auto path = addInternalDevice("arpeggiator", futureDoc);
+        CHECK_FALSE(TrackManager::getInstance().updateDeviceAuthoredState(
+            path, [](ds::Doc& doc) { doc.root.props.set(juce::Identifier("x"), 1); }));
+        const auto* device = TrackManager::getInstance().getDeviceInChainByPath(path);
+        REQUIRE(device != nullptr);
+        CHECK(device->pluginState == futureDoc);
+        TrackManager::getInstance().clearAllTracks();
+    }
+
+    SECTION("LoadImpulseResponseCommand::canExecute rejects future-schema state") {
+        const auto path = addInternalDevice("magda_convolution", futureDoc);
+        juce::MemoryBlock blob;
+        blob.append("x", 1);
+        LoadImpulseResponseCommand command(path, "Some IR", std::move(blob));
+        CHECK_FALSE(command.canExecute());
+        TrackManager::getInstance().clearAllTracks();
+    }
+
+    SECTION("LoadImpulseResponseCommand::canExecute rejects a non-convolution device") {
+        const auto path = addInternalDevice("arpeggiator", {});
+        juce::MemoryBlock blob;
+        blob.append("x", 1);
+        LoadImpulseResponseCommand command(path, "Some IR", std::move(blob));
+        CHECK_FALSE(command.canExecute());
+        TrackManager::getInstance().clearAllTracks();
+    }
+}

--- a/tests/devices/test_device_state_hydration.cpp
+++ b/tests/devices/test_device_state_hydration.cpp
@@ -1,0 +1,242 @@
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+#include "../../magda/daw/audio/plugins/ArpeggiatorPlugin.hpp"
+#include "../../magda/daw/audio/plugins/DevicePluginHandle.hpp"
+#include "../../magda/daw/audio/plugins/DeviceStateHydration.hpp"
+#include "../../magda/daw/audio/plugins/InternalPluginRegistry.hpp"
+#include "../../magda/daw/audio/plugins/MagdaDevice.hpp"
+#include "../../magda/daw/audio/plugins/SidechainPlugin.hpp"
+#include "../../magda/daw/audio/plugins/compiled/CompiledPluginRegistry.hpp"
+#include "../../magda/daw/core/DeviceState.hpp"
+#include "../../magda/daw/core/ParameterUtils.hpp"
+
+using namespace magda;
+namespace ds = magda::device_state;
+namespace hydration = magda::daw::audio::device_state_hydration;
+
+// ============================================================================
+// #2317 — one-time hydration of DeviceInfo::parameters from pre-#2317 device
+// state documents. The model array is the sole parameter authority; these are
+// the chronology rules that read every older document era into it exactly once.
+// ============================================================================
+
+namespace {
+
+DeviceInfo internalDevice(const juce::String& pluginId) {
+    DeviceInfo device;
+    device.id = 1;
+    device.format = PluginFormat::Internal;
+    device.pluginId = pluginId;
+    return device;
+}
+
+/// The display metadata the hydration itself consults, used as the oracle for
+/// normalised->display expectations.
+ParameterInfo slotMetadata(const juce::String& pluginId, int slot) {
+    const auto* spec = daw::audio::findInternalPluginSpec(pluginId);
+    REQUIRE(spec != nullptr);
+    REQUIRE(spec->createDevice != nullptr);
+    juce::ValueTree state{juce::Identifier("PLUGIN")};
+    state.setProperty(juce::Identifier("type"), pluginId, nullptr);
+    auto device = spec->createDevice({.sessionKey = {}, .state = state, .isNewPlugin = true});
+    REQUIRE(device != nullptr);
+    REQUIRE(slot < device->parameterCount());
+    return device->parameterInfo(slot);
+}
+
+const ParameterInfo* paramAt(const DeviceInfo& device, int index) {
+    return device.findParameterByIndex(index);
+}
+
+}  // namespace
+
+TEST_CASE("Hydration fills an empty model array from a marked display document",
+          "[device-state-hydration]") {
+    auto device = internalDevice(daw::audio::ArpeggiatorPlugin::xmlTypeName);
+
+    ds::Doc doc;
+    doc.deviceType = device.pluginId;
+    doc.paramsAreDisplayDomain = true;
+    doc.params.push_back({daw::audio::ArpeggiatorPlugin::kFixedVel, "fixedvel", 100.0f});
+    doc.params.push_back({daw::audio::ArpeggiatorPlugin::kGate, "gate", 0.8f});
+    device.pluginState = ds::encode(doc);
+
+    REQUIRE(hydration::hydrateParametersFromDeviceState(device));
+
+    const auto* fixedVel = paramAt(device, daw::audio::ArpeggiatorPlugin::kFixedVel);
+    REQUIRE(fixedVel != nullptr);
+    CHECK(fixedVel->currentValue == Catch::Approx(100.0f));
+    // Real metadata, not a placeholder: the plan's value layer converts through
+    // these ranges.
+    CHECK(fixedVel->maxValue > 100.0f);
+    CHECK(fixedVel->name.isNotEmpty());
+
+    const auto* gate = paramAt(device, daw::audio::ArpeggiatorPlugin::kGate);
+    REQUIRE(gate != nullptr);
+    CHECK(gate->currentValue == Catch::Approx(0.8f));
+}
+
+TEST_CASE("Hydration never overwrites a parameter the model already carries",
+          "[device-state-hydration]") {
+    auto device = internalDevice(daw::audio::ArpeggiatorPlugin::xmlTypeName);
+
+    ParameterInfo existing;
+    existing.paramIndex = daw::audio::ArpeggiatorPlugin::kFixedVel;
+    existing.name = "Fixed Vel";
+    existing.currentValue = 64.0f;
+    device.parameters.push_back(existing);
+
+    ds::Doc doc;
+    doc.deviceType = device.pluginId;
+    doc.paramsAreDisplayDomain = true;
+    doc.params.push_back({daw::audio::ArpeggiatorPlugin::kFixedVel, "fixedvel", 100.0f});
+    device.pluginState = ds::encode(doc);
+
+    REQUIRE_FALSE(hydration::hydrateParametersFromDeviceState(device));
+    CHECK(paramAt(device, daw::audio::ArpeggiatorPlugin::kFixedVel)->currentValue ==
+          Catch::Approx(64.0f));
+}
+
+TEST_CASE("An unmarked document for a device ported with the marker reads as display",
+          "[device-state-hydration]") {
+    // The #2312 six were never behind the wrapper before the marker existed, so
+    // an unmarked document can only be a capture from the retired display-ranged
+    // plugin - even when every value happens to sit inside [0, 1].
+    auto device = internalDevice(daw::audio::ArpeggiatorPlugin::xmlTypeName);
+
+    ds::Doc doc;
+    doc.deviceType = device.pluginId;
+    doc.params.push_back({daw::audio::ArpeggiatorPlugin::kGate, "gate", 0.8f});
+    device.pluginState = ds::encode(doc);
+    REQUIRE_FALSE(ds::decode(device.pluginState)->paramsAreDisplayDomain);
+
+    REQUIRE(hydration::hydrateParametersFromDeviceState(device));
+    CHECK(paramAt(device, daw::audio::ArpeggiatorPlugin::kGate)->currentValue ==
+          Catch::Approx(0.8f));
+}
+
+TEST_CASE("Unmarked two-era sidechain documents resolve released-state-first",
+          "[device-state-hydration]") {
+    // The sidechain was wrapped before the marker existed, so its unmarked
+    // documents have two eras. Any value outside [0, 1] proves the display era.
+    SECTION("a 0.19 display document is identified by its out-of-range value") {
+        auto device = internalDevice(daw::audio::SidechainPlugin::xmlTypeName);
+
+        ds::Doc doc;
+        doc.deviceType = device.pluginId;
+        doc.params.push_back({daw::audio::SidechainPlugin::kGainParamIndex, "gain", 0.8f});
+        doc.params.push_back({daw::audio::SidechainPlugin::kReleaseParamIndex, "release", 15.0f});
+        device.pluginState = ds::encode(doc);
+
+        REQUIRE(hydration::hydrateParametersFromDeviceState(device));
+        CHECK(paramAt(device, daw::audio::SidechainPlugin::kReleaseParamIndex)->currentValue ==
+              Catch::Approx(15.0f));
+        CHECK(paramAt(device, daw::audio::SidechainPlugin::kGainParamIndex)->currentValue ==
+              Catch::Approx(0.8f));
+    }
+
+    SECTION("the all-unit-interval residue reads as normalised") {
+        auto device = internalDevice(daw::audio::SidechainPlugin::xmlTypeName);
+
+        ds::Doc doc;
+        doc.deviceType = device.pluginId;
+        doc.params.push_back({daw::audio::SidechainPlugin::kAttackParamIndex, "attack", 0.5f});
+        device.pluginState = ds::encode(doc);
+
+        REQUIRE(hydration::hydrateParametersFromDeviceState(device));
+
+        const auto info =
+            slotMetadata(device.pluginId, daw::audio::SidechainPlugin::kAttackParamIndex);
+        const auto expected = ParameterUtils::normalizedToReal(0.5f, info);
+        CHECK(paramAt(device, daw::audio::SidechainPlugin::kAttackParamIndex)->currentValue ==
+              Catch::Approx(expected).margin(1.0e-3));
+    }
+
+    SECTION("pre-0.20 provenance overrides the residue rule") {
+        auto device = internalDevice(daw::audio::SidechainPlugin::xmlTypeName);
+
+        ds::Doc doc;
+        doc.deviceType = device.pluginId;
+        doc.params.push_back({daw::audio::SidechainPlugin::kAttackParamIndex, "attack", 0.5f});
+        device.pluginState = ds::encode(doc);
+
+        REQUIRE(hydration::hydrateParametersFromDeviceState(
+            device, hydration::provenanceFromMagdaVersion("0.19.2")));
+        CHECK(paramAt(device, daw::audio::SidechainPlugin::kAttackParamIndex)->currentValue ==
+              Catch::Approx(0.5f));
+    }
+}
+
+TEST_CASE("A compiled-pack document is always normalised", "[device-state-hydration]") {
+    // The compiled Faust pack's parameters were normalised slots in every era,
+    // documents included, and its documents were never marked.
+    const juce::String compiledId = "magda_utility";
+    const auto* spec = daw::audio::compiled::findCompiledPluginSpec(compiledId);
+    if (spec == nullptr || spec->createDevice == nullptr)
+        SKIP("compiled pack not linked into this test build");
+
+    auto device = internalDevice(compiledId);
+    ds::Doc doc;
+    doc.deviceType = compiledId;
+    doc.params.push_back({0, "", 0.5f});
+    device.pluginState = ds::encode(doc);
+
+    REQUIRE(hydration::hydrateParametersFromDeviceState(device));
+
+    juce::ValueTree state{juce::Identifier("PLUGIN")};
+    state.setProperty(juce::Identifier("type"), compiledId, nullptr);
+    auto sdk = spec->createDevice({.sessionKey = {}, .state = state, .isNewPlugin = true});
+    REQUIRE(sdk != nullptr);
+    const auto expected = ParameterUtils::normalizedToReal(0.5f, sdk->parameterInfo(0));
+    CHECK(paramAt(device, 0)->currentValue == Catch::Approx(expected).margin(1.0e-3));
+}
+
+TEST_CASE("Hydration leaves what it cannot read alone", "[device-state-hydration]") {
+    SECTION("the canonical params-less document is a no-op") {
+        auto device = internalDevice(daw::audio::ArpeggiatorPlugin::xmlTypeName);
+        ds::Doc doc;
+        doc.deviceType = device.pluginId;
+        doc.root.props.set(daw::audio::ArpeggiatorPlugin::SettingIDs::quantizeSub, 8);
+        device.pluginState = ds::encode(doc);
+
+        REQUIRE_FALSE(hydration::hydrateParametersFromDeviceState(device));
+        CHECK(device.parameters.empty());
+    }
+
+    SECTION("a future-schema document is not decoded") {
+        auto device = internalDevice(daw::audio::ArpeggiatorPlugin::xmlTypeName);
+        device.pluginState = juce::String("{\"schema\": 99, \"device\": \"arpeggiator\", ") +
+                             "\"params\": [{\"i\": 0, \"v\": 0.5}]}";
+
+        REQUIRE_FALSE(hydration::hydrateParametersFromDeviceState(device));
+        CHECK(device.parameters.empty());
+    }
+
+    SECTION("pre-v2 engine XML is not a document") {
+        auto device = internalDevice(daw::audio::ArpeggiatorPlugin::xmlTypeName);
+        device.pluginState = "<PLUGIN type=\"arpeggiator\" gate=\"0.4\"/>";
+
+        REQUIRE_FALSE(hydration::hydrateParametersFromDeviceState(device));
+        CHECK(device.parameters.empty());
+    }
+
+    SECTION("an external device is never touched") {
+        DeviceInfo device;
+        device.format = PluginFormat::VST3;
+        device.pluginState = "somebase64chunk";
+
+        REQUIRE_FALSE(hydration::hydrateParametersFromDeviceState(device));
+    }
+}
+
+TEST_CASE("Provenance parses the container's magdaVersion", "[device-state-hydration]") {
+    CHECK(hydration::provenanceFromMagdaVersion("0.19.2").savedBeforeWrapperCutover);
+    CHECK(hydration::provenanceFromMagdaVersion("0.7.0").savedBeforeWrapperCutover);
+    CHECK_FALSE(hydration::provenanceFromMagdaVersion("0.20.0").savedBeforeWrapperCutover);
+    CHECK_FALSE(hydration::provenanceFromMagdaVersion("0.21.3").savedBeforeWrapperCutover);
+    CHECK_FALSE(hydration::provenanceFromMagdaVersion("1.0.0").savedBeforeWrapperCutover);
+    // No version at all: nothing that old postdates the cutover.
+    CHECK(hydration::provenanceFromMagdaVersion("").savedBeforeWrapperCutover);
+    CHECK(hydration::provenanceFromMagdaVersion("unknown").savedBeforeWrapperCutover);
+}

--- a/tests/devices/test_device_state_hydration.cpp
+++ b/tests/devices/test_device_state_hydration.cpp
@@ -8,6 +8,7 @@
 #include "../../magda/daw/audio/plugins/MagdaDevice.hpp"
 #include "../../magda/daw/audio/plugins/SidechainPlugin.hpp"
 #include "../../magda/daw/audio/plugins/compiled/CompiledPluginRegistry.hpp"
+#include "../../magda/daw/core/DeviceParamMigrations.hpp"
 #include "../../magda/daw/core/DeviceState.hpp"
 #include "../../magda/daw/core/ParameterUtils.hpp"
 
@@ -228,6 +229,76 @@ TEST_CASE("Hydration leaves what it cannot read alone", "[device-state-hydration
 
         REQUIRE_FALSE(hydration::hydrateParametersFromDeviceState(device));
     }
+}
+
+TEST_CASE("A document saved against a renumbered parameter order is remapped and seeded",
+          "[device-state-hydration]") {
+    // The pre-Enabled compiled EQ: 33 slots -> 41, with the per-band Enabled
+    // switch inserted at the front of every band. The project-level migration
+    // pass matches on DeviceInfo::parameters.size(), which is empty in exactly
+    // the case hydration exists for (an old preset's document, an imported
+    // chain) - so hydration must run the record through the same table itself,
+    // or every old index lands on the wrong current slot (#2317 review).
+    const juce::String eqId = "magda_eq";
+    const auto* spec = daw::audio::compiled::findCompiledPluginSpec(eqId);
+    if (spec == nullptr || spec->createDevice == nullptr)
+        SKIP("compiled pack not linked into this test build");
+
+    const auto* migration = device_param_migrations::findMigrationForSavedCount(eqId, 33);
+    REQUIRE(migration != nullptr);
+
+    auto device = internalDevice(eqId);
+    ds::Doc doc;
+    doc.deviceType = eqId;
+    // The full 33-entry old order, normalised like every compiled document.
+    for (int i = 0; i < 33; ++i)
+        doc.params.push_back({i, "", 0.25f});
+    device.pluginState = ds::encode(doc);
+
+    REQUIRE(hydration::hydrateParametersFromDeviceState(device));
+
+    // Old band-1 slot 0 (filter type) now lives AFTER the inserted Enabled
+    // switch; nothing may sit on an old index read as a current one.
+    const auto expectedIndex = device_param_migrations::migratedParamIndex(*migration, 0);
+    REQUIRE(expectedIndex.has_value());
+    CHECK(*expectedIndex == 1);
+    CHECK(device.findParameterByIndex(*expectedIndex) != nullptr);
+
+    // The eight Enabled switches the old device did not have are seeded ON, in
+    // display units, so an old EQ keeps shaping the sound.
+    for (const auto& seed : migration->seeded) {
+        const auto* seeded = device.findParameterByIndex(seed.index);
+        REQUIRE(seeded != nullptr);
+        CHECK(seeded->currentValue == Catch::Approx(seed.value));
+    }
+}
+
+TEST_CASE("A renumbered document's dropped slots are dropped, not re-pointed",
+          "[device-state-hydration]") {
+    // The 7-slot limiter lost Hold, Mix and Autogain; their values must not
+    // land on the parameters that moved onto those indices.
+    const juce::String limiterId = "magda_limiter";
+    if (const auto* spec = daw::audio::compiled::findCompiledPluginSpec(limiterId);
+        spec == nullptr || spec->createDevice == nullptr)
+        SKIP("compiled pack not linked into this test build");
+
+    const auto* migration = device_param_migrations::findMigrationForSavedCount(limiterId, 7);
+    REQUIRE(migration != nullptr);
+
+    auto device = internalDevice(limiterId);
+    ds::Doc doc;
+    doc.deviceType = limiterId;
+    for (int i = 0; i < 7; ++i)
+        doc.params.push_back({i, "", 0.5f});
+    device.pluginState = ds::encode(doc);
+
+    REQUIRE(hydration::hydrateParametersFromDeviceState(device));
+
+    // 4 survivors (0,1,3,5 -> 0,1,2,3); the dropped Hold/Mix/Autogain must
+    // not produce entries past the new order's end or duplicates within it.
+    CHECK(device.parameters.size() == 4);
+    for (int i = 0; i < 4; ++i)
+        CHECK(device.findParameterByIndex(i) != nullptr);
 }
 
 TEST_CASE("Provenance parses the container's magdaVersion", "[device-state-hydration]") {

--- a/tests/devices/test_device_state_schema_juce.cpp
+++ b/tests/devices/test_device_state_schema_juce.cpp
@@ -9,9 +9,9 @@
 #include "magda/daw/audio/plugins/InternalPluginRegistry.hpp"
 #include "magda/daw/audio/plugins/MagdaConvolutionPlugin.hpp"
 #include "magda/daw/audio/plugins/MagdaSamplerPlugin.hpp"
-#include "magda/daw/audio/plugins/SidechainPlugin.hpp"
 #include "magda/daw/audio/plugins/tracktion/TracktionDeviceStateBridge.hpp"
 #include "magda/daw/audio/plugins/tracktion/TracktionMagdaDevicePlugin.hpp"
+#include "magda/daw/audio/processors/base/MagdaDeviceProcessor.hpp"
 #include "magda/daw/core/DeviceState.hpp"
 #include "magda/daw/core/ParameterUtils.hpp"
 #include "third_party/tracktion_engine/modules/tracktion_engine/utilities/tracktion_TestUtilities.h"
@@ -71,8 +71,7 @@ class DeviceStateSchemaTest final : public juce::UnitTest {
 
         testCaptureShape(*edit);
         testRoundTrip(*edit);
-        testDisplayDomainDocsRestore(*edit);
-        testParametersReseatByIdWhenIndexMoves(*edit);
+        testModelParametersRestoreThroughWrapper(*edit);
         testNestedDeviceSurvives(*edit);
         testBinaryPropertySurvives(*edit);
         testFutureStateIsNotOverwritten(*edit);
@@ -104,13 +103,22 @@ class DeviceStateSchemaTest final : public juce::UnitTest {
 
         expectEquals(doc->version, ds::kSchemaVersion);
         expectEquals(doc->deviceType, juce::String(audio::ArpeggiatorPlugin::xmlTypeName));
-        expect(!doc->params.empty(), "no parameters captured");
+
+        // #2317: the document carries NO parameter record. DeviceInfo::parameters
+        // is the sole persisted authority for automatable parameters.
+        expect(doc->params.empty(), "capture wrote a duplicate parameter record");
 
         // Engine-owned plugin-state facts must not survive into the document:
         // MAGDA owns each of them in DeviceInfo.
         for (const auto* engineOwned : {"id", "type", "enabled", "process", "windowX"})
             expect(!doc->root.props.contains(juce::Identifier(engineOwned)),
                    juce::String("engine-owned property leaked into the document: ") + engineOwned);
+
+        // The engine's per-parameter properties must not sneak back in as root
+        // props now that the parameter record is gone.
+        for (auto* param : plugin->getAutomatableParameters())
+            expect(!doc->root.props.contains(juce::Identifier(param->paramID)),
+                   "engine parameter property leaked into the document: " + param->paramID);
 
         plugin->deleteFromParent();
     }
@@ -124,8 +132,9 @@ class DeviceStateSchemaTest final : public juce::UnitTest {
         if (sourceArp == nullptr)
             return;
 
-        // Non-parameter property (no automatable parameter mirrors it) plus a
-        // parameter, so both halves of the document are exercised.
+        // Authored (non-parameter) settings: the document's whole payload
+        // since #2317. The parameter is moved too, to prove it does NOT travel
+        // through the document.
         sourceArp->quantizeSub = 8;
         sourceArp->hardAngle = true;
         if (auto gate = source->getAutomatableParameterByID("gate"))
@@ -143,7 +152,6 @@ class DeviceStateSchemaTest final : public juce::UnitTest {
         expect(restored != nullptr);
         if (restored == nullptr)
             return;
-        ta::applyDeviceStateParameters(*restored, state);
 
         auto* restoredArp = ta::deviceFromPlugin<audio::ArpeggiatorPlugin>(restored.get());
         expect(restoredArp != nullptr);
@@ -152,22 +160,24 @@ class DeviceStateSchemaTest final : public juce::UnitTest {
             expect(restoredArp->hardAngle.load());
         }
 
+        // The moved parameter did NOT come back from the document - parameters
+        // restore from DeviceInfo::parameters alone (seated by
+        // syncFromDeviceInfo; the model-authority test below covers it).
         if (auto gate = restored->getAutomatableParameterByID("gate"))
-            expectWithinAbsoluteError(gate->getCurrentBaseValue(), 0.42f, 0.001f);
+            expect(std::abs(gate->getCurrentBaseValue() - 0.42f) > 0.001f,
+                   "a parameter value travelled through the state document");
         else
             expect(false, "restored plugin lost its 'gate' parameter");
 
         restored->deleteFromParent();
     }
 
-    // Documents for the devices that crossed to MagdaDevice carry parameter
-    // values in the device's display domain - which is what every document
-    // captured from the retired display-ranged plugins already held. A released
-    // project's arpeggiator doc says "fixed velocity 100", and applying it to
-    // the wrapper's normalised slot has to land on 100, not clamp to the top of
-    // [0,1] (#2312 review).
-    void testDisplayDomainDocsRestore(te::Edit& edit) {
-        beginTest("A display-domain document restores through the wrapper unclamped");
+    // DeviceInfo::parameters is the sole restore source for automatable
+    // parameters (#2317), in display units. Restoring means seating the model
+    // array through the processor; the wrapper's normalised slots receive the
+    // converted values, and a recapture writes no parameter record back.
+    void testModelParametersRestoreThroughWrapper(te::Edit& edit) {
+        beginTest("Model parameters restore through the wrapper in display units");
 
         auto plugin = createPlugin(edit, audio::ArpeggiatorPlugin::xmlTypeName);
         expect(plugin != nullptr);
@@ -181,11 +191,23 @@ class DeviceStateSchemaTest final : public juce::UnitTest {
             return;
         }
 
-        ds::Doc doc;
-        doc.deviceType = audio::ArpeggiatorPlugin::xmlTypeName;
-        doc.params.push_back({audio::ArpeggiatorPlugin::kFixedVel, "fixedvel", 100.0f});
-        doc.params.push_back({audio::ArpeggiatorPlugin::kGate, "gate", 0.8f});
-        ta::applyDeviceStateParameters(*plugin, ds::encode(doc));
+        magda::MagdaDeviceProcessor processor(9001, plugin);
+        magda::DeviceInfo info;
+        info.format = magda::PluginFormat::Internal;
+        info.pluginId = audio::ArpeggiatorPlugin::xmlTypeName;
+        processor.populateParameters(info);
+
+        auto* fixedVel = info.findParameterByIndex(audio::ArpeggiatorPlugin::kFixedVel);
+        auto* gate = info.findParameterByIndex(audio::ArpeggiatorPlugin::kGate);
+        expect(fixedVel != nullptr && gate != nullptr);
+        if (fixedVel == nullptr || gate == nullptr) {
+            plugin->deleteFromParent();
+            return;
+        }
+        fixedVel->currentValue = 100.0f;  // display units: a velocity, not a fraction
+        gate->currentValue = 0.8f;
+
+        processor.syncFromDeviceInfo(info);
 
         const auto displayOf = [&](int slot, const char* id) {
             auto param = plugin->getAutomatableParameterByID(id);
@@ -198,137 +220,19 @@ class DeviceStateSchemaTest final : public juce::UnitTest {
                                   100.0f, 0.5f);
         expectWithinAbsoluteError(displayOf(audio::ArpeggiatorPlugin::kGate, "gate"), 0.8f, 0.005f);
 
-        // And the capture side writes display values back, marked as such, so
-        // the document is stable across a save/load cycle.
+        // Save writes no second copy of what the model just seated...
         const auto recaptured = ds::decode(ta::captureInternalDeviceState(*plugin, {}));
         expect(recaptured.has_value());
-        if (recaptured) {
-            expect(recaptured->paramsAreDisplayDomain,
-                   "wrapper capture did not mark the parameter domain");
-            for (const auto& saved : recaptured->params)
-                if (saved.id == "fixedvel")
-                    expectWithinAbsoluteError(saved.value, 100.0f, 0.5f);
-        }
+        if (recaptured)
+            expect(recaptured->params.empty(), "recapture wrote a duplicate parameter record");
 
-        plugin->deleteFromParent();
-
-        beginTest("An unmarked normalised document applies raw to an already-wrapped device");
-
-        // The sidechain was behind the wrapper before the domain marker
-        // existed, so its unmarked v2 documents hold normalised values and must
-        // not be reinterpreted as display: a normalised attack of 0.5 means
-        // half the knob (~25 ms), not 0.5 ms.
-        auto sidechain = createPlugin(edit, audio::SidechainPlugin::xmlTypeName);
-        expect(sidechain != nullptr);
-        if (sidechain == nullptr)
-            return;
-
-        ds::Doc sidechainDoc;
-        sidechainDoc.deviceType = audio::SidechainPlugin::xmlTypeName;
-        sidechainDoc.params.push_back({audio::SidechainPlugin::kAttackParamIndex, "attack", 0.5f});
-        expect(!ds::decode(ds::encode(sidechainDoc))->paramsAreDisplayDomain);
-        ta::applyDeviceStateParameters(*sidechain, ds::encode(sidechainDoc));
-
-        if (auto attack = sidechain->getAutomatableParameterByID("attack"))
-            expectWithinAbsoluteError(attack->getCurrentBaseValue(), 0.5f, 0.001f);
-        else
-            expect(false, "sidechain lost its 'attack' parameter");
-
-        beginTest("A v0.19 display-domain sidechain document still restores in ms");
-
-        // The other unmarked era: captured from the host-native sidechain,
-        // whose parameters ran in display ranges. The release value of 15 ms is
-        // what discriminates it - nothing normalised can sit outside [0, 1].
-        auto* sidechainDevice = ta::deviceFromPlugin<audio::SidechainPlugin>(sidechain.get());
-        expect(sidechainDevice != nullptr);
-        if (sidechainDevice == nullptr) {
-            sidechain->deleteFromParent();
-            return;
-        }
-
-        ds::Doc releasedDoc;
-        releasedDoc.deviceType = audio::SidechainPlugin::xmlTypeName;
-        releasedDoc.params.push_back({audio::SidechainPlugin::kGainParamIndex, "gain", 0.8f});
-        releasedDoc.params.push_back({audio::SidechainPlugin::kAttackParamIndex, "attack", 1.0f});
-        releasedDoc.params.push_back(
-            {audio::SidechainPlugin::kReleaseParamIndex, "release", 15.0f});
-        expect(!ds::decode(ds::encode(releasedDoc))->paramsAreDisplayDomain);
-        ta::applyDeviceStateParameters(*sidechain, ds::encode(releasedDoc));
-
-        const auto sidechainDisplay = [&](int slot, const char* id) {
-            auto param = sidechain->getAutomatableParameterByID(id);
-            expect(param != nullptr);
-            return param != nullptr
-                       ? magda::ParameterUtils::normalizedToReal(
-                             param->getCurrentBaseValue(), sidechainDevice->parameterInfo(slot))
-                       : -1.0f;
-        };
-        expectWithinAbsoluteError(
-            sidechainDisplay(audio::SidechainPlugin::kReleaseParamIndex, "release"), 15.0f, 0.1f);
-        expectWithinAbsoluteError(
-            sidechainDisplay(audio::SidechainPlugin::kAttackParamIndex, "attack"), 1.0f, 0.05f);
-        expectWithinAbsoluteError(sidechainDisplay(audio::SidechainPlugin::kGainParamIndex, "gain"),
-                                  0.8f, 0.005f);
-
-        sidechain->deleteFromParent();
-    }
-
-    // The frozen index is authoritative, and the stable id is what re-seats a
-    // value if a device ever renumbers its parameters. Round-trip tests always
-    // have the two agree, so drive them apart deliberately here.
-    void testParametersReseatByIdWhenIndexMoves(te::Edit& edit) {
-        beginTest("A saved parameter follows its id when the index no longer matches");
-
-        auto plugin = createPlugin(edit, audio::ArpeggiatorPlugin::xmlTypeName);
-        expect(plugin != nullptr);
-        if (plugin == nullptr)
-            return;
-
-        const auto& params = plugin->getAutomatableParameters();
-        expect(params.size() >= 2, "need two parameters to swap between");
-        if (params.size() < 2) {
-            plugin->deleteFromParent();
-            return;
-        }
-
-        auto gatePtr = plugin->getAutomatableParameterByID("gate");
-        expect(gatePtr != nullptr, "arpeggiator lost its 'gate' parameter");
-        if (gatePtr == nullptr) {
-            plugin->deleteFromParent();
-            return;
-        }
-        auto* gate = gatePtr.get();
-
-        const int gateIndex = params.indexOf(gate);
-        expect(gateIndex >= 0);
-        // Any in-range index that is not gate's own, so the id has to override.
-        const int wrongIndex = gateIndex == 0 ? 1 : 0;
-
-        ds::Doc doc;
-        doc.deviceType = audio::ArpeggiatorPlugin::xmlTypeName;
-        doc.params.push_back({wrongIndex, "gate", 0.31f});
-        // Also prove an out-of-range index (a parameter removed since the save)
-        // still re-seats rather than being dropped or misapplied.
-        doc.params.push_back({params.size() + 5, "gate", 0.77f});
-
-        ta::applyDeviceStateParameters(*plugin, ds::encode(doc));
-
-        // Doc values are display-domain for wrapper devices, so read the
-        // restored value back through the same conversion.
-        auto* gateDevice = ta::deviceFromPlugin<audio::ArpeggiatorPlugin>(plugin.get());
-        expect(gateDevice != nullptr);
-        if (gateDevice != nullptr)
-            expectWithinAbsoluteError(
-                magda::ParameterUtils::normalizedToReal(
-                    gate->getCurrentBaseValue(),
-                    gateDevice->parameterInfo(audio::ArpeggiatorPlugin::kGate)),
-                0.77f, 0.001f);
-
-        auto* other = params[wrongIndex];
-        expect(other != nullptr);
-        if (other != nullptr && other != gate)
-            expect(std::abs(other->getCurrentBaseValue() - 0.31f) > 0.001f,
-                   "the value landed on the parameter the stale index pointed at");
+        // ...and the model-first metadata refresh keeps the model's values
+        // rather than reading them back off the engine.
+        processor.populateParametersModelFirst(info);
+        auto* refreshed = info.findParameterByIndex(audio::ArpeggiatorPlugin::kFixedVel);
+        expect(refreshed != nullptr);
+        if (refreshed != nullptr)
+            expectWithinAbsoluteError(refreshed->currentValue, 100.0f, 0.001f);
 
         plugin->deleteFromParent();
     }

--- a/tests/devices/test_device_state_schema_juce.cpp
+++ b/tests/devices/test_device_state_schema_juce.cpp
@@ -195,7 +195,7 @@ class DeviceStateSchemaTest final : public juce::UnitTest {
         magda::DeviceInfo info;
         info.format = magda::PluginFormat::Internal;
         info.pluginId = audio::ArpeggiatorPlugin::xmlTypeName;
-        processor.populateParameters(info);
+        processor.populateParameters(info, magda::DeviceProcessor::ValueSource::Engine);
 
         auto* fixedVel = info.findParameterByIndex(audio::ArpeggiatorPlugin::kFixedVel);
         auto* gate = info.findParameterByIndex(audio::ArpeggiatorPlugin::kGate);
@@ -226,9 +226,9 @@ class DeviceStateSchemaTest final : public juce::UnitTest {
         if (recaptured)
             expect(recaptured->params.empty(), "recapture wrote a duplicate parameter record");
 
-        // ...and the model-first metadata refresh keeps the model's values
-        // rather than reading them back off the engine.
-        processor.populateParametersModelFirst(info);
+        // ...and the model-first refresh keeps the model's values rather
+        // than reading them back off the engine.
+        processor.populateParameters(info, magda::DeviceProcessor::ValueSource::Model);
         auto* refreshed = info.findParameterByIndex(audio::ArpeggiatorPlugin::kFixedVel);
         expect(refreshed != nullptr);
         if (refreshed != nullptr)

--- a/tests/devices/test_device_state_schema_juce.cpp
+++ b/tests/devices/test_device_state_schema_juce.cpp
@@ -283,6 +283,10 @@ class DeviceStateSchemaTest final : public juce::UnitTest {
         // The IR device keeps its audio in a binary property. JUCE's JSON writer
         // has no binary case, so an untagged encode emits unquoted base64 and the
         // document stops parsing entirely - the device would lose all its state.
+        // A neutral property name: `irFileData` itself is owned exactly by the
+        // device since the absent-means-none contract (flushState removes it
+        // when no IR is held), so a blob parked there behind the device's back
+        // no longer survives - any other binary property still does.
         auto plugin = createPlugin(edit, audio::MagdaConvolutionPlugin::xmlTypeName);
         expect(plugin != nullptr);
         if (plugin == nullptr)
@@ -293,7 +297,8 @@ class DeviceStateSchemaTest final : public juce::UnitTest {
             const auto byte = static_cast<char>(i & 0xff);
             payload.append(&byte, 1);
         }
-        plugin->state.setProperty(te::IDs::irFileData, juce::var(payload), nullptr);
+        static const juce::Identifier kBlobProp("testBinaryBlob");
+        plugin->state.setProperty(kBlobProp, juce::var(payload), nullptr);
 
         const auto state = ta::captureInternalDeviceState(*plugin, {});
         plugin->deleteFromParent();
@@ -303,14 +308,15 @@ class DeviceStateSchemaTest final : public juce::UnitTest {
         if (!doc)
             return;
 
-        const auto* captured = doc->root.props["irFileData"].getBinaryData();
+        const auto* captured = doc->root.props["testBinaryBlob"].getBinaryData();
         expect(captured != nullptr, "binary property did not decode as binary");
         if (captured != nullptr)
             expect(*captured == payload, "binary property changed through the round-trip");
 
         auto restoredTree = ta::devicePluginTreeFromState(state);
         expect(restoredTree.isValid());
-        const auto* restoredBlock = restoredTree.getProperty(te::IDs::irFileData).getBinaryData();
+        const auto* restoredBlock =
+            restoredTree.getProperty(juce::Identifier("testBinaryBlob")).getBinaryData();
         expect(restoredBlock != nullptr, "restored tree lost the binary property");
         if (restoredBlock != nullptr)
             expect(*restoredBlock == payload, "restored binary property does not match");

--- a/tests/devices/test_drum_grid_serialization_juce.cpp
+++ b/tests/devices/test_drum_grid_serialization_juce.cpp
@@ -15,8 +15,11 @@
 #include "magda/daw/audio/plugins/compiled/CompiledPluginRegistry.hpp"
 #include "magda/daw/audio/plugins/tracktion/TracktionDeviceStateBridge.hpp"
 #include "magda/daw/audio/plugins/tracktion/TracktionInternalPluginAdapter.hpp"
+#include "magda/daw/audio/processors/CompiledFaustProcessor.hpp"
 #include "magda/daw/core/ClipManager.hpp"
+#include "magda/daw/core/DeviceState.hpp"
 #include "magda/daw/core/DrumGridPads.hpp"
+#include "magda/daw/core/ParameterUtils.hpp"
 #include "magda/daw/core/RackInfo.hpp"
 #include "magda/daw/core/TrackManager.hpp"
 #include "magda/daw/project/ProjectManager.hpp"
@@ -212,7 +215,10 @@ class DrumGridPadChainSerializationTest final : public juce::UnitTest {
         expectEquals(built.grid->getPluginDeviceId(chain->index, 0), voiceId,
                      "The pad plugin must carry the model device's id");
 
-        // Tweak a knob, then save the way a project save does.
+        // Tweak a knob the way the app does since #2317: the model's device is
+        // the parameter authority, the plugin follows. populateParameters here
+        // stands in for the UI's model write; the state document deliberately
+        // carries no parameter record any more.
         auto* bodyPitch = kick->getAutomatableParameterByID("magda_kick_body_pitch").get();
         expect(bodyPitch != nullptr, "Kick must expose the body_pitch host parameter");
         if (bodyPitch == nullptr)
@@ -223,7 +229,13 @@ class DrumGridPadChainSerializationTest final : public juce::UnitTest {
         expect(voiceDevice != nullptr, "The pad's device must be in the model");
         if (voiceDevice == nullptr)
             return;
+        magda::CompiledFaustProcessor(voiceId, kick).populateParameters(*voiceDevice);
         capturePadDevice(*built.grid, *voiceDevice);
+
+        const auto capturedDoc = magda::device_state::decode(voiceDevice->pluginState);
+        expect(capturedDoc.has_value(), "captured pad state must be a v2 document");
+        if (capturedDoc)
+            expect(capturedDoc->params.empty(), "pad capture wrote a duplicate parameter record");
 
         DrumGridPlugin* restored = nullptr;
         auto restoredPlugin = rebuildFromModel(built, &restored);
@@ -246,12 +258,20 @@ class DrumGridPadChainSerializationTest final : public juce::UnitTest {
         expectEquals(restoredKick->getPluginType(), juce::String("magda_kick"),
                      "Reloaded pad voice must still be the compiled kick");
 
+        // What registerRackPluginProcessor does for a rebuilt pad: seat the
+        // model's parameter values on the fresh plugin. The document alone
+        // must NOT have restored them.
         auto* restoredParam =
             restoredKick->getAutomatableParameterByID("magda_kick_body_pitch").get();
         expect(restoredParam != nullptr, "Reloaded kick must expose the body_pitch parameter");
-        if (restoredParam != nullptr)
-            expectWithinAbsoluteError(restoredParam->getCurrentBaseValue(), 0.85f, 1.0e-4f,
-                                      "Tweaked kick parameter must survive the reload");
+        if (restoredParam == nullptr)
+            return;
+        expect(std::abs(restoredParam->getCurrentBaseValue() - 0.85f) > 1.0e-4f,
+               "a parameter value travelled through the pad's state document");
+
+        magda::CompiledFaustProcessor(voiceId, restoredKick).syncFromDeviceInfo(*voiceDevice);
+        expectWithinAbsoluteError(restoredParam->getCurrentBaseValue(), 0.85f, 1.0e-4f,
+                                  "Tweaked kick parameter must survive the reload");
 
         expectEquals(restored->getPluginDeviceId(restoredChain->index, 0), voiceId,
                      "Pad voice device id must survive the reload");
@@ -512,11 +532,40 @@ class DrumGridPadChainSerializationTest final : public juce::UnitTest {
             return;
         }
 
-        if (auto* bodyPitch =
-                chain->plugins[0]->getAutomatableParameterByID("magda_kick_body_pitch").get())
-            bodyPitch->setParameterFromHost(0.85f, juce::sendNotificationSync);
+        // Tweak the knob through the MODEL, the only write path since #2317:
+        // save no longer reads parameter values back off the engine, so a
+        // direct engine write would be invisible to the project.
+        auto bodyPitchParam =
+            chain->plugins[0]->getAutomatableParameterByID("magda_kick_body_pitch");
+        expect(bodyPitchParam != nullptr, "Kick must expose the body_pitch host parameter");
+        auto* padChainInfo = tm.getPadChain(devicePath, padIndex);
+        expect(padChainInfo != nullptr && !padChainInfo->elements.empty(),
+               "Kick pad chain must be in the model");
+        if (bodyPitchParam == nullptr || padChainInfo == nullptr ||
+            padChainInfo->elements.empty()) {
+            tm.clearAllTracks();
+            tm.setAudioEngine(nullptr);
+            return;
+        }
+        const int slot =
+            chain->plugins[0]->getAutomatableParameters().indexOf(bodyPitchParam.get());
+        const auto padDevicePath = magda::TrackManager::padChainPath(devicePath, padIndex)
+                                       .withDevice(magda::getDevice(padChainInfo->elements[0]).id);
+        auto* padDevInfo = tm.getDeviceInChainByPath(padDevicePath);
+        const auto* slotInfo =
+            padDevInfo != nullptr ? padDevInfo->findParameterByIndex(slot) : nullptr;
+        expect(slotInfo != nullptr, "Pad device must carry the body_pitch parameter in the model");
+        if (slotInfo == nullptr) {
+            tm.clearAllTracks();
+            tm.setAudioEngine(nullptr);
+            return;
+        }
+        tm.setDeviceParameterValue(padDevicePath, slot,
+                                   magda::ParameterUtils::normalizedToReal(0.85f, *slotInfo));
+        juce::MessageManager::getInstance()->runDispatchLoopUntil(50);
 
-        // Project save: capture plugin state into the model.
+        // Project save: capture the authored state into the model. Parameter
+        // values are already there - the model write above IS the edit.
         bridge->captureAllPluginStates();
 
         auto* devInfo = tm.getDeviceInChainByPath(devicePath);
@@ -620,9 +669,31 @@ class DrumGridPadChainSerializationTest final : public juce::UnitTest {
         auto* chain = drumGrid->getChainForNote(midiNote);
         expect(chain != nullptr, "Kick pad chain must exist before save");
         if (chain != nullptr && !chain->plugins.empty() && chain->plugins[0] != nullptr) {
-            if (auto* bodyPitch =
-                    chain->plugins[0]->getAutomatableParameterByID("magda_kick_body_pitch").get())
-                bodyPitch->setParameterFromHost(0.85f, juce::sendNotificationSync);
+            // Through the MODEL, the only write path since #2317 (see
+            // testModelReloadRestoresCompiledDrumPads).
+            auto bodyPitchParam =
+                chain->plugins[0]->getAutomatableParameterByID("magda_kick_body_pitch");
+            auto* padChainInfo = tm.getPadChain(devicePath, padIndex);
+            if (bodyPitchParam != nullptr && padChainInfo != nullptr &&
+                !padChainInfo->elements.empty()) {
+                const int slot =
+                    chain->plugins[0]->getAutomatableParameters().indexOf(bodyPitchParam.get());
+                const auto padDevicePath =
+                    magda::TrackManager::padChainPath(devicePath, padIndex)
+                        .withDevice(magda::getDevice(padChainInfo->elements[0]).id);
+                auto* padDevInfo = tm.getDeviceInChainByPath(padDevicePath);
+                const auto* slotInfo =
+                    padDevInfo != nullptr ? padDevInfo->findParameterByIndex(slot) : nullptr;
+                expect(slotInfo != nullptr,
+                       "Pad device must carry the body_pitch parameter in the model");
+                if (slotInfo != nullptr)
+                    tm.setDeviceParameterValue(
+                        padDevicePath, slot,
+                        magda::ParameterUtils::normalizedToReal(0.85f, *slotInfo));
+                juce::MessageManager::getInstance()->runDispatchLoopUntil(50);
+            } else {
+                expect(false, "Kick pad chain and parameter must be resolvable");
+            }
         }
 
         // Save the way ProjectManager does: capture states, then serialize.

--- a/tests/devices/test_drum_grid_serialization_juce.cpp
+++ b/tests/devices/test_drum_grid_serialization_juce.cpp
@@ -229,7 +229,8 @@ class DrumGridPadChainSerializationTest final : public juce::UnitTest {
         expect(voiceDevice != nullptr, "The pad's device must be in the model");
         if (voiceDevice == nullptr)
             return;
-        magda::CompiledFaustProcessor(voiceId, kick).populateParameters(*voiceDevice);
+        magda::CompiledFaustProcessor(voiceId, kick)
+            .populateParameters(*voiceDevice, magda::DeviceProcessor::ValueSource::Engine);
         capturePadDevice(*built.grid, *voiceDevice);
 
         const auto capturedDoc = magda::device_state::decode(voiceDevice->pluginState);

--- a/tests/dsp/test_faust_sidechain_juce.cpp
+++ b/tests/dsp/test_faust_sidechain_juce.cpp
@@ -120,7 +120,7 @@ class FaustSidechainTest final : public juce::UnitTest {
         magda::DeviceInfo device;
         device.canSidechain = false;
         magda::FaustProcessor processor(1929, plugin);
-        processor.populateParameters(device);
+        processor.populateParameters(device, magda::DeviceProcessor::ValueSource::Engine);
         expect(device.canSidechain, "DeviceInfo should expose the live DSP capability");
 
         constexpr int kBlockSize = 64;
@@ -196,7 +196,7 @@ class FaustSidechainTest final : public juce::UnitTest {
         expectEquals(inputs.size(), 2);
 
         device.canSidechain = true;
-        processor.populateParameters(device);
+        processor.populateParameters(device, magda::DeviceProcessor::ValueSource::Engine);
         expect(!device.canSidechain, "DeviceInfo should remove the stale capability");
 
         beginTest("A recompile is visible on the host's own parameters");

--- a/tests/project/test_legacy_corpus_migration_juce.cpp
+++ b/tests/project/test_legacy_corpus_migration_juce.cpp
@@ -183,40 +183,25 @@ class LegacyDeviceStateMigrationTest final : public juce::UnitTest {
             if (!decoded)
                 continue;
 
-            const auto live = parameterValues(*plugin);
+            // #2317: the converted document is authored state only. The
+            // parameter values a legacy project carries restore from its
+            // serialized DeviceInfo::parameters array (hydrated at load), not
+            // from this document.
+            expect(decoded->params.empty(),
+                   "conversion wrote a duplicate parameter record: " + where);
 
-            // Every parameter the document claims must be the plugin's value at
-            // that index: the index IS the contract for saved automation.
-            for (const auto& param : decoded->params) {
-                expect(param.index >= 0 && param.index < static_cast<int>(live.size()),
-                       "captured paramIndex " + juce::String(param.index) +
-                           " is out of range: " + where);
-                if (param.index < 0 || param.index >= static_cast<int>(live.size()))
-                    continue;
-                expectWithinAbsoluteError(
-                    param.value, live[static_cast<size_t>(param.index)], 1.0e-4f,
-                    "captured value differs from the live parameter: " + where + " param " +
-                        juce::String(param.index));
-            }
-
-            // Restore from the v2 document into a fresh plugin: same values.
+            // Restore from the v2 document into a fresh plugin: the authored
+            // state round-trips and a second save does not change the file.
             auto restoredTree = bridge::devicePluginTreeFromState(captured);
             expect(restoredTree.isValid(), "v2 document produced no plugin tree: " + where);
             if (restoredTree.isValid()) {
                 if (auto restored = edit->getPluginCache().createNewPlugin(restoredTree)) {
-                    bridge::applyDeviceStateParameters(*restored, captured);
                     const auto restoredValues = parameterValues(*restored);
+                    const auto live = parameterValues(*plugin);
                     expectEquals(static_cast<int>(restoredValues.size()),
                                  static_cast<int>(live.size()),
                                  "restored plugin has a different parameter count: " + where);
 
-                    const auto count = std::min(restoredValues.size(), live.size());
-                    for (size_t i = 0; i < count; ++i)
-                        expectWithinAbsoluteError(restoredValues[i], live[i], 1.0e-4f,
-                                                  "restored value differs: " + where + " param " +
-                                                      juce::String(static_cast<int>(i)));
-
-                    // Saving again must not keep changing the file.
                     const auto recaptured = bridge::captureInternalDeviceState(*restored, captured);
                     expectEquals(recaptured, captured,
                                  "a second capture differs from the first: " + where);


### PR DESCRIPTION
Closes #2317. Stacked on #2312.

`DeviceInfo::parameters` (display domain) is now the sole persisted authority for an internal device's automatable parameters, and authored state flows one way: **UI/agent command → model → Tracktion projection / native projection / serialization**.

## What changed

**Documents stop carrying parameters.** `captureInternalDeviceState` writes authored (non-parameter) state only; `encode` skips the empty record, so a v2 document without `params` is the new canonical form — old builds read it gracefully (their doc-param apply no-ops and `syncFromDeviceInfo` still seats the model array). The live parameter list is still walked at capture so the engine's per-parameter properties stay filtered out of the root.

**The bridge lost its chronology.** `applyDeviceStateParameters`, `displayDomainDeviceFor`, and the `unmarkedDocIsDisplayDomain` allowlist are deleted. Restore paths seat parameters from the model array alone (`syncFromDeviceInfo`); `TracktionDeviceStateBridge` no longer encodes any device migration history.

**One-time load hydration** (`audio/plugins/DeviceStateHydration`). Old documents that do carry `params` are consumed exactly once, at load, before either engine projection exists: entries the model array is missing are hydrated from the record, converted to display domain by the chronology rules that used to live in the bridge — the document's `paramsAreDisplayDomain` marker first, then per-device era resolution (the #2312 six read display; the pre-marker wrapped five resolve by container provenance — a project/preset `magdaVersion` < 0.20 — falling back released-state-first on the value sniff; the compiled pack is always normalised; everything else is display). Slot metadata comes from a throwaway SDK device so the plan's value layer converts through real ranges; the minimal fallback is reserved for devices the native engine can't build anyway. Model entries are never overwritten. Wired into both project staging paths (with project provenance), and device/chain/rack preset loads (with preset-envelope provenance). The duplicate record disappears on the next save because capture no longer writes one.

**Loading and saving no longer copy parameter values Tracktion → model.** `DeviceProcessor::populateParameters(info, ValueSource)` now takes a mandatory `ValueSource::Engine | Model` argument, so every call site states which way values flow — the decision this issue exists to make explicit. `Model` keeps the model's `currentValue` for any entry that still names the same parameter; only entries the model lacked (new device, added parameter, Faust recompile that changed a slot's meaning) take the engine's value, and an external device always reads `Engine` because its chunk is authoritative. The per-processor engine read became the protected `populateParametersFromEngine()` hook (NVI split across the six processors), so the policy lives in one base method. All internal registration/save/capture sites pass `Model`; seeding and external paths pass `Engine`.

**Authored-state edits are model edits.** New `TrackManager::updateDeviceAuthoredState` patches the state document *in the model* and projects it into the running engine (never capture-back). The arpeggiator faceplate's settings edits now publish `(property, value)` patches in the device's own vocabulary (`ArpeggiatorPlugin::SettingIDs`, now public) instead of writing device atomics; the convolution IR load becomes an undoable `LoadImpulseResponseCommand` (snapshot of the whole document, so undo restores the previous IR) with the FLAC encoding factored into a pure static so validation happens before anything is committed.

## Explicitly deferred (owned by their ports)

Faust source publishes, step-sequencer pattern edits, and the 4OSC agent's non-parameter extras still write the live device and capture root-only authored state back. Their inversions need the typed model slices / publish-compile designs settled in #2313, #2314, and #2315, and their parameter edits already go through the model. The 4osc agent's parameter writes were verified to go through `setDeviceParameterValue`.

## Tests

- New Catch2 suite `test_device_state_hydration.cpp`: every document era — marked display, unmarked ported-with-marker, the two unmarked sidechain eras (out-of-range proof, all-unit-interval residue, provenance override), compiled-pack normalised, the params-less canonical form, future schema, pre-v2 XML, external untouched — plus `magdaVersion` provenance parsing.
- `Device State Schema` (JUCE): capture asserts *no* parameter record and no parameter-property leak into root; new model-authority test drives display values through `syncFromDeviceInfo` into the wrapper's normalised slots and proves `populateParametersModelFirst` doesn't read values back; round-trip proves a parameter does *not* travel through the document.
- `Legacy Corpus Device State Migration` and `Convolution Device` rewritten against the authored-state-only contract (conversion writes no duplicate record; second capture still byte-stable).
- Full Catch2 suite: 3,330 cases / 740,651 assertions, 0 failures. JUCE suites green: Device State Schema, Device Param Schema Freeze, Legacy Corpus Device State Migration, Convolution Device, DrumGrid Pad Chain Serialization (its two reload tests now tweak through `setDeviceParameterValue`, the only write path that reaches a save), Master Sidechain, External Plugin State Restore, MIDI Signal Routing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
