### PR TITLE
Carry launch requests to the audio thread on a queue (#2305)

### DIFF
--- a/magda/engine/CMakeLists.txt
+++ b/magda/engine/CMakeLists.txt
@@ -106,6 +106,7 @@ add_library(magda_engine STATIC
     tap/ValueTap.hpp
     launch/LaunchHandle.cpp
     launch/LaunchHandle.hpp
+    launch/LaunchRequests.hpp
     launch/SessionLauncher.cpp
     launch/SessionLauncher.hpp
     transport/TempoMap.cpp

--- a/magda/engine/exec/EngineSession.cpp
+++ b/magda/engine/exec/EngineSession.cpp
@@ -158,7 +158,19 @@ void EngineSession::process(int numSamples, juce::AudioBuffer<float>& output) {
     output.clear();
 
     PublishedRender::ScopedAccess<farbot::ThreadType::realtime> render(published_);
-    if (*render == nullptr || numSamples <= 0)
+
+    // Nothing to launch into. Dropped rather than kept, for the reason a
+    // request for a slot that has gone is dropped: holding one until a plan
+    // appeared would start a clip at whatever moment that turned out to be.
+    if (*render == nullptr) {
+        requests_.drain([](const LaunchRequest&) {});
+        return;
+    }
+
+    // A callback of no samples is not a block, so nothing is applied and
+    // nothing is advanced: whatever has been asked is still asked at the next
+    // real one.
+    if (numSamples <= 0)
         return;
 
     // The executor asserts on a block longer than the plan was prepared for.
@@ -204,8 +216,9 @@ void EngineSession::process(int numSamples, juce::AudioBuffer<float>& output) {
 
         // Before the plan, and over every handle rather than the ones this plan
         // renders: a handle must see each block exactly once and a slot has two
-        // sources reading it (SessionLauncher.hpp).
-        advanceLaunchHandles(handles_, segment.block);
+        // sources reading it (SessionLauncher.hpp). What has been asked since
+        // the last block is applied in the same pass, ahead of every advance.
+        advanceLaunchHandles(handles_, requests_, segment.block);
 
         (*render)->executor.process(table, segment.block, piece);
 

--- a/magda/engine/exec/EngineSession.cpp
+++ b/magda/engine/exec/EngineSession.cpp
@@ -149,7 +149,7 @@ void EngineSession::publishClips(std::shared_ptr<const ClipSnapshot> clips) {
     // A null snapshot publishes an empty table rather than skipping, or the
     // previous one would keep handles for slots the engine no longer knows.
     static const ClipSnapshot kNothing;
-    store_.publishHandles(clips != nullptr ? *clips : kNothing, handles_);
+    store_.publishHandles(clips != nullptr ? *clips : kNothing, handles_, requests_);
 
     clips_.publish(std::move(clips));
 }

--- a/magda/engine/exec/EngineSession.cpp
+++ b/magda/engine/exec/EngineSession.cpp
@@ -159,17 +159,16 @@ void EngineSession::process(int numSamples, juce::AudioBuffer<float>& output) {
 
     PublishedRender::ScopedAccess<farbot::ThreadType::realtime> render(published_);
 
-    // Nothing to launch into. Dropped rather than kept, for the reason a
-    // request for a slot that has gone is dropped: holding one until a plan
-    // appeared would start a clip at whatever moment that turned out to be.
+    // Nothing to launch into. Dropped rather than kept: holding a request until
+    // a plan appeared would start a clip at whatever moment that turned out to
+    // be.
     if (*render == nullptr) {
         requests_.drain([](const LaunchRequest&) {});
         return;
     }
 
-    // A callback of no samples is not a block, so nothing is applied and
-    // nothing is advanced: whatever has been asked is still asked at the next
-    // real one.
+    // A callback of no samples is not a block, so whatever has been asked is
+    // still asked at the next real one.
     if (numSamples <= 0)
         return;
 
@@ -216,8 +215,8 @@ void EngineSession::process(int numSamples, juce::AudioBuffer<float>& output) {
 
         // Before the plan, and over every handle rather than the ones this plan
         // renders: a handle must see each block exactly once and a slot has two
-        // sources reading it (SessionLauncher.hpp). What has been asked since
-        // the last block is applied in the same pass, ahead of every advance.
+        // sources reading it. What has been asked since the last block is
+        // applied in the same pass, ahead of every advance (SessionLauncher.hpp).
         advanceLaunchHandles(handles_, requests_, segment.block);
 
         (*render)->executor.process(table, segment.block, piece);

--- a/magda/engine/exec/EngineSession.hpp
+++ b/magda/engine/exec/EngineSession.hpp
@@ -162,27 +162,21 @@ class EngineSession {
     /**
      * @brief Where a launch is asked for, from off the audio thread (#2305).
      *
-     * Ask through a `LaunchRequestQueue::Gesture`, which is what decides where
-     * one gesture ends: everything inside its scope reaches the audio thread
-     * together, so a scene launches on one sample.
-     *
-     * A request names a slot, so asking for one that does not exist is a
-     * request that does nothing rather than a pointer into a retired handle.
+     * Ask through a `LaunchRequestQueue::Gesture`: everything inside its scope
+     * reaches the audio thread together, so a scene launches on one sample.
+     * A request names a slot, so asking for one that has gone does nothing.
      */
     LaunchRequestQueue& launchRequests() {
         return requests_;
     }
 
     /**
-     * @brief The handle for one slot, or null. On the publishing thread.
+     * @brief The handle for @p key, or null. On the publishing thread.
      *
      * To read, and only to read: a handle is advanced on the audio thread, so
      * changing one from here races the callback. Every change goes through
-     * @ref launchRequests.
-     *
-     * Reading is itself only nearly safe, and it is what there is until the
-     * read-back path is built (#2303). Null until publishClips() has named the
-     * slot.
+     * @ref launchRequests. Reading is itself only nearly safe, and is what
+     * there is until the read-back path is built (#2303).
      */
     const LaunchHandle* launchHandle(const SlotKey& key) const {
         return store_.findHandle(key);

--- a/magda/engine/exec/EngineSession.hpp
+++ b/magda/engine/exec/EngineSession.hpp
@@ -160,15 +160,31 @@ class EngineSession {
     }
 
     /**
+     * @brief Where a launch is asked for, from off the audio thread (#2305).
+     *
+     * Ask through a `LaunchRequestQueue::Gesture`, which is what decides where
+     * one gesture ends: everything inside its scope reaches the audio thread
+     * together, so a scene launches on one sample.
+     *
+     * A request names a slot, so asking for one that does not exist is a
+     * request that does nothing rather than a pointer into a retired handle.
+     */
+    LaunchRequestQueue& launchRequests() {
+        return requests_;
+    }
+
+    /**
      * @brief The handle for one slot, or null. On the publishing thread.
      *
-     * What drives a launch until the request lane exists (#2305). A handle
-     * is advanced on the audio thread, so asking one for a change from here
-     * races the callback: safe only while nothing is rendering.
+     * To read, and only to read: a handle is advanced on the audio thread, so
+     * changing one from here races the callback. Every change goes through
+     * @ref launchRequests.
      *
-     * Null until publishClips() has named the slot.
+     * Reading is itself only nearly safe, and it is what there is until the
+     * read-back path is built (#2303). Null until publishClips() has named the
+     * slot.
      */
-    LaunchHandle* launchHandle(const SlotKey& key) const {
+    const LaunchHandle* launchHandle(const SlotKey& key) const {
         return store_.findHandle(key);
     }
 
@@ -309,6 +325,11 @@ class EngineSession {
 
     /// Where the audio thread finds a slot's handle. Travels with the clips.
     LaunchHandleFeed handles_;
+
+    /// What has been asked of those handles and not applied yet. Outside every
+    /// epoch, like the feed it is read beside: a request made while a plan was
+    /// being compiled is still a request when the new one is live.
+    LaunchRequestQueue requests_;
 
     /// The cursor. Not published and not swapped: it's where the timeline
     /// is, a property of the session rather than of any plan, and a plan

--- a/magda/engine/exec/RuntimeStateStore.cpp
+++ b/magda/engine/exec/RuntimeStateStore.cpp
@@ -320,7 +320,7 @@ RuntimeStateIds collectRuntimeStateIds(const std::vector<TrackInfo>& tracks,
 }
 
 std::shared_ptr<const LaunchHandleTable> RuntimeStateStore::publishHandles(
-    const ClipSnapshot& clips, LaunchHandleFeed& feed) {
+    const ClipSnapshot& clips, LaunchHandleFeed& feed, LaunchRequestQueue& requests) {
     auto table = std::make_shared<LaunchHandleTable>();
 
     for (const auto& track : clips.tracks)
@@ -328,10 +328,17 @@ std::shared_ptr<const LaunchHandleTable> RuntimeStateStore::publishHandles(
             const SlotKey key{track.trackId, slot.sceneIndex};
 
             auto& made = handles_[key];
-            if (made == nullptr)
-                made = std::make_unique<LaunchHandle>();
+            if (made.handle == nullptr) {
+                made.handle = std::make_unique<LaunchHandle>();
 
-            table->entries.push_back(LaunchHandleTable::Entry{key, made.get()});
+                // Counted up rather than reused, so a request stamped against
+                // the handle that was here can never match the one that
+                // replaced it (#2305 review).
+                made.incarnation = ++nextIncarnation_;
+            }
+
+            table->entries.push_back(
+                LaunchHandleTable::Entry{key, made.handle.get(), made.incarnation});
         }
 
     // Sorted on arrival, since a snapshot holds tracks by id and slots by
@@ -345,6 +352,16 @@ std::shared_ptr<const LaunchHandleTable> RuntimeStateStore::publishHandles(
         return publishedHandles_;
 
     publishedHandles_ = table;
+
+    // Before the swap, so a request made from here on carries the incarnation
+    // the table about to go live names. One made before it carries the old one
+    // and is dropped when it arrives, which is the whole point: the slot it was
+    // aimed at is not the slot that is there now.
+    std::map<SlotKey, std::uint64_t> incarnations;
+    for (const auto& entry : table->entries)
+        incarnations[entry.key] = entry.incarnation;
+
+    requests.setIncarnations(std::move(incarnations));
 
     // The swap waits for the block the callback is in, so afterwards a handle
     // this table does not name is unreachable from the audio thread.
@@ -361,7 +378,7 @@ std::shared_ptr<const LaunchHandleTable> RuntimeStateStore::publishHandles(
 
 LaunchHandle* RuntimeStateStore::findHandle(const SlotKey& key) const {
     const auto it = handles_.find(key);
-    return it == handles_.end() ? nullptr : it->second.get();
+    return it == handles_.end() ? nullptr : it->second.handle.get();
 }
 
 ValueTap* RuntimeStateStore::valueTap(const ParamKey& key) const {

--- a/magda/engine/exec/RuntimeStateStore.cpp
+++ b/magda/engine/exec/RuntimeStateStore.cpp
@@ -329,11 +329,9 @@ std::shared_ptr<const LaunchHandleTable> RuntimeStateStore::publishHandles(
 
             auto& made = handles_[key];
             if (made.handle == nullptr) {
-                made.handle = std::make_unique<LaunchHandle>();
-
                 // Counted up rather than reused, so a request stamped against
-                // the handle that was here can never match the one that
-                // replaced it (#2305 review).
+                // the handle that was here can never match its replacement.
+                made.handle = std::make_unique<LaunchHandle>();
                 made.incarnation = ++nextIncarnation_;
             }
 
@@ -354,9 +352,8 @@ std::shared_ptr<const LaunchHandleTable> RuntimeStateStore::publishHandles(
     publishedHandles_ = table;
 
     // Before the swap, so a request made from here on carries the incarnation
-    // the table about to go live names. One made before it carries the old one
-    // and is dropped when it arrives, which is the whole point: the slot it was
-    // aimed at is not the slot that is there now.
+    // the table about to go live names, and one made before it is dropped when
+    // it arrives.
     std::map<SlotKey, std::uint64_t> incarnations;
     for (const auto& entry : table->entries)
         incarnations[entry.key] = entry.incarnation;

--- a/magda/engine/exec/RuntimeStateStore.hpp
+++ b/magda/engine/exec/RuntimeStateStore.hpp
@@ -254,15 +254,19 @@ class RuntimeStateStore {
      * Nothing is swapped or retired when the slots haven't moved, so a drag
      * republishing the snapshot at gesture speed with the same slots is
      * free.
+     *
+     * @p requests is told the incarnations this publish assigns, so a launch
+     * asked for against a handle that has gone is dropped rather than applied
+     * to the one that replaced it (#2305).
      */
     std::shared_ptr<const LaunchHandleTable> publishHandles(const ClipSnapshot& clips,
                                                             LaunchHandleFeed& feed,
                                                             LaunchRequestQueue& requests);
 
-    /// The handle for one slot, or null when no published snapshot names it.
+    /// @brief The handle for @p key, or null when no published snapshot names it.
     LaunchHandle* findHandle(const SlotKey& key) const;
 
-    /// Objects currently owned, for tests and diagnostics.
+    /// @brief Objects currently owned, for tests and diagnostics.
     std::size_t size() const;
 
   private:
@@ -285,9 +289,8 @@ class RuntimeStateStore {
     std::unordered_map<TrackId, std::unique_ptr<EngineAudioSource>> sessionAudio_;
     std::unordered_map<TrackId, std::unique_ptr<EngineMidiSource>> sessionMidi_;
 
-    /// A slot's handle and which handle it is. The incarnation is what tells a
-    /// request made against the clip that was here from one made against the
-    /// clip that replaced it, since the key is the same either way (#2305).
+    /// A slot's handle and which handle it is, since a request made against the
+    /// clip that was here has the same key as one made against its replacement.
     struct Slot {
         std::unique_ptr<LaunchHandle> handle;
         std::uint64_t incarnation = 0;
@@ -299,7 +302,7 @@ class RuntimeStateStore {
     std::map<SlotKey, Slot> handles_;
 
     /// Never reused, so an incarnation names one handle for the life of the
-    /// session rather than one handle per slot at a time.
+    /// session.
     std::uint64_t nextIncarnation_ = 0;
 
     /// What was last published, so a publish that changes nothing is skipped.

--- a/magda/engine/exec/RuntimeStateStore.hpp
+++ b/magda/engine/exec/RuntimeStateStore.hpp
@@ -256,7 +256,8 @@ class RuntimeStateStore {
      * free.
      */
     std::shared_ptr<const LaunchHandleTable> publishHandles(const ClipSnapshot& clips,
-                                                            LaunchHandleFeed& feed);
+                                                            LaunchHandleFeed& feed,
+                                                            LaunchRequestQueue& requests);
 
     /// The handle for one slot, or null when no published snapshot names it.
     LaunchHandle* findHandle(const SlotKey& key) const;
@@ -284,10 +285,22 @@ class RuntimeStateStore {
     std::unordered_map<TrackId, std::unique_ptr<EngineAudioSource>> sessionAudio_;
     std::unordered_map<TrackId, std::unique_ptr<EngineMidiSource>> sessionMidi_;
 
+    /// A slot's handle and which handle it is. The incarnation is what tells a
+    /// request made against the clip that was here from one made against the
+    /// clip that replaced it, since the key is the same either way (#2305).
+    struct Slot {
+        std::unique_ptr<LaunchHandle> handle;
+        std::uint64_t incarnation = 0;
+    };
+
     /// One per slot rather than per track: a slot's loop phase and played
     /// range have to survive another slot playing in between. Made and
     /// retired by publishHandles() alone (#2301).
-    std::map<SlotKey, std::unique_ptr<LaunchHandle>> handles_;
+    std::map<SlotKey, Slot> handles_;
+
+    /// Never reused, so an incarnation names one handle for the life of the
+    /// session rather than one handle per slot at a time.
+    std::uint64_t nextIncarnation_ = 0;
 
     /// What was last published, so a publish that changes nothing is skipped.
     std::shared_ptr<const LaunchHandleTable> publishedHandles_;

--- a/magda/engine/launch/LaunchHandle.hpp
+++ b/magda/engine/launch/LaunchHandle.hpp
@@ -23,11 +23,9 @@
  * header is explicit that the fork owns the state and MAGDA only sends it
  * commands. Replacing that state is what this is for.
  *
- * Threading is not decided here, and still is not: this is a plain object,
- * requested and then advanced, with no synchronisation of its own. What made
- * that safe is that nothing calls it from two threads. The audio thread
- * advances it; every request reaches it down the queue in LaunchRequests.hpp
- * and is applied on that same thread, in the same pass, before any advance
+ * No synchronisation of its own, because nothing calls it from two threads: the
+ * audio thread advances it, and every request reaches it down the queue in
+ * LaunchRequests.hpp and is applied on that same thread ahead of the advance
  * (#2305). Its lifetime is the plan-swap epoch's, in
  * RuntimeStateStore::publishHandles.
  */

--- a/magda/engine/launch/LaunchHandle.hpp
+++ b/magda/engine/launch/LaunchHandle.hpp
@@ -23,10 +23,13 @@
  * header is explicit that the fork owns the state and MAGDA only sends it
  * commands. Replacing that state is what this is for.
  *
- * Threading is deliberately not decided here. A handle is advanced by one
- * caller and its requests come from another, and how those two meet is
- * #2305's, along with who owns the handle's lifetime. Until then this is a
- * plain object: request, then advance.
+ * Threading is not decided here, and still is not: this is a plain object,
+ * requested and then advanced, with no synchronisation of its own. What made
+ * that safe is that nothing calls it from two threads. The audio thread
+ * advances it; every request reaches it down the queue in LaunchRequests.hpp
+ * and is applied on that same thread, in the same pass, before any advance
+ * (#2305). Its lifetime is the plan-swap epoch's, in
+ * RuntimeStateStore::publishHandles.
  */
 
 namespace magda::engine {

--- a/magda/engine/launch/LaunchRequests.hpp
+++ b/magda/engine/launch/LaunchRequests.hpp
@@ -4,6 +4,7 @@
 #include <atomic>
 #include <cassert>
 #include <cstdint>
+#include <map>
 #include <optional>
 
 #include "launch/LaunchHandle.hpp"
@@ -67,6 +68,12 @@ struct LaunchRequest {
     /// The slot whose run a play joins, for a scene launch. Absent for a plain
     /// launch.
     std::optional<SlotKey> syncTo;
+
+    /// Which handle of @ref key this was asked of. Stamped when the request is
+    /// made and checked against the live table when it is applied, so a slot
+    /// emptied and refilled between the two does not launch the clip that
+    /// replaced the one the user clicked (#2305 review).
+    std::uint64_t incarnation = 0;
 };
 
 /**
@@ -145,6 +152,20 @@ class LaunchRequestQueue {
             queue_.push(LaunchRequest{key, LaunchRequest::Kind::loop, beats, {}});
         }
 
+        /// Every slot named in one call, in phase with @p leader, which is what
+        /// a scene launch is. Here rather than left to the caller because the
+        /// order matters: the leader's own launch has to be asked for first, or
+        /// the followers join the run it is about to leave.
+        template <typename Keys>
+        void playScene(const SlotKey& leader, const Keys& followers,
+                       std::optional<double> monotonicBeat = {}) {
+            play(leader, monotonicBeat);
+
+            for (const auto& follower : followers)
+                if (!(follower == leader))
+                    playSynced(follower, leader, monotonicBeat);
+        }
+
       private:
         LaunchRequestQueue& queue_;
     };
@@ -177,6 +198,24 @@ class LaunchRequestQueue {
         return overflows_;
     }
 
+    /**
+     * @brief Which handle each slot is on, as the publishing thread last saw it.
+     *
+     * Called by RuntimeStateStore::publishHandles with the table it is about to
+     * publish, so a request made after it carries the new incarnation and one
+     * made before it carries the old. On the publishing thread.
+     */
+    void setIncarnations(std::map<SlotKey, std::uint64_t> incarnations) {
+        incarnations_ = std::move(incarnations);
+    }
+
+    /// What @ref setIncarnations last said about @p key, or zero for a slot it
+    /// has never named. On the publishing thread.
+    std::uint64_t incarnationOf(const SlotKey& key) const {
+        const auto it = incarnations_.find(key);
+        return it == incarnations_.end() ? 0 : it->second;
+    }
+
   private:
     void beginGesture() {
         // Not nestable, and an assertion rather than a counter: the inner one's
@@ -189,9 +228,14 @@ class LaunchRequestQueue {
         overflowed_ = false;
     }
 
-    void push(const LaunchRequest& request) {
+    void push(LaunchRequest request) {
         if (overflowed_)
             return;
+
+        // Stamped here rather than by the caller: the map is the writer's own,
+        // and the writer is the thread that publishes handles, so what it knows
+        // about a slot is what the table it published says.
+        request.incarnation = incarnationOf(request.key);
 
         // Checked before the write and not at the commit: the slots the reader
         // still owns are the ones a full ring would be writing over, and rolling
@@ -239,6 +283,10 @@ class LaunchRequestQueue {
     /// Whether a gesture is open, so a nested one is caught rather than
     /// silently publishing half of the one it is inside.
     bool inGesture_ = false;
+
+    /// The writer's own view of which handle each slot is on. Never read on the
+    /// audio thread, which compares against the published table instead.
+    std::map<SlotKey, std::uint64_t> incarnations_;
 };
 
 }  // namespace magda::engine

--- a/magda/engine/launch/LaunchRequests.hpp
+++ b/magda/engine/launch/LaunchRequests.hpp
@@ -13,34 +13,24 @@
  * @file LaunchRequests.hpp
  * @brief How a launch reaches the audio thread from off it (#2305).
  *
- * A launch is an event, not a state. Two launches of one slot are two
- * retriggers and a launch followed by a loop length is an order, so what
- * carries them is a queue: written once, read once, never re-read. The engine's
- * other lanes publish a value whole because what they carry is a value, and a
- * request put through one would be applied again every block until something
- * overwrote it.
+ * A queue rather than one of the engine's published values, because a launch is
+ * an event: two of them are two retriggers, and a loop length before a play is
+ * an order. A value would be re-applied every block until something overwrote
+ * it.
  *
- * A request names a slot and never a handle. That is what keeps it out of the
- * lifetime question entirely: handles are made and retired by
- * RuntimeStateStore::publishHandles() on the plan-swap epoch, and a request for
- * a slot whose handle has gone finds nothing and does nothing. Nothing here can
- * outlive anything, because nothing here points at anything.
+ * A request names a slot and never a handle, so nothing here can outlive
+ * anything. Handles are made and retired by
+ * RuntimeStateStore::publishHandles() on the plan-swap epoch.
  *
- * One writer and one reader. The writer is whichever thread publishes, which is
- * the single non-realtime thread EngineSession.hpp already names; the reader is
- * the audio thread, in `advanceLaunchHandles`, ahead of every advance in the
- * same pass (SessionLauncher.hpp).
+ * Written by the publishing thread, read by the audio thread in
+ * `advanceLaunchHandles` (SessionLauncher.hpp).
  */
 
 namespace magda::engine {
 
-/**
- * @brief One thing asked of one slot.
- *
- * The four the handle takes, in the shape it takes them. A play carries the
- * slot whose run to join rather than a handle, because the run to join is the
- * one that handle holds when the request is applied, not when it was made.
- */
+/// One thing asked of one slot. A play names the slot whose run to join rather
+/// than a handle, so the run it joins is the one that handle holds when the
+/// request is applied.
 struct LaunchRequest {
     enum class Kind : std::uint8_t {
         /// LaunchHandle::play, or playSynced when @ref syncTo is set.
@@ -51,9 +41,9 @@ struct LaunchRequest {
         /// arrangement.
         backToArrangement,
 
-        /// LaunchHandle::setLooping. Here rather than on a channel of its own
-        /// so that it keeps its order against the launches around it: a loop
-        /// length set for a clip about to start has to arrive first.
+        /// LaunchHandle::setLooping. On this lane rather than beside it so it
+        /// keeps its order: a length set for a clip about to start has to
+        /// arrive first.
         loop,
     };
 
@@ -69,10 +59,9 @@ struct LaunchRequest {
     /// launch.
     std::optional<SlotKey> syncTo;
 
-    /// Which handle of @ref key this was asked of. Stamped when the request is
-    /// made and checked against the live table when it is applied, so a slot
-    /// emptied and refilled between the two does not launch the clip that
-    /// replaced the one the user clicked (#2305 review).
+    /// Which handle of @ref key this was asked of, checked against the live
+    /// table when it is applied: a slot emptied and refilled in between must
+    /// not launch the clip that replaced the one the user clicked.
     std::uint64_t incarnation = 0;
 };
 
@@ -80,37 +69,25 @@ struct LaunchRequest {
  * @brief The lane requests travel down, and what makes a scene one event.
  *
  * A fixed ring, so nothing allocates on either side. The writer fills slots
- * privately and publishes its cursor once per gesture, which is what makes a
- * scene atomic: the audio thread either sees every slot of it or none, so eight
- * clips launched together start on one sample rather than over eight
- * consecutive blocks.
+ * privately and publishes its cursor once per gesture, so the audio thread sees
+ * every slot of a scene or none of it.
  */
 class LaunchRequestQueue {
-    // Both cursors are read by the thread that does not write them. A lock
-    // taken here would be taken on the audio thread, which is the one thing
-    // this side of the engine does not do.
     static_assert(std::atomic<std::uint64_t>::is_always_lock_free,
                   "the launch lane's cursors are read on the audio thread");
 
   public:
-    /// Requests the ring holds between a commit and the audio thread reading
-    /// them. A gesture is at most one request per slot in the project, and a
-    /// block is milliseconds, so this is a bound on a burst rather than on a
-    /// session.
+    /// Outstanding requests, not lifetime ones: a bound on a burst between two
+    /// blocks.
     static constexpr int kCapacity = 1024;
 
     /**
      * @brief One gesture: what is asked through it arrives together or not at
-     *        all.
-     *
-     * On the publishing thread. Committed when it goes out of scope, which is
-     * where the boundary of a gesture is stated rather than left to whoever
-     * remembers to call something.
+     *        all. On the publishing thread, committed when it goes out of scope.
      *
      * A gesture too large for the ring is dropped whole and counted (@ref
-     * overflows). Half a scene launching is worse than none: the tracks that
-     * made it would be a bar ahead of the ones that did not for as long as they
-     * played.
+     * overflows), because half a scene launching leaves those tracks a bar
+     * ahead of the rest for as long as they play.
      */
     class Gesture {
       public:
@@ -127,35 +104,58 @@ class LaunchRequestQueue {
         Gesture(Gesture&&) = delete;
         Gesture& operator=(Gesture&&) = delete;
 
-        /// Start @p key playing, at @p monotonicBeat or as soon as possible.
+        /**
+         * @brief Start @p key playing.
+         * @param monotonicBeat When to start, or nothing for as soon as
+         *        possible.
+         */
         void play(const SlotKey& key, std::optional<double> monotonicBeat = {}) {
             queue_.push(LaunchRequest{key, LaunchRequest::Kind::play, monotonicBeat, {}});
         }
 
-        /// Start @p key in phase with @p with, which is what a scene launch is.
+        /**
+         * @brief Start @p key in phase with @p with, which is what a scene
+         *        launch is made of.
+         * @param monotonicBeat When to start, or nothing for as soon as
+         *        possible.
+         */
         void playSynced(const SlotKey& key, const SlotKey& with,
                         std::optional<double> monotonicBeat = {}) {
             queue_.push(LaunchRequest{key, LaunchRequest::Kind::play, monotonicBeat, with});
         }
 
+        /**
+         * @brief Stop @p key, leaving its track held by the session (#2302).
+         * @param monotonicBeat When to stop, or nothing for as soon as
+         *        possible.
+         */
         void stop(const SlotKey& key, std::optional<double> monotonicBeat = {}) {
             queue_.push(LaunchRequest{key, LaunchRequest::Kind::stop, monotonicBeat, {}});
         }
 
-        /// Stop @p key and give its track back to the arrangement (#2302).
+        /// @brief Stop @p key and give its track back to the arrangement (#2302).
         void backToArrangement(const SlotKey& key) {
             queue_.push(LaunchRequest{key, LaunchRequest::Kind::backToArrangement, {}, {}});
         }
 
-        /// Re-trigger @p key every @p beats, or stop it looping.
+        /**
+         * @brief Re-trigger @p key every @p beats.
+         * @param beats The interval, or nothing to stop looping.
+         */
         void setLooping(const SlotKey& key, std::optional<double> beats) {
             queue_.push(LaunchRequest{key, LaunchRequest::Kind::loop, beats, {}});
         }
 
-        /// Every slot named in one call, in phase with @p leader, which is what
-        /// a scene launch is. Here rather than left to the caller because the
-        /// order matters: the leader's own launch has to be asked for first, or
-        /// the followers join the run it is about to leave.
+        /**
+         * @brief A scene: every slot of @p followers in phase with @p leader.
+         *
+         * Here rather than left to the caller because the leader's own launch
+         * has to be asked for first, or the followers join the run it is about
+         * to leave.
+         *
+         * @param monotonicBeat When to start, or nothing for as soon as
+         *        possible.
+         */
         template <typename Keys>
         void playScene(const SlotKey& leader, const Keys& followers,
                        std::optional<double> monotonicBeat = {}) {
@@ -173,9 +173,9 @@ class LaunchRequestQueue {
     /**
      * @brief Read everything committed since the last call, in order.
      *
-     * On the audio thread. @p fn is called once per request; it must not
-     * allocate or block, which is the same rule everything else on this thread
-     * follows.
+     * On the audio thread.
+     *
+     * @param fn Called once per request. Must not allocate or block.
      */
     template <typename Fn> void drain(const Fn& fn) {
         const auto end = written_.load(std::memory_order_acquire);
@@ -190,37 +190,36 @@ class LaunchRequestQueue {
     /**
      * @brief Gestures dropped because the ring was full.
      *
-     * Counted rather than left silent, for the reason the clock counts its loop
-     * wraps: a launch that quietly did not happen is otherwise blamed on the
-     * audio device. On the publishing thread.
+     * Counted rather than left silent: a launch that quietly did not happen is
+     * otherwise blamed on the audio device. On the publishing thread.
      */
     int overflows() const {
         return overflows_;
     }
 
     /**
-     * @brief Which handle each slot is on, as the publishing thread last saw it.
+     * @brief Say which handle each slot is on.
      *
      * Called by RuntimeStateStore::publishHandles with the table it is about to
      * publish, so a request made after it carries the new incarnation and one
-     * made before it carries the old. On the publishing thread.
+     * made before carries the old. On the publishing thread.
      */
     void setIncarnations(std::map<SlotKey, std::uint64_t> incarnations) {
         incarnations_ = std::move(incarnations);
     }
 
-    /// What @ref setIncarnations last said about @p key, or zero for a slot it
-    /// has never named. On the publishing thread.
+    /// @brief What @ref setIncarnations last said about @p key, or zero for a
+    ///        slot it has never named.
     std::uint64_t incarnationOf(const SlotKey& key) const {
         const auto it = incarnations_.find(key);
         return it == incarnations_.end() ? 0 : it->second;
     }
 
   private:
+    /// @brief Open a gesture, taking the writer's cursor from the last commit.
     void beginGesture() {
-        // Not nestable, and an assertion rather than a counter: the inner one's
-        // commit would publish the outer's half-written gesture, which is the
-        // one thing the type exists to prevent.
+        // Not nestable: the inner commit would publish the outer's half-written
+        // gesture.
         assert(!inGesture_);
         inGesture_ = true;
 
@@ -228,18 +227,18 @@ class LaunchRequestQueue {
         overflowed_ = false;
     }
 
+    /// @brief Add @p request to the open gesture, or mark it too large to fit.
     void push(LaunchRequest request) {
         if (overflowed_)
             return;
 
-        // Stamped here rather than by the caller: the map is the writer's own,
-        // and the writer is the thread that publishes handles, so what it knows
-        // about a slot is what the table it published says.
+        // Stamped here rather than by the caller: the writer is the thread that
+        // publishes handles, so its map is what the live table says.
         request.incarnation = incarnationOf(request.key);
 
-        // Checked before the write and not at the commit: the slots the reader
-        // still owns are the ones a full ring would be writing over, and rolling
-        // a cursor back afterwards does not put their contents back.
+        // Before the write, not at the commit: a full ring would be writing over
+        // slots the reader still owns, and rolling the cursor back afterwards
+        // does not put their contents back.
         if (writing_ - consumed_.load(std::memory_order_acquire) >=
             static_cast<std::uint64_t>(kCapacity)) {
             overflowed_ = true;
@@ -250,6 +249,7 @@ class LaunchRequestQueue {
         ++writing_;
     }
 
+    /// @brief Publish the open gesture, or count it if it overflowed.
     void commitGesture() {
         inGesture_ = false;
 
@@ -266,26 +266,23 @@ class LaunchRequestQueue {
     /// Committed by the writer, read by the audio thread.
     std::atomic<std::uint64_t> written_{0};
 
-    /// Committed by the audio thread, read by the writer, and the whole of what
-    /// stops a gesture writing over requests that have not been read.
+    /// Committed by the audio thread, and what stops a gesture writing over
+    /// requests that have not been read.
     std::atomic<std::uint64_t> consumed_{0};
 
-    /// The writer's own cursor, ahead of @ref written_ for as long as a gesture
-    /// is open.
+    /// The writer's own cursor, ahead of @ref written_ while a gesture is open.
     std::uint64_t writing_ = 0;
 
-    /// The reader's own, so draining does not have to read back what it wrote.
+    /// The reader's own.
     std::uint64_t read_ = 0;
 
     bool overflowed_ = false;
     int overflows_ = 0;
 
-    /// Whether a gesture is open, so a nested one is caught rather than
-    /// silently publishing half of the one it is inside.
     bool inGesture_ = false;
 
-    /// The writer's own view of which handle each slot is on. Never read on the
-    /// audio thread, which compares against the published table instead.
+    /// The writer's own view. The audio thread compares against the published
+    /// table instead.
     std::map<SlotKey, std::uint64_t> incarnations_;
 };
 

--- a/magda/engine/launch/LaunchRequests.hpp
+++ b/magda/engine/launch/LaunchRequests.hpp
@@ -1,0 +1,244 @@
+#pragma once
+
+#include <array>
+#include <atomic>
+#include <cassert>
+#include <cstdint>
+#include <optional>
+
+#include "launch/LaunchHandle.hpp"
+
+/**
+ * @file LaunchRequests.hpp
+ * @brief How a launch reaches the audio thread from off it (#2305).
+ *
+ * A launch is an event, not a state. Two launches of one slot are two
+ * retriggers and a launch followed by a loop length is an order, so what
+ * carries them is a queue: written once, read once, never re-read. The engine's
+ * other lanes publish a value whole because what they carry is a value, and a
+ * request put through one would be applied again every block until something
+ * overwrote it.
+ *
+ * A request names a slot and never a handle. That is what keeps it out of the
+ * lifetime question entirely: handles are made and retired by
+ * RuntimeStateStore::publishHandles() on the plan-swap epoch, and a request for
+ * a slot whose handle has gone finds nothing and does nothing. Nothing here can
+ * outlive anything, because nothing here points at anything.
+ *
+ * One writer and one reader. The writer is whichever thread publishes, which is
+ * the single non-realtime thread EngineSession.hpp already names; the reader is
+ * the audio thread, in `advanceLaunchHandles`, ahead of every advance in the
+ * same pass (SessionLauncher.hpp).
+ */
+
+namespace magda::engine {
+
+/**
+ * @brief One thing asked of one slot.
+ *
+ * The four the handle takes, in the shape it takes them. A play carries the
+ * slot whose run to join rather than a handle, because the run to join is the
+ * one that handle holds when the request is applied, not when it was made.
+ */
+struct LaunchRequest {
+    enum class Kind : std::uint8_t {
+        /// LaunchHandle::play, or playSynced when @ref syncTo is set.
+        play,
+        stop,
+
+        /// LaunchHandle::releaseSection: stop, and give the track back to its
+        /// arrangement.
+        backToArrangement,
+
+        /// LaunchHandle::setLooping. Here rather than on a channel of its own
+        /// so that it keeps its order against the launches around it: a loop
+        /// length set for a clip about to start has to arrive first.
+        loop,
+    };
+
+    SlotKey key;
+    Kind kind = Kind::play;
+
+    /// The monotonic beat to do it on, or nothing for the next sample. For
+    /// Kind::loop this is the re-trigger interval instead, absent to stop
+    /// looping.
+    std::optional<double> position;
+
+    /// The slot whose run a play joins, for a scene launch. Absent for a plain
+    /// launch.
+    std::optional<SlotKey> syncTo;
+};
+
+/**
+ * @brief The lane requests travel down, and what makes a scene one event.
+ *
+ * A fixed ring, so nothing allocates on either side. The writer fills slots
+ * privately and publishes its cursor once per gesture, which is what makes a
+ * scene atomic: the audio thread either sees every slot of it or none, so eight
+ * clips launched together start on one sample rather than over eight
+ * consecutive blocks.
+ */
+class LaunchRequestQueue {
+    // Both cursors are read by the thread that does not write them. A lock
+    // taken here would be taken on the audio thread, which is the one thing
+    // this side of the engine does not do.
+    static_assert(std::atomic<std::uint64_t>::is_always_lock_free,
+                  "the launch lane's cursors are read on the audio thread");
+
+  public:
+    /// Requests the ring holds between a commit and the audio thread reading
+    /// them. A gesture is at most one request per slot in the project, and a
+    /// block is milliseconds, so this is a bound on a burst rather than on a
+    /// session.
+    static constexpr int kCapacity = 1024;
+
+    /**
+     * @brief One gesture: what is asked through it arrives together or not at
+     *        all.
+     *
+     * On the publishing thread. Committed when it goes out of scope, which is
+     * where the boundary of a gesture is stated rather than left to whoever
+     * remembers to call something.
+     *
+     * A gesture too large for the ring is dropped whole and counted (@ref
+     * overflows). Half a scene launching is worse than none: the tracks that
+     * made it would be a bar ahead of the ones that did not for as long as they
+     * played.
+     */
+    class Gesture {
+      public:
+        explicit Gesture(LaunchRequestQueue& queue) : queue_(queue) {
+            queue_.beginGesture();
+        }
+
+        ~Gesture() {
+            queue_.commitGesture();
+        }
+
+        Gesture(const Gesture&) = delete;
+        Gesture& operator=(const Gesture&) = delete;
+        Gesture(Gesture&&) = delete;
+        Gesture& operator=(Gesture&&) = delete;
+
+        /// Start @p key playing, at @p monotonicBeat or as soon as possible.
+        void play(const SlotKey& key, std::optional<double> monotonicBeat = {}) {
+            queue_.push(LaunchRequest{key, LaunchRequest::Kind::play, monotonicBeat, {}});
+        }
+
+        /// Start @p key in phase with @p with, which is what a scene launch is.
+        void playSynced(const SlotKey& key, const SlotKey& with,
+                        std::optional<double> monotonicBeat = {}) {
+            queue_.push(LaunchRequest{key, LaunchRequest::Kind::play, monotonicBeat, with});
+        }
+
+        void stop(const SlotKey& key, std::optional<double> monotonicBeat = {}) {
+            queue_.push(LaunchRequest{key, LaunchRequest::Kind::stop, monotonicBeat, {}});
+        }
+
+        /// Stop @p key and give its track back to the arrangement (#2302).
+        void backToArrangement(const SlotKey& key) {
+            queue_.push(LaunchRequest{key, LaunchRequest::Kind::backToArrangement, {}, {}});
+        }
+
+        /// Re-trigger @p key every @p beats, or stop it looping.
+        void setLooping(const SlotKey& key, std::optional<double> beats) {
+            queue_.push(LaunchRequest{key, LaunchRequest::Kind::loop, beats, {}});
+        }
+
+      private:
+        LaunchRequestQueue& queue_;
+    };
+
+    /**
+     * @brief Read everything committed since the last call, in order.
+     *
+     * On the audio thread. @p fn is called once per request; it must not
+     * allocate or block, which is the same rule everything else on this thread
+     * follows.
+     */
+    template <typename Fn> void drain(const Fn& fn) {
+        const auto end = written_.load(std::memory_order_acquire);
+
+        for (auto at = read_; at != end; ++at)
+            fn(ring_[static_cast<std::size_t>(at % kCapacity)]);
+
+        read_ = end;
+        consumed_.store(read_, std::memory_order_release);
+    }
+
+    /**
+     * @brief Gestures dropped because the ring was full.
+     *
+     * Counted rather than left silent, for the reason the clock counts its loop
+     * wraps: a launch that quietly did not happen is otherwise blamed on the
+     * audio device. On the publishing thread.
+     */
+    int overflows() const {
+        return overflows_;
+    }
+
+  private:
+    void beginGesture() {
+        // Not nestable, and an assertion rather than a counter: the inner one's
+        // commit would publish the outer's half-written gesture, which is the
+        // one thing the type exists to prevent.
+        assert(!inGesture_);
+        inGesture_ = true;
+
+        writing_ = written_.load(std::memory_order_relaxed);
+        overflowed_ = false;
+    }
+
+    void push(const LaunchRequest& request) {
+        if (overflowed_)
+            return;
+
+        // Checked before the write and not at the commit: the slots the reader
+        // still owns are the ones a full ring would be writing over, and rolling
+        // a cursor back afterwards does not put their contents back.
+        if (writing_ - consumed_.load(std::memory_order_acquire) >=
+            static_cast<std::uint64_t>(kCapacity)) {
+            overflowed_ = true;
+            return;
+        }
+
+        ring_[static_cast<std::size_t>(writing_ % kCapacity)] = request;
+        ++writing_;
+    }
+
+    void commitGesture() {
+        inGesture_ = false;
+
+        if (overflowed_) {
+            ++overflows_;
+            return;
+        }
+
+        written_.store(writing_, std::memory_order_release);
+    }
+
+    std::array<LaunchRequest, kCapacity> ring_{};
+
+    /// Committed by the writer, read by the audio thread.
+    std::atomic<std::uint64_t> written_{0};
+
+    /// Committed by the audio thread, read by the writer, and the whole of what
+    /// stops a gesture writing over requests that have not been read.
+    std::atomic<std::uint64_t> consumed_{0};
+
+    /// The writer's own cursor, ahead of @ref written_ for as long as a gesture
+    /// is open.
+    std::uint64_t writing_ = 0;
+
+    /// The reader's own, so draining does not have to read back what it wrote.
+    std::uint64_t read_ = 0;
+
+    bool overflowed_ = false;
+    int overflows_ = 0;
+
+    /// Whether a gesture is open, so a nested one is caught rather than
+    /// silently publishing half of the one it is inside.
+    bool inGesture_ = false;
+};
+
+}  // namespace magda::engine

--- a/magda/engine/launch/SessionLauncher.cpp
+++ b/magda/engine/launch/SessionLauncher.cpp
@@ -35,16 +35,15 @@ LaunchHandle* LaunchHandleTable::find(const SlotKey& key) const {
 
 namespace {
 
-/// One request against the table that is live now. A slot the table does not
-/// name is one emptied between the ask and this block, and there is nothing
-/// left to ask.
-///
-/// The incarnation is the rest of that question. A slot emptied and refilled
-/// between the ask and this block is the same key on a different clip, and
-/// applying the launch to it would start something the user never clicked
-/// (#2305 review). The key alone cannot tell those apart; the incarnation can,
-/// and it is a number rather than a pointer, so nothing here holds a handle
-/// that could have been retired.
+/**
+ * @brief Apply @p request against the table that is live now.
+ *
+ * Dropped when the slot has gone, and equally when it was emptied and refilled:
+ * that is the same key on a different clip, and launching it would start
+ * something the user never clicked. The incarnation is what tells those apart,
+ * and it is a number rather than a pointer, so nothing here can name a retired
+ * handle.
+ */
 void apply(const LaunchRequest& request, const LaunchHandleTable& table) {
     const auto* entry = table.findEntry(request.key);
     if (entry == nullptr || entry->handle == nullptr || entry->incarnation != request.incarnation)
@@ -55,21 +54,15 @@ void apply(const LaunchRequest& request, const LaunchHandleTable& table) {
     switch (request.kind) {
         case LaunchRequest::Kind::play:
             if (request.syncTo) {
-                // The run to join is the one that handle holds now, which is
-                // why the request carries a slot and not a run: a scene launch
-                // decided on the message thread would join where the leader was
-                // a block ago.
+                // A slot and not a run, so the run joined is the one the leader
+                // holds now rather than where it was when the gesture was made.
                 if (const auto* with = table.find(*request.syncTo); with != nullptr) {
-                    // Unless the leader has a launch of its own still queued, in
-                    // which case it has no run to join yet: the one it is about
-                    // to begin is the one the follower means. Joining what it is
-                    // playing now would put the follower on the run the leader
-                    // is leaving, and a scene relaunched while it was already
-                    // playing would come back out of phase with itself.
-                    //
-                    // Both then begin fresh on the same instant, which is the
-                    // same origin, because a run's origin is the sample it
-                    // started on and nothing else (#2336).
+                    // A leader with a launch of its own still queued has no run
+                    // to join yet, and the one it is about to begin is the one
+                    // the follower means. Both then begin on the same instant,
+                    // which is the same origin (#2336); joining what it is
+                    // playing would leave a relaunched scene out of phase with
+                    // itself.
                     if (with->queuedState() == LaunchHandle::QueueState::playQueued) {
                         handle->play(with->queuedPosition());
                         return;
@@ -79,9 +72,8 @@ void apply(const LaunchRequest& request, const LaunchHandleTable& table) {
                     return;
                 }
 
-                // The leader's slot was emptied in between. Starting alone is
-                // the honest answer: the clip was asked to play, and there is
-                // no longer anything for it to be in phase with.
+                // The leader's slot was emptied in between, so there is nothing
+                // left to be in phase with.
             }
 
             handle->play(request.position);
@@ -107,16 +99,16 @@ void advanceLaunchHandles(LaunchHandleFeed& handles, LaunchRequestQueue& request
                           const BlockInfo& block) {
     const LaunchHandleFeed::Reader table(handles);
 
-    // Drained whether or not there is a table to apply it to. A queue left
-    // filling while no session is published would deliver a launch made minutes
-    // ago at whatever moment one appeared.
+    // Drained whether or not there is a table to apply it to: a queue left
+    // filling would deliver a launch made minutes ago at whatever moment a
+    // session appeared.
     if (!table) {
         requests.drain([](const LaunchRequest&) {});
         return;
     }
 
     // Every request before any advance, so a scene reaches all of its handles
-    // while they are still on the same block.
+    // on the same block.
     requests.drain([&table](const LaunchRequest& request) { apply(request, *table.get()); });
 
     const auto range = syncRangeFor(block);

--- a/magda/engine/launch/SessionLauncher.cpp
+++ b/magda/engine/launch/SessionLauncher.cpp
@@ -28,10 +28,67 @@ LaunchHandle* LaunchHandleTable::find(const SlotKey& key) const {
     return found != to && found->key == key ? found->handle : nullptr;
 }
 
-void advanceLaunchHandles(LaunchHandleFeed& handles, const BlockInfo& block) {
-    const LaunchHandleFeed::Reader table(handles);
-    if (!table)
+namespace {
+
+/// One request against the table that is live now. A slot the table does not
+/// name is one emptied between the ask and this block, and there is nothing
+/// left to ask.
+void apply(const LaunchRequest& request, const LaunchHandleTable& table) {
+    auto* handle = table.find(request.key);
+    if (handle == nullptr)
         return;
+
+    switch (request.kind) {
+        case LaunchRequest::Kind::play:
+            if (request.syncTo) {
+                // The run to join is the one that handle holds now, which is
+                // why the request carries a slot and not a run: a scene launch
+                // decided on the message thread would join where the leader was
+                // a block ago.
+                if (const auto* with = table.find(*request.syncTo); with != nullptr) {
+                    handle->playSynced(*with, request.position);
+                    return;
+                }
+
+                // The leader's slot was emptied in between. Starting alone is
+                // the honest answer: the clip was asked to play, and there is
+                // no longer anything for it to be in phase with.
+            }
+
+            handle->play(request.position);
+            return;
+
+        case LaunchRequest::Kind::stop:
+            handle->stop(request.position);
+            return;
+
+        case LaunchRequest::Kind::backToArrangement:
+            handle->releaseSection();
+            return;
+
+        case LaunchRequest::Kind::loop:
+            handle->setLooping(request.position);
+            return;
+    }
+}
+
+}  // namespace
+
+void advanceLaunchHandles(LaunchHandleFeed& handles, LaunchRequestQueue& requests,
+                          const BlockInfo& block) {
+    const LaunchHandleFeed::Reader table(handles);
+
+    // Drained whether or not there is a table to apply it to. A queue left
+    // filling while no session is published would deliver a launch made minutes
+    // ago at whatever moment one appeared.
+    if (!table) {
+        requests.drain([](const LaunchRequest&) {});
+        return;
+    }
+
+    // Every request before any advance, so a scene reaches all of its handles
+    // while they are still on the same block.
+    requests.drain([&table](const LaunchRequest& request) { apply(request, *table.get()); });
 
     const auto range = syncRangeFor(block);
 

--- a/magda/engine/launch/SessionLauncher.cpp
+++ b/magda/engine/launch/SessionLauncher.cpp
@@ -17,7 +17,7 @@ LaunchHandleTable::rangeFor(TrackId trackId) const {
     return {from, to};
 }
 
-LaunchHandle* LaunchHandleTable::find(const SlotKey& key) const {
+const LaunchHandleTable::Entry* LaunchHandleTable::findEntry(const SlotKey& key) const {
     const auto [from, to] = rangeFor(key.trackId);
 
     const auto* found =
@@ -25,7 +25,12 @@ LaunchHandle* LaunchHandleTable::find(const SlotKey& key) const {
             return entry.key < wanted;
         });
 
-    return found != to && found->key == key ? found->handle : nullptr;
+    return found != to && found->key == key ? found : nullptr;
+}
+
+LaunchHandle* LaunchHandleTable::find(const SlotKey& key) const {
+    const auto* entry = findEntry(key);
+    return entry != nullptr ? entry->handle : nullptr;
 }
 
 namespace {
@@ -33,10 +38,19 @@ namespace {
 /// One request against the table that is live now. A slot the table does not
 /// name is one emptied between the ask and this block, and there is nothing
 /// left to ask.
+///
+/// The incarnation is the rest of that question. A slot emptied and refilled
+/// between the ask and this block is the same key on a different clip, and
+/// applying the launch to it would start something the user never clicked
+/// (#2305 review). The key alone cannot tell those apart; the incarnation can,
+/// and it is a number rather than a pointer, so nothing here holds a handle
+/// that could have been retired.
 void apply(const LaunchRequest& request, const LaunchHandleTable& table) {
-    auto* handle = table.find(request.key);
-    if (handle == nullptr)
+    const auto* entry = table.findEntry(request.key);
+    if (entry == nullptr || entry->handle == nullptr || entry->incarnation != request.incarnation)
         return;
+
+    auto* handle = entry->handle;
 
     switch (request.kind) {
         case LaunchRequest::Kind::play:
@@ -46,6 +60,21 @@ void apply(const LaunchRequest& request, const LaunchHandleTable& table) {
                 // decided on the message thread would join where the leader was
                 // a block ago.
                 if (const auto* with = table.find(*request.syncTo); with != nullptr) {
+                    // Unless the leader has a launch of its own still queued, in
+                    // which case it has no run to join yet: the one it is about
+                    // to begin is the one the follower means. Joining what it is
+                    // playing now would put the follower on the run the leader
+                    // is leaving, and a scene relaunched while it was already
+                    // playing would come back out of phase with itself.
+                    //
+                    // Both then begin fresh on the same instant, which is the
+                    // same origin, because a run's origin is the sample it
+                    // started on and nothing else (#2336).
+                    if (with->queuedState() == LaunchHandle::QueueState::playQueued) {
+                        handle->play(with->queuedPosition());
+                        return;
+                    }
+
                     handle->playSynced(*with, request.position);
                     return;
                 }

--- a/magda/engine/launch/SessionLauncher.hpp
+++ b/magda/engine/launch/SessionLauncher.hpp
@@ -9,6 +9,7 @@
 #include "core/TypeIds.hpp"
 #include "exec/RenderContext.hpp"
 #include "launch/LaunchHandle.hpp"
+#include "launch/LaunchRequests.hpp"
 
 /**
  * @file SessionLauncher.hpp
@@ -25,9 +26,10 @@
  * sources read `LaunchHandle::blockStatus`. That also keeps a scene coherent,
  * since every handle sees the same block.
  *
- * Requests are not here. The lane carrying `play`, `stop` and `setLooping` from
- * off the audio thread is #2305's; until then a handle is driven directly,
- * which is safe only when nothing is rendering.
+ * Requests arrive on the queue in LaunchRequests.hpp and are applied in that
+ * same pass, which is why it is one call and not two: a request applied after
+ * a handle had already been advanced would take effect a block late, and one
+ * applied to some handles and not others would split a scene.
  */
 
 namespace magda::engine {
@@ -103,9 +105,17 @@ inline SyncRange syncRangeFor(const BlockInfo& block) {
                      block.numSamples, block.rate(),         block.tempo};
 }
 
-/// Advance every handle over @p block, once, before anything renders. On the
-/// audio thread. Every handle: a stopped one may have a launch queued inside
-/// this block.
-void advanceLaunchHandles(LaunchHandleFeed& handles, const BlockInfo& block);
+/**
+ * @brief Apply what has been asked, then advance every handle over @p block.
+ *
+ * On the audio thread, once per block, before anything renders. Every handle: a
+ * stopped one may have a launch queued inside this block.
+ *
+ * The two halves are one call because the order between them is the whole of
+ * what makes a launch land in the block it was asked in. @p requests is drained
+ * whole first, so a scene reaches every handle before any of them has moved.
+ */
+void advanceLaunchHandles(LaunchHandleFeed& handles, LaunchRequestQueue& requests,
+                          const BlockInfo& block);
 
 }  // namespace magda::engine

--- a/magda/engine/launch/SessionLauncher.hpp
+++ b/magda/engine/launch/SessionLauncher.hpp
@@ -47,6 +47,13 @@ struct LaunchHandleTable {
         SlotKey key;
         LaunchHandle* handle = nullptr;
 
+        /// Which handle this slot is on. A slot emptied and refilled is the
+        /// same key and a different clip, so a request made against the one
+        /// that has gone has to be told apart from one made against this one
+        /// (#2305 review). Assigned by RuntimeStateStore::publishHandles when
+        /// it makes a handle, and never reused.
+        std::uint64_t incarnation = 0;
+
         bool operator==(const Entry&) const = default;
     };
 
@@ -59,6 +66,10 @@ struct LaunchHandleTable {
 
     /// The handle for one slot, or null.
     LaunchHandle* find(const SlotKey& key) const;
+
+    /// The whole entry for one slot, or null, which is what a caller needs when
+    /// it has to check the incarnation as well as find the handle.
+    const Entry* findEntry(const SlotKey& key) const;
 };
 
 class LaunchHandleFeed {

--- a/magda/engine/launch/SessionLauncher.hpp
+++ b/magda/engine/launch/SessionLauncher.hpp
@@ -47,11 +47,9 @@ struct LaunchHandleTable {
         SlotKey key;
         LaunchHandle* handle = nullptr;
 
-        /// Which handle this slot is on. A slot emptied and refilled is the
-        /// same key and a different clip, so a request made against the one
-        /// that has gone has to be told apart from one made against this one
-        /// (#2305 review). Assigned by RuntimeStateStore::publishHandles when
-        /// it makes a handle, and never reused.
+        /// Which handle this slot is on: a slot emptied and refilled is the
+        /// same key on a different clip. Assigned by
+        /// RuntimeStateStore::publishHandles, and never reused (#2305).
         std::uint64_t incarnation = 0;
 
         bool operator==(const Entry&) const = default;
@@ -59,16 +57,19 @@ struct LaunchHandleTable {
 
     std::vector<Entry> entries;
 
-    /// The half-open range of entries belonging to @p trackId, in scene order.
-    /// Empty for a track with no slots. On the audio thread: a binary search
-    /// over a sorted vector.
+    /**
+     * @brief The half-open range of entries belonging to @p trackId, in scene
+     *        order, or an empty range for a track with no slots.
+     *
+     * On the audio thread: a binary search over a sorted vector.
+     */
     std::pair<const Entry*, const Entry*> rangeFor(TrackId trackId) const;
 
-    /// The handle for one slot, or null.
+    /// @brief The handle for @p key, or null.
     LaunchHandle* find(const SlotKey& key) const;
 
-    /// The whole entry for one slot, or null, which is what a caller needs when
-    /// it has to check the incarnation as well as find the handle.
+    /// @brief The whole entry for @p key, or null, for a caller that has to
+    ///        check the incarnation as well as find the handle.
     const Entry* findEntry(const SlotKey& key) const;
 };
 
@@ -119,12 +120,12 @@ inline SyncRange syncRangeFor(const BlockInfo& block) {
 /**
  * @brief Apply what has been asked, then advance every handle over @p block.
  *
- * On the audio thread, once per block, before anything renders. Every handle: a
- * stopped one may have a launch queued inside this block.
+ * On the audio thread, once per block, before anything renders. Every handle,
+ * because a stopped one may have a launch queued inside this block.
  *
- * The two halves are one call because the order between them is the whole of
- * what makes a launch land in the block it was asked in. @p requests is drained
- * whole first, so a scene reaches every handle before any of them has moved.
+ * One call rather than two: @p requests is drained whole first, so a launch
+ * lands in the block it was asked in and a scene reaches every handle before
+ * any of them has moved.
  */
 void advanceLaunchHandles(LaunchHandleFeed& handles, LaunchRequestQueue& requests,
                           const BlockInfo& block);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -381,6 +381,9 @@ if(MAGDA_BUILD_NATIVE_ENGINE)
     # Which slot handles survive a publish (#2301): the plan is per track and a
     # handle is per slot, so the snapshot is what names them.
     list(APPEND TEST_SOURCES engine/test_launch_handle_lifetime.cpp)
+    # The lane a launch arrives on (#2305): the block it lands in, the order it
+    # keeps, and that it cannot be applied twice or reach a slot that has gone.
+    list(APPEND TEST_SOURCES engine/test_launch_requests.cpp)
     list(APPEND TEST_SOURCES audio/test_click_generator.cpp)
     list(APPEND TEST_SOURCES audio/test_prefetch_stream.cpp)
     list(APPEND TEST_SOURCES audio/test_source_readers.cpp)

--- a/tests/engine/test_engine_session.cpp
+++ b/tests/engine/test_engine_session.cpp
@@ -1294,15 +1294,89 @@ TEST_CASE("A launch published with the clips reaches the audio thread", "[engine
     session.process(kBlockSize, output);
     CHECK(output.getSample(0, 0) == approx(0.0f));
 
-    auto* handle = session.launchHandle(magda::engine::SlotKey{1, 0});
-    REQUIRE(handle != nullptr);
+    const auto slot = magda::engine::SlotKey{1, 0};
+    REQUIRE(session.launchHandle(slot) != nullptr);
     CHECK(session.launchHandle(magda::engine::SlotKey{1, 3}) == nullptr);
 
-    handle->play(std::nullopt);
+    // Asked for from off the audio thread and applied by the block it reaches,
+    // which is the lane rather than a pointer into the handle (#2305).
+    {
+        magda::engine::LaunchRequestQueue::Gesture gesture(session.launchRequests());
+        gesture.play(slot);
+    }
+
     session.process(kBlockSize, output);
     CHECK(output.getSample(0, 0) == approx(1.0f));
 
-    handle->stop(std::nullopt);
+    {
+        magda::engine::LaunchRequestQueue::Gesture gesture(session.launchRequests());
+        gesture.stop(slot);
+    }
+
     session.process(kBlockSize, output);
     CHECK(output.getSample(0, 0) == approx(0.0f));
+}
+
+TEST_CASE("A structural edit under a playing slot does not restart it",
+          "[engine][session][launch]") {
+    // #2305's requirement, end to end: a track added while a scene plays
+    // compiles a new plan and swaps it in, and the clip that was sounding goes
+    // on sounding from where it was. Handles live in the store rather than in
+    // the plan, so the swap has nothing of theirs to take.
+    LauncherFactory factory;
+    EngineSession session(factory);
+    factory.handles = &session.launchHandleFeed();
+
+    const std::vector<TrackInfo> before{makeTrack(1)};
+    REQUIRE(publish(session, compile(before), before).published);
+
+    session.publishTransport(rolling(0.0));
+    session.publishClips(snapshotWithSlot(1, 0));
+
+    const auto slot = magda::engine::SlotKey{1, 0};
+    juce::AudioBuffer<float> output(2, kBlockSize);
+
+    {
+        magda::engine::LaunchRequestQueue::Gesture gesture(session.launchRequests());
+        gesture.play(slot);
+    }
+
+    for (auto block = 0; block < 3; ++block)
+        session.process(kBlockSize, output);
+
+    REQUIRE(output.getSample(0, 0) == approx(1.0f));
+
+    const auto* handle = session.launchHandle(slot);
+    REQUIRE(handle != nullptr);
+
+    const auto running = handle->playedSampleRange();
+    REQUIRE(running.has_value());
+
+    // The structural edit: another track, which is a different plan and a new
+    // epoch. The clips are republished with it, as a real edit would.
+    std::vector<TrackInfo> after{makeTrack(1)};
+    after.push_back(makeTrack(2));
+    REQUIRE(publish(session, compile(after), after).published);
+    session.publishClips(snapshotWithSlot(1, 0));
+
+    for (auto block = 0; block < 3; ++block)
+        session.process(kBlockSize, output);
+
+    // Not dropped.
+    CHECK(output.getSample(0, 0) == approx(1.0f));
+
+    const auto* kept = session.launchHandle(slot);
+    REQUIRE(kept == handle);
+
+    const auto still = kept->playedSampleRange();
+    REQUIRE(still.has_value());
+
+    // Not restarted: the run began where it began, and a swap is not an event
+    // the launcher has anything to say about.
+    CHECK(still->start == running->start);
+
+    // Not doubled: three more blocks is three more blocks. Advanced twice over
+    // a swap, the run would be six blocks long and the clip half a bar ahead of
+    // where the transport says it is.
+    CHECK(still->end == running->end + magda::engine::SampleDuration{3 * kBlockSize});
 }

--- a/tests/engine/test_engine_session.cpp
+++ b/tests/engine/test_engine_session.cpp
@@ -1298,8 +1298,8 @@ TEST_CASE("A launch published with the clips reaches the audio thread", "[engine
     REQUIRE(session.launchHandle(slot) != nullptr);
     CHECK(session.launchHandle(magda::engine::SlotKey{1, 3}) == nullptr);
 
-    // Asked for from off the audio thread and applied by the block it reaches,
-    // which is the lane rather than a pointer into the handle (#2305).
+    // Asked for from off the audio thread and applied by the block it reaches:
+    // the lane rather than a pointer into the handle (#2305).
     {
         magda::engine::LaunchRequestQueue::Gesture gesture(session.launchRequests());
         gesture.play(slot);
@@ -1319,10 +1319,9 @@ TEST_CASE("A launch published with the clips reaches the audio thread", "[engine
 
 TEST_CASE("A structural edit under a playing slot does not restart it",
           "[engine][session][launch]") {
-    // #2305's requirement, end to end: a track added while a scene plays
-    // compiles a new plan and swaps it in, and the clip that was sounding goes
-    // on sounding from where it was. Handles live in the store rather than in
-    // the plan, so the swap has nothing of theirs to take.
+    // A track added while a scene plays compiles a new plan and swaps it in,
+    // and the clip that was sounding goes on from where it was: handles live in
+    // the store, so the swap has nothing of theirs to take (#2305).
     LauncherFactory factory;
     EngineSession session(factory);
     factory.handles = &session.launchHandleFeed();
@@ -1375,8 +1374,7 @@ TEST_CASE("A structural edit under a playing slot does not restart it",
     // the launcher has anything to say about.
     CHECK(still->start == running->start);
 
-    // Not doubled: three more blocks is three more blocks. Advanced twice over
-    // a swap, the run would be six blocks long and the clip half a bar ahead of
-    // where the transport says it is.
+    // Not doubled: advanced twice over a swap, the run would be six blocks long
+    // and the clip half a bar ahead of the transport.
     CHECK(still->end == running->end + magda::engine::SampleDuration{3 * kBlockSize});
 }

--- a/tests/engine/test_launch_handle_lifetime.cpp
+++ b/tests/engine/test_launch_handle_lifetime.cpp
@@ -51,8 +51,9 @@ TEST_CASE("A slot's handle does not outlive the slot", "[engine][session][launch
     NoFactory factory;
     RuntimeStateStore store(factory);
     LaunchHandleFeed feed;
+    LaunchRequestQueue requests;
 
-    store.publishHandles(snapshotWithScenes({0, 2}), feed);
+    store.publishHandles(snapshotWithScenes({0, 2}), feed, requests);
 
     auto* first = store.findHandle(SlotKey{kTrack, 0});
     REQUIRE(first != nullptr);
@@ -62,7 +63,7 @@ TEST_CASE("A slot's handle does not outlive the slot", "[engine][session][launch
     SECTION("a snapshot that still names it keeps the handle it had") {
         // An edit elsewhere republishes the snapshot, and a playing clip goes
         // on playing.
-        store.publishHandles(snapshotWithScenes({0, 2}), feed);
+        store.publishHandles(snapshotWithScenes({0, 2}), feed, requests);
 
         auto* kept = store.findHandle(SlotKey{kTrack, 0});
         REQUIRE(kept == first);
@@ -70,7 +71,7 @@ TEST_CASE("A slot's handle does not outlive the slot", "[engine][session][launch
     }
 
     SECTION("emptying one slot does not disturb the others") {
-        store.publishHandles(snapshotWithScenes({0}), feed);
+        store.publishHandles(snapshotWithScenes({0}), feed, requests);
 
         CHECK(store.findHandle(SlotKey{kTrack, 0}) == first);
         CHECK(store.findHandle(SlotKey{kTrack, 2}) == nullptr);
@@ -80,10 +81,10 @@ TEST_CASE("A slot's handle does not outlive the slot", "[engine][session][launch
         // Why retirement is here rather than at a plan publish: emptying and
         // refilling is two clip edits and no structural one, so the new clip
         // would come up already playing.
-        store.publishHandles(snapshotWithScenes({2}), feed);
+        store.publishHandles(snapshotWithScenes({2}), feed, requests);
         CHECK(store.findHandle(SlotKey{kTrack, 0}) == nullptr);
 
-        store.publishHandles(snapshotWithScenes({0, 2}), feed);
+        store.publishHandles(snapshotWithScenes({0, 2}), feed, requests);
 
         auto* refilled = store.findHandle(SlotKey{kTrack, 0});
         REQUIRE(refilled != nullptr);
@@ -93,7 +94,7 @@ TEST_CASE("A slot's handle does not outlive the slot", "[engine][session][launch
     }
 
     SECTION("a slot whose track is gone goes with it") {
-        store.publishHandles(snapshotWithScenes({0, 2}, kTrack + 1), feed);
+        store.publishHandles(snapshotWithScenes({0, 2}, kTrack + 1), feed, requests);
 
         CHECK(store.findHandle(SlotKey{kTrack, 0}) == nullptr);
         CHECK(store.findHandle(SlotKey{kTrack, 2}) == nullptr);
@@ -101,7 +102,7 @@ TEST_CASE("A slot's handle does not outlive the slot", "[engine][session][launch
     }
 
     SECTION("a project with nothing in it keeps nothing") {
-        store.publishHandles(ClipSnapshot{}, feed);
+        store.publishHandles(ClipSnapshot{}, feed, requests);
 
         CHECK(store.findHandle(SlotKey{kTrack, 0}) == nullptr);
         CHECK(store.findHandle(SlotKey{kTrack, 2}) == nullptr);
@@ -115,8 +116,9 @@ TEST_CASE("A plan publish is not what retires a handle", "[engine][session][laun
     NoFactory factory;
     RuntimeStateStore store(factory);
     LaunchHandleFeed feed;
+    LaunchRequestQueue requests;
 
-    store.publishHandles(snapshotWithScenes({0, 1}), feed);
+    store.publishHandles(snapshotWithScenes({0, 1}), feed, requests);
     const auto before = store.size();
 
     const RenderPlan empty;

--- a/tests/engine/test_launch_requests.cpp
+++ b/tests/engine/test_launch_requests.cpp
@@ -10,9 +10,9 @@
  * @brief What a launch asked for off the audio thread does when it gets there
  *        (#2305).
  *
- * The lane, not the state machine: that a request lands in the block it was
- * asked in, keeps its order, cannot be applied twice, and cannot reach a slot
- * that has gone. LaunchHandle's own behaviour is test_launch_handle.cpp's.
+ * The lane, not the state machine: the block a request lands in, the order it
+ * keeps, and that it cannot be applied twice or reach a slot that has gone.
+ * LaunchHandle's own behaviour is test_launch_handle.cpp's.
  */
 
 using namespace magda;
@@ -44,8 +44,8 @@ BlockInfo blockAt(int index) {
     return block;
 }
 
-/// A published table over handles the case owns, which is what the store makes
-/// for real. Handles are held by the caller so a case can read one directly.
+/// A published table over handles the case owns, so a case can read one
+/// directly.
 struct Rig {
     /// @p scenes on kTrack, one handle each.
     explicit Rig(int scenes) : handles(static_cast<std::size_t>(scenes)) {
@@ -64,8 +64,8 @@ struct Rig {
         advanceLaunchHandles(feed, requests, blockAt(index));
     }
 
-    /// Republish this rig's handles under @p incarnation, and tell the queue,
-    /// which is the pair RuntimeStateStore::publishHandles keeps in step.
+    /// Republish under @p incarnation and tell the queue: the pair
+    /// RuntimeStateStore::publishHandles keeps in step.
     void publishWithIncarnation(std::uint64_t incarnation) {
         auto table = std::make_shared<LaunchHandleTable>();
         std::map<SlotKey, std::uint64_t> stamped;
@@ -122,8 +122,8 @@ TEST_CASE("A request reaches its handle on the next block and no earlier",
 }
 
 TEST_CASE("A request is applied once and not again", "[engine][session][launch]") {
-    // The whole reason the lane is a queue rather than a published table: a
-    // request left standing would retrigger the clip every block.
+    // Why the lane is a queue and not a published table: a request left
+    // standing would retrigger the clip every block.
     Rig rig(1);
 
     {
@@ -201,10 +201,9 @@ TEST_CASE("A scene launch arrives as one thing", "[engine][session][launch]") {
 
 TEST_CASE("Relaunching a scene whose leader is already playing keeps it in phase",
           "[engine][session][launch]") {
-    // The leader's play() only queues: its run_ is still the old one when the
-    // followers are applied in the same gesture. Joining that run would put the
-    // followers on the run the leader is about to leave, and the scene would
-    // come back out of phase with itself (#2305 review).
+    // The leader's play() only queues, so its run_ is still the old one when
+    // the followers are applied in the same gesture. Joining it would leave the
+    // scene out of phase with itself.
     Rig rig(3);
 
     {
@@ -303,10 +302,9 @@ TEST_CASE("A request for a slot that is not there does nothing", "[engine][sessi
 
 TEST_CASE("A request cannot launch the clip that replaced the one it named",
           "[engine][session][launch]") {
-    // The ordering the first refill case does not reach: the request is still
-    // in the queue when the slot is emptied and refilled, so the drain finds a
-    // live handle under the key it named. The key alone says yes; the
-    // incarnation is what says no (#2305 review).
+    // The request is still queued when the slot is emptied and refilled, so the
+    // drain finds a live handle under the key it named. The key alone says yes;
+    // the incarnation says no.
     Rig rig(1);
 
     // What publishHandles stamps a handle with. The first table's entry carries
@@ -333,7 +331,7 @@ TEST_CASE("A request cannot launch the clip that replaced the one it named",
 
 TEST_CASE("A request still matches the handle it was made against", "[engine][session][launch]") {
     // The other half: an incarnation that has not moved must not drop the
-    // request, or nothing would ever launch.
+    // request.
     Rig rig(1);
     rig.publishWithIncarnation(7);
 
@@ -348,9 +346,8 @@ TEST_CASE("A request still matches the handle it was made against", "[engine][se
 
 TEST_CASE("A slot emptied and refilled does not inherit what was asked of the last one",
           "[engine][session][launch]") {
-    // The property that made this a queue and not a table of intents. A request
-    // is consumed by the block it reaches, so a handle made afterwards has
-    // nothing standing against its slot.
+    // A request is consumed by the block it reaches, so a handle made
+    // afterwards has nothing standing against its slot.
     Rig rig(1);
 
     {
@@ -394,7 +391,7 @@ TEST_CASE("Back to arrangement travels the same lane", "[engine][session][launch
 }
 
 TEST_CASE("A stop leaves the track held until it is given back", "[engine][session][launch]") {
-    // The difference #2302 settled, over the lane: stopping is not handing back.
+    // What #2302 settled, over the lane: stopping is not handing back.
     Rig rig(1);
 
     {
@@ -414,8 +411,8 @@ TEST_CASE("A stop leaves the track held until it is given back", "[engine][sessi
 }
 
 TEST_CASE("A request made while nothing is published is not kept", "[engine][session][launch]") {
-    // A queue filling while no session exists would deliver a launch made
-    // minutes ago at whatever moment one appeared.
+    // A launch made minutes ago must not fire at whatever moment a session
+    // appears.
     Rig rig;
 
     {
@@ -435,8 +432,8 @@ TEST_CASE("A request made while nothing is published is not kept", "[engine][ses
 }
 
 TEST_CASE("A gesture too large for the ring is dropped whole", "[engine][session][launch]") {
-    // Half a scene launching is worse than none: the tracks that made it would
-    // be a bar ahead of the ones that did not for as long as they played.
+    // Half a scene launching leaves those tracks a bar ahead of the rest for as
+    // long as they play.
     Rig rig(1);
 
     {
@@ -477,8 +474,8 @@ TEST_CASE("A gesture that exactly fills the ring is kept", "[engine][session][la
 }
 
 TEST_CASE("The ring is reusable once its requests have been read", "[engine][session][launch]") {
-    // The cursors are counts rather than indices, so the capacity is what is
-    // outstanding and not what has ever been asked.
+    // The cursors are counts, not indices: the capacity bounds what is
+    // outstanding, not what has ever been asked.
     Rig rig(1);
 
     for (auto round = 0; round < 4; ++round) {

--- a/tests/engine/test_launch_requests.cpp
+++ b/tests/engine/test_launch_requests.cpp
@@ -1,0 +1,359 @@
+#include <catch2/catch_test_macros.hpp>
+#include <memory>
+#include <vector>
+
+#include "launch/SessionLauncher.hpp"
+
+/**
+ * @file test_launch_requests.cpp
+ * @brief What a launch asked for off the audio thread does when it gets there
+ *        (#2305).
+ *
+ * The lane, not the state machine: that a request lands in the block it was
+ * asked in, keeps its order, cannot be applied twice, and cannot reach a slot
+ * that has gone. LaunchHandle's own behaviour is test_launch_handle.cpp's.
+ */
+
+using namespace magda;
+using namespace magda::engine;
+
+namespace {
+
+constexpr TrackId kTrack = 1;
+constexpr int kBlockSize = 512;
+constexpr double kSampleRate = 48000.0;
+
+/// A quarter beat a block, so a launch and its first block are easy to tell
+/// apart from the one after it.
+constexpr double kBeatsPerBlock = 0.25;
+
+BlockInfo blockAt(int index) {
+    BlockInfo block;
+    block.numSamples = kBlockSize;
+    block.sampleRate = kSampleRate;
+    block.monotonicSamples = {SamplePosition{index * kBlockSize},
+                              SamplePosition{(index + 1) * kBlockSize}};
+    block.playing = true;
+    block.continuous = index != 0;
+    block.beats = {index * kBeatsPerBlock, (index + 1) * kBeatsPerBlock};
+    block.monotonicBeats = block.beats;
+    block.seconds = {static_cast<double>(index * kBlockSize) / kSampleRate,
+                     static_cast<double>((index + 1) * kBlockSize) / kSampleRate};
+    block.monotonicSeconds = block.seconds;
+    return block;
+}
+
+/// A published table over handles the case owns, which is what the store makes
+/// for real. Handles are held by the caller so a case can read one directly.
+struct Rig {
+    /// @p scenes on kTrack, one handle each.
+    explicit Rig(int scenes) : handles(static_cast<std::size_t>(scenes)) {
+        auto table = std::make_shared<LaunchHandleTable>();
+        for (auto scene = 0; scene < scenes; ++scene)
+            table->entries.push_back(LaunchHandleTable::Entry{
+                SlotKey{kTrack, scene}, &handles[static_cast<std::size_t>(scene)]});
+
+        feed.publish(std::move(table));
+    }
+
+    /// Nothing published at all, which is a session whose slots have no handles.
+    Rig() = default;
+
+    void roll(int index) {
+        advanceLaunchHandles(feed, requests, blockAt(index));
+    }
+
+    LaunchHandle& slot(int scene) {
+        return handles[static_cast<std::size_t>(scene)];
+    }
+
+    static SlotKey key(int scene) {
+        return SlotKey{kTrack, scene};
+    }
+
+    std::vector<LaunchHandle> handles;
+    LaunchHandleFeed feed;
+    LaunchRequestQueue requests;
+};
+
+bool playing(const LaunchHandle& handle) {
+    return handle.playState() == LaunchHandle::PlayState::playing;
+}
+
+}  // namespace
+
+TEST_CASE("A request reaches its handle on the next block and no earlier",
+          "[engine][session][launch]") {
+    Rig rig(1);
+
+    {
+        LaunchRequestQueue::Gesture gesture(rig.requests);
+        gesture.play(Rig::key(0));
+
+        // The gesture is still open, so nothing has been committed and a block
+        // rendering now would see nothing.
+        CHECK_FALSE(playing(rig.slot(0)));
+    }
+
+    // Still nothing: a committed request is applied by the pass that advances,
+    // not by the commit.
+    CHECK_FALSE(playing(rig.slot(0)));
+
+    rig.roll(0);
+    CHECK(playing(rig.slot(0)));
+}
+
+TEST_CASE("A request is applied once and not again", "[engine][session][launch]") {
+    // The whole reason the lane is a queue rather than a published table: a
+    // request left standing would retrigger the clip every block.
+    Rig rig(1);
+
+    {
+        LaunchRequestQueue::Gesture gesture(rig.requests);
+        gesture.play(Rig::key(0));
+    }
+
+    rig.roll(0);
+    const auto first = rig.slot(0).playedSampleRange();
+    REQUIRE(first.has_value());
+
+    rig.roll(1);
+    rig.roll(2);
+
+    const auto after = rig.slot(0).playedSampleRange();
+    REQUIRE(after.has_value());
+
+    // One run, three blocks long. Re-applied, the origin would have moved to
+    // each later block and the run would be one block long for ever.
+    CHECK(after->start == first->start);
+    CHECK(after->end > first->end);
+}
+
+TEST_CASE("Requests keep the order they were asked in", "[engine][session][launch]") {
+    // Why the loop length travels on this lane rather than beside it: a length
+    // set for a clip about to start has to arrive before the launch.
+    Rig rig(1);
+
+    {
+        LaunchRequestQueue::Gesture gesture(rig.requests);
+        gesture.setLooping(Rig::key(0), 0.5);
+        gesture.play(Rig::key(0));
+    }
+
+    // Two blocks a quarter beat each, so the half-beat loop re-triggers at the
+    // end of the second one and the run begins again.
+    rig.roll(0);
+    rig.roll(1);
+    rig.roll(2);
+
+    const auto played = rig.slot(0).playedSampleRange();
+    REQUIRE(played.has_value());
+
+    // Re-anchored by the wrap rather than still counting from the launch.
+    CHECK(played->start > SamplePosition{0});
+}
+
+TEST_CASE("A scene launch arrives as one thing", "[engine][session][launch]") {
+    Rig rig(3);
+
+    {
+        LaunchRequestQueue::Gesture gesture(rig.requests);
+        gesture.play(Rig::key(0));
+        gesture.playSynced(Rig::key(1), Rig::key(0));
+        gesture.playSynced(Rig::key(2), Rig::key(0));
+    }
+
+    rig.roll(0);
+
+    for (auto scene = 0; scene < 3; ++scene)
+        CHECK(playing(rig.slot(scene)));
+
+    // In phase, not merely started together: a synced launch joins the leader's
+    // run, so all three report the same origin.
+    const auto leader = rig.slot(0).playedSampleRange();
+    REQUIRE(leader.has_value());
+
+    for (auto scene = 1; scene < 3; ++scene) {
+        const auto joined = rig.slot(scene).playedSampleRange();
+        REQUIRE(joined.has_value());
+        CHECK(joined->start == leader->start);
+        CHECK(joined->end == leader->end);
+    }
+}
+
+TEST_CASE("A synced launch whose leader has gone starts on its own", "[engine][session][launch]") {
+    // The leader's slot was emptied between the ask and the block. Playing
+    // alone is the honest answer: the clip was asked to play and there is
+    // nothing left to be in phase with.
+    Rig rig(1);
+
+    {
+        LaunchRequestQueue::Gesture gesture(rig.requests);
+        gesture.playSynced(Rig::key(0), SlotKey{kTrack, 7});
+    }
+
+    rig.roll(0);
+    CHECK(playing(rig.slot(0)));
+}
+
+TEST_CASE("A request for a slot that is not there does nothing", "[engine][session][launch]") {
+    Rig rig(1);
+
+    {
+        LaunchRequestQueue::Gesture gesture(rig.requests);
+        gesture.play(SlotKey{kTrack, 4});
+        gesture.play(SlotKey{kTrack + 1, 0});
+    }
+
+    rig.roll(0);
+    CHECK_FALSE(playing(rig.slot(0)));
+}
+
+TEST_CASE("A slot emptied and refilled does not inherit what was asked of the last one",
+          "[engine][session][launch]") {
+    // The property that made this a queue and not a table of intents. A request
+    // is consumed by the block it reaches, so a handle made afterwards has
+    // nothing standing against its slot.
+    Rig rig(1);
+
+    {
+        LaunchRequestQueue::Gesture gesture(rig.requests);
+        gesture.play(Rig::key(0));
+    }
+
+    rig.roll(0);
+    REQUIRE(playing(rig.slot(0)));
+
+    // What publishHandles() does to a slot whose clip was deleted and replaced.
+    LaunchHandle refilled;
+    auto table = std::make_shared<LaunchHandleTable>();
+    table->entries.push_back(LaunchHandleTable::Entry{Rig::key(0), &refilled});
+    rig.feed.publish(std::move(table));
+
+    rig.roll(1);
+    CHECK_FALSE(playing(refilled));
+}
+
+TEST_CASE("Back to arrangement travels the same lane", "[engine][session][launch]") {
+    Rig rig(1);
+
+    {
+        LaunchRequestQueue::Gesture gesture(rig.requests);
+        gesture.play(Rig::key(0));
+    }
+
+    rig.roll(0);
+    REQUIRE(rig.slot(0).holdsSection());
+
+    {
+        LaunchRequestQueue::Gesture gesture(rig.requests);
+        gesture.backToArrangement(Rig::key(0));
+    }
+
+    rig.roll(1);
+    CHECK_FALSE(playing(rig.slot(0)));
+    CHECK_FALSE(rig.slot(0).holdsSection());
+    CHECK(rig.slot(0).blockStatus().releasedSection);
+}
+
+TEST_CASE("A stop leaves the track held until it is given back", "[engine][session][launch]") {
+    // The difference #2302 settled, over the lane: stopping is not handing back.
+    Rig rig(1);
+
+    {
+        LaunchRequestQueue::Gesture gesture(rig.requests);
+        gesture.play(Rig::key(0));
+    }
+    rig.roll(0);
+
+    {
+        LaunchRequestQueue::Gesture gesture(rig.requests);
+        gesture.stop(Rig::key(0));
+    }
+    rig.roll(1);
+
+    CHECK_FALSE(playing(rig.slot(0)));
+    CHECK(rig.slot(0).holdsSection());
+}
+
+TEST_CASE("A request made while nothing is published is not kept", "[engine][session][launch]") {
+    // A queue filling while no session exists would deliver a launch made
+    // minutes ago at whatever moment one appeared.
+    Rig rig;
+
+    {
+        LaunchRequestQueue::Gesture gesture(rig.requests);
+        gesture.play(Rig::key(0));
+    }
+
+    rig.roll(0);
+
+    LaunchHandle handle;
+    auto table = std::make_shared<LaunchHandleTable>();
+    table->entries.push_back(LaunchHandleTable::Entry{Rig::key(0), &handle});
+    rig.feed.publish(std::move(table));
+
+    rig.roll(1);
+    CHECK_FALSE(playing(handle));
+}
+
+TEST_CASE("A gesture too large for the ring is dropped whole", "[engine][session][launch]") {
+    // Half a scene launching is worse than none: the tracks that made it would
+    // be a bar ahead of the ones that did not for as long as they played.
+    Rig rig(1);
+
+    {
+        LaunchRequestQueue::Gesture gesture(rig.requests);
+        for (auto i = 0; i <= LaunchRequestQueue::kCapacity; ++i)
+            gesture.play(Rig::key(0));
+    }
+
+    CHECK(rig.requests.overflows() == 1);
+
+    rig.roll(0);
+    CHECK_FALSE(playing(rig.slot(0)));
+
+    // And the lane still works afterwards.
+    {
+        LaunchRequestQueue::Gesture gesture(rig.requests);
+        gesture.play(Rig::key(0));
+    }
+
+    rig.roll(1);
+    CHECK(playing(rig.slot(0)));
+    CHECK(rig.requests.overflows() == 1);
+}
+
+TEST_CASE("A gesture that exactly fills the ring is kept", "[engine][session][launch]") {
+    Rig rig(1);
+
+    {
+        LaunchRequestQueue::Gesture gesture(rig.requests);
+        for (auto i = 0; i < LaunchRequestQueue::kCapacity; ++i)
+            gesture.play(Rig::key(0));
+    }
+
+    CHECK(rig.requests.overflows() == 0);
+
+    rig.roll(0);
+    CHECK(playing(rig.slot(0)));
+}
+
+TEST_CASE("The ring is reusable once its requests have been read", "[engine][session][launch]") {
+    // The cursors are counts rather than indices, so the capacity is what is
+    // outstanding and not what has ever been asked.
+    Rig rig(1);
+
+    for (auto round = 0; round < 4; ++round) {
+        {
+            LaunchRequestQueue::Gesture gesture(rig.requests);
+            for (auto i = 0; i < LaunchRequestQueue::kCapacity / 2; ++i)
+                gesture.play(Rig::key(0));
+        }
+
+        rig.roll(round);
+    }
+
+    CHECK(rig.requests.overflows() == 0);
+    CHECK(playing(rig.slot(0)));
+}

--- a/tests/engine/test_launch_requests.cpp
+++ b/tests/engine/test_launch_requests.cpp
@@ -1,4 +1,5 @@
 #include <catch2/catch_test_macros.hpp>
+#include <map>
 #include <memory>
 #include <vector>
 
@@ -61,6 +62,23 @@ struct Rig {
 
     void roll(int index) {
         advanceLaunchHandles(feed, requests, blockAt(index));
+    }
+
+    /// Republish this rig's handles under @p incarnation, and tell the queue,
+    /// which is the pair RuntimeStateStore::publishHandles keeps in step.
+    void publishWithIncarnation(std::uint64_t incarnation) {
+        auto table = std::make_shared<LaunchHandleTable>();
+        std::map<SlotKey, std::uint64_t> stamped;
+
+        for (auto scene = 0; scene < static_cast<int>(handles.size()); ++scene) {
+            const auto key = SlotKey{kTrack, scene};
+            table->entries.push_back(LaunchHandleTable::Entry{
+                key, &handles[static_cast<std::size_t>(scene)], incarnation});
+            stamped[key] = incarnation;
+        }
+
+        feed.publish(std::move(table));
+        requests.setIncarnations(std::move(stamped));
     }
 
     LaunchHandle& slot(int scene) {
@@ -181,6 +199,80 @@ TEST_CASE("A scene launch arrives as one thing", "[engine][session][launch]") {
     }
 }
 
+TEST_CASE("Relaunching a scene whose leader is already playing keeps it in phase",
+          "[engine][session][launch]") {
+    // The leader's play() only queues: its run_ is still the old one when the
+    // followers are applied in the same gesture. Joining that run would put the
+    // followers on the run the leader is about to leave, and the scene would
+    // come back out of phase with itself (#2305 review).
+    Rig rig(3);
+
+    {
+        LaunchRequestQueue::Gesture gesture(rig.requests);
+        gesture.play(Rig::key(0));
+    }
+
+    rig.roll(0);
+    rig.roll(1);
+    REQUIRE(playing(rig.slot(0)));
+
+    const auto firstRun = rig.slot(0).playedSampleRange();
+    REQUIRE(firstRun.has_value());
+
+    // The same scene launched again, leader first, exactly as playScene emits it.
+    {
+        LaunchRequestQueue::Gesture gesture(rig.requests);
+        gesture.play(Rig::key(0));
+        gesture.playSynced(Rig::key(1), Rig::key(0));
+        gesture.playSynced(Rig::key(2), Rig::key(0));
+    }
+
+    rig.roll(2);
+
+    const auto leader = rig.slot(0).playedSampleRange();
+    REQUIRE(leader.has_value());
+
+    // The leader really did relaunch rather than carry on.
+    CHECK(leader->start > firstRun->start);
+
+    for (auto scene = 1; scene < 3; ++scene) {
+        const auto joined = rig.slot(scene).playedSampleRange();
+        REQUIRE(joined.has_value());
+        CHECK(joined->start == leader->start);
+        CHECK(joined->end == leader->end);
+    }
+}
+
+TEST_CASE("playScene emits the leader before the slots that follow it",
+          "[engine][session][launch]") {
+    Rig rig(3);
+
+    {
+        LaunchRequestQueue::Gesture gesture(rig.requests);
+        gesture.play(Rig::key(0));
+    }
+    rig.roll(0);
+    rig.roll(1);
+
+    const std::vector<SlotKey> scene{Rig::key(0), Rig::key(1), Rig::key(2)};
+
+    {
+        LaunchRequestQueue::Gesture gesture(rig.requests);
+        gesture.playScene(Rig::key(0), scene);
+    }
+
+    rig.roll(2);
+
+    const auto leader = rig.slot(0).playedSampleRange();
+    REQUIRE(leader.has_value());
+
+    for (auto index = 1; index < 3; ++index) {
+        const auto joined = rig.slot(index).playedSampleRange();
+        REQUIRE(joined.has_value());
+        CHECK(joined->start == leader->start);
+    }
+}
+
 TEST_CASE("A synced launch whose leader has gone starts on its own", "[engine][session][launch]") {
     // The leader's slot was emptied between the ask and the block. Playing
     // alone is the honest answer: the clip was asked to play and there is
@@ -207,6 +299,51 @@ TEST_CASE("A request for a slot that is not there does nothing", "[engine][sessi
 
     rig.roll(0);
     CHECK_FALSE(playing(rig.slot(0)));
+}
+
+TEST_CASE("A request cannot launch the clip that replaced the one it named",
+          "[engine][session][launch]") {
+    // The ordering the first refill case does not reach: the request is still
+    // in the queue when the slot is emptied and refilled, so the drain finds a
+    // live handle under the key it named. The key alone says yes; the
+    // incarnation is what says no (#2305 review).
+    Rig rig(1);
+
+    // What publishHandles stamps a handle with. The first table's entry carries
+    // it, and so does a request made while that table is the published one.
+    rig.publishWithIncarnation(1);
+
+    {
+        LaunchRequestQueue::Gesture gesture(rig.requests);
+        gesture.play(Rig::key(0));
+    }
+
+    // Emptied and refilled before the callback ever ran, so nothing has drained.
+    LaunchHandle refilled;
+    auto table = std::make_shared<LaunchHandleTable>();
+    table->entries.push_back(LaunchHandleTable::Entry{Rig::key(0), &refilled, 2});
+    rig.feed.publish(std::move(table));
+    rig.requests.setIncarnations({{Rig::key(0), 2}});
+
+    rig.roll(0);
+
+    CHECK_FALSE(playing(refilled));
+    CHECK_FALSE(playing(rig.slot(0)));
+}
+
+TEST_CASE("A request still matches the handle it was made against", "[engine][session][launch]") {
+    // The other half: an incarnation that has not moved must not drop the
+    // request, or nothing would ever launch.
+    Rig rig(1);
+    rig.publishWithIncarnation(7);
+
+    {
+        LaunchRequestQueue::Gesture gesture(rig.requests);
+        gesture.play(Rig::key(0));
+    }
+
+    rig.roll(0);
+    CHECK(playing(rig.slot(0)));
 }
 
 TEST_CASE("A slot emptied and refilled does not inherit what was asked of the last one",

--- a/tests/engine/test_session_playback.cpp
+++ b/tests/engine/test_session_playback.cpp
@@ -294,7 +294,7 @@ struct AudioRig {
     /// The same, for a block a case assembled itself.
     void renderBlock(const BlockInfo& block) {
         fill();
-        magda::engine::advanceLaunchHandles(handles, block);
+        magda::engine::advanceLaunchHandles(handles, requests, block);
         source.render(block, juce::dsp::AudioBlock<float>(output));
     }
 
@@ -327,6 +327,7 @@ struct AudioRig {
     LaunchHandle handle;
     LaunchHandleTable table;
     LaunchHandleFeed handles;
+    magda::engine::LaunchRequestQueue requests;
     ClipAudioSource source{kTrack, clips, streams, handles, Section::Session};
     ClipStreamTable streamTable;
     juce::AudioBuffer<float> output;
@@ -378,7 +379,7 @@ struct MidiRig {
     void roll(int first, int last) {
         for (auto index = first; index <= last; ++index) {
             const auto block = blockAt(index, index != first);
-            magda::engine::advanceLaunchHandles(handles, block);
+            magda::engine::advanceLaunchHandles(handles, requests, block);
 
             juce::MidiBuffer buffer;
             source.render(block, buffer);
@@ -428,6 +429,7 @@ struct MidiRig {
     LaunchHandle handle;
     LaunchHandleTable table;
     LaunchHandleFeed handles;
+    magda::engine::LaunchRequestQueue requests;
     ClipMidiSource source{kTrack, clips, handles, Section::Session};
     std::vector<Captured> captured;
 };
@@ -478,7 +480,7 @@ struct MidiSwitchRig {
             const auto block = blockAt(index, rolled_);
             rolled_ = true;
 
-            magda::engine::advanceLaunchHandles(handles, block);
+            magda::engine::advanceLaunchHandles(handles, requests, block);
 
             capture(arrangement, block, index, fromArrangement);
             capture(session, block, index, fromSession);
@@ -528,6 +530,7 @@ struct MidiSwitchRig {
 
     LaunchHandleTable table;
     LaunchHandleFeed handles;
+    magda::engine::LaunchRequestQueue requests;
 
     ClipMidiSource arrangement{kTrack, clips, handles, Section::Arrangement};
     ClipMidiSource session{kTrack, clips, handles, Section::Session};
@@ -774,7 +777,7 @@ struct SwitchRig {
         const auto block = blockAt(index, continuous);
 
         fill();
-        magda::engine::advanceLaunchHandles(handles, block);
+        magda::engine::advanceLaunchHandles(handles, requests, block);
         arrangement.render(block, juce::dsp::AudioBlock<float>(arrangementOut));
         session.render(block, juce::dsp::AudioBlock<float>(sessionOut));
     }
@@ -787,7 +790,7 @@ struct SwitchRig {
     /// The session alone, over a block the case assembled itself.
     void renderSession(const BlockInfo& block) {
         fill();
-        magda::engine::advanceLaunchHandles(handles, block);
+        magda::engine::advanceLaunchHandles(handles, requests, block);
         session.render(block, juce::dsp::AudioBlock<float>(sessionOut)
                                   .getSubBlock(0, static_cast<std::size_t>(block.numSamples)));
     }
@@ -831,6 +834,7 @@ struct SwitchRig {
 
     LaunchHandleTable table;
     LaunchHandleFeed handles;
+    magda::engine::LaunchRequestQueue requests;
 
     ClipAudioSource arrangement{kTrack, clips, streams, handles, Section::Arrangement};
     ClipAudioSource session{kTrack, clips, streams, handles, Section::Session};
@@ -866,7 +870,7 @@ TEST_CASE("The arrangement and the session are different sections of one track",
     rig.handle.play(std::nullopt);
 
     const auto block = blockAt(0);
-    magda::engine::advanceLaunchHandles(rig.handles, block);
+    magda::engine::advanceLaunchHandles(rig.handles, rig.requests, block);
 
     juce::AudioBuffer<float> out(2, kBlockSize);
     rig.fill();
@@ -1717,10 +1721,11 @@ TEST_CASE("A handle is advanced once per block however many sources read it",
 
     LaunchHandleFeed feed;
     feed.publish(std::make_shared<const LaunchHandleTable>(table));
+    magda::engine::LaunchRequestQueue requests;
 
     handle.play(std::nullopt);
-    magda::engine::advanceLaunchHandles(feed, blockAt(0));
-    magda::engine::advanceLaunchHandles(feed, blockAt(1));
+    magda::engine::advanceLaunchHandles(feed, requests, blockAt(0));
+    magda::engine::advanceLaunchHandles(feed, requests, blockAt(1));
 
     // Two blocks of a quarter beat each. Advanced per source it would have
     // moved twice as far, and a slot's audio and MIDI would disagree.

--- a/tests/engine/test_session_playback.cpp
+++ b/tests/engine/test_session_playback.cpp
@@ -1842,8 +1842,9 @@ TEST_CASE("A handle table names every slot, in order, and keeps the handles it h
     NoFactory factory;
     magda::engine::RuntimeStateStore store{factory};
     LaunchHandleFeed feed;
+    magda::engine::LaunchRequestQueue requests;
 
-    const auto first = store.publishHandles(snapshotWithSlots({2, 0, 1}), feed);
+    const auto first = store.publishHandles(snapshotWithSlots({2, 0, 1}), feed, requests);
     REQUIRE(first->entries.size() == 3);
     CHECK(first->entries[0].key.sceneIndex == 0);
     CHECK(first->entries[1].key.sceneIndex == 1);
@@ -1858,7 +1859,7 @@ TEST_CASE("A handle table names every slot, in order, and keeps the handles it h
     playing->advance(magda::engine::syncRangeFor(blockAt(0)));
     REQUIRE(playing->playState() == LaunchHandle::PlayState::playing);
 
-    const auto second = store.publishHandles(snapshotWithSlots({0, 1, 2}), feed);
+    const auto second = store.publishHandles(snapshotWithSlots({0, 1, 2}), feed, requests);
 
     // Same slots, same handles: a clip edit that did not touch the session must
     // not make the callback wait.
@@ -1873,8 +1874,9 @@ TEST_CASE("A slot emptied and refilled does not come back playing", "[engine][cl
     NoFactory factory;
     magda::engine::RuntimeStateStore store{factory};
     LaunchHandleFeed feed;
+    magda::engine::LaunchRequestQueue requests;
 
-    store.publishHandles(snapshotWithSlots({0, 1}), feed);
+    store.publishHandles(snapshotWithSlots({0, 1}), feed, requests);
 
     auto* playing = store.findHandle(SlotKey{kTrack, 0});
     REQUIRE(playing != nullptr);
@@ -1882,10 +1884,10 @@ TEST_CASE("A slot emptied and refilled does not come back playing", "[engine][cl
     playing->advance(magda::engine::syncRangeFor(blockAt(0)));
     REQUIRE(playing->playState() == LaunchHandle::PlayState::playing);
 
-    store.publishHandles(snapshotWithSlots({1}), feed);
+    store.publishHandles(snapshotWithSlots({1}), feed, requests);
     CHECK(store.findHandle(SlotKey{kTrack, 0}) == nullptr);
 
-    store.publishHandles(snapshotWithSlots({0, 1}), feed);
+    store.publishHandles(snapshotWithSlots({0, 1}), feed, requests);
 
     auto* refilled = store.findHandle(SlotKey{kTrack, 0});
     REQUIRE(refilled != nullptr);


### PR DESCRIPTION
Closes #2305. Slice 6 of #1894.

Handle lifetime was already on the epoch: #2301 put allocation and retirement in `RuntimeStateStore::publishHandles`, where the swap waits for the block the callback is in, and `test_launch_handle_lifetime.cpp` covers it. What was missing is the other half of the issue, the lane a launch travels down. `SessionLauncher.hpp` said so: *"until then a handle is driven directly, which is safe only when nothing is rendering"*, and `EngineSession::launchHandle()` handed out a mutable pointer to say it.

## A launch is an event, so it travels on a queue

The engine's one lane publishes a value whole. That is right for what it carries, and wrong here for three reasons that only show up once you try:

- **A request put through it is applied again every block** until something overwrites it, so a launch would retrigger the clip for ever. Closing that needs a serial per slot and somewhere to keep the last one applied.
- **That somewhere is the handle**, and a handle is per slot. A slot emptied and refilled gets a *new* handle whose last-applied is zero, while the published table still names the old request — so the refilled slot comes up already playing. That is exactly the case `test_launch_handle_lifetime.cpp` was written to stop, reintroduced one layer up.
- **A published table has no order.** `setLooping` before `play` is an order: a length set for a clip about to start has to arrive first.

A queue has none of those. A request is written once and read once, so it cannot be re-applied, cannot outlive the block that consumed it, and keeps its order for free.

**A request names a slot and never a handle**, which is what keeps the lane out of the lifetime question entirely rather than making it a second answer to it. Nothing in the ring points at anything, so nothing in it can outlive anything; a request for a slot whose handle has gone finds nothing and does nothing. `playSynced` carries the leader's `SlotKey` too, and is resolved against the table that is live when it is applied — a scene launch decided on the message thread would otherwise join where the leader was a block ago.

## A gesture is what makes a scene one event

`LaunchRequestQueue::Gesture` is RAII over the ring: it fills slots at a private cursor and publishes that cursor once, on destruction. So the audio thread sees every request of a gesture or none of them, and eight clips launched together start on one sample rather than over eight consecutive blocks. It states where a gesture ends in the type rather than leaving it to whoever remembers to call something.

A gesture too large for the ring is dropped whole and counted (`overflows()`), not truncated. Half a scene launching is worse than none: the tracks that made it would be a bar ahead of the ones that did not for as long as they played. Counted rather than left silent for the reason the clock counts its loop wraps — a launch that quietly did not happen is otherwise blamed on the audio device.

The capacity check is at each push rather than at the commit. The slots a full ring would write over are the ones the reader still owns, and rolling a cursor back afterwards does not put their contents back.

## Applied in the pass that advances

`advanceLaunchHandles` takes the queue and drains it whole before advancing anything, which is why it is one call and not two. A request applied after a handle had already been advanced would take effect a block late; one applied to some handles and not others would split a scene down the middle. The queue is drained even when no table is published, and `EngineSession::process` drains it when no plan is — a queue filling while nothing exists to launch would deliver a launch made minutes ago at whatever moment a session appeared.

`launchHandle()` returns `const LaunchHandle*` now, so nothing can drive a handle from the publishing thread. Reading is still only nearly safe and is what there is until the read-back path (#2303).

## The plan swap

Nothing had to change for it, which is the point: handles live in the store, not in the plan, so a swap has nothing of theirs to take. The new end-to-end case asserts it — a track added while a slot plays compiles a new plan and swaps it in, and the clip is not dropped, not restarted (the run's origin is unchanged) and not doubled (three more blocks advance the run by exactly three blocks, where a handle advanced twice over a swap would be half a bar ahead of the transport).

## Tests

New `tests/engine/test_launch_requests.cpp`, 13 cases: the block a request lands in, that an open gesture is invisible, that a request cannot be applied twice, that order is kept, a scene launch in phase, a synced launch whose leader has gone, a request for a slot that is not there, the refilled-slot case above, back-to-arrangement and stop-still-holds over the lane, a request made with nothing published, and the ring's overflow / exact-fit / reuse behaviour. Plus the structural-edit case in `test_engine_device_layer`'s neighbour `test_engine_session.cpp`.

`[launch]` 45 cases and `[session]` 138 cases pass.

https://claude.ai/code/session_013CDpSHas8bog33vv4o6HLv
