### PR TITLE
Wire an instrument wrapper's plugin MIDI output only when the device emits MIDI

### DIFF
--- a/magda/daw/audio/AudioBridge.cpp
+++ b/magda/daw/audio/AudioBridge.cpp
@@ -615,10 +615,11 @@ void AudioBridge::devicePropertyChanged(const ChainNodePath& devicePath) {
         if (auto* rackInstance = rackManager.getRackInstance(deviceId)) {
             rackInstance->setEnabled(effectiveEnabled);
         }
-        // Keep the wrapper's raw-MIDI passthrough in sync with the routing model
-        // (always on for a plain instrument; midiInThru-controlled for a
-        // MIDI-output device), so notes keep reaching downstream devices.
-        rackManager.setMidiInThru(deviceId, routing::makeRoutingNode(*device).passesRawMidiInput());
+        // Keep the wrapper's MIDI paths in sync with the routing model: the raw
+        // passthrough (always on for a plain instrument; midiInThru-controlled
+        // for a MIDI-output device) so notes keep reaching downstream devices,
+        // and the plugin's own MIDI output.
+        rackManager.updateMidiRouting(deviceId, routing::makeRoutingNode(*device));
     }
 
     // Push gain to the audio-graph atomic so DeviceGainNode picks it up.

--- a/magda/daw/audio/plugin_manager/PluginManagerSync.cpp
+++ b/magda/daw/audio/plugin_manager/PluginManagerSync.cpp
@@ -1335,15 +1335,14 @@ void PluginManager::pollAsyncPluginLoad(const ChainNodePath& devicePath, te::Plu
                     auto* track = self.trackController_.getAudioTrack(trackId);
                     int pluginIdx = track ? track->pluginList.indexOf(plugin.get()) : -1;
 
-                    const bool passRawMidi =
-                        routing::makeRoutingNode(*devInfo).passesRawMidiInput();
+                    const auto routingNode = routing::makeRoutingNode(*devInfo);
                     te::Plugin::Ptr rackPlugin;
                     if (numOutputChannels > 2) {
                         rackPlugin = self.instrumentRackManager_.wrapMultiOutInstrument(
-                            plugin, numOutputChannels, passRawMidi);
+                            plugin, numOutputChannels, routingNode);
                     } else {
                         rackPlugin =
-                            self.instrumentRackManager_.wrapInstrument(plugin, passRawMidi);
+                            self.instrumentRackManager_.wrapInstrument(plugin, routingNode);
                     }
 
                     if (rackPlugin) {
@@ -2480,13 +2479,13 @@ te::Plugin::Ptr PluginManager::loadDeviceAsPlugin(const ChainNodePath& devicePat
             // Remember the plugin's position before wrapping removes it from the track
             int pluginIdx = track->pluginList.indexOf(plugin.get());
 
-            const bool passRawMidi = routing::makeRoutingNode(device).passesRawMidiInput();
+            const auto routingNode = routing::makeRoutingNode(device);
             te::Plugin::Ptr rackPlugin;
             if (numOutputChannels > 2) {
                 rackPlugin = instrumentRackManager_.wrapMultiOutInstrument(
-                    plugin, numOutputChannels, passRawMidi);
+                    plugin, numOutputChannels, routingNode);
             } else {
-                rackPlugin = instrumentRackManager_.wrapInstrument(plugin, passRawMidi);
+                rackPlugin = instrumentRackManager_.wrapInstrument(plugin, routingNode);
             }
 
             if (rackPlugin) {

--- a/magda/daw/audio/racks/InstrumentRackManager.cpp
+++ b/magda/daw/audio/racks/InstrumentRackManager.cpp
@@ -30,7 +30,7 @@ te::Plugin::Ptr findMeterTapPlugin(te::RackType::Ptr rackType) {
 InstrumentRackManager::InstrumentRackManager(te::Edit& edit) : edit_(edit) {}
 
 te::Plugin::Ptr InstrumentRackManager::wrapInstrument(te::Plugin::Ptr instrument,
-                                                      bool passRawMidiInput) {
+                                                      const routing::ChainRoutingNode& routing) {
     if (!instrument) {
         return nullptr;
     }
@@ -77,18 +77,21 @@ te::Plugin::Ptr InstrumentRackManager::wrapInstrument(te::Plugin::Ptr instrument
     // MIDI: rack input pin 0 --> synth pin 0
     rackType->addConnection(rackIOId, 0, synthId, 0);
 
-    // A wrapped plugin's OWN MIDI output always flows to the rack output, so a
+    // A wrapped plugin's OWN MIDI output flows to the rack output, so a
     // MIDI-producing plugin (sequencer, arpeggiator -- e.g. Stochas) triggers
-    // instruments downstream of it in the chain. This is unconditional: a plain
-    // synth emits no MIDI, so the connection simply carries nothing.
-    rackType->addConnection(synthId, 0, rackIOId, 0);
+    // instruments downstream of it in the chain. Only for a device that declares
+    // a MIDI output: TE's PluginNode passes on whatever the plugin left in the
+    // buffer it was handed, so for a plain synth pin 0 would carry the rack's own
+    // input back out and double every note against the passthrough below (#2346).
+    if (routing.outputsPluginMidi())
+        rackType->addConnection(synthId, 0, rackIOId, 0);
 
     // The rack's raw MIDI INPUT passes straight through (bypassing the plugin) so
     // the notes keep flowing to every downstream device - that is how a
     // MIDI-triggered modulation after an instrument still sees the trigger. The
     // decision comes from ChainRoutingModel: a plain instrument always forwards
     // (RawInputOnly); a MIDI-output device follows its midiInThru flag.
-    if (passRawMidiInput)
+    if (routing.passesRawMidiInput())
         rackType->addConnection(rackIOId, 0, rackIOId, 0);
 
     // Audio passthrough: rack input pin 1 --> rack output pin 1 (left)
@@ -121,11 +124,10 @@ te::Plugin::Ptr InstrumentRackManager::wrapInstrument(te::Plugin::Ptr instrument
     return rackInstance;
 }
 
-te::Plugin::Ptr InstrumentRackManager::wrapMultiOutInstrument(te::Plugin::Ptr instrument,
-                                                              int numOutputChannels,
-                                                              bool passRawMidiInput) {
+te::Plugin::Ptr InstrumentRackManager::wrapMultiOutInstrument(
+    te::Plugin::Ptr instrument, int numOutputChannels, const routing::ChainRoutingNode& routing) {
     if (!instrument || numOutputChannels <= 2) {
-        return wrapInstrument(instrument, passRawMidiInput);  // Fallback to normal wrapping
+        return wrapInstrument(instrument, routing);  // Fallback to normal wrapping
     }
 
     // 1. Create a new RackType in the edit
@@ -171,12 +173,13 @@ te::Plugin::Ptr InstrumentRackManager::wrapMultiOutInstrument(te::Plugin::Ptr in
     // MIDI: rack input pin 0 --> synth pin 0
     rackType->addConnection(rackIOId, 0, synthId, 0);
 
-    // Plugin's own MIDI output always flows downstream (see wrapInstrument).
-    rackType->addConnection(synthId, 0, rackIOId, 0);
+    // Plugin's own MIDI output, for a device that declares one (see wrapInstrument).
+    if (routing.outputsPluginMidi())
+        rackType->addConnection(synthId, 0, rackIOId, 0);
 
     // Raw input bypassing the plugin so notes reach downstream devices (see
     // wrapInstrument).
-    if (passRawMidiInput)
+    if (routing.passesRawMidiInput())
         rackType->addConnection(rackIOId, 0, rackIOId, 0);
 
     // Audio passthrough: rack input pin 1 --> rack output pin 1 (left)
@@ -394,19 +397,27 @@ te::RackType::Ptr InstrumentRackManager::getRackType(DeviceId deviceId) const {
     return nullptr;
 }
 
-void InstrumentRackManager::setMidiInThru(DeviceId deviceId, bool enabled) {
+void InstrumentRackManager::updateMidiRouting(DeviceId deviceId,
+                                              const routing::ChainRoutingNode& routing) {
     auto it = wrapped_.find(deviceId);
     if (it == wrapped_.end() || !it->second.rackType)
         return;
 
-    // Toggle the raw-input-passthrough connection (rack MIDI in --> rack MIDI
-    // out) live. The plugin's own MIDI output (synth pin 0 --> rack out) is
-    // wired unconditionally at wrap time and is untouched here.
+    // Both paths to the rack's MIDI output are re-derived from the routing node,
+    // so a device that gains a MIDI sidechain stops emitting into the chain the
+    // same way a midiInThru toggle stops the raw passthrough.
     auto rackIOId = te::EditItemID();  // rack I/O
     auto& rackType = *it->second.rackType;
+
     rackType.removeConnection(rackIOId, 0, rackIOId, 0);
-    if (enabled)
+    if (routing.passesRawMidiInput())
         rackType.addConnection(rackIOId, 0, rackIOId, 0);
+
+    if (auto* innerPlugin = it->second.innerPlugin.get()) {
+        rackType.removeConnection(innerPlugin->itemID, 0, rackIOId, 0);
+        if (routing.outputsPluginMidi())
+            rackType.addConnection(innerPlugin->itemID, 0, rackIOId, 0);
+    }
 }
 
 void InstrumentRackManager::clear() {

--- a/magda/daw/audio/racks/InstrumentRackManager.hpp
+++ b/magda/daw/audio/racks/InstrumentRackManager.hpp
@@ -6,6 +6,7 @@
 #include <map>
 
 #include "../../core/ChainNodePath.hpp"
+#include "../../core/ChainRoutingModel.hpp"
 
 namespace magda {
 
@@ -19,15 +20,13 @@ namespace te = tracktion;
  * that passes audio through and sums it with the synth output, so both audio clips
  * and synth output are audible on the same track.
  *
- * Rack wiring:
+ * Rack wiring (the MIDI pins follow ChainRoutingModel's policy for the device):
  *   MIDI in:           rack I/O pin 0 --> synth pin 0
- *   Plugin MIDI out:   synth pin 0 --> rack out pin 0 (always; lets a wrapped
- *                      sequencer/arp trigger downstream instruments)
- *   MIDI in thru:      rack I/O pin 0 --> rack out pin 0 (when passRawMidiInput;
+ *   Plugin MIDI out:   synth pin 0 --> rack out pin 0 (when outputsPluginMidi();
+ *                      lets a wrapped sequencer/arp trigger downstream instruments)
+ *   MIDI in thru:      rack I/O pin 0 --> rack out pin 0 (when passesRawMidiInput();
  *                      keeps the incoming MIDI flowing to every downstream device
- *                      so MIDI-triggered modulations fire anywhere in the chain.
- *                      Derived from ChainRoutingModel: always true for a plain
- *                      instrument, midiInThru-controlled for a MIDI-output device.)
+ *                      so MIDI-triggered modulations fire anywhere in the chain)
  *   Audio passthrough: rack I/O pin 1 --> rack out pin 1, pin 2 --> rack out pin 2
  *   Synth output:      synth pin 1/2 --> meter tap pin 1/2 --> rack out pin 1/2
  *   (Multiple connections to same output pin are summed by TE automatically)
@@ -39,22 +38,23 @@ class InstrumentRackManager {
     /**
      * @brief Wrap an instrument plugin in a RackType with audio passthrough
      * @param instrument The instrument plugin to wrap
-     * @param passRawMidiInput Keep the raw MIDI input flowing to the rack output
-     *                   (so devices after the instrument still see the notes).
-     *                   Compute from routing::makeRoutingNode(device).passesRawMidiInput().
+     * @param routing The device's MIDI policy, from routing::makeRoutingNode(device).
+     *                It decides which of the two MIDI paths to the rack output are
+     *                wired (see the class comment).
      * @return The RackInstance plugin to insert on the track (or nullptr on failure)
      */
-    te::Plugin::Ptr wrapInstrument(te::Plugin::Ptr instrument, bool passRawMidiInput = true);
+    te::Plugin::Ptr wrapInstrument(te::Plugin::Ptr instrument,
+                                   const routing::ChainRoutingNode& routing);
 
     /**
      * @brief Wrap a multi-output instrument in a RackType with all output pins exposed
      * @param instrument The instrument plugin to wrap
      * @param numOutputChannels Total number of output channels (e.g. 32 for 16 stereo pairs)
-     * @param passRawMidiInput See wrapInstrument().
+     * @param routing See wrapInstrument().
      * @return The main RackInstance plugin (outputs 1,2) to insert on the track
      */
     te::Plugin::Ptr wrapMultiOutInstrument(te::Plugin::Ptr instrument, int numOutputChannels,
-                                           bool passRawMidiInput = true);
+                                           const routing::ChainRoutingNode& routing);
 
     /**
      * @brief Create a RackInstance for a specific output pair from a multi-out instrument
@@ -116,13 +116,14 @@ class InstrumentRackManager {
     te::RackType::Ptr getRackType(DeviceId deviceId) const;
 
     /**
-     * @brief Toggle the "MIDI in thru" passthrough on a wrapped instrument live
+     * @brief Rewire a wrapped instrument's two MIDI paths to the rack output live
      * @param deviceId The MAGDA device ID
-     * @param enabled  When true, raw MIDI input is passed past the plugin to the
-     *                 rack output; when false it is not. The plugin's own MIDI
-     *                 output to the rack output is always wired and unaffected.
+     * @param routing The device's current MIDI policy, from
+     *                routing::makeRoutingNode(device). Both the raw-input
+     *                passthrough and the plugin's own MIDI output follow it, so a
+     *                midiInThru or sidechain change lands without re-wrapping.
      */
-    void setMidiInThru(DeviceId deviceId, bool enabled);
+    void updateMidiRouting(DeviceId deviceId, const routing::ChainRoutingNode& routing);
 
     /**
      * @brief Check if a TE plugin on a track is one of our wrapper racks

--- a/tests/midi/test_midi_signal_routing_juce.cpp
+++ b/tests/midi/test_midi_signal_routing_juce.cpp
@@ -19,6 +19,7 @@
 #include "magda/daw/audio/plugins/tracktion/TracktionMagdaDevicePlugin.hpp"
 #include "magda/daw/audio/racks/InstrumentRackManager.hpp"
 #include "magda/daw/audio/sequencer/StepClock.hpp"
+#include "magda/daw/core/ChainRoutingModel.hpp"
 #include "magda/daw/core/ClipManager.hpp"
 #include "magda/daw/core/RackInfo.hpp"
 #include "magda/daw/core/StepPatternCommands.hpp"
@@ -55,6 +56,17 @@ bool hasMidiOutputConnection(te::RackType& rackType) {
     return false;
 }
 
+/// The MIDI policy the wrapper wires from, as PluginManagerSync computes it.
+magda::routing::ChainRoutingNode instrumentRouting(bool producesMidi, bool midiInThru = false) {
+    magda::DeviceInfo device;
+    device.id = 1;
+    device.isInstrument = true;
+    device.deviceType = magda::DeviceType::Instrument;
+    device.producesMidi = producesMidi;
+    device.midiInThru = midiInThru;
+    return magda::routing::makeRoutingNode(device);
+}
+
 class ScopedDeviceServicesRegistration {
   public:
     ScopedDeviceServicesRegistration(te::Edit& edit, magda::daw::audio::DeviceServices services)
@@ -80,6 +92,8 @@ class MidiSignalRoutingTest final : public juce::UnitTest {
 
     void runTest() override {
         magda::test::runWithCleanJuceState([this] { testInstrumentRackPassesMidiThrough(); });
+        magda::test::runWithCleanJuceState(
+            [this] { testInstrumentWrapperWiresPluginMidiOnlyForAMidiEmittingDevice(); });
         magda::test::runWithCleanJuceState(
             [this] { testStepSequencerLoadsAProjectSavedWithMidiThru(); });
         magda::test::runWithCleanJuceState([this] { testStepSequencerStepRecordingStopsAtEnd(); });
@@ -141,7 +155,7 @@ class MidiSignalRoutingTest final : public juce::UnitTest {
         ScopedDeviceServicesRegistration servicesRegistration(*edit, deviceServices);
 
         magda::InstrumentRackManager rackManager(*edit);
-        auto rackPlugin = rackManager.wrapInstrument(instrument);
+        auto rackPlugin = rackManager.wrapInstrument(instrument, instrumentRouting(false));
         expect(rackPlugin != nullptr, "Instrument must be wrapped");
 
         auto* rackInstance = dynamic_cast<te::RackInstance*>(rackPlugin.get());
@@ -167,25 +181,31 @@ class MidiSignalRoutingTest final : public juce::UnitTest {
 
         expect(hasConnection(rackType, rackIO, 0, synthId, 0),
                "Rack MIDI input must feed the instrument");
-        expect(hasConnection(rackType, synthId, 0, rackIO, 0),
-               "Instrument's own MIDI output must always reach the rack output so a "
-               "wrapped sequencer/arp triggers downstream instruments");
+        expect(!hasConnection(rackType, synthId, 0, rackIO, 0),
+               "A plain instrument declares no MIDI output, so its pin 0 must not reach the "
+               "rack output - TE hands it the rack's own input and it would double every "
+               "note against the raw passthrough (#2346)");
         expect(hasConnection(rackType, rackIO, 0, rackIO, 0),
-               "Raw MIDI in thru is on by default (preserves historic passthrough)");
+               "A plain instrument forwards the raw MIDI input to the rack output");
 
-        // Toggling MIDI in thru adds/removes only the raw-input passthrough.
+        // Both MIDI paths are re-derived live from the routing model.
         rackManager.recordWrapping(magda::ChainNodePath::topLevelDevice(0, 1), rackInstance->type,
                                    instrument, rackPlugin);
-        rackManager.setMidiInThru(1, true);
+        rackManager.updateMidiRouting(1, instrumentRouting(true, /*midiInThru*/ true));
         expect(hasConnection(rackType, rackIO, 0, rackIO, 0),
                "Enabling MIDI in thru wires the raw-input passthrough");
         expect(hasConnection(rackType, synthId, 0, rackIO, 0),
-               "Plugin MIDI output stays wired when in-thru is enabled");
-        rackManager.setMidiInThru(1, false);
+               "A MIDI-emitting device's plugin output is wired alongside the passthrough");
+        rackManager.updateMidiRouting(1, instrumentRouting(true, /*midiInThru*/ false));
         expect(!hasConnection(rackType, rackIO, 0, rackIO, 0),
                "Disabling MIDI in thru removes the raw-input passthrough");
         expect(hasConnection(rackType, synthId, 0, rackIO, 0),
                "Plugin MIDI output stays wired when in-thru is disabled");
+        rackManager.updateMidiRouting(1, instrumentRouting(false));
+        expect(hasConnection(rackType, rackIO, 0, rackIO, 0),
+               "A plain instrument always forwards the raw input");
+        expect(!hasConnection(rackType, synthId, 0, rackIO, 0),
+               "A device that stops declaring a MIDI output has its pin 0 unwired again");
 
         expect(hasConnection(rackType, rackIO, 1, rackIO, 1),
                "Rack must preserve left audio passthrough");
@@ -255,6 +275,81 @@ class MidiSignalRoutingTest final : public juce::UnitTest {
                                   "Unbound meter tap should pass audio through unchanged");
         expectWithinAbsoluteError(buffer.getSample(1, 0), -0.25f, 0.0001f,
                                   "Unbound meter tap should pass audio through unchanged");
+    }
+
+    void testInstrumentWrapperWiresPluginMidiOnlyForAMidiEmittingDevice() {
+        beginTest("Instrument wrapper wires plugin MIDI out only for a MIDI-emitting device");
+
+        auto& wrapper = magda::test::getSharedEngine();
+        auto edit = te::test_utilities::createTestEdit(*wrapper.getEngine(), 1);
+        expect(edit != nullptr, "Test edit must be created");
+        if (!edit)
+            return;
+
+        magda::DeviceMeteringManager metering;
+        magda::daw::audio::DeviceServices deviceServices;
+        deviceServices.meteringContext = &metering;
+        ScopedDeviceServicesRegistration servicesRegistration(*edit, deviceServices);
+
+        magda::InstrumentRackManager rackManager(*edit);
+        const auto rackIO = te::EditItemID();
+
+        struct Case {
+            const char* name;
+            magda::routing::ChainRoutingNode routing;
+            int numOutputChannels;
+            bool expectPluginMidi;
+            bool expectRawThru;
+        };
+
+        magda::DeviceInfo sidechained;
+        sidechained.id = 2;
+        sidechained.isInstrument = true;
+        sidechained.deviceType = magda::DeviceType::Instrument;
+        sidechained.producesMidi = true;
+        sidechained.sidechain.type = magda::SidechainConfig::Type::MIDI;
+        sidechained.sidechain.sourceTrackId = 7;
+
+        const Case cases[] = {
+            {"MIDI-emitting instrument", instrumentRouting(true), 2, true, false},
+            {"MIDI-emitting instrument with in-thru", instrumentRouting(true, true), 2, true, true},
+            {"plain instrument", instrumentRouting(false), 2, false, true},
+            {"multi-out MIDI-emitting instrument", instrumentRouting(true), 4, true, false},
+            {"multi-out plain instrument", instrumentRouting(false), 4, false, true},
+            // Fed from another track, so nothing of its MIDI belongs in this chain.
+            {"MIDI-sidechained instrument", magda::routing::makeRoutingNode(sidechained), 2, false,
+             false},
+        };
+
+        for (const auto& testCase : cases) {
+            auto instrument =
+                createCustomPlugin(*edit, magda::daw::audio::MagdaSamplerPlugin::xmlTypeName);
+            expect(instrument != nullptr, "Sampler plugin must be created");
+            if (!instrument)
+                continue;
+
+            const auto synthId = instrument->itemID;
+            auto rackPlugin = testCase.numOutputChannels > 2
+                                  ? rackManager.wrapMultiOutInstrument(
+                                        instrument, testCase.numOutputChannels, testCase.routing)
+                                  : rackManager.wrapInstrument(instrument, testCase.routing);
+
+            auto* rackInstance = dynamic_cast<te::RackInstance*>(rackPlugin.get());
+            expect(rackInstance != nullptr && rackInstance->type != nullptr,
+                   juce::String(testCase.name) + ": instrument must be wrapped");
+            if (rackInstance == nullptr || rackInstance->type == nullptr)
+                continue;
+
+            auto& rackType = *rackInstance->type;
+            expect(hasConnection(rackType, rackIO, 0, synthId, 0),
+                   juce::String(testCase.name) + ": rack MIDI input must feed the instrument");
+            expect(hasConnection(rackType, synthId, 0, rackIO, 0) == testCase.expectPluginMidi,
+                   juce::String(testCase.name) + ": plugin MIDI output to the rack output must " +
+                       (testCase.expectPluginMidi ? "be wired" : "be absent (#2346)"));
+            expect(hasConnection(rackType, rackIO, 0, rackIO, 0) == testCase.expectRawThru,
+                   juce::String(testCase.name) + ": raw MIDI passthrough must " +
+                       (testCase.expectRawThru ? "be wired" : "be absent"));
+        }
     }
 
     /// The MagdaDevice inside a host wrapper plugin (#2299).


### PR DESCRIPTION
Fixes #2346.

## The bug

`InstrumentRackManager::wrapInstrument` connected the wrapped plugin's pin 0 to the rack's MIDI output unconditionally, on the assumption that a plain synth emits no MIDI so the connection carries nothing. TE's `PluginNode` hands the plugin the buffer it was given and passes on whatever is left in it, so for a device that does not write MIDI, pin 0 carries the rack's own input back out. `SummingNode` then merged it with the raw passthrough and every MIDI-triggered device after a MAGDA instrument fired twice per note.

## The fix

Both paths to the rack's MIDI output now come from one `ChainRoutingModel` node:

- plugin pin 0 -> rack out, when `outputsPluginMidi()`
- raw input -> rack out, when `passesRawMidiInput()`

`wrapInstrument` / `wrapMultiOutInstrument` take the routing node instead of a lone `passRawMidiInput` bool, so the two decisions cannot drift apart. `setMidiInThru` becomes `updateMidiRouting(deviceId, node)` and re-derives both connections, so a device that gains a MIDI sidechain stops emitting into the chain the same way a `midiInThru` toggle stops the passthrough — no re-wrap needed.

Racks are only ever built programmatically from the model, never restored from a saved edit, so no stored project carries the old wiring.

## What changes per case

| device | plugin pin 0 | raw thru |
|---|---|---|
| plain instrument | **now absent** (was wired, hence the doubling) | on |
| MIDI-emitting device | wired | follows `midiInThru` |
| MIDI-sidechained instrument | **now absent** (was leaking the sidechain notes into this chain) | off |

## Tests

`tests/midi/test_midi_signal_routing_juce.cpp`: the existing wrapper test now asserts a plain instrument's pin 0 stays unwired and drives `updateMidiRouting` through emitting/thru/plain states; a new case-table test covers all six single/multi-out x emitting/plain/sidechained combinations.

Verified negatively — with the `outputsPluginMidi()` guards reverted, 5 assertions fail across the two tests. Full `make test-juce` and `make test` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019sKH5X6HQ8WV82QriCbmLr