### PR TITLE
Remove default arguments from virtual methods

### DIFF
--- a/magda/agents/coder_agent.cpp
+++ b/magda/agents/coder_agent.cpp
@@ -28,8 +28,7 @@ class FaustCoderAgent : public CoderAgent {
     }
 
     juce::String generateAndApply(const juce::String& prompt, const ChainNodePath& path,
-                                  llm::Conversation& conversation,
-                                  TokenCallback onToken = {}) override {
+                                  llm::Conversation& conversation, TokenCallback onToken) override {
         if (plugins_ == nullptr)
             return "(MagdaApi plugin operations are unavailable)";
 

--- a/magda/agents/device_ai_agent.hpp
+++ b/magda/agents/device_ai_agent.hpp
@@ -43,7 +43,7 @@ class DeviceAIAgent {
     /// don't support multi-turn may ignore it.
     virtual juce::String generateAndApply(const juce::String& prompt, const ChainNodePath& path,
                                           llm::Conversation& conversation,
-                                          TokenCallback onToken = {}) = 0;
+                                          TokenCallback onToken) = 0;
 
     /// Best-effort cancel; safe to call from any thread.
     virtual void requestCancel() {}

--- a/magda/agents/generic_sound_design_agent.hpp
+++ b/magda/agents/generic_sound_design_agent.hpp
@@ -32,8 +32,7 @@ class GenericSoundDesignAgent : public SoundDesignAgent {
                             juce::String customPrompt = {});
 
     juce::String generateAndApply(const juce::String& prompt, const ChainNodePath& path,
-                                  llm::Conversation& conversation,
-                                  TokenCallback onToken = {}) override;
+                                  llm::Conversation& conversation, TokenCallback onToken) override;
 
     void setCategoryOverride(const juce::String& category) override {
         categoryOverride_ = category;

--- a/magda/agents/sound_design_agent.cpp
+++ b/magda/agents/sound_design_agent.cpp
@@ -28,8 +28,7 @@ class FourOscSoundDesignAgent : public SoundDesignAgent {
     explicit FourOscSoundDesignAgent(PluginApi* plugins) : plugins_(plugins) {}
 
     juce::String generateAndApply(const juce::String& prompt, const ChainNodePath& path,
-                                  llm::Conversation& conversation,
-                                  TokenCallback onToken = {}) override {
+                                  llm::Conversation& conversation, TokenCallback onToken) override {
         if (plugins_ == nullptr)
             return "(MagdaApi plugin operations are unavailable)";
 
@@ -163,8 +162,7 @@ class PolyStepSequencerSoundDesignAgent : public SoundDesignAgent {
     }
 
     juce::String generateAndApply(const juce::String& prompt, const ChainNodePath& path,
-                                  llm::Conversation& conversation,
-                                  TokenCallback onToken = {}) override {
+                                  llm::Conversation& conversation, TokenCallback onToken) override {
         if (plugins_ == nullptr)
             return "(MagdaApi plugin operations are unavailable)";
 
@@ -269,8 +267,7 @@ class StepSequencerSoundDesignAgent : public SoundDesignAgent {
     }
 
     juce::String generateAndApply(const juce::String& prompt, const ChainNodePath& path,
-                                  llm::Conversation& conversation,
-                                  TokenCallback onToken = {}) override {
+                                  llm::Conversation& conversation, TokenCallback onToken) override {
         if (plugins_ == nullptr)
             return "(MagdaApi plugin operations are unavailable)";
 

--- a/magda/daw/api/automation_api.hpp
+++ b/magda/daw/api/automation_api.hpp
@@ -74,8 +74,7 @@ class AutomationApi {
     virtual const AutomationClipInfo* getClip(AutomationClipId clipId) const = 0;
     virtual void deleteClip(AutomationClipId clipId) = 0;
     virtual void moveClip(AutomationClipId clipId, double startBeats) = 0;
-    virtual void resizeClip(AutomationClipId clipId, double lengthBeats,
-                            bool fromStart = false) = 0;
+    virtual void resizeClip(AutomationClipId clipId, double lengthBeats, bool fromStart) = 0;
     virtual AutomationClipId duplicateClip(AutomationClipId clipId) = 0;
     virtual void setClipName(AutomationClipId clipId, const juce::String& name) = 0;
     virtual void setClipColour(AutomationClipId clipId, juce::Colour colour) = 0;

--- a/magda/daw/api/clip_api.hpp
+++ b/magda/daw/api/clip_api.hpp
@@ -20,7 +20,10 @@ class ClipApi {
     virtual std::vector<ClipId> getClipsOnTrack(TrackId trackId) const = 0;
 
     virtual ClipId createMidiClipBeats(TrackId trackId, double startBeats, double lengthBeats,
-                                       ClipView view = ClipView::Arrangement) = 0;
+                                       ClipView view) = 0;
+    ClipId createMidiClipBeats(TrackId trackId, double startBeats, double lengthBeats) {
+        return createMidiClipBeats(trackId, startBeats, lengthBeats, ClipView::Arrangement);
+    }
     virtual void deleteClip(ClipId clipId) = 0;
 
     virtual void setClipName(ClipId clipId, const juce::String& name) = 0;
@@ -32,9 +35,8 @@ class ClipApi {
 
     virtual bool addMidiNote(ClipId clipId, double startBeat, int noteNumber, double lengthBeats,
                              int velocity) = 0;
-    virtual bool quantizeMidiNotes(
-        ClipId clipId, const std::vector<size_t>& noteIndices, double gridResolution,
-        MidiNoteQuantizeMode mode = MidiNoteQuantizeMode::StartAndLength) = 0;
+    virtual bool quantizeMidiNotes(ClipId clipId, const std::vector<size_t>& noteIndices,
+                                   double gridResolution, MidiNoteQuantizeMode mode) = 0;
     virtual bool sliceMidiNotes(ClipId clipId, const std::vector<size_t>& noteIndices,
                                 int subdivisions) = 0;
     virtual bool transposeMidiClip(ClipId clipId, int semitones) = 0;

--- a/magda/daw/api/track_api.hpp
+++ b/magda/daw/api/track_api.hpp
@@ -33,8 +33,14 @@ class TrackApi {
 
     virtual void setTrackName(TrackId trackId, const juce::String& name) = 0;
     virtual void setTrackColour(TrackId trackId, juce::Colour colour) = 0;
-    virtual void setTrackVolume(TrackId trackId, float volume, bool fromAutomation = false) = 0;
-    virtual void setTrackPan(TrackId trackId, float pan, bool fromAutomation = false) = 0;
+    virtual void setTrackVolume(TrackId trackId, float volume, bool fromAutomation) = 0;
+    void setTrackVolume(TrackId trackId, float volume) {
+        setTrackVolume(trackId, volume, false);
+    }
+    virtual void setTrackPan(TrackId trackId, float pan, bool fromAutomation) = 0;
+    void setTrackPan(TrackId trackId, float pan) {
+        setTrackPan(trackId, pan, false);
+    }
     virtual void setTrackMuted(TrackId trackId, bool muted) = 0;
     virtual void setTrackSoloed(TrackId trackId, bool soloed) = 0;
     virtual void setTrackRecordArmed(TrackId trackId, bool armed) = 0;

--- a/magda/daw/core/DeviceUiContext.hpp
+++ b/magda/daw/core/DeviceUiContext.hpp
@@ -67,7 +67,10 @@ class DeviceCommandController {
     virtual ~DeviceCommandController() = default;
 
     virtual juce::var executeCommand(const juce::Identifier& command,
-                                     const juce::var& arguments = {}) = 0;
+                                     const juce::var& arguments) = 0;
+    juce::var executeCommand(const juce::Identifier& command) {
+        return executeCommand(command, {});
+    }
 };
 
 /**

--- a/magda/daw/engine/AudioEngine.hpp
+++ b/magda/daw/engine/AudioEngine.hpp
@@ -98,8 +98,11 @@ struct SamplerMediaReference {
 class OfflineRenderTask {
   public:
     virtual ~OfflineRenderTask() = default;
-    virtual OfflineRenderResult run(const std::function<bool()>& shouldCancel = {},
-                                    const std::function<void(float)>& onProgress = {}) = 0;
+    virtual OfflineRenderResult run(const std::function<bool()>& shouldCancel,
+                                    const std::function<void(float)>& onProgress) = 0;
+    OfflineRenderResult run() {
+        return run({}, {});
+    }
 };
 
 /**
@@ -252,12 +255,11 @@ class AudioEngine : public AudioEngineListener {
     virtual void addPluginListChangeListener(juce::ChangeListener* listener) = 0;
     virtual void removePluginListChangeListener(juce::ChangeListener* listener) = 0;
     virtual void startPluginScan(
-        std::function<void(float, const juce::String&)> progressCallback = nullptr) = 0;
+        std::function<void(float, const juce::String&)> progressCallback) = 0;
     virtual void abortPluginScan() = 0;
     virtual void detectNewPlugins(
-        std::function<void(PluginScanPhase, const juce::String&)> statusCallback = nullptr,
-        std::function<void(bool, int, int, const juce::StringArray&)> completionCallback =
-            nullptr) = 0;
+        std::function<void(PluginScanPhase, const juce::String&)> statusCallback,
+        std::function<void(bool, int, int, const juce::StringArray&)> completionCallback) = 0;
     virtual void setPluginScanCompletionCallback(
         std::function<void(bool, int, const juce::StringArray&)> callback) = 0;
     virtual bool isPluginScanRunning() const = 0;

--- a/magda/daw/engine/TracktionEngineWrapper.hpp
+++ b/magda/daw/engine/TracktionEngineWrapper.hpp
@@ -96,7 +96,7 @@ class TracktionEngineWrapper : public AudioEngine,
      */
     void sendAllNotesOffToExternalInserts();
     void locate(double position_seconds) override;
-    void locateMusical(int bar, int beat, int tick = 0) override;
+    void locateMusical(int bar, int beat, int tick) override;
     double getCurrentPosition() const override;
     void getCurrentMusicalPosition(int& bar, int& beat, int& tick) const override;
     bool isPlaying() const override;
@@ -364,8 +364,7 @@ class TracktionEngineWrapper : public AudioEngine,
      * Crash files are stored in: ~/Library/Application Support/MAGDA/
      * Call clearPluginExclusions() to retry scanning problematic plugins.
      */
-    void startPluginScan(
-        std::function<void(float, const juce::String&)> progressCallback = nullptr) override;
+    void startPluginScan(std::function<void(float, const juce::String&)> progressCallback) override;
 
     /**
      * @brief Abort an in-progress plugin scan
@@ -443,10 +442,10 @@ class TracktionEngineWrapper : public AudioEngine,
      */
     void detectNewPlugins(
         std::function<void(PluginScanPhase phase, const juce::String& currentPlugin)>
-            statusCallback = nullptr,
+            statusCallback,
         std::function<void(bool success, int addedCount, int totalCount,
                            const juce::StringArray& failedPlugins)>
-            completionCallback = nullptr) override;
+            completionCallback) override;
     void setPluginScanCompletionCallback(
         std::function<void(bool, int, const juce::StringArray&)> callback) override {
         onPluginScanComplete = std::move(callback);

--- a/magda/daw/engine/TracktionEngineWrapperInit.cpp
+++ b/magda/daw/engine/TracktionEngineWrapperInit.cpp
@@ -80,21 +80,23 @@ void TracktionEngineWrapper::initializePluginFormats() {
     // wants a flat string; format the phase here.
     if (!isHeadlessRuntime() && Config::getInstance().getScanPluginsOnStartup()) {
         auto splashStatus = onPluginScanStatus;
-        detectNewPlugins([splashStatus](PluginScanPhase phase, const juce::String& currentPlugin) {
-            if (!splashStatus)
-                return;
-            switch (phase) {
-                case PluginScanPhase::Discovering:
-                    splashStatus("Checking for new plugins...");
-                    break;
-                case PluginScanPhase::UpToDate:
-                    splashStatus("Plugins up to date");
-                    break;
-                case PluginScanPhase::Scanning:
-                    splashStatus("Scanning: " + pluginDisplayName(currentPlugin));
-                    break;
-            }
-        });
+        detectNewPlugins(
+            [splashStatus](PluginScanPhase phase, const juce::String& currentPlugin) {
+                if (!splashStatus)
+                    return;
+                switch (phase) {
+                    case PluginScanPhase::Discovering:
+                        splashStatus("Checking for new plugins...");
+                        break;
+                    case PluginScanPhase::UpToDate:
+                        splashStatus("Plugins up to date");
+                        break;
+                    case PluginScanPhase::Scanning:
+                        splashStatus("Scanning: " + pluginDisplayName(currentPlugin));
+                        break;
+                }
+            },
+            nullptr);
     }
 
     // Log registered plugin formats

--- a/magda/daw/interfaces/prompt_interface.hpp
+++ b/magda/daw/interfaces/prompt_interface.hpp
@@ -20,7 +20,7 @@ class PromptInterface {
      * @param context Optional context about current DAW state
      * @return The model's response
      */
-    virtual std::string sendPrompt(const std::string& prompt, const std::string& context = "") = 0;
+    virtual std::string sendPrompt(const std::string& prompt, const std::string& context) = 0;
 
     /**
      * @brief Send a prompt asynchronously
@@ -30,7 +30,7 @@ class PromptInterface {
      */
     virtual void sendPromptAsync(const std::string& prompt,
                                  std::function<void(const std::string&)> callback,
-                                 const std::string& context = "") = 0;
+                                 const std::string& context) = 0;
 
     /**
      * @brief Generate musical suggestions based on current state
@@ -39,7 +39,7 @@ class PromptInterface {
      * @return Suggested musical elements (chords, melodies, etc.)
      */
     virtual std::string generateMusicalSuggestion(const std::string& style,
-                                                  const std::string& current_progression = "") = 0;
+                                                  const std::string& current_progression) = 0;
 
     /**
      * @brief Convert natural language to DAW commands
@@ -53,7 +53,7 @@ class PromptInterface {
      * @param topic Optional specific topic to get help about
      * @return Help text
      */
-    virtual std::string getHelp(const std::string& topic = "") = 0;
+    virtual std::string getHelp(const std::string& topic) = 0;
 
     /**
      * @brief Set the current DAW context for better responses

--- a/magda/daw/interfaces/transport_interface.hpp
+++ b/magda/daw/interfaces/transport_interface.hpp
@@ -42,7 +42,7 @@ class TransportInterface {
      * @param beat The beat within the bar (1-based)
      * @param tick The tick within the beat (0-based)
      */
-    virtual void locateMusical(int bar, int beat, int tick = 0) = 0;
+    virtual void locateMusical(int bar, int beat, int tick) = 0;
 
     /**
      * @brief Get current playback position in seconds

--- a/magda/daw/ui/components/chain/slot/DeviceCustomUIManager.cpp
+++ b/magda/daw/ui/components/chain/slot/DeviceCustomUIManager.cpp
@@ -348,8 +348,7 @@ class CallbackDeviceCommandController final : public magda::DeviceCommandControl
         std::function<juce::var(const juce::Identifier&, const juce::var&)> execute)
         : execute_(std::move(execute)) {}
 
-    juce::var executeCommand(const juce::Identifier& command,
-                             const juce::var& arguments = {}) override {
+    juce::var executeCommand(const juce::Identifier& command, const juce::var& arguments) override {
         return execute_ ? execute_(command, arguments) : juce::var{};
     }
 


### PR DESCRIPTION
## Summary
- Closes #2389. `google-default-arguments` flags 28 declarations: a default argument on a virtual method binds to the static type of the call, not the override, so an override with a different default would be called with the base's value through a base pointer and its own through a derived one.
- Checked every flagged method against its overrides and its real callers first (not just a mechanical strip):
  - No override anywhere disagreed with its base's default value, so there was no live bug of that shape.
  - Where **no caller relies on the omitted argument**, the default is just stripped: `AudioEngine::startPluginScan`/`detectNewPlugins`, `TransportInterface::locateMusical`, `AutomationApi::resizeClip`, `ClipApi::quantizeMidiNotes`, `DeviceAIAgent::generateAndApply` (base + its 5 overrides across `coder_agent.cpp`, `generic_sound_design_agent.hpp`, `sound_design_agent.cpp`), and `PromptInterface`'s 4 methods (this whole interface turned out to be unused anywhere in the codebase).
  - Where **real callers do rely on the default**, it moves into a same-named non-virtual overload on the interface that forwards to the now-default-free virtual method: `OfflineRenderTask::run()`, `ClipApi::createMidiClipBeats(trackId, start, length)`, `TrackApi::setTrackVolume`/`setTrackPan(trackId, value)`, `DeviceCommandController::executeCommand(command)`.
  - One caller of `detectNewPlugins` (`TracktionEngineWrapperInit.cpp`) was an implicit `this->` call my first grep pass missed since it had no `.`/`->` prefix — caught by a build failure, fixed by passing the omitted callback as `nullptr` explicitly.

## Test plan
- [x] `make debug` — builds clean
- [x] `make test` — 3711/3711 tests passing, 0 failures
- [x] Reran the exact command from the issue (`run-clang-tidy ... -checks='-*,google-default-arguments'` over `magda/`) — 0 remaining findings (deduplicated across the ~880 translation units that include these headers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0149ko34fXR5PeMBqVL1tDWt