### PR TITLE
Apply modernize-avoid-c-style-cast fixes across magda/

### DIFF
--- a/magda/agents/gain_staging_agent.cpp
+++ b/magda/agents/gain_staging_agent.cpp
@@ -100,8 +100,8 @@ const char* GainStagingAgent::getSystemPrompt() {
 juce::String GainStagingAgent::buildUserMessage(float targetPeakDb,
                                                 const std::vector<DeviceLevel>& devices) const {
     juce::Array<juce::var> arr;
-    for (int i = 0; i < (int)devices.size(); ++i) {
-        const auto& d = devices[(size_t)i];
+    for (int i = 0; i < static_cast<int>(devices.size()); ++i) {
+        const auto& d = devices[static_cast<size_t>(i)];
         auto* obj = new juce::DynamicObject();
         obj->setProperty("id", i);  // list index (signal order), unique handle
         obj->setProperty("name", juce::String(d.name));
@@ -136,7 +136,7 @@ void GainStagingAgent::parseDecisions(const juce::String& rawText,
                                       Result& result) const {
     result.rawOutput = rawText.toStdString();
 
-    const int deviceCount = (int)devices.size();
+    const int deviceCount = static_cast<int>(devices.size());
 
     auto parsed = juce::JSON::parse(stripToJsonObject(rawText));
     auto* obj = parsed.getDynamicObject();

--- a/magda/agents/mixing_agent.cpp
+++ b/magda/agents/mixing_agent.cpp
@@ -76,7 +76,8 @@ juce::String MixAnalysisAgent::buildUserMessage(const Input& input) {
             const auto& labels = MixAnalysisData::Track::tonalBandLabels;
             for (size_t i = 0; i < t.tonalDb.size(); ++i)
                 r << " "
-                  << (i < labels.size() ? juce::String(labels[i].data()) : juce::String((int)i))
+                  << (i < labels.size() ? juce::String(labels[i].data())
+                                        : juce::String(static_cast<int>(i)))
                   << "=" << juce::String(t.tonalDb[i], 1);
             r << " | centroid=" << juce::String(juce::roundToInt(t.spectralCentroidHz)) << "Hz"
               << " flat=" << juce::String(t.spectralFlatness, 2)

--- a/magda/daw/audio/AudioBridge.cpp
+++ b/magda/daw/audio/AudioBridge.cpp
@@ -867,7 +867,7 @@ bool AudioBridge::loadPluginPresetFile(const ChainNodePath& devicePath,
         juce::MemoryBlock raw;
         if (!presetFile.loadFileAsData(raw))
             return false;
-        pi->setCurrentProgramStateInformation(raw.getData(), (int)raw.getSize());
+        pi->setCurrentProgramStateInformation(raw.getData(), static_cast<int>(raw.getSize()));
         applied = true;
     }
 

--- a/magda/daw/audio/midi/MidiInputRouter.cpp
+++ b/magda/daw/audio/midi/MidiInputRouter.cpp
@@ -555,10 +555,10 @@ bool MidiInputRouter::setSessionSlotMidiRecordingTarget(TrackId trackId, int sce
     // track's MIDI input device rather than a hardware device
     const bool usesTrackMidiInput = trackInfo->midiInputDevice.startsWith("track:");
     const TrackId configuredSourceId =
-        usesTrackMidiInput
-            ? TrackId(trackInfo->midiInputDevice.fromFirstOccurrenceOf("track:", false, false)
-                          .getIntValue())
-            : INVALID_TRACK_ID;
+        usesTrackMidiInput ? static_cast<TrackId>(trackInfo->midiInputDevice
+                                                      .fromFirstOccurrenceOf("track:", false, false)
+                                                      .getIntValue())
+                           : INVALID_TRACK_ID;
 
     for (auto* inputDeviceInstance : playbackContext->getAllInputs()) {
         auto* midiDevice = getLiveMidiInputDevice(engine_, inputDeviceInstance);

--- a/magda/daw/audio/plugins/InsertCapturePlugin.cpp
+++ b/magda/daw/audio/plugins/InsertCapturePlugin.cpp
@@ -150,7 +150,7 @@ void InsertCapturePlugin::applyToBuffer(const te::PluginRenderContext& fc) {
         // REPLACE semantics: whatever the offline insert produced (silence or
         // dry passthrough) must not mix with the captured return.
         fc.destBuffer->clear(fc.bufferStartSample, fc.bufferNumSamples);
-        if (m.numSamples > 0 && m.fileStartSample < (juce::int64)reader->lengthInSamples) {
+        if (m.numSamples > 0 && m.fileStartSample < reader->lengthInSamples) {
             // std::min, not juce::jmin: an explicit jmin<int64> instantiation
             // drags in the juce::dsp SIMD overload set, which has no
             // SIMDNativeOps<long long> on Linux/GCC and fails to compile.

--- a/magda/daw/core/GainStagingManager.cpp
+++ b/magda/daw/core/GainStagingManager.cpp
@@ -113,8 +113,9 @@ void GainStagingManager::startCollection(TrackId trackId) {
     activeTrackId_ = trackId;
     buildStagedDeviceList(trackId);
 
-    juce::Logger::writeToLog("[GainStaging] start pass on track " + juce::String((int)trackId) +
-                             ": " + juce::String((int)staged_.size()) + " devices, target " +
+    juce::Logger::writeToLog("[GainStaging] start pass on track " +
+                             juce::String(static_cast<int>(trackId)) + ": " +
+                             juce::String(static_cast<int>(staged_.size())) + " devices, target " +
                              juce::String(targetDb_, 1) + " dBFS");
 
     // A fresh pass on these devices supersedes any prior marks on them.

--- a/magda/daw/engine/TracktionEngineWrapperRecording.cpp
+++ b/magda/daw/engine/TracktionEngineWrapperRecording.cpp
@@ -89,8 +89,8 @@ void TracktionEngineWrapper::recordingFinished(
     // don't have — this path needs to be diagnosable from user machines.
     juce::Logger::writeToLog("[MidiRec] finished dev='" + instance.owner.getName() +
                              "' clips=" + juce::String(recordedClips.size()) +
-                             " targetID=" + juce::String((int)targetID.getRawID()) +
-                             " physical=" + juce::String((int)isPhysical));
+                             " targetID=" + juce::String(static_cast<int>(targetID.getRawID())) +
+                             " physical=" + juce::String(static_cast<int>(isPhysical)));
     if (!audioBridge_)
         return;
 
@@ -251,8 +251,9 @@ void TracktionEngineWrapper::recordingFinished(
             "[MidiRec]   midi clip notes=" +
             juce::String(midiClip->getSequence().getNotes().size()) +
             " takes=" + juce::String(midiClip->hasAnyTakes() ? midiClip->getNumTakes(false) : 0) +
-            " len=" + juce::String(midiClip->getPosition().getLength().inSeconds(), 3) + " track=" +
-            juce::String(midiTrackId) + " hasMidiInput=" + juce::String((int)midiTrackHasInput));
+            " len=" + juce::String(midiClip->getPosition().getLength().inSeconds(), 3) +
+            " track=" + juce::String(midiTrackId) +
+            " hasMidiInput=" + juce::String(static_cast<int>(midiTrackHasInput)));
 
         if (!midiTrackHasInput) {
             juce::Logger::writeToLog("[MidiRec]   SKIP: track has no MIDI input configured");
@@ -878,9 +879,9 @@ void TracktionEngineWrapper::finalizeMidiRecording(TrackId trackId) {
                                     : takes[static_cast<size_t>(activeTakeIndex)];
 
     juce::Logger::writeToLog("[MidiRec] finalize track=" + juce::String(trackId) +
-                             " takes=" + juce::String((int)takes.size()) +
+                             " takes=" + juce::String(static_cast<int>(takes.size())) +
                              " active=" + juce::String(activeTakeIndex) +
-                             " notes=" + juce::String((int)active.notes.size()) +
+                             " notes=" + juce::String(static_cast<int>(active.notes.size())) +
                              " len=" + juce::String(lengthSeconds, 3));
 
     midiClip->removeFromParent();

--- a/magda/daw/engine/TracktionEngineWrapperTracks.cpp
+++ b/magda/daw/engine/TracktionEngineWrapperTracks.cpp
@@ -163,8 +163,8 @@ void TracktionEngineWrapper::previewNoteOnTrack(const std::string& track_id, int
     // Inject MIDI directly into the track's plugin chain via LiveMidiInjectingNode,
     // bypassing the MIDI input device and its monitor mode entirely (#762)
     juce::MidiMessage message =
-        isNoteOn ? juce::MidiMessage::noteOn(1, noteNumber, (juce::uint8)velocity)
-                 : juce::MidiMessage::noteOff(1, noteNumber, (juce::uint8)velocity);
+        isNoteOn ? juce::MidiMessage::noteOn(1, noteNumber, static_cast<juce::uint8>(velocity))
+                 : juce::MidiMessage::noteOff(1, noteNumber, static_cast<juce::uint8>(velocity));
 
     audioTrack->injectLiveMidiMessage(message, {});
 }

--- a/magda/daw/music/ChordSuggestionEngine.cpp
+++ b/magda/daw/music/ChordSuggestionEngine.cpp
@@ -448,8 +448,8 @@ std::vector<ChordSuggestionEngine::SuggestionItem> ChordSuggestionEngine::genera
         return n;
     };
     std::set<juce::String> seen;  // normalized chord names
-    for (int i = 0;
-         i < static_cast<int>(boostedCandidates.size()) && (int)suggestions.size() < params.topK;
+    for (int i = 0; i < static_cast<int>(boostedCandidates.size()) &&
+                    static_cast<int>(suggestions.size()) < params.topK;
          ++i) {
         auto candidate = boostedCandidates[i];
         auto k = normName(candidate.chord.name);
@@ -475,10 +475,10 @@ std::vector<ChordSuggestionEngine::SuggestionItem> ChordSuggestionEngine::genera
     const int minDesired =
         std::max(params.topK, minPages * minPerPage);  // at least 16, or topK if larger
 
-    if ((int)suggestions.size() < minDesired) {
+    if (static_cast<int>(suggestions.size()) < minDesired) {
         // Backfill using raw pools but still respect current params to avoid disabled types
         for (const auto& c : diatonicCandidatesRaw) {
-            if ((int)suggestions.size() >= minDesired)
+            if (static_cast<int>(suggestions.size()) >= minDesired)
                 break;
             if (allowedByParams(c))
                 addUnique(c);
@@ -486,7 +486,7 @@ std::vector<ChordSuggestionEngine::SuggestionItem> ChordSuggestionEngine::genera
         // Only consider non-diatonic backfill when novelty > 0
         if (params.novelty > 0.0f) {
             for (const auto& c : nonDiatonicCandidatesRaw) {
-                if ((int)suggestions.size() >= minDesired)
+                if (static_cast<int>(suggestions.size()) >= minDesired)
                     break;
                 if (allowedByParams(c))
                     addUnique(c);
@@ -494,10 +494,10 @@ std::vector<ChordSuggestionEngine::SuggestionItem> ChordSuggestionEngine::genera
         }
     }
 
-    if ((int)suggestions.size() < minDesired) {
+    if (static_cast<int>(suggestions.size()) < minDesired) {
         // Final safety: synthesize only when novelty allows non-diatonic/fallback content
         if (params.novelty > 0.0f) {
-            for (int i = 0; i < 12 && (int)suggestions.size() < minDesired; ++i) {
+            for (int i = 0; i < 12 && static_cast<int>(suggestions.size()) < minDesired; ++i) {
                 juce::String rootName = NOTE_NAMES[i];
                 juce::String quality = (i % 2 == 0) ? "maj" : "min";
                 auto chord = buildChordObject(rootName, quality, targetOctave, effectiveInversions,
@@ -509,7 +509,7 @@ std::vector<ChordSuggestionEngine::SuggestionItem> ChordSuggestionEngine::genera
     }
 
     // Trim to max desired output (preserve earlier ranking at the top)
-    if ((int)suggestions.size() > std::max(minDesired, params.topK)) {
+    if (static_cast<int>(suggestions.size()) > std::max(minDesired, params.topK)) {
         suggestions.resize(std::max(minDesired, params.topK));
     }
 

--- a/magda/daw/ui/components/chain/NodeComponent.cpp
+++ b/magda/daw/ui/components/chain/NodeComponent.cpp
@@ -1603,11 +1603,12 @@ void NodeComponent::initializeModsMacrosPanels() {
 
         // Pick sidechain type from the selected modulator. The envelope follower
         // always sources audio; otherwise it follows the LFO's trigger mode.
-        const bool selValid = selectedModIndex_ >= 0 && selectedModIndex_ < (int)mods.size();
-        const bool isFollower =
-            selValid && mods[(size_t)selectedModIndex_].type == magda::ModType::Follower;
+        const bool selValid =
+            selectedModIndex_ >= 0 && selectedModIndex_ < static_cast<int>(mods.size());
+        const bool isFollower = selValid && mods[static_cast<size_t>(selectedModIndex_)].type ==
+                                                magda::ModType::Follower;
         const bool isAudioMode =
-            isFollower || (selValid && mods[(size_t)selectedModIndex_].triggerMode ==
+            isFollower || (selValid && mods[static_cast<size_t>(selectedModIndex_)].triggerMode ==
                                            magda::LFOTriggerMode::Audio);
         const auto sidechainType =
             isAudioMode ? magda::SidechainConfig::Type::Audio : magda::SidechainConfig::Type::MIDI;
@@ -1652,7 +1653,7 @@ void NodeComponent::initializeModsMacrosPanels() {
                     magda::TrackManager::getInstance().clearRackSidechain(rackPath);
             } else {
                 int index = result - 10;
-                if (index >= 0 && index < (int)trackEntries->size()) {
+                if (index >= 0 && index < static_cast<int>(trackEntries->size())) {
                     if (isDeviceTarget) {
                         magda::TrackManager::getInstance().setSidechainSource(
                             deviceId, (*trackEntries)[index].id, sidechainType);

--- a/magda/daw/ui/components/chain/custom_ui/HaloUI.cpp
+++ b/magda/daw/ui/components/chain/custom_ui/HaloUI.cpp
@@ -58,22 +58,24 @@ HaloUI::HaloUI() {
         c.slider->setTextColour(kText);
         if (isChord(idx)) {
             c.slider->setRange(0.0, 10.0, 1.0);
-            c.slider->setValueFormatter([](double v) { return juce::String((int)std::lround(v)); });
+            c.slider->setValueFormatter(
+                [](double v) { return juce::String(static_cast<int>(std::lround(v))); });
         } else if (isPitch(idx)) {
             c.slider->setRange(-24.0, 24.0, 0.0);
             c.slider->setValueFormatter(
-                [](double v) { return juce::String((int)std::lround(v)) + " st"; });
+                [](double v) { return juce::String(static_cast<int>(std::lround(v))) + " st"; });
         } else if (isFine(idx)) {
             c.slider->setRange(-100.0, 100.0, 0.0);
             c.slider->setValueFormatter(
-                [](double v) { return juce::String((int)std::lround(v)) + " ct"; });
+                [](double v) { return juce::String(static_cast<int>(std::lround(v))) + " ct"; });
         } else if (isLevel(idx)) {
             c.slider->setRange(-60.0, 12.0, 0.0);
             c.slider->setValueFormatter([](double v) { return juce::String(v, 1) + " dB"; });
         } else {
             c.slider->setRange(0.0, 1.0, 0.0);
-            c.slider->setValueFormatter(
-                [](double v) { return juce::String((int)std::lround(v * 100.0)) + "%"; });
+            c.slider->setValueFormatter([](double v) {
+                return juce::String(static_cast<int>(std::lround(v * 100.0))) + "%";
+            });
         }
         c.slider->onValueChanged = [this, idx](double v) {
             if (onParameterChanged)
@@ -112,9 +114,9 @@ void HaloUI::updateFromParameters(const std::vector<magda::ParameterInfo>& param
             break;
         const float value = params[static_cast<size_t>(i)].currentValue;
         if (i == kModel)
-            curModel_ = juce::jlimit(0, kNumModels - 1, (int)std::lround(value));
+            curModel_ = juce::jlimit(0, kNumModels - 1, static_cast<int>(std::lround(value)));
         else if (i == kPolyphony)
-            curPoly_ = juce::jlimit(0, kNumPoly - 1, (int)std::lround(value));
+            curPoly_ = juce::jlimit(0, kNumPoly - 1, static_cast<int>(std::lround(value)));
         else if (controls_[static_cast<size_t>(i)].slider != nullptr)
             controls_[static_cast<size_t>(i)].slider->setValue(value, juce::dontSendNotification);
     }
@@ -152,10 +154,10 @@ void HaloUI::paint(juce::Graphics& g) {
         g.setColour(kBorder);
         g.drawRoundedRectangle(modalVizArea_.toFloat().reduced(0.5f), 4.0f, 1.0f);
         auto b = modalVizArea_.reduced(14, 22);
-        const auto structure = (float)controls_[kStructure].slider->getValue();
-        const auto brightness = (float)controls_[kBrightness].slider->getValue();
-        const auto damping = (float)controls_[kDamping].slider->getValue();
-        const auto position = (float)controls_[kPosition].slider->getValue();
+        const auto structure = static_cast<float>(controls_[kStructure].slider->getValue());
+        const auto brightness = static_cast<float>(controls_[kBrightness].slider->getValue());
+        const auto damping = static_cast<float>(controls_[kDamping].slider->getValue());
+        const auto position = static_cast<float>(controls_[kPosition].slider->getValue());
 
         const float rolloff = juce::jmap(brightness, 0.0f, 1.0f, 0.80f, 0.985f);
         const float level = juce::jmap(damping, 0.0f, 1.0f, 0.5f, 1.0f);

--- a/magda/daw/ui/components/chain/custom_ui/MateriaUI.cpp
+++ b/magda/daw/ui/components/chain/custom_ui/MateriaUI.cpp
@@ -54,18 +54,19 @@ MateriaUI::MateriaUI() {
         if (isPitch(idx)) {
             c.slider->setRange(-24.0, 24.0, 0.0);
             c.slider->setValueFormatter(
-                [](double v) { return juce::String((int)std::lround(v)) + " st"; });
+                [](double v) { return juce::String(static_cast<int>(std::lround(v))) + " st"; });
         } else if (isFine(idx)) {
             c.slider->setRange(-100.0, 100.0, 0.0);
             c.slider->setValueFormatter(
-                [](double v) { return juce::String((int)std::lround(v)) + " ct"; });
+                [](double v) { return juce::String(static_cast<int>(std::lround(v))) + " ct"; });
         } else if (isLevel(idx)) {
             c.slider->setRange(-60.0, 12.0, 0.0);
             c.slider->setValueFormatter([](double v) { return juce::String(v, 1) + " dB"; });
         } else {
             c.slider->setRange(0.0, 1.0, 0.0);
-            c.slider->setValueFormatter(
-                [](double v) { return juce::String((int)std::lround(v * 100.0)) + "%"; });
+            c.slider->setValueFormatter([](double v) {
+                return juce::String(static_cast<int>(std::lround(v * 100.0))) + "%";
+            });
         }
         c.slider->onValueChanged = [this, idx](double v) {
             if (onParameterChanged)
@@ -206,9 +207,9 @@ void MateriaUI::paint(juce::Graphics& g) {
         g.setColour(cStrike);
         g.fillEllipse(juce::Rectangle<float>(8, 8).withCentre(strike));
 
-        const auto wBow = (float)controls_[kBow].slider->getValue();
-        const auto wBlow = (float)controls_[kBlow].slider->getValue();
-        const auto wStrike = (float)controls_[kStrike].slider->getValue();
+        const auto wBow = static_cast<float>(controls_[kBow].slider->getValue());
+        const auto wBlow = static_cast<float>(controls_[kBlow].slider->getValue());
+        const auto wStrike = static_cast<float>(controls_[kStrike].slider->getValue());
         const float sum = wBow + wBlow + wStrike;
         juce::Point<float> dot = sum > 1.0e-4f
                                      ? (bow * wBow + blow * wBlow + strike * wStrike) / sum
@@ -236,10 +237,10 @@ void MateriaUI::paint(juce::Graphics& g) {
         g.setColour(kBorder);
         g.drawRoundedRectangle(modalVizArea_.toFloat().reduced(0.5f), 4.0f, 1.0f);
         auto b = modalVizArea_.reduced(12, 16);
-        const auto geometry = (float)controls_[kGeometry].slider->getValue();
-        const auto brightness = (float)controls_[kBrightness].slider->getValue();
-        const auto damping = (float)controls_[kDamping].slider->getValue();
-        const auto position = (float)controls_[kPosition].slider->getValue();
+        const auto geometry = static_cast<float>(controls_[kGeometry].slider->getValue());
+        const auto brightness = static_cast<float>(controls_[kBrightness].slider->getValue());
+        const auto damping = static_cast<float>(controls_[kDamping].slider->getValue());
+        const auto position = static_cast<float>(controls_[kPosition].slider->getValue());
 
         const float rolloff = juce::jmap(brightness, 0.0f, 1.0f, 0.80f, 0.985f);
         const float level = juce::jmap(damping, 0.0f, 1.0f, 0.45f, 1.0f);
@@ -264,9 +265,11 @@ void MateriaUI::paint(juce::Graphics& g) {
 
 std::array<juce::Point<float>, 3> MateriaUI::triangleCorners() const {
     auto b = blendArea_.reduced(28);
-    return {juce::Point<float>(b.getCentreX(), (float)b.getY()),             // bow   (top)
-            juce::Point<float>((float)b.getX(), (float)b.getBottom()),       // blow  (bottom-left)
-            juce::Point<float>((float)b.getRight(), (float)b.getBottom())};  // strike(bottom-right)
+    return {juce::Point<float>(b.getCentreX(), static_cast<float>(b.getY())),  // bow   (top)
+            juce::Point<float>(static_cast<float>(b.getX()),
+                               static_cast<float>(b.getBottom())),  // blow  (bottom-left)
+            juce::Point<float>(static_cast<float>(b.getRight()),
+                               static_cast<float>(b.getBottom()))};  // strike(bottom-right)
 }
 
 void MateriaUI::applyBlendDrag(juce::Point<int> p) {

--- a/magda/daw/ui/components/chain/custom_ui/NimbusUI.cpp
+++ b/magda/daw/ui/components/chain/custom_ui/NimbusUI.cpp
@@ -65,8 +65,9 @@ NimbusUI::NimbusUI() {
             c.slider->setValueFormatter([](double v) { return juce::String(v, 1) + " st"; });
         } else {
             c.slider->setRange(0.0, 1.0, 0.0);
-            c.slider->setValueFormatter(
-                [](double v) { return juce::String((int)std::lround(v * 100.0)) + "%"; });
+            c.slider->setValueFormatter([](double v) {
+                return juce::String(static_cast<int>(std::lround(v * 100.0))) + "%";
+            });
         }
         c.slider->onValueChanged = [this, idx](double v) {
             if (onParameterChanged)
@@ -135,7 +136,7 @@ void NimbusUI::updateFromParameters(const std::vector<magda::ParameterInfo>& par
             break;
         const float value = params[static_cast<size_t>(i)].currentValue;
         if (i == kMode)
-            curMode_ = juce::jlimit(0, kNumModes - 1, (int)std::lround(value));
+            curMode_ = juce::jlimit(0, kNumModes - 1, static_cast<int>(std::lround(value)));
         else if (i == kFreeze)
             freeze_ = value > 0.5f;
         else if (controls_[static_cast<size_t>(i)].slider != nullptr)
@@ -179,22 +180,22 @@ void NimbusUI::paintBuffer(juce::Graphics& g) {
     }
     const float life = haveAudio ? (0.22f + 0.78f * energy) : 0.5f;  // gentle idle baseline
 
-    const auto position = (float)controls_[kPosition].slider->getValue();
-    const auto size = (float)controls_[kSize].slider->getValue();
-    const auto density = (float)controls_[kDensity].slider->getValue();
-    const auto texture = (float)controls_[kTexture].slider->getValue();
+    const auto position = static_cast<float>(controls_[kPosition].slider->getValue());
+    const auto size = static_cast<float>(controls_[kSize].slider->getValue());
+    const auto density = static_cast<float>(controls_[kDensity].slider->getValue());
+    const auto texture = static_cast<float>(controls_[kTexture].slider->getValue());
 
     // Cloud drifts horizontally with Position, widens with Size, spreads and
     // jitters with Texture, thickens with Density.
     const float cloudW =
-        juce::jmap(size, 0.0f, 1.0f, plot.getWidth() * 0.25f, (float)plot.getWidth());
+        juce::jmap(size, 0.0f, 1.0f, plot.getWidth() * 0.25f, static_cast<float>(plot.getWidth()));
     const float cloudCx = plot.getX() + position * plot.getWidth();
     const float cyc = plot.getCentreY();
     const float spreadY = plot.getHeight() * (0.2f + 0.7f * texture);
 
     g.saveState();
     g.reduceClipRegion(b);
-    const int n = 20 + (int)std::lround(density * 130.0f);
+    const int n = 20 + static_cast<int>(std::lround(density * 130.0f));
     for (int k = 0; k < n; ++k) {
         const float bx = hash1(k * 2 + 1) * 2.0f - 1.0f;
         const float by = hash1(k * 2 + 2) * 2.0f - 1.0f;

--- a/magda/daw/ui/components/chain/layout/NodeHeaderStyles.hpp
+++ b/magda/daw/ui/components/chain/layout/NodeHeaderStyles.hpp
@@ -27,7 +27,7 @@ class FlatGainSliderLookAndFeel : public juce::LookAndFeel_V4 {
         constexpr float thumbHeight = 2.0f;
         const float thumbY = sliderPos - thumbHeight * 0.5f;
         g.setColour(DarkTheme::getSecondaryTextColour());
-        g.fillRect((float)x, thumbY, (float)width, thumbHeight);
+        g.fillRect(static_cast<float>(x), thumbY, static_cast<float>(width), thumbHeight);
     }
 
     int getSliderThumbRadius(juce::Slider&) override {

--- a/magda/daw/ui/components/chain/slot/DevicePresetMenu.cpp
+++ b/magda/daw/ui/components/chain/slot/DevicePresetMenu.cpp
@@ -108,7 +108,7 @@ class PluginPresetsButtonLookAndFeel : public juce::LookAndFeel_V4 {
                         bool /*down*/) override {
         auto bounds = button.getLocalBounds().reduced(6, 0);
         constexpr float chevronW = 10.0f;
-        auto chevronArea = bounds.removeFromRight((int)chevronW).toFloat();
+        auto chevronArea = bounds.removeFromRight(static_cast<int>(chevronW)).toFloat();
 
         g.setFont(FontManager::getInstance().getUIFont(10.0f));
         g.setColour(

--- a/magda/daw/ui/components/mixer/LevelMeter.hpp
+++ b/magda/daw/ui/components/mixer/LevelMeter.hpp
@@ -254,11 +254,11 @@ class LevelMeter : public juce::Component, private juce::Timer {
                                         : juce::ColourGradient(green, 0.0f, bounds.getBottom(), red,
                                                                0.0f, bounds.getY(), false);
         // Green solid, then short fade to yellow around -12dB
-        grad.addColour(std::max(0.0, (double)yellowPos - fade), green);
-        grad.addColour(std::min(1.0, (double)yellowPos + fade), yellow);
+        grad.addColour(std::max(0.0, static_cast<double>(yellowPos) - fade), green);
+        grad.addColour(std::min(1.0, static_cast<double>(yellowPos) + fade), yellow);
         // Yellow solid, then short fade to red around 0dB
-        grad.addColour(std::max(0.0, (double)redPos - fade), yellow);
-        grad.addColour(std::min(1.0, (double)redPos + fade), red);
+        grad.addColour(std::max(0.0, static_cast<double>(redPos) - fade), yellow);
+        grad.addColour(std::min(1.0, static_cast<double>(redPos) + fade), red);
         return grad;
     }
 

--- a/magda/daw/ui/components/pianoroll/PianoRollGridComponent.cpp
+++ b/magda/daw/ui/components/pianoroll/PianoRollGridComponent.cpp
@@ -242,7 +242,8 @@ void PianoRollGridComponent::paint(juce::Graphics& g) {
     if (chordDropActive_) {
         int lineX = beatToPixel(chordDropBeat_);
         g.setColour(DarkTheme::getColour(DarkTheme::PIANO_ROLL_CHORD_PREVIEW).withAlpha(0.8f));
-        g.drawLine(float(lineX), 0.f, float(lineX), float(bounds.getHeight()), 2.0f);
+        g.drawLine(static_cast<float>(lineX), 0.f, static_cast<float>(lineX),
+                   static_cast<float>(bounds.getHeight()), 2.0f);
     }
 
     // Draw pending chord placement preview (after drop, awaiting length confirmation)
@@ -259,12 +260,14 @@ void PianoRollGridComponent::paint(juce::Graphics& g) {
         // Draw blinking start line
         float alpha = pendingChord_.blinkOn ? 0.9f : 0.3f;
         g.setColour(DarkTheme::getColour(DarkTheme::PIANO_ROLL_CHORD_PREVIEW).withAlpha(alpha));
-        g.drawLine(float(startX), 0.f, float(startX), float(bounds.getHeight()), 2.0f);
+        g.drawLine(static_cast<float>(startX), 0.f, static_cast<float>(startX),
+                   static_cast<float>(bounds.getHeight()), 2.0f);
 
         // Draw end line at mouse position
         if (endX > startX + 2) {
             g.setColour(DarkTheme::getColour(DarkTheme::PIANO_ROLL_CHORD_PREVIEW).withAlpha(0.5f));
-            g.drawLine(float(endX), 0.f, float(endX), float(bounds.getHeight()), 1.0f);
+            g.drawLine(static_cast<float>(endX), 0.f, static_cast<float>(endX),
+                       static_cast<float>(bounds.getHeight()), 1.0f);
         }
     }
 
@@ -309,10 +312,13 @@ void PianoRollGridComponent::paint(juce::Graphics& g) {
         int cursorX = beatToPixel(displayBeat);
         if (cursorX >= 0 && cursorX <= bounds.getRight()) {
             g.setColour(DarkTheme::getColour(DarkTheme::TEXT_DARK).withAlpha(0.5f));
-            g.drawLine(float(cursorX - 1), 0.f, float(cursorX - 1), float(bounds.getHeight()), 1.f);
-            g.drawLine(float(cursorX + 1), 0.f, float(cursorX + 1), float(bounds.getHeight()), 1.f);
+            g.drawLine(static_cast<float>(cursorX - 1), 0.f, static_cast<float>(cursorX - 1),
+                       static_cast<float>(bounds.getHeight()), 1.f);
+            g.drawLine(static_cast<float>(cursorX + 1), 0.f, static_cast<float>(cursorX + 1),
+                       static_cast<float>(bounds.getHeight()), 1.f);
             g.setColour(DarkTheme::getColour(DarkTheme::TEXT_BRIGHT));
-            g.drawLine(float(cursorX), 0.f, float(cursorX), float(bounds.getHeight()), 2.f);
+            g.drawLine(static_cast<float>(cursorX), 0.f, static_cast<float>(cursorX),
+                       static_cast<float>(bounds.getHeight()), 2.f);
         }
     }
 

--- a/magda/daw/ui/components/timeline/TimeRuler.cpp
+++ b/magda/daw/ui/components/timeline/TimeRuler.cpp
@@ -825,10 +825,13 @@ void TimeRuler::drawBarsBeatsMode(juce::Graphics& g) {
         int cursorX = timeToPixel(displayTime);
         if (cursorX >= 0 && cursorX <= width) {
             g.setColour(juce::Colours::black.withAlpha(0.5f));
-            g.drawLine(float(cursorX - 1), 0.f, float(cursorX - 1), float(height), 1.f);
-            g.drawLine(float(cursorX + 1), 0.f, float(cursorX + 1), float(height), 1.f);
+            g.drawLine(static_cast<float>(cursorX - 1), 0.f, static_cast<float>(cursorX - 1),
+                       static_cast<float>(height), 1.f);
+            g.drawLine(static_cast<float>(cursorX + 1), 0.f, static_cast<float>(cursorX + 1),
+                       static_cast<float>(height), 1.f);
             g.setColour(juce::Colours::white);
-            g.drawLine(float(cursorX), 0.f, float(cursorX), float(height), 2.f);
+            g.drawLine(static_cast<float>(cursorX), 0.f, static_cast<float>(cursorX),
+                       static_cast<float>(height), 2.f);
         }
     }
 

--- a/magda/daw/ui/components/waveform/WarpedWaveformRenderer.hpp
+++ b/magda/daw/ui/components/waveform/WarpedWaveformRenderer.hpp
@@ -89,8 +89,8 @@ inline void drawWarpedWaveform(juce::Graphics& g, magda::AudioThumbnailManager& 
             if (ce <= cs)
                 continue;
 
-            const int px = (int)std::lround(visX0);
-            const int pw = (int)std::lround(visX1) - px;
+            const int px = static_cast<int>(std::lround(visX0));
+            const int pw = static_cast<int>(std::lround(visX1)) - px;
             if (pw <= 0)
                 continue;
 
@@ -130,7 +130,8 @@ inline void drawWarpedWaveform(juce::Graphics& g, magda::AudioThumbnailManager& 
     // so no arbitrary cap is needed (or wanted).
     const double frontWarp = markers.front().warpTime;
     const double backWarp = markers.back().warpTime;
-    const int kStart = (int)std::floor((leftX - spec.warpToPixelX(backWarp)) / cyclePx);
+    const int kStart =
+        static_cast<int>(std::floor((leftX - spec.warpToPixelX(backWarp)) / cyclePx));
     for (int k = kStart; spec.warpToPixelX(frontWarp + k * spec.cycleWarp) <= rightX; ++k)
         drawPass(k * spec.cycleWarp);
 }

--- a/magda/daw/ui/components/waveform/WaveformGridComponent.cpp
+++ b/magda/daw/ui/components/waveform/WaveformGridComponent.cpp
@@ -662,7 +662,8 @@ void WaveformGridComponent::paintWarpedWaveform(juce::Graphics& g, const magda::
     WarpedWaveformSpec spec;
     spec.clipArea = waveformRect.getIntersection(getLocalBounds()).reduced(0, 4);
     spec.warpToPixelX = [this, displayStartTime](double warpSeconds) {
-        return (double)timeToPixel(displayInfo_.sourceToTimeline(warpSeconds) + displayStartTime);
+        return static_cast<double>(
+            timeToPixel(displayInfo_.sourceToTimeline(warpSeconds) + displayStartTime));
     };
     spec.fileDuration = fileDuration;
     spec.colour = waveColour;
@@ -687,7 +688,7 @@ void WaveformGridComponent::paintWarpedWaveform(juce::Graphics& g, const magda::
             const double mirroredPosition = displayInfo_.activeRegionStartPositionSeconds +
                                             displayInfo_.activeRegionEndPositionSeconds -
                                             forwardPosition;
-            return (double)timeToPixel(displayStartTime + mirroredPosition);
+            return static_cast<double>(timeToPixel(displayStartTime + mirroredPosition));
         };
         drawWarpedWaveform(g, thumbnailManager, audioEventRef(clip).sourceFilePath(), warpMarkers_,
                            spec);

--- a/magda/daw/ui/dialogs/AboutDialog.cpp
+++ b/magda/daw/ui/dialogs/AboutDialog.cpp
@@ -129,8 +129,8 @@ class AboutDialog::ContentComponent : public juce::Component {
         int dotGap = 4;
 
         g.setColour(DarkTheme::getColour(DarkTheme::BORDER));
-        g.drawHorizontalLine(creditsArea.getY(), (float)creditsArea.getX(),
-                             (float)creditsArea.getRight());
+        g.drawHorizontalLine(creditsArea.getY(), static_cast<float>(creditsArea.getX()),
+                             static_cast<float>(creditsArea.getRight()));
         creditsArea.removeFromTop(6);
 
         auto row = creditsArea.removeFromTop(20);

--- a/magda/daw/ui/dialogs/SplashScreen.cpp
+++ b/magda/daw/ui/dialogs/SplashScreen.cpp
@@ -127,8 +127,8 @@ class SplashScreen::ContentComponent : public juce::Component {
         int dotGap = 4;
 
         g.setColour(DarkTheme::getColour(DarkTheme::BORDER));
-        g.drawHorizontalLine(creditsArea.getY(), (float)creditsArea.getX(),
-                             (float)creditsArea.getRight());
+        g.drawHorizontalLine(creditsArea.getY(), static_cast<float>(creditsArea.getX()),
+                             static_cast<float>(creditsArea.getRight()));
         creditsArea.removeFromTop(6);
 
         auto row = creditsArea.removeFromTop(20);

--- a/magda/daw/ui/panels/content/AIChatConsoleContent.cpp
+++ b/magda/daw/ui/panels/content/AIChatConsoleContent.cpp
@@ -2612,8 +2612,7 @@ void AIChatConsoleContent::insertParamAlias(const juce::String& pluginAlias,
         auto newText = before + inserted + " " + after;
         inputDocument_.replaceAllContent(newText);
         inputBox_->moveCaretTo(
-            juce::CodeDocument::Position(inputDocument_, atPos + (int)inserted.length() + 1),
-            false);
+            juce::CodeDocument::Position(inputDocument_, atPos + inserted.length() + 1), false);
     }
 
     suppressAutocompleteForContent_ = inputDocument_.getAllContent();
@@ -2646,7 +2645,7 @@ void AIChatConsoleContent::insertAlias(const juce::String& alias) {
         auto newText = before + "@" + alias + after;
         inputDocument_.replaceAllContent(newText);
         inputBox_->moveCaretTo(
-            juce::CodeDocument::Position(inputDocument_, atPos + 1 + (int)alias.length()), false);
+            juce::CodeDocument::Position(inputDocument_, atPos + 1 + alias.length()), false);
     }
 
     suppressAutocompleteForContent_ = inputDocument_.getAllContent();

--- a/magda/daw/ui/panels/content/ChordPanelContent.cpp
+++ b/magda/daw/ui/panels/content/ChordPanelContent.cpp
@@ -1246,7 +1246,8 @@ void ChordPanelContent::AIRequestThread::run() {
 
     if (!owner_.detectedScales_.empty()) {
         context += "Detected scales: ";
-        for (size_t i = 0; i < std::min(owner_.detectedScales_.size(), size_t(3)); ++i) {
+        for (size_t i = 0; i < std::min(owner_.detectedScales_.size(), static_cast<size_t>(3));
+             ++i) {
             if (i > 0)
                 context += ", ";
             context += juce::String(owner_.detectedScales_[i].name);

--- a/magda/daw/ui/panels/content/MediaExplorerContent.cpp
+++ b/magda/daw/ui/panels/content/MediaExplorerContent.cpp
@@ -2332,7 +2332,8 @@ void MediaExplorerContent::mouseDrag(const juce::MouseEvent& e) {
         {
             juce::Graphics g(dragImg);
             g.setColour(juce::Colours::black.withAlpha(0.78f));
-            g.fillRoundedRectangle(0.0f, 0.0f, (float)width, (float)height, 4.0f);
+            g.fillRoundedRectangle(0.0f, 0.0f, static_cast<float>(width),
+                                   static_cast<float>(height), 4.0f);
             g.setColour(juce::Colours::white);
             g.setFont(13.0f);
             for (int i = 0; i < maxRows; ++i) {

--- a/magda/daw/ui/panels/content/TrackChainContent.cpp
+++ b/magda/daw/ui/panels/content/TrackChainContent.cpp
@@ -2227,7 +2227,8 @@ void TrackChainContent::runAiGainStagingPass() {
         lvl.currentGainDb = s.currentGainDb;
         lvl.suggestedGainDb = s.suggestedGainDb;
         for (const auto& p : s.params)
-            lvl.params.push_back({p.name.toStdString(), (double)p.value, p.unit.toStdString()});
+            lvl.params.push_back(
+                {p.name.toStdString(), static_cast<double>(p.value), p.unit.toStdString()});
         levels.push_back(std::move(lvl));
         paths.push_back(s.path);
     }
@@ -2253,8 +2254,8 @@ void TrackChainContent::runAiGainStagingPass() {
                 reasoning << juce::String(result.summary) << "\n\n";
             for (const auto& d : result.decisions) {
                 juce::String name;
-                if (d.index >= 0 && d.index < (int)levels.size())
-                    name = juce::String(levels[(size_t)d.index].name);
+                if (d.index >= 0 && d.index < static_cast<int>(levels.size()))
+                    name = juce::String(levels[static_cast<size_t>(d.index)].name);
                 reasoning << name << ":  " << (d.newGainDb >= 0.0f ? "+" : "")
                           << juce::String(d.newGainDb, 1) << " dB";
                 if (!d.reason.empty())
@@ -2276,8 +2277,8 @@ void TrackChainContent::runAiGainStagingPass() {
             } else {
                 std::vector<std::pair<magda::ChainNodePath, float>> moves;
                 for (const auto& d : result.decisions)
-                    if (d.index >= 0 && d.index < (int)paths.size())
-                        moves.push_back({paths[(size_t)d.index], d.newGainDb});
+                    if (d.index >= 0 && d.index < static_cast<int>(paths.size()))
+                        moves.push_back({paths[static_cast<size_t>(d.index)], d.newGainDb});
                 m.applyAiMoves(moves);
                 juce::Logger::writeToLog("[GainStaging] AI: " + juce::String(result.summary));
             }

--- a/magda/daw/ui/panels/content/inspector/clip/ClipInspectorSections.cpp
+++ b/magda/daw/ui/panels/content/inspector/clip/ClipInspectorSections.cpp
@@ -730,8 +730,9 @@ void ClipInspector::initClipPropertiesSection() {
     clipPropsContainer_.addChildComponent(*clipLoopToggle_);
 
     // Audio clip properties collapse toggle
-    audioPropsCollapseToggle_.setButtonText(juce::String::charToString(
-        audioPropsCollapsed_ ? (juce::juce_wchar)0x25B6 : (juce::juce_wchar)0x25BC));
+    audioPropsCollapseToggle_.setButtonText(
+        juce::String::charToString(audioPropsCollapsed_ ? static_cast<juce::juce_wchar>(0x25B6)
+                                                        : static_cast<juce::juce_wchar>(0x25BC)));
     audioPropsCollapseToggle_.setColour(juce::TextButton::buttonColourId,
                                         juce::Colours::transparentBlack);
     audioPropsCollapseToggle_.setColour(juce::TextButton::buttonOnColourId,
@@ -746,7 +747,8 @@ void ClipInspector::initClipPropertiesSection() {
     audioPropsCollapseToggle_.onClick = [this]() {
         audioPropsCollapsed_ = !audioPropsCollapsed_;
         audioPropsCollapseToggle_.setButtonText(juce::String::charToString(
-            audioPropsCollapsed_ ? (juce::juce_wchar)0x25B6 : (juce::juce_wchar)0x25BC));
+            audioPropsCollapsed_ ? static_cast<juce::juce_wchar>(0x25B6)
+                                 : static_cast<juce::juce_wchar>(0x25BC)));
         updateFromSelectedClip();
     };
     clipPropsContainer_.addChildComponent(audioPropsCollapseToggle_);

--- a/magda/daw/ui/panels/content/inspector/clip/sections/ClipFadesSection.cpp
+++ b/magda/daw/ui/panels/content/inspector/clip/sections/ClipFadesSection.cpp
@@ -386,10 +386,10 @@ void ClipFadesSection::update() {
                     continue;
                 const auto* c = magda::ClipManager::getInstance().getClip(cid);
                 if (c && c->isAudio()) {
-                    minIn = juce::jmin(minIn, (double)magda::audioEventRef(*c).fadeInSeconds);
-                    maxIn = juce::jmax(maxIn, (double)magda::audioEventRef(*c).fadeInSeconds);
-                    minOut = juce::jmin(minOut, (double)magda::audioEventRef(*c).fadeOutSeconds);
-                    maxOut = juce::jmax(maxOut, (double)magda::audioEventRef(*c).fadeOutSeconds);
+                    minIn = juce::jmin(minIn, magda::audioEventRef(*c).fadeInSeconds);
+                    maxIn = juce::jmax(maxIn, magda::audioEventRef(*c).fadeInSeconds);
+                    minOut = juce::jmin(minOut, magda::audioEventRef(*c).fadeOutSeconds);
+                    maxOut = juce::jmax(maxOut, magda::audioEventRef(*c).fadeOutSeconds);
                 }
             }
             double midIn = (minIn + maxIn) / 2.0;

--- a/magda/daw/ui/views/MainView.cpp
+++ b/magda/daw/ui/views/MainView.cpp
@@ -2401,7 +2401,7 @@ void MainView::SelectionOverlayComponent::drawRecordingRegion(juce::Graphics& g)
     int scrollY = owner.trackContentViewport->getViewPositionY();
     auto& tracks = TrackManager::getInstance().getTracks();
 
-    for (int trackIndex = 0; trackIndex < (int)tracks.size(); ++trackIndex) {
+    for (int trackIndex = 0; trackIndex < static_cast<int>(tracks.size()); ++trackIndex) {
         if (!tracks[trackIndex].recordArmed) {
             continue;
         }

--- a/magda/daw/ui/windows/MainWindowExport.cpp
+++ b/magda/daw/ui/windows/MainWindowExport.cpp
@@ -152,7 +152,7 @@ class ExportProgressWindow : public juce::ThreadWithProgressWindow {
 
         // Keep lead-in silence from the preroll (don't trim it)
         auto effectiveTrim = std::max(0.0, prerollSeconds_ - leadInSilence_);
-        auto samplesToSkip = (juce::int64)(effectiveTrim * reader->sampleRate);
+        auto samplesToSkip = static_cast<juce::int64>(effectiveTrim * reader->sampleRate);
         auto samplesToKeep = reader->lengthInSamples - samplesToSkip;
         if (samplesToKeep <= 0)
             return false;
@@ -170,8 +170,8 @@ class ExportProgressWindow : public juce::ThreadWithProgressWindow {
             std::make_unique<juce::FileOutputStream>(tempFile);
         auto writerOptions = juce::AudioFormatWriterOptions()
                                  .withSampleRate(reader->sampleRate)
-                                 .withNumChannels((int)reader->numChannels)
-                                 .withBitsPerSample((int)reader->bitsPerSample);
+                                 .withNumChannels(static_cast<int>(reader->numChannels))
+                                 .withBitsPerSample(static_cast<int>(reader->bitsPerSample));
         auto writer = format->createWriterFor(outputStream, writerOptions);
         if (!writer)
             return false;


### PR DESCRIPTION
## Summary
- Next of the per-check PRs from #2388: `clang-tidy`'s `modernize-avoid-c-style-cast -fix` applied over `magda/`.
- 108 sites across 30 files — every cast is a plain arithmetic conversion (`int`/`float`/`double`/`size_t`/`juce::uint8`/`juce::int64`/`juce::juce_wchar`), which a C-style cast always resolves to `static_cast` semantics for anyway, so this is behaviorally a no-op — same category as `modernize-use-auto`.
- The fixer's own bug: on 3 sites where the cast operand was followed by a binary operator inside a wider expression (e.g. `(double)yellowPos - fade`), it emitted an extra stray `)`, leaving 5 lines across 3 files uncompilable — `WarpedWaveformRenderer.hpp` (3 sites), `NodeHeaderStyles.hpp`, `LevelMeter.hpp`. Hand-fixed those to restore the original parenthesization (`static_cast<double>(yellowPos) - fade`, etc.) — this is the "no hand edits beyond what the fixer leaves uncompilable" case the issue calls out. Scanned the rest of the diff for the same paren-count bug; nothing else affected.

## Test plan
- [x] `make debug` — builds clean
- [x] `make test` — 3573 passed, 13 skipped, 856978 assertions, 0 failed

Part of #2388.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0149ko34fXR5PeMBqVL1tDWt