### PR TITLE
Apply modernize-use-auto fixes across magda/

### DIFF
--- a/magda/agents/command_model.cpp
+++ b/magda/agents/command_model.cpp
@@ -31,25 +31,25 @@ namespace d = cmdmodel::data;
 // inputs the model sees).
 // ---------------------------------------------------------------------------
 bool isCore(char c) {
-    unsigned char u = static_cast<unsigned char>(c);
+    auto u = static_cast<unsigned char>(c);
     return (u >= 'A' && u <= 'Z') || (u >= 'a' && u <= 'z') || (u >= '0' && u <= '9') || c == '_' ||
            c == '\'' || c == '-';
 }
 
 bool isWordChar(char c) {  // Python regex \w (ASCII)
-    unsigned char u = static_cast<unsigned char>(c);
+    auto u = static_cast<unsigned char>(c);
     return (u >= 'A' && u <= 'Z') || (u >= 'a' && u <= 'z') || (u >= '0' && u <= '9') || c == '_';
 }
 
 char lowerCh(char c) {
-    unsigned char u = static_cast<unsigned char>(c);
+    auto u = static_cast<unsigned char>(c);
     if (u >= 'A' && u <= 'Z')
         return static_cast<char>(u - 'A' + 'a');
     return c;
 }
 
 char upperCh(char c) {
-    unsigned char u = static_cast<unsigned char>(c);
+    auto u = static_cast<unsigned char>(c);
     if (u >= 'a' && u <= 'z')
         return static_cast<char>(u - 'a' + 'A');
     return c;
@@ -91,7 +91,7 @@ std::string join(const std::vector<std::string>& parts, const std::string& sep) 
 bool isLowerWord(const std::string& w) {
     bool anyLower = false;
     for (char c : w) {
-        unsigned char u = static_cast<unsigned char>(c);
+        auto u = static_cast<unsigned char>(c);
         if (u >= 'A' && u <= 'Z')
             return false;
         if (u >= 'a' && u <= 'z')

--- a/magda/agents/command_model_onnx.cpp
+++ b/magda/agents/command_model_onnx.cpp
@@ -42,7 +42,7 @@ constexpr int kMaxLen = 64;  // subwords, matching model/data_encoder.py MAX_LEN
 // to command_model.cpp's tokenizer — both consume the same Python reference,
 // and tests/test_command_model.cpp locks that one to it.
 bool isCore(char c) {
-    unsigned char u = static_cast<unsigned char>(c);
+    auto u = static_cast<unsigned char>(c);
     return (u >= 'A' && u <= 'Z') || (u >= 'a' && u <= 'z') || (u >= '0' && u <= '9') || c == '_' ||
            c == '\'' || c == '-';
 }
@@ -50,7 +50,7 @@ bool isCore(char c) {
 std::string toLowerAscii(const std::string& s) {
     std::string out(s);
     for (auto& c : out) {
-        unsigned char u = static_cast<unsigned char>(c);
+        auto u = static_cast<unsigned char>(c);
         if (u >= 'A' && u <= 'Z')
             c = static_cast<char>(u - 'A' + 'a');
     }
@@ -233,7 +233,7 @@ CommandModel::Prediction CommandModelOnnx::predict(const std::string& text) cons
         canoned.push_back(canonForEncoder(w));
 
     const auto enc = impl_->tokenizer.encodeWords(canoned, kMaxLen);
-    const int64_t seq = static_cast<int64_t>(enc.inputIds.size());
+    const auto seq = static_cast<int64_t>(enc.inputIds.size());
     const std::array<int64_t, 2> shape{1, seq};
 
     auto& mem = impl_->memoryInfo;
@@ -250,7 +250,7 @@ CommandModel::Prediction CommandModelOnnx::predict(const std::string& text) cons
                                       inputs.size(), kOutputNames, 2);
 
     // intent: argmax over [1, n_intents]
-    const float* intentLogits = outputs[0].GetTensorData<float>();
+    const auto* intentLogits = outputs[0].GetTensorData<float>();
     const auto intentCount = outputs[0].GetTensorTypeAndShapeInfo().GetShape().back();
     int bestIntent = 0;
     for (int64_t i = 1; i < intentCount; ++i)
@@ -261,7 +261,7 @@ CommandModel::Prediction CommandModelOnnx::predict(const std::string& text) cons
 
     // slots: argmax per position over [1, seq, n_tags], read at each word's
     // FIRST subword so there is exactly one tag per word (see the header note).
-    const float* slotLogits = outputs[1].GetTensorData<float>();
+    const auto* slotLogits = outputs[1].GetTensorData<float>();
     const auto slotShape = outputs[1].GetTensorTypeAndShapeInfo().GetShape();
     const int64_t nTags = slotShape.back();
 

--- a/magda/agents/dsl_interpreter.cpp
+++ b/magda/agents/dsl_interpreter.cpp
@@ -1015,7 +1015,7 @@ bool Interpreter::executeSetTrack(const Params& params) {
 
         if (params.has("volume_db")) {
             double db = params.getFloat("volume_db");
-            float vol = static_cast<float>(std::pow(10.0, db / 20.0));
+            auto vol = static_cast<float>(std::pow(10.0, db / 20.0));
             tm.setTrackVolume(trackId, vol);
         }
 

--- a/magda/agents/gain_staging_agent.cpp
+++ b/magda/agents/gain_staging_agent.cpp
@@ -55,7 +55,7 @@ bool parseDecisionIndex(const juce::var& value, int& indexOut) {
     if (!isNumericVar(value))
         return false;
 
-    const double asDouble = static_cast<double>(value);
+    const auto asDouble = static_cast<double>(value);
     const double rounded = std::round(asDouble);
     if (std::abs(asDouble - rounded) > 0.000001)
         return false;

--- a/magda/agents/instruction_executor.cpp
+++ b/magda/agents/instruction_executor.cpp
@@ -543,7 +543,7 @@ void InstructionExecutor::applySetProps(int trackId, const juce::StringPairArray
         auto val = props.getValue(key, "");
         if (key == "vol" || key == "volume_db") {
             double db = val.getDoubleValue();
-            float vol = static_cast<float>(std::pow(10.0, db / 20.0));
+            auto vol = static_cast<float>(std::pow(10.0, db / 20.0));
             undo.executeCommand(std::make_unique<SetTrackVolumeCommand>(trackId, vol));
         } else if (key == "pan") {
             undo.executeCommand(std::make_unique<SetTrackPanCommand>(trackId, val.getFloatValue()));

--- a/magda/agents/unigram_tokenizer.cpp
+++ b/magda/agents/unigram_tokenizer.cpp
@@ -71,7 +71,7 @@ std::string metaspace(const std::string& word) {
 // Advance one UTF-8 code point; used so an unknown byte sequence is consumed
 // whole rather than split into invalid fragments.
 size_t utf8Advance(const std::string& s, size_t i) {
-    unsigned char c = static_cast<unsigned char>(s[i]);
+    auto c = static_cast<unsigned char>(s[i]);
     size_t len = 1;
     if ((c & 0xE0) == 0xC0)
         len = 2;

--- a/magda/daw/audio/AudioThumbnailManager.cpp
+++ b/magda/daw/audio/AudioThumbnailManager.cpp
@@ -293,16 +293,16 @@ void AudioThumbnailManager::drawWaveformFromSamples(
 
     const double sampleRate = reader->sampleRate;
     const juce::int64 totalFileLength = reader->lengthInSamples;
-    const juce::int64 startSample = juce::jlimit<juce::int64>(
+    const auto startSample = juce::jlimit<juce::int64>(
         0, totalFileLength, static_cast<juce::int64>(startTime * sampleRate));
-    const juce::int64 endSample = juce::jlimit<juce::int64>(
+    const auto endSample = juce::jlimit<juce::int64>(
         startSample, totalFileLength, static_cast<juce::int64>(endTime * sampleRate));
     const juce::int64 totalSamples = endSample - startSample;
 
     if (totalSamples <= 0)
         return;
 
-    const float midY = static_cast<float>(bounds.getCentreY());
+    const auto midY = static_cast<float>(bounds.getCentreY());
     const float halfHeight = static_cast<float>(height) * 0.5f * verticalZoom;
     const double samplesPerPixel = static_cast<double>(totalSamples) / width;
 
@@ -349,7 +349,7 @@ void AudioThumbnailManager::drawWaveformFromSamples(
                 float val = s0 + static_cast<float>(frac) * (s1 - s0);
 
                 float y = chMidY - val * chHalfHeight;
-                float px = static_cast<float>(bounds.getX() + x);
+                auto px = static_cast<float>(bounds.getX() + x);
 
                 if (x == 0)
                     path.startNewSubPath(px, y);
@@ -391,7 +391,7 @@ void AudioThumbnailManager::drawWaveformFromSamples(
             chunkBuffer.setSize(numChannels, maxChunk);
         }
 
-        const size_t w = static_cast<size_t>(width);
+        const auto w = static_cast<size_t>(width);
 
         for (int ch = 0; ch < numChannels; ++ch) {
             float chMidY = midY;
@@ -406,7 +406,7 @@ void AudioThumbnailManager::drawWaveformFromSamples(
             std::vector<float> maxValues(w);
 
             for (int x = 0; x < width; ++x) {
-                const juce::int64 colStart =
+                const auto colStart =
                     static_cast<juce::int64>(static_cast<double>(x) * totalSamples / width);
                 const juce::int64 colEnd = std::min(
                     static_cast<juce::int64>(static_cast<double>(x + 1) * totalSamples / width),

--- a/magda/daw/audio/automation/AutomationRecordingEngine.cpp
+++ b/magda/daw/audio/automation/AutomationRecordingEngine.cpp
@@ -480,7 +480,7 @@ void AutomationRecordingEngine::onTrackPropertyChanged(int trackId) {
         if (isNewLane) {
             ParameterInfo paramInfo = getParameterInfoForTarget(target);
             float seedDb = gainToDb(preSeedVolume);
-            double seedNorm =
+            auto seedNorm =
                 static_cast<double>(ParameterUtils::realToNormalized(seedDb, paramInfo));
             const auto* lane = autoMgr.getLane(laneId);
             if (lane && !lane->absolutePoints.empty()) {
@@ -496,8 +496,7 @@ void AutomationRecordingEngine::onTrackPropertyChanged(int trackId) {
 
         ParameterInfo paramInfo = getParameterInfoForTarget(target);
         float db = gainToDb(track->volume);
-        double normalizedValue =
-            static_cast<double>(ParameterUtils::realToNormalized(db, paramInfo));
+        auto normalizedValue = static_cast<double>(ParameterUtils::realToNormalized(db, paramInfo));
 
         DBG("[AutoRec] Volume hit: track=" << (int)tid << " vol=" << track->volume << " (" << db
                                            << " dB)"
@@ -522,7 +521,7 @@ void AutomationRecordingEngine::onTrackPropertyChanged(int trackId) {
 
         if (isNewLane) {
             ParameterInfo paramInfo = getParameterInfoForTarget(target);
-            double seedNorm =
+            auto seedNorm =
                 static_cast<double>(ParameterUtils::realToNormalized(preSeedPan, paramInfo));
             const auto* lane = autoMgr.getLane(laneId);
             if (lane && !lane->absolutePoints.empty()) {
@@ -534,7 +533,7 @@ void AutomationRecordingEngine::onTrackPropertyChanged(int trackId) {
         }
 
         ParameterInfo paramInfo = getParameterInfoForTarget(target);
-        double normalizedValue =
+        auto normalizedValue =
             static_cast<double>(ParameterUtils::realToNormalized(track->pan, paramInfo));
 
         DBG("[AutoRec] Pan hit: track=" << (int)tid << " pan=" << track->pan
@@ -555,7 +554,7 @@ void AutomationRecordingEngine::onTrackPropertyChanged(int trackId) {
         if (isNewLane) {
             ParameterInfo paramInfo = getParameterInfoForTarget(target);
             float seedDb = gainToDb(s.preSeedLevel);
-            double seedNorm =
+            auto seedNorm =
                 static_cast<double>(ParameterUtils::realToNormalized(seedDb, paramInfo));
             const auto* lane = autoMgr.getLane(laneId);
             if (lane && !lane->absolutePoints.empty()) {
@@ -568,8 +567,7 @@ void AutomationRecordingEngine::onTrackPropertyChanged(int trackId) {
 
         ParameterInfo paramInfo = getParameterInfoForTarget(target);
         float db = gainToDb(s.newLevel);
-        double normalizedValue =
-            static_cast<double>(ParameterUtils::realToNormalized(db, paramInfo));
+        auto normalizedValue = static_cast<double>(ParameterUtils::realToNormalized(db, paramInfo));
 
         if (!shouldThinPoint(laneId, beatTime, normalizedValue))
             recordPoint(laneId, beatTime, normalizedValue);
@@ -609,7 +607,7 @@ void AutomationRecordingEngine::onModParameterValueChanged(TrackId trackId,
     // Convert raw rate (Hz, etc.) to normalized 0..1 using the lane's stored
     // ParameterInfo so curve points are stored in the same space as draws.
     ParameterInfo info = getParameterInfoForTarget(target);
-    double normalizedValue = static_cast<double>(ParameterUtils::realToNormalized(value, info));
+    auto normalizedValue = static_cast<double>(ParameterUtils::realToNormalized(value, info));
 
     double beatTime = getCurrentBeatTime();
     if (shouldThinPoint(laneId, beatTime, normalizedValue))
@@ -660,7 +658,7 @@ void AutomationRecordingEngine::onMacroValueChanged(TrackId trackId, ChainScope 
     }
 
     double beatTime = getCurrentBeatTime();
-    double normalizedValue = static_cast<double>(value);  // Macros are already 0-1
+    auto normalizedValue = static_cast<double>(value);  // Macros are already 0-1
 
     if (shouldThinPoint(laneId, beatTime, normalizedValue))
         return;

--- a/magda/daw/audio/controllers/ControllerParamReader.cpp
+++ b/magda/daw/audio/controllers/ControllerParamReader.cpp
@@ -104,7 +104,7 @@ std::optional<float> DefaultControllerParamReader::readPluginParam(const Control
         return std::nullopt;
 
     const auto range = param->getValueRange();
-    const float span = static_cast<float>(range.getLength());
+    const auto span = static_cast<float>(range.getLength());
     if (span <= 0.0f)
         return std::nullopt;
 

--- a/magda/daw/audio/controllers/ControllerParamWriter.cpp
+++ b/magda/daw/audio/controllers/ControllerParamWriter.cpp
@@ -112,7 +112,7 @@ void DefaultControllerParamWriter::writePluginParam(const ControlTarget& target,
     // parameter's actual value range before writing — te::AutomatableParameter::
     // setParameter expects raw, not normalized.
     const auto range = param->getValueRange();
-    const float raw = static_cast<float>(range.getStart() + clamped * range.getLength());
+    const auto raw = static_cast<float>(range.getStart() + clamped * range.getLength());
     param->setParameterFromHost(raw, juce::sendNotificationSync);
 
     // Mirror the write into DeviceInfo and notify MAGDA listeners so param

--- a/magda/daw/audio/plugins/FaustInstrumentPlugin.cpp
+++ b/magda/daw/audio/plugins/FaustInstrumentPlugin.cpp
@@ -751,7 +751,7 @@ void FaustInstrumentPlugin::process(DeviceProcessContext& context) {
             continue;
         const float normalised =
             poolValues_[static_cast<size_t>(b.slotIndex)].load(std::memory_order_relaxed);
-        const float value = static_cast<float>(denormalizeForBinding(b, normalised));
+        const auto value = static_cast<float>(denormalizeForBinding(b, normalised));
         for (FAUSTFLOAT* zone : active->voiceZonesBySlot[static_cast<size_t>(b.slotIndex)]) {
             if (zone)
                 *zone = static_cast<FAUSTFLOAT>(value);

--- a/magda/daw/audio/plugins/MagdaSamplerPlugin.cpp
+++ b/magda/daw/audio/plugins/MagdaSamplerPlugin.cpp
@@ -339,7 +339,7 @@ void SamplerVoice::renderNextBlock(juce::AudioBuffer<float>& outputBuffer, int s
         }
 
         int pos0 = static_cast<int>(sourceSamplePosition);
-        float frac = static_cast<float>(sourceSamplePosition - pos0);
+        auto frac = static_cast<float>(sourceSamplePosition - pos0);
 
         // Stop at sample end (if set) or end of file — skip when looping
         if (!(loopEnabled && loopEndSample > loopStartSample)) {

--- a/magda/daw/audio/plugins/compiled/MagdaEqCompiledPlugin.cpp
+++ b/magda/daw/audio/plugins/compiled/MagdaEqCompiledPlugin.cpp
@@ -258,7 +258,7 @@ void MagdaEqCompiledPlugin::processAudio(DeviceProcessContext& context) {
         if (static_cast<int>(bandStates.size()) < hostChannels)
             bandStates.resize(static_cast<size_t>(hostChannels));
 
-    const float sampleRate = static_cast<float>(currentSampleRate());
+    const auto sampleRate = static_cast<float>(currentSampleRate());
     std::array<bool, kBandCount> bandEnabled{};
     std::array<RbjCoeffs, kBandCount> coeffs{};
     for (int band = 0; band < kBandCount; ++band) {

--- a/magda/daw/audio/plugins/engine/EngineMagdaDevice.cpp
+++ b/magda/daw/audio/plugins/engine/EngineMagdaDevice.cpp
@@ -126,7 +126,7 @@ class EngineMidiBufferView final : public DeviceMidiBuffer {
         // Walked to the back by swapping, which exchanges pointers and touches
         // no heap. A copy shift would realloc every entry it passed, and it was
         // only there because vector::erase moves.
-        for (std::size_t at = static_cast<std::size_t>(index); at + 1 < events_.size(); ++at)
+        for (auto at = static_cast<std::size_t>(index); at + 1 < events_.size(); ++at)
             std::swap(events_[at], events_[at + 1]);
 
         // The removed message is at the back now, and pop_back destroys it: the

--- a/magda/daw/audio/plugins/mutable/MutableCloudsPlugin.cpp
+++ b/magda/daw/audio/plugins/mutable/MutableCloudsPlugin.cpp
@@ -82,7 +82,7 @@ struct Resampler {
     bool pull(StereoRing& ring, float& oL, float& oR) {
         if (ring.count < 4)
             return false;
-        const float t = static_cast<float>(pos - 1.0);
+        const auto t = static_cast<float>(pos - 1.0);
         oL = cubic(ring.L(0), ring.L(1), ring.L(2), ring.L(3), t);
         oR = cubic(ring.R(0), ring.R(1), ring.R(2), ring.R(3), t);
         pos += step;

--- a/magda/daw/audio/plugins/mutable/MutableElementsPlugin.cpp
+++ b/magda/daw/audio/plugins/mutable/MutableElementsPlugin.cpp
@@ -195,7 +195,7 @@ struct MutableElementsPlugin::Impl {
             primed_ = true;
         }
         for (int i = 0; i < n; ++i) {
-            const float t = static_cast<float>(frac_);
+            const auto t = static_cast<float>(frac_);
             outL[i] = cubic(xL_, t);
             if (outR != nullptr)
                 outR[i] = cubic(xR_, t);

--- a/magda/daw/audio/plugins/mutable/MutableRingsPlugin.cpp
+++ b/magda/daw/audio/plugins/mutable/MutableRingsPlugin.cpp
@@ -191,7 +191,7 @@ struct MutableRingsPlugin::Impl {
             primed_ = true;
         }
         for (int i = 0; i < n; ++i) {
-            const float t = static_cast<float>(frac_);
+            const auto t = static_cast<float>(frac_);
             outL[i] = cubic(xL_, t);
             if (outR != nullptr)
                 outR[i] = cubic(xR_, t);

--- a/magda/daw/audio/session/ClipSynchronizer.cpp
+++ b/magda/daw/audio/session/ClipSynchronizer.cpp
@@ -142,7 +142,7 @@ bool syncFollowActionToTracktionClip(te::Clip& teClip, const ClipInfo& clip, dou
         changed = true;
     }
 
-    const double loops = static_cast<double>(loopCount);
+    const auto loops = static_cast<double>(loopCount);
     if (std::abs(teClip.followActionNumLoops.get() - loops) > 0.0001) {
         teClip.followActionNumLoops = loops;
         changed = true;
@@ -1469,8 +1469,8 @@ static void interpolateCCEvents(te::MidiList& sequence, const std::vector<EventT
             continue;
         }
 
-        double v1 = static_cast<double>(ev.value);
-        double v2 = static_cast<double>(next.value);
+        auto v1 = static_cast<double>(ev.value);
+        auto v2 = static_cast<double>(next.value);
 
         // Skip dense interpolation across constant-value segments: emitting
         // dozens of identical pitch-wheel/CC events every beat is pure waste

--- a/magda/daw/audio/transport/RampCurve.hpp
+++ b/magda/daw/audio/transport/RampCurve.hpp
@@ -21,9 +21,8 @@ namespace magda::daw::audio::ramp_curve {
  * point.
  */
 inline double applyRampCurve(double t, float depth, float skew, bool hardAngle = false) {
-    double d = static_cast<double>(juce::jlimit(-0.99f, 0.99f, depth));
-    double s =
-        static_cast<double>(juce::jlimit(0.01, 0.99, 0.5 + static_cast<double>(skew) * 0.49));
+    auto d = static_cast<double>(juce::jlimit(-0.99f, 0.99f, depth));
+    auto s = static_cast<double>(juce::jlimit(0.01, 0.99, 0.5 + static_cast<double>(skew) * 0.49));
 
     if (std::abs(d) < 0.001)
         return t;

--- a/magda/daw/core/AutomationManager.cpp
+++ b/magda/daw/core/AutomationManager.cpp
@@ -185,7 +185,7 @@ static std::optional<double> getCurrentTargetValueImpl(const AutomationTarget& t
                 if (mod->tempoSync) {
                     // Lane stores 0-based display index (TE ordinal − 1) so
                     // it never resolves "Hertz" (TE ordinal 0) at the bottom.
-                    float displayIdx =
+                    auto displayIdx =
                         static_cast<float>(syncDivisionToTeRateOrdinal(mod->syncDivision) - 1);
                     return static_cast<double>(
                         ParameterUtils::realToNormalized(displayIdx, paramInfo));
@@ -233,7 +233,7 @@ void AutomationManager::trackPropertyChanged(int trackId) {
 
     // When a track's volume or pan changes, update any automation lanes
     // that target those parameters (if they have points)
-    TrackId tid = static_cast<TrackId>(trackId);
+    auto tid = static_cast<TrackId>(trackId);
 
     for (auto& lane : lanes_) {
         // Only update lanes for this track

--- a/magda/daw/core/MidiNoteCommands.cpp
+++ b/magda/daw/core/MidiNoteCommands.cpp
@@ -112,7 +112,7 @@ std::vector<MidiNoteStartBeat> calculateBentMidiNoteStartBeats(
     }
 
     const int noteCount = static_cast<int>(validStarts.size());
-    const double ordinalDenom = static_cast<double>(noteCount - 1);
+    const auto ordinalDenom = static_cast<double>(noteCount - 1);
 
     std::vector<MidiNoteStartBeat> bentStarts;
     bentStarts.reserve(validStarts.size());

--- a/magda/daw/core/ParameterUtils.cpp
+++ b/magda/daw/core/ParameterUtils.cpp
@@ -649,7 +649,7 @@ std::optional<float> parseValue(const juce::String& text, const ParameterInfo& i
                 t = t.dropLastCharacters(percent.length()).trim();
             if (t.isEmpty())
                 return std::nullopt;
-            float parsed = static_cast<float>(t.getDoubleValue());
+            auto parsed = static_cast<float>(t.getDoubleValue());
             if (storesPercentAsUnitFraction(info))
                 parsed *= 0.01f;
             return clamp(parsed);
@@ -698,7 +698,7 @@ std::optional<float> parseValue(const juce::String& text, const ParameterInfo& i
             t = t.dropLastCharacters(percent.length()).trim();
         if (t.isEmpty())
             return std::nullopt;
-        float parsed = static_cast<float>(t.getDoubleValue());
+        auto parsed = static_cast<float>(t.getDoubleValue());
         if (storesPercentAsUnitFraction(info))
             parsed *= 0.01f;
         return clamp(parsed);

--- a/magda/daw/engine/TracktionEngineWrapperTracks.cpp
+++ b/magda/daw/engine/TracktionEngineWrapperTracks.cpp
@@ -44,7 +44,7 @@ void TracktionEngineWrapper::deleteTrack(const std::string& track_id) {
         // Drop any in-flight recording pass for this track so a deletion
         // mid-record cannot leave a stale preview/target behind.
         try {
-            TrackId magdaTrackId = static_cast<TrackId>(std::stoi(track_id));
+            auto magdaTrackId = static_cast<TrackId>(std::stoi(track_id));
             recordingPreviews_.erase(magdaTrackId);
             sessionSlotRecordingTargets_.erase(magdaTrackId);
         } catch (const std::exception&) {

--- a/magda/daw/media_db/ClapAudioEncoder.cpp
+++ b/magda/daw/media_db/ClapAudioEncoder.cpp
@@ -138,7 +138,7 @@ std::vector<float> ClapAudioEncoder::embed(const float* mono, int numSamples) {
             throw ClapEncoderError("Ort produced no output");
         }
 
-        const float* outData = outputs[0].GetTensorData<float>();
+        const auto* outData = outputs[0].GetTensorData<float>();
         float sumSq = 0.0F;
         for (int i = 0; i < impl_->outputDim; ++i) {
             sumSq += outData[i] * outData[i];

--- a/magda/daw/media_db/ClapTextEncoder.cpp
+++ b/magda/daw/media_db/ClapTextEncoder.cpp
@@ -95,7 +95,7 @@ std::vector<float> ClapTextEncoder::embedTokens(const std::vector<int64_t>& inpu
         throw ClapTextEncoderError("inputIds and attentionMask must be the same non-zero length");
     }
 
-    const int64_t seqLen = static_cast<int64_t>(inputIds.size());
+    const auto seqLen = static_cast<int64_t>(inputIds.size());
     const std::array<int64_t, 2> shape{1, seqLen};
 
     // ORT's input order matches what session.GetInputNameAllocated returned;
@@ -126,7 +126,7 @@ std::vector<float> ClapTextEncoder::embedTokens(const std::vector<int64_t>& inpu
         throw ClapTextEncoderError("Ort produced no output");
     }
 
-    const float* outData = outputs[0].GetTensorData<float>();
+    const auto* outData = outputs[0].GetTensorData<float>();
     std::vector<float> result(outData, outData + impl_->outputDim);
 
     // The exported text encoder already L2-normalizes via the wrapper from

--- a/magda/daw/media_db/MediaDbZeroShotTags.cpp
+++ b/magda/daw/media_db/MediaDbZeroShotTags.cpp
@@ -137,7 +137,7 @@ void l2NormalizeInPlace(float* v, std::size_t n) {
     for (std::size_t i = 0; i < n; ++i) {
         sumSq += static_cast<double>(v[i]) * static_cast<double>(v[i]);
     }
-    const float norm = static_cast<float>(std::sqrt(sumSq));
+    const auto norm = static_cast<float>(std::sqrt(sumSq));
     if (norm <= 0.0F) {
         return;
     }
@@ -232,7 +232,7 @@ std::vector<std::pair<std::string, float>> ZeroShotTagger::scoreEmbedding(
             dot += static_cast<double>(promptMatrix_[rowStart + j]) *
                    static_cast<double>(audioEmbedding[j]);
         }
-        const float score = static_cast<float>(dot);
+        const auto score = static_cast<float>(dot);
         if (score >= threshold) {
             hits.emplace_back(labels_[i], score);
         }

--- a/magda/daw/music/ChordEngine.cpp
+++ b/magda/daw/music/ChordEngine.cpp
@@ -156,7 +156,7 @@ Chord ChordEngine::detect(const std::vector<ChordNote>& heldNotes) const {
     std::vector<ChordCandidate> candidates;
 
     for (int rootOffset = 0; rootOffset < 12; rootOffset++) {
-        ChordRoot candidateRoot = static_cast<ChordRoot>(rootOffset);
+        auto candidateRoot = static_cast<ChordRoot>(rootOffset);
 
         std::vector<ChordQuality> qualities = {
             ChordQuality::Major,     ChordQuality::Minor,     ChordQuality::Diminished,
@@ -502,7 +502,7 @@ std::vector<std::pair<juce::String, float>> ChordEngine::findChordsFromNotes(
                 unionSet.empty() ? 0.0 : static_cast<double>(intersection.size()) / unionSet.size();
 
             if (similarity >= 0.5) {
-                ChordRoot candidateRoot = static_cast<ChordRoot>(rootOffset);
+                auto candidateRoot = static_cast<ChordRoot>(rootOffset);
                 ChordSpec spec(candidateRoot, quality, 0);
                 juce::String chordName = chordSpecToString(spec, false);
                 results.emplace_back(chordName, static_cast<float>(similarity));

--- a/magda/daw/stem_separation/DemucsSeparator.cpp
+++ b/magda/daw/stem_separation/DemucsSeparator.cpp
@@ -102,7 +102,7 @@ struct DemucsSeparator::Impl {
             info.GetElementCount() != count)
             throw std::runtime_error("Demucs model returned an unexpected output shape");
 
-        const float* data = outputs[0].GetTensorData<float>();
+        const auto* data = outputs[0].GetTensorData<float>();
         stemsOut.assign(data, data + count);
     }
 };

--- a/magda/daw/stem_separation/SpleeterSeparator.cpp
+++ b/magda/daw/stem_separation/SpleeterSeparator.cpp
@@ -91,7 +91,7 @@ struct SpleeterSeparator::Impl {
             info.GetElementCount() != x.size())
             throw std::runtime_error("Spleeter model returned an unexpected output shape");
 
-        const float* data = outputs[0].GetTensorData<float>();
+        const auto* data = outputs[0].GetTensorData<float>();
         return {data, data + x.size()};
     }
 };

--- a/magda/daw/transcription/BasicPitchPostprocess.cpp
+++ b/magda/daw/transcription/BasicPitchPostprocess.cpp
@@ -150,7 +150,7 @@ std::vector<int> pitchBendsForNote(const std::vector<float>& contour, int startF
         for (int c = 0; c < nCols; ++c) {
             const int gIdx = gStart + c;
             const double g = (gIdx >= 0 && gIdx < gEnd) ? gaussian[static_cast<size_t>(gIdx)] : 0.0;
-            const float val = static_cast<float>(static_cast<double>(row[freqStartIdx + c]) * g);
+            const auto val = static_cast<float>(static_cast<double>(row[freqStartIdx + c]) * g);
             if (val > bestVal) {
                 bestVal = val;
                 bestCol = c;

--- a/magda/daw/transcription/BasicPitchTranscriber.cpp
+++ b/magda/daw/transcription/BasicPitchTranscriber.cpp
@@ -148,9 +148,9 @@ struct BasicPitchTranscriber::Impl {
         Ort::RunOptions runOpts;
         auto outputs = session.Run(runOpts, inputNames, &tensor, 1, outputNames, 3);
 
-        const float* noteData = outputs[0].GetTensorData<float>();
-        const float* onsetData = outputs[1].GetTensorData<float>();
-        const float* contourData = outputs[2].GetTensorData<float>();
+        const auto* noteData = outputs[0].GetTensorData<float>();
+        const auto* onsetData = outputs[1].GetTensorData<float>();
+        const auto* contourData = outputs[2].GetTensorData<float>();
 
         note.insert(note.end(), noteData,
                     noteData + static_cast<size_t>(bp::kAnnotNFrames) * bp::kNoteFreqBins);

--- a/magda/daw/ui/components/automation/AutomationCurveEditor.cpp
+++ b/magda/daw/ui/components/automation/AutomationCurveEditor.cpp
@@ -262,7 +262,7 @@ void AutomationCurveEditor::paintGrid(juce::Graphics& g) {
     }
 
     auto bounds = getLocalBounds();
-    float width = static_cast<float>(bounds.getWidth());
+    auto width = static_cast<float>(bounds.getWidth());
 
     // For bipolar parameters the neutral-value line (0 dB, 0 st, …) should
     // read as the rest position. Draw it noticeably brighter than the rest

--- a/magda/daw/ui/components/automation/AutomationLaneComponent.cpp
+++ b/magda/daw/ui/components/automation/AutomationLaneComponent.cpp
@@ -777,7 +777,7 @@ void AutomationLaneComponent::paintScaleLabelsFor(juce::Graphics& g, juce::Recta
             // Clamp to range and convert back to normalized for positioning.
             double clamped = juce::jlimit(static_cast<double>(paramInfo.minValue),
                                           static_cast<double>(paramInfo.maxValue), realValue);
-            double normValue = static_cast<double>(
+            auto normValue = static_cast<double>(
                 ParameterUtils::realToNormalized(static_cast<float>(clamped), paramInfo));
             int y = area.getY() + normToYOffset(normValue);
 

--- a/magda/daw/ui/components/automation/AutomationLaneHeader.cpp
+++ b/magda/daw/ui/components/automation/AutomationLaneHeader.cpp
@@ -404,7 +404,7 @@ void paintAutomationLaneHeader(juce::Graphics& g, const AutomationLaneInfo& lane
         int contentBottom =
             y + laneHeight - AutomationLaneComponent::RESIZE_HANDLE_HEIGHT - curvePadding;
         int contentHeight = contentBottom - contentTop;
-        float rightEdge = static_cast<float>(width);
+        auto rightEdge = static_cast<float>(width);
         constexpr float tickLen = 5.0f;
 
         if (contentHeight > 20) {
@@ -543,7 +543,7 @@ void paintAutomationLaneHeader(juce::Graphics& g, const AutomationLaneInfo& lane
                 if (maxLabels == 1) {
                     thinned.push_back(gridValues[gridValues.size() / 2]);
                 } else {
-                    const double srcMax = static_cast<double>(gridValues.size() - 1);
+                    const auto srcMax = static_cast<double>(gridValues.size() - 1);
                     for (int i = 0; i < maxLabels; ++i) {
                         int srcIdx = static_cast<int>(
                             std::round(static_cast<double>(i) * srcMax / (maxLabels - 1)));

--- a/magda/daw/ui/components/chain/ai/AIPanelComponent.cpp
+++ b/magda/daw/ui/components/chain/ai/AIPanelComponent.cpp
@@ -388,7 +388,7 @@ void AIPanelComponent::paint(juce::Graphics& g) {
     if (mcpStripVisible_ && !mcpStripBounds_.isEmpty()) {
         const float r = 6.0f;
         const float cx = static_cast<float>(mcpStripBounds_.getX()) + r * 0.5f + 2.0f;
-        const float cy = static_cast<float>(mcpStripBounds_.getCentreY());
+        const auto cy = static_cast<float>(mcpStripBounds_.getCentreY());
         const auto dot = !mcpEnabled_
                              ? DarkTheme::getColour(DarkTheme::TEXT_PRIMARY).withAlpha(0.3f)
                              : (mcpRunning_ ? juce::Colours::limegreen

--- a/magda/daw/ui/components/chain/compiled/CompiledClipperCurveView.cpp
+++ b/magda/daw/ui/components/chain/compiled/CompiledClipperCurveView.cpp
@@ -109,7 +109,7 @@ void CompiledClipperCurveView::timerCallback() {
     };
 
     float drive = driveDb_;
-    float modeF = static_cast<float>(mode_);
+    auto modeF = static_cast<float>(mode_);
 
     if (compiledPlugin_ != nullptr) {
         drive = readPluginSlot(Clip::kDriveSlot, drive);

--- a/magda/daw/ui/components/chain/compiled/CompiledEqCurveView.cpp
+++ b/magda/daw/ui/components/chain/compiled/CompiledEqCurveView.cpp
@@ -744,7 +744,7 @@ void CompiledEqCurveView::drawSpectrumOverlay(juce::Graphics& g, juce::Rectangle
     if (sampleRate <= 0.0)
         return;
 
-    const float binHz = static_cast<float>(sampleRate / static_cast<double>(kSpectrumFftSize));
+    const auto binHz = static_cast<float>(sampleRate / static_cast<double>(kSpectrumFftSize));
     auto dbToSpectrumY = [area](float db) {
         const float t = (db - kSpectrumMinDb) / (kSpectrumMaxDb - kSpectrumMinDb);
         return area.getBottom() - juce::jlimit(0.0f, 1.0f, t) * area.getHeight();

--- a/magda/daw/ui/components/chain/compiled/CompiledFlangerCurveView.cpp
+++ b/magda/daw/ui/components/chain/compiled/CompiledFlangerCurveView.cpp
@@ -180,8 +180,7 @@ void CompiledFlangerCurveView::paint(juce::Graphics& g) {
     }
 
     // Current delay time from LFO position.
-    const float lfoBi =
-        static_cast<float>(std::sin(lfoPhase_ * juce::MathConstants<double>::twoPi));
+    const auto lfoBi = static_cast<float>(std::sin(lfoPhase_ * juce::MathConstants<double>::twoPi));
     const float delayMs = kCenterMs + lfoBi * depth_ * kSwingMs;
     const float delaySec = delayMs / 1000.0f;
 

--- a/magda/daw/ui/components/chain/compiled/CompiledMultibandCurveView.cpp
+++ b/magda/daw/ui/components/chain/compiled/CompiledMultibandCurveView.cpp
@@ -670,7 +670,7 @@ void CompiledMultibandCurveView::mouseWheelMove(const juce::MouseEvent& e,
     const bool fine = gesture.type == magda::GestureActionType::AdjustValueFine ||
                       gesture.type == magda::GestureActionType::AdjustSecondaryValueFine;
     const float step = fine ? 0.125f : 0.25f;
-    const float y = static_cast<float>(e.y);
+    const auto y = static_cast<float>(e.y);
     const float upperY = dbToY(upperThresholdDb_[idx]);
     const float lowerY = dbToY(lowerThresholdDb_[idx]);
     const bool aboveZone = y < (upperY + lowerY) * 0.5f;

--- a/magda/daw/ui/components/chain/compiled/CompiledRingModCurveView.cpp
+++ b/magda/daw/ui/components/chain/compiled/CompiledRingModCurveView.cpp
@@ -33,7 +33,7 @@ float freqToX(float hz, const juce::Rectangle<float>& plot) {
 // Bipolar carrier sample given a phase in [0,1). Mirrors the DSP's
 // carrierAt(off) selectn over Sine / Triangle / Square.
 float carrierSample(int shape, double phase) {
-    const float p = static_cast<float>(phase - std::floor(phase));
+    const auto p = static_cast<float>(phase - std::floor(phase));
     switch (shape) {
         case 1:
             return 4.0f * std::abs(p - 0.5f) - 1.0f;

--- a/magda/daw/ui/components/chain/custom_ui/DrumVoiceUI.cpp
+++ b/magda/daw/ui/components/chain/custom_ui/DrumVoiceUI.cpp
@@ -279,7 +279,7 @@ void DrumVoiceUI::drawEnvelope(juce::Graphics& g, juce::Rectangle<int> area, con
         (s.attackSlot >= 0 && s.attackSlot < static_cast<int>(controls_.size()))
             ? static_cast<float>(controls_[static_cast<size_t>(s.attackSlot)].slider->getValue())
             : 0.0f;
-    const float decayMs =
+    const auto decayMs =
         static_cast<float>(controls_[static_cast<size_t>(s.decaySlot)].slider->getValue());
 
     // Curve knob (-50..50) -> decay exponent 8^(-c/50), matching the dsp. 0 (or no
@@ -347,7 +347,7 @@ bool DrumVoiceUI::envHandles(int i, juce::Point<float>& peak, juce::Point<float>
         (s.attackSlot >= 0 && s.attackSlot < static_cast<int>(controls_.size()))
             ? static_cast<float>(controls_[static_cast<size_t>(s.attackSlot)].slider->getValue())
             : 0.0f;
-    const float dMs =
+    const auto dMs =
         static_cast<float>(controls_[static_cast<size_t>(s.decaySlot)].slider->getValue());
     const float xA = r.getX() + r.getWidth() * (aMs / axis);
     const float xD = juce::jmin(r.getRight(), r.getX() + r.getWidth() * ((aMs + dMs) / axis));
@@ -431,7 +431,7 @@ void DrumVoiceUI::mouseWheelMove(const juce::MouseEvent& e, const juce::MouseWhe
             continue;
         if (!sectionEnvAreas_[static_cast<size_t>(i)].toFloat().contains(e.position))
             continue;
-        const float cur =
+        const auto cur =
             static_cast<float>(controls_[static_cast<size_t>(s.curveSlot)].slider->getValue());
         // Scroll down bends the curve down (toward fast/negative); up = swelled/positive.
         const float delta = gesture.magnitude * 60.0f;

--- a/magda/daw/ui/components/chain/custom_ui/HaloUI.cpp
+++ b/magda/daw/ui/components/chain/custom_ui/HaloUI.cpp
@@ -152,10 +152,10 @@ void HaloUI::paint(juce::Graphics& g) {
         g.setColour(kBorder);
         g.drawRoundedRectangle(modalVizArea_.toFloat().reduced(0.5f), 4.0f, 1.0f);
         auto b = modalVizArea_.reduced(14, 22);
-        const float structure = (float)controls_[kStructure].slider->getValue();
-        const float brightness = (float)controls_[kBrightness].slider->getValue();
-        const float damping = (float)controls_[kDamping].slider->getValue();
-        const float position = (float)controls_[kPosition].slider->getValue();
+        const auto structure = (float)controls_[kStructure].slider->getValue();
+        const auto brightness = (float)controls_[kBrightness].slider->getValue();
+        const auto damping = (float)controls_[kDamping].slider->getValue();
+        const auto position = (float)controls_[kPosition].slider->getValue();
 
         const float rolloff = juce::jmap(brightness, 0.0f, 1.0f, 0.80f, 0.985f);
         const float level = juce::jmap(damping, 0.0f, 1.0f, 0.5f, 1.0f);
@@ -163,7 +163,7 @@ void HaloUI::paint(juce::Graphics& g) {
         const float bw = b.getWidth() / static_cast<float>(n);
         g.setColour(kAccent.withAlpha(0.75f));
         for (int i = 0; i < n; ++i) {
-            const float harmonic = static_cast<float>(i + 1);
+            const auto harmonic = static_cast<float>(i + 1);
             const float comb = std::abs(
                 std::sin(juce::MathConstants<float>::pi * harmonic * (0.02f + 0.48f * position)));
             const float inharm =

--- a/magda/daw/ui/components/chain/custom_ui/MateriaUI.cpp
+++ b/magda/daw/ui/components/chain/custom_ui/MateriaUI.cpp
@@ -206,9 +206,9 @@ void MateriaUI::paint(juce::Graphics& g) {
         g.setColour(cStrike);
         g.fillEllipse(juce::Rectangle<float>(8, 8).withCentre(strike));
 
-        const float wBow = (float)controls_[kBow].slider->getValue();
-        const float wBlow = (float)controls_[kBlow].slider->getValue();
-        const float wStrike = (float)controls_[kStrike].slider->getValue();
+        const auto wBow = (float)controls_[kBow].slider->getValue();
+        const auto wBlow = (float)controls_[kBlow].slider->getValue();
+        const auto wStrike = (float)controls_[kStrike].slider->getValue();
         const float sum = wBow + wBlow + wStrike;
         juce::Point<float> dot = sum > 1.0e-4f
                                      ? (bow * wBow + blow * wBlow + strike * wStrike) / sum
@@ -236,10 +236,10 @@ void MateriaUI::paint(juce::Graphics& g) {
         g.setColour(kBorder);
         g.drawRoundedRectangle(modalVizArea_.toFloat().reduced(0.5f), 4.0f, 1.0f);
         auto b = modalVizArea_.reduced(12, 16);
-        const float geometry = (float)controls_[kGeometry].slider->getValue();
-        const float brightness = (float)controls_[kBrightness].slider->getValue();
-        const float damping = (float)controls_[kDamping].slider->getValue();
-        const float position = (float)controls_[kPosition].slider->getValue();
+        const auto geometry = (float)controls_[kGeometry].slider->getValue();
+        const auto brightness = (float)controls_[kBrightness].slider->getValue();
+        const auto damping = (float)controls_[kDamping].slider->getValue();
+        const auto position = (float)controls_[kPosition].slider->getValue();
 
         const float rolloff = juce::jmap(brightness, 0.0f, 1.0f, 0.80f, 0.985f);
         const float level = juce::jmap(damping, 0.0f, 1.0f, 0.45f, 1.0f);
@@ -247,7 +247,7 @@ void MateriaUI::paint(juce::Graphics& g) {
         const float bw = b.getWidth() / static_cast<float>(n);
         g.setColour(kReso.withAlpha(0.6f));
         for (int i = 0; i < n; ++i) {
-            const float harmonic = static_cast<float>(i + 1);
+            const auto harmonic = static_cast<float>(i + 1);
             const float comb = std::abs(
                 std::sin(juce::MathConstants<float>::pi * harmonic * (0.02f + 0.48f * position)));
             const float structure =

--- a/magda/daw/ui/components/chain/custom_ui/NimbusUI.cpp
+++ b/magda/daw/ui/components/chain/custom_ui/NimbusUI.cpp
@@ -179,10 +179,10 @@ void NimbusUI::paintBuffer(juce::Graphics& g) {
     }
     const float life = haveAudio ? (0.22f + 0.78f * energy) : 0.5f;  // gentle idle baseline
 
-    const float position = (float)controls_[kPosition].slider->getValue();
-    const float size = (float)controls_[kSize].slider->getValue();
-    const float density = (float)controls_[kDensity].slider->getValue();
-    const float texture = (float)controls_[kTexture].slider->getValue();
+    const auto position = (float)controls_[kPosition].slider->getValue();
+    const auto size = (float)controls_[kSize].slider->getValue();
+    const auto density = (float)controls_[kDensity].slider->getValue();
+    const auto texture = (float)controls_[kTexture].slider->getValue();
 
     // Cloud drifts horizontally with Position, widens with Size, spreads and
     // jitters with Texture, thickens with Density.

--- a/magda/daw/ui/components/chain/custom_ui/PolyStepSequencerUI.cpp
+++ b/magda/daw/ui/components/chain/custom_ui/PolyStepSequencerUI.cpp
@@ -50,8 +50,8 @@ void drawStepRuler(juce::Graphics& g, juce::Rectangle<int> timelineArea,
     g.setColour(DarkTheme::getColour(DarkTheme::BACKGROUND).brighter(0.04f));
     g.fillRect(timelineArea);
 
-    const float top = static_cast<float>(timelineArea.getY());
-    const float bottom = static_cast<float>(timelineArea.getBottom());
+    const auto top = static_cast<float>(timelineArea.getY());
+    const auto bottom = static_cast<float>(timelineArea.getBottom());
 
     // Highlight the playing step.
     if (playStep >= 0 && playStep < count) {
@@ -460,8 +460,8 @@ class PolyStepSequencerUI::KeysView : public PolyStepSequencerUI::PatternView {
 
         g.setColour(canShift ? DarkTheme::getTextColour()
                              : DarkTheme::getSecondaryTextColour().withAlpha(0.3f));
-        const float cx = static_cast<float>(btn.getCentreX());
-        const float cy = static_cast<float>(btn.getCentreY());
+        const auto cx = static_cast<float>(btn.getCentreX());
+        const auto cy = static_cast<float>(btn.getCentreY());
         constexpr float arrowSize = 4.0f;
         juce::Path arrow;
         if (isUp) {
@@ -490,8 +490,8 @@ class PolyStepSequencerUI::KeysView : public PolyStepSequencerUI::PatternView {
 
         g.setColour(enabled ? DarkTheme::getTextColour()
                             : DarkTheme::getSecondaryTextColour().withAlpha(0.3f));
-        const float cx = static_cast<float>(btn.getCentreX());
-        const float cy = static_cast<float>(btn.getCentreY());
+        const auto cx = static_cast<float>(btn.getCentreX());
+        const auto cy = static_cast<float>(btn.getCentreY());
         constexpr float s = 3.0f;
         g.drawLine(cx - s, cy, cx + s, cy, 1.0f);  // minus / plus horizontal bar
         if (isIn)
@@ -967,8 +967,8 @@ class PolyStepSequencerUI::DrumLanesView : public PolyStepSequencerUI::PatternVi
 
         g.setColour(canShift ? DarkTheme::getTextColour()
                              : DarkTheme::getSecondaryTextColour().withAlpha(0.3f));
-        const float cx = static_cast<float>(btn.getCentreX());
-        const float cy = static_cast<float>(btn.getCentreY());
+        const auto cx = static_cast<float>(btn.getCentreX());
+        const auto cy = static_cast<float>(btn.getCentreY());
         constexpr float arrowSize = 4.0f;
         juce::Path arrow;
         if (isUp) {

--- a/magda/daw/ui/components/chain/custom_ui/SamplerUI.cpp
+++ b/magda/daw/ui/components/chain/custom_ui/SamplerUI.cpp
@@ -620,10 +620,10 @@ void SamplerUI::syncEnvGraph() {
         i.paramIndex = idx;
         return i;
     };
-    const float a = static_cast<float>(attackSlider_.getValue());
-    const float d = static_cast<float>(decaySlider_.getValue());
-    const float s = static_cast<float>(sustainSlider_.getValue());
-    const float r = static_cast<float>(releaseSlider_.getValue());
+    const auto a = static_cast<float>(attackSlider_.getValue());
+    const auto d = static_cast<float>(decaySlider_.getValue());
+    const auto s = static_cast<float>(sustainSlider_.getValue());
+    const auto r = static_cast<float>(releaseSlider_.getValue());
     envGraph_.setStage(AdsrGraph::Attack, 0, timeInfo(0.001f, 5.0f, 0, a), a);
     envGraph_.setStage(AdsrGraph::Decay, 1, timeInfo(0.001f, 5.0f, 1, d), d);
     magda::ParameterInfo si;
@@ -639,7 +639,7 @@ void SamplerUI::syncEnvGraph() {
 float SamplerUI::secondsToPixelX(double seconds, juce::Rectangle<int> waveArea) const {
     if (sampleLength_ <= 0.0)
         return static_cast<float>(waveArea.getX());
-    float x =
+    auto x =
         static_cast<float>(waveArea.getX() + (seconds - scrollOffsetSeconds_) * pixelsPerSecond_);
     // Clamp so rightmost markers remain visible within the clip region
     return juce::jmin(x, static_cast<float>(waveArea.getRight() - 1));
@@ -759,7 +759,7 @@ void SamplerUI::mouseDrag(const juce::MouseEvent& e) {
     }
 
     if (currentDrag_ == DragTarget::Scroll) {
-        double pixelDelta = static_cast<double>(e.getDistanceFromDragStartX());
+        auto pixelDelta = static_cast<double>(e.getDistanceFromDragStartX());
         double timeDelta = pixelDelta / pixelsPerSecond_;
         double visibleDuration = static_cast<double>(waveArea.getWidth()) / pixelsPerSecond_;
         double maxScroll = juce::jmax(0.0, sampleLength_ - visibleDuration);
@@ -814,7 +814,7 @@ void SamplerUI::mouseDrag(const juce::MouseEvent& e) {
     }
 
     if (currentDrag_ == DragTarget::LoopRegion) {
-        double pixelDelta = static_cast<double>(e.getDistanceFromDragStartX());
+        auto pixelDelta = static_cast<double>(e.getDistanceFromDragStartX());
         double timeDelta = pixelDelta / pixelsPerSecond_;
         double regionLen = loopDragStartR_ - loopDragStartL_;
 

--- a/magda/daw/ui/components/chain/custom_ui/SpectrumAnalyzerUI.cpp
+++ b/magda/daw/ui/components/chain/custom_ui/SpectrumAnalyzerUI.cpp
@@ -339,7 +339,7 @@ void SpectrumAnalyzerUI::pollOverlayData() {
     fft_->performFrequencyOnlyForwardTransform(overlayScratch_.data());
 
     const float norm = 2.0f / static_cast<float>(fftSize_);
-    const float binHz = static_cast<float>(sr / static_cast<double>(fftSize_));
+    const auto binHz = static_cast<float>(sr / static_cast<double>(fftSize_));
     for (int i = 0; i < numBins_; ++i) {
         const float mag = overlayScratch_[static_cast<size_t>(i)] * norm;
         float db = 20.0f * std::log10(std::max(mag, 1.0e-6f));
@@ -604,7 +604,7 @@ void SpectrumAnalyzerUI::timerCallback() {
 
     const float norm = 2.0f / static_cast<float>(fftSize_);
     const double sr = telemetry_->sampleRate();
-    const float binHz = static_cast<float>(sr / static_cast<double>(fftSize_));
+    const auto binHz = static_cast<float>(sr / static_cast<double>(fftSize_));
     for (int i = 0; i < numBins_; ++i) {
         const float mag = fftData_[static_cast<size_t>(i)] * norm;
         float db = 20.0f * std::log10(std::max(mag, 1.0e-6f));
@@ -712,7 +712,7 @@ void SpectrumAnalyzerUI::paint(juce::Graphics& g) {
         // and smoothing. Drawn in a neutral colour, secondary to this track.
         if (overlayValid_ && !overlaySmoothedDb_.empty()) {
             const double sr = (telemetry_ != nullptr) ? telemetry_->sampleRate() : 44100.0;
-            const float binHz = static_cast<float>(sr / static_cast<double>(fftSize_));
+            const auto binHz = static_cast<float>(sr / static_cast<double>(fftSize_));
             juce::Path op;
             bool started = false;
             for (int i = 1; i < numBins_; ++i) {  // skip DC
@@ -754,7 +754,7 @@ void SpectrumAnalyzerUI::paint(juce::Graphics& g) {
     }
 
     const double sr = (telemetry_ != nullptr) ? telemetry_->sampleRate() : 44100.0;
-    const float binHz = static_cast<float>(sr / static_cast<double>(fftSize_));
+    const auto binHz = static_cast<float>(sr / static_cast<double>(fftSize_));
 
     auto buildPath = [&](const std::vector<float>& db) {
         juce::Path p;

--- a/magda/daw/ui/components/chain/custom_ui/StepSequencerUI.cpp
+++ b/magda/daw/ui/components/chain/custom_ui/StepSequencerUI.cpp
@@ -461,8 +461,8 @@ void StepSequencerUI::drawTimeline(juce::Graphics& g, juce::Rectangle<int> area)
 
     const int count = pattern_.playingLength();
     const float colW = static_cast<float>(area.getWidth()) / static_cast<float>(count);
-    const float top = static_cast<float>(area.getY());
-    const float bottom = static_cast<float>(area.getBottom());
+    const auto top = static_cast<float>(area.getY());
+    const auto bottom = static_cast<float>(area.getBottom());
 
     g.setColour(DarkTheme::getColour(DarkTheme::BACKGROUND).brighter(0.04f));
     g.fillRect(area);
@@ -552,7 +552,7 @@ void StepSequencerUI::drawAccentRow(juce::Graphics& g, juce::Rectangle<int> area
     g.setColour(DarkTheme::getSecondaryTextColour());
     g.drawText("ACC", area.removeFromLeft(24), juce::Justification::centredLeft);
 
-    float startX = static_cast<float>(area.getX());
+    auto startX = static_cast<float>(area.getX());
     boxW = static_cast<float>(area.getWidth()) / static_cast<float>(count);
 
     for (int i = 0; i < count; ++i) {
@@ -622,7 +622,7 @@ void StepSequencerUI::drawKeyboard(juce::Graphics& g, juce::Rectangle<int> area)
     static constexpr int NUM_OCTAVES = 2;
     int totalWhiteKeys = WHITE_KEYS_PER_OCTAVE * NUM_OCTAVES;
     float whiteKeyW = static_cast<float>(area.getWidth()) / static_cast<float>(totalWhiteKeys);
-    float whiteKeyH = static_cast<float>(area.getHeight());
+    auto whiteKeyH = static_cast<float>(area.getHeight());
     float blackKeyW = whiteKeyW * 0.65f;
     float blackKeyH = whiteKeyH * 0.6f;
 

--- a/magda/daw/ui/components/chain/drum_grid/DeviceSlotDrumGridBridge.cpp
+++ b/magda/daw/ui/components/chain/drum_grid/DeviceSlotDrumGridBridge.cpp
@@ -258,8 +258,8 @@ std::optional<juce::Point<float>> getControllerIndicatorAnchor(bool isDrumGrid, 
         return std::nullopt;
 
     const auto modBounds = modButton->getBounds();
-    const float textStartX = static_cast<float>(modBounds.getRight() + 4);
-    const float textCentreY = static_cast<float>(modBounds.getCentreY());
+    const auto textStartX = static_cast<float>(modBounds.getRight() + 4);
+    const auto textCentreY = static_cast<float>(modBounds.getCentreY());
 
     auto font = FontManager::getInstance().getMicrogrammaFont(11.0f);
     juce::GlyphArrangement glyphs;

--- a/magda/daw/ui/components/chain/drum_grid/DrumGridUI.cpp
+++ b/magda/daw/ui/components/chain/drum_grid/DrumGridUI.cpp
@@ -669,8 +669,8 @@ void DrumGridUI::paint(juce::Graphics& g) {
         bool selectedPadHasContent =
             padInfos_[static_cast<size_t>(selectedPad_)].sampleName.isNotEmpty();
         auto divArea = getLocalBounds().reduced(6);
-        float top = static_cast<float>(divArea.getY());
-        float bottom = static_cast<float>(divArea.getBottom());
+        auto top = static_cast<float>(divArea.getY());
+        auto bottom = static_cast<float>(divArea.getBottom());
         g.setColour(DarkTheme::getColour(DarkTheme::BORDER));
         if (selectedPadHasContent) {
             int detailLeft = padChainPanel_.getX() - kGap / 2;

--- a/magda/daw/ui/components/chain/modulation/LFOCurveEditor.cpp
+++ b/magda/daw/ui/components/chain/modulation/LFOCurveEditor.cpp
@@ -856,8 +856,8 @@ void LFOCurveEditor::paintPhaseIndicator(juce::Graphics& g) {
 
 void LFOCurveEditor::paintGrid(juce::Graphics& g) {
     auto bounds = getLocalBounds();
-    float width = static_cast<float>(bounds.getWidth());
-    float height = static_cast<float>(bounds.getHeight());
+    auto width = static_cast<float>(bounds.getWidth());
+    auto height = static_cast<float>(bounds.getHeight());
 
     // Horizontal grid lines (value divisions) - placed using the padded y mapping
     // so they align with the curve and point positions.
@@ -894,8 +894,8 @@ void LFOCurveEditor::paintLoopRegion(juce::Graphics& g) {
         return;
 
     auto content = getContentBounds();
-    float loopStartX = static_cast<float>(xToPixelF(static_cast<double>(modInfo_->loopStart)));
-    float loopEndX = static_cast<float>(xToPixelF(static_cast<double>(modInfo_->loopEnd)));
+    auto loopStartX = static_cast<float>(xToPixelF(static_cast<double>(modInfo_->loopStart)));
+    auto loopEndX = static_cast<float>(xToPixelF(static_cast<double>(modInfo_->loopEnd)));
 
     // Shade areas outside the loop region
     g.setColour(DarkTheme::getColour(DarkTheme::TEXT_DARK).withAlpha(0x30 / 255.0f));
@@ -966,7 +966,7 @@ void LFOCurveEditor::mouseDown(const juce::MouseEvent& e) {
 void LFOCurveEditor::mouseDrag(const juce::MouseEvent& e) {
     if (draggingLoopMarker_ != 0 && modInfo_) {
         constexpr float kMinGap = 0.02f;
-        float phase = static_cast<float>(juce::jlimit(0.0, 1.0, pixelToX(e.x)));
+        auto phase = static_cast<float>(juce::jlimit(0.0, 1.0, pixelToX(e.x)));
         if (snapLoop_ && gridDivisionsX_ > 1) {
             const double step = 1.0 / gridDivisionsX_;
             phase = static_cast<float>(juce::jlimit(0.0, 1.0, std::round(phase / step) * step));

--- a/magda/daw/ui/components/chain/modulation/LFOPhaseOverlay.cpp
+++ b/magda/daw/ui/components/chain/modulation/LFOPhaseOverlay.cpp
@@ -70,8 +70,8 @@ void LFOPhaseOverlay::paintCurve(juce::Graphics& g) {
         return;
 
     const auto bounds = getLocalBounds();
-    const float width = static_cast<float>(bounds.getWidth());
-    const float height = static_cast<float>(bounds.getHeight());
+    const auto width = static_cast<float>(bounds.getWidth());
+    const auto height = static_cast<float>(bounds.getHeight());
 
     juce::Path curvePath;
     const auto& points = mod->curvePoints;
@@ -91,7 +91,7 @@ void LFOPhaseOverlay::paintCurve(juce::Graphics& g) {
         float x2 = p2.phase * width;
         float y2 = (1.0f - p2.value) * height;
 
-        double tension = static_cast<double>(p1.tension);
+        auto tension = static_cast<double>(p1.tension);
 
         if (std::abs(tension) < 0.001) {
             // Pure linear

--- a/magda/daw/ui/components/chain/modulation/MacroKnobComponent.cpp
+++ b/magda/daw/ui/components/chain/modulation/MacroKnobComponent.cpp
@@ -258,7 +258,7 @@ void MacroKnobComponent::paint(juce::Graphics& g) {
     auto knobArea = knobBounds.removeFromTop(KNOB_SIZE);
 
     // Center the knob horizontally
-    float knobDiameter = static_cast<float>(KNOB_SIZE - 4);
+    auto knobDiameter = static_cast<float>(KNOB_SIZE - 4);
     float knobX = knobArea.getCentreX() - knobDiameter / 2.0f;
     float knobY = knobArea.getCentreY() - knobDiameter / 2.0f;
     auto knobRect = juce::Rectangle<float>(knobX, knobY, knobDiameter, knobDiameter);

--- a/magda/daw/ui/components/chain/modulation/ModulatorEditorPanel.cpp
+++ b/magda/daw/ui/components/chain/modulation/ModulatorEditorPanel.cpp
@@ -1251,7 +1251,7 @@ void ModulatorEditorPanel::paintOverChildren(juce::Graphics& g) {
     float currentNorm = 0.0f;
     if (currentMod_.tempoSync) {
         constexpr float kSyncMin = 0.0f;
-        const float kSyncMax = static_cast<float>(std::size(kSyncDivisionOrder) - 1);
+        const auto kSyncMax = static_cast<float>(std::size(kSyncDivisionOrder) - 1);
         if (kSyncMax > kSyncMin)
             currentNorm = juce::jlimit(0.0f, 1.0f,
                                        (static_cast<float>(visibleSlider.getValue()) - kSyncMin) /

--- a/magda/daw/ui/components/chain/params/ParamSlotComponent.cpp
+++ b/magda/daw/ui/components/chain/params/ParamSlotComponent.cpp
@@ -391,7 +391,7 @@ void ParamSlotComponent::showLinkModeSlider(bool /*isNewLink*/, float initialAmo
             if (safeThis == nullptr || !safeThis->linkModeSlider_) {
                 return;
             }
-            float amount = static_cast<float>(safeThis->linkModeSlider_->getValue() / 100.0);
+            auto amount = static_cast<float>(safeThis->linkModeSlider_->getValue() / 100.0);
 
             if (safeThis->activeMod_.isValid() && safeThis->onModAmountChanged) {
                 magda::ControlTarget thisTarget =

--- a/magda/daw/ui/components/chain/slot/DeviceSlotContentPainter.cpp
+++ b/magda/daw/ui/components/chain/slot/DeviceSlotContentPainter.cpp
@@ -33,8 +33,8 @@ void paintSeparators(juce::Graphics& g, juce::Rectangle<int> contentArea,
                            static_cast<float>(contentArea.getBottom() - 2));
     }
 
-    const float left = static_cast<float>(contentArea.getX() + 2);
-    const float right = static_cast<float>(contentArea.getRight() - 2);
+    const auto left = static_cast<float>(contentArea.getX() + 2);
+    const auto right = static_cast<float>(contentArea.getRight() - 2);
     const int headerBottom = contentArea.getY() + contentHeaderHeight;
     if (!skipContentHeader) {
         g.setColour(DarkTheme::getColour(DarkTheme::BORDER));

--- a/magda/daw/ui/components/clips/ClipComponent.cpp
+++ b/magda/daw/ui/components/clips/ClipComponent.cpp
@@ -257,12 +257,12 @@ juce::Path makeClippedRoundedRectPath(juce::Rectangle<int> bounds, juce::Rectang
         return path;
     }
 
-    const float left = static_cast<float>(region.getX());
-    const float right = static_cast<float>(region.getRight());
-    const float top = static_cast<float>(region.getY());
-    const float bottom = static_cast<float>(region.getBottom());
-    const float boundsLeft = static_cast<float>(bounds.getX());
-    const float boundsRight = static_cast<float>(bounds.getRight());
+    const auto left = static_cast<float>(region.getX());
+    const auto right = static_cast<float>(region.getRight());
+    const auto top = static_cast<float>(region.getY());
+    const auto bottom = static_cast<float>(region.getBottom());
+    const auto boundsLeft = static_cast<float>(bounds.getX());
+    const auto boundsRight = static_cast<float>(bounds.getRight());
     const float r = juce::jmin(radius, 0.5f * static_cast<float>(region.getHeight()),
                                0.5f * static_cast<float>(region.getWidth()));
 
@@ -453,7 +453,7 @@ void ClipComponent::paint(juce::Graphics& g) {
         // Calculate pixel spacing between loop boundaries to scale indicators
         float loopPixelWidth =
             static_cast<float>(loopLengthBeats / beatRange) * clipBounds.getWidth();
-        float clipHeight = static_cast<float>(clipBounds.getHeight());
+        auto clipHeight = static_cast<float>(clipBounds.getHeight());
 
         // Below this per-loop pixel width the markers pack so densely they
         // turn the clip into a solid black mass — hide them entirely.
@@ -472,8 +472,8 @@ void ClipComponent::paint(juce::Graphics& g) {
             // Shadow gradient on right side of boundary (fold effect)
             float shadeWidth = juce::jmin(6.0f, loopPixelWidth * 0.15f);
             if (shadeWidth >= 1.0f) {
-                float top = static_cast<float>(clipBounds.getY());
-                float bot = static_cast<float>(clipBounds.getBottom());
+                auto top = static_cast<float>(clipBounds.getY());
+                auto bot = static_cast<float>(clipBounds.getBottom());
                 juce::ColourGradient shade(juce::Colours::black.withAlpha(0.45f), bx, 0.0f,
                                            juce::Colours::transparentBlack, bx + shadeWidth, 0.0f,
                                            false);
@@ -492,7 +492,7 @@ void ClipComponent::paint(juce::Graphics& g) {
             if (cutSize < 2.0f)
                 continue;  // Too small to draw meaningfully
 
-            float top = static_cast<float>(clipBounds.getY());
+            auto top = static_cast<float>(clipBounds.getY());
             juce::Path cut;
             // Left triangle
             cut.addTriangle(bx - cutSize, top, bx, top, bx, top + cutSize);
@@ -526,7 +526,7 @@ void ClipComponent::paint(juce::Graphics& g) {
             // Diagonal hatch, one line every 6px, running the full height so it
             // reads at any clip size.
             g.setColour(juce::Colours::white.withAlpha(0.10f));
-            const float height = static_cast<float>(region.getHeight());
+            const auto height = static_cast<float>(region.getHeight());
             for (float x = static_cast<float>(region.getX()) - height;
                  x < static_cast<float>(region.getRight()); x += 6.0f) {
                 g.drawLine(x, static_cast<float>(region.getBottom()), x + height,
@@ -1145,11 +1145,11 @@ void ClipComponent::paintFadeOverlays(juce::Graphics& g, const ClipInfo& clip,
                                       const EffectiveFades& fades,
                                       juce::Rectangle<int> waveformArea, double pixelsPerSecond) {
     constexpr int NUM_STEPS = 32;
-    float areaTop = static_cast<float>(waveformArea.getY());
-    float areaBottom = static_cast<float>(waveformArea.getBottom());
+    auto areaTop = static_cast<float>(waveformArea.getY());
+    auto areaBottom = static_cast<float>(waveformArea.getBottom());
     float areaHeight = areaBottom - areaTop;
-    float areaLeft = static_cast<float>(waveformArea.getX());
-    float areaRight = static_cast<float>(waveformArea.getRight());
+    auto areaLeft = static_cast<float>(waveformArea.getX());
+    auto areaRight = static_cast<float>(waveformArea.getRight());
 
     // The counterpart curve of a crossfade (the other clip's fade across the
     // same overlap) — drawn by both components of the pair so the X reads the
@@ -1295,16 +1295,16 @@ void ClipComponent::paintFadeHandles(juce::Graphics& g, const ClipInfo& clip,
     if (pixelsPerSecond <= 0.0)
         return;
 
-    float hs = static_cast<float>(FADE_HANDLE_SIZE);
+    auto hs = static_cast<float>(FADE_HANDLE_SIZE);
     float half = hs * 0.5f;
-    float waveTop = static_cast<float>(waveformArea.getY());
+    auto waveTop = static_cast<float>(waveformArea.getY());
 
     auto handleColour = DarkTheme::getColour(DarkTheme::ACCENT_ATTENTION);
     const auto fades = computeEffectiveFades(clip);
 
     // Fade-in handle: only visible on hover
     if (hoverFadeIn_) {
-        float fadeInPx = static_cast<float>(fades.fadeInSeconds * pixelsPerSecond);
+        auto fadeInPx = static_cast<float>(fades.fadeInSeconds * pixelsPerSecond);
         float cx = static_cast<float>(waveformArea.getX()) + fadeInPx;
         g.setColour(handleColour);
         g.fillRect(cx - half, waveTop, hs, hs);
@@ -1312,7 +1312,7 @@ void ClipComponent::paintFadeHandles(juce::Graphics& g, const ClipInfo& clip,
 
     // Fade-out handle: only visible on hover
     if (hoverFadeOut_) {
-        float fadeOutPx = static_cast<float>(fades.fadeOutSeconds * pixelsPerSecond);
+        auto fadeOutPx = static_cast<float>(fades.fadeOutSeconds * pixelsPerSecond);
         float cx = static_cast<float>(waveformArea.getRight()) - fadeOutPx;
         g.setColour(handleColour);
         g.fillRect(cx - half, waveTop, hs, hs);
@@ -2293,7 +2293,7 @@ void ClipComponent::mouseDrag(const juce::MouseEvent& e) {
                              ? static_cast<double>(wfArea.getWidth()) / dragStartLength_
                              : 0.0;
             if (pps > 0.0) {
-                double fadeInPx = static_cast<double>(e.x - wfArea.getX());
+                auto fadeInPx = static_cast<double>(e.x - wfArea.getX());
                 double newFadeIn = juce::jmax(0.0, fadeInPx / pps);
                 const auto* ci = getClipInfo();
                 double maxFadeIn =
@@ -2325,7 +2325,7 @@ void ClipComponent::mouseDrag(const juce::MouseEvent& e) {
                              ? static_cast<double>(wfArea.getWidth()) / dragStartLength_
                              : 0.0;
             if (pps > 0.0) {
-                double fadeOutPx = static_cast<double>(wfArea.getRight() - e.x);
+                auto fadeOutPx = static_cast<double>(wfArea.getRight() - e.x);
                 double newFadeOut = juce::jmax(0.0, fadeOutPx / pps);
                 const auto* ci = getClipInfo();
                 double maxFadeOut =
@@ -2710,7 +2710,7 @@ void ClipComponent::mouseUp(const juce::MouseEvent& e) {
                                      ? static_cast<double>(wfArea.getWidth()) / dragStartLength_
                                      : 0.0;
                     if (pps > 0.0) {
-                        double fadeInPx = static_cast<double>(e.x - wfArea.getX());
+                        auto fadeInPx = static_cast<double>(e.x - wfArea.getX());
                         finalFadeIn = juce::jmax(0.0, fadeInPx / pps);
                         const auto* ci = getClipInfo();
                         double maxFadeIn = ci ? timelineLengthSeconds(*ci, commitTempoBPM) -
@@ -2770,7 +2770,7 @@ void ClipComponent::mouseUp(const juce::MouseEvent& e) {
                                      ? static_cast<double>(wfArea.getWidth()) / dragStartLength_
                                      : 0.0;
                     if (pps > 0.0) {
-                        double fadeOutPx = static_cast<double>(wfArea.getRight() - e.x);
+                        auto fadeOutPx = static_cast<double>(wfArea.getRight() - e.x);
                         finalFadeOut = juce::jmax(0.0, fadeOutPx / pps);
                         const auto* ci = getClipInfo();
                         double maxFadeOut = ci ? timelineLengthSeconds(*ci, commitTempoBPM) -

--- a/magda/daw/ui/components/common/DraggableValueLabel.cpp
+++ b/magda/daw/ui/components/common/DraggableValueLabel.cpp
@@ -319,7 +319,7 @@ void DraggableValueLabel::beginAutomationGesture(double baselineValue) {
     mgr.beginTargetGesture(automationTarget_);
     mgr.setTargetUserTouched(automationTarget_, true);
     const auto info = getParameterInfoForTarget(automationTarget_);
-    const double normalized = static_cast<double>(
+    const auto normalized = static_cast<double>(
         ParameterUtils::realToNormalized(static_cast<float>(baselineValue), info));
     mgr.setTouchBaseline(automationTarget_, normalized);
 }

--- a/magda/daw/ui/components/common/GridOverlayComponent.cpp
+++ b/magda/daw/ui/components/common/GridOverlayComponent.cpp
@@ -194,7 +194,7 @@ void GridOverlayComponent::drawBarsBeatsGrid(juce::Graphics& g, juce::Rectangle<
         gridQuantize, currentZoom, timeSignatureNumerator, minPixelSpacing);
 
     double totalTimelineBeats = timelineLength * tempoBPM / 60.0;
-    double barLengthBeats = static_cast<double>(timeSignatureNumerator);
+    auto barLengthBeats = static_cast<double>(timeSignatureNumerator);
 
     // Check if grid interval aligns with bar and beat boundaries
     bool alignsWithBars = GridConstants::gridAlignsWithBars(markerIntervalBeats, barLengthBeats);

--- a/magda/daw/ui/components/common/QwertyKeyboardPopup.cpp
+++ b/magda/daw/ui/components/common/QwertyKeyboardPopup.cpp
@@ -114,7 +114,7 @@ void QwertyKeyboardPopup::resized() {
 }
 
 juce::Rectangle<float> QwertyKeyboardPopup::whiteKeyBounds(size_t index) const {
-    const float total = static_cast<float>(kWhiteKeys_.size());
+    const auto total = static_cast<float>(kWhiteKeys_.size());
     const float w = keyboardArea_.getWidth() / total;
     return juce::Rectangle<float>(keyboardArea_.getX() + static_cast<float>(index) * w,
                                   static_cast<float>(keyboardArea_.getY()), w,

--- a/magda/daw/ui/components/common/RampCurveDisplay.cpp
+++ b/magda/daw/ui/components/common/RampCurveDisplay.cpp
@@ -62,7 +62,7 @@ void RampCurveDisplay::paint(juce::Graphics& g) {
 
         // Apply curve with cycles to get the x position
         float pos = playbackPos_;
-        float curvedPos =
+        auto curvedPos =
             static_cast<float>(daw::audio::sequencer::StepClock::applyRampCurveWithCycles(
                 pos, depth_, skew_, cycles_, hardAngle_));
         curvedPos = juce::jlimit(0.0f, 1.0f, curvedPos);

--- a/magda/daw/ui/components/common/TextSlider.hpp
+++ b/magda/daw/ui/components/common/TextSlider.hpp
@@ -351,7 +351,7 @@ class TextSlider : public juce::Component,
             // Fader-over-meter mode: paint nothing behind so the LevelMeter
             // sitting underneath shows through, then draw the thumb as a thin
             // pale horizontal bar at the value position.
-            float norm = static_cast<float>(getNormalizedValue());
+            auto norm = static_cast<float>(getNormalizedValue());
             int fillHeight = static_cast<int>(std::round(bounds.getHeight() * norm));
             int handleY = bounds.getBottom() - fillHeight;
 
@@ -373,7 +373,7 @@ class TextSlider : public juce::Component,
             g.drawRoundedRectangle(bounds.toFloat().reduced(0.5f), 2.0f, 1.0f);
 
             if (meterPeakL_ > 0.001f || meterPeakR_ > 0.001f) {
-                float w = static_cast<float>(bounds.getWidth());
+                auto w = static_cast<float>(bounds.getWidth());
 
                 auto gainToWidth = [w](float gain) -> float {
                     float db = juce::Decibels::gainToDecibels(gain, -60.0f);
@@ -690,7 +690,7 @@ class TextSlider : public juce::Component,
         mgr.beginTargetGesture(automationTarget_);
         mgr.setTargetUserTouched(automationTarget_, true);
         const auto info = magda::getParameterInfoForTarget(automationTarget_);
-        const double normalized = static_cast<double>(
+        const auto normalized = static_cast<double>(
             magda::ParameterUtils::realToNormalized(static_cast<float>(baselineValue), info));
         mgr.setTouchBaseline(automationTarget_, normalized);
     }
@@ -810,7 +810,7 @@ class TextSlider : public juce::Component,
         if (bounds.isEmpty())
             return {};
 
-        const float norm = static_cast<float>(getNormalizedValue());
+        const auto norm = static_cast<float>(getNormalizedValue());
         const int handleY =
             bounds.getBottom() - static_cast<int>(std::round(bounds.getHeight() * norm));
         constexpr int editorW = 32;

--- a/magda/daw/ui/components/common/ValueLabelControl.cpp
+++ b/magda/daw/ui/components/common/ValueLabelControl.cpp
@@ -263,7 +263,7 @@ void ValueLabelControl::paint(juce::Graphics& g) {
 
         if (fillMode_ == FillMode::PanCentre) {
             const float centreX = bounds.getCentreX();
-            const float normalizedPan = static_cast<float>(juce::jlimit(-1.0, 1.0, value_));
+            const auto normalizedPan = static_cast<float>(juce::jlimit(-1.0, 1.0, value_));
 
             if (std::abs(normalizedPan) < 0.01f) {
                 g.fillRect(centreX - 1.0f, bounds.getY(), 2.0f, bounds.getHeight());
@@ -277,7 +277,7 @@ void ValueLabelControl::paint(juce::Graphics& g) {
         } else if (fillMode_ == FillMode::BottomToTop) {
             const double norm = fillProportion();
             if (norm > 0.0) {
-                float fillH = static_cast<float>(bounds.getHeight() * norm);
+                auto fillH = static_cast<float>(bounds.getHeight() * norm);
                 g.fillRoundedRectangle(bounds.getX(), bounds.getBottom() - fillH, bounds.getWidth(),
                                        fillH, 2.0f);
             }

--- a/magda/daw/ui/components/common/curve/CurveEditorBase.cpp
+++ b/magda/daw/ui/components/common/curve/CurveEditorBase.cpp
@@ -154,8 +154,8 @@ void CurveEditorBase::paintCurve(juce::Graphics& g) {
         // Just start at the first point - no extra wrap segment needed
         if (!renderPoints.empty()) {
             auto [firstX, firstY] = getEffectivePosition(*renderPoints.front());
-            float firstPixelX = static_cast<float>(xToPixelF(firstX));
-            float firstPixelY = static_cast<float>(yToPixelF(firstY));
+            auto firstPixelX = static_cast<float>(xToPixelF(firstX));
+            auto firstPixelY = static_cast<float>(yToPixelF(firstY));
             curvePath.startNewSubPath(firstPixelX, firstPixelY);
             pathStarted = true;
             pathStartX = firstPixelX;
@@ -164,8 +164,8 @@ void CurveEditorBase::paintCurve(juce::Graphics& g) {
         // For non-looping (automation): Extend from left edge at first point's value
         if (!renderPoints.empty()) {
             auto [firstX, firstY] = getEffectivePosition(*renderPoints.front());
-            float firstPixelX = static_cast<float>(xToPixelF(firstX));
-            float firstPixelY = static_cast<float>(yToPixelF(firstY));
+            auto firstPixelX = static_cast<float>(xToPixelF(firstX));
+            auto firstPixelY = static_cast<float>(yToPixelF(firstY));
 
             if (firstPixelX > 0.0f) {
                 curvePath.startNewSubPath(0.0f, firstPixelY);
@@ -180,8 +180,8 @@ void CurveEditorBase::paintCurve(juce::Graphics& g) {
     for (size_t i = 0; i < renderPoints.size(); ++i) {
         const auto& p = *renderPoints[i];
         auto [x, y] = getEffectivePosition(p);
-        float pixelX = static_cast<float>(xToPixelF(x));
-        float pixelY = static_cast<float>(yToPixelF(y));
+        auto pixelX = static_cast<float>(xToPixelF(x));
+        auto pixelY = static_cast<float>(yToPixelF(y));
 
         if (!pathStarted) {
             curvePath.startNewSubPath(pixelX, pixelY);
@@ -210,8 +210,8 @@ void CurveEditorBase::paintCurve(juce::Graphics& g) {
         if (!renderPoints.empty()) {
             auto [lastX, lastY] = getEffectivePosition(*renderPoints.back());
             juce::ignoreUnused(lastX);
-            float lastPixelY = static_cast<float>(yToPixelF(lastY));
-            float width = static_cast<float>(getWidth());
+            auto lastPixelY = static_cast<float>(yToPixelF(lastY));
+            auto width = static_cast<float>(getWidth());
             curvePath.lineTo(width, lastPixelY);
         }
     }
@@ -236,7 +236,7 @@ void CurveEditorBase::paintCurve(juce::Graphics& g) {
     // visible diagonals across that offset.
     juce::Path fillPath = curvePath;
     const auto curveEnd = curvePath.getCurrentPosition();
-    float fillBaseY = static_cast<float>(yToPixelF(0.0));
+    auto fillBaseY = static_cast<float>(yToPixelF(0.0));
     fillPath.lineTo(curveEnd.x, fillBaseY);
     fillPath.lineTo(pathStartX, fillBaseY);
     fillPath.closeSubPath();
@@ -250,10 +250,10 @@ void CurveEditorBase::renderCurveSegment(juce::Path& path, const CurvePoint& p1,
     auto [x2, y2] = getEffectivePosition(p2);
 
     // Float-precision pixel coords for rendering (no int truncation)
-    float pixelX1 = static_cast<float>(xToPixelF(x1));
-    float pixelY1 = static_cast<float>(yToPixelF(y1));
-    float pixelX2 = static_cast<float>(xToPixelF(x2));
-    float pixelY2 = static_cast<float>(yToPixelF(y2));
+    auto pixelX1 = static_cast<float>(xToPixelF(x1));
+    auto pixelY1 = static_cast<float>(yToPixelF(y1));
+    auto pixelX2 = static_cast<float>(xToPixelF(x2));
+    auto pixelY2 = static_cast<float>(yToPixelF(y2));
 
     switch (p1.curveType) {
         case CurveType::Linear: {

--- a/magda/daw/ui/components/mixer/MasterChannelStrip.cpp
+++ b/magda/daw/ui/components/mixer/MasterChannelStrip.cpp
@@ -142,7 +142,7 @@ class MasterChannelStrip::DbScale : public juce::Component {
         float paddingBottom = metrics.labelTextHeight / 2.0f;
         float top = paddingTop;
         float height = static_cast<float>(bounds.getHeight()) - paddingTop - paddingBottom;
-        float totalWidth = static_cast<float>(bounds.getWidth());
+        auto totalWidth = static_cast<float>(bounds.getWidth());
 
         const float tickShort = metrics.tickWidth();
         const float tickLong = tickShort * 1.8f;

--- a/magda/daw/ui/components/mixer/MidiNoteStrip.hpp
+++ b/magda/daw/ui/components/mixer/MidiNoteStrip.hpp
@@ -59,7 +59,7 @@ class MidiNoteStrip : public juce::Component, private juce::Timer {
         if (height < 1.0f)
             return;
 
-        float noteRange = static_cast<float>(highNote_ - lowNote_);
+        auto noteRange = static_cast<float>(highNote_ - lowNote_);
         if (noteRange <= 0.0f)
             return;
 

--- a/magda/daw/ui/components/pianoroll/MidiDrawerComponent.cpp
+++ b/magda/daw/ui/components/pianoroll/MidiDrawerComponent.cpp
@@ -239,8 +239,8 @@ void MidiDrawerComponent::paintLaneHeaders(juce::Graphics& g) {
         if (removable) {
             // Close button "x" in the top-right corner of the lane's header column
             g.setColour(textColour.withAlpha(0.6f));
-            float closeX = static_cast<float>(leftMargin_ - 11);
-            float closeY = static_cast<float>(row.getY() + 11);
+            auto closeX = static_cast<float>(leftMargin_ - 11);
+            auto closeY = static_cast<float>(row.getY() + 11);
             g.drawLine(closeX - 2.5f, closeY - 2.5f, closeX + 2.5f, closeY + 2.5f, 1.0f);
             g.drawLine(closeX + 2.5f, closeY - 2.5f, closeX - 2.5f, closeY + 2.5f, 1.0f);
         }

--- a/magda/daw/ui/components/pianoroll/PianoRollGridComponent.cpp
+++ b/magda/daw/ui/components/pianoroll/PianoRollGridComponent.cpp
@@ -519,8 +519,8 @@ void PianoRollGridComponent::paintBeatLines(juce::Graphics& g, juce::Rectangle<i
     if (gridRes <= 0.0)
         return;
 
-    const float top = static_cast<float>(area.getY());
-    const float bottom = static_cast<float>(area.getBottom());
+    const auto top = static_cast<float>(area.getY());
+    const auto bottom = static_cast<float>(area.getBottom());
     const int left = area.getX();
     const int right = area.getRight();
     const int tsNum = timeSignatureNumerator_;
@@ -2965,7 +2965,7 @@ double PianoRollGridComponent::expressionRelBeatForX(ClipId clipId, const MidiNo
 juce::Point<float> PianoRollGridComponent::expressionPointToScreen(
     ClipId clipId, const MidiNote& note, const MidiPitchExpressionPoint& point) const {
     const double noteStartDisplayBeat = displayBeatForClipBeat(clipId, note.startBeat);
-    const float x = static_cast<float>(beatToPixel(noteStartDisplayBeat + point.beat));
+    const auto x = static_cast<float>(beatToPixel(noteStartDisplayBeat + point.beat));
     const float centerY =
         static_cast<float>(noteNumberToY(note.noteNumber)) + static_cast<float>(noteHeight_) * 0.5f;
     const float y = centerY - static_cast<float>(point.semitones * noteHeight_);
@@ -3382,8 +3382,8 @@ void PianoRollGridComponent::paintPitchExpression(juce::Graphics& g) {
                 continue;
 
             const double noteStartDisplayBeat = displayBeatForClipBeat(clipId, note.startBeat);
-            const float startX = static_cast<float>(beatToPixel(noteStartDisplayBeat));
-            const float endX =
+            const auto startX = static_cast<float>(beatToPixel(noteStartDisplayBeat));
+            const auto endX =
                 static_cast<float>(beatToPixel(noteStartDisplayBeat + note.lengthBeats));
             const float centerY = static_cast<float>(noteNumberToY(note.noteNumber)) +
                                   static_cast<float>(noteHeight_) * 0.5f;
@@ -3395,7 +3395,7 @@ void PianoRollGridComponent::paintPitchExpression(juce::Graphics& g) {
             juce::Path path;
             path.startNewSubPath(startX, yForSemitones(evaluatePitchExpression(points, 0.0)));
             for (size_t p = 0; p < points.size(); ++p) {
-                const float px =
+                const auto px =
                     static_cast<float>(beatToPixel(noteStartDisplayBeat + points[p].beat));
                 const float clampedX = juce::jlimit(startX, endX, px);
 

--- a/magda/daw/ui/components/pianoroll/VelocityLaneComponent.cpp
+++ b/magda/daw/ui/components/pianoroll/VelocityLaneComponent.cpp
@@ -445,8 +445,8 @@ void VelocityLaneComponent::paint(juce::Graphics& g) {
                     float t = static_cast<float>(seg) / static_cast<float>(numSegments);
                     double beat = firstBeat + t * beatRange;
                     int vel = interpolateVelocity(t);
-                    float px = static_cast<float>(beatToPixel(beat + clipAbsOffset));
-                    float py = static_cast<float>(velocityToY(vel));
+                    auto px = static_cast<float>(beatToPixel(beat + clipAbsOffset));
+                    auto py = static_cast<float>(velocityToY(vel));
 
                     if (!started) {
                         curvePath.startNewSubPath(px, py);
@@ -462,9 +462,9 @@ void VelocityLaneComponent::paint(juce::Graphics& g) {
 
             // Draw curve handle
             if (isCurveHandleVisible_ && !isRampDragging_) {
-                float hx = static_cast<float>(curveHandleX_);
-                float hy = static_cast<float>(curveHandleY_);
-                float hs = static_cast<float>(CURVE_HANDLE_SIZE);
+                auto hx = static_cast<float>(curveHandleX_);
+                auto hy = static_cast<float>(curveHandleY_);
+                auto hs = static_cast<float>(CURVE_HANDLE_SIZE);
 
                 // Diamond shape
                 juce::Path diamond;

--- a/magda/daw/ui/components/timeline/LoopStripRenderer.hpp
+++ b/magda/daw/ui/components/timeline/LoopStripRenderer.hpp
@@ -26,8 +26,8 @@ inline void draw(juce::Graphics& g, float xStart, float xEnd, int stripTop, int 
 
     const auto base =
         enabled ? DarkTheme::getColour(DarkTheme::LOOP_MARKER) : juce::Colour(0xFF808080);
-    const float top = static_cast<float>(stripTop);
-    const float bottom = static_cast<float>(stripTop + stripHeight);
+    const auto top = static_cast<float>(stripTop);
+    const auto bottom = static_cast<float>(stripTop + stripHeight);
     const float mid = (top + bottom) * 0.5f;
     const int railH = juce::jmax(2, stripHeight / 3);
     const float railTop = mid - static_cast<float>(railH) / 2.0f;

--- a/magda/daw/ui/components/timeline/MarkerLaneComponent.cpp
+++ b/magda/daw/ui/components/timeline/MarkerLaneComponent.cpp
@@ -270,7 +270,7 @@ void MarkerLaneComponent::showMarkerMenu(int markerId, juce::Point<int> screenPo
                 if (idx < defaultCount) {
                     colour = juce::Colour(Config::getDefaultColour(idx));
                 } else {
-                    const size_t customIdx = static_cast<size_t>(idx - defaultCount);
+                    const auto customIdx = static_cast<size_t>(idx - defaultCount);
                     if (customIdx >= customPalette.size())
                         return;
                     colour = juce::Colour(customPalette[customIdx].colour);

--- a/magda/daw/ui/components/timeline/TimeRuler.cpp
+++ b/magda/daw/ui/components/timeline/TimeRuler.cpp
@@ -516,7 +516,7 @@ void TimeRuler::drawBarsBeatsMode(juce::Graphics& g) {
 
     double pixelsPerBeat = zoom;
     double pixelsPerBar = zoom * timeSigNumerator;
-    double barLengthBeats = static_cast<double>(timeSigNumerator);
+    auto barLengthBeats = static_cast<double>(timeSigNumerator);
 
     // Check if grid interval aligns with bar and beat boundaries
     bool alignsWithBars = GridConstants::gridAlignsWithBars(intervalBeats, barLengthBeats);
@@ -555,7 +555,7 @@ void TimeRuler::drawBarsBeatsMode(juce::Graphics& g) {
     if (firstVisibleBeat < barOriginBeats)
         firstVisibleBeat = barOriginBeats;
 
-    long long startStep =
+    auto startStep =
         static_cast<long long>(std::floor((firstVisibleBeat - barOriginBeats) / intervalBeats));
     if (startStep < 0)
         startStep = 0;
@@ -631,7 +631,7 @@ void TimeRuler::drawBarsBeatsMode(juce::Graphics& g) {
     // Pass 2: Bar labels (highest priority — always drawn when interval allows)
     {
         // Iterate by bar
-        long long startBarStep = static_cast<long long>(
+        auto startBarStep = static_cast<long long>(
             std::floor((firstVisibleBeat - barOriginBeats) / barLengthBeats));
         if (startBarStep < 0)
             startBarStep = 0;
@@ -666,8 +666,7 @@ void TimeRuler::drawBarsBeatsMode(juce::Graphics& g) {
 
     // Pass 3: Beat labels (skip beat 1 = bar start, check overlap with bar labels)
     if (pixelsPerBeat >= 20) {
-        long long startBeatStep =
-            static_cast<long long>(std::floor(firstVisibleBeat - barOriginBeats));
+        auto startBeatStep = static_cast<long long>(std::floor(firstVisibleBeat - barOriginBeats));
         if (startBeatStep < 0)
             startBeatStep = 0;
 
@@ -682,7 +681,7 @@ void TimeRuler::drawBarsBeatsMode(juce::Graphics& g) {
             if (x < 0)
                 continue;
 
-            double beatsFromOrigin = static_cast<double>(beatStep);
+            auto beatsFromOrigin = static_cast<double>(beatStep);
             double barRemainder = std::fmod(beatsFromOrigin, barLengthBeats);
             bool isBarStart = barRemainder < 0.001;
             if (isBarStart)
@@ -719,7 +718,7 @@ void TimeRuler::drawBarsBeatsMode(juce::Graphics& g) {
     // Pass 4: Subdivision labels at musically meaningful positions
     if (subdivLabelBeats > 0.0 && gridAligned) {
         // Iterate at the subdivision label level (not at grid resolution)
-        long long startSubdivStep = static_cast<long long>(
+        auto startSubdivStep = static_cast<long long>(
             std::floor((firstVisibleBeat - barOriginBeats) / subdivLabelBeats));
         if (startSubdivStep < 0)
             startSubdivStep = 0;
@@ -812,8 +811,8 @@ void TimeRuler::drawBarsBeatsMode(juce::Graphics& g) {
             g.fillRect(phaseX - 1, tickAreaTop, 2, tickHeightMajor());
             // Downward triangle at top of tick area
             juce::Path flag;
-            float fx = static_cast<float>(phaseX);
-            float triTop = static_cast<float>(tickAreaTop);
+            auto fx = static_cast<float>(phaseX);
+            auto triTop = static_cast<float>(tickAreaTop);
             flag.addTriangle(fx - 5.0f, triTop, fx + 5.0f, triTop, fx, triTop + 8.0f);
             g.fillPath(flag);
         }
@@ -844,9 +843,9 @@ void TimeRuler::drawBarsBeatsMode(juce::Graphics& g) {
             // label divider) so it fills that rectangle instead of poking past
             // the ruler bottom into the grid.
             juce::Path triangle;
-            const float x = static_cast<float>(handleX);
-            const float yTop = static_cast<float>(tickAreaTop);
-            const float yTip = static_cast<float>(height - 1);
+            const auto x = static_cast<float>(handleX);
+            const auto yTop = static_cast<float>(tickAreaTop);
+            const auto yTip = static_cast<float>(height - 1);
             triangle.addTriangle(x - 6.0f, yTop, x + 6.0f, yTop, x, yTip);
             g.fillPath(triangle);
         }

--- a/magda/daw/ui/components/timeline/TimelineComponent.cpp
+++ b/magda/daw/ui/components/timeline/TimelineComponent.cpp
@@ -182,8 +182,8 @@ void TimelineComponent::paint(juce::Graphics& g) {
     int arrangementTop = chordHeight;  // Arrangement starts below chord row
 
     auto visibleX = getVisibleXRange(g, getWidth());
-    const float visibleLeft = static_cast<float>(visibleX.getStart());
-    const float visibleRight = static_cast<float>(visibleX.getEnd());
+    const auto visibleLeft = static_cast<float>(visibleX.getStart());
+    const auto visibleRight = static_cast<float>(visibleX.getEnd());
 
     // Draw border for the visible slice only. At deep zoom the timeline component can be
     // millions of pixels wide, and sending that full rectangle to JUCE's software renderer
@@ -197,7 +197,7 @@ void TimelineComponent::paint(juce::Graphics& g) {
     if (isXVisible(g, getWidth(), 0))
         g.drawLine(0.0f, 0.0f, 0.0f, static_cast<float>(getHeight()), 1.0f);
     if (isXVisible(g, getWidth(), getWidth() - 1)) {
-        float rightEdge = static_cast<float>(getWidth() - 1);
+        auto rightEdge = static_cast<float>(getWidth() - 1);
         g.drawLine(rightEdge, 0.0f, rightEdge, static_cast<float>(getHeight()), 1.0f);
     }
 
@@ -844,8 +844,8 @@ void TimelineComponent::drawMarkerGuides(juce::Graphics& g) {
 
     auto visibleX = getVisibleXRange(g, getWidth());
     // Span the bars ruler from the label row down to the ticks.
-    const float top = static_cast<float>(rulerTop);
-    const float bottom = static_cast<float>(rulerBottom);
+    const auto top = static_cast<float>(rulerTop);
+    const auto bottom = static_cast<float>(rulerBottom);
     const int selectedMarkerId =
         timelineListener_.get() ? timelineListener_.get()->getState().selectedMarkerId : 0;
 
@@ -1087,7 +1087,7 @@ void TimelineComponent::drawTimeMarkers(juce::Graphics& g) {
         double markerIntervalBeats = GridConstants::computeGridInterval(
             gridQuantize, pixelsPerBeat, timeSignatureNumerator, minPixelSpacing);
 
-        double barLengthBeats = static_cast<double>(timeSignatureNumerator);
+        auto barLengthBeats = static_cast<double>(timeSignatureNumerator);
 
         // Check if grid interval aligns with bar and beat boundaries
         bool alignsWithBars =
@@ -1320,7 +1320,7 @@ void TimelineComponent::drawSection(juce::Graphics& g, const ArrangementSection&
         g.setColour(section.colour.withAlpha(0.5f));
         // Draw dotted border to indicate locked state
         const float dashLengths[] = {2.0f, 2.0f};
-        float sectionTop = static_cast<float>(chordHeight);
+        auto sectionTop = static_cast<float>(chordHeight);
         auto sectionBottom = static_cast<float>(sectionArea.getBottom());
 
         if (isXVisible(g, getWidth(), startX)) {
@@ -1445,9 +1445,9 @@ void TimelineComponent::drawLoopMarkerFlags(juce::Graphics& g) {
     }
 
     const int stripTop = rulerRows().loopTop;
-    const float startX =
+    const auto startX =
         static_cast<float>(beatsToPixel(loopStartBeats) + LayoutConfig::TIMELINE_LEFT_PADDING);
-    const float endX =
+    const auto endX =
         static_cast<float>(beatsToPixel(loopEndBeats) + LayoutConfig::TIMELINE_LEFT_PADDING);
 
     LoopStripRenderer::draw(g, startX, endX, stripTop, LayoutConfig::loopStripHeight, getWidth(),
@@ -1591,13 +1591,13 @@ void TimelineComponent::drawTimeSelection(juce::Graphics& g) {
     // endpoint markers and double as the drag handles (see hitTimeSelectionEdge).
     const auto handleColour = DarkTheme::getColour(DarkTheme::ACCENT_PRIMARY_SOFT);
     const float cy = static_cast<float>(rows.playheadTop + rows.playheadBottom) * 0.5f;
-    const float dh = static_cast<float>(rows.playheadBottom - rows.playheadTop);
+    const auto dh = static_cast<float>(rows.playheadBottom - rows.playheadTop);
     constexpr float dw = 8.0f;
     g.setColour(handleColour);
     const auto diamond = [&](int x) {
         if (!isXVisible(g, getWidth(), x))
             return;
-        const float fx = static_cast<float>(x);
+        const auto fx = static_cast<float>(x);
         juce::Path d;
         d.startNewSubPath(fx, cy - dh / 2.0f);
         d.lineTo(fx + dw / 2.0f, cy);

--- a/magda/daw/ui/components/timeline/ZoomScrollBar.cpp
+++ b/magda/daw/ui/components/timeline/ZoomScrollBar.cpp
@@ -120,7 +120,7 @@ void ZoomScrollBar::mouseDown(const juce::MouseEvent& event) {
 void ZoomScrollBar::mouseDrag(const juce::MouseEvent& event) {
     reveal();
     auto trackBounds = getTrackBounds();
-    double trackPrimarySize = static_cast<double>(getPrimarySize(trackBounds));
+    auto trackPrimarySize = static_cast<double>(getPrimarySize(trackBounds));
 
     if (trackPrimarySize <= 0)
         return;

--- a/magda/daw/ui/components/tracks/TrackContentPanel.cpp
+++ b/magda/daw/ui/components/tracks/TrackContentPanel.cpp
@@ -854,7 +854,7 @@ void TrackContentPanel::paintRecordingPreviews(juce::Graphics& g) {
             // Draw audio waveform (symmetric around vertical center)
             g.setColour(baseColour.brighter(0.3f));
 
-            float centerY = static_cast<float>(noteArea.getCentreY());
+            auto centerY = static_cast<float>(noteArea.getCentreY());
             float halfHeight = noteArea.getHeight() * 0.5f;
             int numPeaks = static_cast<int>(preview.audioPeaks.size());
 
@@ -1006,9 +1006,9 @@ void TrackContentPanel::paintEditCursor(juce::Graphics& g) {
     }
 
     // Draw edit cursor as a prominent white line
-    float top = static_cast<float>(trackArea.getY());
-    float bottom = static_cast<float>(trackArea.getBottom());
-    float x = static_cast<float>(cursorX);
+    auto top = static_cast<float>(trackArea.getY());
+    auto bottom = static_cast<float>(trackArea.getBottom());
+    auto x = static_cast<float>(cursorX);
 
     // Draw glow/shadow for visibility over grid lines
     g.setColour(juce::Colours::black.withAlpha(0.5f));

--- a/magda/daw/ui/components/waveform/WaveformGridComponent.cpp
+++ b/magda/daw/ui/components/waveform/WaveformGridComponent.cpp
@@ -564,7 +564,7 @@ void WaveformGridComponent::paintBeatGrid(juce::Graphics& g, const magda::ClipIn
     if (bpm <= 0.0)
         return;
     double secondsPerBeat = 60.0 / bpm;
-    double beatsPerBar = static_cast<double>(timeRuler_->getTimeSigNumerator());
+    auto beatsPerBar = static_cast<double>(timeRuler_->getTimeSigNumerator());
 
     // Match the arrangement (GridConstants::computeGridInterval): never draw grid
     // lines or bar numbers denser than ~50px. The display interval grows to
@@ -858,8 +858,8 @@ void WaveformGridComponent::paintTransientMarkers(juce::Graphics& g, const magda
     double firstDrawnTime = 0.0;
 
     auto drawMarkersForCycle = [&](double cycleOffset, double sourceStart, double sourceEnd) {
-        const float top = static_cast<float>(waveformRect.getY());
-        const float bottom = static_cast<float>(waveformRect.getBottom());
+        const auto top = static_cast<float>(waveformRect.getY());
+        const auto bottom = static_cast<float>(waveformRect.getBottom());
         for (double t : transientTimes_) {
             if (t < sourceStart || t >= sourceEnd)
                 continue;
@@ -882,7 +882,7 @@ void WaveformGridComponent::paintTransientMarkers(juce::Graphics& g, const magda
             g.drawVerticalLine(px, top, bottom);
 
             // Downward-pointing handle triangle flush with the top edge.
-            const float fx = static_cast<float>(px);
+            const auto fx = static_cast<float>(px);
             juce::Path handle;
             handle.addTriangle(fx - kHandleHalfW, top, fx + kHandleHalfW, top, fx, top + kHandleH);
             g.setColour(handleColour);
@@ -1832,8 +1832,8 @@ void WaveformGridComponent::paintWarpMarkers(juce::Graphics& g, const magda::Cli
 
         // Draw small triangle handle at top
         juce::Path triangle;
-        float fx = static_cast<float>(px);
-        float fy = static_cast<float>(waveformRect.getY());
+        auto fx = static_cast<float>(px);
+        auto fy = static_cast<float>(waveformRect.getY());
         triangle.addTriangle(fx - 4.0f, fy, fx + 4.0f, fy, fx, fy + 6.0f);
         g.fillPath(triangle);
     }

--- a/magda/daw/ui/dialogs/AISettingsDialog.cpp
+++ b/magda/daw/ui/dialogs/AISettingsDialog.cpp
@@ -284,7 +284,7 @@ class AISettingsDialog::CloudPage : public juce::Component {
     void paint(juce::Graphics& g) override {
         auto borderColour = DarkTheme::getColour(DarkTheme::BORDER);
         float left = 12.0f;
-        float right = static_cast<float>(getWidth() - 12);
+        auto right = static_cast<float>(getWidth() - 12);
 
         // Separator above registered list
         if (registeredLabel_.isVisible()) {

--- a/magda/daw/ui/dialogs/ControllersDialog.cpp
+++ b/magda/daw/ui/dialogs/ControllersDialog.cpp
@@ -393,7 +393,7 @@ void ControllerProfilesPage::onAddClicked() {
                        [this, profiles](int result) {
                            if (result <= 0)
                                return;
-                           size_t idx = static_cast<size_t>(result - 1);
+                           auto idx = static_cast<size_t>(result - 1);
                            if (idx >= profiles.size())
                                return;
                            onProfilePicked(profiles[idx]);
@@ -788,7 +788,7 @@ class LuaScriptsPage : public juce::Component {
                            [self, availableCopy](int result) {
                                if (result <= 0)
                                    return;
-                               const size_t idx = static_cast<size_t>(result - 1);
+                               const auto idx = static_cast<size_t>(result - 1);
                                if (idx >= availableCopy.size())
                                    return;
                                auto& cfg = magda::Config::getInstance();

--- a/magda/daw/ui/dialogs/PreferencesDialog.cpp
+++ b/magda/daw/ui/dialogs/PreferencesDialog.cpp
@@ -1079,12 +1079,12 @@ class AppearancePage : public juce::Component {
 
     std::string themeValueForId(int id) const {
         if (id >= kUserThemeIdBase) {
-            const size_t index = static_cast<size_t>(id - kUserThemeIdBase);
+            const auto index = static_cast<size_t>(id - kUserThemeIdBase);
             if (index < userThemes_.size())
                 return userThemes_[index].id;
         }
         if (id >= kFactoryThemeIdBase) {
-            const size_t index = static_cast<size_t>(id - kFactoryThemeIdBase);
+            const auto index = static_cast<size_t>(id - kFactoryThemeIdBase);
             if (index < factoryThemes_.size())
                 return factoryThemes_[index].id;
         }

--- a/magda/daw/ui/panels/TransportPanel.cpp
+++ b/magda/daw/ui/panels/TransportPanel.cpp
@@ -190,7 +190,7 @@ void TransportPanel::paint(juce::Graphics& g) {
 
         // Separator between header and value, on the boundary the layout drew
         // between the two labels rather than a second guess at it.
-        const float sepY = static_cast<float>(layout_.cpuValue.getY());
+        const auto sepY = static_cast<float>(layout_.cpuValue.getY());
 
         // CPU usage fill bar in value area
         if (currentCpuUsage > 0.0f) {

--- a/magda/daw/ui/panels/content/AIChatConsoleContent.cpp
+++ b/magda/daw/ui/panels/content/AIChatConsoleContent.cpp
@@ -1571,7 +1571,7 @@ void AIChatConsoleContent::paint(juce::Graphics& g) {
         g.drawRoundedRectangle(combined, 4.0f, 1.0f);
 
         // Thin horizontal border between input and bottom bar
-        float separatorY = static_cast<float>(inputBounds.getBottom());
+        auto separatorY = static_cast<float>(inputBounds.getBottom());
         g.drawHorizontalLine(static_cast<int>(separatorY), combined.getX() + 1.0f,
                              combined.getRight() - 1.0f);
 

--- a/magda/daw/ui/panels/content/DrumGridClipContent.cpp
+++ b/magda/daw/ui/panels/content/DrumGridClipContent.cpp
@@ -532,7 +532,7 @@ class DrumGridClipGrid : public juce::Component,
         {
             double beatsVisible =
                 static_cast<double>(bounds.getWidth() - GRID_LEFT_PADDING) / pixelsPerBeat_;
-            float gridBottom = static_cast<float>(numRows * rowHeight_);
+            auto gridBottom = static_cast<float>(numRows * rowHeight_);
             int maxX = bounds.getWidth();
             int tsNum = timeSigNumerator_;
 
@@ -2891,8 +2891,8 @@ void DrumGridClipContent::drawSidebar(juce::Graphics& g, juce::Rectangle<int> ar
     const int topDividerY = topClusterBottom + padding / 2;
     const int bottomDividerY = bottomClusterTop - padding / 2;
 
-    const float x1 = static_cast<float>(area.getX() + 5);
-    const float x2 = static_cast<float>(area.getRight() - 5);
+    const auto x1 = static_cast<float>(area.getX() + 5);
+    const auto x2 = static_cast<float>(area.getRight() - 5);
     if (foldToggle_ && bottomDividerY - topDividerY > padding) {
         g.drawHorizontalLine(topDividerY, x1, x2);
         g.drawHorizontalLine(bottomDividerY, x1, x2);

--- a/magda/daw/ui/panels/content/PianoRollContent.cpp
+++ b/magda/daw/ui/panels/content/PianoRollContent.cpp
@@ -1842,8 +1842,8 @@ void PianoRollContent::drawSidebar(juce::Graphics& g, juce::Rectangle<int> area)
     const int topDividerY = topClusterBottom + padding / 2;
     const int bottomDividerY = bottomClusterTop - padding / 2;
 
-    const float x1 = static_cast<float>(area.getX() + 5);
-    const float x2 = static_cast<float>(area.getRight() - 5);
+    const auto x1 = static_cast<float>(area.getX() + 5);
+    const auto x2 = static_cast<float>(area.getRight() - 5);
     if (bottomDividerY - topDividerY > padding) {
         g.drawHorizontalLine(topDividerY, x1, x2);
         g.drawHorizontalLine(bottomDividerY, x1, x2);

--- a/magda/daw/ui/panels/content/TrackChainContent.cpp
+++ b/magda/daw/ui/panels/content/TrackChainContent.cpp
@@ -180,7 +180,7 @@ class GainMeterComponent : public juce::Component,
         g.fillRect(fillArea);
 
         // Gain position indicator (horizontal line)
-        float gainNormalized = static_cast<float>((gainDb_ + 60.0) / 66.0);  // -60 to +6 dB
+        auto gainNormalized = static_cast<float>((gainDb_ + 60.0) / 66.0);  // -60 to +6 dB
         int gainY =
             meterArea.getY() + static_cast<int>((1.0f - gainNormalized) * meterArea.getHeight());
         g.setColour(DarkTheme::getTextColour());

--- a/magda/daw/ui/panels/content/inspector/TrackInspector.cpp
+++ b/magda/daw/ui/panels/content/inspector/TrackInspector.cpp
@@ -329,7 +329,7 @@ TrackInspector::TrackInspector() {
     panLabel_->onValueChange = [this]() {
         if (selectedTrackId_ == magda::INVALID_TRACK_ID)
             return;
-        float pan = static_cast<float>(panLabel_->getValue());
+        auto pan = static_cast<float>(panLabel_->getValue());
         if (panLabel_->isDragging()) {
             // Apply directly during drag (no undo command per pixel)
             if (selectedTrackId_ == magda::MASTER_TRACK_ID)
@@ -349,8 +349,8 @@ TrackInspector::TrackInspector() {
     panLabel_->onDragEnd = [this](double startValue) {
         if (selectedTrackId_ == magda::INVALID_TRACK_ID)
             return;
-        float oldPan = static_cast<float>(startValue);
-        float newPan = static_cast<float>(panLabel_->getValue());
+        auto oldPan = static_cast<float>(startValue);
+        auto newPan = static_cast<float>(panLabel_->getValue());
         if (selectedTrackId_ == magda::MASTER_TRACK_ID)
             magda::UndoManager::getInstance().executeCommand(
                 std::make_unique<magda::SetMasterPanCommand>(oldPan, newPan));
@@ -868,7 +868,7 @@ void TrackInspector::setSelectedTrack(magda::TrackId trackId) {
         panLabel_->onValueChange = [this]() {
             if (selectedTrackId_ == magda::INVALID_TRACK_ID)
                 return;
-            float pan = static_cast<float>(panLabel_->getValue());
+            auto pan = static_cast<float>(panLabel_->getValue());
             if (panLabel_->isDragging()) {
                 if (selectedTrackId_ == magda::MASTER_TRACK_ID)
                     magda::TrackManager::getInstance().setMasterPan(pan);
@@ -886,8 +886,8 @@ void TrackInspector::setSelectedTrack(magda::TrackId trackId) {
         panLabel_->onDragEnd = [this](double startValue) {
             if (selectedTrackId_ == magda::INVALID_TRACK_ID)
                 return;
-            float oldPan = static_cast<float>(startValue);
-            float newPan = static_cast<float>(panLabel_->getValue());
+            auto oldPan = static_cast<float>(startValue);
+            auto newPan = static_cast<float>(panLabel_->getValue());
             if (selectedTrackId_ == magda::MASTER_TRACK_ID)
                 magda::UndoManager::getInstance().executeCommand(
                     std::make_unique<magda::SetMasterPanCommand>(oldPan, newPan));

--- a/magda/daw/ui/panels/content/inspector/clip/ClipInspectorSections.cpp
+++ b/magda/daw/ui/panels/content/inspector/clip/ClipInspectorSections.cpp
@@ -1600,7 +1600,7 @@ void ClipInspector::initGrooveSection() {
     grooveStrengthValue_->onValueChange = [this]() {
         if (selectedClipIds_.empty())
             return;
-        float newStrength = static_cast<float>(grooveStrengthValue_->getValue());
+        auto newStrength = static_cast<float>(grooveStrengthValue_->getValue());
         magda::ClipBatchEdit batch("Set Clip Groove Strength", selectedClipIds_.size());
         for (auto cid : selectedClipIds_) {
             const auto* c = magda::ClipManager::getInstance().getClip(cid);
@@ -1834,7 +1834,7 @@ void ClipInspector::initPlaybackSection() {
     beatSensitivityValue_->onValueChange = [this]() {
         if (selectedClipIds_.empty())
             return;
-        float sensitivity = static_cast<float>(beatSensitivityValue_->getValue());
+        auto sensitivity = static_cast<float>(beatSensitivityValue_->getValue());
         magda::ClipBatchEdit batch("Set Clip Beat Sensitivity", selectedClipIds_.size());
         for (auto cid : selectedClipIds_) {
             const auto* c = magda::ClipManager::getInstance().getClip(cid);

--- a/magda/daw/ui/views/ClipSlotButton.hpp
+++ b/magda/daw/ui/views/ClipSlotButton.hpp
@@ -260,7 +260,7 @@ class ClipSlotButton : public juce::TextButton {
 
             // Draw progress bar for playing clips
             if (clipIsPlaying && clipLength > 0.0 && sessionPlayheadPos >= 0.0) {
-                float progress = static_cast<float>(sessionPlayheadPos / clipLength);
+                auto progress = static_cast<float>(sessionPlayheadPos / clipLength);
                 progress = juce::jlimit(0.0f, 1.0f, progress);
 
                 auto progressBar = contentArea.toFloat();
@@ -482,7 +482,7 @@ class MiniDbScale : public juce::Component {
 
         static constexpr float PADDING = 4.0f;
         float height = static_cast<float>(bounds.getHeight()) - 2.0f * PADDING;
-        float width = static_cast<float>(bounds.getWidth());
+        auto width = static_cast<float>(bounds.getWidth());
 
         if (height <= 0.0f)
             return;

--- a/magda/daw/ui/views/MainView.cpp
+++ b/magda/daw/ui/views/MainView.cpp
@@ -1729,7 +1729,7 @@ void MainView::PlayheadComponent::paint(juce::Graphics& g) {
         }
         g.setColour(DarkTheme::getColour(DarkTheme::TEXT_PRIMARY).withAlpha(triAlpha));
         // Fill the playhead row: top edge at y0, tip at the row bottom.
-        const float ph = static_cast<float>(LayoutConfig::getInstance().playheadRowHeight);
+        const auto ph = static_cast<float>(LayoutConfig::getInstance().playheadRowHeight);
         juce::Path triangle;
         triangle.addTriangle(editX - 6, 0.0f, editX + 6, 0.0f, editX, ph);
         g.fillPath(triangle);
@@ -1741,7 +1741,7 @@ void MainView::PlayheadComponent::paint(juce::Graphics& g) {
         // Draw thin vertical line extending the full track area, starting at the
         // top of the track content (just below the playhead/triangle row).
         g.setColour(DarkTheme::getColour(DarkTheme::TEXT_PRIMARY).withAlpha(0.85f));
-        const float lineTop = static_cast<float>(LayoutConfig::getInstance().playheadRowHeight);
+        const auto lineTop = static_cast<float>(LayoutConfig::getInstance().playheadRowHeight);
         g.drawLine(static_cast<float>(playX), lineTop, static_cast<float>(playX),
                    static_cast<float>(getHeight()), 1.5f);
     }
@@ -2510,7 +2510,7 @@ void MainView::MasterHeaderPanel::setupControls() {
     volumeLabel->setFillProportionMapper(level_meter_scale::dbFillProportion);
     volumeLabel->setDoubleClickResetsValue(true);
     volumeLabel->onValueChange = [this]() {
-        const float db = static_cast<float>(volumeLabel->getValue());
+        const auto db = static_cast<float>(volumeLabel->getValue());
         UndoManager::getInstance().executeCommand(
             std::make_unique<SetMasterVolumeCommand>(dbToGain(db)));
     };
@@ -2822,7 +2822,7 @@ void MainView::AuxHeadersPanel::rebuildAuxRows() {
         TrackId tid = track.id;
         auto* volLabelPtr = row->volumeLabel.get();
         row->volumeLabel->onValueChange = [tid, volLabelPtr]() {
-            float newDb = static_cast<float>(volLabelPtr->getValue());
+            auto newDb = static_cast<float>(volLabelPtr->getValue());
             float gain = dbToGain(newDb);
             UndoManager::getInstance().executeCommand(
                 std::make_unique<SetTrackVolumeCommand>(tid, gain));

--- a/magda/daw/ui/views/MixerView.cpp
+++ b/magda/daw/ui/views/MixerView.cpp
@@ -243,7 +243,7 @@ class MixerView::ChannelStrip::DbScale : public juce::Component {
         float paddingBottom = metrics.labelTextHeight / 2.0f;
         float top = paddingTop;
         float height = static_cast<float>(bounds.getHeight()) - paddingTop - paddingBottom;
-        float totalWidth = static_cast<float>(bounds.getWidth());
+        auto totalWidth = static_cast<float>(bounds.getWidth());
 
         const float tickShort = metrics.tickWidth();  // regular tick: ~5px
         const float tickLong = tickShort * 1.8f;      // 0 dB tick is noticeably longer

--- a/magda/daw/ui/views/SessionView.cpp
+++ b/magda/daw/ui/views/SessionView.cpp
@@ -569,7 +569,7 @@ class SessionView::BeatBandContainer : public juce::Component {
 
             if (!hidden) {
                 double phase = (i < static_cast<int>(phases_.size())) ? phases_[i] : 0.0;
-                float alpha = static_cast<float>(juce::jmax(0.0, 0.85 - phase * 0.85));
+                auto alpha = static_cast<float>(juce::jmax(0.0, 0.85 - phase * 0.85));
                 g.setColour(pulseColour.withAlpha(alpha));
                 g.fillEllipse(layout.dotCentre.getX() - kDotRadius,
                               layout.dotCentre.getY() - kDotRadius, kDotRadius * 2.0f,
@@ -666,7 +666,7 @@ class SessionView::MasterBeatIndicator : public juce::Component {
         g.setColour(DarkTheme::getColour(DarkTheme::SEPARATOR));
         g.fillRect(0, 0, getWidth(), 1);
 
-        const float alpha = static_cast<float>(juce::jmax(0.0, 0.85 - phase_ * 0.85));
+        const auto alpha = static_cast<float>(juce::jmax(0.0, 0.85 - phase_ * 0.85));
         constexpr float kDotRadius = 3.0f;
         const auto centre = getLocalBounds().toFloat().getCentre();
         g.setColour(DarkTheme::getColour(DarkTheme::ACCENT_INFO).withAlpha(alpha));

--- a/magda/daw/ui/windows/MainWindowCommands.cpp
+++ b/magda/daw/ui/windows/MainWindowCommands.cpp
@@ -1983,7 +1983,7 @@ bool MainWindow::MainComponent::perform(const InvocationInfo& info) {
 
         case uiScaleUp:
         case uiScaleDown: {
-            const double current =
+            const auto current =
                 static_cast<double>(juce::Desktop::getInstance().getGlobalScaleFactor());
             const int direction = (info.commandID == uiScaleUp) ? +1 : -1;
             applyUIScale(stepUIScale(current, direction));

--- a/magda/engine/param/ModLfo.cpp
+++ b/magda/engine/param/ModLfo.cpp
@@ -285,8 +285,8 @@ float advanceLfo(LfoState& state, const LfoSettings& settings,
         // The intro plays once and the region repeats from there. Read off the
         // cumulative position rather than the wrapped phase, because which of
         // the two it is depends on how many cycles have gone by.
-        const double length = static_cast<double>(settings.loopEnd - settings.loopStart);
-        const double start = static_cast<double>(settings.loopStart);
+        const auto length = static_cast<double>(settings.loopEnd - settings.loopStart);
+        const auto start = static_cast<double>(settings.loopStart);
         const double effective =
             cycles < start ? cycles : start + std::fmod(cycles - start, length);
 
@@ -343,8 +343,8 @@ float advanceLfo(LfoState& state, const LfoSettings& settings,
     // started a moment ago. A one-shot is the exception: how far past the end
     // it is is the whole question it answers.
     if (looping) {
-        const double length = static_cast<double>(settings.loopEnd - settings.loopStart);
-        const double start = static_cast<double>(settings.loopStart);
+        const auto length = static_cast<double>(settings.loopEnd - settings.loopStart);
+        const auto start = static_cast<double>(settings.loopStart);
         if (state.cycles >= start + length)
             state.cycles = start + std::fmod(state.cycles - start, length);
     } else if (!settings.oneShot && state.cycles >= 1.0) {

--- a/magda/scripting/LuaRuntime.cpp
+++ b/magda/scripting/LuaRuntime.cpp
@@ -171,7 +171,7 @@ std::optional<long long> LuaRuntime::evalToInt(const juce::String& chunk) {
         lastError_ = "result is not an integer";
         return std::nullopt;
     }
-    long long result = static_cast<long long>(lua_tointeger(L_, -1));
+    auto result = static_cast<long long>(lua_tointeger(L_, -1));
     lua_pop(L_, 1);
     return result;
 }


### PR DESCRIPTION
## Summary
- First of the per-check PRs from #2388: `clang-tidy`'s `modernize-use-auto -fix` applied over `magda/`, no hand edits.
- 264 sites across 93 files — `auto x = static_cast<T>(...)` in place of spelling out `T` twice.
- Reformatted with `clang-format` (a few lines collapsed onto one line once `auto` no longer needed the wrap).

## Test plan
- [x] `make debug` — builds clean
- [x] `make test` — 3573 passed, 13 skipped, 857009 assertions, 0 failed

Closes part of #2388.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0149ko34fXR5PeMBqVL1tDWt