### PR TITLE
One canonical block coordinate, derived, not projected (#2330)

### DIFF
--- a/magda/engine/clip/ClipAudioSource.cpp
+++ b/magda/engine/clip/ClipAudioSource.cpp
@@ -104,25 +104,26 @@ void ClipAudioSource::gatherSession(const TrackClipPlayback& track, const BlockI
 
     // The status is the launcher's, worked out before anything rendered
     // (SessionLauncher.hpp), so this source and the MIDI one see the same block.
-    forEachSlot(
-        *handles.get(), track, [&](const SessionSlotPlayback& slot, const SplitStatus& status) {
-            const auto play = [&](const BlockPiece& piece, int offset, int count) {
-                if (count <= 0 || !piece.origin)
-                    return;
+    forEachSlot(*handles.get(), track,
+                [&](const SessionSlotPlayback& slot, const SplitStatus& status) {
+                    const auto play = [&](const BlockPiece& piece, int offset, int count) {
+                        if (count <= 0 || !piece.origin)
+                            return;
 
-                gather(slot.audio, materialSubBlock(block, piece.range, *piece.origin, count),
-                       offset, streams, sounding, soundingCount);
-            };
+                        gather(slot.audio,
+                               materialSubBlock(block, piece.range, *piece.origin, offset, count),
+                               offset, streams, sounding, soundingCount);
+                    };
 
-            // What is on the far side of the event is not rendered. The ramp
-            // across that boundary is #2302's.
-            const auto split = splitSample(block, status);
+                    // What is on the far side of the event is not rendered. The ramp
+                    // across that boundary is #2302's.
+                    const auto split = splitSample(block, status);
 
-            play(status.beforeEvent, 0, split);
+                    play(status.beforeEvent, 0, split);
 
-            if (status.afterEvent)
-                play(*status.afterEvent, split, block.numSamples - split);
-        });
+                    if (status.afterEvent)
+                        play(*status.afterEvent, split, block.numSamples - split);
+                });
 }
 
 void ClipAudioSource::render(const BlockInfo& block, juce::dsp::AudioBlock<float> out) {

--- a/magda/engine/clip/ClipAudioSource.cpp
+++ b/magda/engine/clip/ClipAudioSource.cpp
@@ -104,26 +104,27 @@ void ClipAudioSource::gatherSession(const TrackClipPlayback& track, const BlockI
 
     // The status is the launcher's, worked out before anything rendered
     // (SessionLauncher.hpp), so this source and the MIDI one see the same block.
-    forEachSlot(*handles.get(), track,
-                [&](const SessionSlotPlayback& slot, const SplitStatus& status) {
-                    const auto play = [&](const BlockPiece& piece, int offset, int count) {
-                        if (count <= 0 || !piece.origin)
-                            return;
+    const auto renderSlot = [&](const SessionSlotPlayback& slot, const SplitStatus& status) {
+        const auto play = [&](const BlockPiece& piece, int offset, int count) {
+            if (count <= 0 || !piece.origin)
+                return;
 
-                        gather(slot.audio,
-                               materialSubBlock(block, piece.range, *piece.origin, offset, count),
-                               offset, streams, sounding, soundingCount);
-                    };
+            const auto material =
+                materialSubBlock(block, piece.range, *piece.origin, offset, count);
+            gather(slot.audio, material, offset, streams, sounding, soundingCount);
+        };
 
-                    // What is on the far side of the event is not rendered. The ramp
-                    // across that boundary is #2302's.
-                    const auto split = splitSample(block, status);
+        // What is on the far side of the event is not rendered. The ramp
+        // across that boundary is #2302's.
+        const auto split = splitSample(block, status);
 
-                    play(status.beforeEvent, 0, split);
+        play(status.beforeEvent, 0, split);
 
-                    if (status.afterEvent)
-                        play(*status.afterEvent, split, block.numSamples - split);
-                });
+        if (status.afterEvent)
+            play(*status.afterEvent, split, block.numSamples - split);
+    };
+
+    forEachSlot(*handles.get(), track, renderSlot);
 }
 
 void ClipAudioSource::render(const BlockInfo& block, juce::dsp::AudioBlock<float> out) {

--- a/magda/engine/clip/SessionPlayback.hpp
+++ b/magda/engine/clip/SessionPlayback.hpp
@@ -18,21 +18,6 @@
 
 namespace magda::engine {
 
-/**
- * @brief Where a beat inside @p block is on the block's own seconds axis.
- *
- * The block's own line, not a tempo map: it is the line sampleForBeat and
- * sampleForTime use, so a sub-range's seconds and its sample count agree.
- */
-inline double secondsWithin(const BlockInfo& block, double beat) {
-    const auto span = block.beats.end - block.beats.start;
-    if (!(span > 0.0))
-        return block.seconds.start;
-
-    return block.seconds.start +
-           (((beat - block.beats.start) / span) * (block.seconds.end - block.seconds.start));
-}
-
 /// Whether the material runs on from the last block. Material beat zero is a
 /// run beginning here (LaunchHandle::virtualStart), which is a discontinuity.
 inline bool runsOn(const BlockInfo& block, const BeatRange& range, const RunOrigin& origin) {
@@ -72,24 +57,38 @@ inline BlockInfo materialBlock(const BlockInfo& block, const BeatRange& range,
     return material;
 }
 
-/// The same, cropped to @p range and the @p count samples it fills, for a
-/// reader handed a sub-block of the output.
+/**
+ * @brief The same, cropped to the @p count samples from @p offset.
+ *
+ * Cropped by samples rather than by beats, which is the only cut that says the
+ * same thing to the reader as it does to the buffer. The seconds face comes
+ * straight off them: a block runs at one second per sample rate whatever the
+ * tempo does, so this is exact rather than a curve read off the block's own two
+ * ends (#2330).
+ */
 inline BlockInfo materialSubBlock(const BlockInfo& block, const BeatRange& range,
-                                  const RunOrigin& origin, int count) {
-    auto material = block;
+                                  const RunOrigin& origin, int offset, int count) {
+    auto material = materialBlock(block, range, origin);
     material.numSamples = count;
     material.beats = BeatRange{range.start - origin.beat, range.end - origin.beat};
-    material.seconds = SecondsRange{secondsWithin(block, range.start) - origin.seconds,
-                                    secondsWithin(block, range.end) - origin.seconds};
-    material.continuous = runsOn(block, range, origin);
-    material.runOrigin = origin;  // see materialBlock
+
+    const auto through = [&](int sample) {
+        return block.numSamples > 0
+                   ? block.seconds.start +
+                         (static_cast<double>(sample) / static_cast<double>(block.numSamples)) *
+                             block.seconds.length()
+                   : block.seconds.start;
+    };
+
+    material.seconds =
+        SecondsRange{through(offset) - origin.seconds, through(offset + count) - origin.seconds};
     return material;
 }
 
 /// Where in @p block the event landed, or the whole block when there was none.
 /// What starts a clip on its beat rather than on a callback boundary.
 inline int splitSample(const BlockInfo& block, const SplitStatus& status) {
-    return status.afterEvent ? block.sampleForBeat(status.beforeEvent.range.end) : block.numSamples;
+    return status.afterEvent ? status.event.sample : block.numSamples;
 }
 
 /**

--- a/magda/engine/launch/LaunchHandle.cpp
+++ b/magda/engine/launch/LaunchHandle.cpp
@@ -253,7 +253,7 @@ SplitStatus LaunchHandle::advanceOver(const SyncRange& range) {
     // The instant the block ran into, worked out once and in one domain. Every
     // face of it below comes off the sample it landed on, so the two halves and
     // the origin they produce cannot disagree about where the cut was (#2330).
-    const auto event = range.atMonotonicBeat(*eventBeat);
+    const auto event = range.eventAtMonotonicBeat(*eventBeat);
     status.event = event;
 
     // At or before the block's first sample: the whole block is in the new

--- a/magda/engine/launch/LaunchHandle.cpp
+++ b/magda/engine/launch/LaunchHandle.cpp
@@ -5,30 +5,6 @@
 
 namespace magda::engine {
 
-namespace {
-
-/// Where @p value, a position in @p from, falls in @p to. The two ranges are
-/// the same stretch of time in two domains, so this is how a monotonic beat
-/// becomes the timeline beat at the same instant.
-double project(const BeatRange& from, const BeatRange& to, double value) {
-    const auto span = from.length();
-    if (span <= 0.0)
-        return to.start;
-
-    return to.start + ((value - from.start) / span) * to.length();
-}
-
-/// The same, from a beat face onto a seconds one.
-double project(const BeatRange& from, const SecondsRange& to, double value) {
-    const auto span = from.length();
-    if (span <= 0.0)
-        return to.start;
-
-    return to.start + (((value - from.start) / span) * to.length());
-}
-
-}  // namespace
-
 double LaunchHandle::virtualStart(const SyncRange& piece) const {
     // Where the run would have begun on the timeline as it stands now, which
     // is not where it did begin once the timeline has wrapped or been located
@@ -131,7 +107,7 @@ std::optional<BeatRange> LaunchHandle::lastPlayedRange() const {
     return lastPlayed_;
 }
 
-void LaunchHandle::beginRun(const SyncPoint& at, double elapsedBeats, double elapsedSeconds) {
+void LaunchHandle::beginRun(const BlockInstant& at, double elapsedBeats, double elapsedSeconds) {
     if (played_)
         lastPlayed_ = played_;
 
@@ -164,7 +140,7 @@ void LaunchHandle::extendRun(const SyncRange& piece) {
     playedMonotonicSeconds_->end += piece.monotonicSeconds.length();
 }
 
-void LaunchHandle::applyEvent(bool fromPending, const SyncPoint& at) {
+void LaunchHandle::applyEvent(bool fromPending, const BlockInstant& at) {
     if (!fromPending) {
         // A loop re-trigger, which is a relaunch at the wrap: same handle, new
         // run, so the played range restarts and whatever reads it seeks.
@@ -189,9 +165,14 @@ void LaunchHandle::applyEvent(bool fromPending, const SyncPoint& at) {
     // Joining means adopting the position, not just the origin. Derived here
     // rather than at the request, which is a different number whenever the
     // launch was queued for a later beat.
-    beginRun(SyncPoint{*pending.syncedTimelineOrigin, *pending.syncedMonotonicOrigin,
-                       *pending.syncedMonotonicSecondsOrigin},
-             at.monotonicBeat - *pending.syncedMonotonicOrigin,
+    // The origin is another handle's, so it is not an instant in this block and
+    // is carried as the three faces that handle recorded rather than derived.
+    BlockInstant origin = at;
+    origin.timelineBeat = *pending.syncedTimelineOrigin;
+    origin.monotonicBeat = *pending.syncedMonotonicOrigin;
+    origin.monotonicSeconds = *pending.syncedMonotonicSecondsOrigin;
+
+    beginRun(origin, at.monotonicBeat - *pending.syncedMonotonicOrigin,
              at.monotonicSeconds - *pending.syncedMonotonicSecondsOrigin);
 }
 
@@ -217,22 +198,22 @@ SplitStatus LaunchHandle::advanceOver(const SyncRange& range) {
     // Giving way costs the wrap nothing. A stop ends the run and a launch
     // restarts it, so either way the run it would have restarted is gone before
     // the block is over.
-    std::optional<double> event;
+    std::optional<double> eventBeat;
     auto fromPending = false;
 
     if (pending_) {
         const auto& position = pending_->position;
 
         if (!position || *position <= range.monotonic.start) {
-            event = range.monotonic.start;
+            eventBeat = range.monotonic.start;
             fromPending = true;
         } else if (*position < range.monotonic.end) {
-            event = *position;
+            eventBeat = *position;
             fromPending = true;
         }
     }
 
-    if (!event && playState_ == PlayState::playing && loopBeats_ && playedMonotonic_) {
+    if (!eventBeat && playState_ == PlayState::playing && loopBeats_ && playedMonotonic_) {
         const auto origin = playedMonotonic_->start;
         const auto elapsed = range.monotonic.start - origin;
 
@@ -249,7 +230,7 @@ SplitStatus LaunchHandle::advanceOver(const SyncRange& range) {
             wrap += *loopBeats_;
 
         if (wrap < range.monotonic.end) {
-            event = wrap;
+            eventBeat = wrap;
             fromPending = false;
 
             // A second wrap inside the same block is one this cannot report.
@@ -260,7 +241,7 @@ SplitStatus LaunchHandle::advanceOver(const SyncRange& range) {
         }
     }
 
-    if (!event) {
+    if (!eventBeat) {
         if (playState_ == PlayState::playing) {
             status.beforeEvent.origin = RunOrigin{virtualStart(range), virtualStartSeconds(range)};
             extendRun(range);
@@ -268,14 +249,19 @@ SplitStatus LaunchHandle::advanceOver(const SyncRange& range) {
 
         return status;
     }
+
+    // The instant the block ran into, worked out once and in one domain. Every
+    // face of it below comes off the sample it landed on, so the two halves and
+    // the origin they produce cannot disagree about where the cut was (#2330).
+    const auto event = range.atMonotonicBeat(*eventBeat);
+    status.event = event;
 
     // At or before the block's first sample: the whole block is in the new
     // state and there is nothing to split. Reporting a split with an empty
     // first half would be the same answer in a shape every caller has to
     // defend against.
-    if (*event <= range.monotonic.start) {
-        applyEvent(fromPending, SyncPoint{range.timeline.start, range.monotonic.start,
-                                          range.monotonicSeconds.start});
+    if (event.sample <= 0) {
+        applyEvent(fromPending, range.start());
 
         if (playState_ == PlayState::playing) {
             status.beforeEvent.origin = RunOrigin{virtualStart(range), virtualStartSeconds(range)};
@@ -285,20 +271,18 @@ SplitStatus LaunchHandle::advanceOver(const SyncRange& range) {
         return status;
     }
 
-    // The instant the block ran into, on every axis: named in monotonic beats
-    // and carried across by where it falls in this block.
-    const auto splitBeat = project(range.monotonic, range.timeline, *event);
-    const auto splitSeconds = project(range.monotonic, range.seconds, *event);
-    const auto splitMonotonicSeconds = project(range.monotonic, range.monotonicSeconds, *event);
-
-    const SyncRange first{BeatRange{range.timeline.start, splitBeat},
-                          BeatRange{range.monotonic.start, *event},
-                          SecondsRange{range.seconds.start, splitSeconds},
-                          SecondsRange{range.monotonicSeconds.start, splitMonotonicSeconds}};
-    const SyncRange second{BeatRange{splitBeat, range.timeline.end},
-                           BeatRange{*event, range.monotonic.end},
-                           SecondsRange{splitSeconds, range.seconds.end},
-                           SecondsRange{splitMonotonicSeconds, range.monotonicSeconds.end}};
+    const SyncRange first{BeatRange{range.timeline.start, event.timelineBeat},
+                          BeatRange{range.monotonic.start, event.monotonicBeat},
+                          SecondsRange{range.seconds.start, event.timelineSeconds},
+                          SecondsRange{range.monotonicSeconds.start, event.monotonicSeconds},
+                          event.sample,
+                          range.tempo};
+    const SyncRange second{BeatRange{event.timelineBeat, range.timeline.end},
+                           BeatRange{event.monotonicBeat, range.monotonic.end},
+                           SecondsRange{event.timelineSeconds, range.seconds.end},
+                           SecondsRange{event.monotonicSeconds, range.monotonicSeconds.end},
+                           range.numSamples - event.sample,
+                           range.tempo};
 
     status.beforeEvent.range = first.timeline;
 
@@ -307,8 +291,7 @@ SplitStatus LaunchHandle::advanceOver(const SyncRange& range) {
         extendRun(first);
     }
 
-    applyEvent(fromPending, SyncPoint{second.timeline.start, second.monotonic.start,
-                                      second.monotonicSeconds.start});
+    applyEvent(fromPending, event);
 
     BlockPiece after;
     after.range = second.timeline;

--- a/magda/engine/launch/LaunchHandle.hpp
+++ b/magda/engine/launch/LaunchHandle.hpp
@@ -1,9 +1,12 @@
 #pragma once
 
+#include <algorithm>
+#include <cmath>
 #include <optional>
 #include <tuple>
 
 #include "core/TypeIds.hpp"
+#include "transport/TempoMap.hpp"
 #include "transport/TimeDomains.hpp"
 
 /**
@@ -48,25 +51,89 @@ struct SlotKey {
 };
 
 /**
- * @brief One block, in the four domains (TimeDomains.hpp).
+ * @brief One block, in the four domains (TimeDomains.hpp), and how to cut it.
  *
  * A queued position is named in monotonic beats; how far into its material a
  * run has got is measured in monotonic seconds. Neither is derived from the
  * other (#2324).
+ *
+ * The map comes with it, because naming an instant inside the block is the one
+ * thing a handle does that the four ranges cannot answer between them. Reading
+ * an instant off each range separately is what @ref BlockInstant exists to stop
+ * (#2330); everything here goes through @ref atSample.
  */
 struct SyncRange {
     BeatRange timeline;
     BeatRange monotonic;
     SecondsRange seconds;
     SecondsRange monotonicSeconds;
-};
 
-/// One instant, in the faces a run's origin is remembered in. Passed together
-/// so a run cannot be started with faces of different instants.
-struct SyncPoint {
-    double timelineBeat = 0.0;
-    double monotonicBeat = 0.0;
-    double monotonicSeconds = 0.0;
+    /// How many samples the block is, which is what an instant is counted in.
+    int numSamples = 0;
+
+    /// The map the block was cut from, or null for a block assembled by hand,
+    /// which is then taken to run at one tempo.
+    const TempoMap* tempo = nullptr;
+
+    /**
+     * @brief The instant @p sample sounds at, in every domain.
+     *
+     * The seconds faces are exact rather than nearly so: a block runs at one
+     * second per sample rate whatever the tempo is doing, so both of them are
+     * straight lines and not approximations of a curve.
+     *
+     * The beat face is the map's, because the block's own two beat ends are a
+     * straight line and the map between them is not. What is left linear is
+     * monotonic against timeline beats, and that one is exact: what makes the
+     * two differ is a wrap, and a wrap ends a block.
+     */
+    BlockInstant atSample(int sample) const {
+        BlockInstant at;
+        at.sample = std::clamp(sample, 0, numSamples);
+
+        const auto through =
+            numSamples > 0 ? static_cast<double>(at.sample) / static_cast<double>(numSamples) : 0.0;
+
+        at.timelineSeconds = seconds.start + through * seconds.length();
+        at.monotonicSeconds = monotonicSeconds.start + through * monotonicSeconds.length();
+
+        at.timelineBeat = tempo != nullptr ? tempo->timeToBeat(at.timelineSeconds)
+                                           : timeline.start + through * timeline.length();
+
+        at.monotonicBeat = monotonic.start + (at.timelineBeat - timeline.start);
+        return at;
+    }
+
+    /// The instant the block begins on.
+    BlockInstant start() const {
+        return atSample(0);
+    }
+
+    /**
+     * @brief The instant @p beat falls on, snapped to the sample it sounds on.
+     *
+     * Snapped, and then every face taken from that sample rather than from the
+     * beat that asked: a launch happens on a sample or it does not happen, and
+     * the faces of the beat it was asked for are the faces of a moment between
+     * two samples that nothing plays.
+     */
+    BlockInstant atMonotonicBeat(double beat) const {
+        if (numSamples <= 0 || seconds.empty())
+            return start();
+
+        const auto timelineBeat = timeline.start + (beat - monotonic.start);
+
+        const auto at =
+            tempo != nullptr
+                ? tempo->beatToTime(timelineBeat)
+                : seconds.start + (timeline.empty()
+                                       ? 0.0
+                                       : ((timelineBeat - timeline.start) / timeline.length()) *
+                                             seconds.length());
+
+        const auto through = (at - seconds.start) / seconds.length();
+        return atSample(static_cast<int>(std::lround(through * numSamples)));
+    }
 };
 
 /// One piece of a block. A piece sounds exactly when there is a run behind it,
@@ -104,6 +171,11 @@ struct SplitStatus {
     /// What was left after it. Absent rather than empty, so a caller cannot
     /// read a piece that was never played.
     std::optional<BlockPiece> afterEvent;
+
+    /// Where the cut is, when @ref afterEvent says there was one. The sample
+    /// the block ran into its event on, so a caller starts the clip there
+    /// rather than working the position out a second time and differently.
+    BlockInstant event;
 
     /// Whether the slot is sounding when the block ends, which is what decides
     /// whether a stop owes note-offs.
@@ -240,7 +312,7 @@ class LaunchHandle {
 
     /// Begin a run at @p at, already @p elapsedBeats and @p elapsedSeconds into
     /// itself. Non-zero only for a synced launch, which joins a run.
-    void beginRun(const SyncPoint& at, double elapsedBeats = 0.0, double elapsedSeconds = 0.0);
+    void beginRun(const BlockInstant& at, double elapsedBeats = 0.0, double elapsedSeconds = 0.0);
     void endRun();
 
     /// Carry the current run through @p piece without changing state.
@@ -251,7 +323,7 @@ class LaunchHandle {
     double virtualStartSeconds(const SyncRange& piece) const;
 
     /// Apply whatever the block ran into, at the instant it ran into it.
-    void applyEvent(bool fromPending, const SyncPoint& at);
+    void applyEvent(bool fromPending, const BlockInstant& at);
 
     /// The advance itself, wrapped so @ref blockStatus is stored in one place.
     SplitStatus advanceOver(const SyncRange& range);

--- a/magda/engine/launch/LaunchHandle.hpp
+++ b/magda/engine/launch/LaunchHandle.hpp
@@ -78,6 +78,12 @@ struct SyncRange {
     /**
      * @brief The instant @p sample sounds at, in every domain.
      *
+     * An edge rather than an event: one past the end of the block is a legal
+     * answer here, the way it is for RenderContext::sampleForTime, because a
+     * range that runs to the end of the block ends at the sample after the last
+     * one. An event has to land on a sample the block actually has, which is
+     * @ref eventAtMonotonicBeat.
+     *
      * The seconds faces are exact rather than nearly so: a block runs at one
      * second per sample rate whatever the tempo is doing, so both of them are
      * straight lines and not approximations of a curve.
@@ -110,14 +116,21 @@ struct SyncRange {
     }
 
     /**
-     * @brief The instant @p beat falls on, snapped to the sample it sounds on.
+     * @brief The instant @p beat falls on, as an event this block can carry.
      *
-     * Snapped, and then every face taken from that sample rather than from the
-     * beat that asked: a launch happens on a sample or it does not happen, and
-     * the faces of the beat it was asked for are the faces of a moment between
-     * two samples that nothing plays.
+     * Snapped to a sample, and then every face taken from that sample rather
+     * than from the beat that asked: a launch happens on a sample or it does
+     * not happen, and the faces of the beat it was asked for are the faces of a
+     * moment between two samples that nothing plays.
+     *
+     * Never one past the end, which is where a beat in the block's last half
+     * sample rounds to. That sample belongs to the next callback, and an event
+     * placed there is written nowhere: a stop would clear its own note state
+     * while its note-offs went to an offset outside the buffer, and the notes
+     * would hang. The block's last sample instead, which is at most one sample
+     * early and is a sample that plays.
      */
-    BlockInstant atMonotonicBeat(double beat) const {
+    BlockInstant eventAtMonotonicBeat(double beat) const {
         if (numSamples <= 0 || seconds.empty())
             return start();
 
@@ -132,7 +145,8 @@ struct SyncRange {
                                              seconds.length());
 
         const auto through = (at - seconds.start) / seconds.length();
-        return atSample(static_cast<int>(std::lround(through * numSamples)));
+        const auto sample = static_cast<int>(std::lround(through * numSamples));
+        return atSample(std::min(sample, numSamples - 1));
     }
 };
 

--- a/magda/engine/launch/SessionLauncher.hpp
+++ b/magda/engine/launch/SessionLauncher.hpp
@@ -93,7 +93,8 @@ class LaunchHandleFeed {
 /// The block as the launcher names it: all four faces, from the one place they
 /// were derived together (RenderContext.hpp).
 inline SyncRange syncRangeFor(const BlockInfo& block) {
-    return SyncRange{block.beats, block.monotonicBeats, block.seconds, block.monotonicSeconds};
+    return SyncRange{block.beats,      block.monotonicBeats, block.seconds, block.monotonicSeconds,
+                     block.numSamples, block.tempo};
 }
 
 /// Advance every handle over @p block, once, before anything renders. On the

--- a/magda/engine/transport/TimeDomains.hpp
+++ b/magda/engine/transport/TimeDomains.hpp
@@ -47,6 +47,36 @@ struct SecondsRange {
 };
 
 /**
+ * @brief One instant inside a block, in every domain the engine names it in.
+ *
+ * Built from one coordinate and one only: the sample. Every face below is
+ * derived from it through the tempo map, so the five of them are one instant
+ * rather than five answers that happen to be near each other.
+ *
+ * That is the whole point of the type. The domains are related by the map,
+ * which is not a straight line, and projecting an instant onto each axis
+ * separately gives a set of faces no single moment has: over a steep ramp the
+ * beat face and the seconds face of one "instant" can be 163 samples apart.
+ * Anything built from those faces inherits the gap, and a run whose origin has
+ * it starts its material somewhere it was never placed (#2330).
+ *
+ * The sample is canonical because it is the one coordinate that is not a
+ * matter of interpretation: it is what plays.
+ */
+struct BlockInstant {
+    /// Offset within the block. What actually sounds at this instant.
+    int sample = 0;
+
+    double timelineBeat = 0.0;
+    double timelineSeconds = 0.0;
+
+    /// The faces that never go back, which is what a queued launch is named in
+    /// and what a run's elapsed material is measured in (#2324).
+    double monotonicBeat = 0.0;
+    double monotonicSeconds = 0.0;
+};
+
+/**
  * @brief Where a run began, in the two domains a source reads it against.
  *
  * One value, because a run whose faces came from different instants would put a

--- a/tests/engine/test_launch_handle.cpp
+++ b/tests/engine/test_launch_handle.cpp
@@ -50,6 +50,29 @@ SyncRange wrapped(double from, double to, double monotonicFrom, double monotonic
 
 }  // namespace
 
+TEST_CASE("An event in the block's last half sample stays inside the block", "[launch]") {
+    // A beat nearer the next callback's first sample than this one's last
+    // rounds past the end of the block. Applied there, the event happens but
+    // nothing can carry it: a stop would clear its own note state while its
+    // note-offs went to an offset outside the buffer, and the notes would hang.
+    LaunchHandle handle;
+
+    const auto range = block(0.0, 1.0);
+    const auto lastSample = range.numSamples - 1;
+
+    // Inside the beat range, and within half a sample of its end.
+    handle.play(1.0 - (0.4 / range.numSamples));
+
+    const auto status = handle.advance(range);
+
+    REQUIRE(status.afterEvent.has_value());
+
+    // On the block's last sample: at most one sample early, and a sample that
+    // plays. Never numSamples, which belongs to the next callback.
+    CHECK(status.event.sample == lastSample);
+    CHECK(status.event.sample < range.numSamples);
+}
+
 TEST_CASE("A handle starts stopped and having played nothing", "[launch]") {
     LaunchHandle handle;
 

--- a/tests/engine/test_launch_handle.cpp
+++ b/tests/engine/test_launch_handle.cpp
@@ -22,19 +22,30 @@ namespace {
 /// 120 bpm, the tempo every case here runs at.
 constexpr double kSecondsPerBeat = 0.5;
 
+constexpr double kSampleRate = 48000.0;
+
+/// How many samples a stretch of beats is at that tempo. A block carries its
+/// sample count because an instant inside it is named in samples: that is the
+/// one coordinate every other is derived from (#2330).
+constexpr int samplesFor(double beats) {
+    return static_cast<int>(beats * kSecondsPerBeat * kSampleRate);
+}
+
 /// One block, in all four faces, with the timeline and monotonic clocks running
 /// together. They diverge only when something wraps the timeline.
 SyncRange block(double from, double to) {
     return SyncRange{BeatRange{from, to}, BeatRange{from, to},
                      SecondsRange{from * kSecondsPerBeat, to * kSecondsPerBeat},
-                     SecondsRange{from * kSecondsPerBeat, to * kSecondsPerBeat}};
+                     SecondsRange{from * kSecondsPerBeat, to * kSecondsPerBeat},
+                     samplesFor(to - from)};
 }
 
 /// A block the timeline has wrapped under.
 SyncRange wrapped(double from, double to, double monotonicFrom, double monotonicTo) {
     return SyncRange{BeatRange{from, to}, BeatRange{monotonicFrom, monotonicTo},
                      SecondsRange{from * kSecondsPerBeat, to * kSecondsPerBeat},
-                     SecondsRange{monotonicFrom * kSecondsPerBeat, monotonicTo * kSecondsPerBeat}};
+                     SecondsRange{monotonicFrom * kSecondsPerBeat, monotonicTo * kSecondsPerBeat},
+                     samplesFor(monotonicTo - monotonicFrom)};
 }
 
 }  // namespace

--- a/tests/engine/test_session_playback.cpp
+++ b/tests/engine/test_session_playback.cpp
@@ -807,6 +807,52 @@ void callback(AudioRig& rig, magda::engine::TransportClock& clock,
 
 }  // namespace
 
+TEST_CASE("A launch inside a block that spans a tempo step names one instant",
+          "[engine][clip][session]") {
+    // The invariant #2330 is about, asserted on a block the clock would no
+    // longer hand out: built by hand so it spans the step, which is exactly the
+    // shape that used to produce an origin with two faces of different moments.
+    //
+    // The cut and this are two answers to the same leak, and only this one
+    // closes the class: whatever a block spans, an instant inside it is worked
+    // out once, in samples, and every face derived from that.
+    const auto map = steppedTempo();  // 120 to beat 4, then 60
+
+    // Half a block either side of the step, at 120 throughout its first half.
+    const auto from = map.beatToTime(4.0) - (kBlockSize / kSampleRate / 2.0);
+
+    magda::engine::BlockInfo block;
+    block.numSamples = kBlockSize;
+    block.playing = true;
+    block.continuous = true;
+    block.seconds = {from, from + (kBlockSize / kSampleRate)};
+    block.beats = {map.timeToBeat(block.seconds.start), map.timeToBeat(block.seconds.end)};
+    block.monotonicBeats = block.beats;
+    block.monotonicSeconds = block.seconds;
+    block.tempo = &map;
+
+    LaunchHandle handle;
+    handle.play(map.timeToBeat(map.beatToTime(4.0)));  // the step itself
+
+    const auto status = handle.advance(magda::engine::syncRangeFor(block));
+
+    REQUIRE(status.afterEvent.has_value());
+    REQUIRE(status.afterEvent->origin.has_value());
+
+    const auto origin = *status.afterEvent->origin;
+
+    // The two faces of a fresh run's origin are the two faces of one sample.
+    // Projected separately they are not: the beat lands where the block's
+    // straight line puts it and the seconds where its other line does, and
+    // across a step those are different moments.
+    CHECK(map.timeToBeat(origin.seconds) == Approx(origin.beat));
+
+    // Which is what the material needs: second zero of the run is beat zero of
+    // it, so an auto-tempo reader starts at the head of its file.
+    const auto material = magda::engine::materialBlock(block, status.afterEvent->range, origin);
+    CHECK(material.beatAtTime(0.0) == Approx(0.0));
+}
+
 TEST_CASE("A slot launched where a block would step tempo starts at its own first sample",
           "[engine][clip][session]") {
     // The launch and the tempo step want the same instant inside one callback.


### PR DESCRIPTION
Closes #2330. Stacked on #2325, and the structural answer to the two review findings there rather than a third patch on top of them.

## The leak

`SyncRange` carries four axes and `advanceOver` read the event off each of them separately, by linear interpolation. That produces one coherent instant only while every mapping is affine across the whole block, which is why the same defect surfaced twice in review: first at an explicit tempo step, then at a baked ramp-section boundary. Cutting blocks closed both cases without closing the class.

## One coordinate

`BlockInstant` is built from a sample and nothing else. Every other face is derived from that one number:

- the two seconds faces exactly, since a block runs at one second per sample rate whatever the tempo does;
- the timeline beat through the map, rather than along the block's own straight line;
- the monotonic beat off the timeline beat, which is exact inside a block because what makes the two differ is a wrap, and a wrap ends a block.

`SyncRange` carries the map and the sample count so it can build one. A launch quantized to a beat is snapped to the sample it sounds on *before* any face is read: a launch happens on a sample or it does not happen, and the faces of the beat that asked belong to a moment between two samples that nothing plays.

## What it buys

The origin. A fresh run's `RunOrigin` is now the two faces of one sample instead of two projections that agree only under one tempo, so material second zero is material beat zero and an auto-tempo clip starts at the head of its file.

On a block spanning a 120 to 60 step the old pair put the run's origin at beat 4 and 2.020833 s, where the map puts beat 4 at 2. The material began a fiftieth of a beat in, about 500 samples at 120 bpm, and that much of every launched clip's attack was skipped.

`SyncPoint` goes, having been the three-faced version of the same idea. `materialSubBlock` crops by samples rather than by a beat read off the block's line, and `splitSample` reads the instant the launcher already resolved instead of working the position out a second time and differently.

## On the section cut

#2325's cut stays. It is no longer what makes the launch path correct, but it is still what keeps `sampleForBeat` honest for everything else placed inside a block, MIDI note placement above all. Removing it is a separate question with its own evidence, and the clock's affine tests are there to answer it when someone asks.

## Testing

The new case asserts the invariant on a block built by hand to span a step, which is a shape the clock no longer produces, so it holds whatever the clock does. Under the old projection it fails at 4.020833 against 4, and `beatAtTime(0)` at 0.020833 against 0.

Full Catch2 suite green locally: 3376 passed, 13 skipped for plugins absent from this machine, 0 failures. The JUCE suite passes, including the real-project corpus through both engines, and the app builds.

https://claude.ai/code/session_013CDpSHas8bog33vv4o6HLv