### PR TITLE
Apply performance-use-std-move fixes across magda/

### DIFF
--- a/magda/agents/automation_agent.cpp
+++ b/magda/agents/automation_agent.cpp
@@ -164,7 +164,7 @@ llm::Request buildRequest(MagdaApi& api, const std::string& message) {
         systemPrompt += "\n\nContext:\n" + ctx;
 
     llm::Request request;
-    request.systemPrompt = systemPrompt;
+    request.systemPrompt = std::move(systemPrompt);
     request.userMessage = juce::String::fromUTF8(message.c_str());
     request.temperature = 0.1f;
     return request;

--- a/magda/agents/automation_executor.cpp
+++ b/magda/agents/automation_executor.cpp
@@ -380,7 +380,7 @@ bool AutomationExecutor::execute(const std::vector<AutoInstruction>& instruction
             auto& op = std::get<AutoClearOp>(inst.payload);
             auto laneId = resolveTarget(api_, op.target, err);
             if (laneId == INVALID_AUTOMATION_LANE_ID) {
-                error_ = err;
+                error_ = std::move(err);
                 return false;
             }
             mgr.clearLanePoints(laneId);
@@ -392,7 +392,7 @@ bool AutomationExecutor::execute(const std::vector<AutoInstruction>& instruction
             auto& op = std::get<AutoFreeformOp>(inst.payload);
             auto laneId = resolveTarget(api_, op.target, err);
             if (laneId == INVALID_AUTOMATION_LANE_ID) {
-                error_ = err;
+                error_ = std::move(err);
                 return false;
             }
             for (const auto& p : op.points) {
@@ -407,7 +407,7 @@ bool AutomationExecutor::execute(const std::vector<AutoInstruction>& instruction
             auto& op = std::get<AutoShapeOp>(inst.payload);
             auto laneId = resolveTarget(api_, op.target, err);
             if (laneId == INVALID_AUTOMATION_LANE_ID) {
-                error_ = err;
+                error_ = std::move(err);
                 return false;
             }
             int before = 0;

--- a/magda/agents/automation_parser.cpp
+++ b/magda/agents/automation_parser.cpp
@@ -44,7 +44,7 @@ bool parseTarget(const juce::String& value, AutoTarget& out, juce::String& err) 
     // Sigil token: @plugin.param
     if (isSigilToken(v)) {
         out.kind = AutoTarget::Kind::Alias;
-        out.aliasToken = v;
+        out.aliasToken = std::move(v);
         return true;
     }
     err = "Unknown target: " + v;
@@ -208,7 +208,7 @@ std::vector<AutoInstruction> AutomationParser::parse(const juce::String& text) {
                 if (k.equalsIgnoreCase("target")) {
                     juce::String err;
                     if (!parseTarget(v, op.target, err)) {
-                        lastError_ = err;
+                        lastError_ = std::move(err);
                         return {};
                     }
                 } else if (k.equalsIgnoreCase("id")) {
@@ -238,7 +238,7 @@ std::vector<AutoInstruction> AutomationParser::parse(const juce::String& text) {
                 } else if (k.equalsIgnoreCase("points")) {
                     juce::String err;
                     if (!parseFreeformPoints(v, op.points, err)) {
-                        lastError_ = err;
+                        lastError_ = std::move(err);
                         return {};
                     }
                 }
@@ -270,7 +270,7 @@ std::vector<AutoInstruction> AutomationParser::parse(const juce::String& text) {
                 if (k.equalsIgnoreCase("target")) {
                     juce::String err;
                     if (!parseTarget(v, op.target, err)) {
-                        lastError_ = err;
+                        lastError_ = std::move(err);
                         return {};
                     }
                 }
@@ -289,13 +289,13 @@ std::vector<AutoInstruction> AutomationParser::parse(const juce::String& text) {
                 if (k.equalsIgnoreCase("target")) {
                     juce::String err;
                     if (!parseTarget(v, op.target, err)) {
-                        lastError_ = err;
+                        lastError_ = std::move(err);
                         return {};
                     }
                 } else if (k.equalsIgnoreCase("points")) {
                     juce::String err;
                     if (!parseFreeformPoints(v, op.points, err)) {
-                        lastError_ = err;
+                        lastError_ = std::move(err);
                         return {};
                     }
                 }
@@ -325,7 +325,7 @@ std::vector<AutoInstruction> AutomationParser::parse(const juce::String& text) {
             if (k.equalsIgnoreCase("target")) {
                 juce::String err;
                 if (!parseTarget(v, op.target, err)) {
-                    lastError_ = err;
+                    lastError_ = std::move(err);
                     return {};
                 }
             } else if (k.equalsIgnoreCase("start"))

--- a/magda/agents/command_agent.cpp
+++ b/magda/agents/command_agent.cpp
@@ -157,7 +157,7 @@ static llm::Request buildRequest(MagdaApi& api, const std::string& message, bool
     if (cfg) {
         request.grammar = juce::String::fromUTF8(dsl::getGrammar());
         request.grammarToolName = "magda_dsl";
-        request.grammarToolDescription = systemPrompt;
+        request.grammarToolDescription = std::move(systemPrompt);
     }
 
     return request;

--- a/magda/agents/compact_parser.cpp
+++ b/magda/agents/compact_parser.cpp
@@ -122,7 +122,7 @@ std::vector<Instruction> CompactParser::parse(const juce::String& compact) {
             if (parseGridLine(line, instructions, gridError))
                 continue;
             if (gridError.isNotEmpty()) {
-                lastError_ = gridError;
+                lastError_ = std::move(gridError);
                 return {};
             }
             // fall through (no `|` after all — shouldn't happen, but safe)

--- a/magda/agents/drummer_agent.cpp
+++ b/magda/agents/drummer_agent.cpp
@@ -196,7 +196,7 @@ juce::String extractLastGridBlock(const juce::String& text) {
     }
 
     if (!currentBlock.isEmpty())
-        lastBlock = currentBlock;
+        lastBlock = std::move(currentBlock);
 
     return lastBlock.joinIntoString("\n").trim();
 }

--- a/magda/agents/instruction_executor.cpp
+++ b/magda/agents/instruction_executor.cpp
@@ -853,7 +853,7 @@ bool InstructionExecutor::executeArp(const ArpOp& op) {
     juce::String chordError;
     if (!music::resolveChordNotes(op.root.toStdString(), op.quality.toStdString(), op.inversion,
                                   midiNotes, chordError)) {
-        error_ = chordError;
+        error_ = std::move(chordError);
         return false;
     }
 
@@ -925,7 +925,7 @@ bool InstructionExecutor::executeChord(const ChordOp& op) {
     juce::String chordError;
     if (!music::resolveChordNotes(op.root.toStdString(), op.quality.toStdString(), op.inversion,
                                   midiNotes, chordError)) {
-        error_ = chordError;
+        error_ = std::move(chordError);
         return false;
     }
 

--- a/magda/agents/mcp/MCPClient.cpp
+++ b/magda/agents/mcp/MCPClient.cpp
@@ -276,10 +276,10 @@ MCPClient::ToolResult MCPClient::callTool(const juce::String& toolName,
     }
 
     if (isError) {
-        result.error = combinedText;
+        result.error = std::move(combinedText);
     } else {
         result.success = true;
-        result.content = combinedText;
+        result.content = std::move(combinedText);
     }
     return result;
 }

--- a/magda/agents/poly_step_sequencer_agent.cpp
+++ b/magda/agents/poly_step_sequencer_agent.cpp
@@ -328,7 +328,7 @@ PolyStepSequencerAgent::GenerateResult PolyStepSequencerAgent::generate(
     auto systemPrompt = juce::String::fromUTF8(getSystemPrompt());
     if (!deviceContext.empty())
         systemPrompt += "\n\n" + juce::String::fromUTF8(deviceContext.c_str());
-    request.systemPrompt = systemPrompt;
+    request.systemPrompt = std::move(systemPrompt);
     request.userMessage = juce::String::fromUTF8(message.c_str());
     request.temperature = 0.3f;  // some creativity for patterns
 
@@ -380,7 +380,7 @@ PolyStepSequencerAgent::GenerateResult PolyStepSequencerAgent::generateStreaming
     auto systemPromptStr = juce::String::fromUTF8(getSystemPrompt());
     if (!deviceContext.empty())
         systemPromptStr += "\n\n" + juce::String::fromUTF8(deviceContext.c_str());
-    request.systemPrompt = systemPromptStr;
+    request.systemPrompt = std::move(systemPromptStr);
     request.userMessage = juce::String::fromUTF8(message.c_str());
     request.temperature = 0.3f;
 

--- a/magda/agents/step_sequencer_agent.cpp
+++ b/magda/agents/step_sequencer_agent.cpp
@@ -273,7 +273,7 @@ StepSequencerAgent::GenerateResult StepSequencerAgent::generate(const std::strin
     auto systemPrompt = juce::String::fromUTF8(getSystemPrompt());
     if (!deviceContext.empty())
         systemPrompt += "\n\n" + juce::String::fromUTF8(deviceContext.c_str());
-    request.systemPrompt = systemPrompt;
+    request.systemPrompt = std::move(systemPrompt);
     request.userMessage = juce::String::fromUTF8(message.c_str());
     request.temperature = 0.5f;  // some creativity for patterns
 
@@ -325,7 +325,7 @@ StepSequencerAgent::GenerateResult StepSequencerAgent::generateStreaming(
     auto systemPromptStr = juce::String::fromUTF8(getSystemPrompt());
     if (!deviceContext.empty())
         systemPromptStr += "\n\n" + juce::String::fromUTF8(deviceContext.c_str());
-    request.systemPrompt = systemPromptStr;
+    request.systemPrompt = std::move(systemPromptStr);
     request.userMessage = juce::String::fromUTF8(message.c_str());
     request.temperature = 0.5f;
 

--- a/magda/daw/audio/plugin_manager/PluginManager.cpp
+++ b/magda/daw/audio/plugin_manager/PluginManager.cpp
@@ -489,7 +489,7 @@ void PluginManager::capturePluginState(const ChainNodePath& devicePath) {
                                                                              devInfo->pluginState);
     }
 
-    devInfo->pluginState = stateStr;
+    devInfo->pluginState = std::move(stateStr);
     if (auto* drumGrid = dynamic_cast<daw::audio::DrumGridPlugin*>(plugin))
         captureDrumGridPads(devicePath, *drumGrid);
     captureVst3Info(*devInfo, capturedExt);

--- a/magda/daw/audio/plugins/FaustMetadataParser.cpp
+++ b/magda/daw/audio/plugins/FaustMetadataParser.cpp
@@ -132,7 +132,7 @@ bool applyFaustAnnotation(const juce::String& key, const juce::String& value,
         auto v = value.trim();
         if (v.length() >= 2 && v.startsWithChar('"') && v.endsWithChar('"'))
             v = v.substring(1, v.length() - 1);
-        metadata.tooltip = v;
+        metadata.tooltip = std::move(v);
         return true;
     }
     if (key == "role") {

--- a/magda/daw/cli/magda_cli_main.cpp
+++ b/magda/daw/cli/magda_cli_main.cpp
@@ -371,7 +371,7 @@ class CommandDispatcher {
             name = tokens[static_cast<int>(index++)];
 
         magda::DeviceInfo device;
-        device.name = name;
+        device.name = std::move(name);
         device.manufacturer = "MAGDA";
         device.pluginId = pluginId;
         device.uniqueId = pluginId;

--- a/magda/daw/core/ChainNodePath.cpp
+++ b/magda/daw/core/ChainNodePath.cpp
@@ -159,7 +159,7 @@ bool fromVar(const juce::var& v, ChainNodePath& out) {
     if (representations > 1)
         return false;
 
-    out = path;
+    out = std::move(path);
     return true;
 }
 

--- a/magda/daw/core/ClipManager.cpp
+++ b/magda/daw/core/ClipManager.cpp
@@ -1416,8 +1416,8 @@ ClipId ClipManager::splitClipAtBeat(ClipId clipId, double splitBeat, double temp
                 }
             }
 
-            clip->midiNotes = leftNotes;
-            rightClip.midiNotes = rightNotes;
+            clip->midiNotes = std::move(leftNotes);
+            rightClip.midiNotes = std::move(rightNotes);
 
             // Partitioning rewrites shared content, so ghost halves cannot
             // stay in their link group: the next propagation would truncate

--- a/magda/daw/core/ControlTarget.cpp
+++ b/magda/daw/core/ControlTarget.cpp
@@ -70,7 +70,7 @@ bool fromVar(const juce::var& v, ControlTarget& out) {
     if (obj->hasProperty("sendBusIndex"))
         target.sendBusIndex = static_cast<int>(obj->getProperty("sendBusIndex"));
 
-    out = target;
+    out = std::move(target);
     return true;
 }
 

--- a/magda/daw/core/TrackManager.cpp
+++ b/magda/daw/core/TrackManager.cpp
@@ -3006,7 +3006,7 @@ void TrackManager::setChainName(const ChainNodePath& chainPath, const juce::Stri
         auto trimmed = name.trim();
         if (trimmed.isEmpty() || trimmed == chain->name)
             return;
-        chain->name = trimmed;
+        chain->name = std::move(trimmed);
         notifyTrackPropertyChanged(chainPath.trackId);
     }
 }

--- a/magda/daw/core/TrackManagerDevices.cpp
+++ b/magda/daw/core/TrackManagerDevices.cpp
@@ -1995,7 +1995,7 @@ bool TrackManager::setDeviceAuthoredState(const ChainNodePath& devicePath,
         canonical = device_state::encode(*decoded);
     }
 
-    device->pluginState = canonical;
+    device->pluginState = std::move(canonical);
     projectAuthoredStateToEngine(audioEngine_, devicePath, device->pluginState, device->pluginId);
     notifyDevicePropertyChanged(devicePath);
     return true;

--- a/magda/daw/core/aliases/ParamSigilParser.cpp
+++ b/magda/daw/core/aliases/ParamSigilParser.cpp
@@ -43,8 +43,8 @@ std::optional<ParsedSigil> tryParse(const juce::String& token) {
         return std::nullopt;
 
     ParsedSigil result;
-    result.pluginKey = pluginKey;
-    result.paramKey = paramKey;
+    result.pluginKey = std::move(pluginKey);
+    result.paramKey = std::move(paramKey);
 
     // Check for scoped forms
     static const juce::StringArray scopedKeys{"focused", "selected", "master"};

--- a/magda/daw/core/aliases/ResolverRegistry.cpp
+++ b/magda/daw/core/aliases/ResolverRegistry.cpp
@@ -61,7 +61,7 @@ std::optional<ControlTarget> FocusedDeviceMacroResolver::resolve(const juce::Str
     int macroIndex = args.getValue("macroIndex", "0").getIntValue();
 
     ControlTarget t;
-    t.devicePath = ownerPath;
+    t.devicePath = std::move(ownerPath);
     t.paramIndex = macroIndex;
     t.kind = ControlTarget::Kind::DeviceMacro;
     return t;

--- a/magda/daw/core/aliases/TargetResolver.cpp
+++ b/magda/daw/core/aliases/TargetResolver.cpp
@@ -148,7 +148,7 @@ ResolveResult TargetResolver::resolveAt(const ParsedSigil& sigil) const {
                                               " -- param not found on focused device");
 
             ResolveResult r;
-            r.target.devicePath = devicePath;
+            r.target.devicePath = std::move(devicePath);
             r.target.paramIndex = paramIdx;
             r.sourceLabel = "@focused." + sigil.paramKey;
             r.resolved = true;

--- a/magda/daw/engine/TracktionEngineWrapperDevices.cpp
+++ b/magda/daw/engine/TracktionEngineWrapperDevices.cpp
@@ -97,7 +97,7 @@ void TracktionEngineWrapper::handlePlaybackContextReallocation(tracktion::Device
 
     lastKnownDeviceCount_ = totalDevices;
     if (currentDeviceName.isNotEmpty())
-        lastKnownAudioDeviceName_ = currentDeviceName;
+        lastKnownAudioDeviceName_ = std::move(currentDeviceName);
 }
 
 void TracktionEngineWrapper::notifyDeviceLoadingComplete(const juce::String& message) {

--- a/magda/daw/music/ChordEngine.cpp
+++ b/magda/daw/music/ChordEngine.cpp
@@ -366,7 +366,7 @@ Chord ChordEngine::detectPolychord(const std::vector<ChordNote>& notes) const {
                     Chord chord(label);
                     chord.notes = notes;
                     chord.name = label;
-                    chord.displayName = label;
+                    chord.displayName = std::move(label);
                     chord.root = static_cast<ChordRoot>(lowerPc);
                     chord.quality = lowerMinor ? ChordQuality::Minor : ChordQuality::Major;
                     chord.inversion = 0;
@@ -399,7 +399,7 @@ Chord ChordEngine::buildChordInRootPosition(ChordRoot root, ChordQuality quality
     juce::String chordName = chordSpecToString(spec);
 
     Chord chord(chordName);
-    chord.notes = notes;
+    chord.notes = std::move(notes);
     return chord;
 }
 
@@ -439,7 +439,7 @@ Chord ChordEngine::buildChordInversion(ChordRoot root, ChordQuality quality, int
     juce::String chordName = chordSpecToString(spec);
 
     Chord chord(chordName);
-    chord.notes = notes;
+    chord.notes = std::move(notes);
     return chord;
 }
 

--- a/magda/daw/music/ChordEnums.hpp
+++ b/magda/daw/music/ChordEnums.hpp
@@ -231,7 +231,7 @@ inline ChordSpec stringToChordSpec(const juce::String& chordString) {
         rootStr = cleanStr.substring(0, spacePos).trim();
         qualityStr = cleanStr.substring(spacePos + 1).trim();
     } else {
-        rootStr = cleanStr;
+        rootStr = std::move(cleanStr);
         qualityStr = "maj";
     }
 

--- a/magda/daw/music/ChordSuggestionEngine.cpp
+++ b/magda/daw/music/ChordSuggestionEngine.cpp
@@ -926,7 +926,7 @@ ChordSuggestionEngine::generateNonDiatonicCandidates(const juce::String& key,
             juce::String uname = upperRoot + (upperMinor ? " min" : " maj");
             juce::String fullName = lname + " + " + uname;
             lowerChord.name = fullName;
-            lowerChord.displayName = fullName;
+            lowerChord.displayName = std::move(fullName);
 
             candidates.push_back({lowerChord, priority, label, "polychord"});
         };
@@ -1174,8 +1174,8 @@ Chord ChordSuggestionEngine::buildChordInRootPosition(const juce::String& root,
 
         // Create chord with base quality (enum), but override names below
         Chord chord(rootEnum, baseQuality, notes, rootMidiNote, std::nullopt, 0);
-        chord.name = finalName;
-        chord.displayName = displayName;
+        chord.name = std::move(finalName);
+        chord.displayName = std::move(displayName);
         return chord;
     }
 
@@ -1213,7 +1213,7 @@ Chord ChordSuggestionEngine::buildChordInRootPosition(const juce::String& root,
 
         Chord chord(rootEnum, baseQuality, notes, rootMidiNote, std::nullopt, 0);
         chord.name = finalName;  // preserve original descriptor like "7alt"
-        chord.displayName = finalName;
+        chord.displayName = std::move(finalName);
         return chord;
     }
 
@@ -1224,7 +1224,7 @@ Chord ChordSuggestionEngine::buildChordInRootPosition(const juce::String& root,
         addNote(rootMidiNote + iv);
     Chord chord(rootEnum, qualityEnum, notes, rootMidiNote, std::nullopt, 0);
     chord.name = finalName;
-    chord.displayName = finalName;
+    chord.displayName = std::move(finalName);
     return chord;
 }
 
@@ -1359,7 +1359,7 @@ Chord ChordSuggestionEngine::optimizeVoicing(const Chord& chord, float inversion
     Chord result;
     if (inversionStrength >= 0.3f) {  // Lower threshold - use voice leading for most cases
         // Use voice leading optimization
-        result = bestInversion;
+        result = std::move(bestInversion);
         result.inversion = bestInversionValue;
     } else {
         // Only interpolate for very low inversion strength (prefer root position)
@@ -1379,7 +1379,7 @@ Chord ChordSuggestionEngine::optimizeVoicing(const Chord& chord, float inversion
                 result = chord;  // Fallback if no inversions available
             }
         } else {
-            result = bestInversion;  // Use the best inversion
+            result = std::move(bestInversion);  // Use the best inversion
         }
         result.inversion =
             static_cast<int>(std::round(bestInversionValue * inversionStrength * 3.0f));

--- a/magda/daw/music/ChordTypes.hpp
+++ b/magda/daw/music/ChordTypes.hpp
@@ -54,7 +54,7 @@ struct Chord {
         quality = parsedSpec.quality;
         inversion = parsedSpec.inversion;
         displayName = chordName.contains(" + ") ? chordName : juce::String();
-        name = chordName;
+        name = std::move(chordName);
         notes = {};
         rootNoteNumber = -1;
         degree = std::nullopt;
@@ -79,7 +79,7 @@ struct Chord {
         quality = parsedSpec.quality;
         inversion = chordInversion;
         displayName = chordName.contains(" + ") ? chordName : juce::String();
-        name = chordName;
+        name = std::move(chordName);
         notes = chordNotes;
         rootNoteNumber = rootNote;
         degree = chordDegree;

--- a/magda/daw/project/ProjectManager.cpp
+++ b/magda/daw/project/ProjectManager.cpp
@@ -391,9 +391,9 @@ bool ProjectManager::saveProjectAs(const juce::File& file) {
     // Commit updated state only after successful save
     const bool wasOpen = isProjectOpen_;
     currentProject_ = std::move(newProject);
-    currentFile_ = actualFile;
+    currentFile_ = std::move(actualFile);
     isProjectOpen_ = true;
-    mediaDirectory_ = targetMediaDir;
+    mediaDirectory_ = std::move(targetMediaDir);
 
     clearDirty();
     deleteAutosaveFile();
@@ -604,7 +604,7 @@ void ProjectManager::loadProjectAsync(const juce::File& file,
     bool recoveredFromAutosave = false;
     if (autosaveFile.existsAsFile()) {
         if (promptAutosaveRecovery(file)) {
-            fileToLoad = autosaveFile;
+            fileToLoad = std::move(autosaveFile);
             recoveredFromAutosave = true;
         } else {
             autosaveFile.deleteFile();

--- a/magda/daw/project/serialization/AutomationModSerializer.cpp
+++ b/magda/daw/project/serialization/AutomationModSerializer.cpp
@@ -418,7 +418,7 @@ bool ProjectSerializer::deserializeMacroInfo(const juce::var& json, MacroInfo& o
             deserializeControlTarget(targetVar.getDynamicObject(), legacy);
             if (legacy.isValid()) {
                 MacroLink link;
-                link.target = legacy;
+                link.target = std::move(legacy);
                 outMacro.links.push_back(link);
             }
         }
@@ -623,7 +623,7 @@ bool ProjectSerializer::deserializeModInfo(const juce::var& json, ModInfo& outMo
             deserializeControlTarget(targetVar.getDynamicObject(), legacy);
             if (legacy.isValid()) {
                 ModLink link;
-                link.target = legacy;
+                link.target = std::move(legacy);
                 link.amount = static_cast<float>(obj->getProperty("amount"));
                 outMod.links.push_back(link);
             }

--- a/magda/daw/project/serialization/ProjectSerializer.cpp
+++ b/magda/daw/project/serialization/ProjectSerializer.cpp
@@ -96,7 +96,7 @@ bool ProjectSerializer::exportToDawProject(const juce::File& file, const Project
     juce::String error;
 
     if (!DawProjectArchive::writeToFile(file, document, error)) {
-        lastError_ = error;
+        lastError_ = std::move(error);
         return false;
     }
 
@@ -109,7 +109,7 @@ bool ProjectSerializer::loadDawProjectAndStage(const juce::File& file, StagedPro
     juce::String error;
 
     if (!DawProjectArchive::readFromFile(file, document, error, audioExtractionDir)) {
-        lastError_ = error;
+        lastError_ = std::move(error);
         return false;
     }
 

--- a/magda/daw/ui/components/clips/ClipComponent.cpp
+++ b/magda/daw/ui/components/clips/ClipComponent.cpp
@@ -4077,7 +4077,7 @@ void ClipComponent::showContextMenu() {
                 auto visibleTracks = TrackManager::getInstance().getVisibleTracks(
                     ViewModeController::getInstance().getViewMode());
                 if (sel.isAllTracks()) {
-                    trackIds = visibleTracks;
+                    trackIds = std::move(visibleTracks);
                 } else {
                     for (int idx : sel.trackIndices) {
                         if (idx >= 0 && idx < static_cast<int>(visibleTracks.size()))

--- a/magda/daw/ui/components/common/QwertyKeyboardPopup.cpp
+++ b/magda/daw/ui/components/common/QwertyKeyboardPopup.cpp
@@ -84,7 +84,7 @@ void QwertyKeyboardPopup::timerCallback() {
     auto octave = keyboard_.getBaseOctave();
     if (octave != lastBaseOctave_ || held != lastHeldNotes_) {
         lastBaseOctave_ = octave;
-        lastHeldNotes_ = held;
+        lastHeldNotes_ = std::move(held);
         octaveLabel_.setText("Base octave: " + juce::String(octave), juce::dontSendNotification);
         repaint();
     }

--- a/magda/daw/ui/components/pianoroll/PianoRollGridComponent.cpp
+++ b/magda/daw/ui/components/pianoroll/PianoRollGridComponent.cpp
@@ -2735,7 +2735,7 @@ void PianoRollGridComponent::itemDropped(const SourceDetails& details) {
     pendingChord_.startBeat = dropBeat;
     pendingChord_.previewEndBeat = dropBeat + gridResolutionBeats_;  // Default length preview
     pendingChord_.notes = std::move(notes);
-    pendingChord_.chordName = chordName;
+    pendingChord_.chordName = std::move(chordName);
     pendingChord_.active = true;
     pendingChord_.blinkOn = true;
 

--- a/magda/daw/ui/components/timeline/TimeRuler.cpp
+++ b/magda/daw/ui/components/timeline/TimeRuler.cpp
@@ -412,7 +412,7 @@ void TimeRuler::mouseMove(const juce::MouseEvent& event) {
         desiredCursor == juce::MouseCursor::IBeamCursor) {
         auto loopCursor = loopInteraction_.getCursor(event.x, event.y);
         if (loopCursor != juce::MouseCursor::NormalCursor)
-            desiredCursor = loopCursor;
+            desiredCursor = std::move(loopCursor);
     }
 
     setMouseCursor(desiredCursor);

--- a/magda/daw/ui/components/timeline/TimelineComponent.cpp
+++ b/magda/daw/ui/components/timeline/TimelineComponent.cpp
@@ -678,7 +678,7 @@ void TimelineComponent::mouseDoubleClick(const juce::MouseEvent& event) {
             // Edit section name (simplified - in real app would show text editor)
             auto& section = *sections[sectionIndex];
             juce::String newName = "Section " + juce::String(sectionIndex + 1);
-            section.name = newName;
+            section.name = std::move(newName);
 
             if (onSectionChanged) {
                 onSectionChanged(sectionIndex, section);

--- a/magda/daw/ui/components/tracks/TrackContentPanel.cpp
+++ b/magda/daw/ui/components/tracks/TrackContentPanel.cpp
@@ -2116,7 +2116,7 @@ void TrackContentPanel::showEmptySpaceContextMenu(const juce::MouseEvent& event)
                 auto visibleTracks = TrackManager::getInstance().getVisibleTracks(
                     ViewModeController::getInstance().getViewMode());
                 if (sel.isAllTracks()) {
-                    trackIds = visibleTracks;
+                    trackIds = std::move(visibleTracks);
                 } else {
                     for (int idx : sel.trackIndices) {
                         if (idx >= 0 && idx < static_cast<int>(visibleTracks.size()))
@@ -2804,7 +2804,7 @@ void TrackContentPanel::updateMarqueeHighlights() {
         clipComp->setMarqueeHighlighted(inMarquee);
     }
 
-    marqueePreviewClips_ = clipsInRect;
+    marqueePreviewClips_ = std::move(clipsInRect);
 }
 
 bool TrackContentPanel::checkIfMarqueeNeeded(const juce::Point<int>& currentPoint) const {

--- a/magda/daw/ui/dialogs/ExportAudioDialog.cpp
+++ b/magda/daw/ui/dialogs/ExportAudioDialog.cpp
@@ -331,7 +331,7 @@ void ExportAudioDialog::showDialog(juce::Component* parent,
     auto* dialog = new ExportAudioDialog();
     dialog->setTimeSelectionAvailable(hasTimeSelection);
     dialog->setLoopRegionAvailable(hasLoopRegion);
-    dialog->onExport = exportCallback;
+    dialog->onExport = std::move(exportCallback);
 
     juce::DialogWindow::LaunchOptions options;
     options.dialogTitle = tr("dialogs.export_audio");

--- a/magda/daw/ui/dialogs/ExportMidiDialog.cpp
+++ b/magda/daw/ui/dialogs/ExportMidiDialog.cpp
@@ -138,7 +138,7 @@ void ExportMidiDialog::showDialog(juce::Component* parent,
     auto* dialog = new ExportMidiDialog();
     dialog->setTimeSelectionAvailable(hasTimeSelection);
     dialog->setLoopRegionAvailable(hasLoopRegion);
-    dialog->onExport = exportCallback;
+    dialog->onExport = std::move(exportCallback);
 
     juce::DialogWindow::LaunchOptions options;
     options.dialogTitle =

--- a/magda/daw/ui/panels/content/AIChatConsoleContent.cpp
+++ b/magda/daw/ui/panels/content/AIChatConsoleContent.cpp
@@ -2080,7 +2080,7 @@ void AIChatConsoleContent::trackSelectionChanged(magda::TrackId trackId) {
         contextText_ = juce::String::fromUTF8("Drummer \xc2\xb7 ") + trackName;
         contextIcon_ = ContextIcon::Drummer;
     } else {
-        contextText_ = trackName;
+        contextText_ = std::move(trackName);
         contextIcon_ = ContextIcon::Track;
     }
     updateContextBar();
@@ -2154,7 +2154,7 @@ void AIChatConsoleContent::chainNodeSelectionChanged(const magda::ChainNodePath&
         else
             contextText_ = trackName + " > " + juce::String(deviceId);
     } else {
-        contextText_ = trackName;
+        contextText_ = std::move(trackName);
     }
     contextIcon_ = ContextIcon::Device;
     updateContextBar();

--- a/magda/daw/ui/panels/content/ChordPanelContent.cpp
+++ b/magda/daw/ui/panels/content/ChordPanelContent.cpp
@@ -553,7 +553,7 @@ void ChordPanelContent::updateFromPlugin() {
         }
     }
     if (scalesChanged) {
-        detectedScales_ = newScales;
+        detectedScales_ = std::move(newScales);
         rebuildScaleBlocks();
         needsLayout = true;
     }

--- a/magda/daw/ui/panels/content/PianoRollContent.cpp
+++ b/magda/daw/ui/panels/content/PianoRollContent.cpp
@@ -834,7 +834,7 @@ void PianoRollContent::setupGridCallbacks() {
             magda::ClipInfo::ChordAnnotation annotation;
             annotation.beatPosition = beat;
             annotation.lengthBeats = noteLength;
-            annotation.chordName = chordName;
+            annotation.chordName = std::move(chordName);
             annotation.chordGroup = groupId;
             auto chordCmd = std::make_unique<magda::AddChordAnnotationCommand>(clipId, annotation);
             magda::UndoManager::getInstance().executeCommand(std::move(chordCmd));

--- a/magda/daw/ui/panels/content/PluginBrowserContent.cpp
+++ b/magda/daw/ui/panels/content/PluginBrowserContent.cpp
@@ -1111,7 +1111,7 @@ void PluginBrowserContent::showEditAliasDialog(const PluginBrowserInfo& plugin) 
                     for (auto& p : plugins_) {
                         juce::String key = p.uniqueId.isNotEmpty() ? p.uniqueId : p.name;
                         if (key == pluginKey) {
-                            p.alias = newAlias;
+                            p.alias = std::move(newAlias);
                             break;
                         }
                     }

--- a/magda/daw/ui/panels/content/WaveformEditorContent.cpp
+++ b/magda/daw/ui/panels/content/WaveformEditorContent.cpp
@@ -1121,7 +1121,7 @@ void WaveformEditorContent::setMultiClipSelection(
     if (names == multiClipNames_)
         return;
 
-    multiClipNames_ = names;
+    multiClipNames_ = std::move(names);
     if (!multiClipNames_.isEmpty()) {
         setClip(magda::INVALID_CLIP_ID);
         setTransientsUpdating(false);

--- a/magda/daw/ui/panels/content/inspector/DeviceInspector.cpp
+++ b/magda/daw/ui/panels/content/inspector/DeviceInspector.cpp
@@ -170,8 +170,8 @@ void DeviceInspector::updateFromSelectedChainNode() {
 
     if (displayName.isNotEmpty()) {
         // Use override info (pad chain plugin)
-        typeStr = displayType;
-        nameStr = displayName;
+        typeStr = std::move(displayType);
+        nameStr = std::move(displayName);
     } else
         switch (type) {
             case magda::ChainNodeType::Device:

--- a/magda/daw/ui/windows/MainWindowCommands.cpp
+++ b/magda/daw/ui/windows/MainWindowCommands.cpp
@@ -555,7 +555,7 @@ bool MainWindow::MainComponent::perform(const InvocationInfo& info) {
         auto visibleTracks = TrackManager::getInstance().getVisibleTracks(
             ViewModeController::getInstance().getViewMode());
         if (sel.isAllTracks()) {
-            trackIds = visibleTracks;
+            trackIds = std::move(visibleTracks);
         } else {
             for (int idx : sel.trackIndices) {
                 if (idx >= 0 && idx < static_cast<int>(visibleTracks.size()))
@@ -1685,7 +1685,7 @@ bool MainWindow::MainComponent::perform(const InvocationInfo& info) {
 
             std::vector<TrackId> trackIds;
             if (state.selection.isAllTracks()) {
-                trackIds = visibleTracks;
+                trackIds = std::move(visibleTracks);
             } else {
                 for (int idx : state.selection.trackIndices) {
                     if (idx >= 0 && idx < static_cast<int>(visibleTracks.size()))


### PR DESCRIPTION
## Summary
- Next of the per-check PRs from #2388: `clang-tidy`'s `performance-use-std-move -fix` applied over `magda/`, no hand edits.
- 75 sites across 44 files — each wraps a local's last use in `std::move()` right before a copy (return, member-init, `push_back`, function argument).
- This check has real runtime effect (avoids a copy) and real correctness risk (use-after-move if the fixer's "last use" guess is wrong), so every hunk was read in full function context rather than just built and tested. Two independent reviews (a Claude subagent reading all 44 files, and a separate Codex pass) both confirmed no use-after-move sites — no loop-carried variables, no branch that reads the source after the move, no real-time audio path affected.

## Test plan
- [x] `make debug` — builds clean
- [x] `make test` — 3573 passed, 13 skipped, 856997 assertions, 0 failed
- [x] Manual line-by-line review of all 75 hunks for use-after-move (two independent passes)

Part of #2388.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0149ko34fXR5PeMBqVL1tDWt