### PR TITLE
Collapse search loops to any_of/find_if/count_if in daw/core and daw/audio

### DIFF
--- a/magda/daw/audio/TrackController.cpp
+++ b/magda/daw/audio/TrackController.cpp
@@ -19,11 +19,8 @@ te::InputDevice::MonitorMode toTeMonitorMode(InputMonitorMode mode) {
 }
 
 bool inputHasTarget(te::InputDeviceInstance& input, te::EditItemID targetID) {
-    for (auto existingTargetID : input.getTargets()) {
-        if (existingTargetID == targetID)
-            return true;
-    }
-    return false;
+    const auto matchesTarget = [targetID](auto id) { return id == targetID; };
+    return std::ranges::any_of(input.getTargets(), matchesTarget);
 }
 
 te::MidiInputDevice* getLiveMidiInputDevice(te::Engine& engine,
@@ -32,12 +29,12 @@ te::MidiInputDevice* getLiveMidiInputDevice(te::Engine& engine,
         return nullptr;
 
     auto* owner = &inputDeviceInstance->owner;
-    for (const auto& midiInput : engine.getDeviceManager().getMidiInDevices()) {
-        if (midiInput && midiInput.get() == owner)
-            return midiInput.get();
-    }
-
-    return nullptr;
+    const auto matchesOwner = [owner](const auto& midiInput) {
+        return midiInput && midiInput.get() == owner;
+    };
+    const auto midiInputs = engine.getDeviceManager().getMidiInDevices();
+    const auto found = std::ranges::find_if(midiInputs, matchesOwner);
+    return found == midiInputs.end() ? nullptr : found->get();
 }
 
 te::WaveInputDevice* getLiveWaveInputDevice(te::Engine& engine,
@@ -46,12 +43,10 @@ te::WaveInputDevice* getLiveWaveInputDevice(te::Engine& engine,
         return nullptr;
 
     auto* owner = &inputDeviceInstance->owner;
-    for (auto* waveInput : engine.getDeviceManager().getWaveInputDevices()) {
-        if (waveInput == owner)
-            return waveInput;
-    }
-
-    return nullptr;
+    const auto matchesOwner = [owner](auto* waveInput) { return waveInput == owner; };
+    const auto waveInputs = engine.getDeviceManager().getWaveInputDevices();
+    const auto found = std::ranges::find_if(waveInputs, matchesOwner);
+    return found == waveInputs.end() ? nullptr : *found;
 }
 
 te::WaveInputDevice* getLiveTrackWaveInputDevice(
@@ -61,18 +56,16 @@ te::WaveInputDevice* getLiveTrackWaveInputDevice(
         return nullptr;
 
     auto* owner = &inputDeviceInstance->owner;
-    for (const auto& [magdaId, teTrack] : trackMapping) {
-        if (!teTrack)
-            continue;
-        auto* waveInput = &teTrack->getWaveInputDevice();
-        if (waveInput == owner) {
-            if (sourceTrackId)
-                *sourceTrackId = magdaId;
-            return waveInput;
-        }
-    }
+    const auto matchesOwner = [owner](const auto& entry) {
+        return entry.second && &entry.second->getWaveInputDevice() == owner;
+    };
+    const auto found = std::ranges::find_if(trackMapping, matchesOwner);
+    if (found == trackMapping.end())
+        return nullptr;
 
-    return nullptr;
+    if (sourceTrackId)
+        *sourceTrackId = found->first;
+    return &found->second->getWaveInputDevice();
 }
 
 }  // namespace
@@ -193,18 +186,15 @@ static te::VolumeAndPanPlugin* getFaderPlugin(te::AudioTrack* track) {
     if (!track)
         return nullptr;
     auto& plugins = track->pluginList;
+    const auto isLevelMeter = [](auto* p) {
+        return dynamic_cast<te::LevelMeterPlugin*>(p) != nullptr;
+    };
     // Search from end — the fader should be the last VolumeAndPan before LevelMeter(s)
     for (int i = plugins.size() - 1; i >= 0; --i) {
         if (auto* vp = dynamic_cast<te::VolumeAndPanPlugin*>(plugins[i])) {
             // Check that everything after this is a LevelMeterPlugin
-            bool onlyMetersAfter = true;
-            for (int j = i + 1; j < plugins.size(); ++j) {
-                if (!dynamic_cast<te::LevelMeterPlugin*>(plugins[j])) {
-                    onlyMetersAfter = false;
-                    break;
-                }
-            }
-            if (onlyMetersAfter)
+            const auto rest = std::ranges::subrange(plugins.begin() + i + 1, plugins.end());
+            if (std::ranges::all_of(rest, isLevelMeter))
                 return vp;
         }
     }
@@ -313,11 +303,12 @@ juce::String TrackController::getTrackAudioOutput(TrackId trackId) const {
     if (auto* destTrack = output.getDestinationTrack()) {
         // Find the MAGDA TrackId for this TE track
         juce::ScopedLock lock(trackLock_);
-        for (const auto& [magdaId, teTrack] : trackMapping_) {
-            if (teTrack == destTrack) {
-                return "track:" + juce::String(magdaId);
-            }
-        }
+        const auto matchesTrack = [destTrack](const auto& entry) {
+            return entry.second == destTrack;
+        };
+        const auto found = std::ranges::find_if(trackMapping_, matchesTrack);
+        if (found != trackMapping_.end())
+            return "track:" + juce::String(found->first);
     }
 
     // Return the output device ID for round-trip consistency
@@ -556,18 +547,18 @@ juce::String TrackController::getTrackAudioInput(TrackId trackId) const {
             }
             if (!waveInput)
                 continue;
-            auto targets = inputDeviceInstance->getTargets();
-            for (auto targetID : targets) {
-                if (targetID == track->itemID) {
-                    if (sourceTrackId != INVALID_TRACK_ID)
-                        return "track:" + juce::String(sourceTrackId);
-                    // Return "default" if this is the first input (for round-trip consistency)
-                    if (i == 0) {
-                        return "default";
-                    }
-                    return waveInput->getName();
-                }
+            const auto matchesTrackId = [target = track->itemID](auto targetID) {
+                return targetID == target;
+            };
+            if (!std::ranges::any_of(inputDeviceInstance->getTargets(), matchesTrackId))
+                continue;
+            if (sourceTrackId != INVALID_TRACK_ID)
+                return "track:" + juce::String(sourceTrackId);
+            // Return "default" if this is the first input (for round-trip consistency)
+            if (i == 0) {
+                return "default";
             }
+            return waveInput->getName();
         }
     }
 

--- a/magda/daw/audio/midi/MidiInputRouter.cpp
+++ b/magda/daw/audio/midi/MidiInputRouter.cpp
@@ -31,12 +31,12 @@ te::MidiInputDevice* getLiveMidiInputDevice(te::Engine& engine,
         return nullptr;
 
     auto* owner = &inputDeviceInstance->owner;
-    for (const auto& midiInput : engine.getDeviceManager().getMidiInDevices()) {
-        if (midiInput && midiInput.get() == owner)
-            return midiInput.get();
-    }
-
-    return nullptr;
+    const auto matchesOwner = [owner](const auto& midiInput) {
+        return midiInput && midiInput.get() == owner;
+    };
+    const auto midiInputs = engine.getDeviceManager().getMidiInDevices();
+    const auto found = std::ranges::find_if(midiInputs, matchesOwner);
+    return found == midiInputs.end() ? nullptr : found->get();
 }
 
 te::MidiInputDevice* getLiveTrackMidiInputDevice(TrackController& trackController,
@@ -48,16 +48,14 @@ te::MidiInputDevice* getLiveTrackMidiInputDevice(TrackController& trackControlle
     auto* owner = &inputDeviceInstance->owner;
     te::MidiInputDevice* result = nullptr;
     trackController.withTrackMapping([&](const auto& mapping) {
-        for (const auto& [magdaId, teTrack] : mapping) {
-            if (!teTrack)
-                continue;
-            auto* midiInput = &teTrack->getMidiInputDevice();
-            if (midiInput == owner) {
-                if (sourceTrackId)
-                    *sourceTrackId = magdaId;
-                result = midiInput;
-                return;
-            }
+        const auto matchesOwner = [owner](const auto& entry) {
+            return entry.second && &entry.second->getMidiInputDevice() == owner;
+        };
+        if (const auto found = std::ranges::find_if(mapping, matchesOwner);
+            found != mapping.end()) {
+            if (sourceTrackId)
+                *sourceTrackId = found->first;
+            result = &found->second->getMidiInputDevice();
         }
     });
 
@@ -73,12 +71,10 @@ te::InputDevice* getLiveInputDevice(te::Engine& engine,
         return nullptr;
 
     auto* owner = &inputDeviceInstance->owner;
-    for (auto* waveInput : engine.getDeviceManager().getWaveInputDevices()) {
-        if (waveInput == owner)
-            return waveInput;
-    }
-
-    return nullptr;
+    const auto matchesOwner = [owner](auto* waveInput) { return waveInput == owner; };
+    const auto waveInputs = engine.getDeviceManager().getWaveInputDevices();
+    const auto found = std::ranges::find_if(waveInputs, matchesOwner);
+    return found == waveInputs.end() ? nullptr : *found;
 }
 
 te::WaveInputDevice* getLiveTrackWaveInputDevice(TrackController& trackController,
@@ -89,15 +85,11 @@ te::WaveInputDevice* getLiveTrackWaveInputDevice(TrackController& trackControlle
     auto* owner = &inputDeviceInstance->owner;
     te::WaveInputDevice* result = nullptr;
     trackController.withTrackMapping([&](const auto& mapping) {
-        for (const auto& [magdaId, teTrack] : mapping) {
-            if (!teTrack)
-                continue;
-            auto* waveInput = &teTrack->getWaveInputDevice();
-            if (waveInput == owner) {
-                result = waveInput;
-                return;
-            }
-        }
+        const auto matchesOwner = [owner](const auto& entry) {
+            return entry.second && &entry.second->getWaveInputDevice() == owner;
+        };
+        if (const auto found = std::ranges::find_if(mapping, matchesOwner); found != mapping.end())
+            result = &found->second->getWaveInputDevice();
     });
 
     return result;
@@ -136,21 +128,19 @@ void MidiInputRouter::setRecordingQueue(RecordingNoteQueue* queue,
 TrackId MidiInputRouter::resolveTargetTrackId(te::EditItemID targetID) const {
     TrackId result = INVALID_TRACK_ID;
     trackController_.withTrackMapping([&](const auto& mapping) {
-        for (const auto& [magdaId, teTrack] : mapping) {
-            if (!teTrack)
-                continue;
-            if (teTrack->itemID == targetID) {
-                result = magdaId;
-                return;
-            }
+        const auto matchesTarget = [targetID](const auto& entry) {
+            if (!entry.second)
+                return false;
+            if (entry.second->itemID == targetID)
+                return true;
             // Session-slot recording targets the slot, not the track.
-            for (auto* slot : teTrack->getClipSlotList().getClipSlots()) {
-                if (slot && slot->itemID == targetID) {
-                    result = magdaId;
-                    return;
-                }
-            }
-        }
+            const auto matchesSlot = [targetID](auto* slot) {
+                return slot && slot->itemID == targetID;
+            };
+            return std::ranges::any_of(entry.second->getClipSlotList().getClipSlots(), matchesSlot);
+        };
+        if (const auto found = std::ranges::find_if(mapping, matchesTarget); found != mapping.end())
+            result = found->first;
     });
     return result;
 }
@@ -178,8 +168,7 @@ void MidiInputRouter::syncTrackMidiPreviewConsumers() {
             const auto* destInfo = tm.getTrack(destTrackId);
             if (!destInfo || !destInfo->recordArmed)
                 continue;
-            if (std::find(armedTargets.begin(), armedTargets.end(), destTrackId) ==
-                armedTargets.end())
+            if (std::ranges::find(armedTargets, destTrackId) == armedTargets.end())
                 armedTargets.push_back(destTrackId);
         }
 
@@ -209,29 +198,28 @@ void MidiInputRouter::handleAsyncUpdate() {
 }
 
 te::VirtualMidiInputDevice* MidiInputRouter::getQwertyMidiDevice() {
+    // Only accept actual VirtualMidiInputDevice instances — a physical device
+    // with the same name would break the cast and leave the feature silently
+    // disabled.
+    const auto isQwertyDevice = [](const auto& dev) {
+        return dev->getName() == "QWERTY Keyboard" &&
+               dynamic_cast<te::VirtualMidiInputDevice*>(dev.get()) != nullptr;
+    };
+
     if (!qwertyMidiDevice_) {
         // Check if it already exists (persisted from a previous session).
-        // Only accept actual VirtualMidiInputDevice instances — a physical
-        // device with the same name would break the cast and leave the
-        // feature silently disabled.
-        for (auto& dev : engine_.getDeviceManager().getMidiInDevices()) {
-            if (dev->getName() == "QWERTY Keyboard" &&
-                dynamic_cast<te::VirtualMidiInputDevice*>(dev.get())) {
-                qwertyMidiDevice_ = dev;
-                break;
-            }
-        }
+        const auto midiInputs = engine_.getDeviceManager().getMidiInDevices();
+        if (const auto found = std::ranges::find_if(midiInputs, isQwertyDevice);
+            found != midiInputs.end())
+            qwertyMidiDevice_ = *found;
 
         if (!qwertyMidiDevice_) {
             auto result = engine_.getDeviceManager().createVirtualMidiDevice("QWERTY Keyboard");
             if (result.wasOk()) {
-                for (auto& dev : engine_.getDeviceManager().getMidiInDevices()) {
-                    if (dev->getName() == "QWERTY Keyboard" &&
-                        dynamic_cast<te::VirtualMidiInputDevice*>(dev.get())) {
-                        qwertyMidiDevice_ = dev;
-                        break;
-                    }
-                }
+                const auto newMidiInputs = engine_.getDeviceManager().getMidiInDevices();
+                if (const auto found = std::ranges::find_if(newMidiInputs, isQwertyDevice);
+                    found != newMidiInputs.end())
+                    qwertyMidiDevice_ = *found;
                 if (qwertyMidiDevice_)
                     qwertyNeedsContextRefresh_ = true;
             } else {
@@ -276,12 +264,10 @@ bool MidiInputRouter::isSurfaceOnlyMidiInput(const juce::String& liveIdentifier,
         keys = surfaceOnlyMidiInputPorts_;
     }
 
-    for (const auto& key : keys) {
-        if (magda::midi::matches(key, liveIdentifier, liveName))
-            return true;
-    }
-
-    return false;
+    const auto matchesLive = [&](const juce::String& key) {
+        return magda::midi::matches(key, liveIdentifier, liveName);
+    };
+    return std::ranges::any_of(keys, matchesLive);
 }
 
 void MidiInputRouter::removeSurfaceOnlyMidiInputTargets() {
@@ -453,20 +439,21 @@ void MidiInputRouter::setTrackMidiInput(TrackId trackId, const juce::String& mid
         } else {
             auto juceDevices = juce::MidiInput::getAvailableDevices();
             juce::String deviceName;
-            for (const auto& d : juceDevices) {
-                if (d.identifier == midiDeviceId) {
-                    deviceName = d.name;
-                    break;
-                }
-            }
+            const auto matchesIdentifier = [&midiDeviceId](const auto& d) {
+                return d.identifier == midiDeviceId;
+            };
+            if (const auto found = std::ranges::find_if(juceDevices, matchesIdentifier);
+                found != juceDevices.end())
+                deviceName = found->name;
 
             if (deviceName.isNotEmpty()) {
-                for (const auto& device : dm.getMidiInDevices()) {
-                    if (device && device->getName() == deviceName) {
-                        midiDevice = device.get();
-                        break;
-                    }
-                }
+                const auto matchesName = [&deviceName](const auto& device) {
+                    return device && device->getName() == deviceName;
+                };
+                const auto midiInputs = dm.getMidiInDevices();
+                if (const auto found = std::ranges::find_if(midiInputs, matchesName);
+                    found != midiInputs.end())
+                    midiDevice = found->get();
             }
         }
 
@@ -476,13 +463,13 @@ void MidiInputRouter::setTrackMidiInput(TrackId trackId, const juce::String& mid
             // Control off on the synth); only "All Inputs" filters it out.
             if (isSurfaceOnlyMidiInput(midiDevice->getDeviceID(), midiDevice->getName())) {
                 bool removedAnyRouting = false;
-                for (auto* inputDeviceInstance : playbackContext->getAllInputs()) {
-                    if (&inputDeviceInstance->owner == midiDevice) {
-                        if (inputDeviceInstance->removeTarget(track->itemID, nullptr))
-                            removedAnyRouting = true;
-                        break;
-                    }
-                }
+                const auto matchesOwner = [midiDevice](auto* inputDeviceInstance) {
+                    return &inputDeviceInstance->owner == midiDevice;
+                };
+                const auto allInputs = playbackContext->getAllInputs();
+                if (const auto found = std::ranges::find_if(allInputs, matchesOwner);
+                    found != allInputs.end())
+                    removedAnyRouting = (*found)->removeTarget(track->itemID, nullptr);
                 if (removedAnyRouting && playbackContext->isPlaybackGraphAllocated())
                     playbackContext->reallocate();
                 return;
@@ -496,14 +483,16 @@ void MidiInputRouter::setTrackMidiInput(TrackId trackId, const juce::String& mid
                 teMonitorModeSpecific = toTeMonitorMode(trackInfo2->inputMonitor);
             midiDevice->setMonitorMode(teMonitorModeSpecific);
 
-            for (auto* inputDeviceInstance : playbackContext->getAllInputs()) {
-                if (&inputDeviceInstance->owner == midiDevice) {
-                    auto result = inputDeviceInstance->setTarget(track->itemID, true, nullptr);
-                    if (result.has_value()) {
-                        (*result)->recordEnabled = false;
-                        addedRouting = true;
-                    }
-                    break;
+            const auto matchesOwner = [midiDevice](auto* inputDeviceInstance) {
+                return &inputDeviceInstance->owner == midiDevice;
+            };
+            const auto allInputs = playbackContext->getAllInputs();
+            if (const auto found = std::ranges::find_if(allInputs, matchesOwner);
+                found != allInputs.end()) {
+                auto result = (*found)->setTarget(track->itemID, true, nullptr);
+                if (result.has_value()) {
+                    (*result)->recordEnabled = false;
+                    addedRouting = true;
                 }
             }
         }
@@ -579,13 +568,9 @@ bool MidiInputRouter::setSessionSlotMidiRecordingTarget(TrackId trackId, int sce
 
             midiDevice->setMonitorMode(teMonitorMode);
 
-            auto hadSlotTarget = false;
-            for (auto targetID : inputDeviceInstance->getTargets()) {
-                if (targetID == slot->itemID) {
-                    hadSlotTarget = true;
-                    break;
-                }
-            }
+            const auto matchesSlotTarget = [&](auto targetID) { return targetID == slot->itemID; };
+            const bool hadSlotTarget =
+                std::ranges::any_of(inputDeviceInstance->getTargets(), matchesSlotTarget);
 
             if (!hadSlotTarget) {
                 auto result = inputDeviceInstance->setTarget(slot->itemID, false, nullptr);
@@ -598,13 +583,9 @@ bool MidiInputRouter::setSessionSlotMidiRecordingTarget(TrackId trackId, int sce
             inputDeviceInstance->setRecordingEnabled(slot->itemID, true);
             armedSlot = true;
         } else {
-            bool hadSlotTarget = false;
-            for (auto targetID : inputDeviceInstance->getTargets()) {
-                if (targetID == slot->itemID) {
-                    hadSlotTarget = true;
-                    break;
-                }
-            }
+            const auto matchesSlotTarget = [&](auto targetID) { return targetID == slot->itemID; };
+            const bool hadSlotTarget =
+                std::ranges::any_of(inputDeviceInstance->getTargets(), matchesSlotTarget);
 
             if (hadSlotTarget) {
                 inputDeviceInstance->setRecordingEnabled(slot->itemID, false);
@@ -612,13 +593,11 @@ bool MidiInputRouter::setSessionSlotMidiRecordingTarget(TrackId trackId, int sce
                     changedRouting = true;
             }
 
-            bool hasTrackTarget = false;
-            for (auto targetID : inputDeviceInstance->getTargets()) {
-                if (targetID == track->itemID) {
-                    hasTrackTarget = true;
-                    break;
-                }
-            }
+            const auto matchesTrackTarget = [&](auto targetID) {
+                return targetID == track->itemID;
+            };
+            const bool hasTrackTarget =
+                std::ranges::any_of(inputDeviceInstance->getTargets(), matchesTrackTarget);
             if (hasTrackTarget)
                 inputDeviceInstance->setRecordingEnabled(track->itemID, trackInfo->recordArmed);
         }
@@ -669,25 +648,22 @@ juce::String MidiInputRouter::getTrackMidiInput(TrackId trackId) const {
     if (!playbackContext)
         return {};
 
+    const auto matchesTrackTarget = [&](auto targetID) { return targetID == track->itemID; };
+
     // Internal track routing takes precedence over hardware devices
     for (auto* inputDeviceInstance : playbackContext->getAllInputs()) {
         TrackId sourceTrackId = INVALID_TRACK_ID;
-        if (getLiveTrackMidiInputDevice(trackController_, inputDeviceInstance, &sourceTrackId)) {
-            for (auto targetID : inputDeviceInstance->getTargets()) {
-                if (targetID == track->itemID)
-                    return "track:" + juce::String(sourceTrackId);
-            }
-        }
+        if (getLiveTrackMidiInputDevice(trackController_, inputDeviceInstance, &sourceTrackId) &&
+            std::ranges::any_of(inputDeviceInstance->getTargets(), matchesTrackTarget))
+            return "track:" + juce::String(sourceTrackId);
     }
 
     juce::StringArray midiInputs;
     for (auto* inputDeviceInstance : playbackContext->getAllInputs()) {
         if (auto* midiDevice = getLiveMidiInputDevice(engine_, inputDeviceInstance)) {
-            auto targets = inputDeviceInstance->getTargets();
-            for (auto targetID : targets) {
-                if (targetID == track->itemID)
+            for (auto targetID : inputDeviceInstance->getTargets())
+                if (matchesTrackTarget(targetID))
                     midiInputs.add(midiDevice->getName());
-            }
         }
     }
 
@@ -788,12 +764,14 @@ void MidiInputRouter::resyncAllInputMonitors() {
         bool anyAuto = false;
 
         for (auto targetID : inputDeviceInstance->getTargets()) {
-            for (const auto& trackInfo : tm.getTracks()) {
+            const auto matchesTarget = [&](const TrackInfo& trackInfo) {
                 auto* track = trackController_.getAudioTrack(trackInfo.id);
-                if (!track || targetID != track->itemID)
-                    continue;
-
-                switch (trackInfo.inputMonitor) {
+                return track && targetID == track->itemID;
+            };
+            const auto& tracks = tm.getTracks();
+            if (const auto found = std::ranges::find_if(tracks, matchesTarget);
+                found != tracks.end()) {
+                switch (found->inputMonitor) {
                     case InputMonitorMode::In:
                         anyIn = true;
                         break;
@@ -803,7 +781,6 @@ void MidiInputRouter::resyncAllInputMonitors() {
                     case InputMonitorMode::Off:
                         break;
                 }
-                break;
             }
         }
 

--- a/magda/daw/audio/modifiers/ModifierSync.cpp
+++ b/magda/daw/audio/modifiers/ModifierSync.cpp
@@ -1,5 +1,7 @@
 #include "modifiers/ModifierSync.hpp"
 
+#include <algorithm>
+
 #include "modifiers/ADSRDebugLog.hpp"
 #include "modifiers/ModifierHelpers.hpp"
 
@@ -23,20 +25,18 @@ te::AutomatableParameter* resolveSameScopeModParam(
     if (teIt == scopeTeMods.end() || !teIt->second)
         return nullptr;
 
-    bool sync = false;
-    for (const auto& m : scopeMods) {
-        if (m.id == link.target.modId) {
-            sync = m.tempoSync;
-            break;
-        }
-    }
+    const auto matchesModId = [&link](const ModInfo& m) { return m.id == link.target.modId; };
+    const auto foundMod = std::ranges::find_if(scopeMods, matchesModId);
+    const bool sync = foundMod != scopeMods.end() && foundMod->tempoSync;
+
     const juce::String wantedID =
         link.target.modParamIndex == 0 ? (sync ? "rateType" : "rate") : "depth";
-    for (auto* p : teIt->second->getAutomatableParameters()) {
-        if (p && p->paramID == wantedID)
-            return p;
-    }
-    return nullptr;
+    const auto params = teIt->second->getAutomatableParameters();
+    const auto matchesParamId = [&wantedID](const te::AutomatableParameter* p) {
+        return p && p->paramID == wantedID;
+    };
+    const auto foundParam = std::ranges::find_if(params, matchesParamId);
+    return foundParam == params.end() ? nullptr : *foundParam;
 }
 
 // Insert a new TE modifier of the right type for `modInfo` into `modList`,

--- a/magda/daw/audio/plugin_manager/PluginManager.cpp
+++ b/magda/daw/audio/plugin_manager/PluginManager.cpp
@@ -514,11 +514,10 @@ void PluginManager::removeDrumGridPadDevicesLocked(const ChainNodePath& drumGrid
 }
 
 bool PluginManager::isDrumGridPadPathLocked(const ChainNodePath& devicePath) const {
-    for (const auto& entry : drumGridPadDevices_) {
-        if (entry.second.find(devicePath) != entry.second.end())
-            return true;
-    }
-    return false;
+    const auto containsDevicePath = [&](const auto& entry) {
+        return entry.second.find(devicePath) != entry.second.end();
+    };
+    return std::ranges::any_of(drumGridPadDevices_, containsDevicePath);
 }
 
 void PluginManager::detachDeviceRuntimeForChainMove(const ChainNodePath& devicePath) {
@@ -691,24 +690,15 @@ void PluginManager::validateMappingConsistency() {
         if (owner) {
             if (devicePath.trackId == MASTER_TRACK_ID) {
                 const auto& masterList = edit_.getMasterPluginList();
-                bool foundOnMaster = false;
-                for (auto i : masterList) {
-                    if (i == sd.plugin.get()) {
-                        foundOnMaster = true;
-                        break;
-                    }
-                }
-                if (foundOnMaster)
+                const auto matchesPlugin = [&](auto i) { return i == sd.plugin.get(); };
+                if (std::ranges::any_of(masterList, matchesPlugin))
                     continue;
             }
 
-            bool found = false;
-            for (auto trackId : trackController_.getAllTrackIds()) {
-                if (trackController_.getAudioTrack(trackId) == owner) {
-                    found = true;
-                    break;
-                }
-            }
+            const auto matchesOwner = [&](auto trackId) {
+                return trackController_.getAudioTrack(trackId) == owner;
+            };
+            const bool found = std::ranges::any_of(trackController_.getAllTrackIds(), matchesOwner);
             if (!found) {
             }
         }
@@ -727,17 +717,13 @@ void PluginManager::validateMappingConsistency() {
     for (auto rackId : syncedRackIds) {
         // Can't easily check trackId without exposing internals, but we can check
         // the rack exists in TrackManager
-        bool found = false;
-        for (const auto& track : TrackManager::getInstance().getTracks()) {
-            for (const auto& element : track.chain.fxChainElements) {
-                if (isRack(element) && getRack(element).id == rackId) {
-                    found = true;
-                    break;
-                }
-            }
-            if (found)
-                break;
-        }
+        const auto rackExists = [rackId](const TrackInfo& track) {
+            const auto matchesRackId = [rackId](const ChainElement& element) {
+                return isRack(element) && getRack(element).id == rackId;
+            };
+            return std::ranges::any_of(track.chain.fxChainElements, matchesRackId);
+        };
+        const bool found = std::ranges::any_of(TrackManager::getInstance().getTracks(), rackExists);
         if (!found) {
         }
     }

--- a/magda/daw/audio/plugin_manager/PluginManagerSync.cpp
+++ b/magda/daw/audio/plugin_manager/PluginManagerSync.cpp
@@ -388,8 +388,8 @@ void PluginManager::syncAllPlugins() {
 
             // Also purge stale sidechain monitors
             for (auto it = sidechainMonitors_.begin(); it != sidechainMonitors_.end();) {
-                auto trackExists = std::any_of(tracks.begin(), tracks.end(),
-                                               [&](const auto& t) { return t.id == it->first; });
+                const auto matchesId = [&](const auto& t) { return t.id == it->first; };
+                auto trackExists = std::ranges::any_of(tracks, matchesId);
                 if (!trackExists) {
                     if (it->second)
                         monitorPluginsToDelete.push_back(it->second.get());
@@ -497,8 +497,7 @@ void PluginManager::syncTrackPlugins(TrackId trackId) {
             if (isDrumGridPadPathLocked(devicePath))
                 continue;
 
-            bool found = std::find(magdaDevices.begin(), magdaDevices.end(), devicePath) !=
-                         magdaDevices.end();
+            bool found = std::ranges::find(magdaDevices, devicePath) != magdaDevices.end();
             if (!found) {
                 toRemove.push_back(devicePath);
                 pluginsToDelete.push_back(sd.plugin);
@@ -561,7 +560,7 @@ void PluginManager::syncTrackPlugins(TrackId trackId) {
     {
         auto syncedIds = rackSyncManager_.getSyncedRackIdsForTrack(trackId);
         for (auto rackId : syncedIds) {
-            if (std::find(magdaRacks.begin(), magdaRacks.end(), rackId) == magdaRacks.end()) {
+            if (std::ranges::find(magdaRacks, rackId) == magdaRacks.end()) {
                 rackSyncManager_.removeRack(rackId);
             }
         }
@@ -681,13 +680,11 @@ void PluginManager::syncTrackPlugins(TrackId trackId) {
             auto rackInstance = rackSyncManager_.syncRack(trackId, rackInfo);
             if (rackInstance) {
                 // Check if this rack instance is already on the track
-                bool alreadyOnTrack = false;
-                for (auto i : teTrack->pluginList) {
-                    if (i == rackInstance.get()) {
-                        alreadyOnTrack = true;
-                        break;
-                    }
-                }
+                const auto matchesRackInstance = [&rackInstance](auto* p) {
+                    return p == rackInstance.get();
+                };
+                const bool alreadyOnTrack =
+                    std::ranges::any_of(teTrack->pluginList, matchesRackInstance);
 
                 if (!alreadyOnTrack) {
                     teTrack->pluginList.insertPlugin(rackInstance, -1, nullptr);
@@ -731,13 +728,10 @@ void PluginManager::syncTrackPlugins(TrackId trackId) {
 
     // Any track with auxBusIndex: ensure AuxReturnPlugin exists with correct bus number
     if (trackInfo->auxBusIndex >= 0) {
-        bool hasReturn = false;
-        for (auto i : teTrack->pluginList) {
-            if (dynamic_cast<te::AuxReturnPlugin*>(i)) {
-                hasReturn = true;
-                break;
-            }
-        }
+        const auto isAuxReturn = [](auto* p) {
+            return dynamic_cast<te::AuxReturnPlugin*>(p) != nullptr;
+        };
+        const bool hasReturn = std::ranges::any_of(teTrack->pluginList, isAuxReturn);
         if (!hasReturn) {
             auto ret = edit_.getPluginCache().createNewPlugin(te::AuxReturnPlugin::xmlTypeName, {});
             if (ret) {
@@ -1395,14 +1389,14 @@ void PluginManager::reconcileSends(const TrackInfo& trackInfo, te::AudioTrack& t
     for (int i = track.pluginList.size() - 1; i >= 0; --i) {
         if (auto* auxSend = dynamic_cast<te::AuxSendPlugin*>(track.pluginList[i])) {
             const int bus = auxSend->getBusNumber();
-            if (std::find(desiredBuses.begin(), desiredBuses.end(), bus) == desiredBuses.end())
+            if (std::ranges::find(desiredBuses, bus) == desiredBuses.end())
                 auxSend->deleteFromParent();
         }
     }
 
     for (const auto& send : trackInfo.sends) {
-        const bool exists = std::find(existingSendBuses.begin(), existingSendBuses.end(),
-                                      send.busIndex) != existingSendBuses.end();
+        const bool exists =
+            std::ranges::find(existingSendBuses, send.busIndex) != existingSendBuses.end();
         if (exists)
             continue;
         auto sendPlugin =
@@ -1469,13 +1463,13 @@ void PluginManager::appendStripOrder(TrackId trackId, const TrackInfo& trackInfo
         for (const auto& send : trackInfo.sends) {
             if (send.preFader != preFader)
                 continue;
-            for (auto i : track.pluginList) {
-                if (auto* aux = dynamic_cast<te::AuxSendPlugin*>(i);
-                    aux != nullptr && aux->getBusNumber() == send.busIndex) {
-                    desiredOrder.push_back(aux);
-                    break;
-                }
-            }
+            const auto matchesBus = [busIndex = send.busIndex](auto* p) {
+                auto* aux = dynamic_cast<te::AuxSendPlugin*>(p);
+                return aux != nullptr && aux->getBusNumber() == busIndex;
+            };
+            const auto found = std::ranges::find_if(track.pluginList, matchesBus);
+            if (found != track.pluginList.end())
+                desiredOrder.push_back(*found);
         }
     };
 
@@ -1530,26 +1524,21 @@ void PluginManager::ensureVolumePluginPosition(TrackId trackId, te::AudioTrack* 
 
     // Where the fader goes: immediately before the first plugin that belongs
     // after it, or at the end when nothing does.
-    int firstPostFader = -1;
-    for (int i = 0; i < plugins.size(); ++i) {
-        if (plugins[i] == volPanRaw)
-            continue;
-        if (postFaderPlugins.count(plugins[i]) != 0) {
-            firstPostFader = i;
-            break;
-        }
-    }
+    const auto isPostFader = [volPanRaw, &postFaderPlugins](auto* p) {
+        return p != volPanRaw && postFaderPlugins.count(p) != 0;
+    };
+    const auto firstPostFaderIt = std::ranges::find_if(plugins, isPostFader);
+    const int firstPostFader =
+        firstPostFaderIt == plugins.end() ? -1 : plugins.indexOf(*firstPostFaderIt);
 
     if (firstPostFader < 0) {
         // Nothing post-fader: the fader is last but for the meter, which is the
         // rule this function has always enforced.
-        bool needsMove = false;
-        for (int i = volPanIndex + 1; i < plugins.size(); ++i) {
-            if (!dynamic_cast<te::LevelMeterPlugin*>(plugins[i])) {
-                needsMove = true;
-                break;
-            }
-        }
+        const auto isNotLevelMeter = [](auto* p) {
+            return dynamic_cast<te::LevelMeterPlugin*>(p) == nullptr;
+        };
+        const auto rest = std::ranges::subrange(plugins.begin() + volPanIndex + 1, plugins.end());
+        const bool needsMove = std::ranges::any_of(rest, isNotLevelMeter);
         if (!needsMove)
             return;
 
@@ -1667,8 +1656,7 @@ void PluginManager::syncMultiOutTrack(TrackId trackId, const TrackInfo& trackInf
             if (isDrumGridPadPathLocked(devicePath))
                 continue;
 
-            const bool found = std::find(magdaDevices.begin(), magdaDevices.end(), devicePath) !=
-                               magdaDevices.end();
+            const bool found = std::ranges::find(magdaDevices, devicePath) != magdaDevices.end();
             if (!found) {
                 toRemove.push_back(devicePath);
                 pluginsToDelete.push_back(sd.plugin);
@@ -1734,13 +1722,11 @@ void PluginManager::syncMultiOutTrack(TrackId trackId, const TrackInfo& trackInf
         rackInstance = instrumentRackManager_.createOutputInstance(
             link.sourceDeviceId, link.outputPairIndex, outPair.firstPin, outPair.numChannels);
         if (rackInstance) {
-            bool alreadyOnTrack = false;
-            for (auto i : teTrack->pluginList) {
-                if (i == rackInstance.get()) {
-                    alreadyOnTrack = true;
-                    break;
-                }
-            }
+            const auto matchesRackInstance = [&rackInstance](auto* p) {
+                return p == rackInstance.get();
+            };
+            const bool alreadyOnTrack =
+                std::ranges::any_of(teTrack->pluginList, matchesRackInstance);
             if (!alreadyOnTrack)
                 teTrack->pluginList.insertPlugin(rackInstance, -1, nullptr);
         }
@@ -1921,16 +1907,10 @@ void PluginManager::syncMasterPlugins() {
             if (!sd.plugin)
                 continue;
             // Check if plugin belongs to master plugin list
-            bool belongsToMaster = false;
-            for (auto i : masterList) {
-                if (i == sd.plugin.get()) {
-                    belongsToMaster = true;
-                    break;
-                }
-            }
+            const auto matchesPlugin = [&sd](auto* p) { return p == sd.plugin.get(); };
+            const bool belongsToMaster = std::ranges::any_of(masterList, matchesPlugin);
             if (belongsToMaster) {
-                bool found = std::find(magdaDevices.begin(), magdaDevices.end(), devicePath) !=
-                             magdaDevices.end();
+                bool found = std::ranges::find(magdaDevices, devicePath) != magdaDevices.end();
                 if (!found) {
                     toRemove.push_back(devicePath);
                     pluginsToDelete.push_back(sd.plugin);
@@ -2683,14 +2663,14 @@ void PluginManager::drumGridChainsChanged(daw::audio::DrumGridPlugin* plugin) {
 
     {
         juce::ScopedLock lock(pluginLock_);
-        for (const auto& [devicePath, synced] : syncedDevices_) {
-            const auto deviceId = devicePath.getDeviceId();
-            if (synced.plugin.get() == plugin ||
-                instrumentRackManager_.getInnerPlugin(deviceId) == plugin) {
-                matchedPath = devicePath;
-                foundMatch = true;
-                break;
-            }
+        const auto matchesPlugin = [this, plugin](const auto& entry) {
+            return entry.second.plugin.get() == plugin ||
+                   instrumentRackManager_.getInnerPlugin(entry.first.getDeviceId()) == plugin;
+        };
+        if (const auto found = std::ranges::find_if(syncedDevices_, matchesPlugin);
+            found != syncedDevices_.end()) {
+            matchedPath = found->first;
+            foundMatch = true;
         }
     }
 
@@ -2906,11 +2886,11 @@ DeviceInfo* PluginManager::padDeviceFor(const ChainNodePath& drumGridPath,
         return nullptr;
 
     const auto deviceId = padDevicePath.getDeviceId();
-    for (auto& element : pad->elements)
-        if (isDevice(element) && getDevice(element).id == deviceId)
-            return &getDevice(element);
-
-    return nullptr;
+    const auto matchesDeviceId = [deviceId](auto& element) {
+        return isDevice(element) && getDevice(element).id == deviceId;
+    };
+    const auto found = std::ranges::find_if(pad->elements, matchesDeviceId);
+    return found == pad->elements.end() ? nullptr : &getDevice(*found);
 }
 
 void PluginManager::syncDrumGridMultiOutTracks(const ChainNodePath& drumGridPath,

--- a/magda/daw/audio/plugins/DrumGridPlugin.cpp
+++ b/magda/daw/audio/plugins/DrumGridPlugin.cpp
@@ -376,12 +376,12 @@ juce::String DrumGridPlugin::padStructureFingerprint(const magda::RackInfo& pads
 std::unique_ptr<DrumGridPlugin::Chain> DrumGridPlugin::takeChain(int index, bool& created) {
     created = false;
 
-    for (auto it = chains_.begin(); it != chains_.end(); ++it) {
-        if ((*it)->index == index) {
-            auto existing = std::move(*it);
-            chains_.erase(it);
-            return existing;
-        }
+    const auto matchesIndex = [index](const auto& chain) { return chain->index == index; };
+    const auto found = std::ranges::find_if(chains_, matchesIndex);
+    if (found != chains_.end()) {
+        auto existing = std::move(*found);
+        chains_.erase(found);
+        return existing;
     }
 
     created = true;
@@ -474,14 +474,15 @@ void DrumGridPlugin::syncPadPlugins(Chain& chain, const magda::ChainInfo& pad,
         // does not rebuild the instrument under it and cut the note it is
         // playing. Matched on the DeviceId the plugin carries, which is the one
         // thing the model and the mirror agree on.
+        const auto matchesDeviceId = [&padDevice](const auto& p) {
+            return p != nullptr &&
+                   static_cast<int>(p->state.getProperty(pluginDeviceIdProp, -1)) == padDevice.id;
+        };
+        const auto found = std::ranges::find_if(chain.plugins, matchesDeviceId);
         te::Plugin::Ptr plugin;
-        for (auto it = chain.plugins.begin(); it != chain.plugins.end(); ++it) {
-            if (*it != nullptr && static_cast<int>((*it)->state.getProperty(pluginDeviceIdProp,
-                                                                            -1)) == padDevice.id) {
-                plugin = *it;
-                chain.plugins.erase(it);
-                break;
-            }
+        if (found != chain.plugins.end()) {
+            plugin = *found;
+            chain.plugins.erase(found);
         }
 
         if (plugin == nullptr) {
@@ -621,27 +622,27 @@ int DrumGridPlugin::getPluginDeviceId(int chainIndex, int pluginIndex) const {
 }
 
 const DrumGridPlugin::Chain* DrumGridPlugin::getChainForNote(int midiNote) const {
-    for (const auto& chain : chains_) {
-        if (midiNote >= chain->lowNote && midiNote <= chain->highNote)
-            return chain.get();
-    }
-    return nullptr;
+    const auto inRange = [midiNote](const auto& chain) {
+        return midiNote >= chain->lowNote && midiNote <= chain->highNote;
+    };
+    const auto found = std::ranges::find_if(chains_, inRange);
+    return found == chains_.end() ? nullptr : found->get();
 }
 
 const DrumGridPlugin::Chain* DrumGridPlugin::getChainByIndex(int chainIndex) const {
-    for (const auto& chain : chains_) {
-        if (chain->index == chainIndex)
-            return chain.get();
-    }
-    return nullptr;
+    const auto matchesIndex = [chainIndex](const auto& chain) {
+        return chain->index == chainIndex;
+    };
+    const auto found = std::ranges::find_if(chains_, matchesIndex);
+    return found == chains_.end() ? nullptr : found->get();
 }
 
 DrumGridPlugin::Chain* DrumGridPlugin::getChainByIndexMutable(int chainIndex) {
-    for (auto& chain : chains_) {
-        if (chain->index == chainIndex)
-            return chain.get();
-    }
-    return nullptr;
+    const auto matchesIndex = [chainIndex](const auto& chain) {
+        return chain->index == chainIndex;
+    };
+    const auto found = std::ranges::find_if(chains_, matchesIndex);
+    return found == chains_.end() ? nullptr : found->get();
 }
 
 int DrumGridPlugin::getChainPluginCount(int chainIndex) const {

--- a/magda/daw/audio/plugins/InternalPluginRegistry.cpp
+++ b/magda/daw/audio/plugins/InternalPluginRegistry.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <mutex>
+#include <ranges>
 #include <vector>
 
 #include "plugins/MagdaDevice.hpp"
@@ -14,12 +15,11 @@ bool typeMatchesAlias(const juce::String& type, const InternalPluginSpec& spec) 
     if (spec.pluginId != nullptr && type.equalsIgnoreCase(spec.pluginId))
         return true;
 
-    for (int i = 0; i < spec.loadAliasCount; ++i)
-        if (spec.loadAliases != nullptr && spec.loadAliases[i] != nullptr &&
-            type.equalsIgnoreCase(spec.loadAliases[i]))
-            return true;
-
-    return false;
+    const auto matchesAlias = [&](int i) {
+        return spec.loadAliases != nullptr && spec.loadAliases[i] != nullptr &&
+               type.equalsIgnoreCase(spec.loadAliases[i]);
+    };
+    return std::ranges::any_of(std::views::iota(0, std::max(0, spec.loadAliasCount)), matchesAlias);
 }
 
 const juce::Identifier& typeProperty() {
@@ -50,9 +50,11 @@ bool InternalPluginRegistry::registerPlugin(InternalPluginSpec spec) {
             return false;
         if (findForLoadType(spec.loadAliases[i]) != nullptr)
             return false;
-        for (int previous = 0; previous < i; ++previous)
-            if (juce::String(spec.loadAliases[i]).equalsIgnoreCase(spec.loadAliases[previous]))
-                return false;
+        const auto duplicatesEarlier = [&](int previous) {
+            return juce::String(spec.loadAliases[i]).equalsIgnoreCase(spec.loadAliases[previous]);
+        };
+        if (std::ranges::any_of(std::views::iota(0, i), duplicatesEarlier))
+            return false;
     }
 
     auto owned = std::make_unique<InternalPluginSpec>(std::move(spec));
@@ -65,11 +67,11 @@ bool InternalPluginRegistry::registerParameterAlias(InternalParameterAliasSpec a
     if (alias.pluginKey == nullptr || alias.alias == nullptr || alias.paramIndex < 0)
         return false;
 
-    const auto duplicate = std::find_if(
-        parameterAliases_.begin(), parameterAliases_.end(), [&alias](const auto& existing) {
-            return juce::String(existing.pluginKey).equalsIgnoreCase(alias.pluginKey) &&
-                   juce::String(existing.alias).equalsIgnoreCase(alias.alias);
-        });
+    const auto matchesAlias = [&alias](const auto& existing) {
+        return juce::String(existing.pluginKey).equalsIgnoreCase(alias.pluginKey) &&
+               juce::String(existing.alias).equalsIgnoreCase(alias.alias);
+    };
+    const auto duplicate = std::ranges::find_if(parameterAliases_, matchesAlias);
     if (duplicate != parameterAliases_.end())
         return false;
 
@@ -90,10 +92,9 @@ const InternalPluginSpec* InternalPluginRegistry::find(const juce::String& plugi
 }
 
 const InternalPluginSpec* InternalPluginRegistry::findForLoadType(const juce::String& type) const {
-    for (const auto& spec : specs_)
-        if (typeMatchesAlias(type, *spec))
-            return spec.get();
-    return nullptr;
+    const auto matchesType = [&type](const auto& spec) { return typeMatchesAlias(type, *spec); };
+    const auto found = std::ranges::find_if(specs_, matchesType);
+    return found == specs_.end() ? nullptr : found->get();
 }
 
 bool registerDevicePack(DevicePackRegistration registerDevices) {
@@ -102,9 +103,8 @@ bool registerDevicePack(DevicePackRegistration registerDevices) {
 
     auto& state = registryState();
     const std::scoped_lock lock(state.mutex);
-    if (state.initialized ||
-        std::find(state.packRegistrations.begin(), state.packRegistrations.end(),
-                  registerDevices) != state.packRegistrations.end())
+    if (state.initialized || std::ranges::find(state.packRegistrations, registerDevices) !=
+                                 state.packRegistrations.end())
         return false;
 
     state.packRegistrations.push_back(registerDevices);
@@ -144,11 +144,11 @@ const InternalPluginSpec* findInternalPluginSpecForLoadType(const juce::String& 
 bool internalPluginHasTag(const InternalPluginSpec& spec, const char* tag) {
     if (tag == nullptr)
         return false;
-    for (int i = 0; i < spec.tagCount; ++i)
-        if (spec.tags != nullptr && spec.tags[i] != nullptr &&
-            juce::String(spec.tags[i]).equalsIgnoreCase(tag))
-            return true;
-    return false;
+    const auto matchesTag = [&](int i) {
+        return spec.tags != nullptr && spec.tags[i] != nullptr &&
+               juce::String(spec.tags[i]).equalsIgnoreCase(tag);
+    };
+    return std::ranges::any_of(std::views::iota(0, std::max(0, spec.tagCount)), matchesTag);
 }
 
 bool internalPluginHasTag(const juce::String& pluginId, const char* tag) {
@@ -158,10 +158,10 @@ bool internalPluginHasTag(const juce::String& pluginId, const char* tag) {
 }
 
 const InternalPluginSpec* findInternalPluginSpecWithTag(const char* tag) {
-    for (const auto* spec : getAllInternalPluginSpecs())
-        if (internalPluginHasTag(*spec, tag))
-            return spec;
-    return nullptr;
+    const auto hasTag = [tag](const auto* spec) { return internalPluginHasTag(*spec, tag); };
+    const auto specs = getAllInternalPluginSpecs();
+    const auto found = std::ranges::find_if(specs, hasTag);
+    return found == specs.end() ? nullptr : *found;
 }
 
 bool isInternalAnalysisPlugin(const juce::String& pluginId) {

--- a/magda/daw/audio/plugins/compiled/CompiledPluginRegistry.cpp
+++ b/magda/daw/audio/plugins/compiled/CompiledPluginRegistry.cpp
@@ -1,6 +1,8 @@
 #include "CompiledPluginRegistry.hpp"
 
+#include <algorithm>
 #include <iterator>
+#include <ranges>
 
 namespace magda::daw::audio::compiled {
 
@@ -66,18 +68,20 @@ std::span<const CompiledPluginSpec* const> getAllCompiledPluginSpecs() {
 }
 
 const CompiledPluginSpec* findCompiledPluginSpec(const juce::String& pluginId) {
-    for (const auto* spec : kAllSpecs) {
+    const auto matchesSpec = [&pluginId](const auto* spec) {
         if (pluginId.equalsIgnoreCase(spec->pluginId))
-            return spec;
-
+            return true;
         if (spec->aliasKey != nullptr && pluginId.equalsIgnoreCase(spec->aliasKey))
-            return spec;
-
-        for (int i = 0; i < spec->loadAliasCount; ++i)
-            if (spec->loadAliases[i] != nullptr && pluginId.equalsIgnoreCase(spec->loadAliases[i]))
-                return spec;
-    }
-    return nullptr;
+            return true;
+        const auto matchesLoadAlias = [&](int i) {
+            return spec->loadAliases[i] != nullptr &&
+                   pluginId.equalsIgnoreCase(spec->loadAliases[i]);
+        };
+        return std::ranges::any_of(std::views::iota(0, std::max(0, spec->loadAliasCount)),
+                                   matchesLoadAlias);
+    };
+    const auto found = std::ranges::find_if(kAllSpecs, matchesSpec);
+    return found == std::end(kAllSpecs) ? nullptr : *found;
 }
 
 }  // namespace magda::daw::audio::compiled

--- a/magda/daw/audio/racks/RackSyncManager.cpp
+++ b/magda/daw/audio/racks/RackSyncManager.cpp
@@ -1,5 +1,7 @@
 #include "racks/RackSyncManager.hpp"
 
+#include <algorithm>
+
 #include "../../core/DrumGridPads.hpp"
 #include "TracktionHelpers.hpp"
 #include "core/ChainRoutingModel.hpp"
@@ -64,11 +66,12 @@ void ensureRackOutputPair(te::RackType& rackType, int outputIndex) {
 }
 
 te::Plugin* findRackPlugin(te::RackType& rackType, te::EditItemID id) {
-    for (auto* plugin : rackType.getPlugins()) {
-        if (plugin && plugin->itemID == id)
-            return plugin;
-    }
-    return nullptr;
+    const auto plugins = rackType.getPlugins();
+    const auto matchesId = [id](const te::Plugin* plugin) {
+        return plugin && plugin->itemID == id;
+    };
+    const auto found = std::ranges::find_if(plugins, matchesId);
+    return found == plugins.end() ? nullptr : *found;
 }
 
 int getAudioInputCount(te::RackType& rackType, te::EditItemID id) {
@@ -371,13 +374,11 @@ std::unordered_map<TrackId, RackSyncManager::TrackMeteringInfo> RackSyncManager:
 }
 
 te::Plugin* RackSyncManager::getInnerPlugin(DeviceId deviceId) const {
-    for (const auto& [rackId, synced] : syncedRacks_) {
-        auto it = synced.innerPlugins.find(deviceId);
-        if (it != synced.innerPlugins.end()) {
-            return it->second.get();
-        }
-    }
-    return nullptr;
+    const auto hasDevice = [deviceId](const auto& entry) {
+        return entry.second.innerPlugins.contains(deviceId);
+    };
+    const auto found = std::ranges::find_if(syncedRacks_, hasDevice);
+    return found == syncedRacks_.end() ? nullptr : found->second.innerPlugins.at(deviceId).get();
 }
 
 void RackSyncManager::syncSidechains(
@@ -435,24 +436,21 @@ bool RackSyncManager::isRackInstance(te::Plugin* plugin) const {
     if (!plugin)
         return false;
 
-    for (const auto& [rackId, synced] : syncedRacks_) {
-        if (synced.rackInstance.get() == plugin) {
-            return true;
-        }
-    }
-    return false;
+    const auto matchesInstance = [plugin](const auto& entry) {
+        return entry.second.rackInstance.get() == plugin;
+    };
+    return std::ranges::any_of(syncedRacks_, matchesInstance);
 }
 
 RackId RackSyncManager::getRackIdForInstance(te::Plugin* plugin) const {
     if (!plugin)
         return INVALID_RACK_ID;
 
-    for (const auto& [rackId, synced] : syncedRacks_) {
-        if (synced.rackInstance.get() == plugin) {
-            return rackId;
-        }
-    }
-    return INVALID_RACK_ID;
+    const auto matchesInstance = [plugin](const auto& entry) {
+        return entry.second.rackInstance.get() == plugin;
+    };
+    const auto found = std::ranges::find_if(syncedRacks_, matchesInstance);
+    return found == syncedRacks_.end() ? INVALID_RACK_ID : found->first;
 }
 
 void RackSyncManager::capturePluginStates(SyncedRack& synced) {
@@ -641,20 +639,19 @@ te::AutomatableParameter* RackSyncManager::findRackModifierParameter(RackId rack
     auto& tm = TrackManager::getInstance();
     auto resolved = tm.resolvePath(ChainNodePath::rack(rackIt->second.trackId, rackId));
     if (resolved.valid && resolved.rack) {
-        for (const auto& m : resolved.rack->mods) {
-            if (m.id == modId) {
-                sync = m.tempoSync;
-                break;
-            }
-        }
+        const auto matchesModId = [modId](const ModInfo& m) { return m.id == modId; };
+        const auto foundMod = std::ranges::find_if(resolved.rack->mods, matchesModId);
+        if (foundMod != resolved.rack->mods.end())
+            sync = foundMod->tempoSync;
     }
     const juce::String wantedID = paramIndex == 0 ? (sync ? "rateType" : "rate") : "depth";
 
-    for (auto* p : modIt->second->getAutomatableParameters()) {
-        if (p && p->paramID == wantedID)
-            return p;
-    }
-    return nullptr;
+    const auto params = modIt->second->getAutomatableParameters();
+    const auto matchesParamId = [&wantedID](const te::AutomatableParameter* p) {
+        return p && p->paramID == wantedID;
+    };
+    const auto foundParam = std::ranges::find_if(params, matchesParamId);
+    return foundParam == params.end() ? nullptr : *foundParam;
 }
 
 void RackSyncManager::resyncAllModifiers(TrackId trackId) {
@@ -816,13 +813,8 @@ void RackSyncManager::buildConnectionsForRack(SyncedRack& synced, const RackInfo
     auto rackIOId = te::EditItemID();  // Default = rack I/O
 
     // Determine if any chain is soloed
-    bool anySoloed = false;
-    for (const auto& chain : rackInfo.chains) {
-        if (chain.solo) {
-            anySoloed = true;
-            break;
-        }
-    }
+    const auto isSoloed = [](const ChainInfo& chain) { return chain.solo; };
+    const bool anySoloed = std::ranges::any_of(rackInfo.chains, isSoloed);
 
     bool anyChainConnectedToOutput = false;
 
@@ -992,21 +984,27 @@ bool RackSyncManager::structureChanged(const SyncedRack& synced, const RackInfo&
 
     if (synced.chainVolPanPlugins.size() != expectedChains.size())
         return true;
-    for (const auto& chainKey : expectedChains)
-        if (synced.chainVolPanPlugins.find(chainKey) == synced.chainVolPanPlugins.end())
-            return true;
+    const auto missingChainVolPan = [&synced](const juce::String& chainKey) {
+        return !synced.chainVolPanPlugins.contains(chainKey);
+    };
+    if (std::ranges::any_of(expectedChains, missingChainVolPan))
+        return true;
 
     if (synced.innerPlugins.size() != expectedDevices.size())
         return true;
-    for (auto deviceId : expectedDevices)
-        if (synced.innerPlugins.find(deviceId) == synced.innerPlugins.end())
-            return true;
+    const auto missingInnerPlugin = [&synced](DeviceId deviceId) {
+        return !synced.innerPlugins.contains(deviceId);
+    };
+    if (std::ranges::any_of(expectedDevices, missingInnerPlugin))
+        return true;
 
     if (synced.nestedRackInstances.size() != expectedNestedRacks.size())
         return true;
-    for (const auto& key : expectedNestedRacks)
-        if (synced.nestedRackInstances.find(key) == synced.nestedRackInstances.end())
-            return true;
+    const auto missingNestedRack = [&synced](const juce::String& key) {
+        return !synced.nestedRackInstances.contains(key);
+    };
+    if (std::ranges::any_of(expectedNestedRacks, missingNestedRack))
+        return true;
 
     return false;
 }
@@ -1337,21 +1335,19 @@ bool RackSyncManager::needsModifierResync(TrackId trackId) const {
     if (!trackInfo)
         return false;
 
-    for (const auto& element : trackInfo->chain.fxChainElements) {
+    const auto rackNeedsResync = [this](const ChainElement& element) {
         if (!isRack(element))
-            continue;
+            return false;
 
         const auto& rack = getRack(element);
-        auto it = syncedRacks_.find(rack.id);
-        if (it == syncedRacks_.end())
-            continue;
+        if (!syncedRacks_.contains(rack.id))
+            return false;
 
         auto storedIt = rackFingerprints_.find(rack.id);
-        if (storedIt == rackFingerprints_.end() || computeRackFingerprint(rack) != storedIt->second)
-            return true;
-    }
-
-    return false;
+        return storedIt == rackFingerprints_.end() ||
+               computeRackFingerprint(rack) != storedIt->second;
+    };
+    return std::ranges::any_of(trackInfo->chain.fxChainElements, rackNeedsResync);
 }
 
 void RackSyncManager::collectLFOModifiers(TrackId trackId,
@@ -1476,18 +1472,17 @@ void RackSyncManager::collectLFOModifiersWithModesForSidechainSource(
         if (rack.sidechain.sourceTrackId == sourceTrackId)
             return true;
 
-        for (const auto& chain : rack.chains) {
-            for (const auto& element : chain.elements) {
-                if (isDevice(element)) {
-                    if (getDevice(element).sidechain.sourceTrackId == sourceTrackId)
-                        return true;
-                } else if (isRack(element)) {
-                    if (self(self, getRack(element)))
-                        return true;
-                }
-            }
-        }
-        return false;
+        const auto elementContainsSource = [&](const ChainElement& element) {
+            if (isDevice(element))
+                return getDevice(element).sidechain.sourceTrackId == sourceTrackId;
+            if (isRack(element))
+                return self(self, getRack(element));
+            return false;
+        };
+        const auto chainContainsSource = [&](const ChainInfo& chain) {
+            return std::ranges::any_of(chain.elements, elementContainsSource);
+        };
+        return std::ranges::any_of(rack.chains, chainContainsSource);
     };
 
     for (const auto& entry : syncedRacks_) {

--- a/magda/daw/core/AutomationCommands.cpp
+++ b/magda/daw/core/AutomationCommands.cpp
@@ -24,20 +24,18 @@ static const AutomationPoint* findPointInLane(AutomationLaneId laneId, Automatio
     auto* lane = AutomationManager::getInstance().getLane(laneId);
     if (!lane)
         return nullptr;
-    for (const auto& p : lane->absolutePoints)
-        if (p.id == pointId)
-            return &p;
-    return nullptr;
+    const auto matchesPointId = [pointId](const AutomationPoint& p) { return p.id == pointId; };
+    const auto found = std::ranges::find_if(lane->absolutePoints, matchesPointId);
+    return found == lane->absolutePoints.end() ? nullptr : &(*found);
 }
 
 static const AutomationPoint* findPointInClip(AutomationClipId clipId, AutomationPointId pointId) {
     auto* clip = AutomationManager::getInstance().getClip(clipId);
     if (!clip)
         return nullptr;
-    for (const auto& p : clip->points)
-        if (p.id == pointId)
-            return &p;
-    return nullptr;
+    const auto matchesPointId = [pointId](const AutomationPoint& p) { return p.id == pointId; };
+    const auto found = std::ranges::find_if(clip->points, matchesPointId);
+    return found == clip->points.end() ? nullptr : &(*found);
 }
 
 static const AutomationPoint* findPoint(bool isClip, AutomationLaneId laneId,
@@ -267,12 +265,11 @@ bool DuplicateAutomationTimeSelectionCommand::shouldDuplicateLane(
     if (lane.target.kind == ControlTarget::Kind::Tempo)
         return false;
     if (!laneIds_.empty()) {
-        return std::find(laneIds_.begin(), laneIds_.end(), lane.id) != laneIds_.end();
+        return std::ranges::find(laneIds_, lane.id) != laneIds_.end();
     }
     if (trackIds_.empty())
         return true;
-    return std::find(trackIds_.begin(), trackIds_.end(), lane.target.devicePath.trackId) !=
-           trackIds_.end();
+    return std::ranges::find(trackIds_, lane.target.devicePath.trackId) != trackIds_.end();
 }
 
 // ============================================================================
@@ -640,16 +637,15 @@ bool DuplicateAutomationTimeSelectionCommand::canDuplicatePoints() const {
         return false;
 
     const auto& mgr = AutomationManager::getInstance();
-    for (const auto& lane : mgr.getLanes()) {
+    const auto laneHasPointInRange = [&](const AutomationLaneInfo& lane) {
         if (!shouldDuplicateLane(lane))
-            continue;
-
-        for (const auto& point : lane.absolutePoints) {
-            if (pointIsInDuplicateRange(point.beatPosition, startBeat_, endBeat_))
-                return true;
-        }
-    }
-    return false;
+            return false;
+        const auto inRange = [&](const AutomationPoint& point) {
+            return pointIsInDuplicateRange(point.beatPosition, startBeat_, endBeat_);
+        };
+        return std::ranges::any_of(lane.absolutePoints, inRange);
+    };
+    return std::ranges::any_of(mgr.getLanes(), laneHasPointInRange);
 }
 
 void DuplicateAutomationTimeSelectionCommand::execute() {
@@ -715,12 +711,11 @@ bool InsertTimeAutomationCommand::shouldShiftLane(const AutomationLaneInfo& lane
     if (lane.target.kind == ControlTarget::Kind::Tempo)
         return false;
     if (!laneIds_.empty()) {
-        return std::find(laneIds_.begin(), laneIds_.end(), lane.id) != laneIds_.end();
+        return std::ranges::find(laneIds_, lane.id) != laneIds_.end();
     }
     if (trackIds_.empty())
         return true;
-    return std::find(trackIds_.begin(), trackIds_.end(), lane.target.devicePath.trackId) !=
-           trackIds_.end();
+    return std::ranges::find(trackIds_, lane.target.devicePath.trackId) != trackIds_.end();
 }
 
 bool InsertTimeAutomationCommand::canShiftPoints() const {
@@ -729,15 +724,15 @@ bool InsertTimeAutomationCommand::canShiftPoints() const {
 
     constexpr double epsilon = 1.0e-9;
     const auto& mgr = AutomationManager::getInstance();
-    for (const auto& lane : mgr.getLanes()) {
+    const auto laneHasPointToShift = [&](const AutomationLaneInfo& lane) {
         if (!shouldShiftLane(lane))
-            continue;
-        for (const auto& point : lane.absolutePoints) {
-            if (point.beatPosition >= insertBeat_ - epsilon)
-                return true;
-        }
-    }
-    return false;
+            return false;
+        const auto afterInsertBeat = [&](const AutomationPoint& point) {
+            return point.beatPosition >= insertBeat_ - epsilon;
+        };
+        return std::ranges::any_of(lane.absolutePoints, afterInsertBeat);
+    };
+    return std::ranges::any_of(mgr.getLanes(), laneHasPointToShift);
 }
 
 void InsertTimeAutomationCommand::execute() {

--- a/magda/daw/core/AutomationManager.cpp
+++ b/magda/daw/core/AutomationManager.cpp
@@ -81,13 +81,14 @@ static std::optional<double> getCurrentTargetValueImpl(const AutomationTarget& t
             const auto* track = TrackManager::getInstance().getTrack(target.devicePath.trackId);
             if (!track)
                 return 0.75;
-            for (const auto& send : track->sends) {
-                if (send.busIndex == target.sendBusIndex) {
-                    float db = gainToDb(send.level);
-                    return static_cast<double>(ParameterUtils::realToNormalized(db, paramInfo));
-                }
-            }
-            return 0.75;  // Default to unity when bus not found
+            const auto matchesBus = [&target](const SendInfo& send) {
+                return send.busIndex == target.sendBusIndex;
+            };
+            const auto found = std::ranges::find_if(track->sends, matchesBus);
+            if (found == track->sends.end())
+                return 0.75;  // Default to unity when bus not found
+            const float db = gainToDb(found->level);
+            return static_cast<double>(ParameterUtils::realToNormalized(db, paramInfo));
         }
         case ControlTarget::Kind::PluginParam: {
             // Prefer the live engine parameter: DeviceInfo::currentValue can
@@ -150,29 +151,24 @@ static std::optional<double> getCurrentTargetValueImpl(const AutomationTarget& t
             const auto* track = TrackManager::getInstance().getTrack(target.devicePath.trackId);
             if (!track)
                 return std::nullopt;
+            const auto matchesModId = [&target](const ModInfo& m) { return m.id == target.modId; };
             const ModInfo* mod = nullptr;
             if (target.devicePath.isValid()) {
                 auto resolved = TrackManager::getInstance().resolvePath(target.devicePath);
                 if (resolved.valid && resolved.rack) {
-                    for (const auto& m : resolved.rack->mods)
-                        if (m.id == target.modId) {
-                            mod = &m;
-                            break;
-                        }
+                    const auto found = std::ranges::find_if(resolved.rack->mods, matchesModId);
+                    if (found != resolved.rack->mods.end())
+                        mod = &(*found);
                 } else if (resolved.valid && resolved.device) {
-                    for (const auto& m : resolved.device->mods)
-                        if (m.id == target.modId) {
-                            mod = &m;
-                            break;
-                        }
+                    const auto found = std::ranges::find_if(resolved.device->mods, matchesModId);
+                    if (found != resolved.device->mods.end())
+                        mod = &(*found);
                 }
             }
             if (!mod) {
-                for (const auto& m : track->mods)
-                    if (m.id == target.modId) {
-                        mod = &m;
-                        break;
-                    }
+                const auto found = std::ranges::find_if(track->mods, matchesModId);
+                if (found != track->mods.end())
+                    mod = &(*found);
             }
             if (!mod)
                 return std::nullopt;
@@ -412,19 +408,15 @@ void AutomationManager::deleteLane(AutomationLaneId laneId) {
 }
 
 AutomationLaneInfo* AutomationManager::getLane(AutomationLaneId laneId) {
-    for (auto& lane : lanes_) {
-        if (lane.id == laneId)
-            return &lane;
-    }
-    return nullptr;
+    const auto matchesId = [laneId](const AutomationLaneInfo& lane) { return lane.id == laneId; };
+    const auto found = std::ranges::find_if(lanes_, matchesId);
+    return found == lanes_.end() ? nullptr : &(*found);
 }
 
 const AutomationLaneInfo* AutomationManager::getLane(AutomationLaneId laneId) const {
-    for (const auto& lane : lanes_) {
-        if (lane.id == laneId)
-            return &lane;
-    }
-    return nullptr;
+    const auto matchesId = [laneId](const AutomationLaneInfo& lane) { return lane.id == laneId; };
+    const auto found = std::ranges::find_if(lanes_, matchesId);
+    return found == lanes_.end() ? nullptr : &(*found);
 }
 
 std::vector<AutomationLaneId> AutomationManager::getLanesForTrack(TrackId trackId) const {
@@ -511,7 +503,7 @@ void AutomationManager::dispatchAuthorityEvent(AutomationLaneId laneId,
 }
 
 void AutomationManager::setTargetUserTouched(const AutomationTarget& target, bool touched) {
-    auto it = std::find(userTouchedTargets_.begin(), userTouchedTargets_.end(), target);
+    auto it = std::ranges::find(userTouchedTargets_, target);
     if (touched) {
         if (it == userTouchedTargets_.end())
             userTouchedTargets_.push_back(target);
@@ -521,8 +513,7 @@ void AutomationManager::setTargetUserTouched(const AutomationTarget& target, boo
 }
 
 bool AutomationManager::isTargetUserTouched(const AutomationTarget& target) const {
-    return std::find(userTouchedTargets_.begin(), userTouchedTargets_.end(), target) !=
-           userTouchedTargets_.end();
+    return std::ranges::find(userTouchedTargets_, target) != userTouchedTargets_.end();
 }
 
 std::vector<AutomationTarget> AutomationManager::getUserTouchedTargets() const {
@@ -835,7 +826,7 @@ void AutomationManager::moveClipToFront(AutomationClipId clipId) {
     if (lane == nullptr)
         return;
     auto& ids = lane->clipIds;
-    auto it = std::find(ids.begin(), ids.end(), clipId);
+    auto it = std::ranges::find(ids, clipId);
     if (it == ids.end() || it == ids.begin())
         return;
     ids.erase(it);
@@ -1123,8 +1114,8 @@ void AutomationManager::notifyClipsChanged(AutomationLaneId laneId) {
 
 void AutomationManager::notifyPointsChanged(AutomationLaneId laneId) {
     if (notificationBatchDepth_ > 0) {
-        if (std::find(pendingPointsChangedLanes_.begin(), pendingPointsChangedLanes_.end(),
-                      laneId) == pendingPointsChangedLanes_.end()) {
+        if (std::ranges::find(pendingPointsChangedLanes_, laneId) ==
+            pendingPointsChangedLanes_.end()) {
             pendingPointsChangedLanes_.push_back(laneId);
         }
         return;
@@ -1212,7 +1203,7 @@ void AutomationManager::restoreClip(AutomationClipInfo& clip) {
     // delete) re-inserts the lane with its clipIds intact, so this is a
     // no-op there.
     if (auto* lane = getLane(laneId)) {
-        if (std::find(lane->clipIds.begin(), lane->clipIds.end(), clipId) == lane->clipIds.end())
+        if (std::ranges::find(lane->clipIds, clipId) == lane->clipIds.end())
             lane->clipIds.push_back(clipId);
     }
 

--- a/magda/daw/core/ClipManager.cpp
+++ b/magda/daw/core/ClipManager.cpp
@@ -958,7 +958,7 @@ void ClipManager::forceNotifyMultipleClipPropertiesChanged(const std::vector<Cli
         return;
     auto listenersCopy = listeners_;
     for (auto* listener : listenersCopy) {
-        if (std::find(listeners_.begin(), listeners_.end(), listener) != listeners_.end()) {
+        if (std::ranges::find(listeners_, listener) != listeners_.end()) {
             listener->clipPropertiesChanged(clipIds);
         }
     }
@@ -2825,15 +2825,15 @@ std::vector<ClipId> ClipManager::getClipsOnTrack(TrackId trackId, ClipView view)
 
 ClipId ClipManager::getClipAtPosition(TrackId trackId, double time) const {
     const double bpm = currentProjectTempoOrDefault();
-    for (const auto& [id, clip] : clips_) {
+    const auto coversTime = [&](const auto& entry) {
+        const auto& clip = entry.second;
         const double clipStart = clip.getTimelineStart(bpm);
         const double clipEnd = clip.getTimelineEnd(bpm);
-        if (clip.view == ClipView::Arrangement && clip.trackId == trackId && time >= clipStart &&
-            time < clipEnd) {
-            return clip.id;
-        }
-    }
-    return INVALID_CLIP_ID;
+        return clip.view == ClipView::Arrangement && clip.trackId == trackId && time >= clipStart &&
+               time < clipEnd;
+    };
+    const auto found = std::ranges::find_if(clips_, coversTime);
+    return found == clips_.end() ? INVALID_CLIP_ID : found->second.id;
 }
 
 std::vector<ClipId> ClipManager::getClipsInRange(TrackId trackId, double startTime,
@@ -2939,7 +2939,7 @@ void ClipManager::stopAllClips() {
 // ============================================================================
 
 void ClipManager::addListener(ClipManagerListener* listener) {
-    if (listener && std::find(listeners_.begin(), listeners_.end(), listener) == listeners_.end()) {
+    if (listener && std::ranges::find(listeners_, listener) == listeners_.end()) {
         listeners_.push_back(listener);
     }
 }
@@ -3043,7 +3043,7 @@ void ClipManager::notifyClipsChanged() {
     // (e.g., ClipComponent destroyed when TrackContentPanel rebuilds)
     auto listenersCopy = listeners_;
     for (auto* listener : listenersCopy) {
-        if (std::find(listeners_.begin(), listeners_.end(), listener) != listeners_.end()) {
+        if (std::ranges::find(listeners_, listener) != listeners_.end()) {
             listener->clipsChanged();
         }
     }
@@ -3068,8 +3068,7 @@ void ClipManager::notifyClipPropertyChanged(ClipId clipId) {
     if (batchDepth_ > 0) {
         // Coalesce: record once, fire at end of outermost batch.
         auto append = [this](ClipId id) {
-            if (std::find(batchedClipIds_.begin(), batchedClipIds_.end(), id) ==
-                batchedClipIds_.end()) {
+            if (std::ranges::find(batchedClipIds_, id) == batchedClipIds_.end()) {
                 batchedClipIds_.push_back(id);
             }
         };
@@ -3080,7 +3079,7 @@ void ClipManager::notifyClipPropertyChanged(ClipId clipId) {
     }
     auto listenersCopy = listeners_;
     for (auto* listener : listenersCopy) {
-        if (std::find(listeners_.begin(), listeners_.end(), listener) != listeners_.end()) {
+        if (std::ranges::find(listeners_, listener) != listeners_.end()) {
             listener->clipPropertyChanged(clipId);
             for (auto siblingId : siblings)
                 listener->clipPropertyChanged(siblingId);
@@ -3108,7 +3107,7 @@ void ClipManager::endBatch() {
 
     auto listenersCopy = listeners_;
     for (auto* listener : listenersCopy) {
-        if (std::find(listeners_.begin(), listeners_.end(), listener) != listeners_.end()) {
+        if (std::ranges::find(listeners_, listener) != listeners_.end()) {
             listener->clipPropertiesChanged(ids);
         }
     }
@@ -3128,7 +3127,7 @@ ClipManager::ScopedListenerMuteForTests::~ScopedListenerMuteForTests() {
 void ClipManager::notifyClipSelectionChanged(ClipId clipId) {
     auto listenersCopy = listeners_;
     for (auto* listener : listenersCopy) {
-        if (std::find(listeners_.begin(), listeners_.end(), listener) != listeners_.end()) {
+        if (std::ranges::find(listeners_, listener) != listeners_.end()) {
             listener->clipSelectionChanged(clipId);
         }
     }
@@ -3137,7 +3136,7 @@ void ClipManager::notifyClipSelectionChanged(ClipId clipId) {
 void ClipManager::notifyClipPlaybackStateChanged(ClipId clipId) {
     auto listenersCopy = listeners_;
     for (auto* listener : listenersCopy) {
-        if (std::find(listeners_.begin(), listeners_.end(), listener) != listeners_.end()) {
+        if (std::ranges::find(listeners_, listener) != listeners_.end()) {
             listener->clipPlaybackStateChanged(clipId);
         }
     }
@@ -3146,7 +3145,7 @@ void ClipManager::notifyClipPlaybackStateChanged(ClipId clipId) {
 void ClipManager::notifyClipPlaybackRequested(ClipId clipId, ClipPlaybackRequest request) {
     auto listenersCopy = listeners_;
     for (auto* listener : listenersCopy) {
-        if (std::find(listeners_.begin(), listeners_.end(), listener) != listeners_.end()) {
+        if (std::ranges::find(listeners_, listener) != listeners_.end()) {
             listener->clipPlaybackRequested(clipId, request);
         }
     }
@@ -3156,18 +3155,15 @@ void ClipManager::notifyClipDragPreview(ClipId clipId, double previewStartTime,
                                         double previewLength) {
     auto listenersCopy = listeners_;
     for (auto* listener : listenersCopy) {
-        if (std::find(listeners_.begin(), listeners_.end(), listener) != listeners_.end()) {
+        if (std::ranges::find(listeners_, listener) != listeners_.end()) {
             listener->clipDragPreview(clipId, previewStartTime, previewLength);
         }
     }
 }
 
 juce::String ClipManager::generateClipName(ClipType type) const {
-    int count = 1;
-    for (const auto& [id, clip] : clips_) {
-        if (clip.getType() == type)
-            count++;
-    }
+    const auto isType = [type](const auto& entry) { return entry.second.getType() == type; };
+    const int count = 1 + static_cast<int>(std::ranges::count_if(clips_, isType));
 
     if (type == ClipType::Audio) {
         return "Audio " + juce::String(count);
@@ -3261,7 +3257,7 @@ void ClipManager::copyBeatRangeToClipboard(double startBeat, double endBeat,
             continue;
         // Filter by track if trackIds is non-empty
         if (!trackIds.empty()) {
-            if (std::find(trackIds.begin(), trackIds.end(), clip.trackId) == trackIds.end())
+            if (std::ranges::find(trackIds, clip.trackId) == trackIds.end())
                 continue;
         }
 
@@ -3596,8 +3592,8 @@ double ClipManager::getClipboardBeatSpan() const {
 }
 
 bool ClipManager::clipboardRequiresTargetTrack() const {
-    return std::any_of(clipboard_.begin(), clipboard_.end(),
-                       [](const auto& clip) { return clip.trackId == INVALID_TRACK_ID; });
+    const auto hasNoTargetTrack = [](const auto& clip) { return clip.trackId == INVALID_TRACK_ID; };
+    return std::ranges::any_of(clipboard_, hasNoTargetTrack);
 }
 
 void ClipManager::clearClipboard() {

--- a/magda/daw/core/MidiNoteCommands.cpp
+++ b/magda/daw/core/MidiNoteCommands.cpp
@@ -474,10 +474,7 @@ bool SetMultipleMidiNoteVelocitiesCommand::canMergeWith(const UndoableCommand* o
     if (!o || o->clipId_ != clipId_ || o->entries_.size() != entries_.size())
         return false;
     // Same note set (same order, which the gesture builds deterministically).
-    for (size_t i = 0; i < entries_.size(); ++i)
-        if (entries_[i].noteIndex != o->entries_[i].noteIndex)
-            return false;
-    return true;
+    return std::ranges::equal(entries_, o->entries_, {}, &Applied::noteIndex, &Applied::noteIndex);
 }
 
 void SetMultipleMidiNoteVelocitiesCommand::mergeWith(const UndoableCommand* other) {

--- a/magda/daw/core/TrackManager.cpp
+++ b/magda/daw/core/TrackManager.cpp
@@ -420,11 +420,9 @@ TrackId TrackManager::createGroupTrack(const juce::String& name) {
 }
 
 TrackId TrackManager::getChordTrackId() const {
-    for (const auto& track : tracks_) {
-        if (track.type == TrackType::Chord)
-            return track.id;
-    }
-    return INVALID_TRACK_ID;
+    const auto isChordTrack = [](const TrackInfo& track) { return track.type == TrackType::Chord; };
+    const auto found = std::ranges::find_if(tracks_, isChordTrack);
+    return found == tracks_.end() ? INVALID_TRACK_ID : found->id;
 }
 
 TrackId TrackManager::ensureChordTrack() {
@@ -494,7 +492,7 @@ TrackId TrackManager::groupTracks(const std::vector<TrackId>& trackIds, const ju
     if (hasSharedParent && parentGroupId != INVALID_TRACK_ID) {
         if (const auto* parent = getTrack(parentGroupId)) {
             for (auto trackId : tracksToGroup) {
-                auto it = std::find(parent->childIds.begin(), parent->childIds.end(), trackId);
+                auto it = std::ranges::find(parent->childIds, trackId);
                 if (it == parent->childIds.end())
                     continue;
 
@@ -547,7 +545,7 @@ std::vector<TrackId> TrackManager::ungroupTrack(TrackId groupId) {
 
     int groupSiblingIndex = -1;
     if (auto* parent = getTrack(parentGroupId)) {
-        auto it = std::find(parent->childIds.begin(), parent->childIds.end(), groupId);
+        auto it = std::ranges::find(parent->childIds, groupId);
         if (it != parent->childIds.end())
             groupSiblingIndex = static_cast<int>(std::distance(parent->childIds.begin(), it));
     }
@@ -717,8 +715,8 @@ void TrackManager::deleteTrack(TrackId trackId) {
     }
 
     // Remove the track itself
-    auto it = std::find_if(tracks_.begin(), tracks_.end(),
-                           [trackId](const TrackInfo& t) { return t.id == trackId; });
+    const auto matchesId = [trackId](const TrackInfo& t) { return t.id == trackId; };
+    auto it = std::ranges::find_if(tracks_, matchesId);
 
     if (it != tracks_.end()) {
         DBG("Deleted track: " << it->name << " (id=" << trackId << ")");
@@ -758,15 +756,15 @@ TrackId TrackManager::multiOutChildTrack(TrackId parentTrackId, DeviceId deviceI
     if (parentTrackId == INVALID_TRACK_ID || deviceId == INVALID_DEVICE_ID || pairIndex < 0)
         return INVALID_TRACK_ID;
 
-    for (const auto& track : tracks_) {
+    const auto isThisPair = [&](const TrackInfo& track) {
         if (!track.multiOutLink)
-            continue;
+            return false;
         const auto& link = *track.multiOutLink;
-        if (link.sourceTrackId == parentTrackId && link.sourceDeviceId == deviceId &&
-            link.outputPairIndex == pairIndex)
-            return track.id;
-    }
-    return INVALID_TRACK_ID;
+        return link.sourceTrackId == parentTrackId && link.sourceDeviceId == deviceId &&
+               link.outputPairIndex == pairIndex;
+    };
+    const auto found = std::ranges::find_if(tracks_, isThisPair);
+    return found == tracks_.end() ? INVALID_TRACK_ID : found->id;
 }
 
 TrackId TrackManager::activateMultiOutPair(TrackId parentTrackId, DeviceId deviceId,
@@ -806,9 +804,10 @@ TrackId TrackManager::activateMultiOutPair(TrackId parentTrackId, DeviceId devic
     newTrack.multiOutLink = MultiOutTrackLink{parentTrackId, deviceId, pairIndex};
 
     // Insert after the parent track (and any existing multi-out siblings) for adjacency
-    auto parentIt =
-        std::find_if(tracks_.begin(), tracks_.end(),
-                     [parentTrackId](const TrackInfo& t) { return t.id == parentTrackId; });
+    const auto matchesParentId = [parentTrackId](const TrackInfo& t) {
+        return t.id == parentTrackId;
+    };
+    auto parentIt = std::ranges::find_if(tracks_, matchesParentId);
     if (parentIt != tracks_.end()) {
         // Find last consecutive multi-out track for this device after the parent
         auto insertIt = parentIt + 1;
@@ -849,8 +848,8 @@ void TrackManager::deactivateMultiOutPair(TrackId parentTrackId, DeviceId device
 
     // Removing the child track removes the assignment: the link went with it,
     // and there is no second copy to clear (#2220).
-    auto it = std::find_if(tracks_.begin(), tracks_.end(),
-                           [trackToRemove](const TrackInfo& t) { return t.id == trackToRemove; });
+    const auto matchesId = [trackToRemove](const TrackInfo& t) { return t.id == trackToRemove; };
+    auto it = std::ranges::find_if(tracks_, matchesId);
     if (it != tracks_.end()) {
         tracks_.erase(it);
     }
@@ -893,7 +892,7 @@ TrackRestorePosition TrackManager::restorePositionOf(TrackId trackId) const {
 
     if (const auto* track = getTrack(trackId); track != nullptr && track->hasParent()) {
         if (const auto* parent = getTrack(track->parentId)) {
-            const auto found = std::find(parent->childIds.begin(), parent->childIds.end(), trackId);
+            const auto found = std::ranges::find(parent->childIds, trackId);
             if (found != parent->childIds.end())
                 position.siblingIndex =
                     static_cast<int>(std::distance(parent->childIds.begin(), found));
@@ -990,8 +989,8 @@ void TrackManager::restoreExternalRouting(const ExternalTrackRouting& routing) {
 
 void TrackManager::restoreTrack(const TrackInfo& trackInfo, TrackRestorePosition position) {
     // Check if a track with this ID already exists
-    auto it = std::find_if(tracks_.begin(), tracks_.end(),
-                           [&trackInfo](const TrackInfo& t) { return t.id == trackInfo.id; });
+    const auto matchesId = [&trackInfo](const TrackInfo& t) { return t.id == trackInfo.id; };
+    auto it = std::ranges::find_if(tracks_, matchesId);
 
     if (it != tracks_.end()) {
         DBG("Warning: Track with id=" << trackInfo.id << " already exists, skipping restore");
@@ -1021,7 +1020,7 @@ void TrackManager::restoreTrack(const TrackInfo& trackInfo, TrackRestorePosition
     if (trackInfo.hasParent()) {
         if (auto* parent = getTrack(trackInfo.parentId)) {
             auto& children = parent->childIds;
-            if (std::find(children.begin(), children.end(), trackInfo.id) == children.end()) {
+            if (std::ranges::find(children, trackInfo.id) == children.end()) {
                 const int amongSiblings =
                     position.siblingIndex < 0
                         ? static_cast<int>(children.size())
@@ -1039,8 +1038,8 @@ void TrackManager::restoreTrack(const TrackInfo& trackInfo, TrackRestorePosition
 }
 
 TrackId TrackManager::duplicateTrack(TrackId trackId, bool includeDevices) {
-    auto it = std::find_if(tracks_.begin(), tracks_.end(),
-                           [trackId](const TrackInfo& t) { return t.id == trackId; });
+    const auto matchesId = [trackId](const TrackInfo& t) { return t.id == trackId; };
+    auto it = std::ranges::find_if(tracks_, matchesId);
 
     if (it == tracks_.end()) {
         return INVALID_TRACK_ID;
@@ -1205,7 +1204,7 @@ void TrackManager::addTrackToGroup(TrackId trackId, TrackId groupId) {
     if (trackId == groupId)
         return;
     auto descendants = getAllDescendants(trackId);
-    if (std::find(descendants.begin(), descendants.end(), groupId) != descendants.end()) {
+    if (std::ranges::find(descendants, groupId) != descendants.end()) {
         DBG("Cannot add group to its own descendant");
         return;
     }
@@ -1237,7 +1236,7 @@ void TrackManager::moveChildWithinGroup(TrackId childId, TrackId beforeChildId) 
         return;
 
     auto& children = parent->childIds;
-    auto cur = std::find(children.begin(), children.end(), childId);
+    auto cur = std::ranges::find(children, childId);
     if (cur == children.end())
         return;
     children.erase(cur);
@@ -1245,7 +1244,7 @@ void TrackManager::moveChildWithinGroup(TrackId childId, TrackId beforeChildId) 
     // Insert before beforeChildId, or append when it's absent / INVALID.
     auto insertPos = (beforeChildId == INVALID_TRACK_ID)
                          ? children.end()
-                         : std::find(children.begin(), children.end(), beforeChildId);
+                         : std::ranges::find(children, beforeChildId);
     children.insert(insertPos, childId);
 
     notifyTracksChanged();
@@ -1317,8 +1316,8 @@ void TrackManager::moveTrackToPosition(TrackId trackId, int oneBasedPosition) {
                                ? desired[static_cast<size_t>(pos - 1)]
                                : INVALID_TRACK_ID;
 
-    auto self = std::find_if(tracks_.begin(), tracks_.end(),
-                             [&](const TrackInfo& t) { return t.id == trackId; });
+    const auto matchesId = [&](const TrackInfo& t) { return t.id == trackId; };
+    auto self = std::ranges::find_if(tracks_, matchesId);
     if (self == tracks_.end())
         return;
     const TrackInfo info = *self;
@@ -1327,8 +1326,8 @@ void TrackManager::moveTrackToPosition(TrackId trackId, int oneBasedPosition) {
     if (anchor == INVALID_TRACK_ID) {
         tracks_.push_back(info);
     } else {
-        auto at = std::find_if(tracks_.begin(), tracks_.end(),
-                               [&](const TrackInfo& t) { return t.id == anchor; });
+        const auto matchesAnchor = [&](const TrackInfo& t) { return t.id == anchor; };
+        auto at = std::ranges::find_if(tracks_, matchesAnchor);
         tracks_.insert(at, info);
     }
     notifyTracksChanged();
@@ -1442,26 +1441,23 @@ bool TrackManager::wouldCreateInputRoutingCycle(TrackId destTrackId, TrackId sou
 TrackInfo* TrackManager::getTrack(TrackId trackId) {
     if (trackId == MASTER_TRACK_ID)
         return &masterTrack_;
-    auto it = std::find_if(tracks_.begin(), tracks_.end(),
-                           [trackId](const TrackInfo& t) { return t.id == trackId; });
+    const auto matchesId = [trackId](const TrackInfo& t) { return t.id == trackId; };
+    auto it = std::ranges::find_if(tracks_, matchesId);
     return (it != tracks_.end()) ? &(*it) : nullptr;
 }
 
 const TrackInfo* TrackManager::getTrack(TrackId trackId) const {
     if (trackId == MASTER_TRACK_ID)
         return &masterTrack_;
-    auto it = std::find_if(tracks_.begin(), tracks_.end(),
-                           [trackId](const TrackInfo& t) { return t.id == trackId; });
+    const auto matchesId = [trackId](const TrackInfo& t) { return t.id == trackId; };
+    auto it = std::ranges::find_if(tracks_, matchesId);
     return (it != tracks_.end()) ? &(*it) : nullptr;
 }
 
 int TrackManager::getTrackIndex(TrackId trackId) const {
-    for (size_t i = 0; i < tracks_.size(); ++i) {
-        if (tracks_[i].id == trackId) {
-            return static_cast<int>(i);
-        }
-    }
-    return -1;
+    const auto matchesId = [trackId](const TrackInfo& t) { return t.id == trackId; };
+    const auto found = std::ranges::find_if(tracks_, matchesId);
+    return found == tracks_.end() ? -1 : static_cast<int>(std::distance(tracks_.begin(), found));
 }
 
 // ============================================================================
@@ -1578,11 +1574,10 @@ void TrackManager::setAllTracksPlaybackMode(TrackPlaybackMode mode) {
 }
 
 bool TrackManager::isAnyTrackInSessionMode() const {
-    for (const auto& track : tracks_) {
-        if (track.playbackMode == TrackPlaybackMode::Session)
-            return true;
-    }
-    return false;
+    const auto isSessionMode = [](const TrackInfo& track) {
+        return track.playbackMode == TrackPlaybackMode::Session;
+    };
+    return std::ranges::any_of(tracks_, isSessionMode);
 }
 
 void TrackManager::setTrackMixerChannelWidth(TrackId trackId, int width) {
@@ -2300,9 +2295,10 @@ DeviceId TrackManager::findMixerAnalysisDevice(TrackId trackId,
 void TrackManager::removeDeviceFromTrack(TrackId trackId, DeviceId deviceId) {
     if (auto* track = getTrack(trackId)) {
         auto& elements = track->chain.fxChainElements;
-        auto it = std::find_if(elements.begin(), elements.end(), [deviceId](const ChainElement& e) {
+        const auto matchesDeviceId = [deviceId](const ChainElement& e) {
             return magda::isDevice(e) && magda::getDevice(e).id == deviceId;
-        });
+        };
+        auto it = std::ranges::find_if(elements, matchesDeviceId);
         if (it != elements.end()) {
             DBG("Removed device: " << magda::getDevice(*it).name << " (id=" << deviceId
                                    << ") from track " << trackId);
@@ -2314,9 +2310,10 @@ void TrackManager::removeDeviceFromTrack(TrackId trackId, DeviceId deviceId) {
         }
         // Post-fader FX list (flat device list).
         auto& postElements = track->chain.postFxChainElements;
-        auto pit = std::find_if(
-            postElements.begin(), postElements.end(),
-            [deviceId](const PostFxChainElement& e) { return e.device.id == deviceId; });
+        const auto matchesPostDeviceId = [deviceId](const PostFxChainElement& e) {
+            return e.device.id == deviceId;
+        };
+        auto pit = std::ranges::find_if(postElements, matchesPostDeviceId);
         if (pit != postElements.end()) {
             DBG("Removed post-fx device: " << pit->device.name << " (id=" << deviceId
                                            << ") from track " << trackId);
@@ -2328,9 +2325,10 @@ void TrackManager::removeDeviceFromTrack(TrackId trackId, DeviceId deviceId) {
         }
         // Mixer-analysis section (rail-managed mini Oscilloscope / Spectrum).
         auto& miniElements = track->chain.mixerAnalysisElements;
-        auto mit = std::find_if(
-            miniElements.begin(), miniElements.end(),
-            [deviceId](const PostFxChainElement& e) { return e.device.id == deviceId; });
+        const auto matchesMiniDeviceId = [deviceId](const PostFxChainElement& e) {
+            return e.device.id == deviceId;
+        };
+        auto mit = std::ranges::find_if(miniElements, matchesMiniDeviceId);
         if (mit != miniElements.end()) {
             DBG("Removed mixer-analysis device: " << mit->device.name << " (id=" << deviceId
                                                   << ") from track " << trackId);
@@ -2507,9 +2505,10 @@ void TrackManager::clearSelectionsUnderRack(const RackInfo& rack, const ChainNod
 void TrackManager::removeRackFromTrack(TrackId trackId, RackId rackId) {
     if (auto* track = getTrack(trackId)) {
         auto& elements = track->chain.fxChainElements;
-        auto it = std::find_if(elements.begin(), elements.end(), [rackId](const ChainElement& e) {
+        const auto matchesRackId = [rackId](const ChainElement& e) {
             return magda::isRack(e) && magda::getRack(e).id == rackId;
-        });
+        };
+        auto it = std::ranges::find_if(elements, matchesRackId);
         if (it != elements.end()) {
             DBG("Removed rack: " << magda::getRack(*it).name << " (id=" << rackId << ") from track "
                                  << trackId);
@@ -2590,10 +2589,11 @@ namespace {
 /// resolves a pad through one: `TrackManager::getPads()` reaches them through
 /// the device that owns them, which is unambiguous (#2207).
 RackInfo* findRackAmong(std::vector<ChainElement>& elements, RackId rackId) {
-    for (auto& element : elements)
-        if (magda::isRack(element) && magda::getRack(element).id == rackId)
-            return &magda::getRack(element);
-    return nullptr;
+    const auto isThisRack = [rackId](const ChainElement& element) {
+        return magda::isRack(element) && magda::getRack(element).id == rackId;
+    };
+    const auto found = std::ranges::find_if(elements, isThisRack);
+    return found == elements.end() ? nullptr : &magda::getRack(*found);
 }
 
 const RackInfo* findRackAmong(const std::vector<ChainElement>& elements, RackId rackId) {
@@ -2635,11 +2635,11 @@ RackInfo* TrackManager::getRackInPadByPath(const ChainNodePath& rackPath) {
     if (chain == nullptr)
         return nullptr;
 
-    for (auto& element : chain->elements)
-        if (magda::isRack(element) && magda::getRack(element).id == last.id)
-            return &magda::getRack(element);
-
-    return nullptr;
+    const auto isThisRack = [&last](const ChainElement& element) {
+        return magda::isRack(element) && magda::getRack(element).id == last.id;
+    };
+    const auto found = std::ranges::find_if(chain->elements, isThisRack);
+    return found == chain->elements.end() ? nullptr : &magda::getRack(*found);
 }
 
 RackInfo* TrackManager::getRackByPath(const ChainNodePath& rackPath) {
@@ -2752,11 +2752,10 @@ RackInfo* TrackManager::getRackByPath(const ChainNodePath& rackPath) {
                 // #2057 behavior of returning its enclosing rack.
                 if (!isLast || currentChain == nullptr)
                     return nullptr;
-                const auto found = std::find_if(
-                    currentChain->elements.begin(), currentChain->elements.end(),
-                    [&step](const ChainElement& element) {
-                        return magda::isDevice(element) && magda::getDevice(element).id == step.id;
-                    });
+                const auto matchesDeviceId = [&step](const ChainElement& element) {
+                    return magda::isDevice(element) && magda::getDevice(element).id == step.id;
+                };
+                const auto found = std::ranges::find_if(currentChain->elements, matchesDeviceId);
                 if (found == currentChain->elements.end())
                     return nullptr;
                 break;
@@ -2794,8 +2793,8 @@ ChainId TrackManager::addChainToRack(const ChainNodePath& rackPath, const juce::
 void TrackManager::removeChainFromRack(TrackId trackId, RackId rackId, ChainId chainId) {
     if (auto* rack = getRack(trackId, rackId)) {
         auto& chains = rack->chains;
-        auto it = std::find_if(chains.begin(), chains.end(),
-                               [chainId](const ChainInfo& c) { return c.id == chainId; });
+        const auto matchesChainId = [chainId](const ChainInfo& c) { return c.id == chainId; };
+        auto it = std::ranges::find_if(chains, matchesChainId);
         if (it != chains.end()) {
             DBG("Removed chain: " << it->name << " (id=" << chainId << ") from rack " << rackId);
             const auto chainPath = ChainNodePath::rack(trackId, rackId).withChain(chainId);
@@ -2833,8 +2832,8 @@ void TrackManager::removeChainByPath(const ChainNodePath& chainPath) {
     // Find the rack and remove the chain
     if (auto* rack = getRackByPath(rackPath)) {
         auto& chains = rack->chains;
-        auto it = std::find_if(chains.begin(), chains.end(),
-                               [chainId](const ChainInfo& c) { return c.id == chainId; });
+        const auto matchesChainId = [chainId](const ChainInfo& c) { return c.id == chainId; };
+        auto it = std::ranges::find_if(chains, matchesChainId);
         if (it != chains.end()) {
             DBG("Removed chain via path: " << it->name << " (id=" << chainId << ")");
             clearSelectionsUnderChain(it->elements, chainPath);
@@ -2937,8 +2936,8 @@ void TrackManager::setChainPan(const ChainNodePath& chainPath, float pan) {
 ChainInfo* TrackManager::getChain(TrackId trackId, RackId rackId, ChainId chainId) {
     if (auto* rack = getRack(trackId, rackId)) {
         auto& chains = rack->chains;
-        auto it = std::find_if(chains.begin(), chains.end(),
-                               [chainId](const ChainInfo& c) { return c.id == chainId; });
+        const auto matchesChainId = [chainId](const ChainInfo& c) { return c.id == chainId; };
+        auto it = std::ranges::find_if(chains, matchesChainId);
         if (it != chains.end()) {
             return &(*it);
         }
@@ -2949,8 +2948,8 @@ ChainInfo* TrackManager::getChain(TrackId trackId, RackId rackId, ChainId chainI
 const ChainInfo* TrackManager::getChain(TrackId trackId, RackId rackId, ChainId chainId) const {
     if (const auto* rack = getRack(trackId, rackId)) {
         const auto& chains = rack->chains;
-        auto it = std::find_if(chains.begin(), chains.end(),
-                               [chainId](const ChainInfo& c) { return c.id == chainId; });
+        const auto matchesChainId = [chainId](const ChainInfo& c) { return c.id == chainId; };
+        auto it = std::ranges::find_if(chains, matchesChainId);
         if (it != chains.end()) {
             return &(*it);
         }
@@ -3057,13 +3056,16 @@ TrackManager::ResolvedPath TrackManager::resolvePath(const ChainNodePath& path) 
 
     // Handle top-level device (legacy)
     if (path.topLevelDeviceId != INVALID_DEVICE_ID) {
-        for (const auto& element : track->chain.fxChainElements) {
-            if (magda::isDevice(element) && magda::getDevice(element).id == path.topLevelDeviceId) {
-                result.valid = true;
-                result.device = &magda::getDevice(element);
-                result.displayPath = result.device->name;
-                return result;
-            }
+        const auto matchesTopLevelDeviceId = [&path](const ChainElement& element) {
+            return magda::isDevice(element) &&
+                   magda::getDevice(element).id == path.topLevelDeviceId;
+        };
+        const auto found =
+            std::ranges::find_if(track->chain.fxChainElements, matchesTopLevelDeviceId);
+        if (found != track->chain.fxChainElements.end()) {
+            result.valid = true;
+            result.device = &magda::getDevice(*found);
+            result.displayPath = result.device->name;
         }
         return result;
     }
@@ -3093,24 +3095,27 @@ TrackManager::ResolvedPath TrackManager::resolvePath(const ChainNodePath& path) 
             case ChainStepType::PadChain:
             case ChainStepType::Chain: {
                 if (currentRack != nullptr) {
-                    for (const auto& chain : currentRack->chains) {
-                        if (chain.id == step.id) {
-                            currentChain = &chain;
-                            pathNames.add(chain.name);
-                            break;
-                        }
+                    const auto matchesChainId = [&step](const ChainInfo& chain) {
+                        return chain.id == step.id;
+                    };
+                    const auto found = std::ranges::find_if(currentRack->chains, matchesChainId);
+                    if (found != currentRack->chains.end()) {
+                        currentChain = &(*found);
+                        pathNames.add(currentChain->name);
                     }
                 }
                 break;
             }
             case ChainStepType::Device: {
                 if (currentChain != nullptr) {
-                    for (const auto& element : currentChain->elements) {
-                        if (magda::isDevice(element) && magda::getDevice(element).id == step.id) {
-                            result.device = &magda::getDevice(element);
-                            pathNames.add(result.device->name);
-                            break;
-                        }
+                    const auto matchesDeviceId = [&step](const ChainElement& element) {
+                        return magda::isDevice(element) && magda::getDevice(element).id == step.id;
+                    };
+                    const auto found =
+                        std::ranges::find_if(currentChain->elements, matchesDeviceId);
+                    if (found != currentChain->elements.end()) {
+                        result.device = &magda::getDevice(*found);
+                        pathNames.add(result.device->name);
                     }
                 }
                 break;
@@ -3266,7 +3271,7 @@ void TrackManager::setMasterVisible(ViewMode mode, bool visible) {
 // ============================================================================
 
 void TrackManager::addListener(TrackManagerListener* listener) {
-    if (listener && std::find(listeners_.begin(), listeners_.end(), listener) == listeners_.end()) {
+    if (listener && std::ranges::find(listeners_, listener) == listeners_.end()) {
         listeners_.push_back(listener);
     }
 }

--- a/magda/daw/core/aliases/TargetResolver.cpp
+++ b/magda/daw/core/aliases/TargetResolver.cpp
@@ -40,22 +40,22 @@ ResolveResult TargetResolver::resolve(const Target& target) const {
 
                 // Path absent -- try to materialise against focused chain
                 auto devices = chainContext_.devicesInFocusedChain();
-                for (const auto& dw : devices) {
-                    if (dw.device == nullptr)
-                        continue;
-                    auto alias = pluginNameToAlias(dw.device->name);
-                    if (alias == stored->pluginTypeKey) {
-                        int paramIdx = findParamByKey(*dw.device, normalizeParamName(t.name));
-                        if (paramIdx < 0)
-                            paramIdx = stored->paramIndex;  // fallback to stored index
+                const auto matchesPluginType = [&](const ChainContext::DeviceWithPath& dw) {
+                    return dw.device != nullptr &&
+                           pluginNameToAlias(dw.device->name) == stored->pluginTypeKey;
+                };
+                if (const auto found = std::ranges::find_if(devices, matchesPluginType);
+                    found != devices.end()) {
+                    int paramIdx = findParamByKey(*found->device, normalizeParamName(t.name));
+                    if (paramIdx < 0)
+                        paramIdx = stored->paramIndex;  // fallback to stored index
 
-                        ResolveResult r;
-                        r.target.devicePath = dw.path;
-                        r.target.paramIndex = paramIdx;
-                        r.sourceLabel = "@" + t.name + " (materialised)";
-                        r.resolved = true;
-                        return r;
-                    }
+                    ResolveResult r;
+                    r.target.devicePath = found->path;
+                    r.target.paramIndex = paramIdx;
+                    r.sourceLabel = "@" + t.name + " (materialised)";
+                    r.resolved = true;
+                    return r;
                 }
 
                 return ResolveResult::failure("Alias path absent and no matching device in "
@@ -200,22 +200,21 @@ ResolveResult TargetResolver::resolveAt(const ParsedSigil& sigil) const {
 
     // Path absent -> scan focused chain for matching plugin type
     auto devices = chainContext_.devicesInFocusedChain();
-    for (const auto& dw : devices) {
-        if (dw.device == nullptr)
-            continue;
-        auto alias = pluginNameToAlias(dw.device->name);
-        if (alias == stored->pluginTypeKey) {
-            int paramIdx = findParamByKey(*dw.device, normalizeParamName(sigil.paramKey));
-            if (paramIdx < 0)
-                paramIdx = stored->paramIndex;
+    const auto matchesPluginType = [&](const ChainContext::DeviceWithPath& dw) {
+        return dw.device != nullptr && pluginNameToAlias(dw.device->name) == stored->pluginTypeKey;
+    };
+    if (const auto found = std::ranges::find_if(devices, matchesPluginType);
+        found != devices.end()) {
+        int paramIdx = findParamByKey(*found->device, normalizeParamName(sigil.paramKey));
+        if (paramIdx < 0)
+            paramIdx = stored->paramIndex;
 
-            ResolveResult r;
-            r.target.devicePath = dw.path;
-            r.target.paramIndex = paramIdx;
-            r.sourceLabel = "@" + sigil.pluginKey + "." + sigil.paramKey + " (chain scan)";
-            r.resolved = true;
-            return r;
-        }
+        ResolveResult r;
+        r.target.devicePath = found->path;
+        r.target.paramIndex = paramIdx;
+        r.sourceLabel = "@" + sigil.pluginKey + "." + sigil.paramKey + " (chain scan)";
+        r.resolved = true;
+        return r;
     }
 
     return ResolveResult::failure("@" + sigil.pluginKey + "." + sigil.paramKey +
@@ -229,18 +228,15 @@ ResolveResult TargetResolver::resolveAt(const ParsedSigil& sigil) const {
 // static
 const ChainContext::DeviceWithPath* TargetResolver::findFirstMatchingDevice(
     const std::vector<ChainContext::DeviceWithPath>& devices, const juce::String& pluginKey) {
-    for (const auto& dw : devices) {
+    const auto matchesName = [&pluginKey](const ChainContext::DeviceWithPath& dw) {
         if (dw.device == nullptr)
-            continue;
-
+            return false;
         // Match against normalised plugin alias OR normalised device name
-        auto alias = pluginNameToAlias(dw.device->name);
-        bool nameMatch = (alias == pluginKey) || (normalizeParamName(dw.device->name) == pluginKey);
-
-        if (nameMatch)
-            return &dw;
-    }
-    return nullptr;
+        const auto alias = pluginNameToAlias(dw.device->name);
+        return alias == pluginKey || normalizeParamName(dw.device->name) == pluginKey;
+    };
+    const auto found = std::ranges::find_if(devices, matchesName);
+    return found == devices.end() ? nullptr : &(*found);
 }
 
 // ============================================================================
@@ -250,15 +246,19 @@ const ChainContext::DeviceWithPath* TargetResolver::findFirstMatchingDevice(
 // static
 int TargetResolver::findParamByKey(const DeviceInfo& device, const juce::String& paramKey) {
     // First: exact normalised match
-    for (const auto& p : device.parameters) {
-        if (normalizeParamName(p.name) == paramKey)
-            return p.paramIndex;
-    }
+    const auto matchesExact = [&paramKey](const ParameterInfo& p) {
+        return normalizeParamName(p.name) == paramKey;
+    };
+    if (const auto found = std::ranges::find_if(device.parameters, matchesExact);
+        found != device.parameters.end())
+        return found->paramIndex;
     // Second: prefix match (paramKey is a prefix of the normalised param name)
-    for (const auto& p : device.parameters) {
-        if (normalizeParamName(p.name).startsWith(paramKey))
-            return p.paramIndex;
-    }
+    const auto matchesPrefix = [&paramKey](const ParameterInfo& p) {
+        return normalizeParamName(p.name).startsWith(paramKey);
+    };
+    if (const auto found = std::ranges::find_if(device.parameters, matchesPrefix);
+        found != device.parameters.end())
+        return found->paramIndex;
     return -1;
 }
 

--- a/magda/daw/core/controllers/BindingRegistry.cpp
+++ b/magda/daw/core/controllers/BindingRegistry.cpp
@@ -89,8 +89,8 @@ bool BindingRegistry::hasAnyBindingForController(const ControllerId& controllerI
     auto match = [&controllerId](const Binding& b) {
         return b.source.controllerId == controllerId;
     };
-    return std::any_of(globalBindings_.begin(), globalBindings_.end(), match) ||
-           std::any_of(projectBindings_.begin(), projectBindings_.end(), match);
+    return std::ranges::any_of(globalBindings_, match) ||
+           std::ranges::any_of(projectBindings_, match);
 }
 
 // ============================================================================
@@ -224,16 +224,15 @@ bool BindingRegistry::hasBindingForDevice(const ChainNodePath& devicePath,
     DefaultChainContext ctx;
     TargetResolver resolver{AliasRegistry::getInstance(), ResolverRegistry::getInstance(), ctx};
 
-    auto check = [&](const std::vector<Binding>& vec) -> bool {
-        for (const auto& b : vec) {
+    const auto check = [&](const std::vector<Binding>& vec) -> bool {
+        const auto matchesDevice = [&](const Binding& b) {
             auto resolved = resolver.resolve(b.target);
             if (!resolved.ok())
-                continue;
+                return false;
             const auto& t = resolved.target;
-            if (t.devicePath == devicePath && t.kind == owner)
-                return true;
-        }
-        return false;
+            return t.devicePath == devicePath && t.kind == owner;
+        };
+        return std::ranges::any_of(vec, matchesDevice);
     };
 
     return check(globalBindings_) || check(projectBindings_);
@@ -243,15 +242,12 @@ bool BindingRegistry::hasActiveBindingFor(const ControlTarget& query) const {
     DefaultChainContext ctx;
     TargetResolver resolver{AliasRegistry::getInstance(), ResolverRegistry::getInstance(), ctx};
 
-    auto check = [&](const std::vector<Binding>& vec) -> bool {
-        for (const auto& b : vec) {
+    const auto check = [&](const std::vector<Binding>& vec) -> bool {
+        const auto matchesQuery = [&](const Binding& b) {
             auto resolved = resolver.resolve(b.target);
-            if (!resolved.ok())
-                continue;
-            if (resolved.target == query)
-                return true;
-        }
-        return false;
+            return resolved.ok() && resolved.target == query;
+        };
+        return std::ranges::any_of(vec, matchesQuery);
     };
 
     return check(globalBindings_) || check(projectBindings_);
@@ -260,17 +256,14 @@ bool BindingRegistry::hasActiveBindingFor(const ControlTarget& query) const {
 bool BindingRegistry::hasResolverBindingForDevice(const ChainNodePath& devicePath) const {
     DefaultChainContext ctx;
     TargetResolver resolver{AliasRegistry::getInstance(), ResolverRegistry::getInstance(), ctx};
-    auto check = [&](const std::vector<Binding>& vec) -> bool {
-        for (const auto& b : vec) {
+    const auto check = [&](const std::vector<Binding>& vec) -> bool {
+        const auto matchesDevice = [&](const Binding& b) {
             if (!std::holds_alternative<ResolverRef>(b.target))
-                continue;
+                return false;
             auto resolved = resolver.resolve(b.target);
-            if (!resolved.ok())
-                continue;
-            if (resolved.target.devicePath == devicePath)
-                return true;
-        }
-        return false;
+            return resolved.ok() && resolved.target.devicePath == devicePath;
+        };
+        return std::ranges::any_of(vec, matchesDevice);
     };
     return check(globalBindings_) || check(projectBindings_);
 }
@@ -279,17 +272,15 @@ std::optional<ControllerId> BindingRegistry::resolverControllerForDevice(
     const ChainNodePath& devicePath) const {
     DefaultChainContext ctx;
     TargetResolver resolver{AliasRegistry::getInstance(), ResolverRegistry::getInstance(), ctx};
-    auto check = [&](const std::vector<Binding>& vec) -> std::optional<ControllerId> {
-        for (const auto& b : vec) {
+    const auto check = [&](const std::vector<Binding>& vec) -> std::optional<ControllerId> {
+        const auto matchesDevice = [&](const Binding& b) {
             if (!std::holds_alternative<ResolverRef>(b.target))
-                continue;
+                return false;
             auto resolved = resolver.resolve(b.target);
-            if (!resolved.ok())
-                continue;
-            if (resolved.target.devicePath == devicePath)
-                return b.source.controllerId;
-        }
-        return std::nullopt;
+            return resolved.ok() && resolved.target.devicePath == devicePath;
+        };
+        const auto found = std::ranges::find_if(vec, matchesDevice);
+        return found == vec.end() ? std::nullopt : std::make_optional(found->source.controllerId);
     };
     if (auto g = check(globalBindings_))
         return g;
@@ -300,17 +291,15 @@ std::optional<ControllerId> BindingRegistry::userMappingControllerForDevice(
     const ChainNodePath& devicePath) const {
     DefaultChainContext ctx;
     TargetResolver resolver{AliasRegistry::getInstance(), ResolverRegistry::getInstance(), ctx};
-    auto check = [&](const std::vector<Binding>& vec) -> std::optional<ControllerId> {
-        for (const auto& b : vec) {
+    const auto check = [&](const std::vector<Binding>& vec) -> std::optional<ControllerId> {
+        const auto matchesDevice = [&](const Binding& b) {
             if (std::holds_alternative<ResolverRef>(b.target))
-                continue;  // resolver bindings are profile defaults, not user mappings
+                return false;  // resolver bindings are profile defaults, not user mappings
             auto resolved = resolver.resolve(b.target);
-            if (!resolved.ok())
-                continue;
-            if (resolved.target.devicePath == devicePath)
-                return b.source.controllerId;
-        }
-        return std::nullopt;
+            return resolved.ok() && resolved.target.devicePath == devicePath;
+        };
+        const auto found = std::ranges::find_if(vec, matchesDevice);
+        return found == vec.end() ? std::nullopt : std::make_optional(found->source.controllerId);
     };
     if (auto g = check(globalBindings_))
         return g;
@@ -320,35 +309,27 @@ std::optional<ControllerId> BindingRegistry::userMappingControllerForDevice(
 bool BindingRegistry::hasUserMappingForDevice(const ChainNodePath& devicePath) const {
     DefaultChainContext ctx;
     TargetResolver resolver{AliasRegistry::getInstance(), ResolverRegistry::getInstance(), ctx};
-    auto check = [&](const std::vector<Binding>& vec) -> bool {
-        for (const auto& b : vec) {
+    const auto check = [&](const std::vector<Binding>& vec) -> bool {
+        const auto matchesDevice = [&](const Binding& b) {
             if (std::holds_alternative<ResolverRef>(b.target))
-                continue;  // resolver bindings are profile defaults, not user mappings
+                return false;  // resolver bindings are profile defaults, not user mappings
             auto resolved = resolver.resolve(b.target);
-            if (!resolved.ok())
-                continue;
-            if (resolved.target.devicePath == devicePath)
-                return true;
-        }
-        return false;
+            return resolved.ok() && resolved.target.devicePath == devicePath;
+        };
+        return std::ranges::any_of(vec, matchesDevice);
     };
     return check(globalBindings_) || check(projectBindings_);
 }
 
 bool BindingRegistry::hasActiveStaticBindingForMacro(const ChainNodePath& devicePath,
                                                      int macroIndex) const {
-    auto check = [&](const std::vector<Binding>& vec) -> bool {
-        for (const auto& b : vec) {
+    const auto check = [&](const std::vector<Binding>& vec) -> bool {
+        const auto matchesMacro = [&](const Binding& b) {
             auto* st = std::get_if<ControlTarget>(&b.target);
-            if (st == nullptr)
-                continue;
-            if (st->kind != ControlTarget::Kind::DeviceMacro)
-                continue;
-            if (st->devicePath != devicePath || st->paramIndex != macroIndex)
-                continue;
-            return true;
-        }
-        return false;
+            return st != nullptr && st->kind == ControlTarget::Kind::DeviceMacro &&
+                   st->devicePath == devicePath && st->paramIndex == macroIndex;
+        };
+        return std::ranges::any_of(vec, matchesMacro);
     };
     return check(globalBindings_) || check(projectBindings_);
 }
@@ -404,15 +385,16 @@ bool BindingRegistry::isAutomapShadowedForMacro(const ChainNodePath& devicePath,
         return false;
 
     // 2. Look for an active static PluginParam binding whose source overlaps.
-    auto hasOverride = [&](const std::vector<Binding>& vec) {
-        for (const auto& b : vec) {
+    const auto hasOverride = [&](const std::vector<Binding>& vec) {
+        const auto overridesAutomap = [&](const Binding& b) {
             if (!isExplicitPluginParamTarget(b.target))
-                continue;
-            for (const auto& s : automapSources)
-                if (sourcesOverlap(b.source, s))
-                    return true;
-        }
-        return false;
+                return false;
+            const auto overlapsSource = [&](const BindingSource& s) {
+                return sourcesOverlap(b.source, s);
+            };
+            return std::ranges::any_of(automapSources, overlapsSource);
+        };
+        return std::ranges::any_of(vec, overridesAutomap);
     };
     return hasOverride(globalBindings_) || hasOverride(projectBindings_);
 }
@@ -447,15 +429,16 @@ bool BindingRegistry::isPluginParamOverridingMacro(const ChainNodePath& devicePa
     //    overlapping source. The resolver does not need to currently resolve —
     //    its presence with a matching CC means the override is in effect for
     //    whichever device is focused.
-    auto hasShadowed = [&](const std::vector<Binding>& vec) {
-        for (const auto& b : vec) {
+    const auto hasShadowed = [&](const std::vector<Binding>& vec) {
+        const auto shadowsStatic = [&](const Binding& b) {
             if (!isFocusedDeviceMacroResolver(b.target))
-                continue;
-            for (const auto& s : staticSources)
-                if (sourcesOverlap(b.source, s))
-                    return true;
-        }
-        return false;
+                return false;
+            const auto overlapsSource = [&](const BindingSource& s) {
+                return sourcesOverlap(b.source, s);
+            };
+            return std::ranges::any_of(staticSources, overlapsSource);
+        };
+        return std::ranges::any_of(vec, shadowsStatic);
     };
     return hasShadowed(globalBindings_) || hasShadowed(projectBindings_);
 }
@@ -465,13 +448,8 @@ int BindingRegistry::removeFor(const ControlTarget& query) {
 
     for (const auto& b : toRemove) {
         // Determine scope by checking which vector contains this binding
-        bool inGlobal = false;
-        for (const auto& gb : globalBindings_) {
-            if (gb.id == b.id) {
-                inGlobal = true;
-                break;
-            }
-        }
+        const auto matchesId = [&b](const Binding& gb) { return gb.id == b.id; };
+        const bool inGlobal = std::ranges::any_of(globalBindings_, matchesId);
         remove(inGlobal ? BindingScope::Global : BindingScope::Project, b.id);
     }
 

--- a/magda/daw/core/controllers/ControllerRegistry.cpp
+++ b/magda/daw/core/controllers/ControllerRegistry.cpp
@@ -15,27 +15,24 @@ ControllerRegistry& ControllerRegistry::getInstance() {
 
 void ControllerRegistry::add(const Controller& c) {
     // Update if exists, otherwise append
-    for (auto& existing : controllers_) {
-        if (existing.id == c.id) {
-            existing = c;
-            rebuildSnapshot();
-            notifyListeners();
-            return;
-        }
+    const auto matchesId = [&c](const Controller& existing) { return existing.id == c.id; };
+    if (const auto found = std::ranges::find_if(controllers_, matchesId);
+        found != controllers_.end()) {
+        *found = c;
+    } else {
+        controllers_.push_back(c);
     }
-    controllers_.push_back(c);
     rebuildSnapshot();
     notifyListeners();
 }
 
 void ControllerRegistry::update(const Controller& c) {
-    for (auto& existing : controllers_) {
-        if (existing.id == c.id) {
-            existing = c;
-            rebuildSnapshot();
-            notifyListeners();
-            return;
-        }
+    const auto matchesId = [&c](const Controller& existing) { return existing.id == c.id; };
+    if (const auto found = std::ranges::find_if(controllers_, matchesId);
+        found != controllers_.end()) {
+        *found = c;
+        rebuildSnapshot();
+        notifyListeners();
     }
 }
 
@@ -52,22 +49,20 @@ void ControllerRegistry::remove(const ControllerId& id) {
 bool ControllerRegistry::rematchInputPorts(const juce::Array<juce::MidiDeviceInfo>& liveInputs) {
     bool changed = false;
     for (auto& c : controllers_) {
-        bool identifierLive = false;
-        for (const auto& dev : liveInputs) {
-            if (dev.identifier == c.inputPort) {
-                identifierLive = true;
-                break;
-            }
-        }
+        const auto matchesIdentifier = [&c](const juce::MidiDeviceInfo& dev) {
+            return dev.identifier == c.inputPort;
+        };
+        const bool identifierLive = std::ranges::any_of(liveInputs, matchesIdentifier);
         if (identifierLive || c.inputPortName.isEmpty())
             continue;
 
-        for (const auto& dev : liveInputs) {
-            if (dev.name == c.inputPortName) {
-                c.inputPort = dev.identifier;
-                changed = true;
-                break;
-            }
+        const auto matchesName = [&c](const juce::MidiDeviceInfo& dev) {
+            return dev.name == c.inputPortName;
+        };
+        if (const auto found = std::ranges::find_if(liveInputs, matchesName);
+            found != liveInputs.end()) {
+            c.inputPort = found->identifier;
+            changed = true;
         }
     }
     if (changed) {
@@ -86,17 +81,15 @@ std::vector<Controller> ControllerRegistry::all() const {
 }
 
 std::optional<Controller> ControllerRegistry::find(const ControllerId& id) const {
-    for (const auto& c : controllers_)
-        if (c.id == id)
-            return c;
-    return std::nullopt;
+    const auto matchesId = [&id](const Controller& c) { return c.id == id; };
+    const auto found = std::ranges::find_if(controllers_, matchesId);
+    return found == controllers_.end() ? std::nullopt : std::make_optional(*found);
 }
 
 std::optional<Controller> ControllerRegistry::findByInputPort(const juce::String& portId) const {
-    for (const auto& c : controllers_)
-        if (c.inputPort == portId)
-            return c;
-    return std::nullopt;
+    const auto matchesPort = [&portId](const Controller& c) { return c.inputPort == portId; };
+    const auto found = std::ranges::find_if(controllers_, matchesPort);
+    return found == controllers_.end() ? std::nullopt : std::make_optional(*found);
 }
 
 bool ControllerRegistry::isControllerInputPort(const juce::String& portId) const {
@@ -104,10 +97,8 @@ bool ControllerRegistry::isControllerInputPort(const juce::String& portId) const
     auto snap = std::atomic_load(&snapshot_);
     if (!snap)
         return false;
-    for (const auto& c : *snap)
-        if (c.inputPort == portId)
-            return true;
-    return false;
+    const auto matchesPort = [&portId](const Controller& c) { return c.inputPort == portId; };
+    return std::ranges::any_of(*snap, matchesPort);
 }
 
 bool ControllerRegistry::isControllerInputPort(const juce::String& liveIdentifier,
@@ -116,10 +107,10 @@ bool ControllerRegistry::isControllerInputPort(const juce::String& liveIdentifie
     auto snap = std::atomic_load(&snapshot_);
     if (!snap)
         return false;
-    for (const auto& c : *snap)
-        if (magda::midi::matches(c.inputPort, liveIdentifier, liveName))
-            return true;
-    return false;
+    const auto matchesLive = [&](const Controller& c) {
+        return magda::midi::matches(c.inputPort, liveIdentifier, liveName);
+    };
+    return std::ranges::any_of(*snap, matchesLive);
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

Collapses hand-written flag-and-break / early-return search loops, and two-iterator `std::find`/`std::find_if`/`std::any_of`/`std::all_of`/`std::count_if` calls, to their one-range `std::ranges::` form, across 17 files in `daw/core` and `daw/audio` (off the audio path). Predicates are pulled into named local lambdas, matching the existing house style (see `magda/engine/plan/PlanCompiler.cpp`).

- `daw/core`: `TrackManager.cpp`, `ClipManager.cpp`, `AutomationManager.cpp`, `AutomationCommands.cpp`, `MidiNoteCommands.cpp`, `controllers/ControllerRegistry.cpp`, `controllers/BindingRegistry.cpp`, `aliases/TargetResolver.cpp`
- `daw/audio`: `midi/MidiInputRouter.cpp`, `TrackController.cpp`, `racks/RackSyncManager.cpp`, `modifiers/ModifierSync.cpp`, `plugin_manager/PluginManager.cpp`, `plugin_manager/PluginManagerSync.cpp`, `plugins/DrumGridPlugin.cpp`, `plugins/InternalPluginRegistry.cpp`, `plugins/compiled/CompiledPluginRegistry.cpp`

We're still on C++20 (the C++23 bump, #2144, is parked separately), so `ranges::contains`/`ranges::to` aren't used — "does X exist" checks use `any_of`/`find` + equality instead.

Skipped throughout: anything with genuine side effects tied to loop position or ordering, loop-carried state, or anything on the audio thread (`applyToBuffer`/per-sample/per-message code) — per the issue's stated exception.

A Codex review of the diff caught two real issues before this landed, both fixed:
- A `views::iota(0, count)` conversion where `count` is an externally-supplied `int` field with no non-negativity invariant — `iota` with a negative bound doesn't produce an empty range, it runs away. Clamped with `std::max(0, count)` at both call sites (`InternalPluginRegistry.cpp`, `CompiledPluginRegistry.cpp`).
- A loop in `MidiInputRouter.cpp` that was mis-converted to `any_of`: its body added a device name once *per matching target*, not once total, so collapsing it to `any_of` silently changed multiplicity-sensitive behavior. Reverted to a loop (this shape doesn't fit any_of/find_if — the "Rules" exception for per-match side effects).

Mechanical, no intended behavior change otherwise.

Closes #2146.

## Test plan
- [x] `make debug` — full incremental build, links clean (run twice: once pre-Codex-review, once post-fix)
- [x] `make test` — 3728/3741 test cases passed (13 pre-existing skips), 996,635/996,635 assertions passed, exit 0 (both runs)
- [x] `-fsyntax-only` replay of each touched TU's compile command
- [x] `scripts/comment_ratio.py` on all touched files — all under 20% except `PluginManagerSync.cpp` (24.1%), confirmed pre-existing at `HEAD` before this PR (23.9%, unrelated to this refactor — note also that `--check` silently no-ops when given explicit file paths, a pre-existing script bug, not something this PR introduces or fixes)
- [x] `clang-format -i` on all touched files
- [x] Independent Codex review of the full diff, findings addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0149ko34fXR5PeMBqVL1tDWt