### PR TITLE
Apply modernize-return-braced-init-list fixes across magda/

### DIFF
--- a/magda/agents/command_model.cpp
+++ b/magda/agents/command_model.cpp
@@ -331,7 +331,7 @@ double parseNumber(const std::string& text) {
 std::string fmtG(double v) {
     char buf[64];
     std::snprintf(buf, sizeof(buf), "%g", v);
-    return std::string(buf);
+    return {buf};
 }
 
 struct Phrase {

--- a/magda/agents/command_model_downloader.cpp
+++ b/magda/agents/command_model_downloader.cpp
@@ -197,7 +197,7 @@ CommandModelDownloader::~CommandModelDownloader() {
 
 juce::File CommandModelDownloader::modelsDir() {
     // Single source of truth: the same directory the backend loads from.
-    return juce::File(juce::String(CommandModelOnnx::defaultAssetDir().string()));
+    return {juce::String(CommandModelOnnx::defaultAssetDir().string())};
 }
 
 std::vector<juce::File> CommandModelDownloader::modelFiles() {

--- a/magda/agents/command_model_onnx.cpp
+++ b/magda/agents/command_model_onnx.cpp
@@ -411,11 +411,11 @@ std::filesystem::path CommandModelOnnx::defaultAssetDir() {
     // <dataDir>/CommandModel/models — same shape as MediaDB/models and
     // StemSeparation/models, so every downloaded bundle sits in the same place
     // relative to its feature.
-    return std::filesystem::path(magda::paths::dataDir()
-                                     .getChildFile("CommandModel")
-                                     .getChildFile("models")
-                                     .getFullPathName()
-                                     .toStdString());
+    return {magda::paths::dataDir()
+                .getChildFile("CommandModel")
+                .getChildFile("models")
+                .getFullPathName()
+                .toStdString()};
 }
 
 }  // namespace magda

--- a/magda/agents/dsl_interpreter.cpp
+++ b/magda/agents/dsl_interpreter.cpp
@@ -91,8 +91,8 @@ Token Tokenizer::readIdentifier() {
         col_++;
     }
 
-    return Token(TokenType::IDENTIFIER, std::string(start, static_cast<size_t>(pos_ - start)),
-                 line_, startCol);
+    return {TokenType::IDENTIFIER, std::string(start, static_cast<size_t>(pos_ - start)), line_,
+            startCol};
 }
 
 Token Tokenizer::readString() {
@@ -136,10 +136,10 @@ Token Tokenizer::readString() {
         pos_++;
         col_++;
     } else {
-        return Token(TokenType::ERROR, "Unterminated string", line_, startCol);
+        return {TokenType::ERROR, "Unterminated string", line_, startCol};
     }
 
-    return Token(TokenType::STRING, value, line_, startCol);
+    return {TokenType::STRING, value, line_, startCol};
 }
 
 Token Tokenizer::readNumber() {
@@ -165,8 +165,8 @@ Token Tokenizer::readNumber() {
         }
     }
 
-    return Token(TokenType::NUMBER, std::string(start, static_cast<size_t>(pos_ - start)), line_,
-                 startCol);
+    return {TokenType::NUMBER, std::string(start, static_cast<size_t>(pos_ - start)), line_,
+            startCol};
 }
 
 Token Tokenizer::next() {
@@ -178,7 +178,7 @@ Token Tokenizer::next() {
     skipWhitespace();
 
     if (!*pos_)
-        return Token(TokenType::END_OF_INPUT, "", line_, col_);
+        return {TokenType::END_OF_INPUT, "", line_, col_};
 
     int startCol = col_;
     char c = *pos_;
@@ -187,71 +187,71 @@ Token Tokenizer::next() {
         case '(':
             pos_++;
             col_++;
-            return Token(TokenType::LPAREN, "(", line_, startCol);
+            return {TokenType::LPAREN, "(", line_, startCol};
         case ')':
             pos_++;
             col_++;
-            return Token(TokenType::RPAREN, ")", line_, startCol);
+            return {TokenType::RPAREN, ")", line_, startCol};
         case '[':
             pos_++;
             col_++;
-            return Token(TokenType::LBRACKET, "[", line_, startCol);
+            return {TokenType::LBRACKET, "[", line_, startCol};
         case ']':
             pos_++;
             col_++;
-            return Token(TokenType::RBRACKET, "]", line_, startCol);
+            return {TokenType::RBRACKET, "]", line_, startCol};
         case '.':
             pos_++;
             col_++;
-            return Token(TokenType::DOT, ".", line_, startCol);
+            return {TokenType::DOT, ".", line_, startCol};
         case ',':
             pos_++;
             col_++;
-            return Token(TokenType::COMMA, ",", line_, startCol);
+            return {TokenType::COMMA, ",", line_, startCol};
         case ';':
             pos_++;
             col_++;
-            return Token(TokenType::SEMICOLON, ";", line_, startCol);
+            return {TokenType::SEMICOLON, ";", line_, startCol};
         case '@':
             pos_++;
             col_++;
-            return Token(TokenType::AT, "@", line_, startCol);
+            return {TokenType::AT, "@", line_, startCol};
         case '=':
             pos_++;
             col_++;
             if (*pos_ == '=') {
                 pos_++;
                 col_++;
-                return Token(TokenType::EQUALS_EQUALS, "==", line_, startCol);
+                return {TokenType::EQUALS_EQUALS, "==", line_, startCol};
             }
-            return Token(TokenType::EQUALS, "=", line_, startCol);
+            return {TokenType::EQUALS, "=", line_, startCol};
         case '!':
             pos_++;
             col_++;
             if (*pos_ == '=') {
                 pos_++;
                 col_++;
-                return Token(TokenType::NOT_EQUALS, "!=", line_, startCol);
+                return {TokenType::NOT_EQUALS, "!=", line_, startCol};
             }
-            return Token(TokenType::ERROR, "!", line_, startCol);
+            return {TokenType::ERROR, "!", line_, startCol};
         case '>':
             pos_++;
             col_++;
             if (*pos_ == '=') {
                 pos_++;
                 col_++;
-                return Token(TokenType::GREATER_EQUALS, ">=", line_, startCol);
+                return {TokenType::GREATER_EQUALS, ">=", line_, startCol};
             }
-            return Token(TokenType::GREATER, ">", line_, startCol);
+            return {TokenType::GREATER, ">", line_, startCol};
         case '<':
             pos_++;
             col_++;
             if (*pos_ == '=') {
                 pos_++;
                 col_++;
-                return Token(TokenType::LESS_EQUALS, "<=", line_, startCol);
+                return {TokenType::LESS_EQUALS, "<=", line_, startCol};
             }
-            return Token(TokenType::LESS, "<", line_, startCol);
+            return {TokenType::LESS, "<", line_, startCol};
         default:
             break;
     }
@@ -269,7 +269,7 @@ Token Tokenizer::next() {
     // Unknown character - skip it
     pos_++;
     col_++;
-    return Token(TokenType::ERROR, std::string(1, c), line_, startCol);
+    return {TokenType::ERROR, std::string(1, c), line_, startCol};
 }
 
 Token Tokenizer::peek() {
@@ -1914,7 +1914,7 @@ juce::var capabilitySummary(const juce::String& pluginId) {
     for (const auto& alias : capabilities.parameterAliases)
         aliases.add(alias);
     object->setProperty("parameter_aliases", aliases);
-    return juce::var(object);
+    return {object};
 }
 
 juce::var parameterSummary(const ParameterInfo& parameter) {
@@ -1930,7 +1930,7 @@ juce::var parameterSummary(const ParameterInfo& parameter) {
     if (std::isfinite(parameter.maxValue))
         object->setProperty("max", parameter.maxValue);
     object->setProperty("modulatable", parameter.modulatable);
-    return juce::var(object);
+    return {object};
 }
 
 juce::var deviceSummary(const DeviceInfo& device, const ChainNodePath& path,
@@ -1958,7 +1958,7 @@ juce::var deviceSummary(const DeviceInfo& device, const ChainNodePath& path,
         object->setProperty("parameters_truncated", static_cast<int>(device.parameters.size()) >
                                                         kMaxSelectedDeviceParameters);
     }
-    return juce::var(object);
+    return {object};
 }
 
 struct DeviceAtPath {

--- a/magda/agents/llama_model_manager.cpp
+++ b/magda/agents/llama_model_manager.cpp
@@ -149,7 +149,7 @@ std::string LlamaModelManager::applyTemplate(const std::string& systemPrompt,
     std::vector<char> buf(static_cast<size_t>(len) + 1);
     llama_chat_apply_template(tmpl, messages, 2, true, buf.data(),
                               static_cast<int32_t>(buf.size()));
-    return std::string(buf.data(), static_cast<size_t>(len));
+    return {buf.data(), static_cast<size_t>(len)};
 }
 
 LlamaModelManager::InferenceResult LlamaModelManager::infer(const InferenceRequest& req,

--- a/magda/daw/api/remote_audit.cpp
+++ b/magda/daw/api/remote_audit.cpp
@@ -70,7 +70,7 @@ juce::var AuditEntry::toJson() const {
     object->setProperty("requestId", requestId);
     object->setProperty("outcome", magda::remote::toString(outcome));
     object->setProperty("detail", detail);
-    return juce::var(object);
+    return {object};
 }
 
 // ===========================================================================

--- a/magda/daw/api/remote_mcp.cpp
+++ b/magda/daw/api/remote_mcp.cpp
@@ -53,7 +53,7 @@ constexpr const char* kInstructions =
     "conditional on the project not having changed since the revision you last saw.";
 
 juce::var makeObject() {
-    return juce::var(new juce::DynamicObject());
+    return {new juce::DynamicObject()};
 }
 
 void setProperty(juce::var& object, const char* name, const juce::var& value) {

--- a/magda/daw/api/remote_mcp_server.cpp
+++ b/magda/daw/api/remote_mcp_server.cpp
@@ -56,7 +56,7 @@ constexpr const char* kBase64Prefix = "=?base64?";
 constexpr const char* kBase64Suffix = "?=";
 
 juce::var makeObject() {
-    return juce::var(new juce::DynamicObject());
+    return {new juce::DynamicObject()};
 }
 
 void setProperty(juce::var& object, const char* name, const juce::var& value) {

--- a/magda/daw/api/remote_subscriptions.cpp
+++ b/magda/daw/api/remote_subscriptions.cpp
@@ -20,7 +20,7 @@ std::size_t indexOf(Topic topic) {
 }
 
 juce::var makeObject() {
-    return juce::var(new juce::DynamicObject());
+    return {new juce::DynamicObject()};
 }
 
 void setProperty(const juce::var& object, const char* name, const juce::var& value) {

--- a/magda/daw/api/remote_websocket_server.cpp
+++ b/magda/daw/api/remote_websocket_server.cpp
@@ -135,7 +135,7 @@ int jsonRpcCodeFor(ErrorCode code) {
 }
 
 juce::var makeObject() {
-    return juce::var(new juce::DynamicObject());
+    return {new juce::DynamicObject()};
 }
 
 void setProperty(juce::var& object, const char* name, const juce::var& value) {

--- a/magda/daw/audio/osc/OscPacket.cpp
+++ b/magda/daw/audio/osc/OscPacket.cpp
@@ -284,7 +284,7 @@ OscMessageView OscMessageView::fromOscMessage(const juce::String& address,
         }
     }
 
-    return OscMessageView(juce::StringRef(address), arguments.data(), count);
+    return {juce::StringRef(address), arguments.data(), count};
 }
 
 const OscArgument& OscMessageView::operator[](int index) const {

--- a/magda/daw/audio/plugins/MagdaSamplerPlugin.cpp
+++ b/magda/daw/audio/plugins/MagdaSamplerPlugin.cpp
@@ -830,7 +830,7 @@ void MagdaSamplerPlugin::relocateSample(const juce::File& file) {
 }
 
 juce::File MagdaSamplerPlugin::getSampleFile() const {
-    return juce::File(samplePath_);
+    return {samplePath_};
 }
 
 const juce::AudioBuffer<float>* MagdaSamplerPlugin::getWaveform() const {

--- a/magda/daw/cli/magda_cli_main.cpp
+++ b/magda/daw/cli/magda_cli_main.cpp
@@ -29,7 +29,7 @@ void printUsage(std::ostream& out);
 
 juce::File fileFromArg(const juce::String& path) {
     if (juce::File::isAbsolutePath(path))
-        return juce::File(path);
+        return {path};
     return juce::File::getCurrentWorkingDirectory().getChildFile(path);
 }
 

--- a/magda/daw/command.cpp
+++ b/magda/daw/command.cpp
@@ -101,7 +101,7 @@ juce::var Command::toJson() const {
             value);
     }
 
-    return juce::var(obj.get());
+    return {obj.get()};
 }
 
 Command Command::fromJsonString(const std::string& json_str) {
@@ -140,5 +140,5 @@ juce::var CommandResponse::toJson() const {
         obj->setProperty("data", data_);
     }
 
-    return juce::var(obj.get());
+    return {obj.get()};
 }

--- a/magda/daw/core/AppPaths.cpp
+++ b/magda/daw/core/AppPaths.cpp
@@ -173,7 +173,7 @@ juce::File configFile() {
     // Read on every call rather than cached in the resolve() snapshot: config
     // has to be readable before resolve() has run.
     if (const auto override_ = envVar("MAGDA_CONFIG_FILE"); override_.isNotEmpty())
-        return juce::File(override_);
+        return {override_};
     return alwaysOSDefault().getChildFile("config.json");
 }
 

--- a/magda/daw/core/ChainNodePath.cpp
+++ b/magda/daw/core/ChainNodePath.cpp
@@ -45,7 +45,7 @@ juce::var toVar(const ChainNodePath& path) {
     }
     obj->setProperty("steps", juce::var(steps));
 
-    return juce::var(obj);
+    return {obj};
 }
 
 bool fromVar(const juce::var& v, ChainNodePath& out) {

--- a/magda/daw/core/ControlTarget.cpp
+++ b/magda/daw/core/ControlTarget.cpp
@@ -38,7 +38,7 @@ juce::var toVar(const ControlTarget& target) {
     obj->setProperty("modParamIndex", target.modParamIndex);
     obj->setProperty("sendBusIndex", target.sendBusIndex);
 
-    return juce::var(obj);
+    return {obj};
 }
 
 bool fromVar(const juce::var& v, ControlTarget& out) {

--- a/magda/daw/core/DeviceState.cpp
+++ b/magda/daw/core/DeviceState.cpp
@@ -35,14 +35,14 @@ juce::var encodeValue(const juce::var& value) {
             obj->setProperty(kBinaryTag, block->toBase64Encoding());
         else
             obj->setProperty(kBinaryTag, juce::String());
-        return juce::var(obj);
+        return {obj};
     }
 
     if (const auto* array = value.getArray()) {
         juce::Array<juce::var> encoded;
         for (const auto& entry : *array)
             encoded.add(encodeValue(entry));
-        return juce::var(encoded);
+        return {encoded};
     }
 
     return value;
@@ -53,7 +53,7 @@ juce::var decodeValue(const juce::var& value) {
         if (obj->hasProperty(kBinaryTag)) {
             juce::MemoryBlock block;
             block.fromBase64Encoding(obj->getProperty(kBinaryTag).toString());
-            return juce::var(block);
+            return {block};
         }
         return value;
     }
@@ -62,7 +62,7 @@ juce::var decodeValue(const juce::var& value) {
         juce::Array<juce::var> decoded;
         for (const auto& entry : *array)
             decoded.add(decodeValue(entry));
-        return juce::var(decoded);
+        return {decoded};
     }
 
     return value;
@@ -72,7 +72,7 @@ juce::var encodeProps(const juce::NamedValueSet& props) {
     auto* obj = new juce::DynamicObject();
     for (int i = 0; i < props.size(); ++i)
         obj->setProperty(props.getName(i), encodeValue(props.getValueAt(i)));
-    return juce::var(obj);
+    return {obj};
 }
 
 void decodeProps(const juce::var& value, juce::NamedValueSet& outProps) {
@@ -95,7 +95,7 @@ juce::var encodeNode(const Node& node) {
             children.add(encodeNode(child));
         obj->setProperty(kKeyChildren, juce::var(children));
     }
-    return juce::var(obj);
+    return {obj};
 }
 
 Node decodeNode(const juce::var& value) {

--- a/magda/daw/core/ParameterUtils.cpp
+++ b/magda/daw/core/ParameterUtils.cpp
@@ -388,7 +388,7 @@ juce::String formatBars(float beats, int beatsPerBar = DEFAULT_TIME_SIGNATURE_NU
     int ticks = static_cast<int>(std::round((rem - b) * TICKS_PER_BEAT));
     char buf[32];
     std::snprintf(buf, sizeof(buf), "%d.%d.%03d", bars + 1, b + 1, ticks);
-    return juce::String(buf);
+    return {buf};
 }
 
 bool storesPercentAsUnitFraction(const ParameterInfo& info) {
@@ -603,7 +603,7 @@ juce::String formatValue(float realValue, const ParameterInfo& info, int decimal
                technicalText(TechnicalTextToken::Percent);
     }
 
-    return juce::String(realValue, decimalPlaces);
+    return {realValue, decimalPlaces};
 }
 
 std::optional<float> parseValue(const juce::String& text, const ParameterInfo& info) {

--- a/magda/daw/core/PluginCapabilities.cpp
+++ b/magda/daw/core/PluginCapabilities.cpp
@@ -83,7 +83,7 @@ juce::var snapshotToVar(const PluginCapabilitySnapshot& snapshot) {
     setBool(*obj, "tracktionTakesAudioInput", snapshot.tracktionTakesAudioInput);
     setBool(*obj, "tracktionProducesAudioWhenNoAudioInput",
             snapshot.tracktionProducesAudioWhenNoAudioInput);
-    return juce::var(obj);
+    return {obj};
 }
 
 DeviceMidiCapabilities fallbackCapabilitiesForDevice(const DeviceInfo& device) {

--- a/magda/daw/core/aliases/AliasRegistry.cpp
+++ b/magda/daw/core/aliases/AliasRegistry.cpp
@@ -237,7 +237,7 @@ juce::var AliasRegistry::saveUserGlobal() const {
     for (const auto& [name, alias] : userGlobalLayer_) {
         obj->setProperty(name, serializeStoredAlias(alias));
     }
-    return juce::var(obj);
+    return {obj};
 }
 
 // ============================================================================
@@ -268,7 +268,7 @@ juce::var AliasRegistry::toProjectJson() const {
     for (const auto& [name, alias] : userProjectLayer_) {
         obj->setProperty(name, serializeStoredAlias(alias));
     }
-    return juce::var(obj);
+    return {obj};
 }
 
 // ============================================================================
@@ -304,7 +304,7 @@ juce::var serializeStoredAlias(const StoredAlias& alias) {
     if (alias.path.has_value())
         obj->setProperty("path", toVar(*alias.path));
 
-    return juce::var(obj);
+    return {obj};
 }
 
 bool deserializeStoredAlias(const juce::var& v, StoredAlias& out) {

--- a/magda/daw/core/controllers/Binding.cpp
+++ b/magda/daw/core/controllers/Binding.cpp
@@ -158,7 +158,7 @@ juce::var encodeBinding(const Binding& b) {
     rangeObj->setProperty("curve", curveToString(b.range.curve));
     obj->setProperty("range", juce::var(rangeObj));
 
-    return juce::var(obj);
+    return {obj};
 }
 
 // ============================================================================

--- a/magda/daw/core/controllers/BindingRegistry.cpp
+++ b/magda/daw/core/controllers/BindingRegistry.cpp
@@ -497,7 +497,7 @@ juce::var BindingRegistry::encodeArray(const std::vector<Binding>& bindings) {
     juce::Array<juce::var> arr;
     for (const auto& b : bindings)
         arr.add(encodeBinding(b));
-    return juce::var(arr);
+    return {arr};
 }
 
 void BindingRegistry::loadGlobal(const juce::var& json) {

--- a/magda/daw/core/controllers/Controller.cpp
+++ b/magda/daw/core/controllers/Controller.cpp
@@ -28,7 +28,7 @@ juce::var encodeController(const Controller& c) {
     obj->setProperty("script", c.script);
     if (c.profileId.isNotEmpty())
         obj->setProperty("profileId", c.profileId);
-    return juce::var(obj);
+    return {obj};
 }
 
 // ============================================================================

--- a/magda/daw/core/controllers/ControllerProfile.cpp
+++ b/magda/daw/core/controllers/ControllerProfile.cpp
@@ -51,7 +51,7 @@ juce::var encodeControllerProfile(const ControllerProfile& p) {
     }
     obj->setProperty("defaultBindings", bindingsArr);
 
-    return juce::var(obj);
+    return {obj};
 }
 
 // ============================================================================

--- a/magda/daw/core/controllers/ControllerRegistry.cpp
+++ b/magda/daw/core/controllers/ControllerRegistry.cpp
@@ -160,7 +160,7 @@ juce::var ControllerRegistry::saveToConfig() const {
     juce::Array<juce::var> arr;
     for (const auto& c : controllers_)
         arr.add(encodeController(c));
-    return juce::var(arr);
+    return {arr};
 }
 
 // ============================================================================

--- a/magda/daw/engine/TracktionEngineWrapperTransport.cpp
+++ b/magda/daw/engine/TracktionEngineWrapperTransport.cpp
@@ -16,10 +16,10 @@ CommandResponse TracktionEngineWrapper::processCommand(const Command& command) {
     try {
         if (type == "play") {
             play();
-            return CommandResponse(CommandResponse::Status::Success, "Playback started");
+            return {CommandResponse::Status::Success, "Playback started"};
         } else if (type == "stop") {
             stop();
-            return CommandResponse(CommandResponse::Status::Success, "Playback stopped");
+            return {CommandResponse::Status::Success, "Playback stopped"};
         } else if (type == "createTrack") {
             // Simple parameter parsing - in a real implementation you'd parse JSON
             auto trackId = createMidiTrack("New Track");
@@ -32,11 +32,11 @@ CommandResponse TracktionEngineWrapper::processCommand(const Command& command) {
             response.setData(responseData);
             return response;
         } else {
-            return CommandResponse(CommandResponse::Status::Error, "Unknown command");
+            return {CommandResponse::Status::Error, "Unknown command"};
         }
     } catch (const std::exception& e) {
-        return CommandResponse(CommandResponse::Status::Error,
-                               "Command execution failed: " + std::string(e.what()));
+        return {CommandResponse::Status::Error,
+                "Command execution failed: " + std::string(e.what())};
     }
 }
 

--- a/magda/daw/media_db/SampleTaggerDownloader.cpp
+++ b/magda/daw/media_db/SampleTaggerDownloader.cpp
@@ -50,7 +50,7 @@ constexpr std::array<ManifestEntry, 3> kManifest = {{
 }};
 
 juce::File modelsDirAsFile() {
-    return juce::File(juce::String(MediaDbContext::getInstance().modelsDir().string()));
+    return {juce::String(MediaDbContext::getInstance().modelsDir().string())};
 }
 
 juce::File destinationFile(const ManifestEntry& entry) {

--- a/magda/daw/music/ChordEngine.cpp
+++ b/magda/daw/music/ChordEngine.cpp
@@ -109,7 +109,7 @@ ChordEngine::~ChordEngine() = default;
 
 Chord ChordEngine::detect(const std::vector<ChordNote>& heldNotes) const {
     if (heldNotes.empty())
-        return Chord("none");
+        return {"none"};
 
     if (heldNotes.size() < 2) {
         Chord chord("");
@@ -130,7 +130,7 @@ Chord ChordEngine::detect(const std::vector<ChordNote>& heldNotes) const {
     }
 
     if (pitchClasses.size() < 2)
-        return Chord("unknown");
+        return {"unknown"};
 
     std::sort(pitchClasses.begin(), pitchClasses.end());
 

--- a/magda/daw/music/ChordEnums.hpp
+++ b/magda/daw/music/ChordEnums.hpp
@@ -235,7 +235,7 @@ inline ChordSpec stringToChordSpec(const juce::String& chordString) {
         qualityStr = "maj";
     }
 
-    return ChordSpec(stringToRoot(rootStr), stringToQuality(qualityStr));
+    return {stringToRoot(rootStr), stringToQuality(qualityStr)};
 }
 
 inline std::vector<int> getChordIntervals(ChordQuality quality) {

--- a/magda/daw/music/ChordSuggestionEngine.cpp
+++ b/magda/daw/music/ChordSuggestionEngine.cpp
@@ -1761,7 +1761,7 @@ std::vector<ChordSuggestionEngine::SuggestionItem> ChordSuggestionEngine::proces
 
 std::vector<Chord> ChordSuggestionEngine::getRecentChords() const {
     std::scoped_lock lock(chordContextMutex);
-    return std::vector<Chord>(recentChords_.begin(), recentChords_.end());
+    return {recentChords_.begin(), recentChords_.end()};
 }
 
 juce::String ChordSuggestionEngine::getContextTailString(int maxChords) const {

--- a/magda/daw/project/serialization/AutomationModSerializer.cpp
+++ b/magda/daw/project/serialization/AutomationModSerializer.cpp
@@ -93,7 +93,7 @@ juce::var ProjectSerializer::serializeAutomationLaneInfo(const AutomationLaneInf
     }
     obj->setProperty("clipIds", juce::var(clipIdsArray));
 
-    return juce::var(obj);
+    return {obj};
 }
 
 bool ProjectSerializer::deserializeAutomationLaneInfo(const juce::var& json,
@@ -178,7 +178,7 @@ juce::var ProjectSerializer::serializeAutomationClipInfo(const AutomationClipInf
     }
     obj->setProperty("points", juce::var(pointsArray));
 
-    return juce::var(obj);
+    return {obj};
 }
 
 bool ProjectSerializer::deserializeAutomationClipInfo(const juce::var& json,
@@ -242,7 +242,7 @@ juce::var ProjectSerializer::serializeAutomationPoint(const AutomationPoint& poi
     obj->setProperty("inHandle", serializeBezierHandle(point.inHandle));
     obj->setProperty("outHandle", serializeBezierHandle(point.outHandle));
 
-    return juce::var(obj);
+    return {obj};
 }
 
 bool ProjectSerializer::deserializeAutomationPoint(const juce::var& json,
@@ -283,7 +283,7 @@ juce::var ProjectSerializer::serializeAutomationTarget(const AutomationTarget& t
     obj->setProperty("modParamIndex", target.modParamIndex);
     obj->setProperty("sendBusIndex", target.sendBusIndex);
 
-    return juce::var(obj);
+    return {obj};
 }
 
 bool ProjectSerializer::deserializeAutomationTarget(const juce::var& json,
@@ -327,7 +327,7 @@ juce::var ProjectSerializer::serializeBezierHandle(const BezierHandle& handle) {
     obj->setProperty("value", handle.value);
     obj->setProperty("linked", handle.linked);
 
-    return juce::var(obj);
+    return {obj};
 }
 
 bool ProjectSerializer::deserializeBezierHandle(const juce::var& json, BezierHandle& outHandle) {
@@ -380,7 +380,7 @@ juce::var ProjectSerializer::serializeMacroInfo(const MacroInfo& macro) {
     }
     obj->setProperty("links", juce::var(linksArray));
 
-    return juce::var(obj);
+    return {obj};
 }
 
 bool ProjectSerializer::deserializeMacroInfo(const juce::var& json, MacroInfo& outMacro) {
@@ -495,7 +495,7 @@ juce::var ProjectSerializer::serializeModInfo(const ModInfo& mod) {
     }
     obj->setProperty("links", juce::var(linksArray));
 
-    return juce::var(obj);
+    return {obj};
 }
 
 bool ProjectSerializer::deserializeModInfo(const juce::var& json, ModInfo& outMod) {
@@ -677,7 +677,7 @@ juce::var ProjectSerializer::serializeParameterInfo(const ParameterInfo& data) {
     }
     obj->setProperty("valueTable", juce::var(valueTableArray));
 
-    return juce::var(obj);
+    return {obj};
 }
 
 bool ProjectSerializer::deserializeParameterInfo(const juce::var& json, ParameterInfo& data) {
@@ -757,7 +757,7 @@ juce::var ProjectSerializer::serializeCurvePointData(const CurvePointData& data)
     SER(inHandleY);
     SER(outHandleX);
     SER(outHandleY);
-    return juce::var(obj);
+    return {obj};
 }
 
 bool ProjectSerializer::deserializeCurvePointData(const juce::var& json, CurvePointData& data) {
@@ -790,7 +790,7 @@ juce::var ProjectSerializer::serializeMacroLink(const MacroLink& data) {
     obj->setProperty("target", juce::var(targetObj));
     SER(amount);
     SER(bipolar);
-    return juce::var(obj);
+    return {obj};
 }
 
 bool ProjectSerializer::deserializeMacroLink(const juce::var& json, MacroLink& data) {
@@ -816,7 +816,7 @@ juce::var ProjectSerializer::serializeModLink(const ModLink& data) {
     SER(amount);
     SER(bipolar);
     SER(enabled);
-    return juce::var(obj);
+    return {obj};
 }
 
 bool ProjectSerializer::deserializeModLink(const juce::var& json, ModLink& data) {

--- a/magda/daw/project/serialization/ClipSerializer.cpp
+++ b/magda/daw/project/serialization/ClipSerializer.cpp
@@ -14,7 +14,7 @@ juce::var serializeMidiCurveHandle(const MidiCurveHandle& handle) {
     obj->setProperty("dx", handle.dx);
     obj->setProperty("dy", handle.dy);
     obj->setProperty("linked", handle.linked);
-    return juce::var(obj);
+    return {obj};
 }
 
 void deserializeMidiCurveHandle(const juce::var& json, MidiCurveHandle& handle) {
@@ -100,7 +100,7 @@ juce::var serializeAudioEvent(const AudioEvent& event) {
     obj->setProperty("fadeInBehaviour", event.fadeInBehaviour);
     obj->setProperty("fadeOutBehaviour", event.fadeOutBehaviour);
 
-    return juce::var(obj);
+    return {obj};
 }
 
 int64_t readSamples(const juce::DynamicObject& obj, const char* key) {
@@ -531,7 +531,7 @@ juce::var ProjectSerializer::serializeClipInfo(const ClipInfo& clip) {
     if (clip.nextChordGroupId > 1)
         obj->setProperty("nextChordGroupId", clip.nextChordGroupId);
 
-    return juce::var(obj);
+    return {obj};
 }
 
 bool ProjectSerializer::deserializeClipInfo(const juce::var& json, ClipInfo& outClip,
@@ -923,7 +923,7 @@ juce::var ProjectSerializer::serializeMidiNote(const MidiNote& data) {
         }
         obj->setProperty("pitchExpression", juce::var(points));
     }
-    return juce::var(obj);
+    return {obj};
 }
 
 bool ProjectSerializer::deserializeMidiNote(const juce::var& json, MidiNote& data) {
@@ -965,7 +965,7 @@ juce::var ProjectSerializer::serializeMidiCCData(const MidiCCData& data) {
     SER(tension);
     obj->setProperty("inHandle", serializeMidiCurveHandle(data.inHandle));
     obj->setProperty("outHandle", serializeMidiCurveHandle(data.outHandle));
-    return juce::var(obj);
+    return {obj};
 }
 
 bool ProjectSerializer::deserializeMidiCCData(const juce::var& json, MidiCCData& data) {
@@ -994,7 +994,7 @@ juce::var ProjectSerializer::serializeMidiPitchBendData(const MidiPitchBendData&
     SER(tension);
     obj->setProperty("inHandle", serializeMidiCurveHandle(data.inHandle));
     obj->setProperty("outHandle", serializeMidiCurveHandle(data.outHandle));
-    return juce::var(obj);
+    return {obj};
 }
 
 bool ProjectSerializer::deserializeMidiPitchBendData(const juce::var& json,

--- a/magda/daw/project/serialization/DawProjectValidator.cpp
+++ b/magda/daw/project/serialization/DawProjectValidator.cpp
@@ -30,7 +30,7 @@ juce::File schemaDirectory() {
     if (bundled.isDirectory())
         return bundled;
 
-    return juce::File(MAGDA_DAWPROJECT_SCHEMA_DIR);
+    return {MAGDA_DAWPROJECT_SCHEMA_DIR};
 }
 
 void appendLibXmlError(void* context, const char* message, ...) {

--- a/magda/daw/project/serialization/ProjectSerializer.cpp
+++ b/magda/daw/project/serialization/ProjectSerializer.cpp
@@ -564,7 +564,7 @@ juce::var ProjectSerializer::serializeProject(const ProjectInfo& info) {
     if (!info.projectBindings.isVoid())
         obj->setProperty("projectBindings", info.projectBindings);
 
-    return juce::var(obj);
+    return {obj};
 }
 
 bool ProjectSerializer::deserializeProject(const juce::var& json, ProjectInfo& outInfo) {
@@ -870,7 +870,7 @@ juce::var ProjectSerializer::serializeTracks() {
         tracksArray.add(serializeTrackInfo(track));
     }
 
-    return juce::var(tracksArray);
+    return {tracksArray};
 }
 
 juce::var ProjectSerializer::serializeSources() {
@@ -905,7 +905,7 @@ juce::var ProjectSerializer::serializeSources() {
             sourceObj->setProperty("detectedKeyScale", juce::String(source.detectedKeyScale));
         sourcesArray.add(juce::var(sourceObj));
     }
-    return juce::var(sourcesArray);
+    return {sourcesArray};
 }
 
 void ProjectSerializer::deserializeSourcesToStaging(const juce::var& json,
@@ -1039,7 +1039,7 @@ juce::var ProjectSerializer::serializeClips() {
         clipsArray.add(serializeClipInfo(clip));
     }
 
-    return juce::var(clipsArray);
+    return {clipsArray};
 }
 
 juce::var ProjectSerializer::serializeAutomation() {
@@ -1059,7 +1059,7 @@ juce::var ProjectSerializer::serializeAutomation() {
     obj->setProperty("lanes", juce::var(lanesArray));
     obj->setProperty("clips", juce::var(clipsArray));
 
-    return juce::var(obj);
+    return {obj};
 }
 
 // ============================================================================

--- a/magda/daw/project/serialization/TrackSerializer.cpp
+++ b/magda/daw/project/serialization/TrackSerializer.cpp
@@ -171,7 +171,7 @@ juce::var ProjectSerializer::serializeTrackInfo(const TrackInfo& track) {
     obj->setProperty("selectedGlobalModIndex", track.selectedGlobalModIndex);
     obj->setProperty("selectedGlobalMacroIndex", track.selectedGlobalMacroIndex);
 
-    return juce::var(obj);
+    return {obj};
 }
 
 bool ProjectSerializer::deserializeTrackInfo(const juce::var& json, TrackInfo& outTrack) {
@@ -395,7 +395,7 @@ juce::var ProjectSerializer::serializeChainElement(const ChainElement& element) 
         obj->setProperty("rack", serializeRackInfo(getRack(element)));
     }
 
-    return juce::var(obj);
+    return {obj};
 }
 
 bool ProjectSerializer::deserializeChainElement(const juce::var& json, ChainElement& outElement) {
@@ -588,7 +588,7 @@ juce::var ProjectSerializer::serializeDeviceInfo(const DeviceInfo& device) {
     if (device.pads)
         obj->setProperty("pads", serializeRackInfo(*device.pads.get()));
 
-    return juce::var(obj);
+    return {obj};
 }
 
 bool ProjectSerializer::deserializeDeviceInfo(const juce::var& json, DeviceInfo& outDevice) {
@@ -872,7 +872,7 @@ juce::var ProjectSerializer::serializeRackInfo(const RackInfo& rack) {
         obj->setProperty("sidechain", juce::var(scObj));
     }
 
-    return juce::var(obj);
+    return {obj};
 }
 
 bool ProjectSerializer::deserializeRackInfo(const juce::var& json, RackInfo& outRack) {
@@ -979,7 +979,7 @@ juce::var ProjectSerializer::serializeChainInfo(const ChainInfo& chain) {
     }
     obj->setProperty("elements", juce::var(elementsArray));
 
-    return juce::var(obj);
+    return {obj};
 }
 
 bool ProjectSerializer::deserializeChainInfo(const juce::var& json, ChainInfo& outChain) {
@@ -1039,7 +1039,7 @@ juce::var ProjectSerializer::serializeSendInfo(const SendInfo& data) {
     SER(level);
     SER(preFader);
     SER(destTrackId);
-    return juce::var(obj);
+    return {obj};
 }
 
 bool ProjectSerializer::deserializeSendInfo(const juce::var& json, SendInfo& data) {

--- a/magda/daw/transcription/BasicPitchTranscriber.cpp
+++ b/magda/daw/transcription/BasicPitchTranscriber.cpp
@@ -30,7 +30,7 @@ constexpr int kHalfOverlapFrames = bp::kOverlappingFrames / 2;                  
 // Resample mono PCM to 22050 Hz. Returns the resampled buffer.
 std::vector<float> resampleTo22050(const float* mono, int numSamples, int sampleRate) {
     if (sampleRate == bp::kSampleRate) {
-        return std::vector<float>(mono, mono + numSamples);
+        return {mono, mono + numSamples};
     }
     const double ratio = static_cast<double>(sampleRate) / bp::kSampleRate;
     const int outLen = static_cast<int>(std::ceil(numSamples / ratio));

--- a/magda/daw/ui/components/automation/AutomationLaneComponent.cpp
+++ b/magda/daw/ui/components/automation/AutomationLaneComponent.cpp
@@ -380,7 +380,7 @@ bool AutomationLaneComponent::hitTest(int x, int y) {
 
 juce::Rectangle<int> AutomationLaneComponent::getResizeHandleArea() const {
     int y = resizeHandleAtTop_ ? 0 : getHeight() - RESIZE_HANDLE_HEIGHT;
-    return juce::Rectangle<int>(0, y, getWidth(), RESIZE_HANDLE_HEIGHT);
+    return {0, y, getWidth(), RESIZE_HANDLE_HEIGHT};
 }
 
 void AutomationLaneComponent::setResizeHandleAtTop(bool atTop) {

--- a/magda/daw/ui/components/chain/compiled/CompiledCompressorCurveView.cpp
+++ b/magda/daw/ui/components/chain/compiled/CompiledCompressorCurveView.cpp
@@ -71,7 +71,7 @@ float compressedOutputDb(float inputDb, float thresholdDb, float ratio, float kn
 juce::String formatDb(float db) {
     if (db <= -90.0f)
         return "-inf";
-    return juce::String(db, db > -10.0f ? 1 : 0);
+    return {db, db > -10.0f ? 1 : 0};
 }
 
 }  // namespace

--- a/magda/daw/ui/components/chain/compiled/CompiledLimiterCurveView.cpp
+++ b/magda/daw/ui/components/chain/compiled/CompiledLimiterCurveView.cpp
@@ -31,7 +31,7 @@ float valueForSlot(const magda::DeviceInfo& device, int slotIndex, float fallbac
 juce::String formatDb(float db) {
     if (db <= -90.0f)
         return "-inf";
-    return juce::String(db, db > -10.0f ? 1 : 0);
+    return {db, db > -10.0f ? 1 : 0};
 }
 
 }  // namespace

--- a/magda/daw/ui/components/chain/custom_ui/ImpulseResponseUI.cpp
+++ b/magda/daw/ui/components/chain/custom_ui/ImpulseResponseUI.cpp
@@ -100,8 +100,7 @@ ImpulseResponseUI::ImpulseResponseUI() {
 
     // Filter Q: 0.1–14.0
     filterQ_.slider.setRange(0.1, 14.0, 0.01);
-    filterQ_.slider.setValueFormatter(
-        [](double value) -> juce::String { return juce::String(value, 2); });
+    filterQ_.slider.setValueFormatter([](double value) -> juce::String { return {value, 2}; });
     filterQ_.slider.setValueParser(
         [](const juce::String& text) -> double { return text.trim().getDoubleValue(); });
     filterQ_.slider.onValueChanged = [this](double value) {

--- a/magda/daw/ui/components/chain/custom_ui/LevelsUI.cpp
+++ b/magda/daw/ui/components/chain/custom_ui/LevelsUI.cpp
@@ -20,7 +20,7 @@ juce::String fmtDb(float v) {
     return v <= kSilenceDb + 1.0f ? juce::String("-inf") : juce::String(v, 1);
 }
 juce::String fmtLu(float v) {
-    return juce::String(v, 1);
+    return {v, 1};
 }
 
 // Colour a true-peak value: hot near/over 0 dBTP, warm approaching it.

--- a/magda/daw/ui/components/chain/modulation/LFOCurveEditor.cpp
+++ b/magda/daw/ui/components/chain/modulation/LFOCurveEditor.cpp
@@ -788,7 +788,7 @@ juce::Rectangle<int> LFOCurveEditor::getIndicatorBounds() const {
 
     // Return a small region around the indicator dot
     constexpr int margin = 8;
-    return juce::Rectangle<int>(x - margin, y - margin, margin * 2, margin * 2);
+    return {x - margin, y - margin, margin * 2, margin * 2};
 }
 
 void LFOCurveEditor::paint(juce::Graphics& g) {

--- a/magda/daw/ui/components/common/BarsBeatsTicksLabel.cpp
+++ b/magda/daw/ui/components/common/BarsBeatsTicksLabel.cpp
@@ -307,7 +307,7 @@ juce::String BarsBeatsTicksLabel::SegmentLabel::formatDisplay() const {
         // Zero-padded to 3 digits
         char buffer[8];
         std::snprintf(buffer, sizeof(buffer), "%03d", displayValue_);
-        return juce::String(buffer);
+        return {buffer};
     }
     return juce::String(displayValue_);
 }

--- a/magda/daw/ui/components/common/DraggableValueLabel.cpp
+++ b/magda/daw/ui/components/common/DraggableValueLabel.cpp
@@ -138,7 +138,7 @@ juce::String DraggableValueLabel::formatValue(double val) const {
             char buffer[32];
             std::snprintf(buffer, sizeof(buffer), "%d.%d.%03d", wholeBars + offset,
                           wholeBeats + offset, ticks);
-            return juce::String(buffer);
+            return {buffer};
         }
 
         case Format::Raw:

--- a/magda/daw/ui/components/common/InternalFileDrag.cpp
+++ b/magda/daw/ui/components/common/InternalFileDrag.cpp
@@ -16,7 +16,7 @@ juce::var makeFilesDragDescription(const juce::StringArray& paths) {
     auto* obj = new juce::DynamicObject();
     obj->setProperty(kTypeKey, juce::var(kFilesType));
     obj->setProperty(kPathsKey, juce::var(pathArray));
-    return juce::var(obj);  // ref-counted from here, so no leak if it goes unused
+    return {obj};  // ref-counted from here, so no leak if it goes unused
 }
 
 void startFilesDrag(juce::Component* sourceComponent, const juce::StringArray& paths,

--- a/magda/daw/ui/components/common/QwertyKeyboardPopup.cpp
+++ b/magda/daw/ui/components/common/QwertyKeyboardPopup.cpp
@@ -116,16 +116,16 @@ void QwertyKeyboardPopup::resized() {
 juce::Rectangle<float> QwertyKeyboardPopup::whiteKeyBounds(size_t index) const {
     const auto total = static_cast<float>(kWhiteKeys_.size());
     const float w = keyboardArea_.getWidth() / total;
-    return juce::Rectangle<float>(keyboardArea_.getX() + static_cast<float>(index) * w,
-                                  static_cast<float>(keyboardArea_.getY()), w,
-                                  static_cast<float>(keyboardArea_.getHeight()));
+    return {keyboardArea_.getX() + static_cast<float>(index) * w,
+            static_cast<float>(keyboardArea_.getY()), w,
+            static_cast<float>(keyboardArea_.getHeight())};
 }
 
 juce::Rectangle<float> QwertyKeyboardPopup::blackKeyBounds(const BlackKey& bk) const {
     auto anchor = whiteKeyBounds(static_cast<size_t>(bk.anchorWhiteIndex));
     const float w = anchor.getWidth() * 0.62f;
     const float h = anchor.getHeight() * (kBlackKeyHeightRatio / 100.0f);
-    return juce::Rectangle<float>(anchor.getRight() - w * 0.5f, anchor.getY(), w, h);
+    return {anchor.getRight() - w * 0.5f, anchor.getY(), w, h};
 }
 
 void QwertyKeyboardPopup::paint(juce::Graphics& g) {

--- a/magda/daw/ui/components/mixer/MasterChannelStrip.cpp
+++ b/magda/daw/ui/components/mixer/MasterChannelStrip.cpp
@@ -299,7 +299,7 @@ void MasterChannelStrip::setupControls() {
             return "-inf";
         if (std::abs(db) < 0.05f)
             db = 0.0f;
-        return juce::String(db, 1);
+        return {db, 1};
     });
 
     // Custom parser: user input text -> normalized position (0-1)
@@ -473,7 +473,7 @@ void MasterChannelStrip::setupControls() {
             return "-inf";
         if (std::abs(db) < 0.05f)
             db = 0.0f;
-        return juce::String(db, 1);
+        return {db, 1};
     });
 
     cueVolumeSlider_->setValueParser([](const juce::String& text) -> double {

--- a/magda/daw/ui/components/navigation/SongNavigatorPanel.cpp
+++ b/magda/daw/ui/components/navigation/SongNavigatorPanel.cpp
@@ -92,9 +92,9 @@ juce::Rectangle<float> SongNavigatorPanel::getViewportBox() const {
     const int left = beatToX(startBeats);
     const int right = beatToX(endBeats);
     // Span the lanes area only - start below the ruler band, like the playhead.
-    return juce::Rectangle<float>(static_cast<float>(left), static_cast<float>(kRulerHeight),
-                                  static_cast<float>(juce::jmax(2, right - left)),
-                                  static_cast<float>(getHeight() - kRulerHeight));
+    return {static_cast<float>(left), static_cast<float>(kRulerHeight),
+            static_cast<float>(juce::jmax(2, right - left)),
+            static_cast<float>(getHeight() - kRulerHeight)};
 }
 
 // ===== Painting =====

--- a/magda/daw/ui/components/timeline/ZoomScrollBar.cpp
+++ b/magda/daw/ui/components/timeline/ZoomScrollBar.cpp
@@ -260,13 +260,11 @@ juce::Rectangle<int> ZoomScrollBar::getTrackBounds() const {
     if (orientation == Orientation::Horizontal) {
         int height = bounds.getHeight() - 8;
         int yOffset = (bounds.getHeight() - height) / 2;
-        return juce::Rectangle<int>(bounds.getX() + 2, bounds.getY() + yOffset,
-                                    bounds.getWidth() - 4, height);
+        return {bounds.getX() + 2, bounds.getY() + yOffset, bounds.getWidth() - 4, height};
     } else {
         int width = bounds.getWidth() - 8;
         int xOffset = (bounds.getWidth() - width) / 2;
-        return juce::Rectangle<int>(bounds.getX() + xOffset, bounds.getY() + 2, width,
-                                    bounds.getHeight() - 4);
+        return {bounds.getX() + xOffset, bounds.getY() + 2, width, bounds.getHeight() - 4};
     }
 }
 
@@ -278,15 +276,13 @@ juce::Rectangle<int> ZoomScrollBar::getThumbBounds() const {
         int thumbWidth = static_cast<int>((visibleEnd - visibleStart) * trackBounds.getWidth());
         thumbWidth = juce::jmax(thumbWidth, MIN_THUMB_SIZE);
 
-        return juce::Rectangle<int>(thumbX, trackBounds.getY(), thumbWidth,
-                                    trackBounds.getHeight());
+        return {thumbX, trackBounds.getY(), thumbWidth, trackBounds.getHeight()};
     } else {
         int thumbY = trackBounds.getY() + static_cast<int>(visibleStart * trackBounds.getHeight());
         int thumbHeight = static_cast<int>((visibleEnd - visibleStart) * trackBounds.getHeight());
         thumbHeight = juce::jmax(thumbHeight, MIN_THUMB_SIZE);
 
-        return juce::Rectangle<int>(trackBounds.getX(), thumbY, trackBounds.getWidth(),
-                                    thumbHeight);
+        return {trackBounds.getX(), thumbY, trackBounds.getWidth(), thumbHeight};
     }
 }
 

--- a/magda/daw/ui/components/tracks/TrackContentPanel.cpp
+++ b/magda/daw/ui/components/tracks/TrackContentPanel.cpp
@@ -1057,7 +1057,7 @@ juce::Rectangle<int> TrackContentPanel::getTrackLaneArea(int trackIndex) const {
     int yPosition = getTrackYPosition(trackIndex);
     int height = static_cast<int>(trackLanes[trackIndex]->height * verticalZoom);
 
-    return juce::Rectangle<int>(0, yPosition, getWidth(), height);
+    return {0, yPosition, getWidth(), height};
 }
 
 bool TrackContentPanel::isInSelectableArea(int x, int y) const {

--- a/magda/daw/ui/components/tracks/TrackHeadersPanel.cpp
+++ b/magda/daw/ui/components/tracks/TrackHeadersPanel.cpp
@@ -1760,7 +1760,7 @@ void TrackHeadersPanel::setupTrackHeaderWithId(TrackHeader& header, int trackId)
         auto& sel = SelectionManager::getInstance();
         if (sel.isTrackSelected(clickedId) && sel.getSelectedTrackCount() > 1) {
             const auto& set = sel.getSelectedTracks();
-            return std::vector<TrackId>(set.begin(), set.end());
+            return {set.begin(), set.end()};
         }
         return {clickedId};
     };
@@ -2142,7 +2142,7 @@ juce::Rectangle<int> TrackHeadersPanel::getTrackHeaderArea(int trackIndex) const
     int yPosition = getTrackYPosition(trackIndex);
     int height = static_cast<int>(trackHeaders[trackIndex]->height * verticalZoom);
 
-    return juce::Rectangle<int>(0, yPosition, getWidth(), height - RESIZE_HANDLE_HEIGHT);
+    return {0, yPosition, getWidth(), height - RESIZE_HANDLE_HEIGHT};
 }
 
 juce::Rectangle<int> TrackHeadersPanel::getResizeHandleArea(int trackIndex) const {
@@ -2153,8 +2153,7 @@ juce::Rectangle<int> TrackHeadersPanel::getResizeHandleArea(int trackIndex) cons
     int yPosition = getTrackYPosition(trackIndex);
     int height = static_cast<int>(trackHeaders[trackIndex]->height * verticalZoom);
 
-    return juce::Rectangle<int>(0, yPosition + height - RESIZE_HANDLE_HEIGHT, getWidth(),
-                                RESIZE_HANDLE_HEIGHT);
+    return {0, yPosition + height - RESIZE_HANDLE_HEIGHT, getWidth(), RESIZE_HANDLE_HEIGHT};
 }
 
 bool TrackHeadersPanel::isResizeHandleArea(const juce::Point<int>& point, int& trackIndex) const {

--- a/magda/daw/ui/dialogs/ParameterConfigDialog.cpp
+++ b/magda/daw/ui/dialogs/ParameterConfigDialog.cpp
@@ -304,7 +304,7 @@ class ParameterConfigDialog::RangeCell : public juce::Component {
                     return "-inf";
                 if (std::isinf(v))
                     return "+inf";
-                return juce::String(v, 1);
+                return {v, 1};
             };
             editor_.setText(formatValue(param.rangeMin) + juce::String::fromUTF8(" — ") +
                                 formatValue(param.rangeMax),

--- a/magda/daw/ui/panels/BottomPanel.cpp
+++ b/magda/daw/ui/panels/BottomPanel.cpp
@@ -1481,7 +1481,7 @@ void BottomPanel::layoutMidiHeaderControls(juce::Rectangle<int> headerBounds) {
 
 juce::Rectangle<int> BottomPanel::getTabBarBounds() {
     // No tab bar for bottom panel - content is auto-switched based on selection
-    return juce::Rectangle<int>();
+    return {};
 }
 
 juce::Rectangle<int> BottomPanel::getContentBounds() {

--- a/magda/daw/ui/panels/content/AIChatConsoleContent.cpp
+++ b/magda/daw/ui/panels/content/AIChatConsoleContent.cpp
@@ -3561,7 +3561,7 @@ static juce::String formatSeconds(float s) {
 
 // Format a normalized 0..1 value as 2-decimal text.
 static juce::String formatNorm(float v) {
-    return juce::String(juce::jlimit(0.0f, 1.0f, v), 2);
+    return {juce::jlimit(0.0f, 1.0f, v), 2};
 }
 
 // Render a parsed preset as a categorized multi-line summary suitable

--- a/magda/daw/ui/panels/content/MediaDbBrowserContent.cpp
+++ b/magda/daw/ui/panels/content/MediaDbBrowserContent.cpp
@@ -134,9 +134,9 @@ juce::String prettyDuration(std::optional<double> seconds) {
 
 juce::String displayNameFor(const magda::media::QueryResult& result) {
     if (result.displayName && !result.displayName->empty()) {
-        return juce::String(*result.displayName);
+        return {*result.displayName};
     }
-    return juce::String(result.path.filename().string());
+    return {result.path.filename().string()};
 }
 
 // A compact, branded chip used as the drag image for preset rows. macOS would

--- a/magda/daw/ui/panels/content/MidiEditorContent.cpp
+++ b/magda/daw/ui/panels/content/MidiEditorContent.cpp
@@ -53,7 +53,7 @@ std::vector<int> MidiEditorContent::collectUsedPitches() const {
             for (const auto& note : clip->midiNotes)
                 used.insert(note.noteNumber);
     }
-    return std::vector<int>(used.begin(), used.end());
+    return {used.begin(), used.end()};
 }
 
 void MidiEditorContent::rebuildFoldMap() {

--- a/magda/daw/ui/panels/content/PianoRollContent.cpp
+++ b/magda/daw/ui/panels/content/PianoRollContent.cpp
@@ -393,7 +393,7 @@ std::vector<int> PianoRollContent::collectUsedPitches() const {
     } else if (editingClipId_ != magda::INVALID_CLIP_ID) {
         collect(editingClipId_);
     }
-    return std::vector<int>(usedPitches.begin(), usedPitches.end());
+    return {usedPitches.begin(), usedPitches.end()};
 }
 
 void PianoRollContent::onFoldMapChanged() {

--- a/magda/daw/ui/panels/content/PluginBrowserContent.cpp
+++ b/magda/daw/ui/panels/content/PluginBrowserContent.cpp
@@ -273,7 +273,7 @@ class PluginBrowserContent::PluginTreeItem : public juce::TreeViewItem {
         // External plugin identification
         obj->setProperty("uniqueId", plugin_.uniqueId);
         obj->setProperty("fileOrIdentifier", plugin_.fileOrIdentifier);
-        return juce::var(obj);
+        return {obj};
     }
 
     bool isInterestedInDragSource(const juce::DragAndDropTarget::SourceDetails&) override {

--- a/magda/daw/ui/panels/content/inspector/NoteInspector.cpp
+++ b/magda/daw/ui/panels/content/inspector/NoteInspector.cpp
@@ -383,7 +383,7 @@ void NoteInspector::refreshMultiRangeDisplay() {
         char buffer[32];
         std::snprintf(buffer, sizeof(buffer), "%d.%d.%03d", wholeBars + offset, wholeBeats + offset,
                       ticks);
-        return juce::String(buffer);
+        return {buffer};
     };
 
     if (std::abs(multiRange_.minStart - multiRange_.maxStart) < 0.001) {

--- a/magda/daw/ui/themes/CursorManager.cpp
+++ b/magda/daw/ui/themes/CursorManager.cpp
@@ -61,7 +61,7 @@ juce::MouseCursor CursorManager::createCurveBendCursor() {
     pass(arrow, 3.4f, 1.6f);
 
     // Hotspot on the curve's own midpoint, which is the thing being grabbed.
-    return juce::MouseCursor(img, 13, 17);
+    return {img, 13, 17};
 }
 
 juce::MouseCursor CursorManager::createGhostCopyCursor() {
@@ -95,7 +95,7 @@ juce::MouseCursor CursorManager::createGhostCopyCursor() {
     g.strokePath(links, bodyStroke);
 
     // Hotspot at the joint between the two links (glyph centre).
-    return juce::MouseCursor(img, 14, 14);
+    return {img, 14, 14};
 }
 
 juce::MouseCursor CursorManager::createBladeCursor() {
@@ -139,7 +139,7 @@ juce::MouseCursor CursorManager::createBladeCursor() {
     g.fillEllipse(13.25f, 14.25f, 1.5f, 1.5f);
 
     // Hotspot at the blade tips (bottom centre)
-    return juce::MouseCursor(img, 14, 23);
+    return {img, 14, 23};
 }
 
 juce::MouseCursor CursorManager::createZoomCursor(ZoomGlyph glyph) {
@@ -191,7 +191,7 @@ juce::MouseCursor CursorManager::createZoomCursor(ZoomGlyph glyph) {
     }
 
     // Hotspot at center of the lens
-    return juce::MouseCursor(img, static_cast<int>(cx), static_cast<int>(cy));
+    return {img, static_cast<int>(cx), static_cast<int>(cy)};
 }
 
 juce::MouseCursor CursorManager::createNoteDrawCursor() {
@@ -235,7 +235,7 @@ juce::MouseCursor CursorManager::createNoteDrawCursor() {
     g.strokePath(tip, juce::PathStrokeType(1.0f));
 
     // Hotspot at pencil tip.
-    return juce::MouseCursor(img, 5, 22);
+    return {img, 5, 22};
 }
 
 juce::MouseCursor CursorManager::createEraseCursor() {
@@ -274,7 +274,7 @@ juce::MouseCursor CursorManager::createEraseCursor() {
     g.drawLine(5.0f, 5.0f, 12.0f, 12.0f, 2.0f);
     g.drawLine(12.0f, 5.0f, 5.0f, 12.0f, 2.0f);
 
-    return juce::MouseCursor(img, 8, 20);
+    return {img, 8, 20};
 }
 
 juce::MouseCursor CursorManager::createNoteRepeatCursor() {
@@ -319,7 +319,7 @@ juce::MouseCursor CursorManager::createNoteRepeatCursor() {
     g.strokePath(c3, hairline);
 
     // Hotspot at the centre of the leftmost cell — the click point lands there.
-    return juce::MouseCursor(img, 7, 14);
+    return {img, 7, 14};
 }
 
 }  // namespace magda

--- a/magda/daw/ui/themes/DarkTheme.hpp
+++ b/magda/daw/ui/themes/DarkTheme.hpp
@@ -37,9 +37,8 @@ inline juce::Colour oklchToColour(float L, float C, float hueDegrees, float alph
         return static_cast<juce::uint8>(juce::jlimit(0.0f, 255.0f, c * 255.0f + 0.5f));
     };
 
-    return juce::Colour(
-        toSrgb(rLin), toSrgb(gLin), toSrgb(bLin),
-        static_cast<juce::uint8>(juce::jlimit(0.0f, 255.0f, alpha * 255.0f + 0.5f)));
+    return {toSrgb(rLin), toSrgb(gLin), toSrgb(bLin),
+            static_cast<juce::uint8>(juce::jlimit(0.0f, 255.0f, alpha * 255.0f + 0.5f))};
 }
 
 // Converts a JUCE sRGB Colour to its true OKLCH hue in degrees. NOTE: this is

--- a/magda/daw/ui/themes/ThemePrompt.cpp
+++ b/magda/daw/ui/themes/ThemePrompt.cpp
@@ -158,7 +158,7 @@ juce::var buildThemeSchema() {
     schema->setProperty("required", rootRequired);
     schema->setProperty("additionalProperties", false);
 
-    return juce::var(schema);
+    return {schema};
 }
 
 std::optional<GeneratedTheme> validateGeneratedTheme(const juce::String& llmText,

--- a/magda/daw/ui/utils/TimelineUtils.hpp
+++ b/magda/daw/ui/utils/TimelineUtils.hpp
@@ -200,7 +200,7 @@ inline std::string formatTimeAsBarsBeats(double time, double bpm, int beatsPerBa
 
     char buffer[32];
     std::snprintf(buffer, sizeof(buffer), "%d.%d.%03d", bar, beat, ticks);
-    return std::string(buffer);
+    return {buffer};
 }
 
 /**
@@ -229,7 +229,7 @@ inline std::string formatDurationAsBarsBeats(double duration, double bpm, int be
         // Sub-beat duration - show as fraction
         std::snprintf(buffer, sizeof(buffer), "%.2f beats", totalBeats);
     }
-    return std::string(buffer);
+    return {buffer};
 }
 
 /**
@@ -246,7 +246,7 @@ inline std::string formatDurationCompact(double duration, double bpm, int beatsP
 
     char buffer[32];
     std::snprintf(buffer, sizeof(buffer), "%d.%.1f", wholeBars, remainingBeats);
-    return std::string(buffer);
+    return {buffer};
 }
 
 /**
@@ -265,7 +265,7 @@ inline std::string formatBeatsAsBarsBeats(double totalBeats, int beatsPerBar) {
 
     char buffer[32];
     std::snprintf(buffer, sizeof(buffer), "%d.%d.%03d", wholeBars, wholeBeats, ticks);
-    return std::string(buffer);
+    return {buffer};
 }
 
 }  // namespace TimelineUtils

--- a/magda/daw/ui/views/MainView.cpp
+++ b/magda/daw/ui/views/MainView.cpp
@@ -60,7 +60,7 @@ juce::String formatDbValue(float db) {
         return "-inf";
     if (std::abs(db) < 0.05f)
         db = 0.0f;
-    return juce::String(db, 1);
+    return {db, 1};
 }
 
 // Route through the position-aware tempo facade when wired (message thread);
@@ -1936,7 +1936,7 @@ juce::Rectangle<int> MainView::getResizeHandleArea() const {
     int x = arrangementLayout.swapped
                 ? arrangementLayout.trackHeadersArea.getX() - layout.componentSpacing
                 : arrangementLayout.trackHeadersArea.getRight();
-    return juce::Rectangle<int>(x, top, layout.componentSpacing, getHeight() - top);
+    return {x, top, layout.componentSpacing, getHeight() - top};
 }
 
 void MainView::paintResizeHandle(juce::Graphics& g) {
@@ -1977,7 +1977,7 @@ juce::Rectangle<int> MainView::getMasterResizeHandleArea() const {
     int horizontalScrollbarHeight = ARRANGEMENT_SCROLLBAR_SIZE;
     int resizeHandleY = getHeight() - horizontalScrollbarHeight - masterStripHeight -
                         MASTER_RESIZE_HANDLE_HEIGHT - effectiveAuxHeight;
-    return juce::Rectangle<int>(0, resizeHandleY, getWidth(), MASTER_RESIZE_HANDLE_HEIGHT);
+    return {0, resizeHandleY, getWidth(), MASTER_RESIZE_HANDLE_HEIGHT};
 }
 
 void MainView::paintMasterResizeHandle(juce::Graphics& g) {

--- a/magda/daw/ui/views/MixerView.cpp
+++ b/magda/daw/ui/views/MixerView.cpp
@@ -113,7 +113,7 @@ std::vector<TrackId> getMultiEditTargets(TrackId clickedId, bool isMaster) {
     auto& sel = SelectionManager::getInstance();
     if (!isMaster && sel.isTrackSelected(clickedId) && sel.getSelectedTrackCount() > 1) {
         const auto& set = sel.getSelectedTracks();
-        return std::vector<TrackId>(set.begin(), set.end());
+        return {set.begin(), set.end()};
     }
     return {clickedId};
 }
@@ -490,7 +490,7 @@ void MixerView::ChannelStrip::setupControls() {
             return "-inf";
         if (std::abs(db) < 0.05f)
             db = 0.0f;
-        return juce::String(db, 1);
+        return {db, 1};
     });
     // Parse typed dB input
     volumeSlider->setValueParser([](const juce::String& text) -> double {

--- a/magda/daw/ui/views/SessionView.cpp
+++ b/magda/daw/ui/views/SessionView.cpp
@@ -107,7 +107,7 @@ std::vector<TrackId> getMultiEditTargets(TrackId clickedId) {
     auto& sel = SelectionManager::getInstance();
     if (sel.isTrackSelected(clickedId) && sel.getSelectedTrackCount() > 1) {
         const auto& set = sel.getSelectedTracks();
-        return std::vector<TrackId>(set.begin(), set.end());
+        return {set.begin(), set.end()};
     }
     return {clickedId};
 }
@@ -1153,7 +1153,7 @@ class SessionView::MiniChannelStrip : public juce::Component {
                 return "-inf";
             if (std::abs(db) < 0.05f)
                 db = 0.0f;
-            return juce::String(db, 1);
+            return {db, 1};
         });
         volumeSlider_->setValueParser([](const juce::String& text) -> double {
             auto t = text.trim();
@@ -1437,7 +1437,7 @@ class SessionView::MiniMasterStrip : public juce::Component {
                 return "-inf";
             if (std::abs(db) < 0.05f)
                 db = 0.0f;
-            return juce::String(db, 1);
+            return {db, 1};
         });
         volumeSlider_->setValueParser([](const juce::String& text) -> double {
             auto t = text.trim();

--- a/magda/engine/exec/PlanExecutor.cpp
+++ b/magda/engine/exec/PlanExecutor.cpp
@@ -879,8 +879,7 @@ std::vector<std::string> PlanExecutor::prepare(const RenderPlan& plan, const Pla
 
 juce::dsp::AudioBlock<float> PlanExecutor::audioBlock(std::size_t row, int numSamples) const {
     const auto channels = static_cast<std::size_t>(context_.numChannels);
-    return juce::dsp::AudioBlock<float>(&slotChannels_[row * channels], channels,
-                                        static_cast<std::size_t>(numSamples));
+    return {&slotChannels_[row * channels], channels, static_cast<std::size_t>(numSamples)};
 }
 
 juce::dsp::AudioBlock<float> PlanExecutor::audioIn(const PortRef& ref, int numSamples) const {

--- a/magda/mcp_bridge/main.cpp
+++ b/magda/mcp_bridge/main.cpp
@@ -65,7 +65,7 @@ constexpr const char* kRecordPattern = "remote-api-*.json";
 constexpr int kInternalError = -32603;
 
 juce::var makeObject() {
-    return juce::var(new juce::DynamicObject());
+    return {new juce::DynamicObject()};
 }
 
 void setProperty(juce::var& object, const char* name, const juce::var& value) {
@@ -107,7 +107,7 @@ juce::String envVar(const char* name) {
  */
 juce::File dataDir() {
     if (const auto fromEnv = envVar("MAGDA_DATA_DIR"); fromEnv.isNotEmpty())
-        return juce::File(fromEnv);
+        return {fromEnv};
 
     const auto osDefault = juce::File::getSpecialLocation(juce::File::userApplicationDataDirectory)
                                .getChildFile("MAGDA");
@@ -116,7 +116,7 @@ juce::File dataDir() {
         juce::var parsed;
         if (juce::JSON::parse(config.loadFileAsString(), parsed).wasOk()) {
             if (const auto configured = parsed["dataDir"].toString(); configured.isNotEmpty())
-                return juce::File(configured);
+                return {configured};
         }
     }
     return osDefault;


### PR DESCRIPTION
## Summary
- Next of the per-check PRs from #2388: `clang-tidy`'s `modernize-return-braced-init-list -fix` applied over `magda/`, no hand edits.
- 154 sites across 69 files — `return Type(args...);` becomes `return {args...};` wherever the return type is already spelled out on the function signature.
- Checked the diff for the two ways this check can silently change behavior: (1) a type with both a normal constructor and a `std::initializer_list` constructor, where braces could pick the wrong one — none of the touched types (`juce::var`, `juce::String`, `juce::File`, `juce::MouseCursor`, `std::string`, `std::filesystem::path`, custom structs) have that ambiguity for the argument shapes used here; (2) narrowing conversions, which braced-init rejects at compile time — the build would have failed if any existed, and it didn't.

## Test plan
- [x] `make debug` — builds clean
- [x] `make test` — 3573 passed, 13 skipped, 856981 assertions, 0 failed

Part of #2388.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0149ko34fXR5PeMBqVL1tDWt