### PR TITLE
Apply modernize-loop-convert fixes across magda/

### DIFF
--- a/magda/agents/command_model_downloader.cpp
+++ b/magda/agents/command_model_downloader.cpp
@@ -78,12 +78,12 @@ class CommandModelDownloader::Worker : public juce::Thread {
             }
         }
 
-        for (int i = 0; i < kNumFiles; ++i) {
-            p.currentFilename = kFiles[i].filename;
+        for (auto kFile : kFiles) {
+            p.currentFilename = kFile.filename;
             p.phase = Phase::Downloading;
             postProgress(p);
 
-            if (!downloadOne(kFiles[i], p)) {
+            if (!downloadOne(kFile, p)) {
                 p.phase = threadShouldExit() ? Phase::Cancelled : Phase::Failed;
                 postProgress(p);
                 return;
@@ -203,8 +203,8 @@ juce::File CommandModelDownloader::modelsDir() {
 std::vector<juce::File> CommandModelDownloader::modelFiles() {
     std::vector<juce::File> files;
     files.reserve(static_cast<size_t>(kNumFiles));
-    for (int i = 0; i < kNumFiles; ++i)
-        files.push_back(modelsDir().getChildFile(kFiles[i].filename));
+    for (auto kFile : kFiles)
+        files.push_back(modelsDir().getChildFile(kFile.filename));
     return files;
 }
 
@@ -217,9 +217,9 @@ const char* CommandModelDownloader::sourceUrl() {
 }
 
 bool CommandModelDownloader::isInstalled() {
-    for (int i = 0; i < kNumFiles; ++i) {
-        auto f = modelsDir().getChildFile(kFiles[i].filename);
-        if (!f.existsAsFile() || f.getSize() != kFiles[i].size)
+    for (auto kFile : kFiles) {
+        auto f = modelsDir().getChildFile(kFile.filename);
+        if (!f.existsAsFile() || f.getSize() != kFile.size)
             return false;
     }
     return true;
@@ -227,8 +227,8 @@ bool CommandModelDownloader::isInstalled() {
 
 juce::int64 CommandModelDownloader::expectedTotalBytes() {
     juce::int64 total = 0;
-    for (int i = 0; i < kNumFiles; ++i)
-        total += kFiles[i].size;
+    for (auto kFile : kFiles)
+        total += kFile.size;
     return total;
 }
 

--- a/magda/agents/dsl_interpreter.cpp
+++ b/magda/agents/dsl_interpreter.cpp
@@ -6,6 +6,7 @@
 #include <cmath>
 #include <cstdlib>
 #include <random>
+#include <ranges>
 #include <sstream>
 
 #include "../daw/api/clip_api.hpp"
@@ -1142,8 +1143,8 @@ bool Interpreter::executeDelete() {
     if (ctx_.inFilterContext) {
         // Delete in reverse order to avoid index shifting issues
         auto ids = ctx_.filteredTrackIds;
-        for (auto it = ids.rbegin(); it != ids.rend(); ++it)
-            tm.deleteTrack(*it);
+        for (int& id : std::views::reverse(ids))
+            tm.deleteTrack(id);
         ctx_.addResult("Deleted " + juce::String(static_cast<int>(ids.size())) + " track(s)");
         ctx_.filteredTrackIds.clear();
     } else if (ctx_.currentTrackId >= 0) {
@@ -2890,8 +2891,8 @@ bool Interpreter::executeGrooveExtract(const Params& params) {
     std::vector<float> latenesses(static_cast<size_t>(numSteps), 0.0f);
     std::vector<bool> hasTransient(static_cast<size_t>(numSteps), false);
 
-    for (int i = 0; i < transients->size(); ++i) {
-        double transientSec = (*transients)[i] - clipStartSec;
+    for (double transient : *transients) {
+        double transientSec = transient - clipStartSec;
         if (transientSec < 0.0 || transientSec >= clipLengthSec)
             continue;
 

--- a/magda/daw/audio/AudioBridge.cpp
+++ b/magda/daw/audio/AudioBridge.cpp
@@ -1557,8 +1557,8 @@ void AudioBridge::ensureSessionMonitorPlugin() {
     auto& masterList = edit_.getMasterPluginList();
 
     // Check if a SessionMonitorPlugin already exists
-    for (int i = 0; i < masterList.size(); ++i) {
-        if (auto* existing = dynamic_cast<SessionMonitorPlugin*>(masterList[i])) {
+    for (auto i : masterList) {
+        if (auto* existing = dynamic_cast<SessionMonitorPlugin*>(i)) {
             sessionMonitorPlugin_ = existing;
             sessionMonitorPlugin_->setSessionContext(&sessionAudioMonitor_);
             return;
@@ -1571,8 +1571,8 @@ void AudioBridge::ensureSessionMonitorPlugin() {
     masterList.insertPlugin(pluginState, 0);
 
     // Find the newly created plugin
-    for (int i = 0; i < masterList.size(); ++i) {
-        if (auto* mon = dynamic_cast<SessionMonitorPlugin*>(masterList[i])) {
+    for (auto i : masterList) {
+        if (auto* mon = dynamic_cast<SessionMonitorPlugin*>(i)) {
             sessionMonitorPlugin_ = mon;
             sessionMonitorPlugin_->setSessionContext(&sessionAudioMonitor_);
             return;

--- a/magda/daw/audio/plugin_manager/PluginManager.cpp
+++ b/magda/daw/audio/plugin_manager/PluginManager.cpp
@@ -692,8 +692,8 @@ void PluginManager::validateMappingConsistency() {
             if (devicePath.trackId == MASTER_TRACK_ID) {
                 const auto& masterList = edit_.getMasterPluginList();
                 bool foundOnMaster = false;
-                for (int i = 0; i < masterList.size(); ++i) {
-                    if (masterList[i] == sd.plugin.get()) {
+                for (auto i : masterList) {
+                    if (i == sd.plugin.get()) {
                         foundOnMaster = true;
                         break;
                     }

--- a/magda/daw/audio/plugin_manager/PluginManagerMeasurement.cpp
+++ b/magda/daw/audio/plugin_manager/PluginManagerMeasurement.cpp
@@ -38,9 +38,9 @@ daw::audio::TrackMeasurementPlugin* PluginManager::ensureTrackMeasurementTap(Tra
         return nullptr;
 
     // Adopt an existing tap if one is already on the chain (e.g. after restore).
-    for (int i = 0; i < list->size(); ++i) {
-        if (auto* existing = dynamic_cast<daw::audio::TrackMeasurementPlugin*>((*list)[i])) {
-            trackMeasurementTaps_[trackId] = (*list)[i];
+    for (auto i : *list) {
+        if (auto* existing = dynamic_cast<daw::audio::TrackMeasurementPlugin*>(i)) {
+            trackMeasurementTaps_[trackId] = i;
             return existing;
         }
     }

--- a/magda/daw/audio/plugin_manager/PluginManagerModifiers.cpp
+++ b/magda/daw/audio/plugin_manager/PluginManagerModifiers.cpp
@@ -74,16 +74,16 @@ void PluginManager::updateDeviceModifierProperties(TrackId trackId) {
     std::function<void(const std::function<void(te::Plugin*)>&)> visitHostPlugins;
     if (teTrack) {
         visitHostPlugins = [teTrack](const std::function<void(te::Plugin*)>& visit) {
-            for (int pi = 0; pi < teTrack->pluginList.size(); ++pi) {
-                if (auto* plugin = teTrack->pluginList[pi])
+            for (auto plugin : teTrack->pluginList) {
+                if (plugin)
                     visit(plugin);
             }
         };
     } else if (trackId == MASTER_TRACK_ID && edit_.getMasterTrack()) {
         visitHostPlugins = [this](const std::function<void(te::Plugin*)>& visit) {
             const auto& masterList = edit_.getMasterPluginList();
-            for (int pi = 0; pi < masterList.size(); ++pi) {
-                if (auto* plugin = masterList[pi])
+            for (auto plugin : masterList) {
+                if (plugin)
                     visit(plugin);
             }
         };
@@ -1077,8 +1077,8 @@ void PluginManager::resyncDeviceModifiers(TrackId trackId) {
         defaultModifierList = teTrack->getModifierList();
         macroList = &teTrack->getMacroParameterListForWriting();
         visitHostPlugins = [teTrack](const std::function<void(te::Plugin*)>& visit) {
-            for (int pi = 0; pi < teTrack->pluginList.size(); ++pi) {
-                if (auto* plugin = teTrack->pluginList[pi])
+            for (auto plugin : teTrack->pluginList) {
+                if (plugin)
                     visit(plugin);
             }
         };
@@ -1090,8 +1090,8 @@ void PluginManager::resyncDeviceModifiers(TrackId trackId) {
             // null macro host as unsupported master macros.
             visitHostPlugins = [this](const std::function<void(te::Plugin*)>& visit) {
                 const auto& masterList = edit_.getMasterPluginList();
-                for (int pi = 0; pi < masterList.size(); ++pi) {
-                    if (auto* plugin = masterList[pi])
+                for (auto plugin : masterList) {
+                    if (plugin)
                         visit(plugin);
                 }
             };

--- a/magda/daw/audio/plugin_manager/PluginManagerSidechain.cpp
+++ b/magda/daw/audio/plugin_manager/PluginManagerSidechain.cpp
@@ -174,12 +174,12 @@ void PluginManager::ensureSidechainMonitor(TrackId sourceTrackId) {
     }
 
     // Check if a SidechainMonitorPlugin already exists on the track
-    for (int i = 0; i < teTrack->pluginList.size(); ++i) {
-        if (dynamic_cast<SidechainMonitorPlugin*>(teTrack->pluginList[i])) {
+    for (auto i : teTrack->pluginList) {
+        if (dynamic_cast<SidechainMonitorPlugin*>(i)) {
             DBG("PluginManager::ensureSidechainMonitor - track "
                 << sourceTrackId << " found existing monitor plugin on TE track");
-            sidechainMonitors_[sourceTrackId] = teTrack->pluginList[i];
-            auto* mon = dynamic_cast<SidechainMonitorPlugin*>(teTrack->pluginList[i]);
+            sidechainMonitors_[sourceTrackId] = i;
+            auto* mon = dynamic_cast<SidechainMonitorPlugin*>(i);
             mon->setSourceTrackId(sourceTrackId);
             mon->setRealtimeContext(this);
             return;

--- a/magda/daw/audio/plugin_manager/PluginManagerSync.cpp
+++ b/magda/daw/audio/plugin_manager/PluginManagerSync.cpp
@@ -680,8 +680,8 @@ void PluginManager::syncTrackPlugins(TrackId trackId) {
             if (rackInstance) {
                 // Check if this rack instance is already on the track
                 bool alreadyOnTrack = false;
-                for (int i = 0; i < teTrack->pluginList.size(); ++i) {
-                    if (teTrack->pluginList[i] == rackInstance.get()) {
+                for (auto i : teTrack->pluginList) {
+                    if (i == rackInstance.get()) {
                         alreadyOnTrack = true;
                         break;
                     }
@@ -730,8 +730,8 @@ void PluginManager::syncTrackPlugins(TrackId trackId) {
     // Any track with auxBusIndex: ensure AuxReturnPlugin exists with correct bus number
     if (trackInfo->auxBusIndex >= 0) {
         bool hasReturn = false;
-        for (int i = 0; i < teTrack->pluginList.size(); ++i) {
-            if (dynamic_cast<te::AuxReturnPlugin*>(teTrack->pluginList[i])) {
+        for (auto i : teTrack->pluginList) {
+            if (dynamic_cast<te::AuxReturnPlugin*>(i)) {
                 hasReturn = true;
                 break;
             }
@@ -763,8 +763,8 @@ void PluginManager::syncTrackPlugins(TrackId trackId) {
     syncDeviceModifiers(trackId, teTrack->getModifierList(),
                         &teTrack->getMacroParameterListForWriting(),
                         [teTrack](const std::function<void(te::Plugin*)>& visit) {
-                            for (int pi = 0; pi < teTrack->pluginList.size(); ++pi) {
-                                if (auto* plugin = teTrack->pluginList[pi])
+                            for (auto plugin : teTrack->pluginList) {
+                                if (plugin)
                                     visit(plugin);
                             }
                         });
@@ -996,15 +996,15 @@ void PluginManager::cleanupTrackPlugins(TrackId trackId) {
     }
 
     // 3. Delete plugins and close windows outside lock
-    for (size_t i = 0; i < devicePaths.size(); ++i) {
-        const auto deviceId = devicePaths[i].getDeviceId();
+    for (const auto& devicePath : devicePaths) {
+        const auto deviceId = devicePath.getDeviceId();
         pluginWindowBridge_.closeWindowsForDevice(deviceId);
 
         // Unwrap instrument racks
-        if (canOwnInstrumentWrapper(devicePaths[i]) &&
+        if (canOwnInstrumentWrapper(devicePath) &&
             instrumentRackManager_.getInnerPlugin(deviceId) != nullptr) {
             instrumentRackManager_.unwrap(deviceId);
-        } else if (auto it = pluginsToDelete.find(devicePaths[i]); it != pluginsToDelete.end()) {
+        } else if (auto it = pluginsToDelete.find(devicePath); it != pluginsToDelete.end()) {
             if (it->second)
                 it->second->deleteFromParent();
         }
@@ -1382,8 +1382,8 @@ void PluginManager::reconcileSends(const TrackInfo& trackInfo, te::AudioTrack& t
     // appendStripOrder could not show, because it can only order plugins that
     // are already there.
     std::vector<int> existingSendBuses;
-    for (int i = 0; i < track.pluginList.size(); ++i)
-        if (auto* auxSend = dynamic_cast<te::AuxSendPlugin*>(track.pluginList[i]))
+    for (auto i : track.pluginList)
+        if (auto* auxSend = dynamic_cast<te::AuxSendPlugin*>(i))
             existingSendBuses.push_back(auxSend->getBusNumber());
 
     std::vector<int> desiredBuses;
@@ -1418,8 +1418,8 @@ void PluginManager::reconcileSends(const TrackInfo& trackInfo, te::AudioTrack& t
     }
 
     for (const auto& send : trackInfo.sends) {
-        for (int i = 0; i < track.pluginList.size(); ++i) {
-            if (auto* auxSend = dynamic_cast<te::AuxSendPlugin*>(track.pluginList[i]);
+        for (auto i : track.pluginList) {
+            if (auto* auxSend = dynamic_cast<te::AuxSendPlugin*>(i);
                 auxSend != nullptr && auxSend->getBusNumber() == send.busIndex) {
                 auxSend->setGainDb(juce::Decibels::gainToDecibels(send.level));
                 break;
@@ -1468,8 +1468,8 @@ void PluginManager::appendStripOrder(TrackId trackId, const TrackInfo& trackInfo
         for (const auto& send : trackInfo.sends) {
             if (send.preFader != preFader)
                 continue;
-            for (int i = 0; i < track.pluginList.size(); ++i) {
-                if (auto* aux = dynamic_cast<te::AuxSendPlugin*>(track.pluginList[i]);
+            for (auto i : track.pluginList) {
+                if (auto* aux = dynamic_cast<te::AuxSendPlugin*>(i);
                     aux != nullptr && aux->getBusNumber() == send.busIndex) {
                     desiredOrder.push_back(aux);
                     break;
@@ -1603,8 +1603,8 @@ std::unordered_set<te::Plugin*> PluginManager::collectPostFaderPlugins(
     for (const auto& send : trackInfo->sends) {
         if (send.preFader)
             continue;
-        for (int i = 0; i < track.pluginList.size(); ++i)
-            if (auto* aux = dynamic_cast<te::AuxSendPlugin*>(track.pluginList[i]);
+        for (auto i : track.pluginList)
+            if (auto* aux = dynamic_cast<te::AuxSendPlugin*>(i);
                 aux != nullptr && aux->getBusNumber() == send.busIndex)
                 result.insert(aux);
     }
@@ -1734,8 +1734,8 @@ void PluginManager::syncMultiOutTrack(TrackId trackId, const TrackInfo& trackInf
             link.sourceDeviceId, link.outputPairIndex, outPair.firstPin, outPair.numChannels);
         if (rackInstance) {
             bool alreadyOnTrack = false;
-            for (int i = 0; i < teTrack->pluginList.size(); ++i) {
-                if (teTrack->pluginList[i] == rackInstance.get()) {
+            for (auto i : teTrack->pluginList) {
+                if (i == rackInstance.get()) {
                     alreadyOnTrack = true;
                     break;
                 }
@@ -1921,8 +1921,8 @@ void PluginManager::syncMasterPlugins() {
                 continue;
             // Check if plugin belongs to master plugin list
             bool belongsToMaster = false;
-            for (int i = 0; i < masterList.size(); ++i) {
-                if (masterList[i] == sd.plugin.get()) {
+            for (auto i : masterList) {
+                if (i == sd.plugin.get()) {
                     belongsToMaster = true;
                     break;
                 }
@@ -1939,8 +1939,8 @@ void PluginManager::syncMasterPlugins() {
         deferredHolders_.clear();  // Drain previous cycle's deferred holders
         std::vector<te::Plugin*> scopePlugins;
         scopePlugins.reserve(masterList.size());
-        for (int i = 0; i < masterList.size(); ++i) {
-            if (auto* plugin = masterList[i])
+        for (auto plugin : masterList) {
+            if (plugin)
                 scopePlugins.push_back(plugin);
         }
         for (const auto& devicePath : toRemove) {

--- a/magda/daw/audio/plugins/FaustUIHarvester.cpp
+++ b/magda/daw/audio/plugins/FaustUIHarvester.cpp
@@ -1,5 +1,6 @@
 #include "FaustUIHarvester.hpp"
 
+#include <ranges>
 #include <utility>
 
 namespace magda::daw::audio {
@@ -40,10 +41,10 @@ ControlMetadata FaustUIHarvester::mergedMetadataFor(FAUSTFLOAT* zone) {
 }
 
 bool FaustUIHarvester::isInsidePolyProxyGroup() const {
-    for (auto it = groupLabelStack_.rbegin(); it != groupLabelStack_.rend(); ++it) {
-        if (*it == "Voices")
+    for (const auto& it : std::views::reverse(groupLabelStack_)) {
+        if (it == "Voices")
             return true;
-        if (isPolyVoiceGroup(*it))
+        if (isPolyVoiceGroup(it))
             return false;
     }
     return false;

--- a/magda/daw/audio/plugins/InsertCapturePlugin.cpp
+++ b/magda/daw/audio/plugins/InsertCapturePlugin.cpp
@@ -122,8 +122,8 @@ void InsertCapturePlugin::stopCapture(bool keepFile) {
 bool InsertCapturePlugin::writeSilence(juce::AudioFormatWriter::ThreadedWriter& writer,
                                        juce::int64 numSamples) {
     const float* chans[kNumChannels];
-    for (int c = 0; c < kNumChannels; ++c)
-        chans[c] = zeroBuf_.data();
+    for (auto& chan : chans)
+        chan = zeroBuf_.data();
 
     while (numSamples > 0) {
         const auto chunk = std::min(numSamples, static_cast<juce::int64>(zeroBuf_.size()));

--- a/magda/daw/audio/plugins/compiled/MagdaCompiledPolyInstrument.cpp
+++ b/magda/daw/audio/plugins/compiled/MagdaCompiledPolyInstrument.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <cmath>
 #include <map>
+#include <ranges>
 
 #include "core/ParameterUtils.hpp"
 #include "faust/dsp/dsp.h"
@@ -81,11 +82,12 @@ class PolyVoiceHarvester : public ::UI {
     }
 
     bool inProxyGroup() const {
-        for (auto it = groupLabels_.rbegin(); it != groupLabels_.rend(); ++it) {
-            if (*it == "Voices")
+        for (const auto& groupLabel : std::views::reverse(groupLabels_)) {
+            if (groupLabel == "Voices")
                 return true;
-            if (it->startsWith("Voice") || (it->length() >= 2 && (*it)[0] == 'V' &&
-                                            juce::CharacterFunctions::isDigit((*it)[1])))
+            if (groupLabel.startsWith("Voice") ||
+                (groupLabel.length() >= 2 && groupLabel[0] == 'V' &&
+                 juce::CharacterFunctions::isDigit(groupLabel[1])))
                 return false;
         }
         return false;

--- a/magda/daw/audio/plugins/mutable/MutableCloudsPlugin.cpp
+++ b/magda/daw/audio/plugins/mutable/MutableCloudsPlugin.cpp
@@ -355,8 +355,8 @@ struct MutableCloudsPlugin::Impl {
         }
         processor_.Prepare();
         processor_.Process(in, out, static_cast<size_t>(kBlock));
-        for (int j = 0; j < kBlock; ++j)
-            wet32k_.push(shortToFloat(out[j].l), shortToFloat(out[j].r));
+        for (auto& j : out)
+            wet32k_.push(shortToFloat(j.l), shortToFloat(j.r));
     }
 
     clouds::GranularProcessor processor_;

--- a/magda/daw/core/AutomationCommands.cpp
+++ b/magda/daw/core/AutomationCommands.cpp
@@ -1,6 +1,7 @@
 #include "AutomationCommands.hpp"
 
 #include <algorithm>
+#include <ranges>
 
 #include "LinkModeManager.hpp"
 #include "TrackManager.hpp"
@@ -696,8 +697,8 @@ void DuplicateAutomationTimeSelectionCommand::undo() {
 
     auto& mgr = AutomationManager::getInstance();
     AutomationManager::BatchScope batch;
-    for (auto it = insertedPoints_.rbegin(); it != insertedPoints_.rend(); ++it) {
-        mgr.deletePoint(it->laneId, it->pointId);
+    for (auto& insertedPoint : std::views::reverse(insertedPoints_)) {
+        mgr.deletePoint(insertedPoint.laneId, insertedPoint.pointId);
     }
     insertedPoints_.clear();
 }
@@ -778,8 +779,9 @@ void InsertTimeAutomationCommand::undo() {
     auto& mgr = AutomationManager::getInstance();
     AutomationManager::BatchScope batch;
     // Move leftmost first so each original beat is empty as we restore it.
-    for (auto it = shiftedPoints_.rbegin(); it != shiftedPoints_.rend(); ++it) {
-        mgr.movePoint(it->laneId, it->pointId, it->oldBeat, it->value);
+    for (auto& shiftedPoint : std::views::reverse(shiftedPoints_)) {
+        mgr.movePoint(shiftedPoint.laneId, shiftedPoint.pointId, shiftedPoint.oldBeat,
+                      shiftedPoint.value);
     }
     shiftedPoints_.clear();
 }

--- a/magda/daw/core/ChainWalk.hpp
+++ b/magda/daw/core/ChainWalk.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <ranges>
 #include <type_traits>
 #include <vector>
 
@@ -89,9 +90,9 @@ enum class Descend { Into, Skip };
 /// own walk; deriving it once is what makes a disagreement between them
 /// impossible rather than untested (#2204).
 inline RackId owningRackId(const ChainNodePath& path) {
-    for (auto it = path.steps.rbegin(); it != path.steps.rend(); ++it)
-        if (it->type == ChainStepType::Rack || it->type == ChainStepType::PadRack)
-            return it->id;
+    for (auto step : std::views::reverse(path.steps))
+        if (step.type == ChainStepType::Rack || step.type == ChainStepType::PadRack)
+            return step.id;
     return INVALID_RACK_ID;
 }
 

--- a/magda/daw/core/ClipOcclusion.cpp
+++ b/magda/daw/core/ClipOcclusion.cpp
@@ -1,6 +1,7 @@
 #include "ClipOcclusion.hpp"
 
 #include <algorithm>
+#include <ranges>
 
 namespace magda {
 
@@ -121,9 +122,9 @@ std::unordered_map<ClipId, AudibleSpan> computeAudibleSpans(
             if (cover.start.value <= start + kTolBeats)
                 start = std::max(start, cover.end.value);
         }
-        for (auto it = covers.rbegin(); it != covers.rend(); ++it) {
-            if (it->end.value >= end - kTolBeats)
-                end = std::min(end, it->start.value);
+        for (auto& cover : std::views::reverse(covers)) {
+            if (cover.end.value >= end - kTolBeats)
+                end = std::min(end, cover.start.value);
         }
 
         if (end <= start + kTolBeats) {

--- a/magda/daw/core/MidiNoteCommands.cpp
+++ b/magda/daw/core/MidiNoteCommands.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <cmath>
 #include <limits>
+#include <ranges>
 
 #include "ClipOperations.hpp"
 #include "audio/sequencer/StepClock.hpp"
@@ -844,8 +845,7 @@ void QuantizeMidiNotesCommand::execute() {
     }
 
     // Apply quantization
-    for (size_t i = 0; i < noteIndices_.size(); ++i) {
-        size_t index = noteIndices_[i];
+    for (size_t index : noteIndices_) {
         if (index >= clip->midiNotes.size()) {
             continue;
         }
@@ -944,10 +944,10 @@ void DeleteMultipleMidiNotesCommand::undo() {
     }
 
     // Re-insert in reverse order (ascending index) to restore original positions
-    for (auto it = deleted_.rbegin(); it != deleted_.rend(); ++it) {
-        size_t insertPos = std::min(it->first, clip->midiNotes.size());
+    for (auto& it : std::views::reverse(deleted_)) {
+        size_t insertPos = std::min(it.first, clip->midiNotes.size());
         clip->midiNotes.insert(clip->midiNotes.begin() + static_cast<std::ptrdiff_t>(insertPos),
-                               it->second);
+                               it.second);
     }
 
     clipManager.forceNotifyClipPropertyChanged(clipId_);
@@ -1451,10 +1451,10 @@ void DeleteMultipleMidiCCEventsCommand::undo() {
         return;
 
     // Re-insert in reverse order (ascending index) to restore original positions
-    for (auto it = deleted_.rbegin(); it != deleted_.rend(); ++it) {
-        size_t insertPos = std::min(it->first, clip->midiCCData.size());
+    for (auto& it : std::views::reverse(deleted_)) {
+        size_t insertPos = std::min(it.first, clip->midiCCData.size());
         clip->midiCCData.insert(clip->midiCCData.begin() + static_cast<std::ptrdiff_t>(insertPos),
-                                it->second);
+                                it.second);
     }
 
     clipManager.forceNotifyClipPropertyChanged(clipId_);
@@ -1660,10 +1660,10 @@ void DeleteMultipleMidiPitchBendEventsCommand::undo() {
         return;
 
     // Re-insert in reverse order (ascending index) to restore original positions
-    for (auto it = deleted_.rbegin(); it != deleted_.rend(); ++it) {
-        size_t insertPos = std::min(it->first, clip->midiPitchBendData.size());
+    for (auto& it : std::views::reverse(deleted_)) {
+        size_t insertPos = std::min(it.first, clip->midiPitchBendData.size());
         clip->midiPitchBendData.insert(
-            clip->midiPitchBendData.begin() + static_cast<std::ptrdiff_t>(insertPos), it->second);
+            clip->midiPitchBendData.begin() + static_cast<std::ptrdiff_t>(insertPos), it.second);
     }
 
     clipManager.forceNotifyClipPropertyChanged(clipId_);

--- a/magda/daw/core/TrackCommands.cpp
+++ b/magda/daw/core/TrackCommands.cpp
@@ -668,12 +668,12 @@ void PasteChainElementsCommand::execute() {
 
 void PasteChainElementsCommand::undo() {
     auto& tm = TrackManager::getInstance();
-    for (auto it = insertedPaths_.rbegin(); it != insertedPaths_.rend(); ++it) {
-        if (it->getType() == ChainNodeType::TopLevelDevice ||
-            it->getType() == ChainNodeType::Device)
-            tm.removeDeviceFromChainByPath(*it);
-        else if (it->getType() == ChainNodeType::Rack)
-            tm.removeRackFromChainByPath(*it);
+    for (auto& insertedPath : std::views::reverse(insertedPaths_)) {
+        if (insertedPath.getType() == ChainNodeType::TopLevelDevice ||
+            insertedPath.getType() == ChainNodeType::Device)
+            tm.removeDeviceFromChainByPath(insertedPath);
+        else if (insertedPath.getType() == ChainNodeType::Rack)
+            tm.removeRackFromChainByPath(insertedPath);
     }
 }
 

--- a/magda/daw/core/TrackManager.cpp
+++ b/magda/daw/core/TrackManager.cpp
@@ -3068,9 +3068,7 @@ TrackManager::ResolvedPath TrackManager::resolvePath(const ChainNodePath& path) 
     const RackInfo* currentRack = nullptr;
     const ChainInfo* currentChain = nullptr;
 
-    for (size_t i = 0; i < path.steps.size(); ++i) {
-        const auto& step = path.steps[i];
-
+    for (auto step : path.steps) {
         switch (step.type) {
             case ChainStepType::PadRack:
             case ChainStepType::Rack: {

--- a/magda/daw/core/TrackManagerDevices.cpp
+++ b/magda/daw/core/TrackManagerDevices.cpp
@@ -1,5 +1,6 @@
 #include <algorithm>
 #include <map>
+#include <ranges>
 #include <set>
 #include <span>
 
@@ -1189,8 +1190,8 @@ RackId TrackManager::wrapChainElementsInRack(const std::vector<ChainNodePath>& p
     for (const auto& [index, _] : orderedPaths)
         chain.elements.push_back(std::move((*sourceElements)[static_cast<size_t>(index)]));
 
-    for (auto it = orderedPaths.rbegin(); it != orderedPaths.rend(); ++it)
-        sourceElements->erase(sourceElements->begin() + it->first);
+    for (auto& orderedPath : std::views::reverse(orderedPaths))
+        sourceElements->erase(sourceElements->begin() + orderedPath.first);
 
     const int insertIndex =
         std::clamp(orderedPaths.front().first, 0, static_cast<int>(sourceElements->size()));

--- a/magda/daw/core/UndoManager.cpp
+++ b/magda/daw/core/UndoManager.cpp
@@ -1,5 +1,7 @@
 #include "UndoManager.hpp"
 
+#include <ranges>
+
 #include "../project/ProjectManager.hpp"
 
 namespace magda {
@@ -214,8 +216,8 @@ void CompoundCommand::execute() {
 
 void CompoundCommand::undo() {
     // Undo all commands in reverse order
-    for (auto it = commands_.rbegin(); it != commands_.rend(); ++it) {
-        (*it)->undo();
+    for (auto& command : std::views::reverse(commands_)) {
+        command->undo();
     }
 }
 

--- a/magda/daw/music/ChordEngine.cpp
+++ b/magda/daw/music/ChordEngine.cpp
@@ -419,8 +419,8 @@ Chord ChordEngine::buildChordInversion(ChordRoot root, ChordQuality quality, int
 
     const int rootMidiNote = static_cast<int>(root) + ((octave + 1) * 12);
 
-    for (size_t i = 0; i < intervals.size(); ++i)
-        notes.emplace_back(rootMidiNote + intervals[i], 100);
+    for (int interval : intervals)
+        notes.emplace_back(rootMidiNote + interval, 100);
 
     const int k = std::max(0, inversion);
     if (k > 0) {

--- a/magda/daw/ui/components/automation/AutomationCurveEditor.cpp
+++ b/magda/daw/ui/components/automation/AutomationCurveEditor.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <ranges>
 
 #include "AutomationLaneComponent.hpp"
 #include "core/AutomationCommands.hpp"
@@ -888,8 +889,8 @@ void AutomationCurveEditor::onDeleteSelectedPoints(const std::set<uint32_t>& poi
 
     {
         CompoundOperationScope scope("Delete Automation Points");
-        for (auto it = pointIds.rbegin(); it != pointIds.rend(); ++it) {
-            onPointDeleted(*it);
+        for (unsigned int pointId : std::views::reverse(pointIds)) {
+            onPointDeleted(pointId);
         }
     }
 

--- a/magda/daw/ui/components/chain/NodeComponent.cpp
+++ b/magda/daw/ui/components/chain/NodeComponent.cpp
@@ -227,26 +227,26 @@ NodeComponent::NodeComponent() {
     addAndMakeVisible(deleteButton_);
 
     // === MOD PANEL CONTROLS ===
-    for (int i = 0; i < 3; ++i) {
-        modSlotButtons_[i] = std::make_unique<juce::TextButton>("+");
-        modSlotButtons_[i]->setColour(juce::TextButton::buttonColourId,
-                                      DarkTheme::getColour(DarkTheme::SURFACE));
-        modSlotButtons_[i]->setColour(juce::TextButton::textColourOffId,
-                                      DarkTheme::getSecondaryTextColour());
-        modSlotButtons_[i]->onClick = [this, i]() {
+    for (auto& modSlotButton : modSlotButtons_) {
+        modSlotButton = std::make_unique<juce::TextButton>("+");
+        modSlotButton->setColour(juce::TextButton::buttonColourId,
+                                 DarkTheme::getColour(DarkTheme::SURFACE));
+        modSlotButton->setColour(juce::TextButton::textColourOffId,
+                                 DarkTheme::getSecondaryTextColour());
+        modSlotButton->onClick = [this, &modSlotButton]() {
             juce::PopupMenu menu;
             menu.addItem(1, "LFO");
             menu.addItem(2, "Bezier LFO");
             menu.addItem(3, "ADSR");
             menu.addItem(4, "Envelope Follower");
-            menu.showMenuAsync(juce::PopupMenu::Options(), [this, i](int result) {
+            menu.showMenuAsync(juce::PopupMenu::Options(), [this, &modSlotButton](int result) {
                 if (result > 0) {
                     juce::StringArray types = {"", "LFO", "BEZ", "ADSR", "ENV"};
-                    modSlotButtons_[i]->setButtonText(types[result]);
+                    modSlotButton->setButtonText(types[result]);
                 }
             });
         };
-        addChildComponent(*modSlotButtons_[i]);
+        addChildComponent(*modSlotButton);
     }
 
     // === PARAM PANEL CONTROLS ===
@@ -1022,9 +1022,9 @@ void NodeComponent::resizedModPanel(juce::Rectangle<int> panelArea) {
     // Default: placeholder mod slot buttons
     panelArea = panelArea.reduced(2);
     int slotHeight = (panelArea.getHeight() - 4) / 3;
-    for (int i = 0; i < 3; ++i) {
-        modSlotButtons_[i]->setBounds(panelArea.removeFromTop(slotHeight).reduced(0, 1));
-        modSlotButtons_[i]->setVisible(true);
+    for (const auto& modSlotButton : modSlotButtons_) {
+        modSlotButton->setBounds(panelArea.removeFromTop(slotHeight).reduced(0, 1));
+        modSlotButton->setVisible(true);
     }
 }
 

--- a/magda/daw/ui/components/chain/ai/AIPanelComponent.cpp
+++ b/magda/daw/ui/components/chain/ai/AIPanelComponent.cpp
@@ -3,6 +3,8 @@
 #include <BinaryData.h>
 #include <juce_llm/juce_llm.h>
 
+#include <ranges>
+
 #include "../../../../agents/internal_plugins.hpp"
 #include "../../../../agents/llm_presets.hpp"
 #include "../../../../agents/mcp/MCPServerManager.hpp"
@@ -563,9 +565,9 @@ void AIPanelComponent::onGenerationFinished(juce::String status, juce::String co
         // with no conversation (4OSC sound design).
         juce::String description;
         auto conv = llm::Conversation::fromVar(juce::JSON::parse(conversationJson));
-        for (auto it = conv.messages.rbegin(); it != conv.messages.rend(); ++it) {
-            if (it->role == "assistant") {
-                description = extractStringField(it->content, "description");
+        for (auto& message : std::views::reverse(conv.messages)) {
+            if (message.role == "assistant") {
+                description = extractStringField(message.content, "description");
                 break;
             }
         }

--- a/magda/daw/ui/components/chain/custom_ui/FourOscUI.cpp
+++ b/magda/daw/ui/components/chain/custom_ui/FourOscUI.cpp
@@ -116,31 +116,28 @@ std::vector<LinkableTextSlider*> FourOscUI::getLinkableSliders() {
     std::vector<LinkableTextSlider*> sliders;
 
     // OSC tab: 4 oscillators x 7 params each (indices 0-27)
-    for (int i = 0; i < 4; ++i) {
-        auto& row = oscTab_->rows_[i];
-        sliders.push_back(&row.tuneSlider);        // oscBase + i*7 + 0
-        sliders.push_back(&row.fineSlider);        // oscBase + i*7 + 1
-        sliders.push_back(&row.levelSlider);       // oscBase + i*7 + 2
-        sliders.push_back(&row.pulseWidthSlider);  // oscBase + i*7 + 3
-        sliders.push_back(&row.detuneSlider);      // oscBase + i*7 + 4
-        sliders.push_back(&row.spreadSlider);      // oscBase + i*7 + 5
-        sliders.push_back(&row.panSlider);         // oscBase + i*7 + 6
+    for (auto& row : oscTab_->rows_) {
+        sliders.push_back(&row.tuneSlider);
+        sliders.push_back(&row.fineSlider);
+        sliders.push_back(&row.levelSlider);
+        sliders.push_back(&row.pulseWidthSlider);
+        sliders.push_back(&row.detuneSlider);
+        sliders.push_back(&row.spreadSlider);
+        sliders.push_back(&row.panSlider);
     }
 
     // LFO tab: 2 LFOs x 2 params each (indices 28-31)
-    for (int i = 0; i < 2; ++i) {
-        auto& row = lfoTab_->rows_[i];
-        sliders.push_back(&row.rateSlider);   // lfoBase + i*2 + 0
-        sliders.push_back(&row.depthSlider);  // lfoBase + i*2 + 1
+    for (auto& row : lfoTab_->rows_) {
+        sliders.push_back(&row.rateSlider);
+        sliders.push_back(&row.depthSlider);
     }
 
     // Mod Env tab: 2 envelopes x 4 params each (indices 32-39)
-    for (int i = 0; i < 2; ++i) {
-        auto& row = modEnvTab_->rows_[i];
-        sliders.push_back(&row.attackSlider);   // modEnvBase + i*4 + 0
-        sliders.push_back(&row.decaySlider);    // modEnvBase + i*4 + 1
-        sliders.push_back(&row.sustainSlider);  // modEnvBase + i*4 + 2
-        sliders.push_back(&row.releaseSlider);  // modEnvBase + i*4 + 3
+    for (auto& row : modEnvTab_->rows_) {
+        sliders.push_back(&row.attackSlider);
+        sliders.push_back(&row.decaySlider);
+        sliders.push_back(&row.sustainSlider);
+        sliders.push_back(&row.releaseSlider);
     }
 
     // Amp tab: 5 params (indices 40-44)
@@ -430,11 +427,10 @@ void FourOscUI::OscTab::resized() {
 
     area.removeFromTop(2);
 
-    for (int i = 0; i < 4; ++i) {
+    for (auto& row : rows_) {
         auto rowArea = area.removeFromTop(rowH);
         area.removeFromTop(gap);
 
-        auto& row = rows_[i];
         row.label.setBounds(rowArea.removeFromLeft(labelW));
         rowArea.removeFromLeft(gap);
         row.waveSelector.setBounds(rowArea.removeFromLeft(waveSelectorW));
@@ -1112,11 +1108,9 @@ void FourOscUI::ModEnvTab::resized() {
     // draggable graph filling the rest of the block on the right.
     constexpr int envBlockH = 46;
     const int boxesW = labelW + gap + 4 * (sliderW + gap);
-    for (int i = 0; i < 2; ++i) {
+    for (auto& row : rows_) {
         auto block = area.removeFromTop(envBlockH);
         area.removeFromTop(gap);
-        auto& row = rows_[i];
-
         auto left = block.removeFromLeft(boxesW);
         block.removeFromLeft(gap);
         row.graph.setBounds(block.reduced(2));
@@ -1311,10 +1305,9 @@ void FourOscUI::LFOTab::resized() {
     hdrSync_.setBounds(headerRow.removeFromLeft(toggleW));
     area.removeFromTop(2);
 
-    for (int i = 0; i < 2; ++i) {
+    for (auto& row : rows_) {
         auto rowArea = area.removeFromTop(rowH);
         area.removeFromTop(gap);
-        auto& row = rows_[i];
         row.label.setBounds(rowArea.removeFromLeft(labelW));
         rowArea.removeFromLeft(gap);
         row.waveSelector.setBounds(rowArea.removeFromLeft(waveSelectorW));
@@ -1379,8 +1372,7 @@ void FourOscUI::LFOTab::updatePluginState(const FourOscPluginState& state) {
 }
 
 void FourOscUI::LFOTab::paint(juce::Graphics& g) {
-    for (int i = 0; i < 2; ++i) {
-        const auto& row = rows_[i];
+    for (const auto& row : rows_) {
         auto b = row.previewBounds.toFloat();
         if (b.getWidth() < 8.0f || b.getHeight() < 6.0f)
             continue;
@@ -1815,8 +1807,7 @@ void FourOscUI::LFOTab::rebuildModRows() {
     modDestRows_.clear();
     modListContent_->removeAllChildren();
 
-    for (size_t i = 0; i < modEntries_.size(); ++i) {
-        auto& entry = modEntries_[i];
+    for (auto& entry : modEntries_) {
         ModDestRow row;
 
         // "LFO 1 > Filter Freq" style label
@@ -1941,8 +1932,7 @@ void FourOscUI::ModEnvTab::rebuildModRows() {
     modDestRows_.clear();
     modListContent_->removeAllChildren();
 
-    for (size_t i = 0; i < modEntries_.size(); ++i) {
-        auto& entry = modEntries_[i];
+    for (auto& entry : modEntries_) {
         ModDestRow row;
 
         juce::String label = entry.sourceName + " > " + entry.paramName;

--- a/magda/daw/ui/components/chain/slot/DeviceSlotHeaderControls.cpp
+++ b/magda/daw/ui/components/chain/slot/DeviceSlotHeaderControls.cpp
@@ -1,6 +1,7 @@
 #include "slot/DeviceSlotHeaderControls.hpp"
 
 #include <algorithm>
+#include <ranges>
 
 #include "slot/DeviceSlotHeaderSpec.hpp"
 
@@ -85,9 +86,9 @@ void layoutExpandedDeviceSlotHeader(juce::Rectangle<int>& headerArea,
             placeLeft(headerArea, spec.component, buttonSize);
     }
 
-    for (auto it = specs.rbegin(); it != specs.rend(); ++it) {
-        if (it->side == HeaderControlSide::Right && it->expandedVisible)
-            placeRight(headerArea, it->component, buttonSize);
+    for (auto& spec : std::views::reverse(specs)) {
+        if (spec.side == HeaderControlSide::Right && spec.expandedVisible)
+            placeRight(headerArea, spec.component, buttonSize);
     }
 }
 

--- a/magda/daw/ui/components/mixer/RoutingSyncHelper.hpp
+++ b/magda/daw/ui/components/mixer/RoutingSyncHelper.hpp
@@ -85,11 +85,11 @@ inline void populateAudioInputOptions(RoutingSelector* selector, juce::AudioIODe
 
             // Mono channels (ID 100+)
             id = 100;
-            for (int i = 0; i < activeIndices.size(); ++i) {
-                int channelNum = activeIndices[i] + 1;
+            for (int activeIndice : activeIndices) {
+                int channelNum = activeIndice + 1;
                 options.push_back({id, juce::String(channelNum) + " (mono)"});
                 if (outChannelMapping)
-                    (*outChannelMapping)[id] = getDeviceName(activeIndices[i]);
+                    (*outChannelMapping)[id] = getDeviceName(activeIndice);
                 ++id;
             }
         }

--- a/magda/daw/ui/views/MainView.cpp
+++ b/magda/daw/ui/views/MainView.cpp
@@ -3,6 +3,7 @@
 #include <BinaryData.h>
 
 #include <cmath>
+#include <ranges>
 #include <set>
 
 #include "../components/automation/AutomationMenu.hpp"
@@ -108,15 +109,15 @@ MainView::MainView(AudioEngine* audioEngine)
         auto rows = cReg.all();
         std::set<juce::String> portWithEnabled;
         bool changed = false;
-        for (auto it = rows.rbegin(); it != rows.rend(); ++it) {
-            if (it->inputPort.isEmpty())
+        for (auto& row : std::views::reverse(rows)) {
+            if (row.inputPort.isEmpty())
                 continue;
-            const bool hasBindings = bReg.hasAnyBindingForController(it->id);
+            const bool hasBindings = bReg.hasAnyBindingForController(row.id);
             if (!hasBindings)
                 continue;
-            if (!portWithEnabled.insert(it->inputPort).second) {
-                bReg.removeAllForController(BindingScope::Global, it->id);
-                bReg.removeAllForController(BindingScope::Project, it->id);
+            if (!portWithEnabled.insert(row.inputPort).second) {
+                bReg.removeAllForController(BindingScope::Global, row.id);
+                bReg.removeAllForController(BindingScope::Project, row.id);
                 changed = true;
             }
         }
@@ -2936,8 +2937,8 @@ void MainView::AuxHeadersPanel::resized() {
     int rowHeight = getHeight() / static_cast<int>(auxRows_.size());
     auto bounds = getLocalBounds();
 
-    for (size_t i = 0; i < auxRows_.size(); ++i) {
-        auto& row = *auxRows_[i];
+    for (const auto& auxRow : auxRows_) {
+        auto& row = *auxRow;
         auto rowArea = bounds.removeFromTop(rowHeight);
         // Centre a fixed 18px-tall strip within the row (matching master header controls)
         auto controlArea = rowArea.withSizeKeepingCentre(rowArea.getWidth() - 8, 18);

--- a/magda/daw/ui/views/MixerView.cpp
+++ b/magda/daw/ui/views/MixerView.cpp
@@ -2085,8 +2085,8 @@ void MixerView::rebuildChannelStrips() {
                 }
             }
             // Check aux strips — use negative index offset for identification
-            for (size_t i = 0; i < auxChannelStrips.size(); ++i) {
-                if (auxChannelStrips[i]->getTrackId() == trackId) {
+            for (const auto& auxChannelStrip : auxChannelStrips) {
+                if (auxChannelStrip->getTrackId() == trackId) {
                     // Select via TrackManager directly
                     SelectionManager::getInstance().selectTrack(trackId);
                     return;

--- a/magda/daw/ui/views/SessionView.cpp
+++ b/magda/daw/ui/views/SessionView.cpp
@@ -2560,8 +2560,8 @@ void SessionView::removeScene() {
     // Check if any clips exist in the last scene
     auto& clipManager = ClipManager::getInstance();
     bool hasClips = false;
-    for (size_t i = 0; i < visibleTrackIds_.size(); ++i) {
-        ClipId clipId = clipManager.getClipInSlot(visibleTrackIds_[i], lastScene);
+    for (int visibleTrackId : visibleTrackIds_) {
+        ClipId clipId = clipManager.getClipInSlot(visibleTrackId, lastScene);
         if (clipId != INVALID_CLIP_ID) {
             hasClips = true;
             break;
@@ -2596,8 +2596,8 @@ void SessionView::removeSceneAsync(int sceneIndex) {
 
     // Stop and delete any clips in this scene
     auto& clipManager = ClipManager::getInstance();
-    for (size_t i = 0; i < visibleTrackIds_.size(); ++i) {
-        ClipId clipId = clipManager.getClipInSlot(visibleTrackIds_[i], sceneIndex);
+    for (int visibleTrackId : visibleTrackIds_) {
+        ClipId clipId = clipManager.getClipInSlot(visibleTrackId, sceneIndex);
         if (clipId != INVALID_CLIP_ID) {
             clipManager.stopClip(clipId);
             clipManager.deleteClip(clipId);

--- a/magda/engine/param/ParamKey.cpp
+++ b/magda/engine/param/ParamKey.cpp
@@ -1,5 +1,6 @@
 #include "param/ParamKey.hpp"
 
+#include <ranges>
 #include <tuple>
 
 namespace magda::engine {
@@ -19,9 +20,9 @@ ChainSegment segmentOf(const magda::ChainNodePath& path) {
 /// The rack a path ends in or passes through last, which is what owns a macro
 /// at rack scope.
 RackId lastRackOf(const magda::ChainNodePath& path) {
-    for (auto step = path.steps.rbegin(); step != path.steps.rend(); ++step)
-        if (magda::isRackStep(step->type))
-            return step->id;
+    for (auto step : std::views::reverse(path.steps))
+        if (magda::isRackStep(step.type))
+            return step.id;
     return INVALID_RACK_ID;
 }
 


### PR DESCRIPTION
## Summary
- Next of the per-check PRs from #2388: `clang-tidy`'s `modernize-loop-convert -fix` applied over `magda/`, then hand-reviewed line-by-line (two independent passes: a Claude subagent reading all 32 files in full function context, and a separate Codex pass) since this check has real failure modes a blind `-fix` can't see: index reuse beyond element access, lock-step iteration over two containers, mutation during iteration, reverse/strided loops.

## What the review caught
- **`TrackManager.cpp` — reverted 14 sites, real bug.** Every `notify*()` method loops over `listeners_` inside a `ScopedNotifyGuard`. `removeListener()` already has explicit reentrancy handling (nullifies instead of erasing while `notifyDepth_ > 0`, to keep iterators valid), but `addListener()` does a bare `push_back()` with no such guard. A reentrant `addListener()` call during notification (plausible: a listener callback can synchronously rebuild UI, whose constructors call `addListener`) can reallocate the vector. The original index loop tolerates this (`operator[]` re-resolves through the vector each time); a range-for caches `begin()`/`end()` once, so a reallocation mid-loop leaves it dereferencing dangling iterators — real undefined behavior. Reverted all 14 to the index form; left the one unrelated, safe `path.steps` conversion in the same file as range-for.
- **`ClipMidiSource.cpp` — reverted entirely.** Real-time audio-callback code with an explicit "may not allocate" comment. The conversion itself doesn't touch `scratch_` and wouldn't have changed behavior, but this check is pure style with zero functional benefit, and this is the single most safety-critical file in the diff — not worth even a theoretical risk in the hottest path in the codebase.
- **`MidiNoteCommands.cpp:848`** — fixer wrote the *resolved* type `unsigned long` instead of the vector's actual `size_t` element type. Harmless on macOS/Linux (same type), but a portability smell (`unsigned long` is 32-bit on Windows LLP64, `size_t` is 64-bit) that could narrow every element. Changed to `size_t`.
- **`FourOscUI.cpp`** — dropped 15 trailing comments (`// oscBase + i*7 + 0`, etc.) that referenced the now-removed index variable `i`; confirmed no caller indexes `getLinkableSliders()`'s result by the literal offset, so these were pure local documentation, now stale.
- **`ChainWalk.hpp`** — the fixer left a duplicate `#include <ranges>`; deduped.

Everything else — including every `std::views::reverse` conversion — was confirmed as straightforward single-container full-traversal loops with no index reuse.

## Test plan
- [x] `make debug` — builds clean
- [x] `make test` — 3581 passed, 13 skipped, 857098 assertions, 0 failed
- [x] `make test-juce` — all passed (this PR touches several UI components)

Part of #2388.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0149ko34fXR5PeMBqVL1tDWt