### PR TITLE
Take the sampler's audio thread off the sound a load can free (#2378)

### DIFF
--- a/magda/daw/audio/plugins/MagdaSamplerPlugin.cpp
+++ b/magda/daw/audio/plugins/MagdaSamplerPlugin.cpp
@@ -475,6 +475,7 @@ MagdaSamplerPlugin::MagdaSamplerPlugin() {
     auto* sound = new SamplerSound();
     currentSound = sound;
     synthesiser.addSound(sound);
+    publishSoundFacts();
 
     for (int i = 0; i < numVoices; ++i)
         synthesiser.addVoice(new SamplerVoice());
@@ -549,10 +550,8 @@ void MagdaSamplerPlugin::updateVoiceParameters() {
     const float pitch = displayValue(kPitch);
     const float fine = displayValue(kFine);
 
-    const double sourceSR = (currentSound != nullptr) ? currentSound->sourceSampleRate : 44100.0;
-    const double lengthSeconds = (currentSound != nullptr && currentSound->hasData())
-                                     ? currentSound->audioData.getNumSamples() / sourceSR
-                                     : 0.0;
+    const double sourceSR = soundSourceRate_.load(std::memory_order_relaxed);
+    const double lengthSeconds = soundLengthSeconds_.load(std::memory_order_relaxed);
     const auto maxSec = static_cast<float>(lengthSeconds);
 
     const float sStart = juce::jlimit(0.0f, maxSec, displayValue(kSampleStart));
@@ -624,7 +623,7 @@ void MagdaSamplerPlugin::process(DeviceProcessContext& context) {
     context.audio->applyGain(context.startSample, context.numSamples, levelLinear);
 
     // Playhead position from the first sounding voice.
-    const double sourceSR = (currentSound != nullptr) ? currentSound->sourceSampleRate : 44100.0;
+    const double sourceSR = soundSourceRate_.load(std::memory_order_relaxed);
     bool foundActive = false;
     for (int i = 0; i < synthesiser.getNumVoices(); ++i) {
         if (auto* voice = dynamic_cast<SamplerVoice*>(synthesiser.getVoice(i))) {
@@ -746,6 +745,7 @@ void MagdaSamplerPlugin::loadSample(const juce::File& file) {
     synthesiser.clearSounds();
     synthesiser.addSound(newSound);
     currentSound = newSound;
+    publishSoundFacts();
 
     samplePath_ = file.getFullPathName();
     sampleFileSize_ = file.getSize();
@@ -763,11 +763,25 @@ void MagdaSamplerPlugin::loadSample(const juce::File& file) {
     setDisplayValue(kLoopEnd, juce::jmin(maxLen, slotInfo(kLoopEnd).maxValue));
 }
 
+void MagdaSamplerPlugin::publishSoundFacts() {
+    const auto rate = (currentSound != nullptr && currentSound->sourceSampleRate > 0.0)
+                          ? currentSound->sourceSampleRate
+                          : 44100.0;
+
+    const auto seconds = (currentSound != nullptr && currentSound->hasData())
+                             ? currentSound->audioData.getNumSamples() / rate
+                             : 0.0;
+
+    soundSourceRate_.store(rate, std::memory_order_relaxed);
+    soundLengthSeconds_.store(seconds, std::memory_order_relaxed);
+}
+
 void MagdaSamplerPlugin::unloadSample() {
     auto* empty = new SamplerSound();
     synthesiser.clearSounds();
     synthesiser.addSound(empty);
     currentSound = empty;
+    publishSoundFacts();
     samplePath_.clear();
     sampleFileSize_ = 0;
     sampleFileModifiedMs_ = 0;

--- a/magda/daw/audio/plugins/MagdaSamplerPlugin.cpp
+++ b/magda/daw/audio/plugins/MagdaSamplerPlugin.cpp
@@ -240,7 +240,8 @@ double SamplerVoice::pitchRatioForNote(int midiNoteNumber, const SamplerSound& s
     if (fractional != 0.0)  // fractional semitones -> exponential
         noteHz *= std::pow(2.0, fractional / 12.0);
 
-    double rootHz = juce::MidiMessage::getMidiNoteInHertz(sound.rootNote);
+    double rootHz =
+        juce::MidiMessage::getMidiNoteInHertz(sound.rootNote.load(std::memory_order_relaxed));
     return (noteHz / rootHz) * (sound.sourceSampleRate / getSampleRate());
 }
 
@@ -740,7 +741,7 @@ void MagdaSamplerPlugin::loadSample(const juce::File& file) {
     auto* newSound = new SamplerSound();
     newSound->audioData = std::move(newBuffer);
     newSound->sourceSampleRate = sourceSR;
-    newSound->rootNote = detectedRootNote;
+    newSound->rootNote.store(detectedRootNote, std::memory_order_relaxed);
 
     synthesiser.clearSounds();
     synthesiser.addSound(newSound);
@@ -855,10 +856,10 @@ int MagdaSamplerPlugin::getRootNote() const {
 
 void MagdaSamplerPlugin::setRootNote(int note) {
     rootNote_ = juce::jlimit(0, 127, note);
-    // rootNote is only read in startNote (not in renderNextBlock hot path),
-    // so a plain write is safe here.
+    // Published rather than assigned: startNote is the audio thread, so a note
+    // arriving during this write would otherwise race it.
     if (currentSound != nullptr)
-        currentSound->rootNote = rootNote_;
+        currentSound->rootNote.store(rootNote_, std::memory_order_relaxed);
 }
 
 }  // namespace magda::daw::audio

--- a/magda/daw/audio/plugins/MagdaSamplerPlugin.hpp
+++ b/magda/daw/audio/plugins/MagdaSamplerPlugin.hpp
@@ -18,7 +18,11 @@ namespace magda::daw::audio {
 struct SamplerSound : public juce::SynthesiserSound {
     juce::AudioBuffer<float> audioData;
     double sourceSampleRate = 44100.0;
-    int rootNote = 60;
+
+    /// Read on the audio thread, in SamplerVoice::startNote, and written by
+    /// setRootNote off it. Atomic because a note starting during that write is
+    /// otherwise a data race, whatever the hot path does (#2383 review).
+    std::atomic<int> rootNote{60};
 
     bool appliesToNote(int) override {
         return true;
@@ -301,9 +305,9 @@ class MagdaSamplerPlugin : public MagdaDevice {
     /// applyToBuffer (#2378).
     SamplerSound* currentSound = nullptr;
 
-    /// What the audio thread needs of the loaded sound, which is only these two
-    /// numbers. Published by the message thread once the synthesiser holds the
-    /// sound they describe.
+    /// What the audio thread needs of the loaded sound besides its root note,
+    /// which the sound carries atomically. Published by the message thread once
+    /// the synthesiser holds the sound they describe.
     ///
     /// Two words rather than one: they are read to clamp marker ranges and to
     /// scale a playhead, so a pair torn across a load costs one block's clamp

--- a/magda/daw/audio/plugins/MagdaSamplerPlugin.hpp
+++ b/magda/daw/audio/plugins/MagdaSamplerPlugin.hpp
@@ -280,6 +280,10 @@ class MagdaSamplerPlugin : public MagdaDevice {
   private:
     //==============================================================================
     void updateVoiceParameters();
+
+    /// Republish what the audio thread reads of the loaded sound. Message
+    /// thread, after the synthesiser holds it (#2378).
+    void publishSoundFacts();
     /// Put the synthesiser back to holding no audio. What an authored document
     /// with no source means (see restoreState).
     void unloadSample();
@@ -290,7 +294,22 @@ class MagdaSamplerPlugin : public MagdaDevice {
     bool holdsAudioFrom(const juce::String& path) const;
 
     SamplerSynth synthesiser;
-    SamplerSound* currentSound = nullptr;  // owned by synthesiser
+
+    /// Owned by the synthesiser, and only ever read on the message thread. The
+    /// audio thread reads @ref soundSourceRate_ and @ref soundLengthSeconds_
+    /// instead: a load frees this one while a block may still be inside
+    /// applyToBuffer (#2378).
+    SamplerSound* currentSound = nullptr;
+
+    /// What the audio thread needs of the loaded sound, which is only these two
+    /// numbers. Published by the message thread once the synthesiser holds the
+    /// sound they describe.
+    ///
+    /// Two words rather than one: they are read to clamp marker ranges and to
+    /// scale a playhead, so a pair torn across a load costs one block's clamp
+    /// and never a dereference.
+    std::atomic<double> soundSourceRate_{44100.0};
+    std::atomic<double> soundLengthSeconds_{0.0};
     double sampleRate = 44100.0;
     int numVoices = 8;
 


### PR DESCRIPTION
Closes #2378.

`updateVoiceParameters()` and the playhead both dereferenced `currentSound`, a raw `SamplerSound*` owned by the synthesiser, with no lock. `loadSample()` replaces it through `clearSounds()`, which destroys the old sound under the synthesiser's lock the audio thread never takes, so a load landing inside a block could have `applyToBuffer` reading a freed `AudioBuffer`. The constructor and `unloadSample()` install sounds the same way.

Every Drum Grid pad is one of these, so dropping a sample onto a pad while the kit plays is the ordinary way in rather than a race in an edge path.

## Not the snapshot the issue proposed

The issue suggested publishing the sound as an immutable reference-counted snapshot with a retire timer, following `FaustPlugin`. Reading the call sites, that is more machinery than the problem needs.

The audio thread only ever wanted two numbers off that pointer: `sourceSampleRate`, and `audioData.getNumSamples()`. It never reaches the buffer through it. The buffer the voices play is held by the synthesiser through JUCE's own reference counting, under its own lock, and that part was never in question.

So rather than making the object outlive its reader, this removes the dereference. `publishSoundFacts()` stores the source rate and the sample's length as atomics on the message thread, at all three sites that install a sound. There is no snapshot to retire, no reference count touched on the audio thread, and nothing new to keep in step.

`currentSound` stays exactly where it was for the message thread, which is where the buffer accessors and `setRootNote` already run.

## Two words, not one

They are read to clamp marker ranges and to scale a playhead. A pair torn across a load costs one block's clamp computed against a mismatched length, and never a dereference. Packing them into a single word the way `LaunchTap` does would buy nothing that matters here.

## No test, and why

`[sampler]` matches nothing, so there is no suite to extend, and the defect is a race whose window is a few instructions between `clearSounds()` and the next block. A test that provoked it would have to hammer `loadSample()` against a running `applyToBuffer` and would still be probabilistic, so a green run would say very little.

What is checkable instead is the property: no `currentSound` dereference remains on the audio thread. `grep currentSound MagdaSamplerPlugin.cpp` now shows only the three assignments, `publishSoundFacts()`, and the message-thread accessors.

## Note on overlap

`fix/2379-sampler-model-writes` is in flight and touches `MagdaSamplerPlugin.{cpp,hpp}` as well. This change is confined to the two audio-thread reads, the three install sites and two new members, so it should rebase cleanly, but whichever lands second is worth a look.

https://claude.ai/code/session_013CDpSHas8bog33vv4o6HLv
