### PR TITLE
Restore a sampler's loop switch as off when the state does not name it

### DIFF
--- a/magda/daw/audio/plugins/MagdaSamplerPlugin.cpp
+++ b/magda/daw/audio/plugins/MagdaSamplerPlugin.cpp
@@ -640,8 +640,11 @@ void MagdaSamplerPlugin::flushState(juce::ValueTree& state) {
 }
 
 void MagdaSamplerPlugin::restoreState(const juce::ValueTree& state) {
-    if (const auto* value = state.getPropertyPointer(StateIDs::loopEnabled))
-        loopEnabled_.store(static_cast<bool>(*value), std::memory_order_relaxed);
+    // Absent means off, as it does for the sample and the root note below: the
+    // document is the whole authored state, so restoring one saved before the
+    // loop was switched on has to switch it back off (#2377).
+    loopEnabled_.store(static_cast<bool>(state.getProperty(StateIDs::loopEnabled, false)),
+                       std::memory_order_relaxed);
 
     const int savedRootNote = state.getPropertyPointer(StateIDs::rootNote) != nullptr
                                   ? static_cast<int>(state[StateIDs::rootNote])

--- a/tests/devices/test_sampler_relocate_juce.cpp
+++ b/tests/devices/test_sampler_relocate_juce.cpp
@@ -70,6 +70,7 @@ class SamplerRelocateTest final : public juce::UnitTest {
         testRelocatePreservesInterpretation();
         testLoadSampleStillResets();
         testLoadTakesMarkersIntoHostParameters();
+        testRestoreWithoutLoopEnabledSwitchesItOff();
     }
 
   private:
@@ -215,6 +216,27 @@ class SamplerRelocateTest final : public juce::UnitTest {
         }
 
         file.deleteFile();
+    }
+
+    void testRestoreWithoutLoopEnabledSwitchesItOff() {
+        beginTest("A restore that does not name loopEnabled switches looping off");
+
+        // The document is the whole authored state, so a state saved before the
+        // loop was switched on has to switch it back off. Keeping the previous
+        // value leaves a pad looping that the project says does not (#2377).
+        MagdaSamplerPlugin sampler;
+        sampler.setLoopEnabled(true);
+
+        juce::ValueTree state{juce::Identifier("PLUGIN")};
+        state.setProperty(juce::Identifier("type"), MagdaSamplerPlugin::xmlTypeName, nullptr);
+        sampler.restoreState(state);
+
+        expect(!sampler.loopEnabled(), "An absent loopEnabled must restore as off");
+
+        state.setProperty(MagdaSamplerPlugin::StateIDs::loopEnabled, true, nullptr);
+        sampler.restoreState(state);
+
+        expect(sampler.loopEnabled(), "A state that names loopEnabled must still restore it");
     }
 };
 


### PR DESCRIPTION
A regression from #2355, found by a Codex review of it.

The retired plugin read `loopEnabled` through `te::copyPropertiesToCachedValues`, which resets an absent property to its default. `MagdaSamplerPlugin::restoreState` only wrote when the property was present, so the previous value survived a restore that did not name it.

The document is the whole authored state, so absent means off — the same rule the sample path and root note beside it already follow. A state saved before the loop was switched on now switches it back off, instead of leaving a pad looping that the project says does not.

Verified negatively: with the old read back in, `An absent loopEnabled must restore as off` fails.

Full Catch2 suite green (3542 passed, 13 skipped) and all JUCE suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018rAnjCekXfSQtpsr7jLtj5
