### PR TITLE
Record a MIDI take, from armed to clip

### DIFF
--- a/magda/engine/CMakeLists.txt
+++ b/magda/engine/CMakeLists.txt
@@ -138,6 +138,7 @@ add_library(magda_engine STATIC
     io/SourceLoopInfo.hpp
     io/PrefetchStream.cpp
     io/PrefetchThread.cpp
+    io/MidiTakeRecorder.cpp
     io/RecordStream.cpp
     io/RecordThread.cpp
     io/TakeFileSink.cpp
@@ -149,9 +150,12 @@ add_library(magda_engine STATIC
     io/ClipPlacement.hpp
     io/PrefetchStream.hpp
     io/PrefetchThread.hpp
+    io/MidiTakeRecorder.hpp
     io/RecordStream.hpp
     io/RecordThread.hpp
+    io/RecordingFeed.hpp
     io/TakeFileSink.hpp
+    io/TakePasses.hpp
     io/TakeRecorder.hpp
     io/SourceReaders.hpp
     io/StreamingAudioSource.hpp

--- a/magda/engine/exec/EngineSession.hpp
+++ b/magda/engine/exec/EngineSession.hpp
@@ -10,7 +10,7 @@
 #include "exec/RenderThreadPool.hpp"
 #include "exec/RuntimeStateStore.hpp"
 #include "io/LiveInput.hpp"
-#include "io/TakeRecorder.hpp"
+#include "io/RecordingFeed.hpp"
 #include "launch/SessionLauncher.hpp"
 #include "transport/ClickGenerator.hpp"
 #include "transport/TransportClock.hpp"
@@ -236,7 +236,7 @@ class EngineSession {
     }
 
     /**
-     * @brief The takes the callback writes into (#2461).
+     * @brief The takes the callback writes into (#2461, #2462).
      *
      * Published like the clips are, and outside every plan for the same
      * reason: arming a track compiles a plan, but starting a recording is not

--- a/magda/engine/io/MidiTakeRecorder.cpp
+++ b/magda/engine/io/MidiTakeRecorder.cpp
@@ -1,0 +1,346 @@
+#include "io/MidiTakeRecorder.hpp"
+
+#include <algorithm>
+#include <utility>
+
+#include "exec/EngineDevice.hpp"
+
+namespace magda::engine {
+
+namespace {
+
+constexpr int kMidiChannels = 16;
+constexpr int kNotesPerChannel = 128;
+
+/// What one channel message is, as far as the model has a field for it.
+enum class Kind : std::uint8_t { noteOn, noteOff, controller, pitchBend, unsupported };
+
+Kind kindOf(const RecordedMidiEvent& event) {
+    switch (event.status & 0xf0) {
+        case 0x80:
+            return Kind::noteOff;
+
+        // Running a note on at zero velocity as a note off is the wire rule,
+        // not a courtesy: most controllers never send 0x80 at all.
+        case 0x90:
+            return event.data2 == 0 ? Kind::noteOff : Kind::noteOn;
+
+        case 0xb0:
+            return Kind::controller;
+
+        case 0xe0:
+            return Kind::pitchBend;
+
+        default:
+            return Kind::unsupported;
+    }
+}
+
+int heldIndex(const RecordedMidiEvent& event) {
+    return ((event.status & 0x0f) * kNotesPerChannel) + (event.data1 & 0x7f);
+}
+
+RecordStreamSettings queueFor(const MidiTakeRecorderSettings& settings) {
+    auto queue = settings.stream;
+    queue.numChannels = 0;
+    return queue;
+}
+
+/// A note that has sounded and not yet stopped.
+struct HeldNote {
+    std::int64_t start = -1;
+    int velocity = 0;
+};
+
+}  // namespace
+
+bool MidiTakeSink::writeMidi(std::span<const RecordedMidiEvent> events) {
+    events_.insert(events_.end(), events.begin(), events.end());
+    return true;
+}
+
+MidiTakeRecorder::MidiTakeRecorder(const LiveInputFeed& feed, MidiTakeRecorderSettings settings)
+    : settings_(std::move(settings)),
+      input_(feed, settings_.source, settings_.latencySamples),
+      stream_(sink_, queueFor(settings_)) {
+    // Sized once, so a block's events are copied into it and never allocate.
+    events_.ensureSize(static_cast<std::size_t>(kMaxMidiBytesPerPort));
+}
+
+void MidiTakeRecorder::capture(const BlockInfo& block, bool countingIn, const LoopRange& loop) {
+    if (state_ == State::stopped)
+        return;
+
+    // A count-in is time before the play position and a stop is where a take
+    // ends, so neither is part of one.
+    if (!block.playing || countingIn) {
+        if (state_ == State::rolling)
+            stop();
+
+        return;
+    }
+
+    if (state_ == State::waiting) {
+        start(block, loop);
+    } else if (!block.continuous) {
+        if (!atLoopStart(block, loop)) {
+            stop();
+            return;
+        }
+
+        openPass(loop);
+    }
+
+    write(block);
+    arrivals_ += block.numSamples;
+}
+
+void MidiTakeRecorder::start(const BlockInfo& block, const LoopRange& loop) {
+    state_ = State::rolling;
+    rolled_ = true;
+    rolling_.store(true, std::memory_order_relaxed);
+
+    startBeat_ = block.beats.start;
+    startSeconds_ = block.seconds.start;
+    sampleRate_ = block.rate();
+    origin_ = block.materialOrigin;
+    startedAtLoopStart_ = atLoopStart(block, loop);
+}
+
+void MidiTakeRecorder::openPass(const LoopRange& loop) {
+    loopStartBeat_ = loop.startBeat;
+    loopEndBeat_ = loop.endBeat;
+
+    // Where the wrap is: the timeline the transport has rolled, which is the
+    // take's own domain and owes the input's latency nothing. No clamp against
+    // what has been queued either, because nothing is committed until finish()
+    // -- an event queued early under a negative adjustment crosses this
+    // boundary rather than pushing it.
+    if (numBoundaries_ == kMaxPasses) {
+        ++boundariesLost_;
+        return;
+    }
+
+    boundaries_[numBoundaries_++] = arrivals_;
+}
+
+void MidiTakeRecorder::stop() {
+    state_ = State::stopped;
+    rolling_.store(false, std::memory_order_relaxed);
+}
+
+void MidiTakeRecorder::write(const BlockInfo& block) {
+    events_.clear();
+    input_.render(block, events_);
+
+    end_ = arrivals_ + block.numSamples - settings_.latencySamples;
+
+    if (events_.isEmpty())
+        return;
+
+    // The one head correction, applied on the way in: everything downstream
+    // reads take positions and never has to know what the latency was.
+    stream_.writeMidi(events_, arrivals_ - settings_.latencySamples);
+    captured_.fetch_add(events_.getNumEvents(), std::memory_order_relaxed);
+}
+
+double MidiTakeRecorder::timeAt(std::int64_t sample) const {
+    if (sampleRate_ <= 0.0)
+        return startSeconds_;
+
+    return startSeconds_ + (static_cast<double>(sample) / sampleRate_);
+}
+
+double MidiTakeRecorder::beatAt(const TempoMap& tempo, double moment) const {
+    return tempo.timeToBeat(moment + origin_.seconds) - origin_.beat;
+}
+
+/**
+ * @brief The events, split into the passes @p edges names and put into beats.
+ *
+ * One walk in arrival order: a pass is closed when an event lands past its end,
+ * which is what makes a note held across a wrap belong to the pass it started
+ * in rather than to both.
+ */
+std::vector<MidiTake> MidiTakeRecorder::passesFrom(const TempoMap& tempo,
+                                                   std::span<const std::int64_t> edges) {
+    const auto numPasses = edges.size() - 1;
+    std::vector<MidiTake> takes(numPasses);
+
+    std::vector<double> passStartBeat(numPasses);
+    for (std::size_t pass = 0; pass < numPasses; ++pass)
+        passStartBeat[pass] = beatAt(tempo, timeAt(edges[pass]));
+
+    std::vector<HeldNote> held(kMidiChannels * kNotesPerChannel);
+
+    // A note the pass owns, positioned against the pass it started in.
+    const auto closeNote = [&](std::size_t pass, int index, std::int64_t endSample) {
+        auto& note = held[static_cast<std::size_t>(index)];
+        if (note.start < 0)
+            return;
+
+        const auto from = beatAt(tempo, timeAt(note.start)) - passStartBeat[pass];
+        const auto to = beatAt(tempo, timeAt(endSample)) - passStartBeat[pass];
+
+        // A note whose whole length fell outside the pass never sounded in it.
+        if (to > from)
+            takes[pass].notes.push_back(MidiNote{.noteNumber = index % kNotesPerChannel,
+                                                 .velocity = note.velocity,
+                                                 .startBeat = from,
+                                                 .lengthBeats = to - from});
+
+        note = {};
+    };
+
+    // Every note still down when a pass ends stops there: a note held across a
+    // wrap belongs to the pass it started in, once, and the pass is the clip.
+    const auto closePass = [&](std::size_t pass) {
+        for (auto index = 0; index < kMidiChannels * kNotesPerChannel; ++index)
+            closeNote(pass, index, edges[pass + 1]);
+    };
+
+    std::size_t pass = 0;
+
+    for (const auto& event : sink_.events()) {
+        if (event.sample < edges.front())
+            continue;
+
+        if (event.sample >= edges.back())
+            break;
+
+        while (pass + 1 < numPasses && event.sample >= edges[pass + 1]) {
+            closePass(pass);
+            ++pass;
+        }
+
+        const auto beatOf = [&] {
+            return beatAt(tempo, timeAt(event.sample)) - passStartBeat[pass];
+        };
+
+        switch (kindOf(event)) {
+            case Kind::noteOn:
+                held[static_cast<std::size_t>(heldIndex(event))] = {event.sample, event.data2};
+                break;
+
+            case Kind::noteOff:
+                closeNote(pass, heldIndex(event), event.sample);
+                break;
+
+            case Kind::controller:
+                takes[pass].cc.push_back(MidiCCData{.controller = event.data1,
+                                                    .value = event.data2,
+                                                    .beatPosition = beatOf(),
+                                                    .curveType = MidiCurveType::Step});
+                break;
+
+            case Kind::pitchBend:
+                takes[pass].pitchBend.push_back(
+                    MidiPitchBendData{.value = event.data1 | (event.data2 << 7),
+                                      .beatPosition = beatOf(),
+                                      .curveType = MidiCurveType::Step});
+                break;
+
+            // Program change, aftertouch, channel pressure, anything from the
+            // system: the model has nowhere to put them, and this is where that
+            // is said rather than inside a converter.
+            case Kind::unsupported:
+                ++result_.messagesDropped;
+                break;
+        }
+    }
+
+    // Whatever was still down when the take ended: a note you were still
+    // holding lasted until then.
+    for (; pass < numPasses; ++pass)
+        closePass(pass);
+
+    // Emitted when they close, so a long note would otherwise sit behind the
+    // short ones that started after it.
+    for (auto& take : takes)
+        std::ranges::sort(take.notes, {}, &MidiNote::startBeat);
+
+    return takes;
+}
+
+RecordedMidiTake MidiTakeRecorder::finish(const TempoMap& tempo) {
+    if (finished_)
+        return result_;
+
+    finished_ = true;
+    stop();
+    stream_.finish();
+
+    result_.eventsLost = stream_.eventsLost();
+    result_.passesLost = boundariesLost_;
+    result_.recorded = rolled_;
+
+    if (!rolled_) {
+        placeClip(tempo, result_);
+        return result_;
+    }
+
+    // The take's passes as edges in its own positions: it opens at zero, every
+    // wrap closes one, and the last block closes the last.
+    std::vector<std::int64_t> edges;
+    edges.reserve(numBoundaries_ + 2);
+    edges.push_back(0);
+
+    for (std::size_t at = 0; at < numBoundaries_; ++at)
+        edges.push_back(std::max(boundaries_[at], edges.back()));
+
+    edges.push_back(std::max(end_, edges.back()));
+
+    // A pass of no length is not a pass: a wrap landing on the take's last
+    // sample, or a stop between a wrap and the samples it was waiting for.
+    edges.erase(std::unique(edges.begin(), edges.end()), edges.end());
+
+    if (edges.size() < 2) {
+        placeClip(tempo, result_);
+        return result_;
+    }
+
+    // A first pass that did not begin on the loop start is a lead-in: with no
+    // offset of its own it cannot share the clip start the others do, and a
+    // wrap having happened at all is what makes it a lead-in rather than the
+    // whole recording.
+    if (edges.size() > 2 && !startedAtLoopStart_)
+        edges.erase(edges.begin());
+
+    const auto numPasses = edges.size() - 1;
+    auto takes = passesFrom(tempo, edges);
+
+    std::vector<std::int64_t> lengths;
+    lengths.reserve(numPasses);
+    for (std::size_t at = 0; at < numPasses; ++at)
+        lengths.push_back(edges[at + 1] - edges[at]);
+
+    const auto active = activeTake(lengths);
+    result_.active = takes[active];
+
+    // One pass is an ordinary clip, and the model keeps `takes` empty for one
+    // of those: they are loop-record alternatives or nothing.
+    if (numPasses > 1) {
+        result_.clip.takes = std::move(takes);
+        result_.clip.currentTakeIndex = static_cast<int>(active);
+    }
+
+    placeClip(tempo, result_);
+    return result_;
+}
+
+void MidiTakeRecorder::placeClip(const TempoMap& tempo, RecordedMidiTake& take) const {
+    // Loop-aligned once a pass boundary has actually been reached, rather than
+    // once a wrap has been seen: a take stopped between the two holds only the
+    // stretch it began on, and putting that at the loop start would play it
+    // somewhere it was never recorded.
+    if (numBoundaries_ > 0 && end_ > boundaries_[0]) {
+        take.startBeat = loopStartBeat_;
+        take.lengthBeats = std::max(0.0, loopEndBeat_ - loopStartBeat_);
+        return;
+    }
+
+    take.startBeat = startBeat_;
+    take.lengthBeats = std::max(0.0, beatAt(tempo, timeAt(end_)) - startBeat_);
+}
+
+}  // namespace magda::engine

--- a/magda/engine/io/MidiTakeRecorder.cpp
+++ b/magda/engine/io/MidiTakeRecorder.cpp
@@ -1,6 +1,8 @@
 #include "io/MidiTakeRecorder.hpp"
 
 #include <algorithm>
+#include <cstddef>
+#include <functional>
 #include <utility>
 
 #include "exec/EngineDevice.hpp"
@@ -9,26 +11,31 @@ namespace magda::engine {
 
 namespace {
 
-constexpr int kMidiChannels = 16;
-constexpr int kNotesPerChannel = 128;
+constexpr std::size_t kMidiChannels = 16;
+constexpr std::size_t kNotesPerChannel = 128;
+constexpr std::size_t kHeldNotes = kMidiChannels * kNotesPerChannel;
+
+constexpr unsigned kTypeMask = 0xf0U;
+constexpr unsigned kChannelMask = 0x0fU;
+constexpr unsigned kDataMask = 0x7fU;
 
 /// What one channel message is, as far as the model has a field for it.
 enum class Kind : std::uint8_t { noteOn, noteOff, controller, pitchBend, unsupported };
 
 Kind kindOf(const RecordedMidiEvent& event) {
-    switch (event.status & 0xf0) {
-        case 0x80:
+    switch (static_cast<unsigned>(event.status) & kTypeMask) {
+        case 0x80U:
             return Kind::noteOff;
 
-        // Running a note on at zero velocity as a note off is the wire rule,
-        // not a courtesy: most controllers never send 0x80 at all.
-        case 0x90:
+        // Note on at zero velocity is a note off: the wire rule, and most
+        // controllers never send 0x80 at all.
+        case 0x90U:
             return event.data2 == 0 ? Kind::noteOff : Kind::noteOn;
 
-        case 0xb0:
+        case 0xb0U:
             return Kind::controller;
 
-        case 0xe0:
+        case 0xe0U:
             return Kind::pitchBend;
 
         default:
@@ -36,8 +43,18 @@ Kind kindOf(const RecordedMidiEvent& event) {
     }
 }
 
-int heldIndex(const RecordedMidiEvent& event) {
-    return ((event.status & 0x0f) * kNotesPerChannel) + (event.data1 & 0x7f);
+/// Where a channel's note sits in the held table.
+std::size_t heldIndex(const RecordedMidiEvent& event) {
+    const auto channel = static_cast<unsigned>(event.status) & kChannelMask;
+    const auto note = static_cast<unsigned>(event.data1) & kDataMask;
+    return (static_cast<std::size_t>(channel) * kNotesPerChannel) + note;
+}
+
+/// The 14 bits a pitch wheel splits across its two data bytes.
+int pitchBendValue(const RecordedMidiEvent& event) {
+    const auto low = static_cast<unsigned>(event.data1) & kDataMask;
+    const auto high = static_cast<unsigned>(event.data2) & kDataMask;
+    return static_cast<int>((high << 7U) | low);
 }
 
 RecordStreamSettings queueFor(const MidiTakeRecorderSettings& settings) {
@@ -52,6 +69,136 @@ struct HeldNote {
     int velocity = 0;
 };
 
+/**
+ * @brief A take's events, split into the passes an edge list names, in beats.
+ *
+ * Fed in arrival order. A pass is closed when an event lands past its end, so a
+ * note held across a wrap belongs to the pass it started in.
+ */
+class PassWalk {
+  public:
+    /// @p beatOf gives the take-relative beat of a take position.
+    PassWalk(std::span<const std::int64_t> edges, std::function<double(std::int64_t)> beatOf)
+        : edges_(edges), beatOf_(std::move(beatOf)), takes_(edges.size() - 1), held_(kHeldNotes) {
+        passStart_.reserve(takes_.size());
+
+        for (std::size_t pass = 0; pass < takes_.size(); ++pass)
+            passStart_.push_back(beatOf_(edges_[pass]));
+    }
+
+    void add(const RecordedMidiEvent& event);
+
+    /// Close every pass still open and hand the takes over.
+    std::vector<MidiTake> close();
+
+    /// Events with no field in the model.
+    std::int64_t dropped() const {
+        return dropped_;
+    }
+
+  private:
+    double beatIn(std::size_t pass, std::int64_t sample) const {
+        return beatOf_(sample) - passStart_[pass];
+    }
+
+    void closeNote(std::size_t pass, std::size_t index, std::int64_t endSample);
+    void closePass(std::size_t pass);
+
+    std::span<const std::int64_t> edges_;
+    std::function<double(std::int64_t)> beatOf_;
+    std::vector<double> passStart_;
+    std::vector<MidiTake> takes_;
+    std::vector<HeldNote> held_;
+
+    std::size_t pass_ = 0;
+    std::int64_t dropped_ = 0;
+};
+
+/// A note the pass owns, positioned against the pass it started in.
+void PassWalk::closeNote(std::size_t pass, std::size_t index, std::int64_t endSample) {
+    auto& note = held_[index];
+    if (note.start < 0)
+        return;
+
+    const auto from = beatIn(pass, note.start);
+    const auto to = beatIn(pass, endSample);
+
+    // A note whose length fell wholly outside the pass never sounded in it.
+    if (to > from) {
+        MidiNote played;
+        played.noteNumber = static_cast<int>(index % kNotesPerChannel);
+        played.velocity = note.velocity;
+        played.startBeat = from;
+        played.lengthBeats = to - from;
+        takes_[pass].notes.push_back(played);
+    }
+
+    note = {};
+}
+
+// A note held across a wrap belongs to the pass it started in, once.
+void PassWalk::closePass(std::size_t pass) {
+    for (std::size_t index = 0; index < kHeldNotes; ++index)
+        closeNote(pass, index, edges_[pass + 1]);
+}
+
+void PassWalk::add(const RecordedMidiEvent& event) {
+    if (event.sample < edges_.front() || event.sample >= edges_.back())
+        return;
+
+    while (pass_ + 1 < takes_.size() && event.sample >= edges_[pass_ + 1]) {
+        closePass(pass_);
+        ++pass_;
+    }
+
+    switch (kindOf(event)) {
+        case Kind::noteOn:
+            held_[heldIndex(event)] = {.start = event.sample, .velocity = event.data2};
+            break;
+
+        case Kind::noteOff:
+            closeNote(pass_, heldIndex(event), event.sample);
+            break;
+
+        case Kind::controller: {
+            MidiCCData cc;
+            cc.controller = event.data1;
+            cc.value = event.data2;
+            cc.beatPosition = beatIn(pass_, event.sample);
+            cc.curveType = MidiCurveType::Step;
+            takes_[pass_].cc.push_back(cc);
+            break;
+        }
+
+        case Kind::pitchBend: {
+            MidiPitchBendData bend;
+            bend.value = pitchBendValue(event);
+            bend.beatPosition = beatIn(pass_, event.sample);
+            bend.curveType = MidiCurveType::Step;
+            takes_[pass_].pitchBend.push_back(bend);
+            break;
+        }
+
+        // Program change, aftertouch, pressure, system: no field to put them
+        // in, counted here rather than dropped inside a converter.
+        case Kind::unsupported:
+            ++dropped_;
+            break;
+    }
+}
+
+std::vector<MidiTake> PassWalk::close() {
+    // A note still down when the take ended lasted until it did.
+    for (; pass_ < takes_.size(); ++pass_)
+        closePass(pass_);
+
+    // Emitted when they close, so a long note lands behind later short ones.
+    for (auto& take : takes_)
+        std::ranges::sort(take.notes, {}, &MidiNote::startBeat);
+
+    return std::move(takes_);
+}
+
 }  // namespace
 
 bool MidiTakeSink::writeMidi(std::span<const RecordedMidiEvent> events) {
@@ -59,8 +206,9 @@ bool MidiTakeSink::writeMidi(std::span<const RecordedMidiEvent> events) {
     return true;
 }
 
-MidiTakeRecorder::MidiTakeRecorder(const LiveInputFeed& feed, MidiTakeRecorderSettings settings)
-    : settings_(std::move(settings)),
+MidiTakeRecorder::MidiTakeRecorder(const LiveInputFeed& feed,
+                                   const MidiTakeRecorderSettings& settings)
+    : settings_(settings),
       input_(feed, settings_.source, settings_.latencySamples),
       stream_(sink_, queueFor(settings_)) {
     // Sized once, so a block's events are copied into it and never allocate.
@@ -111,11 +259,9 @@ void MidiTakeRecorder::openPass(const LoopRange& loop) {
     loopStartBeat_ = loop.startBeat;
     loopEndBeat_ = loop.endBeat;
 
-    // Where the wrap is: the timeline the transport has rolled, which is the
-    // take's own domain and owes the input's latency nothing. No clamp against
-    // what has been queued either, because nothing is committed until finish()
-    // -- an event queued early under a negative adjustment crosses this
-    // boundary rather than pushing it.
+    // The timeline the transport has rolled, which owes the input's latency
+    // nothing. Unclamped: nothing is committed until finish(), so an event
+    // queued early crosses this boundary rather than pushing it.
     if (numBoundaries_ == kMaxPasses) {
         ++boundariesLost_;
         return;
@@ -138,8 +284,7 @@ void MidiTakeRecorder::write(const BlockInfo& block) {
     if (events_.isEmpty())
         return;
 
-    // The one head correction, applied on the way in: everything downstream
-    // reads take positions and never has to know what the latency was.
+    // The one head correction, applied on the way in.
     stream_.writeMidi(events_, arrivals_ - settings_.latencySamples);
     captured_.fetch_add(events_.getNumEvents(), std::memory_order_relaxed);
 }
@@ -155,110 +300,15 @@ double MidiTakeRecorder::beatAt(const TempoMap& tempo, double moment) const {
     return tempo.timeToBeat(moment + origin_.seconds) - origin_.beat;
 }
 
-/**
- * @brief The events, split into the passes @p edges names and put into beats.
- *
- * One walk in arrival order: a pass is closed when an event lands past its end,
- * which is what makes a note held across a wrap belong to the pass it started
- * in rather than to both.
- */
 std::vector<MidiTake> MidiTakeRecorder::passesFrom(const TempoMap& tempo,
                                                    std::span<const std::int64_t> edges) {
-    const auto numPasses = edges.size() - 1;
-    std::vector<MidiTake> takes(numPasses);
+    PassWalk walk(edges, [&](std::int64_t sample) { return beatAt(tempo, timeAt(sample)); });
 
-    std::vector<double> passStartBeat(numPasses);
-    for (std::size_t pass = 0; pass < numPasses; ++pass)
-        passStartBeat[pass] = beatAt(tempo, timeAt(edges[pass]));
+    for (const auto& event : sink_.events())
+        walk.add(event);
 
-    std::vector<HeldNote> held(kMidiChannels * kNotesPerChannel);
-
-    // A note the pass owns, positioned against the pass it started in.
-    const auto closeNote = [&](std::size_t pass, int index, std::int64_t endSample) {
-        auto& note = held[static_cast<std::size_t>(index)];
-        if (note.start < 0)
-            return;
-
-        const auto from = beatAt(tempo, timeAt(note.start)) - passStartBeat[pass];
-        const auto to = beatAt(tempo, timeAt(endSample)) - passStartBeat[pass];
-
-        // A note whose whole length fell outside the pass never sounded in it.
-        if (to > from)
-            takes[pass].notes.push_back(MidiNote{.noteNumber = index % kNotesPerChannel,
-                                                 .velocity = note.velocity,
-                                                 .startBeat = from,
-                                                 .lengthBeats = to - from});
-
-        note = {};
-    };
-
-    // Every note still down when a pass ends stops there: a note held across a
-    // wrap belongs to the pass it started in, once, and the pass is the clip.
-    const auto closePass = [&](std::size_t pass) {
-        for (auto index = 0; index < kMidiChannels * kNotesPerChannel; ++index)
-            closeNote(pass, index, edges[pass + 1]);
-    };
-
-    std::size_t pass = 0;
-
-    for (const auto& event : sink_.events()) {
-        if (event.sample < edges.front())
-            continue;
-
-        if (event.sample >= edges.back())
-            break;
-
-        while (pass + 1 < numPasses && event.sample >= edges[pass + 1]) {
-            closePass(pass);
-            ++pass;
-        }
-
-        const auto beatOf = [&] {
-            return beatAt(tempo, timeAt(event.sample)) - passStartBeat[pass];
-        };
-
-        switch (kindOf(event)) {
-            case Kind::noteOn:
-                held[static_cast<std::size_t>(heldIndex(event))] = {event.sample, event.data2};
-                break;
-
-            case Kind::noteOff:
-                closeNote(pass, heldIndex(event), event.sample);
-                break;
-
-            case Kind::controller:
-                takes[pass].cc.push_back(MidiCCData{.controller = event.data1,
-                                                    .value = event.data2,
-                                                    .beatPosition = beatOf(),
-                                                    .curveType = MidiCurveType::Step});
-                break;
-
-            case Kind::pitchBend:
-                takes[pass].pitchBend.push_back(
-                    MidiPitchBendData{.value = event.data1 | (event.data2 << 7),
-                                      .beatPosition = beatOf(),
-                                      .curveType = MidiCurveType::Step});
-                break;
-
-            // Program change, aftertouch, channel pressure, anything from the
-            // system: the model has nowhere to put them, and this is where that
-            // is said rather than inside a converter.
-            case Kind::unsupported:
-                ++result_.messagesDropped;
-                break;
-        }
-    }
-
-    // Whatever was still down when the take ended: a note you were still
-    // holding lasted until then.
-    for (; pass < numPasses; ++pass)
-        closePass(pass);
-
-    // Emitted when they close, so a long note would otherwise sit behind the
-    // short ones that started after it.
-    for (auto& take : takes)
-        std::ranges::sort(take.notes, {}, &MidiNote::startBeat);
-
+    auto takes = walk.close();
+    result_.messagesDropped += walk.dropped();
     return takes;
 }
 
@@ -279,8 +329,8 @@ RecordedMidiTake MidiTakeRecorder::finish(const TempoMap& tempo) {
         return result_;
     }
 
-    // The take's passes as edges in its own positions: it opens at zero, every
-    // wrap closes one, and the last block closes the last.
+    // Pass edges in the take's own positions: it opens at zero, every wrap
+    // closes one, and the last block closes the last.
     std::vector<std::int64_t> edges;
     edges.reserve(numBoundaries_ + 2);
     edges.push_back(0);
@@ -290,8 +340,7 @@ RecordedMidiTake MidiTakeRecorder::finish(const TempoMap& tempo) {
 
     edges.push_back(std::max(end_, edges.back()));
 
-    // A pass of no length is not a pass: a wrap landing on the take's last
-    // sample, or a stop between a wrap and the samples it was waiting for.
+    // A pass of no length is not a pass.
     edges.erase(std::unique(edges.begin(), edges.end()), edges.end());
 
     if (edges.size() < 2) {
@@ -299,10 +348,8 @@ RecordedMidiTake MidiTakeRecorder::finish(const TempoMap& tempo) {
         return result_;
     }
 
-    // A first pass that did not begin on the loop start is a lead-in: with no
-    // offset of its own it cannot share the clip start the others do, and a
-    // wrap having happened at all is what makes it a lead-in rather than the
-    // whole recording.
+    // A first pass that did not begin on the loop start is a lead-in: MidiTake
+    // has no offset of its own, so it cannot share the clip start.
     if (edges.size() > 2 && !startedAtLoopStart_)
         edges.erase(edges.begin());
 
@@ -317,8 +364,8 @@ RecordedMidiTake MidiTakeRecorder::finish(const TempoMap& tempo) {
     const auto active = activeTake(lengths);
     result_.active = takes[active];
 
-    // One pass is an ordinary clip, and the model keeps `takes` empty for one
-    // of those: they are loop-record alternatives or nothing.
+    // The model keeps `takes` empty for a single pass: they are loop-record
+    // alternatives or nothing.
     if (numPasses > 1) {
         result_.clip.takes = std::move(takes);
         result_.clip.currentTakeIndex = static_cast<int>(active);
@@ -329,10 +376,8 @@ RecordedMidiTake MidiTakeRecorder::finish(const TempoMap& tempo) {
 }
 
 void MidiTakeRecorder::placeClip(const TempoMap& tempo, RecordedMidiTake& take) const {
-    // Loop-aligned once a pass boundary has actually been reached, rather than
-    // once a wrap has been seen: a take stopped between the two holds only the
-    // stretch it began on, and putting that at the loop start would play it
-    // somewhere it was never recorded.
+    // Loop-aligned once a boundary has been reached, not once a wrap has been
+    // seen: a take stopped between the two holds only the stretch it began on.
     if (numBoundaries_ > 0 && end_ > boundaries_[0]) {
         take.startBeat = loopStartBeat_;
         take.lengthBeats = std::max(0.0, loopEndBeat_ - loopStartBeat_);

--- a/magda/engine/io/MidiTakeRecorder.hpp
+++ b/magda/engine/io/MidiTakeRecorder.hpp
@@ -22,29 +22,9 @@
  * @file MidiTakeRecorder.hpp
  * @brief A MIDI take, from armed to clip (#2462).
  *
- * The same pass as an audio take and the other kind of material: the live MIDI
- * slice 1 delivers, through the queue slice 2 drains, into the notes a clip is
- * made of. The loop rules are shared with audio (io/TakePasses.hpp) because
- * they are the model's rather than either kind's.
- *
- * What differs is what a position costs. An audio take is committed to a file
- * as it goes, so a pass boundary can never be named behind what is already
- * queued and a negative adjustment lengthens the first pass. Nothing here is
- * committed until @ref MidiTakeRecorder::finish, so a boundary is named where
- * the wrap is and events fall either side of it by their own stamps: a
- * negative adjustment moves an event across a boundary rather than moving the
- * boundary.
- *
- * Every event is stamped in the take's own positions on the way into the queue
- * -- `arrival - latency`, the one head correction, applied once -- so nothing
- * downstream has to know what the input's latency was. An event landing before
- * the take started is one that arrived before the playhead reached it, and is
- * dropped.
- *
- * Beats are the domain, and the conversion is the last step rather than the
- * first: the audio thread stamps samples, and @ref MidiTakeRecorder::finish
- * asks the tempo map where each one falls. A pass recorded across a tempo
- * change therefore lands where it was played.
+ * The MIDI half of io/TakeRecorder.hpp, over the loop rules both share
+ * (io/TakePasses.hpp). Events are stamped in the take's own positions on the
+ * way into the queue and resolved to beats in finish(), where the tempo map is.
  */
 
 namespace magda::engine {
@@ -55,29 +35,26 @@ struct RecordedMidiTake {
     double startBeat = 0.0;
     double lengthBeats = 0.0;
 
-    /// What the clip plays: the active take's events, which the model holds on
-    /// the clip itself rather than reaching into `clip.takes` for.
+    /// What the clip plays. The model holds these on the clip itself rather
+    /// than reaching into `clip.takes` for them.
     MidiTake active;
 
-    /// The passes and the one that plays. `takes` is empty for a single pass,
-    /// which is what an ordinary clip is.
+    /// The passes and the one that plays. `takes` is empty for a single pass.
     MidiClipModel clip;
 
-    /// Whether the take ever rolled. A recording that captured no events is
-    /// still a take, because an empty MIDI clip is a legitimate result.
+    /// Whether the take ever rolled. A take that captured no events is still a
+    /// take: an empty MIDI clip is a legitimate result.
     bool recorded = false;
 
     /// Events the queue had no room for, or that were longer than the three
-    /// bytes it carries. Above zero is a hole in the performance.
+    /// bytes it carries.
     std::int64_t eventsLost = 0;
 
-    /// Events that arrived whole and have no field in the model: program
-    /// change, aftertouch, channel pressure, anything from the system. Dropped
-    /// here, where it can be said, rather than inside a converter.
+    /// Events with no field in the model: program change, aftertouch, channel
+    /// pressure, anything from the system.
     std::int64_t messagesDropped = 0;
 
-    /// Pass ends that did not fit, which is two loop passes run together in
-    /// one take. Above zero and `clip.takes` is not one pass each.
+    /// Pass ends that did not fit, which is two loop passes run together.
     std::int64_t passesLost = 0;
 
     bool empty() const {
@@ -90,17 +67,11 @@ struct MidiTakeRecorderSettings {
     /// Which input the take listens to, or kAnyLiveMidiSource for all of them.
     LiveMidiSourceId source = kAnyLiveMidiSource;
 
-    /**
-     * @brief The input's declared latency, in samples (#2459).
-     *
-     * What arrived has already happened, so an event's place on the timeline is
-     * `arrival - latency`: a positive latency drops what arrived before the
-     * take started, and a negative one moves everything that much later.
-     */
+    /// The input's declared latency, in samples (#2459). An event's place on
+    /// the timeline is `arrival - latency`.
     int latencySamples = 0;
 
-    /// How much the queue holds. Its channel count is always zero: a MIDI take
-    /// has no audio to carry.
+    /// How much the queue holds. Its channel count is always zero.
     RecordStreamSettings stream;
 };
 
@@ -123,12 +94,11 @@ class MidiTakeSink final : public RecordSink {
  *        stops it.
  *
  * It captures from the first block the transport is rolling and not counting
- * in, and stops at the first block it is not: a take is closed by a stop, and a
- * second play is a second take.
+ * in, and stops at the first block it is not.
  */
 class MidiTakeRecorder final : public TakeCapture {
   public:
-    MidiTakeRecorder(const LiveInputFeed& feed, MidiTakeRecorderSettings settings);
+    MidiTakeRecorder(const LiveInputFeed& feed, const MidiTakeRecorderSettings& settings);
 
     ~MidiTakeRecorder() override = default;
 
@@ -146,8 +116,7 @@ class MidiTakeRecorder final : public TakeCapture {
 
     void capture(const BlockInfo& block, bool countingIn, const LoopRange& loop) override;
 
-    /// Events offered to the queue so far. Read from any thread; what a running
-    /// take is drawn from (#2463).
+    /// Events offered to the queue so far. Read from any thread (#2463).
     std::int64_t capturedEvents() const {
         return captured_.load(std::memory_order_relaxed);
     }
@@ -158,24 +127,19 @@ class MidiTakeRecorder final : public TakeCapture {
     }
 
     /**
-     * @brief Close the take and say what it became.
+     * @brief Close the take and say what it became. Off the audio thread.
      *
-     * Off the audio thread, after the callback can no longer reach this. @p
-     * tempo is asked for every event's beat, which is why it is a parameter
-     * here where the audio take needs none: an audio take converts one
-     * position as it goes, and this one has nothing to convert until the queue
-     * has given the events back.
-     *
-     * Idempotent, and a take that never rolled comes back empty.
+     * @p tempo resolves every event's beat, which an audio take needs no
+     * parameter for because it converts one position as it goes. Idempotent,
+     * and a take that never rolled comes back empty.
      */
     RecordedMidiTake finish(const TempoMap& tempo);
 
   private:
     enum class State : std::uint8_t { waiting, rolling, stopped };
 
-    /// Pass ends one take can hold. As TakeFileSink's own lane: what will not
-    /// fit is refused rather than dropped, so a take can say its passes ran
-    /// together.
+    /// Pass ends one take can hold, as TakeFileSink's own lane: what will not
+    /// fit is refused rather than dropped.
     static constexpr std::size_t kMaxPasses = 256;
 
     void start(const BlockInfo& block, const LoopRange& loop);
@@ -225,8 +189,7 @@ class MidiTakeRecorder final : public TakeCapture {
     double startSeconds_ = 0.0;
     double sampleRate_ = 0.0;
 
-    /// The block's own beat origin, so a beat is read here exactly as the
-    /// render read it.
+    /// The block's own beat origin, so a beat is read here as the render read it.
     MaterialOrigin origin_;
 
     /// Whether the take ever rolled, which a stop cannot be read back from.

--- a/magda/engine/io/MidiTakeRecorder.hpp
+++ b/magda/engine/io/MidiTakeRecorder.hpp
@@ -1,0 +1,250 @@
+#pragma once
+
+#include <juce_audio_basics/juce_audio_basics.h>
+
+#include <array>
+#include <atomic>
+#include <cstdint>
+#include <span>
+#include <vector>
+
+#include "core/ClipInfo.hpp"
+#include "exec/RenderContext.hpp"
+#include "io/LiveInput.hpp"
+#include "io/RecordStream.hpp"
+#include "io/RecordingFeed.hpp"
+#include "io/TakePasses.hpp"
+#include "transport/TempoMap.hpp"
+#include "transport/TimeDomains.hpp"
+#include "transport/TransportState.hpp"
+
+/**
+ * @file MidiTakeRecorder.hpp
+ * @brief A MIDI take, from armed to clip (#2462).
+ *
+ * The same pass as an audio take and the other kind of material: the live MIDI
+ * slice 1 delivers, through the queue slice 2 drains, into the notes a clip is
+ * made of. The loop rules are shared with audio (io/TakePasses.hpp) because
+ * they are the model's rather than either kind's.
+ *
+ * What differs is what a position costs. An audio take is committed to a file
+ * as it goes, so a pass boundary can never be named behind what is already
+ * queued and a negative adjustment lengthens the first pass. Nothing here is
+ * committed until @ref MidiTakeRecorder::finish, so a boundary is named where
+ * the wrap is and events fall either side of it by their own stamps: a
+ * negative adjustment moves an event across a boundary rather than moving the
+ * boundary.
+ *
+ * Every event is stamped in the take's own positions on the way into the queue
+ * -- `arrival - latency`, the one head correction, applied once -- so nothing
+ * downstream has to know what the input's latency was. An event landing before
+ * the take started is one that arrived before the playhead reached it, and is
+ * dropped.
+ *
+ * Beats are the domain, and the conversion is the last step rather than the
+ * first: the audio thread stamps samples, and @ref MidiTakeRecorder::finish
+ * asks the tempo map where each one falls. A pass recorded across a tempo
+ * change therefore lands where it was played.
+ */
+
+namespace magda::engine {
+
+/** @brief What a finished MIDI take became, and what it cost. */
+struct RecordedMidiTake {
+    /// Where the clip goes, and how much of the timeline it covers.
+    double startBeat = 0.0;
+    double lengthBeats = 0.0;
+
+    /// What the clip plays: the active take's events, which the model holds on
+    /// the clip itself rather than reaching into `clip.takes` for.
+    MidiTake active;
+
+    /// The passes and the one that plays. `takes` is empty for a single pass,
+    /// which is what an ordinary clip is.
+    MidiClipModel clip;
+
+    /// Whether the take ever rolled. A recording that captured no events is
+    /// still a take, because an empty MIDI clip is a legitimate result.
+    bool recorded = false;
+
+    /// Events the queue had no room for, or that were longer than the three
+    /// bytes it carries. Above zero is a hole in the performance.
+    std::int64_t eventsLost = 0;
+
+    /// Events that arrived whole and have no field in the model: program
+    /// change, aftertouch, channel pressure, anything from the system. Dropped
+    /// here, where it can be said, rather than inside a converter.
+    std::int64_t messagesDropped = 0;
+
+    /// Pass ends that did not fit, which is two loop passes run together in
+    /// one take. Above zero and `clip.takes` is not one pass each.
+    std::int64_t passesLost = 0;
+
+    bool empty() const {
+        return !recorded;
+    }
+};
+
+/** @brief What a MIDI take reads, and how much it can hold. */
+struct MidiTakeRecorderSettings {
+    /// Which input the take listens to, or kAnyLiveMidiSource for all of them.
+    LiveMidiSourceId source = kAnyLiveMidiSource;
+
+    /**
+     * @brief The input's declared latency, in samples (#2459).
+     *
+     * What arrived has already happened, so an event's place on the timeline is
+     * `arrival - latency`: a positive latency drops what arrived before the
+     * take started, and a negative one moves everything that much later.
+     */
+    int latencySamples = 0;
+
+    /// How much the queue holds. Its channel count is always zero: a MIDI take
+    /// has no audio to carry.
+    RecordStreamSettings stream;
+};
+
+/** @brief The record thread's end of a MIDI take: the events, in arrival order. */
+class MidiTakeSink final : public RecordSink {
+  public:
+    bool writeMidi(std::span<const RecordedMidiEvent> events) override;
+
+    /// After RecordStream::finish, off the record thread.
+    std::span<const RecordedMidiEvent> events() const {
+        return events_;
+    }
+
+  private:
+    std::vector<RecordedMidiEvent> events_;
+};
+
+/**
+ * @brief One MIDI take: fed on the audio thread, closed on the thread that
+ *        stops it.
+ *
+ * It captures from the first block the transport is rolling and not counting
+ * in, and stops at the first block it is not: a take is closed by a stop, and a
+ * second play is a second take.
+ */
+class MidiTakeRecorder final : public TakeCapture {
+  public:
+    MidiTakeRecorder(const LiveInputFeed& feed, MidiTakeRecorderSettings settings);
+
+    ~MidiTakeRecorder() override = default;
+
+    /// Neither copied nor moved: the queue holds a reference to the sink.
+    MidiTakeRecorder(const MidiTakeRecorder&) = delete;
+    MidiTakeRecorder& operator=(const MidiTakeRecorder&) = delete;
+    MidiTakeRecorder(MidiTakeRecorder&&) = delete;
+    MidiTakeRecorder& operator=(MidiTakeRecorder&&) = delete;
+
+    /// The queue the record thread drains. Registered by whoever owns the
+    /// thread, and unregistered before @ref finish.
+    RecordStream& stream() {
+        return stream_;
+    }
+
+    void capture(const BlockInfo& block, bool countingIn, const LoopRange& loop) override;
+
+    /// Events offered to the queue so far. Read from any thread; what a running
+    /// take is drawn from (#2463).
+    std::int64_t capturedEvents() const {
+        return captured_.load(std::memory_order_relaxed);
+    }
+
+    /// Whether the take is still taking blocks. Read from any thread.
+    bool rolling() const {
+        return rolling_.load(std::memory_order_relaxed);
+    }
+
+    /**
+     * @brief Close the take and say what it became.
+     *
+     * Off the audio thread, after the callback can no longer reach this. @p
+     * tempo is asked for every event's beat, which is why it is a parameter
+     * here where the audio take needs none: an audio take converts one
+     * position as it goes, and this one has nothing to convert until the queue
+     * has given the events back.
+     *
+     * Idempotent, and a take that never rolled comes back empty.
+     */
+    RecordedMidiTake finish(const TempoMap& tempo);
+
+  private:
+    enum class State : std::uint8_t { waiting, rolling, stopped };
+
+    /// Pass ends one take can hold. As TakeFileSink's own lane: what will not
+    /// fit is refused rather than dropped, so a take can say its passes ran
+    /// together.
+    static constexpr std::size_t kMaxPasses = 256;
+
+    void start(const BlockInfo& block, const LoopRange& loop);
+
+    /// A wrap: where the pass ended, in the take's own positions.
+    void openPass(const LoopRange& loop);
+
+    void stop();
+
+    /// This block's events, stamped and queued.
+    void write(const BlockInfo& block);
+
+    /// The beat @p moment falls on, as BlockInfo::beatAtTime reads it.
+    double beatAt(const TempoMap& tempo, double moment) const;
+
+    /// The take position @p sample falls on, in seconds.
+    double timeAt(std::int64_t sample) const;
+
+    /// The events, split into the passes @p edges names and put into beats.
+    std::vector<MidiTake> passesFrom(const TempoMap& tempo, std::span<const std::int64_t> edges);
+
+    /// Where the take is, once there is nothing more to add to it.
+    void placeClip(const TempoMap& tempo, RecordedMidiTake& take) const;
+
+    MidiTakeRecorderSettings settings_;
+
+    LiveMidiInput input_;
+    MidiTakeSink sink_;
+    RecordStream stream_;
+
+    /// This block's events, sized once so a capture cannot allocate.
+    juce::MidiBuffer events_;
+
+    State state_ = State::waiting;
+
+    /// The timeline the take has covered, counted in arrivals, and the take
+    /// position its last block reaches. The second is the first corrected by
+    /// the latency, which is the domain every stamp and boundary is in.
+    std::int64_t arrivals_ = 0;
+    std::int64_t end_ = 0;
+
+    std::array<std::int64_t, kMaxPasses> boundaries_{};
+    std::size_t numBoundaries_ = 0;
+    std::int64_t boundariesLost_ = 0;
+
+    double startBeat_ = 0.0;
+    double startSeconds_ = 0.0;
+    double sampleRate_ = 0.0;
+
+    /// The block's own beat origin, so a beat is read here exactly as the
+    /// render read it.
+    MaterialOrigin origin_;
+
+    /// Whether the take ever rolled, which a stop cannot be read back from.
+    bool rolled_ = false;
+
+    /// Whether the take began on the loop start, which is what says its first
+    /// pass is a pass rather than a lead-in.
+    bool startedAtLoopStart_ = false;
+
+    /// The loop the last wrap was seen against.
+    double loopStartBeat_ = 0.0;
+    double loopEndBeat_ = 0.0;
+
+    bool finished_ = false;
+    RecordedMidiTake result_;
+
+    std::atomic<std::int64_t> captured_{0};
+    std::atomic<bool> rolling_{false};
+};
+
+}  // namespace magda::engine

--- a/magda/engine/io/RecordingFeed.hpp
+++ b/magda/engine/io/RecordingFeed.hpp
@@ -20,9 +20,8 @@ namespace magda::engine {
 /**
  * @brief One take being fed, block by block, on the audio thread.
  *
- * Audio (io/TakeRecorder.hpp) and MIDI (io/MidiTakeRecorder.hpp) are the same
- * pass over the same transport, so the callback drives them through one call
- * and a track recording both is two takes rather than a special case.
+ * Audio (io/TakeRecorder.hpp) and MIDI (io/MidiTakeRecorder.hpp) are one call,
+ * so a track recording both is two takes rather than a special case.
  */
 class TakeCapture {
   public:
@@ -31,9 +30,8 @@ class TakeCapture {
     /**
      * @brief Take what this block carried. On the audio thread, once a block.
      *
-     * @p loop is the transport's, and is what tells a loop wrap from a locate:
-     * a wrap opens the next pass, and anything else ends the take, since
-     * material after a jump belongs where the cursor went.
+     * @p loop tells a wrap from a locate: a wrap opens the next pass, anything
+     * else ends the take.
      */
     virtual void capture(const BlockInfo& block, bool countingIn, const LoopRange& loop) = 0;
 };
@@ -46,8 +44,7 @@ using RecordingTakes = std::vector<TakeCapture*>;
  * @brief What the audio thread records into, replaced on the publishing thread.
  *
  * Publishing waits for the block the callback is in, so a take taken out of the
- * set is one nothing is writing to by the time the call returns, which is what
- * makes it safe to finish.
+ * set is safe to finish once the call returns.
  */
 class RecordingFeed {
     using Published = farbot::RealtimeObject<std::shared_ptr<const RecordingTakes>,

--- a/magda/engine/io/RecordingFeed.hpp
+++ b/magda/engine/io/RecordingFeed.hpp
@@ -1,0 +1,83 @@
+#pragma once
+
+#include <farbot/RealtimeObject.hpp>
+#include <memory>
+#include <vector>
+
+#include "exec/RenderContext.hpp"
+#include "transport/TransportState.hpp"
+
+/**
+ * @file RecordingFeed.hpp
+ * @brief What the callback records into, whatever kind of material it is.
+ *
+ * A feed rather than part of a plan: arming a track compiles a plan, but
+ * starting a recording is not a structural edit and must not cost one.
+ */
+
+namespace magda::engine {
+
+/**
+ * @brief One take being fed, block by block, on the audio thread.
+ *
+ * Audio (io/TakeRecorder.hpp) and MIDI (io/MidiTakeRecorder.hpp) are the same
+ * pass over the same transport, so the callback drives them through one call
+ * and a track recording both is two takes rather than a special case.
+ */
+class TakeCapture {
+  public:
+    virtual ~TakeCapture() = default;
+
+    /**
+     * @brief Take what this block carried. On the audio thread, once a block.
+     *
+     * @p loop is the transport's, and is what tells a loop wrap from a locate:
+     * a wrap opens the next pass, and anything else ends the take, since
+     * material after a jump belongs where the cursor went.
+     */
+    virtual void capture(const BlockInfo& block, bool countingIn, const LoopRange& loop) = 0;
+};
+
+/// The takes a callback feeds. Not owned: whoever publishes them keeps them
+/// alive until it has published something that does not name them.
+using RecordingTakes = std::vector<TakeCapture*>;
+
+/**
+ * @brief What the audio thread records into, replaced on the publishing thread.
+ *
+ * Publishing waits for the block the callback is in, so a take taken out of the
+ * set is one nothing is writing to by the time the call returns, which is what
+ * makes it safe to finish.
+ */
+class RecordingFeed {
+    using Published = farbot::RealtimeObject<std::shared_ptr<const RecordingTakes>,
+                                             farbot::RealtimeObjectOptions::nonRealtimeMutatable>;
+
+  public:
+    /// On the publishing thread.
+    void publish(std::shared_ptr<const RecordingTakes> takes) {
+        published_.nonRealtimeReplace(std::move(takes));
+    }
+
+    /// What is live, for as long as this exists. On the audio thread. Null
+    /// until something is published, which is a session recording nothing.
+    class Reader {
+      public:
+        explicit Reader(RecordingFeed& feed) : access_(feed.published_) {}
+
+        const RecordingTakes* get() const noexcept {
+            return (*access_).get();
+        }
+        explicit operator bool() const noexcept {
+            return get() != nullptr;
+        }
+
+      private:
+        Published::ScopedAccess<farbot::ThreadType::realtime> access_;
+    };
+
+  private:
+    Published published_;
+};
+
+}  // namespace magda::engine

--- a/magda/engine/io/TakePasses.hpp
+++ b/magda/engine/io/TakePasses.hpp
@@ -1,0 +1,63 @@
+#pragma once
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <span>
+
+#include "exec/RenderContext.hpp"
+#include "transport/TransportState.hpp"
+
+/**
+ * @file TakePasses.hpp
+ * @brief The loop-record rules a take keeps, whatever it is made of.
+ *
+ * Audio takes are files and MIDI takes are event lists, but which pass plays
+ * and what counts as a pass boundary are the model's questions and have one
+ * answer each (#2461, #2462).
+ */
+
+namespace magda::engine {
+
+/// A wrap anchors the cursor exactly on the loop start, so anything further off
+/// than this is a locate rather than a pass boundary.
+constexpr double kLoopStartTolerance = 1.0e-6;
+
+/// How short the final pass has to be to count as a stop rather than a take.
+constexpr double kFullPassFraction = 0.95;
+
+inline bool atLoopStart(const BlockInfo& block, const LoopRange& loop) {
+    return loop.valid() && std::abs(block.beats.start - loop.startBeat) <= kLoopStartTolerance;
+}
+
+/**
+ * @brief The last full pass, stepping back one if the final pass was cut short.
+ *
+ * Only the last pass can be cut short, and only the first can run long: a
+ * negative adjustment pads its head, and @p headPadding is that padding when
+ * the take's own first pass is still here to carry it. Discounted rather than
+ * measured, so a pass is judged against what was played rather than against a
+ * correction at the top of the file.
+ *
+ * Measured in samples rather than in how much was played into it, because what
+ * makes the final pass different is a stop landing in the middle of it, which
+ * is a fact about its length and not about its contents.
+ */
+inline std::size_t activeTake(std::span<const std::int64_t> lengths, std::int64_t headPadding = 0) {
+    const auto played = [&](std::size_t pass) {
+        return lengths[pass] - (pass == 0 ? headPadding : 0);
+    };
+
+    std::int64_t longest = 0;
+    for (std::size_t pass = 0; pass < lengths.size(); ++pass)
+        longest = std::max(longest, played(pass));
+
+    const auto last = lengths.size() - 1;
+    if (lengths.size() > 1 &&
+        static_cast<double>(played(last)) < static_cast<double>(longest) * kFullPassFraction)
+        return last - 1;
+
+    return last;
+}
+
+}  // namespace magda::engine

--- a/magda/engine/io/TakePasses.hpp
+++ b/magda/engine/io/TakePasses.hpp
@@ -10,11 +10,7 @@
 
 /**
  * @file TakePasses.hpp
- * @brief The loop-record rules a take keeps, whatever it is made of.
- *
- * Audio takes are files and MIDI takes are event lists, but which pass plays
- * and what counts as a pass boundary are the model's questions and have one
- * answer each (#2461, #2462).
+ * @brief The loop-record rules a take keeps, whatever it is made of (#2461, #2462).
  */
 
 namespace magda::engine {
@@ -34,14 +30,7 @@ inline bool atLoopStart(const BlockInfo& block, const LoopRange& loop) {
  * @brief The last full pass, stepping back one if the final pass was cut short.
  *
  * Only the last pass can be cut short, and only the first can run long: a
- * negative adjustment pads its head, and @p headPadding is that padding when
- * the take's own first pass is still here to carry it. Discounted rather than
- * measured, so a pass is judged against what was played rather than against a
- * correction at the top of the file.
- *
- * Measured in samples rather than in how much was played into it, because what
- * makes the final pass different is a stop landing in the middle of it, which
- * is a fact about its length and not about its contents.
+ * negative adjustment pads its head, and @p headPadding discounts that.
  */
 inline std::size_t activeTake(std::span<const std::int64_t> lengths, std::int64_t headPadding = 0) {
     const auto played = [&](std::size_t pass) {

--- a/magda/engine/io/TakeRecorder.cpp
+++ b/magda/engine/io/TakeRecorder.cpp
@@ -9,13 +9,6 @@ namespace magda::engine {
 
 namespace {
 
-/// A wrap anchors the cursor exactly on the loop start, so anything further off
-/// than this is a locate rather than a pass boundary.
-constexpr double kLoopStartTolerance = 1.0e-6;
-
-/// How short the final pass has to be to count as a stop rather than a take.
-constexpr double kFullPassFraction = 0.95;
-
 int takeChannels(const TakeRecorderSettings& settings) {
     return std::max<int>(1, static_cast<int>(settings.channels.size()));
 }
@@ -32,34 +25,15 @@ RecordStreamSettings queueFor(const TakeRecorderSettings& settings) {
     return queue;
 }
 
-bool atLoopStart(const BlockInfo& block, const LoopRange& loop) {
-    return loop.valid() && std::abs(block.beats.start - loop.startBeat) <= kLoopStartTolerance;
-}
+/// The passes' lengths, which is what says which of them plays.
+std::vector<std::int64_t> passLengths(std::span<const RecordedPass> passes) {
+    std::vector<std::int64_t> lengths;
+    lengths.reserve(passes.size());
 
-/**
- * @brief The last full pass, stepping back one if the final pass was cut short.
- *
- * Only the last pass can be cut short, and only the first can run long: a
- * negative adjustment pads its head, and @p headPadding is that padding when
- * the take's own first pass is still here to carry it. Discounted rather than
- * measured, so a pass is judged against what was played rather than against a
- * correction at the top of the file.
- */
-std::size_t activeTake(std::span<const RecordedPass> passes, std::int64_t headPadding) {
-    const auto played = [&](std::size_t pass) {
-        return passes[pass].samples - (pass == 0 ? headPadding : 0);
-    };
+    for (const auto& pass : passes)
+        lengths.push_back(pass.samples);
 
-    std::int64_t longest = 0;
-    for (std::size_t pass = 0; pass < passes.size(); ++pass)
-        longest = std::max(longest, played(pass));
-
-    const auto last = passes.size() - 1;
-    if (passes.size() > 1 &&
-        static_cast<double>(played(last)) < static_cast<double>(longest) * kFullPassFraction)
-        return last - 1;
-
-    return last;
+    return lengths;
 }
 
 }  // namespace
@@ -216,7 +190,7 @@ RecordedTake TakeRecorder::finish() {
     }
 
     if (!passes.empty()) {
-        const auto active = activeTake(passes, headPadding);
+        const auto active = activeTake(passLengths(passes), headPadding);
         result_.file = passes[active].file;
 
         // One pass is an ordinary clip, and the model keeps `takes` empty for

--- a/magda/engine/io/TakeRecorder.hpp
+++ b/magda/engine/io/TakeRecorder.hpp
@@ -4,15 +4,15 @@
 
 #include <atomic>
 #include <cstdint>
-#include <farbot/RealtimeObject.hpp>
-#include <memory>
 #include <vector>
 
 #include "core/ClipInfo.hpp"
 #include "exec/RenderContext.hpp"
 #include "io/LiveInput.hpp"
 #include "io/RecordStream.hpp"
+#include "io/RecordingFeed.hpp"
 #include "io/TakeFileSink.hpp"
+#include "io/TakePasses.hpp"
 #include "transport/TransportState.hpp"
 
 /**
@@ -131,12 +131,12 @@ struct TakeRecorderSettings {
  * not counting in, and stops at the first block it is not: a take is closed by
  * a stop, and a second play is a second take.
  */
-class TakeRecorder {
+class TakeRecorder final : public TakeCapture {
   public:
     TakeRecorder(const LiveInputFeed& feed, const RenderContext& context,
                  TakeRecorderSettings settings);
 
-    ~TakeRecorder() = default;
+    ~TakeRecorder() override = default;
 
     /// Neither copied nor moved: the queue holds a reference to the sink.
     TakeRecorder(const TakeRecorder&) = delete;
@@ -150,14 +150,7 @@ class TakeRecorder {
         return stream_;
     }
 
-    /**
-     * @brief Take what this block carried. On the audio thread, once a block.
-     *
-     * @p loop is the transport's, and is what tells a loop wrap from a locate:
-     * a wrap opens the next pass, and anything else ends the take, since
-     * material after a jump belongs where the cursor went.
-     */
-    void capture(const BlockInfo& block, bool countingIn, const LoopRange& loop);
+    void capture(const BlockInfo& block, bool countingIn, const LoopRange& loop) override;
 
     /// Samples offered to the queue so far. Read from any thread; what a
     /// running take is drawn from (#2463).
@@ -247,50 +240,6 @@ class TakeRecorder {
 
     std::atomic<std::int64_t> captured_{0};
     std::atomic<bool> rolling_{false};
-};
-
-/// The takes a callback feeds. Not owned: whoever publishes them keeps them
-/// alive until it has published something that does not name them.
-using RecordingTakes = std::vector<TakeRecorder*>;
-
-/**
- * @brief What the audio thread records into, replaced on the publishing thread.
- *
- * A feed rather than part of a plan, for the reason the clips are one: arming a
- * track recompiles a plan, but starting a recording is not a structural edit
- * and must not cost one. Publishing waits for the block the callback is in, so
- * a take taken out of the set is one nothing is writing to by the time the call
- * returns, which is what makes it safe to finish.
- */
-class RecordingFeed {
-    using Published = farbot::RealtimeObject<std::shared_ptr<const RecordingTakes>,
-                                             farbot::RealtimeObjectOptions::nonRealtimeMutatable>;
-
-  public:
-    /// On the publishing thread.
-    void publish(std::shared_ptr<const RecordingTakes> takes) {
-        published_.nonRealtimeReplace(std::move(takes));
-    }
-
-    /// What is live, for as long as this exists. On the audio thread. Null
-    /// until something is published, which is a session recording nothing.
-    class Reader {
-      public:
-        explicit Reader(RecordingFeed& feed) : access_(feed.published_) {}
-
-        const RecordingTakes* get() const noexcept {
-            return (*access_).get();
-        }
-        explicit operator bool() const noexcept {
-            return get() != nullptr;
-        }
-
-      private:
-        Published::ScopedAccess<farbot::ThreadType::realtime> access_;
-    };
-
-  private:
-    Published published_;
 };
 
 }  // namespace magda::engine

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -427,6 +427,9 @@ if(MAGDA_BUILD_NATIVE_ENGINE)
     # An arrangement audio take (#2461): where it starts against a declared
     # input latency and a count-in, how a loop splits it, and which pass plays.
     list(APPEND TEST_SOURCES engine/test_take_recorder.cpp)
+    # A MIDI take (#2462): where an event lands, what a held note gets for a
+    # length, and which pass owns one that crossed a wrap.
+    list(APPEND TEST_SOURCES engine/test_midi_take_recorder.cpp)
     list(APPEND TEST_SOURCES engine/test_engine_taps.cpp)
     list(APPEND TEST_SOURCES engine/test_clip_snapshot.cpp)
     list(APPEND TEST_SOURCES engine/test_clip_voice.cpp)

--- a/tests/engine/test_midi_take_recorder.cpp
+++ b/tests/engine/test_midi_take_recorder.cpp
@@ -1,0 +1,574 @@
+#include <juce_audio_basics/juce_audio_basics.h>
+
+#include <array>
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <cstdint>
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "exec/RenderContext.hpp"
+#include "io/LiveInput.hpp"
+#include "io/MidiTakeRecorder.hpp"
+#include "transport/TempoMap.hpp"
+#include "transport/TransportClock.hpp"
+#include "transport/TransportState.hpp"
+
+/**
+ * @file test_midi_take_recorder.cpp
+ * @brief A MIDI take, from armed to clip (#2462).
+ *
+ * A scheduled input and a driven transport, with no session and no thread: an
+ * event is named by the arrival it was played on, so a case says exactly where
+ * the transport was when it happened.
+ */
+
+using magda::MidiCurveType;
+using magda::engine::kAnyLiveMidiSource;
+using magda::engine::LiveInputBlock;
+using magda::engine::LiveInputFeed;
+using magda::engine::LiveMidiInput;
+using magda::engine::LiveMidiStream;
+using magda::engine::LoopRange;
+using magda::engine::MidiTakeRecorder;
+using magda::engine::MidiTakeRecorderSettings;
+using magda::engine::RecordedMidiTake;
+using magda::engine::TempoMap;
+using magda::engine::TransportClock;
+using magda::engine::TransportSnapshot;
+
+namespace {
+
+constexpr double kSampleRate = 8000.0;
+constexpr int kBlockSize = 64;
+
+/// A beat at 120 bpm and this rate, which makes every position in these cases a
+/// whole number of samples.
+constexpr int kBeatSamples = 4000;
+
+TempoMap flat() {
+    return TempoMap({{0.0, 120.0, 0.0f}}, {{0.0, 4, 4}});
+}
+
+/// 120 bpm to beat 2, then 60 bpm. Two changes on one beat is a step rather
+/// than a ramp, which is what makes a case's arithmetic exact.
+TempoMap halvedAtBeatTwo() {
+    return TempoMap({{0.0, 120.0, 0.0f}, {2.0, 120.0, 0.0f}, {2.0, 60.0, 0.0f}}, {{0.0, 4, 4}});
+}
+
+/// One event, named by the arrival it was played on.
+struct Played {
+    std::int64_t arrival = 0;
+    juce::MidiMessage message;
+};
+
+Played noteOn(std::int64_t arrival, int note, int velocity = 100, int channel = 1) {
+    return {arrival, juce::MidiMessage::noteOn(channel, note, static_cast<juce::uint8>(velocity))};
+}
+
+Played noteOff(std::int64_t arrival, int note, int channel = 1) {
+    return {arrival, juce::MidiMessage::noteOff(channel, note)};
+}
+
+Played controller(std::int64_t arrival, int number, int value, int channel = 1) {
+    return {arrival, juce::MidiMessage::controllerEvent(channel, number, value)};
+}
+
+Played pitchBend(std::int64_t arrival, int value, int channel = 1) {
+    return {arrival, juce::MidiMessage::pitchWheel(channel, value)};
+}
+
+/// What the track's instrument was handed, so a case can say recording did not
+/// change it.
+struct Heard {
+    std::int64_t sample = 0;
+    int status = 0;
+    int data1 = 0;
+    int data2 = 0;
+
+    bool operator==(const Heard&) const = default;
+};
+
+MidiTakeRecorderSettings takeOf(int latencySamples = 0) {
+    MidiTakeRecorderSettings settings;
+    settings.source = kAnyLiveMidiSource;
+    settings.latencySamples = latencySamples;
+    return settings;
+}
+
+/**
+ * @brief A transport, a scheduled MIDI input and one take, driven a callback at
+ *        a time.
+ *
+ * The monitor input is rendered every block whether or not a take is recording,
+ * which is what lets a case compare the two.
+ */
+class Rig {
+  public:
+    explicit Rig(MidiTakeRecorderSettings settings, TempoMap tempo = flat(), bool records = true)
+        : monitor_(feed_, kAnyLiveMidiSource) {
+        transport_.tempo = std::move(tempo);
+        feed_.prepare(0, kBlockSize);
+
+        if (records)
+            recorder_ = std::make_unique<MidiTakeRecorder>(feed_, std::move(settings));
+    }
+
+    void schedule(std::vector<Played> events) {
+        schedule_ = std::move(events);
+    }
+
+    void play(double fromBeat = 0.0, double countInBeats = 0.0) {
+        ++transport_.request.generation;
+        transport_.request.playing = true;
+        transport_.request.locate = true;
+        transport_.request.positionBeat = fromBeat;
+        transport_.request.countInBeats = countInBeats;
+    }
+
+    void stop() {
+        ++transport_.request.generation;
+        transport_.request.playing = false;
+        transport_.request.locate = false;
+        transport_.request.countInBeats = 0.0;
+    }
+
+    void loop(double startBeat, double endBeat) {
+        transport_.loop = LoopRange{true, startBeat, endBeat};
+    }
+
+    /// Feed @p numSamples of callbacks through the take.
+    void run(int numSamples) {
+        for (auto left = numSamples; left > 0;) {
+            const auto callback = std::min(kBlockSize, left);
+            deliver(callback);
+            left -= callback;
+        }
+    }
+
+    /// Empty the queue after every callback, the way the record thread would.
+    /// What a take holds must not depend on it.
+    void drainAsItGoes() {
+        drains_ = true;
+    }
+
+    MidiTakeRecorder& recorder() {
+        return *recorder_;
+    }
+
+    RecordedMidiTake finish() {
+        return recorder_->finish(transport_.tempo);
+    }
+
+    const std::vector<Heard>& heard() const {
+        return heard_;
+    }
+
+  private:
+    void deliver(int numSamples) {
+        juce::MidiBuffer arriving;
+        for (const auto& event : schedule_)
+            if (event.arrival >= arrival_ && event.arrival < arrival_ + numSamples)
+                arriving.addEvent(event.message, static_cast<int>(event.arrival - arrival_));
+
+        const std::array streams{LiveMidiStream{0, &arriving}};
+        const LiveInputBlock block{{}, streams};
+
+        feed_.beginCallback(block, numSamples);
+
+        for (const auto& segment : clock_.advance(transport_, kSampleRate, numSamples)) {
+            feed_.beginSegment(segment.startSample, segment.block.numSamples);
+
+            if (recorder_ != nullptr)
+                recorder_->capture(segment.block, segment.countingIn, transport_.loop);
+
+            juce::MidiBuffer monitored;
+            monitor_.render(segment.block, monitored);
+
+            for (const auto metadata : monitored) {
+                const auto message = metadata.getMessage();
+                heard_.push_back(Heard{arrival_ + segment.startSample + metadata.samplePosition,
+                                       message.getRawData()[0], message.getRawData()[1],
+                                       message.getRawDataSize() > 2 ? message.getRawData()[2] : 0});
+            }
+        }
+
+        feed_.endCallback();
+        arrival_ += numSamples;
+
+        if (drains_ && recorder_ != nullptr)
+            while (recorder_->stream().drain()) {
+            }
+    }
+
+    TransportSnapshot transport_;
+    TransportClock clock_;
+    LiveInputFeed feed_;
+    LiveMidiInput monitor_;
+    std::unique_ptr<MidiTakeRecorder> recorder_;
+
+    std::vector<Played> schedule_;
+    std::vector<Heard> heard_;
+
+    /// Input samples delivered since the rig was made, which is what the
+    /// schedule is numbered by.
+    std::int64_t arrival_ = 0;
+
+    bool drains_ = false;
+};
+
+}  // namespace
+
+TEST_CASE("A note lands on the beat it was played on", "[engine][io][record][midi][2462]") {
+    Rig rig(takeOf());
+    rig.schedule({noteOn(kBeatSamples, 60), noteOff(kBeatSamples * 3 / 2, 60)});
+    rig.play();
+    rig.run(kBeatSamples * 2);
+
+    const auto take = rig.finish();
+    REQUIRE_FALSE(take.empty());
+    CHECK(take.eventsLost == 0);
+    CHECK(take.messagesDropped == 0);
+
+    REQUIRE(take.active.notes.size() == 1);
+    CHECK(take.active.notes[0].noteNumber == 60);
+    CHECK(take.active.notes[0].velocity == 100);
+    CHECK(take.active.notes[0].startBeat == Catch::Approx(1.0));
+    CHECK(take.active.notes[0].lengthBeats == Catch::Approx(0.5));
+
+    // A single pass is an ordinary clip: the take list is for loop-record
+    // alternatives and stays empty without them.
+    CHECK(take.clip.takes.empty());
+    CHECK(take.startBeat == 0.0);
+    CHECK(take.lengthBeats == Catch::Approx(2.0));
+}
+
+TEST_CASE("A note recorded across a tempo change lands where it was played",
+          "[engine][io][record][midi][2462]") {
+    // Beat 3 is two beats at 120 and one at 60: one second, then one more.
+    constexpr int kBeatThree = 16000;
+
+    Rig rig(takeOf(), halvedAtBeatTwo());
+    rig.schedule({noteOn(kBeatThree, 64), noteOff(kBeatThree + 8000, 64)});
+    rig.play();
+    rig.run(kBeatThree + 8000);
+
+    const auto take = rig.finish();
+    REQUIRE(take.active.notes.size() == 1);
+    CHECK(take.active.notes[0].startBeat == Catch::Approx(3.0));
+
+    // A beat is 8000 samples on this side of the change, so the note is one.
+    CHECK(take.active.notes[0].lengthBeats == Catch::Approx(1.0));
+}
+
+TEST_CASE("A note still held when the take ends lasts until it does",
+          "[engine][io][record][midi][2462]") {
+    Rig rig(takeOf());
+    rig.schedule({noteOn(kBeatSamples, 62)});
+    rig.play();
+    rig.run(kBeatSamples * 2);
+
+    const auto take = rig.finish();
+    REQUIRE(take.active.notes.size() == 1);
+    CHECK(take.active.notes[0].startBeat == Catch::Approx(1.0));
+    CHECK(take.active.notes[0].lengthBeats == Catch::Approx(1.0));
+}
+
+TEST_CASE("A note held across a loop wrap belongs to one pass, once",
+          "[engine][io][record][midi][2462]") {
+    constexpr int kLoopSamples = kBeatSamples * 4;
+
+    Rig rig(takeOf());
+    rig.loop(0.0, 4.0);
+    // Down three quarters of a beat before the wrap, up a quarter beat after it.
+    rig.schedule({noteOn(kLoopSamples - 3000, 67), noteOff(kLoopSamples + 1000, 67)});
+    rig.play();
+    rig.run(kLoopSamples * 2);
+
+    const auto take = rig.finish();
+    REQUIRE(take.clip.takes.size() == 2);
+
+    REQUIRE(take.clip.takes[0].notes.size() == 1);
+    CHECK(take.clip.takes[0].notes[0].startBeat == Catch::Approx(3.25));
+
+    // Cut off at the pass end rather than running past it: the pass is the
+    // clip, and a note that outlives it has nowhere to go.
+    CHECK(take.clip.takes[0].notes[0].lengthBeats == Catch::Approx(0.75));
+
+    // The note off has no note on in this pass, and starts nothing.
+    CHECK(take.clip.takes[1].notes.empty());
+}
+
+TEST_CASE("Each loop pass is a take, and the clip is loop-aligned",
+          "[engine][io][record][midi][2462]") {
+    constexpr int kLoopSamples = kBeatSamples * 4;
+
+    Rig rig(takeOf());
+    rig.loop(0.0, 4.0);
+    rig.schedule({
+        noteOn(kBeatSamples, 60),
+        noteOff(kBeatSamples + 500, 60),
+        noteOn(kLoopSamples + kBeatSamples, 62),
+        noteOff(kLoopSamples + kBeatSamples + 500, 62),
+        noteOn((kLoopSamples * 2) + kBeatSamples, 64),
+        noteOff((kLoopSamples * 2) + kBeatSamples + 500, 64),
+    });
+    rig.play();
+    rig.run(kLoopSamples * 3);
+
+    const auto take = rig.finish();
+    REQUIRE(take.clip.takes.size() == 3);
+
+    // Every pass positions its own notes against its own start, which is what
+    // makes take 0 at beat 0 true of all of them.
+    for (const auto& pass : take.clip.takes) {
+        REQUIRE(pass.notes.size() == 1);
+        CHECK(pass.notes[0].startBeat == Catch::Approx(1.0));
+    }
+
+    CHECK(take.clip.takes[0].notes[0].noteNumber == 60);
+    CHECK(take.clip.takes[1].notes[0].noteNumber == 62);
+    CHECK(take.clip.takes[2].notes[0].noteNumber == 64);
+
+    CHECK(take.startBeat == Catch::Approx(0.0));
+    CHECK(take.lengthBeats == Catch::Approx(4.0));
+    CHECK(take.passesLost == 0);
+}
+
+TEST_CASE("The active take is the last full pass", "[engine][io][record][midi][2462]") {
+    constexpr int kLoopSamples = kBeatSamples * 4;
+
+    SECTION("three full passes play the third") {
+        Rig rig(takeOf());
+        rig.loop(0.0, 4.0);
+        rig.schedule({noteOn(100, 60), noteOff(200, 60)});
+        rig.play();
+        rig.run(kLoopSamples * 3);
+
+        const auto take = rig.finish();
+        REQUIRE(take.clip.takes.size() == 3);
+        CHECK(take.clip.currentTakeIndex == 2);
+    }
+
+    SECTION("a final pass cut short falls back to the one before it") {
+        Rig rig(takeOf());
+        rig.loop(0.0, 4.0);
+        rig.schedule({noteOn(100, 60), noteOff(200, 60)});
+        rig.play();
+        rig.run((kLoopSamples * 2) + (kLoopSamples / 4));
+
+        const auto take = rig.finish();
+        REQUIRE(take.clip.takes.size() == 3);
+        CHECK(take.clip.currentTakeIndex == 1);
+
+        // The short pass is still a take: it is not the one that plays, and
+        // comping it is the user's to decide.
+        CHECK(take.active.notes.size() == take.clip.takes[1].notes.size());
+    }
+}
+
+TEST_CASE("A first pass that did not start on the loop is a lead-in, not a take",
+          "[engine][io][record][midi][2462]") {
+    constexpr int kLoopSamples = kBeatSamples * 4;
+
+    Rig rig(takeOf());
+    rig.loop(0.0, 4.0);
+    rig.schedule({
+        noteOn(500, 60),
+        noteOff(1000, 60),
+        noteOn(kBeatSamples * 3, 62),
+        noteOff((kBeatSamples * 3) + 500, 62),
+    });
+    // Two beats in, so the first stretch cannot share the clip start.
+    rig.play(2.0);
+    rig.run(kLoopSamples * 2);
+
+    const auto take = rig.finish();
+
+    // Two passes recorded, one kept: the lead-in and the pass that wrapped
+    // into it are not alternatives of each other.
+    REQUIRE(take.clip.takes.size() == 2);
+    CHECK(take.startBeat == Catch::Approx(0.0));
+    CHECK(take.lengthBeats == Catch::Approx(4.0));
+
+    // The lead-in's own note is gone with it; what is left starts at the loop.
+    for (const auto& pass : take.clip.takes)
+        for (const auto& note : pass.notes)
+            CHECK(note.noteNumber != 60);
+}
+
+TEST_CASE("A take starts where the count-in ends", "[engine][io][record][midi][2462]") {
+    Rig rig(takeOf());
+    rig.schedule({noteOn(kBeatSamples, 60), noteOff(kBeatSamples + 500, 60),
+                  noteOn(kBeatSamples * 3, 64), noteOff((kBeatSamples * 3) + 500, 64)});
+    rig.play(0.0, 2.0);
+    rig.run(kBeatSamples * 4);
+
+    const auto take = rig.finish();
+
+    // The count-in is time before the play position, so what was played during
+    // it is not in the take, and what follows starts at the take's own zero.
+    REQUIRE(take.active.notes.size() == 1);
+    CHECK(take.active.notes[0].noteNumber == 64);
+    CHECK(take.active.notes[0].startBeat == Catch::Approx(1.0));
+    CHECK(take.startBeat == Catch::Approx(0.0));
+}
+
+TEST_CASE("An event is placed where it was played, not where it arrived",
+          "[engine][io][record][midi][2462]") {
+    SECTION("a positive latency moves it earlier and drops what precedes the take") {
+        Rig rig(takeOf(800));
+        rig.schedule({noteOn(400, 60), noteOff(600, 60), noteOn(kBeatSamples + 800, 64),
+                      noteOff(kBeatSamples + 1300, 64)});
+        rig.play();
+        rig.run(kBeatSamples * 2);
+
+        const auto take = rig.finish();
+        REQUIRE(take.active.notes.size() == 1);
+        CHECK(take.active.notes[0].noteNumber == 64);
+        CHECK(take.active.notes[0].startBeat == Catch::Approx(1.0));
+    }
+
+    SECTION("a negative adjustment moves it later") {
+        Rig rig(takeOf(-800));
+        rig.schedule({noteOn(kBeatSamples, 64), noteOff(kBeatSamples + 500, 64)});
+        rig.play();
+        rig.run(kBeatSamples * 2);
+
+        const auto take = rig.finish();
+        REQUIRE(take.active.notes.size() == 1);
+        CHECK(take.active.notes[0].startBeat == Catch::Approx(1.2));
+    }
+}
+
+TEST_CASE("A negative adjustment moves an event across a pass boundary, not the boundary",
+          "[engine][io][record][midi][2462]") {
+    constexpr int kLoopSamples = kBeatSamples * 4;
+
+    Rig rig(takeOf(-800));
+    rig.loop(0.0, 4.0);
+    // Arrives 400 before the wrap, which is 400 after it once corrected.
+    rig.schedule({noteOn(kLoopSamples - 400, 67), noteOff(kLoopSamples - 200, 67)});
+    rig.play();
+    rig.run(kLoopSamples * 2);
+
+    const auto take = rig.finish();
+    REQUIRE(take.clip.takes.size() == 2);
+    CHECK(take.clip.takes[0].notes.empty());
+    REQUIRE(take.clip.takes[1].notes.size() == 1);
+    CHECK(take.clip.takes[1].notes[0].startBeat == Catch::Approx(400.0 / kBeatSamples));
+
+    // Both passes are the loop, rather than the first running long by the
+    // adjustment: nothing is committed until the take is closed.
+    CHECK(take.lengthBeats == Catch::Approx(4.0));
+}
+
+TEST_CASE("CC and pitch bend survive with their positions", "[engine][io][record][midi][2462]") {
+    Rig rig(takeOf());
+    rig.schedule({controller(kBeatSamples, 74, 96), pitchBend(kBeatSamples * 3 / 2, 10000)});
+    rig.play();
+    rig.run(kBeatSamples * 2);
+
+    const auto take = rig.finish();
+
+    REQUIRE(take.active.cc.size() == 1);
+    CHECK(take.active.cc[0].controller == 74);
+    CHECK(take.active.cc[0].value == 96);
+    CHECK(take.active.cc[0].beatPosition == Catch::Approx(1.0));
+    CHECK(take.active.cc[0].curveType == MidiCurveType::Step);
+
+    REQUIRE(take.active.pitchBend.size() == 1);
+    CHECK(take.active.pitchBend[0].value == 10000);
+    CHECK(take.active.pitchBend[0].beatPosition == Catch::Approx(1.5));
+}
+
+TEST_CASE("A message the model cannot hold is dropped where it can be said",
+          "[engine][io][record][midi][2462]") {
+    Rig rig(takeOf());
+    rig.schedule({
+        {kBeatSamples, juce::MidiMessage::programChange(1, 7)},
+        {kBeatSamples + 100, juce::MidiMessage::channelPressureChange(1, 64)},
+        {kBeatSamples + 200, juce::MidiMessage::aftertouchChange(1, 60, 64)},
+        noteOn(kBeatSamples + 300, 60),
+        noteOff(kBeatSamples + 400, 60),
+    });
+    rig.play();
+    rig.run(kBeatSamples * 2);
+
+    const auto take = rig.finish();
+    CHECK(take.messagesDropped == 3);
+
+    // What the model does hold is untouched by what it does not.
+    CHECK(take.active.notes.size() == 1);
+    CHECK(take.eventsLost == 0);
+}
+
+TEST_CASE("A note off at zero velocity ends the note", "[engine][io][record][midi][2462]") {
+    Rig rig(takeOf());
+    rig.schedule({noteOn(kBeatSamples, 60), noteOn(kBeatSamples + 2000, 60, 0)});
+    rig.play();
+    rig.run(kBeatSamples * 2);
+
+    const auto take = rig.finish();
+    REQUIRE(take.active.notes.size() == 1);
+    CHECK(take.active.notes[0].lengthBeats == Catch::Approx(0.5));
+}
+
+TEST_CASE("What a take holds does not depend on when the queue was drained",
+          "[engine][io][record][midi][2462]") {
+    constexpr int kLoopSamples = kBeatSamples * 4;
+
+    const auto record = [](bool drains) {
+        Rig rig(takeOf());
+        rig.loop(0.0, 4.0);
+        if (drains)
+            rig.drainAsItGoes();
+
+        rig.schedule({noteOn(kBeatSamples, 60), noteOff(kBeatSamples + 500, 60),
+                      noteOn(kLoopSamples + (kBeatSamples * 2), 62),
+                      noteOff(kLoopSamples + (kBeatSamples * 2) + 500, 62)});
+        rig.play();
+        rig.run(kLoopSamples * 2);
+        return rig.finish();
+    };
+
+    const auto queued = record(false);
+    const auto drained = record(true);
+
+    REQUIRE(queued.clip.takes.size() == drained.clip.takes.size());
+    for (std::size_t pass = 0; pass < queued.clip.takes.size(); ++pass)
+        CHECK(queued.clip.takes[pass] == drained.clip.takes[pass]);
+}
+
+TEST_CASE("Recording does not change what the track hears", "[engine][io][record][midi][2462]") {
+    const auto listen = [](bool records) {
+        Rig rig(takeOf(), flat(), records);
+        rig.schedule({noteOn(kBeatSamples, 60), noteOff(kBeatSamples + 500, 60),
+                      controller(kBeatSamples + 700, 74, 96)});
+        rig.play();
+        rig.run(kBeatSamples * 2);
+
+        if (records)
+            (void)rig.finish();
+
+        return rig.heard();
+    };
+
+    // An armed track's live MIDI reaches its instrument through the input op,
+    // and a take reads the same feed rather than consuming it.
+    CHECK(listen(true) == listen(false));
+    CHECK_FALSE(listen(false).empty());
+}
+
+TEST_CASE("A take that never rolled is empty", "[engine][io][record][midi][2462]") {
+    Rig rig(takeOf());
+    rig.schedule({noteOn(100, 60), noteOff(200, 60)});
+    rig.run(kBeatSamples);
+
+    const auto take = rig.finish();
+    CHECK(take.empty());
+    CHECK(take.active.notes.empty());
+    CHECK(take.clip.takes.empty());
+    CHECK(take.lengthBeats == 0.0);
+}

--- a/tests/engine/test_midi_take_recorder.cpp
+++ b/tests/engine/test_midi_take_recorder.cpp
@@ -19,9 +19,8 @@
  * @file test_midi_take_recorder.cpp
  * @brief A MIDI take, from armed to clip (#2462).
  *
- * A scheduled input and a driven transport, with no session and no thread: an
- * event is named by the arrival it was played on, so a case says exactly where
- * the transport was when it happened.
+ * A scheduled input and a driven transport, offline: an event is named by the
+ * arrival it was played on.
  */
 
 using magda::MidiCurveType;
@@ -43,16 +42,15 @@ namespace {
 constexpr double kSampleRate = 8000.0;
 constexpr int kBlockSize = 64;
 
-/// A beat at 120 bpm and this rate, which makes every position in these cases a
-/// whole number of samples.
+/// A beat at 120 bpm and this rate: every position here is a whole number of
+/// samples.
 constexpr int kBeatSamples = 4000;
 
 TempoMap flat() {
     return TempoMap({{0.0, 120.0, 0.0f}}, {{0.0, 4, 4}});
 }
 
-/// 120 bpm to beat 2, then 60 bpm. Two changes on one beat is a step rather
-/// than a ramp, which is what makes a case's arithmetic exact.
+/// 120 bpm to beat 2, then 60 bpm. Two changes on one beat is a step, not a ramp.
 TempoMap halvedAtBeatTwo() {
     return TempoMap({{0.0, 120.0, 0.0f}, {2.0, 120.0, 0.0f}, {2.0, 60.0, 0.0f}}, {{0.0, 4, 4}});
 }
@@ -79,8 +77,7 @@ Played pitchBend(std::int64_t arrival, int value, int channel = 1) {
     return {arrival, juce::MidiMessage::pitchWheel(channel, value)};
 }
 
-/// What the track's instrument was handed, so a case can say recording did not
-/// change it.
+/// What the track's instrument was handed.
 struct Heard {
     std::int64_t sample = 0;
     int status = 0;
@@ -98,11 +95,9 @@ MidiTakeRecorderSettings takeOf(int latencySamples = 0) {
 }
 
 /**
- * @brief A transport, a scheduled MIDI input and one take, driven a callback at
- *        a time.
+ * @brief A transport, a scheduled MIDI input and one take, a callback at a time.
  *
- * The monitor input is rendered every block whether or not a take is recording,
- * which is what lets a case compare the two.
+ * The monitor input renders every block whether or not a take is recording.
  */
 class Rig {
   public:
@@ -148,7 +143,6 @@ class Rig {
     }
 
     /// Empty the queue after every callback, the way the record thread would.
-    /// What a take holds must not depend on it.
     void drainAsItGoes() {
         drains_ = true;
     }
@@ -211,8 +205,7 @@ class Rig {
     std::vector<Played> schedule_;
     std::vector<Heard> heard_;
 
-    /// Input samples delivered since the rig was made, which is what the
-    /// schedule is numbered by.
+    /// Input samples delivered so far, which the schedule is numbered by.
     std::int64_t arrival_ = 0;
 
     bool drains_ = false;
@@ -237,8 +230,7 @@ TEST_CASE("A note lands on the beat it was played on", "[engine][io][record][mid
     CHECK(take.active.notes[0].startBeat == Catch::Approx(1.0));
     CHECK(take.active.notes[0].lengthBeats == Catch::Approx(0.5));
 
-    // A single pass is an ordinary clip: the take list is for loop-record
-    // alternatives and stays empty without them.
+    // A single pass is an ordinary clip, with no take list.
     CHECK(take.clip.takes.empty());
     CHECK(take.startBeat == 0.0);
     CHECK(take.lengthBeats == Catch::Approx(2.0));
@@ -292,8 +284,7 @@ TEST_CASE("A note held across a loop wrap belongs to one pass, once",
     REQUIRE(take.clip.takes[0].notes.size() == 1);
     CHECK(take.clip.takes[0].notes[0].startBeat == Catch::Approx(3.25));
 
-    // Cut off at the pass end rather than running past it: the pass is the
-    // clip, and a note that outlives it has nowhere to go.
+    // Cut off at the pass end rather than running past it.
     CHECK(take.clip.takes[0].notes[0].lengthBeats == Catch::Approx(0.75));
 
     // The note off has no note on in this pass, and starts nothing.
@@ -320,8 +311,7 @@ TEST_CASE("Each loop pass is a take, and the clip is loop-aligned",
     const auto take = rig.finish();
     REQUIRE(take.clip.takes.size() == 3);
 
-    // Every pass positions its own notes against its own start, which is what
-    // makes take 0 at beat 0 true of all of them.
+    // Every pass positions its notes against its own start: take 0 at beat 0.
     for (const auto& pass : take.clip.takes) {
         REQUIRE(pass.notes.size() == 1);
         CHECK(pass.notes[0].startBeat == Catch::Approx(1.0));
@@ -362,8 +352,7 @@ TEST_CASE("The active take is the last full pass", "[engine][io][record][midi][2
         REQUIRE(take.clip.takes.size() == 3);
         CHECK(take.clip.currentTakeIndex == 1);
 
-        // The short pass is still a take: it is not the one that plays, and
-        // comping it is the user's to decide.
+        // The short pass is still a take, just not the one that plays.
         CHECK(take.active.notes.size() == take.clip.takes[1].notes.size());
     }
 }
@@ -386,8 +375,7 @@ TEST_CASE("A first pass that did not start on the loop is a lead-in, not a take"
 
     const auto take = rig.finish();
 
-    // Two passes recorded, one kept: the lead-in and the pass that wrapped
-    // into it are not alternatives of each other.
+    // Three stretches recorded, the lead-in dropped.
     REQUIRE(take.clip.takes.size() == 2);
     CHECK(take.startBeat == Catch::Approx(0.0));
     CHECK(take.lengthBeats == Catch::Approx(4.0));
@@ -407,8 +395,7 @@ TEST_CASE("A take starts where the count-in ends", "[engine][io][record][midi][2
 
     const auto take = rig.finish();
 
-    // The count-in is time before the play position, so what was played during
-    // it is not in the take, and what follows starts at the take's own zero.
+    // A count-in is time before the play position, so it is not in the take.
     REQUIRE(take.active.notes.size() == 1);
     CHECK(take.active.notes[0].noteNumber == 64);
     CHECK(take.active.notes[0].startBeat == Catch::Approx(1.0));
@@ -459,8 +446,7 @@ TEST_CASE("A negative adjustment moves an event across a pass boundary, not the 
     REQUIRE(take.clip.takes[1].notes.size() == 1);
     CHECK(take.clip.takes[1].notes[0].startBeat == Catch::Approx(400.0 / kBeatSamples));
 
-    // Both passes are the loop, rather than the first running long by the
-    // adjustment: nothing is committed until the take is closed.
+    // Both passes are the loop, rather than the first running long by it.
     CHECK(take.lengthBeats == Catch::Approx(4.0));
 }
 
@@ -555,8 +541,7 @@ TEST_CASE("Recording does not change what the track hears", "[engine][io][record
         return rig.heard();
     };
 
-    // An armed track's live MIDI reaches its instrument through the input op,
-    // and a take reads the same feed rather than consuming it.
+    // A take reads the feed rather than consuming it.
     CHECK(listen(true) == listen(false));
     CHECK_FALSE(listen(false).empty());
 }


### PR DESCRIPTION
Slice 4 of #1895, closes #2462. The same pass as slice 3 and the other kind of material: the live MIDI slice 1 delivers, through the queue slice 2 drains, into the notes a clip is made of.

## What is here

**`MidiTakeRecorder`** is one take, fed a block at a time on the audio thread. It stamps and copies; nothing model-shaped is built there, and no clip exists until `finish()`.

The rules it keeps are the model's rather than any engine's:

- **Every event is stamped in the take's own positions on the way into the queue.** `arrival - latency`, the one head correction, applied once, so nothing downstream has to know what the input's declared latency was. An event that arrived before the playhead reached it is dropped rather than placed before the take.
- **Beats are the domain and the conversion is the last step.** The audio thread stamps samples; `finish()` asks the tempo map where each one falls. A pass recorded across a tempo change lands where it was played, not where a straight line between the block's two ends would put it.
- **A note held across a wrap belongs to the pass it started in, once,** and stops at that pass's end. The pass is the clip, and a note that outlives it has nowhere to go. A note still down when the take ends lasts until it does.
- **A first pass that did not begin on the loop start is a lead-in, not a take.** `MidiTake` has no offset of its own and comping assumes take 0 at t=0, so a pass that cannot share the clip start is dropped once a wrap has proved the take loop-aligned.
- **Program change, aftertouch and channel pressure have no field in the model.** They are dropped here, where the finished take can say how many, rather than silently inside a converter.

### Where MIDI differs from audio

An audio take is committed to a file as it goes, so slice 3 can never name a pass boundary behind what is already queued, and the header there says what that costs: with a negative record adjustment the first pass runs long by it and the passes after it sit that much late against the loop.

Nothing here is committed until `finish()`. So the boundary is named where the wrap is -- the timeline the transport has rolled, which owes the input's latency nothing -- and events fall either side of it by their own stamps. A negative adjustment moves an event across a boundary rather than moving the boundary, and every pass is the loop.

## Shared ground

Two things came out of the second implementation of the same pass.

**`io/TakePasses.hpp`** holds the loop rules both kinds of take keep: what counts as a wrap rather than a locate, and which pass plays.

That second one changes behaviour. The active take is still the last full pass, stepping back one when the final pass is short, but it is now judged by pass **length** rather than by note count. What makes the final pass different is a stop landing in the middle of it, which is a fact about its length; note count was a proxy for that, and it misjudges a full pass you deliberately played less into. Length is also what slice 3 already used, so audio and MIDI now answer the question the same way.

**`io/RecordingFeed.hpp`** holds the feed, moved out of `TakeRecorder.hpp` and put behind a `TakeCapture` interface. A track recording audio and MIDI is two takes rather than a special case, and the callback drives both through one call.

## Verification

`tests/engine/test_midi_take_recorder.cpp`, offline throughout: a scheduled input where an event is named by the arrival it was played on, a driven transport, no session and no thread.

- a note lands on the beat it was played on, at a fixed tempo and across a tempo change inside the pass
- a note still held when the take ends lasts until it does
- a note held across a wrap is in one pass, once, cut off at the pass end
- each loop pass is a take, positioned against its own start, and the clip is loop-aligned
- the active take is the last full pass, and the last-but-one when the final pass is cut short
- a lead-in leaves no take
- a count-in is not part of the take
- a positive latency moves an event earlier and drops what precedes the take; a negative one moves it later
- a negative adjustment moves an event across a pass boundary rather than moving the boundary
- CC and pitch bend survive with their positions; a note off at zero velocity ends the note
- a message the model cannot hold is counted rather than dropped silently
- what a take holds does not depend on when the queue was drained
- what the track hears is identical whether or not a take is running

I mutation-checked the two subtlest rules: reverting the boundary domain and disabling the pass close each break a specific test, so neither is passing by accident. That check also found a `std::min` clamp in the note-closing path that no input could reach, since the pass close always runs first; it is gone.

Full Catch2 suite passes (3759 passed, 13 skipped); app and JUCE test targets build clean.

## Not in this slice

What the app draws while the pass is running (#2463), session slots (#2464), surviving a recompile mid-take (#2465).

https://claude.ai/code/session_013A1GWqAoLZPdkYAMwKrjQj