### PR TITLE
Hold the launch de-click fix with impulse material

### DIFF
--- a/tests/NullDiffCorpus.cpp
+++ b/tests/NullDiffCorpus.cpp
@@ -2400,21 +2400,15 @@ std::vector<Case> buildCorpus(const juce::File& scratchDirectory) {
                              launching(plainTrack()));
         value.endBeat = 8.0;
 
-        // A tone, whose file is windowed at both ends, so the slot's first
-        // sample is silence. Both engines take a step out of a launched clip's
-        // first samples and only one of them asks first whether there is a step
-        // to take: the fork's SlotControlNode de-clicks whatever the block
-        // begins with, while the engine leaves a voice that begins at its own
-        // start alone, on the grounds that what looks like a step there is the
-        // material's own attack (ClipVoice.cpp). Impulses put a full-scale
-        // transient on exactly that sample, so an impulse case here would be
-        // measuring the launch instant, which #2306 asserts and this does not.
-        // The difference itself is #2444.
-        //
-        // Nothing interpolates between the two at one rate and ratio one, so the
-        // ordinary floor still applies: the tone is here for what its first
-        // sample is, not for what an interpolator would do to it.
-        const auto source = writeSource(scratchDirectory, "session", tone());
+        // Impulses, which put a full-scale transient on the slot's very first
+        // sample. That is the sample both engines take a step out of when a
+        // launch begins, and the one they used to disagree about: the fork
+        // de-clicked whatever a launched block began with and removed the
+        // transient, where the engine leaves a voice that begins at its own
+        // start alone (ClipVoice.cpp). Fixed in the fork for #2444, and this
+        // material is what holds it fixed -- a tone would pass either way,
+        // because its file is windowed and its first sample is silence.
+        const auto source = writeSource(scratchDirectory, "session", impulses());
         value.sources.push_back(source);
 
         // Sixteen beats against an eight-beat render, so the run never reaches


### PR DESCRIPTION
Closes #2444. **Draft: do not merge before Conceptual-Machines/tracktion_engine#35**, and the submodule pointer wants moving to `magda_minimal`'s head once that lands rather than the branch commit it names now.

## The fix is in the fork

`SlotControlNode` subtracted a decaying copy of the block's first sample whenever a slot went from stopped to playing, so a slot whose first sample is a transient lost it and gained a click-length tail — a drum one-shot launched from a slot loses its crack. The engine already asks first whether there is a step to take, and leaves a voice that begins at its own start alone (`ClipVoice.cpp`). tracktion_engine#35 gives the fork the same question, and keeps the de-click where there really is a boundary: a scene launch joining a run already playing, or a clip with an offset.

## What changes here

`session.launch` goes back to **impulses**. That is the material that found the bug and the only material that holds it fixed: an impulse puts a full-scale transient on exactly the sample the two engines disagreed about. The case shipped playing a tone because a windowed file's first sample is silence — which passes either way and proves nothing about this.

Measured on the corpus, with the fork patched and unpatched:

| | peak | rms |
|---|---|---|
| impulses, unpatched | **0.0 dBFS** | -32.6 |
| impulses, patched | **-133.0 dB** | -169.9 |

So the corpus is the negative verification: revert the fork commit and this case fails at full scale.

`make test` (976k assertions) and `make test-juce` both pass.

## A correction to the issue

#2444 says fixing the fork is out of scope, on the grounds that `SlotControlNode` is upstream's. That was written from a wrong assumption: `third_party/tracktion_engine` is a Conceptual-Machines fork that already carries its own PRs, so it is ours to patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019sKH5X6HQ8WV82QriCbmLr