### PR TITLE
Declare the Chord Engine for what it is: a listener

### DIFF
--- a/magda/daw/audio/plugins/BaseDevicePack.cpp
+++ b/magda/daw/audio/plugins/BaseDevicePack.cpp
@@ -190,7 +190,8 @@ constexpr const char* kFaustInstrumentAliases[] = {"faustinstrument"};
 constexpr const char* kTracktionTags[] = {"tracktion-engine"};
 constexpr const char* kExternalInsertTags[] = {"tracktion-engine", "external-insert"};
 constexpr const char* kDrumGridTags[] = {"drum-grid"};
-constexpr const char* kChordEngineTags[] = {"chord-engine", "midi-generator"};
+// Not midi-generator: it reads the chain's MIDI and writes none (#2427).
+constexpr const char* kChordEngineTags[] = {"chord-engine"};
 constexpr const char* kArpeggiatorTags[] = {"arpeggiator", "midi-generator"};
 constexpr const char* kStrumTags[] = {"strum"};
 constexpr const char* kStepSequencerTags[] = {"step-sequencer", "midi-generator"};

--- a/magda/daw/core/LegacyDeviceAliases.cpp
+++ b/magda/daw/core/LegacyDeviceAliases.cpp
@@ -821,30 +821,55 @@ void migrateRetiredDevicesInProject(std::vector<TrackInfo>& tracks, TrackInfo* m
     });
 }
 
-bool migrateChordEngineRole(std::vector<TrackInfo>& tracks, TrackInfo* masterTrack) {
+bool normalizeChordEngineRole(DeviceInfo& device) {
+    if (!device.pluginId.equalsIgnoreCase("midichordengine"))
+        return false;
+
     auto changed = false;
 
-    // Every chain rather than the chord track's own: the device shows in the
-    // browser, so it can be dropped anywhere, racks included.
+    if (device.deviceType != DeviceType::Analysis) {
+        device.deviceType = DeviceType::Analysis;
+        changed = true;
+    }
+
+    // Set alongside the type rather than left to it: Analysis does not imply a
+    // MIDI input the way MIDI did, and the device has one.
+    if (!device.canReceiveMidi) {
+        device.canReceiveMidi = true;
+        changed = true;
+    }
+
+    return changed;
+}
+
+bool normalizeChordEngineRoleInChain(std::vector<ChainElement>& elements) {
+    auto changed = false;
+
+    // Pads and nested racks included: the device shows in the browser, so it
+    // can be dropped anywhere a device goes.
+    chain_walk::forEachDevice(elements, {}, chain_walk::Pads::Enter,
+                              [&changed](DeviceInfo& device, const ChainNodePath&) {
+                                  changed = normalizeChordEngineRole(device) || changed;
+                                  return true;
+                              });
+
+    return changed;
+}
+
+bool normalizeChordEngineRoleInRack(RackInfo& rack) {
+    auto changed = false;
+    for (auto& chain : rack.chains)
+        changed = normalizeChordEngineRoleInChain(chain.elements) || changed;
+    return changed;
+}
+
+bool normalizeChordEngineRoleInProject(std::vector<TrackInfo>& tracks, TrackInfo* masterTrack) {
+    auto changed = false;
+
     const auto fix = [&changed](TrackInfo& track) {
-        const auto visit = [&changed](DeviceInfo& device, const ChainNodePath&) {
-            if (!device.pluginId.equalsIgnoreCase("midichordengine"))
-                return true;
-
-            if (device.deviceType != DeviceType::Analysis) {
-                device.deviceType = DeviceType::Analysis;
-                changed = true;
-            }
-            if (!device.canReceiveMidi) {
-                device.canReceiveMidi = true;
-                changed = true;
-            }
-            return true;
-        };
-
-        chain_walk::forEachDevice(track.chain.fxChainElements, {}, chain_walk::Pads::Enter, visit);
+        changed = normalizeChordEngineRoleInChain(track.chain.fxChainElements) || changed;
         for (auto& postFx : track.chain.postFxChainElements)
-            visit(postFx.device, {});
+            changed = normalizeChordEngineRole(postFx.device) || changed;
     };
 
     for (auto& track : tracks)

--- a/magda/daw/core/LegacyDeviceAliases.cpp
+++ b/magda/daw/core/LegacyDeviceAliases.cpp
@@ -821,6 +821,40 @@ void migrateRetiredDevicesInProject(std::vector<TrackInfo>& tracks, TrackInfo* m
     });
 }
 
+bool migrateChordEngineRole(std::vector<TrackInfo>& tracks, TrackInfo* masterTrack) {
+    auto changed = false;
+
+    // Every chain rather than the chord track's own: the device shows in the
+    // browser, so it can be dropped anywhere, racks included.
+    const auto fix = [&changed](TrackInfo& track) {
+        const auto visit = [&changed](DeviceInfo& device, const ChainNodePath&) {
+            if (!device.pluginId.equalsIgnoreCase("midichordengine"))
+                return true;
+
+            if (device.deviceType != DeviceType::Analysis) {
+                device.deviceType = DeviceType::Analysis;
+                changed = true;
+            }
+            if (!device.canReceiveMidi) {
+                device.canReceiveMidi = true;
+                changed = true;
+            }
+            return true;
+        };
+
+        chain_walk::forEachDevice(track.chain.fxChainElements, {}, chain_walk::Pads::Enter, visit);
+        for (auto& postFx : track.chain.postFxChainElements)
+            visit(postFx.device, {});
+    };
+
+    for (auto& track : tracks)
+        fix(track);
+    if (masterTrack != nullptr)
+        fix(*masterTrack);
+
+    return changed;
+}
+
 void migrateRetiredDevicesInChain(std::vector<ChainElement>& elements) {
     migrateFragment(elements);
 }

--- a/magda/daw/core/LegacyDeviceAliases.hpp
+++ b/magda/daw/core/LegacyDeviceAliases.hpp
@@ -144,22 +144,29 @@ void migrateRetiredDevicesInChain(std::vector<ChainElement>& elements);
 void migrateRetiredDevicesInRack(RackInfo& rack);
 
 /**
- * @brief Bring the Chord Engine's declared role up to date (#2427).
+ * @brief State what the Chord Engine's declaration has to be (#2427).
  *
- * It was created as a `DeviceType::MIDI` device, which is the role of a device
- * that produces MIDI: `DeviceInfo::emitsMidi()` reads the type, so the model
- * gave it a MIDI output it never writes to and a thru toggle that does
- * nothing, and a plan compiled for a chord track would put a merge behind it
- * and double every note. It reads the chain's MIDI and writes none, which is
- * `DeviceType::Analysis` plus `canReceiveMidi`.
+ * It reads the chain's MIDI to detect chords and writes none, which is
+ * `DeviceType::Analysis` plus `canReceiveMidi`. Declared `DeviceType::MIDI` it
+ * is the role of a device that produces MIDI: `DeviceInfo::emitsMidi()` reads
+ * the type, so the model gives it a MIDI output it never writes to, a thru
+ * toggle that does nothing, and a merge behind it that doubles every note the
+ * moment a chord track compiles.
  *
- * A migration rather than a fix at the creation site alone, because
- * `deviceType` is saved per device: every project with a chord track in it
- * carries the old declaration.
+ * Applied on the way in as well as on the way up, and both are needed for the
+ * same reason: the declaration arrives wrong from more than one direction.
+ * `deviceType` is saved per device, so every project and every chain or rack
+ * preset with a chord track in it carries the old one; and a device dropped
+ * from the browser takes its type from the registry's browser category, which
+ * is "MIDI" and is about where it is filed rather than what it does.
  *
- * @return whether anything was changed.
+ * @return whether anything was changed, so a caller can tell a fresh insert
+ *         from one it had to correct.
  */
-bool migrateChordEngineRole(std::vector<TrackInfo>& tracks, TrackInfo* masterTrack);
+bool normalizeChordEngineRole(DeviceInfo& device);
+bool normalizeChordEngineRoleInChain(std::vector<ChainElement>& elements);
+bool normalizeChordEngineRoleInRack(RackInfo& rack);
+bool normalizeChordEngineRoleInProject(std::vector<TrackInfo>& tracks, TrackInfo* masterTrack);
 
 }  // namespace legacy_devices
 

--- a/magda/daw/core/LegacyDeviceAliases.hpp
+++ b/magda/daw/core/LegacyDeviceAliases.hpp
@@ -143,6 +143,24 @@ void migrateRetiredDevicesInProject(std::vector<TrackInfo>& tracks, TrackInfo* m
 void migrateRetiredDevicesInChain(std::vector<ChainElement>& elements);
 void migrateRetiredDevicesInRack(RackInfo& rack);
 
+/**
+ * @brief Bring the Chord Engine's declared role up to date (#2427).
+ *
+ * It was created as a `DeviceType::MIDI` device, which is the role of a device
+ * that produces MIDI: `DeviceInfo::emitsMidi()` reads the type, so the model
+ * gave it a MIDI output it never writes to and a thru toggle that does
+ * nothing, and a plan compiled for a chord track would put a merge behind it
+ * and double every note. It reads the chain's MIDI and writes none, which is
+ * `DeviceType::Analysis` plus `canReceiveMidi`.
+ *
+ * A migration rather than a fix at the creation site alone, because
+ * `deviceType` is saved per device: every project with a chord track in it
+ * carries the old declaration.
+ *
+ * @return whether anything was changed.
+ */
+bool migrateChordEngineRole(std::vector<TrackInfo>& tracks, TrackInfo* masterTrack);
+
 }  // namespace legacy_devices
 
 }  // namespace magda

--- a/magda/daw/core/PresetManager.cpp
+++ b/magda/daw/core/PresetManager.cpp
@@ -270,6 +270,12 @@ bool PresetManager::loadChainPreset(const juce::String& presetName,
         outChainElements.push_back(std::move(element));
     }
     legacy_devices::migrateRetiredDevicesInChain(outChainElements);
+
+    // A preset saved before #2427 carries the Chord Engine declared as a MIDI
+    // producer, and a preset loader does not go through the project's staging
+    // pass, so inserting one would put the old declaration back into a project
+    // that had already been migrated.
+    legacy_devices::normalizeChordEngineRoleInChain(outChainElements);
     device_param_migrations::migrateChainPreset(outChainElements);
     namespace hydration = daw::audio::device_state_hydration;
     hydration::hydrateChainElements(outChainElements,
@@ -363,6 +369,7 @@ bool PresetManager::loadRackPreset(const juce::String& presetName, RackInfo& out
         return false;
     }
     legacy_devices::migrateRetiredDevicesInRack(outRack);
+    legacy_devices::normalizeChordEngineRoleInRack(outRack);
     device_param_migrations::migrateRackPreset(outRack);
     namespace hydration = daw::audio::device_state_hydration;
     hydration::hydrateRack(outRack, hydration::provenanceFromMagdaVersion(savedVersion));

--- a/magda/daw/core/TrackManager.cpp
+++ b/magda/daw/core/TrackManager.cpp
@@ -386,7 +386,15 @@ TrackId TrackManager::createTrack(const juce::String& name, TrackType type) {
         engine.uniqueId = "midichordengine";
         engine.fileOrIdentifier = "midichordengine";
         engine.isInstrument = false;
-        engine.deviceType = DeviceType::MIDI;
+
+        // A transparent tap that reads the chain's MIDI and writes none
+        // (#2427). Not DeviceType::MIDI, which is the role of a device that
+        // produces MIDI: DeviceInfo::emitsMidi() reads the type, so declaring
+        // it that way gave the engine a MIDI output it never writes to, a thru
+        // toggle that does nothing, and a merge behind it that would double
+        // every note the moment a chord track compiles.
+        engine.deviceType = DeviceType::Analysis;
+        engine.canReceiveMidi = true;
         engine.format = PluginFormat::Internal;
         addDeviceToTrack(trackId, engine);
 

--- a/magda/daw/core/TrackManager.cpp
+++ b/magda/daw/core/TrackManager.cpp
@@ -15,6 +15,7 @@
 #include "Config.hpp"
 #include "DeviceState.hpp"
 #include "DrumGridPads.hpp"
+#include "LegacyDeviceAliases.hpp"
 #include "ModulatorEngine.hpp"
 #include "PluginCapabilities.hpp"
 #include "PluginPreferences.hpp"
@@ -2216,6 +2217,12 @@ DeviceId TrackManager::addDeviceToPostFx(TrackId trackId, const DeviceInfo& devi
     applyCachedCapabilitiesToDevice(newDevice);
     if (daw::audio::isInternalAnalysisPlugin(newDevice.pluginId))
         newDevice.deviceType = DeviceType::Analysis;
+
+    // This section stamps its own ids from its own counter and so does not go
+    // through prepareNewDevice, which is where the main chain's insertions are
+    // corrected. The declaration a browser drop carries is wrong here for the
+    // same reason it is wrong there (#2427).
+    legacy_devices::normalizeChordEngineRole(newDevice);
 
     auto& elements = track->chain.postFxChainElements;
     insertIndex = std::clamp(insertIndex, 0, static_cast<int>(elements.size()));

--- a/magda/daw/core/TrackManagerDevices.cpp
+++ b/magda/daw/core/TrackManagerDevices.cpp
@@ -13,6 +13,7 @@
 #include "ChainWalk.hpp"
 #include "DeviceState.hpp"
 #include "DrumGridPads.hpp"
+#include "LegacyDeviceAliases.hpp"
 #include "PluginCapabilities.hpp"
 #include "PluginPreferences.hpp"
 #include "RackInfo.hpp"
@@ -2091,6 +2092,12 @@ DeviceInfo TrackManager::prepareNewDevice(TrackId trackId, const DeviceInfo& dev
     stampDefaultKitIfMissing(newDevice);
     if (daw::audio::isInternalAnalysisPlugin(newDevice.pluginId))
         newDevice.deviceType = DeviceType::Analysis;
+
+    // The browser hands over a type derived from where the device is filed, and
+    // the Chord Engine is filed under MIDI. Corrected here, on the one path
+    // every insertion goes through, rather than at each of the six places that
+    // read a browser category (#2427).
+    legacy_devices::normalizeChordEngineRole(newDevice);
     return newDevice;
 }
 

--- a/magda/daw/project/serialization/ProjectSerializer.cpp
+++ b/magda/daw/project/serialization/ProjectSerializer.cpp
@@ -379,7 +379,8 @@ bool ProjectSerializer::loadAndStage(const juce::File& file, StagedProjectData& 
         // DeviceType::MIDI device, which is the role of one that produces MIDI,
         // and it produces none. Before the parameter migrations for no reason
         // of its own; it touches nothing they read.
-        legacy_devices::migrateChordEngineRole(outData.tracks, outData.masterTrack.get());
+        legacy_devices::normalizeChordEngineRoleInProject(outData.tracks,
+                                                          outData.masterTrack.get());
 
         // Then any device that renumbered its parameters, so a saved link still
         // addresses the parameter it was made against (#2079). After the

--- a/magda/daw/project/serialization/ProjectSerializer.cpp
+++ b/magda/daw/project/serialization/ProjectSerializer.cpp
@@ -375,6 +375,12 @@ bool ProjectSerializer::loadAndStage(const juce::File& file, StagedProjectData& 
                                                        outData.automationLanes,
                                                        outData.automationClips);
 
+        // Then the Chord Engine's declared role (#2427). It was created as a
+        // DeviceType::MIDI device, which is the role of one that produces MIDI,
+        // and it produces none. Before the parameter migrations for no reason
+        // of its own; it touches nothing they read.
+        legacy_devices::migrateChordEngineRole(outData.tracks, outData.masterTrack.get());
+
         // Then any device that renumbered its parameters, so a saved link still
         // addresses the parameter it was made against (#2079). After the
         // aliases: a device rewritten onto its successor is already the

--- a/magda/daw/ui/components/chain/slot/DeviceSlotContentLayout.cpp
+++ b/magda/daw/ui/components/chain/slot/DeviceSlotContentLayout.cpp
@@ -174,7 +174,8 @@ bool prepareDeviceSlotContentFrame(juce::Rectangle<int>& contentArea,
         // wet-dry mix. Note-strip utilities keep the strip for their MIDI
         // activity display (gain + mix hidden inside layoutMeterStrip); any other
         // MIDI device drops the strip entirely so the body uses the full width.
-        const bool isMidiDevice = device.deviceType == magda::DeviceType::MIDI;
+        const bool isMidiDevice =
+            device.deviceType == magda::DeviceType::MIDI || traits.isChordEngine;
         const int effectiveMeterWidth =
             (isMidiDevice && !isMidiUtility(traits)) ? 0 : meterStripWidth;
         layoutMeterStrip(contentArea, traits, controls, effectiveMeterWidth);

--- a/magda/daw/ui/components/chain/slot/DeviceSlotHeaderControls.cpp
+++ b/magda/daw/ui/components/chain/slot/DeviceSlotHeaderControls.cpp
@@ -125,7 +125,10 @@ void layoutCollapsedDeviceSlotControls(juce::Rectangle<int>& area,
 void applyMidiOnlyDeviceHeaderVisibility(const DeviceSlotTraits& traits,
                                          const magda::DeviceInfo& device,
                                          juce::Component* modButton, juce::Component* macroButton) {
-    if (device.deviceType != magda::DeviceType::MIDI)
+    // The Chord Engine by name as well as by type: it stopped being a
+    // DeviceType::MIDI device when it was declared for what it is (#2427), and
+    // what it has to modulate did not change -- nothing.
+    if (device.deviceType != magda::DeviceType::MIDI && !traits.isChordEngine)
         return;
 
     setVisibleIfPresent(modButton, false);

--- a/tests/controllers/test_legacy_device_aliases.cpp
+++ b/tests/controllers/test_legacy_device_aliases.cpp
@@ -517,3 +517,69 @@ TEST_CASE("Migrating the IR Reverb keeps the links and lanes that addressed it",
     CHECK(lanes.size() == 1);
     CHECK(clips.size() == 1);
 }
+
+// =============================================================================
+// The Chord Engine's declared role (#2427)
+// =============================================================================
+
+namespace {
+
+DeviceInfo savedChordEngine() {
+    DeviceInfo device;
+    device.id = 1;
+    device.name = "Chord Engine";
+    device.pluginId = "midichordengine";
+    device.uniqueId = "midichordengine";
+    device.format = PluginFormat::Internal;
+
+    // What every project with a chord track in it carries: the role of a device
+    // that produces MIDI, on one that produces none.
+    device.deviceType = DeviceType::MIDI;
+    device.canReceiveMidi = false;
+    return device;
+}
+
+TrackInfo trackCarrying(DeviceInfo device) {
+    TrackInfo track;
+    track.id = 1;
+    track.type = TrackType::Chord;
+    track.chain.fxChainElements.emplace_back(std::move(device));
+    return track;
+}
+
+DeviceInfo& deviceOf(TrackInfo& track) {
+    return std::get<DeviceInfo>(track.chain.fxChainElements.front());
+}
+
+}  // namespace
+
+TEST_CASE("A saved Chord Engine is declared for what it is", "[devices][legacy][aliases]") {
+    std::vector<TrackInfo> tracks{trackCarrying(savedChordEngine())};
+
+    REQUIRE(legacy_devices::migrateChordEngineRole(tracks, nullptr));
+
+    auto& device = deviceOf(tracks.front());
+
+    // Reads the chain's MIDI, writes none. Both halves matter: the type alone
+    // would take its MIDI input away with its output.
+    CHECK(device.consumesMidi());
+    CHECK_FALSE(device.emitsMidi());
+    CHECK(device.deviceType == DeviceType::Analysis);
+
+    // Idempotent, so a project loaded twice is migrated once.
+    CHECK_FALSE(legacy_devices::migrateChordEngineRole(tracks, nullptr));
+}
+
+TEST_CASE("The Chord Engine migration leaves other devices alone", "[devices][legacy][aliases]") {
+    auto other = savedChordEngine();
+    other.pluginId = "arpeggiator";
+    other.uniqueId = "arpeggiator";
+
+    std::vector<TrackInfo> tracks{trackCarrying(other)};
+
+    CHECK_FALSE(legacy_devices::migrateChordEngineRole(tracks, nullptr));
+
+    // An arpeggiator does produce MIDI, and the declaration that says so is the
+    // one this migration must not touch.
+    CHECK(deviceOf(tracks.front()).emitsMidi());
+}

--- a/tests/controllers/test_legacy_device_aliases.cpp
+++ b/tests/controllers/test_legacy_device_aliases.cpp
@@ -556,7 +556,7 @@ DeviceInfo& deviceOf(TrackInfo& track) {
 TEST_CASE("A saved Chord Engine is declared for what it is", "[devices][legacy][aliases]") {
     std::vector<TrackInfo> tracks{trackCarrying(savedChordEngine())};
 
-    REQUIRE(legacy_devices::migrateChordEngineRole(tracks, nullptr));
+    REQUIRE(legacy_devices::normalizeChordEngineRoleInProject(tracks, nullptr));
 
     auto& device = deviceOf(tracks.front());
 
@@ -567,7 +567,28 @@ TEST_CASE("A saved Chord Engine is declared for what it is", "[devices][legacy][
     CHECK(device.deviceType == DeviceType::Analysis);
 
     // Idempotent, so a project loaded twice is migrated once.
-    CHECK_FALSE(legacy_devices::migrateChordEngineRole(tracks, nullptr));
+    CHECK_FALSE(legacy_devices::normalizeChordEngineRoleInProject(tracks, nullptr));
+}
+
+TEST_CASE("A Chord Engine inside a preset fragment is normalized too",
+          "[devices][legacy][aliases]") {
+    // A chain or rack preset saved before #2427 carries the old declaration,
+    // and its loader does not go through the project's staging pass, so an
+    // insert would put it back into a project that had already been migrated.
+    std::vector<ChainElement> elements;
+    elements.emplace_back(savedChordEngine());
+
+    REQUIRE(legacy_devices::normalizeChordEngineRoleInChain(elements));
+    CHECK_FALSE(std::get<DeviceInfo>(elements.front()).emitsMidi());
+
+    RackInfo rack;
+    rack.id = 1;
+    auto& chain = rack.chains.emplace_back();
+    chain.id = 1;
+    chain.elements.emplace_back(savedChordEngine());
+
+    REQUIRE(legacy_devices::normalizeChordEngineRoleInRack(rack));
+    CHECK_FALSE(std::get<DeviceInfo>(rack.chains.front().elements.front()).emitsMidi());
 }
 
 TEST_CASE("The Chord Engine migration leaves other devices alone", "[devices][legacy][aliases]") {
@@ -577,7 +598,7 @@ TEST_CASE("The Chord Engine migration leaves other devices alone", "[devices][le
 
     std::vector<TrackInfo> tracks{trackCarrying(other)};
 
-    CHECK_FALSE(legacy_devices::migrateChordEngineRole(tracks, nullptr));
+    CHECK_FALSE(legacy_devices::normalizeChordEngineRoleInProject(tracks, nullptr));
 
     // An arpeggiator does produce MIDI, and the declaration that says so is the
     // one this migration must not touch.

--- a/tests/devices/test_device_api.cpp
+++ b/tests/devices/test_device_api.cpp
@@ -604,3 +604,31 @@ TEST_CASE("A Chord Engine is inserted as a listener, whatever the browser said",
 
     tracks.clearAllTracks();
 }
+
+TEST_CASE("A Chord Engine dropped into post-FX is a listener too", "[device-api][mutation]") {
+    // Post-FX stamps its ids from its own counter and does not go through
+    // prepareNewDevice, so the correction the main chain gets had to be made
+    // here as well (#2427).
+    auto& tracks = TrackManager::getInstance();
+    const auto trackId = freshTrack("Chords post-fx");
+
+    DeviceInfo fromBrowser;
+    fromBrowser.name = "Chord Engine";
+    fromBrowser.pluginId = "midichordengine";
+    fromBrowser.format = PluginFormat::Internal;
+    fromBrowser.deviceType = DeviceType::MIDI;
+
+    const auto deviceId = tracks.addDeviceToPostFx(trackId, fromBrowser);
+    REQUIRE(deviceId != INVALID_DEVICE_ID);
+
+    const auto* track = tracks.getTrack(trackId);
+    REQUIRE(track != nullptr);
+    REQUIRE(track->chain.postFxChainElements.size() == 1);
+
+    const auto& device = track->chain.postFxChainElements.front().device;
+    CHECK(device.deviceType == DeviceType::Analysis);
+    CHECK(device.consumesMidi());
+    CHECK_FALSE(device.emitsMidi());
+
+    tracks.clearAllTracks();
+}

--- a/tests/devices/test_device_api.cpp
+++ b/tests/devices/test_device_api.cpp
@@ -576,3 +576,31 @@ TEST_CASE("Devices can be added to a chain inside a rack", "[device-api][mutatio
 
     tracks.clearAllTracks();
 }
+
+TEST_CASE("A Chord Engine is inserted as a listener, whatever the browser said",
+          "[device-api][mutation]") {
+    // The browser derives a device's type from where it is filed, and the Chord
+    // Engine is filed under MIDI. That is the role of a device which produces
+    // MIDI, and it produces none (#2427). Corrected on the shared insertion
+    // path, so a freshly dropped one is right before the project is ever saved.
+    auto& tracks = TrackManager::getInstance();
+    const auto trackId = freshTrack("Chords");
+
+    DeviceInfo fromBrowser;
+    fromBrowser.name = "Chord Engine";
+    fromBrowser.pluginId = "midichordengine";
+    fromBrowser.format = PluginFormat::Internal;
+    fromBrowser.deviceType = DeviceType::MIDI;
+
+    const auto deviceId = tracks.addDeviceToTrack(trackId, fromBrowser);
+    REQUIRE(deviceId != INVALID_DEVICE_ID);
+
+    const auto* device = tracks.getDeviceInChainByPath(tracks.findDevicePath(deviceId));
+    REQUIRE(device != nullptr);
+
+    CHECK(device->deviceType == DeviceType::Analysis);
+    CHECK(device->consumesMidi());
+    CHECK_FALSE(device->emitsMidi());
+
+    tracks.clearAllTracks();
+}

--- a/tests/devices/test_internal_plugin_registry.cpp
+++ b/tests/devices/test_internal_plugin_registry.cpp
@@ -225,3 +225,11 @@ TEST_CASE("Device packs can contribute parameter aliases", "[internal-plugin-reg
     REQUIRE(registry.getParameterAliases().size() == 1);
     REQUIRE(registry.getParameterAliases().front().paramIndex == 2);
 }
+
+TEST_CASE("The Chord Engine is not a MIDI generator", "[devices][registry]") {
+    // It reads the chain's MIDI and writes none (#2427). The tag is what
+    // TrackManager reads to keep generators off the master track, and what the
+    // slot traits read; being tagged one gave it both by mistake.
+    CHECK_FALSE(magda::daw::audio::isInternalMidiGeneratorPlugin("midichordengine"));
+    CHECK(magda::daw::audio::internalPluginHasTag("midichordengine", "chord-engine"));
+}

--- a/tests/devices/test_plugin_capabilities.cpp
+++ b/tests/devices/test_plugin_capabilities.cpp
@@ -117,3 +117,26 @@ TEST_CASE("MIDI controls are capability-based for non-instrument devices",
     REQUIRE(magda::hasMidiOutput(nonInstrumentMidiGenerator));
     REQUIRE_FALSE(magda::supportsMidiSourceToggle(nonInstrumentMidiGenerator));
 }
+
+TEST_CASE("A MIDI listener reads the chain and gets no thru toggle", "[plugin_capabilities]") {
+    // The Chord Engine as it is declared since #2427: it reads the chain's MIDI
+    // to detect chords and writes none.
+    magda::DeviceInfo listener;
+    listener.pluginId = "midichordengine";
+    listener.isInstrument = false;
+    listener.deviceType = magda::DeviceType::Analysis;
+    listener.canReceiveMidi = true;
+
+    const auto caps = magda::midiCapabilitiesForDevice(listener);
+
+    REQUIRE(caps.hasMidiInput);
+    REQUIRE(magda::hasMidiInput(listener));
+
+    // The half that was wrong. A MIDI output it never writes to gave it a thru
+    // toggle that does nothing, and a plan compiled for a chord track would
+    // merge that output back over the input and double every note.
+    REQUIRE_FALSE(caps.hasMidiOutput);
+    REQUIRE_FALSE(magda::hasMidiOutput(listener));
+    REQUIRE_FALSE(caps.supportsMidiInputThruToggle);
+    REQUIRE_FALSE(magda::supportsMidiInputThruToggle(listener));
+}


### PR DESCRIPTION
Closes #2427. With #2449, this unblocks #2314.

## The bug

`MidiChordEnginePlugin::applyToBuffer` is a transparent passthrough: it reads the chain's MIDI to detect chords and writes none, clearing the buffer only while audition is muted.

It was declared a MIDI generator anyway — `TrackManager` created it with `DeviceType::MIDI`, `BaseDevicePack` tagged it `midi-generator` — and `DeviceInfo::emitsMidi()` reads the type, so the model gave it a MIDI output it never writes to.

Two things followed:

- its **thru toggle did nothing**, because the plugin passes its input on regardless;
- `ChainRoutingModel` gave it `MergeRawInputAndPluginOutput` while thru is on, which is the default, so a plan compiled for a chord track would put a `ChainMidiMerge` behind a device that produces nothing and **every note would arrive twice**.

The second was latent only because the plan skipped chord tracks. #2449 gives them a way in, which is why this comes with it.

## The fix

`DeviceType::Analysis` plus `canReceiveMidi` — a transparent tap that reads MIDI. `emitsMidi()` false, no thru toggle, and the plan's transparent path keeps its full stereo width rather than narrowing the chain.

**Migrated, not just fixed at the creation site.** `deviceType` is saved per device (`TrackSerializer.cpp:439`), so every project with a chord track carries the old declaration. The migration joins the existing chain in `ProjectSerializer`, runs on the staged model, and is idempotent. It walks every chain rather than the chord track's own, because the device shows in the browser and can be dropped anywhere, racks included.

**The slot UI does not move.** Two places keyed "hide the mod button, hide the macro button, drop the meter strip" on `deviceType == MIDI`. Both now also read `traits.isChordEngine`, which already existed and is keyed on the `chord-engine` tag, so the device's slot looks exactly as it did.

## Tests

- A saved Chord Engine is declared for what it is, and the migration is idempotent.
- The migration leaves an arpeggiator's declaration alone — it does produce MIDI.
- A MIDI listener reads the chain and gets no thru toggle, asserted on both halves: the type alone would have taken its MIDI input away with its output.
- The registry no longer tags it a MIDI generator, and still tags it a chord engine.

`make test` (858k assertions) and `make test-juce` both pass.

## One consequence worth naming

`addDeviceToTrack` keeps MIDI generators off the master track by type and by tag, and the Chord Engine now matches neither, so it can be added there. An analyser on master is what that rule is meant to allow; it was blocked as a side effect of the wrong declaration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019sKH5X6HQ8WV82QriCbmLr