### PR TITLE
Fix arpeggiator input references and lost note-offs

### DIFF
--- a/magda/daw/audio/plugins/ArpeggiatorPlugin.cpp
+++ b/magda/daw/audio/plugins/ArpeggiatorPlugin.cpp
@@ -261,24 +261,25 @@ void ArpeggiatorPlugin::clearHeldNotes() {
 }
 
 void ArpeggiatorPlugin::sendAllNotesOff(DeviceMidiBuffer& midi) {
-    if (lastPlayedNote_ >= 0) {
-        midi.addEvent({juce::MidiMessage::noteOff(1, lastPlayedNote_), 0});
-        lastPlayedNote_ = -1;
-        clearMidiOutDisplay();
-    }
+    sendNoteOff(midi, takeSoundingNote());
 }
 
-void ArpeggiatorPlugin::resetArpState() {
-    currentStep_ = 0;
-    goingUp_ = true;
-    arpOriginBeat_ = -1.0;
+int ArpeggiatorPlugin::takeSoundingNote() {
+    const int note = lastPlayedNote_;
     lastPlayedNote_ = -1;
-    lastPlayedVelocity_ = 0;
     lastNoteOffBeat_ = -1.0;
+    clearMidiOutDisplay();
+    return note;
+}
+
+int ArpeggiatorPlugin::resetArpState() {
+    const int note = takeSoundingNote();
+    currentStep_ = 0;
+    arpOriginBeat_ = -1.0;
     wasPlaying_ = false;
     currentPlayStep_.store(-1, std::memory_order_relaxed);
     currentSeqLength_.store(0, std::memory_order_relaxed);
-    clearMidiOutDisplay();
+    return note;
 }
 
 ArpeggiatorPlugin::ExpandedSequence ArpeggiatorPlugin::buildSequence() const {
@@ -371,9 +372,9 @@ void ArpeggiatorPlugin::process(DeviceProcessContext& context) {
     // note can be sounding on entry; this pass does not generate new notes.
     int pendingNoteOff = -1;
     const auto resetFromInput = [&] {
-        if (lastPlayedNote_ >= 0)
-            pendingNoteOff = lastPlayedNote_;
-        resetArpState();
+        const int note = resetArpState();
+        if (note >= 0)
+            pendingNoteOff = note;
         freeRunSamples_ = 0.0;
     };
     // Hosts can signal panic without a CC event (for example on a playhead
@@ -582,7 +583,6 @@ void ArpeggiatorPlugin::process(DeviceProcessContext& context) {
                 timeInBlock);
 
             lastPlayedNote_ = note.noteNumber;
-            lastPlayedVelocity_ = vel;
             setMidiOutDisplay(note.noteNumber, vel);
 
             // Schedule note-off

--- a/magda/daw/audio/plugins/ArpeggiatorPlugin.cpp
+++ b/magda/daw/audio/plugins/ArpeggiatorPlugin.cpp
@@ -370,14 +370,19 @@ void ArpeggiatorPlugin::process(DeviceProcessContext& context) {
     // and the clear below would discard any note-offs emitted here. Only one
     // note can be sounding on entry; this pass does not generate new notes.
     int pendingNoteOff = -1;
-    const auto deferNoteOff = [&] {
-        if (lastPlayedNote_ >= 0) {
+    const auto resetFromInput = [&] {
+        if (lastPlayedNote_ >= 0)
             pendingNoteOff = lastPlayedNote_;
-            lastPlayedNote_ = -1;
-            lastNoteOffBeat_ = -1.0;
-            clearMidiOutDisplay();
-        }
+        resetArpState();
+        freeRunSamples_ = 0.0;
     };
+    // Hosts can signal panic without a CC event (for example on a playhead
+    // jump). Reset before consuming fresh input, and forward the flag below.
+    const bool inputPanic = midi.isAllNotesOff();
+    if (inputPanic) {
+        clearHeldNotes();
+        resetFromInput();
+    }
     const int incomingCount = midi.size();
     for (int eventIndex = 0; eventIndex < incomingCount; ++eventIndex) {
         const auto& msg = midi.message(eventIndex);
@@ -386,21 +391,16 @@ void ArpeggiatorPlugin::process(DeviceProcessContext& context) {
 
             // Latch: if old set is stale (all keys were released), clear before adding
             if (isLatched && latchedSetStale_) {
-                deferNoteOff();
                 heldCount_ = 0;
                 nextOrder_ = 0;
                 latchedSetStale_ = false;
-                currentStep_ = 0;
-                goingUp_ = true;
             }
 
             bool wasEmpty = (heldCount_ == 0);
             addHeldNote(msg.getNoteNumber(), msg.getVelocity());
             // Reset free-running clock when first note arrives
             if (wasEmpty && heldCount_ > 0) {
-                freeRunSamples_ = 0.0;
-                deferNoteOff();
-                resetArpState();
+                resetFromInput();
             }
         } else if (msg.isNoteOff()) {
             --physicallyHeldCount_;
@@ -415,21 +415,19 @@ void ArpeggiatorPlugin::process(DeviceProcessContext& context) {
                 removeHeldNote(msg.getNoteNumber());
             }
         } else if (msg.isAllNotesOff() || msg.isAllSoundOff()) {
-            deferNoteOff();
             clearHeldNotes();
-            resetArpState();
+            resetFromInput();
         }
     }
 
     // --- 2. Clear MIDI buffer (arp replaces input) ---
     midi.clear();
-    if (pendingNoteOff >= 0)
-        midi.addEvent({juce::MidiMessage::noteOff(1, pendingNoteOff), 0});
+    midi.setAllNotesOff(inputPanic);
+    sendNoteOff(midi, pendingNoteOff);
 
     // --- 3. Handle transport transitions ---
-    // Note: the host briefly toggles isPlaying at loop boundaries, so we only
-    // reset the arp on a genuine stop (isPlaying goes false). On start we
-    // just update the flag — the step counter continues from where it was.
+    // Reset on a playing-to-stopped edge. On start, just update the flag;
+    // the step counter continues from where it was.
     if (context.isPlaying && !wasPlaying_) {
         wasPlaying_ = true;
     } else if (!context.isPlaying && wasPlaying_) {

--- a/magda/daw/audio/plugins/ArpeggiatorPlugin.cpp
+++ b/magda/daw/audio/plugins/ArpeggiatorPlugin.cpp
@@ -366,8 +366,18 @@ void ArpeggiatorPlugin::process(DeviceProcessContext& context) {
     const bool isLatched = displayValue(kLatch) >= 0.5f;
 
     // --- 1. Capture incoming MIDI ---
-    // Over the block's incoming events only: sendAllNotesOff() appends to the
-    // same buffer mid-loop, and the arp must not re-consume its own output.
+    // Keep the input view read-only: appending can invalidate message references,
+    // and the clear below would discard any note-offs emitted here. Only one
+    // note can be sounding on entry; this pass does not generate new notes.
+    int pendingNoteOff = -1;
+    const auto deferNoteOff = [&] {
+        if (lastPlayedNote_ >= 0) {
+            pendingNoteOff = lastPlayedNote_;
+            lastPlayedNote_ = -1;
+            lastNoteOffBeat_ = -1.0;
+            clearMidiOutDisplay();
+        }
+    };
     const int incomingCount = midi.size();
     for (int eventIndex = 0; eventIndex < incomingCount; ++eventIndex) {
         const auto& msg = midi.message(eventIndex);
@@ -376,8 +386,7 @@ void ArpeggiatorPlugin::process(DeviceProcessContext& context) {
 
             // Latch: if old set is stale (all keys were released), clear before adding
             if (isLatched && latchedSetStale_) {
-                // Send note-off for any currently playing note before clearing
-                sendAllNotesOff(midi);
+                deferNoteOff();
                 heldCount_ = 0;
                 nextOrder_ = 0;
                 latchedSetStale_ = false;
@@ -390,6 +399,7 @@ void ArpeggiatorPlugin::process(DeviceProcessContext& context) {
             // Reset free-running clock when first note arrives
             if (wasEmpty && heldCount_ > 0) {
                 freeRunSamples_ = 0.0;
+                deferNoteOff();
                 resetArpState();
             }
         } else if (msg.isNoteOff()) {
@@ -405,6 +415,7 @@ void ArpeggiatorPlugin::process(DeviceProcessContext& context) {
                 removeHeldNote(msg.getNoteNumber());
             }
         } else if (msg.isAllNotesOff() || msg.isAllSoundOff()) {
+            deferNoteOff();
             clearHeldNotes();
             resetArpState();
         }
@@ -412,6 +423,8 @@ void ArpeggiatorPlugin::process(DeviceProcessContext& context) {
 
     // --- 2. Clear MIDI buffer (arp replaces input) ---
     midi.clear();
+    if (pendingNoteOff >= 0)
+        midi.addEvent({juce::MidiMessage::noteOff(1, pendingNoteOff), 0});
 
     // --- 3. Handle transport transitions ---
     // Note: the host briefly toggles isPlaying at loop boundaries, so we only

--- a/magda/daw/audio/plugins/ArpeggiatorPlugin.hpp
+++ b/magda/daw/audio/plugins/ArpeggiatorPlugin.hpp
@@ -139,10 +139,8 @@ class ArpeggiatorPlugin : public MidiMagdaDevice {
 
     // Pattern state
     int currentStep_ = 0;
-    bool goingUp_ = true;
     double arpOriginBeat_ = -1.0;
     int lastPlayedNote_ = -1;
-    int lastPlayedVelocity_ = 0;
     double lastNoteOffBeat_ = -1.0;
 
     // Transport
@@ -169,7 +167,9 @@ class ArpeggiatorPlugin : public MidiMagdaDevice {
     void removeHeldNote(int noteNumber);
     void clearHeldNotes();
     void sendAllNotesOff(DeviceMidiBuffer& midi);
-    void resetArpState();
+    int takeSoundingNote();
+    // Returns the note that the caller must release when resetting during processing.
+    int resetArpState();
 
     struct ExpandedSequence {
         std::array<HeldNote, MAX_HELD * 4> notes{};

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -71,6 +71,7 @@ set(TEST_SOURCES
     devices/test_known_plugin_list_duplicates.cpp
     devices/test_device_parameter_pagination.cpp
     devices/test_mutable_clouds.cpp
+    devices/test_arpeggiator_input.cpp
     devices/test_device_ui_context.cpp
     ui/test_levels_ui.cpp
     # LevelsUI builds into magda_daw_app, so magda_tests needs its implementation

--- a/tests/TestDeviceMidiBuffer.hpp
+++ b/tests/TestDeviceMidiBuffer.hpp
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <algorithm>
+#include <utility>
+#include <vector>
+
+#include "audio/plugins/MagdaDevice.hpp"
+
+namespace magda::test {
+
+// Growable test storage, like the Tracktion view. clear() also consumes the
+// buffer-level panic flag, so transforming devices must explicitly preserve it.
+class DeviceMidiBuffer : public daw::audio::DeviceMidiBuffer {
+  public:
+    int size() const override {
+        return static_cast<int>(events.size());
+    }
+    const juce::MidiMessage& message(int index) const override {
+        return events.at(index).message;
+    }
+    std::uint32_t sourceId(int index) const override {
+        return events.at(index).sourceId;
+    }
+    void setEvent(int index, daw::audio::DeviceMidiEvent event) override {
+        events.at(index) = std::move(event);
+    }
+    void removeEvent(int index) override {
+        events.erase(events.begin() + index);
+    }
+    void addEvent(daw::audio::DeviceMidiEvent event) override {
+        events.push_back(std::move(event));
+    }
+    void clear() override {
+        events.clear();
+        allNotesOff = false;
+    }
+    void sortByTimestamp() override {
+        std::stable_sort(events.begin(), events.end(), [](const auto& a, const auto& b) {
+            return a.message.getTimeStamp() < b.message.getTimeStamp();
+        });
+    }
+    bool isAllNotesOff() const override {
+        return allNotesOff;
+    }
+    void setAllNotesOff(bool value) override {
+        allNotesOff = value;
+    }
+
+    std::vector<daw::audio::DeviceMidiEvent> events;
+    bool allNotesOff = false;
+};
+
+}  // namespace magda::test

--- a/tests/devices/test_arpeggiator_input.cpp
+++ b/tests/devices/test_arpeggiator_input.cpp
@@ -81,8 +81,9 @@ struct Rig {
     }
 
     MidiBuffer run(double start, std::initializer_list<juce::MidiMessage> input = {},
-                   bool playing = true) {
+                   bool playing = true, bool panic = false) {
         MidiBuffer midi;
+        midi.setAllNotesOff(panic);
         for (const auto& message : input)
             midi.events.push_back({message, 42});
         midi.events.shrink_to_fit();
@@ -156,6 +157,44 @@ TEST_CASE("Arpeggiator input resets retain a single pending note-off",
     CHECK(midi.message(1).isNoteOn());
     CHECK(midi.message(1).getNoteNumber() == 67);
     CHECK(midi.message(1).getVelocity() == 73);
+}
+
+TEST_CASE("Arpeggiator buffer panic stops and clears a latched chord",
+          "[arpeggiator][midi][input]") {
+    Rig rig(true);
+    rig.startNote();
+    rig.run(0.05, {juce::MidiMessage::noteOff(1, 60)});
+    auto midi = rig.run(0.1, {}, true, true);
+    CHECK(midi.isAllNotesOff());
+    REQUIRE(midi.size() == 1);
+    checkOff(midi);
+    auto next = rig.run(0.5);
+    CHECK_FALSE(next.isAllNotesOff());
+    CHECK(next.size() == 0);
+}
+
+TEST_CASE("Arpeggiator buffer panic permits fresh input without duplicate note-offs",
+          "[arpeggiator][midi][input]") {
+    Rig rig(true);
+    rig.startNote();
+    auto midi = rig.run(
+        0.5, {juce::MidiMessage::allNotesOff(1), juce::MidiMessage::noteOn(1, 67, juce::uint8{73})},
+        true, true);
+    CHECK(midi.isAllNotesOff());
+    REQUIRE(midi.size() == 2);
+    checkOff(midi);
+    CHECK(midi.message(1).isNoteOn());
+    CHECK(midi.message(1).getNoteNumber() == 67);
+    CHECK(midi.message(1).getVelocity() == 73);
+}
+
+TEST_CASE("Arpeggiator forwards buffer panic even with no sounding note",
+          "[arpeggiator][midi][input]") {
+    Rig rig;
+    auto midi = rig.run(0.0, {}, false, true);
+    CHECK(midi.isAllNotesOff());
+    CHECK(midi.size() == 0);
+    CHECK_FALSE(rig.run(0.05, {}, false).isAllNotesOff());
 }
 
 TEST_CASE("Arpeggiator replacing an unlatched chord stops the previous note",

--- a/tests/devices/test_arpeggiator_input.cpp
+++ b/tests/devices/test_arpeggiator_input.cpp
@@ -1,8 +1,7 @@
-#include <algorithm>
 #include <catch2/catch_test_macros.hpp>
 #include <initializer_list>
-#include <vector>
 
+#include "TestDeviceMidiBuffer.hpp"
 #include "magda/daw/audio/plugins/ArpeggiatorPlugin.hpp"
 
 namespace {
@@ -12,48 +11,19 @@ using Arp = audio::ArpeggiatorPlugin;
 // Like the Tracktion view, additions may invalidate references. Also detect
 // writes before clear deterministically, without depending on a freed read
 // happening to return the wrong note on a particular allocator.
-class MidiBuffer final : public audio::DeviceMidiBuffer {
+class MidiBuffer final : public magda::test::DeviceMidiBuffer {
   public:
-    std::vector<audio::DeviceMidiEvent> events;
     bool cleared = false;
     int additionsBeforeClear = 0;
-    bool allNotesOff = false;
 
-    int size() const override {
-        return static_cast<int>(events.size());
-    }
-    const juce::MidiMessage& message(int index) const override {
-        return events.at(index).message;
-    }
-    std::uint32_t sourceId(int index) const override {
-        return events.at(index).sourceId;
-    }
-    void setEvent(int index, audio::DeviceMidiEvent event) override {
-        events.at(index) = event;
-    }
-    void removeEvent(int index) override {
-        events.erase(events.begin() + index);
-    }
     void addEvent(audio::DeviceMidiEvent event) override {
         if (!cleared)
             ++additionsBeforeClear;
-        events.push_back(event);
+        magda::test::DeviceMidiBuffer::addEvent(std::move(event));
     }
     void clear() override {
-        events.clear();
+        magda::test::DeviceMidiBuffer::clear();
         cleared = true;
-        allNotesOff = false;
-    }
-    void sortByTimestamp() override {
-        std::stable_sort(events.begin(), events.end(), [](const auto& a, const auto& b) {
-            return a.message.getTimeStamp() < b.message.getTimeStamp();
-        });
-    }
-    bool isAllNotesOff() const override {
-        return allNotesOff;
-    }
-    void setAllNotesOff(bool value) override {
-        allNotesOff = value;
     }
 };
 

--- a/tests/devices/test_arpeggiator_input.cpp
+++ b/tests/devices/test_arpeggiator_input.cpp
@@ -1,0 +1,187 @@
+#include <algorithm>
+#include <catch2/catch_test_macros.hpp>
+#include <initializer_list>
+#include <vector>
+
+#include "magda/daw/audio/plugins/ArpeggiatorPlugin.hpp"
+
+namespace {
+namespace audio = magda::daw::audio;
+using Arp = audio::ArpeggiatorPlugin;
+
+// Like the Tracktion view, additions may invalidate references. Also detect
+// writes before clear deterministically, without depending on a freed read
+// happening to return the wrong note on a particular allocator.
+class MidiBuffer final : public audio::DeviceMidiBuffer {
+  public:
+    std::vector<audio::DeviceMidiEvent> events;
+    bool cleared = false;
+    int additionsBeforeClear = 0;
+    bool allNotesOff = false;
+
+    int size() const override {
+        return static_cast<int>(events.size());
+    }
+    const juce::MidiMessage& message(int index) const override {
+        return events.at(index).message;
+    }
+    std::uint32_t sourceId(int index) const override {
+        return events.at(index).sourceId;
+    }
+    void setEvent(int index, audio::DeviceMidiEvent event) override {
+        events.at(index) = event;
+    }
+    void removeEvent(int index) override {
+        events.erase(events.begin() + index);
+    }
+    void addEvent(audio::DeviceMidiEvent event) override {
+        if (!cleared)
+            ++additionsBeforeClear;
+        events.push_back(event);
+    }
+    void clear() override {
+        events.clear();
+        cleared = true;
+        allNotesOff = false;
+    }
+    void sortByTimestamp() override {
+        std::stable_sort(events.begin(), events.end(), [](const auto& a, const auto& b) {
+            return a.message.getTimeStamp() < b.message.getTimeStamp();
+        });
+    }
+    bool isAllNotesOff() const override {
+        return allNotesOff;
+    }
+    void setAllNotesOff(bool value) override {
+        allNotesOff = value;
+    }
+};
+
+class Tempo final : public audio::DeviceTempoMap {
+  public:
+    double beatsAtSeconds(double seconds) const override {
+        return seconds * 2.0;
+    }
+    double bpmAtSeconds(double) const override {
+        return 120.0;
+    }
+};
+
+struct Rig {
+    Arp arp;
+    Tempo tempo;
+
+    explicit Rig(bool latch = false) {
+        arp.prepare({.sampleRate = 48000.0, .maximumBlockSize = 2400});
+        arp.setParameterValue(Arp::kLatch, latch ? 1.0f : 0.0f);
+        arp.setParameterValue(Arp::kGate, 1.0f);
+        arp.setParameterValue(
+            Arp::kRate, magda::ParameterUtils::realToNormalized(
+                            static_cast<float>(Arp::Rate::Quarter), arp.parameterInfo(Arp::kRate)));
+    }
+
+    MidiBuffer run(double start, std::initializer_list<juce::MidiMessage> input = {},
+                   bool playing = true) {
+        MidiBuffer midi;
+        for (const auto& message : input)
+            midi.events.push_back({message, 42});
+        midi.events.shrink_to_fit();
+        audio::DeviceProcessContext context;
+        context.midi = &midi;
+        context.tempoMap = &tempo;
+        context.numSamples = 2400;
+        context.timelineStartSeconds = start;
+        context.timelineEndSeconds = start + 0.05;
+        context.isPlaying = playing;
+        arp.process(context);
+        CHECK(midi.additionsBeforeClear == 0);
+        return midi;
+    }
+
+    void startNote() {
+        auto midi = run(0.0, {juce::MidiMessage::noteOn(1, 60, juce::uint8{91})});
+        REQUIRE(midi.size() == 1);
+        REQUIRE(midi.message(0).isNoteOn());
+        REQUIRE(midi.message(0).getNoteNumber() == 60);
+    }
+};
+
+void checkOff(const MidiBuffer& midi, int index = 0) {
+    REQUIRE(midi.size() > index);
+    CHECK(midi.message(index).isNoteOff());
+    CHECK(midi.message(index).getNoteNumber() == 60);
+    CHECK(midi.message(index).getChannel() == 1);
+    CHECK(midi.message(index).getTimeStamp() == 0.0);
+}
+}  // namespace
+
+TEST_CASE("Arpeggiator latch replacement preserves the old note-off and new input",
+          "[arpeggiator][midi][input]") {
+    Rig rig(true);
+    rig.startNote();
+    REQUIRE(rig.run(0.05, {juce::MidiMessage::noteOff(1, 60)}).size() == 0);
+
+    auto midi = rig.run(0.5, {juce::MidiMessage::noteOn(1, 67, juce::uint8{73})});
+    REQUIRE(midi.size() == 2);
+    checkOff(midi);
+    CHECK(midi.message(1).isNoteOn());
+    CHECK(midi.message(1).getNoteNumber() == 67);
+    CHECK(midi.message(1).getVelocity() == 73);
+}
+
+TEST_CASE("Arpeggiator upstream panic stops its sounding note exactly once",
+          "[arpeggiator][midi][input]") {
+    for (int controller : {120, 123}) {
+        INFO("controller " << controller);
+        Rig rig;
+        rig.startNote();
+        auto midi = rig.run(0.05, {juce::MidiMessage::controllerEvent(1, controller, 0)});
+        REQUIRE(midi.size() == 1);
+        checkOff(midi);
+        CHECK(rig.run(0.1).size() == 0);
+        CHECK(rig.run(0.5).size() == 0);
+    }
+}
+
+TEST_CASE("Arpeggiator input resets retain a single pending note-off",
+          "[arpeggiator][midi][input]") {
+    Rig rig(true);
+    rig.startNote();
+    rig.run(0.05, {juce::MidiMessage::noteOff(1, 60)});
+    auto midi = rig.run(0.5, {juce::MidiMessage::noteOn(1, 64, juce::uint8{80}),
+                              juce::MidiMessage::allNotesOff(1), juce::MidiMessage::allSoundOff(1),
+                              juce::MidiMessage::noteOn(1, 67, juce::uint8{73})});
+    REQUIRE(midi.size() == 2);
+    checkOff(midi);
+    CHECK(midi.message(1).isNoteOn());
+    CHECK(midi.message(1).getNoteNumber() == 67);
+    CHECK(midi.message(1).getVelocity() == 73);
+}
+
+TEST_CASE("Arpeggiator replacing an unlatched chord stops the previous note",
+          "[arpeggiator][midi][input]") {
+    Rig rig;
+    rig.startNote();
+    auto midi = rig.run(0.5, {juce::MidiMessage::noteOff(1, 60),
+                              juce::MidiMessage::noteOn(1, 67, juce::uint8{73})});
+    REQUIRE(midi.size() == 2);
+    checkOff(midi);
+    CHECK(midi.message(1).isNoteOn());
+    CHECK(midi.message(1).getNoteNumber() == 67);
+}
+
+TEST_CASE("Arpeggiator release and transport stop still send one note-off",
+          "[arpeggiator][midi][input]") {
+    Rig rig;
+    rig.startNote();
+    MidiBuffer midi;
+    SECTION("release") {
+        midi = rig.run(0.05, {juce::MidiMessage::noteOff(1, 60)});
+    }
+    SECTION("transport stop") {
+        midi = rig.run(0.05, {}, false);
+    }
+    REQUIRE(midi.size() == 1);
+    checkOff(midi);
+    CHECK(rig.run(0.1, {}, false).size() == 0);
+}

--- a/tests/devices/test_device_sdk_handles.cpp
+++ b/tests/devices/test_device_sdk_handles.cpp
@@ -5,6 +5,7 @@
 #include <utility>
 #include <vector>
 
+#include "TestDeviceMidiBuffer.hpp"
 #include "audio/plugins/DeviceParameterHandle.hpp"
 #include "audio/plugins/DevicePluginHandle.hpp"
 #include "audio/plugins/MagdaDevice.hpp"
@@ -146,44 +147,7 @@ TEST_CASE("MagdaDevice owns telemetry independently of a host plugin lifecycle",
 
 TEST_CASE("MagdaDevice lifecycle, state, parameters, audio, and MIDI need no host plugin",
           "[device-sdk]") {
-    class MidiBuffer final : public audio::DeviceMidiBuffer {
-      public:
-        int size() const override {
-            return static_cast<int>(events.size());
-        }
-        const juce::MidiMessage& message(int index) const override {
-            return events[static_cast<std::size_t>(index)].message;
-        }
-        std::uint32_t sourceId(int index) const override {
-            return events[static_cast<std::size_t>(index)].sourceId;
-        }
-        void setEvent(int index, audio::DeviceMidiEvent event) override {
-            events[static_cast<std::size_t>(index)] = std::move(event);
-        }
-        void removeEvent(int index) override {
-            events.erase(events.begin() + index);
-        }
-        void addEvent(audio::DeviceMidiEvent event) override {
-            events.push_back(std::move(event));
-        }
-        void clear() override {
-            events.clear();
-        }
-        void sortByTimestamp() override {
-            std::sort(events.begin(), events.end(), [](const auto& left, const auto& right) {
-                return left.message.getTimeStamp() < right.message.getTimeStamp();
-            });
-        }
-        bool isAllNotesOff() const override {
-            return allNotesOff;
-        }
-        void setAllNotesOff(bool value) override {
-            allNotesOff = value;
-        }
-
-        std::vector<audio::DeviceMidiEvent> events;
-        bool allNotesOff = false;
-    };
+    using MidiBuffer = magda::test::DeviceMidiBuffer;
 
     class TestDevice final : public audio::MagdaDevice {
       public:


### PR DESCRIPTION
Latch replacement could append a note-off while holding a reference into the MIDI input buffer, invalidating that reference when the Tracktion buffer reallocates. Clearing the input then discarded the note-off. CC120/CC123 and same-block unlatched chord replacement could also reset the arp while forgetting a sounding note. Host panic delivered through the buffer-level all-notes-off flag was ignored and erased by the clear.

Keep the input scan read-only and capture the sounding note as part of each input-triggered reset. Emit its note-off after clearing the buffer, before generating new output. Process buffer-level panic before fresh input and preserve the flag downstream, including when no arp note is sounding. Repeated resets in one block retain exactly one pending note-off. The step scheduler and transport-stop behavior are unchanged; the misleading loop-boundary comment is corrected.

Closes #2361.

Validation:

- 169 assertions across 13 focused arpeggiator, device SDK, and engine device tests passed.
- Coverage includes latch replacement, pitch/velocity preservation, CC120/CC123, buffer-level panic, fresh input after panic, repeated resets, unlatched chord replacement, release, and transport stop.
- The CC120 regression fails against the original implementation because it produces no note-off. All three buffer-panic regressions fail before the follow-up fix. All pass with the fixes applied.
- Pre-commit checks passed.

Sounding-note cleanup is shared by resets and immediate note-offs. Removed write-only state and extracted shared device MIDI test storage.

Review follow-ups tracked separately:

- #2415: event-accurate input scheduling and note-off ordering.
- #2416: seeks, loops, and held-key/free-run behavior across transport changes.
- #2417: non-note MIDI passthrough with metadata and capacity handling.
