### PR TITLE
Define the arpeggiator's transport contract across seeks, loops and stops

### DIFF
--- a/magda/daw/audio/plugins/ArpeggiatorPlugin.cpp
+++ b/magda/daw/audio/plugins/ArpeggiatorPlugin.cpp
@@ -15,6 +15,19 @@ const juce::Identifier ArpeggiatorPlugin::SettingIDs::hardAngle("arpHardAngle");
 
 namespace {
 
+/// Whether the host counts this MIDI source as live input. No list is
+/// "nothing is known live", never "everything is": the native engine says
+/// nothing and stamps every event 0 (#2418).
+bool isLiveSource(const DeviceProcessContext& context, std::uint32_t sourceId) {
+    if (context.liveSourceIds == nullptr)
+        return false;
+    for (int i = 0; i < context.numLiveSourceIds; ++i) {
+        if (context.liveSourceIds[i] == sourceId)
+            return true;
+    }
+    return false;
+}
+
 /// One slot's metadata. The ids, order and display ranges are pinned to what
 /// the retired host-native plugin registered, because saved links address the
 /// slots by index and projects store parameter values in display units.
@@ -228,77 +241,61 @@ double ArpeggiatorPlugin::applyRampCurve(double t, float depth, float skew, bool
     return ramp_curve::applyRampCurve(t, depth, skew, hardAngle);
 }
 
-void ArpeggiatorPlugin::addHeldNote(int noteNumber, int velocity, std::uint32_t sourceId) {
-    // Check if already held
+void ArpeggiatorPlugin::addHeldNote(int noteNumber, int velocity, bool fromLiveSource) {
     for (int i = 0; i < heldCount_; ++i) {
         auto& held = heldNotes_[static_cast<size_t>(i)];
         if (held.noteNumber == noteNumber) {
-            // A host re-asserting its notes after a seek owns the key again.
-            held.physicallyHeld = true;
-            held.sourceId = sourceId;
+            // The pattern already has this pitch; this is another holder of
+            // it, not another note.
+            ++(fromLiveSource ? held.liveHolds : held.hostHolds);
             return;
         }
     }
     if (heldCount_ < MAX_HELD) {
-        heldNotes_[static_cast<size_t>(heldCount_)] = {noteNumber, velocity, nextOrder_++, sourceId,
-                                                       true};
+        heldNotes_[static_cast<size_t>(heldCount_)] = {
+            noteNumber, velocity, nextOrder_++, fromLiveSource ? 1 : 0, fromLiveSource ? 0 : 1};
         ++heldCount_;
     }
 }
 
-void ArpeggiatorPlugin::markHeldNoteReleased(int noteNumber) {
+void ArpeggiatorPlugin::releaseHeldNote(int noteNumber, bool fromLiveSource,
+                                        bool removeWhenUnheld) {
     for (int i = 0; i < heldCount_; ++i) {
-        if (heldNotes_[static_cast<size_t>(i)].noteNumber == noteNumber) {
-            heldNotes_[static_cast<size_t>(i)].physicallyHeld = false;
-            return;
-        }
+        auto& held = heldNotes_[static_cast<size_t>(i)];
+        if (held.noteNumber != noteNumber)
+            continue;
+        auto& holds = fromLiveSource ? held.liveHolds : held.hostHolds;
+        if (holds > 0)
+            --holds;
+        if (removeWhenUnheld && held.liveHolds == 0 && held.hostHolds == 0)
+            removeHeldNoteAt(i);
+        return;
     }
 }
 
-void ArpeggiatorPlugin::retainLiveHeldNotes(const DeviceProcessContext& context) {
-    // No list is "nothing is known live", not "everything is": the native
-    // engine says nothing and stamps every event 0 (#2418).
-    if (context.numLiveSourceIds <= 0 || context.liveSourceIds == nullptr) {
-        clearHeldNotes();
-        return;
-    }
-
-    const auto isLiveSource = [&context](std::uint32_t sourceId) {
-        for (int i = 0; i < context.numLiveSourceIds; ++i) {
-            if (context.liveSourceIds[i] == sourceId)
-                return true;
-        }
-        return false;
-    };
-
+void ArpeggiatorPlugin::retainLiveHeldNotes() {
     int kept = 0;
-    int stillDown = 0;
     for (int i = 0; i < heldCount_; ++i) {
-        const auto& note = heldNotes_[static_cast<size_t>(i)];
-        if (!isLiveSource(note.sourceId))
+        auto note = heldNotes_[static_cast<size_t>(i)];
+        if (note.liveHolds == 0)
             continue;
+        // Whatever the host was holding it is withdrawing, and re-asserts on
+        // the same buffer what should still sound.
+        note.hostHolds = 0;
         heldNotes_[static_cast<size_t>(kept++)] = note;
-        if (note.physicallyHeld)
-            ++stillDown;
     }
     heldCount_ = kept;
-    physicallyHeldCount_ = stillDown;
-    latchedSetStale_ = kept > 0 && stillDown == 0;
+    physicallyHeldCount_ = kept;
+    latchedSetStale_ = false;
     if (kept == 0)
         nextOrder_ = 0;
 }
 
-void ArpeggiatorPlugin::removeHeldNote(int noteNumber) {
-    for (int i = 0; i < heldCount_; ++i) {
-        if (heldNotes_[static_cast<size_t>(i)].noteNumber == noteNumber) {
-            // Swap with last
-            if (i < heldCount_ - 1)
-                heldNotes_[static_cast<size_t>(i)] =
-                    heldNotes_[static_cast<size_t>(heldCount_ - 1)];
-            --heldCount_;
-            return;
-        }
-    }
+void ArpeggiatorPlugin::removeHeldNoteAt(int index) {
+    // Swap with last
+    if (index < heldCount_ - 1)
+        heldNotes_[static_cast<size_t>(index)] = heldNotes_[static_cast<size_t>(heldCount_ - 1)];
+    --heldCount_;
 }
 
 void ArpeggiatorPlugin::clearHeldNotes() {
@@ -434,12 +431,12 @@ void ArpeggiatorPlugin::process(DeviceProcessContext& context) {
     const bool inputPanic = midi.isAllNotesOff();
     if (inputPanic) {
         pendingNoteOff = takeSoundingNote();
-        retainLiveHeldNotes(context);
+        retainLiveHeldNotes();
     }
     const int incomingCount = midi.size();
     for (int eventIndex = 0; eventIndex < incomingCount; ++eventIndex) {
         const auto& msg = midi.message(eventIndex);
-        const std::uint32_t source = midi.sourceId(eventIndex);
+        const bool fromLiveSource = isLiveSource(context, midi.sourceId(eventIndex));
         if (msg.isNoteOn()) {
             ++physicallyHeldCount_;
 
@@ -451,7 +448,7 @@ void ArpeggiatorPlugin::process(DeviceProcessContext& context) {
             }
 
             bool wasEmpty = (heldCount_ == 0);
-            addHeldNote(msg.getNoteNumber(), msg.getVelocity(), source);
+            addHeldNote(msg.getNoteNumber(), msg.getVelocity(), fromLiveSource);
             // Reset free-running clock when first note arrives
             if (wasEmpty && heldCount_ > 0) {
                 resetFromInput();
@@ -461,14 +458,11 @@ void ArpeggiatorPlugin::process(DeviceProcessContext& context) {
             if (physicallyHeldCount_ < 0)
                 physicallyHeldCount_ = 0;
 
-            if (isLatched) {
-                // Don't remove notes; mark stale when all physically released
-                markHeldNoteReleased(msg.getNoteNumber());
-                if (physicallyHeldCount_ == 0)
-                    latchedSetStale_ = true;
-            } else {
-                removeHeldNote(msg.getNoteNumber());
-            }
+            // Latch keeps the note in the pattern and only marks the set
+            // stale once every key is up.
+            releaseHeldNote(msg.getNoteNumber(), fromLiveSource, !isLatched);
+            if (isLatched && physicallyHeldCount_ == 0)
+                latchedSetStale_ = true;
         } else if (msg.isAllNotesOff() || msg.isAllSoundOff()) {
             clearHeldNotes();
             resetFromInput();
@@ -491,7 +485,7 @@ void ArpeggiatorPlugin::process(DeviceProcessContext& context) {
         // clip left behind are dropped, because their note-off is never
         // coming once the transport stops (#2416).
         sendAllNotesOff(midi);
-        retainLiveHeldNotes(context);
+        retainLiveHeldNotes();
         resetArpState();
         freeRunSamples_ = 0.0;
     }

--- a/magda/daw/audio/plugins/ArpeggiatorPlugin.cpp
+++ b/magda/daw/audio/plugins/ArpeggiatorPlugin.cpp
@@ -228,16 +228,68 @@ double ArpeggiatorPlugin::applyRampCurve(double t, float depth, float skew, bool
     return ramp_curve::applyRampCurve(t, depth, skew, hardAngle);
 }
 
-void ArpeggiatorPlugin::addHeldNote(int noteNumber, int velocity) {
+void ArpeggiatorPlugin::addHeldNote(int noteNumber, int velocity, std::uint32_t sourceId) {
     // Check if already held
     for (int i = 0; i < heldCount_; ++i) {
-        if (heldNotes_[static_cast<size_t>(i)].noteNumber == noteNumber)
+        auto& held = heldNotes_[static_cast<size_t>(i)];
+        if (held.noteNumber == noteNumber) {
+            // A host re-asserting its notes after a seek owns the key again.
+            held.physicallyHeld = true;
+            held.sourceId = sourceId;
             return;
+        }
     }
     if (heldCount_ < MAX_HELD) {
-        heldNotes_[static_cast<size_t>(heldCount_)] = {noteNumber, velocity, nextOrder_++};
+        heldNotes_[static_cast<size_t>(heldCount_)] = {noteNumber, velocity, nextOrder_++, sourceId,
+                                                       true};
         ++heldCount_;
     }
+}
+
+void ArpeggiatorPlugin::markHeldNoteReleased(int noteNumber) {
+    for (int i = 0; i < heldCount_; ++i) {
+        if (heldNotes_[static_cast<size_t>(i)].noteNumber == noteNumber) {
+            heldNotes_[static_cast<size_t>(i)].physicallyHeld = false;
+            return;
+        }
+    }
+}
+
+void ArpeggiatorPlugin::noteLiveSource(std::uint32_t sourceId) {
+    // 0 is "the host did not say", which is every event on the native engine
+    // until its port carries source identity (#2418).
+    if (sourceId == 0 || isLiveSource(sourceId))
+        return;
+    if (liveSourceCount_ < kMaxLiveSources)
+        liveSources_[static_cast<size_t>(liveSourceCount_++)] = sourceId;
+}
+
+bool ArpeggiatorPlugin::isLiveSource(std::uint32_t sourceId) const {
+    if (sourceId == 0)
+        return false;
+    for (int i = 0; i < liveSourceCount_; ++i) {
+        if (liveSources_[static_cast<size_t>(i)] == sourceId)
+            return true;
+    }
+    return false;
+}
+
+void ArpeggiatorPlugin::retainLiveHeldNotes() {
+    int kept = 0;
+    int stillDown = 0;
+    for (int i = 0; i < heldCount_; ++i) {
+        const auto& note = heldNotes_[static_cast<size_t>(i)];
+        if (!isLiveSource(note.sourceId))
+            continue;
+        heldNotes_[static_cast<size_t>(kept++)] = note;
+        if (note.physicallyHeld)
+            ++stillDown;
+    }
+    heldCount_ = kept;
+    physicallyHeldCount_ = stillDown;
+    latchedSetStale_ = kept > 0 && stillDown == 0;
+    if (kept == 0)
+        nextOrder_ = 0;
 }
 
 void ArpeggiatorPlugin::removeHeldNote(int noteNumber) {
@@ -276,6 +328,7 @@ int ArpeggiatorPlugin::resetArpState() {
     const int note = takeSoundingNote();
     currentStep_ = 0;
     arpOriginBeat_ = -1.0;
+    lastBlockEndBeat_ = -1.0;
     wasPlaying_ = false;
     currentPlayStep_.store(-1, std::memory_order_relaxed);
     currentSeqLength_.store(0, std::memory_order_relaxed);
@@ -377,18 +430,22 @@ void ArpeggiatorPlugin::process(DeviceProcessContext& context) {
             pendingNoteOff = note;
         freeRunSamples_ = 0.0;
     };
-    // Hosts can signal panic without a CC event (for example on a playhead
-    // jump). Reset before consuming fresh input, and forward the flag below.
+    // Hosts raise this without a CC event, on a playhead jump or a track they
+    // just muted. It says to silence what is sounding, not that the player let
+    // go: the keys stay held and the walk re-anchors below (#2416).
     const bool inputPanic = midi.isAllNotesOff();
-    if (inputPanic) {
-        clearHeldNotes();
-        resetFromInput();
-    }
+    if (inputPanic)
+        pendingNoteOff = takeSoundingNote();
     const int incomingCount = midi.size();
     for (int eventIndex = 0; eventIndex < incomingCount; ++eventIndex) {
         const auto& msg = midi.message(eventIndex);
+        const std::uint32_t source = midi.sourceId(eventIndex);
         if (msg.isNoteOn()) {
             ++physicallyHeldCount_;
+            // Clips are silent with the transport stopped, so whoever plays
+            // now is a live source and its notes survive a stop (#2416).
+            if (!context.isPlaying)
+                noteLiveSource(source);
 
             // Latch: if old set is stale (all keys were released), clear before adding
             if (isLatched && latchedSetStale_) {
@@ -398,7 +455,7 @@ void ArpeggiatorPlugin::process(DeviceProcessContext& context) {
             }
 
             bool wasEmpty = (heldCount_ == 0);
-            addHeldNote(msg.getNoteNumber(), msg.getVelocity());
+            addHeldNote(msg.getNoteNumber(), msg.getVelocity(), source);
             // Reset free-running clock when first note arrives
             if (wasEmpty && heldCount_ > 0) {
                 resetFromInput();
@@ -410,6 +467,7 @@ void ArpeggiatorPlugin::process(DeviceProcessContext& context) {
 
             if (isLatched) {
                 // Don't remove notes; mark stale when all physically released
+                markHeldNoteReleased(msg.getNoteNumber());
                 if (physicallyHeldCount_ == 0)
                     latchedSetStale_ = true;
             } else {
@@ -427,22 +485,26 @@ void ArpeggiatorPlugin::process(DeviceProcessContext& context) {
     sendNoteOff(midi, pendingNoteOff);
 
     // --- 3. Handle transport transitions ---
-    // Reset on a playing-to-stopped edge. On start, just update the flag;
-    // the step counter continues from where it was.
     if (context.isPlaying && !wasPlaying_) {
+        // The transport and the free-running clock are different clocks, so
+        // the walk re-anchors below instead of carrying its step across.
         wasPlaying_ = true;
+        lastBlockEndBeat_ = -1.0;
     } else if (!context.isPlaying && wasPlaying_) {
+        // Keys under the player's fingers keep the arp free-running; notes a
+        // clip left behind are dropped, because their note-off is never
+        // coming once the transport stops (#2416).
         sendAllNotesOff(midi);
-        clearHeldNotes();
+        retainLiveHeldNotes();
         resetArpState();
         freeRunSamples_ = 0.0;
-        wasPlaying_ = false;
     }
 
     // --- 4. No held notes, or no MIDI input while transport is stopped? ---
     if (heldCount_ == 0 || (!context.isPlaying && physicallyHeldCount_ <= 0)) {
         sendAllNotesOff(midi);
         freeRunSamples_ = 0.0;
+        lastBlockEndBeat_ = -1.0;
         return;
     }
 
@@ -465,6 +527,19 @@ void ArpeggiatorPlugin::process(DeviceProcessContext& context) {
 
     if (blockEndBeat <= blockStartBeat)
         return;
+
+    // Seeks, loop wraps and the switch between the two clocks all arrive as a
+    // block that does not continue the last one. Only some of them reach the
+    // device as a panic and a loop wrap reaches it as nothing at all, so the
+    // timeline is what the walk trusts (#2416).
+    constexpr double kContiguousBeats = 1.0e-3;
+    if (lastBlockEndBeat_ < 0.0 ||
+        std::abs(blockStartBeat - lastBlockEndBeat_) > kContiguousBeats) {
+        sendNoteOff(midi, takeSoundingNote());
+        currentStep_ = 0;
+        arpOriginBeat_ = -1.0;
+    }
+    lastBlockEndBeat_ = blockEndBeat;
 
     // --- 6. Build note sequence ---
     auto seq = buildSequence();
@@ -529,9 +604,16 @@ void ArpeggiatorPlugin::process(DeviceProcessContext& context) {
     }
 
     // --- 8. Walk steps and generate notes ---
-    // Catch up: skip past any steps whose warped position is before this block
-    while (computeStepBeat(currentStep_) < blockStartBeat)
-        ++currentStep_;
+    // Catch up to the block. Cycles are evenly spaced whatever the ramp does
+    // inside one, so the cycle holding the block start is a division and only
+    // its steps are walked: bounded work, not one pass per skipped step.
+    if (computeStepBeat(currentStep_) < blockStartBeat) {
+        const int cycle =
+            static_cast<int>(std::floor((blockStartBeat - arpOriginBeat_) / cycleBeats));
+        currentStep_ = std::max(currentStep_, cycle * seq.length);
+        while (computeStepBeat(currentStep_) < blockStartBeat)
+            ++currentStep_;
+    }
 
     double stepBeat = computeStepBeat(currentStep_);
 

--- a/magda/daw/audio/plugins/ArpeggiatorPlugin.cpp
+++ b/magda/daw/audio/plugins/ArpeggiatorPlugin.cpp
@@ -255,30 +255,21 @@ void ArpeggiatorPlugin::markHeldNoteReleased(int noteNumber) {
     }
 }
 
-void ArpeggiatorPlugin::noteLiveSource(std::uint32_t sourceId) {
-    // 0 is "the host did not say", which is every event on the native engine
-    // until its port carries source identity (#2418).
-    if (sourceId == 0 || isLiveSource(sourceId))
-        return;
-    if (liveSourceCount_ < kMaxLiveSources)
-        liveSources_[static_cast<size_t>(liveSourceCount_++)] = sourceId;
-}
-
-bool ArpeggiatorPlugin::isLiveSource(std::uint32_t sourceId) const {
-    if (sourceId == 0)
-        return false;
-    for (int i = 0; i < liveSourceCount_; ++i) {
-        if (liveSources_[static_cast<size_t>(i)] == sourceId)
-            return true;
-    }
-    return false;
-}
-
-void ArpeggiatorPlugin::retainLiveHeldNotes() {
-    if (liveSourceCount_ == 0) {
+void ArpeggiatorPlugin::retainLiveHeldNotes(const DeviceProcessContext& context) {
+    // No list is "nothing is known live", not "everything is": the native
+    // engine says nothing and stamps every event 0 (#2418).
+    if (context.numLiveSourceIds <= 0 || context.liveSourceIds == nullptr) {
         clearHeldNotes();
         return;
     }
+
+    const auto isLiveSource = [&context](std::uint32_t sourceId) {
+        for (int i = 0; i < context.numLiveSourceIds; ++i) {
+            if (context.liveSourceIds[i] == sourceId)
+                return true;
+        }
+        return false;
+    };
 
     int kept = 0;
     int stillDown = 0;
@@ -443,7 +434,7 @@ void ArpeggiatorPlugin::process(DeviceProcessContext& context) {
     const bool inputPanic = midi.isAllNotesOff();
     if (inputPanic) {
         pendingNoteOff = takeSoundingNote();
-        retainLiveHeldNotes();
+        retainLiveHeldNotes(context);
     }
     const int incomingCount = midi.size();
     for (int eventIndex = 0; eventIndex < incomingCount; ++eventIndex) {
@@ -451,10 +442,6 @@ void ArpeggiatorPlugin::process(DeviceProcessContext& context) {
         const std::uint32_t source = midi.sourceId(eventIndex);
         if (msg.isNoteOn()) {
             ++physicallyHeldCount_;
-            // Clips are silent with the transport stopped, so whoever plays
-            // now is a live source and its notes survive a stop (#2416).
-            if (!context.isPlaying)
-                noteLiveSource(source);
 
             // Latch: if old set is stale (all keys were released), clear before adding
             if (isLatched && latchedSetStale_) {
@@ -504,7 +491,7 @@ void ArpeggiatorPlugin::process(DeviceProcessContext& context) {
         // clip left behind are dropped, because their note-off is never
         // coming once the transport stops (#2416).
         sendAllNotesOff(midi);
-        retainLiveHeldNotes();
+        retainLiveHeldNotes(context);
         resetArpState();
         freeRunSamples_ = 0.0;
     }

--- a/magda/daw/audio/plugins/ArpeggiatorPlugin.cpp
+++ b/magda/daw/audio/plugins/ArpeggiatorPlugin.cpp
@@ -241,19 +241,26 @@ double ArpeggiatorPlugin::applyRampCurve(double t, float depth, float skew, bool
     return ramp_curve::applyRampCurve(t, depth, skew, hardAngle);
 }
 
-void ArpeggiatorPlugin::addHeldNote(int noteNumber, int velocity, bool fromLiveSource) {
+void ArpeggiatorPlugin::addHeldNote(int noteNumber, int velocity, bool fromLiveSource,
+                                    std::uint32_t sourceId) {
     for (int i = 0; i < heldCount_; ++i) {
         auto& held = heldNotes_[static_cast<size_t>(i)];
         if (held.noteNumber == noteNumber) {
             // The pattern already has this pitch; this is another holder of
             // it, not another note.
             ++(fromLiveSource ? held.liveHolds : held.hostHolds);
+            (fromLiveSource ? held.liveSourceId : held.hostSourceId) = sourceId;
             return;
         }
     }
     if (heldCount_ < MAX_HELD) {
-        heldNotes_[static_cast<size_t>(heldCount_)] = {
-            noteNumber, velocity, nextOrder_++, fromLiveSource ? 1 : 0, fromLiveSource ? 0 : 1};
+        heldNotes_[static_cast<size_t>(heldCount_)] = {noteNumber,
+                                                       velocity,
+                                                       nextOrder_++,
+                                                       fromLiveSource ? 1 : 0,
+                                                       fromLiveSource ? 0 : 1,
+                                                       fromLiveSource ? sourceId : 0,
+                                                       fromLiveSource ? 0 : sourceId};
         ++heldCount_;
     }
 }
@@ -275,6 +282,7 @@ void ArpeggiatorPlugin::releaseHeldNote(int noteNumber, bool fromLiveSource,
 
 void ArpeggiatorPlugin::retainLiveHeldNotes() {
     int kept = 0;
+    int holds = 0;
     for (int i = 0; i < heldCount_; ++i) {
         auto note = heldNotes_[static_cast<size_t>(i)];
         if (note.liveHolds == 0)
@@ -282,10 +290,13 @@ void ArpeggiatorPlugin::retainLiveHeldNotes() {
         // Whatever the host was holding it is withdrawing, and re-asserts on
         // the same buffer what should still sound.
         note.hostHolds = 0;
+        note.hostSourceId = 0;
+        holds += note.liveHolds;
         heldNotes_[static_cast<size_t>(kept++)] = note;
     }
     heldCount_ = kept;
-    physicallyHeldCount_ = kept;
+    // Keys, not pitches: two inputs on one pitch stay held when one lets go.
+    physicallyHeldCount_ = holds;
     latchedSetStale_ = false;
     if (kept == 0)
         nextOrder_ = 0;
@@ -306,7 +317,8 @@ void ArpeggiatorPlugin::clearHeldNotes() {
 }
 
 void ArpeggiatorPlugin::sendAllNotesOff(DeviceMidiBuffer& midi) {
-    sendNoteOff(midi, takeSoundingNote());
+    const std::uint32_t source = lastPlayedSourceId_;
+    sendNoteOff(midi, takeSoundingNote(), source);
 }
 
 int ArpeggiatorPlugin::takeSoundingNote() {
@@ -358,9 +370,9 @@ ArpeggiatorPlugin::ExpandedSequence ArpeggiatorPlugin::buildSequence() const {
                 break;
             if (seq.length >= static_cast<int>(seq.notes.size()))
                 break;
-            seq.notes[static_cast<size_t>(seq.length)] = {note,
-                                                          sorted[static_cast<size_t>(i)].velocity,
-                                                          sorted[static_cast<size_t>(i)].order};
+            auto expanded = sorted[static_cast<size_t>(i)];
+            expanded.noteNumber = note;
+            seq.notes[static_cast<size_t>(seq.length)] = expanded;
             ++seq.length;
         }
     }
@@ -448,7 +460,8 @@ void ArpeggiatorPlugin::process(DeviceProcessContext& context) {
             }
 
             bool wasEmpty = (heldCount_ == 0);
-            addHeldNote(msg.getNoteNumber(), msg.getVelocity(), fromLiveSource);
+            addHeldNote(msg.getNoteNumber(), msg.getVelocity(), fromLiveSource,
+                        midi.sourceId(eventIndex));
             // Reset free-running clock when first note arrives
             if (wasEmpty && heldCount_ > 0) {
                 resetFromInput();
@@ -472,7 +485,7 @@ void ArpeggiatorPlugin::process(DeviceProcessContext& context) {
     // --- 2. Clear MIDI buffer (arp replaces input) ---
     midi.clear();
     midi.setAllNotesOff(inputPanic);
-    sendNoteOff(midi, pendingNoteOff);
+    sendNoteOff(midi, pendingNoteOff, lastPlayedSourceId_);
 
     // --- 3. Handle transport transitions ---
     if (context.isPlaying && !wasPlaying_) {
@@ -525,7 +538,8 @@ void ArpeggiatorPlugin::process(DeviceProcessContext& context) {
     constexpr double kContiguousBeats = 1.0e-3;
     if (lastBlockEndBeat_ < 0.0 ||
         std::abs(blockStartBeat - lastBlockEndBeat_) > kContiguousBeats) {
-        sendNoteOff(midi, takeSoundingNote());
+        const std::uint32_t source = lastPlayedSourceId_;
+        sendNoteOff(midi, takeSoundingNote(), source);
         currentStep_ = 0;
         arpOriginBeat_ = -1.0;
     }
@@ -578,16 +592,18 @@ void ArpeggiatorPlugin::process(DeviceProcessContext& context) {
     // Block duration in seconds (MIDI timestamps stay in seconds, not samples)
     double blockDurationSecs = static_cast<double>(context.numSamples) / sampleRate_;
 
-    const auto addTimedMessage = [&midi](juce::MidiMessage message, double timeInBlock) {
+    const auto addTimedMessage = [&midi](juce::MidiMessage message, double timeInBlock,
+                                         std::uint32_t sourceId) {
         message.setTimeStamp(timeInBlock);
-        midi.addEvent({std::move(message), 0});
+        midi.addEvent({std::move(message), sourceId});
     };
 
     // --- 7. Emit pending note-off from previous block ---
     if (lastNoteOffBeat_ >= blockStartBeat && lastNoteOffBeat_ < blockEndBeat &&
         lastPlayedNote_ >= 0) {
         double frac = (lastNoteOffBeat_ - blockStartBeat) / (blockEndBeat - blockStartBeat);
-        addTimedMessage(juce::MidiMessage::noteOff(1, lastPlayedNote_), frac * blockDurationSecs);
+        addTimedMessage(juce::MidiMessage::noteOff(1, lastPlayedNote_), frac * blockDurationSecs,
+                        lastPlayedSourceId_);
         lastPlayedNote_ = -1;
         lastNoteOffBeat_ = -1.0;
         clearMidiOutDisplay();
@@ -627,7 +643,8 @@ void ArpeggiatorPlugin::process(DeviceProcessContext& context) {
 
             // Note-off for previous note
             if (lastPlayedNote_ >= 0) {
-                addTimedMessage(juce::MidiMessage::noteOff(1, lastPlayedNote_), timeInBlock);
+                addTimedMessage(juce::MidiMessage::noteOff(1, lastPlayedNote_), timeInBlock,
+                                lastPlayedSourceId_);
                 lastPlayedNote_ = -1;
             }
 
@@ -649,12 +666,16 @@ void ArpeggiatorPlugin::process(DeviceProcessContext& context) {
                 vel = (currentStep_ % 4 == 0) ? juce::jmin(127, note.velocity + 30) : note.velocity;
             }
 
-            // Note-on
+            // Note-on, carrying the provenance of whoever holds the pitch, so
+            // a device behind this one reads it the way this one does (#2416).
+            const std::uint32_t noteSource =
+                note.liveHolds > 0 ? note.liveSourceId : note.hostSourceId;
             addTimedMessage(
                 juce::MidiMessage::noteOn(1, note.noteNumber, static_cast<juce::uint8>(vel)),
-                timeInBlock);
+                timeInBlock, noteSource);
 
             lastPlayedNote_ = note.noteNumber;
+            lastPlayedSourceId_ = noteSource;
             setMidiOutDisplay(note.noteNumber, vel);
 
             // Schedule note-off
@@ -662,7 +683,7 @@ void ArpeggiatorPlugin::process(DeviceProcessContext& context) {
             if (noteOffBeat < blockEndBeat) {
                 double offFrac = (noteOffBeat - blockStartBeat) / (blockEndBeat - blockStartBeat);
                 addTimedMessage(juce::MidiMessage::noteOff(1, note.noteNumber),
-                                offFrac * blockDurationSecs);
+                                offFrac * blockDurationSecs, noteSource);
                 lastPlayedNote_ = -1;
                 lastNoteOffBeat_ = -1.0;
                 clearMidiOutDisplay();

--- a/magda/daw/audio/plugins/ArpeggiatorPlugin.cpp
+++ b/magda/daw/audio/plugins/ArpeggiatorPlugin.cpp
@@ -275,6 +275,11 @@ bool ArpeggiatorPlugin::isLiveSource(std::uint32_t sourceId) const {
 }
 
 void ArpeggiatorPlugin::retainLiveHeldNotes() {
+    if (liveSourceCount_ == 0) {
+        clearHeldNotes();
+        return;
+    }
+
     int kept = 0;
     int stillDown = 0;
     for (int i = 0; i < heldCount_; ++i) {
@@ -431,11 +436,15 @@ void ArpeggiatorPlugin::process(DeviceProcessContext& context) {
         freeRunSamples_ = 0.0;
     };
     // Hosts raise this without a CC event, on a playhead jump or a track they
-    // just muted. It says to silence what is sounding, not that the player let
-    // go: the keys stay held and the walk re-anchors below (#2416).
+    // just muted, and then re-assert whatever should be sounding at the new
+    // position without a note-off for what should not. So the host's notes go
+    // and come back on the same buffer, while keys proven to be a player's are
+    // not the host's to withdraw (#2416).
     const bool inputPanic = midi.isAllNotesOff();
-    if (inputPanic)
+    if (inputPanic) {
         pendingNoteOff = takeSoundingNote();
+        retainLiveHeldNotes();
+    }
     const int incomingCount = midi.size();
     for (int eventIndex = 0; eventIndex < incomingCount; ++eventIndex) {
         const auto& msg = midi.message(eventIndex);

--- a/magda/daw/audio/plugins/ArpeggiatorPlugin.hpp
+++ b/magda/daw/audio/plugins/ArpeggiatorPlugin.hpp
@@ -2,6 +2,7 @@
 
 #include <array>
 #include <atomic>
+#include <cstdint>
 
 #include "core/ParameterUtils.hpp"
 #include "plugins/MidiMagdaDevice.hpp"
@@ -128,6 +129,10 @@ class ArpeggiatorPlugin : public MidiMagdaDevice {
         int noteNumber = -1;
         int velocity = 0;
         int order = 0;
+        /// Who sent the note-on, and whether the key is still down. Together
+        /// they tell a live key from clip playback across a stop (#2416).
+        std::uint32_t sourceId = 0;
+        bool physicallyHeld = false;
     };
     std::array<HeldNote, MAX_HELD> heldNotes_{};
     int heldCount_ = 0;
@@ -137,6 +142,13 @@ class ArpeggiatorPlugin : public MidiMagdaDevice {
     int physicallyHeldCount_ = 0;
     bool latchedSetStale_ = false;
 
+    /// Sources that sent a note while the transport was stopped, so they are
+    /// not clip playback. A stop keeps what they hold and drops the rest,
+    /// which would wait forever for a note-off no clip will send (#2416).
+    static constexpr int kMaxLiveSources = 4;
+    std::array<std::uint32_t, kMaxLiveSources> liveSources_{};
+    int liveSourceCount_ = 0;
+
     // Pattern state
     int currentStep_ = 0;
     double arpOriginBeat_ = -1.0;
@@ -145,6 +157,11 @@ class ArpeggiatorPlugin : public MidiMagdaDevice {
 
     // Transport
     bool wasPlaying_ = false;
+
+    /// Where the previous block ended on the clock it ran on, or -1 for none.
+    /// A block that does not continue it is a seek, a loop wrap or a change of
+    /// clock, and only some of those reach the device as a panic (#2416).
+    double lastBlockEndBeat_ = -1.0;
 
     // Free-running clock for when transport is stopped
     double freeRunSamples_ = 0.0;
@@ -163,9 +180,15 @@ class ArpeggiatorPlugin : public MidiMagdaDevice {
 
     // --- Helpers ---
     static double rateToBeats(Rate r);
-    void addHeldNote(int noteNumber, int velocity);
+    void addHeldNote(int noteNumber, int velocity, std::uint32_t sourceId);
     void removeHeldNote(int noteNumber);
+    void markHeldNoteReleased(int noteNumber);
     void clearHeldNotes();
+    void noteLiveSource(std::uint32_t sourceId);
+    bool isLiveSource(std::uint32_t sourceId) const;
+    /// Drops held notes from sources that never played while stopped, and
+    /// recounts the keys still down. Used on the playing-to-stopped edge.
+    void retainLiveHeldNotes();
     void sendAllNotesOff(DeviceMidiBuffer& midi);
     int takeSoundingNote();
     // Returns the note that the caller must release when resetting during processing.

--- a/magda/daw/audio/plugins/ArpeggiatorPlugin.hpp
+++ b/magda/daw/audio/plugins/ArpeggiatorPlugin.hpp
@@ -134,6 +134,11 @@ class ArpeggiatorPlugin : public MidiMagdaDevice {
         /// at once, and the two release independently (#2416).
         int liveHolds = 0;
         int hostHolds = 0;
+        /// One holder from each side, stamped on whatever this note generates.
+        /// A device downstream reads provenance the way this one does, and the
+        /// source is all of it the host's buffer carries between them (#2416).
+        std::uint32_t liveSourceId = 0;
+        std::uint32_t hostSourceId = 0;
     };
     std::array<HeldNote, MAX_HELD> heldNotes_{};
     int heldCount_ = 0;
@@ -147,6 +152,9 @@ class ArpeggiatorPlugin : public MidiMagdaDevice {
     int currentStep_ = 0;
     double arpOriginBeat_ = -1.0;
     int lastPlayedNote_ = -1;
+    /// Source stamped on the sounding note's note-on, and on every note-off
+    /// that closes it.
+    std::uint32_t lastPlayedSourceId_ = 0;
     double lastNoteOffBeat_ = -1.0;
 
     // Transport
@@ -174,7 +182,7 @@ class ArpeggiatorPlugin : public MidiMagdaDevice {
 
     // --- Helpers ---
     static double rateToBeats(Rate r);
-    void addHeldNote(int noteNumber, int velocity, bool fromLiveSource);
+    void addHeldNote(int noteNumber, int velocity, bool fromLiveSource, std::uint32_t sourceId);
     void releaseHeldNote(int noteNumber, bool fromLiveSource, bool removeWhenUnheld);
     void removeHeldNoteAt(int index);
     void clearHeldNotes();

--- a/magda/daw/audio/plugins/ArpeggiatorPlugin.hpp
+++ b/magda/daw/audio/plugins/ArpeggiatorPlugin.hpp
@@ -129,10 +129,11 @@ class ArpeggiatorPlugin : public MidiMagdaDevice {
         int noteNumber = -1;
         int velocity = 0;
         int order = 0;
-        /// Who sent the note-on, and whether the key is still down. Together
-        /// they tell a live key from clip playback across a stop (#2416).
-        std::uint32_t sourceId = 0;
-        bool physicallyHeld = false;
+        /// Note-ons not yet released, split by whether the host calls their
+        /// source live input. One pitch can be under a finger and in a clip
+        /// at once, and the two release independently (#2416).
+        int liveHolds = 0;
+        int hostHolds = 0;
     };
     std::array<HeldNote, MAX_HELD> heldNotes_{};
     int heldCount_ = 0;
@@ -173,14 +174,14 @@ class ArpeggiatorPlugin : public MidiMagdaDevice {
 
     // --- Helpers ---
     static double rateToBeats(Rate r);
-    void addHeldNote(int noteNumber, int velocity, std::uint32_t sourceId);
-    void removeHeldNote(int noteNumber);
-    void markHeldNoteReleased(int noteNumber);
+    void addHeldNote(int noteNumber, int velocity, bool fromLiveSource);
+    void releaseHeldNote(int noteNumber, bool fromLiveSource, bool removeWhenUnheld);
+    void removeHeldNoteAt(int index);
     void clearHeldNotes();
-    /// Drops held notes the host does not call live input, and recounts the
-    /// keys still down. What a clip left behind has no note-off coming once
-    /// the transport stops, and none coming at all when a seek moves off it.
-    void retainLiveHeldNotes(const DeviceProcessContext& context);
+    /// Drops the held notes no live input is holding, and withdraws the host's
+    /// hold on the rest. What a clip left behind has no note-off coming once
+    /// the transport stops, and none at all when a seek moves off it.
+    void retainLiveHeldNotes();
     void sendAllNotesOff(DeviceMidiBuffer& midi);
     int takeSoundingNote();
     // Returns the note that the caller must release when resetting during processing.

--- a/magda/daw/audio/plugins/ArpeggiatorPlugin.hpp
+++ b/magda/daw/audio/plugins/ArpeggiatorPlugin.hpp
@@ -142,13 +142,6 @@ class ArpeggiatorPlugin : public MidiMagdaDevice {
     int physicallyHeldCount_ = 0;
     bool latchedSetStale_ = false;
 
-    /// Sources that sent a note while the transport was stopped, so they are
-    /// not clip playback. A stop keeps what they hold and drops the rest,
-    /// which would wait forever for a note-off no clip will send (#2416).
-    static constexpr int kMaxLiveSources = 4;
-    std::array<std::uint32_t, kMaxLiveSources> liveSources_{};
-    int liveSourceCount_ = 0;
-
     // Pattern state
     int currentStep_ = 0;
     double arpOriginBeat_ = -1.0;
@@ -184,11 +177,10 @@ class ArpeggiatorPlugin : public MidiMagdaDevice {
     void removeHeldNote(int noteNumber);
     void markHeldNoteReleased(int noteNumber);
     void clearHeldNotes();
-    void noteLiveSource(std::uint32_t sourceId);
-    bool isLiveSource(std::uint32_t sourceId) const;
-    /// Drops held notes from sources that never played while stopped, and
-    /// recounts the keys still down. Used on the playing-to-stopped edge.
-    void retainLiveHeldNotes();
+    /// Drops held notes the host does not call live input, and recounts the
+    /// keys still down. What a clip left behind has no note-off coming once
+    /// the transport stops, and none coming at all when a seek moves off it.
+    void retainLiveHeldNotes(const DeviceProcessContext& context);
     void sendAllNotesOff(DeviceMidiBuffer& midi);
     int takeSoundingNote();
     // Returns the note that the caller must release when resetting during processing.

--- a/magda/daw/audio/plugins/MagdaDevice.hpp
+++ b/magda/daw/audio/plugins/MagdaDevice.hpp
@@ -111,6 +111,17 @@ struct DeviceProcessContext {
     bool isPlaying = false;
     bool isScrubbing = false;
     bool isRendering = false;
+    /**
+     * Sources the host counts as live input, against DeviceMidiBuffer::sourceId.
+     *
+     * A device that holds notes needs this to tell a player's keys from clip
+     * playback: a clip's note-off never arrives once the transport stops, and
+     * a seek re-asserts what sounds at the destination without releasing what
+     * sounded only at the origin. Empty when the host does not say, which a
+     * device must read as "no source is known live", never as "all of them".
+     */
+    const std::uint32_t* liveSourceIds = nullptr;
+    int numLiveSourceIds = 0;
 };
 
 /**

--- a/magda/daw/audio/plugins/MidiMagdaDevice.hpp
+++ b/magda/daw/audio/plugins/MidiMagdaDevice.hpp
@@ -33,10 +33,12 @@ class MidiMagdaDevice : public MagdaDevice {
         sampleRate_ = context.sampleRate;
     }
 
-    /** Send note-off for the given note (channel 1, like the retired base). */
-    static void sendNoteOff(DeviceMidiBuffer& midi, int noteNumber) {
+    /** Send note-off for the given note (channel 1, like the retired base).
+     *  The source is the one the note-on carried, so a device downstream reads
+     *  the pair as one note from one origin (#2416). */
+    static void sendNoteOff(DeviceMidiBuffer& midi, int noteNumber, std::uint32_t sourceId = 0) {
         if (noteNumber >= 0)
-            midi.addEvent({juce::MidiMessage::noteOff(1, noteNumber), 0});
+            midi.addEvent({juce::MidiMessage::noteOff(1, noteNumber), sourceId});
     }
 
     /** Clear the MIDI output note display (no note playing). */

--- a/magda/daw/audio/plugins/MidiStrumPlugin.cpp
+++ b/magda/daw/audio/plugins/MidiStrumPlugin.cpp
@@ -259,8 +259,8 @@ void MidiStrumPlugin::resetStrumState() {
 }
 
 void MidiStrumPlugin::scheduleReleaseAll() {
-    for (int note : sounding_)
-        pending_.push_back({clock_, note, 0, false});
+    for (const auto& note : sounding_)
+        pending_.push_back({clock_, note.note, 0, false, note.sourceId});
 }
 
 void MidiStrumPlugin::scheduleStrum() {
@@ -297,7 +297,8 @@ void MidiStrumPlugin::scheduleStrum() {
         const float onset = juce::jlimit(0.0f, W, sampleCycled(lut_, u, cyc) * W);
         const int note = notes[static_cast<size_t>(i)].note;
         const int vel = juce::jlimit(1, 127, notes[static_cast<size_t>(i)].velocity);
-        pending_.push_back({clock_ + static_cast<std::int64_t>(onset), note, vel, true});
+        pending_.push_back({clock_ + static_cast<std::int64_t>(onset), note, vel, true,
+                            notes[static_cast<size_t>(i)].sourceId});
     }
 }
 
@@ -339,7 +340,7 @@ void MidiStrumPlugin::process(DeviceProcessContext& context) {
             held_.erase(std::remove_if(held_.begin(), held_.end(),
                                        [note](const Held& h) { return h.note == note; }),
                         held_.end());
-            held_.push_back({note, msg.getVelocity(), noteOrder_++});
+            held_.push_back({note, msg.getVelocity(), noteOrder_++, midi.sourceId(eventIndex)});
             collectLeft_ = juce::jmax(1, static_cast<int>(0.03 * sampleRate_));
         } else if (msg.isNoteOff()) {
             const int note = msg.getNoteNumber();
@@ -402,16 +403,19 @@ void MidiStrumPlugin::process(DeviceProcessContext& context) {
             auto message =
                 juce::MidiMessage::noteOn(1, p.note, static_cast<juce::uint8>(p.velocity));
             message.setTimeStamp(tib);
-            midi.addEvent({std::move(message), 0});
-            if (std::find(sounding_.begin(), sounding_.end(), p.note) == sounding_.end())
-                sounding_.push_back(p.note);
+            midi.addEvent({std::move(message), p.sourceId});
+            const auto held = std::find_if(sounding_.begin(), sounding_.end(),
+                                           [&p](const Sounding& s) { return s.note == p.note; });
+            if (held == sounding_.end())
+                sounding_.push_back({p.note, p.sourceId});
             lastDisplayNote = p.note;
             lastDisplayVel = p.velocity;
         } else {
             auto message = juce::MidiMessage::noteOff(1, p.note);
             message.setTimeStamp(tib);
-            midi.addEvent({std::move(message), 0});
-            sounding_.erase(std::remove(sounding_.begin(), sounding_.end(), p.note),
+            midi.addEvent({std::move(message), p.sourceId});
+            sounding_.erase(std::remove_if(sounding_.begin(), sounding_.end(),
+                                           [&p](const Sounding& s) { return s.note == p.note; }),
                             sounding_.end());
         }
     }

--- a/magda/daw/audio/plugins/MidiStrumPlugin.hpp
+++ b/magda/daw/audio/plugins/MidiStrumPlugin.hpp
@@ -92,12 +92,21 @@ class MidiStrumPlugin : public MidiMagdaDevice {
         int note = 0;
         int velocity = 0;
         std::int64_t order = 0;
+        /// Who played it, carried onto what this note strums. A device behind
+        /// this one reads provenance the same way, and the source is all of it
+        /// the host's buffer carries between them (#2416).
+        std::uint32_t sourceId = 0;
     };
     struct Pending {
         std::int64_t fireAt = 0;  // absolute sample clock
         int note = 0;
         int velocity = 0;    // 0..127
         bool gateOn = true;  // true = note-on, false = note-off
+        std::uint32_t sourceId = 0;
+    };
+    struct Sounding {
+        int note = 0;
+        std::uint32_t sourceId = 0;
     };
 
     void scheduleStrum();       // queue note-ons (+ Loop re-strum note-offs)
@@ -118,15 +127,15 @@ class MidiStrumPlugin : public MidiMagdaDevice {
 
     std::vector<Held> held_;
     std::vector<Pending> pending_;
-    std::vector<Pending> due_;       // scratch for the per-block emit pass
-    std::vector<int> sounding_;      // notes we have emitted note-on for, awaiting release
-    std::int64_t clock_ = 0;         // absolute sample counter
-    std::int64_t noteOrder_ = 0;     // play-order stamp for As-Played ordering
-    int collectLeft_ = -1;           // Chord-mode collect debounce (samples)
-    int syncLeft_ = 0;               // Loop-mode interval countdown (samples)
-    int lutShape_ = -1;              // shape index the LUT was built for
-    std::array<float, 1024> lut_{};  // current strum curve, sampled
-    bool wasPlaying_ = false;        // transport state last block (stop -> flush)
+    std::vector<Pending> due_;        // scratch for the per-block emit pass
+    std::vector<Sounding> sounding_;  // notes we have emitted note-on for, awaiting release
+    std::int64_t clock_ = 0;          // absolute sample counter
+    std::int64_t noteOrder_ = 0;      // play-order stamp for As-Played ordering
+    int collectLeft_ = -1;            // Chord-mode collect debounce (samples)
+    int syncLeft_ = 0;                // Loop-mode interval countdown (samples)
+    int lutShape_ = -1;               // shape index the LUT was built for
+    std::array<float, 1024> lut_{};   // current strum curve, sampled
+    bool wasPlaying_ = false;         // transport state last block (stop -> flush)
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(MidiStrumPlugin)
 };

--- a/magda/daw/audio/plugins/tracktion/TracktionMagdaDevicePlugin.cpp
+++ b/magda/daw/audio/plugins/tracktion/TracktionMagdaDevicePlugin.cpp
@@ -187,14 +187,25 @@ void TracktionMagdaDevicePlugin::refreshLiveSourceIds() {
     // (MidiInputDeviceNode), and nothing else in the graph uses those, so this
     // is exactly the set a device can trust as a player's keys.
     auto& deviceManager = engine.getDeviceManager();
-    const int available = std::min(deviceManager.getNumMidiInDevices(), kMaxLiveSourceIds);
-    int count = 0;
-    for (int i = 0; i < available; ++i) {
+    const int numInputs = deviceManager.getNumMidiInDevices();
+    std::vector<std::uint32_t> block;
+    block.reserve(static_cast<size_t>(numInputs) + 1);
+    block.push_back(0);
+    for (int i = 0; i < numInputs; ++i) {
         if (auto input = deviceManager.getMidiInDevice(i))
-            liveSourceIds_[static_cast<size_t>(count++)].store(
-                static_cast<std::uint32_t>(input->getMPESourceID()), std::memory_order_relaxed);
+            block.push_back(static_cast<std::uint32_t>(input->getMPESourceID()));
     }
-    numLiveSourceIds_.store(count, std::memory_order_release);
+    block[0] = static_cast<std::uint32_t>(block.size() - 1);
+
+    // Graphs are rebuilt for far more than a change of MIDI inputs, and an
+    // unchanged list publishes nothing and keeps no further block alive.
+    const auto* current = liveSources_.load(std::memory_order_relaxed);
+    if (current != nullptr && current[0] == block[0] &&
+        std::equal(block.begin() + 1, block.end(), current + 1))
+        return;
+
+    liveSourceBlocks_.push_back(std::move(block));
+    liveSources_.store(liveSourceBlocks_.back().data(), std::memory_order_release);
 }
 
 void TracktionMagdaDevicePlugin::deinitialise() {
@@ -226,11 +237,7 @@ void TracktionMagdaDevicePlugin::applyToBuffer(const te::PluginRenderContext& co
             ? (properties_.outputChannelCount > 0 ? properties_.outputChannelCount : 2)
             : -1;
 
-    std::array<std::uint32_t, kMaxLiveSourceIds> liveSourceIds{};
-    const int numLiveSourceIds = numLiveSourceIds_.load(std::memory_order_acquire);
-    for (int i = 0; i < numLiveSourceIds; ++i)
-        liveSourceIds[static_cast<size_t>(i)] =
-            liveSourceIds_[static_cast<size_t>(i)].load(std::memory_order_relaxed);
+    const auto* liveSources = liveSources_.load(std::memory_order_acquire);
 
     DeviceProcessContext deviceContext{
         .audio = context.destBuffer,
@@ -245,8 +252,8 @@ void TracktionMagdaDevicePlugin::applyToBuffer(const te::PluginRenderContext& co
         .isPlaying = context.isPlaying,
         .isScrubbing = context.isScrubbing,
         .isRendering = context.isRendering,
-        .liveSourceIds = liveSourceIds.data(),
-        .numLiveSourceIds = numLiveSourceIds,
+        .liveSourceIds = liveSources != nullptr ? liveSources + 1 : nullptr,
+        .numLiveSourceIds = liveSources != nullptr ? static_cast<int>(liveSources[0]) : 0,
     };
     device_->process(deviceContext);
 }

--- a/magda/daw/audio/plugins/tracktion/TracktionMagdaDevicePlugin.cpp
+++ b/magda/daw/audio/plugins/tracktion/TracktionMagdaDevicePlugin.cpp
@@ -175,10 +175,26 @@ void TracktionMagdaDevicePlugin::initialise(const te::PluginInitialisationInfo& 
     // was constructed with and audibly ramp to the real values over the first
     // block.
     syncParametersToDevice();
+    refreshLiveSourceIds();
     device_->prepare({
         .sampleRate = info.sampleRate,
         .maximumBlockSize = info.blockSizeSamples,
     });
+}
+
+void TracktionMagdaDevicePlugin::refreshLiveSourceIds() {
+    // Every MIDI input device stamps what it plays with its own MPE source id
+    // (MidiInputDeviceNode), and nothing else in the graph uses those, so this
+    // is exactly the set a device can trust as a player's keys.
+    auto& deviceManager = engine.getDeviceManager();
+    const int available = std::min(deviceManager.getNumMidiInDevices(), kMaxLiveSourceIds);
+    int count = 0;
+    for (int i = 0; i < available; ++i) {
+        if (auto input = deviceManager.getMidiInDevice(i))
+            liveSourceIds_[static_cast<size_t>(count++)].store(
+                static_cast<std::uint32_t>(input->getMPESourceID()), std::memory_order_relaxed);
+    }
+    numLiveSourceIds_.store(count, std::memory_order_release);
 }
 
 void TracktionMagdaDevicePlugin::deinitialise() {
@@ -210,6 +226,12 @@ void TracktionMagdaDevicePlugin::applyToBuffer(const te::PluginRenderContext& co
             ? (properties_.outputChannelCount > 0 ? properties_.outputChannelCount : 2)
             : -1;
 
+    std::array<std::uint32_t, kMaxLiveSourceIds> liveSourceIds{};
+    const int numLiveSourceIds = numLiveSourceIds_.load(std::memory_order_acquire);
+    for (int i = 0; i < numLiveSourceIds; ++i)
+        liveSourceIds[static_cast<size_t>(i)] =
+            liveSourceIds_[static_cast<size_t>(i)].load(std::memory_order_relaxed);
+
     DeviceProcessContext deviceContext{
         .audio = context.destBuffer,
         .sidechainInputChannel = sidechainChannel,
@@ -223,6 +245,8 @@ void TracktionMagdaDevicePlugin::applyToBuffer(const te::PluginRenderContext& co
         .isPlaying = context.isPlaying,
         .isScrubbing = context.isScrubbing,
         .isRendering = context.isRendering,
+        .liveSourceIds = liveSourceIds.data(),
+        .numLiveSourceIds = numLiveSourceIds,
     };
     device_->process(deviceContext);
 }

--- a/magda/daw/audio/plugins/tracktion/TracktionMagdaDevicePlugin.hpp
+++ b/magda/daw/audio/plugins/tracktion/TracktionMagdaDevicePlugin.hpp
@@ -2,7 +2,6 @@
 
 #include <tracktion_engine/tracktion_engine.h>
 
-#include <array>
 #include <atomic>
 #include <cstdint>
 #include <memory>
@@ -76,12 +75,13 @@ class TracktionMagdaDevicePlugin final : public te::Plugin {
     std::vector<te::AutomatableParameter::Ptr> parameters_;
 
     /// MPE source ids of the engine's MIDI inputs, which is what a device
-    /// reads to tell a player's keys from clip playback. Rebuilt whenever the
-    /// graph is, and published as atomics because the rebuild runs while the
-    /// previous graph is still calling applyToBuffer on this same plugin.
-    static constexpr int kMaxLiveSourceIds = 16;
-    std::array<std::atomic<std::uint32_t>, kMaxLiveSourceIds> liveSourceIds_{};
-    std::atomic<int> numLiveSourceIds_{0};
+    /// reads to tell a player's keys from clip playback. One immutable block,
+    /// count first and then the ids, because a graph rebuild runs while the
+    /// previous graph still calls applyToBuffer on this same plugin: a block
+    /// is never rewritten, and the ones it replaces outlive every reader by
+    /// living as long as the plugin.
+    std::atomic<const std::uint32_t*> liveSources_{nullptr};
+    std::vector<std::vector<std::uint32_t>> liveSourceBlocks_;
 };
 
 template <typename DeviceType> DeviceType* deviceFromPlugin(te::Plugin* plugin) {

--- a/magda/daw/audio/plugins/tracktion/TracktionMagdaDevicePlugin.hpp
+++ b/magda/daw/audio/plugins/tracktion/TracktionMagdaDevicePlugin.hpp
@@ -2,6 +2,9 @@
 
 #include <tracktion_engine/tracktion_engine.h>
 
+#include <array>
+#include <atomic>
+#include <cstdint>
 #include <memory>
 #include <vector>
 
@@ -60,6 +63,7 @@ class TracktionMagdaDevicePlugin final : public te::Plugin {
   private:
     void buildParameters();
     void syncParametersToDevice();
+    void refreshLiveSourceIds();
 
     std::unique_ptr<MagdaDevice> device_;
     /// Handed to the parameter conversion lambdas, which an automation curve can
@@ -70,6 +74,14 @@ class TracktionMagdaDevicePlugin final : public te::Plugin {
     const DeviceProperties properties_;
     std::vector<std::unique_ptr<juce::CachedValue<float>>> parameterValues_;
     std::vector<te::AutomatableParameter::Ptr> parameters_;
+
+    /// MPE source ids of the engine's MIDI inputs, which is what a device
+    /// reads to tell a player's keys from clip playback. Rebuilt whenever the
+    /// graph is, and published as atomics because the rebuild runs while the
+    /// previous graph is still calling applyToBuffer on this same plugin.
+    static constexpr int kMaxLiveSourceIds = 16;
+    std::array<std::atomic<std::uint32_t>, kMaxLiveSourceIds> liveSourceIds_{};
+    std::atomic<int> numLiveSourceIds_{0};
 };
 
 template <typename DeviceType> DeviceType* deviceFromPlugin(te::Plugin* plugin) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -73,6 +73,7 @@ set(TEST_SOURCES
     devices/test_mutable_clouds.cpp
     devices/test_arpeggiator_input.cpp
     devices/test_arpeggiator_transport.cpp
+    devices/test_midi_strum_provenance.cpp
     devices/test_device_ui_context.cpp
     ui/test_levels_ui.cpp
     # LevelsUI builds into magda_daw_app, so magda_tests needs its implementation

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -72,6 +72,7 @@ set(TEST_SOURCES
     devices/test_device_parameter_pagination.cpp
     devices/test_mutable_clouds.cpp
     devices/test_arpeggiator_input.cpp
+    devices/test_arpeggiator_transport.cpp
     devices/test_device_ui_context.cpp
     ui/test_levels_ui.cpp
     # LevelsUI builds into magda_daw_app, so magda_tests needs its implementation

--- a/tests/devices/ArpeggiatorTestRig.hpp
+++ b/tests/devices/ArpeggiatorTestRig.hpp
@@ -1,0 +1,99 @@
+#pragma once
+
+#include <catch2/catch_test_macros.hpp>
+#include <cstdint>
+#include <initializer_list>
+
+#include "TestDeviceMidiBuffer.hpp"
+#include "magda/daw/audio/plugins/ArpeggiatorPlugin.hpp"
+
+namespace magda::test {
+
+namespace audio = magda::daw::audio;
+using Arp = audio::ArpeggiatorPlugin;
+
+// Like the Tracktion view, additions may invalidate references. Also detect
+// writes before clear deterministically, without depending on a freed read
+// happening to return the wrong note on a particular allocator.
+class ArpMidiBuffer final : public DeviceMidiBuffer {
+  public:
+    bool cleared = false;
+    int additionsBeforeClear = 0;
+
+    void addEvent(audio::DeviceMidiEvent event) override {
+        if (!cleared)
+            ++additionsBeforeClear;
+        DeviceMidiBuffer::addEvent(std::move(event));
+    }
+    void clear() override {
+        DeviceMidiBuffer::clear();
+        cleared = true;
+    }
+};
+
+class ArpTempo final : public audio::DeviceTempoMap {
+  public:
+    double beatsAtSeconds(double seconds) const override {
+        return seconds * 2.0;
+    }
+    double bpmAtSeconds(double) const override {
+        return 120.0;
+    }
+};
+
+struct ArpRig {
+    Arp arp;
+    ArpTempo tempo;
+    /// Who the events come from. The arp learns which sources are live keys
+    /// rather than clip playback, so a test picks a source per phrase.
+    std::uint32_t source = 42;
+
+    explicit ArpRig(bool latch = false) {
+        arp.prepare({.sampleRate = 48000.0, .maximumBlockSize = 2400});
+        arp.setParameterValue(Arp::kLatch, latch ? 1.0f : 0.0f);
+        arp.setParameterValue(Arp::kGate, 1.0f);
+        setRate(Arp::Rate::Quarter);
+    }
+
+    void setRate(Arp::Rate rate) {
+        arp.setParameterValue(
+            Arp::kRate, magda::ParameterUtils::realToNormalized(static_cast<float>(rate),
+                                                                arp.parameterInfo(Arp::kRate)));
+    }
+
+    ArpMidiBuffer run(double start, std::initializer_list<juce::MidiMessage> input = {},
+                      bool playing = true, bool panic = false) {
+        ArpMidiBuffer midi;
+        midi.setAllNotesOff(panic);
+        for (const auto& message : input)
+            midi.events.push_back({message, source});
+        midi.events.shrink_to_fit();
+        audio::DeviceProcessContext context;
+        context.midi = &midi;
+        context.tempoMap = &tempo;
+        context.numSamples = 2400;
+        context.timelineStartSeconds = start;
+        context.timelineEndSeconds = start + 0.05;
+        context.isPlaying = playing;
+        arp.process(context);
+        CHECK(midi.additionsBeforeClear == 0);
+        return midi;
+    }
+
+    void startNote() {
+        auto midi = run(0.0, {juce::MidiMessage::noteOn(1, 60, juce::uint8{91})});
+        REQUIRE(midi.size() == 1);
+        REQUIRE(midi.message(0).isNoteOn());
+        REQUIRE(midi.message(0).getNoteNumber() == 60);
+    }
+};
+
+inline void checkNoteOff(const ArpMidiBuffer& midi, int index = 0, int noteNumber = 60) {
+    REQUIRE(midi.size() > index);
+    CHECK(midi.message(index).isNoteOff());
+    CHECK(midi.message(index).getNoteNumber() == noteNumber);
+    CHECK(midi.message(index).getChannel() == 1);
+    CHECK(midi.message(index).getTimeStamp() == 0.0);
+}
+
+}  // namespace magda::test

--- a/tests/devices/ArpeggiatorTestRig.hpp
+++ b/tests/devices/ArpeggiatorTestRig.hpp
@@ -3,6 +3,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <cstdint>
 #include <initializer_list>
+#include <vector>
 
 #include "TestDeviceMidiBuffer.hpp"
 #include "magda/daw/audio/plugins/ArpeggiatorPlugin.hpp"
@@ -44,9 +45,11 @@ class ArpTempo final : public audio::DeviceTempoMap {
 struct ArpRig {
     Arp arp;
     ArpTempo tempo;
-    /// Who the events come from. The arp learns which sources are live keys
-    /// rather than clip playback, so a test picks a source per phrase.
+    /// Who the events come from, and which sources the host calls live input.
+    /// The two together are how the arp tells a player's keys from clip
+    /// playback, so a test says which of the two this phrase is.
     std::uint32_t source = 42;
+    std::vector<std::uint32_t> liveSourceIds;
 
     explicit ArpRig(bool latch = false) {
         arp.prepare({.sampleRate = 48000.0, .maximumBlockSize = 2400});
@@ -75,6 +78,8 @@ struct ArpRig {
         context.timelineStartSeconds = start;
         context.timelineEndSeconds = start + 0.05;
         context.isPlaying = playing;
+        context.liveSourceIds = liveSourceIds.empty() ? nullptr : liveSourceIds.data();
+        context.numLiveSourceIds = static_cast<int>(liveSourceIds.size());
         arp.process(context);
         CHECK(midi.additionsBeforeClear == 0);
         return midi;

--- a/tests/devices/test_arpeggiator_input.cpp
+++ b/tests/devices/test_arpeggiator_input.cpp
@@ -54,7 +54,7 @@ TEST_CASE("Arpeggiator input resets retain a single pending note-off",
     CHECK(midi.message(1).getVelocity() == 73);
 }
 
-TEST_CASE("Arpeggiator buffer panic stops its note and keeps the latched chord",
+TEST_CASE("Arpeggiator buffer panic drops a latched chord it cannot prove is live",
           "[arpeggiator][midi][input]") {
     Rig rig(true);
     rig.startNote();
@@ -63,13 +63,11 @@ TEST_CASE("Arpeggiator buffer panic stops its note and keeps the latched chord",
     CHECK(midi.isAllNotesOff());
     REQUIRE(midi.size() == 1);
     checkOff(midi);
-    // The latch is the arp's own memory of a chord, and a host relocating is
-    // not the player letting go, so the walk re-anchors and plays it again.
+    // Nothing here ever played with the transport stopped, so the chord may be
+    // clip playback the host is about to re-assert somewhere else.
     auto next = rig.run(0.5);
     CHECK_FALSE(next.isAllNotesOff());
-    REQUIRE(next.size() == 1);
-    CHECK(next.message(0).isNoteOn());
-    CHECK(next.message(0).getNoteNumber() == 60);
+    CHECK(next.size() == 0);
 }
 
 TEST_CASE("Arpeggiator buffer panic permits fresh input without duplicate note-offs",

--- a/tests/devices/test_arpeggiator_input.cpp
+++ b/tests/devices/test_arpeggiator_input.cpp
@@ -1,88 +1,13 @@
 #include <catch2/catch_test_macros.hpp>
-#include <initializer_list>
 
-#include "TestDeviceMidiBuffer.hpp"
-#include "magda/daw/audio/plugins/ArpeggiatorPlugin.hpp"
+#include "devices/ArpeggiatorTestRig.hpp"
 
 namespace {
-namespace audio = magda::daw::audio;
-using Arp = audio::ArpeggiatorPlugin;
+using magda::test::ArpMidiBuffer;
+using Rig = magda::test::ArpRig;
 
-// Like the Tracktion view, additions may invalidate references. Also detect
-// writes before clear deterministically, without depending on a freed read
-// happening to return the wrong note on a particular allocator.
-class MidiBuffer final : public magda::test::DeviceMidiBuffer {
-  public:
-    bool cleared = false;
-    int additionsBeforeClear = 0;
-
-    void addEvent(audio::DeviceMidiEvent event) override {
-        if (!cleared)
-            ++additionsBeforeClear;
-        magda::test::DeviceMidiBuffer::addEvent(std::move(event));
-    }
-    void clear() override {
-        magda::test::DeviceMidiBuffer::clear();
-        cleared = true;
-    }
-};
-
-class Tempo final : public audio::DeviceTempoMap {
-  public:
-    double beatsAtSeconds(double seconds) const override {
-        return seconds * 2.0;
-    }
-    double bpmAtSeconds(double) const override {
-        return 120.0;
-    }
-};
-
-struct Rig {
-    Arp arp;
-    Tempo tempo;
-
-    explicit Rig(bool latch = false) {
-        arp.prepare({.sampleRate = 48000.0, .maximumBlockSize = 2400});
-        arp.setParameterValue(Arp::kLatch, latch ? 1.0f : 0.0f);
-        arp.setParameterValue(Arp::kGate, 1.0f);
-        arp.setParameterValue(
-            Arp::kRate, magda::ParameterUtils::realToNormalized(
-                            static_cast<float>(Arp::Rate::Quarter), arp.parameterInfo(Arp::kRate)));
-    }
-
-    MidiBuffer run(double start, std::initializer_list<juce::MidiMessage> input = {},
-                   bool playing = true, bool panic = false) {
-        MidiBuffer midi;
-        midi.setAllNotesOff(panic);
-        for (const auto& message : input)
-            midi.events.push_back({message, 42});
-        midi.events.shrink_to_fit();
-        audio::DeviceProcessContext context;
-        context.midi = &midi;
-        context.tempoMap = &tempo;
-        context.numSamples = 2400;
-        context.timelineStartSeconds = start;
-        context.timelineEndSeconds = start + 0.05;
-        context.isPlaying = playing;
-        arp.process(context);
-        CHECK(midi.additionsBeforeClear == 0);
-        return midi;
-    }
-
-    void startNote() {
-        auto midi = run(0.0, {juce::MidiMessage::noteOn(1, 60, juce::uint8{91})});
-        REQUIRE(midi.size() == 1);
-        REQUIRE(midi.message(0).isNoteOn());
-        REQUIRE(midi.message(0).getNoteNumber() == 60);
-    }
-};
-
-void checkOff(const MidiBuffer& midi, int index = 0) {
-    REQUIRE(midi.size() > index);
-    CHECK(midi.message(index).isNoteOff());
-    CHECK(midi.message(index).getNoteNumber() == 60);
-    CHECK(midi.message(index).getChannel() == 1);
-    CHECK(midi.message(index).getTimeStamp() == 0.0);
+void checkOff(const ArpMidiBuffer& midi, int index = 0) {
+    magda::test::checkNoteOff(midi, index);
 }
 }  // namespace
 
@@ -129,7 +54,7 @@ TEST_CASE("Arpeggiator input resets retain a single pending note-off",
     CHECK(midi.message(1).getVelocity() == 73);
 }
 
-TEST_CASE("Arpeggiator buffer panic stops and clears a latched chord",
+TEST_CASE("Arpeggiator buffer panic stops its note and keeps the latched chord",
           "[arpeggiator][midi][input]") {
     Rig rig(true);
     rig.startNote();
@@ -138,9 +63,13 @@ TEST_CASE("Arpeggiator buffer panic stops and clears a latched chord",
     CHECK(midi.isAllNotesOff());
     REQUIRE(midi.size() == 1);
     checkOff(midi);
+    // The latch is the arp's own memory of a chord, and a host relocating is
+    // not the player letting go, so the walk re-anchors and plays it again.
     auto next = rig.run(0.5);
     CHECK_FALSE(next.isAllNotesOff());
-    CHECK(next.size() == 0);
+    REQUIRE(next.size() == 1);
+    CHECK(next.message(0).isNoteOn());
+    CHECK(next.message(0).getNoteNumber() == 60);
 }
 
 TEST_CASE("Arpeggiator buffer panic permits fresh input without duplicate note-offs",
@@ -183,7 +112,7 @@ TEST_CASE("Arpeggiator release and transport stop still send one note-off",
           "[arpeggiator][midi][input]") {
     Rig rig;
     rig.startNote();
-    MidiBuffer midi;
+    ArpMidiBuffer midi;
     SECTION("release") {
         midi = rig.run(0.05, {juce::MidiMessage::noteOff(1, 60)});
     }

--- a/tests/devices/test_arpeggiator_transport.cpp
+++ b/tests/devices/test_arpeggiator_transport.cpp
@@ -63,6 +63,44 @@ TEST_CASE("Arpeggiator keeps live keys across a transport stop", "[arpeggiator][
         CHECK(rig.run(0.0, {}, false).size() == 0);
 }
 
+TEST_CASE("Arpeggiator keeps a live key a clip is doubling", "[arpeggiator][midi][transport]") {
+    Rig rig;
+    rig.liveSourceIds = {rig.source};
+    rig.startNote();
+
+    // A clip lands on the pitch already under the player's finger. The pattern
+    // holds one note either way, but two holders now have it.
+    const auto live = rig.source;
+    rig.source = live + 1;
+    rig.run(0.05, {on(60)});
+    rig.source = live;
+
+    auto midi = rig.run(0.1, {}, false);
+    REQUIRE(midi.size() == 2);
+    checkNoteOff(midi, 0);
+    CHECK(midi.message(1).isNoteOn());
+    CHECK(midi.message(1).getNoteNumber() == 60);
+}
+
+TEST_CASE("Arpeggiator drops a clip note a live key of another pitch does not hold",
+          "[arpeggiator][midi][transport]") {
+    Rig rig;
+    rig.liveSourceIds = {rig.source + 1};
+    rig.startNote();
+
+    rig.source = rig.source + 1;
+    rig.run(0.05, {on(67)});
+
+    auto midi = rig.run(0.1, {}, false);
+    REQUIRE(midi.size() >= 1);
+    // Only the live key is left, so the pattern has one note and it is not 60.
+    for (int block = 0; block < 12; ++block) {
+        auto next = rig.run(0.0, {}, false);
+        for (int i = 0; i < next.size(); ++i)
+            CHECK(next.message(i).getNoteNumber() == 67);
+    }
+}
+
 TEST_CASE("Arpeggiator stopping drops held notes the host does not call live input",
           "[arpeggiator][midi][transport]") {
     Rig rig;

--- a/tests/devices/test_arpeggiator_transport.cpp
+++ b/tests/devices/test_arpeggiator_transport.cpp
@@ -1,0 +1,102 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "devices/ArpeggiatorTestRig.hpp"
+
+namespace {
+using magda::test::checkNoteOff;
+using Arp = magda::test::Arp;
+using Rig = magda::test::ArpRig;
+
+juce::MidiMessage on(int note) {
+    return juce::MidiMessage::noteOn(1, note, juce::uint8{91});
+}
+}  // namespace
+
+TEST_CASE("Arpeggiator re-anchors on a loop wrap no host flags", "[arpeggiator][midi][transport]") {
+    Rig rig;
+    rig.startNote();
+    // Contiguous playback up to the loop end, with the note still sounding.
+    for (int block = 1; block < 10; ++block)
+        rig.run(block * 0.05);
+
+    auto midi = rig.run(0.0);
+    CHECK_FALSE(midi.isAllNotesOff());
+    REQUIRE(midi.size() == 2);
+    checkNoteOff(midi, 0);
+    CHECK(midi.message(1).isNoteOn());
+    CHECK(midi.message(1).getNoteNumber() == 60);
+}
+
+TEST_CASE("Arpeggiator seeking far ahead lands on the new grid", "[arpeggiator][midi][transport]") {
+    Rig rig;
+    rig.setRate(Arp::Rate::ThirtySecond);
+    auto first = rig.run(0.0, {on(60), on(64), on(67)});
+    REQUIRE(first.size() == 1);
+    CHECK(first.message(0).isNoteOn());
+
+    // Ten minutes on at 1/32 is some 9600 steps away.
+    auto midi = rig.run(600.0);
+    REQUIRE(midi.size() == 2);
+    checkNoteOff(midi, 0);
+    CHECK(midi.message(1).isNoteOn());
+    CHECK(midi.message(1).getNoteNumber() == 60);
+    CHECK(midi.message(1).getTimeStamp() == 0.0);
+}
+
+TEST_CASE("Arpeggiator keeps live keys across a transport stop", "[arpeggiator][midi][transport]") {
+    Rig rig;
+    // Played with the transport stopped, so this source is not clip playback.
+    REQUIRE(rig.run(0.0, {on(60)}, false).size() == 1);
+    rig.run(0.0, {}, true);
+
+    auto midi = rig.run(0.05, {}, false);
+    REQUIRE(midi.size() == 2);
+    checkNoteOff(midi, 0);
+    CHECK(midi.message(1).isNoteOn());
+    CHECK(midi.message(1).getNoteNumber() == 60);
+
+    // The key releases the arp the way it would have before the stop.
+    rig.run(0.0, {juce::MidiMessage::noteOff(1, 60)}, false);
+    for (int block = 0; block < 20; ++block)
+        CHECK(rig.run(0.0, {}, false).size() == 0);
+}
+
+TEST_CASE("Arpeggiator drops notes a clip left behind when the transport stops",
+          "[arpeggiator][midi][transport]") {
+    Rig rig;
+    // Only ever seen while playing, so it may be a clip whose note-off will
+    // never arrive.
+    rig.startNote();
+
+    auto midi = rig.run(0.05, {}, false);
+    REQUIRE(midi.size() == 1);
+    checkNoteOff(midi, 0);
+    for (int block = 0; block < 20; ++block)
+        CHECK(rig.run(0.0, {}, false).size() == 0);
+}
+
+TEST_CASE("Arpeggiator keeps live keys when the transport starts under a panic",
+          "[arpeggiator][midi][transport]") {
+    Rig rig;
+    REQUIRE(rig.run(0.0, {on(60)}, false).size() == 1);
+
+    auto midi = rig.run(0.0, {}, true, true);
+    CHECK(midi.isAllNotesOff());
+    REQUIRE(midi.size() == 2);
+    checkNoteOff(midi, 0);
+    CHECK(midi.message(1).isNoteOn());
+    CHECK(midi.message(1).getNoteNumber() == 60);
+}
+
+TEST_CASE("Arpeggiator locating under a panic keeps the chord and re-anchors",
+          "[arpeggiator][midi][transport]") {
+    Rig rig;
+    rig.startNote();
+
+    auto midi = rig.run(4.0, {}, true, true);
+    CHECK(midi.isAllNotesOff());
+    REQUIRE(midi.size() == 2);
+    checkNoteOff(midi, 0);
+    CHECK(midi.message(1).isNoteOn());
+    CHECK(midi.message(1).getNoteNumber() == 60);
+}

--- a/tests/devices/test_arpeggiator_transport.cpp
+++ b/tests/devices/test_arpeggiator_transport.cpp
@@ -61,7 +61,7 @@ TEST_CASE("Arpeggiator keeps live keys across a transport stop", "[arpeggiator][
         CHECK(rig.run(0.0, {}, false).size() == 0);
 }
 
-TEST_CASE("Arpeggiator drops notes a clip left behind when the transport stops",
+TEST_CASE("Arpeggiator stopping drops held notes it cannot prove came from a player",
           "[arpeggiator][midi][transport]") {
     Rig rig;
     // Only ever seen while playing, so it may be a clip whose note-off will
@@ -88,10 +88,11 @@ TEST_CASE("Arpeggiator keeps live keys when the transport starts under a panic",
     CHECK(midi.message(1).getNoteNumber() == 60);
 }
 
-TEST_CASE("Arpeggiator locating under a panic keeps the chord and re-anchors",
+TEST_CASE("Arpeggiator locating under a panic keeps a chord proven live",
           "[arpeggiator][midi][transport]") {
     Rig rig;
-    rig.startNote();
+    REQUIRE(rig.run(0.0, {on(60)}, false).size() == 1);
+    rig.run(0.0, {}, true);
 
     auto midi = rig.run(4.0, {}, true, true);
     CHECK(midi.isAllNotesOff());
@@ -99,4 +100,31 @@ TEST_CASE("Arpeggiator locating under a panic keeps the chord and re-anchors",
     checkNoteOff(midi, 0);
     CHECK(midi.message(1).isNoteOn());
     CHECK(midi.message(1).getNoteNumber() == 60);
+}
+
+TEST_CASE("Arpeggiator locating out of a clip note does not retrigger it",
+          "[arpeggiator][midi][transport]") {
+    Rig rig;
+    rig.startNote();
+
+    // The host re-asserts what sounds at the destination and says nothing
+    // about what only sounded at the old position, so the note goes with it.
+    auto midi = rig.run(4.0, {}, true, true);
+    CHECK(midi.isAllNotesOff());
+    REQUIRE(midi.size() == 1);
+    checkNoteOff(midi, 0);
+    for (int block = 0; block < 10; ++block)
+        CHECK(rig.run(4.05 + block * 0.05).size() == 0);
+}
+
+TEST_CASE("Arpeggiator plays what the host re-asserts under a panic",
+          "[arpeggiator][midi][transport]") {
+    Rig rig;
+    rig.startNote();
+
+    auto midi = rig.run(4.0, {on(64)}, true, true);
+    REQUIRE(midi.size() == 2);
+    checkNoteOff(midi, 0);
+    CHECK(midi.message(1).isNoteOn());
+    CHECK(midi.message(1).getNoteNumber() == 64);
 }

--- a/tests/devices/test_arpeggiator_transport.cpp
+++ b/tests/devices/test_arpeggiator_transport.cpp
@@ -45,9 +45,10 @@ TEST_CASE("Arpeggiator seeking far ahead lands on the new grid", "[arpeggiator][
 
 TEST_CASE("Arpeggiator keeps live keys across a transport stop", "[arpeggiator][midi][transport]") {
     Rig rig;
-    // Played with the transport stopped, so this source is not clip playback.
-    REQUIRE(rig.run(0.0, {on(60)}, false).size() == 1);
-    rig.run(0.0, {}, true);
+    rig.liveSourceIds = {rig.source};
+    // First pressed with the transport already rolling, which is the case that
+    // no amount of watching the input can tell apart from a clip.
+    rig.startNote();
 
     auto midi = rig.run(0.05, {}, false);
     REQUIRE(midi.size() == 2);
@@ -55,17 +56,18 @@ TEST_CASE("Arpeggiator keeps live keys across a transport stop", "[arpeggiator][
     CHECK(midi.message(1).isNoteOn());
     CHECK(midi.message(1).getNoteNumber() == 60);
 
-    // The key releases the arp the way it would have before the stop.
-    rig.run(0.0, {juce::MidiMessage::noteOff(1, 60)}, false);
+    auto released = rig.run(0.0, {juce::MidiMessage::noteOff(1, 60)}, false);
+    REQUIRE(released.size() == 1);
+    checkNoteOff(released, 0);
     for (int block = 0; block < 20; ++block)
         CHECK(rig.run(0.0, {}, false).size() == 0);
 }
 
-TEST_CASE("Arpeggiator stopping drops held notes it cannot prove came from a player",
+TEST_CASE("Arpeggiator stopping drops held notes the host does not call live input",
           "[arpeggiator][midi][transport]") {
     Rig rig;
-    // Only ever seen while playing, so it may be a clip whose note-off will
-    // never arrive.
+    // A live input exists, but this phrase is not coming from it.
+    rig.liveSourceIds = {rig.source + 1};
     rig.startNote();
 
     auto midi = rig.run(0.05, {}, false);
@@ -78,6 +80,7 @@ TEST_CASE("Arpeggiator stopping drops held notes it cannot prove came from a pla
 TEST_CASE("Arpeggiator keeps live keys when the transport starts under a panic",
           "[arpeggiator][midi][transport]") {
     Rig rig;
+    rig.liveSourceIds = {rig.source};
     REQUIRE(rig.run(0.0, {on(60)}, false).size() == 1);
 
     auto midi = rig.run(0.0, {}, true, true);
@@ -91,8 +94,8 @@ TEST_CASE("Arpeggiator keeps live keys when the transport starts under a panic",
 TEST_CASE("Arpeggiator locating under a panic keeps a chord proven live",
           "[arpeggiator][midi][transport]") {
     Rig rig;
-    REQUIRE(rig.run(0.0, {on(60)}, false).size() == 1);
-    rig.run(0.0, {}, true);
+    rig.liveSourceIds = {rig.source};
+    rig.startNote();
 
     auto midi = rig.run(4.0, {}, true, true);
     CHECK(midi.isAllNotesOff());
@@ -105,6 +108,7 @@ TEST_CASE("Arpeggiator locating under a panic keeps a chord proven live",
 TEST_CASE("Arpeggiator locating out of a clip note does not retrigger it",
           "[arpeggiator][midi][transport]") {
     Rig rig;
+    rig.liveSourceIds = {rig.source + 1};
     rig.startNote();
 
     // The host re-asserts what sounds at the destination and says nothing

--- a/tests/devices/test_arpeggiator_transport.cpp
+++ b/tests/devices/test_arpeggiator_transport.cpp
@@ -101,6 +101,51 @@ TEST_CASE("Arpeggiator drops a clip note a live key of another pitch does not ho
     }
 }
 
+TEST_CASE("Arpeggiator keeps a pitch two live inputs hold when one lets go",
+          "[arpeggiator][midi][transport]") {
+    Rig rig;
+    const auto first = rig.source;
+    const auto second = first + 1;
+    rig.liveSourceIds = {first, second};
+    rig.startNote();
+    rig.source = second;
+    rig.run(0.05, {on(60)});
+
+    rig.run(0.1, {}, false);
+    rig.run(0.0, {juce::MidiMessage::noteOff(1, 60)}, false);
+
+    // One input let go of the pitch; the other still has it down.
+    bool played = false;
+    for (int block = 0; block < 12 && !played; ++block) {
+        auto midi = rig.run(0.0, {}, false);
+        played = midi.size() > 0 && midi.message(midi.size() - 1).isNoteOn();
+    }
+    CHECK(played);
+}
+
+TEST_CASE("Arpeggiator stamps what it plays with the provenance it was given",
+          "[arpeggiator][midi][transport]") {
+    Rig rig;
+    rig.liveSourceIds = {rig.source};
+    auto midi = rig.run(0.0, {on(60)});
+    REQUIRE(midi.size() == 1);
+    CHECK(midi.message(0).isNoteOn());
+    CHECK(midi.events[0].sourceId == rig.source);
+
+    // The note-off closing it says the same, so a device behind this one reads
+    // one note from one origin.
+    auto stopped = rig.run(0.05, {}, false);
+    REQUIRE(stopped.size() >= 1);
+    CHECK(stopped.message(0).isNoteOff());
+    CHECK(stopped.events[0].sourceId == rig.source);
+
+    // A clip's note keeps its own origin rather than being flattened to none.
+    Rig fromClip;
+    auto clipMidi = fromClip.run(0.0, {on(60)});
+    REQUIRE(clipMidi.size() == 1);
+    CHECK(clipMidi.events[0].sourceId == fromClip.source);
+}
+
 TEST_CASE("Arpeggiator stopping drops held notes the host does not call live input",
           "[arpeggiator][midi][transport]") {
     Rig rig;

--- a/tests/devices/test_midi_strum_provenance.cpp
+++ b/tests/devices/test_midi_strum_provenance.cpp
@@ -1,0 +1,46 @@
+#include <catch2/catch_test_macros.hpp>
+#include <cstdint>
+#include <initializer_list>
+
+#include "TestDeviceMidiBuffer.hpp"
+#include "magda/daw/audio/plugins/MidiStrumPlugin.hpp"
+
+namespace {
+namespace audio = magda::daw::audio;
+
+magda::test::DeviceMidiBuffer runBlock(audio::MidiStrumPlugin& strum,
+                                       std::initializer_list<juce::MidiMessage> input,
+                                       std::uint32_t source) {
+    magda::test::DeviceMidiBuffer midi;
+    for (const auto& message : input)
+        midi.events.push_back({message, source});
+    audio::DeviceProcessContext context;
+    context.midi = &midi;
+    context.numSamples = 2400;
+    context.isPlaying = true;
+    strum.process(context);
+    return midi;
+}
+}  // namespace
+
+TEST_CASE("Strum hands on the provenance of the chord it was given", "[strum][midi]") {
+    audio::MidiStrumPlugin strum;
+    strum.prepare({.sampleRate = 48000.0, .maximumBlockSize = 2400});
+
+    constexpr std::uint32_t kSource = 77;
+    int strummed = 0;
+    // The collect window closes inside the first block; the onsets are spread
+    // over the strum length, so give them a few blocks to all land.
+    for (int block = 0; block < 4; ++block) {
+        const auto midi =
+            block == 0
+                ? runBlock(strum, {juce::MidiMessage::noteOn(1, 60, juce::uint8{91})}, kSource)
+                : runBlock(strum, {}, 0);
+        for (int i = 0; i < midi.size(); ++i) {
+            INFO("block " << block << " event " << i);
+            CHECK(midi.events[static_cast<size_t>(i)].sourceId == kSource);
+            ++strummed;
+        }
+    }
+    CHECK(strummed > 0);
+}


### PR DESCRIPTION
Closes #2416.

## The signals, traced

| Event | Tracktion | Native engine |
| --- | --- | --- |
| Transport start | panic flag (`PlayHead::play` moves `isPlayHeadRunning`) | nothing |
| Locate / drag | panic flag (`userInteraction()` -> `didPlayheadJump()`) | nothing |
| Loop wrap | **nothing** (`firstBlockOfLoop`, which `PluginNode` does not turn into a panic) | nothing |
| Track mute | panic flag (`wasJustMuted()`) | nothing |
| Transport stop | nothing (`PlayHead::stop` re-sets the same position, so no interaction) | nothing |
| CC120 / CC123 | message | message |

The native engine column is empty because `EngineMidiBufferView::allNotesOff_` is a per-block local that is never seeded or read back (#2418).

## What the device does now

**Discontinuity comes from the timeline, not from the flag.** A block that does not continue the previous one, by seek, loop wrap or the switch between the transport and the free-running clock, releases the sounding note once and re-anchors the walk. The loop wrap is the case that mattered: no host flags it, and `currentStep_` was left ahead of the transport, so the arp fell silent for the rest of playback with its last note still sounding.

**Catch-up is bounded.** Cycles are evenly spaced whatever the ramp does inside one, so the cycle holding the block start is a division and only its steps are walked.

**The panic flag says the host is re-asserting, not that the player let go.** It stops the sounding note and is forwarded downstream. The host's own held notes go with it and come back on the same buffer, because a seek re-asserts what sounds at the destination and says nothing about what sounded only at the old position; keeping them retriggered a stale clip note. Keys proven to be a player's stay. A CC120/CC123 *message* still clears the set, because that is a real all-notes-off from the source.

**Provenance travels with the note.** A device that rewrites its input used to stamp what it emitted with source 0, so an arpeggiator behind a strum or another arpeggiator read a live chord as host playback. Both now carry the source of the input the output came from, and a note-off repeats its note-on's. The source is the whole of the provenance the host's buffer keeps between two devices, so propagating it is what makes this survive a chain; a new field on `DeviceMidiEvent` would be dropped at the first `te::MidiMessageArray`.

**A pitch tracks its holders per side.** The pattern carries a pitch once, but a player and a clip can both be holding it, so a held note counts live and host holds separately and releases them independently. Deduplicating by pitch alone let the last note-on claim the note, which lost a key still under a finger to a clip landing on the same pitch, and kept a clip note alive on a live key's claim the other way round.

**Both edges use one rule: keep what the host's live inputs hold.** `DeviceProcessContext` now carries the source ids the host calls live input, and the Tracktion adapter fills it from the MPE source id every `MidiInputDevice` stamps its messages with, which nothing else in the graph uses. A key first pressed mid-playback is therefore known to be a key, which no amount of watching the input could establish. Its notes survive a panic and carry into free-run after a stop, releasing normally when it comes up; everything else is dropped. An empty list means nothing is known live, never everything, so the native engine keeps the behavior it had (#2418).

## Tests

Twelve cases in `tests/devices/test_arpeggiator_transport.cpp`: loop wrap, far seek, a chord first pressed mid-playback surviving a stop and releasing normally, notes from a source the host does not call live input dropped on stop, start under a panic, locate under a panic, locate out of a clip note without a retrigger, playing what the host re-asserts under a panic, a live key a clip is doubling surviving a stop, a clip note dropped when the live key holds a different pitch, a pitch two live inputs hold surviving one of them letting go, and the provenance stamped on what the arp plays. `tests/devices/test_midi_strum_provenance.cpp` covers the strum's half. Discontinuities are driven with the flag both on and off, which is what separates the two adapters today. The rig moved to a shared `tests/devices/ArpeggiatorTestRig.hpp`.

One existing case says what it actually pins: a buffer panic drops a latched chord it cannot prove is live.

Full Catch2 suite green: 3601 passed, 13 skipped.

## Left open

The native engine names no live input and stamps every event 0, so on that adapter a stop still drops every held note, as it did before. That is #2418, which also blocks a genuine engine-adapter loop and restart test.

An explicit discontinuity kind on `DeviceProcessContext` (start, stop, seek, loop wrap, mute) would beat inferring it from the timeline, but it needs both adapters to fill it and Tracktion does not separate those cases either, so the timeline comparison stays the mechanism rather than a fallback for now.

https://claude.ai/code/session_013A1GWqAoLZPdkYAMwKrjQj
