### PR TITLE
Trim the session switch comments (#2302)

### DIFF
--- a/magda/engine/clip/ClipAudioSource.cpp
+++ b/magda/engine/clip/ClipAudioSource.cpp
@@ -43,8 +43,8 @@ ClipVoice* ClipAudioSource::voiceFor(ClipId clipId, EventId eventId) {
         if (voice.playing(clipId, eventId))
             return &voice;
 
-    // A voice still carrying a release ramp holds no entry and yet is still
-    // sounding, so claiming it would cut the tail it is in the middle of.
+    // A fading voice holds no entry and is still sounding, so claiming it would
+    // cut the tail it is in the middle of.
     for (auto& voice : voices_)
         if (voice.clipId() == INVALID_CLIP_ID && !voice.fading())
             return &voice;
@@ -123,12 +123,10 @@ void ClipAudioSource::gatherSession(const TrackClipPlayback& track, const BlockI
         if (status.afterEvent)
             play(*status.afterEvent, split, block.numSamples - split);
 
-        // Where this slot stopped sounding, noted per clip rather than per
-        // track: the ramp is the voice's own (ClipVoice::releaseInto), so
-        // whether some other slot goes on sounding through the same samples
-        // does not come into it. The handle's answer rather than the shape of
-        // the split, so a stop on the block's first sample is the same edge as
-        // one half way through it (LaunchHandle::silencedAt).
+        // Per clip rather than per track, because the ramp is the voice's own
+        // (ClipVoice::releaseInto). The handle's answer rather than the shape
+        // of the split, so a stop on the first sample is the same edge as one
+        // half way through (LaunchHandle::silencedAt).
         const auto silenced = status.silencedAt();
         if (!silenced)
             return;
@@ -147,9 +145,8 @@ void ClipAudioSource::gatherSession(const TrackClipPlayback& track, const BlockI
 }
 
 void ClipAudioSource::render(const BlockInfo& block, juce::dsp::AudioBlock<float> out) {
-    // Cleared for the block rather than by whatever gathers, because every path
-    // through the render can return before the gather does: a stale edge would
-    // release a voice a second time, blocks after the stop it belongs to.
+    // Here rather than in the gather, which every path through the render can
+    // return before reaching: a stale edge would release a voice twice.
     stoppingCount_ = 0;
 
     renderMaterial(block, out);
@@ -168,28 +165,25 @@ void ClipAudioSource::applySectionHold(juce::dsp::AudioBlock<float> out) {
 
     const auto until = std::clamp(hold.until.value, 0, numSamples);
 
-    // What it rendered and gets to keep, before anything corrects it, which is
-    // the order StopDeClick::push asks for.
+    // What it rendered and keeps, before anything corrects it (StopDeClick::push).
     if (until > 0)
         handOver_.push(out.getSubBlock(0, static_cast<std::size_t>(until)));
 
-    // The session's share of the block is dropped. What the arrangement
-    // rendered into it still advanced every voice, stream and stretcher, which
-    // is what makes taking the track back land where the timeline says rather
-    // than where the arrangement was when it lost it. Only the output goes.
+    // The session's share is dropped, but rendering it advanced every voice,
+    // stream and stretcher: that is what makes taking the track back land where
+    // the timeline says rather than where the arrangement lost it.
     if (until < numSamples)
         out.getSubBlock(static_cast<std::size_t>(until)).clear();
 
-    // Taking the track back lands mid-material, which is the same step a voice
-    // starting mid-file leaves and comes out the same way.
+    // Taking it back lands mid-material, the same step a voice starting
+    // mid-file leaves.
     if (hold.gained)
         handBack_.begin(out, kSectionDeClickSamples);
     else
         handBack_.advance(out);
 
-    // Losing it leaves the other step. A ramp still running from an earlier
-    // block finishes into whatever is here now rather than being cut off, which
-    // would be the click it exists to remove.
+    // Losing it leaves the other step. A ramp from an earlier block finishes
+    // into whatever is here now rather than being cut off.
     if (hold.lost)
         handOver_.begin(out, until, kSectionDeClickSamples);
     else
@@ -269,9 +263,8 @@ void ClipAudioSource::renderMaterial(const BlockInfo& block, juce::dsp::AudioBlo
     else
         gather(track->audio, lane, 0, table, sounding, soundingCount);
 
-    // Pointers rather than the array's own iterators, which are a class type on
-    // MSVC and a pointer on libc++: deducing `const auto*` from one compiles on
-    // exactly one of the two.
+    // Pointers, not the array's iterators: those are a class type on MSVC and a
+    // pointer on libc++, so `const auto*` deduces from one and not the other.
     const auto stopping = [&](const ClipVoice& voice) -> const Stopping* {
         const auto* first = stopping_.data();
         const auto* last = first + stoppingCount_;
@@ -296,9 +289,8 @@ void ClipAudioSource::renderMaterial(const BlockInfo& block, juce::dsp::AudioBlo
             });
 
         // Let go before anything renders, so a voice holding a clip that
-        // stopped last block does not keep a slot a clip starting this one
-        // needs. Not one the launcher says is stopping in this block: that one
-        // is released below, once it has rendered whatever it still had to.
+        // stopped last block does not keep a slot this one needs. Not one
+        // stopping in this block: that is released below, after it renders.
         if (!stillSounding && stopping(voice) == nullptr)
             voice.release();
     }
@@ -326,11 +318,9 @@ void ClipAudioSource::renderMaterial(const BlockInfo& block, juce::dsp::AudioBlo
                                       static_cast<std::size_t>(entry.block.numSamples)));
     }
 
-    // After rendering, because a slot that stops half way through a block still
-    // sounds the first half of it, and the ramp carries on from what that half
-    // ended at. A slot stopped on the block's first sample rendered nothing
-    // here and carries on from the block before, which is the same thing said
-    // about a different sample (StopDeClick::push).
+    // After rendering: a slot that stops half way through a block still sounds
+    // the first half, and the ramp carries on from what that half ended at. One
+    // stopped on the first sample carries on from the block before.
     for (auto& voice : voices_) {
         if (voice.clipId() == INVALID_CLIP_ID)
             continue;

--- a/magda/engine/clip/ClipMidiSource.cpp
+++ b/magda/engine/clip/ClipMidiSource.cpp
@@ -595,12 +595,10 @@ void ClipMidiSource::render(const BlockInfo& block, juce::MidiBuffer& out) {
         return;
     }
 
-    // The arrangement's, and only while the session has not taken the track off
-    // it (#2302). A source built without the feed is the whole track and has no
-    // section to lose.
-    // The arrangement's share of the block, which is the whole of it on a track
-    // the session never took (#2302). The same fold the audio source reads, so
-    // the two are on the same side of every switch.
+    // A source built without the feed is the whole track and has no section to
+    // lose.
+    // The arrangement's share, which is all of it on a track the session never
+    // took (#2302). The same fold the audio source reads.
     auto lane = block;
     auto until = block.numSamples;
     auto lost = false;
@@ -612,20 +610,17 @@ void ClipMidiSource::render(const BlockInfo& block, juce::MidiBuffer& out) {
         until = std::clamp(hold.until.value, 0, block.numSamples);
         lost = hold.lost;
 
-        // Taking the track back is a discontinuity even though the transport
-        // never moved: the arrangement's notes were ended when it lost the
-        // track and the timeline has run on underneath. Resuming without a
-        // chase leaves a sustained pad silent, and every controller at whatever
-        // it was before, until the next event happens to arrive. That is the
+        // A discontinuity even though the transport never moved: its notes were
+        // ended when it lost the track and the timeline ran on underneath.
+        // Resuming without a chase leaves a sustained pad silent, which is the
         // case playLane already answers for a locate.
         if (hold.gained)
             lane.continuous = false;
     }
 
-    // The session owns every sample of the block. What the arrangement owes is
-    // whether it lost the track here: note-offs on the block it loses it, even
-    // when it loses it on the first sample and sounds none of that block, and
-    // nothing on the blocks after, where what it had was ended already.
+    // The session owns every sample. The arrangement owes note-offs on the
+    // block it loses the track, even losing it on the first sample and sounding
+    // none of that block, and nothing on the blocks after.
     if (until == 0) {
         if (lost)
             endAll(out, EventSample{0});
@@ -647,9 +642,8 @@ void ClipMidiSource::render(const BlockInfo& block, juce::MidiBuffer& out) {
     playLane(out, lane, track->midi, lane.beats.start, laneEnd);
 
     // It sounds up to the hand-over the way its audio renders up to it, and
-    // owes note-offs there: the session's own notes start on that sample, and
-    // one the arrangement left holding would sound under them until the
-    // transport stopped.
+    // owes note-offs there: a note left holding would sound under the session's
+    // own until the transport stopped.
     if (lost)
         endAll(out, EventSample{std::min(until, block.numSamples - 1)});
 

--- a/magda/engine/clip/ClipVoice.hpp
+++ b/magda/engine/clip/ClipVoice.hpp
@@ -77,16 +77,11 @@ class ClipVoice {
      * @brief Stop, carrying this voice's own last sample down into @p out.
      *
      * The stop edge belongs here for the reason the start edge does: a voice is
-     * the only thing that knows what it alone was contributing. One ramp over a
-     * track's summed output cannot take one voice's step out of it while other
-     * voices go on sounding through the same samples, and a track whose slots
-     * change independently is exactly that (#2344 review).
+     * the only thing that knows what it alone was contributing, and one ramp
+     * over a track's sum cannot isolate it while other voices keep sounding.
      *
-     * @p offset is where in the block it stopped, so a slot that ends half way
-     * through a callback ends there rather than on the boundary.
-     *
-     * The voice is not free until the ramp is spent (@ref fading), because what
-     * is left of it is still sounding.
+     * @p offset is where in the block it stopped. The voice is not free until
+     * the ramp is spent (@ref fading).
      */
     void releaseInto(juce::dsp::AudioBlock<float> out, int offset, int fadeSamples);
 
@@ -185,8 +180,8 @@ class ClipVoice {
     /// every block size (FadeCurves.hpp).
     StartDeClick deClick_;
 
-    /// This voice's own stop edge: what it was contributing when it ended,
-    /// carried down without touching anything else on the track.
+    /// What it was contributing when it ended, carried down without touching
+    /// anything else on the track.
     StopDeClick stop_;
 
     /// One cell's output, and how much of it a block has taken. Allocated in

--- a/magda/engine/clip/FadeCurves.hpp
+++ b/magda/engine/clip/FadeCurves.hpp
@@ -116,26 +116,13 @@ class StartDeClick {
 /**
  * @brief Return the end of a voice to zero without fading what came before it.
  *
- * The other edge of StartDeClick, and the same trick read backwards. Where a
- * start subtracts the step the material begins on, a stop carries the step it
- * ends on: the last sample that sounded is held and decayed to zero over the
- * ramp, added on top of the silence that follows. The material itself is never
- * attenuated, so a clip stopped a sample before its own tail ends keeps that
- * tail exactly as far as it got.
+ * StartDeClick read backwards: the last sample that sounded is held and decayed
+ * to zero over the ramp, added on top of the silence that follows, so the
+ * material itself is never attenuated.
  *
- * What it is for is the discontinuity of ending mid-material: a session slot
- * stopped on a beat, a track handed from the arrangement to the session, a
- * launch that cuts the arrangement off mid-note. None of those end on a zero
- * crossing except by luck, and the step left behind is a click whose energy is
- * spread across the spectrum rather than confined below the ramp's own rate.
- *
- * It carries across blocks, for the reason StartDeClick does: a ramp that
- * stopped at the end of the block it began in would decay over min(length,
- * block) samples, and the same stop would come out differently at 128 samples a
- * block and at 1024.
- *
- * A held value of zero costs nothing, which is why a source can stop through
- * this unconditionally rather than deciding first whether it clicks.
+ * Carries across blocks for the reason StartDeClick does, or the same stop
+ * would come out differently at 128 samples a block and at 1024. A held value
+ * of zero costs nothing, so a source can stop through this unconditionally.
  */
 class StopDeClick {
   public:
@@ -145,29 +132,16 @@ class StopDeClick {
     /**
      * @brief Remember where @p audio ended.
      *
-     * The contract, and the whole of it: call this with what you rendered,
-     * before anything corrects it. Then what is remembered is always the last
-     * sample of your own signal, and @ref begin never has to guess which of the
-     * things in a buffer was yours.
-     *
-     * Getting that order wrong is what every way of using this wrongly looks
-     * like. Push a buffer a ramp has already been added to and the remembered
-     * sample is part decayed correction rather than signal; push a buffer
-     * somebody else also wrote into and it is their signal too, and a ramp that
-     * decays it corrects for something that never stopped. The caller that owns
-     * one signal is the caller that can push, which is why a voice pushes its
-     * own region and a source pushes its own output.
+     * The contract: call this with what you rendered, before anything corrects
+     * it. Push a buffer a ramp was added to and the remembered sample is part
+     * correction; push one somebody else wrote into and it is their signal too.
+     * So a voice pushes its own region and a source pushes its own output.
      */
     void push(juce::dsp::AudioBlock<float> audio);
 
-    /**
-     * @brief Start decaying into @p audio from @p offset, over @p fadeSamples.
-     *
-     * What it decays is what @ref push last remembered, never anything read
-     * back out of @p audio: by the time a stop is applied that buffer may hold
-     * other voices, an earlier ramp, or nothing at all, and none of those is
-     * the signal that stopped.
-     */
+    /// Start decaying into @p audio from @p offset, over @p fadeSamples. What
+    /// it decays is what @ref push remembered, never anything read back out of
+    /// @p audio, which by then may hold other voices or an earlier ramp.
     void begin(juce::dsp::AudioBlock<float> audio, int offset, int fadeSamples);
 
     /// Carry on from the start of @p audio. Does nothing once the ramp has run

--- a/magda/engine/clip/SessionPlayback.hpp
+++ b/magda/engine/clip/SessionPlayback.hpp
@@ -97,76 +97,39 @@ inline EdgeSample splitSample(const BlockInfo& block, const SplitStatus& status)
     return EdgeSample{status.afterEvent ? status.event.sample : block.numSamples};
 }
 
-/**
- * @brief How long a section takes to hand a track over, and to take it back.
- *
- * Short, and much shorter than ClipInfo::launchFadeSamples, because it is the
- * other kind of ramp. A start de-click subtracts an offset from material that
- * goes on sounding underneath it, so its length costs nothing and 256 samples
- * buys a gentler correction. A stop de-click has no material underneath: what
- * it spends its length on is a held constant, and 5 ms of one is a thump in
- * place of a click rather than the absence of both.
- *
- * 32 samples puts what the correction does spend below about 750 Hz at 48 kHz,
- * which is under the step's own broadband energy without lasting long enough to
- * be heard as a level of its own. The incumbent spends between 10 and 40 on the
- * same edge, in two places that disagree with each other; this is one number
- * for one job.
- *
- * A constant rather than a per-clip figure, unlike a slot's own launch ramp: an
- * arrangement handed over is a whole track's worth of clips at once, and no one
- * of them owns the number.
- */
+/// How long a section takes to hand a track over, and to take it back.
+///
+/// Much shorter than a launch ramp: what a stop de-click spends its length on
+/// is a held constant, and 5 ms of one is a thump in place of a click.
 constexpr int kSectionDeClickSamples = 32;
 
 /**
  * @brief The stretch of a block the arrangement sounds, and what happens at its ends.
  *
- * A track plays its arrangement or its session, never both (#2302). This is
- * that as a span rather than as endpoints a caller then reconciles: the samples
- * the arrangement owns, and whether each end of them is an edge that has to be
- * ramped or merely where the block stopped.
+ * A track plays its arrangement or its session, never both (#2302). A span
+ * rather than endpoints a caller reconciles, so a zero-length one carries no
+ * edges and cannot ramp a signal that was not playing.
  *
- * One span is enough, and it always begins at the block's first sample. The two
- * directions happen at different kinds of instant and that is what bounds it: a
- * session takes a track on the sample its slot launches, and gives one up at a
- * block boundary, because a release is a request the advance applies at sample
- * zero. So the arrangement can only ever gain the track at zero and lose it
- * once, and a list of spans could hold no more than this does.
+ * One span, always from the block's first sample: a session takes a track on
+ * the sample its slot launches and gives one up at a block boundary, since a
+ * release applies at sample zero.
  *
- * Saying it as a span is what makes a zero-length one harmless. Ownership
- * expressed as endpoints plus flags cannot tell "the arrangement had the track
- * for no samples" from "the arrangement had the track", and the difference is
- * whether there is an edge to ramp: a slot released and another launched on the
- * same sample would otherwise start a stop ramp over a signal that was not
- * playing, decaying whatever the arrangement last pushed, from before the
- * session took the track at all (#2344 review).
- *
- * Derived rather than stored, from the table both of a track's sources read,
- * after the launcher has advanced every handle and before anything renders. Two
- * sources folding the same table over the same block reach the same answer,
- * which is what keeps a track's audio and its MIDI on the same side of every
- * switch with nothing of their own to keep in step.
+ * Derived per block from the table both of a track's sources read, so its audio
+ * and its MIDI reach the same answer with nothing of their own to keep in step.
  */
 struct SectionHold {
     /// The edge past which the arrangement is silent. Zero for a block the
     /// session owns entirely.
     EdgeSample until{0};
 
-    /// Whether the arrangement takes the track at the block's first sample
-    /// rather than already having it: a resume, which lands mid-material and
-    /// owes both a ramp out of silence and a chase of what is sounding there.
-    ///
-    /// Never set for a span with no samples in it, because nothing resumes.
+    /// Whether the arrangement takes the track at the block's first sample: a
+    /// resume, which owes a ramp out of silence and a chase. Never set for a
+    /// span with no samples, because nothing resumes.
     bool gained = false;
 
-    /// Whether it loses the track at @ref until rather than simply running to
-    /// the end of the block: the edge that has to be carried down, and that
-    /// owes note-offs for whatever it had sounding.
-    ///
-    /// Set for a span with no samples in it only when the arrangement owned the
-    /// block before this one, which is a launch landing on a callback boundary:
-    /// there is a step there, and it comes off the block before.
+    /// Whether it loses the track at @ref until: the edge to carry down, which
+    /// owes note-offs. Set for an empty span only when the arrangement owned
+    /// the block before, which is a launch on a callback boundary.
     bool lost = false;
 
     /// Whether the arrangement sounds any of this block.
@@ -174,32 +137,24 @@ struct SectionHold {
         return until.value > 0;
     }
 
-    /// The whole of a block, with no edges: a track nothing can launch on.
-    ///
-    /// Named rather than left to a default, because the right answer is the
-    /// block's length and a default cannot know it. Defaulting to zero says the
-    /// session owns everything, which is the opposite of what a track with no
-    /// handles is, and silences its arrangement (#2344 review).
+    /// The whole of a block, with no edges. Named rather than defaulted,
+    /// because the answer is the block's length and a default cannot know it.
     static SectionHold arrangement(int numSamples) {
         return SectionHold{EdgeSample{numSamples}, false, false};
     }
 };
 
-/**
- * @copydoc SectionHold
- *
- * @p handles is null until the store has published a table, which is a session
- * whose slots have no handles yet rather than an error (SessionLauncher.hpp).
- * Nothing can hold a track then, so the arrangement has all of it.
- */
+/// @copydoc SectionHold
+/// @p handles is null until the store publishes one, which is legal: nothing
+/// can hold a track then, so the arrangement has all of it.
 inline SectionHold sectionHold(const LaunchHandleTable* handles, TrackId trackId, int numSamples) {
     if (handles == nullptr)
         return SectionHold::arrangement(numSamples);
 
     const auto [first, last] = handles->rangeFor(trackId);
 
-    // Who owned the track before anything in this block, who owns its first
-    // sample once releases have applied, and who owns its last.
+    // Before anything in this block, at its first sample once releases have
+    // applied, and at its last.
     auto sessionBefore = false;
     auto sessionAtZero = false;
     auto sessionAtEnd = false;
@@ -213,8 +168,7 @@ inline SectionHold sectionHold(const LaunchHandleTable* handles, TrackId trackId
 
         sessionBefore = sessionBefore || status.heldSectionAtStart;
 
-        // A release applies on the first sample, so a slot that was released
-        // holds nothing by the time anything sounds.
+        // A release applies on the first sample.
         const auto heldThrough = status.heldSectionAtStart && !status.releasedSection;
         sessionAtZero = sessionAtZero || heldThrough;
 
@@ -223,8 +177,8 @@ inline SectionHold sectionHold(const LaunchHandleTable* handles, TrackId trackId
 
         sessionAtEnd = true;
 
-        // Where this slot took the track. One that already had it took it
-        // before this block; one that launched here took it on its own sample.
+        // One that already had it took it before this block; one that launched
+        // here took it on its own sample.
         if (heldThrough || status.beforeEvent.playing())
             takenAt = 0;
         else if (status.afterEvent && status.afterEvent->playing())
@@ -240,9 +194,8 @@ inline SectionHold sectionHold(const LaunchHandleTable* handles, TrackId trackId
     else
         hold.until = EdgeSample{numSamples};
 
-    // Both edges are about a signal, so neither exists without one. The
-    // exception is a loss on a block boundary, where the signal is the block
-    // before's and the step is still there.
+    // An edge is about a signal, so neither exists without one. Except a loss
+    // on a block boundary, where the signal is the block before's.
     hold.gained = sessionBefore && !sessionAtZero && hold.sounds();
     hold.lost = sessionAtEnd && (hold.sounds() || !sessionBefore);
 

--- a/magda/engine/launch/LaunchHandle.cpp
+++ b/magda/engine/launch/LaunchHandle.cpp
@@ -171,14 +171,9 @@ std::optional<BeatRange> LaunchHandle::lastPlayedRange() const {
 }
 
 void LaunchHandle::releaseSection() {
-    // A request rather than a state change, like every other way a slot stops.
-    // The advance is what turns a stop into an edge a source can see and ramp;
-    // a run ended behind their backs is a step nobody is told about, and the
-    // slot would cut off rather than decay (#2344 review).
-    //
-    // The stop and the hand-back are one request, so a later one replaces both
-    // or neither: a launch arriving before the next block means the clip is
-    // what was wanted, and it keeps the track it was already holding.
+    // A request, like every other way a slot stops: a run ended behind the
+    // sources' backs is a step nobody can ramp. The stop and the hand-back are
+    // one request, so a launch arriving before the next block replaces both.
     stop(std::nullopt);
     pending_->releasesSection = true;
 }
@@ -189,9 +184,8 @@ void LaunchHandle::beginRun(const SyncRange& range, const BlockInstant& at, doub
 
     playState_ = PlayState::playing;
 
-    // The hand-over, at the sample the run begins on rather than at the one it
-    // was asked on: a launch quantized to the next bar leaves the arrangement
-    // playing until the bar (#2302).
+    // At the sample the run begins on, not the one it was asked on, so a launch
+    // quantized to the next bar leaves the arrangement playing until the bar.
     holdsSection_ = true;
 
     Run run;
@@ -268,9 +262,8 @@ void LaunchHandle::applyEvent(const SyncRange& range, bool fromPending, const Bl
     if (pending.state == QueueState::stopQueued) {
         endRun();
 
-        // The hand-back happens where the stop does, because it is the same
-        // request: the slot cannot give a track up on one sample and fall
-        // silent on another.
+        // Where the stop does: a slot cannot give a track up on one sample and
+        // fall silent on another.
         if (pending.releasesSection)
             holdsSection_ = false;
 
@@ -296,8 +289,8 @@ SplitStatus LaunchHandle::advanceOver(const SyncRange& range) {
     SplitStatus status;
     status.beforeEvent.range = range.timeline;
 
-    // Before anything below can apply an event and change it. A stop landing on
-    // the first sample leaves no first half to read this off afterwards.
+    // Before an event below can change either: a stop on the first sample
+    // leaves no first half to read them off afterwards.
     status.soundingAtStart = playState_ == PlayState::playing;
     status.heldSectionAtStart = holdsSection_;
 
@@ -328,10 +321,7 @@ SplitStatus LaunchHandle::advanceOver(const SyncRange& range) {
             fromPending = true;
         }
 
-        // Reported here because applyEvent consumes the request: by the time it
-        // has run there is nothing left to ask. A hand-back is always at the
-        // block's first sample, since Back to Arrangement queues its stop for
-        // as soon as possible.
+        // Here because applyEvent consumes the request.
         status.releasedSection =
             fromPending && pending_->state == QueueState::stopQueued && pending_->releasesSection;
     }

--- a/magda/engine/launch/LaunchHandle.hpp
+++ b/magda/engine/launch/LaunchHandle.hpp
@@ -266,10 +266,9 @@ struct SplitStatus {
     /// in it applied (@ref LaunchHandle::holdsSection).
     bool heldSectionAtStart = false;
 
-    /// Whether this slot gave its track up in this block. A release is a
-    /// request the advance applies at sample zero, so ownership of the first
-    /// sample already reflects it and nothing downstream could otherwise tell a
-    /// track just handed back from one that was never taken.
+    /// Whether it gave the track up here. Ownership of the first sample already
+    /// reflects it, so this is what tells a track just handed back from one
+    /// that was never taken.
     bool releasedSection = false;
 
     /// Whether the slot is sounding when the block ends, which is what decides
@@ -278,15 +277,9 @@ struct SplitStatus {
         return afterEvent ? afterEvent->playing() : beforeEvent.playing();
     }
 
-    /**
-     * @brief Where the slot stopped sounding inside this block, if it did.
-     *
-     * The one question a de-click asks, answered in one place because the two
-     * shapes a stop arrives in have the same answer: @ref event is the sample
-     * the block ran into whatever it ran into, whether or not there was a first
-     * half to report. Absent when the slot sounded nothing here, and when it is
-     * still sounding at the end.
-     */
+    /// Where the slot stopped sounding inside this block, if it did. Both
+    /// shapes a stop arrives in have the same answer, since @ref event is set
+    /// whether or not there was a first half to report.
     std::optional<EdgeSample> silencedAt() const {
         if (!soundingAtStart || playingAtEnd())
             return std::nullopt;
@@ -401,32 +394,19 @@ class LaunchHandle {
     /**
      * @brief Whether this slot holds its track's playback (#2302).
      *
-     * A track sounds its arrangement or its session, never both, and launching
-     * a slot is what hands it over. The hand-back is not the slot stopping:
-     * silence after a stop is the session still holding the track, exactly as
-     * it is in the incumbent, and the arrangement comes back only when
-     * @ref releaseSection asks for it.
-     *
-     * Set the moment a run begins rather than when one is queued, so a launch
-     * quantized to the next bar leaves the arrangement playing until the bar.
-     *
-     * Per slot for a question that is per track, because the track's answer is
-     * the fold: a track is held by whichever of its slots holds it. Keeping it
-     * here is what lets both of a slot's sources reach the same answer from the
-     * table they already read, with nothing published between them.
+     * The hand-back is not the slot stopping: silence after a stop is the
+     * session still holding the track, and the arrangement comes back only when
+     * @ref releaseSection asks. Set when a run begins rather than when one is
+     * queued, so a launch quantized to the next bar leaves the arrangement
+     * playing until the bar.
      */
     bool holdsSection() const {
         return holdsSection_;
     }
 
-    /**
-     * @brief Give the track back to its arrangement. Back to Arrangement.
-     *
-     * A request, applied by the next advance: the slot stops and the hold goes
-     * at that block's first sample, and the block reports both. Every change of
-     * this state goes through the advance for the reason every stop does, which
-     * is that an edge nothing was told about is an edge nothing can ramp.
-     */
+    /// Give the track back to its arrangement. A request, applied by the next
+    /// advance at that block's first sample: an edge nothing was told about is
+    /// an edge nothing can ramp.
     void releaseSection();
 
     /**
@@ -509,13 +489,10 @@ class LaunchHandle {
         /// of it, or the handles agree about the bar and not the sample.
         std::optional<Run> synced;
 
-        /// Whether this stop is Back to Arrangement rather than an ordinary
-        /// one, so the slot gives the track up as it stops.
-        ///
-        /// Here rather than beside it, because a request replaces this one
-        /// whole. Two fields would let a later play cancel the stop and leave
-        /// the hand-back behind, and the slot would go on sounding while the
-        /// track said it belonged to the arrangement (#2344 review).
+        /// Whether this stop is Back to Arrangement, so the slot gives the
+        /// track up as it stops. Here rather than beside it, because a request
+        /// replaces this one whole: two fields would let a later play cancel
+        /// the stop and leave the hand-back behind.
         bool releasesSection = false;
     };
 

--- a/magda/engine/launch/SessionLauncher.hpp
+++ b/magda/engine/launch/SessionLauncher.hpp
@@ -32,15 +32,9 @@
 
 namespace magda::engine {
 
-/**
- * @brief Which of a track's two bodies of material a source plays (#2302).
- *
- * A track has both and sounds one: the arrangement laid out on the timeline,
- * and the session's slots positioned by their handles. Stated rather than
- * inferred from whether a source was given a handle feed, because both sources
- * need the feed now: the one that plays the arrangement reads it to know when
- * the session has taken the track off it.
- */
+/// Which of a track's two bodies of material a source plays (#2302). Stated
+/// rather than inferred from having a handle feed, because both sources need
+/// one: the arrangement's reads it to know when the session has taken the track.
 enum class Section : std::uint8_t { Arrangement, Session };
 
 /// Every slot's handle, at one moment. Sorted by slot key, so a source finds


### PR DESCRIPTION
Comments only. No code changed, and the engine suite is unmoved.

The doc blocks that came out of the #2344 review rounds carried the whole argument for each decision, because each was being argued at the time. The decisions are settled now, so what is left is the sentence or two that stops someone undoing them.

- `SectionHold`: 27 lines to 12
- `kSectionDeClickSamples`: 20 to 4
- `StopDeClick`: 24 to 10
- `SplitStatus::soundingAtStart`, `silencedAt`, `Pending::releasesSection`, `releaseSection`, `ClipVoice::releaseInto`, and the inline comments through both sources

Net 133 lines.

https://claude.ai/code/session_013CDpSHas8bog33vv4o6HLv
