### PR TITLE
A track sounds one section, and both edges of the switch are ramped (#2302)

### DIFF
--- a/magda/engine/clip/ClipAudioSource.cpp
+++ b/magda/engine/clip/ClipAudioSource.cpp
@@ -24,8 +24,8 @@ ClipAudioSource::ClipAudioSource(TrackId trackId, ClipSnapshotFeed& clips, ClipS
     : trackId_(trackId), clips_(clips), streams_(streams) {}
 
 ClipAudioSource::ClipAudioSource(TrackId trackId, ClipSnapshotFeed& clips, ClipStreamFeed& streams,
-                                 LaunchHandleFeed& handles)
-    : trackId_(trackId), clips_(clips), streams_(streams), handles_(&handles) {}
+                                 LaunchHandleFeed& handles, Section section)
+    : trackId_(trackId), clips_(clips), streams_(streams), handles_(&handles), section_(section) {}
 
 void ClipAudioSource::prepare(const RenderContext& context) {
     // Longer than a block, because a clip playing faster than its file consumes
@@ -104,6 +104,11 @@ void ClipAudioSource::gatherSession(const TrackClipPlayback& track, const BlockI
 
     // The status is the launcher's, worked out before anything rendered
     // (SessionLauncher.hpp), so this source and the MIDI one see the same block.
+    // Whether anything is still sounding when the block ends, gathered in the
+    // one walk that renders: a track with a slot still going has not stepped,
+    // whatever its other slots did.
+    auto stillSounding = false;
+
     const auto renderSlot = [&](const SessionSlotPlayback& slot, const SplitStatus& status) {
         const auto play = [&](const BlockPiece& piece, int offset, int count) {
             if (count <= 0 || !piece.origin)
@@ -114,20 +119,103 @@ void ClipAudioSource::gatherSession(const TrackClipPlayback& track, const BlockI
             gather(slot.audio, material, offset, streams, sounding, soundingCount);
         };
 
-        // What is on the far side of the event is not rendered. The ramp
-        // across that boundary is #2302's.
         const auto split = splitSample(block, status).value;
 
         play(status.beforeEvent, 0, split);
 
         if (status.afterEvent)
             play(*status.afterEvent, split, block.numSamples - split);
+
+        // Where this slot stopped sounding, for the ramp that takes the step
+        // out of it. A slot still sounding at the end of the block leaves no
+        // step, and one that stopped in an earlier block has none left here.
+        if (status.beforeEvent.playing() && !status.playingAtEnd())
+            sessionSilentFrom_ = std::max(sessionSilentFrom_.value_or(0), split);
+
+        stillSounding = stillSounding || status.playingAtEnd();
     };
 
     forEachSlot(*handles.get(), track, renderSlot);
+
+    // The ramp is bound to the same grain as the signal it corrects, which is
+    // the track: the op is per track because a track sounds one session clip at
+    // a time, so a sum that did not step needs no correction.
+    if (stillSounding)
+        sessionSilentFrom_.reset();
 }
 
 void ClipAudioSource::render(const BlockInfo& block, juce::dsp::AudioBlock<float> out) {
+    // Cleared for the block rather than by whatever gathers, because every path
+    // through the render can return before the gather does: a stale edge would
+    // de-click a second time, blocks after the stop it belongs to.
+    sessionSilentFrom_.reset();
+
+    renderMaterial(block, out);
+
+    switch (section_) {
+        case Section::Arrangement:
+            // Only a source that shares its track with a session has a section
+            // to lose it to. One built without the feed is the whole track.
+            if (handles_ != nullptr)
+                applySectionHold(out);
+            break;
+
+        case Section::Session:
+            if (sessionSilentFrom_) {
+                sessionStop_.begin(out, *sessionSilentFrom_, kSectionDeClickSamples);
+            } else {
+                sessionStop_.advance(out);
+
+                // What sounded, remembered for a stop that lands on the first
+                // sample of some later block.
+                sessionStop_.push(out);
+            }
+            break;
+    }
+}
+
+void ClipAudioSource::applySectionHold(juce::dsp::AudioBlock<float> out) {
+    const LaunchHandleFeed::Reader handles(*handles_);
+    const auto hold = handles ? sectionHold(*handles.get(), trackId_) : SectionHold{};
+
+    if (!hold.session) {
+        // The track is the arrangement's. Coming back to it lands mid-material,
+        // which is the same step a voice starting mid-file leaves and comes out
+        // the same way.
+        if (wasHeld_)
+            handBack_.begin(out, kSectionDeClickSamples);
+        else
+            handBack_.advance(out);
+
+        // A hand-over taken back inside its own ramp finishes into the material
+        // rather than being cut off, which would be the click it exists to
+        // remove.
+        handOver_.advance(out);
+        handOver_.push(out);
+
+        wasHeld_ = false;
+        return;
+    }
+
+    // The session has the track. What the arrangement rendered still advanced
+    // every voice, stream and stretcher, which is what makes handing the track
+    // back land where the timeline says rather than where the arrangement was
+    // when it lost it. Only the output is dropped.
+    const auto numSamples = static_cast<int>(out.getNumSamples());
+    const auto from = wasHeld_ ? 0 : std::clamp(hold.takenAt.value, 0, numSamples);
+
+    out.getSubBlock(static_cast<std::size_t>(from)).clear();
+
+    if (wasHeld_)
+        handOver_.advance(out);
+    else
+        handOver_.begin(out, from, kSectionDeClickSamples);
+
+    handBack_.reset();
+    wasHeld_ = true;
+}
+
+void ClipAudioSource::renderMaterial(const BlockInfo& block, juce::dsp::AudioBlock<float> out) {
     out.clear();
 
     const ClipStreamFeed::Reader streams(streams_);
@@ -195,10 +283,10 @@ void ClipAudioSource::render(const BlockInfo& block, juce::dsp::AudioBlock<float
     std::array<Sounding, kMaxVoicesPerTrack> sounding;
     auto soundingCount = 0;
 
-    if (handles_ == nullptr)
-        gather(track->audio, lane, 0, table, sounding, soundingCount);
-    else
+    if (section_ == Section::Session)
         gatherSession(*track, lane, table, sounding, soundingCount);
+    else
+        gather(track->audio, lane, 0, table, sounding, soundingCount);
 
     for (auto& voice : voices_) {
         if (voice.clipId() == INVALID_CLIP_ID)

--- a/magda/engine/clip/ClipAudioSource.cpp
+++ b/magda/engine/clip/ClipAudioSource.cpp
@@ -161,16 +161,15 @@ void ClipAudioSource::render(const BlockInfo& block, juce::dsp::AudioBlock<float
 }
 
 void ClipAudioSource::applySectionHold(juce::dsp::AudioBlock<float> out) {
-    const LaunchHandleFeed::Reader handles(*handles_);
-    const auto hold = handles ? sectionHold(*handles.get(), trackId_) : SectionHold{};
-
     const auto numSamples = static_cast<int>(out.getNumSamples());
-    const auto until = std::clamp(hold.arrangementUntil(numSamples).value, 0, numSamples);
+
+    const LaunchHandleFeed::Reader handles(*handles_);
+    const auto hold = handles ? sectionHold(*handles.get(), trackId_, numSamples) : SectionHold{};
+
+    const auto until = std::clamp(hold.until.value, 0, numSamples);
 
     // What it rendered and gets to keep, before anything corrects it, which is
-    // the order StopDeClick::push asks for. Empty when the session already owned
-    // the first sample, and the ramp then carries down what the block before
-    // pushed, which is the same sample on the other side of a boundary.
+    // the order StopDeClick::push asks for.
     if (until > 0)
         handOver_.push(out.getSubBlock(0, static_cast<std::size_t>(until)));
 
@@ -183,7 +182,7 @@ void ClipAudioSource::applySectionHold(juce::dsp::AudioBlock<float> out) {
 
     // Taking the track back lands mid-material, which is the same step a voice
     // starting mid-file leaves and comes out the same way.
-    if (hold.handedBack && hold.atStart == Section::Arrangement)
+    if (hold.gained)
         handBack_.begin(out, kSectionDeClickSamples);
     else
         handBack_.advance(out);
@@ -191,7 +190,7 @@ void ClipAudioSource::applySectionHold(juce::dsp::AudioBlock<float> out) {
     // Losing it leaves the other step. A ramp still running from an earlier
     // block finishes into whatever is here now rather than being cut off, which
     // would be the click it exists to remove.
-    if (until < numSamples && hold.atStart == Section::Arrangement)
+    if (hold.lost)
         handOver_.begin(out, until, kSectionDeClickSamples);
     else
         handOver_.advance(out);

--- a/magda/engine/clip/ClipAudioSource.cpp
+++ b/magda/engine/clip/ClipAudioSource.cpp
@@ -43,8 +43,10 @@ ClipVoice* ClipAudioSource::voiceFor(ClipId clipId, EventId eventId) {
         if (voice.playing(clipId, eventId))
             return &voice;
 
+    // A voice still carrying a release ramp holds no entry and yet is still
+    // sounding, so claiming it would cut the tail it is in the middle of.
     for (auto& voice : voices_)
-        if (voice.clipId() == INVALID_CLIP_ID)
+        if (voice.clipId() == INVALID_CLIP_ID && !voice.fading())
             return &voice;
 
     return nullptr;
@@ -104,14 +106,6 @@ void ClipAudioSource::gatherSession(const TrackClipPlayback& track, const BlockI
 
     // The status is the launcher's, worked out before anything rendered
     // (SessionLauncher.hpp), so this source and the MIDI one see the same block.
-    // Whether some other slot sounded right across the block. Only that masks
-    // another slot's stop: the ramp reads the step off the summed buffer, and a
-    // slot that was already sounding before the stop sample is still in that
-    // sum afterwards, so decaying it would correct for a signal that never
-    // stopped. A slot that starts where another stops was not in the sum
-    // before, so the value at the stop is the outgoing slot's alone.
-    auto soundedThroughout = false;
-
     const auto renderSlot = [&](const SessionSlotPlayback& slot, const SplitStatus& status) {
         const auto play = [&](const BlockPiece& piece, int offset, int count) {
             if (count <= 0 || !piece.origin)
@@ -129,50 +123,41 @@ void ClipAudioSource::gatherSession(const TrackClipPlayback& track, const BlockI
         if (status.afterEvent)
             play(*status.afterEvent, split, block.numSamples - split);
 
-        // Where this slot stopped sounding, for the ramp that takes the step out
-        // of it. The handle's answer rather than the shape of the split, so a
-        // stop on the block's first sample is the same edge as one half way
-        // through it (LaunchHandle::silencedAt).
-        if (const auto silenced = status.silencedAt())
-            sessionSilentFrom_ = std::max(sessionSilentFrom_.value_or(0), silenced->value);
+        // Where this slot stopped sounding, noted per clip rather than per
+        // track: the ramp is the voice's own (ClipVoice::releaseInto), so
+        // whether some other slot goes on sounding through the same samples
+        // does not come into it. The handle's answer rather than the shape of
+        // the split, so a stop on the block's first sample is the same edge as
+        // one half way through it (LaunchHandle::silencedAt).
+        const auto silenced = status.silencedAt();
+        if (!silenced)
+            return;
 
-        soundedThroughout = soundedThroughout || (status.soundingAtStart && status.playingAtEnd());
+        for (const auto& clip : slot.audio)
+            for (const auto& event : clip.events) {
+                if (stoppingCount_ >= kMaxVoicesPerTrack)
+                    return;
+
+                stopping_[static_cast<std::size_t>(stoppingCount_++)] =
+                    Stopping{clip.clipId, event.eventId, silenced->value};
+            }
     };
 
     forEachSlot(*handles.get(), track, renderSlot);
-
-    if (soundedThroughout)
-        sessionSilentFrom_.reset();
 }
 
 void ClipAudioSource::render(const BlockInfo& block, juce::dsp::AudioBlock<float> out) {
     // Cleared for the block rather than by whatever gathers, because every path
     // through the render can return before the gather does: a stale edge would
-    // de-click a second time, blocks after the stop it belongs to.
-    sessionSilentFrom_.reset();
+    // release a voice a second time, blocks after the stop it belongs to.
+    stoppingCount_ = 0;
 
     renderMaterial(block, out);
 
-    switch (section_) {
-        case Section::Arrangement:
-            // Only a source that shares its track with a session has a section
-            // to lose it to. One built without the feed is the whole track.
-            if (handles_ != nullptr)
-                applySectionHold(out);
-            break;
-
-        case Section::Session:
-            if (sessionSilentFrom_) {
-                sessionStop_.begin(out, *sessionSilentFrom_, kSectionDeClickSamples);
-            } else {
-                sessionStop_.advance(out);
-
-                // What sounded, remembered for a stop that lands on the first
-                // sample of some later block.
-                sessionStop_.push(out);
-            }
-            break;
-    }
+    // Only a source that shares its track with a session has a section to lose
+    // it to. One built without the feed is the whole track.
+    if (section_ == Section::Arrangement && handles_ != nullptr)
+        applySectionHold(out);
 }
 
 void ClipAudioSource::applySectionHold(juce::dsp::AudioBlock<float> out) {
@@ -180,6 +165,11 @@ void ClipAudioSource::applySectionHold(juce::dsp::AudioBlock<float> out) {
     const auto hold = handles ? sectionHold(*handles.get(), trackId_) : SectionHold{};
 
     if (!hold.session) {
+        // What the arrangement rendered, before anything corrects it, which is
+        // the order StopDeClick::push asks for: pushed after the ramps below
+        // this would remember a correction rather than a signal.
+        handOver_.push(out);
+
         // The track is the arrangement's. Coming back to it lands mid-material,
         // which is the same step a voice starting mid-file leaves and comes out
         // the same way.
@@ -192,7 +182,6 @@ void ClipAudioSource::applySectionHold(juce::dsp::AudioBlock<float> out) {
         // rather than being cut off, which would be the click it exists to
         // remove.
         handOver_.advance(out);
-        handOver_.push(out);
 
         wasHeld_ = false;
         return;
@@ -204,6 +193,12 @@ void ClipAudioSource::applySectionHold(juce::dsp::AudioBlock<float> out) {
     // when it lost it. Only the output is dropped.
     const auto numSamples = static_cast<int>(out.getNumSamples());
     const auto from = wasHeld_ ? 0 : std::clamp(hold.takenAt.value, 0, numSamples);
+
+    // What it rendered up to the cut, which is what the ramp carries down.
+    // Empty for a hand-over on the block's first sample, where what the ramp
+    // carries down is the block before's, pushed then.
+    if (!wasHeld_)
+        handOver_.push(out.getSubBlock(0, static_cast<std::size_t>(from)));
 
     out.getSubBlock(static_cast<std::size_t>(from)).clear();
 
@@ -289,7 +284,19 @@ void ClipAudioSource::renderMaterial(const BlockInfo& block, juce::dsp::AudioBlo
     else
         gather(track->audio, lane, 0, table, sounding, soundingCount);
 
+    const auto stopping = [&](const ClipVoice& voice) {
+        const auto* found =
+            std::find_if(stopping_.begin(), stopping_.begin() + stoppingCount_,
+                         [&](const Stopping& s) { return voice.playing(s.clipId, s.eventId); });
+
+        return found != stopping_.begin() + stoppingCount_ ? found : nullptr;
+    };
+
     for (auto& voice : voices_) {
+        // A release ramp from an earlier block, which sounds whether or not
+        // anything replaced the voice that left it.
+        voice.carryTail(out);
+
         if (voice.clipId() == INVALID_CLIP_ID)
             continue;
 
@@ -298,7 +305,11 @@ void ClipAudioSource::renderMaterial(const BlockInfo& block, juce::dsp::AudioBlo
                 return voice.playing(s.clip->clipId, s.event->eventId);
             });
 
-        if (!stillSounding)
+        // Let go before anything renders, so a voice holding a clip that
+        // stopped last block does not keep a slot a clip starting this one
+        // needs. Not one the launcher says is stopping in this block: that one
+        // is released below, once it has rendered whatever it still had to.
+        if (!stillSounding && stopping(voice) == nullptr)
             voice.release();
     }
 
@@ -323,6 +334,19 @@ void ClipAudioSource::renderMaterial(const BlockInfo& block, juce::dsp::AudioBlo
                       entry.preRoll, scratch,
                       out.getSubBlock(static_cast<std::size_t>(entry.outOffset),
                                       static_cast<std::size_t>(entry.block.numSamples)));
+    }
+
+    // After rendering, because a slot that stops half way through a block still
+    // sounds the first half of it, and the ramp carries on from what that half
+    // ended at. A slot stopped on the block's first sample rendered nothing
+    // here and carries on from the block before, which is the same thing said
+    // about a different sample (StopDeClick::push).
+    for (auto& voice : voices_) {
+        if (voice.clipId() == INVALID_CLIP_ID)
+            continue;
+
+        if (const auto* stopped = stopping(voice))
+            voice.releaseInto(out, stopped->offset, kSectionDeClickSamples);
     }
 }
 

--- a/magda/engine/clip/ClipAudioSource.cpp
+++ b/magda/engine/clip/ClipAudioSource.cpp
@@ -164,51 +164,37 @@ void ClipAudioSource::applySectionHold(juce::dsp::AudioBlock<float> out) {
     const LaunchHandleFeed::Reader handles(*handles_);
     const auto hold = handles ? sectionHold(*handles.get(), trackId_) : SectionHold{};
 
-    if (!hold.session) {
-        // What the arrangement rendered, before anything corrects it, which is
-        // the order StopDeClick::push asks for: pushed after the ramps below
-        // this would remember a correction rather than a signal.
-        handOver_.push(out);
-
-        // The track is the arrangement's. Coming back to it lands mid-material,
-        // which is the same step a voice starting mid-file leaves and comes out
-        // the same way.
-        if (wasHeld_)
-            handBack_.begin(out, kSectionDeClickSamples);
-        else
-            handBack_.advance(out);
-
-        // A hand-over taken back inside its own ramp finishes into the material
-        // rather than being cut off, which would be the click it exists to
-        // remove.
-        handOver_.advance(out);
-
-        wasHeld_ = false;
-        return;
-    }
-
-    // The session has the track. What the arrangement rendered still advanced
-    // every voice, stream and stretcher, which is what makes handing the track
-    // back land where the timeline says rather than where the arrangement was
-    // when it lost it. Only the output is dropped.
     const auto numSamples = static_cast<int>(out.getNumSamples());
-    const auto from = wasHeld_ ? 0 : std::clamp(hold.takenAt.value, 0, numSamples);
+    const auto until = std::clamp(hold.arrangementUntil(numSamples).value, 0, numSamples);
 
-    // What it rendered up to the cut, which is what the ramp carries down.
-    // Empty for a hand-over on the block's first sample, where what the ramp
-    // carries down is the block before's, pushed then.
-    if (!wasHeld_)
-        handOver_.push(out.getSubBlock(0, static_cast<std::size_t>(from)));
+    // What it rendered and gets to keep, before anything corrects it, which is
+    // the order StopDeClick::push asks for. Empty when the session already owned
+    // the first sample, and the ramp then carries down what the block before
+    // pushed, which is the same sample on the other side of a boundary.
+    if (until > 0)
+        handOver_.push(out.getSubBlock(0, static_cast<std::size_t>(until)));
 
-    out.getSubBlock(static_cast<std::size_t>(from)).clear();
+    // The session's share of the block is dropped. What the arrangement
+    // rendered into it still advanced every voice, stream and stretcher, which
+    // is what makes taking the track back land where the timeline says rather
+    // than where the arrangement was when it lost it. Only the output goes.
+    if (until < numSamples)
+        out.getSubBlock(static_cast<std::size_t>(until)).clear();
 
-    if (wasHeld_)
-        handOver_.advance(out);
+    // Taking the track back lands mid-material, which is the same step a voice
+    // starting mid-file leaves and comes out the same way.
+    if (hold.handedBack && hold.atStart == Section::Arrangement)
+        handBack_.begin(out, kSectionDeClickSamples);
     else
-        handOver_.begin(out, from, kSectionDeClickSamples);
+        handBack_.advance(out);
 
-    handBack_.reset();
-    wasHeld_ = true;
+    // Losing it leaves the other step. A ramp still running from an earlier
+    // block finishes into whatever is here now rather than being cut off, which
+    // would be the click it exists to remove.
+    if (until < numSamples && hold.atStart == Section::Arrangement)
+        handOver_.begin(out, until, kSectionDeClickSamples);
+    else
+        handOver_.advance(out);
 }
 
 void ClipAudioSource::renderMaterial(const BlockInfo& block, juce::dsp::AudioBlock<float> out) {

--- a/magda/engine/clip/ClipAudioSource.cpp
+++ b/magda/engine/clip/ClipAudioSource.cpp
@@ -129,16 +129,14 @@ void ClipAudioSource::gatherSession(const TrackClipPlayback& track, const BlockI
         if (status.afterEvent)
             play(*status.afterEvent, split, block.numSamples - split);
 
-        // Where this slot stopped sounding, for the ramp that takes the step
-        // out of it. A slot still sounding at the end of the block leaves no
-        // step, and one that stopped in an earlier block has none left here.
-        if (status.beforeEvent.playing() && !status.playingAtEnd())
-            sessionSilentFrom_ = std::max(sessionSilentFrom_.value_or(0), split);
+        // Where this slot stopped sounding, for the ramp that takes the step out
+        // of it. The handle's answer rather than the shape of the split, so a
+        // stop on the block's first sample is the same edge as one half way
+        // through it (LaunchHandle::silencedAt).
+        if (const auto silenced = status.silencedAt())
+            sessionSilentFrom_ = std::max(sessionSilentFrom_.value_or(0), silenced->value);
 
-        soundedThroughout =
-            soundedThroughout || (status.beforeEvent.playing() && status.playingAtEnd());
-
-        sessionSounded_ = sessionSounded_ || status.playingAtEnd();
+        soundedThroughout = soundedThroughout || (status.soundingAtStart && status.playingAtEnd());
     };
 
     forEachSlot(*handles.get(), track, renderSlot);
@@ -150,12 +148,8 @@ void ClipAudioSource::gatherSession(const TrackClipPlayback& track, const BlockI
 void ClipAudioSource::render(const BlockInfo& block, juce::dsp::AudioBlock<float> out) {
     // Cleared for the block rather than by whatever gathers, because every path
     // through the render can return before the gather does: a stale edge would
-    // de-click a second time, blocks after the stop it belongs to. The same
-    // goes for whether anything sounded, which every early return answers no.
+    // de-click a second time, blocks after the stop it belongs to.
     sessionSilentFrom_.reset();
-
-    const auto soundedLastBlock = sessionSounded_;
-    sessionSounded_ = false;
 
     renderMaterial(block, out);
 
@@ -168,15 +162,6 @@ void ClipAudioSource::render(const BlockInfo& block, juce::dsp::AudioBlock<float
             break;
 
         case Section::Session:
-            // A stop landing on this block's first sample. The handle reports
-            // it as a block that was never playing, which is the same
-            // SplitStatus as a slot that stopped long ago, so the edge is only
-            // visible from here: something sounded last block and nothing does
-            // now. The value it steps down from is the one push remembered,
-            // which is what push is for.
-            if (!sessionSilentFrom_ && soundedLastBlock && !sessionSounded_)
-                sessionSilentFrom_ = 0;
-
             if (sessionSilentFrom_) {
                 sessionStop_.begin(out, *sessionSilentFrom_, kSectionDeClickSamples);
             } else {

--- a/magda/engine/clip/ClipAudioSource.cpp
+++ b/magda/engine/clip/ClipAudioSource.cpp
@@ -164,7 +164,7 @@ void ClipAudioSource::applySectionHold(juce::dsp::AudioBlock<float> out) {
     const auto numSamples = static_cast<int>(out.getNumSamples());
 
     const LaunchHandleFeed::Reader handles(*handles_);
-    const auto hold = handles ? sectionHold(*handles.get(), trackId_, numSamples) : SectionHold{};
+    const auto hold = sectionHold(handles.get(), trackId_, numSamples);
 
     const auto until = std::clamp(hold.until.value, 0, numSamples);
 

--- a/magda/engine/clip/ClipAudioSource.cpp
+++ b/magda/engine/clip/ClipAudioSource.cpp
@@ -270,12 +270,17 @@ void ClipAudioSource::renderMaterial(const BlockInfo& block, juce::dsp::AudioBlo
     else
         gather(track->audio, lane, 0, table, sounding, soundingCount);
 
-    const auto stopping = [&](const ClipVoice& voice) {
-        const auto* found =
-            std::find_if(stopping_.begin(), stopping_.begin() + stoppingCount_,
-                         [&](const Stopping& s) { return voice.playing(s.clipId, s.eventId); });
+    // Pointers rather than the array's own iterators, which are a class type on
+    // MSVC and a pointer on libc++: deducing `const auto*` from one compiles on
+    // exactly one of the two.
+    const auto stopping = [&](const ClipVoice& voice) -> const Stopping* {
+        const auto* first = stopping_.data();
+        const auto* last = first + stoppingCount_;
 
-        return found != stopping_.begin() + stoppingCount_ ? found : nullptr;
+        const auto* found = std::find_if(
+            first, last, [&](const Stopping& s) { return voice.playing(s.clipId, s.eventId); });
+
+        return found != last ? found : nullptr;
     };
 
     for (auto& voice : voices_) {

--- a/magda/engine/clip/ClipAudioSource.cpp
+++ b/magda/engine/clip/ClipAudioSource.cpp
@@ -104,10 +104,13 @@ void ClipAudioSource::gatherSession(const TrackClipPlayback& track, const BlockI
 
     // The status is the launcher's, worked out before anything rendered
     // (SessionLauncher.hpp), so this source and the MIDI one see the same block.
-    // Whether anything is still sounding when the block ends, gathered in the
-    // one walk that renders: a track with a slot still going has not stepped,
-    // whatever its other slots did.
-    auto stillSounding = false;
+    // Whether some other slot sounded right across the block. Only that masks
+    // another slot's stop: the ramp reads the step off the summed buffer, and a
+    // slot that was already sounding before the stop sample is still in that
+    // sum afterwards, so decaying it would correct for a signal that never
+    // stopped. A slot that starts where another stops was not in the sum
+    // before, so the value at the stop is the outgoing slot's alone.
+    auto soundedThroughout = false;
 
     const auto renderSlot = [&](const SessionSlotPlayback& slot, const SplitStatus& status) {
         const auto play = [&](const BlockPiece& piece, int offset, int count) {
@@ -132,15 +135,13 @@ void ClipAudioSource::gatherSession(const TrackClipPlayback& track, const BlockI
         if (status.beforeEvent.playing() && !status.playingAtEnd())
             sessionSilentFrom_ = std::max(sessionSilentFrom_.value_or(0), split);
 
-        stillSounding = stillSounding || status.playingAtEnd();
+        soundedThroughout =
+            soundedThroughout || (status.beforeEvent.playing() && status.playingAtEnd());
     };
 
     forEachSlot(*handles.get(), track, renderSlot);
 
-    // The ramp is bound to the same grain as the signal it corrects, which is
-    // the track: the op is per track because a track sounds one session clip at
-    // a time, so a sum that did not step needs no correction.
-    if (stillSounding)
+    if (soundedThroughout)
         sessionSilentFrom_.reset();
 }
 

--- a/magda/engine/clip/ClipAudioSource.cpp
+++ b/magda/engine/clip/ClipAudioSource.cpp
@@ -137,6 +137,8 @@ void ClipAudioSource::gatherSession(const TrackClipPlayback& track, const BlockI
 
         soundedThroughout =
             soundedThroughout || (status.beforeEvent.playing() && status.playingAtEnd());
+
+        sessionSounded_ = sessionSounded_ || status.playingAtEnd();
     };
 
     forEachSlot(*handles.get(), track, renderSlot);
@@ -148,8 +150,12 @@ void ClipAudioSource::gatherSession(const TrackClipPlayback& track, const BlockI
 void ClipAudioSource::render(const BlockInfo& block, juce::dsp::AudioBlock<float> out) {
     // Cleared for the block rather than by whatever gathers, because every path
     // through the render can return before the gather does: a stale edge would
-    // de-click a second time, blocks after the stop it belongs to.
+    // de-click a second time, blocks after the stop it belongs to. The same
+    // goes for whether anything sounded, which every early return answers no.
     sessionSilentFrom_.reset();
+
+    const auto soundedLastBlock = sessionSounded_;
+    sessionSounded_ = false;
 
     renderMaterial(block, out);
 
@@ -162,6 +168,15 @@ void ClipAudioSource::render(const BlockInfo& block, juce::dsp::AudioBlock<float
             break;
 
         case Section::Session:
+            // A stop landing on this block's first sample. The handle reports
+            // it as a block that was never playing, which is the same
+            // SplitStatus as a slot that stopped long ago, so the edge is only
+            // visible from here: something sounded last block and nothing does
+            // now. The value it steps down from is the one push remembered,
+            // which is what push is for.
+            if (!sessionSilentFrom_ && soundedLastBlock && !sessionSounded_)
+                sessionSilentFrom_ = 0;
+
             if (sessionSilentFrom_) {
                 sessionStop_.begin(out, *sessionSilentFrom_, kSectionDeClickSamples);
             } else {

--- a/magda/engine/clip/ClipAudioSource.hpp
+++ b/magda/engine/clip/ClipAudioSource.hpp
@@ -216,13 +216,19 @@ class ClipAudioSource final : public EngineAudioSource {
     StopDeClick handOver_;
     StartDeClick handBack_;
 
-    /// Where this track's session output went silent in the block just
-    /// gathered, when it did. Per track rather than per slot, on the same terms
-    /// as the op: a track sounds one session clip at a time.
-    std::optional<int> sessionSilentFrom_;
+    /// One entry of this track's session that stopped in the block just
+    /// gathered, and where. Per entry rather than per track, because the ramp
+    /// that takes its step out belongs to the voice playing it: one ramp over
+    /// the track's sum could not tell an outgoing slot from one still sounding
+    /// through the same samples (#2344 review).
+    struct Stopping {
+        ClipId clipId = INVALID_CLIP_ID;
+        EventId eventId = INVALID_EVENT_ID;
+        int offset = 0;
+    };
 
-    /// The step that leaves behind.
-    StopDeClick sessionStop_;
+    std::array<Stopping, kMaxVoicesPerTrack> stopping_;
+    int stoppingCount_ = 0;
 
     std::array<ClipVoice, kMaxVoicesPerTrack> voices_;
 

--- a/magda/engine/clip/ClipAudioSource.hpp
+++ b/magda/engine/clip/ClipAudioSource.hpp
@@ -221,11 +221,6 @@ class ClipAudioSource final : public EngineAudioSource {
     /// as the op: a track sounds one session clip at a time.
     std::optional<int> sessionSilentFrom_;
 
-    /// Whether any of this track's slots was sounding when the last block
-    /// ended. A stop on a block's first sample is reported as a block that was
-    /// never playing, so this is the only thing that can tell the two apart.
-    bool sessionSounded_ = false;
-
     /// The step that leaves behind.
     StopDeClick sessionStop_;
 

--- a/magda/engine/clip/ClipAudioSource.hpp
+++ b/magda/engine/clip/ClipAudioSource.hpp
@@ -221,6 +221,11 @@ class ClipAudioSource final : public EngineAudioSource {
     /// as the op: a track sounds one session clip at a time.
     std::optional<int> sessionSilentFrom_;
 
+    /// Whether any of this track's slots was sounding when the last block
+    /// ended. A stop on a block's first sample is reported as a block that was
+    /// never playing, so this is the only thing that can tell the two apart.
+    bool sessionSounded_ = false;
+
     /// The step that leaves behind.
     StopDeClick sessionStop_;
 

--- a/magda/engine/clip/ClipAudioSource.hpp
+++ b/magda/engine/clip/ClipAudioSource.hpp
@@ -205,11 +205,6 @@ class ClipAudioSource final : public EngineAudioSource {
     LaunchHandleFeed* handles_ = nullptr;
     Section section_ = Section::Arrangement;
 
-    /// Whether the session held this track when the last block ended, which is
-    /// what makes the hand-over an edge rather than a state (#2302). The switch
-    /// sample comes from the handles; only the previous answer is remembered.
-    bool wasHeld_ = false;
-
     /// The two edges of the arrangement's own playback: the step it carries
     /// down when the session takes the track, and the one it subtracts when it
     /// gets the track back mid-material.

--- a/magda/engine/clip/ClipAudioSource.hpp
+++ b/magda/engine/clip/ClipAudioSource.hpp
@@ -11,6 +11,7 @@
 #include "clip/ClipSnapshotFeed.hpp"
 #include "clip/ClipStreamFeed.hpp"
 #include "clip/ClipVoice.hpp"
+#include "clip/FadeCurves.hpp"
 #include "core/TypeIds.hpp"
 #include "exec/EngineDevice.hpp"
 #include "launch/SessionLauncher.hpp"
@@ -89,11 +90,19 @@ class ClipAudioSource final : public EngineAudioSource {
      */
     ClipAudioSource(TrackId trackId, ClipSnapshotFeed& clips, ClipStreamFeed& streams);
 
-    /// The session's source for @p trackId, positioned by @p handles instead of
-    /// by the timeline. The feed is the section selector: with one it plays the
-    /// track's slots, without one its arrangement. @p handles outlives it.
+    /**
+     * @brief The @p section's source for @p trackId, reading @p handles.
+     *
+     * Both sources of a track take the feed, and @p section says which of them
+     * this is (#2302). A session source is positioned by the handles instead of
+     * by the timeline; an arrangement source is positioned by the timeline as
+     * ever and reads the handles only to know when the session has taken the
+     * track off it, and where in the block that happened.
+     *
+     * @p handles outlives it.
+     */
     ClipAudioSource(TrackId trackId, ClipSnapshotFeed& clips, ClipStreamFeed& streams,
-                    LaunchHandleFeed& handles);
+                    LaunchHandleFeed& handles, Section section);
 
     void prepare(const RenderContext& context) override;
 
@@ -186,7 +195,34 @@ class ClipAudioSource final : public EngineAudioSource {
     ClipStreamFeed& streams_;
 
     /// The section. Null is the arrangement, which needs no handles.
+    /// Sum this track's material for @p block, on whichever section this is.
+    void renderMaterial(const BlockInfo& block, juce::dsp::AudioBlock<float> out);
+
+    /// Drop what the arrangement rendered for as long as the session holds the
+    /// track, and de-click both edges of the hand-over (#2302).
+    void applySectionHold(juce::dsp::AudioBlock<float> out);
+
     LaunchHandleFeed* handles_ = nullptr;
+    Section section_ = Section::Arrangement;
+
+    /// Whether the session held this track when the last block ended, which is
+    /// what makes the hand-over an edge rather than a state (#2302). The switch
+    /// sample comes from the handles; only the previous answer is remembered.
+    bool wasHeld_ = false;
+
+    /// The two edges of the arrangement's own playback: the step it carries
+    /// down when the session takes the track, and the one it subtracts when it
+    /// gets the track back mid-material.
+    StopDeClick handOver_;
+    StartDeClick handBack_;
+
+    /// Where this track's session output went silent in the block just
+    /// gathered, when it did. Per track rather than per slot, on the same terms
+    /// as the op: a track sounds one session clip at a time.
+    std::optional<int> sessionSilentFrom_;
+
+    /// The step that leaves behind.
+    StopDeClick sessionStop_;
 
     std::array<ClipVoice, kMaxVoicesPerTrack> voices_;
 

--- a/magda/engine/clip/ClipMidiSource.cpp
+++ b/magda/engine/clip/ClipMidiSource.cpp
@@ -603,16 +603,15 @@ void ClipMidiSource::render(const BlockInfo& block, juce::MidiBuffer& out) {
     // the two are on the same side of every switch.
     auto lane = block;
     auto until = block.numSamples;
-    auto handedBack = false;
-    auto sessionOwnedStart = false;
+    auto lost = false;
 
     if (handles_ != nullptr) {
         const LaunchHandleFeed::Reader handles(*handles_);
-        const auto hold = handles ? sectionHold(*handles.get(), trackId_) : SectionHold{};
+        const auto hold =
+            handles ? sectionHold(*handles.get(), trackId_, block.numSamples) : SectionHold{};
 
-        until = std::clamp(hold.arrangementUntil(block.numSamples).value, 0, block.numSamples);
-        handedBack = hold.handedBack && hold.atStart == Section::Arrangement;
-        sessionOwnedStart = hold.atStart == Section::Session;
+        until = std::clamp(hold.until.value, 0, block.numSamples);
+        lost = hold.lost;
 
         // Taking the track back is a discontinuity even though the transport
         // never moved: the arrangement's notes were ended when it lost the
@@ -620,17 +619,16 @@ void ClipMidiSource::render(const BlockInfo& block, juce::MidiBuffer& out) {
         // chase leaves a sustained pad silent, and every controller at whatever
         // it was before, until the next event happens to arrive. That is the
         // case playLane already answers for a locate.
-        if (handedBack)
+        if (hold.gained)
             lane.continuous = false;
     }
 
-    // The session owns every sample of the block. Whether the arrangement owes
-    // anything turns on which block this is: it owes note-offs on the one where
-    // it lost the track, even when that happened on the first sample and it
-    // sounded none of it, and nothing on the blocks after, where what it had
-    // was ended already.
+    // The session owns every sample of the block. What the arrangement owes is
+    // whether it lost the track here: note-offs on the block it loses it, even
+    // when it loses it on the first sample and sounds none of that block, and
+    // nothing on the blocks after, where what it had was ended already.
     if (until == 0) {
-        if (!sessionOwnedStart)
+        if (lost)
             endAll(out, EventSample{0});
 
         lastSnapshot_ = live;
@@ -653,7 +651,7 @@ void ClipMidiSource::render(const BlockInfo& block, juce::MidiBuffer& out) {
     // owes note-offs there: the session's own notes start on that sample, and
     // one the arrangement left holding would sound under them until the
     // transport stopped.
-    if (until < block.numSamples)
+    if (lost)
         endAll(out, EventSample{std::min(until, block.numSamples - 1)});
 
     lastSnapshot_ = live;

--- a/magda/engine/clip/ClipMidiSource.cpp
+++ b/magda/engine/clip/ClipMidiSource.cpp
@@ -24,8 +24,9 @@ constexpr int kOwedCapacity = ActiveNoteList::kChannels * ActiveNoteList::kNotes
 ClipMidiSource::ClipMidiSource(TrackId trackId, ClipSnapshotFeed& clips)
     : trackId_(trackId), clips_(clips) {}
 
-ClipMidiSource::ClipMidiSource(TrackId trackId, ClipSnapshotFeed& clips, LaunchHandleFeed& handles)
-    : trackId_(trackId), clips_(clips), handles_(&handles) {}
+ClipMidiSource::ClipMidiSource(TrackId trackId, ClipSnapshotFeed& clips, LaunchHandleFeed& handles,
+                               Section section)
+    : trackId_(trackId), clips_(clips), handles_(&handles), section_(section) {}
 
 void ClipMidiSource::prepare(const RenderContext&) {
     // Everything the audio thread may need room for, reserved here and never
@@ -586,12 +587,52 @@ void ClipMidiSource::render(const BlockInfo& block, juce::MidiBuffer& out) {
     // from the wrong owner and the note hangs until the transport stops.
     const auto swapped = live != lastSnapshot_;
 
-    if (handles_ != nullptr) {
+    if (section_ == Section::Session) {
         if (!renderSession(out, block, *track, swapped))
             endAll(out, EventSample{0});  // no handles published yet: nothing can be playing
 
         lastSnapshot_ = live;
         return;
+    }
+
+    // The arrangement's, and only while the session has not taken the track off
+    // it (#2302). A source built without the feed is the whole track and has no
+    // section to lose.
+    if (handles_ != nullptr) {
+        const LaunchHandleFeed::Reader handles(*handles_);
+        const auto hold = handles ? sectionHold(*handles.get(), trackId_) : SectionHold{};
+
+        if (hold.session) {
+            if (!wasHeld_) {
+                // The arrangement still sounds up to the hand-over, the way its
+                // audio still renders up to it: a note due a sample before the
+                // launch is one the listener was going to hear.
+                const auto at = std::clamp(hold.takenAt.value, 0, block.numSamples);
+                const auto range = syncRangeFor(block);
+                const auto until = range.timelineBeatAt(range.atSample(at));
+
+                if (swapped) {
+                    NoteMask expected;
+                    expectLane(out, block, track->midi, block.beats.start, until, expected);
+                    endUnexpected(out, expected);
+                }
+
+                playLane(out, block, track->midi, block.beats.start, until);
+
+                // And owes note-offs there. The session's own notes start on
+                // that sample, and one the arrangement left holding would sound
+                // under them until the transport stopped.
+                endAll(out, EventSample{std::min(at, block.numSamples - 1)});
+            }
+
+            wasHeld_ = true;
+            lastSnapshot_ = live;
+            return;
+        }
+
+        // Taken back. Nothing sounded while the session held it, so there is
+        // nothing to chase and the lane simply resumes where the timeline is.
+        wasHeld_ = false;
     }
 
     if (swapped) {

--- a/magda/engine/clip/ClipMidiSource.cpp
+++ b/magda/engine/clip/ClipMidiSource.cpp
@@ -607,8 +607,7 @@ void ClipMidiSource::render(const BlockInfo& block, juce::MidiBuffer& out) {
 
     if (handles_ != nullptr) {
         const LaunchHandleFeed::Reader handles(*handles_);
-        const auto hold =
-            handles ? sectionHold(*handles.get(), trackId_, block.numSamples) : SectionHold{};
+        const auto hold = sectionHold(handles.get(), trackId_, block.numSamples);
 
         until = std::clamp(hold.until.value, 0, block.numSamples);
         lost = hold.lost;

--- a/magda/engine/clip/ClipMidiSource.cpp
+++ b/magda/engine/clip/ClipMidiSource.cpp
@@ -598,63 +598,64 @@ void ClipMidiSource::render(const BlockInfo& block, juce::MidiBuffer& out) {
     // The arrangement's, and only while the session has not taken the track off
     // it (#2302). A source built without the feed is the whole track and has no
     // section to lose.
+    // The arrangement's share of the block, which is the whole of it on a track
+    // the session never took (#2302). The same fold the audio source reads, so
+    // the two are on the same side of every switch.
+    auto lane = block;
+    auto until = block.numSamples;
     auto handedBack = false;
+    auto sessionOwnedStart = false;
 
     if (handles_ != nullptr) {
         const LaunchHandleFeed::Reader handles(*handles_);
         const auto hold = handles ? sectionHold(*handles.get(), trackId_) : SectionHold{};
 
-        if (hold.session) {
-            if (!wasHeld_) {
-                // The arrangement still sounds up to the hand-over, the way its
-                // audio still renders up to it: a note due a sample before the
-                // launch is one the listener was going to hear.
-                const auto at = std::clamp(hold.takenAt.value, 0, block.numSamples);
-                const auto range = syncRangeFor(block);
-                const auto until = range.timelineBeatAt(range.atSample(at));
+        until = std::clamp(hold.arrangementUntil(block.numSamples).value, 0, block.numSamples);
+        handedBack = hold.handedBack && hold.atStart == Section::Arrangement;
+        sessionOwnedStart = hold.atStart == Section::Session;
 
-                if (swapped) {
-                    NoteMask expected;
-                    expectLane(out, block, track->midi, block.beats.start, until, expected);
-                    endUnexpected(out, expected);
-                }
-
-                playLane(out, block, track->midi, block.beats.start, until);
-
-                // And owes note-offs there. The session's own notes start on
-                // that sample, and one the arrangement left holding would sound
-                // under them until the transport stopped.
-                endAll(out, EventSample{std::min(at, block.numSamples - 1)});
-            }
-
-            wasHeld_ = true;
-            lastSnapshot_ = live;
-            return;
-        }
-
-        // Taken back, which is a discontinuity even though the transport never
-        // moved: the arrangement's notes were ended at the hand-over and the
-        // timeline has run on underneath. Resuming without a chase leaves a
-        // sustained pad silent, and every controller at whatever it was before
-        // the session took the track, until the next event happens to arrive.
-        // That is the case playLane already answers for a locate.
-        handedBack = wasHeld_;
-        wasHeld_ = false;
+        // Taking the track back is a discontinuity even though the transport
+        // never moved: the arrangement's notes were ended when it lost the
+        // track and the timeline has run on underneath. Resuming without a
+        // chase leaves a sustained pad silent, and every controller at whatever
+        // it was before, until the next event happens to arrive. That is the
+        // case playLane already answers for a locate.
+        if (handedBack)
+            lane.continuous = false;
     }
 
-    // The block as the lane should read it: its own, unless this is the block
-    // the arrangement got its track back on.
-    auto lane = block;
-    if (handedBack)
-        lane.continuous = false;
+    // The session owns every sample of the block. Whether the arrangement owes
+    // anything turns on which block this is: it owes note-offs on the one where
+    // it lost the track, even when that happened on the first sample and it
+    // sounded none of it, and nothing on the blocks after, where what it had
+    // was ended already.
+    if (until == 0) {
+        if (!sessionOwnedStart)
+            endAll(out, EventSample{0});
+
+        lastSnapshot_ = live;
+        return;
+    }
+
+    const auto range = syncRangeFor(block);
+    const auto laneEnd =
+        until == block.numSamples ? block.beats.end : range.timelineBeatAt(range.atSample(until));
 
     if (swapped) {
         NoteMask expected;
-        expectLane(out, lane, track->midi, lane.beats.start, lane.beats.end, expected);
+        expectLane(out, lane, track->midi, lane.beats.start, laneEnd, expected);
         endUnexpected(out, expected);
     }
 
-    playLane(out, lane, track->midi, lane.beats.start, lane.beats.end);
+    playLane(out, lane, track->midi, lane.beats.start, laneEnd);
+
+    // It sounds up to the hand-over the way its audio renders up to it, and
+    // owes note-offs there: the session's own notes start on that sample, and
+    // one the arrangement left holding would sound under them until the
+    // transport stopped.
+    if (until < block.numSamples)
+        endAll(out, EventSample{std::min(until, block.numSamples - 1)});
+
     lastSnapshot_ = live;
 }
 

--- a/magda/engine/clip/ClipMidiSource.cpp
+++ b/magda/engine/clip/ClipMidiSource.cpp
@@ -598,6 +598,8 @@ void ClipMidiSource::render(const BlockInfo& block, juce::MidiBuffer& out) {
     // The arrangement's, and only while the session has not taken the track off
     // it (#2302). A source built without the feed is the whole track and has no
     // section to lose.
+    auto handedBack = false;
+
     if (handles_ != nullptr) {
         const LaunchHandleFeed::Reader handles(*handles_);
         const auto hold = handles ? sectionHold(*handles.get(), trackId_) : SectionHold{};
@@ -630,18 +632,29 @@ void ClipMidiSource::render(const BlockInfo& block, juce::MidiBuffer& out) {
             return;
         }
 
-        // Taken back. Nothing sounded while the session held it, so there is
-        // nothing to chase and the lane simply resumes where the timeline is.
+        // Taken back, which is a discontinuity even though the transport never
+        // moved: the arrangement's notes were ended at the hand-over and the
+        // timeline has run on underneath. Resuming without a chase leaves a
+        // sustained pad silent, and every controller at whatever it was before
+        // the session took the track, until the next event happens to arrive.
+        // That is the case playLane already answers for a locate.
+        handedBack = wasHeld_;
         wasHeld_ = false;
     }
 
+    // The block as the lane should read it: its own, unless this is the block
+    // the arrangement got its track back on.
+    auto lane = block;
+    if (handedBack)
+        lane.continuous = false;
+
     if (swapped) {
         NoteMask expected;
-        expectLane(out, block, track->midi, block.beats.start, block.beats.end, expected);
+        expectLane(out, lane, track->midi, lane.beats.start, lane.beats.end, expected);
         endUnexpected(out, expected);
     }
 
-    playLane(out, block, track->midi, block.beats.start, block.beats.end);
+    playLane(out, lane, track->midi, lane.beats.start, lane.beats.end);
     lastSnapshot_ = live;
 }
 

--- a/magda/engine/clip/ClipMidiSource.hpp
+++ b/magda/engine/clip/ClipMidiSource.hpp
@@ -79,9 +79,19 @@ class ClipMidiSource final : public EngineMidiSource {
     /// The arrangement's source for @p trackId.
     ClipMidiSource(TrackId trackId, ClipSnapshotFeed& clips);
 
-    /// The session's source for @p trackId, positioned by @p handles rather
-    /// than by the timeline. @p handles outlives it.
-    ClipMidiSource(TrackId trackId, ClipSnapshotFeed& clips, LaunchHandleFeed& handles);
+    /**
+     * @brief The @p section's source for @p trackId, reading @p handles.
+     *
+     * Both sources of a track take the feed, and @p section says which of them
+     * this is (#2302). A session source is positioned by the handles rather
+     * than by the timeline; an arrangement source reads them only to know when
+     * the session has taken the track off it, and where in the block, which is
+     * where it owes note-offs for whatever it had sounding.
+     *
+     * @p handles outlives it.
+     */
+    ClipMidiSource(TrackId trackId, ClipSnapshotFeed& clips, LaunchHandleFeed& handles,
+                   Section section);
 
     void prepare(const RenderContext& context) override;
 
@@ -220,6 +230,11 @@ class ClipMidiSource final : public EngineMidiSource {
 
     /// The section. Null is the arrangement, which needs no handles.
     LaunchHandleFeed* handles_ = nullptr;
+    Section section_ = Section::Arrangement;
+
+    /// Whether the session held this track when the last block ended, which is
+    /// what makes the hand-over an edge rather than a state (#2302).
+    bool wasHeld_ = false;
 
     ActiveNoteList active_;
     int activeCount_ = 0;

--- a/magda/engine/clip/ClipMidiSource.hpp
+++ b/magda/engine/clip/ClipMidiSource.hpp
@@ -232,10 +232,6 @@ class ClipMidiSource final : public EngineMidiSource {
     LaunchHandleFeed* handles_ = nullptr;
     Section section_ = Section::Arrangement;
 
-    /// Whether the session held this track when the last block ended, which is
-    /// what makes the hand-over an edge rather than a state (#2302).
-    bool wasHeld_ = false;
-
     ActiveNoteList active_;
     int activeCount_ = 0;
 

--- a/magda/engine/clip/ClipVoice.cpp
+++ b/magda/engine/clip/ClipVoice.cpp
@@ -18,6 +18,20 @@ void ClipVoice::prepare(const RenderContext& context) {
     held_.setSize(std::max(1, context.numChannels), kCellSamples, false, true, false);
 
     release();
+    stop_.reset();
+}
+
+void ClipVoice::releaseInto(juce::dsp::AudioBlock<float> out, int offset, int fadeSamples) {
+    // What it was contributing, remembered by the render that produced it, so
+    // the ramp decays this voice and nothing else that landed in the same
+    // samples (StopDeClick::push).
+    stop_.begin(out, offset, fadeSamples);
+
+    release();
+}
+
+void ClipVoice::carryTail(juce::dsp::AudioBlock<float> out) {
+    stop_.advance(out);
 }
 
 void ClipVoice::release() {
@@ -26,6 +40,9 @@ void ClipVoice::release() {
     sounded_ = false;
     primed_ = nullptr;
     deClick_.reset();
+
+    // stop_ is deliberately left alone: releasing is what starts its ramp, and
+    // what is left of it is still sounding.
     pending_ = false;
     pendingCount_ = 0;
     pendingRead_ = 0;
@@ -394,6 +411,11 @@ bool ClipVoice::render(const AudioClipPlayback& clip, const AudioEventPlayback& 
     } else {
         deClick_.advance(region);
     }
+
+    // Before it is summed with anything else, and before any correction is
+    // added to it: what is remembered has to be this voice's own signal, or a
+    // ramp that decays it corrects for whatever else landed here too.
+    stop_.push(region.getSubBlock(0, static_cast<std::size_t>(count)));
 
     out.getSubBlock(static_cast<std::size_t>(first.value), static_cast<std::size_t>(count))
         .add(region);

--- a/magda/engine/clip/ClipVoice.hpp
+++ b/magda/engine/clip/ClipVoice.hpp
@@ -74,6 +74,33 @@ class ClipVoice {
     void release();
 
     /**
+     * @brief Stop, carrying this voice's own last sample down into @p out.
+     *
+     * The stop edge belongs here for the reason the start edge does: a voice is
+     * the only thing that knows what it alone was contributing. One ramp over a
+     * track's summed output cannot take one voice's step out of it while other
+     * voices go on sounding through the same samples, and a track whose slots
+     * change independently is exactly that (#2344 review).
+     *
+     * @p offset is where in the block it stopped, so a slot that ends half way
+     * through a callback ends there rather than on the boundary.
+     *
+     * The voice is not free until the ramp is spent (@ref fading), because what
+     * is left of it is still sounding.
+     */
+    void releaseInto(juce::dsp::AudioBlock<float> out, int offset, int fadeSamples);
+
+    /// Carry an unfinished release ramp into @p out. Called every block for a
+    /// voice that is @ref fading, and does nothing for one that is not.
+    void carryTail(juce::dsp::AudioBlock<float> out);
+
+    /// Whether a release ramp is still sounding. Such a voice plays nothing and
+    /// holds no entry, and may not be claimed until this goes false.
+    bool fading() const {
+        return stop_.active();
+    }
+
+    /**
      * @brief Add this block's contribution to @p out.
      *
      * On the audio thread. @p scratch is working space of at least
@@ -157,6 +184,10 @@ class ClipVoice {
     /// so a ramp that lived inside one block would be a different length at
     /// every block size (FadeCurves.hpp).
     StartDeClick deClick_;
+
+    /// This voice's own stop edge: what it was contributing when it ended,
+    /// carried down without touching anything else on the track.
+    StopDeClick stop_;
 
     /// One cell's output, and how much of it a block has taken. Allocated in
     /// prepare(), never on the callback.

--- a/magda/engine/clip/FadeCurves.cpp
+++ b/magda/engine/clip/FadeCurves.cpp
@@ -136,31 +136,10 @@ void StopDeClick::hold(juce::dsp::AudioBlock<float> audio, int upTo) {
 }
 
 void StopDeClick::push(juce::dsp::AudioBlock<float> audio) {
-    // Not while a ramp is running, and this is what keeps the ramp independent
-    // of how the render was cut up. What a running ramp decays is the value the
-    // signal stopped at, and the buffer it was just written into now holds that
-    // value part way down. Taking the remembered sample from there would
-    // multiply the rest of the cosine by an already decayed number, so the ramp
-    // would bend at every block seam and a stop would come out differently at
-    // 8 samples a block and at 1024.
-    //
-    // Refusing here rather than at the callers, because every caller pushes
-    // unconditionally every block: which of those blocks a ramp happens to be
-    // running through is exactly what they should not have to know.
-    if (active())
-        return;
-
     hold(audio, static_cast<int>(audio.getNumSamples()));
 }
 
 void StopDeClick::begin(juce::dsp::AudioBlock<float> audio, int offset, int fadeSamples) {
-    // Whatever a previous ramp had left is finished by this one: a stop landing
-    // while an earlier stop is still decaying steps down from where the signal
-    // is now, not from where it was two stops ago. Deliberately past the guard
-    // in push, because a new stop is the one thing that should re-anchor a
-    // running ramp.
-    hold(audio, offset);
-
     length_ = std::max(0, fadeSamples);
     done_ = 0;
 

--- a/magda/engine/clip/FadeCurves.cpp
+++ b/magda/engine/clip/FadeCurves.cpp
@@ -120,4 +120,84 @@ void StartDeClick::applyFrom(juce::dsp::AudioBlock<float> audio, int alreadyDone
     done_ = alreadyDone + static_cast<int>(count);
 }
 
+void StopDeClick::push(juce::dsp::AudioBlock<float> audio) {
+    const auto numSamples = audio.getNumSamples();
+    if (numSamples == 0)
+        return;
+
+    const auto channels = std::min(audio.getNumChannels(), kMaxChannels);
+    for (std::size_t channel = 0; channel < channels; ++channel)
+        held_[channel] = audio.getChannelPointer(channel)[numSamples - 1];
+
+    // Channels this block did not have are stale rather than silent, and a
+    // stop that decayed them would add a sample the source stopped producing
+    // some blocks ago. A track that narrows keeps its wider channels quiet.
+    for (auto channel = channels; channel < kMaxChannels; ++channel)
+        held_[channel] = 0.0f;
+}
+
+void StopDeClick::begin(juce::dsp::AudioBlock<float> audio, int offset, int fadeSamples) {
+    // Whatever a previous ramp had left is finished by this one: a stop landing
+    // while an earlier stop is still decaying steps down from where the signal
+    // is now, not from where it was two stops ago.
+    if (offset > 0)
+        push(audio.getSubBlock(0, static_cast<std::size_t>(offset)));
+
+    length_ = std::max(0, fadeSamples);
+    done_ = 0;
+
+    if (length_ == 0)
+        return;
+
+    applyFrom(audio, offset, 0);
+}
+
+void StopDeClick::advance(juce::dsp::AudioBlock<float> audio) {
+    if (!active())
+        return;
+
+    applyFrom(audio, 0, done_);
+}
+
+void StopDeClick::applyFrom(juce::dsp::AudioBlock<float> audio, int offset, int alreadyDone) {
+    const auto remaining = length_ - alreadyDone;
+    if (remaining <= 0)
+        return;
+
+    const auto room = static_cast<int>(audio.getNumSamples()) - offset;
+    if (room <= 0)
+        return;
+
+    const auto count = static_cast<std::size_t>(std::min(remaining, room));
+    const auto channels = std::min(audio.getNumChannels(), kMaxChannels);
+
+    for (std::size_t channel = 0; channel < channels; ++channel) {
+        const auto discontinuity = held_[channel];
+
+        // Nothing to step down from. A source that ended on a zero crossing,
+        // and every source that ended through a fade out, lands here.
+        if (discontinuity == 0.0f)
+            continue;
+
+        auto* samples = audio.getChannelPointer(channel) + offset;
+
+        if (length_ == 1) {
+            samples[0] += discontinuity;
+            continue;
+        }
+
+        for (std::size_t i = 0; i < count; ++i) {
+            // Phase runs across the whole ramp rather than across this block,
+            // which is what carrying the progress is for: the same stop has to
+            // come out the same however the render was cut up.
+            const auto phase = static_cast<float>(alreadyDone + static_cast<int>(i)) /
+                               static_cast<float>(length_ - 1);
+            const auto correction = 0.5f * (1.0f + std::cos(kPi * phase));
+            samples[i] += discontinuity * correction;
+        }
+    }
+
+    done_ = alreadyDone + static_cast<int>(count);
+}
+
 }  // namespace magda::engine

--- a/magda/engine/clip/FadeCurves.cpp
+++ b/magda/engine/clip/FadeCurves.cpp
@@ -120,14 +120,13 @@ void StartDeClick::applyFrom(juce::dsp::AudioBlock<float> audio, int alreadyDone
     done_ = alreadyDone + static_cast<int>(count);
 }
 
-void StopDeClick::push(juce::dsp::AudioBlock<float> audio) {
-    const auto numSamples = audio.getNumSamples();
-    if (numSamples == 0)
+void StopDeClick::hold(juce::dsp::AudioBlock<float> audio, int upTo) {
+    if (upTo <= 0)
         return;
 
     const auto channels = std::min(audio.getNumChannels(), kMaxChannels);
     for (std::size_t channel = 0; channel < channels; ++channel)
-        held_[channel] = audio.getChannelPointer(channel)[numSamples - 1];
+        held_[channel] = audio.getChannelPointer(channel)[static_cast<std::size_t>(upTo) - 1];
 
     // Channels this block did not have are stale rather than silent, and a
     // stop that decayed them would add a sample the source stopped producing
@@ -136,12 +135,31 @@ void StopDeClick::push(juce::dsp::AudioBlock<float> audio) {
         held_[channel] = 0.0f;
 }
 
+void StopDeClick::push(juce::dsp::AudioBlock<float> audio) {
+    // Not while a ramp is running, and this is what keeps the ramp independent
+    // of how the render was cut up. What a running ramp decays is the value the
+    // signal stopped at, and the buffer it was just written into now holds that
+    // value part way down. Taking the remembered sample from there would
+    // multiply the rest of the cosine by an already decayed number, so the ramp
+    // would bend at every block seam and a stop would come out differently at
+    // 8 samples a block and at 1024.
+    //
+    // Refusing here rather than at the callers, because every caller pushes
+    // unconditionally every block: which of those blocks a ramp happens to be
+    // running through is exactly what they should not have to know.
+    if (active())
+        return;
+
+    hold(audio, static_cast<int>(audio.getNumSamples()));
+}
+
 void StopDeClick::begin(juce::dsp::AudioBlock<float> audio, int offset, int fadeSamples) {
     // Whatever a previous ramp had left is finished by this one: a stop landing
     // while an earlier stop is still decaying steps down from where the signal
-    // is now, not from where it was two stops ago.
-    if (offset > 0)
-        push(audio.getSubBlock(0, static_cast<std::size_t>(offset)));
+    // is now, not from where it was two stops ago. Deliberately past the guard
+    // in push, because a new stop is the one thing that should re-anchor a
+    // running ramp.
+    hold(audio, offset);
 
     length_ = std::max(0, fadeSamples);
     done_ = 0;

--- a/magda/engine/clip/FadeCurves.hpp
+++ b/magda/engine/clip/FadeCurves.hpp
@@ -142,9 +142,18 @@ class StopDeClick {
     /// The most channels one source renders, as StartDeClick sizes it.
     static constexpr std::size_t kMaxChannels = StartDeClick::kMaxChannels;
 
-    /// Remember where @p audio ended. Called with what sounded, every block a
-    /// source produces anything, so a stop landing on the first sample of some
-    /// later block still knows what it is stepping down from.
+    /**
+     * @brief Remember where @p audio ended.
+     *
+     * Called with what sounded, every block a source produces anything, so a
+     * stop landing on the first sample of some later block still knows what it
+     * is stepping down from.
+     *
+     * Does nothing while a ramp is running: the buffer then holds the value
+     * being decayed rather than a signal, and remembering that would bend the
+     * rest of the ramp. Safe to call unconditionally, which is how a source
+     * that does not track its own ramps wants to call it.
+     */
     void push(juce::dsp::AudioBlock<float> audio);
 
     /**
@@ -175,6 +184,9 @@ class StopDeClick {
     }
 
   private:
+    /// Remember the sample before @p upTo, whatever a ramp is doing.
+    void hold(juce::dsp::AudioBlock<float> audio, int upTo);
+
     void applyFrom(juce::dsp::AudioBlock<float> audio, int offset, int alreadyDone);
 
     std::array<float, kMaxChannels> held_{};

--- a/magda/engine/clip/FadeCurves.hpp
+++ b/magda/engine/clip/FadeCurves.hpp
@@ -113,4 +113,73 @@ class StartDeClick {
     int done_ = 0;
 };
 
+/**
+ * @brief Return the end of a voice to zero without fading what came before it.
+ *
+ * The other edge of StartDeClick, and the same trick read backwards. Where a
+ * start subtracts the step the material begins on, a stop carries the step it
+ * ends on: the last sample that sounded is held and decayed to zero over the
+ * ramp, added on top of the silence that follows. The material itself is never
+ * attenuated, so a clip stopped a sample before its own tail ends keeps that
+ * tail exactly as far as it got.
+ *
+ * What it is for is the discontinuity of ending mid-material: a session slot
+ * stopped on a beat, a track handed from the arrangement to the session, a
+ * launch that cuts the arrangement off mid-note. None of those end on a zero
+ * crossing except by luck, and the step left behind is a click whose energy is
+ * spread across the spectrum rather than confined below the ramp's own rate.
+ *
+ * It carries across blocks, for the reason StartDeClick does: a ramp that
+ * stopped at the end of the block it began in would decay over min(length,
+ * block) samples, and the same stop would come out differently at 128 samples a
+ * block and at 1024.
+ *
+ * A held value of zero costs nothing, which is why a source can stop through
+ * this unconditionally rather than deciding first whether it clicks.
+ */
+class StopDeClick {
+  public:
+    /// The most channels one source renders, as StartDeClick sizes it.
+    static constexpr std::size_t kMaxChannels = StartDeClick::kMaxChannels;
+
+    /// Remember where @p audio ended. Called with what sounded, every block a
+    /// source produces anything, so a stop landing on the first sample of some
+    /// later block still knows what it is stepping down from.
+    void push(juce::dsp::AudioBlock<float> audio);
+
+    /**
+     * @brief Start decaying at @p offset samples into @p audio.
+     *
+     * The value decayed is the sample before @p offset when the stop lands
+     * inside a block that sounded, and the one @ref push last saw when it lands
+     * on the block's first sample. Those are the same sample; which side of a
+     * callback boundary it fell on is not something a stop should be able to
+     * hear.
+     */
+    void begin(juce::dsp::AudioBlock<float> audio, int offset, int fadeSamples);
+
+    /// Carry on from the start of @p audio. Does nothing once the ramp has run
+    /// out, so a caller can ask every block without checking.
+    void advance(juce::dsp::AudioBlock<float> audio);
+
+    /// Whether there is any decay left to add.
+    bool active() const {
+        return done_ < length_;
+    }
+
+    /// Forget the ramp and what it was decaying, for a source starting over.
+    void reset() {
+        held_.fill(0.0f);
+        length_ = 0;
+        done_ = 0;
+    }
+
+  private:
+    void applyFrom(juce::dsp::AudioBlock<float> audio, int offset, int alreadyDone);
+
+    std::array<float, kMaxChannels> held_{};
+    int length_ = 0;
+    int done_ = 0;
+};
+
 }  // namespace magda::engine

--- a/magda/engine/clip/FadeCurves.hpp
+++ b/magda/engine/clip/FadeCurves.hpp
@@ -145,25 +145,28 @@ class StopDeClick {
     /**
      * @brief Remember where @p audio ended.
      *
-     * Called with what sounded, every block a source produces anything, so a
-     * stop landing on the first sample of some later block still knows what it
-     * is stepping down from.
+     * The contract, and the whole of it: call this with what you rendered,
+     * before anything corrects it. Then what is remembered is always the last
+     * sample of your own signal, and @ref begin never has to guess which of the
+     * things in a buffer was yours.
      *
-     * Does nothing while a ramp is running: the buffer then holds the value
-     * being decayed rather than a signal, and remembering that would bend the
-     * rest of the ramp. Safe to call unconditionally, which is how a source
-     * that does not track its own ramps wants to call it.
+     * Getting that order wrong is what every way of using this wrongly looks
+     * like. Push a buffer a ramp has already been added to and the remembered
+     * sample is part decayed correction rather than signal; push a buffer
+     * somebody else also wrote into and it is their signal too, and a ramp that
+     * decays it corrects for something that never stopped. The caller that owns
+     * one signal is the caller that can push, which is why a voice pushes its
+     * own region and a source pushes its own output.
      */
     void push(juce::dsp::AudioBlock<float> audio);
 
     /**
-     * @brief Start decaying at @p offset samples into @p audio.
+     * @brief Start decaying into @p audio from @p offset, over @p fadeSamples.
      *
-     * The value decayed is the sample before @p offset when the stop lands
-     * inside a block that sounded, and the one @ref push last saw when it lands
-     * on the block's first sample. Those are the same sample; which side of a
-     * callback boundary it fell on is not something a stop should be able to
-     * hear.
+     * What it decays is what @ref push last remembered, never anything read
+     * back out of @p audio: by the time a stop is applied that buffer may hold
+     * other voices, an earlier ramp, or nothing at all, and none of those is
+     * the signal that stopped.
      */
     void begin(juce::dsp::AudioBlock<float> audio, int offset, int fadeSamples);
 

--- a/magda/engine/clip/SessionPlayback.hpp
+++ b/magda/engine/clip/SessionPlayback.hpp
@@ -120,62 +120,70 @@ inline EdgeSample splitSample(const BlockInfo& block, const SplitStatus& status)
 constexpr int kSectionDeClickSamples = 32;
 
 /**
- * @brief Which section owns a track across one block, and where that changed.
+ * @brief The stretch of a block the arrangement sounds, and what happens at its ends.
  *
- * A track plays its arrangement or its session, never both (#2302), and this is
- * the whole of who owns it when: not a final state a caller then reconciles
- * against what it remembers, but the block's own ownership, start to end.
+ * A track plays its arrangement or its session, never both (#2302). This is
+ * that as a span rather than as endpoints a caller then reconciles: the samples
+ * the arrangement owns, and whether each end of them is an edge that has to be
+ * ramped or merely where the block stopped.
  *
- * That distinction is the point. Combining "who owns it at the end" with a
- * caller's memory of the last block cannot express a block in which the session
- * gave the track up and took it again, so the arrangement lost an interval it
- * owned (#2344 review). Two transitions is what a block can hold, because the
- * two directions happen at different kinds of instant: a session takes a track
- * at the sample its slot launches, and gives one up at a block boundary, since
- * a release is a request the advance applies at sample zero.
+ * One span is enough, and it always begins at the block's first sample. The two
+ * directions happen at different kinds of instant and that is what bounds it: a
+ * session takes a track on the sample its slot launches, and gives one up at a
+ * block boundary, because a release is a request the advance applies at sample
+ * zero. So the arrangement can only ever gain the track at zero and lose it
+ * once, and a list of spans could hold no more than this does.
  *
- * Derived rather than stored, from the table both of a track's sources already
- * read, after the launcher has advanced every handle and before anything
- * renders. Two sources folding the same table over the same block reach the
- * same answer, which is what keeps a track's audio and its MIDI on the same
- * side of the switch without a third thing to publish between them, and with
- * nothing of their own to keep in step.
+ * Saying it as a span is what makes a zero-length one harmless. Ownership
+ * expressed as endpoints plus flags cannot tell "the arrangement had the track
+ * for no samples" from "the arrangement had the track", and the difference is
+ * whether there is an edge to ramp: a slot released and another launched on the
+ * same sample would otherwise start a stop ramp over a signal that was not
+ * playing, decaying whatever the arrangement last pushed, from before the
+ * session took the track at all (#2344 review).
+ *
+ * Derived rather than stored, from the table both of a track's sources read,
+ * after the launcher has advanced every handle and before anything renders. Two
+ * sources folding the same table over the same block reach the same answer,
+ * which is what keeps a track's audio and its MIDI on the same side of every
+ * switch with nothing of their own to keep in step.
  */
 struct SectionHold {
-    /// Who owns the block's first sample, after any release has applied.
-    Section atStart = Section::Arrangement;
+    /// The edge past which the arrangement is silent. Zero for a block the
+    /// session owns entirely.
+    EdgeSample until{0};
 
-    /// Who owns its last.
-    Section atEnd = Section::Arrangement;
+    /// Whether the arrangement takes the track at the block's first sample
+    /// rather than already having it: a resume, which lands mid-material and
+    /// owes both a ramp out of silence and a chase of what is sounding there.
+    ///
+    /// Never set for a span with no samples in it, because nothing resumes.
+    bool gained = false;
 
-    /// Where @ref atEnd took the track, when the two differ.
-    EdgeSample changeAt{0};
+    /// Whether it loses the track at @ref until rather than simply running to
+    /// the end of the block: the edge that has to be carried down, and that
+    /// owes note-offs for whatever it had sounding.
+    ///
+    /// Set for a span with no samples in it only when the arrangement owned the
+    /// block before this one, which is a launch landing on a callback boundary:
+    /// there is a step there, and it comes off the block before.
+    bool lost = false;
 
-    /// Whether the session gave the track up in this block. Needed as well as
-    /// @ref atStart, and not implied by it: by the time the arrangement owns
-    /// the first sample the release has already happened, so this is the only
-    /// thing that separates a track just handed back from one never taken.
-    bool handedBack = false;
-
-    /// The edge past which the arrangement is silent, over a block of @p
-    /// numSamples. The one question both sources ask.
-    EdgeSample arrangementUntil(int numSamples) const {
-        if (atStart == Section::Session)
-            return EdgeSample{0};
-
-        if (atEnd == Section::Session)
-            return changeAt;
-
-        return EdgeSample{numSamples};
+    /// Whether the arrangement sounds any of this block.
+    bool sounds() const {
+        return until.value > 0;
     }
 };
 
 /// @copydoc SectionHold
-inline SectionHold sectionHold(const LaunchHandleTable& handles, TrackId trackId) {
+inline SectionHold sectionHold(const LaunchHandleTable& handles, TrackId trackId, int numSamples) {
     const auto [first, last] = handles.rangeFor(trackId);
 
-    SectionHold hold;
-    auto held = false;
+    // Who owned the track before anything in this block, who owns its first
+    // sample once releases have applied, and who owns its last.
+    auto sessionBefore = false;
+    auto sessionAtZero = false;
+    auto sessionAtEnd = false;
     auto takenAt = std::numeric_limits<int>::max();
 
     for (const auto* entry = first; entry != last; ++entry) {
@@ -184,34 +192,40 @@ inline SectionHold sectionHold(const LaunchHandleTable& handles, TrackId trackId
 
         const auto& status = entry->handle->blockStatus();
 
-        // Who owns the first sample: a slot that held the track when the block
-        // opened and did not give it up here. A release applies at sample zero,
-        // so a slot that was released holds nothing by the time anything sounds.
-        if (status.heldSectionAtStart && !status.releasedSection)
-            hold.atStart = Section::Session;
+        sessionBefore = sessionBefore || status.heldSectionAtStart;
 
-        hold.handedBack = hold.handedBack || status.releasedSection;
+        // A release applies on the first sample, so a slot that was released
+        // holds nothing by the time anything sounds.
+        const auto heldThrough = status.heldSectionAtStart && !status.releasedSection;
+        sessionAtZero = sessionAtZero || heldThrough;
 
         if (!entry->handle->holdsSection())
             continue;
 
-        held = true;
+        sessionAtEnd = true;
 
-        // Where this slot took the track. One already holding it at the start
-        // took it before this block; one that launched here took it on the
-        // sample it launched.
-        if (status.heldSectionAtStart && !status.releasedSection)
+        // Where this slot took the track. One that already had it took it
+        // before this block; one that launched here took it on its own sample.
+        if (heldThrough || status.beforeEvent.playing())
             takenAt = 0;
         else if (status.afterEvent && status.afterEvent->playing())
             takenAt = std::min(takenAt, status.event.sample);
-        else if (status.beforeEvent.playing())
-            takenAt = 0;
     }
 
-    hold.atEnd = held ? Section::Session : Section::Arrangement;
+    SectionHold hold;
 
-    if (hold.atStart != hold.atEnd && takenAt != std::numeric_limits<int>::max())
-        hold.changeAt = EdgeSample{takenAt};
+    if (sessionAtZero)
+        hold.until = EdgeSample{0};
+    else if (sessionAtEnd && takenAt != std::numeric_limits<int>::max())
+        hold.until = EdgeSample{std::clamp(takenAt, 0, numSamples)};
+    else
+        hold.until = EdgeSample{numSamples};
+
+    // Both edges are about a signal, so neither exists without one. The
+    // exception is a loss on a block boundary, where the signal is the block
+    // before's and the step is still there.
+    hold.gained = sessionBefore && !sessionAtZero && hold.sounds();
+    hold.lost = sessionAtEnd && (hold.sounds() || !sessionBefore);
 
     return hold;
 }

--- a/magda/engine/clip/SessionPlayback.hpp
+++ b/magda/engine/clip/SessionPlayback.hpp
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <algorithm>
+#include <limits>
+
 #include "clip/ClipSnapshot.hpp"
 #include "exec/RenderContext.hpp"
 #include "launch/SessionLauncher.hpp"
@@ -92,6 +95,83 @@ inline BlockInfo materialSubBlock(const BlockInfo& block, const BeatRange& range
 /// other begins, and with no event it is the boundary past the last sample.
 inline EdgeSample splitSample(const BlockInfo& block, const SplitStatus& status) {
     return EdgeSample{status.afterEvent ? status.event.sample : block.numSamples};
+}
+
+/**
+ * @brief How long a section takes to hand a track over, and to take it back.
+ *
+ * Short, and much shorter than ClipInfo::launchFadeSamples, because it is the
+ * other kind of ramp. A start de-click subtracts an offset from material that
+ * goes on sounding underneath it, so its length costs nothing and 256 samples
+ * buys a gentler correction. A stop de-click has no material underneath: what
+ * it spends its length on is a held constant, and 5 ms of one is a thump in
+ * place of a click rather than the absence of both.
+ *
+ * 32 samples puts what the correction does spend below about 750 Hz at 48 kHz,
+ * which is under the step's own broadband energy without lasting long enough to
+ * be heard as a level of its own. The incumbent spends between 10 and 40 on the
+ * same edge, in two places that disagree with each other; this is one number
+ * for one job.
+ *
+ * A constant rather than a per-clip figure, unlike a slot's own launch ramp: an
+ * arrangement handed over is a whole track's worth of clips at once, and no one
+ * of them owns the number.
+ */
+constexpr int kSectionDeClickSamples = 32;
+
+/**
+ * @brief Which section a track sounds over one block, and where that changed.
+ *
+ * A track plays its arrangement or its session, never both (#2302). The answer
+ * is the fold over the track's slots: the session holds the track if any slot
+ * holds it, and it took it over at the earliest sample any of them began on.
+ *
+ * Derived rather than stored, from the table both of a track's sources already
+ * read, after the launcher has advanced every handle and before anything
+ * renders. Two sources folding the same table over the same block reach the
+ * same answer, which is what keeps the audio and the MIDI of one track on the
+ * same side of the switch without a third thing to publish between them.
+ */
+struct SectionHold {
+    /// Whether the session holds the track when this block ends.
+    bool session = false;
+
+    /// Where it took the track over, for the block in which that happened.
+    /// Zero when it already held it, which is also what a caller that was
+    /// already handed over does with it: mute the whole block.
+    EdgeSample takenAt{0};
+};
+
+/// @copydoc SectionHold
+inline SectionHold sectionHold(const LaunchHandleTable& handles, TrackId trackId) {
+    const auto [first, last] = handles.rangeFor(trackId);
+
+    SectionHold hold;
+    auto earliest = std::numeric_limits<int>::max();
+
+    for (const auto* entry = first; entry != last; ++entry) {
+        if (entry->handle == nullptr || !entry->handle->holdsSection())
+            continue;
+
+        hold.session = true;
+
+        // Where this slot began sounding within the block, if it did. A slot
+        // already playing when the block opened took the track at its start; a
+        // slot that holds the track and sounded nothing here is one that
+        // stopped in an earlier block and is still holding it, which is the
+        // same answer.
+        const auto& status = entry->handle->blockStatus();
+
+        if (status.beforeEvent.playing())
+            earliest = 0;
+        else if (status.afterEvent && status.afterEvent->playing())
+            earliest = std::min(earliest, status.event.sample);
+    }
+
+    if (hold.session && earliest != std::numeric_limits<int>::max())
+        hold.takenAt = EdgeSample{earliest};
+
+    return hold;
 }
 
 /**

--- a/magda/engine/clip/SessionPlayback.hpp
+++ b/magda/engine/clip/SessionPlayback.hpp
@@ -120,26 +120,54 @@ inline EdgeSample splitSample(const BlockInfo& block, const SplitStatus& status)
 constexpr int kSectionDeClickSamples = 32;
 
 /**
- * @brief Which section a track sounds over one block, and where that changed.
+ * @brief Which section owns a track across one block, and where that changed.
  *
- * A track plays its arrangement or its session, never both (#2302). The answer
- * is the fold over the track's slots: the session holds the track if any slot
- * holds it, and it took it over at the earliest sample any of them began on.
+ * A track plays its arrangement or its session, never both (#2302), and this is
+ * the whole of who owns it when: not a final state a caller then reconciles
+ * against what it remembers, but the block's own ownership, start to end.
+ *
+ * That distinction is the point. Combining "who owns it at the end" with a
+ * caller's memory of the last block cannot express a block in which the session
+ * gave the track up and took it again, so the arrangement lost an interval it
+ * owned (#2344 review). Two transitions is what a block can hold, because the
+ * two directions happen at different kinds of instant: a session takes a track
+ * at the sample its slot launches, and gives one up at a block boundary, since
+ * a release is a request the advance applies at sample zero.
  *
  * Derived rather than stored, from the table both of a track's sources already
  * read, after the launcher has advanced every handle and before anything
  * renders. Two sources folding the same table over the same block reach the
- * same answer, which is what keeps the audio and the MIDI of one track on the
- * same side of the switch without a third thing to publish between them.
+ * same answer, which is what keeps a track's audio and its MIDI on the same
+ * side of the switch without a third thing to publish between them, and with
+ * nothing of their own to keep in step.
  */
 struct SectionHold {
-    /// Whether the session holds the track when this block ends.
-    bool session = false;
+    /// Who owns the block's first sample, after any release has applied.
+    Section atStart = Section::Arrangement;
 
-    /// Where it took the track over, for the block in which that happened.
-    /// Zero when it already held it, which is also what a caller that was
-    /// already handed over does with it: mute the whole block.
-    EdgeSample takenAt{0};
+    /// Who owns its last.
+    Section atEnd = Section::Arrangement;
+
+    /// Where @ref atEnd took the track, when the two differ.
+    EdgeSample changeAt{0};
+
+    /// Whether the session gave the track up in this block. Needed as well as
+    /// @ref atStart, and not implied by it: by the time the arrangement owns
+    /// the first sample the release has already happened, so this is the only
+    /// thing that separates a track just handed back from one never taken.
+    bool handedBack = false;
+
+    /// The edge past which the arrangement is silent, over a block of @p
+    /// numSamples. The one question both sources ask.
+    EdgeSample arrangementUntil(int numSamples) const {
+        if (atStart == Section::Session)
+            return EdgeSample{0};
+
+        if (atEnd == Section::Session)
+            return changeAt;
+
+        return EdgeSample{numSamples};
+    }
 };
 
 /// @copydoc SectionHold
@@ -147,29 +175,43 @@ inline SectionHold sectionHold(const LaunchHandleTable& handles, TrackId trackId
     const auto [first, last] = handles.rangeFor(trackId);
 
     SectionHold hold;
-    auto earliest = std::numeric_limits<int>::max();
+    auto held = false;
+    auto takenAt = std::numeric_limits<int>::max();
 
     for (const auto* entry = first; entry != last; ++entry) {
-        if (entry->handle == nullptr || !entry->handle->holdsSection())
+        if (entry->handle == nullptr)
             continue;
 
-        hold.session = true;
-
-        // Where this slot began sounding within the block, if it did. A slot
-        // already playing when the block opened took the track at its start; a
-        // slot that holds the track and sounded nothing here is one that
-        // stopped in an earlier block and is still holding it, which is the
-        // same answer.
         const auto& status = entry->handle->blockStatus();
 
-        if (status.beforeEvent.playing())
-            earliest = 0;
+        // Who owns the first sample: a slot that held the track when the block
+        // opened and did not give it up here. A release applies at sample zero,
+        // so a slot that was released holds nothing by the time anything sounds.
+        if (status.heldSectionAtStart && !status.releasedSection)
+            hold.atStart = Section::Session;
+
+        hold.handedBack = hold.handedBack || status.releasedSection;
+
+        if (!entry->handle->holdsSection())
+            continue;
+
+        held = true;
+
+        // Where this slot took the track. One already holding it at the start
+        // took it before this block; one that launched here took it on the
+        // sample it launched.
+        if (status.heldSectionAtStart && !status.releasedSection)
+            takenAt = 0;
         else if (status.afterEvent && status.afterEvent->playing())
-            earliest = std::min(earliest, status.event.sample);
+            takenAt = std::min(takenAt, status.event.sample);
+        else if (status.beforeEvent.playing())
+            takenAt = 0;
     }
 
-    if (hold.session && earliest != std::numeric_limits<int>::max())
-        hold.takenAt = EdgeSample{earliest};
+    hold.atEnd = held ? Section::Session : Section::Arrangement;
+
+    if (hold.atStart != hold.atEnd && takenAt != std::numeric_limits<int>::max())
+        hold.changeAt = EdgeSample{takenAt};
 
     return hold;
 }

--- a/magda/engine/clip/SessionPlayback.hpp
+++ b/magda/engine/clip/SessionPlayback.hpp
@@ -173,11 +173,30 @@ struct SectionHold {
     bool sounds() const {
         return until.value > 0;
     }
+
+    /// The whole of a block, with no edges: a track nothing can launch on.
+    ///
+    /// Named rather than left to a default, because the right answer is the
+    /// block's length and a default cannot know it. Defaulting to zero says the
+    /// session owns everything, which is the opposite of what a track with no
+    /// handles is, and silences its arrangement (#2344 review).
+    static SectionHold arrangement(int numSamples) {
+        return SectionHold{EdgeSample{numSamples}, false, false};
+    }
 };
 
-/// @copydoc SectionHold
-inline SectionHold sectionHold(const LaunchHandleTable& handles, TrackId trackId, int numSamples) {
-    const auto [first, last] = handles.rangeFor(trackId);
+/**
+ * @copydoc SectionHold
+ *
+ * @p handles is null until the store has published a table, which is a session
+ * whose slots have no handles yet rather than an error (SessionLauncher.hpp).
+ * Nothing can hold a track then, so the arrangement has all of it.
+ */
+inline SectionHold sectionHold(const LaunchHandleTable* handles, TrackId trackId, int numSamples) {
+    if (handles == nullptr)
+        return SectionHold::arrangement(numSamples);
+
+    const auto [first, last] = handles->rangeFor(trackId);
 
     // Who owned the track before anything in this block, who owns its first
     // sample once releases have applied, and who owns its last.

--- a/magda/engine/launch/LaunchHandle.cpp
+++ b/magda/engine/launch/LaunchHandle.cpp
@@ -171,10 +171,13 @@ std::optional<BeatRange> LaunchHandle::lastPlayedRange() const {
 }
 
 void LaunchHandle::releaseSection() {
-    if (playState_ == PlayState::playing)
-        endRun();
+    // A request rather than a state change, like every other way a slot stops.
+    // The advance is what turns a stop into an edge a source can see and ramp;
+    // a run ended behind their backs is a step nobody is told about, and the
+    // slot would cut off rather than decay (#2344 review). It also replaces a
+    // queued launch, so nothing fires after the track has been handed back.
+    stop(std::nullopt);
 
-    pending_.reset();
     holdsSection_ = false;
 }
 
@@ -283,6 +286,10 @@ SplitStatus LaunchHandle::advanceOver(const SyncRange& range) {
 
     SplitStatus status;
     status.beforeEvent.range = range.timeline;
+
+    // Before anything below can apply an event and change it. A stop landing on
+    // the first sample leaves no first half to read this off afterwards.
+    status.soundingAtStart = playState_ == PlayState::playing;
 
     // What happens inside this block, in monotonic beats. At most one, and a
     // request always outranks a loop wrap.

--- a/magda/engine/launch/LaunchHandle.cpp
+++ b/magda/engine/launch/LaunchHandle.cpp
@@ -94,11 +94,11 @@ std::optional<double> LaunchHandle::queuedPosition() const {
 }
 
 void LaunchHandle::play(std::optional<double> monotonicBeat) {
-    pending_ = Pending{QueueState::playQueued, monotonicBeat, {}};
+    pending_ = Pending{QueueState::playQueued, monotonicBeat, {}, false};
 }
 
 void LaunchHandle::stop(std::optional<double> monotonicBeat) {
-    pending_ = Pending{QueueState::stopQueued, monotonicBeat, {}};
+    pending_ = Pending{QueueState::stopQueued, monotonicBeat, {}, false};
 }
 
 void LaunchHandle::playSynced(const LaunchHandle& other, std::optional<double> monotonicBeat) {
@@ -110,7 +110,7 @@ void LaunchHandle::playSynced(const LaunchHandle& other, std::optional<double> m
     // The whole run, because its faces are one instant. Copying some of them
     // and deriving the rest is how two handles end up agreeing about the bar
     // and not the sample.
-    pending_ = Pending{QueueState::playQueued, monotonicBeat, other.run_};
+    pending_ = Pending{QueueState::playQueued, monotonicBeat, other.run_, false};
 }
 
 void LaunchHandle::setLooping(std::optional<double> beats) {
@@ -174,11 +174,13 @@ void LaunchHandle::releaseSection() {
     // A request rather than a state change, like every other way a slot stops.
     // The advance is what turns a stop into an edge a source can see and ramp;
     // a run ended behind their backs is a step nobody is told about, and the
-    // slot would cut off rather than decay (#2344 review). It also replaces a
-    // queued launch, so nothing fires after the track has been handed back.
+    // slot would cut off rather than decay (#2344 review).
+    //
+    // The stop and the hand-back are one request, so a later one replaces both
+    // or neither: a launch arriving before the next block means the clip is
+    // what was wanted, and it keeps the track it was already holding.
     stop(std::nullopt);
-
-    releasePending_ = true;
+    pending_->releasesSection = true;
 }
 
 void LaunchHandle::beginRun(const SyncRange& range, const BlockInstant& at, double scheduledBeat) {
@@ -265,6 +267,13 @@ void LaunchHandle::applyEvent(const SyncRange& range, bool fromPending, const Bl
 
     if (pending.state == QueueState::stopQueued) {
         endRun();
+
+        // The hand-back happens where the stop does, because it is the same
+        // request: the slot cannot give a track up on one sample and fall
+        // silent on another.
+        if (pending.releasesSection)
+            holdsSection_ = false;
+
         return;
     }
 
@@ -292,15 +301,6 @@ SplitStatus LaunchHandle::advanceOver(const SyncRange& range) {
     status.soundingAtStart = playState_ == PlayState::playing;
     status.heldSectionAtStart = holdsSection_;
 
-    // At the block's first sample, which is where a request that arrived
-    // between blocks happens. A launch inside this block can take the track
-    // back afterwards, and the two are different samples.
-    if (releasePending_) {
-        holdsSection_ = false;
-        releasePending_ = false;
-        status.releasedSection = true;
-    }
-
     // What happens inside this block, in monotonic beats. At most one, and a
     // request always outranks a loop wrap.
     //
@@ -327,6 +327,13 @@ SplitStatus LaunchHandle::advanceOver(const SyncRange& range) {
             eventBeat = *position;
             fromPending = true;
         }
+
+        // Reported here because applyEvent consumes the request: by the time it
+        // has run there is nothing left to ask. A hand-back is always at the
+        // block's first sample, since Back to Arrangement queues its stop for
+        // as soon as possible.
+        status.releasedSection =
+            fromPending && pending_->state == QueueState::stopQueued && pending_->releasesSection;
     }
 
     if (!eventBeat && playState_ == PlayState::playing && loopBeats_ && run_) {

--- a/magda/engine/launch/LaunchHandle.cpp
+++ b/magda/engine/launch/LaunchHandle.cpp
@@ -178,7 +178,7 @@ void LaunchHandle::releaseSection() {
     // queued launch, so nothing fires after the track has been handed back.
     stop(std::nullopt);
 
-    holdsSection_ = false;
+    releasePending_ = true;
 }
 
 void LaunchHandle::beginRun(const SyncRange& range, const BlockInstant& at, double scheduledBeat) {
@@ -290,6 +290,16 @@ SplitStatus LaunchHandle::advanceOver(const SyncRange& range) {
     // Before anything below can apply an event and change it. A stop landing on
     // the first sample leaves no first half to read this off afterwards.
     status.soundingAtStart = playState_ == PlayState::playing;
+    status.heldSectionAtStart = holdsSection_;
+
+    // At the block's first sample, which is where a request that arrived
+    // between blocks happens. A launch inside this block can take the track
+    // back afterwards, and the two are different samples.
+    if (releasePending_) {
+        holdsSection_ = false;
+        releasePending_ = false;
+        status.releasedSection = true;
+    }
 
     // What happens inside this block, in monotonic beats. At most one, and a
     // request always outranks a loop wrap.

--- a/magda/engine/launch/LaunchHandle.cpp
+++ b/magda/engine/launch/LaunchHandle.cpp
@@ -170,11 +170,24 @@ std::optional<BeatRange> LaunchHandle::lastPlayedRange() const {
     return lastPlayed_;
 }
 
+void LaunchHandle::releaseSection() {
+    if (playState_ == PlayState::playing)
+        endRun();
+
+    pending_.reset();
+    holdsSection_ = false;
+}
+
 void LaunchHandle::beginRun(const SyncRange& range, const BlockInstant& at, double scheduledBeat) {
     if (const auto played = playedRange())
         lastPlayed_ = played;
 
     playState_ = PlayState::playing;
+
+    // The hand-over, at the sample the run begins on rather than at the one it
+    // was asked on: a launch quantized to the next bar leaves the arrangement
+    // playing until the bar (#2302).
+    holdsSection_ = true;
 
     Run run;
     run.origin = at.monotonic;
@@ -196,6 +209,7 @@ void LaunchHandle::joinRun(const SyncRange& range, const BlockInstant& at, const
         lastPlayed_ = played;
 
     playState_ = PlayState::playing;
+    holdsSection_ = true;
 
     // Adopting the position, not just the origin. Derived here rather than at
     // the request, which is a different number whenever the launch was queued

--- a/magda/engine/launch/LaunchHandle.hpp
+++ b/magda/engine/launch/LaunchHandle.hpp
@@ -508,6 +508,15 @@ class LaunchHandle {
         /// Set only by playSynced: the run to join rather than start. The whole
         /// of it, or the handles agree about the bar and not the sample.
         std::optional<Run> synced;
+
+        /// Whether this stop is Back to Arrangement rather than an ordinary
+        /// one, so the slot gives the track up as it stops.
+        ///
+        /// Here rather than beside it, because a request replaces this one
+        /// whole. Two fields would let a later play cancel the stop and leave
+        /// the hand-back behind, and the slot would go on sounding while the
+        /// track said it belonged to the arrangement (#2344 review).
+        bool releasesSection = false;
     };
 
     /// Begin a run at @p at, scheduled for @p scheduledBeat.
@@ -552,9 +561,6 @@ class LaunchHandle {
 
     /// Whether this slot has sounded since the last release (#2302).
     bool holdsSection_ = false;
-
-    /// A release waiting for the advance that applies it.
-    bool releasePending_ = false;
 
     SplitStatus blockStatus_;
 

--- a/magda/engine/launch/LaunchHandle.hpp
+++ b/magda/engine/launch/LaunchHandle.hpp
@@ -251,10 +251,37 @@ struct SplitStatus {
     /// rather than working the position out a second time and differently.
     BlockInstant event;
 
+    /**
+     * @brief Whether the slot was sounding when the block opened.
+     *
+     * Not the same as @ref beforeEvent playing, and that is the whole of it: an
+     * event at or before the first sample puts the whole block in the new state
+     * and reports no first half, so a slot stopped there looks exactly like one
+     * stopped ten blocks ago. It is still an edge, and this is what the handle
+     * knows about it that nothing downstream can work out (#2344 review).
+     */
+    bool soundingAtStart = false;
+
     /// Whether the slot is sounding when the block ends, which is what decides
     /// whether a stop owes note-offs.
     bool playingAtEnd() const {
         return afterEvent ? afterEvent->playing() : beforeEvent.playing();
+    }
+
+    /**
+     * @brief Where the slot stopped sounding inside this block, if it did.
+     *
+     * The one question a de-click asks, answered in one place because the two
+     * shapes a stop arrives in have the same answer: @ref event is the sample
+     * the block ran into whatever it ran into, whether or not there was a first
+     * half to report. Absent when the slot sounded nothing here, and when it is
+     * still sounding at the end.
+     */
+    std::optional<EdgeSample> silencedAt() const {
+        if (!soundingAtStart || playingAtEnd())
+            return std::nullopt;
+
+        return EdgeSample{std::max(0, event.sample)};
     }
 };
 
@@ -382,8 +409,8 @@ class LaunchHandle {
         return holdsSection_;
     }
 
-    /// Give the track back to its arrangement, stopping this slot at once if it
-    /// is playing. The engine side of Back to Arrangement.
+    /// Give the track back to its arrangement, stopping this slot as soon as
+    /// the next block begins. The engine side of Back to Arrangement.
     void releaseSection();
 
     /**

--- a/magda/engine/launch/LaunchHandle.hpp
+++ b/magda/engine/launch/LaunchHandle.hpp
@@ -362,6 +362,31 @@ class LaunchHandle {
     std::optional<BeatRange> lastPlayedRange() const;
 
     /**
+     * @brief Whether this slot holds its track's playback (#2302).
+     *
+     * A track sounds its arrangement or its session, never both, and launching
+     * a slot is what hands it over. The hand-back is not the slot stopping:
+     * silence after a stop is the session still holding the track, exactly as
+     * it is in the incumbent, and the arrangement comes back only when
+     * @ref releaseSection asks for it.
+     *
+     * Set the moment a run begins rather than when one is queued, so a launch
+     * quantized to the next bar leaves the arrangement playing until the bar.
+     *
+     * Per slot for a question that is per track, because the track's answer is
+     * the fold: a track is held by whichever of its slots holds it. Keeping it
+     * here is what lets both of a slot's sources reach the same answer from the
+     * table they already read, with nothing published between them.
+     */
+    bool holdsSection() const {
+        return holdsSection_;
+    }
+
+    /// Give the track back to its arrangement, stopping this slot at once if it
+    /// is playing. The engine side of Back to Arrangement.
+    void releaseSection();
+
+    /**
      * @brief Blocks in which a loop was too short to be re-triggered fully.
      *
      * A handle reports one event per block, so a loop duration shorter than a
@@ -481,6 +506,9 @@ class LaunchHandle {
     std::optional<BeatRange> lastPlayed_;
 
     std::optional<double> loopBeats_;
+
+    /// Whether this slot has sounded since the last release (#2302).
+    bool holdsSection_ = false;
 
     SplitStatus blockStatus_;
 

--- a/magda/engine/launch/LaunchHandle.hpp
+++ b/magda/engine/launch/LaunchHandle.hpp
@@ -262,6 +262,16 @@ struct SplitStatus {
      */
     bool soundingAtStart = false;
 
+    /// Whether this slot held its track when the block opened, before anything
+    /// in it applied (@ref LaunchHandle::holdsSection).
+    bool heldSectionAtStart = false;
+
+    /// Whether this slot gave its track up in this block. A release is a
+    /// request the advance applies at sample zero, so ownership of the first
+    /// sample already reflects it and nothing downstream could otherwise tell a
+    /// track just handed back from one that was never taken.
+    bool releasedSection = false;
+
     /// Whether the slot is sounding when the block ends, which is what decides
     /// whether a stop owes note-offs.
     bool playingAtEnd() const {
@@ -409,8 +419,14 @@ class LaunchHandle {
         return holdsSection_;
     }
 
-    /// Give the track back to its arrangement, stopping this slot as soon as
-    /// the next block begins. The engine side of Back to Arrangement.
+    /**
+     * @brief Give the track back to its arrangement. Back to Arrangement.
+     *
+     * A request, applied by the next advance: the slot stops and the hold goes
+     * at that block's first sample, and the block reports both. Every change of
+     * this state goes through the advance for the reason every stop does, which
+     * is that an edge nothing was told about is an edge nothing can ramp.
+     */
     void releaseSection();
 
     /**
@@ -536,6 +552,9 @@ class LaunchHandle {
 
     /// Whether this slot has sounded since the last release (#2302).
     bool holdsSection_ = false;
+
+    /// A release waiting for the advance that applies it.
+    bool releasePending_ = false;
 
     SplitStatus blockStatus_;
 

--- a/magda/engine/launch/SessionLauncher.hpp
+++ b/magda/engine/launch/SessionLauncher.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <farbot/RealtimeObject.hpp>
 #include <memory>
 #include <utility>
@@ -30,6 +31,17 @@
  */
 
 namespace magda::engine {
+
+/**
+ * @brief Which of a track's two bodies of material a source plays (#2302).
+ *
+ * A track has both and sounds one: the arrangement laid out on the timeline,
+ * and the session's slots positioned by their handles. Stated rather than
+ * inferred from whether a source was given a handle feed, because both sources
+ * need the feed now: the one that plays the arrangement reads it to know when
+ * the session has taken the track off it.
+ */
+enum class Section : std::uint8_t { Arrangement, Session };
 
 /// Every slot's handle, at one moment. Sorted by slot key, so a source finds
 /// its track's range without hashing. Not owned: the store keeps them alive for

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -379,6 +379,9 @@ if(MAGDA_BUILD_NATIVE_ENGINE)
     list(APPEND TEST_SOURCES engine/test_engine_taps.cpp)
     list(APPEND TEST_SOURCES engine/test_clip_snapshot.cpp)
     list(APPEND TEST_SOURCES engine/test_clip_voice.cpp)
+    # The two edges of a voice (#2302): the step a start subtracts and the
+    # one a stop carries down, which is what a section switch is made of.
+    list(APPEND TEST_SOURCES engine/test_de_click.cpp)
     list(APPEND TEST_SOURCES engine/test_session_playback.cpp)
     list(APPEND TEST_SOURCES engine/test_clip_voice_pool.cpp)
     list(APPEND TEST_SOURCES engine/test_clip_stretch.cpp)

--- a/tests/engine/test_de_click.cpp
+++ b/tests/engine/test_de_click.cpp
@@ -132,6 +132,61 @@ TEST_CASE("A stop ramp longer than the block carries on into the next", "[engine
     }
 }
 
+TEST_CASE("A stop ramp is the same however the render was cut up", "[engine][clip][declick]") {
+    // The property the carried progress exists for, driven the way a source
+    // drives it: push every block, because a source does not track whether one
+    // of its own ramps happens to be running (#2344 review).
+    constexpr int kRamp = 32;
+
+    const auto tailOverBlocks = [](int blockSize) {
+        StopDeClick deClick;
+
+        Signal sounded(blockSize, 1.0f);
+        deClick.push(sounded.block);
+
+        std::vector<float> tail;
+
+        while (static_cast<int>(tail.size()) < kRamp * 2) {
+            Signal out(blockSize);
+
+            if (tail.empty())
+                deClick.begin(out.block, 0, kRamp);
+            else
+                deClick.advance(out.block);
+
+            for (auto sample = 0; sample < blockSize; ++sample)
+                tail.push_back(out.at(sample));
+
+            // What a source does every block, running ramp or not.
+            deClick.push(out.block);
+        }
+
+        return tail;
+    };
+
+    const auto whole = tailOverBlocks(kRamp * 2);
+    const auto chopped = tailOverBlocks(8);
+
+    REQUIRE(chopped.size() >= whole.size());
+
+    for (auto sample = 0; sample < kRamp * 2; ++sample) {
+        INFO("sample " << sample);
+        REQUIRE(chopped[static_cast<std::size_t>(sample)] ==
+                Approx(whole[static_cast<std::size_t>(sample)]).margin(1e-6));
+    }
+
+    // And it is a decay to zero rather than a staircase that restarts at every
+    // seam, which is what refreshing the held sample mid-ramp would make it.
+    for (auto sample = 1; sample < kRamp; ++sample) {
+        INFO("sample " << sample);
+        REQUIRE(chopped[static_cast<std::size_t>(sample)] <=
+                chopped[static_cast<std::size_t>(sample) - 1]);
+    }
+
+    CHECK(chopped[kRamp - 1] == Approx(0.0f).margin(1e-6));
+    CHECK(chopped[kRamp] == Approx(0.0f));
+}
+
 TEST_CASE("A stop on a zero crossing adds nothing at all", "[engine][clip][declick]") {
     Signal signal(64);
 

--- a/tests/engine/test_de_click.cpp
+++ b/tests/engine/test_de_click.cpp
@@ -46,9 +46,10 @@ TEST_CASE("A stop carries the last sample down to zero", "[engine][clip][declick
     // A source at full swing that stops a third of the way into the block. What
     // it leaves behind is a step from 1 to 0, which is the click.
     Signal signal(64, 1.0f);
-    signal.clearFrom(20);
 
     StopDeClick deClick;
+    deClick.push(signal.block.getSubBlock(0, 20));  // what the source rendered
+    signal.clearFrom(20);
     deClick.begin(signal.block, 20, 16);
 
     SECTION("the tail begins where the signal was") {
@@ -100,6 +101,7 @@ TEST_CASE("A stop ramp longer than the block carries on into the next", "[engine
     StopDeClick deClick;
 
     Signal first(32, 1.0f);
+    deClick.push(first.block.getSubBlock(0, 24));
     first.clearFrom(24);
     deClick.begin(first.block, 24, 64);
 
@@ -157,8 +159,9 @@ TEST_CASE("A stop ramp is the same however the render was cut up", "[engine][cli
             for (auto sample = 0; sample < blockSize; ++sample)
                 tail.push_back(out.at(sample));
 
-            // What a source does every block, running ramp or not.
-            deClick.push(out.block);
+            // Nothing is pushed here, because nothing rendered: what is in the
+            // buffer is the ramp itself. A source with material to push would
+            // be pushing that material, not this.
         }
 
         return tail;
@@ -203,9 +206,10 @@ TEST_CASE("A stop ramp of zero leaves the step exactly as it was", "[engine][cli
     // The dual of a launch ramp of zero preserving the leading transient: a
     // caller that asked for no de-click gets the material and nothing else.
     Signal signal(64, 1.0f);
-    signal.clearFrom(20);
 
     StopDeClick deClick;
+    deClick.push(signal.block.getSubBlock(0, 20));
+    signal.clearFrom(20);
     deClick.begin(signal.block, 20, 0);
 
     REQUIRE(signal.at(19) == Approx(1.0f));
@@ -220,10 +224,16 @@ TEST_CASE("A second stop steps down from where the signal is now", "[engine][cli
     StopDeClick deClick;
 
     Signal signal(64, 1.0f);
+    deClick.push(signal.block.getSubBlock(0, 8));
     signal.clearFrom(8);
     deClick.begin(signal.block, 8, 32);
 
-    // The other side comes back at half the level, and goes again.
+    // The other side comes back at half the level, and goes again. What the
+    // caller pushes is its own material at that point, not the buffer, which
+    // by now also holds the first ramp.
+    Signal resumed(8, 0.5f);
+    deClick.push(resumed.block);
+
     for (auto channel = 0; channel < kChannels; ++channel)
         juce::FloatVectorOperations::fill(signal.buffer.getWritePointer(channel) + 16, 0.5f, 8);
     signal.clearFrom(24);

--- a/tests/engine/test_de_click.cpp
+++ b/tests/engine/test_de_click.cpp
@@ -1,0 +1,203 @@
+#include <juce_dsp/juce_dsp.h>
+
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <vector>
+
+#include "clip/FadeCurves.hpp"
+
+using namespace magda::engine;
+using Catch::Approx;
+
+namespace {
+
+constexpr int kChannels = 2;
+
+/// A buffer and a block over it, so a test writes samples rather than plumbing.
+struct Signal {
+    explicit Signal(int numSamples, float value = 0.0f)
+        : buffer(kChannels, numSamples), block(buffer) {
+        buffer.clear();
+
+        if (value != 0.0f)
+            for (auto channel = 0; channel < kChannels; ++channel)
+                juce::FloatVectorOperations::fill(buffer.getWritePointer(channel), value,
+                                                  numSamples);
+    }
+
+    float at(int sample, int channel = 0) const {
+        return buffer.getSample(channel, sample);
+    }
+
+    /// Silence from @p from onwards, which is what a source leaves behind when
+    /// it stops partway through a block.
+    void clearFrom(int from) {
+        for (auto channel = 0; channel < kChannels; ++channel)
+            buffer.clear(channel, from, buffer.getNumSamples() - from);
+    }
+
+    juce::AudioBuffer<float> buffer;
+    juce::dsp::AudioBlock<float> block;
+};
+
+}  // namespace
+
+TEST_CASE("A stop carries the last sample down to zero", "[engine][clip][declick]") {
+    // A source at full swing that stops a third of the way into the block. What
+    // it leaves behind is a step from 1 to 0, which is the click.
+    Signal signal(64, 1.0f);
+    signal.clearFrom(20);
+
+    StopDeClick deClick;
+    deClick.begin(signal.block, 20, 16);
+
+    SECTION("the tail begins where the signal was") {
+        REQUIRE(signal.at(20) == Approx(1.0f));
+    }
+
+    SECTION("and reaches zero by the end of the ramp") {
+        REQUIRE(signal.at(35) == Approx(0.0f).margin(1e-6));
+        REQUIRE(signal.at(36) == Approx(0.0f));
+        REQUIRE(signal.at(63) == Approx(0.0f));
+    }
+
+    SECTION("monotonically, because a decay that overshoots is its own click") {
+        for (auto sample = 21; sample <= 35; ++sample) {
+            INFO("sample " << sample);
+            REQUIRE(signal.at(sample) <= signal.at(sample - 1));
+        }
+    }
+
+    SECTION("and it does not touch what sounded before it") {
+        for (auto sample = 0; sample < 20; ++sample) {
+            INFO("sample " << sample);
+            REQUIRE(signal.at(sample) == Approx(1.0f));
+        }
+    }
+}
+
+TEST_CASE("A stop on a block boundary steps down from the block before it",
+          "[engine][clip][declick]") {
+    // The same stop, one sample later, so it lands on the first sample of the
+    // next callback. Which side of a boundary it fell on is not something a
+    // stop should be able to hear.
+    StopDeClick deClick;
+
+    Signal sounded(64, 1.0f);
+    deClick.push(sounded.block);
+
+    Signal after(64);
+    deClick.begin(after.block, 0, 16);
+
+    REQUIRE(after.at(0) == Approx(1.0f));
+    REQUIRE(after.at(15) == Approx(0.0f).margin(1e-6));
+    REQUIRE(after.at(16) == Approx(0.0f));
+}
+
+TEST_CASE("A stop ramp longer than the block carries on into the next", "[engine][clip][declick]") {
+    // Block size is an I/O batching concept and never a precision one: the same
+    // stop has to come out the same however the render was cut up.
+    StopDeClick deClick;
+
+    Signal first(32, 1.0f);
+    first.clearFrom(24);
+    deClick.begin(first.block, 24, 64);
+
+    REQUIRE(deClick.active());
+    REQUIRE(first.at(24) == Approx(1.0f));
+    REQUIRE(first.at(31) > 0.0f);
+
+    Signal second(64);
+    deClick.advance(second.block);
+
+    SECTION("picking up where the first block left off") {
+        // Continuous across the seam: the 8th sample of the ramp ended the
+        // first block, the 9th begins this one.
+        REQUIRE(second.at(0) < first.at(31));
+        REQUIRE(second.at(0) > 0.0f);
+    }
+
+    SECTION("and ending where a ramp of that length should") {
+        // Eight of the ramp's 64 samples went into the first block, so the
+        // remaining 56 end this one at index 55.
+        REQUIRE(second.at(55) == Approx(0.0f).margin(1e-6));
+        REQUIRE(second.at(56) == Approx(0.0f));
+        REQUIRE(!deClick.active());
+    }
+
+    SECTION("after which asking again costs nothing") {
+        Signal third(64, 0.5f);
+        deClick.advance(third.block);
+        REQUIRE(third.at(0) == Approx(0.5f));
+    }
+}
+
+TEST_CASE("A stop on a zero crossing adds nothing at all", "[engine][clip][declick]") {
+    Signal signal(64);
+
+    StopDeClick deClick;
+    deClick.begin(signal.block, 20, 16);
+
+    for (auto sample = 0; sample < 64; ++sample) {
+        INFO("sample " << sample);
+        REQUIRE(signal.at(sample) == Approx(0.0f));
+    }
+}
+
+TEST_CASE("A stop ramp of zero leaves the step exactly as it was", "[engine][clip][declick]") {
+    // The dual of a launch ramp of zero preserving the leading transient: a
+    // caller that asked for no de-click gets the material and nothing else.
+    Signal signal(64, 1.0f);
+    signal.clearFrom(20);
+
+    StopDeClick deClick;
+    deClick.begin(signal.block, 20, 0);
+
+    REQUIRE(signal.at(19) == Approx(1.0f));
+    REQUIRE(signal.at(20) == Approx(0.0f));
+    REQUIRE(!deClick.active());
+}
+
+TEST_CASE("A second stop steps down from where the signal is now", "[engine][clip][declick]") {
+    // Two switches inside one block, which one ramp cannot both complete. The
+    // second does not resume the first: it decays what is actually there, which
+    // is the only value continuous with what the listener just heard.
+    StopDeClick deClick;
+
+    Signal signal(64, 1.0f);
+    signal.clearFrom(8);
+    deClick.begin(signal.block, 8, 32);
+
+    // The other side comes back at half the level, and goes again.
+    for (auto channel = 0; channel < kChannels; ++channel)
+        juce::FloatVectorOperations::fill(signal.buffer.getWritePointer(channel) + 16, 0.5f, 8);
+    signal.clearFrom(24);
+
+    deClick.begin(signal.block, 24, 32);
+
+    REQUIRE(signal.at(24) == Approx(0.5f));
+    REQUIRE(signal.at(55) == Approx(0.0f).margin(1e-6));
+}
+
+TEST_CASE("The two de-clicks are mirrors of one another", "[engine][clip][declick]") {
+    // A start subtracts the step the material begins on; a stop carries the one
+    // it ends on. Run over the same step in opposite directions they describe
+    // the same curve, which is the property that says the pair is one idea and
+    // not two.
+    constexpr int kLength = 32;
+
+    Signal starting(kLength, 1.0f);
+    StartDeClick start;
+    start.begin(starting.block, kLength);
+
+    Signal stopping(kLength);
+    StopDeClick stop;
+    Signal sounded(4, 1.0f);
+    stop.push(sounded.block);
+    stop.begin(stopping.block, 0, kLength);
+
+    for (auto sample = 0; sample < kLength; ++sample) {
+        INFO("sample " << sample);
+        REQUIRE(starting.at(sample) + stopping.at(sample) == Approx(1.0f));
+    }
+}

--- a/tests/engine/test_session_playback.cpp
+++ b/tests/engine/test_session_playback.cpp
@@ -1409,6 +1409,55 @@ TEST_CASE("A release on its own still hands the track back", "[engine][clip][ses
     CHECK(rig.sessionAt(kSectionDeClickSamples) == Approx(0.0f).margin(1e-5));
 }
 
+TEST_CASE("A slot swap on a boundary leaves no ghost of the arrangement",
+          "[engine][clip][session][section]") {
+    // The arrangement owns nothing in this block: one slot is released and
+    // another launches on the same sample, so its span is zero samples long.
+    // Expressed as endpoints plus flags that reads as "handed back, then lost
+    // at zero", and the stop ramp decayed whatever the arrangement last
+    // pushed, which was from before the session ever took the track
+    // (#2344 review).
+    SwitchRig rig;
+    rig.giveArrangement(1, 1.0f);
+    rig.giveSlot(2, 400.0, 0.5f, kScene);
+    rig.giveSlot(3, 400.0, 0.5f, kScene + 1);
+    rig.publish();
+
+    // The arrangement sounds first, so there is a stale sample to leak.
+    rig.roll(0, 1);
+    REQUIRE(rig.arrangementAt(0) == Approx(1.0f));
+
+    // Then the session takes the track and keeps it for a while.
+    rig.handle.play(std::nullopt);
+    rig.roll(2, 4);
+    REQUIRE(rig.arrangementPeak() == 0.0f);
+    REQUIRE(rig.sessionAt(0) == Approx(0.5f));
+
+    // Release one slot and launch the other, both as soon as possible, so both
+    // land on this block's first sample.
+    rig.handle.releaseSection();
+    rig.second.play(std::nullopt);
+    rig.render(5);
+
+    SECTION("the arrangement stays silent") {
+        CHECK(rig.arrangementPeak() == 0.0f);
+    }
+
+    SECTION("and the track is the two slots swapping, and nothing else") {
+        // The outgoing slot's own ramp is there and belongs there: its voice
+        // carries its 0.5 down while the incoming slot's 0.5 sounds under it.
+        // What must not be there is a third thing.
+        CHECK(rig.sessionAt(0) == Approx(1.0f));
+        CHECK(rig.sessionAt(kSectionDeClickSamples) == Approx(0.5f));
+        CHECK(rig.sessionAt(kBlockSize - 1) == Approx(0.5f));
+
+        for (auto sample = 0; sample < kBlockSize; ++sample) {
+            INFO("sample " << sample);
+            REQUIRE(rig.trackAt(sample) == Approx(rig.sessionAt(sample)));
+        }
+    }
+}
+
 TEST_CASE("A track never sounds both of its sections", "[engine][clip][session][section]") {
     // The property the switch exists for. The two sections are summed into one
     // track input, so a sample both contribute material to is a track playing

--- a/tests/engine/test_session_playback.cpp
+++ b/tests/engine/test_session_playback.cpp
@@ -44,11 +44,13 @@ using magda::engine::ClipSnapshot;
 using magda::engine::ClipSnapshotFeed;
 using magda::engine::ClipStreamFeed;
 using magda::engine::ClipStreamTable;
+using magda::engine::kSectionDeClickSamples;
 using magda::engine::LaunchHandle;
 using magda::engine::LaunchHandleFeed;
 using magda::engine::LaunchHandleTable;
 using magda::engine::PrefetchStream;
 using magda::engine::RenderContext;
+using magda::engine::Section;
 using magda::engine::SessionSlotPlayback;
 using magda::engine::SlotKey;
 using magda::engine::SnapshotSpan;
@@ -89,6 +91,34 @@ class ConstantReader final : public magda::engine::AudioFileReader {
                 destination.setSample(channel, destinationOffset + sample, 1.0f);
         return numSamples;
     }
+};
+
+/// Every sample the same known level, so which section reached the output is
+/// readable off the value.
+class LevelReader final : public magda::engine::AudioFileReader {
+  public:
+    explicit LevelReader(float level) : level_(level) {}
+
+    std::int64_t lengthInSamples() const override {
+        return 10000000;
+    }
+    double sampleRate() const override {
+        return kSampleRate;
+    }
+    int numChannels() const override {
+        return 2;
+    }
+
+    int read(juce::AudioBuffer<float>& destination, int destinationOffset, std::int64_t,
+             int numSamples) override {
+        for (auto channel = 0; channel < destination.getNumChannels(); ++channel)
+            for (auto sample = 0; sample < numSamples; ++sample)
+                destination.setSample(channel, destinationOffset + sample, level_);
+        return numSamples;
+    }
+
+  private:
+    float level_;
 };
 
 /// Sample n reads back as n, so where in the material a sample came from is
@@ -275,7 +305,7 @@ struct AudioRig {
     LaunchHandle handle;
     LaunchHandleTable table;
     LaunchHandleFeed handles;
-    ClipAudioSource source{kTrack, clips, streams, handles};
+    ClipAudioSource source{kTrack, clips, streams, handles, Section::Session};
     ClipStreamTable streamTable;
     juce::AudioBuffer<float> output;
 };
@@ -376,8 +406,116 @@ struct MidiRig {
     LaunchHandle handle;
     LaunchHandleTable table;
     LaunchHandleFeed handles;
-    ClipMidiSource source{kTrack, clips, handles};
+    ClipMidiSource source{kTrack, clips, handles, Section::Session};
     std::vector<Captured> captured;
+};
+
+/// A clip on the timeline, from beat @p start, carrying @p notes.
+ClipInfo arrangementMidiClip(magda::ClipId id, double start, double lengthBeats,
+                             std::vector<MidiNote> notes) {
+    ClipInfo clip;
+    clip.id = id;
+    clip.trackId = kTrack;
+    clip.view = magda::ClipView::Arrangement;
+    clip.setMidiContent();
+    clip.setPlacementBeats(start, lengthBeats);
+    clip.midiNotes = std::move(notes);
+    return clip;
+}
+
+/// One track's MIDI in both sections, with a source for each (#2302).
+struct MidiSwitchRig {
+    MidiSwitchRig() {
+        table.entries.push_back(LaunchHandleTable::Entry{SlotKey{kTrack, kScene}, &handle});
+        handles.publish(std::make_shared<const LaunchHandleTable>(table));
+        arrangement.prepare(context());
+        session.prepare(context());
+    }
+
+    void publish(std::vector<ClipInfo> arrangementClips, std::vector<ClipInfo> sessionClips) {
+        ClipLane lane;
+        lane.trackId = kTrack;
+        lane.clips = std::move(arrangementClips);
+        lane.session = std::move(sessionClips);
+
+        auto compiled = std::make_shared<const ClipSnapshot>(
+            magda::engine::compileClipSnapshot({lane}, {}, tempoMap(), {}));
+        REQUIRE(compiled->diagnostics.empty());
+        clips.publish(compiled);
+    }
+
+    /// Continuous across calls, not just within one: only the very first block
+    /// this rig ever rolls is a discontinuity, or a case that rolls in two
+    /// stages would chase its own notes in the middle.
+    void roll(int first, int last) {
+        for (auto index = first; index <= last; ++index) {
+            const auto block = blockAt(index, rolled_);
+            rolled_ = true;
+
+            magda::engine::advanceLaunchHandles(handles, block);
+
+            capture(arrangement, block, index, fromArrangement);
+            capture(session, block, index, fromSession);
+        }
+    }
+
+    static std::vector<Captured> notesOn(const std::vector<Captured>& all) {
+        std::vector<Captured> out;
+        for (const auto& entry : all)
+            if (entry.message.isNoteOn())
+                out.push_back(entry);
+        return out;
+    }
+
+    static std::vector<Captured> notesOff(const std::vector<Captured>& all) {
+        std::vector<Captured> out;
+        for (const auto& entry : all)
+            if (entry.message.isNoteOff())
+                out.push_back(entry);
+        return out;
+    }
+
+    /// Notes the section left sounding, which is the invariant a hand-over has
+    /// to keep: whatever it started, it owes an off for.
+    static std::vector<std::string> hanging(const std::vector<Captured>& all) {
+        std::vector<std::string> sounding;
+
+        for (const auto& entry : all) {
+            const auto key = std::to_string(entry.message.getChannel()) + ":" +
+                             std::to_string(entry.message.getNoteNumber());
+            const auto found = std::find(sounding.begin(), sounding.end(), key);
+
+            if (entry.message.isNoteOn() && found == sounding.end())
+                sounding.push_back(key);
+            else if (entry.message.isNoteOff() && found != sounding.end())
+                sounding.erase(found);
+        }
+
+        return sounding;
+    }
+
+    ClipSnapshotFeed clips;
+    LaunchHandle handle;
+    LaunchHandleTable table;
+    LaunchHandleFeed handles;
+
+    ClipMidiSource arrangement{kTrack, clips, handles, Section::Arrangement};
+    ClipMidiSource session{kTrack, clips, handles, Section::Session};
+
+    std::vector<Captured> fromArrangement;
+    std::vector<Captured> fromSession;
+
+  private:
+    bool rolled_ = false;
+
+    static void capture(ClipMidiSource& source, const BlockInfo& block, int index,
+                        std::vector<Captured>& into) {
+        juce::MidiBuffer buffer;
+        source.render(block, buffer);
+
+        for (const auto metadata : buffer)
+            into.push_back(Captured{index, metadata.samplePosition, metadata.getMessage()});
+    }
 };
 
 }  // namespace
@@ -538,12 +676,134 @@ TEST_CASE("A stop quantized inside a block ends on its beat", "[engine][clip][se
 
     CHECK(rig.at(0) == Approx(1.0f));
     CHECK(rig.at(2999) == Approx(1.0f));
-    CHECK(rig.at(3000) == Approx(0.0f));
+
+    // Past the beat the material is over, and what is left is the ramp that
+    // takes the step out of it rather than the material going on (#2302).
+    CHECK(rig.at(3000 + kSectionDeClickSamples - 1) == Approx(0.0f).margin(1e-5));
+    CHECK(rig.at(3000 + kSectionDeClickSamples) == Approx(0.0f));
     CHECK(rig.at(kBlockSize - 1) == Approx(0.0f));
 
     rig.render(42);
     CHECK(rig.peak() == 0.0f);
 }
+
+/**
+ * One track with material in both sections and a source for each, sharing the
+ * one handle feed (#2302).
+ *
+ * The arrangement runs the whole time; the session's slot is launched by the
+ * case. What is asserted is which of them reaches the output, and how the
+ * hand-over between them sounds.
+ */
+struct SwitchRig {
+    SwitchRig() {
+        table.entries.push_back(LaunchHandleTable::Entry{SlotKey{kTrack, kScene}, &handle});
+        handles.publish(std::make_shared<const LaunchHandleTable>(table));
+
+        arrangement.prepare(context());
+        session.prepare(context());
+
+        arrangementOut.setSize(2, kBlockSize);
+        sessionOut.setSize(2, kBlockSize);
+        arrangementOut.clear();
+        sessionOut.clear();
+    }
+
+    /// A clip on the timeline, sounding @p level from beat zero onwards.
+    void giveArrangement(magda::ClipId id, float level) {
+        lane.audio.push_back(clipOver(id, beats(0.0, 1000.0)));
+        addStream(lane.audio.back(), level);
+    }
+
+    /// A slot in the scene, @p lengthBeats long, sounding @p level.
+    void giveSlot(magda::ClipId id, double lengthBeats, float level) {
+        SessionSlotPlayback slot;
+        slot.sceneIndex = kScene;
+        slot.lengthBeats = lengthBeats;
+        slot.audio.push_back(clipOver(id, beats(0.0, lengthBeats)));
+        lane.session.push_back(std::move(slot));
+        addStream(lane.session.back().audio.front(), level);
+    }
+
+    void publish() {
+        auto compiled = std::make_shared<ClipSnapshot>();
+        compiled->tracks.push_back(lane);
+        clips.publish(std::move(compiled));
+        streams.publish(std::make_shared<const ClipStreamTable>(streamTable));
+    }
+
+    /// Roll one block through the launcher and both sources, in the order the
+    /// session does it: every handle advanced before anything renders.
+    void render(int index, bool continuous = true) {
+        const auto block = blockAt(index, continuous);
+
+        fill();
+        magda::engine::advanceLaunchHandles(handles, block);
+        arrangement.render(block, juce::dsp::AudioBlock<float>(arrangementOut));
+        session.render(block, juce::dsp::AudioBlock<float>(sessionOut));
+    }
+
+    void roll(int first, int last) {
+        for (auto index = first; index <= last; ++index)
+            render(index, index != first);
+    }
+
+    void fill() {
+        auto worked = true;
+        while (worked) {
+            worked = false;
+            for (const auto& entry : streamTable.entries)
+                worked = entry.stream->fill() || worked;
+        }
+    }
+
+    float arrangementAt(int sample) const {
+        return arrangementOut.getSample(0, sample);
+    }
+    float sessionAt(int sample) const {
+        return sessionOut.getSample(0, sample);
+    }
+
+    float arrangementPeak() const {
+        return arrangementOut.getMagnitude(0, kBlockSize);
+    }
+    float sessionPeak() const {
+        return sessionOut.getMagnitude(0, kBlockSize);
+    }
+
+    /// What the track sounds, which is the sum of its two sections: the one
+    /// assertion that says a switch did not leave a hole or double the signal.
+    float trackAt(int sample) const {
+        return arrangementAt(sample) + sessionAt(sample);
+    }
+
+    TrackClipPlayback lane{kTrack, {}, {}};
+    ClipSnapshotFeed clips;
+    ClipStreamFeed streams;
+    LaunchHandle handle;
+    LaunchHandleTable table;
+    LaunchHandleFeed handles;
+
+    ClipAudioSource arrangement{kTrack, clips, streams, handles, Section::Arrangement};
+    ClipAudioSource session{kTrack, clips, streams, handles, Section::Session};
+
+    ClipStreamTable streamTable;
+    juce::AudioBuffer<float> arrangementOut;
+    juce::AudioBuffer<float> sessionOut;
+
+  private:
+    void addStream(const AudioClipPlayback& clip, float level) {
+        const auto& event = clip.events.front();
+
+        auto stream = std::make_shared<PrefetchStream>(
+            magda::engine::readThrough(std::make_unique<LevelReader>(level),
+                                       magda::engine::sourceReadFor(event, kSampleRate)),
+            context(), magda::engine::PrefetchSettings{1024, 8});
+
+        streamTable.entries.push_back(
+            ClipStreamTable::Entry{kTrack, clip.clipId, event.eventId, stream});
+    }
+};
 
 TEST_CASE("The arrangement and the session are different sections of one track",
           "[engine][clip][session]") {
@@ -565,6 +825,326 @@ TEST_CASE("The arrangement and the session are different sections of one track",
     arrangement.render(block, juce::dsp::AudioBlock<float>(out));
 
     CHECK(out.getMagnitude(0, kBlockSize) == 0.0f);  // nothing is in the arrangement
+}
+
+// =============================================================================
+// Handing a track from one section to the other (#2302)
+// =============================================================================
+
+TEST_CASE("A launch takes the track off its arrangement, at the sample it lands on",
+          "[engine][clip][session][section]") {
+    SwitchRig rig;
+    rig.giveArrangement(1, 1.0f);
+    rig.giveSlot(2, 4.0, 0.5f);
+    rig.publish();
+
+    // Two blocks of arrangement, then a launch quantized to the beat that falls
+    // halfway through the third.
+    rig.roll(0, 1);
+    REQUIRE(rig.arrangementAt(0) == Approx(1.0f));
+    REQUIRE(rig.sessionPeak() == 0.0f);
+
+    rig.handle.play(kBeatsPerBlock * 2.5);
+    rig.render(2);
+
+    const auto launchSample = kBlockSize / 2;
+
+    SECTION("the arrangement sounds up to the launch and not past it") {
+        CHECK(rig.arrangementAt(launchSample - 1) == Approx(1.0f));
+        CHECK(rig.arrangementAt(launchSample + kSectionDeClickSamples) == Approx(0.0f));
+    }
+
+    SECTION("the session begins there") {
+        CHECK(rig.sessionAt(launchSample - 1) == Approx(0.0f));
+        CHECK(rig.sessionAt(launchSample) == Approx(0.5f));
+    }
+
+    SECTION("and the block after it is the session alone") {
+        rig.render(3);
+        CHECK(rig.arrangementPeak() == 0.0f);
+        CHECK(rig.sessionAt(0) == Approx(0.5f));
+    }
+}
+
+TEST_CASE("The arrangement is carried down rather than cut off",
+          "[engine][clip][session][section]") {
+    SwitchRig rig;
+    rig.giveArrangement(1, 1.0f);
+    rig.giveSlot(2, 4.0, 0.0f);  // silent, so only the arrangement's edge is read
+    rig.publish();
+
+    rig.roll(0, 1);
+    rig.handle.play(kBeatsPerBlock * 2.5);
+    rig.render(2);
+
+    const auto launchSample = kBlockSize / 2;
+
+    SECTION("the first sample past the launch is where the signal was") {
+        CHECK(rig.arrangementAt(launchSample) == Approx(1.0f));
+    }
+
+    SECTION("and it reaches zero over the ramp, monotonically") {
+        for (auto sample = launchSample + 1; sample < launchSample + kSectionDeClickSamples;
+             ++sample) {
+            INFO("sample " << sample);
+            REQUIRE(rig.arrangementAt(sample) <= rig.arrangementAt(sample - 1));
+        }
+
+        CHECK(rig.arrangementAt(launchSample + kSectionDeClickSamples - 1) ==
+              Approx(0.0f).margin(1e-5));
+    }
+}
+
+TEST_CASE("A stopped slot goes on holding the track", "[engine][clip][session][section]") {
+    // The hand-back is not the slot stopping. Silence after a stop is the
+    // session still holding the track, exactly as it is in the incumbent.
+    SwitchRig rig;
+    rig.giveArrangement(1, 1.0f);
+    rig.giveSlot(2, 4.0, 0.5f);
+    rig.publish();
+
+    rig.handle.play(std::nullopt);
+    rig.roll(0, 2);
+    REQUIRE(rig.sessionAt(0) == Approx(0.5f));
+    REQUIRE(rig.arrangementPeak() == 0.0f);
+
+    rig.handle.stop(std::nullopt);
+    rig.render(3);
+    rig.render(4);
+
+    CHECK(rig.sessionPeak() == 0.0f);
+    CHECK(rig.arrangementPeak() == 0.0f);  // and the arrangement has not crept back
+}
+
+TEST_CASE("Releasing the section gives the track back to its arrangement",
+          "[engine][clip][session][section]") {
+    SwitchRig rig;
+    rig.giveArrangement(1, 1.0f);
+    rig.giveSlot(2, 4.0, 0.5f);
+    rig.publish();
+
+    rig.handle.play(std::nullopt);
+    rig.roll(0, 2);
+    REQUIRE(rig.arrangementPeak() == 0.0f);
+
+    rig.handle.releaseSection();
+    rig.render(3);
+
+    SECTION("the session stops with it") {
+        CHECK(rig.sessionPeak() == 0.0f);
+    }
+
+    SECTION("and the arrangement comes back where the timeline is, not where it left off") {
+        // It kept rendering all along, so it resumes at the sample the timeline
+        // says rather than at the one it was on when it lost the track.
+        CHECK(rig.arrangementAt(kSectionDeClickSamples) == Approx(1.0f));
+    }
+
+    SECTION("stepping up out of silence over the ramp") {
+        CHECK(rig.arrangementAt(0) == Approx(0.0f).margin(1e-5));
+
+        for (auto sample = 1; sample < kSectionDeClickSamples; ++sample) {
+            INFO("sample " << sample);
+            REQUIRE(rig.arrangementAt(sample) >= rig.arrangementAt(sample - 1));
+        }
+    }
+}
+
+TEST_CASE("A slot stopping mid-block carries its own last sample down",
+          "[engine][clip][session][section]") {
+    SwitchRig rig;
+    rig.giveArrangement(1, 0.0f);
+    rig.giveSlot(2, 4.0, 0.5f);
+    rig.publish();
+
+    rig.handle.play(std::nullopt);
+    rig.roll(0, 1);
+    REQUIRE(rig.sessionAt(0) == Approx(0.5f));
+
+    rig.handle.stop(kBeatsPerBlock * 2.5);
+    rig.render(2);
+
+    const auto stopSample = kBlockSize / 2;
+
+    CHECK(rig.sessionAt(stopSample - 1) == Approx(0.5f));
+    CHECK(rig.sessionAt(stopSample) == Approx(0.5f));
+    CHECK(rig.sessionAt(stopSample + kSectionDeClickSamples - 1) == Approx(0.0f).margin(1e-5));
+
+    for (auto sample = stopSample + 1; sample < stopSample + kSectionDeClickSamples; ++sample) {
+        INFO("sample " << sample);
+        REQUIRE(rig.sessionAt(sample) <= rig.sessionAt(sample - 1));
+    }
+}
+
+TEST_CASE("A track never sounds both of its sections", "[engine][clip][session][section]") {
+    // The property the switch exists for. The two sections are summed into one
+    // track input, so a sample both contribute material to is a track playing
+    // itself twice.
+    //
+    // The hand-over ramp is the one exception and is not one of those: what
+    // overlaps there is the outgoing section's last sample decaying, which is
+    // the step being taken out rather than a second signal.
+    SwitchRig rig;
+    rig.giveArrangement(1, 1.0f);
+    rig.giveSlot(2, 4.0, 1.0f);
+    rig.publish();
+
+    rig.roll(0, 1);
+    rig.handle.play(kBeatsPerBlock * 2.5);
+
+    const auto launchSample = kBlockSize / 2;
+
+    for (auto index = 2; index <= 6; ++index) {
+        rig.render(index);
+
+        for (auto sample = 0; sample < kBlockSize; ++sample) {
+            // Everything except the ramp that follows the launch.
+            if (index == 2 && sample >= launchSample &&
+                sample < launchSample + kSectionDeClickSamples)
+                continue;
+
+            INFO("block " << index << " sample " << sample);
+            REQUIRE(rig.trackAt(sample) <= 1.0f + 1e-5f);
+        }
+    }
+}
+
+TEST_CASE("The arrangement's MIDI sounds up to the hand-over and owes note-offs there",
+          "[engine][clip][session][section]") {
+    MidiSwitchRig rig;
+
+    // An arrangement note that begins before the launch and would run well past
+    // it, and a slot with a note of its own.
+    rig.publish({arrangementMidiClip(1, 0.0, 8.0, {MidiNote{60, 100, 0.25, 4.0, 0, {}}})},
+                {sessionMidiClip(2, 4.0, {MidiNote{67, 100, 0.0, 2.0, 0, {}}})});
+
+    rig.roll(0, 1);
+    REQUIRE(rig.notesOn(rig.fromArrangement).size() == 1);
+    REQUIRE(rig.notesOn(rig.fromArrangement).front().message.getNoteNumber() == 60);
+
+    // A launch quantized to the middle of the next block.
+    rig.handle.play(kBeatsPerBlock * 2.5);
+    rig.roll(2, 4);
+
+    const auto launchSample = kBlockSize / 2;
+
+    SECTION("the arrangement's note ends where the session takes the track") {
+        const auto offs = rig.notesOff(rig.fromArrangement);
+        REQUIRE(offs.size() == 1);
+        CHECK(offs.front().block == 2);
+        CHECK(offs.front().sample == launchSample);
+        CHECK(offs.front().message.getNoteNumber() == 60);
+    }
+
+    SECTION("and nothing of the arrangement's is left sounding") {
+        CHECK(rig.hanging(rig.fromArrangement).empty());
+    }
+
+    SECTION("the session's note starts there") {
+        const auto ons = rig.notesOn(rig.fromSession);
+        REQUIRE(ons.size() == 1);
+        CHECK(ons.front().block == 2);
+        CHECK(ons.front().sample == launchSample);
+        CHECK(ons.front().message.getNoteNumber() == 67);
+    }
+
+    SECTION("and the arrangement emits nothing at all afterwards") {
+        const auto afterward = std::count_if(rig.fromArrangement.begin(), rig.fromArrangement.end(),
+                                             [](const Captured& entry) { return entry.block > 2; });
+        CHECK(afterward == 0);
+    }
+}
+
+TEST_CASE("A note due before the hand-over still sounds", "[engine][clip][session][section]") {
+    // The arrangement's MIDI runs up to the switch the way its audio renders up
+    // to it: a note due a sample before the launch is one the listener was
+    // going to hear.
+    MidiSwitchRig rig;
+    rig.publish({arrangementMidiClip(1, 0.0, 8.0, {MidiNote{62, 100, 0.6, 0.1, 0, {}}})},
+                {sessionMidiClip(2, 4.0, {})});
+
+    rig.roll(0, 1);
+    REQUIRE(rig.notesOn(rig.fromArrangement).empty());
+
+    // Beat 0.625 is the middle of block 2; the note is at 0.6, just inside it.
+    rig.handle.play(kBeatsPerBlock * 2.5);
+    rig.roll(2, 2);
+
+    const auto ons = rig.notesOn(rig.fromArrangement);
+    REQUIRE(ons.size() == 1);
+    CHECK(ons.front().message.getNoteNumber() == 62);
+    CHECK(ons.front().sample < kBlockSize / 2);
+    CHECK(rig.hanging(rig.fromArrangement).empty());
+}
+
+TEST_CASE("Releasing the section brings the arrangement's MIDI back",
+          "[engine][clip][session][section]") {
+    MidiSwitchRig rig;
+    rig.publish({arrangementMidiClip(1, 0.0, 8.0, {MidiNote{64, 100, 2.0, 1.0, 0, {}}})},
+                {sessionMidiClip(2, 8.0, {MidiNote{67, 100, 0.0, 8.0, 0, {}}})});
+
+    rig.handle.play(std::nullopt);
+    rig.roll(0, 4);
+    REQUIRE(rig.notesOn(rig.fromSession).size() == 1);
+
+    rig.handle.releaseSection();
+    rig.roll(5, 12);  // through beat 2, where the arrangement's note is
+
+    SECTION("the session's note is ended by the release") {
+        CHECK(rig.hanging(rig.fromSession).empty());
+    }
+
+    SECTION("and the arrangement plays what the timeline has reached") {
+        const auto ons = rig.notesOn(rig.fromArrangement);
+        REQUIRE(ons.size() == 1);
+        CHECK(ons.front().message.getNoteNumber() == 64);
+    }
+}
+
+TEST_CASE("The hand-over overlap is the ramp and no longer", "[engine][clip][session][section]") {
+    // What the outgoing section adds past its own ramp is nothing at all, which
+    // is what says the de-click is a correction to an edge rather than a fade
+    // the two sections share.
+    SwitchRig rig;
+    rig.giveArrangement(1, 1.0f);
+    rig.giveSlot(2, 4.0, 1.0f);
+    rig.publish();
+
+    rig.roll(0, 1);
+    rig.handle.play(kBeatsPerBlock * 2.5);
+    rig.render(2);
+
+    const auto launchSample = kBlockSize / 2;
+
+    CHECK(rig.arrangementAt(launchSample + kSectionDeClickSamples - 1) ==
+          Approx(0.0f).margin(1e-5));
+    CHECK(rig.arrangementAt(launchSample + kSectionDeClickSamples) == Approx(0.0f));
+    CHECK(rig.arrangementAt(kBlockSize - 1) == Approx(0.0f));
+
+    // And the incoming one is at full level throughout, never attenuated by the
+    // hand-over: a launch is not a gain fade (FadeCurves.hpp).
+    for (auto sample = launchSample; sample < kBlockSize; ++sample) {
+        INFO("sample " << sample);
+        REQUIRE(rig.sessionAt(sample) == Approx(1.0f));
+    }
+}
+
+TEST_CASE("A launch on the first sample of a block is the same switch",
+          "[engine][clip][session][section]") {
+    // Which side of a callback boundary the launch fell on is not something the
+    // hand-over should be able to hear: the step comes off the block before.
+    SwitchRig rig;
+    rig.giveArrangement(1, 1.0f);
+    rig.giveSlot(2, 4.0, 0.0f);
+    rig.publish();
+
+    rig.roll(0, 1);
+    rig.handle.play(kBeatsPerBlock * 2.0);
+    rig.render(2);
+
+    CHECK(rig.arrangementAt(0) == Approx(1.0f));
+    CHECK(rig.arrangementAt(kSectionDeClickSamples - 1) == Approx(0.0f).margin(1e-5));
+    CHECK(rig.arrangementAt(kSectionDeClickSamples) == Approx(0.0f));
 }
 
 // =============================================================================

--- a/tests/engine/test_session_playback.cpp
+++ b/tests/engine/test_session_playback.cpp
@@ -171,6 +171,28 @@ BlockInfo blockAt(int index, bool continuous = true) {
     return block;
 }
 
+/// A block of @p count samples beginning at @p startSample, at the one tempo.
+/// For the cases that assert a render does not depend on how the callback was
+/// cut up, where the block is smaller than the fixture's own.
+BlockInfo smallBlockAt(std::int64_t startSample, int count, bool continuous = true) {
+    BlockInfo block;
+    block.numSamples = count;
+    block.sampleRate = kSampleRate;
+    block.monotonicSamples = {magda::engine::SamplePosition{startSample},
+                              magda::engine::SamplePosition{startSample + count}};
+    block.playing = true;
+    block.continuous = continuous;
+    block.seconds.start = static_cast<double>(startSample) / kSampleRate;
+    block.seconds.end = static_cast<double>(startSample + count) / kSampleRate;
+    block.beats.start = block.seconds.start / kSecondsPerBeat;
+    block.beats.end = block.seconds.end / kSecondsPerBeat;
+    block.monotonicBeats.start = block.beats.start;
+    block.monotonicBeats.end = block.beats.end;
+    block.monotonicSeconds.start = block.seconds.start;
+    block.monotonicSeconds.end = block.seconds.end;
+    return block;
+}
+
 /// The block covering @p startSeconds, on @p map rather than at one tempo. The
 /// two faces are derived through the one map, the way the transport derives
 /// them (RenderContext.hpp).
@@ -749,6 +771,14 @@ struct SwitchRig {
             render(index, index != first);
     }
 
+    /// The session alone, over a block the case assembled itself.
+    void renderSession(const BlockInfo& block) {
+        fill();
+        magda::engine::advanceLaunchHandles(handles, block);
+        session.render(block, juce::dsp::AudioBlock<float>(sessionOut)
+                                  .getSubBlock(0, static_cast<std::size_t>(block.numSamples)));
+    }
+
     void fill() {
         auto worked = true;
         while (worked) {
@@ -936,6 +966,14 @@ TEST_CASE("Releasing the section gives the track back to its arrangement",
     rig.render(3);
 
     SECTION("the session stops with it") {
+        // Its material is gone; what is left in this block is the ramp taking
+        // the step out of the sample it stopped on.
+        CHECK(rig.sessionAt(0) == Approx(0.5f));
+        CHECK(rig.sessionAt(kSectionDeClickSamples - 1) == Approx(0.0f).margin(1e-5));
+        CHECK(rig.sessionAt(kSectionDeClickSamples) == Approx(0.0f));
+        CHECK(rig.sessionAt(kBlockSize - 1) == Approx(0.0f));
+
+        rig.render(4);
         CHECK(rig.sessionPeak() == 0.0f);
     }
 
@@ -1060,6 +1098,64 @@ TEST_CASE("A slot sounding right through masks another's stop",
     CHECK(rig.sessionAt(stopSample - 1) == Approx(1.0f));
     CHECK(rig.sessionAt(stopSample) == Approx(0.5f));
     CHECK(rig.sessionAt(kBlockSize - 1) == Approx(0.5f));
+}
+
+TEST_CASE("A session stop sounds the same however the callback is cut up",
+          "[engine][clip][session][section]") {
+    // Block size is an I/O batching concept and never a precision one
+    // (RenderContext.hpp). The ramp after a stop is carried across blocks for
+    // exactly this reason, so a stop rendered in one block and the same stop
+    // rendered in eight-sample blocks have to agree sample for sample
+    // (#2344 review).
+    const auto tailOf = [](int blockSize) {
+        SwitchRig rig;
+        rig.giveArrangement(1, 0.0f);
+        rig.giveSlot(2, 400.0, 0.5f);
+        rig.publish();
+
+        rig.handle.play(std::nullopt);
+
+        // Up to the stop in whole blocks, so both runs start it from the same
+        // place, then onwards in blocks of the size under test.
+        rig.roll(0, 1);
+
+        std::vector<float> tail;
+        auto sample = static_cast<std::int64_t>(2 * kBlockSize);
+
+        // Stopped as soon as possible, so it lands on the first sample of the
+        // block after this one whatever that block's size is.
+        rig.handle.stop(std::nullopt);
+
+        while (static_cast<int>(tail.size()) < kSectionDeClickSamples * 2) {
+            rig.renderSession(smallBlockAt(sample, blockSize));
+
+            for (auto index = 0; index < blockSize; ++index)
+                tail.push_back(rig.sessionAt(index));
+
+            sample += blockSize;
+        }
+
+        return tail;
+    };
+
+    const auto whole = tailOf(kSectionDeClickSamples * 2);
+    const auto chopped = tailOf(8);
+
+    for (auto sample = 0; sample < kSectionDeClickSamples * 2; ++sample) {
+        INFO("sample " << sample);
+        REQUIRE(chopped[static_cast<std::size_t>(sample)] ==
+                Approx(whole[static_cast<std::size_t>(sample)]).margin(1e-6));
+    }
+
+    // A decay to zero rather than a staircase restarting at every seam.
+    CHECK(chopped[0] == Approx(0.5f));
+    CHECK(chopped[kSectionDeClickSamples - 1] == Approx(0.0f).margin(1e-5));
+
+    for (auto sample = 1; sample < kSectionDeClickSamples; ++sample) {
+        INFO("sample " << sample);
+        REQUIRE(chopped[static_cast<std::size_t>(sample)] <=
+                chopped[static_cast<std::size_t>(sample) - 1]);
+    }
 }
 
 TEST_CASE("A track never sounds both of its sections", "[engine][clip][session][section]") {

--- a/tests/engine/test_session_playback.cpp
+++ b/tests/engine/test_session_playback.cpp
@@ -1071,6 +1071,48 @@ TEST_CASE("One slot handing over to another carries the outgoing one down",
     }
 }
 
+TEST_CASE("A slot swap on a block boundary carries the outgoing one down too",
+          "[engine][clip][session][section]") {
+    // The boundary-aligned version of the swap above. The handle reports an
+    // event on sample zero as a block that was never playing, so the outgoing
+    // slot's stop is invisible in the shape of the split; and the incoming
+    // slot's own first half does report as playing, so a rule reading either
+    // one off beforeEvent gets both of them wrong (#2344 review).
+    SwitchRig rig;
+    rig.giveArrangement(1, 0.0f);
+    rig.giveSlot(2, 400.0, 0.8f, kScene);
+    rig.giveSlot(3, 400.0, -0.3f, kScene + 1);
+    rig.publish();
+
+    rig.handle.play(std::nullopt);
+    rig.roll(0, 1);
+    REQUIRE(rig.sessionAt(kBlockSize - 1) == Approx(0.8f));
+
+    // Both requests before the same advance, both as soon as possible, so both
+    // events land on the first sample of the next block.
+    rig.handle.stop(std::nullopt);
+    rig.second.play(std::nullopt);
+    rig.render(2);
+
+    SECTION("the outgoing level is carried down from where the last block left it") {
+        CHECK(rig.sessionAt(0) == Approx(0.8f - 0.3f));
+        CHECK(rig.sessionAt(kSectionDeClickSamples) == Approx(-0.3f));
+
+        for (auto sample = 1; sample < kSectionDeClickSamples; ++sample) {
+            INFO("sample " << sample);
+            REQUIRE(rig.sessionAt(sample) <= rig.sessionAt(sample - 1));
+        }
+    }
+
+    SECTION("so the swap adds no step beyond the incoming clip's own attack") {
+        // Without it the seam jumps 0.8 to -0.3 between two callbacks.
+        for (auto sample = 1; sample < kBlockSize; ++sample) {
+            INFO("sample " << sample);
+            REQUIRE(std::abs(rig.sessionAt(sample) - rig.sessionAt(sample - 1)) <= 0.3f + 1e-5f);
+        }
+    }
+}
+
 TEST_CASE("A slot sounding right through masks another's stop",
           "[engine][clip][session][section]") {
     // The other side of the same rule. The ramp reads its step off the summed

--- a/tests/engine/test_session_playback.cpp
+++ b/tests/engine/test_session_playback.cpp
@@ -1113,16 +1113,17 @@ TEST_CASE("A slot swap on a block boundary carries the outgoing one down too",
     }
 }
 
-TEST_CASE("A slot sounding right through masks another's stop",
+TEST_CASE("A slot stopping under one that keeps sounding is still ramped",
           "[engine][clip][session][section]") {
-    // The other side of the same rule. The ramp reads its step off the summed
-    // buffer, so a slot that was already sounding before the stop is still in
-    // that sum afterwards and decaying it would correct for a signal that never
-    // stopped.
+    // The case one ramp over the track's sum could not do, and the reason the
+    // ramp belongs to the voice: the outgoing slot's own 0.5 is carried down
+    // while the other slot's 0.5 goes on sounding through the same samples,
+    // rather than the stop being passed over because something else was still
+    // playing (#2344 review).
     SwitchRig rig;
     rig.giveArrangement(1, 0.0f);
-    rig.giveSlot(2, 4.0, 0.5f, kScene);
-    rig.giveSlot(3, 4.0, 0.5f, kScene + 1);
+    rig.giveSlot(2, 400.0, 0.5f, kScene);
+    rig.giveSlot(3, 400.0, 0.5f, kScene + 1);
     rig.publish();
 
     rig.handle.play(std::nullopt);
@@ -1135,11 +1136,27 @@ TEST_CASE("A slot sounding right through masks another's stop",
 
     const auto stopSample = kBlockSize / 2;
 
-    // One of the two stops, and what is left is the other at its own level
-    // rather than that plus a decaying copy of the pair.
-    CHECK(rig.sessionAt(stopSample - 1) == Approx(1.0f));
-    CHECK(rig.sessionAt(stopSample) == Approx(0.5f));
-    CHECK(rig.sessionAt(kBlockSize - 1) == Approx(0.5f));
+    SECTION("the outgoing half decays rather than vanishing") {
+        CHECK(rig.sessionAt(stopSample - 1) == Approx(1.0f));
+        CHECK(rig.sessionAt(stopSample) == Approx(1.0f));
+
+        for (auto sample = stopSample + 1; sample < stopSample + kSectionDeClickSamples; ++sample) {
+            INFO("sample " << sample);
+            REQUIRE(rig.sessionAt(sample) <= rig.sessionAt(sample - 1));
+        }
+    }
+
+    SECTION("leaving exactly the slot that is still playing") {
+        CHECK(rig.sessionAt(stopSample + kSectionDeClickSamples) == Approx(0.5f));
+        CHECK(rig.sessionAt(kBlockSize - 1) == Approx(0.5f));
+    }
+
+    SECTION("and the track never steps") {
+        for (auto sample = 1; sample < kBlockSize; ++sample) {
+            INFO("sample " << sample);
+            REQUIRE(std::abs(rig.sessionAt(sample) - rig.sessionAt(sample - 1)) < 0.05f);
+        }
+    }
 }
 
 TEST_CASE("A session stop sounds the same however the callback is cut up",
@@ -1197,6 +1214,67 @@ TEST_CASE("A session stop sounds the same however the callback is cut up",
         INFO("sample " << sample);
         REQUIRE(chopped[static_cast<std::size_t>(sample)] <=
                 chopped[static_cast<std::size_t>(sample) - 1]);
+    }
+}
+
+TEST_CASE("A stop inside another slot's unfinished ramp starts from its own level",
+          "[engine][clip][session][section]") {
+    // Slot A hands over to B near a block end, A's ramp carries into the next
+    // block, and B stops on the boundary after that. With one ramp over the
+    // track's sum, B's tail would have started from A's anchor or from a
+    // half decayed correction, whichever the aggregate happened to hold. Two
+    // voices, two ramps, and neither can reach the other (#2344 review).
+    constexpr int kSmall = 16;  // so a 32-sample ramp spans blocks
+
+    SwitchRig rig;
+    rig.giveArrangement(1, 0.0f);
+    rig.giveSlot(2, 400.0, 0.8f, kScene);
+    rig.giveSlot(3, 400.0, -0.3f, kScene + 1);
+    rig.publish();
+
+    rig.handle.play(std::nullopt);
+    rig.roll(0, 1);
+    REQUIRE(rig.sessionAt(kBlockSize - 1) == Approx(0.8f));
+
+    std::vector<float> tail;
+    auto at = static_cast<std::int64_t>(2 * kBlockSize);
+
+    const auto step = [&] {
+        rig.renderSession(smallBlockAt(at, kSmall));
+        for (auto index = 0; index < kSmall; ++index)
+            tail.push_back(rig.sessionAt(index));
+        at += kSmall;
+    };
+
+    // A out, B in, on the same sample.
+    rig.handle.stop(std::nullopt);
+    rig.second.play(std::nullopt);
+    step();
+
+    // B out while A's ramp is still running.
+    rig.second.stop(std::nullopt);
+    step();
+
+    // And on, until both ramps are spent.
+    for (auto index = 0; index < 6; ++index)
+        step();
+
+    SECTION("B's own level is what its tail starts from") {
+        // A's ramp is 16 samples in and worth 0.8 * cos-decay; B contributes
+        // its own -0.3 carried down from where it was. Neither is the other's.
+        REQUIRE(tail[kSmall] < tail[kSmall - 1] + 1e-5f);
+        REQUIRE(tail[kSmall] > -0.3f);
+    }
+
+    SECTION("and nothing steps anywhere across either seam") {
+        for (std::size_t sample = 1; sample < tail.size(); ++sample) {
+            INFO("sample " << sample);
+            REQUIRE(std::abs(tail[sample] - tail[sample - 1]) <= 0.3f + 1e-5f);
+        }
+    }
+
+    SECTION("ending in silence once both are spent") {
+        CHECK(tail.back() == Approx(0.0f).margin(1e-5));
     }
 }
 

--- a/tests/engine/test_session_playback.cpp
+++ b/tests/engine/test_session_playback.cpp
@@ -447,10 +447,13 @@ ClipInfo arrangementMidiClip(magda::ClipId id, double start, double lengthBeats,
 
 /// One track's MIDI in both sections, with a source for each (#2302).
 struct MidiSwitchRig {
-    MidiSwitchRig() {
+    /// @copydoc SwitchRig
+    explicit MidiSwitchRig(bool publishHandles = true) {
         table.entries.push_back(LaunchHandleTable::Entry{SlotKey{kTrack, kScene}, &handle});
         table.entries.push_back(LaunchHandleTable::Entry{SlotKey{kTrack, kScene + 1}, &second});
-        handles.publish(std::make_shared<const LaunchHandleTable>(table));
+
+        if (publishHandles)
+            handles.publish(std::make_shared<const LaunchHandleTable>(table));
         arrangement.prepare(context());
         session.prepare(context());
     }
@@ -723,10 +726,15 @@ TEST_CASE("A stop quantized inside a block ends on its beat", "[engine][clip][se
  * hand-over between them sounds.
  */
 struct SwitchRig {
-    SwitchRig() {
+    /// @p publishHandles false leaves the feed as it is before the store has
+    /// ever published, which the contract permits and which a track's sources
+    /// have to survive.
+    explicit SwitchRig(bool publishHandles = true) {
         table.entries.push_back(LaunchHandleTable::Entry{SlotKey{kTrack, kScene}, &handle});
         table.entries.push_back(LaunchHandleTable::Entry{SlotKey{kTrack, kScene + 1}, &second});
-        handles.publish(std::make_shared<const LaunchHandleTable>(table));
+
+        if (publishHandles)
+            handles.publish(std::make_shared<const LaunchHandleTable>(table));
 
         arrangement.prepare(context());
         session.prepare(context());
@@ -1456,6 +1464,42 @@ TEST_CASE("A slot swap on a boundary leaves no ghost of the arrangement",
             REQUIRE(rig.trackAt(sample) == Approx(rig.sessionAt(sample)));
         }
     }
+}
+
+TEST_CASE("A track whose handles have not been published yet plays its arrangement",
+          "[engine][clip][session][section]") {
+    // The feed is null until the store publishes, which the contract permits
+    // and which is a session whose slots have no handles yet rather than an
+    // error. Nothing can hold a track then, so the arrangement has all of it:
+    // a fallback that said otherwise would silence every arrangement on the
+    // blocks before the first publish (#2344 review).
+    SwitchRig rig{false};
+    rig.giveArrangement(1, 1.0f);
+    rig.giveSlot(2, 400.0, 0.5f, kScene);
+    rig.publish();
+
+    // Requested anyway, which changes nothing: no table means no handle the
+    // sources can reach.
+    rig.handle.play(std::nullopt);
+    rig.roll(0, 2);
+
+    CHECK(rig.arrangementAt(0) == Approx(1.0f));
+    CHECK(rig.arrangementAt(kBlockSize - 1) == Approx(1.0f));
+    CHECK(rig.sessionPeak() == 0.0f);
+}
+
+TEST_CASE("The same track's MIDI plays its arrangement too", "[engine][clip][session][section]") {
+    MidiSwitchRig rig{false};
+    rig.publish({arrangementMidiClip(1, 0.0, 16.0, {MidiNote{64, 100, 0.3, 1.0, 0, {}}})},
+                {sessionMidiClip(2, 16.0, {MidiNote{67, 100, 0.0, 16.0, 0, {}}})});
+
+    rig.handle.play(std::nullopt);
+    rig.roll(0, 4);
+
+    const auto ons = rig.notesOn(rig.fromArrangement);
+    REQUIRE(ons.size() == 1);
+    CHECK(ons.front().message.getNoteNumber() == 64);
+    CHECK(rig.notesOn(rig.fromSession).empty());
 }
 
 TEST_CASE("A track never sounds both of its sections", "[engine][clip][session][section]") {

--- a/tests/engine/test_session_playback.cpp
+++ b/tests/engine/test_session_playback.cpp
@@ -449,6 +449,7 @@ ClipInfo arrangementMidiClip(magda::ClipId id, double start, double lengthBeats,
 struct MidiSwitchRig {
     MidiSwitchRig() {
         table.entries.push_back(LaunchHandleTable::Entry{SlotKey{kTrack, kScene}, &handle});
+        table.entries.push_back(LaunchHandleTable::Entry{SlotKey{kTrack, kScene + 1}, &second});
         handles.publish(std::make_shared<const LaunchHandleTable>(table));
         arrangement.prepare(context());
         session.prepare(context());
@@ -518,6 +519,10 @@ struct MidiSwitchRig {
 
     ClipSnapshotFeed clips;
     LaunchHandle handle;
+
+    /// The scene below, for the cases where one slot hands over to another.
+    LaunchHandle second;
+
     LaunchHandleTable table;
     LaunchHandleFeed handles;
 
@@ -1275,6 +1280,77 @@ TEST_CASE("A stop inside another slot's unfinished ramp starts from its own leve
 
     SECTION("ending in silence once both are spent") {
         CHECK(tail.back() == Approx(0.0f).margin(1e-5));
+    }
+}
+
+TEST_CASE("A release and a relaunch in one block leave the arrangement the gap between",
+          "[engine][clip][session][section]") {
+    // The block a final state cannot describe. The session held the track, Back
+    // to Arrangement gives it up at sample zero, and another slot takes it back
+    // part way through: the arrangement owns everything in between and sounded
+    // none of it while ownership was one answer per block (#2344 review).
+    SwitchRig rig;
+    rig.giveArrangement(1, 1.0f);
+    rig.giveSlot(2, 400.0, 0.5f, kScene);
+    rig.giveSlot(3, 400.0, 0.5f, kScene + 1);
+    rig.publish();
+
+    rig.handle.play(std::nullopt);
+    rig.roll(0, 1);
+    REQUIRE(rig.arrangementPeak() == 0.0f);
+
+    // Both before the same advance: the release applies on the block's first
+    // sample, the launch on its own.
+    rig.handle.releaseSection();
+    rig.second.play(kBeatsPerBlock * 2.5);
+    rig.render(2);
+
+    const auto relaunch = kBlockSize / 2;
+
+    SECTION("the arrangement sounds the gap") {
+        CHECK(rig.arrangementAt(kSectionDeClickSamples) == Approx(1.0f));
+        CHECK(rig.arrangementAt(relaunch - 1) == Approx(1.0f));
+    }
+
+    SECTION("and loses the track again at the relaunch") {
+        CHECK(rig.arrangementAt(relaunch + kSectionDeClickSamples) == Approx(0.0f));
+        CHECK(rig.arrangementAt(kBlockSize - 1) == Approx(0.0f));
+    }
+
+    SECTION("the session is silent across the gap and back for the rest") {
+        CHECK(rig.sessionAt(kSectionDeClickSamples) == Approx(0.0f).margin(1e-5));
+        CHECK(rig.sessionAt(relaunch) == Approx(0.5f));
+        CHECK(rig.sessionAt(kBlockSize - 1) == Approx(0.5f));
+    }
+}
+
+TEST_CASE("A release and a relaunch in one block put the arrangement's MIDI in the gap",
+          "[engine][clip][session][section]") {
+    // The same block, on the other source: they read one fold, so they are on
+    // the same side of both switches.
+    MidiSwitchRig rig;
+    rig.publish({arrangementMidiClip(1, 0.0, 16.0, {MidiNote{64, 100, 0.55, 0.2, 0, {}}})},
+                {sessionMidiClip(2, 16.0, {MidiNote{67, 100, 0.0, 16.0, 0, {}}})});
+
+    rig.handle.play(std::nullopt);
+    rig.roll(0, 1);
+    REQUIRE(rig.notesOn(rig.fromArrangement).empty());
+
+    // Beat 0.5 to 0.75 is block 2; the arrangement's note is at 0.55, inside the
+    // gap, and the relaunch is at 0.625 which is half way through.
+    rig.handle.releaseSection();
+    rig.second.play(kBeatsPerBlock * 2.5);
+    rig.roll(2, 2);
+
+    SECTION("the note in the gap sounds") {
+        const auto ons = rig.notesOn(rig.fromArrangement);
+        REQUIRE(ons.size() == 1);
+        CHECK(ons.front().message.getNoteNumber() == 64);
+        CHECK(ons.front().sample < kBlockSize / 2);
+    }
+
+    SECTION("and is ended when the session takes the track back") {
+        CHECK(rig.hanging(rig.fromArrangement).empty());
     }
 }
 

--- a/tests/engine/test_session_playback.cpp
+++ b/tests/engine/test_session_playback.cpp
@@ -1354,6 +1354,61 @@ TEST_CASE("A release and a relaunch in one block put the arrangement's MIDI in t
     }
 }
 
+TEST_CASE("A launch arriving after a release keeps the track it was holding",
+          "[engine][clip][session][section]") {
+    // One handle, both requests, before the same advance. The stop and the
+    // hand-back are one request, so the launch replaces both: split across two
+    // fields it replaced only the stop, and the track was handed to the
+    // arrangement while the slot went on sounding (#2344 review).
+    SwitchRig rig;
+    rig.giveArrangement(1, 1.0f);
+    rig.giveSlot(2, 400.0, 0.5f, kScene);
+    rig.publish();
+
+    rig.handle.play(std::nullopt);
+    rig.roll(0, 1);
+    REQUIRE(rig.sessionAt(0) == Approx(0.5f));
+    REQUIRE(rig.arrangementPeak() == 0.0f);
+
+    // Back to Arrangement, then a launch queued for a beat away, both before
+    // the next block.
+    rig.handle.releaseSection();
+    rig.handle.play(kBeatsPerBlock * 8.0);
+    rig.render(2);
+
+    SECTION("the slot goes on sounding") {
+        CHECK(rig.sessionAt(0) == Approx(0.5f));
+        CHECK(rig.sessionAt(kBlockSize - 1) == Approx(0.5f));
+    }
+
+    SECTION("and the arrangement stays off it, so the track sounds one section") {
+        CHECK(rig.arrangementPeak() == 0.0f);
+
+        for (auto sample = 0; sample < kBlockSize; ++sample) {
+            INFO("sample " << sample);
+            REQUIRE(rig.trackAt(sample) == Approx(0.5f));
+        }
+    }
+}
+
+TEST_CASE("A release on its own still hands the track back", "[engine][clip][session][section]") {
+    // The other side of the same rule: nothing replaced it, so it applies.
+    SwitchRig rig;
+    rig.giveArrangement(1, 1.0f);
+    rig.giveSlot(2, 400.0, 0.5f, kScene);
+    rig.publish();
+
+    rig.handle.play(std::nullopt);
+    rig.roll(0, 1);
+    REQUIRE(rig.arrangementPeak() == 0.0f);
+
+    rig.handle.releaseSection();
+    rig.render(2);
+
+    CHECK(rig.arrangementAt(kSectionDeClickSamples) == Approx(1.0f));
+    CHECK(rig.sessionAt(kSectionDeClickSamples) == Approx(0.0f).margin(1e-5));
+}
+
 TEST_CASE("A track never sounds both of its sections", "[engine][clip][session][section]") {
     // The property the switch exists for. The two sections are summed into one
     // track input, so a sample both contribute material to is a track playing

--- a/tests/engine/test_session_playback.cpp
+++ b/tests/engine/test_session_playback.cpp
@@ -698,6 +698,7 @@ TEST_CASE("A stop quantized inside a block ends on its beat", "[engine][clip][se
 struct SwitchRig {
     SwitchRig() {
         table.entries.push_back(LaunchHandleTable::Entry{SlotKey{kTrack, kScene}, &handle});
+        table.entries.push_back(LaunchHandleTable::Entry{SlotKey{kTrack, kScene + 1}, &second});
         handles.publish(std::make_shared<const LaunchHandleTable>(table));
 
         arrangement.prepare(context());
@@ -715,10 +716,10 @@ struct SwitchRig {
         addStream(lane.audio.back(), level);
     }
 
-    /// A slot in the scene, @p lengthBeats long, sounding @p level.
-    void giveSlot(magda::ClipId id, double lengthBeats, float level) {
+    /// A slot in @p scene, @p lengthBeats long, sounding @p level.
+    void giveSlot(magda::ClipId id, double lengthBeats, float level, int scene = kScene) {
         SessionSlotPlayback slot;
-        slot.sceneIndex = kScene;
+        slot.sceneIndex = scene;
         slot.lengthBeats = lengthBeats;
         slot.audio.push_back(clipOver(id, beats(0.0, lengthBeats)));
         lane.session.push_back(std::move(slot));
@@ -781,6 +782,10 @@ struct SwitchRig {
     ClipSnapshotFeed clips;
     ClipStreamFeed streams;
     LaunchHandle handle;
+
+    /// The scene below, for the cases where one slot hands over to another.
+    LaunchHandle second;
+
     LaunchHandleTable table;
     LaunchHandleFeed handles;
 
@@ -976,6 +981,87 @@ TEST_CASE("A slot stopping mid-block carries its own last sample down",
     }
 }
 
+TEST_CASE("One slot handing over to another carries the outgoing one down",
+          "[engine][clip][session][section]") {
+    // The incoming clip's own start ramp corrects its own edge and knows
+    // nothing about the one it replaced, so without this the track sum steps
+    // from the old signal straight to the new (#2344 review).
+    SwitchRig rig;
+    rig.giveArrangement(1, 0.0f);
+    rig.giveSlot(2, 4.0, 0.8f, kScene);
+    rig.giveSlot(3, 4.0, -0.3f, kScene + 1);
+    rig.publish();
+
+    rig.handle.play(std::nullopt);
+    rig.roll(0, 1);
+    REQUIRE(rig.sessionAt(0) == Approx(0.8f));
+
+    // The first stops and the second starts on the same beat, half way through
+    // the block: the swap a scene launch makes on a track already playing.
+    const auto at = kBeatsPerBlock * 2.5;
+    rig.handle.stop(at);
+    rig.second.play(at);
+    rig.render(2);
+
+    const auto swapSample = kBlockSize / 2;
+
+    SECTION("the outgoing level carries on under the incoming one") {
+        // 0.8 carried on, with the incoming clip's own opening sample on top of
+        // it. That clip begins at its own start, so it is not de-clicked and
+        // must not be: the step it makes is its attack (ClipVoice.cpp, #2040).
+        CHECK(rig.sessionAt(swapSample - 1) == Approx(0.8f));
+        CHECK(rig.sessionAt(swapSample) == Approx(0.8f - 0.3f));
+    }
+
+    SECTION("and decays out from under it, leaving the incoming clip alone") {
+        CHECK(rig.sessionAt(swapSample + kSectionDeClickSamples) == Approx(-0.3f));
+
+        for (auto sample = swapSample + 1; sample < swapSample + kSectionDeClickSamples; ++sample) {
+            INFO("sample " << sample);
+            REQUIRE(rig.sessionAt(sample) <= rig.sessionAt(sample - 1));
+        }
+    }
+
+    SECTION("so the swap adds no step beyond the incoming clip's own attack") {
+        // The whole point. Without the outgoing ramp the sum jumps 0.8 to -0.3
+        // in one sample, which is 1.1 of step where the material only ever
+        // asked for 0.3.
+        for (auto sample = 1; sample < kBlockSize; ++sample) {
+            INFO("sample " << sample);
+            REQUIRE(std::abs(rig.sessionAt(sample) - rig.sessionAt(sample - 1)) <= 0.3f + 1e-5f);
+        }
+    }
+}
+
+TEST_CASE("A slot sounding right through masks another's stop",
+          "[engine][clip][session][section]") {
+    // The other side of the same rule. The ramp reads its step off the summed
+    // buffer, so a slot that was already sounding before the stop is still in
+    // that sum afterwards and decaying it would correct for a signal that never
+    // stopped.
+    SwitchRig rig;
+    rig.giveArrangement(1, 0.0f);
+    rig.giveSlot(2, 4.0, 0.5f, kScene);
+    rig.giveSlot(3, 4.0, 0.5f, kScene + 1);
+    rig.publish();
+
+    rig.handle.play(std::nullopt);
+    rig.second.play(std::nullopt);
+    rig.roll(0, 1);
+    REQUIRE(rig.sessionAt(0) == Approx(1.0f));
+
+    rig.handle.stop(kBeatsPerBlock * 2.5);
+    rig.render(2);
+
+    const auto stopSample = kBlockSize / 2;
+
+    // One of the two stops, and what is left is the other at its own level
+    // rather than that plus a decaying copy of the pair.
+    CHECK(rig.sessionAt(stopSample - 1) == Approx(1.0f));
+    CHECK(rig.sessionAt(stopSample) == Approx(0.5f));
+    CHECK(rig.sessionAt(kBlockSize - 1) == Approx(0.5f));
+}
+
 TEST_CASE("A track never sounds both of its sections", "[engine][clip][session][section]") {
     // The property the switch exists for. The two sections are summed into one
     // track input, so a sample both contribute material to is a track playing
@@ -1099,6 +1185,38 @@ TEST_CASE("Releasing the section brings the arrangement's MIDI back",
         REQUIRE(ons.size() == 1);
         CHECK(ons.front().message.getNoteNumber() == 64);
     }
+}
+
+TEST_CASE("A hand-back inside a sustained note strikes it rather than waiting",
+          "[engine][clip][session][section]") {
+    // The hand-back is a discontinuity even though the transport never moved:
+    // the arrangement's notes were ended at the hand-over and the timeline ran
+    // on underneath. Releasing into the middle of a pad has to strike it, the
+    // way locating into one does, or the track is silent until the next onset
+    // (#2344 review).
+    MidiSwitchRig rig;
+    rig.publish({arrangementMidiClip(1, 0.0, 16.0, {MidiNote{64, 100, 0.5, 12.0, 0, {}}})},
+                {sessionMidiClip(2, 16.0, {MidiNote{67, 100, 0.0, 16.0, 0, {}}})});
+
+    // Launch while the arrangement's note is already sounding, so the hand-over
+    // ends it and the timeline runs well past its onset.
+    rig.roll(0, 2);
+    REQUIRE(rig.notesOn(rig.fromArrangement).size() == 1);
+
+    rig.handle.play(std::nullopt);
+    rig.roll(3, 12);
+    REQUIRE(rig.hanging(rig.fromArrangement).empty());  // ended at the hand-over
+
+    const auto before = rig.notesOn(rig.fromArrangement).size();
+
+    // Beat 3 by now, which is inside the note and nowhere near its onset.
+    rig.handle.releaseSection();
+    rig.roll(13, 13);
+
+    const auto ons = rig.notesOn(rig.fromArrangement);
+    REQUIRE(ons.size() == before + 1);
+    CHECK(ons.back().block == 13);
+    CHECK(ons.back().message.getNoteNumber() == 64);
 }
 
 TEST_CASE("The hand-over overlap is the ramp and no longer", "[engine][clip][session][section]") {


### PR DESCRIPTION
Slice 3 of #1894. Depends on slice 2, which is #2318.

A track has an arrangement and a session and sounded both at once: the compiler emits `ClipAudio` and `SessionAudio` into the same track mix (`PlanCompiler.cpp:1296-1310`) and nothing decided between them. Launching a slot played it over the top of whatever the timeline was already doing.

## What decides

A slot holds its track from the sample its run begins, and goes on holding it after it stops. The hand-back is not the clip stopping: silence after a stop is the session still holding the track, which is the incumbent's `playSlotClips` and is what Back to Arrangement is for. `LaunchHandle::releaseSection` is the engine side of that; the lane carrying it from off the audio thread is #2305's, so nothing in the app reaches it yet.

Per slot for a question that is per track, because the track's answer is the fold and the fold is over the table both of its sources already read (`sectionHold`, `SessionPlayback.hpp`). Two sources folding one table over one block reach the same answer, so a track's audio and its MIDI end up on the same side of the switch with nothing published between them. Set when the run begins rather than when it is queued, so a launch quantized to the next bar leaves the arrangement playing until the bar.

The incumbent's equivalent is a message-thread timer noticing that a slot has started (`ArrangerLauncherSwitchingNode::sharedTimerCallback`), which is a race it covers with a fade. This is decided on the audio thread, in the pass that has already advanced every handle, and is exact.

**The plan does not change.** A launch is a data change inside a stable plan: both ops stay in the mix and one of them renders silence, so a scene launch recompiles nothing and the differ does no structural work on the callback.

## Not a crossfade

The issue proposed binding `OpKind::Crossfade` to a new cause. That is the wrong shape here, and `FadeCurves.hpp` already says why: a gain fade would attenuate the incoming clip's opening transient, which is the thing the incumbent's de-click is deliberately built to avoid ("A conventional gain fade attenuates the entire first attack, which is especially obvious after a phase-vocoder has spread the transient across the opening window").

The two edges are not one ramp between two signals. They are two corrections:

- the outgoing section carries its last sample down to zero — `StopDeClick`, the mirror of the `StartDeClick` that was already there — which removes the step without touching anything else
- the incoming one simply starts, de-clicked by the ramp it already had

So the incoming clip is never attenuated, and what overlaps during the ramp is the outgoing step being taken out rather than a second signal. There is a test for exactly that.

**32 samples, not the 256 of a launch ramp.** A start de-click subtracts an offset from material that keeps sounding underneath, so its length is free and a longer one is gentler. A stop de-click has no material underneath: what it spends its length on is a held constant, and 5 ms of one is a thump in place of a click. The incumbent spends between 10 and 40 on this edge, in two places that disagree with each other; this is one number for one job.

## What the sources do

Both sources take the handle feed now, and an explicit `Section` says which of them a source is rather than the presence of the feed implying it.

The arrangement renders every block and drops the output while the session holds the track. That costs the CPU of a track nobody is hearing, and it is what makes handing the track back land where the timeline says rather than where the arrangement was when it lost it — the incumbent pays the same, for the same reason. Its MIDI plays up to the hand-over sample and owes note-offs there, so a note due just before a launch still sounds and none is left holding under the session's own.

## The cases the slice existed to settle

- **A switch mid-block**, at the split point slice 1 reports, rather than at a block boundary. At 512 samples and 120 bpm that is up to 11 ms, and it differs per track.
- **A stop with nothing to switch to.** The ramp is to silence and the arrangement stays away, because a stopped slot still holds the track.
- **Two switches inside one block.** Not a case: the ramp decays whatever the signal actually is now rather than resuming an earlier one, so a second switch inside a running ramp steps down from where the listener last heard it.
- **Per track or per source.** The decision is per track and the ramp is per source. Each source de-clicks its own signal with its own last sample, and both act on the one instant, so eight tracks in a scene switch on the same sample.

## Verification

`test_de_click.cpp` covers the pair on its own: both edges, carried across blocks so block size stays an I/O concept, a second stop inside a running ramp, a ramp of zero, and the two read against each other as mirrors.

`test_session_playback.cpp` covers the switch: the arrangement stops at the launch sample and not a block boundary, it is carried down rather than cut off, a launch on a block's first sample is the same switch, a stopped slot goes on holding the track, releasing gives it back mid-material, a slot stopping mid-block carries its own last sample down, the sum of a track's two sections never carries both their materials, and the MIDI hand-over sounds what was due and owes offs for what it started.

One existing assertion changed: a session stop asserted a hard cut to zero at the stop sample, and is now the ramp. That is the slice.

Full engine suite green: 809 cases, 522k assertions.

https://claude.ai/code/session_013CDpSHas8bog33vv4o6HLv
