### PR TITLE
Stop calling virtual methods from constructors and destructors

### DIFF
--- a/magda/daw/engine/TracktionEngineWrapper.hpp
+++ b/magda/daw/engine/TracktionEngineWrapper.hpp
@@ -74,7 +74,7 @@ class TracktionEngineWrapper : public AudioEngine,
 
     // Initialize the engine
     bool initialize() override;
-    void shutdown() override;
+    void shutdown() final;
     bool hasActiveEdit() const override {
         return currentEdit_ != nullptr;
     }

--- a/magda/daw/ui/components/automation/AutomationCurveEditor.hpp
+++ b/magda/daw/ui/components/automation/AutomationCurveEditor.hpp
@@ -188,7 +188,7 @@ class AutomationCurveEditor : public CurveEditorBase,
     // edges would overhang the clip borders into the pads — clip it out.
     void paintCurve(juce::Graphics& g) override;
     void syncSelectionState() override;
-    void rebuildPointComponents() override;
+    void rebuildPointComponents() final;
 
   private:
     AutomationLaneId laneId_;

--- a/magda/daw/ui/components/automation/AutomationLaneComponent.hpp
+++ b/magda/daw/ui/components/automation/AutomationLaneComponent.hpp
@@ -32,7 +32,7 @@ class AutomationLaneComponent : public juce::Component,
     void paint(juce::Graphics& g) override;
     void paintOverChildren(juce::Graphics& g) override;
     void modifierKeysChanged(const juce::ModifierKeys& modifiers) override;
-    void resized() override;
+    void resized() final;
 
     // Mouse interaction
     void mouseDown(const juce::MouseEvent& e) override;

--- a/magda/daw/ui/components/chain/DeviceSlotComponent.hpp
+++ b/magda/daw/ui/components/chain/DeviceSlotComponent.hpp
@@ -135,8 +135,8 @@ class DeviceSlotComponent : public NodeComponent,
     }
 
     // Mod/macro data providers
-    const magda::ModArray* getModsData() const override;
-    const magda::MacroArray* getMacrosData() const override;
+    const magda::ModArray* getModsData() const final;
+    const magda::MacroArray* getMacrosData() const final;
     std::vector<std::pair<magda::DeviceId, juce::String>> getAvailableDevices() const override;
     std::map<magda::DeviceId, std::vector<juce::String>> getDeviceParamNames() const override;
 

--- a/magda/daw/ui/components/common/BarsBeatsTicksLabel.hpp
+++ b/magda/daw/ui/components/common/BarsBeatsTicksLabel.hpp
@@ -98,7 +98,7 @@ class BarsBeatsTicksLabel : public juce::Component {
 
     // Component overrides
     void paint(juce::Graphics& g) override;
-    void resized() override;
+    void resized() final;
 
   private:
     // Width each segment needs for the digits it is showing right now; the

--- a/magda/daw/ui/components/mixer/MixAnalysisModal.hpp
+++ b/magda/daw/ui/components/mixer/MixAnalysisModal.hpp
@@ -23,7 +23,7 @@ class MixAnalysisModal : public juce::Component, public MixAnalysisService::List
     ~MixAnalysisModal() override;
 
     void paint(juce::Graphics& g) override;
-    void resized() override;
+    void resized() final;
     void parentHierarchyChanged() override;  // block input once shown + rendering
 
     // MixAnalysisService::Listener

--- a/magda/daw/ui/components/tracks/TrackContentPanel.hpp
+++ b/magda/daw/ui/components/tracks/TrackContentPanel.hpp
@@ -52,7 +52,7 @@ class TrackContentPanel : public juce::Component,
 
     void paint(juce::Graphics& g) override;
     void paintOverChildren(juce::Graphics& g) override;
-    void resized() override;
+    void resized() final;
 
     // Keyboard handling
     bool keyPressed(const juce::KeyPress& key) override;
@@ -61,7 +61,7 @@ class TrackContentPanel : public juce::Component,
     void timelineStateChanged(const TimelineState& state, ChangeFlags changes) override;
 
     // TrackManagerListener implementation
-    void tracksChanged() override;
+    void tracksChanged() final;
     void trackSelectionChanged(magda::TrackId trackId) override;
     void trackPropertyChanged(int trackId) override;
 

--- a/magda/daw/ui/components/tracks/TrackHeadersPanel.hpp
+++ b/magda/daw/ui/components/tracks/TrackHeadersPanel.hpp
@@ -50,7 +50,7 @@ class TrackHeadersPanel : public juce::Component,
     void timerCallback() override;
 
     // TrackManagerListener
-    void tracksChanged() override;
+    void tracksChanged() final;
     void trackPropertyChanged(int trackId) override;
     void trackDevicesChanged(magda::TrackId trackId) override;
     void devicePropertyChanged(const magda::ChainNodePath& devicePath) override;

--- a/magda/daw/ui/dialogs/AISettingsDialog.cpp
+++ b/magda/daw/ui/dialogs/AISettingsDialog.cpp
@@ -1052,7 +1052,7 @@ class AISettingsDialog::ConfigPage : public juce::Component {
         updateSetupUI();
     }
 
-    void resized() override {
+    void resized() final {
         auto bounds = getLocalBounds().reduced(12);
         const int rowH = 28;
         const int labelW = 80;
@@ -1785,7 +1785,7 @@ class AISettingsDialog::SampleTaggerPage : public juce::Component {
         refreshStatus();
     }
 
-    void resized() override {
+    void resized() final {
         auto bounds = getLocalBounds().reduced(12);
         const int rowH = 24;
         const int labelW = 110;
@@ -2410,7 +2410,7 @@ class AISettingsDialog::ModelDownloadsPage : public juce::Component {
         updateVisiblePage();
     }
 
-    void resized() override {
+    void resized() final {
         auto bounds = getLocalBounds().reduced(12);
         auto categoryRow = bounds.removeFromTop(28);
         categoryLabel_.setBounds(categoryRow.removeFromLeft(80));

--- a/magda/daw/ui/dialogs/AudioSettingsDialog.hpp
+++ b/magda/daw/ui/dialogs/AudioSettingsDialog.hpp
@@ -17,7 +17,7 @@ class CustomChannelSelector : public juce::Component {
                           AudioEngine* audioEngine);
     ~CustomChannelSelector() override;
 
-    void resized() override;
+    void resized() final;
     void paint(juce::Graphics& g) override;
     void updateFromDevice();
     void applyToDevice();

--- a/magda/daw/ui/panels/BottomPanel.cpp
+++ b/magda/daw/ui/panels/BottomPanel.cpp
@@ -269,6 +269,11 @@ BottomPanel::BottomPanel() : TabbedPanel(daw::ui::PanelLocation::Bottom) {
     // Create header controls
     setupHeaderControls();
 
+    // All header members the overrides below depend on now exist, so this is
+    // the earliest safe point to activate content — updateContentBasedOnSelection()
+    // relies on getActiveContent() already being valid (#2391).
+    completeConstruction();
+
     // Register as listener for selection changes
     ClipManager::getInstance().addListener(this);
     TrackManager::getInstance().addListener(this);

--- a/magda/daw/ui/panels/LeftPanel.cpp
+++ b/magda/daw/ui/panels/LeftPanel.cpp
@@ -6,6 +6,7 @@ namespace magda {
 
 LeftPanel::LeftPanel() : TabbedPanel(daw::ui::PanelLocation::Right) {
     setName("Left Panel");
+    completeConstruction();
 }
 
 void LeftPanel::setCollapsed(bool collapsed) {

--- a/magda/daw/ui/panels/RightPanel.cpp
+++ b/magda/daw/ui/panels/RightPanel.cpp
@@ -6,6 +6,7 @@ namespace magda {
 
 RightPanel::RightPanel() : TabbedPanel(daw::ui::PanelLocation::Left) {
     setName("Right Panel");
+    completeConstruction();
 }
 
 void RightPanel::setCollapsed(bool collapsed) {

--- a/magda/daw/ui/panels/TabbedPanel.cpp
+++ b/magda/daw/ui/panels/TabbedPanel.cpp
@@ -25,8 +25,11 @@ TabbedPanel::TabbedPanel(PanelLocation location) : location_(location), tabBar_(
 
     // Register as listener
     PanelController::getInstance().addListener(this);
+}
 
-    // Initialize from current state
+void TabbedPanel::completeConstruction() {
+    // Deferred from the constructor: resized()/getContentBounds()/onContentWillSwitch()
+    // are virtual, and subclasses (BottomPanel) override them (#2391).
     updateFromState();
 }
 

--- a/magda/daw/ui/panels/TabbedPanel.hpp
+++ b/magda/daw/ui/panels/TabbedPanel.hpp
@@ -104,6 +104,11 @@ class TabbedPanel : public juce::Component, public PanelStateListener {
      */
     virtual juce::Rectangle<int> getTabBarBounds();
 
+    // Call from every derived class's constructor, once the members its own
+    // overrides of the hooks above depend on exist, and before any code that
+    // assumes getActiveContent() is already valid.
+    void completeConstruction();
+
   private:
     PanelLocation location_;
     bool collapsed_ = false;

--- a/magda/daw/ui/panels/content/AIChatConsoleContent.hpp
+++ b/magda/daw/ui/panels/content/AIChatConsoleContent.hpp
@@ -75,7 +75,7 @@ class AIChatConsoleContent : public PanelContent,
     }
 
     void paint(juce::Graphics& g) override;
-    void resized() override;
+    void resized() final;
     void lookAndFeelChanged() override;
 
     void onActivated() override;
@@ -99,9 +99,9 @@ class AIChatConsoleContent : public PanelContent,
 
     // SelectionManagerListener
     void selectionTypeChanged(magda::SelectionType newType) override;
-    void trackSelectionChanged(magda::TrackId trackId) override;
+    void trackSelectionChanged(magda::TrackId trackId) final;
     void multiTrackSelectionChanged(const std::unordered_set<magda::TrackId>& trackIds) override;
-    void clipSelectionChanged(magda::ClipId clipId) override;
+    void clipSelectionChanged(magda::ClipId clipId) final;
     void multiClipSelectionChanged(const std::unordered_set<magda::ClipId>& clipIds) override;
     void chainNodeSelectionChanged(const magda::ChainNodePath& path) override;
 

--- a/magda/daw/ui/panels/content/DrumGridClipContent.cpp
+++ b/magda/daw/ui/panels/content/DrumGridClipContent.cpp
@@ -2386,6 +2386,9 @@ DrumGridClipContent::DrumGridClipContent() {
     if (editingClipId_ != magda::INVALID_CLIP_ID) {
         setClip(editingClipId_);
     }
+
+    // Deferred from the base constructor: needs gridComponent_ to exist (#2391).
+    applyClipGridSettings();
 }
 
 DrumGridClipContent::~DrumGridClipContent() {

--- a/magda/daw/ui/panels/content/DrumGridClipContent.hpp
+++ b/magda/daw/ui/panels/content/DrumGridClipContent.hpp
@@ -78,15 +78,15 @@ class DrumGridClipContent : public MidiEditorContent, private juce::Timer {
     int getLeftPanelWidth() const override {
         return SIDEBAR_WIDTH + ZOOM_STRIP_WIDTH + labelWidth_ + LABEL_DIVIDER_WIDTH;
     }
-    void updateGridSize() override;
+    void updateGridSize() final;
     void setGridPixelsPerBeat(double ppb) override;
     void setGridPlayheadPosition(double position) override;
     void setGridEditCursorPosition(double positionSeconds, bool visible) override;
     void onScrollPositionChanged(int scrollX, int scrollY) override;
-    void onGridResolutionChanged() override;
+    void onGridResolutionChanged() final;
     void updateGridLoopRegion() override;
     void setGridPhasePreview(double beats, bool active) override;
-    void applyOverlayTracks() override;
+    void applyOverlayTracks() final;
 
     // Fold hooks (base owns foldEnabled_/applyFold): drum fold filters the pad
     // rows to those that have notes rather than using the pitch fold map.
@@ -95,7 +95,7 @@ class DrumGridClipContent : public MidiEditorContent, private juce::Timer {
     void updateLaneToggleStates() override;
 
     // Override velocity lane methods
-    void updateVelocityLane() override;
+    void updateVelocityLane() final;
 
     // Live MIDI note monitor hooks (plumbing lives in MidiEditorContent):
     // highlight the played pad row and scroll it into view.

--- a/magda/daw/ui/panels/content/MediaExplorerContent.hpp
+++ b/magda/daw/ui/panels/content/MediaExplorerContent.hpp
@@ -36,7 +36,7 @@ class MediaExplorerContent : public PanelContent,
     }
 
     void paint(juce::Graphics& g) override;
-    void resized() override;
+    void resized() final;
     void lookAndFeelChanged() override;
 
     void onActivated() override;

--- a/magda/daw/ui/panels/content/MidiEditorContent.cpp
+++ b/magda/daw/ui/panels/content/MidiEditorContent.cpp
@@ -414,8 +414,9 @@ MidiEditorContent::MidiEditorContent() {
         }
     }
 
-    // Initialize grid from clip settings (or auto-compute from zoom)
-    applyClipGridSettings();
+    // Initial grid resolution is applied by each subclass, once its own grid
+    // component exists — onGridResolutionChanged() is virtual, and this base
+    // constructor can't reach a derived override yet (#2391).
 }
 
 MidiEditorContent::~MidiEditorContent() {

--- a/magda/daw/ui/panels/content/PianoRollContent.cpp
+++ b/magda/daw/ui/panels/content/PianoRollContent.cpp
@@ -350,6 +350,9 @@ PianoRollContent::PianoRollContent() {
         gridComponent_->setClip(editingClipId_);
         updateTimeRuler();
     }
+
+    // Deferred from the base constructor: needs gridComponent_ to exist (#2391).
+    applyClipGridSettings();
 }
 
 void PianoRollContent::applyOverlayTracks() {

--- a/magda/daw/ui/panels/content/PianoRollContent.hpp
+++ b/magda/daw/ui/panels/content/PianoRollContent.hpp
@@ -162,12 +162,12 @@ class PianoRollContent : public MidiEditorContent,
     int getLeftPanelWidth() const override {
         return SIDEBAR_WIDTH + ZOOM_STRIP_WIDTH + OCTAVE_LABEL_WIDTH + KEYBOARD_WIDTH;
     }
-    void updateGridSize() override;
+    void updateGridSize() final;
     void setGridPixelsPerBeat(double ppb) override;
     void setGridPlayheadPosition(double position) override;
     void setGridEditCursorPosition(double positionSeconds, bool visible) override;
     void onScrollPositionChanged(int scrollX, int scrollY) override;
-    void onGridResolutionChanged() override;
+    void onGridResolutionChanged() final;
     void updateGridLoopRegion() override;
     void setGridPhasePreview(double beats, bool active) override;
 
@@ -253,7 +253,7 @@ class PianoRollContent : public MidiEditorContent,
     void loadNoteHeightFromClip(magda::ClipId clipId);
 
     // Multi-track overlay: push the shared overlay set into the grid
-    void applyOverlayTracks() override;
+    void applyOverlayTracks() final;
 
     // Helper to get current header height based on chord row visibility
     int getHeaderHeight() const {

--- a/magda/daw/ui/panels/content/TrackChainContent.hpp
+++ b/magda/daw/ui/panels/content/TrackChainContent.hpp
@@ -57,7 +57,7 @@ class TrackChainContent : public PanelContent,
     }
 
     void paint(juce::Graphics& g) override;
-    void resized() override;
+    void resized() final;
     void lookAndFeelChanged() override;
     void mouseDown(const juce::MouseEvent& e) override;
     void mouseDrag(const juce::MouseEvent& e) override;

--- a/magda/daw/ui/panels/content/inspector/InspectorContainer.hpp
+++ b/magda/daw/ui/panels/content/inspector/InspectorContainer.hpp
@@ -37,7 +37,7 @@ class InspectorContainer : public PanelContent, public magda::SelectionManagerLi
     void onDeactivated() override;
 
     void paint(juce::Graphics& g) override;
-    void resized() override;
+    void resized() final;
 
     /**
      * @brief Set the timeline controller reference

--- a/magda/daw/ui/views/MainView.hpp
+++ b/magda/daw/ui/views/MainView.hpp
@@ -418,7 +418,7 @@ class MainView::MasterHeaderPanel : public juce::Component,
 
     // TrackManagerListener
     void tracksChanged() override {}
-    void masterChannelChanged() override;
+    void masterChannelChanged() final;
 
     // AutomationManagerListener
     void automationLanesChanged() override;

--- a/magda/daw/ui/views/MixerView.hpp
+++ b/magda/daw/ui/views/MixerView.hpp
@@ -58,7 +58,7 @@ class MixerView : public juce::Component,
     }
 
     void paint(juce::Graphics& g) override;
-    void resized() override;
+    void resized() final;
     void lookAndFeelChanged() override;
     bool keyPressed(const juce::KeyPress& key) override;
     void mouseMove(const juce::MouseEvent& event) override;
@@ -76,7 +76,7 @@ class MixerView : public juce::Component,
     void trackDevicesChanged(TrackId trackId) override;
     void devicePropertyChanged(const ChainNodePath& devicePath) override;
     void masterChannelChanged() override;
-    void trackSelectionChanged(TrackId trackId) override;
+    void trackSelectionChanged(TrackId trackId) final;
 
     // SelectionManagerListener
     void selectionTypeChanged(SelectionType newType) override;
@@ -116,7 +116,7 @@ class MixerView : public juce::Component,
 
         void paint(juce::Graphics& g) override;
         void paintOverChildren(juce::Graphics& g) override;
-        void resized() override;
+        void resized() final;
         void mouseDown(const juce::MouseEvent& event) override;
         void lookAndFeelChanged() override;
 

--- a/magda/daw/ui/views/SessionView.hpp
+++ b/magda/daw/ui/views/SessionView.hpp
@@ -47,7 +47,7 @@ class SessionView : public juce::Component,
 
     void paint(juce::Graphics& g) override;
     void paintOverChildren(juce::Graphics& g) override;
-    void resized() override;
+    void resized() final;
     void lookAndFeelChanged() override;
 
     // Timer callback for meter updates

--- a/magda/daw/ui/windows/MainWindow.hpp
+++ b/magda/daw/ui/windows/MainWindow.hpp
@@ -148,7 +148,7 @@ class MainWindow::MainComponent : public juce::Component,
 
     // TrackManagerListener
     void tracksChanged() override;
-    void trackPropertyChanged(int trackId) override;
+    void trackPropertyChanged(int trackId) final;
 
     // MidiLearnCoordinatorListener
     void midiLearnStateChanged(const magda::ChainNodePath& path, int paramIndex,


### PR DESCRIPTION
## Summary
- Closes #2391. The static analyser's `optin.cplusplus.VirtualCall` flagged 43 constructors/destructors calling a virtual method on `this`, where any override never runs.
- For every site with no subclass override, marks the method `final` so the compiler resolves the call directly instead of bypassing virtual dispatch.
- Where a real override exists — `TabbedPanel` (overridden by `BottomPanel`/`RightPanel`/`LeftPanel`) and `MidiEditorContent` (overridden by `PianoRollContent`/`DrumGridClipContent`) — defers the call via a `completeConstruction()`-style hook invoked from the derived class's own constructor, once the members its overrides depend on exist.
- Also fixes 2 more findings the same check turned up beyond the original 43 (`TrackContentPanel::resized`, `SessionView::resized`) — the general 43-item list `TrackContentPanel::tracksChanged` finding transitively called `resized()`, and `SessionView::rebuildTracks()` (base ctor path) did likewise.
- `BottomPanel`'s `completeConstruction()` call had to be placed carefully: right after `setupHeaderControls()` (so the header widgets its overrides need already exist) and *before* `updateContentBasedOnSelection()` (which assumes `getActiveContent()` is already valid) — an ordering bug caught by a Codex second-pass review.

## Test plan
- [x] `make debug` — builds clean
- [x] `make test` — 3711/3711 tests passing, 0 failures
- [x] Reran the exact command from the issue (`run-clang-tidy ... -checks='-*,clang-analyzer-optin.cplusplus.VirtualCall'` over `magda/`) — 0 remaining findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0149ko34fXR5PeMBqVL1tDWt