### PR TITLE
Port the Faust Instrument to MagdaDevice (#2315)

### DIFF
--- a/magda/daw/api/plugin_api_live.cpp
+++ b/magda/daw/api/plugin_api_live.cpp
@@ -458,7 +458,8 @@ juce::String PluginApiLive::applyFaustSource(const ChainNodePath& path,
 
     auto* bridge = getAudioBridge();
     auto plugin = bridge != nullptr ? bridge->getPlugin(path) : nullptr;
-    auto* faust = dynamic_cast<daw::audio::IFaustEditorModel*>(plugin.get());
+    auto* faust = daw::audio::tracktion_adapter::deviceFromPlugin<daw::audio::IFaustEditorModel>(
+        plugin.get());
     if (faust == nullptr)
         return "(could not resolve live Faust plugin)";
 

--- a/magda/daw/audio/plugin_manager/PluginManagerSync.cpp
+++ b/magda/daw/audio/plugin_manager/PluginManagerSync.cpp
@@ -2246,6 +2246,14 @@ void PluginManager::refreshDeviceParameters(const ChainNodePath& devicePath) {
         plugin = it->second.plugin;
     }
 
+    // Before the model is repopulated, because the model is filled from the
+    // host's parameters and a device that reassigned its own values -- a
+    // runtime Faust patch swap rebinding its pool -- would otherwise have them
+    // pushed back over by the next block (#2315).
+    if (auto* wrapper =
+            dynamic_cast<daw::audio::tracktion_adapter::TracktionMagdaDevicePlugin*>(plugin.get()))
+        wrapper->pullParametersFromDevice();
+
     DeviceId sidechainToClear = INVALID_DEVICE_ID;
     if (auto* devInfo = TrackManager::getInstance().getDeviceInChainByPath(devicePath)) {
         processor->populateParameters(*devInfo, DeviceProcessor::ValueSource::Model);

--- a/magda/daw/audio/plugins/BaseDevicePack.cpp
+++ b/magda/daw/audio/plugins/BaseDevicePack.cpp
@@ -435,14 +435,14 @@ void registerNativeDevices(InternalPluginRegistry& registry) {
                    .createMode = InternalPluginCreateMode::SavedStateOrFresh,
                    .loadAliases = kFaustInstrumentAliases,
                    .loadAliasCount = static_cast<int>(std::size(kFaustInstrumentAliases)),
-                   .matchesPlugin = matches<FaustInstrumentPlugin>,
+                   .matchesPlugin = matchesDevice<FaustInstrumentPlugin>,
                    .createProcessor = makeProcessor<FaustInstrumentProcessor>,
                    .showInBrowser = true,
                    .isInstrument = true,
                    .tags = kFaustInstrumentTags,
                    .tagCount = static_cast<int>(std::size(kFaustInstrumentTags)),
                    .createInSession = createValueTreePlugin,
-                   .createPlugin = createPlugin<FaustInstrumentPlugin>});
+                   .createDevice = createDevice<FaustInstrumentPlugin>});
     add(registry,
         {.pluginId = OscilloscopePlugin::xmlTypeName,
          .displayName = "Oscilloscope",

--- a/magda/daw/audio/plugins/FaustInstrumentPlugin.cpp
+++ b/magda/daw/audio/plugins/FaustInstrumentPlugin.cpp
@@ -959,6 +959,10 @@ void FaustInstrumentPlugin::restoreState(const juce::ValueTree& v) {
             stageSourceForEditing(savedName.isNotEmpty() ? savedName : juce::String("Loaded"),
                                   savedSource);
         }
+    } else if (savedName.isNotEmpty()) {
+        // The name is state of its own: a patch renamed without being edited
+        // needs no recompile and would otherwise keep the default's name.
+        dspName_ = savedName;
     }
 
     // Stable ids (param_01 ... param_64), so a macro or automation lane keeps

--- a/magda/daw/audio/plugins/FaustInstrumentPlugin.cpp
+++ b/magda/daw/audio/plugins/FaustInstrumentPlugin.cpp
@@ -431,10 +431,8 @@ std::shared_ptr<FaustInstrumentPlugin::FaustState> FaustInstrumentPlugin::compil
 }
 
 int FaustInstrumentPlugin::readVoiceMode() const {
-    if (!voiceModeParam_)
-        return Poly;
     // The parameter is normalised 0..1 over three modes.
-    const float real = voiceModeParam_->getCurrentValue() * 2.0f;
+    const float real = hostValue(kVoiceModeParamIndex) * 2.0f;
     return juce::jlimit(0, 2, static_cast<int>(std::lround(real)));
 }
 
@@ -463,8 +461,7 @@ void FaustInstrumentPlugin::resetAllVoices(const std::shared_ptr<FaustState>& st
 float FaustInstrumentPlugin::readBendRatio() const {
     if (bendNormalised_ == 0.0f)
         return 1.0f;
-    const float semitones =
-        (bendRangeParam_ ? bendRangeParam_->getCurrentValue() : 0.0f) * kMaxBendSemitones;
+    const float semitones = hostValue(kBendRangeParamIndex) * kMaxBendSemitones;
     return std::pow(2.0f, bendNormalised_ * semitones / 12.0f);
 }
 
@@ -554,7 +551,6 @@ void FaustInstrumentPlugin::handleMonoNoteOff(const std::shared_ptr<FaustState>&
 void FaustInstrumentPlugin::initialiseUnsetPoolValues(
     const std::vector<FaustParamPool::ActiveBindingDescriptor>& bindings,
     const std::array<FaustParamSlot, FaustParamPool::kSize>& previousSlots) {
-    auto* um = getUndoManager();
     for (const auto& binding : bindings) {
         const int slotIndex = binding.slotIndex;
         if (slotIndex < 0 || slotIndex >= FaustParamPool::kSize)
@@ -567,73 +563,41 @@ void FaustInstrumentPlugin::initialiseUnsetPoolValues(
         if (sameControl || restoredBeforeFirstBind)
             continue;
 
-        const float normalisedDefault = normaliseDefaultForSlot(pool_.slot(slotIndex));
-        auto& cached = poolCached_[static_cast<size_t>(slotIndex)];
-        cached.setValue(normalisedDefault, um);
-
-        auto& param = poolParams_[static_cast<size_t>(slotIndex)];
-        if (param)
-            param->updateFromAttachedValue();
+        poolValues_[static_cast<size_t>(slotIndex)].store(
+            normaliseDefaultForSlot(pool_.slot(slotIndex)), std::memory_order_relaxed);
     }
+    refreshPoolDomains();
 }
 
-FaustInstrumentPlugin::FaustInstrumentPlugin(const te::PluginCreationInfo& info)
-    : te::Plugin(info) {
-    // Mono/legato note-ons push onto this from applyToBuffer. MIDI cannot hold
-    // more than 128 notes down at once, so reserving here means the audio
-    // thread never grows it.
+FaustInstrumentPlugin::FaustInstrumentPlugin() {
+    // Mono/legato note-ons push onto this from process(). MIDI cannot hold more
+    // than 128 notes down at once, so reserving here means the audio thread
+    // never grows it.
     heldNotes_.reserve(128);
-    poolParams_.resize(FaustParamPool::kSize);
-    auto* um = getUndoManager();
-    juce::NormalisableRange<float> normalisedRange{0.0f, 1.0f};
-    for (int i = 0; i < FaustParamPool::kSize; ++i) {
-        const auto id = poolParamId(i);
-        poolValueWasRestored_[static_cast<size_t>(i)] = state.hasProperty(juce::Identifier(id));
-        poolCached_[static_cast<size_t>(i)].referTo(this->state, juce::Identifier(id), um, 0.0f);
-        poolParams_[static_cast<size_t>(i)] = addParam(id, id, normalisedRange);
-        poolParams_[static_cast<size_t>(i)]->attachToCurrentValue(
-            poolCached_[static_cast<size_t>(i)]);
-    }
 
-    // Host-owned voice allocation, added after the pool so the pool's parameter
-    // indices stay put. Both are normalised 0..1 like every other TE parameter;
-    // faustInstrumentHostParamInfo() carries the real ranges for display.
-    voiceModeCached_.referTo(this->state, juce::Identifier("voiceMode"), um, 0.0f);
-    voiceModeParam_ = addParam("voiceMode", "Voice Mode", normalisedRange);
-    voiceModeParam_->attachToCurrentValue(voiceModeCached_);
+    for (auto& value : poolValues_)
+        value.store(0.0f, std::memory_order_relaxed);
 
-    glideCached_.referTo(this->state, juce::Identifier("glide"), um, 0.0f);
-    glideParam_ = addParam("glide", "Glide", normalisedRange);
-    glideParam_->attachToCurrentValue(glideCached_);
+    hostValues_[0].store(0.0f, std::memory_order_relaxed);  // Poly
+    hostValues_[1].store(0.0f, std::memory_order_relaxed);  // no glide
+    // 2 semitones, the near-universal synth default, normalised against
+    // kMaxBendSemitones like every other parameter here.
+    hostValues_[2].store(2.0f / kMaxBendSemitones, std::memory_order_relaxed);
 
-    // Default 2 semitones, the near-universal synth default, stored normalised
-    // against kMaxBendSemitones like every other parameter here.
-    constexpr float kDefaultBendNorm = 2.0f / kMaxBendSemitones;
-    bendRangeCached_.referTo(this->state, juce::Identifier("bendRange"), um, kDefaultBendNorm);
-    bendRangeParam_ = addParam("bendRange", "Bend Range", normalisedRange);
-    bendRangeParam_->attachToCurrentValue(bendRangeCached_);
-
-    const auto savedSource = state.getProperty("dspSource", juce::String()).toString();
-    const auto savedName = state.getProperty("dspName", juce::String()).toString();
-
+    // The pool is lifetime-stable and starts empty; a saved source arrives
+    // later through restoreState(), which recompiles and rebinds onto the same
+    // slots. Construction settles on the default patch so the device is
+    // answerable before any project has been loaded into it.
     juce::String err;
-    auto compiled = compileAndRebind(
-        savedSource.isNotEmpty() ? savedSource : juce::String(kDefaultDspSource), err);
-    if (!compiled) {
-        DBG("FaustInstrumentPlugin: failed to compile saved source: " << err << " - using default");
-        compiled = compileAndRebind(kDefaultDspSource, err);
-    }
+    auto compiled = compileAndRebind(kDefaultDspSource, err);
 
-    dspSource_ = savedSource.isNotEmpty() ? savedSource : juce::String(kDefaultDspSource);
-    dspName_ = savedName.isNotEmpty() ? savedName : juce::String("Simple Synth");
+    dspSource_ = kDefaultDspSource;
+    dspName_ = "Simple Synth";
     // Derived, not restored: the source is the only thing that has to persist.
     viewName_ = readCustomViewName(dspSource_);
 
     reservePointerScratch(compiled);
     std::atomic_store(&active_, compiled);
-
-    state.setProperty("dspSource", dspSource_, nullptr);
-    state.setProperty("dspName", dspName_, nullptr);
 
     retireTimer_.startTimer(100);
 
@@ -643,16 +607,7 @@ FaustInstrumentPlugin::FaustInstrumentPlugin(const te::PluginCreationInfo& info)
 }
 
 FaustInstrumentPlugin::~FaustInstrumentPlugin() {
-    notifyListenersOfDeletion();
     retireTimer_.stopTimer();
-    for (auto& p : poolParams_) {
-        if (p)
-            p->detachFromCurrentValue();
-    }
-    if (voiceModeParam_)
-        voiceModeParam_->detachFromCurrentValue();
-    if (glideParam_)
-        glideParam_->detachFromCurrentValue();
     std::atomic_store(&active_, std::shared_ptr<FaustState>{});
     {
         const juce::ScopedLock lk(retiredLock_);
@@ -695,8 +650,6 @@ bool FaustInstrumentPlugin::loadDspSource(const juce::String& name, const juce::
     dspName_ = name;
     dspSource_ = source;
     viewName_ = readCustomViewName(source);
-    state.setProperty("dspName", dspName_, getUndoManager());
-    state.setProperty("dspSource", dspSource_, getUndoManager());
 
     DBG("FaustInstrumentPlugin::loadDspSource ok name=" << name << " out=" << compiled->dspOut
                                                         << " active=" << pool_.activeCount());
@@ -709,12 +662,30 @@ void FaustInstrumentPlugin::stageSourceForEditing(const juce::String& name,
     // without replacing the audible polyphonic DSP or its parameter pool.
     dspName_ = name;
     dspSource_ = source;
-    state.setProperty("dspName", dspName_, getUndoManager());
-    state.setProperty("dspSource", dspSource_, getUndoManager());
 }
 
-void FaustInstrumentPlugin::initialise(const te::PluginInitialisationInfo& info) {
-    currentSampleRate_ = static_cast<int>(info.sampleRate);
+DeviceProperties FaustInstrumentPlugin::properties() const {
+    // The output count is the compiled dsp's own. No audio input at all: this
+    // is a source, and the plan mixes what it writes into the chain's bus.
+    const auto active = std::atomic_load(&active_);
+
+    return {
+        .pluginId = xmlTypeName,
+        .name = getPluginName(),
+        .shortName = "FaustInst",
+        .takesMidiInput = true,
+        .takesAudioInput = false,
+        .isSynth = true,
+        .producesAudioWithoutInput = true,
+        .outputChannelCount = active && active->dspOut > 0 ? active->dspOut : 2,
+        .inputChannelCount = 0,
+    };
+}
+
+void FaustInstrumentPlugin::release() {}
+
+void FaustInstrumentPlugin::prepare(const DevicePrepareContext& context) {
+    currentSampleRate_ = static_cast<int>(context.sampleRate);
 
     if (auto state = std::atomic_load(&active_)) {
         if (state->poly)
@@ -730,19 +701,16 @@ void FaustInstrumentPlugin::initialise(const te::PluginInitialisationInfo& info)
     }
 
     const int dspOut = std::atomic_load(&active_) ? std::atomic_load(&active_)->dspOut : 2;
-    scratchOut_.setSize(std::max(dspOut, 2), info.blockSizeSamples, false, true, false);
+    scratchOut_.setSize(std::max(dspOut, 2), context.maximumBlockSize, false, true, false);
 
-    DBG("FaustInstrumentPlugin::initialise sr=" << currentSampleRate_
-                                                << " blockSize=" << info.blockSizeSamples);
+    DBG("FaustInstrumentPlugin::prepare sr=" << currentSampleRate_
+                                             << " blockSize=" << context.maximumBlockSize);
 }
 
-void FaustInstrumentPlugin::deinitialise() {}
-
 void FaustInstrumentPlugin::reset() {
-    // Called from the message thread (TE's plugin API, and AudioBridge's
-    // resetSynthsOnTrack after a record pass) while the audio thread may be
-    // inside compute(). Only raise the flag; the flush runs at the top of the
-    // next applyToBuffer.
+    // Called from the message thread while the audio thread may be inside
+    // compute(). Only raise the flag; the flush runs at the top of the next
+    // process().
     pendingVoiceFlush_.store(true, std::memory_order_release);
 }
 
@@ -752,8 +720,8 @@ void FaustInstrumentPlugin::reservePointerScratch(const std::shared_ptr<FaustSta
     outPtrs_.reserve(static_cast<size_t>(std::max(0, state->dspOut)));
 }
 
-void FaustInstrumentPlugin::applyToBuffer(const te::PluginRenderContext& fc) {
-    if (!fc.destBuffer || fc.bufferNumSamples <= 0)
+void FaustInstrumentPlugin::process(DeviceProcessContext& context) {
+    if (context.audio == nullptr || context.numSamples <= 0)
         return;
 
     auto active = std::atomic_load(&active_);
@@ -767,9 +735,9 @@ void FaustInstrumentPlugin::applyToBuffer(const te::PluginRenderContext& fc) {
 
     // Stopping mid-note delivers no note-offs, so a sounding clip voice would
     // hang gated on. Flush on the playing -> stopped edge.
-    if (wasPlaying_ && !fc.isPlaying)
+    if (wasPlaying_ && !context.isPlaying)
         resetAllVoices(active);
-    wasPlaying_ = fc.isPlaying;
+    wasPlaying_ = context.isPlaying;
 
     // Apply user parameter values: denormalize once per slot, then fan the
     // value out to every voice's zone (plain pointer writes — RT-safe). The
@@ -780,10 +748,9 @@ void FaustInstrumentPlugin::applyToBuffer(const te::PluginRenderContext& fc) {
             continue;
         if (b.slotIndex < 0 || b.slotIndex >= FaustParamPool::kSize)
             continue;
-        const auto& param = poolParams_[static_cast<size_t>(b.slotIndex)];
-        if (!param)
-            continue;
-        const float value = static_cast<float>(denormalizeForBinding(b, param->getCurrentValue()));
+        const float normalised =
+            poolValues_[static_cast<size_t>(b.slotIndex)].load(std::memory_order_relaxed);
+        const float value = static_cast<float>(denormalizeForBinding(b, normalised));
         for (FAUSTFLOAT* zone : active->voiceZonesBySlot[static_cast<size_t>(b.slotIndex)]) {
             if (zone)
                 *zone = static_cast<FAUSTFLOAT>(value);
@@ -804,8 +771,11 @@ void FaustInstrumentPlugin::applyToBuffer(const te::PluginRenderContext& fc) {
         const auto& zones = active->voiceZonesBySlot[static_cast<size_t>(b.slotIndex)];
         if (zones.empty())
             continue;
-        if (cachedBpm < 0.0)
-            cachedBpm = edit.tempoSequence.getBpmAt(fc.editTime.getStart());
+        if (cachedBpm < 0.0) {
+            cachedBpm = context.tempoMap != nullptr
+                            ? context.tempoMap->bpmAtSeconds(context.timelineStartSeconds)
+                            : 120.0;
+        }
         for (FAUSTFLOAT* zone : zones) {
             if (zone)
                 *zone = static_cast<FAUSTFLOAT>(cachedBpm);
@@ -814,9 +784,9 @@ void FaustInstrumentPlugin::applyToBuffer(const te::PluginRenderContext& fc) {
             *monoZone = static_cast<FAUSTFLOAT>(cachedBpm);
     }
 
-    const int hostChannels = fc.destBuffer->getNumChannels();
-    const int n = fc.bufferNumSamples;
-    const int start = fc.bufferStartSample;
+    const int hostChannels = context.audio->getNumChannels();
+    const int n = context.numSamples;
+    const int start = context.startSample;
     const int dspOut = active->dspOut;
 
     if (hostChannels <= 0 || dspOut <= 0 || scratchOut_.getNumSamples() <= 0)
@@ -839,7 +809,7 @@ void FaustInstrumentPlugin::applyToBuffer(const te::PluginRenderContext& fc) {
     // get from si.smooth(ba.tau2pole(glide)) inside their DSP. Here the host
     // owns the ramp instead, because a runtime patch reads `freq` directly and
     // cannot be assumed to smooth anything itself.
-    const float glideMs = glideParam_ ? glideParam_->getCurrentValue() * 2000.0f : 0.0f;
+    const float glideMs = hostValue(kGlideParamIndex) * 2000.0f;
     const float glideTau = glideMs * 0.001f;
 
     outPtrs_.resize(static_cast<size_t>(dspOut));
@@ -888,7 +858,7 @@ void FaustInstrumentPlugin::applyToBuffer(const te::PluginRenderContext& fc) {
             for (int ch = 0; ch < hostChannels; ++ch) {
                 // One-output ("mono") DSP drives both channels; else channel-map.
                 const int srcCh = (dspOut == 1) ? 0 : (ch % dspOut);
-                fc.destBuffer->addFrom(ch, start + segStart + done, scratchOut_, srcCh, 0, chunk);
+                context.audio->addFrom(ch, start + segStart + done, scratchOut_, srcCh, 0, chunk);
             }
             done += chunk;
         }
@@ -898,8 +868,9 @@ void FaustInstrumentPlugin::applyToBuffer(const te::PluginRenderContext& fc) {
     // Mono retrigger depends on this: its envelope restarts on a gate edge, and
     // an edge only exists if samples are rendered either side of it.
     int cursor = 0;
-    if (fc.bufferForMidiMessages != nullptr && !fc.bufferForMidiMessages->isEmpty()) {
-        for (auto& m : *fc.bufferForMidiMessages) {
+    if (context.midi != nullptr) {
+        for (int eventIndex = 0; eventIndex < context.midi->size(); ++eventIndex) {
+            const auto& m = context.midi->message(eventIndex);
             int evSample = juce::roundToInt(m.getTimeStamp() * currentSampleRate_);
             evSample = juce::jlimit(cursor, n, evSample);  // clamp + keep monotonic
             renderSegment(cursor, evSample - cursor);
@@ -962,7 +933,22 @@ void FaustInstrumentPlugin::applyToBuffer(const te::PluginRenderContext& fc) {
     renderSegment(cursor, n - cursor);
 }
 
-void FaustInstrumentPlugin::restorePluginStateFromValueTree(const juce::ValueTree& v) {
+void FaustInstrumentPlugin::flushState(juce::ValueTree& state) {
+    state.setProperty("dspName", dspName_, nullptr);
+    state.setProperty("dspSource", dspSource_, nullptr);
+    for (int i = 0; i < FaustParamPool::kSize; ++i)
+        state.setProperty(juce::Identifier(poolParamId(i)),
+                          poolValues_[static_cast<size_t>(i)].load(std::memory_order_relaxed),
+                          nullptr);
+
+    // The host's three, under the spellings the retired plugin registered, so
+    // a project saved before the port reads back onto the same controls.
+    state.setProperty("voiceMode", hostValue(kVoiceModeParamIndex), nullptr);
+    state.setProperty("glide", hostValue(kGlideParamIndex), nullptr);
+    state.setProperty("bendRange", hostValue(kBendRangeParamIndex), nullptr);
+}
+
+void FaustInstrumentPlugin::restoreState(const juce::ValueTree& v) {
     const auto savedSource = v.getProperty("dspSource", juce::String()).toString();
     const auto savedName = v.getProperty("dspName", juce::String()).toString();
 
@@ -971,20 +957,75 @@ void FaustInstrumentPlugin::restorePluginStateFromValueTree(const juce::ValueTre
         if (!loadDspSource(savedName.isNotEmpty() ? savedName : juce::String("Loaded"), savedSource,
                            err)) {
             DBG("FaustInstrumentPlugin::restore: compile failed: " << err);
+
+            // Staged rather than dropped, as the effect does: the source stays
+            // editable so whoever opens the project sees what failed and can
+            // repair it, instead of the patch silently becoming the default.
+            stageSourceForEditing(savedName.isNotEmpty() ? savedName : juce::String("Loaded"),
+                                  savedSource);
         }
     }
 
-    for (size_t i = 0; i < poolCached_.size(); ++i) {
-        const auto id = poolParamId(static_cast<int>(i));
-        if (auto p = v.getPropertyPointer(juce::Identifier(id)))
-            poolCached_[i] = static_cast<float>(*p);
-        else
-            poolCached_[i].resetToDefault();
+    // Pool values are saved under stable ids (param_01 ... param_64), which is
+    // what lets a macro or automation lane keep pointing at the same control
+    // across a recompile.
+    for (int i = 0; i < FaustParamPool::kSize; ++i) {
+        const auto* saved = v.getPropertyPointer(juce::Identifier(poolParamId(i)));
+        poolValueWasRestored_[static_cast<size_t>(i)] = saved != nullptr;
+        poolValues_[static_cast<size_t>(i)].store(
+            saved != nullptr ? static_cast<float>(*saved) : 0.0f, std::memory_order_relaxed);
     }
-    for (auto& p : poolParams_) {
-        if (p)
-            p->updateFromAttachedValue();
+    refreshPoolDomains();
+
+    // A property the project does not name keeps what the constructor set,
+    // which for the bend range is two semitones rather than none: absent and
+    // zero have to stay different, or every older project would open with the
+    // wheel doing nothing.
+    const auto restoreHost = [&v, this](const char* id, int parameterIndex) {
+        if (const auto* saved = v.getPropertyPointer(juce::Identifier(id)))
+            setParameterValue(parameterIndex, static_cast<float>(*saved));
+    };
+    restoreHost("voiceMode", kVoiceModeParamIndex);
+    restoreHost("glide", kGlideParamIndex);
+    restoreHost("bendRange", kBendRangeParamIndex);
+}
+
+void FaustInstrumentPlugin::refreshPoolDomains() {
+    for (int i = 0; i < FaustParamPool::kSize; ++i)
+        poolDomains_[static_cast<size_t>(i)] =
+            ParameterUtils::domainOf(paramInfoFromSlot(pool_.slot(i)));
+}
+
+ParameterInfo FaustInstrumentPlugin::parameterInfo(int index) const {
+    if (index >= FaustParamPool::kSize && index < parameterCount())
+        return faustInstrumentHostParamInfo(index - FaustParamPool::kSize);
+    if (index < 0 || index >= FaustParamPool::kSize)
+        return {};
+
+    auto info = paramInfoFromSlot(pool_.slot(index));
+    info.paramIndex = index;
+    info.stableId = poolParamId(index);
+    return info;
+}
+
+float FaustInstrumentPlugin::parameterValue(int index) const {
+    if (index >= FaustParamPool::kSize && index < parameterCount())
+        return hostValue(index);
+    if (index < 0 || index >= FaustParamPool::kSize)
+        return 0.0f;
+    return poolValues_[static_cast<size_t>(index)].load(std::memory_order_relaxed);
+}
+
+void FaustInstrumentPlugin::setParameterValue(int index, float value) {
+    const float clamped = juce::jlimit(0.0f, 1.0f, value);
+    if (index >= FaustParamPool::kSize && index < parameterCount()) {
+        hostValues_[static_cast<size_t>(index - FaustParamPool::kSize)].store(
+            clamped, std::memory_order_relaxed);
+        return;
     }
+    if (index < 0 || index >= FaustParamPool::kSize)
+        return;
+    poolValues_[static_cast<size_t>(index)].store(clamped, std::memory_order_relaxed);
 }
 
 }  // namespace magda::daw::audio

--- a/magda/daw/audio/plugins/FaustInstrumentPlugin.cpp
+++ b/magda/daw/audio/plugins/FaustInstrumentPlugin.cpp
@@ -570,9 +570,8 @@ void FaustInstrumentPlugin::initialiseUnsetPoolValues(
 }
 
 FaustInstrumentPlugin::FaustInstrumentPlugin() {
-    // Mono/legato note-ons push onto this from process(). MIDI cannot hold more
-    // than 128 notes down at once, so reserving here means the audio thread
-    // never grows it.
+    // Reserved so process() never grows it. See #2351: without a dedup this
+    // bound is note-ons rather than held notes, and can be exceeded.
     heldNotes_.reserve(128);
 
     for (auto& value : poolValues_)
@@ -580,14 +579,11 @@ FaustInstrumentPlugin::FaustInstrumentPlugin() {
 
     hostValues_[0].store(0.0f, std::memory_order_relaxed);  // Poly
     hostValues_[1].store(0.0f, std::memory_order_relaxed);  // no glide
-    // 2 semitones, the near-universal synth default, normalised against
-    // kMaxBendSemitones like every other parameter here.
+    // 2 semitones, the usual default, normalised against kMaxBendSemitones.
     hostValues_[2].store(2.0f / kMaxBendSemitones, std::memory_order_relaxed);
 
-    // The pool is lifetime-stable and starts empty; a saved source arrives
-    // later through restoreState(), which recompiles and rebinds onto the same
-    // slots. Construction settles on the default patch so the device is
-    // answerable before any project has been loaded into it.
+    // The default patch, so the device is answerable before a project loads
+    // into it. A saved source arrives later through restoreState().
     juce::String err;
     auto compiled = compileAndRebind(kDefaultDspSource, err);
 
@@ -665,8 +661,8 @@ void FaustInstrumentPlugin::stageSourceForEditing(const juce::String& name,
 }
 
 DeviceProperties FaustInstrumentPlugin::properties() const {
-    // The output count is the compiled dsp's own. No audio input at all: this
-    // is a source, and the plan mixes what it writes into the chain's bus.
+    // The compiled dsp's own output count. No audio input: the plan mixes what
+    // this writes into the chain's bus.
     const auto active = std::atomic_load(&active_);
 
     return {
@@ -941,8 +937,8 @@ void FaustInstrumentPlugin::flushState(juce::ValueTree& state) {
                           poolValues_[static_cast<size_t>(i)].load(std::memory_order_relaxed),
                           nullptr);
 
-    // The host's three, under the spellings the retired plugin registered, so
-    // a project saved before the port reads back onto the same controls.
+    // The retired plugin's spellings, so an older project reads back onto the
+    // same controls.
     state.setProperty("voiceMode", hostValue(kVoiceModeParamIndex), nullptr);
     state.setProperty("glide", hostValue(kGlideParamIndex), nullptr);
     state.setProperty("bendRange", hostValue(kBendRangeParamIndex), nullptr);
@@ -958,17 +954,15 @@ void FaustInstrumentPlugin::restoreState(const juce::ValueTree& v) {
                            err)) {
             DBG("FaustInstrumentPlugin::restore: compile failed: " << err);
 
-            // Staged rather than dropped, as the effect does: the source stays
-            // editable so whoever opens the project sees what failed and can
-            // repair it, instead of the patch silently becoming the default.
+            // Staged rather than dropped, as the effect does, so the source
+            // stays editable instead of silently becoming the default.
             stageSourceForEditing(savedName.isNotEmpty() ? savedName : juce::String("Loaded"),
                                   savedSource);
         }
     }
 
-    // Pool values are saved under stable ids (param_01 ... param_64), which is
-    // what lets a macro or automation lane keep pointing at the same control
-    // across a recompile.
+    // Stable ids (param_01 ... param_64), so a macro or automation lane keeps
+    // pointing at the same control across a recompile.
     for (int i = 0; i < FaustParamPool::kSize; ++i) {
         const auto* saved = v.getPropertyPointer(juce::Identifier(poolParamId(i)));
         poolValueWasRestored_[static_cast<size_t>(i)] = saved != nullptr;
@@ -977,10 +971,8 @@ void FaustInstrumentPlugin::restoreState(const juce::ValueTree& v) {
     }
     refreshPoolDomains();
 
-    // A property the project does not name keeps what the constructor set,
-    // which for the bend range is two semitones rather than none: absent and
-    // zero have to stay different, or every older project would open with the
-    // wheel doing nothing.
+    // An absent property keeps the constructor's value: for the bend range
+    // that is two semitones, and absent must not read as zero.
     const auto restoreHost = [&v, this](const char* id, int parameterIndex) {
         if (const auto* saved = v.getPropertyPointer(juce::Identifier(id)))
             setParameterValue(parameterIndex, static_cast<float>(*saved));

--- a/magda/daw/audio/plugins/FaustInstrumentPlugin.hpp
+++ b/magda/daw/audio/plugins/FaustInstrumentPlugin.hpp
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <tracktion_engine/tracktion_engine.h>
-
 #include <array>
 #include <atomic>
 #include <memory>
@@ -10,6 +8,8 @@
 #include "FaustParamInfo.hpp"
 #include "FaustParamPool.hpp"
 #include "IFaustEditorModel.hpp"
+#include "core/ParameterUtils.hpp"
+#include "plugins/MagdaDevice.hpp"
 
 // libfaust types are forward-declared so consumers don't need the Faust
 // runtime headers on their include path. Implementation pulls them in.
@@ -19,22 +19,26 @@ class dsp_poly;
 
 namespace magda::daw::audio {
 
-namespace te = tracktion::engine;
-
 // A Faust-based polyphonic *instrument*. Sibling of FaustPlugin (the
 // effect host) — it shares the same runtime-compile + FaustParamPool design,
 // but reports as a synth, wraps the compiled DSP in a polyphonic voice
 // allocator (mydsp_poly), and drives note allocation from the MIDI in the
-// PluginRenderContext. The .dsp source is expected to follow the Faust
+// process context. The .dsp source is expected to follow the Faust
 // polyphonic convention: the reserved controls `freq`, `gain`, `gate` are
 // driven per-voice by the allocator and are NOT exposed as user parameters.
+//
+// A MagdaDevice since #2315, like its effect sibling: one instrument, whichever
+// engine is running it. The compiled factory and its voices live for as long as
+// the device does, which is the runtime store's lifetime rather than the plan's
+// - so recompiling a plan because a fader moved never rebuilds a voice
+// mid-note.
 //
 // Shared scaffolding (UIHarvester, pool rebind, atomic state swap, retire
 // timer) is still copied from FaustPlugin rather than shared; a future
 // refactor can extract a common base. See docs/architecture/faust-param-pool.md.
-class FaustInstrumentPlugin : public te::Plugin, public IFaustEditorModel {
+class FaustInstrumentPlugin : public MagdaDevice, public IFaustEditorModel {
   public:
-    FaustInstrumentPlugin(const te::PluginCreationInfo& info);
+    FaustInstrumentPlugin();
     ~FaustInstrumentPlugin() override;
 
     static const char* getPluginName() {
@@ -42,43 +46,24 @@ class FaustInstrumentPlugin : public te::Plugin, public IFaustEditorModel {
     }
     static const char* xmlTypeName;
 
-    juce::String getName() const override {
-        return getPluginName();
-    }
-    juce::String getPluginType() override {
-        return xmlTypeName;
-    }
-    juce::String getShortName(int) override {
-        return "FaustInst";
-    }
-    juce::String getSelectableDescription() override {
-        return getName();
-    }
+    DeviceProperties properties() const override;
 
-    void initialise(const te::PluginInitialisationInfo& info) override;
-    void deinitialise() override;
+    void prepare(const DevicePrepareContext& context) override;
+    void release() override;
     void reset() override;
+    void process(DeviceProcessContext& context) override;
 
-    void applyToBuffer(const te::PluginRenderContext& fc) override;
+    // The pool's stable slots, then the three the host owns. See
+    // kVoiceModeParamIndex below: a patch keeps all 64 of its own.
+    int parameterCount() const override {
+        return FaustParamPool::kSize + kHostParamCount;
+    }
+    ParameterInfo parameterInfo(int index) const override;
+    float parameterValue(int index) const override;
+    void setParameterValue(int index, float value) override;
 
-    // Instrument reporting: consumes MIDI, generates audio, no audio input.
-    bool takesMidiInput() override {
-        return true;
-    }
-    bool takesAudioInput() override {
-        return false;
-    }
-    bool isSynth() override {
-        return true;
-    }
-    bool producesAudioWhenNoAudioInput() override {
-        return true;
-    }
-    double getTailLength() const override {
-        return 0.0;
-    }
-
-    void restorePluginStateFromValueTree(const juce::ValueTree&) override;
+    void flushState(juce::ValueTree& state) override;
+    void restoreState(const juce::ValueTree& state) override;
 
     // Compile `source`, wrap it in a fresh poly voice allocator, swap it in,
     // and persist source+name to plugin state. Returns true on success; on
@@ -192,6 +177,9 @@ class FaustInstrumentPlugin : public te::Plugin, public IFaustEditorModel {
     void initialiseUnsetPoolValues(
         const std::vector<FaustParamPool::ActiveBindingDescriptor>& bindings,
         const std::array<FaustParamSlot, FaustParamPool::kSize>& previousSlots);
+    /// Re-cache the conversion domain of every pool slot, so process() never
+    /// builds one. Called whenever the slot table changes.
+    void refreshPoolDomains();
 
     // Active dsp + factory + binding bundle. Read/written via the std::shared_ptr
     // atomic free functions (libc++ lacks std::atomic<std::shared_ptr<T>>).
@@ -199,19 +187,29 @@ class FaustInstrumentPlugin : public te::Plugin, public IFaustEditorModel {
 
     // Lifetime-stable parameter pool (macro/mod/automation links pin to slots).
     FaustParamPool pool_;
-    std::vector<te::AutomatableParameter::Ptr> poolParams_;
-    std::array<juce::CachedValue<float>, FaustParamPool::kSize> poolCached_;
+    // Normalised 0..1 per slot, written by the host and read on the audio
+    // thread. Relaxed atomics rather than a lock: a torn read is a value one
+    // block stale, which a parameter already is.
+    std::array<std::atomic<float>, FaustParamPool::kSize> poolValues_{};
+    std::array<ParameterUtils::ParameterDomain, FaustParamPool::kSize> poolDomains_{};
     std::array<bool, FaustParamPool::kSize> poolValueWasRestored_{};
 
     // ---- Host-owned voice allocation -------------------------------------
-    // Added after the pool params, so their TE parameter indices are
-    // kVoiceModeParamIndex / kGlideParamIndex and nothing in the pool moves.
-    te::AutomatableParameter::Ptr voiceModeParam_;
-    te::AutomatableParameter::Ptr glideParam_;
-    te::AutomatableParameter::Ptr bendRangeParam_;
-    juce::CachedValue<float> voiceModeCached_;
-    juce::CachedValue<float> glideCached_;
-    juce::CachedValue<float> bendRangeCached_;
+    // Addressed past the end of the pool, so their indices are
+    // kVoiceModeParamIndex / kGlideParamIndex / kBendRangeParamIndex and
+    // nothing in the pool moves. Normalised like every other parameter here;
+    // faustInstrumentHostParamInfo() carries the real ranges for display.
+    std::array<std::atomic<float>, kHostParamCount> hostValues_{};
+
+    /// One of the three host-owned parameters, normalised, by its parameter
+    /// index (kVoiceModeParamIndex and friends) rather than its slot in the
+    /// array - every caller has the index to hand and none has the offset.
+    float hostValue(int parameterIndex) const {
+        const auto slot = static_cast<std::size_t>(parameterIndex - FaustParamPool::kSize);
+        if (slot >= hostValues_.size())
+            return 0.0f;
+        return hostValues_[slot].load(std::memory_order_relaxed);
+    }
 
     int readVoiceMode() const;
     // Frequency multiplier for the current wheel position, 1.0 when centred.

--- a/magda/daw/audio/plugins/FaustInstrumentPlugin.hpp
+++ b/magda/daw/audio/plugins/FaustInstrumentPlugin.hpp
@@ -27,11 +27,8 @@ namespace magda::daw::audio {
 // polyphonic convention: the reserved controls `freq`, `gain`, `gate` are
 // driven per-voice by the allocator and are NOT exposed as user parameters.
 //
-// A MagdaDevice since #2315, like its effect sibling: one instrument, whichever
-// engine is running it. The compiled factory and its voices live for as long as
-// the device does, which is the runtime store's lifetime rather than the plan's
-// - so recompiling a plan because a fader moved never rebuilds a voice
-// mid-note.
+// A MagdaDevice since #2315. The factory and its voices live as long as the
+// device, so a plan recompile never rebuilds a voice mid-note.
 //
 // Shared scaffolding (UIHarvester, pool rebind, atomic state swap, retire
 // timer) is still copied from FaustPlugin rather than shared; a future
@@ -53,8 +50,7 @@ class FaustInstrumentPlugin : public MagdaDevice, public IFaustEditorModel {
     void reset() override;
     void process(DeviceProcessContext& context) override;
 
-    // The pool's stable slots, then the three the host owns. See
-    // kVoiceModeParamIndex below: a patch keeps all 64 of its own.
+    // The pool's stable slots, then the three the host owns.
     int parameterCount() const override {
         return FaustParamPool::kSize + kHostParamCount;
     }
@@ -187,23 +183,18 @@ class FaustInstrumentPlugin : public MagdaDevice, public IFaustEditorModel {
 
     // Lifetime-stable parameter pool (macro/mod/automation links pin to slots).
     FaustParamPool pool_;
-    // Normalised 0..1 per slot, written by the host and read on the audio
-    // thread. Relaxed atomics rather than a lock: a torn read is a value one
-    // block stale, which a parameter already is.
+    // Normalised 0..1, written by the host and read on the audio thread.
     std::array<std::atomic<float>, FaustParamPool::kSize> poolValues_{};
     std::array<ParameterUtils::ParameterDomain, FaustParamPool::kSize> poolDomains_{};
     std::array<bool, FaustParamPool::kSize> poolValueWasRestored_{};
 
     // ---- Host-owned voice allocation -------------------------------------
-    // Addressed past the end of the pool, so their indices are
-    // kVoiceModeParamIndex / kGlideParamIndex / kBendRangeParamIndex and
-    // nothing in the pool moves. Normalised like every other parameter here;
+    // Past the end of the pool, so nothing in the pool moves. Normalised;
     // faustInstrumentHostParamInfo() carries the real ranges for display.
     std::array<std::atomic<float>, kHostParamCount> hostValues_{};
 
-    /// One of the three host-owned parameters, normalised, by its parameter
-    /// index (kVoiceModeParamIndex and friends) rather than its slot in the
-    /// array - every caller has the index to hand and none has the offset.
+    /// A host-owned parameter by its parameter index (kVoiceModeParamIndex and
+    /// friends), which is what every caller has to hand.
     float hostValue(int parameterIndex) const {
         const auto slot = static_cast<std::size_t>(parameterIndex - FaustParamPool::kSize);
         if (slot >= hostValues_.size())

--- a/magda/daw/audio/plugins/FaustParamInfo.cpp
+++ b/magda/daw/audio/plugins/FaustParamInfo.cpp
@@ -28,6 +28,7 @@ constexpr const char* kHostParamGroup = "Voice";
 
 magda::ParameterInfo voiceModeInfo() {
     magda::ParameterInfo info;
+    info.stableId = "voiceMode";
     info.paramIndex = FaustParamPool::kSize;
     info.name = "Voice Mode";
     info.group = kHostParamGroup;
@@ -52,6 +53,7 @@ magda::ParameterInfo voiceModeInfo() {
 
 magda::ParameterInfo glideInfo() {
     magda::ParameterInfo info;
+    info.stableId = "glide";
     info.paramIndex = FaustParamPool::kSize + 1;
     info.name = "Glide";
     info.group = kHostParamGroup;
@@ -68,6 +70,7 @@ magda::ParameterInfo glideInfo() {
 
 magda::ParameterInfo bendRangeInfo() {
     magda::ParameterInfo info;
+    info.stableId = "bendRange";
     info.paramIndex = FaustParamPool::kSize + 2;
     info.name = "Bend Range";
     info.group = kHostParamGroup;
@@ -178,6 +181,10 @@ magda::ParameterInfo discreteInfo(const FaustParamSlot& slot) {
 
 }  // namespace
 
+// The three ids below are the retired plugin's own property spellings. The host
+// wrapper keys its CachedValue on stableId and falls back to
+// "<pluginId>_param_<n>" without one, which would neither read what flushState
+// writes nor survive a project saved before the port (#2315).
 magda::ParameterInfo faustInstrumentHostParamInfo(int hostIndex) {
     switch (hostIndex) {
         case 0:

--- a/magda/daw/audio/plugins/tracktion/TracktionMagdaDevicePlugin.cpp
+++ b/magda/daw/audio/plugins/tracktion/TracktionMagdaDevicePlugin.cpp
@@ -315,6 +315,11 @@ te::AutomatableParameter* TracktionMagdaDevicePlugin::parameterForDeviceSlot(int
 }
 
 void TracktionMagdaDevicePlugin::flushPluginStateToValueTree() {
+    // The host owns parameter values here and the device's copy is only as
+    // fresh as the last block: nothing has pushed into it since construction if
+    // the plugin has not rendered. Without this, flushState() writes those
+    // stale values over what the parameters actually hold (#2315).
+    syncParametersToDevice();
     device_->flushState(state);
     te::Plugin::flushPluginStateToValueTree();
 }
@@ -328,10 +333,18 @@ void TracktionMagdaDevicePlugin::restorePluginStateFromValueTree(
     // edit and every settings edit snapped Rate, Swing and Gate back to their
     // defaults mid-play (#2335). A slot the state says nothing about keeps
     // what the model last wrote.
-    for (auto& parameterValue : parameterValues_) {
-        if (const auto* property =
-                restoredState.getPropertyPointer(parameterValue->getPropertyID()))
-            *parameterValue = static_cast<float>(*property);
+    for (std::size_t index = 0; index < parameterValues_.size(); ++index) {
+        auto& parameterValue = parameterValues_[index];
+        const auto* property = restoredState.getPropertyPointer(parameterValue->getPropertyID());
+        if (property == nullptr)
+            continue;
+
+        *parameterValue = static_cast<float>(*property);
+        // The parameter caches its value and does not watch the CachedValue, so
+        // without this the restore reached the tree and nothing else -- and the
+        // next syncParametersToDevice() pushed the stale one back (#2315).
+        if (auto& parameter = parameters_[index])
+            parameter->updateFromAttachedValue();
     }
     syncParametersToDevice();
     device_->restoreState(restoredState);
@@ -383,6 +396,18 @@ void TracktionMagdaDevicePlugin::buildParameters() {
     }
 
     syncParametersToDevice();
+}
+
+void TracktionMagdaDevicePlugin::pullParametersFromDevice() {
+    for (int index = 0; index < static_cast<int>(parameters_.size()); ++index) {
+        auto& parameter = parameters_[static_cast<std::size_t>(index)];
+        if (parameter == nullptr)
+            continue;
+
+        const auto value = device_->parameterValue(index);
+        if (parameter->getCurrentValue() != value)
+            parameter->setParameterFromHost(value, juce::sendNotificationSync);
+    }
 }
 
 void TracktionMagdaDevicePlugin::syncParametersToDevice() {

--- a/magda/daw/audio/plugins/tracktion/TracktionMagdaDevicePlugin.hpp
+++ b/magda/daw/audio/plugins/tracktion/TracktionMagdaDevicePlugin.hpp
@@ -25,6 +25,15 @@ class TracktionMagdaDevicePlugin final : public te::Plugin {
     }
     te::AutomatableParameter* parameterForDeviceSlot(int slotIndex) const;
 
+    /// Take the device's own parameter values back into the host's.
+    ///
+    /// The host is the authority every other block -- syncParametersToDevice()
+    /// pushes on every applyToBuffer -- so a device that changes its own values
+    /// has them overwritten unless something pulls. A runtime Faust patch swap
+    /// is the case: rebinding the pool assigns new defaults to slots whose
+    /// control changed identity. Message thread only.
+    void pullParametersFromDevice();
+
     juce::String getName() const override;
     juce::String getPluginType() override;
     juce::String getShortName(int) override;

--- a/magda/daw/audio/processors/internal/NativeDeviceProcessors.cpp
+++ b/magda/daw/audio/processors/internal/NativeDeviceProcessors.cpp
@@ -207,14 +207,18 @@ FaustInstrumentProcessor::FaustInstrumentProcessor(DeviceId deviceId, te::Plugin
     : DeviceProcessor(deviceId, std::move(plugin)) {}
 
 int FaustInstrumentProcessor::getParameterCount() const {
-    auto* faust = dynamic_cast<daw::audio::FaustInstrumentPlugin*>(plugin_.get());
+    auto* faust =
+        daw::audio::tracktion_adapter::deviceFromPlugin<daw::audio::FaustInstrumentPlugin>(
+            plugin_.get());
     if (faust == nullptr)
         return 0;
     return faust->getPool().activeCount();
 }
 
 ParameterInfo FaustInstrumentProcessor::getParameterInfo(int index) const {
-    auto* faust = dynamic_cast<daw::audio::FaustInstrumentPlugin*>(plugin_.get());
+    auto* faust =
+        daw::audio::tracktion_adapter::deviceFromPlugin<daw::audio::FaustInstrumentPlugin>(
+            plugin_.get());
     if (faust == nullptr || index < 0)
         return {};
     // Voice Mode and Glide sit past the pool: they belong to the host, not to
@@ -230,7 +234,9 @@ ParameterInfo FaustInstrumentProcessor::getParameterInfo(int index) const {
 
 void FaustInstrumentProcessor::populateParametersFromEngine(DeviceInfo& info) const {
     info.parameters.clear();
-    auto* faust = dynamic_cast<daw::audio::FaustInstrumentPlugin*>(plugin_.get());
+    auto* faust =
+        daw::audio::tracktion_adapter::deviceFromPlugin<daw::audio::FaustInstrumentPlugin>(
+            plugin_.get());
     if (faust == nullptr)
         return;
     // Only push active, non-hidden slots; each ParameterInfo carries its real

--- a/magda/daw/ui/components/chain/slot/DeviceSlotInlineUiFactory.cpp
+++ b/magda/daw/ui/components/chain/slot/DeviceSlotInlineUiFactory.cpp
@@ -5,6 +5,7 @@
 #include "audio/plugins/FaustParamPool.hpp"
 #include "audio/plugins/FaustPlugin.hpp"
 #include "audio/plugins/IFaustEditorModel.hpp"
+#include "audio/plugins/tracktion/TracktionMagdaDevicePlugin.hpp"
 #include "compiled/CompiledPluginPresentation.hpp"
 #include "core/ControlTarget.hpp"
 #include "core/LinkModeManager.hpp"
@@ -175,7 +176,9 @@ DeviceSlotInlineUiKind createDeviceSlotInlineUi(const magda::DeviceInfo& device,
         storage.faustUI = std::make_unique<FaustUI>();
 
         if (auto plugin = resolveLivePlugin(nodePath, callbacks)) {
-            if (auto* faustModel = dynamic_cast<daw::audio::IFaustEditorModel*>(plugin.get())) {
+            if (auto* faustModel =
+                    daw::audio::tracktion_adapter::deviceFromPlugin<daw::audio::IFaustEditorModel>(
+                        plugin.get())) {
                 storage.faustUI->setPlugin(faustModel);
                 storage.faustCustomView = FaustCustomUIRegistry::getInstance().create(
                     faustModel->getCustomViewName(), *faustModel);
@@ -214,7 +217,9 @@ void bindDeviceSlotFaustInlineUi(
     faustUI->setDevicePath(nodePath);
 
     if (auto plugin = getLivePlugin(nodePath)) {
-        if (auto* faustModel = dynamic_cast<daw::audio::IFaustEditorModel*>(plugin.get())) {
+        if (auto* faustModel =
+                daw::audio::tracktion_adapter::deviceFromPlugin<daw::audio::IFaustEditorModel>(
+                    plugin.get())) {
             faustUI->setPlugin(faustModel);
             if (setMeterSource) {
                 setMeterSource([plugin, faustModel](int meterIndex) {

--- a/tests/DawProjectRoundTrip.cpp
+++ b/tests/DawProjectRoundTrip.cpp
@@ -593,6 +593,7 @@ const std::map<std::string, std::vector<Loss>>& lossTable() {
         {"plugin.sidechain", {deviceSidechain()}},
         {"plugin.instrument.midiout", {deviceMidiPorts()}},
         {"plugin.instrument.midiout.thru", {deviceMidiPorts()}},
+        {"plugin.faust.instrument", {internalDevices()}},
         {"multiout.pair", {internalDevices(), multiOutRouting()}},
         {"project.mixed", {internalDevices()}},
         {"midi.notes", {internalDevices()}},

--- a/tests/NullDiffCase.hpp
+++ b/tests/NullDiffCase.hpp
@@ -207,6 +207,24 @@ struct Case {
     /// it the corpus says so rather than absorbing it.
     double incumbentNoteEndEarlySeconds = 0.0001;
 
+    /// Whether this case's AUDIO changes at a note's end, and not only at its
+    /// start.
+    ///
+    /// Almost none do. A corpus instrument answers a note-on with an impulse
+    /// and ignores the off (NullDiffHostedPlugin's voice), so the nudge above
+    /// -- which the fork applies to every note-off there has ever been -- shows
+    /// up in the MIDI comparison, where it is declared and absorbed, and nowhere
+    /// in the audio. A sustaining instrument is the case that hears it: the two
+    /// legs hold the note for a different four samples, and the residual is the
+    /// whole note.
+    ///
+    /// Set here rather than detected, because the harness cannot tell a synth
+    /// that sustains from one that does not, and guessing wrong in the
+    /// permissive direction would quietly stop comparing note ends everywhere.
+    /// A case that sets it takes the fork's four samples out of its own audio
+    /// comparison by naming them, and is held to bit identity everywhere else.
+    bool audioChangesAtNoteEnds = false;
+
     /// The largest step this case's material may take from one sample to the
     /// next, for a case in the Invariants tier. Required there and refused
     /// without, because the tier has no residual to fall back on: a bound

--- a/tests/NullDiffCase.hpp
+++ b/tests/NullDiffCase.hpp
@@ -207,22 +207,9 @@ struct Case {
     /// it the corpus says so rather than absorbing it.
     double incumbentNoteEndEarlySeconds = 0.0001;
 
-    /// Whether this case's AUDIO changes at a note's end, and not only at its
-    /// start.
-    ///
-    /// Almost none do. A corpus instrument answers a note-on with an impulse
-    /// and ignores the off (NullDiffHostedPlugin's voice), so the nudge above
-    /// -- which the fork applies to every note-off there has ever been -- shows
-    /// up in the MIDI comparison, where it is declared and absorbed, and nowhere
-    /// in the audio. A sustaining instrument is the case that hears it: the two
-    /// legs hold the note for a different four samples, and the residual is the
-    /// whole note.
-    ///
-    /// Set here rather than detected, because the harness cannot tell a synth
-    /// that sustains from one that does not, and guessing wrong in the
-    /// permissive direction would quietly stop comparing note ends everywhere.
-    /// A case that sets it takes the fork's four samples out of its own audio
-    /// comparison by naming them, and is held to bit identity everywhere else.
+    /// Whether this case's audio changes when a note ENDS, not only when it
+    /// starts. Set by hand: the harness cannot tell a synth that sustains from
+    /// one that does not, and the nudge above is only audible to the first.
     bool audioChangesAtNoteEnds = false;
 
     /// The largest step this case's material may take from one sample to the

--- a/tests/NullDiffCompare.cpp
+++ b/tests/NullDiffCompare.cpp
@@ -686,11 +686,30 @@ AudioComparison compareAudio(const juce::AudioBuffer<float>& native,
     auto peak = 0.0;
     auto sumOfSquares = 0.0;
 
+    // Samples the corpus named and took out, counted once rather than per
+    // channel: what is skipped is an instant in the render, not a sample in a
+    // buffer. Ranges arrive sorted, so a cursor walks them alongside the index
+    // instead of searching for each one.
+    std::int64_t excludedSamples = 0;
+
     for (auto channel = 0; channel < native.getNumChannels(); ++channel) {
         const auto* a = native.getReadPointer(channel);
         const auto* b = incumbent.getReadPointer(channel);
 
+        std::size_t range = 0;
+
         for (auto index = begin; index < end; ++index) {
+            while (range < options.excludedRanges.size() &&
+                   options.excludedRanges[range].second <= index)
+                ++range;
+
+            if (range < options.excludedRanges.size() &&
+                index >= options.excludedRanges[range].first) {
+                if (channel == 0)
+                    ++excludedSamples;
+                continue;
+            }
+
             const auto left = static_cast<double>(a[index]);
             const auto right = static_cast<double>(b[index + shift]);
 
@@ -706,7 +725,7 @@ AudioComparison compareAudio(const juce::AudioBuffer<float>& native,
         }
     }
 
-    result.comparedSamples = end - begin;
+    result.comparedSamples = end - begin - excludedSamples;
     result.peakDb = toDb(peak);
 
     const auto count =

--- a/tests/NullDiffCompare.cpp
+++ b/tests/NullDiffCompare.cpp
@@ -686,10 +686,8 @@ AudioComparison compareAudio(const juce::AudioBuffer<float>& native,
     auto peak = 0.0;
     auto sumOfSquares = 0.0;
 
-    // Samples the corpus named and took out, counted once rather than per
-    // channel: what is skipped is an instant in the render, not a sample in a
-    // buffer. Ranges arrive sorted, so a cursor walks them alongside the index
-    // instead of searching for each one.
+    // Counted once rather than per channel: what is skipped is an instant, not
+    // a sample in a buffer. Ranges arrive sorted, so a cursor suffices.
     std::int64_t excludedSamples = 0;
 
     for (auto channel = 0; channel < native.getNumChannels(); ++channel) {

--- a/tests/NullDiffCompare.hpp
+++ b/tests/NullDiffCompare.hpp
@@ -5,6 +5,7 @@
 #include <cstdint>
 #include <limits>
 #include <string>
+#include <utility>
 #include <vector>
 
 /**
@@ -73,6 +74,18 @@ struct AudioCompareOptions {
     /// How far the search may look, in samples. A stretcher's priming is a
     /// window or two; anything beyond this is not priming.
     int maxShiftSamples = 8192;
+
+    /// Half-open sample ranges, in the native render's domain, that the
+    /// residual is not taken over. Sorted and non-overlapping.
+    ///
+    /// Not a tolerance and not a floor: the samples are named, they are counted
+    /// out of `comparedSamples`, and everything either side of them is still
+    /// held to bit identity. What earns a range is a fact about the incumbent
+    /// the corpus has already written down and can derive a position from --
+    /// today only the note-end nudge (Case::incumbentNoteEndEarlySeconds), which
+    /// the MIDI comparison has always honoured and this one could not see.
+    /// A range nobody can derive is an allowance, and belongs nowhere near here.
+    std::vector<std::pair<std::int64_t, std::int64_t>> excludedRanges;
 
     double sampleRate = 44100.0;
 };

--- a/tests/NullDiffCompare.hpp
+++ b/tests/NullDiffCompare.hpp
@@ -75,16 +75,10 @@ struct AudioCompareOptions {
     /// window or two; anything beyond this is not priming.
     int maxShiftSamples = 8192;
 
-    /// Half-open sample ranges, in the native render's domain, that the
-    /// residual is not taken over. Sorted and non-overlapping.
-    ///
-    /// Not a tolerance and not a floor: the samples are named, they are counted
-    /// out of `comparedSamples`, and everything either side of them is still
-    /// held to bit identity. What earns a range is a fact about the incumbent
-    /// the corpus has already written down and can derive a position from --
-    /// today only the note-end nudge (Case::incumbentNoteEndEarlySeconds), which
-    /// the MIDI comparison has always honoured and this one could not see.
-    /// A range nobody can derive is an allowance, and belongs nowhere near here.
+    /// Half-open sample ranges the residual is not taken over. Sorted, merged,
+    /// and counted out of `comparedSamples`. Only for samples a declared fact
+    /// about the incumbent can place: a range nobody can derive is an
+    /// allowance, not a shape. See NullDiffRunner's noteEndNudgeRanges.
     std::vector<std::pair<std::int64_t, std::int64_t>> excludedRanges;
 
     double sampleRate = 44100.0;

--- a/tests/NullDiffCorpus.cpp
+++ b/tests/NullDiffCorpus.cpp
@@ -10,8 +10,10 @@
 #include "NullDiffMaterial.hpp"
 #include "core/ChainWalk.hpp"
 #include "core/DeviceInfo.hpp"
+#include "core/DeviceState.hpp"
 #include "core/SourcePool.hpp"
 #include "core/TimeStretchModes.hpp"
+#include "magda/daw/audio/plugins/FaustInstrumentPlugin.hpp"
 #include "magda/daw/audio/plugins/engine/EngineDeviceFactory.hpp"
 
 /**
@@ -605,6 +607,55 @@ void expectsPrimingShift(Case& value) {
 }
 
 }  // namespace
+
+/// A runtime Faust instrument carrying @p source, as a project would save it.
+///
+/// The patch is spelled out here rather than left at the device's default
+/// because the default imports stdfaust.lib, and the target this corpus runs in
+/// has no faustlibraries directory beside it (#2238). A source that mentions
+/// the library in a comment skips the automatic import, which is the same trick
+/// the device's own tests use -- so the DSP is self-contained arithmetic and
+/// both legs compile exactly it.
+magda::DeviceInfo faustInstrumentDevice(magda::DeviceId id, const char* source) {
+    magda::DeviceInfo device;
+    device.id = id;
+    device.name = "Faust Instrument";
+    device.pluginId = magda::daw::audio::FaustInstrumentPlugin::xmlTypeName;
+    device.deviceType = magda::DeviceType::Instrument;
+    device.isInstrument = true;
+    device.canReceiveMidi = true;
+    device.format = magda::PluginFormat::Internal;
+    device.audioInputChannels = 0;
+    device.audioOutputChannels = 2;
+
+    // The source travels as saved device state, which is the path a project
+    // takes: the engine factory restores it before the adapter reads any
+    // parameter metadata, and the fork's wrapper restores the same document.
+    magda::device_state::Doc doc;
+    doc.deviceType = device.pluginId;
+    doc.root.props.set("dspName", "Null Diff Faust Synth");
+    doc.root.props.set("dspSource", source);
+    device.pluginState = magda::device_state::encode(doc);
+
+    return device;
+}
+
+/// A gated DC level per voice, scaled by the note. No oscillator and no
+/// envelope: what this case is about is the host's voice allocation - which
+/// note reached which voice, when it was gated on and when it was released -
+/// and a level that changes only on a gate edge shows exactly that, at the
+/// sample it happened. An oscillator would bury the same information under a
+/// waveform the two legs would then have to agree about phase on.
+constexpr const char* kNullDiffFaustSynthDsp = R"FAUST(
+// Self-contained: the literal "stdfaust.lib" here is load-bearing, since the
+// compiler only skips its automatic import when the source already names it.
+freq = hslider("freq", 440, 20, 20000, 0.01);
+gain = hslider("gain", 0.5, 0, 1, 0.01);
+gate = button("gate");
+
+voice = (freq / 20000.0) * gain * gate;
+process = voice <: _, _;
+)FAUST";
 
 std::vector<Case> buildCorpus(const juce::File& scratchDirectory) {
     scratchDirectory.createDirectory();
@@ -2421,6 +2472,53 @@ std::vector<Case> buildCorpus(const juce::File& scratchDirectory) {
         auto clip = midiClip(341, 0.0, 8.0);
         for (auto index = 0; index < 8; ++index)
             clip.midiNotes.push_back(note(60 + index, static_cast<double>(index), 0.5, 127));
+        value.clips.push_back(std::move(clip));
+
+        corpus.push_back(std::move(value));
+    }
+
+    {
+        // The runtime Faust instrument, on both legs (#2315). ~1300 lines of
+        // voice management around libfaust is exactly where a silent drift
+        // hides, and nothing else in the corpus reaches it: the compiled Faust
+        // devices are a different host and the hosted plugins are a different
+        // format.
+        //
+        // Chords rather than a line, so the poly allocator has to hold several
+        // voices at once and release the right one - the level at any sample is
+        // the sum of the notes gated on, and a leg that allocated, stole or
+        // released a voice differently reads off as a different level.
+        auto track = plainTrack();
+        track.chain.fxChainElements.emplace_back(
+            faustInstrumentDevice(983, kNullDiffFaustSynthDsp));
+
+        auto value = newCase("plugin.faust.instrument",
+                             "a runtime Faust instrument's voice allocation", std::move(track));
+        value.endBeat = 8.0;
+
+        // The first case in the corpus whose audio changes when a note ENDS.
+        // Every instrument here until now answered a note-on with an impulse
+        // and ignored the off, so the fork's note-end nudge lived entirely in
+        // the MIDI comparison. A sustaining synth hears it: the two legs
+        // release four samples apart, and those four samples are the whole
+        // note. See Case::audioChangesAtNoteEnds.
+        value.audioChangesAtNoteEnds = true;
+        value.mechanism =
+            "the fork ends every note 0.0001 s early (MidiNote::getPlaybackTime nudges the "
+            "note-off back to keep an off ahead of an on at the same instant); the engine orders "
+            "events when it compiles them and keeps the authored length. The four samples between "
+            "the two releases are named per note and taken out of the residual; every other "
+            "sample, note-ons included, is held to bit identity";
+
+        auto clip = midiClip(342, 0.0, 8.0);
+        for (auto index = 0; index < 4; ++index) {
+            const auto at = static_cast<double>(index) * 2.0;
+            // Overlapping releases: the third note is still sounding when the
+            // next chord starts, so voices are reused rather than always free.
+            clip.midiNotes.push_back(note(48 + index, at, 1.0, 100));
+            clip.midiNotes.push_back(note(55 + index, at, 1.0, 100));
+            clip.midiNotes.push_back(note(64 + index, at, 2.5, 100));
+        }
         value.clips.push_back(std::move(clip));
 
         corpus.push_back(std::move(value));

--- a/tests/NullDiffCorpus.cpp
+++ b/tests/NullDiffCorpus.cpp
@@ -609,13 +609,8 @@ void expectsPrimingShift(Case& value) {
 }  // namespace
 
 /// A runtime Faust instrument carrying @p source, as a project would save it.
-///
-/// The patch is spelled out here rather than left at the device's default
-/// because the default imports stdfaust.lib, and the target this corpus runs in
-/// has no faustlibraries directory beside it (#2238). A source that mentions
-/// the library in a comment skips the automatic import, which is the same trick
-/// the device's own tests use -- so the DSP is self-contained arithmetic and
-/// both legs compile exactly it.
+/// Spelled out rather than left at the device's default, which imports
+/// stdfaust.lib and cannot compile in this target (#2238).
 magda::DeviceInfo faustInstrumentDevice(magda::DeviceId id, const char* source) {
     magda::DeviceInfo device;
     device.id = id;
@@ -628,9 +623,7 @@ magda::DeviceInfo faustInstrumentDevice(magda::DeviceId id, const char* source) 
     device.audioInputChannels = 0;
     device.audioOutputChannels = 2;
 
-    // The source travels as saved device state, which is the path a project
-    // takes: the engine factory restores it before the adapter reads any
-    // parameter metadata, and the fork's wrapper restores the same document.
+    // As saved device state, which is the path a project takes on both legs.
     magda::device_state::Doc doc;
     doc.deviceType = device.pluginId;
     doc.root.props.set("dspName", "Null Diff Faust Synth");
@@ -640,12 +633,9 @@ magda::DeviceInfo faustInstrumentDevice(magda::DeviceId id, const char* source) 
     return device;
 }
 
-/// A gated DC level per voice, scaled by the note. No oscillator and no
-/// envelope: what this case is about is the host's voice allocation - which
-/// note reached which voice, when it was gated on and when it was released -
-/// and a level that changes only on a gate edge shows exactly that, at the
-/// sample it happened. An oscillator would bury the same information under a
-/// waveform the two legs would then have to agree about phase on.
+/// A gated DC level per voice. No oscillator and no envelope, so the output is
+/// a staircase and every change is a gate edge - which is what the case
+/// measures.
 constexpr const char* kNullDiffFaustSynthDsp = R"FAUST(
 // Self-contained: the literal "stdfaust.lib" here is load-bearing, since the
 // compiler only skips its automatic import when the source already names it.
@@ -2478,16 +2468,9 @@ std::vector<Case> buildCorpus(const juce::File& scratchDirectory) {
     }
 
     {
-        // The runtime Faust instrument, on both legs (#2315). ~1300 lines of
-        // voice management around libfaust is exactly where a silent drift
-        // hides, and nothing else in the corpus reaches it: the compiled Faust
-        // devices are a different host and the hosted plugins are a different
-        // format.
-        //
-        // Chords rather than a line, so the poly allocator has to hold several
-        // voices at once and release the right one - the level at any sample is
-        // the sum of the notes gated on, and a leg that allocated, stole or
-        // released a voice differently reads off as a different level.
+        // The runtime Faust instrument on both legs (#2315). Chords rather
+        // than a line, so the allocator holds several voices at once and has to
+        // release the right one.
         auto track = plainTrack();
         track.chain.fxChainElements.emplace_back(
             faustInstrumentDevice(983, kNullDiffFaustSynthDsp));
@@ -2496,19 +2479,13 @@ std::vector<Case> buildCorpus(const juce::File& scratchDirectory) {
                              "a runtime Faust instrument's voice allocation", std::move(track));
         value.endBeat = 8.0;
 
-        // The first case in the corpus whose audio changes when a note ENDS.
-        // Every instrument here until now answered a note-on with an impulse
-        // and ignored the off, so the fork's note-end nudge lived entirely in
-        // the MIDI comparison. A sustaining synth hears it: the two legs
-        // release four samples apart, and those four samples are the whole
-        // note. See Case::audioChangesAtNoteEnds.
+        // The corpus's first sustaining synth, so the first case that can hear
+        // the fork's note-end nudge at all.
         value.audioChangesAtNoteEnds = true;
         value.mechanism =
-            "the fork ends every note 0.0001 s early (MidiNote::getPlaybackTime nudges the "
-            "note-off back to keep an off ahead of an on at the same instant); the engine orders "
-            "events when it compiles them and keeps the authored length. The four samples between "
-            "the two releases are named per note and taken out of the residual; every other "
-            "sample, note-ons included, is held to bit identity";
+            "the fork ends every note 0.0001 s early (MidiNote::getPlaybackTime) and the engine "
+            "keeps the authored length; the four samples between the two releases are named per "
+            "note and taken out of the residual, everything else held to bit identity";
 
         auto clip = midiClip(342, 0.0, 8.0);
         for (auto index = 0; index < 4; ++index) {

--- a/tests/NullDiffRunner.cpp
+++ b/tests/NullDiffRunner.cpp
@@ -302,22 +302,13 @@ bool judgeStretched(const Case& value, const NativeRender& native, const Incumbe
 }
 
 /**
- * @brief The samples the fork's note-end nudge makes unanswerable, or none.
+ * @brief [end - nudge, end) per note: where one leg has released and the other
+ *        has not.
  *
- * MidiNote::getPlaybackTime ends every note 0.0001 s early "to make sure the
- * ordering is correct" (tracktion_MidiList.cpp:829). The engine orders its
- * events when it compiles them and keeps the length the note was drawn at, so
- * the two legs release a note four samples apart at 44.1 kHz. The corpus has
- * always known the figure -- Case::incumbentNoteEndEarlySeconds -- and the MIDI
- * comparison has always subtracted it. The audio comparison could not: until a
- * case rendered an instrument that sustains, no audio depended on when a note
- * ended, and the difference had nowhere to show.
- *
+ * MidiNote::getPlaybackTime ends every note 0.0001 s early to keep an off ahead
+ * of an on (tracktion_MidiList.cpp:829); the engine keeps the authored length.
  * Derived from the authored notes rather than found in the residual, which is
- * the whole difference between naming a known window and widening a tolerance
- * until a case passes. Each range is [end - nudge, end): the samples where one
- * leg has released and the other has not. Every other sample of the case,
- * note-ons included, is still held to bit identity.
+ * what makes it a named window and not a tolerance.
  */
 std::vector<std::pair<std::int64_t, std::int64_t>> noteEndNudgeRanges(const Case& value) {
     if (!value.audioChangesAtNoteEnds)

--- a/tests/NullDiffRunner.cpp
+++ b/tests/NullDiffRunner.cpp
@@ -6,9 +6,11 @@
 #include <algorithm>
 #include <chrono>
 #include <cmath>
+#include <cstdint>
 #include <map>
 #include <memory>
 #include <set>
+#include <utility>
 
 #include "AssertionWatch.hpp"
 #include "NullDiffHostedPlugin.hpp"
@@ -299,6 +301,61 @@ bool judgeStretched(const Case& value, const NativeRender& native, const Incumbe
     return held;
 }
 
+/**
+ * @brief The samples the fork's note-end nudge makes unanswerable, or none.
+ *
+ * MidiNote::getPlaybackTime ends every note 0.0001 s early "to make sure the
+ * ordering is correct" (tracktion_MidiList.cpp:829). The engine orders its
+ * events when it compiles them and keeps the length the note was drawn at, so
+ * the two legs release a note four samples apart at 44.1 kHz. The corpus has
+ * always known the figure -- Case::incumbentNoteEndEarlySeconds -- and the MIDI
+ * comparison has always subtracted it. The audio comparison could not: until a
+ * case rendered an instrument that sustains, no audio depended on when a note
+ * ended, and the difference had nowhere to show.
+ *
+ * Derived from the authored notes rather than found in the residual, which is
+ * the whole difference between naming a known window and widening a tolerance
+ * until a case passes. Each range is [end - nudge, end): the samples where one
+ * leg has released and the other has not. Every other sample of the case,
+ * note-ons included, is still held to bit identity.
+ */
+std::vector<std::pair<std::int64_t, std::int64_t>> noteEndNudgeRanges(const Case& value) {
+    if (!value.audioChangesAtNoteEnds)
+        return {};
+
+    const auto nudge = static_cast<std::int64_t>(
+        std::llround(value.incumbentNoteEndEarlySeconds * value.sampleRate));
+    if (nudge <= 0)
+        return {};
+
+    const auto samplesPerBeat = 60.0 / value.startBpm() * value.sampleRate;
+
+    std::vector<std::pair<std::int64_t, std::int64_t>> ranges;
+    for (const auto& clip : value.clips) {
+        for (const auto& note : clip.midiNotes) {
+            // A note is authored inside its clip and a clip cuts it off, which
+            // is where the fork takes its own minimum too.
+            const auto endBeat =
+                std::min(clip.placement.startBeat + note.startBeat + note.lengthBeats,
+                         clip.placement.endBeat());
+            const auto end = static_cast<std::int64_t>(std::llround(endBeat * samplesPerBeat));
+            ranges.emplace_back(std::max<std::int64_t>(0, end - nudge), end);
+        }
+    }
+
+    // Sorted and merged: the residual loop walks them with a cursor, and two
+    // notes released together would otherwise have it skip only the first.
+    std::sort(ranges.begin(), ranges.end());
+    std::vector<std::pair<std::int64_t, std::int64_t>> merged;
+    for (const auto& range : ranges) {
+        if (!merged.empty() && range.first <= merged.back().second)
+            merged.back().second = std::max(merged.back().second, range.second);
+        else
+            merged.push_back(range);
+    }
+    return merged;
+}
+
 }  // namespace
 
 juce::File nullDiffScratchDirectory() {
@@ -582,6 +639,7 @@ CaseReport runCase(const Case& value, const RunnerLog& log) {
     options.sampleRate = value.sampleRate;
     options.measureShift = value.tier == AudioTier::Spectral;
     options.maxShiftSamples = value.maxShiftSamples;
+    options.excludedRanges = noteEndNudgeRanges(value);
 
     report.hasAudio = true;
     report.audio = compareAudio(aligned, incumbent.audio, options);

--- a/tests/dsp/test_faust_instrument_tempo_juce.cpp
+++ b/tests/dsp/test_faust_instrument_tempo_juce.cpp
@@ -3,6 +3,7 @@
 
 #include "SharedTestEngine.hpp"
 #include "magda/daw/audio/plugins/FaustInstrumentPlugin.hpp"
+#include "magda/daw/audio/plugins/tracktion/TracktionMagdaDevicePlugin.hpp"
 #include "third_party/tracktion_engine/modules/tracktion_engine/utilities/tracktion_TestUtilities.h"
 
 namespace {
@@ -29,8 +30,7 @@ te::Plugin::Ptr createFaustInstrument(te::Edit& edit) {
     return edit.getPluginCache().createNewPlugin(state);
 }
 
-float renderBlock(audio::FaustInstrumentPlugin& instrument, double startSeconds,
-                  te::MidiMessageArray& midi) {
+float renderBlock(te::Plugin& plugin, double startSeconds, te::MidiMessageArray& midi) {
     constexpr int kBlockSize = 64;
     juce::AudioBuffer<float> buffer(2, kBlockSize);
     buffer.clear();
@@ -41,7 +41,7 @@ float renderBlock(audio::FaustInstrumentPlugin& instrument, double startSeconds,
             tracktion::TimePosition::fromSeconds(startSeconds),
             tracktion::TimePosition::fromSeconds(startSeconds + kBlockSize / 44100.0)),
         true, false, false, false);
-    instrument.applyToBuffer(context);
+    plugin.applyToBuffer(context);
     return buffer.getSample(0, kBlockSize - 1);
 }
 
@@ -59,7 +59,10 @@ class FaustInstrumentTempoTest final : public juce::UnitTest {
             return;
 
         auto plugin = createFaustInstrument(*edit);
-        auto* instrument = dynamic_cast<audio::FaustInstrumentPlugin*>(plugin.get());
+        // The device inside the host wrapper (#2315): a MagdaDevice is what a
+        // Faust instrument is now, and the wrapper is what the fork holds.
+        auto* instrument =
+            audio::tracktion_adapter::deviceFromPlugin<audio::FaustInstrumentPlugin>(plugin.get());
         expect(instrument != nullptr, "Runtime Faust instrument should be created");
         if (!instrument)
             return;
@@ -74,7 +77,7 @@ class FaustInstrumentTempoTest final : public juce::UnitTest {
         initInfo.startTime = tracktion::TimePosition();
         initInfo.sampleRate = 44100.0;
         initInfo.blockSizeSamples = 64;
-        instrument->baseClassInitialise(initInfo);
+        plugin->baseClassInitialise(initInfo);
 
         auto* firstTempo = edit->tempoSequence.getTempo(0);
         expect(firstTempo != nullptr, "Test edit should have an initial tempo");
@@ -87,11 +90,11 @@ class FaustInstrumentTempoTest final : public juce::UnitTest {
                                te::MPESourceID{});
         noteOns.addMidiMessage(juce::MidiMessage::noteOn(1, 67, static_cast<juce::uint8>(127)), 0.0,
                                te::MPESourceID{});
-        const float at90Bpm = renderBlock(*instrument, 0.0, noteOns);
+        const float at90Bpm = renderBlock(*plugin, 0.0, noteOns);
 
         firstTempo->setBpm(180.0);
         te::MidiMessageArray noMidi;
-        const float at180Bpm = renderBlock(*instrument, 1.0, noMidi);
+        const float at180Bpm = renderBlock(*plugin, 1.0, noMidi);
 
         expectWithinAbsoluteError(at90Bpm, 0.6f, 0.0001f,
                                   "Two voices should each render (90 / 300) at full velocity");

--- a/tests/dsp/test_faust_instrument_voice_modes_juce.cpp
+++ b/tests/dsp/test_faust_instrument_voice_modes_juce.cpp
@@ -1,7 +1,9 @@
 #include <juce_core/juce_core.h>
 #include <tracktion_engine/tracktion_engine.h>
 
+#include <array>
 #include <cmath>
+#include <utility>
 
 #include "SharedTestEngine.hpp"
 #include "magda/daw/audio/plugins/FaustInstrumentPlugin.hpp"
@@ -397,7 +399,85 @@ class FaustInstrumentSampleRateTest final : public juce::UnitTest {
     }
 };
 
+// The host's three parameters persist under the retired plugin's own property
+// names. Without a stableId the wrapper keys them on "<pluginId>_param_<n>",
+// which neither reads what flushState writes nor matches a project saved before
+// the port -- and syncParametersToDevice() then pushes the default back over
+// whatever restoreState() recovered (#2315).
+class FaustInstrumentHostParamStateTest final : public juce::UnitTest {
+  public:
+    FaustInstrumentHostParamStateTest()
+        : juce::UnitTest("Faust Instrument Host Parameter State Tests", "magda") {}
+
+    void runTest() override {
+        beginTest("Voice Mode, Glide and Bend Range persist under their released names");
+
+        auto& wrapper = magda::test::getSharedEngine();
+        auto edit = te::test_utilities::createTestEdit(*wrapper.getEngine(), 1);
+        expect(edit != nullptr, "Test edit should be created");
+        if (!edit)
+            return;
+
+        auto plugin = createFaustInstrument(*edit);
+        auto* instrument =
+            audio::tracktion_adapter::deviceFromPlugin<audio::FaustInstrumentPlugin>(plugin.get());
+        expect(instrument != nullptr, "Faust instrument should be created");
+        if (instrument == nullptr)
+            return;
+
+        const std::array<std::pair<const char*, int>, 3> hostParams{
+            {{"voiceMode", audio::FaustInstrumentPlugin::kVoiceModeParamIndex},
+             {"glide", audio::FaustInstrumentPlugin::kGlideParamIndex},
+             {"bendRange", audio::FaustInstrumentPlugin::kBendRangeParamIndex}}};
+
+        auto params = plugin->getAutomatableParameters();
+        for (const auto& [name, index] : hostParams) {
+            expect(index < params.size() && params[index] != nullptr,
+                   juce::String(name) + " must have a host parameter");
+            if (index >= params.size() || params[index] == nullptr)
+                return;
+            expectEquals(params[index]->paramID, juce::String(name),
+                         "The host parameter must carry the released id, not a generated one");
+        }
+
+        // A value the defaults cannot produce, so what comes back could only
+        // have been restored.
+        for (const auto& [name, index] : hostParams) {
+            juce::ignoreUnused(name);
+            params[index]->setParameterFromHost(0.375f, juce::sendNotificationSync);
+        }
+
+        plugin->flushPluginStateToValueTree();
+        for (const auto& [name, index] : hostParams) {
+            juce::ignoreUnused(index);
+            expect(plugin->state.hasProperty(juce::Identifier(name)),
+                   juce::String("The saved state must name ") + name);
+        }
+
+        auto reloaded = createFaustInstrument(*edit);
+        auto* restored = audio::tracktion_adapter::deviceFromPlugin<audio::FaustInstrumentPlugin>(
+            reloaded.get());
+        expect(restored != nullptr, "The reloaded instrument should be created");
+        if (restored == nullptr)
+            return;
+
+        reloaded->restorePluginStateFromValueTree(plugin->state);
+
+        // Read through the wrapper, which is what the audio thread is pushed
+        // from: a device that restored correctly but a host that did not is the
+        // failure this is here for.
+        auto reloadedParams = reloaded->getAutomatableParameters();
+        for (const auto& [name, index] : hostParams) {
+            expectWithinAbsoluteError(reloadedParams[index]->getCurrentValue(), 0.375f, 1.0e-6f,
+                                      juce::String(name) + " must survive a save and reload");
+            expectWithinAbsoluteError(restored->parameterValue(index), 0.375f, 1.0e-6f,
+                                      juce::String(name) + " must reach the device too");
+        }
+    }
+};
+
 FaustInstrumentVoiceModeTest faustInstrumentVoiceModeTest;
 FaustInstrumentSampleRateTest faustInstrumentSampleRateTest;
+FaustInstrumentHostParamStateTest faustInstrumentHostParamStateTest;
 
 }  // namespace

--- a/tests/dsp/test_faust_instrument_voice_modes_juce.cpp
+++ b/tests/dsp/test_faust_instrument_voice_modes_juce.cpp
@@ -5,6 +5,7 @@
 
 #include "SharedTestEngine.hpp"
 #include "magda/daw/audio/plugins/FaustInstrumentPlugin.hpp"
+#include "magda/daw/audio/plugins/tracktion/TracktionMagdaDevicePlugin.hpp"
 #include "third_party/tracktion_engine/modules/tracktion_engine/utilities/tracktion_TestUtilities.h"
 
 namespace {
@@ -43,8 +44,8 @@ te::Plugin::Ptr createFaustInstrument(te::Edit& edit) {
     return edit.getPluginCache().createNewPlugin(state);
 }
 
-void setHostParam(audio::FaustInstrumentPlugin& instrument, int paramIndex, float normalised) {
-    auto params = instrument.getAutomatableParameters();
+void setHostParam(te::Plugin& plugin, int paramIndex, float normalised) {
+    auto params = plugin.getAutomatableParameters();
     if (paramIndex < params.size() && params[paramIndex])
         params[paramIndex]->setParameterFromHost(normalised, juce::sendNotificationSync);
 }
@@ -52,8 +53,7 @@ void setHostParam(audio::FaustInstrumentPlugin& instrument, int paramIndex, floa
 // Renders one block and returns its final sample. Taking the last sample rather
 // than the first matters for the glide tests: the ramp advances across the
 // block, so the end is where movement has actually happened.
-float renderBlock(audio::FaustInstrumentPlugin& instrument, double startSeconds,
-                  te::MidiMessageArray& midi) {
+float renderBlock(te::Plugin& plugin, double startSeconds, te::MidiMessageArray& midi) {
     juce::AudioBuffer<float> buffer(2, kBlockSize);
     buffer.clear();
 
@@ -63,7 +63,7 @@ float renderBlock(audio::FaustInstrumentPlugin& instrument, double startSeconds,
             tracktion::TimePosition::fromSeconds(startSeconds),
             tracktion::TimePosition::fromSeconds(startSeconds + kBlockSize / kSampleRate)),
         true, false, false, false);
-    instrument.applyToBuffer(context);
+    plugin.applyToBuffer(context);
     return buffer.getSample(0, kBlockSize - 1);
 }
 
@@ -112,7 +112,9 @@ class FaustInstrumentVoiceModeTest final : public juce::UnitTest {
             return;
 
         auto plugin = createFaustInstrument(*edit);
-        auto* instrument = dynamic_cast<audio::FaustInstrumentPlugin*>(plugin.get());
+        // The device inside the host wrapper (#2315).
+        auto* instrument =
+            audio::tracktion_adapter::deviceFromPlugin<audio::FaustInstrumentPlugin>(plugin.get());
         expect(instrument != nullptr, "Faust instrument should be created");
         if (instrument == nullptr)
             return;
@@ -125,13 +127,13 @@ class FaustInstrumentVoiceModeTest final : public juce::UnitTest {
         initInfo.startTime = tracktion::TimePosition();
         initInfo.sampleRate = kSampleRate;
         initInfo.blockSizeSamples = kBlockSize;
-        instrument->baseClassInitialise(initInfo);
+        plugin->baseClassInitialise(initInfo);
 
         const int voiceModeIdx = audio::FaustInstrumentPlugin::kVoiceModeParamIndex;
         const int glideIdx = audio::FaustInstrumentPlugin::kGlideParamIndex;
 
         {
-            auto params = instrument->getAutomatableParameters();
+            auto params = plugin->getAutomatableParameters();
             expect(params.size() > audio::FaustInstrumentPlugin::kBendRangeParamIndex,
                    "Instrument should expose three parameters beyond the 64-slot pool");
         }
@@ -140,25 +142,25 @@ class FaustInstrumentVoiceModeTest final : public juce::UnitTest {
         {
             // Poly is the default. Two held notes should sound together, so the
             // level is the sum of both - the point of the mode.
-            setHostParam(*instrument, voiceModeIdx, 0.0f);
-            setHostParam(*instrument, glideIdx, 0.0f);
+            setHostParam(*plugin, voiceModeIdx, 0.0f);
+            setHostParam(*plugin, glideIdx, 0.0f);
             instrument->reset();
 
             auto first = noteOn(60);
-            renderBlock(*instrument, 0.0, first);
+            renderBlock(*plugin, 0.0, first);
             auto second = noteOn(72);
-            const float polyLevel = renderBlock(*instrument, 0.1, second);
+            const float polyLevel = renderBlock(*plugin, 0.1, second);
 
             const float bothNotes = expectedLevelForNote(60) + expectedLevelForNote(72);
             expectWithinAbsoluteError(polyLevel, bothNotes, 0.002f);
 
             // Mono: the same two notes leave only the newest sounding.
-            setHostParam(*instrument, voiceModeIdx, 0.5f);  // 0.5 * 2 == Mono
+            setHostParam(*plugin, voiceModeIdx, 0.5f);  // 0.5 * 2 == Mono
             instrument->reset();
             auto monoFirst = noteOn(60);
-            renderBlock(*instrument, 0.2, monoFirst);
+            renderBlock(*plugin, 0.2, monoFirst);
             auto monoSecond = noteOn(72);
-            const float monoLevel = renderBlock(*instrument, 0.3, monoSecond);
+            const float monoLevel = renderBlock(*plugin, 0.3, monoSecond);
 
             expectWithinAbsoluteError(monoLevel, expectedLevelForNote(72), 0.002f);
             expect(monoLevel < bothNotes * 0.75f, "Mono should not stack the two notes");
@@ -166,43 +168,43 @@ class FaustInstrumentVoiceModeTest final : public juce::UnitTest {
 
         beginTest("Releasing a Mono note falls back to the one still held");
         {
-            setHostParam(*instrument, voiceModeIdx, 0.5f);
-            setHostParam(*instrument, glideIdx, 0.0f);
+            setHostParam(*plugin, voiceModeIdx, 0.5f);
+            setHostParam(*plugin, glideIdx, 0.0f);
             instrument->reset();
 
             auto low = noteOn(60);
-            renderBlock(*instrument, 0.4, low);
+            renderBlock(*plugin, 0.4, low);
             auto high = noteOn(72);
-            renderBlock(*instrument, 0.5, high);
+            renderBlock(*plugin, 0.5, high);
 
             // Letting the top note go should return to the note underneath it,
             // not cut off - that fallback is what makes legato lines work.
             auto releaseHigh = noteOff(72);
-            const float afterRelease = renderBlock(*instrument, 0.6, releaseHigh);
+            const float afterRelease = renderBlock(*plugin, 0.6, releaseHigh);
             expectWithinAbsoluteError(afterRelease, expectedLevelForNote(60), 0.002f);
         }
 
         beginTest("Glide ramps between notes instead of jumping");
         {
-            setHostParam(*instrument, voiceModeIdx, 0.5f);
+            setHostParam(*plugin, voiceModeIdx, 0.5f);
             instrument->reset();
 
             // 0 ms: the second note lands immediately.
-            setHostParam(*instrument, glideIdx, 0.0f);
+            setHostParam(*plugin, glideIdx, 0.0f);
             auto from = noteOn(60);
-            renderBlock(*instrument, 0.7, from);
+            renderBlock(*plugin, 0.7, from);
             auto to = noteOn(72);
-            const float instant = renderBlock(*instrument, 0.8, to);
+            const float instant = renderBlock(*plugin, 0.8, to);
             expectWithinAbsoluteError(instant, expectedLevelForNote(72), 0.002f);
 
             // 500 ms against a 64-sample block (~1.5 ms): one block in, the
             // pitch must have left the old note without arriving at the new one.
-            setHostParam(*instrument, glideIdx, 0.25f);  // 0.25 * 2000 ms
+            setHostParam(*plugin, glideIdx, 0.25f);  // 0.25 * 2000 ms
             instrument->reset();
             auto glideFrom = noteOn(60);
-            renderBlock(*instrument, 0.9, glideFrom);
+            renderBlock(*plugin, 0.9, glideFrom);
             auto glideTo = noteOn(72);
-            const float mid = renderBlock(*instrument, 1.0, glideTo);
+            const float mid = renderBlock(*plugin, 1.0, glideTo);
 
             const float lowLevel = expectedLevelForNote(60);
             const float highLevel = expectedLevelForNote(72);
@@ -216,17 +218,17 @@ class FaustInstrumentVoiceModeTest final : public juce::UnitTest {
             // A note held in Mono has no note-off delivered when the mode
             // changes, so without a flush it would sound forever underneath the
             // poly engine with nothing able to release it.
-            setHostParam(*instrument, voiceModeIdx, 0.5f);
-            setHostParam(*instrument, glideIdx, 0.0f);
+            setHostParam(*plugin, voiceModeIdx, 0.5f);
+            setHostParam(*plugin, glideIdx, 0.0f);
             instrument->reset();
 
             auto held = noteOn(60);
-            const float sounding = renderBlock(*instrument, 1.1, held);
+            const float sounding = renderBlock(*plugin, 1.1, held);
             expect(sounding > 0.001f, "Mono note should be sounding before the switch");
 
-            setHostParam(*instrument, voiceModeIdx, 0.0f);  // back to Poly
+            setHostParam(*plugin, voiceModeIdx, 0.0f);  // back to Poly
             te::MidiMessageArray none;
-            const float afterSwitch = renderBlock(*instrument, 1.2, none);
+            const float afterSwitch = renderBlock(*plugin, 1.2, none);
             expectWithinAbsoluteError(afterSwitch, 0.0f, 0.001f);
         }
 
@@ -239,55 +241,55 @@ class FaustInstrumentVoiceModeTest final : public juce::UnitTest {
             // in an empty midi::pitchWheel) instead of driving freq directly.
 
             // --- Poly: wheel up on a sounding note -------------------------
-            setHostParam(*instrument, voiceModeIdx, 0.0f);
-            setHostParam(*instrument, glideIdx, 0.0f);
-            setHostParam(*instrument, bendIdx, 2.0f / kMax);
+            setHostParam(*plugin, voiceModeIdx, 0.0f);
+            setHostParam(*plugin, glideIdx, 0.0f);
+            setHostParam(*plugin, bendIdx, 2.0f / kMax);
             instrument->reset();
 
             auto held = noteOn(69);
-            const float unbent = renderBlock(*instrument, 1.3, held);
+            const float unbent = renderBlock(*plugin, 1.3, held);
             expectWithinAbsoluteError(unbent, expectedLevelForNote(69), 0.002f);
 
             auto up = pitchWheel(1.0f);
-            const float bentUp = renderBlock(*instrument, 1.4, up);
+            const float bentUp = renderBlock(*plugin, 1.4, up);
             expectWithinAbsoluteError(bentUp, expectedLevelForBentNote(69, 2.0f), 0.002f);
 
             // --- and back down through centre ------------------------------
             auto down = pitchWheel(-1.0f);
-            const float bentDown = renderBlock(*instrument, 1.5, down);
+            const float bentDown = renderBlock(*plugin, 1.5, down);
             expectWithinAbsoluteError(bentDown, expectedLevelForBentNote(69, -2.0f), 0.002f);
 
             // --- A note started while the wheel is held is bent too --------
             // keyOn writes an unbent freq, so this covers the re-apply that
             // has to follow it rather than the wheel handler alone.
             auto release = noteOff(69);
-            renderBlock(*instrument, 1.6, release);
+            renderBlock(*plugin, 1.6, release);
             auto late = noteOn(69);
-            const float startedBent = renderBlock(*instrument, 1.7, late);
+            const float startedBent = renderBlock(*plugin, 1.7, late);
             expectWithinAbsoluteError(startedBent, expectedLevelForBentNote(69, -2.0f), 0.002f);
 
             // --- Range scales the same wheel position ----------------------
-            setHostParam(*instrument, bendIdx, 12.0f / kMax);
+            setHostParam(*plugin, bendIdx, 12.0f / kMax);
             auto upAgain = pitchWheel(1.0f);
-            const float octave = renderBlock(*instrument, 1.8, upAgain);
+            const float octave = renderBlock(*plugin, 1.8, upAgain);
             expectWithinAbsoluteError(octave, expectedLevelForBentNote(69, 12.0f), 0.004f);
 
             // --- Range 0 makes the wheel inert -----------------------------
-            setHostParam(*instrument, bendIdx, 0.0f);
+            setHostParam(*plugin, bendIdx, 0.0f);
             auto stillUp = pitchWheel(1.0f);
-            const float inert = renderBlock(*instrument, 1.9, stillUp);
+            const float inert = renderBlock(*plugin, 1.9, stillUp);
             expectWithinAbsoluteError(inert, expectedLevelForNote(69), 0.002f);
 
             // --- reset() recentres the wheel -------------------------------
             // Otherwise a transport stop or mode change, neither of which
             // delivers a note-off or a wheel message, would leave everything
             // played afterwards silently detuned.
-            setHostParam(*instrument, bendIdx, 2.0f / kMax);
+            setHostParam(*plugin, bendIdx, 2.0f / kMax);
             auto bendUp = pitchWheel(1.0f);
-            renderBlock(*instrument, 1.91, bendUp);
+            renderBlock(*plugin, 1.91, bendUp);
             instrument->reset();
             auto afterReset = noteOn(69);
-            const float unbentAgain = renderBlock(*instrument, 1.92, afterReset);
+            const float unbentAgain = renderBlock(*plugin, 1.92, afterReset);
             expectWithinAbsoluteError(unbentAgain, expectedLevelForNote(69), 0.002f);
         }
 
@@ -296,29 +298,29 @@ class FaustInstrumentVoiceModeTest final : public juce::UnitTest {
             const int bendIdx = audio::FaustInstrumentPlugin::kBendRangeParamIndex;
             constexpr float kMax = audio::FaustInstrumentPlugin::kMaxBendSemitones;
 
-            setHostParam(*instrument, voiceModeIdx, 0.5f);  // Mono
-            setHostParam(*instrument, glideIdx, 0.0f);
-            setHostParam(*instrument, bendIdx, 2.0f / kMax);
+            setHostParam(*plugin, voiceModeIdx, 0.5f);  // Mono
+            setHostParam(*plugin, glideIdx, 0.0f);
+            setHostParam(*plugin, bendIdx, 2.0f / kMax);
             instrument->reset();
 
             // The previous block left the wheel up; reset() recentres it, so
             // this note starts at concert pitch without a wheel message.
             auto held = noteOn(69);
-            const float unbent = renderBlock(*instrument, 2.0, held);
+            const float unbent = renderBlock(*plugin, 2.0, held);
             expectWithinAbsoluteError(unbent, expectedLevelForNote(69), 0.002f);
 
             auto up = pitchWheel(1.0f);
-            const float bent = renderBlock(*instrument, 2.1, up);
+            const float bent = renderBlock(*plugin, 2.1, up);
             expectWithinAbsoluteError(bent, expectedLevelForBentNote(69, 2.0f), 0.002f);
 
             // Bend must ride on top of the glide ramp rather than replacing it:
             // with the wheel still held, a new note lands bent as well.
             auto next = noteOn(72);
-            const float movedBent = renderBlock(*instrument, 2.2, next);
+            const float movedBent = renderBlock(*plugin, 2.2, next);
             expectWithinAbsoluteError(movedBent, expectedLevelForBentNote(72, 2.0f), 0.002f);
         }
 
-        instrument->baseClassDeinitialise();
+        plugin->baseClassDeinitialise();
     }
 };
 
@@ -352,7 +354,9 @@ class FaustInstrumentSampleRateTest final : public juce::UnitTest {
             return;
 
         auto plugin = createFaustInstrument(*edit);
-        auto* instrument = dynamic_cast<audio::FaustInstrumentPlugin*>(plugin.get());
+        // The device inside the host wrapper (#2315).
+        auto* instrument =
+            audio::tracktion_adapter::deviceFromPlugin<audio::FaustInstrumentPlugin>(plugin.get());
         expect(instrument != nullptr, "Faust instrument should be created");
         if (instrument == nullptr)
             return;
@@ -368,28 +372,28 @@ class FaustInstrumentSampleRateTest final : public juce::UnitTest {
         initInfo.startTime = tracktion::TimePosition();
         initInfo.sampleRate = kDeviceRate;
         initInfo.blockSizeSamples = kBlockSize;
-        instrument->baseClassInitialise(initInfo);
+        plugin->baseClassInitialise(initInfo);
 
         const float expected = static_cast<float>(kDeviceRate / 96000.0);
         const int voiceModeIdx = audio::FaustInstrumentPlugin::kVoiceModeParamIndex;
 
         {
-            setHostParam(*instrument, voiceModeIdx, 0.0f);  // Poly
+            setHostParam(*plugin, voiceModeIdx, 0.0f);  // Poly
             instrument->reset();
             auto note = noteOn(69);
-            const float level = renderBlock(*instrument, 0.0, note);
+            const float level = renderBlock(*plugin, 0.0, note);
             expectWithinAbsoluteError(level, expected, 0.002f);
         }
 
         {
-            setHostParam(*instrument, voiceModeIdx, 0.5f);  // Mono
+            setHostParam(*plugin, voiceModeIdx, 0.5f);  // Mono
             instrument->reset();
             auto note = noteOn(69);
-            const float level = renderBlock(*instrument, 0.1, note);
+            const float level = renderBlock(*plugin, 0.1, note);
             expectWithinAbsoluteError(level, expected, 0.002f);
         }
 
-        instrument->baseClassDeinitialise();
+        plugin->baseClassDeinitialise();
     }
 };
 

--- a/tests/engine/test_null_diff_corpus.cpp
+++ b/tests/engine/test_null_diff_corpus.cpp
@@ -36,7 +36,7 @@ juce::File scratch() {
 TEST_CASE("The corpus builds and covers what the slice claims", "[nulldiff][corpus]") {
     const auto corpus = sharedCorpus(scratch());
 
-    REQUIRE(corpus.size() == 65);
+    REQUIRE(corpus.size() == 66);
 
     std::set<std::string> names;
     for (const auto& value : corpus)
@@ -108,7 +108,8 @@ TEST_CASE("The corpus builds and covers what the slice claims", "[nulldiff][corp
                                  "plugin.transport",
                                  "plugin.instrument",
                                  "plugin.instrument.midiout",
-                                 "plugin.instrument.midiout.thru"})
+                                 "plugin.instrument.midiout.thru",
+                                 "plugin.faust.instrument"})
         CHECK(names.count(expected) == 1);
 }
 


### PR DESCRIPTION
Closes #2315. Part of #2299.

## The port

`FaustInstrumentPlugin` was `te::Plugin` only, so a project using it rendered as passthrough on the native leg — `createSdkDevice()` returned null and the executor bound a `Passthrough` for the Device op. It is a `MagdaDevice` now, following the runtime Faust effect that crossed in #2196.

- `properties` / `prepare` / `release` / `reset` / `process` replace `initialise` / `deinitialise` / `applyToBuffer`.
- The 64 pool slots become relaxed atomics read on the audio thread instead of `te::AutomatableParameter` + `CachedValue`. The three host-owned controls (voice mode, glide, bend range) keep their indices past the end of the pool, so a patch still has all 64 of its own and nothing a macro, mod or automation lane pinned to moves.
- State goes through `flushState` / `restoreState` under the spellings the retired plugin registered, so a saved project reads back onto the same controls.
- Voice allocation, glide, bend, the mono note stack and the retire timer are unchanged. This is a port, not a rewrite, and the corpus case below is what says so.

The compiled factory and its voices now live for as long as the device does — the runtime store's lifetime rather than the plan's — so recompiling a plan because a fader moved never rebuilds a voice mid-note.

## The editor was unreachable through the wrapper

`dynamic_cast<IFaustEditorModel*>` on a `te::Plugin` has returned null since the Faust **effect** became a `MagdaDevice`: `TracktionMagdaDevicePlugin` is `final` and is not that interface. The instrument needs the unwrap, and the same `deviceFromPlugin<IFaustEditorModel>` call repairs the effect's inline editor and `PluginApiLive::applyFaustSource` at the same time (`DeviceSlotInlineUiFactory.cpp` ×2, `plugin_api_live.cpp`).

## Null-diff, and what it found

The issue asks for this to be null-diffed against the TE leg, and the corpus had no Faust case at all. `plugin.faust.instrument` renders overlapping chords through a deliberately trivial patch — a gated DC per voice, no oscillator, no envelope — so the output is a staircase and any difference can only come from *when* a gate flips.

It failed on the first run: `peak=-36.2 rms=-74.6 shift=0.000`. The cause is not the port.

**The fork ends every note 0.0001 s early.** `MidiNote::getPlaybackTime` subtracts it — *"nudge the note-up backwards just a bit to make sure the ordering is correct"* (`tracktion_MidiList.cpp:829-831`) — which at 44.1 kHz is 4.41 samples, so after rounding the fork releases four samples before the engine does. The engine orders its events when it compiles them and keeps the length the note was drawn at.

The corpus has always known the figure: `Case::incumbentNoteEndEarlySeconds` (`NullDiffCase.hpp:208`) declares it, with that explanation. Its only consumer was the MIDI comparison (`NullDiffRunner.cpp:421`). The audio comparison could not see it, and until now never needed to — every corpus instrument answers a note-on with an impulse and ignores the off (`NullDiffHostedPlugin.cpp` `processVoice`), so no rendered audio depended on when a note ended. A sustaining synth is the first case that hears it.

Every divergence was a contiguous four-sample window ending exactly on an authored note-off, with a magnitude equal to the sum of the released notes' DC levels, and **no divergence at any note-on**.

So the audio comparison learns the fact the corpus already wrote down:

- `AudioCompareOptions::excludedRanges` — half-open sample ranges the residual is not taken over, counted out of `comparedSamples`.
- `noteEndNudgeRanges()` derives them from the authored notes and the declared constant: `[end - nudge, end)` per note, clipped by the clip end, sorted and merged.
- `Case::audioChangesAtNoteEnds` opts a case in, with the mechanism recorded beside it.

This is a change to the shape of the comparison, not a widened tolerance. The samples are named per note rather than found in the residual, and every other sample of the case — note-ons included — is still held to bit identity. Result: `peak=-inf`.

## Results

`plugin.faust.instrument` reports `peak=-inf` on both legs. Verified negatively: with `audioChangesAtNoteEnds` off, `peak=-36.2 rms=-74.6` comes back exactly.

Full Catch2 suite green (3421 passed, 13 skipped). JUCE suites **Null Diff Corpus**, **Faust Instrument Project Tempo**, **Faust Instrument Voice Mode** and **MIDI Signal Routing** all clean. `placement.grid` still fails on a `tracktion_DeviceManager.cpp:432` assertion — reproduced on unmodified `dev/0.20.0`, pre-existing and unrelated.

## Follow-ups filed

- #2351 - the mono held-note stack has no dedup, where the compiled poly instrument erases a matching pitch first. Pre-existing, not introduced here.
- #2352 - the corpus has no case for `MagdaCompiledPolyInstrument`, which would have hit the same upstream divergence. The harness change above is what it needs; it is now waiting on the case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018rAnjCekXfSQtpsr7jLtj5