### PR TITLE
Let a plan carry the chord track for playback and never for a file

### DIFF
--- a/magda/engine/plan/PlanCompiler.cpp
+++ b/magda/engine/plan/PlanCompiler.cpp
@@ -407,10 +407,11 @@ std::vector<const TrackInfo*> Compiler::computeTrackOrder() {
     for (std::size_t i = 0; i < numTracks; ++i)
         indexById[tracks_[i].id] = i;
 
-    // The chord track is a monitor-only progression lane and never renders.
+    // The chord track is a monitor lane: it sounds while somebody is listening
+    // and never reaches a file (CompileOptions::monitorTracks, #2446).
     std::vector<bool> skipped(numTracks, false);
     for (std::size_t i = 0; i < numTracks; ++i)
-        skipped[i] = tracks_[i].type == TrackType::Chord;
+        skipped[i] = !options_.monitorTracks && tracks_[i].type == TrackType::Chord;
 
     std::vector<std::vector<std::size_t>> successors(numTracks);
     std::vector<int> indegree(numTracks, 0);

--- a/magda/engine/plan/PlanCompiler.hpp
+++ b/magda/engine/plan/PlanCompiler.hpp
@@ -15,6 +15,28 @@ struct CompileOptions {
     /// Emit a level tap after each device slot, feeding the chain UI's meters.
     /// Off in golden tests that are not about metering.
     bool deviceMeters = true;
+
+    /**
+     * @brief Compile the tracks that exist to be monitored rather than kept
+     *        (#2446).
+     *
+     * The chord track is the only one today. It carries a Chord Engine and an
+     * instrument, it is routed to master, and its mute is the audition toggle
+     * the user reaches for, so it sounds during playback: a plan for playback
+     * has to carry it or audition does nothing.
+     *
+     * It must never reach a file. The app's own export says so and already
+     * excludes it by id (`MainWindowExport.cpp`), and printing a chord track
+     * into somebody's master is the kind of wrong nobody notices until the
+     * bounce is already sent.
+     *
+     * Default off, and that is the whole reason this is a compile option rather
+     * than a filter every caller applies. A bounce that forgets to ask gets a
+     * plan without the chord track, which is right; a playback path that
+     * forgets to ask loses audition, which is visible the moment somebody
+     * tries it. The two ways of being wrong are not worth the same.
+     */
+    bool monitorTracks = false;
 };
 
 /**

--- a/tests/engine/test_render_plan_compiler.cpp
+++ b/tests/engine/test_render_plan_compiler.cpp
@@ -729,14 +729,39 @@ TEST_CASE("Liveness propagates downstream from a live input", "[engine][plan][co
     CHECK(liveOf(plan.outputOps.front()));
 }
 
-TEST_CASE("The chord track is excluded from the plan", "[engine][plan][compiler]") {
+TEST_CASE("The chord track is what a plan for a file leaves out", "[engine][plan][compiler]") {
     std::vector<TrackInfo> tracks{makeTrack(1), makeTrack(9, TrackType::Chord)};
 
-    const auto plan = magda::engine::compileRenderPlan(tracks, makeMaster());
-    requireWellFormed(plan);
+    // The default, which is what a bounce compiles under. Asserted as the
+    // default rather than by asking for it: a caller that forgets to say what
+    // its plan is for must not print a chord track into somebody's master
+    // (#2446).
+    const auto bounce = magda::engine::compileRenderPlan(tracks, makeMaster());
+    requireWellFormed(bounce);
 
-    for (const auto& op : plan.ops)
+    for (const auto& op : bounce.ops)
         CHECK(op.key.trackId != 9);
+}
+
+TEST_CASE("The chord track is in a plan for playback", "[engine][plan][compiler]") {
+    std::vector<TrackInfo> tracks{makeTrack(1), makeTrack(9, TrackType::Chord)};
+
+    // Its mute is the audition toggle, so a playback plan that left it out
+    // would be a chord track that never sounds (#2446).
+    magda::engine::CompileOptions options;
+    options.monitorTracks = true;
+
+    const auto playback = magda::engine::compileRenderPlan(tracks, makeMaster(), options);
+    requireWellFormed(playback);
+
+    auto reached = false;
+    for (const auto& op : playback.ops)
+        reached = reached || op.key.trackId == 9;
+    CHECK(reached);
+
+    // And the plan is larger for it, rather than the track being named by an
+    // op the default plan already had.
+    CHECK(playback.ops.size() > magda::engine::compileRenderPlan(tracks, makeMaster()).ops.size());
 }
 
 TEST_CASE("A send cycle is broken and reported", "[engine][plan][compiler]") {


### PR DESCRIPTION
Closes #2446. Found while starting #2314, which names this work but describes it as a missing `ClipSnapshot` lane. It is not — it is one line in the plan compiler.

## What was wrong

`Compiler::computeTrackOrder` excluded chord tracks from the topological order outright, so the plan carried nothing for one: no clip ops, no device ops, no route to master.

The comment on that line stated a decision the rest of the app does not make. `TrackManager::createTrack` builds a chord track with a Chord Engine **and an instrument**, routes it to master, and seeds its `muted` flag from the chord-preview preference. That mute is the audition toggle: `TrackManager::isChordTrackMuted()` returns the chord track's own `muted`, and the Chord Engine reads it to decide whether to drop playback MIDI before it reaches the instrument. The chord track is a monitor lane that sounds, and it sounds on the fork today.

## The constraint

It must never reach a file, and the app already says so — `MainWindowExport.cpp:359` excludes it by id, "so its notes never reach the master render".

So the rule is **audible in playback, absent from a render**, and it is now `CompileOptions::monitorTracks`, defaulting to **off**.

A compile option rather than a filter every caller applies, because the two ways of getting it wrong are not worth the same:

- a bounce that forgets to ask gets a plan without the chord track — right;
- a playback path that forgets loses audition — visible the moment somebody tries it.

Printing a chord track into somebody's master is the kind of wrong nobody notices until the bounce is already sent.

## Tests

Both sides asserted, and the bounce side asserts the *default* rather than asking for it — a caller that says nothing must not print a chord track.

`make test` (858k assertions) and `make test-juce` both pass.

## Not in this change

The Chord Engine is declared a MIDI generator (`deviceType = DeviceType::MIDI`) and emits none, so the moment a chord track compiles, `ChainRoutingModel` gives it `MergeRawInputAndPluginOutput` and the plan puts a `ChainMidiMerge` behind a device that produces nothing. `deviceType` is persisted per device (`TrackSerializer.cpp:439`), so declaring it correctly is a migration rather than a one-line edit. Reopened as #2427 with the analysis, and **nothing may set `monitorTracks = true` until it lands** — which is why the default is off.

Between them these unblock #2314.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019sKH5X6HQ8WV82QriCbmLr