### PR TITLE
Make deleted special member functions public across magda/

### DIFF
--- a/magda/agents/llama_model_manager.hpp
+++ b/magda/agents/llama_model_manager.hpp
@@ -17,6 +17,9 @@ struct LlamaModelManagerTestAccess;
 
 class LlamaModelManager {
   public:
+    LlamaModelManager(const LlamaModelManager&) = delete;
+    LlamaModelManager& operator=(const LlamaModelManager&) = delete;
+
     static LlamaModelManager& getInstance();
 
     struct Config {
@@ -56,9 +59,6 @@ class LlamaModelManager {
 
     LlamaModelManager() = default;
     ~LlamaModelManager();
-
-    LlamaModelManager(const LlamaModelManager&) = delete;
-    LlamaModelManager& operator=(const LlamaModelManager&) = delete;
 
     static std::string cpuCompatibilityError(bool isIntel, bool hasSSE42, bool hasAVX);
     static std::string currentCpuCompatibilityError();

--- a/magda/daw/core/ClipOperations.hpp
+++ b/magda/daw/core/ClipOperations.hpp
@@ -30,6 +30,8 @@ namespace magda {
  */
 class ClipOperations {
   public:
+    ClipOperations() = delete;  // Static class, no instances
+
     // ========================================================================
     // Constraint Constants
     // ========================================================================
@@ -1107,9 +1109,6 @@ class ClipOperations {
 
         clip.midiNotes = std::move(flatNotes);
     }
-
-  private:
-    ClipOperations() = delete;  // Static class, no instances
 };
 
 }  // namespace magda

--- a/magda/daw/core/PresetManager.hpp
+++ b/magda/daw/core/PresetManager.hpp
@@ -24,6 +24,9 @@ namespace magda {
  */
 class PresetManager {
   public:
+    PresetManager(const PresetManager&) = delete;
+    PresetManager& operator=(const PresetManager&) = delete;
+
     static PresetManager& getInstance();
 
     // ========================================================================
@@ -224,10 +227,6 @@ class PresetManager {
   private:
     PresetManager();
     ~PresetManager() = default;
-
-    // Non-copyable
-    PresetManager(const PresetManager&) = delete;
-    PresetManager& operator=(const PresetManager&) = delete;
 
     /**
      * @brief Ensure a directory exists, creating it if necessary

--- a/magda/daw/core/UpdateChecker.hpp
+++ b/magda/daw/core/UpdateChecker.hpp
@@ -18,6 +18,8 @@ namespace magda {
  */
 class UpdateChecker {
   public:
+    UpdateChecker() = delete;
+
     struct Result {
         bool success = false;          // Network + parse succeeded
         bool updateAvailable = false;  // True when latest > current
@@ -52,9 +54,6 @@ class UpdateChecker {
      * the clean version.
      */
     static int compareVersions(const juce::String& a, const juce::String& b);
-
-  private:
-    UpdateChecker() = delete;
 };
 
 }  // namespace magda

--- a/magda/daw/ui/themes/CursorManager.hpp
+++ b/magda/daw/ui/themes/CursorManager.hpp
@@ -10,6 +10,9 @@ namespace magda {
  */
 class CursorManager {
   public:
+    CursorManager(const CursorManager&) = delete;
+    CursorManager& operator=(const CursorManager&) = delete;
+
     static CursorManager& getInstance();
 
     // Get zoom cursors
@@ -45,9 +48,6 @@ class CursorManager {
   private:
     CursorManager();
     ~CursorManager() = default;
-
-    CursorManager(const CursorManager&) = delete;
-    CursorManager& operator=(const CursorManager&) = delete;
 
     // Draw a magnifying glass cursor with optional +/- glyph
     enum class ZoomGlyph { None, Plus, Minus };

--- a/magda/daw/ui/themes/FontManager.hpp
+++ b/magda/daw/ui/themes/FontManager.hpp
@@ -27,6 +27,9 @@ inline bool resolvesOwnFonts(const juce::Component& component) {
 
 class FontManager {
   public:
+    FontManager(const FontManager&) = delete;
+    FontManager& operator=(const FontManager&) = delete;
+
     enum class Weight { Regular, Medium, SemiBold, Bold };
 
     static FontManager& getInstance();
@@ -62,10 +65,6 @@ class FontManager {
   private:
     FontManager() = default;
     ~FontManager() = default;
-
-    // Non-copyable
-    FontManager(const FontManager&) = delete;
-    FontManager& operator=(const FontManager&) = delete;
 
     bool initialized = false;
 

--- a/magda/daw/ui/windows/MenuManager.hpp
+++ b/magda/daw/ui/windows/MenuManager.hpp
@@ -10,6 +10,9 @@ namespace magda {
 
 class MenuManager : public juce::MenuBarModel, public UndoManagerListener {
   public:
+    MenuManager(const MenuManager&) = delete;
+    MenuManager& operator=(const MenuManager&) = delete;
+
     // Menu callbacks
     struct MenuCallbacks {
         // File menu
@@ -152,10 +155,6 @@ class MenuManager : public juce::MenuBarModel, public UndoManagerListener {
   private:
     MenuManager();
     ~MenuManager();
-
-    // Non-copyable
-    MenuManager(const MenuManager&) = delete;
-    MenuManager& operator=(const MenuManager&) = delete;
 
     // MenuBarModel implementation
     juce::StringArray getMenuBarNames() override;


### PR DESCRIPTION
## Summary
- Next of the per-check PRs from #2388: `modernize-use-equals-delete`'s "deleted member function should be public" diagnostic, applied by hand — this check has no `-fix` in this clang-tidy version (0 files changed when run with `-fix`; it only warns).
- 12 sites across 7 files, all the same shape: a singleton or static-utility class with `private: Ctor(); ~Dtor(); Copy(const T&) = delete; T& operator=(const T&) = delete;`. Moved just the two deleted declarations to the top of `public:`, leaving the real (non-deleted) constructor/destructor private where they belong.
- Zero behavior change: a deleted function can never be called regardless of access. Access control on a deleted function only changes which compiler error a caller sees (`is private` vs. `call to deleted function`) — the public placement gives the clearer message, which is the entire point of the check.
- Files: `ClipOperations.hpp`, `PresetManager.hpp`, `UpdateChecker.hpp`, `llama_model_manager.hpp`, `CursorManager.hpp`, `FontManager.hpp`, `MenuManager.hpp`.

## Test plan
- [x] `make debug` — builds clean
- [x] `make test` — 3573 passed, 13 skipped, 859008 assertions, 0 failed

Part of #2388.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0149ko34fXR5PeMBqVL1tDWt