### PR TITLE
Reinstall the Convolution's unit impulse at the prepared sample rate

### DIFF
--- a/magda/daw/audio/plugins/MagdaConvolutionPlugin.cpp
+++ b/magda/daw/audio/plugins/MagdaConvolutionPlugin.cpp
@@ -213,15 +213,9 @@ bool MagdaConvolutionPlugin::loadImpulseResponse(const void* sourceData, size_t 
 void MagdaConvolutionPlugin::prepare(const DevicePrepareContext& context) {
     sampleRate_ = context.sampleRate;
 
-    // restoreState() runs before the first prepare() in both hosts, so a
-    // device restored with no IR queued its pass-through dirac stamped at
-    // the 44100 default (#2360). juce::dsp::Convolution loads impulse
-    // responses through a background queue, but chain_.prepare() below pops
-    // it synchronously before rebuilding the convolution engine for the
-    // now-real sampleRate_ - reinstalling here, before that pop, replaces
-    // the stale stamp in time for that same rebuild, rather than racing a
-    // background thread to replace it after. Skipped once a real IR is
-    // loaded: its source rate came from the file, not this default.
+    // restoreState() stamps a no-IR dirac at the stale 44100 default before
+    // sampleRate_ is real; reinstall it here, before chain_.prepare() pops
+    // the load queue and rebuilds against the new rate (#2360).
     if (irData_.getSize() == 0)
         loadImpulseResponseFromData();
 

--- a/magda/daw/audio/plugins/MagdaConvolutionPlugin.cpp
+++ b/magda/daw/audio/plugins/MagdaConvolutionPlugin.cpp
@@ -213,6 +213,18 @@ bool MagdaConvolutionPlugin::loadImpulseResponse(const void* sourceData, size_t 
 void MagdaConvolutionPlugin::prepare(const DevicePrepareContext& context) {
     sampleRate_ = context.sampleRate;
 
+    // restoreState() runs before the first prepare() in both hosts, so a
+    // device restored with no IR queued its pass-through dirac stamped at
+    // the 44100 default (#2360). juce::dsp::Convolution loads impulse
+    // responses through a background queue, but chain_.prepare() below pops
+    // it synchronously before rebuilding the convolution engine for the
+    // now-real sampleRate_ - reinstalling here, before that pop, replaces
+    // the stale stamp in time for that same rebuild, rather than racing a
+    // background thread to replace it after. Skipped once a real IR is
+    // loaded: its source rate came from the file, not this default.
+    if (irData_.getSize() == 0)
+        loadImpulseResponseFromData();
+
     juce::dsp::ProcessSpec spec;
     spec.sampleRate = context.sampleRate;
     spec.maximumBlockSize = static_cast<juce::uint32>(std::max(1, context.maximumBlockSize));

--- a/tests/devices/test_convolution_device_juce.cpp
+++ b/tests/devices/test_convolution_device_juce.cpp
@@ -107,21 +107,17 @@ int peakIndex(const juce::AudioBuffer<float>& buffer) {
     return index;
 }
 
-/// The RMS of `measureCycles` complete cycles of a `frequency` Hz sine at
-/// `sampleRate`, rendered after `settleBlocks` warm-up blocks (the biquads'
-/// own filter state starts at zero and needs a few blocks to reach steady
-/// state - the convolution engine itself does not: prepare() installs it
-/// directly, with no crossfade, per Convolution::Impl::prepare()).
-///
-/// Measuring a whole number of cycles matters: `frequency` must divide
-/// `sampleRate` exactly, or the last block ends mid-cycle and its RMS carries
-/// a windowing residual large enough on its own to swallow the bug this test
-/// is for - e.g. one block of a 100 Hz tone's last-256-samples RMS is ~0.749
-/// at 44.1 kHz vs ~0.705 at 48 kHz, a gap from the window alone that is
-/// comparable to the bug's. 300 Hz divides both 44100 and 48000 exactly (147
-/// and 160 samples/cycle), so the measured window has no residual, and the
-/// result is compared to the sine's own exact RMS rather than to a render at
-/// another rate - independent of that rate's filter coefficients entirely.
+/**
+ * @brief RMS of a steady-state `frequency` Hz tone through `plugin`.
+ *
+ * `frequency` must divide `sampleRate` evenly (300 Hz fits both 44100 and
+ * 48000) so the measured window is a whole number of cycles - otherwise its
+ * windowing residual can rival the #2360 gain bug this test is for.
+ *
+ * @param settleBlocks Blocks rendered and discarded before measuring, to
+ *                     clear the filters' startup transient.
+ * @param measureCycles Whole tone cycles accumulated into the RMS.
+ */
 float steadyStateSineRms(te::Plugin& plugin, double sampleRate, double frequency, int settleBlocks,
                          int measureCycles) {
     juce::AudioBuffer<float> buffer(2, kBlockSize);
@@ -440,14 +436,9 @@ class ConvolutionDeviceTest final : public juce::UnitTest {
         holder->deleteFromParent();
     }
 
-    // restoreState() stamps the no-IR dirac at its 44100 default before the
-    // first prepare() ever runs (both hosts restore before preparing), so a
-    // session at any other rate must not hear that stamp resampled (#2360).
-    // 300 Hz sits far enough inside the low-cut/high-cut defaults (10 Hz/20
-    // kHz) that their coefficients are close enough to flat, at either rate,
-    // to not be the source of a gain error here - unlike a broadband
-    // impulse, whose peak the high-cut colours differently simply because
-    // 20 kHz sits closer to Nyquist at 44.1 kHz than it does at 48 kHz.
+    // No IR must be a pass-through at any session rate, not just 44.1 kHz
+    // (#2360). 300 Hz avoids the low-cut/high-cut colouring near Nyquist
+    // that a broadband impulse would show.
     void testNoIrIsAPassThroughAtANonDefaultSampleRate(te::Edit& edit) {
         beginTest("No IR is a pass-through on a session that is not 44.1 kHz");
 

--- a/tests/devices/test_convolution_device_juce.cpp
+++ b/tests/devices/test_convolution_device_juce.cpp
@@ -107,12 +107,70 @@ int peakIndex(const juce::AudioBuffer<float>& buffer) {
     return index;
 }
 
-void prepareForRender(te::Plugin& plugin) {
+/// The RMS of `measureCycles` complete cycles of a `frequency` Hz sine at
+/// `sampleRate`, rendered after `settleBlocks` warm-up blocks (the biquads'
+/// own filter state starts at zero and needs a few blocks to reach steady
+/// state - the convolution engine itself does not: prepare() installs it
+/// directly, with no crossfade, per Convolution::Impl::prepare()).
+///
+/// Measuring a whole number of cycles matters: `frequency` must divide
+/// `sampleRate` exactly, or the last block ends mid-cycle and its RMS carries
+/// a windowing residual large enough on its own to swallow the bug this test
+/// is for - e.g. one block of a 100 Hz tone's last-256-samples RMS is ~0.749
+/// at 44.1 kHz vs ~0.705 at 48 kHz, a gap from the window alone that is
+/// comparable to the bug's. 300 Hz divides both 44100 and 48000 exactly (147
+/// and 160 samples/cycle), so the measured window has no residual, and the
+/// result is compared to the sine's own exact RMS rather than to a render at
+/// another rate - independent of that rate's filter coefficients entirely.
+float steadyStateSineRms(te::Plugin& plugin, double sampleRate, double frequency, int settleBlocks,
+                         int measureCycles) {
+    juce::AudioBuffer<float> buffer(2, kBlockSize);
+    te::MidiMessageArray midi;
+    double phase = 0.0;
+    const double phaseIncrement = juce::MathConstants<double>::twoPi * frequency / sampleRate;
+
+    const auto renderBlock = [&] {
+        for (int i = 0; i < kBlockSize; ++i) {
+            const auto sample = static_cast<float>(std::sin(phase));
+            buffer.setSample(0, i, sample);
+            buffer.setSample(1, i, sample);
+            phase += phaseIncrement;
+        }
+        te::PluginRenderContext context(&buffer, juce::AudioChannelSet::stereo(), 0, kBlockSize,
+                                        &midi, 0.0, tracktion::TimeRange(), true, false, false,
+                                        true);
+        plugin.applyToBuffer(context);
+    };
+
+    for (int block = 0; block < settleBlocks; ++block)
+        renderBlock();
+
+    const int samplesPerCycle = juce::roundToInt(sampleRate / frequency);
+    const int measureSamples = measureCycles * samplesPerCycle;
+    double sumSquares = 0.0;
+    int measured = 0;
+    while (measured < measureSamples) {
+        renderBlock();
+        const int take = std::min(kBlockSize, measureSamples - measured);
+        for (int i = 0; i < take; ++i) {
+            const auto sample = buffer.getSample(0, i);
+            sumSquares += sample * sample;
+        }
+        measured += take;
+    }
+    return std::sqrt(static_cast<float>(sumSquares / measured));
+}
+
+void prepareForRenderAtSampleRate(te::Plugin& plugin, double sampleRate) {
     te::PluginInitialisationInfo info;
     info.startTime = tracktion::TimePosition();
-    info.sampleRate = kSampleRate;
+    info.sampleRate = sampleRate;
     info.blockSizeSamples = kBlockSize;
     plugin.baseClassInitialise(info);
+}
+
+void prepareForRender(te::Plugin& plugin) {
+    prepareForRenderAtSampleRate(plugin, kSampleRate);
 }
 
 class ConvolutionDeviceTest final : public juce::UnitTest {
@@ -134,6 +192,7 @@ class ConvolutionDeviceTest final : public juce::UnitTest {
         testImpulseResponseSurvivesSaveAndReload(*edit);
         testRestoringAStatelessDocumentUnloadsTheImpulseResponse(*edit);
         testDryPassesThroughUntouched(*edit);
+        testNoIrIsAPassThroughAtANonDefaultSampleRate(*edit);
     }
 
   private:
@@ -379,6 +438,43 @@ class ConvolutionDeviceTest final : public juce::UnitTest {
         expectEquals(peakIndex(rendered), 0);
 
         holder->deleteFromParent();
+    }
+
+    // restoreState() stamps the no-IR dirac at its 44100 default before the
+    // first prepare() ever runs (both hosts restore before preparing), so a
+    // session at any other rate must not hear that stamp resampled (#2360).
+    // 300 Hz sits far enough inside the low-cut/high-cut defaults (10 Hz/20
+    // kHz) that their coefficients are close enough to flat, at either rate,
+    // to not be the source of a gain error here - unlike a broadband
+    // impulse, whose peak the high-cut colours differently simply because
+    // 20 kHz sits closer to Nyquist at 44.1 kHz than it does at 48 kHz.
+    void testNoIrIsAPassThroughAtANonDefaultSampleRate(te::Edit& edit) {
+        beginTest("No IR is a pass-through on a session that is not 44.1 kHz");
+
+        constexpr double kToneHz = 300.0;
+        constexpr int kSettleBlocks = 4;
+        constexpr int kMeasureCycles = 20;
+        const float kExpectedRms = std::sqrt(0.5f);
+
+        for (const double rate : {kSampleRate, 48000.0}) {
+            te::Plugin::Ptr holder;
+            auto* convolution = createConvolution(edit, holder);
+            expect(convolution != nullptr);
+            if (convolution == nullptr)
+                continue;
+
+            setSlotDisplayValue(*holder, *convolution, audio::MagdaConvolutionPlugin::kMix, 1.0f);
+            prepareForRenderAtSampleRate(*holder, rate);
+            const auto rms =
+                steadyStateSineRms(*holder, rate, kToneHz, kSettleBlocks, kMeasureCycles);
+
+            expectWithinAbsoluteError(rms, kExpectedRms, 0.005f,
+                                      "the pass-through dirac was resampled from the 44100 "
+                                      "default at " +
+                                          juce::String(rate));
+
+            holder->deleteFromParent();
+        }
     }
 };
 


### PR DESCRIPTION
Closes #2360.

## Problem

With no IR loaded, `MagdaConvolutionPlugin` loads a one-sample unit-impulse dirac (the pass-through identity) stamped with `sampleRate_`, which defaults to 44100 at construction. `restoreState()` runs before the first `prepare()` in both hosts, so a device restored with no IR gets that dirac loaded at the stale 44100 default. `prepare()` then set `sampleRate_` to the real session rate but never reinstalled the impulse, so `juce::dsp::Convolution::prepare()` resampled the stale 44100-stamped dirac to the session rate — with `Normalise::no`, scaling by `44100/rate` and running it through the resampler's low-pass — so a session at any rate but 44.1 kHz heard "no IR" as a slight low-pass and level drop instead of a transparent pass-through.

## Fix

Reinstall the dirac, stamped with the now-real `sampleRate_`, before `chain_.prepare(spec)` rather than after. `Convolution::loadImpulseResponse()` only *queues* the load — `Convolution::Impl::prepare()` pops that queue synchronously before it rebuilds the engine for the new spec, so installing before is what lands the correction in time for that same rebuild. Installing after queues a correction that only takes effect whenever something later happens to drain the queue, which a synchronous prepare-then-process host does not guarantee before the very next block. (Verified this ordering against the actual JUCE source, and empirically: installing after `chain_.prepare()` only partially fixed the measured gain error.)

## Test

Added a regression test comparing a 300 Hz tone's RMS against its own exact theoretical value at both 44.1 kHz and 48 kHz with no IR loaded. 300 Hz divides both 44100 and 48000 into a whole number of samples/cycle, so the measurement window carries no windowing residual to confound the comparison (an earlier version of this test measured a non-whole-cycle window and had a residual large enough to rival the bug's own signal — caught in review).

Verified negatively: reverting just the source change reproduces a clear divergence (0.707 expected vs 0.542 measured at 48 kHz). Full "Convolution Device" JUCE suite passes.

## Review

Reviewed by Codex, which confirmed the core ordering fix against the actual JUCE `Convolution::Impl::prepare()` source (citing the `popAll()`-before-`setProcessSpec()` ordering and `makeEngine()`'s resample/scale logic), found no remaining edge-case bugs (second `prepare()`, IR unload path, threading), and flagged the windowing issue in the first draft of the regression test, which was then fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NJcMXn1jyk4tvFGh4wUAu8