### PR TITLE
Publish a slot's state from the block that decided it (#2303)

### DIFF
--- a/.claude/skills/comments-not-essays/SKILL.md
+++ b/.claude/skills/comments-not-essays/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: comments-not-essays
+description: Comment and docstring discipline. Load before writing or editing any comment, doc block, or docstring in code. Cuts essay-length doc blocks, rhetorical structure, rejected-alternatives narration, and restated code.
+---
+
+# Comments Are Not Essays
+
+A comment is a line or two. Two paragraphs is the hard ceiling. Anything that needs more than
+that is a technical document: put it in `docs/` and leave a one-line pointer.
+
+This applies to every comment form: `//`, `///`, `/** */`, docstrings, module headers, file
+headers, test-case preambles.
+
+## The test, before any comment ships
+
+**Would someone about to change this code do the wrong thing without it?**
+
+No -> cut it. That is the whole rule.
+
+## Never
+
+- **Markdown section headings inside a comment.** `## Why it is not a meter`, `## One word`,
+  `## What no writes means`. A doc block with headings is a document that has been pasted into a
+  source file. Move it to `docs/` or delete it.
+- **Narrating rejected alternatives.** "The alternative is X, which would be wrong because Y."
+  Nobody is proposing X. State what the code does; the reader does not need the road not taken.
+- **Building a case.** No "which is the whole of it", "which is exactly why", "and that is the
+  point", "for the reason that". These are argument connectives. A settled decision needs no
+  argument, only a statement.
+- **Restating the code below it.** If the line says `if (x == nullptr) return;`, do not write
+  "returns early when x is null".
+- **Worked examples and arithmetic.** "at 48 kHz and 123 bpm a beat is 23,414.634 samples, so a
+  thousand retriggers finish 366 samples late". Put it in a test, where it can fail.
+- **Repeating a rationale across files.** Say it once, at the definition. Other sites get a
+  cross-reference, not a copy.
+- **Essay openings.** "The whole reason X is Y", "Two things come apart here", "What decides".
+
+## What earns more than a line
+
+Only these, and only the sentence that carries them:
+
+- an issue number (`(#2305)`)
+- an external constraint: a Tracktion quirk, a JUCE contract, a wire-format rule, a platform bug
+- a measured figure, with its units
+- a non-obvious decision someone would otherwise undo
+
+## Shape
+
+Doc block on a method: `@brief` one sentence, then `@param`/`@return` if the name does not
+already say it. Fields and short methods: one `///` line. Follow the surrounding file.
+
+    /**
+     * @brief Publish what this block left @p handle doing. Audio thread.
+     *
+     * Once per block, from the pass that advanced it, so the reading and the
+     * audio it describes are the same block.
+     */
+
+That is the maximum for a normal method. Not a section, not an argument, not a comparison to
+what the old engine did.
+
+## When you catch yourself
+
+If a comment you are writing has a second paragraph, stop and ask whether the first one already
+did the job. It usually did. If it genuinely did not, the material is a `docs/` page.
+
+Trimming your own comments in a later pass does not fix this. Do not write them.
+
+## MAGDA specifics
+
+`CLAUDE.md` at the repo root carries the same rule. `scripts/comment_ratio.py` measures the
+line ratio, but the ratio is a proxy: dense one-liners at a high ratio are fine, and a short
+essay at a low ratio is not. Judge the prose, not the count.

--- a/magda/engine/CMakeLists.txt
+++ b/magda/engine/CMakeLists.txt
@@ -107,6 +107,7 @@ add_library(magda_engine STATIC
     launch/LaunchHandle.cpp
     launch/LaunchHandle.hpp
     launch/LaunchRequests.hpp
+    tap/LaunchTap.hpp
     launch/SessionLauncher.cpp
     launch/SessionLauncher.hpp
     transport/TempoMap.cpp

--- a/magda/engine/exec/EngineSession.hpp
+++ b/magda/engine/exec/EngineSession.hpp
@@ -173,9 +173,12 @@ class EngineSession {
     /**
      * @brief Where @p key's state is published for the UI, or null (#2303).
      *
-     * Read from any thread, as often as a repaint likes. The pointer is good
-     * until a publishClips() stops naming the slot, the same lifetime
-     * valueTap() hands out.
+     * Both the lookup and the pointer belong to the publishing thread, exactly
+     * as valueTap() does: the next publishClips() that stops naming the slot
+     * destroys the tap on that thread, with nothing deferring it, so a pointer
+     * cached and read from a paint or animation thread is a use-after-free
+     * waiting for a clip edit. Fetch it here, use it before returning to the
+     * message loop, and ask again after every publish.
      */
     const LaunchTap* launchTap(const SlotKey& key) const {
         return store_.launchTap(key);

--- a/magda/engine/exec/EngineSession.hpp
+++ b/magda/engine/exec/EngineSession.hpp
@@ -171,12 +171,26 @@ class EngineSession {
     }
 
     /**
+     * @brief Where @p key's state is published for the UI, or null (#2303).
+     *
+     * What a slot button and a session playhead draw from. Read from any
+     * thread, as often as a repaint likes; the block that decided the state is
+     * what published it, so nothing polls and nothing is a frame behind.
+     *
+     * The pointer belongs to the publishing thread and is good until a
+     * publishClips() stops naming the slot, which is the same lifetime
+     * valueTap() hands out. Null until publishClips() has named it.
+     */
+    const LaunchTap* launchTap(const SlotKey& key) const {
+        return store_.launchTap(key);
+    }
+
+    /**
      * @brief The handle for @p key, or null. On the publishing thread.
      *
-     * To read, and only to read: a handle is advanced on the audio thread, so
-     * changing one from here races the callback. Every change goes through
-     * @ref launchRequests. Reading is itself only nearly safe, and is what
-     * there is until the read-back path is built (#2303).
+     * For tests and diagnostics. What the state is belongs to @ref launchTap
+     * and what changes it belongs to @ref launchRequests; a handle is advanced
+     * on the audio thread, so reading one from here races the callback.
      */
     const LaunchHandle* launchHandle(const SlotKey& key) const {
         return store_.findHandle(key);

--- a/magda/engine/exec/EngineSession.hpp
+++ b/magda/engine/exec/EngineSession.hpp
@@ -173,24 +173,20 @@ class EngineSession {
     /**
      * @brief Where @p key's state is published for the UI, or null (#2303).
      *
-     * What a slot button and a session playhead draw from. Read from any
-     * thread, as often as a repaint likes; the block that decided the state is
-     * what published it, so nothing polls and nothing is a frame behind.
-     *
-     * The pointer belongs to the publishing thread and is good until a
-     * publishClips() stops naming the slot, which is the same lifetime
-     * valueTap() hands out. Null until publishClips() has named it.
+     * Read from any thread, as often as a repaint likes. The pointer is good
+     * until a publishClips() stops naming the slot, the same lifetime
+     * valueTap() hands out.
      */
     const LaunchTap* launchTap(const SlotKey& key) const {
         return store_.launchTap(key);
     }
 
     /**
-     * @brief The handle for @p key, or null. On the publishing thread.
+     * @brief The handle for @p key, or null. Tests and diagnostics only.
      *
-     * For tests and diagnostics. What the state is belongs to @ref launchTap
-     * and what changes it belongs to @ref launchRequests; a handle is advanced
-     * on the audio thread, so reading one from here races the callback.
+     * State belongs to @ref launchTap and changes to @ref launchRequests; a
+     * handle is advanced on the audio thread, so reading one here races the
+     * callback.
      */
     const LaunchHandle* launchHandle(const SlotKey& key) const {
         return store_.findHandle(key);

--- a/magda/engine/exec/RuntimeStateStore.cpp
+++ b/magda/engine/exec/RuntimeStateStore.cpp
@@ -333,10 +333,11 @@ std::shared_ptr<const LaunchHandleTable> RuntimeStateStore::publishHandles(
                 // the handle that was here can never match its replacement.
                 made.handle = std::make_unique<LaunchHandle>();
                 made.incarnation = ++nextIncarnation_;
+                made.tap = std::make_unique<LaunchTap>();
             }
 
             table->entries.push_back(
-                LaunchHandleTable::Entry{key, made.handle.get(), made.incarnation});
+                LaunchHandleTable::Entry{key, made.handle.get(), made.incarnation, made.tap.get()});
         }
 
     // Sorted on arrival, since a snapshot holds tracks by id and slots by
@@ -376,6 +377,11 @@ std::shared_ptr<const LaunchHandleTable> RuntimeStateStore::publishHandles(
 LaunchHandle* RuntimeStateStore::findHandle(const SlotKey& key) const {
     const auto it = handles_.find(key);
     return it == handles_.end() ? nullptr : it->second.handle.get();
+}
+
+const LaunchTap* RuntimeStateStore::launchTap(const SlotKey& key) const {
+    const auto it = handles_.find(key);
+    return it == handles_.end() ? nullptr : it->second.tap.get();
 }
 
 ValueTap* RuntimeStateStore::valueTap(const ParamKey& key) const {

--- a/magda/engine/exec/RuntimeStateStore.hpp
+++ b/magda/engine/exec/RuntimeStateStore.hpp
@@ -266,8 +266,13 @@ class RuntimeStateStore {
     /// @brief The handle for @p key, or null when no published snapshot names it.
     LaunchHandle* findHandle(const SlotKey& key) const;
 
-    /// @brief Where @p key's state is published, or null (#2303). Made and
-    ///        retired with the handle beside it.
+    /**
+     * @brief Where @p key's state is published, or null (#2303).
+     *
+     * Made and retired with the handle beside it, and on the publishing thread
+     * both to look up and to read: publishHandles() destroys a dropped slot's
+     * tap as soon as the audio thread is out of it, and waits for nothing else.
+     */
     const LaunchTap* launchTap(const SlotKey& key) const;
 
     /// @brief Objects currently owned, for tests and diagnostics.

--- a/magda/engine/exec/RuntimeStateStore.hpp
+++ b/magda/engine/exec/RuntimeStateStore.hpp
@@ -266,6 +266,14 @@ class RuntimeStateStore {
     /// @brief The handle for @p key, or null when no published snapshot names it.
     LaunchHandle* findHandle(const SlotKey& key) const;
 
+    /**
+     * @brief Where @p key's state is published, or null (#2303).
+     *
+     * Made and retired with the handle beside it, so a pointer taken from here
+     * is good until the next publishHandles() that stops naming the slot.
+     */
+    const LaunchTap* launchTap(const SlotKey& key) const;
+
     /// @brief Objects currently owned, for tests and diagnostics.
     std::size_t size() const;
 
@@ -294,6 +302,10 @@ class RuntimeStateStore {
     struct Slot {
         std::unique_ptr<LaunchHandle> handle;
         std::uint64_t incarnation = 0;
+
+        /// Beside the handle rather than in the table, so the address a host
+        /// read stays put across a publish that did not retire the slot.
+        std::unique_ptr<LaunchTap> tap;
     };
 
     /// One per slot rather than per track: a slot's loop phase and played

--- a/magda/engine/exec/RuntimeStateStore.hpp
+++ b/magda/engine/exec/RuntimeStateStore.hpp
@@ -266,12 +266,8 @@ class RuntimeStateStore {
     /// @brief The handle for @p key, or null when no published snapshot names it.
     LaunchHandle* findHandle(const SlotKey& key) const;
 
-    /**
-     * @brief Where @p key's state is published, or null (#2303).
-     *
-     * Made and retired with the handle beside it, so a pointer taken from here
-     * is good until the next publishHandles() that stops naming the slot.
-     */
+    /// @brief Where @p key's state is published, or null (#2303). Made and
+    ///        retired with the handle beside it.
     const LaunchTap* launchTap(const SlotKey& key) const;
 
     /// @brief Objects currently owned, for tests and diagnostics.
@@ -303,8 +299,8 @@ class RuntimeStateStore {
         std::unique_ptr<LaunchHandle> handle;
         std::uint64_t incarnation = 0;
 
-        /// Beside the handle rather than in the table, so the address a host
-        /// read stays put across a publish that did not retire the slot.
+        /// Beside the handle, so a host's pointer survives a publish that did
+        /// not retire the slot.
         std::unique_ptr<LaunchTap> tap;
     };
 

--- a/magda/engine/launch/SessionLauncher.cpp
+++ b/magda/engine/launch/SessionLauncher.cpp
@@ -114,8 +114,14 @@ void advanceLaunchHandles(LaunchHandleFeed& handles, LaunchRequestQueue& request
     const auto range = syncRangeFor(block);
 
     for (const auto& entry : table->entries)
-        if (entry.handle != nullptr)
+        if (entry.handle != nullptr) {
             entry.handle->advance(range);
+
+            // Published by the block that decided it, so the UI is never a
+            // frame behind the audio and has nothing to poll (#2303).
+            if (entry.tap != nullptr)
+                entry.tap->write(*entry.handle);
+        }
 }
 
 }  // namespace magda::engine

--- a/magda/engine/launch/SessionLauncher.hpp
+++ b/magda/engine/launch/SessionLauncher.hpp
@@ -10,6 +10,7 @@
 #include "exec/RenderContext.hpp"
 #include "launch/LaunchHandle.hpp"
 #include "launch/LaunchRequests.hpp"
+#include "tap/LaunchTap.hpp"
 
 /**
  * @file SessionLauncher.hpp
@@ -51,6 +52,10 @@ struct LaunchHandleTable {
         /// same key on a different clip. Assigned by
         /// RuntimeStateStore::publishHandles, and never reused (#2305).
         std::uint64_t incarnation = 0;
+
+        /// Where this slot's state is published for the UI to read (#2303).
+        /// Owned by the store, like the handle beside it.
+        LaunchTap* tap = nullptr;
 
         bool operator==(const Entry&) const = default;
     };

--- a/magda/engine/tap/LaunchTap.hpp
+++ b/magda/engine/tap/LaunchTap.hpp
@@ -1,7 +1,8 @@
 #pragma once
 
+#include <algorithm>
 #include <atomic>
-#include <bit>
+#include <cmath>
 #include <cstdint>
 
 #include "launch/LaunchHandle.hpp"
@@ -15,7 +16,13 @@
  * value tap: a slot no block has advanced is stopped, which is what a button
  * should draw anyway.
  *
- * One writer, the audio thread. Any number of readers.
+ * The position is fixed point rather than a float because a run accumulates for
+ * as long as a clip plays: a float's step reaches 16 ms after three days at 120
+ * bpm and 250 ms after thirty-three, so a playhead in a long-running set would
+ * stall and jump (#2303 review).
+ *
+ * One writer, the audio thread. Readers on the publishing thread, whose
+ * lifetime rule this follows (RuntimeStateStore::launchTap).
  */
 
 namespace magda::engine {
@@ -33,7 +40,7 @@ class LaunchTap {
         /// Timeline beats this run has covered, unlooped, or zero while
         /// stopped. The UI wraps it against the clip length, which is the
         /// model's.
-        float elapsedBeats = 0.0f;
+        double elapsedBeats = 0.0;
 
         bool playing = false;
 
@@ -48,7 +55,7 @@ class LaunchTap {
     /**
      * @brief What the last block to render left the slot doing.
      *
-     * Off the audio thread, from any number of readers. One load, so the
+     * On the publishing thread, as often as a repaint likes. One load, so the
      * position and the state are one block's own.
      */
     Reading read() const {
@@ -71,32 +78,45 @@ class LaunchTap {
                 *queued == LaunchHandle::QueueState::playQueued ? Queued::play : Queued::stop;
 
         if (const auto played = handle.playedRange())
-            reading.elapsedBeats = static_cast<float>(played->length());
+            reading.elapsedBeats = played->length();
 
+        write(reading);
+    }
+
+    /// @brief Publish @p reading as it stands. Audio thread.
+    void write(const Reading& reading) {
         state_.store(pack(reading), std::memory_order_release);
     }
 
   private:
-    /// Status half: playing, the two queued bits, then the section hold.
-    static std::uint32_t packStatus(const Reading& reading) {
-        return static_cast<std::uint32_t>(reading.playing ? 1U : 0U) |
-               (static_cast<std::uint32_t>(reading.queued) << 1U) |
-               (static_cast<std::uint32_t>(reading.holdsSection ? 1U : 0U) << 3U);
+    /// Four status bits: playing, the two queued bits, then the section hold.
+    static constexpr int kStatusBits = 4;
+
+    /// Beat fractions per unit. A twelfth of a millisecond at 120 bpm, and the
+    /// remaining 60 bits still reach further than any session will.
+    static constexpr double kUnitsPerBeat = 4096.0;
+
+    static constexpr std::uint64_t kMaxUnits = (1ULL << (64 - kStatusBits)) - 1ULL;
+
+    static std::uint64_t packStatus(const Reading& reading) {
+        return static_cast<std::uint64_t>(reading.playing ? 1U : 0U) |
+               (static_cast<std::uint64_t>(reading.queued) << 1U) |
+               (static_cast<std::uint64_t>(reading.holdsSection ? 1U : 0U) << 3U);
     }
 
     static std::uint64_t pack(const Reading& reading) {
-        return static_cast<std::uint64_t>(std::bit_cast<std::uint32_t>(reading.elapsedBeats)) |
-               (static_cast<std::uint64_t>(packStatus(reading)) << 32U);
+        const auto units = std::clamp(std::round(reading.elapsedBeats * kUnitsPerBeat), 0.0,
+                                      static_cast<double>(kMaxUnits));
+
+        return packStatus(reading) | (static_cast<std::uint64_t>(units) << kStatusBits);
     }
 
     static Reading unpack(std::uint64_t word) {
-        const auto status = static_cast<std::uint32_t>(word >> 32U);
-
         Reading reading;
-        reading.elapsedBeats = std::bit_cast<float>(static_cast<std::uint32_t>(word));
-        reading.playing = (status & 1U) != 0U;
-        reading.queued = static_cast<Queued>((status >> 1U) & 0b11U);
-        reading.holdsSection = ((status >> 3U) & 1U) != 0U;
+        reading.elapsedBeats = static_cast<double>(word >> kStatusBits) / kUnitsPerBeat;
+        reading.playing = (word & 1U) != 0U;
+        reading.queued = static_cast<Queued>((word >> 1U) & 0b11U);
+        reading.holdsSection = ((word >> 3U) & 1U) != 0U;
         return reading;
     }
 

--- a/magda/engine/tap/LaunchTap.hpp
+++ b/magda/engine/tap/LaunchTap.hpp
@@ -1,0 +1,131 @@
+#pragma once
+
+#include <atomic>
+#include <bit>
+#include <cstdint>
+
+#include "launch/LaunchHandle.hpp"
+
+/**
+ * @file LaunchTap.hpp
+ * @brief What a block left a slot doing, for whoever draws it (#2303).
+ *
+ * The read-back side of the launcher. A slot button knows it is queued, a
+ * session playhead knows how far into its clip it is, and neither asks: the
+ * block that decided it publishes it, the way a value tap publishes what a
+ * parameter resolved to (ValueTap.hpp).
+ *
+ * The incumbent polls instead -- `SessionClipScheduler::processStateEvents` off
+ * a 33 ms timer -- which puts the UI a frame behind the audio on every launch
+ * and needs a second entry point (`relaunchActiveClips`) for the case where
+ * that mattered. Both go with the poll.
+ *
+ * ## One word
+ *
+ * A reading pairs a position with the state it was in, so a slot cannot draw a
+ * playhead from before the launch that started it, or a queued badge beside a
+ * position that has already begun moving. A float and a 32-bit status fit in
+ * one 64-bit word, which is one store on the audio thread and one load off it,
+ * with nothing to retry.
+ *
+ * ## Why there is no write count
+ *
+ * A ValueTap counts blocks because a modifier that holds while the engine is
+ * stopped is indistinguishable from one that is not moving, and because a value
+ * nothing publishes has to fall back to the model's. Neither applies here. A
+ * slot that is not playing is not playing whether or not a block has ever said
+ * so, and that is exactly what a button should draw, so the default reading is
+ * already the true one and there is nothing for a count to disambiguate.
+ *
+ * One writer, the audio thread. Any number of readers.
+ */
+
+namespace magda::engine {
+
+class LaunchTap {
+    static_assert(std::atomic<std::uint64_t>::is_always_lock_free,
+                  "a launch tap is written on the audio thread and must not take a lock");
+
+  public:
+    /// What a slot has been asked for and has not reached yet.
+    enum class Queued : std::uint8_t { nothing, play, stop };
+
+    /** @brief What one block left the slot doing. */
+    struct Reading {
+        /// Timeline beats this run has covered, unlooped, or zero while
+        /// stopped. The UI wraps it against the clip's own length: a playhead
+        /// is a position in the material, and the length that turns one into
+        /// the other belongs to the model.
+        float elapsedBeats = 0.0f;
+
+        bool playing = false;
+
+        /// What is queued, which is what a slot button blinks on.
+        Queued queued = Queued::nothing;
+
+        /// Whether this slot holds its track's playback, so the arrangement is
+        /// silent behind it even when the slot itself is not sounding (#2302).
+        bool holdsSection = false;
+    };
+
+    /**
+     * @brief What the last block to render left the slot doing.
+     *
+     * Off the audio thread, from as many readers as like. Nothing is consumed.
+     *
+     * One load, so the position and the state are one block's own.
+     */
+    Reading read() const {
+        return unpack(state_.load(std::memory_order_acquire));
+    }
+
+    /**
+     * @brief Publish what this block left @p handle doing. Audio thread.
+     *
+     * Once per block per slot, from the pass that advanced it, so the reading
+     * and the audio it describes are the same block.
+     */
+    void write(const LaunchHandle& handle) {
+        Reading reading;
+        reading.playing = handle.playState() == LaunchHandle::PlayState::playing;
+        reading.holdsSection = handle.holdsSection();
+
+        if (const auto queued = handle.queuedState())
+            reading.queued =
+                *queued == LaunchHandle::QueueState::playQueued ? Queued::play : Queued::stop;
+
+        if (const auto played = handle.playedRange())
+            reading.elapsedBeats = static_cast<float>(played->length());
+
+        state_.store(pack(reading), std::memory_order_release);
+    }
+
+  private:
+    /// The three flags in the status half: playing, then the two queued bits,
+    /// then the section hold.
+    static std::uint32_t packStatus(const Reading& reading) {
+        return static_cast<std::uint32_t>(reading.playing ? 1U : 0U) |
+               (static_cast<std::uint32_t>(reading.queued) << 1U) |
+               (static_cast<std::uint32_t>(reading.holdsSection ? 1U : 0U) << 3U);
+    }
+
+    static std::uint64_t pack(const Reading& reading) {
+        return static_cast<std::uint64_t>(std::bit_cast<std::uint32_t>(reading.elapsedBeats)) |
+               (static_cast<std::uint64_t>(packStatus(reading)) << 32U);
+    }
+
+    static Reading unpack(std::uint64_t word) {
+        const auto status = static_cast<std::uint32_t>(word >> 32U);
+
+        Reading reading;
+        reading.elapsedBeats = std::bit_cast<float>(static_cast<std::uint32_t>(word));
+        reading.playing = (status & 1U) != 0U;
+        reading.queued = static_cast<Queued>((status >> 1U) & 0b11U);
+        reading.holdsSection = ((status >> 3U) & 1U) != 0U;
+        return reading;
+    }
+
+    std::atomic<std::uint64_t> state_{0};
+};
+
+}  // namespace magda::engine

--- a/magda/engine/tap/LaunchTap.hpp
+++ b/magda/engine/tap/LaunchTap.hpp
@@ -10,32 +10,10 @@
  * @file LaunchTap.hpp
  * @brief What a block left a slot doing, for whoever draws it (#2303).
  *
- * The read-back side of the launcher. A slot button knows it is queued, a
- * session playhead knows how far into its clip it is, and neither asks: the
- * block that decided it publishes it, the way a value tap publishes what a
- * parameter resolved to (ValueTap.hpp).
- *
- * The incumbent polls instead -- `SessionClipScheduler::processStateEvents` off
- * a 33 ms timer -- which puts the UI a frame behind the audio on every launch
- * and needs a second entry point (`relaunchActiveClips`) for the case where
- * that mattered. Both go with the poll.
- *
- * ## One word
- *
- * A reading pairs a position with the state it was in, so a slot cannot draw a
- * playhead from before the launch that started it, or a queued badge beside a
- * position that has already begun moving. A float and a 32-bit status fit in
- * one 64-bit word, which is one store on the audio thread and one load off it,
- * with nothing to retry.
- *
- * ## Why there is no write count
- *
- * A ValueTap counts blocks because a modifier that holds while the engine is
- * stopped is indistinguishable from one that is not moving, and because a value
- * nothing publishes has to fall back to the model's. Neither applies here. A
- * slot that is not playing is not playing whether or not a block has ever said
- * so, and that is exactly what a button should draw, so the default reading is
- * already the true one and there is nothing for a count to disambiguate.
+ * The launcher's read-back, following ValueTap.hpp. Position and state are one
+ * 64-bit word so a reading is always one block's own. No write count, unlike a
+ * value tap: a slot no block has advanced is stopped, which is what a button
+ * should draw anyway.
  *
  * One writer, the audio thread. Any number of readers.
  */
@@ -53,9 +31,8 @@ class LaunchTap {
     /** @brief What one block left the slot doing. */
     struct Reading {
         /// Timeline beats this run has covered, unlooped, or zero while
-        /// stopped. The UI wraps it against the clip's own length: a playhead
-        /// is a position in the material, and the length that turns one into
-        /// the other belongs to the model.
+        /// stopped. The UI wraps it against the clip length, which is the
+        /// model's.
         float elapsedBeats = 0.0f;
 
         bool playing = false;
@@ -63,17 +40,16 @@ class LaunchTap {
         /// What is queued, which is what a slot button blinks on.
         Queued queued = Queued::nothing;
 
-        /// Whether this slot holds its track's playback, so the arrangement is
-        /// silent behind it even when the slot itself is not sounding (#2302).
+        /// Whether this slot holds its track, which outlasts it sounding
+        /// (#2302).
         bool holdsSection = false;
     };
 
     /**
      * @brief What the last block to render left the slot doing.
      *
-     * Off the audio thread, from as many readers as like. Nothing is consumed.
-     *
-     * One load, so the position and the state are one block's own.
+     * Off the audio thread, from any number of readers. One load, so the
+     * position and the state are one block's own.
      */
     Reading read() const {
         return unpack(state_.load(std::memory_order_acquire));
@@ -82,8 +58,8 @@ class LaunchTap {
     /**
      * @brief Publish what this block left @p handle doing. Audio thread.
      *
-     * Once per block per slot, from the pass that advanced it, so the reading
-     * and the audio it describes are the same block.
+     * Once per block, from the pass that advanced it, so the reading and the
+     * audio it describes are the same block.
      */
     void write(const LaunchHandle& handle) {
         Reading reading;
@@ -101,8 +77,7 @@ class LaunchTap {
     }
 
   private:
-    /// The three flags in the status half: playing, then the two queued bits,
-    /// then the section hold.
+    /// Status half: playing, the two queued bits, then the section hold.
     static std::uint32_t packStatus(const Reading& reading) {
         return static_cast<std::uint32_t>(reading.playing ? 1U : 0U) |
                (static_cast<std::uint32_t>(reading.queued) << 1U) |

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -384,6 +384,9 @@ if(MAGDA_BUILD_NATIVE_ENGINE)
     # The lane a launch arrives on (#2305): the block it lands in, the order it
     # keeps, and that it cannot be applied twice or reach a slot that has gone.
     list(APPEND TEST_SOURCES engine/test_launch_requests.cpp)
+    # What a slot publishes about itself (#2303): the block's own reading,
+    # rather than a UI polling the launcher a frame behind the audio.
+    list(APPEND TEST_SOURCES engine/test_launch_tap.cpp)
     list(APPEND TEST_SOURCES audio/test_click_generator.cpp)
     list(APPEND TEST_SOURCES audio/test_prefetch_stream.cpp)
     list(APPEND TEST_SOURCES audio/test_source_readers.cpp)

--- a/tests/engine/test_engine_session.cpp
+++ b/tests/engine/test_engine_session.cpp
@@ -1378,3 +1378,43 @@ TEST_CASE("A structural edit under a playing slot does not restart it",
     // and the clip half a bar ahead of the transport.
     CHECK(still->end == running->end + magda::engine::SampleDuration{3 * kBlockSize});
 }
+
+TEST_CASE("A slot's state is readable off the session as the block leaves it",
+          "[engine][session][launch][tap]") {
+    // The store makes a tap with the handle and the launcher writes it, so a
+    // host reads what the block decided rather than polling for it (#2303).
+    LauncherFactory factory;
+    EngineSession session(factory);
+    factory.handles = &session.launchHandleFeed();
+
+    const std::vector<TrackInfo> tracks{makeTrack(1)};
+    REQUIRE(publish(session, compile(tracks), tracks).published);
+
+    session.publishTransport(rolling(0.0));
+    session.publishClips(snapshotWithSlot(1, 0));
+
+    const auto slot = magda::engine::SlotKey{1, 0};
+    const auto* tap = session.launchTap(slot);
+    REQUIRE(tap != nullptr);
+    CHECK(session.launchTap(magda::engine::SlotKey{1, 3}) == nullptr);
+
+    CHECK_FALSE(tap->read().playing);
+
+    {
+        magda::engine::LaunchRequestQueue::Gesture gesture(session.launchRequests());
+        gesture.play(slot);
+    }
+
+    juce::AudioBuffer<float> output(2, kBlockSize);
+    session.process(kBlockSize, output);
+
+    const auto playing = tap->read();
+    CHECK(playing.playing);
+    CHECK(playing.holdsSection);
+    CHECK(playing.elapsedBeats > 0.0f);
+
+    // The same publish again keeps the tap the host is already reading: an edit
+    // elsewhere must not hand it a pointer to nothing.
+    session.publishClips(snapshotWithSlot(1, 0));
+    CHECK(session.launchTap(slot) == tap);
+}

--- a/tests/engine/test_launch_tap.cpp
+++ b/tests/engine/test_launch_tap.cpp
@@ -1,0 +1,272 @@
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <map>
+#include <memory>
+#include <vector>
+
+#include "launch/SessionLauncher.hpp"
+
+/**
+ * @file test_launch_tap.cpp
+ * @brief What a slot publishes about itself, and when (#2303).
+ *
+ * That the reading is the block's own rather than a frame behind it, that a
+ * position and the state beside it are never from different blocks, and that a
+ * slot nobody has rendered reads as the truth rather than as nothing.
+ */
+
+using namespace magda;
+using namespace magda::engine;
+
+namespace {
+
+constexpr TrackId kTrack = 1;
+constexpr int kBlockSize = 512;
+constexpr double kSampleRate = 48000.0;
+
+/// A quarter beat a block, so elapsed beats are countable by eye.
+constexpr double kBeatsPerBlock = 0.25;
+
+BlockInfo blockAt(int index) {
+    BlockInfo block;
+    block.numSamples = kBlockSize;
+    block.sampleRate = kSampleRate;
+    block.monotonicSamples = {SamplePosition{index * kBlockSize},
+                              SamplePosition{(index + 1) * kBlockSize}};
+    block.playing = true;
+    block.continuous = index != 0;
+    block.beats = {index * kBeatsPerBlock, (index + 1) * kBeatsPerBlock};
+    block.monotonicBeats = block.beats;
+    block.seconds = {static_cast<double>(index * kBlockSize) / kSampleRate,
+                     static_cast<double>((index + 1) * kBlockSize) / kSampleRate};
+    block.monotonicSeconds = block.seconds;
+    return block;
+}
+
+/// Handles and their taps, published the way the store publishes them.
+struct Rig {
+    explicit Rig(int scenes)
+        : handles(static_cast<std::size_t>(scenes)), taps(static_cast<std::size_t>(scenes)) {
+        auto table = std::make_shared<LaunchHandleTable>();
+        std::map<SlotKey, std::uint64_t> incarnations;
+
+        for (auto scene = 0; scene < scenes; ++scene) {
+            const auto key = SlotKey{kTrack, scene};
+            const auto at = static_cast<std::size_t>(scene);
+            table->entries.push_back(LaunchHandleTable::Entry{key, &handles[at], 1, &taps[at]});
+            incarnations[key] = 1;
+        }
+
+        feed.publish(std::move(table));
+        requests.setIncarnations(std::move(incarnations));
+    }
+
+    void roll(int index) {
+        advanceLaunchHandles(feed, requests, blockAt(index));
+    }
+
+    LaunchTap::Reading reading(int scene = 0) const {
+        return taps[static_cast<std::size_t>(scene)].read();
+    }
+
+    static SlotKey key(int scene) {
+        return SlotKey{kTrack, scene};
+    }
+
+    std::vector<LaunchHandle> handles;
+    std::vector<LaunchTap> taps;
+    LaunchHandleFeed feed;
+    LaunchRequestQueue requests;
+};
+
+}  // namespace
+
+TEST_CASE("A slot nobody has rendered reads as stopped", "[engine][session][launch][tap]") {
+    // Why the tap needs no write count: the default reading is already true, so
+    // there is nothing for one to disambiguate.
+    const LaunchTap tap;
+    const auto reading = tap.read();
+
+    CHECK_FALSE(reading.playing);
+    CHECK(reading.queued == LaunchTap::Queued::nothing);
+    CHECK_FALSE(reading.holdsSection);
+    CHECK(reading.elapsedBeats == 0.0f);
+}
+
+TEST_CASE("A launch is published by the block that made it", "[engine][session][launch][tap]") {
+    // The whole of what replaces the poll: no frame of delay, and no second
+    // entry point for the case where that delay was noticed.
+    Rig rig(1);
+
+    {
+        LaunchRequestQueue::Gesture gesture(rig.requests);
+        gesture.play(Rig::key(0));
+    }
+
+    CHECK_FALSE(rig.reading().playing);
+
+    rig.roll(0);
+    CHECK(rig.reading().playing);
+}
+
+TEST_CASE("A queued launch is visible before it sounds", "[engine][session][launch][tap]") {
+    // What a slot button blinks on. Queued at a beat two blocks out, so there
+    // are blocks in which the slot is queued and not yet playing.
+    Rig rig(1);
+
+    {
+        LaunchRequestQueue::Gesture gesture(rig.requests);
+        gesture.play(Rig::key(0), 0.75);
+    }
+
+    rig.roll(0);
+
+    const auto queued = rig.reading();
+    CHECK_FALSE(queued.playing);
+    CHECK(queued.queued == LaunchTap::Queued::play);
+
+    rig.roll(1);
+    rig.roll(2);
+    CHECK_FALSE(rig.reading().playing);
+
+    // Beat 0.75 is the first sample of block 3, so that is the block it sounds
+    // in and not one earlier.
+    rig.roll(3);
+
+    const auto started = rig.reading();
+    CHECK(started.playing);
+    CHECK(started.queued == LaunchTap::Queued::nothing);
+}
+
+TEST_CASE("A pending stop is visible while the slot still sounds",
+          "[engine][session][launch][tap]") {
+    // What isSessionTrackStopPending answers by comparing intent against a
+    // polled state. Here the slot says so itself.
+    Rig rig(1);
+
+    {
+        LaunchRequestQueue::Gesture gesture(rig.requests);
+        gesture.play(Rig::key(0));
+    }
+    rig.roll(0);
+
+    {
+        LaunchRequestQueue::Gesture gesture(rig.requests);
+        gesture.stop(Rig::key(0), 1.75);
+    }
+    rig.roll(1);
+
+    const auto pending = rig.reading();
+    CHECK(pending.playing);
+    CHECK(pending.queued == LaunchTap::Queued::stop);
+}
+
+TEST_CASE("The published position is what the run has covered", "[engine][session][launch][tap]") {
+    Rig rig(1);
+
+    {
+        LaunchRequestQueue::Gesture gesture(rig.requests);
+        gesture.play(Rig::key(0));
+    }
+
+    rig.roll(0);
+    CHECK(rig.reading().elapsedBeats == Catch::Approx(kBeatsPerBlock).margin(1e-5));
+
+    rig.roll(1);
+    rig.roll(2);
+
+    // Three blocks of a quarter beat. Unlooped, because wrapping it against the
+    // clip's own length is the UI's, and the length is the model's.
+    CHECK(rig.reading().elapsedBeats == Catch::Approx(3.0 * kBeatsPerBlock).margin(1e-5));
+}
+
+TEST_CASE("A stop leaves the track held, and says so", "[engine][session][launch][tap]") {
+    // The #2302 distinction, read back: silence after a stop is the session
+    // still holding the track, and a UI that drew the arrangement as live would
+    // be drawing the opposite of what is sounding.
+    Rig rig(1);
+
+    {
+        LaunchRequestQueue::Gesture gesture(rig.requests);
+        gesture.play(Rig::key(0));
+    }
+    rig.roll(0);
+    REQUIRE(rig.reading().holdsSection);
+
+    {
+        LaunchRequestQueue::Gesture gesture(rig.requests);
+        gesture.stop(Rig::key(0));
+    }
+    rig.roll(1);
+
+    CHECK_FALSE(rig.reading().playing);
+    CHECK(rig.reading().holdsSection);
+
+    {
+        LaunchRequestQueue::Gesture gesture(rig.requests);
+        gesture.backToArrangement(Rig::key(0));
+    }
+    rig.roll(2);
+
+    CHECK_FALSE(rig.reading().holdsSection);
+}
+
+TEST_CASE("A reading is one block's own", "[engine][session][launch][tap]") {
+    // The reason the position and the state are one word. A slot launched this
+    // block must not read as playing beside a position from before it started,
+    // nor as stopped beside one that has moved.
+    Rig rig(1);
+
+    {
+        LaunchRequestQueue::Gesture gesture(rig.requests);
+        gesture.play(Rig::key(0));
+    }
+
+    rig.roll(0);
+
+    const auto reading = rig.reading();
+    REQUIRE(reading.playing);
+    CHECK(reading.elapsedBeats > 0.0f);
+}
+
+TEST_CASE("Every slot of a scene publishes the same position", "[engine][session][launch][tap]") {
+    Rig rig(3);
+
+    {
+        LaunchRequestQueue::Gesture gesture(rig.requests);
+        gesture.play(Rig::key(0));
+        gesture.playSynced(Rig::key(1), Rig::key(0));
+        gesture.playSynced(Rig::key(2), Rig::key(0));
+    }
+
+    rig.roll(0);
+    rig.roll(1);
+
+    const auto leader = rig.reading(0);
+    REQUIRE(leader.playing);
+
+    for (auto scene = 1; scene < 3; ++scene) {
+        const auto joined = rig.reading(scene);
+        CHECK(joined.playing);
+        CHECK(joined.elapsedBeats == Catch::Approx(leader.elapsedBeats).margin(1e-6));
+    }
+}
+
+TEST_CASE("A slot goes on publishing while the transport is stopped",
+          "[engine][session][launch][tap]") {
+    // A stopped engine renders no blocks, so the tap holds. Holding is the
+    // right answer: the slot really is where it was left, and a UI that
+    // simulated one forward would diverge from the audio at the next launch.
+    Rig rig(1);
+
+    {
+        LaunchRequestQueue::Gesture gesture(rig.requests);
+        gesture.play(Rig::key(0));
+    }
+
+    rig.roll(0);
+    const auto held = rig.reading();
+
+    CHECK(rig.reading().playing == held.playing);
+    CHECK(rig.reading().elapsedBeats == held.elapsedBeats);
+}

--- a/tests/engine/test_launch_tap.cpp
+++ b/tests/engine/test_launch_tap.cpp
@@ -169,6 +169,30 @@ TEST_CASE("The published position is what the run has covered", "[engine][sessio
     CHECK(rig.reading().elapsedBeats == Catch::Approx(3.0 * kBeatsPerBlock).margin(1e-5));
 }
 
+TEST_CASE("A run days long still moves the playhead", "[engine][session][launch][tap]") {
+    // A run accumulates for as long as the clip plays, and a float's step
+    // reaches 16 ms after three days at 120 bpm (#2303 review). The published
+    // position has to resolve a block at any age the run reaches.
+    LaunchTap tap;
+
+    // Beats covered by thirty-three days at 120 bpm.
+    constexpr double kDays = 33.0 * 24.0 * 60.0 * 120.0;
+    constexpr double kStep = 1.0 / 4096.0;
+
+    LaunchTap::Reading written;
+    written.playing = true;
+    written.elapsedBeats = kDays;
+    tap.write(written);
+    const auto first = tap.read();
+
+    written.elapsedBeats = kDays + kBeatsPerBlock;
+    tap.write(written);
+    const auto second = tap.read();
+
+    CHECK(first.elapsedBeats == Catch::Approx(kDays).margin(kStep));
+    CHECK(second.elapsedBeats - first.elapsedBeats == Catch::Approx(kBeatsPerBlock).margin(kStep));
+}
+
 TEST_CASE("A stop leaves the track held, and says so", "[engine][session][launch][tap]") {
     // #2302: silence after a stop is the session still holding the track.
     Rig rig(1);

--- a/tests/engine/test_launch_tap.cpp
+++ b/tests/engine/test_launch_tap.cpp
@@ -9,10 +9,6 @@
 /**
  * @file test_launch_tap.cpp
  * @brief What a slot publishes about itself, and when (#2303).
- *
- * That the reading is the block's own rather than a frame behind it, that a
- * position and the state beside it are never from different blocks, and that a
- * slot nobody has rendered reads as the truth rather than as nothing.
  */
 
 using namespace magda;
@@ -82,8 +78,7 @@ struct Rig {
 }  // namespace
 
 TEST_CASE("A slot nobody has rendered reads as stopped", "[engine][session][launch][tap]") {
-    // Why the tap needs no write count: the default reading is already true, so
-    // there is nothing for one to disambiguate.
+    // Why the tap needs no write count.
     const LaunchTap tap;
     const auto reading = tap.read();
 
@@ -94,8 +89,6 @@ TEST_CASE("A slot nobody has rendered reads as stopped", "[engine][session][laun
 }
 
 TEST_CASE("A launch is published by the block that made it", "[engine][session][launch][tap]") {
-    // The whole of what replaces the poll: no frame of delay, and no second
-    // entry point for the case where that delay was noticed.
     Rig rig(1);
 
     {
@@ -110,8 +103,6 @@ TEST_CASE("A launch is published by the block that made it", "[engine][session][
 }
 
 TEST_CASE("A queued launch is visible before it sounds", "[engine][session][launch][tap]") {
-    // What a slot button blinks on. Queued at a beat two blocks out, so there
-    // are blocks in which the slot is queued and not yet playing.
     Rig rig(1);
 
     {
@@ -140,8 +131,7 @@ TEST_CASE("A queued launch is visible before it sounds", "[engine][session][laun
 
 TEST_CASE("A pending stop is visible while the slot still sounds",
           "[engine][session][launch][tap]") {
-    // What isSessionTrackStopPending answers by comparing intent against a
-    // polled state. Here the slot says so itself.
+    // What isSessionTrackStopPending answers by polling, asked of the slot.
     Rig rig(1);
 
     {
@@ -175,15 +165,12 @@ TEST_CASE("The published position is what the run has covered", "[engine][sessio
     rig.roll(1);
     rig.roll(2);
 
-    // Three blocks of a quarter beat. Unlooped, because wrapping it against the
-    // clip's own length is the UI's, and the length is the model's.
+    // Three blocks of a quarter beat, unlooped.
     CHECK(rig.reading().elapsedBeats == Catch::Approx(3.0 * kBeatsPerBlock).margin(1e-5));
 }
 
 TEST_CASE("A stop leaves the track held, and says so", "[engine][session][launch][tap]") {
-    // The #2302 distinction, read back: silence after a stop is the session
-    // still holding the track, and a UI that drew the arrangement as live would
-    // be drawing the opposite of what is sounding.
+    // #2302: silence after a stop is the session still holding the track.
     Rig rig(1);
 
     {
@@ -212,9 +199,7 @@ TEST_CASE("A stop leaves the track held, and says so", "[engine][session][launch
 }
 
 TEST_CASE("A reading is one block's own", "[engine][session][launch][tap]") {
-    // The reason the position and the state are one word. A slot launched this
-    // block must not read as playing beside a position from before it started,
-    // nor as stopped beside one that has moved.
+    // Why position and state are one word.
     Rig rig(1);
 
     {
@@ -254,9 +239,7 @@ TEST_CASE("Every slot of a scene publishes the same position", "[engine][session
 
 TEST_CASE("A slot goes on publishing while the transport is stopped",
           "[engine][session][launch][tap]") {
-    // A stopped engine renders no blocks, so the tap holds. Holding is the
-    // right answer: the slot really is where it was left, and a UI that
-    // simulated one forward would diverge from the audio at the next launch.
+    // A stopped engine renders no blocks, so the tap holds where it was left.
     Rig rig(1);
 
     {


### PR DESCRIPTION
Closes #2303. Slice 4 of #1894.

The fork's UI learns what the launcher did by polling: `SessionClipScheduler::processStateEvents` off a 33 ms timer, plus `relaunchActiveClips` as a second entry point that exists only because the first one is a poll. `LaunchTap` is the read-back the value taps already established for parameters (#2122), applied to a slot: the block that decides the state publishes it, in the pass that advanced the handle, so the reading and the audio it describes are the same block.

## What a slot publishes

`play state`, `queued state`, the section hold, and how far the run has got. The issue asks for the played range rather than a position, and what a playhead actually needs off it is its length -- elapsed beats since the run began, unlooped. Wrapping that against the clip's own length stays in the UI, because the length belongs to the model and `elapsedBeatsToSeconds` inside the engine is exactly the conversion the issue objects to.

The section hold rides along because #2302 made it a separate question from playing: silence after a stop is the session still holding the track, and a UI drawing the arrangement as live there would be drawing the opposite of what is sounding.

## One word

A reading pairs the position with the state it was in. Split across two atomics, a slot could draw a playhead from before the launch that started it, or a queued badge beside a position that has already begun moving. A float and a 32-bit status fit in one 64-bit word: one store on the audio thread, one load off it, nothing to retry -- the same argument `ValueTap` makes for its value-and-count pair.

## No write count, unlike ValueTap

`ValueTap` counts blocks because a modifier holding while the engine is stopped is indistinguishable from one that is not moving, and because a value nothing publishes has to fall back to the model's. Neither applies here. A slot that is not playing is not playing whether or not a block has ever said so, so the default reading is already the true one and a count would have nothing to disambiguate. That also means a tap holds correctly across a stopped transport rather than needing to be told the engine went away.

## Lifetime

The tap is made and retired with the handle beside it, in `RuntimeStateStore::publishHandles`, so `EngineSession::launchTap()` hands out the same lifetime `valueTap()` already does: good until a `publishClips()` stops naming the slot. It lives beside the handle rather than in the published table so the address a host is reading stays put across a publish that did not retire the slot -- there is a case for that.

`launchHandle()` is now documented as being for tests and diagnostics: what the state is belongs to the tap, and what changes it belongs to `launchRequests` (#2305).

## Tests

New `tests/engine/test_launch_tap.cpp`, 9 cases: an unrendered slot reads as stopped, a launch is visible in the block that made it, a queued launch is visible before it sounds, a pending stop is visible while the slot still sounds, the position is what the run covered, the stop-still-holds distinction, a reading is one block's own, a scene reports one position across its slots, and a stopped transport holds. Plus an end-to-end case on `EngineSession` for the store plumbing and the tap's identity across a republish.

`[tap]` 43, `[launch]` 58 and `[session]` 151 cases pass.

## Also here

`.claude/skills/comments-not-essays/SKILL.md`. `CLAUDE.md` states the comment rule; this is the working form of it, naming the failure modes that keep recurring -- markdown headings inside a doc block, rejected-alternatives narration, argument connectives, worked arithmetic. Bundled rather than given its own PR so it does not cost a second CI run.

The tap's own doc blocks were an example of the problem before the last two commits, and are now the size the rule asks for.

https://claude.ai/code/session_013CDpSHas8bog33vv4o6HLv
