### PR TITLE
Trim comment bloat

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,11 @@
+# MAGDA Core
+
+## Comment density
+
+A comment is a line or two. Longer needs a reason: an issue number, an external constraint
+(a TE quirk, a JUCE contract, a wire-format rule), a measured figure, or a non-obvious decision.
+Don't restate the code below it, narrate rejected alternatives, or write worked examples —
+those belong in `docs/` or a test.
+
+Check the ratio with `scripts/comment_ratio.py`; `--check <percent>` fails on any file over
+the threshold.

--- a/docs/architecture/engine-device-factory.md
+++ b/docs/architecture/engine-device-factory.md
@@ -1,0 +1,102 @@
+# Engine device factory
+
+`magda/daw/audio/plugins/engine/EngineDeviceFactory.hpp` turns a plan's
+`Device` op (an identity, no plugin) into a runnable `EngineDevice`. A plan is
+topology; binding an identity to a plugin instance is the host's job, the way
+opening a WAV is (#2174).
+
+## Internal devices (top half of the file)
+
+Resolution asks the same two catalogs the current (TE) engine asks — the
+internal registry and the compiled-Faust catalog — rather than keeping a
+third list of what exists. It returns null for anything not yet ported to the
+SDK (`InternalPluginSpec`/`CompiledPluginSpec` both carry `createDevice`).
+That null must stay visible: a caller has to report an unrunnable device
+rather than silently pass signal through, because a stand-in the incumbent
+engine doesn't have is a divergence disguised as a null.
+
+Parameters aren't written here — the plan's value layer resolves them per
+block and the adapter writes them before each `process()`, so a device starts
+at its defaults and is at the project's values by the first sample. The rest
+of a device's state (`MagdaDevice::restoreState()`, the pluginState v2
+contract, #1887) belongs to the state slice, not this one.
+
+`canCreateEngineDevice` vs. `isRegisteredDevice`: the first asks "can the
+engine build this", the second "does either catalog know this id at all".
+`isRegisteredDevice == false` is normal (unset chain slot, external plugin,
+test fixture) — the engine running nothing is what every host does there.
+`isRegisteredDevice == true` with `canCreateEngineDevice == false` is the case
+worth reporting: the app knows this device but the native engine can't build
+it, so a render that passed audio through would be a render of a different
+project.
+
+## External plugins (bottom half of the file, #2243)
+
+An external plugin is a file on a machine, not a class this build contains —
+it can fail to load for reasons worth telling a user (moved, upgraded,
+uninstalled), so these entry points return *why* rather than a null.
+
+Unlike an internal device, an external plugin's saved state does travel:
+MAGDA persists the plugin's own chunk, and the adapter applies it along with
+the saved parameter array it overlays (`EngineExternalDevice::applySavedState`).
+Writing the chunk back out of a native-engine instance so a project
+round-trips between engines during the dual-engine release is the other half,
+tracked separately (#2244).
+
+### The synchronous path
+
+`adaptExternalPluginInstance` is one transaction over an instance the host
+created: enable all buses (must happen before channel counts can be read),
+apply the saved parameter array, then the chunk (chunk wins on conflict), and
+hand back what the plugin holds now in `ExternalDeviceResult::restoredParameters`.
+
+The engine never corrects the model itself — the model is the one authority
+and this is a render path — so the correction is handed back for the caller
+to apply on the message thread (`magda::applyRestoredParameters`). A caller
+whose model already matches the plugin (e.g. a project a newer build already
+refreshed) just re-applies the same values.
+
+`createEngineExternalDevice` blocks until the plugin loads, which suits a
+render with nothing else to do meanwhile (offline bounce, corpus case). A
+session opening a project with many plugins needs the async form instead.
+
+### The asynchronous path
+
+Loading is async because a plugin can take seconds and a project keeps
+running while it does. By completion time the device may have been edited,
+had a preset applied, or been deleted — so:
+
+- `CurrentDeviceLookup` reads the model **at completion**, not captured at
+  request time, so restoration doesn't clobber whatever happened while the
+  plugin was loading. It's keyed on `engine::DeviceKey`, not a bare
+  `DeviceId`, because `DeviceId` is allocated per section (main FX, post-FX,
+  mixer-analysis), so a bare id can name up to three different devices.
+
+- `RequestedPlugin` is a self-contained, weak-reference snapshot of the
+  question being answered (`PluginAssignments.hpp`), deliberately excluding
+  saved plugin metadata — resolving a moved plugin or an imported DAWproject
+  may legitimately correct that before the request completes.
+
+- `completeExternalPluginLoad` enforces an **identity boundary**: it only
+  completes onto the assignment it was requested for. It refuses the load if
+  that assignment was deleted, had its plugin replaced, was duplicated or
+  pasted from, had its id reused after a project clear, was never
+  registered, or if the whole runtime went away while loading. Because the
+  check needs only the requested snapshot, it works even after the runtime
+  that issued the request no longer exists.
+
+- `createEngineExternalDeviceAsync` reads the saved device once (to decide
+  what to load) and reads `currentDevice` again at completion (to decide what
+  to restore) — two different questions, both above. `key`/`assignments` are
+  read once, here, to build a self-contained request; the runtime is not
+  captured, so it destructing mid-load makes the request expire rather than
+  dangle. The same expiry gates the `completed` callback: if the runtime that
+  owns `assignments` is destroyed first, `completed` is simply never called —
+  a caller only needs to keep `assignments` alive for as long as it wants to
+  hear about the load, nothing more. Until a device binds, the executor's
+  existing pass-through behavior applies (op passes audio through, reports it
+  in diagnostics); completion re-prepares the plan rather than hot-swapping
+  the device in.
+
+`isInstalledExternalPlugin` only says a scanned plugin exists to try loading
+— it does not promise instantiation will succeed.

--- a/docs/architecture/modifier-lfo.md
+++ b/docs/architecture/modifier-lfo.md
@@ -1,0 +1,80 @@
+# Modifier LFO engine
+
+`magda/engine/param/ModLfo.hpp` is the runtime that moves an LFO modifier. It
+replaces the old model, where a modifier was a published number that never
+moved between publishes.
+
+## Settings vs. state
+
+Two structs, kept separate on purpose:
+
+- `LfoSettings` is what the model says the LFO is. Flat and copyable, it rides
+  in the published table and is immutable for as long as that table is. The
+  drawn curve rides beside it in the table's own arena rather than inside the
+  struct, so a knob move doesn't allocate a vector per modifier.
+- `LfoState` is where the LFO has got to. It belongs to the runtime, not the
+  table, because a knob move republishes the table many times a second, and an
+  LFO that restarted on every publish would never finish a cycle.
+
+`advanceLfo` applies one block of settings to state.
+
+## Block-rate timing
+
+The LFO advances once per block, from the block's first sample, because that
+matches Tracktion Engine: TE advances a modifier timer at the top of the block
+and every plugin reading it that block sees one value. A per-sample LFO would
+diverge from the TE reference implementation on every modulated parameter in
+every project — a decision left for after the native-engine port.
+
+## Depth and polarity live outside the LFO
+
+One LFO can drive several parameters by different amounts and directions.
+MAGDA keeps that per link, applied where contributions are summed
+(`ParamResolve.hpp`); the LFO itself knows nothing about it. TE's own depth,
+offset and bipolar modifier parameters are held at unity for the same reason.
+
+## Bar-relative timing (`modBarPosition`, `modBarsElapsed`, `barBeatsOf`)
+
+A synced LFO's period is measured in bars read off the tempo map, not in beats
+divided by a fixed bar length, because the two diverge across a signature
+change (a change always starts a new bar — see `TempoMap.hpp`). Two bars of
+4/4 followed by a 6/8 bar puts a bar line at beat 8, and 8 divided by the 3
+beats a 6/8 bar lasts is 8/3 — a modifier using flat division opens every 6/8
+bar two-thirds of the way through its cycle and stays wrong.
+
+A bar's length in beats is `numerator * 4 / denominator` quarter notes (a beat
+is a quarter note everywhere in the engine), so a 6/8 bar is 3 beats, not 6.
+The four TE modifiers were patched to use this arithmetic rather than the
+other way around, because an engine being replaced isn't a reason to carry its
+bug forward, and matching keeps the null-diff parity corpus meaningful
+(#2128). A block that spans a tempo or signature change sums what each span is
+worth in its own bar length rather than reading one bpm/signature for the
+whole block (#2340).
+
+A stopped transport has no beats to read, so a free-running modifier measures
+bars there as wall-clock time at the tempo and signature the cursor sits on.
+
+## Rate lane indexing
+
+The Rate lane's stored value counts from the first musical division rather
+than the enum's own zero, because zero is Hertz and Hertz isn't a division —
+a synced modifier whose lane ran to the bottom of its range would otherwise
+resolve to "not synced". `rateTypeFromLaneValue`/`laneValueFromRateType` apply
+the same shift as `AutomationInfo::makeSyncDivisionInfo` on the model side.
+
+## `LfoSettings::skipNativeResync`
+
+A cross-track sidechain LFO is driven only by its source track: the track it
+modulates must not retrigger its phase or slam its gate on every note it
+happens to be playing. An earlier version of this flag was set at LFO
+creation and not restated when a source was picked later, so the destination
+track kept retriggering an LFO that had stopped being its own — this flag is
+re-asserted from the model on every property update instead.
+
+## `LfoState::forceZero`
+
+A trigger arrives mid-block, after that block's parameters are already
+resolved, so the earliest a device can see the retrigger is the following
+block. `forceZero` latches "output one block of nothing" so that block reads
+as a transition rather than a continuation; the same block resets the phase,
+matching the fork's own one-block-late sequence.

--- a/docs/architecture/remote-api-host.md
+++ b/docs/architecture/remote-api-host.md
@@ -1,0 +1,93 @@
+# RemoteApiHost lifecycle
+
+`RemoteApiHost` (`magda/daw/api/remote_api_host.hpp`) owns the remote API for
+the lifetime of a running MAGDA (#1856, #1858): the dispatcher, the
+`ModelChangeBridge` that feeds it local edits, and the WebSocket and MCP
+transports. One dispatcher and one `SubscriptionHub` are shared by both
+transports on purpose, not as an optimization — two dispatchers would be two
+revision counters and two undo groupings over one project, and two hubs would
+be two projections of the model drifting apart.
+
+Construct, destroy, and call `start()`/`startTransport()`/`rotateToken()` on
+the message thread only: `ModelChangeBridge` attaches to the model singletons,
+which notify there.
+
+## Discovery record and token
+
+The token is generated per run and never persisted to config — a config file
+gets copied between machines, committed by accident, or pasted into a bug
+report, and a credential in one leaks eventually. Instead it lives in a file
+beside the other app data, owner-only permissions, deleted on shutdown, named
+after the process (MAGDA allows more than one running instance, so one shared
+file would let the second instance's start hide the first, and the first
+instance's stop would delete a record for the instance still running):
+
+```
+remote-api-<pid>.json
+{"port":51734,"token":"...","url":"ws://127.0.0.1:51734/rpc",
+ "mcpPort":51735,"mcpUrl":"http://127.0.0.1:51735/mcp","pid":4021}
+```
+
+This is the same shape Jupyter uses for its local server: a client on the
+machine needs no configuration, a process elsewhere gets nothing. Both
+transports are named in one record because a client picks one (an MCP host
+wants `mcpUrl`, a script wanting pushed state wants `url`); the token is
+shared because it authenticates the user at the keyboard, not a protocol.
+
+`start()` collects any record left behind by a crashed process, but an
+instance only ever deletes its own live record. `publishRecord()` rewrites
+the file after every start/stop/rotation, and deletes it once neither
+transport is up — the record is a live projection of what's listening, not a
+mirror of config, because a port in it that nothing answers on is exactly the
+failure mode it exists to prevent.
+
+Disabled means disabled: `start()` returns false and opens no socket when the
+feature is off, no token could be generated, or the port is taken. There's no
+partial state where MAGDA listens but nobody can authenticate.
+
+## Per-transport control (#2142)
+
+`startTransport`/`stopTransport`/`rotateToken` all take a `Transport` and
+touch only that one: separate credentials, separate discovery-record entries,
+separate connection lists. Rotating one transport's token disconnects only
+its clients and leaves the other's alone — re-credentialling a misbehaving
+script no longer drops an AI host mid-conversation. That's granularity, not
+isolation: both tokens still live in the same owner-only file and both doors
+open onto the same dispatcher and the same grants.
+
+## stop() vs. stopListening()
+
+`stop()` is the destruction path: it also shuts the dispatcher and
+subscription hub down permanently (`RemoteApiService::shutdown()` never comes
+back), so `start()` must never be called afterward — it would bind listeners
+around a dispatcher that answers every request with `Cancelled`.
+
+`stopListening()` is what the settings toggle uses: sockets close and the
+token is withdrawn, but the dispatcher, bridge, and hub stay alive, so a later
+`start()` produces a working server again.
+
+## GrantWriter
+
+Grant changes come from two places — the settings dialog (message thread) and
+a client connecting for the first time (a transport thread) — and both are
+persisted through `persistGrants()`/`GrantWriter`, so config writes have to be
+serialized and ordered. `mutex` guards `latest`/`posted` and is held only
+briefly; `applyMutex` serializes the actual file write and is always taken
+before `mutex`, never after, so a transport thread recording a newer grant is
+never blocked behind a save — it just leaves `latest` for whoever is inside
+the write to pick up. Whoever finds `posted == false` owns the hop to the
+message thread; every later caller just replaces `latest`, so the newest
+state always wins and a burst of changes costs one write. `GrantWriter` is
+held by `shared_ptr` so a queued write can outlive the host.
+
+## Member declaration order
+
+Declaration order is destruction order reversed, and it's load-bearing: a
+transport's connections deregister from the hub, the hub listens to the
+service's change source, and the bridge writes into the service — each has to
+outlive what talks to it. `clients_` (the `RemoteClientRegistry`) comes first
+because both transports hold a raw pointer to it. `audit_` is a `shared_ptr`
+rather than a `unique_ptr` because declaration order alone isn't enough for
+it: a dispatch completion carrying it can still be queued on the message
+thread when the host is destroyed, and member ordering only governs what
+happens *inside* the destructor — whoever still holds a share keeps it alive.

--- a/magda/daw/api/remote_api_host.hpp
+++ b/magda/daw/api/remote_api_host.hpp
@@ -23,55 +23,21 @@ class SubscriptionHub;
 /**
  * @brief Owns the remote API for the lifetime of a running MAGDA (#1856, #1858).
  *
- * The dispatcher, the model bridge that feeds it local edits, and the two
- * transports are objects with one lifetime and a required construction order, so
- * something has to own them together. This is that something, and it is the only
- * place in the app that knows the remote API exists at all.
- *
- * Both transports share one dispatcher and one subscription hub. That is the
- * point of the layering rather than an optimisation: two dispatchers would be
- * two revision counters and two undo groupings over one project, and two hubs
- * would be two projections of the same model drifting apart.
+ * Owns the dispatcher, the model bridge that feeds it local edits, and the two
+ * transports, which share one required construction order. Both transports
+ * share one dispatcher and one subscription hub, not as an optimization: two
+ * dispatchers would be two revision counters and two undo groupings over one
+ * project, and two hubs would be two projections of the model drifting apart.
  *
  * Construct and destroy on the message thread: `ModelChangeBridge` attaches to
  * the model singletons, which notify there.
  *
- * ## The token
- *
- * Generated per run, never persisted to config. A config file gets copied
- * between machines, committed by accident, and pasted into bug reports; a
- * credential in one is a credential that leaks eventually. Instead the token
- * lives in a file beside the other app data, written with owner-only
- * permissions and deleted on shutdown, carrying the port alongside it:
- *
- *     remote-api-<pid>.json
- *     {"port":51734,"token":"…","url":"ws://127.0.0.1:51734/rpc",
- *      "mcpPort":51735,"mcpUrl":"http://127.0.0.1:51735/mcp","pid":4021}
- *
- * A client reads that file to learn where to connect and what to present. This
- * is the same shape Jupyter uses for its local server, and it means a client on
- * the machine needs no configuration while a process elsewhere gets nothing.
- *
- * Both transports are named because a client picks one: an MCP host wants
- * `mcpUrl`, a script that needs pushed state wants `url`. The token is the same
- * for both — it authenticates the user at the keyboard, not a protocol.
- *
- * The record is named after the process because MAGDA allows more than one
- * instance. One shared file would mean the second instance to start hides the
- * first, and the first to stop deletes the record of the one still running —
- * and with a fixed port, where SO_REUSEPORT lets both listeners bind, a client
- * could hold one instance's token and be routed to the other. A client that
- * finds several records is looking at several running instances and has to
- * choose; each is independently valid for the port it names.
- *
- * A record whose process is gone is debris from a crash, and any instance's
- * `start()` will collect it. An instance only ever deletes its own live record.
- *
- * ## Disabled means disabled
- *
- * `start()` returns false and opens no socket when the feature is off in
- * config, when no token could be generated, or when the port is taken. There is
- * no partial state where MAGDA is listening but unauthenticated.
+ * The auth token is generated per run, never persisted to config, and lives in
+ * an owner-only, per-process discovery file deleted on shutdown (see
+ * docs/architecture/remote-api-host.md for the file format and why). `start()`
+ * returns false and opens no socket when the feature is off, no token could be
+ * generated, or the port is taken -- there is no partial state where MAGDA is
+ * listening but unauthenticated.
  */
 /// Which listener. Both are carried by one `RemoteApiHost`, but they are
 /// started, stopped, and credentialled independently (#2142).
@@ -83,10 +49,8 @@ class RemoteApiHost {
      * @brief Construct the remote API over a facade, and optionally an engine.
      *
      * `engine` is what the `meters` subscription reads (#1857) and the only
-     * thing it is used for. Passing nothing is a supported configuration, not a
-     * degraded one: the whole API works, and `meters` delivers empty samples
-     * rather than failing — a host with no audio engine is not something a
-     * remote client can detect or act on.
+     * thing it is used for. Passing nothing is supported, not degraded: the
+     * whole API works and `meters` delivers empty samples instead of failing.
      */
     explicit RemoteApiHost(MagdaApi& api, AudioEngine* engine = nullptr);
     ~RemoteApiHost();
@@ -97,84 +61,60 @@ class RemoteApiHost {
     /**
      * @brief Start whichever transports config enables, and publish the record.
      *
-     * Each transport is independent: one that is disabled is skipped, and one
-     * that fails to bind does not take the other down. Returns true when at
-     * least one listener came up, so false means nothing is answering — which is
-     * also what it returns when both are switched off.
+     * Each transport is independent: a disabled one is skipped, and a failed
+     * bind does not take the other down. Returns true when at least one
+     * listener came up.
      */
     bool start();
 
     /**
      * @brief Open one transport, leaving the other exactly as it is (#2142).
      *
-     * What a settings toggle needs. Mints that transport's credential, binds its
-     * port, and rewrites the discovery record to add it; the other transport's
-     * entry and token in that record are untouched, so a client already
-     * connected over it never notices.
-     *
-     * Returns false when config has this transport switched off, when it is
-     * already running, or when the port could not be bound.
-     *
-     * Message thread only, like `start()`.
+     * Mints that transport's credential, binds its port, and rewrites the
+     * discovery record to add it without touching the other transport's
+     * entry. Returns false when config has it off, it is already running, or
+     * the port could not be bound. Message thread only, like `start()`.
      */
     bool startTransport(Transport transport);
 
     /**
      * @brief Close one transport, leaving the other listening.
      *
-     * Withdraws that transport's credential and its entry in the discovery
-     * record, and drops the connections it was carrying. Idempotent. When it is
-     * the last one listening the record goes away entirely, because a record
-     * with neither transport in it advertises nothing.
+     * Withdraws its credential and discovery-record entry, and drops its
+     * connections. Idempotent. Removes the record entirely once neither
+     * transport is up.
      */
     void stopTransport(Transport transport);
 
     /**
      * @brief Close the listeners and withdraw the credential, permanently.
      *
-     * Shuts the dispatcher and the subscription hub down as well, which is
-     * one-way: `RemoteApiService::shutdown()` retires its execution state and
-     * never comes back. This is the destruction path, and `start()` must not be
-     * called afterwards — it would bind listeners around a dispatcher that
-     * answers every request with `Cancelled`.
-     *
-     * Idempotent; the destructor calls it. To turn the feature off and leave it
-     * restartable, use `stopListening()`.
+     * Also shuts the dispatcher and subscription hub down, one-way
+     * (`RemoteApiService::shutdown()` never comes back) -- this is the
+     * destruction path, and `start()` must not be called afterwards. Use
+     * `stopListening()` to turn the feature off and leave it restartable.
      */
     void stop();
 
     /**
      * @brief Close the listeners and withdraw the credential, reversibly.
      *
-     * What the settings toggle needs: no socket and no published token, but the
-     * dispatcher, the model bridge, and the subscription hub all still alive, so
-     * a later `start()` produces a working server rather than one whose every
-     * operation is already cancelled.
-     *
-     * Idempotent, and safe to call when nothing is listening.
+     * What the settings toggle needs: no socket, no published token, but the
+     * dispatcher, model bridge, and subscription hub stay alive so a later
+     * `start()` works again. Idempotent.
      */
     void stopListening();
 
     /**
      * @brief Throw the current credential away and issue a new one (#1860).
      *
-     * Every connected client is disconnected, because that is what rotation
-     * means: a token that still admitted the sessions it was replacing would
-     * not have been revoked. Clients reconnect by re-reading the discovery
-     * record, which this rewrites before returning — so a well-behaved one
-     * recovers on its own and a stale copy of the old token never works again.
-     *
-     * A no-op returning false when this transport is not listening: there is no
-     * credential to rotate, and minting one without a listener would publish a
-     * record for a port nobody is answering on.
-     *
-     * Per transport since #2142. The two hold separate tokens, so rotating one
-     * leaves the other's clients connected — re-credentialling a misbehaving
-     * script no longer drops an AI host mid-conversation. It buys granularity,
-     * not isolation: both tokens live in the same owner-only file and both doors
-     * open onto the same dispatcher and the same grants.
-     *
-     * Message thread only, like `start()`.
+     * Every connected client is disconnected, since that is what rotation
+     * means. Clients reconnect by re-reading the discovery record, rewritten
+     * before this returns. A no-op returning false when this transport is
+     * not listening. Per transport since #2142: the two hold separate
+     * tokens, so re-credentialling one doesn't drop the other's clients --
+     * that buys granularity, not isolation, since both still live in the same
+     * owner-only file. Message thread only, like `start()`.
      */
     bool rotateToken(Transport transport);
 
@@ -187,29 +127,27 @@ class RemoteApiHost {
     /// The WebSocket port actually bound, or 0 when not running.
     int boundPort() const;
 
-    /// The MCP port actually bound, or 0 when it is not listening. Zero with a
-    /// live WebSocket is a supported state, not a broken one — see `start()`.
+    /// The MCP port actually bound, or 0 when not listening. Zero with a live
+    /// WebSocket is a supported state, not a broken one -- see `start()`.
     int mcpPort() const;
 
     /// Where the token was published, whether or not it currently exists.
     juce::File tokenFile() const;
 
-    /// The dispatcher, shared by both transports: it must be one instance, or
-    /// revisions, undo grouping, and idempotency would each exist twice over one
-    /// project.
+    /// The dispatcher, shared by both transports so revisions, undo grouping,
+    /// and idempotency each exist once per project, not twice.
     RemoteApiService& service();
 
-    /// The subscription hub, for the same reason: MCP resource updates and
-    /// WebSocket subscriptions have to be fed by one projection of the model,
-    /// not two.
+    /// The subscription hub, for the same reason: one projection of the
+    /// model feeding both MCP resource updates and WebSocket subscriptions.
     SubscriptionHub& subscriptions();
 
     /**
      * @brief Who may do what, and who is connected right now (#1860).
      *
-     * Shared by both transports and edited by the settings dialog. Outlives the
-     * listeners deliberately: a grant is the user's decision about a client, and
-     * switching the feature off and on again must not silently forget it.
+     * Shared by both transports and edited by the settings dialog. Outlives
+     * the listeners deliberately: switching the feature off and on must not
+     * silently forget a grant.
      */
     RemoteClientRegistry& clients();
 
@@ -220,54 +158,34 @@ class RemoteApiHost {
     /**
      * @brief Mirror the registry's grants into the config file.
      *
-     * Wired as the registry's change handler, so a grant made in the settings
-     * dialog and one created by a client connecting for the first time are
-     * persisted by the same path — which means this is called from transport
-     * threads as well as the message thread.
+     * Wired as the registry's change handler, so a grant from the settings
+     * dialog and one from a client's first connection are persisted by the
+     * same path -- called from transport threads as well as the message
+     * thread.
      */
     void persistGrants();
 
     /**
      * @brief The pending config write, shared by every thread that asks for one.
      *
-     * A slot rather than a value captured per call, because the writes have to
-     * be ordered and there is more than one writer. A transport thread can
-     * snapshot the grants, the user can then revoke a scope and have that saved,
-     * and the transport's older snapshot would otherwise land last and restore
-     * what was just revoked — in the file the next launch reads.
-     *
-     * Whoever finds `posted` false owns the hop; everyone after simply replaces
-     * `latest`, which the pending task re-reads when it runs. So the newest
-     * state always wins and a burst of changes costs one write.
-     *
-     * Held by `shared_ptr` so a queued write can outlive this host without
-     * reaching into it.
+     * A slot rather than a value captured per call, because writes must be
+     * ordered across more than one writer. See
+     * docs/architecture/remote-api-host.md for the two-mutex protocol.
+     * Held by `shared_ptr` so a queued write can outlive this host.
      */
     struct GrantWriter {
         /// Guards `latest` and `posted`. Held briefly, never across I/O.
         std::mutex mutex;
-        /// Serialises the config write itself. Separate from `mutex` so a
-        /// transport thread recording a newer grant is never blocked behind a
-        /// file save — it leaves `latest` for whoever is inside the write to
-        /// pick up. Always taken before `mutex`, never after.
+        /// Serializes the config write itself. Always taken before `mutex`,
+        /// never after.
         std::mutex applyMutex;
         juce::var latest;
         bool posted = false;
     };
     std::shared_ptr<GrantWriter> grantWriter_ = std::make_shared<GrantWriter>();
-    // Declaration order is destruction order reversed, and it is load-bearing:
-    // a transport's connections deregister from the hub, the hub listens to the
-    // service's change source, and the bridge writes into the service. Each has
-    // to outlive the thing that talks to it.
-    //
-    // The client registry comes first because both transports hold a raw
-    // pointer to it, so it has to outlive them.
-    //
-    // The audit log is a `shared_ptr` rather than a `unique_ptr` because
-    // declaration order is not enough for it: a dispatch completion carrying it
-    // can still be queued on the message thread when this whole object is
-    // destroyed, and ordering members only decides what happens *inside* the
-    // destructor. Whoever still holds a share keeps it alive.
+
+    // Declaration order is destruction order reversed, and it is load-bearing.
+    // See docs/architecture/remote-api-host.md ("Member declaration order").
     std::shared_ptr<RemoteAuditLog> audit_;
     std::unique_ptr<RemoteClientRegistry> clients_;
     std::unique_ptr<RemoteApiService> service_;
@@ -284,39 +202,30 @@ class RemoteApiHost {
     /**
      * @brief Rewrite the discovery record from whatever is listening right now.
      *
-     * Called after every start, stop, and rotation, because the record is a
-     * projection of live state rather than of config: a port in it that nothing
-     * is answering on is the one failure mode it exists to prevent. Deletes the
-     * file instead when neither transport is up.
-     *
-     * Returns false when the record could not be written, which the callers
-     * treat as fatal to the listeners they just brought up — a listener whose
-     * token nobody can read is useless and still a listener.
+     * Called after every start, stop, and rotation: the record is a
+     * projection of live state, not of config, so a port in it that nothing
+     * answers on is exactly the failure mode it exists to prevent. Deletes
+     * the file when neither transport is up. Returns false when the record
+     * could not be written, which callers treat as fatal to the listeners
+     * they just brought up.
      */
     bool publishRecord();
 
-    /// Drop the connections one transport was carrying. Its sockets are gone by
-    /// the time this runs, so anything still listed is a phantom row in the
-    /// settings table with a disconnect button that would answer false.
+    /// Drop the connections one transport was carrying.
     void forgetConnections(Transport transport);
 };
 
 /**
  * @brief The host the running application owns, or nullptr.
  *
- * The settings UI has to be able to turn the remote API on and off while MAGDA
- * is running — a toggle that only took effect after a restart would be a worse
- * answer than no toggle. The dialog is constructed from a static entry point
- * with no context to thread a pointer through, so the one instance the app owns
- * registers itself here.
+ * The settings UI needs to toggle the remote API at runtime, so the one
+ * instance the app owns registers itself here rather than being threaded
+ * through the dialog's static entry point.
  *
- * Message thread only, and last-constructed-wins. The application creates
- * exactly one; tests create several in sequence, and each destructor clears this
- * only if it is still the registered one, so an earlier host outliving a later
- * one cannot leave a dangling pointer behind.
- *
- * Returns nullptr in the headless CLI, in tests, and before the app has finished
- * starting — callers must check.
+ * Message thread only, last-constructed-wins: the application creates
+ * exactly one, tests create several in sequence, and each destructor clears
+ * this only if it is still the registered one. Returns nullptr in the
+ * headless CLI, in tests, and before the app has finished starting.
  */
 RemoteApiHost* activeHost();
 

--- a/magda/daw/api/remote_api_host.hpp
+++ b/magda/daw/api/remote_api_host.hpp
@@ -32,12 +32,19 @@ class SubscriptionHub;
  * Construct and destroy on the message thread: `ModelChangeBridge` attaches to
  * the model singletons, which notify there.
  *
- * The auth token is generated per run, never persisted to config, and lives in
- * an owner-only, per-process discovery file deleted on shutdown (see
- * docs/architecture/remote-api-host.md for the file format and why). `start()`
- * returns false and opens no socket when the feature is off, no token could be
- * generated, or the port is taken -- there is no partial state where MAGDA is
- * listening but unauthenticated.
+ * The auth token is generated per run, never persisted to config, and lives
+ * in an owner-only file beside the other app data, named after the process
+ * and deleted on shutdown so a client can find it with no configuration:
+ *
+ *     remote-api-<pid>.json
+ *     {"port":51734,"token":"...","url":"ws://127.0.0.1:51734/rpc",
+ *      "mcpPort":51735,"mcpUrl":"http://127.0.0.1:51735/mcp","pid":4021}
+ *
+ * See docs/architecture/remote-api-host.md for why (crash recovery, multiple
+ * instances, why the token isn't in config). `start()` returns false and
+ * opens no socket when the feature is off, no token could be generated, or
+ * the port is taken -- there is no partial state where MAGDA is listening
+ * but unauthenticated.
  */
 /// Which listener. Both are carried by one `RemoteApiHost`, but they are
 /// started, stopped, and credentialled independently (#2142).

--- a/magda/daw/api/remote_api_host.hpp
+++ b/magda/daw/api/remote_api_host.hpp
@@ -111,9 +111,9 @@ class RemoteApiHost {
      * Every connected client is disconnected, since that is what rotation
      * means. Clients reconnect by re-reading the discovery record, rewritten
      * before this returns. A no-op returning false when this transport is
-     * not listening. Per transport since #2142: the two hold separate
-     * tokens, so re-credentialling one doesn't drop the other's clients --
-     * that buys granularity, not isolation, since both still live in the same
+     * not listening. Each transport holds a separate token (#2142), so
+     * re-credentialling one doesn't drop the other's clients -- that buys
+     * granularity, not isolation, since both still live in the same
      * owner-only file. Message thread only, like `start()`.
      */
     bool rotateToken(Transport transport);

--- a/magda/daw/api/remote_service.hpp
+++ b/magda/daw/api/remote_service.hpp
@@ -45,38 +45,34 @@ struct Response {
  * @brief Executes remote operations safely against `MagdaApi`.
  *
  * The single point where a transport's thread becomes a DAW mutation. Every
- * adapter — WebSocket (#1856), MCP (#1858), and any later one — routes through
- * this rather than reaching into the facade itself, so validation, revisions,
- * undo grouping, idempotency, and error mapping exist once.
+ * adapter (WebSocket, MCP, and any later one) routes through this rather
+ * than reaching into the facade itself, so validation, revisions, undo
+ * grouping, idempotency, and error mapping exist once.
  *
  * ## Threading
  *
  * `dispatch` may be called from any thread. The work splits three ways:
+ * operation lookup and JSON-schema validation on the calling thread (pure
+ * functions of the request, so a malformed request never reaches the
+ * message thread); the handler and DTO copying on the message thread
+ * (forced, since `MagdaApi` reads live model state); serializing the DTO to
+ * bytes back on the calling thread, in the adapter.
  *
- * - **Calling thread**: operation lookup and JSON-schema validation. Both are
- *   pure functions of the request, so rejecting a malformed request never
- *   reaches the message thread at all — a client sending garbage cannot cost
- *   the DAW anything.
- * - **Message thread**: the handler, and copying results into DTOs. This is
- *   forced, not chosen: `MagdaApi` reads live model state, which is
- *   message-thread-only.
- * - **Calling thread again**: serializing the DTO to bytes, in the adapter.
+ * Handlers therefore run serially -- a real throughput ceiling inherent to
+ * the engine, not this design, since a worker pool would only queue on the
+ * same thread. Deadlines and the bounded idempotency cache are the
+ * mitigation; per-client rate/concurrency limits are separate (#1860).
  *
- * Handlers therefore run serially. That is a real throughput ceiling and is
- * inherent to the engine rather than to this design — a worker pool would only
- * queue on the same thread. Deadlines and the bounded idempotency cache are the
- * mitigation; per-client rate and concurrency limits are #1860.
- *
- * Nothing here touches the audio thread, and no `MessageManagerLock` is taken:
- * the hop is always an async post, never a blocking wait.
+ * Nothing here touches the audio thread, and no `MessageManagerLock` is
+ * taken: the hop is always an async post, never a blocking wait.
  *
  * ## Lifetime
  *
- * Queued work captures a shared cancellation token rather than `this`. After
- * `shutdown()` — which the destructor calls — any lambda still in the message
- * queue observes the cancelled token and completes with `Cancelled` without
- * dereferencing the service. `projectReplaced()` does the same for work queued
- * against a project that no longer exists.
+ * Queued work captures a shared cancellation token rather than `this`.
+ * After `shutdown()` (which the destructor calls), any lambda still in the
+ * message queue observes the cancelled token and completes with
+ * `Cancelled` without dereferencing the service. `projectReplaced()` does
+ * the same for work queued against a project that no longer exists.
  */
 class RemoteApiService {
   public:
@@ -176,23 +172,23 @@ class RemoteApiService {
     /**
      * @brief Where every dispatched request is recorded (#1860).
      *
-     * Optional and empty by default, so a test or a headless host pays nothing
-     * for it. Set once, by `RemoteApiHost`, before any transport starts.
+     * Optional and empty by default, so a test or headless host pays
+     * nothing for it. Set once, by `RemoteApiHost`, before any transport
+     * starts.
      *
-     * Shared ownership rather than a borrowed pointer, and that is not
-     * defensive: a dispatch completion carries the log and runs on the message
-     * thread, so it can still be queued when the host is destroyed and run
-     * afterwards. Declaring the log before the service only orders destruction
-     * *within* the host — it cannot help work that outlives the whole
-     * destructor. Holding a `shared_ptr` keeps the log alive for exactly as long
-     * as something might still write to it.
+     * Shared ownership rather than a borrowed pointer, not defensively: a
+     * dispatch completion carries the log and runs on the message thread,
+     * so it can still be queued when the host is destroyed and run
+     * afterwards -- declaration order in the host only protects destruction
+     * within the host, not work that outlives it, so the `shared_ptr` is
+     * what keeps the log alive for as long as something might write to it.
      *
-     * Auditing here rather than in each adapter is the same argument as
-     * enforcing scopes here: two transports would otherwise produce two
-     * differently-shaped records of the same operation, and a third would
-     * produce none until someone noticed. What the adapters do record is what
-     * this cannot see — connections opening, closing, and being refused before
-     * they became requests.
+     * Auditing here rather than in each adapter for the same reason scopes
+     * are enforced here: two transports would otherwise produce two
+     * differently-shaped records of one operation, and a third would
+     * produce none. What the adapters record instead is what this can't
+     * see -- connections opening, closing, and being refused before they
+     * became requests.
      */
     void setAuditLog(std::shared_ptr<RemoteAuditLog> log);
     std::shared_ptr<RemoteAuditLog> auditLog() const;
@@ -206,17 +202,17 @@ class RemoteApiService {
     /**
      * @brief Shared gate between queued work and the service's lifetime.
      *
-     * A queued job holds a `shared_ptr` to this, never a bare `this`. It takes
-     * `mutex` and re-reads `service`: non-null means the service is alive and
-     * stays alive for the duration, because `shutdown()` clears the pointer
-     * under the same lock and therefore cannot complete while a job is running.
-     * A raw `this` guarded by a separate flag would leave a window between
-     * observing the flag and dereferencing the pointer.
+     * A queued job holds a `shared_ptr` to this, never a bare `this`. It
+     * takes `mutex` and re-reads `service`: non-null means the service is
+     * alive and stays alive for the duration, since `shutdown()` clears the
+     * pointer under the same lock and can't complete while a job is
+     * running. A raw `this` guarded by a separate flag would leave a window
+     * between observing the flag and dereferencing the pointer.
      *
-     * The same lock serializes execution. On a host with a message thread that
-     * is nearly free — handlers already run only there. On a headless host,
-     * where `dispatch` runs inline on the caller's thread, it is what preserves
-     * the one-handler-at-a-time guarantee that the model requires.
+     * The same lock serializes execution. Nearly free on a host with a
+     * message thread, where handlers already run only there; on a headless
+     * host, where `dispatch` runs inline on the caller's thread, it's what
+     * preserves the one-handler-at-a-time guarantee the model requires.
      */
     struct ExecutionState {
         std::mutex mutex;

--- a/magda/daw/audio/MidiBridge.hpp
+++ b/magda/daw/audio/MidiBridge.hpp
@@ -19,15 +19,12 @@ namespace te = tracktion;
 class AudioBridge;
 
 /**
- * @brief Bridges MAGDA's MIDI model to Tracktion Engine's MIDI system
+ * @brief Bridges MAGDA's MIDI model to Tracktion Engine's MIDI system.
  *
- * Responsibilities:
- * - Enumerate and manage MIDI input devices
- * - Route MIDI inputs to tracks
- * - Monitor MIDI activity for visualization
- * - Thread-safe communication between UI and audio threads
- *
- * Similar to AudioBridge, but for MIDI.
+ * Enumerates and manages MIDI input/output devices, routes inputs to tracks,
+ * and monitors MIDI activity for visualization, with thread-safe
+ * communication between the UI and audio threads. The MIDI counterpart to
+ * AudioBridge.
  */
 // ============================================================================
 // RawMidiListener
@@ -65,22 +62,23 @@ class MidiBridge : public juce::MidiInputCallback {
     MidiBridge& operator=(MidiBridge&&) = delete;
 
     /**
-     * @brief Set AudioBridge reference for triggering MIDI activity and track lookup
-     * Must be called after AudioBridge is created
+     * @brief Set the AudioBridge reference used for triggering MIDI activity
+     * and track lookup. Must be called after AudioBridge is created.
      */
     void setAudioBridge(AudioBridge* audioBridge);
 
     /**
-     * @brief Clear the AudioBridge pointer before it's destroyed
-     * Prevents dangling pointer between shutdown steps
+     * @brief Clear the AudioBridge pointer before it's destroyed, to avoid a
+     * dangling pointer between shutdown steps.
      */
     void clearAudioBridge() {
         audioBridge_ = nullptr;
     }
 
     /**
-     * @brief Enable/disable forwarding MIDI to instrument plugins
-     * When enabled, incoming MIDI is injected into Tracktion tracks
+     * @brief Enable/disable forwarding MIDI to instrument plugins.
+     *
+     * When enabled, incoming MIDI is injected into Tracktion tracks.
      * @param enabled True to forward MIDI to plugins
      */
     void setMidiToPluginsEnabled(bool enabled) {

--- a/magda/daw/audio/osc/OscAddress.hpp
+++ b/magda/daw/audio/osc/OscAddress.hpp
@@ -46,11 +46,10 @@ namespace magda::osc {
  * addresses eight strips needs eight dense numbers. Resolving a position to a
  * track happens at apply time, on the message thread.
  *
- * Parsing is deliberately strict: an address carrying a wildcard where the
- * track number belongs is rejected, and so is `/magda/track/03/volume`. OSC
- * address *patterns* are a real part of the protocol, and quietly reading one
- * as an index would mean a surface driving every track at once when its author
- * meant one — or two spellings of the same strip drifting apart.
+ * Parsing is deliberately strict: a wildcard where the track number belongs
+ * is rejected, and so is `/magda/track/03/volume`. OSC address *patterns*
+ * are a real part of the protocol, and quietly reading one as an index would
+ * mean a surface driving every track at once when its author meant one.
  */
 
 /// Highest 1-based track number the fixed namespace addresses. Positions past
@@ -149,11 +148,11 @@ std::optional<OscCommand> parseOscAddress(juce::StringRef address);
 /**
  * @brief The address a command is spelled with. The inverse of the parser.
  *
- * Feedback (#2091) sends on the address a value is received on, so the spelling
- * has to come from the same place the grammar does rather than from a second
- * list of string literals that agrees with it today. `parseOscAddress` of the
- * result is `command` again, for every command the parser can produce, which is
- * what the round-trip test asserts over the whole slot space.
+ * Feedback sends on the address a value is received on (#2091), so the
+ * spelling has to come from the same place the grammar does rather than a
+ * second list of string literals that could drift from it. `parseOscAddress`
+ * of the result is `command` again, for every command the parser can
+ * produce -- what the round-trip test asserts over the whole slot space.
  *
  * Called on the message thread, once per address that actually changed, so it
  * builds a `juce::String` rather than writing into a caller's buffer.

--- a/magda/daw/audio/osc/OscPeers.hpp
+++ b/magda/daw/audio/osc/OscPeers.hpp
@@ -9,88 +9,78 @@
 
 namespace magda::osc {
 
-/// A peer's identity as it travels through the router: a number rather than a
-/// string, so a slot table, a ring entry and a binding row can each carry one
-/// cheaply.
+/// A peer's identity as it travels through the router: a number rather than
+/// a string, so a slot table, a ring entry and a binding row can each carry
+/// one cheaply.
 ///
-/// **Unique for the life of the process, and never a slot index.** The table
-/// below is bounded and reuses storage, but a value already published into the
-/// router's queues names the peer that published it and has to keep naming it
-/// until it drains. Handing an evicted host's number to whoever took its slot
-/// would let a held binding value from the old peer be recorded as the echo of
-/// the new one, so the new surface's first update would be suppressed while it
-/// still showed its pre-drain snapshot. An id that is never reused makes a
-/// stale one match nothing, which is exactly what should happen to it.
+/// **Unique for the life of the process, and never a slot index.** The
+/// table below is bounded and reuses storage, but a value already published
+/// into the router's queues names the peer that published it until it
+/// drains. Handing an evicted host's number to whoever took its slot would
+/// let a held binding value from the old peer be recorded as the new peer's
+/// own echo, so the new surface's first update would be wrongly suppressed.
+/// An id that is never reused makes a stale one match nothing.
 ///
-/// Unsigned and 64 bits wide because "never reused" has to survive an adversary
-/// as well as a session. Ids are minted only by `admit`, so a flood of spoofed
-/// junk cannot advance the counter at all; even a flood of *well-formed* OSC
-/// from spoofed hosts, at a million admissions a second, would take half a
-/// million years to exhaust it. A signed counter would have been undefined
-/// behaviour long before that and would have handed old ids back on the way.
+/// Unsigned and 64 bits wide because "never reused" has to survive an
+/// adversary as well as a session: ids are minted only by `admit`, so a
+/// flood of spoofed junk can't advance the counter, and even a flood of
+/// well-formed OSC from spoofed hosts at a million admissions a second
+/// would take half a million years to exhaust it.
 using OscPeerId = std::uint64_t;
 
-/// No peer: a message that did not come off a socket, or one from a host that
-/// has not said anything MAGDA understood yet. Reserved rather than allocated,
-/// which is why ids start at 1.
+/// No peer: a message that did not come off a socket, or one from a host
+/// that has not said anything MAGDA understood yet. Reserved rather than
+/// allocated, which is why ids start at 1.
 inline constexpr OscPeerId kNoOscPeer = 0;
 
 /**
  * @brief Who is talking to MAGDA over OSC (#2096).
  *
- * The thing #2091 could not have. `juce::OSCReceiver` consumed the datagram's
- * source address inside its own receive loop, so feedback had to be aimed at a
- * host the user typed in. MAGDA now owns the read loop, and every datagram
- * arrives with the address it came from — which is what makes "answer whoever
- * is talking" expressible at all.
+ * `juce::OSCReceiver` used to consume the datagram's source address inside
+ * its own receive loop, so feedback could only aim at a host the user typed
+ * in. MAGDA now owns the read loop, so every datagram arrives with the
+ * address it came from, making "answer whoever is talking" possible (#2091).
  *
  * ## Identity is the host, not the host and port
  *
- * A surface sends from an ephemeral port and listens on a fixed one. That
- * asymmetry is why `oscFeedbackPort` survives: the port to reply on cannot be
- * inferred from the port a message came from. It also means the sending port is
- * not part of who a peer *is* — keying on it would mint a new peer, and a new
- * snapshot, every time a surface's socket was recycled.
- *
- * The cost is that two surfaces on one machine are one peer. That is the same
- * limitation stated from the other end: there is one reply port, so there is
- * one reply.
+ * A surface sends from an ephemeral port and listens on a fixed one
+ * (`oscFeedbackPort`), since the reply port can't be inferred from the port
+ * a message arrived on. Keying on the sending port would mint a new peer
+ * every time a surface's socket recycled. The cost: two surfaces on one
+ * machine are one peer, since there's one reply port and so one reply.
  *
  * ## Bounded, and least-recently-heard evicted
  *
- * Eight, which is more surfaces than a mixer has fingers. The bound is what
- * keeps an unauthenticated UDP port from turning a spoofed source address into
- * unbounded growth, and eviction by last-heard is what keeps a real surface
- * from being pushed out by one.
+ * Eight, more surfaces than a mixer has fingers. The bound keeps an
+ * unauthenticated UDP port from turning a spoofed source address into
+ * unbounded growth; eviction by last-heard keeps a real surface from being
+ * pushed out by one.
  *
  * ## Threading
  *
- * `intern` is the receive thread; everything else is the message thread. A
- * `CriticalSection` rather than something lock-free, because the contended case
- * does not exist: the receive thread holds it for a scan of at most eight short
- * strings, and the message thread takes it once per tick.
+ * `intern` runs on the receive thread; everything else on the message
+ * thread. A `CriticalSection` rather than lock-free, since there's no
+ * contended case: the receive thread holds it for a scan of at most eight
+ * short strings, and the message thread takes it once per tick.
  *
- * `generation` is the cheap question — it changes only when the set of peers
- * *worth answering* changes, so the projector can notice a surface appearing
- * without comparing strings on every tick. It is atomic so that question needs
- * no lock at all.
+ * `generation` changes only when the set of peers *worth answering*
+ * changes, so the projector can notice a surface appearing without
+ * comparing strings every tick, and is atomic so that check needs no lock.
  *
  * ## Being heard from is not being answered
  *
- * A peer exists as soon as a datagram arrives, because "something is arriving
- * and none of it parses" is a different problem from silence and the settings
- * UI has to be able to tell them apart. But a peer is only *answerable* once it
- * has sent something MAGDA understood.
+ * A peer exists as soon as a datagram arrives, but is only *answerable*
+ * once it has sent something MAGDA understood -- the settings UI needs to
+ * tell "garbage arriving" apart from silence.
  *
- * That distinction is load-bearing rather than tidy. The bind address defaults
- * to every interface, UDP source addresses are trivially spoofed, and a
- * snapshot is hundreds of messages: without it, four bytes of garbage naming
- * someone else as the sender would enrol a peer, and the next tick would open a
- * sender to that host and stream a full project at it. Cycling more spoofed
- * sources than the table holds would sustain that indefinitely and evict the
- * real surface on the way past. Answering only peers that have said one
- * well-formed thing closes it, and the eviction order below is what keeps the
- * flood from pushing the real tablet out.
+ * That distinction is a security boundary, not tidiness: the bind address
+ * defaults to every interface, UDP source addresses are trivially spoofed,
+ * and a snapshot is hundreds of messages. Without it, four spoofed bytes
+ * naming someone else as sender would enrol a peer and the next tick would
+ * stream a full project at that host, and cycling more spoofed sources than
+ * the table holds would sustain that indefinitely while evicting the real
+ * surface. Answering only peers that have said one well-formed thing closes
+ * that hole.
  */
 class OscPeers {
   public:
@@ -101,20 +91,20 @@ class OscPeers {
         juce::String host;
         juce::int64 firstSeenMs = 0;
         juce::int64 lastSeenMs = 0;
-        /// Number of times this answerable peer spoke after at least five
-        /// seconds of silence. Lets the projector distinguish this peer's
-        /// restart from a generation change caused by some other peer.
+        /// Times this answerable peer spoke after 5+ seconds of silence.
+        /// Lets the projector tell this peer's restart apart from a
+        /// generation change caused by some other peer.
         std::uint64_t resumptions = 0;
-        /// Datagrams, not accepted messages: this counts what arrived from the
+        /// Datagrams, not accepted messages: counts what arrived from the
         /// peer, including what the router went on to reject.
         std::uint64_t datagrams = 0;
-        /// At least one message from this peer was understood. Only these are
-        /// answered — see the class comment.
+        /// At least one message from this peer was understood. Only these
+        /// are answered -- see the class comment.
         bool answerable = false;
     };
 
-    /// What a datagram's sender turned out to be. `answerable` is the peer's
-    /// state *before* this datagram, which is what lets the caller skip `admit`
+    /// What a datagram's sender turned out to be. `answerable` is the
+    /// peer's state *before* this datagram, letting the caller skip `admit`
     /// on the hot path.
     struct Arrival {
         OscPeerId id = kNoOscPeer;
@@ -126,35 +116,35 @@ class OscPeers {
      *
      * Receive thread. Allocates only when a host is seen for the first time.
      *
-     * The id is `kNoOscPeer` either way: an unvalidated host is counted in the
-     * table so the settings list can show it, but it is not given a number,
-     * because a number is what a surface is answered by and what a spoofed
-     * flood would otherwise consume without limit.
+     * Always returns `kNoOscPeer`: an unvalidated host is counted in the
+     * table so the settings list can show it, but isn't given a number,
+     * since a number is what answers a surface and what a spoofed flood
+     * would otherwise consume without limit.
      *
      * **An unvalidated host never displaces a peer that is being answered.**
-     * With every slot holding a real surface there is nowhere to put it, and
-     * the arrival is dropped entirely. Evicting here instead
-     * would mean one spoofed packet could drop a live surface, and the surface
-     * coming back would re-take the slot and be re-snapshotted — the same churn
-     * the answerable bit exists to stop, just one level up.
+     * With every slot holding a real surface the arrival is dropped
+     * entirely -- evicting here would mean one spoofed packet could drop a
+     * live surface, which would then re-take its slot and be
+     * re-snapshotted, the same churn the answerable bit exists to stop.
      *
-     * The cost is that the settings list stops counting new hosts once eight
-     * surfaces are connected. Losing a diagnostic line at that bound is a much
-     * better trade than losing a surface.
+     * The cost: the settings list stops counting new hosts once eight
+     * surfaces are connected. Losing that diagnostic line is a much better
+     * trade than losing a surface.
      */
     Arrival intern(juce::StringRef host, juce::int64 nowMs);
 
     /**
      * @brief Admit `host` as a peer worth answering.
      *
-     * Receive thread, and only once the router has accepted something from this
-     * datagram. Marks an existing peer answerable, or takes a slot for a host
-     * `intern` had no room for — evicting the least recently heard peer if that
-     * is what it costs, because a surface that has proved itself outranks one
-     * that has been quiet longer.
+     * Receive thread, once the router has accepted something from this
+     * datagram. Marks an existing peer answerable, or takes a slot for a
+     * host `intern` had no room for -- evicting the least recently heard
+     * peer if needed, since a surface that has proved itself outranks one
+     * that's been quiet longer.
      *
-     * Idempotent, and only a transition moves the generation: a fader mid
-     * gesture must not make the projector rebuild its fleet on every packet.
+     * Idempotent, and only a transition moves the generation: a fader
+     * mid-gesture must not make the projector rebuild its fleet on every
+     * packet.
      */
     OscPeerId admit(juce::StringRef host, juce::int64 nowMs);
 
@@ -167,11 +157,9 @@ class OscPeers {
     int count() const;
 
     /// Bumped when a peer becomes answerable, resumes after five seconds,
-    /// when an answerable peer is displaced, and by `clear`. Deliberately not
-    /// bumped by ordinary traffic from a
-    /// host that has said nothing usable: a spoofed flood would otherwise make
-    /// the projector rebuild its fleet every tick without ever creating a
-    /// surface.
+    /// is displaced, or by `clear`. Deliberately not bumped by ordinary
+    /// traffic from a host that's said nothing usable, or a spoofed flood
+    /// would make the projector rebuild its fleet every tick for nothing.
     std::uint64_t generation() const {
         return generation_.load(std::memory_order_acquire);
     }
@@ -183,10 +171,8 @@ class OscPeers {
   private:
     struct Entry {
         bool used = false;
-        /// `kNoOscPeer` until the host is admitted. Being admitted and having an
-        /// id are the same thing: nothing that has not said something MAGDA
-        /// understood is worth a number, and not minting one is what keeps a
-        /// spoofed flood from advancing the counter.
+        /// `kNoOscPeer` until the host is admitted -- being admitted and
+        /// having an id are the same thing (see OscPeerId).
         OscPeerId id = kNoOscPeer;
         juce::String host;
         juce::int64 firstSeenMs = 0;
@@ -204,8 +190,8 @@ class OscPeers {
     int slotForUnvalidatedHost() const;
 
     std::array<Entry, kMaxPeers> entries_;
-    /// Never reset, not even by `clear` — see `OscPeerId`. Advanced only by
-    /// `admit`.
+    /// Never reset, not even by `clear` -- see `OscPeerId`. Advanced only
+    /// by `admit`.
     OscPeerId nextId_ = 1;
     std::atomic<std::uint64_t> generation_{0};
     mutable juce::CriticalSection lock_;

--- a/magda/daw/audio/osc/OscRouter.hpp
+++ b/magda/daw/audio/osc/OscRouter.hpp
@@ -27,8 +27,8 @@ namespace magda::osc {
  * @brief Where a drained command is applied.
  *
  * The seam between "an OSC message arrived and survived coalescing" and "the
- * DAW changed", so the routing above it is testable without an engine, a
- * project, or a socket. `apply` is always called on the message thread.
+ * DAW changed", so routing is testable without an engine, project, or
+ * socket. `apply` is always called on the message thread.
  */
 class OscCommandSink {
   public:
@@ -52,7 +52,7 @@ class OscCommandSink {
  * @brief Where a bound OSC value is applied.
  *
  * Separate from `OscCommandSink` because a binding carries its own mode,
- * range and curve, and resolves through the alias/resolver machinery — none of
+ * range and curve and resolves through the alias/resolver machinery, none of
  * which the fixed namespace has. Both are called on the message thread.
  */
 class OscBindingSink {
@@ -88,17 +88,16 @@ struct OscLearnCapture {
  * @brief The OSC bindings in force, with a pending value for each.
  *
  * Built on the message thread whenever the binding registry changes, then
- * published whole. The receive thread takes a `shared_ptr` copy — a reference
- * count bump, no lock and no allocation — and reads through it.
+ * published whole; the receive thread takes a `shared_ptr` copy (a refcount
+ * bump, no lock, no allocation) and reads through it.
  *
- * The pending values live *in here* rather than in the router, and that is the
- * point. A slot index only means anything relative to the list it was resolved
- * against, so an index and its value have to be interpreted against the same
- * snapshot or a re-bind could land one control's value on another's parameter.
- * Keeping both together makes that impossible to express: a value written into
- * a snapshot that has since been replaced is simply dropped along with it,
- * which for a fader mid-gesture is one lost update at the moment the user
- * edited their bindings.
+ * Pending values live in here rather than in the router because a slot index
+ * only means anything relative to the list it was resolved against -- index
+ * and value must be interpreted against the same snapshot, or a re-bind
+ * could land one control's value on another's parameter. A value written
+ * into a snapshot that's since been replaced is simply dropped with it,
+ * which for a fader mid-gesture is one lost update at the moment bindings
+ * were edited.
  */
 struct OscBindingRoutes {
     struct Entry {
@@ -119,7 +118,7 @@ struct OscBindingRoutes {
     std::size_t dirtyWords = 0;
 
     /// Build from the bindings in force. Anything that is not a valid OSC
-    /// source is skipped rather than rejected — the registry holds both kinds.
+    /// source is skipped rather than rejected -- the registry holds both kinds.
     static std::shared_ptr<OscBindingRoutes> build(const std::vector<Binding>& bindings);
 
     /// The half-open range of entries matching `address`, or an empty range.
@@ -134,12 +133,10 @@ struct OscBindingRoutes {
  * @brief What a message means for the command its address named.
  *
  * Returns nullopt when the message should be ignored: the release half of a
- * momentary button, or a value-carrying address sent without a number to carry
- * (a bare `/magda/track/1/volume` says nothing about where the fader is).
- *
- * Int and float arguments are both accepted because surfaces disagree about
- * which to send for a button, and a template that works in TouchOSC should not
- * fail in Open Stage Control over the type tag of a 1.
+ * momentary button, or a value-carrying address sent without a number to
+ * carry (a bare `/magda/track/1/volume` says nothing about where the fader
+ * is). Accepts both int and float arguments, since surfaces disagree about
+ * which to send for a button.
  */
 std::optional<float> oscValueFor(const OscCommand& command, const OscMessageView& message);
 
@@ -153,71 +150,57 @@ std::optional<float> oscValueFor(const OscCommand& command, const OscMessageView
  * ## Every message carries who sent it
  *
  * MAGDA reads its own datagrams (#2096), so an `OscPeerId` travels with a
- * message from the socket all the way to the feedback taps. That is what lets
- * the answering half suppress the echo to the surface that produced a value
- * without also suppressing it to the surface that did not. The peer table lives
- * here rather than in `OscService` because the router is the layer that already
- * knows what a message *was*, and because the feedback projector holds a router
- * reference and nothing else.
+ * message from the socket to the feedback taps -- what lets the answering
+ * half suppress an echo to the surface that produced a value without
+ * suppressing it to every other surface. The peer table lives here rather
+ * than in `OscService` because the router already knows what a message
+ * *was*, and the feedback projector holds only a router reference.
  *
- * `kNoOscPeer` is legal and means "not from a socket" — a test, or anything
- * driving the router directly. It names no surface, so the feedback taps report
- * it and nothing answers, which is the right outcome: a value that came from
- * nowhere is not an echo of anyone.
+ * `kNoOscPeer` means "not from a socket" (a test, or code driving the router
+ * directly): it names no surface, so feedback taps report it and nothing
+ * answers -- correct, since a value from nowhere is not an echo of anyone.
  *
  * ## Two kinds of traffic, two paths
  *
- * A tablet mixer sends continuously while a finger is down — a fader stream at
- * 100 Hz per control is the normal case, not the adversarial one, and eight
- * strips moving at once is a chord change. Posting each message to the message
- * thread would put the DAW's UI thread on the far end of a network firehose,
- * and posting each one *in order* would mean the user's last fader position
- * waiting behind several hundred stale ones.
+ * A tablet mixer sends continuously while a finger is down -- a fader stream
+ * at 100 Hz per control is normal, not adversarial. Posting every message to
+ * the message thread in order would put the DAW's UI thread behind a network
+ * firehose, with the user's latest fader position queued behind stale ones.
  *
- * So a **continuous value** — a level, a tempo, a beat position — is not
- * posted, it is published. Every address in the fixed namespace owns a slot
- * (`oscSlotIndex`), a store into that slot overwrites whatever had not been
- * applied yet, and the message thread drains the whole table at once. What
- * lands is the most recent value per address, at whatever rate the message
- * thread can absorb, and the cost of a faster surface is finer resolution
- * rather than a longer queue.
+ * So a **continuous value** (a level, a tempo, a beat position) is
+ * published, not posted: every fixed-namespace address owns a slot
+ * (`oscSlotIndex`), a store overwrites whatever hadn't been applied yet, and
+ * the message thread drains the whole table at once. Only the latest value
+ * per address lands, at whatever rate the message thread can absorb.
  *
- * A **discrete command** — a trigger or a toggle — cannot be treated that way,
- * because it is an edge rather than a value and latest-value-wins is the wrong
- * algebra for edges. Two bare mute messages are two flips and should cancel;
- * collapsing them into one slot leaves the track muted. Worse, `play` and
- * `stop` are two addresses over one state, so resolving them by slot order
- * rather than arrival order makes a bundle of `[stop, position, play]` — an
- * ordinary show-control cue, delivered atomically into a single drain — land
- * stopped. So triggers and toggles go into a small bounded ring in arrival
- * order instead, which is affordable precisely because they come from fingers
- * and buttons rather than from a fader stream.
+ * A **discrete command** (a trigger or toggle) can't be treated that way: it
+ * is an edge, and latest-value-wins is the wrong algebra for edges (two bare
+ * mute messages should cancel, not collapse into "stays muted"; a
+ * `[stop, position, play]` bundle resolved by slot order rather than arrival
+ * order would land stopped). So triggers and toggles go into a small bounded
+ * ring in arrival order instead -- affordable because they come from fingers
+ * and buttons, not a fader stream.
  *
- * The drain applies the coalesced values first and the ordered commands after.
- * That is the useful order for the cue above: the locate lands, then the
- * transport acts on it, rather than rolling from the old position and jumping.
- *
- * What remains is that two *continuous* addresses are not applied in arrival
- * order relative to each other — a drain walks slots. Within one address order
- * is preserved trivially, because only the latest value exists. That is the
- * standard control-surface tradeoff, and with edges moved off this path there
- * is no longer a pair of addresses whose relative order changes the outcome.
+ * The drain applies coalesced values first, then ordered commands -- so for
+ * the cue above, the locate lands and then the transport acts on it, rather
+ * than rolling from the old position. Two continuous addresses are still not
+ * ordered relative to each other (a drain walks slots), which is the
+ * standard control-surface tradeoff once edges are off this path.
  *
  * ## Threading
  *
  * `handleMessage` runs on the OSC receive thread. Ordinary routing takes no
- * lock and, apart from the one `callAsync` that carries a drain to the message
- * thread, it allocates nothing: parsing is a scan over the address bytes, and
- * publishing is a store plus an atomic bit. An armed learn session briefly
- * locks while claiming its one capture so cancellation can safely happen from
- * another thread. Because at most one drain is outstanding at a time, the
- * drain allocation is bounded by the drain rate rather than by the message
- * rate — a surface sending faster cannot make the receive thread allocate
- * more. A slow or blocked message thread makes MAGDA coarser, never the network
+ * lock and allocates nothing except the one `callAsync` that carries a drain
+ * to the message thread: parsing is a scan over address bytes, publishing is
+ * a store plus an atomic bit. An armed learn session briefly locks while
+ * claiming its one capture, so cancellation can happen safely from another
+ * thread. At most one drain is outstanding at a time, so drain allocation is
+ * bounded by drain rate, not message rate -- a faster surface can't make the
+ * receive thread allocate more, only make MAGDA coarser, never the network
  * thread slower.
  *
- * Nothing here touches the audio thread; parameter writes reach it through the
- * same host-write path the MIDI control surfaces use.
+ * Nothing here touches the audio thread; parameter writes reach it through
+ * the same host-write path the MIDI control surfaces use.
  */
 class OscRouter {
   public:
@@ -230,37 +213,33 @@ class OscRouter {
     /**
      * @brief Whether a call to `handleMessage` should act or only answer.
      *
-     * `Preflight` decides acceptance and changes nothing: no value published,
-     * no drain scheduled, no learn session consumed, no counter advanced. It
-     * exists because the receive loop has to know whether a packet is worth
-     * anything *before* it publishes it — a peer that has not been admitted yet
-     * has no id, and publishing under `kNoOscPeer` would lose the first
-     * gesture's echo bit, which is exactly the gesture a new surface makes.
-     *
-     * Only paid on packets from a host that is not answerable yet, so it is
-     * once per surface rather than once per datagram.
+     * `Preflight` decides acceptance and changes nothing (no value
+     * published, no drain scheduled, no learn session consumed) -- the
+     * receive loop needs to know a packet is worth anything *before*
+     * publishing it, since a peer not yet admitted has no id and publishing
+     * under `kNoOscPeer` would lose that new surface's first echo bit. Paid
+     * once per surface, not once per datagram.
      */
     enum class Dispatch : std::uint8_t { Preflight, Apply };
 
     /**
      * @brief Receive-thread entry point.
      *
-     * **One caller at a time.** The ordered ring below is single-producer, and
-     * this is the only thing that writes to it. That holds today because a
-     * service owns one socket and therefore one receive loop, and because
-     * rebinding stops the old thread before the new one starts — but it is an
-     * invariant of this method rather than an accident of the caller, and a
-     * second concurrent caller would corrupt the ring silently.
+     * **One caller at a time**: the ordered ring is single-producer and this
+     * is the only writer to it. True today because one service owns one
+     * socket and one receive loop, and rebinding stops the old thread before
+     * the new one starts -- an invariant of this method, not an accident of
+     * the caller; a second concurrent caller would corrupt the ring silently.
      *
-     * @param message A view over the datagram it was parsed from, so it is only
-     *                valid for the duration of this call.
+     * @param message A view over the datagram it was parsed from, valid only
+     *                for the duration of this call.
      * @param peer    Who sent it, from `peers()`. `kNoOscPeer` for a caller
      *                that is not a socket.
      *
-     * @return true when the message was accepted. False means either that its
-     *         address was unknown or that a reserved fixed-namespace address
-     *         carried no usable value. Reserved addresses are never offered to
-     *         learn or bindings, regardless of this return value.
+     * @return true when the message was accepted. False means either its
+     *         address was unknown or a reserved fixed-namespace address
+     *         carried no usable value. Reserved addresses are never offered
+     *         to learn or bindings regardless of this return value.
      */
     bool handleMessage(const OscMessageView& message, OscPeerId peer = kNoOscPeer,
                        Dispatch dispatch = Dispatch::Apply);
@@ -268,9 +247,9 @@ class OscRouter {
     /**
      * @brief The same, for a caller holding one of JUCE's messages.
      *
-     * Tests, and anything that built a message rather than receiving one. The
-     * receive path does not come through here: it parses into a view directly,
-     * because building an `OSCMessage` is what allocates.
+     * Tests, and anything that built a message rather than receiving one.
+     * The receive path parses into a view directly, since building an
+     * `OSCMessage` is what allocates.
      */
     bool handleMessage(const juce::OSCMessage& message, OscPeerId peer = kNoOscPeer,
                        Dispatch dispatch = Dispatch::Apply);
@@ -287,9 +266,9 @@ class OscRouter {
     /**
      * @brief Apply everything pending right now, on the calling thread.
      *
-     * The message thread reaches this through the scheduled drain. It is public
-     * because tests drive it directly, and because a caller shutting the
-     * service down can flush rather than strand the last fader position.
+     * The message thread reaches this through the scheduled drain. Public
+     * because tests drive it directly, and a service shutting down can
+     * flush rather than strand the last fader position.
      */
     void drainPending();
 
@@ -302,14 +281,14 @@ class OscRouter {
     /**
      * @brief Publish the OSC bindings now in force.
      *
-     * Message thread only. Called whenever the binding registry changes; the
-     * receive thread picks the new set up on its next message without
-     * synchronising with anything.
+     * Message thread only. Called whenever the binding registry changes;
+     * the receive thread picks up the new set on its next message with no
+     * synchronisation needed.
      *
-     * Bindings are consulted only for addresses the fixed namespace declines,
-     * so `/magda/…` cannot be shadowed by one. That is deliberate: those
-     * addresses are a documented contract, and a binding that quietly took one
-     * over would make a stock template stop working with no way to see why.
+     * Bindings are consulted only for addresses the fixed namespace
+     * declines, so `/magda/...` can't be shadowed by one -- those addresses
+     * are a documented contract, and a binding quietly taking one over would
+     * break a stock template with no way to see why.
      */
     void updateBindings(const std::vector<Binding>& bindings);
 
@@ -322,15 +301,14 @@ class OscRouter {
     /**
      * @brief Capture the next control a surface moves.
      *
-     * Any session in progress is cancelled first. The next message carrying a
-     * readable number fires `onCaptured` on the message thread, and is consumed
-     * rather than routed — wiggling a fader to learn it should not also move
-     * whatever it is currently bound to.
+     * Cancels any session in progress. The next message with a readable
+     * number fires `onCaptured` on the message thread and is consumed
+     * rather than routed, so wiggling a fader to learn it doesn't also move
+     * whatever it's currently bound to.
      *
-     * Addresses in the fixed namespace are not captured. They already do
-     * something, that something is a documented contract, and binding one would
-     * mean the same gesture both moving a track fader and driving a parameter.
-     * A surface whose controls sit on `/magda/…` is already mapped.
+     * Addresses in the fixed namespace are never captured -- they already
+     * do something documented, and a surface whose controls sit on
+     * `/magda/...` is already mapped.
      *
      * May be called from any thread.
      */
@@ -344,22 +322,19 @@ class OscRouter {
     /**
      * @brief Watch the fixed-namespace values this router applies (#2091).
      *
-     * Called from `drainPending` with the slot and the value that landed, so
-     * feedback can tell its own echo from a change the user made in MAGDA. On
-     * the message thread, inside the drain, once per applied address.
+     * Called from `drainPending` with the slot and value that landed, so
+     * feedback can tell its own echo from a change the user made in MAGDA.
+     * On the message thread, inside the drain, once per applied address.
      *
-     * A toggle sent with no argument is not reported: it asks for a flip rather
-     * than naming a state, so the surface does not know what it produced and has
-     * to be told. Delta addresses are not reported for the same reason they are
-     * never echoed — there is no state behind them.
+     * A toggle sent with no argument is not reported (it asks for a flip,
+     * not a state, so the surface has to be told what it produced). Delta
+     * addresses are not reported for the same reason they are never echoed:
+     * there is no state behind them.
      *
-     * Set before any message is handled, and cleared by passing `{}`.
-     *
-     * The peer is the one whose value the drain applied. Where two surfaces
-     * wrote the same address between drains only the last is reported, which is
-     * the same latest-value-wins the slot itself is: the other surface is told
-     * the value, which is correct, because what it sent is no longer what MAGDA
-     * holds.
+     * Set before any message is handled, cleared by passing `{}`. The peer
+     * reported is whichever surface's value the drain actually applied --
+     * where two surfaces wrote the same address between drains, only the
+     * last is reported, matching the slot's own latest-value-wins.
      */
     using FeedbackTap = std::function<void(OscPeerId peer, int slot, float value)>;
     void setFeedbackTap(FeedbackTap tap);
@@ -367,11 +342,10 @@ class OscRouter {
     /**
      * @brief The same watch, for bound addresses (#2091).
      *
-     * Separate because a binding is not a slot: it is addressed by the string
-     * the surface sends, and the value reported is the surface's own position
-     * before the binding's mode, curve and range are applied — which is the
-     * quantity feedback has to compare against, since that is what it would
-     * send back.
+     * Separate because a binding is addressed by the string the surface
+     * sends, not a slot, and the value reported is the surface's own
+     * position before the binding's mode/curve/range are applied -- the
+     * quantity feedback needs, since that's what it would send back.
      *
      * Called from `drainPending`, on the message thread, once per applied
      * binding value.
@@ -383,38 +357,40 @@ class OscRouter {
     /**
      * @brief How a pending drain reaches the message thread.
      *
-     * Defaults to posting one, or running it inline when the caller is already
-     * on the message thread and when there is no message loop at all — the
-     * headless case, where deferring would mean never applying.
+     * Defaults to posting one, or running inline when already on the
+     * message thread or when there is no message loop at all (headless,
+     * where deferring would mean never applying).
      *
-     * A test replaces it to hold the drain instead of running it, which is the
-     * only way to observe what coalescing kept: applied inline, every value
-     * lands as it arrives and the table never holds more than one at a time.
-     * Set before any message is handled.
+     * A test can replace it to hold the drain instead of running it -- the
+     * only way to observe what coalescing kept, since applied inline every
+     * value lands as it arrives and the table never holds more than one at
+     * a time. Set before any message is handled.
      */
     void setDrainScheduler(std::function<void()> scheduler);
 
-    /// Messages accepted since construction, for the settings UI and tests —
-    /// "is anything actually arriving?" is the first question a surface that
-    /// will not talk to MAGDA raises.
+    /// Messages accepted since construction, for the settings UI and tests --
+    /// "is anything actually arriving?" is the first question a silent
+    /// surface raises.
     std::uint64_t acceptedMessageCount() const;
 
     /// Discrete commands dropped because the ordered ring was full. Non-zero
-    /// means a sender outran the message thread with buttons, which no surface
-    /// driven by fingers can do — so it reads as a flood rather than as use.
+    /// means a sender outran the message thread with buttons, which no
+    /// finger-driven surface can do -- reads as a flood, not normal use.
     std::uint64_t droppedCommandCount() const;
 
-    /// Depth of the ordered ring, and the most discrete commands one drain
-    /// applies before yielding. Public because it is a characteristic of the
-    /// class rather than an implementation detail: it bounds both how much a
-    /// burst can carry and how long the message thread stays inside a drain.
-    ///
-    /// Sized above the whole discrete address space — every track's mute and
-    /// solo, plus the transport's four — so a surface can state-dump every
-    /// button it owns in one bundle and lose none of it. That is the realistic
-    /// worst case; past it, a sender is outrunning the message thread with
-    /// buttons, which fingers cannot do. Bounded so that costs a fixed amount
-    /// of memory and some dropped presses rather than unbounded growth.
+    /**
+     * @brief Depth of the ordered ring, and the most discrete commands one
+     * drain applies before yielding.
+     *
+     * Public because it's a characteristic of the class, not an
+     * implementation detail: it bounds how much a burst can carry and how
+     * long the message thread stays inside a drain. Sized above the whole
+     * discrete address space (every track's mute and solo, plus the
+     * transport's four) so a surface can state-dump every button it owns in
+     * one bundle and lose none of it -- past that, a sender is outrunning
+     * the message thread with buttons, which fingers cannot do. Bounded so
+     * the cost is fixed memory and some dropped presses, not unbounded growth.
+     */
     static constexpr std::uint32_t kOrderedCapacity = 512;
     static_assert(kOrderedCapacity > (kMaxTrackNumber * 2) + 4,
                   "the ring must hold one press of every discrete address at once");
@@ -437,10 +413,10 @@ class OscRouter {
     bool pushOrdered(const OscCommand& command, float value, OscPeerId peer);
     void drainOrdered();
 
-    /// nullopt when the address is outside the fixed namespace; otherwise the
-    /// bool says whether its payload was accepted. A recognized address with an
-    /// unusable payload is still reserved and must not fall through to learn or
-    /// bindings.
+    /// nullopt when the address is outside the fixed namespace; otherwise
+    /// the bool says whether its payload was accepted. A recognized address
+    /// with an unusable payload is still reserved and must not fall through
+    /// to learn or bindings.
     std::optional<bool> handleFixedNamespace(const OscMessageView& message, OscPeerId peer,
                                              Dispatch dispatch);
     bool handleBindings(const OscMessageView& message, OscPeerId peer, Dispatch dispatch);
@@ -464,38 +440,36 @@ class OscRouter {
     FeedbackTap feedbackTap_;
     BindingFeedbackTap bindingFeedbackTap_;
 
-    /// Swapped whole on the message thread, read through a shared_ptr copy on
-    /// the receive thread. Null until bindings are first published.
+    /// Swapped whole on the message thread, read through a shared_ptr copy
+    /// on the receive thread. Null until bindings are first published.
     std::shared_ptr<OscBindingRoutes> bindingRoutes_;
 
-    /// Latest unapplied value per address. Written by the receive thread, read
-    /// by the drain; a torn read is impossible and a stale one is corrected by
-    /// the next store, which re-dirties the slot.
+    /// Latest unapplied value per address. Written by the receive thread,
+    /// read by the drain; a torn read is impossible and a stale one is
+    /// corrected by the next store, which re-dirties the slot.
     std::array<std::atomic<float>, kOscSlotCount> values_{};
 
-    /// Who wrote the value in the slot beside it. Never read without the dirty
-    /// bit, and the bit is only set after both stores, so there is no "unset"
-    /// state to initialise this to.
-    ///
-    /// A full id rather than a byte: ids are unique for the session precisely so
-    /// that one sitting here when its peer goes away resolves to nobody rather
-    /// than to whoever took its place.
+    /// Who wrote the value in the slot beside it. Never read without the
+    /// dirty bit, which is only set after both stores, so there is no
+    /// "unset" state to initialise this to. A full id rather than a byte,
+    /// since ids are unique for the session so one left here after its peer
+    /// goes away resolves to nobody rather than to whoever took its place.
     std::array<std::atomic<OscPeerId>, kOscSlotCount> valuePeers_{};
 
-    /// Which slots have something to apply. A bitmap rather than a queue so the
-    /// receive thread's publish is one `fetch_or` and repeated writes to one
-    /// address cost nothing extra.
+    /// Which slots have something to apply. A bitmap rather than a queue so
+    /// the receive thread's publish is one `fetch_or` and repeated writes to
+    /// one address cost nothing extra.
     std::array<std::atomic<std::uint64_t>, kDirtyWords> dirty_{};
 
-    /// Whether a drain is already posted. Cleared at the *start* of the drain,
-    /// not the end: a value published while the drain is walking the table must
-    /// be able to schedule the next one, or it would sit in its slot until the
-    /// surface happened to move again.
+    /// Whether a drain is already posted. Cleared at the *start* of the
+    /// drain, not the end: a value published while the drain is walking the
+    /// table must still be able to schedule the next one, or it would sit
+    /// in its slot until the surface happened to move again.
     std::atomic<bool> drainScheduled_{false};
 
-    /// Triggers and toggles, in the order they arrived. Single-producer: one
-    /// socket owns one receive loop, and `handleMessage` is documented as that
-    /// thread's entry point. Single-consumer: the drain.
+    /// Triggers and toggles, in arrival order. Single-producer (one socket
+    /// owns one receive loop; `handleMessage` is documented as its entry
+    /// point), single-consumer (the drain).
     std::array<OrderedCommand, kOrderedCapacity> ordered_{};
     std::atomic<std::uint32_t> orderedWrite_{0};
     std::atomic<std::uint32_t> orderedRead_{0};
@@ -505,8 +479,8 @@ class OscRouter {
 
     OscPeers peers_;
 
-    /// Cleared before the object dies so a drain still sitting in the message
-    /// queue completes without touching it.
+    /// Cleared before the object dies so a drain still sitting in the
+    /// message queue completes without touching it.
     std::shared_ptr<std::atomic<bool>> alive_{std::make_shared<std::atomic<bool>>(true)};
 };
 

--- a/magda/daw/audio/plugins/engine/ControlExecutor.hpp
+++ b/magda/daw/audio/plugins/engine/ControlExecutor.hpp
@@ -14,82 +14,73 @@
  * @file ControlExecutor.hpp
  * @brief The one thread everything that is not a block runs on (#2270).
  *
- * A device has two sides. The audio side is a block arriving on whatever thread
- * the host renders from, and it is already serialised by being one callback.
- * The control side -- reading a plugin's state, loading a preset, changing a
- * program, opening an editor -- is not serialised by anything unless something
- * says so, and the plugin underneath it is entitled to assume it is: every one
- * of those operations suspends the plugin, does something to it, and resumes
- * it, so two of them overlapping means the first to finish resumes a plugin the
- * second is still working on.
+ * A device has two sides. The audio side is a block arriving on whatever
+ * thread the host renders from, serialised by being one callback. The
+ * control side -- reading a plugin's state, loading a preset, changing a
+ * program, opening an editor -- isn't serialised by anything unless
+ * something says so, yet the plugin underneath is entitled to assume it is:
+ * every one of those operations suspends the plugin, does something to it,
+ * and resumes it, so two overlapping means the first to finish resumes a
+ * plugin the second is still working on.
  *
- * A host with a GUI already has an answer, and it is the message thread. The
- * mistake worth naming is treating the absence of one as an absence of the
- * question: a headless host has whatever threads it has, and "no message
- * manager" is not permission for all of them to reach a plugin at once. So the
- * control side has an execution context of its own, explicitly, and both kinds
- * of host name one rather than one kind going without.
+ * A host with a GUI already has an answer: the message thread. A headless
+ * host has whatever threads it has, and "no message manager" is not
+ * permission for all of them to reach a plugin at once -- so the control
+ * side gets an execution context of its own, explicitly, in every host.
  *
- * ## One at a time, and that includes nesting
+ * ## One at a time, including nesting
  *
- * Work is queued, always, including work asked for from the executor itself.
- * Running a nested piece inline would be the very failure this exists to
- * prevent: an operation that has suspended a plugin and asks for another would
+ * Work is queued, always, including work asked for from the executor
+ * itself. Running a nested piece inline would be the failure this exists to
+ * prevent: an operation that suspended a plugin and asks for another would
  * have the second run inside it, resume the plugin, and let audio back in
- * halfway through the first. It would also jump the queue past work already
- * waiting.
+ * halfway through the first, while also jumping the queue past work already
+ * waiting. So run() is fire and forget in every case, and composition is by
+ * callback: an operation needing another does it from its own completion,
+ * which by then has ended.
  *
- * So run() is fire and forget in every case, and composition is by callback:
- * an operation that needs another does it from its own completion, which by
- * then has ended.
+ * ## What happens to accepted work
  *
- * ## What happens to work that was accepted
+ * Accepted work is called exactly once, on the executor, and told which of
+ * two things happened: it ran, or it was cancelled because the executor
+ * went away before its turn came. Both arrive on the executor's own
+ * thread -- the whole point of having one -- so a caller writing a
+ * project's model in a completion is entitled to that thread either way,
+ * with no isCurrent() check or extra hop needed in every consumer.
  *
- * Accepted work is called exactly once, on the executor, and told which of the
- * two it is: it either ran, or it was cancelled because the executor is going
- * away before its turn came. Both arrive on the executor's own thread, which is
- * the whole point of having one -- a caller writing a project's model in a
- * completion is entitled to be on the same thread whichever of the two it got,
- * and an answer that arrived somewhere else would put an isCurrent() check and
- * a hop of its own into every consumer.
+ * A cancellation is not a late chance to reach a plugin; the device is
+ * going away, and this just lets whoever was waiting stop waiting.
  *
- * A cancellation is not a late chance to reach a plugin. The devices are going
- * away; what it is for is letting whoever was waiting stop waiting.
+ * Submission itself can fail: a stopped executor accepts nothing, and says
+ * so synchronously rather than pretending. A refused caller still owes
+ * whatever it owed for that operation, on its own thread, with no callback
+ * arriving later to say so.
  *
- * Submission itself can fail, and says so rather than pretending: an executor
- * that has stopped accepts nothing. A caller that is refused has been told,
- * synchronously, that nothing will run and nothing will be called -- so
- * whatever it owed for that operation is still its own to answer, on its own
- * thread, without a callback arriving from somewhere unexpected to say so.
- *
- * ## The one edge the guarantee is scoped to
+ * ## Where the guarantee is scoped
  *
  * "Exactly once, on the executor" holds for as long as the executor has a
- * context to run on. A SerialControlThread owns its thread and therefore owns
- * the guarantee outright. A MessageThreadControlExecutor borrows the host's
- * message loop: work it posted is cancelled on that loop when the executor is
- * destroyed, but a loop torn down under a posted call takes the call with it,
- * and nothing in this file can be standing on a thread that no longer exists.
- * That is process teardown rather than a project closing, and it is written
- * here rather than left as a surprise.
+ * context to run on. A SerialControlThread owns its thread and owns the
+ * guarantee outright. A MessageThreadControlExecutor borrows the host's
+ * message loop: work it posted is cancelled on that loop when the executor
+ * is destroyed, but a loop torn down under a posted call takes the call
+ * with it -- that's process teardown rather than a project closing, and is
+ * noted here rather than left as a surprise.
  *
- * ## What this is for
+ * ## What runs here
  *
- * Every control operation on a device runs here, and every answer to one is
- * delivered here. That is what makes an out-of-process implementation an
- * add-on: its request goes out from this thread and its reply is marshalled
- * back onto the same one, so a caller writing a project's model in a callback
- * is on the thread it was always on, whichever process answered.
+ * Every control operation on a device runs here, and every answer is
+ * delivered here, which is what makes an out-of-process implementation an
+ * add-on: its request goes out from this thread and its reply is
+ * marshalled back onto the same one, so a caller writing a project's model
+ * in a callback is on the thread it was always on, whichever process
+ * answered. The capture is the first such operation (DeviceControl.hpp);
+ * presets, programs and editor windows are the same shape and belong here
+ * as they arrive.
  *
- * The capture is the first of those operations (DeviceControl.hpp). Presets,
- * programs and editor windows are the same shape and belong here as they
- * arrive, rather than each finding its own thread and its own convention.
- *
- * The asynchronous load is the one control operation that predates this and
- * still has a contract of its own: it completes on the message thread, which is
- * where JUCE hands a plugin over. It is not wrong, and it is the next thing to
- * join, so that a host with plugins in another process has one thread its
- * device operations happen on rather than two.
+ * The asynchronous plugin load predates this file and keeps its own
+ * contract: it completes on the message thread, where JUCE hands a plugin
+ * over. That's the next one to fold in, so a host with plugins in another
+ * process ends up with one thread for all of its device operations.
  */
 
 namespace magda::daw::audio::engine_adapter {
@@ -128,15 +119,13 @@ class ControlExecutor {
      * @brief Queue @p work, to run on this executor in the order it arrived.
      *
      * Never immediate, including when the caller is already on the executor.
-     * See the file comment: an operation that ran nested work inline would be
-     * letting a second transaction into a plugin the first has open.
+     * See the file comment: an operation that ran nested work inline would
+     * be letting a second transaction into a plugin the first has open.
      *
-     * @return whether it was accepted. Accepted work is called exactly once and
-     *         on this executor, with Ran or with Cancelled, scoped as the file
-     *         comment scopes it. A refusal means nothing will run it and
-     *         nothing will call it, so whatever the caller owed for it is still
-     *         owed -- and is owed on the caller's own thread, which is where it
-     *         has just been told.
+     * @return whether it was accepted. Accepted work is called exactly once
+     *         and on this executor, with Ran or Cancelled. A refusal means
+     *         nothing will run it and nothing will call it, so whatever the
+     *         caller owed for it is still owed, on the caller's own thread.
      */
     virtual bool run(Work work) = 0;
 
@@ -147,19 +136,19 @@ class ControlExecutor {
 /**
  * @brief The executor for a host that has a message thread.
  *
- * Which is every host with a window in it. Control work belongs on the message
- * thread there for reasons older than this file: it is the thread a plugin's
- * editor lives on, the one its own host callbacks expect, and the one the model
- * a callback writes into is edited from.
+ * Every host with a window in it. Control work belongs on the message
+ * thread there for reasons older than this file: it's the thread a
+ * plugin's editor lives on, the one its host callbacks expect, and the one
+ * the model a callback writes into is edited from.
  *
- * Work it has posted and this executor has not outlived is cancelled rather
- * than left to run against a plane that is gone: the post still arrives on the
- * message thread and is told it was cancelled, which keeps the answer on the
- * executor in both cases.
+ * Work already posted when this executor is destroyed is cancelled rather
+ * than left to run against a plane that's gone -- the post still arrives on
+ * the message thread and is told it was cancelled, keeping the answer on
+ * the executor either way.
  *
- * The loop is the host's rather than this object's, which is where the base
- * guarantee is scoped rather than kept: a message loop torn down under a posted
- * call takes the call with it, and there is no thread left to say so on.
+ * The loop is the host's, not this object's, which is where the base
+ * guarantee is scoped rather than kept: a message loop torn down under a
+ * posted call takes the call with it, with no thread left to say so on.
  */
 class MessageThreadControlExecutor final : public ControlExecutor {
   public:
@@ -183,27 +172,23 @@ class MessageThreadControlExecutor final : public ControlExecutor {
 /**
  * @brief The executor for a host that has no message thread.
  *
- * An offline render, a command-line tool, a test binary. It owns a thread and
- * runs what it is given on that one, in order, which is the same guarantee the
- * message thread gives an application and the reason a headless host is not
- * left deciding per call site.
+ * An offline render, a command-line tool, a test binary. It owns a thread
+ * and runs what it's given on that one, in order -- the same guarantee the
+ * message thread gives an application, so a headless host isn't left
+ * deciding per call site.
  *
- * Work still queued when this is destroyed is cancelled rather than dropped, so
- * every accepted operation is still answered once -- and answered on the worker
- * itself, which drains what is left as cancellations before it stops. The
- * destructor waits for that, so an executor that has been destroyed has
- * accounted for everything it accepted, on the one thread it promised to
- * account for it on.
- *
- * ## Being destroyed by its own work
+ * Work still queued when this is destroyed is cancelled rather than
+ * dropped, so every accepted operation is answered once, on the worker
+ * itself, which drains what's left as cancellations before stopping. The
+ * destructor waits for that.
  *
  * A completion running here is entitled to close the thing that owns this
- * executor -- a project closing from a callback is an ordinary outcome -- and
- * that makes the last reference fall on the executor's own thread. So the state
- * the worker touches is held apart from this object and outlives it, and a
- * destructor that finds itself on the worker detaches rather than joining: a
- * thread cannot wait for itself, and a worker whose state is still alive can be
- * left to finish the block it is in and stop.
+ * executor (a project closing from a callback is ordinary), which puts the
+ * last reference on the executor's own thread. So the state the worker
+ * touches is held apart from this object and outlives it, and a destructor
+ * that finds itself on the worker detaches rather than joining -- a thread
+ * can't wait for itself, and a worker whose state is still alive can finish
+ * the block it's in and stop on its own.
  */
 class SerialControlThread final : public ControlExecutor {
   public:

--- a/magda/daw/audio/plugins/engine/DeviceControl.hpp
+++ b/magda/daw/audio/plugins/engine/DeviceControl.hpp
@@ -13,39 +13,32 @@
 
 /**
  * @file DeviceControl.hpp
- * @brief Everything that is not rendering, addressed the way rendering is (#2270).
+ * @brief Everything that is not rendering, addressed the way rendering is.
  *
- * #1893 asks for location transparency from day one, so running a plugin in
- * another process later is an add-on rather than a rework. The realtime half
- * already has it (EngineDevice says nothing about where a device lives); the
- * control half did not, since editor windows and state captures reached the
- * plugin by asking for its juce::AudioPluginInstance directly -- the one
- * thing a plugin in another process can't hand over.
+ * Location transparency is a goal from day one (#1893): running a plugin in
+ * another process later should be an add-on, not a rework. The realtime half
+ * already has it -- EngineDevice says nothing about where a device lives --
+ * but editor windows and state captures used to reach the plugin directly via
+ * its juce::AudioPluginInstance, the one thing a plugin in another process
+ * can't hand over.
  *
  * This is an endpoint rather than an accessor because a bare instance pointer
  * is also how the "reading state and rendering must not overlap" rule loses
- * its owner: #2268 found two races of the same shape, where control and audio
- * both reached the plugin and neither side owned the rule. Behind an
- * endpoint, only the object owning the instance can touch it, from either
- * side.
+ * its owner: control and audio each reaching the plugin directly caused two
+ * races of the same shape (#2268). Behind an endpoint, only the object
+ * owning the instance can touch it, from either side.
  *
  * Keyed by magda::engine::DeviceKey rather than a live reference. Async and
  * fallible, since a remote implementation has IPC, a timeout, and a device
  * that can go away mid-call. Everything runs and answers on the plane's
- * ControlExecutor (ControlExecutor.hpp) -- one executor per plane serializes
- * every operation against every other, including reads that suspend/resume a
- * plugin, which is what actually needs serializing and can't be done by
- * checking a thread on a headless host.
+ * ControlExecutor (ControlExecutor.hpp), which serializes every operation
+ * against every other -- including reads that suspend/resume a plugin, which
+ * can't be done safely by checking a thread on a headless host.
  *
- * Nothing here writes a model directly: a capture comes back as data, the
- * caller checks the assignment it was read from still holds, then writes it
- * -- the same boundary completeExternalPluginLoad() applies on the load path,
- * for the same reason (a slot can be given a different plugin, or none,
- * between asking and answering).
- *
- * Not here yet: the editor window, MAGDA's other caller that reaches for an
- * instance. It belongs here when it's ported off the fork's plugin windows --
- * an editor is a control-plane request like any other.
+ * Nothing here writes a model directly: a capture comes back as data, and
+ * the caller checks the assignment it was read from still holds before
+ * writing it -- the same boundary completeExternalPluginLoad() applies on
+ * the load path (#2270).
  */
 
 namespace magda::daw::audio::engine_adapter {

--- a/magda/daw/audio/plugins/engine/DeviceControl.hpp
+++ b/magda/daw/audio/plugins/engine/DeviceControl.hpp
@@ -13,64 +13,39 @@
 
 /**
  * @file DeviceControl.hpp
- * @brief Everything that is not rendering, addressed the way rendering is
- *        (#2270).
+ * @brief Everything that is not rendering, addressed the way rendering is (#2270).
  *
- * #1893 asks for one thing beyond parity: the device op contract is
- * location-transparent from day one, so that running a plugin in another
- * process later is an add-on rather than a rework. The realtime half already
- * honours it -- magda::engine::EngineDevice says nothing about where a device
- * lives, and EngineExternalDevice is one implementation of it -- and the
- * control half did not. Editor windows and state captures reached the plugin by
- * asking the adapter for its juce::AudioPluginInstance, which is the one thing
- * a plugin in another process cannot hand over.
+ * #1893 asks for location transparency from day one, so running a plugin in
+ * another process later is an add-on rather than a rework. The realtime half
+ * already has it (EngineDevice says nothing about where a device lives); the
+ * control half did not, since editor windows and state captures reached the
+ * plugin by asking for its juce::AudioPluginInstance directly -- the one
+ * thing a plugin in another process can't hand over.
  *
- * ## Why it is an endpoint rather than an accessor
+ * This is an endpoint rather than an accessor because a bare instance pointer
+ * is also how the "reading state and rendering must not overlap" rule loses
+ * its owner: #2268 found two races of the same shape, where control and audio
+ * both reached the plugin and neither side owned the rule. Behind an
+ * endpoint, only the object owning the instance can touch it, from either
+ * side.
  *
- * A pointer to an instance is not only unavailable across a process boundary;
- * it is also how the serialisation rule lost its owner. Reading a plugin's
- * state and rendering through it must not overlap, and that rule needs one
- * object that can enforce it. Two races in the #2268 review were the same shape
- * twice: an operation reached the plugin from the control side while the audio
- * side was reaching it too, and neither side owned the rule. Behind an endpoint
- * the question does not arise -- the object that owns the instance is the only
- * thing that can touch it, from either side.
+ * Keyed by magda::engine::DeviceKey rather than a live reference. Async and
+ * fallible, since a remote implementation has IPC, a timeout, and a device
+ * that can go away mid-call. Everything runs and answers on the plane's
+ * ControlExecutor (ControlExecutor.hpp) -- one executor per plane serializes
+ * every operation against every other, including reads that suspend/resume a
+ * plugin, which is what actually needs serializing and can't be done by
+ * checking a thread on a headless host.
  *
- * ## The shape
+ * Nothing here writes a model directly: a capture comes back as data, the
+ * caller checks the assignment it was read from still holds, then writes it
+ * -- the same boundary completeExternalPluginLoad() applies on the load path,
+ * for the same reason (a slot can be given a different plugin, or none,
+ * between asking and answering).
  *
- * Keyed by magda::engine::DeviceKey, which is the identity the plan and the
- * assignment table already use, rather than by a reference to a live object.
- * Asynchronous and fallible, because a remote implementation has IPC, a
- * timeout, and a device that can go away mid-call.
- *
- * ## Where it all runs
- *
- * On the plane's ControlExecutor, which is the part that has to be explicit
- * rather than assumed (ControlExecutor.hpp). Every operation runs there and
- * every answer is delivered there: a caller may ask from any thread, and what
- * it gets back arrives on the one thread the control side of a device is
- * allowed to be on.
- *
- * That is what serialises these. Reading a plugin's state suspends it and
- * resumes it afterwards, so two operations overlapping would have the first to
- * finish resuming a plugin the second is still inside -- and neither the
- * endpoint nor the device can prevent it by checking a thread, because a
- * headless host has whatever threads it has. One executor answers it for every
- * operation at once, including the ones that are not written yet.
- *
- * Nothing here reaches a model. A capture comes back as data, the caller checks
- * that the assignment it was read from still holds, and only then is it written
- * down -- the same boundary completeExternalPluginLoad() applies to the other
- * direction, and for the same reason: between asking and answering, a slot can
- * have been given a different plugin, or none.
- *
- * ## What is not here yet
- *
- * The editor window. It is the other caller that reaches for an instance, and
- * it does not exist on this path yet: MAGDA's plugin windows are still the
- * fork's. It belongs here when it arrives -- an editor is a control-plane
- * request like any other -- and this file is where it goes rather than a second
- * accessor next to it.
+ * Not here yet: the editor window, MAGDA's other caller that reaches for an
+ * instance. It belongs here when it's ported off the fork's plugin windows --
+ * an editor is a control-plane request like any other.
  */
 
 namespace magda::daw::audio::engine_adapter {
@@ -80,18 +55,14 @@ class EngineExternalDevice;
 /**
  * @brief What a capture came back with: a snapshot, or a reason there is none.
  *
- * Exactly one of the two, and the type is what says so rather than a sentence
- * in a comment. That matters most at the boundary this is being built for: an
- * out-of-process implementation decodes one of these from bytes, and an
- * aggregate that permitted both or neither would leave every decoder
- * reconstructing an invariant nothing enforced -- with the both-present case
- * reading as success and carrying a reason nobody would look at.
+ * Exactly one of the two, enforced by the type rather than a comment -- this
+ * matters most at the boundary this is built for, where an out-of-process
+ * implementation decodes one of these from bytes and a both-or-neither
+ * aggregate would read a "success with an ignored reason" as fine.
  *
- * A failure is a string rather than an enumeration because every one of them is
- * something to tell a person and nothing to branch on: there is no device here,
- * this plugin would not describe itself, the answer did not come back in time.
- * A failure with nothing to say is refused the same way an empty snapshot is,
- * and gets a generic reason instead of an empty one.
+ * A failure is a string, not an enum: every one of them is something to tell
+ * a person (no device here, plugin wouldn't describe itself, timed out), not
+ * to branch on.
  */
 class CaptureOutcome {
   public:
@@ -105,8 +76,7 @@ class CaptureOutcome {
         return snapshot_.has_value();
     }
 
-    /// The snapshot. Only when ok(); a caller that asks otherwise is asking for
-    /// state that was never read.
+    /// The snapshot. Only when ok().
     const magda::ExternalPluginSnapshot& snapshot() const;
 
     /// Why there is none. Empty when ok().
@@ -124,16 +94,16 @@ class CaptureOutcome {
 /**
  * @brief Where a host asks a device for anything that is not a block.
  *
- * One implementation runs the plugin in this process and answers out of its own
- * table; another asks a process that is not this one. Which of them a host
- * holds is the whole of the difference between an in-process plugin and a
- * sandboxed one, and nothing above this has to know which it is (#1899).
+ * One implementation runs the plugin in this process; another asks a process
+ * that is not this one. Which a host holds is the whole difference between
+ * an in-process and a sandboxed plugin, and nothing above this needs to know
+ * which (#1899).
  */
 class DeviceControlPlane {
   public:
-    /// @p executor is where this plane's work runs and its answers arrive. Held
-    /// by shared_ptr because a remote implementation's reply comes back long
-    /// after the call that sent it.
+    /// @p executor is where this plane's work runs and its answers arrive.
+    /// Held by shared_ptr because a remote implementation's reply comes back
+    /// long after the call that sent it.
     explicit DeviceControlPlane(std::shared_ptr<ControlExecutor> executor);
 
     virtual ~DeviceControlPlane() = default;
@@ -149,33 +119,24 @@ class DeviceControlPlane {
     /**
      * @brief Ask the device at @p key what its plugin holds.
      *
-     * Asked from any thread, answered on the executor, always later than this
-     * returns. A caller writing a project's model in that callback is therefore
-     * on the thread it is entitled to write one from, whichever thread asked
-     * and whichever process answered -- and it is never handed that callback
-     * anywhere else, which is what keeps an isCurrent() check and a hop of its
-     * own out of every consumer.
+     * Asked from any thread, answered on the executor, always later than
+     * this returns -- so a caller writing a project's model in the callback
+     * is always on the thread it's entitled to write from.
      *
-     * @return whether the request was accepted. False is a plane that is
-     *         closing: nothing will run and @p completed will not be called, so
-     *         the caller still owes whatever it owed and has been told so here,
-     *         synchronously, rather than by a callback arriving from a thread
-     *         it was not expecting one on.
+     * @return whether the request was accepted. False means the plane is
+     *         closing: @p completed will not be called, and the caller is
+     *         told so synchronously rather than by a callback arriving from
+     *         an unexpected thread.
      *
      * An accepted request calls @p completed exactly once, on the executor,
-     * either with what the capture found or with a failure saying the plane
-     * closed before its turn came. The one thing that can take an accepted
-     * request away without a word is the host's message loop being torn down
-     * under it, which is process teardown (ControlExecutor.hpp).
-     *
-     * The callback outlives the call. Whatever it captures must still be there
-     * when it runs, or must be held weakly and checked -- the plane keeps its
-     * own end of that with the registry below and cannot keep the caller's.
+     * with either the capture or a failure saying the plane closed first.
+     * The callback outlives the call: whatever it captures must still be
+     * there when it runs, or held weakly and checked.
      */
     virtual bool captureState(magda::engine::DeviceKey key, CaptureCallback completed) = 0;
 
-    /// Where this plane's work runs, for a host that has something else to put
-    /// on the same thread.
+    /// Where this plane's work runs, for a host that has something else to
+    /// put on the same thread.
     const std::shared_ptr<ControlExecutor>& executor() const {
         return executor_;
     }
@@ -185,35 +146,15 @@ class DeviceControlPlane {
 };
 
 /**
- * @brief A registry that finds nothing is a failure, not an empty snapshot.
- *
- * Worth saying where the two meet: a slot with no plugin in it and a plugin
- * that would not describe itself are different findings, and a caller told the
- * second when the first happened would write a project's plugin state away as
- * absent.
- */
-
-/**
  * @brief The devices a plane can reach, owned by whoever runs them (#2270).
  *
- * A plane's work runs later than the call that queued it, so between the two a
- * project can be closed and a device can be taken out of the chain it was in.
- * Two lifetimes, and both have to be answered where the answer cannot be
- * forgotten.
- *
- * The registry answers the first: the plane holds it weakly, locks it before it
- * asks anything, and a registry that will not lock is a runtime that has gone.
- * The lease answers the second: what comes back from find() carries the device
- * rather than pointing at it, so a device removed or destroyed while a capture
- * is reading it is a device the capture is still holding.
- *
- * Neither is a caller's to remember. A token beside a lookup was the version
- * that could be got wrong -- keeping one alive says nothing about what the
- * other captured -- and the types say it now instead.
- *
- * The same shape the load path already has for the same problem, where an
- * assignment is held weakly and a completion that finds it gone is refused
- * (PluginAssignments.hpp).
+ * A plane's work runs later than the call that queued it, so between the two
+ * a project can close and a device can leave the chain it was in. The
+ * registry itself is held weakly (a registry that won't lock is a runtime
+ * that's gone); what find() returns is a lease that carries the device
+ * rather than pointing at it, so a device removed or destroyed mid-capture
+ * is one the capture is still holding. Same shape the load path already
+ * uses for the same problem (PluginAssignments.hpp).
  */
 class DeviceRegistry {
   public:
@@ -228,20 +169,12 @@ class DeviceRegistry {
     /**
      * @brief A lease on the device at @p key, or nothing.
      *
-     * A lease rather than a pointer, and that is the whole of what this
-     * interface is for. Holding the registry alive says only that the registry
-     * is alive: a device can be taken out of it, or destroyed by whatever owns
-     * it, while the registry itself carries on -- and a capture that had a bare
-     * pointer would be reading a plugin that had gone. So the lifetime comes
-     * back with the answer, and the operation holds it until it is finished.
-     *
-     * Which means a runtime owns its external devices by shared_ptr. That is
-     * the cost of this, and it is the smaller half of the bill: the alternative
-     * is every control operation reasoning about what else might be removing a
-     * device while it works.
-     *
-     * Empty for a key nothing is bound to, which includes one whose plugin has
-     * not finished loading. Called on the control executor.
+     * A lease rather than a bare pointer: holding the registry alive only
+     * says the registry is alive, not that a given device wasn't removed or
+     * destroyed from under it. The lifetime comes back with the answer, and
+     * the operation holds it until finished -- which is why a runtime owns
+     * its external devices by shared_ptr. Empty for a key nothing is bound
+     * to (including one still loading). Called on the control executor.
      */
     virtual std::shared_ptr<EngineExternalDevice> find(magda::engine::DeviceKey key) const = 0;
 };
@@ -249,10 +182,9 @@ class DeviceRegistry {
 /**
  * @brief The plane for plugins running in this process.
  *
- * It owns nothing: which device is at a key is the runtime's business, and the
- * runtime's registry is held weakly so that a project closing between a request
- * and its turn is a failure with a reason rather than a dereference of
- * something that has gone.
+ * Owns nothing: the runtime's registry is held weakly, so a project closing
+ * between a request and its turn is a failure with a reason rather than a
+ * dereference of something gone.
  */
 class LocalDeviceControlPlane final : public DeviceControlPlane {
   public:
@@ -268,37 +200,26 @@ class LocalDeviceControlPlane final : public DeviceControlPlane {
 /**
  * @brief The device a key names now, to write onto.
  *
- * The same question CurrentDeviceLookup asks on the load path, asked for
- * writing rather than for reading, and asked at the same moment: at completion
- * rather than when the operation started. A model captured when the capture was
- * requested would be a model whatever happened since has already left behind.
- *
- * Null for a key whose device is gone, which is a commit that does not happen.
+ * The write-side twin of CurrentDeviceLookup on the load path: asked at
+ * completion, not when the capture was requested, so a model that changed in
+ * between isn't clobbered. Null for a key whose device is gone, which is a
+ * commit that does not happen.
  */
 using MutableDeviceLookup = std::function<magda::DeviceInfo*(magda::engine::DeviceKey)>;
 
 /**
- * @brief Write @p snapshot onto the device @p request was made for, if that is
- *        still the device it was read from.
+ * @brief Write @p snapshot onto the device @p request was made for, if that
+ *        is still the device it was read from.
  *
- * The commit half, and the reason a capture is two steps with only data
- * between them. A snapshot is read from a plugin at one moment and written into
- * a project at another, and in between a slot can have been given a different
- * plugin, or emptied, or the whole runtime can have gone: writing it down then
- * would put one plugin's patch onto another's device, which is the failure the
- * assignment table exists to make impossible.
- *
- * The device is resolved here, from @p request's own key through @p device,
- * rather than passed in beside the token. A caller that handed over both would
- * be free to hand over a model the token says nothing about -- the check would
- * pass, the write would land somewhere else, and the boundary would be a
- * gesture. Validating one thing and writing another is the failure this exists
- * to prevent, so only one of them is the caller's to choose.
- *
- * @p request is what PluginAssignments::request() returned for the key when the
- * capture was asked for. Checked rather than trusted, and checked here rather
- * than at each call site, so the rule has one owner in this direction as it
- * does in the other (completeExternalPluginLoad).
+ * The commit half of a capture: between reading a snapshot and writing it, a
+ * slot can have been given a different plugin, emptied, or the runtime can
+ * be gone -- writing anyway would put one plugin's patch onto another's
+ * device. The device is resolved here, from @p request's own key through
+ * @p device, rather than accepted as a separate argument, so a caller can't
+ * validate one device and write another. @p request is what
+ * PluginAssignments::request() returned when the capture was asked for, and
+ * is checked here rather than at each call site (same owner as the
+ * equivalent check in completeExternalPluginLoad).
  *
  * @return whether anything was written.
  */

--- a/magda/daw/audio/plugins/engine/EngineDeviceFactory.hpp
+++ b/magda/daw/audio/plugins/engine/EngineDeviceFactory.hpp
@@ -18,39 +18,9 @@
  * @file EngineDeviceFactory.hpp
  * @brief What a Device op resolves to, asked of the app's own catalogs (#2174).
  *
- * The plan is topology: a Device op names an identity and owns no plugin, and
- * binding one is the host's job the way opening a WAV is. This is that job for
- * the devices MAGDA ships, and it asks the same two catalogs the current engine
- * asks -- the internal registry and the compiled-Faust catalog -- rather than
- * keeping a third list of what exists.
- *
- * It answers for a device that has moved to the SDK (InternalPluginSpec and
- * CompiledPluginSpec both carry `createDevice`) and returns null for one that
- * has not. That null is the honest answer and it is meant to be visible: a
- * device the engine cannot run has to be reported by whoever asked, never
- * quietly replaced by something that passes signal, because a stand-in the
- * incumbent does not have is a divergence wearing the costume of a null.
- *
- * Parameters are not written here. The plan's value layer resolves every one of
- * them per block and the adapter writes them before each process() call, so a
- * device created here starts at its own defaults and is at the project's values
- * by the first sample. What is not carried yet is the rest of a device's state
- * -- what MagdaDevice::restoreState() takes -- which is the pluginState v2
- * contract (#1887) and belongs with the state slice rather than with this one.
- *
- * The second half of the file is the same job for a plugin MAGDA did not write
- * (#2243). It is a different job in one respect that shapes everything below:
- * an internal device is a class this build contains and either exists or does
- * not, while an external plugin is a file on a machine that may have moved,
- * been upgraded, or never been installed. So creating one can fail for reasons
- * worth telling a user about, and it returns why rather than a null.
- *
- * An external plugin's saved state does travel, unlike an internal device's:
- * MAGDA persists the plugin's own chunk, and the adapter applies it along with
- * the saved parameter array it overlays (EngineExternalDevice::applySavedState).
- * What that leaves for the state slice (#2244) is the other direction --
- * writing the chunk back out of an instance the native engine holds, so a
- * project round-trips between the two engines during the dual-engine release.
+ * Internal devices ported to the SDK, plus external plugins (#2243) loaded
+ * sync or async. See docs/architecture/engine-device-factory.md for the full
+ * contract, including the async-load identity-boundary and lifetime rules.
  */
 
 namespace magda::daw::audio::engine_adapter {
@@ -58,53 +28,30 @@ namespace magda::daw::audio::engine_adapter {
 /**
  * @brief The engine device @p device names, or null when nothing can make one.
  *
- * Null for a device whose id is in neither catalog, and for one that is in a
- * catalog but has not moved to the SDK yet.
- *
- * @p offlineRender says which kind of render this instance is being built for,
- * and defaults to a live one. See EngineMagdaDevice's constructor: it decides
- * what a device is told about isRendering, and the default is the reading a
- * device may not get wrong.
+ * Null for a device whose id is in neither catalog, or that hasn't moved to
+ * the SDK yet. @p offlineRender selects what the device is told about
+ * isRendering (see EngineMagdaDevice's constructor); defaults to a live one.
  */
 std::unique_ptr<magda::engine::EngineDevice> createEngineDevice(const magda::DeviceInfo& device,
                                                                 bool offlineRender = false);
 
-/**
- * @brief Whether @p pluginId names a device the engine can run.
- *
- * The same question createEngineDevice() answers, without building one. What
- * asks is anything that has to report a project's unrunnable devices before it
- * renders: a corpus case, and the bridge at cutover.
- */
+/** @brief Whether @p pluginId names a device the engine can build right now. */
 bool canCreateEngineDevice(const juce::String& pluginId);
 
 /**
  * @brief Whether either catalog knows @p pluginId at all.
  *
- * A different question from the one above, and the two together are what
- * separates a device the engine is missing from a device there is none of.
- * False for an id nothing registered -- an external plugin, a device written
- * for a test, an empty id on a chain slot that stands for nothing -- and for
- * those the engine running nothing is what every host does.
- *
- * True with canCreateEngineDevice() false is the case worth reporting: the app
- * can build this device and the engine cannot, so a render that passed the
- * signal through is a render of a different project.
+ * True with canCreateEngineDevice() false is the case worth reporting: the
+ * app knows the device, the engine can't build it.
  */
 bool isRegisteredDevice(const juce::String& pluginId);
 
 /**
  * @brief What a host hands over before the engine can make an external plugin.
  *
- * Two things the engine has no way to own: the formats this build can load, and
- * what the last scan found installed. Both are the app's, and both are plain
- * JUCE rather than anything of the incumbent engine's, which is what lets the
- * native engine ask for them without reaching into it.
- *
- * The render context is here because a plugin is told the rate and block size
- * as it is created, before anything prepares it. It is prepared again by the
- * adapter, so this is not the authority on either number -- it is what a plugin
- * that allocates at construction has to go on.
+ * The formats this build can load and the last scan's results, both
+ * app-owned. `context` is only what a plugin allocating at construction goes
+ * on; the adapter prepares it for real afterward.
  */
 struct ExternalPluginServices {
     juce::AudioPluginFormatManager* formats = nullptr;
@@ -115,12 +62,9 @@ struct ExternalPluginServices {
 /**
  * @brief The exact installed plugin and the model facts safe to compile from.
  *
- * @ref planDevice is a transient copy. Resolution may correct the ordinary
- * effect/instrument role and apply capabilities cached under the installed
- * plugin's exact identifier, but it never rekeys or mutates the persistent
- * model. Display names, user preferences, explicit MIDI/Analysis roles and
- * saved channel widths remain the project's. Live channel topology is only
- * known after JUCE has instantiated the plugin and enabled all of its buses.
+ * A transient copy: resolution never rekeys or mutates the persistent model.
+ * Live channel topology is only known after JUCE instantiates the plugin and
+ * enables its buses.
  */
 struct ExternalPluginResolution {
     magda::DeviceInfo planDevice;
@@ -132,17 +76,14 @@ struct ExternalPluginResolution {
     }
 };
 
-/** Resolve once for both plan compilation and plugin creation. */
+/** @brief Resolve once for both plan compilation and plugin creation. */
 ExternalPluginResolution resolveEngineExternalPlugin(const magda::DeviceInfo& device,
                                                      const ExternalPluginServices& services);
 
 /**
  * @brief An external device, or why there is not one.
  *
- * Exactly one of the two is set. The failure is a sentence for a person: which
- * plugin, and what went wrong finding or loading it. A caller that has nowhere
- * to put it may drop it; a caller rendering a corpus case prints it, because a
- * project rendered without its plugin is a render of a different project.
+ * Exactly one of the two is set; `failure` is a message for a person.
  */
 struct ExternalDeviceResult {
     std::unique_ptr<magda::engine::EngineDevice> device;
@@ -151,41 +92,24 @@ struct ExternalDeviceResult {
     /**
      * @brief What the plugin holds now, for the caller to write into its model.
      *
-     * Restoring a plugin is not only something done to the plugin: a project's
-     * saved parameter array and the chunk beside it can disagree, the chunk
-     * wins, and everything downstream reads the model rather than the plugin.
-     * An automation lane's base value, a knob's position, and the values a
-     * render writes every block all come from there, so a model left holding
-     * the stale array would put them back on the next block.
-     *
-     * The engine does not correct the model itself and could not: the model is
-     * the one authority and this is a render path. So the correction is handed
-     * back, and applying it is the caller's, on the message thread
-     * (magda::applyRestoredParameters). A caller that already knows its model
-     * agrees with the plugin -- a project saved by a build that refreshed it --
-     * applies the same values it already had.
-     *
-     * Empty when nothing was created.
+     * The chunk wins over the saved parameter array; every downstream read
+     * (automation base value, knob position, render writes) comes from the
+     * model, so applying it is the caller's job, on the message thread
+     * (magda::applyRestoredParameters). Empty when nothing was created.
      */
     std::vector<magda::RestoredParameter> restoredParameters;
 
-    /**
-     * The current assignment enriched from the live instance after all buses
-     * were enabled. A caller may validate and publish this only on success;
-     * failures leave the persistent model exactly as it was.
-     */
+    /// The assignment enriched from the live instance after all buses were
+    /// enabled. Publish only on success; on failure leave the model as-is.
     std::optional<magda::DeviceInfo> resolvedDevice;
 };
 
 /**
  * @brief The adapter over an instance the host made itself.
  *
- * What both entry points below end at, and the seam for a host that creates its
- * plugins some other way. One transaction: the instance's buses are enabled,
- * which has to happen before anything reads its channel counts; the project's
- * saved parameter array and its chunk are applied in that order; and what the
- * plugin holds afterwards comes back in the result for the caller to write into
- * its model (ExternalPluginState.hpp).
+ * One transaction: enables buses, applies the saved parameter array then the
+ * chunk (in that order), and returns what the plugin holds afterward for the
+ * caller's model (ExternalPluginState.hpp).
  */
 ExternalDeviceResult adaptExternalPluginInstance(
     std::unique_ptr<juce::AudioPluginInstance> instance, const magda::DeviceInfo& device,
@@ -194,13 +118,9 @@ ExternalDeviceResult adaptExternalPluginInstance(
 /**
  * @brief The external plugin @p device names, created and ready to bind.
  *
- * Blocking: it resolves the description, loads the plugin and returns. What
- * that suits is a render waiting for the answer -- an offline bounce, a corpus
- * case -- where there is nothing to do until the plugin is there.
- *
- * A session opening a project wants the asynchronous form below instead, since
- * a plugin can take seconds to load and a project with forty of them would
- * otherwise open in a minute.
+ * Blocking: suits a render with nothing else to do meanwhile (offline
+ * bounce, corpus case). A session opening a project should use the async
+ * form below instead.
  */
 ExternalDeviceResult createEngineExternalDevice(const magda::DeviceInfo& device,
                                                 const ExternalPluginServices& services,
@@ -209,35 +129,20 @@ ExternalDeviceResult createEngineExternalDevice(const magda::DeviceInfo& device,
 /**
  * @brief What the model says about this device now, asked on the message thread.
  *
- * A plugin takes seconds to load and a project does not stop while it does. By
- * the time one arrives its device may have been edited, had a preset applied,
- * or been deleted, and the restoration is about to write the model's parameter
- * values onto the instance and hand corrected ones back. Doing that from a copy
- * taken when the load was requested would quietly undo whatever happened in
- * between.
- *
- * So the model is read at completion rather than captured at request. Null
- * means the device is gone, and the load is abandoned rather than completed
- * against a project that no longer has it.
- *
- * Keyed on engine::DeviceKey, not on a bare DeviceId: DeviceId is allocated per
- * section, so the main FX, post-FX and mixer-analysis sections can each hold the
- * same integer and a bare one names up to three devices.
+ * Read at completion rather than captured at request time, so a slow load
+ * can't clobber edits made while it was in flight. Null means the device is
+ * gone. Keyed on engine::DeviceKey rather than a bare DeviceId, since
+ * DeviceId is allocated per section and a bare id can name up to three
+ * devices.
  */
 using CurrentDeviceLookup = std::function<const magda::DeviceInfo*(magda::engine::DeviceKey)>;
 
 /**
  * @brief What an asynchronous load remembers about what it asked for.
  *
- * The assignment is the stable question the loader is answering, and it is a
- * weak reference to something the runtime owns rather than anything read off
- * the model (PluginAssignments.hpp). Saved plugin metadata is not part of the
- * question: resolving a moved plugin or an imported DAWproject legitimately
- * corrects it before this request completes.
- *
- * The display name makes an abandoned/failing request intelligible, and the
- * resolved role is the one installed fact completion still needs. The full
- * PluginDescription is deliberately not retained.
+ * A self-contained, weak-reference snapshot (PluginAssignments.hpp). Saved
+ * plugin metadata is deliberately excluded: resolving a moved plugin may
+ * legitimately correct it before completion.
  */
 struct RequestedPlugin {
     AssignmentRequest assignment;
@@ -248,25 +153,11 @@ struct RequestedPlugin {
 /**
  * @brief The end of an asynchronous load, once the instance exists.
  *
- * The seam the callback below ends at, and a host with a loader of its own
- * calls it directly. @p error is what the loader reported, used only when @p
- * instance is null.
- *
- * The requested assignment is asked first, and it is the identity boundary: the
- * load is completed only onto the assignment it was requested for. A device
- * that was deleted, had its plugin replaced, was duplicated or pasted from, or
- * whose id was handed out again after the project was cleared, no longer holds
- * that assignment. Nor does one that was never registered, which is why a
- * forgotten registration refuses the load instead of accepting it, nor one
- * whose whole runtime went away while the plugin loaded. Mutable plugin
- * metadata is deliberately not compared.
- *
- * Nothing but @p requested is needed for that, which is why it is a value:
- * a completion arriving after the runtime is gone answers from weak references
- * that have expired, rather than by reaching into it.
- *
- * @p currentDevice then supplies the model to restore from, read now rather
- * than captured when the load was requested.
+ * Enforces an identity boundary: completes only onto the assignment it was
+ * requested for, refusing if that assignment was deleted, replaced,
+ * duplicated/pasted from, had its id reused, was never registered, or its
+ * runtime is gone. @p error is what the loader reported, used only when
+ * @p instance is null. See docs/architecture/engine-device-factory.md.
  */
 ExternalDeviceResult completeExternalPluginLoad(std::unique_ptr<juce::AudioPluginInstance> instance,
                                                 const juce::String& error,
@@ -278,34 +169,15 @@ ExternalDeviceResult completeExternalPluginLoad(std::unique_ptr<juce::AudioPlugi
  * @brief The same as createEngineExternalDevice, without waiting for it.
  *
  * @p completed runs on the message thread when the plugin is ready or has
- * failed. Until then the plan has no device bound for that op, which the
- * executor already handles the way the incumbent does: the op passes its audio
- * through and says so in the diagnostics. Completion is therefore a re-prepare
- * rather than a hand-off -- bindings are resolved when a plan is prepared, so a
- * device that arrives later is published and the plan prepared again.
- *
- * The returned resolution carries the installed role and cached capabilities
- * a plan compiled while the instance loads must use. The persistent @p device
- * is never changed here; only a successful result carries live facts suitable
- * for validation and publication.
- *
- * The saved @p device is read once to work out which plugin to load.
- * @p currentDevice is read again at completion, to work out what to restore
- * onto it; see CurrentDeviceLookup for why those are two different questions.
- *
- * @p key says which live device this is being loaded for, and @p assignments is
- * read once, here, for the assignment that key holds now. It is not captured:
- * the request that comes out of it is self-contained and holds weak references,
- * so a runtime destroyed while a plugin is still loading is a load that expires
- * rather than a dangling one. A key with no assignment yields a request that
- * completion refuses.
- *
- * That expiry also gates @p completed. It is the runtime's own callback -- it
- * publishes the device into the project and reports the failures -- so if the
- * runtime that owns @p assignments is destroyed before the plugin arrives, it
- * is not called at all. A caller therefore does not have to make its completion
- * survive its own destruction; it has to keep the assignments alive for exactly
- * as long as it wants to hear about loads, which is the same thing said once.
+ * failed; until then the op passes audio through per the executor's existing
+ * diagnostics, and completion triggers a re-prepare rather than a hot swap.
+ * The saved @p device is read once to decide what to load; @p currentDevice
+ * is read again at completion to decide what to restore. @p key and
+ * @p assignments are read once, here, to build a self-contained request that
+ * expires rather than dangles if the runtime is destroyed mid-load; that
+ * same expiry gates @p completed, which is simply never called if the
+ * runtime owning @p assignments is gone first. See
+ * docs/architecture/engine-device-factory.md.
  */
 ExternalPluginResolution createEngineExternalDeviceAsync(
     const magda::DeviceInfo& device, magda::engine::DeviceKey key,
@@ -316,11 +188,7 @@ ExternalPluginResolution createEngineExternalDeviceAsync(
 /**
  * @brief Whether the scan knows the plugin @p device names.
  *
- * The question a report asks before it renders: a project whose plugin is not
- * installed on this machine renders without it in both engines, and that is
- * worth saying once rather than being read off a residual afterwards. True does
- * not promise the plugin will load -- a scanned plugin can still fail to
- * instantiate -- only that there is one to try.
+ * True doesn't promise the plugin will load, only that there is one to try.
  */
 bool isInstalledExternalPlugin(const magda::DeviceInfo& device,
                                const juce::KnownPluginList& knownPlugins);

--- a/magda/daw/audio/plugins/engine/EngineExternalDevice.hpp
+++ b/magda/daw/audio/plugins/engine/EngineExternalDevice.hpp
@@ -13,74 +13,56 @@
 
 /**
  * @file EngineExternalDevice.hpp
- * @brief A VST3, AU or LV2 plugin, as the native engine's executor sees it
- *        (#2241).
+ * @brief A VST3, AU or LV2 plugin, as the native engine's executor sees it (#2241).
  *
- * The third adapter, and the one with no MAGDA device behind it. EngineMagdaDevice
- * hosts a device this repository wrote and can ask anything of; this hosts a
- * binary somebody else shipped, whose only contract is juce::AudioPluginInstance.
- * What it owes the corpus is the same thing: given one project, render what the
- * fork renders.
+ * The one adapter with no MAGDA device behind it: it hosts a binary somebody
+ * else shipped, whose only contract is juce::AudioPluginInstance, and owes
+ * the corpus the same thing every device does -- given one project, render
+ * what the fork renders. That makes this a transcription of what
+ * te::ExternalPlugin does with a block, in the same order, rather than a
+ * design: a difference here is a difference in every project hosting a
+ * plugin, with no third opinion to appeal to. Each parity point is named
+ * beside the fork's reason for it, so a future fork change shows up as a
+ * diff here rather than an archaeology exercise:
  *
- * That makes this file a transcription rather than a design. Everything it does
- * between receiving a block and handing it back is what te::ExternalPlugin does
- * with the same block, in the same order, because a difference here is a
- * difference in every project that hosts a plugin and there is no third opinion
- * to appeal to. Each piece is written out below beside the fork's own reason for
- * it, so that the day the fork changes one, the divergence is a diff rather than
- * an archaeology exercise:
+ * - **Channel adaptation.** Processed at `max(max(1, inputs), outputs)`
+ *   channels; a mismatch with the block is bridged by the fork's rules: mono
+ *   feeding stereo duplicates, stereo feeding mono averages at half gain, a
+ *   mono output is spread back over a stereo block.
+ * - **Wet/dry.** Every external plugin gets a slot-level dry/wet pair it
+ *   never declared, defaulting fully wet, mixed in after processing and
+ *   persisted (DeviceInfo::wrapperParameters) so both engines agree on what
+ *   "40% wet" means.
+ * - **Parameter identity.** The automatable list is dry, then wet, then the
+ *   plugin's own parameters in plugin order -- the same positions MAGDA saved
+ *   as ParameterInfo::paramIndex, so the live mapping must reproduce that
+ *   list rather than invent one.
+ * - **Chunk vs. parameter array.** A project saves a plugin both ways; where
+ *   they disagree the chunk wins. Resolved before this class exists
+ *   (ExternalPluginState.hpp) -- by render time the model is the answer and
+ *   this only writes what the plan resolves from it.
+ * - **Further output pairs.** A multi-out sampler's extra channels get a plan
+ *   port each, copied out by the same mapping the engine wires its rack pins
+ *   by, not a second guess at plugin output layout.
+ * - **Latency.** Read once from the instance after prepareToPlay, reported to
+ *   the executor, compensated like any device.
+ * - **The playhead.** A tempo-synced plugin told nothing about the transport
+ *   renders a different project; the block already carries the answer.
  *
- * - **Channel adaptation.** A plugin is processed at
- *   `max(max(1, inputs), outputs)` channels whatever the chain around it is, and
- *   a mismatch between that and the block is bridged by the fork's own rules: a
- *   mono block feeding a stereo input duplicates, a stereo block feeding a mono
- *   input averages at half gain, and a mono output is spread back over a stereo
- *   block so the next device has two channels to read.
- * - **Wet/dry.** The fork gives every external plugin a slot-level dry/wet pair
- *   the plugin never declared, defaulting to fully wet, and mixes with it after
- *   processing. MAGDA persists both (DeviceInfo::wrapperParameters), so a
- *   project can carry a plugin that is 40% wet and the two engines have to agree
- *   about what that means.
- * - **Parameter identity.** The fork's automatable list is dry, then wet, then
- *   the plugin's own automatable parameters in plugin order. Those positions are
- *   what MAGDA saved as ParameterInfo::paramIndex and what the plan's value
- *   layer resolves against, so the mapping back onto the live instance has to
- *   reproduce that list rather than invent one.
- * - **Which of the two saved records wins** is settled before this class
- *   exists. A project saves a plugin twice, as a chunk and as an array of
- *   parameter values, and where they disagree the chunk is right; the
- *   restoration applies both in that order and hands the corrected values back
- *   for the model to record (ExternalPluginState.hpp). By the time a device is
- *   rendering, the model is the answer and this writes what the plan resolves
- *   from it.
- * - **Further output pairs.** A multi-out sampler's drum outs are the channels
- *   past its main pair, and the plan opens a port for each one the model
- *   recorded. They are copied out by the same mapping the current engine wires
- *   its rack pins by, rather than by a second guess at how a plugin lays its
- *   outputs out.
- * - **Latency.** Read once from the instance after prepareToPlay and reported to
- *   the executor, which compensates it the same way it compensates any device.
- * - **The playhead.** A plugin asks where the transport is, and a tempo-synced
- *   delay that is told nothing renders a different project. The block already
- *   carries the answer.
+ * Three known, named differences:
  *
- * Three differences are known and named here rather than found later:
- *
- * - **The all-notes-off flag.** The fork's MIDI container carries one beside the
- *   events, and turns it into per-channel note-offs, sustain-pedal releases and
- *   an MPE reset before the plugin sees the block. juce::MidiBuffer has no such
- *   flag, so the engine has nowhere to read it from; the same gap
- *   EngineMagdaDevice declares, and it closes in one place for both of them.
- * - **Denormal sanitising.** The fork clamps a plugin's output on Intel when the
- *   CPU's denormal flag was raised during the call. The native engine has no
- *   denormal handling at all yet, anywhere, so this adapter is not the place to
- *   add one: it is an executor-wide question (#2240) and it is a no-op on Apple
- *   silicon either way.
- * - **The transport's own state.** The fork's playhead reports whether the edit
- *   is recording and where its loop points are. A device under the plan is
- *   handed a stretch of timeline and not a transport, so those two fields are
- *   left unset until the recording and launcher subsystems give the block
- *   something to read them off (#1894, #1895).
+ * - **All-notes-off flag.** The fork's MIDI container carries one and expands
+ *   it into per-channel note-offs, sustain releases and an MPE reset before
+ *   the plugin sees the block. juce::MidiBuffer has no such flag -- the same
+ *   gap EngineMagdaDevice has, closed in one place for both.
+ * - **Denormal sanitising.** The fork clamps plugin output on Intel when the
+ *   CPU's denormal flag was raised. The native engine has none yet anywhere,
+ *   so this isn't the place to add it -- an executor-wide question (#2240),
+ *   and a no-op on Apple silicon regardless.
+ * - **Transport state.** The fork's playhead reports recording state and loop
+ *   points; a device under the plan gets a stretch of timeline, not a
+ *   transport, so those fields stay unset until the recording/launcher
+ *   subsystems can supply them (#1894, #1895).
  */
 
 namespace magda::daw::audio::engine_adapter {
@@ -88,34 +70,30 @@ namespace magda::daw::audio::engine_adapter {
 /**
  * @brief One external plugin instance bound to one Device op.
  *
- * Owns the instance. Everything the audio thread touches is sized in prepare():
- * the channel pointer array, the processing scratch, the dry copy the wet/dry
- * mix reads, and the MIDI buffer.
+ * Owns the instance. Everything the audio thread touches is sized in
+ * prepare(): the channel pointer array, processing scratch, the dry copy the
+ * wet/dry mix reads, and the MIDI buffer.
  *
- * The instance arrives created and with its buses enabled; what the project
- * saved for it is applied here, because the order of that is bound up with the
+ * The instance arrives created with buses already enabled; the project's
+ * saved state is applied here since that order is bound up with the
  * parameter list this class builds. Instantiation itself is a message-thread
- * job with a plugin format manager behind it, and it is not this class's (see
- * EngineDeviceFactory.hpp).
+ * job elsewhere (EngineDeviceFactory.hpp).
  */
 class EngineExternalDevice final : public magda::engine::EngineDevice {
   public:
     /**
      * @brief Binds @p instance, whose parameters @p device describes.
      *
-     * @p device is read for its parameter metadata and nothing else: the value
-     * the plan resolves for a slot is in that parameter's own units, and its
-     * ParameterInfo is what converts it back to the normalised position the
-     * plugin takes. The mapping from a slot to a live parameter comes from the
-     * instance rather than from the model, because that is where the fork's
-     * comes from and a stale model would otherwise write a project's values
-     * onto whatever the plugin's parameters are called this version.
+     * @p device is read only for parameter metadata: the plan resolves a
+     * slot's value in that parameter's own units, and its ParameterInfo
+     * converts it to the normalised position the plugin takes. The
+     * slot-to-live-parameter mapping comes from the instance, not the model
+     * -- a stale model would otherwise write a project's values onto
+     * whatever the plugin's parameters are called this version.
      *
-     * @p offlineRender says which kind of render this instance is being built
-     * for. It is the flag the fork sets on every external plugin before a
-     * bounce and clears afterwards, and a plugin is entitled to behave
-     * differently under it: an analogue-modelled saturator may oversample where
-     * it would not in a callback.
+     * @p offlineRender is the flag the fork sets on every external plugin
+     * before a bounce and clears after; a plugin may legitimately behave
+     * differently under it (e.g. oversampling only when bouncing).
      */
     EngineExternalDevice(std::unique_ptr<juce::AudioPluginInstance> instance,
                          const magda::DeviceInfo& device, bool offlineRender);
@@ -127,48 +105,38 @@ class EngineExternalDevice final : public magda::engine::EngineDevice {
     void setMidiOutputBoundBytes(int bytes) override;
     int latencySamples() const override;
 
-    /// One block through the plugin: its parameters written, its audio
-    /// processed, its MIDI carried.
-    ///
-    /// Does none of that while a host holds the plugin for a state read or
-    /// write, and passes the block through instead. That is the one thing in
-    /// this class which is not the fork's arrangement transcribed: the fork
-    /// waits on its own processMutex where this declines to block the audio
-    /// thread. The two can only differ while a save is in flight, and a corpus
-    /// render never takes one.
+    /**
+     * @brief One block through the plugin: parameters written, audio
+     * processed, MIDI carried.
+     *
+     * Passes the block through untouched while a control-side state read or
+     * write holds the plugin, instead of blocking the audio thread the way
+     * the fork's processMutex does -- the one place this class doesn't
+     * transcribe the fork verbatim. The two can only differ mid-save, and a
+     * corpus render never triggers one.
+     */
     void process(magda::engine::DeviceBlock& block) override;
 
     /**
      * @brief What the plugin holds now: chunk, parameter values, VST3 records.
      *
-     * The control half of this device, and the reason it is here rather than
-     * anywhere with a pointer to the instance (#2270). Reading a plugin and
-     * rendering through it are two things that must not overlap, and the rule
-     * saying so has to have one owner: this object holds the instance, honours
-     * the suspension in process(), and is therefore the only thing that can
-     * promise the two are serialised. A caller handed the instance instead
-     * would be holding half of a rule and no way to keep it.
+     * Lives here rather than behind a raw instance pointer (#2270) because
+     * reading a plugin and rendering through it must not overlap, and this
+     * object -- which holds the instance and honours the suspension in
+     * process() -- is the only thing that can enforce that.
      *
-     * Nullopt when the plugin threw describing itself, which is a plugin whose
-     * records would not agree with each other (ExternalPluginState.hpp).
+     * Nullopt when the plugin throws describing itself.
      *
-     * Called on the control executor, which is where every control operation on
-     * a device runs and what serialises them against each other
-     * (ControlExecutor.hpp). It matters here more than it looks: the read
-     * suspends the plugin and resumes it afterwards, so two overlapping readers
-     * would have the first to finish resuming the plugin underneath the second
-     * and letting a block back in mid-capture. This device does not check --
-     * a lock here would be a second answer to a question the executor already
-     * answers for the editor and the preset load as well.
+     * Called on the control executor, which serialises it against every
+     * other control operation on this device (ControlExecutor.hpp) -- needed
+     * because the read suspends and resumes the plugin, and two overlapping
+     * readers would race that. process() itself is gated by the plugin's own
+     * callback lock and suspended flag, tried rather than waited on, so a
+     * capture in flight costs a block its passthrough, never the deadline.
      *
-     * The audio thread is not party to any of it. process() is gated by the
-     * plugin's own callback lock and its suspended flag, which it tries rather
-     * than waits on, so a capture in flight costs a block its passthrough and
-     * never the deadline.
-     *
-     * It reads and does not write. What to do with a snapshot -- and whether
-     * the device it was read from is still the device the model means -- is the
-     * caller's, over in the control plane (DeviceControl.hpp).
+     * Read-only: what to do with a snapshot, and whether the device it came
+     * from is still the one the model means, is the caller's job in the
+     * control plane (DeviceControl.hpp).
      */
     std::optional<magda::ExternalPluginSnapshot> captureState();
 
@@ -181,8 +149,8 @@ class EngineExternalDevice final : public magda::engine::EngineDevice {
     /// plugin processes in place, at the width it asked for.
     void processPluginBlock(juce::AudioBuffer<float>& audio);
 
-    /// The block through a buffer of the plugin's own width, for a plugin whose
-    /// width is not the chain's or which has a sidechain bus to fill.
+    /// The block through a buffer of the plugin's own width, for a plugin
+    /// whose width differs from the chain's or has a sidechain bus to fill.
     void processThroughScratch(magda::engine::DeviceBlock& block, int numSamples, int destChannels);
 
     void readMidiIn(const juce::MidiBuffer& in);
@@ -199,51 +167,44 @@ class EngineExternalDevice final : public magda::engine::EngineDevice {
     /**
      * @brief What the plan's parameter slot at this index addresses.
      *
-     * Indexed by plan slot, which is the fork's automatable-parameter index:
-     * zero is the dry level, one is the wet level, and the rest are the
-     * plugin's automatable parameters in plugin order. A slot with no live
-     * parameter behind it -- a project saved against a plugin that has since
-     * dropped one -- carries a null and is skipped, which leaves the plugin
-     * wherever its own state put it.
+     * Indexed by the fork's automatable-parameter index: zero is dry, one is
+     * wet, the rest are the plugin's own parameters in plugin order. A slot
+     * with no live parameter behind it (a plugin that has since dropped one)
+     * carries a null and is skipped, leaving the plugin at its own state.
      */
     struct ParameterMapping {
         juce::AudioProcessorParameter* parameter = nullptr;
         magda::WrapperRole role = magda::WrapperRole::None;
 
-        /// The model's description of this parameter, or none. What it is for
-        /// is the conversion out of the plan's units, which is the same
-        /// conversion the value went in through.
+        /// The model's description of this parameter, if any -- used to
+        /// convert a value out of the plan's units the same way it went in.
         std::optional<magda::ParameterInfo> info;
     };
 
     std::vector<ParameterMapping> parameters_;
 
-    /// The wet/dry pair, held rather than written through: they are the host's
-    /// own numbers and the plugin has never heard of them.
+    /// The wet/dry pair, held rather than written through: the host's own
+    /// numbers, which the plugin has never heard of.
     float dryGain_ = 0.0f;
     float wetGain_ = 1.0f;
 
-    /// The width the plugin is processed at, which is its own rather than the
-    /// chain's: max(max(1, inputs), outputs).
+    /// The width the plugin is processed at: max(max(1, inputs), outputs).
     int processChannels_ = 0;
 
-    /// How many of those channels the plugin writes. Not the same number
-    /// whenever it has more inputs than outputs, and it is this one the chain
-    /// is filled from: the channels between the two carry input.
+    /// How many of those channels the plugin writes -- not the same as
+    /// processChannels_ whenever it has more inputs than outputs; this is
+    /// the count the chain is filled from.
     int outputChannels_ = 0;
 
     /**
      * @brief Where each further output pair starts in the plugin's own output.
      *
-     * Entry k is the pair the plan's `extraOutputs[k]` stands for, which is
-     * pair k + 1: pair 0 is the main output and is the buffer the chain carries
-     * on from. The channel it starts at is what the model recorded when it read
-     * the plugin's output buses (MultiOutOutputPair::firstPin, one-based), so
-     * this is the same mapping the current engine wires its rack pins by rather
-     * than a second guess at how a plugin lays its outputs out.
-     *
-     * Empty for every plugin that is not multi-out, which is almost all of
-     * them.
+     * Entry k is the plan's `extraOutputs[k]`, i.e. pair k + 1 (pair 0 is the
+     * main output the chain carries on from). The start channel is what the
+     * model recorded reading the plugin's output buses
+     * (MultiOutOutputPair::firstPin, one-based) -- the same mapping the
+     * engine wires its rack pins by. Empty for the (near-universal) case of
+     * a non-multi-out plugin.
      */
     struct OutputPair {
         int firstChannel = 0;
@@ -252,18 +213,17 @@ class EngineExternalDevice final : public magda::engine::EngineDevice {
 
     std::vector<OutputPair> extraOutputPairs_;
 
-    /// Input channels on the plugin's main bus, and how many it has after them.
-    /// The second is where a sidechain key lands, which is how every dynamics
-    /// plugin takes one.
+    /// Input channels on the plugin's main bus, and how many follow -- the
+    /// latter is where a sidechain key lands, how every dynamics plugin takes one.
     int mainInputChannels_ = 0;
     int sidechainInputChannels_ = 0;
 
-    /// Non-owning view over the block, for the case where the plugin's width
-    /// and the block's already agree and nothing needs copying.
+    /// Non-owning view over the block, used when the plugin's width and the
+    /// block's already agree and nothing needs copying.
     std::vector<float*> channels_;
 
-    /// The plugin's buffer when they do not agree, and the dry copy the mix
-    /// reads. Both sized in prepare() and never resized on the audio thread.
+    /// The plugin's buffer when they don't agree, and the dry copy the mix
+    /// reads. Both sized in prepare(), never resized on the audio thread.
     juce::AudioBuffer<float> scratch_;
     juce::AudioBuffer<float> dryScratch_;
 
@@ -271,19 +231,17 @@ class EngineExternalDevice final : public magda::engine::EngineDevice {
 
     double sampleRate_ = 44100.0;
 
-    /// What the instance was last prepared at, so a second prepare at the same
-    /// settings does not prepare it again. See prepare().
+    /// What the instance was last prepared at, so a repeat prepare() at the
+    /// same settings is a no-op.
     int preparedBlockSize_ = 0;
 
     int latencySamples_ = 0;
     int midiInputBoundBytes_ = magda::engine::kMaxMidiBytesPerPort;
 
-    /// What the executor reserved on the output port: one producer's worth,
-    /// because a plugin's MIDI output is its own. Every JUCE format replaces
-    /// the host's buffer with what the plugin declared, and a chain that wants
-    /// the raw input as well gets it from the plan's merge rather than from
-    /// here (#2345). Read from the executor rather than from the constant
-    /// because the figure is the port's (#2341).
+    /// What the executor reserved on the output port (one producer's worth --
+    /// every JUCE format replaces the host's MIDI-out buffer with what the
+    /// plugin declared, #2345). Read from the executor rather than the
+    /// constant because the figure is the port's (#2341).
     int midiOutputBoundBytes_ = magda::engine::kMaxMidiBytesPerPort;
     bool offlineRender_ = false;
     bool prepared_ = false;

--- a/magda/daw/audio/plugins/engine/PluginAssignments.hpp
+++ b/magda/daw/audio/plugins/engine/PluginAssignments.hpp
@@ -10,33 +10,28 @@
  * @file PluginAssignments.hpp
  * @brief Who a plugin is being loaded for, owned at runtime (#2261).
  *
- * An asynchronous plugin load takes seconds, and the answer has to be refused
- * when it comes back for a device that is no longer asking. Mutable plugin
- * metadata cannot decide that: resolution deliberately tolerates a moved file,
- * a renamed plugin, a missing vendor and an unreliable imported role, so a
- * comparison of names or paths finds a legitimate correction indistinguishable
- * from a swap. The question needs an identity nothing about the plugin can
- * change.
+ * An async plugin load takes seconds, and a stale answer must be refused
+ * when the device that asked for it is no longer asking. Mutable plugin
+ * metadata can't decide that: resolution deliberately tolerates a moved
+ * file, a renamed plugin, a missing vendor, an unreliable imported role -- so
+ * comparing names or paths can't tell a legitimate correction from a swap.
  *
- * That identity used to live in the model, as a counter on DeviceInfo minted by
- * whichever call site remembered to. It could not hold: DeviceInfo is a value,
- * and C++ copying cannot tell a snapshot from an undo record from a browser
- * template from a duplicate from a paste from a new live placement. The
- * invariant survived only as a habit, missed sites were found one at a time,
- * and a missed one failed the wrong way -- the copy kept the token, so a stale
- * load was *accepted* and one plugin's state was restored onto another.
+ * Identity used to live in the model, as a counter on DeviceInfo minted by
+ * whichever call site remembered to. That failed: DeviceInfo is a value, and
+ * copying it can't distinguish a snapshot from an undo record from a
+ * duplicate from a new live placement. A missed call site failed the wrong
+ * way -- the copy kept the token, so a stale load was accepted and one
+ * plugin's state got restored onto another.
  *
- * So identity is owned here instead, by whoever runs the plugins, and it is a
- * pointer rather than a number. A device that becomes live gets a handle; the
- * request holds a weak reference to it, and to the table it lives in; a load is
- * accepted only if that table still holds that same handle for that same key.
- * Nothing in the model carries it, so no copy, re-key or serialization path can
- * get it wrong, and a device that was never registered has no handle to lend --
- * which rejects its load rather than accepting it.
+ * So identity is owned here, as a pointer rather than a number. A live
+ * device gets a handle; a request holds a weak reference to it and to the
+ * table it lives in; a load is accepted only if the table still holds that
+ * same handle for that same key. Nothing in the model carries it, so no
+ * copy, re-key or serialization path can get it wrong, and an unregistered
+ * device has no handle to lend, so its load is rejected rather than accepted.
  *
- * Message thread only. Registration happens as devices are placed, and JUCE
- * calls an asynchronous load back on the message thread, so both ends of the
- * question are already there.
+ * Message thread only: registration happens as devices are placed, and JUCE
+ * calls an async load back on the message thread too.
  */
 
 namespace magda::daw::audio::engine_adapter {
@@ -44,21 +39,21 @@ namespace magda::daw::audio::engine_adapter {
 /**
  * @brief The identity of one live plugin assignment.
  *
- * Deliberately empty: it is identified by its address and by nothing else, so
- * there is no field a copy could carry and no value a caller could forge. Held
- * by shared_ptr so a request can hold a weak reference that expires on its own
- * when the assignment ends.
+ * Deliberately empty: identified by its address alone, so there's no field a
+ * copy could carry and no value a caller could forge. Held by shared_ptr so
+ * a request can hold a weak reference that expires on its own when the
+ * assignment ends.
  */
 struct AssignmentHandle {};
 
 /**
  * @brief The live set, held apart from the object that manages it.
  *
- * A load in flight outlives things. The project can be closed and the runtime
- * that owns the assignments destroyed while a plugin is still loading, and the
- * completion that arrives afterwards still has to answer -- so it cannot answer
- * by dereferencing the owner. It holds a weak reference to this instead, and a
- * table that is gone is a load nobody is waiting for.
+ * A load in flight can outlive its owner: the project can close and the
+ * runtime destroy the assignments while a plugin is still loading, and the
+ * completion that arrives afterward still has to answer without
+ * dereferencing anything gone. It holds a weak reference to this instead --
+ * a table that's gone is simply a load nobody is waiting for.
  */
 class AssignmentTable {
   public:
@@ -87,23 +82,22 @@ struct ActiveAssignment {
 /**
  * @brief What an asynchronous operation remembers about the device it is for.
  *
- * Both directions carry one. A load is answered by a plugin arriving and asks
- * whether the slot that wanted it still does; a state capture is answered by a
- * snapshot arriving and asks the same thing before writing it into a project
- * (DeviceControl.hpp). It is the same question either way -- is this still the
- * assignment the operation was started against -- so it is one type, and the
- * check is one function rather than a convention each caller reimplements.
+ * Both directions carry one: a load asks whether the slot that wanted it
+ * still does when the plugin arrives, and a state capture asks the same
+ * thing before writing a snapshot into a project (DeviceControl.hpp). Same
+ * question either way -- is this still the assignment the operation started
+ * against -- so it's one type with one check, not a convention every caller
+ * reimplements.
  *
- * Weak at both ends, and for the same reason. An operation must not keep an
- * assignment alive, because an assignment outliving its device is exactly the
- * state in which a stale answer would be accepted; and it must not keep the
- * table alive either, because the runtime that owns it may be gone by the time
- * the answer arrives. Either reference expiring is the answer "no longer
- * wanted", and an unregistered device hands out an already-expired handle, so
- * forgetting to register fails closed.
+ * Weak at both ends, for the same reason: an operation must not keep an
+ * assignment alive (that's exactly the state a stale answer would be
+ * accepted in), and must not keep the table alive either, since the runtime
+ * owning it may be gone by the time the answer arrives. Either reference
+ * expiring means "no longer wanted", and an unregistered device hands out an
+ * already-expired handle, so forgetting to register fails closed.
  *
- * Self-contained on purpose: completion needs nothing but this to decide, so
- * nothing about the runtime has to be captured by an asynchronous callback.
+ * Self-contained on purpose: completion needs nothing else to decide, so no
+ * async callback has to capture anything about the runtime.
  */
 struct AssignmentRequest {
     magda::engine::DeviceKey key;
@@ -113,18 +107,19 @@ struct AssignmentRequest {
     /**
      * @brief Whether a load answering this is still wanted.
      *
-     * True only when the table is still there and still holds, for this key,
-     * the very handle the request was made against. Every part matters: the
-     * weak handle can still be locked by a caller holding the ActiveAssignment
-     * it was given, and a key can be live again under a different assignment.
+     * True only when the table is still there and still holds, for this
+     * key, the exact handle the request was made against. Both parts
+     * matter: the weak handle can still be locked by a caller holding the
+     * ActiveAssignment it was given, and the key can be live again under a
+     * different assignment.
      */
     bool isStillWanted() const;
 
     /**
      * @brief Whether the key is live again under a different assignment.
      *
-     * Only for telling a person which of the two happened: a slot now asking
-     * for a different plugin, against a device that went away. Never the basis
+     * For telling a person which of the two happened -- a slot now wanting
+     * a different plugin, vs. a device that went away -- never as the basis
      * for accepting anything.
      */
     bool keyWasReassigned() const;
@@ -132,12 +127,12 @@ struct AssignmentRequest {
     /**
      * @brief Whether the runtime that owns this assignment is still there.
      *
-     * A different question from isStillWanted(), and the one a caller asks
-     * before *reporting* rather than before accepting. A device deleted while
-     * its runtime lives is a load to refuse and say so about, because something
-     * is waiting to hear it. A runtime that is gone is not: there is nothing to
-     * publish onto and nobody to tell, and a completion callback made by that
-     * runtime is exactly the thing that must not be called now.
+     * A different question from isStillWanted(), asked before *reporting*
+     * rather than before accepting: a device deleted while its runtime
+     * lives is a load to refuse and report, since something is waiting to
+     * hear it. A runtime that's gone is not -- there's nothing to publish
+     * onto and nobody to tell, and its completion callback is exactly what
+     * must not be called now.
      */
     bool runtimeIsAlive() const;
 };

--- a/magda/daw/audio/session/ClipSynchronizer.hpp
+++ b/magda/daw/audio/session/ClipSynchronizer.hpp
@@ -29,7 +29,7 @@ struct WarpMarkerInfo;
  * @brief Manages clip synchronization between ClipManager and Tracktion Engine
  *
  * Responsibilities:
- * - Bidirectional clip ID mapping (ClipId ↔ TE EditItemID)
+ * - Bidirectional clip ID mapping (ClipId <-> TE EditItemID)
  * - ClipManagerListener implementation (clips changed, property changed)
  * - Arrangement clip synchronization (audio + MIDI)
  * - Session clip slot management (create, launch, stop)
@@ -47,18 +47,10 @@ struct WarpMarkerInfo;
  */
 class ClipSynchronizer : public ClipManagerListener, public TrackManagerListener {
   public:
-    /**
-     * @brief Construct ClipSynchronizer with required dependencies
-     * @param edit Reference to the current Edit (project)
-     * @param trackController Reference to TrackController for track operations
-     * @param warpMarkerManager Reference to WarpMarkerManager for warp operations
-     */
     ClipSynchronizer(te::Edit& edit, TrackController& trackController,
                      WarpMarkerManager& warpMarkerManager);
 
-    /**
-     * @brief Destructor - unregisters from ClipManager listener
-     */
+    /** @brief Unregisters from ClipManager listener. */
     ~ClipSynchronizer() override;
 
     // =========================================================================
@@ -66,35 +58,25 @@ class ClipSynchronizer : public ClipManagerListener, public TrackManagerListener
     // =========================================================================
 
     /**
-     * @brief Handle clip additions, deletions, and reordering
+     * @brief Handle clip additions, deletions, and reordering.
      *
-     * - Removes clips that no longer exist in ClipManager
-     * - Syncs all arrangement clips to TE
-     * - Syncs all session clips to slots
+     * Removes clips no longer in ClipManager, then syncs all arrangement
+     * clips to TE and all session clips to slots.
      */
     void clipsChanged() override;
 
-    /**
-     * @brief Handle individual clip property changes
-     * @param clipId The clip whose properties changed
-     *
-     * Routes to appropriate sync method based on clip view type
-     */
+    /** @brief Route a single clip's property change to the right sync method. */
     void clipPropertyChanged(ClipId clipId) override;
 
     /**
-     * @brief Handle batched clip property changes synchronously
-     * @param clipIds The clips whose properties changed
+     * @brief Handle batched clip property changes synchronously.
      *
      * Deduplicates IDs and coalesces playback graph reallocation while still
      * leaving TE state up to date before returning.
      */
     void clipPropertiesChanged(const std::vector<ClipId>& clipIds) override;
 
-    /**
-     * @brief Handle clip selection changes (no-op)
-     * @param clipId The newly selected clip
-     */
+    /** @brief No-op: clip selection does not need to sync to TE. */
     void clipSelectionChanged(ClipId clipId) override;
 
     // =========================================================================
@@ -108,27 +90,13 @@ class ClipSynchronizer : public ClipManagerListener, public TrackManagerListener
     // Arrangement Clip Operations
     // =========================================================================
 
-    /**
-     * @brief Sync a clip from ClipManager to Tracktion Engine
-     * @param clipId The MAGDA clip ID
-     *
-     * Routes to syncMidiClipToEngine() or syncAudioClipToEngine() based on type
-     */
+    /** @brief Route to syncMidiClipToEngine() or syncAudioClipToEngine() based on type. */
     void syncClipToEngine(ClipId clipId);
 
-    /**
-     * @brief Remove a clip from Tracktion Engine
-     * @param clipId The MAGDA clip ID
-     *
-     * Removes from TE timeline and clears bidirectional mapping
-     */
+    /** @brief Remove a clip from TE and clear its bidirectional mapping. */
     void removeClipFromEngine(ClipId clipId);
 
-    /**
-     * @brief Get Tracktion Engine clip for arrangement clip
-     * @param clipId The MAGDA clip ID
-     * @return The TE Clip, or nullptr if not found
-     */
+    /** @brief The TE Clip for this arrangement clip, or nullptr if not found. */
     te::Clip* getArrangementTeClip(ClipId clipId) const;
 
     // =========================================================================
@@ -136,108 +104,52 @@ class ClipSynchronizer : public ClipManagerListener, public TrackManagerListener
     // =========================================================================
 
     /**
-     * @brief Sync a session clip to its slot in TE Edit
-     * @param clipId The MAGDA clip ID
-     * @return true if a new clip was created (requires graph reallocation)
-     *
-     * Creates or updates clip in session slot, handles audio and MIDI clips
+     * @brief Sync a session clip to its slot in TE Edit.
+     * @return true if a new clip was created (requires graph reallocation).
      */
     bool syncSessionClipToSlot(ClipId clipId);
 
-    /**
-     * @brief Remove a session clip from its slot
-     * @param clipId The MAGDA clip ID
-     */
+    /** @brief Remove a session clip from its slot. */
     void removeSessionClipFromSlot(ClipId clipId);
 
-    /**
-     * @brief Launch a session clip for playback
-     * @param clipId The MAGDA clip ID
-     *
-     * Configures looping and launches via LaunchHandle
-     */
+    /** @brief Configure looping and launch a session clip via LaunchHandle. */
     void launchSessionClip(ClipId clipId, bool forceImmediate = false);
 
-    /**
-     * @brief Stop a playing session clip immediately
-     * @param clipId The MAGDA clip ID
-     */
+    /** @brief Stop a playing session clip immediately. */
     void stopSessionClip(ClipId clipId);
 
-    /**
-     * @brief Stop a playing session clip at the next quantization grid point
-     * @param clipId The MAGDA clip ID
-     * @param quantize The quantization to use for the stop
-     */
+    /** @brief Stop a playing session clip at the next quantization grid point. */
     void stopSessionClipQueued(ClipId clipId, LaunchQuantize quantize);
 
-    /**
-     * @brief Get Tracktion Engine clip for session clip
-     * @param clipId The MAGDA clip ID
-     * @return The TE Clip in the slot, or nullptr if not found
-     */
+    /** @brief The TE Clip in the session slot, or nullptr if not found. */
     te::Clip* getSessionTeClip(ClipId clipId);
 
     // =========================================================================
     // Warp Marker Operations (Delegated to WarpMarkerManager)
     // =========================================================================
 
-    /**
-     * @brief Set transient detection sensitivity and re-run detection
-     * @param clipId The MAGDA clip ID
-     * @param sensitivity Sensitivity value (0.0 to 1.0)
-     */
+    /** @brief Set transient detection sensitivity and re-run detection. */
     void setTransientSensitivity(ClipId clipId, float sensitivity);
 
-    /**
-     * @brief Get transient detection times for a clip
-     * @param clipId The MAGDA clip ID
-     * @return true if transients were found
-     */
+    /** @return true if transients were found. */
     bool getTransientTimes(ClipId clipId);
 
-    /**
-     * @brief Enable warp/time-stretch for a clip
-     * @param clipId The MAGDA clip ID
-     */
+    /** @brief Enable warp/time-stretch for a clip. */
     void enableWarp(ClipId clipId);
 
-    /**
-     * @brief Disable warp/time-stretch for a clip
-     * @param clipId The MAGDA clip ID
-     */
+    /** @brief Disable warp/time-stretch for a clip. */
     void disableWarp(ClipId clipId);
 
-    /**
-     * @brief Get all warp markers for a clip
-     * @param clipId The MAGDA clip ID
-     * @return Vector of warp marker information
-     */
+    /** @brief All warp markers for a clip. */
     std::vector<WarpMarkerInfo> getWarpMarkers(ClipId clipId);
 
-    /**
-     * @brief Add a warp marker to a clip
-     * @param clipId The MAGDA clip ID
-     * @param sourceTime Time in source audio
-     * @param warpTime Warped time position
-     * @return Index of the added marker
-     */
+    /** @brief Add a warp marker; returns the index of the added marker. */
     int addWarpMarker(ClipId clipId, double sourceTime, double warpTime);
 
-    /**
-     * @brief Move an existing warp marker
-     * @param clipId The MAGDA clip ID
-     * @param markerIndex Index of marker to move
-     * @param newWarpTime New warped time position
-     * @return Actual new warp time (may be clamped)
-     */
+    /** @return the actual new warp time, which may be clamped. */
     double moveWarpMarker(ClipId clipId, int markerIndex, double newWarpTime);
 
-    /**
-     * @brief Remove a warp marker from a clip
-     * @param clipId The MAGDA clip ID
-     * @param markerIndex Index of marker to remove
-     */
+    /** @brief Remove a warp marker from a clip. */
     void removeWarpMarker(ClipId clipId, int markerIndex);
 
     // =========================================================================
@@ -250,27 +162,17 @@ class ClipSynchronizer : public ClipManagerListener, public TrackManagerListener
      */
     std::function<void()> onGraphReallocated;
 
-    /**
-     * @brief Check if a reverse proxy operation is pending
-     * @return ClipId of pending clip, or INVALID_CLIP_ID
-     *
-     * Called from AudioBridge timer to poll for completion
-     */
+    /** @brief The clip a reverse proxy operation is pending for, polled by AudioBridge's timer. */
     ClipId getPendingReverseClipId() const {
         return pendingReverseClipId_;
     }
 
-    /**
-     * @brief Clear pending reverse clip ID after proxy completion
-     */
+    /** @brief Clear pending reverse clip ID after proxy completion. */
     void clearPendingReverseClipId() {
         pendingReverseClipId_ = INVALID_CLIP_ID;
     }
 
-    /**
-     * @brief Get the precise quantized launch time for a track's last-launched session clip.
-     * @param trackId The track to query
-     * @return Time in seconds, or 0.0 if no launch recorded
+    /** @return the precise quantized launch time for a track's last-launched session clip, or 0.0.
      */
     double getLastLaunchTimeForTrack(TrackId trackId) const;
 
@@ -285,71 +187,46 @@ class ClipSynchronizer : public ClipManagerListener, public TrackManagerListener
     /** Reallocate playback graph and fire onGraphReallocated callback. */
     void reallocateAndNotify();
 
-    /**
-     * @brief Sync one clip property notification into Tracktion Engine
-     * @return true if this sync changed topology requiring graph reallocation
-     */
+    /** @return true if this sync changed topology, requiring graph reallocation. */
     bool syncClipPropertyToEngine(ClipId clipId);
 
-    /**
-     * @brief Sync arrangement clip data and report whether graph reallocation is needed
-     */
+    /** @brief Sync arrangement clip data; returns whether graph reallocation is needed. */
     bool syncArrangementClipToEngine(ClipId clipId);
 
-    /**
-     * @brief Sync MIDI clip properties to Tracktion Engine
-     * @param clipId The MAGDA clip ID
-     * @param clip The ClipInfo from ClipManager
-     *
-     * Handles position, looping, offset, and note data synchronization
-     */
+    /** @brief Sync MIDI clip position, looping, offset, and note data to TE. */
     bool syncMidiClipToEngine(ClipId clipId, const ClipInfo* clip);
 
     /**
-     * @brief Sync audio clip properties to Tracktion Engine
-     * @param clipId The MAGDA clip ID
-     * @param clip The ClipInfo from ClipManager
-     *
-     * Handles position, speed, tempo sync, loop, offset, pitch, fades, etc.
-     * Complex logic for beat-based vs. time-based properties
+     * @brief Sync audio clip position, speed, tempo sync, loop, offset, pitch,
+     * and fades to TE. Beat-based and time-based properties need separate
+     * handling (see docs/coordinate-system).
      */
     bool syncAudioClipToEngine(ClipId clipId, const ClipInfo* clip);
 
     /**
      * @brief Re-attach loop-record takes onto a freshly built TE clip.
      *
-     * The model owns the take list (one audio file per loop pass); the TE clip
-     * is rebuilt from scratch on record and on project load, so the takes must
-     * be re-added each time. Idempotent: a no-op if the model has no takes or
-     * the TE clip already carries them. The active take plays back because the
-     * clip's source already points at takes[currentTakeIndex]; the others are
-     * preserved as alternates.
+     * The model owns the take list; the TE clip is rebuilt from scratch on
+     * record and on project load, so takes must be re-added each time.
+     * Idempotent. The active take plays because the clip's source already
+     * points at takes[currentTakeIndex]; the rest are kept as alternates.
      */
     void applyModelTakesToTeClip(tracktion::WaveAudioClip& teClip, const ClipInfo& clip);
 
     /**
-     * @brief Configure autoTempo on a session audio clip in TE
-     * @param audioClip The TE WaveAudioClip to configure
-     * @param clip The ClipInfo model data
+     * @brief Configure autoTempo on a session audio clip in TE.
      *
-     * Shared by syncSessionClipToSlot() and clipPropertyChanged().
-     * Syncs source interpretation BPM, stretch mode, speedRatio, autoTempo flag,
+     * Shared by syncSessionClipToSlot() and clipPropertyChanged(). Syncs
+     * source interpretation BPM, stretch mode, speedRatio, autoTempo flag,
      * offset, and beat-based loop range.
      */
     void configureSessionAutoTempo(te::WaveAudioClip* audioClip, const ClipInfo* clip);
 
-    /**
-     * @brief Sync TrackInfo::playbackMode to TE's audioTrack->playSlotClips
-     * @param trackId The track to sync
-     *
-     * This is the SINGLE place that writes audioTrack->playSlotClips.
-     */
+    /** @brief Sync TrackInfo::playbackMode to TE. The single place that writes
+     * audioTrack->playSlotClips. */
     void syncPlaybackModeToEngine(TrackId trackId);
 
-    /**
-     * @brief Remove a TE clip by its engine ID from any track
-     * @param engineId The TE EditItemID string
-     */
+    /** @brief Remove a TE clip by its engine ID from any track. */
     void removeTeClipByEngineId(const std::string& engineId);
 
     // References to dependencies (not owned)

--- a/magda/daw/audio/session/ClipSynchronizer.hpp
+++ b/magda/daw/audio/session/ClipSynchronizer.hpp
@@ -29,7 +29,7 @@ struct WarpMarkerInfo;
  * @brief Manages clip synchronization between ClipManager and Tracktion Engine
  *
  * Responsibilities:
- * - Bidirectional clip ID mapping (ClipId <-> TE EditItemID)
+ * - Bidirectional clip ID mapping (ClipId ↔ TE EditItemID)
  * - ClipManagerListener implementation (clips changed, property changed)
  * - Arrangement clip synchronization (audio + MIDI)
  * - Session clip slot management (create, launch, stop)
@@ -47,10 +47,18 @@ struct WarpMarkerInfo;
  */
 class ClipSynchronizer : public ClipManagerListener, public TrackManagerListener {
   public:
+    /**
+     * @brief Construct ClipSynchronizer with required dependencies
+     * @param edit Reference to the current Edit (project)
+     * @param trackController Reference to TrackController for track operations
+     * @param warpMarkerManager Reference to WarpMarkerManager for warp operations
+     */
     ClipSynchronizer(te::Edit& edit, TrackController& trackController,
                      WarpMarkerManager& warpMarkerManager);
 
-    /** @brief Unregisters from ClipManager listener. */
+    /**
+     * @brief Destructor - unregisters from ClipManager listener
+     */
     ~ClipSynchronizer() override;
 
     // =========================================================================
@@ -58,25 +66,35 @@ class ClipSynchronizer : public ClipManagerListener, public TrackManagerListener
     // =========================================================================
 
     /**
-     * @brief Handle clip additions, deletions, and reordering.
+     * @brief Handle clip additions, deletions, and reordering
      *
-     * Removes clips no longer in ClipManager, then syncs all arrangement
-     * clips to TE and all session clips to slots.
+     * - Removes clips that no longer exist in ClipManager
+     * - Syncs all arrangement clips to TE
+     * - Syncs all session clips to slots
      */
     void clipsChanged() override;
 
-    /** @brief Route a single clip's property change to the right sync method. */
+    /**
+     * @brief Handle individual clip property changes
+     * @param clipId The clip whose properties changed
+     *
+     * Routes to appropriate sync method based on clip view type
+     */
     void clipPropertyChanged(ClipId clipId) override;
 
     /**
-     * @brief Handle batched clip property changes synchronously.
+     * @brief Handle batched clip property changes synchronously
+     * @param clipIds The clips whose properties changed
      *
      * Deduplicates IDs and coalesces playback graph reallocation while still
      * leaving TE state up to date before returning.
      */
     void clipPropertiesChanged(const std::vector<ClipId>& clipIds) override;
 
-    /** @brief No-op: clip selection does not need to sync to TE. */
+    /**
+     * @brief Handle clip selection changes (no-op)
+     * @param clipId The newly selected clip
+     */
     void clipSelectionChanged(ClipId clipId) override;
 
     // =========================================================================
@@ -90,13 +108,27 @@ class ClipSynchronizer : public ClipManagerListener, public TrackManagerListener
     // Arrangement Clip Operations
     // =========================================================================
 
-    /** @brief Route to syncMidiClipToEngine() or syncAudioClipToEngine() based on type. */
+    /**
+     * @brief Sync a clip from ClipManager to Tracktion Engine
+     * @param clipId The MAGDA clip ID
+     *
+     * Routes to syncMidiClipToEngine() or syncAudioClipToEngine() based on type
+     */
     void syncClipToEngine(ClipId clipId);
 
-    /** @brief Remove a clip from TE and clear its bidirectional mapping. */
+    /**
+     * @brief Remove a clip from Tracktion Engine
+     * @param clipId The MAGDA clip ID
+     *
+     * Removes from TE timeline and clears bidirectional mapping
+     */
     void removeClipFromEngine(ClipId clipId);
 
-    /** @brief The TE Clip for this arrangement clip, or nullptr if not found. */
+    /**
+     * @brief Get Tracktion Engine clip for arrangement clip
+     * @param clipId The MAGDA clip ID
+     * @return The TE Clip, or nullptr if not found
+     */
     te::Clip* getArrangementTeClip(ClipId clipId) const;
 
     // =========================================================================
@@ -104,52 +136,108 @@ class ClipSynchronizer : public ClipManagerListener, public TrackManagerListener
     // =========================================================================
 
     /**
-     * @brief Sync a session clip to its slot in TE Edit.
-     * @return true if a new clip was created (requires graph reallocation).
+     * @brief Sync a session clip to its slot in TE Edit
+     * @param clipId The MAGDA clip ID
+     * @return true if a new clip was created (requires graph reallocation)
+     *
+     * Creates or updates clip in session slot, handles audio and MIDI clips
      */
     bool syncSessionClipToSlot(ClipId clipId);
 
-    /** @brief Remove a session clip from its slot. */
+    /**
+     * @brief Remove a session clip from its slot
+     * @param clipId The MAGDA clip ID
+     */
     void removeSessionClipFromSlot(ClipId clipId);
 
-    /** @brief Configure looping and launch a session clip via LaunchHandle. */
+    /**
+     * @brief Launch a session clip for playback
+     * @param clipId The MAGDA clip ID
+     *
+     * Configures looping and launches via LaunchHandle
+     */
     void launchSessionClip(ClipId clipId, bool forceImmediate = false);
 
-    /** @brief Stop a playing session clip immediately. */
+    /**
+     * @brief Stop a playing session clip immediately
+     * @param clipId The MAGDA clip ID
+     */
     void stopSessionClip(ClipId clipId);
 
-    /** @brief Stop a playing session clip at the next quantization grid point. */
+    /**
+     * @brief Stop a playing session clip at the next quantization grid point
+     * @param clipId The MAGDA clip ID
+     * @param quantize The quantization to use for the stop
+     */
     void stopSessionClipQueued(ClipId clipId, LaunchQuantize quantize);
 
-    /** @brief The TE Clip in the session slot, or nullptr if not found. */
+    /**
+     * @brief Get Tracktion Engine clip for session clip
+     * @param clipId The MAGDA clip ID
+     * @return The TE Clip in the slot, or nullptr if not found
+     */
     te::Clip* getSessionTeClip(ClipId clipId);
 
     // =========================================================================
     // Warp Marker Operations (Delegated to WarpMarkerManager)
     // =========================================================================
 
-    /** @brief Set transient detection sensitivity and re-run detection. */
+    /**
+     * @brief Set transient detection sensitivity and re-run detection
+     * @param clipId The MAGDA clip ID
+     * @param sensitivity Sensitivity value (0.0 to 1.0)
+     */
     void setTransientSensitivity(ClipId clipId, float sensitivity);
 
-    /** @return true if transients were found. */
+    /**
+     * @brief Get transient detection times for a clip
+     * @param clipId The MAGDA clip ID
+     * @return true if transients were found
+     */
     bool getTransientTimes(ClipId clipId);
 
-    /** @brief Enable warp/time-stretch for a clip. */
+    /**
+     * @brief Enable warp/time-stretch for a clip
+     * @param clipId The MAGDA clip ID
+     */
     void enableWarp(ClipId clipId);
 
-    /** @brief Disable warp/time-stretch for a clip. */
+    /**
+     * @brief Disable warp/time-stretch for a clip
+     * @param clipId The MAGDA clip ID
+     */
     void disableWarp(ClipId clipId);
 
-    /** @brief All warp markers for a clip. */
+    /**
+     * @brief Get all warp markers for a clip
+     * @param clipId The MAGDA clip ID
+     * @return Vector of warp marker information
+     */
     std::vector<WarpMarkerInfo> getWarpMarkers(ClipId clipId);
 
-    /** @brief Add a warp marker; returns the index of the added marker. */
+    /**
+     * @brief Add a warp marker to a clip
+     * @param clipId The MAGDA clip ID
+     * @param sourceTime Time in source audio
+     * @param warpTime Warped time position
+     * @return Index of the added marker
+     */
     int addWarpMarker(ClipId clipId, double sourceTime, double warpTime);
 
-    /** @return the actual new warp time, which may be clamped. */
+    /**
+     * @brief Move an existing warp marker
+     * @param clipId The MAGDA clip ID
+     * @param markerIndex Index of marker to move
+     * @param newWarpTime New warped time position
+     * @return Actual new warp time (may be clamped)
+     */
     double moveWarpMarker(ClipId clipId, int markerIndex, double newWarpTime);
 
-    /** @brief Remove a warp marker from a clip. */
+    /**
+     * @brief Remove a warp marker from a clip
+     * @param clipId The MAGDA clip ID
+     * @param markerIndex Index of marker to remove
+     */
     void removeWarpMarker(ClipId clipId, int markerIndex);
 
     // =========================================================================
@@ -162,17 +250,27 @@ class ClipSynchronizer : public ClipManagerListener, public TrackManagerListener
      */
     std::function<void()> onGraphReallocated;
 
-    /** @brief The clip a reverse proxy operation is pending for, polled by AudioBridge's timer. */
+    /**
+     * @brief Check if a reverse proxy operation is pending
+     * @return ClipId of pending clip, or INVALID_CLIP_ID
+     *
+     * Called from AudioBridge timer to poll for completion
+     */
     ClipId getPendingReverseClipId() const {
         return pendingReverseClipId_;
     }
 
-    /** @brief Clear pending reverse clip ID after proxy completion. */
+    /**
+     * @brief Clear pending reverse clip ID after proxy completion
+     */
     void clearPendingReverseClipId() {
         pendingReverseClipId_ = INVALID_CLIP_ID;
     }
 
-    /** @return the precise quantized launch time for a track's last-launched session clip, or 0.0.
+    /**
+     * @brief Get the precise quantized launch time for a track's last-launched session clip.
+     * @param trackId The track to query
+     * @return Time in seconds, or 0.0 if no launch recorded
      */
     double getLastLaunchTimeForTrack(TrackId trackId) const;
 
@@ -187,46 +285,71 @@ class ClipSynchronizer : public ClipManagerListener, public TrackManagerListener
     /** Reallocate playback graph and fire onGraphReallocated callback. */
     void reallocateAndNotify();
 
-    /** @return true if this sync changed topology, requiring graph reallocation. */
+    /**
+     * @brief Sync one clip property notification into Tracktion Engine
+     * @return true if this sync changed topology requiring graph reallocation
+     */
     bool syncClipPropertyToEngine(ClipId clipId);
 
-    /** @brief Sync arrangement clip data; returns whether graph reallocation is needed. */
+    /**
+     * @brief Sync arrangement clip data and report whether graph reallocation is needed
+     */
     bool syncArrangementClipToEngine(ClipId clipId);
 
-    /** @brief Sync MIDI clip position, looping, offset, and note data to TE. */
+    /**
+     * @brief Sync MIDI clip properties to Tracktion Engine
+     * @param clipId The MAGDA clip ID
+     * @param clip The ClipInfo from ClipManager
+     *
+     * Handles position, looping, offset, and note data synchronization
+     */
     bool syncMidiClipToEngine(ClipId clipId, const ClipInfo* clip);
 
     /**
-     * @brief Sync audio clip position, speed, tempo sync, loop, offset, pitch,
-     * and fades to TE. Beat-based and time-based properties need separate
-     * handling (see docs/coordinate-system).
+     * @brief Sync audio clip properties to Tracktion Engine
+     * @param clipId The MAGDA clip ID
+     * @param clip The ClipInfo from ClipManager
+     *
+     * Handles position, speed, tempo sync, loop, offset, pitch, fades, etc.
+     * Complex logic for beat-based vs. time-based properties
      */
     bool syncAudioClipToEngine(ClipId clipId, const ClipInfo* clip);
 
     /**
      * @brief Re-attach loop-record takes onto a freshly built TE clip.
      *
-     * The model owns the take list; the TE clip is rebuilt from scratch on
-     * record and on project load, so takes must be re-added each time.
-     * Idempotent. The active take plays because the clip's source already
-     * points at takes[currentTakeIndex]; the rest are kept as alternates.
+     * The model owns the take list (one audio file per loop pass); the TE clip
+     * is rebuilt from scratch on record and on project load, so the takes must
+     * be re-added each time. Idempotent: a no-op if the model has no takes or
+     * the TE clip already carries them. The active take plays back because the
+     * clip's source already points at takes[currentTakeIndex]; the others are
+     * preserved as alternates.
      */
     void applyModelTakesToTeClip(tracktion::WaveAudioClip& teClip, const ClipInfo& clip);
 
     /**
-     * @brief Configure autoTempo on a session audio clip in TE.
+     * @brief Configure autoTempo on a session audio clip in TE
+     * @param audioClip The TE WaveAudioClip to configure
+     * @param clip The ClipInfo model data
      *
-     * Shared by syncSessionClipToSlot() and clipPropertyChanged(). Syncs
-     * source interpretation BPM, stretch mode, speedRatio, autoTempo flag,
+     * Shared by syncSessionClipToSlot() and clipPropertyChanged().
+     * Syncs source interpretation BPM, stretch mode, speedRatio, autoTempo flag,
      * offset, and beat-based loop range.
      */
     void configureSessionAutoTempo(te::WaveAudioClip* audioClip, const ClipInfo* clip);
 
-    /** @brief Sync TrackInfo::playbackMode to TE. The single place that writes
-     * audioTrack->playSlotClips. */
+    /**
+     * @brief Sync TrackInfo::playbackMode to TE's audioTrack->playSlotClips
+     * @param trackId The track to sync
+     *
+     * This is the SINGLE place that writes audioTrack->playSlotClips.
+     */
     void syncPlaybackModeToEngine(TrackId trackId);
 
-    /** @brief Remove a TE clip by its engine ID from any track. */
+    /**
+     * @brief Remove a TE clip by its engine ID from any track
+     * @param engineId The TE EditItemID string
+     */
     void removeTeClipByEngineId(const std::string& engineId);
 
     // References to dependencies (not owned)

--- a/magda/daw/core/LinkModeManager.hpp
+++ b/magda/daw/core/LinkModeManager.hpp
@@ -11,8 +11,18 @@ namespace magda {
 // link mode at a time. While active, clicking any parameter creates or edits
 // a link to that modulator, with an overlay slider to set the amount. It ends
 // when the link button is clicked again, ESC is pressed, or another modulator
-// enters link mode. Components implement LinkModeManagerListener and register
-// with LinkModeManager::getInstance() to react to changes.
+// enters link mode.
+//
+// Components implement LinkModeManagerListener and register with
+// LinkModeManager::getInstance() to react to changes:
+//
+//   class MyComponent : public LinkModeManagerListener {
+//       void modLinkModeChanged(bool active, const ModSelection& sel) override;
+//       void macroLinkModeChanged(bool active, const MacroSelection& sel) override;
+//   };
+//
+// Register in constructor: LinkModeManager::getInstance().addListener(this);
+// Unregister in destructor: LinkModeManager::getInstance().removeListener(this);
 
 /**
  * @brief Type of modulator in link mode

--- a/magda/daw/core/LinkModeManager.hpp
+++ b/magda/daw/core/LinkModeManager.hpp
@@ -7,48 +7,12 @@
 
 namespace magda {
 
-// ============================================================================
-// LINK MODE PATTERN (Bitwig-style)
-// ============================================================================
-//
-// This module implements a link mode state manager for creating modulation
-// links between mods/macros and device parameters.
-//
-// ## Core Concept
-//
-// Only ONE modulator (mod or macro) can be in link mode at a time. When
-// a modulator's link button is clicked, it enters link mode. In this state:
-//   - Clicking any parameter creates/edits a link to that modulator
-//   - An overlay text slider appears on the parameter to set the amount
-//   - Link mode stays active until:
-//     a) The link button is clicked again
-//     b) ESC key is pressed
-//     c) Another modulator enters link mode
-//
-// ## Link Mode Flow
-//
-//   1. User clicks link button on a mod/macro knob
-//   2. LinkModeManager::enterModLinkMode() or enterMacroLinkMode() is called
-//   3. LinkModeManager:
-//      a) Stores the modulator path and index
-//      b) Notifies all listeners via LinkModeManagerListener callbacks
-//   4. ParamSlotComponent receives callback and enables link mode UI
-//   5. User clicks a param → creates/edits link with overlay slider
-//   6. User clicks link button again or presses ESC → exits link mode
-//
-// ## Listener Pattern
-//
-// Components implement LinkModeManagerListener to receive link mode changes:
-//
-//   class MyComponent : public LinkModeManagerListener {
-//       void modLinkModeChanged(bool active, const ModSelection& sel) override;
-//       void macroLinkModeChanged(bool active, const MacroSelection& sel) override;
-//   };
-//
-// Register in constructor: LinkModeManager::getInstance().addListener(this);
-// Unregister in destructor: LinkModeManager::getInstance().removeListener(this);
-//
-// ============================================================================
+// Link mode (Bitwig-style): exactly one modulator, mod or macro, can be in
+// link mode at a time. While active, clicking any parameter creates or edits
+// a link to that modulator, with an overlay slider to set the amount. It ends
+// when the link button is clicked again, ESC is pressed, or another modulator
+// enters link mode. Components implement LinkModeManagerListener and register
+// with LinkModeManager::getInstance() to react to changes.
 
 /**
  * @brief Type of modulator in link mode

--- a/magda/daw/core/PresetManager.hpp
+++ b/magda/daw/core/PresetManager.hpp
@@ -203,9 +203,8 @@ class PresetManager {
     //
     // External producers (the AI sound-design agent, future preset-import
     // flows) can stash a default name keyed by DeviceId so the next save
-    // dialog on that device pre-fills the name field without needing the
-    // user to retype it. Values persist until overwritten or cleared —
-    // they're transient session state, never serialized.
+    // dialog on that device pre-fills it. Transient session state only,
+    // never serialized.
 
     void setSuggestedPresetName(DeviceId deviceId, const juce::String& name);
     juce::String getSuggestedPresetName(DeviceId deviceId) const;

--- a/magda/daw/core/controllers/BindingRegistry.hpp
+++ b/magda/daw/core/controllers/BindingRegistry.hpp
@@ -46,7 +46,8 @@ class BindingRegistryListener {
  *
  * Thread-safety: mutations happen on the message thread; reads from the MIDI
  * thread are served via an atomic snapshot that is swapped on every mutation
- * across both scopes.
+ * across both scopes. Except where a query is explicitly marked MIDI-thread
+ * safe below, all queries run on the message thread.
  */
 class BindingRegistry {
   public:
@@ -111,11 +112,10 @@ class BindingRegistry {
     /**
      * @brief Find all bindings whose target resolves to a given ControlTarget.
      *
-     * Resolves each binding's target using a DefaultChainContext + TargetResolver.
-     * Must be called on the message thread.
-     *
-     * Kind-filtered so a macro-targeted binding at (path, 0, DeviceMacro) does NOT
-     * match a plugin-param query at (path, 0, PluginParam).
+     * Resolves each binding's target using a DefaultChainContext +
+     * TargetResolver, kind-filtered so a macro-targeted binding at (path, 0,
+     * DeviceMacro) does not match a plugin-param query at (path, 0,
+     * PluginParam).
      *
      * @return All matching bindings from both Global and Project scopes.
      */
@@ -123,115 +123,95 @@ class BindingRegistry {
 
     /**
      * @brief Remove all bindings whose target resolves to the given ControlTarget.
-     *
-     * Convenience wrapper: calls findFor, then removes each match from its scope.
-     * Must be called on the message thread.
-     *
      * @return Number of bindings removed.
      */
     int removeFor(const ControlTarget& target);
 
     /**
-     * @brief Return true if any binding (Global + Project) resolves to a target
-     * on this devicePath with the given owner kind AND has an active source.
+     * @brief True if any binding (Global + Project) resolves to a target on
+     * this devicePath with the given owner kind AND has an active source.
      *
-     * Used by device-header indicators to answer "is this device actively
-     * being driven by a controller?". Bindings whose source controller is
-     * registered but disabled are skipped so the indicator matches the
-     * ControllerRouter's actual routing behavior. Port-only bindings (no
-     * controllerId, from the Learn path) always count.
-     *
-     * Must be called on the message thread.
+     * For the "is this device actively driven by a controller?" device-header
+     * indicator. Bindings whose source controller is registered but disabled
+     * are skipped, to match ControllerRouter's actual routing. Port-only
+     * bindings (no controllerId, from the Learn path) always count.
      */
     bool hasBindingForDevice(const ChainNodePath& devicePath, ControlTarget::Kind owner) const;
 
     /**
-     * @brief Return true if any active focused-device-macro resolver binding
-     * currently resolves to this device — i.e. the device has automap-profile
-     * coverage, regardless of any user Learn'd bindings on top.
+     * @brief True if an active focused-device-macro resolver binding
+     * resolves to this device: automap-profile coverage, regardless of user
+     * Learn'd bindings on top.
      */
     bool hasResolverBindingForDevice(const ChainNodePath& devicePath) const;
 
     /**
-     * @brief Return the owning controller of the first resolver (automap)
-     * binding that resolves to this device, or nullopt if none.
+     * @brief The owning controller of the first resolver (automap) binding
+     * that resolves to this device, or nullopt.
      *
      * Lets the caller gate the automap indicator on that controller's live
-     * connection / activation state instead of merely whether a profile
-     * mapping exists in config. See magda::controllers::isDeviceAutomapLive.
+     * connection/activation state rather than just config having a profile
+     * mapping. See magda::controllers::isDeviceAutomapLive.
      */
     std::optional<ControllerId> resolverControllerForDevice(const ChainNodePath& devicePath) const;
 
     /**
-     * @brief Return true if any active explicit user mapping (ControlTarget or
-     * AliasRef) targets a parameter / macro / mod on this device. Excludes
+     * @brief True if any active explicit user mapping (ControlTarget or
+     * AliasRef) targets a parameter/macro/mod on this device. Excludes
      * resolver-based automap-profile bindings.
      */
     bool hasUserMappingForDevice(const ChainNodePath& devicePath) const;
 
     /**
-     * @brief Return the owning controller of the first explicit user mapping
-     * (ControlTarget / AliasRef, excluding resolver automap) that targets this
-     * device, or nullopt if none. Counterpart to resolverControllerForDevice
-     * for the pinned (user-mapped) indicator.
+     * @brief The owning controller of the first explicit user mapping
+     * (excluding resolver automap) targeting this device, or nullopt.
+     * Counterpart to resolverControllerForDevice, for the pinned
+     * (user-mapped) indicator.
      */
     std::optional<ControllerId> userMappingControllerForDevice(
         const ChainNodePath& devicePath) const;
 
     /**
-     * @brief Return true if any active binding (Global + Project) resolves to the
+     * @brief True if any active binding (Global + Project) resolves to the
      * given ControlTarget.
      *
-     * Same "active" semantics as hasBindingForDevice — bindings whose source
-     * controller is registered but disabled are skipped. Use this for
-     * per-parameter indicators (macro knobs, param slots, linkable sliders)
-     * instead of `!findFor(...).empty()` so the indicator disappears when the
-     * binding's controller is disabled.
-     *
-     * Must be called on the message thread.
+     * Same "active" semantics as hasBindingForDevice. Use for per-parameter
+     * indicators (macro knobs, param slots, linkable sliders) instead of
+     * `!findFor(...).empty()`, so the indicator drops when the binding's
+     * controller is disabled.
      */
     bool hasActiveBindingFor(const ControlTarget& target) const;
 
     /**
-     * @brief Return true if any active binding (Global + Project) for this macro
-     * is an explicit static target (ControlTarget owner=DeviceMacro) — i.e. came
-     * from a user MIDI Learn gesture, not an automap profile resolver.
-     *
-     * Used to paint the macro indicator orange (Learn override) vs green (profile
-     * default). Same "active" semantics as hasActiveBindingFor.
+     * @brief True if any active binding for this macro is an explicit static
+     * target (owner=DeviceMacro) from a user Learn gesture, rather than an
+     * automap resolver. Paints the macro indicator orange (Learn override)
+     * vs green (profile default).
      */
     bool hasActiveStaticBindingForMacro(const ChainNodePath& devicePath, int macroIndex) const;
 
     /**
-     * @brief Remove only user Learn'd static DeviceMacro bindings on (path, macroIndex).
-     *
-     * Mirrors hasActiveStaticBindingForMacro: leaves focused-device-macro
-     * resolver bindings (automap profile defaults) alone so the macro falls
-     * back to its profile mapping after the user clears their override.
+     * @brief Remove only user Learn'd static DeviceMacro bindings on (path,
+     * macroIndex), leaving resolver (automap profile) bindings alone so the
+     * macro falls back to its profile mapping.
      */
     int removeStaticBindingsForMacro(const ChainNodePath& devicePath, int macroIndex);
 
     /**
-     * @brief Return true when an automap profile binding (focused-device-macro
-     * resolver) targeting this (devicePath, macroIndex) is shadowed by an
-     * overlapping static PluginParam binding — i.e. a MIDI Learn override is
-     * stealing the CC and the green automap dot should drop.
-     *
-     * Must be called on the message thread.
+     * @brief True when an automap resolver binding at (devicePath,
+     * macroIndex) is shadowed by an overlapping static PluginParam binding:
+     * a Learn override is stealing the CC and the green automap dot should
+     * drop.
      */
     bool isAutomapShadowedForMacro(const ChainNodePath& devicePath, int macroIndex) const;
 
     /**
-     * @brief Return true when a static PluginParam binding at (devicePath,
-     * paramIndex) is overriding an overlapping focused-device-macro resolver
-     * binding — i.e. the param is stealing the CC from a profile-mapped macro
-     * and should paint a red override dot.
-     *
-     * The resolver-side binding is matched by its declared kind, regardless of
-     * whether it currently resolves to a focused device, so the indicator is
+     * @brief True when a static PluginParam binding at (devicePath,
+     * paramIndex) overrides an overlapping resolver binding: the param is
+     * stealing the CC from a profile-mapped macro and should paint a red
+     * override dot. The resolver side is matched by declared kind regardless
+     * of whether it currently resolves to a focused device, so this stays
      * stable across focus changes.
-     *
-     * Must be called on the message thread.
      */
     bool isPluginParamOverridingMacro(const ChainNodePath& devicePath, int paramIndex) const;
 

--- a/magda/engine/clip/ClipAudioSource.hpp
+++ b/magda/engine/clip/ClipAudioSource.hpp
@@ -21,33 +21,32 @@
  * @brief What a track's audio clips sum to, block by block.
  *
  * The source behind a ClipAudio op. The plan names a track and nothing else
- * (RenderPlan.hpp); what that track plays is read here, from the clip snapshot,
- * which is why moving a clip never recompiles a plan.
+ * (RenderPlan.hpp); what that track plays is read here, from the clip
+ * snapshot, which is why moving a clip never recompiles a plan.
  *
- * It decides nothing about overlaps. The snapshot has already resolved which
+ * It decides nothing about overlaps: the snapshot has already resolved which
  * clips are audible where and what fades they play (#2003), so entries that
- * overlap simply sum: the lane's rules were applied when the snapshot was
- * compiled, and a crossfade reaching here is two voices each playing the fade
- * it was handed.
+ * overlap simply sum -- a crossfade reaching here is two voices each playing
+ * the fade it was handed.
  *
  * ## The two sections
  *
- * One class plays a track's arrangement and its session, chosen at construction
- * (#2301). Spans, fades, stretching, warping, readers and voices are shared, so
- * a clip dragged out of a slot onto the timeline sounds the same in both.
+ * One class plays a track's arrangement and its session, chosen at
+ * construction (#2301). Spans, fades, stretching, warping, readers and
+ * voices are shared, so a clip dragged out of a slot onto the timeline
+ * sounds the same in both. What differs is where the material sits, which
+ * for a slot is nowhere: a session block is this block on the run's own
+ * axes (SessionPlayback.hpp), and a split block is two of them over two
+ * sub-blocks of the output.
  *
- * What differs is where the material sits, which for a slot is nowhere: a
- * session block is this block on the run's own axes (SessionPlayback.hpp), and
- * a split block is two of them over two sub-blocks of the output.
- *
- * How many clips a track may sound at once is decided rather than discovered:
- * kMaxVoicesPerTrack, below. That is not how many readers a track may have,
- * which is larger and is ClipVoicePool.hpp's (kMaxReadersPerTrack), because a
- * reader has to exist before its clip is due while a voice is only needed while
- * it plays. So a block can be handed more entries than it can render, and a
- * track wanting more than either says so through @ref
- * ClipAudioSource::starvedVoices, because silence nobody counted is
- * indistinguishable from a gap in the material.
+ * How many clips a track may sound at once is decided rather than
+ * discovered: kMaxVoicesPerTrack, below. That is not how many readers a
+ * track may have, which is larger and is ClipVoicePool.hpp's
+ * (kMaxReadersPerTrack), since a reader has to exist before its clip is due
+ * while a voice is only needed while it plays. So a block can be handed more
+ * entries than it can render, and a track wanting more than either says so
+ * through @ref ClipAudioSource::starvedVoices, since silence nobody counted
+ * is indistinguishable from a gap in the material.
  */
 
 namespace magda::engine {
@@ -55,27 +54,27 @@ namespace magda::engine {
 /**
  * @brief Clips one track may sound in a single callback.
  *
- * Capacity, and only capacity. How many readers a track may have standing by is
- * kMaxReadersPerTrack, which is larger and answers a different question: this
- * one is what a callback can render at once, that one is how far ahead of the
- * transport the material has to be open. Collapsing the two starves clips that
- * fit here perfectly well and simply have no reader yet.
+ * Capacity, and only capacity. kMaxReadersPerTrack answers a different
+ * question -- how many readers a track may have standing by, i.e. how far
+ * ahead of the transport the material has to be open -- while this is what
+ * a callback can render at once. Collapsing the two starves clips that fit
+ * here perfectly well and simply have no reader yet.
  *
- * Live, not overlapping. Everything a callback touches is live for that
- * callback, whether or not the clips overlap by a sample: they are rendered in
- * the same call, so each holds its own voice for it. At the default block that
- * makes back to back clips shorter than about a millisecond and a half count
- * against this, and a host running a large block stretches that to tens of
- * milliseconds. The pool measures against the same block for that reason, so
- * what it reports and what the callback enforces are the same thing.
+ * Live, not overlapping: everything a callback touches is live for that
+ * callback whether or not the clips overlap by a sample, since they render
+ * in the same call and each holds its own voice for it. At the default
+ * block that makes back-to-back clips shorter than about 1.5ms count
+ * against this (tens of milliseconds at a large block size); the pool
+ * measures against the same block so what it reports and what the callback
+ * enforces are the same thing.
  *
- * Sixteen. A crossfade is two, a clip dropped inside another is two, and a clip
- * made of several events is one voice per event (#1901), so the shapes a lane
- * can legitimately be in add up well past the obvious pair, and a lane of
- * slices adds up faster still.
+ * Sixteen: a crossfade is two, a clip dropped inside another is two, and a
+ * clip made of several events is one voice per event (#1901), so the shapes
+ * a lane can legitimately be in add up well past the obvious pair.
  *
- * Past it the track reports rather than quietly dropping the extras, through
- * @ref ClipAudioSource::starvedVoices and ClipVoicePool::overSubscribed.
+ * Past it the track reports rather than quietly dropping the extras,
+ * through @ref ClipAudioSource::starvedVoices and
+ * ClipVoicePool::overSubscribed.
  */
 constexpr int kMaxVoicesPerTrack = 16;
 
@@ -84,20 +83,20 @@ class ClipAudioSource final : public EngineAudioSource {
     /**
      * @brief The arrangement's source for @p trackId.
      *
-     * Both feeds outlive it and are shared with every other track: what a track
-     * plays and which readers are standing by are properties of the session,
-     * not of any one source or any one plan.
+     * Both feeds outlive it and are shared with every other track: what a
+     * track plays and which readers are standing by are properties of the
+     * session, not of any one source or any one plan.
      */
     ClipAudioSource(TrackId trackId, ClipSnapshotFeed& clips, ClipStreamFeed& streams);
 
     /**
      * @brief The @p section's source for @p trackId, reading @p handles.
      *
-     * Both sources of a track take the feed, and @p section says which of them
-     * this is (#2302). A session source is positioned by the handles instead of
-     * by the timeline; an arrangement source is positioned by the timeline as
-     * ever and reads the handles only to know when the session has taken the
-     * track off it, and where in the block that happened.
+     * Both sources of a track take the feed, and @p section says which of
+     * them this is (#2302). A session source is positioned by the handles
+     * instead of the timeline; an arrangement source is positioned by the
+     * timeline as ever, reading the handles only to know when the session
+     * has taken the track off it, and where in the block that happened.
      *
      * @p handles outlives it.
      */
@@ -118,11 +117,11 @@ class ClipAudioSource final : public EngineAudioSource {
     /**
      * @brief Clips that should have sounded and had no reader to sound through.
      *
-     * Counted per clip per block, the way PrefetchStream counts an underrun and
-     * for the same reason: a track asking for more simultaneous clips than it
-     * was given streams for is silence that has to be visible. A rising count
+     * Counted per clip per block, the way PrefetchStream counts an
+     * underrun: a track asking for more simultaneous clips than it was
+     * given streams for is silence that has to be visible. A rising count
      * means either the ceiling above is too low for the material or the
-     * provisioning thread is not keeping up with the transport.
+     * provisioning thread isn't keeping up with the transport.
      */
     int starvedVoices() const {
         return starved_.load(std::memory_order_relaxed);
@@ -132,21 +131,17 @@ class ClipAudioSource final : public EngineAudioSource {
      * @brief Blocks rendered against a map the snapshot was not compiled for.
      *
      * A snapshot carries the fingerprint of the tempo map its seconds were
-     * derived through. One that is not the transport's was compiled against a
-     * tempo that has since changed, so every second in it is wrong by however
-     * much the map moved.
+     * derived through; one that isn't the transport's was compiled against
+     * a tempo that has since changed, so every second in it is wrong by
+     * however much the map moved.
      *
-     * Counted and then played anyway. Refusing to play it is a hole in the
-     * middle of a set to report a bug that should not happen, and it buys
-     * little, because stale spans usually stop overlapping the block in any
-     * case: what that mostly converts is an accidental gap into a deliberate
-     * one.
-     *
-     * Zero is the only right answer, and reaching it is the publish's job
-     * rather than this one's: the map and the snapshot compiled for it are
-     * meant to swap together (#2337). Non-zero says they did not, which is a
-     * publish-ordering bug that would otherwise be inaudible until somebody
-     * wondered why a clip was in the wrong place.
+     * Counted and played anyway: refusing would trade an accidental gap for
+     * a deliberate one, since stale spans usually stop overlapping the
+     * block regardless. Zero is the only right answer, and reaching it is
+     * the publish's job, not this one's -- the map and the snapshot
+     * compiled for it are meant to swap together (#2337). Non-zero means
+     * they didn't, a publish-ordering bug that would otherwise be inaudible
+     * until somebody wondered why a clip was in the wrong place.
      */
     int staleSnapshots() const {
         return staleSnapshots_.load(std::memory_order_relaxed);
@@ -194,7 +189,6 @@ class ClipAudioSource final : public EngineAudioSource {
     ClipSnapshotFeed& clips_;
     ClipStreamFeed& streams_;
 
-    /// The section. Null is the arrangement, which needs no handles.
     /// Sum this track's material for @p block, on whichever section this is.
     void renderMaterial(const BlockInfo& block, juce::dsp::AudioBlock<float> out);
 
@@ -202,6 +196,7 @@ class ClipAudioSource final : public EngineAudioSource {
     /// track, and de-click both edges of the hand-over (#2302).
     void applySectionHold(juce::dsp::AudioBlock<float> out);
 
+    /// Null is the arrangement, which needs no handles.
     LaunchHandleFeed* handles_ = nullptr;
     Section section_ = Section::Arrangement;
 
@@ -211,11 +206,15 @@ class ClipAudioSource final : public EngineAudioSource {
     StopDeClick handOver_;
     StartDeClick handBack_;
 
-    /// One entry of this track's session that stopped in the block just
-    /// gathered, and where. Per entry rather than per track, because the ramp
-    /// that takes its step out belongs to the voice playing it: one ramp over
-    /// the track's sum could not tell an outgoing slot from one still sounding
-    /// through the same samples (#2344 review).
+    /**
+     * @brief One entry of this track's session that stopped in the block
+     * just gathered, and where.
+     *
+     * Per entry rather than per track: the ramp that takes its step out
+     * belongs to the voice playing it, since one ramp over the track's sum
+     * couldn't tell an outgoing slot from one still sounding through the
+     * same samples (#2344 review).
+     */
     struct Stopping {
         ClipId clipId = INVALID_CLIP_ID;
         EventId eventId = INVALID_EVENT_ID;

--- a/magda/engine/clip/ClipSnapshot.hpp
+++ b/magda/engine/clip/ClipSnapshot.hpp
@@ -17,30 +17,29 @@
  *
  * Clip positions are deliberately not in the render plan (see RenderPlan.hpp):
  * a plan is topology, and moving a clip is not a topology change. Clips reach
- * the audio thread through this instead, swapped in whole the way a plan is, so
- * an edit to a clip never recompiles a plan.
+ * the audio thread through this instead, swapped in whole the way a plan is,
+ * so an edit to a clip never recompiles a plan.
  *
- * Resolved is the point of it. Occlusion and crossfades are worked out once, at
- * compile time, by the model functions that already own those rules
+ * Resolved is the point of it. Occlusion and crossfades are worked out once,
+ * at compile time, by the model functions that already own those rules
  * (computeAudibleSpans, effectiveFadesIn), so a `ClipAudio` or `ClipMidi` op
- * never sees an overlap: it plays a span with fades. An edit recompiles this the
- * way a structural change recompiles a plan, which is why there is no sync
- * protocol between two representations of a lane and no state that can go stale
- * (#2003).
+ * never sees an overlap: it plays a span with fades. An edit recompiles this
+ * the way a structural change recompiles a plan, so there's no sync protocol
+ * between two representations of a lane and no state that can go stale (#2003).
  *
  * Both faces of every instant are carried, beats and seconds. Beats are the
- * model's authority and what auto tempo and warp keep working in; the seconds
- * are derived here, once, through the tempo map, because a source is handed
- * seconds (ClipPlacement.hpp) and there must not be a second tempo map on the
- * audio thread. The transport publishes both faces of its cursor for the same
- * reason; that the two were derived through the same map is what the
- * fingerprint below is for.
+ * model's authority and what auto tempo and warp keep working in; seconds are
+ * derived here, once, through the tempo map, since a source is handed seconds
+ * (ClipPlacement.hpp) and there must not be a second tempo map on the audio
+ * thread. The transport publishes both faces of its cursor for the same
+ * reason, and the fingerprint below exists to confirm both were derived
+ * through the same map.
  *
- * Not keyed to a plan. Everything here is keyed by TrackId, so unlike PlanValues
- * it carries no plan fingerprint and a plan swap does not invalidate it. It does
- * carry the fingerprint of the tempo map its seconds were derived through: a
- * tempo edit moves every one of them, so a snapshot compiled against another map
- * is stale in a way nothing downstream could otherwise notice.
+ * Not keyed to a plan: everything here is keyed by TrackId, so unlike
+ * PlanValues it carries no plan fingerprint and a plan swap doesn't
+ * invalidate it. It does carry the tempo map's own fingerprint, since a tempo
+ * edit moves every second in it, and a snapshot compiled against a stale map
+ * is wrong in a way nothing downstream could otherwise notice.
  */
 
 namespace magda::engine {
@@ -49,12 +48,11 @@ namespace magda::engine {
  * @brief A stretch of timeline, in both domains.
  *
  * The seconds are what the ends actually are: a beat span occupies different
- * wall-clock seconds depending on where it sits on the tempo curve, so the two
- * ends are converted separately rather than a length being scaled.
- *
- * Two typed ranges rather than four doubles, for the reason TimeDomains.hpp
- * gives: what goes wrong is a value from one domain arriving where the other
- * was meant, and nothing at the call site tells them apart.
+ * wall-clock seconds depending on where it sits on the tempo curve, so each
+ * end is converted separately rather than a length being scaled. Two typed
+ * ranges rather than four doubles, so a value from one domain can't arrive
+ * where the other was meant with nothing at the call site to catch it
+ * (TimeDomains.hpp).
  */
 struct SnapshotSpan {
     BeatRange beats;
@@ -64,32 +62,28 @@ struct SnapshotSpan {
 /**
  * @brief One audio event of a clip, and how its file is to be read.
  *
- * The source-domain positions stay in samples at the source's own rate, as the
- * model holds them: that is what makes a source-BPM reinterpretation leave the
- * audible region untouched. Converting them is playback's business, and which
- * conversion depends on the interpretation below.
+ * The source-domain positions stay in samples at the source's own rate, as
+ * the model holds them, so a source-BPM reinterpretation leaves the audible
+ * region untouched; converting them is playback's business.
  */
 struct AudioEventPlayback {
     EventId eventId = INVALID_EVENT_ID;
     SourceId sourceId = INVALID_SOURCE_ID;
 
-    /// Resolved from the source table at compile time, so nothing on the audio
-    /// thread reaches a pool. Always set in a compiled snapshot: an event whose
-    /// source the table does not hold is dropped with a diagnostic rather than
-    /// carried with nothing to read.
+    /// Resolved from the source table at compile time, so nothing on the
+    /// audio thread reaches a pool. Always set in a compiled snapshot: an
+    /// event whose source the table doesn't hold is dropped with a
+    /// diagnostic rather than carried with nothing to read.
     std::string filePath;
     double sourceSampleRate = 0.0;
     double sourceDurationSeconds = 0.0;
 
-    /// Where this event sits on the timeline, absolute: the clip's start plus
-    /// the event's own offset.
-    ///
-    /// Not cropped to what the lane leaves audible, deliberately. The anchor
-    /// below is the sample heard at startSeconds, so this is the origin every
-    /// read is derived from; moving it to the audible start would mean
-    /// advancing the anchor with it, and by how much is a question only the
-    /// stretch and warp settings can answer. The clip's span and its silences
-    /// do the cropping, at playback, where that answer exists.
+    /// Where this event sits on the timeline, absolute: the clip's start
+    /// plus the event's own offset. Not cropped to what the lane leaves
+    /// audible -- the anchor below is the sample heard at startSeconds, so
+    /// this is the origin every read derives from, and only the stretch and
+    /// warp settings know how far to advance it if it moved. Cropping
+    /// happens via the clip's span and silences, at playback.
     SnapshotSpan span;
 
     // ---- Source domain (samples at the source's own rate) ------------------
@@ -109,34 +103,38 @@ struct AudioEventPlayback {
 
     /// What actually runs, not the raw field: a mode left at Off still
     /// stretches when something else forced a stretcher on
-    /// (AudioEvent::getEffectiveTimeStretchMode). The values are the pinned
+    /// (AudioEvent::getEffectiveTimeStretchMode). Values are the pinned
     /// project-file integers in TimeStretchModes.hpp.
     int timeStretchMode = 0;
 
-    /// Resampling rather than stretching, and only in force when nothing else
+    /// Resampling rather than stretching, only in force when nothing else
     /// has already forced a stretcher on (AudioEvent::isAnalogPitchActive).
     bool analogPitch = false;
 
-    /// Whether the event warps at all, which is not the same question as
-    /// whether @ref warp bends anything.
-    ///
-    /// Warp with no markers is identity as a map and is still warp as an
-    /// interpretation: the model puts such an event in the beat domain at its
-    /// own bpm and forces a stretcher on it
-    /// (AudioEvent::sourceInstantToTimelineBeats,
-    /// AudioEvent::getEffectiveTimeStretchMode). Reading that off the map being
-    /// empty would play it on the seconds face instead, which is a clip that
-    /// stops following the tempo the moment its last marker is deleted.
+    /**
+     * @brief Whether the event warps at all -- not the same question as
+     * whether @ref warp bends anything.
+     *
+     * Warp with no markers is identity as a map but is still warp as an
+     * interpretation: the model puts such an event in the beat domain at its
+     * own bpm and forces a stretcher on it
+     * (AudioEvent::sourceInstantToTimelineBeats,
+     * AudioEvent::getEffectiveTimeStretchMode). Reading an empty map as "not
+     * warping" would play it on the seconds face instead -- a clip that
+     * stops following tempo the moment its last marker is deleted.
+     */
     bool warpEnabled = false;
 
-    /// Compiled and inverted, never the model's marker list (WarpMap.hpp).
-    /// Empty is the identity lookup, which is what an event with no markers and
-    /// one with none left after the compile both get.
-    ///
-    /// In the model's own coordinates, forwards. Reverse is not baked in: it is
-    /// a coordinate change that EventPlacement.hpp resolves per lookup, because
-    /// mirroring the map would need the length of the region the event reads
-    /// and that is itself an answer from the map.
+    /**
+     * @brief Compiled and inverted, never the model's marker list (WarpMap.hpp).
+     *
+     * Empty is the identity lookup, for an event with no markers and one
+     * with none left after compiling alike. In the model's own coordinates,
+     * forwards; reverse is a coordinate change EventPlacement.hpp resolves
+     * per lookup rather than being baked in, since mirroring the map would
+     * need the length of the region the event reads, itself an answer from
+     * the map.
+     */
     WarpMap warp;
 
     bool autoPitch = false;
@@ -151,18 +149,17 @@ struct AudioEventPlayback {
     /// This event's own trim. The clip's gain sits above it.
     float gainDb = 0.0f;
 
-    // ---- The event's own fades ---------------------------------------------
-    //
-    // Its own, and not the clip's. The pair on the clip is what its EDGES play,
-    // resolved against the lane; these are what this event fades with inside
-    // it. For the event at a clip edge the two are the same fade before and
-    // after resolution, so playback shapes that edge once, with the clip's.
-    //
-    // They are carried per event because fades are per event in the model, and
-    // a clip holding several of them (#1901) has fades the clip-level pair
-    // cannot express: promoting only the primary event's would lose every
-    // other event's.
-
+    /**
+     * @brief The event's own fades, not the clip's.
+     *
+     * The clip's pair is what its edges play, resolved against the lane;
+     * these are what this event fades with inside it. For the event at a
+     * clip edge the two are the same fade before and after resolution, so
+     * playback shapes that edge once, together with the clip's. Carried per
+     * event because fades are per event in the model, and a clip holding
+     * several events (#1901) has fades the clip-level pair can't express --
+     * promoting only the primary event's would lose every other event's.
+     */
     double fadeInSeconds = 0.0;
     double fadeOutSeconds = 0.0;
     FadeCurve fadeInCurve = FadeCurve::Linear;
@@ -176,10 +173,10 @@ struct AudioEventPlayback {
 /**
  * @brief One audio clip, as it plays.
  *
- * The span is what the lane leaves audible, not the clip's placement, and the
- * silenced ranges are the holes inside it. Nothing on a lane is cut any more, so
- * a clip dropped inside another leaves a hole in the middle of an audio clip
- * rather than splitting it (#2003).
+ * The span is what the lane leaves audible, not the clip's placement, and
+ * the silenced ranges are the holes inside it: nothing on a lane is cut any
+ * more, so a clip dropped inside another leaves a hole in the middle of an
+ * audio clip rather than splitting it (#2003).
  */
 struct AudioClipPlayback {
     ClipId clipId = INVALID_CLIP_ID;
@@ -187,41 +184,41 @@ struct AudioClipPlayback {
     SnapshotSpan span;
     std::vector<SnapshotSpan> silenced;
 
-    // ---- Fades, already resolved -------------------------------------------
-    //
-    // What the clip plays with once the lane is known: its own fades, replaced
-    // at either edge by a crossfade the length of the overlap that covers it,
-    // and scaled to fit when the two would together outrun the clip. A
-    // crossfade between two clips is therefore two clips each playing the fade
-    // it was given, and nothing downstream pairs them up.
-
+    /**
+     * @brief Fades, already resolved.
+     *
+     * What the clip plays with once the lane is known: its own fades,
+     * replaced at either edge by a crossfade the length of the overlap that
+     * covers it, and scaled to fit when the two would together outrun the
+     * clip. A crossfade between two clips is therefore two clips each
+     * playing the fade it was given, with nothing downstream pairing them up.
+     */
     double fadeInSeconds = 0.0;
     double fadeOutSeconds = 0.0;
     FadeCurve fadeInCurve = FadeCurve::Linear;
     FadeCurve fadeOutCurve = FadeCurve::Linear;
 
-    /// The same two lengths on the beat face, derived here through the same
-    /// tempo map. Only a speed ramp asks for them, and only on an auto tempo
-    /// clip, where where the material has got to is a question about beats: the
-    /// ramp then has to be measured in the domain the position is derived from,
-    /// and converting a fade length on the audio thread would need a tempo map
-    /// there.
+    /// The same two lengths on the beat face, derived through the same tempo
+    /// map. Only a speed ramp asks for them, and only on an auto tempo clip,
+    /// where the material's position is a question about beats -- the ramp
+    /// has to be measured in that domain, and converting a fade length on
+    /// the audio thread would need a tempo map there.
     double fadeInBeats = 0.0;
     double fadeOutBeats = 0.0;
 
-    /// 0 = gain fade, 1 = speed ramp. A speed ramp is a stretch feature rather
-    /// than a gain one, which is why it travels with the fade.
+    /// 0 = gain fade, 1 = speed ramp. A speed ramp is a stretch feature
+    /// rather than a gain one, which is why it travels with the fade.
     int fadeInBehaviour = 0;
     int fadeOutBehaviour = 0;
 
     // ---- Mix ---------------------------------------------------------------
 
-    /// The clip's volume and gain summed, which is how the incumbent applies
-    /// them, in dB. Per-event trim sits under it on the event.
+    /// The clip's volume and gain summed, as the incumbent applies them, in
+    /// dB. Per-event trim sits under it on the event.
     float gainDb = 0.0f;
     float pan = 0.0f;
 
-    /// Ramp on the stopped to playing transition. 0 preserves the leading
+    /// Ramp on the stopped-to-playing transition. 0 preserves the leading
     /// transient.
     int launchFadeSamples = 0;
 
@@ -231,65 +228,63 @@ struct AudioClipPlayback {
 /**
  * @brief One MIDI clip, as it plays.
  *
- * The events are the clip's authoritative lists resolved into the messages they
- * play (MidiEventList.hpp), which is what a fronted take or an assembled comp
- * has already been written into: choosing between takes happens in the model,
- * never here, and turning a note into a note-on happens at compile time, never
- * on the audio thread.
+ * The events are the clip's authoritative lists resolved into the messages
+ * they play (MidiEventList.hpp) -- what a fronted take or an assembled comp
+ * has already been written into: choosing between takes happens in the
+ * model, never here, and turning a note into a note-on happens at compile
+ * time, never on the audio thread.
  */
 struct MidiClipPlayback {
     ClipId clipId = INVALID_CLIP_ID;
 
     SnapshotSpan span;
 
-    /// A note starting inside one of these does not sound. MIDI plays around a
-    /// hole rather than being cut by it.
+    /// A note starting inside one of these does not sound. MIDI plays
+    /// around a hole rather than being cut by it.
     std::vector<SnapshotSpan> silenced;
 
-    /// Compiled, never the model's own lists: the curve densification, the MPE
-    /// channel assignment, the same-pitch overlap rule and the two offsets all
-    /// resolve once, in the compiler that already owns the rest of the
+    /// Compiled, never the model's own lists: curve densification, MPE
+    /// channel assignment, the same-pitch overlap rule and the two offsets
+    /// all resolve once, in the compiler that already owns the rest of the
     /// resolution.
     MidiEventList events;
 
-    /// How the clip's content maps onto the timeline: its loop, its phase and
-    /// its content origin, which is the only interpretation left for the block
+    /// How the clip's content maps onto the timeline: its loop, its phase
+    /// and its content origin -- the only interpretation left for the block
     /// to do.
     MidiFold fold;
 
-    /// Compiled against this clip's own strength, and the one thing here the
-    /// audio thread evaluates rather than reads: groove is anchored to the
-    /// project grid, so a looped clip grooves each pass differently whenever its
-    /// loop length is not a whole multiple of the template's period. Empty is
-    /// the identity.
+    /// Compiled against this clip's own strength; the one thing here the
+    /// audio thread evaluates rather than reads, since groove is anchored to
+    /// the project grid and a looped clip grooves each pass differently
+    /// whenever its loop length isn't a whole multiple of the template's
+    /// period. Empty is the identity.
     GrooveTemplate groove;
 };
 
-/** Everything one track plays. */
 /**
  * @brief One session slot's material, as if it began at beat zero.
  *
- * A session clip has no position on the timeline. Its scene index says which
- * slot it sits in and nothing about when it sounds, because when it sounds is
- * decided by a launch at runtime rather than by the model (#2301). So it is
- * compiled at the origin, describing the material and nothing else, and the
- * launch handle's virtual origin is what maps a block onto it.
- *
- * Compiled through the same path the arrangement's clips go through, so a clip
- * dragged from a slot to the timeline sounds the same in both places.
+ * A session clip has no position on the timeline: its scene index says
+ * which slot it sits in, not when it sounds, since that's decided by a
+ * launch at runtime rather than by the model (#2301). So it's compiled at
+ * the origin, describing the material and nothing else, and the launch
+ * handle's virtual origin maps a block onto it. Compiled through the same
+ * path the arrangement's clips go through, so a clip dragged from a slot to
+ * the timeline sounds the same in both places.
  */
 struct SessionSlotPlayback {
     int sceneIndex = -1;
 
-    /// The slot's material, at most one of each. Empty means the slot holds a
-    /// clip that compiled to nothing playable, which is a diagnostic rather
-    /// than a slot that does nothing.
+    /// The slot's material, at most one of each. Empty means the slot holds
+    /// a clip that compiled to nothing playable, a diagnostic rather than a
+    /// slot that does nothing.
     std::vector<AudioClipPlayback> audio;
     std::vector<MidiClipPlayback> midi;
 
-    /// What one pass through the slot is worth, which is what a launch handle
-    /// re-triggers on. The clip's own loop is a separate thing that happens
-    /// inside this.
+    /// What one pass through the slot is worth, which is what a launch
+    /// handle re-triggers on. The clip's own loop is a separate thing that
+    /// happens inside this.
     double lengthBeats = 0.0;
 };
 
@@ -308,9 +303,9 @@ struct TrackClipPlayback {
 /**
  * @brief The whole arrangement, resolved.
  *
- * Tracks are sorted by id and clips within a track by start, so two compiles of
- * the same model produce the same snapshot, which is what makes it golden
- * testable and what keeps a dump diff meaningful.
+ * Tracks are sorted by id and clips within a track by start, so two compiles
+ * of the same model produce the same snapshot -- what makes it golden
+ * testable and keeps a dump diff meaningful.
  */
 struct ClipSnapshot {
     static constexpr int kVersion = 1;
@@ -318,21 +313,22 @@ struct ClipSnapshot {
     int version = kVersion;
 
     /// The tempo map the seconds were derived through. A snapshot whose
-    /// fingerprint is not the transport's was compiled against a tempo that has
-    /// since changed, and every second in it is wrong by however much the map
-    /// moved.
+    /// fingerprint is not the transport's was compiled against a tempo that
+    /// has since changed, and every second in it is wrong by however much
+    /// the map moved.
     std::uint64_t tempoFingerprint = 0;
 
     std::vector<TrackClipPlayback> tracks;
 
-    /// Clips the compile could not express, in compile order. Never a silent
-    /// drop: a clip that will not sound says here why. A clip the lane leaves
-    /// inaudible is not one of these, because being covered is not a failure.
+    /// Clips the compile could not express, in compile order. Never a
+    /// silent drop: a clip that will not sound says here why. A clip the
+    /// lane leaves inaudible is not one of these, since being covered isn't
+    /// a failure.
     std::vector<std::string> diagnostics;
 
-    /// The track's playback, or null. A binary search: the audio thread asks
-    /// once per block and the list is sorted, so nothing hashes and nothing
-    /// allocates.
+    /// The track's playback, or null. A binary search: the audio thread
+    /// asks once per block and the list is sorted, so nothing hashes and
+    /// nothing allocates.
     const TrackClipPlayback* find(TrackId trackId) const;
 };
 

--- a/magda/engine/clip/ClipStretcher.hpp
+++ b/magda/engine/clip/ClipStretcher.hpp
@@ -13,36 +13,35 @@
  * @file ClipStretcher.hpp
  * @brief Playing a clip at a speed that is not its file's.
  *
- * Everything below this reads a file: which of its samples answer a position,
- * mirrored, tiled and converted to the device's rate (io/SourceReaders.hpp).
- * Everything above it consumes one sample of that reading per output sample.
- * This is what sits between when those two numbers are not the same.
+ * Everything below this reads a file: which of its samples answer a
+ * position, mirrored, tiled and converted to the device's rate
+ * (io/SourceReaders.hpp). Everything above it consumes one sample of that
+ * reading per output sample. This sits between when those two numbers
+ * differ.
  *
- * It is not in the reading chain, and that is a decision rather than an
- * accident. That chain is random access and pure: two reads that overlap agree
- * to the last bit, which is what lets a bounce resolve the same samples the
- * callback did. A stretcher is sequential state with a warm-up, so putting one
- * down there would quietly cost that property. It is not in the voice either,
- * because a voice is claimed and released per block and a stretcher that was
- * rebuilt whenever a voice changed hands would allocate on the audio thread.
+ * Not in the reading chain: that chain is random access and pure (two
+ * overlapping reads agree to the last bit, which is what lets a bounce
+ * match the callback), while a stretcher is sequential state with a
+ * warm-up. Not in the voice either, since a voice is claimed and released
+ * per block and rebuilding a stretcher on every handoff would allocate on
+ * the audio thread.
  *
- * So it lives beside the stream, one per provisioned event, made and configured
- * by ClipVoicePool on the thread that is allowed to wait, and carried to the
- * callback in the same table (ClipStreamFeed.hpp). Three things follow, and they
- * are the answers to what a stretcher does about the transport moving:
+ * So it lives beside the stream, one per provisioned event, made and
+ * configured by ClipVoicePool on the thread that's allowed to wait, and
+ * carried to the callback in the same table (ClipStreamFeed.hpp). That
+ * placement answers what a stretcher does about the transport moving: a
+ * plan swap doesn't touch it (it never enters a plan epoch); a loop wrap
+ * doesn't either (tiling happens below the stream, so a wrap is a
+ * discontinuity in the material, not a change of position); a locate
+ * resets and re-primes something that already exists, with no allocation
+ * and no file handle.
  *
- * - a plan swap does nothing to it, because it never enters a plan epoch;
- * - a loop wrap does nothing to it, because tiling happens below the stream and
- *   a wrap is a discontinuity in the material rather than a change of position;
- * - a locate resets and re-primes something that already exists, which costs no
- *   allocation and no file handle.
- *
- * Latency is answered here rather than reported upwards. Every implementation
- * asks for @ref preRollSamples of material from *before* the first sample that
- * is to be heard, and the pool cues the stream that far back, so a voice's first
- * read is one contiguous read that begins with the priming samples. What comes
- * out of @ref process is then aligned with what an unstretched voice on the same
- * track is playing, and a ClipAudio op goes on reporting no latency at all.
+ * Latency is answered here rather than reported upwards: every
+ * implementation asks for @ref preRollSamples of material from before the
+ * first sample heard, the pool cues the stream that far back, and a
+ * voice's first read is one contiguous read starting with the priming
+ * samples -- so @ref process comes out aligned with an unstretched voice
+ * on the same track, and a ClipAudio op keeps reporting no latency at all.
  */
 
 namespace magda::engine {
@@ -50,16 +49,16 @@ namespace magda::engine {
 /**
  * @brief What one event asks of a stretcher.
  *
- * Compared rather than remembered: the pool holds the setup a stretcher was made
- * for and rebuilds when an edit no longer matches it, the same way it rebuilds a
- * reader whose file or reading changed.
+ * Compared rather than remembered: the pool holds the setup a stretcher was
+ * made for and rebuilds it when an edit no longer matches, the same way it
+ * rebuilds a reader whose file or reading changed.
  */
 struct StretchSetup {
-    /// The pinned project-file integer, and what actually runs rather than the
-    /// raw field: a mode left at Off still stretches when something else forced
-    /// a stretcher on (AudioEvent::getEffectiveTimeStretchMode). kDisabled here
-    /// with a rate that is not one is a clip that resamples instead, which is
-    /// what analog pitch is.
+    /// The pinned project-file integer, and what actually runs rather than
+    /// the raw field: a mode left at Off still stretches when something
+    /// else forced a stretcher on (AudioEvent::getEffectiveTimeStretchMode).
+    /// kDisabled with a non-unity rate is a clip that resamples instead,
+    /// which is what analog pitch is.
     int mode = 0;
 
     float semitones = 0.0f;
@@ -68,22 +67,22 @@ struct StretchSetup {
     double sampleRate = 44100.0;
     int maxBlockSamples = 512;
 
-    /// Reading samples consumed per output sample, at the event's usual rate.
-    /// What the pre-roll is sized against; the rate a block actually runs at is
-    /// whatever that block's own two positions say, which is how a moving auto
-    /// tempo ratio costs nothing.
+    /// Reading samples consumed per output sample, at the event's usual
+    /// rate. What the pre-roll is sized against; a block actually runs at
+    /// whatever its own two positions say, which is how a moving auto tempo
+    /// ratio costs nothing.
     double nominalRate = 1.0;
 
-    /// Whether either of the clip's edges ramps its speed rather than its gain.
-    /// A clip at its file's own speed still needs something that can land
-    /// between samples if it does, because for the length of the ramp it is not
-    /// at its file's own speed at all.
+    /// Whether either of the clip's edges ramps its speed rather than its
+    /// gain. A clip at its file's own speed still needs something that can
+    /// land between samples during the ramp, since it isn't at that speed
+    /// for its length.
     bool speedRamp = false;
 
     /// Whether the clip follows the project's tempo. Carried because @ref
-    /// nominalRate is only an average for one that does, and a clip averaging
-    /// unity is still stretching in both directions around it: it needs an
-    /// engine where a clip actually pinned at unity does not.
+    /// nominalRate is only an average for one that does, and a clip
+    /// averaging unity is still stretching in both directions around it --
+    /// it needs an engine a clip truly pinned at unity does not.
     bool followsTempo = false;
 
     bool operator==(const StretchSetup&) const = default;
@@ -96,12 +95,12 @@ class ClipStretcher {
     /**
      * @brief How far ahead of the nominal position the reading is consumed.
      *
-     * Zero for a stretcher, which is handed the samples an output block spans
-     * and nothing more. Not zero for the resampling path, whose curve reaches
-     * past the sample it lands on: a sequential stream cannot be read twice, so
-     * the read runs a fixed few samples ahead and the curve looks backwards
-     * into what it kept. A constant offset rather than a cursor, so a position
-     * is still derived from the timeline and nothing drifts.
+     * Zero for a stretcher, which is handed exactly the samples an output
+     * block spans. Non-zero for the resampling path, whose curve reaches
+     * past the sample it lands on: a sequential stream can't be read twice,
+     * so the read runs a fixed few samples ahead and the curve looks back
+     * into what it kept. A constant offset rather than a cursor, so
+     * position is still derived from the timeline and nothing drifts.
      */
     virtual int readAheadSamples() const {
         return 0;
@@ -110,55 +109,55 @@ class ClipStretcher {
     /**
      * @brief Material before the first sample heard that priming needs.
      *
-     * At @p rate, because what a stretcher holds back depends on how fast it is
-     * being asked to run. The pool cues a stream this far behind where the event
-     * starts, so the samples exist by the time a voice asks for them.
+     * At @p rate, since what a stretcher holds back depends on how fast
+     * it's being asked to run. The pool cues a stream this far behind where
+     * the event starts, so the samples exist by the time a voice asks.
      */
     virtual int preRollSamples(double rate) const = 0;
 
-    /// Forget everything. Follows the transport jumping, and is always followed
-    /// by a @ref prime. Allocation-free: what a reset drops is state, not memory.
+    /// Forget everything. Follows the transport jumping, and is always
+    /// followed by a @ref prime. Allocation-free: a reset drops state, not
+    /// memory.
     virtual void reset() = 0;
 
     /**
      * @brief Take up the material leading to @p until and align to it.
      *
-     * On the audio thread, in the block a voice starts or resumes in. @p rate is
-     * the reading consumed per output sample at that moment.
+     * On the audio thread, in the block a voice starts or resumes in. @p
+     * rate is the reading consumed per output sample at that moment.
      *
-     * @p samples is how much material to take, and is passed rather than asked
-     * for so that it is the same number the stream was cued with. Asking again
-     * here would answer for the rate this block happens to run at, which under
-     * a tempo curve is not the rate the cue was worked out at, and a first read
-     * that begins a few samples from where the stream was pointed is a seek.
+     * @p samples is passed rather than recomputed here so it's the same
+     * number the stream was cued with -- asking again would answer for
+     * this block's rate, which under a tempo curve can differ from the
+     * rate the cue used, making the first read a seek instead of a
+     * continuation.
      *
-     * Reads through @p stream, and leaves it pointed exactly at @p until, so the
-     * block that follows continues the same read rather than seeking. That is
-     * also why the pre-roll is read here rather than handed in: how much
-     * material priming wants is the implementation's own business and runs to
-     * tens of thousands of samples for a phase vocoder, so the buffer for it
-     * belongs to the stretcher that needs it rather than to every track that
-     * has one.
+     * Reads through @p stream and leaves it pointed exactly at @p until,
+     * so the next block continues the read rather than seeking. The
+     * pre-roll buffer is also owned by the implementation rather than
+     * passed in, since how much material priming wants runs to tens of
+     * thousands of samples for a phase vocoder and is the stretcher's own
+     * business, not every track's.
      *
-     * Short is allowed, and is what a clip cued at the very start of its own
-     * file gets, and what a locate gets while the reader is still catching up.
-     * Alignment is then as good as the material available makes it, which is the
-     * incumbent's answer too.
+     * Short is allowed: a clip cued at the very start of its file gets
+     * this, as does a locate while the reader is still catching up.
+     * Alignment is then as good as the available material allows, matching
+     * the incumbent.
      */
     virtual void prime(PrefetchStream& stream, std::int64_t until, int samples, double rate) = 0;
 
     /**
      * @brief Turn @p input into exactly @p output.
      *
-     * On the audio thread. The ratio is whatever the two lengths say, which is
-     * what makes a tempo curve and a speed ramp free: a block that has to
-     * consume more reading than the last one simply passes more in.
+     * On the audio thread. The ratio is whatever the two lengths say, which
+     * makes a tempo curve and a speed ramp free: a block consuming more
+     * reading than the last simply passes more in.
      *
-     * @p offset is where output sample zero sits relative to input sample zero,
-     * in input samples, and @p step is how far apart consecutive output samples
-     * are in them. Both matter only to the resampling path, which lands between
-     * samples; a stretcher is aligned by priming and reads the ratio off the
-     * lengths.
+     * @p offset is where output sample zero sits relative to input sample
+     * zero, in input samples; @p step is the spacing between consecutive
+     * output samples in them. Both matter only to the resampling path,
+     * which lands between samples -- a stretcher is aligned by priming and
+     * reads the ratio off the lengths.
      */
     virtual void process(juce::dsp::AudioBlock<const float> input, double offset, double step,
                          juce::dsp::AudioBlock<float> output) = 0;
@@ -167,17 +166,16 @@ class ClipStretcher {
     /**
      * @brief The buffer @ref prime reads its material into.
      *
-     * Allocated once, by the implementation, on the thread that made it. What it
-     * holds is worst case for the rate the event usually runs at rather than for
-     * the fastest rate anything may ever run at, because that is what the event
-     * will actually ask for; a rate that has since climbed past it primes with
-     * what fits, which is the same short-pre-roll case as a clip at the very
-     * start of its file.
+     * Allocated once, by the implementation, on the thread that made it.
+     * Sized for the rate the event usually runs at rather than the fastest
+     * rate it might ever hit, since that's what it will actually ask for; a
+     * rate that's since climbed past it primes with what fits, the same
+     * short-pre-roll case as a clip at the start of its file.
      */
     void allocatePreRoll(int numChannels, int numSamples);
 
-    /// @p wanted samples ending at @p until, or as many of them as fit and as
-    /// the stream had. On the audio thread.
+    /// @p wanted samples ending at @p until, or as many as fit and the
+    /// stream had. On the audio thread.
     juce::dsp::AudioBlock<const float> readPreRoll(PrefetchStream& stream, std::int64_t until,
                                                    int wanted);
 
@@ -188,66 +186,43 @@ class ClipStretcher {
 /**
  * @brief A stretcher for @p setup, or null when the event asks for nothing.
  *
- * Off the audio thread: every implementation allocates its working buffers here
- * and none of them allocates again. Null is the ordinary answer for a clip
- * playing its file at its file's own speed, which then reads through no extra
- * layer at all and pays for none.
+ * Off the audio thread: every implementation allocates its working buffers
+ * here and none again. Null is the ordinary answer for a clip playing its
+ * file at its own speed, which then reads through no extra layer and pays
+ * for none.
  */
 std::unique_ptr<ClipStretcher> makeStretcher(const StretchSetup& setup);
 
 /**
  * @brief The rate a stretcher will refuse to go beyond.
  *
- * The incumbent's limits, and they are the reason a scratch buffer can be sized
- * at all: a block consumes at most this much reading per output sample, so the
- * most a voice can be asked to read in one callback is bounded before the
- * callback happens.
+ * The incumbent's limits, and the reason a scratch buffer can be sized at
+ * all: a block consumes at most this much reading per output sample, so the
+ * most a voice can be asked to read in one callback is bounded up front.
  */
 constexpr double kMinStretchRate = 0.1;
 constexpr double kMaxStretchRate = 10.0;
 
 /**
- * @brief The most reading one block may consume.
- *
- * Bounded only because the rate is (@ref kMaxStretchRate): without a ceiling on
- * how fast a clip may play there would be no size to allocate a buffer at, and
- * every buffer here has to be allocated before the callback.
- *
- * It is one function because more than one thing is sized against it: the
- * voice's scratch, the interleaving a pipe needs, and the bound the voice
- * clamps a block's reading to. Two of those disagreeing by a few samples is a
- * write past the end of the third, so they are not allowed to be separately
- * derived.
- *
- * The clamp is what makes the ceiling true rather than merely intended. A rate
- * can exceed it: a constant ratio is clamped where it is read, but auto tempo's
- * is the project's tempo over the file's own and a file analysed at an absurd
- * bpm can ask for anything. Bounding what is consumed rather than the position
- * itself keeps the position map pure, which is what makes one block's reading
- * end where the next one's begins; a clip past the ceiling then plays wrongly,
- * the way one with a ratio past the ceiling already does, rather than writing
- * where it should not.
- */
-/**
  * @brief How much output a stretcher is driven in at a time.
  *
- * A voice feeds a stretcher on a fixed grid rather than a block at a time, so
- * that what it receives follows position on the timeline and not how the
- * callback was cut up (ClipVoice::renderThroughCells). This is that grid, and
- * it lives here rather than with the voice because everything sized against a
- * stretcher has to be sized against it: a device running 64-sample blocks still
- * drives whole 128-sample cells through, and a capacity derived from the block
- * would be half of what one cell needs.
+ * A voice feeds a stretcher on a fixed grid rather than a block at a time,
+ * so what it receives follows position on the timeline rather than how the
+ * callback was cut up (ClipVoice::renderThroughCells). Lives here rather
+ * than with the voice because everything sized against a stretcher has to
+ * be sized against it: a device running 64-sample blocks still drives whole
+ * 128-sample cells through, and a capacity derived from the block would be
+ * half of what one cell needs.
  */
 constexpr int kStretchCellSamples = 128;
 
 /**
  * @brief The most output a stretcher can be asked for in one go.
  *
- * The block, or one cell, whichever is larger. Below the cell size the block
- * stops being the unit anything is driven in, and sizing from it would leave a
- * stretcher writing half a cell and zero-filling the rest, which is audible as
- * alternating material and silence rather than as an error anybody sees.
+ * The block, or one cell, whichever is larger. Below the cell size the
+ * block stops being the unit anything is driven in, and sizing from it
+ * would leave a stretcher writing half a cell and zero-filling the rest --
+ * audible as alternating material and silence rather than a visible error.
  */
 inline int stretchWorkSamples(int maxBlockSamples) {
     return std::max(maxBlockSamples, kStretchCellSamples);
@@ -260,8 +235,7 @@ inline int maxReadingSamples(int maxBlockSamples) {
 /**
  * @brief Working space one voice needs for one block.
  *
- * What it renders, and behind that the most reading a block of that length can
- * consume.
+ * What it renders, plus the most reading a block of that length can consume.
  */
 inline int stretchScratchSamples(int maxBlockSamples) {
     return stretchWorkSamples(maxBlockSamples) + maxReadingSamples(maxBlockSamples);
@@ -270,24 +244,18 @@ inline int stretchScratchSamples(int maxBlockSamples) {
 /**
  * @brief The largest run of input a stretcher is ever handed in one push.
  *
- * A cell's worth of reading, and it takes no block size at all. That is the
- * point of it rather than an omission (#2078).
+ * A cell's worth of reading, deliberately independent of block size
+ * (#2078): a voice drives every stretcher one cell at a time
+ * (ClipVoice::renderThroughCells), so a cell's reading is the true answer.
  *
- * The functions above answer "how much space does this need", and a block is a
- * fair input to that question because a caller may ask for a whole block at
- * once. This one answers a different question: how much material goes into the
- * library in a single call. A voice drives every stretcher one cell at a time
- * (ClipVoice::renderThroughCells), so a cell's reading is the true answer, and
- * the block never enters it.
- *
- * The distinction is not academic and it is not about memory. A library given
- * the same total in a different number of pushes is not guaranteed to be in the
- * same state afterwards, and SoundTouch is not: TDStretch::skipFract carries the
- * fraction of a sample a splice did not consume into the next one, and neither
- * clear() nor setTempo() resets it. Feed it a warm-up sized from the block and
- * playback inherits a different fraction at every block size, which is output as
- * a function of how the callback was cut up. It cost a decibel on the corpus at
- * 4096 and it was invisible at 512.
+ * This matters because a library given the same total split across a
+ * different number of pushes is not guaranteed to end in the same state.
+ * SoundTouch isn't: TDStretch::skipFract carries the leftover fraction of a
+ * sample from one splice into the next, and neither clear() nor setTempo()
+ * resets it. A warm-up sized from the block would make playback inherit a
+ * different fraction at every block size -- output as a function of how the
+ * callback happened to be cut up. It cost a decibel on the corpus at 4096
+ * and was invisible at 512.
  */
 inline int stretchPushSamples() {
     return maxReadingSamples(kStretchCellSamples);

--- a/magda/engine/clip/ClipVoice.hpp
+++ b/magda/engine/clip/ClipVoice.hpp
@@ -13,39 +13,36 @@
  * @file ClipVoice.hpp
  * @brief One entry of the snapshot, playing.
  *
- * A voice is one audio event of one clip, read through one prefetch stream. It
- * holds no decision about what should sound: the snapshot has already resolved
- * occlusion, crossfades and takes, so a voice plays a span with fades and never
- * looks at its neighbours (#2003). Two clips crossfading are two voices each
- * playing the fade it was handed, and nothing pairs them up.
+ * A voice is one audio event of one clip, read through one prefetch stream.
+ * It holds no decision about what should sound: the snapshot has already
+ * resolved occlusion, crossfades and takes (#2003), so a voice plays a span
+ * with fades and never looks at its neighbours. Two clips crossfading are
+ * two voices each playing the fade it was handed, with nothing pairing them
+ * up.
  *
- * The span crops what it reads, the interior silences punch holes in what it
- * read, and the fades shape the edges of the span rather than the edges of the
- * clip's placement: the span is what the lane leaves audible, and that is what
- * a listener hears begin and end.
+ * The span crops what it reads, interior silences punch holes in what it
+ * read, and fades shape the edges of the span rather than the clip's
+ * placement -- the span is what the lane leaves audible, and what a
+ * listener hears begin and end.
  *
- * Reading through a hole rather than around it is deliberate. A silence mutes
- * material that is still running underneath, so the stream is read straight
- * across and the hole is cleared afterwards; skipping the read would leave the
- * reader somewhere it was not pointed, which is a seek and costs a block of
- * silence on the far side (#2016).
+ * A silence is read through, not around: it mutes material still running
+ * underneath, so the stream reads straight across and the hole is cleared
+ * afterward. Skipping the read would leave the reader unpointed, which is a
+ * seek and costs a block of silence on the far side (#2016).
  *
- * Reverse, looping and rate conversion are not here either, and not because
- * they are missing: they are underneath, in what the stream reads through
- * (io/SourceReaders.hpp). Each of them is a question about which of a file's
- * samples answer a position, so each is a reader wrapped around a reader, and a
- * voice goes on consuming one sample of one forward stream per output sample at
- * the device's rate whether the clip is reversed, tiled, resampled or none of
- * them.
+ * Reverse, looping and rate conversion live underneath, in what the stream
+ * reads through (io/SourceReaders.hpp): each is a question of which of a
+ * file's samples answer a position, so each is a reader wrapped around a
+ * reader, and a voice always consumes one sample of one forward stream per
+ * output sample at the device's rate.
  *
- * Speed and pitch are the other way round (#2037). They change how fast the
- * reading is consumed rather than what it holds, so they are above the stream
- * rather than below it, and this is where the two meet: a voice asks
- * EventPlacement.hpp where in the reading the block's two ends are, reads
- * exactly that much, and hands it to the stretcher standing beside the stream
- * to come back as this block's length. A clip at its file's own speed has no
- * stretcher and reads one sample per sample, which is the same code path with
- * nothing in the middle.
+ * Speed and pitch work the other way (#2037): they change how fast the
+ * reading is consumed, not what it holds, so they sit above the stream. A
+ * voice asks EventPlacement.hpp where in the reading the block's two ends
+ * are, reads exactly that much, and hands it to the stretcher beside the
+ * stream to come back as this block's length. A clip at its file's own
+ * speed has no stretcher and reads one sample per sample -- the same code
+ * path with nothing in the middle.
  */
 
 namespace magda::engine {
@@ -99,18 +96,18 @@ class ClipVoice {
      * @brief Add this block's contribution to @p out.
      *
      * On the audio thread. @p scratch is working space of at least
-     * stretchScratchSamples(maxBlockSize), owned by the caller because one is
-     * enough for every voice on a track: they are rendered one after another and
-     * summed as they go. It holds what this voice renders and, behind it, the
-     * reading that block was made from, which is longer than the block whenever
-     * the clip plays faster than its file.
+     * stretchScratchSamples(maxBlockSize), owned by the caller since one is
+     * enough for every voice on a track (rendered one after another and
+     * summed as they go). It holds what this voice renders and, behind it,
+     * the reading that block was made from, which is longer than the block
+     * whenever the clip plays faster than its file.
      *
      * @p stretcher is the one standing beside @p stream, or null for a clip
-     * played at its file's own speed, and @p preRoll is what that stretcher was
+     * played at its file's own speed; @p preRoll is what that stretcher was
      * cued with (ClipStreamFeed.hpp).
      *
-     * Returns false when nothing was added, which is the ordinary answer for a
-     * voice whose entry does not reach into this block.
+     * Returns false when nothing was added, the ordinary answer for a voice
+     * whose entry does not reach into this block.
      */
     bool render(const AudioClipPlayback& clip, const AudioEventPlayback& event,
                 const BlockInfo& block, PrefetchStream& stream, ClipStretcher* stretcher,
@@ -122,20 +119,19 @@ class ClipVoice {
      * @brief Render @p count samples of a clip that consumes its reading at a
      *        rate, feeding the stretcher on a fixed grid.
      *
-     * Why a grid at all. A stretcher is a stateful thing whose output follows
-     * the sequence of sizes it was handed, and a rate that varies within a
-     * block used to be resolved from that block's own two ends. Both make the
-     * result a function of how the callback was cut up, which RenderContext.hpp
-     * forbids: block size is an I/O batching concept and never a precision one.
-     * A bounce at 1024 samples a block that disagrees with playback at 128 is
-     * the audible form of the same thing.
+     * A stretcher's output follows the sequence of sizes it's handed, and a
+     * rate resolved from a block's own two ends would make the result a
+     * function of how the callback was cut up -- which RenderContext.hpp
+     * forbids, since block size is an I/O batching concept, not a precision
+     * one (a bounce at 1024 disagreeing with playback at 128 is the audible
+     * form of the same bug).
      *
-     * So the timeline is divided into cells anchored to where the event begins,
-     * the ratio is resolved per cell from the same readingPositionAt, and the
-     * stretcher is fed one whole cell at a time. What it receives is then a
-     * function of position on the timeline and of nothing else. Cells rarely
-     * line up with blocks, so what a cell produces beyond the block that asked
-     * for it is held here until the next one.
+     * So the timeline is divided into cells anchored to where the event
+     * begins, the ratio is resolved per cell from the same
+     * readingPositionAt, and the stretcher is fed one whole cell at a time --
+     * what it receives is then a function of position on the timeline alone.
+     * Cells rarely line up with blocks, so what a cell produces beyond the
+     * block that asked for it is held here until the next one.
      *
      * @return whether every cell got the reading it asked for. The region is
      *         filled either way.
@@ -200,16 +196,16 @@ class ClipVoice {
     int skip_ = 0;
 
     /// The stretcher this voice primed, or null for one that has not primed
-    /// anything. An identity rather than a flag, because the pool replaces a
-    /// stretcher without touching the stream whenever a rate, a pitch or a mode
-    /// is edited, and the entry a voice is playing does not change when it does:
-    /// a fresh engine would otherwise reach the callback cold and stay cold,
-    /// which for a phase vocoder is its whole latency late for the rest of the
-    /// take.
+    /// anything. An identity rather than a flag: the pool replaces a
+    /// stretcher without touching the stream whenever a rate, pitch or mode
+    /// is edited, and the entry a voice is playing doesn't change when it
+    /// does, so an unprimed fresh engine would otherwise reach the callback
+    /// cold and stay cold -- a phase vocoder's whole latency, late for the
+    /// rest of the take.
     ///
-    /// Separate from @ref sounded_, because a block that came back short is not
-    /// a reason to prime again: the reader is behind, and priming reads
-    /// backwards, so doing it would seek and keep it behind for good.
+    /// Separate from @ref sounded_: a block that came back short is not a
+    /// reason to prime again, since priming reads backwards and the reader
+    /// is already behind -- doing it would seek and keep it behind for good.
     const ClipStretcher* primed_ = nullptr;
 };
 

--- a/magda/engine/clip/ClipVoicePool.hpp
+++ b/magda/engine/clip/ClipVoicePool.hpp
@@ -25,23 +25,23 @@
  * @file ClipVoicePool.hpp
  * @brief Which clips have a reader standing by, and where it is pointed.
  *
- * A clip that starts on the beat is a read the stream was not expecting, and a
- * read that does not continue the last one is a seek: what was read ahead is
- * for somewhere else, and nothing plays until the reader catches up (#2016).
- * The whole point of this file is that it never happens. The transport's
- * position is watched from off the audio thread, clips about to sound are given
- * a stream and the stream is cued to the sample they start on, and by the time
- * the callback asks the material is already in memory.
+ * A clip that starts on the beat is a read the stream wasn't expecting, and
+ * a read that doesn't continue the last one is a seek: what was read ahead
+ * is for somewhere else, and nothing plays until the reader catches up
+ * (#2016). This file exists so that never happens: the transport's position
+ * is watched from off the audio thread, clips about to sound are given a
+ * stream cued to the sample they start on, and by the time the callback
+ * asks, the material is already in memory.
  *
- * Nothing here is on the audio thread and nothing here may be. Opening a file,
- * allocating a chunk pool and cueing a stream are all things that wait, so they
- * happen on a thread that is allowed to (ClipVoiceThread below), and what
- * reaches the callback is a published table (ClipStreamFeed.hpp).
+ * Nothing here runs on the audio thread. Opening a file, allocating a chunk
+ * pool and cueing a stream all wait, so they happen on a thread allowed to
+ * (ClipVoiceThread below), and what reaches the callback is a published
+ * table (ClipStreamFeed.hpp).
  *
- * Not the prefetch thread. The two jobs are separate on purpose: deciding what
- * to read must not queue behind a disk that is being read, and retiring a
- * stream waits for the prefetch thread to be out of it, which a caller running
- * on that thread would wait for for ever.
+ * Not the prefetch thread: deciding what to read must not queue behind a
+ * disk that's being read, and retiring a stream waits for the prefetch
+ * thread to be out of it, which a caller running on that thread would wait
+ * for forever.
  */
 
 namespace magda::engine {
@@ -49,16 +49,14 @@ namespace magda::engine {
 /**
  * @brief How far ahead of the transport a clip is given a reader.
  *
- * A cue is only worth giving if the reader has time to act on it, and what it
- * has to do is fill its pool: chunkSamples x (chunkCount - 1) samples of
- * read-ahead, which is two thirds of a second at the default settings and a
- * 44.1 kHz device, and less at every higher rate. Add a provisioning round and
- * the time it takes to open a file, and a second is that with room to spare.
+ * A cue is only worth giving if the reader has time to fill its pool:
+ * chunkSamples x (chunkCount - 1) samples of read-ahead, two thirds of a
+ * second at the default settings and 44.1 kHz. A second covers that plus a
+ * provisioning round and a file open, with room to spare.
  *
- * Longer is not better. Every clip inside the window is an open file and a
- * chunk pool, and a window wide enough to hold a chorus' worth of edits would
- * have the disk reading material that is a bar away instead of the material
- * that is due.
+ * Longer is not better: every clip inside the window is an open file and a
+ * chunk pool, and a wider window would have the disk reading material a bar
+ * away instead of material that's due.
  */
 constexpr double kCueAheadSeconds = 1.0;
 
@@ -66,57 +64,52 @@ constexpr double kCueAheadSeconds = 1.0;
  * @brief How soon a clip may be due and still be given a reader in time.
  *
  * A round finds a clip, opens its file and points the stream at it; the
- * prefetch thread notices on its next poll and reads. Until both have happened
- * the clip has a reader that cannot answer, so a clip due sooner than this is
- * one this pool was too late for however much budget it had.
+ * prefetch thread notices on its next poll and reads. Until both happen the
+ * clip's reader can't answer, so a clip due sooner than this was one this
+ * pool was too late for.
  *
- * It is what the reader budget has to cover, and the reason that budget is not
- * the voice ceiling. A callback can only sound kMaxVoicesPerTrack clips, but
- * the pool has to have opened every clip that will sound before it next wakes,
- * which is a different and larger set: sixteen readers is sixteen clips, and
- * sixteen clips is a tenth of a second of chopped material or an hour of a
- * ballad.
+ * This is what the reader budget has to cover, and why that budget isn't
+ * the voice ceiling: a callback can only sound kMaxVoicesPerTrack clips, but
+ * the pool has to have opened every clip that will sound before it next
+ * wakes -- a larger set, since sixteen readers can be sixteen clips, and
+ * sixteen clips can be a tenth of a second of chopped material.
  */
 constexpr double kReadAheadBridgeSeconds = 0.1;
 
 /**
  * @brief Readers one track may have standing by.
  *
- * The voice ceiling plus room to be early. Every clip that is sounding needs a
- * reader, and so does every clip that will start before this pool next gets to
- * look, so the budget has to hold both: kMaxVoicesPerTrack for the first and as
- * much again for the second. Sized to the voice ceiling instead, a lane would
- * spend its whole budget on what is playing and open the next clip at the
- * moment it was due, which is a seek, which is the one thing this file exists
- * to avoid.
+ * The voice ceiling plus room to be early: every sounding clip needs a
+ * reader, and so does every clip that will start before this pool next
+ * looks, so the budget covers both -- kMaxVoicesPerTrack for the first and
+ * as much again for the second. Sized to the voice ceiling alone, a lane
+ * would spend its whole budget on what's playing and open the next clip at
+ * the moment it was due, which is exactly the seek this file exists to avoid.
  *
- * Thirty-two is where the memory is too: each of these is an open file and a
- * chunk pool, a quarter of a megabyte at the default settings, so eight
- * megabytes for a track with clips near the cursor and nothing at all for one
+ * Thirty-two is also where the memory is: each reader is an open file and a
+ * chunk pool, a quarter of a megabyte at default settings, so eight
+ * megabytes for a track with clips near the cursor and nothing for one
  * without.
  *
- * It does not make the pool keep up with anything. Material dense enough that
- * even this cannot reach kReadAheadBridgeSeconds ahead is reported rather than
- * silently late (@ref ClipVoicePool::unbridged).
+ * Doesn't guarantee keeping up: material too dense for even this to reach
+ * kReadAheadBridgeSeconds ahead is reported rather than silently late (@ref
+ * ClipVoicePool::unbridged).
  */
 constexpr int kMaxReadersPerTrack = 2 * kMaxVoicesPerTrack;
 
 /**
  * @brief Session slots one track may have standing by.
  *
- * Its own budget, not a share of the one above. An arrangement reader is a
- * window the transport moves through, so a passed clip hands its reader on and
- * a crowded lane costs read-ahead. A slot is never passed, so sharing would
- * leave the slots behind the first 32 permanently silent rather than late
- * (#2301).
+ * Its own budget, not a share of the one above: an arrangement reader is a
+ * window the transport moves through, so a passed clip hands its reader on,
+ * while a slot is never passed, so sharing would leave slots past the first
+ * 32 permanently silent rather than late.
  *
- * A ceiling on standing cost, not on how many scenes a project may have: each
- * reader is an open file and a chunk pool, a quarter of a megabyte at the
- * default settings. Slots past it are reported
- * (@ref ClipVoicePool::unprovisionedSlots).
- *
- * Interim: once a launch is a request (#2305), what is worth provisioning is
- * what is playing or queued.
+ * A ceiling on standing cost, not on how many scenes a project may have:
+ * each reader is an open file and a chunk pool, a quarter of a megabyte at
+ * default settings. Slots past it are reported (@ref
+ * ClipVoicePool::unprovisionedSlots). Sized against the full launch
+ * surface; #2305's request lane will narrow this to what's playing or queued.
  */
 constexpr int kMaxSessionReadersPerTrack = kMaxReadersPerTrack;
 
@@ -126,9 +119,9 @@ class ClipVoicePool {
      * @brief A pool opening files through @p files and filled by @p reader.
      *
      * Neither is owned and both outlive it. @p context is the device the
-     * streams are read for, and the rate every cue is worked out at: a file
-     * sample is consumed per output sample, so a position derived at any other
-     * rate would disagree with what playing gets through (ClipPlacement.hpp).
+     * streams are read for and the rate every cue is worked out at: a file
+     * sample is consumed per output sample, so a position derived at any
+     * other rate would disagree with playback (ClipPlacement.hpp).
      */
     ClipVoicePool(AudioFileReaderFactory& files, PrefetchThread& reader,
                   const RenderContext& context, const PrefetchSettings& settings = {});
@@ -136,15 +129,14 @@ class ClipVoicePool {
     /**
      * @brief Give every reader back.
      *
-     * Publishes an empty table so nothing the audio thread can reach names a
+     * Publishes an empty table so nothing on the audio thread can reach a
      * stream, then waits for the prefetch thread to be out of each one.
      *
-     * Nothing may call @ref service() again from here on, and that is the
-     * caller's to guarantee rather than this class's: a round in flight would
-     * publish a full table straight after the empty one and the streams it
-     * named would be pulled out from under the reader. A host driving this with
-     * a ClipVoiceThread destroys the thread first, which is what declaring the
-     * thread after the pool gets for free.
+     * The caller must guarantee @ref service() is never called again after
+     * this starts -- a round still in flight could publish a full table
+     * right after the empty one and pull streams out from under the
+     * reader. A host using ClipVoiceThread gets this for free by declaring
+     * the thread after the pool, so it's destroyed first.
      */
     ~ClipVoicePool();
 
@@ -161,23 +153,22 @@ class ClipVoicePool {
     /**
      * @brief The snapshot to provision against.
      *
-     * On the publishing thread, beside EngineSession::publishClips: the same
-     * value reaches the audio thread through the feed and this side through
-     * here, so the clips a callback plays and the clips a reader is pointed at
-     * are the same clips.
+     * On the publishing thread, beside EngineSession::publishClips: the
+     * same value reaches the audio thread through the feed and this side
+     * through here, so the clips a callback plays and the clips a reader
+     * points at are the same clips.
      */
     void setSnapshot(std::shared_ptr<const ClipSnapshot> snapshot);
 
     /**
      * @brief Where the transport is, in seconds.
      *
-     * From the audio thread, once per block: a relaxed store of a double and
-     * nothing else. Seconds rather than beats because that is the face a file's
-     * samples are counted in, and because a tempo map on this thread would be a
-     * second one.
+     * From the audio thread, once per block: a relaxed store of a double.
+     * Seconds rather than beats, since that's how a file's samples are
+     * counted, and a tempo map on this thread would be a second one.
      *
-     * A pool nobody tells provisions around zero, which is where a session that
-     * has not played yet is.
+     * A pool nobody tells provisions around zero, where a session that
+     * hasn't played yet is.
      */
     void setPosition(double seconds) {
         position_.store(seconds, std::memory_order_relaxed);
@@ -186,39 +177,35 @@ class ClipVoicePool {
     /**
      * @brief One round of provisioning: open, cue, publish, retire.
      *
-     * On a thread that may wait for a disk, and not the prefetch thread (see
-     * the file comment). Idempotent, and cheaply so: a round that finds every
-     * clip in the window already provisioned opens nothing, retires nothing and
-     * publishes nothing, so an idle session is not swapping a table at a
-     * hundred hertz and making the callback wait for each one.
+     * On a thread that may wait for a disk, and not the prefetch thread
+     * (see the file comment). Idempotent, and cheaply so: a round finding
+     * every clip in the window already provisioned opens, retires and
+     * publishes nothing, so an idle session isn't swapping a table at a
+     * hundred hertz.
      *
-     * A window holding more clips than there are readers is not a failure and
-     * is not reported as one. A window is a second of timeline and the budget
-     * is spent soonest first, so a clip that has been passed gives its reader
-     * back to the one behind it, and a queue of clips rotates through. What a
-     * crowded window costs is the read-ahead of the clips at the far end of it,
-     * which is nothing until the far end comes close.
-     *
-     * When it does come close, that is @ref unbridged. When more clips want to
-     * sound at once than a callback can render, that is @ref overSubscribed.
-     * The two are separate because they fail separately.
+     * A window holding more clips than there are readers isn't a failure:
+     * the budget is spent soonest-first, a passed clip gives its reader to
+     * the one behind it, and a queue of clips rotates through. That costs
+     * only the read-ahead of clips at the far end, which is nothing until
+     * the far end comes close -- when it does, that's @ref unbridged. When
+     * more clips want to sound at once than a callback can render, that's
+     * @ref overSubscribed. The two are separate because they fail separately.
      */
     void service();
 
     /**
      * @brief Read every provisioned stream up to capacity, here and now.
      *
-     * For a caller with no callback to starve, which in practice means an
-     * offline render. Servicing alone only opens files and points readers at
-     * them; what a voice actually copies out of is what the prefetch thread has
-     * managed to fetch, and a render moving a second of timeline every ten
-     * milliseconds outruns any thread. Doing the reading in step makes the
-     * render a function of the material rather than of the scheduler.
+     * For a caller with no callback to starve, in practice an offline
+     * render: servicing alone only opens files and points readers, while
+     * what a voice copies out of is what the prefetch thread has fetched,
+     * and a render moving a second of timeline every ten milliseconds
+     * outruns any thread. Reading in step here makes the render a function
+     * of the material rather than the scheduler.
      *
-     * Refuses when the reader has a thread of its own, because two things
-     * inside one stream's fill is a race over its cursor rather than a slow
-     * path. A host that wants this builds its PrefetchThread with the thread
-     * switched off.
+     * Refuses when the reader has a thread of its own, since two things
+     * filling one stream is a race over its cursor, not a slow path. A
+     * host that wants this builds its PrefetchThread with the thread off.
      */
     void fillNow();
 
@@ -228,19 +215,16 @@ class ClipVoicePool {
     /**
      * @brief Clips the last round found stacked past what a track can sound.
      *
-     * The most that are live at once anywhere in the window, less
-     * kMaxVoicesPerTrack. Live rather than overlapping, and measured against
-     * the same block the callback renders: clips that share a callback each
-     * need their own voice for it whether or not they overlap by a sample, so
-     * measuring bare overlap here would report zero while the callback was
-     * dropping the extras.
+     * The most live at once anywhere in the window, less kMaxVoicesPerTrack.
+     * Live rather than overlapping, measured against the same block the
+     * callback renders: clips sharing a callback each need their own voice
+     * whether or not they overlap by a sample, so measuring bare overlap
+     * would report zero while the callback was dropping the extras.
      *
-     * Not the number the window turned away, which is a different and usually
-     * harmless thing (see @ref service).
-     *
-     * A gauge rather than a tally, so it falls back to zero when the material
-     * stops asking. Non-zero means clips that will not be heard, and
-     * ClipAudioSource::starvedVoices counts them as they are not heard.
+     * Not the number the window turned away, which is usually harmless
+     * (see @ref service). A gauge, not a tally: falls back to zero once the
+     * material stops asking. Non-zero means clips that won't be heard;
+     * ClipAudioSource::starvedVoices counts them as unheard.
      */
     int overSubscribed() const {
         return overSubscribed_.load(std::memory_order_relaxed);
@@ -249,21 +233,21 @@ class ClipVoicePool {
     /**
      * @brief Clips due too soon for the reader budget to have reached them.
      *
-     * The other way a clip goes silent, and the one that has nothing to do with
-     * how many can sound at once: entries the budget turned away that start
-     * inside kReadAheadBridgeSeconds. Every one of them fits the voice ceiling
-     * and will still play nothing, because the round that could have opened it
-     * spent its budget on the clips in front of it.
+     * The other way a clip goes silent, unrelated to how many can sound at
+     * once: entries the budget turned away that start inside
+     * kReadAheadBridgeSeconds. Every one fits the voice ceiling and will
+     * still play nothing, because the round that could have opened it
+     * spent its budget on the clips ahead of it.
      *
-     * Fits the ceiling is checked rather than assumed. A clip dropped into a
-     * stretch where every voice is already spoken for was not going to sound
-     * whatever the budget had been, and it belongs to @ref overSubscribed; a
-     * clip counted here would otherwise be counted twice and send a reader for
-     * a voice that was never free.
+     * Fitting the ceiling is checked, not assumed: a clip dropped into a
+     * stretch where every voice is already spoken for was never going to
+     * sound regardless of budget, and belongs to @ref overSubscribed
+     * instead -- counting it here too would send a reader for a voice that
+     * was never free.
      *
-     * Non-zero means the material is denser than this track can read ahead for.
-     * Nothing in the engine fixes that by trying harder; what it can do is say
-     * so rather than let a lane of slices go quiet for no stated reason.
+     * Non-zero means the material is denser than this track can read ahead
+     * for; nothing here fixes that by trying harder, only reports it rather
+     * than letting a lane of slices go quiet unexplained.
      */
     int unbridged() const {
         return unbridged_.load(std::memory_order_relaxed);
@@ -279,10 +263,9 @@ class ClipVoicePool {
     /**
      * @brief Session slots the budget could not reach, in the last round.
      *
-     * A launch that will play nothing. Unlike @ref unbridged this is not
-     * lateness: nothing the transport does brings such a slot into reach.
-     *
-     * A gauge rather than a tally, like the others.
+     * A launch that will play nothing. Unlike @ref unbridged this isn't
+     * lateness -- nothing the transport does brings such a slot into reach.
+     * A gauge, not a tally, like the others.
      */
     int unprovisionedSlots() const {
         return unprovisionedSlots_.load(std::memory_order_relaxed);
@@ -291,11 +274,11 @@ class ClipVoicePool {
     /**
      * @brief Tables handed to the audio thread since this pool was made.
      *
-     * Every one of them made a callback finish its block before the swap could
-     * land, so this is the cost of provisioning as the audio thread sees it. It
-     * should climb while the transport moves through new material and stand
-     * still otherwise; a session sitting idle and still counting means rounds
-     * are publishing work that has not changed.
+     * Every one made a callback finish its block before the swap could
+     * land, so this is the cost of provisioning as the audio thread sees
+     * it. Should climb while the transport moves through new material and
+     * hold still otherwise; a still-climbing idle session means rounds are
+     * publishing unchanged work.
      */
     int tablesPublished() const {
         return tablesPublished_.load(std::memory_order_relaxed);
@@ -323,42 +306,41 @@ class ClipVoicePool {
     /**
      * @brief A reader, and what it was opened for.
      *
-     * The identity matters because the key does not carry it. An id survives
-     * edits that change everything a reader was opened for: swap a clip's file
-     * and the ids are the same clip and the same event over different material,
-     * and a reader kept on the strength of its id would go on playing the file
-     * that is no longer there. The anchor is here for the milder version of the
-     * same thing, a trim that moves where the reader should be pointed.
+     * Identity matters because the key doesn't carry it: an id survives
+     * edits that change everything a reader was opened for (swap a clip's
+     * file and the ids still name the same clip and event over different
+     * material), so a reader kept on id alone would keep playing a file
+     * that's no longer there. The anchor covers the milder case, a trim
+     * that moves where the reader should point.
      *
-     * The path is not the whole of what was opened either. Reverse, looping and
-     * rate conversion are built into the reader rather than asked of it per
-     * block (io/SourceReaders.hpp), so a clip that has been reversed since is
-     * reading a different file from the same path and needs a new one.
+     * The path alone isn't enough either: reverse, looping and rate
+     * conversion are built into the reader rather than asked of it per
+     * block (io/SourceReaders.hpp), so a clip reversed since is reading a
+     * different file from the same path.
      *
-     * The stream is null where the file would not open. Kept rather than
-     * dropped so a path that failed is not retried every round for as long as
-     * it sits in the window; leaving the window and coming back is what asks
-     * again.
+     * The stream is null where the file wouldn't open, kept rather than
+     * dropped so a failed path isn't retried every round while it sits in
+     * the window -- leaving and re-entering the window is what asks again.
      */
     struct Reader {
         std::shared_ptr<PrefetchStream> stream;
         std::string path;
         SourceRead read;
 
-        /// The sample of that reading the stream is pointed at: where the event
-        /// starts, less whatever its stretcher wants in front of it. Derived
-        /// rather than the event's own anchor, because a mirrored read counts
-        /// from the other end and a stretched one starts behind itself
-        /// (clip/EventPlacement.hpp, clip/ClipStretcher.hpp).
+        /// The sample of that reading the stream is pointed at: where the
+        /// event starts, less whatever its stretcher wants in front of it.
+        /// Derived rather than the event's own anchor, since a mirrored
+        /// read counts from the other end and a stretched one starts
+        /// behind itself (clip/EventPlacement.hpp, clip/ClipStretcher.hpp).
         std::int64_t cueSamples = 0;
 
-        /// What plays it at a speed that is not its file's, and how far in front
-        /// of the event that one wants to be handed. Null and zero for a clip
-        /// that asks for neither, which is every clip in slice 3.
+        /// What plays it at a speed that isn't its file's, and how far
+        /// ahead of the event it wants to be handed. Null and zero for a
+        /// clip asking for neither.
         ///
-        /// Kept across an edit that leaves the setup alone, and replaced without
-        /// touching the stream when only the setup changed: a pitch change
-        /// should not close a file and pay a seek for it.
+        /// Kept across an edit that leaves the setup alone, and replaced
+        /// without touching the stream when only the setup changed: a
+        /// pitch change shouldn't close a file and pay for a seek.
         std::shared_ptr<ClipStretcher> stretcher;
         StretchSetup setup;
         int preRoll = 0;
@@ -408,14 +390,14 @@ class ClipVoicePool {
 /**
  * @brief The thread a pool provisions on.
  *
- * It polls, like the prefetch thread and for the same reason: waking a thread
- * takes a lock, and the audio thread does not take locks. A clip that came into
- * the window between two rounds is found on the next one, which is a fraction
- * of the second the window is wide.
+ * Polls, like the prefetch thread and for the same reason: waking a thread
+ * takes a lock, and the audio thread doesn't take locks. A clip entering
+ * the window between two rounds is found on the next one, a fraction of a
+ * second later.
  *
- * Declare it after the pool it drives. Destruction runs in reverse, so the
- * thread stops before the pool gives its readers back, which is the order
- * ~ClipVoicePool requires and the one nothing else enforces.
+ * Declared after the pool it drives: destruction runs in reverse, so the
+ * thread stops before the pool gives its readers back, the order
+ * ~ClipVoicePool requires.
  */
 class ClipVoiceThread final : private juce::Thread {
   public:

--- a/magda/engine/clip/MidiEventList.hpp
+++ b/magda/engine/clip/MidiEventList.hpp
@@ -8,29 +8,29 @@
  * @file MidiEventList.hpp
  * @brief One MIDI clip's messages, resolved, and how a block finds them.
  *
- * The compiled form of everything the model says about a MIDI clip. Between a
- * `MidiNote` and a note-on stand the curve densification, the MPE channel
- * assignment, the same-pitch overlap rule and the two offsets, and every one of
- * those is a question about the model with one answer that does not change until
- * the model does. So they are answered once, off the audio thread, and what
+ * The compiled form of everything the model says about a MIDI clip. Between
+ * a `MidiNote` and a note-on stand the curve densification, the MPE channel
+ * assignment, the same-pitch overlap rule and the two offsets, each a
+ * question about the model with one answer that doesn't change until the
+ * model does -- so they're answered once, off the audio thread, and what
  * reaches the callback is one sorted array of short messages.
  *
- * The same move `AudioEventPlayback` makes with `WarpMap`, and the same move the
- * fork makes by a longer road: it builds a playback sequence per clip
- * (`MidiList::createDefaultPlaybackMidiSequence`) and its node walks that. What
- * differs is where the sequence lives and what rebuilding it costs. The fork's
- * lives inside `te::MidiClip`, so editing a curve clears and rebuilds it, TE's
- * TreeWatcher sees the tree change and restarts playback, and the graph is
- * rebuilt under a rolling transport. This one is a value in an immutable
- * snapshot, so an edit compiles a new one and swaps it in.
+ * The same move `AudioEventPlayback` makes with `WarpMap`, and the same move
+ * the fork makes by a longer road: it builds a playback sequence per clip
+ * (`MidiList::createDefaultPlaybackMidiSequence`) and its node walks that.
+ * What differs is where the sequence lives and what rebuilding it costs. The
+ * fork's lives inside `te::MidiClip`, so editing a curve clears and rebuilds
+ * it, TE's TreeWatcher sees the tree change and restarts playback, and the
+ * graph is rebuilt under a rolling transport. This one is a value in an
+ * immutable snapshot, so an edit compiles a new one and swaps it in.
  *
- * Groove is the one thing NOT resolved here, because it cannot be: it is
- * anchored to the project grid, so a looped clip grooves each pass differently
- * whenever its loop length is not a whole multiple of the template's period
- * (GrooveTemplate.hpp).
+ * Groove is the one thing not resolved here: it can't be, since it's
+ * anchored to the project grid, so a looped clip grooves each pass
+ * differently whenever its loop length isn't a whole multiple of the
+ * template's period (GrooveTemplate.hpp).
  *
- * Beats throughout, in the clip's own content domain. Where those land on the
- * timeline is the fold's answer, below.
+ * Beats throughout, in the clip's own content domain. Where those land on
+ * the timeline is the fold's answer, below.
  */
 
 namespace magda::engine {
@@ -38,10 +38,10 @@ namespace magda::engine {
 /**
  * @brief One short message, at one content beat.
  *
- * Three data bytes and no more, because a MIDI clip has no SysEx: the model
- * holds notes, CC and pitch bend and nothing else. That is what keeps the
- * per-block cost bounded by events rather than by bytes, which matters against
- * a port budget counted in bytes (EngineDevice.hpp).
+ * Three data bytes and no more, since a MIDI clip has no SysEx: the model
+ * holds notes, CC and pitch bend and nothing else. That keeps the per-block
+ * cost bounded by events rather than by bytes, which matters against a port
+ * budget counted in bytes (EngineDevice.hpp).
  */
 struct MidiClipEvent {
     double beat = 0.0;
@@ -53,18 +53,18 @@ struct MidiClipEvent {
 
     /// Note-ons only: the beat this note stops sounding at.
     ///
-    /// The only field with no counterpart in the model, and what makes "which
-    /// notes are sounding at this instant" answerable without a scan of
-    /// unbounded length. That question is asked on every locate.
+    /// The only field with no counterpart in the model, and what makes
+    /// "which notes are sounding at this instant" answerable without an
+    /// unbounded scan -- asked on every locate.
     ///
-    /// Where it STOPS sounding, which is not always where its own note-off is,
-    /// and the difference matters to exactly one caller. A note whose pitch is
-    /// struck again before it ends has its note-off dropped at compile time,
-    /// because emitting it would cut the second note short (the fork's
-    /// `useNoteUp = false`). Such a note still sounds from its onset until the
-    /// retrigger replaces it, so this is the retrigger's beat: a locate landing
-    /// in that stretch has to hear it, and reading a dropped note-off as "never
-    /// sounding" would give silence instead.
+    /// Where it stops sounding, which isn't always where its own note-off
+    /// is: a note whose pitch is struck again before it ends has its
+    /// note-off dropped at compile time, since emitting it would cut the
+    /// second note short (the fork's `useNoteUp = false`). Such a note keeps
+    /// sounding from its onset until the retrigger replaces it, so this
+    /// holds the retrigger's beat -- a locate landing in that stretch has to
+    /// hear it, and reading a dropped note-off as "never sounding" would
+    /// give silence instead.
     double endBeat = 0.0;
 
     unsigned kind() const {
@@ -87,16 +87,17 @@ struct MidiClipEvent {
 /**
  * @brief Every controller of one kind on one channel, in order.
  *
- * What the chase reads. Locating into the middle of a clip has to leave every
- * controller at the value the curve is at, and the answer is the last event of
- * each stream before the instant, which is one binary search per stream rather
- * than the scan of the whole sequence the fork does
+ * What the chase reads. Locating into the middle of a clip has to leave
+ * every controller at the value the curve is at; the answer is the last
+ * event of each stream before the instant, one binary search per stream
+ * rather than the whole-sequence scan the fork does
  * (`chocMidiHelpers::createControllerUpdatesForTime`).
  *
- * Emitting on value change makes that lookup exactly right rather than nearly
- * right: if nothing was emitted since, nothing changed since, so the last event
- * IS the current value. Under a fixed grid it would be up to a grid step stale,
- * and the synth would sit on the stale value until the next point arrived.
+ * Emitting only on value change makes that lookup exactly right rather than
+ * nearly right: if nothing was emitted since, nothing changed since, so the
+ * last event is the current value. Under a fixed grid it would be up to a
+ * grid step stale, with the synth sitting on the stale value until the next
+ * point arrived.
  */
 struct MidiControllerStream {
     /// 1 to 16.
@@ -110,22 +111,22 @@ struct MidiControllerStream {
 
     static constexpr int kPitchBend = 256;
 
-    /// Channel pressure. Per-channel state a synth holds exactly as it holds a
-    /// controller, so it is chased like one: under MPE a member channel is
+    /// Channel pressure. Per-channel state a synth holds exactly as it holds
+    /// a controller, so it's chased like one: under MPE a member channel is
     /// reused round robin, and a note located into on a channel carrying
-    /// another note's pressure is the same staleness the compile takes care to
-    /// avoid at a note's start.
+    /// another note's pressure is the same staleness the compile takes care
+    /// to avoid at a note's start.
     static constexpr int kChannelPressure = 257;
 };
 
 /**
  * @brief One stretch of a block, in one pass of a clip's loop.
  *
- * A loop is a coordinate change rather than a copy. The fork unrolls, writing
- * one copy of the sequence per repetition, so a two-bar loop under a sixty-four
- * bar clip is thirty-two copies rebuilt whenever a note moves. Nothing here
- * needs that: a block is a beat range, and folding a range through a loop gives
- * a handful of sub-ranges over the one list.
+ * A loop is a coordinate change rather than a copy. The fork unrolls,
+ * writing one copy of the sequence per repetition, so a two-bar loop under
+ * a sixty-four bar clip is thirty-two copies rebuilt whenever a note moves.
+ * Nothing here needs that: a block is a beat range, and folding a range
+ * through a loop gives a handful of sub-ranges over the one list.
  */
 struct MidiFoldPass {
     /// The half-open content range this pass covers of the block.
@@ -156,10 +157,11 @@ struct MidiFoldPass {
  */
 struct MidiEventList {
     /// Sorted by beat, and at equal beats by kind: controllers, then pitch
-    /// bend, then note-offs, then note-ons. Controllers first because a bank or
-    /// program change has to land before the note it configures, which is the
-    /// fork's rule too; offs before ons because two notes of one pitch meeting
-    /// exactly is otherwise a coin toss between a retrigger and a hung note.
+    /// bend, then note-offs, then note-ons. Controllers first since a bank
+    /// or program change has to land before the note it configures (the
+    /// fork's rule too); offs before ons since two notes of one pitch
+    /// meeting exactly is otherwise a coin toss between a retrigger and a
+    /// hung note.
     std::vector<MidiClipEvent> events;
 
     std::vector<MidiControllerStream> controllers;
@@ -184,14 +186,14 @@ struct MidiEventList {
     /**
      * @brief The value of every controller as of @p beat, into @p out.
      *
-     * Event indices. A stream with nothing before the instant has no value to
-     * chase to and contributes nothing.
+     * Event indices. A stream with nothing before the instant has no value
+     * to chase to and contributes nothing.
      *
-     * @p allowed vetoes an event the caller knows never sounded, and the walk
-     * then keeps going back through that stream rather than giving up: what a
-     * synth is holding is the last value that actually reached it. A clip hole
-     * suppresses controllers during playback, so chasing one from inside a hole
-     * would set a value the listener never got.
+     * @p allowed vetoes an event the caller knows never sounded, and the
+     * walk keeps going back through that stream rather than giving up: what
+     * a synth is holding is the last value that actually reached it. A clip
+     * hole suppresses controllers during playback, so chasing one from
+     * inside a hole would set a value the listener never got.
      */
     template <typename Allowed>
     void controllerStateAt(double beat, Allowed&& allowed, std::vector<std::int32_t>& out) const {
@@ -218,17 +220,18 @@ struct MidiEventList {
     /**
      * @brief Note-ons before @p beat whose note ends after it, into @p out.
      *
-     * What a locate needs, and what a loop pass needs: a note hanging over the
-     * point being jumped to has to be struck, and the fork does the same thing
-     * for the same reason (`getNotesOnAtTime`, and the clip-in half of its
-     * unrolling). A note with no note-off at all is never sounding here, because
-     * what ended it was a boundary rather than itself.
+     * What a locate needs, and what a loop pass needs: a note hanging over
+     * the point being jumped to has to be struck, and the fork does the
+     * same for the same reason (`getNotesOnAtTime`, and the clip-in half of
+     * its unrolling). A note with no note-off at all is never sounding
+     * here, since what ended it was a boundary rather than itself.
      *
      * Bounded by @ref longestNoteBeats rather than walked from the top.
      *
-     * @p widen is what a groove can move an edge by. With one in force these are
-     * candidates rather than an answer, because where a note sounds is not where
-     * it was written, and the caller settles it on the grooved edges.
+     * @p widen is what a groove can move an edge by. With one in force
+     * these are candidates rather than an answer, since where a note
+     * sounds is not where it was written, and the caller settles it on the
+     * grooved edges.
      */
     void notesSoundingAt(double beat, double widen, std::vector<std::int32_t>& out) const;
 };
@@ -236,23 +239,23 @@ struct MidiEventList {
 /**
  * @brief How a clip's content maps onto the timeline, and back.
  *
- * The fold's inputs, kept together because they are asked about together and
- * because their interaction is the whole of what a MIDI clip's placement means.
+ * The fold's inputs, kept together since they're asked about together and
+ * their interaction is the whole of what a MIDI clip's placement means.
  */
 struct MidiFold {
     /// Timeline beat the clip starts at.
     double clipStartBeat = 0.0;
 
-    /// The content origin a left-resize left behind, which only exists when the
-    /// clip does not loop: a looped clip's window is the loop region and the
-    /// trim has nothing to say about it, which is what the model's own
+    /// The content origin a left-resize left behind, which only exists when
+    /// the clip does not loop: a looped clip's window is the loop region and
+    /// the trim has nothing to say about it, which is what the model's own
     /// getMidiVisibleRange already decides.
     double trimOffsetBeats = 0.0;
 
     /// The phase, which applies whether or not the clip loops. The fork's
-    /// arranger path drops it for a clip that does not loop while its session
-    /// path applies it; that is a gap in the sync layer rather than a semantic,
-    /// and it is recorded as a divergence.
+    /// arranger path drops it for a clip that does not loop while its
+    /// session path applies it -- a gap in the sync layer rather than a
+    /// semantic, recorded here as a divergence.
     double offsetBeats = 0.0;
 
     bool loopEnabled = false;
@@ -260,10 +263,10 @@ struct MidiFold {
     double loopLengthBeats = 0.0;
 };
 
-/// How many passes of one clip's loop a single block may cover. A loop shorter
-/// than a block is pathological and reachable: loopLengthBeats has no floor in
-/// the model. Past this the source counts rather than looping unbounded on the
-/// audio thread.
+/// How many passes of one clip's loop a single block may cover. A loop
+/// shorter than a block is pathological and reachable: loopLengthBeats has
+/// no floor in the model. Past this the source counts rather than looping
+/// unbounded on the audio thread.
 constexpr int kMaxFoldPassesPerBlock = 8;
 
 /**

--- a/magda/engine/exec/EngineDevice.hpp
+++ b/magda/engine/exec/EngineDevice.hpp
@@ -25,39 +25,27 @@ namespace magda::engine {
  * @brief Encoded MIDI one source or device may write to one port over any
  *        RenderContext::maxBlockSize samples of the timeline.
  *
- * The executor reserves storage for every MIDI port before the first block, so
- * nothing on the audio thread has to grow a buffer. A port fed by a merge is
- * sized from the sum of what feeds it; the chain has to end somewhere, and this
- * is where: a producer that writes past this forces the very allocation the
- * reservation exists to avoid. Debug builds assert on it at every write site.
+ * The executor reserves storage for every MIDI port before the first block,
+ * so nothing on the audio thread grows a buffer; a producer writing past this
+ * forces the allocation the reservation exists to avoid (debug builds assert
+ * on it at every write site). A port fed by a merge is sized from the sum of
+ * what feeds it.
  *
- * The budget is per span of samples rather than per callback, and the
- * difference is not pedantry. Blocks may be shorter than the one the plan was
- * prepared for, so a callback is not a fixed amount of time: a host delivering
- * one sample at a time against a plan prepared for five hundred and twelve
- * would fit five hundred and twelve callbacks inside the same stretch of
- * timeline, and any storage sized from a per-callback figure would be short by
- * that factor. Nothing noticed while every reservation covered one block; a
- * delay line holds what is in flight across many, and it is what the amount of
- * time a callback stands for has to be pinned down for.
+ * Sized per span of samples, not per callback: blocks may be shorter than
+ * the plan was prepared for, so a host delivering one sample at a time
+ * against a 512-sample plan fits 512 callbacks in the same stretch of
+ * timeline, and a per-callback figure would be short by that factor. Every
+ * MIDI producer is positioned on the timeline for this reason, not per call.
  *
- * Every producer the engine has already works this way, because MIDI is
- * positioned on the timeline rather than per call: a clip source renders the
- * events its block's time range contains, live input delivers what arrived
- * while that time passed, and a generator places notes at musical positions.
- * Spelling it out is what lets storage be sized from it.
+ * The debug asserts only see one callback, so the actual enforcement is
+ * downstream, at the one place a violation costs something: a delay line
+ * holding more than it reserved room for reports it
+ * (MidiDelayLine::hasOverflowed), in release as well as debug.
  *
- * The debug asserts at the write sites see one callback and so can only check
- * the looser reading of this, which is all a producer can be caught at where it
- * writes. What actually enforces the budget is downstream, at the one place a
- * violation costs something: a delay line holding more than it reserved room
- * for reports it (MidiDelayLine::hasOverflowed), in release as well as debug.
- *
- * The budget is bytes rather than events because a MIDI message is not a fixed
- * size: one SysEx dump from a controller can outweigh a thousand notes, and a
- * cap on the number of events would let it through. An event costs six bytes
- * plus its own length, so a note or a controller change is nine, and this
- * budget holds around four hundred and fifty of them.
+ * Budgeted in bytes rather than events, since a MIDI message has no fixed
+ * size (one SysEx dump can outweigh a thousand notes). An event costs six
+ * bytes plus its own length, so a note or controller change is nine, and
+ * this budget holds around 450 of them.
  */
 constexpr int kMaxMidiBytesPerPort = 4096;
 
@@ -74,14 +62,16 @@ struct DeviceBlock {
     /// MIDI reaching the device. Empty when the plan left the slot unconnected.
     const juce::MidiBuffer* midiIn = nullptr;
 
-    /// Where a MIDI-producing device writes, cleared before the call. Null when
-    /// the plan gave the device no MIDI output port. At most what
-    /// setMidiOutputBoundBytes said; past it the buffer allocates.
-    ///
-    /// What the device produced, not what it was handed. MIDI thru is the
-    /// plan's merge behind the device (DeviceInfo::midiInThru), so a device
-    /// that also passed its input on would send every note twice and leave
-    /// every reservation downstream counting one stream as two (#2345).
+    /**
+     * @brief Where a MIDI-producing device writes, cleared before the call.
+     *
+     * Null when the plan gave the device no MIDI output port. At most what
+     * setMidiOutputBoundBytes said; past it the buffer allocates.
+     *
+     * What the device produced, not what it was handed: MIDI thru is the
+     * plan's own merge behind the device (DeviceInfo::midiInThru), so a
+     * device that also echoed its input would double every note (#2345).
+     */
     juce::MidiBuffer* midiOut = nullptr;
 
     /// Sidechain audio. A zero-channel block when the slot is unconnected, so
@@ -91,39 +81,31 @@ struct DeviceBlock {
     /**
      * @brief A multi-out instrument's further output pairs.
      *
-     * `extraOutputs[k]` is pair k + 1: pair 0 is `audio` above, which is what
-     * the device's own chain carries on from. Empty for every device that is
-     * not multi-out, which is almost all of them.
+     * `extraOutputs[k]` is pair k + 1: pair 0 is `audio` above. Empty for
+     * every device that is not multi-out (almost all of them).
      *
-     * One block per pair the device declares, whether or not a MultiOut track
-     * was opened for it, so a device writes its outputs where its own layout
-     * says they go and never has to ask what is being listened to. That is what
-     * the current engine does too: the instrument writes every pin of the rack
-     * around it, and it is the RackInstance for a pair that decides whether
-     * anyone reads those pins. A pair no track opened is rendered and dropped.
-     *
-     * Each block arrives cleared, so a device that writes only the pairs it has
-     * material for leaves the rest silent rather than stale.
+     * One block per pair the device declares, whether or not a MultiOut
+     * track was opened for it -- a device writes its own layout and never
+     * asks what's being listened to, matching the current engine (the
+     * instrument writes every rack pin; the RackInstance decides who reads
+     * it). Each block arrives cleared, so a device writing only the pairs it
+     * has material for leaves the rest silent rather than stale.
      */
     std::span<juce::dsp::AudioBlock<float>> extraOutputs;
 
     /**
      * @brief The device's parameters, resolved for this block (#2116).
      *
-     * Indexed the way the device declared them, and already everything the
-     * device could want to know: the stored value, the automation curve over
-     * it and the modifiers linked to it have been resolved into one value
-     * stream per parameter, clamped, quantised, and in the parameter's own
-     * units. A device reads these and has no other way to find out what a
-     * parameter is, which is what keeps the precedence rules in one place
-     * (param/ParamResolve.hpp) rather than in every device.
+     * Indexed the way the device declared them. Each entry is already the
+     * stored value, its automation curve and its linked modifiers resolved
+     * into one clamped, quantised value stream in the parameter's own
+     * units -- a device has no other way to read a parameter, which keeps
+     * the precedence rules in one place (param/ParamResolve.hpp).
      *
-     * Resolved before this call and before the MIDI above is looked at, so an
-     * event at sample zero sees the value automation put there rather than the
-     * one from the block before.
-     *
-     * Empty for a device with no parameters, and for every device until the
-     * table is published against a plan.
+     * Resolved before this call and before the MIDI above, so an event at
+     * sample zero sees this block's automated value, not the previous one.
+     * Empty for a device with no parameters, or before the table is first
+     * published against a plan.
      */
     DeviceParams params;
 
@@ -149,43 +131,35 @@ class EngineDevice {
     /**
      * @brief The most encoded MIDI that can reach this device in one block.
      *
-     * Called off the audio thread when a plan is prepared, before any block, by
-     * the executor that knows the answer. A device that buffers its input sizes
-     * that buffer from this and nothing else.
+     * Called off the audio thread when a plan is prepared, by the executor
+     * that knows the answer. A device that buffers its input sizes that
+     * buffer from this and nothing else.
      *
-     * Not kMaxMidiBytesPerPort. That is one producer's budget, and a device's
-     * input port is often a merge: the executor sums the bound through the MIDI
-     * graph precisely because fan-in outgrows any fixed figure, and a device
-     * that assumed the per-producer cap would drop everything past it on a
-     * track with more sources than one. Zero for a device the plan gave no MIDI
-     * input.
-     *
-     * Ignored by default, because most devices read the block's buffer where it
-     * lies and never need to know how big it can get.
+     * Not kMaxMidiBytesPerPort: that's one producer's budget, while a
+     * device's input port is often a merge, and the executor sums the bound
+     * through the MIDI graph so a device assuming the per-producer cap
+     * wouldn't drop input on a track fed by more than one source. Zero for a
+     * device the plan gave no MIDI input. Ignored by default, since most
+     * devices read the block's buffer where it lies without needing to know
+     * how big it can get.
      */
     virtual void setMidiInputBoundBytes(int) {}
 
     /**
      * @brief The most encoded MIDI this device may write in one block.
      *
-     * Called off the audio thread beside setMidiInputBoundBytes, by the same
-     * executor and for the same reason: the figure belongs to the plan and no
-     * device can work it out for itself.
+     * Called off the audio thread beside setMidiInputBoundBytes, for the
+     * same reason: the figure belongs to the plan, not the device.
      *
-     * A device is a producer and only a producer -- thru is the plan's merge,
-     * not the device's (#2345) -- so what arrives here is one producer's worth,
-     * for what the device makes of its own: a pattern, an arpeggio, the
-     * all-notes-off it owes after a prepare. It is said rather than assumed
-     * because the figure is the port's and the plan owns the port: a device
-     * reading the constant instead would be right today and silently wrong the
-     * day an op behind it reserves differently. Zero for a device the plan gave
-     * no MIDI output.
-     *
-     * Deliberately not the input bound, which is often larger: a device may
-     * read a whole merged stream and still emit only its own.
-     *
-     * Ignored by default, because a device that writes what it means to write
-     * and no more never comes near it.
+     * A device is a producer only -- thru is the plan's merge, not the
+     * device's (#2345) -- so this is one producer's worth, sized for what
+     * the device itself makes (a pattern, an arpeggio, a post-prepare
+     * all-notes-off). Passed in rather than assumed because the port owns
+     * the figure and a device reading a constant instead would go silently
+     * wrong the day an op behind it reserves differently. Zero for a device
+     * the plan gave no MIDI output; deliberately not the (often larger)
+     * input bound, since a device may read a merged stream and emit only
+     * its own. Ignored by default.
      */
     virtual void setMidiOutputBoundBytes(int) {}
 
@@ -223,39 +197,26 @@ class EngineMidiSource {
 };
 
 /**
- * @brief One hardware insert: what leaves the machine, and what comes back
- *        (#2245).
+ * @brief One hardware insert: what leaves the machine, and what comes back (#2245).
  *
- * The outside world, as the engine is allowed to see it. An insert is a send op
- * and a return op in the plan, and both of them resolve to one of these: the
- * send hands over what is leaving, the return is asked for what arrived, and
- * how those reach an interface is the host's business exactly as a live input's
- * is.
+ * An insert is a send op and a return op in the plan, both resolving to one
+ * of these -- one object rather than a source and a sink, since a round trip
+ * is one thing and the latency below is a property of the pair.
  *
- * One object rather than a source and a sink, because a round trip is one
- * thing. The latency below is a property of the pair -- what left, coming back
- * -- and an implementation that had to correlate a separately bound sink with a
- * separately bound source would be rebuilding the pairing the plan already did.
+ * Offline rendering (a bounce played back from a capture rather than run at
+ * real time, since the outside world can't be sped up) is not modeled here:
+ * an implementation returning captured samples and one returning what an
+ * interface just handed it satisfy the same two calls, and which one a
+ * render binds is what decides. Same shape as the location-transparent
+ * device op, for the same reason (#1893).
  *
- * ## The offline case
- *
- * A bounce cannot run the outside world faster than real time, so it either
- * runs at real time or plays back a capture, and the incumbent does the latter.
- * Nothing about that is here, and that is the seam rather than a gap: an
- * implementation that returns captured samples and one that returns what an
- * interface just handed it satisfy the same two calls, and which one a render
- * binds is what decides. Same shape as the location-transparent device op
- * (#1893), for the same reason.
- *
- * What this interface deliberately does not have is a notion of an
- * implementation that is present but unfit to render -- a capture taken at
- * another sample rate, one with a gap in it. Nothing here could enforce such a
- * state: the executor binds a pointer and calls it, so a "check me first" flag
- * would be a rule some caller has to remember, and the render that forgot would
- * be wrong with nothing downstream able to see it. A capture that cannot be
- * replayed must therefore fail to be constructed rather than fail to be valid,
- * which is a decision for whatever owns captures (#2279) and is why none of it
- * is here.
+ * There is deliberately no notion of an implementation that exists but is
+ * unfit to render (a capture at the wrong sample rate, one with a gap in
+ * it): the executor just binds a pointer and calls it, so a "check me
+ * first" flag would be a rule some caller could forget with nothing
+ * downstream able to catch it. A capture that can't be replayed must fail
+ * to construct rather than fail to be valid -- a decision for whatever owns
+ * captures (#2279).
  */
 class EngineInsert {
   public:
@@ -269,17 +230,15 @@ class EngineInsert {
     /**
      * @brief The round trip, in samples, as this insert measures it.
      *
-     * Asked when a plan is prepared, beside every device's, and compensated by
-     * the same pass: an insert reporting a round trip is a latency on an edge,
-     * and the graph aligns it against everything else arriving where it lands.
-     * That is what makes a chain with an insert in it line up with a chain
-     * without one, and it is why this is not an insert-shaped special case.
+     * Asked when a plan is prepared, beside every device's, and compensated
+     * by the same pass -- an insert's round trip is a latency on an edge,
+     * so a chain with an insert lines up with one without.
      *
-     * The user's manual correction is included here rather than applied
-     * somewhere above, because it is part of the same number: the interface
-     * reports its own buffering and knows nothing about the converter and the
-     * cable past it, so what an insert measures and what a person measured with
-     * a loopback are one figure by the time anything compensates for it.
+     * The user's manual correction lives here rather than applied
+     * elsewhere, since it's part of the same number: the interface reports
+     * its own buffering and knows nothing of the converter and cable past
+     * it, so what the insert measures and what a person measured with a
+     * loopback end up as one figure by the time anything compensates.
      */
     virtual int latencySamples() const {
         return 0;
@@ -288,16 +247,14 @@ class EngineInsert {
     /**
      * @brief What is leaving the machine this block.
      *
-     * Independent of @ref receive within one block, and deliberately: what comes
-     * back now is what left several blocks ago, so there is no ordering between
-     * the two and the plan declares none. The scheduler is free to run them on
-     * different threads, which means an implementation must not carry state
-     * from one to the other inside a block.
+     * Independent of @ref receive within one block: what comes back now
+     * left several blocks ago, so there's no ordering between the two and
+     * the plan declares none -- an implementation must not carry state from
+     * one to the other inside a block.
      *
-     *
-     * Either may be empty, which is an insert with no send of that kind: an
+     * Either may be empty, which is an insert with no send of that kind (an
      * external effect sends audio and no MIDI, an external instrument the
-     * reverse. Called on the audio thread.
+     * reverse). Called on the audio thread.
      */
     virtual void send(const BlockInfo&, juce::dsp::AudioBlock<const float> audio,
                       const juce::MidiBuffer& midi) = 0;

--- a/magda/engine/exec/EngineSession.hpp
+++ b/magda/engine/exec/EngineSession.hpp
@@ -17,27 +17,27 @@
  * @file EngineSession.hpp
  * @brief The live engine: one plan on the audio thread, swapped from another.
  *
- * A published plan is immutable, so a structural change does not edit it: it
- * compiles a new one and swaps it in whole. This is where that swap happens,
- * and where the old one is reclaimed.
+ * A published plan is immutable, so a structural change compiles a new one
+ * and swaps it in whole. This is where that swap happens, and where the old
+ * plan is reclaimed.
  *
- * The rule the swap exists to keep is that the audio thread never waits and
- * never destroys. Publishing blocks the thread doing the publishing until the
- * audio thread has finished the block it is in, and everything the retired
- * epoch was the last owner of is destroyed there, on that thread. Nothing that
- * runs on the callback allocates, locks, or frees.
+ * The rule the swap exists to keep: the audio thread never waits and never
+ * destroys. Publishing blocks the publishing thread until the audio thread
+ * finishes its current block, and everything the retired epoch owned is
+ * destroyed there, on the publishing thread. Nothing on the callback
+ * allocates, locks, or frees.
  *
- * Threading contract: one audio thread and one publishing thread. Everything
- * that is not process() belongs to a single non-realtime thread and is not
- * synchronised against itself, because the swap primitive only promises to
- * keep the audio thread out of the publisher's way, not publishers out of each
- * other's. Two threads publishing at once is a race, not a slow path.
+ * Threading contract: one audio thread, one publishing thread. Everything
+ * that is not process() runs on a single non-realtime thread and is not
+ * synchronised against itself -- the swap primitive only keeps the audio
+ * thread out of the publisher's way, not publishers out of each other's. Two
+ * threads publishing at once is a race, not a slow path.
  */
 
 namespace magda::engine {
 
-/// Only ever held as a pointer here, and only ever used from the .cpp, so the
-/// session does not hand its own includers a thread and a stream pool.
+/// Only ever held as a pointer here, and only ever used from the .cpp, so
+/// the session does not hand its own includers a thread and a stream pool.
 class ClipVoicePool;
 
 class EngineSession {
@@ -45,27 +45,25 @@ class EngineSession {
     /**
      * @brief A session rendering on @p pool.
      *
-     * Null is a session that renders every block on the audio thread alone,
-     * which is the same executor with one thread rather than a different one.
-     * A host with a pool passes it here, once: it outlives every plan, and it
-     * has to outlive this, because the epochs retired here are what let go of
-     * it.
+     * Null means every block renders on the audio thread alone (the same
+     * executor with one thread instead of many). A host passing a pool does
+     * so once: the pool outlives every plan, and must outlive this session,
+     * since retired epochs are what release it.
      *
-     * @p voices provisions the readers a track's clips play through (#2035),
-     * and is null for a session with no arrangement audio: an offline render
-     * that reads straight through its files, and every test that publishes no
-     * clips. It is passed here rather than fed separately because a snapshot
-     * has to reach it and the audio thread together, and because it is what
-     * wants to know where the transport is.
+     * @p voices provisions the readers a track's clips play through
+     * (#2035); null for a session with no arrangement audio (an offline
+     * render reading straight through its files, or a test that publishes
+     * no clips). Passed here rather than fed separately because a snapshot
+     * has to reach it and the audio thread together, and it needs to know
+     * where the transport is.
      */
     explicit EngineSession(RuntimeStateFactory& factory, RenderThreadPool* pool = nullptr,
                            ClipVoicePool* voices = nullptr)
         : store_(factory), pool_(pool), voices_(voices) {}
 
     /// What came of a publish. `published` false means the plan was refused
-    /// and the previous one is still playing; true with messages means it is
-    /// live and something in it could not be honoured. The caller should not
-    /// have to infer which by watching livePlan().
+    /// and the previous one is still playing; true with messages means it's
+    /// live but something in it could not be honoured.
     struct Result {
         bool published = false;
         std::vector<std::string> messages;
@@ -74,29 +72,23 @@ class EngineSession {
     /**
      * @brief Prepare a plan and make it the one the audio thread renders.
      *
-     * On the publishing thread. A plan that does not prepare is not published
-     * at all and the previous one keeps playing, which is the only safe
-     * reading of a plan the executor has refused.
+     * On the publishing thread. A plan that fails to prepare is not
+     * published; the previous one keeps playing.
      *
-     * @p modelIds is what the model still holds, which is not the same
-     * question as what the plan uses: runtime state is kept for everything the
-     * model names and destroyed only for what it has lost. It only ever
-     * extends retention, so a set that has drifted from the plan being
-     * published costs a dormant object its retirement, never the audio thread
-     * a pointer.
+     * @p modelIds is what the model still holds -- not the same as what the
+     * plan uses. Runtime state is kept for everything the model names and
+     * destroyed only for what it has lost; retention only ever extends, so
+     * a set that has drifted from the published plan costs a dormant object
+     * its retirement, never the audio thread a pointer.
      *
-     * @p values is what the new plan renders with until publishValues() sends
-     * something newer, and it is not optional. A plan swap invalidates whatever
-     * was in flight, because those values were resolved against the plan being
-     * replaced; without a table of its own, the new plan would render at unity
-     * for the block or two before the next one arrives, and a fader sitting at
-     * -20 dB jumping to 0 dB is louder than any click the swap could have made.
-     * So a plan and the values it was resolved with travel together, and
-     * publishValues() is left as what it is: the mixer-speed update path.
-     *
-     * They have to be values for this plan. A table resolved against another
-     * one is refused rather than published, because the executor would decline
-     * to apply it and render at unity with nothing saying why.
+     * @p values is what the new plan renders with until publishValues()
+     * sends something newer, and is not optional: a plan swap invalidates
+     * whatever was in flight, since those values were resolved against the
+     * plan being replaced. Without a table of its own the new plan would
+     * render at unity for a block or two, and a fader jumping from -20 dB to
+     * 0 dB is louder than any click the swap could have made. Values for
+     * another plan are refused rather than published, since the executor
+     * would decline to apply them and render at unity with no explanation.
      */
     Result publish(std::shared_ptr<const RenderPlan> plan, const RenderContext& context,
                    const RuntimeStateIds& modelIds, PlanValues values);
@@ -107,33 +99,32 @@ class EngineSession {
      * On the publishing thread. Values change at mixer speed rather than
      * structural speed, so they travel on their own.
      *
-     * The parameter table rides along with them (#2117), and it can change
-     * shape without the plan changing at all: linking a macro for the first
-     * time gives it a parameter, and linking one more thing to the parameter
-     * that already had the most widens the room a block gathers contributions
-     * in. Neither is visible to the fingerprint, and neither fits what the live
-     * epoch allocated.
+     * The parameter table rides along (#2117) and can change shape without
+     * the plan changing: linking a macro for the first time gives it a
+     * parameter, and linking one more thing to an already-linked parameter
+     * widens the room a block gathers contributions in. Neither shows up in
+     * the fingerprint, and neither fits what the live epoch allocated.
      *
      * So a publish of that shape is escalated here into a structural one, on
-     * the plan that is already playing. It costs a prepare and a swap, which is
-     * what a structural edit costs, and it is what a link edit is: rare, human
-     * speed, and not something to make a block pay for. The alternative is a
-     * table nothing can render and a project whose parameters quietly stop
-     * following the model.
+     * the plan already playing -- a prepare and a swap, the cost of any
+     * structural edit, which is what a link edit is: rare, human speed, not
+     * something to make a block pay for. The alternative is a table nothing
+     * can render, with a project's parameters quietly ceasing to follow the
+     * model.
      *
-     * Values that belong to another plan are refused rather than escalated:
-     * republishing the live plan with them would refuse them a second time,
-     * one layer further in.
+     * Values belonging to another plan are refused rather than escalated,
+     * since republishing the live plan with them would just refuse them a
+     * second time, one layer further in.
      */
     Result publishValues(PlanValues values);
 
     /**
-     * @brief Tempo, loop, metronome and where the transport has been asked to
-     *        be, as one value.
+     * @brief Tempo, loop, metronome and where the transport has been asked
+     *        to be, as one value.
      *
-     * On the publishing thread. Travels on its own for the same reason values
-     * do: a tempo edit, a loop drag and a locate are all things that happen
-     * while the plan they apply to keeps playing.
+     * On the publishing thread. Travels on its own for the same reason
+     * values do: a tempo edit, a loop drag and a locate all happen while the
+     * plan they apply to keeps playing.
      *
      * Nothing is published by default, so a session that has never seen one
      * renders stopped at the beginning at 120 bpm rather than refusing to run.
@@ -143,30 +134,27 @@ class EngineSession {
     /**
      * @brief What every track plays, resolved (#2034).
      *
-     * On the publishing thread, and on its own, like values and the transport:
-     * moving a clip is not a topology change and must not compile a plan. The
-     * one it replaces is destroyed here, on this thread.
+     * On the publishing thread, on its own like values and the transport:
+     * moving a clip is not a topology change and must not compile a plan.
+     * The clip snapshot it replaces is destroyed here, on this thread.
      *
-     * Its seconds were derived through a tempo map, so a tempo edit publishes
-     * both: a snapshot compiled against the previous map places every clip at
-     * the seconds that map gave it.
+     * Its seconds were derived through a tempo map, so a tempo edit
+     * publishes both -- a snapshot compiled against the previous map would
+     * place every clip at the seconds that map gave it.
      */
     void publishClips(std::shared_ptr<const ClipSnapshot> clips);
 
-    /**
-     * @brief The feed clip sources read.
-     *
-     * Handed to a source when it is created, and owned here because it outlives
-     * every plan those sources are bound into: a structural recompile must not
-     * cost a track the clips it was playing.
-     */
+    /// The feed clip sources read. Handed to a source when created, and
+    /// owned here because it outlives every plan those sources are bound
+    /// into: a structural recompile must not cost a track the clips it was
+    /// playing.
     ClipSnapshotFeed& clipFeed() {
         return clips_;
     }
 
-    /// The feed session sources read their handles from (#2301). Owned here for
-    /// the reason the clip feed is: a structural recompile must not stop a clip
-    /// that is sounding. Published by publishClips().
+    /// The feed session sources read their handles from (#2301). Owned here
+    /// for the same reason as the clip feed: a structural recompile must not
+    /// stop a clip that is sounding. Published by publishClips().
     LaunchHandleFeed& launchHandleFeed() {
         return handles_;
     }
@@ -174,9 +162,9 @@ class EngineSession {
     /**
      * @brief The handle for one slot, or null. On the publishing thread.
      *
-     * What drives a launch until the request lane exists (#2305). A handle is
-     * advanced on the audio thread, so asking one for a change from here races
-     * the callback: safe only while nothing is rendering.
+     * What drives a launch until the request lane exists (#2305). A handle
+     * is advanced on the audio thread, so asking one for a change from here
+     * races the callback: safe only while nothing is rendering.
      *
      * Null until publishClips() has named the slot.
      */
@@ -187,21 +175,20 @@ class EngineSession {
     /**
      * @brief Render @p numSamples. On the audio thread.
      *
-     * The transport decides what stretch of timeline that is: the caller says
-     * how many samples the device wants and nothing about where they come from.
-     * A callback that a loop wraps inside is rendered as two blocks, back to
-     * back, and neither of them straddles the wrap.
+     * The transport decides what stretch of timeline that is -- the caller
+     * only says how many samples the device wants. A callback that a loop
+     * wraps inside renders as two blocks back to back, and neither straddles
+     * the wrap.
      *
-     * Renders silence until a plan is published, and the cursor stands still
-     * while it does. Not a policy about what a transport may do without a
-     * graph: the sample rate is settled when a plan is prepared, and a clock
-     * with no idea how long a sample lasts would be inventing a position rather
-     * than reporting one.
+     * Renders silence until a plan is published, and the cursor stands
+     * still while it does: the sample rate is only settled when a plan is
+     * prepared, and a clock with no idea how long a sample lasts would be
+     * inventing a position, not reporting one.
      */
     void process(int numSamples, juce::AudioBuffer<float>& output);
 
-    /// Where the transport is, in beats. Readable from any thread; this is
-    /// what a playhead is drawn from.
+    /// Where the transport is, in beats. Readable from any thread; what a
+    /// playhead is drawn from.
     double positionBeats() const {
         return clock_.positionBeats();
     }
@@ -224,24 +211,24 @@ class EngineSession {
      * under modulation, a modifier editor, and a touch or latch gesture all
      * draw from.
      *
-     * Both the lookup and the pointer belong to the publishing thread, and that
-     * is a lifetime rather than a convention: the next publish can destroy the
-     * tap outright, on that thread, with nothing deferring the reclamation. A
-     * cached pointer read from a paint or animation thread is a use-after-free
-     * waiting for an edit. Fetch it here, use it before returning to the
-     * message loop, and ask again after every publish; read() is safe from
-     * wherever it is called for exactly as long as the pointer is.
+     * Both the lookup and the pointer belong to the publishing thread as a
+     * lifetime rule, not a convention: the next publish can destroy the tap
+     * outright, on that thread, with nothing deferring reclamation. A cached
+     * pointer read from a paint or animation thread is a use-after-free
+     * waiting for an edit -- fetch it here, use it before returning to the
+     * message loop, and ask again after every publish.
      *
-     * See RuntimeStateStore::valueTap() for what null means, which is not the
-     * same as the tap being unbound.
+     * See RuntimeStateStore::valueTap() for what null means, which is not
+     * the same as the tap being unbound.
      */
     ValueTap* valueTap(const ParamKey& key) const {
         return store_.valueTap(key);
     }
 
-    /// Values the live plan found somewhere to publish from, which is not the
-    /// number of taps the store holds: a key the parameter table does not carry
-    /// has a tap and is never written through it. On the publishing thread.
+    /// Values the live plan found somewhere to publish from -- not the
+    /// number of taps the store holds, since a key the parameter table does
+    /// not carry has a tap that is never written through. On the publishing
+    /// thread.
     int boundValueTapCount() const {
         return live_ == nullptr ? 0 : live_->executor.boundValueTapCount();
     }
@@ -254,30 +241,32 @@ class EngineSession {
     /**
      * @brief Fades of the live plan that have not finished, by its OpIds.
      *
-     * On the publishing thread, and what insertCrossfades needs to know before
-     * the next plan is compiled: a fade whose edge has arrived is re-emitted
-     * while it is still running and dropped once it is not. Empty when nothing
-     * is published, which is what a caller with no epoch to ask should pass.
+     * On the publishing thread; what insertCrossfades needs before the next
+     * plan is compiled: a fade whose edge has arrived is re-emitted while
+     * still running and dropped once it is not. Empty when nothing is
+     * published.
      */
     std::vector<char> unfinishedCrossfades() const {
         return live_ == nullptr ? std::vector<char>{} : live_->executor.unfinishedCrossfades();
     }
 
   private:
-    /// One epoch: a plan, the executor prepared for it, and the values it was
-    /// published with. The executor points into the plan, so the three are
-    /// retired together and never separately.
-    ///
-    /// The values are the floor rather than the current reading: whatever
-    /// publishValues() has sent since is used when it belongs to this plan, and
-    /// these are what the epoch renders with until it does. An epoch never
-    /// renders without values that were resolved for it.
-    ///
-    /// The device properties and the metronome ride along for the same reason:
-    /// both are settled against a context, and the only safe moment to settle
-    /// them is while making an epoch nothing is rendering yet. The metronome is
-    /// shared with the epoch it replaces whenever the context has not changed,
-    /// so a click that is sounding is not cut off by a structural edit.
+    /**
+     * @brief One epoch: a plan, the executor prepared for it, and the
+     * values it was published with.
+     *
+     * The executor points into the plan, so the three are retired together,
+     * never separately. `values` is a floor rather than the current
+     * reading: whatever publishValues() has sent since is used when it
+     * belongs to this plan, and this is what the epoch renders with until
+     * then -- an epoch never renders without values resolved for it.
+     *
+     * The device properties and metronome ride along for the same reason:
+     * both are settled against a context, and the only safe moment is while
+     * building an epoch nothing is rendering yet. The metronome is shared
+     * with the epoch it replaces whenever the context hasn't changed, so a
+     * click that is sounding isn't cut off by a structural edit.
+     */
     struct PreparedRender {
         explicit PreparedRender(RenderThreadPool* pool) : executor(pool) {}
 
@@ -299,15 +288,15 @@ class EngineSession {
 
     RuntimeStateStore store_;
 
-    /// The threads every epoch renders on, or null for a session that renders
-    /// on the audio thread alone. Not owned, and shared across epochs: threads
+    /// The threads every epoch renders on, or null for a session rendering
+    /// on the audio thread alone. Not owned, shared across epochs: threads
     /// are made once and a structural edit is not a reason to remake them.
     RenderThreadPool* pool_ = nullptr;
 
-    /// Where the readers behind a track's clips come from, or null. Not owned
-    /// and not swapped with anything: like the clip feed, it is a property of
-    /// the session, and a structural edit must not cost a track the readers it
-    /// was playing through.
+    /// Where the readers behind a track's clips come from, or null. Not
+    /// owned or swapped: a property of the session, like the clip feed, and
+    /// a structural edit must not cost a track the readers it was playing
+    /// through.
     ClipVoicePool* voices_ = nullptr;
 
     PublishedRender published_;
@@ -321,21 +310,21 @@ class EngineSession {
     /// Where the audio thread finds a slot's handle. Travels with the clips.
     LaunchHandleFeed handles_;
 
-    /// The cursor. Not published and not swapped: it is where the timeline is,
-    /// which is a property of the session rather than of any plan, and a plan
+    /// The cursor. Not published and not swapped: it's where the timeline
+    /// is, a property of the session rather than of any plan, and a plan
     /// swap must not move it.
     TransportClock clock_;
 
-    /// What the model held at the last publish. Kept so a values publish that
-    /// has to become a structural one has the set to publish with: retention
-    /// only ever extends, so the worst a set from a moment ago can cost is a
-    /// dormant object its retirement.
+    /// What the model held at the last publish. Kept so a values publish
+    /// escalated into a structural one has a set to publish with; retention
+    /// only ever extends, so the worst a stale set can cost is a dormant
+    /// object its retirement.
     RuntimeStateIds lastModelIds_;
 
-    /// This thread's own handle on the epoch that is rendering. Held because
-    /// the next publish prepares against it: the differ needs the plan it was
-    /// built for, and whatever survives is shared with it rather than copied
-    /// out of it. Replaced after the swap, which is where the epoch it
+    /// This thread's own handle on the rendering epoch. Held because the
+    /// next publish prepares against it: the differ needs the plan it was
+    /// built for, and whatever survives is shared with it rather than
+    /// copied out. Replaced after the swap, which is where the epoch it
     /// displaces is destroyed, on this thread.
     std::shared_ptr<PreparedRender> live_;
     std::shared_ptr<const RenderPlan> livePlan_;

--- a/magda/engine/exec/PlanExecutor.hpp
+++ b/magda/engine/exec/PlanExecutor.hpp
@@ -22,17 +22,17 @@
  * @file PlanExecutor.hpp
  * @brief The reference executor: one plan, one thread, one op at a time.
  *
- * This is not the engine that ships. The parallel executor is, and it renders
- * the same plans through the same ops; this one exists to be obviously correct.
- * When the two disagree, this is the arbiter, so it stays a straight walk of
- * the op vector with no scheduling of any kind: ops are in dependency order, so
- * running them in order is enough.
+ * This is not the engine that ships. The parallel executor is, and it
+ * renders the same plans through the same ops; this one exists to be
+ * obviously correct and is the arbiter when the two disagree. It stays a
+ * straight walk of the op vector with no scheduling: ops are already in
+ * dependency order, so running them in order is enough.
  *
- * "Through the same ops" is meant literally. Everything below the walk lives
- * here and both executors use it: preparing a plan against its bindings, the
- * buffers it renders through, and the body of every op. What the parallel
- * executor replaces is the loop and nothing else, which is why its output is
- * bit-identical to this one's rather than close to it.
+ * "Through the same ops" is literal: preparing a plan against its bindings,
+ * the buffers it renders through, and the body of every op all live here and
+ * both executors use them. The parallel executor only replaces the loop,
+ * which is why its output is bit-identical to this one's rather than close
+ * to it.
  */
 
 namespace magda::engine {
@@ -41,17 +41,17 @@ namespace magda::engine {
  * @brief A fixed delay on one audio port, in samples.
  *
  * Reads and writes the same block: the input is captured before the delayed
- * output is read back, so a delay whose output shares its input's buffer is no
- * different from one that does not.
+ * output is read back, so a delay whose output shares its input's buffer
+ * behaves no differently from one that doesn't.
  */
 class AudioDelayLine {
   public:
     void prepare(int numChannels, int delaySamples, int maxBlockSize);
     void process(juce::dsp::AudioBlock<float> block, int numSamples);
 
-    /// Whether a line already running is one this configuration could adopt
-    /// rather than build. Everything here changes what the ring means, so
-    /// anything that differs is a new line and a fresh start.
+    /// Whether a running line could adopt this configuration rather than be
+    /// rebuilt. Everything here changes what the ring means, so any
+    /// difference means a fresh start.
     bool hasConfiguration(int numChannels, int delaySamples, int maxBlockSize) const {
         return delay_ == delaySamples && ring_.getNumChannels() == numChannels &&
                ring_.getNumSamples() == delaySamples + maxBlockSize;
@@ -66,11 +66,10 @@ class AudioDelayLine {
 /**
  * @brief The same delay for one MIDI port.
  *
- * Events move by sample position and the ones that fall past the end of the
- * block are held for the next one, so the storage has to cover every sample the
- * delay spans rather than one block's worth. That span is what
- * kMaxMidiBytesPerPort is a budget over: measured per callback it would be
- * whatever the host chose the block size to be.
+ * Events move by sample position, and ones falling past the end of a block
+ * are held for the next, so storage must cover the whole delay span rather
+ * than one block's worth. That span is what kMaxMidiBytesPerPort budgets
+ * over -- measured per callback it would vary with the host's block size.
  */
 class MidiDelayLine {
   public:
@@ -79,17 +78,16 @@ class MidiDelayLine {
 
     /// Whether more has ever been in flight than prepare() reserved room for.
     /// Reported rather than only asserted: past the reservation the buffer
-    /// grows on the callback, and a release build would do that quietly.
+    /// grows on the callback, which a release build would do silently.
     ///
-    /// Safe to read while rendering. The per-write asserts can only see one
-    /// callback's worth, which for short callbacks is looser than the budget
-    /// the reservation is computed from, so this is where the budget is
-    /// actually enforced and it has to be readable from wherever asks.
+    /// Safe to read while rendering. The per-write asserts only see one
+    /// callback's worth (looser than the budget for short callbacks), so
+    /// this is where the budget is actually enforced.
     bool hasOverflowed() const {
         return overflowed_.load(std::memory_order_relaxed);
     }
 
-    /// As AudioDelayLine::hasConfiguration. The reservation is part of it: a
+    /// As AudioDelayLine::hasConfiguration. The reservation counts too: a
     /// line whose port now carries more would be adopted with too little room.
     bool hasConfiguration(int delaySamples, int capacityBytes) const {
         return delay_ == delaySamples && capacity_ == capacityBytes;
@@ -98,50 +96,48 @@ class MidiDelayLine {
   private:
     juce::MidiBuffer pending_, scratch_;
     int delay_ = 0;
-    /// What prepare() reserved, kept so process() can tell when the budget the
-    /// reservation was computed from has been exceeded.
+    /// What prepare() reserved, kept so process() can tell when the
+    /// reservation's budget has been exceeded.
     int capacity_ = 0;
-    /// Written on the audio thread, read from anywhere. Relaxed both ways: it
-    /// orders nothing and guards nothing, it only has to be a read and a write
-    /// the standard has an answer for.
+    /// Written on the audio thread, read from anywhere. Relaxed both ways:
+    /// it orders nothing and guards nothing.
     std::atomic<bool> overflowed_{false};
 };
 
 /**
  * @brief How long an edge takes to become the edge that replaced it.
  *
- * Long enough that the step is a slope rather than an edge, short enough that
- * dragging a device around does not sound like a fader move. It is a time
- * rather than a block count: the executor is block-size invariant everywhere
- * else and a fade that lasted longer at 64 samples than at 512 would be the one
- * thing in the plan that was not.
+ * Long enough that the step is a slope, short enough that dragging a device
+ * around doesn't sound like a fader move. A time rather than a block count,
+ * since the executor is block-size invariant everywhere else and a fade
+ * lasting longer at 64 samples than at 512 would be the one exception.
  */
 inline constexpr double kCrossfadeSeconds = 0.005;
 
 /**
  * @brief The ramp from one side of a changed edge to the other.
  *
- * Equal gain, linearly: the two sides are the same material a moment apart, so
- * they are correlated and sum to full amplitude. A constant-power law, which is
- * right for uncorrelated material, would put a bulge in the middle of every
+ * Equal gain, linearly: the two sides are the same material a moment apart,
+ * so they're correlated and sum to full amplitude. A constant-power law
+ * (right for uncorrelated material) would bulge in the middle of every
  * device insert.
  *
- * Position is counted off what is left rather than off blocks, so the fade is
- * the same length however the host cuts its callbacks, and a fade that runs out
- * mid-block finishes there rather than at the next boundary.
+ * Position is counted off what's left rather than off blocks, so the fade
+ * is the same length regardless of callback size, and finishes mid-block
+ * rather than waiting for the next boundary.
  */
 class CrossfadeRamp {
   public:
     void prepare(int lengthSamples);
 
-    /// Whether a ramp already running is one this configuration could adopt
-    /// rather than build. A different length is a different fade.
+    /// Whether a running ramp could adopt this configuration. A different
+    /// length is a different fade.
     bool hasConfiguration(int lengthSamples) const {
         return length_ == lengthSamples;
     }
 
-    /// Whether the fade has finished. Safe to read from anywhere, which is what
-    /// the thread publishing the next plan asks so it knows to let it go.
+    /// Whether the fade has finished. Safe to read from anywhere, which is
+    /// what the thread publishing the next plan asks to know when to let it go.
     bool spent() const {
         return remaining_.load(std::memory_order_relaxed) <= 0;
     }
@@ -158,9 +154,8 @@ class CrossfadeRamp {
   private:
     int length_ = 0;
 
-    /// Samples of fade left. Written on the audio thread and read from the
-    /// thread that publishes the next plan; relaxed both ways, because it
-    /// orders nothing and guards nothing.
+    /// Samples of fade left. Written on the audio thread, read from the
+    /// thread publishing the next plan; relaxed both ways.
     std::atomic<int> remaining_{0};
 };
 
@@ -169,33 +164,32 @@ class PlanExecutor {
     /**
      * @brief Bind a plan to its runtime objects and allocate everything.
      *
-     * Off the audio thread. Returns one message per thing the executor cannot
-     * honour: an op with no binding, a plan that does not validate. A plan that
-     * does not validate is not prepared at all, and process() renders silence
-     * until a good one arrives.
+     * Off the audio thread. Returns one message per thing the executor
+     * can't honour (an unbound op, a plan that fails validation); a plan
+     * that fails validation is not prepared at all, and process() renders
+     * silence until a good one arrives.
      *
-     * @p bindings arrive already prepared for @p context. The executor does not
-     * own those objects and must not prepare them: they are shared with the
-     * epoch still rendering, and preparing a device the audio thread is inside
-     * is both a race and the loss of the state a swap exists to keep. Whoever
-     * owns them prepares them when they are made, which is the one moment
-     * nothing can reach them.
+     * @p bindings arrive already prepared for @p context. The executor does
+     * not own those objects and must not prepare them itself: they're
+     * shared with the epoch still rendering, and preparing a device the
+     * audio thread is inside is both a race and a loss of the state a swap
+     * exists to keep. Whoever owns them prepares them when made, the one
+     * moment nothing can reach them.
      *
-     * This is also where everything that depends on the bound instances is
-     * settled: how many samples each delay holds, and therefore which ports can
-     * share a buffer. A plugin that changes its reported latency is a re-prepare
-     * of the same plan, not a recompile of a new one.
+     * This is also where everything depending on the bound instances is
+     * settled: how many samples each delay holds, and which ports can
+     * therefore share a buffer. A plugin changing its reported latency is a
+     * re-prepare of the same plan, not a recompile of a new one.
      *
-     * @p previous is the executor this one is about to replace, if there is
-     * one. Ops the differ matches adopt its state rather than starting again,
-     * which is what keeps a structural edit from cutting whatever was in
-     * flight. Nothing it owns is written to here: the audio thread is still
-     * rendering through it until the swap, so a carried object is shared, never
-     * reset, and one that cannot be shared is rebuilt beside it instead.
-     *
-     * It has to still be prepared, and the plan it was prepared with has to
-     * still exist, which is why the session holds its own handle on the epoch
-     * that is rendering rather than reaching for whatever is published.
+     * @p previous is the executor this one is replacing, if any. Ops the
+     * differ matches adopt its state rather than restarting, which keeps a
+     * structural edit from cutting off whatever was in flight. Nothing it
+     * owns is written to here -- the audio thread is still rendering
+     * through it until the swap, so a carried object is shared, never
+     * reset, and one that can't be shared is rebuilt beside it instead.
+     * @p previous must still be prepared and its plan must still exist,
+     * which is why the session holds its own handle on the rendering epoch
+     * rather than reaching for whatever is currently published.
      */
     std::vector<std::string> prepare(const RenderPlan& plan, const PlanBindings& bindings,
                                      const RenderContext& context,
@@ -203,8 +197,8 @@ class PlanExecutor {
                                      const ParamTable* params = nullptr);
 
     /// Forget the prepared plan and everything sized for it. Off the audio
-    /// thread. Every prepare starts here, so a plan that is refused leaves
-    /// nothing behind that could still be rendered.
+    /// thread. Every prepare starts here, so a refused plan leaves nothing
+    /// behind that could still be rendered.
     void reset();
 
     /**
@@ -219,25 +213,26 @@ class PlanExecutor {
 
     /** @brief Where one block's render starts, before any op has run. */
     struct BlockStart {
-        /// The block as this plan will actually render it, which is the one
-        /// asked for clipped to what it was prepared for.
+        /// The block as this plan will actually render it: what was asked
+        /// for, clipped to what it was prepared for.
         BlockInfo block;
 
-        /// Whether the values belong to this plan. When they do not, every op
-        /// renders at unity rather than at whatever the table happens to say.
+        /// Whether the values belong to this plan. When they don't, every
+        /// op renders at unity rather than at whatever the table says.
         bool applyValues = false;
 
-        /// False when there is nothing to render at all: no plan prepared, or
-        /// no samples asked for. The output has been cleared either way.
+        /// False when there is nothing to render at all: no plan prepared,
+        /// or no samples asked for. The output has been cleared either way.
         bool render = false;
     };
 
     /**
      * @brief Settle what a block is, and clear @p output.
      *
-     * Shared with the parallel executor because the two have to agree on it:
-     * how much of the block this plan can render, and whether the values were
-     * resolved against it. A second copy of that reasoning is a second answer.
+     * Shared with the parallel executor since the two must agree on how
+     * much of the block this plan can render and whether the values were
+     * resolved against it -- a second copy of that reasoning is a second
+     * answer.
      */
     BlockStart beginBlock(const PlanValues& values, const BlockInfo& requested,
                           juce::AudioBuffer<float>& output) const;
@@ -245,41 +240,43 @@ class PlanExecutor {
     /**
      * @brief Resolve the block's parameters, before any op runs (#2117).
      *
-     * On the audio thread, after beginBlock and before anything is rendered,
+     * On the audio thread, after beginBlock and before anything renders,
      * from both executors: a device reads what its parameters are and the
      * answer has to be there when it does.
      *
-     * The table travels with the values, so what makes one applicable makes the
-     * other applicable. A table that does not belong to this plan leaves every
-     * parameter empty rather than resolved against the wrong addresses, and a
-     * device is handed a window of nothing, which is what it would have had
-     * before any table was published at all.
+     * The table travels with the values, so what makes one applicable makes
+     * the other applicable. A table that doesn't belong to this plan leaves
+     * every parameter empty rather than resolved against the wrong
+     * addresses, handing a device the same window of nothing it would have
+     * had before any table was published.
      */
     void resolveParameters(const PlanValues& values, const BlockInfo& block);
 
     /**
      * @brief Render the MIDI a block has before it has any audio (#2120).
      *
-     * On the audio thread, after beginBlock and before resolveParameters, from
-     * both executors. What it renders is the set of ops whose outputs are all
-     * MIDI and whose producers are all in that same set: clip readers, live
-     * input queues, the merges that gather them, and the delays on those edges.
-     * None of it reads a parameter and none of it reads audio, so running it
-     * early is the same schedule seen from a different place.
+     * On the audio thread, after beginBlock and before resolveParameters,
+     * from both executors. Renders every op whose outputs are all MIDI and
+     * whose producers are all in that same set -- clip readers, live input
+     * queues, the merges that gather them, and the delays on those edges.
+     * None of it reads a parameter or audio, so running it early is the
+     * same schedule seen from a different place.
      *
-     * What that buys is the one block a note-triggered modifier would otherwise
-     * be late by. Parameters resolve at the top of a block, so a trigger fired
-     * by an op during the walk is not spent until the next block's resolve; a
-     * trigger read off a MIDI buffer that already exists is spent in this one.
+     * That buys the one block a note-triggered modifier would otherwise be
+     * late by: parameters resolve at the top of a block, so a trigger fired
+     * by an op during the walk isn't spent until the next block's resolve,
+     * while a trigger read off a MIDI buffer that already exists is spent
+     * in this one.
      *
-     * MIDI a device makes is not in the prefix and cannot be: an arpeggiator's
-     * notes are work that has not happened yet at resolve time. A modifier
-     * triggered from those is a block late, which is the lag an audio trigger
-     * has as well (ModFollower.hpp).
+     * MIDI a device makes is not in the prefix and cannot be: an
+     * arpeggiator's notes are work that hasn't happened yet at resolve
+     * time. A modifier triggered from those is a block late, the same lag
+     * an audio trigger has (ModFollower.hpp).
      *
-     * The caller must not render these ops again. They stay in the schedule so
-     * their consumers are released as usual, and both executors skip re-running
-     * them: a live input queue rendered twice is a queue read twice.
+     * The caller must not render these ops again -- they stay in the
+     * schedule so their consumers are released as usual, but both executors
+     * skip re-running them, since a live input queue rendered twice is a
+     * queue read twice.
      */
     void renderMidiPrefix(const PlanValues& values, const BlockInfo& block);
 
@@ -292,34 +289,35 @@ class PlanExecutor {
     /**
      * @brief Render one op of the prepared plan.
      *
-     * Every op the engine renders passes through here, from both executors,
-     * and that is what makes their output bit-identical rather than merely
-     * close: the arithmetic is in one place, and scheduling is the only thing
+     * Every op the engine renders passes through here, from both executors
+     * -- what makes their output bit-identical rather than merely close:
+     * the arithmetic lives in one place, and scheduling is the only thing
      * the parallel executor changes. Anything that sums does so in compiled
-     * order, whatever order its inputs arrived in.
+     * order, regardless of what order its inputs arrived in.
      *
-     * The caller owes it a schedule. Every op this one reads has finished, and
-     * nothing that reads what it writes has started; ports share buffers on
-     * exactly that promise (see assignBuffers).
+     * The caller owes it a schedule: everything this op reads has finished,
+     * and nothing that reads what it writes has started; ports share
+     * buffers on exactly that promise (see assignBuffers).
      *
-     * @p output is touched by Output ops alone. Those accumulate into a buffer
-     * every one of them shares, so whoever drives the block runs them itself,
-     * in plan order, rather than letting a schedule decide what adds to what
-     * first.
+     * @p output is touched by Output ops alone. Those accumulate into a
+     * buffer every one of them shares, so whoever drives the block runs
+     * them itself, in plan order, rather than letting a schedule decide
+     * what adds to what first.
      */
     void renderOp(OpId op, const OpValue& value, const BlockInfo& block,
                   juce::AudioBuffer<float>& output);
 
     /// Meter ops whose tap the bindings filled. The rest still render; they
-    /// publish nothing, because nothing is reading them.
+    /// just publish nothing, since nothing is reading them.
     int boundMeterCount() const {
         return boundMeterCount_;
     }
 
-    /// Value taps this plan's table found a home for (#2122): a parameter the
-    /// table carries, or a modifier the runtime holds. A key the bindings
-    /// offered and the table does not have is not one of these and is not an
-    /// error; it is a host asking about a value this project does not move.
+    /// Value taps this plan's table found a home for (#2122): a parameter
+    /// the table carries, or a modifier the runtime holds. A key the
+    /// bindings offered that the table doesn't have isn't one of these and
+    /// isn't an error -- it's a host asking about a value this project
+    /// doesn't move.
     int boundValueTapCount() const {
         return static_cast<int>(paramTaps_.size() + modTaps_.size());
     }
@@ -327,35 +325,35 @@ class PlanExecutor {
     /**
      * @brief Take back what this plan no longer publishes (#2122).
      *
-     * Off the audio thread, and only after the swap that made this plan live.
-     * Every tap the bindings offered and this table found no home for is
+     * Off the audio thread, only after the swap that made this plan live.
+     * Every tap the bindings offered that this table found no home for is
      * cleared, so a host reads no writes at all rather than a value frozen
      * where the last plan left it.
      *
-     * That is not a rare case. A lane deleted off a fader takes that fader out
-     * of the parameter table, because a mixer value is carried only while
-     * something reaches it; without this the tap would sit at the last
-     * automated position under a count that never moves again, which the header
-     * tells hosts to read as an engine that has stopped.
+     * Not a rare case: a lane deleted off a fader takes that fader out of
+     * the parameter table, since a mixer value is carried only while
+     * something reaches it. Without this the tap would sit at the last
+     * automated position under a count that never moves again, which the
+     * header tells hosts to read as an engine that has stopped.
      *
-     * After the swap rather than at prepare, because until the swap the epoch
-     * being replaced is still rendering: a tap cleared while it is still being
-     * written would be counting from one again by the next block.
+     * Called after the swap rather than at prepare, since until the swap
+     * the epoch being replaced is still rendering -- a tap cleared while
+     * still being written would be counting from one again by the next block.
      */
     void clearUnboundValueTaps();
 
     /// Modulation taps that took over the detector of the executor they
-    /// replaced rather than starting again. What that buys is the same thing
-    /// ModRuntime's carry buys: an edit during playback does not restate a
-    /// gate the source never changed.
+    /// replaced rather than starting again -- the same thing ModRuntime's
+    /// carry buys: an edit during playback doesn't restate a gate the
+    /// source never changed.
     int carriedTriggerDetectors() const {
         return carriedTriggerDetectors_;
     }
 
-    /// Detectors no two taps share. Every modulation tap owns its own level and
-    /// gate, so this is the number of taps: a track read at both its points has
-    /// two, and one detector between them would let a level at one point work
-    /// the gate at the other.
+    /// Detectors no two taps share. Every modulation tap owns its own level
+    /// and gate, so this is the number of taps: a track read at both its
+    /// points has two, since one detector between them would let a level at
+    /// one point work the gate at the other.
     int distinctTriggerDetectors() const {
         std::set<const TriggerDetector*> seen;
         for (const auto& detector : triggerForOp_)
@@ -364,15 +362,15 @@ class PlanExecutor {
         return static_cast<int>(seen.size());
     }
 
-    /// Samples the prepared plan's output is delayed by: what the devices along
-    /// its longest path to the output report between them.
+    /// Samples the prepared plan's output is delayed by: what the devices
+    /// along its longest path to the output report between them.
     int latencySamples() const {
         return latencySamples_;
     }
 
-    /// Audio and MIDI buffers the prepared plan renders through. One per output
-    /// port would always work; sharing is what the assignment pass is for, so
-    /// these are how much it saved.
+    /// Audio and MIDI buffers the prepared plan renders through. One per
+    /// output port would always work; sharing is what the assignment pass
+    /// is for, so these are how much it saved.
     int audioBufferCount() const {
         return static_cast<int>(audioSlots_.size());
     }
@@ -380,9 +378,9 @@ class PlanExecutor {
         return static_cast<int>(midiSlots_.size());
     }
 
-    /// MIDI delay lines that have held more than they reserved room for, which
-    /// means a producer wrote past the budget every reservation here is
-    /// computed from. Zero on anything that keeps to it.
+    /// MIDI delay lines that have held more than they reserved room for --
+    /// a producer wrote past the budget every reservation is computed from.
+    /// Zero on anything that keeps to it.
     int midiDelayOverflows() const {
         int overflows = 0;
         for (const auto& line : midiDelays_)
@@ -391,7 +389,7 @@ class PlanExecutor {
     }
 
     /// Delay lines this executor took over from the one it replaced, rather
-    /// than building. What the differ bought, in other words.
+    /// than building fresh -- what the differ bought.
     int carriedDelayLines() const {
         return carriedDelayLines_;
     }
@@ -399,26 +397,26 @@ class PlanExecutor {
     /**
      * @brief Per op of the prepared plan: 1 where a fade is still running.
      *
-     * Off the audio thread, and the whole of the retirement protocol. The pass
-     * that compiles the next plan asks this: a fade whose edge has arrived is
-     * re-emitted while it says 1 and dropped once it does not, so a spent fade
-     * leaves at the next publish and nothing on the callback ever has to remove
-     * an op from a plan the audio thread can see.
+     * Off the audio thread; the whole of the retirement protocol. The pass
+     * compiling the next plan asks this: a fade whose edge has arrived is
+     * re-emitted while it says 1 and dropped once it doesn't, so a spent
+     * fade leaves at the next publish and nothing on the callback ever
+     * removes an op from a plan the audio thread can see.
      */
     std::vector<char> unfinishedCrossfades() const;
 
     /// Fades still running. What unfinishedCrossfades() counts, for tests.
     int activeCrossfades() const;
 
-    /// Fades this executor took over mid-ramp from the one it replaced, rather
-    /// than starting again.
+    /// Fades this executor took over mid-ramp from the one it replaced,
+    /// rather than starting again.
     int carriedCrossfades() const {
         return carriedCrossfades_;
     }
 
-    /// Modifiers this executor took over mid-cycle from the one it replaced.
-    /// An LFO that did not restart because a device was inserted somewhere
-    /// else in the project (#2119).
+    /// Modifiers this executor took over mid-cycle from the one it replaced
+    /// -- an LFO that didn't restart because a device was inserted
+    /// elsewhere in the project (#2119).
     int carriedModifiers() const {
         return mods_.carried();
     }
@@ -431,12 +429,12 @@ class PlanExecutor {
     /**
      * @brief The device properties the prepared plan was prepared for.
      *
-     * Readable because anything driving the executor has to agree with it, and
-     * because the disagreement is silent where it matters. process() renders at
-     * most maxBlockSize samples and says so only through an assert, so a caller
-     * that sized its blocks from a different context prints the first
-     * maxBlockSize samples of each one and silence for the rest: a bounce full
-     * of regular gaps, in release, from a build that passed every test.
+     * Readable because anything driving the executor has to agree with it,
+     * and the disagreement is silent where it matters: process() renders at
+     * most maxBlockSize samples and only asserts otherwise, so a caller
+     * sizing blocks from a different context prints the first maxBlockSize
+     * samples of each one and silence for the rest -- a bounce full of
+     * regular gaps, in release, from a build that passed every test.
      */
     const RenderContext& preparedContext() const {
         return context_;
@@ -445,24 +443,24 @@ class PlanExecutor {
     /**
      * @brief Whether the table @p values carries fits what was prepared for it.
      *
-     * The other half of applicable, and the half the plan's fingerprint cannot
-     * answer. A link edit changes no op and no plan, so a table that gained a
-     * parameter, moved one, or grew the room a block gathers contributions in
-     * travels on a values publish, matches the plan, and does not fit what was
-     * allocated for it.
+     * The other half of "applicable" -- the half the plan's fingerprint
+     * can't answer, since a link edit changes no op and no plan: a table
+     * that gained a parameter, moved one, or grew the room a block gathers
+     * contributions in still travels on a values publish, matches the
+     * plan's fingerprint, and yet doesn't fit what was allocated for it.
      *
-     * Three things, because there are three ways to not fit. The layout says
-     * the parameter at an index is still the one that index was resolved for,
-     * which a count cannot: a macro that stopped being used in one scope and
-     * started being used in another leaves the count alone and moves every
-     * device window after it, and the windows are cached here from the table
-     * the plan was prepared with. The count says the answers are the right size
-     * for it. The link width says a parameter's contributions all fit, since
-     * the block gathers them into room found before it started.
+     * Three checks, three ways to not fit. The layout says the parameter at
+     * an index is still the one that index was resolved for, which a count
+     * can't: a macro dropped from one scope and picked up in another leaves
+     * the count alone while moving every device window after it, and the
+     * windows are cached here from the table the plan was prepared with.
+     * The count says the answers are the right size. The link width says a
+     * parameter's contributions all fit, since the block gathers them into
+     * room found before it started.
      *
-     * Asked here so the publisher and the block get one answer: the publisher
-     * escalates such a publish into a structural one, and a block that meets
-     * one anyway renders empty rather than stale or half-applied.
+     * Asked here so the publisher and the block reach one answer: the
+     * publisher escalates such a publish into a structural one, and a block
+     * that meets one anyway renders empty rather than stale or half-applied.
      */
     bool fitsParameters(const PlanValues& values) const {
         return values.params == nullptr ||
@@ -475,13 +473,13 @@ class PlanExecutor {
     /**
      * @brief Whether process() would apply @p values rather than ignore them.
      *
-     * The one definition of applicable, so that a caller deciding which table
-     * to hand over and the block that reads it cannot come to different
-     * answers. A matching fingerprint says the table was resolved against this
-     * structure; a matching op count says it is all there, which a table
-     * assembled halfway can fail while still carrying the right fingerprint.
-     * Anything else renders at unity, which is why what publishes an epoch
-     * checks this before letting it play rather than after.
+     * The one definition of "applicable", so a caller deciding which table
+     * to hand over and the block that reads it can't reach different
+     * answers. A matching fingerprint says the table was resolved against
+     * this structure; a matching op count says it's all there, which a
+     * table assembled halfway can fail while still carrying the right
+     * fingerprint. Anything else renders at unity, which is why whatever
+     * publishes an epoch checks this before letting it play, not after.
      */
     bool appliesValues(const PlanValues& values) const {
         return plan_ != nullptr && values.planFingerprint == planFingerprint_ &&
@@ -489,18 +487,18 @@ class PlanExecutor {
     }
 
   private:
-    /// Where an op's output port keeps its buffer. Ports are flattened in op
-    /// order so a PortRef resolves with two array reads and no branching.
+    /// Where an op's output port keeps its buffer. Ports are flattened in
+    /// op order so a PortRef resolves with two array reads and no branching.
     int slotFor(const PortRef& ref) const {
         return portSlots_[static_cast<std::size_t>(portOffsets_[static_cast<std::size_t>(ref.op)] +
                                                    ref.port)];
     }
 
     /// One audio slot, as an op sees it. Built from the cached channel
-    /// pointers rather than from the buffer, because making a block out of a
-    /// juce::AudioBuffer writes the buffer's isClear flag: two ops reading the
-    /// same port at once would be two threads writing one byte, which is
-    /// benign in value and a data race in fact.
+    /// pointers rather than the buffer, since making a block out of a
+    /// juce::AudioBuffer writes the buffer's isClear flag: two ops reading
+    /// the same port at once would be two threads writing one byte, benign
+    /// in value but a data race in fact.
     juce::dsp::AudioBlock<float> audioBlock(std::size_t row, int numSamples) const;
 
     juce::dsp::AudioBlock<float> audioIn(const PortRef& ref, int numSamples) const;
@@ -508,8 +506,8 @@ class PlanExecutor {
     const juce::MidiBuffer& midiIn(const PortRef& ref) const;
     juce::MidiBuffer& midiOut(OpId op, int port);
 
-    /// Whether an op's output port 0 is the buffer one of its inputs arrived
-    /// in, so the copy that would fill it has already happened.
+    /// Whether an op's output port 0 is the buffer one of its inputs
+    /// arrived in, so the copy that would fill it has already happened.
     bool writesInPlace(std::size_t op) const {
         return writesInPlace_[op] != 0;
     }
@@ -523,18 +521,19 @@ class PlanExecutor {
     const RenderPlan* plan_ = nullptr;
     RenderContext context_;
 
-    /// The arena. Ports share these where no schedule can want both at once,
-    /// which is worked out in assignBuffers rather than here.
+    /// The arena. Ports share these where no schedule can want both at
+    /// once, worked out in assignBuffers rather than here.
     std::vector<juce::AudioBuffer<float>> audioSlots_;
     std::vector<juce::MidiBuffer> midiSlots_;
 
     /// Channel pointers into the arena, flattened: slot s, channel c is at
-    /// s * numChannels + c, and the row past the last slot is silence_. Every
-    /// audio block an op is handed is made from these, so nothing on the
-    /// render path touches a juce::AudioBuffer (see audioBlock).
+    /// s * numChannels + c, and the row past the last slot is silence_.
+    /// Every audio block an op is handed is made from these, so nothing on
+    /// the render path touches a juce::AudioBuffer (see audioBlock).
     std::vector<float*> slotChannels_;
-    /// Encoded bytes each MIDI buffer can hold without growing, summed through
-    /// the MIDI graph at prepare time. Checked in debug where producers write.
+    /// Encoded bytes each MIDI buffer can hold without growing, summed
+    /// through the MIDI graph at prepare time. Checked in debug where
+    /// producers write.
     std::vector<int> midiByteBounds_;
     std::vector<int> portOffsets_;
     std::vector<int> portSlots_;
@@ -546,8 +545,8 @@ class PlanExecutor {
     /// Held by shared pointer because a line can outlive the executor that
     /// built it: the one replacing this takes a reference to every line it
     /// adopts, and the rest go when this does. Nothing else shares them, and
-    /// only one epoch renders at a time, so there is no concurrent use to
-    /// guard against, only an owner to outlive.
+    /// only one epoch renders at a time, so there's an owner to outlive but
+    /// no concurrent use to guard against.
     std::vector<int> audioDelayForOp_;
     std::vector<int> midiDelayForOp_;
     std::vector<std::shared_ptr<AudioDelayLine>> audioDelays_;
@@ -555,37 +554,38 @@ class PlanExecutor {
     int latencySamples_ = 0;
     int carriedDelayLines_ = 0;
 
-    /// Per op: the ramp a Crossfade op runs, or -1. Held by shared pointer for
-    /// the same reason the delay lines are: a fade the next plan re-emits is
-    /// still running while the audio thread is inside the executor that owns
-    /// it, so the one taking over shares it rather than copying where it had
-    /// got to. A fade whose two sides do not arrive at the same latency has no
-    /// ramp at all and passes the new side through (see prepare).
+    /// Per op: the ramp a Crossfade op runs, or -1. Held by shared pointer
+    /// for the same reason the delay lines are: a fade the next plan
+    /// re-emits is still running while the audio thread is inside the
+    /// executor that owns it, so the one taking over shares it rather than
+    /// copying where it had got to. A fade whose two sides don't arrive at
+    /// the same latency has no ramp at all and passes the new side through
+    /// (see prepare).
     std::vector<int> crossfadeForOp_;
     std::vector<std::shared_ptr<CrossfadeRamp>> crossfades_;
     int carriedCrossfades_ = 0;
 
-    /// Identity of the prepared plan; values that do not carry the same one
-    /// were resolved against something else and are not applied.
+    /// Identity of the prepared plan; values not carrying the same one were
+    /// resolved against something else and are not applied.
     std::uint64_t planFingerprint_ = 0;
 
     // Bindings resolved per op, so the audio thread never hashes anything.
     std::vector<EngineDevice*> deviceForOp_;
 
-    /// The outside world behind each InsertSend and InsertReturn op (#2245).
-    /// Both halves of one insert hold the same pointer, because a round trip is
-    /// one object.
+    /// The outside world behind each InsertSend and InsertReturn op
+    /// (#2245). Both halves of one insert hold the same pointer, since a
+    /// round trip is one object.
     std::vector<EngineInsert*> insertForOp_;
     std::vector<EngineAudioSource*> audioSourceForOp_;
     std::vector<EngineMidiSource*> midiSourceForOp_;
 
-    /// Handed to ops whose input slot the plan left unconnected. Kept zeroed:
-    /// nothing writes to it.
+    /// Handed to ops whose input slot the plan left unconnected. Kept
+    /// zeroed: nothing writes to it.
     juce::AudioBuffer<float> silence_;
     juce::MidiBuffer noMidi_;
 
-    /// Per op: where a Meter op publishes, or null for one nobody reads. Bound
-    /// once here so the audio thread never looks a key up.
+    /// Per op: where a Meter op publishes, or null for one nobody reads.
+    /// Bound once here so the audio thread never looks a key up.
     std::vector<LevelTap*> meterForOp_;
     int boundMeterCount_ = 0;
 
@@ -600,85 +600,86 @@ class PlanExecutor {
         ValueTap* tap = nullptr;
     };
 
-    /// Compact rather than one slot per parameter, which is the difference
-    /// between these and the per-op bindings above. A plan has hundreds of ops
-    /// and a host binds a good fraction of the meters; a table has a parameter
-    /// per parameter of every device in the project and a host draws the few
-    /// dozen it has on screen. A vector the length of the table would be
-    /// thousands of nulls walked every block to find them.
+    /// Compact rather than one slot per parameter, the difference between
+    /// these and the per-op bindings above: a plan has hundreds of ops and
+    /// a host binds a good fraction of the meters, while a table has a
+    /// parameter per parameter of every device in the project and a host
+    /// draws only the few dozen on screen. A vector the length of the table
+    /// would be thousands of nulls walked every block to find the few bound
+    /// ones.
     ///
-    /// Resolved at prepare against the table the plan was prepared with, so the
-    /// block never looks a key up, and safe to hold by index for exactly as
-    /// long as the windows are: a table whose layout differs is refused whole
-    /// (see fitsParameters).
+    /// Resolved at prepare against the table the plan was prepared with, so
+    /// the block never looks a key up, and safe to hold by index for
+    /// exactly as long as the windows are -- a table whose layout differs
+    /// is refused whole (see fitsParameters).
     std::vector<BoundValueTap> paramTaps_;
     std::vector<BoundValueTap> modTaps_;
 
-    /// The other side of those two: taps the bindings offered that this table
-    /// has nowhere to publish from. Kept so the swap can clear them, which is
+    /// The other side of those two: taps the bindings offered that this
+    /// table has nowhere to publish from. Kept so the swap can clear them,
     /// the only thing anything does with them.
     std::vector<ValueTap*> unboundTaps_;
 
     /// This block's parameter values, and the room the resolver gathers one
     /// parameter's links in. Sized at prepare from the table the plan was
-    /// published with, so the block that fills them allocates nothing.
+    /// published with, so the block filling them allocates nothing.
     ResolvedParams paramValues_;
     std::vector<ModContribution> paramScratch_;
 
-    /// Where the modifiers of this plan have got to (#2119). Sized at prepare
-    /// from the same table, and carried from the executor being replaced, so a
-    /// device insert does not restart every LFO in the project.
+    /// Where the modifiers of this plan have got to (#2119). Sized at
+    /// prepare from the same table, carried from the executor being
+    /// replaced, so a device insert doesn't restart every LFO in the project.
     ModRuntime mods_;
 
     /**
      * @brief Ops that can run before the block's parameters are resolved.
      *
-     * Every op whose outputs are all MIDI and whose producers are all in this
-     * set, which is the MIDI a block has before any audio exists: clip readers,
-     * live input queues, the merges that gather them, and the delays on those
-     * edges. None of it reads a parameter and none of it reads audio, so
-     * running it first is the same schedule seen from a different place rather
-     * than a reordering.
+     * Every op whose outputs are all MIDI and whose producers are all in
+     * this set: clip readers, live input queues, the merges that gather
+     * them, and the delays on those edges -- the MIDI a block has before
+     * any audio exists. None of it reads a parameter or audio, so running
+     * it first is the same schedule seen from a different place, not a
+     * reordering.
      *
-     * What that buys is the one block a note-triggered modifier would otherwise
-     * be late by. Parameters resolve at the top of a block, so a trigger fired
-     * by an op is not spent until the next block's resolve; a trigger read off
-     * a MIDI buffer that already exists is spent in this one. The fork's own
-     * gate is the later of the two and its monitor is the earlier, so this is
-     * the fork's best case made unconditional.
+     * That buys the one block a note-triggered modifier would otherwise be
+     * late by: parameters resolve at the top of a block, so a trigger fired
+     * by an op isn't spent until the next block's resolve, while a trigger
+     * read off a MIDI buffer that already exists is spent in this one. The
+     * fork's own gate is the later of the two and its monitor the earlier,
+     * so this makes the fork's best case unconditional.
      *
-     * MIDI a device makes is not in here and cannot be: an arpeggiator's notes
-     * are audio-thread work that has not happened yet at resolve time. A
-     * modifier triggered from those is a block late, and that is the same lag
-     * an audio trigger has and is documented in the same place.
+     * MIDI a device makes is not in here and cannot be: an arpeggiator's
+     * notes are audio-thread work that hasn't happened yet at resolve time.
+     * A modifier triggered from those is a block late, the same lag an
+     * audio trigger has, documented in the same place.
      */
     std::vector<OpId> midiPrefix_;
 
-    /// Per op: whether it belongs to @ref midiPrefix_, so the block's main walk
-    /// leaves alone what the prefix already rendered.
+    /// Per op: whether it belongs to @ref midiPrefix_, so the block's main
+    /// walk leaves alone what the prefix already rendered.
     std::vector<char> inMidiPrefix_;
 
-    /// Per op: the modifiers a ModSource op feeds, or an empty span. Resolved
-    /// at prepare from the table's own record of what listens to what.
+    /// Per op: the modifiers a ModSource op feeds, or an empty span.
+    /// Resolved at prepare from the table's own record of what listens to what.
     std::vector<std::span<const int>> modSourceForOp_;
 
     /// One block of the source's audio, downmixed to mono, which is what a
     /// detector reads. Sized at prepare.
     std::vector<float> detectMono_;
 
-    /// Per follower: what its own detection needs to know about the level its
-    /// audio trigger is at, kept out of the modifier states because it belongs
-    /// to the source rather than to the modifier.
+    /// Per follower: what its own detection needs to know about the level
+    /// its audio trigger is at, kept out of the modifier states since it
+    /// belongs to the source rather than the modifier.
     struct TriggerDetector {
         float envelope = 0.0f;
         bool open = false;
     };
 
     /// Per ModSource op, indexed the same way the ops are. Held by shared
-    /// pointer for the reason the delay lines are: a tap the next plan also has
-    /// is the same detector rather than a copy of one read at some instant, and
-    /// only one epoch renders at a time so there is an owner to outlive and no
-    /// concurrent use to guard against.
+    /// pointer for the reason the delay lines are: a tap the next plan also
+    /// has is the same detector rather than a copy read at some instant,
+    /// and only one epoch renders at a time so there's an owner to outlive
+    /// and no concurrent use to guard against.
     std::vector<std::shared_ptr<TriggerDetector>> triggerForOp_;
 
     int carriedTriggerDetectors_ = 0;
@@ -686,17 +687,17 @@ class PlanExecutor {
     /**
      * @brief The table this block resolved against, or null.
      *
-     * Set once at the top of the block and read by the ops that need to name a
-     * modifier. Not a second copy of anything: it is the same table
-     * resolveParameters was handed, kept for the length of the walk because a
-     * modulation tap runs inside the walk and the values it was given do not
-     * reach renderOp.
+     * Set once at the top of the block and read by ops that need to name a
+     * modifier. Not a second copy of anything: it's the same table
+     * resolveParameters was handed, kept for the length of the walk because
+     * a modulation tap runs inside the walk and the values it was given
+     * don't reach renderOp.
      */
     const ParamTable* blockTable_ = nullptr;
 
-    /// Settle @ref blockTable_ for this block. Called by whichever of the two
-    /// entry points runs first, and idempotent, because beginBlock is const and
-    /// the prefix needs the answer before the resolve does.
+    /// Settle @ref blockTable_ for this block. Called by whichever of the
+    /// two entry points runs first, and idempotent, since beginBlock is
+    /// const and the prefix needs the answer before the resolve does.
     void settleBlockTable(const PlanValues& values);
 
     /// Read one modulation tap: hand the source's level to the followers
@@ -706,16 +707,16 @@ class PlanExecutor {
     /**
      * @brief Publish what this block settled, to whoever is watching (#2122).
      *
-     * On the audio thread, at the end of the resolve and nowhere else: that is
-     * the moment both numbers exist and the last moment they are still the
+     * On the audio thread, at the end of the resolve and nowhere else --
+     * the moment both numbers exist and the last moment they're still the
      * block's own rather than something a device has since been handed.
      *
      * A block that resolved no table publishes nothing at all, rather than
-     * publishing the zeros an empty table would answer with. The values a host
-     * is drawing then hold, which is what they do whenever nothing is
-     * rendering; slamming every watched knob to zero for the one block a
-     * mismatched table takes to be replaced would be a visible fault reporting
-     * an invisible one.
+     * the zeros an empty table would answer with. The values a host is
+     * drawing then hold, as they do whenever nothing is rendering --
+     * slamming every watched knob to zero for the one block a mismatched
+     * table takes to be replaced would be a visible fault reporting an
+     * invisible one.
      */
     void publishValueTaps();
 
@@ -735,11 +736,11 @@ class PlanExecutor {
     /// Per op, resolved at prepare so the audio thread never looks a key up.
     std::vector<OpMixerParams> mixerParamForOp_;
 
-    /// The gains @p op renders with: what the publisher resolved, unless a lane
-    /// or a link reaches the value it stands for, in which case what the block
-    /// resolved wins. A fader is the one value both layers can have an opinion
-    /// about, and the block's is the newer one by exactly the amount a lane
-    /// moves inside it.
+    /// The gains @p op renders with: what the publisher resolved, unless a
+    /// lane or a link reaches the value it stands for, in which case what
+    /// the block resolved wins. A fader is the one value both layers can
+    /// have an opinion about, and the block's is the newer one by exactly
+    /// the amount a lane moves inside it.
     OpValue mixerValueFor(std::size_t op, const OpValue& published) const;
 
     /// Where one parameter's curve is baked before it is resolved. One
@@ -748,8 +749,8 @@ class PlanExecutor {
     std::vector<ParamSegment> paramSegments_;
 
     /// Per op: the window of the table a Device op's device reads, resolved
-    /// once here so the audio thread never hashes a DeviceKey. Cached from one
-    /// table's layout, which is what paramLayout_ below is for.
+    /// once here so the audio thread never hashes a DeviceKey. Cached from
+    /// one table's layout, which is what paramLayout_ below is for.
     std::vector<ParamTable::DeviceWindow> paramWindowForOp_;
 
     /// Identity of the layout those windows were cached from. A table with

--- a/magda/engine/exec/RenderContext.hpp
+++ b/magda/engine/exec/RenderContext.hpp
@@ -41,15 +41,15 @@ struct RenderContext {
 /**
  * @brief The stretch of timeline one block covers.
  *
- * Beats, because beats are what the model positions things in. The transport's
- * sample clock is what turns the audio device's sample count into this, once
- * per block, and it is the only thing that reads a tempo map: an op is handed
- * the two ends of its block and needs nothing else to know where it is.
+ * Beats, since beats are what the model positions things in. The transport's
+ * sample clock turns the audio device's sample count into this, once per
+ * block, and is the only thing that reads a tempo map: an op gets the two
+ * ends of its block and needs nothing else to know where it is.
  *
- * A block never spans a jump. The transport cuts a callback at every loop wrap,
- * so what arrives here always runs from one end of @ref beats to the other without
- * interruption, and @ref continuous says whether the previous block ended where
- * this one begins.
+ * A block never spans a jump: the transport cuts a callback at every loop
+ * wrap, so this always runs from one end of @ref beats to the other without
+ * interruption, and @ref continuous says whether the previous block ended
+ * where this one begins.
  */
 struct BlockInfo {
     int numSamples = 0;
@@ -57,23 +57,21 @@ struct BlockInfo {
     /**
      * @brief What one sample of it is worth, in seconds.
      *
-     * Here as well as on the RenderContext because the conversions below are
-     * the block's own and most of what calls them holds a block and nothing
-     * else: a MIDI clip placing a note, a metronome placing a tick.
+     * Here as well as on RenderContext because most callers of the
+     * conversions below hold only a block (a MIDI clip placing a note, a
+     * metronome placing a tick).
      *
-     * Zero says a block did not state one, which is a block assembled by hand,
-     * and the conversions then take it from the two faces the block does have.
-     * That derivation is the rate exactly whenever the block is well formed,
-     * because a block runs at one rate whatever the tempo does. What it cannot
-     * do is answer for a block that covers no time at all, which is a stopped
-     * one, and a stopped block places nothing.
+     * Zero means a hand-assembled block that didn't state one; the
+     * conversions then derive it from the block's two faces, which is exact
+     * whenever the block is well formed (a block runs at one rate whatever
+     * the tempo does) except for a stopped block, which covers no time and
+     * places nothing.
      */
     double sampleRate = 0.0;
 
-    /// Whether the transport is rolling. A stopped block still renders: the
-    /// graph keeps running so tails ring out and live input passes through.
-    /// What a stopped block does not do is advance the timeline, so its start
-    /// and end beats are the same.
+    /// Whether the transport is rolling. A stopped block still renders (the
+    /// graph keeps running so tails ring out and live input passes through);
+    /// it just doesn't advance the timeline, so its start and end beats match.
     bool playing = false;
 
     /// Where on the timeline it is. Goes backwards at a loop wrap and a locate.
@@ -82,34 +80,31 @@ struct BlockInfo {
     /**
      * @brief The same stretch of timeline, in seconds.
      *
-     * Not a second opinion about where the block is: the clock derives the
-     * beats from this, so they are two faces of one instant and the conversion
-     * between them has happened exactly once, in the one place that owns a
-     * tempo map.
+     * Not a second opinion about where the block is -- the clock derives
+     * @ref beats from this, so the two are one instant, converted once in
+     * the one place that owns a tempo map.
      *
-     * Both are here because both are asked for, and by different things.
-     * Beats say where on the timeline something is, which is how the model
-     * positions everything. Seconds say how much audio has gone by, which is
-     * what recorded material is measured in and what a file's samples are
-     * counted in. A source reading a file needs the second question answered
-     * and would otherwise need a tempo map to answer it.
+     * Both faces exist because both are asked for by different things:
+     * beats say where on the timeline something is (how the model positions
+     * everything); seconds say how much audio has gone by (what recorded
+     * material and file samples are counted in). A file-reading source
+     * needs the seconds answer and would otherwise need a tempo map to get it.
      */
     SecondsRange seconds;
 
     /**
      * @brief The same stretch, counted in beats that only ever go forwards.
      *
-     * The timeline beat is where the cursor is, and it goes backwards every
-     * time a loop wraps and every time somebody locates. That is right for
-     * placing material and wrong for scheduling anything against a future
-     * beat: a launch quantized to the next bar, resolved against a beat the
-     * loop is about to take back, fires at the wrong moment or twice.
+     * The timeline beat goes backwards on every wrap and locate, which is
+     * right for placing material and wrong for scheduling against a future
+     * beat -- a launch quantized to the next bar, resolved against a beat
+     * the loop is about to take back, would fire at the wrong moment or
+     * twice.
      *
-     * This is the third face of the same instant, alongside beats and seconds,
-     * and it is derived in the same one place they are. It counts musical time
-     * the transport has actually rolled through since the clock began, so it
-     * survives a wrap, a locate and a tempo edit, and it is the domain a
-     * queued launch names its position in (#2300).
+     * A third face of the same instant, derived alongside beats and
+     * seconds. It counts musical time actually rolled through since the
+     * clock began, so it survives a wrap, a locate and a tempo edit, and is
+     * the domain a queued launch names its position in (#2300).
      *
      * A stopped block does not advance it, for the same reason it does not
      * advance the timeline.
@@ -119,18 +114,17 @@ struct BlockInfo {
     /**
      * @brief The same stretch, in seconds that only ever go forwards.
      *
-     * Accumulated from the samples each block rendered, so it is elapsed time
-     * rather than a position. Nothing derives it from the beat faces and
-     * nothing may: a map converts a position, and after a wrap two monotonic
-     * beats are not in the same cycle (#2324).
+     * Accumulated from the samples each block rendered -- elapsed time, not
+     * a position. Never derived from the beat faces: after a wrap, two
+     * monotonic beats are not in the same cycle, so a map can't convert
+     * between them (#2324).
      *
-     * Kept because it is the one thing @ref monotonicSamples cannot answer: how
-     * long the transport has actually rolled, across a rate change as well as
-     * within one. A count of samples divided by the rate they are being counted
-     * at now is not that, because they were not all worth the same amount of
-     * time. A run's own elapsed time is measured from the samples instead
-     * (LaunchHandle.hpp), and it handles a rate change by re-counting its
-     * origin rather than by reading this.
+     * This is the one thing @ref monotonicSamples can't answer: how long
+     * the transport has actually rolled, across a rate change as well as
+     * within one (a sample count divided by the current rate isn't that,
+     * since the samples weren't all worth the same time). A run's own
+     * elapsed time is instead measured from its samples (LaunchHandle.hpp),
+     * re-counting its origin on a rate change rather than reading this.
      *
      * A stopped block does not advance it.
      */
@@ -139,26 +133,23 @@ struct BlockInfo {
     /**
      * @brief Whether the timeline ran into this block out of the last one.
      *
-     * False on the first block after the transport starts, after a locate, and
-     * after a loop wrap. What that licenses is narrow: anything an op derived
-     * from where the cursor *was* is stale and has to be derived again, which
-     * for a source means seeking.
+     * False on the first block after the transport starts, after a locate,
+     * and after a loop wrap -- meaning anything an op derived from where the
+     * cursor *was* is stale and must be re-derived (for a source, a seek).
      *
-     * What it does not license is a reset. Audio did not stop flowing through
-     * the graph because the cursor moved, so delay lines, reverb tails and
-     * envelopes carry on across a jump exactly as they carry on across any
-     * other block boundary. An op that clears its state here is inventing a gap
-     * the transport never asked for.
+     * It does not mean a reset: audio didn't stop flowing because the
+     * cursor moved, so delay lines, reverb tails and envelopes carry on
+     * across a jump exactly as across any other block boundary. An op
+     * clearing its state here invents a gap the transport never asked for.
      */
     bool continuous = false;
 
     /**
      * @brief What one sample of this block is worth, in seconds.
      *
-     * What the block says, or what its own two faces say when it says nothing.
-     * The derivation is the rate exactly whenever a block is well formed, since
-     * a block runs at one rate whatever the tempo does; zero for a block that
-     * covers no time and states no rate, which converts nothing.
+     * What the block says, or what its own two faces say when it says
+     * nothing. Exact whenever the block is well formed; zero for a block
+     * that covers no time and states no rate, which converts nothing.
      */
     double rate() const {
         if (sampleRate > 0.0)
@@ -170,11 +161,11 @@ struct BlockInfo {
     /**
      * @brief The moment @p beat falls on, on this block's own seconds axis.
      *
-     * The inverse of @ref beatAtTime, through the map for the same reason and
-     * with the same detour through the origin on a shifted block. The one
-     * conversion under everything below: a beat becomes a moment here, and a
-     * moment becomes a sample by counting them, which is the only step that
-     * does not need a tempo (#2336).
+     * The inverse of @ref beatAtTime, through the map for the same reason
+     * and with the same detour through the origin on a shifted block -- the
+     * one conversion under everything below: a beat becomes a moment here,
+     * and a moment becomes a sample by counting, the only step needing no
+     * tempo (#2336).
      */
     double timeForBeat(double beat) const {
         if (tempo != nullptr)
@@ -189,28 +180,26 @@ struct BlockInfo {
     /**
      * @brief The beat sample zero sounds on, to the tolerance the clock uses.
      *
-     * Not quite the block's start, which is where anything asking the map about
-     * this block's tempo, signature or bar would naturally look. A musical
-     * position within a hundredth of a sample of the cursor is the cursor as
-     * far as the clock is concerned (TransportClock::samplesUntil), so a block
-     * can open that close before a boundary while every sample it renders is
-     * past it. The beat at its start is then in the section it has already
-     * left, and a consumer that takes one signature or one bar for the whole
-     * block takes the wrong one.
+     * Not quite the block's start. A musical position within a hundredth of
+     * a sample of the cursor still counts as the cursor
+     * (TransportClock::samplesUntil), so a block can open that close before
+     * a boundary while every sample it renders is past it -- the beat at
+     * its literal start would then be in the section it already left, and a
+     * consumer taking one signature or bar for the whole block would take
+     * the wrong one.
      *
-     * So this is the start nudged forward by that same hundredth of a sample of
-     * seconds, converted to a beat at the tempo the block opens on rather than
-     * at the block's own average slope: through the map, the way @ref
-     * beatAtTime reads any other moment, which is what matters once a block may
-     * span a tempo change. The block-average slope would over-nudge across a
-     * step up and under-nudge across a step down, either of which can land the
-     * nudge on the wrong side of the very boundary it exists to cross (#2340).
-     * A block with no seconds face at all is one assembled by hand from beats,
-     * and the average slope is the only line there is to nudge along.
+     * So this nudges the start forward by that same hundredth of a sample
+     * of seconds, converted to a beat at the tempo the block opens on
+     * rather than at the block's average slope (through the map, the way
+     * @ref beatAtTime reads any other moment) -- the average slope would
+     * over- or under-nudge across a tempo step, landing on the wrong side
+     * of the very boundary this exists to cross (#2340). A block with no
+     * seconds face (assembled by hand) has only the average slope to nudge
+     * along.
      *
-     * Where the block *is* stays @ref beats and @ref seconds. This only says
-     * which side of a boundary its first sample is on, and a position derived
-     * under that section is projected back by the caller (#2336).
+     * Where the block *is* stays @ref beats and @ref seconds; this only
+     * says which side of a boundary its first sample is on, and a position
+     * derived under that section is projected back by the caller (#2336).
      */
     double openingBeat() const {
         if (numSamples <= 0 || beats.empty())
@@ -225,8 +214,8 @@ struct BlockInfo {
     /**
      * @brief How many samples into this block @p moment falls, unrounded.
      *
-     * By counting samples, which is the one step that needs no tempo: a block
-     * runs at one rate whatever the map is doing.
+     * By counting samples, the one step that needs no tempo: a block runs
+     * at one rate whatever the map is doing.
      */
     double offsetForTime(double moment) const {
         return (moment - seconds.start) * rate();
@@ -235,13 +224,11 @@ struct BlockInfo {
     /**
      * @brief How many samples into this block @p beat falls, unrounded.
      *
-     * Through the seconds face, because that is where samples are counted, and
-     * therefore through the map wherever there is one: a beat's distance into
-     * the block is a question about when it happens, and the answer is only a
-     * straight line while the tempo is.
-     *
-     * A block with no seconds face at all is one assembled by hand from beats,
-     * and its own two beat ends are then the only line there is.
+     * Through the seconds face (where samples are counted) and so through
+     * the map wherever there is one -- a beat's distance into the block is
+     * a question about when it happens, a straight line only while the
+     * tempo is. A block with no seconds face (assembled by hand) has only
+     * its own two beat ends as that line.
      */
     double offsetForBeat(double beat) const {
         if (!seconds.empty() && rate() > 0.0)
@@ -274,14 +261,15 @@ struct BlockInfo {
     /**
      * @brief The sample an edge that has to be heard is emitted on.
      *
-     * A note-off is where a note's stretch ends, so it is an edge and lands on
-     * N whenever a clip or a loop pass ends on the block boundary. It is also a
-     * message, and a message at N is written into nobody's buffer: the block
-     * that owns that sample is the next one, and by the time it renders, the
-     * stretch that owed the off has gone. What is left is a note that hangs.
+     * A note-off is where a note's stretch ends, so it's an edge and lands
+     * on N whenever a clip or loop pass ends on the block boundary. It's
+     * also a message, and a message at N is written into nobody's buffer:
+     * the block owning sample N is the next one, and by the time it
+     * renders, the stretch that owed the off has gone -- leaving a note
+     * that hangs.
      *
-     * So an emitted edge at N sounds on N-1 instead. One sample early, against
-     * a note that rings until the session ends.
+     * So an emitted edge at N sounds on N-1 instead: one sample early,
+     * against a note ringing until the session ends.
      */
     EventSample soundsAt(EdgeSample edge) const {
         return EventSample{std::clamp(edge.value, 0, std::max(0, numSamples - 1))};
@@ -290,31 +278,26 @@ struct BlockInfo {
     /**
      * @brief The beat face of a moment inside this block.
      *
-     * The two faces are two views of one stretch of timeline, so a moment given
-     * in one has an answer in the other, and this is the conversion that does
-     * not need a tempo map: the ends are known in both, and a block is short
-     * enough that the curve between them is a straight line to well under a
-     * sample.
+     * The conversion that needs no tempo map: both ends are known in both
+     * faces, and a block is short enough that the curve between them is a
+     * straight line to well under a sample.
      *
-     * What asks is a clip whose material is consumed against beats rather than
-     * against seconds, which is what auto tempo is (clip/EventPlacement.hpp).
-     * The window such a clip plays over is worked out in seconds, because that
-     * is what spans and fades are in, and then has to be asked about in beats.
+     * What asks is a clip whose material is consumed against beats rather
+     * than seconds (auto tempo, clip/EventPlacement.hpp): the window such a
+     * clip plays over is worked out in seconds (what spans and fades use)
+     * and then has to be asked about in beats.
      */
     double beatAtTime(double moment) const {
-        // The map itself where there is one, which matters for the moments that
-        // are not inside this block. A block's own two ends make a straight
-        // line, and that line is exact only while the tempo does not change
-        // along it: anything reading past the block's end, or across a step
-        // inside it, gets the slope this block happened to have rather than the
-        // one the map has there. A clip whose rate follows the tempo is read at
-        // instants beyond the block that produced them (ClipVoice's cells), so
-        // it is exactly the caller that cannot afford the straight line.
+        // The map itself where there is one, which matters for moments
+        // outside this block: a block's own two ends make a straight line,
+        // exact only while the tempo doesn't change along it. A clip whose
+        // rate follows the tempo is read at instants beyond the block that
+        // produced them (ClipVoice's cells), so it can't afford that line.
         //
-        // Through the origin in both directions on a shifted block, which is
-        // what keeps the map usable there: the moment goes back onto the
-        // timeline to be asked about, and the answer comes back onto the run's
-        // own axis. Zero on a timeline block, where this is the map itself.
+        // Through the origin in both directions on a shifted block: the
+        // moment goes back onto the timeline to be asked about, and the
+        // answer comes back onto the run's own axis. Zero on a timeline
+        // block, where this is the map itself.
         if (tempo != nullptr)
             return tempo->timeToBeat(moment + materialOrigin.seconds) - materialOrigin.beat;
 
@@ -328,41 +311,40 @@ struct BlockInfo {
     /**
      * @brief Where the block sits on the transport's own sample count.
      *
-     * The durable coordinate, and the one every other face here is ultimately
-     * an interpretation of (transport/TimeDomains.hpp). A locate does not move
-     * it, a wrap does not take it back and a tempo edit does not rescale it, so
-     * it is the only one of them two blocks can be compared on without knowing
-     * what happened between.
+     * The durable coordinate every other face here interprets
+     * (transport/TimeDomains.hpp): a locate doesn't move it, a wrap doesn't
+     * take it back, a tempo edit doesn't rescale it -- the only face two
+     * blocks can be compared on without knowing what happened between.
      *
      * A stopped block does not advance it, for the same reason it does not
      * advance the timeline: nothing played.
      *
-     * Empty on a block assembled by hand, which is why nothing may assume it is
-     * set (#2332 is what makes it load-bearing).
+     * Empty on a hand-assembled block, which is why nothing may assume it
+     * is set (#2332 is what makes it load-bearing).
      */
     SampleRange monotonicSamples;
 
-    /// The map this block was cut from, or null for a caller that assembles a
-    /// block by hand. Not owned, and it outlives the block: what publishes a
-    /// transport keeps it alive for as long as the callback reading it runs.
+    /// The map this block was cut from, or null for a hand-assembled block.
+    /// Not owned, and outlives the block: whatever publishes a transport
+    /// keeps it alive for as long as the callback reading it runs.
     ///
     /// Always the timeline's, even where the axes above are not: a shifted
-    /// block records the shift below rather than pretending the map is its own.
-    /// Anything reaching for this directly is asking a timeline question and
-    /// has to put @ref materialOrigin back first.
+    /// block records the shift below rather than pretending the map is its
+    /// own. Anything reaching for this directly is asking a timeline
+    /// question and must put @ref materialOrigin back first.
     const TempoMap* tempo = nullptr;
 
     /**
      * @brief What the two axes above were shifted by, or zero on the timeline.
      *
      * A session slot plays over a block moved onto the run's own origin
-     * (clip/SessionPlayback.hpp), and the two faces move by different amounts:
-     * a beat is where something sits and a second is how long a run has
-     * lasted, and under a tempo curve those are not one number (#2324).
+     * (clip/SessionPlayback.hpp), and the two faces move by different
+     * amounts: a beat is a position and a second is elapsed time, and under
+     * a tempo curve those aren't one number (#2324).
      *
-     * Carried so the shift stays undoable. Dropping the map instead would
-     * leave the block's own two ends as the only answer, and that straight
-     * line is exactly what the cell path above cannot afford.
+     * Carried so the shift stays undoable -- dropping the map would leave
+     * the block's own two ends as the only answer, and that straight line
+     * is exactly what the cell path above cannot afford.
      */
     MaterialOrigin materialOrigin;
 };

--- a/magda/engine/exec/RuntimeStateStore.hpp
+++ b/magda/engine/exec/RuntimeStateStore.hpp
@@ -23,12 +23,12 @@ struct TrackInfo;
  * @file RuntimeStateStore.hpp
  * @brief Who owns the objects a plan renders through, and for how long.
  *
- * A plan is topology and nothing else, so it cannot own a plugin instance or a
- * file reader: it is rebuilt every time a device moves, and rebuilding an
- * instrument because a fader was reordered above it is the rebuild-click
- * problem in miniature. The store owns them instead, keyed by section-aware
- * model identity the way OpKey is, so the same edit that recompiles the plan
- * leaves the objects it names untouched.
+ * A plan is topology and nothing else, so it cannot own a plugin instance or
+ * a file reader: it's rebuilt every time a device moves, and rebuilding an
+ * instrument because a fader was reordered above it would be the
+ * rebuild-click problem in miniature. The store owns them instead, keyed by
+ * section-aware model identity the way OpKey is, so the same edit that
+ * recompiles the plan leaves the objects it names untouched.
  *
  * Everything here runs off the audio thread.
  */
@@ -40,10 +40,10 @@ struct ParamTable;
 /**
  * @brief Makes the runtime objects a plan asks for.
  *
- * Implemented by the host, because the engine has no idea what a device is: it
+ * Implemented by the host, since the engine has no idea what a device is: it
  * knows a section-aware DeviceKey, and the host knows which plugin that is.
- * Returning nullptr is allowed and means the object does not exist; the
- * executor reports the op as unbound rather than pretending otherwise.
+ * Returning nullptr means the object doesn't exist; the executor reports the
+ * op as unbound rather than pretending otherwise.
  */
 class RuntimeStateFactory {
   public:
@@ -74,15 +74,15 @@ class RuntimeStateFactory {
     /**
      * @brief The level tap behind one Meter op, or nullptr for one nobody reads.
      *
-     * Declining is the ordinary answer rather than a failure: a plan has a
-     * meter at every track, every device slot and the master, and a host with
-     * no mixer on screen wants none of them. What it costs to decline is the
-     * meter, and nothing else: the op still renders, because a Meter op is a
-     * point in the signal path first and a display second.
+     * Declining is the ordinary answer, not a failure: a plan has a meter at
+     * every track, every device slot and the master, and a host with no
+     * mixer on screen wants none of them. Declining costs only the meter --
+     * the op still renders, since a Meter op is a point in the signal path
+     * first and a display second.
      *
-     * Handed the whole key because a device's meter and the device itself share
-     * a DeviceId. Which track or device the tap belongs to is read off the key,
-     * and so is what kind of meter it is.
+     * Handed the whole key because a device's meter and the device itself
+     * share a DeviceId; which track/device and what kind of meter are both
+     * read off the key.
      */
     virtual std::unique_ptr<LevelTap> createMeter(const OpKey&) {
         return nullptr;
@@ -92,32 +92,30 @@ class RuntimeStateFactory {
      * @brief The values the host wants read back (#2122).
      *
      * Asked once per plan publish, off the audio thread. Every key returned
-     * gets a ValueTap it can read at whatever rate it draws: a parameter's key
-     * for the position that parameter resolved to, a modifier's for the output
-     * that modifier published.
+     * gets a ValueTap readable at whatever rate the host draws: a
+     * parameter's key for the position it resolved to, a modifier's for the
+     * output it published.
      *
-     * A modifier is named by its key with no parameter index, which means
-     * `index = -1` and not the default a hand-built ParamKey carries: index 0
-     * is the modifier's own Rate parameter, so a key left at its default asks
-     * about the rate rather than the output. modifierKeyFor() builds the right
-     * shape from a ControlTarget and is the way to avoid choosing.
+     * A modifier is named by its key with `index = -1`, not the default a
+     * hand-built ParamKey carries -- index 0 is the modifier's own Rate
+     * parameter, so a default-index key would ask about the rate rather
+     * than the output. modifierKeyFor() builds the right shape from a
+     * ControlTarget so callers don't have to choose.
      *
-     * Shaped as one question rather than as a createValueTap() beside the
-     * others, which is the one asymmetry here and is a matter of how many there
-     * are. A plan has hundreds of ops and a host with a mixer open wants a
-     * meter on a good fraction of them, so asking op by op costs about what the
-     * answers are worth. A table has a parameter per parameter of every device
-     * in the project, which is thousands, and a host wants the few dozen it has
-     * on screen: asking one by one would be thousands of declines per edit to
-     * find them. So the host says what it wants and the store makes them.
+     * Shaped as one question rather than a createValueTap() beside the
+     * others because of scale: a plan has hundreds of ops and a host with a
+     * mixer open wants meters on a good fraction of them, so asking op by
+     * op is cheap. A parameter table has thousands of entries and a host
+     * wants a few dozen, so asking one by one would mean thousands of
+     * declines to find them -- the host states what it wants instead.
      *
-     * The store makes them, rather than this handing back instances, because a
-     * ValueTap is not a thing the engine needs the host's help to build. The
-     * methods above exist because the engine has no idea what a device or a
-     * file reader is; it knows exactly what a tap on a number is.
+     * The store builds the taps itself, rather than handing back instances,
+     * because a ValueTap needs no host help to construct; the methods above
+     * exist only because the engine can't build a device or file reader on
+     * its own.
      *
-     * Returning nothing is the ordinary answer. An offline render wants none of
-     * these, and neither does a session whose windows are all shut.
+     * Returning nothing is the ordinary answer: an offline render, or a
+     * session with no windows open, wants none of these.
      */
     virtual std::vector<ParamKey> valuesToTap() {
         return {};
@@ -127,27 +125,29 @@ class RuntimeStateFactory {
 /**
  * @brief Model IDs that still exist, whatever the current plan happens to use.
  *
- * Eviction is model-aware rather than plan-aware, and the difference is not
- * academic: bypass and chain power are structural, so a bypassed device
- * contributes no ops at all. Keyed on the plan, switching chain power off would
- * tear down every plugin on the track and switching it back on would rebuild
- * them, losing tails, plugin state and load time on a gesture the user expects
- * to be free. Plan-named means playing, model-named means kept, and only
- * deletion from the model destroys anything.
+ * Eviction is model-aware rather than plan-aware: bypass and chain power are
+ * structural, so a bypassed device contributes no ops at all. If eviction
+ * were plan-keyed, switching chain power off would tear down every plugin on
+ * the track and switching it back on would rebuild them, losing tails,
+ * plugin state and load time on a gesture the user expects to be free.
+ * Plan-named means playing, model-named means kept; only deletion from the
+ * model destroys anything.
  */
 struct RuntimeStateIds {
     std::set<DeviceKey> devices;
     std::set<TrackId> tracks;
 };
 
-// Launch handles are deliberately not here: a slot is a clip, so what exists is
-// answered by the snapshot and their lifetime follows publishHandles() (#2301).
+// Launch handles are deliberately not tracked here: a slot is a clip, so
+// what exists is answered by the snapshot, and their lifetime follows
+// publishHandles() instead (#2301).
 
 /**
  * @brief Every device and track the model holds, nested racks included.
  *
- * Deliberately not the compiler's walk: that one answers what plays, this one
- * answers what exists, and the gap between the two is exactly what gets kept.
+ * Deliberately not the compiler's walk: that one answers what plays, this
+ * one answers what exists, and the gap between the two is exactly what gets
+ * kept.
  */
 RuntimeStateIds collectRuntimeStateIds(const std::vector<TrackInfo>& tracks,
                                        const TrackInfo& master);
@@ -162,55 +162,55 @@ class RuntimeStateStore {
     /**
      * @brief Bindings for @p plan, creating what is new and reusing what is not.
      *
-     * Never destroys anything: a plan being prepared is not published yet, and
-     * until it is, the audio thread is still rendering the previous one.
+     * Never destroys anything: a plan being prepared isn't published yet, so
+     * the audio thread is still rendering the previous one.
      *
-     * Preparing an object is part of creating it and happens nowhere else, for
-     * the same reason. A device the store already holds is one the live plan
-     * may be inside the process() of this instant, and prepare() on a real
-     * plugin resizes and clears what process() is reading: it is a race, and on
-     * the runs where it is not, it is the tail, the delay line and the filter
-     * state the swap exists to keep. So an object is prepared once, when it is
-     * new, before anything can reach it.
+     * Preparing an object happens here, as part of creation, and nowhere
+     * else: a device the store already holds may be inside the live plan's
+     * process() this instant, and prepare() on a real plugin resizes and
+     * clears what process() is reading -- a race, except on the runs it
+     * costs the tail, delay line and filter state the swap exists to keep.
+     * So an object is prepared exactly once, when new, before anything can
+     * reach it.
      *
-     * @p context changing is not a live operation. Every object the store holds
-     * is prepared again for it, which is only safe because a sample rate or
-     * block size change means the audio device has stopped and there is no
-     * callback to race.
+     * @p context changing is not a live operation: every held object is
+     * prepared again for it, safe only because a sample rate or block size
+     * change means the audio device has stopped and there's no callback to
+     * race.
      */
     PlanBindings realise(const RenderPlan& plan, const RenderContext& context);
 
     /**
      * @brief Destroy what neither @p livePlan nor @p modelIds names.
      *
-     * Two keep sets, for two different reasons, and the plan's is the one that
-     * cannot be waived. Anything @p livePlan names is reachable from the audio
-     * thread right now, so destroying it is a use-after-free rather than an
-     * early eviction; taking the plan here rather than trusting the caller's
-     * IDs is what stops that from depending on the two arguments agreeing.
-     * They will not always agree: plans are compiled from a model revision and
-     * published later, so a caller collecting IDs from the current model can
-     * hand over a set that has already lost something the plan still uses.
+     * Two keep sets for two different reasons, and the plan's is the one
+     * that can't be waived: anything @p livePlan names is reachable from the
+     * audio thread right now, so destroying it is a use-after-free, not an
+     * early eviction. Taking the plan here rather than trusting the
+     * caller's IDs is what guards against them disagreeing -- and they
+     * won't always agree, since plans compile from a model revision and
+     * publish later, so a caller collecting IDs from the current model can
+     * hand over a set that's already lost something the plan still uses.
      *
-     * @p modelIds only ever extends retention, to what exists but is not
-     * playing: a bypassed device, a chain with the power off, the input source
-     * of a track nobody has armed.
+     * @p modelIds only ever extends retention, to what exists but isn't
+     * playing: a bypassed device, a chain with the power off, an unarmed
+     * track's input source.
      *
      * Call only after the swap, with the plan that is now live. Destructors
      * run on the calling thread.
      *
-     * @p liveTable is the parameter table that plan is rendering with, and it
-     * is to the value taps what the plan is to everything else: the one thing
-     * that says which of them the audio thread can reach. A plan does not name
-     * a parameter, so nothing else here could answer it. Null is a session
-     * rendering without a table, where no value tap is reachable at all.
+     * @p liveTable is the parameter table that plan renders with, and is to
+     * the value taps what the plan is to everything else: the one thing
+     * that says which taps the audio thread can reach (a plan doesn't name
+     * a parameter, so nothing else here could answer it). Null means a
+     * session rendering without a table, where no value tap is reachable.
      *
-     * Required rather than defaulted, for the reason the plan is passed rather
-     * than trusted to the caller's IDs. Omitting it would leave eviction to the
-     * model IDs alone, and a tap the live table carries but the ID set does not
-     * name would be destroyed while the executor still holds its pointer: the
-     * next block writes through freed memory, on the audio thread. A keep that
-     * cannot be waived must not be possible to leave out.
+     * Required rather than defaulted, for the same reason the plan is
+     * required rather than trusted to the caller's IDs: omitting it would
+     * leave eviction to the model IDs alone, and a tap the live table
+     * carries but the ID set doesn't name would be destroyed while the
+     * executor still holds its pointer -- the next block writes through
+     * freed memory, on the audio thread.
      */
     std::size_t releaseDeleted(const RenderPlan& livePlan, const RuntimeStateIds& modelIds,
                                const ParamTable* liveTable);
@@ -218,23 +218,23 @@ class RuntimeStateStore {
     /**
      * @brief The tap publishing @p key, or nullptr (#2122).
      *
-     * The other half of valuesToTap(): the host says which values it wants read
-     * back and this is where it collects them. Off the audio thread; what it
-     * hands back is readable from any thread, which is the whole point of it.
+     * The other half of valuesToTap(): the host says which values it wants
+     * read back, and this is where it collects them. Off the audio thread;
+     * what it hands back is readable from any thread, the whole point of it.
      *
-     * Null until a publish has been attempted, because that is when the taps
-     * are made: a window that opens between two of them is drawing a value
-     * nothing has offered yet, and it gets one at the next publish rather than
-     * never. Attempted rather than succeeded, since the taps are realised
-     * before a plan is known to prepare; non-null therefore says the store has
-     * one, not that anything is publishing through it. What answers that is the
-     * tap's own count, where zero means nothing in the engine moves this value
-     * and the model's own is the answer (ValueTap.hpp).
+     * Null until a publish has been attempted, since that's when taps are
+     * made -- a window opening between two publishes draws a value nothing
+     * has offered yet, and gets one at the next publish rather than never.
+     * "Attempted" rather than "succeeded" because taps are realised before
+     * a plan is known to prepare, so non-null says the store has one, not
+     * that anything is publishing through it; the tap's own count answers
+     * that (zero means nothing in the engine moves this value, and the
+     * model's own value is the answer -- see ValueTap.hpp).
      *
      * Good until the next publish, like every other pointer the store hands
-     * out. A tap whose device has been deleted goes when the plan that named it
-     * stops being live, and a caller holding one across that has a pointer to
-     * nothing; asking again is how a holder finds out.
+     * out: a tap whose device was deleted goes away when the plan that
+     * named it stops being live, so a caller holding one across that has a
+     * pointer to nothing, and asking again is how it finds out.
      */
     ValueTap* valueTap(const ParamKey& key) const;
 
@@ -242,17 +242,18 @@ class RuntimeStateStore {
      * @brief Make a handle for every slot @p clips names, publish them, and
      *        retire the ones the snapshot has stopped naming.
      *
-     * On the publishing thread, and the whole of a handle's lifetime: nothing
-     * else creates or retires them.
+     * On the publishing thread, and the whole of a handle's lifetime --
+     * nothing else creates or retires them.
      *
-     * All three in one call because they cannot be separated. A clip edit does
-     * not compile a plan, so releaseDeleted() would not run between a slot
-     * being emptied and refilled, and the refilled slot would come up already
-     * playing. And retiring is only safe on the far side of the publish, which
-     * waits for the block the callback is in.
+     * All three happen in one call because they can't be separated: a clip
+     * edit doesn't compile a plan, so releaseDeleted() wouldn't run between
+     * a slot being emptied and refilled, and the refilled slot would come
+     * up already playing. Retiring is only safe on the far side of the
+     * publish, which waits for the current callback's block.
      *
-     * Nothing is swapped, and nothing retired, when the slots have not moved: a
-     * drag republishes the snapshot at gesture speed with the same slots.
+     * Nothing is swapped or retired when the slots haven't moved, so a drag
+     * republishing the snapshot at gesture speed with the same slots is
+     * free.
      */
     std::shared_ptr<const LaunchHandleTable> publishHandles(const ClipSnapshot& clips,
                                                             LaunchHandleFeed& feed);
@@ -265,15 +266,15 @@ class RuntimeStateStore {
 
   private:
     /// The tap for one Meter op, asking the factory once if there is none. A
-    /// factory that declines is asked again next time, exactly as it is for
-    /// everything else: a mixer that opens after the plan was published should
-    /// get its meters at the next publish rather than never.
+    /// factory that declines is asked again next time, so a mixer opened
+    /// after the plan was published still gets its meters at the next
+    /// publish.
     LevelTap* realiseMeter(const OpKey& key);
 
     RuntimeStateFactory& factory_;
 
-    /// What everything the store holds has been prepared for. Set by the first
-    /// realise() and only ever changed by one that disagrees with it.
+    /// What everything the store holds has been prepared for. Set by the
+    /// first realise() and only ever changed by one that disagrees with it.
     RenderContext context_;
     bool hasContext_ = false;
 
@@ -283,9 +284,9 @@ class RuntimeStateStore {
     std::unordered_map<TrackId, std::unique_ptr<EngineAudioSource>> sessionAudio_;
     std::unordered_map<TrackId, std::unique_ptr<EngineMidiSource>> sessionMidi_;
 
-    /// One per slot rather than per track: a slot's loop phase and played range
-    /// have to survive another slot playing in between. Made and retired by
-    /// publishHandles() alone (#2301).
+    /// One per slot rather than per track: a slot's loop phase and played
+    /// range have to survive another slot playing in between. Made and
+    /// retired by publishHandles() alone (#2301).
     std::map<SlotKey, std::unique_ptr<LaunchHandle>> handles_;
 
     /// What was last published, so a publish that changes nothing is skipped.
@@ -293,17 +294,18 @@ class RuntimeStateStore {
     std::unordered_map<TrackId, std::unique_ptr<EngineAudioSource>> audioInputs_;
     std::unordered_map<TrackId, std::unique_ptr<EngineMidiSource>> midiInputs_;
 
-    /// Keyed by the op's whole key, and retained by the model IDs that key
-    /// names: a meter is kept while the track or device it reads exists, which
-    /// is the same rule everything else here follows read through the one
-    /// binding whose identity is the whole op rather than a DeviceKey or TrackId.
+    /// Keyed by the op's whole key and retained by the model IDs that key
+    /// names -- a meter is kept while the track or device it reads exists,
+    /// the same rule everything else here follows, read through the one
+    /// binding whose identity is the whole op rather than a DeviceKey or
+    /// TrackId.
     std::map<OpKey, std::unique_ptr<LevelTap>> meters_;
 
-    /// The values the host has asked to read back, kept across publishes for
-    /// the reason everything else here is: an edit elsewhere in the project
-    /// must not restate a number something is watching. Retained by the model
-    /// IDs its key names, and by the live table, which is the only thing that
-    /// says whether the audio thread can reach one.
+    /// The values the host has asked to read back, kept across publishes so
+    /// an edit elsewhere in the project doesn't restate a number something
+    /// is watching. Retained by the model IDs its key names, and by the
+    /// live table, the only thing that says whether the audio thread can
+    /// reach one.
     std::map<ParamKey, std::unique_ptr<ValueTap>> valueTaps_;
 };
 

--- a/magda/engine/io/PrefetchStream.hpp
+++ b/magda/engine/io/PrefetchStream.hpp
@@ -22,16 +22,16 @@
  * @file PrefetchStream.hpp
  * @brief One file, read ahead of the callback that plays it.
  *
- * The audio thread cannot wait for a disk, so it never touches one: a thread
- * that is allowed to block reads whole chunks ahead of where playback is, and
- * the callback copies out of what is already in memory. What arrives on the
- * audio thread is therefore a pointer swap and a copy, and nothing else.
+ * The audio thread can't wait for a disk, so it never touches one: a thread
+ * allowed to block reads whole chunks ahead of where playback is, and the
+ * callback copies out of what's already in memory -- a pointer swap and a
+ * copy, nothing else.
  *
- * Chunks rather than a ring of samples, because a chunk can be stamped. A seek
- * makes everything already read wrong, and the stamp is how the callback knows
- * that without the reader having to reach into a buffer the callback is using:
- * stale chunks are recognised on the way out and dropped, which is the same
- * epoch discipline the plan swap uses.
+ * Chunks rather than a ring of samples, because a chunk can be stamped. A
+ * seek makes everything already read wrong, and the stamp lets the callback
+ * recognise and drop stale chunks on the way out without the reader having
+ * to reach into a buffer the callback is using -- the same epoch discipline
+ * the plan swap uses.
  *
  * Threading: read() on the audio thread, fill() on the prefetch thread,
  * everything else before either is running. One stream is one reader and is
@@ -64,10 +64,10 @@ class PrefetchStream {
      * On the audio thread. Returns how many samples were there to give; the
      * rest of the destination is silent.
      *
-     * A start that is not where the last read left off is a seek: what has been
-     * read ahead is for somewhere else, so it is dropped and the reader is
-     * pointed at the new position. Nothing plays until it has caught up, which
-     * is what @ref underruns counts.
+     * A start that isn't where the last read left off is a seek: what's
+     * been read ahead is for somewhere else, so it's dropped and the reader
+     * is pointed at the new position. Nothing plays until it catches up,
+     * which is what @ref underruns counts.
      */
     int read(std::int64_t sourceStart, juce::dsp::AudioBlock<float> destination, int numSamples);
 
@@ -83,17 +83,15 @@ class PrefetchStream {
      * @brief Point the reader before anything is reading it at all.
      *
      * Before the stream is registered with a prefetch thread and before any
-     * block has read from it, on the thread that made it. Not a seek and not a
-     * cue: it moves both cursors while there is nobody to disagree with, so
-     * there is no generation to bump, nothing in flight to throw away, and no
-     * block to wait for.
+     * block has read from it, on the thread that made it. Not a seek and
+     * not a cue: it moves both cursors while there's nobody to disagree
+     * with, so there's no generation to bump and nothing in flight to
+     * throw away.
      *
-     * What it is for is that a stream is made for a clip, and a clip starts
-     * somewhere. Without this a new stream spends its first reads on the
-     * material at sample zero, which is not what it was opened for, and the
-     * cue that redirects it cannot be taken up until a callback has run
-     * (@ref applyPendingCue). Every one of those reads would then be thrown
-     * away, and the reader would start again from behind.
+     * Without this, a new stream spends its first reads on the material at
+     * sample zero -- not what it was opened for -- and a cue can't be taken
+     * up until a callback has run (@ref applyPendingCue), so those reads
+     * would be thrown away and the reader would start again from behind.
      */
     void startAt(std::int64_t sourceStart);
 
@@ -101,58 +99,55 @@ class PrefetchStream {
      * @brief Point the reader at a position before anything asks for it.
      *
      * From any thread that is not the audio thread, at any time: whoever
-     * schedules material knows where playback will be before the callback does,
-     * and a stream told in advance is one that does not have to seek in the
-     * block that needs the samples.
+     * schedules material knows where playback will be before the callback
+     * does, so a stream told in advance doesn't have to seek in the block
+     * that needs the samples.
      *
-     * Nothing here touches what the callback owns. It publishes a cue, and the
-     * callback picks it up at the top of its next block through
-     * @ref applyPendingCue, so the seek itself happens where every other seek
-     * happens. That is a block's delay before the reader starts moving, which
-     * is nothing against the reason to cue at all: a clip scheduled a moment
-     * ahead is read ahead long before it plays.
+     * Nothing here touches what the callback owns. It publishes a cue, and
+     * the callback picks it up at the top of its next block through
+     * @ref applyPendingCue, so the seek happens where every other seek
+     * does -- a block's delay, which is nothing against the reason to cue
+     * at all.
      *
-     * A cue points a stream that is not sounding. One that is keeps playing and
-     * takes the cue up when it stops, because a single reader cannot be in two
-     * places: pointing it somewhere else would abandon the material still
-     * playing and hand back the pool holding it, for a position the next read
-     * would immediately override.
+     * A cue points a stream that isn't sounding. One that is keeps playing
+     * and takes the cue up when it stops, since a single reader can't be in
+     * two places: pointing it elsewhere would abandon the material still
+     * playing for a position the next read would immediately override.
      *
-     * A clip's loop does not come through here at all, which is what it took to
-     * make its return seamless. Reading the top of a loop through a cue would
-     * mean holding two positions at once, a second fill cursor and a second
-     * pool; instead the tiling happens below this, in what the stream reads
-     * (io/SourceReaders.hpp), so a wrap is a discontinuity in the material and
-     * a position like any other to everything here.
+     * A clip's loop doesn't come through here: reading the top of a loop
+     * through a cue would mean holding two positions at once. Instead
+     * tiling happens below this, in what the stream reads
+     * (io/SourceReaders.hpp), so a wrap is just a discontinuity in the
+     * material and a position like any other to everything here.
      */
     void seek(std::int64_t sourceStart);
 
     /**
      * @brief Take up a cue, if one is waiting. On the audio thread.
      *
-     * Once per block, at the top of it, by whoever drives the stream. Not done
-     * inside read(), and the difference matters: what decides whether a cue is
-     * taken up now or waits is whether this stream is sounding, and that
-     * question is only answerable at a block boundary. Asked again halfway
-     * through, a stream that simply has not reached its read yet looks exactly
-     * like one that is silent.
+     * Once per block, at the top of it, by whoever drives the stream. Not
+     * done inside read(): whether a cue is taken up now or waits depends on
+     * whether this stream is sounding, and that's only answerable at a
+     * block boundary -- asked mid-block, a stream that simply hasn't
+     * reached its read yet looks exactly like a silent one.
      *
-     * It has to be a separate call for the same reason. The stream a cue is
-     * most useful to is one nobody is reading from: a clip that has not started
-     * would otherwise not hear about it until the material was already due.
+     * It's a separate call for the same reason: the stream a cue is most
+     * useful to is one nobody is reading from, and a clip that hasn't
+     * started would otherwise not hear about it until the material was
+     * already due.
      */
     void applyPendingCue();
 
     /**
      * @brief Blocks the callback could not be given the samples for.
      *
-     * A seek costs at least one, because a disk cannot be read inside a
-     * callback. Anything beyond that is the reader failing to keep up, which is
-     * a property of the machine rather than of the music, and it has to be
-     * visible: silence that nobody counted is indistinguishable from a gap in
-     * the material.
+     * A seek costs at least one, since a disk can't be read inside a
+     * callback. Anything beyond that is the reader failing to keep up -- a
+     * property of the machine rather than the music -- and has to be
+     * visible, since silence nobody counted is indistinguishable from a gap
+     * in the material.
      *
-     * The end of the file is not an underrun. There is nothing late about
+     * The end of the file is not an underrun; there's nothing late about
      * silence past the last sample.
      */
     int underruns() const {

--- a/magda/engine/param/ModLfo.hpp
+++ b/magda/engine/param/ModLfo.hpp
@@ -8,32 +8,11 @@
 
 /**
  * @file ModLfo.hpp
- * @brief The LFO: what it is, where it has got to, and how far a block moves it.
+ * @brief LFO modifier runtime: advances LfoState by one block per LfoSettings.
  *
- * A modifier was a number until now. Slice 2 gave it an identity so a link
- * could name one, and the value it published was whatever the model last saw,
- * which is a value that does not move between publishes. This is the engine
- * that makes it move.
- *
- * Three pieces, and they are separate on purpose. LfoSettings is what the
- * model says the LFO is, which travels in the published table and is immutable
- * for as long as that table is. LfoState is where the LFO has got to, which
- * belongs to the runtime rather than to the table: a knob move republishes the
- * table many times a second and an LFO that restarted on each of them would
- * never finish a cycle. advanceLfo is one block of the first applied to the
- * second.
- *
- * Block rate, once per block, from the block's first sample, because that is
- * what the incumbent does: TE advances a modifier timer at the top of the
- * block and every plugin reading it that block reads one value. A modifier
- * that ran per sample would differ from the fork on every modulated parameter
- * in every project, which is a decision for after the port.
- *
- * What is deliberately not here is depth and polarity. One LFO drives several
- * parameters by different amounts and in different directions, and MAGDA keeps
- * that per link; it is applied where the contributions are summed
- * (ParamResolve.hpp) and the LFO knows nothing about it. The incumbent holds
- * TE's own depth, offset and bipolar parameters at unity for the same reason.
+ * See docs/architecture/modifier-lfo.md for the settings/state split,
+ * block-rate timing, bar-relative sync math, and the skipNativeResync /
+ * forceZero invariants.
  */
 
 namespace magda::engine {
@@ -41,78 +20,63 @@ namespace magda::engine {
 /**
  * @brief What drives a modifier's output.
  *
- * Only the LFO runs during this slice. The rest are named so a table can
- * describe a modifier the engine cannot yet advance, which reads its model
- * value and holds it, exactly as every modifier did before this slice; they
- * arrive in #2120.
+ * Only Lfo runs so far; the rest read their model value and hold it,
+ * unchanged from before this slice (#2120).
  */
 enum class ModKind : std::uint8_t { Lfo, Adsr, Random, Follower };
 
 /**
  * @brief Where a modifier's phase comes from.
  *
- * The model says trigger mode and tempo sync separately, and the fork folds
- * the two into one choice (ModifierHelpers::mapSyncType). Folded here as well,
- * and for the same reason: what actually differs is whether the phase is a
- * function of the timeline, a ramp of its own, or a ramp of its own that
- * something restarts.
+ * Folds the model's separate trigger mode and tempo-sync flags into one
+ * choice (ModifierHelpers::mapSyncType).
  */
 enum class ModSync : std::uint8_t {
-    /// A ramp of its own, advanced by however long the block was. Keeps
-    /// running with the transport stopped, because the graph is still
-    /// processing and the LFO is still moving.
+    /// A free-running ramp, advanced by block length. Keeps moving while
+    /// the transport is stopped.
     Free,
 
-    /// A function of where the timeline is, so two LFOs at one rate are in
-    /// phase with each other and with the bar however playback got there.
-    /// Standing still while the transport is stopped is the same statement.
+    /// Locked to the timeline, so two LFOs at one rate stay in phase.
     Transport,
 
-    /// A ramp of its own, restarted by a trigger. What a note-triggered LFO
-    /// is, and what a cross-track sidechain LFO is.
+    /// A free-running ramp restarted by a trigger (note-on or sidechain).
     Note,
 };
 
 /** @brief The rate of one modifier, as the block reads it. */
 struct LfoRate {
-    /// Cycles per second, when the modifier is not tempo synced.
+    /// Cycles per second, when not tempo synced.
     float hz = 1.0f;
 
-    /// A ModRateType ordinal, when it is. The persisted ordinal rather than a
-    /// division of MAGDA's own, because it is what lands in project files
-    /// through the Rate lane, so the divisions are a mapping rather than a
-    /// decision (ModInfo.hpp says so at the enum).
+    /// A ModRateType ordinal, when tempo synced. Persisted as-is because
+    /// it lands in project files via the Rate lane (see ModInfo.hpp).
     int rateType = static_cast<int>(magda::ModRateType::Hertz);
 };
 
 /**
  * @brief What the model says one LFO is.
  *
- * Flat and copyable: it rides in the published table, and the drawn curve
- * rides beside it in the table's own arena rather than in here, because a
- * vector per modifier would be an allocation per modifier.
+ * Flat and copyable: rides in the published table. The drawn curve rides
+ * beside it in the table's arena, not here.
  */
 struct LfoSettings {
     magda::LFOWaveform wave = magda::LFOWaveform::Sine;
 
-    /// The shape behind a Custom waveform with nothing drawn on it yet.
+    /// Shape behind a Custom waveform with nothing drawn yet.
     magda::CurvePreset preset = magda::CurvePreset::Triangle;
 
     ModSync sync = ModSync::Free;
 
     /**
-     * @brief What the model says triggers it, before the fold into @ref sync.
+     * @brief What the model says triggers this, before the fold into @ref sync.
      *
-     * Carried as well as folded, because the fold is lossy in the one place it
-     * matters: MIDI and audio both run as ModSync::Note and gate differently,
-     * so the gate cannot be reconciled against the folded form. A mode change
-     * is the one edit that has to reach a running LFO's gate (LfoState::gated).
+     * Carried separately because MIDI and audio both fold to ModSync::Note
+     * but gate differently; a mode change is the one edit that must reach a
+     * running LFO's gate (LfoState::gated).
      */
     magda::LFOTriggerMode trigger = magda::LFOTriggerMode::Free;
 
-    /// Whether the rate is a musical division rather than a frequency. What
-    /// the Rate parameter means depends on it, which is why the two travel
-    /// together.
+    /// Whether rate is a musical division rather than a frequency.
     bool tempoSync = false;
 
     LfoRate rate;
@@ -120,158 +84,81 @@ struct LfoSettings {
     /// Added to the phase before the shape is read, 0 to 1.
     float phaseOffset = 0.0f;
 
-    /// Play one cycle and hold what it ended on. A sustain loop overrides it:
-    /// the region repeats rather than the cycle finishing.
+    /// Play one cycle and hold the end value. A sustain loop overrides this.
     bool oneShot = false;
 
     /**
      * @brief Whether the drawn curve is a level rather than an amount.
      *
-     * An inactive modifier outputs 0, which is the engine convention every
-     * gate and every untriggered LFO relies on. A curve drawn as an audible
-     * level therefore has to be applied as its complement, or idle would read
-     * as silence: the Sidechain device draws the gain shape the user hears and
-     * the engine receives the duck.
+     * An inactive modifier outputs 0 by convention, so a curve drawn as an
+     * audible level (e.g. Sidechain) is applied as its complement.
      */
     bool invertOutput = false;
 
-    /// The sustain loop of a drawn curve: the intro [0, loopStart) plays once
-    /// and [loopStart, loopEnd] repeats from there.
+    /// The sustain loop of a drawn curve: [0, loopStart) plays once,
+    /// [loopStart, loopEnd] repeats.
     bool useLoopRegion = false;
     float loopStart = 0.0f;
     float loopEnd = 1.0f;
 
-    /**
-     * @brief Whether this LFO ignores triggers from where it lives.
-     *
-     * A cross-track sidechain LFO is driven by the source track alone: the
-     * track it modulates must not retrigger its phase or slam its gate on
-     * every note it happens to be playing. The fork learned this the hard way,
-     * with a flag that was set at creation and not restated when a source was
-     * picked later, so the destination track went on retriggering an LFO that
-     * had stopped being its own.
-     */
+    /// True for a cross-track sidechain LFO: it ignores triggers from the
+    /// track it modulates. See docs/architecture/modifier-lfo.md.
     bool skipNativeResync = false;
 
-    /**
-     * @brief Whether triggers gate the output as well as restarting the phase.
-     *
-     * A note-triggered LFO behaves like an envelope: silent between notes,
-     * running while one is held. Off for a cross-track LFO, whose idle state
-     * is the one-shot hold or a free-running loop rather than nothing at all.
-     */
+    /// Whether triggers gate the output as well as restarting the phase
+    /// (note-triggered LFOs behave like envelopes). Off for cross-track LFOs.
     bool gateOnTrigger = false;
 
-    /// Whether the LFO starts with its gate shut. What an audio-triggered LFO
-    /// is between hits, and what a note-triggered one is before the first note.
+    /// Whether the LFO starts with its gate shut.
     bool startGated = false;
 };
 
 /**
  * @brief Where one LFO has got to.
  *
- * Owned by the runtime and carried across publishes and plan swaps, so a knob
- * move, a link edit or a device insert leaves the phase where it was.
+ * Owned by the runtime and carried across publishes and plan swaps, so a
+ * knob move or link edit leaves phase alone.
  */
 struct LfoState {
-    /**
-     * @brief Cycles since the run began, fractional and monotonic.
-     *
-     * The phase is its fractional part, and everything that needs to know how
-     * far through the LFO is rather than where in the cycle it is asks this:
-     * a one-shot is through when it reaches one, and a sustain loop folds it
-     * back into the region. A transport-locked LFO derives it from the
-     * timeline instead of accumulating it.
-     */
+    /// Cycles since the run began, fractional and monotonic. Fractional
+    /// part is the phase; a transport-locked LFO derives this from the
+    /// timeline.
     double cycles = 0.0;
 
-    /// What the last block published, for the UI and for the read-back taps
-    /// (#2122). The phase is the position the shape was read at, so a looped
-    /// curve reports where in the loop it is rather than the raw sweep.
+    /// What the last block published, for the UI and read-back taps (#2122).
     float phase = 0.0f;
     float value = 0.0f;
 
-    /// Output held at zero. Not a pause: the phase goes on advancing
-    /// underneath, so ungating resumes where the LFO would have been rather
-    /// than where it was when the gate shut.
+    /// Output held at zero; phase keeps advancing underneath, so ungating
+    /// resumes where the LFO would have been.
     bool gated = false;
 
     /// A one-shot that has played through and is holding its end value.
     bool completed = false;
 
-    /**
-     * @brief A trigger has asked for one block of nothing.
-     *
-     * The gap a gated retrigger would have left, so a device sees a transition
-     * rather than a continuation. Latched rather than written straight to the
-     * output, because a trigger arrives inside a block whose parameters have
-     * already been resolved: the block after it is the first one a device can
-     * see, and a value written at the moment of the trigger would be
-     * overwritten before anything read it.
-     *
-     * The block that spends it holds the phase as well, so the shape resumes
-     * from its start on the block after. That is the fork's own sequence, one
-     * block later, which is the same block the trigger itself is late by.
-     */
+    /// See docs/architecture/modifier-lfo.md ("forceZero").
     bool forceZero = false;
 
-    /// Notes holding the gate open. The gate shuts when the last one lifts,
-    /// which is what makes a note-triggered LFO read as an envelope.
+    /// Notes holding the gate open; the gate shuts when the last one lifts.
     int heldNotes = 0;
 
-    /**
-     * @brief Whether this state has run at all.
-     *
-     * A fresh LFO takes its gate from LfoSettings::startGated on its first
-     * block; after that the gate belongs to the triggers. The fork re-asserts
-     * it from the model on every property update, because a TE modifier's gate
-     * cannot be reached from the message thread any other way; here the gate
-     * lives beside the phase, so a publish that re-asserted it would be
-     * fighting the note that had just opened it.
-     */
+    /// Whether this state has run at all. A fresh LFO takes its gate from
+    /// LfoSettings::startGated on the first block only.
     bool started = false;
 
-    /**
-     * @brief The trigger mode this state's gate was seeded under.
-     *
-     * The one edit a running gate has to hear. A gate belongs to the triggers
-     * of the mode that opened it, and a mode change retires all of them: an
-     * audio-triggered LFO sits shut between hits, and switching it to free
-     * running would otherwise leave it shut for ever, because nothing in the
-     * new mode ever opens a gate.
-     *
-     * Compared rather than re-applied, so an ordinary publish leaves the gate
-     * where the last note put it. The fork gets the same effect by re-applying
-     * unconditionally, which it can afford because its gate is not also where
-     * a held note is counted.
-     */
+    /// The trigger mode this state's gate was seeded under; a mode change
+    /// retires the gate rather than leaving it stuck under the old mode.
     magda::LFOTriggerMode trigger = magda::LFOTriggerMode::Free;
 };
 
 /**
- * @brief What one block needs to know about time that the block itself cannot say.
+ * @brief Sample rate, tempo and signature a block opens on.
  *
- * The sample rate, because a free-running LFO advances by how long the block
- * lasted rather than by how far the timeline moved, and the two are different
- * things while the transport is stopped. The tempo, because a stopped block
- * covers no beats and a free-running modifier still has to keep musical time.
- * And the whole signature, because a musical division is a fraction of a bar
- * and a bar is neither number on its own: a rolling block reads the bars it
- * covers off the map instead (@ref modBarsElapsed), which is what a stopped
- * one has no map to read them from.
+ * For advancing a modifier's own ramp independent of the timeline.
  */
 struct ModTiming {
     double sampleRate = 44100.0;
-
-    /// The tempo the block opens at. What a stopped block keeps time at, and
-    /// nothing else: a rolling block says how many bars it covers, and that is
-    /// the map's own answer across a tempo or signature change inside it (@ref
-    /// modBarsElapsed).
     double bpm = 120.0;
-
-    /// The signature at the block's first beat. Both halves of it, because a
-    /// bar is the numerator counted in the denominator's note value and either
-    /// on its own describes the wrong bar.
     int numerator = 4;
     int denominator = 4;
 };
@@ -280,103 +167,43 @@ struct ModTiming {
 ModTiming modTimingFor(const BlockInfo& block, double sampleRate);
 
 /**
- * @brief Where @p block opens, counted in bars.
+ * @brief Where @p block opens, in bars (bar-grid based, not beats / bar-length).
  *
- * The bar grid rather than a beat count divided by a bar's length, because the
- * two part company at a signature change: a change always starts a bar
- * (TempoMap.hpp), so two bars of four four followed by six eight puts a bar
- * line at beat eight, and eight divided by the three beats a six eight bar
- * lasts is two and two thirds. A modifier reading that opens every six eight
- * bar two thirds of the way through its cycle and stays there.
- *
- * Whole bars plus the fraction of this one that has gone by, which restarts at
- * the change and carries the denominator with it, since the beat inside a bar
- * is counted in the signature's own note value.
- *
- * Without a map there are no changes to survive, and the closed form is the
- * same number: a hand-assembled block gets the arithmetic the grid would have
- * given it.
- *
- * Shared because every timeline-locked modifier asks it, not only the LFO: a
- * synced random walk that stepped on a different grid from the LFO beside it
- * would be two answers to one question.
+ * See docs/architecture/modifier-lfo.md for why signature changes require
+ * this instead of simple division.
  */
 double modBarPosition(const BlockInfo& block, const ModTiming& timing);
 
-/**
- * @brief How long a bar is, in beats, under one signature.
- *
- * The numerator counted in the denominator's own note value:
- * `numerator * 4 / denominator` quarter notes, because a beat is a quarter
- * note here and everywhere else in the engine. A bar of six eight is three of
- * them, not six. Shared between @ref cycleBeats, which asks it of one
- * signature, and @ref modBarsElapsed, which asks it of every signature a
- * block crosses.
- */
+/** @brief How long a bar is, in beats, under one signature: numerator * 4 / denominator. */
 double barBeatsOf(int numerator, int denominator);
 
 /**
  * @brief How many bars @p block covers, for a modifier advancing its own ramp.
  *
- * The block's own beat length, translated into bars off the map. Not a single
- * division, because a bar is a different number of beats on each side of a
- * signature change, and a block that spans one covers a fraction of each: the
- * map knows where the change is, so this walks the spans between them and
- * sums what each is worth in its own bar length. Right across a tempo step as
- * well, since @ref modBarsElapsed reads through the same grid the beats
- * themselves came from; block seconds scaled by a single bpm and signature
- * read anywhere in the block is not, and runs the rest of a block that spans a
- * change at the numbers it opened on (#2340).
- *
- * A stopped block is the one that still needs a tempo and a signature. It
- * covers no beats at all, and a free-running modifier goes on turning through
- * it, so there the bars are how long the block lasted at the tempo and
- * signature the cursor is sitting on. A stopped cursor is on one beat, so one
- * bpm and one bar length are exact there.
- *
- * Shared because the LFO, the random walk and the envelope all ask it, and two
- * answers to one question is what a modifier drifting from the one beside it
- * would be.
+ * Handles blocks that span a tempo or signature change (#2340); see
+ * docs/architecture/modifier-lfo.md.
  */
 double modBarsElapsed(const BlockInfo& block, const ModTiming& timing);
 
 /**
- * @brief How much of a bar one rate type is.
+ * @brief How much of a bar one rate type is (ModifierCommon::getBarFraction parity table).
  *
- * The fork's own table (ModifierCommon::getBarFraction), because a synced LFO's
- * period has to be the same number of beats in both engines or every synced
- * project drifts. Note that these are fractions of a bar rather than of a whole
- * note: "1/2" is half a bar, which is a half note in four four and three
- * quarters of one in three four.
+ * Fractions of a bar, not of a whole note.
  */
 double barFractionOf(int rateType);
 
 /**
  * @brief How many beats one cycle of a tempo-synced LFO lasts.
  *
- * The bar fraction times the length of a bar, and a bar is the signature's
- * numerator counted in its own note value: `numerator * 4 / denominator`
- * quarter notes, because a beat is a quarter note here and everywhere else in
- * the engine. A bar of six eight is three of them, not six.
- *
- * The fork used to count the numerator in quarter notes, so a "1 Bar" modifier
- * in six eight ran two written bars long and every other division was out by
- * the same ratio. The four TE modifiers are patched to match this rather than
- * this being bent to match them: an engine being replaced is not a reason to
- * carry its arithmetic forward, and the two agreeing is what keeps the
- * null-diff corpus meaningful (#2128).
+ * Matches the TE modifiers' corrected bar arithmetic rather than the
+ * reverse (#2128).
  */
 double cycleBeats(int rateType, int numerator, int denominator);
 
 /**
  * @brief The rate ordinal a Rate lane's value stands for, and back again.
  *
- * The lane counts from the first musical division rather than from the
- * enumeration's own zero, because zero is Hertz and Hertz is not a division: a
- * synced modifier whose lane ran to the bottom of its range would otherwise
- * resolve to "not synced at all". The model's Rate control stores the shifted
- * index (AutomationInfo::makeSyncDivisionInfo) and this is the same shift on
- * the engine's side of the same lane.
+ * See docs/architecture/modifier-lfo.md ("Rate lane indexing").
  */
 int rateTypeFromLaneValue(float laneValue);
 float laneValueFromRateType(int rateType);
@@ -384,37 +211,26 @@ float laneValueFromRateType(int rateType);
 /**
  * @brief The level @p settings has at @p phase, before gating and inversion.
  *
- * The model's own reading of the shape (core/ModCurve.hpp). Exposed because
- * the read-back taps and the tests both want the shape without the run.
+ * The model's own reading of the shape (core/ModCurve.hpp).
  */
 float lfoShapeAt(const LfoSettings& settings, std::span<const magda::CurvePointData> curve,
                  float phase);
 
 /**
- * @brief Restart @p state, as a trigger does.
+ * @brief Restart @p state as a trigger does.
  *
- * The phase goes back to the top and a finished one-shot plays again. A
- * free-running or timeline-locked LFO is not restarted at all, which is the
- * fork's rule as well: resync only acts when the sync type is note, so an LFO
- * that is not listening for a trigger ignores the notes going past it.
- *
- * Whether a trigger is one this LFO listens to is the caller's question rather
- * than this one's: LfoSettings::skipNativeResync says the LFO belongs to
- * another track's monitor, and that is about where a trigger came from.
+ * Phase to zero, and a finished one-shot plays again. Free-running and
+ * transport-locked LFOs are not restarted; callers should not invoke this
+ * unless sync == ModSync::Note.
  */
 void restartLfo(LfoState& state, const LfoSettings& settings);
 
 /**
  * @brief Advance @p state over one block and publish what @p settings says.
  *
- * On the audio thread, once per block, before anything reads the modifier.
- * Returns the output: 0 to 1, inverted where the curve is a level, and 0 flat
- * while the gate is shut, which is the convention that makes an inactive
- * modifier mean "doing nothing" everywhere it is read.
- *
- * The value published is the one the block opens on, and the ramp is moved on
- * afterwards, which is the order the fork's timer uses and therefore the order
- * a parity case is measured against.
+ * Call on the audio thread, once per block, before anything reads the
+ * modifier. Returns 0 to 1, inverted where the curve is a level, flat 0
+ * while gated.
  */
 float advanceLfo(LfoState& state, const LfoSettings& settings,
                  std::span<const magda::CurvePointData> curve, const BlockInfo& block,

--- a/magda/engine/param/ModRuntime.hpp
+++ b/magda/engine/param/ModRuntime.hpp
@@ -17,49 +17,37 @@
  * @file ModRuntime.hpp
  * @brief The modifiers of one plan, and where each of them has got to.
  *
- * The table says what a modifier is; this says where it is. The two are apart
- * because they live at different speeds: a table is republished every time a
- * knob moves, and an LFO that restarted on each of those would never finish a
- * cycle. So the settings travel with the values and the phase stays here,
- * carried from one epoch to the next by the modifier's own address.
- *
- * Carried by sharing rather than by copying. The executor being replaced is
- * still rendering while the next one is prepared, so its states are taken by
- * reference the way a delay line is: an LFO whose modifier survives a device
- * insert goes on turning through the swap rather than resuming from wherever
- * it was read at.
+ * The table says what a modifier is; this says where it is. Apart because
+ * they live at different speeds: a table is republished on every knob move,
+ * and an LFO restarting each time would never finish a cycle. State is
+ * carried from one epoch to the next by the modifier's own address, shared
+ * rather than copied -- the executor being replaced is still rendering while
+ * the next one is prepared, so an LFO surviving a device insert keeps turning
+ * through the swap rather than resuming from wherever it was read at.
  *
  * Prepared off the audio thread, advanced on it, once per modifier per block,
- * from inside the table's resolution order so that anything a modifier reads
- * has already been resolved when it runs (ParamResolve.hpp).
+ * from inside the table's resolution order so anything a modifier reads has
+ * already been resolved (ParamResolve.hpp).
  *
- * ## Where a trigger comes from
+ * ## Triggers (#2120)
  *
- * Two of the three trigger modes need something outside the parameter system
- * to say when, and both feeds are wired here (#2120).
+ * Note-triggered: driven by MIDI reaching the modifier's scope, known before
+ * the block resolves (PlanExecutor's MIDI prefix runs first), so the notes in
+ * a block reach that block's modifiers.
  *
- * A note-triggered modifier is driven by the MIDI reaching the scope it lives
- * in, and that MIDI is known before the block resolves: the ops that produce it
- * read clips and input queues rather than audio, so the executor renders them
- * first and the notes in a block reach the modifiers of that same block
- * (PlanExecutor's MIDI prefix).
+ * Audio-triggered: driven by the level of the track it watches, which is not
+ * known before the block resolves since it's what that block's ops are about
+ * to produce -- arrives exactly one block late, a property of resolving
+ * parameters at the top of a block (ModFollower.hpp weighs the alternative).
  *
- * An audio-triggered one is driven by the level of the track it watches, and
- * that is not known before the block resolves, because the level is what the
- * ops are about to produce. It arrives one block late, always exactly one, and
- * that is a property of resolving parameters at the top of a block rather than
- * an accident (ModFollower.hpp weighs the alternative).
+ * Transport: needs nothing, a timeline-locked modifier is a function of
+ * where the block is.
  *
- * The transport mode needs nothing: a timeline-locked modifier is a function
- * of where the block is.
- *
- * ## What a trigger means depends on the kind
- *
- * Four engines and three answers. An LFO restarts its phase, and gates as well
- * if the model asked it to. An envelope is nothing but a gate, so a trigger
- * opens it and the last note lifting shuts it. A random walk restarts and has
- * no gate at all, which is the fork's own shape. A follower has neither: its
- * input is a level, and a level has nothing to retrigger.
+ * What a trigger means depends on the kind: an LFO restarts its phase (and
+ * gates too if the model asked); an envelope is nothing but a gate, opened by
+ * a trigger and shut when the last note lifts; a random walk restarts with no
+ * gate; a follower has neither, since its input is a level with nothing to
+ * retrigger.
  */
 
 namespace magda::engine {
@@ -70,10 +58,9 @@ struct ParamModifier;
 /**
  * @brief Where one modifier has got to.
  *
- * All four kinds, side by side, for the reason ParamModifier holds four
- * settings structs: exactly one is live and a state is a few dozen bytes, so
- * the padding buys a flat struct that carries by address without a discriminant
- * to check first.
+ * All four kinds side by side, matching ParamModifier's four settings
+ * structs: only one is ever live, so the padding buys a flat struct carried
+ * by address with no discriminant to check.
  */
 struct ModState {
     LfoState lfo;
@@ -85,19 +72,18 @@ struct ModState {
 /**
  * @brief The modifier engines behind one plan.
  *
- * Indexed the way ParamTable::modifiers is, because a link names a modifier by
- * that index and the block has no time to look one up.
+ * Indexed the way ParamTable::modifiers is: a link names a modifier by that
+ * index and the block has no time to look one up.
  */
 class ModRuntime {
   public:
     /**
      * @brief Size for @p table and adopt what @p previous already had.
      *
-     * Off the audio thread, when a plan is prepared. A modifier the previous
-     * runtime holds at the same address and of the same kind keeps its state,
-     * shared rather than copied; everything else starts fresh.
-     *
-     * @p previous may be null, which is a session's first plan.
+     * Off the audio thread, when a plan is prepared. A modifier @p previous
+     * holds at the same address and kind keeps its state, shared rather than
+     * copied; everything else starts fresh. @p previous may be null (a
+     * session's first plan).
      */
     void prepare(const ParamTable& table, const RenderContext& context,
                  const ModRuntime* previous = nullptr);
@@ -109,9 +95,8 @@ class ModRuntime {
         return static_cast<int>(states_.size());
     }
 
-    /// Modifiers this runtime took over from the one it replaced, rather than
-    /// starting again. What the address-keyed carry bought, in other words:
-    /// every one of these is an LFO that did not restart on the edit.
+    /// Modifiers carried over from the runtime this replaced rather than
+    /// restarted -- every one is an LFO that didn't reset on the edit.
     int carried() const {
         return carried_;
     }
@@ -119,10 +104,9 @@ class ModRuntime {
     /**
      * @brief Identity of the modifier list this was sized for.
      *
-     * What ParamTable::layoutFingerprint is to the parameters. A table with
-     * another one puts different modifiers at the same indices, so the state
-     * kept here would be another LFO's phase and a link would read another
-     * modifier's output.
+     * What ParamTable::layoutFingerprint is to the parameters: a table with a
+     * different one puts different modifiers at the same indices, so state
+     * kept here would be another LFO's phase.
      */
     std::uint64_t fingerprint() const {
         return fingerprint_;
@@ -135,30 +119,26 @@ class ModRuntime {
     /**
      * @brief Advance modifier @p index over the block and publish its output.
      *
-     * On the audio thread, from the table's resolution order. @p rate is what
-     * its Rate parameter resolved to this block, which is a frequency or a
-     * division ordinal depending on whether the modifier is tempo synced. Only
-     * the two kinds that have a rate read it.
+     * On the audio thread, from the table's resolution order. @p rate is
+     * what its Rate parameter resolved to (a frequency or division ordinal,
+     * per tempo sync); only the two kinds with a rate read it.
      */
     void advance(int index, const ParamTable& table, const LfoRate& rate, const BlockInfo& block);
 
     /**
      * @brief Hand modifier @p index the block its source just rendered.
      *
-     * On the audio thread, after the source's ops have run and before the next
-     * block resolves. Only a follower has anything to do with it; everything
-     * else ignores it, so the caller can offer a track's output to every
-     * modifier listening to that track without asking what kind each is.
-     *
-     * @p mono is the source's block downmixed to one channel. The detection
-     * happens here rather than at the next resolve because the audio is only
-     * valid until the next block overwrites the buffer it is in.
+     * On the audio thread, after the source's ops run and before the next
+     * block resolves. Only a follower does anything with it, so a caller can
+     * offer a track's output to every modifier listening to it without
+     * asking what kind each is. @p mono is the source's block downmixed to
+     * one channel; detection happens here because the buffer is only valid
+     * until the next block overwrites it.
      */
     void detectSource(int index, const ParamTable& table, std::span<const float> mono);
 
-    /// Every modifier listening to track @p track, for the executor to offer
-    /// that track's signal to. Off the audio thread: it is built at prepare and
-    /// read by index on the block path.
+    /// Every modifier listening to track @p track. Off the audio thread:
+    /// built at prepare and read by index on the block path.
     std::span<const int> listenersOf(magda::TrackId track) const;
 
     /// The tracks anything in this runtime listens to.
@@ -166,81 +146,76 @@ class ModRuntime {
         return listened_;
     }
 
-    /// What modifier @p index listens to its source for, so a note reaches the
-    /// modifiers waiting for one and a level reaches the modifiers waiting for
-    /// that. One list of listeners per track and this to sort them, rather than
-    /// three lists that could disagree about who is on which.
+    /// What modifier @p index listens to its source for, so a note reaches
+    /// note-waiting modifiers and a level reaches level-waiting ones. One
+    /// listener list per track plus this to sort them, rather than three
+    /// lists that could disagree about who is on which.
     ModListen listensFor(int index, const ParamTable& table) const;
 
     /**
      * @brief Whether modifier @p index is driven by a track other than its own.
      *
-     * The two kinds of listener a source's tap feeds, and they take a trigger
-     * through different doors. One living on the source hears its notes as its
-     * own: it counts them, and the gate shuts when the last one lifts. One
-     * living somewhere else is following that track rather than playing it, so
-     * the note-counting path refuses it outright and @ref trigger is the way
-     * in, which is the fork's arrangement too (SidechainMonitorPlugin fires
-     * triggerSidechain and does nothing at all on note-off).
-     *
-     * Exposed because the executor holds the tap and cannot otherwise tell the
-     * two apart.
+     * Two kinds of listener take a trigger through different doors: one
+     * living on the source hears its own notes and counts them (gate shuts
+     * on the last one); one living elsewhere is following that track rather
+     * than playing it, so the note-counting path refuses it and @ref trigger
+     * is the way in -- the fork's arrangement too (SidechainMonitorPlugin
+     * fires triggerSidechain and ignores note-off). Exposed because the
+     * executor holds the tap and cannot otherwise tell the two apart.
      */
     bool drivenFromElsewhere(int index, const ParamTable& table) const;
 
-    /// What modifier @p index published this block, or the model's own value
-    /// for one nothing has advanced.
+    /// What modifier @p index published this block, or the model's own
+    /// value for one nothing has advanced.
     float value(int index) const;
 
-    /// Where modifier @p index has got to, for the read-back taps and the
-    /// tests. Null for an index this runtime does not have.
+    /// Where modifier @p index has got to, for read-back taps and tests.
+    /// Null for an index this runtime does not have.
     const ModState* state(int index) const;
 
-    /// The modifier at @p key, or -1. Off the audio thread: it is a scan, and
-    /// what asks is a caller holding an address rather than an index.
+    /// The modifier at @p key, or -1. Off the audio thread: a scan, for a
+    /// caller holding an address rather than an index.
     int indexOf(const ParamKey& key) const;
 
     /**
      * @brief A trigger from where the modifier lives.
      *
      * A note-on on the stream the modifier's own scope plays. Restarts the
-     * phase, and opens the gate where the modifier has one that its trigger
-     * owns: an LFO the model asked to be gated, and an envelope, whose gate is
-     * the whole of what it is. A random walk restarts and is not gated; a
+     * phase and opens the gate where the modifier has one that its trigger
+     * owns (a gated LFO, an envelope); a random walk restarts ungated, a
      * follower does neither.
      *
      * Refused when the modifier belongs to another track's monitor
-     * (LfoSettings::skipNativeResync): a cross-track sidechain modifier follows
-     * its source and must not be retriggered by whatever the track it ducks
-     * happens to be playing.
+     * (LfoSettings::skipNativeResync): a cross-track sidechain modifier
+     * follows its source and must not be retriggered by whatever the track
+     * it ducks happens to be playing.
      */
     void noteOn(int index, const ParamTable& table);
 
-    /// The other half of it: the gate shuts when the last held note lifts.
-    /// Refused on the same terms, because a gate that only one half of the
-    /// pair could reach would latch open on the first note it heard.
+    /// The other half: the gate shuts when the last held note lifts.
+    /// Refused on the same terms, or a gate only one half could reach would
+    /// latch open on the first note it heard.
     void noteOff(int index, const ParamTable& table);
 
-    /// Every held note at once, which is what an all-notes-off is. Refused on
-    /// the same terms again.
+    /// Every held note at once, i.e. an all-notes-off. Refused on the same terms.
     void allNotesOff(int index, const ParamTable& table);
 
     /**
      * @brief A trigger from somewhere else.
      *
-     * What the source track's level detector does to a cross-track sidechain
-     * modifier, and the one path skipNativeResync does not refuse: it is the
-     * trigger the modifier exists to follow.
+     * What the source track's level detector does to a cross-track
+     * sidechain modifier -- the one path skipNativeResync does not refuse,
+     * since it is the trigger the modifier exists to follow.
      *
-     * @p forceZero publishes a zero for the trigger block, so the device sees
+     * @p forceZero publishes a zero for the trigger block so the device sees
      * the gap a gated retrigger would have left. Never for a level curve,
      * where zero output is full level and forcing one would pop the gain up
-     * for a block in the middle of a duck.
+     * mid-duck.
      */
     void trigger(int index, const ParamTable& table, bool forceZero = true);
 
-    /// Shut or open the gate directly, which is what an audio trigger does
-    /// between hits. Ignored by the kinds that have no gate.
+    /// Shut or open the gate directly, as an audio trigger does between
+    /// hits. Ignored by kinds with no gate.
     void setGated(int index, const ParamTable& table, bool gated);
 
   private:
@@ -249,18 +224,17 @@ class ModRuntime {
     /// Work out which modifiers listen to which track, once per prepare.
     void buildListenerRouting(const ParamTable& table);
 
-    /// Send @p state back to the top, whatever kind it is. @p fromZero is what
-    /// a cross-track trigger asks for, and only the envelope has anywhere to
-    /// put it: an LFO's gap is a latch and a walk has none at all.
+    /// Send @p state back to the top, whatever kind it is. @p fromZero is
+    /// what a cross-track trigger asks for; only the envelope has anywhere
+    /// to put it (an LFO's gap is a latch, a walk has none).
     static void restart(ModState& state, const ParamModifier& modifier, bool fromZero);
 
     /// Shared rather than owned outright, so an epoch being replaced and the
-    /// one replacing it are the same LFO rather than two copies of it. Only
-    /// one epoch renders at a time, so there is an owner to outlive and no
-    /// concurrent use to guard against.
+    /// one replacing it are the same LFO, not two copies. Only one epoch
+    /// renders at a time, so there's one owner and no concurrent use to guard.
     std::vector<std::shared_ptr<ModState>> states_;
 
-    /// What each modifier published this block. Filled by advance(), and by
+    /// What each modifier published this block. Filled by advance(), or by
     /// the table's own value for a kind with no engine yet.
     std::vector<float> values_;
 
@@ -269,17 +243,16 @@ class ModRuntime {
     std::vector<ModKind> kinds_;
 
     /// Which modifiers listen to which track: listeners_[listenerOffsets_[t],
-    /// listenerOffsets_[t + 1]) are the indices listening to listened_[t]. One
-    /// arena and a parallel list of tracks, because almost no project has a
-    /// listening modifier at all and a map keyed by track would be a lookup per
-    /// block for it.
+    /// listenerOffsets_[t + 1]) listen to listened_[t]. One arena plus a
+    /// parallel track list, since almost no project has a listening modifier
+    /// at all and a map keyed by track would cost a lookup per block.
     std::vector<magda::TrackId> listened_;
     std::vector<int> listeners_;
     std::vector<int> listenerOffsets_;
 
-    /// Room for one block of band-limited detection, shared by every follower
-    /// because they run one at a time. Sized at prepare, so the block path
-    /// never allocates.
+    /// Room for one block of band-limited detection, shared by every
+    /// follower since they run one at a time. Sized at prepare, so the block
+    /// path never allocates.
     std::vector<float> detectScratch_;
 
     std::uint64_t fingerprint_ = 0;

--- a/magda/engine/param/ParamTable.hpp
+++ b/magda/engine/param/ParamTable.hpp
@@ -20,18 +20,18 @@
  * @brief Every parameter behind one plan, and what writes each of them.
  *
  * The plan is topology and carries no values (RenderPlan.hpp). PlanValues is
- * what a mixer move can touch, resolved per op. This is the third of the three:
- * what a device reads, resolved per parameter, and it is where a parameter's
- * scale, its stored value and the links reaching it are settled against the
- * plan they belong to.
+ * what a mixer move can touch, resolved per op. This is the third piece:
+ * what a device reads, resolved per parameter, where a parameter's scale,
+ * stored value and links are settled against the plan they belong to.
  *
- * Built off the audio thread, published with the values, and read on the audio
- * thread by ParamResolve.hpp, which turns it into the value streams devices
- * see. Immutable once published, like everything else that crosses that line.
+ * Built off the audio thread, published with the values, and read on the
+ * audio thread by ParamResolve.hpp, which turns it into the value streams
+ * devices see. Immutable once published, like everything else that crosses
+ * that line.
  *
- * Fingerprinted against the plan for the same reason PlanValues is: parameters
- * are addressed by index, and a table resolved against a plan that has since
- * been swapped would put one device's cutoff on another.
+ * Fingerprinted against the plan for the same reason PlanValues is:
+ * parameters are addressed by index, and a table resolved against a plan
+ * that has since been swapped would put one device's cutoff on another.
  */
 
 namespace magda::engine {
@@ -56,8 +56,8 @@ struct ParamLink {
     ParamSourceRef source;
 
     /// Depth and polarity, per link rather than per source: one macro drives
-    /// several parameters by different amounts and in different directions, and
-    /// that is where MAGDA keeps them.
+    /// several parameters by different amounts and directions, and that is
+    /// where MAGDA keeps them.
     float amount = 0.0f;
     bool bipolar = false;
 };
@@ -65,16 +65,15 @@ struct ParamLink {
 /**
  * @brief One modifier instance, as the thing links read.
  *
- * A source with an identity, so a link can name one and the resolution order
- * can account for one, plus what it takes to run it.
+ * A source with an identity, so a link can name one and the resolution
+ * order can account for it, plus what it takes to run it.
  *
- * Four kinds and four settings structs, side by side rather than in a union or
- * a variant. Exactly one of them is live and the other three are dead weight,
- * which is about a hundred bytes per modifier: a project with a modifier on
- * every scope it could have one on spends a few tens of kilobytes on the
- * padding, once, off the audio thread. A variant would save that and cost a
- * discriminated read on the block path, and the table's whole design is that
- * what crosses to the audio thread is flat and copyable.
+ * Four kinds, four settings structs side by side rather than a union or
+ * variant: only one is ever live, costing about a hundred bytes of padding
+ * per modifier, spent once off the audio thread. A variant would save that
+ * at the cost of a discriminated read on the block path, and the table's
+ * whole design is that what crosses to the audio thread is flat and
+ * copyable.
  */
 struct ParamModifier {
     /// The modifier itself: its owner's scope and its id, with no parameter
@@ -87,14 +86,14 @@ struct ParamModifier {
 
     ModKind kind = ModKind::Lfo;
 
-    /// A modifier the model has switched off contributes nothing at all: its
-    /// links are not carried, because a bipolar link reading an output of zero
-    /// would push its parameter down by the link's own depth, and the model's
+    /// A modifier the model has switched off contributes nothing: its links
+    /// are not carried, since a bipolar link reading a zero output would
+    /// push its parameter down by the link's own depth, and the model's
     /// answer is that there is no modifier there.
     bool enabled = true;
 
-    /// What the modifier is, for whichever @ref kind it is. The other three are
-    /// left at their defaults and never read.
+    /// What the modifier is, for whichever @ref kind it is. The other three
+    /// are left at their defaults and never read.
     LfoSettings lfo;
     AdsrSettings adsr;
     RandomSettings random;
@@ -104,37 +103,36 @@ struct ParamModifier {
      * @brief The track whose signal this modifier listens to, or
      *        INVALID_TRACK_ID.
      *
-     * Set for every modifier that listens at all: a follower, which is nothing
-     * but its source, and a MIDI- or audio-triggered one, which waits on that
-     * track's notes or its level. A free-running or timeline-locked modifier
-     * listens to nothing and says so by having none of this, which is what
-     * keeps a plan from carrying a track's signal nobody reads.
+     * Set for any modifier that listens at all: a follower (nothing but its
+     * source), or a MIDI-/audio-triggered one (waiting on that track's notes
+     * or level). A free-running or timeline-locked modifier listens to
+     * nothing, keeping a plan from carrying a track's signal nobody reads.
      *
      * Which track it is is ModSources.hpp's rule, called by both compilers.
-     * Carried on the modifier rather than in the plan because it is not
-     * topology, and read by the executor to decide who is on the far end of
-     * each modulation tap.
+     * Carried on the modifier rather than the plan since it isn't topology,
+     * and read by the executor to decide who's on the far end of each
+     * modulation tap.
      */
     magda::TrackId source = magda::INVALID_TRACK_ID;
 
-    /// Where in @ref source's chain it listens. Only read for a modifier that
-    /// listens to audio; a note reaches its listeners from one point because
-    /// MIDI has no fader to sit either side of.
+    /// Where in @ref source's chain it listens. Only read for a modifier
+    /// listening to audio; a note reaches its listeners from one point,
+    /// since MIDI has no fader to sit either side of.
     magda::ModTapPoint tap = magda::ModTapPoint::PreFx;
 
     /**
      * @brief The modifier's own Rate parameter, or INVALID_PARAM_ID.
      *
-     * Carried only when something reaches it: a lane playing over the rate, or
-     * a macro or another modifier driving it. The overwhelming majority of
-     * modifiers have a rate nothing touches, and one parameter each for them
-     * would be a table mostly made of numbers that never move.
+     * Carried only when something reaches it (a lane over the rate, a
+     * macro, or another modifier). Most modifiers have a rate nothing
+     * touches, and a parameter each for them would be a table mostly made
+     * of numbers that never move.
      *
-     * Its value is a frequency or a division ordinal depending on whether the
-     * modifier is tempo synced, which is the same one lane the model's Rate
-     * control writes (AutomationInfo's makeHzRateInfo / makeSyncDivisionInfo).
-     * The LFO and the random walk share it; an envelope's stage lengths and a
-     * follower's time constants are not rates and have none.
+     * Its value is a frequency or a division ordinal depending on tempo
+     * sync, the same lane the model's Rate control writes
+     * (AutomationInfo's makeHzRateInfo / makeSyncDivisionInfo). The LFO and
+     * random walk share it; an envelope's stage lengths and a follower's
+     * time constants aren't rates and have none.
      */
     ParamId rate = INVALID_PARAM_ID;
 };
@@ -142,11 +140,11 @@ struct ParamModifier {
 /**
  * @brief One step of the order a block resolves in.
  *
- * Two kinds of thing resolve, and they depend on each other in both
- * directions: a parameter reads the modifiers linked to it, and a modifier
- * reads the Rate parameter driving it. One order over both is what lets a
- * macro drive an LFO's rate while the LFO drives a cutoff, in one pass, with
- * no second look and no fixed point.
+ * Parameters and modifiers depend on each other in both directions: a
+ * parameter reads the modifiers linked to it, a modifier reads the Rate
+ * parameter driving it. One order over both lets a macro drive an LFO's
+ * rate while the LFO drives a cutoff, in one pass, with no second look and
+ * no fixed point.
  */
 struct ParamStep {
     enum class Kind : std::uint8_t {
@@ -163,24 +161,25 @@ struct ParamStep {
 /**
  * @brief The parameters of one plan, with their scales, values and links.
  *
- * Flat and index-parallel: a ParamId indexes keys, specs and base alike. Links
- * are stored once, in one vector, with each parameter's own in a half-open
- * range of it.
+ * Flat and index-parallel: a ParamId indexes keys, specs and base alike.
+ * Links are stored once, in one vector, with each parameter's own in a
+ * half-open range of it.
  */
 struct ParamTable {
     /// The plan this was resolved against. Zero for a table belonging to no
-    /// plan, which is what a test that resolves parameters on their own has.
+    /// plan, which is what a test resolving parameters on their own has.
     std::uint64_t planFingerprint = 0;
 
     std::vector<ParamKey> keys;
     std::vector<ParamSpec> specs;
 
-    /// The stored value, normalised. What a knob, a control surface or a host
-    /// write moves, and what the parameter is where no automation covers it.
+    /// The stored value, normalised. What a knob, a control surface or a
+    /// host write moves, and what the parameter is where no automation
+    /// covers it.
     std::vector<float> base;
 
     /// Links reaching parameter i: links[linkOffsets[i], linkOffsets[i + 1]).
-    /// One vector rather than one per parameter, because almost no parameter
+    /// One vector rather than one per parameter, since almost no parameter
     /// has a link and a vector each would be an allocation each.
     std::vector<ParamLink> links;
     std::vector<int> linkOffsets;
@@ -190,10 +189,10 @@ struct ParamTable {
     /**
      * @brief The curves drawn on the modifiers, in one arena.
      *
-     * modCurvePoints[modCurveOffsets[i], modCurveOffsets[i + 1]) is the cycle
-     * modifier i has drawn on it, and empty is a modifier playing a built-in
-     * waveform, which is almost all of them. One arena rather than a vector
-     * each, for the reason the links have one.
+     * modCurvePoints[modCurveOffsets[i], modCurveOffsets[i + 1]) is the
+     * cycle modifier i has drawn on it; empty means a built-in waveform,
+     * which is almost all of them. One arena rather than a vector each, for
+     * the reason the links have one.
      */
     std::vector<magda::CurvePointData> modCurvePoints;
     std::vector<int> modCurveOffsets;
@@ -202,19 +201,19 @@ struct ParamTable {
      * @brief The lane playing over each parameter, in beats.
      *
      * Breakpoints, as the model draws them: curvePoints[curveOffsets[i],
-     * curveOffsets[i + 1]) is the curve over parameter i, and empty is a
-     * parameter with no lane, a lane with nothing on it, or a lane the model is
-     * not currently playing.
+     * curveOffsets[i + 1]) is the curve over parameter i; empty is a
+     * parameter with no lane, an empty lane, or one the model isn't
+     * currently playing.
      *
-     * Beats rather than samples, and not baked into segments here, because a
-     * block is what decides which part of a curve is being asked about and how
-     * long it lasts. A curve resolved into samples at publish time would be a
-     * curve that had to be republished every time the tempo moved.
+     * Beats rather than samples, and not baked into segments here, since a
+     * block decides which part of a curve is being asked about and how long
+     * it lasts -- resolving into samples at publish time would force a
+     * republish on every tempo move.
      *
-     * A clip-based lane arrives already flattened: its loops unrolled, its gaps
-     * held at the nearest clip edge, its overlaps resolved by the lane's own
-     * precedence. That is the model's answer to what the lane is (#1087), and
-     * the engine asks for it rather than working out a second one.
+     * A clip-based lane arrives already flattened (loops unrolled, gaps
+     * held at the nearest clip edge, overlaps resolved by the lane's own
+     * precedence) -- the model's answer to what the lane is (#1087), which
+     * the engine reuses rather than recomputing.
      */
     std::vector<magda::AutomationPoint> curvePoints;
     std::vector<int> curveOffsets;
@@ -222,43 +221,42 @@ struct ParamTable {
     /**
      * @brief The order the block resolves in.
      *
-     * Every parameter and every modifier, once each, arranged so that anything
-     * a step reads has already been resolved when it is reached. A macro
-     * driving an LFO's rate while the LFO drives a device parameter therefore
-     * needs no second pass and no fixed point, and the audio thread walks a
-     * vector.
+     * Every parameter and every modifier, once each, arranged so anything a
+     * step reads has already been resolved when reached -- a macro driving
+     * an LFO's rate while the LFO drives a device parameter needs no second
+     * pass and no fixed point, and the audio thread just walks a vector.
      */
     std::vector<ParamStep> order;
 
-    /// The most links any one parameter has, which is how much room the block
+    /// The most links any one parameter has, i.e. how much room the block
     /// resolver needs to gather one parameter's contributions.
     int maxLinksPerParam = 0;
 
     /**
      * @brief Identity of the layout: which parameter is at which ParamId.
      *
-     * What the plan's fingerprint is to the op values, one level down. A table
-     * is read by index, and by windows of indices, and two tables of the same
-     * size can still put different parameters at the same address: a macro that
-     * stopped being used in one scope and started being used in another leaves
-     * the count alone and moves every device window after it. Anything holding
-     * an index resolved against one table has to be able to tell that the other
-     * is not it.
+     * What the plan's fingerprint is to the op values, one level down. Two
+     * tables of the same size can still put different parameters at the
+     * same address (a macro dropped from one scope and picked up in another
+     * leaves the count alone but moves every device window after it), so
+     * anything holding an index resolved against one table must be able to
+     * tell the other table isn't it.
      *
-     * Over the keys in order, and nothing else. Values, links and the
-     * resolution order all change without moving a parameter, and a fingerprint
-     * that moved with them would turn every knob into a structural edit.
+     * Over the keys in order, and nothing else: values, links and the
+     * resolution order all change without moving a parameter, and a
+     * fingerprint that moved with them would turn every knob into a
+     * structural edit.
      */
     std::uint64_t layoutFingerprint = 0;
 
     /**
      * @brief Identity of the modifier list: which modifier is at which index.
      *
-     * What @ref layoutFingerprint is to the parameters, and needed separately
-     * because modifiers are not parameters: a scope gaining a page of them
+     * What @ref layoutFingerprint is to the parameters, needed separately
+     * because modifiers aren't parameters: a scope gaining a page of them
      * moves every modifier after it without touching a key, and the runtime
-     * holding each one's phase is indexed the same way. Without it a values
-     * publish would hand one LFO's phase to another.
+     * holding each one's phase is indexed the same way. Without it, a
+     * values publish would hand one LFO's phase to another.
      */
     std::uint64_t modifierFingerprint = 0;
 
@@ -272,13 +270,13 @@ struct ParamTable {
     /// parameter index, which is what lets a device be handed a window.
     std::unordered_map<DeviceKey, DeviceWindow, DeviceKeyHash> deviceWindows;
 
-    /// What the model asked for that this could not express, in the order it
-    /// was met. Never a silent drop, exactly as the plan compiler's are.
+    /// What the model asked for that this could not express, in the order
+    /// it was met. Never a silent drop, exactly as the plan compiler's are.
     std::vector<std::string> diagnostics;
 
-    /// Parameters by their key. Built with the table, because both the link
-    /// resolution that fills it and the lane binding that will read it (#2118)
-    /// ask the same question.
+    /// Parameters by their key. Built with the table, since both the link
+    /// resolution that fills it and the lane binding that will read it
+    /// (#2118) ask the same question.
     std::unordered_map<ParamKey, ParamId, ParamKeyHash> byKey;
 
     int size() const {
@@ -311,9 +309,9 @@ struct ParamTable {
 /**
  * @brief The layout fingerprint of a sequence of keys.
  *
- * Exposed because the thing that has to agree about a layout is not always the
- * thing that built it: an executor prepared against one table meets another,
- * and the question it asks is whether the parameter at an index is still the
+ * Exposed because the thing that has to agree about a layout isn't always
+ * the thing that built it: an executor prepared against one table meets
+ * another, and asks whether the parameter at an index is still the
  * parameter that index was resolved for.
  */
 std::uint64_t paramLayoutFingerprint(const std::vector<ParamKey>& keys);
@@ -321,9 +319,9 @@ std::uint64_t paramLayoutFingerprint(const std::vector<ParamKey>& keys);
 /**
  * @brief The modifier fingerprint of a modifier list.
  *
- * Exposed for the same reason the layout's is: the thing holding a modifier's
- * phase was prepared against one list and has to be able to tell that the
- * table it meets is not it.
+ * Exposed for the same reason the layout's is: the thing holding a
+ * modifier's phase was prepared against one list and has to be able to
+ * tell the table it meets is not it.
  */
 std::uint64_t paramModifierFingerprint(const std::vector<ParamModifier>& modifiers);
 

--- a/scripts/comment_ratio.py
+++ b/scripts/comment_ratio.py
@@ -76,11 +76,12 @@ def main() -> int:
     results = []
     total_comment = 0
     total_code = 0
+    min_code = 0 if args.paths else args.min_code
     for path in targets:
         comment, code = classify_lines(path.read_text(encoding="utf-8", errors="replace"))
         total_comment += comment
         total_code += code
-        if code >= args.min_code:
+        if code >= min_code:
             ratio = (comment / code * 100) if code else 0.0
             results.append((ratio, comment, code, path))
 

--- a/scripts/comment_ratio.py
+++ b/scripts/comment_ratio.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""
+Reports comment-to-code line ratio for C++ sources under magda/.
+
+Usage:
+  scripts/comment_ratio.py                  # overall ratio + worst offenders
+  scripts/comment_ratio.py --top 20         # show more offenders
+  scripts/comment_ratio.py --check 60       # exit 1 if any file with >60 code
+                                             # lines exceeds 60% comment ratio
+  scripts/comment_ratio.py path/to/file.hpp # ratio for a single file
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+SOURCE_EXTENSIONS = {".h", ".hpp", ".cpp", ".mm"}
+
+
+def classify_lines(text: str) -> tuple[int, int]:
+    """Returns (comment_lines, code_lines). Blank lines count as neither."""
+    comment_lines = 0
+    code_lines = 0
+    in_block_comment = False
+
+    for raw_line in text.split("\n"):
+        line = raw_line.strip()
+        if not line:
+            continue
+
+        if in_block_comment:
+            comment_lines += 1
+            if "*/" in line:
+                in_block_comment = False
+                rest = line.split("*/", 1)[1].strip()
+                if rest and not rest.startswith("//"):
+                    code_lines += 1
+            continue
+
+        if line.startswith("//"):
+            comment_lines += 1
+        elif line.startswith("/*"):
+            comment_lines += 1
+            if "*/" not in line:
+                in_block_comment = True
+        else:
+            code_lines += 1
+
+    return comment_lines, code_lines
+
+
+def iter_source_files(root: Path):
+    for path in root.rglob("*"):
+        if path.suffix not in SOURCE_EXTENSIONS:
+            continue
+        if "third_party" in path.parts or "cmake-build" in " ".join(path.parts):
+            continue
+        yield path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("paths", nargs="*", help="specific files to report on")
+    parser.add_argument("--top", type=int, default=10, help="how many worst offenders to list")
+    parser.add_argument("--min-code", type=int, default=60, help="ignore files with fewer code lines than this")
+    parser.add_argument("--check", type=int, metavar="PERCENT",
+                         help="exit 1 if any qualifying file exceeds this comment/code percent")
+    args = parser.parse_args()
+
+    if args.paths:
+        targets = [Path(p) for p in args.paths]
+    else:
+        targets = list(iter_source_files(ROOT / "magda"))
+
+    results = []
+    total_comment = 0
+    total_code = 0
+    for path in targets:
+        comment, code = classify_lines(path.read_text(encoding="utf-8", errors="replace"))
+        total_comment += comment
+        total_code += code
+        if code >= args.min_code:
+            ratio = (comment / code * 100) if code else 0.0
+            results.append((ratio, comment, code, path))
+
+    results.sort(key=lambda r: r[0], reverse=True)
+
+    if args.paths:
+        for ratio, comment, code, path in results:
+            print(f"{ratio:6.1f}%  {comment:6d} comment / {code:6d} code  {path}")
+        return 0
+
+    overall = (total_comment / total_code * 100) if total_code else 0.0
+    print(f"Overall: {total_comment} comment lines / {total_code} code lines = {overall:.1f}%\n")
+
+    print(f"Worst offenders (files with >= {args.min_code} code lines):")
+    for ratio, comment, code, path in results[: args.top]:
+        rel = path.relative_to(ROOT)
+        print(f"{ratio:6.1f}%  {comment:6d} comment / {code:6d} code  {rel}")
+
+    if args.check is not None:
+        offenders = [r for r in results if r[0] > args.check]
+        if offenders:
+            print(f"\nFAIL: {len(offenders)} file(s) exceed {args.check}% comment ratio")
+            return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- Cuts restated-code prose, rejected-alternatives narration, and worked examples from the ten headers named in #2353, moving genuinely useful architectural narrative into `docs/architecture/` for three of them.
- Adds `CLAUDE.md` at the repo root with the comment-density rule.
- Adds `scripts/comment_ratio.py` to measure the comment-to-code ratio going forward (`--top`, `--check PERCENT`, or specific files).

Comment-only changes: verified by diff that no code/declaration lines changed in any of the ten headers.

Closes #2353

## Test plan
- [x] CI build passes

https://claude.ai/code/session_01SdpaazGnnZqbN2sgJ9MEYV