### PR TITLE
Measure a compiled poly instrument against the fork

### DIFF
--- a/tests/DawProjectRoundTrip.cpp
+++ b/tests/DawProjectRoundTrip.cpp
@@ -597,6 +597,7 @@ const std::map<std::string, std::vector<Loss>>& lossTable() {
         {"plugin.instrument.midiout.thru", {deviceMidiPorts()}},
         {"plugin.faust.instrument", {internalDevices()}},
         {"plugin.sampler", {internalDevices()}},
+        {"plugin.compiled.instrument", {internalDevices()}},
         {"multiout.pair", {internalDevices(), multiOutRouting()}},
         {"project.mixed", {internalDevices()}},
         {"midi.notes", {internalDevices()}},

--- a/tests/NullDiffCorpus.cpp
+++ b/tests/NullDiffCorpus.cpp
@@ -15,6 +15,7 @@
 #include "core/TimeStretchModes.hpp"
 #include "magda/daw/audio/plugins/FaustInstrumentPlugin.hpp"
 #include "magda/daw/audio/plugins/MagdaSamplerPlugin.hpp"
+#include "magda/daw/audio/plugins/compiled/MagdaPolySynthCompiledPlugin.hpp"
 #include "magda/daw/audio/plugins/engine/EngineDeviceFactory.hpp"
 
 /**
@@ -676,6 +677,58 @@ magda::DeviceInfo samplerDevice(magda::DeviceId id, const juce::File& sampleFile
     doc.root.props.set("rootNote", 60);
     doc.root.props.set("loopEnabled", false);
     device.pluginState = magda::device_state::encode(doc);
+
+    return device;
+}
+
+/// The Poly Synth's shortest envelope stage, in the milliseconds its slots
+/// carry. Every amp stage sits here, so the note is as near a gate as the
+/// device allows and the window the case excludes stays short.
+constexpr float kPolySynthEnvelopeMs = 1.0f;
+
+/// How long the amp release takes to leave the corpus floor, which is not the
+/// stage's own length: the DSP's envelope is en.adsre, a one-pole, so the
+/// number above is where it is 60 dB down rather than where it ends. Three of
+/// them measures -209 dB, against a floor of -120.
+constexpr double kPolySynthReleaseSettlingSeconds = 3.0 * kPolySynthEnvelopeMs / 1000.0;
+
+/// The Poly Synth, which is MagdaCompiledPolyInstrument and therefore every
+/// compiled synth MAGDA ships, as a project would save it (#2352).
+///
+/// The whole slot table travels, defaults and all: a gap in an internal
+/// device's parameter indices is a diagnostic rather than a render
+/// (ParamTableCompiler::Builder). The amp envelope is flattened on top of it,
+/// and the filter's envelope amount is already zero by default, so the only
+/// thing shaping a note is its gate.
+magda::DeviceInfo polySynthDevice(magda::DeviceId id) {
+    using PolySynth = magda::daw::audio::compiled::MagdaPolySynthCompiledPlugin;
+
+    magda::DeviceInfo device;
+    device.id = id;
+    device.name = "Poly Synth";
+    device.pluginId = PolySynth::xmlTypeName;
+    device.deviceType = magda::DeviceType::Instrument;
+    device.isInstrument = true;
+    device.canReceiveMidi = true;
+    device.format = magda::PluginFormat::Internal;
+    device.audioInputChannels = 0;
+    device.audioOutputChannels = 2;
+
+    const PolySynth metadata;
+    for (auto index = 0; index < metadata.parameterCount(); ++index) {
+        auto info = metadata.parameterInfo(index);
+        info.currentValue = info.defaultValue;
+        device.parameters.push_back(std::move(info));
+    }
+
+    // Values travel on the model, which owns them since #2317.
+    const auto set = [&device](int index, float value) {
+        device.parameters[static_cast<size_t>(index)].currentValue = value;
+    };
+    set(PolySynth::kAmpAttackSlot, kPolySynthEnvelopeMs);
+    set(PolySynth::kAmpDecaySlot, kPolySynthEnvelopeMs);
+    set(PolySynth::kAmpSustainSlot, 1.0f);
+    set(PolySynth::kAmpReleaseSlot, kPolySynthEnvelopeMs);
 
     return device;
 }
@@ -2659,6 +2712,50 @@ std::vector<Case> buildCorpus(const juce::File& scratchDirectory) {
             // free, and two pitches at once so the pitch ratio is exercised.
             clip.midiNotes.push_back(note(60, at, 1.0, 100));
             clip.midiNotes.push_back(note(67, at, 2.5, 80));
+        }
+        value.clips.push_back(std::move(clip));
+
+        corpus.push_back(std::move(value));
+    }
+
+    {
+        // The compiled poly instrument on both legs (#2352). Every synth MAGDA
+        // ships is one of these, and none of them had been measured against the
+        // fork before this case: the corpus's other instruments answer a
+        // note-on with an impulse, so what they pin is that a note arrived and
+        // where, not which voice took it or when it was let go.
+        auto track = plainTrack();
+        track.chain.fxChainElements.emplace_back(polySynthDevice(987));
+
+        auto value = newCase("plugin.compiled.instrument",
+                             "a compiled poly instrument's voice allocation", std::move(track));
+        value.endBeat = 8.0;
+
+        // A sustaining instrument with an envelope, so it hears the fork's
+        // note-end nudge the way the sampler does (#2271).
+        value.audioChangesAtNoteEnds = true;
+        value.noteEndReleaseSeconds = kPolySynthReleaseSettlingSeconds;
+        value.mechanism =
+            "the fork ends every note 0.0001 s early (MidiNote::getPlaybackTime) and the engine "
+            "keeps the authored length; the two legs then run the same one-pole release four "
+            "samples apart, so the three time constants it takes to leave the floor are named "
+            "per note and taken out of the residual, everything else held to bit identity";
+
+        auto clip = midiClip(344, 0.0, 8.0);
+        for (auto index = 0; index < 4; ++index) {
+            const auto at = static_cast<double>(index) * 2.0;
+            // Three voices held at once and released in an order the onsets do
+            // not give: the middle pitch goes first, the lowest last, and the
+            // lowest is still sounding when the next chord arrives, so a voice
+            // is reused rather than always free.
+            //
+            // Every length is a whole half-beat, which at 120 bpm is a whole
+            // number of samples. A note ending between two samples is rounded
+            // one way here and the other way by the fork, and the window below
+            // is derived from this end rather than found in the residual.
+            clip.midiNotes.push_back(note(48 + index, at, 2.5, 100));
+            clip.midiNotes.push_back(note(55 + index, at, 1.0, 100));
+            clip.midiNotes.push_back(note(64 + index, at, 1.5, 100));
         }
         value.clips.push_back(std::move(clip));
 

--- a/tests/engine/test_null_diff_block_size.cpp
+++ b/tests/engine/test_null_diff_block_size.cpp
@@ -385,10 +385,18 @@ TEST_CASE("Every project renders the same audio at 64, 512 and 4096", "[nulldiff
     // calibration list gives a residual without an explanation: a bound nobody
     // has justified is how a real difference ends up inside an expected one.
     // They are named so that neither a new failure nor a fixed one is quiet.
+    //
+    // plugin.compiled.instrument is the fifth, and the only one that arrives
+    // with its mechanism. It asks the claim above of a compiled poly instrument
+    // directly rather than through a project, and the answer is no: mydsp_poly
+    // returns a released voice to the free pool inside compute(), when the peak
+    // it just mixed falls under VOICE_STOP_LEVEL (poly-dsp.h), so which voice
+    // is free is a function of how the block was cut. The case diverges by
+    // 0.6 at 64 and first differs at sample 44100, the second chord's onset,
+    // which is the first note-on that can be handed a different voice. Every
+    // compiled synth MAGDA ships is one of these. See #2436.
     const std::set<std::string> knownDependent{
-        "project.demo",
-        "project.faust",
-        "project.fmchain",
+        "plugin.compiled.instrument", "project.demo", "project.faust", "project.fmchain",
         "project.sidechain",
     };
 

--- a/tests/engine/test_null_diff_corpus.cpp
+++ b/tests/engine/test_null_diff_corpus.cpp
@@ -36,7 +36,7 @@ juce::File scratch() {
 TEST_CASE("The corpus builds and covers what the slice claims", "[nulldiff][corpus]") {
     const auto corpus = sharedCorpus(scratch());
 
-    REQUIRE(corpus.size() == 69);
+    REQUIRE(corpus.size() == 70);
 
     std::set<std::string> names;
     for (const auto& value : corpus)


### PR DESCRIPTION
Closes #2352.

## What was missing

`MagdaCompiledPolyInstrument` hosts every compiled synth MAGDA ships, and the null-diff corpus had no case for it, so neither engine's handling of one had ever been measured against the other. The corpus's instrument cases answer a note-on with a one-sample impulse and ignore the note-off, which pins that a note arrived and where, not which voice took it or when it was let go.

## The case

`plugin.compiled.instrument` carries a Poly Synth with its amp envelope flattened to a gate, playing four chords whose three voices are released in an order their onsets do not give, and whose lowest note is still sounding when the next chord arrives, so voices are reused rather than always free. It nulls at -204.7 dB against a floor of -120.

Two things it took to get there, both measured rather than assumed:

**The declared note-end window is three release time constants, not one.** The DSP's envelope is `en.adsre`, a one-pole, so the stage's own length is where it is 60 dB down rather than where it ends. Declaring the parameter's own 1 ms left -89 dB sitting just past the window edge.

**Every note length is a whole half-beat**, which at 120 bpm is a whole number of samples. A first draft used 1.75 beats, which ends on sample 170887.5; the harness rounds that one way and the fork the other, and the peak residual landed one sample outside the derived window. The window is derived from the authored end, so the authored end has to be a sample.

The whole slot table travels on the device, defaults and all: a gap in an internal device's parameter indices is a diagnostic rather than a render.

## What the case found

**#2436: a compiled poly instrument's voice allocation depends on the host block size.** `mydsp_poly::compute` returns a released voice to the free pool inside the compute call, when the peak it just mixed falls under `VOICE_STOP_LEVEL`, so which voice is free is a function of how the block was cut. The case diverges from its own 512-sample render by 0.6 at block size 64, first differing at sample 44100 — the second chord's onset, the first note-on that can be handed a recycled voice. Recorded in the block-size gate's `knownDependent` list with the mechanism named; it is the only entry on that list that arrives with one.

DAWproject carries no internal device, so the case declares the same `TrackInfo::chain` loss the sampler and the Faust instrument declare.

## Tests

Catch2: 3639 passed, 13 skipped. Null-diff corpus through both engines: every case holds except `placement.grid`, which asserts at `tracktion_DeviceManager.cpp:432` on this machine. I checked it against a clean `dev/0.20.0`: it fails there identically and CI was green on #2434, so it is local and pre-existing.

https://claude.ai/code/session_013A1GWqAoLZPdkYAMwKrjQj