### PR TITLE
Record an arrangement audio take, from armed to clip

### DIFF
--- a/magda/engine/CMakeLists.txt
+++ b/magda/engine/CMakeLists.txt
@@ -140,6 +140,8 @@ add_library(magda_engine STATIC
     io/PrefetchThread.cpp
     io/RecordStream.cpp
     io/RecordThread.cpp
+    io/TakeFileSink.cpp
+    io/TakeRecorder.cpp
     io/SourceReaders.cpp
     io/StreamingAudioSource.cpp
     io/FileAudioSource.cpp
@@ -149,6 +151,8 @@ add_library(magda_engine STATIC
     io/PrefetchThread.hpp
     io/RecordStream.hpp
     io/RecordThread.hpp
+    io/TakeFileSink.hpp
+    io/TakeRecorder.hpp
     io/SourceReaders.hpp
     io/StreamingAudioSource.hpp
     io/FileAudioSource.hpp

--- a/magda/engine/exec/EngineSession.cpp
+++ b/magda/engine/exec/EngineSession.cpp
@@ -220,6 +220,10 @@ void EngineSession::process(int numSamples, juce::AudioBuffer<float>& output,
 
     PublishedTransport::ScopedAccess<farbot::ThreadType::realtime> transport(transport_);
 
+    // Held for the callback rather than fetched per block: what is being
+    // recorded cannot change in the middle of one.
+    const RecordingFeed::Reader takes(recording_);
+
     // One callback is one or more stretches of timeline. It is more than one
     // exactly when a loop wraps inside it, and the pieces are rendered as
     // separate blocks so that nothing downstream has to know a wrap can happen
@@ -233,6 +237,12 @@ void EngineSession::process(int numSamples, juce::AudioBuffer<float>& output,
                                        segment.startSample, segment.block.numSamples);
 
         liveInputs_.beginSegment(segment.startSample, segment.block.numSamples);
+
+        // Before the plan and outside it: a take holds the input the device
+        // captured, not what the track's chain went on to make of it.
+        if (takes)
+            for (auto* recorder : *takes.get())
+                recorder->capture(segment.block, segment.countingIn, transport->loop);
 
         // Where the transport is, for the thread that reads ahead of it. A
         // relaxed store of a double, before the block rather than after: the

--- a/magda/engine/exec/EngineSession.hpp
+++ b/magda/engine/exec/EngineSession.hpp
@@ -10,6 +10,7 @@
 #include "exec/RenderThreadPool.hpp"
 #include "exec/RuntimeStateStore.hpp"
 #include "io/LiveInput.hpp"
+#include "io/TakeRecorder.hpp"
 #include "launch/SessionLauncher.hpp"
 #include "transport/ClickGenerator.hpp"
 #include "transport/TransportClock.hpp"
@@ -234,6 +235,19 @@ class EngineSession {
         return liveInputs_;
     }
 
+    /**
+     * @brief The takes the callback writes into (#2461).
+     *
+     * Published like the clips are, and outside every plan for the same
+     * reason: arming a track compiles a plan, but starting a recording is not
+     * a structural edit and must not cost one. A take taken out of the set is
+     * one nothing is writing to by the time publish returns, which is what
+     * makes it safe to close.
+     */
+    RecordingFeed& recordingFeed() {
+        return recording_;
+    }
+
     /// Where the transport is, in beats. Readable from any thread; what a
     /// playhead is drawn from.
     double positionBeats() const {
@@ -371,6 +385,10 @@ class EngineSession {
     /// the same reason the clock is: what the device captured is a property of
     /// the callback, not of the plan rendering it.
     LiveInputFeed liveInputs_;
+
+    /// The takes that input is written to. Outside every epoch beside it, and
+    /// for the same reason.
+    RecordingFeed recording_;
 
     /// What the model held at the last publish. Kept so a values publish
     /// escalated into a structural one has a set to publish with; retention

--- a/magda/engine/io/AudioFileSink.cpp
+++ b/magda/engine/io/AudioFileSink.cpp
@@ -83,6 +83,10 @@ DitherMode defaultDitherFor(int bitDepth) {
     return bitDepth >= 32 ? DitherMode::none : DitherMode::tpdf;
 }
 
+juce::String extensionFor(AudioFileFormat format) {
+    return format == AudioFileFormat::flac ? ".flac" : ".wav";
+}
+
 std::unique_ptr<AudioFileSink> AudioFileSink::create(const juce::File& destination,
                                                      const AudioFileSpec& spec,
                                                      const RenderContext& context) {
@@ -159,25 +163,36 @@ AudioFileSink::~AudioFileSink() {
 }
 
 void AudioFileSink::write(const juce::AudioBuffer<float>& block, int numSamples) {
+    // The const buffer picks AudioBlock's read-pointer constructor, so nothing
+    // here marks the caller's buffer as written to.
+    write(juce::dsp::AudioBlock<const float>(block), numSamples);
+}
+
+void AudioFileSink::write(juce::dsp::AudioBlock<const float> block, int numSamples) {
     if (failed_ || writer_ == nullptr || numSamples <= 0)
         return;
 
     // A block narrower than the file has no samples for the channels past its
     // own, and the writer would store whatever was in that memory. Refused, so
     // the file ends where the render stopped making sense.
-    if (block.getNumChannels() < numChannels_) {
+    if (static_cast<int>(block.getNumChannels()) < numChannels_) {
         failed_ = true;
         return;
     }
 
+    sourceChannels_.resize(static_cast<std::size_t>(numChannels_));
+    for (auto channel = 0; channel < numChannels_; ++channel)
+        sourceChannels_[static_cast<std::size_t>(channel)] =
+            block.getChannelPointer(static_cast<std::size_t>(channel));
+
     if (!quantiser_) {
-        failed_ = !writer_->writeFromFloatArrays(block.getArrayOfReadPointers(), numChannels_,
-                                                 numSamples);
+        failed_ = !writer_->writeFromFloatArrays(sourceChannels_.data(), numChannels_, numSamples);
     } else {
         resizeCodes(numSamples);
 
         for (auto channel = 0; channel < numChannels_; ++channel)
-            scratch_.copyFrom(channel, 0, block, channel, 0, numSamples);
+            scratch_.copyFrom(channel, 0, sourceChannels_[static_cast<std::size_t>(channel)],
+                              numSamples);
 
         quantiser_->processToCodes(scratch_, numSamples, codeChannels_.data());
 

--- a/magda/engine/io/AudioFileSink.hpp
+++ b/magda/engine/io/AudioFileSink.hpp
@@ -59,6 +59,9 @@ struct AudioFileSpec {
 /// What a depth is dithered with when the spec does not say.
 DitherMode defaultDitherFor(int bitDepth);
 
+/// The extension a container's files carry, dot included.
+juce::String extensionFor(AudioFileFormat format);
+
 class AudioFileSink final : public OfflineRenderSink {
   public:
     /**
@@ -94,6 +97,10 @@ class AudioFileSink final : public OfflineRenderSink {
     /// on its first block and writes a file on every one.
     void write(const juce::AudioBuffer<float>& block, int numSamples) override;
 
+    /// The same block, as a record path hands one over (#2461): what a take
+    /// drains out of its queue is a window on a ring, never a buffer.
+    void write(juce::dsp::AudioBlock<const float> block, int numSamples);
+
     /**
      * @brief Finish the file, put it at the destination, and say whether it
      *        holds the render.
@@ -111,6 +118,13 @@ class AudioFileSink final : public OfflineRenderSink {
     /// Samples per channel handed to the writer.
     std::int64_t samplesWritten() const {
         return samplesWritten_;
+    }
+
+    /// Whether a block was refused. What close() reports, before the file has
+    /// been closed: a take asks after every write so a broken one is broken
+    /// once rather than for the rest of a pass.
+    bool failed() const {
+        return failed_;
     }
 
   private:
@@ -143,6 +157,10 @@ class AudioFileSink final : public OfflineRenderSink {
 
     std::vector<int> codes_;
     std::vector<int*> codeChannels_;
+
+    /// The block's channels, as the writer wants them. A member because a
+    /// block hands them over one at a time and the writer takes an array.
+    std::vector<const float*> sourceChannels_;
 
     /// Samples per channel the code buffer holds, which is also its stride: a
     /// shorter block writes the front of each channel's room and leaves the

--- a/magda/engine/io/TakeFileSink.cpp
+++ b/magda/engine/io/TakeFileSink.cpp
@@ -1,0 +1,131 @@
+#include "io/TakeFileSink.hpp"
+
+#include <algorithm>
+#include <utility>
+
+namespace magda::engine {
+
+TakeFileSink::TakeFileSink(juce::File directory, juce::String baseName, AudioFileSpec spec,
+                           RenderContext context)
+    : directory_(std::move(directory)),
+      baseName_(std::move(baseName)),
+      spec_(spec),
+      context_(context) {
+    directory_.createDirectory();
+}
+
+bool TakeFileSink::markPassEnd(std::int64_t takeSample) {
+    const auto write = boundaryWrite_.load(std::memory_order_relaxed);
+    const auto read = boundaryRead_.load(std::memory_order_acquire);
+
+    if (write - read >= kBoundaryCapacity)
+        return false;
+
+    boundaries_[static_cast<std::size_t>(write % kBoundaryCapacity)] = takeSample;
+    boundaryWrite_.store(write + 1, std::memory_order_release);
+    return true;
+}
+
+std::optional<std::int64_t> TakeFileSink::peekBoundary() const {
+    const auto read = boundaryRead_.load(std::memory_order_relaxed);
+
+    if (boundaryWrite_.load(std::memory_order_acquire) == read)
+        return {};
+
+    return boundaries_[static_cast<std::size_t>(read % kBoundaryCapacity)];
+}
+
+void TakeFileSink::popBoundary() {
+    boundaryRead_.store(boundaryRead_.load(std::memory_order_relaxed) + 1,
+                        std::memory_order_release);
+}
+
+bool TakeFileSink::writeAudio(juce::dsp::AudioBlock<const float> audio, int numSamples) {
+    auto offset = 0;
+
+    while (offset < numSamples) {
+        // Boundaries first: one already reached ends the pass before anything
+        // more goes into it, and two in a row are a pass that captured nothing.
+        for (auto boundary = peekBoundary(); boundary && *boundary <= written_;
+             boundary = peekBoundary()) {
+            closePass();
+            popBoundary();
+        }
+
+        auto chunk = numSamples - offset;
+        if (const auto boundary = peekBoundary(); boundary)
+            chunk = static_cast<int>(std::min<std::int64_t>(chunk, *boundary - written_));
+
+        if (!writeToPass(audio.getSubBlock(static_cast<std::size_t>(offset),
+                                           static_cast<std::size_t>(chunk)),
+                         chunk))
+            return false;
+
+        offset += chunk;
+        written_ += chunk;
+    }
+
+    return true;
+}
+
+bool TakeFileSink::writeToPass(juce::dsp::AudioBlock<const float> audio, int numSamples) {
+    if (failed_)
+        return false;
+
+    if (pass_ == nullptr) {
+        passFile_ = nextFile();
+        pass_ = AudioFileSink::create(passFile_, spec_, context_);
+
+        if (pass_ == nullptr) {
+            failed_ = true;
+            return false;
+        }
+    }
+
+    pass_->write(audio, numSamples);
+
+    if (pass_->failed()) {
+        failed_ = true;
+        return false;
+    }
+
+    return true;
+}
+
+void TakeFileSink::closePass() {
+    if (pass_ == nullptr)
+        return;
+
+    const auto samples = pass_->samplesWritten();
+    const auto stored = pass_->close();
+
+    pass_.reset();
+
+    if (!stored) {
+        failed_ = true;
+        return;
+    }
+
+    if (samples > 0)
+        passes_.push_back(
+            {passFile_, samples,
+             context_.sampleRate > 0.0 ? static_cast<double>(samples) / context_.sampleRate : 0.0});
+}
+
+void TakeFileSink::finish() {
+    closePass();
+}
+
+juce::File TakeFileSink::nextFile() {
+    for (auto index = nextIndex_;; ++index) {
+        auto file = directory_.getChildFile(baseName_ + "_" + juce::String(index) +
+                                            extensionFor(spec_.format));
+
+        if (!file.exists()) {
+            nextIndex_ = index + 1;
+            return file;
+        }
+    }
+}
+
+}  // namespace magda::engine

--- a/magda/engine/io/TakeFileSink.hpp
+++ b/magda/engine/io/TakeFileSink.hpp
@@ -1,0 +1,118 @@
+#pragma once
+
+#include <juce_core/juce_core.h>
+
+#include <array>
+#include <atomic>
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <span>
+#include <vector>
+
+#include "exec/RenderContext.hpp"
+#include "io/AudioFileSink.hpp"
+#include "io/RecordStream.hpp"
+
+/**
+ * @file TakeFileSink.hpp
+ * @brief Where a take's samples land: one file per loop pass (#2461).
+ *
+ * The record thread's end of a RecordStream. A file is opened at the first
+ * sample of a pass rather than when the take is armed, so a pass that captured
+ * nothing leaves nothing behind, and the next one opens where the audio thread
+ * said the last one ended.
+ *
+ * Boundaries travel on a lane of their own because the queue carries only
+ * audio: where a loop wrapped is something only the audio thread knows, and a
+ * chunk handed over here may straddle one.
+ */
+
+namespace magda::engine {
+
+/** @brief One pass, once it is on disk. */
+struct RecordedPass {
+    juce::File file;
+    std::int64_t samples = 0;
+    double durationSeconds = 0.0;
+};
+
+class TakeFileSink final : public RecordSink {
+  public:
+    /**
+     * @brief A sink writing passes of @p spec into @p directory.
+     *
+     * Files are named `<baseName>_<n>`, taking the first number nothing holds,
+     * so two takes named alike cannot land on one file. @p context gives the
+     * rate and the channel count they are written at, which is the width of the
+     * input the take reads rather than the plan's.
+     */
+    TakeFileSink(juce::File directory, juce::String baseName, AudioFileSpec spec,
+                 RenderContext context);
+
+    /**
+     * @brief End the pass being written at @p takeSample. On the audio thread.
+     *
+     * Counted from the take's first sample, so the record thread can split a
+     * chunk it was handed whole. False when the lane is full, which is a disk
+     * dozens of passes behind and a take already reporting lost samples.
+     */
+    bool markPassEnd(std::int64_t takeSample);
+
+    bool writeAudio(juce::dsp::AudioBlock<const float> audio, int numSamples) override;
+
+    void finish() override;
+
+    /// The passes written, in order. After finish(), off the record thread.
+    std::span<const RecordedPass> passes() const {
+        return passes_;
+    }
+
+    /// Whether a file refused a write or would not open at all.
+    bool failed() const {
+        return failed_;
+    }
+
+  private:
+    /// The boundary the current pass ends on, or nothing.
+    std::optional<std::int64_t> peekBoundary() const;
+    void popBoundary();
+
+    /// Finish whatever file is open and count the pass. A pass with no samples
+    /// has no file and is not one.
+    void closePass();
+
+    /// Write @p numSamples into the open pass, opening a file for it if this is
+    /// its first. False once the take is broken.
+    bool writeToPass(juce::dsp::AudioBlock<const float> audio, int numSamples);
+
+    /// The first name in the take's series that nothing holds.
+    juce::File nextFile();
+
+    juce::File directory_;
+    juce::String baseName_;
+    AudioFileSpec spec_;
+    RenderContext context_;
+
+    std::unique_ptr<AudioFileSink> pass_;
+    juce::File passFile_;
+    int nextIndex_ = 1;
+
+    std::vector<RecordedPass> passes_;
+
+    /// Samples handed to the sink so far, which is what a boundary is counted
+    /// in. Not the same as the samples the take offered, once it has lost any.
+    std::int64_t written_ = 0;
+
+    bool failed_ = false;
+
+    /// Outstanding pass ends. A loop pass is seconds of audio, so a lane this
+    /// deep is a disk that stopped writing rather than one running behind.
+    static constexpr std::size_t kBoundaryCapacity = 64;
+
+    std::array<std::int64_t, kBoundaryCapacity> boundaries_{};
+    std::atomic<std::uint64_t> boundaryWrite_{0};
+    std::atomic<std::uint64_t> boundaryRead_{0};
+};
+
+}  // namespace magda::engine

--- a/magda/engine/io/TakeFileSink.hpp
+++ b/magda/engine/io/TakeFileSink.hpp
@@ -53,9 +53,10 @@ class TakeFileSink final : public RecordSink {
     /**
      * @brief End the pass being written at @p takeSample. On the audio thread.
      *
-     * Counted from the take's first sample, so the record thread can split a
-     * chunk it was handed whole. False when the lane is full, which is a disk
-     * dozens of passes behind and a take already reporting lost samples.
+     * Counted from the take's first sample, and may be ahead of what has been
+     * written: the boundary is where the pass ends, not a signal that it has.
+     * False when the lane is full, which is a disk hundreds of passes behind,
+     * and what the caller does with that is say so on the finished take.
      */
     bool markPassEnd(std::int64_t takeSample);
 
@@ -106,9 +107,11 @@ class TakeFileSink final : public RecordSink {
 
     bool failed_ = false;
 
-    /// Outstanding pass ends. A loop pass is seconds of audio, so a lane this
-    /// deep is a disk that stopped writing rather than one running behind.
-    static constexpr std::size_t kBoundaryCapacity = 64;
+    /// Pass ends asked for and not reached yet. The counterpart of the queue's
+    /// own capacity: that bounds how far behind the disk may fall in samples,
+    /// and this bounds it in passes. What will not fit is refused rather than
+    /// dropped, so a take can say its passes ran together (#2461).
+    static constexpr std::size_t kBoundaryCapacity = 256;
 
     std::array<std::int64_t, kBoundaryCapacity> boundaries_{};
     std::atomic<std::uint64_t> boundaryWrite_{0};

--- a/magda/engine/io/TakeFileSink.hpp
+++ b/magda/engine/io/TakeFileSink.hpp
@@ -26,6 +26,11 @@
  * Boundaries travel on a lane of their own because the queue carries only
  * audio: where a loop wrapped is something only the audio thread knows, and a
  * chunk handed over here may straddle one.
+ *
+ * What the lane relies on is that a boundary is named before the audio past it
+ * is queued (io/TakeRecorder.hpp). That is what lets this split on a position
+ * rather than guess from one: nothing can be written past a boundary that has
+ * not arrived yet, so a pass holds the same samples whenever it is drained.
  */
 
 namespace magda::engine {

--- a/magda/engine/io/TakeRecorder.cpp
+++ b/magda/engine/io/TakeRecorder.cpp
@@ -1,0 +1,238 @@
+#include "io/TakeRecorder.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <span>
+#include <utility>
+
+namespace magda::engine {
+
+namespace {
+
+/// A wrap anchors the cursor exactly on the loop start, so anything further off
+/// than this is a locate rather than a pass boundary.
+constexpr double kLoopStartTolerance = 1.0e-6;
+
+/// How short the final pass has to be to count as a stop rather than a take.
+constexpr double kFullPassFraction = 0.95;
+
+int takeChannels(const TakeRecorderSettings& settings) {
+    return std::max<int>(1, static_cast<int>(settings.channels.size()));
+}
+
+RenderContext fileContext(const RenderContext& context, const TakeRecorderSettings& settings) {
+    return {.sampleRate = context.sampleRate,
+            .maxBlockSize = context.maxBlockSize,
+            .numChannels = takeChannels(settings)};
+}
+
+RecordStreamSettings queueFor(const TakeRecorderSettings& settings) {
+    auto queue = settings.stream;
+    queue.numChannels = takeChannels(settings);
+    return queue;
+}
+
+bool atLoopStart(const BlockInfo& block, const LoopRange& loop) {
+    return loop.valid() && std::abs(block.beats.start - loop.startBeat) <= kLoopStartTolerance;
+}
+
+/// The last full pass, stepping back one if the final pass was cut short. Only
+/// the last one can be, which is what makes the rule this simple.
+std::size_t activeTake(std::span<const RecordedPass> passes) {
+    auto longest = 0.0;
+    for (const auto& pass : passes)
+        longest = std::max(longest, pass.durationSeconds);
+
+    const auto last = passes.size() - 1;
+    if (passes.size() > 1 && passes[last].durationSeconds < longest * kFullPassFraction)
+        return last - 1;
+
+    return last;
+}
+
+}  // namespace
+
+TakeRecorder::TakeRecorder(const LiveInputFeed& feed, const RenderContext& context,
+                           TakeRecorderSettings settings)
+    : settings_(std::move(settings)),
+      input_(feed, settings_.channels, settings_.latencySamples),
+      sink_(settings_.directory, settings_.name, settings_.file, fileContext(context, settings_)),
+      stream_(sink_, queueFor(settings_)) {
+    scratch_.setSize(takeChannels(settings_), std::max(1, context.maxBlockSize), false, true,
+                     false);
+
+    if (settings_.latencySamples < 0)
+        pad_.setSize(takeChannels(settings_), -settings_.latencySamples, false, true, false);
+
+    latencySeconds_ = context.sampleRate > 0.0
+                          ? static_cast<double>(settings_.latencySamples) / context.sampleRate
+                          : 0.0;
+}
+
+void TakeRecorder::capture(const BlockInfo& block, bool countingIn, const LoopRange& loop) {
+    if (state_ == State::stopped)
+        return;
+
+    // A count-in is time before the play position and a stop is where a take
+    // ends, so neither is part of one.
+    if (!block.playing || countingIn) {
+        if (state_ == State::rolling)
+            stop();
+
+        return;
+    }
+
+    if (state_ == State::waiting) {
+        start(block, loop);
+    } else if (!block.continuous) {
+        if (!atLoopStart(block, loop)) {
+            stop();
+            return;
+        }
+
+        openPass(loop);
+    }
+
+    write(block);
+
+    // What a take holds is what happened, and what happened at the end of this
+    // block arrives a latency later: the tail runs on by exactly as much as the
+    // head gave up.
+    lastBeat_ = block.beatAtTime(block.seconds.end - latencySeconds_);
+}
+
+void TakeRecorder::start(const BlockInfo& block, const LoopRange& loop) {
+    state_ = State::rolling;
+    rolling_.store(true, std::memory_order_relaxed);
+
+    startBeat_ = block.beats.start;
+    startedAtLoopStart_ = atLoopStart(block, loop);
+    headDrop_ = std::max(0, settings_.latencySamples);
+
+    // A negative latency asks for samples from before the take was armed.
+    // Silence stands in for them, which is what leaves the first real sample
+    // where it happened.
+    if (const auto padded = pad_.getNumSamples(); padded > 0) {
+        stream_.writeAudio(juce::dsp::AudioBlock<const float>(std::as_const(pad_)), padded);
+        written_ += padded;
+        captured_.store(written_, std::memory_order_relaxed);
+    }
+}
+
+void TakeRecorder::openPass(const LoopRange& loop) {
+    wrapped_ = true;
+    loopStartBeat_ = loop.startBeat;
+    loopEndBeat_ = loop.endBeat;
+
+    // The samples the wrap belongs to are still a latency away. A negative one
+    // puts that boundary in the past, where the only thing left is to end the
+    // pass here and be late by the adjustment.
+    pendingSplit_ = std::max(0, settings_.latencySamples);
+}
+
+void TakeRecorder::stop() {
+    state_ = State::stopped;
+    rolling_.store(false, std::memory_order_relaxed);
+}
+
+void TakeRecorder::write(const BlockInfo& block) {
+    const auto numSamples = std::min(block.numSamples, scratch_.getNumSamples());
+    if (numSamples <= 0)
+        return;
+
+    input_.render(block, juce::dsp::AudioBlock<float>(scratch_).getSubBlock(
+                             0, static_cast<std::size_t>(numSamples)));
+
+    const auto captured = juce::dsp::AudioBlock<const float>(std::as_const(scratch_));
+
+    auto offset = 0;
+    if (headDrop_ > 0) {
+        const auto dropped = std::min(headDrop_, numSamples);
+        headDrop_ -= dropped;
+        offset += dropped;
+    }
+
+    for (;;) {
+        if (pendingSplit_ == 0) {
+            sink_.markPassEnd(written_);
+            pendingSplit_ = -1;
+        }
+
+        if (offset >= numSamples)
+            break;
+
+        auto chunk = numSamples - offset;
+        if (pendingSplit_ > 0)
+            chunk = std::min(chunk, pendingSplit_);
+
+        stream_.writeAudio(
+            captured.getSubBlock(static_cast<std::size_t>(offset), static_cast<std::size_t>(chunk)),
+            chunk);
+        written_ += chunk;
+
+        if (pendingSplit_ > 0)
+            pendingSplit_ -= chunk;
+
+        offset += chunk;
+    }
+
+    captured_.store(written_, std::memory_order_relaxed);
+}
+
+RecordedTake TakeRecorder::finish() {
+    if (finished_)
+        return result_;
+
+    finished_ = true;
+    stop();
+    stream_.finish();
+
+    result_.samplesLost = stream_.samplesLost();
+    result_.failed = stream_.failed() || sink_.failed();
+
+    auto passes = sink_.passes();
+
+    // A first pass that did not begin on the loop start is a lead-in: with no
+    // offset of its own it cannot share the clip start the others do, and a
+    // wrap having happened at all is what makes it a lead-in rather than the
+    // whole recording.
+    if (passes.size() > 1 && !startedAtLoopStart_) {
+        passes.front().file.deleteFile();
+        passes = passes.subspan(1);
+    }
+
+    if (!passes.empty()) {
+        const auto active = activeTake(passes);
+        result_.file = passes[active].file;
+
+        // One pass is an ordinary clip, and the model keeps `takes` empty for
+        // one of those: they are loop-record alternatives or nothing.
+        if (passes.size() > 1) {
+            for (const auto& pass : passes)
+                result_.clip.takes.push_back(AudioTake{
+                    .filePath = pass.file.getFullPathName(),
+                    .durationSeconds = pass.durationSeconds,
+                });
+
+            result_.clip.currentTakeIndex = static_cast<int>(active);
+        }
+    }
+
+    placeClip(result_);
+    return result_;
+}
+
+void TakeRecorder::placeClip(RecordedTake& take) const {
+    // Loop-aligned the moment a wrap happened: every pass that survived covers
+    // the loop, so that is where the clip goes and how long it is.
+    if (wrapped_) {
+        take.startBeat = loopStartBeat_;
+        take.lengthBeats = std::max(0.0, loopEndBeat_ - loopStartBeat_);
+        return;
+    }
+
+    take.startBeat = startBeat_;
+    take.lengthBeats = std::max(0.0, lastBeat_ - startBeat_);
+}
+
+}  // namespace magda::engine

--- a/magda/engine/io/TakeRecorder.cpp
+++ b/magda/engine/io/TakeRecorder.cpp
@@ -32,6 +32,16 @@ RecordStreamSettings queueFor(const TakeRecorderSettings& settings) {
     return queue;
 }
 
+/// The beats @p numSamples of @p block cover. A block is short enough that the
+/// tempo across it is a straight line, which is the same tolerance BlockInfo's
+/// own conversions take on a block with no map.
+double beatsFor(const BlockInfo& block, int numSamples) {
+    if (block.numSamples <= 0)
+        return 0.0;
+
+    return block.beats.length() * (static_cast<double>(numSamples) / block.numSamples);
+}
+
 bool atLoopStart(const BlockInfo& block, const LoopRange& loop) {
     return loop.valid() && std::abs(block.beats.start - loop.startBeat) <= kLoopStartTolerance;
 }
@@ -63,10 +73,6 @@ TakeRecorder::TakeRecorder(const LiveInputFeed& feed, const RenderContext& conte
 
     if (settings_.latencySamples < 0)
         pad_.setSize(takeChannels(settings_), -settings_.latencySamples, false, true, false);
-
-    latencySeconds_ = context.sampleRate > 0.0
-                          ? static_cast<double>(settings_.latencySamples) / context.sampleRate
-                          : 0.0;
 }
 
 void TakeRecorder::capture(const BlockInfo& block, bool countingIn, const LoopRange& loop) {
@@ -95,10 +101,10 @@ void TakeRecorder::capture(const BlockInfo& block, bool countingIn, const LoopRa
 
     write(block);
 
-    // What a take holds is what happened, and what happened at the end of this
-    // block arrives a latency later: the tail runs on by exactly as much as the
-    // head gave up.
-    lastBeat_ = block.beatAtTime(block.seconds.end - latencySeconds_);
+    // Timeline the take has covered, which is what a pass boundary is counted
+    // in. Not the samples written: those are the same stretch read a latency
+    // later, and the head correction is what puts the two back together.
+    arrivals_ += block.numSamples;
 }
 
 void TakeRecorder::start(const BlockInfo& block, const LoopRange& loop) {
@@ -115,19 +121,25 @@ void TakeRecorder::start(const BlockInfo& block, const LoopRange& loop) {
     if (const auto padded = pad_.getNumSamples(); padded > 0) {
         stream_.writeAudio(juce::dsp::AudioBlock<const float>(std::as_const(pad_)), padded);
         written_ += padded;
+        capturedBeats_ += beatsFor(block, padded);
         captured_.store(written_, std::memory_order_relaxed);
     }
 }
 
 void TakeRecorder::openPass(const LoopRange& loop) {
-    wrapped_ = true;
     loopStartBeat_ = loop.startBeat;
     loopEndBeat_ = loop.endBeat;
 
-    // The samples the wrap belongs to are still a latency away. A negative one
-    // puts that boundary in the past, where the only thing left is to end the
-    // pass here and be late by the adjustment.
-    pendingSplit_ = std::max(0, settings_.latencySamples);
+    // Where the pass ends, in the take's own samples: the timeline it has
+    // covered so far. The latency does not enter it -- the head correction
+    // already put sample i of the take at i samples past its start -- and the
+    // boundary is handed over now rather than counted down to, so a loop
+    // shorter than one cannot overtake the last one still pending.
+    if (firstBoundary_ < 0)
+        firstBoundary_ = arrivals_;
+
+    if (!sink_.markPassEnd(arrivals_))
+        ++boundariesLost_;
 }
 
 void TakeRecorder::stop() {
@@ -152,30 +164,15 @@ void TakeRecorder::write(const BlockInfo& block) {
         offset += dropped;
     }
 
-    for (;;) {
-        if (pendingSplit_ == 0) {
-            sink_.markPassEnd(written_);
-            pendingSplit_ = -1;
-        }
+    const auto kept = numSamples - offset;
+    if (kept <= 0)
+        return;
 
-        if (offset >= numSamples)
-            break;
-
-        auto chunk = numSamples - offset;
-        if (pendingSplit_ > 0)
-            chunk = std::min(chunk, pendingSplit_);
-
-        stream_.writeAudio(
-            captured.getSubBlock(static_cast<std::size_t>(offset), static_cast<std::size_t>(chunk)),
-            chunk);
-        written_ += chunk;
-
-        if (pendingSplit_ > 0)
-            pendingSplit_ -= chunk;
-
-        offset += chunk;
-    }
-
+    stream_.writeAudio(
+        captured.getSubBlock(static_cast<std::size_t>(offset), static_cast<std::size_t>(kept)),
+        kept);
+    written_ += kept;
+    capturedBeats_ += beatsFor(block, kept);
     captured_.store(written_, std::memory_order_relaxed);
 }
 
@@ -188,6 +185,7 @@ RecordedTake TakeRecorder::finish() {
     stream_.finish();
 
     result_.samplesLost = stream_.samplesLost();
+    result_.passesLost = boundariesLost_;
     result_.failed = stream_.failed() || sink_.failed();
 
     auto passes = sink_.passes();
@@ -223,16 +221,18 @@ RecordedTake TakeRecorder::finish() {
 }
 
 void TakeRecorder::placeClip(RecordedTake& take) const {
-    // Loop-aligned the moment a wrap happened: every pass that survived covers
-    // the loop, so that is where the clip goes and how long it is.
-    if (wrapped_) {
+    // Loop-aligned once a pass boundary has actually been reached, rather than
+    // once a wrap has been seen: a take stopped between the two holds only the
+    // stretch it began on, and putting that at the loop start would play it
+    // somewhere it was never recorded.
+    if (firstBoundary_ >= 0 && written_ > firstBoundary_) {
         take.startBeat = loopStartBeat_;
         take.lengthBeats = std::max(0.0, loopEndBeat_ - loopStartBeat_);
         return;
     }
 
     take.startBeat = startBeat_;
-    take.lengthBeats = std::max(0.0, lastBeat_ - startBeat_);
+    take.lengthBeats = std::max(0.0, capturedBeats_);
 }
 
 }  // namespace magda::engine

--- a/magda/engine/io/TakeRecorder.cpp
+++ b/magda/engine/io/TakeRecorder.cpp
@@ -36,15 +36,27 @@ bool atLoopStart(const BlockInfo& block, const LoopRange& loop) {
     return loop.valid() && std::abs(block.beats.start - loop.startBeat) <= kLoopStartTolerance;
 }
 
-/// The last full pass, stepping back one if the final pass was cut short. Only
-/// the last one can be, which is what makes the rule this simple.
-std::size_t activeTake(std::span<const RecordedPass> passes) {
-    auto longest = 0.0;
-    for (const auto& pass : passes)
-        longest = std::max(longest, pass.durationSeconds);
+/**
+ * @brief The last full pass, stepping back one if the final pass was cut short.
+ *
+ * Only the last pass can be cut short, and only the first can run long: a
+ * negative adjustment pads its head, and @p headPadding is that padding when
+ * the take's own first pass is still here to carry it. Discounted rather than
+ * measured, so a pass is judged against what was played rather than against a
+ * correction at the top of the file.
+ */
+std::size_t activeTake(std::span<const RecordedPass> passes, std::int64_t headPadding) {
+    const auto played = [&](std::size_t pass) {
+        return passes[pass].samples - (pass == 0 ? headPadding : 0);
+    };
+
+    std::int64_t longest = 0;
+    for (std::size_t pass = 0; pass < passes.size(); ++pass)
+        longest = std::max(longest, played(pass));
 
     const auto last = passes.size() - 1;
-    if (passes.size() > 1 && passes[last].durationSeconds < longest * kFullPassFraction)
+    if (passes.size() > 1 &&
+        static_cast<double>(played(last)) < static_cast<double>(longest) * kFullPassFraction)
         return last - 1;
 
     return last;
@@ -193,13 +205,18 @@ RecordedTake TakeRecorder::finish() {
     // offset of its own it cannot share the clip start the others do, and a
     // wrap having happened at all is what makes it a lead-in rather than the
     // whole recording.
+    auto headPadding = static_cast<std::int64_t>(pad_.getNumSamples());
+
     if (passes.size() > 1 && !startedAtLoopStart_) {
         passes.front().file.deleteFile();
         passes = passes.subspan(1);
+
+        // The padding went with the pass it was at the head of.
+        headPadding = 0;
     }
 
     if (!passes.empty()) {
-        const auto active = activeTake(passes);
+        const auto active = activeTake(passes, headPadding);
         result_.file = passes[active].file;
 
         // One pass is an ordinary clip, and the model keeps `takes` empty for

--- a/magda/engine/io/TakeRecorder.cpp
+++ b/magda/engine/io/TakeRecorder.cpp
@@ -89,12 +89,6 @@ void TakeRecorder::capture(const BlockInfo& block, bool countingIn, const LoopRa
         openPass(loop);
     }
 
-    // A negative adjustment queues a pass's last samples before the wrap that
-    // ends it is ever seen, so the loop end is read off the block instead. A
-    // positive one never needs it: there the wrap comes first.
-    if (settings_.latencySamples < 0)
-        markLoopEndAhead(block, loop);
-
     write(block);
 
     // Timeline the take has covered, which is what a pass boundary is counted
@@ -124,40 +118,16 @@ void TakeRecorder::start(const BlockInfo& block, const LoopRange& loop) {
 }
 
 void TakeRecorder::openPass(const LoopRange& loop) {
-    // The wrap is where the pass ended, unless the block ahead of it already
-    // said so: one loop end is one boundary, named once.
-    if (!cycleBoundaryMarked_)
-        markBoundary(arrivals_, loop);
-
-    // The cycle this wrap opens has its own end to find.
-    cycleBoundaryMarked_ = false;
-}
-
-void TakeRecorder::markLoopEndAhead(const BlockInfo& block, const LoopRange& loop) {
-    if (cycleBoundaryMarked_ || !loop.valid())
-        return;
-
-    // Where the loop ends, and when the samples belonging to it are delivered:
-    // a latency earlier, which is what makes this block the last chance to name
-    // the boundary before its audio is queued.
-    const auto untilEnd = std::llround(block.offsetForBeat(loop.endBeat));
-    const auto delivered = untilEnd + settings_.latencySamples;
-
-    if (delivered < 0 || delivered >= block.numSamples)
-        return;
-
-    markBoundary(arrivals_ + untilEnd, loop);
-}
-
-void TakeRecorder::markBoundary(std::int64_t index, const LoopRange& loop) {
     loopStartBeat_ = loop.startBeat;
     loopEndBeat_ = loop.endBeat;
-    cycleBoundaryMarked_ = true;
 
-    // Never behind what is already queued. A boundary the writer has passed
+    // Never behind what is already queued. A boundary the writer has gone past
     // could only be honoured wherever it happened to have got to, which is a
-    // pass whose length depends on when the disk ran.
-    const auto boundary = std::max(index, written_);
+    // pass whose length depends on when the disk ran. The clamp is what a
+    // negative adjustment costs: it queues a pass's last samples before the
+    // wrap, so its first pass runs that much long and the rest of the grid
+    // sits that much late.
+    const auto boundary = std::max(arrivals_, written_);
 
     if (firstBoundary_ < 0)
         firstBoundary_ = boundary;

--- a/magda/engine/io/TakeRecorder.cpp
+++ b/magda/engine/io/TakeRecorder.cpp
@@ -32,16 +32,6 @@ RecordStreamSettings queueFor(const TakeRecorderSettings& settings) {
     return queue;
 }
 
-/// The beats @p numSamples of @p block cover. A block is short enough that the
-/// tempo across it is a straight line, which is the same tolerance BlockInfo's
-/// own conversions take on a block with no map.
-double beatsFor(const BlockInfo& block, int numSamples) {
-    if (block.numSamples <= 0)
-        return 0.0;
-
-    return block.beats.length() * (static_cast<double>(numSamples) / block.numSamples);
-}
-
 bool atLoopStart(const BlockInfo& block, const LoopRange& loop) {
     return loop.valid() && std::abs(block.beats.start - loop.startBeat) <= kLoopStartTolerance;
 }
@@ -99,6 +89,12 @@ void TakeRecorder::capture(const BlockInfo& block, bool countingIn, const LoopRa
         openPass(loop);
     }
 
+    // A negative adjustment queues a pass's last samples before the wrap that
+    // ends it is ever seen, so the loop end is read off the block instead. A
+    // positive one never needs it: there the wrap comes first.
+    if (settings_.latencySamples < 0)
+        markLoopEndAhead(block, loop);
+
     write(block);
 
     // Timeline the take has covered, which is what a pass boundary is counted
@@ -112,6 +108,8 @@ void TakeRecorder::start(const BlockInfo& block, const LoopRange& loop) {
     rolling_.store(true, std::memory_order_relaxed);
 
     startBeat_ = block.beats.start;
+    startSeconds_ = block.seconds.start;
+    endBeat_ = startBeat_;
     startedAtLoopStart_ = atLoopStart(block, loop);
     headDrop_ = std::max(0, settings_.latencySamples);
 
@@ -121,24 +119,50 @@ void TakeRecorder::start(const BlockInfo& block, const LoopRange& loop) {
     if (const auto padded = pad_.getNumSamples(); padded > 0) {
         stream_.writeAudio(juce::dsp::AudioBlock<const float>(std::as_const(pad_)), padded);
         written_ += padded;
-        capturedBeats_ += beatsFor(block, padded);
         captured_.store(written_, std::memory_order_relaxed);
     }
 }
 
 void TakeRecorder::openPass(const LoopRange& loop) {
+    // The wrap is where the pass ended, unless the block ahead of it already
+    // said so: one loop end is one boundary, named once.
+    if (!cycleBoundaryMarked_)
+        markBoundary(arrivals_, loop);
+
+    // The cycle this wrap opens has its own end to find.
+    cycleBoundaryMarked_ = false;
+}
+
+void TakeRecorder::markLoopEndAhead(const BlockInfo& block, const LoopRange& loop) {
+    if (cycleBoundaryMarked_ || !loop.valid())
+        return;
+
+    // Where the loop ends, and when the samples belonging to it are delivered:
+    // a latency earlier, which is what makes this block the last chance to name
+    // the boundary before its audio is queued.
+    const auto untilEnd = std::llround(block.offsetForBeat(loop.endBeat));
+    const auto delivered = untilEnd + settings_.latencySamples;
+
+    if (delivered < 0 || delivered >= block.numSamples)
+        return;
+
+    markBoundary(arrivals_ + untilEnd, loop);
+}
+
+void TakeRecorder::markBoundary(std::int64_t index, const LoopRange& loop) {
     loopStartBeat_ = loop.startBeat;
     loopEndBeat_ = loop.endBeat;
+    cycleBoundaryMarked_ = true;
 
-    // Where the pass ends, in the take's own samples: the timeline it has
-    // covered so far. The latency does not enter it -- the head correction
-    // already put sample i of the take at i samples past its start -- and the
-    // boundary is handed over now rather than counted down to, so a loop
-    // shorter than one cannot overtake the last one still pending.
+    // Never behind what is already queued. A boundary the writer has passed
+    // could only be honoured wherever it happened to have got to, which is a
+    // pass whose length depends on when the disk ran.
+    const auto boundary = std::max(index, written_);
+
     if (firstBoundary_ < 0)
-        firstBoundary_ = arrivals_;
+        firstBoundary_ = boundary;
 
-    if (!sink_.markPassEnd(arrivals_))
+    if (!sink_.markPassEnd(boundary))
         ++boundariesLost_;
 }
 
@@ -172,8 +196,13 @@ void TakeRecorder::write(const BlockInfo& block) {
         captured.getSubBlock(static_cast<std::size_t>(offset), static_cast<std::size_t>(kept)),
         kept);
     written_ += kept;
-    capturedBeats_ += beatsFor(block, kept);
     captured_.store(written_, std::memory_order_relaxed);
+
+    // Where the take now ends, asked of the tempo map at the moment its own
+    // audio reaches: the samples were placed a latency earlier than they
+    // arrived, and across a tempo change the two are not the same length.
+    if (const auto rate = block.rate(); rate > 0.0)
+        endBeat_ = block.beatAtTime(startSeconds_ + (static_cast<double>(written_) / rate));
 }
 
 RecordedTake TakeRecorder::finish() {
@@ -232,7 +261,7 @@ void TakeRecorder::placeClip(RecordedTake& take) const {
     }
 
     take.startBeat = startBeat_;
-    take.lengthBeats = std::max(0.0, capturedBeats_);
+    take.lengthBeats = std::max(0.0, endBeat_ - startBeat_);
 }
 
 }  // namespace magda::engine

--- a/magda/engine/io/TakeRecorder.hpp
+++ b/magda/engine/io/TakeRecorder.hpp
@@ -39,10 +39,18 @@
  * - how much of it reached a file, which is the writer's and nobody else's.
  *
  * The contract with TakeFileSink follows from that. A pass end is named as a
- * take index, and always before the audio past it is queued -- by the wrap that
- * ended the pass, or, where a negative adjustment queues that audio first, by
- * the block that saw the loop end coming. So the writer never reconstructs a
- * boundary and a pass holds the same samples however often the disk is drained.
+ * take index, by the wrap that ended the pass, and never behind what has already
+ * been queued. So the writer splits on a position it cannot have passed, and a
+ * pass holds the same samples however often the disk is drained.
+ *
+ * A boundary is never named for a wrap that has not happened. It could be:
+ * a negative adjustment queues a pass's last samples before the transport
+ * reaches the loop end, so the end is predictable a block or two ahead. But a
+ * prediction can be falsified -- the loop can be switched off in between -- and
+ * a boundary handed over cannot be withdrawn, which would cut continuous audio
+ * into takes of a loop that never came round. The clamp above is what is paid
+ * instead: with a negative adjustment the first pass runs long by it, and the
+ * passes after it sit that much late against the loop.
  *
  * Nothing here makes a model object on the audio thread and no clip exists
  * until the recording ends: @ref TakeRecorder::finish is where a take becomes
@@ -177,16 +185,9 @@ class TakeRecorder {
     /// The first block of the take: where it starts, and the head correction.
     void start(const BlockInfo& block, const LoopRange& loop);
 
-    /// A wrap: where the pass ended, unless the block ahead of it said so.
+    /// A wrap: where the pass ended, handed to the sink. The one place a
+    /// boundary is named, so the rule above it holds everywhere.
     void openPass(const LoopRange& loop);
-
-    /// The loop end read off a block before its audio has been queued, which
-    /// is the only way a negative adjustment can name a boundary in time.
-    void markLoopEndAhead(const BlockInfo& block, const LoopRange& loop);
-
-    /// Hand the sink a pass end. The one place that does, so the rule above it
-    /// holds everywhere: named before the audio past it is queued.
-    void markBoundary(std::int64_t index, const LoopRange& loop);
 
     void stop();
 
@@ -223,10 +224,6 @@ class TakeRecorder {
     /// The first pass end asked for, or -1. What says whether any pass ever
     /// began where the loop does.
     std::int64_t firstBoundary_ = -1;
-
-    /// Whether this cycle's pass end has been named. One loop end is one
-    /// boundary, whether the wrap or the block ahead of it found it.
-    bool cycleBoundaryMarked_ = false;
 
     std::int64_t boundariesLost_ = 0;
 

--- a/magda/engine/io/TakeRecorder.hpp
+++ b/magda/engine/io/TakeRecorder.hpp
@@ -60,6 +60,11 @@ struct RecordedTake {
     /// performance, and the boundaries between passes moved by as much.
     std::int64_t samplesLost = 0;
 
+    /// Pass ends the write path could not be told about, which is two loop
+    /// passes run together in one file. Above zero and the takes below are not
+    /// one pass each.
+    std::int64_t passesLost = 0;
+
     /// Whether a file refused a write or could not be opened at all.
     bool failed = false;
 
@@ -159,14 +164,14 @@ class TakeRecorder {
     /// The first block of the take: where it starts, and the head correction.
     void start(const BlockInfo& block, const LoopRange& loop);
 
-    /// A wrap: the pass ends a latency later, since that is when the samples
-    /// the wrap belongs to arrive.
+    /// A wrap: where the pass ends, handed to the sink as a position rather
+    /// than counted down to.
     void openPass(const LoopRange& loop);
 
     void stop();
 
-    /// This block's input, into the queue, split at a pass end if one falls
-    /// inside it.
+    /// This block's input, into the queue. Where a pass ends inside it is the
+    /// sink's to act on, since only the sink knows what reached the disk.
     void write(const BlockInfo& block);
 
     /// Where the take is, once there is nothing more to add to it.
@@ -189,21 +194,29 @@ class TakeRecorder {
     /// Arrivals still to drop before the take's first sample.
     int headDrop_ = 0;
 
-    /// Samples still to write before the current pass ends, or -1 for none.
-    int pendingSplit_ = -1;
-
+    /// Samples written to the queue, and the timeline the take has covered.
+    /// The second is the first read a latency earlier, which is why a pass
+    /// boundary is counted in it.
     std::int64_t written_ = 0;
+    std::int64_t arrivals_ = 0;
+
+    /// The first pass end asked for, or -1. What says whether any pass ever
+    /// began where the loop does.
+    std::int64_t firstBoundary_ = -1;
+
+    std::int64_t boundariesLost_ = 0;
 
     double startBeat_ = 0.0;
-    double lastBeat_ = 0.0;
-    double latencySeconds_ = 0.0;
+
+    /// Beats the take covers, accumulated from what each block wrote. Not
+    /// derived from where the cursor ended: a wrap takes that back.
+    double capturedBeats_ = 0.0;
 
     /// Whether the take began on the loop start, which is what says its first
     /// pass is a pass rather than a lead-in.
     bool startedAtLoopStart_ = false;
 
-    /// The loop a wrap was seen against, and whether one ever was.
-    bool wrapped_ = false;
+    /// The loop the last wrap was seen against.
     double loopStartBeat_ = 0.0;
     double loopEndBeat_ = 0.0;
 

--- a/magda/engine/io/TakeRecorder.hpp
+++ b/magda/engine/io/TakeRecorder.hpp
@@ -31,6 +31,19 @@
  * - The active take is the last full pass, since only the last one can be cut
  *   off mid-way.
  *
+ * Three positions are kept apart on purpose, because latency, tempo and a disk
+ * that falls behind separate them:
+ *
+ * - when a sample arrived, which is what the callback counts;
+ * - where it belongs, which is `arrival - latency` and the take's own index;
+ * - how much of it reached a file, which is the writer's and nobody else's.
+ *
+ * The contract with TakeFileSink follows from that. A pass end is named as a
+ * take index, and always before the audio past it is queued -- by the wrap that
+ * ended the pass, or, where a negative adjustment queues that audio first, by
+ * the block that saw the loop end coming. So the writer never reconstructs a
+ * boundary and a pass holds the same samples however often the disk is drained.
+ *
  * Nothing here makes a model object on the audio thread and no clip exists
  * until the recording ends: @ref TakeRecorder::finish is where a take becomes
  * one, on the thread that asked for it.
@@ -164,9 +177,16 @@ class TakeRecorder {
     /// The first block of the take: where it starts, and the head correction.
     void start(const BlockInfo& block, const LoopRange& loop);
 
-    /// A wrap: where the pass ends, handed to the sink as a position rather
-    /// than counted down to.
+    /// A wrap: where the pass ended, unless the block ahead of it said so.
     void openPass(const LoopRange& loop);
+
+    /// The loop end read off a block before its audio has been queued, which
+    /// is the only way a negative adjustment can name a boundary in time.
+    void markLoopEndAhead(const BlockInfo& block, const LoopRange& loop);
+
+    /// Hand the sink a pass end. The one place that does, so the rule above it
+    /// holds everywhere: named before the audio past it is queued.
+    void markBoundary(std::int64_t index, const LoopRange& loop);
 
     void stop();
 
@@ -204,13 +224,18 @@ class TakeRecorder {
     /// began where the loop does.
     std::int64_t firstBoundary_ = -1;
 
+    /// Whether this cycle's pass end has been named. One loop end is one
+    /// boundary, whether the wrap or the block ahead of it found it.
+    bool cycleBoundaryMarked_ = false;
+
     std::int64_t boundariesLost_ = 0;
 
+    /// Where the take begins, and where its audio reaches. The end is asked of
+    /// the tempo map rather than accumulated, so a tempo change inside a take
+    /// moves it by what actually happened.
     double startBeat_ = 0.0;
-
-    /// Beats the take covers, accumulated from what each block wrote. Not
-    /// derived from where the cursor ended: a wrap takes that back.
-    double capturedBeats_ = 0.0;
+    double startSeconds_ = 0.0;
+    double endBeat_ = 0.0;
 
     /// Whether the take began on the loop start, which is what says its first
     /// pass is a pass rather than a lead-in.

--- a/magda/engine/io/TakeRecorder.hpp
+++ b/magda/engine/io/TakeRecorder.hpp
@@ -74,8 +74,8 @@ struct RecordedTake {
     std::int64_t samplesLost = 0;
 
     /// Pass ends the write path could not be told about, which is two loop
-    /// passes run together in one file. Above zero and the takes below are not
-    /// one pass each.
+    /// passes run together in one file. Above zero and `clip.takes` is not one
+    /// pass each.
     std::int64_t passesLost = 0;
 
     /// Whether a file refused a write or could not be opened at all.

--- a/magda/engine/io/TakeRecorder.hpp
+++ b/magda/engine/io/TakeRecorder.hpp
@@ -1,0 +1,261 @@
+#pragma once
+
+#include <juce_audio_basics/juce_audio_basics.h>
+
+#include <atomic>
+#include <cstdint>
+#include <farbot/RealtimeObject.hpp>
+#include <memory>
+#include <vector>
+
+#include "core/ClipInfo.hpp"
+#include "exec/RenderContext.hpp"
+#include "io/LiveInput.hpp"
+#include "io/RecordStream.hpp"
+#include "io/TakeFileSink.hpp"
+#include "transport/TransportState.hpp"
+
+/**
+ * @file TakeRecorder.hpp
+ * @brief An arrangement audio take, from armed to clip (#2461).
+ *
+ * One track's recording: the input slice 1 delivers, through the queue slice 2
+ * drains, into the files a clip is made of. The rules it keeps are the model's
+ * rather than any engine's, which is why they live here:
+ *
+ * - A take holds what happened, so the head is corrected by the input's
+ *   declared latency rather than the clip being moved to meet it.
+ * - Loop recording is loop-aligned: one file per pass, all sharing the clip
+ *   start, and a pass that cannot share it is not a take (AudioTake has no
+ *   offset of its own).
+ * - The active take is the last full pass, since only the last one can be cut
+ *   off mid-way.
+ *
+ * Nothing here makes a model object on the audio thread and no clip exists
+ * until the recording ends: @ref TakeRecorder::finish is where a take becomes
+ * one, on the thread that asked for it.
+ */
+
+namespace magda::engine {
+
+/** @brief What a finished take became, and what it cost. */
+struct RecordedTake {
+    /// Where the clip goes, and how much of the timeline it covers.
+    double startBeat = 0.0;
+    double lengthBeats = 0.0;
+
+    /// What the clip plays. Empty for a take that captured nothing.
+    juce::File file;
+
+    /**
+     * @brief The passes and the one that plays.
+     *
+     * `takes` is empty for a single pass, which is what an ordinary clip is;
+     * `events` is empty either way, because an event names a SourceId and the
+     * pool that hands those out is the host's.
+     */
+    AudioClipModel clip;
+
+    /// Samples the disk could not keep up with. Above zero is a hole in the
+    /// performance, and the boundaries between passes moved by as much.
+    std::int64_t samplesLost = 0;
+
+    /// Whether a file refused a write or could not be opened at all.
+    bool failed = false;
+
+    bool empty() const {
+        return file == juce::File();
+    }
+};
+
+/** @brief What a take reads, and where it writes. */
+struct TakeRecorderSettings {
+    /// Channels of the device's input the take holds, in file order: one for a
+    /// mono input, two for a stereo pair. Never widened -- what a stereo track
+    /// makes of a mono input is playback's business, not the file's.
+    std::vector<int> channels;
+
+    /**
+     * @brief The input's declared latency, in samples (#2459).
+     *
+     * What arrives has already happened, so the sample under the playhead at
+     * record start arrives this much later: a positive latency drops that many
+     * from the head of the take. A negative one is an adjustment pulling the
+     * other way, and pads the head with that much silence instead.
+     */
+    int latencySamples = 0;
+
+    /// The project's recordings directory, which the host names.
+    juce::File directory;
+
+    /// What the take's files are called, before the pass number.
+    juce::String name = "take";
+
+    AudioFileSpec file;
+
+    /// How much the queue holds. Its channel count is the take's.
+    RecordStreamSettings stream;
+};
+
+/**
+ * @brief One take: fed on the audio thread, closed on the thread that stops it.
+ *
+ * Made before recording starts, because nothing about a file can happen on the
+ * audio thread. It captures from the first block the transport is rolling and
+ * not counting in, and stops at the first block it is not: a take is closed by
+ * a stop, and a second play is a second take.
+ */
+class TakeRecorder {
+  public:
+    TakeRecorder(const LiveInputFeed& feed, const RenderContext& context,
+                 TakeRecorderSettings settings);
+
+    ~TakeRecorder() = default;
+
+    /// Neither copied nor moved: the queue holds a reference to the sink.
+    TakeRecorder(const TakeRecorder&) = delete;
+    TakeRecorder& operator=(const TakeRecorder&) = delete;
+    TakeRecorder(TakeRecorder&&) = delete;
+    TakeRecorder& operator=(TakeRecorder&&) = delete;
+
+    /// The queue the record thread drains. Registered by whoever owns the
+    /// thread, and unregistered before @ref finish.
+    RecordStream& stream() {
+        return stream_;
+    }
+
+    /**
+     * @brief Take what this block carried. On the audio thread, once a block.
+     *
+     * @p loop is the transport's, and is what tells a loop wrap from a locate:
+     * a wrap opens the next pass, and anything else ends the take, since
+     * material after a jump belongs where the cursor went.
+     */
+    void capture(const BlockInfo& block, bool countingIn, const LoopRange& loop);
+
+    /// Samples offered to the queue so far. Read from any thread; what a
+    /// running take is drawn from (#2463).
+    std::int64_t capturedSamples() const {
+        return captured_.load(std::memory_order_relaxed);
+    }
+
+    /// Whether the take is still taking blocks. Read from any thread.
+    bool rolling() const {
+        return rolling_.load(std::memory_order_relaxed);
+    }
+
+    /**
+     * @brief Close the take and say what it became.
+     *
+     * Off the audio thread, after the callback can no longer reach this: it
+     * drains what is queued, closes the last file and reads the passes back.
+     * Idempotent, and a take that never rolled comes back empty.
+     */
+    RecordedTake finish();
+
+  private:
+    enum class State : std::uint8_t { waiting, rolling, stopped };
+
+    /// The first block of the take: where it starts, and the head correction.
+    void start(const BlockInfo& block, const LoopRange& loop);
+
+    /// A wrap: the pass ends a latency later, since that is when the samples
+    /// the wrap belongs to arrive.
+    void openPass(const LoopRange& loop);
+
+    void stop();
+
+    /// This block's input, into the queue, split at a pass end if one falls
+    /// inside it.
+    void write(const BlockInfo& block);
+
+    /// Where the take is, once there is nothing more to add to it.
+    void placeClip(RecordedTake& take) const;
+
+    TakeRecorderSettings settings_;
+
+    LiveAudioInput input_;
+    TakeFileSink sink_;
+    RecordStream stream_;
+
+    /// The block, narrowed to the channels the take holds.
+    juce::AudioBuffer<float> scratch_;
+
+    /// The silence a negative latency puts at the head, sized once.
+    juce::AudioBuffer<float> pad_;
+
+    State state_ = State::waiting;
+
+    /// Arrivals still to drop before the take's first sample.
+    int headDrop_ = 0;
+
+    /// Samples still to write before the current pass ends, or -1 for none.
+    int pendingSplit_ = -1;
+
+    std::int64_t written_ = 0;
+
+    double startBeat_ = 0.0;
+    double lastBeat_ = 0.0;
+    double latencySeconds_ = 0.0;
+
+    /// Whether the take began on the loop start, which is what says its first
+    /// pass is a pass rather than a lead-in.
+    bool startedAtLoopStart_ = false;
+
+    /// The loop a wrap was seen against, and whether one ever was.
+    bool wrapped_ = false;
+    double loopStartBeat_ = 0.0;
+    double loopEndBeat_ = 0.0;
+
+    bool finished_ = false;
+    RecordedTake result_;
+
+    std::atomic<std::int64_t> captured_{0};
+    std::atomic<bool> rolling_{false};
+};
+
+/// The takes a callback feeds. Not owned: whoever publishes them keeps them
+/// alive until it has published something that does not name them.
+using RecordingTakes = std::vector<TakeRecorder*>;
+
+/**
+ * @brief What the audio thread records into, replaced on the publishing thread.
+ *
+ * A feed rather than part of a plan, for the reason the clips are one: arming a
+ * track recompiles a plan, but starting a recording is not a structural edit
+ * and must not cost one. Publishing waits for the block the callback is in, so
+ * a take taken out of the set is one nothing is writing to by the time the call
+ * returns, which is what makes it safe to finish.
+ */
+class RecordingFeed {
+    using Published = farbot::RealtimeObject<std::shared_ptr<const RecordingTakes>,
+                                             farbot::RealtimeObjectOptions::nonRealtimeMutatable>;
+
+  public:
+    /// On the publishing thread.
+    void publish(std::shared_ptr<const RecordingTakes> takes) {
+        published_.nonRealtimeReplace(std::move(takes));
+    }
+
+    /// What is live, for as long as this exists. On the audio thread. Null
+    /// until something is published, which is a session recording nothing.
+    class Reader {
+      public:
+        explicit Reader(RecordingFeed& feed) : access_(feed.published_) {}
+
+        const RecordingTakes* get() const noexcept {
+            return (*access_).get();
+        }
+        explicit operator bool() const noexcept {
+            return get() != nullptr;
+        }
+
+      private:
+        Published::ScopedAccess<farbot::ThreadType::realtime> access_;
+    };
+
+  private:
+    Published published_;
+};
+
+}  // namespace magda::engine

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -424,6 +424,9 @@ if(MAGDA_BUILD_NATIVE_ENGINE)
     # The write path a take goes to disk through (#2460): what it keeps, what
     # it refuses to overwrite, and what it says it lost.
     list(APPEND TEST_SOURCES engine/test_record_stream.cpp)
+    # An arrangement audio take (#2461): where it starts against a declared
+    # input latency and a count-in, how a loop splits it, and which pass plays.
+    list(APPEND TEST_SOURCES engine/test_take_recorder.cpp)
     list(APPEND TEST_SOURCES engine/test_engine_taps.cpp)
     list(APPEND TEST_SOURCES engine/test_clip_snapshot.cpp)
     list(APPEND TEST_SOURCES engine/test_clip_voice.cpp)

--- a/tests/engine/test_take_recorder.cpp
+++ b/tests/engine/test_take_recorder.cpp
@@ -324,6 +324,26 @@ TEST_CASE("The active take is the last full pass", "[engine][io][record][2461]")
     }
 }
 
+TEST_CASE("Head padding does not make a whole final pass look short",
+          "[engine][io][record][2461]") {
+    // The first pass carries the padding a negative adjustment put at the head,
+    // so it is longer than the loop. Judged against that, a final pass that ran
+    // its full length would be taken for a stop.
+    Rig rig(emptyDirectory("padded_first_pass"), floatTake({0, 1}, -512));
+    rig.loop(0.0, 2.0);
+    rig.play();
+    rig.run(3 * 2 * kBeatSamples);
+
+    const auto take = rig.recorder().finish();
+    REQUIRE(take.clip.takes.size() == 3);
+    CHECK(readBack(juce::File(take.clip.takes[0].filePath)).getNumSamples() ==
+          (2 * kBeatSamples) + 512);
+    CHECK(readBack(juce::File(take.clip.takes[2].filePath)).getNumSamples() == 2 * kBeatSamples);
+
+    CHECK(take.clip.currentTakeIndex == 2);
+    CHECK(take.file.getFullPathName() == take.clip.takes[2].filePath);
+}
+
 TEST_CASE("A lead-in recorded before the loop is not a take", "[engine][io][record][2461]") {
     const auto directory = emptyDirectory("lead_in");
 

--- a/tests/engine/test_take_recorder.cpp
+++ b/tests/engine/test_take_recorder.cpp
@@ -128,6 +128,10 @@ class Rig {
         transport_.loop = LoopRange{true, startBeat, endBeat};
     }
 
+    void unloop() {
+        transport_.loop = {};
+    }
+
     /// Feed @p numSamples of callbacks through the take.
     void run(int numSamples) {
         for (auto left = numSamples; left > 0;) {
@@ -405,15 +409,35 @@ TEST_CASE("A pass holds the same samples however often the disk is drained",
     REQUIRE(late == each);
     REQUIRE_FALSE(late.empty());
 
-    // Three loops delivered, so three passes of the loop, and the padding the
-    // head gained comes out as a short pass of the fourth.
-    REQUIRE(late.size() == 4);
-    for (std::size_t pass = 0; pass < 3; ++pass) {
+    // Three loops delivered, so three passes. The first runs long by the head
+    // padding, because a boundary is never named behind audio already queued
+    // and a negative adjustment queues a pass's tail before the wrap; every
+    // pass after it is the loop.
+    REQUIRE(late.size() == 3);
+    CHECK(late.front() == (2 * kBeatSamples) + 128);
+
+    for (std::size_t pass = 1; pass < late.size(); ++pass) {
         INFO("pass " << pass);
         REQUIRE(late[pass] == 2 * kBeatSamples);
     }
+}
 
-    CHECK(late.back() == 128);
+TEST_CASE("A loop switched off is not a pass boundary", "[engine][io][record][2461]") {
+    // The loop end is close enough that a take reading ahead would have named a
+    // boundary for it. No wrap comes: the loop goes away first, and continuous
+    // audio must not turn into takes of a loop that never came round.
+    Rig rig(emptyDirectory("loop_switched_off"), floatTake({0, 1}, -128));
+    rig.loop(0.0, 2.0);
+    rig.play();
+    rig.run((2 * kBeatSamples) - 64);
+    rig.unloop();
+    rig.run((2 * kBeatSamples) + 64);
+
+    const auto take = rig.recorder().finish();
+    CHECK(take.clip.takes.empty());
+    CHECK(readBack(take.file).getNumSamples() == (4 * kBeatSamples) + 128);
+    CHECK(take.startBeat == Catch::Approx(0.0));
+    CHECK(take.lengthBeats == Catch::Approx(4.032));
 }
 
 TEST_CASE("A take's length is measured where its audio sits, not where it arrived",

--- a/tests/engine/test_take_recorder.cpp
+++ b/tests/engine/test_take_recorder.cpp
@@ -326,6 +326,62 @@ TEST_CASE("A lead-in recorded before the loop is not a take", "[engine][io][reco
     CHECK(directory.getNumberOfChildFiles(juce::File::findFiles) == 1);
 }
 
+TEST_CASE("A lead-in kept for want of a whole pass stays where it was recorded",
+          "[engine][io][record][2461]") {
+    // The wrap has been seen, but the samples belonging to it are still a
+    // latency away when the transport stops, so the only pass captured is the
+    // lead-in. Placing that at the loop start would play it a beat early.
+    Rig rig(emptyDirectory("lead_in_only"), floatTake({0, 1}, 128));
+    rig.loop(0.0, 2.0);
+    rig.play(1.0);
+    rig.run(kBeatSamples + 64);
+
+    const auto take = rig.recorder().finish();
+    CHECK(take.clip.takes.empty());
+    CHECK(take.startBeat == Catch::Approx(1.0));
+    CHECK(take.lengthBeats == Catch::Approx((kBeatSamples + 64 - 128.0) / kBeatSamples));
+    CHECK(readBack(take.file).getNumSamples() == kBeatSamples + 64 - 128);
+}
+
+TEST_CASE("A loop shorter than the input latency still splits every pass",
+          "[engine][io][record][2461]") {
+    // Every wrap is a pass end that has not arrived yet, so several are
+    // outstanding at once. A boundary counted down to rather than named would
+    // be replaced by the next wrap and never reached.
+    constexpr int kLoopSamples = 64;
+    constexpr int kLatency = 128;
+
+    Rig rig(emptyDirectory("short_loop"), floatTake({0, 1}, kLatency));
+    rig.loop(0.0, static_cast<double>(kLoopSamples) / kBeatSamples);
+    rig.play();
+    rig.run(10 * kLoopSamples);
+
+    const auto take = rig.recorder().finish();
+
+    // Ten loops delivered, less the two the head correction gave up.
+    REQUIRE(take.clip.takes.size() == 8);
+    for (const auto& pass : take.clip.takes)
+        CHECK(readBack(juce::File(pass.filePath)).getNumSamples() == kLoopSamples);
+}
+
+TEST_CASE("A pass end the write path could not take is reported", "[engine][io][record][2461]") {
+    // A loop this short fills the boundary lane long before the audio queue,
+    // so the passes run together in one file. That is not a shorter recording
+    // and must not read as a clean one.
+    constexpr int kLoopSamples = 64;
+    constexpr int kPasses = 300;
+
+    Rig rig(emptyDirectory("boundary_overflow"), floatTake({0, 1}));
+    rig.loop(0.0, static_cast<double>(kLoopSamples) / kBeatSamples);
+    rig.play();
+    rig.run(kPasses * kLoopSamples);
+
+    const auto take = rig.recorder().finish();
+    CHECK(take.samplesLost == 0);
+    CHECK(take.passesLost > 0);
+    CHECK(static_cast<int>(take.clip.takes.size()) < kPasses - 1);
+}
+
 TEST_CASE("A stop mid-pass keeps what was recorded up to it", "[engine][io][record][2461]") {
     Rig rig(emptyDirectory("stop_mid_pass"), floatTake({0, 1}));
     rig.play();

--- a/tests/engine/test_take_recorder.cpp
+++ b/tests/engine/test_take_recorder.cpp
@@ -1,0 +1,366 @@
+#include <juce_audio_formats/juce_audio_formats.h>
+
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <cstdint>
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "exec/RenderContext.hpp"
+#include "io/LiveInput.hpp"
+#include "io/TakeRecorder.hpp"
+#include "transport/TempoMap.hpp"
+#include "transport/TransportClock.hpp"
+#include "transport/TransportState.hpp"
+
+/**
+ * @file test_take_recorder.cpp
+ * @brief An arrangement audio take, from armed to clip (#2461).
+ *
+ * A synthetic input and a driven transport, with no session and no thread: the
+ * take is fed a callback at a time and drained when it is closed, so a case
+ * says exactly where the transport was when a sample arrived.
+ *
+ * Every input sample says which arrival it is, which is what lets a case assert
+ * on where a take begins rather than only on how long it is.
+ */
+
+using magda::engine::AudioFileFormat;
+using magda::engine::LiveInputBlock;
+using magda::engine::LiveInputFeed;
+using magda::engine::LoopRange;
+using magda::engine::RecordedTake;
+using magda::engine::RenderContext;
+using magda::engine::TakeRecorder;
+using magda::engine::TakeRecorderSettings;
+using magda::engine::TempoMap;
+using magda::engine::TransportClock;
+using magda::engine::TransportSnapshot;
+
+namespace {
+
+constexpr double kSampleRate = 8000.0;
+constexpr int kBlockSize = 64;
+
+/// A beat at 120 bpm and this rate, which makes every position in these cases
+/// a whole number of samples.
+constexpr int kBeatSamples = 4000;
+
+/// What arrival @p sample of @p channel carries. Inside full scale, and spaced
+/// far enough apart that two arrivals cannot round onto one float.
+float material(std::int64_t sample, int channel) {
+    return static_cast<float>(sample + 1 + (static_cast<std::int64_t>(channel) * 50000)) * 1.0e-5f;
+}
+
+juce::File scratch() {
+    auto root = juce::File::getSpecialLocation(juce::File::tempDirectory)
+                    .getChildFile("magda_take_recorder_test");
+    root.createDirectory();
+    return root;
+}
+
+/// A directory of its own, so a case can say what is left in it.
+juce::File emptyDirectory(const juce::String& name) {
+    auto directory = scratch().getChildFile(name);
+    directory.deleteRecursively();
+    directory.createDirectory();
+    return directory;
+}
+
+juce::AudioBuffer<float> readBack(const juce::File& file) {
+    juce::AudioFormatManager formats;
+    formats.registerBasicFormats();
+
+    const std::unique_ptr<juce::AudioFormatReader> reader(formats.createReaderFor(file));
+    REQUIRE(reader != nullptr);
+
+    juce::AudioBuffer<float> buffer(static_cast<int>(reader->numChannels),
+                                    static_cast<int>(reader->lengthInSamples));
+    reader->read(&buffer, 0, buffer.getNumSamples(), 0, true, true);
+    return buffer;
+}
+
+/// A take with nothing to round: float files hold what they were handed, so a
+/// case can compare against the input itself.
+TakeRecorderSettings floatTake(std::vector<int> channels, int latencySamples = 0) {
+    TakeRecorderSettings settings;
+    settings.channels = std::move(channels);
+    settings.latencySamples = latencySamples;
+    settings.name = "take";
+    settings.file.format = AudioFileFormat::wav;
+    settings.file.bitDepth = 32;
+    return settings;
+}
+
+/**
+ * @brief A transport, an input and one take, driven a callback at a time.
+ */
+class Rig {
+  public:
+    Rig(const juce::File& directory, TakeRecorderSettings settings, int inputChannels = 2)
+        : input_(inputChannels, kBlockSize) {
+        transport_.tempo = TempoMap({{0.0, 120.0, 0.0f}}, {{0.0, 4, 4}});
+        feed_.prepare(inputChannels, kBlockSize);
+
+        settings.directory = directory;
+        recorder_ = std::make_unique<TakeRecorder>(
+            feed_, RenderContext{kSampleRate, kBlockSize, inputChannels}, std::move(settings));
+    }
+
+    void play(double fromBeat = 0.0, double countInBeats = 0.0) {
+        ++transport_.request.generation;
+        transport_.request.playing = true;
+        transport_.request.locate = true;
+        transport_.request.positionBeat = fromBeat;
+        transport_.request.countInBeats = countInBeats;
+    }
+
+    void stop() {
+        ++transport_.request.generation;
+        transport_.request.playing = false;
+        transport_.request.locate = false;
+        transport_.request.countInBeats = 0.0;
+    }
+
+    void loop(double startBeat, double endBeat) {
+        transport_.loop = LoopRange{true, startBeat, endBeat};
+    }
+
+    /// Feed @p numSamples of callbacks through the take.
+    void run(int numSamples) {
+        for (auto left = numSamples; left > 0;) {
+            const auto callback = std::min(kBlockSize, left);
+            deliver(callback);
+            left -= callback;
+        }
+    }
+
+    TakeRecorder& recorder() {
+        return *recorder_;
+    }
+
+  private:
+    void deliver(int numSamples) {
+        for (auto channel = 0; channel < input_.getNumChannels(); ++channel)
+            for (auto at = 0; at < numSamples; ++at)
+                input_.setSample(channel, at, material(arrival_ + at, channel));
+
+        const LiveInputBlock block{juce::dsp::AudioBlock<const float>(input_).getSubBlock(
+                                       0, static_cast<std::size_t>(numSamples)),
+                                   {}};
+
+        feed_.beginCallback(block, numSamples);
+
+        for (const auto& segment : clock_.advance(transport_, kSampleRate, numSamples)) {
+            feed_.beginSegment(segment.startSample, segment.block.numSamples);
+            recorder_->capture(segment.block, segment.countingIn, transport_.loop);
+        }
+
+        feed_.endCallback();
+        arrival_ += numSamples;
+    }
+
+    TransportSnapshot transport_;
+    TransportClock clock_;
+    LiveInputFeed feed_;
+    juce::AudioBuffer<float> input_;
+    std::unique_ptr<TakeRecorder> recorder_;
+
+    /// Input samples delivered since the rig was made, which is what the
+    /// material is numbered by.
+    std::int64_t arrival_ = 0;
+};
+
+/// The arrival the take's first sample came from, read out of the file itself.
+std::int64_t firstArrival(const juce::AudioBuffer<float>& stored) {
+    return std::llround(static_cast<double>(stored.getSample(0, 0)) * 1.0e5) - 1;
+}
+
+}  // namespace
+
+TEST_CASE("A take holds the input the device delivered, sample for sample",
+          "[engine][io][record][2461]") {
+    Rig rig(emptyDirectory("plain"), floatTake({0, 1}));
+    rig.play();
+    rig.run(256);
+
+    const auto take = rig.recorder().finish();
+    REQUIRE_FALSE(take.empty());
+    CHECK(take.samplesLost == 0);
+    CHECK_FALSE(take.failed);
+
+    const auto stored = readBack(take.file);
+    REQUIRE(stored.getNumChannels() == 2);
+    REQUIRE(stored.getNumSamples() == 256);
+
+    for (auto channel = 0; channel < 2; ++channel)
+        for (auto at = 0; at < stored.getNumSamples(); ++at) {
+            INFO("channel " << channel << " sample " << at);
+            REQUIRE(stored.getSample(channel, at) == material(at, channel));
+        }
+
+    // A single pass is an ordinary clip: the take list is for loop-record
+    // alternatives and stays empty without them.
+    CHECK(take.clip.takes.empty());
+    CHECK(take.startBeat == 0.0);
+    CHECK(take.lengthBeats == Catch::Approx(256.0 / kBeatSamples));
+}
+
+TEST_CASE("The take's first sample is the one under the playhead at record start",
+          "[engine][io][record][2461]") {
+    SECTION("a positive latency drops what arrived before it") {
+        Rig rig(emptyDirectory("latency_positive"), floatTake({0, 1}, 128));
+        rig.play();
+        rig.run(256);
+
+        const auto stored = readBack(rig.recorder().finish().file);
+        CHECK(stored.getNumSamples() == 128);
+        CHECK(firstArrival(stored) == 128);
+    }
+
+    SECTION("a negative latency stands silence in for what never arrived") {
+        Rig rig(emptyDirectory("latency_negative"), floatTake({0, 1}, -128));
+        rig.play();
+        rig.run(256);
+
+        const auto stored = readBack(rig.recorder().finish().file);
+        REQUIRE(stored.getNumSamples() == 384);
+
+        for (auto at = 0; at < 128; ++at) {
+            INFO("sample " << at);
+            REQUIRE(stored.getSample(0, at) == 0.0f);
+        }
+
+        CHECK(stored.getSample(0, 128) == material(0, 0));
+    }
+
+    SECTION("no latency keeps the first arrival") {
+        Rig rig(emptyDirectory("latency_none"), floatTake({0, 1}));
+        rig.play();
+        rig.run(256);
+
+        const auto stored = readBack(rig.recorder().finish().file);
+        CHECK(stored.getNumSamples() == 256);
+        CHECK(firstArrival(stored) == 0);
+    }
+}
+
+TEST_CASE("A count-in is not part of the take", "[engine][io][record][2461]") {
+    Rig rig(emptyDirectory("count_in"), floatTake({0, 1}));
+    rig.play(1.0, 1.0);
+    rig.run(kBeatSamples + 256);
+
+    const auto stored = readBack(rig.recorder().finish().file);
+    CHECK(stored.getNumSamples() == 256);
+    CHECK(firstArrival(stored) == kBeatSamples);
+}
+
+TEST_CASE("Loop recording is one file a pass, loop-aligned", "[engine][io][record][2461]") {
+    const auto directory = emptyDirectory("loop_passes");
+
+    Rig rig(directory, floatTake({0, 1}));
+    rig.loop(0.0, 2.0);
+    rig.play();
+    rig.run(3 * 2 * kBeatSamples);
+
+    const auto take = rig.recorder().finish();
+    REQUIRE(take.clip.takes.size() == 3);
+
+    for (const auto& pass : take.clip.takes) {
+        INFO(pass.filePath);
+        CHECK(pass.durationSeconds == Catch::Approx(1.0));
+        CHECK(readBack(juce::File(pass.filePath)).getNumSamples() == 2 * kBeatSamples);
+    }
+
+    // Every pass starts where the loop does, which is where the clip goes.
+    CHECK(take.startBeat == 0.0);
+    CHECK(take.lengthBeats == Catch::Approx(2.0));
+    CHECK(take.clip.currentTakeIndex == 2);
+
+    CHECK(directory.getNumberOfChildFiles(juce::File::findFiles) == 3);
+}
+
+TEST_CASE("The active take is the last full pass", "[engine][io][record][2461]") {
+    SECTION("a pass cut off mid-way is not the one that plays") {
+        Rig rig(emptyDirectory("short_final"), floatTake({0, 1}));
+        rig.loop(0.0, 2.0);
+        rig.play();
+        rig.run((3 * 2 * kBeatSamples) + 2000);
+
+        const auto take = rig.recorder().finish();
+        REQUIRE(take.clip.takes.size() == 4);
+        CHECK(take.clip.takes.back().durationSeconds == Catch::Approx(0.25));
+        CHECK(take.clip.currentTakeIndex == 2);
+        CHECK(take.file.getFullPathName() == take.clip.takes[2].filePath);
+    }
+
+    SECTION("a final pass that ran its length is the one that plays") {
+        Rig rig(emptyDirectory("full_final"), floatTake({0, 1}));
+        rig.loop(0.0, 2.0);
+        rig.play();
+        rig.run(2 * 2 * kBeatSamples);
+
+        const auto take = rig.recorder().finish();
+        REQUIRE(take.clip.takes.size() == 2);
+        CHECK(take.clip.currentTakeIndex == 1);
+    }
+}
+
+TEST_CASE("A lead-in recorded before the loop is not a take", "[engine][io][record][2461]") {
+    const auto directory = emptyDirectory("lead_in");
+
+    Rig rig(directory, floatTake({0, 1}));
+    rig.loop(0.0, 2.0);
+    rig.play(1.0);
+    rig.run(kBeatSamples + (2 * kBeatSamples));
+
+    const auto take = rig.recorder().finish();
+
+    // The lead-in cannot share the clip start the other passes do, so it is
+    // dropped rather than kept as a take that plays in the wrong place.
+    CHECK(take.clip.takes.empty());
+    CHECK(readBack(take.file).getNumSamples() == 2 * kBeatSamples);
+    CHECK(take.startBeat == 0.0);
+    CHECK(take.lengthBeats == Catch::Approx(2.0));
+    CHECK(directory.getNumberOfChildFiles(juce::File::findFiles) == 1);
+}
+
+TEST_CASE("A stop mid-pass keeps what was recorded up to it", "[engine][io][record][2461]") {
+    Rig rig(emptyDirectory("stop_mid_pass"), floatTake({0, 1}));
+    rig.play();
+    rig.run(1000);
+    rig.stop();
+    rig.run(256);
+
+    CHECK_FALSE(rig.recorder().rolling());
+
+    const auto take = rig.recorder().finish();
+    CHECK(readBack(take.file).getNumSamples() == 1000);
+    CHECK(take.lengthBeats == Catch::Approx(1000.0 / kBeatSamples));
+}
+
+TEST_CASE("A mono input is recorded mono", "[engine][io][record][2461]") {
+    Rig rig(emptyDirectory("mono"), floatTake({1}));
+    rig.play();
+    rig.run(256);
+
+    const auto stored = readBack(rig.recorder().finish().file);
+    REQUIRE(stored.getNumChannels() == 1);
+    CHECK(stored.getSample(0, 0) == material(0, 1));
+}
+
+TEST_CASE("An overrun reaches the finished take", "[engine][io][record][2461]") {
+    auto settings = floatTake({0, 1});
+    settings.stream.capacitySamples = 1024;
+
+    // Nothing drains until the take is closed, so a queue this small is a disk
+    // that stopped writing: what it could not hold is lost.
+    Rig rig(emptyDirectory("overrun"), std::move(settings));
+    rig.play();
+    rig.run(4000);
+
+    const auto take = rig.recorder().finish();
+    CHECK(take.samplesLost > 0);
+    CHECK(readBack(take.file).getNumSamples() == 1024);
+}

--- a/tests/engine/test_take_recorder.cpp
+++ b/tests/engine/test_take_recorder.cpp
@@ -98,9 +98,10 @@ TakeRecorderSettings floatTake(std::vector<int> channels, int latencySamples = 0
  */
 class Rig {
   public:
-    Rig(const juce::File& directory, TakeRecorderSettings settings, int inputChannels = 2)
+    Rig(const juce::File& directory, TakeRecorderSettings settings, int inputChannels = 2,
+        TempoMap tempo = TempoMap({{0.0, 120.0, 0.0f}}, {{0.0, 4, 4}}))
         : input_(inputChannels, kBlockSize) {
-        transport_.tempo = TempoMap({{0.0, 120.0, 0.0f}}, {{0.0, 4, 4}});
+        transport_.tempo = std::move(tempo);
         feed_.prepare(inputChannels, kBlockSize);
 
         settings.directory = directory;
@@ -136,6 +137,12 @@ class Rig {
         }
     }
 
+    /// Empty the queue after every callback, the way the record thread would.
+    /// What a take holds must not depend on it.
+    void drainAsItGoes() {
+        drains_ = true;
+    }
+
     TakeRecorder& recorder() {
         return *recorder_;
     }
@@ -159,6 +166,10 @@ class Rig {
 
         feed_.endCallback();
         arrival_ += numSamples;
+
+        if (drains_)
+            while (recorder_->stream().drain()) {
+            }
     }
 
     TransportSnapshot transport_;
@@ -170,6 +181,8 @@ class Rig {
     /// Input samples delivered since the rig was made, which is what the
     /// material is numbered by.
     std::int64_t arrival_ = 0;
+
+    bool drains_ = false;
 };
 
 /// The arrival the take's first sample came from, read out of the file itself.
@@ -362,6 +375,65 @@ TEST_CASE("A loop shorter than the input latency still splits every pass",
     REQUIRE(take.clip.takes.size() == 8);
     for (const auto& pass : take.clip.takes)
         CHECK(readBack(juce::File(pass.filePath)).getNumSamples() == kLoopSamples);
+}
+
+TEST_CASE("A pass holds the same samples however often the disk is drained",
+          "[engine][io][record][2461]") {
+    // A negative adjustment queues a pass's last samples before the transport
+    // wraps, so a boundary named at the wrap would already be behind them and
+    // the pass would end wherever the writer had got to.
+    const auto passSamples = [](bool drains) {
+        Rig rig(emptyDirectory(drains ? "drained_each" : "drained_late"), floatTake({0, 1}, -128));
+        rig.loop(0.0, 2.0);
+        rig.play();
+
+        if (drains)
+            rig.drainAsItGoes();
+
+        rig.run(3 * 2 * kBeatSamples);
+
+        const auto take = rig.recorder().finish();
+        std::vector<int> lengths;
+        for (const auto& pass : take.clip.takes)
+            lengths.push_back(readBack(juce::File(pass.filePath)).getNumSamples());
+        return lengths;
+    };
+
+    const auto late = passSamples(false);
+    const auto each = passSamples(true);
+
+    REQUIRE(late == each);
+    REQUIRE_FALSE(late.empty());
+
+    // Three loops delivered, so three passes of the loop, and the padding the
+    // head gained comes out as a short pass of the fourth.
+    REQUIRE(late.size() == 4);
+    for (std::size_t pass = 0; pass < 3; ++pass) {
+        INFO("pass " << pass);
+        REQUIRE(late[pass] == 2 * kBeatSamples);
+    }
+
+    CHECK(late.back() == 128);
+}
+
+TEST_CASE("A take's length is measured where its audio sits, not where it arrived",
+          "[engine][io][record][2461]") {
+    // A step from 120 to 240 bpm at beat 1. The head correction moves the
+    // recorded stretch a latency earlier, and the beats it covers there are not
+    // the beats the arriving blocks counted.
+    Rig rig(emptyDirectory("tempo_step"), floatTake({0, 1}, 128), 2,
+            TempoMap({{0.0, 120.0, 0.0f}, {1.0, 120.0, 0.0f}, {1.0, 240.0, 0.0f}}, {{0.0, 4, 4}}));
+    rig.play();
+    rig.run(8000);
+
+    const auto take = rig.recorder().finish();
+    const auto stored = readBack(take.file);
+    REQUIRE(stored.getNumSamples() == 8000 - 128);
+
+    // A beat is 4000 samples until beat 1 and 2000 after it, so what the file
+    // holds reaches beat 2.936 and the clip has to say so.
+    CHECK(take.startBeat == Catch::Approx(0.0));
+    CHECK(take.lengthBeats == Catch::Approx(2.936));
 }
 
 TEST_CASE("A pass end the write path could not take is reported", "[engine][io][record][2461]") {


### PR DESCRIPTION
Slice 3 of #1895, closes #2461. Where slices 1 and 2 meet: the input a monitoring track hears, through the queue a writer thread drains, into the files a clip is made of.

## What is here

**`TakeRecorder`** is one take, fed a block at a time on the audio thread. It reads the channels its track named and no others, so a mono input is a mono file and what a stereo track makes of it stays playback's business.

The rules it keeps are the model's rather than any engine's:

- **The head is corrected by the input's declared latency.** What arrives has already happened, and a take holds what happened, so a positive latency drops that many arrivals and a negative adjustment pads the head with that much silence. The clip lands on the record position rather than being moved back to meet the file.
- **A loop wrap opens the next pass a latency later**, for the same reason: the samples the wrap belongs to have not arrived yet. A negative adjustment cannot make a boundary retroactive, and the header says so.
- **A first pass that did not begin on the loop start is a lead-in, not a take.** `AudioTake` has no offset of its own, so a pass that cannot share the clip start would play in the wrong place. It is dropped and its file deleted once a wrap has proved the take loop-aligned.
- **The pass that plays is the last full one**, stepping back when the final one is under 95% of the longest, since only the last pass can be cut off mid-way.
- **A count-in is not part of the take**: it is time before the play position, and the take starts where it ends.

Nothing makes a model object on the audio thread. `finish()` is where passes become an `AudioClipModel`, on the thread that stopped the take, and a take that lost samples or could not write says so on the result rather than passing as a shorter clip.

**`TakeFileSink`** is the record thread's end of it: a file opened at a pass's first sample rather than when the take was armed, so a pass that captured nothing leaves nothing behind, and pass boundaries travel on a lane of their own because the queue carries only audio. It writes through `AudioFileSink`, which grew an `AudioBlock` overload and a `failed()` getter so the engine has one file-writing path rather than two.

The takes reach the callback through a feed beside the clips and outside every plan: arming a track compiles a plan, but starting a recording is not a structural edit and must not cost one.

## Verification

`tests/engine/test_take_recorder.cpp`, offline throughout: a synthetic input whose every sample says which arrival it is, a driven transport, no session and no thread.

- what the file holds is what the input carried, sample for sample
- the first recorded sample is the one under the playhead at record start, at a positive, a negative and no declared latency
- with a count-in set, the file starts at the count-in's end
- three loop passes are three files, all loop-length, and the clip is loop-aligned
- the active take is the last full pass, and the last-but-one when the final pass is cut short
- a lead-in leaves no file and no take
- a stop mid-pass keeps what was recorded up to it
- a mono input is recorded mono
- an overrun reaches the finished take rather than passing as a shorter file

Full Catch2 suite passes (3736 passed, 13 skipped); app and JUCE test targets build clean.

## Not in this slice

MIDI (#2462), what the app draws while the pass is running (#2463), session slots, and surviving a recompile mid-take.

https://claude.ai/code/session_013A1GWqAoLZPdkYAMwKrjQj