### PR TITLE
Render with flush-to-zero, and clear what a plugin leaves that is not a number

### DIFF
--- a/magda/daw/audio/plugins/engine/EngineExternalDevice.cpp
+++ b/magda/daw/audio/plugins/engine/EngineExternalDevice.cpp
@@ -43,6 +43,30 @@ std::optional<magda::ParameterInfo> modelParameterAt(const magda::DeviceInfo& de
     return std::nullopt;
 }
 
+/**
+ * @brief Replace anything that is not a number with silence (#2240).
+ *
+ * A NaN is not a loud sound, it is a permanent one: it survives every gain,
+ * poisons every sum it reaches, and the track stays silent-but-broken after the
+ * plugin that made it has been bypassed. An infinity does the same on the first
+ * multiply by zero. Neither is a level to be managed, so neither is clamped:
+ * they are cleared.
+ *
+ * Deliberately not the fork's rule, which clamps to a magnitude of 100 and only
+ * looks at all when the CPU raised its denormal flag during the call, on Intel.
+ * That gate is for denormals and says nothing about a NaN, and the magnitude is
+ * a number nothing derives: +40 dBFS protects no speaker.
+ */
+void clearNonFinite(juce::AudioBuffer<float>& audio, int numSamples) {
+    for (int channel = 0; channel < audio.getNumChannels(); ++channel) {
+        auto* samples = audio.getWritePointer(channel);
+
+        for (int at = 0; at < numSamples; ++at)
+            if (!std::isfinite(samples[at]))
+                samples[at] = 0.0f;
+    }
+}
+
 }  // namespace
 
 /**
@@ -411,6 +435,7 @@ void EngineExternalDevice::processPluginBlock(juce::AudioBuffer<float>& audio) {
 
     if (dryGain_ <= kDryLevelFloor) {
         instance_->processBlock(audio, midi_);
+        clearNonFinite(audio, numSamples);
 
         if (wetGain_ < kWetLevelCeiling)
             audio.applyGain(0, numSamples, wetGain_);
@@ -424,6 +449,10 @@ void EngineExternalDevice::processPluginBlock(juce::AudioBuffer<float>& audio) {
         dryScratch_.copyFrom(channel, 0, audio, channel, 0, numSamples);
 
     instance_->processBlock(audio, midi_);
+
+    // Before the dry is added back, so a plugin that produced nothing usable
+    // leaves the dry signal rather than poisoning it.
+    clearNonFinite(audio, numSamples);
 
     if (wetGain_ < kWetLevelCeiling)
         audio.applyGain(0, numSamples, wetGain_);

--- a/magda/engine/exec/ParallelPlanExecutor.cpp
+++ b/magda/engine/exec/ParallelPlanExecutor.cpp
@@ -195,6 +195,11 @@ void ParallelPlanExecutor::takeWork() {
 
 void ParallelPlanExecutor::process(const PlanValues& values, const BlockInfo& requestedBlock,
                                    juce::AudioBuffer<float>& output) {
+    // This thread's share of the block (#2240). The workers set their own, in
+    // RenderThreadPool::Worker, since the mode is per thread and a worker only
+    // ever renders.
+    const juce::ScopedNoDenormals noDenormals;
+
     const auto start = core_.beginBlock(values, requestedBlock, output);
     if (!start.render || plan_ == nullptr)
         return;

--- a/magda/engine/exec/PlanExecutor.cpp
+++ b/magda/engine/exec/PlanExecutor.cpp
@@ -1184,6 +1184,12 @@ void PlanExecutor::publishValueTaps() {
 
 void PlanExecutor::process(const PlanValues& values, const BlockInfo& requestedBlock,
                            juce::AudioBuffer<float>& output) {
+    // Flush-to-zero for everything this block runs (#2240). A device that feeds
+    // its own output back through a filter decays into the denormal range and
+    // stays there, where on Intel every multiply is a microcode trap; the mode
+    // is per thread, so it is set where the render is and not once at startup.
+    const juce::ScopedNoDenormals noDenormals;
+
     const auto start = beginBlock(values, requestedBlock, output);
     if (!start.render) {
         resolveParameters(values, start.block);

--- a/magda/engine/exec/RenderThreadPool.cpp
+++ b/magda/engine/exec/RenderThreadPool.cpp
@@ -1,5 +1,7 @@
 #include "exec/RenderThreadPool.hpp"
 
+#include <juce_audio_basics/juce_audio_basics.h>
+
 #include <algorithm>
 
 namespace magda::engine {
@@ -19,6 +21,10 @@ class RenderThreadPool::Worker final : public juce::Thread {
         : juce::Thread("MAGDA render " + juce::String(index)), pool_(pool) {}
 
     void run() override {
+        // For the thread rather than per job: flush-to-zero is a CPU mode this
+        // thread carries, and a worker does nothing but render (#2240).
+        const juce::ScopedNoDenormals noDenormals;
+
         while (!threadShouldExit()) {
             wait(-1);
             if (threadShouldExit())

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -342,6 +342,7 @@ if(MAGDA_BUILD_NATIVE_ENGINE)
     list(APPEND TEST_SOURCES engine/test_render_plan_compiler.cpp)
     list(APPEND TEST_SOURCES engine/test_render_plan_executor.cpp)
     list(APPEND TEST_SOURCES engine/test_parallel_executor.cpp)
+    list(APPEND TEST_SOURCES engine/test_render_denormals.cpp)
     list(APPEND TEST_SOURCES engine/test_plan_layout.cpp)
     # The note-range gate a pad chain needs (#2200).
     list(APPEND TEST_SOURCES engine/test_plan_note_gate.cpp)

--- a/tests/engine/test_engine_external_device.cpp
+++ b/tests/engine/test_engine_external_device.cpp
@@ -5,9 +5,11 @@
 #include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <chrono>
+#include <cmath>
 #include <cstring>
 #include <functional>
 #include <future>
+#include <limits>
 #include <memory>
 #include <optional>
 #include <stdexcept>
@@ -205,6 +207,14 @@ class StubPlugin final : public juce::AudioPluginInstance {
                 samples[sample] = (samples[sample] * level) + marker;
         }
 
+        // What a plugin that has gone wrong leaves behind, on demand: a NaN
+        // and an infinity in the first two samples of the first channel.
+        if (writesNonFinite && written > 0 && buffer.getNumSamples() >= 2) {
+            auto* samples = buffer.getWritePointer(0);
+            samples[0] = std::numeric_limits<float>::quiet_NaN();
+            samples[1] = std::numeric_limits<float>::infinity();
+        }
+
         if (emitsMidi) {
             midi.clear();
             midi.addEvent(juce::MidiMessage::noteOn(1, 64, 1.0f), 0);
@@ -396,6 +406,9 @@ class StubPlugin final : public juce::AudioPluginInstance {
     int preparedBlockSize = 0;
     int prepareCount = 0;
     bool nonRealtimeAtPrepare = false;
+
+    /// Whether this block's output carries a NaN and an infinity (#2240).
+    bool writesNonFinite = false;
 
     int channelsSeen = 0;
     int samplesSeen = 0;
@@ -3098,4 +3111,57 @@ TEST_CASE("Two captures of one device do not overlap", "[engine][external][contr
 
     CHECK(taken == 4);
     CHECK(mostAtOnce == 1);
+}
+
+TEST_CASE("A plugin's NaN and infinity never leave the device", "[engine][external][2240]") {
+    auto plugin = std::make_unique<StubPlugin>();
+    auto* raw = plugin.get();
+    raw->writesNonFinite = true;
+
+    adapter::EngineExternalDevice device(std::move(plugin), externalDevice(), false);
+    const auto context = contextFor();
+    device.prepare(context);
+
+    ParamArena arena({0.0f, 1.0f, 1.0f, 0.0f});
+    Block block(context, 2);
+    block.fill(0.5f);
+
+    auto deviceBlock = block.deviceBlock(arena.params(context.maxBlockSize));
+    device.process(deviceBlock);
+
+    // Cleared rather than clamped. A NaN is not a level to be managed: it
+    // survives every gain, poisons every sum it reaches, and the track stays
+    // broken after the plugin that made it has been bypassed.
+    CHECK(block.buffer.getSample(0, 0) == 0.0f);
+    CHECK(block.buffer.getSample(0, 1) == 0.0f);
+
+    for (int channel = 0; channel < block.buffer.getNumChannels(); ++channel)
+        for (int sample = 0; sample < block.buffer.getNumSamples(); ++sample) {
+            INFO("channel " << channel << " sample " << sample);
+            REQUIRE(std::isfinite(block.buffer.getSample(channel, sample)));
+        }
+}
+
+TEST_CASE("The dry signal survives a plugin that produced nothing usable",
+          "[engine][external][2240]") {
+    auto plugin = std::make_unique<StubPlugin>();
+    auto* raw = plugin.get();
+    raw->writesNonFinite = true;
+
+    adapter::EngineExternalDevice device(std::move(plugin), externalDevice(), false);
+    const auto context = contextFor();
+    device.prepare(context);
+
+    // Half dry, half wet: the wet side of these two samples is gone and the dry
+    // side is what the slot was handed, which is the whole point of clearing
+    // before the dry is added back rather than after.
+    ParamArena arena({0.5f, 0.5f, 1.0f, 0.0f});
+    Block block(context, 2);
+    block.fill(0.5f);
+
+    auto deviceBlock = block.deviceBlock(arena.params(context.maxBlockSize));
+    device.process(deviceBlock);
+
+    CHECK(block.buffer.getSample(0, 0) == Catch::Approx(0.25f));
+    CHECK(block.buffer.getSample(0, 1) == Catch::Approx(0.25f));
 }

--- a/tests/engine/test_render_denormals.cpp
+++ b/tests/engine/test_render_denormals.cpp
@@ -1,0 +1,180 @@
+#include <catch2/catch_test_macros.hpp>
+#include <limits>
+#include <memory>
+
+#include "NullDiffGain.hpp"
+#include "core/TrackInfo.hpp"
+#include "exec/ParallelPlanExecutor.hpp"
+#include "exec/PlanExecutor.hpp"
+#include "exec/RenderThreadPool.hpp"
+#include "plan/PlanCompiler.hpp"
+
+/**
+ * @file test_render_denormals.cpp
+ * @brief Flush-to-zero is on wherever a block is rendered (#2240).
+ *
+ * A device that feeds its own output back through a filter decays into the
+ * denormal range and stays there, where on Intel every multiply is a microcode
+ * trap and a reverb tail is where a dropout comes from. The mode is a per-thread
+ * CPU flag, so it has to be set on every thread that renders rather than once at
+ * startup: the audio callback's, the offline render's, and each of the pool's.
+ *
+ * Asserted from inside a device, because that is where the arithmetic the mode
+ * exists for actually happens.
+ */
+
+using namespace magda::engine;
+
+namespace {
+
+constexpr int kBlockSize = 512;
+
+/**
+ * @brief A denormal multiplied here and now, and what came back.
+ *
+ * Through volatile, so the compiler cannot fold it into a constant that never
+ * met the CPU's flush-to-zero bit: a folded answer is the same on every thread
+ * and would make this file pass without the mode being set anywhere.
+ */
+float multiplyDenormal() {
+    volatile float tiny = std::numeric_limits<float>::denorm_min();
+    volatile float one = 1.0f;
+    return tiny * one;
+}
+
+/// Records, from inside the render, what a denormal multiply came to.
+class DenormalProbe final : public EngineDevice {
+  public:
+    void process(DeviceBlock&) override {
+        product = multiplyDenormal();
+        rendered = true;
+    }
+
+    void setMidiInputBoundBytes(int) override {}
+    void setMidiOutputBoundBytes(int) override {}
+
+    bool forwardsMidiInput() const override {
+        return false;
+    }
+
+    float product = std::numeric_limits<float>::quiet_NaN();
+    bool rendered = false;
+};
+
+/// One track carrying one device, feeding the master.
+RenderPlan planWithDevice(magda::DeviceId device) {
+    magda::TrackInfo track;
+    track.id = 1;
+    track.type = magda::TrackType::Media;
+    track.name = "Track";
+    track.chain.fxChainElements.emplace_back(magda::nulldiff::gainDevice(device));
+
+    magda::TrackInfo master;
+    master.id = magda::MASTER_TRACK_ID;
+    master.type = magda::TrackType::Master;
+    master.name = "Master";
+
+    return compileRenderPlan({track}, master);
+}
+
+PlanBindings bindingsFor(const RenderPlan& plan, EngineDevice& probe) {
+    PlanBindings bindings;
+    for (const auto& op : plan.ops)
+        if (op.kind == OpKind::Device)
+            bindings.devices[op.key.deviceKey()] = &probe;
+
+    return bindings;
+}
+
+PlanValues valuesFor(const RenderPlan& plan) {
+    PlanValues values;
+    values.planFingerprint = planFingerprint(plan);
+    values.ops.assign(plan.ops.size(), kUnityValue);
+    return values;
+}
+
+/// Prepare, reporting whatever it says. A plan with no clip source bound
+/// renders silence and says so, which is what this file wants: the device is
+/// the point and there is nothing for it to be fed.
+template <typename Executor>
+void prepared(Executor& executor, const RenderPlan& plan, PlanBindings& bindings) {
+    for (const auto& message :
+         executor.prepare(plan, bindings, RenderContext{44100.0, kBlockSize, 2}))
+        UNSCOPED_INFO("prepare: " << message);
+
+    REQUIRE(executor.isPrepared());
+}
+
+BlockInfo oneBlock() {
+    BlockInfo block;
+    block.numSamples = kBlockSize;
+    block.playing = true;
+    block.continuous = true;
+    return block;
+}
+
+}  // namespace
+
+TEST_CASE("A device renders with flush-to-zero on", "[engine][render][denormals][2240]") {
+    // Without the mode this is denorm_min, which is what a filter tail decays
+    // into and where the multiplies stop being free.
+    REQUIRE(multiplyDenormal() > 0.0f);
+
+    const auto plan = planWithDevice(10);
+
+    DenormalProbe probe;
+    auto bindings = bindingsFor(plan, probe);
+    auto values = valuesFor(plan);
+
+    PlanExecutor executor;
+    prepared(executor, plan, bindings);
+
+    juce::AudioBuffer<float> output(2, kBlockSize);
+    output.clear();
+    executor.process(values, oneBlock(), output);
+
+    REQUIRE(probe.rendered);
+    CHECK(probe.product == 0.0f);
+}
+
+TEST_CASE("A device rendered on a pool thread has it too", "[engine][render][denormals][2240]") {
+    const auto plan = planWithDevice(11);
+
+    DenormalProbe probe;
+    auto bindings = bindingsFor(plan, probe);
+    auto values = valuesFor(plan);
+
+    // The workers set their own, since the flag belongs to the thread and the
+    // executor's caller is not the one running the op.
+    RenderThreadPool pool(2, false);
+    ParallelPlanExecutor executor(&pool);
+    prepared(executor, plan, bindings);
+
+    juce::AudioBuffer<float> output(2, kBlockSize);
+    output.clear();
+    executor.process(values, oneBlock(), output);
+
+    REQUIRE(probe.rendered);
+    CHECK(probe.product == 0.0f);
+}
+
+TEST_CASE("The mode does not outlive the block it was set for",
+          "[engine][render][denormals][2240]") {
+    const auto plan = planWithDevice(12);
+
+    DenormalProbe probe;
+    auto bindings = bindingsFor(plan, probe);
+    auto values = valuesFor(plan);
+
+    PlanExecutor executor;
+    prepared(executor, plan, bindings);
+
+    juce::AudioBuffer<float> output(2, kBlockSize);
+    output.clear();
+    executor.process(values, oneBlock(), output);
+
+    // Scoped rather than set once: the host's thread is not the engine's to
+    // leave in a mode it did not ask for, and an offline render runs on a
+    // thread that goes on to do other things.
+    CHECK(multiplyDenormal() > 0.0f);
+}

--- a/tests/engine/test_render_denormals.cpp
+++ b/tests/engine/test_render_denormals.cpp
@@ -1,6 +1,11 @@
 #include <catch2/catch_test_macros.hpp>
+#include <chrono>
+#include <condition_variable>
 #include <limits>
 #include <memory>
+#include <mutex>
+#include <thread>
+#include <vector>
 
 #include "NullDiffGain.hpp"
 #include "core/TrackInfo.hpp"
@@ -61,20 +66,82 @@ class DenormalProbe final : public EngineDevice {
     bool rendered = false;
 };
 
-/// One track carrying one device, feeding the master.
-RenderPlan planWithDevice(magda::DeviceId device) {
-    magda::TrackInfo track;
-    track.id = 1;
-    track.type = magda::TrackType::Media;
-    track.name = "Track";
-    track.chain.fxChainElements.emplace_back(magda::nulldiff::gainDevice(device));
+/**
+ * @brief Two devices that stay inside process() until both are.
+ *
+ * The pool's caller takes work as well as waking the workers
+ * (RenderThreadPool::render), so a plan with one device is usually rendered by
+ * the thread that asked for it, under the executor's own guard. One op cannot
+ * prove a worker set anything. Two that have to overlap can, because one thread
+ * cannot be inside both.
+ *
+ * Blocking inside process() is a thing no real device may do. It is safe here
+ * for the reason it is safe in test_parallel_executor.cpp: the branches are
+ * independent, and the wait times out rather than hanging.
+ */
+struct Meeting {
+    std::mutex mutex;
+    std::condition_variable arrived;
+    int inside = 0;
+    bool met = false;
+};
+
+/// Records the thread it ran on and what a denormal came to there.
+class RendezvousProbe final : public EngineDevice {
+  public:
+    explicit RendezvousProbe(Meeting& meeting) : meeting_(meeting) {}
+
+    void process(DeviceBlock&) override {
+        product = multiplyDenormal();
+        thread = std::this_thread::get_id();
+
+        std::unique_lock<std::mutex> lock(meeting_.mutex);
+        if (++meeting_.inside >= 2) {
+            meeting_.met = true;
+            meeting_.arrived.notify_all();
+        } else {
+            meeting_.arrived.wait_for(lock, std::chrono::seconds(2),
+                                      [this] { return meeting_.met; });
+        }
+        --meeting_.inside;
+    }
+
+    void setMidiInputBoundBytes(int) override {}
+    void setMidiOutputBoundBytes(int) override {}
+
+    bool forwardsMidiInput() const override {
+        return false;
+    }
+
+    float product = std::numeric_limits<float>::quiet_NaN();
+    std::thread::id thread;
+
+  private:
+    Meeting& meeting_;
+};
+
+/// One track per device, each feeding the master.
+RenderPlan planWithDevices(const std::vector<magda::DeviceId>& devices) {
+    std::vector<magda::TrackInfo> tracks;
+    for (std::size_t at = 0; at < devices.size(); ++at) {
+        magda::TrackInfo track;
+        track.id = static_cast<magda::TrackId>(at + 1);
+        track.type = magda::TrackType::Media;
+        track.name = "Track " + juce::String(track.id);
+        track.chain.fxChainElements.emplace_back(magda::nulldiff::gainDevice(devices[at]));
+        tracks.push_back(std::move(track));
+    }
 
     magda::TrackInfo master;
     master.id = magda::MASTER_TRACK_ID;
     master.type = magda::TrackType::Master;
     master.name = "Master";
 
-    return compileRenderPlan({track}, master);
+    return compileRenderPlan(tracks, master);
+}
+
+RenderPlan planWithDevice(magda::DeviceId device) {
+    return planWithDevices({device});
 }
 
 PlanBindings bindingsFor(const RenderPlan& plan, EngineDevice& probe) {
@@ -138,15 +205,22 @@ TEST_CASE("A device renders with flush-to-zero on", "[engine][render][denormals]
 }
 
 TEST_CASE("A device rendered on a pool thread has it too", "[engine][render][denormals][2240]") {
-    const auto plan = planWithDevice(11);
+    const auto plan = planWithDevices({11, 12});
 
-    DenormalProbe probe;
-    auto bindings = bindingsFor(plan, probe);
+    Meeting meeting;
+    RendezvousProbe first(meeting);
+    RendezvousProbe second(meeting);
+
+    PlanBindings bindings;
+    for (const auto& op : plan.ops)
+        if (op.kind == OpKind::Device)
+            bindings.devices[op.key.deviceKey()] = op.key.deviceId == 11
+                                                       ? static_cast<EngineDevice*>(&first)
+                                                       : static_cast<EngineDevice*>(&second);
+
     auto values = valuesFor(plan);
 
-    // The workers set their own, since the flag belongs to the thread and the
-    // executor's caller is not the one running the op.
-    RenderThreadPool pool(2, false);
+    RenderThreadPool pool(3, false);
     ParallelPlanExecutor executor(&pool);
     prepared(executor, plan, bindings);
 
@@ -154,8 +228,16 @@ TEST_CASE("A device rendered on a pool thread has it too", "[engine][render][den
     output.clear();
     executor.process(values, oneBlock(), output);
 
-    REQUIRE(probe.rendered);
-    CHECK(probe.product == 0.0f);
+    // Both were inside process() at once, so one thread cannot have run them:
+    // at least one is a worker, and it set its own mode rather than inheriting
+    // the caller's.
+    REQUIRE(meeting.met);
+    REQUIRE(first.thread != second.thread);
+    CHECK((first.thread != std::this_thread::get_id() ||
+           second.thread != std::this_thread::get_id()));
+
+    CHECK(first.product == 0.0f);
+    CHECK(second.product == 0.0f);
 }
 
 TEST_CASE("The mode does not outlive the block it was set for",


### PR DESCRIPTION
Closes #2240.

## The gap

The native engine had no denormal handling anywhere: no flush-to-zero around a render, and nothing looking at what an op wrote. A device feeding its own output back through a filter decays into the denormal range and stays there, where on Intel every multiply is a microcode trap and a reverb tail is where a dropout comes from.

## Flush-to-zero

A per-thread CPU mode, so it is set on every thread that renders rather than once at startup:

- `PlanExecutor::process` and `ParallelPlanExecutor::process`, which between them cover the audio callback and the offline render.
- `RenderThreadPool::Worker::run`, once for the worker's whole life, since a worker does nothing but render.

Scoped rather than left on: the host's thread is not the engine's to hand back in a mode it did not ask for, and an offline render runs on a thread that goes on to do other things. There is a case for that too.

## The sanitising half, which is not the fork's rule

#2240 asked for this to be a decision rather than a transcription, so: a plugin's output is checked for values that are not numbers, and those are cleared. Before the dry signal is added back, so a plugin that produced nothing usable leaves the dry rather than poisoning it.

The fork instead clamps to a magnitude of 100, and only looks at all when the CPU raised its denormal flag during the call, on Intel. Both halves of that are wrong for what this guards against:

- **The gate is for denormals.** It says nothing about a NaN, so the fork's protection misses the case entirely on any plugin that does not also denormalise, and misses it on Apple silicon regardless.
- **The clamp treats it as a level.** A NaN is not one: it survives every gain, poisons every sum it reaches, and the track stays broken after the plugin that made it has been bypassed. An infinity does the same on the first multiply by zero. 100 is a number nothing derives, and +40 dBFS protects no speaker.

That is a declared divergence from the incumbent, and it is written down where the code is.

## Tests

`tests/engine/test_render_denormals.cpp` asserts the mode from inside a device, which is where the arithmetic it exists for happens: on the calling thread, on a pool thread, and off again after the block. The denormal is multiplied through `volatile` so the compiler cannot fold it into a constant that never met the CPU flag.

Two cases in `test_engine_external_device.cpp` cover a plugin that writes a NaN and an infinity: nothing non-finite leaves the device, and with the wrapper pair half dry, the dry signal is what those samples come back as.

Reverting either half fails its own cases. Full suite: 3651 passed, 13 skipped.

https://claude.ai/code/session_013A1GWqAoLZPdkYAMwKrjQj