### PR TITLE
Samples are what runtime operations are in: one origin, one conversion, and no drift (#2336)

### DIFF
--- a/magda/daw/audio/plugins/engine/EngineExternalDevice.cpp
+++ b/magda/daw/audio/plugins/engine/EngineExternalDevice.cpp
@@ -76,9 +76,19 @@ class EngineExternalDevice::PlayHead final : public juce::AudioPlayHead {
             return;
         }
 
-        bpm_.store(block.tempo->bpmAt(block.beats.start), std::memory_order_relaxed);
+        // The tempo and the bar grid of the section the block renders in, not
+        // of its first beat: a block can open a fraction of a sample before a
+        // boundary it is otherwise entirely past (BlockInfo::sectionBeat). The
+        // plugin is told one bpm and one signature for the whole call, so
+        // taking them from the old section would run the call on the wrong one.
+        //
+        // Where the block is stays its own: the time and the PPQ position above
+        // are its first sample's, which is what the plugin is being handed.
+        const auto inside = block.sectionBeat();
 
-        const auto position = block.tempo->barsAndBeatsAt(block.beats.start);
+        bpm_.store(block.tempo->bpmAt(inside), std::memory_order_relaxed);
+
+        const auto position = block.tempo->barsAndBeatsAt(inside);
         numerator_.store(position.numerator, std::memory_order_relaxed);
         denominator_.store(position.denominator, std::memory_order_relaxed);
 
@@ -87,8 +97,28 @@ class EngineExternalDevice::PlayHead final : public juce::AudioPlayHead {
         // denominator is not four: three eighths into a 6/8 bar is one and a
         // half quarter notes, not three.
         const auto quartersPerBeat = 4.0 / std::max(1, position.denominator);
-        ppqOfBarStart_.store(block.beats.start - (position.beat * quartersPerBeat),
-                             std::memory_order_relaxed);
+        const auto barBeats = std::max(position.numerator * quartersPerBeat, 1.0e-6);
+
+        // The bar the block's first sample is in, under the signature it
+        // renders in. Not the bar its midpoint is in: a block is cut at every
+        // tempo section but not at every bar line, so a long one can straddle
+        // one, and taking the midpoint's bar would make what the plugin is told
+        // depend on how the host happened to size the callback.
+        //
+        // Which is a sample's question, not a beat's, so it is answered to a
+        // hundredth of one: a block that opens before the bar line by less than
+        // that is the swallowed boundary above, and is in the bar it is about to
+        // render, not in the one before it.
+        const auto perSample = block.numSamples > 0
+                                   ? block.beats.length() / static_cast<double>(block.numSamples)
+                                   : 0.0;
+        const auto tolerance = magda::engine::kSampleEpsilon * perSample;
+
+        auto intoBar = block.beats.start - (inside - (position.beat * quartersPerBeat));
+        while (intoBar < -tolerance)
+            intoBar += barBeats;
+
+        ppqOfBarStart_.store(block.beats.start - intoBar, std::memory_order_relaxed);
     }
 
     juce::Optional<PositionInfo> getPosition() const override {

--- a/magda/engine/clip/ClipAudioSource.cpp
+++ b/magda/engine/clip/ClipAudioSource.cpp
@@ -116,7 +116,7 @@ void ClipAudioSource::gatherSession(const TrackClipPlayback& track, const BlockI
 
         // What is on the far side of the event is not rendered. The ramp
         // across that boundary is #2302's.
-        const auto split = splitSample(block, status);
+        const auto split = splitSample(block, status).value;
 
         play(status.beforeEvent, 0, split);
 

--- a/magda/engine/clip/ClipAudioSource.cpp
+++ b/magda/engine/clip/ClipAudioSource.cpp
@@ -159,6 +159,31 @@ void ClipAudioSource::render(const BlockInfo& block, juce::dsp::AudioBlock<float
     if (!snapshot)
         return silence();
 
+    // Compiled against a tempo map that has since changed: every second in it
+    // is wrong by however much the map moved (ClipSnapshot.hpp).
+    //
+    // Counted, and then played anyway. Not because playing it is right, but
+    // because the alternatives are worse in front of an audience: silence is a
+    // hole in the middle of a set, and the stale spans usually stop overlapping
+    // the block anyway, so refusing them mostly turns an accidental gap into a
+    // deliberate one. Re-deriving the seconds from the beats, which do survive
+    // a tempo edit, would be compiling on the audio thread, which is the one
+    // thing a snapshot exists to have already done.
+    //
+    // The count is the point. Zero is the only right answer and reaching it is
+    // the publish's job: the map and the snapshot compiled for it are meant to
+    // swap together, and this says when they did not (#2337).
+    //
+    // Coarser than the question it stands in for, and knowingly. The
+    // fingerprint is the whole map, while an arrangement clip's seconds depend
+    // on the map at its own placement and a session slot's depend on it only
+    // over beats zero to its length, because a slot compiles at the origin
+    // (ClipSnapshotCompiler.cpp). A tempo change at bar 200 moves neither a
+    // slot nor a clip before it, and still changes the fingerprint. Which is
+    // another reason this counts rather than acts.
+    if (block.tempo != nullptr && snapshot->tempoFingerprint != block.tempo->fingerprint())
+        staleSnapshots_.fetch_add(1, std::memory_order_relaxed);
+
     const auto* track = snapshot->find(trackId_);
     if (track == nullptr)
         return silence();

--- a/magda/engine/clip/ClipAudioSource.hpp
+++ b/magda/engine/clip/ClipAudioSource.hpp
@@ -119,6 +119,23 @@ class ClipAudioSource final : public EngineAudioSource {
         return starved_.load(std::memory_order_relaxed);
     }
 
+    /**
+     * @brief Blocks that rendered nothing because the snapshot was stale.
+     *
+     * A snapshot carries the fingerprint of the tempo map its seconds were
+     * derived through. One that is not the transport's was compiled against a
+     * tempo that has since changed, and playing it would put clips somewhere
+     * the transport is not.
+     *
+     * Zero is the only right answer, and reaching it is the publish's job
+     * rather than this one's: the map and the snapshot compiled for it are
+     * meant to swap together (#2337). Non-zero says they did not, which is a
+     * publish-ordering bug wearing the costume of an audio dropout.
+     */
+    int staleSnapshots() const {
+        return staleSnapshots_.load(std::memory_order_relaxed);
+    }
+
   private:
     /// One entry that sounds in this block, and the reader it sounds through.
     struct Sounding {
@@ -173,6 +190,7 @@ class ClipAudioSource final : public EngineAudioSource {
     juce::AudioBuffer<float> scratch_;
 
     std::atomic<int> starved_{0};
+    std::atomic<int> staleSnapshots_{0};
 };
 
 }  // namespace magda::engine

--- a/magda/engine/clip/ClipAudioSource.hpp
+++ b/magda/engine/clip/ClipAudioSource.hpp
@@ -120,17 +120,24 @@ class ClipAudioSource final : public EngineAudioSource {
     }
 
     /**
-     * @brief Blocks that rendered nothing because the snapshot was stale.
+     * @brief Blocks rendered against a map the snapshot was not compiled for.
      *
      * A snapshot carries the fingerprint of the tempo map its seconds were
      * derived through. One that is not the transport's was compiled against a
-     * tempo that has since changed, and playing it would put clips somewhere
-     * the transport is not.
+     * tempo that has since changed, so every second in it is wrong by however
+     * much the map moved.
+     *
+     * Counted and then played anyway. Refusing to play it is a hole in the
+     * middle of a set to report a bug that should not happen, and it buys
+     * little, because stale spans usually stop overlapping the block in any
+     * case: what that mostly converts is an accidental gap into a deliberate
+     * one.
      *
      * Zero is the only right answer, and reaching it is the publish's job
      * rather than this one's: the map and the snapshot compiled for it are
      * meant to swap together (#2337). Non-zero says they did not, which is a
-     * publish-ordering bug wearing the costume of an audio dropout.
+     * publish-ordering bug that would otherwise be inaudible until somebody
+     * wondered why a clip was in the wrong place.
      */
     int staleSnapshots() const {
         return staleSnapshots_.load(std::memory_order_relaxed);

--- a/magda/engine/clip/ClipMidiSource.cpp
+++ b/magda/engine/clip/ClipMidiSource.cpp
@@ -530,6 +530,31 @@ void ClipMidiSource::render(const BlockInfo& block, juce::MidiBuffer& out) {
         return;
     }
 
+    // Compiled against a tempo map that has since changed: every second in it
+    // is wrong by however much the map moved (ClipSnapshot.hpp).
+    //
+    // Counted, and then played anyway. Not because playing it is right, but
+    // because the alternatives are worse in front of an audience: silence is a
+    // hole in the middle of a set, and the stale spans usually stop overlapping
+    // the block anyway, so refusing them mostly turns an accidental gap into a
+    // deliberate one. Re-deriving the seconds from the beats, which do survive
+    // a tempo edit, would be compiling on the audio thread, which is the one
+    // thing a snapshot exists to have already done.
+    //
+    // The count is the point. Zero is the only right answer and reaching it is
+    // the publish's job: the map and the snapshot compiled for it are meant to
+    // swap together, and this says when they did not (#2337).
+    //
+    // Coarser than the question it stands in for, and knowingly. The
+    // fingerprint is the whole map, while an arrangement clip's seconds depend
+    // on the map at its own placement and a session slot's depend on it only
+    // over beats zero to its length, because a slot compiles at the origin
+    // (ClipSnapshotCompiler.cpp). A tempo change at bar 200 moves neither a
+    // slot nor a clip before it, and still changes the fingerprint. Which is
+    // another reason this counts rather than acts.
+    if (block.tempo != nullptr && live->tempoFingerprint != block.tempo->fingerprint())
+        staleSnapshots_.fetch_add(1, std::memory_order_relaxed);
+
     const auto* track = live->find(trackId_);
 
     // A stopped transport does not advance the timeline, so nothing new sounds;

--- a/magda/engine/clip/ClipMidiSource.cpp
+++ b/magda/engine/clip/ClipMidiSource.cpp
@@ -43,7 +43,7 @@ bool ClipMidiSource::fits(int bytes) const {
     return bytesUsed_ + bytes + reserved <= kMaxMidiBytesPerPort;
 }
 
-void ClipMidiSource::emit(juce::MidiBuffer& out, int sample, const MidiClipEvent& event) {
+void ClipMidiSource::emit(juce::MidiBuffer& out, EventSample sample, const MidiClipEvent& event) {
     // Two bytes or three, by status. Program change and channel pressure carry
     // one data byte, and building them as three makes a message whose length
     // disagrees with its status: JUCE would hand a synth a byte nobody sent.
@@ -54,7 +54,7 @@ void ClipMidiSource::emit(juce::MidiBuffer& out, int sample, const MidiClipEvent
                              ? juce::MidiMessage(event.status, event.data1)
                              : juce::MidiMessage(event.status, event.data1, event.data2);
 
-    out.addEvent(message, sample);
+    out.addEvent(message, sample.value);
 
     // Charged as a short message either way. The budget is a ceiling, and one
     // byte of slack per two-byte message spends it slightly early rather than
@@ -62,7 +62,7 @@ void ClipMidiSource::emit(juce::MidiBuffer& out, int sample, const MidiClipEvent
     bytesUsed_ += kMidiShortMessageBytes;
 }
 
-void ClipMidiSource::endNote(juce::MidiBuffer& out, int sample, int channel, int note) {
+void ClipMidiSource::endNote(juce::MidiBuffer& out, EventSample sample, int channel, int note) {
     if (!active_.active(channel, note))
         return;
 
@@ -70,7 +70,7 @@ void ClipMidiSource::endNote(juce::MidiBuffer& out, int sample, int channel, int
     activeCount_ = std::max(0, activeCount_ - 1);
 
     if (bytesUsed_ + kMidiShortMessageBytes <= kMaxMidiBytesPerPort) {
-        out.addEvent(juce::MidiMessage::noteOff(channel, note), sample);
+        out.addEvent(juce::MidiMessage::noteOff(channel, note), sample.value);
         bytesUsed_ += kMidiShortMessageBytes;
         return;
     }
@@ -83,7 +83,7 @@ void ClipMidiSource::endNote(juce::MidiBuffer& out, int sample, int channel, int
         owed_.push_back(OwedNote{channel, note});
 }
 
-void ClipMidiSource::endAll(juce::MidiBuffer& out, int sample) {
+void ClipMidiSource::endAll(juce::MidiBuffer& out, EventSample sample) {
     // Gathered before anything is emitted: endNote mutates the list.
     scratch_.clear();
     active_.forEach([this](int channel, int note) {
@@ -94,7 +94,7 @@ void ClipMidiSource::endAll(juce::MidiBuffer& out, int sample) {
         endNote(out, sample, packed / 1000, packed % 1000);
 }
 
-void ClipMidiSource::endClip(juce::MidiBuffer& out, int sample, ClipId clipId) {
+void ClipMidiSource::endClip(juce::MidiBuffer& out, EventSample sample, ClipId clipId) {
     scratch_.clear();
     active_.forEach([this, clipId](int channel, int note) {
         if (active_.owner(channel, note) == clipId)
@@ -144,7 +144,7 @@ void ClipMidiSource::startNote(juce::MidiBuffer& out, const BlockInfo& block,
         active_.startBeat(channel, note) == timelineBeat)
         return;
 
-    emit(out, block.sampleForBeat(timelineBeat), event);
+    emit(out, block.eventForBeat(timelineBeat), event);
 
     if (!active_.active(channel, note))
         ++activeCount_;
@@ -156,7 +156,7 @@ void ClipMidiSource::chaseClip(juce::MidiBuffer& out, const BlockInfo& block,
                                const MidiClipPlayback& clip, const MidiFoldPass& pass,
                                double timelineBeat) {
     const auto contentBeat = timelineBeat - pass.timelineOfContentZero;
-    const auto sample = block.sampleForBeat(timelineBeat);
+    const auto sample = block.eventForBeat(timelineBeat);
 
     // Controllers first, so a note struck below lands on a configured synth.
     //
@@ -327,7 +327,10 @@ void ClipMidiSource::renderClip(juce::MidiBuffer& out, const BlockInfo& block,
                     const auto onBeat = active_.startBeat(channel, note);
                     const auto at = std::clamp(timelineBeat, onBeat, passEndBeat);
 
-                    endNote(out, block.sampleForBeat(at), channel, note);
+                    // The end of a note's stretch, so an edge: one that falls
+                    // on the block boundary is heard a sample early rather than
+                    // written past the buffer (RenderContext.hpp).
+                    endNote(out, block.soundsAt(block.edgeForBeat(at)), channel, note);
                     continue;
                 }
 
@@ -339,7 +342,7 @@ void ClipMidiSource::renderClip(juce::MidiBuffer& out, const BlockInfo& block,
                     continue;
                 }
 
-                emit(out, block.sampleForBeat(timelineBeat), event);
+                emit(out, block.eventForBeat(timelineBeat), event);
             }
         }
 
@@ -347,7 +350,8 @@ void ClipMidiSource::renderClip(juce::MidiBuffer& out, const BlockInfo& block,
         // it. This is what the fold owes the invariant: every note that sounded
         // in a pass is ended inside the same pass.
         if (pass.endsPass)
-            endClip(out, block.sampleForBeat(pass.timelineOfContentZero + pass.windowEnd),
+            endClip(out,
+                    block.soundsAt(block.edgeForBeat(pass.timelineOfContentZero + pass.windowEnd)),
                     clip.clipId);
     }
 
@@ -391,7 +395,7 @@ void ClipMidiSource::playLane(juce::MidiBuffer& out, const BlockInfo& block,
         // looping off does not shorten a clip the way MidiClip::disableLooping
         // does.
         if (clip.span.beats.end > from && clip.span.beats.end <= to)
-            endClip(out, block.sampleForBeat(clip.span.beats.end), clip.clipId);
+            endClip(out, block.soundsAt(block.edgeForBeat(clip.span.beats.end)), clip.clipId);
     }
 }
 
@@ -426,7 +430,7 @@ void ClipMidiSource::expectLane(juce::MidiBuffer& out, const BlockInfo& block,
             // leaving it: ending first keeps the receiver's count right, and
             // striking it again is what makes the new clip's own note-off
             // legal when it arrives instead of rejected for the wrong owner.
-            endNote(out, 0, channel, note);
+            endNote(out, EventSample{0}, channel, note);
             startNote(out, block, clip, index, from);
         }
     }
@@ -442,10 +446,11 @@ void ClipMidiSource::endUnexpected(juce::MidiBuffer& out, const NoteMask& expect
     });
 
     for (std::size_t i = 0; i < scratch_.size(); ++i)
-        endNote(out, 0, scratch_[i] / 1000, scratch_[i] % 1000);
+        endNote(out, EventSample{0}, scratch_[i] / 1000, scratch_[i] % 1000);
 }
 
-void ClipMidiSource::endSlot(juce::MidiBuffer& out, int sample, const SessionSlotPlayback& slot) {
+void ClipMidiSource::endSlot(juce::MidiBuffer& out, EventSample sample,
+                             const SessionSlotPlayback& slot) {
     for (const auto& clip : slot.midi)
         endClip(out, sample, clip.clipId);
 }
@@ -489,21 +494,21 @@ bool ClipMidiSource::renderSession(juce::MidiBuffer& out, const BlockInfo& block
         endUnexpected(out, expected);
     }
 
-    forEachSlot(*handles.get(), track,
-                [&](const SessionSlotPlayback& slot, const SplitStatus& status) {
-                    eachPlaying(status, [&](const BlockInfo& material, double from, double to) {
-                        playLane(out, material, slot.midi, from, to);
-                    });
+    forEachSlot(
+        *handles.get(), track, [&](const SessionSlotPlayback& slot, const SplitStatus& status) {
+            eachPlaying(status, [&](const BlockInfo& material, double from, double to) {
+                playLane(out, material, slot.midi, from, to);
+            });
 
-                    // The session's own way for a note to end: a stop is not a hole,
-                    // not a snapshot swap and not the end of a span.
-                    //
-                    // Unconditional rather than edge-triggered. An already stopped
-                    // slot holds nothing, so this emits nothing and needs no memory
-                    // of the previous block.
-                    if (!status.playingAtEnd())
-                        endSlot(out, status.afterEvent ? splitSample(block, status) : 0, slot);
-                });
+            // The session's own way for a note to end: a stop is not a hole,
+            // not a snapshot swap and not the end of a span.
+            //
+            // Unconditional rather than edge-triggered. An already stopped
+            // slot holds nothing, so this emits nothing and needs no memory
+            // of the previous block.
+            if (!status.playingAtEnd())
+                endSlot(out, EventSample{status.afterEvent ? status.event.sample : 0}, slot);
+        });
 
     return true;
 }
@@ -525,7 +530,7 @@ void ClipMidiSource::render(const BlockInfo& block, juce::MidiBuffer& out) {
     const auto* live = snapshot.get();
 
     if (live == nullptr) {
-        endAll(out, 0);
+        endAll(out, EventSample{0});
         lastSnapshot_ = nullptr;
         return;
     }
@@ -560,13 +565,13 @@ void ClipMidiSource::render(const BlockInfo& block, juce::MidiBuffer& out) {
     // A stopped transport does not advance the timeline, so nothing new sounds;
     // what was sounding still has to end. The graph keeps running either way.
     if (!block.playing || track == nullptr || block.numSamples <= 0) {
-        endAll(out, 0);
+        endAll(out, EventSample{0});
         lastSnapshot_ = live;
         return;
     }
 
     if (!block.continuous)
-        endAll(out, 0);
+        endAll(out, EventSample{0});
 
     // A swap that moved or deleted what was sounding. Everything the new
     // snapshot agrees should be sounding here is left alone; the rest is
@@ -583,7 +588,7 @@ void ClipMidiSource::render(const BlockInfo& block, juce::MidiBuffer& out) {
 
     if (handles_ != nullptr) {
         if (!renderSession(out, block, *track, swapped))
-            endAll(out, 0);  // no handles published yet: nothing can be playing
+            endAll(out, EventSample{0});  // no handles published yet: nothing can be playing
 
         lastSnapshot_ = live;
         return;

--- a/magda/engine/clip/ClipMidiSource.hpp
+++ b/magda/engine/clip/ClipMidiSource.hpp
@@ -155,15 +155,15 @@ class ClipMidiSource final : public EngineMidiSource {
     /// Whether @p bytes more will fit, leaving room for every off still owed.
     bool fits(int bytes) const;
 
-    void emit(juce::MidiBuffer& out, int sample, const MidiClipEvent& event);
+    void emit(juce::MidiBuffer& out, EventSample sample, const MidiClipEvent& event);
 
     /// Note-off now, or owed if it will not fit. Always leaves the note not
     /// sounding.
-    void endNote(juce::MidiBuffer& out, int sample, int channel, int note);
+    void endNote(juce::MidiBuffer& out, EventSample sample, int channel, int note);
 
     /// End everything, or everything one clip owns.
-    void endAll(juce::MidiBuffer& out, int sample);
-    void endClip(juce::MidiBuffer& out, int sample, ClipId clipId);
+    void endAll(juce::MidiBuffer& out, EventSample sample);
+    void endClip(juce::MidiBuffer& out, EventSample sample, ClipId clipId);
 
     /// The notes of @p clip actually sounding at @p timelineBeat, into @ref
     /// scratch_. Grooved edges, not written ones, and one implementation for
@@ -197,7 +197,7 @@ class ClipMidiSource final : public EngineMidiSource {
     void endUnexpected(juce::MidiBuffer& out, const NoteMask& expected);
 
     /// Every note one slot started, ended at @p sample. What a stop owes.
-    void endSlot(juce::MidiBuffer& out, int sample, const SessionSlotPlayback& slot);
+    void endSlot(juce::MidiBuffer& out, EventSample sample, const SessionSlotPlayback& slot);
 
     /// What a launched slot plays and what a stopped one owes. False when no
     /// handles have been published yet.

--- a/magda/engine/clip/ClipMidiSource.hpp
+++ b/magda/engine/clip/ClipMidiSource.hpp
@@ -107,17 +107,24 @@ class ClipMidiSource final : public EngineMidiSource {
     }
 
     /**
-     * @brief Blocks that rendered nothing because the snapshot was stale.
+     * @brief Blocks rendered against a map the snapshot was not compiled for.
      *
      * A snapshot carries the fingerprint of the tempo map its seconds were
      * derived through. One that is not the transport's was compiled against a
-     * tempo that has since changed, and playing it would put clips somewhere
-     * the transport is not.
+     * tempo that has since changed, so every second in it is wrong by however
+     * much the map moved.
+     *
+     * Counted and then played anyway. Refusing to play it is a hole in the
+     * middle of a set to report a bug that should not happen, and it buys
+     * little, because stale spans usually stop overlapping the block in any
+     * case: what that mostly converts is an accidental gap into a deliberate
+     * one.
      *
      * Zero is the only right answer, and reaching it is the publish's job
      * rather than this one's: the map and the snapshot compiled for it are
      * meant to swap together (#2337). Non-zero says they did not, which is a
-     * publish-ordering bug wearing the costume of an audio dropout.
+     * publish-ordering bug that would otherwise be inaudible until somebody
+     * wondered why a clip was in the wrong place.
      */
     int staleSnapshots() const {
         return staleSnapshots_.load(std::memory_order_relaxed);

--- a/magda/engine/clip/ClipMidiSource.hpp
+++ b/magda/engine/clip/ClipMidiSource.hpp
@@ -106,6 +106,23 @@ class ClipMidiSource final : public EngineMidiSource {
         return overflowed_.load(std::memory_order_relaxed);
     }
 
+    /**
+     * @brief Blocks that rendered nothing because the snapshot was stale.
+     *
+     * A snapshot carries the fingerprint of the tempo map its seconds were
+     * derived through. One that is not the transport's was compiled against a
+     * tempo that has since changed, and playing it would put clips somewhere
+     * the transport is not.
+     *
+     * Zero is the only right answer, and reaching it is the publish's job
+     * rather than this one's: the map and the snapshot compiled for it are
+     * meant to swap together (#2337). Non-zero says they did not, which is a
+     * publish-ordering bug wearing the costume of an audio dropout.
+     */
+    int staleSnapshots() const {
+        return staleSnapshots_.load(std::memory_order_relaxed);
+    }
+
   private:
     /// One note owed an off that would not fit in the block that owed it.
     struct OwedNote {
@@ -212,6 +229,7 @@ class ClipMidiSource final : public EngineMidiSource {
 
     std::atomic<int> dropped_{0};
     std::atomic<int> overflowed_{0};
+    std::atomic<int> staleSnapshots_{0};
 };
 
 }  // namespace magda::engine

--- a/magda/engine/clip/ClipVoice.cpp
+++ b/magda/engine/clip/ClipVoice.cpp
@@ -147,7 +147,7 @@ bool ClipVoice::renderThroughCells(const AudioClipPlayback& clip, const AudioEve
     return full;
 }
 
-void ClipVoice::applyFade(juce::dsp::AudioBlock<float> region, int regionFirstSample,
+void ClipVoice::applyFade(juce::dsp::AudioBlock<float> region, EdgeSample regionFirstSample,
                           const BlockInfo& block, double startSeconds, double endSeconds,
                           FadeCurve curve, bool rising) const {
     const auto length = endSeconds - startSeconds;
@@ -159,23 +159,24 @@ void ClipVoice::applyFade(juce::dsp::AudioBlock<float> region, int regionFirstSa
         return;
 
     // The samples of the block the fade covers, narrowed to the ones this
-    // region holds. sampleForTime clamps to the block, so a fade that began
-    // before it or runs past it contributes the part that is here.
+    // region holds. Bounds rather than moments, so they may sit one past the
+    // block's last sample, and edgeForTime clamps them to it: a fade that began
+    // before this block or runs past it contributes the part that is here.
     const auto count = static_cast<int>(region.getNumSamples());
-    const auto from = std::max(regionFirstSample, block.sampleForTime(startSeconds));
-    const auto to = std::min(regionFirstSample + count, block.sampleForTime(endSeconds));
+    const auto from = std::max(regionFirstSample, block.edgeForTime(startSeconds));
+    const auto to = std::min(regionFirstSample + count, block.edgeForTime(endSeconds));
     if (to <= from)
         return;
 
     const auto secondsPerSample = blockSeconds / block.numSamples;
     const auto channels = region.getNumChannels();
 
-    for (auto sample = from; sample < to; ++sample) {
-        const auto seconds = block.seconds.start + sample * secondsPerSample;
+    for (auto sample = from.value; sample < to.value; ++sample) {
+        const auto seconds = block.seconds.start + (sample * secondsPerSample);
         const auto progress = static_cast<float>((seconds - startSeconds) / length);
         const auto gain = fadeGain(curve, rising ? progress : 1.0f - progress);
 
-        const auto index = static_cast<std::size_t>(sample - regionFirstSample);
+        const auto index = static_cast<std::size_t>(sample - regionFirstSample.value);
         for (std::size_t channel = 0; channel < channels; ++channel)
             region.getChannelPointer(channel)[index] *= gain;
     }
@@ -213,8 +214,8 @@ bool ClipVoice::render(const AudioClipPlayback& clip, const AudioEventPlayback& 
     if (windowEnd <= windowStart)
         return nothing();
 
-    const auto first = block.sampleForTime(windowStart);
-    const auto count = block.sampleForTime(windowEnd) - first;
+    const auto first = block.edgeForTime(windowStart);
+    const auto count = block.edgeForTime(windowEnd) - first;
     if (count <= 0)
         return nothing();
 
@@ -300,8 +301,8 @@ bool ClipVoice::render(const AudioClipPlayback& clip, const AudioEventPlayback& 
         if (holeEnd <= holeStart)
             continue;
 
-        const auto from = std::clamp(block.sampleForTime(holeStart) - first, 0, count);
-        const auto to = std::clamp(block.sampleForTime(holeEnd) - first, 0, count);
+        const auto from = std::clamp(block.edgeForTime(holeStart) - first, 0, count);
+        const auto to = std::clamp(block.edgeForTime(holeEnd) - first, 0, count);
         if (to > from)
             region.getSubBlock(static_cast<std::size_t>(from), static_cast<std::size_t>(to - from))
                 .clear();
@@ -394,7 +395,8 @@ bool ClipVoice::render(const AudioClipPlayback& clip, const AudioEventPlayback& 
         deClick_.advance(region);
     }
 
-    out.getSubBlock(static_cast<std::size_t>(first), static_cast<std::size_t>(count)).add(region);
+    out.getSubBlock(static_cast<std::size_t>(first.value), static_cast<std::size_t>(count))
+        .add(region);
 
     // Silence the reader could not fill is not sounding, and a block it only
     // half filled ends in that silence as surely as one it missed entirely.

--- a/magda/engine/clip/ClipVoice.hpp
+++ b/magda/engine/clip/ClipVoice.hpp
@@ -126,7 +126,7 @@ class ClipVoice {
 
     /// Multiply the part of @p region inside [@p startSeconds, @p endSeconds)
     /// by a curve running across it, rising or falling.
-    void applyFade(juce::dsp::AudioBlock<float> region, int regionFirstSample,
+    void applyFade(juce::dsp::AudioBlock<float> region, EdgeSample regionFirstSample,
                    const BlockInfo& block, double startSeconds, double endSeconds, FadeCurve curve,
                    bool rising) const;
 

--- a/magda/engine/clip/SessionPlayback.hpp
+++ b/magda/engine/clip/SessionPlayback.hpp
@@ -20,7 +20,7 @@ namespace magda::engine {
 
 /// Whether the material runs on from the last block. Material beat zero is a
 /// run beginning here (LaunchHandle::virtualStart), which is a discontinuity.
-inline bool runsOn(const BlockInfo& block, const BeatRange& range, const RunOrigin& origin) {
+inline bool runsOn(const BlockInfo& block, const BeatRange& range, const MaterialOrigin& origin) {
     return block.continuous && (range.start - origin.beat) > 0.0;
 }
 
@@ -40,7 +40,7 @@ inline bool runsOn(const BlockInfo& block, const BeatRange& range, const RunOrig
  * caller's.
  */
 inline BlockInfo materialBlock(const BlockInfo& block, const BeatRange& range,
-                               const RunOrigin& origin) {
+                               const MaterialOrigin& origin) {
     auto material = block;
     material.beats = BeatRange{block.beats.start - origin.beat, block.beats.end - origin.beat};
     material.seconds =
@@ -53,7 +53,7 @@ inline BlockInfo materialBlock(const BlockInfo& block, const BeatRange& range,
     // reader consuming its material against beats is asked about instants past
     // the end of the block, where the block's own two ends are a straight line
     // through whatever the tempo does next (RenderContext.hpp).
-    material.runOrigin = origin;
+    material.materialOrigin = origin;
     return material;
 }
 
@@ -67,7 +67,7 @@ inline BlockInfo materialBlock(const BlockInfo& block, const BeatRange& range,
  * ends (#2330).
  */
 inline BlockInfo materialSubBlock(const BlockInfo& block, const BeatRange& range,
-                                  const RunOrigin& origin, int offset, int count) {
+                                  const MaterialOrigin& origin, int offset, int count) {
     auto material = materialBlock(block, range, origin);
     material.numSamples = count;
     material.beats = BeatRange{range.start - origin.beat, range.end - origin.beat};

--- a/magda/engine/clip/SessionPlayback.hpp
+++ b/magda/engine/clip/SessionPlayback.hpp
@@ -87,8 +87,11 @@ inline BlockInfo materialSubBlock(const BlockInfo& block, const BeatRange& range
 
 /// Where in @p block the event landed, or the whole block when there was none.
 /// What starts a clip on its beat rather than on a callback boundary.
-inline int splitSample(const BlockInfo& block, const SplitStatus& status) {
-    return status.afterEvent ? status.event.sample : block.numSamples;
+///
+/// A bound rather than a moment: it is where one half of the block ends and the
+/// other begins, and with no event it is the boundary past the last sample.
+inline EdgeSample splitSample(const BlockInfo& block, const SplitStatus& status) {
+    return EdgeSample{status.afterEvent ? status.event.sample : block.numSamples};
 }
 
 /**

--- a/magda/engine/exec/RenderContext.hpp
+++ b/magda/engine/exec/RenderContext.hpp
@@ -54,6 +54,22 @@ struct RenderContext {
 struct BlockInfo {
     int numSamples = 0;
 
+    /**
+     * @brief What one sample of it is worth, in seconds.
+     *
+     * Here as well as on the RenderContext because the conversions below are
+     * the block's own and most of what calls them holds a block and nothing
+     * else: a MIDI clip placing a note, a metronome placing a tick.
+     *
+     * Zero says a block did not state one, which is a block assembled by hand,
+     * and the conversions then take it from the two faces the block does have.
+     * That derivation is the rate exactly whenever the block is well formed,
+     * because a block runs at one rate whatever the tempo does. What it cannot
+     * do is answer for a block that covers no time at all, which is a stopped
+     * one, and a stopped block places nothing.
+     */
+    double sampleRate = 0.0;
+
     /// Whether the transport is rolling. A stopped block still renders: the
     /// graph keeps running so tails ring out and live input passes through.
     /// What a stopped block does not do is advance the timeline, so its start
@@ -131,53 +147,151 @@ struct BlockInfo {
     bool continuous = false;
 
     /**
-     * @brief Sample offset within this block of a musical position inside it.
+     * @brief What one sample of this block is worth, in seconds.
      *
-     * The conversion every op needs and none of them should be doing twice: a
-     * MIDI clip placing a note, a metronome placing a tick. Linear across the
-     * block, which is exact at a constant tempo and, across a ramp, wrong by
-     * far less than a sample over the few milliseconds a block lasts.
-     *
-     * Positions outside the block clamp to its ends: an event has to land on a
-     * sample this block actually has.
+     * What the block says, or what its own two faces say when it says nothing.
+     * The derivation is the rate exactly whenever a block is well formed, since
+     * a block runs at one rate whatever the tempo does; zero for a block that
+     * covers no time and states no rate, which converts nothing.
      */
-    int sampleForBeat(double beat) const {
-        if (numSamples <= 0)
-            return 0;
-        if (beats.empty())
-            return 0;
+    double rate() const {
+        if (sampleRate > 0.0)
+            return sampleRate;
 
-        // Nearest rather than truncated: a position that lands exactly on a
-        // sample has to resolve to that sample, and the arithmetic getting
-        // there is not exact enough for truncation to promise it.
-        const auto position = (beat - beats.start) / beats.length();
-        const auto sample = static_cast<int>(std::lround(position * numSamples));
-        return std::clamp(sample, 0, numSamples - 1);
+        return seconds.length() > 0.0 ? static_cast<double>(numSamples) / seconds.length() : 0.0;
     }
 
     /**
-     * @brief Sample offset within this block of a moment inside it.
+     * @brief The moment @p beat falls on, on this block's own seconds axis.
      *
-     * As sampleForBeat, for the seconds face of the same instant. Exact rather
-     * than nearly so: the timeline runs at one second per sample rate through a
-     * block whatever the tempo is doing, so this is a straight line and not an
-     * approximation of a curve.
-     *
-     * One sample past the end of the block is a legal answer here, where it is
-     * not for a beat, and the difference is what the two are for. A beat places
-     * an event, which has to land on a sample this block has. Seconds place the
-     * edges of a region, and a region that runs to the end of the block ends at
-     * the sample after the last one, the way every half-open range does.
+     * The inverse of @ref beatAtTime, through the map for the same reason and
+     * with the same detour through the origin on a shifted block. The one
+     * conversion under everything below: a beat becomes a moment here, and a
+     * moment becomes a sample by counting them, which is the only step that
+     * does not need a tempo (#2336).
      */
-    int sampleForTime(double moment) const {
-        if (numSamples <= 0)
-            return 0;
-        if (seconds.empty())
-            return 0;
+    double timeForBeat(double beat) const {
+        if (tempo != nullptr)
+            return tempo->beatToTime(beat + runOrigin.beat) - runOrigin.seconds;
 
-        const auto position = (moment - seconds.start) / seconds.length();
-        const auto sample = static_cast<int>(std::lround(position * numSamples));
-        return std::clamp(sample, 0, numSamples);
+        if (beats.empty())
+            return seconds.start;
+
+        return seconds.start + (((beat - beats.start) / beats.length()) * seconds.length());
+    }
+
+    /**
+     * @brief How many samples into this block @p moment falls, unrounded.
+     *
+     * By counting samples, which is the one step that needs no tempo: a block
+     * runs at one rate whatever the map is doing.
+     */
+    double offsetForTime(double moment) const {
+        return (moment - seconds.start) * rate();
+    }
+
+    /**
+     * @brief How many samples into this block @p beat falls, unrounded.
+     *
+     * Through the seconds face, because that is where samples are counted, and
+     * therefore through the map wherever there is one: a beat's distance into
+     * the block is a question about when it happens, and the answer is only a
+     * straight line while the tempo is.
+     *
+     * A block with no seconds face at all is one assembled by hand from beats,
+     * and its own two beat ends are then the only line there is.
+     */
+    double offsetForBeat(double beat) const {
+        if (!seconds.empty() && rate() > 0.0)
+            return offsetForTime(timeForBeat(beat));
+
+        return beats.empty() ? 0.0 : ((beat - beats.start) / beats.length()) * numSamples;
+    }
+
+    /**
+     * @brief The sample of this block that something @p offset samples in
+     * happens on.
+     *
+     * Floor rather than nearest, which is what makes the answer total. A block
+     * covers the half-open stretch its samples run over, so a moment inside it
+     * is somewhere in `[0, N)` and the sample it is inside is `0..N-1`, always,
+     * with no case to clamp away. Nearest has one: a moment in the block's last
+     * half sample rounds to N, which is not a sample this block has, and the
+     * clamp that used to hide that is the defect the epic names (#2336).
+     *
+     * A moment on the boundary belongs to the next block, where it is sample
+     * zero, and it gets there without anything being carried: the next block's
+     * stretch begins there.
+     *
+     * The epsilon is why this is not plain truncation. A moment that is the
+     * block's own start can come out at minus a billionth of a sample, and a
+     * beat asked for on a shifted block has had an origin taken off it and put
+     * back on. Floor turns either into the sample before, which is an event in
+     * the wrong block or none at all; the same reason TransportClock guards its
+     * own ceiling.
+     *
+     * The clamp is a guard rather than the rule. Every caller resolves a
+     * position its own bounds have already put inside the block.
+     */
+    EventSample eventAt(double offset) const {
+        if (numSamples <= 0)
+            return EventSample{0};
+
+        const auto sample = static_cast<int>(std::floor(offset + kSampleEpsilon));
+        return EventSample{std::clamp(sample, 0, numSamples - 1)};
+    }
+
+    /**
+     * @brief Where a stretch that begins or ends @p offset samples in has its
+     * edge.
+     *
+     * Nearest, and N is a legal answer: a region that runs to the end of the
+     * block ends at the sample after the last one, the way every half-open
+     * range does. An edge is a bound rather than a moment something happens at,
+     * so it is not floored to the sample it is inside; a fade that begins a
+     * hair before a sample begins on it.
+     */
+    EdgeSample edgeAt(double offset) const {
+        if (numSamples <= 0)
+            return EdgeSample{0};
+
+        return EdgeSample{std::clamp(static_cast<int>(std::lround(offset)), 0, numSamples)};
+    }
+
+    /// The sample of this block that @p moment happens on.
+    EventSample eventForTime(double moment) const {
+        return seconds.empty() ? EventSample{0} : eventAt(offsetForTime(moment));
+    }
+
+    /// The sample of this block that @p beat happens on.
+    EventSample eventForBeat(double beat) const {
+        return beats.empty() ? EventSample{0} : eventAt(offsetForBeat(beat));
+    }
+
+    /// Where a stretch bounded by @p moment has its edge.
+    EdgeSample edgeForTime(double moment) const {
+        return seconds.empty() ? EdgeSample{0} : edgeAt(offsetForTime(moment));
+    }
+
+    /// Where a stretch bounded by @p beat has its edge.
+    EdgeSample edgeForBeat(double beat) const {
+        return beats.empty() ? EdgeSample{0} : edgeAt(offsetForBeat(beat));
+    }
+
+    /**
+     * @brief The sample an edge that has to be heard is emitted on.
+     *
+     * A note-off is where a note's stretch ends, so it is an edge and lands on
+     * N whenever a clip or a loop pass ends on the block boundary. It is also a
+     * message, and a message at N is written into nobody's buffer: the block
+     * that owns that sample is the next one, and by the time it renders, the
+     * stretch that owed the off has gone. What is left is a note that hangs.
+     *
+     * So an emitted edge at N sounds on N-1 instead. One sample early, against
+     * a note that rings until the session ends.
+     */
+    EventSample soundsAt(EdgeSample edge) const {
+        return EventSample{std::clamp(edge.value, 0, std::max(0, numSamples - 1))};
     }
 
     /**

--- a/magda/engine/exec/RenderContext.hpp
+++ b/magda/engine/exec/RenderContext.hpp
@@ -124,8 +124,14 @@ struct BlockInfo {
      * nothing may: a map converts a position, and after a wrap two monotonic
      * beats are not in the same cycle (#2324).
      *
-     * What asks is a run needing to know how far into its material it is: a
-     * launched session clip reading a file at its own speed (LaunchHandle.hpp).
+     * Kept because it is the one thing @ref monotonicSamples cannot answer: how
+     * long the transport has actually rolled, across a rate change as well as
+     * within one. A count of samples divided by the rate they are being counted
+     * at now is not that, because they were not all worth the same amount of
+     * time. A run's own elapsed time is measured from the samples instead
+     * (LaunchHandle.hpp), and it handles a rate change by re-counting its
+     * origin rather than by reading this.
+     *
      * A stopped block does not advance it.
      */
     SecondsRange monotonicSeconds;
@@ -172,7 +178,7 @@ struct BlockInfo {
      */
     double timeForBeat(double beat) const {
         if (tempo != nullptr)
-            return tempo->beatToTime(beat + runOrigin.beat) - runOrigin.seconds;
+            return tempo->beatToTime(beat + materialOrigin.beat) - materialOrigin.seconds;
 
         if (beats.empty())
             return seconds.start;
@@ -208,74 +214,25 @@ struct BlockInfo {
         return beats.empty() ? 0.0 : ((beat - beats.start) / beats.length()) * numSamples;
     }
 
-    /**
-     * @brief The sample of this block that something @p offset samples in
-     * happens on.
-     *
-     * Floor rather than nearest, which is what makes the answer total. A block
-     * covers the half-open stretch its samples run over, so a moment inside it
-     * is somewhere in `[0, N)` and the sample it is inside is `0..N-1`, always,
-     * with no case to clamp away. Nearest has one: a moment in the block's last
-     * half sample rounds to N, which is not a sample this block has, and the
-     * clamp that used to hide that is the defect the epic names (#2336).
-     *
-     * A moment on the boundary belongs to the next block, where it is sample
-     * zero, and it gets there without anything being carried: the next block's
-     * stretch begins there.
-     *
-     * The epsilon is why this is not plain truncation. A moment that is the
-     * block's own start can come out at minus a billionth of a sample, and a
-     * beat asked for on a shifted block has had an origin taken off it and put
-     * back on. Floor turns either into the sample before, which is an event in
-     * the wrong block or none at all; the same reason TransportClock guards its
-     * own ceiling.
-     *
-     * The clamp is a guard rather than the rule. Every caller resolves a
-     * position its own bounds have already put inside the block.
-     */
-    EventSample eventAt(double offset) const {
-        if (numSamples <= 0)
-            return EventSample{0};
-
-        const auto sample = static_cast<int>(std::floor(offset + kSampleEpsilon));
-        return EventSample{std::clamp(sample, 0, numSamples - 1)};
-    }
-
-    /**
-     * @brief Where a stretch that begins or ends @p offset samples in has its
-     * edge.
-     *
-     * Nearest, and N is a legal answer: a region that runs to the end of the
-     * block ends at the sample after the last one, the way every half-open
-     * range does. An edge is a bound rather than a moment something happens at,
-     * so it is not floored to the sample it is inside; a fade that begins a
-     * hair before a sample begins on it.
-     */
-    EdgeSample edgeAt(double offset) const {
-        if (numSamples <= 0)
-            return EdgeSample{0};
-
-        return EdgeSample{std::clamp(static_cast<int>(std::lround(offset)), 0, numSamples)};
-    }
-
-    /// The sample of this block that @p moment happens on.
+    /// The sample of this block that @p moment happens on
+    /// (TimeDomains::eventAt).
     EventSample eventForTime(double moment) const {
-        return seconds.empty() ? EventSample{0} : eventAt(offsetForTime(moment));
+        return seconds.empty() ? EventSample{0} : eventAt(offsetForTime(moment), numSamples);
     }
 
     /// The sample of this block that @p beat happens on.
     EventSample eventForBeat(double beat) const {
-        return beats.empty() ? EventSample{0} : eventAt(offsetForBeat(beat));
+        return beats.empty() ? EventSample{0} : eventAt(offsetForBeat(beat), numSamples);
     }
 
-    /// Where a stretch bounded by @p moment has its edge.
+    /// Where a stretch bounded by @p moment has its edge (TimeDomains::edgeAt).
     EdgeSample edgeForTime(double moment) const {
-        return seconds.empty() ? EdgeSample{0} : edgeAt(offsetForTime(moment));
+        return seconds.empty() ? EdgeSample{0} : edgeAt(offsetForTime(moment), numSamples);
     }
 
     /// Where a stretch bounded by @p beat has its edge.
     EdgeSample edgeForBeat(double beat) const {
-        return beats.empty() ? EdgeSample{0} : edgeAt(offsetForBeat(beat));
+        return beats.empty() ? EdgeSample{0} : edgeAt(offsetForBeat(beat), numSamples);
     }
 
     /**
@@ -323,7 +280,7 @@ struct BlockInfo {
         // timeline to be asked about, and the answer comes back onto the run's
         // own axis. Zero on a timeline block, where this is the map itself.
         if (tempo != nullptr)
-            return tempo->timeToBeat(moment + runOrigin.seconds) - runOrigin.beat;
+            return tempo->timeToBeat(moment + materialOrigin.seconds) - materialOrigin.beat;
 
         if (seconds.empty())
             return beats.start;
@@ -356,7 +313,7 @@ struct BlockInfo {
     /// Always the timeline's, even where the axes above are not: a shifted
     /// block records the shift below rather than pretending the map is its own.
     /// Anything reaching for this directly is asking a timeline question and
-    /// has to put @ref runOrigin back first.
+    /// has to put @ref materialOrigin back first.
     const TempoMap* tempo = nullptr;
 
     /**
@@ -371,7 +328,7 @@ struct BlockInfo {
      * leave the block's own two ends as the only answer, and that straight
      * line is exactly what the cell path above cannot afford.
      */
-    RunOrigin runOrigin;
+    MaterialOrigin materialOrigin;
 };
 
 }  // namespace magda::engine

--- a/magda/engine/exec/RenderContext.hpp
+++ b/magda/engine/exec/RenderContext.hpp
@@ -187,6 +187,29 @@ struct BlockInfo {
     }
 
     /**
+     * @brief Which beat to ask the map about this block's own tempo, signature
+     * or bar.
+     *
+     * Not the block's start, which is where anything reading one of those would
+     * naturally look. A block covers one tempo section, because the transport
+     * cuts a callback at every boundary (TransportClock.cpp), but a cut lands
+     * on the first sample at or after the boundary, so the block can begin a
+     * fraction of a sample before it. The beat at its start is then in the
+     * section it is leaving while every sample it renders is in the next, and a
+     * consumer that takes one rate for the whole block takes the wrong one: an
+     * LFO runs the block at the tempo it just left, a hosted plugin is told the
+     * old signature for the whole call.
+     *
+     * The middle is inside the section on every alignment. This answers "which
+     * section is this block in" and nothing else; where the block *is* stays
+     * @ref beats and @ref seconds, and a position derived under this section is
+     * projected back to them by the caller (#2336).
+     */
+    double sectionBeat() const {
+        return beats.start + (0.5 * beats.length());
+    }
+
+    /**
      * @brief How many samples into this block @p moment falls, unrounded.
      *
      * By counting samples, which is the one step that needs no tempo: a block

--- a/magda/engine/io/FileAudioSource.cpp
+++ b/magda/engine/io/FileAudioSource.cpp
@@ -22,8 +22,8 @@ void FileAudioSource::render(const BlockInfo& block, juce::dsp::AudioBlock<float
     // both ends, so a clip ending exactly on a block boundary contributes
     // nothing to the block that starts there. Identical to the streaming
     // source, because it is the same clip in the same place.
-    const auto first = block.sampleForTime(std::max(block.seconds.start, placement_.seconds.start));
-    const auto last = block.sampleForTime(std::min(block.seconds.end, placement_.seconds.end));
+    const auto first = block.edgeForTime(std::max(block.seconds.start, placement_.seconds.start));
+    const auto last = block.edgeForTime(std::min(block.seconds.end, placement_.seconds.end));
     const auto count = last - first;
 
     if (count <= 0)
@@ -47,7 +47,7 @@ void FileAudioSource::render(const BlockInfo& block, juce::dsp::AudioBlock<float
         std::min(static_cast<int>(out.getNumChannels()), scratch_.getNumChannels());
     for (auto channel = 0; channel < channels; ++channel)
         juce::FloatVectorOperations::copy(out.getChannelPointer(static_cast<std::size_t>(channel)) +
-                                              first,
+                                              first.value,
                                           scratch_.getReadPointer(channel), count);
 }
 

--- a/magda/engine/io/StreamingAudioSource.cpp
+++ b/magda/engine/io/StreamingAudioSource.cpp
@@ -26,8 +26,8 @@ void StreamingAudioSource::render(const BlockInfo& block, juce::dsp::AudioBlock<
     // The part of the block the clip covers, as samples of it. Half-open at
     // both ends, so a clip ending exactly on a block boundary contributes
     // nothing to the block that starts there.
-    const auto first = block.sampleForTime(std::max(block.seconds.start, placement_.seconds.start));
-    const auto last = block.sampleForTime(std::min(block.seconds.end, placement_.seconds.end));
+    const auto first = block.edgeForTime(std::max(block.seconds.start, placement_.seconds.start));
+    const auto last = block.edgeForTime(std::min(block.seconds.end, placement_.seconds.end));
     const auto count = last - first;
 
     if (count <= 0)
@@ -40,9 +40,10 @@ void StreamingAudioSource::render(const BlockInfo& block, juce::dsp::AudioBlock<
     const auto sourceStart =
         sourceSampleAt(std::max(block.seconds.start, placement_.seconds.start));
 
-    stream_.read(sourceStart,
-                 out.getSubBlock(static_cast<std::size_t>(first), static_cast<std::size_t>(count)),
-                 count);
+    stream_.read(
+        sourceStart,
+        out.getSubBlock(static_cast<std::size_t>(first.value), static_cast<std::size_t>(count)),
+        count);
 }
 
 }  // namespace magda::engine

--- a/magda/engine/launch/LaunchHandle.cpp
+++ b/magda/engine/launch/LaunchHandle.cpp
@@ -16,13 +16,46 @@ double LaunchHandle::virtualStart(const SyncRange& piece) const {
     // Derived from monotonic elapsed, which is the one quantity that survives
     // the wrap. It may sit before the block or before zero, and that is what it
     // means: the run began that far back.
-    return piece.timeline.start - (piece.monotonic.start - playedMonotonic_->start);
+    return piece.timeline.start - (piece.monotonic.start - run_->originBeat);
+}
+
+double LaunchHandle::elapsedSecondsAt(const SyncRange& piece) const {
+    // A subtraction of two sample counts, which is exact, rather than an
+    // accumulation of per-block seconds. Between rate changes: a count that
+    // spans one counts samples that were not all worth the same amount of time,
+    // which is what followRate is for.
+    return (piece.monotonicSamples.start - run_->origin).seconds(run_->sampleRate);
 }
 
 double LaunchHandle::virtualStartSeconds(const SyncRange& piece) const {
-    // The same, off the monotonic seconds. Not the beat origin converted: a map
-    // says where a beat sits, not how long a run has lasted (#2324).
-    return piece.seconds.start - (piece.monotonicSeconds.start - playedMonotonicSeconds_->start);
+    // The same as virtualStart, on the seconds axis. Not the beat origin
+    // converted: a map says where a beat sits, not how long a run has lasted
+    // (#2324).
+    return piece.seconds.start - elapsedSecondsAt(piece);
+}
+
+void LaunchHandle::followRate(const SyncRange& piece) {
+    if (!run_ || piece.rate() <= 0.0 || piece.rate() == run_->sampleRate)
+        return;
+
+    // The device changed rate under a slot that is playing. The origin is a
+    // count of samples and the samples are not the same length any more, so
+    // holding the number would silently change how far into its material the
+    // run is. What is kept instead is the elapsed time it has actually had, and
+    // the origin is re-counted behind the block at the new rate.
+    //
+    // Which depends on this block being the first at the new rate, and that is
+    // an invariant rather than a guess: advanceLaunchHandles advances every
+    // handle over every block before anything renders (SessionLauncher.hpp), so
+    // a handle cannot miss the block a change arrives on.
+    if (run_->sampleRate > 0.0) {
+        const auto elapsed = elapsedSecondsAt(piece);
+        run_->origin =
+            piece.monotonicSamples.start - SampleDuration::ofSeconds(elapsed, piece.rate());
+        run_->through = std::max(run_->through, run_->origin);
+    }
+
+    run_->sampleRate = piece.rate();
 }
 
 std::optional<LaunchHandle::QueueState> LaunchHandle::queuedState() const {
@@ -40,29 +73,23 @@ std::optional<double> LaunchHandle::queuedPosition() const {
 }
 
 void LaunchHandle::play(std::optional<double> monotonicBeat) {
-    pending_ = Pending{QueueState::playQueued, monotonicBeat, {}, {}, {}};
+    pending_ = Pending{QueueState::playQueued, monotonicBeat, {}};
 }
 
 void LaunchHandle::stop(std::optional<double> monotonicBeat) {
-    pending_ = Pending{QueueState::stopQueued, monotonicBeat, {}, {}, {}};
+    pending_ = Pending{QueueState::stopQueued, monotonicBeat, {}};
 }
 
 void LaunchHandle::playSynced(const LaunchHandle& other, std::optional<double> monotonicBeat) {
-    Pending pending{QueueState::playQueued, monotonicBeat, {}, {}, {}};
-
-    // The origin rather than the launch point, which is the whole difference
+    // The run rather than the launch point, which is the whole difference
     // between this and play(): a handle joining one that is already three bars
     // into its run reports the same played range as it does, so the two agree
     // about where in the material they are instead of merely starting together.
     //
-    // All three faces, or the agreement is only musical.
-    if (other.played_ && other.playedMonotonic_ && other.playedMonotonicSeconds_) {
-        pending.syncedTimelineOrigin = other.played_->start;
-        pending.syncedMonotonicOrigin = other.playedMonotonic_->start;
-        pending.syncedMonotonicSecondsOrigin = other.playedMonotonicSeconds_->start;
-    }
-
-    pending_ = pending;
+    // The whole run, because its faces are one instant. Copying some of them
+    // and deriving the rest is how two handles end up agreeing about the bar
+    // and not the sample.
+    pending_ = Pending{QueueState::playQueued, monotonicBeat, other.run_};
 }
 
 void LaunchHandle::setLooping(std::optional<double> beats) {
@@ -74,77 +101,124 @@ void LaunchHandle::setLooping(std::optional<double> beats) {
     loopBeats_ = beats;
 }
 
-void LaunchHandle::nudge(double beats, double seconds) {
+void LaunchHandle::nudge(double beats, SampleDuration samples) {
     // The origin moves, not the end: the played length is what a source reads
     // its position from, so shifting where the run began is what moves the
     // playhead through the material without interrupting the run.
-    if (!played_ || !playedMonotonic_ || !playedMonotonicSeconds_)
+    if (!run_)
         return;
 
     // Backwards only as far as the run has got, each axis by its own length.
     // Further would put the origin in the future.
-    const auto effectiveBeats = std::max(beats, -played_->length());
-    const auto effectiveSeconds = std::max(seconds, -playedMonotonicSeconds_->length());
+    const auto effectiveBeats = std::max(beats, -run_->elapsedBeats);
+    const auto effectiveSamples =
+        std::max(samples, SampleDuration{-(run_->through - run_->origin).samples});
 
-    played_->start -= effectiveBeats;
-    playedMonotonic_->start -= effectiveBeats;
-    playedMonotonicSeconds_->start -= effectiveSeconds;
+    run_->originBeat -= effectiveBeats;
+    run_->originTimelineBeat -= effectiveBeats;
+    run_->elapsedBeats += effectiveBeats;
+    run_->origin = run_->origin - effectiveSamples;
+
+    // The schedule moves with the run: a loop counts from where the run now
+    // begins, or a nudge would leave the wraps where the un-nudged run put them.
+    run_->scheduleBeat -= effectiveBeats;
 }
 
 std::optional<BeatRange> LaunchHandle::playedRange() const {
-    return played_;
+    if (!run_)
+        return {};
+
+    return BeatRange{run_->originTimelineBeat, run_->originTimelineBeat + run_->elapsedBeats};
 }
 
 std::optional<BeatRange> LaunchHandle::playedMonotonicRange() const {
-    return playedMonotonic_;
+    if (!run_)
+        return {};
+
+    return BeatRange{run_->originBeat, run_->originBeat + run_->elapsedBeats};
 }
 
-std::optional<SecondsRange> LaunchHandle::playedMonotonicSecondsRange() const {
-    return playedMonotonicSeconds_;
+std::optional<SampleRange> LaunchHandle::playedSampleRange() const {
+    if (!run_)
+        return {};
+
+    return SampleRange{run_->origin, run_->through};
 }
 
 std::optional<BeatRange> LaunchHandle::lastPlayedRange() const {
     return lastPlayed_;
 }
 
-void LaunchHandle::beginRun(const BlockInstant& at, double elapsedBeats, double elapsedSeconds) {
-    if (played_)
-        lastPlayed_ = played_;
+void LaunchHandle::beginRun(const SyncRange& range, const BlockInstant& at, double scheduledBeat) {
+    if (const auto played = playedRange())
+        lastPlayed_ = played;
 
     playState_ = PlayState::playing;
-    played_ = BeatRange{at.timelineBeat, at.timelineBeat + elapsedBeats};
-    playedMonotonic_ = BeatRange{at.monotonicBeat, at.monotonicBeat + elapsedBeats};
-    playedMonotonicSeconds_ =
-        SecondsRange{at.monotonicSeconds, at.monotonicSeconds + elapsedSeconds};
+
+    Run run;
+    run.origin = at.monotonic;
+    run.through = at.monotonic;
+    run.originBeat = range.monotonicBeatAt(at);
+    run.originTimelineBeat = range.timelineBeatAt(at);
+
+    // The beat that was asked for, not the one the sample landed on. Everything
+    // a run sounds is measured from the sample; everything it schedules is
+    // measured from here (Run::scheduleBeat).
+    run.scheduleBeat = scheduledBeat;
+    run.sampleRate = range.rate();
+
+    run_ = run;
+}
+
+void LaunchHandle::joinRun(const SyncRange& range, const BlockInstant& at, const Run& other) {
+    if (const auto played = playedRange())
+        lastPlayed_ = played;
+
+    playState_ = PlayState::playing;
+
+    // Adopting the position, not just the origin. Derived here rather than at
+    // the request, which is a different number whenever the launch was queued
+    // for a later beat.
+    auto run = other;
+    run.through = at.monotonic;
+    run.elapsedBeats = range.monotonicBeatAt(at) - other.originBeat;
+
+    run_ = run;
 }
 
 void LaunchHandle::endRun() {
-    if (played_)
-        lastPlayed_ = played_;
+    if (const auto played = playedRange())
+        lastPlayed_ = played;
 
     playState_ = PlayState::stopped;
-    played_.reset();
-    playedMonotonic_.reset();
-    playedMonotonicSeconds_.reset();
+    run_.reset();
 }
 
 void LaunchHandle::extendRun(const SyncRange& piece) {
-    if (!played_ || !playedMonotonic_ || !playedMonotonicSeconds_)
+    if (!run_)
         return;
 
-    // Lengths rather than endpoints. The timeline goes backwards every time the
-    // loop wraps and the played range may not, so a run that assigned the
+    // A length rather than an endpoint. The timeline goes backwards every time
+    // the loop wraps and the played range may not, so a run that assigned the
     // block's end beat would shrink at every wrap.
-    played_->end += piece.timeline.length();
-    playedMonotonic_->end += piece.monotonic.length();
-    playedMonotonicSeconds_->end += piece.monotonicSeconds.length();
+    run_->elapsedBeats += piece.monotonic.length();
+
+    // The far end of the sample axis is an endpoint, and can be: nothing takes
+    // it back.
+    run_->through = piece.monotonicSamples.end;
 }
 
-void LaunchHandle::applyEvent(bool fromPending, const BlockInstant& at) {
+void LaunchHandle::applyEvent(const SyncRange& range, bool fromPending, const BlockInstant& at,
+                              double scheduledBeat) {
     if (!fromPending) {
         // A loop re-trigger, which is a relaunch at the wrap: same handle, new
         // run, so the played range restarts and whatever reads it seeks.
-        beginRun(at);
+        //
+        // The schedule carries over rather than restarting with it. Re-anchoring
+        // it to the wrap that just fired is what makes the next interval start
+        // from a rounded beat, and that error accumulates (Run::scheduleBeat).
+        const auto schedule = run_ ? run_->scheduleBeat : scheduledBeat;
+        beginRun(range, at, schedule);
         return;
     }
 
@@ -156,24 +230,12 @@ void LaunchHandle::applyEvent(bool fromPending, const BlockInstant& at) {
         return;
     }
 
-    if (!pending.syncedMonotonicOrigin || !pending.syncedTimelineOrigin ||
-        !pending.syncedMonotonicSecondsOrigin) {
-        beginRun(at);
+    if (!pending.synced) {
+        beginRun(range, at, scheduledBeat);
         return;
     }
 
-    // Joining means adopting the position, not just the origin. Derived here
-    // rather than at the request, which is a different number whenever the
-    // launch was queued for a later beat.
-    // The origin is another handle's, so it is not an instant in this block and
-    // is carried as the three faces that handle recorded rather than derived.
-    BlockInstant origin = at;
-    origin.timelineBeat = *pending.syncedTimelineOrigin;
-    origin.monotonicBeat = *pending.syncedMonotonicOrigin;
-    origin.monotonicSeconds = *pending.syncedMonotonicSecondsOrigin;
-
-    beginRun(origin, at.monotonicBeat - *pending.syncedMonotonicOrigin,
-             at.monotonicSeconds - *pending.syncedMonotonicSecondsOrigin);
+    joinRun(range, at, *pending.synced);
 }
 
 SplitStatus LaunchHandle::advance(const SyncRange& range) {
@@ -182,6 +244,8 @@ SplitStatus LaunchHandle::advance(const SyncRange& range) {
 }
 
 SplitStatus LaunchHandle::advanceOver(const SyncRange& range) {
+    followRate(range);
+
     SplitStatus status;
     status.beforeEvent.range = range.timeline;
 
@@ -213,8 +277,10 @@ SplitStatus LaunchHandle::advanceOver(const SyncRange& range) {
         }
     }
 
-    if (!eventBeat && playState_ == PlayState::playing && loopBeats_ && playedMonotonic_) {
-        const auto origin = playedMonotonic_->start;
+    if (!eventBeat && playState_ == PlayState::playing && loopBeats_ && run_) {
+        // From the beat the run was scheduled for rather than the one it
+        // sounded on, which is what keeps a thousand wraps exact (#2336).
+        const auto origin = run_->scheduleBeat;
         const auto elapsed = range.monotonic.start - origin;
 
         // The first wrap at or after this block begins, which is ceil rather
@@ -224,7 +290,7 @@ SplitStatus LaunchHandle::advanceOver(const SyncRange& range) {
         // block-aligned wrap after it. Never the origin itself, which is where
         // the run started rather than somewhere it repeats.
         const auto turns = std::max(1.0, std::ceil(elapsed / *loopBeats_));
-        auto wrap = origin + turns * *loopBeats_;
+        auto wrap = origin + (turns * *loopBeats_);
 
         while (wrap < range.monotonic.start)
             wrap += *loopBeats_;
@@ -243,7 +309,8 @@ SplitStatus LaunchHandle::advanceOver(const SyncRange& range) {
 
     if (!eventBeat) {
         if (playState_ == PlayState::playing) {
-            status.beforeEvent.origin = RunOrigin{virtualStart(range), virtualStartSeconds(range)};
+            status.beforeEvent.origin =
+                MaterialOrigin{virtualStart(range), virtualStartSeconds(range)};
             extendRun(range);
         }
 
@@ -261,43 +328,34 @@ SplitStatus LaunchHandle::advanceOver(const SyncRange& range) {
     // first half would be the same answer in a shape every caller has to
     // defend against.
     if (event.sample <= 0) {
-        applyEvent(fromPending, range.start());
+        applyEvent(range, fromPending, range.start(), *eventBeat);
 
         if (playState_ == PlayState::playing) {
-            status.beforeEvent.origin = RunOrigin{virtualStart(range), virtualStartSeconds(range)};
+            status.beforeEvent.origin =
+                MaterialOrigin{virtualStart(range), virtualStartSeconds(range)};
             extendRun(range);
         }
 
         return status;
     }
 
-    const SyncRange first{BeatRange{range.timeline.start, event.timelineBeat},
-                          BeatRange{range.monotonic.start, event.monotonicBeat},
-                          SecondsRange{range.seconds.start, event.timelineSeconds},
-                          SecondsRange{range.monotonicSeconds.start, event.monotonicSeconds},
-                          event.sample,
-                          range.tempo};
-    const SyncRange second{BeatRange{event.timelineBeat, range.timeline.end},
-                           BeatRange{event.monotonicBeat, range.monotonic.end},
-                           SecondsRange{event.timelineSeconds, range.seconds.end},
-                           SecondsRange{event.monotonicSeconds, range.monotonicSeconds.end},
-                           range.numSamples - event.sample,
-                           range.tempo};
+    const auto first = range.upTo(event);
+    const auto second = range.from(event);
 
     status.beforeEvent.range = first.timeline;
 
     if (playState_ == PlayState::playing) {
-        status.beforeEvent.origin = RunOrigin{virtualStart(first), virtualStartSeconds(first)};
+        status.beforeEvent.origin = MaterialOrigin{virtualStart(first), virtualStartSeconds(first)};
         extendRun(first);
     }
 
-    applyEvent(fromPending, event);
+    applyEvent(range, fromPending, event, *eventBeat);
 
     BlockPiece after;
     after.range = second.timeline;
 
     if (playState_ == PlayState::playing) {
-        after.origin = RunOrigin{virtualStart(second), virtualStartSeconds(second)};
+        after.origin = MaterialOrigin{virtualStart(second), virtualStartSeconds(second)};
         extendRun(second);
     }
 

--- a/magda/engine/launch/LaunchHandle.cpp
+++ b/magda/engine/launch/LaunchHandle.cpp
@@ -34,28 +34,49 @@ double LaunchHandle::virtualStartSeconds(const SyncRange& piece) const {
     return piece.seconds.start - elapsedSecondsAt(piece);
 }
 
+void LaunchHandle::recountRun(Run& run, const SyncRange& piece) {
+    // The device changed rate under a run. The origin is a count of samples and
+    // the samples are not the same length any more, so holding the number would
+    // silently change how far into its material the run is. What is kept
+    // instead is the elapsed time it has actually had, and the origin is
+    // re-counted behind the block at the new rate.
+    if (run.sampleRate > 0.0) {
+        const auto elapsed = (piece.monotonicSamples.start - run.origin).seconds(run.sampleRate);
+        run.origin =
+            piece.monotonicSamples.start - SampleDuration::ofSeconds(elapsed, piece.rate());
+        run.through = std::max(run.through, run.origin);
+    }
+
+    run.sampleRate = piece.rate();
+}
+
 void LaunchHandle::followRate(const SyncRange& piece) {
-    if (!run_ || piece.rate() <= 0.0 || piece.rate() == run_->sampleRate)
+    if (piece.rate() <= 0.0)
         return;
 
-    // The device changed rate under a slot that is playing. The origin is a
-    // count of samples and the samples are not the same length any more, so
-    // holding the number would silently change how far into its material the
-    // run is. What is kept instead is the elapsed time it has actually had, and
-    // the origin is re-counted behind the block at the new rate.
-    //
     // Which depends on this block being the first at the new rate, and that is
     // an invariant rather than a guess: advanceLaunchHandles advances every
     // handle over every block before anything renders (SessionLauncher.hpp), so
     // a handle cannot miss the block a change arrives on.
-    if (run_->sampleRate > 0.0) {
-        const auto elapsed = elapsedSecondsAt(piece);
-        run_->origin =
-            piece.monotonicSamples.start - SampleDuration::ofSeconds(elapsed, piece.rate());
-        run_->through = std::max(run_->through, run_->origin);
-    }
+    if (run_ && piece.rate() != run_->sampleRate)
+        recountRun(*run_, piece);
 
-    run_->sampleRate = piece.rate();
+    // The run a synced launch is waiting to join, on the same blocks. It was
+    // copied when the launch was requested and is joined whenever its beat
+    // arrives, and a rate change in between would otherwise leave the follower
+    // adopting an origin counted in samples of another length: at 44.1 to 48
+    // kHz with a second between the two, the follower would sit about 90 ms off
+    // the leader for the rest of the run.
+    //
+    // Carried rather than re-read from the leader at the launch instant, which
+    // would be the other way to keep it current. A handle has no safe way to
+    // name another one across the blocks in between: the store frees a handle
+    // the next published table does not name, and a pending request holding a
+    // pointer to one would be holding it after it went. Lockstep gets the same
+    // answer, because the copy and the leader's own run start identical and
+    // every handle is advanced over every block.
+    if (pending_ && pending_->synced && piece.rate() != pending_->synced->sampleRate)
+        recountRun(*pending_->synced, piece);
 }
 
 std::optional<LaunchHandle::QueueState> LaunchHandle::queuedState() const {

--- a/magda/engine/launch/LaunchHandle.hpp
+++ b/magda/engine/launch/LaunchHandle.hpp
@@ -460,7 +460,11 @@ class LaunchHandle {
     /// How long the run had been going when @p piece began.
     double elapsedSecondsAt(const SyncRange& piece) const;
 
-    /// Re-count the origin when the device changes rate under a running slot.
+    /// Re-count @p run's origin at @p piece's rate, keeping its elapsed time.
+    static void recountRun(Run& run, const SyncRange& piece);
+
+    /// Follow the device's rate on every run this handle holds: the one it is
+    /// playing, and the one a queued synced launch is waiting to join.
     void followRate(const SyncRange& piece);
 
     /// Apply whatever the block ran into, at the instant it ran into it.

--- a/magda/engine/launch/LaunchHandle.hpp
+++ b/magda/engine/launch/LaunchHandle.hpp
@@ -51,68 +51,106 @@ struct SlotKey {
 };
 
 /**
- * @brief One block, in the four domains (TimeDomains.hpp), and how to cut it.
+ * @brief One block, in the domains a handle names things in, and how to cut it.
  *
- * A queued position is named in monotonic beats; how far into its material a
- * run has got is measured in monotonic seconds. Neither is derived from the
- * other (#2324).
+ * A queued position is named in monotonic beats; where a run began and how far
+ * it has got are counted in samples, which is the coordinate no wrap, locate or
+ * tempo edit moves (#2336). The timeline faces are here because a piece of a
+ * block is reported in them.
  *
  * The map comes with it, because naming an instant inside the block is the one
- * thing a handle does that the four ranges cannot answer between them. Reading
- * an instant off each range separately is what @ref BlockInstant exists to stop
- * (#2330); everything here goes through @ref atSample.
+ * thing a handle does that the ranges cannot answer between them. An instant is
+ * a sample and only a sample; every face of it is derived here, through the map,
+ * which is what stops two faces of one moment disagreeing (#2330).
  */
 struct SyncRange {
     BeatRange timeline;
     BeatRange monotonic;
     SecondsRange seconds;
-    SecondsRange monotonicSeconds;
+
+    /// Where the block sits on the transport's own count.
+    SampleRange monotonicSamples;
 
     /// How many samples the block is, which is what an instant is counted in.
     int numSamples = 0;
+
+    /// What one of those samples is worth. Zero for a block assembled by hand
+    /// that did not say, which then converts through its own two seconds ends.
+    double sampleRate = 0.0;
 
     /// The map the block was cut from, or null for a block assembled by hand,
     /// which is then taken to run at one tempo.
     const TempoMap* tempo = nullptr;
 
+    /// What one sample is worth, stated or taken from the block's own faces.
+    double rate() const {
+        if (sampleRate > 0.0)
+            return sampleRate;
+
+        return seconds.length() > 0.0 ? static_cast<double>(numSamples) / seconds.length() : 0.0;
+    }
+
     /**
-     * @brief The instant @p sample sounds at, in every domain.
+     * @brief The instant @p sample sounds at.
      *
      * An edge rather than an event: one past the end of the block is a legal
-     * answer here, the way it is for RenderContext::sampleForTime, because a
-     * range that runs to the end of the block ends at the sample after the last
-     * one. An event has to land on a sample the block actually has, which is
-     * @ref eventAtMonotonicBeat.
-     *
-     * The seconds faces are exact rather than nearly so: a block runs at one
-     * second per sample rate whatever the tempo is doing, so both of them are
-     * straight lines and not approximations of a curve.
-     *
-     * The beat face is the map's, because the block's own two beat ends are a
-     * straight line and the map between them is not. What is left linear is
-     * monotonic against timeline beats, and that one is exact: what makes the
-     * two differ is a wrap, and a wrap ends a block.
+     * answer here, because a range that runs to the end of the block ends at
+     * the sample after the last one. An event has to land on a sample the block
+     * actually has, which is @ref eventAtMonotonicBeat.
      */
     BlockInstant atSample(int sample) const {
-        BlockInstant at;
-        at.sample = std::clamp(sample, 0, numSamples);
-
-        const auto through =
-            numSamples > 0 ? static_cast<double>(at.sample) / static_cast<double>(numSamples) : 0.0;
-
-        at.timelineSeconds = seconds.start + through * seconds.length();
-        at.monotonicSeconds = monotonicSeconds.start + through * monotonicSeconds.length();
-
-        at.timelineBeat = tempo != nullptr ? tempo->timeToBeat(at.timelineSeconds)
-                                           : timeline.start + through * timeline.length();
-
-        at.monotonicBeat = monotonic.start + (at.timelineBeat - timeline.start);
-        return at;
+        const auto offset = std::clamp(sample, 0, numSamples);
+        return BlockInstant{offset, monotonicSamples.start + SampleDuration{offset}};
     }
 
     /// The instant the block begins on.
     BlockInstant start() const {
         return atSample(0);
+    }
+
+    /**
+     * @brief The moment @p at falls on, in the timeline's seconds.
+     *
+     * Exact rather than nearly so: a block runs at one second per sample rate
+     * whatever the tempo is doing, so this is a straight line and not an
+     * approximation of a curve.
+     */
+    double timeAt(BlockInstant at) const {
+        if (const auto perSecond = rate(); perSecond > 0.0)
+            return seconds.start + (static_cast<double>(at.sample) / perSecond);
+
+        return numSamples > 0
+                   ? seconds.start +
+                         ((static_cast<double>(at.sample) / static_cast<double>(numSamples)) *
+                          seconds.length())
+                   : seconds.start;
+    }
+
+    /**
+     * @brief The timeline beat @p at falls on.
+     *
+     * The map's, because the block's own two beat ends are a straight line and
+     * the map between them is not.
+     */
+    double timelineBeatAt(BlockInstant at) const {
+        if (tempo != nullptr)
+            return tempo->timeToBeat(timeAt(at));
+
+        if (numSamples <= 0)
+            return timeline.start;
+
+        const auto through = static_cast<double>(at.sample) / static_cast<double>(numSamples);
+        return timeline.start + (through * timeline.length());
+    }
+
+    /**
+     * @brief The monotonic beat @p at falls on.
+     *
+     * Off the timeline beat, and exact inside a block: what makes the two
+     * differ is a wrap, and a wrap ends a block.
+     */
+    double monotonicBeatAt(BlockInstant at) const {
+        return monotonic.start + (timelineBeatAt(at) - timeline.start);
     }
 
     /**
@@ -123,15 +161,16 @@ struct SyncRange {
      * not happen, and the faces of the beat it was asked for are the faces of a
      * moment between two samples that nothing plays.
      *
-     * Never one past the end, which is where a beat in the block's last half
-     * sample rounds to. That sample belongs to the next callback, and an event
-     * placed there is written nowhere: a stop would clear its own note state
-     * while its note-offs went to an offset outside the buffer, and the notes
-     * would hang. The block's last sample instead, which is at most one sample
-     * early and is a sample that plays.
+     * Never one past the end, which is where nearest would put a beat in the
+     * block's last half sample. That sample belongs to the next callback, and
+     * an event placed there is written nowhere: a stop would clear its own note
+     * state while its note-offs went to an offset outside the buffer, and the
+     * notes would hang. Floor answers 0 to N-1 for anything inside the block
+     * without a case to clamp away (TimeDomains::eventAt).
      */
     BlockInstant eventAtMonotonicBeat(double beat) const {
-        if (numSamples <= 0 || seconds.empty())
+        const auto perSecond = rate();
+        if (numSamples <= 0 || seconds.empty() || perSecond <= 0.0)
             return start();
 
         const auto timelineBeat = timeline.start + (beat - monotonic.start);
@@ -144,9 +183,31 @@ struct SyncRange {
                                        : ((timelineBeat - timeline.start) / timeline.length()) *
                                              seconds.length());
 
-        const auto through = (at - seconds.start) / seconds.length();
-        const auto sample = static_cast<int>(std::lround(through * numSamples));
-        return atSample(std::min(sample, numSamples - 1));
+        return atSample(eventAt((at - seconds.start) * perSecond, numSamples).value);
+    }
+
+    /// The part of this block up to @p at, which is the half a run was already
+    /// playing when the block ran into something.
+    SyncRange upTo(BlockInstant at) const {
+        return SyncRange{BeatRange{timeline.start, timelineBeatAt(at)},
+                         BeatRange{monotonic.start, monotonicBeatAt(at)},
+                         SecondsRange{seconds.start, timeAt(at)},
+                         SampleRange{monotonicSamples.start, at.monotonic},
+                         at.sample,
+                         sampleRate,
+                         tempo};
+    }
+
+    /// The part from @p at onwards, which is the half whatever happened there
+    /// applies to.
+    SyncRange from(BlockInstant at) const {
+        return SyncRange{BeatRange{timelineBeatAt(at), timeline.end},
+                         BeatRange{monotonicBeatAt(at), monotonic.end},
+                         SecondsRange{timeAt(at), seconds.end},
+                         SampleRange{at.monotonic, monotonicSamples.end},
+                         numSamples - at.sample,
+                         sampleRate,
+                         tempo};
     }
 };
 
@@ -156,10 +217,9 @@ struct BlockPiece {
     BeatRange range;
 
     /// Where the run sounding over this piece began, or nothing. Projected onto
-    /// this block from each monotonic domain, since after a wrap the instant it
-    /// really started on is not in this cycle: either face can sit before the
-    /// block, or before zero.
-    std::optional<RunOrigin> origin;
+    /// this block, since after a wrap the instant it really started on is not
+    /// in this cycle: either face can sit before the block, or before zero.
+    std::optional<MaterialOrigin> origin;
 
     /// Whether the slot sounded over this piece.
     bool playing() const {
@@ -253,9 +313,14 @@ class LaunchHandle {
      */
     void setLooping(std::optional<double> beats);
 
-    /// Move the played position without restarting. Both faces are given
-    /// rather than converted: the caller has the block and therefore has both.
-    void nudge(double beats, double seconds);
+    /**
+     * @brief Move the played position without restarting.
+     *
+     * Both axes are given rather than one converted from the other: a map says
+     * where a beat sits, not how long a run has lasted (#2324). They change
+     * units here and they do not become one number.
+     */
+    void nudge(double beats, SampleDuration samples);
 
     /**
      * @brief Advance over one block and say what it was.
@@ -286,9 +351,11 @@ class LaunchHandle {
     /// The same run in monotonic beats, which is what another handle syncs to.
     std::optional<BeatRange> playedMonotonicRange() const;
 
-    /// The run in monotonic seconds: how long it has been going, which is what
-    /// a source reading a file at its own speed needs.
-    std::optional<SecondsRange> playedMonotonicSecondsRange() const;
+    /// The run on the transport's own count: where it began and how far it has
+    /// got, in the one coordinate a wrap, a locate and a tempo edit all leave
+    /// alone. How long it has been going is this divided by the rate, which is
+    /// what a source reading a file at its own speed needs (#2336).
+    std::optional<SampleRange> playedSampleRange() const;
 
     /// The last completed run, kept after a stop so a follow action can ask
     /// what it followed.
@@ -313,20 +380,74 @@ class LaunchHandle {
     }
 
   private:
+    /**
+     * @brief The run in progress: where it began, and how far it has got.
+     *
+     * One origin rather than one per axis. A run whose faces came from
+     * different instants would put a clip's notes and its samples in different
+     * places, which is what #2330 closed; keeping the sample is what makes the
+     * agreement survive the blocks after the launch as well (#2336).
+     */
+    struct Run {
+        /// Where it began on the transport's count. The durable identity: a
+        /// locate does not move it, a wrap does not take it back, a tempo edit
+        /// does not rescale it, and two runs that began on the same sample
+        /// began together whatever happened to the timeline since.
+        SamplePosition origin;
+
+        /// Where it has been advanced to. The far end of the same axis, so
+        /// elapsed samples is a subtraction and elapsed seconds is that divided
+        /// by the rate, exactly.
+        SamplePosition through;
+
+        /// The monotonic beat the origin sample fell on. Not recoverable from
+        /// the sample afterwards: a map converts a position, and after a wrap
+        /// the origin is not a position on this cycle of the timeline (#2324).
+        double originBeat = 0.0;
+
+        /// The timeline beat it fell on, kept for what @ref playedRange
+        /// reports. Stale after a wrap by construction, which is why nothing
+        /// derives anything from it: the cycle it names has been taken back.
+        double originTimelineBeat = 0.0;
+
+        /// Monotonic beats covered since the origin.
+        double elapsedBeats = 0.0;
+
+        /**
+         * @brief The beat the loop counts from, as it was asked for.
+         *
+         * Not @ref originBeat, and that is the whole of the retrigger fix. A
+         * launch is snapped to the sample it sounds on, and a wrap scheduled
+         * from that snapped beat starts the next interval from a rounded value:
+         * at 48 kHz and 123 bpm a beat is 23,414.634 samples, so a thousand
+         * one-beat retriggers finish about 366 samples late. The schedule
+         * counts from the beat that was asked for and is never re-anchored to
+         * what any wrap landed on, so the error stays under a sample for ever
+         * (#2336).
+         */
+        double scheduleBeat = 0.0;
+
+        /// The rate the origin was counted at. A block arriving at another rate
+        /// re-counts it, so the run keeps the elapsed time it has actually had
+        /// rather than silently changing length.
+        double sampleRate = 0.0;
+    };
+
     struct Pending {
         QueueState state = QueueState::playQueued;
         std::optional<double> position;
 
-        /// Set only by playSynced: the run to join rather than start. All
-        /// three faces, or the handles agree about the bar and not the sample.
-        std::optional<double> syncedTimelineOrigin;
-        std::optional<double> syncedMonotonicOrigin;
-        std::optional<double> syncedMonotonicSecondsOrigin;
+        /// Set only by playSynced: the run to join rather than start. The whole
+        /// of it, or the handles agree about the bar and not the sample.
+        std::optional<Run> synced;
     };
 
-    /// Begin a run at @p at, already @p elapsedBeats and @p elapsedSeconds into
-    /// itself. Non-zero only for a synced launch, which joins a run.
-    void beginRun(const BlockInstant& at, double elapsedBeats = 0.0, double elapsedSeconds = 0.0);
+    /// Begin a run at @p at, scheduled for @p scheduledBeat.
+    void beginRun(const SyncRange& range, const BlockInstant& at, double scheduledBeat);
+
+    /// Join @p other's run, as it stands at @p at.
+    void joinRun(const SyncRange& range, const BlockInstant& at, const Run& other);
+
     void endRun();
 
     /// Carry the current run through @p piece without changing state.
@@ -336,8 +457,15 @@ class LaunchHandle {
     double virtualStart(const SyncRange& piece) const;
     double virtualStartSeconds(const SyncRange& piece) const;
 
+    /// How long the run had been going when @p piece began.
+    double elapsedSecondsAt(const SyncRange& piece) const;
+
+    /// Re-count the origin when the device changes rate under a running slot.
+    void followRate(const SyncRange& piece);
+
     /// Apply whatever the block ran into, at the instant it ran into it.
-    void applyEvent(bool fromPending, const BlockInstant& at);
+    void applyEvent(const SyncRange& range, bool fromPending, const BlockInstant& at,
+                    double scheduledBeat);
 
     /// The advance itself, wrapped so @ref blockStatus is stored in one place.
     SplitStatus advanceOver(const SyncRange& range);
@@ -345,9 +473,7 @@ class LaunchHandle {
     PlayState playState_ = PlayState::stopped;
     std::optional<Pending> pending_;
 
-    std::optional<BeatRange> played_;
-    std::optional<BeatRange> playedMonotonic_;
-    std::optional<SecondsRange> playedMonotonicSeconds_;
+    std::optional<Run> run_;
     std::optional<BeatRange> lastPlayed_;
 
     std::optional<double> loopBeats_;

--- a/magda/engine/launch/SessionLauncher.hpp
+++ b/magda/engine/launch/SessionLauncher.hpp
@@ -90,11 +90,11 @@ class LaunchHandleFeed {
     Published published_;
 };
 
-/// The block as the launcher names it: all four faces, from the one place they
-/// were derived together (RenderContext.hpp).
+/// The block as the launcher names it, from the one place its faces were
+/// derived together (RenderContext.hpp).
 inline SyncRange syncRangeFor(const BlockInfo& block) {
-    return SyncRange{block.beats,      block.monotonicBeats, block.seconds, block.monotonicSeconds,
-                     block.numSamples, block.tempo};
+    return SyncRange{block.beats,      block.monotonicBeats, block.seconds, block.monotonicSamples,
+                     block.numSamples, block.rate(),         block.tempo};
 }
 
 /// Advance every handle over @p block, once, before anything renders. On the

--- a/magda/engine/param/ModLfo.cpp
+++ b/magda/engine/param/ModLfo.cpp
@@ -121,8 +121,21 @@ float laneValueFromRateType(int rateType) {
 
 double modBarPosition(const BlockInfo& block, const ModTiming& timing) {
     if (block.tempo != nullptr) {
-        const auto grid = block.tempo->barsAndBeatsAt(block.beats.start);
-        return grid.bar + grid.beat / std::max(grid.numerator, 1);
+        // The bar grid the block renders in, which is the section's rather than
+        // the one its first beat happens to sit in (BlockInfo::sectionBeat).
+        // A signature the epsilon swallowed would otherwise run this whole
+        // block at the old bar fraction instead of restarting on the new bar:
+        // four four to three four at the boundary is a bar-rate LFO a quarter
+        // of a cycle out for the length of the block.
+        const auto inside = block.sectionBeat();
+        const auto grid = block.tempo->barsAndBeatsAt(inside);
+        const auto barBeats = 4.0 * grid.numerator / std::max(1, grid.denominator);
+
+        // Back to the block's own first sample, under that grid. The phase is
+        // the value the block opens on, and the section is only what says how
+        // long a bar is there.
+        const auto atSectionBeat = grid.bar + (grid.beat / std::max(grid.numerator, 1));
+        return atSectionBeat - ((inside - block.beats.start) / std::max(barBeats, 1.0e-6));
     }
 
     const auto barBeats = 4.0 * timing.numerator / timing.denominator;
@@ -137,15 +150,10 @@ ModTiming modTimingFor(const BlockInfo& block, double sampleRate) {
     // what it gets is what a session that has never seen a transport renders
     // at: 120 in four four, which is the same default TransportState holds.
     //
-    // Asked at the middle of the block rather than at its start. This is one
-    // rate for the whole block, which is sound because the transport cuts a
-    // callback at every tempo section (TransportClock.cpp); what the start is
-    // not, is reliably inside that section. A cut lands on the first sample at
-    // or after the boundary, so a block can open a fraction of a sample before
-    // one and read the tempo it is leaving for every sample it renders. The
-    // middle is inside the section on every alignment.
+    // Asked about the section the block renders in rather than about its first
+    // beat, which is not reliably in it (BlockInfo::sectionBeat).
     if (block.tempo != nullptr) {
-        const auto inside = block.beats.start + (0.5 * block.beats.length());
+        const auto inside = block.sectionBeat();
         const auto signature = block.tempo->barsAndBeatsAt(inside);
         timing.bpm = block.tempo->bpmAt(inside);
         timing.numerator = signature.numerator;

--- a/magda/engine/param/ModLfo.cpp
+++ b/magda/engine/param/ModLfo.cpp
@@ -136,9 +136,18 @@ ModTiming modTimingFor(const BlockInfo& block, double sampleRate) {
     // The map where there is one. A block assembled by hand carries none, and
     // what it gets is what a session that has never seen a transport renders
     // at: 120 in four four, which is the same default TransportState holds.
+    //
+    // Asked at the middle of the block rather than at its start. This is one
+    // rate for the whole block, which is sound because the transport cuts a
+    // callback at every tempo section (TransportClock.cpp); what the start is
+    // not, is reliably inside that section. A cut lands on the first sample at
+    // or after the boundary, so a block can open a fraction of a sample before
+    // one and read the tempo it is leaving for every sample it renders. The
+    // middle is inside the section on every alignment.
     if (block.tempo != nullptr) {
-        const auto signature = block.tempo->barsAndBeatsAt(block.beats.start);
-        timing.bpm = block.tempo->bpmAt(block.beats.start);
+        const auto inside = block.beats.start + (0.5 * block.beats.length());
+        const auto signature = block.tempo->barsAndBeatsAt(inside);
+        timing.bpm = block.tempo->bpmAt(inside);
         timing.numerator = signature.numerator;
         timing.denominator = signature.denominator;
     }

--- a/magda/engine/param/ParamResolve.cpp
+++ b/magda/engine/param/ParamResolve.cpp
@@ -193,7 +193,8 @@ int bakeCurve(std::span<const magda::AutomationPoint> curve, const ParamSpec& sp
         curve.begin(), curve.end(), block.beats.end,
         [](const magda::AutomationPoint& point, double beat) { return point.beatPosition < beat; });
     const bool hasKnotInside = boundary != curve.begin();
-    const int endingSample = hasKnotInside ? block.sampleForBeat((boundary - 1)->beatPosition) : 0;
+    const int endingSample =
+        hasKnotInside ? block.eventForBeat((boundary - 1)->beatPosition).value : 0;
     const float endingHeld = hasKnotInside ? valueAt((boundary - 1)->beatPosition) : opening;
 
     int written = 0;
@@ -206,7 +207,9 @@ int bakeCurve(std::span<const magda::AutomationPoint> curve, const ParamSpec& sp
     // value at a knot is the curve's value after it, which for a step is the
     // jump and for everything else is where the previous run arrived.
     const auto closeAt = [&](double beat) {
-        const auto sample = block.sampleForBeat(beat);
+        // A segment starts where a value takes effect, which is an event: one
+        // sample of this block, never the boundary past its last (#2336).
+        const auto sample = block.eventForBeat(beat).value;
         const auto value = valueAt(beat);
 
         if (sample > startSample) {

--- a/magda/engine/transport/ClickGenerator.cpp
+++ b/magda/engine/transport/ClickGenerator.cpp
@@ -92,9 +92,9 @@ void ClickGenerator::render(const TempoMap& tempo, const ClickSettings& click,
     // falls silent without being told to.
     for (auto tick = tempo.tickAtOrAfter(block.beats.start); tick.beat < block.beats.end;
          tick = tempo.tickAtOrAfter(tick.nextBeat)) {
-        const auto offset = block.sampleForBeat(tick.beat);
+        const auto offset = block.eventForBeat(tick.beat);
         trigger(click.emphasiseBars && tick.startsBar);
-        pour(output, startSample + offset, block.numSamples - offset, click.gain);
+        pour(output, startSample + offset.value, block.numSamples - offset.value, click.gain);
     }
 }
 

--- a/magda/engine/transport/TimeDomains.hpp
+++ b/magda/engine/transport/TimeDomains.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <algorithm>
 #include <cmath>
 #include <compare>
 #include <cstdint>
@@ -221,51 +222,101 @@ inline EdgeSample operator+(EdgeSample edge, int count) {
 }
 
 /**
- * @brief One instant inside a block, in every domain the engine names it in.
+ * @brief The sample of an @p numSamples block that something @p offset samples
+ * in happens on.
  *
- * Built from one coordinate and one only: the sample. Every face below is
- * derived from it through the tempo map, so the five of them are one instant
- * rather than five answers that happen to be near each other.
+ * Floor rather than nearest, which is what makes the answer total. A block
+ * covers the half-open stretch its samples run over, so a position inside it is
+ * somewhere in `[0, N)` and the sample it is inside is `0..N-1`, always, with
+ * no case to clamp away. Nearest has one: a position in the block's last half
+ * sample rounds to N, which is not a sample this block has, and the clamp that
+ * used to hide that is the defect the epic names (#2336).
  *
- * That is the whole point of the type. The domains are related by the map,
- * which is not a straight line, and projecting an instant onto each axis
- * separately gives a set of faces no single moment has: over a steep ramp the
- * beat face and the seconds face of one "instant" can be 163 samples apart.
- * Anything built from those faces inherits the gap, and a run whose origin has
- * it starts its material somewhere it was never placed (#2330).
+ * A position on the boundary belongs to the next block, where it is sample
+ * zero, and it gets there without anything being carried: the next block's
+ * stretch begins there.
  *
- * The sample is canonical because it is the one coordinate that is not a
- * matter of interpretation: it is what plays.
+ * The epsilon is why this is not plain truncation, and the clamp is a guard
+ * rather than the rule: every caller resolves a position its own bounds have
+ * already put inside the block.
+ */
+inline EventSample eventAt(double offset, int numSamples) {
+    if (numSamples <= 0)
+        return EventSample{0};
+
+    const auto sample = static_cast<int>(std::floor(offset + kSampleEpsilon));
+    return EventSample{std::clamp(sample, 0, numSamples - 1)};
+}
+
+/**
+ * @brief Where a stretch of an @p numSamples block that begins or ends
+ * @p offset samples in has its edge.
+ *
+ * Nearest, and N is a legal answer: a region that runs to the end of the block
+ * ends at the sample after the last one, the way every half-open range does. An
+ * edge is a bound rather than a moment something happens at, so it is not
+ * floored to the sample it is inside; a fade that begins a hair before a sample
+ * begins on it.
+ */
+inline EdgeSample edgeAt(double offset, int numSamples) {
+    if (numSamples <= 0)
+        return EdgeSample{0};
+
+    return EdgeSample{std::clamp(static_cast<int>(std::lround(offset)), 0, numSamples)};
+}
+
+/**
+ * @brief One instant inside a block: the sample it sounds on, and nothing else.
+ *
+ * Two numbers that are one number. The offset is where in this block's buffer
+ * it is, and the position is the same sample on the transport's own count, so
+ * an instant stays comparable once the block that produced it is gone.
+ *
+ * Every other domain is a face of it, and none of them are stored here. That is
+ * the point of the type. The domains are related by a map, which is not a
+ * straight line, and an instant carrying its own copies of them is a set of
+ * faces anything may overwrite one of: over a steep ramp the beat face and the
+ * seconds face of one "instant" can be 163 samples apart, and a run whose
+ * origin has that gap starts its material somewhere it was never placed
+ * (#2330). The faces come from the block instead, which is the only thing that
+ * knows the map (SyncRange in launch/LaunchHandle.hpp).
+ *
+ * The sample is canonical because it is the one coordinate that is not a matter
+ * of interpretation: it is what plays.
  */
 struct BlockInstant {
     /// Offset within the block. What actually sounds at this instant.
     int sample = 0;
 
-    double timelineBeat = 0.0;
-    double timelineSeconds = 0.0;
+    /// The same instant on the transport's count, which no wrap, locate or
+    /// tempo edit moves (#2336).
+    SamplePosition monotonic;
 
-    /// The faces that never go back, which is what a queued launch is named in
-    /// and what a run's elapsed material is measured in (#2324).
-    double monotonicBeat = 0.0;
-    double monotonicSeconds = 0.0;
+    bool operator==(const BlockInstant&) const = default;
 };
 
 /**
- * @brief Where a run began, in the two domains a source reads it against.
+ * @brief Where a run's material begins, on one block's own axes.
  *
- * One value, because a run whose faces came from different instants would put a
- * clip's notes and its samples in different places. The two are not one number
- * converted: a map says where a beat sits, not how long a run has lasted, so
- * each face is projected from its own monotonic domain (#2324).
+ * What a block is shifted by to become the run's, so a source reading it is
+ * reading material beats and elapsed run time rather than timeline positions
+ * (clip/SessionPlayback.hpp).
  *
- * Here rather than with the launcher because it is what shifts a block onto a
- * run's own axes, and the block is not a launcher concept.
+ * Derived per block rather than stored: after a wrap, the instant a run really
+ * began on is not in this cycle of the timeline, so either face can sit before
+ * the block or before zero, and what that means is that the run began that far
+ * back. The run's own durable origin is a sample, and it is the launcher's
+ * (launch/LaunchHandle.hpp).
+ *
+ * The two faces are not one number converted. A map says where a beat sits, not
+ * how long a run has lasted, so the beat face comes off the monotonic beats and
+ * the seconds face off the sample count (#2324).
  */
-struct RunOrigin {
+struct MaterialOrigin {
     double beat = 0.0;
     double seconds = 0.0;
 
-    bool operator==(const RunOrigin&) const = default;
+    bool operator==(const MaterialOrigin&) const = default;
 };
 
 }  // namespace magda::engine

--- a/magda/engine/transport/TimeDomains.hpp
+++ b/magda/engine/transport/TimeDomains.hpp
@@ -1,10 +1,12 @@
 #pragma once
 
+#include <cmath>
+#include <compare>
 #include <cstdint>
 
 /**
  * @file TimeDomains.hpp
- * @brief The four domains the engine says "when" in.
+ * @brief The four domains the engine says "when" in, and the samples under them.
  *
  * Beats and seconds, each in a timeline form that goes backwards at a loop wrap
  * or a locate and a monotonic form that never does (RenderContext.hpp).
@@ -12,9 +14,28 @@
  * Two types rather than one shape reused, so the compiler catches a beat passed
  * where a second was meant. No conversion between them lives here: a tempo map
  * converts a position, not an elapsed duration (#2324).
+ *
+ * Then the samples, which are what the four domains are interpretations of: a
+ * position on the transport's own count, a number of them, and the two things a
+ * sample offset inside a block can mean (#2336).
  */
 
 namespace magda::engine {
+
+/**
+ * @brief A hundredth of a sample: the slack in a conversion to one.
+ *
+ * Beats and seconds are doubles and the arithmetic between them is not exact,
+ * so a moment that is a sample exactly can come out a billionth of a sample
+ * either side of it. Anything that rounds in one direction has to be told, or
+ * it answers with the sample next door: the first sample at or after a beat
+ * becomes the one after that, and the sample a moment sits inside becomes the
+ * one before it.
+ *
+ * Small enough not to move anything real. A hundredth of a sample is two tenths
+ * of a microsecond at 48 kHz.
+ */
+inline constexpr double kSampleEpsilon = 1.0e-2;
 
 /// A stretch of beats, half open.
 struct BeatRange {
@@ -49,7 +70,50 @@ struct SecondsRange {
 };
 
 /**
- * @brief A stretch of the transport's own sample count, half open.
+ * @brief A number of samples: how long something lasts, or how far apart two
+ * moments are.
+ *
+ * Separate from a position for the reason a duration is separate from a date.
+ * Two positions can be subtracted and cannot be added; a duration can be added
+ * to a position and to another duration. A single integer standing for both
+ * lets every one of those through.
+ *
+ * Signed, because the distance between two moments is asked for in both orders
+ * and a run can be nudged backwards.
+ */
+struct SampleDuration {
+    std::int64_t samples = 0;
+
+    /**
+     * @brief How long this lasts at @p sampleRate.
+     *
+     * Exact between rate changes and meaningless across one: a count that spans
+     * a rate change counts samples that were not all worth the same amount of
+     * time, and no single rate turns it back into seconds (#2336).
+     */
+    double seconds(double sampleRate) const {
+        return sampleRate > 0.0 ? static_cast<double>(samples) / sampleRate : 0.0;
+    }
+
+    /// The samples @p seconds is worth at @p sampleRate, to the nearest one.
+    static SampleDuration ofSeconds(double seconds, double sampleRate) {
+        return SampleDuration{static_cast<std::int64_t>(std::llround(seconds * sampleRate))};
+    }
+
+    bool operator==(const SampleDuration&) const = default;
+    auto operator<=>(const SampleDuration&) const = default;
+};
+
+inline SampleDuration operator+(SampleDuration a, SampleDuration b) {
+    return SampleDuration{a.samples + b.samples};
+}
+
+inline SampleDuration operator-(SampleDuration a, SampleDuration b) {
+    return SampleDuration{a.samples - b.samples};
+}
+
+/**
+ * @brief A point on the transport's own sample count.
  *
  * The count never goes back. A locate does not move it, a loop wrap does not
  * take it back, a tempo edit does not rescale it, and re-anchoring the cursor
@@ -63,11 +127,36 @@ struct SecondsRange {
  * elapsed seconds can disagree about which cycle they are in, but no two
  * samples are the same sample.
  */
-struct SampleRange {
-    std::int64_t start = 0;
-    std::int64_t end = 0;
+struct SamplePosition {
+    std::int64_t sample = 0;
 
-    std::int64_t length() const {
+    bool operator==(const SamplePosition&) const = default;
+    auto operator<=>(const SamplePosition&) const = default;
+};
+
+inline SampleDuration operator-(SamplePosition a, SamplePosition b) {
+    return SampleDuration{a.sample - b.sample};
+}
+
+inline SamplePosition operator+(SamplePosition position, SampleDuration duration) {
+    return SamplePosition{position.sample + duration.samples};
+}
+
+inline SamplePosition operator-(SamplePosition position, SampleDuration duration) {
+    return SamplePosition{position.sample - duration.samples};
+}
+
+inline SamplePosition& operator+=(SamplePosition& position, SampleDuration duration) {
+    position.sample += duration.samples;
+    return position;
+}
+
+/// A stretch of the transport's count, half open.
+struct SampleRange {
+    SamplePosition start;
+    SamplePosition end;
+
+    SampleDuration length() const {
         return end - start;
     }
 
@@ -77,6 +166,59 @@ struct SampleRange {
 
     bool operator==(const SampleRange&) const = default;
 };
+
+/**
+ * @brief A sample of a block that something happens on, from 0 to N-1.
+ *
+ * A note-on, a click, the start of a parameter segment: one moment, on one
+ * sample the block actually plays. N is not one of them. It is the boundary
+ * after the block's last sample, so a message written there is written into
+ * nobody's buffer, and the block that owns that sample is the next one, where
+ * the same moment is sample zero.
+ *
+ * @see EdgeSample, which is the other thing a sample offset can mean.
+ */
+struct EventSample {
+    int value = 0;
+
+    bool operator==(const EventSample&) const = default;
+    auto operator<=>(const EventSample&) const = default;
+};
+
+/**
+ * @brief Where a stretch of a block begins or ends, from 0 to N.
+ *
+ * A fade bound, a region's ends, the edges of a hole. Stretches are half open,
+ * so N is a legal answer and a common one: "this fade runs to the end of the
+ * block" is exactly an end edge of N.
+ *
+ * The distinction from @ref EventSample is meaning rather than axis, which is
+ * why it is a type and not a naming convention. A note-off arrives as a beat,
+ * the way a note-on does, but it is where a note's stretch ends, and a note-off
+ * on the block boundary is the one case where the two rules differ: as an event
+ * it would be written nowhere and the note would hang. What it needs is to be
+ * heard one sample early, which is @ref BlockInfo::soundsAt, in one place and
+ * under a name, rather than an unexplained clamp at each site that emits one.
+ */
+struct EdgeSample {
+    int value = 0;
+
+    bool operator==(const EdgeSample&) const = default;
+    auto operator<=>(const EdgeSample&) const = default;
+};
+
+/// How many samples lie between two edges. An int rather than an edge: the
+/// distance between two bounds is a count, and it is what a buffer loop runs
+/// over.
+inline int operator-(EdgeSample a, EdgeSample b) {
+    return a.value - b.value;
+}
+
+/// The edge @p count samples past @p edge, which is how a region's far end is
+/// named once its near end and its length are known.
+inline EdgeSample operator+(EdgeSample edge, int count) {
+    return EdgeSample{edge.value + count};
+}
 
 /**
  * @brief One instant inside a block, in every domain the engine names it in.

--- a/magda/engine/transport/TransportClock.cpp
+++ b/magda/engine/transport/TransportClock.cpp
@@ -188,11 +188,20 @@ std::span<const TransportClock::Segment> TransportClock::advance(const Transport
         // run at the tempo it opened on for the rest of it. The cut is what
         // makes that reading exact rather than nearly right, and it costs one
         // extra segment per tempo change (#2333).
-        const auto boundary = tempo.nextSectionBoundaryAfter(beatAfter(tempo, samplesSinceAnchor_));
-        if (std::isfinite(boundary)) {
-            if (const auto untilBoundary = samplesUntil(tempo, boundary); untilBoundary > 0)
-                samples = std::min(samples, untilBoundary);
-        }
+        //
+        // Past a boundary the epsilon has already swallowed, or the guarantee
+        // has a hole exactly where it is hardest to see. A boundary within a
+        // hundredth of a sample ahead of the cursor counts as zero samples
+        // away, and a zero cut is no cut: the segment would then run to
+        // whatever else ends it, through that boundary and every later one in
+        // the callback. The cursor is on that boundary for all practical
+        // purposes, so the one to cut at is the next one after it.
+        auto boundary = tempo.nextSectionBoundaryAfter(beatAfter(tempo, samplesSinceAnchor_));
+        while (std::isfinite(boundary) && samplesUntil(tempo, boundary) <= 0)
+            boundary = tempo.nextSectionBoundaryAfter(boundary);
+
+        if (std::isfinite(boundary))
+            samples = std::min(samples, samplesUntil(tempo, boundary));
 
         // Clamped from inside the loop only. From outside it the count is
         // negative and would cut a callback that is not looping at all; from

--- a/magda/engine/transport/TransportClock.cpp
+++ b/magda/engine/transport/TransportClock.cpp
@@ -175,10 +175,19 @@ std::span<const TransportClock::Segment> TransportClock::advance(const Transport
 
         // A block never spans a tempo section, which is the stretch the map is
         // linear over. Not a jump: audio flows straight through a tempo change
-        // and the next segment carries on continuous. The cut is what keeps the
-        // block's own straight lines honest, since everything inside a block is
-        // placed on the line between its two ends, and that line is the map
-        // within a section and a guess across a boundary (TempoMap.hpp).
+        // and the next segment carries on continuous.
+        //
+        // What the cut is for has changed. It arrived to keep the block's own
+        // straight line honest, because everything inside a block was placed on
+        // the line between its two ends; placement goes through the map now, so
+        // that is no longer what pays for it (#2336).
+        //
+        // What it still buys is that a block is one tempo and one signature. A
+        // rate-synced modifier reads a single bpm for the whole block it is
+        // rendering (ModLfo's modTimingFor), and a block spanning a step would
+        // run at the tempo it opened on for the rest of it. The cut is what
+        // makes that reading exact rather than nearly right, and it costs one
+        // extra segment per tempo change (#2333).
         const auto boundary = tempo.nextSectionBoundaryAfter(beatAfter(tempo, samplesSinceAnchor_));
         if (std::isfinite(boundary)) {
             if (const auto untilBoundary = samplesUntil(tempo, boundary); untilBoundary > 0)

--- a/magda/engine/transport/TransportClock.cpp
+++ b/magda/engine/transport/TransportClock.cpp
@@ -9,11 +9,6 @@ namespace {
 
 constexpr double kBeatEpsilon = 1.0e-9;
 
-/// A boundary this close to the cursor is the cursor. Rounding up to the first
-/// sample at or past a musical position would otherwise turn the position the
-/// clock just anchored to into a boundary one sample ahead of itself.
-constexpr double kSampleEpsilon = 1.0e-2;
-
 }  // namespace
 
 void TransportClock::anchorTo(const TempoMap& tempo, double beat) {
@@ -33,6 +28,9 @@ double TransportClock::beatAfter(const TempoMap& tempo, std::int64_t samples) co
 }
 
 std::int64_t TransportClock::samplesUntil(const TempoMap& tempo, double beat) const {
+    // A boundary within the epsilon of the cursor is the cursor: rounding up to
+    // the first sample at or past a musical position would otherwise turn the
+    // position just anchored to into a boundary one sample ahead of itself.
     const auto now = secondsAfter(samplesSinceAnchor_);
     const auto target = tempo.beatToTime(beat);
     return static_cast<std::int64_t>(std::ceil((target - now) * sampleRate_ - kSampleEpsilon));
@@ -127,6 +125,7 @@ std::span<const TransportClock::Segment> TransportClock::advance(const Transport
         segment.block.monotonicSeconds.end = monotonicSeconds_;
         segment.block.monotonicSamples.start = monotonicSamples_;
         segment.block.monotonicSamples.end = monotonicSamples_;
+        segment.block.sampleRate = sampleRate_;
         segment.block.continuous = continuous_;
         segment.block.tempo = &tempo;
         segment.startSample = 0;
@@ -234,8 +233,10 @@ std::span<const TransportClock::Segment> TransportClock::advance(const Transport
         // longer one conversion apart, and this side of it is the one that did
         // not move (#2332).
         segment.block.monotonicSamples.start = monotonicSamples_;
-        monotonicSamples_ += samples;
+        monotonicSamples_ += SampleDuration{samples};
         segment.block.monotonicSamples.end = monotonicSamples_;
+
+        segment.block.sampleRate = sampleRate_;
 
         segment.block.continuous = continuous_;
         segment.block.tempo = &tempo;

--- a/magda/engine/transport/TransportClock.hpp
+++ b/magda/engine/transport/TransportClock.hpp
@@ -89,9 +89,9 @@ class TransportClock {
         return monotonicSeconds_;
     }
 
-    /// Samples the transport has rolled since the clock began. Never goes back,
-    /// and is not re-anchored by anything that moves the cursor.
-    std::int64_t monotonicSamples() const {
+    /// Where the transport has rolled to on its own sample count. Never goes
+    /// back, and is not re-anchored by anything that moves the cursor.
+    SamplePosition monotonicSamples() const {
         return monotonicSamples_;
     }
 
@@ -176,7 +176,7 @@ class TransportClock {
     /// Samples rolled since the clock began. What the two monotonic faces above
     /// are counted from, and the one coordinate a locate, a wrap, a tempo edit
     /// and a re-anchor all leave alone (#2332).
-    std::int64_t monotonicSamples_ = 0;
+    SamplePosition monotonicSamples_;
 
     std::atomic<double> positionBeats_{0.0};
     std::atomic<bool> playingPublic_{false};

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -361,6 +361,9 @@ if(MAGDA_BUILD_NATIVE_ENGINE)
     list(APPEND TEST_SOURCES engine/test_value_taps.cpp)
     list(APPEND TEST_SOURCES engine/test_tempo_map.cpp)
     list(APPEND TEST_SOURCES engine/test_transport_clock.cpp)
+    # The two meanings of a sample offset inside a block (#2336): an event on a
+    # sample the block plays, an edge that may be the boundary past its last.
+    list(APPEND TEST_SOURCES engine/test_block_samples.cpp)
     # The launcher's state machine (#2300): quantized launch and stop against
     # monotonic beats, and the split a block straddling one reports.
     list(APPEND TEST_SOURCES engine/test_launch_handle.cpp)

--- a/tests/audio/test_click_generator.cpp
+++ b/tests/audio/test_click_generator.cpp
@@ -16,12 +16,18 @@ constexpr int kBlockSize = 512;
 /// 120 bpm: 22050 samples to the beat.
 constexpr double kSamplesPerBeat = kSampleRate / 2.0;
 
+/// A block at 120 bpm, with both faces and the rate the transport would give
+/// it: a tick is placed through the map, and the map needs a seconds face to
+/// answer against (RenderContext::offsetForBeat).
 BlockInfo blockFrom(double startBeat, int numSamples) {
     BlockInfo block;
     block.numSamples = numSamples;
+    block.sampleRate = kSampleRate;
     block.playing = true;
     block.beats.start = startBeat;
     block.beats.end = startBeat + numSamples / kSamplesPerBeat;
+    block.seconds.start = block.beats.start * 0.5;
+    block.seconds.end = block.beats.end * 0.5;
     block.continuous = true;
     return block;
 }
@@ -49,7 +55,8 @@ struct Fixture {
         output.clear();
     }
 
-    void render(const BlockInfo& block, bool countingIn = false) {
+    void render(BlockInfo block, bool countingIn = false) {
+        block.tempo = &tempo;
         generator.render(tempo, click, block, countingIn, output, 0);
     }
 
@@ -187,6 +194,7 @@ TEST_CASE("Two beats inside one block both sound", "[engine][transport][click]")
     output.clear();
 
     auto block = blockFrom(0.0, output.getNumSamples());
+    block.tempo = &fixture.tempo;
     fixture.generator.render(fixture.tempo, fixture.click, block, false, output, 0);
 
     CHECK(clickStart(output) == 0);

--- a/tests/audio/test_click_generator.cpp
+++ b/tests/audio/test_click_generator.cpp
@@ -200,3 +200,33 @@ TEST_CASE("Two beats inside one block both sound", "[engine][transport][click]")
     CHECK(clickStart(output) == 0);
     CHECK(output.getSample(0, static_cast<int>(kSamplesPerBeat) + 1) != 0.0f);
 }
+
+TEST_CASE("The metronome follows a signature change inside one block",
+          "[engine][transport][click][2336]") {
+    // The other thing the tempo-section cut incidentally provides: a block
+    // inside one time signature. The metronome walks the map's own ticks rather
+    // than a grid it worked out from the block's ends, so it does not need one,
+    // and this is the case that says so (#2333).
+    //
+    // The transport does not hand out such a block today. Built by hand, the
+    // assertion holds whatever the clock decides about cutting.
+    Fixture fixture;
+    fixture.tempo = TempoMap({}, {{0.0, 4, 4}, {2.0, 6, 8}});
+
+    constexpr auto kSamples = static_cast<int>(1.5 * kSamplesPerBeat);
+    fixture.output.setSize(2, kSamples);
+    fixture.output.clear();
+
+    fixture.render(blockFrom(1.5, kSamples));
+
+    // The beat at 2, half a beat into the block.
+    const auto first = static_cast<int>(0.5 * kSamplesPerBeat);
+    CHECK(clickStart(fixture.output) == first);
+
+    // And the one at 2.5, which only exists because six eighths to the bar puts
+    // a tick every half beat. Under four four the next tick would be at beat 3,
+    // past the end of the block, and this half of it would be silent.
+    const auto blip = static_cast<int>(0.05 * kSampleRate);
+    CHECK(firstSounding(fixture.output, first + blip) - 1 ==
+          static_cast<int>(1.0 * kSamplesPerBeat));
+}

--- a/tests/audio/test_file_audio_source.cpp
+++ b/tests/audio/test_file_audio_source.cpp
@@ -1,6 +1,7 @@
 #include <algorithm>
 #include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
+#include <cmath>
 #include <memory>
 #include <vector>
 
@@ -70,6 +71,10 @@ Catch::Approx approx(float value) {
 BlockInfo blockFrom(double startSeconds, int numSamples = kBlockSize, bool continuous = true) {
     BlockInfo block;
     block.numSamples = numSamples;
+    block.sampleRate = kSampleRate;
+    block.monotonicSamples = {
+        magda::engine::SamplePosition{std::llround(startSeconds * kSampleRate)},
+        magda::engine::SamplePosition{std::llround(startSeconds * kSampleRate) + numSamples}};
     block.playing = true;
     block.seconds.start = startSeconds;
     block.seconds.end = startSeconds + numSamples / kSampleRate;

--- a/tests/audio/test_streaming_audio_source.cpp
+++ b/tests/audio/test_streaming_audio_source.cpp
@@ -2,6 +2,7 @@
 #include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <chrono>
+#include <cmath>
 #include <memory>
 #include <thread>
 
@@ -72,6 +73,10 @@ Catch::Approx approx(float value) {
 BlockInfo blockFrom(double startSeconds, int numSamples = kBlockSize, bool continuous = true) {
     BlockInfo block;
     block.numSamples = numSamples;
+    block.sampleRate = kSampleRate;
+    block.monotonicSamples = {
+        magda::engine::SamplePosition{std::llround(startSeconds * kSampleRate)},
+        magda::engine::SamplePosition{std::llround(startSeconds * kSampleRate) + numSamples}};
     block.playing = true;
     block.seconds.start = startSeconds;
     block.seconds.end = startSeconds + numSamples / kSampleRate;

--- a/tests/engine/test_automation_bake.cpp
+++ b/tests/engine/test_automation_bake.cpp
@@ -105,6 +105,9 @@ ParamKey deviceParam(TrackId track, DeviceId device, int index) {
     return key;
 }
 
+/// A block in beats alone, which is what a resolver walk is about: no seconds
+/// face and no map, so a knot is placed along the block's own beat line
+/// (RenderContext::offsetForBeat).
 magda::engine::BlockInfo blockAt(double startBeat, double beats = 1.0, int numSamples = 64) {
     magda::engine::BlockInfo block;
     block.numSamples = numSamples;

--- a/tests/engine/test_block_samples.cpp
+++ b/tests/engine/test_block_samples.cpp
@@ -1,5 +1,7 @@
+#include <algorithm>
 #include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
+#include <cmath>
 
 #include "exec/RenderContext.hpp"
 
@@ -122,24 +124,43 @@ TEST_CASE("A beat is placed through the map, not along the block's line",
     // holds whatever the clock does about cutting (#2333).
     const TempoMap ramp({{0.0, 20.0, 0.0f}, {1.0, 300.0, 0.0f}}, {});
 
+    // Long enough to cross the baked boundary at 0.75, which is where the slope
+    // changes: the map cuts a ramp four ways to the beat. A block of the usual
+    // few hundred samples sits inside one section, where the line is the map.
+    const auto from = ramp.beatToTime(0.5);
+    const auto to = ramp.beatToTime(0.85);
+
     BlockInfo block;
-    block.numSamples = kBlockSize;
+    block.numSamples = static_cast<int>(std::lround((to - from) * kSampleRate));
     block.sampleRate = kSampleRate;
     block.playing = true;
-    block.seconds.start = ramp.beatToTime(0.5);
-    block.seconds.end = block.seconds.start + (kBlockSize / kSampleRate);
-    block.beats.start = ramp.timeToBeat(block.seconds.start);
-    block.beats.end = ramp.timeToBeat(block.seconds.end);
+    block.seconds.start = from;
+    block.seconds.end = to;
+    block.beats.start = ramp.timeToBeat(from);
+    block.beats.end = ramp.timeToBeat(to);
     block.tempo = &ramp;
+
+    auto worstOnTheLine = 0.0;
 
     for (const auto through : {0.25, 0.5, 0.75}) {
         const auto beat = block.beats.start + (through * block.beats.length());
+        const auto exact = (ramp.beatToTime(beat) - block.seconds.start) * kSampleRate;
 
-        const auto exact =
-            static_cast<int>((ramp.beatToTime(beat) - block.seconds.start) * kSampleRate);
+        // Where the block's own two ends would have put it, which is what the
+        // conversion used to do.
+        const auto onTheLine = through * block.numSamples;
+        worstOnTheLine = std::max(worstOnTheLine, std::abs(onTheLine - exact));
 
-        CHECK(block.eventForBeat(beat).value == exact);
+        // To the sample, rather than to the exact integer: which side of a
+        // fractional answer a rounding rule lands on is the rule's business
+        // (TimeDomains::eventAt), and asserting it here would be asserting the
+        // rule twice.
+        CHECK(std::abs(static_cast<double>(block.eventForBeat(beat).value) - exact) <= 1.0);
     }
+
+    // And this is a block where the map and the line differ, or the case above
+    // would pass on one that could not tell them apart.
+    CHECK(worstOnTheLine > 1.0);
 }
 
 TEST_CASE("A block with beats alone places along its own line", "[engine][block][samples]") {

--- a/tests/engine/test_block_samples.cpp
+++ b/tests/engine/test_block_samples.cpp
@@ -1,0 +1,158 @@
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+#include "exec/RenderContext.hpp"
+
+/**
+ * @file test_block_samples.cpp
+ * @brief The two things a sample offset inside a block can mean (#2336).
+ *
+ * An event is a sample the block plays and an edge is a bound of a stretch it
+ * covers, and the difference shows at exactly one place: the boundary past the
+ * block's last sample, which is a legal edge and not a sample anything sounds
+ * on.
+ */
+
+using magda::engine::BlockInfo;
+using magda::engine::EdgeSample;
+using magda::engine::EventSample;
+using magda::engine::TempoMap;
+
+namespace {
+
+constexpr double kSampleRate = 48000.0;
+constexpr int kBlockSize = 512;
+
+/// 120 bpm: half a second to the beat, 24000 samples.
+constexpr double kSecondsPerBeat = 0.5;
+
+/// The block starting @p fromSample of a transport rolling from zero at one
+/// tempo, with every face the clock would give it.
+BlockInfo blockFrom(std::int64_t fromSample, const TempoMap* tempo = nullptr) {
+    BlockInfo block;
+    block.numSamples = kBlockSize;
+    block.sampleRate = kSampleRate;
+    block.playing = true;
+    block.continuous = true;
+    block.seconds.start = static_cast<double>(fromSample) / kSampleRate;
+    block.seconds.end = static_cast<double>(fromSample + kBlockSize) / kSampleRate;
+    block.beats.start = block.seconds.start / kSecondsPerBeat;
+    block.beats.end = block.seconds.end / kSecondsPerBeat;
+    block.monotonicBeats = block.beats;
+    block.monotonicSeconds = block.seconds;
+    block.monotonicSamples = {magda::engine::SamplePosition{fromSample},
+                              magda::engine::SamplePosition{fromSample + kBlockSize}};
+    block.tempo = tempo;
+    return block;
+}
+
+}  // namespace
+
+TEST_CASE("An event lands on a sample the block plays", "[engine][block][samples]") {
+    const auto block = blockFrom(0);
+
+    CHECK(block.eventForTime(block.seconds.start) == EventSample{0});
+    CHECK(block.eventForBeat(block.beats.start) == EventSample{0});
+
+    // Inside a sample rather than nearest to it: what plays at a moment is the
+    // sample that moment is within.
+    const auto halfWay = block.seconds.start + (100.6 / kSampleRate);
+    CHECK(block.eventForTime(halfWay) == EventSample{100});
+}
+
+TEST_CASE("No event is ever placed past the block's last sample",
+          "[engine][block][samples][2336]") {
+    const auto block = blockFrom(0);
+
+    // The acceptance criterion, from both faces. Nearest would round anything
+    // in the last half sample to 512, which is a buffer index this block does
+    // not have: a MIDI message written there reaches nobody, and a voice
+    // started there starts nothing.
+    const auto lastSample = block.seconds.end - (0.25 / kSampleRate);
+
+    CHECK(block.eventForTime(lastSample) == EventSample{kBlockSize - 1});
+    CHECK(block.eventForBeat(block.beats.end - 1e-9) == EventSample{kBlockSize - 1});
+}
+
+TEST_CASE("A moment on the boundary is the next block's first sample",
+          "[engine][block][samples][2336]") {
+    // Where the event that resolved to N goes, and it gets there without being
+    // carried: the next block's stretch begins on it.
+    const auto first = blockFrom(0);
+    const auto second = blockFrom(kBlockSize);
+
+    const auto boundary = first.seconds.end;
+    REQUIRE(boundary == Catch::Approx(second.seconds.start));
+
+    CHECK(second.eventForTime(boundary) == EventSample{0});
+    CHECK(second.eventForBeat(second.beats.start) == EventSample{0});
+}
+
+TEST_CASE("An edge may be the boundary past the last sample", "[engine][block][samples]") {
+    const auto block = blockFrom(0);
+
+    // Which is what a half-open stretch that runs to the end of the block is,
+    // and why an edge is a different type from an event.
+    CHECK(block.edgeForTime(block.seconds.end) == EdgeSample{kBlockSize});
+    CHECK(block.edgeForBeat(block.beats.end) == EdgeSample{kBlockSize});
+
+    CHECK(block.edgeForTime(block.seconds.start) == EdgeSample{0});
+    CHECK(block.edgeForTime(block.seconds.end) - block.edgeForTime(block.seconds.start) ==
+          kBlockSize);
+}
+
+TEST_CASE("An edge that has to be heard sounds a sample early", "[engine][block][samples][2336]") {
+    const auto block = blockFrom(0);
+
+    // A note-off on the block boundary. Written at 512 it is written nowhere,
+    // and the stretch that owed it has gone by the time the next block renders:
+    // the note would hang.
+    CHECK(block.soundsAt(block.edgeForBeat(block.beats.end)) == EventSample{kBlockSize - 1});
+
+    // Everything short of the boundary is left where it is.
+    CHECK(block.soundsAt(EdgeSample{0}) == EventSample{0});
+    CHECK(block.soundsAt(EdgeSample{17}) == EventSample{17});
+}
+
+TEST_CASE("A beat is placed through the map, not along the block's line",
+          "[engine][block][samples][2336]") {
+    // A ramp baked into sections, and a block that spans a boundary: the line
+    // between the block's two ends is not the map inside it. The transport does
+    // not currently hand out such a block, so this is built by hand, and it
+    // holds whatever the clock does about cutting (#2333).
+    const TempoMap ramp({{0.0, 20.0, 0.0f}, {1.0, 300.0, 0.0f}}, {});
+
+    BlockInfo block;
+    block.numSamples = kBlockSize;
+    block.sampleRate = kSampleRate;
+    block.playing = true;
+    block.seconds.start = ramp.beatToTime(0.5);
+    block.seconds.end = block.seconds.start + (kBlockSize / kSampleRate);
+    block.beats.start = ramp.timeToBeat(block.seconds.start);
+    block.beats.end = ramp.timeToBeat(block.seconds.end);
+    block.tempo = &ramp;
+
+    for (const auto through : {0.25, 0.5, 0.75}) {
+        const auto beat = block.beats.start + (through * block.beats.length());
+
+        const auto exact =
+            static_cast<int>((ramp.beatToTime(beat) - block.seconds.start) * kSampleRate);
+
+        CHECK(block.eventForBeat(beat).value == exact);
+    }
+}
+
+TEST_CASE("A block with beats alone places along its own line", "[engine][block][samples]") {
+    // What a caller assembling a block by hand from beats gets, which is every
+    // resolver test in the tree: no seconds face, no map, and the block's own
+    // two beat ends as the only line there is.
+    BlockInfo block;
+    block.numSamples = 64;
+    block.playing = true;
+    block.beats = {4.0, 5.0};
+
+    CHECK(block.eventForBeat(4.0) == EventSample{0});
+    CHECK(block.eventForBeat(4.5) == EventSample{32});
+    CHECK(block.eventForBeat(5.0) == EventSample{63});
+    CHECK(block.edgeForBeat(5.0) == EdgeSample{64});
+}

--- a/tests/engine/test_clip_voice.cpp
+++ b/tests/engine/test_clip_voice.cpp
@@ -169,6 +169,10 @@ SnapshotSpan blocks(int firstBlock, int lastBlock) {
 BlockInfo blockFrom(double startSeconds, bool continuous = true) {
     BlockInfo block;
     block.numSamples = kBlockSize;
+    block.sampleRate = kSampleRate;
+    block.monotonicSamples = {
+        magda::engine::SamplePosition{std::llround(startSeconds * kSampleRate)},
+        magda::engine::SamplePosition{std::llround(startSeconds * kSampleRate) + kBlockSize}};
     block.playing = true;
     block.seconds.start = startSeconds;
     block.seconds.end = startSeconds + kBlockSize / kSampleRate;

--- a/tests/engine/test_engine_external_device.cpp
+++ b/tests/engine/test_engine_external_device.cpp
@@ -1001,6 +1001,99 @@ TEST_CASE("The plugin is told where the transport is", "[engine][external]") {
     CHECK(*position.getTimeInSeconds() == Catch::Approx(tempo.beatToTime(7.0)));
 }
 
+TEST_CASE("The plugin is told the section the block renders in", "[engine][external][2336]") {
+    // A block covers one tempo section, but a cut lands on the first sample at
+    // or after the boundary, so it can open a fraction of a sample before one
+    // (BlockInfo::sectionBeat). A plugin is told one bpm and one signature for
+    // the whole call, and taking them from the block's first beat would run the
+    // call on the section it had already left.
+    auto plugin = std::make_unique<StubPlugin>();
+    auto* raw = plugin.get();
+
+    adapter::EngineExternalDevice device(std::move(plugin), externalDevice(), false);
+    const auto context = contextFor();
+    device.prepare(context);
+
+    // 120 to 60 at beat 4, and four four to three four with it. A step is two
+    // changes at the one beat, which is how it is written rather than a ramp.
+    const magda::engine::TempoMap tempo({{.startBeat = 0.0, .bpm = 120.0},
+                                         {.startBeat = 4.0, .bpm = 120.0},
+                                         {.startBeat = 4.0, .bpm = 60.0}},
+                                        {{.startBeat = 0.0, .numerator = 4, .denominator = 4},
+                                         {.startBeat = 4.0, .numerator = 3, .denominator = 4}});
+
+    // A hundredth of a sample before the boundary, at 120 bpm and 44.1 kHz.
+    constexpr auto kNudge = 0.01 / 22050.0;
+
+    ParamArena arena({0.0f, 1.0f, 1.0f, 0.0f});
+    Block block(context, 2);
+    block.info.beats.start = 4.0 - kNudge;
+    block.info.beats.end = block.info.beats.start + 0.25;
+    block.info.seconds.start = tempo.beatToTime(block.info.beats.start);
+    block.info.seconds.end = tempo.beatToTime(block.info.beats.end);
+    block.info.tempo = &tempo;
+
+    auto deviceBlock = block.deviceBlock(arena.params(context.maxBlockSize));
+    device.process(deviceBlock);
+
+    const auto& position = raw->positionSeen;
+
+    // The section the block is in, not the one its first beat is in.
+    REQUIRE(position.getBpm().hasValue());
+    CHECK(*position.getBpm() == Catch::Approx(60.0));
+    REQUIRE(position.getTimeSignature().hasValue());
+    CHECK(position.getTimeSignature()->numerator == 3);
+    CHECK(position.getTimeSignature()->denominator == 4);
+
+    // And the bar that section starts, rather than the four four bar the
+    // block's first beat is still a whole bar into.
+    REQUIRE(position.getPpqPositionOfLastBarStart().hasValue());
+    CHECK(*position.getPpqPositionOfLastBarStart() == Catch::Approx(4.0));
+
+    // Where the block is stays its own first sample, which is what the plugin
+    // is being handed.
+    REQUIRE(position.getPpqPosition().hasValue());
+    CHECK(*position.getPpqPosition() == Catch::Approx(block.info.beats.start));
+    REQUIRE(position.getTimeInSeconds().hasValue());
+    CHECK(*position.getTimeInSeconds() == Catch::Approx(block.info.seconds.start));
+}
+
+TEST_CASE("A block straddling a bar line reports the bar it began in", "[engine][external][2336]") {
+    // The section a block renders in is one thing and the bar its first sample
+    // is in is another. A block is cut at every tempo section and at no bar
+    // line, so a long one straddles one, and reporting the bar its middle is in
+    // would make what the plugin is told depend on how the host sized the
+    // callback: the same first sample, two answers.
+    auto plugin = std::make_unique<StubPlugin>();
+    auto* raw = plugin.get();
+
+    adapter::EngineExternalDevice device(std::move(plugin), externalDevice(), false);
+    const auto context = contextFor();
+    device.prepare(context);
+
+    const magda::engine::TempoMap tempo({{.startBeat = 0.0, .bpm = 90.0}},
+                                        {{.startBeat = 0.0, .numerator = 3, .denominator = 4}});
+
+    ParamArena arena({0.0f, 1.0f, 1.0f, 0.0f});
+    Block block(context, 2);
+
+    // Opens just before the bar line at beat 6 and runs past it.
+    block.info.beats.start = 5.99;
+    block.info.beats.end = 6.25;
+    block.info.seconds.start = tempo.beatToTime(block.info.beats.start);
+    block.info.seconds.end = tempo.beatToTime(block.info.beats.end);
+    block.info.tempo = &tempo;
+
+    auto deviceBlock = block.deviceBlock(arena.params(context.maxBlockSize));
+    device.process(deviceBlock);
+
+    const auto& position = raw->positionSeen;
+
+    // The bar the block began in, which is the one before the line it crosses.
+    REQUIRE(position.getPpqPositionOfLastBarStart().hasValue());
+    CHECK(*position.getPpqPositionOfLastBarStart() == Catch::Approx(3.0));
+}
+
 TEST_CASE("A parameter that did not move is not written again", "[engine][external]") {
     auto plugin = std::make_unique<StubPlugin>();
     auto* raw = plugin.get();

--- a/tests/engine/test_launch_handle.cpp
+++ b/tests/engine/test_launch_handle.cpp
@@ -633,3 +633,63 @@ TEST_CASE("A run's origin is the same sample after the timeline wraps", "[launch
     // And the run has got as far as the count says, whatever the cursor did.
     CHECK(handle.playedSampleRange()->length() == SampleDuration{samplesFor(6.0)});
 }
+
+TEST_CASE("A synced launch joins the run as the rate left it", "[launch][2336]") {
+    // A scene launch is a request now and a launch at the quantized beat, and
+    // between the two the device can change rate. The run to join is held as a
+    // copy, and a copy counted in samples of one length adopted at another puts
+    // the follower somewhere the leader is not: at 44.1 to 48 kHz with a second
+    // in between it is about 90 ms, for the rest of the run.
+    //
+    // So the copy follows the rate on the same blocks the leader's own run
+    // does, which is what makes joining at the launch instant and joining a
+    // copy the same answer.
+    LaunchHandle leader;
+    LaunchHandle follower;
+
+    leader.play({});
+    leader.advance(block(0.0, 2.0));  // one second at 48 kHz
+
+    // Queued for a beat that has not arrived, which is what a scene launch is.
+    follower.playSynced(leader, 4.0);
+
+    // The device doubles its rate. The transport's count carries straight on;
+    // what changes is what each sample is worth.
+    const auto doubled = [](double from, double to, std::int64_t fromSample) {
+        return SyncRange{BeatRange{from, to},
+                         BeatRange{from, to},
+                         SecondsRange{from * kSecondsPerBeat, to * kSecondsPerBeat},
+                         SampleRange{SamplePosition{fromSample},
+                                     SamplePosition{fromSample + static_cast<std::int64_t>(
+                                                                     (to - from) * kSecondsPerBeat *
+                                                                     2.0 * kSampleRate)}},
+                         static_cast<int>((to - from) * kSecondsPerBeat * 2.0 * kSampleRate),
+                         2.0 * kSampleRate};
+    };
+
+    const auto second = doubled(2.0, 3.0, 48000);
+    leader.advance(second);
+    follower.advance(second);
+
+    // And now the launch beat arrives.
+    const auto third = doubled(3.0, 5.0, 96000);
+    const auto leading = leader.advance(third);
+    const auto following = follower.advance(third);
+
+    REQUIRE(follower.playedSampleRange().has_value());
+    REQUIRE(leader.playedSampleRange().has_value());
+
+    // The same origin, which is the whole point of a synced launch: the same
+    // sample, not merely the same bar.
+    CHECK(follower.playedSampleRange()->start == leader.playedSampleRange()->start);
+
+    REQUIRE(following.afterEvent.has_value());
+    REQUIRE(following.afterEvent->origin.has_value());
+    REQUIRE(leading.beforeEvent.origin.has_value());
+
+    // And what a source is handed says the same thing on both axes. The origin
+    // is where the run began in absolute terms, so the two agree whatever piece
+    // of the block each was worked out over.
+    CHECK(following.afterEvent->origin->beat == Approx(leading.beforeEvent.origin->beat));
+    CHECK(following.afterEvent->origin->seconds == Approx(leading.beforeEvent.origin->seconds));
+}

--- a/tests/engine/test_launch_handle.cpp
+++ b/tests/engine/test_launch_handle.cpp
@@ -1,5 +1,8 @@
 #include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
+#include <cmath>
+#include <cstdint>
+#include <vector>
 
 #include "launch/LaunchHandle.hpp"
 
@@ -31,30 +34,42 @@ constexpr int samplesFor(double beats) {
     return static_cast<int>(beats * kSecondsPerBeat * kSampleRate);
 }
 
-/// One block, in all four faces, with the timeline and monotonic clocks running
-/// together. They diverge only when something wraps the timeline.
+/// Where a monotonic beat sits on the transport's count, at that tempo. The
+/// count is what a run's origin is recorded as, so a block carries it (#2336).
+SamplePosition at(double monotonicBeat) {
+    return SamplePosition{static_cast<std::int64_t>(monotonicBeat * kSecondsPerBeat * kSampleRate)};
+}
+
+/// One block, with the timeline and monotonic clocks running together. They
+/// diverge only when something wraps the timeline.
 SyncRange block(double from, double to) {
-    return SyncRange{BeatRange{from, to}, BeatRange{from, to},
+    return SyncRange{BeatRange{from, to},
+                     BeatRange{from, to},
                      SecondsRange{from * kSecondsPerBeat, to * kSecondsPerBeat},
-                     SecondsRange{from * kSecondsPerBeat, to * kSecondsPerBeat},
-                     samplesFor(to - from)};
+                     SampleRange{at(from), at(to)},
+                     samplesFor(to - from),
+                     kSampleRate};
 }
 
 /// A block the timeline has wrapped under.
 SyncRange wrapped(double from, double to, double monotonicFrom, double monotonicTo) {
-    return SyncRange{BeatRange{from, to}, BeatRange{monotonicFrom, monotonicTo},
+    return SyncRange{BeatRange{from, to},
+                     BeatRange{monotonicFrom, monotonicTo},
                      SecondsRange{from * kSecondsPerBeat, to * kSecondsPerBeat},
-                     SecondsRange{monotonicFrom * kSecondsPerBeat, monotonicTo * kSecondsPerBeat},
-                     samplesFor(monotonicTo - monotonicFrom)};
+                     SampleRange{at(monotonicFrom), at(monotonicTo)},
+                     samplesFor(monotonicTo - monotonicFrom),
+                     kSampleRate};
 }
 
 }  // namespace
 
 TEST_CASE("An event in the block's last half sample stays inside the block", "[launch]") {
-    // A beat nearer the next callback's first sample than this one's last
-    // rounds past the end of the block. Applied there, the event happens but
-    // nothing can carry it: a stop would clear its own note state while its
-    // note-offs went to an offset outside the buffer, and the notes would hang.
+    // A beat nearer the next callback's first sample than this one's last is
+    // where nearest would answer past the end of the block. Applied there, the
+    // event happens but nothing can carry it: a stop would clear its own note
+    // state while its note-offs went to an offset outside the buffer, and the
+    // notes would hang. Floor answers the sample the beat is inside, which is
+    // one this block has (TimeDomains::eventAt).
     LaunchHandle handle;
 
     const auto range = block(0.0, 1.0);
@@ -307,7 +322,7 @@ TEST_CASE("Nudge moves the playhead without ending the run", "[launch]") {
     handle.play({});
     handle.advance(block(0.0, 2.0));
 
-    handle.nudge(0.5, 0.5 * kSecondsPerBeat);
+    handle.nudge(0.5, SampleDuration::ofSeconds(0.5 * kSecondsPerBeat, kSampleRate));
 
     REQUIRE(handle.playedRange().has_value());
     CHECK(handle.playedRange()->length() == Approx(2.5));
@@ -465,12 +480,12 @@ TEST_CASE("A backward nudge cannot take a run before it started", "[launch]") {
     handle.advance(block(0.0, 2.0));
 
     SECTION("within the run it shifts the origin") {
-        handle.nudge(-0.5, -0.5 * kSecondsPerBeat);
+        handle.nudge(-0.5, SampleDuration::ofSeconds(-0.5 * kSecondsPerBeat, kSampleRate));
         CHECK(handle.playedRange()->length() == Approx(1.5));
     }
 
     SECTION("past the start it clamps rather than inverting") {
-        handle.nudge(-3.0, -3.0 * kSecondsPerBeat);
+        handle.nudge(-3.0, SampleDuration::ofSeconds(-3.0 * kSecondsPerBeat, kSampleRate));
 
         const auto played = *handle.playedRange();
         CHECK(played.length() == Approx(0.0));
@@ -498,4 +513,123 @@ TEST_CASE("playStartTime survives the timeline wrapping under it", "[launch]") {
     // in, because that is how long the run has been going.
     CHECK(status.beforeEvent.range.start - status.beforeEvent.origin->beat == Approx(2.0));
     CHECK(status.beforeEvent.origin->beat == Approx(-2.0));
+}
+
+TEST_CASE("A thousand retriggers do not walk off the beat", "[launch][2336]") {
+    // The drift the epic opens with. At 48 kHz and 123 bpm a beat is 23,414.634
+    // samples, so no whole number of samples is a beat, and a wrap scheduled
+    // from the sample the previous wrap landed on rounds up every time: after a
+    // thousand of them the run is about 366 samples late, a third of a beat
+    // short of eight milliseconds.
+    //
+    // What stops it is that the schedule and the sound are different questions.
+    // A wrap sounds on a sample, because that is the only thing that can sound;
+    // the next wrap is counted from the beat the run was asked for, which no
+    // rounding has ever touched (LaunchHandle::Run::scheduleBeat).
+    constexpr auto kBpm = 123.0;
+    constexpr auto kRate = 48000.0;
+    constexpr auto kBlock = 512;
+    constexpr auto kTurns = 1000;
+
+    const TempoMap tempo({{0.0, kBpm, 0.0f}}, {});
+    const auto samplesPerBeat = (60.0 / kBpm) * kRate;
+
+    const auto blockFrom = [&](std::int64_t sample) {
+        const auto from = static_cast<double>(sample) / kRate;
+        const auto to = static_cast<double>(sample + kBlock) / kRate;
+
+        return SyncRange{BeatRange{tempo.timeToBeat(from), tempo.timeToBeat(to)},
+                         BeatRange{tempo.timeToBeat(from), tempo.timeToBeat(to)},
+                         SecondsRange{from, to},
+                         SampleRange{SamplePosition{sample}, SamplePosition{sample + kBlock}},
+                         kBlock,
+                         kRate,
+                         &tempo};
+    };
+
+    LaunchHandle handle;
+    handle.play({});
+    handle.setLooping(1.0);
+
+    std::vector<std::int64_t> wraps;
+    auto origin = SamplePosition{0};
+
+    // A beat past the last wrap that is due, so the thousandth has somewhere to
+    // land and nothing after it is counted.
+    const auto blocks = static_cast<std::int64_t>(((kTurns + 1) * samplesPerBeat) / kBlock);
+
+    for (std::int64_t i = 0; i < blocks; ++i) {
+        handle.advance(blockFrom(i * kBlock));
+
+        const auto run = handle.playedSampleRange();
+        REQUIRE(run.has_value());
+
+        if (run->start != origin) {
+            origin = run->start;
+            wraps.push_back(origin.sample);
+        }
+    }
+
+    REQUIRE(wraps.size() >= static_cast<std::size_t>(kTurns));
+
+    for (std::size_t turn = 0; turn < static_cast<std::size_t>(kTurns); ++turn) {
+        // Where the beat is, rather than where a chain of rounded intervals
+        // would have got to. Within a sample at the thousandth as at the first.
+        const auto expected = static_cast<double>(turn + 1) * samplesPerBeat;
+        CHECK(std::abs(static_cast<double>(wraps[turn]) - expected) <= 1.0);
+    }
+}
+
+TEST_CASE("A rate change does not reinterpret a run's origin", "[launch][2336]") {
+    // A run's origin is a count of samples, and a device that changes rate
+    // changes what a sample is worth. Holding the number would silently move
+    // the run: a clip a second into its file would be half a second in, or two,
+    // depending on which way the rate went.
+    //
+    // What is kept is the time the run has actually had. The origin is
+    // re-counted behind the block at the new rate, which is the only thing that
+    // leaves the material where the listener last heard it.
+    LaunchHandle handle;
+    handle.play({});
+    handle.advance(block(0.0, 2.0));  // one second at 120 bpm
+
+    // The same transport count, carrying on: what changes is what each sample
+    // is worth, not how many have gone by.
+    const auto doubled = SyncRange{BeatRange{2.0, 3.0},
+                                   BeatRange{2.0, 3.0},
+                                   SecondsRange{1.0, 1.5},
+                                   SampleRange{SamplePosition{48000}, SamplePosition{96000}},
+                                   48000,
+                                   2.0 * kSampleRate};
+
+    const auto status = handle.advance(doubled);
+
+    REQUIRE(status.beforeEvent.origin.has_value());
+
+    // Still one second in, so the run's material begins where the block does
+    // minus the second it has had. Without the re-count it would read half a
+    // second, and every launched clip would jump backwards through its file.
+    CHECK(status.beforeEvent.origin->seconds == Approx(0.0));
+    CHECK(doubled.seconds.start - status.beforeEvent.origin->seconds == Approx(1.0));
+}
+
+TEST_CASE("A run's origin is the same sample after the timeline wraps", "[launch][2336]") {
+    // The durable identity. The beat the run began on stops being a beat in
+    // any cycle the moment the loop takes it back, and the second it began on
+    // is one the transport has passed twice; the sample it began on is the
+    // sample it began on.
+    LaunchHandle handle;
+    handle.play({});
+    handle.advance(wrapped(6.0, 8.0, 6.0, 8.0));
+
+    REQUIRE(handle.playedSampleRange().has_value());
+    const auto origin = handle.playedSampleRange()->start;
+
+    handle.advance(wrapped(0.0, 2.0, 8.0, 10.0));
+    handle.advance(wrapped(2.0, 4.0, 10.0, 12.0));
+
+    CHECK(handle.playedSampleRange()->start == origin);
+
+    // And the run has got as far as the count says, whatever the cursor did.
+    CHECK(handle.playedSampleRange()->length() == SampleDuration{samplesFor(6.0)});
 }

--- a/tests/engine/test_launch_handle_lifetime.cpp
+++ b/tests/engine/test_launch_handle_lifetime.cpp
@@ -40,7 +40,8 @@ ClipSnapshot snapshotWithScenes(const std::vector<int>& scenes, TrackId trackId 
 void launch(LaunchHandle& handle) {
     handle.play({});
     handle.advance(SyncRange{BeatRange{0.0, 2.0}, BeatRange{0.0, 2.0}, SecondsRange{0.0, 1.0},
-                             SecondsRange{0.0, 1.0}});
+                             SampleRange{SamplePosition{0}, SamplePosition{48000}}, 48000,
+                             48000.0});
     REQUIRE(handle.playState() == LaunchHandle::PlayState::playing);
 }
 

--- a/tests/engine/test_mod_lfo.cpp
+++ b/tests/engine/test_mod_lfo.cpp
@@ -1133,3 +1133,48 @@ TEST_CASE("An LFO moves a device parameter through a live session", "[engine][mo
         CHECK(render() == approx(0.5f * gain));
     }
 }
+
+TEST_CASE("A bar-rate LFO reads the bar the block renders in", "[engine][mod][lfo][2336]") {
+    // The other half of a block being one section. The tempo and the signature
+    // a block runs at come from inside it (BlockInfo::sectionBeat), and so does
+    // the bar its phase is measured against, or an LFO locked to the bar reads
+    // one grid and runs at another.
+    //
+    // Four four to three four at beat 1, which is not a bar line of either, and
+    // a block that opens a hundredth of a sample before it. Every sample it
+    // renders is in the three four bar that starts there; its first beat is
+    // still a quarter of the way through a four four bar.
+    const magda::engine::TempoMap tempo({{.startBeat = 0.0, .bpm = 120.0}},
+                                        {{.startBeat = 0.0, .numerator = 4, .denominator = 4},
+                                         {.startBeat = 1.0, .numerator = 3, .denominator = 4}});
+
+    // 24000 samples to the beat at 120 bpm and 48 kHz.
+    constexpr auto kNudge = 0.01 / 24000.0;
+
+    BlockInfo block;
+    block.numSamples = 512;
+    block.sampleRate = kSampleRate;
+    block.playing = true;
+    block.beats.start = 1.0 - kNudge;
+    block.beats.end = block.beats.start + (512.0 / 24000.0);
+    block.seconds.start = tempo.beatToTime(block.beats.start);
+    block.seconds.end = tempo.beatToTime(block.beats.end);
+    block.tempo = &tempo;
+
+    LfoState state;
+    LfoSettings settings;
+    settings.wave = LFOWaveform::Saw;
+    settings.sync = ModSync::Transport;
+    settings.tempoSync = true;
+    settings.rate.rateType = static_cast<int>(ModRateType::Bar);
+
+    const auto value = step(state, settings, block, {}, modTimingFor(block, kSampleRate));
+
+    // On the bar line, which for a saw is either end of its cycle: the block
+    // opens a hundredth of a sample before one, so both are the same instant.
+    // What is not the same instant is a quarter of the way through a bar, which
+    // is what reading the grid at the block's first beat gives.
+    const auto fromTheBarLine = std::min(value, 1.0f - value);
+
+    CHECK(fromTheBarLine < 0.001f);
+}

--- a/tests/engine/test_session_playback.cpp
+++ b/tests/engine/test_session_playback.cpp
@@ -214,9 +214,14 @@ struct AudioRig {
         lane.session.push_back(std::move(slot));
     }
 
-    void publish() {
+    /// @p map is the one the blocks will carry, and the snapshot is stamped
+    /// with its fingerprint. A source counts a snapshot compiled against
+    /// another map, so a fixture that publishes one is a fixture that lies
+    /// about its own setup (#2337). Absent for cases whose blocks carry none.
+    void publish(const magda::engine::TempoMap* map = nullptr) {
         auto compiled = std::make_shared<ClipSnapshot>();
         compiled->tracks.push_back(lane);
+        compiled->tempoFingerprint = map != nullptr ? map->fingerprint() : 0;
         clips.publish(std::move(compiled));
         streams.publish(std::make_shared<const ClipStreamTable>(streamTable));
     }
@@ -749,7 +754,7 @@ TEST_CASE("A slot launched where the tempo differs reads forward, not twice",
 
     AudioRig rig;
     rig.give(1, 4.0, std::make_unique<CountingReader>());
-    rig.publish();
+    rig.publish(&map);
 
     // Beat 8 is four seconds in, and everything from there runs at half the
     // tempo the slot was compiled at.
@@ -806,6 +811,80 @@ void callback(AudioRig& rig, magda::engine::TransportClock& clock,
 }
 
 }  // namespace
+
+// =============================================================================
+// The map a snapshot was compiled for
+// =============================================================================
+
+TEST_CASE("A snapshot compiled against another tempo map is counted",
+          "[engine][clip][session][tempo]") {
+    // A snapshot carries the fingerprint of the map its seconds came through.
+    // One that is not the transport's was compiled against a tempo that has
+    // since changed, and every second in it is wrong by however much the map
+    // moved.
+    //
+    // It still plays. What it does not do is pass unnoticed: the publish is
+    // meant to swap the map and the snapshot compiled for it together, and a
+    // count above zero is how anyone finds out that it did not (#2337).
+    const auto map = steppedTempo();
+    const magda::engine::TempoMap other({{0.0, 90.0, 0.0f}}, {{0.0, 4, 4}});
+
+    AudioRig rig;
+    rig.give(1, 8.0, std::make_unique<ConstantReader>());
+    rig.publish(&other);
+
+    rig.handle.play(std::nullopt);
+    rig.renderBlock(blockOnMap(map, map.beatToTime(4.0)));
+
+    CHECK(rig.source.staleSnapshots() == 1);
+}
+
+TEST_CASE("A snapshot that is the map's is not counted", "[engine][clip][session][tempo]") {
+    // The other half: the count is the fingerprint's doing rather than
+    // something every block does.
+    const auto map = steppedTempo();
+
+    AudioRig rig;
+    rig.give(1, 8.0, std::make_unique<ConstantReader>());
+    rig.publish(&map);
+
+    rig.handle.play(std::nullopt);
+    rig.renderBlock(blockOnMap(map, map.beatToTime(4.0)));
+
+    CHECK(rig.peak() == Approx(1.0f));
+    CHECK(rig.source.staleSnapshots() == 0);
+}
+
+TEST_CASE("A stale snapshot does not cost the notes it started", "[engine][clip][session][tempo]") {
+    // Counted, not cut off. A mismatch is a publish-ordering bug, and taking
+    // the notes away to report it would put a hole in the middle of a set to
+    // say so.
+    MidiRig rig;
+    rig.publish({sessionMidiClip(1, 4.0, {MidiNote{60, 100, 0.0, 4.0, 0, {}}})});
+
+    rig.handle.play(std::nullopt);
+    rig.roll(0, 2);
+
+    REQUIRE(rig.noteOns().size() == 1);
+    REQUIRE(rig.hanging().size() == 1);
+
+    const magda::engine::TempoMap other({{0.0, 90.0, 0.0f}}, {{0.0, 4, 4}});
+    auto block = blockAt(3);
+    block.tempo = &other;
+
+    juce::MidiBuffer buffer;
+    rig.source.render(block, buffer);
+
+    CHECK(rig.source.staleSnapshots() == 1);
+
+    // Still sounding: nothing was ended to report the mismatch.
+    auto offs = 0;
+    for (const auto metadata : buffer)
+        if (metadata.getMessage().isNoteOff())
+            ++offs;
+
+    CHECK(offs == 0);
+}
 
 TEST_CASE("A launch inside a block that spans a tempo step names one instant",
           "[engine][clip][session]") {
@@ -874,7 +953,7 @@ TEST_CASE("A slot launched where a block would step tempo starts at its own firs
 
     AudioRig rig;
     rig.give(1, 8.0, std::make_unique<CountingReader>());
-    rig.publish();
+    rig.publish(&map);
 
     magda::engine::TransportClock clock;
 
@@ -903,7 +982,7 @@ TEST_CASE("A launched slot plays straight through a loop wrap", "[engine][clip][
 
     AudioRig rig;
     rig.give(1, 8.0, std::make_unique<CountingReader>());
-    rig.publish();
+    rig.publish(&map);
 
     magda::engine::TransportClock clock;
 
@@ -937,7 +1016,7 @@ TEST_CASE("A launched slot keeps its place across a locate", "[engine][clip][ses
 
     AudioRig rig;
     rig.give(1, 8.0, std::make_unique<CountingReader>());
-    rig.publish();
+    rig.publish(&map);
 
     magda::engine::TransportClock clock;
 

--- a/tests/engine/test_session_playback.cpp
+++ b/tests/engine/test_session_playback.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
+#include <cmath>
 #include <cstdint>
 #include <memory>
 #include <optional>
@@ -124,6 +125,9 @@ RenderContext context() {
 BlockInfo blockAt(int index, bool continuous = true) {
     BlockInfo block;
     block.numSamples = kBlockSize;
+    block.sampleRate = kSampleRate;
+    block.monotonicSamples = {magda::engine::SamplePosition{index * kBlockSize},
+                              magda::engine::SamplePosition{(index + 1) * kBlockSize}};
     block.playing = true;
     block.continuous = continuous;
     block.beats.start = index * kBeatsPerBlock;
@@ -144,6 +148,10 @@ BlockInfo blockOnMap(const magda::engine::TempoMap& map, double startSeconds,
                      bool continuous = true) {
     BlockInfo block;
     block.numSamples = kBlockSize;
+    block.sampleRate = kSampleRate;
+    block.monotonicSamples = {
+        magda::engine::SamplePosition{std::llround(startSeconds * kSampleRate)},
+        magda::engine::SamplePosition{std::llround(startSeconds * kSampleRate) + kBlockSize}};
     block.playing = true;
     block.continuous = continuous;
     block.seconds.start = startSeconds;
@@ -396,7 +404,7 @@ TEST_CASE("A session block is the block with its beats moved onto the run",
     // callback's own buffer.
     CHECK(material.numSamples == block.numSamples);
     for (const auto beat : {0.0, 0.1, 0.2})
-        CHECK(material.sampleForBeat(beat) == block.sampleForBeat(block.beats.start + beat));
+        CHECK(material.eventForBeat(beat) == block.eventForBeat(block.beats.start + beat));
 
     // A run that began here is not continuous with the last block, whatever the
     // transport was doing.

--- a/tests/engine/test_session_playback.cpp
+++ b/tests/engine/test_session_playback.cpp
@@ -392,7 +392,7 @@ TEST_CASE("A session block is the block with its beats moved onto the run",
 
     magda::engine::BeatRange whole{block.beats.start, block.beats.end};
     const auto material = magda::engine::materialBlock(
-        block, whole, magda::engine::RunOrigin{block.beats.start, block.seconds.start});
+        block, whole, magda::engine::MaterialOrigin{block.beats.start, block.seconds.start});
 
     // Beat zero of the material, at the seconds beat zero has.
     CHECK(material.beats.start == Approx(0.0));
@@ -426,14 +426,14 @@ TEST_CASE("A session block answers about beats through the map, not its own line
                                       {{0.0, 4, 4}});
     const auto block = blockOnMap(map, 2.0 - (kBlockSize / kSampleRate));
 
-    const magda::engine::RunOrigin origin{block.beats.start, block.seconds.start};
+    const magda::engine::MaterialOrigin origin{block.beats.start, block.seconds.start};
     const magda::engine::BeatRange whole{block.beats.start, block.beats.end};
     const auto material = magda::engine::materialBlock(block, whole, origin);
 
     // The map comes with the block, and the shift it was moved by comes with
     // it too, which is what keeps the map answerable here.
     CHECK(material.tempo == &map);
-    CHECK(material.runOrigin == origin);
+    CHECK(material.materialOrigin == origin);
 
     // A cell boundary past the end of the block, which is where ClipVoice reads
     // (RenderContext.hpp): the grid is anchored to the event rather than to the
@@ -457,8 +457,8 @@ TEST_CASE("A run already under way is continuous with the block before it",
     const auto block = blockAt(40);
 
     // The run began four blocks ago, so this block is one beat into it.
-    const magda::engine::RunOrigin origin{block.beats.start - 1.0,
-                                          block.seconds.start - kSecondsPerBeat};
+    const magda::engine::MaterialOrigin origin{block.beats.start - 1.0,
+                                               block.seconds.start - kSecondsPerBeat};
     const magda::engine::BeatRange whole{block.beats.start, block.beats.end};
     const auto material = magda::engine::materialBlock(block, whole, origin);
 
@@ -1042,7 +1042,7 @@ TEST_CASE("A launched slot keeps its place across a locate", "[engine][clip][ses
     CHECK(rig.at(0) == Approx(kRunBlocks * kBlockSize));
 }
 
-TEST_CASE("Synced handles agree in beats and in seconds", "[engine][clip][session]") {
+TEST_CASE("Synced handles agree in beats and in samples", "[engine][clip][session]") {
     // What makes a scene one event rather than N. Beats alone would put a
     // scene's MIDI in the right bar and its audio somewhere else.
     LaunchHandle leader;
@@ -1059,15 +1059,16 @@ TEST_CASE("Synced handles agree in beats and in seconds", "[engine][clip][sessio
 
     REQUIRE(leader.playedMonotonicRange().has_value());
     REQUIRE(follower.playedMonotonicRange().has_value());
-    REQUIRE(leader.playedMonotonicSecondsRange().has_value());
-    REQUIRE(follower.playedMonotonicSecondsRange().has_value());
+    REQUIRE(leader.playedSampleRange().has_value());
+    REQUIRE(follower.playedSampleRange().has_value());
 
     CHECK(follower.playedMonotonicRange()->start == Approx(leader.playedMonotonicRange()->start));
     CHECK(follower.playedMonotonicRange()->end == Approx(leader.playedMonotonicRange()->end));
-    CHECK(follower.playedMonotonicSecondsRange()->start ==
-          Approx(leader.playedMonotonicSecondsRange()->start));
-    CHECK(follower.playedMonotonicSecondsRange()->end ==
-          Approx(leader.playedMonotonicSecondsRange()->end));
+
+    // The same sample, not the same second: two runs that began on one sample
+    // began together whatever the tempo does afterwards (#2336).
+    CHECK(follower.playedSampleRange()->start == leader.playedSampleRange()->start);
+    CHECK(follower.playedSampleRange()->end == leader.playedSampleRange()->end);
 
     // And the same origin to whatever renders them, on both axes.
     REQUIRE(follower.blockStatus().beforeEvent.origin.has_value());

--- a/tests/engine/test_transport_clock.cpp
+++ b/tests/engine/test_transport_clock.cpp
@@ -800,3 +800,36 @@ TEST_CASE("The monotonic seconds count rendered time, not converted beats",
         CHECK(whole.monotonicSeconds() == approx(pieces.monotonicSeconds()));
     }
 }
+
+TEST_CASE("A block is one tempo, which is what a rate-synced modifier reads",
+          "[engine][transport][clock][tempo][2336]") {
+    // Why the section cut stays now that placement goes through the map
+    // (#2333). A modifier synced to the tempo reads one bpm for the whole block
+    // it renders (ModLfo's modTimingFor), and so does anything else that takes
+    // a rate rather than a position: a block spanning a step would run at the
+    // tempo it opened on for the rest of itself.
+    TransportClock clock;
+    auto snapshot = playing(0.0);
+    snapshot.tempo = TempoMap({{0.0, 20.0, 0.0f}, {1.0, 300.0, 0.0f}}, {});
+
+    const auto rendered = advance(clock, snapshot, static_cast<int>(kSampleRate * 2));
+    requireCovers(rendered, static_cast<int>(kSampleRate * 2));
+
+    REQUIRE(rendered.segments.size() > 1);
+
+    for (const auto& segment : rendered.segments) {
+        const auto& block = segment.block;
+
+        // At the last sample as well as the first. The end beat itself is
+        // excluded and can sit a fraction of a sample past the boundary, since
+        // a cut lands on the first sample at or after it; what has to be one
+        // tempo is every sample the block actually renders.
+        const auto last =
+            snapshot.tempo.timeToBeat(block.seconds.start + ((block.numSamples - 1) / kSampleRate));
+
+        const auto opening = snapshot.tempo.bpmAt(block.beats.start);
+        const auto closing = snapshot.tempo.bpmAt(last);
+
+        CHECK(closing == approx(opening));
+    }
+}

--- a/tests/engine/test_transport_clock.cpp
+++ b/tests/engine/test_transport_clock.cpp
@@ -820,16 +820,71 @@ TEST_CASE("A block is one tempo, which is what a rate-synced modifier reads",
     for (const auto& segment : rendered.segments) {
         const auto& block = segment.block;
 
-        // At the last sample as well as the first. The end beat itself is
-        // excluded and can sit a fraction of a sample past the boundary, since
-        // a cut lands on the first sample at or after it; what has to be one
-        // tempo is every sample the block actually renders.
+        // Read where the consumer reads, which is the middle of the block. Not
+        // its start: a cut lands on the first sample at or after a boundary, so
+        // a block can open a fraction of a sample before one, and the beat at
+        // its start is then in the section it is leaving while every sample it
+        // renders is in the next.
+        const auto inside = block.beats.start + (0.5 * block.beats.length());
+
+        const auto first = snapshot.tempo.timeToBeat(block.seconds.start);
         const auto last =
             snapshot.tempo.timeToBeat(block.seconds.start + ((block.numSamples - 1) / kSampleRate));
 
-        const auto opening = snapshot.tempo.bpmAt(block.beats.start);
-        const auto closing = snapshot.tempo.bpmAt(last);
+        // Every sample the block renders is at the tempo that reading gives.
+        // The end beat is excluded and may sit past the boundary, which is why
+        // the far end is asked about by its last sample rather than by it.
+        const auto bpm = snapshot.tempo.bpmAt(inside);
 
-        CHECK(closing == approx(opening));
+        CHECK(snapshot.tempo.bpmAt(first) == approx(bpm));
+        CHECK(snapshot.tempo.bpmAt(last) == approx(bpm));
+    }
+}
+
+TEST_CASE("A boundary the epsilon swallows is still cut at",
+          "[engine][transport][clock][tempo][2336]") {
+    // The hole in the guarantee above, and it is the epsilon's. A boundary
+    // within a hundredth of a sample ahead of the cursor is zero samples away,
+    // and a zero cut is no cut: the segment then runs to whatever else ends it,
+    // through that boundary and every later one in the callback. What comes out
+    // is exactly the block the cut exists to prevent, on exactly the alignment
+    // nobody would think to try.
+    //
+    // Built by choosing a tempo that puts the first boundary a hundredth of a
+    // sample past a sample, so the cut at it leaves the cursor a hundredth of a
+    // sample short of it. Swept over several fractions, because which of them
+    // the arithmetic actually lands on is not the point.
+    for (const auto fraction : {0.001, 0.005, 0.009}) {
+        // 24000 samples to the first boundary, plus the fraction of one.
+        const auto bpm = 60.0 * kSampleRate / (24000.0 + fraction);
+
+        TransportClock clock;
+        auto snapshot = playing(0.0);
+
+        // Two steps: one at beat 1, one at beat 1.5. A step is two changes at
+        // the one beat, which is how it is written rather than a ramp to it.
+        snapshot.tempo = TempoMap({{0.0, bpm, 0.0f},
+                                   {1.0, bpm, 0.0f},
+                                   {1.0, 240.0, 0.0f},
+                                   {1.5, 240.0, 0.0f},
+                                   {1.5, 60.0, 0.0f}},
+                                  {});
+
+        // Past both boundaries, so a segment that missed the first has the
+        // second to run through.
+        const auto rendered = advance(clock, snapshot, 32768);
+        requireCovers(rendered, 32768);
+
+        for (const auto& segment : rendered.segments) {
+            const auto& block = segment.block;
+
+            const auto inside = block.beats.start + (0.5 * block.beats.length());
+            const auto last = snapshot.tempo.timeToBeat(block.seconds.start +
+                                                        ((block.numSamples - 1) / kSampleRate));
+
+            INFO("fraction " << fraction << " block " << block.beats.start << ".."
+                             << block.beats.end);
+            CHECK(snapshot.tempo.bpmAt(last) == approx(snapshot.tempo.bpmAt(inside)));
+        }
     }
 }

--- a/tests/engine/test_transport_clock.cpp
+++ b/tests/engine/test_transport_clock.cpp
@@ -4,6 +4,7 @@
 
 #include "transport/TransportClock.hpp"
 
+using magda::engine::SamplePosition;
 using magda::engine::TempoMap;
 using magda::engine::TransportClock;
 using magda::engine::TransportSnapshot;
@@ -14,6 +15,11 @@ constexpr double kSampleRate = 44100.0;
 
 /// 120 bpm: a beat is half a second, 22050 samples, and a bar is four of them.
 constexpr double kSamplesPerBeat = kSampleRate / 2.0;
+
+/// A position on the transport's count, which is what the clock answers in.
+SamplePosition at(std::int64_t sample) {
+    return SamplePosition{sample};
+}
 
 Catch::Approx approx(double value) {
     return Catch::Approx(value).margin(1e-9);
@@ -341,10 +347,14 @@ TEST_CASE("A steep ramp leaves every block affine to within a sample",
     // map puts at sample 256 of an uncut block lands at sample 93 on the
     // block's own line.
     //
-    // That line is what everything inside a block is placed on: where a launch
-    // lands, where a note goes, which instant a run began on. The invariant it
-    // needs is not a segment count but this: inside a block, the line and the
-    // map are the same answer to within the sample the block is allowed.
+    // That line is what a reader without a map has: the seconds face of a
+    // shifted block, the monotonic offset a launcher works in, the crop
+    // materialSubBlock takes. Placement itself goes through the map now
+    // (RenderContext::eventForBeat), so what is asserted here is the property
+    // the cut exists to provide rather than any consumer of it: inside a block,
+    // the line and the map are the same answer to within the sample the block
+    // is allowed. Whether anything still needs that is what decides whether the
+    // cut stays (#2333).
     TransportClock clock;
     auto snapshot = playing(0.0);
     snapshot.tempo = TempoMap({{0.0, 20.0, 0.0f}, {1.0, 300.0, 0.0f}}, {});
@@ -369,7 +379,11 @@ TEST_CASE("A steep ramp leaves every block affine to within a sample",
             const auto exact =
                 (snapshot.tempo.beatToTime(beat) - block.seconds.start) * kSampleRate;
 
-            CHECK(static_cast<double>(block.sampleForBeat(beat)) == approx(exact).margin(1.0));
+            // And where the block's own two ends put it, which is the line.
+            const auto online =
+                ((beat - block.beats.start) / block.beats.length()) * block.numSamples;
+
+            CHECK(online == approx(exact).margin(1.0));
         }
     }
 
@@ -397,18 +411,18 @@ TEST_CASE("Monotonic samples count what the transport rolled",
     TransportClock clock;
     const auto snapshot = playing(0.0);
 
-    CHECK(clock.monotonicSamples() == 0);
+    CHECK(clock.monotonicSamples() == at(0));
 
     const auto first = advance(clock, snapshot, 512);
-    CHECK(first.segments[0].block.monotonicSamples.start == 0);
-    CHECK(first.segments[0].block.monotonicSamples.end == 512);
-    CHECK(clock.monotonicSamples() == 512);
+    CHECK(first.segments[0].block.monotonicSamples.start == at(0));
+    CHECK(first.segments[0].block.monotonicSamples.end == at(512));
+    CHECK(clock.monotonicSamples() == at(512));
 
     // Picks up where the last block left off, so two blocks are adjacent on
     // this axis whatever the timeline did between them.
     const auto second = advance(clock, snapshot, 512);
-    CHECK(second.segments[0].block.monotonicSamples.start == 512);
-    CHECK(clock.monotonicSamples() == 1024);
+    CHECK(second.segments[0].block.monotonicSamples.start == at(512));
+    CHECK(clock.monotonicSamples() == at(1024));
 }
 
 TEST_CASE("A stopped transport rolls no samples", "[engine][transport][clock][samples]") {
@@ -417,13 +431,13 @@ TEST_CASE("A stopped transport rolls no samples", "[engine][transport][clock][sa
     TransportClock clock;
 
     advance(clock, playing(0.0), 512);
-    REQUIRE(clock.monotonicSamples() == 512);
+    REQUIRE(clock.monotonicSamples() == at(512));
 
     const auto rendered = advance(clock, halt(2), 512);
 
-    CHECK(rendered.segments[0].block.monotonicSamples.start == 512);
-    CHECK(rendered.segments[0].block.monotonicSamples.end == 512);
-    CHECK(clock.monotonicSamples() == 512);
+    CHECK(rendered.segments[0].block.monotonicSamples.start == at(512));
+    CHECK(rendered.segments[0].block.monotonicSamples.end == at(512));
+    CHECK(clock.monotonicSamples() == at(512));
 }
 
 TEST_CASE("Nothing that moves the cursor moves the sample count",
@@ -447,13 +461,13 @@ TEST_CASE("Nothing that moves the cursor moves the sample count",
         CHECK(wrapped.segments[i].block.monotonicSamples.start ==
               wrapped.segments[i - 1].block.monotonicSamples.end);
 
-    CHECK(clock.monotonicSamples() == kSamples);
+    CHECK(clock.monotonicSamples() == at(kSamples));
 
     // A locate backwards, which is where a beat-counting axis would go back.
     const auto located = advance(clock, playing(0.0, 2), 512);
 
-    CHECK(located.segments[0].block.monotonicSamples.start == kSamples);
-    CHECK(clock.monotonicSamples() == kSamples + 512);
+    CHECK(located.segments[0].block.monotonicSamples.start == at(kSamples));
+    CHECK(clock.monotonicSamples() == at(kSamples + 512));
 }
 
 TEST_CASE("A request is applied once", "[engine][transport][clock]") {

--- a/tests/midi/test_midi_clip_playback.cpp
+++ b/tests/midi/test_midi_clip_playback.cpp
@@ -1378,3 +1378,80 @@ TEST_CASE("Offs owed by a full block arrive in the next one", "[engine][clip][mi
 
     CHECK(recorder.hanging().empty());
 }
+
+TEST_CASE("A note inside a ramp is placed where the map puts it", "[engine][clip][midi][2336]") {
+    // The consumer half of #2336's placement rule, and the evidence for #2333.
+    // A ramp is baked into constant-tempo sections, and between two of them the
+    // slope changes as surely as it does at a step: over this one, a beat the
+    // map puts at sample 256 of a block lands at sample 93 on the line between
+    // the block's own two ends.
+    //
+    // The transport does not hand out a block that spans a boundary today,
+    // because it cuts at every one. This block is built by hand so the
+    // assertion holds whatever the clock decides about cutting: what places a
+    // note is the map, not the block's shape.
+    const TempoMap ramp({{0.0, 20.0, 0.0f}, {1.0, 300.0, 0.0f}}, {});
+
+    // Either side of the baked boundary at 0.75, which is where the slope
+    // changes: the map cuts a ramp four ways to the beat.
+    auto clip = makeMidiClip(1, 0.0, 8.0);
+    for (const auto beat : {0.6, 0.7, 0.8})
+        clip.midiNotes.push_back(note(60, beat, 0.02));
+
+    ClipSnapshotFeed feed;
+    const auto snapshot = std::make_shared<const ClipSnapshot>(
+        compileClipSnapshot({ClipLane{kTrack, {clip}}}, {}, ramp, {}));
+    feed.publish(snapshot);
+
+    // Long enough to hold all three notes and to cross that boundary, which is
+    // what makes the block's own line and the map two different answers.
+    const auto from = ramp.beatToTime(0.5);
+    const auto to = ramp.beatToTime(0.85);
+    const auto samples = static_cast<int>(std::lround((to - from) * kSampleRate));
+
+    ClipMidiSource source(kTrack, feed);
+    source.prepare(RenderContext{kSampleRate, samples, 2});
+
+    BlockInfo block;
+    block.numSamples = samples;
+    block.sampleRate = kSampleRate;
+    block.playing = true;
+    block.continuous = true;
+    block.seconds.start = from;
+    block.seconds.end = to;
+    block.beats.start = ramp.timeToBeat(block.seconds.start);
+    block.beats.end = ramp.timeToBeat(block.seconds.end);
+    block.monotonicBeats = block.beats;
+    block.monotonicSeconds = block.seconds;
+    block.tempo = &ramp;
+
+    juce::MidiBuffer buffer;
+    source.render(block, buffer);
+
+    Recorder recorder;
+    recorder.add(0, buffer);
+
+    const auto ons = recorder.noteOns();
+    REQUIRE(ons.size() == 3);
+
+    auto index = std::size_t{0};
+    auto worstOnTheLine = 0.0;
+
+    for (const auto beat : {0.6, 0.7, 0.8}) {
+        const auto exact = (ramp.beatToTime(beat) - block.seconds.start) * kSampleRate;
+
+        // Where the block's own two ends would have put it, which is what the
+        // conversion used to do and what the section cut exists to keep honest.
+        const auto onTheLine =
+            ((beat - block.beats.start) / block.beats.length()) * block.numSamples;
+
+        worstOnTheLine = std::max(worstOnTheLine, std::abs(onTheLine - exact));
+
+        CHECK(std::abs(static_cast<double>(ons[index].sample) - exact) <= 1.0);
+        ++index;
+    }
+
+    // And this is a block where the two answers differ, or the case above
+    // would pass on a block that could not tell them apart.
+    CHECK(worstOnTheLine > 1.0);
+}

--- a/tests/midi/test_midi_clip_playback.cpp
+++ b/tests/midi/test_midi_clip_playback.cpp
@@ -202,6 +202,9 @@ class Rig {
     static BlockInfo blockAt(int index, bool continuous) {
         BlockInfo block;
         block.numSamples = kBlockSize;
+        block.sampleRate = kSampleRate;
+        block.monotonicSamples = {magda::engine::SamplePosition{index * kBlockSize},
+                                  magda::engine::SamplePosition{(index + 1) * kBlockSize}};
         block.playing = true;
         block.continuous = continuous;
         block.beats.start = index * kBeatsPerBlock;
@@ -609,8 +612,10 @@ TEST_CASE("A note running past the loop end is cut there", "[engine][clip][midi]
     REQUIRE(offs.size() == 2);
 
     // On the pass boundary, nudged back one sample so it is not lost to the
-    // block that starts there. The fork does the same by hand; here the clamp in
-    // BlockInfo::sampleForBeat does it without being asked.
+    // block that starts there. The fork does the same by hand; here it is the
+    // edge rule: a note-off is where a note's stretch ends, and an edge that
+    // has to be heard sounds on the block's last sample rather than on the
+    // boundary past it (BlockInfo::soundsAt).
     CHECK(offs[0].beat() == Approx(2.0).margin(kBeatsPerBlock / kBlockSize + 1e-9));
     CHECK(recorder.hanging().empty());
 }


### PR DESCRIPTION
Closes #2336, and with it #2332, #2333 and #2337, which were folded into it. Stacked on #2318 because it rewrites the launcher and the clip sources that stack owns.

## The sample is what plays

Most of the engine was already sample-authoritative. The gap was the transport and session boundary, where beats were still a coordinate rather than musical intent, and #2331 had made every face of an instant derive from one sample without making that sample durable.

**Two things a sample offset inside a block can mean.** An event happens on one sample the block plays, `0` to `N-1`: a note-on, a click, the start of a parameter segment. An edge bounds a stretch the block covers, `0` to `N`: a fade, a region, a hole. The split used to fall along the axis by accident, since beats mostly placed events and seconds mostly placed bounds, so `sampleForBeat` clamped to `N-1` and `sampleForTime` allowed `N`.

A note-off is where the two come apart. It arrives as a beat, so it went through the beat conversion; it is where a note's stretch ends, so it is an edge; and it still has to be written into this buffer, so an edge at `N` has to become `N-1` or the note hangs. That rule was an unnamed clamp and a comment in one test. It is `BlockInfo::soundsAt` now, and `EventSample` and `EdgeSample` are what stop the next consumer getting it wrong: a caller that uses an event as a range end drops that event's sample, one that emits at an edge writes past the buffer, and both are compile errors.

**Events floor.** A block covers a half-open stretch, so a moment inside it is somewhere in `[0, N)` and the sample it is inside is `0..N-1`, always, with no case to clamp away. Nearest has one: a moment in the last half sample rounds to `N`, a buffer index this block does not have. The block that owns that sample is the next one, where the same moment is sample zero, so no event is emitted at `numSamples` and nothing has to be carried to get it there. Guarded by a hundredth of a sample, for the reason the clock guards its own ceiling: a beat asked for on a shifted block has had an origin taken off it and put back on, and `(a - o) + o` is not `a`.

Both conversions go through the map rather than along the block's own line. Blocks carry the rate they run at so nothing else is needed, and a block assembled from beats alone still places along its own line, which is every resolver fixture in the tree.

## A run begins on a sample

Three authorities collapse into one. `played_`, `playedMonotonic_` and `playedMonotonicSeconds_` were three ranges maintained in parallel, and #2331 had only made them agree at the instant of the launch. What a run keeps now is an origin, which is a sample, plus the one face a map cannot recover afterwards: the monotonic beat that sample fell on. A map converts a position, not an elapsed duration, and after a wrap the origin is not a position on this cycle at all. Everything else comes off the samples, and elapsed seconds is a subtraction of two counts rather than an accumulation of per-block seconds.

The type carrying a run between blocks was doing two jobs under one name. What the launcher keeps is where a run began, durably; what a block carries is what its axes were shifted by, per block and derived. Those are `RunOrigin`, private to the handle, and `MaterialOrigin`, which is what a source is handed.

`BlockInstant` keeps only its canonical identity: the sample it sounds on, and the same sample on the transport's count. Every face is derived from the block that knows the map, and the split is `upTo` and `from` rather than two range literals assembled by hand. That deletes what #2332 named: `applyEvent` used to build an instant and then overwrite three of its faces with another handle's origin. A synced launch adopts the whole run now, which is what it always meant.

## The drift

The wrap was already computed phase-exactly from the origin. The bug was that a retrigger re-anchored that origin to the snapped instant, so every interval restarted from a rounded beat. The fix is that the schedule and the sound are different questions: a wrap sounds on a sample, because that is the only thing that can sound, and the next wrap is counted from the beat the run was asked for, which no rounding has touched.

The regression is a thousand one-beat retriggers at 48 kHz and 123 bpm, where a beat is 23,414.634 samples. Every wrap lands within a sample of where the beat is. Re-anchoring instead, which is what this replaces, puts the thousandth 634 samples adrift and fails the case from about the second wrap on.

## A rate change has semantics

A run's origin is a count of samples and a rate change changes what a sample is worth, so holding the number would move the run through its material: a clip a second into its file would be half a second in, or two. The origin is re-counted behind the block at the new rate, keeping the time the run has actually had. That depends on the handle seeing every block, which is an invariant rather than a hope, and the comment says which one.

`BlockInfo::monotonicSeconds` stays, with its comment corrected. It is the one thing a sample count cannot answer, because a count spanning a rate change counts samples that were not all worth the same amount of time. What it no longer is, is how a run measures itself.

## The section cut stays, for a reason it did not have before

#2325 cut a segment at every tempo-section boundary because everything inside a block was placed on the line between its two ends. Placement goes through the map now, so that justification is gone and the question was whether anything else was paying for it.

Something is. `ModLfo::modTimingFor` takes a single bpm and signature for the whole block it renders, so a block spanning a step would run at the tempo it opened on for the rest of itself. That is asserted now rather than assumed: every sample a block renders is at one tempo, over a ramp cut four ways to the beat. The end beat is excluded and has to be, since a cut lands on the first sample at or after the boundary and can sit a fraction of a sample past it.

Two consumer cases decide the placement half, both on blocks built by hand so they hold whatever the clock does about cutting. A note inside a ramp lands where the map puts it, to the sample, on a block where the map and the line are 130 samples apart at the far end; the case asserts that divergence too, so it cannot pass on a block that could not tell the two answers apart. And the metronome follows a signature change inside one block, walking the map's own ticks rather than a grid worked out from the block's ends. #2333 flagged the metronome as the thing that might need one signature per block. It does not.

## One acceptance criterion answered differently from its wording

"Arrangement audio cannot render spans compiled against a different tempo map" is a count and a play here, not a refusal, following the finding on #2337 that a dropout mid-set is a worse failure than the bug it reports. #2338's commit rides at the front of this branch unchanged rather than being rebuilt, since its branch was deleted when it was closed. The atomic publish is still the real fix and is not here: `EngineSession::publishClips` is called only from tests, so there is no production publisher to make atomic yet.

## Testing

Full Catch2 suite green locally: 3396 passed, 13 skipped for plugins absent from this machine, 0 failures. The JUCE suite passes, including the real project corpus through both engines, and the app builds.

The two new cases were each verified to fail without their fix: the retrigger case against a re-anchored schedule, and the note-off edge rule against the test that already named the old clamp.

https://claude.ai/code/session_013CDpSHas8bog33vv4o6HLv
