### PR TITLE
Act on a slot's follow action in the block it falls in (#2304)

### DIFF
--- a/magda/engine/CMakeLists.txt
+++ b/magda/engine/CMakeLists.txt
@@ -104,6 +104,8 @@ add_library(magda_engine STATIC
     tap/LevelTap.hpp
     tap/SampleRing.hpp
     tap/ValueTap.hpp
+    launch/FollowActions.cpp
+    launch/FollowActions.hpp
     launch/LaunchHandle.cpp
     launch/LaunchHandle.hpp
     launch/LaunchRequests.hpp

--- a/magda/engine/clip/ClipSnapshot.hpp
+++ b/magda/engine/clip/ClipSnapshot.hpp
@@ -9,6 +9,7 @@
 #include "clip/WarpMap.hpp"
 #include "core/ClipInfo.hpp"
 #include "core/TypeIds.hpp"
+#include "launch/FollowActions.hpp"
 #include "transport/TimeDomains.hpp"
 
 /**
@@ -286,6 +287,10 @@ struct SessionSlotPlayback {
     /// handle re-triggers on. The clip's own loop is a separate thing that
     /// happens inside this.
     double lengthBeats = 0.0;
+
+    /// What the slot does when its run reaches the end (#2304). Carried into
+    /// the handle table, which is what the audio thread reads it from.
+    SlotFollow follow;
 };
 
 struct TrackClipPlayback {

--- a/magda/engine/clip/ClipSnapshotCompiler.cpp
+++ b/magda/engine/clip/ClipSnapshotCompiler.cpp
@@ -12,6 +12,32 @@ namespace magda::engine {
 
 namespace {
 
+/// The model's follow action at the launcher's altitude (#2304). The engine has
+/// no track groups to name, so the model's five actions map across whole.
+SlotFollow compileFollow(const ClipInfo& clip) {
+    const auto action = [&] {
+        switch (clip.followAction) {
+            case magda::FollowAction::None:
+                return SlotAction::none;
+            case magda::FollowAction::PlayNext:
+                return SlotAction::next;
+            case magda::FollowAction::PlayPrevious:
+                return SlotAction::previous;
+            case magda::FollowAction::PlayRandom:
+                return SlotAction::random;
+            case magda::FollowAction::Stop:
+                return SlotAction::stop;
+            case magda::FollowAction::PlayAgain:
+                return SlotAction::again;
+        }
+
+        return SlotAction::none;
+    }();
+
+    return SlotFollow{action, std::max(1, clip.followActionLoopCount),
+                      std::max(0.0, clip.followActionDelayBeats), clip.placement.lengthBeats};
+}
+
 std::string clipLabel(TrackId trackId, ClipId clipId) {
     return "track " + std::to_string(trackId) + " clip " + std::to_string(clipId) + ": ";
 }
@@ -400,6 +426,7 @@ ClipSnapshot compileClipSnapshot(const std::vector<ClipLane>& lanes,
             SessionSlotPlayback slot;
             slot.sceneIndex = clip.sceneIndex;
             slot.lengthBeats = clip.placement.lengthBeats;
+            slot.follow = compileFollow(clip);
             slot.audio = std::move(compiled.tracks.front().audio);
             slot.midi = std::move(compiled.tracks.front().midi);
 

--- a/magda/engine/exec/RuntimeStateStore.cpp
+++ b/magda/engine/exec/RuntimeStateStore.cpp
@@ -336,8 +336,11 @@ std::shared_ptr<const LaunchHandleTable> RuntimeStateStore::publishHandles(
                 made.tap = std::make_unique<LaunchTap>();
             }
 
-            table->entries.push_back(
-                LaunchHandleTable::Entry{key, made.handle.get(), made.incarnation, made.tap.get()});
+            table->entries.push_back(LaunchHandleTable::Entry{.key = key,
+                                                              .handle = made.handle.get(),
+                                                              .incarnation = made.incarnation,
+                                                              .tap = made.tap.get(),
+                                                              .follow = slot.follow});
         }
 
     // Sorted on arrival, since a snapshot holds tracks by id and slots by

--- a/magda/engine/launch/FollowActions.cpp
+++ b/magda/engine/launch/FollowActions.cpp
@@ -35,15 +35,15 @@ std::size_t randomIndex(const SlotKey& key, double dueBeat, std::size_t count) {
     return static_cast<std::size_t>(seed % count);
 }
 
-/// The slot @p follow names, or null for an action that starts nothing: a stop,
-/// and a neighbour at the end of the track.
-const LaunchHandleTable::Entry* followTarget(const LaunchHandleTable& table, const SlotKey& key,
-                                             const SlotFollow& follow, double dueBeat) {
+}  // namespace
+
+LaunchHandle* followTarget(const LaunchHandleTable& table, const SlotKey& key,
+                           const SlotFollow& follow, double dueBeat) {
     if (follow.action == SlotAction::none || follow.action == SlotAction::stop)
         return nullptr;
 
     if (follow.action == SlotAction::again)
-        return table.findEntry(key);
+        return table.find(key);
 
     // Every slot of the track that has a handle, in scene order, which is every
     // slot holding a clip: the table is built from the slots the snapshot named
@@ -61,13 +61,13 @@ const LaunchHandleTable::Entry* followTarget(const LaunchHandleTable& table, con
         case SlotAction::next:
             // No wrap at the ends, which is the incumbent's: the last slot of a
             // track stops rather than starting the first again.
-            return at + 1 < count ? first + at + 1 : nullptr;
+            return at + 1 < count ? first[at + 1].handle : nullptr;
 
         case SlotAction::previous:
-            return at > 0 ? first + at - 1 : nullptr;
+            return at > 0 ? first[at - 1].handle : nullptr;
 
         case SlotAction::random:
-            return first + randomIndex(key, dueBeat, count);
+            return first[randomIndex(key, dueBeat, count)].handle;
 
         case SlotAction::none:
         case SlotAction::stop:
@@ -77,8 +77,6 @@ const LaunchHandleTable::Entry* followTarget(const LaunchHandleTable& table, con
 
     return nullptr;
 }
-
-}  // namespace
 
 std::optional<double> followDueBeat(const LaunchHandle& handle, const SlotFollow& follow) {
     const auto schedule = handle.scheduleBeat();
@@ -100,14 +98,6 @@ std::optional<double> followDueBeat(const LaunchHandle& handle, const SlotFollow
     const auto passes = loop ? std::max(1, follow.loopCount) : 1;
 
     return *schedule + (pass * passes) + std::max(0.0, follow.delayBeats);
-}
-
-void applyFollowAction(const LaunchHandleTable& table, const SlotKey& key, const SlotFollow& follow,
-                       double dueBeat) {
-    const auto* target = followTarget(table, key, follow, dueBeat);
-
-    if (target != nullptr && target->handle != nullptr)
-        target->handle->play(dueBeat);
 }
 
 }  // namespace magda::engine

--- a/magda/engine/launch/FollowActions.cpp
+++ b/magda/engine/launch/FollowActions.cpp
@@ -9,13 +9,8 @@ namespace magda::engine {
 
 namespace {
 
-/**
- * @brief Which of @p count slots a random action picks, at @p dueBeat.
- *
- * A hash rather than a generator with state, so two renders of one project
- * produce one file (#1896). splitmix64's finaliser: its avalanche is what makes
- * two adjacent beats pick unrelated slots.
- */
+/// Scrambles @p value for @ref randomIndex below, so that inputs one bit apart
+/// come out unrelated. splitmix64's finaliser, whose constants are tuned for it.
 std::uint64_t mix(std::uint64_t value) {
     value += 0x9e3779b97f4a7c15ULL;
     value = (value ^ (value >> 30U)) * 0xbf58476d1ce4e5b9ULL;
@@ -23,6 +18,12 @@ std::uint64_t mix(std::uint64_t value) {
     return value ^ (value >> 31U);
 }
 
+/**
+ * @brief Which of @p count slots a random action picks, at @p dueBeat.
+ *
+ * Drawn by hashing the slot and the instant rather than by a generator with
+ * state, so two renders of one project produce one file (#1896).
+ */
 std::size_t randomIndex(const SlotKey& key, double dueBeat, std::size_t count) {
     auto seed = mix(static_cast<std::uint64_t>(static_cast<std::uint32_t>(key.trackId)));
     seed = mix(seed ^ static_cast<std::uint64_t>(static_cast<std::uint32_t>(key.sceneIndex)));

--- a/magda/engine/launch/FollowActions.cpp
+++ b/magda/engine/launch/FollowActions.cpp
@@ -1,0 +1,112 @@
+#include "launch/FollowActions.hpp"
+
+#include <algorithm>
+#include <bit>
+
+#include "launch/SessionLauncher.hpp"
+
+namespace magda::engine {
+
+namespace {
+
+/**
+ * @brief Which of @p count slots a random action picks, at @p dueBeat.
+ *
+ * A hash rather than a generator with state, so two renders of one project
+ * produce one file (#1896). splitmix64's finaliser: its avalanche is what makes
+ * two adjacent beats pick unrelated slots.
+ */
+std::uint64_t mix(std::uint64_t value) {
+    value += 0x9e3779b97f4a7c15ULL;
+    value = (value ^ (value >> 30U)) * 0xbf58476d1ce4e5b9ULL;
+    value = (value ^ (value >> 27U)) * 0x94d049bb133111ebULL;
+    return value ^ (value >> 31U);
+}
+
+std::size_t randomIndex(const SlotKey& key, double dueBeat, std::size_t count) {
+    auto seed = mix(static_cast<std::uint64_t>(static_cast<std::uint32_t>(key.trackId)));
+    seed = mix(seed ^ static_cast<std::uint64_t>(static_cast<std::uint32_t>(key.sceneIndex)));
+
+    // Unrounded, or a scene's worth of slots firing on one beat would share a
+    // seed.
+    seed = mix(seed ^ std::bit_cast<std::uint64_t>(dueBeat));
+
+    return static_cast<std::size_t>(seed % count);
+}
+
+/// The slot @p follow names, or null for an action that starts nothing: a stop,
+/// and a neighbour at the end of the track.
+const LaunchHandleTable::Entry* followTarget(const LaunchHandleTable& table, const SlotKey& key,
+                                             const SlotFollow& follow, double dueBeat) {
+    if (follow.action == SlotAction::none || follow.action == SlotAction::stop)
+        return nullptr;
+
+    if (follow.action == SlotAction::again)
+        return table.findEntry(key);
+
+    // Every slot of the track that has a handle, in scene order, which is every
+    // slot holding a clip: the table is built from the slots the snapshot named
+    // (RuntimeStateStore::publishHandles).
+    const auto [first, last] = table.rangeFor(key.trackId);
+    const auto count = static_cast<std::size_t>(last - first);
+
+    const auto* self = std::find_if(first, last, [&key](const auto& e) { return e.key == key; });
+    if (self == last)
+        return nullptr;
+
+    const auto at = static_cast<std::size_t>(self - first);
+
+    switch (follow.action) {
+        case SlotAction::next:
+            // No wrap at the ends, which is the incumbent's: the last slot of a
+            // track stops rather than starting the first again.
+            return at + 1 < count ? first + at + 1 : nullptr;
+
+        case SlotAction::previous:
+            return at > 0 ? first + at - 1 : nullptr;
+
+        case SlotAction::random:
+            return first + randomIndex(key, dueBeat, count);
+
+        case SlotAction::none:
+        case SlotAction::stop:
+        case SlotAction::again:
+            break;
+    }
+
+    return nullptr;
+}
+
+}  // namespace
+
+std::optional<double> followDueBeat(const LaunchHandle& handle, const SlotFollow& follow) {
+    const auto schedule = handle.scheduleBeat();
+    if (!schedule)
+        return {};
+
+    const auto loop = handle.loopBeats();
+
+    // The one run with no end. A slot that does not loop always has one, since
+    // reaching the end of its material is where it stops even with nothing to
+    // follow it.
+    if (loop && follow.action == SlotAction::none)
+        return {};
+
+    const auto pass = loop.value_or(follow.lengthBeats);
+    if (pass <= 0.0)
+        return {};
+
+    const auto passes = loop ? std::max(1, follow.loopCount) : 1;
+
+    return *schedule + (pass * passes) + std::max(0.0, follow.delayBeats);
+}
+
+void applyFollowAction(const LaunchHandleTable& table, const SlotKey& key, const SlotFollow& follow,
+                       double dueBeat) {
+    const auto* target = followTarget(table, key, follow, dueBeat);
+
+    if (target != nullptr && target->handle != nullptr)
+        target->handle->play(dueBeat);
+}
+
+}  // namespace magda::engine

--- a/magda/engine/launch/FollowActions.hpp
+++ b/magda/engine/launch/FollowActions.hpp
@@ -1,0 +1,85 @@
+#pragma once
+
+#include <cstdint>
+#include <optional>
+
+#include "launch/LaunchHandle.hpp"
+
+/**
+ * @file FollowActions.hpp
+ * @brief What a slot does when its run reaches the end (#2304).
+ *
+ * The one launch the engine makes itself. Every other arrives down the queue in
+ * LaunchRequests.hpp; this one is a beat the clip named when it was written, so
+ * the audio thread works it out and acts on it in the block it falls in.
+ *
+ * It reaches the handle through `LaunchHandle::play` and `stop`, which is what a
+ * user launch reaches, so the slot it starts publishes itself through its own
+ * tap exactly as a clicked one does and there is nothing to adopt (#1894).
+ */
+
+namespace magda::engine {
+
+struct LaunchHandleTable;
+
+/// What a slot asks for at the end of its run. The model's `FollowAction` at the
+/// launcher's altitude, named apart from it: a slot rather than a clip.
+enum class SlotAction : std::uint8_t {
+    /// Stop, or carry on for ever when the slot loops.
+    none,
+
+    stop,
+
+    /// Launch this slot again, which restarts the run.
+    again,
+
+    /// The next slot of this track that holds a clip, or nothing at the last.
+    next,
+
+    /// The previous one, or nothing at the first.
+    previous,
+
+    /// Any slot of this track that holds a clip, this one included.
+    random,
+};
+
+/// What ends one slot's run: the action, and how long the run gets first.
+struct SlotFollow {
+    SlotAction action = SlotAction::none;
+
+    /// Passes before it fires. Counted only while the slot re-triggers.
+    int loopCount = 1;
+
+    /// Beats added after those passes.
+    double delayBeats = 0.0;
+
+    /// The slot's own length, which is what a pass is worth when the handle is
+    /// not re-triggering. Zero leaves the run with no end.
+    double lengthBeats = 0.0;
+
+    bool operator==(const SlotFollow&) const = default;
+};
+
+/**
+ * @brief The monotonic beat @p handle's run ends on, if it ends.
+ *
+ * Counted from `LaunchHandle::scheduleBeat`, which survives a re-trigger; the
+ * run's origin does not, so a third pass of three would never arrive.
+ *
+ * Absent for a slot that loops with nothing to do at the end.
+ */
+std::optional<double> followDueBeat(const LaunchHandle& handle, const SlotFollow& follow);
+
+/**
+ * @brief Do what @p follow asks of @p key, at @p dueBeat. Audio thread.
+ *
+ * Only what starts next; the stop is the caller's, since a run that reached its
+ * end stops whether or not anything follows it.
+ *
+ * Named against @p table as it stands now, so a slot deleted or moved since the
+ * project loaded is not in the list this searches.
+ */
+void applyFollowAction(const LaunchHandleTable& table, const SlotKey& key, const SlotFollow& follow,
+                       double dueBeat);
+
+}  // namespace magda::engine

--- a/magda/engine/launch/FollowActions.hpp
+++ b/magda/engine/launch/FollowActions.hpp
@@ -71,15 +71,16 @@ struct SlotFollow {
 std::optional<double> followDueBeat(const LaunchHandle& handle, const SlotFollow& follow);
 
 /**
- * @brief Do what @p follow asks of @p key, at @p dueBeat. Audio thread.
+ * @brief The handle @p follow starts at @p dueBeat, or null when it starts none.
  *
- * Only what starts next; the stop is the caller's, since a run that reached its
- * end stops whether or not anything follows it.
+ * Null for a stop, and for a neighbour past either end of the track. The caller
+ * owns the source's stop, since a run that reached its end stops whether or not
+ * anything follows it.
  *
  * Named against @p table as it stands now, so a slot deleted or moved since the
  * project loaded is not in the list this searches.
  */
-void applyFollowAction(const LaunchHandleTable& table, const SlotKey& key, const SlotFollow& follow,
-                       double dueBeat);
+LaunchHandle* followTarget(const LaunchHandleTable& table, const SlotKey& key,
+                           const SlotFollow& follow, double dueBeat);
 
 }  // namespace magda::engine

--- a/magda/engine/launch/LaunchHandle.cpp
+++ b/magda/engine/launch/LaunchHandle.cpp
@@ -170,6 +170,13 @@ std::optional<BeatRange> LaunchHandle::lastPlayedRange() const {
     return lastPlayed_;
 }
 
+std::optional<double> LaunchHandle::scheduleBeat() const {
+    if (!run_)
+        return {};
+
+    return run_->scheduleBeat;
+}
+
 void LaunchHandle::releaseSection() {
     // A request, like every other way a slot stops: a run ended behind the
     // sources' backs is a step nobody can ramp. The stop and the hand-back are

--- a/magda/engine/launch/LaunchHandle.hpp
+++ b/magda/engine/launch/LaunchHandle.hpp
@@ -444,6 +444,22 @@ class LaunchHandle {
         return loopRetriggerOverflows_;
     }
 
+    /**
+     * @brief Blocks in which a run ended before the launcher could act on it.
+     *
+     * A run shorter than a callback: its launch was the block's one event, so
+     * the end had nowhere to go and lands on the next block's first sample.
+     * Counted rather than left silent, for the reason above (#2304).
+     */
+    int lateRunEnds() const {
+        return lateRunEnds_;
+    }
+
+    /// Count one, from the pass that noticed. Audio thread.
+    void noteLateRunEnd() {
+        ++lateRunEnds_;
+    }
+
   private:
     /**
      * @brief The run in progress: where it began, and how far it has got.
@@ -559,6 +575,8 @@ class LaunchHandle {
     SplitStatus blockStatus_;
 
     int loopRetriggerOverflows_ = 0;
+
+    int lateRunEnds_ = 0;
 };
 
 }  // namespace magda::engine

--- a/magda/engine/launch/LaunchHandle.hpp
+++ b/magda/engine/launch/LaunchHandle.hpp
@@ -393,6 +393,22 @@ class LaunchHandle {
     std::optional<BeatRange> lastPlayedRange() const;
 
     /**
+     * @brief The monotonic beat this run's schedule counts from.
+     *
+     * Where the launch that began the run was asked for, carried across every
+     * re-trigger since (@ref Run::scheduleBeat). What a follow action counts
+     * its passes from, since the origin restarts at each wrap and would never
+     * reach the third pass of three (#2304).
+     */
+    std::optional<double> scheduleBeat() const;
+
+    /// The re-trigger interval @ref setLooping was last given, which is what a
+    /// pass through the slot is worth while it is set.
+    std::optional<double> loopBeats() const {
+        return loopBeats_;
+    }
+
+    /**
      * @brief Whether this slot holds its track's playback (#2302).
      *
      * The hand-back is not the slot stopping: silence after a stop is the

--- a/magda/engine/launch/SessionLauncher.cpp
+++ b/magda/engine/launch/SessionLauncher.cpp
@@ -2,6 +2,8 @@
 
 #include <algorithm>
 
+#include "launch/FollowActions.hpp"
+
 namespace magda::engine {
 
 std::pair<const LaunchHandleTable::Entry*, const LaunchHandleTable::Entry*>
@@ -93,6 +95,37 @@ void apply(const LaunchRequest& request, const LaunchHandleTable& table) {
     }
 }
 
+/**
+ * @brief End the runs that reach their end inside @p range, and start what
+ *        follows them (#2304).
+ *
+ * Before the advance, so the stop and the launch it triggers land on one beat
+ * inside this block rather than on the next callback boundary.
+ *
+ * A slot with anything queued is left alone: a handle holds one pending request,
+ * so writing a stop over it would drop what the user asked for.
+ */
+void applyDueFollowActions(const LaunchHandleTable& table, const SyncRange& range) {
+    for (const auto& entry : table.entries) {
+        if (entry.handle == nullptr ||
+            entry.handle->playState() != LaunchHandle::PlayState::playing)
+            continue;
+
+        if (entry.handle->queuedState())
+            continue;
+
+        const auto due = followDueBeat(*entry.handle, entry.follow);
+
+        // No lower bound: the handle clamps a position it has passed, so a slot
+        // shorter than a callback still reaches its end.
+        if (!due || *due >= range.monotonic.end)
+            continue;
+
+        entry.handle->stop(*due);
+        applyFollowAction(table, entry.key, entry.follow, *due);
+    }
+}
+
 }  // namespace
 
 void advanceLaunchHandles(LaunchHandleFeed& handles, LaunchRequestQueue& requests,
@@ -112,6 +145,10 @@ void advanceLaunchHandles(LaunchHandleFeed& handles, LaunchRequestQueue& request
     requests.drain([&table](const LaunchRequest& request) { apply(request, *table.get()); });
 
     const auto range = syncRangeFor(block);
+
+    // After the requests, so a launch made in this block beats the follow
+    // action of the run it replaces.
+    applyDueFollowActions(*table.get(), range);
 
     for (const auto& entry : table->entries)
         if (entry.handle != nullptr) {

--- a/magda/engine/launch/SessionLauncher.cpp
+++ b/magda/engine/launch/SessionLauncher.cpp
@@ -115,14 +115,28 @@ void applyDueFollowActions(const LaunchHandleTable& table, const SyncRange& rang
             continue;
 
         const auto due = followDueBeat(*entry.handle, entry.follow);
-
-        // No lower bound: the handle clamps a position it has passed, so a slot
-        // shorter than a callback still reaches its end.
         if (!due || *due >= range.monotonic.end)
             continue;
 
+        // A run whose end was already behind this block: one shorter than a
+        // callback, whose launch was this block's one event and left the end
+        // nowhere to go. The handle clamps it to the first sample here, and the
+        // block it slipped is counted rather than left silent (#2304 review).
+        if (*due < range.monotonic.start)
+            entry.handle->noteLateRunEnd();
+
+        auto* target = followTarget(table, entry.key, entry.follow, *due);
+
+        // Asked before the stop below, so a slot following itself is not turned
+        // away by the stop this pass is about to write. A target already spoken
+        // for keeps what it was asked: a handle holds one pending request, and
+        // the user's outranks this one.
+        const auto spokenFor = target != nullptr && target->queuedState().has_value();
+
         entry.handle->stop(*due);
-        applyFollowAction(table, entry.key, entry.follow, *due);
+
+        if (target != nullptr && !spokenFor)
+            target->play(*due);
     }
 }
 

--- a/magda/engine/launch/SessionLauncher.hpp
+++ b/magda/engine/launch/SessionLauncher.hpp
@@ -8,6 +8,7 @@
 
 #include "core/TypeIds.hpp"
 #include "exec/RenderContext.hpp"
+#include "launch/FollowActions.hpp"
 #include "launch/LaunchHandle.hpp"
 #include "launch/LaunchRequests.hpp"
 #include "tap/LaunchTap.hpp"
@@ -56,6 +57,11 @@ struct LaunchHandleTable {
         /// Where this slot's state is published for the UI to read (#2303).
         /// Owned by the store, like the handle beside it.
         LaunchTap* tap = nullptr;
+
+        /// What ends this slot's run, and what starts next (#2304). Here rather
+        /// than looked up in the snapshot beside it, because the audio thread
+        /// already has this table and the two publish separately.
+        SlotFollow follow;
 
         bool operator==(const Entry&) const = default;
     };

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -387,6 +387,9 @@ if(MAGDA_BUILD_NATIVE_ENGINE)
     # What a slot publishes about itself (#2303): the block's own reading,
     # rather than a UI polling the launcher a frame behind the audio.
     list(APPEND TEST_SOURCES engine/test_launch_tap.cpp)
+    # What ends a slot's run and what starts next (#2304), and that a launch
+    # the engine made reads out exactly as a clicked one does.
+    list(APPEND TEST_SOURCES engine/test_follow_actions.cpp)
     list(APPEND TEST_SOURCES audio/test_click_generator.cpp)
     list(APPEND TEST_SOURCES audio/test_prefetch_stream.cpp)
     list(APPEND TEST_SOURCES audio/test_source_readers.cpp)

--- a/tests/engine/test_follow_actions.cpp
+++ b/tests/engine/test_follow_actions.cpp
@@ -44,8 +44,9 @@ BlockInfo blockAt(int index) {
     return block;
 }
 
-SlotFollow follows(SlotAction action, int loopCount = 1, double delayBeats = 0.0) {
-    return SlotFollow{action, loopCount, delayBeats, kPassBeats};
+SlotFollow follows(SlotAction action, int loopCount = 1, double delayBeats = 0.0,
+                   double lengthBeats = kPassBeats) {
+    return SlotFollow{action, loopCount, delayBeats, lengthBeats};
 }
 
 /// A track's slots, published the way the store publishes them.
@@ -417,4 +418,77 @@ TEST_CASE("A chain of follow actions plays the scenes in order",
         CHECK(rig.handles[scene].lastPlayedRange()->start == Approx(scene * kPassBeats));
         CHECK(rig.handles[scene].lastPlayedRange()->length() == Approx(kPassBeats));
     }
+}
+
+TEST_CASE("A follow action leaves a target the user has already asked for",
+          "[engine][session][launch][follow]") {
+    // The rule the source already obeys, applied to the slot it hands over to:
+    // a handle holds one pending request, so launching over a queued one would
+    // drop what the user asked for (#2304 review).
+    Rig rig({follows(SlotAction::next), follows(SlotAction::none)});
+
+    launch(rig, 0);
+    rig.rollThrough(0, kBlocksPerPass - 1);
+
+    // Slot 1 is spoken for, two passes out, before the hand-over is due.
+    {
+        LaunchRequestQueue::Gesture gesture(rig.requests);
+        gesture.play(Rig::key(1), kPassBeats * 2);
+    }
+
+    rig.rollThrough(kBlocksPerPass - 1, kBlocksPerPass * 2);
+
+    // The source still stopped on its own beat; slot 1 waited for the beat the
+    // user named rather than starting a pass early.
+    CHECK(rig.sounding() == -1);
+
+    rig.roll(kBlocksPerPass * 2);
+
+    CHECK(rig.sounding() == 1);
+    REQUIRE(rig.handles[1].playedMonotonicRange().has_value());
+    CHECK(rig.handles[1].playedMonotonicRange()->start == Approx(kPassBeats * 2));
+}
+
+TEST_CASE("Play again is not turned away by its own stop", "[engine][session][launch][follow]") {
+    // The source is its own target, and the stop this pass writes must not read
+    // as somebody else having asked for the slot.
+    Rig rig({follows(SlotAction::again)});
+
+    launch(rig, 0);
+    rig.rollThrough(0, (kBlocksPerPass * 2) + 1);
+
+    CHECK(rig.reading(0).playing);
+    REQUIRE(rig.handles[0].playedMonotonicRange().has_value());
+    CHECK(rig.handles[0].playedMonotonicRange()->start == Approx(kPassBeats * 2));
+}
+
+TEST_CASE("A run shorter than a callback counts the block it slipped",
+          "[engine][session][launch][follow]") {
+    // Its launch is the block's one event, so its end has nowhere to go. The
+    // handle clamps it to the next block and the slip is counted rather than
+    // left to look like an audio device fault (#2304 review).
+    const auto shorterThanABlock = kBeatsPerBlock / 2.0;
+    Rig rig({follows(SlotAction::none, 1, 0.0, shorterThanABlock)});
+
+    launch(rig, 0);
+    rig.roll(0);
+
+    CHECK(rig.reading(0).playing);
+    CHECK(rig.handles[0].lateRunEnds() == 0);
+
+    rig.roll(1);
+
+    CHECK_FALSE(rig.reading(0).playing);
+    CHECK(rig.handles[0].lateRunEnds() == 1);
+}
+
+TEST_CASE("A run that ends on its own beat is not counted late",
+          "[engine][session][launch][follow]") {
+    Rig rig({follows(SlotAction::none)});
+
+    launch(rig, 0);
+    rig.rollThrough(0, kBlocksPerPass + 1);
+
+    CHECK_FALSE(rig.reading(0).playing);
+    CHECK(rig.handles[0].lateRunEnds() == 0);
 }

--- a/tests/engine/test_follow_actions.cpp
+++ b/tests/engine/test_follow_actions.cpp
@@ -1,0 +1,420 @@
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <map>
+#include <memory>
+#include <vector>
+
+#include "launch/SessionLauncher.hpp"
+
+/**
+ * @file test_follow_actions.cpp
+ * @brief What a slot does when its run ends, and who hears about it (#2304).
+ */
+
+using namespace magda;
+using namespace magda::engine;
+using Catch::Approx;
+
+namespace {
+
+constexpr TrackId kTrack = 1;
+constexpr int kBlockSize = 512;
+constexpr double kSampleRate = 48000.0;
+
+/// A quarter beat a block, so a one-beat slot is four blocks.
+constexpr double kBeatsPerBlock = 0.25;
+
+/// The slot length every case here uses, in blocks and in beats.
+constexpr int kBlocksPerPass = 4;
+constexpr double kPassBeats = kBlocksPerPass * kBeatsPerBlock;
+
+BlockInfo blockAt(int index) {
+    BlockInfo block;
+    block.numSamples = kBlockSize;
+    block.sampleRate = kSampleRate;
+    block.monotonicSamples = {SamplePosition{index * kBlockSize},
+                              SamplePosition{(index + 1) * kBlockSize}};
+    block.playing = true;
+    block.continuous = index != 0;
+    block.beats = {index * kBeatsPerBlock, (index + 1) * kBeatsPerBlock};
+    block.monotonicBeats = block.beats;
+    block.seconds = {static_cast<double>(index * kBlockSize) / kSampleRate,
+                     static_cast<double>((index + 1) * kBlockSize) / kSampleRate};
+    block.monotonicSeconds = block.seconds;
+    return block;
+}
+
+SlotFollow follows(SlotAction action, int loopCount = 1, double delayBeats = 0.0) {
+    return SlotFollow{action, loopCount, delayBeats, kPassBeats};
+}
+
+/// A track's slots, published the way the store publishes them.
+struct Rig {
+    explicit Rig(std::vector<SlotFollow> slots)
+        : follow(std::move(slots)), handles(follow.size()), taps(follow.size()) {
+        std::vector<int> all;
+        for (auto scene = 0; scene < scenes(); ++scene)
+            all.push_back(scene);
+
+        publish(all);
+    }
+
+    /// Name only @p scenes, which is what the store does after a slot is
+    /// emptied: the handles of the rest stay where they are.
+    void publish(const std::vector<int>& scenes) {
+        auto table = std::make_shared<LaunchHandleTable>();
+        std::map<SlotKey, std::uint64_t> incarnations;
+
+        for (const auto scene : scenes) {
+            const auto key = SlotKey{kTrack, scene};
+            const auto at = static_cast<std::size_t>(scene);
+            table->entries.push_back(LaunchHandleTable::Entry{.key = key,
+                                                              .handle = &handles[at],
+                                                              .incarnation = 1,
+                                                              .tap = &taps[at],
+                                                              .follow = follow[at]});
+            incarnations[key] = 1;
+        }
+
+        feed.publish(std::move(table));
+        requests.setIncarnations(std::move(incarnations));
+    }
+
+    void roll(int index) {
+        advanceLaunchHandles(feed, requests, blockAt(index));
+    }
+
+    /// Roll blocks @p from up to but not including @p to.
+    void rollThrough(int from, int to) {
+        for (auto index = from; index < to; ++index)
+            roll(index);
+    }
+
+    LaunchTap::Reading reading(int scene) const {
+        return taps[static_cast<std::size_t>(scene)].read();
+    }
+
+    /// The one slot of the track that is sounding, or -1. What a track's active
+    /// slot is, read off the taps rather than tracked alongside them.
+    int sounding() const {
+        for (auto scene = 0; scene < scenes(); ++scene)
+            if (reading(scene).playing)
+                return scene;
+
+        return -1;
+    }
+
+    int scenes() const {
+        return static_cast<int>(follow.size());
+    }
+
+    static SlotKey key(int scene) {
+        return SlotKey{kTrack, scene};
+    }
+
+    std::vector<SlotFollow> follow;
+    std::vector<LaunchHandle> handles;
+    std::vector<LaunchTap> taps;
+    LaunchHandleFeed feed;
+    LaunchRequestQueue requests;
+};
+
+/// Launch @p scene at the first sample of the next block rolled.
+void launch(Rig& rig, int scene) {
+    LaunchRequestQueue::Gesture gesture(rig.requests);
+    gesture.play(Rig::key(scene));
+}
+
+/// Re-trigger @p scene every pass, which is what a looping session clip does.
+void loopIt(Rig& rig, int scene) {
+    LaunchRequestQueue::Gesture gesture(rig.requests);
+    gesture.setLooping(Rig::key(scene), kPassBeats);
+}
+
+}  // namespace
+
+TEST_CASE("A slot that does not loop stops at the end of its material",
+          "[engine][session][launch][follow]") {
+    // With nothing to follow it. A run ends where its material does, which is
+    // the same question a follow action is asked at.
+    Rig rig({follows(SlotAction::none)});
+
+    launch(rig, 0);
+    rig.rollThrough(0, kBlocksPerPass);
+
+    CHECK(rig.reading(0).playing);
+    CHECK(rig.reading(0).elapsedBeats == Approx(kPassBeats));
+
+    rig.roll(kBlocksPerPass);
+
+    CHECK_FALSE(rig.reading(0).playing);
+
+    // The session keeps the track: silence after a stop is not the arrangement
+    // coming back (#2302).
+    CHECK(rig.reading(0).holdsSection);
+}
+
+TEST_CASE("A looping slot with nothing to follow it plays on",
+          "[engine][session][launch][follow]") {
+    Rig rig({follows(SlotAction::none)});
+
+    loopIt(rig, 0);
+    launch(rig, 0);
+    rig.rollThrough(0, kBlocksPerPass * 4);
+
+    CHECK(rig.reading(0).playing);
+}
+
+TEST_CASE("A stop action ends the run on its own beat", "[engine][session][launch][follow]") {
+    Rig rig({follows(SlotAction::stop)});
+
+    loopIt(rig, 0);
+    launch(rig, 0);
+    rig.rollThrough(0, kBlocksPerPass);
+
+    CHECK(rig.reading(0).playing);
+
+    rig.roll(kBlocksPerPass);
+
+    CHECK_FALSE(rig.reading(0).playing);
+    CHECK_FALSE(rig.handles[0].playedRange().has_value());
+
+    // The run it ended covered exactly one pass, so the stop landed on the beat
+    // rather than on the callback boundary before or after it.
+    REQUIRE(rig.handles[0].lastPlayedRange().has_value());
+    CHECK(rig.handles[0].lastPlayedRange()->length() == Approx(kPassBeats));
+}
+
+TEST_CASE("Play next hands the track to the following slot on one beat",
+          "[engine][session][launch][follow]") {
+    Rig rig({follows(SlotAction::next), follows(SlotAction::none)});
+
+    launch(rig, 0);
+    rig.rollThrough(0, kBlocksPerPass);
+
+    CHECK(rig.sounding() == 0);
+
+    rig.roll(kBlocksPerPass);
+
+    CHECK(rig.sounding() == 1);
+
+    // One instant, not two: the run that started begins where the one that
+    // ended left off, so nothing of the track is played twice or missed.
+    REQUIRE(rig.handles[0].lastPlayedRange().has_value());
+    REQUIRE(rig.handles[1].playedMonotonicRange().has_value());
+    CHECK(rig.handles[0].lastPlayedRange()->end == Approx(kPassBeats));
+    CHECK(rig.handles[1].playedMonotonicRange()->start == Approx(kPassBeats));
+}
+
+TEST_CASE("Play next at the last slot stops and starts nothing",
+          "[engine][session][launch][follow]") {
+    Rig rig({follows(SlotAction::none), follows(SlotAction::next)});
+
+    launch(rig, 1);
+    rig.rollThrough(0, kBlocksPerPass + 1);
+
+    CHECK(rig.sounding() == -1);
+}
+
+TEST_CASE("Play previous hands the track back up the scenes", "[engine][session][launch][follow]") {
+    Rig rig({follows(SlotAction::none), follows(SlotAction::previous)});
+
+    launch(rig, 1);
+    rig.rollThrough(0, kBlocksPerPass + 1);
+
+    CHECK(rig.sounding() == 0);
+}
+
+TEST_CASE("Play previous at the first slot stops and starts nothing",
+          "[engine][session][launch][follow]") {
+    Rig rig({follows(SlotAction::previous), follows(SlotAction::none)});
+
+    launch(rig, 0);
+    rig.rollThrough(0, kBlocksPerPass + 1);
+
+    CHECK(rig.sounding() == -1);
+}
+
+TEST_CASE("Play again restarts the run rather than ending it",
+          "[engine][session][launch][follow]") {
+    Rig rig({follows(SlotAction::again)});
+
+    launch(rig, 0);
+    rig.rollThrough(0, kBlocksPerPass + 1);
+
+    CHECK(rig.reading(0).playing);
+
+    // Restarted, so the played range counts from the new run and not from the
+    // launch a pass ago.
+    REQUIRE(rig.handles[0].playedMonotonicRange().has_value());
+    CHECK(rig.handles[0].playedMonotonicRange()->start == Approx(kPassBeats));
+}
+
+TEST_CASE("A loop count holds the action off until the pass it names",
+          "[engine][session][launch][follow]") {
+    // The case a played range cannot answer: every wrap restarts the run, so
+    // what counts the passes is the beat the launch was asked for.
+    Rig rig({follows(SlotAction::next, 3), follows(SlotAction::none)});
+
+    loopIt(rig, 0);
+    launch(rig, 0);
+
+    rig.rollThrough(0, kBlocksPerPass * 3);
+
+    CHECK(rig.sounding() == 0);
+
+    rig.roll(kBlocksPerPass * 3);
+
+    CHECK(rig.sounding() == 1);
+}
+
+TEST_CASE("A loop count is one pass for a slot that does not loop",
+          "[engine][session][launch][follow]") {
+    // A slot with one pass in it has one to count, whatever the clip asks for.
+    Rig rig({follows(SlotAction::next, 3), follows(SlotAction::none)});
+
+    launch(rig, 0);
+    rig.rollThrough(0, kBlocksPerPass + 1);
+
+    CHECK(rig.sounding() == 1);
+}
+
+TEST_CASE("A follow delay is beats on top of the passes", "[engine][session][launch][follow]") {
+    Rig rig({follows(SlotAction::next, 1, kPassBeats), follows(SlotAction::none)});
+
+    launch(rig, 0);
+    rig.rollThrough(0, kBlocksPerPass * 2);
+
+    CHECK(rig.sounding() == 0);
+
+    rig.roll(kBlocksPerPass * 2);
+
+    CHECK(rig.sounding() == 1);
+}
+
+TEST_CASE("A request the user made outranks the follow action",
+          "[engine][session][launch][follow]") {
+    // A handle holds one pending request, so a follow action written over a
+    // queued launch would drop what was asked for.
+    Rig rig({follows(SlotAction::next), follows(SlotAction::none)});
+
+    launch(rig, 0);
+    rig.rollThrough(0, kBlocksPerPass - 1);
+
+    {
+        LaunchRequestQueue::Gesture gesture(rig.requests);
+        gesture.play(Rig::key(0), kPassBeats * 2);
+    }
+
+    rig.rollThrough(kBlocksPerPass - 1, (kBlocksPerPass * 2) + 1);
+
+    // Slot 1 was never started, and slot 0 relaunches when the user said.
+    CHECK(rig.sounding() == 0);
+    REQUIRE(rig.handles[0].playedMonotonicRange().has_value());
+    CHECK(rig.handles[0].playedMonotonicRange()->start == Approx(kPassBeats * 2));
+}
+
+TEST_CASE("A follow action names the slots there are now", "[engine][session][launch][follow]") {
+    // Nothing stores a target, so a slot emptied since the project loaded is
+    // simply not in the list the action searches.
+    Rig rig({follows(SlotAction::next), follows(SlotAction::none), follows(SlotAction::none)});
+
+    launch(rig, 0);
+    rig.rollThrough(0, kBlocksPerPass - 1);
+
+    rig.publish({0, 2});
+    rig.roll(kBlocksPerPass - 1);
+    rig.roll(kBlocksPerPass);
+
+    CHECK(rig.sounding() == 2);
+}
+
+TEST_CASE("A random action picks the same slot for the same beat",
+          "[engine][session][launch][follow]") {
+    // Deterministic on purpose: two renders of one project have to produce one
+    // file (#1896).
+    const auto pick = [](int launchBlock) {
+        Rig rig({follows(SlotAction::random), follows(SlotAction::none), follows(SlotAction::none),
+                 follows(SlotAction::none)});
+
+        rig.rollThrough(0, launchBlock);
+        launch(rig, 0);
+        rig.rollThrough(launchBlock, launchBlock + kBlocksPerPass + 1);
+        return rig.sounding();
+    };
+
+    CHECK(pick(0) == pick(0));
+    CHECK(pick(0) >= 0);
+
+    // A different beat is a different draw, or a random action would pick one
+    // slot for the life of the set.
+    auto differs = false;
+    for (auto block = 1; block <= 8 && !differs; ++block)
+        differs = pick(block) != pick(0);
+
+    CHECK(differs);
+}
+
+TEST_CASE("An engine-initiated launch reads out exactly as a clicked one does",
+          "[engine][session][launch][follow][tap]") {
+    // The whole of the read-back: what a follow action started is published by
+    // the slot that is playing it, so there is nothing for the model to adopt.
+    Rig followed({follows(SlotAction::next), follows(SlotAction::none)});
+    Rig clicked({follows(SlotAction::none), follows(SlotAction::none)});
+
+    launch(followed, 0);
+    launch(clicked, 0);
+
+    followed.rollThrough(0, kBlocksPerPass);
+    clicked.rollThrough(0, kBlocksPerPass);
+
+    // The user clicks slot 1 on the beat the follow action would have.
+    {
+        LaunchRequestQueue::Gesture gesture(clicked.requests);
+        gesture.stop(Rig::key(0), kPassBeats);
+    }
+    {
+        LaunchRequestQueue::Gesture gesture(clicked.requests);
+        gesture.play(Rig::key(1), kPassBeats);
+    }
+
+    followed.rollThrough(kBlocksPerPass, kBlocksPerPass * 2);
+    clicked.rollThrough(kBlocksPerPass, kBlocksPerPass * 2);
+
+    for (auto scene = 0; scene < 2; ++scene) {
+        const auto a = followed.reading(scene);
+        const auto b = clicked.reading(scene);
+
+        CHECK(a.playing == b.playing);
+        CHECK(a.queued == b.queued);
+        CHECK(a.holdsSection == b.holdsSection);
+        CHECK(a.elapsedBeats == Approx(b.elapsedBeats));
+    }
+}
+
+TEST_CASE("A chain of follow actions plays the scenes in order",
+          "[engine][session][launch][follow]") {
+    // The issue's own verification: a known sequence of played ranges, with the
+    // taps agreeing at every step rather than only at the end.
+    Rig rig({follows(SlotAction::next), follows(SlotAction::next), follows(SlotAction::next)});
+
+    launch(rig, 0);
+
+    for (auto pass = 0; pass < 3; ++pass) {
+        rig.rollThrough(pass * kBlocksPerPass, (pass + 1) * kBlocksPerPass);
+
+        CHECK(rig.sounding() == pass);
+        CHECK(rig.reading(pass).elapsedBeats == Approx(kPassBeats));
+    }
+
+    // The last slot has nothing to hand on to, so the chain ends there.
+    rig.roll(kBlocksPerPass * 3);
+
+    CHECK(rig.sounding() == -1);
+
+    for (auto scene = 0; scene < 3; ++scene) {
+        REQUIRE(rig.handles[scene].lastPlayedRange().has_value());
+        CHECK(rig.handles[scene].lastPlayedRange()->start == Approx(scene * kPassBeats));
+        CHECK(rig.handles[scene].lastPlayedRange()->length() == Approx(kPassBeats));
+    }
+}

--- a/tests/engine/test_launch_requests.cpp
+++ b/tests/engine/test_launch_requests.cpp
@@ -51,8 +51,9 @@ struct Rig {
     explicit Rig(int scenes) : handles(static_cast<std::size_t>(scenes)) {
         auto table = std::make_shared<LaunchHandleTable>();
         for (auto scene = 0; scene < scenes; ++scene)
-            table->entries.push_back(LaunchHandleTable::Entry{
-                SlotKey{kTrack, scene}, &handles[static_cast<std::size_t>(scene)]});
+            table->entries.push_back(
+                LaunchHandleTable::Entry{.key = SlotKey{kTrack, scene},
+                                         .handle = &handles[static_cast<std::size_t>(scene)]});
 
         feed.publish(std::move(table));
     }
@@ -72,8 +73,10 @@ struct Rig {
 
         for (auto scene = 0; scene < static_cast<int>(handles.size()); ++scene) {
             const auto key = SlotKey{kTrack, scene};
-            table->entries.push_back(LaunchHandleTable::Entry{
-                key, &handles[static_cast<std::size_t>(scene)], incarnation});
+            table->entries.push_back(
+                LaunchHandleTable::Entry{.key = key,
+                                         .handle = &handles[static_cast<std::size_t>(scene)],
+                                         .incarnation = incarnation});
             stamped[key] = incarnation;
         }
 
@@ -319,7 +322,8 @@ TEST_CASE("A request cannot launch the clip that replaced the one it named",
     // Emptied and refilled before the callback ever ran, so nothing has drained.
     LaunchHandle refilled;
     auto table = std::make_shared<LaunchHandleTable>();
-    table->entries.push_back(LaunchHandleTable::Entry{Rig::key(0), &refilled, 2});
+    table->entries.push_back(
+        LaunchHandleTable::Entry{.key = Rig::key(0), .handle = &refilled, .incarnation = 2});
     rig.feed.publish(std::move(table));
     rig.requests.setIncarnations({{Rig::key(0), 2}});
 
@@ -361,7 +365,7 @@ TEST_CASE("A slot emptied and refilled does not inherit what was asked of the la
     // What publishHandles() does to a slot whose clip was deleted and replaced.
     LaunchHandle refilled;
     auto table = std::make_shared<LaunchHandleTable>();
-    table->entries.push_back(LaunchHandleTable::Entry{Rig::key(0), &refilled});
+    table->entries.push_back(LaunchHandleTable::Entry{.key = Rig::key(0), .handle = &refilled});
     rig.feed.publish(std::move(table));
 
     rig.roll(1);
@@ -424,7 +428,7 @@ TEST_CASE("A request made while nothing is published is not kept", "[engine][ses
 
     LaunchHandle handle;
     auto table = std::make_shared<LaunchHandleTable>();
-    table->entries.push_back(LaunchHandleTable::Entry{Rig::key(0), &handle});
+    table->entries.push_back(LaunchHandleTable::Entry{.key = Rig::key(0), .handle = &handle});
     rig.feed.publish(std::move(table));
 
     rig.roll(1);

--- a/tests/engine/test_launch_tap.cpp
+++ b/tests/engine/test_launch_tap.cpp
@@ -49,7 +49,8 @@ struct Rig {
         for (auto scene = 0; scene < scenes; ++scene) {
             const auto key = SlotKey{kTrack, scene};
             const auto at = static_cast<std::size_t>(scene);
-            table->entries.push_back(LaunchHandleTable::Entry{key, &handles[at], 1, &taps[at]});
+            table->entries.push_back(LaunchHandleTable::Entry{
+                .key = key, .handle = &handles[at], .incarnation = 1, .tap = &taps[at]});
             incarnations[key] = 1;
         }
 

--- a/tests/engine/test_session_playback.cpp
+++ b/tests/engine/test_session_playback.cpp
@@ -248,7 +248,8 @@ AudioClipPlayback clipOver(magda::ClipId id, SnapshotSpan span) {
 /// what a store does with handles has its own cases below.
 struct AudioRig {
     AudioRig() {
-        table.entries.push_back(LaunchHandleTable::Entry{SlotKey{kTrack, kScene}, &handle});
+        table.entries.push_back(
+            LaunchHandleTable::Entry{.key = SlotKey{kTrack, kScene}, .handle = &handle});
         handles.publish(std::make_shared<const LaunchHandleTable>(table));
 
         source.prepare(context());
@@ -360,7 +361,8 @@ struct Captured {
 
 struct MidiRig {
     MidiRig() {
-        table.entries.push_back(LaunchHandleTable::Entry{SlotKey{kTrack, kScene}, &handle});
+        table.entries.push_back(
+            LaunchHandleTable::Entry{.key = SlotKey{kTrack, kScene}, .handle = &handle});
         handles.publish(std::make_shared<const LaunchHandleTable>(table));
         source.prepare(context());
     }
@@ -451,8 +453,10 @@ ClipInfo arrangementMidiClip(magda::ClipId id, double start, double lengthBeats,
 struct MidiSwitchRig {
     /// @copydoc SwitchRig
     explicit MidiSwitchRig(bool publishHandles = true) {
-        table.entries.push_back(LaunchHandleTable::Entry{SlotKey{kTrack, kScene}, &handle});
-        table.entries.push_back(LaunchHandleTable::Entry{SlotKey{kTrack, kScene + 1}, &second});
+        table.entries.push_back(
+            LaunchHandleTable::Entry{.key = SlotKey{kTrack, kScene}, .handle = &handle});
+        table.entries.push_back(
+            LaunchHandleTable::Entry{.key = SlotKey{kTrack, kScene + 1}, .handle = &second});
 
         if (publishHandles)
             handles.publish(std::make_shared<const LaunchHandleTable>(table));
@@ -733,8 +737,10 @@ struct SwitchRig {
     /// ever published, which the contract permits and which a track's sources
     /// have to survive.
     explicit SwitchRig(bool publishHandles = true) {
-        table.entries.push_back(LaunchHandleTable::Entry{SlotKey{kTrack, kScene}, &handle});
-        table.entries.push_back(LaunchHandleTable::Entry{SlotKey{kTrack, kScene + 1}, &second});
+        table.entries.push_back(
+            LaunchHandleTable::Entry{.key = SlotKey{kTrack, kScene}, .handle = &handle});
+        table.entries.push_back(
+            LaunchHandleTable::Entry{.key = SlotKey{kTrack, kScene + 1}, .handle = &second});
 
         if (publishHandles)
             handles.publish(std::make_shared<const LaunchHandleTable>(table));
@@ -1717,7 +1723,8 @@ TEST_CASE("A handle is advanced once per block however many sources read it",
           "[engine][clip][session]") {
     LaunchHandle handle;
     LaunchHandleTable table;
-    table.entries.push_back(LaunchHandleTable::Entry{SlotKey{kTrack, kScene}, &handle});
+    table.entries.push_back(
+        LaunchHandleTable::Entry{.key = SlotKey{kTrack, kScene}, .handle = &handle});
 
     LaunchHandleFeed feed;
     feed.publish(std::make_shared<const LaunchHandleTable>(table));


### PR DESCRIPTION
Closes #2304. Slice 5 of #1894.

The engine's first launch of its own. Every other arrives down the queue in `LaunchRequests.hpp` (#2305); this one is a beat the clip named when it was written, so the audio thread works it out and acts on it.

## Where it runs

In `advanceLaunchHandles`, after the request drain and before the advance. That ordering is the whole of the sample accuracy: a launch decided after the handles had moved would take effect on the next callback boundary, and both halves -- the slot that stops and the slot that starts -- are handed the same beat, so the advance cuts both blocks at the same sample.

A slot with anything queued is left alone. A handle holds one pending request and the last write wins, so a follow action written over a queued launch would drop what the user asked for. The incumbent only defends against a queued stop; this is the same rule taken to its end.

## Counting the passes

The due beat counts from `LaunchHandle::scheduleBeat`, which is carried across every re-trigger, not from the run's origin, which is not.

That difference is a bug in the incumbent rather than a preference. `SlotControlNode` computes its stop point as `playedMonotonicRange().start + stopDuration`, and TE's own loop wrap resets that start. With `FollowActionDurationType::loops` and a count above one, the stop point moves forward by a loop length every time the loop wraps, so it is never reached and the action never fires. Counting from the schedule beat is exact and stable across a thousand wraps, which is what #2336 put it there for.

`loopCount` multiplies only while the handle is re-triggering, matching `syncFollowActionToTracktionClip`: a slot with one pass in it has one to count.

## A run that ends

A non-looping slot now stops at the end of its material. The engine did not do this at all before -- a launched slot ran until something stopped it -- and it is the same question a follow action is asked at, so it falls out of the same calculation rather than needing its own.

## Random

Hashed from the slot and the due beat, not carried in a generator. Two renders of one project have to produce one file, and a seed carried block to block would put every random follow action beyond the null-diff harness (#1896). splitmix64's finaliser, so two adjacent beats pick unrelated slots.

## A target that has gone

Nothing stores one. `next`, `previous` and `random` are resolved against the handle table as it stands at the instant the action fires, and that table is built from the slots the snapshot named, so a slot deleted since the project loaded is simply not in the list searched and a moved one is at its new scene index. An action with nothing left to name does nothing beyond the stop, which is also what the incumbent does at the ends of a track: `trackNext` at the last slot returns nothing rather than wrapping.

## The read-back, and what is not here

The action reaches the handle through `play` and `stop` -- what a user launch reaches -- so the slot it starts publishes through its own tap (#2303) exactly as a clicked one does. `test_follow_actions.cpp` asserts that field by field against a control rig where the user clicked on the same beat instead.

So there is nothing to adopt, which is what #1894 asked for. What there is not is an app-side subscription: nothing in the app drives the native launcher yet, and the fork's `SessionClipScheduler::processStateEvents` still owns `activeSessionClipId` and its adoption loop. That is the issue's "or a stated reason why it cannot" -- the reporting is in place and the model reading it is wiring that belongs with whatever turns the native launcher on.

## Shape

`SlotAction` and `SlotFollow` are named apart from the model's `FollowAction` on purpose: a slot rather than a clip, and no track-group actions, because the model does not offer them. The config rides on `LaunchHandleTable::Entry` beside the handle and the tap, so the audio thread reads one table rather than merging two lists that publish separately, and a follow-action edit republishes it through the existing `entries ==` comparison.

## Tests

New `tests/engine/test_follow_actions.cpp`, 16 cases: a non-looping slot stopping at its end, a looping one with nothing to follow it playing on, the stop landing on its beat, next and previous handing the track over on one instant and doing nothing at the ends, again restarting rather than ending, a loop count holding the action off until the third pass, a loop count being one pass for a slot that does not loop, the delay, a user request outranking the action, a target deleted mid-run, random being deterministic per beat and not per set, an engine launch reading out identically to a clicked one, and a three-slot chain producing a known sequence of played ranges.

Full engine suite green: 554,643 assertions in 875 cases.

## Also here

Every `LaunchHandleTable::Entry` construction site now names its fields. The new member would otherwise have left `-Wmissing-field-initializers` across four test files, and a positional aggregate is what made adding one noisy in the first place.

https://claude.ai/code/session_013CDpSHas8bog33vv4o6HLv
