### PR TITLE
One canonical block coordinate, derived, not projected (#2330)

### DIFF
--- a/magda/engine/clip/ClipAudioSource.cpp
+++ b/magda/engine/clip/ClipAudioSource.cpp
@@ -104,25 +104,26 @@ void ClipAudioSource::gatherSession(const TrackClipPlayback& track, const BlockI
 
     // The status is the launcher's, worked out before anything rendered
     // (SessionLauncher.hpp), so this source and the MIDI one see the same block.
-    forEachSlot(
-        *handles.get(), track, [&](const SessionSlotPlayback& slot, const SplitStatus& status) {
-            const auto play = [&](const BlockPiece& piece, int offset, int count) {
-                if (count <= 0 || !piece.origin)
-                    return;
+    forEachSlot(*handles.get(), track,
+                [&](const SessionSlotPlayback& slot, const SplitStatus& status) {
+                    const auto play = [&](const BlockPiece& piece, int offset, int count) {
+                        if (count <= 0 || !piece.origin)
+                            return;
 
-                gather(slot.audio, materialSubBlock(block, piece.range, *piece.origin, count),
-                       offset, streams, sounding, soundingCount);
-            };
+                        gather(slot.audio,
+                               materialSubBlock(block, piece.range, *piece.origin, offset, count),
+                               offset, streams, sounding, soundingCount);
+                    };
 
-            // What is on the far side of the event is not rendered. The ramp
-            // across that boundary is #2302's.
-            const auto split = splitSample(block, status);
+                    // What is on the far side of the event is not rendered. The ramp
+                    // across that boundary is #2302's.
+                    const auto split = splitSample(block, status);
 
-            play(status.beforeEvent, 0, split);
+                    play(status.beforeEvent, 0, split);
 
-            if (status.afterEvent)
-                play(*status.afterEvent, split, block.numSamples - split);
-        });
+                    if (status.afterEvent)
+                        play(*status.afterEvent, split, block.numSamples - split);
+                });
 }
 
 void ClipAudioSource::render(const BlockInfo& block, juce::dsp::AudioBlock<float> out) {

--- a/magda/engine/clip/ClipAudioSource.cpp
+++ b/magda/engine/clip/ClipAudioSource.cpp
@@ -104,26 +104,27 @@ void ClipAudioSource::gatherSession(const TrackClipPlayback& track, const BlockI
 
     // The status is the launcher's, worked out before anything rendered
     // (SessionLauncher.hpp), so this source and the MIDI one see the same block.
-    forEachSlot(*handles.get(), track,
-                [&](const SessionSlotPlayback& slot, const SplitStatus& status) {
-                    const auto play = [&](const BlockPiece& piece, int offset, int count) {
-                        if (count <= 0 || !piece.origin)
-                            return;
+    const auto renderSlot = [&](const SessionSlotPlayback& slot, const SplitStatus& status) {
+        const auto play = [&](const BlockPiece& piece, int offset, int count) {
+            if (count <= 0 || !piece.origin)
+                return;
 
-                        gather(slot.audio,
-                               materialSubBlock(block, piece.range, *piece.origin, offset, count),
-                               offset, streams, sounding, soundingCount);
-                    };
+            const auto material =
+                materialSubBlock(block, piece.range, *piece.origin, offset, count);
+            gather(slot.audio, material, offset, streams, sounding, soundingCount);
+        };
 
-                    // What is on the far side of the event is not rendered. The ramp
-                    // across that boundary is #2302's.
-                    const auto split = splitSample(block, status);
+        // What is on the far side of the event is not rendered. The ramp
+        // across that boundary is #2302's.
+        const auto split = splitSample(block, status);
 
-                    play(status.beforeEvent, 0, split);
+        play(status.beforeEvent, 0, split);
 
-                    if (status.afterEvent)
-                        play(*status.afterEvent, split, block.numSamples - split);
-                });
+        if (status.afterEvent)
+            play(*status.afterEvent, split, block.numSamples - split);
+    };
+
+    forEachSlot(*handles.get(), track, renderSlot);
 }
 
 void ClipAudioSource::render(const BlockInfo& block, juce::dsp::AudioBlock<float> out) {

--- a/magda/engine/clip/SessionPlayback.hpp
+++ b/magda/engine/clip/SessionPlayback.hpp
@@ -18,21 +18,6 @@
 
 namespace magda::engine {
 
-/**
- * @brief Where a beat inside @p block is on the block's own seconds axis.
- *
- * The block's own line, not a tempo map: it is the line sampleForBeat and
- * sampleForTime use, so a sub-range's seconds and its sample count agree.
- */
-inline double secondsWithin(const BlockInfo& block, double beat) {
-    const auto span = block.beats.end - block.beats.start;
-    if (!(span > 0.0))
-        return block.seconds.start;
-
-    return block.seconds.start +
-           (((beat - block.beats.start) / span) * (block.seconds.end - block.seconds.start));
-}
-
 /// Whether the material runs on from the last block. Material beat zero is a
 /// run beginning here (LaunchHandle::virtualStart), which is a discontinuity.
 inline bool runsOn(const BlockInfo& block, const BeatRange& range, const RunOrigin& origin) {
@@ -72,24 +57,38 @@ inline BlockInfo materialBlock(const BlockInfo& block, const BeatRange& range,
     return material;
 }
 
-/// The same, cropped to @p range and the @p count samples it fills, for a
-/// reader handed a sub-block of the output.
+/**
+ * @brief The same, cropped to the @p count samples from @p offset.
+ *
+ * Cropped by samples rather than by beats, which is the only cut that says the
+ * same thing to the reader as it does to the buffer. The seconds face comes
+ * straight off them: a block runs at one second per sample rate whatever the
+ * tempo does, so this is exact rather than a curve read off the block's own two
+ * ends (#2330).
+ */
 inline BlockInfo materialSubBlock(const BlockInfo& block, const BeatRange& range,
-                                  const RunOrigin& origin, int count) {
-    auto material = block;
+                                  const RunOrigin& origin, int offset, int count) {
+    auto material = materialBlock(block, range, origin);
     material.numSamples = count;
     material.beats = BeatRange{range.start - origin.beat, range.end - origin.beat};
-    material.seconds = SecondsRange{secondsWithin(block, range.start) - origin.seconds,
-                                    secondsWithin(block, range.end) - origin.seconds};
-    material.continuous = runsOn(block, range, origin);
-    material.runOrigin = origin;  // see materialBlock
+
+    const auto through = [&](int sample) {
+        return block.numSamples > 0
+                   ? block.seconds.start +
+                         (static_cast<double>(sample) / static_cast<double>(block.numSamples)) *
+                             block.seconds.length()
+                   : block.seconds.start;
+    };
+
+    material.seconds =
+        SecondsRange{through(offset) - origin.seconds, through(offset + count) - origin.seconds};
     return material;
 }
 
 /// Where in @p block the event landed, or the whole block when there was none.
 /// What starts a clip on its beat rather than on a callback boundary.
 inline int splitSample(const BlockInfo& block, const SplitStatus& status) {
-    return status.afterEvent ? block.sampleForBeat(status.beforeEvent.range.end) : block.numSamples;
+    return status.afterEvent ? status.event.sample : block.numSamples;
 }
 
 /**

--- a/magda/engine/exec/RenderContext.hpp
+++ b/magda/engine/exec/RenderContext.hpp
@@ -218,6 +218,23 @@ struct BlockInfo {
         return beats.start + (position * beats.length());
     }
 
+    /**
+     * @brief Where the block sits on the transport's own sample count.
+     *
+     * The durable coordinate, and the one every other face here is ultimately
+     * an interpretation of (transport/TimeDomains.hpp). A locate does not move
+     * it, a wrap does not take it back and a tempo edit does not rescale it, so
+     * it is the only one of them two blocks can be compared on without knowing
+     * what happened between.
+     *
+     * A stopped block does not advance it, for the same reason it does not
+     * advance the timeline: nothing played.
+     *
+     * Empty on a block assembled by hand, which is why nothing may assume it is
+     * set (#2332 is what makes it load-bearing).
+     */
+    SampleRange monotonicSamples;
+
     /// The map this block was cut from, or null for a caller that assembles a
     /// block by hand. Not owned, and it outlives the block: what publishes a
     /// transport keeps it alive for as long as the callback reading it runs.

--- a/magda/engine/launch/LaunchHandle.cpp
+++ b/magda/engine/launch/LaunchHandle.cpp
@@ -253,7 +253,7 @@ SplitStatus LaunchHandle::advanceOver(const SyncRange& range) {
     // The instant the block ran into, worked out once and in one domain. Every
     // face of it below comes off the sample it landed on, so the two halves and
     // the origin they produce cannot disagree about where the cut was (#2330).
-    const auto event = range.atMonotonicBeat(*eventBeat);
+    const auto event = range.eventAtMonotonicBeat(*eventBeat);
     status.event = event;
 
     // At or before the block's first sample: the whole block is in the new

--- a/magda/engine/launch/LaunchHandle.cpp
+++ b/magda/engine/launch/LaunchHandle.cpp
@@ -5,30 +5,6 @@
 
 namespace magda::engine {
 
-namespace {
-
-/// Where @p value, a position in @p from, falls in @p to. The two ranges are
-/// the same stretch of time in two domains, so this is how a monotonic beat
-/// becomes the timeline beat at the same instant.
-double project(const BeatRange& from, const BeatRange& to, double value) {
-    const auto span = from.length();
-    if (span <= 0.0)
-        return to.start;
-
-    return to.start + ((value - from.start) / span) * to.length();
-}
-
-/// The same, from a beat face onto a seconds one.
-double project(const BeatRange& from, const SecondsRange& to, double value) {
-    const auto span = from.length();
-    if (span <= 0.0)
-        return to.start;
-
-    return to.start + (((value - from.start) / span) * to.length());
-}
-
-}  // namespace
-
 double LaunchHandle::virtualStart(const SyncRange& piece) const {
     // Where the run would have begun on the timeline as it stands now, which
     // is not where it did begin once the timeline has wrapped or been located
@@ -131,7 +107,7 @@ std::optional<BeatRange> LaunchHandle::lastPlayedRange() const {
     return lastPlayed_;
 }
 
-void LaunchHandle::beginRun(const SyncPoint& at, double elapsedBeats, double elapsedSeconds) {
+void LaunchHandle::beginRun(const BlockInstant& at, double elapsedBeats, double elapsedSeconds) {
     if (played_)
         lastPlayed_ = played_;
 
@@ -164,7 +140,7 @@ void LaunchHandle::extendRun(const SyncRange& piece) {
     playedMonotonicSeconds_->end += piece.monotonicSeconds.length();
 }
 
-void LaunchHandle::applyEvent(bool fromPending, const SyncPoint& at) {
+void LaunchHandle::applyEvent(bool fromPending, const BlockInstant& at) {
     if (!fromPending) {
         // A loop re-trigger, which is a relaunch at the wrap: same handle, new
         // run, so the played range restarts and whatever reads it seeks.
@@ -189,9 +165,14 @@ void LaunchHandle::applyEvent(bool fromPending, const SyncPoint& at) {
     // Joining means adopting the position, not just the origin. Derived here
     // rather than at the request, which is a different number whenever the
     // launch was queued for a later beat.
-    beginRun(SyncPoint{*pending.syncedTimelineOrigin, *pending.syncedMonotonicOrigin,
-                       *pending.syncedMonotonicSecondsOrigin},
-             at.monotonicBeat - *pending.syncedMonotonicOrigin,
+    // The origin is another handle's, so it is not an instant in this block and
+    // is carried as the three faces that handle recorded rather than derived.
+    BlockInstant origin = at;
+    origin.timelineBeat = *pending.syncedTimelineOrigin;
+    origin.monotonicBeat = *pending.syncedMonotonicOrigin;
+    origin.monotonicSeconds = *pending.syncedMonotonicSecondsOrigin;
+
+    beginRun(origin, at.monotonicBeat - *pending.syncedMonotonicOrigin,
              at.monotonicSeconds - *pending.syncedMonotonicSecondsOrigin);
 }
 
@@ -217,22 +198,22 @@ SplitStatus LaunchHandle::advanceOver(const SyncRange& range) {
     // Giving way costs the wrap nothing. A stop ends the run and a launch
     // restarts it, so either way the run it would have restarted is gone before
     // the block is over.
-    std::optional<double> event;
+    std::optional<double> eventBeat;
     auto fromPending = false;
 
     if (pending_) {
         const auto& position = pending_->position;
 
         if (!position || *position <= range.monotonic.start) {
-            event = range.monotonic.start;
+            eventBeat = range.monotonic.start;
             fromPending = true;
         } else if (*position < range.monotonic.end) {
-            event = *position;
+            eventBeat = *position;
             fromPending = true;
         }
     }
 
-    if (!event && playState_ == PlayState::playing && loopBeats_ && playedMonotonic_) {
+    if (!eventBeat && playState_ == PlayState::playing && loopBeats_ && playedMonotonic_) {
         const auto origin = playedMonotonic_->start;
         const auto elapsed = range.monotonic.start - origin;
 
@@ -249,7 +230,7 @@ SplitStatus LaunchHandle::advanceOver(const SyncRange& range) {
             wrap += *loopBeats_;
 
         if (wrap < range.monotonic.end) {
-            event = wrap;
+            eventBeat = wrap;
             fromPending = false;
 
             // A second wrap inside the same block is one this cannot report.
@@ -260,7 +241,7 @@ SplitStatus LaunchHandle::advanceOver(const SyncRange& range) {
         }
     }
 
-    if (!event) {
+    if (!eventBeat) {
         if (playState_ == PlayState::playing) {
             status.beforeEvent.origin = RunOrigin{virtualStart(range), virtualStartSeconds(range)};
             extendRun(range);
@@ -268,14 +249,19 @@ SplitStatus LaunchHandle::advanceOver(const SyncRange& range) {
 
         return status;
     }
+
+    // The instant the block ran into, worked out once and in one domain. Every
+    // face of it below comes off the sample it landed on, so the two halves and
+    // the origin they produce cannot disagree about where the cut was (#2330).
+    const auto event = range.atMonotonicBeat(*eventBeat);
+    status.event = event;
 
     // At or before the block's first sample: the whole block is in the new
     // state and there is nothing to split. Reporting a split with an empty
     // first half would be the same answer in a shape every caller has to
     // defend against.
-    if (*event <= range.monotonic.start) {
-        applyEvent(fromPending, SyncPoint{range.timeline.start, range.monotonic.start,
-                                          range.monotonicSeconds.start});
+    if (event.sample <= 0) {
+        applyEvent(fromPending, range.start());
 
         if (playState_ == PlayState::playing) {
             status.beforeEvent.origin = RunOrigin{virtualStart(range), virtualStartSeconds(range)};
@@ -285,20 +271,18 @@ SplitStatus LaunchHandle::advanceOver(const SyncRange& range) {
         return status;
     }
 
-    // The instant the block ran into, on every axis: named in monotonic beats
-    // and carried across by where it falls in this block.
-    const auto splitBeat = project(range.monotonic, range.timeline, *event);
-    const auto splitSeconds = project(range.monotonic, range.seconds, *event);
-    const auto splitMonotonicSeconds = project(range.monotonic, range.monotonicSeconds, *event);
-
-    const SyncRange first{BeatRange{range.timeline.start, splitBeat},
-                          BeatRange{range.monotonic.start, *event},
-                          SecondsRange{range.seconds.start, splitSeconds},
-                          SecondsRange{range.monotonicSeconds.start, splitMonotonicSeconds}};
-    const SyncRange second{BeatRange{splitBeat, range.timeline.end},
-                           BeatRange{*event, range.monotonic.end},
-                           SecondsRange{splitSeconds, range.seconds.end},
-                           SecondsRange{splitMonotonicSeconds, range.monotonicSeconds.end}};
+    const SyncRange first{BeatRange{range.timeline.start, event.timelineBeat},
+                          BeatRange{range.monotonic.start, event.monotonicBeat},
+                          SecondsRange{range.seconds.start, event.timelineSeconds},
+                          SecondsRange{range.monotonicSeconds.start, event.monotonicSeconds},
+                          event.sample,
+                          range.tempo};
+    const SyncRange second{BeatRange{event.timelineBeat, range.timeline.end},
+                           BeatRange{event.monotonicBeat, range.monotonic.end},
+                           SecondsRange{event.timelineSeconds, range.seconds.end},
+                           SecondsRange{event.monotonicSeconds, range.monotonicSeconds.end},
+                           range.numSamples - event.sample,
+                           range.tempo};
 
     status.beforeEvent.range = first.timeline;
 
@@ -307,8 +291,7 @@ SplitStatus LaunchHandle::advanceOver(const SyncRange& range) {
         extendRun(first);
     }
 
-    applyEvent(fromPending, SyncPoint{second.timeline.start, second.monotonic.start,
-                                      second.monotonicSeconds.start});
+    applyEvent(fromPending, event);
 
     BlockPiece after;
     after.range = second.timeline;

--- a/magda/engine/launch/LaunchHandle.hpp
+++ b/magda/engine/launch/LaunchHandle.hpp
@@ -1,9 +1,12 @@
 #pragma once
 
+#include <algorithm>
+#include <cmath>
 #include <optional>
 #include <tuple>
 
 #include "core/TypeIds.hpp"
+#include "transport/TempoMap.hpp"
 #include "transport/TimeDomains.hpp"
 
 /**
@@ -48,25 +51,89 @@ struct SlotKey {
 };
 
 /**
- * @brief One block, in the four domains (TimeDomains.hpp).
+ * @brief One block, in the four domains (TimeDomains.hpp), and how to cut it.
  *
  * A queued position is named in monotonic beats; how far into its material a
  * run has got is measured in monotonic seconds. Neither is derived from the
  * other (#2324).
+ *
+ * The map comes with it, because naming an instant inside the block is the one
+ * thing a handle does that the four ranges cannot answer between them. Reading
+ * an instant off each range separately is what @ref BlockInstant exists to stop
+ * (#2330); everything here goes through @ref atSample.
  */
 struct SyncRange {
     BeatRange timeline;
     BeatRange monotonic;
     SecondsRange seconds;
     SecondsRange monotonicSeconds;
-};
 
-/// One instant, in the faces a run's origin is remembered in. Passed together
-/// so a run cannot be started with faces of different instants.
-struct SyncPoint {
-    double timelineBeat = 0.0;
-    double monotonicBeat = 0.0;
-    double monotonicSeconds = 0.0;
+    /// How many samples the block is, which is what an instant is counted in.
+    int numSamples = 0;
+
+    /// The map the block was cut from, or null for a block assembled by hand,
+    /// which is then taken to run at one tempo.
+    const TempoMap* tempo = nullptr;
+
+    /**
+     * @brief The instant @p sample sounds at, in every domain.
+     *
+     * The seconds faces are exact rather than nearly so: a block runs at one
+     * second per sample rate whatever the tempo is doing, so both of them are
+     * straight lines and not approximations of a curve.
+     *
+     * The beat face is the map's, because the block's own two beat ends are a
+     * straight line and the map between them is not. What is left linear is
+     * monotonic against timeline beats, and that one is exact: what makes the
+     * two differ is a wrap, and a wrap ends a block.
+     */
+    BlockInstant atSample(int sample) const {
+        BlockInstant at;
+        at.sample = std::clamp(sample, 0, numSamples);
+
+        const auto through =
+            numSamples > 0 ? static_cast<double>(at.sample) / static_cast<double>(numSamples) : 0.0;
+
+        at.timelineSeconds = seconds.start + through * seconds.length();
+        at.monotonicSeconds = monotonicSeconds.start + through * monotonicSeconds.length();
+
+        at.timelineBeat = tempo != nullptr ? tempo->timeToBeat(at.timelineSeconds)
+                                           : timeline.start + through * timeline.length();
+
+        at.monotonicBeat = monotonic.start + (at.timelineBeat - timeline.start);
+        return at;
+    }
+
+    /// The instant the block begins on.
+    BlockInstant start() const {
+        return atSample(0);
+    }
+
+    /**
+     * @brief The instant @p beat falls on, snapped to the sample it sounds on.
+     *
+     * Snapped, and then every face taken from that sample rather than from the
+     * beat that asked: a launch happens on a sample or it does not happen, and
+     * the faces of the beat it was asked for are the faces of a moment between
+     * two samples that nothing plays.
+     */
+    BlockInstant atMonotonicBeat(double beat) const {
+        if (numSamples <= 0 || seconds.empty())
+            return start();
+
+        const auto timelineBeat = timeline.start + (beat - monotonic.start);
+
+        const auto at =
+            tempo != nullptr
+                ? tempo->beatToTime(timelineBeat)
+                : seconds.start + (timeline.empty()
+                                       ? 0.0
+                                       : ((timelineBeat - timeline.start) / timeline.length()) *
+                                             seconds.length());
+
+        const auto through = (at - seconds.start) / seconds.length();
+        return atSample(static_cast<int>(std::lround(through * numSamples)));
+    }
 };
 
 /// One piece of a block. A piece sounds exactly when there is a run behind it,
@@ -104,6 +171,11 @@ struct SplitStatus {
     /// What was left after it. Absent rather than empty, so a caller cannot
     /// read a piece that was never played.
     std::optional<BlockPiece> afterEvent;
+
+    /// Where the cut is, when @ref afterEvent says there was one. The sample
+    /// the block ran into its event on, so a caller starts the clip there
+    /// rather than working the position out a second time and differently.
+    BlockInstant event;
 
     /// Whether the slot is sounding when the block ends, which is what decides
     /// whether a stop owes note-offs.
@@ -240,7 +312,7 @@ class LaunchHandle {
 
     /// Begin a run at @p at, already @p elapsedBeats and @p elapsedSeconds into
     /// itself. Non-zero only for a synced launch, which joins a run.
-    void beginRun(const SyncPoint& at, double elapsedBeats = 0.0, double elapsedSeconds = 0.0);
+    void beginRun(const BlockInstant& at, double elapsedBeats = 0.0, double elapsedSeconds = 0.0);
     void endRun();
 
     /// Carry the current run through @p piece without changing state.
@@ -251,7 +323,7 @@ class LaunchHandle {
     double virtualStartSeconds(const SyncRange& piece) const;
 
     /// Apply whatever the block ran into, at the instant it ran into it.
-    void applyEvent(bool fromPending, const SyncPoint& at);
+    void applyEvent(bool fromPending, const BlockInstant& at);
 
     /// The advance itself, wrapped so @ref blockStatus is stored in one place.
     SplitStatus advanceOver(const SyncRange& range);

--- a/magda/engine/launch/LaunchHandle.hpp
+++ b/magda/engine/launch/LaunchHandle.hpp
@@ -78,6 +78,12 @@ struct SyncRange {
     /**
      * @brief The instant @p sample sounds at, in every domain.
      *
+     * An edge rather than an event: one past the end of the block is a legal
+     * answer here, the way it is for RenderContext::sampleForTime, because a
+     * range that runs to the end of the block ends at the sample after the last
+     * one. An event has to land on a sample the block actually has, which is
+     * @ref eventAtMonotonicBeat.
+     *
      * The seconds faces are exact rather than nearly so: a block runs at one
      * second per sample rate whatever the tempo is doing, so both of them are
      * straight lines and not approximations of a curve.
@@ -110,14 +116,21 @@ struct SyncRange {
     }
 
     /**
-     * @brief The instant @p beat falls on, snapped to the sample it sounds on.
+     * @brief The instant @p beat falls on, as an event this block can carry.
      *
-     * Snapped, and then every face taken from that sample rather than from the
-     * beat that asked: a launch happens on a sample or it does not happen, and
-     * the faces of the beat it was asked for are the faces of a moment between
-     * two samples that nothing plays.
+     * Snapped to a sample, and then every face taken from that sample rather
+     * than from the beat that asked: a launch happens on a sample or it does
+     * not happen, and the faces of the beat it was asked for are the faces of a
+     * moment between two samples that nothing plays.
+     *
+     * Never one past the end, which is where a beat in the block's last half
+     * sample rounds to. That sample belongs to the next callback, and an event
+     * placed there is written nowhere: a stop would clear its own note state
+     * while its note-offs went to an offset outside the buffer, and the notes
+     * would hang. The block's last sample instead, which is at most one sample
+     * early and is a sample that plays.
      */
-    BlockInstant atMonotonicBeat(double beat) const {
+    BlockInstant eventAtMonotonicBeat(double beat) const {
         if (numSamples <= 0 || seconds.empty())
             return start();
 
@@ -132,7 +145,8 @@ struct SyncRange {
                                              seconds.length());
 
         const auto through = (at - seconds.start) / seconds.length();
-        return atSample(static_cast<int>(std::lround(through * numSamples)));
+        const auto sample = static_cast<int>(std::lround(through * numSamples));
+        return atSample(std::min(sample, numSamples - 1));
     }
 };
 

--- a/magda/engine/launch/SessionLauncher.hpp
+++ b/magda/engine/launch/SessionLauncher.hpp
@@ -93,7 +93,8 @@ class LaunchHandleFeed {
 /// The block as the launcher names it: all four faces, from the one place they
 /// were derived together (RenderContext.hpp).
 inline SyncRange syncRangeFor(const BlockInfo& block) {
-    return SyncRange{block.beats, block.monotonicBeats, block.seconds, block.monotonicSeconds};
+    return SyncRange{block.beats,      block.monotonicBeats, block.seconds, block.monotonicSeconds,
+                     block.numSamples, block.tempo};
 }
 
 /// Advance every handle over @p block, once, before anything renders. On the

--- a/magda/engine/transport/TimeDomains.hpp
+++ b/magda/engine/transport/TimeDomains.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstdint>
+
 /**
  * @file TimeDomains.hpp
  * @brief The four domains the engine says "when" in.
@@ -44,6 +46,36 @@ struct SecondsRange {
     }
 
     bool operator==(const SecondsRange&) const = default;
+};
+
+/**
+ * @brief A stretch of the transport's own sample count, half open.
+ *
+ * The count never goes back. A locate does not move it, a loop wrap does not
+ * take it back, a tempo edit does not rescale it, and re-anchoring the cursor
+ * does not reset it: it is how many samples the transport has rolled, and the
+ * device only ever hands over more of them.
+ *
+ * Which is what makes it the coordinate the others are derived from rather than
+ * one more of them. A beat is where something sits and a second is how long
+ * something lasted, and both are answers a tempo map gives; a sample is what
+ * played. Two beats a thousand blocks apart can be the same beat and two
+ * elapsed seconds can disagree about which cycle they are in, but no two
+ * samples are the same sample.
+ */
+struct SampleRange {
+    std::int64_t start = 0;
+    std::int64_t end = 0;
+
+    std::int64_t length() const {
+        return end - start;
+    }
+
+    bool empty() const {
+        return end <= start;
+    }
+
+    bool operator==(const SampleRange&) const = default;
 };
 
 /**

--- a/magda/engine/transport/TimeDomains.hpp
+++ b/magda/engine/transport/TimeDomains.hpp
@@ -47,6 +47,36 @@ struct SecondsRange {
 };
 
 /**
+ * @brief One instant inside a block, in every domain the engine names it in.
+ *
+ * Built from one coordinate and one only: the sample. Every face below is
+ * derived from it through the tempo map, so the five of them are one instant
+ * rather than five answers that happen to be near each other.
+ *
+ * That is the whole point of the type. The domains are related by the map,
+ * which is not a straight line, and projecting an instant onto each axis
+ * separately gives a set of faces no single moment has: over a steep ramp the
+ * beat face and the seconds face of one "instant" can be 163 samples apart.
+ * Anything built from those faces inherits the gap, and a run whose origin has
+ * it starts its material somewhere it was never placed (#2330).
+ *
+ * The sample is canonical because it is the one coordinate that is not a
+ * matter of interpretation: it is what plays.
+ */
+struct BlockInstant {
+    /// Offset within the block. What actually sounds at this instant.
+    int sample = 0;
+
+    double timelineBeat = 0.0;
+    double timelineSeconds = 0.0;
+
+    /// The faces that never go back, which is what a queued launch is named in
+    /// and what a run's elapsed material is measured in (#2324).
+    double monotonicBeat = 0.0;
+    double monotonicSeconds = 0.0;
+};
+
+/**
  * @brief Where a run began, in the two domains a source reads it against.
  *
  * One value, because a run whose faces came from different instants would put a

--- a/magda/engine/transport/TransportClock.cpp
+++ b/magda/engine/transport/TransportClock.cpp
@@ -125,6 +125,8 @@ std::span<const TransportClock::Segment> TransportClock::advance(const Transport
         segment.block.monotonicBeats.end = monotonicBeat_;
         segment.block.monotonicSeconds.start = monotonicSeconds_;
         segment.block.monotonicSeconds.end = monotonicSeconds_;
+        segment.block.monotonicSamples.start = monotonicSamples_;
+        segment.block.monotonicSamples.end = monotonicSamples_;
         segment.block.continuous = continuous_;
         segment.block.tempo = &tempo;
         segment.startSample = 0;
@@ -225,6 +227,15 @@ std::span<const TransportClock::Segment> TransportClock::advance(const Transport
         segment.block.monotonicSeconds.start = monotonicSeconds_;
         monotonicSeconds_ += static_cast<double>(samples) / sampleRate_;
         segment.block.monotonicSeconds.end = monotonicSeconds_;
+
+        // The samples themselves, which is what the seconds above are counted
+        // from and what everything else here is an interpretation of. Kept
+        // rather than divided back out of them: a rate change makes the two no
+        // longer one conversion apart, and this side of it is the one that did
+        // not move (#2332).
+        segment.block.monotonicSamples.start = monotonicSamples_;
+        monotonicSamples_ += samples;
+        segment.block.monotonicSamples.end = monotonicSamples_;
 
         segment.block.continuous = continuous_;
         segment.block.tempo = &tempo;

--- a/magda/engine/transport/TransportClock.hpp
+++ b/magda/engine/transport/TransportClock.hpp
@@ -89,6 +89,12 @@ class TransportClock {
         return monotonicSeconds_;
     }
 
+    /// Samples the transport has rolled since the clock began. Never goes back,
+    /// and is not re-anchored by anything that moves the cursor.
+    std::int64_t monotonicSamples() const {
+        return monotonicSamples_;
+    }
+
     /**
      * @brief Callbacks in which a loop was too short to be honoured.
      *
@@ -166,6 +172,11 @@ class TransportClock {
     /// buys is what it refuses: two monotonic beats and a tempo map cannot
     /// produce elapsed seconds, because a map answers where a beat is.
     double monotonicSeconds_ = 0.0;
+
+    /// Samples rolled since the clock began. What the two monotonic faces above
+    /// are counted from, and the one coordinate a locate, a wrap, a tempo edit
+    /// and a re-anchor all leave alone (#2332).
+    std::int64_t monotonicSamples_ = 0;
 
     std::atomic<double> positionBeats_{0.0};
     std::atomic<bool> playingPublic_{false};

--- a/tests/engine/test_launch_handle.cpp
+++ b/tests/engine/test_launch_handle.cpp
@@ -50,6 +50,29 @@ SyncRange wrapped(double from, double to, double monotonicFrom, double monotonic
 
 }  // namespace
 
+TEST_CASE("An event in the block's last half sample stays inside the block", "[launch]") {
+    // A beat nearer the next callback's first sample than this one's last
+    // rounds past the end of the block. Applied there, the event happens but
+    // nothing can carry it: a stop would clear its own note state while its
+    // note-offs went to an offset outside the buffer, and the notes would hang.
+    LaunchHandle handle;
+
+    const auto range = block(0.0, 1.0);
+    const auto lastSample = range.numSamples - 1;
+
+    // Inside the beat range, and within half a sample of its end.
+    handle.play(1.0 - (0.4 / range.numSamples));
+
+    const auto status = handle.advance(range);
+
+    REQUIRE(status.afterEvent.has_value());
+
+    // On the block's last sample: at most one sample early, and a sample that
+    // plays. Never numSamples, which belongs to the next callback.
+    CHECK(status.event.sample == lastSample);
+    CHECK(status.event.sample < range.numSamples);
+}
+
 TEST_CASE("A handle starts stopped and having played nothing", "[launch]") {
     LaunchHandle handle;
 

--- a/tests/engine/test_launch_handle.cpp
+++ b/tests/engine/test_launch_handle.cpp
@@ -22,19 +22,30 @@ namespace {
 /// 120 bpm, the tempo every case here runs at.
 constexpr double kSecondsPerBeat = 0.5;
 
+constexpr double kSampleRate = 48000.0;
+
+/// How many samples a stretch of beats is at that tempo. A block carries its
+/// sample count because an instant inside it is named in samples: that is the
+/// one coordinate every other is derived from (#2330).
+constexpr int samplesFor(double beats) {
+    return static_cast<int>(beats * kSecondsPerBeat * kSampleRate);
+}
+
 /// One block, in all four faces, with the timeline and monotonic clocks running
 /// together. They diverge only when something wraps the timeline.
 SyncRange block(double from, double to) {
     return SyncRange{BeatRange{from, to}, BeatRange{from, to},
                      SecondsRange{from * kSecondsPerBeat, to * kSecondsPerBeat},
-                     SecondsRange{from * kSecondsPerBeat, to * kSecondsPerBeat}};
+                     SecondsRange{from * kSecondsPerBeat, to * kSecondsPerBeat},
+                     samplesFor(to - from)};
 }
 
 /// A block the timeline has wrapped under.
 SyncRange wrapped(double from, double to, double monotonicFrom, double monotonicTo) {
     return SyncRange{BeatRange{from, to}, BeatRange{monotonicFrom, monotonicTo},
                      SecondsRange{from * kSecondsPerBeat, to * kSecondsPerBeat},
-                     SecondsRange{monotonicFrom * kSecondsPerBeat, monotonicTo * kSecondsPerBeat}};
+                     SecondsRange{monotonicFrom * kSecondsPerBeat, monotonicTo * kSecondsPerBeat},
+                     samplesFor(monotonicTo - monotonicFrom)};
 }
 
 }  // namespace

--- a/tests/engine/test_session_playback.cpp
+++ b/tests/engine/test_session_playback.cpp
@@ -807,6 +807,52 @@ void callback(AudioRig& rig, magda::engine::TransportClock& clock,
 
 }  // namespace
 
+TEST_CASE("A launch inside a block that spans a tempo step names one instant",
+          "[engine][clip][session]") {
+    // The invariant #2330 is about, asserted on a block the clock would no
+    // longer hand out: built by hand so it spans the step, which is exactly the
+    // shape that used to produce an origin with two faces of different moments.
+    //
+    // The cut and this are two answers to the same leak, and only this one
+    // closes the class: whatever a block spans, an instant inside it is worked
+    // out once, in samples, and every face derived from that.
+    const auto map = steppedTempo();  // 120 to beat 4, then 60
+
+    // Half a block either side of the step, at 120 throughout its first half.
+    const auto from = map.beatToTime(4.0) - (kBlockSize / kSampleRate / 2.0);
+
+    magda::engine::BlockInfo block;
+    block.numSamples = kBlockSize;
+    block.playing = true;
+    block.continuous = true;
+    block.seconds = {from, from + (kBlockSize / kSampleRate)};
+    block.beats = {map.timeToBeat(block.seconds.start), map.timeToBeat(block.seconds.end)};
+    block.monotonicBeats = block.beats;
+    block.monotonicSeconds = block.seconds;
+    block.tempo = &map;
+
+    LaunchHandle handle;
+    handle.play(map.timeToBeat(map.beatToTime(4.0)));  // the step itself
+
+    const auto status = handle.advance(magda::engine::syncRangeFor(block));
+
+    REQUIRE(status.afterEvent.has_value());
+    REQUIRE(status.afterEvent->origin.has_value());
+
+    const auto origin = *status.afterEvent->origin;
+
+    // The two faces of a fresh run's origin are the two faces of one sample.
+    // Projected separately they are not: the beat lands where the block's
+    // straight line puts it and the seconds where its other line does, and
+    // across a step those are different moments.
+    CHECK(map.timeToBeat(origin.seconds) == Approx(origin.beat));
+
+    // Which is what the material needs: second zero of the run is beat zero of
+    // it, so an auto-tempo reader starts at the head of its file.
+    const auto material = magda::engine::materialBlock(block, status.afterEvent->range, origin);
+    CHECK(material.beatAtTime(0.0) == Approx(0.0));
+}
+
 TEST_CASE("A slot launched where a block would step tempo starts at its own first sample",
           "[engine][clip][session]") {
     // The launch and the tempo step want the same instant inside one callback.

--- a/tests/engine/test_transport_clock.cpp
+++ b/tests/engine/test_transport_clock.cpp
@@ -392,6 +392,70 @@ TEST_CASE("One tempo throughout cuts nothing", "[engine][transport][clock][tempo
     CHECK(rendered.segments.size() == 1);
 }
 
+TEST_CASE("Monotonic samples count what the transport rolled",
+          "[engine][transport][clock][samples]") {
+    TransportClock clock;
+    const auto snapshot = playing(0.0);
+
+    CHECK(clock.monotonicSamples() == 0);
+
+    const auto first = advance(clock, snapshot, 512);
+    CHECK(first.segments[0].block.monotonicSamples.start == 0);
+    CHECK(first.segments[0].block.monotonicSamples.end == 512);
+    CHECK(clock.monotonicSamples() == 512);
+
+    // Picks up where the last block left off, so two blocks are adjacent on
+    // this axis whatever the timeline did between them.
+    const auto second = advance(clock, snapshot, 512);
+    CHECK(second.segments[0].block.monotonicSamples.start == 512);
+    CHECK(clock.monotonicSamples() == 1024);
+}
+
+TEST_CASE("A stopped transport rolls no samples", "[engine][transport][clock][samples]") {
+    // A stopped block still renders, so tails ring out, but nothing played:
+    // the count stands still for the same reason the timeline does.
+    TransportClock clock;
+
+    advance(clock, playing(0.0), 512);
+    REQUIRE(clock.monotonicSamples() == 512);
+
+    const auto rendered = advance(clock, halt(2), 512);
+
+    CHECK(rendered.segments[0].block.monotonicSamples.start == 512);
+    CHECK(rendered.segments[0].block.monotonicSamples.end == 512);
+    CHECK(clock.monotonicSamples() == 512);
+}
+
+TEST_CASE("Nothing that moves the cursor moves the sample count",
+          "[engine][transport][clock][samples]") {
+    // The point of the axis. A wrap takes the timeline back and a locate puts
+    // it anywhere, and neither is a thing that unplays a sample.
+    TransportClock clock;
+
+    auto looping = playing(0.0);
+    looping.loop = {true, 0.0, 1.0};
+
+    // Several beats' worth at 120 bpm, so the loop wraps more than once.
+    constexpr auto kSamples = static_cast<int>(kSamplesPerBeat * 3);
+
+    const auto wrapped = advance(clock, looping, kSamples);
+    requireCovers(wrapped, kSamples);
+
+    // Cut into pieces by the wraps, and the pieces are adjacent: the count
+    // carries across a boundary the timeline does not.
+    for (std::size_t i = 1; i < wrapped.segments.size(); ++i)
+        CHECK(wrapped.segments[i].block.monotonicSamples.start ==
+              wrapped.segments[i - 1].block.monotonicSamples.end);
+
+    CHECK(clock.monotonicSamples() == kSamples);
+
+    // A locate backwards, which is where a beat-counting axis would go back.
+    const auto located = advance(clock, playing(0.0, 2), 512);
+
+    CHECK(located.segments[0].block.monotonicSamples.start == kSamples);
+    CHECK(clock.monotonicSamples() == kSamples + 512);
+}
+
 TEST_CASE("A request is applied once", "[engine][transport][clock]") {
     TransportClock clock;
     const auto snapshot = playing(2.0);


### PR DESCRIPTION
Closes #2330. Replaces #2331, which GitHub closed when its base branch was deleted on merging #2325; same branch, same commits, rebased onto the merged base.

The structural answer to the two review findings on #2325 rather than a third patch on top of them.

## The leak

`SyncRange` carries four axes and `advanceOver` read the event off each of them separately, by linear interpolation. That produces one coherent instant only while every mapping is affine across the whole block, which is why the same defect surfaced twice in review: first at an explicit tempo step, then at a baked ramp-section boundary. Cutting blocks closed both cases without closing the class.

## One coordinate

`BlockInstant` is built from a sample and nothing else. Every other face is derived from that one number:

- the two seconds faces exactly, since a block runs at one second per sample rate whatever the tempo does;
- the timeline beat through the map, rather than along the block's own straight line;
- the monotonic beat off the timeline beat, which is exact inside a block because what makes the two differ is a wrap, and a wrap ends a block.

`SyncRange` carries the map and the sample count so it can build one. A launch quantized to a beat is snapped to the sample it sounds on *before* any face is read: a launch happens on a sample or it does not happen.

An event and a range edge are separate questions and get separate conversions. `atSample` answers for an edge, where one past the end of the block is legal; `eventAtMonotonicBeat` never answers past the block's last sample, because an event placed there is written nowhere and a stop would clear its note state while its note-offs went outside the buffer.

## What it buys

The origin. A fresh run's `RunOrigin` is now the two faces of one sample instead of two projections that agree only under one tempo, so material second zero is material beat zero and an auto-tempo clip starts at the head of its file.

On a block spanning a 120 to 60 step the old pair put the run's origin at beat 4 and 2.020833 s, where the map puts beat 4 at 2. The material began a fiftieth of a beat in, about 500 samples at 120 bpm, and that much of every launched clip's attack was skipped.

`SyncPoint` goes, having been the three-faced version of the same idea. `materialSubBlock` crops by samples rather than by a beat read off the block's line, and `splitSample` reads the instant the launcher already resolved.

## What this does not do

It makes the sample canonical *within a block*; it does not make it durable. The origin is still stored as beat and seconds, so a retrigger is scheduled from an already-rounded beat and the error accumulates: about 366 samples over a thousand one-beat retriggers at 48 kHz and 123 bpm. `BlockInstant`'s fields are public and `applyEvent` overwrites three of them for a synced launch, so the invariant is a convention rather than an enforcement.

Both are #2332, along with the absolute monotonic sample range on `BlockInfo` that they need. #2333 is the follow-on: once `sampleForBeat` derives through the map, #2325's tempo-section block cut stops paying for itself.

## Also here

The first step of #2332, added after the review that prompted it: the transport now counts its own samples and every block carries an absolute `monotonicSamples` range. Additive, nothing reads it yet, but it is the durable coordinate the origin has to move onto and it can be verified on its own. A locate, a loop wrap, a tempo edit and a re-anchor all leave it alone.

## Testing

The new case asserts the invariant on a block built by hand to span a step, which is a shape the clock no longer produces, so it holds whatever the clock does. Under the old projection it fails at 4.020833 against 4, and `beatAtTime(0)` at 0.020833 against 0. The event-clamp case fails at 24000 against 23999.

Full Catch2 suite green locally after the rebase: 3377 passed, 13 skipped for plugins absent from this machine, 0 failures.

https://claude.ai/code/session_013CDpSHas8bog33vv4o6HLv