### PR TITLE
Read the arpeggiator's input where the host put it

### DIFF
--- a/magda/daw/audio/plugins/ArpeggiatorPlugin.cpp
+++ b/magda/daw/audio/plugins/ArpeggiatorPlugin.cpp
@@ -45,8 +45,17 @@ bool isLiveSource(const DeviceProcessContext& context, std::uint32_t sourceId) {
 /// device rather than the notes.
 class NonNoteForwarder {
   public:
-    NonNoteForwarder(const DeviceMidiInput& in, double offsetSeconds)
-        : in_(in), offsetSeconds_(offsetSeconds) {}
+    NonNoteForwarder(const DeviceMidiInput& in, double offsetSeconds, double blockDurationSecs)
+        : in_(in), offsetSeconds_(offsetSeconds), blockDurationSecs_(blockDurationSecs) {}
+
+    /// Where in the block the host put event @p index: its timestamp with the
+    /// host's sub-block offset added, inside the block it belongs to. The one
+    /// answer the arp reads an input time by, so a forwarded message and the
+    /// notes generated around it share a timeline (#2415).
+    double timeOf(int index) const {
+        return juce::jlimit(0.0, blockDurationSecs_,
+                            in_.message(index).getTimeStamp() + offsetSeconds_);
+    }
 
     /// Everything up to and including @p timeInBlock. A message coincident
     /// with a generated note goes out first: a controller moved on the beat
@@ -54,7 +63,8 @@ class NonNoteForwarder {
     void flushUpTo(DeviceMidiOutput& midi, double timeInBlock) {
         for (const int count = in_.size(); next_ < count; ++next_) {
             const auto& message = in_.message(next_);
-            if (message.getTimeStamp() + offsetSeconds_ > timeInBlock)
+            const double time = timeOf(next_);
+            if (time > timeInBlock)
                 return;
             // Channel messages only: getChannel() is 0 for SysEx and for
             // everything the transport carries.
@@ -63,6 +73,7 @@ class NonNoteForwarder {
 
             auto forwarded = message;  // short message: inline storage, no allocation
             forwarded.setChannel(1);
+            forwarded.setTimeStamp(time);
             midi.addEvent({std::move(forwarded), in_.sourceId(next_)});
         }
     }
@@ -73,9 +84,8 @@ class NonNoteForwarder {
 
   private:
     const DeviceMidiInput& in_;
-    /// The host's sub-block offset, added to every input timestamp the way the
-    /// arp adds it when placing the same events on its own timeline (#2415).
     double offsetSeconds_ = 0.0;
+    double blockDurationSecs_ = 0.0;
     int next_ = 0;
 };
 
@@ -475,7 +485,7 @@ void ArpeggiatorPlugin::process(DeviceProcessContext& context) {
     // What the arp passes on rather than consumes, emitted beside the notes it
     // generates. The guard covers the returns below: a block the arp leaves
     // early is still a block the instrument behind it is owed its pedal on.
-    NonNoteForwarder forward(in, context.midiTimeOffsetSeconds);
+    NonNoteForwarder forward(in, context.midiTimeOffsetSeconds, blockDurationSecs);
     const juce::ScopeGuard forwardRest{[&] { forward.flushRest(midi); }};
 
     const auto addTimedMessage = [&](juce::MidiMessage message, double timeInBlock,
@@ -529,10 +539,7 @@ void ArpeggiatorPlugin::process(DeviceProcessContext& context) {
     }
 
     // --- 3. Where the input sits in the block ---
-    const auto eventTime = [&](int index) {
-        return juce::jlimit(0.0, blockDurationSecs,
-                            in.message(index).getTimeStamp() + context.midiTimeOffsetSeconds);
-    };
+    const auto eventTime = [&](int index) { return forward.timeOf(index); };
 
     /// The pattern's material changes here, so the block is cut here.
     const auto changesPattern = [](const juce::MidiMessage& message) {

--- a/magda/daw/audio/plugins/ArpeggiatorPlugin.cpp
+++ b/magda/daw/audio/plugins/ArpeggiatorPlugin.cpp
@@ -29,37 +29,58 @@ bool isLiveSource(const DeviceProcessContext& context, std::uint32_t sourceId) {
     return false;
 }
 
-/// What the arp does not consume, copied onto its output in timestamp order
-/// (#2417).
-///
-/// Notes are the device's material: they go in and an arpeggio comes out.
-/// Everything else the channel carries -- mod wheel, expression, sustain,
-/// bend, aftertouch, program change -- is addressed to the instrument behind
-/// this one, and reaches it nowhere else: thru carries the held chord too, so
-/// a track that wants the pedal cannot have it without the notes under it.
-///
-/// Forwarded on channel 1, the one the generated notes are on, so an
-/// instrument that keeps per-channel state applies them to what it is
-/// playing. SysEx is not forwarded: copying one allocates on the audio thread
-/// (JUCE holds anything past eight bytes on the heap), and it addresses a
-/// device rather than the notes.
+/**
+ * @brief What the arp does not consume, copied onto its output in timestamp
+ *        order (#2417).
+ *
+ * Notes are the device's material: they go in and an arpeggio comes out.
+ * Everything else the channel carries -- mod wheel, expression, sustain,
+ * bend, aftertouch, program change -- is addressed to the instrument behind
+ * this one, and reaches it nowhere else: thru carries the held chord too, so
+ * a track that wants the pedal cannot have it without the notes under it.
+ *
+ * Forwarded on channel 1, the one the generated notes are on, so an
+ * instrument that keeps per-channel state applies them to what it is
+ * playing. SysEx is not forwarded: copying one allocates on the audio thread
+ * (JUCE holds anything past eight bytes on the heap), and it addresses a
+ * device rather than the notes.
+ */
 class NonNoteForwarder {
   public:
+    /**
+     * @param in The block's MIDI input.
+     * @param offsetSeconds The host's sub-block offset, added to every input
+     *                      timestamp.
+     * @param blockDurationSecs The block's length, which no event is read past.
+     */
     NonNoteForwarder(const DeviceMidiInput& in, double offsetSeconds, double blockDurationSecs)
         : in_(in), offsetSeconds_(offsetSeconds), blockDurationSecs_(blockDurationSecs) {}
 
-    /// Where in the block the host put event @p index: its timestamp with the
-    /// host's sub-block offset added, inside the block it belongs to. The one
-    /// answer the arp reads an input time by, so a forwarded message and the
-    /// notes generated around it share a timeline (#2415).
+    /**
+     * @brief Where in the block the host put an input event.
+     *
+     * The one answer the arp reads an input time by, so a forwarded message and
+     * the notes generated around it share a timeline (#2415).
+     *
+     * @param index Index into the block's MIDI input.
+     * @return Seconds from the block start: the event's timestamp with the
+     *         host's sub-block offset added, inside the block it belongs to.
+     */
     double timeOf(int index) const {
         return juce::jlimit(0.0, blockDurationSecs_,
                             in_.message(index).getTimeStamp() + offsetSeconds_);
     }
 
-    /// Everything up to and including @p timeInBlock. A message coincident
-    /// with a generated note goes out first: a controller moved on the beat
-    /// belongs to the note that starts on it.
+    /**
+     * @brief Forwards everything up to and including @p timeInBlock.
+     *
+     * A message coincident with a generated note goes out first: a controller
+     * moved on the beat belongs to the note that starts on it.
+     *
+     * @param midi Where the arp writes its output.
+     * @param timeInBlock Seconds from the block start; nothing later is
+     *                    forwarded yet.
+     */
     void flushUpTo(DeviceMidiOutput& midi, double timeInBlock) {
         for (const int count = in_.size(); next_ < count; ++next_) {
             const auto& message = in_.message(next_);
@@ -78,6 +99,10 @@ class NonNoteForwarder {
         }
     }
 
+    /**
+     * @brief Forwards whatever is left of the block.
+     * @param midi Where the arp writes its output.
+     */
     void flushRest(DeviceMidiOutput& midi) {
         flushUpTo(midi, std::numeric_limits<double>::max());
     }
@@ -495,8 +520,8 @@ void ArpeggiatorPlugin::process(DeviceProcessContext& context) {
         midi.addEvent({std::move(message), sourceId});
     };
 
-    /// A note-off at its own instant in the block, behind the non-note traffic
-    /// that precedes it (#2415).
+    // A note-off at its own instant in the block, behind the non-note traffic
+    // that precedes it (#2415).
     const auto emitNoteOff = [&](int noteNumber, double timeInBlock, std::uint32_t source) {
         if (noteNumber < 0)
             return;
@@ -504,7 +529,7 @@ void ArpeggiatorPlugin::process(DeviceProcessContext& context) {
         sendNoteOff(midi, noteNumber, source, timeInBlock);
     };
 
-    /// Closes the note the arp is sounding, wherever it is being closed.
+    // Closes the note the arp is sounding, wherever it is being closed.
     const auto closeSoundingNote = [&](double timeInBlock) {
         const std::uint32_t source = lastPlayedSourceId_;
         emitNoteOff(takeSoundingNote(), timeInBlock, source);
@@ -541,13 +566,13 @@ void ArpeggiatorPlugin::process(DeviceProcessContext& context) {
     // --- 3. Where the input sits in the block ---
     const auto eventTime = [&](int index) { return forward.timeOf(index); };
 
-    /// The pattern's material changes here, so the block is cut here.
+    // The pattern's material changes here, so the block is cut here.
     const auto changesPattern = [](const juce::MidiMessage& message) {
         return message.isNoteOnOrOff() || message.isAllNotesOff() || message.isAllSoundOff();
     };
 
-    /// Everything the arp was doing, dropped where the input dropped it: the
-    /// note it sounds, its walk, and the clock the walk runs on.
+    // Everything the arp was doing, dropped where the input dropped it: the
+    // note it sounds, its walk, and the clock the walk runs on.
     const auto restartAt = [&](double timeInBlock) {
         const std::uint32_t source = lastPlayedSourceId_;
         emitNoteOff(resetArpState(), timeInBlock, source);

--- a/magda/daw/audio/plugins/ArpeggiatorPlugin.cpp
+++ b/magda/daw/audio/plugins/ArpeggiatorPlugin.cpp
@@ -45,7 +45,8 @@ bool isLiveSource(const DeviceProcessContext& context, std::uint32_t sourceId) {
 /// device rather than the notes.
 class NonNoteForwarder {
   public:
-    explicit NonNoteForwarder(const DeviceMidiInput& in) : in_(in) {}
+    NonNoteForwarder(const DeviceMidiInput& in, double offsetSeconds)
+        : in_(in), offsetSeconds_(offsetSeconds) {}
 
     /// Everything up to and including @p timeInBlock. A message coincident
     /// with a generated note goes out first: a controller moved on the beat
@@ -53,7 +54,7 @@ class NonNoteForwarder {
     void flushUpTo(DeviceMidiOutput& midi, double timeInBlock) {
         for (const int count = in_.size(); next_ < count; ++next_) {
             const auto& message = in_.message(next_);
-            if (message.getTimeStamp() > timeInBlock)
+            if (message.getTimeStamp() + offsetSeconds_ > timeInBlock)
                 return;
             // Channel messages only: getChannel() is 0 for SysEx and for
             // everything the transport carries.
@@ -72,6 +73,9 @@ class NonNoteForwarder {
 
   private:
     const DeviceMidiInput& in_;
+    /// The host's sub-block offset, added to every input timestamp the way the
+    /// arp adds it when placing the same events on its own timeline (#2415).
+    double offsetSeconds_ = 0.0;
     int next_ = 0;
 };
 
@@ -363,11 +367,6 @@ void ArpeggiatorPlugin::clearHeldNotes() {
     nextOrder_ = 0;
 }
 
-void ArpeggiatorPlugin::sendAllNotesOff(DeviceMidiOutput& midi) {
-    const std::uint32_t source = lastPlayedSourceId_;
-    sendNoteOff(midi, takeSoundingNote(), source);
-}
-
 int ArpeggiatorPlugin::takeSoundingNote() {
     const int note = lastPlayedNote_;
     lastPlayedNote_ = -1;
@@ -471,37 +470,88 @@ void ArpeggiatorPlugin::process(DeviceProcessContext& context) {
     const auto& in = *context.midiIn;
     auto& midi = *context.midiOut;
     const bool isLatched = displayValue(kLatch) >= 0.5f;
+    const double blockDurationSecs = static_cast<double>(context.numSamples) / sampleRate_;
 
     // What the arp passes on rather than consumes, emitted beside the notes it
     // generates. The guard covers the returns below: a block the arp leaves
     // early is still a block the instrument behind it is owed its pedal on.
-    NonNoteForwarder forward(in);
+    NonNoteForwarder forward(in, context.midiTimeOffsetSeconds);
     const juce::ScopeGuard forwardRest{[&] { forward.flushRest(midi); }};
 
-    // --- 1. Capture incoming MIDI ---
-    // Only one note can be sounding on entry, and this pass generates none, so
-    // one pending note-off is enough.
-    int pendingNoteOff = -1;
-    const auto resetFromInput = [&] {
-        const int note = resetArpState();
-        if (note >= 0)
-            pendingNoteOff = note;
-        freeRunSamples_ = 0.0;
+    const auto addTimedMessage = [&](juce::MidiMessage message, double timeInBlock,
+                                     std::uint32_t sourceId) {
+        forward.flushUpTo(midi, timeInBlock);
+        message.setTimeStamp(timeInBlock);
+        midi.addEvent({std::move(message), sourceId});
     };
+
+    /// A note-off at its own instant in the block, behind the non-note traffic
+    /// that precedes it (#2415).
+    const auto emitNoteOff = [&](int noteNumber, double timeInBlock, std::uint32_t source) {
+        if (noteNumber < 0)
+            return;
+        forward.flushUpTo(midi, timeInBlock);
+        sendNoteOff(midi, noteNumber, source, timeInBlock);
+    };
+
+    /// Closes the note the arp is sounding, wherever it is being closed.
+    const auto closeSoundingNote = [&](double timeInBlock) {
+        const std::uint32_t source = lastPlayedSourceId_;
+        emitNoteOff(takeSoundingNote(), timeInBlock, source);
+    };
+
+    // --- 1. The buffer's panic, which the host raises for the block ---
     // Hosts raise this without a CC event, on a playhead jump or a track they
     // just muted, and then re-assert whatever should be sounding at the new
     // position without a note-off for what should not. So the host's notes go
     // and come back on the same buffer, while keys proven to be a player's are
     // not the host's to withdraw (#2416).
     const bool inputPanic = in.isAllNotesOff();
+    midi.setAllNotesOff(inputPanic);
     if (inputPanic) {
-        pendingNoteOff = takeSoundingNote();
+        closeSoundingNote(0.0);
         retainLiveHeldNotes();
     }
-    const int incomingCount = in.size();
-    for (int eventIndex = 0; eventIndex < incomingCount; ++eventIndex) {
-        const auto& msg = in.message(eventIndex);
-        const bool fromLiveSource = isLiveSource(context, in.sourceId(eventIndex));
+
+    // --- 2. Transport transitions ---
+    if (context.isPlaying && !wasPlaying_) {
+        // The transport and the free-running clock are different clocks, so
+        // the walk re-anchors below instead of carrying its step across.
+        lastBlockEndBeat_ = -1.0;
+    } else if (!context.isPlaying && wasPlaying_) {
+        // Keys under the player's fingers keep the arp free-running; notes a
+        // clip left behind are dropped, because their note-off is never
+        // coming once the transport stops (#2416).
+        closeSoundingNote(0.0);
+        retainLiveHeldNotes();
+        resetArpState();
+        freeRunSamples_ = 0.0;
+    }
+
+    // --- 3. Where the input sits in the block ---
+    const auto eventTime = [&](int index) {
+        return juce::jlimit(0.0, blockDurationSecs,
+                            in.message(index).getTimeStamp() + context.midiTimeOffsetSeconds);
+    };
+
+    /// The pattern's material changes here, so the block is cut here.
+    const auto changesPattern = [](const juce::MidiMessage& message) {
+        return message.isNoteOnOrOff() || message.isAllNotesOff() || message.isAllSoundOff();
+    };
+
+    /// Everything the arp was doing, dropped where the input dropped it: the
+    /// note it sounds, its walk, and the clock the walk runs on.
+    const auto restartAt = [&](double timeInBlock) {
+        const std::uint32_t source = lastPlayedSourceId_;
+        emitNoteOff(resetArpState(), timeInBlock, source);
+        freeRunSamples_ = 0.0;
+    };
+
+    const auto applyEvent = [&](int index, double timeInBlock) {
+        const auto& msg = in.message(index);
+        const auto sourceId = in.sourceId(index);
+        const bool fromLiveSource = isLiveSource(context, sourceId);
+
         if (msg.isNoteOn()) {
             ++physicallyHeldCount_;
 
@@ -512,13 +562,10 @@ void ArpeggiatorPlugin::process(DeviceProcessContext& context) {
                 latchedSetStale_ = false;
             }
 
-            bool wasEmpty = (heldCount_ == 0);
-            addHeldNote(msg.getNoteNumber(), msg.getVelocity(), fromLiveSource,
-                        in.sourceId(eventIndex));
-            // Reset free-running clock when first note arrives
-            if (wasEmpty && heldCount_ > 0) {
-                resetFromInput();
-            }
+            const bool wasEmpty = (heldCount_ == 0);
+            addHeldNote(msg.getNoteNumber(), msg.getVelocity(), fromLiveSource, sourceId);
+            if (wasEmpty && heldCount_ > 0)
+                restartAt(timeInBlock);
         } else if (msg.isNoteOff()) {
             --physicallyHeldCount_;
             if (physicallyHeldCount_ < 0)
@@ -531,236 +578,257 @@ void ArpeggiatorPlugin::process(DeviceProcessContext& context) {
                 latchedSetStale_ = true;
         } else if (msg.isAllNotesOff() || msg.isAllSoundOff()) {
             clearHeldNotes();
-            resetFromInput();
+            restartAt(timeInBlock);
         }
-    }
-
-    // --- 2. Pass the panic on and close the note the input pass ended ---
-    // One flush covers every note-off below that lands at the top of the
-    // block, since none of them advances past that instant.
-    midi.setAllNotesOff(inputPanic);
-    forward.flushUpTo(midi, 0.0);
-    sendNoteOff(midi, pendingNoteOff, lastPlayedSourceId_);
-
-    // --- 3. Handle transport transitions ---
-    if (context.isPlaying && !wasPlaying_) {
-        // The transport and the free-running clock are different clocks, so
-        // the walk re-anchors below instead of carrying its step across.
-        wasPlaying_ = true;
-        lastBlockEndBeat_ = -1.0;
-    } else if (!context.isPlaying && wasPlaying_) {
-        // Keys under the player's fingers keep the arp free-running; notes a
-        // clip left behind are dropped, because their note-off is never
-        // coming once the transport stops (#2416).
-        sendAllNotesOff(midi);
-        retainLiveHeldNotes();
-        resetArpState();
-        freeRunSamples_ = 0.0;
-    }
-
-    // --- 4. No held notes, or no MIDI input while transport is stopped? ---
-    if (heldCount_ == 0 || (!context.isPlaying && physicallyHeldCount_ <= 0)) {
-        sendAllNotesOff(midi);
-        freeRunSamples_ = 0.0;
-        lastBlockEndBeat_ = -1.0;
-        return;
-    }
-
-    // --- 5. Get beat positions ---
-    double blockStartBeat, blockEndBeat;
-
-    if (context.isPlaying && context.tempoMap != nullptr) {
-        // Use transport position
-        blockStartBeat = context.tempoMap->beatsAtSeconds(context.timelineStartSeconds);
-        blockEndBeat = context.tempoMap->beatsAtSeconds(context.timelineEndSeconds);
-    } else {
-        // Free-running clock — get tempo from timeline position 0
-        const double bpm =
-            context.tempoMap != nullptr ? context.tempoMap->bpmAtSeconds(0.0) : 120.0;
-        double beatsPerSample = bpm / (60.0 * sampleRate_);
-        blockStartBeat = freeRunSamples_ * beatsPerSample;
-        freeRunSamples_ += context.numSamples;
-        blockEndBeat = freeRunSamples_ * beatsPerSample;
-    }
-
-    if (blockEndBeat <= blockStartBeat)
-        return;
-
-    // Seeks, loop wraps and the switch between the two clocks all arrive as a
-    // block that does not continue the last one. Only some of them reach the
-    // device as a panic and a loop wrap reaches it as nothing at all, so the
-    // timeline is what the walk trusts (#2416).
-    constexpr double kContiguousBeats = 1.0e-3;
-    if (lastBlockEndBeat_ < 0.0 ||
-        std::abs(blockStartBeat - lastBlockEndBeat_) > kContiguousBeats) {
-        const std::uint32_t source = lastPlayedSourceId_;
-        sendNoteOff(midi, takeSoundingNote(), source);
-        currentStep_ = 0;
-        arpOriginBeat_ = -1.0;
-    }
-    lastBlockEndBeat_ = blockEndBeat;
-
-    // --- 6. Build note sequence ---
-    auto seq = buildSequence();
-    if (seq.length == 0)
-        return;
-
-    auto pat = static_cast<Pattern>(displayIndex(kPattern));
-    auto currentRate = static_cast<Rate>(displayIndex(kRate));
-    double stepBeats = rateToBeats(currentRate);
-    float gateVal = juce::jlimit(0.01f, 1.0f, displayValue(kGate));
-    float swingVal = juce::jlimit(0.0f, 1.0f, displayValue(kSwing));
-    float rampVal = juce::jlimit(-1.0f, 1.0f, displayValue(kRamp));
-    float skewVal = juce::jlimit(-1.0f, 1.0f, displayValue(kSkew));
-    auto velMode = static_cast<VelocityMode>(displayIndex(kVelMode));
-    int fixedVel = juce::jlimit(1, 127, displayIndex(kFixedVel));
-    float quantizeAmount = juce::jlimit(0.0f, 1.0f, quantize.load(std::memory_order_relaxed));
-    int quantizeSubVal = juce::jlimit(16, 512, quantizeSub.load(std::memory_order_relaxed));
-    bool hardAngleVal = hardAngle.load(std::memory_order_relaxed);
-
-    // Cycle length in beats (one full pass through the sequence)
-    double cycleBeats = seq.length * stepBeats;
-
-    // Initialise arp origin on first buffer — align to step grid
-    if (arpOriginBeat_ < 0.0) {
-        arpOriginBeat_ = std::floor(blockStartBeat / stepBeats) * stepBeats;
-    }
-
-    // Compute the beat position for a given global step index.
-    // With ramp, steps within each cycle are warped by the bezier curve.
-    // Without ramp, steps are evenly spaced at stepBeats intervals.
-    auto computeStepBeat = [&](int step) -> double {
-        int cycle = step / seq.length;
-        int stepInCycle = step % seq.length;
-        double cycleStart = arpOriginBeat_ + cycle * cycleBeats;
-
-        if (std::abs(rampVal) > 0.001f && seq.length > 1) {
-            int cyc = juce::jlimit(1, 8, rampCycles.load(std::memory_order_relaxed));
-            double tLinear = static_cast<double>(stepInCycle) / static_cast<double>(seq.length);
-            double tCurved =
-                ramp_curve::applyRampCurveWithCycles(tLinear, rampVal, skewVal, cyc, hardAngleVal);
-            return cycleStart + tCurved * cycleBeats;
-        }
-        return cycleStart + stepInCycle * stepBeats;
     };
 
-    // Where the step is actually played: swing on odd steps, then quantize
-    // pulling that toward a regular grid. Neither can carry a step past its
-    // neighbour, so the walk below keys on this instead of the raw grid and a
-    // step warped past the block end stays pending rather than being consumed
-    // unplayed (#2362).
-    auto warpedStepBeat = [&](int step) -> double {
-        double beat = computeStepBeat(step);
-        // Half the gap to the next step, not half the nominal rate: Time Bend
-        // can compress two steps onto one beat, and a fixed offset would then
-        // swing the odd one past the even one that follows it.
-        if (step % 2 == 1 && swingVal > 0.0f)
-            beat += static_cast<double>(swingVal) * (computeStepBeat(step + 1) - beat) * 0.5;
+    // --- 4. Settings the walk reads, fixed for the block ---
+    const auto pat = static_cast<Pattern>(displayIndex(kPattern));
+    const double stepBeats = rateToBeats(static_cast<Rate>(displayIndex(kRate)));
+    const float gateVal = juce::jlimit(0.01f, 1.0f, displayValue(kGate));
+    const float swingVal = juce::jlimit(0.0f, 1.0f, displayValue(kSwing));
+    const float rampVal = juce::jlimit(-1.0f, 1.0f, displayValue(kRamp));
+    const float skewVal = juce::jlimit(-1.0f, 1.0f, displayValue(kSkew));
+    const auto velMode = static_cast<VelocityMode>(displayIndex(kVelMode));
+    const int fixedVel = juce::jlimit(1, 127, displayIndex(kFixedVel));
+    const float quantizeAmount = juce::jlimit(0.0f, 1.0f, quantize.load(std::memory_order_relaxed));
+    const int quantizeSubVal = juce::jlimit(16, 512, quantizeSub.load(std::memory_order_relaxed));
+    const bool hardAngleVal = hardAngle.load(std::memory_order_relaxed);
 
-        if (quantizeAmount > 0.0f && quantizeSubVal > 0) {
-            double gridSpacing = cycleBeats / static_cast<double>(quantizeSubVal);
-            double snapped = std::round(beat / gridSpacing) * gridSpacing;
-            beat += (snapped - beat) * static_cast<double>(quantizeAmount);
-        }
-        return beat;
-    };
+    // The block's beat span on the transport clock, which every segment
+    // divides. The free-running clock counts samples and is read per segment.
+    const bool onTransportClock = context.isPlaying && context.tempoMap != nullptr;
+    const double blockStartBeat =
+        onTransportClock ? context.tempoMap->beatsAtSeconds(context.timelineStartSeconds) : 0.0;
+    const double blockEndBeat =
+        onTransportClock ? context.tempoMap->beatsAtSeconds(context.timelineEndSeconds) : 0.0;
 
-    // Block duration in seconds (MIDI timestamps stay in seconds, not samples)
-    double blockDurationSecs = static_cast<double>(context.numSamples) / sampleRate_;
-
-    const auto addTimedMessage = [&](juce::MidiMessage message, double timeInBlock,
-                                     std::uint32_t sourceId) {
-        forward.flushUpTo(midi, timeInBlock);
-        message.setTimeStamp(timeInBlock);
-        midi.addEvent({std::move(message), sourceId});
-    };
-
-    // --- 7. Emit pending note-off from previous block ---
-    if (lastNoteOffBeat_ >= blockStartBeat && lastNoteOffBeat_ < blockEndBeat &&
-        lastPlayedNote_ >= 0) {
-        double frac = (lastNoteOffBeat_ - blockStartBeat) / (blockEndBeat - blockStartBeat);
-        addTimedMessage(juce::MidiMessage::noteOff(1, lastPlayedNote_), frac * blockDurationSecs,
-                        lastPlayedSourceId_);
-        lastPlayedNote_ = -1;
-        lastNoteOffBeat_ = -1.0;
-        clearMidiOutDisplay();
-    }
-
-    // --- 8. Walk steps and generate notes ---
-    // Catch up to the block. Cycles are evenly spaced whatever the warp does
-    // inside one, so the cycle is a division and only its steps are walked:
-    // bounded work, not one pass per skipped step.
-    if (warpedStepBeat(currentStep_) < blockStartBeat) {
-        // Warp carries a step across the cycle boundary either way, so the
-        // division lands a cycle early and the walk closes the rest.
-        const int cycle =
-            static_cast<int>(std::floor((blockStartBeat - arpOriginBeat_) / cycleBeats)) - 1;
-        currentStep_ = std::max(currentStep_, cycle * seq.length);
-        while (warpedStepBeat(currentStep_) < blockStartBeat)
-            ++currentStep_;
-    }
-
-    double stepBeat = warpedStepBeat(currentStep_);
-
-    while (stepBeat < blockEndBeat) {
-        double frac = (stepBeat - blockStartBeat) / (blockEndBeat - blockStartBeat);
-        double timeInBlock = frac * blockDurationSecs;
-
-        // Note-off for previous note
-        if (lastPlayedNote_ >= 0) {
-            addTimedMessage(juce::MidiMessage::noteOff(1, lastPlayedNote_), timeInBlock,
-                            lastPlayedSourceId_);
-            lastPlayedNote_ = -1;
+    // --- 5. One stretch of the block over which the held notes do not change ---
+    const auto generate = [&](double segStartSecs, double segEndSecs) {
+        // Nothing to play: close what is sounding and idle the clock.
+        if (heldCount_ == 0 || (!context.isPlaying && physicallyHeldCount_ <= 0)) {
+            closeSoundingNote(segStartSecs);
+            freeRunSamples_ = 0.0;
+            lastBlockEndBeat_ = -1.0;
+            return;
         }
 
-        // Determine which note to play
-        int stepIdx;
-        if (pat == Pattern::Random) {
-            stepIdx = arpRandom_.nextInt(seq.length);
+        const double segDurationSecs = segEndSecs - segStartSecs;
+        if (segDurationSecs <= 0.0)
+            return;
+
+        double segStartBeat = 0.0;
+        double segEndBeat = 0.0;
+        if (onTransportClock) {
+            // Divided the way the output timestamps are computed below, so a
+            // beat and a time within the block are each other's inverse.
+            const double beats = blockEndBeat - blockStartBeat;
+            segStartBeat = blockStartBeat + (segStartSecs / blockDurationSecs) * beats;
+            segEndBeat = blockStartBeat + (segEndSecs / blockDurationSecs) * beats;
         } else {
-            stepIdx = currentStep_ % seq.length;
+            // Free-running clock — get tempo from timeline position 0
+            const double bpm =
+                context.tempoMap != nullptr ? context.tempoMap->bpmAtSeconds(0.0) : 120.0;
+            const double beatsPerSample = bpm / (60.0 * sampleRate_);
+            segStartBeat = freeRunSamples_ * beatsPerSample;
+            freeRunSamples_ += segDurationSecs * sampleRate_;
+            segEndBeat = freeRunSamples_ * beatsPerSample;
         }
 
-        auto& note = seq.notes[static_cast<size_t>(stepIdx)];
+        if (segEndBeat <= segStartBeat)
+            return;
 
-        // Determine velocity
-        int vel = note.velocity;
-        if (velMode == VelocityMode::Fixed) {
-            vel = fixedVel;
-        } else if (velMode == VelocityMode::Accent) {
-            vel = (currentStep_ % 4 == 0) ? juce::jmin(127, note.velocity + 30) : note.velocity;
+        // Seeks, loop wraps and the switch between the two clocks all arrive as
+        // a stretch that does not continue the last one. Only some of them
+        // reach the device as a panic and a loop wrap reaches it as nothing at
+        // all, so the timeline is what the walk trusts (#2416).
+        constexpr double kContiguousBeats = 1.0e-3;
+        if (lastBlockEndBeat_ < 0.0 ||
+            std::abs(segStartBeat - lastBlockEndBeat_) > kContiguousBeats) {
+            closeSoundingNote(segStartSecs);
+            currentStep_ = 0;
+            arpOriginBeat_ = -1.0;
         }
+        lastBlockEndBeat_ = segEndBeat;
 
-        // Note-on, carrying the provenance of whoever holds the pitch, so
-        // a device behind this one reads it the way this one does (#2416).
-        const std::uint32_t noteSource = note.liveHolds > 0 ? note.liveSourceId : note.hostSourceId;
-        addTimedMessage(
-            juce::MidiMessage::noteOn(1, note.noteNumber, static_cast<juce::uint8>(vel)),
-            timeInBlock, noteSource);
+        const auto seq = buildSequence();
+        if (seq.length == 0)
+            return;
 
-        lastPlayedNote_ = note.noteNumber;
-        lastPlayedSourceId_ = noteSource;
-        setMidiOutDisplay(note.noteNumber, vel);
+        // Cycle length in beats (one full pass through the sequence)
+        const double cycleBeats = seq.length * stepBeats;
 
-        // Schedule note-off
-        double noteOffBeat = stepBeat + stepBeats * static_cast<double>(gateVal);
-        if (noteOffBeat < blockEndBeat) {
-            double offFrac = (noteOffBeat - blockStartBeat) / (blockEndBeat - blockStartBeat);
-            addTimedMessage(juce::MidiMessage::noteOff(1, note.noteNumber),
-                            offFrac * blockDurationSecs, noteSource);
+        // Anchor on the grid at the point the pattern starts from, which is
+        // where the chord arrived rather than wherever its block began.
+        if (arpOriginBeat_ < 0.0)
+            arpOriginBeat_ = std::floor(segStartBeat / stepBeats) * stepBeats;
+
+        // Compute the beat position for a given global step index.
+        // With ramp, steps within each cycle are warped by the bezier curve.
+        // Without ramp, steps are evenly spaced at stepBeats intervals.
+        const auto computeStepBeat = [&](int step) -> double {
+            int cycle = step / seq.length;
+            int stepInCycle = step % seq.length;
+            double cycleStart = arpOriginBeat_ + cycle * cycleBeats;
+
+            if (std::abs(rampVal) > 0.001f && seq.length > 1) {
+                int cyc = juce::jlimit(1, 8, rampCycles.load(std::memory_order_relaxed));
+                double tLinear = static_cast<double>(stepInCycle) / static_cast<double>(seq.length);
+                double tCurved = ramp_curve::applyRampCurveWithCycles(tLinear, rampVal, skewVal,
+                                                                      cyc, hardAngleVal);
+                return cycleStart + tCurved * cycleBeats;
+            }
+            return cycleStart + stepInCycle * stepBeats;
+        };
+
+        // Where the step is actually played: swing on odd steps, then quantize
+        // pulling that toward a regular grid. Neither can carry a step past its
+        // neighbour, so the walk below keys on this instead of the raw grid and
+        // a step warped past the end of a stretch stays pending rather than
+        // being consumed unplayed (#2362).
+        const auto warpedStepBeat = [&](int step) -> double {
+            double beat = computeStepBeat(step);
+            // Half the gap to the next step, not half the nominal rate: Time
+            // Bend can compress two steps onto one beat, and a fixed offset
+            // would then swing the odd one past the even one that follows it.
+            if (step % 2 == 1 && swingVal > 0.0f)
+                beat += static_cast<double>(swingVal) * (computeStepBeat(step + 1) - beat) * 0.5;
+
+            if (quantizeAmount > 0.0f && quantizeSubVal > 0) {
+                const double gridSpacing = cycleBeats / static_cast<double>(quantizeSubVal);
+                const double snapped = std::round(beat / gridSpacing) * gridSpacing;
+                beat += (snapped - beat) * static_cast<double>(quantizeAmount);
+            }
+            return beat;
+        };
+
+        const auto timeOf = [&](double beat) {
+            const double frac = (beat - segStartBeat) / (segEndBeat - segStartBeat);
+            return segStartSecs + frac * segDurationSecs;
+        };
+
+        // --- Note-off a previous stretch scheduled into this one ---
+        if (lastPlayedNote_ >= 0 && lastNoteOffBeat_ >= 0.0 && lastNoteOffBeat_ < segEndBeat) {
+            addTimedMessage(juce::MidiMessage::noteOff(1, lastPlayedNote_),
+                            std::max(segStartSecs, timeOf(lastNoteOffBeat_)), lastPlayedSourceId_);
             lastPlayedNote_ = -1;
             lastNoteOffBeat_ = -1.0;
             clearMidiOutDisplay();
-        } else {
-            // Note-off in a future block
-            lastNoteOffBeat_ = noteOffBeat;
         }
 
-        ++currentStep_;
-        currentPlayStep_.store(currentStep_ % seq.length, std::memory_order_relaxed);
-        currentSeqLength_.store(seq.length, std::memory_order_relaxed);
-        stepBeat = warpedStepBeat(currentStep_);
+        // Catch up to the stretch. Cycles are evenly spaced whatever the warp
+        // does inside one, so the cycle is a division and only its steps are
+        // walked: bounded work, not one pass per skipped step.
+        if (warpedStepBeat(currentStep_) < segStartBeat) {
+            // Warp carries a step across the cycle boundary either way, so the
+            // division lands a cycle early and the walk closes the rest.
+            const int cycle =
+                static_cast<int>(std::floor((segStartBeat - arpOriginBeat_) / cycleBeats)) - 1;
+            currentStep_ = std::max(currentStep_, cycle * seq.length);
+            while (warpedStepBeat(currentStep_) < segStartBeat)
+                ++currentStep_;
+        }
+
+        // --- Walk steps and generate notes ---
+        for (;;) {
+            const double stepBeat = warpedStepBeat(currentStep_);
+            // Left where it is rather than consumed: a step the warp moved past
+            // this stretch is played by the stretch that holds it, so the same
+            // input plays the same notes however the host cuts its callbacks up
+            // (#2415).
+            if (stepBeat >= segEndBeat)
+                break;
+
+            // Never ahead of the stretch it is played in: the catch-up
+            // above leaves the walk on a step at or after the start, and a
+            // sequence rebuilt mid-block can only move one closer to it.
+            const double timeInBlock = std::max(segStartSecs, timeOf(stepBeat));
+
+            // Note-off for previous note
+            if (lastPlayedNote_ >= 0) {
+                addTimedMessage(juce::MidiMessage::noteOff(1, lastPlayedNote_), timeInBlock,
+                                lastPlayedSourceId_);
+                lastPlayedNote_ = -1;
+            }
+
+            // Determine which note to play
+            int stepIdx;
+            if (pat == Pattern::Random) {
+                stepIdx = arpRandom_.nextInt(seq.length);
+            } else {
+                stepIdx = currentStep_ % seq.length;
+            }
+
+            const auto& note = seq.notes[static_cast<size_t>(stepIdx)];
+
+            // Determine velocity
+            int vel = note.velocity;
+            if (velMode == VelocityMode::Fixed) {
+                vel = fixedVel;
+            } else if (velMode == VelocityMode::Accent) {
+                vel = (currentStep_ % 4 == 0) ? juce::jmin(127, note.velocity + 30) : note.velocity;
+            }
+
+            // Note-on, carrying the provenance of whoever holds the pitch, so
+            // a device behind this one reads it the way this one does (#2416).
+            const std::uint32_t noteSource =
+                note.liveHolds > 0 ? note.liveSourceId : note.hostSourceId;
+            addTimedMessage(
+                juce::MidiMessage::noteOn(1, note.noteNumber, static_cast<juce::uint8>(vel)),
+                timeInBlock, noteSource);
+
+            lastPlayedNote_ = note.noteNumber;
+            lastPlayedSourceId_ = noteSource;
+            setMidiOutDisplay(note.noteNumber, vel);
+
+            // Schedule note-off
+            const double noteOffBeat = stepBeat + stepBeats * static_cast<double>(gateVal);
+            if (noteOffBeat < segEndBeat) {
+                addTimedMessage(juce::MidiMessage::noteOff(1, note.noteNumber), timeOf(noteOffBeat),
+                                noteSource);
+                lastPlayedNote_ = -1;
+                lastNoteOffBeat_ = -1.0;
+                clearMidiOutDisplay();
+            } else {
+                // Note-off in a later stretch, or a later block
+                lastNoteOffBeat_ = noteOffBeat;
+            }
+            ++currentStep_;
+            currentPlayStep_.store(currentStep_ % seq.length, std::memory_order_relaxed);
+            currentSeqLength_.store(seq.length, std::memory_order_relaxed);
+        }
+    };
+
+    // --- 6. Walk the block, cut where the input changes what is held ---
+    const int incomingCount = in.size();
+    int nextEvent = 0;
+    double segmentStartSecs = 0.0;
+    for (;;) {
+        while (nextEvent < incomingCount) {
+            if (!changesPattern(in.message(nextEvent))) {
+                ++nextEvent;
+                continue;
+            }
+            if (eventTime(nextEvent) > segmentStartSecs)
+                break;
+            applyEvent(nextEvent, segmentStartSecs);
+            ++nextEvent;
+        }
+
+        const double segmentEndSecs =
+            nextEvent < incomingCount ? eventTime(nextEvent) : blockDurationSecs;
+        generate(segmentStartSecs, segmentEndSecs);
+
+        // Input stamped at or past the block end still changes what the next
+        // block holds; it just has no stretch of this one left to play in.
+        if (nextEvent >= incomingCount)
+            break;
+        segmentStartSecs = segmentEndSecs;
     }
+
+    // Re-asserted rather than left to whichever input event ran last: a chord
+    // arriving mid-block resets the walk, and the walk's reset clears this too.
+    wasPlaying_ = context.isPlaying;
 }
 
 }  // namespace magda::daw::audio

--- a/magda/daw/audio/plugins/ArpeggiatorPlugin.cpp
+++ b/magda/daw/audio/plugins/ArpeggiatorPlugin.cpp
@@ -493,6 +493,358 @@ ArpeggiatorPlugin::ExpandedSequence ArpeggiatorPlugin::buildSequence() const {
 // Audio thread
 // =============================================================================
 
+/**
+ * @brief What one process() call holds still.
+ *
+ * The parameters are read once, here: a block is one position for every slot,
+ * whatever the input does inside it. What changes inside a block is what the
+ * player holds, and that belongs to the stretches below.
+ */
+struct ArpeggiatorPlugin::BlockScope {
+    DeviceProcessContext& context;
+    const DeviceMidiInput& in;
+    DeviceMidiOutput& midi;
+    NonNoteForwarder forward;
+
+    double blockDurationSecs = 0.0;
+    bool isLatched = false;
+
+    /// The transport's clock, against the free-running one a stopped transport
+    /// leaves the arp on.
+    bool onTransportClock = false;
+    double blockStartBeat = 0.0;
+    double blockEndBeat = 0.0;
+
+    Pattern pattern = Pattern::Up;
+    double stepBeats = 0.5;
+    float gate = 1.0f;
+    float swing = 0.0f;
+    float ramp = 0.0f;
+    float skew = 0.0f;
+    VelocityMode velocityMode = VelocityMode::Original;
+    int fixedVelocity = 100;
+    float quantizeAmount = 0.0f;
+    int quantizeSubdivisions = 16;
+    bool hardAngleCurve = false;
+    int rampCycleCount = 1;
+
+    /**
+     * @brief Where in the block the host put an input event.
+     * @param index Index into the block's MIDI input.
+     * @return Seconds from the block start.
+     */
+    double eventTime(int index) const {
+        return forward.timeOf(index);
+    }
+
+    /**
+     * @brief Emits an event the arp generated, behind the non-note traffic that
+     *        precedes it.
+     * @param message The event; its timestamp is set from @p timeInBlock.
+     * @param timeInBlock Seconds from the block start.
+     * @param sourceId The provenance to stamp it with.
+     */
+    void addTimedMessage(juce::MidiMessage message, double timeInBlock, std::uint32_t sourceId) {
+        forward.flushUpTo(midi, timeInBlock);
+        message.setTimeStamp(timeInBlock);
+        midi.addEvent({std::move(message), sourceId});
+    }
+
+    /**
+     * @brief Emits a note-off, or nothing when @p noteNumber is negative.
+     * @param noteNumber The note to close, or -1 for none.
+     * @param timeInBlock Seconds from the block start.
+     * @param sourceId The provenance its note-on carried.
+     */
+    void emitNoteOff(int noteNumber, double timeInBlock, std::uint32_t sourceId) {
+        if (noteNumber < 0)
+            return;
+        forward.flushUpTo(midi, timeInBlock);
+        sendNoteOff(midi, noteNumber, sourceId, timeInBlock);
+    }
+};
+
+/**
+ * @brief One stretch of a block over which the held notes do not change.
+ *
+ * The block is cut where the input changes what is held (#2415) and each piece
+ * walks its own steps against its own span, so a step plays the chord that was
+ * down when it sounded.
+ */
+struct ArpeggiatorPlugin::Stretch {
+    const BlockScope& block;
+
+    double startSecs = 0.0;
+    double endSecs = 0.0;
+    double durationSecs = 0.0;
+    double startBeat = 0.0;
+    double endBeat = 0.0;
+
+    /// The grid the walk is anchored to, and the notes it steps through.
+    double originBeat = 0.0;
+    ExpandedSequence seq;
+    /// One full pass through the sequence.
+    double cycleBeats = 0.0;
+
+    /**
+     * @brief Where a beat inside this stretch lands in the block.
+     * @param beat A beat between startBeat and endBeat.
+     * @return Seconds from the block start.
+     */
+    double timeOf(double beat) const {
+        return startSecs + (beat - startBeat) / (endBeat - startBeat) * durationSecs;
+    }
+
+    /**
+     * @brief The grid position of a step, warped by the ramp curve inside its
+     *        cycle. Without ramp, steps are evenly spaced.
+     * @param step Global step index.
+     * @return The beat the step sits on before swing and quantize.
+     */
+    double gridBeat(int step) const {
+        const int cycle = step / seq.length;
+        const int stepInCycle = step % seq.length;
+        const double cycleStart = originBeat + cycle * cycleBeats;
+
+        if (std::abs(block.ramp) > 0.001f && seq.length > 1) {
+            const double tLinear =
+                static_cast<double>(stepInCycle) / static_cast<double>(seq.length);
+            const double tCurved = ramp_curve::applyRampCurveWithCycles(
+                tLinear, block.ramp, block.skew, block.rampCycleCount, block.hardAngleCurve);
+            return cycleStart + tCurved * cycleBeats;
+        }
+        return cycleStart + stepInCycle * block.stepBeats;
+    }
+
+    /**
+     * @brief Where the step is actually played: swing on odd steps, then
+     *        quantize pulling that toward a regular grid.
+     *
+     * Neither can carry a step past its neighbour, so the walk keys on this
+     * instead of the raw grid and a step warped past the end of a stretch stays
+     * pending rather than being consumed unplayed (#2362).
+     *
+     * @param step Global step index.
+     * @return The beat the step is played on.
+     */
+    double warpedStepBeat(int step) const {
+        double beat = gridBeat(step);
+        // Half the gap to the next step, not half the nominal rate: Time Bend
+        // can compress two steps onto one beat, and a fixed offset would then
+        // swing the odd one past the even one that follows it.
+        if (step % 2 == 1 && block.swing > 0.0f)
+            beat += static_cast<double>(block.swing) * (gridBeat(step + 1) - beat) * 0.5;
+
+        if (block.quantizeAmount > 0.0f && block.quantizeSubdivisions > 0) {
+            const double gridSpacing = cycleBeats / static_cast<double>(block.quantizeSubdivisions);
+            const double snapped = std::round(beat / gridSpacing) * gridSpacing;
+            beat += (snapped - beat) * static_cast<double>(block.quantizeAmount);
+        }
+        return beat;
+    }
+};
+
+void ArpeggiatorPlugin::closeSoundingNote(BlockScope& block, double timeInBlock) {
+    const std::uint32_t source = lastPlayedSourceId_;
+    block.emitNoteOff(takeSoundingNote(), timeInBlock, source);
+}
+
+void ArpeggiatorPlugin::restartAt(BlockScope& block, double timeInBlock) {
+    const std::uint32_t source = lastPlayedSourceId_;
+    block.emitNoteOff(resetArpState(), timeInBlock, source);
+    freeRunSamples_ = 0.0;
+}
+
+void ArpeggiatorPlugin::applyInputEvent(BlockScope& block, int index, double timeInBlock) {
+    const auto& msg = block.in.message(index);
+    const auto sourceId = block.in.sourceId(index);
+    const bool fromLiveSource = isLiveSource(block.context, sourceId);
+
+    if (msg.isNoteOn()) {
+        ++physicallyHeldCount_;
+
+        // Latch: if old set is stale (all keys were released), clear before adding
+        if (block.isLatched && latchedSetStale_) {
+            heldCount_ = 0;
+            nextOrder_ = 0;
+            latchedSetStale_ = false;
+        }
+
+        const bool wasEmpty = (heldCount_ == 0);
+        addHeldNote(msg.getNoteNumber(), msg.getVelocity(), fromLiveSource, sourceId);
+        if (wasEmpty && heldCount_ > 0)
+            restartAt(block, timeInBlock);
+    } else if (msg.isNoteOff()) {
+        --physicallyHeldCount_;
+        if (physicallyHeldCount_ < 0)
+            physicallyHeldCount_ = 0;
+
+        // Latch keeps the note in the pattern and only marks the set stale once
+        // every key is up.
+        releaseHeldNote(msg.getNoteNumber(), fromLiveSource, !block.isLatched);
+        if (block.isLatched && physicallyHeldCount_ == 0)
+            latchedSetStale_ = true;
+    } else if (msg.isAllNotesOff() || msg.isAllSoundOff()) {
+        clearHeldNotes();
+        restartAt(block, timeInBlock);
+    }
+}
+
+void ArpeggiatorPlugin::walkSteps(BlockScope& block, const Stretch& stretch) {
+    // Catch up to the stretch. Cycles are evenly spaced whatever the warp does
+    // inside one, so the cycle is a division and only its steps are walked:
+    // bounded work, not one pass per skipped step.
+    if (stretch.warpedStepBeat(currentStep_) < stretch.startBeat) {
+        // Warp carries a step across the cycle boundary either way, so the
+        // division lands a cycle early and the walk closes the rest.
+        const int cycle = static_cast<int>(std::floor((stretch.startBeat - stretch.originBeat) /
+                                                      stretch.cycleBeats)) -
+                          1;
+        currentStep_ = std::max(currentStep_, cycle * stretch.seq.length);
+        while (stretch.warpedStepBeat(currentStep_) < stretch.startBeat)
+            ++currentStep_;
+    }
+
+    for (;;) {
+        const double stepBeat = stretch.warpedStepBeat(currentStep_);
+        // Left where it is rather than consumed: a step the warp moved past this
+        // stretch is played by the stretch that holds it, so the same input
+        // plays the same notes however the host cuts its callbacks up (#2415).
+        if (stepBeat >= stretch.endBeat)
+            break;
+
+        // Never ahead of the stretch it is played in: the catch-up above leaves
+        // the walk on a step at or after the start, and a sequence rebuilt
+        // mid-block can only move one closer to it.
+        const double timeInBlock = std::max(stretch.startSecs, stretch.timeOf(stepBeat));
+
+        // Note-off for previous note
+        if (lastPlayedNote_ >= 0) {
+            block.addTimedMessage(juce::MidiMessage::noteOff(1, lastPlayedNote_), timeInBlock,
+                                  lastPlayedSourceId_);
+            lastPlayedNote_ = -1;
+        }
+
+        // Determine which note to play
+        int stepIdx;
+        if (block.pattern == Pattern::Random) {
+            stepIdx = arpRandom_.nextInt(stretch.seq.length);
+        } else {
+            stepIdx = currentStep_ % stretch.seq.length;
+        }
+
+        const auto& note = stretch.seq.notes[static_cast<size_t>(stepIdx)];
+
+        // Determine velocity
+        int vel = note.velocity;
+        if (block.velocityMode == VelocityMode::Fixed) {
+            vel = block.fixedVelocity;
+        } else if (block.velocityMode == VelocityMode::Accent) {
+            vel = (currentStep_ % 4 == 0) ? juce::jmin(127, note.velocity + 30) : note.velocity;
+        }
+
+        // Note-on, carrying the provenance of whoever holds the pitch, so a
+        // device behind this one reads it the way this one does (#2416).
+        const std::uint32_t noteSource = note.liveHolds > 0 ? note.liveSourceId : note.hostSourceId;
+        block.addTimedMessage(
+            juce::MidiMessage::noteOn(1, note.noteNumber, static_cast<juce::uint8>(vel)),
+            timeInBlock, noteSource);
+
+        lastPlayedNote_ = note.noteNumber;
+        lastPlayedSourceId_ = noteSource;
+        setMidiOutDisplay(note.noteNumber, vel);
+
+        // Schedule note-off
+        const double noteOffBeat = stepBeat + block.stepBeats * static_cast<double>(block.gate);
+        if (noteOffBeat < stretch.endBeat) {
+            block.addTimedMessage(juce::MidiMessage::noteOff(1, note.noteNumber),
+                                  stretch.timeOf(noteOffBeat), noteSource);
+            lastPlayedNote_ = -1;
+            lastNoteOffBeat_ = -1.0;
+            clearMidiOutDisplay();
+        } else {
+            // Note-off in a later stretch, or a later block
+            lastNoteOffBeat_ = noteOffBeat;
+        }
+
+        ++currentStep_;
+        currentPlayStep_.store(currentStep_ % stretch.seq.length, std::memory_order_relaxed);
+        currentSeqLength_.store(stretch.seq.length, std::memory_order_relaxed);
+    }
+}
+
+void ArpeggiatorPlugin::playStretch(BlockScope& block, double startSecs, double endSecs) {
+    // Nothing to play: close what is sounding and idle the clock.
+    if (heldCount_ == 0 || (!block.context.isPlaying && physicallyHeldCount_ <= 0)) {
+        closeSoundingNote(block, startSecs);
+        freeRunSamples_ = 0.0;
+        lastBlockEndBeat_ = -1.0;
+        return;
+    }
+
+    Stretch stretch{.block = block};
+    stretch.startSecs = startSecs;
+    stretch.endSecs = endSecs;
+    stretch.durationSecs = endSecs - startSecs;
+    if (stretch.durationSecs <= 0.0)
+        return;
+
+    if (block.onTransportClock) {
+        // The block's span, divided the way the output timestamps are computed:
+        // a beat and a time within the block are each other's inverse.
+        const double beats = block.blockEndBeat - block.blockStartBeat;
+        stretch.startBeat = block.blockStartBeat + (startSecs / block.blockDurationSecs) * beats;
+        stretch.endBeat = block.blockStartBeat + (endSecs / block.blockDurationSecs) * beats;
+    } else {
+        // Free-running clock — get tempo from timeline position 0
+        const double bpm =
+            block.context.tempoMap != nullptr ? block.context.tempoMap->bpmAtSeconds(0.0) : 120.0;
+        const double beatsPerSample = bpm / (60.0 * sampleRate_);
+        stretch.startBeat = freeRunSamples_ * beatsPerSample;
+        freeRunSamples_ += stretch.durationSecs * sampleRate_;
+        stretch.endBeat = freeRunSamples_ * beatsPerSample;
+    }
+
+    if (stretch.endBeat <= stretch.startBeat)
+        return;
+
+    // Seeks, loop wraps and the switch between the two clocks all arrive as a
+    // stretch that does not continue the last one. Only some of them reach the
+    // device as a panic and a loop wrap reaches it as nothing at all, so the
+    // timeline is what the walk trusts (#2416).
+    constexpr double kContiguousBeats = 1.0e-3;
+    if (lastBlockEndBeat_ < 0.0 ||
+        std::abs(stretch.startBeat - lastBlockEndBeat_) > kContiguousBeats) {
+        closeSoundingNote(block, startSecs);
+        currentStep_ = 0;
+        arpOriginBeat_ = -1.0;
+    }
+    lastBlockEndBeat_ = stretch.endBeat;
+
+    stretch.seq = buildSequence();
+    if (stretch.seq.length == 0)
+        return;
+    stretch.cycleBeats = stretch.seq.length * block.stepBeats;
+
+    // Anchor on the grid at the point the pattern starts from, which is where
+    // the chord arrived rather than wherever its block began.
+    if (arpOriginBeat_ < 0.0)
+        arpOriginBeat_ = std::floor(stretch.startBeat / block.stepBeats) * block.stepBeats;
+    stretch.originBeat = arpOriginBeat_;
+
+    // The note-off an earlier stretch scheduled into this one.
+    if (lastPlayedNote_ >= 0 && lastNoteOffBeat_ >= 0.0 && lastNoteOffBeat_ < stretch.endBeat) {
+        block.addTimedMessage(juce::MidiMessage::noteOff(1, lastPlayedNote_),
+                              std::max(startSecs, stretch.timeOf(lastNoteOffBeat_)),
+                              lastPlayedSourceId_);
+        lastPlayedNote_ = -1;
+        lastNoteOffBeat_ = -1.0;
+        clearMidiOutDisplay();
+    }
+
+    walkSteps(block, stretch);
+}
+
 void ArpeggiatorPlugin::process(DeviceProcessContext& context) {
     if (context.midiIn == nullptr || context.midiOut == nullptr || context.numSamples <= 0)
         return;
@@ -502,38 +854,40 @@ void ArpeggiatorPlugin::process(DeviceProcessContext& context) {
     displayedRamp_.store(displayValue(kRamp), std::memory_order_relaxed);
     displayedSkew_.store(displayValue(kSkew), std::memory_order_relaxed);
 
-    const auto& in = *context.midiIn;
-    auto& midi = *context.midiOut;
-    const bool isLatched = displayValue(kLatch) >= 0.5f;
     const double blockDurationSecs = static_cast<double>(context.numSamples) / sampleRate_;
+    const bool onTransportClock = context.isPlaying && context.tempoMap != nullptr;
+
+    BlockScope block{
+        .context = context,
+        .in = *context.midiIn,
+        .midi = *context.midiOut,
+        .forward =
+            NonNoteForwarder(*context.midiIn, context.midiTimeOffsetSeconds, blockDurationSecs),
+        .blockDurationSecs = blockDurationSecs,
+        .isLatched = displayValue(kLatch) >= 0.5f,
+        .onTransportClock = onTransportClock,
+        .blockStartBeat =
+            onTransportClock ? context.tempoMap->beatsAtSeconds(context.timelineStartSeconds) : 0.0,
+        .blockEndBeat =
+            onTransportClock ? context.tempoMap->beatsAtSeconds(context.timelineEndSeconds) : 0.0,
+        .pattern = static_cast<Pattern>(displayIndex(kPattern)),
+        .stepBeats = rateToBeats(static_cast<Rate>(displayIndex(kRate))),
+        .gate = juce::jlimit(0.01f, 1.0f, displayValue(kGate)),
+        .swing = juce::jlimit(0.0f, 1.0f, displayValue(kSwing)),
+        .ramp = juce::jlimit(-1.0f, 1.0f, displayValue(kRamp)),
+        .skew = juce::jlimit(-1.0f, 1.0f, displayValue(kSkew)),
+        .velocityMode = static_cast<VelocityMode>(displayIndex(kVelMode)),
+        .fixedVelocity = juce::jlimit(1, 127, displayIndex(kFixedVel)),
+        .quantizeAmount = juce::jlimit(0.0f, 1.0f, quantize.load(std::memory_order_relaxed)),
+        .quantizeSubdivisions = juce::jlimit(16, 512, quantizeSub.load(std::memory_order_relaxed)),
+        .hardAngleCurve = hardAngle.load(std::memory_order_relaxed),
+        .rampCycleCount = juce::jlimit(1, 8, rampCycles.load(std::memory_order_relaxed)),
+    };
 
     // What the arp passes on rather than consumes, emitted beside the notes it
     // generates. The guard covers the returns below: a block the arp leaves
     // early is still a block the instrument behind it is owed its pedal on.
-    NonNoteForwarder forward(in, context.midiTimeOffsetSeconds, blockDurationSecs);
-    const juce::ScopeGuard forwardRest{[&] { forward.flushRest(midi); }};
-
-    const auto addTimedMessage = [&](juce::MidiMessage message, double timeInBlock,
-                                     std::uint32_t sourceId) {
-        forward.flushUpTo(midi, timeInBlock);
-        message.setTimeStamp(timeInBlock);
-        midi.addEvent({std::move(message), sourceId});
-    };
-
-    // A note-off at its own instant in the block, behind the non-note traffic
-    // that precedes it (#2415).
-    const auto emitNoteOff = [&](int noteNumber, double timeInBlock, std::uint32_t source) {
-        if (noteNumber < 0)
-            return;
-        forward.flushUpTo(midi, timeInBlock);
-        sendNoteOff(midi, noteNumber, source, timeInBlock);
-    };
-
-    // Closes the note the arp is sounding, wherever it is being closed.
-    const auto closeSoundingNote = [&](double timeInBlock) {
-        const std::uint32_t source = lastPlayedSourceId_;
-        emitNoteOff(takeSoundingNote(), timeInBlock, source);
-    };
+    const juce::ScopeGuard forwardRest{[&] { block.forward.flushRest(block.midi); }};
 
     // --- 1. The buffer's panic, which the host raises for the block ---
     // Hosts raise this without a CC event, on a playhead jump or a track they
@@ -541,321 +895,60 @@ void ArpeggiatorPlugin::process(DeviceProcessContext& context) {
     // position without a note-off for what should not. So the host's notes go
     // and come back on the same buffer, while keys proven to be a player's are
     // not the host's to withdraw (#2416).
-    const bool inputPanic = in.isAllNotesOff();
-    midi.setAllNotesOff(inputPanic);
+    const bool inputPanic = block.in.isAllNotesOff();
+    block.midi.setAllNotesOff(inputPanic);
     if (inputPanic) {
-        closeSoundingNote(0.0);
+        closeSoundingNote(block, 0.0);
         retainLiveHeldNotes();
     }
 
     // --- 2. Transport transitions ---
     if (context.isPlaying && !wasPlaying_) {
-        // The transport and the free-running clock are different clocks, so
-        // the walk re-anchors below instead of carrying its step across.
+        // The transport and the free-running clock are different clocks, so the
+        // walk re-anchors below instead of carrying its step across.
         lastBlockEndBeat_ = -1.0;
     } else if (!context.isPlaying && wasPlaying_) {
         // Keys under the player's fingers keep the arp free-running; notes a
-        // clip left behind are dropped, because their note-off is never
-        // coming once the transport stops (#2416).
-        closeSoundingNote(0.0);
+        // clip left behind are dropped, because their note-off is never coming
+        // once the transport stops (#2416).
+        closeSoundingNote(block, 0.0);
         retainLiveHeldNotes();
         resetArpState();
         freeRunSamples_ = 0.0;
     }
 
-    // --- 3. Where the input sits in the block ---
-    const auto eventTime = [&](int index) { return forward.timeOf(index); };
-
-    // The pattern's material changes here, so the block is cut here.
-    const auto changesPattern = [](const juce::MidiMessage& message) {
-        return message.isNoteOnOrOff() || message.isAllNotesOff() || message.isAllSoundOff();
-    };
-
-    // Everything the arp was doing, dropped where the input dropped it: the
-    // note it sounds, its walk, and the clock the walk runs on.
-    const auto restartAt = [&](double timeInBlock) {
-        const std::uint32_t source = lastPlayedSourceId_;
-        emitNoteOff(resetArpState(), timeInBlock, source);
-        freeRunSamples_ = 0.0;
-    };
-
-    const auto applyEvent = [&](int index, double timeInBlock) {
-        const auto& msg = in.message(index);
-        const auto sourceId = in.sourceId(index);
-        const bool fromLiveSource = isLiveSource(context, sourceId);
-
-        if (msg.isNoteOn()) {
-            ++physicallyHeldCount_;
-
-            // Latch: if old set is stale (all keys were released), clear before adding
-            if (isLatched && latchedSetStale_) {
-                heldCount_ = 0;
-                nextOrder_ = 0;
-                latchedSetStale_ = false;
-            }
-
-            const bool wasEmpty = (heldCount_ == 0);
-            addHeldNote(msg.getNoteNumber(), msg.getVelocity(), fromLiveSource, sourceId);
-            if (wasEmpty && heldCount_ > 0)
-                restartAt(timeInBlock);
-        } else if (msg.isNoteOff()) {
-            --physicallyHeldCount_;
-            if (physicallyHeldCount_ < 0)
-                physicallyHeldCount_ = 0;
-
-            // Latch keeps the note in the pattern and only marks the set
-            // stale once every key is up.
-            releaseHeldNote(msg.getNoteNumber(), fromLiveSource, !isLatched);
-            if (isLatched && physicallyHeldCount_ == 0)
-                latchedSetStale_ = true;
-        } else if (msg.isAllNotesOff() || msg.isAllSoundOff()) {
-            clearHeldNotes();
-            restartAt(timeInBlock);
-        }
-    };
-
-    // --- 4. Settings the walk reads, fixed for the block ---
-    const auto pat = static_cast<Pattern>(displayIndex(kPattern));
-    const double stepBeats = rateToBeats(static_cast<Rate>(displayIndex(kRate)));
-    const float gateVal = juce::jlimit(0.01f, 1.0f, displayValue(kGate));
-    const float swingVal = juce::jlimit(0.0f, 1.0f, displayValue(kSwing));
-    const float rampVal = juce::jlimit(-1.0f, 1.0f, displayValue(kRamp));
-    const float skewVal = juce::jlimit(-1.0f, 1.0f, displayValue(kSkew));
-    const auto velMode = static_cast<VelocityMode>(displayIndex(kVelMode));
-    const int fixedVel = juce::jlimit(1, 127, displayIndex(kFixedVel));
-    const float quantizeAmount = juce::jlimit(0.0f, 1.0f, quantize.load(std::memory_order_relaxed));
-    const int quantizeSubVal = juce::jlimit(16, 512, quantizeSub.load(std::memory_order_relaxed));
-    const bool hardAngleVal = hardAngle.load(std::memory_order_relaxed);
-
-    // The block's beat span on the transport clock, which every segment
-    // divides. The free-running clock counts samples and is read per segment.
-    const bool onTransportClock = context.isPlaying && context.tempoMap != nullptr;
-    const double blockStartBeat =
-        onTransportClock ? context.tempoMap->beatsAtSeconds(context.timelineStartSeconds) : 0.0;
-    const double blockEndBeat =
-        onTransportClock ? context.tempoMap->beatsAtSeconds(context.timelineEndSeconds) : 0.0;
-
-    // --- 5. One stretch of the block over which the held notes do not change ---
-    const auto generate = [&](double segStartSecs, double segEndSecs) {
-        // Nothing to play: close what is sounding and idle the clock.
-        if (heldCount_ == 0 || (!context.isPlaying && physicallyHeldCount_ <= 0)) {
-            closeSoundingNote(segStartSecs);
-            freeRunSamples_ = 0.0;
-            lastBlockEndBeat_ = -1.0;
-            return;
-        }
-
-        const double segDurationSecs = segEndSecs - segStartSecs;
-        if (segDurationSecs <= 0.0)
-            return;
-
-        double segStartBeat = 0.0;
-        double segEndBeat = 0.0;
-        if (onTransportClock) {
-            // Divided the way the output timestamps are computed below, so a
-            // beat and a time within the block are each other's inverse.
-            const double beats = blockEndBeat - blockStartBeat;
-            segStartBeat = blockStartBeat + (segStartSecs / blockDurationSecs) * beats;
-            segEndBeat = blockStartBeat + (segEndSecs / blockDurationSecs) * beats;
-        } else {
-            // Free-running clock — get tempo from timeline position 0
-            const double bpm =
-                context.tempoMap != nullptr ? context.tempoMap->bpmAtSeconds(0.0) : 120.0;
-            const double beatsPerSample = bpm / (60.0 * sampleRate_);
-            segStartBeat = freeRunSamples_ * beatsPerSample;
-            freeRunSamples_ += segDurationSecs * sampleRate_;
-            segEndBeat = freeRunSamples_ * beatsPerSample;
-        }
-
-        if (segEndBeat <= segStartBeat)
-            return;
-
-        // Seeks, loop wraps and the switch between the two clocks all arrive as
-        // a stretch that does not continue the last one. Only some of them
-        // reach the device as a panic and a loop wrap reaches it as nothing at
-        // all, so the timeline is what the walk trusts (#2416).
-        constexpr double kContiguousBeats = 1.0e-3;
-        if (lastBlockEndBeat_ < 0.0 ||
-            std::abs(segStartBeat - lastBlockEndBeat_) > kContiguousBeats) {
-            closeSoundingNote(segStartSecs);
-            currentStep_ = 0;
-            arpOriginBeat_ = -1.0;
-        }
-        lastBlockEndBeat_ = segEndBeat;
-
-        const auto seq = buildSequence();
-        if (seq.length == 0)
-            return;
-
-        // Cycle length in beats (one full pass through the sequence)
-        const double cycleBeats = seq.length * stepBeats;
-
-        // Anchor on the grid at the point the pattern starts from, which is
-        // where the chord arrived rather than wherever its block began.
-        if (arpOriginBeat_ < 0.0)
-            arpOriginBeat_ = std::floor(segStartBeat / stepBeats) * stepBeats;
-
-        // Compute the beat position for a given global step index.
-        // With ramp, steps within each cycle are warped by the bezier curve.
-        // Without ramp, steps are evenly spaced at stepBeats intervals.
-        const auto computeStepBeat = [&](int step) -> double {
-            int cycle = step / seq.length;
-            int stepInCycle = step % seq.length;
-            double cycleStart = arpOriginBeat_ + cycle * cycleBeats;
-
-            if (std::abs(rampVal) > 0.001f && seq.length > 1) {
-                int cyc = juce::jlimit(1, 8, rampCycles.load(std::memory_order_relaxed));
-                double tLinear = static_cast<double>(stepInCycle) / static_cast<double>(seq.length);
-                double tCurved = ramp_curve::applyRampCurveWithCycles(tLinear, rampVal, skewVal,
-                                                                      cyc, hardAngleVal);
-                return cycleStart + tCurved * cycleBeats;
-            }
-            return cycleStart + stepInCycle * stepBeats;
-        };
-
-        // Where the step is actually played: swing on odd steps, then quantize
-        // pulling that toward a regular grid. Neither can carry a step past its
-        // neighbour, so the walk below keys on this instead of the raw grid and
-        // a step warped past the end of a stretch stays pending rather than
-        // being consumed unplayed (#2362).
-        const auto warpedStepBeat = [&](int step) -> double {
-            double beat = computeStepBeat(step);
-            // Half the gap to the next step, not half the nominal rate: Time
-            // Bend can compress two steps onto one beat, and a fixed offset
-            // would then swing the odd one past the even one that follows it.
-            if (step % 2 == 1 && swingVal > 0.0f)
-                beat += static_cast<double>(swingVal) * (computeStepBeat(step + 1) - beat) * 0.5;
-
-            if (quantizeAmount > 0.0f && quantizeSubVal > 0) {
-                const double gridSpacing = cycleBeats / static_cast<double>(quantizeSubVal);
-                const double snapped = std::round(beat / gridSpacing) * gridSpacing;
-                beat += (snapped - beat) * static_cast<double>(quantizeAmount);
-            }
-            return beat;
-        };
-
-        const auto timeOf = [&](double beat) {
-            const double frac = (beat - segStartBeat) / (segEndBeat - segStartBeat);
-            return segStartSecs + frac * segDurationSecs;
-        };
-
-        // --- Note-off a previous stretch scheduled into this one ---
-        if (lastPlayedNote_ >= 0 && lastNoteOffBeat_ >= 0.0 && lastNoteOffBeat_ < segEndBeat) {
-            addTimedMessage(juce::MidiMessage::noteOff(1, lastPlayedNote_),
-                            std::max(segStartSecs, timeOf(lastNoteOffBeat_)), lastPlayedSourceId_);
-            lastPlayedNote_ = -1;
-            lastNoteOffBeat_ = -1.0;
-            clearMidiOutDisplay();
-        }
-
-        // Catch up to the stretch. Cycles are evenly spaced whatever the warp
-        // does inside one, so the cycle is a division and only its steps are
-        // walked: bounded work, not one pass per skipped step.
-        if (warpedStepBeat(currentStep_) < segStartBeat) {
-            // Warp carries a step across the cycle boundary either way, so the
-            // division lands a cycle early and the walk closes the rest.
-            const int cycle =
-                static_cast<int>(std::floor((segStartBeat - arpOriginBeat_) / cycleBeats)) - 1;
-            currentStep_ = std::max(currentStep_, cycle * seq.length);
-            while (warpedStepBeat(currentStep_) < segStartBeat)
-                ++currentStep_;
-        }
-
-        // --- Walk steps and generate notes ---
-        for (;;) {
-            const double stepBeat = warpedStepBeat(currentStep_);
-            // Left where it is rather than consumed: a step the warp moved past
-            // this stretch is played by the stretch that holds it, so the same
-            // input plays the same notes however the host cuts its callbacks up
-            // (#2415).
-            if (stepBeat >= segEndBeat)
-                break;
-
-            // Never ahead of the stretch it is played in: the catch-up
-            // above leaves the walk on a step at or after the start, and a
-            // sequence rebuilt mid-block can only move one closer to it.
-            const double timeInBlock = std::max(segStartSecs, timeOf(stepBeat));
-
-            // Note-off for previous note
-            if (lastPlayedNote_ >= 0) {
-                addTimedMessage(juce::MidiMessage::noteOff(1, lastPlayedNote_), timeInBlock,
-                                lastPlayedSourceId_);
-                lastPlayedNote_ = -1;
-            }
-
-            // Determine which note to play
-            int stepIdx;
-            if (pat == Pattern::Random) {
-                stepIdx = arpRandom_.nextInt(seq.length);
-            } else {
-                stepIdx = currentStep_ % seq.length;
-            }
-
-            const auto& note = seq.notes[static_cast<size_t>(stepIdx)];
-
-            // Determine velocity
-            int vel = note.velocity;
-            if (velMode == VelocityMode::Fixed) {
-                vel = fixedVel;
-            } else if (velMode == VelocityMode::Accent) {
-                vel = (currentStep_ % 4 == 0) ? juce::jmin(127, note.velocity + 30) : note.velocity;
-            }
-
-            // Note-on, carrying the provenance of whoever holds the pitch, so
-            // a device behind this one reads it the way this one does (#2416).
-            const std::uint32_t noteSource =
-                note.liveHolds > 0 ? note.liveSourceId : note.hostSourceId;
-            addTimedMessage(
-                juce::MidiMessage::noteOn(1, note.noteNumber, static_cast<juce::uint8>(vel)),
-                timeInBlock, noteSource);
-
-            lastPlayedNote_ = note.noteNumber;
-            lastPlayedSourceId_ = noteSource;
-            setMidiOutDisplay(note.noteNumber, vel);
-
-            // Schedule note-off
-            const double noteOffBeat = stepBeat + stepBeats * static_cast<double>(gateVal);
-            if (noteOffBeat < segEndBeat) {
-                addTimedMessage(juce::MidiMessage::noteOff(1, note.noteNumber), timeOf(noteOffBeat),
-                                noteSource);
-                lastPlayedNote_ = -1;
-                lastNoteOffBeat_ = -1.0;
-                clearMidiOutDisplay();
-            } else {
-                // Note-off in a later stretch, or a later block
-                lastNoteOffBeat_ = noteOffBeat;
-            }
-            ++currentStep_;
-            currentPlayStep_.store(currentStep_ % seq.length, std::memory_order_relaxed);
-            currentSeqLength_.store(seq.length, std::memory_order_relaxed);
-        }
-    };
-
-    // --- 6. Walk the block, cut where the input changes what is held ---
-    const int incomingCount = in.size();
+    // --- 3. The block, cut where the input changes what is held ---
+    // The pattern the arp plays from a given instant is the one its input had
+    // at that instant: a latch replacement or a panic nine tenths of the way
+    // through a block leaves the steps before it alone (#2415).
+    const int incomingCount = block.in.size();
     int nextEvent = 0;
-    double segmentStartSecs = 0.0;
+    double stretchStartSecs = 0.0;
     for (;;) {
+        // Everything the host stamped at this instant, before anything is
+        // played for it.
         while (nextEvent < incomingCount) {
-            if (!changesPattern(in.message(nextEvent))) {
-                ++nextEvent;
+            const auto& msg = block.in.message(nextEvent);
+            const bool changesPattern =
+                msg.isNoteOnOrOff() || msg.isAllNotesOff() || msg.isAllSoundOff();
+            if (!changesPattern) {
+                ++nextEvent;  // the forwarder carries it, in its own time
                 continue;
             }
-            if (eventTime(nextEvent) > segmentStartSecs)
+            if (block.eventTime(nextEvent) > stretchStartSecs)
                 break;
-            applyEvent(nextEvent, segmentStartSecs);
+            applyInputEvent(block, nextEvent, stretchStartSecs);
             ++nextEvent;
         }
 
-        const double segmentEndSecs =
-            nextEvent < incomingCount ? eventTime(nextEvent) : blockDurationSecs;
-        generate(segmentStartSecs, segmentEndSecs);
+        playStretch(block, stretchStartSecs,
+                    nextEvent < incomingCount ? block.eventTime(nextEvent) : blockDurationSecs);
 
         // Input stamped at or past the block end still changes what the next
         // block holds; it just has no stretch of this one left to play in.
         if (nextEvent >= incomingCount)
             break;
-        segmentStartSecs = segmentEndSecs;
+        stretchStartSecs = block.eventTime(nextEvent);
     }
 
     // Re-asserted rather than left to whichever input event ran last: a chord

--- a/magda/daw/audio/plugins/ArpeggiatorPlugin.hpp
+++ b/magda/daw/audio/plugins/ArpeggiatorPlugin.hpp
@@ -202,6 +202,33 @@ class ArpeggiatorPlugin : public MidiMagdaDevice {
     };
     ExpandedSequence buildSequence() const;
 
+    /// What one process() call holds still: where the block's MIDI goes, the
+    /// clock it runs on, and the settings the walk reads. Defined in the .cpp,
+    /// which is the only place a block exists.
+    struct BlockScope;
+
+    /// One stretch of a block over which the held notes do not change, and the
+    /// step positions that follow from them.
+    struct Stretch;
+
+    /// Applies one input event where the host put it: the pattern the arp plays
+    /// from an instant is the one its input had at that instant (#2415).
+    void applyInputEvent(BlockScope& block, int index, double timeInBlock);
+
+    /// Plays one stretch: its span on the clock, the sequence the notes held
+    /// through it make, and the steps that land inside it.
+    void playStretch(BlockScope& block, double startSecs, double endSecs);
+
+    /// Walks @p stretch's steps, emitting a note for each one it holds.
+    void walkSteps(BlockScope& block, const Stretch& stretch);
+
+    /// Closes the note the arp is sounding, at the instant that closed it.
+    void closeSoundingNote(BlockScope& block, double timeInBlock);
+
+    /// Everything the arp was doing, dropped where the input dropped it: the
+    /// note it sounds, its walk, and the clock the walk runs on.
+    void restartAt(BlockScope& block, double timeInBlock);
+
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(ArpeggiatorPlugin)
 };
 

--- a/magda/daw/audio/plugins/ArpeggiatorPlugin.hpp
+++ b/magda/daw/audio/plugins/ArpeggiatorPlugin.hpp
@@ -192,7 +192,6 @@ class ArpeggiatorPlugin : public MidiMagdaDevice {
     /// hold on the rest. What a clip left behind has no note-off coming once
     /// the transport stops, and none at all when a seek moves off it.
     void retainLiveHeldNotes();
-    void sendAllNotesOff(DeviceMidiOutput& midi);
     int takeSoundingNote();
     // Returns the note that the caller must release when resetting during processing.
     int resetArpState();

--- a/magda/daw/audio/plugins/MidiMagdaDevice.hpp
+++ b/magda/daw/audio/plugins/MidiMagdaDevice.hpp
@@ -35,10 +35,17 @@ class MidiMagdaDevice : public MagdaDevice {
 
     /** Send note-off for the given note (channel 1, like the retired base).
      *  The source is the one the note-on carried, so a device downstream reads
-     *  the pair as one note from one origin (#2416). */
-    static void sendNoteOff(DeviceMidiOutput& midi, int noteNumber, std::uint32_t sourceId = 0) {
-        if (noteNumber >= 0)
-            midi.addEvent({juce::MidiMessage::noteOff(1, noteNumber), sourceId});
+     *  the pair as one note from one origin (#2416). @p timeInBlock is seconds
+     *  from the block start, like every other timestamp the SDK carries: a note
+     *  closed by something that happened inside the block is closed there
+     *  rather than at its top (#2415). */
+    static void sendNoteOff(DeviceMidiOutput& midi, int noteNumber, std::uint32_t sourceId = 0,
+                            double timeInBlock = 0.0) {
+        if (noteNumber < 0)
+            return;
+        auto message = juce::MidiMessage::noteOff(1, noteNumber);
+        message.setTimeStamp(timeInBlock);
+        midi.addEvent({std::move(message), sourceId});
     }
 
     /** Clear the MIDI output note display (no note playing). */

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -72,6 +72,7 @@ set(TEST_SOURCES
     devices/test_device_parameter_pagination.cpp
     devices/test_mutable_clouds.cpp
     devices/test_mutable_rings_chord.cpp
+    devices/test_arpeggiator_event_time.cpp
     devices/test_arpeggiator_input.cpp
     devices/test_arpeggiator_passthru.cpp
     devices/test_arpeggiator_swing.cpp
@@ -644,6 +645,8 @@ target_sources(magda_juce_tests PRIVATE
     devices/test_convolution_device_juce.cpp
     # One device, one discontinuity, both adapters (#2418).
     devices/test_device_panic_flag_juce.cpp
+    # Where each adapter puts an input event, and the arp's answer to it (#2415).
+    devices/test_arpeggiator_event_time_juce.cpp
     # The traffic the same device passes on rather than consumes (#2417).
     devices/test_device_midi_passthru_juce.cpp
     devices/test_mutable_add_not_replace_juce.cpp

--- a/tests/devices/ArpeggiatorTestRig.hpp
+++ b/tests/devices/ArpeggiatorTestRig.hpp
@@ -2,7 +2,6 @@
 
 #include <catch2/catch_test_macros.hpp>
 #include <cstdint>
-#include <initializer_list>
 #include <vector>
 
 #include "TestDeviceMidiBuffer.hpp"
@@ -47,7 +46,7 @@ struct ArpRig {
 
     /// @p seconds is the block length: long enough to hold several arp steps
     /// when a case needs the output to interleave with something (#2417).
-    DeviceMidiBuffer run(double start, std::initializer_list<juce::MidiMessage> input = {},
+    DeviceMidiBuffer run(double start, const std::vector<juce::MidiMessage>& input = {},
                          bool playing = true, bool panic = false, double seconds = 0.05) {
         DeviceMidiBuffer in;
         in.allNotesOff = panic;
@@ -75,6 +74,13 @@ struct ArpRig {
         REQUIRE(midi.message(0).getNoteNumber() == 60);
     }
 };
+
+/// An input event where the host put it, in the units the SDK carries:
+/// seconds from the start of the block (#2415).
+inline juce::MidiMessage at(double timeInBlock, juce::MidiMessage message) {
+    message.setTimeStamp(timeInBlock);
+    return message;
+}
 
 inline void checkNoteOff(const DeviceMidiBuffer& midi, int index = 0, int noteNumber = 60) {
     REQUIRE(midi.size() > index);

--- a/tests/devices/ArpeggiatorTestRig.hpp
+++ b/tests/devices/ArpeggiatorTestRig.hpp
@@ -30,6 +30,9 @@ struct ArpRig {
     /// playback, so a test says which of the two this phrase is.
     std::uint32_t source = 42;
     std::vector<std::uint32_t> liveSourceIds;
+    /// What the host says the timestamps on its buffer are offset by, which is
+    /// how a sub-block reaches a device.
+    double midiTimeOffset = 0.0;
 
     explicit ArpRig(bool latch = false) {
         arp.prepare({.sampleRate = 48000.0, .maximumBlockSize = 2400});
@@ -61,6 +64,7 @@ struct ArpRig {
         context.timelineStartSeconds = start;
         context.timelineEndSeconds = start + seconds;
         context.isPlaying = playing;
+        context.midiTimeOffsetSeconds = midiTimeOffset;
         context.liveSourceIds = liveSourceIds.empty() ? nullptr : liveSourceIds.data();
         context.numLiveSourceIds = static_cast<int>(liveSourceIds.size());
         arp.process(context);

--- a/tests/devices/test_arpeggiator_event_time.cpp
+++ b/tests/devices/test_arpeggiator_event_time.cpp
@@ -231,6 +231,27 @@ TEST_CASE("Arpeggiator plays a step from the notes held when it sounds",
     CHECK(playedTheNewPitch);
 }
 
+TEST_CASE("Arpeggiator reads a host's sub-block offset once, for everything it emits",
+          "[arpeggiator][midi][event-time]") {
+    Rig rig;
+    rig.startNote();
+
+    // A host that hands the device a sub-block says where its buffer starts.
+    // The offset belongs to every time the arp reads, so the reset it forwards
+    // and the note-off it answers with land together rather than a sub-block
+    // apart.
+    rig.midiTimeOffset = 0.01;
+    const double offsetInBlock = rig.midiTimeOffset + 0.005;
+    auto midi = rig.run(kBlockSeconds, {at(0.005, juce::MidiMessage::allNotesOff(1))});
+
+    REQUIRE(midi.size() == 2);
+    CHECK(midi.message(0).isController());
+    CHECK(midi.message(0).getTimeStamp() == Catch::Approx(offsetInBlock));
+    CHECK(midi.message(1).isNoteOff());
+    CHECK(midi.message(1).getNoteNumber() == 60);
+    CHECK(midi.message(1).getTimeStamp() == Catch::Approx(offsetInBlock));
+}
+
 TEST_CASE("Arpeggiator plays the same phrase however the host cuts its callbacks",
           "[arpeggiator][midi][event-time]") {
     // Held, released and replaced at times that fall inside a block for one

--- a/tests/devices/test_arpeggiator_event_time.cpp
+++ b/tests/devices/test_arpeggiator_event_time.cpp
@@ -1,0 +1,269 @@
+#include <algorithm>
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <map>
+#include <vector>
+
+#include "devices/ArpeggiatorTestRig.hpp"
+
+// The arp reads its input where the host put it rather than all at the top of
+// the block (#2415), so a note is closed by the event that closed it and the
+// notes a step plays are the ones held when that step sounds.
+
+namespace {
+using magda::test::at;
+using magda::test::DeviceMidiBuffer;
+using Arp = magda::test::Arp;
+using Rig = magda::test::ArpRig;
+
+constexpr double kBlockSeconds = 0.05;
+/// Nine tenths of the way in: far enough that a block-start approximation
+/// cuts the note by most of a block.
+constexpr double kLateInBlock = 0.045;
+
+juce::MidiMessage on(int note, int velocity = 91) {
+    return juce::MidiMessage::noteOn(1, note, static_cast<juce::uint8>(velocity));
+}
+
+juce::MidiMessage off(int note) {
+    return juce::MidiMessage::noteOff(1, note);
+}
+
+/// One output event on the timeline the phrase was written on, so partitions
+/// that cut it into different blocks are comparable.
+struct TimedEvent {
+    double seconds = 0.0;
+    juce::MidiMessage message;
+};
+
+struct PhraseEvent {
+    double seconds = 0.0;
+    juce::MidiMessage message;
+};
+
+/// Runs @p phrase over [0, totalSeconds) with the block lengths cycled from
+/// @p blockLengths, and returns what the arp played on the phrase's own
+/// timeline.
+std::vector<TimedEvent> render(const std::vector<PhraseEvent>& phrase, double totalSeconds,
+                               const std::vector<double>& blockLengths) {
+    Rig rig;
+    std::vector<TimedEvent> played;
+    double blockStart = 0.0;
+    size_t nextEvent = 0;
+    size_t nextLength = 0;
+
+    while (blockStart < totalSeconds - 1.0e-12) {
+        const double length =
+            std::min(blockLengths[nextLength++ % blockLengths.size()], totalSeconds - blockStart);
+
+        std::vector<juce::MidiMessage> input;
+        while (nextEvent < phrase.size() && phrase[nextEvent].seconds < blockStart + length) {
+            input.push_back(at(phrase[nextEvent].seconds - blockStart, phrase[nextEvent].message));
+            ++nextEvent;
+        }
+
+        const auto midi = rig.run(blockStart, input, true, false, length);
+        for (int index = 0; index < midi.size(); ++index)
+            played.push_back(
+                {blockStart + midi.message(index).getTimeStamp(), midi.message(index)});
+
+        blockStart += length;
+    }
+
+    return played;
+}
+
+/// Every pitch alternates on, off, on: no voice left sounding, none started
+/// twice, and none cut by a note-off that arrives after its note-on.
+void checkNotesBalance(const std::vector<TimedEvent>& played) {
+    std::map<int, int> sounding;
+    for (const auto& event : played) {
+        const int note = event.message.getNoteNumber();
+        if (event.message.isNoteOn()) {
+            INFO("note " << note << " at " << event.seconds);
+            CHECK(sounding[note] == 0);
+            ++sounding[note];
+        } else if (event.message.isNoteOff()) {
+            INFO("note " << note << " at " << event.seconds);
+            CHECK(sounding[note] == 1);
+            --sounding[note];
+        }
+    }
+    for (const auto& [note, count] : sounding) {
+        INFO("note " << note);
+        CHECK(count == 0);
+    }
+}
+
+/// A rig whose output is kept on the timeline the blocks were run on.
+struct Recorder {
+    Rig rig;
+    std::vector<TimedEvent> played;
+
+    explicit Recorder(bool latch = false) : rig(latch) {}
+
+    void run(double start, const std::vector<juce::MidiMessage>& input = {},
+             double seconds = kBlockSeconds) {
+        const auto midi = rig.run(start, input, true, false, seconds);
+        for (int index = 0; index < midi.size(); ++index)
+            played.push_back({start + midi.message(index).getTimeStamp(), midi.message(index)});
+    }
+};
+
+std::string describe(const std::vector<TimedEvent>& played) {
+    juce::String text;
+    for (const auto& event : played)
+        text << juce::String(event.seconds, 6) << " " << event.message.getDescription() << "\n";
+    return text.toStdString();
+}
+
+}  // namespace
+
+TEST_CASE("Arpeggiator holds a latched note until the input that replaces it",
+          "[arpeggiator][midi][event-time]") {
+    Rig rig(true);
+    rig.startNote();
+
+    // The key comes up at the top of the block and the replacement lands nine
+    // tenths of the way through it. Both are the same buffer, and the note the
+    // replacement ends must last until the replacement.
+    auto midi = rig.run(kBlockSeconds, {off(60), at(kLateInBlock, on(67))});
+
+    REQUIRE(midi.size() == 1);
+    CHECK(midi.message(0).isNoteOff());
+    CHECK(midi.message(0).getNoteNumber() == 60);
+    CHECK(midi.message(0).getTimeStamp() == Catch::Approx(kLateInBlock));
+}
+
+TEST_CASE("Arpeggiator holds its note until the panic that stops it",
+          "[arpeggiator][midi][event-time]") {
+    for (int controller : {120, 123}) {
+        INFO("controller " << controller);
+        Rig rig;
+        rig.startNote();
+
+        auto midi =
+            rig.run(kBlockSeconds,
+                    {at(kLateInBlock, juce::MidiMessage::controllerEvent(1, controller, 0))});
+
+        // The reset travels on to whatever plays the notes (#2417), and the
+        // arp closes what it was sounding behind it, both where it happened.
+        REQUIRE(midi.size() == 2);
+        CHECK(midi.message(0).isController());
+        CHECK(midi.message(0).getTimeStamp() == Catch::Approx(kLateInBlock));
+        CHECK(midi.message(1).isNoteOff());
+        CHECK(midi.message(1).getNoteNumber() == 60);
+        CHECK(midi.message(1).getTimeStamp() == Catch::Approx(kLateInBlock));
+    }
+}
+
+TEST_CASE("Arpeggiator closes a replaced pitch before it plays it again",
+          "[arpeggiator][midi][event-time]") {
+    Recorder recorder(true);
+    recorder.rig.setRate(Arp::Rate::ThirtySecond);
+    recorder.run(0.0, {on(60)});
+
+    // The same pitch, released and pressed again inside one block: the voice
+    // it replaces has to be closed before the retrigger sounds, or the note-off
+    // it was owed arrives on top of the new note.
+    recorder.run(kBlockSeconds, {off(60), at(kLateInBlock, on(60))});
+    for (int block = 2; block < 8; ++block)
+        recorder.run(block * kBlockSeconds);
+    // Stopped rather than left mid-phrase, so the timeline balances.
+    recorder.run(8 * kBlockSeconds, {juce::MidiMessage::allNotesOff(1)});
+
+    INFO(describe(recorder.played));
+    checkNotesBalance(recorder.played);
+
+    const double replacedAt = kBlockSeconds + kLateInBlock;
+    const auto closed =
+        std::find_if(recorder.played.begin(), recorder.played.end(), [&](const TimedEvent& event) {
+            return event.message.isNoteOff() && event.seconds == Catch::Approx(replacedAt);
+        });
+    REQUIRE(closed != recorder.played.end());
+    CHECK(closed->message.getNoteNumber() == 60);
+
+    const auto retriggered =
+        std::find_if(closed, recorder.played.end(),
+                     [](const TimedEvent& event) { return event.message.isNoteOn(); });
+    REQUIRE(retriggered != recorder.played.end());
+    CHECK(retriggered->message.getNoteNumber() == 60);
+    CHECK(retriggered->seconds > replacedAt);
+}
+
+TEST_CASE("Arpeggiator answers every replacement in one block where it happened",
+          "[arpeggiator][midi][event-time]") {
+    Rig rig;
+    rig.startNote();
+
+    // Three chords in one buffer, each one ending the last.
+    auto midi = rig.run(kBlockSeconds,
+                        {at(0.01, off(60)), at(0.02, on(64)), at(0.03, off(64)), at(0.04, on(67))});
+
+    REQUIRE(midi.size() == 1);
+    CHECK(midi.message(0).isNoteOff());
+    CHECK(midi.message(0).getNoteNumber() == 60);
+    CHECK(midi.message(0).getTimeStamp() == Catch::Approx(0.01));
+}
+
+TEST_CASE("Arpeggiator plays a step from the notes held when it sounds",
+          "[arpeggiator][midi][event-time]") {
+    Rig rig;
+    rig.setRate(Arp::Rate::ThirtySecond);
+    rig.startNote();
+
+    // A second pitch arrives after this block's steps have already sounded, so
+    // it belongs to the steps that follow it and to none of the ones before.
+    const auto midi = rig.run(kBlockSeconds, {at(kLateInBlock, on(72))});
+    for (int index = 0; index < midi.size(); ++index) {
+        INFO("event " << index);
+        if (midi.message(index).isNoteOn() && midi.message(index).getTimeStamp() < kLateInBlock)
+            CHECK(midi.message(index).getNoteNumber() == 60);
+    }
+
+    bool playedTheNewPitch = false;
+    for (int block = 2; block < 10 && !playedTheNewPitch; ++block) {
+        const auto next = rig.run(block * kBlockSeconds);
+        for (int index = 0; index < next.size(); ++index)
+            playedTheNewPitch |=
+                next.message(index).isNoteOn() && next.message(index).getNoteNumber() == 72;
+    }
+    CHECK(playedTheNewPitch);
+}
+
+TEST_CASE("Arpeggiator plays the same phrase however the host cuts its callbacks",
+          "[arpeggiator][midi][event-time]") {
+    // Held, released and replaced at times that fall inside a block for one
+    // partition and on a boundary for another.
+    const std::vector<PhraseEvent> phrase{
+        {0.0, on(60)},   {0.0, on(64)},   {0.313, off(60)}, {0.313, off(64)},
+        {0.517, on(67)}, {0.911, on(71)}, {1.244, off(67)}, {1.244, off(71)},
+    };
+    constexpr double kTotalSeconds = 2.0;
+
+    const auto reference = render(phrase, kTotalSeconds, {0.05});
+    INFO(describe(reference));
+    CHECK_FALSE(reference.empty());
+    checkNotesBalance(reference);
+
+    const std::vector<std::vector<double>> partitions{
+        {64.0 / 48000.0},                              // small
+        {2048.0 / 48000.0},                            // large
+        {0.011, 0.0007, 0.043, 0.0031, 0.128, 0.019},  // irregular
+    };
+
+    for (const auto& blockLengths : partitions) {
+        const auto played = render(phrase, kTotalSeconds, blockLengths);
+        INFO("partition of " << blockLengths.size() << ", first block " << blockLengths.front());
+        INFO(describe(played));
+        checkNotesBalance(played);
+        REQUIRE(played.size() == reference.size());
+        for (size_t index = 0; index < played.size(); ++index) {
+            INFO("event " << index);
+            CHECK(played[index].seconds == Catch::Approx(reference[index].seconds).margin(1.0e-9));
+            CHECK(played[index].message.getNoteNumber() ==
+                  reference[index].message.getNoteNumber());
+            CHECK(played[index].message.isNoteOn() == reference[index].message.isNoteOn());
+        }
+    }
+}

--- a/tests/devices/test_arpeggiator_event_time_juce.cpp
+++ b/tests/devices/test_arpeggiator_event_time_juce.cpp
@@ -1,0 +1,160 @@
+#include <juce_core/juce_core.h>
+#include <tracktion_engine/tracktion_engine.h>
+
+#include <memory>
+#include <optional>
+
+#include "SharedTestEngine.hpp"
+#include "exec/EngineDevice.hpp"
+#include "exec/RenderContext.hpp"
+#include "magda/daw/audio/plugins/ArpeggiatorPlugin.hpp"
+#include "magda/daw/audio/plugins/engine/EngineMagdaDevice.hpp"
+#include "third_party/tracktion_engine/modules/tracktion_engine/utilities/tracktion_TestUtilities.h"
+
+// Input read at event time, through both adapters (#2415).
+//
+// The arp closes the note it is sounding when a panic reaches it. Where that
+// note-off lands is the question: at the top of the block, which is a whole
+// block early, or at the panic. The two hosts stamp their MIDI differently --
+// the fork carries seconds on its container, the engine's ports count samples
+// -- so the same phrase is driven through each and the answers compared.
+
+namespace {
+
+namespace audio = magda::daw::audio;
+namespace adapter = magda::daw::audio::engine_adapter;
+namespace te = tracktion::engine;
+
+constexpr double kSampleRate = 44100.0;
+constexpr int kBlockSize = 64;
+/// Nine tenths of the way into the second block.
+constexpr int kPanicSample = 57;
+
+juce::MidiMessage noteOn(int note) {
+    return juce::MidiMessage::noteOn(1, note, juce::uint8{100});
+}
+
+/// Where the arp put the note-off closing what it was sounding, in samples from
+/// the start of the block that carried the panic, or nothing if it sent none.
+std::optional<int> teLegNoteOffSample(te::Edit& edit) {
+    juce::ValueTree state(te::IDs::PLUGIN);
+    state.setProperty(te::IDs::type, audio::ArpeggiatorPlugin::xmlTypeName, nullptr);
+    auto plugin = edit.getPluginCache().createNewPlugin(state);
+    if (plugin == nullptr)
+        return {};
+
+    te::PluginInitialisationInfo initInfo;
+    initInfo.startTime = tracktion::TimePosition();
+    initInfo.sampleRate = kSampleRate;
+    initInfo.blockSizeSamples = kBlockSize;
+    plugin->baseClassInitialise(initInfo);
+
+    juce::AudioBuffer<float> buffer(2, kBlockSize);
+    const auto blockSeconds = kBlockSize / kSampleRate;
+
+    const auto runBlock = [&](int blockIndex, te::MidiMessageArray& midi) {
+        buffer.clear();
+        te::PluginRenderContext context(
+            &buffer, juce::AudioChannelSet::stereo(), 0, kBlockSize, &midi, 0.0,
+            tracktion::TimeRange(
+                tracktion::TimePosition::fromSeconds(blockIndex * blockSeconds),
+                tracktion::TimePosition::fromSeconds((blockIndex + 1) * blockSeconds)),
+            true, false, false, false);
+        plugin->applyToBuffer(context);
+    };
+
+    // A key, so the arp has something to sound.
+    te::MidiMessageArray held;
+    held.addMidiMessage(noteOn(60), 0.0, te::MPESourceID());
+    runBlock(0, held);
+
+    // The panic, nine tenths of the way through the block that follows.
+    te::MidiMessageArray panic;
+    panic.addMidiMessage(juce::MidiMessage::allNotesOff(1), kPanicSample / kSampleRate,
+                         te::MPESourceID());
+    runBlock(1, panic);
+
+    std::optional<int> found;
+    for (const auto& message : panic) {
+        if (message.isNoteOff())
+            found = juce::roundToInt(message.getTimeStamp() * kSampleRate);
+    }
+
+    plugin->deleteFromParent();
+    return found;
+}
+
+/// The same phrase through the engine's adapter, whose ports carry samples.
+std::optional<int> engineLegNoteOffSample() {
+    adapter::EngineMagdaDevice hosted(std::make_unique<audio::ArpeggiatorPlugin>(),
+                                      /*offlineRender=*/false);
+    hosted.prepare({.sampleRate = kSampleRate, .maxBlockSize = kBlockSize, .numChannels = 2});
+
+    juce::AudioBuffer<float> buffer(2, kBlockSize);
+    const auto blockSeconds = kBlockSize / kSampleRate;
+
+    const auto runBlock = [&](int blockIndex, juce::MidiBuffer& in, juce::MidiBuffer& out) {
+        buffer.clear();
+        magda::engine::DeviceBlock block;
+        block.audio = juce::dsp::AudioBlock<float>(buffer);
+        block.midiIn = &in;
+        block.midiOut = &out;
+        block.block.numSamples = kBlockSize;
+        block.block.sampleRate = kSampleRate;
+        block.block.playing = true;
+        block.block.seconds.start = blockIndex * blockSeconds;
+        block.block.seconds.end = (blockIndex + 1) * blockSeconds;
+        hosted.process(block);
+    };
+
+    juce::MidiBuffer held;
+    juce::MidiBuffer heldOut;
+    held.addEvent(noteOn(60), 0);
+    runBlock(0, held, heldOut);
+
+    juce::MidiBuffer panic;
+    juce::MidiBuffer panicOut;
+    panic.addEvent(juce::MidiMessage::allNotesOff(1), kPanicSample);
+    runBlock(1, panic, panicOut);
+
+    std::optional<int> found;
+    for (const auto metadata : panicOut) {
+        if (metadata.getMessage().isNoteOff())
+            found = metadata.samplePosition;
+    }
+    return found;
+}
+
+class ArpeggiatorEventTimeTest final : public juce::UnitTest {
+  public:
+    ArpeggiatorEventTimeTest() : juce::UnitTest("Arpeggiator Event Time", "magda") {}
+
+    void runTest() override {
+        beginTest("Engine setup");
+
+        auto& wrapper = magda::test::getSharedEngine();
+        auto edit = te::test_utilities::createTestEdit(*wrapper.getEngine(), 1);
+        expect(edit != nullptr);
+        if (edit == nullptr)
+            return;
+
+        beginTest("Both adapters close the note where the panic reached the device");
+
+        const auto teLeg = teLegNoteOffSample(*edit);
+        expect(teLeg.has_value(), "The fork's leg should close the sounding note");
+        expect(teLeg.value_or(-1) == kPanicSample,
+               "The fork's leg put the note-off at sample " + juce::String(teLeg.value_or(-1)) +
+                   " rather than at the panic's " + juce::String(kPanicSample));
+
+        const auto engineLeg = engineLegNoteOffSample();
+        expect(engineLeg.has_value(), "The engine's leg should close the sounding note");
+        expect(engineLeg.value_or(-1) == kPanicSample,
+               "The engine's leg put the note-off at sample " +
+                   juce::String(engineLeg.value_or(-1)) + " rather than at the panic's " +
+                   juce::String(kPanicSample));
+    }
+};
+
+ArpeggiatorEventTimeTest arpeggiatorEventTimeTest;
+
+}  // namespace

--- a/tests/devices/test_arpeggiator_passthru.cpp
+++ b/tests/devices/test_arpeggiator_passthru.cpp
@@ -11,13 +11,9 @@
 
 namespace {
 using magda::test::Arp;
+using magda::test::at;
 using magda::test::DeviceMidiBuffer;
 using Rig = magda::test::ArpRig;
-
-juce::MidiMessage at(juce::MidiMessage message, double timeStamp) {
-    message.setTimeStamp(timeStamp);
-    return message;
-}
 }  // namespace
 
 TEST_CASE("Arpeggiator forwards the non-note traffic its notes displace",
@@ -114,9 +110,9 @@ TEST_CASE("Arpeggiator merges forwarded traffic into its output in timestamp ord
     rig.setRate(Arp::Rate::Sixteenth);
     auto midi = rig.run(0.0,
                         {juce::MidiMessage::noteOn(1, 60, juce::uint8{91}),
-                         at(juce::MidiMessage::controllerEvent(1, 1, 20), 0.2),
-                         at(juce::MidiMessage::controllerEvent(1, 1, 30), 0.25),
-                         at(juce::MidiMessage::controllerEvent(1, 1, 40), 0.3)},
+                         at(0.2, juce::MidiMessage::controllerEvent(1, 1, 20)),
+                         at(0.25, juce::MidiMessage::controllerEvent(1, 1, 30)),
+                         at(0.3, juce::MidiMessage::controllerEvent(1, 1, 40))},
                         true, false, 0.5);
 
     REQUIRE(midi.size() > 6);
@@ -168,7 +164,7 @@ TEST_CASE("Arpeggiator passes a buffer panic on beside what it forwards",
     rig.liveSourceIds = {rig.source};
     rig.startNote();
 
-    auto midi = rig.run(0.05, {at(juce::MidiMessage::controllerEvent(1, 64, 127), 0.01)}, true,
+    auto midi = rig.run(0.05, {at(0.01, juce::MidiMessage::controllerEvent(1, 64, 127))}, true,
                         /*panic=*/true);
 
     CHECK(midi.allNotesOff);


### PR DESCRIPTION
Fixes #2415.

## The bug

`ArpeggiatorPlugin::process()` consumed the whole input buffer before generating anything, so every held-note change applied from the top of the block. Two consequences, both in the issue:

- A latch replacement or a CC120/123 nine tenths of the way through a block released the note it replaced at timestamp 0 — up to a full block early.
- The steps that had already sounded earlier in that block were built from the chord that arrived *after* them.

## The fix

`process()` cuts the block where the input changes what is held, and runs the beat walk over each stretch between those events. A note is closed by the event that closed it, at that event's own time; a stretch plays the chord held while it lasts; and the arp anchors its grid where the chord arrived rather than wherever the block containing it began.

Ordering at one instant is: the non-note traffic the arp forwards, then the note-off the input caused, then the stretch's own steps — so a controller moved before a note-off still reaches the instrument first, and an old voice is always closed before the note that replaces it sounds.

## Two things that follow from the cut

Both are acceptance criteria on the issue:

- **A step is placed by the beat it is played on, not by its grid position.** One whose swing or quantize offset carries it past the end of a stretch is left for the stretch that holds it, rather than consumed and dropped. Before this, a swung step landing past a block boundary was lost outright, and *which* steps were lost depended on the block size — so the same input played different notes at different buffer sizes.
- **The host's sub-block offset is added wherever an input timestamp is read**, the non-note forwarder included, rather than only in the arp's own scan.

`MidiMagdaDevice::sendNoteOff` now takes a time within the block (seconds from the block start, like every other timestamp the SDK carries).

## Tests

`tests/devices/test_arpeggiator_event_time.cpp` — late latch replacement, late panic (CC120 and CC123), same-pitch retrigger, several replacements in one block, a step playing what was held when it sounded, and one phrase rendered over small (64), large (2048) and irregular partitions agreeing event for event with no stuck or duplicate notes.

`tests/devices/test_arpeggiator_event_time_juce.cpp` — the same panic driven through **both host adapters**, since the two stamp their MIDI differently (the fork carries seconds on its container, the engine's ports count samples).

Verified negatively: with the fix reverted all seven fail, both legs putting the note-off at sample 0 rather than at the panic's 57. The 27 existing arpeggiator cases pass unchanged, as do `make test` and `make test-juce` in full.

## Follow-up

The SDK's MIDI timestamps stay in seconds here. Switching them to integer sample offsets is worth doing on its own — it deletes six device-side `roundToInt(ts * sampleRate)` conversions and `midiTimeOffsetSeconds`, which both Tracktion nodes hard-code to 0 — and is a separate, mechanical change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019sKH5X6HQ8WV82QriCbmLr