### PR TITLE
Judge a poly voice's release level over the render, not the block

### DIFF
--- a/magda/daw/audio/plugins/compiled/MagdaCompiledPolyInstrument.cpp
+++ b/magda/daw/audio/plugins/compiled/MagdaCompiledPolyInstrument.cpp
@@ -181,6 +181,8 @@ void MagdaCompiledPolyInstrument::rebuildEngineState(int sampleRate) {
                                          /*group*/ false);
     poly_->init(sampleRate);
     numOutputs_ = poly_->getNumOutputs();
+    voiceLevels_.assign(static_cast<size_t>(numVoices()), {});
+    renderPosition_ = 0;
 
     PolyVoiceHarvester harvester;
     poly_->buildUserInterface(&harvester);
@@ -320,6 +322,65 @@ void MagdaCompiledPolyInstrument::releasePolyVoicesForPitch(int pitch) {
     }
 }
 
+void MagdaCompiledPolyInstrument::snapshotVoiceStates() {
+    auto* impl = static_cast<mydsp_poly*>(poly_.get());
+    if (impl == nullptr)
+        return;
+
+    const auto voices = std::min(voiceLevels_.size(), impl->fVoiceTable.size());
+    for (size_t i = 0; i < voices; ++i)
+        voiceLevels_[i].noteBeforeCompute = impl->fVoiceTable[i]->fCurNote;
+}
+
+void MagdaCompiledPolyInstrument::foldVoiceLevels(int samples) {
+    auto* impl = static_cast<mydsp_poly*>(poly_.get());
+    if (impl == nullptr)
+        return;
+
+    const auto voices = std::min(voiceLevels_.size(), impl->fVoiceTable.size());
+    for (size_t i = 0; i < voices; ++i) {
+        auto* voice = impl->fVoiceTable[i];
+        auto& level = voiceLevels_[i];
+
+        // A voice the engine did not compute left its level from whenever it
+        // last sounded, and a free one starts its next note with a clean window.
+        if (level.noteBeforeCompute == kFreeVoice) {
+            level.sumSquares = 0.0;
+            level.samples = 0;
+            continue;
+        }
+
+        // Put back what compute() freed: the level of one call is not the
+        // window's, and the window is where the decision belongs (#2436).
+        if (level.noteBeforeCompute == kReleaseVoice && voice->fCurNote == kFreeVoice)
+            voice->fCurNote = kReleaseVoice;
+
+        // mixCheckVoice returns the RMS of the call it was handed, so the
+        // window's RMS is the sample-weighted mean of the squares.
+        level.sumSquares += static_cast<double>(voice->fLevel) * voice->fLevel * samples;
+        level.samples += samples;
+    }
+}
+
+void MagdaCompiledPolyInstrument::closeVoiceLevelWindow() {
+    auto* impl = static_cast<mydsp_poly*>(poly_.get());
+    if (impl == nullptr)
+        return;
+
+    const auto voices = std::min(voiceLevels_.size(), impl->fVoiceTable.size());
+    for (size_t i = 0; i < voices; ++i) {
+        auto* voice = impl->fVoiceTable[i];
+        auto& level = voiceLevels_[i];
+
+        if (voice->fCurNote == kReleaseVoice && level.samples > 0 &&
+            std::sqrt(level.sumSquares / level.samples) < VOICE_STOP_LEVEL)
+            voice->fCurNote = kFreeVoice;
+
+        level.sumSquares = 0.0;
+        level.samples = 0;
+    }
+}
+
 bool MagdaCompiledPolyInstrument::handleMonoNoteOn(int note, int velocity, int mode) {
     const float g = static_cast<float>(velocity) / 127.0f;
     const bool wasEmpty = heldNotes_.empty();
@@ -427,6 +488,9 @@ void MagdaCompiledPolyInstrument::process(DeviceProcessContext& context) {
     ::dsp* active =
         (mode == Poly) ? static_cast<::dsp*>(poly_.get()) : static_cast<::dsp*>(monoVoice_.get());
 
+    // Only the poly engine allocates voices; the mono voice is driven by hand.
+    const bool windowedVoices = (mode == Poly && poly_ != nullptr);
+
     const bool hasOutputStage = gainSlot() >= 0;
     const float gain =
         hasOutputStage ? juce::Decibels::decibelsToGain(slotRealValue(gainSlot())) : 1.0f;
@@ -439,10 +503,23 @@ void MagdaCompiledPolyInstrument::process(DeviceProcessContext& context) {
     auto renderSegment = [&](int segStart, int segLen) {
         int done = 0;
         while (done < segLen) {
-            const int chunk = std::min(segLen - done, maxChunk);
+            // Cut on the voice-level grid as well as the block, so a window is
+            // the same stretch of the render whatever the host's buffer is.
+            const int windowLeft = static_cast<int>(kVoiceLevelWindowSamples -
+                                                    renderPosition_ % kVoiceLevelWindowSamples);
+            const int chunk = std::min({segLen - done, maxChunk, windowLeft});
             for (int ch = 0; ch < numOutputs_; ++ch)
                 outPtrs_[static_cast<size_t>(ch)] = scratchOut_.getWritePointer(ch % scratchCh);
+
+            if (windowedVoices)
+                snapshotVoiceStates();
             active->compute(chunk, nullptr, outPtrs_.data());
+            if (windowedVoices) {
+                foldVoiceLevels(chunk);
+                if ((renderPosition_ + chunk) % kVoiceLevelWindowSamples == 0)
+                    closeVoiceLevelWindow();
+            }
+            renderPosition_ += chunk;
 
             // Gain, peak limiter and NaN panic, for a device that leaves its
             // output stage to the wrapper. A synth whose dsp trims and

--- a/magda/daw/audio/plugins/compiled/MagdaCompiledPolyInstrument.hpp
+++ b/magda/daw/audio/plugins/compiled/MagdaCompiledPolyInstrument.hpp
@@ -2,6 +2,7 @@
 
 #include <array>
 #include <atomic>
+#include <cstdint>
 #include <memory>
 #include <vector>
 
@@ -191,6 +192,41 @@ class MagdaCompiledPolyInstrument : public CompiledFaustDevice {
     // still-monitored live input that fed it), so unbalanced deliveries must
     // never strand a sounding voice.
     void releasePolyVoicesForPitch(int pitch);
+
+    /// Records what each voice was before a compute() call, so a voice the
+    /// engine frees inside the window can be put back until the window closes.
+    void snapshotVoiceStates();
+    /// Folds one compute() call's voice levels into the open window.
+    void foldVoiceLevels(int samples);
+    /// Ends the window: a released voice whose level over the whole of it is
+    /// under the engine's stop level goes back to the free pool.
+    void closeVoiceLevelWindow();
+
+    /// The stretch of the timeline a released voice's level is judged over.
+    ///
+    /// mydsp_poly frees a released voice inside compute() when the RMS of that
+    /// one call is under VOICE_STOP_LEVEL, so which voice is free -- and
+    /// therefore which voice the next note-on lands on, and what phase its
+    /// oscillators are at -- was a function of how the host cut the render up.
+    /// Judging the level over a fixed window of the timeline makes it a
+    /// function of the render instead (#2436).
+    ///
+    /// 64 samples: the shortest window a host asks for today, so no voice is
+    /// held longer than one already is at that buffer size.
+    static constexpr std::int64_t kVoiceLevelWindowSamples = 64;
+
+    /// One voice's level over the open window, and what it was before the last
+    /// compute() call.
+    struct VoiceLevel {
+        double sumSquares = 0.0;
+        int samples = 0;
+        int noteBeforeCompute = 0;
+    };
+    std::vector<VoiceLevel> voiceLevels_;
+    /// Samples rendered since prepare(), which is what the window grid counts.
+    /// Never re-anchored on a transport edge: those are found per block, and a
+    /// grid moved by one would be a grid the host's buffer size decides.
+    std::int64_t renderPosition_ = 0;
     /// Takes the held-note stack's storage, off the audio thread.
     void reserveHeldNotes();
     /// One entry per MIDI pitch, which handleMonoNoteOn() keeps it to.

--- a/tests/engine/test_null_diff_block_size.cpp
+++ b/tests/engine/test_null_diff_block_size.cpp
@@ -386,17 +386,21 @@ TEST_CASE("Every project renders the same audio at 64, 512 and 4096", "[nulldiff
     // has justified is how a real difference ends up inside an expected one.
     // They are named so that neither a new failure nor a fixed one is quiet.
     //
-    // plugin.compiled.instrument is the fifth, and the only one that arrives
-    // with its mechanism. It asks the claim above of a compiled poly instrument
-    // directly rather than through a project, and the answer is no: mydsp_poly
-    // returns a released voice to the free pool inside compute(), when the peak
-    // it just mixed falls under VOICE_STOP_LEVEL (poly-dsp.h), so which voice
-    // is free is a function of how the block was cut. The case diverges by
-    // 0.6 at 64 and first differs at sample 44100, the second chord's onset,
-    // which is the first note-on that can be handed a different voice. Every
-    // compiled synth MAGDA ships is one of these. See #2436.
+    // plugin.compiled.instrument was the fifth, and the only one that arrived
+    // with its mechanism: mydsp_poly returns a released voice to the free pool
+    // inside compute() when the RMS of that one call falls under
+    // VOICE_STOP_LEVEL (poly-dsp.h), so which voice was free -- and therefore
+    // which voice the next note-on was handed, and what phase its oscillators
+    // were at -- was a function of how the block was cut. It diverged by 0.6 at
+    // 64, first at sample 44100, the second chord's onset. The device now
+    // judges that level over a fixed window of the render rather than over
+    // whatever the host asked for (#2436), and the case holds at every rung, so
+    // it is gated like the rest. Every compiled synth MAGDA ships is one of
+    // these, which is why it is worth a case of its own.
     const std::set<std::string> knownDependent{
-        "plugin.compiled.instrument", "project.demo", "project.faust", "project.fmchain",
+        "project.demo",
+        "project.faust",
+        "project.fmchain",
         "project.sidechain",
     };
 


### PR DESCRIPTION
Closes #2436.

## The mechanism

`mydsp_poly::compute()` returns a released voice to the free pool inside the call (`poly-dsp.h:851`):

```cpp
voice->fLevel = mixCheckVoice(count, fMixBuffer, fOutBuffer);
if ((voice->fCurNote == kReleaseVoice) && (voice->fLevel < VOICE_STOP_LEVEL))
    voice->fCurNote = kFreeVoice;
```

`mixCheckVoice` returns the RMS of that one call, so the sample at which a voice becomes free is a function of how the render was cut into `compute()` calls. `getFreeVoice()` hands out the lowest-index free voice, so a note-on arriving after a differently-timed free lands on a different voice — and the oscillators free-run unless Osc Reset is on, so a different voice is a different phase and a different render.

`plugin.compiled.instrument` diverged from its own 512-sample render by a peak of **0.6 at 64, 1.2 at 96 and 1.7 at 4096**, first differing at sample 44100 — the second chord's onset, the first note-on that can be handed a voice another note has already used. Every compiled synth MAGDA ships is a `MagdaCompiledPolyInstrument`.

## The fix

The device judges that level over a fixed **64-sample window of the render** instead:

- each `compute()` call is folded into the open window (the window's RMS is the sample-weighted mean of the calls' squares, which is exactly what one call over the whole window would have returned);
- a free the engine makes *inside* a window is put back until the window closes, so the decision is taken only on the grid;
- chunks are cut on the window grid as well as on MIDI events and the block, so a window is the same stretch of the render whatever the host's buffer is.

64 samples because that is the shortest window a host asks for today: no voice is held longer than it already is at that buffer size, and no voice is judged over a shorter one.

## Faust's or ours

The mechanism is upstream's, in a vendored architecture header. Fixed in the wrapper rather than in the submodule, so nothing in `third_party/faust` is forked — `MagdaCompiledPolyInstrument` already reaches into `fVoiceTable` for `releasePolyVoicesForPitch()`. Proposing it upstream is tracked separately.

## What this changes about the render

Voices free on the grid rather than per call, so at a 512-sample block they are recycled up to 448 samples earlier than before — at an RMS under -90 dB, which is the level the engine already calls silent. One consequence worth naming: a steal (`getFreeVoice()` with no free voice) fades the stolen voice over `count/2`, so its crossfade is now the window rather than the block. That is a behaviour change in the steal path, and an invariant one.

## Tests

`plugin.compiled.instrument` comes off the block-size gate's `knownDependent` list and is asked like every other case (#2078). It holds at 64, 96, 512 and 4096. Reverting the device change fails all three rungs by the figures above.

`make test` (858k assertions) and `make test-juce` both pass; the real-project cost table is unchanged within run-to-run noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019sKH5X6HQ8WV82QriCbmLr