### PR TITLE
Move the device, chain and track predicates onto the model structs

### DIFF
--- a/magda/daw/core/ChainRoutingModel.hpp
+++ b/magda/daw/core/ChainRoutingModel.hpp
@@ -77,7 +77,7 @@ inline bool usesExternalMidiSidechain(const DeviceInfo& device) {
 
 inline ChainRoutingNode makeRoutingNode(const DeviceInfo& device) {
     const auto externalMidiSidechain = usesExternalMidiSidechain(device);
-    const auto outputsMidi = device.producesMidi || device.deviceType == DeviceType::MIDI;
+    const auto outputsMidi = device.emitsMidi();
 
     ChainRoutingNode node;
     node.kind = ChainRoutingNodeKind::Device;

--- a/magda/daw/core/DeviceInfo.cpp
+++ b/magda/daw/core/DeviceInfo.cpp
@@ -1,8 +1,17 @@
 #include "DeviceInfo.hpp"
 
+#include <algorithm>
+
 #include "RackInfo.hpp"
 
 namespace magda {
+
+int DeviceInfo::paramIndexFor(const std::string& stableId) const {
+    const auto found = std::ranges::find_if(parameters, [&](const ParameterInfo& param) {
+        return param.stableId.toStdString() == stableId;
+    });
+    return found == parameters.end() ? -1 : found->paramIndex;
+}
 
 // Out of line because RackInfo is only complete once RackInfo.hpp has been
 // seen, and RackInfo.hpp includes DeviceInfo.hpp, so the header cannot see it.

--- a/magda/daw/core/DeviceInfo.hpp
+++ b/magda/daw/core/DeviceInfo.hpp
@@ -4,6 +4,7 @@
 
 #include <memory>
 #include <optional>
+#include <string>
 
 #include "KitRow.hpp"
 #include "MacroInfo.hpp"
@@ -452,6 +453,26 @@ struct DeviceInfo {
     bool hasEditorWindow() const {
         return format != PluginFormat::Internal;
     }
+
+    /// Anything upstream MIDI reaches: an instrument, a MIDI effect, or a plugin
+    /// that declared a MIDI input.
+    bool consumesMidi() const {
+        return isInstrument || canReceiveMidi || deviceType == DeviceType::MIDI;
+    }
+
+    /// Its MIDI output port carries what it produced: a MIDI effect, or a plugin
+    /// that declared a MIDI output.
+    bool emitsMidi() const {
+        return producesMidi || deviceType == DeviceType::MIDI;
+    }
+
+    /// Analysis devices are transparent passthroughs: no gain trim, no meter.
+    bool isTransparentTap() const {
+        return deviceType == DeviceType::Analysis;
+    }
+
+    /// Index of the parameter declared under @p stableId, or -1.
+    int paramIndexFor(const std::string& stableId) const;
 };
 
 }  // namespace magda

--- a/magda/daw/core/PluginCapabilities.cpp
+++ b/magda/daw/core/PluginCapabilities.cpp
@@ -88,10 +88,8 @@ juce::var snapshotToVar(const PluginCapabilitySnapshot& snapshot) {
 
 DeviceMidiCapabilities fallbackCapabilitiesForDevice(const DeviceInfo& device) {
     DeviceMidiCapabilities capabilities;
-    const bool midiInputOverride = hasMidiInputOverride(device);
-    const bool midiOutputOverride = hasMidiOutputOverride(device);
-    capabilities.hasMidiInput = device.isInstrument || device.canReceiveMidi || midiInputOverride;
-    capabilities.hasMidiOutput = device.producesMidi || midiOutputOverride;
+    capabilities.hasMidiInput = device.consumesMidi();
+    capabilities.hasMidiOutput = device.emitsMidi();
     capabilities.hasAudioInput = device.deviceType == DeviceType::Effect || device.canSidechain;
     capabilities.hasAudioOutput = device.isInstrument || device.deviceType == DeviceType::Effect;
     capabilities.supportsMidiInputThruToggle =

--- a/magda/daw/core/RackInfo.hpp
+++ b/magda/daw/core/RackInfo.hpp
@@ -88,6 +88,12 @@ struct ChainInfo {
         return lowNote > highNote;
     }
 
+    /// Compiled at all: not bypassed, and on the main output. Aux-routed chains
+    /// are not wired yet.
+    bool isActive() const {
+        return !bypassed && outputIndex == 0;
+    }
+
     // UI state
     bool expanded = true;
 

--- a/magda/daw/core/TrackInfo.hpp
+++ b/magda/daw/core/TrackInfo.hpp
@@ -288,6 +288,12 @@ struct TrackInfo {
         return inputMonitor != InputMonitorMode::Off || recordArmed;
     }
 
+    /// Live input reaches the chain: armed, or monitoring set to In. Narrower
+    /// than receivesLiveMidiInput, which answers for the UI's activity light.
+    bool monitorsInput() const {
+        return recordArmed || inputMonitor == InputMonitorMode::In;
+    }
+
     // View settings helpers
     bool isVisibleIn(ViewMode mode) const {
         return viewSettings.isVisible(mode);

--- a/magda/engine/plan/PlanCompiler.cpp
+++ b/magda/engine/plan/PlanCompiler.cpp
@@ -37,22 +37,6 @@ struct ChainSite {
     ChainSegment segment = ChainSegment::Fx;
 };
 
-/// Analysis devices are transparent passthroughs with no gain trim and no
-/// meter of their own, so they compile to the process op alone.
-bool isTransparentTap(const DeviceInfo& device) {
-    return device.deviceType == DeviceType::Analysis;
-}
-
-bool consumesMidi(const DeviceInfo& device) {
-    return device.isInstrument || device.canReceiveMidi || device.deviceType == DeviceType::MIDI;
-}
-
-/// True when a chain inside a rack will be compiled at all. Aux-routed chains
-/// are not wired yet, and bypassed ones contribute nothing.
-bool chainIsActive(const ChainInfo& chain) {
-    return !chain.bypassed && chain.outputIndex == 0;
-}
-
 /// Whether anything the compiler will actually emit consumes MIDI. Walks only
 /// the live elements, so a bypassed instrument does not keep the track's MIDI
 /// source ops in the plan with nothing to read them, and neither does anything
@@ -61,7 +45,7 @@ bool elementsConsumeMidi(const std::vector<ChainElement>& elements, RackNesting&
     return std::ranges::any_of(elements, [&](const ChainElement& element) {
         if (isDevice(element)) {
             const auto& device = getDevice(element);
-            return !device.bypassed && consumesMidi(device);
+            return !device.bypassed && device.consumesMidi();
         }
         if (isRack(element)) {
             const auto& rack = getRack(element);
@@ -70,7 +54,7 @@ bool elementsConsumeMidi(const std::vector<ChainElement>& elements, RackNesting&
 
             const RackNesting::Scope scope{nesting, rack.id};
             return std::ranges::any_of(rack.chains, [&](const ChainInfo& chain) {
-                return chainIsActive(chain) && elementsConsumeMidi(chain.elements, nesting);
+                return chain.isActive() && elementsConsumeMidi(chain.elements, nesting);
             });
         }
         return false;
@@ -90,7 +74,7 @@ bool rackHasInstrument(const RackInfo& rack, RackNesting& nesting) {
 
     const RackNesting::Scope scope{nesting, rack.id};
     return std::ranges::any_of(rack.chains, [&](const ChainInfo& chain) {
-        if (!chainIsActive(chain))
+        if (!chain.isActive())
             return false;
         return std::ranges::any_of(chain.elements, [&](const ChainElement& element) {
             if (isDevice(element)) {
@@ -108,7 +92,7 @@ bool rackHasInstrument(const RackInfo& rack, RackNesting& nesting) {
 
 bool sectionConsumesMidi(const std::vector<PostFxChainElement>& section) {
     return std::ranges::any_of(section, [](const PostFxChainElement& element) {
-        return !element.device.bypassed && consumesMidi(element.device);
+        return !element.device.bypassed && element.device.consumesMidi();
     });
 }
 
@@ -141,7 +125,7 @@ void collectSidechainSources(const std::vector<ChainElement>& elements,
 
             const RackNesting::Scope scope{nesting, rack.id};
             for (const auto& chain : rack.chains)
-                if (chainIsActive(chain))
+                if (chain.isActive())
                     collectSidechainSources(chain.elements, type, out, nesting);
         }
     }
@@ -168,19 +152,6 @@ void collectSidechainSources(const TrackInfo& track, std::optional<SidechainConf
 
     collectSidechainSources(track.chain.postFxChainElements, type, out);
     collectSidechainSources(track.chain.mixerAnalysisElements, type, out);
-}
-
-/// Whether input reaches the track at all, for either audio or MIDI.
-///
-/// Auto is deliberately not enough on its own: automatic monitoring passes
-/// input only while the track is armed. Including it
-/// unarmed would emit a live input op the current engine keeps silent, and
-/// would mark the whole downstream chain Live, pessimising the anticipative
-/// executor for a track that cannot sound. This is why the compiler does not
-/// use TrackInfo::receivesLiveMidiInput, which answers a broader question for
-/// the UI's input-activity light.
-bool monitorsInput(const TrackInfo& track) {
-    return track.recordArmed || track.inputMonitor == InputMonitorMode::In;
 }
 
 class Compiler {
@@ -403,13 +374,13 @@ bool Compiler::carriesClips(const TrackInfo& track) const {
 }
 
 TrackRoute Compiler::activeAudioInputRoute(const TrackInfo& track) const {
-    if (!carriesClips(track) || !monitorsInput(track) || track.audioInputDevice.isEmpty())
+    if (!carriesClips(track) || !track.monitorsInput() || track.audioInputDevice.isEmpty())
         return {RouteKind::None, INVALID_TRACK_ID};
     return parseTrackRoute(track.audioInputDevice);
 }
 
 TrackRoute Compiler::activeMidiInputRoute(const TrackInfo& track) const {
-    if (!carriesClips(track) || !monitorsInput(track) || track.midiInputDevice.isEmpty())
+    if (!carriesClips(track) || !track.monitorsInput() || track.midiInputDevice.isEmpty())
         return {RouteKind::None, INVALID_TRACK_ID};
     return parseTrackRoute(track.midiInputDevice);
 }
@@ -803,7 +774,7 @@ ChainSignal Compiler::emitDevice(const DeviceInfo& device, const ChainSite& site
     // Channel widths, read off the plugin the way RackSyncManager reads them.
     // A transparent tap keeps full stereo: its output is its input, so
     // narrowing it would narrow the chain rather than the device.
-    const bool transparent = isTransparentTap(device);
+    const bool transparent = device.isTransparentTap();
     const bool injector = !transparent && node.injectsAudio();
 
     // An external plugin is handed the bus and adapts its own channels, and
@@ -1074,14 +1045,6 @@ ChainSignal Compiler::emitRack(const RackInfo& rack, const ChainSite& site, Chai
     return out;
 }
 
-/// The index of the parameter @p device declares under @p stableId, or -1.
-int deviceParamIndex(const DeviceInfo& device, const std::string& stableId) {
-    const auto found = std::ranges::find_if(device.parameters, [&](const ParameterInfo& param) {
-        return param.stableId.toStdString() == stableId;
-    });
-    return found == device.parameters.end() ? -1 : found->paramIndex;
-}
-
 /// A pad-per-chain device, expanded the way a rack is.
 ///
 /// The device itself never becomes an op. Its pads are chains, and each one is
@@ -1158,8 +1121,8 @@ ChainSignal Compiler::emitPadRack(const DeviceInfo& device, const ChainSite& sit
         // published value.
         if (const auto slot = padParameterSlot(pad); slot >= 0) {
             auto& fader = plan_.ops[static_cast<std::size_t>(faderOp)];
-            fader.padLevelParam = deviceParamIndex(device, "padLevel" + std::to_string(slot));
-            fader.padPanParam = deviceParamIndex(device, "padPan" + std::to_string(slot));
+            fader.padLevelParam = device.paramIndexFor("padLevel" + std::to_string(slot));
+            fader.padPanParam = device.paramIndexFor("padPan" + std::to_string(slot));
         }
 
         busAudio[pad.outputIndex].push_back(PortRef{faderOp, 0});

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -319,6 +319,7 @@ set(TEST_SOURCES
     audio/test_demucs_chunking.cpp
     audio/test_demucs_separator.cpp
     audio/test_spleeter_separator.cpp
+    core/test_device_info_predicates.cpp
 )
 
 # Native audio engine (epic #1882). The engine is a dark target with no TE and

--- a/tests/core/test_device_info_predicates.cpp
+++ b/tests/core/test_device_info_predicates.cpp
@@ -1,0 +1,48 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "magda/daw/core/DeviceInfo.hpp"
+
+using magda::DeviceInfo;
+using magda::DeviceType;
+
+TEST_CASE("consumesMidi reads isInstrument, canReceiveMidi and MIDI type", "[core][devices]") {
+    DeviceInfo instrument;
+    instrument.isInstrument = true;
+    REQUIRE(instrument.consumesMidi());
+
+    DeviceInfo midiType;
+    midiType.deviceType = DeviceType::MIDI;
+    REQUIRE(midiType.consumesMidi());
+
+    DeviceInfo receivingEffect;
+    receivingEffect.canReceiveMidi = true;
+    REQUIRE(receivingEffect.consumesMidi());
+
+    DeviceInfo producingEffect;
+    producingEffect.producesMidi = true;
+    REQUIRE_FALSE(producingEffect.consumesMidi());
+
+    DeviceInfo plainEffect;
+    REQUIRE_FALSE(plainEffect.consumesMidi());
+}
+
+TEST_CASE("emitsMidi reads producesMidi and MIDI type", "[core][devices]") {
+    DeviceInfo instrument;
+    instrument.isInstrument = true;
+    REQUIRE_FALSE(instrument.emitsMidi());
+
+    DeviceInfo midiType;
+    midiType.deviceType = DeviceType::MIDI;
+    REQUIRE(midiType.emitsMidi());
+
+    DeviceInfo receivingEffect;
+    receivingEffect.canReceiveMidi = true;
+    REQUIRE_FALSE(receivingEffect.emitsMidi());
+
+    DeviceInfo producingEffect;
+    producingEffect.producesMidi = true;
+    REQUIRE(producingEffect.emitsMidi());
+
+    DeviceInfo plainEffect;
+    REQUIRE_FALSE(plainEffect.emitsMidi());
+}


### PR DESCRIPTION
## What

Facts about a device, chain or track that are pure reads of the model's own fields now live as const members on the model structs, and every caller uses the member.

The MIDI ones were written three times and agreed by coincidence: `consumesMidi` in the plan compiler, `hasMidiInput` in the capabilities fallback, and `outputsMidi` in the routing model with its twin `hasMidiOutput`. The first device to grow a new way of taking MIDI would have split them.

- `DeviceInfo::consumesMidi()`, `emitsMidi()`, `isTransparentTap()`, `paramIndexFor()`
- `ChainInfo::isActive()`
- `TrackInfo::monitorsInput()`

The compiler drops its five free helpers and calls the members. The composed rules stay in the compiler: `elementsConsumeMidi`, `rackHasInstrument`, `sectionConsumesMidi` and the exported `chainConsumesMidi`, since they fold in bypass, chain power and rack nesting.

No formula changed. `PluginCapabilities::mergeSnapshotWithDevice` keeps its own override helpers because its formula is not the same one.

A Catch2 test covers both MIDI predicates over five device shapes.

https://claude.ai/code/session_01WnFtPLfo2TUoSynbysJRri
