### PR TITLE
Port the sampler to MagdaDevice (#2271)

### DIFF
--- a/magda/daw/audio/ClipCommands.cpp
+++ b/magda/daw/audio/ClipCommands.cpp
@@ -14,6 +14,7 @@
 #include "audio/plugins/DrumGridPlugin.hpp"
 #include "audio/plugins/InsertCapturePlugin.hpp"
 #include "audio/plugins/MagdaSamplerPlugin.hpp"
+#include "audio/plugins/tracktion/TracktionMagdaDevicePlugin.hpp"
 #include "audio/racks/InstrumentRackManager.hpp"
 #include "core/ClipOcclusion.hpp"
 #include "core/ClipOperations.hpp"
@@ -21,6 +22,7 @@
 #include "core/Config.hpp"
 #include "core/ControlTarget.hpp"
 #include "core/DrumGridPads.hpp"
+#include "core/ParameterUtils.hpp"
 #include "core/TrackManager.hpp"
 
 namespace magda {
@@ -2858,20 +2860,38 @@ void prepareDrumGridAdsrMacros(DeviceInfo& drumGridDevice) {
     }
 }
 
-void zeroSamplerAdsrBase(daw::audio::MagdaSamplerPlugin& sampler) {
-    const float attackMin = sampler.attackParam->getValueRange().getStart();
-    const float decayMin = sampler.decayParam->getValueRange().getStart();
-    const float releaseMin = sampler.releaseParam->getValueRange().getStart();
+/// Write one sampler slot in its display units, through the HOST WRAPPER's
+/// parameter rather than onto the device. The wrapper mirrors its parameters
+/// into the device on every sync, so a write straight to the device is undone
+/// at the next one. setParameterFromHost, not setParameter: the latter is
+/// silently dropped once a macro or mod is attached to the parameter.
+void setSamplerSlot(te::Plugin& plugin, int index, float displayValue) {
+    auto* sampler =
+        daw::audio::tracktion_adapter::deviceFromPlugin<daw::audio::MagdaSamplerPlugin>(&plugin);
+    if (sampler == nullptr)
+        return;
 
-    sampler.attackParam->setParameterFromHost(attackMin, juce::dontSendNotification);
-    sampler.decayParam->setParameterFromHost(decayMin, juce::dontSendNotification);
-    sampler.sustainParam->setParameterFromHost(0.0f, juce::dontSendNotification);
-    sampler.releaseParam->setParameterFromHost(releaseMin, juce::dontSendNotification);
+    auto params = plugin.getAutomatableParameters();
+    if (index < 0 || index >= params.size())
+        return;
 
-    sampler.attackValue = attackMin;
-    sampler.decayValue = decayMin;
-    sampler.sustainValue = 0.0f;
-    sampler.releaseValue = releaseMin;
+    const float normalized =
+        ParameterUtils::realToNormalized(displayValue, sampler->parameterInfo(index));
+    params[index]->setParameterFromHost(normalized, juce::dontSendNotification);
+}
+
+/// Flatten the pad sampler's envelope so the DrumGrid ADSR macros, which are
+/// added next, are the only thing shaping it.
+void zeroSamplerAdsrBase(te::Plugin& plugin) {
+    using Sampler = daw::audio::MagdaSamplerPlugin;
+    auto* sampler = daw::audio::tracktion_adapter::deviceFromPlugin<Sampler>(&plugin);
+    if (sampler == nullptr)
+        return;
+
+    setSamplerSlot(plugin, Sampler::kAttack, sampler->parameterInfo(Sampler::kAttack).minValue);
+    setSamplerSlot(plugin, Sampler::kDecay, sampler->parameterInfo(Sampler::kDecay).minValue);
+    setSamplerSlot(plugin, Sampler::kSustain, 0.0f);
+    setSamplerSlot(plugin, Sampler::kRelease, sampler->parameterInfo(Sampler::kRelease).minValue);
 }
 
 void addSamplerAdsrMacroLinks(DeviceInfo& drumGridDevice, TrackId trackId, int chainIndex,
@@ -2918,13 +2938,15 @@ void linkAssignedDrumGridSamplerAdsrMacros(DeviceInfo& drumGridDevice, TrackId t
         if (chain == nullptr || chain->plugins.empty())
             continue;
 
-        auto* sampler = dynamic_cast<daw::audio::MagdaSamplerPlugin*>(chain->plugins[0].get());
-        if (sampler == nullptr)
+        auto* plugin = chain->plugins[0].get();
+        if (plugin == nullptr ||
+            daw::audio::tracktion_adapter::deviceFromPlugin<daw::audio::MagdaSamplerPlugin>(
+                plugin) == nullptr)
             continue;
 
-        zeroSamplerAdsrBase(*sampler);
+        zeroSamplerAdsrBase(*plugin);
         addSamplerAdsrMacroLinks(drumGridDevice, trackId, chain->index,
-                                 drumGrid.getPluginDeviceId(chain->index, 0), *sampler);
+                                 drumGrid.getPluginDeviceId(chain->index, 0), *plugin);
     }
 }
 
@@ -3005,17 +3027,11 @@ void buildDrumGridFromSlices(const std::vector<SliceRegion>& slices, const ClipI
 
         auto* chain = drumGrid->getChainForNote(daw::audio::DrumGridPlugin::baseNote + i);
         if (chain && !chain->plugins.empty()) {
-            auto* sampler = dynamic_cast<daw::audio::MagdaSamplerPlugin*>(chain->plugins[0].get());
-            if (sampler) {
-                auto startSec = static_cast<float>(slice.sourceStart);
-                auto endSec = static_cast<float>(slice.sourceEnd);
-                // setParameterFromHost, not setParameter: the latter is silently
-                // dropped once a macro or mod is attached to the parameter.
-                sampler->sampleStartParam->setParameterFromHost(startSec,
-                                                                juce::dontSendNotification);
-                sampler->sampleStartValue = startSec;
-                sampler->sampleEndParam->setParameterFromHost(endSec, juce::dontSendNotification);
-                sampler->sampleEndValue = endSec;
+            if (auto* plugin = chain->plugins[0].get()) {
+                setSamplerSlot(*plugin, daw::audio::MagdaSamplerPlugin::kSampleStart,
+                               static_cast<float>(slice.sourceStart));
+                setSamplerSlot(*plugin, daw::audio::MagdaSamplerPlugin::kSampleEnd,
+                               static_cast<float>(slice.sourceEnd));
             }
         }
     }

--- a/magda/daw/audio/plugins/BaseDevicePack.cpp
+++ b/magda/daw/audio/plugins/BaseDevicePack.cpp
@@ -293,13 +293,15 @@ void registerNativeDevices(InternalPluginRegistry& registry) {
          .browserCategory = "Sampler",
          .description =
              "Sample playback instrument with envelope, pitch, start/end, and looping controls.",
-         .createMode = InternalPluginCreateMode::FreshValueTree,
-         .matchesPlugin = matches<MagdaSamplerPlugin>,
+         // The sample path lives in the device state, so a restore has to
+         // rebuild the plugin from it rather than from a fresh tree.
+         .createMode = InternalPluginCreateMode::SavedStateOrFresh,
+         .matchesPlugin = matchesDevice<MagdaSamplerPlugin>,
          .createProcessor = makeProcessor<MagdaSamplerProcessor>,
          .showInBrowser = true,
          .isInstrument = true,
-         .createInSession = createFreshValueTreePlugin,
-         .createPlugin = createPlugin<MagdaSamplerPlugin>});
+         .createInSession = createValueTreePlugin,
+         .createDevice = createDevice<MagdaSamplerPlugin>});
     add(registry,
         {.pluginId = DrumGridPlugin::xmlTypeName,
          .displayName = "Drum Grid",

--- a/magda/daw/audio/plugins/MagdaSamplerPlugin.cpp
+++ b/magda/daw/audio/plugins/MagdaSamplerPlugin.cpp
@@ -2,24 +2,191 @@
 
 #include <algorithm>
 #include <cmath>
+#include <memory>
 
 namespace magda::daw::audio {
 
-namespace te = tracktion::engine;
-
 namespace {
 
-float clampToParameterRange(const te::AutomatableParameter::Ptr& param, float value) {
-    if (param == nullptr)
-        return value;
+/// The formats a sample can arrive in. The retired plugin read through its own
+/// basic-format manager; keeping that list keeps the device engine-neutral.
+juce::AudioFormatManager& sampleFormats() {
+    static juce::AudioFormatManager formats;
+    [[maybe_unused]] static const bool registered = [] {
+        formats.registerBasicFormats();
+        return true;
+    }();
+    return formats;
+}
 
-    auto range = param->getValueRange();
-    return juce::jlimit(range.getStart(), range.getEnd(), value);
+/// One slot's metadata, pinned to what the retired host-native plugin
+/// registered: saved automation addresses these normalised positions.
+/// Its curves came from `juce::NormalisableRange` skews, where real =
+/// min + span * norm^(1/skew); MAGDA's Exponential is norm^k * span + min,
+/// so k is the RECIPROCAL of the JUCE skew.
+ParameterInfo slotInfo(int index) {
+    ParameterInfo info;
+    info.paramIndex = index;
+
+    // Time params used a JUCE skew of 0.4 so equal knob/macro movement gives
+    // perceptually-even change: most audible action is in the first few hundred
+    // ms, which a linear range crams into the bottom of the range.
+    constexpr float kTimeSkew = 1.0f / 0.4f;
+
+    switch (index) {
+        case MagdaSamplerPlugin::kAttack:
+            info.stableId = "attack";
+            info.name = "Attack";
+            info.unit = "s";
+            info.scale = ParameterScale::Exponential;
+            info.skewFactor = kTimeSkew;
+            info.minValue = 0.001f;
+            info.maxValue = 5.0f;
+            info.defaultValue = 0.001f;
+            break;
+
+        case MagdaSamplerPlugin::kDecay:
+            info.stableId = "decay";
+            info.name = "Decay";
+            info.unit = "s";
+            info.scale = ParameterScale::Exponential;
+            info.skewFactor = kTimeSkew;
+            info.minValue = 0.001f;
+            info.maxValue = 5.0f;
+            info.defaultValue = 0.1f;
+            break;
+
+        case MagdaSamplerPlugin::kSustain:
+            info.stableId = "sustain";
+            info.name = "Sustain";
+            info.minValue = 0.0f;
+            info.maxValue = 1.0f;
+            info.defaultValue = 1.0f;
+            info.displayFormat = DisplayFormat::Percent;
+            break;
+
+        case MagdaSamplerPlugin::kRelease:
+            info.stableId = "release";
+            info.name = "Release";
+            info.unit = "s";
+            info.scale = ParameterScale::Exponential;
+            info.skewFactor = kTimeSkew;
+            info.minValue = 0.001f;
+            info.maxValue = 10.0f;
+            info.defaultValue = 0.1f;
+            break;
+
+        case MagdaSamplerPlugin::kPitch:
+            info.stableId = "pitch";
+            info.name = "Pitch";
+            info.unit = "st";
+            info.minValue = -24.0f;
+            info.maxValue = 24.0f;
+            info.defaultValue = 0.0f;
+            break;
+
+        case MagdaSamplerPlugin::kFine:
+            info.stableId = "fine";
+            info.name = "Fine";
+            info.unit = "ct";
+            info.minValue = -100.0f;
+            info.maxValue = 100.0f;
+            info.defaultValue = 0.0f;
+            break;
+
+        case MagdaSamplerPlugin::kLevel:
+            info.stableId = "level";
+            info.name = "Level";
+            info.unit = "dB";
+            // JUCE skew 4.0: unity sits high in the range, so the usable trim
+            // around 0 dB gets most of the travel.
+            info.scale = ParameterScale::Exponential;
+            info.skewFactor = 1.0f / 4.0f;
+            info.minValue = -60.0f;
+            info.maxValue = 12.0f;
+            info.defaultValue = 0.0f;
+            break;
+
+        case MagdaSamplerPlugin::kSampleStart:
+            info.stableId = "sampleStart";
+            info.name = "Sample Start";
+            info.unit = "s";
+            info.minValue = 0.0f;
+            info.maxValue = 300.0f;
+            info.defaultValue = 0.0f;
+            break;
+
+        case MagdaSamplerPlugin::kSampleEnd:
+            info.stableId = "sampleEnd";
+            info.name = "Sample End";
+            info.unit = "s";
+            info.minValue = 0.0f;
+            info.maxValue = 300.0f;
+            info.defaultValue = 0.0f;
+            break;
+
+        case MagdaSamplerPlugin::kLoopStart:
+            info.stableId = "loopStart";
+            info.name = "Loop Start";
+            info.unit = "s";
+            info.minValue = 0.0f;
+            info.maxValue = 300.0f;
+            info.defaultValue = 0.0f;
+            break;
+
+        case MagdaSamplerPlugin::kLoopEnd:
+            info.stableId = "loopEnd";
+            info.name = "Loop End";
+            info.unit = "s";
+            info.minValue = 0.0f;
+            info.maxValue = 300.0f;
+            info.defaultValue = 0.0f;
+            break;
+
+        case MagdaSamplerPlugin::kVelAmount:
+            info.stableId = "velAmount";
+            info.name = "Vel Amount";
+            info.minValue = 0.0f;
+            info.maxValue = 1.0f;
+            info.defaultValue = 1.0f;
+            info.displayFormat = DisplayFormat::Percent;
+            break;
+
+        case MagdaSamplerPlugin::kVoiceMode:
+            info.stableId = "voiceMode";
+            info.name = "Voice Mode";
+            info.scale = ParameterScale::Discrete;
+            info.minValue = 0.0f;
+            info.maxValue = 2.0f;
+            info.defaultValue = 0.0f;
+            info.choices = {"Poly", "Mono", "Legato"};
+            break;
+
+        case MagdaSamplerPlugin::kGlide:
+            info.stableId = "glide";
+            info.name = "Glide";
+            info.unit = "ms";
+            info.scale = ParameterScale::Exponential;
+            info.skewFactor = kTimeSkew;
+            info.minValue = 0.0f;
+            info.maxValue = 2000.0f;
+            info.defaultValue = 0.0f;
+            break;
+
+        default:
+            break;
+    }
+
+    return info;
 }
 
 }  // namespace
 
 const char* MagdaSamplerPlugin::xmlTypeName = "magdasampler";
+
+const juce::Identifier MagdaSamplerPlugin::StateIDs::source("source");
+const juce::Identifier MagdaSamplerPlugin::StateIDs::rootNote("rootNote");
+const juce::Identifier MagdaSamplerPlugin::StateIDs::loopEnabled("loopEnabled");
 
 //==============================================================================
 // SamplerVoice Implementation
@@ -283,161 +450,15 @@ void SamplerSynth::allNotesOff(int midiChannel, bool allowTailOff) {
 // MagdaSamplerPlugin Implementation
 //==============================================================================
 
-MagdaSamplerPlugin::MagdaSamplerPlugin(const te::PluginCreationInfo& info) : Plugin(info) {
-    auto um = getUndoManager();
+MagdaSamplerPlugin::MagdaSamplerPlugin() {
+    for (int index = 0; index < kNumParams; ++index) {
+        const auto info = slotInfo(index);
+        domains_[static_cast<size_t>(index)] = ParameterUtils::domainOf(info);
+        values_[static_cast<size_t>(index)].store(
+            ParameterUtils::realToNormalized(info.defaultValue, info), std::memory_order_relaxed);
+    }
+    tailSeconds_.store(displayValue(kRelease), std::memory_order_relaxed);
 
-    // ADSR parameters
-    attackValue.referTo(state, te::IDs::attack, um, 0.001f);
-    // Time params use a logarithmic skew (0.4) so equal knob/macro movement
-    // gives perceptually-even change: most audible action is in the first few
-    // hundred ms, which a linear range crams into the bottom of the range.
-    attackParam = addParam(
-        "attack", "Attack", {0.001f, 5.0f, 0.001f, 0.4f},
-        [](float v) { return juce::String(v, 3) + " s"; },
-        [](const juce::String& s) {
-            return s.upToFirstOccurrenceOf(" ", false, false).getFloatValue();
-        });
-
-    static const juce::Identifier decayId("decay");
-    decayValue.referTo(state, decayId, um, 0.1f);
-    decayParam = addParam(
-        "decay", "Decay", {0.001f, 5.0f, 0.001f, 0.4f},
-        [](float v) { return juce::String(v, 3) + " s"; },
-        [](const juce::String& s) {
-            return s.upToFirstOccurrenceOf(" ", false, false).getFloatValue();
-        });
-
-    static const juce::Identifier sustainId("sustain");
-    sustainValue.referTo(state, sustainId, um, 1.0f);
-    sustainParam = addParam("sustain", "Sustain", {0.0f, 1.0f});
-
-    releaseValue.referTo(state, te::IDs::release, um, 0.1f);
-    releaseParam = addParam(
-        "release", "Release", {0.001f, 10.0f, 0.001f, 0.4f},
-        [](float v) { return juce::String(v, 3) + " s"; },
-        [](const juce::String& s) {
-            return s.upToFirstOccurrenceOf(" ", false, false).getFloatValue();
-        });
-
-    // Pitch parameters
-    pitchValue.referTo(state, te::IDs::pitch, um, 0.0f);
-    pitchParam = addParam(
-        "pitch", "Pitch", {-24.0f, 24.0f, 0.0f},
-        [](float v) { return juce::String(static_cast<int>(v)) + " st"; },
-        [](const juce::String& s) {
-            return s.upToFirstOccurrenceOf(" ", false, false).getFloatValue();
-        });
-
-    fineValue.referTo(state, te::IDs::fineTune, um, 0.0f);
-    fineParam = addParam(
-        "fine", "Fine", {-100.0f, 100.0f, 0.0f},
-        [](float v) { return juce::String(static_cast<int>(v)) + " ct"; },
-        [](const juce::String& s) {
-            return s.upToFirstOccurrenceOf(" ", false, false).getFloatValue();
-        });
-
-    // Level
-    levelValue.referTo(state, te::IDs::level, um, 0.0f);
-    levelParam = addParam(
-        "level", "Level", {-60.0f, 12.0f, 0.0f, 4.0f},
-        [](float v) { return juce::String(v, 1) + " dB"; },
-        [](const juce::String& s) {
-            return s.upToFirstOccurrenceOf(" ", false, false).getFloatValue();
-        });
-
-    // Sample start / loop parameters
-    static const juce::Identifier sampleStartId("sampleStart");
-    sampleStartValue.referTo(state, sampleStartId, um, 0.0f);
-    sampleStartParam = addParam(
-        "sampleStart", "Sample Start", {0.0f, 300.0f, 0.0f},
-        [](float v) { return juce::String(v, 3) + " s"; },
-        [](const juce::String& s) {
-            return s.upToFirstOccurrenceOf(" ", false, false).getFloatValue();
-        });
-
-    static const juce::Identifier sampleEndId("sampleEnd");
-    sampleEndValue.referTo(state, sampleEndId, um, 0.0f);
-    sampleEndParam = addParam(
-        "sampleEnd", "Sample End", {0.0f, 300.0f, 0.0f},
-        [](float v) { return juce::String(v, 3) + " s"; },
-        [](const juce::String& s) {
-            return s.upToFirstOccurrenceOf(" ", false, false).getFloatValue();
-        });
-
-    static const juce::Identifier loopStartId("loopStart");
-    loopStartValue.referTo(state, loopStartId, um, 0.0f);
-    loopStartParam = addParam(
-        "loopStart", "Loop Start", {0.0f, 300.0f, 0.0f},
-        [](float v) { return juce::String(v, 3) + " s"; },
-        [](const juce::String& s) {
-            return s.upToFirstOccurrenceOf(" ", false, false).getFloatValue();
-        });
-
-    static const juce::Identifier loopEndId("loopEnd");
-    loopEndValue.referTo(state, loopEndId, um, 0.0f);
-    loopEndParam = addParam(
-        "loopEnd", "Loop End", {0.0f, 300.0f, 0.0f},
-        [](float v) { return juce::String(v, 3) + " s"; },
-        [](const juce::String& s) {
-            return s.upToFirstOccurrenceOf(" ", false, false).getFloatValue();
-        });
-
-    // Velocity amount (0 = no velocity sensitivity, 1 = full)
-    static const juce::Identifier velAmountId("velAmount");
-    velAmountValue.referTo(state, velAmountId, um, 1.0f);
-    velAmountParam = addParam(
-        "velAmount", "Vel Amount", {0.0f, 1.0f, 1.0f},
-        [](float v) { return juce::String(static_cast<int>(v * 100)) + "%"; },
-        [](const juce::String& s) {
-            juce::String t = s.trim();
-            if (t.endsWithIgnoreCase("%"))
-                t = t.dropLastCharacters(1).trim();
-            float v = t.getFloatValue();
-            return v > 1.0f ? v / 100.0f : v;
-        });
-
-    // Voice mode (Poly / Mono / Legato) + portamento glide.
-    static const juce::Identifier voiceModeId("voiceMode");
-    voiceModeValue.referTo(state, voiceModeId, um, 0.0f);
-    voiceModeParam = addParam(
-        "voiceMode", "Voice Mode", {0.0f, 2.0f, 1.0f},
-        [](float v) {
-            const int m = juce::jlimit(0, 2, static_cast<int>(std::lround(v)));
-            return juce::String(m == 0 ? "Poly" : m == 1 ? "Mono" : "Legato");
-        },
-        [](const juce::String& s) {
-            if (s.startsWithIgnoreCase("mono"))
-                return 1.0f;
-            if (s.startsWithIgnoreCase("leg"))
-                return 2.0f;
-            return 0.0f;
-        });
-
-    static const juce::Identifier glideId("glide");
-    glideValue.referTo(state, glideId, um, 0.0f);
-    glideParam = addParam(
-        "glide", "Glide", {0.0f, 2000.0f, 0.0f, 0.4f},
-        [](float v) {
-            return v < 1000.0f ? juce::String(static_cast<int>(v)) + " ms"
-                               : juce::String(v / 1000.0f, 2) + " s";
-        },
-        [](const juce::String& s) {
-            juce::String t = s.trim();
-            if (t.endsWithIgnoreCase("ms"))
-                return t.dropLastCharacters(2).trim().getFloatValue();
-            if (t.endsWithIgnoreCase("s"))
-                return t.dropLastCharacters(1).trim().getFloatValue() * 1000.0f;
-            return t.getFloatValue();
-        });
-
-    // Non-parameter state
-    samplePathValue.referTo(state, te::IDs::source, um, juce::String());
-    rootNoteValue.referTo(state, te::IDs::rootNote, um, 60);
-    static const juce::Identifier loopEnabledId("loopEnabled");
-    loopEnabledValue.referTo(state, loopEnabledId, um, false);
-    loopEnabledAtomic.store(loopEnabledValue.get(), std::memory_order_relaxed);
-
-    // Initialize synthesiser
     synthesiser.clearVoices();
     synthesiser.clearSounds();
 
@@ -447,79 +468,61 @@ MagdaSamplerPlugin::MagdaSamplerPlugin(const te::PluginCreationInfo& info) : Plu
 
     for (int i = 0; i < numVoices; ++i)
         synthesiser.addVoice(new SamplerVoice());
-
-    attackValue = clampToParameterRange(attackParam, attackValue.get());
-    decayValue = clampToParameterRange(decayParam, decayValue.get());
-    sustainValue = clampToParameterRange(sustainParam, sustainValue.get());
-    releaseValue = clampToParameterRange(releaseParam, releaseValue.get());
-
-    // Initialize automatable parameters to their default values.
-    // addParam() defaults to range minimum; we must explicitly set the intended defaults.
-    attackParam->setParameterFromHost(attackValue.get(), juce::dontSendNotification);
-    decayParam->setParameterFromHost(decayValue.get(), juce::dontSendNotification);
-    sustainParam->setParameterFromHost(sustainValue.get(), juce::dontSendNotification);
-    releaseParam->setParameterFromHost(releaseValue.get(), juce::dontSendNotification);
-    pitchParam->setParameterFromHost(pitchValue.get(), juce::dontSendNotification);
-    fineParam->setParameterFromHost(fineValue.get(), juce::dontSendNotification);
-    levelParam->setParameterFromHost(levelValue.get(), juce::dontSendNotification);
-    sampleStartParam->setParameterFromHost(sampleStartValue.get(), juce::dontSendNotification);
-    sampleEndParam->setParameterFromHost(sampleEndValue.get(), juce::dontSendNotification);
-    loopStartParam->setParameterFromHost(loopStartValue.get(), juce::dontSendNotification);
-    loopEndParam->setParameterFromHost(loopEndValue.get(), juce::dontSendNotification);
-    velAmountParam->setParameterFromHost(velAmountValue.get(), juce::dontSendNotification);
-    voiceModeParam->setParameterFromHost(voiceModeValue.get(), juce::dontSendNotification);
-    glideParam->setParameterFromHost(glideValue.get(), juce::dontSendNotification);
-
-    // Restore sample from saved state
-    juce::String savedPath = samplePathValue.get();
-    if (savedPath.isNotEmpty()) {
-        // Save parameter values before loadSample resets them
-        int savedRootNote = rootNoteValue.get();
-        float savedStart = sampleStartValue.get();
-        float savedEnd = sampleEndValue.get();
-        float savedLoopStart = loopStartValue.get();
-        float savedLoopEnd = loopEndValue.get();
-
-        juce::File savedFile(savedPath);
-        if (savedFile.existsAsFile())
-            loadSample(savedFile);
-
-        // Restore root note (loadSample overwrites with detected metadata)
-        setRootNote(savedRootNote);
-
-        // Re-apply saved values if they were set (non-zero end means user had set it)
-        double lenSec = getSampleLengthSeconds();
-        float maxLen = static_cast<float>(lenSec);
-
-        if (savedStart > 0.001f && savedStart < maxLen) {
-            sampleStartParam->setParameterFromHost(savedStart, juce::dontSendNotification);
-            sampleStartValue = savedStart;
-        }
-        if (savedEnd > 0.001f && savedEnd < maxLen) {
-            sampleEndParam->setParameterFromHost(savedEnd, juce::dontSendNotification);
-            sampleEndValue = savedEnd;
-        }
-        if (savedLoopStart > 0.001f && savedLoopStart < maxLen) {
-            loopStartParam->setParameterFromHost(savedLoopStart, juce::dontSendNotification);
-            loopStartValue = savedLoopStart;
-        }
-        if (savedLoopEnd > 0.001f && savedLoopEnd < maxLen) {
-            loopEndParam->setParameterFromHost(savedLoopEnd, juce::dontSendNotification);
-            loopEndValue = savedLoopEnd;
-        }
-    }
 }
 
-MagdaSamplerPlugin::~MagdaSamplerPlugin() {
-    notifyListenersOfDeletion();
+MagdaSamplerPlugin::~MagdaSamplerPlugin() = default;
+
+//==============================================================================
+ParameterInfo MagdaSamplerPlugin::parameterInfo(int index) const {
+    if (index < 0 || index >= kNumParams)
+        return {};
+
+    auto info = slotInfo(index);
+    info.currentValue = displayValue(index);
+    return info;
 }
 
-void MagdaSamplerPlugin::initialise(const te::PluginInitialisationInfo& info) {
-    sampleRate = info.sampleRate;
+float MagdaSamplerPlugin::parameterValue(int index) const {
+    if (index < 0 || index >= kNumParams)
+        return 0.0f;
+    return values_[static_cast<size_t>(index)].load(std::memory_order_relaxed);
+}
+
+void MagdaSamplerPlugin::setParameterValue(int index, float value) {
+    if (index < 0 || index >= kNumParams)
+        return;
+
+    values_[static_cast<size_t>(index)].store(juce::jlimit(0.0f, 1.0f, value),
+                                              std::memory_order_relaxed);
+
+    // The tail the host asks for is the release stage's length, so it has to
+    // follow the slot rather than be read once at construction.
+    if (index == kRelease)
+        tailSeconds_.store(displayValue(kRelease), std::memory_order_relaxed);
+}
+
+float MagdaSamplerPlugin::displayValue(int index) const {
+    if (index < 0 || index >= kNumParams)
+        return 0.0f;
+    return ParameterUtils::normalizedToReal(
+        values_[static_cast<size_t>(index)].load(std::memory_order_relaxed),
+        domains_[static_cast<size_t>(index)]);
+}
+
+void MagdaSamplerPlugin::setDisplayValue(int index, float value) {
+    if (index < 0 || index >= kNumParams)
+        return;
+    setParameterValue(
+        index, ParameterUtils::realToNormalized(value, domains_[static_cast<size_t>(index)]));
+}
+
+//==============================================================================
+void MagdaSamplerPlugin::prepare(const DevicePrepareContext& context) {
+    sampleRate = context.sampleRate;
     synthesiser.setCurrentPlaybackSampleRate(sampleRate);
 }
 
-void MagdaSamplerPlugin::deinitialise() {
+void MagdaSamplerPlugin::release() {
     synthesiser.allNotesOff(0, false);
 }
 
@@ -527,15 +530,168 @@ void MagdaSamplerPlugin::reset() {
     synthesiser.allNotesOff(0, false);
 }
 
-double MagdaSamplerPlugin::getTailLength() const {
-    return releaseValue.get();
+void MagdaSamplerPlugin::updateVoiceParameters() {
+    const float attack = displayValue(kAttack);
+    const float decay = displayValue(kDecay);
+    const float sustain = displayValue(kSustain);
+    const float release = displayValue(kRelease);
+
+    const float pitch = displayValue(kPitch);
+    const float fine = displayValue(kFine);
+
+    const double sourceSR = (currentSound != nullptr) ? currentSound->sourceSampleRate : 44100.0;
+    const double lengthSeconds = (currentSound != nullptr && currentSound->hasData())
+                                     ? currentSound->audioData.getNumSamples() / sourceSR
+                                     : 0.0;
+    const auto maxSec = static_cast<float>(lengthSeconds);
+
+    const float sStart = juce::jlimit(0.0f, maxSec, displayValue(kSampleStart));
+    const float sEnd = juce::jlimit(0.0f, maxSec, displayValue(kSampleEnd));
+    const bool loopOn = loopEnabled_.load(std::memory_order_relaxed);
+    const float lStart = juce::jlimit(0.0f, maxSec, displayValue(kLoopStart));
+    const float lEnd = juce::jlimit(0.0f, maxSec, displayValue(kLoopEnd));
+
+    const float velAmt = displayValue(kVelAmount);
+
+    const int voiceMode =
+        juce::jlimit(0, 2, static_cast<int>(std::lround(displayValue(kVoiceMode))));
+    const double glideSeconds = displayValue(kGlide) / 1000.0;
+    synthesiser.setVoiceMode(voiceMode);
+    synthesiser.setGlideSeconds(glideSeconds);
+
+    for (int i = 0; i < synthesiser.getNumVoices(); ++i) {
+        if (auto* voice = dynamic_cast<SamplerVoice*>(synthesiser.getVoice(i))) {
+            voice->setADSR(attack, decay, sustain, release);
+            voice->setPitchOffset(pitch, fine);
+            voice->setPlaybackRegion(sStart, sEnd, loopOn, lStart, lEnd, sourceSR);
+            voice->setVelocityAmount(velAmt);
+        }
+    }
 }
 
-void MagdaSamplerPlugin::loadSample(const juce::File& file) {
-    juce::AudioFormatManager formatManager;
-    formatManager.registerBasicFormats();
+void MagdaSamplerPlugin::process(DeviceProcessContext& context) {
+    if (context.audio == nullptr)
+        return;
 
-    std::unique_ptr<juce::AudioFormatReader> reader(formatManager.createReaderFor(file));
+    updateVoiceParameters();
+
+    const float levelLinear = juce::Decibels::decibelsToGain(displayValue(kLevel));
+
+    // Device MIDI timestamps are block-relative seconds — convert to a sample
+    // offset within the block. Deduplicate on note AND sample position, because
+    // several input devices can route the same message at the same instant.
+    juce::MidiBuffer midiBuffer;
+    if (context.midi != nullptr) {
+        struct SeenKey {
+            int note;
+            int samplePos;
+            bool isNoteOn;
+            bool operator==(const SeenKey& o) const {
+                return note == o.note && samplePos == o.samplePos && isNoteOn == o.isNoteOn;
+            }
+        };
+        juce::Array<SeenKey> seen;
+
+        for (int i = 0; i < context.midi->size(); ++i) {
+            const auto& m = context.midi->message(i);
+            int midiPos = juce::roundToInt(m.getTimeStamp() * sampleRate);
+            midiPos = juce::jlimit(0, juce::jmax(0, context.numSamples - 1), midiPos);
+
+            if (m.isNoteOn() || m.isNoteOff()) {
+                const SeenKey key{m.getNoteNumber(), midiPos, m.isNoteOn()};
+                if (seen.contains(key))
+                    continue;
+                seen.add(key);
+            }
+
+            midiBuffer.addEvent(m, midiPos + context.startSample);
+        }
+    }
+
+    synthesiser.renderNextBlock(*context.audio, midiBuffer, context.startSample,
+                                context.numSamples);
+
+    context.audio->applyGain(context.startSample, context.numSamples, levelLinear);
+
+    // Playhead position from the first sounding voice.
+    const double sourceSR = (currentSound != nullptr) ? currentSound->sourceSampleRate : 44100.0;
+    bool foundActive = false;
+    for (int i = 0; i < synthesiser.getNumVoices(); ++i) {
+        if (auto* voice = dynamic_cast<SamplerVoice*>(synthesiser.getVoice(i))) {
+            if (voice->isVoiceActive()) {
+                currentPlaybackPosition_.store(voice->getSourceSamplePosition() / sourceSR,
+                                               std::memory_order_relaxed);
+                foundActive = true;
+                break;
+            }
+        }
+    }
+    if (!foundActive)
+        currentPlaybackPosition_.store(0.0, std::memory_order_relaxed);
+}
+
+//==============================================================================
+void MagdaSamplerPlugin::flushState(juce::ValueTree& state) {
+    // Parameters are the model's (#2317); what the device owns here is the
+    // sample it points at and how to read it.
+    state.setProperty(StateIDs::source, samplePath_, nullptr);
+    state.setProperty(StateIDs::rootNote, rootNote_, nullptr);
+    state.setProperty(StateIDs::loopEnabled, loopEnabled_.load(std::memory_order_relaxed), nullptr);
+}
+
+void MagdaSamplerPlugin::restoreState(const juce::ValueTree& state) {
+    if (const auto* value = state.getPropertyPointer(StateIDs::loopEnabled))
+        loopEnabled_.store(static_cast<bool>(*value), std::memory_order_relaxed);
+
+    const int savedRootNote = state.getPropertyPointer(StateIDs::rootNote) != nullptr
+                                  ? static_cast<int>(state[StateIDs::rootNote])
+                                  : 60;
+
+    const auto savedPath = state.getPropertyPointer(StateIDs::source) != nullptr
+                               ? state[StateIDs::source].toString()
+                               : juce::String();
+
+    // The document is the whole authored state, so no source MEANS no sample:
+    // restoring a document saved before the sample was chosen has to unload it,
+    // or the model says "empty" while playback keeps sounding the old audio.
+    if (savedPath.isEmpty()) {
+        unloadSample();
+        return;
+    }
+
+    // loadSample() re-derives the markers from the file, which is right for a
+    // newly chosen sample and wrong here: the document's markers are the
+    // authored ones. Take them back afterwards.
+    const float savedStart = displayValue(kSampleStart);
+    const float savedEnd = displayValue(kSampleEnd);
+    const float savedLoopStart = displayValue(kLoopStart);
+    const float savedLoopEnd = displayValue(kLoopEnd);
+
+    const juce::File file(savedPath);
+    if (file.existsAsFile()) {
+        loadSample(file);
+    } else {
+        // The path is still what the project authored — a missing file is a
+        // relocate away, not a reason to forget which sample this pad holds.
+        samplePath_ = savedPath;
+    }
+
+    setRootNote(savedRootNote);
+
+    const auto maxLen = static_cast<float>(getSampleLengthSeconds());
+    const auto restore = [this, maxLen](int index, float saved) {
+        if (saved > 0.001f && (maxLen <= 0.0f || saved < maxLen))
+            setDisplayValue(index, saved);
+    };
+    restore(kSampleStart, savedStart);
+    restore(kSampleEnd, savedEnd);
+    restore(kLoopStart, savedLoopStart);
+    restore(kLoopEnd, savedLoopEnd);
+}
+
+//==============================================================================
+void MagdaSamplerPlugin::loadSample(const juce::File& file) {
+    std::unique_ptr<juce::AudioFormatReader> reader(sampleFormats().createReaderFor(file));
     if (reader == nullptr)
         return;
 
@@ -551,10 +707,10 @@ void MagdaSamplerPlugin::loadSample(const juce::File& file) {
     else if (metadata.containsKey("smpl_MIDIUnityNote"))
         detectedRootNote = metadata.getValue("smpl_MIDIUnityNote", "60").getIntValue();
 
-    double sourceSR = reader->sampleRate;
+    const double sourceSR = reader->sampleRate;
 
-    // Swap in a new sound — synthesiser manages ownership
-    // clearSounds/addSound internally lock the synthesiser
+    // Swap in a new sound — synthesiser manages ownership, and
+    // clearSounds/addSound take its lock, so a sounding voice is stopped first.
     auto* newSound = new SamplerSound();
     newSound->audioData = std::move(newBuffer);
     newSound->sourceSampleRate = sourceSR;
@@ -564,33 +720,37 @@ void MagdaSamplerPlugin::loadSample(const juce::File& file) {
     synthesiser.addSound(newSound);
     currentSound = newSound;
 
-    // Update state
-    samplePathValue = file.getFullPathName();
-    rootNoteValue = detectedRootNote;
+    samplePath_ = file.getFullPathName();
+    rootNote_ = detectedRootNote;
 
-    // Reset markers to defaults for new sample loads, preserve on restore
-    double lengthSeconds = static_cast<double>(newSound->audioData.getNumSamples()) / sourceSR;
-    float maxLen = static_cast<float>(lengthSeconds);
-    float endClamped = juce::jmin(maxLen, sampleEndParam->getValueRange().getEnd());
-    float loopEndClamped = juce::jmin(maxLen, loopEndParam->getValueRange().getEnd());
-    sampleStartParam->setParameterFromHost(0.0f, juce::dontSendNotification);
-    sampleStartValue = 0.0f;
-    sampleEndParam->setParameterFromHost(endClamped, juce::dontSendNotification);
-    sampleEndValue = endClamped;
-    loopStartParam->setParameterFromHost(0.0f, juce::dontSendNotification);
-    loopStartValue = 0.0f;
-    loopEndParam->setParameterFromHost(loopEndClamped, juce::dontSendNotification);
-    loopEndValue = loopEndClamped;
+    // Markers reset to span the new sample. restoreState() puts the authored
+    // ones back over the top; a user-chosen sample keeps these.
+    const double lengthSeconds =
+        static_cast<double>(newSound->audioData.getNumSamples()) / sourceSR;
+    const auto maxLen = static_cast<float>(lengthSeconds);
+    setDisplayValue(kSampleStart, 0.0f);
+    setDisplayValue(kSampleEnd, juce::jmin(maxLen, slotInfo(kSampleEnd).maxValue));
+    setDisplayValue(kLoopStart, 0.0f);
+    setDisplayValue(kLoopEnd, juce::jmin(maxLen, slotInfo(kLoopEnd).maxValue));
+}
+
+void MagdaSamplerPlugin::unloadSample() {
+    auto* empty = new SamplerSound();
+    synthesiser.clearSounds();
+    synthesiser.addSound(empty);
+    currentSound = empty;
+    samplePath_.clear();
+    rootNote_ = 60;
 }
 
 void MagdaSamplerPlugin::relocateSample(const juce::File& file) {
     // See the header: the audio is unchanged, only its path moved, so how the
     // user set the sampler up to interpret it has to survive the reload.
-    const int savedRootNote = rootNoteValue.get();
-    const float savedStart = sampleStartValue.get();
-    const float savedEnd = sampleEndValue.get();
-    const float savedLoopStart = loopStartValue.get();
-    const float savedLoopEnd = loopEndValue.get();
+    const int savedRootNote = rootNote_;
+    const float savedStart = displayValue(kSampleStart);
+    const float savedEnd = displayValue(kSampleEnd);
+    const float savedLoopStart = displayValue(kLoopStart);
+    const float savedLoopEnd = displayValue(kLoopEnd);
 
     loadSample(file);
 
@@ -604,20 +764,14 @@ void MagdaSamplerPlugin::relocateSample(const juce::File& file) {
     // Same audio means the saved markers still fit, but clamp anyway rather
     // than trust that the file on the other end is byte-identical.
     const auto maxLen = static_cast<float>(getSampleLengthSeconds());
-    const auto restore = [maxLen](const te::AutomatableParameter::Ptr& param,
-                                  juce::CachedValue<float>& cached, float saved) {
-        const float clamped = clampToParameterRange(param, juce::jmin(saved, maxLen));
-        param->setParameterFromHost(clamped, juce::dontSendNotification);
-        cached = clamped;
-    };
-    restore(sampleStartParam, sampleStartValue, savedStart);
-    restore(sampleEndParam, sampleEndValue, savedEnd);
-    restore(loopStartParam, loopStartValue, savedLoopStart);
-    restore(loopEndParam, loopEndValue, savedLoopEnd);
+    setDisplayValue(kSampleStart, juce::jmin(savedStart, maxLen));
+    setDisplayValue(kSampleEnd, juce::jmin(savedEnd, maxLen));
+    setDisplayValue(kLoopStart, juce::jmin(savedLoopStart, maxLen));
+    setDisplayValue(kLoopEnd, juce::jmin(savedLoopEnd, maxLen));
 }
 
 juce::File MagdaSamplerPlugin::getSampleFile() const {
-    return juce::File(samplePathValue.get());
+    return juce::File(samplePath_);
 }
 
 const juce::AudioBuffer<float>* MagdaSamplerPlugin::getWaveform() const {
@@ -640,210 +794,15 @@ double MagdaSamplerPlugin::getSampleRate() const {
 }
 
 int MagdaSamplerPlugin::getRootNote() const {
-    return rootNoteValue.get();
+    return rootNote_;
 }
 
 void MagdaSamplerPlugin::setRootNote(int note) {
-    rootNoteValue = juce::jlimit(0, 127, note);
+    rootNote_ = juce::jlimit(0, 127, note);
     // rootNote is only read in startNote (not in renderNextBlock hot path),
-    // so a simple atomic-style write is safe here
+    // so a plain write is safe here.
     if (currentSound != nullptr)
-        currentSound->rootNote = rootNoteValue.get();
-}
-
-void MagdaSamplerPlugin::syncCachedValueFromParam(int paramIndex) {
-    auto params = getAutomatableParameters();
-    if (paramIndex < 0 || paramIndex >= params.size())
-        return;
-
-    float value = params[paramIndex]->getCurrentBaseValue();
-
-    // Map param index to the corresponding CachedValue
-    // Order: attack(0), decay(1), sustain(2), release(3), pitch(4), fine(5), level(6),
-    //        sampleStart(7), sampleEnd(8), loopStart(9), loopEnd(10), velAmount(11),
-    //        voiceMode(12), glide(13)
-    switch (paramIndex) {
-        case 0:
-            attackValue = value;
-            break;
-        case 1:
-            decayValue = value;
-            break;
-        case 2:
-            sustainValue = value;
-            break;
-        case 3:
-            releaseValue = value;
-            break;
-        case 4:
-            pitchValue = value;
-            break;
-        case 5:
-            fineValue = value;
-            break;
-        case 6:
-            levelValue = value;
-            break;
-        case 7:
-            sampleStartValue = value;
-            break;
-        case 8:
-            sampleEndValue = value;
-            break;
-        case 9:
-            loopStartValue = value;
-            break;
-        case 10:
-            loopEndValue = value;
-            break;
-        case 11:
-            velAmountValue = value;
-            break;
-        case 12:
-            voiceModeValue = value;
-            break;
-        case 13:
-            glideValue = value;
-            break;
-        default:
-            break;
-    }
-}
-
-void MagdaSamplerPlugin::updateVoiceParameters() {
-    float attack = juce::jlimit(0.001f, 5.0f, attackParam->getCurrentValue());
-    float decay = juce::jlimit(0.001f, 5.0f, decayParam->getCurrentValue());
-    float sustain = juce::jlimit(0.0f, 1.0f, sustainParam->getCurrentValue());
-    float release = juce::jlimit(0.001f, 10.0f, releaseParam->getCurrentValue());
-
-    float pitch = juce::jlimit(-24.0f, 24.0f, pitchParam->getCurrentValue());
-    float fine = juce::jlimit(-100.0f, 100.0f, fineParam->getCurrentValue());
-
-    double sourceSR = (currentSound != nullptr) ? currentSound->sourceSampleRate : 44100.0;
-    double lengthSeconds = (currentSound != nullptr && currentSound->hasData())
-                               ? currentSound->audioData.getNumSamples() / sourceSR
-                               : 0.0;
-    float maxSec = static_cast<float>(lengthSeconds);
-
-    float sStart = juce::jlimit(0.0f, maxSec, sampleStartParam->getCurrentValue());
-    float sEnd = juce::jlimit(0.0f, maxSec, sampleEndParam->getCurrentValue());
-    bool loopOn = loopEnabledAtomic.load(std::memory_order_relaxed);
-    float lStart = juce::jlimit(0.0f, maxSec, loopStartParam->getCurrentValue());
-    float lEnd = juce::jlimit(0.0f, maxSec, loopEndParam->getCurrentValue());
-
-    float velAmt = juce::jlimit(0.0f, 1.0f, velAmountParam->getCurrentValue());
-
-    const int voiceMode =
-        juce::jlimit(0, 2, static_cast<int>(std::lround(voiceModeParam->getCurrentValue())));
-    const double glideSeconds = juce::jlimit(0.0f, 2000.0f, glideParam->getCurrentValue()) / 1000.0;
-    synthesiser.setVoiceMode(voiceMode);
-    synthesiser.setGlideSeconds(glideSeconds);
-
-    for (int i = 0; i < synthesiser.getNumVoices(); ++i) {
-        if (auto* voice = dynamic_cast<SamplerVoice*>(synthesiser.getVoice(i))) {
-            voice->setADSR(attack, decay, sustain, release);
-            voice->setPitchOffset(pitch, fine);
-            voice->setPlaybackRegion(sStart, sEnd, loopOn, lStart, lEnd, sourceSR);
-            voice->setVelocityAmount(velAmt);
-        }
-    }
-}
-
-void MagdaSamplerPlugin::applyToBuffer(const te::PluginRenderContext& fc) {
-    if (fc.destBuffer == nullptr)
-        return;
-
-    updateVoiceParameters();
-
-    float levelDb = levelParam->getCurrentValue();
-    float levelLinear = juce::Decibels::decibelsToGain(levelDb);
-
-    // Convert MidiMessageArray to juce::MidiBuffer for synthesiser
-    // TE timestamps are block-relative seconds — convert to sample offset within the block
-    // Deduplicate MIDI events (multiple input devices can route the same message)
-    juce::MidiBuffer midiBuffer;
-    if (fc.bufferForMidiMessages != nullptr && !fc.bufferForMidiMessages->isEmpty()) {
-        // Deduplicate: only drop events that match note number AND sample position
-        // (multiple input devices can route the same message at the same time)
-        struct SeenKey {
-            int note;
-            int samplePos;
-            bool isNoteOn;
-            bool operator==(const SeenKey& o) const {
-                return note == o.note && samplePos == o.samplePos && isNoteOn == o.isNoteOn;
-            }
-        };
-        juce::Array<SeenKey> seen;
-
-        for (auto& m : *fc.bufferForMidiMessages) {
-            int midiPos = juce::roundToInt(m.getTimeStamp() * sampleRate);
-            midiPos = juce::jlimit(0, fc.bufferNumSamples - 1, midiPos);
-
-            if (m.isNoteOn() || m.isNoteOff()) {
-                SeenKey key{m.getNoteNumber(), midiPos, m.isNoteOn()};
-                if (seen.contains(key))
-                    continue;
-                seen.add(key);
-            }
-
-            midiBuffer.addEvent(m, midiPos + fc.bufferStartSample);
-        }
-    }
-
-    synthesiser.renderNextBlock(*fc.destBuffer, midiBuffer, fc.bufferStartSample,
-                                fc.bufferNumSamples);
-
-    fc.destBuffer->applyGain(fc.bufferStartSample, fc.bufferNumSamples, levelLinear);
-
-    // Update playhead position from first active voice
-    double sourceSR = (currentSound != nullptr) ? currentSound->sourceSampleRate : 44100.0;
-    bool foundActive = false;
-    for (int i = 0; i < synthesiser.getNumVoices(); ++i) {
-        if (auto* voice = dynamic_cast<SamplerVoice*>(synthesiser.getVoice(i))) {
-            if (voice->isVoiceActive()) {
-                currentPlaybackPosition.store(voice->getSourceSamplePosition() / sourceSR,
-                                              std::memory_order_relaxed);
-                foundActive = true;
-                break;
-            }
-        }
-    }
-    if (!foundActive)
-        currentPlaybackPosition.store(0.0, std::memory_order_relaxed);
-}
-
-void MagdaSamplerPlugin::restorePluginStateFromValueTree(const juce::ValueTree& v) {
-    te::copyPropertiesToCachedValues(
-        v, attackValue, decayValue, sustainValue, releaseValue, pitchValue, fineValue, levelValue,
-        sampleStartValue, sampleEndValue, loopStartValue, loopEndValue, voiceModeValue, glideValue);
-
-    attackValue = clampToParameterRange(attackParam, attackValue.get());
-    decayValue = clampToParameterRange(decayParam, decayValue.get());
-    sustainValue = clampToParameterRange(sustainParam, sustainValue.get());
-    releaseValue = clampToParameterRange(releaseParam, releaseValue.get());
-
-    // Handle non-float CachedValues separately to avoid MSVC C2440 ambiguity
-    // with var -> String conversion in TE's copyPropertiesToCachedValues
-    if (auto p = v.getPropertyPointer(samplePathValue.getPropertyID()))
-        samplePathValue = p->toString();
-    else
-        samplePathValue.resetToDefault();
-    te::copyPropertiesToCachedValues(v, rootNoteValue, loopEnabledValue, velAmountValue);
-    loopEnabledAtomic.store(loopEnabledValue.get(), std::memory_order_relaxed);
-
-    for (auto p : getAutomatableParameters())
-        p->updateFromAttachedValue();
-
-    // Reload sample if path is set
-    juce::String path = samplePathValue.get();
-    if (path.isNotEmpty()) {
-        int savedRootNote = rootNoteValue.get();
-        juce::File file(path);
-        if (file.existsAsFile())
-            loadSample(file);
-        // Restore root note (loadSample overwrites with detected metadata)
-        setRootNote(savedRootNote);
-    }
+        currentSound->rootNote = rootNote_;
 }
 
 }  // namespace magda::daw::audio

--- a/magda/daw/audio/plugins/MagdaSamplerPlugin.hpp
+++ b/magda/daw/audio/plugins/MagdaSamplerPlugin.hpp
@@ -1,12 +1,15 @@
 #pragma once
 
-#include <tracktion_engine/tracktion_engine.h>
+#include <juce_audio_utils/juce_audio_utils.h>
 
+#include <array>
+#include <atomic>
 #include <vector>
 
-namespace magda::daw::audio {
+#include "core/ParameterUtils.hpp"
+#include "plugins/MagdaDevice.hpp"
 
-namespace te = tracktion::engine;
+namespace magda::daw::audio {
 
 //==============================================================================
 /**
@@ -133,12 +136,54 @@ class SamplerSynth : public juce::Synthesiser {
 
 //==============================================================================
 /**
- * @brief Sample-based instrument plugin with ADSR, pitch/fine, and level controls
+ * @brief Sample-based instrument device with ADSR, pitch/fine, and level controls.
+ *
+ * A MagdaDevice since #2271: one DSP hosted by whichever engine is running it.
+ * Every Drum Grid pad holds one, so until it crossed, a drum kit built the
+ * ordinary way rendered as passthrough under the native engine.
+ *
+ * The slot ids, order and display ranges are the ones the retired host-native
+ * plugin registered, so saved automation, macro links and mod links survive
+ * the migration untouched.
+ *
+ * The sample is referenced by PATH, not embedded: unlike the IR the
+ * convolution device carries in its own state, a sample is arbitrarily large
+ * and the project media tree already owns relocating it (relocateSample).
  */
-class MagdaSamplerPlugin : public te::Plugin {
+class MagdaSamplerPlugin : public MagdaDevice {
   public:
-    MagdaSamplerPlugin(const te::PluginCreationInfo&);
+    MagdaSamplerPlugin();
     ~MagdaSamplerPlugin() override;
+
+    //==============================================================================
+    /// FROZEN parameter order — the compatibility surface saved automation,
+    /// macro and mod links address, and the order `syncCachedValueFromParam()`
+    /// documented on the retired plugin.
+    enum ParamIndex {
+        kAttack = 0,
+        kDecay,
+        kSustain,
+        kRelease,
+        kPitch,
+        kFine,
+        kLevel,
+        kSampleStart,
+        kSampleEnd,
+        kLoopStart,
+        kLoopEnd,
+        kVelAmount,
+        kVoiceMode,
+        kGlide,
+        kNumParams,
+    };
+
+    /// The device's own non-parameter state. The spellings are the retired
+    /// plugin's, so a saved project reads its sample back.
+    struct StateIDs {
+        static const juce::Identifier source;
+        static const juce::Identifier rootNote;
+        static const juce::Identifier loopEnabled;
+    };
 
     //==============================================================================
     static const char* getPluginName() {
@@ -146,49 +191,45 @@ class MagdaSamplerPlugin : public te::Plugin {
     }
     static const char* xmlTypeName;
 
-    juce::String getName() const override {
-        return getPluginName();
-    }
-    juce::String getPluginType() override {
-        return xmlTypeName;
-    }
-    juce::String getShortName(int) override {
-        return "Sampler";
-    }
-    juce::String getSelectableDescription() override {
-        return getName();
+    DeviceProperties properties() const override {
+        return {
+            .pluginId = xmlTypeName,
+            .name = getPluginName(),
+            .shortName = "Sampler",
+            .takesMidiInput = true,
+            .takesAudioInput = false,
+            .isSynth = true,
+            .producesAudioWithoutInput = true,
+            // A released voice rings for the length of its release stage, so an
+            // offline render or a freeze keeps the tail instead of cutting it
+            // at the last note-off.
+            .tailLengthSeconds = tailSeconds_.load(std::memory_order_relaxed),
+        };
     }
 
-    //==============================================================================
-    void initialise(const te::PluginInitialisationInfo&) override;
-    void deinitialise() override;
+    void prepare(const DevicePrepareContext& context) override;
+    void release() override;
     void reset() override;
+    void process(DeviceProcessContext& context) override;
 
-    void applyToBuffer(const te::PluginRenderContext&) override;
+    int parameterCount() const override {
+        return kNumParams;
+    }
+    ParameterInfo parameterInfo(int index) const override;
+    float parameterValue(int index) const override;
+    void setParameterValue(int index, float value) override;
+
+    /// One slot's value in its own display units (seconds, dB, semitones).
+    /// What the custom UI draws markers from, and what the retired plugin's
+    /// CachedValues held.
+    float displayValue(int index) const;
+    void setDisplayValue(int index, float value);
+
+    void flushState(juce::ValueTree& state) override;
+    void restoreState(const juce::ValueTree& state) override;
 
     //==============================================================================
-    bool takesMidiInput() override {
-        return true;
-    }
-    bool takesAudioInput() override {
-        return false;
-    }
-    bool isSynth() override {
-        return true;
-    }
-    bool producesAudioWhenNoAudioInput() override {
-        return true;
-    }
-    double getTailLength() const override;
-
-    void restorePluginStateFromValueTree(const juce::ValueTree&) override;
-
-    //==============================================================================
-    // Sync CachedValue from current AutomatableParameter value (for persistence)
-    void syncCachedValueFromParam(int paramIndex);
-
-    //==============================================================================
-    // Sample loading
+    // Sample loading. Message thread only.
     void loadSample(const juce::File& file);
 
     /**
@@ -210,40 +251,44 @@ class MagdaSamplerPlugin : public te::Plugin {
     int getRootNote() const;
     void setRootNote(int note);
 
-    //==============================================================================
-    // Automatable parameters
-    juce::CachedValue<float> attackValue, decayValue, sustainValue, releaseValue;
-    juce::CachedValue<float> pitchValue, fineValue, levelValue;
-    juce::CachedValue<float> sampleStartValue, sampleEndValue, loopStartValue, loopEndValue;
-    juce::CachedValue<float> velAmountValue;
-    juce::CachedValue<float> voiceModeValue, glideValue;
+    /// Loop on/off. Never a parameter on the retired plugin either — the
+    /// faceplate writes it and it persists as device state.
+    bool loopEnabled() const {
+        return loopEnabled_.load(std::memory_order_relaxed);
+    }
+    void setLoopEnabled(bool enabled) {
+        loopEnabled_.store(enabled, std::memory_order_relaxed);
+    }
 
-    te::AutomatableParameter::Ptr attackParam, decayParam, sustainParam, releaseParam;
-    te::AutomatableParameter::Ptr pitchParam, fineParam, levelParam;
-    te::AutomatableParameter::Ptr sampleStartParam, sampleEndParam, loopStartParam, loopEndParam;
-    te::AutomatableParameter::Ptr velAmountParam;
-    te::AutomatableParameter::Ptr voiceModeParam, glideParam;
-
-    // Non-parameter state
-    juce::CachedValue<juce::String> samplePathValue;
-    juce::CachedValue<int> rootNoteValue;
-    juce::CachedValue<bool> loopEnabledValue;    // persisted state (message thread only)
-    std::atomic<bool> loopEnabledAtomic{false};  // audio-thread-safe mirror
-
-    // Playhead position (written by audio thread, read by UI)
-    std::atomic<double> currentPlaybackPosition{0.0};
+    /// Where in the sample the first sounding voice is, in seconds. Written by
+    /// the audio thread, read by the UI.
     double getPlaybackPosition() const {
-        return currentPlaybackPosition.load(std::memory_order_relaxed);
+        return currentPlaybackPosition_.load(std::memory_order_relaxed);
     }
 
   private:
     //==============================================================================
+    void updateVoiceParameters();
+    /// Put the synthesiser back to holding no audio. What an authored document
+    /// with no source means (see restoreState).
+    void unloadSample();
+
     SamplerSynth synthesiser;
     SamplerSound* currentSound = nullptr;  // owned by synthesiser
     double sampleRate = 44100.0;
     int numVoices = 8;
 
-    void updateVoiceParameters();
+    // Normalised slot values. The audio thread reads them every block while the
+    // message thread writes them, so they are atomics rather than plain floats.
+    std::array<std::atomic<float>, kNumParams> values_{};
+    std::array<ParameterUtils::ParameterDomain, kNumParams> domains_{};
+
+    std::atomic<bool> loopEnabled_{false};
+    std::atomic<double> tailSeconds_{0.1};
+    std::atomic<double> currentPlaybackPosition_{0.0};
+
+    juce::String samplePath_;
+    int rootNote_ = 60;
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(MagdaSamplerPlugin)
 };

--- a/magda/daw/audio/plugins/tracktion/SamplerHostBinding.hpp
+++ b/magda/daw/audio/plugins/tracktion/SamplerHostBinding.hpp
@@ -1,0 +1,61 @@
+#pragma once
+
+#include "core/ParameterUtils.hpp"
+#include "plugins/MagdaSamplerPlugin.hpp"
+#include "plugins/tracktion/TracktionMagdaDevicePlugin.hpp"
+
+namespace magda::daw::audio::tracktion_adapter {
+
+/**
+ * @brief Driving a sampler that sits inside the host's device wrapper.
+ *
+ * Callers work in display units and the wrapper's parameters are normalised.
+ * A write goes to BOTH sides: `syncParametersToDevice()` pushes on every
+ * `applyToBuffer`, so a write to the device alone is undone at the next render,
+ * and the device holds the value between renders, so a write to the parameter
+ * alone is invisible until one happens. A load travels the other way — the
+ * device derives the markers — and is pulled back.
+ */
+
+inline float samplerSlotDisplayValue(const te::Plugin& plugin, int index) {
+    const auto* sampler = deviceFromPlugin<MagdaSamplerPlugin>(&plugin);
+    return sampler != nullptr ? sampler->displayValue(index) : 0.0f;
+}
+
+/// setParameterFromHost, not setParameter: the latter is silently dropped once
+/// a macro or mod is attached to the parameter.
+inline void setSamplerSlotDisplayValue(te::Plugin& plugin, int index, float displayValue,
+                                       juce::NotificationType notification) {
+    auto* sampler = deviceFromPlugin<MagdaSamplerPlugin>(&plugin);
+    if (sampler == nullptr || index < 0 || index >= MagdaSamplerPlugin::kNumParams)
+        return;
+
+    const float normalized =
+        ParameterUtils::realToNormalized(displayValue, sampler->parameterInfo(index));
+
+    if (auto* wrapper = dynamic_cast<TracktionMagdaDevicePlugin*>(&plugin)) {
+        if (auto* parameter = wrapper->parameterForDeviceSlot(index))
+            parameter->setParameterFromHost(normalized, notification);
+    }
+    sampler->setParameterValue(index, normalized);
+}
+
+/// Load @p file into the sampler and take the markers it derived from the audio
+/// back into the host's parameters. Message thread only.
+inline void loadSamplerSample(te::Plugin& plugin, const juce::File& file) {
+    if (auto* sampler = deviceFromPlugin<MagdaSamplerPlugin>(&plugin))
+        sampler->loadSample(file);
+    if (auto* wrapper = dynamic_cast<TracktionMagdaDevicePlugin*>(&plugin))
+        wrapper->pullParametersFromDevice();
+}
+
+/// The same, for a file that merely moved: the sampler puts the root note and
+/// markers back rather than re-deriving them. Message thread only.
+inline void relocateSamplerSample(te::Plugin& plugin, const juce::File& file) {
+    if (auto* sampler = deviceFromPlugin<MagdaSamplerPlugin>(&plugin))
+        sampler->relocateSample(file);
+    if (auto* wrapper = dynamic_cast<TracktionMagdaDevicePlugin*>(&plugin))
+        wrapper->pullParametersFromDevice();
+}
+
+}  // namespace magda::daw::audio::tracktion_adapter

--- a/magda/daw/audio/processors/internal/NativeDeviceProcessors.cpp
+++ b/magda/daw/audio/processors/internal/NativeDeviceProcessors.cpp
@@ -17,7 +17,7 @@ namespace magda {
 // =============================================================================
 
 MagdaSamplerProcessor::MagdaSamplerProcessor(DeviceId deviceId, te::Plugin::Ptr plugin)
-    : AutomatablePluginProcessor(deviceId, std::move(plugin)) {}
+    : MagdaDeviceProcessor(deviceId, std::move(plugin)) {}
 
 MutableElementsProcessor::MutableElementsProcessor(DeviceId deviceId, te::Plugin::Ptr plugin)
     : MagdaDeviceProcessor(deviceId, std::move(plugin)) {}

--- a/magda/daw/audio/processors/internal/NativeDeviceProcessors.hpp
+++ b/magda/daw/audio/processors/internal/NativeDeviceProcessors.hpp
@@ -32,11 +32,12 @@ struct FourOscPluginState {
 };
 
 /**
- * @brief Processor for the built-in Magda Sampler device
+ * @brief Processor for the built-in Magda Sampler device.
  *
- * Sets parameters directly on the MagdaSamplerPlugin's automatable parameters by index.
+ * The sampler is a MagdaDevice (#2271), so the chain holds the host's wrapper
+ * and the display metadata comes from the device's own slots.
  */
-class MagdaSamplerProcessor : public AutomatablePluginProcessor {
+class MagdaSamplerProcessor : public MagdaDeviceProcessor {
   public:
     MagdaSamplerProcessor(DeviceId deviceId, te::Plugin::Ptr plugin);
 };

--- a/magda/daw/audio/sampling/SamplerFileLoader.cpp
+++ b/magda/daw/audio/sampling/SamplerFileLoader.cpp
@@ -3,6 +3,7 @@
 #include "core/ChainNodePath.hpp"
 #include "plugin_manager/PluginManager.hpp"
 #include "plugins/MagdaSamplerPlugin.hpp"
+#include "plugins/tracktion/SamplerHostBinding.hpp"
 
 namespace magda {
 
@@ -14,11 +15,11 @@ bool SamplerFileLoader::loadSample(const ChainNodePath& devicePath, const juce::
     if (!plugin)
         return false;
 
-    auto* sampler = dynamic_cast<daw::audio::MagdaSamplerPlugin*>(plugin.get());
-    if (!sampler)
+    if (daw::audio::tracktion_adapter::deviceFromPlugin<daw::audio::MagdaSamplerPlugin>(
+            plugin.get()) == nullptr)
         return false;
 
-    sampler->loadSample(file);
+    daw::audio::tracktion_adapter::loadSamplerSample(*plugin, file);
     return true;
 }
 

--- a/magda/daw/engine/TracktionEngineWrapper.cpp
+++ b/magda/daw/engine/TracktionEngineWrapper.cpp
@@ -3,6 +3,7 @@
 #include "../audio/AudioBridge.hpp"
 #include "../audio/plugins/DrumGridPlugin.hpp"
 #include "../audio/plugins/MagdaSamplerPlugin.hpp"
+#include "../audio/plugins/tracktion/SamplerHostBinding.hpp"
 #include "../audio/session/SessionClipAudioMonitor.hpp"
 #include "../audio/session/SessionClipScheduler.hpp"
 
@@ -104,17 +105,19 @@ std::vector<SamplerMediaReference> TracktionEngineWrapper::getSamplerMediaRefere
         return references;
 
     auto addSampler = [&references](tracktion::Plugin* plugin) {
-        auto* sampler = dynamic_cast<daw::audio::MagdaSamplerPlugin*>(plugin);
+        auto* sampler =
+            daw::audio::tracktion_adapter::deviceFromPlugin<daw::audio::MagdaSamplerPlugin>(plugin);
         if (sampler == nullptr)
             return;
-        tracktion::Plugin::Ptr keepAlive(sampler);
-        references.push_back(
-            {sampler->getSampleFile(), [keepAlive](const juce::File& replacement) {
-                 // relocateSample, not loadSample: the file moved, the user's
-                 // root note and trim/loop markers did not.
-                 if (auto* live = dynamic_cast<daw::audio::MagdaSamplerPlugin*>(keepAlive.get()))
-                     live->relocateSample(replacement);
-             }});
+        // The PLUGIN is what is reference counted; the device lives inside it.
+        tracktion::Plugin::Ptr keepAlive(plugin);
+        references.push_back({sampler->getSampleFile(), [keepAlive](const juce::File& replacement) {
+                                  // relocateSamplerSample, not loadSamplerSample: the file
+                                  // moved, the user's root note and trim/loop markers did not.
+                                  if (keepAlive != nullptr)
+                                      daw::audio::tracktion_adapter::relocateSamplerSample(
+                                          *keepAlive, replacement);
+                              }});
     };
 
     for (auto plugin : tracktion::getAllPlugins(*currentEdit_, true)) {

--- a/magda/daw/ui/components/chain/drum_grid/PadChainPanel.cpp
+++ b/magda/daw/ui/components/chain/drum_grid/PadChainPanel.cpp
@@ -3,6 +3,7 @@
 #include <tracktion_engine/tracktion_engine.h>
 
 #include "audio/plugins/MagdaSamplerPlugin.hpp"
+#include "audio/plugins/tracktion/TracktionMagdaDevicePlugin.hpp"
 #include "core/TrackManager.hpp"
 #include "ui/themes/DarkTheme.hpp"
 #include "ui/themes/FontManager.hpp"
@@ -239,7 +240,7 @@ void PadChainPanel::rebuildSlots() {
 
         // Set plugin content
         if (info.isSampler) {
-            slot->setSampler(dynamic_cast<daw::audio::MagdaSamplerPlugin*>(info.plugin));
+            slot->setSampler(info.plugin);
         } else if (info.plugin) {
             slot->setPlugin(info.plugin, info.device, info.livePlugin);
         }

--- a/magda/daw/ui/components/chain/drum_grid/PadDeviceSlot.cpp
+++ b/magda/daw/ui/components/chain/drum_grid/PadDeviceSlot.cpp
@@ -4,6 +4,8 @@
 #include <tracktion_engine/tracktion_engine.h>
 
 #include "audio/plugins/MagdaSamplerPlugin.hpp"
+#include "audio/plugins/tracktion/SamplerHostBinding.hpp"
+#include "audio/plugins/tracktion/TracktionMagdaDevicePlugin.hpp"
 #include "compiled/CompiledPluginPresentation.hpp"
 #include "core/ParameterUtils.hpp"
 #include "custom_ui/FaustCustomUIRegistry.hpp"
@@ -154,8 +156,9 @@ void PadDeviceSlot::setPlugin(te::Plugin* plugin) {
     }
 
     // Check if it's a sampler
-    if (auto* sampler = dynamic_cast<daw::audio::MagdaSamplerPlugin*>(plugin)) {
-        setupForSampler(sampler);
+    if (daw::audio::tracktion_adapter::deviceFromPlugin<daw::audio::MagdaSamplerPlugin>(plugin) !=
+        nullptr) {
+        setupForSampler(plugin);
     } else {
         setupForExternalPlugin(plugin);
     }
@@ -183,8 +186,9 @@ void PadDeviceSlot::setPlugin(te::Plugin* plugin, const magda::DeviceInfo& devic
         return;
     }
 
-    if (auto* sampler = dynamic_cast<daw::audio::MagdaSamplerPlugin*>(plugin)) {
-        setupForSampler(sampler);
+    if (daw::audio::tracktion_adapter::deviceFromPlugin<daw::audio::MagdaSamplerPlugin>(plugin) !=
+        nullptr) {
+        setupForSampler(plugin);
     } else if (!setupForSharedDeviceUi(plugin, device)) {
         setupForExternalPlugin(plugin);
     }
@@ -199,17 +203,17 @@ void PadDeviceSlot::setPlugin(te::Plugin* plugin, const magda::DeviceInfo& devic
     resized();
 }
 
-void PadDeviceSlot::setSampler(daw::audio::MagdaSamplerPlugin* sampler) {
-    plugin_ = sampler;
+void PadDeviceSlot::setSampler(te::Plugin* samplerPlugin) {
+    plugin_ = samplerPlugin;
     livePluginProvider_ = {};
     resetSharedInlineUi();
-    if (!sampler) {
+    if (!samplerPlugin) {
         clear();
         return;
     }
-    setupForSampler(sampler);
-    onButton_->setToggleState(sampler->isEnabled(), juce::dontSendNotification);
-    onButton_->setActive(sampler->isEnabled());
+    setupForSampler(samplerPlugin);
+    onButton_->setToggleState(samplerPlugin->isEnabled(), juce::dontSendNotification);
+    onButton_->setActive(samplerPlugin->isEnabled());
     resized();
 }
 
@@ -255,7 +259,12 @@ void PadDeviceSlot::resetSharedInlineUi() {
     customUI_.reset();
 }
 
-void PadDeviceSlot::setupForSampler(daw::audio::MagdaSamplerPlugin* sampler) {
+void PadDeviceSlot::setupForSampler(te::Plugin* samplerPlugin) {
+    namespace ta = daw::audio::tracktion_adapter;
+    using Sampler = daw::audio::MagdaSamplerPlugin;
+    auto* sampler = ta::deviceFromPlugin<Sampler>(samplerPlugin);
+    if (sampler == nullptr)
+        return;
     resetSharedInlineUi();
     preferredWidth_ = SAMPLER_SLOT_WIDTH;
     uiButton_->setVisible(false);
@@ -269,18 +278,13 @@ void PadDeviceSlot::setupForSampler(daw::audio::MagdaSamplerPlugin* sampler) {
     }
 
     // Wire SamplerUI callbacks
-    samplerUI_->onParameterChanged = [sampler](int paramIndex, float value) {
-        auto params = sampler->getAutomatableParameters();
-        if (paramIndex >= 0 && paramIndex < params.size()) {
-            params[paramIndex]->setParameterFromHost(value, juce::sendNotificationSync);
-            // Sync CachedValue for persistence (param and CachedValue are independent)
-            sampler->syncCachedValueFromParam(paramIndex);
-        }
+    samplerUI_->onParameterChanged = [samplerPlugin](int paramIndex, float value) {
+        ta::setSamplerSlotDisplayValue(*samplerPlugin, paramIndex, value,
+                                       juce::sendNotificationSync);
     };
 
     samplerUI_->onLoopEnabledChanged = [sampler](bool enabled) {
-        sampler->loopEnabledAtomic.store(enabled, std::memory_order_relaxed);
-        sampler->loopEnabledValue = enabled;
+        sampler->setLoopEnabled(enabled);
     };
 
     samplerUI_->onRootNoteChanged = [sampler](int note) { sampler->setRootNote(note); };
@@ -305,13 +309,13 @@ void PadDeviceSlot::setupForSampler(daw::audio::MagdaSamplerPlugin* sampler) {
     if (file.existsAsFile())
         sampleName = file.getFileNameWithoutExtension();
 
+    const auto slot = [sampler](int index) { return sampler->displayValue(index); };
     samplerUI_->updateParameters(
-        sampler->attackValue.get(), sampler->decayValue.get(), sampler->sustainValue.get(),
-        sampler->releaseValue.get(), sampler->pitchValue.get(), sampler->fineValue.get(),
-        sampler->levelValue.get(), sampler->sampleStartValue.get(), sampler->sampleEndValue.get(),
-        sampler->loopEnabledValue.get(), sampler->loopStartValue.get(), sampler->loopEndValue.get(),
-        sampler->velAmountValue.get(), sampleName, sampler->getRootNote(),
-        sampler->voiceModeValue.get(), sampler->glideValue.get());
+        slot(Sampler::kAttack), slot(Sampler::kDecay), slot(Sampler::kSustain),
+        slot(Sampler::kRelease), slot(Sampler::kPitch), slot(Sampler::kFine), slot(Sampler::kLevel),
+        slot(Sampler::kSampleStart), slot(Sampler::kSampleEnd), sampler->loopEnabled(),
+        slot(Sampler::kLoopStart), slot(Sampler::kLoopEnd), slot(Sampler::kVelAmount), sampleName,
+        sampler->getRootNote(), slot(Sampler::kVoiceMode), slot(Sampler::kGlide));
 
     samplerUI_->setWaveformData(sampler->getWaveform(), sampler->getSampleRate(),
                                 sampler->getSampleLengthSeconds());
@@ -648,7 +652,9 @@ void PadDeviceSlot::resized() {
     nameLabel_.setVisible(true);
     nameLabel_.setColour(juce::Label::textColourId, DarkTheme::getTextColour());
     if (plugin_) {
-        bool isSampler = dynamic_cast<daw::audio::MagdaSamplerPlugin*>(plugin_) != nullptr;
+        bool isSampler =
+            daw::audio::tracktion_adapter::deviceFromPlugin<daw::audio::MagdaSamplerPlugin>(
+                plugin_) != nullptr;
         if (samplerUI_)
             samplerUI_->setVisible(isSampler);
         if (compiledPanel_)

--- a/magda/daw/ui/components/chain/drum_grid/PadDeviceSlot.hpp
+++ b/magda/daw/ui/components/chain/drum_grid/PadDeviceSlot.hpp
@@ -55,7 +55,7 @@ class PadDeviceSlot : public juce::Component, private juce::Timer {
     void setPlugin(tracktion::engine::Plugin* plugin);
     void setPlugin(tracktion::engine::Plugin* plugin, const magda::DeviceInfo& device,
                    std::function<tracktion::engine::Plugin::Ptr()> livePlugin);
-    void setSampler(daw::audio::MagdaSamplerPlugin* sampler);
+    void setSampler(te::Plugin* samplerPlugin);
     void clear();
     int getPreferredWidth() const;
     void setPreferredWidth(int width) {
@@ -164,7 +164,9 @@ class PadDeviceSlot : public juce::Component, private juce::Timer {
 
     void timerCallback() override;
 
-    void setupForSampler(daw::audio::MagdaSamplerPlugin* sampler);
+    // Takes the PLUGIN, not the device: parameter writes go through the host
+    // wrapper's parameters, which is what the device reads its slots back from.
+    void setupForSampler(te::Plugin* samplerPlugin);
     void setupForExternalPlugin(tracktion::engine::Plugin* plugin);
     bool setupForSharedDeviceUi(tracktion::engine::Plugin* plugin, const magda::DeviceInfo& device);
     void resetSharedInlineUi();

--- a/magda/daw/ui/components/chain/slot/DeviceCustomUIManager.cpp
+++ b/magda/daw/ui/components/chain/slot/DeviceCustomUIManager.cpp
@@ -860,6 +860,25 @@ void DeviceCustomUIManager::createToneGeneratorUI(const magda::DeviceInfo& devic
     update(device);
 }
 
+namespace {
+
+/// Push every sampler slot into the faceplate, reading each in its display
+/// units off the device. The faceplate's argument order is frozen; the enum
+/// spells out which slot each one is.
+void pushSamplerParameters(SamplerUI& ui, const daw::audio::MagdaSamplerPlugin& sampler,
+                           const juce::String& sampleName) {
+    using Sampler = daw::audio::MagdaSamplerPlugin;
+    const auto slot = [&sampler](int index) { return sampler.displayValue(index); };
+    ui.updateParameters(slot(Sampler::kAttack), slot(Sampler::kDecay), slot(Sampler::kSustain),
+                        slot(Sampler::kRelease), slot(Sampler::kPitch), slot(Sampler::kFine),
+                        slot(Sampler::kLevel), slot(Sampler::kSampleStart),
+                        slot(Sampler::kSampleEnd), sampler.loopEnabled(), slot(Sampler::kLoopStart),
+                        slot(Sampler::kLoopEnd), slot(Sampler::kVelAmount), sampleName,
+                        sampler.getRootNote(), slot(Sampler::kVoiceMode), slot(Sampler::kGlide));
+}
+
+}  // namespace
+
 bool DeviceCustomUIManager::createSamplerUI(const magda::DeviceInfo& device,
                                             juce::Component& parent, const Callbacks& callbacks) {
     if (!device.pluginId.containsIgnoreCase(daw::audio::MagdaSamplerPlugin::xmlTypeName))
@@ -1306,7 +1325,9 @@ bool DeviceCustomUIManager::createDrumGridUI(const magda::DeviceInfo& device,
         auto& firstPlugin = chain.plugins[0];
         if (firstPlugin == nullptr)
             return {};
-        if (auto* sampler = dynamic_cast<daw::audio::MagdaSamplerPlugin*>(firstPlugin.get())) {
+        if (auto* sampler =
+                daw::audio::tracktion_adapter::deviceFromPlugin<daw::audio::MagdaSamplerPlugin>(
+                    firstPlugin.get())) {
             auto f = sampler->getSampleFile();
             if (f.existsAsFile())
                 return f.getFileNameWithoutExtension();
@@ -1558,7 +1579,9 @@ bool DeviceCustomUIManager::createDrumGridUI(const magda::DeviceInfo& device,
         const int pluginCount = dg->getPadPluginCount(padIndex);
         for (int i = 0; i < pluginCount; ++i) {
             if (auto* plugin = dg->getPadPlugin(padIndex, i)) {
-                sampler = dynamic_cast<daw::audio::MagdaSamplerPlugin*>(plugin);
+                sampler =
+                    daw::audio::tracktion_adapter::deviceFromPlugin<daw::audio::MagdaSamplerPlugin>(
+                        plugin);
                 if (sampler != nullptr)
                     break;
             }
@@ -1588,12 +1611,12 @@ bool DeviceCustomUIManager::createDrumGridUI(const magda::DeviceInfo& device,
             return;
 
         const auto file = sampler->getSampleFile();
-        const double startSeconds = sampler->sampleStartParam != nullptr
-                                        ? sampler->sampleStartParam->getCurrentValue()
-                                        : 0.0;
-        const double endSeconds = sampler->sampleEndParam != nullptr
-                                      ? sampler->sampleEndParam->getCurrentValue()
-                                      : sampler->getSampleLengthSeconds();
+        const double startSeconds =
+            sampler->displayValue(daw::audio::MagdaSamplerPlugin::kSampleStart);
+        const double sampleEnd = sampler->displayValue(daw::audio::MagdaSamplerPlugin::kSampleEnd);
+        // A zero end is the marker never having been set, not a zero-length
+        // region: the whole sample is what the analysis should read.
+        const double endSeconds = sampleEnd > 0.0 ? sampleEnd : sampler->getSampleLengthSeconds();
         const auto trackId = nodePath.trackId;
         const auto deviceId = nodePath.getDeviceId();
         const int noteNumber = daw::audio::DrumGridPlugin::baseNote + padIndex;
@@ -1712,7 +1735,9 @@ bool DeviceCustomUIManager::createDrumGridUI(const magda::DeviceInfo& device,
             info.livePlugin = [plugin]() { return plugin; };
             info.deviceId = dg->getPluginDeviceId(chain->index, pluginIndex);
             info.device = projectPadPluginDevice(info.deviceId, plugin);
-            info.isSampler = dynamic_cast<daw::audio::MagdaSamplerPlugin*>(plugin.get()) != nullptr;
+            info.isSampler =
+                daw::audio::tracktion_adapter::deviceFromPlugin<daw::audio::MagdaSamplerPlugin>(
+                    plugin.get()) != nullptr;
             info.name = info.device.name.isNotEmpty() ? info.device.name : plugin->getName();
 
             // A pad plugin runs inside the grid, not on the track's graph, so
@@ -1978,14 +2003,13 @@ bool DeviceCustomUIManager::createDrumGridUI(const magda::DeviceInfo& device,
 juce::var DeviceCustomUIManager::executeSamplerCommand(const juce::Identifier& command,
                                                        const juce::var& arguments) {
     auto plugin = getLivePlugin();
-    auto* sampler = dynamic_cast<daw::audio::MagdaSamplerPlugin*>(plugin.get());
+    auto* sampler = daw::audio::tracktion_adapter::deviceFromPlugin<daw::audio::MagdaSamplerPlugin>(
+        plugin.get());
 
     if (command == kSamplerSetLoopEnabled) {
         if (sampler == nullptr)
             return false;
-        const bool enabled = static_cast<bool>(arguments);
-        sampler->loopEnabledAtomic.store(enabled, std::memory_order_relaxed);
-        sampler->loopEnabledValue = enabled;
+        sampler->setLoopEnabled(static_cast<bool>(arguments));
         return true;
     }
 
@@ -2014,16 +2038,10 @@ juce::var DeviceCustomUIManager::executeSamplerCommand(const juce::Identifier& c
         return false;
 
     plugin = getLivePlugin();
-    sampler = dynamic_cast<daw::audio::MagdaSamplerPlugin*>(plugin.get());
+    sampler = daw::audio::tracktion_adapter::deviceFromPlugin<daw::audio::MagdaSamplerPlugin>(
+        plugin.get());
     if (sampler != nullptr && samplerUI_ != nullptr) {
-        samplerUI_->updateParameters(
-            sampler->attackValue.get(), sampler->decayValue.get(), sampler->sustainValue.get(),
-            sampler->releaseValue.get(), sampler->pitchValue.get(), sampler->fineValue.get(),
-            sampler->levelValue.get(), sampler->sampleStartValue.get(),
-            sampler->sampleEndValue.get(), sampler->loopEnabledValue.get(),
-            sampler->loopStartValue.get(), sampler->loopEndValue.get(),
-            sampler->velAmountValue.get(), file.getFileNameWithoutExtension(),
-            sampler->getRootNote(), sampler->voiceModeValue.get(), sampler->glideValue.get());
+        pushSamplerParameters(*samplerUI_, *sampler, file.getFileNameWithoutExtension());
         samplerUI_->setWaveformData(sampler->getWaveform(), sampler->getSampleRate(),
                                     sampler->getSampleLengthSeconds());
     }
@@ -2409,15 +2427,17 @@ void DeviceCustomUIManager::update(const magda::DeviceInfo& device) {
         }
 
         auto plugin = getLivePlugin();
-        if (auto* sampler = dynamic_cast<daw::audio::MagdaSamplerPlugin*>(plugin.get())) {
+        if (auto* sampler =
+                daw::audio::tracktion_adapter::deviceFromPlugin<daw::audio::MagdaSamplerPlugin>(
+                    plugin.get())) {
             auto file = sampler->getSampleFile();
             if (file.existsAsFile())
                 sampleName = file.getFileNameWithoutExtension();
-            loopEnabled = sampler->loopEnabledValue.get();
-            sampleStart = sampler->sampleStartParam->getCurrentValue();
-            sampleEnd = sampler->sampleEndParam->getCurrentValue();
-            loopStart = sampler->loopStartParam->getCurrentValue();
-            loopEnd = sampler->loopEndParam->getCurrentValue();
+            loopEnabled = sampler->loopEnabled();
+            sampleStart = sampler->displayValue(daw::audio::MagdaSamplerPlugin::kSampleStart);
+            sampleEnd = sampler->displayValue(daw::audio::MagdaSamplerPlugin::kSampleEnd);
+            loopStart = sampler->displayValue(daw::audio::MagdaSamplerPlugin::kLoopStart);
+            loopEnd = sampler->displayValue(daw::audio::MagdaSamplerPlugin::kLoopEnd);
             rootNote = sampler->getRootNote();
             if (!samplerUI_->hasWaveform())
                 samplerUI_->setWaveformData(sampler->getWaveform(), sampler->getSampleRate(),
@@ -2440,8 +2460,8 @@ void DeviceCustomUIManager::update(const magda::DeviceInfo& device) {
             for (const auto& chain : dg->getChains()) {
                 juce::String displayName;
                 if (!chain->plugins.empty() && chain->plugins[0] != nullptr) {
-                    if (auto* sampler = dynamic_cast<daw::audio::MagdaSamplerPlugin*>(
-                            chain->plugins[0].get())) {
+                    if (auto* sampler = daw::audio::tracktion_adapter::deviceFromPlugin<
+                            daw::audio::MagdaSamplerPlugin>(chain->plugins[0].get())) {
                         auto file = sampler->getSampleFile();
                         if (file.existsAsFile())
                             displayName = file.getFileNameWithoutExtension();

--- a/magda/daw/ui/panels/content/DrumGridClipContent.cpp
+++ b/magda/daw/ui/panels/content/DrumGridClipContent.cpp
@@ -16,6 +16,7 @@
 #include "audio/plugins/DrumGridRoles.hpp"
 #include "audio/plugins/DrumGridTemplates.hpp"
 #include "audio/plugins/MagdaSamplerPlugin.hpp"
+#include "audio/plugins/tracktion/TracktionMagdaDevicePlugin.hpp"
 #include "core/ClipOperations.hpp"
 #include "core/DrumkitManager.hpp"
 #include "core/GestureRouter.hpp"
@@ -2968,7 +2969,8 @@ juce::String DrumGridClipContent::resolvePadName(int padIndex) const {
 
             // Check for MagdaSamplerPlugin with loaded sample
             for (const auto& plugin : chain->plugins) {
-                if (auto* sampler = dynamic_cast<daw::audio::MagdaSamplerPlugin*>(plugin.get())) {
+                if (auto* sampler = daw::audio::tracktion_adapter::deviceFromPlugin<
+                        daw::audio::MagdaSamplerPlugin>(plugin.get())) {
                     auto sampleFile = sampler->getSampleFile();
                     if (sampleFile.existsAsFile())
                         return sampleFile.getFileNameWithoutExtension();

--- a/tests/DawProjectRoundTrip.cpp
+++ b/tests/DawProjectRoundTrip.cpp
@@ -594,6 +594,7 @@ const std::map<std::string, std::vector<Loss>>& lossTable() {
         {"plugin.instrument.midiout", {deviceMidiPorts()}},
         {"plugin.instrument.midiout.thru", {deviceMidiPorts()}},
         {"plugin.faust.instrument", {internalDevices()}},
+        {"plugin.sampler", {internalDevices()}},
         {"multiout.pair", {internalDevices(), multiOutRouting()}},
         {"project.mixed", {internalDevices()}},
         {"midi.notes", {internalDevices()}},

--- a/tests/MgdFixtures.cpp
+++ b/tests/MgdFixtures.cpp
@@ -164,22 +164,11 @@ std::vector<MgdFixture> build() {
         fixture.declaration = declarationFor(
             "project.v1bounces", "two v1 audio clips with their sources inline, at 120", 0.0, 16.0);
 
-        // The grid's pads, said out loud rather than substituted in silence.
-        //
-        // A Drum Grid fills every pad with a magdasampler when it restores
-        // (DrumGridPads.cpp), and that device has not moved to the SDK, so the
-        // native engine cannot build one (#2271). Until #2175 the harness never
-        // looked inside a pad and the substitution was invisible; it looks now,
-        // so the gap is named here.
-        //
-        // Declared rather than skipped, because the grid on this project's third
-        // track has nothing to play and the two v1 audio clips are what the
-        // fixture exists for. Declaring it keeps those live and asserts the gap
-        // in both directions: the day the sampler runs natively (#2271), this
-        // line fails and comes out.
-        fixture.declaration.expectedDiagnostics = {
-            "no native device for magdasampler",
-        };
+        // The grid's pads no longer need declaring. A Drum Grid fills every pad
+        // with a magdasampler when it restores (DrumGridPads.cpp); until #2271
+        // that device had no SDK form, so the native leg substituted a
+        // passthrough for each pad and said so. The sampler is a MagdaDevice
+        // now, so the pads build and no diagnostic is expected.
 
         // Impulses on both: neither clip is stretched -- the source's own bpm is
         // the project's -- so where each sample lands is the whole assertion.

--- a/tests/NullDiffCase.hpp
+++ b/tests/NullDiffCase.hpp
@@ -212,6 +212,15 @@ struct Case {
     /// one that does not, and the nudge above is only audible to the first.
     bool audioChangesAtNoteEnds = false;
 
+    /// This case's instrument's release stage, in seconds.
+    ///
+    /// The nudge above puts the two legs' releases four samples apart, so an
+    /// instrument with a release ramp differs for that ramp's whole length
+    /// rather than for four samples. The device's number, not the fork's, and
+    /// a case is expected to keep it short: the longer it is, the less of the
+    /// render is held to bit identity.
+    double noteEndReleaseSeconds = 0.0;
+
     /// The largest step this case's material may take from one sample to the
     /// next, for a case in the Invariants tier. Required there and refused
     /// without, because the tier has no residual to fall back on: a bound

--- a/tests/NullDiffCorpus.cpp
+++ b/tests/NullDiffCorpus.cpp
@@ -14,6 +14,7 @@
 #include "core/SourcePool.hpp"
 #include "core/TimeStretchModes.hpp"
 #include "magda/daw/audio/plugins/FaustInstrumentPlugin.hpp"
+#include "magda/daw/audio/plugins/MagdaSamplerPlugin.hpp"
 #include "magda/daw/audio/plugins/engine/EngineDeviceFactory.hpp"
 
 /**
@@ -628,6 +629,52 @@ magda::DeviceInfo faustInstrumentDevice(magda::DeviceId id, const char* source) 
     doc.deviceType = device.pluginId;
     doc.root.props.set("dspName", "Null Diff Faust Synth");
     doc.root.props.set("dspSource", source);
+    device.pluginState = magda::device_state::encode(doc);
+
+    return device;
+}
+
+/// The sampler's shortest envelope stage. Its attack, decay and release ranges
+/// all start here, and the case wants every one of them as close to a gate as
+/// the device allows.
+constexpr float kSamplerEnvelopeSeconds = 0.001f;
+
+/// A sampler pointed at @p sampleFile, as a project would save it (#2271).
+/// Root note 60 so a C4 plays the file back at its own rate: a wrong pitch
+/// ratio then shows up as a stretched staircase rather than as nothing.
+magda::DeviceInfo samplerDevice(magda::DeviceId id, const juce::File& sampleFile) {
+    magda::DeviceInfo device;
+    device.id = id;
+    device.name = "Sampler";
+    device.pluginId = magda::daw::audio::MagdaSamplerPlugin::xmlTypeName;
+    device.deviceType = magda::DeviceType::Instrument;
+    device.isInstrument = true;
+    device.canReceiveMidi = true;
+    device.format = magda::PluginFormat::Internal;
+    device.audioInputChannels = 0;
+    device.audioOutputChannels = 2;
+
+    // The envelope flattened to a gate, so the note-end nudge stays confined
+    // to the window the case excludes (Case::noteEndReleaseSeconds). Values
+    // travel on the model, which owns them since #2317.
+    using Sampler = magda::daw::audio::MagdaSamplerPlugin;
+    const auto slot = [](int index, float value) {
+        magda::daw::audio::MagdaSamplerPlugin metadata;
+        auto info = metadata.parameterInfo(index);
+        info.currentValue = value;
+        return info;
+    };
+    device.parameters.push_back(slot(Sampler::kAttack, kSamplerEnvelopeSeconds));
+    device.parameters.push_back(slot(Sampler::kDecay, kSamplerEnvelopeSeconds));
+    device.parameters.push_back(slot(Sampler::kSustain, 1.0f));
+    device.parameters.push_back(slot(Sampler::kRelease, kSamplerEnvelopeSeconds));
+
+    // As saved device state, which is the path a project takes on both legs.
+    magda::device_state::Doc doc;
+    doc.deviceType = device.pluginId;
+    doc.root.props.set("source", sampleFile.getFullPathName());
+    doc.root.props.set("rootNote", 60);
+    doc.root.props.set("loopEnabled", false);
     device.pluginState = magda::device_state::encode(doc);
 
     return device;
@@ -2495,6 +2542,43 @@ std::vector<Case> buildCorpus(const juce::File& scratchDirectory) {
             clip.midiNotes.push_back(note(48 + index, at, 1.0, 100));
             clip.midiNotes.push_back(note(55 + index, at, 1.0, 100));
             clip.midiNotes.push_back(note(64 + index, at, 2.5, 100));
+        }
+        value.clips.push_back(std::move(clip));
+
+        corpus.push_back(std::move(value));
+    }
+
+    {
+        // The sampler on both legs (#2271) — every Drum Grid pad is one.
+        // Staircase material read back at its own rate, so a read head in the
+        // wrong place shows as a step on the wrong sample, not a level change.
+        auto track = plainTrack();
+        const auto sampleFile = writeMaterial(scratchDirectory, "sampler", stepsEvery(0.05));
+        track.chain.fxChainElements.emplace_back(samplerDevice(984, sampleFile));
+
+        auto value = newCase("plugin.sampler", "a sampler's voice allocation and playback region",
+                             std::move(track));
+        value.endBeat = 8.0;
+
+        // A sustaining instrument, so this case hears the fork's note-end nudge
+        // exactly as the Faust instrument does (#2315) — and unlike that one it
+        // has an envelope, so the difference does not end at the note-off. The
+        // release is at the device's minimum to keep that carry short.
+        value.audioChangesAtNoteEnds = true;
+        value.noteEndReleaseSeconds = kSamplerEnvelopeSeconds;
+        value.mechanism =
+            "the fork ends every note 0.0001 s early (MidiNote::getPlaybackTime) and the engine "
+            "keeps the authored length; the two legs then run the same 0.001 s release four "
+            "samples apart, so that window is named per note and taken out of the residual, "
+            "everything else held to bit identity";
+
+        auto clip = midiClip(343, 0.0, 8.0);
+        for (auto index = 0; index < 4; ++index) {
+            const auto at = static_cast<double>(index) * 2.0;
+            // Overlapping releases, so voices are reused rather than always
+            // free, and two pitches at once so the pitch ratio is exercised.
+            clip.midiNotes.push_back(note(60, at, 1.0, 100));
+            clip.midiNotes.push_back(note(67, at, 2.5, 80));
         }
         value.clips.push_back(std::move(clip));
 

--- a/tests/NullDiffRunner.cpp
+++ b/tests/NullDiffRunner.cpp
@@ -321,6 +321,12 @@ std::vector<std::pair<std::int64_t, std::int64_t>> noteEndNudgeRanges(const Case
 
     const auto samplesPerBeat = 60.0 / value.startBpm() * value.sampleRate;
 
+    // The instrument's release carries the difference past the note-off: the
+    // two legs run the same ramp four samples apart, so the whole ramp differs,
+    // not only the gap between the two releases.
+    const auto release = std::max<std::int64_t>(
+        0, static_cast<std::int64_t>(std::llround(value.noteEndReleaseSeconds * value.sampleRate)));
+
     std::vector<std::pair<std::int64_t, std::int64_t>> ranges;
     for (const auto& clip : value.clips) {
         for (const auto& note : clip.midiNotes) {
@@ -330,7 +336,7 @@ std::vector<std::pair<std::int64_t, std::int64_t>> noteEndNudgeRanges(const Case
                 std::min(clip.placement.startBeat + note.startBeat + note.lengthBeats,
                          clip.placement.endBeat());
             const auto end = static_cast<std::int64_t>(std::llround(endBeat * samplesPerBeat));
-            ranges.emplace_back(std::max<std::int64_t>(0, end - nudge), end);
+            ranges.emplace_back(std::max<std::int64_t>(0, end - nudge), end + release);
         }
     }
 

--- a/tests/devices/test_drum_grid_serialization_juce.cpp
+++ b/tests/devices/test_drum_grid_serialization_juce.cpp
@@ -15,6 +15,7 @@
 #include "magda/daw/audio/plugins/compiled/CompiledPluginRegistry.hpp"
 #include "magda/daw/audio/plugins/tracktion/TracktionDeviceStateBridge.hpp"
 #include "magda/daw/audio/plugins/tracktion/TracktionInternalPluginAdapter.hpp"
+#include "magda/daw/audio/plugins/tracktion/TracktionMagdaDevicePlugin.hpp"
 #include "magda/daw/audio/processors/CompiledFaustProcessor.hpp"
 #include "magda/daw/core/ClipManager.hpp"
 #include "magda/daw/core/DeviceState.hpp"
@@ -304,8 +305,8 @@ class DrumGridPadChainSerializationTest final : public juce::UnitTest {
 
         // The sample path and root note are model state, so the plugin comes up
         // pointing at the file with nothing captured first.
-        auto* sampled =
-            dynamic_cast<magda::daw::audio::MagdaSamplerPlugin*>(chain->plugins[0].get());
+        auto* sampled = magda::daw::audio::tracktion_adapter::deviceFromPlugin<
+            magda::daw::audio::MagdaSamplerPlugin>(chain->plugins[0].get());
         expect(sampled != nullptr, "Pad voice must be the sampler");
         if (sampled != nullptr) {
             expectEquals(sampled->getSampleFile().getFullPathName(),
@@ -855,8 +856,8 @@ class DrumGridPadChainSerializationTest final : public juce::UnitTest {
             auto* reloadedChain = reloaded->getChainForNote(midiNote);
             expect(reloadedChain != nullptr, "Reloaded Drum Grid must have the sampler pad chain");
             if (reloadedChain != nullptr && !reloadedChain->plugins.empty()) {
-                auto* sampler = dynamic_cast<magda::daw::audio::MagdaSamplerPlugin*>(
-                    reloadedChain->plugins[0].get());
+                auto* sampler = magda::daw::audio::tracktion_adapter::deviceFromPlugin<
+                    magda::daw::audio::MagdaSamplerPlugin>(reloadedChain->plugins[0].get());
                 expect(sampler != nullptr, "Reloaded pad plugin must be the sampler");
                 if (sampler != nullptr)
                     expectEquals(sampler->getSampleFile().getFullPathName(), samplePath,

--- a/tests/devices/test_sampler_relocate_juce.cpp
+++ b/tests/devices/test_sampler_relocate_juce.cpp
@@ -6,6 +6,7 @@
 #include "JuceTestStateGuard.hpp"
 #include "SharedTestEngine.hpp"
 #include "magda/daw/audio/plugins/MagdaSamplerPlugin.hpp"
+#include "magda/daw/audio/plugins/tracktion/SamplerHostBinding.hpp"
 #include "third_party/tracktion_engine/modules/tracktion_engine/utilities/tracktion_TestUtilities.h"
 
 namespace te = tracktion;
@@ -29,12 +30,11 @@ juce::File testScratchDir() {
     return dir;
 }
 
-// Mirrors how the plugin itself moves a marker: through the host-write path,
-// with the CachedValue kept in step, since that is what relocateSample reads.
-void setMarker(const te::AutomatableParameter::Ptr& param, juce::CachedValue<float>& cached,
-               float seconds) {
-    param->setParameterFromHost(seconds, juce::dontSendNotification);
-    cached = seconds;
+// Mirrors how the faceplate itself moves a marker: through the host wrapper's
+// parameter, which is what the device reads its slot back from.
+void setMarker(te::Plugin& plugin, int slot, float seconds) {
+    magda::daw::audio::tracktion_adapter::setSamplerSlotDisplayValue(plugin, slot, seconds,
+                                                                     juce::dontSendNotification);
 }
 
 // One second of sine, long enough that trim markers have somewhere to sit other
@@ -69,6 +69,7 @@ class SamplerRelocateTest final : public juce::UnitTest {
     void runTest() override {
         testRelocatePreservesInterpretation();
         testLoadSampleStillResets();
+        testLoadTakesMarkersIntoHostParameters();
     }
 
   private:
@@ -77,20 +78,21 @@ class SamplerRelocateTest final : public juce::UnitTest {
     MagdaSamplerPlugin* prepare(te::Edit& edit, const juce::File& sampleFile,
                                 te::Plugin::Ptr& keepAlive) {
         keepAlive = createCustomPlugin(edit, MagdaSamplerPlugin::xmlTypeName);
-        auto* sampler = dynamic_cast<MagdaSamplerPlugin*>(keepAlive.get());
+        auto* sampler = magda::daw::audio::tracktion_adapter::deviceFromPlugin<MagdaSamplerPlugin>(
+            keepAlive.get());
         expect(sampler != nullptr, "Sampler plugin must be created");
         if (sampler == nullptr)
             return nullptr;
 
-        sampler->loadSample(sampleFile);
+        magda::daw::audio::tracktion_adapter::loadSamplerSample(*keepAlive, sampleFile);
         expectEquals(sampler->getSampleFile().getFullPathName(), sampleFile.getFullPathName(),
                      "Sampler must have adopted the sample");
 
         sampler->setRootNote(48);
-        setMarker(sampler->sampleStartParam, sampler->sampleStartValue, 0.25f);
-        setMarker(sampler->sampleEndParam, sampler->sampleEndValue, 0.75f);
-        setMarker(sampler->loopStartParam, sampler->loopStartValue, 0.3f);
-        setMarker(sampler->loopEndParam, sampler->loopEndValue, 0.6f);
+        setMarker(*keepAlive, MagdaSamplerPlugin::kSampleStart, 0.25f);
+        setMarker(*keepAlive, MagdaSamplerPlugin::kSampleEnd, 0.75f);
+        setMarker(*keepAlive, MagdaSamplerPlugin::kLoopStart, 0.3f);
+        setMarker(*keepAlive, MagdaSamplerPlugin::kLoopEnd, 0.6f);
         return sampler;
     }
 
@@ -115,19 +117,19 @@ class SamplerRelocateTest final : public juce::UnitTest {
         auto moved = testScratchDir().getNonexistentChildFile("relocate_dest", ".wav");
         expect(original.moveFileTo(moved), "Sample must move");
 
-        sampler->relocateSample(moved);
+        magda::daw::audio::tracktion_adapter::relocateSamplerSample(*keepAlive, moved);
 
         expectEquals(sampler->getSampleFile().getFullPathName(), moved.getFullPathName(),
                      "Sampler must follow the file");
         expectEquals(sampler->getRootNote(), 48, "Root note must survive relocation");
-        expectWithinAbsoluteError(sampler->sampleStartValue.get(), 0.25f, 0.0001f,
-                                  "Sample start must survive relocation");
-        expectWithinAbsoluteError(sampler->sampleEndValue.get(), 0.75f, 0.0001f,
-                                  "Sample end must survive relocation");
-        expectWithinAbsoluteError(sampler->loopStartValue.get(), 0.3f, 0.0001f,
-                                  "Loop start must survive relocation");
-        expectWithinAbsoluteError(sampler->loopEndValue.get(), 0.6f, 0.0001f,
-                                  "Loop end must survive relocation");
+        expectWithinAbsoluteError(sampler->displayValue(MagdaSamplerPlugin::kSampleStart), 0.25f,
+                                  0.0001f, "Sample start must survive relocation");
+        expectWithinAbsoluteError(sampler->displayValue(MagdaSamplerPlugin::kSampleEnd), 0.75f,
+                                  0.0001f, "Sample end must survive relocation");
+        expectWithinAbsoluteError(sampler->displayValue(MagdaSamplerPlugin::kLoopStart), 0.3f,
+                                  0.0001f, "Loop start must survive relocation");
+        expectWithinAbsoluteError(sampler->displayValue(MagdaSamplerPlugin::kLoopEnd), 0.6f,
+                                  0.0001f, "Loop end must survive relocation");
 
         moved.deleteFile();
     }
@@ -154,16 +156,65 @@ class SamplerRelocateTest final : public juce::UnitTest {
         auto other = testScratchDir().getNonexistentChildFile("reset_other", ".wav");
         expect(writeTestWav(other), "Second test sample must be written");
 
-        sampler->loadSample(other);
+        magda::daw::audio::tracktion_adapter::loadSamplerSample(*keepAlive, other);
 
         expectEquals(sampler->getRootNote(), 60, "A newly chosen sample resets the root note");
-        expectWithinAbsoluteError(sampler->sampleStartValue.get(), 0.0f, 0.0001f,
-                                  "A newly chosen sample resets the start marker");
-        expectWithinAbsoluteError(sampler->loopStartValue.get(), 0.0f, 0.0001f,
-                                  "A newly chosen sample resets the loop start");
+        expectWithinAbsoluteError(sampler->displayValue(MagdaSamplerPlugin::kSampleStart), 0.0f,
+                                  0.0001f, "A newly chosen sample resets the start marker");
+        expectWithinAbsoluteError(sampler->displayValue(MagdaSamplerPlugin::kLoopStart), 0.0f,
+                                  0.0001f, "A newly chosen sample resets the loop start");
 
         original.deleteFile();
         other.deleteFile();
+    }
+
+    void testLoadTakesMarkersIntoHostParameters() {
+        beginTest("A sample load reaches the host's parameters, not only the device");
+
+        // The device derives the trim markers from the audio it just loaded,
+        // and the host is the authority every block: syncParametersToDevice()
+        // pushes on every applyToBuffer. Without the pull back, the host's
+        // stale markers overwrite the derived ones at the next render, and the
+        // sample plays a region that belongs to whatever was loaded before.
+        auto& wrapper = magda::test::getSharedEngine();
+        auto edit = te::test_utilities::createTestEdit(*wrapper.getEngine(), 1);
+        expect(edit != nullptr, "Test edit must be created");
+        if (!edit)
+            return;
+
+        auto file = testScratchDir().getNonexistentChildFile("host_sync", ".wav");
+        expect(writeTestWav(file), "Test sample must be written");
+
+        te::Plugin::Ptr keepAlive;
+        auto* sampler = prepare(*edit, file, keepAlive);
+        if (sampler == nullptr)
+            return;
+
+        // prepare() moved the markers off the load's defaults; reloading the
+        // same file resets them, which is the change that has to travel.
+        magda::daw::audio::tracktion_adapter::loadSamplerSample(*keepAlive, file);
+
+        auto* devicePlugin =
+            dynamic_cast<magda::daw::audio::tracktion_adapter::TracktionMagdaDevicePlugin*>(
+                keepAlive.get());
+        expect(devicePlugin != nullptr, "The sampler must sit inside the host's device wrapper");
+        if (devicePlugin == nullptr)
+            return;
+
+        for (const int index : {MagdaSamplerPlugin::kSampleStart, MagdaSamplerPlugin::kSampleEnd,
+                                MagdaSamplerPlugin::kLoopStart, MagdaSamplerPlugin::kLoopEnd}) {
+            auto* parameter = devicePlugin->parameterForDeviceSlot(index);
+            expect(parameter != nullptr, "Every sampler slot must have a host parameter");
+            if (parameter == nullptr)
+                continue;
+
+            const float fromHost = magda::ParameterUtils::normalizedToReal(
+                parameter->getCurrentValue(), sampler->parameterInfo(index));
+            expectWithinAbsoluteError(fromHost, sampler->displayValue(index), 0.0001f,
+                                      "The host parameter must carry the marker the load derived");
+        }
+
+        file.deleteFile();
     }
 };
 

--- a/tests/engine/test_null_diff_corpus.cpp
+++ b/tests/engine/test_null_diff_corpus.cpp
@@ -36,7 +36,7 @@ juce::File scratch() {
 TEST_CASE("The corpus builds and covers what the slice claims", "[nulldiff][corpus]") {
     const auto corpus = sharedCorpus(scratch());
 
-    REQUIRE(corpus.size() == 66);
+    REQUIRE(corpus.size() == 67);
 
     std::set<std::string> names;
     for (const auto& value : corpus)


### PR DESCRIPTION
Closes #2271. Part of #1882.

## The port

`MagdaSamplerPlugin` was `te::Plugin` only, so `createSdkDevice()` returned null and the executor bound a `Passthrough` for the Device op. Every Drum Grid pad is one (`DrumGridPads.cpp`), so a drum kit built the ordinary way rendered as passthrough on the native leg.

- `properties` / `prepare` / `release` / `reset` / `process` replace `initialise` / `deinitialise` / `applyToBuffer`.
- The fourteen parameters become normalised atomics behind a frozen slot table. The ids, order and curves are the ones the retired plugin registered, so saved automation, macro links and mod links keep pointing at the same controls. The JUCE skews map onto `ParameterScale::Exponential` by their **reciprocal** — `NormalisableRange::convertFrom0to1` computes `min + span * norm^(1/skew)` and MAGDA's Exponential is `norm^k * span + min`.
- Parameter values are the model's (#2317), so `flushState`/`restoreState` carry only what the device owns: the sample path, the root note and the loop switch, under the spellings the retired plugin used.
- Voice allocation, glide, the mono/legato note stack and the ADSR are untouched. This is a port, not a rewrite, and the corpus case below is what says so.

The sample stays a **path** rather than a blob in device state. Unlike the convolution's impulse response, a sample is arbitrarily large and the project media tree already owns relocating it — which is what `relocateSample` exists for.

The processor becomes a `MagdaDeviceProcessor`, and the registry entry moves to `SavedStateOrFresh` + `createValueTreePlugin` for the same reason the convolution's did: the sample path is device state, so a restore has to rebuild the plugin from it rather than from a fresh tree.

## Both sides of the wrapper have to be written

Eighteen `dynamic_cast<MagdaSamplerPlugin*>` sites become `deviceFromPlugin`, which is the mechanical half. The half that is not mechanical is `SamplerHostBinding.hpp`.

The faceplate, the drum-grid commands and the media relocator all work in display units — seconds, dB, semitones — while the wrapper's parameters are normalised. Neither side can be written on its own:

- The host is the authority every block: `syncParametersToDevice()` pushes on every `applyToBuffer`, so a write straight to the device is undone at the next render.
- The device is what actually holds a value between renders, so a write to the parameter alone is invisible until something renders.

So a write goes to both. And a **device-driven** change travels the other way: loading a sample makes the device derive the trim and loop markers from the audio, and without `pullParametersFromDevice()` the host's stale markers overwrite them at the next render — the pad then plays a region belonging to whatever was loaded before it. `Sampler Relocate Tests` asserts the host parameter carries what the load derived; reverting the pull fails all four markers.

## Null-diff

`plugin.sampler` renders overlapping notes through a sampler whose envelope is flattened to a gate, over staircase material read back at its own rate at root note, so a read head in the wrong place shows as a step landing on the wrong sample rather than as a level change.

**It found something the Faust case could not.** #2350 taught the audio comparison about the fork's note-end nudge — `MidiNote::getPlaybackTime` subtracts 0.0001 s, four samples at 44.1 kHz — and excluded a four-sample window per note. That was sufficient there because the patch has no envelope: the gate flips and the difference ends. An instrument with a **release** runs the same ramp four samples apart, so the whole ramp differs, not just the gap between the two releases. The first run said `peak=-68.9 rms=-78.9`.

- `Case::noteEndReleaseSeconds` declares how long the instrument carries a note-off difference forward. It is the device's number, not the fork's.
- `noteEndNudgeRanges()` widens each window to `[end - nudge, end + release)`.
- The case sets attack, decay and release to the device's minimum and sustain wide open, so that window is 48 samples rather than the 4410 the default release would ask for. The comment says why: the longer it is, the less of the render is held to bit identity.

Result: `peak=-inf`. Verified negatively in **both** directions — with `audioChangesAtNoteEnds` off, and with `noteEndReleaseSeconds` left at zero, `peak=-28.9` comes back each time. Both halves are load-bearing.

`plugin.sampler` also declares the `internalDevices()` DAWproject loss the other internal-device cases do.

## The marker #2271 named for itself

The Drum Grid fixture's `expectedDiagnostics` line is gone from `MgdFixtures.cpp`. That declaration was written to fail in the direction it was asserted in the day the sampler ran natively, and it did.

## Results

Full Catch2 suite: 3512 passed, 13 skipped, **1 failed** — `test_engine_device_layer.cpp:655` (`synthProbe.bound == 2 * kMaxMidiBytesPerPort`, 12288 vs 8192), tagged `[2341][2345]`. Confirmed pre-existing: it fails identically on unmodified `dev/0.20.0` with this branch stashed. Filed separately.

All JUCE suites green, including **Null Diff Corpus**, **Sampler Relocate Tests**, **DrumGrid Pad Chain Serialization**, **Device State Schema** and **MIDI Signal Routing**.

Not verified in the running app — I can't drive MAGDA's UI. The sampler faceplate and the Drum Grid pads are worth a click-through: loading a sample, dragging the trim and loop markers, and switching a pad's voice mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018rAnjCekXfSQtpsr7jLtj5
