### PR TITLE
Add the capture queue and the writer thread

### DIFF
--- a/magda/engine/CMakeLists.txt
+++ b/magda/engine/CMakeLists.txt
@@ -138,6 +138,8 @@ add_library(magda_engine STATIC
     io/SourceLoopInfo.hpp
     io/PrefetchStream.cpp
     io/PrefetchThread.cpp
+    io/RecordStream.cpp
+    io/RecordThread.cpp
     io/SourceReaders.cpp
     io/StreamingAudioSource.cpp
     io/FileAudioSource.cpp
@@ -145,6 +147,8 @@ add_library(magda_engine STATIC
     io/ClipPlacement.hpp
     io/PrefetchStream.hpp
     io/PrefetchThread.hpp
+    io/RecordStream.hpp
+    io/RecordThread.hpp
     io/SourceReaders.hpp
     io/StreamingAudioSource.hpp
     io/FileAudioSource.hpp

--- a/magda/engine/io/RecordStream.cpp
+++ b/magda/engine/io/RecordStream.cpp
@@ -1,0 +1,151 @@
+#include "io/RecordStream.hpp"
+
+#include <algorithm>
+
+namespace magda::engine {
+
+namespace {
+
+int roundedCapacity(int wanted, int floorSamples) {
+    return juce::nextPowerOfTwo(std::max(floorSamples, wanted));
+}
+
+}  // namespace
+
+RecordStream::RecordStream(RecordSink& sink, const RecordStreamSettings& settings)
+    : sink_(sink),
+      capacity_(roundedCapacity(settings.capacitySamples, 1024)),
+      mask_(static_cast<std::uint64_t>(capacity_) - 1),
+      chunkSamples_(std::max(1, settings.chunkSamples)) {
+    if (settings.numChannels > 0)
+        audio_.setSize(settings.numChannels, capacity_);
+
+    midi_.resize(static_cast<std::size_t>(roundedCapacity(settings.midiCapacityEvents, 64)));
+    midiMask_ = midi_.size() - 1;
+}
+
+bool RecordStream::writeAudio(juce::dsp::AudioBlock<const float> audio, int numSamples) {
+    const auto channels = audio_.getNumChannels();
+    if (numSamples <= 0 || channels == 0)
+        return true;
+
+    const auto write = audioWrite_.load(std::memory_order_relaxed);
+    const auto read = audioRead_.load(std::memory_order_acquire);
+    const auto free = static_cast<std::uint64_t>(capacity_) - (write - read);
+
+    if (free < static_cast<std::uint64_t>(numSamples)) {
+        samplesLost_.fetch_add(numSamples, std::memory_order_relaxed);
+        return false;
+    }
+
+    const auto offset = static_cast<int>(write & mask_);
+    const auto first = std::min(numSamples, capacity_ - offset);
+    const auto rest = numSamples - first;
+    const auto sourceChannels = static_cast<int>(audio.getNumChannels());
+
+    for (auto channel = 0; channel < channels; ++channel) {
+        // A stream given fewer channels than it holds writes silence into the
+        // rest rather than leaving the last take's samples there.
+        if (channel >= sourceChannels) {
+            audio_.clear(channel, offset, first);
+            if (rest > 0)
+                audio_.clear(channel, 0, rest);
+            continue;
+        }
+
+        const auto* source = audio.getChannelPointer(static_cast<std::size_t>(channel));
+        audio_.copyFrom(channel, offset, source, first);
+        if (rest > 0)
+            audio_.copyFrom(channel, 0, source + first, rest);
+    }
+
+    audioWrite_.store(write + static_cast<std::uint64_t>(numSamples), std::memory_order_release);
+    return true;
+}
+
+bool RecordStream::writeMidi(const juce::MidiBuffer& midi, std::int64_t blockStartSample) {
+    auto kept = true;
+
+    for (const auto metadata : midi) {
+        if (metadata.numBytes > 3) {
+            eventsLost_.fetch_add(1, std::memory_order_relaxed);
+            kept = false;
+            continue;
+        }
+
+        const auto write = midiWrite_.load(std::memory_order_relaxed);
+        const auto read = midiRead_.load(std::memory_order_acquire);
+
+        if (midi_.size() - (write - read) == 0) {
+            eventsLost_.fetch_add(1, std::memory_order_relaxed);
+            kept = false;
+            continue;
+        }
+
+        auto& slot = midi_[static_cast<std::size_t>(write & midiMask_)];
+        slot.sample = blockStartSample + metadata.samplePosition;
+        slot.numBytes = static_cast<std::uint8_t>(metadata.numBytes);
+        slot.status = metadata.data[0];
+        slot.data1 = metadata.numBytes > 1 ? metadata.data[1] : 0;
+        slot.data2 = metadata.numBytes > 2 ? metadata.data[2] : 0;
+
+        midiWrite_.store(write + 1, std::memory_order_release);
+    }
+
+    return kept;
+}
+
+int RecordStream::contiguousAudioToDrain(std::uint64_t read, std::uint64_t available) const {
+    const auto offset = static_cast<int>(read & mask_);
+    const auto wanted =
+        std::min<std::uint64_t>(available, static_cast<std::uint64_t>(chunkSamples_));
+    return std::min(static_cast<int>(wanted), capacity_ - offset);
+}
+
+bool RecordStream::drain() {
+    auto worked = false;
+
+    if (audio_.getNumChannels() > 0) {
+        const auto read = audioRead_.load(std::memory_order_relaxed);
+        const auto write = audioWrite_.load(std::memory_order_acquire);
+
+        if (const auto available = write - read; available > 0) {
+            const auto take = contiguousAudioToDrain(read, available);
+            const auto offset = static_cast<std::size_t>(read & mask_);
+            const auto chunk = juce::dsp::AudioBlock<const float>(audio_).getSubBlock(
+                offset, static_cast<std::size_t>(take));
+
+            if (!failed_.load(std::memory_order_relaxed) && !sink_.writeAudio(chunk, take))
+                failed_.store(true, std::memory_order_relaxed);
+
+            audioRead_.store(read + static_cast<std::uint64_t>(take), std::memory_order_release);
+            worked = true;
+        }
+    }
+
+    const auto midiRead = midiRead_.load(std::memory_order_relaxed);
+    const auto midiWrite = midiWrite_.load(std::memory_order_acquire);
+
+    if (const auto available = midiWrite - midiRead; available > 0) {
+        const auto offset = static_cast<std::size_t>(midiRead & midiMask_);
+        const auto take = std::min<std::size_t>(available, midi_.size() - offset);
+
+        if (!failed_.load(std::memory_order_relaxed) &&
+            !sink_.writeMidi(std::span<const RecordedMidiEvent>(midi_.data() + offset, take)))
+            failed_.store(true, std::memory_order_relaxed);
+
+        midiRead_.store(midiRead + take, std::memory_order_release);
+        worked = true;
+    }
+
+    return worked;
+}
+
+void RecordStream::finish() {
+    while (drain()) {
+    }
+
+    sink_.finish();
+}
+
+}  // namespace magda::engine

--- a/magda/engine/io/RecordStream.cpp
+++ b/magda/engine/io/RecordStream.cpp
@@ -1,6 +1,7 @@
 #include "io/RecordStream.hpp"
 
 #include <algorithm>
+#include <utility>
 
 namespace magda::engine {
 
@@ -112,8 +113,11 @@ bool RecordStream::drain() {
         if (const auto available = write - read; available > 0) {
             const auto take = contiguousAudioToDrain(read, available);
             const auto offset = static_cast<std::size_t>(read & mask_);
-            const auto chunk = juce::dsp::AudioBlock<const float>(audio_).getSubBlock(
-                offset, static_cast<std::size_t>(take));
+            // as_const, and not for tidiness: the AudioBlock constructor taking a
+            // mutable buffer calls getArrayOfWritePointers, which writes the
+            // buffer's isClear flag that the audio thread's copyFrom writes too.
+            const auto chunk = juce::dsp::AudioBlock<const float>(std::as_const(audio_))
+                                   .getSubBlock(offset, static_cast<std::size_t>(take));
 
             if (!failed_.load(std::memory_order_relaxed) && !sink_.writeAudio(chunk, take))
                 failed_.store(true, std::memory_order_relaxed);

--- a/magda/engine/io/RecordStream.hpp
+++ b/magda/engine/io/RecordStream.hpp
@@ -1,0 +1,201 @@
+#pragma once
+
+#include <juce_audio_basics/juce_audio_basics.h>
+#include <juce_dsp/juce_dsp.h>
+
+#include <atomic>
+#include <cstdint>
+#include <span>
+#include <vector>
+
+/**
+ * @file RecordStream.hpp
+ * @brief What the audio thread hands a disk during a take (#2460).
+ *
+ * The mirror of PrefetchStream: one reads ahead of the callback, this one
+ * writes behind it. The callback copies into memory and returns; a thread
+ * allowed to block moves it to disk.
+ *
+ * Not tap/SampleRing.hpp, whose contract is the opposite one. A ring lets the
+ * writer overwrite what the reader has not taken, which is right for a meter
+ * and for a retro-capture buffer (#2311) where the present matters more than
+ * the past. A take is the past: a sample the disk did not keep up with is a
+ * hole in a performance, so this refuses to overwrite and says how much it
+ * had to drop instead.
+ */
+
+namespace magda::engine {
+
+/**
+ * @brief One short message, at a sample from the take's start.
+ *
+ * Three data bytes and no more, as clip/MidiEventList.hpp and
+ * insert/InsertCapture.hpp: what a MIDI take holds is notes, CC and pitch
+ * bend, so a longer message has nowhere to go and is dropped and counted
+ * rather than truncated into a different message.
+ */
+struct RecordedMidiEvent {
+    std::int64_t sample = 0;
+
+    /// A program change kept three bytes long is a different message.
+    std::uint8_t numBytes = 0;
+
+    std::uint8_t status = 0;
+    std::uint8_t data1 = 0;
+    std::uint8_t data2 = 0;
+};
+
+/**
+ * @brief Where a drained take goes.
+ *
+ * Called on the record thread and nowhere else, which is what makes a file
+ * safe to touch here. Returning false means the write failed and the take is
+ * broken: the stream stops offering it samples and says so (#2461 decides
+ * what a broken take becomes).
+ */
+class RecordSink {
+  public:
+    virtual ~RecordSink() = default;
+
+    virtual bool writeAudio(juce::dsp::AudioBlock<const float> audio, int numSamples) {
+        juce::ignoreUnused(audio, numSamples);
+        return true;
+    }
+
+    virtual bool writeMidi(std::span<const RecordedMidiEvent> events) {
+        juce::ignoreUnused(events);
+        return true;
+    }
+
+    /// After the last sample, on the thread that called RecordStream::finish.
+    virtual void finish() {}
+};
+
+/** How much a stream holds, and how much of it one round of draining moves. */
+struct RecordStreamSettings {
+    /// Zero for a MIDI-only take.
+    int numChannels = 2;
+
+    /**
+     * @brief Samples of room, per channel. Rounded up to a power of two.
+     *
+     * How long the disk may stall before a take loses samples. The default is
+     * about a second and a half at 44.1 kHz, which is far longer than a write
+     * that is merely slow and short enough that a stream costs kilobytes
+     * rather than megabytes per armed track.
+     */
+    int capacitySamples = 65536;
+
+    int midiCapacityEvents = 1024;
+
+    /// Samples one drain hands the sink. The unit of disk work, as
+    /// PrefetchSettings::chunkSamples is the unit of reading.
+    int chunkSamples = 4096;
+};
+
+/**
+ * @brief One take's queue: written on the audio thread, drained on the record
+ *        thread.
+ *
+ * Single producer, single consumer, and neither side allocates or locks. The
+ * room is taken at construction, which is what makes a write a copy and
+ * nothing else.
+ */
+class RecordStream {
+  public:
+    explicit RecordStream(RecordSink& sink, const RecordStreamSettings& settings = {});
+
+    RecordStream(const RecordStream&) = delete;
+    RecordStream& operator=(const RecordStream&) = delete;
+
+    /**
+     * @brief Append @p numSamples of @p audio. On the audio thread.
+     *
+     * False when there was no room: the whole block is dropped and counted.
+     * Dropped whole rather than in part, because half a block leaves a hole
+     * in the middle of a file that nothing downstream can see; a count of
+     * lost samples is a fact the finished take can carry.
+     */
+    bool writeAudio(juce::dsp::AudioBlock<const float> audio, int numSamples);
+
+    /**
+     * @brief Append @p midi, stamped from @p blockStartSample. On the audio
+     *        thread.
+     *
+     * The position is the caller's because a MIDI-only take has no audio to
+     * count samples with, and because both must be stamped against the take's
+     * clock rather than each against its own.
+     *
+     * False when anything was dropped: no room, or a message longer than
+     * three bytes.
+     */
+    bool writeMidi(const juce::MidiBuffer& midi, std::int64_t blockStartSample);
+
+    /**
+     * @brief Move one chunk to the sink. On the record thread.
+     *
+     * Returns whether it did anything, so a thread servicing several streams
+     * can tell a busy round from an idle one. A failed write drops the chunk
+     * rather than holding it: the take is already broken, and a queue nobody
+     * drains would stop the audio thread writing the next one.
+     */
+    bool drain();
+
+    /**
+     * @brief Drain what is left and close the sink.
+     *
+     * After the audio thread has stopped writing, on a thread that may block.
+     * Draining and closing are one call because a sink closed with samples
+     * still queued is a take that ends early with nothing to say about it.
+     */
+    void finish();
+
+    /// Samples the disk could not keep up with. Read from any thread; a take
+    /// reporting more than zero has a hole in it.
+    std::int64_t samplesLost() const {
+        return samplesLost_.load(std::memory_order_relaxed);
+    }
+
+    /// Events dropped for want of room, or for being longer than three bytes.
+    std::int64_t eventsLost() const {
+        return eventsLost_.load(std::memory_order_relaxed);
+    }
+
+    /// Whether a write to the sink failed. Read from any thread.
+    bool failed() const {
+        return failed_.load(std::memory_order_relaxed);
+    }
+
+    /// Samples of room per channel, after rounding.
+    int capacitySamples() const {
+        return capacity_;
+    }
+
+    int numChannels() const {
+        return audio_.getNumChannels();
+    }
+
+  private:
+    int contiguousAudioToDrain(std::uint64_t read, std::uint64_t available) const;
+
+    RecordSink& sink_;
+
+    juce::AudioBuffer<float> audio_;
+    int capacity_ = 0;
+    std::uint64_t mask_ = 0;
+    int chunkSamples_ = 0;
+
+    std::vector<RecordedMidiEvent> midi_;
+    std::uint64_t midiMask_ = 0;
+
+    std::atomic<std::uint64_t> audioWrite_{0};
+    std::atomic<std::uint64_t> audioRead_{0};
+    std::atomic<std::uint64_t> midiWrite_{0};
+    std::atomic<std::uint64_t> midiRead_{0};
+
+    std::atomic<std::int64_t> samplesLost_{0};
+    std::atomic<std::int64_t> eventsLost_{0};
+    std::atomic<bool> failed_{false};
+};
+
+}  // namespace magda::engine

--- a/magda/engine/io/RecordThread.cpp
+++ b/magda/engine/io/RecordThread.cpp
@@ -1,0 +1,61 @@
+#include "io/RecordThread.hpp"
+
+#include <algorithm>
+
+namespace magda::engine {
+
+RecordThread::RecordThread(bool runInBackground)
+    : juce::Thread("MAGDA record"), runsInBackground_(runInBackground) {
+    // The same priority the reader runs at. A writer that lost to a redraw is
+    // what a hole in a take is made of.
+    if (runsInBackground_)
+        startThread(juce::Thread::Priority::high);
+}
+
+RecordThread::~RecordThread() {
+    stopThread(2000);
+}
+
+void RecordThread::add(RecordStream& stream) {
+    {
+        const std::scoped_lock guard(lock_);
+        if (std::find(streams_.begin(), streams_.end(), &stream) == streams_.end())
+            streams_.push_back(&stream);
+    }
+
+    notify();
+}
+
+void RecordThread::remove(RecordStream& stream) {
+    const std::scoped_lock guard(lock_);
+    streams_.erase(std::remove(streams_.begin(), streams_.end(), &stream), streams_.end());
+}
+
+std::size_t RecordThread::streamCount() const {
+    const std::scoped_lock guard(lock_);
+    return streams_.size();
+}
+
+bool RecordThread::drainOnce() {
+    const std::scoped_lock guard(lock_);
+
+    auto worked = false;
+    for (auto* stream : streams_)
+        worked = stream->drain() || worked;
+
+    return worked;
+}
+
+void RecordThread::run() {
+    while (!threadShouldExit()) {
+        // Straight round again while there is anything to write: a stream that
+        // has fallen behind holds samples nothing else can keep, and sleeping
+        // between chunks is how it comes to lose them.
+        if (drainOnce())
+            continue;
+
+        wait(kIdleMilliseconds);
+    }
+}
+
+}  // namespace magda::engine

--- a/magda/engine/io/RecordThread.hpp
+++ b/magda/engine/io/RecordThread.hpp
@@ -1,0 +1,77 @@
+#pragma once
+
+#include <juce_core/juce_core.h>
+
+#include <mutex>
+#include <vector>
+
+#include "io/RecordStream.hpp"
+
+/**
+ * @file RecordThread.hpp
+ * @brief The one thread allowed to write a take to disk.
+ *
+ * PrefetchThread's counterpart, and the same shape for the same reasons: one
+ * thread rather than one per take, above the interface and below the callback,
+ * polling rather than woken from the audio thread, since waking a thread takes
+ * a lock and the callback does not take locks.
+ *
+ * A round that is behind is not a glitch here, it is a hole in a recording, so
+ * it drains every stream that has anything before it sleeps at all.
+ */
+
+namespace magda::engine {
+
+class RecordThread final : private juce::Thread {
+  public:
+    /**
+     * @brief A writer, with or without the thread behind it.
+     *
+     * Off is for tests, which want to say exactly how far behind the disk got
+     * before the next block was written.
+     */
+    explicit RecordThread(bool runInBackground = true);
+    ~RecordThread() override;
+
+    RecordThread(const RecordThread&) = delete;
+    RecordThread& operator=(const RecordThread&) = delete;
+
+    /// Start draining this stream. Off the audio thread; the stream must
+    /// outlive the registration.
+    void add(RecordStream& stream);
+
+    /**
+     * @brief Stop draining it.
+     *
+     * Off the audio thread, and blocks until the thread is out of the stream,
+     * which is what makes it safe to finish and destroy afterwards. What is
+     * still queued stays queued: closing a take is RecordStream::finish, and
+     * an unregister that also flushed would decide where a take ends.
+     */
+    void remove(RecordStream& stream);
+
+    /// Streams registered right now.
+    std::size_t streamCount() const;
+
+    /// One round of draining, without the thread.
+    bool drainOnce();
+
+    /// Whether anything is draining behind the caller's back.
+    bool runsInBackground() const {
+        return runsInBackground_;
+    }
+
+  private:
+    void run() override;
+
+    /// How long to sleep when every stream is empty. Long enough that an idle
+    /// project is not a thread spinning, short enough that a take stopped
+    /// between rounds is on disk before anyone asks for it.
+    static constexpr int kIdleMilliseconds = 5;
+
+    mutable std::mutex lock_;
+    std::vector<RecordStream*> streams_;
+    bool runsInBackground_ = true;
+};
+
+}  // namespace magda::engine

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -421,6 +421,9 @@ if(MAGDA_BUILD_NATIVE_ENGINE)
     # What an armed or monitoring track hears (#2459): the callback's own
     # samples, its own piece of a split callback, and nothing between callbacks.
     list(APPEND TEST_SOURCES engine/test_live_input.cpp)
+    # The write path a take goes to disk through (#2460): what it keeps, what
+    # it refuses to overwrite, and what it says it lost.
+    list(APPEND TEST_SOURCES engine/test_record_stream.cpp)
     list(APPEND TEST_SOURCES engine/test_engine_taps.cpp)
     list(APPEND TEST_SOURCES engine/test_clip_snapshot.cpp)
     list(APPEND TEST_SOURCES engine/test_clip_voice.cpp)

--- a/tests/engine/test_record_stream.cpp
+++ b/tests/engine/test_record_stream.cpp
@@ -1,0 +1,290 @@
+#include <atomic>
+#include <catch2/catch_test_macros.hpp>
+#include <chrono>
+#include <thread>
+#include <vector>
+
+#include "io/RecordStream.hpp"
+#include "io/RecordThread.hpp"
+
+/**
+ * @file test_record_stream.cpp
+ * @brief The write path, with nothing on either end of it (#2460).
+ *
+ * No take, no file, no input: a producer that pushes blocks and a consumer
+ * that may or may not keep up. What the cases are about is the one thing that
+ * separates this from a tap -- a sample the disk misses is a hole in a
+ * performance, so it is refused and counted rather than overwritten.
+ */
+
+using magda::engine::RecordedMidiEvent;
+using magda::engine::RecordSink;
+using magda::engine::RecordStream;
+using magda::engine::RecordStreamSettings;
+using magda::engine::RecordThread;
+
+namespace {
+
+/// Keeps everything it is handed, in the order it was handed it.
+class CollectingSink final : public RecordSink {
+  public:
+    bool writeAudio(juce::dsp::AudioBlock<const float> audio, int numSamples) override {
+        for (auto sample = 0; sample < numSamples; ++sample)
+            left.push_back(audio.getSample(0, sample));
+
+        ++audioWrites;
+        written.store(static_cast<int>(left.size()), std::memory_order_release);
+        return !fails;
+    }
+
+    bool writeMidi(std::span<const RecordedMidiEvent> events) override {
+        for (const auto& event : events)
+            midi.push_back(event);
+
+        return !fails;
+    }
+
+    void finish() override {
+        ++finishes;
+    }
+
+    std::vector<float> left;
+    std::vector<RecordedMidiEvent> midi;
+    int audioWrites = 0;
+    int finishes = 0;
+    bool fails = false;
+
+    /// Readable while the record thread is writing, which the ones below are
+    /// not: a case waiting for a background round polls this.
+    std::atomic<int> written{0};
+};
+
+/// A block whose samples say which sample of the take they are.
+juce::AudioBuffer<float> countingBlock(int numChannels, int numSamples, int from) {
+    juce::AudioBuffer<float> buffer(numChannels, numSamples);
+    for (auto channel = 0; channel < numChannels; ++channel)
+        for (auto sample = 0; sample < numSamples; ++sample)
+            buffer.setSample(channel, sample, static_cast<float>(from + sample));
+    return buffer;
+}
+
+bool writeBlock(RecordStream& stream, const juce::AudioBuffer<float>& block) {
+    return stream.writeAudio(juce::dsp::AudioBlock<const float>(block), block.getNumSamples());
+}
+
+/// True once @p predicate holds, or false when it has not within a second.
+/// Polled rather than slept through: a fixed wait is either flaky or slow.
+template <typename Predicate> bool waitFor(Predicate predicate) {
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(1);
+
+    while (std::chrono::steady_clock::now() < deadline) {
+        if (predicate())
+            return true;
+        std::this_thread::yield();
+    }
+
+    return predicate();
+}
+
+}  // namespace
+
+TEST_CASE("A drained stream holds every sample, in order", "[engine][record]") {
+    CollectingSink sink;
+    RecordStream stream(sink, {2, 4096, 64, 256});
+
+    constexpr int kBlockSize = 128;
+    for (auto block = 0; block < 40; ++block) {
+        REQUIRE(writeBlock(stream, countingBlock(2, kBlockSize, block * kBlockSize)));
+        stream.drain();
+    }
+
+    stream.finish();
+
+    REQUIRE(sink.left.size() == 40 * kBlockSize);
+    for (std::size_t sample = 0; sample < sink.left.size(); ++sample)
+        CHECK(sink.left[sample] == static_cast<float>(sample));
+
+    CHECK(stream.samplesLost() == 0);
+    CHECK_FALSE(stream.failed());
+    CHECK(sink.finishes == 1);
+}
+
+TEST_CASE("A take crossing the end of the queue comes back unbroken", "[engine][record]") {
+    CollectingSink sink;
+    // Deliberately small, so 40 blocks lap it several times.
+    RecordStream stream(sink, {1, 1024, 64, 300});
+    REQUIRE(stream.capacitySamples() == 1024);
+
+    constexpr int kBlockSize = 128;
+    for (auto block = 0; block < 40; ++block) {
+        REQUIRE(writeBlock(stream, countingBlock(1, kBlockSize, block * kBlockSize)));
+        while (stream.drain()) {
+        }
+    }
+
+    stream.finish();
+
+    REQUIRE(sink.left.size() == 40 * kBlockSize);
+    for (std::size_t sample = 0; sample < sink.left.size(); ++sample)
+        CHECK(sink.left[sample] == static_cast<float>(sample));
+}
+
+TEST_CASE("A stalled writer costs samples, and says how many", "[engine][record]") {
+    CollectingSink sink;
+    RecordStream stream(sink, {1, 1024, 64, 256});
+
+    constexpr int kBlockSize = 128;
+    auto written = 0;
+    auto refused = 0;
+
+    // Nothing drains, so the queue fills and every block after it is refused.
+    for (auto block = 0; block < 16; ++block) {
+        if (writeBlock(stream, countingBlock(1, kBlockSize, block * kBlockSize)))
+            written += kBlockSize;
+        else
+            refused += kBlockSize;
+    }
+
+    CHECK(written == stream.capacitySamples());
+    CHECK(stream.samplesLost() == refused);
+
+    // The room is what it was asked for: an overrun costs samples rather than
+    // buying a bigger queue.
+    CHECK(stream.capacitySamples() == 1024);
+
+    // What it did keep is the earliest samples, not the latest: a queue that
+    // overwrote would come back holding the end of the take.
+    while (stream.drain()) {
+    }
+    stream.finish();
+
+    REQUIRE(sink.left.size() == static_cast<std::size_t>(written));
+    for (std::size_t sample = 0; sample < sink.left.size(); ++sample)
+        CHECK(sink.left[sample] == static_cast<float>(sample));
+
+    // And it recovers: a stall is a hole, not the end of the take.
+    CHECK(writeBlock(stream, countingBlock(1, kBlockSize, 0)));
+}
+
+TEST_CASE("A write the sink refuses breaks the take rather than the queue", "[engine][record]") {
+    CollectingSink sink;
+    sink.fails = true;
+    RecordStream stream(sink, {1, 1024, 64, 256});
+
+    constexpr int kBlockSize = 128;
+    for (auto block = 0; block < 8; ++block) {
+        REQUIRE(writeBlock(stream, countingBlock(1, kBlockSize, block * kBlockSize)));
+        while (stream.drain()) {
+        }
+    }
+
+    CHECK(stream.failed());
+
+    // The failure is reported once and the queue keeps draining, so the audio
+    // thread is never blocked by a disk that has already given up.
+    CHECK(stream.samplesLost() == 0);
+    CHECK(sink.audioWrites == 1);
+    CHECK(writeBlock(stream, countingBlock(1, kBlockSize, 0)));
+}
+
+TEST_CASE("MIDI keeps the sample it was played on", "[engine][record]") {
+    CollectingSink sink;
+    RecordStream stream(sink, {0, 1024, 8, 256});
+
+    juce::MidiBuffer first;
+    first.addEvent(juce::MidiMessage::noteOn(1, 60, 1.0f), 5);
+    first.addEvent(juce::MidiMessage::controllerEvent(1, 74, 100), 63);
+
+    juce::MidiBuffer second;
+    second.addEvent(juce::MidiMessage::noteOff(1, 60), 10);
+
+    REQUIRE(stream.writeMidi(first, 0));
+    REQUIRE(stream.writeMidi(second, 512));
+    while (stream.drain()) {
+    }
+    stream.finish();
+
+    REQUIRE(sink.midi.size() == 3);
+    CHECK(sink.midi[0].sample == 5);
+    CHECK(sink.midi[0].numBytes == 3);
+    CHECK(sink.midi[1].sample == 63);
+    CHECK(sink.midi[2].sample == 522);
+    CHECK(stream.eventsLost() == 0);
+}
+
+TEST_CASE("MIDI a stream cannot hold is dropped and counted", "[engine][record]") {
+    CollectingSink sink;
+    RecordStream stream(sink, {0, 1024, 64, 256});
+
+    SECTION("a burst past the room it has") {
+        juce::MidiBuffer flood;
+        for (auto event = 0; event < 200; ++event)
+            flood.addEvent(juce::MidiMessage::controllerEvent(1, 74, event % 128), event);
+
+        CHECK_FALSE(stream.writeMidi(flood, 0));
+        CHECK(stream.eventsLost() == 200 - 64);
+
+        while (stream.drain()) {
+        }
+        CHECK(sink.midi.size() == 64);
+    }
+
+    SECTION("and a message longer than a take can hold") {
+        const std::vector<std::uint8_t> payload{0x7D, 0x01, 0x02, 0x03};
+        juce::MidiBuffer sysex;
+        sysex.addEvent(
+            juce::MidiMessage::createSysExMessage(payload.data(), static_cast<int>(payload.size())),
+            0);
+
+        CHECK_FALSE(stream.writeMidi(sysex, 0));
+        CHECK(stream.eventsLost() == 1);
+
+        while (stream.drain()) {
+        }
+        CHECK(sink.midi.empty());
+    }
+}
+
+TEST_CASE("The record thread drains what it is given and nothing else", "[engine][record]") {
+    CollectingSink sink;
+    RecordStream stream(sink, {1, 4096, 64, 256});
+
+    SECTION("driven by hand, with no thread behind it") {
+        RecordThread thread(false);
+        REQUIRE(thread.streamCount() == 0);
+        CHECK_FALSE(thread.drainOnce());
+
+        thread.add(stream);
+        REQUIRE(thread.streamCount() == 1);
+
+        REQUIRE(writeBlock(stream, countingBlock(1, 128, 0)));
+        CHECK(thread.drainOnce());
+        CHECK(sink.left.size() == 128);
+
+        thread.remove(stream);
+        REQUIRE(thread.streamCount() == 0);
+
+        // What is written after it was removed stays queued: closing a take is
+        // finish(), not unregistering.
+        REQUIRE(writeBlock(stream, countingBlock(1, 128, 128)));
+        CHECK_FALSE(thread.drainOnce());
+        CHECK(sink.left.size() == 128);
+    }
+
+    SECTION("and in the background, without being asked") {
+        RecordThread thread;
+        thread.add(stream);
+
+        for (auto block = 0; block < 8; ++block)
+            REQUIRE(writeBlock(stream, countingBlock(1, 128, block * 128)));
+
+        CHECK(waitFor([&sink] { return sink.written.load(std::memory_order_acquire) == 1024; }));
+
+        thread.remove(stream);
+        stream.finish();
+
+        REQUIRE(sink.left.size() == 1024);
+        for (std::size_t sample = 0; sample < sink.left.size(); ++sample)
+            CHECK(sink.left[sample] == static_cast<float>(sample));
+    }
+}


### PR DESCRIPTION
Slice 2 of #1895, closes #2460. Independent of slice 1: one gets the input in,
this one gets samples out to disk, and slice 3 is where they meet.

`RecordStream` is one take's queue, single producer and single consumer, with the
room taken at construction so a write on the audio thread is a copy and nothing
else. `RecordThread` is its counterpart to `PrefetchThread`: one thread rather
than one per take, polling rather than woken from the callback, and draining
every stream that has anything before it sleeps at all, because a round that is
behind here is a hole in a recording rather than a glitch.

Not `tap/SampleRing.hpp`, and the header says why: a ring lets the writer
overwrite what the reader has not taken, which is right for a meter and for the
retro capture buffers in #2311. A take is the past, so this refuses to overwrite
and reports what it had to drop instead. Sample stamped MIDI goes through the
same path, bounded by event count and by three bytes a message, so a burst
cannot allocate either. A sink that refuses a write breaks the take once and the
queue keeps draining, leaving #2461 to decide what a broken take becomes.

## Verification

Offline throughout: a synthetic producer, a consumer that may or may not keep up,
and no take, no file and no input anywhere in the cases.

| What #2460 asks for | Case |
| --- | --- |
| nothing lost when the writer keeps up, and in order | A drained stream holds every sample, in order; A take crossing the end of the queue comes back unbroken |
| an overrun reported with a count, not blocked or overwritten | A stalled writer costs samples, and says how many |
| capacity is what was set and does not grow under load | A stalled writer costs samples, and says how many |
| MIDI keeps its sample stamps, burst included | MIDI keeps the sample it was played on; MIDI a stream cannot hold is dropped and counted |
| a failed write reported once and reaching the asker | A write the sink refuses breaks the take rather than the queue |

Full suite green: 3740 cases, 997128 assertions. `[record]` green over 30
consecutive runs, which is the case with a real background thread behind it.

## One divergence from the issue

#2460 says capacity is fixed at prepare. It is fixed at construction here, which
is stricter and is what makes a write a copy and nothing else. Slice 3 reads that
contract, so it is worth a word now if you would rather it match the wording.

https://claude.ai/code/session_013A1GWqAoLZPdkYAMwKrjQj
