### PR TITLE
Clock Nimbus's DSP at 32 kHz and declare its priming latency

### DIFF
--- a/magda/daw/audio/plugins/mutable/MutableCloudsPlugin.cpp
+++ b/magda/daw/audio/plugins/mutable/MutableCloudsPlugin.cpp
@@ -1,9 +1,11 @@
 #include "plugins/mutable/MutableCloudsPlugin.hpp"
 
+#include <algorithm>
 #include <array>
 #include <cmath>
 #include <cstdint>
 #include <cstring>
+#include <iterator>
 
 // Upstream Mutable Instruments DSP (third_party/eurorack, magda::mutable),
 // compiled with -DTEST. Walled behind the pimpl so this is the only TU in the
@@ -27,6 +29,80 @@ inline float cubic(float x0, float x1, float x2, float x3, float t) {
     const float c = -0.5f * x0 + 0.5f * x2;
     return ((a * t + b) * t + c) * t + x1;
 }
+
+// One biquad section, transposed direct form II.
+struct Biquad {
+    float b0 = 1.0f, b1 = 0.0f, b2 = 0.0f, a1 = 0.0f, a2 = 0.0f;
+    float z1 = 0.0f, z2 = 0.0f;
+
+    void clear() {
+        z1 = z2 = 0.0f;
+    }
+    void setLowpass(double fc, double fs, double q) {
+        const double w0 = 2.0 * juce::MathConstants<double>::pi * fc / fs;
+        const double cw = std::cos(w0);
+        const double alpha = std::sin(w0) / (2.0 * q);
+        const double a0 = 1.0 + alpha;
+        b0 = static_cast<float>((1.0 - cw) * 0.5 / a0);
+        b1 = static_cast<float>((1.0 - cw) / a0);
+        b2 = b0;
+        a1 = static_cast<float>(-2.0 * cw / a0);
+        a2 = static_cast<float>((1.0 - alpha) / a0);
+    }
+    float process(float x) {
+        const float y = b0 * x + z1;
+        z1 = b1 * x - a1 * y + z2;
+        z2 = b2 * x - a2 * y;
+        return y;
+    }
+};
+
+// Pole Qs of an 8th-order Butterworth, 1/(2 cos(pi (2k+1)/16)).
+constexpr double kButterworthQ[4] = {0.50979558, 0.60134489, 0.89997622, 2.56291545};
+constexpr double kBandLimitHz = MutableCloudsPlugin::kBandLimitHz;
+
+// A section's DC group delay is 1/(Q w0), so the filter's is sum(1/Q)/w0. The
+// header declares the latency from it and cannot see this table, so tie them.
+constexpr double kQSum = 1.0 / kButterworthQ[0] + 1.0 / kButterworthQ[1] + 1.0 / kButterworthQ[2] +
+                         1.0 / kButterworthQ[3];
+static_assert(kQSum > MutableCloudsPlugin::kBandLimitQSum - 1e-6 &&
+                  kQSum < MutableCloudsPlugin::kBandLimitQSum + 1e-6,
+              "the declared latency is derived from these pole Qs");
+static_assert(kBlock == 32, "kLatencySeconds counts a 32-sample grain block");
+
+// The 32 kHz DSP is band-limited to 16 kHz and the cubic interpolators do not
+// enforce it: unfiltered, a 20 kHz tone folds to 12 kHz louder than it left,
+// and a 10 kHz tone's image sits 17 dB down coming back up. One lowpass per
+// crossing, both at host rate, both idle at 32 kHz where neither leg resamples.
+struct BandLimit {
+    Biquad l[4], r[4];
+    bool active = false;
+
+    void prepare(double hostRate) {
+        active = hostRate > static_cast<double>(kInternalRate) + 1.0;
+        if (!active)
+            return;
+        for (int i = 0; i < 4; ++i) {
+            l[i].setLowpass(kBandLimitHz, hostRate, kButterworthQ[i]);
+            r[i].setLowpass(kBandLimitHz, hostRate, kButterworthQ[i]);
+        }
+        clear();
+    }
+    void clear() {
+        for (int i = 0; i < 4; ++i) {
+            l[i].clear();
+            r[i].clear();
+        }
+    }
+    void process(float& L, float& R) {
+        if (!active)
+            return;
+        for (int i = 0; i < 4; ++i) {
+            L = l[i].process(L);
+            R = r[i].process(R);
+        }
+    }
+};
 
 inline short floatToShort(float x) {
     return static_cast<short>(juce::jlimit(-32768, 32767, juce::roundToInt(x * 32767.0f)));
@@ -80,7 +156,10 @@ struct Resampler {
         pos = 1.0;
     }
     bool pull(StereoRing& ring, float& oL, float& oR) {
-        if (ring.count < 4)
+        // The 4-point window plus whatever this call pops: step can exceed 1,
+        // and popping past count leaves it negative, which puts the next push
+        // behind head (#2365 review).
+        if (ring.count < 3 + static_cast<int>(std::ceil(step)))
             return false;
         const auto t = static_cast<float>(pos - 1.0);
         oL = cubic(ring.L(0), ring.L(1), ring.L(2), ring.L(3), t);
@@ -184,6 +263,8 @@ struct MutableCloudsPlugin::Impl {
         // the output one reads 32 kHz.
         inResampler_.step = hostRate / kInternalRate;   // host -> 32k (downsample)
         outResampler_.step = kInternalRate / hostRate;  // 32k -> host (upsample)
+        inLimit_.prepare(hostRate);
+        outLimit_.prepare(hostRate);
         reset();
     }
 
@@ -192,6 +273,8 @@ struct MutableCloudsPlugin::Impl {
         wet32k_.clear();
         inResampler_.reset();
         outResampler_.reset();
+        inLimit_.clear();
+        outLimit_.clear();
         grainFill_ = 0;
     }
 
@@ -202,33 +285,48 @@ struct MutableCloudsPlugin::Impl {
         processor_.set_playback_mode(static_cast<clouds::PlaybackMode>(mode));
     }
 
-    // Push one host input frame, drain whatever full grain blocks it enables,
-    // and pull host output frames back out. Output lags input by the resampler
-    // + grain-block latency; the rings carry the cushion.
+    // Push host input, drain whatever full grain blocks it enables, and pull
+    // host output back out. Output lags input by the resampler + grain-block
+    // latency; the rings carry the cushion.
+    //
+    // In chunks, because pushing a whole call before draining any of it makes
+    // StereoRing::kCap a limit on the host's buffer size: at 8192 the ring
+    // overruns and drops input continuously (#2365 review). A chunk bounds
+    // occupancy at roughly kChunk * max(1, 32000/hostRate) whatever the host
+    // hands over, so prepare() does not have to be told the block size.
     void process(float* L, float* R, int n) {
-        for (int i = 0; i < n; ++i)
-            hostIn_.push(L[i], R != nullptr ? R[i] : L[i]);
+        constexpr int kChunk = 256;
 
-        float sL, sR;
-        while (inResampler_.pull(hostIn_, sL, sR)) {
-            grainIn_[grainFill_].l = sL;
-            grainIn_[grainFill_].r = sR;
-            if (++grainFill_ == kBlock) {
-                runBlock();
-                grainFill_ = 0;
+        for (int base = 0; base < n; base += kChunk) {
+            const int m = std::min(kChunk, n - base);
+
+            for (int i = 0; i < m; ++i) {
+                float inL = L[base + i];
+                float inR = R != nullptr ? R[base + i] : inL;
+                inLimit_.process(inL, inR);
+                hostIn_.push(inL, inR);
             }
-        }
 
-        for (int i = 0; i < n; ++i) {
-            float oL, oR;
-            if (outResampler_.pull(wet32k_, oL, oR)) {
-                L[i] = oL;
+            float sL, sR;
+            while (inResampler_.pull(hostIn_, sL, sR)) {
+                grainIn_[grainFill_].l = sL;
+                grainIn_[grainFill_].r = sR;
+                if (++grainFill_ == kBlock) {
+                    runBlock();
+                    grainFill_ = 0;
+                }
+            }
+
+            for (int i = 0; i < m; ++i) {
+                // Zero unless the ring has a window yet: priming latency only.
+                // The filter still sees those samples, so its state stays
+                // continuous across the transition into real output.
+                float oL = 0.0f, oR = 0.0f;
+                outResampler_.pull(wet32k_, oL, oR);
+                outLimit_.process(oL, oR);
+                L[base + i] = oL;
                 if (R != nullptr)
-                    R[i] = oR;
-            } else {
-                L[i] = 0.0f;  // priming latency only
-                if (R != nullptr)
-                    R[i] = 0.0f;
+                    R[base + i] = oR;
             }
         }
     }
@@ -255,6 +353,8 @@ struct MutableCloudsPlugin::Impl {
     StereoRing wet32k_;  // 32 kHz processed output awaiting upsample
     Resampler inResampler_;
     Resampler outResampler_;
+    BandLimit inLimit_;   // before the decimation, against aliasing
+    BandLimit outLimit_;  // after the interpolation, against imaging
 
     clouds::FloatFrame grainIn_[kBlock];
     int grainFill_ = 0;
@@ -284,10 +384,47 @@ float MutableCloudsPlugin::parameterValue(int index) const {
     return values_[static_cast<size_t>(index)];
 }
 
+double MutableCloudsPlugin::tailSecondsFor(float reverb, float feedback, bool freeze) {
+    // Upstream's own reverb_amount (granular_processor.cc): feedback only joins
+    // it once frozen, and reverb alone tops out at 0.95.
+    const float amount =
+        juce::jlimit(0.0f, 1.0f, reverb * 0.95f + (freeze ? feedback * (2.0f - feedback) : 0.0f));
+
+    // Measured 90%-decay against reverb, +25% headroom (see the test). A curve
+    // rather than a formula: the decay is not a single exponential, so a fitted
+    // one is either wrong in the middle or absurd at the top.
+    constexpr float kAmount[] = {0.0f,   0.095f,  0.2375f, 0.38f, 0.5225f,
+                                 0.665f, 0.8075f, 0.95f,   1.0f};
+    constexpr double kSeconds[] = {0.1, 1.3, 2.3, 3.2, 4.2, 6.2, 10.7, 20.0, 20.0};
+    constexpr int kPoints = static_cast<int>(std::size(kAmount));
+
+    double seconds = kSeconds[kPoints - 1];
+    for (int i = 1; i < kPoints; ++i) {
+        if (amount <= kAmount[i]) {
+            const double t = (amount - kAmount[i - 1]) / (kAmount[i] - kAmount[i - 1]);
+            seconds = kSeconds[i - 1] + t * (kSeconds[i] - kSeconds[i - 1]);
+            break;
+        }
+    }
+
+    // Unfrozen feedback recirculates on its own: below 0.7 it dies with the
+    // grain, from 0.85 it never does. Declare the ceiling rather than a decay
+    // the device is not performing.
+    if (feedback >= 0.8f)
+        seconds = kMaxTailSeconds;
+
+    return juce::jlimit(0.25, kMaxTailSeconds, seconds);
+}
+
 void MutableCloudsPlugin::setParameterValue(int index, float value) {
     if (index < 0 || index >= kNumParams)
         return;
     values_[static_cast<size_t>(index)] = juce::jlimit(0.0f, 1.0f, value);
+
+    if (index == kReverb || index == kFeedback || index == kFreeze)
+        tailSeconds_.store(tailSecondsFor(displayValue(kReverb), displayValue(kFeedback),
+                                          displayValue(kFreeze) > 0.5f),
+                           std::memory_order_relaxed);
 }
 
 float MutableCloudsPlugin::displayValue(int index) const {

--- a/magda/daw/audio/plugins/mutable/MutableCloudsPlugin.cpp
+++ b/magda/daw/audio/plugins/mutable/MutableCloudsPlugin.cpp
@@ -50,9 +50,9 @@ struct Biquad {
         a2 = static_cast<float>((1.0 - alpha) / a0);
     }
     float process(float x) {
-        const float y = b0 * x + z1;
-        z1 = b1 * x - a1 * y + z2;
-        z2 = b2 * x - a2 * y;
+        const float y = (b0 * x) + z1;
+        z1 = (b1 * x) - (a1 * y) + z2;
+        z2 = (b2 * x) - (a2 * y);
         return y;
     }
 };
@@ -63,8 +63,8 @@ constexpr double kBandLimitHz = MutableCloudsPlugin::kBandLimitHz;
 
 // A section's DC group delay is 1/(Q w0), so the filter's is sum(1/Q)/w0. The
 // header declares the latency from it and cannot see this table, so tie them.
-constexpr double kQSum = 1.0 / kButterworthQ[0] + 1.0 / kButterworthQ[1] + 1.0 / kButterworthQ[2] +
-                         1.0 / kButterworthQ[3];
+constexpr double kQSum = (1.0 / kButterworthQ[0]) + (1.0 / kButterworthQ[1]) +
+                         (1.0 / kButterworthQ[2]) + (1.0 / kButterworthQ[3]);
 static_assert(kQSum > MutableCloudsPlugin::kBandLimitQSum - 1e-6 &&
                   kQSum < MutableCloudsPlugin::kBandLimitQSum + 1e-6,
               "the declared latency is derived from these pole Qs");
@@ -73,15 +73,14 @@ static_assert(kBlock == 32, "kLatencySeconds counts a 32-sample grain block");
 // The 32 kHz DSP is band-limited to 16 kHz and the cubic interpolators do not
 // enforce it: unfiltered, a 20 kHz tone folds to 12 kHz louder than it left,
 // and a 10 kHz tone's image sits 17 dB down coming back up. One lowpass per
-// crossing, both at host rate, both idle at 32 kHz where neither leg resamples.
+// crossing, both at host rate.
 struct BandLimit {
     Biquad l[4], r[4];
-    bool active = false;
 
     void prepare(double hostRate) {
-        active = hostRate > static_cast<double>(kInternalRate) + 1.0;
-        if (!active)
-            return;
+        // At every rate, 32 kHz included. Bypassing where nothing resamples
+        // would save a filter nobody hears and put the declared latency 3
+        // samples out at that rate (#2365 review).
         for (int i = 0; i < 4; ++i) {
             l[i].setLowpass(kBandLimitHz, hostRate, kButterworthQ[i]);
             r[i].setLowpass(kBandLimitHz, hostRate, kButterworthQ[i]);
@@ -95,8 +94,6 @@ struct BandLimit {
         }
     }
     void process(float& L, float& R) {
-        if (!active)
-            return;
         for (int i = 0; i < 4; ++i) {
             L = l[i].process(L);
             R = r[i].process(R);
@@ -182,17 +179,17 @@ struct Desc {
 };
 
 const std::array<Desc, MutableCloudsPlugin::kNumParams> kDescs = {{
-    {"position", "Position", 0.5f, Kind::Normalised},
-    {"size", "Size", 0.5f, Kind::Normalised},
-    {"pitch", "Pitch", 0.0f, Kind::Pitch},
-    {"density", "Density", 0.4f, Kind::Normalised},
-    {"texture", "Texture", 0.5f, Kind::Normalised},
-    {"dryWet", "Dry/Wet", 0.5f, Kind::Normalised},
-    {"spread", "Spread", 0.5f, Kind::Normalised},
-    {"feedback", "Feedback", 0.0f, Kind::Normalised},
-    {"reverb", "Reverb", 0.0f, Kind::Normalised},
-    {"mode", "Mode", 0.0f, Kind::Mode},
-    {"freeze", "Freeze", 0.0f, Kind::Freeze},
+    {.id = "position", .name = "Position", .def = 0.5f, .kind = Kind::Normalised},
+    {.id = "size", .name = "Size", .def = 0.5f, .kind = Kind::Normalised},
+    {.id = "pitch", .name = "Pitch", .def = 0.0f, .kind = Kind::Pitch},
+    {.id = "density", .name = "Density", .def = 0.4f, .kind = Kind::Normalised},
+    {.id = "texture", .name = "Texture", .def = 0.5f, .kind = Kind::Normalised},
+    {.id = "dryWet", .name = "Dry/Wet", .def = 0.5f, .kind = Kind::Normalised},
+    {.id = "spread", .name = "Spread", .def = 0.5f, .kind = Kind::Normalised},
+    {.id = "feedback", .name = "Feedback", .def = 0.0f, .kind = Kind::Normalised},
+    {.id = "reverb", .name = "Reverb", .def = 0.0f, .kind = Kind::Normalised},
+    {.id = "mode", .name = "Mode", .def = 0.0f, .kind = Kind::Mode},
+    {.id = "freeze", .name = "Freeze", .def = 0.0f, .kind = Kind::Freeze},
 }};
 
 /// One slot's metadata, from the descriptor table. The ids, order and display
@@ -384,18 +381,21 @@ float MutableCloudsPlugin::parameterValue(int index) const {
     return values_[static_cast<size_t>(index)];
 }
 
-double MutableCloudsPlugin::tailSecondsFor(float reverb, float feedback, bool freeze) {
+double MutableCloudsPlugin::tailSecondsFor(float reverb, float feedback, bool freeze,
+                                           float position, int mode) {
     // Upstream's own reverb_amount (granular_processor.cc): feedback only joins
     // it once frozen, and reverb alone tops out at 0.95.
     const float amount =
-        juce::jlimit(0.0f, 1.0f, reverb * 0.95f + (freeze ? feedback * (2.0f - feedback) : 0.0f));
+        juce::jlimit(0.0f, 1.0f, (reverb * 0.95f) + (freeze ? feedback * (2.0f - feedback) : 0.0f));
 
-    // Measured 90%-decay against reverb, +25% headroom (see the test). A curve
-    // rather than a formula: the decay is not a single exponential, so a fitted
-    // one is either wrong in the middle or absurd at the top.
+    // Measured decay to -60 dBFS against reverb, +20% headroom, in granular at
+    // grain size 1: that is the longest of the four modes by about 60%, and the
+    // curve has to cover the worst. A table rather than a formula, because the
+    // decay is not a single exponential and a fit is either wrong in the middle
+    // or absurd at the top.
     constexpr float kAmount[] = {0.0f,   0.095f,  0.2375f, 0.38f, 0.5225f,
                                  0.665f, 0.8075f, 0.95f,   1.0f};
-    constexpr double kSeconds[] = {0.1, 1.3, 2.3, 3.2, 4.2, 6.2, 10.7, 20.0, 20.0};
+    constexpr double kSeconds[] = {0.7, 2.8, 3.8, 5.4, 7.3, 10.1, 16.4, 39.0, 40.0};
     constexpr int kPoints = static_cast<int>(std::size(kAmount));
 
     double seconds = kSeconds[kPoints - 1];
@@ -406,6 +406,19 @@ double MutableCloudsPlugin::tailSecondsFor(float reverb, float feedback, bool fr
             break;
         }
     }
+
+    // Every mode replays the buffer from `position`, so a delayed copy outlives
+    // the input on top of the decay above: 0.51 s at position 0, which the
+    // curve's first point already carries, rising to 1.10 s at position 1. Rate
+    // independent, longest at grain size 1.
+    seconds += 0.8 * position;
+
+    // Spectral resynthesis is not deterministic: three identical renders at
+    // reverb 0.75 gave 0 s, 0 s and 20.7 s, where the curve above says 11.9.
+    // Nothing measurable to fit, so double it and let the ceiling catch the
+    // rest.
+    if (mode == 3)
+        seconds *= 2.0;
 
     // Unfrozen feedback recirculates on its own: below 0.7 it dies with the
     // grain, from 0.85 it never does. Declare the ceiling rather than a decay
@@ -421,9 +434,11 @@ void MutableCloudsPlugin::setParameterValue(int index, float value) {
         return;
     values_[static_cast<size_t>(index)] = juce::jlimit(0.0f, 1.0f, value);
 
-    if (index == kReverb || index == kFeedback || index == kFreeze)
+    if (index == kReverb || index == kFeedback || index == kFreeze || index == kPosition ||
+        index == kMode)
         tailSeconds_.store(tailSecondsFor(displayValue(kReverb), displayValue(kFeedback),
-                                          displayValue(kFreeze) > 0.5f),
+                                          displayValue(kFreeze) > 0.5f, displayValue(kPosition),
+                                          juce::roundToInt(displayValue(kMode))),
                            std::memory_order_relaxed);
 }
 

--- a/magda/daw/audio/plugins/mutable/MutableCloudsPlugin.cpp
+++ b/magda/daw/audio/plugins/mutable/MutableCloudsPlugin.cpp
@@ -61,6 +61,9 @@ struct Biquad {
 constexpr double kButterworthQ[4] = {0.50979558, 0.60134489, 0.89997622, 2.56291545};
 constexpr double kBandLimitHz = MutableCloudsPlugin::kBandLimitHz;
 
+// Feedback at or above this never decays, so no finite tail describes it.
+constexpr float kFeedbackSustains = 0.75f;
+
 // A section's DC group delay is 1/(Q w0), so the filter's is sum(1/Q)/w0. The
 // header declares the latency from it and cannot see this table, so tie them.
 constexpr double kQSum = (1.0 / kButterworthQ[0]) + (1.0 / kButterworthQ[1]) +
@@ -78,12 +81,15 @@ struct BandLimit {
     Biquad l[4], r[4];
 
     void prepare(double hostRate) {
-        // At every rate, 32 kHz included. Bypassing where nothing resamples
-        // would save a filter nobody hears and put the declared latency 3
-        // samples out at that rate (#2365 review).
+        // At every rate, 32 kHz included: bypassing where nothing resamples
+        // puts the declared latency 3 samples out at that rate. Below Nyquist
+        // at every rate too. OfflineMixAnalysis renders at 22.05 kHz with
+        // plugins in, and a 15 kHz corner there is an unstable biquad: it took
+        // the output to 1e37 and then to NaN (#2365 review).
+        const double corner = std::min(kBandLimitHz, 0.45 * hostRate);
         for (int i = 0; i < 4; ++i) {
-            l[i].setLowpass(kBandLimitHz, hostRate, kButterworthQ[i]);
-            r[i].setLowpass(kBandLimitHz, hostRate, kButterworthQ[i]);
+            l[i].setLowpass(corner, hostRate, kButterworthQ[i]);
+            r[i].setLowpass(corner, hostRate, kButterworthQ[i]);
         }
         clear();
     }
@@ -420,10 +426,19 @@ double MutableCloudsPlugin::tailSecondsFor(float reverb, float feedback, bool fr
     if (mode == 3)
         seconds *= 2.0;
 
-    // Unfrozen feedback recirculates on its own: below 0.7 it dies with the
-    // grain, from 0.85 it never does. Declare the ceiling rather than a decay
-    // the device is not performing.
-    if (feedback >= 0.8f)
+    // Unfrozen feedback is a delay line: the buffer repeats every `position`
+    // seconds at that gain, so the tail is however many repeats reach -60 dB.
+    // Analytic rather than measured, which over-declares by up to 2x at low
+    // feedback and covers it at high (#2365 review).
+    if (feedback > 0.01f && feedback < kFeedbackSustains) {
+        const double delaySeconds = 0.1 + 1.02 * position;
+        seconds = std::max(seconds, delaySeconds * 3.0 / -std::log10(feedback));
+    }
+
+    // Past that it stops decaying at all: 0.7 with a full delay runs 17 s, 0.79
+    // was still above -60 dBFS after 45. Declare the ceiling rather than a
+    // decay the device is not performing.
+    if (feedback >= kFeedbackSustains)
         seconds = kMaxTailSeconds;
 
     return juce::jlimit(0.25, kMaxTailSeconds, seconds);

--- a/magda/daw/audio/plugins/mutable/MutableCloudsPlugin.cpp
+++ b/magda/daw/audio/plugins/mutable/MutableCloudsPlugin.cpp
@@ -179,8 +179,11 @@ struct MutableCloudsPlugin::Impl {
     }
 
     void prepare(double hostRate) {
-        inResampler_.step = kInternalRate / hostRate;   // host -> 32k (downsample)
-        outResampler_.step = hostRate / kInternalRate;  // 32k -> host (upsample)
+        // step = Fin/Fout, the rate the ring is read at over the rate it is
+        // pulled at (see Resampler). The input resampler reads host-rate data,
+        // the output one reads 32 kHz.
+        inResampler_.step = hostRate / kInternalRate;   // host -> 32k (downsample)
+        outResampler_.step = kInternalRate / hostRate;  // 32k -> host (upsample)
         reset();
     }
 

--- a/magda/daw/audio/plugins/mutable/MutableCloudsPlugin.cpp
+++ b/magda/daw/audio/plugins/mutable/MutableCloudsPlugin.cpp
@@ -18,7 +18,13 @@ namespace magda::daw::audio {
 namespace {
 
 constexpr int kBlock = static_cast<int>(clouds::kMaxBlockSize);  // 32
-const float kInternalRate = 32000.0f;                            // Clouds native rate
+
+// Silence placed in the output ring at reset. A grain block arrives 32 samples
+// at a time while the output is drawn continuously, so the ring swings by a
+// block; the window on top of that is what the interpolator reads. See
+// Impl::reset.
+constexpr int kWetPrimeFrames = kBlock + 4;
+const float kInternalRate = 32000.0f;  // Clouds native rate
 
 const char* const kModeNames[] = {"Granular", "Stretch", "Looping Delay", "Spectral"};
 constexpr int kNumModes = 4;
@@ -272,6 +278,18 @@ struct MutableCloudsPlugin::Impl {
         inLimit_.clear();
         outLimit_.clear();
         grainFill_ = 0;
+
+        // Start the output ring with a grain block of silence in it. Without
+        // that cushion, whether a pull finds data depends on where the host's
+        // callback boundaries fall, and a starved pull emits a zero WITHOUT
+        // advancing the resampler, so each one adds a sample of delay for
+        // good. Two hosts with different buffer sizes then produce different
+        // audio permanently, not just a different transient: at 48 kHz a
+        // 1-sample callback diverged from a 128-sample one across the whole
+        // render (#2365 review). Placed here, the delay is designed rather
+        // than discovered, and after startup a starved pull cannot happen.
+        for (int i = 0; i < kWetPrimeFrames; ++i)
+            wet32k_.push(0.0f, 0.0f);
     }
 
     clouds::Parameters* parameters() {
@@ -412,12 +430,13 @@ double MutableCloudsPlugin::tailSecondsFor(float reverb, float feedback, bool fr
     // independent, longest at grain size 1.
     seconds += 0.8 * position;
 
-    // Spectral resynthesis is not deterministic: three identical renders at
-    // reverb 0.75 gave 0 s, 0 s and 20.7 s, where the curve above says 11.9.
-    // Nothing measurable to fit, so double it and let the ceiling catch the
-    // rest.
+    // Spectral resynthesis is not deterministic: identical renders at reverb
+    // 0.75 have come back 0 s, 0 s, 20.7 s and 37.7 s, where the curve above
+    // says 12.2. Nothing measurable to fit, so take enough headroom that any
+    // engaged reverb reaches the ceiling, which is the only honest bound on a
+    // mode that can ring for most of a minute.
     if (mode == 3)
-        seconds *= 2.0;
+        seconds *= 4.0;
 
     // Unfrozen feedback is a delay line: the buffer repeats every `position`
     // seconds at that gain, so the tail is however many repeats reach -60 dB.

--- a/magda/daw/audio/plugins/mutable/MutableCloudsPlugin.cpp
+++ b/magda/daw/audio/plugins/mutable/MutableCloudsPlugin.cpp
@@ -64,14 +64,7 @@ constexpr double kBandLimitHz = MutableCloudsPlugin::kBandLimitHz;
 // Feedback at or above this never decays, so no finite tail describes it.
 constexpr float kFeedbackSustains = 0.75f;
 
-// A section's DC group delay is 1/(Q w0), so the filter's is sum(1/Q)/w0. The
-// header declares the latency from it and cannot see this table, so tie them.
-constexpr double kQSum = (1.0 / kButterworthQ[0]) + (1.0 / kButterworthQ[1]) +
-                         (1.0 / kButterworthQ[2]) + (1.0 / kButterworthQ[3]);
-static_assert(kQSum > MutableCloudsPlugin::kBandLimitQSum - 1e-6 &&
-                  kQSum < MutableCloudsPlugin::kBandLimitQSum + 1e-6,
-              "the declared latency is derived from these pole Qs");
-static_assert(kBlock == 32, "kLatencySeconds counts a 32-sample grain block");
+static_assert(kBlock == 32, "the measured latency assumes a 32-sample grain block");
 
 // The 32 kHz DSP is band-limited to 16 kHz and the cubic interpolators do not
 // enforce it: unfiltered, a 20 kHz tone folds to 12 kHz louder than it left,

--- a/magda/daw/audio/plugins/mutable/MutableCloudsPlugin.hpp
+++ b/magda/daw/audio/plugins/mutable/MutableCloudsPlugin.hpp
@@ -55,27 +55,35 @@ class MutableCloudsPlugin : public MagdaDevice {
     }
     static const char* xmlTypeName;
 
-    /// The lowpass either side of the 32 kHz DSP, and its DC group delay,
-    /// sum(1/Q)/w0 over an 8th-order Butterworth. The .cpp asserts its filter
-    /// table against both.
+    /// The lowpass either side of the 32 kHz DSP. Its corner drops to stay
+    /// under Nyquist at low rates, so the .cpp designs it per rate.
     static constexpr double kBandLimitHz = 15000.0;
-    static constexpr double kBandLimitQSum = 5.12583089;
-    static constexpr double kBandLimitDelaySeconds =
-        kBandLimitQSum / (2.0 * juce::MathConstants<double>::pi * kBandLimitHz);
 
-    /// The 32-sample grain block and a sample of resampler delay at 32 kHz, plus
-    /// both filters, which run at every rate so this holds at every rate. In
-    /// seconds because properties() is a construction-time snapshot; the dry
-    /// path carries it too, since Clouds mixes dry itself.
-    static constexpr double kLatencySeconds = 33.0 / 32000.0 + 2.0 * kBandLimitDelaySeconds;
+    /// Output lag: the grain block, the resampler priming and both filters.
+    ///
+    /// Measured, not derived. The obvious derivation is wrong: the filters'
+    /// group delay is not the analog prototype's sum(1/Q)/w0, because the
+    /// bilinear transform collapses it as the corner nears Nyquist, from 53 us
+    /// at 192 kHz to 13 us at 32 kHz. It is not one number either, varying 36
+    /// to 88 us across the band at 48 kHz, so no single figure cancels an IIR
+    /// at every frequency.
+    ///
+    /// In seconds because properties() is a construction-time snapshot, taken
+    /// before the host rate is known; the dry path carries it too, since Clouds
+    /// mixes dry itself.
+    static constexpr double kLatencySeconds = 1120.8e-6;
 
-    /// The input guard holds 3 + ceil(step) samples, a fixed count and so a
-    /// shrinking duration as the rate climbs, 125 us at 32 kHz against 47 us at
-    /// 192 kHz. That spread lands in a delay declared in seconds, so the real
-    /// figure sits within this of the constant from 22.05 kHz to 192 kHz rather
-    /// than on it. A bound, not an exactness: closing it needs a compensating
-    /// output delay sized from a probe at prepare().
-    static constexpr double kLatencyToleranceSeconds = 90.0e-6;
+    /// The real delay spans 1062 to 1179 us from 32 kHz to 192 kHz, so this is
+    /// the tightest a single constant can be: a bound, not an exactness.
+    /// Closing it needs a rate-aware declaration or a compensating output delay
+    /// sized at prepare(), neither of which fits in the device's current
+    /// construction-time properties() contract.
+    static constexpr double kLatencyToleranceSeconds = 60.0e-6;
+
+    /// OfflineMixAnalysis renders here, where the delay is 104 us past the
+    /// constant. Analysis is a measurement pass with nothing to align against,
+    /// so it sits outside the compensation contract above.
+    static constexpr double kAnalysisRate = 22050.0;
 
     /// Past this the device sustains rather than decays: feedback from 0.85
     /// recirculates indefinitely. Granular at full reverb rings for 32 s, so

--- a/magda/daw/audio/plugins/mutable/MutableCloudsPlugin.hpp
+++ b/magda/daw/audio/plugins/mutable/MutableCloudsPlugin.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <array>
+#include <atomic>
 #include <memory>
 
 #include "audio/analysis/AudioTapBuffer.hpp"
@@ -54,11 +55,23 @@ class MutableCloudsPlugin : public MagdaDevice {
     }
     static const char* xmlTypeName;
 
-    /// Output lag through the resampler pair and the 32-sample grain block: the
-    /// block plus a sample of resampler group delay, at the DSP's own 32 kHz.
-    /// In seconds because properties() is read once, before the host rate is
-    /// known; the dry path carries it too, since Clouds mixes dry in itself.
-    static constexpr double kLatencySeconds = 33.0 / 32000.0;
+    /// The lowpass either side of the 32 kHz DSP, and its DC group delay,
+    /// sum(1/Q)/w0 over an 8th-order Butterworth. The .cpp asserts its filter
+    /// table against both.
+    static constexpr double kBandLimitHz = 15000.0;
+    static constexpr double kBandLimitQSum = 5.12583089;
+    static constexpr double kBandLimitDelaySeconds =
+        kBandLimitQSum / (2.0 * juce::MathConstants<double>::pi * kBandLimitHz);
+
+    /// The 32-sample grain block and a sample of resampler delay at 32 kHz, plus
+    /// both filters. In seconds because properties() is a construction-time
+    /// snapshot; the dry path carries it too, since Clouds mixes dry itself. A
+    /// 32 kHz host bypasses the filters and lands ~3 samples early against it.
+    static constexpr double kLatencySeconds = 33.0 / 32000.0 + 2.0 * kBandLimitDelaySeconds;
+
+    /// Past this the device is sustaining rather than decaying: feedback from
+    /// 0.85 recirculates indefinitely, which no finite tail covers.
+    static constexpr double kMaxTailSeconds = 20.0;
 
     //==============================================================================
     DeviceProperties properties() const override {
@@ -67,9 +80,14 @@ class MutableCloudsPlugin : public MagdaDevice {
             .name = getPluginName(),
             .shortName = "Nimbus",
             .latencySeconds = kLatencySeconds,
-            .tailLengthSeconds = 2.0,  // diffuser/reverb + grain tail
+            // Off the reverb, not a constant: the decay runs 60 ms to past 18 s
+            // across that parameter, and getTailLength() is read per render.
+            .tailLengthSeconds = tailSeconds_.load(std::memory_order_relaxed),
         };
     }
+
+    /// @brief The tail those three parameters imply, in seconds.
+    static double tailSecondsFor(float reverb, float feedback, bool freeze);
 
     void prepare(const DevicePrepareContext& context) override;
     void reset() override;
@@ -103,6 +121,10 @@ class MutableCloudsPlugin : public MagdaDevice {
     std::array<ParameterUtils::ParameterDomain, kNumParams> domains_{};
 
     double sampleRate_ = 44100.0;
+
+    /// setParameterValue writes it, getTailLength() reads it off the message
+    /// thread.
+    std::atomic<double> tailSeconds_{tailSecondsFor(0.0f, 0.0f, false)};
 
     // Input-envelope decimation state (audio thread).
     AudioTapBuffer inputEnvelope_{1024};

--- a/magda/daw/audio/plugins/mutable/MutableCloudsPlugin.hpp
+++ b/magda/daw/audio/plugins/mutable/MutableCloudsPlugin.hpp
@@ -59,35 +59,23 @@ class MutableCloudsPlugin : public MagdaDevice {
     /// under Nyquist at low rates, so the .cpp designs it per rate.
     static constexpr double kBandLimitHz = 15000.0;
 
-    /// Output lag: the grain block, the resampler priming and both filters.
-    ///
-    /// Measured, not derived. The obvious derivation is wrong: the filters'
-    /// group delay is not the analog prototype's sum(1/Q)/w0, because the
-    /// bilinear transform collapses it as the corner nears Nyquist, from 53 us
-    /// at 192 kHz to 13 us at 32 kHz. It is not one number either, varying 36
-    /// to 88 us across the band at 48 kHz, so no single figure cancels an IIR
-    /// at every frequency.
-    ///
-    /// In seconds because properties() is a construction-time snapshot, taken
-    /// before the host rate is known; the dry path carries it too, since Clouds
-    /// mixes dry itself.
-    static constexpr double kLatencySeconds = 1120.8e-6;
+    /// Output lag: the grain block, the placed output cushion and both filters.
+    /// Measured, not derived: the filters' group delay is not the analog
+    /// prototype's sum(1/Q)/w0, since the bilinear transform collapses it as
+    /// the corner nears Nyquist, and it is not one number across the band
+    /// anyway. In seconds because properties() is a construction-time
+    /// snapshot; the dry path carries it too, since Clouds mixes dry itself.
+    static constexpr double kLatencySeconds = 1145.9e-6;
 
-    /// The real delay spans 1062 to 1179 us from 32 kHz to 192 kHz, so this is
-    /// the tightest a single constant can be: a bound, not an exactness.
-    /// Closing it needs a rate-aware declaration or a compensating output delay
-    /// sized at prepare(), neither of which fits in the device's current
-    /// construction-time properties() contract.
-    static constexpr double kLatencyToleranceSeconds = 60.0e-6;
+    /// How far the delay moves across 22.05 kHz to 192 kHz, which is the
+    /// measured quantity rather than a tolerance picked to pass a test. What is
+    /// left is the input guard holding a fixed sample count, a shrinking
+    /// duration as the rate climbs; closing it needs a rate-aware declaration,
+    /// which construction-time properties() has no room for.
+    static constexpr double kLatencySpreadSeconds = 55.0e-6;
 
-    /// OfflineMixAnalysis renders here, where the delay is 104 us past the
-    /// constant. Analysis is a measurement pass with nothing to align against,
-    /// so it sits outside the compensation contract above.
-    static constexpr double kAnalysisRate = 22050.0;
-
-    /// Past this the device sustains rather than decays: feedback from 0.85
-    /// recirculates indefinitely. Granular at full reverb rings for 32 s, so
-    /// the ceiling has to clear that.
+    /// Past this the device sustains rather than decays: feedback from 0.75
+    /// recirculates indefinitely, and granular at full reverb rings for 32 s.
     static constexpr double kMaxTailSeconds = 40.0;
 
     //==============================================================================

--- a/magda/daw/audio/plugins/mutable/MutableCloudsPlugin.hpp
+++ b/magda/daw/audio/plugins/mutable/MutableCloudsPlugin.hpp
@@ -72,8 +72,10 @@ class MutableCloudsPlugin : public MagdaDevice {
     /// The input guard holds 3 + ceil(step) samples, a fixed count and so a
     /// shrinking duration as the rate climbs, 125 us at 32 kHz against 47 us at
     /// 192 kHz. That spread lands in a delay declared in seconds, so the real
-    /// figure sits within this of the constant rather than on it.
-    static constexpr double kLatencyToleranceSeconds = 80.0e-6;
+    /// figure sits within this of the constant from 22.05 kHz to 192 kHz rather
+    /// than on it. A bound, not an exactness: closing it needs a compensating
+    /// output delay sized from a probe at prepare().
+    static constexpr double kLatencyToleranceSeconds = 90.0e-6;
 
     /// Past this the device sustains rather than decays: feedback from 0.85
     /// recirculates indefinitely. Granular at full reverb rings for 32 s, so

--- a/magda/daw/audio/plugins/mutable/MutableCloudsPlugin.hpp
+++ b/magda/daw/audio/plugins/mutable/MutableCloudsPlugin.hpp
@@ -54,12 +54,19 @@ class MutableCloudsPlugin : public MagdaDevice {
     }
     static const char* xmlTypeName;
 
+    /// Output lag through the resampler pair and the 32-sample grain block: the
+    /// block plus a sample of resampler group delay, at the DSP's own 32 kHz.
+    /// In seconds because properties() is read once, before the host rate is
+    /// known; the dry path carries it too, since Clouds mixes dry in itself.
+    static constexpr double kLatencySeconds = 33.0 / 32000.0;
+
     //==============================================================================
     DeviceProperties properties() const override {
         return {
             .pluginId = xmlTypeName,
             .name = getPluginName(),
             .shortName = "Nimbus",
+            .latencySeconds = kLatencySeconds,
             .tailLengthSeconds = 2.0,  // diffuser/reverb + grain tail
         };
     }

--- a/magda/daw/audio/plugins/mutable/MutableCloudsPlugin.hpp
+++ b/magda/daw/audio/plugins/mutable/MutableCloudsPlugin.hpp
@@ -64,14 +64,21 @@ class MutableCloudsPlugin : public MagdaDevice {
         kBandLimitQSum / (2.0 * juce::MathConstants<double>::pi * kBandLimitHz);
 
     /// The 32-sample grain block and a sample of resampler delay at 32 kHz, plus
-    /// both filters. In seconds because properties() is a construction-time
-    /// snapshot; the dry path carries it too, since Clouds mixes dry itself. A
-    /// 32 kHz host bypasses the filters and lands ~3 samples early against it.
+    /// both filters, which run at every rate so this holds at every rate. In
+    /// seconds because properties() is a construction-time snapshot; the dry
+    /// path carries it too, since Clouds mixes dry itself.
     static constexpr double kLatencySeconds = 33.0 / 32000.0 + 2.0 * kBandLimitDelaySeconds;
 
-    /// Past this the device is sustaining rather than decaying: feedback from
-    /// 0.85 recirculates indefinitely, which no finite tail covers.
-    static constexpr double kMaxTailSeconds = 20.0;
+    /// The input guard holds 3 + ceil(step) samples, a fixed count and so a
+    /// shrinking duration as the rate climbs, 125 us at 32 kHz against 47 us at
+    /// 192 kHz. That spread lands in a delay declared in seconds, so the real
+    /// figure sits within this of the constant rather than on it.
+    static constexpr double kLatencyToleranceSeconds = 80.0e-6;
+
+    /// Past this the device sustains rather than decays: feedback from 0.85
+    /// recirculates indefinitely. Granular at full reverb rings for 32 s, so
+    /// the ceiling has to clear that.
+    static constexpr double kMaxTailSeconds = 40.0;
 
     //==============================================================================
     DeviceProperties properties() const override {
@@ -86,8 +93,11 @@ class MutableCloudsPlugin : public MagdaDevice {
         };
     }
 
-    /// @brief The tail those three parameters imply, in seconds.
-    static double tailSecondsFor(float reverb, float feedback, bool freeze);
+    /// @brief The tail those parameters imply, in seconds. `position` because
+    ///        every mode replays the buffer from there, `mode` because spectral
+    ///        rings unpredictably.
+    static double tailSecondsFor(float reverb, float feedback, bool freeze, float position,
+                                 int mode);
 
     void prepare(const DevicePrepareContext& context) override;
     void reset() override;
@@ -124,7 +134,7 @@ class MutableCloudsPlugin : public MagdaDevice {
 
     /// setParameterValue writes it, getTailLength() reads it off the message
     /// thread.
-    std::atomic<double> tailSeconds_{tailSecondsFor(0.0f, 0.0f, false)};
+    std::atomic<double> tailSeconds_{tailSecondsFor(0.0f, 0.0f, false, 0.5f, 0)};
 
     // Input-envelope decimation state (audio thread).
     AudioTapBuffer inputEnvelope_{1024};

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -70,6 +70,7 @@ set(TEST_SOURCES
     devices/test_prune_missing_plugins.cpp
     devices/test_known_plugin_list_duplicates.cpp
     devices/test_device_parameter_pagination.cpp
+    devices/test_mutable_clouds.cpp
     devices/test_device_ui_context.cpp
     ui/test_levels_ui.cpp
     # LevelsUI builds into magda_daw_app, so magda_tests needs its implementation

--- a/tests/devices/test_mutable_clouds.cpp
+++ b/tests/devices/test_mutable_clouds.cpp
@@ -249,32 +249,24 @@ double decayToSilenceSeconds(const juce::AudioBuffer<float>& buffer, double rate
 
 TEST_CASE("Nimbus declares the priming delay it imposes on the dry path",
           "[nimbus][clouds][latency]") {
-    // Every rate a host runs at, and block sizes either side of the internal
-    // chunk: the delay is a property of the plumbing, not of how the host
-    // happens to slice its buffer (#2365 review).
-    for (double rate : {44100.0, 48000.0, 88200.0, 96000.0}) {
+    // Every rate a host runs at, up to 192 kHz, and block sizes either side of
+    // the internal chunk: the delay is a property of the plumbing, not of how
+    // the host slices its buffer (#2365 review).
+    //
+    // Checked in seconds, the unit the declaration is in. The input guard holds
+    // a fixed sample count, so its share shrinks as the rate climbs and one
+    // constant cannot sit exactly on every rate at once.
+    for (double rate : {32000.0, 44100.0, 48000.0, 88200.0, 96000.0, 176400.0, 192000.0}) {
         const double declared = MutableCloudsPlugin::kLatencySeconds * rate;
         for (int blockSize : {16, 128, 512, 2048}) {
             const int measured = bulkDelaySamples(rate, blockSize);
+            const double errorSeconds = (measured - declared) / rate;
             INFO("rate " << rate << " block " << blockSize << ": declared " << declared
-                         << " samples, measured " << measured);
-            CHECK(std::abs(measured - declared) <= 3.0);
+                         << " samples, measured " << measured << ", out by " << errorSeconds * 1.0e6
+                         << " us");
+            CHECK(std::abs(errorSeconds) <= MutableCloudsPlugin::kLatencyToleranceSeconds);
         }
     }
-}
-
-TEST_CASE("A 32 kHz host resamples nothing and skips the band limiting",
-          "[nimbus][clouds][latency]") {
-    // The one rate where both steps are 1. Nothing aliases, so both filters are
-    // bypassed and the output arrives their group delay early against a
-    // constant that has to assume they are in.
-    const double bypassed = 2.0 * MutableCloudsPlugin::kBandLimitDelaySeconds * 32000.0;
-    const double declared = MutableCloudsPlugin::kLatencySeconds * 32000.0;
-    const int measured = bulkDelaySamples(32000.0, kBlockSize);
-
-    INFO("declared " << declared << " samples, measured " << measured << ", filters worth "
-                     << bypassed);
-    CHECK(std::abs(measured - (declared - bypassed)) <= 1.0);
 }
 
 TEST_CASE("Nimbus band-limits both crossings of its 32 kHz rate", "[nimbus][clouds][resampler]") {
@@ -338,53 +330,88 @@ TEST_CASE("Nimbus takes a host buffer larger than its own ring", "[nimbus][cloud
     }
 }
 
-TEST_CASE("Nimbus declares the tail its reverb is actually running", "[nimbus][clouds][latency]") {
-    // A constant cannot: the decay runs from 60 ms to past 18 s across the one
-    // parameter, and a bounce trusting 2 s was cut at the last note (#2365
-    // review). getTailLength() is read per render, so this can follow.
+TEST_CASE("Nimbus declares the tail it is actually running", "[nimbus][clouds][latency]") {
+    // A constant cannot: the decay runs from half a second to past 32 s across
+    // the reverb, every mode replays the buffer from `position` on top of that,
+    // and a bounce trusting 2 s was cut at the last note (#2365 review).
+    // getTailLength() is read per render, so this can follow.
     constexpr double rate = 48000.0;
 
-    const auto measureDecay = [rate](float reverb) {
+    const auto declarationFor = [](int mode, float reverb, float position, float feedback) {
         CloudsRig rig(rate);
-        rig.set(MutableCloudsPlugin::kMode, 2.0f);
-        rig.set(MutableCloudsPlugin::kPosition, 0.0f);
-        rig.set(MutableCloudsPlugin::kDensity, 0.0f);
-        rig.set(MutableCloudsPlugin::kTexture, 0.5f);
-        rig.set(MutableCloudsPlugin::kFeedback, 0.0f);
-        rig.set(MutableCloudsPlugin::kDryWet, 1.0f);
+        rig.set(MutableCloudsPlugin::kMode, static_cast<float>(mode));
         rig.set(MutableCloudsPlugin::kReverb, reverb);
-
-        auto buffer = burstThenSilence(rate, kBurstSeconds, 40.0);
-        rig.render(buffer);
-        return decayToSilenceSeconds(buffer, rate, secondsToSamples(kBurstSeconds, rate));
+        rig.set(MutableCloudsPlugin::kPosition, position);
+        rig.set(MutableCloudsPlugin::kFeedback, feedback);
+        return rig.device.properties().tailLengthSeconds;
     };
 
-    SECTION("the declaration covers the decay at every reverb setting") {
-        for (float reverb : {0.0f, 0.25f, 0.5f, 0.75f, 1.0f}) {
-            CloudsRig rig(rate);
-            rig.set(MutableCloudsPlugin::kReverb, reverb);
-            const double declared = rig.device.properties().tailLengthSeconds;
-            const double measured = measureDecay(reverb);
+    // Longest the output stays above -60 dBFS after the burst, over the three
+    // deterministic modes and the extremes of grain size. Spectral is left out:
+    // its resynthesis is random, so it has no envelope to measure.
+    const auto worstDecay = [](float reverb, float position) {
+        double worst = 0.0;
+        for (int mode : {0, 1, 2}) {
+            for (float size : {0.0f, 0.5f, 1.0f}) {
+                CloudsRig rig(rate);
+                rig.set(MutableCloudsPlugin::kMode, static_cast<float>(mode));
+                rig.set(MutableCloudsPlugin::kPosition, position);
+                rig.set(MutableCloudsPlugin::kSize, size);
+                rig.set(MutableCloudsPlugin::kDensity, 0.0f);
+                rig.set(MutableCloudsPlugin::kTexture, 0.5f);
+                rig.set(MutableCloudsPlugin::kFeedback, 0.0f);
+                rig.set(MutableCloudsPlugin::kDryWet, 1.0f);
+                rig.set(MutableCloudsPlugin::kReverb, reverb);
 
+                // The buffer has to be full before the burst, or there is
+                // nothing behind `position` to replay.
+                juce::AudioBuffer<float> settle(2, secondsToSamples(4.0, rate));
+                settle.clear();
+                rig.render(settle);
+
+                auto buffer = burstThenSilence(rate, kBurstSeconds, 50.0);
+                rig.render(buffer);
+                worst = std::max(worst, decayToSilenceSeconds(
+                                            buffer, rate, secondsToSamples(kBurstSeconds, rate)));
+            }
+        }
+        return worst;
+    };
+
+    SECTION("the declaration covers the reverb's decay") {
+        for (float reverb : {0.0f, 0.25f, 0.55f, 0.85f}) {
+            const double declared = declarationFor(0, reverb, 0.0f, 0.0f);
+            const double measured = worstDecay(reverb, 0.0f);
             INFO("reverb " << reverb << ": declared " << declared << "s, decays in " << measured
                            << "s");
             CHECK(declared >= measured);
-            CHECK(declared <= measured + 3.0);
+            CHECK(declared <= measured * 2.0 + 1.0);
         }
     }
 
-    SECTION("a reverb that is off does not extend the render") {
-        CloudsRig rig(rate);
-        rig.set(MutableCloudsPlugin::kReverb, 0.0f);
-        CHECK(rig.device.properties().tailLengthSeconds < 1.0);
+    SECTION("and the buffer the delay position replays") {
+        // With the reverb off this is the whole tail, and it is what a constant
+        // 250 ms missed: a delayed copy outlives the input by over a second.
+        for (float position : {0.0f, 0.5f, 1.0f}) {
+            const double declared = declarationFor(0, 0.0f, position, 0.0f);
+            const double measured = worstDecay(0.0f, position);
+            INFO("position " << position << ": declared " << declared << "s, decays in " << measured
+                             << "s");
+            CHECK(declared >= measured);
+            CHECK(declared <= measured + 1.5);
+        }
+    }
+
+    SECTION("spectral gets headroom rather than a measurement") {
+        // Three identical renders at reverb 0.75 gave 0 s, 0 s and 20.7 s.
+        CHECK(declarationFor(3, 0.75f, 0.0f, 0.0f) ==
+              Catch::Approx(2.0 * declarationFor(0, 0.75f, 0.0f, 0.0f)));
     }
 
     SECTION("feedback that never decays declares the ceiling") {
         // From 0.85 the buffer recirculates indefinitely. No finite tail covers
         // that, so the most useful thing to say is the ceiling.
-        CloudsRig rig(rate);
-        rig.set(MutableCloudsPlugin::kFeedback, 1.0f);
-        CHECK(rig.device.properties().tailLengthSeconds ==
+        CHECK(declarationFor(0, 0.0f, 0.0f, 1.0f) ==
               Catch::Approx(MutableCloudsPlugin::kMaxTailSeconds));
     }
 }

--- a/tests/devices/test_mutable_clouds.cpp
+++ b/tests/devices/test_mutable_clouds.cpp
@@ -2,6 +2,7 @@
 #include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <cmath>
+#include <vector>
 
 #include "magda/daw/audio/plugins/mutable/MutableCloudsPlugin.hpp"
 #include "magda/daw/core/ParameterUtils.hpp"
@@ -236,7 +237,9 @@ int bulkDelaySamples(double rate, int blockSize) {
     return bestLag;
 }
 
-/// Seconds after `burstEnd` until the output last exceeds -60 dBFS.
+/// Seconds after `burstEnd` until the output last exceeds -60 dBFS. Saturates
+/// at the buffer, so a window shorter than the tail reads as the whole window,
+/// which is still a lower bound on what the declaration has to cover.
 double decayToSilenceSeconds(const juce::AudioBuffer<float>& buffer, double rate, int burstEnd) {
     int last = burstEnd;
     for (int i = burstEnd; i < buffer.getNumSamples(); ++i)
@@ -245,15 +248,70 @@ double decayToSilenceSeconds(const juce::AudioBuffer<float>& buffer, double rate
     return static_cast<double>(last - burstEnd) / rate;
 }
 
+/// Render through `device` in the given callback sizes, cycling them, so a
+/// partition can be irregular and end on a short final callback. Every call
+/// but the first has a nonzero startSample.
+void renderWithPartitions(MutableCloudsPlugin& device, juce::AudioBuffer<float>& buffer,
+                          const std::vector<int>& partitions) {
+    int pos = 0;
+    size_t next = 0;
+    while (pos < buffer.getNumSamples()) {
+        const int n =
+            std::min(partitions[next++ % partitions.size()], buffer.getNumSamples() - pos);
+        audio::DeviceProcessContext context;
+        context.audio = &buffer;
+        context.startSample = pos;
+        context.numSamples = n;
+        device.process(context);
+        pos += n;
+    }
+}
+
+/// The tail measured for one setting. `windowSeconds` bounds the render, so a
+/// routine case can cost a few seconds where the full decay costs forty.
+double tailFor(double rate, int mode, float reverb, float position, float feedback, float size,
+               double settleSeconds, double windowSeconds) {
+    CloudsRig rig(rate);
+    rig.set(MutableCloudsPlugin::kMode, static_cast<float>(mode));
+    rig.set(MutableCloudsPlugin::kPosition, position);
+    rig.set(MutableCloudsPlugin::kSize, size);
+    rig.set(MutableCloudsPlugin::kDensity, 0.0f);
+    rig.set(MutableCloudsPlugin::kTexture, 0.5f);
+    rig.set(MutableCloudsPlugin::kDryWet, 1.0f);
+    rig.set(MutableCloudsPlugin::kReverb, reverb);
+    rig.set(MutableCloudsPlugin::kFeedback, feedback);
+
+    // The buffer has to be full before the burst, or there is nothing behind
+    // `position` to replay.
+    juce::AudioBuffer<float> settle(2, secondsToSamples(settleSeconds, rate));
+    settle.clear();
+    rig.render(settle);
+
+    auto buffer = burstThenSilence(rate, kBurstSeconds, windowSeconds);
+    rig.render(buffer);
+    return decayToSilenceSeconds(buffer, rate, secondsToSamples(kBurstSeconds, rate));
+}
+
+/// What properties() reports for a setting, with nothing rendered.
+double declarationFor(double rate, int mode, float reverb, float position, float feedback) {
+    CloudsRig rig(rate);
+    rig.set(MutableCloudsPlugin::kMode, static_cast<float>(mode));
+    rig.set(MutableCloudsPlugin::kReverb, reverb);
+    rig.set(MutableCloudsPlugin::kPosition, position);
+    rig.set(MutableCloudsPlugin::kFeedback, feedback);
+    return rig.device.properties().tailLengthSeconds;
+}
+
 }  // namespace
 
 TEST_CASE("Nimbus declares the priming delay it imposes on the dry path",
           "[nimbus][clouds][latency]") {
-    // Every host rate inside the compensation contract, and block sizes either
-    // side of the internal chunk: the delay is a property of the plumbing, not
-    // of how the host slices its buffer (#2365 review). The analysis rate sits
-    // outside it, and has its own case below.
-    for (double rate : {32000.0, 44100.0, 48000.0, 88200.0, 96000.0, 176400.0, 192000.0}) {
+    // Every rate the application uses, the 22.05 kHz analysis render included,
+    // and block sizes either side of the internal chunk: the delay is a
+    // property of the plumbing, not of how the host slices its buffer.
+    //
+    // Checked in seconds, the unit the declaration is in.
+    for (double rate : {22050.0, 32000.0, 44100.0, 48000.0, 88200.0, 96000.0, 176400.0, 192000.0}) {
         const double declared = MutableCloudsPlugin::kLatencySeconds * rate;
         for (int blockSize : {16, 128, 512, 2048}) {
             const int measured = bulkDelaySamples(rate, blockSize);
@@ -261,7 +319,7 @@ TEST_CASE("Nimbus declares the priming delay it imposes on the dry path",
             INFO("rate " << rate << " block " << blockSize << ": declared " << declared
                          << " samples, measured " << measured << ", out by " << errorSeconds * 1.0e6
                          << " us");
-            CHECK(std::abs(errorSeconds) <= MutableCloudsPlugin::kLatencyToleranceSeconds);
+            CHECK(std::abs(errorSeconds) <= MutableCloudsPlugin::kLatencySpreadSeconds);
         }
     }
 }
@@ -329,119 +387,148 @@ TEST_CASE("Nimbus takes a host buffer larger than its own ring", "[nimbus][cloud
 
 TEST_CASE("Nimbus declares the tail it is actually running", "[nimbus][clouds][latency]") {
     // A constant cannot: the decay runs from half a second to past 32 s across
-    // the reverb, every mode replays the buffer from `position` on top of that,
-    // and a bounce trusting 2 s was cut at the last note (#2365 review).
-    // getTailLength() is read per render, so this can follow.
+    // the reverb, every mode replays the buffer from `position`, and feedback
+    // keeps repeating whatever the delay holds. A bounce trusting 2 s was cut
+    // at the last note (#2365 review).
+    //
+    // The named reproductions only. The full matrix over mode, grain size,
+    // reverb and position is a sweep, and lives under [.nimbus-sweep] below,
+    // because following every decay to silence costs about fifty minutes of
+    // rendered audio and this file runs on every push.
     constexpr double rate = 48000.0;
 
-    const auto declarationFor = [](int mode, float reverb, float position, float feedback) {
-        CloudsRig rig(rate);
-        rig.set(MutableCloudsPlugin::kMode, static_cast<float>(mode));
-        rig.set(MutableCloudsPlugin::kReverb, reverb);
-        rig.set(MutableCloudsPlugin::kPosition, position);
-        rig.set(MutableCloudsPlugin::kFeedback, feedback);
-        return rig.device.properties().tailLengthSeconds;
-    };
+    SECTION("the repeats feedback keeps alive") {
+        // Wet, density 0, texture 0.5, five seconds of settling, a 250 ms
+        // burst and twenty of silence: declared 1.5 s against 17.256 s
+        // measured, which is the case that found the threshold wrong.
+        const double declared = declarationFor(rate, 2, 0.0f, 1.0f, 0.7f);
+        const double measured = tailFor(rate, 2, 0.0f, 1.0f, 0.7f, 0.5f, 5.0, 20.0);
 
-    // Longest the output stays above -60 dBFS after the burst, over the three
-    // deterministic modes and the extremes of grain size. Spectral is left out:
-    // its resynthesis is random, so it has no envelope to measure.
-    const auto worstDecay = [](float reverb, float position) {
-        double worst = 0.0;
-        for (int mode : {0, 1, 2}) {
-            for (float size : {0.0f, 0.5f, 1.0f}) {
-                CloudsRig rig(rate);
-                rig.set(MutableCloudsPlugin::kMode, static_cast<float>(mode));
-                rig.set(MutableCloudsPlugin::kPosition, position);
-                rig.set(MutableCloudsPlugin::kSize, size);
-                rig.set(MutableCloudsPlugin::kDensity, 0.0f);
-                rig.set(MutableCloudsPlugin::kTexture, 0.5f);
-                rig.set(MutableCloudsPlugin::kFeedback, 0.0f);
-                rig.set(MutableCloudsPlugin::kDryWet, 1.0f);
-                rig.set(MutableCloudsPlugin::kReverb, reverb);
-
-                // The buffer has to be full before the burst, or there is
-                // nothing behind `position` to replay.
-                juce::AudioBuffer<float> settle(2, secondsToSamples(4.0, rate));
-                settle.clear();
-                rig.render(settle);
-
-                auto buffer = burstThenSilence(rate, kBurstSeconds, 50.0);
-                rig.render(buffer);
-                worst = std::max(worst, decayToSilenceSeconds(
-                                            buffer, rate, secondsToSamples(kBurstSeconds, rate)));
-            }
-        }
-        return worst;
-    };
-
-    SECTION("the declaration covers the reverb's decay") {
-        for (float reverb : {0.0f, 0.25f, 0.55f, 0.85f}) {
-            const double declared = declarationFor(0, reverb, 0.0f, 0.0f);
-            const double measured = worstDecay(reverb, 0.0f);
-            INFO("reverb " << reverb << ": declared " << declared << "s, decays in " << measured
-                           << "s");
-            CHECK(declared >= measured);
-            CHECK(declared <= measured * 2.0 + 1.0);
-        }
+        INFO("declared " << declared << "s, still sounding at " << measured << "s");
+        CHECK(declared >= measured);
     }
 
-    SECTION("and the buffer the delay position replays") {
-        // With the reverb off this is the whole tail, and it is what a constant
-        // 250 ms missed: a delayed copy outlives the input by over a second.
-        for (float position : {0.0f, 0.5f, 1.0f}) {
-            const double declared = declarationFor(0, 0.0f, position, 0.0f);
-            const double measured = worstDecay(0.0f, position);
-            INFO("position " << position << ": declared " << declared << "s, decays in " << measured
-                             << "s");
-            CHECK(declared >= measured);
-            CHECK(declared <= measured + 1.5);
-        }
+    SECTION("the buffer the delay position replays") {
+        // Reverb and feedback out, so this is the playback history alone: the
+        // 250 ms declaration against a delayed copy outliving the input.
+        const double declared = declarationFor(rate, 2, 0.0f, 1.0f, 0.0f);
+        const double measured = tailFor(rate, 2, 0.0f, 1.0f, 0.0f, 0.5f, 4.0, 3.0);
+
+        INFO("declared " << declared << "s, still sounding at " << measured << "s");
+        CHECK(declared >= measured);
+        CHECK(measured > 0.5);  // the tail this case exists to catch
     }
 
-    SECTION("and the repeats feedback keeps alive") {
-        // Feedback is a delay line: it contributes nothing at position 0 and
-        // many seconds at position 1, which a threshold on feedback alone
-        // missed entirely (#2365 review).
-        for (float feedback : {0.3f, 0.5f, 0.7f}) {
-            for (float position : {0.25f, 1.0f}) {
-                CloudsRig rig(rate);
-                rig.set(MutableCloudsPlugin::kMode, 2.0f);  // Looping Delay
-                rig.set(MutableCloudsPlugin::kPosition, position);
-                rig.set(MutableCloudsPlugin::kDensity, 0.0f);
-                rig.set(MutableCloudsPlugin::kTexture, 0.5f);
-                rig.set(MutableCloudsPlugin::kDryWet, 1.0f);
-                rig.set(MutableCloudsPlugin::kReverb, 0.0f);
-                rig.set(MutableCloudsPlugin::kFeedback, feedback);
+    SECTION("the reverb's own decay") {
+        const double declared = declarationFor(rate, 0, 0.25f, 0.0f, 0.0f);
+        const double measured = tailFor(rate, 0, 0.25f, 0.0f, 0.0f, 1.0f, 0.0, 6.0);
 
-                juce::AudioBuffer<float> settle(2, secondsToSamples(5.0, rate));
-                settle.clear();
-                rig.render(settle);
+        INFO("declared " << declared << "s, still sounding at " << measured << "s");
+        CHECK(declared >= measured);
+    }
 
-                auto buffer = burstThenSilence(rate, kBurstSeconds, 45.0);
-                rig.render(buffer);
-                const double measured =
-                    decayToSilenceSeconds(buffer, rate, secondsToSamples(kBurstSeconds, rate));
-
-                INFO("feedback " << feedback << " position " << position << ": declared "
-                                 << rig.device.properties().tailLengthSeconds << "s, decays in "
-                                 << measured << "s");
-                CHECK(rig.device.properties().tailLengthSeconds >= measured);
-            }
-        }
+    // The rest is what the declaration says, which needs no audio at all.
+    SECTION("it rises with everything that lengthens the tail") {
+        CHECK(declarationFor(rate, 0, 0.5f, 0.0f, 0.0f) >
+              declarationFor(rate, 0, 0.0f, 0.0f, 0.0f));
+        CHECK(declarationFor(rate, 0, 0.0f, 1.0f, 0.0f) >
+              declarationFor(rate, 0, 0.0f, 0.0f, 0.0f));
+        CHECK(declarationFor(rate, 0, 0.0f, 1.0f, 0.5f) >
+              declarationFor(rate, 0, 0.0f, 1.0f, 0.0f));
     }
 
     SECTION("spectral gets headroom rather than a measurement") {
-        // Three identical renders at reverb 0.75 gave 0 s, 0 s and 20.7 s.
-        CHECK(declarationFor(3, 0.75f, 0.0f, 0.0f) ==
-              Catch::Approx(2.0 * declarationFor(0, 0.75f, 0.0f, 0.0f)));
+        // Identical renders at reverb 0.75 have come back 0 s, 0 s, 20.7 s and
+        // 37.7 s, so there is no envelope to fit: any engaged reverb takes the
+        // ceiling. Policy, checked without rendering.
+        CHECK(declarationFor(rate, 3, 0.75f, 0.0f, 0.0f) ==
+              Catch::Approx(MutableCloudsPlugin::kMaxTailSeconds));
     }
 
     SECTION("feedback that never decays declares the ceiling") {
         // From 0.75 the buffer recirculates indefinitely: 0.79 was still above
-        // -60 dBFS after 45 s. No finite tail covers that.
-        CHECK(declarationFor(0, 0.0f, 0.0f, 0.79f) ==
+        // -60 dBFS after 45 s. Policy again, not a wait for silence.
+        CHECK(declarationFor(rate, 0, 0.0f, 0.0f, 0.79f) ==
               Catch::Approx(MutableCloudsPlugin::kMaxTailSeconds));
+    }
+}
+
+TEST_CASE("Nimbus renders the same whatever the callback partition",
+          "[nimbus][clouds][resampler]") {
+    // The dry path in looping delay is the plumbing with nothing random in it,
+    // so the same input has one right answer. Callback boundaries decide when
+    // the rings are pushed and drained, and must not decide what comes out.
+    constexpr double rate = 48000.0;
+    const auto input = steadyTone(rate, 440.0, 0.3);
+
+    const auto renderWith = [&input](const std::vector<int>& partitions) {
+        CloudsRig rig(rate);
+        makeDryPath(rig);
+        juce::AudioBuffer<float> buffer(2, input.getNumSamples());
+        buffer.makeCopyOf(input);
+        renderWithPartitions(rig.device, buffer, partitions);
+        return buffer;
+    };
+
+    const auto reference = renderWith({128});
+
+    // Every size the plan names, plus an irregular partition that ends on a
+    // short final callback.
+    const std::vector<std::vector<int>> partitions = {
+        {1}, {16}, {32}, {48}, {256}, {512}, {2048}, {8192}, {37, 1, 512, 3, 129}};
+
+    for (const auto& partition : partitions) {
+        const auto rendered = renderWith(partition);
+        REQUIRE(rendered.getNumSamples() == reference.getNumSamples());
+
+        double worst = 0.0;
+        int worstAt = -1;
+        for (int i = 0; i < reference.getNumSamples(); ++i) {
+            const double diff = std::abs(rendered.getSample(0, i) - reference.getSample(0, i));
+            if (diff > worst) {
+                worst = diff;
+                worstAt = i;
+            }
+        }
+
+        INFO("partition starting " << partition.front() << ": worst " << worst << " at sample "
+                                   << worstAt);
+        CHECK(worst < 1.0e-6);
+    }
+}
+
+TEST_CASE("Nimbus survives being prepared again at a different rate",
+          "[nimbus][clouds][resampler]") {
+    // The filters are designed per rate and the rings hold the old rate's
+    // samples, so a re-prepare has to reset both. Same instance throughout.
+    MutableCloudsPlugin device;
+
+    for (double rate : {48000.0, 22050.0, 192000.0, 44100.0}) {
+        device.prepare({.sampleRate = rate, .maximumBlockSize = kBlockSize});
+        device.setParameterValue(MutableCloudsPlugin::kDryWet, 0.0f);
+
+        auto buffer = steadyTone(rate, 1000.0, 0.1);
+        for (int pos = 0; pos < buffer.getNumSamples(); pos += kBlockSize) {
+            audio::DeviceProcessContext context;
+            context.audio = &buffer;
+            context.startSample = pos;
+            context.numSamples = std::min(kBlockSize, buffer.getNumSamples() - pos);
+            device.process(context);
+        }
+
+        int nonFinite = 0;
+        float peak = 0.0f;
+        for (int i = 0; i < buffer.getNumSamples(); ++i) {
+            const float sample = buffer.getSample(0, i);
+            if (!std::isfinite(sample))
+                ++nonFinite;
+            else
+                peak = std::max(peak, std::abs(sample));
+        }
+
+        INFO("rate " << rate << ": " << nonFinite << " non-finite, peak " << peak);
+        CHECK(nonFinite == 0);
+        CHECK(peak < 1.0f);
     }
 }
 
@@ -469,5 +556,65 @@ TEST_CASE("Nimbus stays finite at the offline analysis rate", "[nimbus][clouds][
         INFO("rate " << rate << ": " << nonFinite << " non-finite, peak " << peak);
         CHECK(nonFinite == 0);
         CHECK(peak < 1.0f);
+    }
+}
+
+//==============================================================================
+// Sweeps. Tagged with a leading dot, so Catch2 leaves them out of a bare run
+// and `magda_tests "[nimbus-sweep]"` still picks them up. They are the full
+// domains behind the bounded cases above, and following every decay to silence
+// costs roughly fifty minutes of rendered audio.
+
+TEST_CASE("Nimbus tail declaration covers every mode, size, reverb and position",
+          "[.nimbus-sweep]") {
+    constexpr double rate = 48000.0;
+
+    for (float reverb : {0.0f, 0.25f, 0.55f, 0.85f, 1.0f}) {
+        for (float position : {0.0f, 0.5f, 1.0f}) {
+            const double declared = declarationFor(rate, 0, reverb, position, 0.0f);
+
+            // Spectral is left out: its resynthesis is random, and it takes
+            // double the curve rather than a measured envelope.
+            for (int mode : {0, 1, 2}) {
+                for (float size : {0.0f, 0.5f, 1.0f}) {
+                    const double measured =
+                        tailFor(rate, mode, reverb, position, 0.0f, size, 4.0, 45.0);
+                    INFO("reverb " << reverb << " position " << position << " mode " << mode
+                                   << " size " << size << ": declared " << declared
+                                   << "s, still sounding at " << measured << "s");
+                    CHECK(declared >= measured);
+                }
+            }
+        }
+    }
+}
+
+TEST_CASE("Nimbus tail declaration covers feedback short of sustain", "[.nimbus-sweep]") {
+    constexpr double rate = 48000.0;
+
+    for (float feedback : {0.3f, 0.5f, 0.7f}) {
+        for (float position : {0.0f, 0.25f, 0.5f, 1.0f}) {
+            const double declared = declarationFor(rate, 2, 0.0f, position, feedback);
+            const double measured = tailFor(rate, 2, 0.0f, position, feedback, 0.5f, 5.0, 45.0);
+
+            INFO("feedback " << feedback << " position " << position << ": declared " << declared
+                             << "s, still sounding at " << measured << "s");
+            CHECK(declared >= measured);
+        }
+    }
+}
+
+TEST_CASE("Nimbus spectral tail is not deterministic", "[.nimbus-sweep]") {
+    // Kept as evidence rather than as a bound: identical renders here have
+    // come back 0 s, 0 s, 20.7 s and 37.7 s, which is why spectral takes
+    // enough headroom to reach the ceiling.
+    constexpr double rate = 48000.0;
+    const double declared = declarationFor(rate, 3, 0.75f, 0.0f, 0.0f);
+
+    for (int run = 0; run < 5; ++run) {
+        const double measured = tailFor(rate, 3, 0.75f, 0.0f, 0.0f, 0.5f, 4.0, 45.0);
+        INFO("run " << run << ": declared " << declared << "s, still sounding at " << measured
+                    << "s");
+        CHECK(declared >= measured);
     }
 }

--- a/tests/devices/test_mutable_clouds.cpp
+++ b/tests/devices/test_mutable_clouds.cpp
@@ -249,14 +249,15 @@ double decayToSilenceSeconds(const juce::AudioBuffer<float>& buffer, double rate
 
 TEST_CASE("Nimbus declares the priming delay it imposes on the dry path",
           "[nimbus][clouds][latency]") {
-    // Every rate a host runs at, up to 192 kHz, and block sizes either side of
+    // Every rate a host runs at, the 22.05 kHz analysis render included, and
+    // block sizes either side of
     // the internal chunk: the delay is a property of the plumbing, not of how
     // the host slices its buffer (#2365 review).
     //
     // Checked in seconds, the unit the declaration is in. The input guard holds
     // a fixed sample count, so its share shrinks as the rate climbs and one
     // constant cannot sit exactly on every rate at once.
-    for (double rate : {32000.0, 44100.0, 48000.0, 88200.0, 96000.0, 176400.0, 192000.0}) {
+    for (double rate : {22050.0, 32000.0, 44100.0, 48000.0, 88200.0, 96000.0, 176400.0, 192000.0}) {
         const double declared = MutableCloudsPlugin::kLatencySeconds * rate;
         for (int blockSize : {16, 128, 512, 2048}) {
             const int measured = bulkDelaySamples(rate, blockSize);
@@ -402,6 +403,38 @@ TEST_CASE("Nimbus declares the tail it is actually running", "[nimbus][clouds][l
         }
     }
 
+    SECTION("and the repeats feedback keeps alive") {
+        // Feedback is a delay line: it contributes nothing at position 0 and
+        // many seconds at position 1, which a threshold on feedback alone
+        // missed entirely (#2365 review).
+        for (float feedback : {0.3f, 0.5f, 0.7f}) {
+            for (float position : {0.25f, 1.0f}) {
+                CloudsRig rig(rate);
+                rig.set(MutableCloudsPlugin::kMode, 2.0f);  // Looping Delay
+                rig.set(MutableCloudsPlugin::kPosition, position);
+                rig.set(MutableCloudsPlugin::kDensity, 0.0f);
+                rig.set(MutableCloudsPlugin::kTexture, 0.5f);
+                rig.set(MutableCloudsPlugin::kDryWet, 1.0f);
+                rig.set(MutableCloudsPlugin::kReverb, 0.0f);
+                rig.set(MutableCloudsPlugin::kFeedback, feedback);
+
+                juce::AudioBuffer<float> settle(2, secondsToSamples(5.0, rate));
+                settle.clear();
+                rig.render(settle);
+
+                auto buffer = burstThenSilence(rate, kBurstSeconds, 45.0);
+                rig.render(buffer);
+                const double measured =
+                    decayToSilenceSeconds(buffer, rate, secondsToSamples(kBurstSeconds, rate));
+
+                INFO("feedback " << feedback << " position " << position << ": declared "
+                                 << rig.device.properties().tailLengthSeconds << "s, decays in "
+                                 << measured << "s");
+                CHECK(rig.device.properties().tailLengthSeconds >= measured);
+            }
+        }
+    }
+
     SECTION("spectral gets headroom rather than a measurement") {
         // Three identical renders at reverb 0.75 gave 0 s, 0 s and 20.7 s.
         CHECK(declarationFor(3, 0.75f, 0.0f, 0.0f) ==
@@ -409,9 +442,36 @@ TEST_CASE("Nimbus declares the tail it is actually running", "[nimbus][clouds][l
     }
 
     SECTION("feedback that never decays declares the ceiling") {
-        // From 0.85 the buffer recirculates indefinitely. No finite tail covers
-        // that, so the most useful thing to say is the ceiling.
-        CHECK(declarationFor(0, 0.0f, 0.0f, 1.0f) ==
+        // From 0.75 the buffer recirculates indefinitely: 0.79 was still above
+        // -60 dBFS after 45 s. No finite tail covers that.
+        CHECK(declarationFor(0, 0.0f, 0.0f, 0.79f) ==
               Catch::Approx(MutableCloudsPlugin::kMaxTailSeconds));
+    }
+}
+
+TEST_CASE("Nimbus stays finite at the offline analysis rate", "[nimbus][clouds][resampler]") {
+    // OfflineMixAnalysis renders at 22.05 kHz with plugins in. A 15 kHz corner
+    // is above Nyquist there, and the biquads it produces are unstable: the
+    // output reached 1e37 and then stopped being a number (#2365 review).
+    for (double rate : {22050.0, 24000.0, 32000.0}) {
+        CloudsRig rig(rate);
+        makeDryPath(rig);
+
+        auto buffer = steadyTone(rate, 1000.0, 0.1);
+        rig.render(buffer);
+
+        int nonFinite = 0;
+        float peak = 0.0f;
+        for (int i = 0; i < buffer.getNumSamples(); ++i) {
+            const float sample = buffer.getSample(0, i);
+            if (!std::isfinite(sample))
+                ++nonFinite;
+            else
+                peak = std::max(peak, std::abs(sample));
+        }
+
+        INFO("rate " << rate << ": " << nonFinite << " non-finite, peak " << peak);
+        CHECK(nonFinite == 0);
+        CHECK(peak < 1.0f);
     }
 }

--- a/tests/devices/test_mutable_clouds.cpp
+++ b/tests/devices/test_mutable_clouds.cpp
@@ -249,15 +249,11 @@ double decayToSilenceSeconds(const juce::AudioBuffer<float>& buffer, double rate
 
 TEST_CASE("Nimbus declares the priming delay it imposes on the dry path",
           "[nimbus][clouds][latency]") {
-    // Every rate a host runs at, the 22.05 kHz analysis render included, and
-    // block sizes either side of
-    // the internal chunk: the delay is a property of the plumbing, not of how
-    // the host slices its buffer (#2365 review).
-    //
-    // Checked in seconds, the unit the declaration is in. The input guard holds
-    // a fixed sample count, so its share shrinks as the rate climbs and one
-    // constant cannot sit exactly on every rate at once.
-    for (double rate : {22050.0, 32000.0, 44100.0, 48000.0, 88200.0, 96000.0, 176400.0, 192000.0}) {
+    // Every host rate inside the compensation contract, and block sizes either
+    // side of the internal chunk: the delay is a property of the plumbing, not
+    // of how the host slices its buffer (#2365 review). The analysis rate sits
+    // outside it, and has its own case below.
+    for (double rate : {32000.0, 44100.0, 48000.0, 88200.0, 96000.0, 176400.0, 192000.0}) {
         const double declared = MutableCloudsPlugin::kLatencySeconds * rate;
         for (int blockSize : {16, 128, 512, 2048}) {
             const int measured = bulkDelaySamples(rate, blockSize);

--- a/tests/devices/test_mutable_clouds.cpp
+++ b/tests/devices/test_mutable_clouds.cpp
@@ -30,9 +30,10 @@ constexpr int kBlockSize = 128;
 
 struct CloudsRig {
     MutableCloudsPlugin device;
+    int blockSize = kBlockSize;
 
-    explicit CloudsRig(double rate) {
-        device.prepare({.sampleRate = rate, .maximumBlockSize = kBlockSize});
+    explicit CloudsRig(double rate, int bs = kBlockSize) : blockSize(bs) {
+        device.prepare({.sampleRate = rate, .maximumBlockSize = bs});
     }
 
     /// Slots take normalised values; the tests speak in display units.
@@ -42,11 +43,11 @@ struct CloudsRig {
     }
 
     void render(juce::AudioBuffer<float>& buffer) {
-        for (int pos = 0; pos < buffer.getNumSamples(); pos += kBlockSize) {
+        for (int pos = 0; pos < buffer.getNumSamples(); pos += blockSize) {
             audio::DeviceProcessContext context;
             context.audio = &buffer;
             context.startSample = pos;
-            context.numSamples = std::min(kBlockSize, buffer.getNumSamples() - pos);
+            context.numSamples = std::min(blockSize, buffer.getNumSamples() - pos);
             device.process(context);
         }
     }
@@ -140,45 +141,250 @@ TEST_CASE("Nimbus clocks its DSP at 32 kHz whatever the host rate", "[nimbus][cl
     CHECK(at48k == Catch::Approx(at32k).epsilon(0.05));
 }
 
-TEST_CASE("Nimbus declares the priming delay it imposes on the dry path",
-          "[nimbus][clouds][latency]") {
-    constexpr double kRate = 48000.0;
+namespace {
 
-    CloudsRig rig(kRate);
-    // What the hosts compensate by: both take it off properties(), in seconds,
-    // once at construction.
-    const auto declared =
-        static_cast<int>(std::lround(rig.device.properties().latencySeconds * kRate));
-    rig.set(MutableCloudsPlugin::kMode, 2.0f);    // Looping Delay
-    rig.set(MutableCloudsPlugin::kDryWet, 0.0f);  // dry only: a clean delayed copy
+/// Energy at `hz` over the whole buffer (Goertzel).
+double toneEnergy(const juce::AudioBuffer<float>& buffer, double rate, double hz) {
+    const double w = 2.0 * juce::MathConstants<double>::pi * hz / rate;
+    const double coeff = 2.0 * std::cos(w);
+    double s1 = 0.0, s2 = 0.0;
+    for (int i = 0; i < buffer.getNumSamples(); ++i) {
+        const double s = coeff * s1 - s2 + buffer.getSample(0, i);
+        s2 = s1;
+        s1 = s;
+    }
+    return s1 * s1 + s2 * s2 - coeff * s1 * s2;
+}
+
+juce::AudioBuffer<float> steadyTone(double rate, double hz, double seconds) {
+    juce::AudioBuffer<float> buffer(2, secondsToSamples(seconds, rate));
+    for (int i = 0; i < buffer.getNumSamples(); ++i) {
+        const auto s = static_cast<float>(
+            0.5 * std::sin(2.0 * juce::MathConstants<double>::pi * hz * i / rate));
+        buffer.setSample(0, i, s);
+        buffer.setSample(1, i, s);
+    }
+    return buffer;
+}
+
+/// Dry only, in looping delay with the reverb and feedback out: a clean delayed
+/// copy, so what comes back is the plumbing rather than the granulator.
+void makeDryPath(CloudsRig& rig) {
+    rig.set(MutableCloudsPlugin::kMode, 2.0f);
+    rig.set(MutableCloudsPlugin::kDryWet, 0.0f);
     rig.set(MutableCloudsPlugin::kReverb, 0.0f);
     rig.set(MutableCloudsPlugin::kFeedback, 0.0f);
+}
 
+void warmUp(CloudsRig& rig, double rate) {
     // The DSP holds its output at zero until it has cleared its buffers, and
     // the resampler rings need their window filled.
-    juce::AudioBuffer<float> warmup(2, secondsToSamples(0.2, kRate));
+    juce::AudioBuffer<float> warmup(2, secondsToSamples(0.2, rate));
     warmup.clear();
     rig.render(warmup);
+}
 
+/// Output energy at `probeHz` for a `inHz` tone in. Absolute, because a spur
+/// has to be read against a passband reference and not against a source the
+/// band limiting has already removed.
+double spurEnergy(double rate, double inHz, double probeHz) {
+    CloudsRig rig(rate);
+    makeDryPath(rig);
+    warmUp(rig, rate);
+
+    auto buffer = steadyTone(rate, inHz, 0.25);
+    rig.render(buffer);
+    return toneEnergy(buffer, rate, probeHz);
+}
+
+/// Bulk delay through the device in samples, by correlating the output against
+/// the input. Not an energy centroid: the band-limiting filters ring, and a
+/// centroid counts that ringing as delay.
+int bulkDelaySamples(double rate, int blockSize) {
+    CloudsRig rig(rate, blockSize);
+    makeDryPath(rig);
+    warmUp(rig, rate);
+
+    // A 4 kHz half-cycle, inside every passband here, so this reads the bulk
+    // delay rather than a group delay at the filter's corner.
     const int impulseAt = 512;
-    juce::AudioBuffer<float> buffer(2, 2048);
+    const int width = static_cast<int>(rate / 8000.0);
+    juce::AudioBuffer<float> buffer(2, 4096);
     buffer.clear();
-    buffer.setSample(0, impulseAt, 0.5f);
-    buffer.setSample(1, impulseAt, 0.5f);
+    for (int i = 0; i < width; ++i) {
+        const auto s =
+            static_cast<float>(0.5 * std::sin(juce::MathConstants<double>::pi * i / width));
+        buffer.setSample(0, impulseAt + i, s);
+        buffer.setSample(1, impulseAt + i, s);
+    }
+
+    juce::AudioBuffer<float> reference(2, buffer.getNumSamples());
+    reference.makeCopyOf(buffer);
     rig.render(buffer);
 
-    // Energy centroid rather than the peak: the cubic interpolators spread the
-    // impulse over a few samples, and which one is highest moves with the phase
-    // the impulse lands on.
-    double weighted = 0.0;
-    double energy = 0.0;
-    for (int i = impulseAt; i < buffer.getNumSamples(); ++i) {
-        weighted += energyAt(buffer, i) * (i - impulseAt);
-        energy += energyAt(buffer, i);
+    double best = -1.0e30;
+    int bestLag = -1;
+    for (int lag = 0; lag < 512; ++lag) {
+        double acc = 0.0;
+        for (int i = 0; i < width * 4; ++i)
+            acc += reference.getSample(0, impulseAt + i) * buffer.getSample(0, impulseAt + i + lag);
+        if (acc > best) {
+            best = acc;
+            bestLag = lag;
+        }
     }
-    REQUIRE(energy > 0.0);
+    return bestLag;
+}
 
-    const double measured = weighted / energy;
-    INFO("declared " << declared << " samples, measured " << measured);
-    CHECK(std::abs(measured - declared) <= 2.0);
+/// Seconds after `burstEnd` until the output last exceeds -60 dBFS.
+double decayToSilenceSeconds(const juce::AudioBuffer<float>& buffer, double rate, int burstEnd) {
+    int last = burstEnd;
+    for (int i = burstEnd; i < buffer.getNumSamples(); ++i)
+        if (std::abs(buffer.getSample(0, i)) > 0.001)
+            last = i;
+    return static_cast<double>(last - burstEnd) / rate;
+}
+
+}  // namespace
+
+TEST_CASE("Nimbus declares the priming delay it imposes on the dry path",
+          "[nimbus][clouds][latency]") {
+    // Every rate a host runs at, and block sizes either side of the internal
+    // chunk: the delay is a property of the plumbing, not of how the host
+    // happens to slice its buffer (#2365 review).
+    for (double rate : {44100.0, 48000.0, 88200.0, 96000.0}) {
+        const double declared = MutableCloudsPlugin::kLatencySeconds * rate;
+        for (int blockSize : {16, 128, 512, 2048}) {
+            const int measured = bulkDelaySamples(rate, blockSize);
+            INFO("rate " << rate << " block " << blockSize << ": declared " << declared
+                         << " samples, measured " << measured);
+            CHECK(std::abs(measured - declared) <= 3.0);
+        }
+    }
+}
+
+TEST_CASE("A 32 kHz host resamples nothing and skips the band limiting",
+          "[nimbus][clouds][latency]") {
+    // The one rate where both steps are 1. Nothing aliases, so both filters are
+    // bypassed and the output arrives their group delay early against a
+    // constant that has to assume they are in.
+    const double bypassed = 2.0 * MutableCloudsPlugin::kBandLimitDelaySeconds * 32000.0;
+    const double declared = MutableCloudsPlugin::kLatencySeconds * 32000.0;
+    const int measured = bulkDelaySamples(32000.0, kBlockSize);
+
+    INFO("declared " << declared << " samples, measured " << measured << ", filters worth "
+                     << bypassed);
+    CHECK(std::abs(measured - (declared - bypassed)) <= 1.0);
+}
+
+TEST_CASE("Nimbus band-limits both crossings of its 32 kHz rate", "[nimbus][clouds][resampler]") {
+    constexpr double rate = 48000.0;
+    // Everything is read against a passband tone at the same input level.
+    const double reference = spurEnergy(rate, 1000.0, 1000.0);
+    REQUIRE(reference > 0.0);
+
+    const auto belowReference = [reference](double energy) {
+        return -10.0 * std::log10(energy / reference + 1.0e-30);
+    };
+
+    SECTION("what folds coming down to 32 kHz") {
+        // Undertaken, an 18 kHz tone arrives at 14 kHz louder than it left, and
+        // 20 kHz lands at 12 kHz only 5 dB below a passband reference.
+        const double fold18 = belowReference(spurEnergy(rate, 18000.0, 14000.0));
+        const double fold20 = belowReference(spurEnergy(rate, 20000.0, 12000.0));
+        INFO("18k->14k " << fold18 << " dB down, 20k->12k " << fold20 << " dB down");
+        CHECK(fold18 > 30.0);
+        CHECK(fold20 > 50.0);
+    }
+
+    SECTION("what images going back up") {
+        // The cubic alone leaves a 10 kHz tone's image 17 dB down.
+        const double image = belowReference(spurEnergy(rate, 10000.0, 22000.0));
+        INFO("10k image at 22k, " << image << " dB down");
+        CHECK(image > 60.0);
+    }
+
+    SECTION("and the passband survives it") {
+        // The rolloff below the corner is the cubic interpolators', which the
+        // filters are not allowed to add meaningfully to.
+        for (double hz : {1000.0, 5000.0, 10000.0}) {
+            const double loss = belowReference(spurEnergy(rate, hz, hz));
+            INFO(hz << " Hz down " << loss << " dB");
+            CHECK(loss < 2.0);
+        }
+    }
+}
+
+TEST_CASE("Nimbus takes a host buffer larger than its own ring", "[nimbus][clouds][resampler]") {
+    // Pushing a whole call before draining any of it made StereoRing::kCap a
+    // limit on the host's buffer: at 8192 it overran and dropped input
+    // continuously, which is a render that quietly loses level (#2365 review).
+    constexpr double rate = 48000.0;
+    const auto throughputAt = [rate](int blockSize) {
+        CloudsRig rig(rate, blockSize);
+        makeDryPath(rig);
+        warmUp(rig, rate);
+        auto buffer = steadyTone(rate, 1000.0, 0.5);
+        rig.render(buffer);
+        return toneEnergy(buffer, rate, 1000.0);
+    };
+
+    const double reference = throughputAt(kBlockSize);
+    REQUIRE(reference > 0.0);
+
+    for (int blockSize : {2048, 4096, 8192, 16384}) {
+        INFO("block " << blockSize);
+        CHECK(throughputAt(blockSize) == Catch::Approx(reference).epsilon(0.01));
+    }
+}
+
+TEST_CASE("Nimbus declares the tail its reverb is actually running", "[nimbus][clouds][latency]") {
+    // A constant cannot: the decay runs from 60 ms to past 18 s across the one
+    // parameter, and a bounce trusting 2 s was cut at the last note (#2365
+    // review). getTailLength() is read per render, so this can follow.
+    constexpr double rate = 48000.0;
+
+    const auto measureDecay = [rate](float reverb) {
+        CloudsRig rig(rate);
+        rig.set(MutableCloudsPlugin::kMode, 2.0f);
+        rig.set(MutableCloudsPlugin::kPosition, 0.0f);
+        rig.set(MutableCloudsPlugin::kDensity, 0.0f);
+        rig.set(MutableCloudsPlugin::kTexture, 0.5f);
+        rig.set(MutableCloudsPlugin::kFeedback, 0.0f);
+        rig.set(MutableCloudsPlugin::kDryWet, 1.0f);
+        rig.set(MutableCloudsPlugin::kReverb, reverb);
+
+        auto buffer = burstThenSilence(rate, kBurstSeconds, 40.0);
+        rig.render(buffer);
+        return decayToSilenceSeconds(buffer, rate, secondsToSamples(kBurstSeconds, rate));
+    };
+
+    SECTION("the declaration covers the decay at every reverb setting") {
+        for (float reverb : {0.0f, 0.25f, 0.5f, 0.75f, 1.0f}) {
+            CloudsRig rig(rate);
+            rig.set(MutableCloudsPlugin::kReverb, reverb);
+            const double declared = rig.device.properties().tailLengthSeconds;
+            const double measured = measureDecay(reverb);
+
+            INFO("reverb " << reverb << ": declared " << declared << "s, decays in " << measured
+                           << "s");
+            CHECK(declared >= measured);
+            CHECK(declared <= measured + 3.0);
+        }
+    }
+
+    SECTION("a reverb that is off does not extend the render") {
+        CloudsRig rig(rate);
+        rig.set(MutableCloudsPlugin::kReverb, 0.0f);
+        CHECK(rig.device.properties().tailLengthSeconds < 1.0);
+    }
+
+    SECTION("feedback that never decays declares the ceiling") {
+        // From 0.85 the buffer recirculates indefinitely. No finite tail covers
+        // that, so the most useful thing to say is the ceiling.
+        CloudsRig rig(rate);
+        rig.set(MutableCloudsPlugin::kFeedback, 1.0f);
+        CHECK(rig.device.properties().tailLengthSeconds ==
+              Catch::Approx(MutableCloudsPlugin::kMaxTailSeconds));
+    }
 }

--- a/tests/devices/test_mutable_clouds.cpp
+++ b/tests/devices/test_mutable_clouds.cpp
@@ -1,0 +1,184 @@
+#include <algorithm>
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <cmath>
+
+#include "magda/daw/audio/plugins/mutable/MutableCloudsPlugin.hpp"
+#include "magda/daw/core/ParameterUtils.hpp"
+
+// Nimbus (Mutable Clouds) runs its DSP at a fixed 32 kHz, with the host audio
+// resampled down into it and the result resampled back up. Two things ride on
+// that plumbing and neither announces itself as a fault, so they are pinned
+// here.
+//
+// The rate: every time constant inside Clouds - grain size and density, the
+// reverb and diffuser decay, the looping-delay length, the feedback filter
+// corner - is written in 32 kHz samples. Hand the engine more than 32000 of
+// them per second and all of it speeds up together, which sounds like a
+// different patch rather than like a bug (#2365).
+//
+// The latency: the output lags the input by the grain block plus the resampler
+// windows, and the dry path lags with it, because Clouds mixes dry in itself. A
+// host can only compensate for what the device declares.
+
+namespace {
+
+namespace audio = magda::daw::audio;
+using audio::MutableCloudsPlugin;
+
+constexpr int kBlockSize = 128;
+
+struct CloudsRig {
+    MutableCloudsPlugin device;
+
+    explicit CloudsRig(double rate) {
+        device.prepare({.sampleRate = rate, .maximumBlockSize = kBlockSize});
+    }
+
+    /// Slots take normalised values; the tests speak in display units.
+    void set(int slot, float displayValue) {
+        device.setParameterValue(slot, magda::ParameterUtils::realToNormalized(
+                                           displayValue, device.parameterInfo(slot)));
+    }
+
+    void render(juce::AudioBuffer<float>& buffer) {
+        for (int pos = 0; pos < buffer.getNumSamples(); pos += kBlockSize) {
+            audio::DeviceProcessContext context;
+            context.audio = &buffer;
+            context.startSample = pos;
+            context.numSamples = std::min(kBlockSize, buffer.getNumSamples() - pos);
+            device.process(context);
+        }
+    }
+};
+
+int secondsToSamples(double seconds, double rate) {
+    return static_cast<int>(std::lround(seconds * rate));
+}
+
+double energyAt(const juce::AudioBuffer<float>& buffer, int index) {
+    const double s = buffer.getSample(0, index);
+    return s * s;
+}
+
+/// How long the tail after `burstEnd` takes to deliver `fraction` of its own
+/// energy, in seconds. A running integral rather than a level crossing: the
+/// reverb's envelope ripples by several dB, which walks a threshold across
+/// whole buckets, and a cumulative measure cannot be moved that way.
+double tailEnergySpanSeconds(const juce::AudioBuffer<float>& buffer, double rate, int burstEnd,
+                             double fraction) {
+    double total = 0.0;
+    for (int i = burstEnd; i < buffer.getNumSamples(); ++i)
+        total += energyAt(buffer, i);
+    if (total <= 0.0)
+        return -1.0;
+
+    double running = 0.0;
+    for (int i = burstEnd; i < buffer.getNumSamples(); ++i) {
+        running += energyAt(buffer, i);
+        if (running >= fraction * total)
+            return static_cast<double>(i - burstEnd) / rate;
+    }
+    return -1.0;
+}
+
+/// A 220 Hz burst followed by silence: the same signal whatever the host rate,
+/// so two runs compare the DSP rather than their own input.
+juce::AudioBuffer<float> burstThenSilence(double rate, double burstSeconds, double tailSeconds) {
+    const int burst = secondsToSamples(burstSeconds, rate);
+    juce::AudioBuffer<float> buffer(2, burst + secondsToSamples(tailSeconds, rate));
+    buffer.clear();
+    for (int i = 0; i < burst; ++i) {
+        const auto s = static_cast<float>(
+            0.5 * std::sin(2.0 * juce::MathConstants<double>::pi * 220.0 * i / rate));
+        buffer.setSample(0, i, s);
+        buffer.setSample(1, i, s);
+    }
+    return buffer;
+}
+
+constexpr double kBurstSeconds = 0.25;
+constexpr double kTailSeconds = 3.0;
+
+/// The reverb tail's 90%-energy span in seconds, rendered at `rate`. Wet only,
+/// in looping delay mode with the diffuser and the feedback path out, so the
+/// tail is the reverb's own decay and nothing in the path is random.
+double reverbTailSpanAt(double rate) {
+    CloudsRig rig(rate);
+    rig.set(MutableCloudsPlugin::kMode, 2.0f);  // Looping Delay
+    rig.set(MutableCloudsPlugin::kPosition, 0.0f);
+    rig.set(MutableCloudsPlugin::kDensity, 0.0f);  // diffusion off in this mode
+    rig.set(MutableCloudsPlugin::kTexture, 0.5f);  // filters wide open
+    rig.set(MutableCloudsPlugin::kFeedback, 0.0f);
+    rig.set(MutableCloudsPlugin::kDryWet, 1.0f);
+    rig.set(MutableCloudsPlugin::kReverb, 0.5f);
+
+    auto buffer = burstThenSilence(rate, kBurstSeconds, kTailSeconds);
+    rig.render(buffer);
+    return tailEnergySpanSeconds(buffer, rate, secondsToSamples(kBurstSeconds, rate), 0.9);
+}
+
+}  // namespace
+
+TEST_CASE("Nimbus clocks its DSP at 32 kHz whatever the host rate", "[nimbus][clouds][resampler]") {
+    // 32 kHz is the one host rate at which both resampler steps are 1, so it is
+    // the rate the engine has always been fed correctly at. Every other rate
+    // has to reproduce it in real seconds.
+    const double at32k = reverbTailSpanAt(32000.0);
+    const double at44k = reverbTailSpanAt(44100.0);
+    const double at48k = reverbTailSpanAt(48000.0);
+
+    INFO("reverb 90% tail span: 32k=" << at32k << "s 44.1k=" << at44k << "s 48k=" << at48k << "s");
+    REQUIRE(at32k > 0.0);
+    REQUIRE(at44k > 0.0);
+    REQUIRE(at48k > 0.0);
+
+    // Steps swapped, the engine runs (host/32000)^2 fast - 1.9x at 44.1 kHz,
+    // 2.25x at 48 kHz. 5% is far inside that and far outside the difference
+    // between two correctly clocked runs.
+    CHECK(at44k == Catch::Approx(at32k).epsilon(0.05));
+    CHECK(at48k == Catch::Approx(at32k).epsilon(0.05));
+}
+
+TEST_CASE("Nimbus declares the priming delay it imposes on the dry path",
+          "[nimbus][clouds][latency]") {
+    constexpr double kRate = 48000.0;
+
+    CloudsRig rig(kRate);
+    // What the hosts compensate by: both take it off properties(), in seconds,
+    // once at construction.
+    const auto declared =
+        static_cast<int>(std::lround(rig.device.properties().latencySeconds * kRate));
+    rig.set(MutableCloudsPlugin::kMode, 2.0f);    // Looping Delay
+    rig.set(MutableCloudsPlugin::kDryWet, 0.0f);  // dry only: a clean delayed copy
+    rig.set(MutableCloudsPlugin::kReverb, 0.0f);
+    rig.set(MutableCloudsPlugin::kFeedback, 0.0f);
+
+    // The DSP holds its output at zero until it has cleared its buffers, and
+    // the resampler rings need their window filled.
+    juce::AudioBuffer<float> warmup(2, secondsToSamples(0.2, kRate));
+    warmup.clear();
+    rig.render(warmup);
+
+    const int impulseAt = 512;
+    juce::AudioBuffer<float> buffer(2, 2048);
+    buffer.clear();
+    buffer.setSample(0, impulseAt, 0.5f);
+    buffer.setSample(1, impulseAt, 0.5f);
+    rig.render(buffer);
+
+    // Energy centroid rather than the peak: the cubic interpolators spread the
+    // impulse over a few samples, and which one is highest moves with the phase
+    // the impulse lands on.
+    double weighted = 0.0;
+    double energy = 0.0;
+    for (int i = impulseAt; i < buffer.getNumSamples(); ++i) {
+        weighted += energyAt(buffer, i) * (i - impulseAt);
+        energy += energyAt(buffer, i);
+    }
+    REQUIRE(energy > 0.0);
+
+    const double measured = weighted / energy;
+    INFO("declared " << declared << " samples, measured " << measured);
+    CHECK(std::abs(measured - declared) <= 2.0);
+}


### PR DESCRIPTION
Closes #2365.

## The clock

`Resampler` documents `step = Fin/Fout` and implements it, but `prepare` set both steps the other way round: the input resampler, which reads host-rate data and produces 32 kHz, got `32000/host`, and the output one got `host/32000`. Elements has the same resampler the right way.

Throughput balanced either way, so nothing starved and dry pitch survived — which is why it was never heard as wrong. The engine's clock was not: it was fed `(host/32000)^2` more samples per real second than it assumes, 2.25x at 48 kHz and 1.9x at 44.1 kHz. Grain size and density, the reverb and diffuser decay, the looping delay length, the buffer's memory span and the feedback filter corner were all off by that factor, and only right on a 32 kHz host.

**Existing projects will change sound.** They were tuned against the wrong clock; this is the correct outcome.

## The latency

The device declared `latencySeconds` 0 while its output lags its input by a 32-sample grain block plus the resampler windows — 33 samples at 32 kHz, measured. Clouds mixes dry and wet internally, so the dry path is delayed too, and neither host was compensating for any of it. Declared in seconds because `properties()` is read once, at construction, before the host rate is known.

## Tests

`tests/devices/test_mutable_clouds.cpp` (new, `[nimbus]`), driving the device directly:

- **Rate.** The reverb tail's 90%-energy span has to be the same number of real seconds at 44.1 and 48 kHz as at 32 kHz — the one host rate whose steps are 1 either way round, so the one the engine was always fed correctly at. A cumulative integral rather than a level crossing, because the reverb's envelope ripples by several dB. Measured: 0.83597 s / 0.83603 s / 0.83594 s.
- **Latency.** The energy centroid of an impulse through the dry path has to land where `properties().latencySeconds` says. Measured 50.0 samples at 48 kHz against 50 declared.

Both verified negatively. Restoring the swapped steps: the spans become 0.836 / 0.372 / 0.199 s, and the impulse lands at 21.2 samples. Dropping the `latencySeconds` line: declared 0, measured 50.

## Test runs

- `magda_tests`: 3584 cases, all passed.
- `magda_juce_tests` "Real Project Corpus": `project.fmchain` — the corpus project that hosts a Nimbus — passes. `project.v1bounces` fails, and fails identically on `origin/dev/0.20.0` with these changes reverted.
- `magda_juce_tests` "Null Diff Corpus": `placement.grid` fails, also identically at base. Neither project contains a Nimbus.

Both of those are a red base, not this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018rAnjCekXfSQtpsr7jLtj5