### PR TITLE
Stop the test binary starting JUCE timers with no message thread

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1439,17 +1439,17 @@ jobs:
       shell: powershell
       run: sccache --show-stats
 
-    # A timeout is here to catch a hang, not to enforce a performance budget.
-    # At five minutes it was doing the second job badly: the last green run on
-    # dev finished this step in 4:53, so any test added anywhere in the suite
-    # failed Windows and nowhere else, with a timeout for a message.
+    # Two timeouts doing two jobs. The inner one is per shard: a shard that has
+    # stopped making progress is killed, its output printed and the step fails
+    # naming it, because the outer timeout kills the step before the reporting
+    # loop runs and prints nothing at all.
     #
-    # Fifteen went the same way. The suite reached 11:32 on dev, and the next
-    # test matrix added anywhere took it over, again on Windows and nowhere
-    # else. Debug MSVC runs this suite about ten times slower than a Debug
-    # clang build does, so this is the step that meets every addition first.
-    # Thirty still kills a hang long before the job's own limit, and leaves the
-    # suite room to grow without the gate reading "timed out" for "slower".
+    # The outer one is for a hang, not a performance budget. At five minutes it
+    # was doing the second job badly: the last green run on dev finished this
+    # step in 4:53, so any test added anywhere failed Windows and nowhere else.
+    # Fifteen went the same way at 11:32. Debug MSVC runs this suite about ten
+    # times slower than a Debug clang build does, so this is the step that meets
+    # every addition first.
     - name: Run tests
       timeout-minutes: 30
       run: |
@@ -1464,6 +1464,10 @@ jobs:
         # to roughly the heaviest shard. Own TMP per shard: concurrent shards
         # must not collide on temp file names.
         $shards = 16
+        # A shard that stopped, not one that is slow: a healthy step is four
+        # minutes on the self-hosted runner and four to six on a hosted one,
+        # the heaviest shard being most of that.
+        $shardTimeoutMinutes = 12
         # On the self-hosted runner the job is a session-0 service child, and
         # Windows gives such work EcoQoS: reduced clocks, roughly half speed
         # measured on the heaviest shard. The parent owns the child handles,
@@ -1491,20 +1495,25 @@ jobs:
           New-Item -ItemType Directory -Force -Path $tmpDir | Out-Null
           $env:TMP = $tmpDir
           $env:TEMP = $tmpDir
+          # Durations, so a shard killed mid-run says which case it was in:
+          # Catch2 prints nothing per case otherwise, and a killed shard would
+          # leave an empty file behind.
           $p = Start-Process -FilePath $testExe.FullName `
-            -ArgumentList "--abort", "--shard-count", "$shards", "--shard-index", "$i" `
+            -ArgumentList "--abort", "--durations", "yes", "--shard-count", "$shards", "--shard-index", "$i" `
             -NoNewWindow -PassThru `
             -RedirectStandardOutput (Join-Path $outDir "shard-$i.out") `
             -RedirectStandardError (Join-Path $outDir "shard-$i.err")
           # Without this, ExitCode can read null after WaitForExit.
           $null = $p.Handle
           try { [PowerThrottle]::Disable($p.Handle) | Out-Null } catch {}
-          $runs += @{ Index = $i; Proc = $p }
+          $runs += @{ Index = $i; Proc = $p; Started = Get-Date; Seconds = 0; TimedOut = $false }
         }
         $env:TMP = $savedTmp
         $env:TEMP = $savedTmp
+        Write-Host "launched $shards shards, killing any that has not finished in $shardTimeoutMinutes min"
         # Announce completions as they happen; a silent multi-minute wait
         # reads as a hang from the run page.
+        $deadline = (Get-Date).AddMinutes($shardTimeoutMinutes)
         $pending = @($runs)
         $done = 0
         while ($pending.Count -gt 0) {
@@ -1513,21 +1522,52 @@ jobs:
           foreach ($r in $pending) {
             if ($r.Proc.HasExited) {
               $done++
-              Write-Host "shard $($r.Index) finished (exit $($r.Proc.ExitCode), $done/$shards done)"
+              $r.Seconds = [int]((Get-Date) - $r.Started).TotalSeconds
+              Write-Host "shard $($r.Index) finished (exit $($r.Proc.ExitCode), $($r.Seconds)s, $done/$shards done)"
             } else {
               $still += $r
             }
           }
           $pending = $still
+
+          if ($pending.Count -gt 0 -and (Get-Date) -gt $deadline) {
+            foreach ($r in $pending) {
+              $r.Seconds = [int]((Get-Date) - $r.Started).TotalSeconds
+              $r.TimedOut = $true
+              Write-Host "shard $($r.Index) has been running $($r.Seconds)s and is being killed"
+              try { $r.Proc.Kill() } catch {}
+              $null = $r.Proc.WaitForExit(30000)
+            }
+            $pending = @()
+          }
         }
         $failed = 0
         foreach ($r in $runs) {
+          $out = @(Get-Content (Join-Path $outDir "shard-$($r.Index).out") -ErrorAction SilentlyContinue)
+          $err = @(Get-Content (Join-Path $outDir "shard-$($r.Index).err") -ErrorAction SilentlyContinue)
           $code = $r.Proc.ExitCode
-          Write-Host "===== shard $($r.Index)/$shards exit $code ====="
-          Get-Content (Join-Path $outDir "shard-$($r.Index).out") -ErrorAction SilentlyContinue
-          $err = Get-Content (Join-Path $outDir "shard-$($r.Index).err") -ErrorAction SilentlyContinue
+
+          if ($r.TimedOut) {
+            Write-Host "===== shard $($r.Index)/$shards killed after $($r.Seconds)s ====="
+            # The last case printed is the one before the hang. Output is block
+            # buffered, so the last few lines of it can be lost with the kill.
+            $out
+            $failed++
+          } elseif ($code -ne 0) {
+            Write-Host "===== shard $($r.Index)/$shards exit $code after $($r.Seconds)s ====="
+            $out
+            $failed++
+          } else {
+            # A green shard gets its Catch2 summary rather than 200 timings.
+            Write-Host "===== shard $($r.Index)/$shards exit 0 after $($r.Seconds)s ====="
+            $out | Select-Object -Last 3
+          }
+
           if ($err) { Write-Host "--- stderr ---"; $err }
-          if ($code -ne 0) { $failed++ }
+        }
+        Write-Host "===== shard wall times, slowest first ====="
+        foreach ($r in ($runs | Sort-Object { $_.Seconds } -Descending)) {
+          Write-Host ("shard {0,2}  {1,5}s" -f $r.Index, $r.Seconds)
         }
         if ($failed -gt 0) {
           Write-Error "$failed of $shards test shards failed"

--- a/magda/daw/audio/plugins/MidiChordEnginePlugin.cpp
+++ b/magda/daw/audio/plugins/MidiChordEnginePlugin.cpp
@@ -11,7 +11,12 @@ MidiChordEnginePlugin::MidiChordEnginePlugin() {
     // Started here rather than in prepare(), because the UI reads this device
     // whether or not a graph was ever built for it: a chord track sitting in a
     // stopped project still shows what its panel detected.
-    startTimerHz(30);
+    //
+    // A headless host has no message thread for it to fire on, and JUCE tears
+    // a timer thread down after the message manager, waiting on it without a
+    // deadline. Detection is for the panel, so there is nothing to run.
+    if (juce::MessageManager::getInstanceWithoutCreating() != nullptr)
+        startTimerHz(30);
 }
 
 MidiChordEnginePlugin::~MidiChordEnginePlugin() {

--- a/magda/daw/project/ProjectManager.cpp
+++ b/magda/daw/project/ProjectManager.cpp
@@ -254,12 +254,29 @@ ProjectManager::ProjectManager() {
     createTempMediaDirectory();
     ensureMediaSubdirectories(mediaDirectory_);
 
-    // Start auto-save timer
-    startTimer(kDefaultAutoSaveIntervalMs);
+    startAutoSaveTimer(kDefaultAutoSaveIntervalMs);
+}
+
+/**
+ * @brief Start autosaving, if there is a message thread to autosave on.
+ *
+ * A headless host reaches this singleton too, and has no message loop: the
+ * test binary does, through the timeline's tempo sync. Making a timer there
+ * costs the process its exit, because JUCE tears its timer thread down after
+ * the message manager, waiting on it without a deadline.
+ */
+void ProjectManager::startAutoSaveTimer(int intervalMs) {
+    if (juce::MessageManager::getInstanceWithoutCreating() == nullptr)
+        return;
+
+    if (autoSaveTimer_ == nullptr)
+        autoSaveTimer_ = std::make_unique<juce::TimedCallback>([this] { autoSaveTick(); });
+
+    autoSaveTimer_->startTimer(intervalMs);
 }
 
 ProjectManager::~ProjectManager() {
-    stopTimer();
+    autoSaveTimer_.reset();
     joinBackgroundThread();
 }
 
@@ -1020,13 +1037,13 @@ void ProjectManager::cleanupStaleTempDirectories() {
 void ProjectManager::setAutoSaveEnabled(bool enabled, int intervalSeconds) {
     autoSaveEnabled_ = enabled;
     if (enabled) {
-        startTimer(intervalSeconds * 1000);
+        startAutoSaveTimer(intervalSeconds * 1000);
     } else {
-        stopTimer();
+        autoSaveTimer_.reset();
     }
 }
 
-void ProjectManager::timerCallback() {
+void ProjectManager::autoSaveTick() {
     if (autoSaveEnabled_ && isDirty_ && isProjectOpen_) {
         performAutosave();
     }

--- a/magda/daw/project/ProjectManager.hpp
+++ b/magda/daw/project/ProjectManager.hpp
@@ -5,6 +5,7 @@
 
 #include <cstdint>
 #include <functional>
+#include <memory>
 #include <thread>
 #include <vector>
 
@@ -56,7 +57,7 @@ class ProjectManagerListener {
  *
  * Handles new/open/save/close operations and tracks unsaved changes.
  */
-class ProjectManager : private juce::Timer {
+class ProjectManager {
   public:
     static ProjectManager& getInstance();
 
@@ -327,10 +328,11 @@ class ProjectManager : private juce::Timer {
     friend class UndoManager;
 
     ProjectManager();
-    ~ProjectManager() override;
+    ~ProjectManager();
 
     void joinBackgroundThread();
-    void timerCallback() override;
+    void startAutoSaveTimer(int intervalMs);
+    void autoSaveTick();
     void performAutosave();
     void deleteAutosaveFile();
 
@@ -344,6 +346,11 @@ class ProjectManager : private juce::Timer {
     bool autoSaveEnabled_ = true;
     int undoableMutationDepth_ = 0;
     std::uint64_t mutationRevision_ = 0;
+
+    /// Held rather than inherited, and made only when autosave starts: a
+    /// juce::Timer that lives as long as this singleton outlives the message
+    /// system it needs, and JUCE tears the two down in that order.
+    std::unique_ptr<juce::TimedCallback> autoSaveTimer_;
 
     std::vector<ProjectManagerListener*> listeners_;
     juce::String lastError_;

--- a/tests/devices/test_scan_report.cpp
+++ b/tests/devices/test_scan_report.cpp
@@ -1,4 +1,5 @@
 #include <juce_core/juce_core.h>
+#include <juce_events/juce_events.h>
 
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_string.hpp>
@@ -58,6 +59,11 @@ TEST_CASE("PluginScanResult stores multiple plugin names", "[scan-report]") {
 // ============================================================================
 
 TEST_CASE("getScanReportFile returns expected path", "[scan-report]") {
+    // The coordinator is a juce::Timer, and a timer built with no message
+    // manager is one JUCE tears down against an event system that was never
+    // there.
+    const juce::ScopedJuceInitialiser_GUI juce;
+
     magda::PluginScanCoordinator coordinator;
     auto reportFile = coordinator.getScanReportFile();
 


### PR DESCRIPTION
A Windows CI shard ran all 234 of its cases green and then never exited, and the step's 30 minute timeout killed it with nothing printed.

ProjectManager is a function-local static that started its 60 second autosave timer in its constructor, reached from the timeline's tempo sync. In magda_tests there is no MessageManager, so JUCE built its timer thread without an event system and tore it down at static destruction with stopThread(-1), an unbounded wait. MidiChordEnginePlugin started a 30 Hz timer in its constructor the same way, and test_scan_report builds a PluginScanCoordinator, which is a juce::Timer, with no message manager around it.

ProjectManager holds a juce::TimedCallback made when autosave starts rather than inheriting Timer, both constructors check for a message loop before starting anything, and the scan report test gets a ScopedJuceInitialiser_GUI. No startTimer call is left anywhere in the test binary.

The Windows test step also gets a timeout of its own per shard: one that has not finished in twelve minutes is killed, its output printed and the step failed naming it, since the step timeout takes the reporting loop with it. Shards run with --durations so a killed one says which case it was in, finish lines carry elapsed time, and a wall time table shows the imbalance that makes shard 15 the tail of every run.

Claude-Session: https://claude.ai/code/session_013A1GWqAoLZPdkYAMwKrjQj