### PR TITLE
Propagate a port's MIDI byte bound through the ops that pass MIDI through (#2341)

### DIFF
--- a/magda/daw/audio/plugins/engine/EngineExternalDevice.cpp
+++ b/magda/daw/audio/plugins/engine/EngineExternalDevice.cpp
@@ -250,6 +250,10 @@ void EngineExternalDevice::setMidiInputBoundBytes(int bytes) {
                          magda::engine::kMaxMidiBytesPerPort);
 }
 
+void EngineExternalDevice::setMidiOutputBoundBytes(int bytes) {
+    midiOutputBoundBytes_ = bytes;
+}
+
 int EngineExternalDevice::latencySamples() const {
     return latencySamples_;
 }
@@ -326,12 +330,14 @@ void EngineExternalDevice::writeMidiOut(juce::MidiBuffer& out, int numSamples) c
     // is in it afterwards, and a chain that wanted the raw input as well asks
     // the plan for it (DeviceInfo::midiInThru) rather than asking the plugin.
     //
-    // Counted in bytes against the port's budget, like every other producer.
+    // Counted in bytes against what the executor reserved for this port, which
+    // for a plugin handing its input back is that input's bound plus a
+    // producer's worth rather than the flat constant (#2341).
     int bytesWritten = 0;
 
     for (const auto metadata : midi_) {
         const auto cost = kMidiEventOverheadBytes + metadata.numBytes;
-        if (bytesWritten + cost > magda::engine::kMaxMidiBytesPerPort) {
+        if (bytesWritten + cost > midiOutputBoundBytes_) {
             jassertfalse;  // a plugin past the port's budget
             break;
         }

--- a/magda/daw/audio/plugins/engine/EngineExternalDevice.hpp
+++ b/magda/daw/audio/plugins/engine/EngineExternalDevice.hpp
@@ -124,6 +124,7 @@ class EngineExternalDevice final : public magda::engine::EngineDevice {
     void prepare(const magda::engine::RenderContext& context) override;
     void reset() override;
     void setMidiInputBoundBytes(int bytes) override;
+    void setMidiOutputBoundBytes(int bytes) override;
     int latencySamples() const override;
 
     /// One block through the plugin: its parameters written, its audio
@@ -276,6 +277,11 @@ class EngineExternalDevice final : public magda::engine::EngineDevice {
 
     int latencySamples_ = 0;
     int midiInputBoundBytes_ = magda::engine::kMaxMidiBytesPerPort;
+
+    /// What the executor reserved on the output port: this device's input
+    /// carried through plus a producer's worth of its own. A plugin handed a
+    /// merged input hands one back, and the flat constant would cut it (#2341).
+    int midiOutputBoundBytes_ = magda::engine::kMaxMidiBytesPerPort;
     bool offlineRender_ = false;
     bool prepared_ = false;
 };

--- a/magda/daw/audio/plugins/engine/EngineMagdaDevice.cpp
+++ b/magda/daw/audio/plugins/engine/EngineMagdaDevice.cpp
@@ -75,12 +75,17 @@ DeviceProperties propertiesForRequiredDevice(const std::unique_ptr<MagdaDevice>&
 /// that already owns its messages, so this is a real difference between the two
 /// hosts and it needs the SDK to close (#1836).
 ///
-/// Nothing here grows the vector. Its capacity is the most events the input
-/// port's own bound admits, so what is refused is a producer past that bound
-/// rather than an ordinary block: growing it would allocate, and one dropped
-/// event is cheaper than a callback that missed its deadline. The engine treats
-/// the same violation the same way -- assert where it is written, count it
-/// where it costs something.
+/// Nothing here grows the vector. Its capacity is the most events the wider of
+/// the device's two port bounds admits, so what is refused is a producer past
+/// that bound rather than an ordinary block: growing it would allocate, and one
+/// dropped event is cheaper than a callback that missed its deadline. The
+/// engine treats the same violation the same way -- assert where it is written,
+/// count it where it costs something.
+///
+/// The wider of the two, because one vector serves both directions: a device
+/// passing its input through and adding its own events reads and writes the
+/// same scratch, and sizing it from the input alone left a device with a full
+/// input no room to say anything of its own (#2341).
 ///
 /// That bound is a count of events and it is only half the rule. The port's
 /// budget is bytes, and the two part company on SysEx: a handful of dumps sit
@@ -274,12 +279,22 @@ void EngineMagdaDevice::setMidiInputBoundBytes(int bytes) {
     sizeMidiScratch();
 }
 
+void EngineMagdaDevice::setMidiOutputBoundBytes(int bytes) {
+    midiOutputBoundBytes_ = bytes;
+    sizeMidiScratch();
+}
+
 void EngineMagdaDevice::sizeMidiScratch() {
-    // Both callers run off the audio thread, and both run again if the other
-    // does: prepare() sizes from whatever bound is known, and the executor tells
-    // us the real one straight after. A device the plan gave no MIDI input is
-    // told zero and keeps nothing.
-    midiCapacity_ = midiEventsWithin(midiInputBoundBytes_);
+    // Every caller runs off the audio thread, and each runs again when another
+    // does: prepare() sizes from whatever bounds are known, and the executor
+    // tells us the real ones straight after.
+    //
+    // From the wider of the two, because the device reads its input out of this
+    // vector and writes its own events back into the same one. Sized from the
+    // input alone, a device handed a block that fills its input port had
+    // nowhere to put the all-notes-off it owes after a prepare (#2341). A
+    // device the plan gave neither port is told zero twice and keeps nothing.
+    midiCapacity_ = midiEventsWithin(std::max(midiInputBoundBytes_, midiOutputBoundBytes_));
 
     midiScratch_.clear();
     midiScratch_.reserve(static_cast<std::size_t>(midiCapacity_));
@@ -395,13 +410,19 @@ void EngineMagdaDevice::process(magda::engine::DeviceBlock& block) {
     // executor sized its storage from. The scratch's own guard is a count of
     // events, which is the right bound for a vector and the wrong one for this:
     // a device emitting SysEx stays far inside that count while going far past
-    // kMaxMidiBytesPerPort, and every byte over it grows a juce::MidiBuffer the
+    // the port's budget, and every byte over it grows a juce::MidiBuffer the
     // executor reserved once and a delay line downstream sized to match.
+    //
+    // Against what the executor reserved for this port, never the flat
+    // constant. The port carries this device's input through plus what it adds
+    // of its own, so a device with MIDI thru on a track with two sources may
+    // legally write more than one producer's worth; capping at the constant
+    // dropped half of it here, whatever the plan had made room for (#2341).
     int bytesWritten = 0;
 
     for (const auto& event : midiScratch_) {
         const auto cost = kMidiEventOverheadBytes + event.message.getRawDataSize();
-        if (bytesWritten + cost > magda::engine::kMaxMidiBytesPerPort) {
+        if (bytesWritten + cost > midiOutputBoundBytes_) {
             jassertfalse;  // a device past the port's budget; see the view's comment
             break;
         }

--- a/magda/daw/audio/plugins/engine/EngineMagdaDevice.hpp
+++ b/magda/daw/audio/plugins/engine/EngineMagdaDevice.hpp
@@ -82,6 +82,7 @@ class EngineMagdaDevice final : public magda::engine::EngineDevice {
     void prepare(const magda::engine::RenderContext& context) override;
     void reset() override;
     void setMidiInputBoundBytes(int bytes) override;
+    void setMidiOutputBoundBytes(int bytes) override;
     int latencySamples() const override;
     void process(magda::engine::DeviceBlock& block) override;
 
@@ -126,6 +127,12 @@ class EngineMagdaDevice final : public magda::engine::EngineDevice {
     /// until it says otherwise, so a host that never tells us is no worse off
     /// than before it could.
     int midiInputBoundBytes_ = magda::engine::kMaxMidiBytesPerPort;
+
+    /// What the executor reserved on the output port, which is the input's
+    /// bound plus a producer's worth: a device passing a merged input through
+    /// emits the merge, and the constant would cut it in half. The constant
+    /// until the executor says otherwise, for the reason above (#2341).
+    int midiOutputBoundBytes_ = magda::engine::kMaxMidiBytesPerPort;
 
     double sampleRate_ = 44100.0;
     int latencySamples_ = 0;

--- a/magda/engine/exec/EngineDevice.hpp
+++ b/magda/engine/exec/EngineDevice.hpp
@@ -75,8 +75,9 @@ struct DeviceBlock {
     const juce::MidiBuffer* midiIn = nullptr;
 
     /// Where a MIDI-producing device writes, cleared before the call. Null when
-    /// the plan gave the device no MIDI output port. At most
-    /// kMaxMidiBytesPerPort of encoded MIDI; past that the buffer allocates.
+    /// the plan gave the device no MIDI output port. At most what
+    /// setMidiOutputBoundBytes said, which for a device that passes its input
+    /// through is more than kMaxMidiBytesPerPort; past it the buffer allocates.
     juce::MidiBuffer* midiOut = nullptr;
 
     /// Sidechain audio. A zero-channel block when the slot is unconnected, so
@@ -159,6 +160,29 @@ class EngineDevice {
      * lies and never need to know how big it can get.
      */
     virtual void setMidiInputBoundBytes(int) {}
+
+    /**
+     * @brief The most encoded MIDI this device may write in one block.
+     *
+     * Called off the audio thread beside setMidiInputBoundBytes, by the same
+     * executor and for the same reason: the figure belongs to the plan and no
+     * device can work it out for itself.
+     *
+     * Not kMaxMidiBytesPerPort either. A device that passes its MIDI input
+     * through is a conduit, and a conduit fed a merge emits a merge: held to
+     * one producer's budget it would drop half of a legal two-source stream on
+     * the way out, and no choice about which half is a good one. So the
+     * executor reserves a device's MIDI output port its input's bound plus one
+     * producer's worth on top, and that sum is what arrives here. The headroom
+     * is for what the device adds of its own -- a pattern, an arpeggio, the
+     * all-notes-off it owes after a prepare -- which is the same budget every
+     * other producer in the graph is held to. Zero for a device the plan gave
+     * no MIDI output.
+     *
+     * Ignored by default, because a device that writes what it means to write
+     * and no more never comes near it.
+     */
+    virtual void setMidiOutputBoundBytes(int) {}
 
     /// Samples the device delays its output by. Read but not yet compensated:
     /// latency compensation is its own slice, and the executor reports any

--- a/magda/engine/exec/PlanExecutor.cpp
+++ b/magda/engine/exec/PlanExecutor.cpp
@@ -655,7 +655,14 @@ std::vector<std::string> PlanExecutor::prepare(const RenderPlan& plan, const Pla
             continue;
         }
 
-        if (op.kind != OpKind::MergeMidi && op.kind != OpKind::Fader)
+        // Everything that carries MIDI on from what reached it. A merge is the
+        // obvious one and a fader carries a rack chain's MIDI out beside its
+        // audio, but a conduit is a conduit: a note gate passes on whatever
+        // falls in its range, and a device with MIDI thru switched on passes on
+        // the lot. Leaving those two out is how a device fed a legal merged
+        // input could only emit one producer's worth of it (#2341).
+        if (op.kind != OpKind::MergeMidi && op.kind != OpKind::Fader &&
+            op.kind != OpKind::MidiNoteGate && op.kind != OpKind::Device)
             continue;
 
         int carried = 0;
@@ -668,6 +675,15 @@ std::vector<std::string> PlanExecutor::prepare(const RenderPlan& plan, const Pla
                 continue;
             carried += portMidiBytes[flatPort(input)];
         }
+
+        // A device is a conduit and a producer at once, and the two add up: it
+        // may hand its whole input on and place its own events among them. One
+        // producer's worth of headroom is what it may add, which is the budget
+        // every other producer in the graph is held to and what the external
+        // adapter already sizes its own buffer by. A device with no MIDI input
+        // is left at exactly that, which is where every port starts.
+        if (op.kind == OpKind::Device)
+            carried += kMaxMidiBytesPerPort;
 
         for (std::size_t port = 0; port < op.outputs.size(); ++port)
             if (op.outputs[port].kind == SignalKind::Midi)
@@ -689,15 +705,22 @@ std::vector<std::string> PlanExecutor::prepare(const RenderPlan& plan, const Pla
     for (std::size_t slot = 0; slot < midiSlots_.size(); ++slot)
         midiSlots_[slot].ensureSize(static_cast<std::size_t>(midiByteBounds_[slot]));
 
-    // Tell every bound device how much MIDI can reach it, now that the sums are
-    // known and while there is still a thread that may allocate.
+    // Tell every bound device how much MIDI can reach it and how much it may
+    // write, now that the sums are known and while there is still a thread that
+    // may allocate.
     //
-    // A device that buffers its input cannot work this out for itself:
-    // kMaxMidiBytesPerPort is what one producer may write, and a device fed by
-    // a merge is fed the sum of several. Sizing from the constant is how a
-    // device on a track with two MIDI sources silently drops the second one's
-    // tail. The executor is the only thing that knows, so it is the thing that
+    // A device can work out neither for itself: kMaxMidiBytesPerPort is what
+    // one producer may write, a device fed by a merge is fed the sum of
+    // several, and a device that hands that on emits the sum too. Sizing from
+    // the constant is how a device on a track with two MIDI sources silently
+    // drops the second one's tail on the way in, and truncates it on the way
+    // out. The executor is the only thing that knows, so it is the thing that
     // says.
+    //
+    // The input is the slot's bound and the output is the port's own. A slot
+    // holds the largest of the ports sharing it, which is the right size for a
+    // buffer to read from and the wrong figure to write against: everything
+    // downstream reserved its room from this port's sum, not its neighbour's.
     for (std::size_t i = 0; i < numOps; ++i) {
         auto* device = deviceForOp_[i];
         if (device == nullptr)
@@ -707,6 +730,10 @@ std::vector<std::string> PlanExecutor::prepare(const RenderPlan& plan, const Pla
         const auto hasMidiIn = op.inputs.size() > 1 && op.inputs[1].valid();
         device->setMidiInputBoundBytes(
             hasMidiIn ? midiByteBounds_[static_cast<std::size_t>(slotFor(op.inputs[1]))] : 0);
+
+        const auto hasMidiOut = op.outputs.size() > 1 && op.outputs[1].kind == SignalKind::Midi;
+        device->setMidiOutputBoundBytes(
+            hasMidiOut ? portMidiBytes[static_cast<std::size_t>(portOffsets_[i]) + 1] : 0);
     }
 
     // Delay lines, for the edges that turned out to need one. A plan with no
@@ -1483,7 +1510,12 @@ void PlanExecutor::renderOp(OpId id, const OpValue& published, const BlockInfo& 
                 else
                     slot.clear();
             }
-            jassert(deviceMidiOut == nullptr || deviceMidiOut->data.size() <= kMaxMidiBytesPerPort);
+            // The port's reservation, not the flat constant: a device passing a
+            // merged input through legally writes more than one producer's
+            // worth, and that is what its port was sized for (#2341).
+            jassert(deviceMidiOut == nullptr ||
+                    deviceMidiOut->data.size() <=
+                        midiByteBounds_[static_cast<std::size_t>(slotFor(PortRef{id, 1}))]);
             break;
         }
 

--- a/tests/engine/test_engine_device_layer.cpp
+++ b/tests/engine/test_engine_device_layer.cpp
@@ -133,7 +133,7 @@ class EmittingDevice final : public magda::daw::audio::MagdaDevice {
     std::vector<std::uint8_t> payload_;
 };
 
-/// Records what the executor told it, and renders nothing.
+/// Records what the executor told it about either port, and renders nothing.
 class BoundProbe final : public magda::engine::EngineDevice {
   public:
     void process(magda::engine::DeviceBlock&) override {}
@@ -142,7 +142,12 @@ class BoundProbe final : public magda::engine::EngineDevice {
         bound = bytes;
     }
 
+    void setMidiOutputBoundBytes(int bytes) override {
+        outBound = bytes;
+    }
+
     int bound = -1;
+    int outBound = -1;
 };
 
 /// Rewrites, reorders and drops what it was handed, on messages big enough to
@@ -429,21 +434,15 @@ TEST_CASE("a step sequencer passing MIDI through keeps the whole legal block",
     const auto context = contextFor();
     hosted.prepare(context);
 
-    // One block first, to spend the all-notes-off a freshly prepared device
-    // owes. A port's budget is the OUTPUT's as well as the input's, so a block
-    // that already fills it leaves no room for anything the device adds on top
-    // - the asymmetry between an input bound the executor sums across producers
-    // and an output bound fixed at kMaxMidiBytesPerPort is the engine's to
-    // settle, not this device's. What passing through guarantees, and what this
-    // asserts, is that the device itself takes nothing out.
-    {
-        Block warmUp(context);
-        warmUp.info.playing = false;
-        juce::MidiBuffer warmUpOut;
-        auto warmUpBlock = warmUp.deviceBlock();
-        warmUpBlock.midiOut = &warmUpOut;
-        hosted.process(warmUpBlock);
-    }
+    // What the executor tells a device fed by one producer: a port's worth in,
+    // and that carried through plus a producer's worth of its own on the way
+    // out. Said rather than assumed, which is the whole of #2341 -- the block
+    // below fills the input port to the byte, and the all-notes-off a freshly
+    // prepared device owes is what tipped the total past a flat
+    // kMaxMidiBytesPerPort and was refused. This test used to spend that
+    // all-notes-off on a warm-up block to stay out of its way.
+    hosted.setMidiInputBoundBytes(magda::engine::kMaxMidiBytesPerPort);
+    hosted.setMidiOutputBoundBytes(2 * magda::engine::kMaxMidiBytesPerPort);
 
     Block block(context);
     // Stopped, so the sequencer writes nothing of its own and what comes out is
@@ -464,10 +463,13 @@ TEST_CASE("a step sequencer passing MIDI through keeps the whole legal block",
 
     int clocks = 0;
     int noteOffs = 0;
+    int allNotesOffs = 0;
     for (const auto metadata : out) {
         const auto message = metadata.getMessage();
         if (message.isMidiClock())
             ++clocks;
+        else if (message.isAllNotesOff())
+            ++allNotesOffs;
         else if (message.isNoteOff())
             ++noteOffs;
     }
@@ -476,6 +478,68 @@ TEST_CASE("a step sequencer passing MIDI through keeps the whole legal block",
     // The note-off is the last event in. Losing it is what leaves the
     // instrument downstream holding the note.
     CHECK(noteOffs == 1);
+    // And the device's own event survived a block that already filled the input
+    // port, because the output port was told it had room for it.
+    CHECK(allNotesOffs == 1);
+}
+
+TEST_CASE("a device passing a merged input through emits all of it", "[engine][devices][2341]") {
+    // A device's input port is often a merge, and the executor sums the bound
+    // across the producers feeding it for that reason. Its output port is the
+    // same stream on the way out whenever the device passes MIDI through, and
+    // an output held to one producer's budget dropped everything past the
+    // halfway point of a legal two-source block -- at the adapter, where the
+    // device has no say in what goes.
+    //
+    // Two producers' worth of clocks, which no arrangement of one producer can
+    // reach.
+    constexpr int kEventOverheadBytes = magda::engine::kMidiShortMessageBytes - 3;
+    constexpr int kInputBound = 2 * magda::engine::kMaxMidiBytesPerPort;
+    constexpr int kClocks = kInputBound / (kEventOverheadBytes + 1);
+
+    auto sequencer = std::make_unique<magda::daw::audio::StepSequencerPlugin>();
+    sequencer->midiThru.store(true);
+
+    adapter::EngineMagdaDevice hosted(std::move(sequencer), /*offlineRender=*/false);
+    const auto context = contextFor();
+    hosted.prepare(context);
+    hosted.setMidiInputBoundBytes(kInputBound);
+    hosted.setMidiOutputBoundBytes(kInputBound + magda::engine::kMaxMidiBytesPerPort);
+
+    Block block(context);
+    // Stopped, so what comes out is the input plus the all-notes-off the device
+    // owes, and nothing it decided to play.
+    block.info.playing = false;
+    for (int event = 0; event < kClocks; ++event)
+        block.midi.addEvent(juce::MidiMessage::midiClock(), event % context.maxBlockSize);
+
+    REQUIRE(block.midi.getNumEvents() == kClocks);
+    REQUIRE(budgetCostOf(block.midi) <= kInputBound);
+    REQUIRE(budgetCostOf(block.midi) > magda::engine::kMaxMidiBytesPerPort);
+
+    juce::MidiBuffer out;
+    auto deviceBlock = block.deviceBlock();
+    deviceBlock.midiOut = &out;
+    hosted.process(deviceBlock);
+
+    int clocks = 0;
+    int allNotesOffs = 0;
+    for (const auto metadata : out) {
+        const auto message = metadata.getMessage();
+        if (message.isMidiClock())
+            ++clocks;
+        else if (message.isAllNotesOff())
+            ++allNotesOffs;
+    }
+
+    CHECK(clocks == kClocks);
+
+    // And the device's own event on top of that, which is what the headroom
+    // above the input's bound is for. The adapter decodes the block into one
+    // scratch and the device writes its own events back into the same one, so
+    // a scratch sized from the input alone refuses this even where the output
+    // port has room for it.
+    CHECK(allNotesOffs == 1);
 }
 
 TEST_CASE("the adapter carries a merged input, not one producer's worth",
@@ -552,6 +616,64 @@ TEST_CASE("the executor tells a device what can reach its MIDI input", "[engine]
     // rather than being left at whatever it assumed.
     CHECK(synthProbe.bound >= magda::engine::kMaxMidiBytesPerPort);
     CHECK(gainProbe.bound == 0);
+}
+
+TEST_CASE("the executor tells a device what it may write, its input carried through",
+          "[engine][devices][2341]") {
+    // The other half of the same fact, and the half nothing used to say. A
+    // device is a conduit as well as a producer: with MIDI thru on it hands its
+    // whole input to the port and places its own events among them, so what it
+    // may write is what reached it plus one producer's worth. A flat
+    // kMaxMidiBytesPerPort is a producer's budget, and it is what the adapter
+    // truncated a legal merged block against.
+    //
+    // Clips and a hardware input both merge onto this track, so the figure
+    // being propagated is two producers' worth rather than one -- exactly the
+    // sum a device could not have worked out for itself.
+    magda::TrackInfo instrument;
+    instrument.id = 1;
+    instrument.type = magda::TrackType::Media;
+    instrument.name = "Instrument";
+    instrument.recordArmed = true;  // what makes the input route active
+    instrument.midiInputDevice = "midi-hardware";
+
+    auto synth = magda::nulldiff::synthDevice(10);
+    synth.producesMidi = true;  // so the plan gives the op a MIDI output port
+    instrument.chain.fxChainElements.emplace_back(synth);
+
+    magda::TrackInfo effect;
+    effect.id = 2;
+    effect.type = magda::TrackType::Media;
+    effect.name = "Effect";
+    effect.chain.fxChainElements.emplace_back(magda::nulldiff::gainDevice(20));
+
+    magda::TrackInfo master;
+    master.id = magda::MASTER_TRACK_ID;
+    master.type = magda::TrackType::Master;
+    master.name = "Master";
+
+    const auto plan = magda::engine::compileRenderPlan({instrument, effect}, master);
+
+    BoundProbe synthProbe;
+    BoundProbe gainProbe;
+
+    magda::engine::PlanBindings bindings;
+    for (const auto& op : plan.ops)
+        if (op.kind == magda::engine::OpKind::Device)
+            bindings.devices[op.key.deviceKey()] =
+                op.key.deviceId == 10 ? static_cast<magda::engine::EngineDevice*>(&synthProbe)
+                                      : static_cast<magda::engine::EngineDevice*>(&gainProbe);
+
+    magda::engine::PlanExecutor executor;
+    executor.prepare(plan, bindings, contextFor(), nullptr, nullptr);
+    REQUIRE(executor.isPrepared());
+
+    REQUIRE(synthProbe.bound == 2 * magda::engine::kMaxMidiBytesPerPort);
+    CHECK(synthProbe.outBound == synthProbe.bound + magda::engine::kMaxMidiBytesPerPort);
+
+    // The gain emits no MIDI at all, and is told so rather than being left at
+    // whatever it assumed.
+    CHECK(gainProbe.outBound == 0);
 }
 
 TEST_CASE("a device may rewrite, reorder and drop long messages", "[engine][devices][2174]") {

--- a/tests/engine/test_plan_note_gate.cpp
+++ b/tests/engine/test_plan_note_gate.cpp
@@ -140,6 +140,20 @@ juce::MidiMessage noteOn(int note) {
     return juce::MidiMessage::noteOn(1, note, 1.0f);
 }
 
+/// Records the input bound the executor told it, and renders nothing.
+class BoundProbe final : public EngineDevice {
+  public:
+    void process(DeviceBlock& block) override {
+        block.audio.clear();
+    }
+
+    void setMidiInputBoundBytes(int bytes) override {
+        bound = bytes;
+    }
+
+    int bound = -1;
+};
+
 }  // namespace
 
 TEST_CASE("A note gate passes only the notes in its range", "[engine][exec][notegate]") {
@@ -208,4 +222,80 @@ TEST_CASE("A note gate is a MidiNoteGate in a plan dump", "[engine][exec][notega
     CHECK(std::string(magda::engine::toString(magda::engine::OpRole::PadNoteGate)) ==
           "padNoteGate");
     CHECK(magda::engine::arityOf(OpKind::MidiNoteGate) == 1);
+}
+
+TEST_CASE("A note gate carries its input's MIDI bound to what it feeds",
+          "[engine][exec][notegate][2341]") {
+    // A gate is a pure conduit: everything it emits arrived, so its port has to
+    // be reserved for what reached it. The forward pass recomputed the bound
+    // for a merge and left every other op at one producer's budget, which made
+    // a gate the place a two-source stream stopped being one -- the pad's
+    // sampler was told 4096 for an input carrying 8192, and sized whatever it
+    // buffers from a figure half the truth.
+    RenderPlan plan;
+
+    for (int source = 0; source < 2; ++source) {
+        magda::engine::PlanOp input;
+        input.kind = OpKind::MidiInput;
+        input.key.trackId = 1;
+        input.key.role = magda::engine::OpRole::LiveMidiInput;
+        input.key.index = source;
+        input.outputs = {SignalKind::Midi};
+        plan.ops.push_back(input);
+    }
+
+    magda::engine::PlanOp merge;
+    merge.kind = OpKind::MergeMidi;
+    merge.key.trackId = 1;
+    merge.key.role = magda::engine::OpRole::TrackMidiInput;
+    merge.inputs = {PortRef{0, 0}, PortRef{1, 0}};
+    merge.outputs = {SignalKind::Midi};
+    plan.ops.push_back(merge);
+
+    magda::engine::PlanOp gate;
+    gate.kind = OpKind::MidiNoteGate;
+    gate.key.trackId = 1;
+    gate.key.rackId = 5;
+    gate.key.chainId = 2;
+    gate.key.role = magda::engine::OpRole::PadNoteGate;
+    gate.inputs = {PortRef{2, 0}};
+    gate.outputs = {SignalKind::Midi};
+    gate.noteGateLow = 36;
+    gate.noteGateHigh = 39;
+    plan.ops.push_back(gate);
+
+    magda::engine::PlanOp device;
+    device.kind = OpKind::Device;
+    device.key.trackId = 1;
+    device.key.rackId = 5;
+    device.key.chainId = 2;
+    device.key.deviceId = 9;
+    device.key.role = magda::engine::OpRole::DeviceProcess;
+    device.inputs = {PortRef{}, PortRef{3, 0}, PortRef{}};
+    device.outputs = {SignalKind::Audio};
+    plan.ops.push_back(device);
+
+    magda::engine::PlanOp out;
+    out.kind = OpKind::Output;
+    out.key.trackId = 1;
+    out.key.role = magda::engine::OpRole::HardwareOutput;
+    out.inputs = {PortRef{4, 0}};
+    plan.ops.push_back(out);
+
+    plan.outputOps = {5};
+    magda::engine::bakeScheduling(plan);
+
+    BoundProbe probe;
+    PlanBindings bindings;
+    NoteSource source({});
+    bindings.midiInputs[1] = &source;
+    bindings.devices[DeviceKey{9}] = &probe;
+
+    PlanExecutor executor;
+    const auto messages = executor.prepare(plan, bindings, RenderContext{44100.0, kBlockSize, 2});
+    for (const auto& message : messages)
+        UNSCOPED_INFO("prepare: " << message);
+    REQUIRE(executor.isPrepared());
+
+    CHECK(probe.bound == 2 * magda::engine::kMaxMidiBytesPerPort);
 }


### PR DESCRIPTION
Closes #2341.

## The gap

A device was told how much MIDI could reach it and nothing about how much it could emit.

`PlanExecutor::prepare` sums the byte budget forward through the MIDI graph, but it recomputed the figure for `MergeMidi`, `Fader` and `Delay` only — every other port kept the flat `kMaxMidiBytesPerPort` it started at. That models a device as a *producer*: writes at most one producer's worth. Devices are *conduits* whenever they pass MIDI through, and `MidiNoteGate` is a pure conduit with the identical gap.

So a passthrough device handed a legal 8192-byte merged input could emit 4096 of it. Half the stream died at `EngineMagdaDevice`, and nothing the device did changed which half.

## The fix

- **`Device` and `MidiNoteGate` carry their MIDI input's bound to their output port.** A gate emits only what arrived, so its port is its input's. A device is a conduit *and* a producer, so its port is its input's plus one producer's worth of headroom for what it adds of its own — a pattern, an arpeggio, the all-notes-off it owes after a prepare. That is the same budget every other producer is held to, and the figure `EngineExternalDevice` already sized its own buffer by.
- **`EngineDevice::setMidiOutputBoundBytes`** beside the input one. The executor tells every bound device its port's own figure; both adapters cap their write-back on that instead of on the constant. The input stays the *slot's* bound (the right size for a buffer to read from); the output is the *port's* own (everything downstream reserved its room from this port's sum, not its neighbour's).
- **`EngineMagdaDevice`'s scratch was the same bug one layer down.** One vector serves both directions — the device reads its input out of it and writes its own events back into it — and sized from the input bound alone, a device handed a block that filled its input port had nowhere to put its own all-notes-off. Sized from the wider of the two bounds now.

The Tracktion path has no count bound at all, so nothing changes there.

## Tests

Three new cases, each verified negatively (reverted the fix, watched it fail):

| Test | Without the fix |
|---|---|
| `a device passing a merged input through emits all of it` | 585 of 1170 clocks arrive, and the device's own event is refused by the scratch |
| `the executor tells a device what it may write, its input carried through` | output bound is 4096 for an input of 8192 |
| `A note gate carries its input's MIDI bound to what it feeds` | the pad's device is told 4096 for an input carrying 8192 |

`a step sequencer passing MIDI through keeps the whole legal block` no longer spends the all-notes-off on a warm-up block to stay out of the assertion's way — that warm-up existed only because of this asymmetry — and now asserts the device's own event survives a block that already fills the input port.

Full suite: 3422 passed, 13 skipped, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018rAnjCekXfSQtpsr7jLtj5