### PR TITLE
Keep the JUCE test binary out of libfaust for importing sources

### DIFF
--- a/magda/daw/audio/FaustResources.cpp
+++ b/magda/daw/audio/FaustResources.cpp
@@ -1,12 +1,27 @@
 #include "FaustResources.hpp"
 
 #include <algorithm>
+#include <atomic>
 #include <regex>
 #include <string>
 
 #include "core/AppPaths.hpp"
 
 namespace magda::daw::audio {
+
+namespace {
+
+std::atomic<bool> faustLibraryImportsOff{false};
+
+}  // namespace
+
+void disallowFaustLibraryImports() {
+    faustLibraryImportsOff.store(true, std::memory_order_relaxed);
+}
+
+bool faustLibraryImportsDisallowed() {
+    return faustLibraryImportsOff.load(std::memory_order_relaxed);
+}
 
 namespace {
 

--- a/magda/daw/audio/FaustResources.hpp
+++ b/magda/daw/audio/FaustResources.hpp
@@ -34,6 +34,19 @@ juce::String readCustomViewName(const juce::String& source);
 // case so the plugin always loads.
 juce::File getFaustLibrariesPath();
 
+/** Refuse Faust sources that import libraries, for the whole process.
+ *
+ *  For test binaries that ship no faustlibraries: an importing source could
+ *  only fail its compile into passthrough while still entering libfaust,
+ *  which aborts on Linux under some suites (#2238). Disallowed, importing
+ *  sources are passthrough by contract without touching libfaust, and
+ *  self-contained sources still compile for real. Not undoable.
+ */
+void disallowFaustLibraryImports();
+
+/// True once disallowFaustLibraryImports() has been called.
+bool faustLibraryImportsDisallowed();
+
 // Root of the runtime .dsp library staged alongside the app. Like
 // getFaustLibrariesPath(), the returned File may not exist outside an
 // installed bundle.

--- a/magda/daw/audio/plugins/FaustInstrumentPlugin.cpp
+++ b/magda/daw/audio/plugins/FaustInstrumentPlugin.cpp
@@ -242,8 +242,17 @@ FaustInstrumentPlugin::FaustState::~FaustState() {
 
 std::shared_ptr<FaustInstrumentPlugin::FaustState> FaustInstrumentPlugin::compile(
     const juce::String& source, int sampleRate, juce::String& errorOut) {
+    // Passthrough by contract, without entering libfaust. See FaustResources.hpp.
+    // The stdfaust injection below is skipped in that mode for the same
+    // reason: it would turn a self-contained source into an importing one.
+    if (faustLibraryImportsDisallowed() && source.contains("import(")) {
+        errorOut = "Faust library imports are disallowed in this process";
+        return nullptr;
+    }
+
     const auto libsPath = getFaustLibrariesPath().getFullPathName().toStdString();
-    const juce::String normalised = ensureStdfaustImport(source);
+    const juce::String normalised =
+        faustLibraryImportsDisallowed() ? source : ensureStdfaustImport(source);
     const auto src = normalised.toStdString();
 
     std::vector<const char*> argv;

--- a/magda/daw/audio/plugins/FaustPlugin.cpp
+++ b/magda/daw/audio/plugins/FaustPlugin.cpp
@@ -177,6 +177,12 @@ FaustPlugin::FaustState::~FaustState() {
 std::shared_ptr<FaustPlugin::FaustState> FaustPlugin::compile(const juce::String& source,
                                                               int sampleRate,
                                                               juce::String& errorOut) {
+    // Passthrough by contract, without entering libfaust. See FaustResources.hpp.
+    if (faustLibraryImportsDisallowed() && source.contains("import(")) {
+        errorOut = "Faust library imports are disallowed in this process";
+        return nullptr;
+    }
+
     // Pass the bundled faustlibraries dir as `-I` so `import("stdfaust.lib")`
     // and friends resolve at compile time. The path may not exist when running
     // outside the installed bundle (e.g. unit tests) — libfaust falls back to
@@ -212,7 +218,10 @@ std::shared_ptr<FaustPlugin::FaustState> FaustPlugin::compile(const juce::String
         return state;
     };
 
-    const juce::String normalised = ensureStdfaustImport(source);
+    // In disallowed mode the injection is skipped too: it would turn a
+    // self-contained source into an importing one. See FaustResources.hpp.
+    const juce::String normalised =
+        faustLibraryImportsDisallowed() ? source : ensureStdfaustImport(source);
 
     auto state = compileSource(normalised, errorOut);
     if (!state)

--- a/tests/juce_tests_main.cpp
+++ b/tests/juce_tests_main.cpp
@@ -6,6 +6,7 @@
 
 #include "AssertionWatch.hpp"
 #include "JuceTestStateGuard.hpp"
+#include "magda/daw/audio/FaustResources.hpp"
 
 /**
  * @brief Main entry point for JUCE unit tests
@@ -25,6 +26,12 @@ int main(int argc, char* argv[]) {
     // earlier suite could have started, is what keeps that write from racing a
     // read. It is never taken down. See AssertionWatch.hpp.
     magda::test::AssertionWatch::instance();
+
+    // This binary ships no faustlibraries (staging them aborts libfaust on
+    // Linux, #2238), so an importing Faust source could only fail its compile
+    // into passthrough anyway. Disallowed, that passthrough is the contract
+    // and libfaust is never entered; self-contained sources still compile.
+    magda::daw::audio::disallowFaustLibraryImports();
 
     // Initialize JUCE GUI subsystem - required for message loop, timers, async updaters, etc.
     // This must be alive for the entire test run to avoid SIGSEGV from singleton cleanup issues


### PR DESCRIPTION
magda_juce_tests ships no faustlibraries (staging them aborts libfaust on Linux, #2238), so every project-saved Faust source failed its compile into passthrough while still entering libfaust - 26 "unable to open file stdfaust.lib" per run, and the abort risk with them.

disallowFaustLibraryImports() makes that passthrough the contract: importing sources are refused before libfaust is entered, and the automatic stdfaust injection is skipped so a self-contained source stays self-contained and still compiles for real. The sidechain suite's lib-free DSPs are untouched - they already dodge the injection with their load-bearing "stdfaust.lib" comments - and nothing outside the JUCE test main flips the switch, so magda_tests and the app are unchanged.


Claude-Session: https://claude.ai/code/session_01GvA5d4Q5JYR8HWoKWnfyR4