### PR TITLE
Dedup the Faust Instrument's mono note stack

### DIFF
--- a/magda/daw/audio/plugins/FaustInstrumentPlugin.cpp
+++ b/magda/daw/audio/plugins/FaustInstrumentPlugin.cpp
@@ -540,8 +540,6 @@ bool FaustInstrumentPlugin::handleMonoNoteOn(const std::shared_ptr<FaustState>& 
 }
 
 void FaustInstrumentPlugin::handleMonoNoteOff(const std::shared_ptr<FaustState>& state, int note) {
-    // Search from the top so releasing one of a repeated pitch drops the most
-    // recent, leaving any earlier hold of the same note intact.
     for (auto it = heldNotes_.rbegin(); it != heldNotes_.rend(); ++it)
         if (it->note == note) {
             heldNotes_.erase(std::next(it).base());

--- a/magda/daw/audio/plugins/FaustInstrumentPlugin.cpp
+++ b/magda/daw/audio/plugins/FaustInstrumentPlugin.cpp
@@ -507,6 +507,14 @@ bool FaustInstrumentPlugin::handleMonoNoteOn(const std::shared_ptr<FaustState>& 
                                              int velocity, int mode) {
     const float g = static_cast<float>(velocity) / 127.0f;
     const bool wasEmpty = heldNotes_.empty();
+
+    // One entry per pitch, as MagdaCompiledPolyInstrument does: otherwise a
+    // duplicate note-on strands a pitch that only gets one note-off (#2351).
+    for (auto it = heldNotes_.begin(); it != heldNotes_.end(); ++it)
+        if (it->note == note) {
+            heldNotes_.erase(it);
+            break;
+        }
     heldNotes_.push_back({note, g});
 
     glideTargetHz_ = midiNoteToHz(note);
@@ -570,8 +578,7 @@ void FaustInstrumentPlugin::initialiseUnsetPoolValues(
 }
 
 FaustInstrumentPlugin::FaustInstrumentPlugin() {
-    // Reserved so process() never grows it. See #2351: without a dedup this
-    // bound is note-ons rather than held notes, and can be exceeded.
+    // 128 held pitches, never note-ons, thanks to handleMonoNoteOn's dedup (#2351).
     heldNotes_.reserve(128);
 
     for (auto& value : poolValues_)

--- a/tests/dsp/test_faust_instrument_voice_modes_juce.cpp
+++ b/tests/dsp/test_faust_instrument_voice_modes_juce.cpp
@@ -322,6 +322,30 @@ class FaustInstrumentVoiceModeTest final : public juce::UnitTest {
             expectWithinAbsoluteError(movedBent, expectedLevelForBentNote(72, 2.0f), 0.002f);
         }
 
+        beginTest("A duplicate note-on does not strand a pitch, in Mono or Legato (#2351)");
+        {
+            setHostParam(*plugin, glideIdx, 0.0f);
+
+            double t = 2.3;
+            for (const float mode : {0.5f, 1.0f}) {  // Mono, Legato
+                setHostParam(*plugin, voiceModeIdx, mode);
+                instrument->reset();
+
+                auto firstOn = noteOn(60);
+                renderBlock(*plugin, t, firstOn);
+                auto duplicateOn = noteOn(60);
+                renderBlock(*plugin, t += 0.01, duplicateOn);
+                auto off = noteOff(60);
+                const float afterOff = renderBlock(*plugin, t += 0.01, off);
+                t += 0.01;
+
+                expectWithinAbsoluteError(afterOff, 0.0f, 0.001f,
+                                          "one note-off after a duplicate note-on should have "
+                                          "released the pitch, mode=" +
+                                              juce::String(mode));
+            }
+        }
+
         plugin->baseClassDeinitialise();
     }
 };


### PR DESCRIPTION
Closes #2351.

## Problem

`FaustInstrumentPlugin::handleMonoNoteOn` appended to `heldNotes_` unconditionally. A duplicate note-on for a pitch already held pushed a second entry; one note-off then left the first behind, so the gate never fell and the note sustained with nothing able to release it. `MagdaCompiledPolyInstrument::handleMonoNoteOn` already erases a matching pitch before pushing, and explains why: a recorded clip merged with the live input that fed it can send a pitch twice, and appending has no bound (MIDI note numbers stop at 128, note-ons do not).

## Fix

Mirrors the poly instrument's dedup: erase a matching pitch before pushing.

## Test

Added a case to the "Faust Instrument Voice Mode Tests" suite that drives two note-ons and one note-off for the same pitch through both Mono and Legato, asserting the pitch is silent afterward. Verified negatively: reverting just the source change reproduces the stranded pitch in both modes (level 0.0131, exactly the expected level for the held note).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NJcMXn1jyk4tvFGh4wUAu8