### PR TITLE
Apply modernize-use-override fixes across magda/

### DIFF
--- a/magda/daw/audio/DeviceMeteringManager.hpp
+++ b/magda/daw/audio/DeviceMeteringManager.hpp
@@ -32,7 +32,7 @@ class PluginManager;
 class DeviceMeteringManager : public daw::audio::DeviceMeteringContext {
   public:
     DeviceMeteringManager() = default;
-    ~DeviceMeteringManager() = default;
+    ~DeviceMeteringManager() override = default;
 
     /**
      * @brief Set the PluginManager for plugin→device lookup

--- a/magda/daw/audio/WarpMarkerManager.hpp
+++ b/magda/daw/audio/WarpMarkerManager.hpp
@@ -42,7 +42,7 @@ struct WarpMarkerInfo {
 class WarpMarkerManager : private te::WarpTimeManager::Listener, private juce::Timer {
   public:
     WarpMarkerManager() = default;
-    ~WarpMarkerManager();
+    ~WarpMarkerManager() override;
 
     /**
      * @brief Detect transient times for an audio clip's source file

--- a/magda/daw/core/AutomationManager.hpp
+++ b/magda/daw/core/AutomationManager.hpp
@@ -551,7 +551,7 @@ class AutomationManager : public TrackManagerListener {
 
   private:
     AutomationManager();
-    ~AutomationManager();
+    ~AutomationManager() override;
 
     std::vector<AutomationLaneInfo> lanes_;
     std::vector<AutomationClipInfo> clips_;

--- a/magda/daw/core/TrackManager.hpp
+++ b/magda/daw/core/TrackManager.hpp
@@ -1245,7 +1245,7 @@ class TrackManager : public daw::audio::DeviceIdAllocator, public daw::audio::De
 
   private:
     TrackManager();
-    ~TrackManager() = default;
+    ~TrackManager() override = default;
 
     // Register a track with MidiBridge for input monitoring. No-op when no audio
     // engine is attached or the track takes no external input (Aux, Group).

--- a/magda/daw/engine/TracktionEngineWrapper.hpp
+++ b/magda/daw/engine/TracktionEngineWrapper.hpp
@@ -58,7 +58,7 @@ class TracktionEngineWrapper : public AudioEngine,
     static constexpr int AUDIO_DEVICE_CHECK_THRESHOLD = 3;
 
     TracktionEngineWrapper();
-    ~TracktionEngineWrapper();
+    ~TracktionEngineWrapper() override;
 
     /**
      * @brief Force the wrapper to skip UI/timer-backed runtime helpers.

--- a/magda/daw/project/ProjectManager.hpp
+++ b/magda/daw/project/ProjectManager.hpp
@@ -327,7 +327,7 @@ class ProjectManager : private juce::Timer {
     friend class UndoManager;
 
     ProjectManager();
-    ~ProjectManager();
+    ~ProjectManager() override;
 
     void joinBackgroundThread();
     void timerCallback() override;

--- a/magda/daw/ui/components/chain/modulation/ModKnobComponent.hpp
+++ b/magda/daw/ui/components/chain/modulation/ModKnobComponent.hpp
@@ -24,7 +24,7 @@ class MiniWaveformDisplay : public juce::Component, private juce::Timer {
         startTimer(33);  // 30 FPS animation
     }
 
-    ~MiniWaveformDisplay() {
+    ~MiniWaveformDisplay() override {
         stopTimer();
     }
 

--- a/magda/daw/ui/windows/MainWindow.cpp
+++ b/magda/daw/ui/windows/MainWindow.cpp
@@ -71,7 +71,7 @@ class MainWindow::MainComponent::LoadingOverlay : public juce::Component, privat
         setInterceptsMouseClicks(false, false);  // Non-blocking - clicks pass through
     }
 
-    ~LoadingOverlay() {
+    ~LoadingOverlay() override {
         stopTimer();
     }
 

--- a/magda/daw/ui/windows/MenuManager.hpp
+++ b/magda/daw/ui/windows/MenuManager.hpp
@@ -154,7 +154,7 @@ class MenuManager : public juce::MenuBarModel, public UndoManagerListener {
 
   private:
     MenuManager();
-    ~MenuManager();
+    ~MenuManager() override;
 
     // MenuBarModel implementation
     juce::StringArray getMenuBarNames() override;


### PR DESCRIPTION
## Summary
- Next of the per-check PRs from #2388: `clang-tidy`'s `modernize-use-override -fix` applied over `magda/`.
- 9 sites across 9 files — a destructor that overrides a virtual base destructor now says so.
- The fixer's own bug: on 6 of the 9 sites it inserted `override` once per virtual base it matched against, without checking whether it had already inserted one — `TrackManager.hpp`'s destructor ended up with **23** repeated `override override override...` keywords, `AutomationManager.hpp` with 16, others with 9 or 2. Collapsed each back down to a single `override`. `override` is compiler-checked (a non-overriding function fails to compile with it), so the build itself is the correctness proof here — it wouldn't have compiled if any of these destructors didn't genuinely override a virtual base.

## Test plan
- [x] `make debug` — builds clean
- [x] `make test` — 3573 passed, 13 skipped, 856979 assertions, 0 failed

Part of #2388.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0149ko34fXR5PeMBqVL1tDWt