### PR TITLE
Let a monitoring track hear the input the device just captured

### DIFF
--- a/magda/engine/CMakeLists.txt
+++ b/magda/engine/CMakeLists.txt
@@ -130,6 +130,8 @@ add_library(magda_engine STATIC
     io/AudioFileReader.cpp
     io/AudioFileSink.cpp
     io/AudioFileSink.hpp
+    io/LiveInput.cpp
+    io/LiveInput.hpp
     io/PcmQuantiser.cpp
     io/PcmQuantiser.hpp
     io/SourceLoopInfo.cpp

--- a/magda/engine/exec/EngineSession.cpp
+++ b/magda/engine/exec/EngineSession.cpp
@@ -6,6 +6,25 @@
 
 namespace magda::engine {
 
+namespace {
+
+/// Closes the feed's callback however process() leaves, so a source reached
+/// between callbacks reads nothing rather than the last one's samples.
+struct ScopedLiveInput {
+    explicit ScopedLiveInput(LiveInputFeed& feed) : feed_(feed) {}
+
+    ~ScopedLiveInput() {
+        feed_.endCallback();
+    }
+
+    ScopedLiveInput(const ScopedLiveInput&) = delete;
+    ScopedLiveInput& operator=(const ScopedLiveInput&) = delete;
+
+    LiveInputFeed& feed_;
+};
+
+}  // namespace
+
 EngineSession::Result EngineSession::publish(std::shared_ptr<const RenderPlan> plan,
                                              const RenderContext& context,
                                              const RuntimeStateIds& modelIds, PlanValues values) {
@@ -156,6 +175,20 @@ void EngineSession::publishClips(std::shared_ptr<const ClipSnapshot> clips) {
 
 void EngineSession::process(int numSamples, juce::AudioBuffer<float>& output,
                             const LiveInputBlock& input) {
+    // The executor asserts on a block longer than the plan was prepared for.
+    // Here the same number also says how much buffer there is to write into, so
+    // it is held to what the caller actually provided rather than trusted: the
+    // pieces of a split callback are views onto this, and a view past the end
+    // of it is not a wrong answer, it is someone else's memory.
+    jassert(numSamples <= output.getNumSamples());
+    numSamples = std::min(numSamples, output.getNumSamples());
+
+    // Before the clear, and before anything else touches the output: a host may
+    // hand the same memory for input and output, and the feed's copy is what
+    // makes that the caller's business rather than a silent loss of the take.
+    liveInputs_.beginCallback(input, numSamples);
+    const ScopedLiveInput scopedInput(liveInputs_);
+
     output.clear();
 
     PublishedRender::ScopedAccess<farbot::ThreadType::realtime> render(published_);
@@ -172,19 +205,6 @@ void EngineSession::process(int numSamples, juce::AudioBuffer<float>& output,
     // still asked at the next real one.
     if (numSamples <= 0)
         return;
-
-    // The executor asserts on a block longer than the plan was prepared for.
-    // Here the same number also says how much buffer there is to write into, so
-    // it is held to what the caller actually provided rather than trusted: the
-    // pieces of a split callback are views onto this, and a view past the end
-    // of it is not a wrong answer, it is someone else's memory.
-    jassert(numSamples <= output.getNumSamples());
-    numSamples = std::min(numSamples, output.getNumSamples());
-
-    // What the device captured, held once for the callback and narrowed to
-    // each block below. Ended before returning, so a source reached outside a
-    // callback reads nothing rather than the last one's samples.
-    liveInputs_.beginCallback(input, numSamples);
 
     // Values and plans travel separately and are swapped one after the other,
     // so for the moment between the two the ones in flight can belong to the
@@ -236,8 +256,6 @@ void EngineSession::process(int numSamples, juce::AudioBuffer<float>& output,
             (*render)->click->render(transport->tempo, transport->click, segment.block,
                                      segment.countingIn, output, segment.startSample);
     }
-
-    liveInputs_.endCallback();
 }
 
 }  // namespace magda::engine

--- a/magda/engine/exec/EngineSession.cpp
+++ b/magda/engine/exec/EngineSession.cpp
@@ -154,7 +154,8 @@ void EngineSession::publishClips(std::shared_ptr<const ClipSnapshot> clips) {
     clips_.publish(std::move(clips));
 }
 
-void EngineSession::process(int numSamples, juce::AudioBuffer<float>& output) {
+void EngineSession::process(int numSamples, juce::AudioBuffer<float>& output,
+                            const LiveInputBlock& input) {
     output.clear();
 
     PublishedRender::ScopedAccess<farbot::ThreadType::realtime> render(published_);
@@ -179,6 +180,11 @@ void EngineSession::process(int numSamples, juce::AudioBuffer<float>& output) {
     // of it is not a wrong answer, it is someone else's memory.
     jassert(numSamples <= output.getNumSamples());
     numSamples = std::min(numSamples, output.getNumSamples());
+
+    // What the device captured, held once for the callback and narrowed to
+    // each block below. Ended before returning, so a source reached outside a
+    // callback reads nothing rather than the last one's samples.
+    liveInputs_.beginCallback(input, numSamples);
 
     // Values and plans travel separately and are swapped one after the other,
     // so for the moment between the two the ones in flight can belong to the
@@ -206,6 +212,8 @@ void EngineSession::process(int numSamples, juce::AudioBuffer<float>& output) {
         juce::AudioBuffer<float> piece(output.getArrayOfWritePointers(), output.getNumChannels(),
                                        segment.startSample, segment.block.numSamples);
 
+        liveInputs_.beginSegment(segment.startSample, segment.block.numSamples);
+
         // Where the transport is, for the thread that reads ahead of it. A
         // relaxed store of a double, before the block rather than after: the
         // pool's window starts here, and a clip inside it has until the next
@@ -228,6 +236,8 @@ void EngineSession::process(int numSamples, juce::AudioBuffer<float>& output) {
             (*render)->click->render(transport->tempo, transport->click, segment.block,
                                      segment.countingIn, output, segment.startSample);
     }
+
+    liveInputs_.endCallback();
 }
 
 }  // namespace magda::engine

--- a/magda/engine/exec/EngineSession.hpp
+++ b/magda/engine/exec/EngineSession.hpp
@@ -9,6 +9,7 @@
 #include "exec/ParallelPlanExecutor.hpp"
 #include "exec/RenderThreadPool.hpp"
 #include "exec/RuntimeStateStore.hpp"
+#include "io/LiveInput.hpp"
 #include "launch/SessionLauncher.hpp"
 #include "transport/ClickGenerator.hpp"
 #include "transport/TransportClock.hpp"
@@ -203,12 +204,30 @@ class EngineSession {
      * wraps inside renders as two blocks back to back, and neither straddles
      * the wrap.
      *
+     * @p input is what the device just captured (#2459), read by the live
+     * sources an armed or monitoring track compiles. Default for a host with
+     * no inputs and for every offline render, where the ops are not compiled
+     * at all.
+     *
      * Renders silence until a plan is published, and the cursor stands
      * still while it does: the sample rate is only settled when a plan is
      * prepared, and a clock with no idea how long a sample lasts would be
      * inventing a position, not reporting one.
      */
-    void process(int numSamples, juce::AudioBuffer<float>& output);
+    void process(int numSamples, juce::AudioBuffer<float>& output,
+                 const LiveInputBlock& input = {});
+
+    /**
+     * @brief The feed a live source reads its block from.
+     *
+     * The host builds LiveAudioInput and LiveMidiInput against this and binds
+     * them through RuntimeStateFactory::createAudioInput / createMidiInput;
+     * process() narrows it to each block as it goes. One per session rather
+     * than one per source, since every input op reads the same callback.
+     */
+    LiveInputFeed& liveInputs() {
+        return liveInputs_;
+    }
 
     /// Where the transport is, in beats. Readable from any thread; what a
     /// playhead is drawn from.
@@ -342,6 +361,11 @@ class EngineSession {
     /// is, a property of the session rather than of any plan, and a plan
     /// swap must not move it.
     TransportClock clock_;
+
+    /// The callback's live input, narrowed per block. Outside every epoch for
+    /// the same reason the clock is: what the device captured is a property of
+    /// the callback, not of the plan rendering it.
+    LiveInputFeed liveInputs_;
 
     /// What the model held at the last publish. Kept so a values publish
     /// escalated into a structural one has a set to publish with; retention

--- a/magda/engine/exec/EngineSession.hpp
+++ b/magda/engine/exec/EngineSession.hpp
@@ -224,6 +224,11 @@ class EngineSession {
      * them through RuntimeStateFactory::createAudioInput / createMidiInput;
      * process() narrows it to each block as it goes. One per session rather
      * than one per source, since every input op reads the same callback.
+     *
+     * Prepare it when the audio device opens, with the channels and block size
+     * that device delivers: the feed copies each callback's input, and the room
+     * for that copy cannot be taken while a callback is running. An unprepared
+     * feed reads silence and counts what it could not hold.
      */
     LiveInputFeed& liveInputs() {
         return liveInputs_;

--- a/magda/engine/io/LiveInput.cpp
+++ b/magda/engine/io/LiveInput.cpp
@@ -1,0 +1,132 @@
+#include "io/LiveInput.hpp"
+
+#include <algorithm>
+
+namespace magda::engine {
+
+namespace {
+
+/// What one event costs against a port's byte budget: MidiBuffer stores a
+/// sample position and a length in front of the message itself.
+constexpr int kEventOverheadBytes = 6;
+
+}  // namespace
+
+void LiveInputFeed::beginCallback(const LiveInputBlock& input, int numSamples) {
+    callbackAudio_ = input.audio;
+    midi_ = input.midi;
+
+    const auto delivered = static_cast<int>(callbackAudio_.getNumSamples());
+    const auto silent = callbackAudio_.getNumChannels() == 0;
+
+    // A host that delivered fewer input samples than it asked to render is a
+    // host bug, and the blocks past what it delivered read silence rather than
+    // whatever is behind the pointer.
+    const bool enough = silent || delivered >= numSamples;
+    jassert(enough);
+    juce::ignoreUnused(enough);
+
+    callbackSamples_ = silent ? 0 : std::min(numSamples, delivered);
+
+    beginSegment(0, 0);
+}
+
+void LiveInputFeed::beginSegment(int startSample, int numSamples) {
+    segmentStart_ = startSample;
+    segmentSamples_ = numSamples;
+
+    if (startSample < 0 || numSamples <= 0 || startSample + numSamples > callbackSamples_) {
+        audio_ = {};
+        return;
+    }
+
+    audio_ = callbackAudio_.getSubBlock(static_cast<std::size_t>(startSample),
+                                        static_cast<std::size_t>(numSamples));
+}
+
+void LiveInputFeed::endCallback() {
+    callbackAudio_ = {};
+    audio_ = {};
+    midi_ = {};
+    callbackSamples_ = 0;
+    segmentStart_ = 0;
+    segmentSamples_ = 0;
+}
+
+int LiveInputFeed::appendEvents(LiveMidiSourceId source, juce::MidiBuffer& out,
+                                int maxBytes) const {
+    if (segmentSamples_ <= 0)
+        return 0;
+
+    const auto end = segmentStart_ + segmentSamples_;
+    int dropped = 0;
+
+    for (const auto& stream : midi_) {
+        if (stream.events == nullptr)
+            continue;
+        if (source != kAnyLiveMidiSource && stream.source != source)
+            continue;
+
+        for (const auto metadata : *stream.events) {
+            if (metadata.samplePosition < segmentStart_ || metadata.samplePosition >= end)
+                continue;
+
+            if (static_cast<int>(out.data.size()) + kEventOverheadBytes + metadata.numBytes >
+                maxBytes) {
+                ++dropped;
+                continue;
+            }
+
+            out.addEvent(metadata.data, metadata.numBytes, metadata.samplePosition - segmentStart_);
+        }
+    }
+
+    return dropped;
+}
+
+LiveAudioInput::LiveAudioInput(const LiveInputFeed& feed, std::span<const int> channels,
+                               int latencySamples)
+    : feed_(feed), channels_(channels.begin(), channels.end()), latencySamples_(latencySamples) {}
+
+void LiveAudioInput::render(const BlockInfo& /*block*/, juce::dsp::AudioBlock<float> out) {
+    const auto in = feed_.audio();
+    const auto numSamples = out.getNumSamples();
+    const auto available = in.getNumChannels();
+
+    if (channels_.empty() || available == 0 || in.getNumSamples() < numSamples) {
+        out.clear();
+        if (!channels_.empty())
+            missingChannels_.fetch_add(1, std::memory_order_relaxed);
+        return;
+    }
+
+    bool missing = false;
+
+    for (std::size_t c = 0; c < out.getNumChannels(); ++c) {
+        // A destination wider than the map repeats the map's last channel, so
+        // a mono input fills both ears.
+        const auto index = channels_[std::min(c, channels_.size() - 1)];
+
+        if (index < 0 || static_cast<std::size_t>(index) >= available) {
+            out.getSingleChannelBlock(c).clear();
+            missing = true;
+            continue;
+        }
+
+        out.getSingleChannelBlock(c).copyFrom(
+            in.getSingleChannelBlock(static_cast<std::size_t>(index)).getSubBlock(0, numSamples));
+    }
+
+    if (missing)
+        missingChannels_.fetch_add(1, std::memory_order_relaxed);
+}
+
+LiveMidiInput::LiveMidiInput(const LiveInputFeed& feed, LiveMidiSourceId source, int latencySamples)
+    : feed_(feed), source_(source), latencySamples_(latencySamples) {}
+
+void LiveMidiInput::render(const BlockInfo& /*block*/, juce::MidiBuffer& out) {
+    if (const auto dropped = feed_.appendEvents(source_, out, kMaxMidiBytesPerPort); dropped > 0)
+        dropped_.fetch_add(static_cast<std::uint32_t>(dropped), std::memory_order_relaxed);
+}
+
+}  // namespace magda::engine

--- a/magda/engine/io/LiveInput.cpp
+++ b/magda/engine/io/LiveInput.cpp
@@ -12,21 +12,43 @@ constexpr int kEventOverheadBytes = 6;
 
 }  // namespace
 
+void LiveInputFeed::prepare(int maxChannels, int maxBlockSize) {
+    const auto channels = std::max(scratch_.getNumChannels(), std::max(0, maxChannels));
+    const auto samples = std::max(scratch_.getNumSamples(), std::max(0, maxBlockSize));
+
+    if (channels != scratch_.getNumChannels() || samples != scratch_.getNumSamples())
+        scratch_.setSize(channels, samples, false, true, false);
+}
+
 void LiveInputFeed::beginCallback(const LiveInputBlock& input, int numSamples) {
-    callbackAudio_ = input.audio;
     midi_ = input.midi;
 
-    const auto delivered = static_cast<int>(callbackAudio_.getNumSamples());
-    const auto silent = callbackAudio_.getNumChannels() == 0;
+    const auto delivered = static_cast<int>(input.audio.getNumSamples());
+    const auto deliveredChannels = static_cast<int>(input.audio.getNumChannels());
+    const auto wanted = std::min(numSamples, delivered);
+
+    const auto channels = std::min(deliveredChannels, scratch_.getNumChannels());
+    const auto samples = std::min(wanted, scratch_.getNumSamples());
 
     // A host that delivered fewer input samples than it asked to render is a
-    // host bug, and the blocks past what it delivered read silence rather than
-    // whatever is behind the pointer.
-    const bool enough = silent || delivered >= numSamples;
+    // host bug; what it did deliver is copied, and the rest of the block is
+    // silence rather than whatever is behind the pointer.
+    const bool enough = deliveredChannels == 0 || delivered >= numSamples;
     jassert(enough);
     juce::ignoreUnused(enough);
 
-    callbackSamples_ = silent ? 0 : std::min(numSamples, delivered);
+    if (deliveredChannels > 0 && (channels < deliveredChannels || samples < wanted))
+        unfit_.fetch_add(1, std::memory_order_relaxed);
+
+    // The copy, and the reason this holds a buffer rather than the caller's
+    // pointers: that memory may be the output buffer, which is cleared and
+    // written before any input op runs.
+    for (auto channel = 0; channel < channels; ++channel)
+        scratch_.copyFrom(
+            channel, 0, input.audio.getChannelPointer(static_cast<std::size_t>(channel)), samples);
+
+    callbackChannels_ = samples > 0 ? channels : 0;
+    callbackSamples_ = callbackChannels_ > 0 ? samples : 0;
 
     beginSegment(0, 0);
 }
@@ -35,19 +57,22 @@ void LiveInputFeed::beginSegment(int startSample, int numSamples) {
     segmentStart_ = startSample;
     segmentSamples_ = numSamples;
 
-    if (startSample < 0 || numSamples <= 0 || startSample + numSamples > callbackSamples_) {
+    if (callbackChannels_ <= 0 || startSample < 0 || numSamples <= 0 ||
+        startSample + numSamples > callbackSamples_) {
         audio_ = {};
         return;
     }
 
-    audio_ = callbackAudio_.getSubBlock(static_cast<std::size_t>(startSample),
-                                        static_cast<std::size_t>(numSamples));
+    audio_ = juce::dsp::AudioBlock<const float>(scratch_)
+                 .getSubsetChannelBlock(0, static_cast<std::size_t>(callbackChannels_))
+                 .getSubBlock(static_cast<std::size_t>(startSample),
+                              static_cast<std::size_t>(numSamples));
 }
 
 void LiveInputFeed::endCallback() {
-    callbackAudio_ = {};
     audio_ = {};
     midi_ = {};
+    callbackChannels_ = 0;
     callbackSamples_ = 0;
     segmentStart_ = 0;
     segmentSamples_ = 0;

--- a/magda/engine/io/LiveInput.hpp
+++ b/magda/engine/io/LiveInput.hpp
@@ -67,11 +67,34 @@ struct LiveInputBlock {
  * (EngineSession::process), and each piece renders separately. The input is
  * not timeline material and knows nothing about that, so the feed holds the
  * callback's input once and hands out the window belonging to the piece in
- * flight. Written and read on the audio thread only, within one callback.
+ * flight.
+ *
+ * Held as a copy rather than as the caller's pointers, because a host may
+ * hand the same memory for input and output -- an AudioProcessor is given one
+ * buffer for both -- and the render clears and fills the output before an
+ * input op reads anything. A borrowed view of that memory would be zeros by
+ * the time a source looked at it.
+ *
+ * The room for the copy is taken by @ref prepare, so the copy itself cannot
+ * allocate. Written and read on the audio thread only, within one callback.
  */
 class LiveInputFeed {
   public:
-    /// Audio thread, once per callback, before any block of it renders.
+    /**
+     * @brief Room for what a callback may deliver. Off the audio thread.
+     *
+     * Called when the audio device opens or changes, like every other prepare
+     * in the engine, and never while a callback can run: it allocates. It only
+     * ever grows, so a session preparing for its plan cannot shrink what the
+     * host sized for its interface.
+     *
+     * A feed with no room reads silence and counts the callback
+     * (@ref unfitCallbacks), which is what a host that never prepared gets.
+     */
+    void prepare(int maxChannels, int maxBlockSize);
+
+    /// Audio thread, once per callback, before any block of it renders and
+    /// before anything writes to the output.
     void beginCallback(const LiveInputBlock& input, int numSamples);
 
     /// Audio thread, per block of that callback, before the plan runs.
@@ -97,13 +120,29 @@ class LiveInputFeed {
      */
     int appendEvents(LiveMidiSourceId source, juce::MidiBuffer& out, int maxBytes) const;
 
+    /// Callbacks whose input did not fit the room prepare() took, in channels
+    /// or in samples. Read from any thread; what did not fit reads silence.
+    std::uint32_t unfitCallbacks() const {
+        return unfit_.load(std::memory_order_relaxed);
+    }
+
+    int preparedChannels() const {
+        return scratch_.getNumChannels();
+    }
+
+    int preparedBlockSize() const {
+        return scratch_.getNumSamples();
+    }
+
   private:
-    juce::dsp::AudioBlock<const float> callbackAudio_;
+    juce::AudioBuffer<float> scratch_;
     juce::dsp::AudioBlock<const float> audio_;
     std::span<const LiveMidiStream> midi_;
+    int callbackChannels_ = 0;
     int callbackSamples_ = 0;
     int segmentStart_ = 0;
     int segmentSamples_ = 0;
+    std::atomic<std::uint32_t> unfit_{0};
 };
 
 /**

--- a/magda/engine/io/LiveInput.hpp
+++ b/magda/engine/io/LiveInput.hpp
@@ -1,0 +1,193 @@
+#pragma once
+
+#include <juce_audio_basics/juce_audio_basics.h>
+#include <juce_dsp/juce_dsp.h>
+
+#include <atomic>
+#include <cstdint>
+#include <span>
+#include <vector>
+
+#include "exec/EngineDevice.hpp"
+#include "exec/RenderContext.hpp"
+
+/**
+ * @file LiveInput.hpp
+ * @brief What the audio device just handed the engine, and the sources reading it (#2459).
+ *
+ * An AudioInput or MidiInput op is compiled for a track that is armed or
+ * monitoring, and the plan says nothing about where the signal comes from
+ * (PlanCompiler.cpp). These are the objects behind those ops: one live
+ * source per track, reading the callback's own input rather than a buffer
+ * filled at some other time.
+ *
+ * Which hardware channels a track's `audioInputDevice` names, and which
+ * device its `midiInputDevice` names, is the host's to resolve: the engine
+ * knows channel indices and an opaque source id, never a device name.
+ */
+
+namespace magda::engine {
+
+/**
+ * @brief Which MIDI input a stream came from.
+ *
+ * Opaque to the engine. The host assigns one per enabled device and resolves
+ * a track's model string to it; kAnyLiveMidiSource is the "all" that string
+ * also accepts, and merges every stream in the callback.
+ */
+using LiveMidiSourceId = int;
+
+constexpr LiveMidiSourceId kAnyLiveMidiSource = -1;
+
+/** @brief One MIDI input's events for a callback, stamped from its first sample. */
+struct LiveMidiStream {
+    LiveMidiSourceId source = kAnyLiveMidiSource;
+    const juce::MidiBuffer* events = nullptr;
+};
+
+/**
+ * @brief The device's input for one callback.
+ *
+ * Handed to EngineSession::process alongside the output it fills. Views, not
+ * copies: everything here belongs to the caller and lives for the call.
+ */
+struct LiveInputBlock {
+    /// The hardware input channels, in the order the device reports them.
+    juce::dsp::AudioBlock<const float> audio;
+
+    /// One entry per enabled MIDI input. Empty for a host with none, which is
+    /// every offline render.
+    std::span<const LiveMidiStream> midi;
+};
+
+/**
+ * @brief The callback's input, narrowed to the block a source is rendering.
+ *
+ * A callback is one or more blocks: the transport cuts it at every loop wrap
+ * (EngineSession::process), and each piece renders separately. The input is
+ * not timeline material and knows nothing about that, so the feed holds the
+ * callback's input once and hands out the window belonging to the piece in
+ * flight. Written and read on the audio thread only, within one callback.
+ */
+class LiveInputFeed {
+  public:
+    /// Audio thread, once per callback, before any block of it renders.
+    void beginCallback(const LiveInputBlock& input, int numSamples);
+
+    /// Audio thread, per block of that callback, before the plan runs.
+    void beginSegment(int startSample, int numSamples);
+
+    /// Audio thread, after the last block. A source reaching the feed outside
+    /// a callback reads nothing rather than the previous callback's samples.
+    void endCallback();
+
+    /// The current block's input audio, empty when the host supplied none.
+    juce::dsp::AudioBlock<const float> audio() const {
+        return audio_;
+    }
+
+    /**
+     * @brief Append @p source's events for this block to @p out, offset to it.
+     *
+     * kAnyLiveMidiSource merges every stream. Events land at the sample
+     * offsets the host stamped, which is what makes a live note recordable at
+     * the position it was played rather than at a block boundary.
+     *
+     * Stops at @p maxBytes of encoded MIDI and counts what would not fit.
+     */
+    int appendEvents(LiveMidiSourceId source, juce::MidiBuffer& out, int maxBytes) const;
+
+  private:
+    juce::dsp::AudioBlock<const float> callbackAudio_;
+    juce::dsp::AudioBlock<const float> audio_;
+    std::span<const LiveMidiStream> midi_;
+    int callbackSamples_ = 0;
+    int segmentStart_ = 0;
+    int segmentSamples_ = 0;
+};
+
+/**
+ * @brief A track's live audio input: the hardware channels it was pointed at.
+ *
+ * Channels are resolved once, off the audio thread, and are indices into what
+ * the device delivers. A destination wider than the source repeats the
+ * source's last channel across the rest, which is what the current engine
+ * does (`WaveInputDeviceNode::process` copies its last read channel over the
+ * remaining destination channels), so a mono input is heard in both ears
+ * rather than only the left.
+ */
+class LiveAudioInput final : public EngineAudioSource {
+  public:
+    /**
+     * @brief Reads @p channels of @p feed.
+     *
+     * @p latencySamples is what the device reports for its input: see
+     * @ref latencySamples for what it is and is not for.
+     */
+    LiveAudioInput(const LiveInputFeed& feed, std::span<const int> channels,
+                   int latencySamples = 0);
+
+    void render(const BlockInfo& /*block*/, juce::dsp::AudioBlock<float> out) override;
+
+    /**
+     * @brief The input's own latency, in samples.
+     *
+     * Not a plan latency and deliberately not declared to the compensation
+     * pass: what arrives has already happened, so delaying the rest of the
+     * graph to match it would push playback and the click behind the live
+     * signal rather than align anything. It is the number a recorded take is
+     * placed by (#2461), which is the only thing that can act on it.
+     */
+    int latencySamples() const {
+        return latencySamples_;
+    }
+
+    /// Blocks that found fewer channels than the map named. Read from any
+    /// thread; a wrong channel count is silence, which nothing else reports.
+    std::uint32_t missingChannelBlocks() const {
+        return missingChannels_.load(std::memory_order_relaxed);
+    }
+
+  private:
+    const LiveInputFeed& feed_;
+    std::vector<int> channels_;
+    int latencySamples_ = 0;
+    std::atomic<std::uint32_t> missingChannels_{0};
+};
+
+/**
+ * @brief A track's live MIDI input, from one device or from all of them.
+ *
+ * The events are the host's, already stamped against the callback. The
+ * current engine collects messages between callbacks and places them
+ * relative to the first one's timestamp, which its own comment calls "near
+ * enough for live stuff" (`MidiInputDeviceNode::processSection`); a stamp
+ * taken against the block the event arrived in is what slice #2462 needs to
+ * record a note where it was played.
+ */
+class LiveMidiInput final : public EngineMidiSource {
+  public:
+    explicit LiveMidiInput(const LiveInputFeed& feed, LiveMidiSourceId source = kAnyLiveMidiSource,
+                           int latencySamples = 0);
+
+    void render(const BlockInfo& /*block*/, juce::MidiBuffer& out) override;
+
+    /// As LiveAudioInput::latencySamples, for the MIDI port.
+    int latencySamples() const {
+        return latencySamples_;
+    }
+
+    /// Events dropped for want of room in the port's byte budget
+    /// (kMaxMidiBytesPerPort). Read from any thread.
+    std::uint32_t droppedEvents() const {
+        return dropped_.load(std::memory_order_relaxed);
+    }
+
+  private:
+    const LiveInputFeed& feed_;
+    LiveMidiSourceId source_ = kAnyLiveMidiSource;
+    int latencySamples_ = 0;
+    std::atomic<std::uint32_t> dropped_{0};
+};
+
+}  // namespace magda::engine

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -418,6 +418,9 @@ if(MAGDA_BUILD_NATIVE_ENGINE)
     list(APPEND TEST_SOURCES engine/test_pcm_quantiser.cpp)
     list(APPEND TEST_SOURCES engine/test_audio_file_sink.cpp)
     list(APPEND TEST_SOURCES engine/test_insert_capture_session.cpp)
+    # What an armed or monitoring track hears (#2459): the callback's own
+    # samples, its own piece of a split callback, and nothing between callbacks.
+    list(APPEND TEST_SOURCES engine/test_live_input.cpp)
     list(APPEND TEST_SOURCES engine/test_engine_taps.cpp)
     list(APPEND TEST_SOURCES engine/test_clip_snapshot.cpp)
     list(APPEND TEST_SOURCES engine/test_clip_voice.cpp)

--- a/tests/engine/test_live_input.cpp
+++ b/tests/engine/test_live_input.cpp
@@ -189,6 +189,7 @@ TEST_CASE("An input op is compiled for a track that is armed or monitoring in",
 TEST_CASE("A live audio input reads the callback's own samples", "[engine][live-input]") {
     const auto captured = rampBuffer(2, kBlockSize);
     LiveInputFeed feed;
+    feed.prepare(2, kBlockSize);
     feed.beginCallback({blockOf(captured), {}}, kBlockSize);
     feed.beginSegment(0, kBlockSize);
 
@@ -247,6 +248,7 @@ TEST_CASE("A live audio input reads the callback's own samples", "[engine][live-
 TEST_CASE("A live audio input renders silence with no callback around it", "[engine][live-input]") {
     const auto captured = rampBuffer(2, kBlockSize);
     LiveInputFeed feed;
+    feed.prepare(2, kBlockSize);
     static constexpr std::array<int, 2> stereo{0, 1};
     LiveAudioInput input(feed, stereo);
 
@@ -283,6 +285,7 @@ TEST_CASE("A live MIDI input keeps the offsets the host stamped", "[engine][live
                                                 LiveMidiStream{2, &pads}};
 
     LiveInputFeed feed;
+    feed.prepare(2, kBlockSize);
     feed.beginCallback({{}, streams}, kBlockSize);
     feed.beginSegment(0, kBlockSize);
 
@@ -333,6 +336,7 @@ TEST_CASE("A live MIDI burst past the port's budget is dropped and counted",
     const std::array<LiveMidiStream, 1> streams{LiveMidiStream{1, &flood}};
 
     LiveInputFeed feed;
+    feed.prepare(2, kBlockSize);
     feed.beginCallback({{}, streams}, kBlockSize);
     feed.beginSegment(0, kBlockSize);
 
@@ -348,6 +352,7 @@ TEST_CASE("A live MIDI burst past the port's budget is dropped and counted",
 TEST_CASE("An input declares its latency and the plan is not compensated for it",
           "[engine][live-input]") {
     LiveInputFeed feed;
+    feed.prepare(2, kBlockSize);
     static constexpr std::array<int, 2> stereo{0, 1};
     const LiveAudioInput input(feed, stereo, 512);
     const LiveMidiInput midi(feed, kAnyLiveMidiSource, 512);
@@ -372,6 +377,7 @@ TEST_CASE("A monitoring track hears its live input through the plan", "[engine][
     LiveInputFactory factory;
     EngineSession session(factory);
     factory.feed = &session.liveInputs();
+    session.liveInputs().prepare(2, kBlockSize);
 
     const std::vector<TrackInfo> tracks{monitoringTrack(InputMonitorMode::In, false)};
     const auto plan = compile(tracks);
@@ -405,6 +411,7 @@ TEST_CASE("Each piece of a callback the loop wraps inside reads its own input",
     LiveInputFactory factory;
     EngineSession session(factory);
     factory.feed = &session.liveInputs();
+    session.liveInputs().prepare(2, kBlockSize);
 
     const std::vector<TrackInfo> tracks{monitoringTrack(InputMonitorMode::In, false)};
     const auto plan = compile(tracks);
@@ -440,4 +447,84 @@ TEST_CASE("Each piece of a callback the loop wraps inside reads its own input",
     for (auto sample = 0; sample < kBlockSize; ++sample)
         CHECK(tapped.rendered[tail + static_cast<std::size_t>(sample)] ==
               captured.getSample(0, sample));
+}
+
+TEST_CASE("A host handing one buffer for input and output keeps its input",
+          "[engine][live-input]") {
+    LiveInputFactory factory;
+    EngineSession session(factory);
+    factory.feed = &session.liveInputs();
+    session.liveInputs().prepare(2, kBlockSize);
+
+    const std::vector<TrackInfo> tracks{monitoringTrack(InputMonitorMode::In, false)};
+    const auto plan = compile(tracks);
+    REQUIRE(publish(session, plan, tracks).published);
+    REQUIRE(factory.lastAudioInput != nullptr);
+
+    // An AudioProcessor is handed one buffer for both, and the render clears
+    // and fills the output before an input op reads anything. The feed copies
+    // the input at the top of the callback, so the two do not have to be
+    // different memory (#2467 review).
+    auto shared = rampBuffer(2, kBlockSize);
+    session.process(kBlockSize, shared, {blockOf(shared), {}});
+
+    auto& tapped = *factory.lastAudioInput;
+    REQUIRE(tapped.rendered.size() == static_cast<std::size_t>(kBlockSize));
+
+    const auto expected = rampBuffer(2, kBlockSize);
+    for (auto sample = 0; sample < kBlockSize; ++sample)
+        CHECK(tapped.rendered[static_cast<std::size_t>(sample)] == expected.getSample(0, sample));
+
+    CHECK(shared.getMagnitude(0, kBlockSize) > 0.0f);
+    CHECK(session.liveInputs().unfitCallbacks() == 0);
+}
+
+TEST_CASE("A feed with no room for a callback reads silence and counts it",
+          "[engine][live-input]") {
+    const auto captured = rampBuffer(2, kBlockSize);
+    static constexpr std::array<int, 2> stereo{0, 1};
+
+    SECTION("with nothing prepared at all") {
+        LiveInputFeed feed;
+        LiveAudioInput input(feed, stereo);
+
+        feed.beginCallback({blockOf(captured), {}}, kBlockSize);
+        feed.beginSegment(0, kBlockSize);
+
+        juce::AudioBuffer<float> out(2, kBlockSize);
+        input.render(blockInfo(kBlockSize), juce::dsp::AudioBlock<float>(out));
+
+        CHECK(out.getMagnitude(0, kBlockSize) == 0.0f);
+        CHECK(feed.unfitCallbacks() == 1);
+    }
+
+    SECTION("and with room for fewer channels than arrived") {
+        LiveInputFeed feed;
+        feed.prepare(1, kBlockSize);
+        LiveAudioInput input(feed, stereo);
+
+        feed.beginCallback({blockOf(captured), {}}, kBlockSize);
+        feed.beginSegment(0, kBlockSize);
+
+        juce::AudioBuffer<float> out(2, kBlockSize);
+        input.render(blockInfo(kBlockSize), juce::dsp::AudioBlock<float>(out));
+
+        // The channel it had room for is the input's; the one it did not is
+        // silence, counted twice over: by the feed and by the source.
+        for (auto sample = 0; sample < kBlockSize; ++sample)
+            CHECK(out.getSample(0, sample) == captured.getSample(0, sample));
+
+        CHECK(out.getMagnitude(1, 0, kBlockSize) == 0.0f);
+        CHECK(feed.unfitCallbacks() == 1);
+        CHECK(input.missingChannelBlocks() == 1);
+    }
+
+    SECTION("and prepare only ever grows the room") {
+        LiveInputFeed feed;
+        feed.prepare(4, 512);
+        feed.prepare(2, kBlockSize);
+
+        CHECK(feed.preparedChannels() == 4);
+        CHECK(feed.preparedBlockSize() == 512);
+    }
 }

--- a/tests/engine/test_live_input.cpp
+++ b/tests/engine/test_live_input.cpp
@@ -1,0 +1,443 @@
+#include <array>
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "core/TrackInfo.hpp"
+#include "exec/EngineSession.hpp"
+#include "exec/PlanLayout.hpp"
+#include "exec/PlanValues.hpp"
+#include "io/LiveInput.hpp"
+#include "plan/PlanCompiler.hpp"
+#include "plan/RenderPlan.hpp"
+
+/**
+ * @file test_live_input.cpp
+ * @brief What an armed or monitoring track hears (#2459).
+ *
+ * The input ops were already compiled and already had bindings; what is new is
+ * everything behind them. So these cases are about what a live source reads
+ * and when: the callback's own samples, its own piece of a split callback, and
+ * nothing at all outside a callback.
+ */
+
+using namespace magda;
+using magda::engine::BlockInfo;
+using magda::engine::EngineAudioSource;
+using magda::engine::EngineSession;
+using magda::engine::kAnyLiveMidiSource;
+using magda::engine::kMaxMidiBytesPerPort;
+using magda::engine::LiveAudioInput;
+using magda::engine::LiveInputFeed;
+using magda::engine::LiveMidiInput;
+using magda::engine::LiveMidiStream;
+using magda::engine::OpKind;
+using magda::engine::PlanValues;
+using magda::engine::RenderContext;
+using magda::engine::RenderPlan;
+using magda::engine::RuntimeStateFactory;
+
+namespace {
+
+constexpr int kBlockSize = 64;
+
+TrackInfo makeMaster() {
+    TrackInfo master;
+    master.id = MASTER_TRACK_ID;
+    master.type = TrackType::Master;
+    master.name = "Master";
+    return master;
+}
+
+/// A track pointed at hardware, which is what makes its input route External.
+TrackInfo monitoringTrack(InputMonitorMode monitor, bool armed) {
+    TrackInfo track;
+    track.id = 1;
+    track.type = TrackType::Media;
+    track.name = "Track 1";
+    track.audioOutputDevice = "master";
+    track.audioInputDevice = "In 1 + 2";
+    track.midiInputDevice = "all";
+    track.inputMonitor = monitor;
+    track.recordArmed = armed;
+    return track;
+}
+
+int countKind(const RenderPlan& plan, OpKind kind) {
+    int found = 0;
+    for (const auto& op : plan.ops)
+        if (op.kind == kind)
+            ++found;
+    return found;
+}
+
+std::shared_ptr<const RenderPlan> compile(const std::vector<TrackInfo>& tracks) {
+    return std::make_shared<const RenderPlan>(
+        magda::engine::compileRenderPlan(tracks, makeMaster()));
+}
+
+int inputOpsFor(InputMonitorMode monitor, bool armed, OpKind kind) {
+    const std::vector<TrackInfo> tracks{monitoringTrack(monitor, armed)};
+    return countKind(*compile(tracks), kind);
+}
+
+/// A block of samples whose value says which sample it is, so a window onto
+/// the wrong part of a callback reads as a wrong number rather than a wrong
+/// shape.
+juce::AudioBuffer<float> rampBuffer(int numChannels, int numSamples) {
+    juce::AudioBuffer<float> buffer(numChannels, numSamples);
+    for (auto channel = 0; channel < numChannels; ++channel)
+        for (auto sample = 0; sample < numSamples; ++sample)
+            buffer.setSample(channel, sample,
+                             static_cast<float>(sample) + (100.0f * static_cast<float>(channel)));
+    return buffer;
+}
+
+juce::dsp::AudioBlock<const float> blockOf(const juce::AudioBuffer<float>& buffer) {
+    return juce::dsp::AudioBlock<const float>(buffer);
+}
+
+BlockInfo blockInfo(int numSamples) {
+    BlockInfo block;
+    block.numSamples = numSamples;
+    block.sampleRate = 44100.0;
+    return block;
+}
+
+/// Renders through a live input and keeps what came out, so a case can assert
+/// on the source itself rather than on whatever the chain did to it afterwards.
+class TappedAudioInput final : public EngineAudioSource {
+  public:
+    TappedAudioInput(const LiveInputFeed& feed, std::span<const int> channels)
+        : input_(feed, channels) {}
+
+    void render(const BlockInfo& block, juce::dsp::AudioBlock<float> out) override {
+        input_.render(block, out);
+
+        for (std::size_t sample = 0; sample < out.getNumSamples(); ++sample)
+            rendered.push_back(out.getSample(0, static_cast<int>(sample)));
+
+        blockSizes.push_back(static_cast<int>(out.getNumSamples()));
+    }
+
+    std::vector<float> rendered;
+    std::vector<int> blockSizes;
+
+  private:
+    LiveAudioInput input_;
+};
+
+/// Binds one live audio input against the session's own feed. The feed is set
+/// after the session exists, which is the order a host wires this in: the
+/// session owns the feed and the factory is what the session was built with.
+class LiveInputFactory final : public RuntimeStateFactory {
+  public:
+    std::unique_ptr<EngineAudioSource> createAudioInput(TrackId) override {
+        static constexpr std::array<int, 2> stereo{0, 1};
+        REQUIRE(feed != nullptr);
+        auto source = std::make_unique<TappedAudioInput>(*feed, stereo);
+        lastAudioInput = source.get();
+        return source;
+    }
+
+    LiveInputFeed* feed = nullptr;
+    TappedAudioInput* lastAudioInput = nullptr;
+};
+
+RenderContext context() {
+    return RenderContext{44100.0, kBlockSize, 2};
+}
+
+EngineSession::Result publish(EngineSession& session, const std::shared_ptr<const RenderPlan>& plan,
+                              const std::vector<TrackInfo>& tracks) {
+    PlanValues values;
+    magda::engine::resolvePlanValues(*plan, tracks, makeMaster(), values);
+    return session.publish(plan, context(),
+                           magda::engine::collectRuntimeStateIds(tracks, makeMaster()),
+                           std::move(values));
+}
+
+magda::engine::TransportSnapshot rolling(double fromBeat) {
+    magda::engine::TransportSnapshot transport;
+    transport.request.generation = 1;
+    transport.request.playing = true;
+    transport.request.positionBeat = fromBeat;
+    return transport;
+}
+
+}  // namespace
+
+TEST_CASE("An input op is compiled for a track that is armed or monitoring in",
+          "[engine][live-input]") {
+    // monitorsInput(): armed, or monitoring set to In. Auto lights the activity
+    // indicator (receivesLiveMidiInput) but is not audible until the track is
+    // armed, which is what ships and what the compiler gates on.
+    CHECK(inputOpsFor(InputMonitorMode::Off, false, OpKind::AudioInput) == 0);
+    CHECK(inputOpsFor(InputMonitorMode::Auto, false, OpKind::AudioInput) == 0);
+    CHECK(inputOpsFor(InputMonitorMode::In, false, OpKind::AudioInput) == 1);
+    CHECK(inputOpsFor(InputMonitorMode::Off, true, OpKind::AudioInput) == 1);
+    CHECK(inputOpsFor(InputMonitorMode::Auto, true, OpKind::AudioInput) == 1);
+
+    CHECK(inputOpsFor(InputMonitorMode::Off, false, OpKind::MidiInput) == 0);
+    CHECK(inputOpsFor(InputMonitorMode::Auto, false, OpKind::MidiInput) == 0);
+    CHECK(inputOpsFor(InputMonitorMode::In, false, OpKind::MidiInput) == 1);
+    CHECK(inputOpsFor(InputMonitorMode::Off, true, OpKind::MidiInput) == 1);
+}
+
+TEST_CASE("A live audio input reads the callback's own samples", "[engine][live-input]") {
+    const auto captured = rampBuffer(2, kBlockSize);
+    LiveInputFeed feed;
+    feed.beginCallback({blockOf(captured), {}}, kBlockSize);
+    feed.beginSegment(0, kBlockSize);
+
+    juce::AudioBuffer<float> out(2, kBlockSize);
+    out.clear();
+
+    SECTION("channel for channel, where the map names both") {
+        static constexpr std::array<int, 2> stereo{0, 1};
+        LiveAudioInput input(feed, stereo);
+        input.render(blockInfo(kBlockSize), juce::dsp::AudioBlock<float>(out));
+
+        for (auto sample = 0; sample < kBlockSize; ++sample) {
+            CHECK(out.getSample(0, sample) == captured.getSample(0, sample));
+            CHECK(out.getSample(1, sample) == captured.getSample(1, sample));
+        }
+        CHECK(input.missingChannelBlocks() == 0);
+    }
+
+    SECTION("a mono input fills both ears rather than the left one") {
+        static constexpr std::array<int, 1> mono{1};
+        LiveAudioInput input(feed, mono);
+        input.render(blockInfo(kBlockSize), juce::dsp::AudioBlock<float>(out));
+
+        for (auto sample = 0; sample < kBlockSize; ++sample) {
+            CHECK(out.getSample(0, sample) == captured.getSample(1, sample));
+            CHECK(out.getSample(1, sample) == captured.getSample(1, sample));
+        }
+        CHECK(input.missingChannelBlocks() == 0);
+    }
+
+    SECTION("a channel the device does not have is silence, and is counted") {
+        static constexpr std::array<int, 2> beyond{0, 7};
+        LiveAudioInput input(feed, beyond);
+        input.render(blockInfo(kBlockSize), juce::dsp::AudioBlock<float>(out));
+
+        CHECK(out.getSample(0, 3) == captured.getSample(0, 3));
+        CHECK(out.getSample(1, 3) == 0.0f);
+        CHECK(input.missingChannelBlocks() == 1);
+    }
+
+    SECTION("and a block of a split callback reads its own part of it") {
+        static constexpr std::array<int, 2> stereo{0, 1};
+        LiveAudioInput input(feed, stereo);
+
+        const auto half = kBlockSize / 2;
+        feed.beginSegment(half, half);
+
+        juce::AudioBuffer<float> second(2, half);
+        input.render(blockInfo(half), juce::dsp::AudioBlock<float>(second));
+
+        for (auto sample = 0; sample < half; ++sample)
+            CHECK(second.getSample(0, sample) == captured.getSample(0, half + sample));
+    }
+}
+
+TEST_CASE("A live audio input renders silence with no callback around it", "[engine][live-input]") {
+    const auto captured = rampBuffer(2, kBlockSize);
+    LiveInputFeed feed;
+    static constexpr std::array<int, 2> stereo{0, 1};
+    LiveAudioInput input(feed, stereo);
+
+    juce::AudioBuffer<float> out(2, kBlockSize);
+
+    SECTION("before the first one") {
+        for (auto sample = 0; sample < kBlockSize; ++sample)
+            out.setSample(0, sample, 1.0f);
+
+        input.render(blockInfo(kBlockSize), juce::dsp::AudioBlock<float>(out));
+        CHECK(out.getMagnitude(0, kBlockSize) == 0.0f);
+    }
+
+    SECTION("and after the last one ends") {
+        feed.beginCallback({blockOf(captured), {}}, kBlockSize);
+        feed.beginSegment(0, kBlockSize);
+        feed.endCallback();
+
+        input.render(blockInfo(kBlockSize), juce::dsp::AudioBlock<float>(out));
+        CHECK(out.getMagnitude(0, kBlockSize) == 0.0f);
+    }
+}
+
+TEST_CASE("A live MIDI input keeps the offsets the host stamped", "[engine][live-input]") {
+    juce::MidiBuffer keyboard;
+    keyboard.addEvent(juce::MidiMessage::noteOn(1, 60, 1.0f), 0);
+    keyboard.addEvent(juce::MidiMessage::noteOn(1, 64, 1.0f), 17);
+    keyboard.addEvent(juce::MidiMessage::noteOff(1, 60), 63);
+
+    juce::MidiBuffer pads;
+    pads.addEvent(juce::MidiMessage::noteOn(10, 36, 1.0f), 20);
+
+    const std::array<LiveMidiStream, 2> streams{LiveMidiStream{1, &keyboard},
+                                                LiveMidiStream{2, &pads}};
+
+    LiveInputFeed feed;
+    feed.beginCallback({{}, streams}, kBlockSize);
+    feed.beginSegment(0, kBlockSize);
+
+    juce::MidiBuffer out;
+
+    SECTION("from the device the track names") {
+        LiveMidiInput input(feed, 1);
+        input.render(blockInfo(kBlockSize), out);
+
+        std::vector<int> positions;
+        std::vector<int> notes;
+        for (const auto metadata : out) {
+            positions.push_back(metadata.samplePosition);
+            notes.push_back(metadata.getMessage().getNoteNumber());
+        }
+
+        const std::vector<int> expectedPositions{0, 17, 63};
+        const std::vector<int> expectedNotes{60, 64, 60};
+        CHECK(positions == expectedPositions);
+        CHECK(notes == expectedNotes);
+        CHECK(input.droppedEvents() == 0);
+    }
+
+    SECTION("or from every device at once") {
+        LiveMidiInput input(feed, kAnyLiveMidiSource);
+        input.render(blockInfo(kBlockSize), out);
+
+        CHECK(out.getNumEvents() == 4);
+    }
+
+    SECTION("and a block of a split callback takes only its own, re-offset") {
+        LiveMidiInput input(feed, 1);
+        feed.beginSegment(16, 16);
+        input.render(blockInfo(16), out);
+
+        REQUIRE(out.getNumEvents() == 1);
+        for (const auto metadata : out)
+            CHECK(metadata.samplePosition == 1);
+    }
+}
+
+TEST_CASE("A live MIDI burst past the port's budget is dropped and counted",
+          "[engine][live-input]") {
+    juce::MidiBuffer flood;
+    for (auto event = 0; event < 1000; ++event)
+        flood.addEvent(juce::MidiMessage::controllerEvent(1, 74, event % 128), event % kBlockSize);
+
+    const std::array<LiveMidiStream, 1> streams{LiveMidiStream{1, &flood}};
+
+    LiveInputFeed feed;
+    feed.beginCallback({{}, streams}, kBlockSize);
+    feed.beginSegment(0, kBlockSize);
+
+    LiveMidiInput input(feed, 1);
+    juce::MidiBuffer out;
+    input.render(blockInfo(kBlockSize), out);
+
+    CHECK(out.data.size() <= kMaxMidiBytesPerPort);
+    CHECK(input.droppedEvents() > 0);
+    CHECK(out.getNumEvents() + static_cast<int>(input.droppedEvents()) == 1000);
+}
+
+TEST_CASE("An input declares its latency and the plan is not compensated for it",
+          "[engine][live-input]") {
+    LiveInputFeed feed;
+    static constexpr std::array<int, 2> stereo{0, 1};
+    const LiveAudioInput input(feed, stereo, 512);
+    const LiveMidiInput midi(feed, kAnyLiveMidiSource, 512);
+
+    CHECK(input.latencySamples() == 512);
+    CHECK(midi.latencySamples() == 512);
+
+    // What arrives has already happened, so the compensation pass is never told
+    // about it: delaying the rest of the graph to match would put playback and
+    // the click behind the live signal. The number places a recorded take
+    // (#2461) and does nothing to the plan.
+    const std::vector<TrackInfo> tracks{monitoringTrack(InputMonitorMode::In, false)};
+    const auto plan = compile(tracks);
+    const auto layout = magda::engine::resolveLayout(*plan, std::vector<int>(plan->ops.size(), 0));
+
+    CHECK(layout.latency.outputLatency == 0);
+    for (const auto delay : layout.latency.delaySamples)
+        CHECK(delay == 0);
+}
+
+TEST_CASE("A monitoring track hears its live input through the plan", "[engine][live-input]") {
+    LiveInputFactory factory;
+    EngineSession session(factory);
+    factory.feed = &session.liveInputs();
+
+    const std::vector<TrackInfo> tracks{monitoringTrack(InputMonitorMode::In, false)};
+    const auto plan = compile(tracks);
+    REQUIRE(publish(session, plan, tracks).published);
+    REQUIRE(factory.lastAudioInput != nullptr);
+
+    const auto captured = rampBuffer(2, kBlockSize);
+    juce::AudioBuffer<float> output(2, kBlockSize);
+    output.clear();
+
+    session.process(kBlockSize, output, {blockOf(captured), {}});
+
+    auto& tapped = *factory.lastAudioInput;
+    REQUIRE(tapped.rendered.size() == static_cast<std::size_t>(kBlockSize));
+
+    for (auto sample = 0; sample < kBlockSize; ++sample)
+        CHECK(tapped.rendered[static_cast<std::size_t>(sample)] == captured.getSample(0, sample));
+
+    // It reached the master rather than stopping at the op.
+    CHECK(output.getMagnitude(0, kBlockSize) > 0.0f);
+
+    // And the feed is closed once the callback is over, so a source reached
+    // between callbacks reads nothing rather than the last one's samples.
+    juce::AudioBuffer<float> afterwards(2, kBlockSize);
+    tapped.render(blockInfo(kBlockSize), juce::dsp::AudioBlock<float>(afterwards));
+    CHECK(afterwards.getMagnitude(0, kBlockSize) == 0.0f);
+}
+
+TEST_CASE("Each piece of a callback the loop wraps inside reads its own input",
+          "[engine][live-input]") {
+    LiveInputFactory factory;
+    EngineSession session(factory);
+    factory.feed = &session.liveInputs();
+
+    const std::vector<TrackInfo> tracks{monitoringTrack(InputMonitorMode::In, false)};
+    const auto plan = compile(tracks);
+    REQUIRE(publish(session, plan, tracks).published);
+    REQUIRE(factory.lastAudioInput != nullptr);
+
+    // A loop one beat long at 120 bpm is 22050 samples, which a callback of 64
+    // lands inside of after 344 of them.
+    auto transport = rolling(0.0);
+    transport.loop = {true, 0.0, 1.0};
+    session.publishTransport(transport);
+
+    juce::AudioBuffer<float> output(2, kBlockSize);
+    const auto captured = rampBuffer(2, kBlockSize);
+
+    for (auto block = 0; block < 345; ++block) {
+        output.clear();
+        session.process(kBlockSize, output, {blockOf(captured), {}});
+    }
+
+    auto& tapped = *factory.lastAudioInput;
+    REQUIRE(tapped.blockSizes.size() == 346);
+
+    const auto first = tapped.blockSizes[344];
+    const auto second = tapped.blockSizes[345];
+    CHECK(first + second == kBlockSize);
+    CHECK(first > 0);
+    CHECK(second > 0);
+
+    // The wrap splits the timeline, not the input: the two pieces read the
+    // callback's samples in order, and neither re-reads the first ones.
+    const auto tail = tapped.rendered.size() - static_cast<std::size_t>(kBlockSize);
+    for (auto sample = 0; sample < kBlockSize; ++sample)
+        CHECK(tapped.rendered[tail + static_cast<std::size_t>(sample)] ==
+              captured.getSample(0, sample));
+}


### PR DESCRIPTION
Slice 1 of #1895, closes #2459.

## What was missing

Less than it looked like. `PlanCompiler` already emits an `AudioInput` or `MidiInput` op for a track whose input route is External, tags it `LivenessDomain::Live`, and leaves it out entirely for a track that is neither armed nor monitoring; `PlanBindings` already has `audioInputs` and `midiInputs` keyed by track, and `PlanExecutor` already renders them through whatever is bound. Arming was structural before this and still is.

What was missing was anything to bind. `EngineSession::process(int numSamples, juce::AudioBuffer<float>& output)` took an output buffer and nothing else, so the callback's input had no way into a render at all.

## What this adds

`magda/engine/io/LiveInput`:

- **`LiveInputFeed`** holds the callback's input and narrows it to each block. A callback a loop wraps inside renders as two blocks, and the input is not timeline material and knows nothing about that, so the window is handed out per block rather than read per callback. It is closed when the callback ends, so a source reached between callbacks reads silence rather than the last one's samples.
- **`LiveAudioInput`** reads the channels its track was pointed at. A destination wider than the map repeats the map's last channel, which is what `WaveInputDeviceNode::process` does (it copies its last read channel across the remaining destination channels), so a mono input is heard in both ears rather than only the left. A channel the device does not have is silence and is counted, since a wrong channel map is otherwise indistinguishable from a quiet room.
- **`LiveMidiInput`** takes one device's events or every device's, at the offsets the host stamped. The fork collects messages between callbacks and places them relative to the first one's timestamp, which its own comment calls "near enough for live stuff" (`MidiInputDeviceNode::processSection`); a stamp against the block the event arrived in is what #2462 needs to record a note where it was played. A burst past the port's byte budget is dropped and counted rather than overrunning `kMaxMidiBytesPerPort`.

`EngineSession::process` takes a `LiveInputBlock` alongside the output it fills, defaulted for the hosts that have no inputs and for every offline render. `liveInputs()` hands the host the feed to build sources against, which it binds through the `createAudioInput` / `createMidiInput` hooks the factory already had.

Which hardware channels a track's `audioInputDevice` names, and which device its `midiInputDevice` names, stays the host's to resolve: the engine knows channel indices and an opaque source id, never a device name.

## One decision, and it reverses what the issue said

Input latency is declared on the source and never handed to the compensation pass. The issue asked for it to be carried by the plan so the monitored path was "compensated like any other latency", and that is wrong: what arrives has already happened, so declaring it would delay every other branch to match, putting playback and the click behind the live signal rather than aligning anything. The number exists to place a recorded take, which is #2461's job. #2459 has been corrected to say so, and a case pins it: a plan carrying an input op resolves to no delay at all.

## Verification

`tests/engine/test_live_input.cpp`, eight cases, offline throughout:

- the compiler gate over all six monitor-mode and armed combinations, including that `Auto` alone is silent until the track is armed
- the callback's own samples channel for channel, and a mono input in both ears
- a channel the device does not have reading silence, and being counted
- a block of a split callback reading its own part of the input, both as a unit and through a real session with a loop set, where the two pieces of the wrapped callback read the input in order
- MIDI at the offsets the host stamped, filtered to one device or merged across all, re-offset inside a split callback
- a 1000-event burst dropping exactly what the byte budget cannot hold
- silence before the first callback and after the last one ends

Full engine suite green locally: 958 cases, 680,001 assertions.

## Not in this PR

Anything that writes. No queue, no file, no take: a monitored input is audible and nothing else. The capture queue and writer thread are #2460, which is independent of this and can go in either order.

https://claude.ai/code/session_013A1GWqAoLZPdkYAMwKrjQj
