### PR TITLE
Move the Faust/Mutable prebuilt artifacts to R2 on hosted runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,7 +200,11 @@ jobs:
       run: |
         echo "faust_sha=$(git -C third_party/faust rev-parse HEAD)" >> "$GITHUB_OUTPUT"
         echo "eurorack_sha=$(git -C third_party/eurorack rev-parse HEAD)" >> "$GITHUB_OUTPUT"
-        echo "compiler=$(cc --version | head -n1 | shasum | cut -c1-12)" >> "$GITHUB_OUTPUT"
+        # Both DSP builds' flags live in DevicesDependencies.cmake; folding it
+        # into the fingerprint re-keys the artifacts when a flag changes, which
+        # the submodule SHAs alone would miss.
+        dsp_cfg=$(shasum magda/daw/audio/DevicesDependencies.cmake | cut -c1-12)
+        echo "compiler=$(cc --version | head -n1 | shasum | cut -c1-12)-${dsp_cfg}" >> "$GITHUB_OUTPUT"
 
     # Same bucket as sccache/vcpkg, dsp/ prefix. actions/cache scopes a push
     # run's restores to its own branch plus main, so the first run on every
@@ -513,7 +517,8 @@ jobs:
       run: |
         FAUST_SHA=$(git -C third_party/faust rev-parse HEAD)
         EURORACK_SHA=$(git -C third_party/eurorack rev-parse HEAD)
-        COMPILER=$(cc --version | head -n1 | shasum | cut -c1-12)
+        # See the Linux key step: flag changes must re-key the artifacts.
+        COMPILER="$(cc --version | head -n1 | shasum | cut -c1-12)-$(shasum magda/daw/audio/DevicesDependencies.cmake | cut -c1-12)"
         CACHE_ROOT="$HOME/magda-ci-cache"
 
         FAUST_DEBUG_DIR="$CACHE_ROOT/faust-artifact-${FAUST_SHA}-${COMPILER}-wasm-debug"
@@ -1088,10 +1093,12 @@ jobs:
         git config --global --add safe.directory "*"
         $faustSha = (git -C third_party/faust rev-parse HEAD).Trim()
         $eurorackSha = (git -C third_party/eurorack rev-parse HEAD).Trim()
+        # See the Linux key step: flag changes must re-key the artifacts.
+        $dspCfg = (Get-FileHash -Algorithm SHA1 "magda/daw/audio/DevicesDependencies.cmake").Hash.Substring(0, 12).ToLower()
         $compiler = if ($env:VCToolsVersion) { $env:VCToolsVersion } else { "unknown" }
         echo "faust_sha=$faustSha" >> $env:GITHUB_OUTPUT
         echo "eurorack_sha=$eurorackSha" >> $env:GITHUB_OUTPUT
-        echo "compiler=$compiler" >> $env:GITHUB_OUTPUT
+        echo "compiler=$compiler-$dspCfg" >> $env:GITHUB_OUTPUT
 
     # Faust/Mutable prebuilt artifacts (#1669). Same self-hosted-vs-hosted
     # split as the vcpkg binary cache above: a fixed local dir on the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,7 +202,41 @@ jobs:
         echo "eurorack_sha=$(git -C third_party/eurorack rev-parse HEAD)" >> "$GITHUB_OUTPUT"
         echo "compiler=$(cc --version | head -n1 | shasum | cut -c1-12)" >> "$GITHUB_OUTPUT"
 
+    # Same bucket as sccache/vcpkg, dsp/ prefix. actions/cache scopes a push
+    # run's restores to its own branch plus main, so the first run on every
+    # branch rebuilt Faust from source and stored another copy of the same
+    # artifact against the shared 10 GB budget. R2 has no branch scoping; the
+    # bucket's 14-day expiry bounds staleness.
+    - name: Restore prebuilt Faust/Mutable artifacts (R2)
+      id: dsp-r2
+      if: steps.r2-creds.outcome == 'success'
+      env:
+        R2_BUCKET: ${{ secrets.R2_BUCKET }}
+        R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+        AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+        AWS_DEFAULT_REGION: auto
+        # R2 rejects the trailing checksums newer AWS CLIs send by default.
+        AWS_REQUEST_CHECKSUM_CALCULATION: when_required
+        AWS_RESPONSE_CHECKSUM_VALIDATION: when_required
+      run: |
+        endpoint="https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com"
+        fetch() {
+          local key="$1" out="$2"
+          if aws s3 cp "s3://${R2_BUCKET}/dsp/${key}.tar.gz" - --endpoint-url "$endpoint" --only-show-errors | tar -xzf - 2>/dev/null; then
+            echo "${out}=true" >> "$GITHUB_OUTPUT"
+            echo "restored ${key}"
+          else
+            echo "miss: ${key}"
+          fi
+        }
+        fetch "${{ runner.os }}-faust-artifact-${{ steps.dsp-cache-keys.outputs.faust_sha }}-${{ steps.dsp-cache-keys.outputs.compiler }}-wasm-debug" faust_hit
+        fetch "${{ runner.os }}-mutable-artifact-${{ steps.dsp-cache-keys.outputs.eurorack_sha }}-${{ steps.dsp-cache-keys.outputs.compiler }}-debug" mutable_hit
+
+    # Credential-less fallback (e.g. Dependabot): branch-scoped and duplicated,
+    # but better than a guaranteed cold Faust build.
     - name: Cache prebuilt Faust artifact
+      if: steps.r2-creds.outcome != 'success'
       id: faust-cache
       uses: actions/cache@v6
       with:
@@ -212,6 +246,7 @@ jobs:
         key: ${{ runner.os }}-faust-artifact-${{ steps.dsp-cache-keys.outputs.faust_sha }}-${{ steps.dsp-cache-keys.outputs.compiler }}-wasm-debug
 
     - name: Cache prebuilt Mutable artifact
+      if: steps.r2-creds.outcome != 'success'
       id: mutable-cache
       uses: actions/cache@v6
       with:
@@ -232,13 +267,40 @@ jobs:
           -DMAGDA_PRO_DEVICES=ON \
           "-DCMAKE_C_COMPILER_LAUNCHER=${{ steps.sccache.outcome == 'success' && 'sccache' || '' }}" \
           "-DCMAKE_CXX_COMPILER_LAUNCHER=${{ steps.sccache.outcome == 'success' && 'sccache' || '' }}" \
-          ${{ steps.faust-cache.outputs.cache-hit == 'true' && format('-DMAGDA_FAUST_PREBUILT_DIR={0}/third_party/faust/build', github.workspace) || '' }} \
-          ${{ steps.mutable-cache.outputs.cache-hit == 'true' && format('-DMAGDA_MUTABLE_PREBUILT_DIR={0}/third_party/eurorack/build', github.workspace) || '' }}
+          ${{ (steps.dsp-r2.outputs.faust_hit == 'true' || steps.faust-cache.outputs.cache-hit == 'true') && format('-DMAGDA_FAUST_PREBUILT_DIR={0}/third_party/faust/build', github.workspace) || '' }} \
+          ${{ (steps.dsp-r2.outputs.mutable_hit == 'true' || steps.mutable-cache.outputs.cache-hit == 'true') && format('-DMAGDA_MUTABLE_PREBUILT_DIR={0}/third_party/eurorack/build', github.workspace) || '' }}
 
     - name: Build
       run: |
         echo "Building with $(nproc) cores..."
         cmake --build build --config Debug -j$(nproc)
+
+    - name: Populate prebuilt Faust/Mutable artifacts (R2)
+      if: steps.r2-creds.outcome == 'success'
+      continue-on-error: true
+      env:
+        R2_BUCKET: ${{ secrets.R2_BUCKET }}
+        R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+        AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+        AWS_DEFAULT_REGION: auto
+        AWS_REQUEST_CHECKSUM_CALCULATION: when_required
+        AWS_RESPONSE_CHECKSUM_VALIDATION: when_required
+      run: |
+        endpoint="https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com"
+        put() {
+          local key="$1"; shift
+          tar -czf - "$@" | aws s3 cp - "s3://${R2_BUCKET}/dsp/${key}.tar.gz" --endpoint-url "$endpoint" --only-show-errors
+          echo "uploaded ${key}"
+        }
+        if [ "${{ steps.dsp-r2.outputs.faust_hit }}" != "true" ] && [ -d third_party/faust/build/bin ] && [ -d third_party/faust/build/lib ]; then
+          put "${{ runner.os }}-faust-artifact-${{ steps.dsp-cache-keys.outputs.faust_sha }}-${{ steps.dsp-cache-keys.outputs.compiler }}-wasm-debug" \
+            third_party/faust/build/bin third_party/faust/build/lib
+        fi
+        if [ "${{ steps.dsp-r2.outputs.mutable_hit }}" != "true" ] && [ -d third_party/eurorack/build/lib ]; then
+          put "${{ runner.os }}-mutable-artifact-${{ steps.dsp-cache-keys.outputs.eurorack_sha }}-${{ steps.dsp-cache-keys.outputs.compiler }}-debug" \
+            third_party/eurorack/build/lib
+        fi
 
     - name: Check build artifacts
       run: |
@@ -1058,8 +1120,50 @@ jobs:
         if (Test-Path "$mutableDebugDir\lib") { echo "mutable_debug_hit=true" >> $env:GITHUB_OUTPUT }
         if (Test-Path "$mutableReleaseDir\lib") { echo "mutable_release_hit=true" >> $env:GITHUB_OUTPUT }
 
+    # Same bucket as sccache/vcpkg, dsp/ prefix; see the Linux job's twin step
+    # for why actions/cache alone rebuilt Faust on every new branch. Temp files
+    # rather than pipes: PowerShell pipelines corrupt binary streams.
+    - name: Restore prebuilt Faust/Mutable artifacts (R2, github-hosted)
+      id: dsp-r2-hosted
+      if: runner.environment == 'github-hosted' && steps.r2-creds.outcome == 'success'
+      shell: powershell
+      env:
+        R2_BUCKET: ${{ secrets.R2_BUCKET }}
+        R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+        AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+        AWS_DEFAULT_REGION: auto
+        AWS_REQUEST_CHECKSUM_CALCULATION: when_required
+        AWS_RESPONSE_CHECKSUM_VALIDATION: when_required
+      run: |
+        if (-not (Get-Command aws -ErrorAction SilentlyContinue)) {
+          Write-Host "AWS CLI not found, skipping the R2 artifact cache"
+          exit 0
+        }
+        # A miss is normal, never a step failure.
+        $ErrorActionPreference = 'Continue'
+        $endpoint = "https://$env:R2_ACCOUNT_ID.r2.cloudflarestorage.com"
+        function Restore-Artifact([string]$key, [string]$out) {
+          $tmp = Join-Path $env:RUNNER_TEMP "$key.tar.gz"
+          aws s3 cp "s3://$env:R2_BUCKET/dsp/$key.tar.gz" $tmp --endpoint-url $endpoint --only-show-errors
+          if ($LASTEXITCODE -eq 0 -and (Test-Path $tmp)) {
+            tar.exe -xzf $tmp
+            if ($LASTEXITCODE -eq 0) {
+              echo "$out=true" >> $env:GITHUB_OUTPUT
+              Write-Host "restored $key"
+              return
+            }
+          }
+          Write-Host "miss: $key"
+          $global:LASTEXITCODE = 0
+        }
+        Restore-Artifact "${{ runner.os }}-faust-artifact-${{ steps.dsp-cache-keys.outputs.faust_sha }}-${{ steps.dsp-cache-keys.outputs.compiler }}-wasm-debug" "faust_hit"
+        Restore-Artifact "${{ runner.os }}-mutable-artifact-${{ steps.dsp-cache-keys.outputs.eurorack_sha }}-${{ steps.dsp-cache-keys.outputs.compiler }}-debug" "mutable_hit"
+
+    # Credential-less fallback (e.g. Dependabot): branch-scoped and duplicated,
+    # but better than a guaranteed cold Faust build.
     - name: Cache prebuilt Faust artifact (github-hosted)
-      if: runner.environment == 'github-hosted'
+      if: runner.environment == 'github-hosted' && steps.r2-creds.outcome != 'success'
       id: faust-cache-hosted
       uses: actions/cache@v6
       with:
@@ -1069,7 +1173,7 @@ jobs:
         key: ${{ runner.os }}-faust-artifact-${{ steps.dsp-cache-keys.outputs.faust_sha }}-${{ steps.dsp-cache-keys.outputs.compiler }}-wasm-debug
 
     - name: Cache prebuilt Mutable artifact (github-hosted)
-      if: runner.environment == 'github-hosted'
+      if: runner.environment == 'github-hosted' && steps.r2-creds.outcome != 'success'
       id: mutable-cache-hosted
       uses: actions/cache@v6
       with:
@@ -1193,8 +1297,8 @@ jobs:
           "-DCMAKE_CXX_COMPILER_LAUNCHER=${{ steps.sccache.outcome == 'success' && 'sccache' || '' }}" `
           -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_ROOT\scripts\buildsystems\vcpkg.cmake" `
           -DVCPKG_TARGET_TRIPLET=x64-windows `
-          ${{ (steps.dsp-prebuilt-self.outputs.faust_debug_hit == 'true' && format('-DMAGDA_FAUST_PREBUILT_DIR={0}', steps.dsp-prebuilt-self.outputs.faust_debug_dir)) || (steps.faust-cache-hosted.outputs.cache-hit == 'true' && format('-DMAGDA_FAUST_PREBUILT_DIR={0}/third_party/faust/build', github.workspace)) || '' }} `
-          ${{ (steps.dsp-prebuilt-self.outputs.mutable_debug_hit == 'true' && format('-DMAGDA_MUTABLE_PREBUILT_DIR={0}', steps.dsp-prebuilt-self.outputs.mutable_debug_dir)) || (steps.mutable-cache-hosted.outputs.cache-hit == 'true' && format('-DMAGDA_MUTABLE_PREBUILT_DIR={0}/third_party/eurorack/build', github.workspace)) || '' }}
+          ${{ (steps.dsp-prebuilt-self.outputs.faust_debug_hit == 'true' && format('-DMAGDA_FAUST_PREBUILT_DIR={0}', steps.dsp-prebuilt-self.outputs.faust_debug_dir)) || ((steps.dsp-r2-hosted.outputs.faust_hit == 'true' || steps.faust-cache-hosted.outputs.cache-hit == 'true') && format('-DMAGDA_FAUST_PREBUILT_DIR={0}/third_party/faust/build', github.workspace)) || '' }} `
+          ${{ (steps.dsp-prebuilt-self.outputs.mutable_debug_hit == 'true' && format('-DMAGDA_MUTABLE_PREBUILT_DIR={0}', steps.dsp-prebuilt-self.outputs.mutable_debug_dir)) || ((steps.dsp-r2-hosted.outputs.mutable_hit == 'true' || steps.mutable-cache-hosted.outputs.cache-hit == 'true') && format('-DMAGDA_MUTABLE_PREBUILT_DIR={0}/third_party/eurorack/build', github.workspace)) || '' }}
 
     # Scoped to magda_tests only: this job doesn't otherwise need
     # magda_daw_app built during the Debug pass, and the Release pass below
@@ -1217,6 +1321,37 @@ jobs:
         if ("${{ steps.dsp-prebuilt-self.outputs.mutable_debug_hit }}" -ne "true" -and (Test-Path "third_party\eurorack\build\lib")) {
           New-Item -ItemType Directory -Force -Path "${{ steps.dsp-prebuilt-self.outputs.mutable_debug_dir }}" | Out-Null
           Copy-Item -Recurse -Force "third_party\eurorack\build\lib" "${{ steps.dsp-prebuilt-self.outputs.mutable_debug_dir }}\"
+        }
+
+    - name: Populate prebuilt Faust/Mutable artifacts (R2, github-hosted)
+      if: runner.environment == 'github-hosted' && steps.r2-creds.outcome == 'success'
+      continue-on-error: true
+      shell: powershell
+      env:
+        R2_BUCKET: ${{ secrets.R2_BUCKET }}
+        R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+        AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+        AWS_DEFAULT_REGION: auto
+        AWS_REQUEST_CHECKSUM_CALCULATION: when_required
+        AWS_RESPONSE_CHECKSUM_VALIDATION: when_required
+      run: |
+        if (-not (Get-Command aws -ErrorAction SilentlyContinue)) { exit 0 }
+        $ErrorActionPreference = 'Continue'
+        $endpoint = "https://$env:R2_ACCOUNT_ID.r2.cloudflarestorage.com"
+        function Publish-Artifact([string]$key, [string[]]$paths) {
+          $tmp = Join-Path $env:RUNNER_TEMP "$key.up.tar.gz"
+          tar.exe -czf $tmp @paths
+          if ($LASTEXITCODE -eq 0) {
+            aws s3 cp $tmp "s3://$env:R2_BUCKET/dsp/$key.tar.gz" --endpoint-url $endpoint --only-show-errors
+            Write-Host "uploaded $key"
+          }
+        }
+        if ("${{ steps.dsp-r2-hosted.outputs.faust_hit }}" -ne "true" -and (Test-Path "third_party\faust\build\bin") -and (Test-Path "third_party\faust\build\lib")) {
+          Publish-Artifact "${{ runner.os }}-faust-artifact-${{ steps.dsp-cache-keys.outputs.faust_sha }}-${{ steps.dsp-cache-keys.outputs.compiler }}-wasm-debug" @("third_party/faust/build/bin", "third_party/faust/build/lib")
+        }
+        if ("${{ steps.dsp-r2-hosted.outputs.mutable_hit }}" -ne "true" -and (Test-Path "third_party\eurorack\build\lib")) {
+          Publish-Artifact "${{ runner.os }}-mutable-artifact-${{ steps.dsp-cache-keys.outputs.eurorack_sha }}-${{ steps.dsp-cache-keys.outputs.compiler }}-debug" @("third_party/eurorack/build/lib")
         }
 
     - name: Show sccache statistics


### PR DESCRIPTION
actions/cache scopes a push run's restores to its own branch plus main, and main only moves at release, so the first run on every branch missed, rebuilt Faust from source, and saved another copy of the same artifact - five copies of one 69-80 MB blob were sitting in the shared 10 GB budget, evicting everything else. Same disease that moved vcpkg archives and the compile cache to R2 (#2373); same cure, dsp/ prefix, same keys as before.

The actions/cache steps stay as the credential-less fallback (Dependabot does not see repo secrets). Self-hosted keeps its local artifact dirs. Windows uses temp files rather than pipes: PowerShell pipelines corrupt binary streams.


Claude-Session: https://claude.ai/code/session_01GvA5d4Q5JYR8HWoKWnfyR4