### PR TITLE
Preserve non-note MIDI through the arpeggiator

### DIFF
--- a/magda/daw/audio/plugins/ArpeggiatorPlugin.cpp
+++ b/magda/daw/audio/plugins/ArpeggiatorPlugin.cpp
@@ -1,6 +1,7 @@
 #include "plugins/ArpeggiatorPlugin.hpp"
 
 #include <algorithm>
+#include <limits>
 
 #include "transport/RampCurve.hpp"
 
@@ -27,6 +28,52 @@ bool isLiveSource(const DeviceProcessContext& context, std::uint32_t sourceId) {
     }
     return false;
 }
+
+/// What the arp does not consume, copied onto its output in timestamp order
+/// (#2417).
+///
+/// Notes are the device's material: they go in and an arpeggio comes out.
+/// Everything else the channel carries -- mod wheel, expression, sustain,
+/// bend, aftertouch, program change -- is addressed to the instrument behind
+/// this one, and reaches it nowhere else: thru carries the held chord too, so
+/// a track that wants the pedal cannot have it without the notes under it.
+///
+/// Forwarded on channel 1, the one the generated notes are on, so an
+/// instrument that keeps per-channel state applies them to what it is
+/// playing. SysEx is not forwarded: copying one allocates on the audio thread
+/// (JUCE holds anything past eight bytes on the heap), and it addresses a
+/// device rather than the notes.
+class NonNoteForwarder {
+  public:
+    explicit NonNoteForwarder(const DeviceMidiInput& in) : in_(in) {}
+
+    /// Everything up to and including @p timeInBlock. A message coincident
+    /// with a generated note goes out first: a controller moved on the beat
+    /// belongs to the note that starts on it.
+    void flushUpTo(DeviceMidiOutput& midi, double timeInBlock) {
+        for (const int count = in_.size(); next_ < count; ++next_) {
+            const auto& message = in_.message(next_);
+            if (message.getTimeStamp() > timeInBlock)
+                return;
+            // Channel messages only: getChannel() is 0 for SysEx and for
+            // everything the transport carries.
+            if (message.getChannel() == 0 || message.isNoteOnOrOff())
+                continue;
+
+            auto forwarded = message;  // short message: inline storage, no allocation
+            forwarded.setChannel(1);
+            midi.addEvent({std::move(forwarded), in_.sourceId(next_)});
+        }
+    }
+
+    void flushRest(DeviceMidiOutput& midi) {
+        flushUpTo(midi, std::numeric_limits<double>::max());
+    }
+
+  private:
+    const DeviceMidiInput& in_;
+    int next_ = 0;
+};
 
 /// One slot's metadata. The ids, order and display ranges are pinned to what
 /// the retired host-native plugin registered, because saved links address the
@@ -425,6 +472,12 @@ void ArpeggiatorPlugin::process(DeviceProcessContext& context) {
     auto& midi = *context.midiOut;
     const bool isLatched = displayValue(kLatch) >= 0.5f;
 
+    // What the arp passes on rather than consumes, emitted beside the notes it
+    // generates. The guard covers the returns below: a block the arp leaves
+    // early is still a block the instrument behind it is owed its pedal on.
+    NonNoteForwarder forward(in);
+    const juce::ScopeGuard forwardRest{[&] { forward.flushRest(midi); }};
+
     // --- 1. Capture incoming MIDI ---
     // Only one note can be sounding on entry, and this pass generates none, so
     // one pending note-off is enough.
@@ -483,7 +536,10 @@ void ArpeggiatorPlugin::process(DeviceProcessContext& context) {
     }
 
     // --- 2. Pass the panic on and close the note the input pass ended ---
+    // One flush covers every note-off below that lands at the top of the
+    // block, since none of them advances past that instant.
     midi.setAllNotesOff(inputPanic);
+    forward.flushUpTo(midi, 0.0);
     sendNoteOff(midi, pendingNoteOff, lastPlayedSourceId_);
 
     // --- 3. Handle transport transitions ---
@@ -591,8 +647,9 @@ void ArpeggiatorPlugin::process(DeviceProcessContext& context) {
     // Block duration in seconds (MIDI timestamps stay in seconds, not samples)
     double blockDurationSecs = static_cast<double>(context.numSamples) / sampleRate_;
 
-    const auto addTimedMessage = [&midi](juce::MidiMessage message, double timeInBlock,
-                                         std::uint32_t sourceId) {
+    const auto addTimedMessage = [&](juce::MidiMessage message, double timeInBlock,
+                                     std::uint32_t sourceId) {
+        forward.flushUpTo(midi, timeInBlock);
         message.setTimeStamp(timeInBlock);
         midi.addEvent({std::move(message), sourceId});
     };

--- a/magda/daw/audio/plugins/ArpeggiatorPlugin.hpp
+++ b/magda/daw/audio/plugins/ArpeggiatorPlugin.hpp
@@ -70,6 +70,7 @@ class ArpeggiatorPlugin : public MidiMagdaDevice {
             .shortName = "Arp",
             .takesMidiInput = true,
             .producesMidi = true,
+            .forwardsMidiInput = true,
         };
     }
 

--- a/magda/daw/audio/plugins/MagdaDevice.hpp
+++ b/magda/daw/audio/plugins/MagdaDevice.hpp
@@ -18,6 +18,12 @@ struct DeviceProperties {
     /// The device emits MIDI of its own, written to DeviceProcessContext::midiOut.
     /// Its input never passes through it: thru is the host's merge (#2347).
     bool producesMidi = false;
+    /// The device copies part of its input onto its output: what it consumes
+    /// is its material, and the rest belongs to whatever plays its notes (the
+    /// arpeggiator's non-note traffic, #2417). Not thru, which is the host's
+    /// whole-stream merge; a host sizes this device's MIDI output for its
+    /// input as well as its own production.
+    bool forwardsMidiInput = false;
     bool takesAudioInput = true;
     bool isSynth = false;
     bool producesAudioWithoutInput = false;

--- a/magda/daw/audio/plugins/engine/EngineMagdaDevice.cpp
+++ b/magda/daw/audio/plugins/engine/EngineMagdaDevice.cpp
@@ -209,6 +209,12 @@ void EngineMagdaDevice::setMidiOutputBoundBytes(int bytes) {
     sizeMidiScratch();
 }
 
+bool EngineMagdaDevice::forwardsMidiInput() const {
+    // Only meaningful for a device the plan reads MIDI from: what a device
+    // that declares no output writes is dropped either way.
+    return properties_.forwardsMidiInput && properties_.producesMidi;
+}
+
 void EngineMagdaDevice::sizeMidiScratch() {
     // Every caller runs off the audio thread, and each runs again when another
     // does: prepare() sizes from whatever bounds are known, and the executor

--- a/magda/daw/audio/plugins/engine/EngineMagdaDevice.hpp
+++ b/magda/daw/audio/plugins/engine/EngineMagdaDevice.hpp
@@ -86,6 +86,7 @@ class EngineMagdaDevice final : public magda::engine::EngineDevice {
     void reset() override;
     void setMidiInputBoundBytes(int bytes) override;
     void setMidiOutputBoundBytes(int bytes) override;
+    bool forwardsMidiInput() const override;
     int latencySamples() const override;
     void process(magda::engine::DeviceBlock& block) override;
 
@@ -132,10 +133,11 @@ class EngineMagdaDevice final : public magda::engine::EngineDevice {
     /// than before it could.
     int midiInputBoundBytes_ = magda::engine::kMaxMidiBytesPerPort;
 
-    /// What the executor reserved on the output port, which is one producer's
-    /// worth: a device emits what it made, and MIDI thru is the plan's merge
-    /// behind it (#2345, #2347). The constant until it says otherwise, for the
-    /// reason above.
+    /// What the executor reserved on the output port: one producer's worth,
+    /// plus the input's when the device forwards part of it (#2417). A device
+    /// emits what it made, and MIDI thru is the plan's merge behind it
+    /// (#2345, #2347). The constant until it says otherwise, for the reason
+    /// above.
     int midiOutputBoundBytes_ = magda::engine::kMaxMidiBytesPerPort;
 
     double sampleRate_ = 44100.0;

--- a/magda/engine/exec/EngineDevice.hpp
+++ b/magda/engine/exec/EngineDevice.hpp
@@ -184,6 +184,19 @@ class EngineDevice {
      */
     virtual void setMidiOutputBoundBytes(int) {}
 
+    /**
+     * @brief Whether part of this device's MIDI input leaves on its output.
+     *
+     * A device is a producer, not a conduit: thru is the plan's merge behind
+     * it (#2345). A MIDI FX that consumes notes and hands the rest of the
+     * channel's traffic to the instrument behind it is the exception, and its
+     * output port is budgeted for what reached it as well as what it makes
+     * (#2417). Read off the audio thread, beside the two bounds above.
+     */
+    virtual bool forwardsMidiInput() const {
+        return false;
+    }
+
     /// Samples the device delays its output by. Read but not yet compensated:
     /// latency compensation is its own slice, and the executor reports any
     /// non-zero value from prepare() rather than pretending it is aligned.

--- a/magda/engine/exec/PlanExecutor.cpp
+++ b/magda/engine/exec/PlanExecutor.cpp
@@ -673,6 +673,25 @@ std::vector<std::string> PlanExecutor::prepare(const RenderPlan& plan, const Pla
         // a device doing it as well made every note a pair (#2345). So a device
         // is a producer like any other and its port stays at the budget every
         // port starts on.
+        //
+        // Unless it says otherwise: a MIDI FX that consumes notes hands the
+        // rest of the channel on, since thru would bring the notes back with
+        // it (#2417). Its port holds what it makes and what reached it, and
+        // what reached it is a merge's sum rather than one producer's budget.
+        if (op.kind == OpKind::Device) {
+            const auto* device = deviceForOp_[i];
+            const auto hasMidiOut = op.outputs.size() > 1 && op.outputs[1].kind == SignalKind::Midi;
+            if (device == nullptr || !device->forwardsMidiInput() || !hasMidiOut)
+                continue;
+
+            const auto reaching = op.inputs.size() > 1 && op.inputs[1].valid()
+                                      ? portMidiBytes[flatPort(op.inputs[1])]
+                                      : 0;
+            portMidiBytes[static_cast<std::size_t>(portOffsets_[i]) + 1] =
+                kMaxMidiBytesPerPort + reaching;
+            continue;
+        }
+
         if (op.kind != OpKind::MergeMidi && op.kind != OpKind::Fader &&
             op.kind != OpKind::MidiNoteGate)
             continue;

--- a/manual/docs/devices/arpeggiator.md
+++ b/manual/docs/devices/arpeggiator.md
@@ -42,6 +42,12 @@ The interactive curve display shows the timing transformation in real time. Duri
 
 Depth, Skew, and Cycles can be linked to [Macros](../modulation/macros.md) for automatable timing modulation — morph from straight to swung patterns in real time.
 
+## MIDI pass-through
+
+The Arpeggiator replaces the notes you play with its own pattern, and passes everything else on the channel to the instrument behind it — mod wheel, expression, sustain, pitch bend, aftertouch and program change all reach the synth unchanged. Sustain still holds the arpeggiated notes, and the wheel still bends them.
+
+Turn on **MIDI thru** in the device header only when you want the chord itself to play alongside the pattern: thru passes the raw input on, notes included.
+
 ## Usage
 
 1. Place the Arpeggiator before an instrument on a track's device chain

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -72,6 +72,7 @@ set(TEST_SOURCES
     devices/test_device_parameter_pagination.cpp
     devices/test_mutable_clouds.cpp
     devices/test_arpeggiator_input.cpp
+    devices/test_arpeggiator_passthru.cpp
     devices/test_arpeggiator_transport.cpp
     devices/test_midi_strum_lifecycle.cpp
     devices/test_midi_strum_provenance.cpp
@@ -641,6 +642,8 @@ target_sources(magda_juce_tests PRIVATE
     devices/test_convolution_device_juce.cpp
     # One device, one discontinuity, both adapters (#2418).
     devices/test_device_panic_flag_juce.cpp
+    # The traffic the same device passes on rather than consumes (#2417).
+    devices/test_device_midi_passthru_juce.cpp
     devices/test_mutable_add_not_replace_juce.cpp
     devices/test_master_sidechain_juce.cpp
     midi/test_midi_bridge_note_events_juce.cpp

--- a/tests/devices/ArpeggiatorTestRig.hpp
+++ b/tests/devices/ArpeggiatorTestRig.hpp
@@ -45,8 +45,10 @@ struct ArpRig {
                                                                 arp.parameterInfo(Arp::kRate)));
     }
 
+    /// @p seconds is the block length: long enough to hold several arp steps
+    /// when a case needs the output to interleave with something (#2417).
     DeviceMidiBuffer run(double start, std::initializer_list<juce::MidiMessage> input = {},
-                         bool playing = true, bool panic = false) {
+                         bool playing = true, bool panic = false, double seconds = 0.05) {
         DeviceMidiBuffer in;
         in.allNotesOff = panic;
         for (const auto& message : input)
@@ -56,9 +58,9 @@ struct ArpRig {
         context.midiIn = &in;
         context.midiOut = &out;
         context.tempoMap = &tempo;
-        context.numSamples = 2400;
+        context.numSamples = static_cast<int>(seconds * 48000.0);
         context.timelineStartSeconds = start;
-        context.timelineEndSeconds = start + 0.05;
+        context.timelineEndSeconds = start + seconds;
         context.isPlaying = playing;
         context.liveSourceIds = liveSourceIds.empty() ? nullptr : liveSourceIds.data();
         context.numLiveSourceIds = static_cast<int>(liveSourceIds.size());

--- a/tests/devices/test_arpeggiator_input.cpp
+++ b/tests/devices/test_arpeggiator_input.cpp
@@ -31,9 +31,13 @@ TEST_CASE("Arpeggiator upstream panic stops its sounding note exactly once",
         INFO("controller " << controller);
         Rig rig;
         rig.startNote();
+        // The reset travels on to whatever plays the notes (#2417), and the
+        // arp closes what it was sounding once behind it.
         auto midi = rig.run(0.05, {juce::MidiMessage::controllerEvent(1, controller, 0)});
-        REQUIRE(midi.size() == 1);
-        checkOff(midi);
+        REQUIRE(midi.size() == 2);
+        CHECK(midi.message(0).isController());
+        CHECK(midi.message(0).getControllerNumber() == controller);
+        checkOff(midi, 1);
         CHECK(rig.run(0.1).size() == 0);
         CHECK(rig.run(0.5).size() == 0);
     }
@@ -47,11 +51,15 @@ TEST_CASE("Arpeggiator input resets retain a single pending note-off",
     auto midi = rig.run(0.5, {juce::MidiMessage::noteOn(1, 64, juce::uint8{80}),
                               juce::MidiMessage::allNotesOff(1), juce::MidiMessage::allSoundOff(1),
                               juce::MidiMessage::noteOn(1, 67, juce::uint8{73})});
-    REQUIRE(midi.size() == 2);
-    checkOff(midi);
-    CHECK(midi.message(1).isNoteOn());
-    CHECK(midi.message(1).getNoteNumber() == 67);
-    CHECK(midi.message(1).getVelocity() == 73);
+    // Both resets forwarded ahead of it (#2417), then one note-off however
+    // many resets the block carried.
+    REQUIRE(midi.size() == 4);
+    CHECK(midi.message(0).isController());
+    CHECK(midi.message(1).isController());
+    checkOff(midi, 2);
+    CHECK(midi.message(3).isNoteOn());
+    CHECK(midi.message(3).getNoteNumber() == 67);
+    CHECK(midi.message(3).getVelocity() == 73);
 }
 
 TEST_CASE("Arpeggiator buffer panic drops a latched chord it cannot prove is live",
@@ -78,11 +86,14 @@ TEST_CASE("Arpeggiator buffer panic permits fresh input without duplicate note-o
         0.5, {juce::MidiMessage::allNotesOff(1), juce::MidiMessage::noteOn(1, 67, juce::uint8{73})},
         true, true);
     CHECK(midi.isAllNotesOff());
-    REQUIRE(midi.size() == 2);
-    checkOff(midi);
-    CHECK(midi.message(1).isNoteOn());
-    CHECK(midi.message(1).getNoteNumber() == 67);
-    CHECK(midi.message(1).getVelocity() == 73);
+    // The forwarded reset (#2417), then the single note-off the panic and the
+    // controller between them are owed.
+    REQUIRE(midi.size() == 3);
+    CHECK(midi.message(0).isController());
+    checkOff(midi, 1);
+    CHECK(midi.message(2).isNoteOn());
+    CHECK(midi.message(2).getNoteNumber() == 67);
+    CHECK(midi.message(2).getVelocity() == 73);
 }
 
 TEST_CASE("Arpeggiator forwards buffer panic even with no sounding note",

--- a/tests/devices/test_arpeggiator_passthru.cpp
+++ b/tests/devices/test_arpeggiator_passthru.cpp
@@ -1,0 +1,180 @@
+#include <array>
+#include <catch2/catch_test_macros.hpp>
+
+#include "devices/ArpeggiatorTestRig.hpp"
+
+// What the arpeggiator passes on rather than consumes (#2417).
+//
+// Notes are the device's material. Everything else the channel carries is
+// addressed to the instrument behind it, and reaches it nowhere else: MIDI
+// thru would bring the held chord back with it.
+
+namespace {
+using magda::test::Arp;
+using magda::test::DeviceMidiBuffer;
+using Rig = magda::test::ArpRig;
+
+juce::MidiMessage at(juce::MidiMessage message, double timeStamp) {
+    message.setTimeStamp(timeStamp);
+    return message;
+}
+}  // namespace
+
+TEST_CASE("Arpeggiator forwards the non-note traffic its notes displace",
+          "[arpeggiator][midi][passthru][2417]") {
+    Rig rig;
+    auto midi = rig.run(0.0, {juce::MidiMessage::noteOn(1, 60, juce::uint8{91}),
+                              juce::MidiMessage::controllerEvent(1, 1, 64),
+                              juce::MidiMessage::controllerEvent(1, 11, 100),
+                              juce::MidiMessage::controllerEvent(1, 64, 127),
+                              juce::MidiMessage::pitchWheel(1, 4096),
+                              juce::MidiMessage::channelPressureChange(1, 55),
+                              juce::MidiMessage::aftertouchChange(1, 60, 33),
+                              juce::MidiMessage::programChange(1, 12)});
+
+    // Seven forwarded, then the note the arp generated for the chord it was
+    // handed: everything arrived at the top of the block, and a controller
+    // coincident with a note goes out ahead of it.
+    REQUIRE(midi.size() == 8);
+
+    CHECK(midi.message(0).isController());
+    CHECK(midi.message(0).getControllerNumber() == 1);
+    CHECK(midi.message(0).getControllerValue() == 64);
+    CHECK(midi.message(1).getControllerNumber() == 11);
+    CHECK(midi.message(2).getControllerNumber() == 64);
+    CHECK(midi.message(2).getControllerValue() == 127);
+    CHECK(midi.message(3).isPitchWheel());
+    CHECK(midi.message(3).getPitchWheelValue() == 4096);
+    CHECK(midi.message(4).isChannelPressure());
+    CHECK(midi.message(4).getChannelPressureValue() == 55);
+    CHECK(midi.message(5).isAftertouch());
+    CHECK(midi.message(5).getNoteNumber() == 60);
+    CHECK(midi.message(5).getAfterTouchValue() == 33);
+    CHECK(midi.message(6).isProgramChange());
+    CHECK(midi.message(6).getProgramChangeNumber() == 12);
+    CHECK(midi.message(7).isNoteOn());
+
+    // Provenance travels with the message: a device behind this one reads a
+    // forwarded controller the way it reads the notes beside it (#2416).
+    for (int index = 0; index < 7; ++index)
+        CHECK(midi.events[static_cast<std::size_t>(index)].sourceId == rig.source);
+}
+
+TEST_CASE("Arpeggiator forwards non-note messages on the channel it plays on",
+          "[arpeggiator][midi][passthru][2417]") {
+    // The arp collapses every input channel onto channel 1, so a controller
+    // left on its own channel would address an instrument voice that is not
+    // there.
+    Rig rig;
+    auto midi = rig.run(0.0, {juce::MidiMessage::noteOn(7, 60, juce::uint8{91}),
+                              juce::MidiMessage::controllerEvent(7, 74, 90)});
+
+    REQUIRE(midi.size() == 2);
+    CHECK(midi.message(0).isController());
+    CHECK(midi.message(0).getControllerNumber() == 74);
+    CHECK(midi.message(0).getChannel() == 1);
+    CHECK(midi.message(1).isNoteOn());
+    CHECK(midi.message(1).getChannel() == 1);
+}
+
+TEST_CASE("Arpeggiator does not echo the notes it consumes",
+          "[arpeggiator][midi][passthru][2417]") {
+    Rig rig;
+    rig.startNote();
+
+    // One note-off, the arp closing what it started. A second would be the
+    // input's own, which the pattern already replaced.
+    auto midi = rig.run(0.05, {juce::MidiMessage::noteOff(1, 60)});
+    REQUIRE(midi.size() == 1);
+    magda::test::checkNoteOff(midi);
+}
+
+TEST_CASE("Arpeggiator drops what it cannot forward without allocating",
+          "[arpeggiator][midi][passthru][2417]") {
+    // SysEx addresses a device rather than the notes, and copying one would
+    // put a heap allocation on the audio thread. Clock and start belong to the
+    // transport, which is not this port's traffic either.
+    const std::array<std::uint8_t, 6> payload{0x7d, 1, 2, 3, 4, 5};
+
+    Rig rig;
+    auto midi = rig.run(0.0, {juce::MidiMessage::noteOn(1, 60, juce::uint8{91}),
+                              juce::MidiMessage::createSysExMessage(
+                                  payload.data(), static_cast<int>(payload.size())),
+                              juce::MidiMessage::midiClock(), juce::MidiMessage::midiStart()});
+
+    REQUIRE(midi.size() == 1);
+    CHECK(midi.message(0).isNoteOn());
+}
+
+TEST_CASE("Arpeggiator merges forwarded traffic into its output in timestamp order",
+          "[arpeggiator][midi][passthru][2417]") {
+    // A block long enough to hold four sixteenths, so the forwarded messages
+    // have generated notes on both sides of them rather than only after.
+    Rig rig;
+    rig.setRate(Arp::Rate::Sixteenth);
+    auto midi = rig.run(0.0,
+                        {juce::MidiMessage::noteOn(1, 60, juce::uint8{91}),
+                         at(juce::MidiMessage::controllerEvent(1, 1, 20), 0.2),
+                         at(juce::MidiMessage::controllerEvent(1, 1, 30), 0.25),
+                         at(juce::MidiMessage::controllerEvent(1, 1, 40), 0.3)},
+                        true, false, 0.5);
+
+    REQUIRE(midi.size() > 6);
+    for (int index = 1; index < midi.size(); ++index)
+        CHECK(midi.message(index - 1).getTimeStamp() <= midi.message(index).getTimeStamp());
+
+    int controllers = 0;
+    for (int index = 0; index < midi.size(); ++index) {
+        if (!midi.message(index).isController())
+            continue;
+        ++controllers;
+
+        // The one coincident with a step is ahead of the notes at that
+        // instant, the way it would be if the arp were not in the chain.
+        if (midi.message(index).getControllerValue() == 30) {
+            REQUIRE(index + 1 < midi.size());
+            CHECK(midi.message(index).getTimeStamp() == 0.25);
+            CHECK(midi.message(index + 1).getTimeStamp() == 0.25);
+            CHECK(!midi.message(index + 1).isController());
+        }
+    }
+    CHECK(controllers == 3);
+}
+
+TEST_CASE("Arpeggiator forwards the reset it acts on", "[arpeggiator][midi][passthru][2417]") {
+    // CC120 and CC123 stop this device, and the instrument behind it is owed
+    // the same instruction: the arp's own note-off releases what it started
+    // and nothing else.
+    for (int controller : {120, 123}) {
+        INFO("controller " << controller);
+        Rig rig;
+        rig.startNote();
+
+        auto midi = rig.run(0.05, {juce::MidiMessage::controllerEvent(1, controller, 0)});
+        REQUIRE(midi.size() == 2);
+        CHECK(midi.message(0).isController());
+        CHECK(midi.message(0).getControllerNumber() == controller);
+        magda::test::checkNoteOff(midi, 1);
+
+        CHECK(rig.run(0.1).size() == 0);
+    }
+}
+
+TEST_CASE("Arpeggiator passes a buffer panic on beside what it forwards",
+          "[arpeggiator][midi][passthru][2417]") {
+    // The flag is the CC-less twin of the reset above, and the two travel the
+    // same way: the panic on the buffer, the pedal as an event (#2418).
+    Rig rig;
+    rig.liveSourceIds = {rig.source};
+    rig.startNote();
+
+    auto midi = rig.run(0.05, {at(juce::MidiMessage::controllerEvent(1, 64, 127), 0.01)}, true,
+                        /*panic=*/true);
+
+    CHECK(midi.allNotesOff);
+    REQUIRE(midi.size() == 2);
+    magda::test::checkNoteOff(midi, 0);
+    CHECK(midi.message(1).isController());
+    CHECK(midi.message(1).getControllerNumber() == 64);
+    CHECK(midi.message(1).getTimeStamp() == 0.01);
+}

--- a/tests/devices/test_device_midi_passthru_juce.cpp
+++ b/tests/devices/test_device_midi_passthru_juce.cpp
@@ -1,0 +1,161 @@
+#include <juce_core/juce_core.h>
+#include <tracktion_engine/tracktion_engine.h>
+
+#include <memory>
+#include <vector>
+
+#include "SharedTestEngine.hpp"
+#include "exec/EngineDevice.hpp"
+#include "exec/RenderContext.hpp"
+#include "magda/daw/audio/plugins/ArpeggiatorPlugin.hpp"
+#include "magda/daw/audio/plugins/engine/EngineMagdaDevice.hpp"
+#include "third_party/tracktion_engine/modules/tracktion_engine/utilities/tracktion_TestUtilities.h"
+
+// Non-note MIDI through the arpeggiator, on both adapters (#2417).
+//
+// The device replaces the notes it is handed and passes the rest of the
+// channel on, because thru would bring the held chord back with it. Both hosts
+// hand the device its input and take its output through containers of their
+// own -- the fork swaps a te::MidiMessageArray, the engine writes back onto a
+// juce::MidiBuffer -- so the two are driven over the same block and compared
+// rather than assumed.
+
+namespace {
+
+namespace audio = magda::daw::audio;
+namespace adapter = magda::daw::audio::engine_adapter;
+namespace te = tracktion::engine;
+
+constexpr double kSampleRate = 44100.0;
+constexpr int kBlockSize = 64;
+constexpr int kController = 11;
+constexpr int kControllerValue = 77;
+
+/// A held note and an expression pedal on the same instant, which is the input
+/// both legs are given.
+juce::MidiMessage heldNote() {
+    return juce::MidiMessage::noteOn(1, 60, juce::uint8{90});
+}
+
+juce::MidiMessage pedal() {
+    return juce::MidiMessage::controllerEvent(1, kController, kControllerValue);
+}
+
+int count(const std::vector<juce::MidiMessage>& midi, bool (*matches)(const juce::MidiMessage&)) {
+    int total = 0;
+    for (const auto& message : midi)
+        if (matches(message))
+            ++total;
+    return total;
+}
+
+bool isForwardedPedal(const juce::MidiMessage& message) {
+    return message.isController() && message.getControllerNumber() == kController &&
+           message.getControllerValue() == kControllerValue && message.getChannel() == 1;
+}
+
+bool isNoteOn(const juce::MidiMessage& message) {
+    return message.isNoteOn();
+}
+
+/// What the fork's leg leaves on the buffer the host reads back.
+std::vector<juce::MidiMessage> teLegOutput(te::Edit& edit) {
+    juce::ValueTree state(te::IDs::PLUGIN);
+    state.setProperty(te::IDs::type, audio::ArpeggiatorPlugin::xmlTypeName, nullptr);
+    auto plugin = edit.getPluginCache().createNewPlugin(state);
+    if (plugin == nullptr)
+        return {};
+
+    te::PluginInitialisationInfo initInfo;
+    initInfo.startTime = tracktion::TimePosition();
+    initInfo.sampleRate = kSampleRate;
+    initInfo.blockSizeSamples = kBlockSize;
+    plugin->baseClassInitialise(initInfo);
+
+    juce::AudioBuffer<float> buffer(2, kBlockSize);
+    buffer.clear();
+
+    te::MidiMessageArray midi;
+    midi.addMidiMessage(heldNote(), 0.0, te::MPESourceID{});
+    midi.addMidiMessage(pedal(), 0.0, te::MPESourceID{});
+
+    te::PluginRenderContext context(
+        &buffer, juce::AudioChannelSet::stereo(), 0, kBlockSize, &midi, 0.0,
+        tracktion::TimeRange(tracktion::TimePosition(),
+                             tracktion::TimePosition::fromSeconds(kBlockSize / kSampleRate)),
+        true, false, false, false);
+    plugin->applyToBuffer(context);
+
+    std::vector<juce::MidiMessage> output;
+    output.reserve(static_cast<std::size_t>(midi.size()));
+    for (const auto& message : midi)
+        output.push_back(message);
+
+    plugin->deleteFromParent();
+    return output;
+}
+
+/// The same block through the engine's leg, read back off the port.
+std::vector<juce::MidiMessage> engineLegOutput() {
+    adapter::EngineMagdaDevice hosted(std::make_unique<audio::ArpeggiatorPlugin>(),
+                                      /*offlineRender=*/false);
+    hosted.prepare({.sampleRate = kSampleRate, .maxBlockSize = kBlockSize, .numChannels = 2});
+
+    juce::AudioBuffer<float> buffer(2, kBlockSize);
+    buffer.clear();
+    juce::MidiBuffer in;
+    juce::MidiBuffer out;
+    in.addEvent(heldNote(), 0);
+    in.addEvent(pedal(), 0);
+
+    magda::engine::DeviceBlock block;
+    block.audio = juce::dsp::AudioBlock<float>(buffer);
+    block.midiIn = &in;
+    block.midiOut = &out;
+    block.block.numSamples = kBlockSize;
+    block.block.sampleRate = kSampleRate;
+    block.block.playing = true;
+    block.block.seconds.end = kBlockSize / kSampleRate;
+
+    hosted.process(block);
+
+    std::vector<juce::MidiMessage> output;
+    output.reserve(static_cast<std::size_t>(out.getNumEvents()));
+    for (const auto metadata : out)
+        output.push_back(metadata.getMessage());
+    return output;
+}
+
+class DeviceMidiPassThruTest final : public juce::UnitTest {
+  public:
+    DeviceMidiPassThruTest() : juce::UnitTest("Device MIDI Pass-Through", "magda") {}
+
+    void runTest() override {
+        beginTest("Engine setup");
+
+        auto& wrapper = magda::test::getSharedEngine();
+        auto edit = te::test_utilities::createTestEdit(*wrapper.getEngine(), 1);
+        expect(edit != nullptr);
+        if (edit == nullptr)
+            return;
+
+        beginTest("Both adapters carry the pedal past the arpeggiator");
+
+        const auto teLeg = teLegOutput(*edit);
+        const auto engineLeg = engineLegOutput();
+
+        expect(count(teLeg, isForwardedPedal) == 1, "The fork's leg should pass the pedal on");
+        expect(count(engineLeg, isForwardedPedal) == 1, "The engine's leg should pass it on too");
+
+        beginTest("Neither adapter echoes the note the arpeggiator replaced");
+
+        // One note-on on each leg: the arpeggio's. The input's own would be
+        // the chord playing under the pattern, which is what thru is for.
+        expect(count(teLeg, isNoteOn) == 1, "The fork's leg should emit only the generated note");
+        expect(count(engineLeg, isNoteOn) == 1, "The engine's leg should emit only its own too");
+    }
+};
+
+DeviceMidiPassThruTest deviceMidiPassThruTest;
+
+}  // namespace

--- a/tests/engine/test_engine_device_layer.cpp
+++ b/tests/engine/test_engine_device_layer.cpp
@@ -150,8 +150,13 @@ class BoundProbe final : public magda::engine::EngineDevice {
         outBound = bytes;
     }
 
+    bool forwardsMidiInput() const override {
+        return forwards;
+    }
+
     int bound = -1;
     int outBound = -1;
+    bool forwards = false;
 };
 
 /// Copies its input to its output reversed, dropping the middle event, on
@@ -681,6 +686,46 @@ TEST_CASE("the executor tells a device what it may write, apart from what it may
     // The gain emits no MIDI at all, and is told so rather than being left at
     // whatever it assumed.
     CHECK(gainProbe.outBound == 0);
+}
+
+TEST_CASE("the executor budgets a forwarding device's output for its input as well",
+          "[engine][devices][2417]") {
+    // The exception to the case above. A MIDI FX that consumes notes hands the
+    // rest of the channel on, since thru would bring the notes back with it,
+    // so its port holds what reached it as well as what it makes. Same three
+    // producers as above, so the two figures can be read against each other.
+    magda::TrackInfo instrument;
+    instrument.id = 1;
+    instrument.type = magda::TrackType::Media;
+    instrument.name = "Instrument";
+    instrument.recordArmed = true;  // what makes the input route active
+    instrument.midiInputDevice = "midi-hardware";
+
+    auto arp = magda::nulldiff::synthDevice(10);
+    arp.producesMidi = true;  // so the plan gives the op a MIDI output port
+    instrument.chain.fxChainElements.emplace_back(arp);
+
+    magda::TrackInfo master;
+    master.id = magda::MASTER_TRACK_ID;
+    master.type = magda::TrackType::Master;
+    master.name = "Master";
+
+    const auto plan = magda::engine::compileRenderPlan({instrument}, master);
+
+    BoundProbe probe;
+    probe.forwards = true;
+
+    magda::engine::PlanBindings bindings;
+    for (const auto& op : plan.ops)
+        if (op.kind == magda::engine::OpKind::Device)
+            bindings.devices[op.key.deviceKey()] = &probe;
+
+    magda::engine::PlanExecutor executor;
+    executor.prepare(plan, bindings, contextFor(), nullptr, nullptr);
+    REQUIRE(executor.isPrepared());
+
+    REQUIRE(probe.bound == 3 * magda::engine::kMaxMidiBytesPerPort);
+    CHECK(probe.outBound == probe.bound + magda::engine::kMaxMidiBytesPerPort);
 }
 
 TEST_CASE("a device forwards long messages by copying them, never in place",


### PR DESCRIPTION
Closes #2417.

## Problem

`ArpeggiatorPlugin` replaces the notes it is handed with a pattern of its own, and dropped everything else with them. Mod wheel, expression, sustain, pitch bend, aftertouch and program change never reached the instrument behind it — the device's output is its whole output on both hosts (the fork swaps its `te::MidiMessageArray`, the engine writes back onto the port), so nothing else carries them.

MIDI thru is not the answer. It passes the raw input on, notes included, so a track that wants the pedal gets the held chord playing under the pattern.

## Policy

Every channel message that is not a note-on or note-off is copied from `context.midiIn` to `context.midiOut`:

| | |
|---|---|
| forwarded | controllers (CC1/CC11/CC64 and the rest), pitch bend, channel pressure, poly aftertouch, program change |
| consumed | note-on, note-off — the device's material |
| dropped | SysEx, and everything the transport carries (clock, start, stop) |

- **Channel 1**, the one the generated notes are on. The arp already collapses every input channel onto it, so a controller left on its own channel would address a voice that is not there.
- **CC120/CC123 forwarded.** The arp resets on them, and the instrument behind it is owed the same instruction — the same thing it does with the buffer panic flag, which is the CC-less twin (#2418).
- **SysEx dropped.** Copying one allocates on the audio thread (JUCE holds anything past eight bytes on the heap), and it addresses a device rather than the notes. This is what keeps the forwarding allocation-free, which the issue asked for.
- **Timestamps, source ids and order preserved.** A cursor over the input flushes everything up to each generated event before emitting it, so the output stays in time order rather than being a block of forwarded traffic followed by the arpeggio. A message coincident with a note goes out ahead of it: a controller moved on the beat belongs to the note that starts on it. A `juce::ScopeGuard` flushes the remainder, so the early returns (no held notes, empty block, transport stopped) still pass the pedal on.

## Capacity

A device is a producer, not a conduit, and its MIDI output port is budgeted at one producer's worth while its input can be a merge of several (#2345). A device that forwards would go past that bound on a track with more than one MIDI source, and the engine's answer to a device past its bound is to drop events.

So the device declares it — `DeviceProperties::forwardsMidiInput`, `EngineDevice::forwardsMidiInput()` — and `PlanExecutor` sizes that port for what reaches the device as well as what it makes. Nothing else changes: every other device's port stays where it was. The fork's leg has no bound to raise; its container grows.

## Validation

Full Catch2 suite (3633 passed, 857,911 assertions, 13 skipped) and the full JUCE suite green, the null-diff corpus through both engines included.

Verified negatively:
- disabling the forwarding fails 8 of the arpeggiator's Catch2 cases, and fails the both-adapter JUCE case on **both** legs;
- reverting the executor's budget branch fails the port-bound case (4096 where 16384 is owed).

New tests: the forwarded set and the messages that are not, channel rewriting, the timestamp merge (with a controller coincident with a step), the forwarded reset beside the arp's own note-off, panic and forwarding together, source-id provenance, one JUCE case running a pedal through both adapters, and the executor's budget for a forwarding device.

Three existing cases in `test_arpeggiator_input.cpp` now expect the reset they send to be forwarded.

Not in scope: `MidiStrumPlugin` and the step sequencers consume notes the same way and would want the same pass-through; that is #2432, and the forwarder is local to the arpeggiator until there is a second caller.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019sKH5X6HQ8WV82QriCbmLr

