### PR TITLE
Speed up Linux CI with Catch2 sharding and focused builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -277,7 +277,9 @@ jobs:
     - name: Build
       run: |
         echo "Building with $(nproc) cores..."
-        cmake --build build --config Debug -j$(nproc)
+        # JUCE tests are built and run by juce-tests-linux.yml. Keep the app
+        # link check here, without also building that second test executable.
+        cmake --build build --config Debug --target magda_daw_app magda_tests -j"$(nproc)"
 
     - name: Populate prebuilt Faust/Mutable artifacts (R2)
       if: steps.r2-creds.outcome == 'success'
@@ -313,17 +315,13 @@ jobs:
         find build -name "magda_tests" -type f || echo "magda_tests executable not found"
 
     - name: Run tests
+      timeout-minutes: 15
       run: |
-        if [ -f build/tests/magda_tests ]; then
-          echo "Running tests..."
-          cd build
-          ./tests/magda_tests
-        else
-          echo "❌ Tests executable not found at build/tests/magda_tests"
-          echo "Build directory contents:"
-          find build -type f -name "*test*" || true
-          exit 1
-        fi
+        # Match available cores, capped at four to bound Debug-process memory.
+        shards=$(nproc)
+        if [ "$shards" -gt 4 ]; then shards=4; fi
+        cd build
+        bash "$GITHUB_WORKSPACE/scripts/ci-test-shards.sh" ./tests/magda_tests "$shards"
 
     - name: Show sccache statistics
       if: steps.sccache.outcome == 'success'

--- a/scripts/ci-test-shards.sh
+++ b/scripts/ci-test-shards.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Run disjoint Catch2 shards concurrently, preserving every shard's output.
+# Usage: bash scripts/ci-test-shards.sh TEST_BINARY SHARD_COUNT [CATCH2_ARGS...]
+set -euo pipefail
+
+test_binary=${1:?Expected a Catch2 test executable}
+shards=${2:?Expected a shard count}
+shift 2
+if [[ ! -x "$test_binary" ]]; then
+    echo "Test executable not found or not executable: $test_binary" >&2
+    exit 1
+fi
+if [[ ! "$shards" =~ ^[1-9][0-9]*$ ]]; then
+    echo "Shard count must be a positive integer: $shards" >&2
+    exit 1
+fi
+
+outdir=$(mktemp -d "${RUNNER_TEMP:-${TMPDIR:-/tmp}}/magda-test-shards.XXXXXX")
+echo "Running $shards Catch2 shards; logs and isolated state: $outdir"
+pids=()
+stop_shards() {
+    for pid in "${pids[@]}"; do
+        kill "$pid" 2>/dev/null || true
+    done
+    wait || true
+}
+trap 'exit 130' INT
+trap 'exit 143' TERM
+trap stop_shards EXIT
+
+for ((i = 0; i < shards; i++)); do
+    shard_dir="$outdir/shard-$i"
+    mkdir -p "$shard_dir/tmp" "$shard_dir/config" "$shard_dir/data" "$shard_dir/cache"
+    # Shared fixture names and application settings must not cross processes.
+    TMPDIR="$shard_dir/tmp" \
+    XDG_CONFIG_HOME="$shard_dir/config" \
+    XDG_DATA_HOME="$shard_dir/data" \
+    XDG_CACHE_HOME="$shard_dir/cache" \
+        "$test_binary" --shard-count "$shards" --shard-index "$i" "$@" \
+        > "$outdir/shard-$i.log" 2>&1 &
+    pids+=("$!")
+done
+
+failed=0
+for ((i = 0; i < shards; i++)); do
+    rc=0
+    wait "${pids[$i]}" || rc=$?
+    echo "===== Catch2 shard $i/$shards (exit $rc) ====="
+    cat "$outdir/shard-$i.log"
+    if [[ "$rc" -ne 0 ]]; then
+        failed=$((failed + 1))
+    fi
+done
+trap - EXIT
+echo "$failed of $shards Catch2 shards failed"
+[[ "$failed" -eq 0 ]]


### PR DESCRIPTION
The main Linux CI job still runs Catch2 serially and builds the JUCE test executable already covered by the separate Linux JUCE workflow. In successful dev run 33978190323, Linux spent 14m08s building and 3m05s testing.

Build the app and Catch2 targets explicitly, preserving the app link check, and run disjoint Catch2 shards concurrently using the available core count, capped at four. Each shard gets isolated temporary files and XDG settings/data/cache directories. The runner collects every shard's output, fails if any shard fails, and terminates children on cancellation. The test step has a 15-minute timeout.

Validation: workflow structure validated with actionlint (embedded shell checking disabled because the existing dynamic Windows runner steps are interpreted as Bash); the new script passes ShellCheck and Bash syntax checks. A local four-shard Catch2 smoke run passed all 8 cases / 69 assertions, and a failing executable verified failure aggregation. Full Linux CI and wall-time improvement remain to be verified by this PR's run.
