### PR TITLE
Pin what the launcher does across tracks

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -400,6 +400,7 @@ if(MAGDA_BUILD_NATIVE_ENGINE)
     # The lane a launch arrives on (#2305): the block it lands in, the order it
     # keeps, and that it cannot be applied twice or reach a slot that has gone.
     list(APPEND TEST_SOURCES engine/test_launch_requests.cpp)
+    list(APPEND TEST_SOURCES engine/test_launch_behaviour.cpp)
     # What a slot publishes about itself (#2303): the block's own reading,
     # rather than a UI polling the launcher a frame behind the audio.
     list(APPEND TEST_SOURCES engine/test_launch_tap.cpp)

--- a/tests/engine/test_launch_behaviour.cpp
+++ b/tests/engine/test_launch_behaviour.cpp
@@ -1,0 +1,292 @@
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <vector>
+
+#include "launch/SessionLauncher.hpp"
+
+/**
+ * @file test_launch_behaviour.cpp
+ * @brief A scene across tracks, and the events that meet on one handle (#2306).
+ *
+ * What the launcher does when more than one track is involved. test_launch_-
+ * handle.cpp is one handle's own state machine and test_launch_requests.cpp is
+ * the lane a request travels down; both build their slots on a single track,
+ * which is the one thing a scene is not.
+ *
+ * Assertions about which slot is playing on which beat rather than about audio.
+ * A scene that started seven of its eight tracks on one beat and the eighth on
+ * the next sounds like a scene, which is why it needs pinning here.
+ */
+
+using Catch::Approx;
+using namespace magda;
+using namespace magda::engine;
+
+namespace {
+
+constexpr int kBlockSize = 512;
+constexpr double kSampleRate = 48000.0;
+
+/// A quarter beat a block, so a launch and its first block are easy to tell
+/// apart from the one after it. Carried per sample too, since the sizes at the
+/// bottom of this file cut the same beats differently.
+constexpr double kBeatsPerBlock = 0.25;
+constexpr double kBeatsPerSample = kBeatsPerBlock / kBlockSize;
+
+BlockInfo blockOf(std::int64_t startSample, int numSamples) {
+    const auto endSample = startSample + numSamples;
+
+    BlockInfo block;
+    block.numSamples = numSamples;
+    block.sampleRate = kSampleRate;
+    block.monotonicSamples = {SamplePosition{startSample}, SamplePosition{endSample}};
+    block.playing = true;
+    block.continuous = startSample != 0;
+    block.beats = {static_cast<double>(startSample) * kBeatsPerSample,
+                   static_cast<double>(endSample) * kBeatsPerSample};
+    block.monotonicBeats = block.beats;
+    block.seconds = {static_cast<double>(startSample) / kSampleRate,
+                     static_cast<double>(endSample) / kSampleRate};
+    block.monotonicSeconds = block.seconds;
+    return block;
+}
+
+BlockInfo blockAt(int index) {
+    return blockOf(static_cast<std::int64_t>(index) * kBlockSize, kBlockSize);
+}
+
+/// The block covering @p beat, so a case names the beat it is rolling to rather
+/// than counting callbacks.
+int blockHolding(double beat) {
+    return static_cast<int>(beat / kBeatsPerBlock);
+}
+
+/**
+ * @brief A published table over @p tracks tracks of @p scenes slots each.
+ *
+ * Sorted by slot key, which for more than one track means every scene of track
+ * one before any of track two: what `rangeFor` binary-searches and what a scene
+ * launch has to reach across.
+ */
+struct Rig {
+    Rig(int tracks, int scenes) : trackCount(tracks), sceneCount(scenes) {
+        handles.resize(static_cast<std::size_t>(tracks) * static_cast<std::size_t>(scenes));
+
+        auto table = std::make_shared<LaunchHandleTable>();
+        for (auto track = 0; track < tracks; ++track)
+            for (auto scene = 0; scene < scenes; ++scene)
+                table->entries.push_back(LaunchHandleTable::Entry{.key = key(track, scene),
+                                                                  .handle = &at(track, scene)});
+
+        feed.publish(std::move(table));
+    }
+
+    static SlotKey key(int track, int scene) {
+        return SlotKey{static_cast<TrackId>(track + 1), scene};
+    }
+
+    LaunchHandle& at(int track, int scene) {
+        return handles[static_cast<std::size_t>(track) * static_cast<std::size_t>(sceneCount) +
+                       static_cast<std::size_t>(scene)];
+    }
+
+    bool playing(int track, int scene) {
+        return at(track, scene).playState() == LaunchHandle::PlayState::playing;
+    }
+
+    void roll(int index) {
+        advanceLaunchHandles(feed, requests, blockAt(index));
+    }
+
+    /// Every block from @p first up to and including the one holding @p beat.
+    void rollTo(double beat, int first = 0) {
+        for (auto index = first; index <= blockHolding(beat); ++index)
+            roll(index);
+    }
+
+    int trackCount = 0;
+    int sceneCount = 0;
+    std::vector<LaunchHandle> handles;
+    LaunchHandleFeed feed;
+    LaunchRequestQueue requests;
+};
+
+/// The monotonic sample a run began on, which is what "the same beat" means
+/// once a scene is more than one track.
+std::int64_t startedAt(const LaunchHandle& handle) {
+    REQUIRE(handle.playedSampleRange().has_value());
+    return handle.playedSampleRange()->start.sample;
+}
+
+}  // namespace
+
+TEST_CASE("A scene starts every track it names on one beat", "[engine][session][launch][scene]") {
+    Rig rig(4, 2);
+
+    // The leader and its followers in one gesture, which is what makes a scene
+    // one event rather than four launches that happen to be adjacent.
+    {
+        LaunchRequestQueue::Gesture gesture(rig.requests);
+        std::vector<SlotKey> followers;
+        followers.reserve(4);
+        for (auto track = 0; track < 4; ++track)
+            followers.push_back(rig.key(track, 1));
+
+        gesture.playScene(rig.key(0, 1), followers, 1.0);
+    }
+
+    rig.rollTo(1.0);
+
+    const auto leader = startedAt(rig.at(0, 1));
+    for (auto track = 0; track < 4; ++track) {
+        INFO("track " << track);
+        REQUIRE(rig.playing(track, 1));
+        CHECK(startedAt(rig.at(track, 1)) == leader);
+    }
+
+    // The beat asked for, not the boundary of the block it landed in.
+    CHECK(leader == static_cast<std::int64_t>(1.0 / kBeatsPerSample));
+}
+
+TEST_CASE("A scene joins a track that was already playing to the others",
+          "[engine][session][launch][scene]") {
+    Rig rig(3, 2);
+
+    // Track 0 is already running scene 1, out of phase with the scene about to
+    // be launched. A synced launch joins the leader's run rather than starting
+    // its own, so the three report one origin afterwards.
+    {
+        LaunchRequestQueue::Gesture gesture(rig.requests);
+        gesture.play(rig.key(0, 1), 0.5);
+    }
+    rig.rollTo(0.5);
+    REQUIRE(rig.playing(0, 1));
+
+    {
+        LaunchRequestQueue::Gesture gesture(rig.requests);
+        std::vector<SlotKey> followers{rig.key(0, 1), rig.key(1, 1), rig.key(2, 1)};
+        gesture.playScene(rig.key(1, 1), followers, 2.0);
+    }
+    rig.rollTo(2.0, blockHolding(0.5) + 1);
+
+    const auto leader = startedAt(rig.at(1, 1));
+    for (auto track = 0; track < 3; ++track) {
+        INFO("track " << track);
+        REQUIRE(rig.playing(track, 1));
+        CHECK(startedAt(rig.at(track, 1)) == leader);
+    }
+}
+
+TEST_CASE("A scene stops the track it has no clip for, on the scene's own beat",
+          "[engine][session][launch][scene]") {
+    Rig rig(3, 2);
+
+    // Track 2 is playing something else. The scene about to be launched holds
+    // no clip for it, which the surface above turns into a stop travelling in
+    // the same gesture as the launches (SessionLaunchService).
+    {
+        LaunchRequestQueue::Gesture gesture(rig.requests);
+        gesture.play(rig.key(2, 0), 0.5);
+    }
+    rig.rollTo(0.5);
+    REQUIRE(rig.playing(2, 0));
+
+    {
+        LaunchRequestQueue::Gesture gesture(rig.requests);
+        std::vector<SlotKey> followers{rig.key(0, 1), rig.key(1, 1)};
+        gesture.playScene(rig.key(0, 1), followers, 2.0);
+        gesture.stop(rig.key(2, 0), 2.0);
+    }
+    rig.rollTo(2.0, blockHolding(0.5) + 1);
+
+    CHECK(rig.playing(0, 1));
+    CHECK(rig.playing(1, 1));
+
+    // Stopped on the beat the others started on, rather than a block either
+    // side of it: the whole gesture is drained before any handle advances.
+    CHECK_FALSE(rig.playing(2, 0));
+    REQUIRE(rig.at(2, 0).lastPlayedRange().has_value());
+    CHECK(rig.at(2, 0).lastPlayedRange()->end == Approx(2.0));
+    CHECK(startedAt(rig.at(0, 1)) == static_cast<std::int64_t>(2.0 / kBeatsPerSample));
+}
+
+TEST_CASE("A stop replaces a launch that has not fired", "[engine][session][launch]") {
+    Rig rig(1, 1);
+
+    // A handle holds one pending request, so a stop arriving over a queued
+    // launch is what was asked for last and the slot never starts.
+    {
+        LaunchRequestQueue::Gesture gesture(rig.requests);
+        gesture.play(rig.key(0, 0), 2.0);
+    }
+    rig.roll(0);
+    REQUIRE(rig.at(0, 0).queuedState() == LaunchHandle::QueueState::playQueued);
+
+    {
+        LaunchRequestQueue::Gesture gesture(rig.requests);
+        gesture.stop(rig.key(0, 0), 1.0);
+    }
+    rig.rollTo(3.0, 1);
+
+    CHECK_FALSE(rig.playing(0, 0));
+    CHECK_FALSE(rig.at(0, 0).playedSampleRange().has_value());
+}
+
+TEST_CASE("A stop later than the launch it replaces still cancels it",
+          "[engine][session][launch]") {
+    Rig rig(1, 1);
+
+    // The stop is quantized past the launch's own beat. It is still the pending
+    // request, so the beat the launch was waiting for passes with nothing on it
+    // rather than starting a run the stop then ends.
+    {
+        LaunchRequestQueue::Gesture gesture(rig.requests);
+        gesture.play(rig.key(0, 0), 1.0);
+    }
+    rig.roll(0);
+    REQUIRE(rig.at(0, 0).queuedState() == LaunchHandle::QueueState::playQueued);
+
+    {
+        LaunchRequestQueue::Gesture gesture(rig.requests);
+        gesture.stop(rig.key(0, 0), 2.0);
+    }
+    rig.rollTo(3.0, 1);
+
+    CHECK_FALSE(rig.playing(0, 0));
+    CHECK_FALSE(rig.at(0, 0).playedSampleRange().has_value());
+}
+
+TEST_CASE("A scene lands on the same sample at every block size",
+          "[engine][session][launch][scene]") {
+    // The sizes the invariance gate renders at (#2078), and one that divides no
+    // beat in this rig evenly.
+    for (const auto blockSize : {64, 96, 512, 4096}) {
+        INFO("block size " << blockSize);
+
+        Rig rig(4, 1);
+        {
+            LaunchRequestQueue::Gesture gesture(rig.requests);
+            std::vector<SlotKey> followers;
+            followers.reserve(4);
+            for (auto track = 0; track < 4; ++track)
+                followers.push_back(rig.key(track, 0));
+
+            gesture.playScene(rig.key(0, 0), followers, 1.0);
+        }
+
+        const auto endSample = static_cast<std::int64_t>(2.0 / kBeatsPerSample);
+        for (std::int64_t at = 0; at < endSample; at += blockSize)
+            advanceLaunchHandles(rig.feed, rig.requests, blockOf(at, blockSize));
+
+        // The beat, not the callback boundary it fell inside: a scene quantized
+        // to beat one starts at sample 2048 whatever the host asked for.
+        for (auto track = 0; track < 4; ++track) {
+            INFO("track " << track);
+            REQUIRE(rig.playing(track, 0));
+            CHECK(startedAt(rig.at(track, 0)) == static_cast<std::int64_t>(1.0 / kBeatsPerSample));
+        }
+    }
+}

--- a/tests/engine/test_launch_behaviour.cpp
+++ b/tests/engine/test_launch_behaviour.cpp
@@ -231,8 +231,12 @@ TEST_CASE("A stop replaces a launch that has not fired", "[engine][session][laun
     }
     rig.rollTo(3.0, 1);
 
+    // Never started, rather than started and then stopped. A stop clears the
+    // run it ended, so the run it did not have is the last run there has been:
+    // both of the checks above pass on a slot that played beat one to beat two.
     CHECK_FALSE(rig.playing(0, 0));
     CHECK_FALSE(rig.at(0, 0).playedSampleRange().has_value());
+    CHECK_FALSE(rig.at(0, 0).lastPlayedRange().has_value());
 }
 
 TEST_CASE("A stop later than the launch it replaces still cancels it",
@@ -257,6 +261,7 @@ TEST_CASE("A stop later than the launch it replaces still cancels it",
 
     CHECK_FALSE(rig.playing(0, 0));
     CHECK_FALSE(rig.at(0, 0).playedSampleRange().has_value());
+    CHECK_FALSE(rig.at(0, 0).lastPlayedRange().has_value());
 }
 
 TEST_CASE("A scene lands on the same sample at every block size",

--- a/tests/engine/test_session_playback.cpp
+++ b/tests/engine/test_session_playback.cpp
@@ -2290,3 +2290,238 @@ TEST_CASE("Synced handles agree in beats and in samples", "[engine][clip][sessio
     REQUIRE(follower.blockStatus().beforeEvent.origin.has_value());
     CHECK(*follower.blockStatus().beforeEvent.origin == *leader.blockStatus().beforeEvent.origin);
 }
+
+// =============================================================================
+// Two tracks, one in each section, at the same time (#2306)
+// =============================================================================
+
+namespace {
+
+constexpr magda::TrackId kSessionTrack = 11;
+constexpr magda::TrackId kArrangementTrack = 12;
+
+/**
+ * @brief Two tracks that render together, one launched and one not.
+ *
+ * SwitchRig above is one track handing itself between its two sections. This is
+ * the other half of the same claim: a session that has taken one track has not
+ * taken the others, and a project mid-performance is normally in both states at
+ * once. Every track carries both sources whether or not it is launched, which
+ * is what makes this worth asserting rather than assuming.
+ */
+struct PairRig {
+    PairRig() {
+        table.entries.push_back(LaunchHandleTable::Entry{.key = SlotKey{kSessionTrack, kScene},
+                                                         .handle = &sessionHandle});
+        table.entries.push_back(LaunchHandleTable::Entry{.key = SlotKey{kArrangementTrack, kScene},
+                                                         .handle = &idleHandle});
+        handles.publish(std::make_shared<const LaunchHandleTable>(table));
+
+        for (auto* source :
+             {&launchedArrangement, &launchedSession, &idleArrangement, &idleSession})
+            source->prepare(context());
+
+        for (auto* buffer :
+             {&launchedArrangementOut, &launchedSessionOut, &idleArrangementOut, &idleSessionOut}) {
+            buffer->setSize(2, kBlockSize);
+            buffer->clear();
+        }
+    }
+
+    /// A clip on @p track's timeline, sounding @p level from beat zero.
+    void giveArrangement(magda::TrackId track, magda::ClipId id, float level) {
+        auto& lane = laneFor(track);
+        lane.audio.push_back(clipOver(id, beats(0.0, 1000.0)));
+        addStream(track, lane.audio.back(), level);
+    }
+
+    /// A slot on @p track, @p lengthBeats long, sounding @p level.
+    void giveSlot(magda::TrackId track, magda::ClipId id, double lengthBeats, float level) {
+        SessionSlotPlayback slot;
+        slot.sceneIndex = kScene;
+        slot.lengthBeats = lengthBeats;
+        slot.audio.push_back(clipOver(id, beats(0.0, lengthBeats)));
+
+        auto& lane = laneFor(track);
+        lane.session.push_back(std::move(slot));
+        addStream(track, lane.session.back().audio.front(), level);
+    }
+
+    void publish() {
+        auto compiled = std::make_shared<ClipSnapshot>();
+        compiled->tracks.push_back(launched);
+        compiled->tracks.push_back(idle);
+        clips.publish(std::move(compiled));
+        streams.publish(std::make_shared<const ClipStreamTable>(streamTable));
+    }
+
+    /// One block through the launcher and all four sources, in the order the
+    /// session does it: every handle advanced before anything renders.
+    void render(int index, bool continuous = true) {
+        const auto block = blockAt(index, continuous);
+
+        fill();
+        magda::engine::advanceLaunchHandles(handles, requests, block);
+
+        // A section renders into its own buffer and the track is the sum, which
+        // is how a hand-over can be checked for a hole or a doubling.
+        launchedArrangement.render(block, juce::dsp::AudioBlock<float>(launchedArrangementOut));
+        launchedSession.render(block, juce::dsp::AudioBlock<float>(launchedSessionOut));
+        idleArrangement.render(block, juce::dsp::AudioBlock<float>(idleArrangementOut));
+        idleSession.render(block, juce::dsp::AudioBlock<float>(idleSessionOut));
+    }
+
+    /// What the launched track sounds: both of its sections together.
+    float launchedAt(int sample) const {
+        return launchedArrangementOut.getSample(0, sample) +
+               launchedSessionOut.getSample(0, sample);
+    }
+
+    /// And the track nobody launched.
+    float idleAt(int sample) const {
+        return idleArrangementOut.getSample(0, sample) + idleSessionOut.getSample(0, sample);
+    }
+
+    float launchedPeak() const {
+        return std::max(launchedArrangementOut.getMagnitude(0, kBlockSize),
+                        launchedSessionOut.getMagnitude(0, kBlockSize));
+    }
+
+    float idlePeak() const {
+        return std::max(idleArrangementOut.getMagnitude(0, kBlockSize),
+                        idleSessionOut.getMagnitude(0, kBlockSize));
+    }
+
+    void roll(int first, int last) {
+        for (auto index = first; index <= last; ++index)
+            render(index, index != first);
+    }
+
+    void fill() {
+        auto worked = true;
+        while (worked) {
+            worked = false;
+            for (const auto& entry : streamTable.entries)
+                worked = entry.stream->fill() || worked;
+        }
+    }
+
+    TrackClipPlayback& laneFor(magda::TrackId track) {
+        return track == kSessionTrack ? launched : idle;
+    }
+
+    TrackClipPlayback launched{kSessionTrack, {}, {}};
+    TrackClipPlayback idle{kArrangementTrack, {}, {}};
+
+    ClipSnapshotFeed clips;
+    ClipStreamFeed streams;
+
+    LaunchHandle sessionHandle;
+    LaunchHandle idleHandle;
+    LaunchHandleTable table;
+    LaunchHandleFeed handles;
+    magda::engine::LaunchRequestQueue requests;
+
+    // Both sections on both tracks, because that is what a session builds: a
+    // track nobody has launched still carries a session source.
+    ClipAudioSource launchedArrangement{kSessionTrack, clips, streams, handles,
+                                        Section::Arrangement};
+    ClipAudioSource launchedSession{kSessionTrack, clips, streams, handles, Section::Session};
+    ClipAudioSource idleArrangement{kArrangementTrack, clips, streams, handles,
+                                    Section::Arrangement};
+    ClipAudioSource idleSession{kArrangementTrack, clips, streams, handles, Section::Session};
+
+    ClipStreamTable streamTable;
+    juce::AudioBuffer<float> launchedArrangementOut;
+    juce::AudioBuffer<float> launchedSessionOut;
+    juce::AudioBuffer<float> idleArrangementOut;
+    juce::AudioBuffer<float> idleSessionOut;
+
+  private:
+    void addStream(magda::TrackId track, const AudioClipPlayback& clip, float level) {
+        const auto& event = clip.events.front();
+
+        auto stream = std::make_shared<PrefetchStream>(
+            magda::engine::readThrough(std::make_unique<LevelReader>(level),
+                                       magda::engine::sourceReadFor(event, kSampleRate)),
+            context(), magda::engine::PrefetchSettings{1024, 8});
+
+        streamTable.entries.push_back(
+            ClipStreamTable::Entry{track, clip.clipId, event.eventId, stream});
+    }
+};
+
+}  // namespace
+
+TEST_CASE("One track's session plays beside another track's arrangement",
+          "[engine][clip][session][section]") {
+    PairRig rig;
+    rig.giveArrangement(kSessionTrack, 1, 1.0f);
+    rig.giveSlot(kSessionTrack, 2, 4.0, 0.5f);
+    rig.giveArrangement(kArrangementTrack, 3, 0.25f);
+    rig.publish();
+
+    rig.roll(0, 1);
+    REQUIRE(rig.launchedAt(0) == Approx(1.0f));
+    REQUIRE(rig.idleAt(0) == Approx(0.25f));
+
+    // One track is launched. The other was never asked for anything, and a
+    // launch is a fact about a track rather than about the session.
+    rig.sessionHandle.play(std::nullopt);
+    rig.render(2);
+
+    SECTION("the launched track is on its slot") {
+        CHECK(rig.launchedAt(kBlockSize - 1) == Approx(0.5f));
+    }
+
+    SECTION("the other track is still on its arrangement") {
+        CHECK(rig.idleAt(0) == Approx(0.25f));
+        CHECK(rig.idleAt(kBlockSize - 1) == Approx(0.25f));
+    }
+
+    SECTION("the two are sounding in the same block") {
+        CHECK(rig.launchedPeak() > 0.0f);
+        CHECK(rig.idlePeak() > 0.0f);
+    }
+}
+
+TEST_CASE("A track nobody launched keeps its arrangement through the whole scene",
+          "[engine][clip][session][section]") {
+    PairRig rig;
+    rig.giveSlot(kSessionTrack, 1, 1.0, 0.5f);
+    rig.giveArrangement(kArrangementTrack, 2, 0.25f);
+    rig.publish();
+
+    // The launched track loops its slot for four blocks. The other track's
+    // arrangement is the same level on every one of them: a handle advancing
+    // does not reach a track it does not belong to.
+    rig.sessionHandle.setLooping(kBeatsPerBlock);
+    rig.sessionHandle.play(std::nullopt);
+
+    for (auto index = 0; index < 4; ++index) {
+        rig.render(index, index != 0);
+
+        INFO("block " << index);
+        CHECK(rig.idleAt(0) == Approx(0.25f));
+        CHECK(rig.idleAt(kBlockSize - 1) == Approx(0.25f));
+    }
+}
+
+TEST_CASE("Handing one track back does not touch the other", "[engine][clip][session][section]") {
+    PairRig rig;
+    rig.giveArrangement(kSessionTrack, 1, 1.0f);
+    rig.giveSlot(kSessionTrack, 2, 4.0, 0.5f);
+    rig.giveArrangement(kArrangementTrack, 3, 0.25f);
+    rig.publish();
+
+    rig.sessionHandle.play(std::nullopt);
+    rig.roll(0, 1);
+    REQUIRE(rig.launchedAt(kBlockSize - 1) == Approx(0.5f));
+
+    rig.sessionHandle.stop(std::nullopt);
+    rig.sessionHandle.releaseSection();
+    rig.render(2);
+
+    CHECK(rig.launchedAt(kBlockSize - 1) == Approx(1.0f));
+    CHECK(rig.idleAt(kBlockSize - 1) == Approx(0.25f));
+}


### PR DESCRIPTION
Part of #2306. Two of its three kinds of case; the third is #2441.

## What was missing

Every launcher suite builds its slots on a single track, which is the one thing a scene is not. `test_launch_handle.cpp` is one handle's state machine, `test_launch_requests.cpp` is the lane a request travels down, and both put every slot on `kTrack`. A scene that started seven of its eight tracks on one beat and the eighth on the next sounds like a scene, so nothing would have caught it.

Follow actions needed nothing: #2304 landed `test_follow_actions.cpp` with twenty cases over them.

## Across tracks

`tests/engine/test_launch_behaviour.cpp`:

- A scene starts every track it names on the beat it was asked for, in phase, in one gesture.
- A track already playing joins the leader's run rather than starting its own.
- The stop a scene carries for a track it holds no clip for lands on that same beat, not a block either side of it: the whole gesture drains before any handle advances.
- The scene case again at 64, 96, 512 and 4096, the sizes the invariance gate renders at. Beat one is sample 2048 whatever the host asked for.

## The two events that meet on one handle

Also uncovered, and not a multi-track question: every existing stop case stops a handle that is already playing. A handle holds one pending request, so a stop arriving over a queued launch is what was asked for and the slot never starts — whether the stop is quantized before that launch's own beat or after it.

## Two tracks rendering together

`test_session_playback.cpp` gains the other half of its own section claim. Its `SwitchRig` is one track handing itself between its two sections; `PairRig` is two tracks rendering together, one launched and one never asked for anything, which is what a project mid-performance normally is. A session that has taken one track has not taken the others, a handle advancing does not reach a track it does not belong to, and handing one track back leaves the other alone.

## What is left of #2306, and where it went

**Post-launch audio that nulls is #2441.** Not a scoping choice: both legs drop session clips on purpose (`NullDiffNativeLeg.cpp:469`, and `ClipSynchronizer` on the fork side), so the corpus renders an offline arrangement and neither leg has a step that launches anything. The model is not the blocker — `ClipInfo` already carries `sceneIndex` — the runner is.

**The empty-slot rule stays untested at the app layer.** `SessionLaunchService::launchScene` sits behind the `ClipManager` and `TrackManager` singletons; the launcher's half of the rule is asserted here, and the drift the issue worries about is already prevented by the rule living in one function both surfaces call. Nothing filed for it, and #2306 says so.

## Tests

3655 passed, 13 skipped.

https://claude.ai/code/session_013A1GWqAoLZPdkYAMwKrjQj