### PR TITLE
Null a launched session slot against the fork

### DIFF
--- a/magda/engine/exec/OfflineRender.cpp
+++ b/magda/engine/exec/OfflineRender.cpp
@@ -4,6 +4,7 @@
 #include <cmath>
 
 #include "clip/ClipVoicePool.hpp"
+#include "launch/SessionLauncher.hpp"
 #include "transport/TransportState.hpp"
 
 namespace magda::engine {
@@ -93,7 +94,7 @@ class LatencyTrimmedSink final : public OfflineRenderSink {
 OfflineRenderResult renderOffline(PlanExecutor& executor, const PlanValues& values,
                                   const RenderContext& context, const TempoMap& tempo,
                                   const OfflineRenderRequest& request, OfflineRenderSink& sink,
-                                  ClipVoicePool* voices,
+                                  ClipVoicePool* voices, const OfflineLauncher& launcher,
                                   const std::function<bool()>& shouldContinue) {
     OfflineRenderResult result;
 
@@ -195,6 +196,13 @@ OfflineRenderResult renderOffline(PlanExecutor& executor, const PlanValues& valu
                     voices->service();
                     voices->fillNow();
                 }
+
+                // Before the plan and over every handle, which is where playback
+                // puts it (EngineSession.cpp): a handle sees each block exactly
+                // once, and a slot's audio and MIDI sources both read what this
+                // decided.
+                if (launcher.present())
+                    advanceLaunchHandles(*launcher.handles, *launcher.requests, segment.block);
 
                 executor.process(values, segment.block, piece);
             }

--- a/magda/engine/exec/OfflineRender.hpp
+++ b/magda/engine/exec/OfflineRender.hpp
@@ -33,6 +33,29 @@ namespace magda::engine {
 /// not take a prefetch thread and a stream pool with it.
 class ClipVoicePool;
 
+/// The launcher's two halves, named for the same reason.
+class LaunchHandleFeed;
+class LaunchRequestQueue;
+
+/**
+ * @brief The launcher a render drives, for one whose session slots sound (#2441).
+ *
+ * Both or neither. A table nothing can ask of never launches anything, and a
+ * queue with no table has nothing to apply a launch to, so a render given one
+ * half would render an arrangement and say it had a session.
+ *
+ * Absent for a bounce, which is what every render was until now: the session is
+ * not what a bounce prints.
+ */
+struct OfflineLauncher {
+    LaunchHandleFeed* handles = nullptr;
+    LaunchRequestQueue* requests = nullptr;
+
+    bool present() const {
+        return handles != nullptr && requests != nullptr;
+    }
+};
+
 /** What to render, and how much of the machine to hand it. */
 struct OfflineRenderRequest {
     /// The stretch of timeline to render, in beats, half-open. Beats because
@@ -130,6 +153,11 @@ class OfflineRenderSink {
  * it. Two things provisioning one pool is a race over which readers exist,
  * which is what the pool's own threading contract already says.
  *
+ * @p launcher is what makes a session slot sound. Its handles are advanced
+ * before the plan on every block, which is where playback advances them
+ * (EngineSession.cpp) and the only place they can be: a handle must see each
+ * block exactly once and a slot's two sources both read it.
+ *
  * @p shouldContinue is asked once per block and may be empty. A render of a
  * long range is the one thing in the engine a user is left waiting for, so it
  * is interruptible from the start rather than once someone complains.
@@ -141,6 +169,7 @@ OfflineRenderResult renderOffline(PlanExecutor& executor, const PlanValues& valu
                                   const RenderContext& context, const TempoMap& tempo,
                                   const OfflineRenderRequest& request, OfflineRenderSink& sink,
                                   ClipVoicePool* voices = nullptr,
+                                  const OfflineLauncher& launcher = {},
                                   const std::function<bool()>& shouldContinue = {});
 
 }  // namespace magda::engine

--- a/tests/DawProjectRoundTrip.cpp
+++ b/tests/DawProjectRoundTrip.cpp
@@ -605,6 +605,12 @@ const std::map<std::string, std::vector<Loss>>& lossTable() {
         {"midi.mpe", {internalDevices(), controllers()}},
         {"midi.fold", {internalDevices(), groove()}},
         {"midi.offset", {internalDevices()}},
+        // The session cases (#2441). The slot itself makes the trip -- the
+        // format has scenes and clip slots, and the clip comes back in the
+        // right one with its notes and its length -- so the only declaration
+        // either of them needs is the one every instrument track in the corpus
+        // needs, and the audio one has no chain to lose.
+        {"session.launch.midi", {internalDevices()}},
     };
 
     return table;

--- a/tests/NullDiffCase.hpp
+++ b/tests/NullDiffCase.hpp
@@ -47,6 +47,39 @@ struct TempoPoint {
     double bpm = 120.0;
 };
 
+/**
+ * @brief A slot this case launches, and the beat both legs launch it on (#2441).
+ *
+ * The corpus renders an offline arrangement and neither leg has anything that
+ * launches by itself, so a session clip put in a case sounds on neither side
+ * until something says this. Both legs queue it before the render, against the
+ * same beat, which is what makes the two runs start on one sample rather than
+ * on whichever moment each engine happened to begin at.
+ *
+ * No quantization, and that is not an omission. Quantization is the host's:
+ * MAGDA resolves a clip's LaunchQuantize into a beat and hands the engine that
+ * beat (ClipSynchronizer::launchSessionClip), and the native side's requests
+ * carry a beat for the same reason. What a case declares is therefore the beat
+ * a launch was already resolved to, and where the grid put it is #2306's to
+ * assert rather than this corpus's to null.
+ */
+struct LaunchInfo {
+    TrackId trackId = INVALID_TRACK_ID;
+    int sceneIndex = 0;
+
+    /// The timeline beat to start the run on.
+    ///
+    /// Both engines take a launch inside a block on the sample its beat falls
+    /// on, and they round to it differently -- the engine floors the offset it
+    /// derives through the tempo map, the fork rounds the beat's proportion of
+    /// the block. So a case that wants a null puts the launch on the render's
+    /// own start beat, where the answer is sample zero on both sides and every
+    /// block after it is the ordinary clip render #2306 says it is. The field
+    /// is a beat rather than a flag because the difference above is a finding
+    /// to pin, and pinning it needs a case that can ask for one.
+    double beat = 0.0;
+};
+
 /// What a case wrote to disk and told the source pool about. Carried on the
 /// case so that a leg never has to probe a file to find out what it is.
 struct SourceFact {
@@ -110,6 +143,11 @@ struct Case {
     std::vector<ClipInfo> clips;
     std::vector<SourceFact> sources;
     std::vector<TempoPoint> tempo{{0.0, 120.0}};
+
+    /// The slots this case launches, in the order it wants them asked for.
+    /// Empty for every case that renders an arrangement, which is all of them
+    /// but the session ones.
+    std::vector<LaunchInfo> launches;
 
     /// The automation the project plays, and the clips a clip-based lane names
     /// (#2123). Model values like the rest of a case: both legs are handed the

--- a/tests/NullDiffCorpus.cpp
+++ b/tests/NullDiffCorpus.cpp
@@ -522,6 +522,26 @@ ClipInfo midiClip(ClipId id, double startBeat, double lengthBeats) {
     return midiClipOn(kTrack, id, startBeat, lengthBeats);
 }
 
+/// The same clip, in a slot rather than on the timeline (#2441).
+///
+/// A slot has no beat: the compiler normalises the placement away and compiles
+/// it from the origin, and the fork's ClipOwner sets a slot clip's start to zero
+/// when it is inserted. What survives is the length, the scene, and everything
+/// the clip itself is made of.
+ClipInfo inSlot(ClipInfo clip, int sceneIndex) {
+    clip.view = ClipView::Session;
+    clip.sceneIndex = sceneIndex;
+    return clip;
+}
+
+/// @p track, with its session in front of its arrangement. The model's
+/// TrackPlaybackMode, which the incumbent syncs to the fork's playSlotClips and
+/// the engine expresses as the section hold a launched handle takes (#2302).
+TrackInfo launching(TrackInfo track) {
+    track.playbackMode = TrackPlaybackMode::Session;
+    return track;
+}
+
 MidiNote note(int pitch, double startBeat, double lengthBeats, int velocity = 100) {
     MidiNote value;
     value.noteNumber = pitch;
@@ -2358,6 +2378,78 @@ std::vector<Case> buildCorpus(const juce::File& scratchDirectory) {
         value.mechanism =
             "the fork's arranger path drops midiOffset on an unlooped clip while its session "
             "path applies it; the engine applies it either way";
+
+        corpus.push_back(std::move(value));
+    }
+
+    // --- the session -----------------------------------------------------------
+    //
+    // The first cases in the corpus whose material is in a slot rather than on
+    // the timeline (#2441). Both legs are handed the same launch and queue it
+    // before the render, in monotonic beats, which begin at zero on the render's
+    // first block on both sides -- so the two runs start on one sample rather
+    // than on whichever moment each engine happened to begin at.
+    //
+    // Launched on the render's own start beat and over a slot longer than the
+    // render, so neither end of a run is in these. What a launch inside a block
+    // rounds to and what happens when a run ends are #2306's, which asserts
+    // them; these null what #2306 calls the ordinary clip render in between.
+
+    {
+        auto value = newCase("session.launch", "an audio slot playing from the first sample",
+                             launching(plainTrack()));
+        value.endBeat = 8.0;
+
+        // A tone, whose file is windowed at both ends, so the slot's first
+        // sample is silence. Both engines take a step out of a launched clip's
+        // first samples and only one of them asks first whether there is a step
+        // to take: the fork's SlotControlNode de-clicks whatever the block
+        // begins with, while the engine leaves a voice that begins at its own
+        // start alone, on the grounds that what looks like a step there is the
+        // material's own attack (ClipVoice.cpp). Impulses put a full-scale
+        // transient on exactly that sample, so an impulse case here would be
+        // measuring the launch instant, which #2306 asserts and this does not.
+        //
+        // Nothing interpolates between the two at one rate and ratio one, so the
+        // ordinary floor still applies: the tone is here for what its first
+        // sample is, not for what an interpolator would do to it.
+        const auto source = writeSource(scratchDirectory, "session", tone());
+        value.sources.push_back(source);
+
+        // Sixteen beats against an eight-beat render, so the run never reaches
+        // its own end inside the case.
+        value.clips.push_back(inSlot(audioClip(400, 0.0, 16.0, source), 0));
+        value.launches.push_back(LaunchInfo{kTrack, 0, 0.0});
+
+        corpus.push_back(std::move(value));
+    }
+
+    {
+        auto value = newCase("session.launch.midi", "a MIDI slot playing from the first sample",
+                             launching(instrumentTrack()));
+        value.endBeat = 8.0;
+
+        auto clip = midiClip(410, 0.0, 16.0);
+        for (auto index = 0; index < 8; ++index)
+            clip.midiNotes.push_back(
+                note(60 + index, static_cast<double>(index), 0.5, 40 + index * 10));
+        value.clips.push_back(inSlot(std::move(clip), 0));
+        value.launches.push_back(LaunchInfo{kTrack, 0, 0.0});
+
+        value.tier = AudioTier::None;
+        value.compareMidiStreams = true;
+
+        // The fork's launcher path does not make the nudge its arranger path
+        // makes. MidiNote::getPlaybackTime pulls every note-off back by a tenth
+        // of a millisecond to keep an off ahead of an on at the same instant,
+        // and that is what the corpus's default allows for; a clip played from
+        // a slot reaches the graph through LoopingMidiNode and keeps the length
+        // the note was drawn at, which is what the engine does everywhere.
+        //
+        // Declared as the zero it is rather than left at the corpus default, so
+        // the case is asserting that the two agree exactly rather than
+        // forgiving four samples of whatever.
+        value.incumbentNoteEndEarlySeconds = 0.0;
 
         corpus.push_back(std::move(value));
     }

--- a/tests/NullDiffCorpus.cpp
+++ b/tests/NullDiffCorpus.cpp
@@ -2409,6 +2409,7 @@ std::vector<Case> buildCorpus(const juce::File& scratchDirectory) {
         // material's own attack (ClipVoice.cpp). Impulses put a full-scale
         // transient on exactly that sample, so an impulse case here would be
         // measuring the launch instant, which #2306 asserts and this does not.
+        // The difference itself is #2444.
         //
         // Nothing interpolates between the two at one rate and ratio one, so the
         // ordinary floor still applies: the tone is here for what its first

--- a/tests/NullDiffNativeLeg.cpp
+++ b/tests/NullDiffNativeLeg.cpp
@@ -18,6 +18,7 @@
 #include "exec/PlanExecutor.hpp"
 #include "exec/PlanValues.hpp"
 #include "io/PrefetchThread.hpp"
+#include "launch/SessionLauncher.hpp"
 #include "magda/daw/audio/plugin_manager/ExternalPluginState.hpp"
 #include "magda/daw/audio/plugins/engine/EngineDeviceFactory.hpp"
 #include "magda/daw/core/ChainWalk.hpp"
@@ -448,28 +449,24 @@ NativeRender renderNative(const Case& value, const InstalledPlugins& installed) 
             if (clip.trackId != track.id)
                 continue;
 
-            // The arrangement's clips, which is what an arrangement lane is.
-            // Filtered here rather than left to the compiler's own guard,
-            // because the two are answering different questions: the guard
-            // exists so that a caller who put a session clip in an arrangement
-            // lane hears about it, and this leg is the caller deciding what
-            // goes in one.
+            // Sorted into the lane it belongs to rather than left to the
+            // compiler's own guard, because the two are answering different
+            // questions: the guard exists so that a caller who put a session
+            // clip in an arrangement lane hears about it, and this leg is the
+            // caller deciding what goes in one.
             //
-            // A code-built case never had the distinction to make -- every clip
-            // in the corpus is an arrangement clip -- and a real project always
-            // does, since the session and the arrangement are two views of one
-            // project and both are saved. Without this the demo project reports
-            // sixty-four diagnostics for having a session view, and every one of
-            // them would make it unmeasurable.
+            // A session clip is a slot, positioned by scene rather than by
+            // beat, and it sounds only once something launches it (#2441). The
+            // demo project's sixty-four were dropped here until now, and were
+            // sixty-four diagnostics before that.
             //
-            // The same rule the incumbent already applies at the same point:
+            // Where the incumbent puts the same split:
             // ClipSynchronizer::syncArrangementClipToEngine refuses a session
-            // clip and the launcher schedules it instead, so an offline
-            // arrangement render plays the arrangement on both sides.
-            if (clip.view != ClipView::Arrangement)
-                continue;
-
-            lane.clips.push_back(clip);
+            // clip and syncSessionClipToSlot puts it in a te::ClipSlot.
+            if (clip.view == ClipView::Session)
+                lane.session.push_back(clip);
+            else
+                lane.clips.push_back(clip);
         }
         lanes.push_back(std::move(lane));
     }
@@ -543,8 +540,42 @@ NativeRender renderNative(const Case& value, const InstalledPlugins& installed) 
     ClipVoicePool voices(files, reader, context);
     voices.setSnapshot(snapshot);
 
+    // A handle per slot the snapshot compiled, published whole, which is what
+    // RuntimeStateStore::publishHandles does for playback (#2441). Built once
+    // and never replaced, so every incarnation is left at zero: what the number
+    // exists to catch is a slot emptied and refilled between the click and the
+    // block, and a render has no in between.
+    std::map<SlotKey, std::unique_ptr<LaunchHandle>> handleStore;
+    auto handleTable = std::make_shared<LaunchHandleTable>();
+
+    for (const auto& track : snapshot->tracks)
+        for (const auto& slot : track.session) {
+            const SlotKey key{track.trackId, slot.sceneIndex};
+            auto& handle = handleStore[key];
+            handle = std::make_unique<LaunchHandle>();
+            handleTable->entries.push_back(LaunchHandleTable::Entry{
+                .key = key, .handle = handle.get(), .follow = slot.follow});
+        }
+
+    // The audio thread's binary search depends on it, and the snapshot already
+    // arrives in this order.
+    std::sort(handleTable->entries.begin(), handleTable->entries.end(),
+              [](const auto& a, const auto& b) { return a.key < b.key; });
+
+    // Whether this case has a session at all, which decides how the
+    // arrangement's sources are built below. An empty table renders the same
+    // arrangement either way (sectionHold over no entries is the whole block),
+    // so this leaves a case without one on the path it has always taken.
+    const auto hasSession = !handleTable->entries.empty();
+
+    LaunchHandleFeed handles;
+    LaunchRequestQueue requests;
+    handles.publish(handleTable);
+
     std::map<TrackId, std::unique_ptr<ClipAudioSource>> audioSources;
     std::map<TrackId, std::unique_ptr<ClipMidiSource>> midiSources;
+    std::map<TrackId, std::unique_ptr<ClipAudioSource>> sessionAudioSources;
+    std::map<TrackId, std::unique_ptr<ClipMidiSource>> sessionMidiSources;
     std::vector<std::unique_ptr<Passthrough>> passthroughs;
 
     // The devices the app's own factory built, kept alive for the render. One
@@ -571,9 +602,16 @@ NativeRender renderNative(const Case& value, const InstalledPlugins& installed) 
 
     for (const auto& op : plan.ops) {
         switch (op.kind) {
+            // A track's arrangement source reads the handles too, so that it
+            // knows the block a slot took the track off it and where in that
+            // block it happened (#2302). Only where there is a session to take
+            // it: a case with no slots is the render it always was.
             case OpKind::ClipAudio: {
                 auto source =
-                    std::make_unique<ClipAudioSource>(op.key.trackId, clips, voices.feed());
+                    hasSession
+                        ? std::make_unique<ClipAudioSource>(op.key.trackId, clips, voices.feed(),
+                                                            handles, Section::Arrangement)
+                        : std::make_unique<ClipAudioSource>(op.key.trackId, clips, voices.feed());
                 source->prepare(context);
                 bindings.clipAudio[op.key.trackId] = source.get();
                 audioSources[op.key.trackId] = std::move(source);
@@ -581,10 +619,41 @@ NativeRender renderNative(const Case& value, const InstalledPlugins& installed) 
             }
 
             case OpKind::ClipMidi: {
-                auto source = std::make_unique<ClipMidiSource>(op.key.trackId, clips);
+                auto source = hasSession ? std::make_unique<ClipMidiSource>(
+                                               op.key.trackId, clips, handles, Section::Arrangement)
+                                         : std::make_unique<ClipMidiSource>(op.key.trackId, clips);
                 source->prepare(context);
                 bindings.clipMidi[op.key.trackId] = source.get();
                 midiSources[op.key.trackId] = std::move(source);
+                break;
+            }
+
+            // The session's two, bound only for a case that has one. The plan
+            // emits these for every clip-carrying track whether or not the
+            // project has a session, and the executor reports an unbound
+            // session op only when something else bound one, so a case with no
+            // slots binds none of them and says nothing (PlanExecutor.cpp).
+            case OpKind::SessionAudio: {
+                if (!hasSession)
+                    break;
+
+                auto source = std::make_unique<ClipAudioSource>(
+                    op.key.trackId, clips, voices.feed(), handles, Section::Session);
+                source->prepare(context);
+                bindings.sessionAudio[op.key.trackId] = source.get();
+                sessionAudioSources[op.key.trackId] = std::move(source);
+                break;
+            }
+
+            case OpKind::SessionMidi: {
+                if (!hasSession)
+                    break;
+
+                auto source = std::make_unique<ClipMidiSource>(op.key.trackId, clips, handles,
+                                                               Section::Session);
+                source->prepare(context);
+                bindings.sessionMidi[op.key.trackId] = source.get();
+                sessionMidiSources[op.key.trackId] = std::move(source);
                 break;
             }
 
@@ -752,13 +821,28 @@ NativeRender renderNative(const Case& value, const InstalledPlugins& installed) 
                     result.primingSamples = std::max(result.primingSamples, entry.preRollSamples);
     }
 
+    // What the case asked to launch, queued before the first block rather than
+    // driven during the render (#2441).
+    //
+    // In monotonic beats, which start at zero on the render's first block: the
+    // clock accumulates the beats it has rolled and the locate never enters
+    // them (TransportClock.cpp). A render has no pre-roll to count, which the
+    // fork's does -- the incumbent leg's launch works out its own origin.
+    if (!value.launches.empty()) {
+        LaunchRequestQueue::Gesture gesture(requests);
+        for (const auto& launch : value.launches)
+            gesture.play(SlotKey{launch.trackId, launch.sceneIndex}, launch.beat - value.startBeat);
+    }
+
     OfflineRenderRequest request;
     request.startBeat = value.startBeat;
     request.endBeat = value.endBeat;
     request.blockSize = value.blockSize;
 
     BufferSink sink(value.channels);
-    const auto rendered = renderOffline(executor, values, context, tempo, request, sink, &voices);
+    const auto rendered = renderOffline(
+        executor, values, context, tempo, request, sink, &voices,
+        OfflineLauncher{hasSession ? &handles : nullptr, hasSession ? &requests : nullptr});
 
     if (rendered.refused) {
         result.failure = "the offline render refused the plan it was given";
@@ -771,7 +855,11 @@ NativeRender renderNative(const Case& value, const InstalledPlugins& installed) 
     // that every entry it provisioned has been through it.
     for (const auto& [trackId, source] : audioSources)
         result.starvedVoices += source->starvedVoices();
+    for (const auto& [trackId, source] : sessionAudioSources)
+        result.starvedVoices += source->starvedVoices();
     for (const auto& [trackId, source] : midiSources)
+        result.droppedMidiEvents += source->droppedEvents();
+    for (const auto& [trackId, source] : sessionMidiSources)
         result.droppedMidiEvents += source->droppedEvents();
 
     // Every eligible track gets an entry, including one whose tap never fired.

--- a/tests/NullDiffTeLeg.cpp
+++ b/tests/NullDiffTeLeg.cpp
@@ -47,6 +47,17 @@ namespace {
 /// is never going to finish does not hold the suite up.
 constexpr int kProxyTimeoutMs = 20000;
 
+/// The clip in the slot @p launch names, or null for a case that asked to
+/// launch a slot it did not fill.
+const ClipInfo* sessionClipIn(const Case& value, const LaunchInfo& launch) {
+    for (const auto& clip : value.clips)
+        if (clip.view == ClipView::Session && clip.trackId == launch.trackId &&
+            clip.sceneIndex == launch.sceneIndex)
+            return &clip;
+
+    return nullptr;
+}
+
 /// Records what reaches the instrument slot. The comparison point on this side,
 /// and it has to be the same point as on the other: what a synth receives.
 ///
@@ -1046,8 +1057,24 @@ IncumbentRender renderIncumbent(const Case& value) {
     ClipManager::getInstance().clearAllClips();
     for (const auto& clip : value.clips)
         ClipManager::getInstance().restoreClip(clip);
-    for (const auto& clip : value.clips)
-        clipSync.syncClipToEngine(clip.id);
+
+    // Each clip through the sync path its view belongs to. syncClipToEngine
+    // refuses a session clip and always has -- the launcher owns those -- so a
+    // case with a session in it reached neither engine until something asked
+    // for the other path (#2441).
+    for (const auto& clip : value.clips) {
+        if (clip.view == ClipView::Session)
+            clipSync.syncSessionClipToSlot(clip.id);
+        else
+            clipSync.syncClipToEngine(clip.id);
+    }
+
+    // Whether a track's arranger still plays underneath its launcher: the
+    // model's TrackPlaybackMode, and the fork's playSlotClips. Through the app's
+    // own single writer for that property, and after the tracks are in
+    // TrackManager, which is where it reads them from.
+    for (const auto& track : value.tracks)
+        clipSync.trackPropertyChanged(static_cast<int>(track.id));
 
     // --- wait for the proxies -----------------------------------------------
 
@@ -1072,6 +1099,55 @@ IncumbentRender renderIncumbent(const Case& value) {
         edit->tempoSequence.toTime(te::BeatPosition::fromBeats(value.startBeat)).inSeconds();
     const auto endSeconds =
         edit->tempoSequence.toTime(te::BeatPosition::fromBeats(value.endBeat)).inSeconds();
+
+    // --- the launch ----------------------------------------------------------
+    //
+    // Queued before the render, in the monotonic beats a handle names a position
+    // in (#2441). Not through ClipSynchronizer::launchSessionClip, which
+    // resolves the clip's LaunchQuantize against a transport this has none of;
+    // the beat a case declares is the resolved one.
+    //
+    // Those beats do not begin at zero here. A render rolls its playhead through
+    // pre-roll before the range and ProcessState counts a monotonic beat for
+    // every block it rolls for, so the fork is already that far along when the
+    // range's first block runs, where the engine's own count starts. Launching
+    // both at zero put the fork's run 11264 samples ahead.
+    //
+    // How much of the pre-roll counts is the fork's arithmetic
+    // (tracktion_NodeRenderContext.cpp:117, 203-217): `(rate / 2) / blockSize +
+    // 1` blocks ahead of the range, with the playhead started at the halfway
+    // one. Written out rather than measured, so the day the fork changes it
+    // these cases fail and say so.
+    if (!value.launches.empty()) {
+        const auto preRollBlocks =
+            static_cast<int>((value.sampleRate / 2.0) / value.blockSize + 1.0) / 2;
+        const auto preRollSeconds =
+            static_cast<double>(preRollBlocks) * value.blockSize / value.sampleRate;
+
+        // The beats those blocks covered. Each contributed its own edit beat
+        // range and they are adjacent, so the sum telescopes to the span.
+        const auto preRollBeats =
+            edit->tempoSequence.toBeats(te::TimePosition::fromSeconds(startSeconds)).inBeats() -
+            edit->tempoSequence
+                .toBeats(te::TimePosition::fromSeconds(startSeconds - preRollSeconds))
+                .inBeats();
+
+        for (const auto& launch : value.launches) {
+            const auto* clip = sessionClipIn(value, launch);
+            auto* teClip = clip != nullptr ? clipSync.getSessionTeClip(clip->id) : nullptr;
+            auto handle = teClip != nullptr ? teClip->getLaunchHandle() : nullptr;
+
+            if (handle == nullptr) {
+                result.failure = "no launch handle for the slot the case launches";
+                ClipManager::getInstance().clearAllClips();
+                ProjectManager::getInstance().setTempo(previousTempo);
+                return result;
+            }
+
+            handle->play(te::MonotonicBeat{
+                te::BeatPosition::fromBeats(preRollBeats + (launch.beat - value.startBeat))});
+        }
+    }
 
     juce::TemporaryFile destination(".wav");
 

--- a/tests/engine/test_null_diff_corpus.cpp
+++ b/tests/engine/test_null_diff_corpus.cpp
@@ -36,7 +36,7 @@ juce::File scratch() {
 TEST_CASE("The corpus builds and covers what the slice claims", "[nulldiff][corpus]") {
     const auto corpus = sharedCorpus(scratch());
 
-    REQUIRE(corpus.size() == 70);
+    REQUIRE(corpus.size() == 72);
 
     std::set<std::string> names;
     for (const auto& value : corpus)
@@ -101,6 +101,8 @@ TEST_CASE("The corpus builds and covers what the slice claims", "[nulldiff][corp
                                  "midi.mpe",
                                  "midi.fold",
                                  "midi.offset",
+                                 "session.launch",
+                                 "session.launch.midi",
                                  "plugin.wetdry",
                                  "plugin.wetdry.dry",
                                  "plugin.mono",

--- a/tests/engine/test_offline_render.cpp
+++ b/tests/engine/test_offline_render.cpp
@@ -222,7 +222,7 @@ struct Harness {
                                               CollectingSink& sink,
                                               const std::function<bool()>& shouldContinue = {}) {
         return magda::engine::renderOffline(executor, values, context, tempo, request, sink,
-                                            nullptr, shouldContinue);
+                                            nullptr, {}, shouldContinue);
     }
 
     std::vector<TrackInfo> tracks;


### PR DESCRIPTION
Closes #2441.

The corpus rendered an offline arrangement on both legs and dropped every session clip on the way in, so no case could ask what #2306 calls most of the launcher's surface: whether two handles playing the same clip from the same beat null like an ordinary clip render.

## What was added

- `renderOffline` takes an `OfflineLauncher` and advances its handles before the plan on every block, which is where playback advances them (`EngineSession.cpp`). Absent for a bounce, which is every render there was until now.
- A `Case` declares its launches: a slot, and the beat both legs start the run on. No quantization, because that is the host's — MAGDA resolves a `LaunchQuantize` into a beat and hands the engine the beat (`ClipSynchronizer::launchSessionClip`), and the native side's requests carry a beat for the same reason.
- The native leg sorts session clips into the snapshot's session lanes, makes a handle per slot, publishes the table, binds the `SessionAudio` and `SessionMidi` ops, and queues the case's launches before the render.
- The incumbent leg syncs a session clip through `syncSessionClipToSlot`, syncs each track's playback mode through the app's own single writer for it, and plays the handle.

## What the two legs' clocks disagree about

Launching both at monotonic beat zero put the fork's run **11264 samples ahead** of the engine's. A render rolls its playhead through pre-roll before the range, and `ProcessState` counts a monotonic beat for every block the playhead rolls for, so the fork is already that far along at the block where the engine's own count starts.

The incumbent leg works its origin out from the fork's own arithmetic — `(rate / 2) / blockSize + 1` blocks of pre-roll with the playhead started at the halfway one (`tracktion_NodeRenderContext.cpp:117, 203-217`) — which comes to exactly 22 blocks of 512. Written out rather than measured, so the day the fork changes it these cases fail and say so.

## The cases

| case | verdict |
|---|---|
| `session.launch` | peak **-130.5 dB**, rms -140.9 — a null |
| `session.launch.midi` | all eight notes matched on the sample |

`session.launch.midi` declares `incumbentNoteEndEarlySeconds` as the zero it is: the fork's launcher path does not make the note-off nudge its arranger path makes, so the two agree exactly rather than by four samples of allowance.

`session.launch` plays a tone rather than impulses. The fork's `SlotControlNode` de-clicks whatever a launched block begins with, where the engine leaves a voice that begins at its own start alone, so an impulse on the launch sample would be measuring the launch instant — which #2306 asserts and this does not. The difference is filed as #2444.

Both launch on the render's own start beat and over a slot longer than the render, so neither end of a run is in scope here.

## Gates

- Block-size invariance (#2078): both hold at 64, 96, 512 and 4096, unlisted.
- DAWproject round trip: the slot itself makes the trip — scenes and clip slots are in the format, and the clip comes back in the right one with its notes and its length — so `session.launch.midi` needs only the internal-device loss every instrument track in the corpus declares, and `session.launch` has no chain to lose.
- `make test` (858k assertions) and `make test-juce` both pass.

Verified negatively: with the launcher pass dropped from the render, `session.launch` fails at -6 dB and `session.launch.midi` captures nothing on the engine side — the incumbent plays and the engine renders silence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019sKH5X6HQ8WV82QriCbmLr