### PR TITLE
A track's MIDI merge has three producers, not two (#2356)

### DIFF
--- a/tests/engine/test_engine_device_layer.cpp
+++ b/tests/engine/test_engine_device_layer.cpp
@@ -610,10 +610,10 @@ TEST_CASE("the executor tells a device what it may write, apart from what it may
     // its output port is one producer's worth, because a device emits what it
     // made and thru is the plan's merge behind it (#2345).
     //
-    // Clips and a hardware input both merge onto this track, so what reaches
-    // the device is two producers' worth rather than one -- exactly the sum a
-    // device could not have worked out for itself, and exactly the figure it
-    // must not size its own writing from.
+    // Clips, the session launcher and a hardware input all merge onto this
+    // track, so what reaches the device is three producers' worth -- the sum a
+    // device could not have worked out for itself, and the figure it must not
+    // size its own writing from. Session sources joined the merge in #2318.
     magda::TrackInfo instrument;
     instrument.id = 1;
     instrument.type = magda::TrackType::Media;
@@ -652,7 +652,7 @@ TEST_CASE("the executor tells a device what it may write, apart from what it may
     executor.prepare(plan, bindings, contextFor(), nullptr, nullptr);
     REQUIRE(executor.isPrepared());
 
-    REQUIRE(synthProbe.bound == 2 * magda::engine::kMaxMidiBytesPerPort);
+    REQUIRE(synthProbe.bound == 3 * magda::engine::kMaxMidiBytesPerPort);
     CHECK(synthProbe.outBound == magda::engine::kMaxMidiBytesPerPort);
 
     // The gain emits no MIDI at all, and is told so rather than being left at


### PR DESCRIPTION
Closes #2356.

`dev/0.20.0` has been red on **macOS, Linux and Windows alike** since `931925f7`, and every branch off it inherits the failure. This is the one assertion:

```
tests/engine/test_engine_device_layer.cpp:655: FAILED:
  REQUIRE( synthProbe.bound == 2 * magda::engine::kMaxMidiBytesPerPort )
with expansion:
  12288 (0x3000) == 8192 (0x2000)
```

## The plan grew a producer

#2318 gave a track that carries clips a `SessionMidi` source beside its `ClipMidi` one (`PlanCompiler.cpp`, the `carriesClips(track)` branch). So a record-armed track's `TrackMidiInput` merge takes three inputs, not two. Dumped rather than inferred from the arithmetic:

```
ClipMidi                    inputs=0
SessionMidi                 inputs=0
MidiInput  (LiveMidiInput)  inputs=0
MergeMidi  (TrackMidiInput) inputs=3
```

## Three is right, so the expectation is what moves

A track can be sounding its arranger and a launched session clip at the same time — during a section switch both are live while the crossfade runs (#2302). The bound a device is handed has to cover both, or it sizes its reading from two producers and drops the third's tail on the way in, which is the exact failure #2341 set out to remove.

So the plan and the executor's forward pass are untouched. Only the number in the test moves, with the reason recorded beside it so the next person who reads `2` in a comment does not have to re-derive this.

The sibling assertion above it (`synthProbe.bound >= kMaxMidiBytesPerPort`) is a lower bound and was passing throughout, which is why only one of the pair failed.

## Results

Full Catch2 suite green: **3513 passed, 0 failed, 13 skipped**. Verified negatively — putting `2` back reproduces the failure exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018rAnjCekXfSQtpsr7jLtj5
