### PR TITLE
Apply modernize-use-scoped-lock fixes across magda/

### DIFF
--- a/magda/agents/conversation_store.cpp
+++ b/magda/agents/conversation_store.cpp
@@ -37,7 +37,7 @@ void ConversationStore::record(Channel channel, const std::string& user,
     if (user.empty() && assistant.empty())
         return;
 
-    std::lock_guard<std::mutex> lock(mutex_);
+    std::scoped_lock lock(mutex_);
     auto& thread = threads_[channel];
     thread.push_back({user, assistant});
     while (thread.size() > kMaxStoredTurns)
@@ -45,7 +45,7 @@ void ConversationStore::record(Channel channel, const std::string& user,
 }
 
 std::string ConversationStore::render(Channel channel, int maxTurns) const {
-    std::lock_guard<std::mutex> lock(mutex_);
+    std::scoped_lock lock(mutex_);
     auto it = threads_.find(channel);
     if (it == threads_.end() || it->second.empty() || maxTurns <= 0)
         return {};
@@ -66,12 +66,12 @@ std::string ConversationStore::render(Channel channel, int maxTurns) const {
 }
 
 void ConversationStore::clear(Channel channel) {
-    std::lock_guard<std::mutex> lock(mutex_);
+    std::scoped_lock lock(mutex_);
     threads_.erase(channel);
 }
 
 void ConversationStore::clearAll() {
-    std::lock_guard<std::mutex> lock(mutex_);
+    std::scoped_lock lock(mutex_);
     threads_.clear();
 }
 

--- a/magda/agents/llama_model_manager.cpp
+++ b/magda/agents/llama_model_manager.cpp
@@ -58,7 +58,7 @@ bool LlamaModelManager::loadModel(const Config& config, std::string* errorMessag
         }
     } loadingReset{loading_};
 
-    std::lock_guard<std::mutex> lock(mutex_);
+    std::scoped_lock lock(mutex_);
 
     // Status reads happen on the message thread, so publish state via the lock-free
     // snapshot instead of the mutex held across model loading and inference.
@@ -103,7 +103,7 @@ bool LlamaModelManager::loadModel(const Config& config, std::string* errorMessag
 }
 
 void LlamaModelManager::unloadModel() {
-    std::lock_guard<std::mutex> lock(mutex_);
+    std::scoped_lock lock(mutex_);
 
     std::atomic_store_explicit(&loadedPathSnapshot_, std::shared_ptr<const std::string>{},
                                std::memory_order_release);
@@ -154,7 +154,7 @@ std::string LlamaModelManager::applyTemplate(const std::string& systemPrompt,
 
 LlamaModelManager::InferenceResult LlamaModelManager::infer(const InferenceRequest& req,
                                                             TokenCallback onToken) {
-    std::lock_guard<std::mutex> lock(mutex_);
+    std::scoped_lock lock(mutex_);
     InferenceResult result;
 
     if (model_ == nullptr || ctx_ == nullptr) {

--- a/magda/daw/api/remote_api_host.cpp
+++ b/magda/daw/api/remote_api_host.cpp
@@ -239,7 +239,7 @@ RemoteApiHost::~RemoteApiHost() {
 void RemoteApiHost::persistGrants() {
     auto writer = grantWriter_;
     {
-        const std::lock_guard<std::mutex> lock(writer->mutex);
+        const std::scoped_lock lock(writer->mutex);
         // Snapshotted *under* this lock, not before it. Reading first and
         // storing second leaves the same reordering one level down: a thread
         // can read A, be preempted while another reads B and stores it, then
@@ -283,11 +283,11 @@ void RemoteApiHost::persistGrants() {
         // only ever takes `mutex`, so a recorder is never blocked behind a file
         // write; it just leaves a newer `latest` for whoever is inside here to
         // pick up.
-        const std::lock_guard<std::mutex> applying(writer->applyMutex);
+        const std::scoped_lock applying(writer->applyMutex);
 
         juce::var latest;
         {
-            const std::lock_guard<std::mutex> lock(writer->mutex);
+            const std::scoped_lock lock(writer->mutex);
             latest = writer->latest;
             writer->posted = false;
         }
@@ -316,7 +316,7 @@ void RemoteApiHost::persistGrants() {
     // is not persisted — the same outcome as the process being killed a moment
     // earlier, and not something worth a synchronous write on shutdown.
     if (!juce::MessageManager::callAsync(apply)) {
-        const std::lock_guard<std::mutex> lock(writer->mutex);
+        const std::scoped_lock lock(writer->mutex);
         writer->posted = false;
     }
 }

--- a/magda/daw/api/remote_audit.cpp
+++ b/magda/daw/api/remote_audit.cpp
@@ -87,7 +87,7 @@ void RemoteAuditLog::record(AuditEntry entry) {
     // the call sites instead would mean each new one is a chance to forget.
     entry.detail = redactSecrets(entry.detail);
 
-    const std::lock_guard<std::mutex> lock(mutex_);
+    const std::scoped_lock lock(mutex_);
     entries_.push_back(std::move(entry));
     ++totalRecorded_;
     while (entries_.size() > capacity_)
@@ -95,18 +95,18 @@ void RemoteAuditLog::record(AuditEntry entry) {
 }
 
 std::vector<AuditEntry> RemoteAuditLog::entries() const {
-    const std::lock_guard<std::mutex> lock(mutex_);
+    const std::scoped_lock lock(mutex_);
     return {entries_.begin(), entries_.end()};
 }
 
 std::vector<AuditEntry> RemoteAuditLog::recent(std::size_t count) const {
-    const std::lock_guard<std::mutex> lock(mutex_);
+    const std::scoped_lock lock(mutex_);
     const auto take = std::min(count, entries_.size());
     return {entries_.end() - static_cast<std::ptrdiff_t>(take), entries_.end()};
 }
 
 std::vector<AuditEntry> RemoteAuditLog::forClient(const juce::String& clientName) const {
-    const std::lock_guard<std::mutex> lock(mutex_);
+    const std::scoped_lock lock(mutex_);
     std::vector<AuditEntry> result;
     for (const auto& entry : entries_) {
         if (entry.client == clientName)
@@ -116,7 +116,7 @@ std::vector<AuditEntry> RemoteAuditLog::forClient(const juce::String& clientName
 }
 
 void RemoteAuditLog::clear() {
-    const std::lock_guard<std::mutex> lock(mutex_);
+    const std::scoped_lock lock(mutex_);
     entries_.clear();
     // `totalRecorded_` deliberately survives: it is the "did anything change"
     // cursor the UI polls, and resetting it would make a clear look like no
@@ -124,24 +124,24 @@ void RemoteAuditLog::clear() {
 }
 
 std::size_t RemoteAuditLog::size() const {
-    const std::lock_guard<std::mutex> lock(mutex_);
+    const std::scoped_lock lock(mutex_);
     return entries_.size();
 }
 
 std::size_t RemoteAuditLog::capacity() const {
-    const std::lock_guard<std::mutex> lock(mutex_);
+    const std::scoped_lock lock(mutex_);
     return capacity_;
 }
 
 void RemoteAuditLog::setCapacity(std::size_t capacity) {
-    const std::lock_guard<std::mutex> lock(mutex_);
+    const std::scoped_lock lock(mutex_);
     capacity_ = capacity == 0 ? DEFAULT_CAPACITY : capacity;
     while (entries_.size() > capacity_)
         entries_.pop_front();
 }
 
 std::uint64_t RemoteAuditLog::totalRecorded() const {
-    const std::lock_guard<std::mutex> lock(mutex_);
+    const std::scoped_lock lock(mutex_);
     return totalRecorded_;
 }
 
@@ -157,20 +157,20 @@ void registerRemoteSecret(const juce::String& secret) {
     if (secret.length() < 8)
         return;
 
-    const std::lock_guard<std::mutex> lock(secretsMutex());
+    const std::scoped_lock lock(secretsMutex());
     auto& values = secrets();
     if (std::find(values.begin(), values.end(), secret) == values.end())
         values.push_back(secret);
 }
 
 void forgetRemoteSecret(const juce::String& secret) {
-    const std::lock_guard<std::mutex> lock(secretsMutex());
+    const std::scoped_lock lock(secretsMutex());
     auto& values = secrets();
     values.erase(std::remove(values.begin(), values.end(), secret), values.end());
 }
 
 void forgetAllRemoteSecrets() {
-    const std::lock_guard<std::mutex> lock(secretsMutex());
+    const std::scoped_lock lock(secretsMutex());
     secrets().clear();
 }
 
@@ -180,7 +180,7 @@ juce::String redactSecrets(const juce::String& text) {
 
     juce::String result = text;
     {
-        const std::lock_guard<std::mutex> lock(secretsMutex());
+        const std::scoped_lock lock(secretsMutex());
         for (const auto& secret : secrets())
             result = result.replace(secret, kMask, false);
     }

--- a/magda/daw/api/remote_changes.cpp
+++ b/magda/daw/api/remote_changes.cpp
@@ -91,7 +91,7 @@ ChangeSource::~ChangeSource() = default;
 int ChangeSource::addListener(Listener listener) {
     int token = 0;
     {
-        const std::lock_guard<std::mutex> lock(listenerMutex_);
+        const std::scoped_lock lock(listenerMutex_);
         token = nextToken_++;
         listeners_.emplace_back(token, std::move(listener));
     }
@@ -101,7 +101,7 @@ int ChangeSource::addListener(Listener listener) {
 
 void ChangeSource::removeListener(int token) {
     {
-        const std::lock_guard<std::mutex> lock(listenerMutex_);
+        const std::scoped_lock lock(listenerMutex_);
         listeners_.erase(
             std::remove_if(listeners_.begin(), listeners_.end(),
                            [token](const auto& entry) { return entry.first == token; }),
@@ -145,7 +145,7 @@ void ChangeSource::flush() {
     // invalidate the iterator mid-notification.
     std::vector<Listener> targets;
     {
-        const std::lock_guard<std::mutex> lock(listenerMutex_);
+        const std::scoped_lock lock(listenerMutex_);
         targets.reserve(listeners_.size());
         for (const auto& [token, listener] : listeners_)
             targets.push_back(listener);
@@ -179,7 +179,7 @@ void ChangeSource::startPumpIfNeeded() {
 }
 
 void ChangeSource::stopPumpIfIdle() {
-    const std::lock_guard<std::mutex> lock(listenerMutex_);
+    const std::scoped_lock lock(listenerMutex_);
     if (listeners_.empty())
         pump_.reset();
 }

--- a/magda/daw/api/remote_clients.cpp
+++ b/magda/daw/api/remote_clients.cpp
@@ -25,7 +25,7 @@ ScopeSet RemoteClientRegistry::scopesFor(const juce::String& clientName) {
     bool created = false;
     ScopeSet scopes;
     {
-        const std::lock_guard<std::mutex> lock(mutex_);
+        const std::scoped_lock lock(mutex_);
         auto found = grants_.find(key);
         if (found == grants_.end()) {
             ClientGrant grant;
@@ -52,7 +52,7 @@ ScopeSet RemoteClientRegistry::scopesFor(const juce::String& clientName) {
 
 std::optional<ScopeSet> RemoteClientRegistry::peekScopes(const juce::String& clientName) const {
     const auto key = normaliseClientName(clientName).toStdString();
-    const std::lock_guard<std::mutex> lock(mutex_);
+    const std::scoped_lock lock(mutex_);
     const auto found = grants_.find(key);
     if (found == grants_.end())
         return std::nullopt;
@@ -68,7 +68,7 @@ void RemoteClientRegistry::setScopes(const juce::String& clientName, ScopeSet sc
     scopes.add(Scope::Read);
 
     {
-        const std::lock_guard<std::mutex> lock(mutex_);
+        const std::scoped_lock lock(mutex_);
         auto& grant = grants_[key];
         if (grant.name.isEmpty()) {
             grant.name = juce::String(key);
@@ -85,7 +85,7 @@ void RemoteClientRegistry::setScopes(const juce::String& clientName, ScopeSet sc
 void RemoteClientRegistry::forget(const juce::String& clientName) {
     const auto key = normaliseClientName(clientName).toStdString();
     {
-        const std::lock_guard<std::mutex> lock(mutex_);
+        const std::scoped_lock lock(mutex_);
         if (grants_.erase(key) == 0)
             return;
     }
@@ -93,7 +93,7 @@ void RemoteClientRegistry::forget(const juce::String& clientName) {
 }
 
 std::vector<ClientGrant> RemoteClientRegistry::grants() const {
-    const std::lock_guard<std::mutex> lock(mutex_);
+    const std::scoped_lock lock(mutex_);
     std::vector<ClientGrant> result;
     result.reserve(grants_.size());
     for (const auto& [key, grant] : grants_)
@@ -110,7 +110,7 @@ void RemoteClientRegistry::noteConnected(ConnectedClient client) {
     if (client.connectedAtMs == 0)
         client.connectedAtMs = nowMs();
 
-    const std::lock_guard<std::mutex> lock(mutex_);
+    const std::scoped_lock lock(mutex_);
     // Replace rather than append on a repeated id. A transport that reuses one
     // would otherwise leave a phantom row that no disconnect could clear,
     // because `noteDisconnected` removes a single entry.
@@ -125,7 +125,7 @@ void RemoteClientRegistry::noteConnected(ConnectedClient client) {
 }
 
 void RemoteClientRegistry::noteDisconnected(const juce::String& connectionId) {
-    const std::lock_guard<std::mutex> lock(mutex_);
+    const std::scoped_lock lock(mutex_);
     connections_.erase(std::remove_if(connections_.begin(), connections_.end(),
                                       [&](const ConnectedClient& client) {
                                           return client.connectionId == connectionId;
@@ -134,18 +134,18 @@ void RemoteClientRegistry::noteDisconnected(const juce::String& connectionId) {
 }
 
 std::vector<ConnectedClient> RemoteClientRegistry::connections() const {
-    const std::lock_guard<std::mutex> lock(mutex_);
+    const std::scoped_lock lock(mutex_);
     return connections_;
 }
 
 int RemoteClientRegistry::connectionCount() const {
-    const std::lock_guard<std::mutex> lock(mutex_);
+    const std::scoped_lock lock(mutex_);
     return static_cast<int>(connections_.size());
 }
 
 void RemoteClientRegistry::setDisconnectHandler(const juce::String& transport,
                                                 DisconnectHandler handler) {
-    const std::lock_guard<std::mutex> lock(mutex_);
+    const std::scoped_lock lock(mutex_);
     if (handler)
         disconnectHandlers_[transport.toStdString()] = std::move(handler);
     else
@@ -155,7 +155,7 @@ void RemoteClientRegistry::setDisconnectHandler(const juce::String& transport,
 bool RemoteClientRegistry::disconnect(const juce::String& connectionId) {
     DisconnectHandler handler;
     {
-        const std::lock_guard<std::mutex> lock(mutex_);
+        const std::scoped_lock lock(mutex_);
         const auto found = std::find_if(
             connections_.begin(), connections_.end(),
             [&](const ConnectedClient& client) { return client.connectionId == connectionId; });
@@ -182,7 +182,7 @@ int RemoteClientRegistry::disconnectClient(const juce::String& clientName) {
     // Snapshot the ids under the lock, close outside it, for the reason above.
     std::vector<juce::String> ids;
     {
-        const std::lock_guard<std::mutex> lock(mutex_);
+        const std::scoped_lock lock(mutex_);
         for (const auto& client : connections_) {
             if (client.name == name)
                 ids.push_back(client.connectionId);
@@ -235,7 +235,7 @@ void RemoteClientRegistry::loadGrantsFromJson(const juce::var& value) {
     }
 
     {
-        const std::lock_guard<std::mutex> lock(mutex_);
+        const std::scoped_lock lock(mutex_);
         grants_ = std::move(loaded);
     }
     // Deliberately silent. This runs during startup, from the same code that
@@ -244,14 +244,14 @@ void RemoteClientRegistry::loadGrantsFromJson(const juce::var& value) {
 }
 
 void RemoteClientRegistry::setChangeHandler(std::function<void()> onChanged) {
-    const std::lock_guard<std::mutex> lock(changeHandlerMutex_);
+    const std::scoped_lock lock(changeHandlerMutex_);
     onChanged_ = std::move(onChanged);
 }
 
 void RemoteClientRegistry::notifyChanged() {
     std::function<void()> handler;
     {
-        const std::lock_guard<std::mutex> lock(changeHandlerMutex_);
+        const std::scoped_lock lock(changeHandlerMutex_);
         handler = onChanged_;
     }
     // Copied and called outside both locks: a handler is free to read grants

--- a/magda/daw/api/remote_mcp_server.cpp
+++ b/magda/daw/api/remote_mcp_server.cpp
@@ -198,7 +198,7 @@ struct EventStream {
 
     bool push(std::string frame) {
         {
-            const std::lock_guard<std::mutex> lock(mutex);
+            const std::scoped_lock lock(mutex);
             if (closed || static_cast<int>(outbox.size()) >= capacity)
                 return false;
             outbox.push_back(std::move(frame));
@@ -219,7 +219,7 @@ struct EventStream {
     bool publish(Topic topic, const McpEndpoint& endpoint) {
         std::vector<std::string> frames;
         {
-            const std::lock_guard<std::mutex> lock(mutex);
+            const std::scoped_lock lock(mutex);
             if (closed)
                 return false;
             const auto uris = endpoint.urisAffectedBy(topic, filter);
@@ -262,7 +262,7 @@ struct EventStream {
 
     void close(std::string terminalFrame = {}) {
         {
-            const std::lock_guard<std::mutex> lock(mutex);
+            const std::scoped_lock lock(mutex);
             if (closed)
                 return;
             outbox.clear();
@@ -274,17 +274,17 @@ struct EventStream {
     }
 
     bool isClosed() const {
-        const std::lock_guard<std::mutex> lock(mutex);
+        const std::scoped_lock lock(mutex);
         return closed;
     }
 
     void setFilter(McpEndpoint::ListenFilter updated) {
-        const std::lock_guard<std::mutex> lock(mutex);
+        const std::scoped_lock lock(mutex);
         filter = std::move(updated);
     }
 
     McpEndpoint::ListenFilter currentFilter() const {
-        const std::lock_guard<std::mutex> lock(mutex);
+        const std::scoped_lock lock(mutex);
         return filter;
     }
 };
@@ -382,7 +382,7 @@ struct RemoteMcpServer::Impl {
     // -----------------------------------------------------------------------
 
     bool admit() {
-        const std::lock_guard<std::mutex> lock(rateMutex);
+        const std::scoped_lock lock(rateMutex);
         const auto now = std::chrono::steady_clock::now();
         const auto elapsed = std::chrono::duration<double>(now - lastRefill).count();
         lastRefill = now;
@@ -464,7 +464,7 @@ struct RemoteMcpServer::Impl {
     void collectIdleSessions() {
         std::vector<juce::String> collected;
         {
-            const std::lock_guard<std::mutex> lock(sessionMutex);
+            const std::scoped_lock lock(sessionMutex);
             collectIdleSessionsLocked(collected);
         }
         noteSessionsClosed(collected);
@@ -475,7 +475,7 @@ struct RemoteMcpServer::Impl {
         std::vector<juce::String> collected;
         juce::String id;
         {
-            const std::lock_guard<std::mutex> lock(sessionMutex);
+            const std::scoped_lock lock(sessionMutex);
             collectIdleSessionsLocked(collected);
             if (static_cast<int>(sessions.size()) >= options.maxSessions) {
                 // Still report the sessions that were just collected, or the
@@ -505,7 +505,7 @@ struct RemoteMcpServer::Impl {
     };
 
     std::optional<SessionState> touchSession(const juce::String& id) {
-        const std::lock_guard<std::mutex> lock(sessionMutex);
+        const std::scoped_lock lock(sessionMutex);
         const auto it = sessions.find(id.toStdString());
         if (it == sessions.end())
             return std::nullopt;
@@ -517,7 +517,7 @@ struct RemoteMcpServer::Impl {
         std::shared_ptr<EventStream> stream;
         juce::String clientName;
         {
-            const std::lock_guard<std::mutex> lock(sessionMutex);
+            const std::scoped_lock lock(sessionMutex);
             const auto it = sessions.find(id.toStdString());
             if (it == sessions.end())
                 return false;
@@ -603,7 +603,7 @@ struct RemoteMcpServer::Impl {
     bool disconnectByHandle(const juce::String& handle) {
         std::shared_ptr<EventStream> target;
         {
-            const std::lock_guard<std::mutex> lock(streamMutex);
+            const std::scoped_lock lock(streamMutex);
             const auto found = std::find_if(
                 streams.begin(), streams.end(),
                 [&](const std::shared_ptr<EventStream>& s) { return s->handle == handle; });
@@ -630,7 +630,7 @@ struct RemoteMcpServer::Impl {
                                              const juce::String& clientName) {
         std::shared_ptr<EventStream> stream;
         {
-            const std::lock_guard<std::mutex> lock(streamMutex);
+            const std::scoped_lock lock(streamMutex);
             if (static_cast<int>(streams.size()) >= options.maxStreams)
                 return nullptr;
             // Sized against the connection's own reading. Each entry is one
@@ -746,7 +746,7 @@ struct RemoteMcpServer::Impl {
         stream->close(std::move(terminal));
 
         {
-            const std::lock_guard<std::mutex> lock(streamMutex);
+            const std::scoped_lock lock(streamMutex);
             streams.erase(std::remove(streams.begin(), streams.end(), stream), streams.end());
         }
 
@@ -996,7 +996,7 @@ struct RemoteMcpServer::Impl {
     };
 
     bool registerWaiter(const std::shared_ptr<Waiter>& waiter) {
-        const std::lock_guard<std::mutex> lock(waiterMutex);
+        const std::scoped_lock lock(waiterMutex);
         // Synchronises with cancelWaiters(): a handler that reaches this point
         // after stop() has already swept the list must not add an unwakeable
         // waiter behind that sweep.
@@ -1010,7 +1010,7 @@ struct RemoteMcpServer::Impl {
     }
 
     void unregisterWaiter(const std::shared_ptr<Waiter>& waiter) {
-        const std::lock_guard<std::mutex> lock(waiterMutex);
+        const std::scoped_lock lock(waiterMutex);
         waiters.erase(std::remove_if(waiters.begin(), waiters.end(),
                                      [&](const auto& weak) {
                                          const auto live = weak.lock();
@@ -1022,7 +1022,7 @@ struct RemoteMcpServer::Impl {
     void cancelWaiters() {
         std::vector<std::shared_ptr<Waiter>> live;
         {
-            const std::lock_guard<std::mutex> lock(waiterMutex);
+            const std::scoped_lock lock(waiterMutex);
             for (const auto& weak : waiters)
                 if (auto waiter = weak.lock())
                     live.push_back(std::move(waiter));
@@ -1030,7 +1030,7 @@ struct RemoteMcpServer::Impl {
         }
         for (const auto& waiter : live) {
             {
-                const std::lock_guard<std::mutex> lock(waiter->mutex);
+                const std::scoped_lock lock(waiter->mutex);
                 if (waiter->done)
                     continue;
                 waiter->reply =
@@ -1062,7 +1062,7 @@ struct RemoteMcpServer::Impl {
         }
         endpoint.handle(call, [waiter](McpReply reply) {
             {
-                const std::lock_guard<std::mutex> lock(waiter->mutex);
+                const std::scoped_lock lock(waiter->mutex);
                 if (waiter->done)
                     return;
                 waiter->reply = std::move(reply);
@@ -1170,7 +1170,7 @@ struct RemoteMcpServer::Impl {
 
         std::shared_ptr<EventStream> stream;
         {
-            const std::lock_guard<std::mutex> lock(sessionMutex);
+            const std::scoped_lock lock(sessionMutex);
             const auto it = sessions.find(call.idempotencyScope.toStdString());
             if (it == sessions.end()) {
                 writeJson(response, httplib::StatusCode::NotFound_404,
@@ -1410,7 +1410,7 @@ struct RemoteMcpServer::Impl {
         }
 
         {
-            const std::lock_guard<std::mutex> lock(sessionMutex);
+            const std::scoped_lock lock(sessionMutex);
             const auto it = sessions.find(sessionId.toStdString());
             if (it == sessions.end()) {
                 releaseStream(stream);
@@ -1470,12 +1470,12 @@ const McpEndpoint& RemoteMcpServer::endpoint() const {
 }
 
 int RemoteMcpServer::streamCount() const {
-    const std::lock_guard<std::mutex> lock(impl_->streamMutex);
+    const std::scoped_lock lock(impl_->streamMutex);
     return static_cast<int>(impl_->streams.size());
 }
 
 int RemoteMcpServer::sessionCount() const {
-    const std::lock_guard<std::mutex> lock(impl_->sessionMutex);
+    const std::scoped_lock lock(impl_->sessionMutex);
     return static_cast<int>(impl_->sessions.size());
 }
 
@@ -1580,7 +1580,7 @@ void RemoteMcpServer::stop() {
     // them waiting on a condition variable nobody was going to notify.
     std::vector<std::shared_ptr<EventStream>> live;
     {
-        const std::lock_guard<std::mutex> lock(impl_->streamMutex);
+        const std::scoped_lock lock(impl_->streamMutex);
         live = impl_->streams;
     }
     // `releaseStream` deregisters each from the client registry, so the
@@ -1592,7 +1592,7 @@ void RemoteMcpServer::stop() {
     {
         std::vector<juce::String> closed;
         {
-            const std::lock_guard<std::mutex> lock(impl_->sessionMutex);
+            const std::scoped_lock lock(impl_->sessionMutex);
             closed.reserve(impl_->sessions.size());
             for (const auto& [key, session] : impl_->sessions)
                 closed.push_back(session.id);

--- a/magda/daw/api/remote_service.cpp
+++ b/magda/daw/api/remote_service.cpp
@@ -136,14 +136,14 @@ RemoteApiService::~RemoteApiService() {
 }
 
 std::shared_ptr<RemoteApiService::ExecutionState> RemoteApiService::currentState() const {
-    const std::lock_guard<std::mutex> lock(stateMutex_);
+    const std::scoped_lock lock(stateMutex_);
     return state_;
 }
 
 void RemoteApiService::retireState() {
     std::shared_ptr<ExecutionState> retiring;
     {
-        const std::lock_guard<std::mutex> lock(stateMutex_);
+        const std::scoped_lock lock(stateMutex_);
         retiring = std::move(state_);
         state_.reset();
     }
@@ -152,7 +152,7 @@ void RemoteApiService::retireState() {
     // Taking the execution lock here is the whole point: it cannot be acquired
     // while a job is inside execute(), so once this returns no job is running
     // and none can start.
-    const std::lock_guard<std::mutex> lock(retiring->mutex);
+    const std::scoped_lock lock(retiring->mutex);
     retiring->revisionAtRetirement = currentRevision();
     retiring->service = nullptr;
 }
@@ -265,7 +265,7 @@ void RemoteApiService::dispatch(const juce::String& operationName, const juce::v
             // The lock is held across the handler, so the service cannot be
             // retired out from under it, and two handlers cannot run at once
             // even when the caller's thread executes them inline.
-            const std::lock_guard<std::mutex> lock(state->mutex);
+            const std::scoped_lock lock(state->mutex);
             if (state->service == nullptr) {
                 // The revision the service had when it was retired, not zero:
                 // a client's cursor must never be moved backwards by a failure.
@@ -434,7 +434,7 @@ void RemoteApiService::projectReplaced() {
     // queued work.
     retireState();
     {
-        const std::lock_guard<std::mutex> lock(stateMutex_);
+        const std::scoped_lock lock(stateMutex_);
         state_ = std::make_shared<ExecutionState>();
         state_->service = this;
     }
@@ -461,7 +461,7 @@ void RemoteApiService::projectReplaced() {
     }
 
     {
-        const std::lock_guard<std::mutex> lock(cacheMutex_);
+        const std::scoped_lock lock(cacheMutex_);
         cache_.clear();
     }
 }
@@ -504,12 +504,12 @@ const ChangeSource& RemoteApiService::changes() const {
 }
 
 void RemoteApiService::setAuditLog(std::shared_ptr<RemoteAuditLog> log) {
-    const std::lock_guard<std::mutex> lock(auditMutex_);
+    const std::scoped_lock lock(auditMutex_);
     audit_ = std::move(log);
 }
 
 std::shared_ptr<RemoteAuditLog> RemoteApiService::auditLog() const {
-    const std::lock_guard<std::mutex> lock(auditMutex_);
+    const std::scoped_lock lock(auditMutex_);
     return audit_;
 }
 
@@ -553,7 +553,7 @@ void RemoteApiService::recordAudit(const std::shared_ptr<RemoteAuditLog>& log,
 }
 
 void RemoteApiService::setIdempotencyCacheCapacity(std::size_t capacity) {
-    const std::lock_guard<std::mutex> lock(cacheMutex_);
+    const std::scoped_lock lock(cacheMutex_);
     cacheCapacity_ = capacity;
     if (cache_.size() > cacheCapacity_)
         cache_.erase(cache_.begin(),
@@ -569,7 +569,7 @@ juce::String RemoteApiService::idempotencyKey(const RequestContext& context) {
 }
 
 std::optional<Response> RemoteApiService::cachedResponse(const juce::String& key) const {
-    const std::lock_guard<std::mutex> lock(cacheMutex_);
+    const std::scoped_lock lock(cacheMutex_);
     const auto found =
         std::find_if(cache_.begin(), cache_.end(),
                      [&key](const CachedResponse& entry) { return entry.key == key; });
@@ -579,7 +579,7 @@ std::optional<Response> RemoteApiService::cachedResponse(const juce::String& key
 }
 
 void RemoteApiService::cacheResponse(const juce::String& key, const Response& response) {
-    const std::lock_guard<std::mutex> lock(cacheMutex_);
+    const std::scoped_lock lock(cacheMutex_);
     const auto found =
         std::find_if(cache_.begin(), cache_.end(),
                      [&key](const CachedResponse& entry) { return entry.key == key; });

--- a/magda/daw/api/remote_subscriptions.cpp
+++ b/magda/daw/api/remote_subscriptions.cpp
@@ -344,13 +344,13 @@ void SubscriptionHub::shutdown() {
     // until any flush already inside publish() has finished, and that flush
     // needs mutex_ to finish.
     {
-        const std::lock_guard<std::mutex> lock(gate_->mutex);
+        const std::scoped_lock lock(gate_->mutex);
         gate_->hub = nullptr;
     }
 
     int token = 0;
     {
-        const std::lock_guard<std::mutex> lock(mutex_);
+        const std::scoped_lock lock(mutex_);
         if (shutdown_)
             return;
         shutdown_ = true;
@@ -367,7 +367,7 @@ void SubscriptionHub::shutdown() {
 }
 
 SubscriptionHub::ClientId SubscriptionHub::addClient(Sink sink, Disconnect disconnect) {
-    const std::lock_guard<std::mutex> lock(mutex_);
+    const std::scoped_lock lock(mutex_);
     if (shutdown_)
         return 0;
 
@@ -378,7 +378,7 @@ SubscriptionHub::ClientId SubscriptionHub::addClient(Sink sink, Disconnect disco
 
 void SubscriptionHub::removeClient(ClientId client) {
     {
-        const std::lock_guard<std::mutex> lock(mutex_);
+        const std::scoped_lock lock(mutex_);
         const auto found = std::remove_if(clients_.begin(), clients_.end(),
                                           [client](const Client& c) { return c.id == client; });
         if (found == clients_.end())
@@ -392,12 +392,12 @@ void SubscriptionHub::removeClient(ClientId client) {
 }
 
 int SubscriptionHub::clientCount() const {
-    const std::lock_guard<std::mutex> lock(mutex_);
+    const std::scoped_lock lock(mutex_);
     return static_cast<int>(clients_.size());
 }
 
 void SubscriptionHub::setMeterSource(std::unique_ptr<MeterSource> source) {
-    const std::lock_guard<std::mutex> lock(mutex_);
+    const std::scoped_lock lock(mutex_);
     meters_ = std::move(source);
 }
 
@@ -444,7 +444,7 @@ void SubscriptionHub::applyTopology() {
     bool wantSampler = false;
     int existing = 0;
     {
-        const std::lock_guard<std::mutex> lock(mutex_);
+        const std::scoped_lock lock(mutex_);
         topologyPending_ = false;
         if (shutdown_)
             return;
@@ -476,14 +476,14 @@ void SubscriptionHub::applyTopology() {
         auto gate = gate_;
         const auto token = service_.changes().addListener(
             [gate](const std::vector<ChangeSource::Change>& changes) {
-                const std::lock_guard<std::mutex> lock(gate->mutex);
+                const std::scoped_lock lock(gate->mutex);
                 if (gate->hub != nullptr)
                     gate->hub->publish(changes);
             });
 
         bool keep = false;
         {
-            const std::lock_guard<std::mutex> lock(mutex_);
+            const std::scoped_lock lock(mutex_);
             // Shutdown may have landed while the listener was being attached,
             // in which case this token is surplus.
             if (!shutdown_ && changeToken_ == 0) {
@@ -498,7 +498,7 @@ void SubscriptionHub::applyTopology() {
 
     int token = 0;
     {
-        const std::lock_guard<std::mutex> lock(mutex_);
+        const std::scoped_lock lock(mutex_);
         token = changeToken_;
         changeToken_ = 0;
     }
@@ -516,7 +516,7 @@ void SubscriptionHub::scheduleTopology() {
     }
 
     {
-        const std::lock_guard<std::mutex> lock(mutex_);
+        const std::scoped_lock lock(mutex_);
         if (shutdown_ || topologyPending_)
             return;
         topologyPending_ = true;
@@ -524,13 +524,13 @@ void SubscriptionHub::scheduleTopology() {
 
     auto gate = gate_;
     if (!juce::MessageManager::callAsync([gate] {
-            const std::lock_guard<std::mutex> lock(gate->mutex);
+            const std::scoped_lock lock(gate->mutex);
             if (gate->hub != nullptr)
                 gate->hub->applyTopology();
         })) {
         // The message loop is going away, so nothing will reconcile anything
         // again; shutdown() detaches everything regardless.
-        const std::lock_guard<std::mutex> lock(mutex_);
+        const std::scoped_lock lock(mutex_);
         topologyPending_ = false;
     }
 }
@@ -702,7 +702,7 @@ void SubscriptionHub::publish(const std::vector<ChangeSource::Change>& changes) 
     bool dropped = false;
     std::vector<Topic> stillOwed;
     {
-        const std::lock_guard<std::mutex> lock(mutex_);
+        const std::scoped_lock lock(mutex_);
         if (shutdown_)
             return;
 
@@ -752,7 +752,7 @@ void SubscriptionHub::publish(const std::vector<ChangeSource::Change>& changes) 
 }
 
 void SubscriptionHub::sampleNow() {
-    const std::lock_guard<std::mutex> lock(mutex_);
+    const std::scoped_lock lock(mutex_);
     if (shutdown_)
         return;
 
@@ -881,7 +881,7 @@ bool SubscriptionHub::handle(ClientId client, const juce::String& method, const 
                 onComplete = std::move(onComplete)]() mutable {
         Response response;
         {
-            const std::lock_guard<std::mutex> lock(gate->mutex);
+            const std::scoped_lock lock(gate->mutex);
             response = gate->hub != nullptr
                            ? gate->hub->execute(client, method, params, requested, topicsGiven)
                            : Response::failure(ErrorCode::Cancelled, "subscriptions are shut down",
@@ -912,7 +912,7 @@ Response SubscriptionHub::execute(ClientId client, const juce::String& method,
 
     Response response;
     {
-        const std::lock_guard<std::mutex> lock(mutex_);
+        const std::scoped_lock lock(mutex_);
         if (shutdown_)
             return Response::failure(ErrorCode::Cancelled, "remote API service is shut down",
                                      revision);

--- a/magda/daw/api/remote_websocket_server.cpp
+++ b/magda/daw/api/remote_websocket_server.cpp
@@ -324,7 +324,7 @@ struct Connection {
      */
     bool enqueue(std::string payload, bool ownsSlot) {
         {
-            const std::lock_guard<std::mutex> lock(mutex);
+            const std::scoped_lock lock(mutex);
             if (closed || queuedReplies >= maxQueuedReplies) {
                 if (ownsSlot)
                     releaseLocked();
@@ -349,7 +349,7 @@ struct Connection {
      */
     bool enqueueEvent(std::string payload) {
         {
-            const std::lock_guard<std::mutex> lock(mutex);
+            const std::scoped_lock lock(mutex);
             if (closed || queuedEvents >= maxQueuedEvents)
                 return false;
             ++queuedEvents;
@@ -373,7 +373,7 @@ struct Connection {
 
     void release() {
         {
-            const std::lock_guard<std::mutex> lock(mutex);
+            const std::scoped_lock lock(mutex);
             releaseLocked();
         }
         ready.notify_one();
@@ -391,14 +391,14 @@ struct Connection {
      * executed, mutations and all, and only its replies are thrown away.
      */
     bool isClosed() const {
-        const std::lock_guard<std::mutex> lock(mutex);
+        const std::scoped_lock lock(mutex);
         return closed;
     }
 
     void markClosed() {
         std::deque<Outgoing> abandoned;
         {
-            const std::lock_guard<std::mutex> lock(mutex);
+            const std::scoped_lock lock(mutex);
             closed = true;
             abandoned.swap(outbox);
             queuedReplies = 0;
@@ -428,7 +428,7 @@ struct Connection {
      * Returns an empty string when the request may proceed.
      */
     juce::String admit(int maxInFlight, double ratePerSecond, double burst) {
-        const std::lock_guard<std::mutex> lock(mutex);
+        const std::scoped_lock lock(mutex);
 
         const auto now = std::chrono::steady_clock::now();
         const auto elapsed = std::chrono::duration<double>(now - lastRefill).count();
@@ -511,7 +511,7 @@ struct RemoteWebSocketServer::Impl {
     std::vector<std::shared_ptr<Connection>> live;
 
     int connectionCount() const {
-        const std::lock_guard<std::mutex> lock(liveMutex);
+        const std::scoped_lock lock(liveMutex);
         return static_cast<int>(live.size());
     }
 
@@ -545,7 +545,7 @@ struct RemoteWebSocketServer::Impl {
      * immediately before that WebSocket is destroyed.
      */
     bool disconnectByHandle(const juce::String& handle) {
-        const std::lock_guard<std::mutex> lock(liveMutex);
+        const std::scoped_lock lock(liveMutex);
         const auto found =
             std::find_if(live.begin(), live.end(),
                          [&](const std::shared_ptr<Connection>& c) { return c->handle == handle; });
@@ -573,7 +573,7 @@ struct RemoteWebSocketServer::Impl {
      * the same function that removes one.
      */
     bool registerConnection(const std::shared_ptr<Connection>& connection) {
-        const std::lock_guard<std::mutex> lock(liveMutex);
+        const std::scoped_lock lock(liveMutex);
         if (static_cast<int>(live.size()) >= options.maxConnections)
             return false;
         live.push_back(connection);
@@ -925,7 +925,7 @@ struct RemoteWebSocketServer::Impl {
         writer.join();
 
         {
-            const std::lock_guard<std::mutex> lock(liveMutex);
+            const std::scoped_lock lock(liveMutex);
             live.erase(std::remove(live.begin(), live.end(), connection), live.end());
         }
 
@@ -1031,7 +1031,7 @@ void RemoteWebSocketServer::stop() {
     // OS shutdown is safe across threads and wakes the one framed reader; unlike
     // WebSocket::close(), it does not start a competing read for a Close echo.
     {
-        const std::lock_guard<std::mutex> lock(impl_->liveMutex);
+        const std::scoped_lock lock(impl_->liveMutex);
         for (const auto& connection : impl_->live)
             connection->shutdown();
     }

--- a/magda/daw/audio/plugins/InternalPluginRegistry.cpp
+++ b/magda/daw/audio/plugins/InternalPluginRegistry.cpp
@@ -101,7 +101,7 @@ bool registerDevicePack(DevicePackRegistration registerDevices) {
         return false;
 
     auto& state = registryState();
-    const std::lock_guard lock(state.mutex);
+    const std::scoped_lock lock(state.mutex);
     if (state.initialized ||
         std::find(state.packRegistrations.begin(), state.packRegistrations.end(),
                   registerDevices) != state.packRegistrations.end())
@@ -115,7 +115,7 @@ InternalPluginRegistry& getInternalPluginRegistry() {
     static InternalPluginRegistry registry;
     static const bool initialized = [] {
         auto& state = registryState();
-        const std::lock_guard lock(state.mutex);
+        const std::scoped_lock lock(state.mutex);
         for (const auto hook : state.packRegistrations)
             hook(registry);
         state.initialized = true;

--- a/magda/daw/audio/plugins/MidiChordEnginePlugin.cpp
+++ b/magda/daw/audio/plugins/MidiChordEnginePlugin.cpp
@@ -217,7 +217,7 @@ void MidiChordEnginePlugin::seedFromChords(const std::vector<magda::music::Chord
     // Prime the engine's context from an authored progression (e.g. the chord
     // track) so key / suggestions / scales appear without live play. Message
     // thread; serialised with runDetection via stateMutex_.
-    std::lock_guard<std::mutex> lock(stateMutex_);
+    std::scoped_lock lock(stateMutex_);
 
     suggestionEngine_.reset();
     keyHistogram_.reset();
@@ -253,7 +253,7 @@ void MidiChordEnginePlugin::runDetection() {
     }
 
     if (heldNotes.empty()) {
-        std::lock_guard<std::mutex> lock(stateMutex_);
+        std::scoped_lock lock(stateMutex_);
         if (currentChord_.name.isNotEmpty()) {
             currentChord_ = {};
             // Don't notify — UI uses lastDetectedChord_ for display
@@ -268,7 +268,7 @@ void MidiChordEnginePlugin::runDetection() {
     if (detected.name.isEmpty() || detected.name == "none" || detected.name == "unknown")
         return;
 
-    std::lock_guard<std::mutex> lock(stateMutex_);
+    std::scoped_lock lock(stateMutex_);
 
     bool chordChanged = detected.getDisplayName() != currentChord_.getDisplayName();
     currentChord_ = detected;
@@ -303,47 +303,47 @@ void MidiChordEnginePlugin::runDetection() {
 // =============================================================================
 
 juce::String MidiChordEnginePlugin::getCurrentChordName() const {
-    std::lock_guard<std::mutex> lock(stateMutex_);
+    std::scoped_lock lock(stateMutex_);
     return currentChord_.getDisplayName();
 }
 
 juce::String MidiChordEnginePlugin::getLastDetectedChordName() const {
-    std::lock_guard<std::mutex> lock(stateMutex_);
+    std::scoped_lock lock(stateMutex_);
     return lastDetectedChordName_;
 }
 
 magda::music::Chord MidiChordEnginePlugin::getCurrentChord() const {
-    std::lock_guard<std::mutex> lock(stateMutex_);
+    std::scoped_lock lock(stateMutex_);
     return currentChord_;
 }
 
 std::vector<magda::music::Chord> MidiChordEnginePlugin::getRecentChords() const {
-    std::lock_guard<std::mutex> lock(stateMutex_);
+    std::scoped_lock lock(stateMutex_);
     return chordHistory_;
 }
 
 std::optional<std::pair<juce::String, juce::String>> MidiChordEnginePlugin::getDetectedKeyMode()
     const {
-    std::lock_guard<std::mutex> lock(stateMutex_);
+    std::scoped_lock lock(stateMutex_);
     return cachedKeyMode_;
 }
 
 std::vector<magda::music::ChordEngine::SuggestionItem> MidiChordEnginePlugin::getSuggestions()
     const {
-    std::lock_guard<std::mutex> lock(stateMutex_);
+    std::scoped_lock lock(stateMutex_);
     return cachedSuggestions_;
 }
 
 std::vector<magda::music::ScaleWithChords> MidiChordEnginePlugin::getDetectedScales(
     int maxResults) const {
-    std::lock_guard<std::mutex> lock(stateMutex_);
+    std::scoped_lock lock(stateMutex_);
     if (static_cast<int>(cachedScales_.size()) <= maxResults)
         return cachedScales_;
     return {cachedScales_.begin(), cachedScales_.begin() + maxResults};
 }
 
 void MidiChordEnginePlugin::clearHistory() {
-    std::lock_guard<std::mutex> lock(stateMutex_);
+    std::scoped_lock lock(stateMutex_);
     chordHistory_.clear();
     currentChord_ = {};
     lastDetectedChordName_.clear();
@@ -358,7 +358,7 @@ void MidiChordEnginePlugin::clearHistory() {
 }
 
 void MidiChordEnginePlugin::refreshSuggestions() {
-    std::lock_guard<std::mutex> lock(stateMutex_);
+    std::scoped_lock lock(stateMutex_);
     auto recentChords = suggestionEngine_.getRecentChords();
     if (recentChords.empty() && !cachedKeyMode_.has_value()) {
         // No input yet — don't show default C major suggestions

--- a/magda/daw/audio/plugins/engine/ControlExecutor.cpp
+++ b/magda/daw/audio/plugins/engine/ControlExecutor.cpp
@@ -73,7 +73,7 @@ SerialControlThread::SerialControlThread() : shared_(std::make_shared<Shared>())
 
 SerialControlThread::~SerialControlThread() {
     {
-        const std::lock_guard<std::mutex> held(shared_->lock);
+        const std::scoped_lock held(shared_->lock);
         shared_->stopping = true;
     }
 
@@ -100,7 +100,7 @@ bool SerialControlThread::run(Work work) {
         return false;
 
     {
-        const std::lock_guard<std::mutex> held(shared_->lock);
+        const std::scoped_lock held(shared_->lock);
         if (shared_->stopping)
             return false;
 

--- a/magda/daw/core/AppPaths.cpp
+++ b/magda/daw/core/AppPaths.cpp
@@ -36,7 +36,7 @@ std::shared_ptr<const Resolved>& cachedSlot() {
 }
 
 std::shared_ptr<const Resolved> snapshot() {
-    std::lock_guard<std::mutex> lock(cacheMutex());
+    std::scoped_lock lock(cacheMutex());
     if (cachedSlot() == nullptr) {
         // Bootstrap: first reader before resolve() ran. Compute defaults
         // on demand so paths remain useful even if a consumer touches them
@@ -249,7 +249,7 @@ void resolve() {
     fresh->renderFromEnv = render.fromEnv;
 
     {
-        std::lock_guard<std::mutex> lock(cacheMutex());
+        std::scoped_lock lock(cacheMutex());
         cachedSlot() = fresh;
     }
 }

--- a/magda/daw/core/LLMClientProvider.cpp
+++ b/magda/daw/core/LLMClientProvider.cpp
@@ -169,12 +169,12 @@ bool supportsOpenAICFG(const Config::AgentLLMConfig& config) {
 }
 
 void setLLMClientProvider(LLMClientProvider provider) {
-    std::lock_guard<std::mutex> lock(providerMutex());
+    std::scoped_lock lock(providerMutex());
     providerSlot() = std::move(provider);
 }
 
 void setLLMProviderShutdownHandler(LLMProviderShutdownHandler handler) {
-    std::lock_guard<std::mutex> lock(providerMutex());
+    std::scoped_lock lock(providerMutex());
     shutdownHandlerSlot() = std::move(handler);
 }
 
@@ -182,7 +182,7 @@ std::unique_ptr<llm::LLMClient> createLLMClient(const Config::AgentLLMConfig& co
                                                 const std::string& agentName) {
     LLMClientProvider provider;
     {
-        std::lock_guard<std::mutex> lock(providerMutex());
+        std::scoped_lock lock(providerMutex());
         provider = providerSlot();
     }
 
@@ -192,7 +192,7 @@ std::unique_ptr<llm::LLMClient> createLLMClient(const Config::AgentLLMConfig& co
 void shutdownLLMClientProvider() {
     LLMProviderShutdownHandler handler;
     {
-        std::lock_guard<std::mutex> lock(providerMutex());
+        std::scoped_lock lock(providerMutex());
         handler = shutdownHandlerSlot();
     }
 

--- a/magda/daw/core/ParameterDetector.cpp
+++ b/magda/daw/core/ParameterDetector.cpp
@@ -28,7 +28,7 @@ juce::File getDetectorLogFile() {
 
 void logDetector(const juce::String& msg) {
     static std::mutex logMutex;
-    std::lock_guard<std::mutex> lock(logMutex);
+    std::scoped_lock lock(logMutex);
     auto f = getDetectorLogFile();
     f.appendText(msg + "\n");
 }
@@ -637,7 +637,7 @@ int parseAIResponse(const juce::String& responseText, const std::vector<Ambiguou
     }
 
     int parsedCount = 0;
-    std::lock_guard<std::mutex> lock(resultsMutex);
+    std::scoped_lock lock(resultsMutex);
     for (const auto& paramVar : *paramsArray) {
         if (auto* pObj = paramVar.getDynamicObject()) {
             int paramIndex = -1;

--- a/magda/daw/core/PluginCapabilities.cpp
+++ b/magda/daw/core/PluginCapabilities.cpp
@@ -151,7 +151,7 @@ std::optional<PluginCapabilitySnapshot> PluginCapabilityCache::find(
     if (pluginIdentifier.isEmpty())
         return std::nullopt;
 
-    std::lock_guard<std::mutex> lock(mutex_);
+    std::scoped_lock lock(mutex_);
     auto it = snapshots_.find(pluginIdentifier);
     if (it == snapshots_.end())
         return std::nullopt;
@@ -162,7 +162,7 @@ void PluginCapabilityCache::update(const PluginCapabilitySnapshot& snapshot) {
     if (snapshot.pluginIdentifier.isEmpty())
         return;
 
-    std::lock_guard<std::mutex> lock(mutex_);
+    std::scoped_lock lock(mutex_);
     if (auto it = snapshots_.find(snapshot.pluginIdentifier);
         it != snapshots_.end() && snapshotsEqual(it->second, snapshot)) {
         return;

--- a/magda/daw/core/PluginPreferences.cpp
+++ b/magda/daw/core/PluginPreferences.cpp
@@ -63,7 +63,7 @@ PluginPreferences::PluginPreferences() {
 bool PluginPreferences::prefersDrumGrid(const juce::String& pluginIdentifier) const {
     if (pluginIdentifier.isEmpty() || pluginIdentifier == kInstrumentRackWrapperId)
         return false;
-    std::lock_guard<std::mutex> lock(mutex_);
+    std::scoped_lock lock(mutex_);
     if (drumGridPlugins_.find(pluginIdentifier) != drumGridPlugins_.end())
         return true;
     // Built-in default: MAGDA's DrumGrid plugin opens in the drum-grid view
@@ -77,7 +77,7 @@ void PluginPreferences::setPrefersDrumGrid(const juce::String& pluginIdentifier,
 
     bool changed = false;
     {
-        std::lock_guard<std::mutex> lock(mutex_);
+        std::scoped_lock lock(mutex_);
         changed = prefer ? drumGridPlugins_.insert(pluginIdentifier).second
                          : drumGridPlugins_.erase(pluginIdentifier) > 0;
         if (changed)
@@ -101,7 +101,7 @@ void PluginPreferences::setTreatsAsMidiFx(const juce::String& pluginIdentifier,
 bool PluginPreferences::aiSoundDesignerEnabled(const juce::String& pluginIdentifier) const {
     if (pluginIdentifier.isEmpty() || pluginIdentifier == kInstrumentRackWrapperId)
         return true;
-    std::lock_guard<std::mutex> lock(mutex_);
+    std::scoped_lock lock(mutex_);
     return aiSoundDesignerHidden_.find(pluginIdentifier) == aiSoundDesignerHidden_.end();
 }
 
@@ -112,7 +112,7 @@ void PluginPreferences::setAiSoundDesignerEnabled(const juce::String& pluginIden
 
     bool changed = false;
     {
-        std::lock_guard<std::mutex> lock(mutex_);
+        std::scoped_lock lock(mutex_);
         changed = enabled ? aiSoundDesignerHidden_.erase(pluginIdentifier) > 0
                           : aiSoundDesignerHidden_.insert(pluginIdentifier).second;
         if (changed)
@@ -128,7 +128,7 @@ juce::String PluginPreferences::browserCategoryOverride(
     if (pluginIdentifier.isEmpty() || pluginIdentifier == kInstrumentRackWrapperId)
         return {};
 
-    std::lock_guard<std::mutex> lock(mutex_);
+    std::scoped_lock lock(mutex_);
     auto it = categoryOverrides_.find(pluginIdentifier);
     return it == categoryOverrides_.end() ? juce::String() : it->second;
 }
@@ -138,7 +138,7 @@ void PluginPreferences::setBrowserCategoryOverride(const juce::String& pluginIde
     if (pluginIdentifier.isEmpty() || pluginIdentifier == kInstrumentRackWrapperId)
         return;
 
-    std::lock_guard<std::mutex> lock(mutex_);
+    std::scoped_lock lock(mutex_);
     const auto normalized = categoryOverride.trim();
     bool changed = false;
     if (normalized.isEmpty()) {
@@ -154,7 +154,7 @@ void PluginPreferences::setBrowserCategoryOverride(const juce::String& pluginIde
 }
 
 PluginFormat PluginPreferences::externalPluginFormatPreference() const {
-    std::lock_guard<std::mutex> lock(mutex_);
+    std::scoped_lock lock(mutex_);
     return externalFormatPreference_;
 }
 
@@ -162,7 +162,7 @@ void PluginPreferences::setExternalPluginFormatPreference(PluginFormat preferenc
     preference = preference == PluginFormat::AU ? PluginFormat::AU : PluginFormat::VST3;
     bool changed = false;
     {
-        std::lock_guard<std::mutex> lock(mutex_);
+        std::scoped_lock lock(mutex_);
         if (externalFormatPreference_ == preference)
             return;
         externalFormatPreference_ = preference;
@@ -241,7 +241,7 @@ std::vector<magda::KitRow> PluginPreferences::defaultKitRows(
     const juce::String& pluginIdentifier) const {
     if (pluginIdentifier.isEmpty() || !hasGlobalKitDefault(pluginIdentifier))
         return {};
-    std::lock_guard<std::mutex> lock(mutex_);
+    std::scoped_lock lock(mutex_);
     auto it = defaultKits_.find(pluginIdentifier);
     if (it == defaultKits_.end())
         return {};
@@ -252,7 +252,7 @@ void PluginPreferences::setDefaultKitRows(const juce::String& pluginIdentifier,
                                           const std::vector<KitRow>& rows) {
     if (pluginIdentifier.isEmpty() || !hasGlobalKitDefault(pluginIdentifier))
         return;
-    std::lock_guard<std::mutex> lock(mutex_);
+    std::scoped_lock lock(mutex_);
     if (rows.empty())
         defaultKits_.erase(pluginIdentifier);
     else

--- a/magda/daw/core/TrackManager.cpp
+++ b/magda/daw/core/TrackManager.cpp
@@ -1688,7 +1688,7 @@ void TrackManager::setTrackMidiInput(TrackId trackId, const juce::String& device
     // Reset held-note state and flush pending MIDI triggers for this track
     // so stale triggers from the old input don't keep LFOs running
     {
-        std::lock_guard<std::mutex> lock(midiTriggerMutex_);
+        std::scoped_lock lock(midiTriggerMutex_);
         midiHeldNotes_.erase(trackId);
         pendingMidiNoteOns_.erase(trackId);
         pendingMidiNoteOffs_.erase(trackId);
@@ -3307,7 +3307,7 @@ void TrackManager::clearAllTracks() {
     // first-note-on detection after project close/reopen.
     midiHeldNotes_.clear();
     {
-        std::lock_guard<std::mutex> lock(midiTriggerMutex_);
+        std::scoped_lock lock(midiTriggerMutex_);
         pendingMidiNoteOns_.clear();
         pendingMidiNoteOffs_.clear();
     }

--- a/magda/daw/core/TrackManagerModulation.cpp
+++ b/magda/daw/core/TrackManagerModulation.cpp
@@ -676,7 +676,7 @@ void TrackManager::removeModPage(const ChainNodePath& path) {
 }
 
 void TrackManager::triggerMidiNoteOn(TrackId trackId) {
-    std::lock_guard<std::mutex> lock(midiTriggerMutex_);
+    std::scoped_lock lock(midiTriggerMutex_);
     pendingMidiNoteOns_[trackId]++;
 }
 
@@ -709,7 +709,7 @@ const ModInfo* TrackManager::getModById(TrackId trackId, ModId modId) const {
 }
 
 void TrackManager::triggerMidiNoteOff(TrackId trackId) {
-    std::lock_guard<std::mutex> lock(midiTriggerMutex_);
+    std::scoped_lock lock(midiTriggerMutex_);
     pendingMidiNoteOffs_[trackId]++;
 }
 
@@ -744,7 +744,7 @@ void TrackManager::updateAllMods(double deltaTime, double bpm, bool transportJus
     std::map<TrackId, int> noteOnsThisTick;
     std::map<TrackId, int> noteOffsThisTick;
     {
-        std::lock_guard<std::mutex> lock(midiTriggerMutex_);
+        std::scoped_lock lock(midiTriggerMutex_);
         noteOnsThisTick.swap(pendingMidiNoteOns_);
         noteOffsThisTick.swap(pendingMidiNoteOffs_);
     }

--- a/magda/daw/engine/PluginMetadataStore.cpp
+++ b/magda/daw/engine/PluginMetadataStore.cpp
@@ -74,7 +74,7 @@ PluginMetadataStore::PluginMetadataStore(const juce::File& databaseFile, LegacyF
         // busy handler when two connections open a fresh database together.
         // Cover that step as well as the transactional setup for concurrent
         // first opens within the application.
-        const std::lock_guard initializationLock(initializationMutex);
+        const std::scoped_lock initializationLock(initializationMutex);
         sqlite::exec(db_.get(), "PRAGMA journal_mode=WAL", "set plugin metadata journal mode");
         sqlite::exec(db_.get(), "PRAGMA synchronous=NORMAL",
                      "set plugin metadata synchronous mode");

--- a/magda/daw/media_db/MediaDbIndexer.cpp
+++ b/magda/daw/media_db/MediaDbIndexer.cpp
@@ -1068,7 +1068,7 @@ MediaDbIndexer::Stats MediaDbIndexer::indexDirectory(const std::filesystem::path
     const auto scanTagOptions = scanTagOptions_;
     FailureFn failureRef = [failureCallback, &failureMutex](const std::filesystem::path& current,
                                                             const std::string& reason) {
-        std::lock_guard<std::mutex> lock(failureMutex);
+        std::scoped_lock lock(failureMutex);
         reportFailure(failureCallback, current, reason);
     };
 
@@ -1102,13 +1102,13 @@ MediaDbIndexer::Stats MediaDbIndexer::indexDirectory(const std::filesystem::path
                                    scanTagOptions);
                     const int nowDone = ++doneCounter;
                     if (progressRef) {
-                        std::lock_guard<std::mutex> lock(progressMutex);
+                        std::scoped_lock lock(progressMutex);
                         progressRef(nowDone, total, files[i].path);
                     }
                 }
             }
 
-            std::lock_guard<std::mutex> lock(statsMutex);
+            std::scoped_lock lock(statsMutex);
             aggregate.inserted += local.inserted;
             aggregate.updated += local.updated;
             aggregate.skipped += local.skipped;

--- a/magda/daw/media_db/MelSpectrogram.cpp
+++ b/magda/daw/media_db/MelSpectrogram.cpp
@@ -70,7 +70,7 @@ std::shared_ptr<const std::vector<float>> cachedMelFilterbank(const MelConfig& c
     static std::vector<CachedFilterbank> cache;
 
     const auto key = keyFor(cfg);
-    std::lock_guard lock(cacheMutex);
+    std::scoped_lock lock(cacheMutex);
     for (const auto& entry : cache) {
         if (entry.key == key) {
             return entry.filterbank;

--- a/magda/daw/music/ChordEngine.cpp
+++ b/magda/daw/music/ChordEngine.cpp
@@ -33,14 +33,14 @@ ChordEngine* ChordEngine::instance = nullptr;
 std::mutex ChordEngine::instanceMutex;
 
 ChordEngine& ChordEngine::getInstance() {
-    std::lock_guard<std::mutex> lock(instanceMutex);
+    std::scoped_lock lock(instanceMutex);
     if (instance == nullptr)
         instance = new ChordEngine();
     return *instance;
 }
 
 void ChordEngine::cleanup() {
-    std::lock_guard<std::mutex> lock(instanceMutex);
+    std::scoped_lock lock(instanceMutex);
     if (instance != nullptr) {
         delete instance;
         instance = nullptr;

--- a/magda/daw/music/ChordSuggestionEngine.cpp
+++ b/magda/daw/music/ChordSuggestionEngine.cpp
@@ -51,7 +51,7 @@ juce::String ChordSuggestionEngine::getNoteName(int pitchClass) {
 }
 
 void ChordSuggestionEngine::updateWithChord(const Chord& chord, double currentTimeSeconds) {
-    std::lock_guard<std::mutex> lock(pcsHistogramMutex);
+    std::scoped_lock lock(pcsHistogramMutex);
 
     // Decay histogram since last update (exponential decay)
     if (lastPcsUpdateTime > 0.0) {
@@ -83,7 +83,7 @@ bool ChordSuggestionEngine::addChordToContext(const Chord& chord, double current
     // Check for duplicates and manage context
     bool wasAdded = false;
     {
-        std::lock_guard<std::mutex> lock(chordContextMutex);
+        std::scoped_lock lock(chordContextMutex);
 
         bool isDuplicate = false;
         if (!recentChords_.empty()) {
@@ -124,18 +124,18 @@ bool ChordSuggestionEngine::addChordToContext(const Chord& chord, double current
 
 void ChordSuggestionEngine::reset() {
     {
-        std::lock_guard<std::mutex> lock(pcsHistogramMutex);
+        std::scoped_lock lock(pcsHistogramMutex);
         pcsHistogram.fill(0.0);
         lastPcsUpdateTime = 0.0;
     }
     {
-        std::lock_guard<std::mutex> lock(chordContextMutex);
+        std::scoped_lock lock(chordContextMutex);
         recentChords_.clear();
     }
 }
 
 void ChordSuggestionEngine::clearContext() {
-    std::lock_guard<std::mutex> lock(chordContextMutex);
+    std::scoped_lock lock(chordContextMutex);
     recentChords_.clear();
 }
 
@@ -157,7 +157,7 @@ std::array<double, 12> ChordSuggestionEngine::getDecayedHistogram(double current
 
 std::optional<std::pair<juce::String, juce::String>>
 ChordSuggestionEngine::inferKeyModeFromHistogram() const {
-    std::lock_guard<std::mutex> lock(pcsHistogramMutex);
+    std::scoped_lock lock(pcsHistogramMutex);
 
     const auto hist = getDecayedHistogram(juce::Time::getMillisecondCounter() / 1000.0);
 
@@ -1710,7 +1710,7 @@ std::vector<ChordSuggestionEngine::SuggestionItem> ChordSuggestionEngine::proces
     bool isDuplicate = false;
     std::vector<Chord> contextCopy;
     {
-        std::lock_guard<std::mutex> lock(chordContextMutex);
+        std::scoped_lock lock(chordContextMutex);
 
         if (!recentChords_.empty()) {
             const Chord& last = recentChords_.back();
@@ -1760,12 +1760,12 @@ std::vector<ChordSuggestionEngine::SuggestionItem> ChordSuggestionEngine::proces
 }
 
 std::vector<Chord> ChordSuggestionEngine::getRecentChords() const {
-    std::lock_guard<std::mutex> lock(chordContextMutex);
+    std::scoped_lock lock(chordContextMutex);
     return std::vector<Chord>(recentChords_.begin(), recentChords_.end());
 }
 
 juce::String ChordSuggestionEngine::getContextTailString(int maxChords) const {
-    std::lock_guard<std::mutex> lock(chordContextMutex);
+    std::scoped_lock lock(chordContextMutex);
 
     juce::String contextTail;
     int count = 0;
@@ -1831,7 +1831,7 @@ std::vector<ChordSuggestionEngine::SuggestionItem> ChordSuggestionEngine::filter
 // Infer key/mode using comprehensive scale detection system
 std::optional<std::pair<juce::String, juce::String>>
 ChordSuggestionEngine::inferKeyModeFromScaleDetection() const {
-    std::lock_guard<std::mutex> lock(chordContextMutex);
+    std::scoped_lock lock(chordContextMutex);
 
     if (recentChords_.empty()) {
         return std::nullopt;
@@ -1917,7 +1917,7 @@ ChordSuggestionEngine::inferKeyModeFromScaleDetection() const {
 }
 
 juce::String ChordSuggestionEngine::getDetectedScalesString(float /*novelty*/) const {
-    std::lock_guard<std::mutex> lock(chordContextMutex);
+    std::scoped_lock lock(chordContextMutex);
 
     if (recentChords_.empty()) {
         return "";

--- a/magda/daw/ui/components/chain/slot/DeviceCustomUIManager.cpp
+++ b/magda/daw/ui/components/chain/slot/DeviceCustomUIManager.cpp
@@ -193,7 +193,7 @@ std::vector<CachedRoleEmbedding> roleTextEmbeddings(magda::media::ClapTextEncode
     static const magda::media::RobertaTokenizer* cachedTokenizer = nullptr;
     static std::vector<CachedRoleEmbedding> cached;
 
-    std::lock_guard<std::mutex> lock(cacheMutex);
+    std::scoped_lock lock(cacheMutex);
     if (cachedTextEncoder == &textEncoder && cachedTokenizer == &tokenizer && !cached.empty())
         return cached;
 

--- a/magda/daw/ui/panels/content/AIChatConsoleContent.cpp
+++ b/magda/daw/ui/panels/content/AIChatConsoleContent.cpp
@@ -707,7 +707,7 @@ void AIChatConsoleContent::RequestThread::run() {
 
     auto appendToken = [safeThis, singleState](const juce::String& token) {
         {
-            std::lock_guard<std::mutex> lk(singleState->mu);
+            std::scoped_lock lk(singleState->mu);
             singleState->pending += token;
         }
         bool expected = false;
@@ -719,7 +719,7 @@ void AIChatConsoleContent::RequestThread::run() {
                 return;
             juce::String chunk;
             {
-                std::lock_guard<std::mutex> lk(singleState->mu);
+                std::scoped_lock lk(singleState->mu);
                 chunk = std::move(singleState->pending);
                 singleState->pending.clear();
             }
@@ -3394,7 +3394,7 @@ void AIChatConsoleContent::ThemeRequestThread::run() {
         if (threadShouldExit())
             return false;
         {
-            std::lock_guard<std::mutex> lk(buf->mu);
+            std::scoped_lock lk(buf->mu);
             buf->pending += token;
         }
         bool expected = false;
@@ -3406,7 +3406,7 @@ void AIChatConsoleContent::ThemeRequestThread::run() {
                 return;
             juce::String chunk;
             {
-                std::lock_guard<std::mutex> lk(buf->mu);
+                std::scoped_lock lk(buf->mu);
                 chunk = std::move(buf->pending);
                 buf->pending.clear();
             }

--- a/magda/daw/ui/panels/content/MediaDbBrowserContent.cpp
+++ b/magda/daw/ui/panels/content/MediaDbBrowserContent.cpp
@@ -2424,7 +2424,7 @@ void MediaDbBrowserContent::runIndexing(const juce::File& dir,
                                      juce::String(reason);
                 juce::Logger::writeToLog(message);
 
-                std::lock_guard<std::mutex> lock(failureMutex);
+                std::scoped_lock lock(failureMutex);
                 ++failureCount;
                 if (firstFailures.size() < 5) {
                     firstFailures.push_back(message);
@@ -2509,7 +2509,7 @@ void MediaDbBrowserContent::runIndexing(const juce::File& dir,
                 juce::Logger::writeToLog(juce::String("[MediaDbIndexer] ") + skipReason);
             }
 
-            std::lock_guard<std::mutex> lock(failureMutex);
+            std::scoped_lock lock(failureMutex);
             for (const auto& failure : firstFailures) {
                 juce::Logger::writeToLog(juce::String("[MediaDbIndexer] First failure: ") +
                                          failure);

--- a/magda/engine/clip/ClipVoicePool.cpp
+++ b/magda/engine/clip/ClipVoicePool.cpp
@@ -196,7 +196,7 @@ ClipVoicePool::~ClipVoicePool() {
     // the reader, and waits for it.
     feed_.publish(std::make_shared<const ClipStreamTable>());
 
-    const std::lock_guard<std::mutex> guard(streamsLock_);
+    const std::scoped_lock guard(streamsLock_);
     for (auto& [key, reader] : streams_)
         if (reader.stream != nullptr)
             reader_.remove(*reader.stream);
@@ -205,12 +205,12 @@ ClipVoicePool::~ClipVoicePool() {
 }
 
 void ClipVoicePool::setSnapshot(std::shared_ptr<const ClipSnapshot> snapshot) {
-    const std::lock_guard<std::mutex> guard(snapshotLock_);
+    const std::scoped_lock guard(snapshotLock_);
     snapshot_ = std::move(snapshot);
 }
 
 std::size_t ClipVoicePool::streamCount() const {
-    const std::lock_guard<std::mutex> guard(streamsLock_);
+    const std::scoped_lock guard(streamsLock_);
     return streams_.size();
 }
 
@@ -297,7 +297,7 @@ ClipVoicePool::Reader ClipVoicePool::open(const AudioClipPlayback& clip,
 void ClipVoicePool::service() {
     std::shared_ptr<const ClipSnapshot> snapshot;
     {
-        const std::lock_guard<std::mutex> guard(snapshotLock_);
+        const std::scoped_lock guard(snapshotLock_);
         snapshot = snapshot_;
     }
 
@@ -318,7 +318,7 @@ void ClipVoicePool::service() {
     std::vector<Candidate> slots;
 
     {
-        const std::lock_guard<std::mutex> guard(streamsLock_);
+        const std::scoped_lock guard(streamsLock_);
 
         if (snapshot != nullptr) {
             for (const auto& track : snapshot->tracks) {

--- a/magda/engine/io/PrefetchThread.cpp
+++ b/magda/engine/io/PrefetchThread.cpp
@@ -18,7 +18,7 @@ PrefetchThread::~PrefetchThread() {
 
 void PrefetchThread::add(PrefetchStream& stream) {
     {
-        const std::lock_guard<std::mutex> guard(lock_);
+        const std::scoped_lock guard(lock_);
         if (std::find(streams_.begin(), streams_.end(), &stream) == streams_.end())
             streams_.push_back(&stream);
     }
@@ -27,17 +27,17 @@ void PrefetchThread::add(PrefetchStream& stream) {
 }
 
 void PrefetchThread::remove(PrefetchStream& stream) {
-    const std::lock_guard<std::mutex> guard(lock_);
+    const std::scoped_lock guard(lock_);
     streams_.erase(std::remove(streams_.begin(), streams_.end(), &stream), streams_.end());
 }
 
 std::size_t PrefetchThread::streamCount() const {
-    const std::lock_guard<std::mutex> guard(lock_);
+    const std::scoped_lock guard(lock_);
     return streams_.size();
 }
 
 bool PrefetchThread::fillOnce() {
-    const std::lock_guard<std::mutex> guard(lock_);
+    const std::scoped_lock guard(lock_);
 
     auto worked = false;
     for (auto* stream : streams_)

--- a/magda/mcp_bridge/main.cpp
+++ b/magda/mcp_bridge/main.cpp
@@ -240,7 +240,7 @@ class Bridge {
         }
 
         auto finished = std::make_shared<std::atomic<bool>>(false);
-        std::lock_guard<std::mutex> lock(threadsMutex_);
+        std::scoped_lock lock(threadsMutex_);
 
         // Reap before adding. A thread handle is a native resource, and a host
         // that stays open for hours sends thousands of requests — without this
@@ -426,7 +426,7 @@ class Bridge {
     /// Whether this stream was stopped on purpose, which is the difference
     /// between "the host closed it" and "the connection broke".
     bool isCancelled(const juce::var& id) {
-        std::lock_guard<std::mutex> lock(streamMutex_);
+        std::scoped_lock lock(streamMutex_);
         return cancelled_.erase(juce::JSON::toString(id, true).toStdString()) > 0;
     }
 
@@ -507,7 +507,7 @@ class Bridge {
                 ? juce::JSON::toString(parsed, true).toStdString()
                 : json;
 
-        std::lock_guard<std::mutex> lock(outputMutex_);
+        std::scoped_lock lock(outputMutex_);
         std::cout << text << '\n' << std::flush;
     }
 
@@ -528,7 +528,7 @@ class Bridge {
         setProperty(reply, "id", id);
         setProperty(reply, "error", error);
 
-        std::lock_guard<std::mutex> lock(outputMutex_);
+        std::scoped_lock lock(outputMutex_);
         std::cout << juce::JSON::toString(reply, true).toStdString() << '\n' << std::flush;
     }
 
@@ -565,7 +565,7 @@ class Bridge {
     // -----------------------------------------------------------------------
 
     std::optional<Endpoint> currentEndpoint(bool forceRefresh) {
-        std::lock_guard<std::mutex> lock(endpointMutex_);
+        std::scoped_lock lock(endpointMutex_);
         if (forceRefresh || !endpoint_)
             endpoint_ = resolveEndpoint();
         return endpoint_;
@@ -574,29 +574,29 @@ class Bridge {
     void rememberSession(const httplib::Response& response) {
         if (!response.has_header("Mcp-Session-Id"))
             return;
-        std::lock_guard<std::mutex> lock(sessionMutex_);
+        std::scoped_lock lock(sessionMutex_);
         session_ = response.get_header_value("Mcp-Session-Id");
     }
 
     std::string currentSession() const {
-        std::lock_guard<std::mutex> lock(sessionMutex_);
+        std::scoped_lock lock(sessionMutex_);
         return session_;
     }
 
     void clearSession() {
-        std::lock_guard<std::mutex> lock(sessionMutex_);
+        std::scoped_lock lock(sessionMutex_);
         session_.clear();
     }
 
     /// The `initialize` the host sent, kept so a session can be rebuilt without
     /// it. Empty when the host speaks the modern era and never sent one.
     void rememberHandshake(const std::string& body) {
-        std::lock_guard<std::mutex> lock(sessionMutex_);
+        std::scoped_lock lock(sessionMutex_);
         handshake_ = body;
     }
 
     std::string currentHandshake() const {
-        std::lock_guard<std::mutex> lock(sessionMutex_);
+        std::scoped_lock lock(sessionMutex_);
         return handshake_;
     }
 
@@ -620,19 +620,19 @@ class Bridge {
     }
 
     void registerStream(const juce::var& id, std::shared_ptr<httplib::Client> client) {
-        std::lock_guard<std::mutex> lock(streamMutex_);
+        std::scoped_lock lock(streamMutex_);
         streams_[juce::JSON::toString(id, true).toStdString()] = std::move(client);
     }
 
     void unregisterStream(const juce::var& id) {
-        std::lock_guard<std::mutex> lock(streamMutex_);
+        std::scoped_lock lock(streamMutex_);
         streams_.erase(juce::JSON::toString(id, true).toStdString());
     }
 
     void cancel(const juce::var& requestId) {
         std::shared_ptr<httplib::Client> client;
         {
-            std::lock_guard<std::mutex> lock(streamMutex_);
+            std::scoped_lock lock(streamMutex_);
             const auto key = juce::JSON::toString(requestId, true).toStdString();
             const auto it = streams_.find(key);
             if (it == streams_.end())
@@ -648,13 +648,13 @@ class Bridge {
 
     void shutdown() {
         {
-            std::lock_guard<std::mutex> lock(streamMutex_);
+            std::scoped_lock lock(streamMutex_);
             for (auto& [id, client] : streams_) {
                 cancelled_.insert(id);
                 client->stop();
             }
         }
-        std::lock_guard<std::mutex> lock(threadsMutex_);
+        std::scoped_lock lock(threadsMutex_);
         for (auto& [thread, finished] : threads_)
             if (thread.joinable())
                 thread.join();


### PR DESCRIPTION
## Summary
- Next of the per-check PRs from #2388: `clang-tidy`'s `modernize-use-scoped-lock -fix` applied over `magda/`, no hand edits.
- 197 sites across 31 files — every site is a single-mutex `std::lock_guard<std::mutex>` swapped for `std::scoped_lock`, behavior-identical.

## Test plan
- [x] `make debug` — builds clean
- [x] `make test` — 3573 passed, 13 skipped, 856932 assertions, 0 failed

Part of #2388.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0149ko34fXR5PeMBqVL1tDWt