### PR TITLE
Widen before multiplying where clang-tidy flags a cast after the product

### DIFF
--- a/magda/daw/api/remote_mcp_server.cpp
+++ b/magda/daw/api/remote_mcp_server.cpp
@@ -1514,8 +1514,8 @@ bool RemoteMcpServer::start() {
     // its whole lifetime — so with cpp-httplib's default pool, enough
     // subscribers would leave nothing to answer requests with and the endpoint
     // would stall while still accepting connections.
-    const auto poolSize = static_cast<std::size_t>(impl_->options.maxStreams +
-                                                   impl_->options.maxConcurrentRequests + 2);
+    const auto poolSize = static_cast<std::size_t>(impl_->options.maxStreams) +
+                          impl_->options.maxConcurrentRequests + 2;
     impl_->server.new_task_queue = [poolSize] { return new httplib::ThreadPool(poolSize); };
 
     impl_->server.Post(kEndpoint,

--- a/magda/daw/audio/ClipCommands.cpp
+++ b/magda/daw/audio/ClipCommands.cpp
@@ -3056,7 +3056,7 @@ void buildDrumGridFromSlices(const std::vector<SliceRegion>& slices, const ClipI
         double noteStartBeat = noteStartTime * beatsPerSecond;
 
         double nextTimeline =
-            (i + 1 < numSlices) ? slices[static_cast<size_t>(i + 1)].timelinePos : clipEnd;
+            (i + 1 < numSlices) ? slices[static_cast<size_t>(i) + 1].timelinePos : clipEnd;
         double noteDuration = nextTimeline - slice.timelinePos;
         double noteLengthBeats = noteDuration * beatsPerSecond;
 

--- a/magda/daw/audio/Vst3Preset.hpp
+++ b/magda/daw/audio/Vst3Preset.hpp
@@ -21,7 +21,7 @@ inline constexpr int kVst3PresetClassIdLength = 32;
 // ExtensionsVisitor::VST3Client::getPreset()). Returns an empty string if
 // the blob is too small, lacks the 'VST3' magic, or the id isn't valid hex.
 inline juce::String classIdFromPreset(const juce::MemoryBlock& preset) {
-    if (preset.getSize() < static_cast<size_t>(kVst3PresetClassIdOffset + kVst3PresetClassIdLength))
+    if (preset.getSize() < static_cast<size_t>(kVst3PresetClassIdOffset) + kVst3PresetClassIdLength)
         return {};
 
     const auto* bytes = static_cast<const char*>(preset.getData());

--- a/magda/daw/audio/plugins/MagdaConvolutionPlugin.cpp
+++ b/magda/daw/audio/plugins/MagdaConvolutionPlugin.cpp
@@ -293,7 +293,7 @@ void MagdaConvolutionPlugin::process(DeviceProcessContext& context) {
             updateCoefficients(numThisTime);
 
             auto block = juce::dsp::AudioBlock<float>(buffer).getSubBlock(
-                static_cast<size_t>(start + done), static_cast<size_t>(numThisTime));
+                static_cast<size_t>(start) + done, static_cast<size_t>(numThisTime));
             juce::dsp::ProcessContextReplacing<float> processContext(block);
             chain_.process(processContext);
 

--- a/magda/daw/audio/plugins/MidiChordEnginePlugin.cpp
+++ b/magda/daw/audio/plugins/MidiChordEnginePlugin.cpp
@@ -140,7 +140,7 @@ void MidiChordEnginePlugin::processNoteEvents() {
 
     auto processRange = [this](int start, int count) {
         for (int i = 0; i < count; ++i) {
-            const auto& evt = noteBuffer_[static_cast<size_t>(start + i)];
+            const auto& evt = noteBuffer_[static_cast<size_t>(start) + i];
             keyHistogram_.updateWithMidiNote(evt.noteNumber, evt.timeSeconds);
         }
     };

--- a/magda/daw/audio/plugins/MidiStrumPlugin.cpp
+++ b/magda/daw/audio/plugins/MidiStrumPlugin.cpp
@@ -49,7 +49,7 @@ void buildLut(int shapeIdx, std::array<float, 1024>& lut) {
     int si = 0;
     for (int i = 0; i < 1024; ++i) {
         const float x = static_cast<float>(i) / 1023.0f;
-        while (si + 1 <= K && xs[static_cast<size_t>(si + 1)] < x)
+        while (si + 1 <= K && xs[static_cast<size_t>(si) + 1] < x)
             ++si;
         const int j = std::min(si + 1, K);
         const float span = xs[static_cast<size_t>(j)] - xs[static_cast<size_t>(si)];

--- a/magda/daw/audio/plugins/compiled/MagdaCompiledPolyInstrument.cpp
+++ b/magda/daw/audio/plugins/compiled/MagdaCompiledPolyInstrument.cpp
@@ -136,7 +136,7 @@ std::vector<MagdaCompiledPolyInstrument::HostSlotInfo> MagdaCompiledPolyInstrume
     using magda::ParameterScale;
 
     auto infos = voiceSlotInfos_;
-    infos.resize(static_cast<size_t>(voiceSlotCount() + (hasVoiceModes() ? 2 : 1)));
+    infos.resize(static_cast<size_t>(voiceSlotCount()) + (hasVoiceModes() ? 2 : 1));
     infos[static_cast<size_t>(voiceSlotCount())] = {.name = "Gain",
                                                     .unit = "dB",
                                                     .scale = ParameterScale::Linear,
@@ -144,7 +144,7 @@ std::vector<MagdaCompiledPolyInstrument::HostSlotInfo> MagdaCompiledPolyInstrume
                                                     .maxValue = 6.0f,
                                                     .defaultValue = -6.0f};
     if (hasVoiceModes())
-        infos[static_cast<size_t>(voiceSlotCount() + 1)] = {.name = "Voice Mode",
+        infos[static_cast<size_t>(voiceSlotCount()) + 1] = {.name = "Voice Mode",
                                                             .scale = ParameterScale::Discrete,
                                                             .minValue = 0.0f,
                                                             .maxValue = 2.0f,

--- a/magda/daw/audio/plugins/compiled/MagdaLimiterCompiledPlugin.cpp
+++ b/magda/daw/audio/plugins/compiled/MagdaLimiterCompiledPlugin.cpp
@@ -68,7 +68,7 @@ void MagdaLimiterDspCore::prepare(double sampleRate, int, int numChannels) {
     sampleRate_ = sampleRate > 0.0 ? sampleRate : 44100.0;
     delaySamples_ = std::max(1, static_cast<int>(std::ceil(sampleRate_ * 0.005)));
     const auto channels = static_cast<size_t>(std::max(1, numChannels));
-    const auto lineLength = static_cast<size_t>(delaySamples_ + 1);
+    const auto lineLength = static_cast<size_t>(delaySamples_) + 1;
 
     delayLines_.assign(channels, std::vector<float>(lineLength, 0.0f));
     frame_.assign(channels, 0.0f);

--- a/magda/daw/audio/plugins/engine/EngineMagdaDevice.cpp
+++ b/magda/daw/audio/plugins/engine/EngineMagdaDevice.cpp
@@ -194,7 +194,7 @@ void EngineMagdaDevice::prepare(const magda::engine::RenderContext& context) {
 
     // Room for the device's own channels plus a sidechain key of the same
     // width appended after them, which is how the SDK hands one over.
-    channels_.assign(static_cast<std::size_t>(std::max(0, context.numChannels) * 2), nullptr);
+    channels_.assign(static_cast<std::size_t>(std::max(0, context.numChannels)) * 2, nullptr);
 
     sizeMidiScratch();
 }

--- a/magda/daw/core/DeviceParamMigrations.cpp
+++ b/magda/daw/core/DeviceParamMigrations.cpp
@@ -33,7 +33,7 @@ constexpr std::array<int, kEqOldCount> makeEqMapping() {
     std::array<int, kEqOldCount> mapping{};
     for (int band = 0; band < kEqBandCount; ++band)
         for (int slot = 0; slot < kEqSlotsPerBandOld; ++slot)
-            mapping[static_cast<size_t>(band * kEqSlotsPerBandOld + slot)] =
+            mapping[static_cast<size_t>(band) * kEqSlotsPerBandOld + slot] =
                 band * kEqSlotsPerBandNew + 1 + slot;
     mapping[kEqOldCount - 1] = kEqBandCount * kEqSlotsPerBandNew;  // Output
     return mapping;

--- a/magda/daw/core/TrackCommands.cpp
+++ b/magda/daw/core/TrackCommands.cpp
@@ -650,7 +650,7 @@ void PasteChainElementsCommand::execute() {
     const int start = requestedIndex;
     for (int i = 0; i < elementCount && start + i < static_cast<int>(destinationElements.size());
          ++i) {
-        const auto& element = destinationElements[static_cast<size_t>(start + i)];
+        const auto& element = destinationElements[static_cast<size_t>(start) + i];
         if (isDevice(element)) {
             const auto deviceId = getDevice(element).id;
             insertedPaths_.push_back(

--- a/magda/daw/stem_separation/DemucsSeparator.cpp
+++ b/magda/daw/stem_separation/DemucsSeparator.cpp
@@ -184,7 +184,7 @@ std::vector<Stem> DemucsSeparator::separate(const juce::AudioBuffer<float>& inpu
             }
         }
         for (int i = 0; i < clen; ++i)
-            weight[static_cast<size_t>(start + i)] += window[static_cast<size_t>(i)];
+            weight[static_cast<size_t>(start) + i] += window[static_cast<size_t>(i)];
 
         if (progress != nullptr &&
             !progress(static_cast<float>(c + 1) / static_cast<float>(numChunks)))

--- a/magda/daw/stem_separation/HpssSeparator.cpp
+++ b/magda/daw/stem_separation/HpssSeparator.cpp
@@ -74,7 +74,7 @@ std::vector<Stem> HpssSeparator::separate(const juce::AudioBuffer<float>& input,
     for (int t = 0; t < numFrames; ++t) {
         const int start = t * kHop;
         for (int i = 0; i < kFftSize && start + i < paddedLen; ++i)
-            norm[static_cast<size_t>(start + i)] +=
+            norm[static_cast<size_t>(start) + i] +=
                 window[static_cast<size_t>(i)] * window[static_cast<size_t>(i)];
     }
 
@@ -99,13 +99,13 @@ std::vector<Stem> HpssSeparator::separate(const juce::AudioBuffer<float>& input,
             std::fill(frame.begin(), frame.end(), 0.0F);
             for (int i = 0; i < kFftSize && start + i < paddedLen; ++i)
                 frame[static_cast<size_t>(i)] =
-                    padded[static_cast<size_t>(start + i)] * window[static_cast<size_t>(i)];
+                    padded[static_cast<size_t>(start) + i] * window[static_cast<size_t>(i)];
 
             fft.performRealOnlyForwardTransform(frame.data(), true);
 
             for (int k = 0; k < kNumBins; ++k) {
-                const float re = frame[static_cast<size_t>(2 * k)];
-                const float im = frame[static_cast<size_t>(2 * k + 1)];
+                const float re = frame[static_cast<size_t>(2) * k];
+                const float im = frame[static_cast<size_t>(2) * k + 1];
                 const size_t idx = static_cast<size_t>(t) * kNumBins + static_cast<size_t>(k);
                 spectra[idx * 2] = re;
                 spectra[idx * 2 + 1] = im;
@@ -169,10 +169,10 @@ std::vector<Stem> HpssSeparator::separate(const juce::AudioBuffer<float>& input,
 
                 const float re = spectra[idx * 2];
                 const float im = spectra[idx * 2 + 1];
-                frameH[static_cast<size_t>(2 * k)] = re * maskH;
-                frameH[static_cast<size_t>(2 * k + 1)] = im * maskH;
-                frameP[static_cast<size_t>(2 * k)] = re * maskP;
-                frameP[static_cast<size_t>(2 * k + 1)] = im * maskP;
+                frameH[static_cast<size_t>(2) * k] = re * maskH;
+                frameH[static_cast<size_t>(2) * k + 1] = im * maskH;
+                frameP[static_cast<size_t>(2) * k] = re * maskP;
+                frameP[static_cast<size_t>(2) * k + 1] = im * maskP;
             }
 
             fft.performRealOnlyInverseTransform(frameH.data());
@@ -181,18 +181,18 @@ std::vector<Stem> HpssSeparator::separate(const juce::AudioBuffer<float>& input,
             const int start = t * kHop;
             for (int i = 0; i < kFftSize && start + i < paddedLen; ++i) {
                 const float w = window[static_cast<size_t>(i)];
-                outHarm[static_cast<size_t>(start + i)] += frameH[static_cast<size_t>(i)] * w;
-                outPerc[static_cast<size_t>(start + i)] += frameP[static_cast<size_t>(i)] * w;
+                outHarm[static_cast<size_t>(start) + i] += frameH[static_cast<size_t>(i)] * w;
+                outPerc[static_cast<size_t>(start) + i] += frameP[static_cast<size_t>(i)] * w;
             }
         }
 
         float* dstH = stems[0].audio.getWritePointer(ch);
         float* dstP = stems[1].audio.getWritePointer(ch);
         for (int i = 0; i < numSamples; ++i) {
-            const float n = norm[static_cast<size_t>(i + pad)];
+            const float n = norm[static_cast<size_t>(i) + pad];
             const float scale = n > 1.0e-8F ? 1.0F / n : 0.0F;
-            dstH[i] = outHarm[static_cast<size_t>(i + pad)] * scale;
-            dstP[i] = outPerc[static_cast<size_t>(i + pad)] * scale;
+            dstH[i] = outHarm[static_cast<size_t>(i) + pad] * scale;
+            dstP[i] = outPerc[static_cast<size_t>(i) + pad] * scale;
         }
         if (!report(1.0F))
             return {};

--- a/magda/daw/stem_separation/SpleeterSeparator.cpp
+++ b/magda/daw/stem_separation/SpleeterSeparator.cpp
@@ -180,14 +180,14 @@ std::vector<Stem> SpleeterSeparator::separate(const juce::AudioBuffer<float>& in
                             signal[static_cast<size_t>(ch)][static_cast<size_t>(pos)] *
                             window[static_cast<size_t>(i)];
                     if (ch == 0 && start + i < paddedLen)
-                        norm[static_cast<size_t>(start + i)] +=
+                        norm[static_cast<size_t>(start) + i] +=
                             window[static_cast<size_t>(i)] * window[static_cast<size_t>(i)];
                 }
                 fft.performRealOnlyForwardTransform(frame.data(), true);
 
                 for (int b = 0; b < sp::kKeptBins; ++b) {
-                    const float re = frame[static_cast<size_t>(2 * b)];
-                    const float im = frame[static_cast<size_t>(2 * b + 1)];
+                    const float re = frame[static_cast<size_t>(2) * b];
+                    const float im = frame[static_cast<size_t>(2) * b + 1];
                     const size_t xIdx = (static_cast<size_t>(ch) * sp::kFramesPerSplit +
                                          static_cast<size_t>(localFrame)) *
                                             sp::kKeptBins +
@@ -203,9 +203,9 @@ std::vector<Stem> SpleeterSeparator::separate(const juce::AudioBuffer<float>& in
                     const size_t sIdx =
                         (static_cast<size_t>(localFrame) * sp::kNumBins + static_cast<size_t>(b)) *
                         2;
-                    spectra[static_cast<size_t>(ch)][sIdx] = frame[static_cast<size_t>(2 * b)];
+                    spectra[static_cast<size_t>(ch)][sIdx] = frame[static_cast<size_t>(2) * b];
                     spectra[static_cast<size_t>(ch)][sIdx + 1] =
-                        frame[static_cast<size_t>(2 * b + 1)];
+                        frame[static_cast<size_t>(2) * b + 1];
                 }
             }
         }
@@ -237,9 +237,9 @@ std::vector<Stem> SpleeterSeparator::separate(const juce::AudioBuffer<float>& in
                         const size_t sIdx = (static_cast<size_t>(localFrame) * sp::kNumBins +
                                              static_cast<size_t>(b)) *
                                             2;
-                        frame[static_cast<size_t>(2 * b)] =
+                        frame[static_cast<size_t>(2) * b] =
                             spectra[static_cast<size_t>(ch)][sIdx] * mask;
-                        frame[static_cast<size_t>(2 * b + 1)] =
+                        frame[static_cast<size_t>(2) * b + 1] =
                             spectra[static_cast<size_t>(ch)][sIdx + 1] * mask;
                     }
 
@@ -247,7 +247,7 @@ std::vector<Stem> SpleeterSeparator::separate(const juce::AudioBuffer<float>& in
                     const int start = (firstFrame + localFrame) * sp::kHop;
                     auto& output = rendered[static_cast<size_t>(stem)][static_cast<size_t>(ch)];
                     for (int i = 0; i < sp::kFftSize && start + i < paddedLen; ++i)
-                        output[static_cast<size_t>(start + i)] +=
+                        output[static_cast<size_t>(start) + i] +=
                             frame[static_cast<size_t>(i)] * window[static_cast<size_t>(i)];
                 }
             }

--- a/magda/daw/ui/components/chain/DeviceSlotComponent.cpp
+++ b/magda/daw/ui/components/chain/DeviceSlotComponent.cpp
@@ -1332,7 +1332,7 @@ std::map<magda::DeviceId, std::vector<juce::String>> DeviceSlotComponent::getDev
         if (param.paramIndex < 0)
             continue;
         if (param.paramIndex >= static_cast<int>(names.size()))
-            names.resize(static_cast<size_t>(param.paramIndex + 1));
+            names.resize(static_cast<size_t>(param.paramIndex) + 1);
         names[static_cast<size_t>(param.paramIndex)] = param.name;
     }
     std::map<magda::DeviceId, std::vector<juce::String>> result = {{device_.id, std::move(names)}};

--- a/magda/daw/ui/components/chain/RackComponent.cpp
+++ b/magda/daw/ui/components/chain/RackComponent.cpp
@@ -745,7 +745,7 @@ std::map<magda::DeviceId, std::vector<juce::String>> RackComponent::getDevicePar
                 if (param.paramIndex < 0)
                     continue;
                 if (param.paramIndex >= static_cast<int>(names.size()))
-                    names.resize(static_cast<size_t>(param.paramIndex + 1));
+                    names.resize(static_cast<size_t>(param.paramIndex) + 1);
                 names[static_cast<size_t>(param.paramIndex)] = param.name;
             }
             result[device.id] = std::move(names);

--- a/magda/daw/ui/components/chain/compiled/CompiledMultibandCurveView.cpp
+++ b/magda/daw/ui/components/chain/compiled/CompiledMultibandCurveView.cpp
@@ -404,7 +404,7 @@ CompiledMultibandCurveView::Handle CompiledMultibandCurveView::pickHandle(float 
     float nearestDist = kThresholdPickPx + 1.0f;
     for (int band = 0; band < 3; ++band) {
         const float x0 = bandEdges[static_cast<size_t>(band)] - 2.0f;
-        const float x1 = bandEdges[static_cast<size_t>(band + 1)] + 2.0f;
+        const float x1 = bandEdges[static_cast<size_t>(band) + 1] + 2.0f;
         if (x < x0 || x > x1)
             continue;
         auto check = [&](float lineY, Handle h) {

--- a/magda/daw/ui/components/chain/custom_ui/FMUI.cpp
+++ b/magda/daw/ui/components/chain/custom_ui/FMUI.cpp
@@ -75,7 +75,7 @@ FMUI::FMUI() {
         populateWaveSelector(sel);
         sel.onChange = [this, op](int wave) { setOpWave(op, wave); };
         addAndMakeVisible(sel);
-        controls_[static_cast<size_t>(kWaveBase + op)].slider->setVisible(false);
+        controls_[static_cast<size_t>(kWaveBase) + op].slider->setVisible(false);
     }
 
     // Draggable amp ADSR. A handle drag writes the plugin value and keeps the
@@ -105,9 +105,9 @@ FMUI::FMUI() {
         btn->onClick = [this, op]() { setOpReset(op, !opReset_[static_cast<size_t>(op)]); };
         addAndMakeVisible(*btn);
         resetButtons_[static_cast<size_t>(op)] = std::move(btn);
-        controls_[static_cast<size_t>(kResetBase + op)].slider->setVisible(false);
-        if (controls_[static_cast<size_t>(kResetBase + op)].label)
-            controls_[static_cast<size_t>(kResetBase + op)].label->setVisible(false);
+        controls_[static_cast<size_t>(kResetBase) + op].slider->setVisible(false);
+        if (controls_[static_cast<size_t>(kResetBase) + op].label)
+            controls_[static_cast<size_t>(kResetBase) + op].label->setVisible(false);
     }
 
     // Per-op enable (mute) toggle, doubling as the operator column header.
@@ -126,9 +126,9 @@ FMUI::FMUI() {
         btn->onClick = [this, op]() { setOpEnable(op, !opEnabled_[static_cast<size_t>(op)]); };
         addAndMakeVisible(*btn);
         enableButtons_[static_cast<size_t>(op)] = std::move(btn);
-        controls_[static_cast<size_t>(kEnableBase + op)].slider->setVisible(false);
-        if (controls_[static_cast<size_t>(kEnableBase + op)].label)
-            controls_[static_cast<size_t>(kEnableBase + op)].label->setVisible(false);
+        controls_[static_cast<size_t>(kEnableBase) + op].slider->setVisible(false);
+        if (controls_[static_cast<size_t>(kEnableBase) + op].label)
+            controls_[static_cast<size_t>(kEnableBase) + op].label->setVisible(false);
     }
     updateEnableButtons();
 }
@@ -223,7 +223,7 @@ void FMUI::updateWaveSelectors() {
         const int wave =
             juce::jlimit(0, kNumWaves - 1,
                          static_cast<int>(std::round(
-                             controls_[static_cast<size_t>(kWaveBase + op)].slider->getValue())));
+                             controls_[static_cast<size_t>(kWaveBase) + op].slider->getValue())));
         waveSelectors_[static_cast<size_t>(op)].setSelectedIndex(wave, juce::dontSendNotification);
     }
 }
@@ -309,7 +309,7 @@ void FMUI::resized() {
         for (int src = 0; src < kNumOps; ++src)
             for (int dst = 0; dst < kNumOps; ++dst) {
                 juce::Rectangle<int> cell(a.getX() + dst * cw, a.getY() + src * chh, cw, chh);
-                controls_[static_cast<size_t>(kMatrixBase + src * kNumOps + dst)].slider->setBounds(
+                controls_[static_cast<size_t>(kMatrixBase) + src * kNumOps + dst].slider->setBounds(
                     cell.reduced(kCellPad));
             }
     }
@@ -336,7 +336,7 @@ void FMUI::resized() {
             col.removeFromTop(2);
             // Wave icon selector (hidden slider tracks beneath it).
             auto waveRow = col.removeFromTop(col.getHeight() * 44 / 100);
-            controls_[static_cast<size_t>(kWaveBase + op)].slider->setBounds(waveRow);
+            controls_[static_cast<size_t>(kWaveBase) + op].slider->setBounds(waveRow);
             waveSelectors_[static_cast<size_t>(op)].setBounds(waveRow.reduced(0, kCellLabelH / 2));
 
             // One row: Ratio | Level | Reset (a small toggle on the right).
@@ -346,7 +346,7 @@ void FMUI::resized() {
             auto ratioCell = row.removeFromLeft(row.getWidth() / 2);
             place(kRatioBase + op, ratioCell);
             place(kLevelBase + op, row);
-            controls_[static_cast<size_t>(kResetBase + op)].slider->setBounds(resetCell);
+            controls_[static_cast<size_t>(kResetBase) + op].slider->setBounds(resetCell);
             resetCell.removeFromTop(kCellLabelH);  // align the toggle with the value boxes
             resetButtons_[static_cast<size_t>(op)]->setBounds(resetCell.reduced(1, 0));
         }

--- a/magda/daw/ui/components/chain/custom_ui/FourOscUI.cpp
+++ b/magda/daw/ui/components/chain/custom_ui/FourOscUI.cpp
@@ -485,17 +485,17 @@ void FourOscUI::OscTab::updateFromParameters(const std::vector<magda::ParameterI
         auto& row = rows_[i];
         row.tuneSlider.setValue(params[static_cast<size_t>(base)].currentValue,
                                 juce::dontSendNotification);
-        row.fineSlider.setValue(params[static_cast<size_t>(base + 1)].currentValue,
+        row.fineSlider.setValue(params[static_cast<size_t>(base) + 1].currentValue,
                                 juce::dontSendNotification);
-        row.levelSlider.setValue(params[static_cast<size_t>(base + 2)].currentValue,
+        row.levelSlider.setValue(params[static_cast<size_t>(base) + 2].currentValue,
                                  juce::dontSendNotification);
-        row.pulseWidthSlider.setValue(params[static_cast<size_t>(base + 3)].currentValue,
+        row.pulseWidthSlider.setValue(params[static_cast<size_t>(base) + 3].currentValue,
                                       juce::dontSendNotification);
-        row.detuneSlider.setValue(params[static_cast<size_t>(base + 4)].currentValue,
+        row.detuneSlider.setValue(params[static_cast<size_t>(base) + 4].currentValue,
                                   juce::dontSendNotification);
-        row.spreadSlider.setValue(params[static_cast<size_t>(base + 5)].currentValue,
+        row.spreadSlider.setValue(params[static_cast<size_t>(base) + 5].currentValue,
                                   juce::dontSendNotification);
-        row.panSlider.setValue(params[static_cast<size_t>(base + 6)].currentValue,
+        row.panSlider.setValue(params[static_cast<size_t>(base) + 6].currentValue,
                                juce::dontSendNotification);
     }
     // Global automatable params
@@ -1162,22 +1162,22 @@ void FourOscUI::ModEnvTab::updateFromParameters(const std::vector<magda::Paramet
             break;
         rows_[i].attackSlider.setValue(params[static_cast<size_t>(base)].currentValue,
                                        juce::dontSendNotification);
-        rows_[i].decaySlider.setValue(params[static_cast<size_t>(base + 1)].currentValue,
+        rows_[i].decaySlider.setValue(params[static_cast<size_t>(base) + 1].currentValue,
                                       juce::dontSendNotification);
-        rows_[i].sustainSlider.setValue(params[static_cast<size_t>(base + 2)].currentValue,
+        rows_[i].sustainSlider.setValue(params[static_cast<size_t>(base) + 2].currentValue,
                                         juce::dontSendNotification);
-        rows_[i].releaseSlider.setValue(params[static_cast<size_t>(base + 3)].currentValue,
+        rows_[i].releaseSlider.setValue(params[static_cast<size_t>(base) + 3].currentValue,
                                         juce::dontSendNotification);
 
         // Mirror the ADSR slots into this env's graph (carries each stage's range).
         rows_[i].graph.setStage(AdsrGraph::Attack, base, params[static_cast<size_t>(base)],
                                 params[static_cast<size_t>(base)].currentValue);
-        rows_[i].graph.setStage(AdsrGraph::Decay, base + 1, params[static_cast<size_t>(base + 1)],
-                                params[static_cast<size_t>(base + 1)].currentValue);
-        rows_[i].graph.setStage(AdsrGraph::Sustain, base + 2, params[static_cast<size_t>(base + 2)],
-                                params[static_cast<size_t>(base + 2)].currentValue);
-        rows_[i].graph.setStage(AdsrGraph::Release, base + 3, params[static_cast<size_t>(base + 3)],
-                                params[static_cast<size_t>(base + 3)].currentValue);
+        rows_[i].graph.setStage(AdsrGraph::Decay, base + 1, params[static_cast<size_t>(base) + 1],
+                                params[static_cast<size_t>(base) + 1].currentValue);
+        rows_[i].graph.setStage(AdsrGraph::Sustain, base + 2, params[static_cast<size_t>(base) + 2],
+                                params[static_cast<size_t>(base) + 2].currentValue);
+        rows_[i].graph.setStage(AdsrGraph::Release, base + 3, params[static_cast<size_t>(base) + 3],
+                                params[static_cast<size_t>(base) + 3].currentValue);
     }
 }
 
@@ -1355,9 +1355,9 @@ void FourOscUI::LFOTab::updateFromParameters(const std::vector<magda::ParameterI
             break;
         rows_[i].rateSlider.setValue(params[static_cast<size_t>(base)].currentValue,
                                      juce::dontSendNotification);
-        rows_[i].depthSlider.setValue(params[static_cast<size_t>(base + 1)].currentValue,
+        rows_[i].depthSlider.setValue(params[static_cast<size_t>(base) + 1].currentValue,
                                       juce::dontSendNotification);
-        rows_[i].depth = static_cast<float>(params[static_cast<size_t>(base + 1)].currentValue);
+        rows_[i].depth = static_cast<float>(params[static_cast<size_t>(base) + 1].currentValue);
     }
     repaint();
 }

--- a/magda/daw/ui/components/chain/custom_ui/OscilloscopeUI.cpp
+++ b/magda/daw/ui/components/chain/custom_ui/OscilloscopeUI.cpp
@@ -427,7 +427,7 @@ void OscilloscopeUI::paint(juce::Graphics& g) {
         for (int i = 0; i < displaySamples_; ++i) {
             const float x =
                 area.getX() + w * (static_cast<float>(i) / static_cast<float>(displaySamples_ - 1));
-            const float y = yOf(window_[static_cast<size_t>(trigger + i)]);
+            const float y = yOf(window_[static_cast<size_t>(trigger) + i]);
             if (i == 0)
                 path.startNewSubPath(x, y);
             else

--- a/magda/daw/ui/components/chain/custom_ui/PolyStepSequencerUI.cpp
+++ b/magda/daw/ui/components/chain/custom_ui/PolyStepSequencerUI.cpp
@@ -111,7 +111,7 @@ void toggleStepNote(step_pattern::PolyPattern& pattern, int stepIndex, int note)
         if (step.notes[static_cast<size_t>(i)].noteNumber != note)
             continue;
         for (int j = i; j + 1 < step.noteCount; ++j)
-            step.notes[static_cast<size_t>(j)] = step.notes[static_cast<size_t>(j + 1)];
+            step.notes[static_cast<size_t>(j)] = step.notes[static_cast<size_t>(j) + 1];
         --step.noteCount;
         step.notes[static_cast<size_t>(step.noteCount)] = {};
         return;

--- a/magda/daw/ui/components/chain/custom_ui/PolySynthUI.cpp
+++ b/magda/daw/ui/components/chain/custom_ui/PolySynthUI.cpp
@@ -34,10 +34,10 @@ PolySynthUI::PolySynthUI() {
     // the oscillator number, so these are bare control names.
     for (int osc = 0; osc < kNumOscillators; ++osc) {
         const int base = osc * kOscSlotCount;
-        labels_[static_cast<size_t>(base + 0)] = "Wave";
-        labels_[static_cast<size_t>(base + 1)] = "Level";
-        labels_[static_cast<size_t>(base + 2)] = "Coarse";
-        labels_[static_cast<size_t>(base + 3)] = "Fine";
+        labels_[static_cast<size_t>(base) + 0] = "Wave";
+        labels_[static_cast<size_t>(base) + 1] = "Level";
+        labels_[static_cast<size_t>(base) + 2] = "Coarse";
+        labels_[static_cast<size_t>(base) + 3] = "Fine";
     }
     labels_[kFilterTypeSlot] = "Type";
     labels_[kCutoffSlot] = "Cutoff";
@@ -373,7 +373,7 @@ void PolySynthUI::applyOscColumnEnabled(int osc) {
     // enable toggle itself, which stays live so the column can be re-enabled.
     const int base = osc * kOscSlotCount;
     for (int p = 0; p < kOscSlotCount; ++p) {
-        auto& c = controls_[static_cast<size_t>(base + p)];
+        auto& c = controls_[static_cast<size_t>(base) + p];
         c.slider->setEnabled(on);
         c.slider->setAlpha(alpha);
         if (c.label)
@@ -386,7 +386,7 @@ void PolySynthUI::applyOscColumnEnabled(int osc) {
         rst->setEnabled(on);
         rst->setAlpha(alpha);
     }
-    if (auto& rlabel = controls_[static_cast<size_t>(kOscResetBaseSlot + osc)].label)
+    if (auto& rlabel = controls_[static_cast<size_t>(kOscResetBaseSlot) + osc].label)
         rlabel->setAlpha(alpha);
 }
 
@@ -589,7 +589,7 @@ void PolySynthUI::layoutOscSection() {
         const int boxH = col.getHeight() / 3;
         for (int p = 1; p < kOscSlotCount; ++p) {  // Level / Coarse / Fine
             auto cell = col.removeFromTop(boxH).reduced(0, 1);
-            auto& c = controls_[static_cast<size_t>(osc * kOscSlotCount + p)];
+            auto& c = controls_[static_cast<size_t>(osc) * kOscSlotCount + p];
             c.label->setBounds(cell.removeFromTop(kCellLabelH));
             c.slider->setBounds(cell);
         }

--- a/magda/daw/ui/components/pianoroll/PianoRollGridComponent.cpp
+++ b/magda/daw/ui/components/pianoroll/PianoRollGridComponent.cpp
@@ -3247,7 +3247,7 @@ void PianoRollGridComponent::handleExpressionMouseDrag(const juce::MouseEvent& e
     if (expressionDragPointIndex_ > 0)
         minBeat = expressionWorkingPoints_[static_cast<size_t>(expressionDragPointIndex_ - 1)].beat;
     if (expressionDragPointIndex_ + 1 < static_cast<int>(expressionWorkingPoints_.size()))
-        maxBeat = expressionWorkingPoints_[static_cast<size_t>(expressionDragPointIndex_ + 1)].beat;
+        maxBeat = expressionWorkingPoints_[static_cast<size_t>(expressionDragPointIndex_) + 1].beat;
 
     const double noteStartDisplayBeat = displayBeatForClipBeat(expressionClipId_, note.startBeat);
     point.beat = juce::jlimit(minBeat, maxBeat, pixelToBeat(e.x) - noteStartDisplayBeat);

--- a/magda/daw/ui/components/tracks/TrackContentPanelClipDrag.cpp
+++ b/magda/daw/ui/components/tracks/TrackContentPanelClipDrag.cpp
@@ -767,7 +767,7 @@ bool TrackContentPanel::nudgeSelectedClipsToAdjacentTrack(int direction) {
 
     CompoundOperationScope undoScope("Move Clips to Track");
     for (const auto& move : moves) {
-        const auto targetIndex = static_cast<size_t>(move.trackIndex + trackDelta);
+        const auto targetIndex = static_cast<size_t>(move.trackIndex) + trackDelta;
         UndoManager::getInstance().executeCommand(
             std::make_unique<MoveClipToTrackCommand>(move.clipId, hostTrackIds[targetIndex]));
     }

--- a/magda/daw/ui/panels/content/AIChatConsoleContent.cpp
+++ b/magda/daw/ui/panels/content/AIChatConsoleContent.cpp
@@ -2002,7 +2002,7 @@ juce::String formatClipAsDrummerContext(magda::ClipId clipId) {
                 if (i > 0)
                     line += " ";
                 line +=
-                    juce::String::charToString(cells[static_cast<size_t>(bar * kCellsPerBar + i)]);
+                    juce::String::charToString(cells[static_cast<size_t>(bar) * kCellsPerBar + i]);
             }
         }
         line += "\n";

--- a/magda/engine/clip/ClipStretcher.cpp
+++ b/magda/engine/clip/ClipStretcher.cpp
@@ -178,9 +178,9 @@ class SoundTouchClipStretcher final : public ClipStretcher {
         //
         // Grown here, on the thread that made this, and never again.
         const auto frames = stretchPushSamples();
-        interleaved_.resize(static_cast<std::size_t>(frames * channels_));
-        deinterleaved_.resize(
-            static_cast<std::size_t>(stretchWorkSamples(setup.maxBlockSamples) * channels_));
+        interleaved_.resize(static_cast<std::size_t>(frames) * channels_);
+        deinterleaved_.resize(static_cast<std::size_t>(stretchWorkSamples(setup.maxBlockSamples)) *
+                              channels_);
 
         allocatePreRoll(channels_, static_cast<int>(std::ceil(preRollSamples(setup.nominalRate) *
                                                               kPreRollHeadroom)));
@@ -348,7 +348,7 @@ class SoundTouchClipStretcher final : public ClipStretcher {
 
             for (auto sample = 0; sample < ready; ++sample)
                 destination[sample] =
-                    deinterleaved_[static_cast<std::size_t>(sample * channels_ + source)];
+                    deinterleaved_[static_cast<std::size_t>(sample) * channels_ + source];
 
             // A pipe that has not caught up yet is silence rather than whatever
             // the scratch held. It happens on the blocks a locate is still being
@@ -458,7 +458,7 @@ class SoundTouchClipStretcher final : public ClipStretcher {
             for (auto channel = 0; channel < channels_; ++channel) {
                 const auto source =
                     std::min(static_cast<std::size_t>(channel), block.getNumChannels() - 1);
-                interleaved_[static_cast<std::size_t>(sample * channels_ + channel)] =
+                interleaved_[static_cast<std::size_t>(sample) * channels_ + channel] =
                     block.getChannelPointer(source)[offset + sample];
             }
 

--- a/magda/engine/exec/PlanExecutor.cpp
+++ b/magda/engine/exec/PlanExecutor.cpp
@@ -641,7 +641,7 @@ std::vector<std::string> PlanExecutor::prepare(const RenderPlan& plan, const Pla
     const auto numPorts = static_cast<std::size_t>(portOffsets_.back());
     std::vector<int> portMidiBytes(numPorts, kMaxMidiBytesPerPort);
     const auto flatPort = [this](const PortRef& ref) {
-        return static_cast<std::size_t>(portOffsets_[static_cast<std::size_t>(ref.op)] + ref.port);
+        return static_cast<std::size_t>(portOffsets_[static_cast<std::size_t>(ref.op)]) + ref.port;
     };
 
     for (std::size_t i = 0; i < numOps; ++i) {
@@ -1552,7 +1552,7 @@ void PlanExecutor::renderOp(OpId id, const OpValue& published, const BlockInfo& 
                 std::array<juce::dsp::AudioBlock<float>, kMaxMultiOutPairs> pairs;
                 for (int pair = 0; pair < multiOutPairs; ++pair) {
                     const auto& port =
-                        op.outputs[static_cast<std::size_t>(firstMultiOutPort + pair)];
+                        op.outputs[static_cast<std::size_t>(firstMultiOutPort) + pair];
                     pairs[static_cast<std::size_t>(pair)] =
                         audioOut(id, firstMultiOutPort + pair, numSamples)
                             .getSubsetChannelBlock(0, static_cast<std::size_t>(port.channels));

--- a/magda/engine/exec/PlanLayout.cpp
+++ b/magda/engine/exec/PlanLayout.cpp
@@ -141,7 +141,7 @@ PlanLatency resolvePlanLatency(const RenderPlan& plan, const std::vector<int>& p
     resolved.portLatency.assign(static_cast<std::size_t>(portOffsets.back()), 0);
 
     const auto flat = [&portOffsets](const PortRef& ref) {
-        return static_cast<std::size_t>(portOffsets[static_cast<std::size_t>(ref.op)] + ref.port);
+        return static_cast<std::size_t>(portOffsets[static_cast<std::size_t>(ref.op)]) + ref.port;
     };
 
     // What an input carries before its delay compensates anything. A delay op
@@ -212,7 +212,7 @@ BufferLayout assignBuffers(const RenderPlan& plan, const std::vector<int>& portO
     layout.elided.assign(numOps, 0);
 
     const auto flat = [&portOffsets](const PortRef& ref) {
-        return static_cast<std::size_t>(portOffsets[static_cast<std::size_t>(ref.op)] + ref.port);
+        return static_cast<std::size_t>(portOffsets[static_cast<std::size_t>(ref.op)]) + ref.port;
     };
 
     // A delay holding no samples writes exactly what it read, so its output is

--- a/magda/engine/plan/PlanCompiler.cpp
+++ b/magda/engine/plan/PlanCompiler.cpp
@@ -814,7 +814,7 @@ ChainSignal Compiler::emitDevice(const DeviceInfo& device, const ChainSite& site
     // width is what pair p + 1 declares; pair 0 is the main output.
     const auto firstMultiOutPort = static_cast<int>(outputs.size());
     for (int pair = 0; pair < multiOutPairCount; ++pair) {
-        const auto& declared = device.multiOut.outputPairs[static_cast<std::size_t>(pair + 1)];
+        const auto& declared = device.multiOut.outputPairs[static_cast<std::size_t>(pair) + 1];
         outputs.push_back(
             {SignalKind::Audio, static_cast<std::uint8_t>(std::clamp(declared.numChannels, 0, 2))});
     }


### PR DESCRIPTION
## Summary
- Closes #2390. `bugprone-misplaced-widening-cast` reports 86 sites of the shape `static_cast<size_t>(a * b)` / `static_cast<size_t>(a + b)`: the arithmetic runs in `int` and only the result gets widened, so the cast does nothing about overflow.
- Fix: cast the first operand instead of the whole expression, so the rest promotes to `size_t` through it (`static_cast<size_t>(a) * b`) — the pattern the issue calls for ("cast an operand rather than the result").
- Checked every site's operands before fixing: all are small, real-time-bounded counts — oscillator/operator slot indices in the device UIs (FM/4OSC/PolySynth), FFT frame/bin/channel indexing in the stem separators, and port/buffer offsets in the plan executor/layout/compiler. None was anywhere near a real `int` overflow, so this is a mechanical widen rather than a sign of a latent bug — no site needed a `NOLINT` carve-out.
- 29 files touched, one fix per flagged site (a couple of files had double-digit counts: `FourOscUI.cpp` 17, `HpssSeparator.cpp` 13, `FMUI.cpp` 11).

## Test plan
- [x] `make debug` — builds clean
- [x] `make test` — 3711/3711 tests passing, 0 failures
- [x] Reran the exact command from the issue (`run-clang-tidy ... -checks='-*,bugprone-misplaced-widening-cast'` over `magda/`) — 0 remaining findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0149ko34fXR5PeMBqVL1tDWt