### PR TITLE
Make Elements and Rings add to the host buffer on the TE leg

### DIFF
--- a/magda/daw/audio/plugins/mutable/MutableElementsPlugin.cpp
+++ b/magda/daw/audio/plugins/mutable/MutableElementsPlugin.cpp
@@ -330,7 +330,7 @@ void MutableElementsPlugin::process(DeviceProcessContext& context) {
     const int start = context.startSample;
     const int numChannels = buffer.getNumChannels();
     auto* destL = scratch_.getWritePointer(0);
-    float* destR = numChannels > 1 ? scratch_.getWritePointer(1) : nullptr;
+    auto* destR = numChannels > 1 ? scratch_.getWritePointer(1) : nullptr;
 
     // Split the block at each MIDI event so note timing lands at the right
     // sample, generating each segment with the performance state up to it.

--- a/magda/daw/audio/plugins/mutable/MutableElementsPlugin.cpp
+++ b/magda/daw/audio/plugins/mutable/MutableElementsPlugin.cpp
@@ -1,5 +1,6 @@
 #include "plugins/mutable/MutableElementsPlugin.hpp"
 
+#include <algorithm>
 #include <array>
 #include <cstdint>
 #include <cstring>
@@ -284,6 +285,7 @@ float MutableElementsPlugin::displayValue(int index) const {
 void MutableElementsPlugin::prepare(const DevicePrepareContext& context) {
     sampleRate_ = context.sampleRate;
     impl_->prepare(sampleRate_);
+    scratch_.setSize(2, std::max(context.maximumBlockSize, 1), false, true, false);
 }
 
 void MutableElementsPlugin::reset() {
@@ -326,8 +328,9 @@ void MutableElementsPlugin::process(DeviceProcessContext& context) {
 
     auto& buffer = *context.audio;
     const int start = context.startSample;
-    auto* destL = buffer.getWritePointer(0, start);
-    float* destR = buffer.getNumChannels() > 1 ? buffer.getWritePointer(1, start) : nullptr;
+    const int numChannels = buffer.getNumChannels();
+    auto* destL = scratch_.getWritePointer(0);
+    float* destR = numChannels > 1 ? scratch_.getWritePointer(1) : nullptr;
 
     // Split the block at each MIDI event so note timing lands at the right
     // sample, generating each segment with the performance state up to it.
@@ -360,8 +363,14 @@ void MutableElementsPlugin::process(DeviceProcessContext& context) {
     }
     renderTo(context.numSamples);
 
+    // Add rather than replace (#2370): on the TE leg the buffer may already
+    // carry an audio clip's signal that must not be clobbered. The native
+    // engine clears an instrument's channels before running it, so add is a
+    // no-op difference there.
     const float gain = juce::Decibels::decibelsToGain(v[kLevel]);
-    buffer.applyGain(start, context.numSamples, gain);
+    buffer.addFrom(0, start, scratch_, 0, 0, context.numSamples, gain);
+    if (destR != nullptr)
+        buffer.addFrom(1, start, scratch_, 1, 0, context.numSamples, gain);
 }
 
 }  // namespace magda::daw::audio

--- a/magda/daw/audio/plugins/mutable/MutableElementsPlugin.hpp
+++ b/magda/daw/audio/plugins/mutable/MutableElementsPlugin.hpp
@@ -104,6 +104,11 @@ class MutableElementsPlugin : public MagdaDevice {
 
     double sampleRate_ = 44100.0;
 
+    /// Rendered here, then added into the host buffer (#2370): the DSP writes
+    /// straight into these pointers, so it can't itself sum onto whatever the
+    /// host handed us.
+    juce::AudioBuffer<float> scratch_;
+
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(MutableElementsPlugin)
 };
 

--- a/magda/daw/audio/plugins/mutable/MutableRingsPlugin.cpp
+++ b/magda/daw/audio/plugins/mutable/MutableRingsPlugin.cpp
@@ -1,5 +1,6 @@
 #include "plugins/mutable/MutableRingsPlugin.hpp"
 
+#include <algorithm>
 #include <array>
 #include <cstdint>
 #include <cstring>
@@ -291,6 +292,7 @@ float MutableRingsPlugin::displayValue(int index) const {
 void MutableRingsPlugin::prepare(const DevicePrepareContext& context) {
     sampleRate_ = context.sampleRate;
     impl_->prepare(sampleRate_);
+    scratch_.setSize(2, std::max(context.maximumBlockSize, 1), false, true, false);
 }
 
 void MutableRingsPlugin::reset() {
@@ -315,8 +317,8 @@ void MutableRingsPlugin::process(DeviceProcessContext& context) {
 
     auto& buffer = *context.audio;
     const int start = context.startSample;
-    auto* destL = buffer.getWritePointer(0, start);
-    float* destR = buffer.getNumChannels() > 1 ? buffer.getWritePointer(1, start) : nullptr;
+    auto* destL = scratch_.getWritePointer(0);
+    float* destR = buffer.getNumChannels() > 1 ? scratch_.getWritePointer(1) : nullptr;
 
     int pos = 0;
     auto renderTo = [&](int upto) {
@@ -339,8 +341,14 @@ void MutableRingsPlugin::process(DeviceProcessContext& context) {
     }
     renderTo(context.numSamples);
 
+    // Add rather than replace (#2370): on the TE leg the buffer may already
+    // carry an audio clip's signal that must not be clobbered. The native
+    // engine clears an instrument's channels before running it, so add is a
+    // no-op difference there.
     const float gain = juce::Decibels::decibelsToGain(displayValue(kLevel));
-    buffer.applyGain(start, context.numSamples, gain);
+    buffer.addFrom(0, start, scratch_, 0, 0, context.numSamples, gain);
+    if (destR != nullptr)
+        buffer.addFrom(1, start, scratch_, 1, 0, context.numSamples, gain);
 }
 
 }  // namespace magda::daw::audio

--- a/magda/daw/audio/plugins/mutable/MutableRingsPlugin.cpp
+++ b/magda/daw/audio/plugins/mutable/MutableRingsPlugin.cpp
@@ -318,7 +318,7 @@ void MutableRingsPlugin::process(DeviceProcessContext& context) {
     auto& buffer = *context.audio;
     const int start = context.startSample;
     auto* destL = scratch_.getWritePointer(0);
-    float* destR = buffer.getNumChannels() > 1 ? scratch_.getWritePointer(1) : nullptr;
+    auto* destR = buffer.getNumChannels() > 1 ? scratch_.getWritePointer(1) : nullptr;
 
     int pos = 0;
     auto renderTo = [&](int upto) {

--- a/magda/daw/audio/plugins/mutable/MutableRingsPlugin.hpp
+++ b/magda/daw/audio/plugins/mutable/MutableRingsPlugin.hpp
@@ -91,6 +91,11 @@ class MutableRingsPlugin : public MagdaDevice {
 
     double sampleRate_ = 44100.0;
 
+    /// Rendered here, then added into the host buffer (#2370): the DSP writes
+    /// straight into these pointers, so it can't itself sum onto whatever the
+    /// host handed us.
+    juce::AudioBuffer<float> scratch_;
+
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(MutableRingsPlugin)
 };
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -624,6 +624,7 @@ target_sources(magda_juce_tests PRIVATE
     project/test_legacy_corpus_migration_juce.cpp
     devices/test_device_state_schema_juce.cpp
     devices/test_convolution_device_juce.cpp
+    devices/test_mutable_add_not_replace_juce.cpp
     devices/test_master_sidechain_juce.cpp
     midi/test_midi_bridge_note_events_juce.cpp
     devices/test_section_scoped_device_ids_juce.cpp

--- a/tests/devices/test_mutable_add_not_replace_juce.cpp
+++ b/tests/devices/test_mutable_add_not_replace_juce.cpp
@@ -1,0 +1,88 @@
+#include <juce_core/juce_core.h>
+#include <tracktion_engine/tracktion_engine.h>
+
+#include "SharedTestEngine.hpp"
+#include "magda/daw/audio/plugins/mutable/MutableElementsPlugin.hpp"
+#include "magda/daw/audio/plugins/mutable/MutableRingsPlugin.hpp"
+#include "third_party/tracktion_engine/modules/tracktion_engine/utilities/tracktion_TestUtilities.h"
+
+// #2370: on the TE leg the plugin node has already copied the track's input
+// into the render buffer, so an instrument ahead of another device on the
+// same chain must add its signal rather than overwrite what is already
+// there - the same contract FaustInstrumentPlugin already follows.
+
+namespace {
+
+namespace audio = magda::daw::audio;
+namespace te = tracktion::engine;
+
+constexpr double kSampleRate = 44100.0;
+constexpr int kBlockSize = 64;
+
+template <typename Device> te::Plugin::Ptr createDevice(te::Edit& edit) {
+    juce::ValueTree state(te::IDs::PLUGIN);
+    state.setProperty(te::IDs::type, Device::xmlTypeName, nullptr);
+    return edit.getPluginCache().createNewPlugin(state);
+}
+
+void prepareForRender(te::Plugin& plugin) {
+    te::PluginInitialisationInfo info;
+    info.startTime = tracktion::TimePosition();
+    info.sampleRate = kSampleRate;
+    info.blockSizeSamples = kBlockSize;
+    plugin.baseClassInitialise(info);
+}
+
+/// Render one block with no MIDI over a buffer pre-filled with a DC value,
+/// standing in for an audio clip ahead of the instrument on the same chain.
+/// With no note played the device itself contributes silence, so the DC
+/// value survives unless the device replaced the buffer outright.
+float renderOverExistingSignal(te::Plugin& plugin) {
+    juce::AudioBuffer<float> buffer(2, kBlockSize);
+    for (int i = 0; i < kBlockSize; ++i) {
+        buffer.setSample(0, i, 0.5f);
+        buffer.setSample(1, i, 0.5f);
+    }
+
+    te::MidiMessageArray midi;
+    te::PluginRenderContext context(&buffer, juce::AudioChannelSet::stereo(), 0, kBlockSize, &midi,
+                                    0.0, tracktion::TimeRange(), true, false, false, true);
+    plugin.applyToBuffer(context);
+    return buffer.getSample(0, kBlockSize - 1);
+}
+
+class MutableAddNotReplaceTest final : public juce::UnitTest {
+  public:
+    MutableAddNotReplaceTest() : juce::UnitTest("Mutable Add Not Replace", "magda") {}
+
+    void runTest() override {
+        beginTest("Engine setup");
+        auto& wrapper = magda::test::getSharedEngine();
+        auto edit = te::test_utilities::createTestEdit(*wrapper.getEngine(), 1);
+        expect(edit != nullptr);
+        if (edit == nullptr)
+            return;
+
+        beginTest("Materia (Elements) adds to, rather than replaces, the host buffer");
+        if (auto holder = createDevice<audio::MutableElementsPlugin>(*edit)) {
+            prepareForRender(*holder);
+            expectWithinAbsoluteError(renderOverExistingSignal(*holder), 0.5f, 0.05f);
+            holder->deleteFromParent();
+        } else {
+            expect(false, "Materia plugin should have been created");
+        }
+
+        beginTest("Rings adds to, rather than replaces, the host buffer");
+        if (auto holder = createDevice<audio::MutableRingsPlugin>(*edit)) {
+            prepareForRender(*holder);
+            expectWithinAbsoluteError(renderOverExistingSignal(*holder), 0.5f, 0.05f);
+            holder->deleteFromParent();
+        } else {
+            expect(false, "Rings plugin should have been created");
+        }
+    }
+};
+
+MutableAddNotReplaceTest mutableAddNotReplaceTest;
+
+}  // namespace

--- a/tests/devices/test_mutable_add_not_replace_juce.cpp
+++ b/tests/devices/test_mutable_add_not_replace_juce.cpp
@@ -1,23 +1,36 @@
 #include <juce_core/juce_core.h>
 #include <tracktion_engine/tracktion_engine.h>
 
+#include <algorithm>
+#include <cmath>
+#include <vector>
+
 #include "SharedTestEngine.hpp"
 #include "magda/daw/audio/plugins/mutable/MutableElementsPlugin.hpp"
 #include "magda/daw/audio/plugins/mutable/MutableRingsPlugin.hpp"
+#include "magda/daw/audio/plugins/tracktion/TracktionMagdaDevicePlugin.hpp"
+#include "magda/daw/core/ParameterUtils.hpp"
 #include "third_party/tracktion_engine/modules/tracktion_engine/utilities/tracktion_TestUtilities.h"
 
 // #2370: on the TE leg the plugin node has already copied the track's input
 // into the render buffer, so an instrument ahead of another device on the
 // same chain must add its signal rather than overwrite what is already
-// there - the same contract FaustInstrumentPlugin already follows.
+// there - the same contract FaustInstrumentPlugin already follows. Covers
+// the three ways that contract can break: the device's own output getting
+// lost in the scratch buffer, gain being applied to the pre-existing signal
+// instead of just the device's contribution, and either channel replacing
+// rather than summing.
 
 namespace {
 
 namespace audio = magda::daw::audio;
+namespace ta = magda::daw::audio::tracktion_adapter;
 namespace te = tracktion::engine;
 
 constexpr double kSampleRate = 44100.0;
 constexpr int kBlockSize = 64;
+constexpr int kNumBlocks = 8;
+constexpr float kExistingSignal = 0.5f;
 
 template <typename Device> te::Plugin::Ptr createDevice(te::Edit& edit) {
     juce::ValueTree state(te::IDs::PLUGIN);
@@ -33,22 +46,62 @@ void prepareForRender(te::Plugin& plugin) {
     plugin.baseClassInitialise(info);
 }
 
-/// Render one block with no MIDI over a buffer pre-filled with a DC value,
-/// standing in for an audio clip ahead of the instrument on the same chain.
-/// With no note played the device itself contributes silence, so the DC
-/// value survives unless the device replaced the buffer outright.
-float renderOverExistingSignal(te::Plugin& plugin) {
-    juce::AudioBuffer<float> buffer(2, kBlockSize);
-    for (int i = 0; i < kBlockSize; ++i) {
-        buffer.setSample(0, i, 0.5f);
-        buffer.setSample(1, i, 0.5f);
-    }
+template <typename Device> void setLevelDb(te::Plugin& plugin, const Device& device, float db) {
+    auto* adapter = dynamic_cast<ta::TracktionMagdaDevicePlugin*>(&plugin);
+    if (auto* param =
+            adapter != nullptr ? adapter->parameterForDeviceSlot(Device::kLevel) : nullptr)
+        param->setParameterFromHost(
+            magda::ParameterUtils::realToNormalized(db, device.parameterInfo(Device::kLevel)),
+            juce::sendNotificationSync);
+}
 
-    te::MidiMessageArray midi;
-    te::PluginRenderContext context(&buffer, juce::AudioChannelSet::stereo(), 0, kBlockSize, &midi,
-                                    0.0, tracktion::TimeRange(), true, false, false, true);
-    plugin.applyToBuffer(context);
-    return buffer.getSample(0, kBlockSize - 1);
+void fillWithExistingSignal(juce::AudioBuffer<float>& buffer) {
+    for (int ch = 0; ch < buffer.getNumChannels(); ++ch)
+        for (int i = 0; i < buffer.getNumSamples(); ++i)
+            buffer.setSample(ch, i, kExistingSignal);
+}
+
+/// Renders `kNumBlocks` blocks with a note-on struck on the first block,
+/// returning every rendered sample per channel in order. When `preFillExisting`
+/// is set, each block starts from a buffer already carrying `kExistingSignal`,
+/// standing in for an audio clip ahead of the instrument on the same chain.
+struct RenderResult {
+    std::vector<float> left, right;
+};
+
+RenderResult renderNote(te::Plugin& plugin, bool preFillExisting) {
+    RenderResult result;
+
+    te::MidiMessageArray noteOnMidi;
+    noteOnMidi.addMidiMessage(juce::MidiMessage::noteOn(1, 60, static_cast<juce::uint8>(127)), 0.0,
+                              te::MidiMessageArray::notMPE);
+
+    for (int block = 0; block < kNumBlocks; ++block) {
+        juce::AudioBuffer<float> buffer(2, kBlockSize);
+        buffer.clear();
+        if (preFillExisting)
+            fillWithExistingSignal(buffer);
+
+        te::MidiMessageArray empty;
+        te::MidiMessageArray& midi = block == 0 ? noteOnMidi : empty;
+        te::PluginRenderContext context(&buffer, juce::AudioChannelSet::stereo(), 0, kBlockSize,
+                                        &midi, 0.0, tracktion::TimeRange(), true, false, false,
+                                        true);
+        plugin.applyToBuffer(context);
+
+        for (int i = 0; i < kBlockSize; ++i) {
+            result.left.push_back(buffer.getSample(0, i));
+            result.right.push_back(buffer.getSample(1, i));
+        }
+    }
+    return result;
+}
+
+float peakAbs(const std::vector<float>& samples) {
+    float peak = 0.0f;
+    for (float s : samples)
+        peak = std::max(peak, std::abs(s));
+    return peak;
 }
 
 class MutableAddNotReplaceTest final : public juce::UnitTest {
@@ -63,22 +116,93 @@ class MutableAddNotReplaceTest final : public juce::UnitTest {
         if (edit == nullptr)
             return;
 
-        beginTest("Materia (Elements) adds to, rather than replaces, the host buffer");
-        if (auto holder = createDevice<audio::MutableElementsPlugin>(*edit)) {
+        runDeviceTests<audio::MutableElementsPlugin>(*edit, "Materia (Elements)");
+        runDeviceTests<audio::MutableRingsPlugin>(*edit, "Rings");
+    }
+
+  private:
+    template <typename Device> void runDeviceTests(te::Edit& edit, const juce::String& name) {
+        {
+            beginTest(name + ": a silent block adds to (does not replace) the host buffer");
+            auto holder = createDevice<Device>(edit);
+            expect(holder != nullptr);
+            if (holder == nullptr)
+                return;
             prepareForRender(*holder);
-            expectWithinAbsoluteError(renderOverExistingSignal(*holder), 0.5f, 0.05f);
+
+            juce::AudioBuffer<float> buffer(2, kBlockSize);
+            fillWithExistingSignal(buffer);
+            te::MidiMessageArray midi;
+            te::PluginRenderContext context(&buffer, juce::AudioChannelSet::stereo(), 0, kBlockSize,
+                                            &midi, 0.0, tracktion::TimeRange(), true, false, false,
+                                            true);
+            holder->applyToBuffer(context);
+
+            for (int ch = 0; ch < 2; ++ch)
+                for (int i = 0; i < kBlockSize; ++i)
+                    expectWithinAbsoluteError(buffer.getSample(ch, i), kExistingSignal, 0.05f);
             holder->deleteFromParent();
-        } else {
-            expect(false, "Materia plugin should have been created");
         }
 
-        beginTest("Rings adds to, rather than replaces, the host buffer");
-        if (auto holder = createDevice<audio::MutableRingsPlugin>(*edit)) {
+        {
+            beginTest(name + ": a struck note is not dropped by the scratch buffer");
+            auto holder = createDevice<Device>(edit);
+            expect(holder != nullptr);
+            if (holder == nullptr)
+                return;
             prepareForRender(*holder);
-            expectWithinAbsoluteError(renderOverExistingSignal(*holder), 0.5f, 0.05f);
+
+            const auto dry = renderNote(*holder, false);
+            // Rings' main/aux outputs split partials by structure; one can sit
+            // at exact silence for a given patch, so this only checks that the
+            // device's contribution reaches the buffer at all, not per channel.
+            // Channel fidelity is what the next test checks, sample by sample.
+            expect(std::max(peakAbs(dry.left), peakAbs(dry.right)) > 0.01f,
+                   "A struck note should produce audible output on at least one channel");
             holder->deleteFromParent();
-        } else {
-            expect(false, "Rings plugin should have been created");
+        }
+
+        {
+            beginTest(name + ": a struck note adds onto, rather than replaces, an existing signal");
+            auto dryHolder = createDevice<Device>(edit);
+            auto wetHolder = createDevice<Device>(edit);
+            expect(dryHolder != nullptr && wetHolder != nullptr);
+            if (dryHolder == nullptr || wetHolder == nullptr)
+                return;
+            prepareForRender(*dryHolder);
+            prepareForRender(*wetHolder);
+
+            const auto dry = renderNote(*dryHolder, false);
+            const auto wet = renderNote(*wetHolder, true);
+
+            for (size_t i = 0; i < dry.left.size(); ++i) {
+                expectWithinAbsoluteError(wet.left[i], dry.left[i] + kExistingSignal, 0.01f);
+                expectWithinAbsoluteError(wet.right[i], dry.right[i] + kExistingSignal, 0.01f);
+            }
+            dryHolder->deleteFromParent();
+            wetHolder->deleteFromParent();
+        }
+
+        {
+            beginTest(name + ": gain scales the device's own signal, not the existing buffer");
+            auto holder = createDevice<Device>(edit);
+            expect(holder != nullptr);
+            if (holder == nullptr)
+                return;
+            prepareForRender(*holder);
+
+            auto* device = ta::deviceFromPlugin<Device>(holder.get());
+            expect(device != nullptr);
+            if (device == nullptr)
+                return;
+            setLevelDb(*holder, *device, -48.0f);  // gain ~= 0.004: device output near silent
+
+            const auto wet = renderNote(*holder, true);
+            for (size_t i = 0; i < wet.left.size(); ++i) {
+                expectWithinAbsoluteError(wet.left[i], kExistingSignal, 0.02f);
+                expectWithinAbsoluteError(wet.right[i], kExistingSignal, 0.02f);
+            }
+            holder->deleteFromParent();
         }
     }
 };


### PR DESCRIPTION
## Summary
- `MutableElementsPlugin` and `MutableRingsPlugin` wrote their output straight into the host buffer, replacing whatever an upstream device on the same TE chain had already put there. `FaustInstrumentPlugin` already rendered to a scratch buffer and added it in — Elements and Rings now do the same.
- Fixes #2370.

## Test plan
- [x] `make debug` builds clean (app, CLI, both test targets)
- [x] Added `tests/devices/test_mutable_add_not_replace_juce.cpp`: pre-fills the buffer with a DC signal (standing in for an upstream audio clip), renders a silent block, and checks the signal survives
- [x] Verified negatively: reverted just the fix, rebuilt, confirmed the new test fails (buffer read back as 0, the old replace behavior), then reapplied and confirmed green
- [x] `clang-format --dry-run` clean on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NJcMXn1jyk4tvFGh4wUAu8