### PR TITLE
Apply modernize-use-equals-default fixes across magda/

### DIFF
--- a/magda/daw/core/LinkModeManager.cpp
+++ b/magda/daw/core/LinkModeManager.cpp
@@ -15,9 +15,7 @@ LinkModeManager& LinkModeManager::getInstance() {
     return instance;
 }
 
-LinkModeManager::LinkModeManager() {
-    // Start with no link mode active
-}
+LinkModeManager::LinkModeManager() = default;
 
 // ============================================================================
 // Mod Link Mode

--- a/magda/daw/core/RackInfo.hpp
+++ b/magda/daw/core/RackInfo.hpp
@@ -208,21 +208,8 @@ struct RackInfo {
     RackInfo(RackInfo&&) = default;
     RackInfo& operator=(RackInfo&&) = default;
 
-    // Copy constructor
-    RackInfo(const RackInfo& other)
-        : id(other.id),
-          name(other.name),
-          chains(other.chains),  // ChainInfo has its own deep copy
-          bypassed(other.bypassed),
-          deltaSolo(other.deltaSolo),
-          expanded(other.expanded),
-          volume(other.volume),
-          pan(other.pan),
-          modPanelOpen(other.modPanelOpen),
-          paramPanelOpen(other.paramPanelOpen),
-          macros(other.macros),
-          mods(other.mods),
-          sidechain(other.sidechain) {}
+    // Copy constructor. chains deep-copies via ChainInfo's own copy constructor.
+    RackInfo(const RackInfo& other) = default;
 
     // Copy assignment
     RackInfo& operator=(const RackInfo& other) {

--- a/magda/daw/core/SelectionManager.cpp
+++ b/magda/daw/core/SelectionManager.cpp
@@ -74,9 +74,7 @@ SelectionManager& SelectionManager::getInstance() {
     return instance;
 }
 
-SelectionManager::SelectionManager() {
-    // Start with no selection
-}
+SelectionManager::SelectionManager() = default;
 
 // ============================================================================
 // Primary-track alignment helper (shared by selectDevice / selectChainNode)

--- a/magda/daw/core/TrackInfo.hpp
+++ b/magda/daw/core/TrackInfo.hpp
@@ -114,42 +114,8 @@ struct TrackInfo {
     TrackInfo(TrackInfo&&) = default;
     TrackInfo& operator=(TrackInfo&&) = default;
 
-    // Copy constructor - deep copies chainElements
-    TrackInfo(const TrackInfo& other)
-        : id(other.id),
-          type(other.type),
-          name(other.name),
-          colour(other.colour),
-          parentId(other.parentId),
-          childIds(other.childIds),
-          volume(other.volume),
-          pan(other.pan),
-          manualVolume(other.manualVolume),
-          manualPan(other.manualPan),
-          muted(other.muted),
-          soloed(other.soloed),
-          recordArmed(other.recordArmed),
-          inputMonitor(other.inputMonitor),
-          frozen(other.frozen),
-          playbackMode(other.playbackMode),
-          mixerChannelWidth(other.mixerChannelWidth),
-          mixerFaderTopInset(other.mixerFaderTopInset),
-          activeSessionClipId(other.activeSessionClipId),
-          midiInputDevice(other.midiInputDevice),
-          midiOutputDevice(other.midiOutputDevice),
-          audioInputDevice(other.audioInputDevice),
-          audioOutputDevice(other.audioOutputDevice),
-          sends(other.sends),
-          auxBusIndex(other.auxBusIndex),
-          multiOutLink(other.multiOutLink),
-          chain(other.chain),
-          viewSettings(other.viewSettings),
-          mods(other.mods),
-          macros(other.macros),
-          globalModsPanelOpen(other.globalModsPanelOpen),
-          globalMacrosPanelOpen(other.globalMacrosPanelOpen),
-          selectedGlobalModIndex(other.selectedGlobalModIndex),
-          selectedGlobalMacroIndex(other.selectedGlobalMacroIndex) {}
+    // Copy constructor. chain deep-copies via TrackChain's own copy constructor.
+    TrackInfo(const TrackInfo& other) = default;
 
     // Copy assignment - deep copies chainElements
     TrackInfo& operator=(const TrackInfo& other) {

--- a/magda/daw/ui/components/common/SvgButton.cpp
+++ b/magda/daw/ui/components/common/SvgButton.cpp
@@ -30,9 +30,8 @@ SvgButton::SvgButton(const juce::String& buttonName, const char* offSvgData, siz
     setMouseClickGrabsKeyboardFocus(false);
 }
 
-SvgButton::~SvgButton() {
-    // RAII cleanup handled automatically by ManagedDrawable
-}
+// RAII cleanup handled automatically by ManagedDrawable
+SvgButton::~SvgButton() = default;
 
 juce::Colour SvgButton::resolveThemeColour(juce::Colour colour,
                                            const std::optional<ColourRole>& role) {

--- a/magda/daw/ui/views/MainView.cpp
+++ b/magda/daw/ui/views/MainView.cpp
@@ -2660,9 +2660,8 @@ void MainView::MasterHeaderPanel::setPeakLevels(float leftPeak, float rightPeak)
 
 // ===== MasterContentPanel Implementation =====
 
-MainView::MasterContentPanel::MasterContentPanel() {
-    // Empty for now - will show waveform later
-}
+// Empty for now - will show waveform later
+MainView::MasterContentPanel::MasterContentPanel() = default;
 
 void MainView::MasterContentPanel::paint(juce::Graphics& g) {
     // Background matching track content area

--- a/magda/daw/utils/ComponentManager.hpp
+++ b/magda/daw/utils/ComponentManager.hpp
@@ -57,11 +57,10 @@ class ManagedDrawable {
         return managed;
     }
 
-    // Destructor - RAII cleanup (like Python's __exit__)
-    ~ManagedDrawable() {
-        // Let unique_ptr handle destruction naturally
-        // No manual deleteAllChildren needed - Component destructor handles it correctly
-    }
+    // Destructor - RAII cleanup (like Python's __exit__). Let unique_ptr handle
+    // destruction naturally; no manual deleteAllChildren needed - Component's
+    // destructor handles it correctly.
+    ~ManagedDrawable() = default;
 
     // Move-only (like Python context managers)
     ManagedDrawable(ManagedDrawable&&) noexcept = default;


### PR DESCRIPTION
## Summary
- Next of the per-check PRs from #2388: `modernize-use-equals-default`, applied entirely by hand.
- `clang-tidy -fix` catastrophically corrupted the two struct sites it did attempt: it kept the initializer list's comma structure but deleted every `member(other.member)` expression, leaving syntax garbage like `: ,\n ,\n ... = default;` in `RackInfo.hpp`/`TrackInfo.hpp` — discarded that output entirely.
- The other 5 sites got no fixer output at all (the fixer declines when the body contains a comment it would have to discard).
- All 7 hand-verified and hand-applied:
  - `RackInfo.hpp` / `TrackInfo.hpp`: the copy constructors' initializer lists were confirmed to exactly match member-declaration order, one entry per member, no special-casing — genuinely identical to what `= default` generates. The build (which would reject `= default` on any member the compiler can't default-copy) is the proof.
  - `LinkModeManager.cpp`, `SelectionManager.cpp`, `SvgButton.cpp`, `MainView.cpp`, `ComponentManager.hpp` (defines `ManagedDrawable`): trivial ctor/dtor bodies containing only an explanatory comment — converted to `T::T() = default;`, keeping the comment above where it explained a non-obvious reason.

## Test plan
- [x] `make debug` — builds clean
- [x] `make test` — 3573 passed, 13 skipped, 856983 assertions, 0 failed

Part of #2388 — `modernize-loop-convert` and `performance-unnecessary-value-param` still remain, both needing per-site review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0149ko34fXR5PeMBqVL1tDWt