### PR TITLE
Modifiers read the bars the block covers, and the section cut goes (#2340)

### DIFF
--- a/magda/daw/audio/plugins/engine/EngineExternalDevice.cpp
+++ b/magda/daw/audio/plugins/engine/EngineExternalDevice.cpp
@@ -76,19 +76,24 @@ class EngineExternalDevice::PlayHead final : public juce::AudioPlayHead {
             return;
         }
 
-        // The tempo and the bar grid of the section the block renders in, not
-        // of its first beat: a block can open a fraction of a sample before a
-        // boundary it is otherwise entirely past (BlockInfo::sectionBeat). The
-        // plugin is told one bpm and one signature for the whole call, so
-        // taking them from the old section would run the call on the wrong one.
+        // The tempo and the bar grid the block's first sample sounds under, not
+        // the ones its first beat sits in: a block can open a hundredth of a
+        // sample before a boundary it is otherwise entirely past
+        // (BlockInfo::openingBeat), and taking them from there would run the
+        // call on the section it had already left.
+        //
+        // One bpm and one signature for the whole call is all this interface
+        // has to give, so a block spanning a tempo change reports what its
+        // first sample is in for all of it. That is what every host does and
+        // what plugins are built to tolerate (#2340).
         //
         // Where the block is stays its own: the time and the PPQ position above
         // are its first sample's, which is what the plugin is being handed.
-        const auto inside = block.sectionBeat();
+        const auto opening = block.openingBeat();
 
-        bpm_.store(block.tempo->bpmAt(inside), std::memory_order_relaxed);
+        bpm_.store(block.tempo->bpmAt(opening), std::memory_order_relaxed);
 
-        const auto position = block.tempo->barsAndBeatsAt(inside);
+        const auto position = block.tempo->barsAndBeatsAt(opening);
         numerator_.store(position.numerator, std::memory_order_relaxed);
         denominator_.store(position.denominator, std::memory_order_relaxed);
 
@@ -97,28 +102,17 @@ class EngineExternalDevice::PlayHead final : public juce::AudioPlayHead {
         // denominator is not four: three eighths into a 6/8 bar is one and a
         // half quarter notes, not three.
         const auto quartersPerBeat = 4.0 / std::max(1, position.denominator);
-        const auto barBeats = std::max(position.numerator * quartersPerBeat, 1.0e-6);
 
         // The bar the block's first sample is in, under the signature it
-        // renders in. Not the bar its midpoint is in: a block is cut at every
-        // tempo section but not at every bar line, so a long one can straddle
-        // one, and taking the midpoint's bar would make what the plugin is told
-        // depend on how the host happened to size the callback.
+        // renders in. Not the bar its middle is in: a block is not cut at bar
+        // lines, so a long one straddles one, and taking the middle's bar would
+        // make what the plugin is told depend on how the host happened to size
+        // the callback.
         //
-        // Which is a sample's question, not a beat's, so it is answered to a
-        // hundredth of one: a block that opens before the bar line by less than
-        // that is the swallowed boundary above, and is in the bar it is about to
-        // render, not in the one before it.
-        const auto perSample = block.numSamples > 0
-                                   ? block.beats.length() / static_cast<double>(block.numSamples)
-                                   : 0.0;
-        const auto tolerance = magda::engine::kSampleEpsilon * perSample;
-
-        auto intoBar = block.beats.start - (inside - (position.beat * quartersPerBeat));
-        while (intoBar < -tolerance)
-            intoBar += barBeats;
-
-        ppqOfBarStart_.store(block.beats.start - intoBar, std::memory_order_relaxed);
+        // Straight back from where the grid was read, because the opening beat
+        // already carries the tolerance a sample's question is answered to.
+        ppqOfBarStart_.store(opening - (position.beat * quartersPerBeat),
+                             std::memory_order_relaxed);
     }
 
     juce::Optional<PositionInfo> getPosition() const override {

--- a/magda/engine/exec/RenderContext.hpp
+++ b/magda/engine/exec/RenderContext.hpp
@@ -187,26 +187,31 @@ struct BlockInfo {
     }
 
     /**
-     * @brief Which beat to ask the map about this block's own tempo, signature
-     * or bar.
+     * @brief The beat sample zero sounds on, to the tolerance the clock uses.
      *
-     * Not the block's start, which is where anything reading one of those would
-     * naturally look. A block covers one tempo section, because the transport
-     * cuts a callback at every boundary (TransportClock.cpp), but a cut lands
-     * on the first sample at or after the boundary, so the block can begin a
-     * fraction of a sample before it. The beat at its start is then in the
-     * section it is leaving while every sample it renders is in the next, and a
-     * consumer that takes one rate for the whole block takes the wrong one: an
-     * LFO runs the block at the tempo it just left, a hosted plugin is told the
-     * old signature for the whole call.
+     * Not quite the block's start, which is where anything asking the map about
+     * this block's tempo, signature or bar would naturally look. A musical
+     * position within a hundredth of a sample of the cursor is the cursor as
+     * far as the clock is concerned (TransportClock::samplesUntil), so a block
+     * can open that close before a boundary while every sample it renders is
+     * past it. The beat at its start is then in the section it has already
+     * left, and a consumer that takes one signature or one bar for the whole
+     * block takes the wrong one.
      *
-     * The middle is inside the section on every alignment. This answers "which
-     * section is this block in" and nothing else; where the block *is* stays
-     * @ref beats and @ref seconds, and a position derived under this section is
-     * projected back to them by the caller (#2336).
+     * So this is the start nudged forward by that same hundredth of a sample,
+     * in beats at the block's own rate: a block opening that close before a
+     * boundary reads the section on the far side of it, and every other block
+     * reads the section its start is in.
+     *
+     * Where the block *is* stays @ref beats and @ref seconds. This only says
+     * which side of a boundary its first sample is on, and a position derived
+     * under that section is projected back by the caller (#2336).
      */
-    double sectionBeat() const {
-        return beats.start + (0.5 * beats.length());
+    double openingBeat() const {
+        if (numSamples <= 0 || beats.empty())
+            return beats.start;
+
+        return beats.start + (kSampleEpsilon * (beats.length() / numSamples));
     }
 
     /**

--- a/magda/engine/exec/RenderContext.hpp
+++ b/magda/engine/exec/RenderContext.hpp
@@ -198,10 +198,15 @@ struct BlockInfo {
      * left, and a consumer that takes one signature or one bar for the whole
      * block takes the wrong one.
      *
-     * So this is the start nudged forward by that same hundredth of a sample,
-     * in beats at the block's own rate: a block opening that close before a
-     * boundary reads the section on the far side of it, and every other block
-     * reads the section its start is in.
+     * So this is the start nudged forward by that same hundredth of a sample of
+     * seconds, converted to a beat at the tempo the block opens on rather than
+     * at the block's own average slope: through the map, the way @ref
+     * beatAtTime reads any other moment, which is what matters once a block may
+     * span a tempo change. The block-average slope would over-nudge across a
+     * step up and under-nudge across a step down, either of which can land the
+     * nudge on the wrong side of the very boundary it exists to cross (#2340).
+     * A block with no seconds face at all is one assembled by hand from beats,
+     * and the average slope is the only line there is to nudge along.
      *
      * Where the block *is* stays @ref beats and @ref seconds. This only says
      * which side of a boundary its first sample is on, and a position derived
@@ -211,7 +216,10 @@ struct BlockInfo {
         if (numSamples <= 0 || beats.empty())
             return beats.start;
 
-        return beats.start + (kSampleEpsilon * (beats.length() / numSamples));
+        if (seconds.empty() || rate() <= 0.0)
+            return beats.start + (kSampleEpsilon * (beats.length() / numSamples));
+
+        return beatAtTime(seconds.start + (kSampleEpsilon / rate()));
     }
 
     /**

--- a/magda/engine/param/ModAdsr.cpp
+++ b/magda/engine/param/ModAdsr.cpp
@@ -100,33 +100,74 @@ void enterStage(AdsrState& state, AdsrStage stage, float startValue) {
     state.stageStartValue = startValue;
 }
 
+/// Whether an envelope's stages are a musical length rather than a duration. A
+/// division of Hertz is not a division, and falls back to the milliseconds,
+/// which is the fork's rule (adsrStageSeconds says so).
+bool runsInBeats(const AdsrSettings& settings) {
+    return settings.tempoSync && settings.rateType != static_cast<int>(magda::ModRateType::Hertz);
+}
+
 /**
- * @brief Run the stage machine forward by @p seconds.
+ * @brief The three timed stages of one envelope, and the floor below which a
+ *        stage is instant.
+ *
+ * All four in one unit: seconds for an envelope whose stages are milliseconds,
+ * beats for one whose stages are a division. The machine below only compares an
+ * elapsed amount against a length and divides one by the other, so it does not
+ * care which, and running a synced envelope in beats is what lets the block say
+ * how far it moved rather than a bpm (#2340).
+ */
+struct StageLengths {
+    double attack = 0.0;
+    double decay = 0.0;
+    double release = 0.0;
+    double instant = 0.0;
+};
+
+StageLengths stageLengthsFor(const AdsrSettings& settings, const ModTiming& timing) {
+    if (runsInBeats(settings)) {
+        // One division for all three stages, which is what the model carries.
+        const auto beats = cycleBeats(settings.rateType, timing.numerator, timing.denominator);
+
+        // The same instant the seconds floor stands for, converted once at the
+        // tempo the block opens on: what counts as no time at all is a duration
+        // rather than a musical length, and a hundredth of a millisecond is far
+        // below any division a project can name.
+        return {beats, beats, beats, kMinStageSeconds * timing.bpm / 60.0};
+    }
+
+    return {adsrStageSeconds(settings.attackMs, settings, timing),
+            adsrStageSeconds(settings.decayMs, settings, timing),
+            adsrStageSeconds(settings.releaseMs, settings, timing), kMinStageSeconds};
+}
+
+/**
+ * @brief Run the stage machine forward by @p elapsed.
  *
  * The fork's own loop. A stage that ends inside the block hands what is left of
  * it to the next one, so a block longer than the attack arrives somewhere in
  * the decay rather than being clamped at the top of it.
+ *
+ * @p elapsed and @p lengths are in the same unit and the machine never asks
+ * which (@ref StageLengths).
  */
-void advanceStages(AdsrState& state, const AdsrSettings& settings, const ModTiming& timing,
-                   double seconds, bool freeRunning, bool gateOpen) {
-    const double attackSeconds = adsrStageSeconds(settings.attackMs, settings, timing);
-    const double decaySeconds = adsrStageSeconds(settings.decayMs, settings, timing);
-    const double releaseSeconds = adsrStageSeconds(settings.releaseMs, settings, timing);
+void advanceStages(AdsrState& state, const AdsrSettings& settings, const StageLengths& lengths,
+                   double elapsed, bool freeRunning, bool gateOpen) {
     const float sustain = std::clamp(settings.sustain, 0.0f, 1.0f);
 
     /// One timed stage: what it travels from, what it arrives at, how long it
     /// takes, how it is bent, and where it goes when it is through.
     const auto run = [&](double length, float destination, float curve, AdsrStage next) {
-        if (length <= kMinStageSeconds) {
+        if (length <= lengths.instant) {
             state.value = destination;
             enterStage(state, next, destination);
             return true;
         }
 
-        state.timeInStage += seconds;
+        state.timeInStage += elapsed;
 
         if (state.timeInStage >= length) {
-            seconds = state.timeInStage - length;
+            elapsed = state.timeInStage - length;
             state.value = destination;
             enterStage(state, next, destination);
             return true;
@@ -152,12 +193,12 @@ void advanceStages(AdsrState& state, const AdsrSettings& settings, const ModTimi
                 return;
 
             case AdsrStage::Attack:
-                if (run(attackSeconds, 1.0f, settings.attackCurve, AdsrStage::Decay))
+                if (run(lengths.attack, 1.0f, settings.attackCurve, AdsrStage::Decay))
                     continue;
                 return;
 
             case AdsrStage::Decay:
-                if (run(decaySeconds, sustain, settings.decayCurve, AdsrStage::Sustain))
+                if (run(lengths.decay, sustain, settings.decayCurve, AdsrStage::Sustain))
                     continue;
                 return;
 
@@ -176,7 +217,7 @@ void advanceStages(AdsrState& state, const AdsrSettings& settings, const ModTimi
                 return;
 
             case AdsrStage::Release:
-                if (run(releaseSeconds, 0.0f, settings.releaseCurve, AdsrStage::Idle))
+                if (run(lengths.release, 0.0f, settings.releaseCurve, AdsrStage::Idle))
                     continue;
                 return;
         }
@@ -189,7 +230,7 @@ double adsrStageSeconds(float milliseconds, const AdsrSettings& settings, const 
     // A division of Hertz is not a division. The model reaches that state by
     // having tempo sync on with nothing musical selected, and the fork's answer
     // is to fall back to the milliseconds rather than to invent a period.
-    if (settings.tempoSync && settings.rateType != static_cast<int>(magda::ModRateType::Hertz)) {
+    if (runsInBeats(settings)) {
         const auto beats = cycleBeats(settings.rateType, timing.numerator, timing.denominator);
         return beats * 60.0 / std::max(timing.bpm, 1.0e-6);
     }
@@ -265,10 +306,18 @@ float advanceAdsr(AdsrState& state, const AdsrSettings& settings, const BlockInf
 
     state.lastGate = gateOpen;
 
-    const double blockSeconds =
-        static_cast<double>(std::max(block.numSamples, 0)) / std::max(timing.sampleRate, 1.0);
+    const auto lengths = stageLengthsFor(settings, timing);
 
-    advanceStages(state, settings, timing, blockSeconds, freeRunning, gateOpen);
+    // A synced envelope's stages are a number of beats, so the block moves it on
+    // by the beats it covered, which the map answered for exactly this stretch.
+    // A millisecond envelope is a duration and moves on by how long the block
+    // lasted (#2340).
+    const double elapsed =
+        runsInBeats(settings)
+            ? modBeatsElapsed(block, timing)
+            : static_cast<double>(std::max(block.numSamples, 0)) / std::max(timing.sampleRate, 1.0);
+
+    advanceStages(state, settings, lengths, elapsed, freeRunning, gateOpen);
 
     // Advanced first and published after, which is the fork's ADSR timer and
     // the opposite of its LFO timer: the value a block renders with is where

--- a/magda/engine/param/ModAdsr.cpp
+++ b/magda/engine/param/ModAdsr.cpp
@@ -103,7 +103,7 @@ void enterStage(AdsrState& state, AdsrStage stage, float startValue) {
 /// Whether an envelope's stages are a musical length rather than a duration. A
 /// division of Hertz is not a division, and falls back to the milliseconds,
 /// which is the fork's rule (adsrStageSeconds says so).
-bool runsInBeats(const AdsrSettings& settings) {
+bool runsInBars(const AdsrSettings& settings) {
     return settings.tempoSync && settings.rateType != static_cast<int>(magda::ModRateType::Hertz);
 }
 
@@ -112,10 +112,11 @@ bool runsInBeats(const AdsrSettings& settings) {
  *        stage is instant.
  *
  * All four in one unit: seconds for an envelope whose stages are milliseconds,
- * beats for one whose stages are a division. The machine below only compares an
+ * bars for one whose stages are a division. The machine below only compares an
  * elapsed amount against a length and divides one by the other, so it does not
- * care which, and running a synced envelope in beats is what lets the block say
- * how far it moved rather than a bpm (#2340).
+ * care which, and running a synced envelope in bars is what lets the block say
+ * how many it moved through rather than a bpm and a signature read once
+ * (#2340).
  */
 struct StageLengths {
     double attack = 0.0;
@@ -125,15 +126,20 @@ struct StageLengths {
 };
 
 StageLengths stageLengthsFor(const AdsrSettings& settings, const ModTiming& timing) {
-    if (runsInBeats(settings)) {
-        // One division for all three stages, which is what the model carries.
-        const auto beats = cycleBeats(settings.rateType, timing.numerator, timing.denominator);
+    if (runsInBars(settings)) {
+        // One division for all three stages, which is what the model carries,
+        // and a division is a number of bars whatever the signature is doing:
+        // no signature to ask, unlike the seconds this same division is worth
+        // (adsrStageSeconds).
+        const auto bars = barFractionOf(settings.rateType);
 
         // The same instant the seconds floor stands for, converted once at the
-        // tempo the block opens on: what counts as no time at all is a duration
-        // rather than a musical length, and a hundredth of a millisecond is far
-        // below any division a project can name.
-        return {beats, beats, beats, kMinStageSeconds * timing.bpm / 60.0};
+        // tempo and signature the block opens on: what counts as no time at all
+        // is a duration rather than a musical length, and a hundredth of a
+        // millisecond is far below any division a project can name.
+        return {bars, bars, bars,
+                kMinStageSeconds * timing.bpm / 60.0 /
+                    std::max(barBeatsOf(timing.numerator, timing.denominator), 1.0e-6)};
     }
 
     return {adsrStageSeconds(settings.attackMs, settings, timing),
@@ -230,7 +236,7 @@ double adsrStageSeconds(float milliseconds, const AdsrSettings& settings, const 
     // A division of Hertz is not a division. The model reaches that state by
     // having tempo sync on with nothing musical selected, and the fork's answer
     // is to fall back to the milliseconds rather than to invent a period.
-    if (runsInBeats(settings)) {
+    if (runsInBars(settings)) {
         const auto beats = cycleBeats(settings.rateType, timing.numerator, timing.denominator);
         return beats * 60.0 / std::max(timing.bpm, 1.0e-6);
     }
@@ -308,13 +314,40 @@ float advanceAdsr(AdsrState& state, const AdsrSettings& settings, const BlockInf
 
     const auto lengths = stageLengthsFor(settings, timing);
 
-    // A synced envelope's stages are a number of beats, so the block moves it on
-    // by the beats it covered, which the map answered for exactly this stretch.
+    // A tempo-sync toggle mid-stage changes what unit timeInStage is counted
+    // in without emptying it, and reinterpreting a duration as a bar count (or
+    // the reverse) would snap the envelope to wherever that number happens to
+    // land in the new unit rather than leaving it where it was. Converted
+    // instead, from the phase the old unit had already worked out: the current
+    // stage's length in the new unit times how far through it the envelope is
+    // puts the accumulator back at the same point (#2340).
+    if (runsInBars(settings) != state.stageInBars) {
+        const auto currentLength = [&]() {
+            switch (state.stage) {
+                case AdsrStage::Attack:
+                    return lengths.attack;
+                case AdsrStage::Decay:
+                    return lengths.decay;
+                case AdsrStage::Release:
+                    return lengths.release;
+                case AdsrStage::Idle:
+                case AdsrStage::Sustain:
+                    return 0.0;
+            }
+            return 0.0;
+        }();
+
+        state.timeInStage = static_cast<double>(state.stagePhase) * currentLength;
+        state.stageInBars = runsInBars(settings);
+    }
+
+    // A synced envelope's stages are a number of bars, so the block moves it on
+    // by the bars it covered, which the map answered for exactly this stretch.
     // A millisecond envelope is a duration and moves on by how long the block
     // lasted (#2340).
     const double elapsed =
-        runsInBeats(settings)
-            ? modBeatsElapsed(block, timing)
+        runsInBars(settings)
+            ? modBarsElapsed(block, timing)
             : static_cast<double>(std::max(block.numSamples, 0)) / std::max(timing.sampleRate, 1.0);
 
     advanceStages(state, settings, lengths, elapsed, freeRunning, gateOpen);

--- a/magda/engine/param/ModAdsr.hpp
+++ b/magda/engine/param/ModAdsr.hpp
@@ -90,7 +90,8 @@ struct AdsrSettings {
     magda::LFOTriggerMode trigger = magda::LFOTriggerMode::Free;
 
     /// Whether the stage lengths are musical divisions rather than
-    /// milliseconds.
+    /// milliseconds. Which unit the envelope runs in, not only how its lengths
+    /// are worked out: a synced one advances by the beats a block covered.
     bool tempoSync = false;
 
     /**
@@ -116,7 +117,9 @@ struct AdsrSettings {
 struct AdsrState {
     AdsrStage stage = AdsrStage::Idle;
 
-    /// How long the current stage has been running, in seconds.
+    /// How far the current stage has run, in whatever its length is counted in:
+    /// seconds for an envelope whose stages are milliseconds, beats for one
+    /// whose stages are a musical division (#2340).
     double timeInStage = 0.0;
 
     /// The level the stage started from, so a gate change is click-free from
@@ -161,6 +164,12 @@ struct AdsrState {
  * The milliseconds the model stores, or the musical division they are replaced
  * by when the envelope is tempo synced. A division of Hertz is not a division,
  * and falls back to the milliseconds, which is the fork's own rule.
+ *
+ * What a synced envelope actually runs on is that division in beats, because
+ * the block says how many beats it covered and a bpm read once per block does
+ * not survive a tempo change inside it (#2340). This is the same length said in
+ * seconds, which is what the millisecond path needs and what a reader asking
+ * how long a stage is wants to hear.
  */
 double adsrStageSeconds(float milliseconds, const AdsrSettings& settings, const ModTiming& timing);
 

--- a/magda/engine/param/ModAdsr.hpp
+++ b/magda/engine/param/ModAdsr.hpp
@@ -91,7 +91,7 @@ struct AdsrSettings {
 
     /// Whether the stage lengths are musical divisions rather than
     /// milliseconds. Which unit the envelope runs in, not only how its lengths
-    /// are worked out: a synced one advances by the beats a block covered.
+    /// are worked out: a synced one advances by the bars a block covered.
     bool tempoSync = false;
 
     /**
@@ -118,9 +118,17 @@ struct AdsrState {
     AdsrStage stage = AdsrStage::Idle;
 
     /// How far the current stage has run, in whatever its length is counted in:
-    /// seconds for an envelope whose stages are milliseconds, beats for one
+    /// seconds for an envelope whose stages are milliseconds, bars for one
     /// whose stages are a musical division (#2340).
     double timeInStage = 0.0;
+
+    /// The unit @ref timeInStage is counted in: true for bars, false for
+    /// seconds. Compared against runsInBars(settings) on every block rather
+    /// than trusted, because a tempo-sync toggle mid-stage does not empty the
+    /// accumulator, and reinterpreting seconds as bars (or the reverse) without
+    /// converting would snap the envelope to a different point in the stage
+    /// than the one it was actually at (#2340).
+    bool stageInBars = false;
 
     /// The level the stage started from, so a gate change is click-free from
     /// wherever the envelope happened to be rather than from the top.
@@ -165,11 +173,11 @@ struct AdsrState {
  * by when the envelope is tempo synced. A division of Hertz is not a division,
  * and falls back to the milliseconds, which is the fork's own rule.
  *
- * What a synced envelope actually runs on is that division in beats, because
- * the block says how many beats it covered and a bpm read once per block does
- * not survive a tempo change inside it (#2340). This is the same length said in
- * seconds, which is what the millisecond path needs and what a reader asking
- * how long a stage is wants to hear.
+ * What a synced envelope actually runs on is that division in bars, because
+ * the block says how many bars it covered and a bpm and signature read once
+ * per block do not survive a tempo or signature change inside it (#2340). This
+ * is the same length said in seconds, which is what the millisecond path needs
+ * and what a reader asking how long a stage is wants to hear.
  */
 double adsrStageSeconds(float milliseconds, const AdsrSettings& settings, const ModTiming& timing);
 

--- a/magda/engine/param/ModLfo.cpp
+++ b/magda/engine/param/ModLfo.cpp
@@ -119,23 +119,39 @@ float laneValueFromRateType(int rateType) {
         std::max(rateType, static_cast<int>(magda::ModRateType::SixteenBars)) - 1);
 }
 
+double modBeatsElapsed(const BlockInfo& block, const ModTiming& timing) {
+    // The map's own answer for this stretch, which is what the clock derived
+    // the block's beat ends from. Right across a tempo change inside the block,
+    // where seconds times one bpm is not.
+    if (block.playing && !block.beats.empty())
+        return block.beats.length();
+
+    // A stopped block covers no beats and still has to turn a free-running
+    // modifier, so it keeps its own time at the tempo the cursor sits on. One
+    // beat, one bpm, and no conversion to be wrong about.
+    const auto seconds =
+        static_cast<double>(std::max(block.numSamples, 0)) / std::max(timing.sampleRate, 1.0);
+    return seconds * timing.bpm / 60.0;
+}
+
 double modBarPosition(const BlockInfo& block, const ModTiming& timing) {
     if (block.tempo != nullptr) {
-        // The bar grid the block renders in, which is the section's rather than
-        // the one its first beat happens to sit in (BlockInfo::sectionBeat).
-        // A signature the epsilon swallowed would otherwise run this whole
-        // block at the old bar fraction instead of restarting on the new bar:
-        // four four to three four at the boundary is a bar-rate LFO a quarter
-        // of a cycle out for the length of the block.
-        const auto inside = block.sectionBeat();
-        const auto grid = block.tempo->barsAndBeatsAt(inside);
+        // The bar grid the block renders in, which is the one its first sample
+        // sounds under rather than the one its first beat happens to sit in
+        // (BlockInfo::openingBeat). A signature the epsilon swallowed would
+        // otherwise run this whole block at the old bar fraction instead of
+        // restarting on the new bar: four four to three four at the boundary is
+        // a bar-rate LFO a quarter of a cycle out for the length of the block.
+        const auto opening = block.openingBeat();
+        const auto grid = block.tempo->barsAndBeatsAt(opening);
         const auto barBeats = 4.0 * grid.numerator / std::max(1, grid.denominator);
 
-        // Back to the block's own first sample, under that grid. The phase is
-        // the value the block opens on, and the section is only what says how
-        // long a bar is there.
-        const auto atSectionBeat = grid.bar + (grid.beat / std::max(grid.numerator, 1));
-        return atSectionBeat - ((inside - block.beats.start) / std::max(barBeats, 1.0e-6));
+        // Back to the block's own first sample, under that grid. A hundredth of
+        // a sample at most, since that is all the opening beat is nudged by,
+        // but the phase is the value the block opens on and the grid is only
+        // what says how long a bar is there.
+        const auto atOpeningBeat = grid.bar + (grid.beat / std::max(grid.numerator, 1));
+        return atOpeningBeat - ((opening - block.beats.start) / std::max(barBeats, 1.0e-6));
     }
 
     const auto barBeats = 4.0 * timing.numerator / timing.denominator;
@@ -150,12 +166,17 @@ ModTiming modTimingFor(const BlockInfo& block, double sampleRate) {
     // what it gets is what a session that has never seen a transport renders
     // at: 120 in four four, which is the same default TransportState holds.
     //
-    // Asked about the section the block renders in rather than about its first
-    // beat, which is not reliably in it (BlockInfo::sectionBeat).
+    // Asked at the beat the block's first sample sounds on rather than at its
+    // first beat, which is not reliably in the same section
+    // (BlockInfo::openingBeat).
+    //
+    // The bpm here is what a stopped block keeps time at. A rolling one reads
+    // the beats it covers instead (modBeatsElapsed), so a block spanning a
+    // tempo change is not this reading's problem.
     if (block.tempo != nullptr) {
-        const auto inside = block.sectionBeat();
-        const auto signature = block.tempo->barsAndBeatsAt(inside);
-        timing.bpm = block.tempo->bpmAt(inside);
+        const auto opening = block.openingBeat();
+        const auto signature = block.tempo->barsAndBeatsAt(opening);
+        timing.bpm = block.tempo->bpmAt(opening);
         timing.numerator = signature.numerator;
         timing.denominator = signature.denominator;
     }
@@ -277,12 +298,16 @@ float advanceLfo(LfoState& state, const LfoSettings& settings,
     // which is the order the fork's timer uses: the value a block renders with
     // is the value at its first sample.
     if (settings.sync != ModSync::Transport && !holding && !zeroed) {
-        const double blockSeconds =
-            static_cast<double>(std::max(block.numSamples, 0)) / timing.sampleRate;
-        const double periodSeconds =
-            settings.tempoSync ? beatsPerCycle * 60.0 / timing.bpm : 1.0 / hz;
-
-        state.cycles += blockSeconds / std::max(periodSeconds, 1.0e-9);
+        if (settings.tempoSync) {
+            // The beats the block covered over the beats a cycle lasts. Off the
+            // block rather than through a bpm, so a block spanning a tempo
+            // change advances by what the map says it covered (#2340).
+            state.cycles += modBeatsElapsed(block, timing) / beatsPerCycle;
+        } else {
+            const double blockSeconds = static_cast<double>(std::max(block.numSamples, 0)) /
+                                        std::max(timing.sampleRate, 1.0);
+            state.cycles += blockSeconds * hz;
+        }
     }
 
     // Kept bounded, so an LFO left running for hours is as precise as one that

--- a/magda/engine/param/ModLfo.cpp
+++ b/magda/engine/param/ModLfo.cpp
@@ -100,12 +100,15 @@ double barFractionOf(int rateType) {
     return 1.0;
 }
 
-double cycleBeats(int rateType, int numerator, int denominator) {
+double barBeatsOf(int numerator, int denominator) {
     // A bar in quarter notes, which is what a beat is here. The signature's
     // own note value is the denominator's, so six eight is three quarter notes
     // rather than six.
-    const auto barBeats = 4.0 * std::max(numerator, 1) / std::max(denominator, 1);
-    return barFractionOf(rateType) * barBeats;
+    return 4.0 * std::max(numerator, 1) / std::max(denominator, 1);
+}
+
+double cycleBeats(int rateType, int numerator, int denominator) {
+    return barFractionOf(rateType) * barBeatsOf(numerator, denominator);
 }
 
 int rateTypeFromLaneValue(float laneValue) {
@@ -119,19 +122,45 @@ float laneValueFromRateType(int rateType) {
         std::max(rateType, static_cast<int>(magda::ModRateType::SixteenBars)) - 1);
 }
 
-double modBeatsElapsed(const BlockInfo& block, const ModTiming& timing) {
-    // The map's own answer for this stretch, which is what the clock derived
-    // the block's beat ends from. Right across a tempo change inside the block,
-    // where seconds times one bpm is not.
-    if (block.playing && !block.beats.empty())
-        return block.beats.length();
-
+double modBarsElapsed(const BlockInfo& block, const ModTiming& timing) {
     // A stopped block covers no beats and still has to turn a free-running
-    // modifier, so it keeps its own time at the tempo the cursor sits on. One
-    // beat, one bpm, and no conversion to be wrong about.
-    const auto seconds =
-        static_cast<double>(std::max(block.numSamples, 0)) / std::max(timing.sampleRate, 1.0);
-    return seconds * timing.bpm / 60.0;
+    // modifier, so it keeps its own time at the tempo and signature the cursor
+    // sits on. One beat, one bpm, one bar length, and no conversion to be wrong
+    // about.
+    if (!(block.playing && !block.beats.empty())) {
+        const auto seconds =
+            static_cast<double>(std::max(block.numSamples, 0)) / std::max(timing.sampleRate, 1.0);
+        return seconds * timing.bpm / 60.0 /
+               std::max(barBeatsOf(timing.numerator, timing.denominator), 1.0e-6);
+    }
+
+    // A block assembled by hand carries no map, so its own beat length under
+    // the one signature it was given is the only line there is.
+    if (block.tempo == nullptr)
+        return block.beats.length() /
+               std::max(barBeatsOf(timing.numerator, timing.denominator), 1.0e-6);
+
+    // Through the origin in both directions on a shifted block, which is what
+    // keeps the map usable there (BlockInfo::beatAtTime says the same about a
+    // moment).
+    const auto from = block.beats.start + block.materialOrigin.beat;
+    const auto to = block.beats.end + block.materialOrigin.beat;
+
+    // A bar is a different number of beats on each side of a signature change,
+    // so a block that spans one covers a fraction of each: the map knows where
+    // the change is, so the block's bars are the sum over the spans it runs
+    // through (#2340).
+    double bars = 0.0;
+    double at = from;
+    for (int guard = 0; guard < 64 && at < to; ++guard) {
+        const auto grid = block.tempo->barsAndBeatsAt(at);
+        const auto end = std::min(to, block.tempo->signatureEndAfter(at));
+        if (!(end > at))
+            break;
+        bars += (end - at) / std::max(barBeatsOf(grid.numerator, grid.denominator), 1.0e-6);
+        at = end;
+    }
+    return bars;
 }
 
 double modBarPosition(const BlockInfo& block, const ModTiming& timing) {
@@ -171,8 +200,8 @@ ModTiming modTimingFor(const BlockInfo& block, double sampleRate) {
     // (BlockInfo::openingBeat).
     //
     // The bpm here is what a stopped block keeps time at. A rolling one reads
-    // the beats it covers instead (modBeatsElapsed), so a block spanning a
-    // tempo change is not this reading's problem.
+    // the bars it covers instead (modBarsElapsed), so a block spanning a tempo
+    // or signature change is not this reading's problem.
     if (block.tempo != nullptr) {
         const auto opening = block.openingBeat();
         const auto signature = block.tempo->barsAndBeatsAt(opening);
@@ -228,8 +257,6 @@ float advanceLfo(LfoState& state, const LfoSettings& settings,
         state.completed = false;
 
     const double hz = std::max(static_cast<double>(settings.rate.hz), kMinHz);
-    const double beatsPerCycle =
-        std::max(cycleBeats(settings.rate.rateType, timing.numerator, timing.denominator), 1.0e-6);
 
     // A timeline-locked LFO is a function of where the block is rather than of
     // how many blocks have gone by, which is what puts two of them at one rate
@@ -299,10 +326,12 @@ float advanceLfo(LfoState& state, const LfoSettings& settings,
     // is the value at its first sample.
     if (settings.sync != ModSync::Transport && !holding && !zeroed) {
         if (settings.tempoSync) {
-            // The beats the block covered over the beats a cycle lasts. Off the
-            // block rather than through a bpm, so a block spanning a tempo
-            // change advances by what the map says it covered (#2340).
-            state.cycles += modBeatsElapsed(block, timing) / beatsPerCycle;
+            // The bars the block covered over the bars a cycle lasts. Off the
+            // block rather than through a bpm and a signature, so a block
+            // spanning a tempo or signature change advances by what the map
+            // says it covered (#2340).
+            state.cycles += modBarsElapsed(block, timing) /
+                            std::max(barFractionOf(settings.rate.rateType), 1.0e-6);
         } else {
             const double blockSeconds = static_cast<double>(std::max(block.numSamples, 0)) /
                                         std::max(timing.sampleRate, 1.0);

--- a/magda/engine/param/ModLfo.hpp
+++ b/magda/engine/param/ModLfo.hpp
@@ -256,15 +256,17 @@ struct LfoState {
  * things while the transport is stopped. The tempo, because a stopped block
  * covers no beats and a free-running modifier still has to keep musical time.
  * And the whole signature, because a musical division is a fraction of a bar
- * and a bar is neither number on its own.
+ * and a bar is neither number on its own: a rolling block reads the bars it
+ * covers off the map instead (@ref modBarsElapsed), which is what a stopped
+ * one has no map to read them from.
  */
 struct ModTiming {
     double sampleRate = 44100.0;
 
     /// The tempo the block opens at. What a stopped block keeps time at, and
-    /// nothing else: a rolling block says how many beats it covers, and that is
-    /// the map's own answer across a tempo change inside it (@ref
-    /// modBeatsElapsed).
+    /// nothing else: a rolling block says how many bars it covers, and that is
+    /// the map's own answer across a tempo or signature change inside it (@ref
+    /// modBarsElapsed).
     double bpm = 120.0;
 
     /// The signature at the block's first beat. Both halves of it, because a
@@ -302,24 +304,41 @@ ModTiming modTimingFor(const BlockInfo& block, double sampleRate);
 double modBarPosition(const BlockInfo& block, const ModTiming& timing);
 
 /**
- * @brief How many beats @p block covers, for a modifier advancing its own ramp.
+ * @brief How long a bar is, in beats, under one signature.
  *
- * The block's own beat length while the transport rolls. That is the map's
- * answer for exactly this stretch, derived once by the clock, so it is right
- * across a tempo step or a baked ramp boundary inside the block; block seconds
- * scaled by a single bpm read anywhere in the block is not, and runs the rest
- * of a block that spans a step at the tempo it opened on (#2340).
+ * The numerator counted in the denominator's own note value:
+ * `numerator * 4 / denominator` quarter notes, because a beat is a quarter
+ * note here and everywhere else in the engine. A bar of six eight is three of
+ * them, not six. Shared between @ref cycleBeats, which asks it of one
+ * signature, and @ref modBarsElapsed, which asks it of every signature a
+ * block crosses.
+ */
+double barBeatsOf(int numerator, int denominator);
+
+/**
+ * @brief How many bars @p block covers, for a modifier advancing its own ramp.
  *
- * A stopped block is the one that still needs a tempo. It covers no beats at
- * all, and a free-running modifier goes on turning through it, so there the
- * beats are how long the block lasted at the tempo the cursor is sitting on. A
- * stopped cursor is on one beat, so one bpm is exact there.
+ * The block's own beat length, translated into bars off the map. Not a single
+ * division, because a bar is a different number of beats on each side of a
+ * signature change, and a block that spans one covers a fraction of each: the
+ * map knows where the change is, so this walks the spans between them and
+ * sums what each is worth in its own bar length. Right across a tempo step as
+ * well, since @ref modBarsElapsed reads through the same grid the beats
+ * themselves came from; block seconds scaled by a single bpm and signature
+ * read anywhere in the block is not, and runs the rest of a block that spans a
+ * change at the numbers it opened on (#2340).
+ *
+ * A stopped block is the one that still needs a tempo and a signature. It
+ * covers no beats at all, and a free-running modifier goes on turning through
+ * it, so there the bars are how long the block lasted at the tempo and
+ * signature the cursor is sitting on. A stopped cursor is on one beat, so one
+ * bpm and one bar length are exact there.
  *
  * Shared because the LFO, the random walk and the envelope all ask it, and two
  * answers to one question is what a modifier drifting from the one beside it
  * would be.
  */
-double modBeatsElapsed(const BlockInfo& block, const ModTiming& timing);
+double modBarsElapsed(const BlockInfo& block, const ModTiming& timing);
 
 /**
  * @brief How much of a bar one rate type is.

--- a/magda/engine/param/ModLfo.hpp
+++ b/magda/engine/param/ModLfo.hpp
@@ -253,12 +253,18 @@ struct LfoState {
  *
  * The sample rate, because a free-running LFO advances by how long the block
  * lasted rather than by how far the timeline moved, and the two are different
- * things while the transport is stopped. The tempo and the whole signature,
- * because a musical division is a fraction of a bar and a bar is none of those
- * on its own.
+ * things while the transport is stopped. The tempo, because a stopped block
+ * covers no beats and a free-running modifier still has to keep musical time.
+ * And the whole signature, because a musical division is a fraction of a bar
+ * and a bar is neither number on its own.
  */
 struct ModTiming {
     double sampleRate = 44100.0;
+
+    /// The tempo the block opens at. What a stopped block keeps time at, and
+    /// nothing else: a rolling block says how many beats it covers, and that is
+    /// the map's own answer across a tempo change inside it (@ref
+    /// modBeatsElapsed).
     double bpm = 120.0;
 
     /// The signature at the block's first beat. Both halves of it, because a
@@ -294,6 +300,26 @@ ModTiming modTimingFor(const BlockInfo& block, double sampleRate);
  * would be two answers to one question.
  */
 double modBarPosition(const BlockInfo& block, const ModTiming& timing);
+
+/**
+ * @brief How many beats @p block covers, for a modifier advancing its own ramp.
+ *
+ * The block's own beat length while the transport rolls. That is the map's
+ * answer for exactly this stretch, derived once by the clock, so it is right
+ * across a tempo step or a baked ramp boundary inside the block; block seconds
+ * scaled by a single bpm read anywhere in the block is not, and runs the rest
+ * of a block that spans a step at the tempo it opened on (#2340).
+ *
+ * A stopped block is the one that still needs a tempo. It covers no beats at
+ * all, and a free-running modifier goes on turning through it, so there the
+ * beats are how long the block lasted at the tempo the cursor is sitting on. A
+ * stopped cursor is on one beat, so one bpm is exact there.
+ *
+ * Shared because the LFO, the random walk and the envelope all ask it, and two
+ * answers to one question is what a modifier drifting from the one beside it
+ * would be.
+ */
+double modBeatsElapsed(const BlockInfo& block, const ModTiming& timing);
 
 /**
  * @brief How much of a bar one rate type is.

--- a/magda/engine/param/ModRandom.cpp
+++ b/magda/engine/param/ModRandom.cpp
@@ -145,12 +145,17 @@ float advanceRandom(RandomState& state, const RandomSettings& settings, const Bl
     // order and the fork's: the value a block renders with is the value at its
     // first sample.
     if (settings.sync != ModSync::Transport) {
-        const double blockSeconds =
-            static_cast<double>(std::max(block.numSamples, 0)) / std::max(timing.sampleRate, 1.0);
-        const double periodSeconds =
-            settings.tempoSync ? beatsPerCycle * 60.0 / timing.bpm : 1.0 / hz;
-
-        state.cycles += blockSeconds / std::max(periodSeconds, 1.0e-9);
+        if (settings.tempoSync) {
+            // The beats the block covered over the beats a step lasts, off the
+            // block rather than through a bpm, which is the LFO's advance and
+            // is what makes a step across a tempo change the map's length
+            // rather than the opening tempo's (#2340).
+            state.cycles += modBeatsElapsed(block, timing) / beatsPerCycle;
+        } else {
+            const double blockSeconds = static_cast<double>(std::max(block.numSamples, 0)) /
+                                        std::max(timing.sampleRate, 1.0);
+            state.cycles += blockSeconds * hz;
+        }
     }
 
     // Kept bounded, so a walk left running for hours steps as precisely as one

--- a/magda/engine/param/ModRandom.cpp
+++ b/magda/engine/param/ModRandom.cpp
@@ -93,8 +93,6 @@ void restartRandom(RandomState& state, const RandomSettings& settings) {
 float advanceRandom(RandomState& state, const RandomSettings& settings, const BlockInfo& block,
                     const ModTiming& timing) {
     const double hz = std::max(static_cast<double>(settings.rate.hz), kMinHz);
-    const double beatsPerCycle =
-        std::max(cycleBeats(settings.rate.rateType, timing.numerator, timing.denominator), 1.0e-6);
 
     const bool noise = settings.type == RandomShape::Noise;
 
@@ -146,11 +144,13 @@ float advanceRandom(RandomState& state, const RandomSettings& settings, const Bl
     // first sample.
     if (settings.sync != ModSync::Transport) {
         if (settings.tempoSync) {
-            // The beats the block covered over the beats a step lasts, off the
-            // block rather than through a bpm, which is the LFO's advance and
-            // is what makes a step across a tempo change the map's length
-            // rather than the opening tempo's (#2340).
-            state.cycles += modBeatsElapsed(block, timing) / beatsPerCycle;
+            // The bars the block covered over the bars a step lasts, off the
+            // block rather than through a bpm and a signature, which is the
+            // LFO's advance and is what makes a step across a tempo or
+            // signature change the map's length rather than the opening
+            // numbers' (#2340).
+            state.cycles += modBarsElapsed(block, timing) /
+                            std::max(barFractionOf(settings.rate.rateType), 1.0e-6);
         } else {
             const double blockSeconds = static_cast<double>(std::max(block.numSamples, 0)) /
                                         std::max(timing.sampleRate, 1.0);

--- a/magda/engine/transport/TempoMap.cpp
+++ b/magda/engine/transport/TempoMap.cpp
@@ -302,6 +302,14 @@ BarsAndBeats TempoMap::barsAndBeatsAt(double beat) const {
             section.numerator, section.denominator};
 }
 
+double TempoMap::signatureEndAfter(double beat) const {
+    // Already infinity on the section under the last signature change (built
+    // that way above), so there is nothing left to guard here: a beat with no
+    // change ahead of it answers with a number nothing on the timeline is ever
+    // past.
+    return sectionForBeat(beat).signatureEndBeat;
+}
+
 BeatTick TempoMap::tickAtOrAfter(double beat) const {
     const auto& section = sectionForBeat(beat);
     const auto tickBeats = tickBeatsOf(section.denominator);

--- a/magda/engine/transport/TempoMap.cpp
+++ b/magda/engine/transport/TempoMap.cpp
@@ -257,14 +257,6 @@ TempoMap::TempoMap(std::vector<TempoChange> tempos, std::vector<TimeSignatureCha
     }
 }
 
-double TempoMap::nextSectionBoundaryAfter(double beat) const {
-    const auto next = std::upper_bound(
-        sections_.begin(), sections_.end(), beat + kBeatEpsilon,
-        [](double value, const Section& section) { return value < section.startBeat; });
-
-    return next == sections_.end() ? std::numeric_limits<double>::infinity() : next->startBeat;
-}
-
 const TempoMap::Section& TempoMap::sectionForBeat(double beat) const {
     // Before the first section is the first section extended backwards: the
     // timeline exists before beat zero and has to have a tempo there.

--- a/magda/engine/transport/TempoMap.hpp
+++ b/magda/engine/transport/TempoMap.hpp
@@ -128,6 +128,18 @@ class TempoMap {
     BarsAndBeats barsAndBeatsAt(double beat) const;
 
     /**
+     * @brief Where the signature at @p beat gives way to the next, or infinity.
+     *
+     * A modifier that runs in bars has to know how far its own bar length
+     * carries before the map cuts it short: a bar is a different number of
+     * beats on the far side of a change, so a stretch that crosses one is a
+     * sum over two grids rather than one division (ModLfo.hpp's
+     * modBarsElapsed). The metronome already needed this per section
+     * (Section::signatureEndBeat); this is the same number, public.
+     */
+    double signatureEndAfter(double beat) const;
+
+    /**
      * @brief The first metronome tick at or after @p beat.
      *
      * A beat sitting exactly on a tick is that tick, so a block starting on the

--- a/magda/engine/transport/TempoMap.hpp
+++ b/magda/engine/transport/TempoMap.hpp
@@ -136,27 +136,6 @@ class TempoMap {
     BeatTick tickAtOrAfter(double beat) const;
 
     /**
-     * @brief The first section boundary strictly after @p beat, or infinity.
-     *
-     * A section is the stretch this map is linear over, which is what makes
-     * both conversions a multiply. What asks is the transport, which ends a
-     * segment there and never hands out a block that spans one.
-     *
-     * That cut is what makes the rest of the engine's arithmetic true. Inside a
-     * block every position is worked out on a straight line between its two
-     * ends: where a launch lands, where a note goes, which instant a run began
-     * on (exec/RenderContext.hpp). Within one section that line is the map;
-     * across a boundary it is a guess, and the block's two faces stop naming
-     * one instant.
-     *
-     * Every boundary, not only the steps a tempo track spells out. A ramp is
-     * baked into constant-tempo sections, and between two of them the slope
-     * changes as surely as it does at a step: over a steep one, a beat the map
-     * puts at sample 256 of a block lands at sample 93 on its line.
-     */
-    double nextSectionBoundaryAfter(double beat) const;
-
-    /**
      * @brief Identity of the tempo track this was baked from.
      *
      * Two maps with the same fingerprint place every beat identically. The

--- a/magda/engine/transport/TransportClock.cpp
+++ b/magda/engine/transport/TransportClock.cpp
@@ -173,36 +173,14 @@ std::span<const TransportClock::Segment> TransportClock::advance(const Transport
         if (countingIn_)
             samples = std::min(samples, samplesUntil(tempo, countInUntilBeat_));
 
-        // A block never spans a tempo section, which is the stretch the map is
-        // linear over. Not a jump: audio flows straight through a tempo change
-        // and the next segment carries on continuous.
+        // A tempo section boundary is not cut at. It used to be, so that the
+        // block's own straight line stayed honest and so that a modifier
+        // reading one bpm per block read the right one; placement goes through
+        // the map now (#2336) and a modifier reads the beats the block covers
+        // (#2340), so nothing is left that a section boundary inside a block
+        // would be wrong for. A tempo change is not a jump either: audio flows
+        // straight through one and the block carries on continuous.
         //
-        // What the cut is for has changed. It arrived to keep the block's own
-        // straight line honest, because everything inside a block was placed on
-        // the line between its two ends; placement goes through the map now, so
-        // that is no longer what pays for it (#2336).
-        //
-        // What it still buys is that a block is one tempo and one signature. A
-        // rate-synced modifier reads a single bpm for the whole block it is
-        // rendering (ModLfo's modTimingFor), and a block spanning a step would
-        // run at the tempo it opened on for the rest of it. The cut is what
-        // makes that reading exact rather than nearly right, and it costs one
-        // extra segment per tempo change (#2333).
-        //
-        // Past a boundary the epsilon has already swallowed, or the guarantee
-        // has a hole exactly where it is hardest to see. A boundary within a
-        // hundredth of a sample ahead of the cursor counts as zero samples
-        // away, and a zero cut is no cut: the segment would then run to
-        // whatever else ends it, through that boundary and every later one in
-        // the callback. The cursor is on that boundary for all practical
-        // purposes, so the one to cut at is the next one after it.
-        auto boundary = tempo.nextSectionBoundaryAfter(beatAfter(tempo, samplesSinceAnchor_));
-        while (std::isfinite(boundary) && samplesUntil(tempo, boundary) <= 0)
-            boundary = tempo.nextSectionBoundaryAfter(boundary);
-
-        if (std::isfinite(boundary))
-            samples = std::min(samples, samplesUntil(tempo, boundary));
-
         // Clamped from inside the loop only. From outside it the count is
         // negative and would cut a callback that is not looping at all; from
         // inside, it can still be zero, for a loop so short that its end is not

--- a/tests/engine/test_block_samples.cpp
+++ b/tests/engine/test_block_samples.cpp
@@ -177,3 +177,57 @@ TEST_CASE("A block with beats alone places along its own line", "[engine][block]
     CHECK(block.eventForBeat(5.0) == EventSample{63});
     CHECK(block.edgeForBeat(5.0) == EdgeSample{64});
 }
+
+TEST_CASE("The opening beat is nudged through the map, not the block's average slope",
+          "[engine][block][samples][2340]") {
+    // openingBeat() nudges by a hundredth of a sample of real time, converted
+    // at the tempo the block opens on. A block's own average slope is a
+    // different number whenever a step sits inside it, because it is the
+    // whole block's beats over the whole block's samples rather than the rate
+    // at the very start, and it can land the nudge on the wrong side of the
+    // boundary the tolerance is measured against.
+    constexpr double kRate = 44100.0;
+
+    SECTION("a step up: the true nudge falls short, the average slope overshoots") {
+        // 20 bpm to beat 1, then 300, written as two changes at the one beat.
+        // The block opens 0.02 samples of real time before the boundary, which
+        // at 20 bpm is farther than the hundredth-of-a-sample tolerance: the
+        // true opening beat stays on the near side of it. The average slope is
+        // pulled toward the fast section that dominates the rest of the block
+        // and crosses the boundary anyway.
+        const TempoMap tempo({{0.0, 20.0, 0.0f}, {1.0, 20.0, 0.0f}, {1.0, 300.0, 0.0f}}, {});
+
+        BlockInfo block;
+        block.numSamples = 4096;
+        block.sampleRate = kRate;
+        block.playing = true;
+        block.seconds.start = tempo.beatToTime(1.0) - (0.02 / kRate);
+        block.seconds.end = block.seconds.start + (4096.0 / kRate);
+        block.beats.start = tempo.timeToBeat(block.seconds.start);
+        block.beats.end = tempo.timeToBeat(block.seconds.end);
+        block.tempo = &tempo;
+
+        CHECK(tempo.bpmAt(block.openingBeat()) == Catch::Approx(20.0));
+    }
+
+    SECTION("a step down: the true nudge crosses, the average slope falls short") {
+        // 300 bpm to beat 1, then 20. The block opens 0.005 samples of real
+        // time before the boundary, which at 300 bpm is inside the tolerance:
+        // the true opening beat is already on the far side of it. The average
+        // slope is pulled toward the slow section that dominates the rest of
+        // the block and stays short.
+        const TempoMap tempo({{0.0, 300.0, 0.0f}, {1.0, 300.0, 0.0f}, {1.0, 20.0, 0.0f}}, {});
+
+        BlockInfo block;
+        block.numSamples = 4096;
+        block.sampleRate = kRate;
+        block.playing = true;
+        block.seconds.start = tempo.beatToTime(1.0) - (0.005 / kRate);
+        block.seconds.end = block.seconds.start + (4096.0 / kRate);
+        block.beats.start = tempo.timeToBeat(block.seconds.start);
+        block.beats.end = tempo.timeToBeat(block.seconds.end);
+        block.tempo = &tempo;
+
+        CHECK(tempo.bpmAt(block.openingBeat()) == Catch::Approx(20.0));
+    }
+}

--- a/tests/engine/test_engine_external_device.cpp
+++ b/tests/engine/test_engine_external_device.cpp
@@ -1002,9 +1002,10 @@ TEST_CASE("The plugin is told where the transport is", "[engine][external]") {
 }
 
 TEST_CASE("The plugin is told the section the block renders in", "[engine][external][2336]") {
-    // A block covers one tempo section, but a cut lands on the first sample at
-    // or after the boundary, so it can open a fraction of a sample before one
-    // (BlockInfo::sectionBeat). A plugin is told one bpm and one signature for
+    // A musical position within a hundredth of a sample of the cursor is the
+    // cursor as far as the transport is concerned, so a block can open that
+    // close before a section boundary while every sample it renders is past it
+    // (BlockInfo::openingBeat). A plugin is told one bpm and one signature for
     // the whole call, and taking them from the block's first beat would run the
     // call on the section it had already left.
     auto plugin = std::make_unique<StubPlugin>();
@@ -1059,11 +1060,10 @@ TEST_CASE("The plugin is told the section the block renders in", "[engine][exter
 }
 
 TEST_CASE("A block straddling a bar line reports the bar it began in", "[engine][external][2336]") {
-    // The section a block renders in is one thing and the bar its first sample
-    // is in is another. A block is cut at every tempo section and at no bar
-    // line, so a long one straddles one, and reporting the bar its middle is in
-    // would make what the plugin is told depend on how the host sized the
-    // callback: the same first sample, two answers.
+    // The bar a block's first sample is in is what the plugin is told, and a
+    // block is not cut at bar lines, so a long one straddles one. Reporting the
+    // bar its middle is in would make what the plugin hears depend on how the
+    // host sized the callback: the same first sample, two answers.
     auto plugin = std::make_unique<StubPlugin>();
     auto* raw = plugin.get();
 

--- a/tests/engine/test_mod_adsr.cpp
+++ b/tests/engine/test_mod_adsr.cpp
@@ -10,6 +10,7 @@
 #include "param/ParamResolve.hpp"
 #include "param/ParamTableCompiler.hpp"
 #include "plan/PlanCompiler.hpp"
+#include "transport/TempoMap.hpp"
 
 /**
  * @file test_mod_adsr.cpp
@@ -39,6 +40,7 @@ using magda::engine::ModKind;
 using magda::engine::ModRuntime;
 using magda::engine::ModSync;
 using magda::engine::ModTiming;
+using magda::engine::modTimingFor;
 using magda::engine::ParamKey;
 using magda::engine::ParamSegment;
 using magda::engine::ParamTable;
@@ -387,6 +389,42 @@ TEST_CASE("A stage with no time in it is instant", "[engine][mod][adsr]") {
         CHECK(value >= 0.0f);
         CHECK(value <= 1.0f);
     }
+}
+
+TEST_CASE("A synced stage lasts the map's beats across a tempo step", "[engine][mod][adsr][2340]") {
+    // 120 held to beat 2, then 60, and a block from beat 1.5 to 2.5: half a
+    // beat either side of the step, a quarter of a second at 120 and half a
+    // second at 60, three quarters of a second in all.
+    //
+    // A stage of one half note is two beats and the block covered one of them,
+    // so the envelope is halfway up the attack. Three quarters of a second
+    // against a stage the opening tempo makes a second long would have put it
+    // three quarters of the way up (#2340).
+    const magda::engine::TempoMap tempo({{.startBeat = 0.0, .bpm = 120.0},
+                                         {.startBeat = 2.0, .bpm = 120.0},
+                                         {.startBeat = 2.0, .bpm = 60.0}},
+                                        {{.startBeat = 0.0, .numerator = 4, .denominator = 4}});
+
+    BlockInfo block;
+    block.playing = true;
+    block.beats.start = 1.5;
+    block.beats.end = 2.5;
+    block.seconds.start = tempo.beatToTime(block.beats.start);
+    block.seconds.end = tempo.beatToTime(block.beats.end);
+    block.numSamples =
+        static_cast<int>(std::llround((block.seconds.end - block.seconds.start) * kSampleRate));
+    block.sampleRate = kSampleRate;
+    block.tempo = &tempo;
+
+    AdsrSettings settings;
+    settings.sync = ModSync::Free;
+    settings.tempoSync = true;
+    settings.rateType = static_cast<int>(ModRateType::Half);
+
+    AdsrState state;
+
+    CHECK(step(state, settings, block, modTimingFor(block, kSampleRate)) == approx(0.5f));
+    CHECK(state.stage == AdsrStage::Attack);
 }
 
 TEST_CASE("A block longer than a stage lands in the stage after it", "[engine][mod][adsr]") {

--- a/tests/engine/test_mod_adsr.cpp
+++ b/tests/engine/test_mod_adsr.cpp
@@ -427,6 +427,65 @@ TEST_CASE("A synced stage lasts the map's beats across a tempo step", "[engine][
     CHECK(state.stage == AdsrStage::Attack);
 }
 
+TEST_CASE("A synced attack runs in bars, not the opening signature's beats",
+          "[engine][mod][adsr][2340]") {
+    // The LFO's claim, on the envelope. 120 throughout, four four to beat 2 and
+    // three four from it: a block from beat 1 to beat 3 covers one beat of the
+    // four-beat bar and one beat of the three-beat bar that follows, a quarter
+    // plus a third. A one-bar attack is that far up, linearly from zero; the
+    // opening signature's formula would divide the whole two beats by four and
+    // say a half (#2340).
+    const magda::engine::TempoMap tempo({{.startBeat = 0.0, .bpm = 120.0}},
+                                        {{.startBeat = 0.0, .numerator = 4, .denominator = 4},
+                                         {.startBeat = 2.0, .numerator = 3, .denominator = 4}});
+
+    BlockInfo block;
+    block.playing = true;
+    block.beats.start = 1.0;
+    block.beats.end = 3.0;
+    block.seconds.start = tempo.beatToTime(block.beats.start);
+    block.seconds.end = tempo.beatToTime(block.beats.end);
+    block.numSamples =
+        static_cast<int>(std::llround((block.seconds.end - block.seconds.start) * kSampleRate));
+    block.sampleRate = kSampleRate;
+    block.tempo = &tempo;
+
+    AdsrSettings settings;
+    settings.sync = ModSync::Free;
+    settings.tempoSync = true;
+    settings.rateType = static_cast<int>(ModRateType::Bar);
+
+    AdsrState state;
+
+    const auto expected = static_cast<float>(0.25 + 1.0 / 3.0);
+    CHECK(step(state, settings, block, modTimingFor(block, kSampleRate)) == approx(expected));
+    CHECK(state.stage == AdsrStage::Attack);
+}
+
+TEST_CASE("A tempo-sync toggle mid-stage converts the accumulator instead of reinterpreting it",
+          "[engine][mod][adsr][2340]") {
+    AdsrSettings settings;
+    settings.sync = ModSync::Free;
+    settings.attackMs = 2000.0f;
+
+    AdsrState state;
+
+    // A one-second block against a two-second attack is halfway up it.
+    CHECK(step(state, settings, rollingBlock(48000)) == approx(0.5f));
+    REQUIRE(state.stage == AdsrStage::Attack);
+    CHECK(state.stagePhase == approx(0.5f));
+
+    // A bar at 120 in four four is two seconds as well, so the stage length
+    // does not move under the flip: only the unit timeInStage is counted in
+    // does. Reinterpreting the one second already banked as one bar would
+    // overshoot the attack outright; converting it through the phase leaves
+    // the envelope where it was and lets it finish across the next second.
+    settings.tempoSync = true;
+    settings.rateType = static_cast<int>(ModRateType::Bar);
+
+    CHECK(step(state, settings, rollingBlock(48000)) == approx(1.0f).margin(1.0e-3));
+}
+
 TEST_CASE("A block longer than a stage lands in the stage after it", "[engine][mod][adsr]") {
     const auto settings = tenTenTen();
     AdsrState state;

--- a/tests/engine/test_mod_lfo.cpp
+++ b/tests/engine/test_mod_lfo.cpp
@@ -301,6 +301,68 @@ TEST_CASE("A free-running LFO keeps turning while the transport is stopped", "[e
     step(state, settings, block);
 
     CHECK(step(state, settings, block) == approx(0.25f));
+
+    SECTION("and so does a tempo-synced one, at the tempo the cursor sits on") {
+        LfoSettings synced;
+        synced.wave = LFOWaveform::Saw;
+        synced.sync = ModSync::Free;
+        synced.tempoSync = true;
+        synced.rate.rateType = static_cast<int>(ModRateType::Bar);
+
+        // A stopped block covers no beats, so what it is worth is how long it
+        // lasted at the tempo the cursor is on: a quarter of a second at 120 is
+        // half a beat, which is an eighth of a four four bar.
+        LfoState turning;
+        step(turning, synced, block);
+
+        CHECK(step(turning, synced, block) == approx(0.125f));
+    }
+}
+
+TEST_CASE("A free-running synced LFO turns by the map's beats, not the opening tempo's",
+          "[engine][mod][lfo][2340]") {
+    // 120 held to beat 2, then 60. Two changes at the one beat, which is how a
+    // step is written rather than a ramp to it.
+    //
+    // A block from beat 1.5 to 2.5 is half a beat either side of it: a quarter
+    // of a second at 120 and half a second at 60, three quarters of a second in
+    // all. What it covers is one beat, which is what the map says and what the
+    // block carries. Three quarters of a second at the tempo it opened on would
+    // say one and a half, and the LFO would turn half as far again as the music
+    // did (#2340).
+    const magda::engine::TempoMap tempo({{.startBeat = 0.0, .bpm = 120.0},
+                                         {.startBeat = 2.0, .bpm = 120.0},
+                                         {.startBeat = 2.0, .bpm = 60.0}},
+                                        {{.startBeat = 0.0, .numerator = 4, .denominator = 4}});
+
+    BlockInfo block;
+    block.playing = true;
+    block.beats.start = 1.5;
+    block.beats.end = 2.5;
+    block.seconds.start = tempo.beatToTime(block.beats.start);
+    block.seconds.end = tempo.beatToTime(block.beats.end);
+    block.numSamples =
+        static_cast<int>(std::llround((block.seconds.end - block.seconds.start) * kSampleRate));
+    block.sampleRate = kSampleRate;
+    block.tempo = &tempo;
+
+    LfoSettings settings;
+    settings.wave = LFOWaveform::Saw;
+    settings.sync = ModSync::Free;
+    settings.tempoSync = true;
+    settings.rate.rateType = static_cast<int>(ModRateType::Bar);
+
+    LfoState state;
+    const auto timings = modTimingFor(block, kSampleRate);
+
+    // The value a block renders with is the one it opens on, so the turn shows
+    // up on the block after the one that made it.
+    CHECK(step(state, settings, block, {}, timings) == approx(0.0f));
+
+    // One beat of a four-beat bar. The opening tempo's one and a half beats
+    // would have put it three eighths of the way round.
+    CHECK(state.cycles == Catch::Approx(0.25));
+    CHECK(step(state, settings, block, {}, timings) == approx(0.25f));
 }
 
 TEST_CASE("A transport-locked LFO is a function of where the block is", "[engine][mod][lfo]") {
@@ -1135,10 +1197,10 @@ TEST_CASE("An LFO moves a device parameter through a live session", "[engine][mo
 }
 
 TEST_CASE("A bar-rate LFO reads the bar the block renders in", "[engine][mod][lfo][2336]") {
-    // The other half of a block being one section. The tempo and the signature
-    // a block runs at come from inside it (BlockInfo::sectionBeat), and so does
-    // the bar its phase is measured against, or an LFO locked to the bar reads
-    // one grid and runs at another.
+    // The other half of a block's first sample deciding its section. The tempo
+    // and the signature a block runs at come from the beat that sample sounds
+    // on (BlockInfo::openingBeat), and so does the bar its phase is measured
+    // against, or an LFO locked to the bar reads one grid and runs at another.
     //
     // Four four to three four at beat 1, which is not a bar line of either, and
     // a block that opens a hundredth of a sample before it. Every sample it

--- a/tests/engine/test_mod_lfo.cpp
+++ b/tests/engine/test_mod_lfo.cpp
@@ -365,6 +365,49 @@ TEST_CASE("A free-running synced LFO turns by the map's beats, not the opening t
     CHECK(step(state, settings, block, {}, timings) == approx(0.25f));
 }
 
+TEST_CASE("A free-running synced LFO turns by the map's bars, not the opening signature's",
+          "[engine][mod][lfo][2340]") {
+    // 120 throughout, four four to beat 2 and three four from it: a bar-rate
+    // LFO reading one signature for the whole block would run it at four beats
+    // a bar the entire way, where the map says a bar is three beats past the
+    // change.
+    //
+    // A block from beat 1 to beat 3 covers one beat of the four-beat bar and
+    // one beat of the three-beat bar that follows it, which is a quarter of the
+    // first plus a third of the second. The opening signature's formula would
+    // divide the whole two beats by four and say a half (#2340).
+    const magda::engine::TempoMap tempo({{.startBeat = 0.0, .bpm = 120.0}},
+                                        {{.startBeat = 0.0, .numerator = 4, .denominator = 4},
+                                         {.startBeat = 2.0, .numerator = 3, .denominator = 4}});
+
+    BlockInfo block;
+    block.playing = true;
+    block.beats.start = 1.0;
+    block.beats.end = 3.0;
+    block.seconds.start = tempo.beatToTime(block.beats.start);
+    block.seconds.end = tempo.beatToTime(block.beats.end);
+    block.numSamples =
+        static_cast<int>(std::llround((block.seconds.end - block.seconds.start) * kSampleRate));
+    block.sampleRate = kSampleRate;
+    block.tempo = &tempo;
+
+    LfoSettings settings;
+    settings.wave = LFOWaveform::Saw;
+    settings.sync = ModSync::Free;
+    settings.tempoSync = true;
+    settings.rate.rateType = static_cast<int>(ModRateType::Bar);
+
+    LfoState state;
+    const auto timings = modTimingFor(block, kSampleRate);
+
+    CHECK(step(state, settings, block, {}, timings) == approx(0.0f));
+
+    // A quarter of the four-beat bar plus a third of the three-beat one.
+    CHECK(state.cycles == Catch::Approx(0.25 + 1.0 / 3.0));
+    CHECK(step(state, settings, block, {}, timings) ==
+          approx(static_cast<float>(0.25 + 1.0 / 3.0)));
+}
+
 TEST_CASE("A transport-locked LFO is a function of where the block is", "[engine][mod][lfo]") {
     auto settings = freeRunning(1.0f);
     settings.sync = ModSync::Transport;

--- a/tests/engine/test_mod_random.cpp
+++ b/tests/engine/test_mod_random.cpp
@@ -414,6 +414,45 @@ TEST_CASE("A free-running synced walk steps on the map's beats", "[engine][mod][
     CHECK(state.phase == approx(0.25f));
 }
 
+TEST_CASE("A free-running synced walk steps on the map's bars, not the opening signature's",
+          "[engine][mod][random][2340]") {
+    // The LFO's claim, on the walk. 120 throughout, four four to beat 2 and
+    // three four from it: a block from beat 1 to beat 3 covers one beat of the
+    // four-beat bar and one beat of the three-beat bar that follows, a quarter
+    // plus a third. The opening signature's formula would divide the whole two
+    // beats by four and say a half (#2340).
+    const magda::engine::TempoMap tempo({{.startBeat = 0.0, .bpm = 120.0}},
+                                        {{.startBeat = 0.0, .numerator = 4, .denominator = 4},
+                                         {.startBeat = 2.0, .numerator = 3, .denominator = 4}});
+
+    BlockInfo block;
+    block.playing = true;
+    block.beats.start = 1.0;
+    block.beats.end = 3.0;
+    block.seconds.start = tempo.beatToTime(block.beats.start);
+    block.seconds.end = tempo.beatToTime(block.beats.end);
+    block.numSamples =
+        static_cast<int>(std::llround((block.seconds.end - block.seconds.start) * kSampleRate));
+    block.sampleRate = kSampleRate;
+    block.tempo = &tempo;
+
+    auto settings = stepped();
+    settings.sync = ModSync::Free;
+    settings.tempoSync = true;
+    settings.rate.rateType = static_cast<int>(ModRateType::Bar);
+
+    auto state = seeded();
+    const auto timings = modTimingFor(block, kSampleRate);
+
+    step(state, settings, block, timings);
+
+    // A quarter of the four-beat bar plus a third of the three-beat one.
+    CHECK(state.cycles == Catch::Approx(0.25 + 1.0 / 3.0));
+
+    step(state, settings, block, timings);
+    CHECK(state.phase == approx(static_cast<float>(0.25 + 1.0 / 3.0)));
+}
+
 TEST_CASE("A trigger restarts the walk and takes a step", "[engine][mod][random]") {
     auto settings = stepped();
     settings.sync = ModSync::Note;

--- a/tests/engine/test_mod_random.cpp
+++ b/tests/engine/test_mod_random.cpp
@@ -10,6 +10,7 @@
 #include "param/ParamResolve.hpp"
 #include "param/ParamTableCompiler.hpp"
 #include "plan/PlanCompiler.hpp"
+#include "transport/TempoMap.hpp"
 
 /**
  * @file test_mod_random.cpp
@@ -38,6 +39,7 @@ using magda::engine::ModKind;
 using magda::engine::ModRuntime;
 using magda::engine::ModSync;
 using magda::engine::ModTiming;
+using magda::engine::modTimingFor;
 using magda::engine::ParamKey;
 using magda::engine::ParamSegment;
 using magda::engine::ParamTable;
@@ -370,6 +372,46 @@ TEST_CASE("A free-running walk advances by how long the block was", "[engine][mo
 
     step(state, settings, block);
     CHECK(state.phase == approx(0.0f));
+}
+
+TEST_CASE("A free-running synced walk steps on the map's beats", "[engine][mod][random][2340]") {
+    // The LFO's claim, on the walk. 120 held to beat 2, then 60, and a block
+    // from beat 1.5 to 2.5: half a beat either side of the step, a quarter of a
+    // second at 120 and half a second at 60. What it covers is one beat; three
+    // quarters of a second at the tempo it opened on would say one and a half
+    // (#2340).
+    const magda::engine::TempoMap tempo({{.startBeat = 0.0, .bpm = 120.0},
+                                         {.startBeat = 2.0, .bpm = 120.0},
+                                         {.startBeat = 2.0, .bpm = 60.0}},
+                                        {{.startBeat = 0.0, .numerator = 4, .denominator = 4}});
+
+    BlockInfo block;
+    block.playing = true;
+    block.beats.start = 1.5;
+    block.beats.end = 2.5;
+    block.seconds.start = tempo.beatToTime(block.beats.start);
+    block.seconds.end = tempo.beatToTime(block.beats.end);
+    block.numSamples =
+        static_cast<int>(std::llround((block.seconds.end - block.seconds.start) * kSampleRate));
+    block.sampleRate = kSampleRate;
+    block.tempo = &tempo;
+
+    auto settings = stepped();
+    settings.sync = ModSync::Free;
+    settings.tempoSync = true;
+    settings.rate.rateType = static_cast<int>(ModRateType::Bar);
+
+    auto state = seeded();
+    const auto timings = modTimingFor(block, kSampleRate);
+
+    step(state, settings, block, timings);
+
+    // One beat of a four-beat step. The opening tempo's one and a half beats
+    // would have put the walk three eighths of the way through it.
+    CHECK(state.cycles == Catch::Approx(0.25));
+
+    step(state, settings, block, timings);
+    CHECK(state.phase == approx(0.25f));
 }
 
 TEST_CASE("A trigger restarts the walk and takes a step", "[engine][mod][random]") {

--- a/tests/engine/test_session_playback.cpp
+++ b/tests/engine/test_session_playback.cpp
@@ -940,19 +940,19 @@ TEST_CASE("A launch inside a block that spans a tempo step names one instant",
     CHECK(material.beatAtTime(0.0) == Approx(0.0));
 }
 
-TEST_CASE("A slot launched where a block would step tempo starts at its own first sample",
+TEST_CASE("A slot launched where a block steps tempo starts at its own first sample",
           "[engine][clip][session]") {
-    // The launch and the tempo step want the same instant inside one callback.
-    // Uncut, the block spans the step, and the launcher names the split in
-    // monotonic beats and projects it onto the timeline and the seconds axes
-    // separately, each a straight line across the block (LaunchHandle.cpp).
-    // Those two lines disagree across a jump: beat 4 projects to 2.020833 s
-    // where the map puts it at 2, so the run's origin is not one instant and
-    // material second zero sits a fiftieth of a beat past material beat zero.
+    // The launch and the tempo step want the same instant inside one callback,
+    // and the block is not cut at the step (#2340). The launcher used to name
+    // the split in monotonic beats and project it onto the timeline and the
+    // seconds axes separately, each a straight line across the block, and those
+    // two lines disagree across a step: beat 4 projects to 2.020833 s where the
+    // map puts it at 2, so the run's origin was not one instant and material
+    // second zero sat a fiftieth of a beat past material beat zero.
     //
-    // What that costs is the head of the clip. The transport cuts the block at
-    // the step instead, which leaves one tempo inside it and both projections
-    // exact (TempoMap::nextTempoStepAfter).
+    // What that cost was the head of the clip. The split is worked out once, in
+    // samples, and every face taken from that sample (#2336), so an uncut block
+    // hands the run its own first sample either way.
     const auto map = steppedTempo();  // 120 to beat 4, then 60
 
     // Half a block before the step, so both the step and the launch fall inside
@@ -965,17 +965,21 @@ TEST_CASE("A slot launched where a block would step tempo starts at its own firs
 
     magda::engine::TransportClock clock;
 
-    // Monotonic beat 0.125 is timeline beat 4: the step itself.
+    // Monotonic beat 0.125 is timeline beat 4: the step itself, and half a
+    // block into the callback.
     rig.handle.play(kBeatsPerBlock / 2.0);
 
     callback(rig, clock, snapshot);
 
-    // The buffer holds the last segment, which is the one the run begins on, so
-    // its samples are the material's own from the first. CountingReader reads
-    // sample n back as n, so a clip that skipped its head would say so here.
-    CHECK(rig.at(0) == Approx(0.0f));
-    CHECK(rig.at(1000) == Approx(1000.0f));
-    CHECK(rig.at(2999) == Approx(2999.0f));
+    // Nothing before the launch sample, and the material's own samples from it.
+    // CountingReader reads sample n back as n, so a clip that skipped its head
+    // would say so here.
+    constexpr auto kLaunchSample = kBlockSize / 2;
+
+    CHECK(rig.at(kLaunchSample - 1) == Approx(0.0f));
+    CHECK(rig.at(kLaunchSample) == Approx(0.0f));
+    CHECK(rig.at(kLaunchSample + 1000) == Approx(1000.0f));
+    CHECK(rig.at(kBlockSize - 1) == Approx(kLaunchSample - 1.0f));
 }
 
 TEST_CASE("A launched slot plays straight through a loop wrap", "[engine][clip][session]") {

--- a/tests/engine/test_transport_clock.cpp
+++ b/tests/engine/test_transport_clock.cpp
@@ -309,10 +309,16 @@ TEST_CASE("Editing the tempo moves the seconds, not the beat",
     CHECK(block.segments[0].block.continuous);
 }
 
-TEST_CASE("A callback that crosses a tempo step is cut at it",
+TEST_CASE("A callback that crosses a tempo step runs straight through it",
           "[engine][transport][clock][tempo]") {
     // 120 held to beat 2, then 60. Two changes at the one beat, which is how a
     // step is written rather than a ramp to it (TempoMap.hpp).
+    //
+    // The callback used to be cut here, so that everything inside a block sat
+    // on one straight line and so that a modifier reading one bpm per block
+    // read the right one. Placement goes through the map now (#2336) and a
+    // modifier advances by the beats the block covers (#2340), so a step is no
+    // longer a reason to end a segment.
     TransportClock clock;
     auto snapshot = playing(0.0);
     snapshot.tempo = TempoMap({{0.0, 120.0, 0.0f}, {2.0, 120.0, 0.0f}, {2.0, 60.0, 0.0f}}, {});
@@ -322,81 +328,25 @@ TEST_CASE("A callback that crosses a tempo step is cut at it",
 
     const auto rendered = advance(clock, snapshot, static_cast<int>(kSamplesPerBeat * 2));
 
-    // Cut on the step, not around it: the callback is covered once, in order.
     requireCovers(rendered, static_cast<int>(kSamplesPerBeat * 2));
-    REQUIRE(rendered.segments.size() == 2);
+    REQUIRE(rendered.segments.size() == 1);
 
+    // One beat at 120 and then half of one at 60. The beats the block covers
+    // are the map's answer for it, which is what a modifier reads: the opening
+    // tempo alone would have said two.
     CHECK(rendered.segments[0].block.beats.start == approx(1.0));
-    CHECK(rendered.segments[0].block.beats.end == approx(2.0));
-    CHECK(rendered.segments[0].block.numSamples == static_cast<int>(kSamplesPerBeat));
-
-    // Half the tempo past it, so the same samples again are half the beats.
-    CHECK(rendered.segments[1].block.beats.start == approx(2.0));
-    CHECK(rendered.segments[1].block.beats.end == approx(2.5));
+    CHECK(rendered.segments[0].block.beats.end == approx(2.5));
+    CHECK(rendered.segments[0].block.numSamples == static_cast<int>(kSamplesPerBeat * 2));
 
     // Not a jump. Audio flows straight through a tempo change, so an op that
     // reset here would invent a gap the transport never asked for.
     CHECK(rendered.segments[0].block.continuous);
-    CHECK(rendered.segments[1].block.continuous);
-}
-
-TEST_CASE("A steep ramp leaves every block affine to within a sample",
-          "[engine][transport][clock][tempo]") {
-    // A ramp is baked into constant-tempo sections, and between two of them the
-    // slope changes as surely as it does at a step. Over this one, a beat the
-    // map puts at sample 256 of an uncut block lands at sample 93 on the
-    // block's own line.
-    //
-    // That line is what a reader without a map has: the seconds face of a
-    // shifted block, the monotonic offset a launcher works in, the crop
-    // materialSubBlock takes. Placement itself goes through the map now
-    // (RenderContext::eventForBeat), so what is asserted here is the property
-    // the cut exists to provide rather than any consumer of it: inside a block,
-    // the line and the map are the same answer to within the sample the block
-    // is allowed. Whether anything still needs that is what decides whether the
-    // cut stays (#2333).
-    TransportClock clock;
-    auto snapshot = playing(0.0);
-    snapshot.tempo = TempoMap({{0.0, 20.0, 0.0f}, {1.0, 300.0, 0.0f}}, {});
-
-    // Long enough to cross several sections: at 20 bpm a beat is three seconds,
-    // and the ramp opens with its widest ones.
-    const auto rendered = advance(clock, snapshot, static_cast<int>(kSampleRate * 2));
-    requireCovers(rendered, static_cast<int>(kSampleRate * 2));
-
-    REQUIRE(rendered.segments.size() > 1);
-
-    for (const auto& segment : rendered.segments) {
-        const auto& block = segment.block;
-        REQUIRE(block.numSamples > 0);
-
-        for (const auto through : {0.0, 0.25, 0.5, 0.75}) {
-            const auto beat = block.beats.start + through * block.beats.length();
-
-            // Where the map puts it, in samples of this block. The seconds axis
-            // is exact by construction: a block runs at one second per sample
-            // rate whatever the tempo does.
-            const auto exact =
-                (snapshot.tempo.beatToTime(beat) - block.seconds.start) * kSampleRate;
-
-            // And where the block's own two ends put it, which is the line.
-            const auto online =
-                ((beat - block.beats.start) / block.beats.length()) * block.numSamples;
-
-            CHECK(online == approx(exact).margin(1.0));
-        }
-    }
-
-    // Crossing a tempo change is not a jump. Audio flows through one, so an op
-    // that reset here would invent a gap the transport never asked for. The
-    // first segment is the exception every callback has: starting is a jump.
-    for (std::size_t i = 1; i < rendered.segments.size(); ++i)
-        CHECK(rendered.segments[i].block.continuous);
 }
 
 TEST_CASE("One tempo throughout cuts nothing", "[engine][transport][clock][tempo]") {
-    // The cut is bounded by what the map actually does: a project at one tempo
-    // has one section, so a callback is one segment however long it is.
+    // What is left ending a segment is a loop wrap and the end of a count-in. A
+    // project at one tempo has neither, so a callback is one segment however
+    // long it is.
     TransportClock clock;
     const auto snapshot = playing(0.0);
 
@@ -798,93 +748,5 @@ TEST_CASE("The monotonic seconds count rendered time, not converted beats",
         }
 
         CHECK(whole.monotonicSeconds() == approx(pieces.monotonicSeconds()));
-    }
-}
-
-TEST_CASE("A block is one tempo, which is what a rate-synced modifier reads",
-          "[engine][transport][clock][tempo][2336]") {
-    // Why the section cut stays now that placement goes through the map
-    // (#2333). A modifier synced to the tempo reads one bpm for the whole block
-    // it renders (ModLfo's modTimingFor), and so does anything else that takes
-    // a rate rather than a position: a block spanning a step would run at the
-    // tempo it opened on for the rest of itself.
-    TransportClock clock;
-    auto snapshot = playing(0.0);
-    snapshot.tempo = TempoMap({{0.0, 20.0, 0.0f}, {1.0, 300.0, 0.0f}}, {});
-
-    const auto rendered = advance(clock, snapshot, static_cast<int>(kSampleRate * 2));
-    requireCovers(rendered, static_cast<int>(kSampleRate * 2));
-
-    REQUIRE(rendered.segments.size() > 1);
-
-    for (const auto& segment : rendered.segments) {
-        const auto& block = segment.block;
-
-        // Read where the consumer reads, which is the middle of the block. Not
-        // its start: a cut lands on the first sample at or after a boundary, so
-        // a block can open a fraction of a sample before one, and the beat at
-        // its start is then in the section it is leaving while every sample it
-        // renders is in the next.
-        const auto inside = block.beats.start + (0.5 * block.beats.length());
-
-        const auto first = snapshot.tempo.timeToBeat(block.seconds.start);
-        const auto last =
-            snapshot.tempo.timeToBeat(block.seconds.start + ((block.numSamples - 1) / kSampleRate));
-
-        // Every sample the block renders is at the tempo that reading gives.
-        // The end beat is excluded and may sit past the boundary, which is why
-        // the far end is asked about by its last sample rather than by it.
-        const auto bpm = snapshot.tempo.bpmAt(inside);
-
-        CHECK(snapshot.tempo.bpmAt(first) == approx(bpm));
-        CHECK(snapshot.tempo.bpmAt(last) == approx(bpm));
-    }
-}
-
-TEST_CASE("A boundary the epsilon swallows is still cut at",
-          "[engine][transport][clock][tempo][2336]") {
-    // The hole in the guarantee above, and it is the epsilon's. A boundary
-    // within a hundredth of a sample ahead of the cursor is zero samples away,
-    // and a zero cut is no cut: the segment then runs to whatever else ends it,
-    // through that boundary and every later one in the callback. What comes out
-    // is exactly the block the cut exists to prevent, on exactly the alignment
-    // nobody would think to try.
-    //
-    // Built by choosing a tempo that puts the first boundary a hundredth of a
-    // sample past a sample, so the cut at it leaves the cursor a hundredth of a
-    // sample short of it. Swept over several fractions, because which of them
-    // the arithmetic actually lands on is not the point.
-    for (const auto fraction : {0.001, 0.005, 0.009}) {
-        // 24000 samples to the first boundary, plus the fraction of one.
-        const auto bpm = 60.0 * kSampleRate / (24000.0 + fraction);
-
-        TransportClock clock;
-        auto snapshot = playing(0.0);
-
-        // Two steps: one at beat 1, one at beat 1.5. A step is two changes at
-        // the one beat, which is how it is written rather than a ramp to it.
-        snapshot.tempo = TempoMap({{0.0, bpm, 0.0f},
-                                   {1.0, bpm, 0.0f},
-                                   {1.0, 240.0, 0.0f},
-                                   {1.5, 240.0, 0.0f},
-                                   {1.5, 60.0, 0.0f}},
-                                  {});
-
-        // Past both boundaries, so a segment that missed the first has the
-        // second to run through.
-        const auto rendered = advance(clock, snapshot, 32768);
-        requireCovers(rendered, 32768);
-
-        for (const auto& segment : rendered.segments) {
-            const auto& block = segment.block;
-
-            const auto inside = block.beats.start + (0.5 * block.beats.length());
-            const auto last = snapshot.tempo.timeToBeat(block.seconds.start +
-                                                        ((block.numSamples - 1) / kSampleRate));
-
-            INFO("fraction " << fraction << " block " << block.beats.start << ".."
-                             << block.beats.end);
-            CHECK(snapshot.tempo.bpmAt(last) == approx(snapshot.tempo.bpmAt(inside)));
-        }
     }
 }


### PR DESCRIPTION
Closes #2340. Follows #2339, which kept the tempo-section callback cut for one reason: three modifiers read a single bpm per block.

## Modifiers read the bars the block covers

`ModLfo`, `ModRandom` and `ModAdsr` each used one bpm and one signature per block to turn block seconds into a fraction of a cycle. The block already knows how far it moved: `block.beats.length()` is derived through the map by the clock and is exact across a tempo step or a baked ramp boundary inside the block. A new shared `modBarsElapsed` turns that into bars off the map, walking the signature spans inside the block and summing what each is worth in its own bar length, so a block that crosses a 4/4 to 3/4 change covers one beat over four plus one beat over three rather than two over four. On a stopped block it returns the block's seconds at the tempo and signature the cursor sits on, since a stopped block covers no beats and a free-running modifier still has to keep time. A stopped cursor is on one beat, so one bpm and one bar length are exact there. `TempoMap::signatureEndAfter` is the one new map accessor it needs.

The LFO and the random walk advance their tempo-synced ramp by bars over the rate's bar fraction. The ADSR's stage machine is unit-agnostic now, comparing an elapsed amount against stage lengths without asking which unit; a synced envelope runs in bars, and the millisecond path is unchanged. The state records which unit its accumulator counts in, so toggling tempo sync mid-stage converts through the stage phase instead of reinterpreting seconds as bars.

## The opening beat replaces the midpoint

`sectionBeat()` was a midpoint read that only made sense while the cut guaranteed one section per block. `openingBeat()` is the block's start nudged forward by the clock's own tolerance, a hundredth of a sample in seconds converted through the map at the tempo the block opens on: a block that opens that close before a boundary reads the section on the far side of it, and every other block reads the section its start is in. The block-average slope would over-nudge across a step up and under-nudge across a step down, which is why it goes through the map now that a block can span a change. `modTimingFor`, the bar position and the hosted-plugin playhead read there. The playhead's tolerance and bar-start walk-back are gone, since the opening beat already carries the tolerance.

The playhead is the one block-wide reader that cannot use a bar length: JUCE hands a plugin one bpm and one signature per call. A block spanning a step reports its first sample's section for all of it, which is what other hosts do.

## The section cut goes

Nothing reads a per-block tempo or signature while rolling any more, so `TransportClock::advance` no longer ends a segment at a section boundary, and `TempoMap::nextSectionBoundaryAfter` is removed with it; nothing else called it. What still ends a segment is a loop wrap and the end of a count-in. Dropping the cut also removes the epsilon hole found in review on #2339.

## Tests

- `test_transport_clock.cpp`: the step case asserts one continuous segment covering beats 1.0 to 2.5. "A steep ramp leaves every block affine to within a sample", "A block is one tempo" and "A boundary the epsilon swallows is still cut at" are gone; they asserted the property the cut provided.
- New `[2340]` cases in `test_mod_lfo.cpp`, `test_mod_random.cpp` and `test_mod_adsr.cpp`: a hand-built block from beat 1.5 to 2.5 across a 120-to-60 step, where the opening-tempo formula would overshoot by half; a block across a 4/4 to 3/4 change at a bar rate, where the opening-signature formula would say half a bar and the map says a quarter plus a third; and an ADSR whose tempo sync is toggled halfway through an attack and keeps its place. The stopped-transport LFO case gains a tempo-synced section.
- `test_block_samples.cpp`: `openingBeat()` across a 20-to-300 step stays in the old section when the boundary is farther than the tolerance, and across a 300-to-20 step crosses when it is within it; the block-average slope gets both wrong.
- `test_session_playback.cpp`: the launched-slot case reads the material from the launch sample inside the now uncut block.
- Full Catch2 suite: 3406 passed, 13 skipped for plugins absent from this machine, 0 failures.

https://claude.ai/code/session_01WnFtPLfo2TUoSynbysJRri
