### PR TITLE
Declare a device's sidechain as a port, and model its source

### DIFF
--- a/docs/architecture/native-engine.md
+++ b/docs/architecture/native-engine.md
@@ -311,6 +311,15 @@ The op vocabulary is deliberately small: `ClipAudio`, `ClipMidi`, `AudioInput`, 
 `Device`, `MixAudio`, `MergeMidi`, `Subtract`, `Delay`, `Crossfade`, `Gain`, `Fader`, `SendTap`,
 `Meter`, `ModSource`, `Output`.
 
+**A device's sidechain is a slot fed from a modelled source** (#2329). The `Device` op's three
+inputs are `[audio, MIDI, sidechain]`, and `SidechainConfig` says more than which track the key
+comes from: `tapPoint` picks between the two points a modifier also chooses between, so a key
+taken pre-FX reads the source's trigger tap and one taken post-fader reads its sidechain tap;
+`gainDb` is a `Gain` op on the edge, emitted wherever a key is connected so moving the trim is a
+value rather than a recompile; `listen` is a value on the process op, like a delta solo, and
+replaces the slot's output with the key it was handed. Which slot a device wants is the device's
+own declaration (`DeviceProperties::sidechain`), not something inferred from its channel counts.
+
 ---
 
 ## 4. The life of an edit

--- a/magda/agents/faust_agent.cpp
+++ b/magda/agents/faust_agent.cpp
@@ -107,9 +107,12 @@ SOURCE RULES — VERY IMPORTANT:
 - Up to 64 controls. Keep it musically tasteful; 4–8 is usually plenty.
 - Do NOT use buttons (momentary), bargraphs (display-only), or soundfile()
   (no external sample loading).
-- For a stereo effect with a stereo audio sidechain, declare four inputs:
+- An audio sidechain must be declared, and the key is the inputs past the
+  outputs. For a stereo effect with a stereo key:
+      declare magda_sidechain "audio";
       process(mainL, mainR, sideL, sideR) = ...;
-  MAGDA supplies the source track as the third and fourth channels.
+  Without the declaration the extra inputs are the device's own and MAGDA
+  routes no key to them.
 - Use only functions from stdfaust.lib (the standard library is bundled).
   Common picks: fi.lowpass / fi.highpass / fi.peak_eq, ef.cubicnl,
   re.zita_rev1_stereo, de.delay, os.osc, en.adsr, ba.beat.

--- a/magda/daw/api/remote_api.cpp
+++ b/magda/daw/api/remote_api.cpp
@@ -253,10 +253,25 @@ const juce::var& deviceSchema() {
                 "format":{"type":"string","enum":["vst3","au","lv2","internal"]},
                 "instrument":{"type":"boolean"},
                 "bypassed":{"type":"boolean"},
-                "gainDb":{"type":"number"}
+                "gainDb":{"type":"number"},
+                "sidechain":{
+                    "type":"object",
+                    "properties":{
+                        "port":{"type":"string","enum":["none","audio","midi"]},
+                        "portChannels":{"type":"integer","minimum":0},
+                        "type":{"type":"string","enum":["none","audio","midi"]},
+                        "sourceTrackId":{"type":["integer","null"]},
+                        "tapPoint":{"type":"string","enum":["preFx","postFader"]},
+                        "gainDb":{"type":"number"},
+                        "listen":{"type":"boolean"}
+                    },
+                    "required":["port","portChannels","type","sourceTrackId","tapPoint","gainDb",
+                                "listen"],
+                    "additionalProperties":false
+                }
             },
             "required":["id","trackId","rackId","chainId","devicePath","name","type","format",
-                        "instrument","bypassed","gainDb"],
+                        "instrument","bypassed","gainDb","sidechain"],
             "additionalProperties":false
         })json");
         schema["properties"].getDynamicObject()->setProperty("devicePath", devicePathSchema());
@@ -1036,6 +1051,18 @@ juce::var toJson(const ClipDto& dto) {
     return object;
 }
 
+juce::var toJson(const DeviceSidechainDto& dto) {
+    auto object = new juce::DynamicObject();
+    object->setProperty("port", dto.port);
+    object->setProperty("portChannels", dto.portChannels);
+    object->setProperty("type", dto.type);
+    object->setProperty("sourceTrackId", nullableId(dto.sourceTrackId));
+    object->setProperty("tapPoint", dto.tapPoint);
+    object->setProperty("gainDb", dto.gainDb);
+    object->setProperty("listen", dto.listen);
+    return object;
+}
+
 juce::var toJson(const DeviceDto& dto) {
     auto object = new juce::DynamicObject();
     object->setProperty("id", dto.id);
@@ -1049,6 +1076,7 @@ juce::var toJson(const DeviceDto& dto) {
     object->setProperty("instrument", dto.instrument);
     object->setProperty("bypassed", dto.bypassed);
     object->setProperty("gainDb", dto.gainDb);
+    object->setProperty("sidechain", toJson(dto.sidechain));
     return object;
 }
 
@@ -1318,6 +1346,15 @@ std::optional<DeviceDto> deviceFromJson(const juce::var& json, Error& error) {
     dto.instrument = static_cast<bool>(json["instrument"]);
     dto.bypassed = static_cast<bool>(json["bypassed"]);
     dto.gainDb = static_cast<double>(json["gainDb"]);
+
+    const auto& sidechain = json["sidechain"];
+    dto.sidechain.port = sidechain["port"].toString();
+    dto.sidechain.portChannels = readInt(sidechain, "portChannels");
+    dto.sidechain.type = sidechain["type"].toString();
+    dto.sidechain.sourceTrackId = readNullableId<TrackId>(sidechain, "sourceTrackId");
+    dto.sidechain.tapPoint = sidechain["tapPoint"].toString();
+    dto.sidechain.gainDb = static_cast<double>(sidechain["gainDb"]);
+    dto.sidechain.listen = static_cast<bool>(sidechain["listen"]);
     return dto;
 }
 

--- a/magda/daw/api/remote_api.hpp
+++ b/magda/daw/api/remote_api.hpp
@@ -183,6 +183,33 @@ struct DevicePathDto {
     bool operator==(const DevicePathDto&) const = default;
 };
 
+/**
+ * @brief A device's sidechain: the slot it declares and the source feeding it.
+ *
+ * The declaration and the routing together, because neither is much use alone:
+ * `port` says what the device will take, the rest says what it is being given
+ * (#2329). A device that declares no port still reports one, as "none".
+ */
+struct DeviceSidechainDto {
+    /// What the device declares on its slot: "none", "audio" or "midi".
+    juce::String port = "none";
+    /// Channels an audio key carries. Zero for every other port.
+    int portChannels = 0;
+
+    /// What is routed to it: "none", "audio" or "midi".
+    juce::String type = "none";
+    /// The track the key is taken from; absent when nothing is routed.
+    std::optional<TrackId> sourceTrackId;
+    /// Where on that track: "preFx" or "postFader".
+    juce::String tapPoint = "postFader";
+    /// Trim on the key, on the edge feeding the device.
+    double gainDb = 0.0;
+    /// Monitor the key in place of the device's own output.
+    bool listen = false;
+
+    bool operator==(const DeviceSidechainDto&) const = default;
+};
+
 struct DeviceDto {
     DeviceId id = INVALID_DEVICE_ID;
     TrackId trackId = INVALID_TRACK_ID;
@@ -199,6 +226,7 @@ struct DeviceDto {
     bool instrument = false;
     bool bypassed = false;
     double gainDb = 0.0;
+    DeviceSidechainDto sidechain;
 
     bool operator==(const DeviceDto&) const = default;
 };

--- a/magda/daw/api/remote_api_projection.cpp
+++ b/magda/daw/api/remote_api_projection.cpp
@@ -157,6 +157,43 @@ juce::String safeRoutingId(const juce::String& id) {
     return {};
 }
 
+const char* sidechainKindName(SidechainConfig::Type type) {
+    switch (type) {
+        case SidechainConfig::Type::Audio:
+            return "audio";
+        case SidechainConfig::Type::MIDI:
+            return "midi";
+        case SidechainConfig::Type::None:
+            break;
+    }
+    return "none";
+}
+
+const char* sidechainPortName(SidechainPort::Kind kind) {
+    switch (kind) {
+        case SidechainPort::Kind::Audio:
+            return "audio";
+        case SidechainPort::Kind::MIDI:
+            return "midi";
+        case SidechainPort::Kind::None:
+            break;
+    }
+    return "none";
+}
+
+DeviceSidechainDto makeSidechainDto(const DeviceInfo& device) {
+    DeviceSidechainDto dto;
+    dto.port = sidechainPortName(device.sidechainPort.kind);
+    dto.portChannels = device.sidechainPort.channels;
+    dto.type = sidechainKindName(device.sidechain.type);
+    if (device.sidechain.isActive())
+        dto.sourceTrackId = device.sidechain.sourceTrackId;
+    dto.tapPoint = device.sidechain.tapPoint == ModTapPoint::PreFx ? "preFx" : "postFader";
+    dto.gainDb = device.sidechain.gainDb;
+    dto.listen = device.sidechain.listen;
+    return dto;
+}
+
 DeviceDto makeDeviceDto(const DeviceInfo& device, TrackId trackId, std::optional<RackId> rackId,
                         std::optional<ChainId> chainId, const ChainNodePath& devicePath) {
     DeviceDto dto;
@@ -171,6 +208,7 @@ DeviceDto makeDeviceDto(const DeviceInfo& device, TrackId trackId, std::optional
     dto.instrument = device.isInstrument;
     dto.bypassed = device.bypassed;
     dto.gainDb = device.gainDb;
+    dto.sidechain = makeSidechainDto(device);
     return dto;
 }
 

--- a/magda/daw/audio/DEVICE_SDK.md
+++ b/magda/daw/audio/DEVICE_SDK.md
@@ -18,6 +18,20 @@ declares `producesMidi` in `DeviceProperties`. The chain's raw MIDI never
 passes through a device: thru is the host's merge behind it
 (`DeviceInfo::midiInThru`, #2347).
 
+A sidechain key is a declared port, not extra channels of the buffer. A device
+says what it takes in `DeviceProperties::sidechain` -- `{None, Audio(channels),
+MIDI}` -- and reads it from `DeviceProcessContext::sidechain`, which carries
+`numSidechainChannels` read-only channels indexed from `startSample` like the
+audio. Zero channels means nothing is routed, which is not the same as a silent
+key. Declaring more inputs than outputs is not a request for one (#2329).
+
+A compiled Faust device declares its key by overriding
+`MagdaCompiledEffect::sidechainPort()`; `MagdaCompiledEffect` copies the key
+into the dsp inputs after the device's own, so no dsp reads the port itself. A
+runtime Faust patch declares it in the source, with `declare magda_sidechain
+"audio";`, and the key is the inputs the process function takes past its
+outputs.
+
 ## Public surface
 
 A pack may use:

--- a/magda/daw/audio/DevicesDependencies.cmake
+++ b/magda/daw/audio/DevicesDependencies.cmake
@@ -327,7 +327,7 @@ function(magda_validate_device_pack_sources PACK_NAME)
             if(_magda_pack_include MATCHES "[<\"]([^>\"]*/)?core/([^>\"]+)[>\"]")
                 set(_magda_pack_core_header "${CMAKE_MATCH_2}")
                 if(NOT _magda_pack_core_header MATCHES
-                   "^(TypeIds|TechnicalText|ChainNodePath|ControlTarget|ParameterInfo|ParameterUtils|DeviceInfo|KitRow|MacroInfo|ModInfo|TempoUtils)\\.hpp$")
+                   "^(TypeIds|TechnicalText|ChainNodePath|ControlTarget|ParameterInfo|ParameterUtils|DeviceInfo|KitRow|MacroInfo|ModInfo|SidechainPort|TempoUtils)\\.hpp$")
                     message(FATAL_ERROR
                         "${PACK_NAME} includes a non-SDK core header: "
                         "${_magda_pack_source}\n${_magda_pack_include}")

--- a/magda/daw/audio/FaustResources.cpp
+++ b/magda/daw/audio/FaustResources.cpp
@@ -43,6 +43,20 @@ juce::String readCustomViewName(const juce::String& source) {
     return readDeclare(source, "magda_view");
 }
 
+magda::SidechainPort readSidechainPort(const juce::String& source, int inputCount,
+                                       int outputCount) {
+    if (!readDeclare(source, "magda_sidechain").equalsIgnoreCase("audio"))
+        return {};
+
+    // A patch that asks for a key and leaves it nowhere to arrive has declared
+    // nothing the host can route: the dsp reads the key off its own inputs.
+    const int channels = inputCount - outputCount;
+    if (channels <= 0)
+        return {};
+
+    return {.kind = magda::SidechainPort::Kind::Audio, .channels = std::min(channels, 2)};
+}
+
 FaustPatchInfo readPatchInfo(const juce::String& source) {
     FaustPatchInfo info;
     info.author = readDeclare(source, "author");

--- a/magda/daw/audio/FaustResources.hpp
+++ b/magda/daw/audio/FaustResources.hpp
@@ -4,6 +4,7 @@
 
 #include <vector>
 
+#include "core/SidechainPort.hpp"
 #include "plugins/FaustPatchInfo.hpp"
 
 namespace magda::daw::audio {
@@ -27,6 +28,21 @@ struct StarterDsp {
  * same way, and no call site can forget to supply it.
  */
 juce::String readCustomViewName(const juce::String& source);
+
+/**
+ * @brief The sidechain slot a patch asks for via `declare magda_sidechain "audio";`.
+ *
+ * None when the patch declares none, which is the common case. Declared rather
+ * than read off the channel counts: a patch with three inputs and two outputs
+ * may be a widener's dry line as easily as a key, and only the patch knows
+ * (#2329). The key's width is the inputs past the outputs, because that is
+ * where the dsp reads it -- the declaration says the last inputs are a key, not
+ * how many signals the process function takes.
+ *
+ * @param inputCount   the compiled dsp's input count
+ * @param outputCount  its output count
+ */
+magda::SidechainPort readSidechainPort(const juce::String& source, int inputCount, int outputCount);
 
 // Path to the Faust standard libraries directory bundled alongside the app.
 // Returned File may not exist when running outside an installed bundle (e.g.

--- a/magda/daw/audio/plugin_manager/PluginManagerSync.cpp
+++ b/magda/daw/audio/plugin_manager/PluginManagerSync.cpp
@@ -129,8 +129,18 @@ void updateDeviceCapabilityFlags(DeviceInfo& device, te::Plugin& plugin) {
     const auto snapshot = makePluginCapabilitySnapshot(device, plugin);
     PluginCapabilityCache::getInstance().update(snapshot);
 
-    if (plugin.canSidechain())
-        device.canSidechain = true;
+    // A MagdaDevice declares its key and says how wide it is; everything else
+    // is asked the only question the fork can answer, and a key with no
+    // declared width is one channel (#2329).
+    if (auto* magdaDevice =
+            dynamic_cast<daw::audio::tracktion_adapter::TracktionMagdaDevicePlugin*>(&plugin))
+        device.sidechainPort = magdaDevice->device().properties().sidechain;
+    else if (plugin.canSidechain())
+        device.sidechainPort = {
+            .kind = SidechainPort::Kind::Audio,
+            .channels =
+                std::clamp(snapshot.audioInputChannels - snapshot.audioOutputChannels, 1, 2)};
+
     if (snapshot.hasMidiInput && !device.isInstrument)
         device.canReceiveMidi = true;
     device.producesMidi = snapshot.hasMidiOutput;
@@ -140,14 +150,15 @@ void updateDeviceCapabilityFlags(DeviceInfo& device, te::Plugin& plugin) {
     applyLiveChannelCounts(device, plugin);
 }
 
-// Faust's processor owns a dynamic canSidechain flag, while the generic
-// capability updater only ever promotes flags to true. Keep the type guard so
-// a stale serialized flag on another plugin cannot erase valid routing.
-// Return the id instead of changing TrackManager inline: its notification path
-// must run after callers are finished with their borrowed DeviceInfo pointer.
+// Faust's processor owns a declaration that changes with every recompile, while
+// the generic capability updater only ever promotes a port into existence. Keep
+// the type guard so a stale serialized port on another plugin cannot erase valid
+// routing. Return the id instead of changing TrackManager inline: its
+// notification path must run after callers are finished with their borrowed
+// DeviceInfo pointer.
 DeviceId clearStaleFaustAudioSidechain(const DeviceInfo& device, te::Plugin* plugin) {
     auto* faust = daw::audio::tracktion_adapter::deviceFromPlugin<daw::audio::FaustPlugin>(plugin);
-    if (faust == nullptr || !faust->activeDspMatchesSource() || device.canSidechain ||
+    if (faust == nullptr || !faust->activeDspMatchesSource() || device.sidechainPort.takesAudio() ||
         !device.sidechain.isActive() || device.sidechain.type != SidechainConfig::Type::Audio)
         return INVALID_DEVICE_ID;
 

--- a/magda/daw/audio/plugins/FaustPlugin.cpp
+++ b/magda/daw/audio/plugins/FaustPlugin.cpp
@@ -215,6 +215,7 @@ std::shared_ptr<FaustPlugin::FaustState> FaustPlugin::compile(const juce::String
         state->dsp->init(sampleRate);
         state->dspIn = state->dsp->getNumInputs();
         state->dspOut = state->dsp->getNumOutputs();
+        state->sidechain = readSidechainPort(s, state->dspIn, state->dspOut);
         return state;
     };
 
@@ -375,10 +376,10 @@ bool FaustPlugin::loadDspSource(const juce::String& name, const juce::String& so
     std::atomic_store(&active_, compiled);
     activeDspMatchesSource_ = true;
 
-    // A stereo-only replacement can no longer consume the host's appended key
-    // channels. The device says so through properties().canSidechain, which the
-    // host re-reads when refreshDeviceParameters() runs after a compile; there
-    // is nothing for the device itself to unroute.
+    // A stereo-only replacement can no longer consume a key. The device says so
+    // through properties().sidechain, which the host re-reads when
+    // refreshDeviceParameters() runs after a compile; there is nothing for the
+    // device itself to unroute.
 
     if (previous) {
         const juce::ScopedLock lk(retiredLock_);
@@ -421,19 +422,20 @@ void FaustPlugin::prepare(const DevicePrepareContext& context) {
 }
 
 DeviceProperties FaustPlugin::properties() const {
-    // The channel counts are the compiled dsp's own, and more inputs than
-    // outputs is how this device says it takes a sidechain key.
+    // The channel counts are the compiled dsp's own; the key is what the source
+    // declares, and the inputs it occupies are not the device's own (#2329).
     const auto active = std::atomic_load(&active_);
     const int inputCount = active ? active->dspIn : 2;
     const int outputCount = active ? active->dspOut : 2;
+    const auto sidechain = active ? active->sidechain : magda::SidechainPort{};
 
     return {
         .pluginId = xmlTypeName,
         .name = getPluginName(),
         .shortName = "Faust",
-        .canSidechain = inputCount > 2,
+        .sidechain = sidechain,
         .outputChannelCount = outputCount,
-        .inputChannelCount = inputCount,
+        .inputChannelCount = inputCount - sidechain.channels,
     };
 }
 
@@ -511,14 +513,26 @@ void FaustPlugin::process(DeviceProcessContext& context) {
     inPtrs_.resize(static_cast<size_t>(active->dspIn));
     outPtrs_.resize(static_cast<size_t>(active->dspOut));
 
+    // The declared key occupies the dsp inputs after the device's own, which is
+    // where the source that declared it reads the key from (#2329). A source
+    // narrower than the key feeds its last channel to the rest.
+    const int ownIn = active->dspIn - active->sidechain.channels;
+
     for (int ch = 0; ch < active->dspIn; ++ch) {
         float* dst = scratchIn_.getWritePointer(ch);
-        if (ch < hostChannels) {
-            const float* src = context.audio->getReadPointer(ch, start);
-            std::copy(src, src + n, dst);
-        } else {
-            std::fill(dst, dst + n, 0.0f);
+        const float* src = nullptr;
+        if (ch >= ownIn) {
+            const int key = std::min(ch - ownIn, context.numSidechainChannels - 1);
+            if (key >= 0)
+                src = context.sidechain[key] + start;
+        } else if (ch < hostChannels) {
+            src = context.audio->getReadPointer(ch, start);
         }
+
+        if (src != nullptr)
+            std::copy(src, src + n, dst);
+        else
+            std::fill(dst, dst + n, 0.0f);
         inPtrs_[static_cast<size_t>(ch)] = dst;
     }
 

--- a/magda/daw/audio/plugins/FaustPlugin.hpp
+++ b/magda/daw/audio/plugins/FaustPlugin.hpp
@@ -137,6 +137,9 @@ class FaustPlugin : public MagdaDevice, public IFaustEditorModel {
         dsp_factory* factory = nullptr;
         int dspIn = 0;
         int dspOut = 0;
+        /// The key this source declared, frozen with the compile that read it
+        /// so properties() never touches the editable source (#2329).
+        magda::SidechainPort sidechain;
         // Audio-thread view of the active slots: which pool slot →
         // which zone, plus the denormalization metadata frozen at
         // compile time. Built by `compileAndRebind` and never

--- a/magda/daw/audio/plugins/MagdaDevice.hpp
+++ b/magda/daw/audio/plugins/MagdaDevice.hpp
@@ -7,6 +7,7 @@
 #include <string_view>
 
 #include "core/ParameterInfo.hpp"
+#include "core/SidechainPort.hpp"
 
 namespace magda::daw::audio {
 
@@ -27,7 +28,10 @@ struct DeviceProperties {
     bool takesAudioInput = true;
     bool isSynth = false;
     bool producesAudioWithoutInput = false;
-    bool canSidechain = false;
+    /// The sidechain slot the device asks for, if it wants one (#2329).
+    /// Declared here rather than read off the channel counts below: a device
+    /// with more inputs than outputs is not by itself asking for a key.
+    magda::SidechainPort sidechain;
     double latencySeconds = 0.0;
     double tailLengthSeconds = 0.0;
     /// Output channels the device always produces, whatever it is handed. Zero
@@ -35,9 +39,9 @@ struct DeviceProperties {
     /// this when its DSP has a fixed output width (a mono-in/stereo-out
     /// widener, a stereo-only dynamics stage).
     int outputChannelCount = 0;
-    /// Input channels the device reads, sidechain key included. Zero means the
-    /// host decides. What the model wires from: a device asking for more inputs
-    /// than it outputs is asking for a key.
+    /// Input channels the device reads for its own signal, the sidechain key
+    /// not among them: the key is a port (@ref sidechain), not the tail of this
+    /// count. Zero means the host decides. What the model wires from.
     int inputChannelCount = 0;
 };
 
@@ -109,16 +113,21 @@ class DeviceMidiOutput {
 struct DeviceProcessContext {
     juce::AudioBuffer<float>* audio = nullptr;
     /**
-     * First channel of @ref audio carrying the device's sidechain key, or -1
-     * when the host routed nothing to it.
+     * The sidechain key routed to the slot the device declared, as
+     * @ref numSidechainChannels read-only channel pointers indexed from
+     * @ref startSample, like @ref audio (#2329).
      *
-     * The key arrives as further channels of the same buffer, after the ones
-     * the device reads and writes as its own signal, which is how MAGDA's
-     * compiled dynamics DSPs are written and what both hosts can supply
-     * without a copy. A device with no sidechain never sees anything above its
-     * own width.
+     * Its own port, not further channels of @ref audio: where a host keeps the
+     * key is the host's business, and a device that had to know carried that
+     * convention in its own DSP. Null with a zero count when nothing is routed,
+     * which is "no key" rather than a silent one.
+     *
+     * Fewer channels than the device declared is legal -- a mono source into a
+     * stereo key -- so a device reads what is there rather than what it asked
+     * for.
      */
-    int sidechainInputChannel = -1;
+    const float* const* sidechain = nullptr;
+    int numSidechainChannels = 0;
     /// Both null when the host routed no MIDI to or from the device, otherwise
     /// both set; a device that declares no MIDI output still gets a sink, which
     /// the host discards.

--- a/magda/daw/audio/plugins/compiled/MagdaCompiledEffect.cpp
+++ b/magda/daw/audio/plugins/compiled/MagdaCompiledEffect.cpp
@@ -346,7 +346,7 @@ DeviceProperties MagdaCompiledEffect::properties() const {
         .takesAudioInput = true,
         .isSynth = false,
         .producesAudioWithoutInput = producesAudioWithoutInput(),
-        .canSidechain = wantsSidechain(),
+        .sidechain = sidechainPort(),
         .latencySeconds = latencySeconds(),
         .tailLengthSeconds = tailSeconds(),
         .outputChannelCount = outputChannelCount(),
@@ -460,16 +460,33 @@ void MagdaCompiledEffect::computeEngine(int engineIndex, DeviceProcessContext& c
     if (static_cast<int>(outPtrs_.size()) < numOutputs)
         outPtrs_.resize(static_cast<size_t>(numOutputs), nullptr);
 
+    // The key occupies the dsp inputs after the device's own, which is where
+    // every compiled dynamics dsp reads it. Copied in here, once, so no dsp
+    // has to know where a host keeps the key (#2329).
+    const auto port = sidechainPort();
+    const int keyInputs = port.takesAudio() ? std::min(port.channels, numInputs) : 0;
+    const int ownInputs = numInputs - keyInputs;
+
     // Faust does not allow input and output to alias, so the input is copied
     // out first. Channels the host does not have read as silence.
     for (int channel = 0; channel < numInputs; ++channel) {
         float* destination = scratchIn_.getWritePointer(channel);
-        if (channel < hostChannels) {
-            const float* source = context.audio->getReadPointer(channel, startSample);
-            std::copy(source, source + numSamples, destination);
-        } else {
-            std::fill(destination, destination + numSamples, 0.0f);
+        const float* source = nullptr;
+        if (channel >= ownInputs) {
+            // A source narrower than the key the dsp asked for feeds its last
+            // channel to the rest: a mono send into a stereo key is the key on
+            // both sides, not the key and silence.
+            const int key = std::min(channel - ownInputs, context.numSidechainChannels - 1);
+            if (key >= 0)
+                source = context.sidechain[key] + startSample;
+        } else if (channel < hostChannels) {
+            source = context.audio->getReadPointer(channel, startSample);
         }
+
+        if (source != nullptr)
+            std::copy(source, source + numSamples, destination);
+        else
+            std::fill(destination, destination + numSamples, 0.0f);
         inPtrs_[static_cast<size_t>(channel)] = destination;
     }
 
@@ -489,19 +506,11 @@ void MagdaCompiledEffect::computeEngine(int engineIndex, DeviceProcessContext& c
     // A device that declares a fixed output width owns exactly that many
     // channels, so anything above them is not its output -- it is the input it
     // was handed, and passing that through would leak the dry signal around a
-    // widener that was asked to replace it.
-    //
-    // The key is not the device's to clear, though. It arrives as channels of
-    // this buffer but it belongs to whatever produced it, the engine hands it
-    // over read-only, and the same source may be fanned out to other ops: zeroing
-    // it here would empty their input from under them. Stop at the first key
-    // channel when there is one.
-    if (outputChannelCount() > 0) {
-        const int firstForeignChannel =
-            context.sidechainInputChannel >= 0 ? context.sidechainInputChannel : hostChannels;
-        for (int channel = numOutputs; channel < firstForeignChannel; ++channel)
+    // widener that was asked to replace it. The key is not in this buffer to be
+    // cleared: it is a port now, and it belongs to whatever produced it.
+    if (outputChannelCount() > 0)
+        for (int channel = numOutputs; channel < hostChannels; ++channel)
             context.audio->clear(channel, startSample, numSamples);
-    }
 }
 
 void MagdaCompiledEffect::processAudio(DeviceProcessContext& context) {

--- a/magda/daw/audio/plugins/compiled/MagdaCompiledEffect.hpp
+++ b/magda/daw/audio/plugins/compiled/MagdaCompiledEffect.hpp
@@ -169,8 +169,11 @@ class MagdaCompiledEffect : public CompiledFaustDevice {
     virtual bool wantsMidiInput() const {
         return false;
     }
-    virtual bool wantsSidechain() const {
-        return false;
+    /// The sidechain slot the device's dsp reads, as the inputs after its own
+    /// (#2329). None by default; MagdaCompiledEffect copies the key into those
+    /// inputs, so no dsp has to know where a host keeps it.
+    virtual magda::SidechainPort sidechainPort() const {
+        return {};
     }
     /// Whether the host should keep pumping the device once dry input stops. A
     /// device with a tail in its delay lines says yes, or the trail is cut.
@@ -188,8 +191,9 @@ class MagdaCompiledEffect : public CompiledFaustDevice {
     virtual int outputChannelCount() const {
         return 0;
     }
-    /// Input channels the device reads, sidechain key included, or 0 to let the
-    /// host decide. See DeviceProperties::inputChannelCount.
+    /// Input channels the device reads for its own signal, the key not among
+    /// them, or 0 to let the host decide. See
+    /// DeviceProperties::inputChannelCount.
     virtual int inputChannelCount() const {
         return 0;
     }

--- a/magda/daw/audio/plugins/compiled/MagdaCompressorCompiledPlugin.cpp
+++ b/magda/daw/audio/plugins/compiled/MagdaCompressorCompiledPlugin.cpp
@@ -48,16 +48,31 @@ float gainReductionForLevel(float levelDb, float thresholdDb, float ratio, float
     return std::max(0.0f, over - compressedOver);
 }
 
+/// Peak magnitude over @p numSamples of one channel.
+float peakOfChannel(const float* samples, int numSamples) {
+    float peak = 0.0f;
+    for (int i = 0; i < numSamples; ++i)
+        peak = std::max(peak, std::fabs(samples[i]));
+    return peak;
+}
+
 /// Peak magnitude over one channel range of @p buffer.
 float peakOfChannels(const juce::AudioBuffer<float>& buffer, int firstChannel, int lastChannel,
                      int startSample, int numSamples) {
     float peak = 0.0f;
     for (int channel = firstChannel; channel < std::min(lastChannel, buffer.getNumChannels());
-         ++channel) {
-        const float* samples = buffer.getReadPointer(channel, startSample);
-        for (int i = 0; i < numSamples; ++i)
-            peak = std::max(peak, std::fabs(samples[i]));
-    }
+         ++channel)
+        peak =
+            std::max(peak, peakOfChannel(buffer.getReadPointer(channel, startSample), numSamples));
+    return peak;
+}
+
+/// Peak magnitude over every channel of the key the host routed.
+float peakOfSidechain(const DeviceProcessContext& context) {
+    float peak = 0.0f;
+    for (int channel = 0; channel < context.numSidechainChannels; ++channel)
+        peak = std::max(peak, peakOfChannel(context.sidechain[channel] + context.startSample,
+                                            context.numSamples));
     return peak;
 }
 
@@ -178,7 +193,7 @@ std::vector<MagdaCompressorCompiledPlugin::HostSlotInfo> MagdaCompressorCompiled
 }
 
 void MagdaCompressorCompiledPlugin::beforeCompute(DeviceProcessContext& context, int engineIndex) {
-    const bool external = context.sidechainInputChannel >= 0;
+    const bool external = context.numSidechainChannels > 0;
 
     // The hidden zone that tells the dsp to detect off the key rather than off
     // its own input. Only the Clean engine has one; Glue has no external
@@ -188,10 +203,7 @@ void MagdaCompressorCompiledPlugin::beforeCompute(DeviceProcessContext& context,
 
     const float inputPeak =
         peakOfChannels(*context.audio, 0, 2, context.startSample, context.numSamples);
-    const float keyPeak = external ? peakOfChannels(*context.audio, context.sidechainInputChannel,
-                                                    context.sidechainInputChannel + 1,
-                                                    context.startSample, context.numSamples)
-                                   : inputPeak;
+    const float keyPeak = external ? peakOfSidechain(context) : inputPeak;
 
     inputPeakDb_.store(ampToDb(inputPeak), std::memory_order_relaxed);
     keyPeakDb_.store(ampToDb(keyPeak), std::memory_order_relaxed);

--- a/magda/daw/audio/plugins/compiled/MagdaCompressorCompiledPlugin.hpp
+++ b/magda/daw/audio/plugins/compiled/MagdaCompressorCompiledPlugin.hpp
@@ -91,14 +91,14 @@ class MagdaCompressorCompiledPlugin : public MagdaCompiledEffect {
     int engineSlot() const override {
         return kEngineSlot;
     }
-    bool wantsSidechain() const override {
-        return true;
+    magda::SidechainPort sidechainPort() const override {
+        return magda::monoAudioSidechain;
     }
     int outputChannelCount() const override {
         return 2;
     }
     int inputChannelCount() const override {
-        return 3;  // Left, Right, and the key.
+        return 2;  // Left and Right. The key is a port, not a third input.
     }
     void beforeCompute(DeviceProcessContext& context, int engineIndex) override;
     void afterCompute(DeviceProcessContext& context, int engineIndex) override;

--- a/magda/daw/audio/plugins/compiled/MagdaRingModCompiledPlugin.hpp
+++ b/magda/daw/audio/plugins/compiled/MagdaRingModCompiledPlugin.hpp
@@ -49,8 +49,14 @@ class MagdaRingModCompiledPlugin : public MagdaCompiledEffect {
     const char* slotIdPrefix() const override {
         return "magda_ring_mod_";
     }
-    bool wantsSidechain() const override {
-        return true;  // Source=Sidechain takes the carrier from input 3.
+    magda::SidechainPort sidechainPort() const override {
+        return magda::monoAudioSidechain;  // Source=Sidechain takes the carrier from it.
+    }
+    int outputChannelCount() const override {
+        return 2;
+    }
+    int inputChannelCount() const override {
+        return 2;
     }
     bool resetsOnPlayStart() const override {
         return true;

--- a/magda/daw/audio/plugins/engine/EngineMagdaDevice.cpp
+++ b/magda/daw/audio/plugins/engine/EngineMagdaDevice.cpp
@@ -192,9 +192,9 @@ void EngineMagdaDevice::prepare(const magda::engine::RenderContext& context) {
     latencySamples_ =
         static_cast<int>(std::llround(properties_.latencySeconds * context.sampleRate));
 
-    // Room for the device's own channels plus a sidechain key of the same
-    // width appended after them, which is how the SDK hands one over.
-    channels_.assign(static_cast<std::size_t>(std::max(0, context.numChannels)) * 2, nullptr);
+    channels_.assign(static_cast<std::size_t>(std::max(0, context.numChannels)), nullptr);
+    sidechainChannels_.assign(static_cast<std::size_t>(std::max(0, properties_.sidechain.channels)),
+                              nullptr);
 
     sizeMidiScratch();
 }
@@ -263,21 +263,17 @@ void EngineMagdaDevice::process(magda::engine::DeviceBlock& block) {
     for (std::size_t channel = 0; channel < numChannels; ++channel)
         channels_[channel] = block.audio.getChannelPointer(channel);
 
-    // The key, appended after the device's own channels: the SDK hands a
-    // sidechain over as further channels of the same buffer, and the executor
-    // gives it to us as a separate block. The const_cast is safe because the
-    // contract is that a device reads its key and never writes it, and the
-    // alternative is copying the block every callback to say so in the type.
-    auto sidechainChannels = std::min(channels_.size() - numChannels,
-                                      static_cast<std::size_t>(block.sidechain.getNumChannels()));
+    // The key on its own port, sized to what the device declared: the plan
+    // gives it to us as its own block and the SDK takes it as one, so nothing
+    // in between decides where in a buffer a key belongs (#2329).
+    const auto sidechainChannels = std::min(
+        sidechainChannels_.size(), static_cast<std::size_t>(block.sidechain.getNumChannels()));
     for (std::size_t channel = 0; channel < sidechainChannels; ++channel)
-        channels_[numChannels + channel] =
-            const_cast<float*>(block.sidechain.getChannelPointer(channel));
+        sidechainChannels_[channel] = block.sidechain.getChannelPointer(channel);
 
     // Non-owning: the executor's buffer, seen through the container the SDK
     // takes. Nothing is copied and nothing is allocated.
-    juce::AudioBuffer<float> audio(channels_.data(),
-                                   static_cast<int>(numChannels + sidechainChannels), numSamples);
+    juce::AudioBuffer<float> audio(channels_.data(), static_cast<int>(numChannels), numSamples);
 
     // Both views or neither, which is the SDK's contract: a device with an input
     // and nothing to write to still gets a sink, and its output is discarded.
@@ -315,7 +311,8 @@ void EngineMagdaDevice::process(magda::engine::DeviceBlock& block) {
 
     DeviceProcessContext context{
         .audio = &audio,
-        .sidechainInputChannel = sidechainChannels > 0 ? static_cast<int>(numChannels) : -1,
+        .sidechain = sidechainChannels > 0 ? sidechainChannels_.data() : nullptr,
+        .numSidechainChannels = static_cast<int>(sidechainChannels),
         .midiIn = midiIn ? &*midiIn : nullptr,
         .midiOut = midiOut ? &*midiOut : nullptr,
         .tempoMap = tempo ? &*tempo : nullptr,

--- a/magda/daw/audio/plugins/engine/EngineMagdaDevice.hpp
+++ b/magda/daw/audio/plugins/engine/EngineMagdaDevice.hpp
@@ -44,11 +44,10 @@
  * so the engine carries it beside the port instead: DeviceBlock::midiInAllNotesOff
  * on the way in, DeviceBlock::midiOutAllNotesOff on the way out (#2418).
  *
- * Sidechain audio used to be a third. DeviceBlock::sidechain now reaches the
- * device as further channels of its own buffer, after the ones it owns, with
- * DeviceProcessContext::sidechainInputChannel saying where they start -- the
- * layout MAGDA's compiled dynamics DSPs already read and the one the fork
- * hands them (#2192).
+ * Sidechain audio is neither: DeviceBlock::sidechain is the plan's own slot and
+ * DeviceProcessContext::sidechain is the SDK's, so the key crosses here as a
+ * port on both sides and no adapter decides where in a buffer it belongs
+ * (#2192, #2329).
  */
 
 namespace magda::daw::audio::engine_adapter {
@@ -119,6 +118,9 @@ class EngineMagdaDevice final : public magda::engine::EngineDevice {
 
     std::vector<ParameterMapping> parameters_;
     std::vector<float*> channels_;
+    /// The key's channel pointers, sized in prepare() to what the device
+    /// declared. Read-only: a device reads its key and never writes it.
+    std::vector<const float*> sidechainChannels_;
 
     /// What the device reads this block and what it wrote, one vector each,
     /// reserved to its own port's bound and never grown past it (#2347).

--- a/magda/daw/audio/plugins/tracktion/TracktionMagdaDevicePlugin.cpp
+++ b/magda/daw/audio/plugins/tracktion/TracktionMagdaDevicePlugin.cpp
@@ -131,6 +131,7 @@ TracktionMagdaDevicePlugin::TracktionMagdaDevicePlugin(const te::PluginCreationI
       device_(std::move(device)),
       deviceHandle_(std::make_shared<MagdaDevice*>(device_.get())),
       properties_(propertiesForRequiredDevice(device_)) {
+    refreshChannelLayout();
     buildParameters();
     device_->restoreState(state);
 }
@@ -167,12 +168,20 @@ void TracktionMagdaDevicePlugin::initialise(const te::PluginInitialisationInfo& 
     // block.
     syncParametersToDevice();
     refreshLiveSourceIds();
+    refreshChannelLayout();
     // So a normal block's output never allocates on the audio thread.
     midiOut_.reserve(128);
     device_->prepare({
         .sampleRate = info.sampleRate,
         .maximumBlockSize = info.blockSizeSamples,
     });
+}
+
+void TracktionMagdaDevicePlugin::refreshChannelLayout() {
+    const auto live = device_->properties();
+    ownInputChannels_.store(live.inputChannelCount, std::memory_order_relaxed);
+    sidechainChannels_.store(live.sidechain.takesAudio() ? live.sidechain.channels : 0,
+                             std::memory_order_relaxed);
 }
 
 void TracktionMagdaDevicePlugin::refreshLiveSourceIds() {
@@ -227,18 +236,38 @@ void TracktionMagdaDevicePlugin::applyToBuffer(const te::PluginRenderContext& co
 
     TracktionTempoMapView tempoMap{edit.tempoSequence};
 
-    // The fork appends the key to the plugin's own channels, so the device's
-    // declared width is where it starts.
-    const int sidechainChannel =
-        getSidechainSourceID().isValid()
-            ? (properties_.outputChannelCount > 0 ? properties_.outputChannelCount : 2)
-            : -1;
+    // The fork appends the key after the plugin's own inputs, and widens the
+    // buffer only when a source is routed. So the key is whatever this buffer
+    // carries past the device's own width, up to what the device declared.
+    // Split off here, once, rather than told to the device as an offset into
+    // its own buffer (#2329).
+    //
+    // No buffer at all is a parameter-only call, which the fork makes; there is
+    // nothing to split and nothing to hand over.
+    const int totalChannels =
+        context.destBuffer != nullptr ? context.destBuffer->getNumChannels() : 0;
+    const int declaredKey = sidechainChannels_.load(std::memory_order_relaxed);
+    const int declaredOwn = ownInputChannels_.load(std::memory_order_relaxed);
+    const int ownWidth = declaredOwn > 0 ? declaredOwn : std::max(0, totalChannels - declaredKey);
+    const int keyChannels = std::clamp(totalChannels - ownWidth, 0, declaredKey);
+    const int ownChannels = totalChannels - keyChannels;
+
+    // Non-owning views over the same channels: nothing is copied.
+    juce::AudioBuffer<float> ownAudio;
+    const float* const* key = nullptr;
+    if (context.destBuffer != nullptr) {
+        ownAudio.setDataToReferTo(context.destBuffer->getArrayOfWritePointers(), ownChannels,
+                                  context.destBuffer->getNumSamples());
+        if (keyChannels > 0)
+            key = context.destBuffer->getArrayOfReadPointers() + ownChannels;
+    }
 
     const auto* liveSources = liveSources_.load(std::memory_order_acquire);
 
     DeviceProcessContext deviceContext{
-        .audio = context.destBuffer,
-        .sidechainInputChannel = sidechainChannel,
+        .audio = context.destBuffer != nullptr ? &ownAudio : nullptr,
+        .sidechain = key,
+        .numSidechainChannels = keyChannels,
         .midiIn = midiIn ? &*midiIn : nullptr,
         .midiOut = midiOut ? &*midiOut : nullptr,
         .tempoMap = &tempoMap,
@@ -289,13 +318,15 @@ bool TracktionMagdaDevicePlugin::producesAudioWhenNoAudioInput() {
 
 bool TracktionMagdaDevicePlugin::canSidechain() {
     // Live, not cached. Most devices' properties are fixed for their lifetime,
-    // but the runtime Faust device recompiles to a different channel width and
-    // the host has to follow it. Dropping the extra inputs also drops the route
-    // that fed them, which nothing downstream would otherwise clear.
+    // but the runtime Faust device recompiles to a source that declares a
+    // different key, or none, and the host has to follow it. Withdrawing the
+    // declaration also drops the route that fed it, which nothing downstream
+    // would otherwise clear.
+    refreshChannelLayout();
     const auto live = device_->properties();
-    if (!live.canSidechain && getSidechainSourceID().isValid())
+    if (!live.sidechain.takesAudio() && getSidechainSourceID().isValid())
         setSidechainSourceID({});
-    return live.canSidechain;
+    return live.sidechain.takesAudio();
 }
 
 int TracktionMagdaDevicePlugin::getNumOutputChannelsGivenInputs(int numInputChannels) {
@@ -312,31 +343,29 @@ void TracktionMagdaDevicePlugin::getChannelNames(juce::StringArray* inputs,
     // connected to the bus at all.
     te::Plugin::getChannelNames(inputs, outputs);
 
+    refreshChannelLayout();
     const auto live = device_->properties();
 
-    // Inputs past the output width are the key, which is the SDK's sidechain
-    // layout. A stereo key is named per side; a single one is just the key.
-    const int keyChannels = std::max(0, live.inputChannelCount - live.outputChannelCount);
-    const auto name = [&](int index) {
-        if (live.outputChannelCount > 0 && index >= live.outputChannelCount) {
-            if (keyChannels < 2)
-                return juce::String("Sidechain");
-            return juce::String(index == live.outputChannelCount ? "Sidechain Left"
-                                                                 : "Sidechain Right");
-        }
-        return juce::String(index == 0 ? "Left" : "Right");
-    };
+    const auto sideName = [](int index) { return juce::String(index == 0 ? "Left" : "Right"); };
+
+    // The key is named after the device's own inputs, because that is where the
+    // fork appends it: guessSidechainRouting reads exactly this list to decide
+    // which channels the source lands on. A stereo key is named per side; a
+    // single one is just the key. Outputs never carry one.
+    const int keyChannels = live.sidechain.takesAudio() ? live.sidechain.channels : 0;
 
     if (inputs != nullptr && live.inputChannelCount > 0) {
         inputs->clear();
         for (int index = 0; index < live.inputChannelCount; ++index)
-            inputs->add(name(index));
+            inputs->add(sideName(index));
+        for (int key = 0; key < keyChannels; ++key)
+            inputs->add(keyChannels < 2 ? juce::String("Sidechain") : "Sidechain " + sideName(key));
     }
 
     if (outputs != nullptr && live.outputChannelCount > 0) {
         outputs->clear();
         for (int index = 0; index < live.outputChannelCount; ++index)
-            outputs->add(name(index));
+            outputs->add(sideName(index));
     }
 }
 

--- a/magda/daw/audio/plugins/tracktion/TracktionMagdaDevicePlugin.hpp
+++ b/magda/daw/audio/plugins/tracktion/TracktionMagdaDevicePlugin.hpp
@@ -63,6 +63,11 @@ class TracktionMagdaDevicePlugin final : public te::Plugin {
     void buildParameters();
     void syncParametersToDevice();
     void refreshLiveSourceIds();
+    /// Re-read the two widths the render path splits its buffer on. Message
+    /// thread, from wherever the fork asks this plugin about its shape: most
+    /// devices' properties never change, but the runtime Faust device
+    /// recompiles into a different one and the split has to follow it (#2329).
+    void refreshChannelLayout();
 
     std::unique_ptr<MagdaDevice> device_;
     /// Handed to the parameter conversion lambdas, which an automation curve can
@@ -71,6 +76,10 @@ class TracktionMagdaDevicePlugin final : public te::Plugin {
     /// calling into a device that is gone.
     std::shared_ptr<MagdaDevice*> deviceHandle_;
     const DeviceProperties properties_;
+    /// The live channel split, published for the audio thread: the device's own
+    /// input width, and the key channels the fork appends after them.
+    std::atomic<int> ownInputChannels_{0};
+    std::atomic<int> sidechainChannels_{0};
     std::vector<std::unique_ptr<juce::CachedValue<float>>> parameterValues_;
     std::vector<te::AutomatableParameter::Ptr> parameters_;
     /// The device's MIDI output for the current block, swapped into the host's

--- a/magda/daw/audio/processors/internal/NativeDeviceProcessors.cpp
+++ b/magda/daw/audio/processors/internal/NativeDeviceProcessors.cpp
@@ -147,7 +147,7 @@ void FaustProcessor::populateParametersFromEngine(DeviceInfo& info) const {
         DBG("[FaustProcessor] populateParameters: plugin cast NULL");
         return;
     }
-    info.canSidechain = faust->properties().canSidechain;
+    info.sidechainPort = faust->properties().sidechain;
     // Only push active, non-hidden slots so the standard ParamGridComponent
     // shows populated cells only. Each ParameterInfo carries its real slot
     // index in `paramIndex`, so links / automation / MIDI Learn still

--- a/magda/daw/core/DeviceInfo.hpp
+++ b/magda/daw/core/DeviceInfo.hpp
@@ -10,6 +10,7 @@
 #include "MacroInfo.hpp"
 #include "ModInfo.hpp"
 #include "ParameterInfo.hpp"
+#include "SidechainPort.hpp"
 #include "TypeIds.hpp"
 
 namespace magda {
@@ -133,15 +134,36 @@ struct MultiOutConfig {
 };
 
 /**
- * @brief Sidechain routing configuration for a plugin
+ * @brief Where a device's sidechain key comes from, and what happens on the way.
  *
- * Allows a plugin (e.g., compressor) to receive audio or MIDI from another track
- * as a sidechain/key input.
+ * A source rather than a track id (#2329). The track is only half of where a
+ * key is taken from: @ref tapPoint says which of the two points on that track
+ * it is taken at, @ref gainDb trims it on the edge before the device sees it,
+ * and @ref listen monitors it in place of the device's own output. Adding a
+ * kind of source later -- a hardware input, a rack chain -- is a field here
+ * rather than a rewrite of everything that carries one.
+ *
+ * RackInfo carries this struct too, for a rack's own trigger and follower
+ * source. Only @ref type and @ref sourceTrackId mean anything there.
  */
 struct SidechainConfig {
     enum class Type { None, Audio, MIDI };
     Type type = Type::None;
     TrackId sourceTrackId = INVALID_TRACK_ID;
+
+    /// Which point on the source track the key is taken at, the same two points
+    /// a modifier chooses between. PostFader is where the current engine's
+    /// sidechain send sits, so a project that predates the field sounds as it
+    /// always did.
+    ModTapPoint tapPoint = ModTapPoint::PostFader;
+
+    /// Trim on the key, applied on the edge feeding the device rather than
+    /// inside it. Filtering the key stays the device's own job.
+    float gainDb = 0.0f;
+
+    /// Monitor the key instead of what the device made of its input. A value
+    /// the plan reads per block, so turning it on rebuilds nothing.
+    bool listen = false;
 
     bool isActive() const {
         return type != Type::None && sourceTrackId != INVALID_TRACK_ID;
@@ -370,7 +392,11 @@ struct DeviceInfo {
     /// compiles a send op and a return op from it rather than a Device op
     /// (#2245).
     InsertConfig insert;
-    bool canSidechain = false;    // true if TE plugin supports audio sidechain input
+    /// What the live device declared it takes on its sidechain slot, projected
+    /// here by its processor (#2329). What the routing menu offers, what the
+    /// plan wires and what the API reports all read this one declaration.
+    SidechainPort sidechainPort;
+
     bool canReceiveMidi = false;  // true if TE plugin accepts MIDI input (for cross-track MIDI)
     bool producesMidi = false;    // true if the live plugin can output MIDI
 

--- a/magda/daw/core/DeviceInfo.hpp
+++ b/magda/daw/core/DeviceInfo.hpp
@@ -168,6 +168,16 @@ struct SidechainConfig {
     bool isActive() const {
         return type != Type::None && sourceTrackId != INVALID_TRACK_ID;
     }
+
+    /// Whether the slot actually monitors its key. Only an audio key can be
+    /// monitored: a MIDI source feeds the device's MIDI slot and leaves the
+    /// sidechain slot empty, so a device "listening" to one would put out the
+    /// silence that slot carries. Asked here rather than at each reader,
+    /// because @ref listen survives a change of source type and the model can
+    /// therefore hold the pair legitimately.
+    bool listensToKey() const {
+        return listen && type == Type::Audio && sourceTrackId != INVALID_TRACK_ID;
+    }
 };
 
 /**

--- a/magda/daw/core/PluginCapabilities.cpp
+++ b/magda/daw/core/PluginCapabilities.cpp
@@ -90,7 +90,8 @@ DeviceMidiCapabilities fallbackCapabilitiesForDevice(const DeviceInfo& device) {
     DeviceMidiCapabilities capabilities;
     capabilities.hasMidiInput = device.consumesMidi();
     capabilities.hasMidiOutput = device.emitsMidi();
-    capabilities.hasAudioInput = device.deviceType == DeviceType::Effect || device.canSidechain;
+    capabilities.hasAudioInput =
+        device.deviceType == DeviceType::Effect || device.sidechainPort.takesAudio();
     capabilities.hasAudioOutput = device.isInstrument || device.deviceType == DeviceType::Effect;
     capabilities.supportsMidiInputThruToggle =
         capabilities.hasMidiInput && capabilities.hasMidiOutput;
@@ -263,7 +264,7 @@ bool supportsMidiSidechainSource(const DeviceInfo& device) {
 }
 
 bool supportsSidechainRoutingMenu(const DeviceInfo& device) {
-    return device.canSidechain || supportsMidiSidechainSource(device);
+    return device.sidechainPort.takesAudio() || supportsMidiSidechainSource(device);
 }
 
 void applyCachedCapabilitiesToDevice(DeviceInfo& device) {

--- a/magda/daw/core/RackInfo.hpp
+++ b/magda/daw/core/RackInfo.hpp
@@ -198,7 +198,9 @@ struct RackInfo {
     // Modulators for rack-wide modulation
     ModArray mods = createDefaultMods(0);
 
-    // Sidechain config for rack-level MIDI/Audio triggering (cross-track source)
+    // The source a rack's own triggers and followers listen to (cross-track).
+    // Only `type` and `sourceTrackId` apply: a rack has no sidechain edge for
+    // the tap point, trim and listen a device's key carries (#2329).
     SidechainConfig sidechain;
 
     // Default constructor

--- a/magda/daw/core/SidechainPort.hpp
+++ b/magda/daw/core/SidechainPort.hpp
@@ -1,0 +1,45 @@
+#pragma once
+
+namespace magda {
+
+/**
+ * @brief What a device declares on its sidechain slot (#2329).
+ *
+ * Declared by the device, never inferred from a channel count: more inputs than
+ * outputs is not by itself a request for a key, and a host that guessed one had
+ * no way to know how wide it was. A device's processor projects this onto
+ * DeviceInfo with the rest of the device's facts, so the menu that offers a
+ * source, the plan that wires it and the API that reports it read one
+ * declaration.
+ */
+struct SidechainPort {
+    enum class Kind {
+        None,
+        /// Audio, on the device's own port rather than as further channels of
+        /// the buffer it processes.
+        Audio,
+        /// MIDI from another track, which reaches the device on its MIDI input:
+        /// the plan fills that slot from the source instead of from the chain
+        /// (ChainRoutingModel).
+        MIDI,
+    };
+
+    Kind kind = Kind::None;
+    /// Channels an audio key carries. Zero for every other kind.
+    int channels = 0;
+
+    bool takesAudio() const {
+        return kind == Kind::Audio && channels > 0;
+    }
+    bool declared() const {
+        return kind != Kind::None;
+    }
+
+    bool operator==(const SidechainPort&) const = default;
+};
+
+/// The audio key most dynamics devices ask for.
+inline constexpr SidechainPort monoAudioSidechain{.kind = SidechainPort::Kind::Audio,
+                                                  .channels = 1};
+
+}  // namespace magda

--- a/magda/daw/core/TrackManager.hpp
+++ b/magda/daw/core/TrackManager.hpp
@@ -837,6 +837,12 @@ class TrackManager : public daw::audio::DeviceIdAllocator, public daw::audio::De
 
     // Sidechain configuration (device-level)
     void setSidechainSource(DeviceId targetDevice, TrackId sourceTrack, SidechainConfig::Type type);
+    /// Which point on the source track the key is taken at (#2329).
+    void setSidechainTapPoint(DeviceId targetDevice, ModTapPoint tapPoint);
+    /// Trim on the key, applied on the edge feeding the device.
+    void setSidechainGainDb(DeviceId targetDevice, float gainDb);
+    /// Monitor the key in place of the device's own output.
+    void setSidechainListen(DeviceId targetDevice, bool listen);
     void clearSidechain(DeviceId targetDevice);
 
     // Sidechain configuration (rack-level)
@@ -1250,6 +1256,10 @@ class TrackManager : public daw::audio::DeviceIdAllocator, public daw::audio::De
     // engine is attached or the track takes no external input (Aux, Group).
     // Single place for the create/restore/duplicate/engine-attach wiring.
     void startMidiMonitoring(const TrackInfo& track, const juce::String& deviceId);
+
+    /// Find @p targetDevice anywhere in any track, change its sidechain source,
+    /// then notify. The one walk every sidechain edit shares (#2329).
+    void editSidechain(DeviceId targetDevice, const std::function<void(SidechainConfig&)>& edit);
 
     // Mutable resolver — used only by the unified setters in
     // TrackManagerModulation.cpp. Kept private so external callers can't

--- a/magda/daw/core/TrackManagerDevices.cpp
+++ b/magda/daw/core/TrackManagerDevices.cpp
@@ -2567,15 +2567,18 @@ void TrackManager::removeRackFromChainByPath(const ChainNodePath& rackPath) {
 // Sidechain Configuration
 // ============================================================================
 
-void TrackManager::setSidechainSource(DeviceId targetDevice, TrackId sourceTrack,
-                                      SidechainConfig::Type type) {
+// Every sidechain edit is the same walk with a different write, so the walk is
+// written once: find the device, change its source, notify. Callers that only
+// move the tap point, the trim or the listen switch go through here too, which
+// is what keeps a sidechain edit one shape for undo and for the API (#2329).
+void TrackManager::editSidechain(DeviceId targetDevice,
+                                 const std::function<void(SidechainConfig&)>& edit) {
     auto updateElements = [&](auto&& self, std::vector<ChainElement>& elements) -> bool {
         for (auto& element : elements) {
             if (magda::isDevice(element)) {
                 auto& device = magda::getDevice(element);
                 if (device.id == targetDevice) {
-                    device.sidechain.type = type;
-                    device.sidechain.sourceTrackId = sourceTrack;
+                    edit(device.sidechain);
                     notifyDevicePropertyChanged(findDevicePath(targetDevice));
                     return true;
                 }
@@ -2606,8 +2609,30 @@ void TrackManager::setSidechainSource(DeviceId targetDevice, TrackId sourceTrack
     }
 }
 
+void TrackManager::setSidechainSource(DeviceId targetDevice, TrackId sourceTrack,
+                                      SidechainConfig::Type type) {
+    editSidechain(targetDevice, [&](SidechainConfig& sidechain) {
+        sidechain.type = type;
+        sidechain.sourceTrackId = sourceTrack;
+    });
+}
+
+void TrackManager::setSidechainTapPoint(DeviceId targetDevice, ModTapPoint tapPoint) {
+    editSidechain(targetDevice, [&](SidechainConfig& sidechain) { sidechain.tapPoint = tapPoint; });
+}
+
+void TrackManager::setSidechainGainDb(DeviceId targetDevice, float gainDb) {
+    editSidechain(targetDevice, [&](SidechainConfig& sidechain) { sidechain.gainDb = gainDb; });
+}
+
+void TrackManager::setSidechainListen(DeviceId targetDevice, bool listen) {
+    editSidechain(targetDevice, [&](SidechainConfig& sidechain) { sidechain.listen = listen; });
+}
+
 void TrackManager::clearSidechain(DeviceId targetDevice) {
-    setSidechainSource(targetDevice, INVALID_TRACK_ID, SidechainConfig::Type::None);
+    // The whole source, the fields that shape it included: a slot that is not
+    // keyed off anything is not still trimming and monitoring a key.
+    editSidechain(targetDevice, [](SidechainConfig& sidechain) { sidechain = {}; });
 }
 
 void TrackManager::setRackSidechainSource(const ChainNodePath& rackPath, TrackId sourceTrack,

--- a/magda/daw/project/serialization/TrackSerializer.cpp
+++ b/magda/daw/project/serialization/TrackSerializer.cpp
@@ -526,8 +526,9 @@ juce::var ProjectSerializer::serializeDeviceInfo(const DeviceInfo& device) {
     }
 
     // Sidechain / MIDI receive capabilities
-    if (device.canSidechain) {
-        obj->setProperty("canSidechain", true);
+    if (device.sidechainPort.declared()) {
+        obj->setProperty("sidechainPortKind", static_cast<int>(device.sidechainPort.kind));
+        obj->setProperty("sidechainPortChannels", device.sidechainPort.channels);
     }
     if (device.canReceiveMidi) {
         obj->setProperty("canReceiveMidi", true);
@@ -579,6 +580,14 @@ juce::var ProjectSerializer::serializeDeviceInfo(const DeviceInfo& device) {
         auto* scObj = new juce::DynamicObject();
         scObj->setProperty("type", static_cast<int>(device.sidechain.type));
         scObj->setProperty("sourceTrackId", device.sidechain.sourceTrackId);
+        // Only when they are not the defaults a project that predates them
+        // reads back as: post-fader, no trim, not listening (#2329).
+        if (device.sidechain.tapPoint != ModTapPoint::PostFader)
+            scObj->setProperty("tapPoint", static_cast<int>(device.sidechain.tapPoint));
+        if (device.sidechain.gainDb != 0.0f)
+            scObj->setProperty("gainDb", device.sidechain.gainDb);
+        if (device.sidechain.listen)
+            scObj->setProperty("listen", true);
         obj->setProperty("sidechain", juce::var(scObj));
     }
 
@@ -745,9 +754,14 @@ bool ProjectSerializer::deserializeDeviceInfo(const juce::var& json, DeviceInfo&
     }
 
     // Sidechain / MIDI receive capabilities
-    auto canSidechainVar = obj->getProperty("canSidechain");
-    if (!canSidechainVar.isVoid()) {
-        outDevice.canSidechain = static_cast<bool>(canSidechainVar);
+    if (obj->hasProperty("sidechainPortKind")) {
+        outDevice.sidechainPort.kind = static_cast<SidechainPort::Kind>(
+            static_cast<int>(obj->getProperty("sidechainPortKind")));
+        outDevice.sidechainPort.channels = obj->getProperty("sidechainPortChannels");
+    } else if (static_cast<bool>(obj->getProperty("canSidechain"))) {
+        // Projects that predate the declared port, where the only fact saved
+        // was that the device had one (#2329).
+        outDevice.sidechainPort = monoAudioSidechain;
     }
     auto canReceiveMidiVar = obj->getProperty("canReceiveMidi");
     if (!canReceiveMidiVar.isVoid()) {
@@ -824,6 +838,14 @@ bool ProjectSerializer::deserializeDeviceInfo(const juce::var& json, DeviceInfo&
         outDevice.sidechain.type =
             static_cast<SidechainConfig::Type>(static_cast<int>(scObj->getProperty("type")));
         outDevice.sidechain.sourceTrackId = scObj->getProperty("sourceTrackId");
+        // Absent in a project that predates them, which is the default each
+        // field carries: post-fader, no trim, not listening.
+        if (scObj->hasProperty("tapPoint"))
+            outDevice.sidechain.tapPoint =
+                static_cast<ModTapPoint>(static_cast<int>(scObj->getProperty("tapPoint")));
+        if (scObj->hasProperty("gainDb"))
+            outDevice.sidechain.gainDb = static_cast<float>(double(scObj->getProperty("gainDb")));
+        outDevice.sidechain.listen = static_cast<bool>(scObj->getProperty("listen"));
     }
 
     applyCachedCapabilitiesToDevice(outDevice);

--- a/magda/daw/ui/components/chain/slot/DeviceSlotSidechainControls.cpp
+++ b/magda/daw/ui/components/chain/slot/DeviceSlotSidechainControls.cpp
@@ -18,6 +18,30 @@ struct TrackEntry {
     juce::String name;
 };
 
+/// One thing the menu can do, looked up by item id rather than decoded out of
+/// an id range. Two unbounded lists of tracks and a handful of fixed actions
+/// cannot share one id space: with enough tracks the source ids run into the
+/// action ids, and picking a track changes the tap point instead.
+struct MenuAction {
+    enum class Kind { Clear, SetSource, SetTapPoint, SetTrim, ToggleListen };
+
+    Kind kind = Kind::Clear;
+    magda::TrackId trackId = magda::INVALID_TRACK_ID;
+    magda::SidechainConfig::Type type = magda::SidechainConfig::Type::None;
+    magda::ModTapPoint tapPoint = magda::ModTapPoint::PostFader;
+    float gainDb = 0.0f;
+    bool listen = false;
+};
+
+using MenuActions = std::vector<MenuAction>;
+
+/// Adds @p action and returns the item id that runs it. Ids are 1-based: a
+/// PopupMenu reports 0 for "nothing was chosen".
+int addAction(MenuActions& actions, MenuAction action) {
+    actions.push_back(action);
+    return static_cast<int>(actions.size());
+}
+
 /// The trim steps the menu offers. A menu cannot drag a value, and a key's trim
 /// is a matching decision rather than a ride, so a handful of steps is what it
 /// is for; anything finer belongs to whoever automates it (#2329).
@@ -43,99 +67,91 @@ void showDeviceSlotSidechainMenu(const magda::DeviceInfo& device,
         canMidi = supportsMidiSidechainSource(*currentDevice);
     }
 
+    auto actions = std::make_shared<MenuActions>();
+
     const bool isNone = !currentSidechain.isActive();
-    menu.addItem(1, "None", true, isNone);
+    menu.addItem(addAction(*actions, {.kind = MenuAction::Kind::Clear}), "None", true, isNone);
     menu.addSeparator();
 
-    auto trackEntries = std::make_shared<std::vector<TrackEntry>>();
-    const auto& tracks = magda::TrackManager::getInstance().getTracks();
-    for (const auto& track : tracks) {
+    std::vector<TrackEntry> trackEntries;
+    for (const auto& track : magda::TrackManager::getInstance().getTracks()) {
         if (track.id == nodePath.trackId)
             continue;
-        trackEntries->push_back({track.id, track.name});
+        trackEntries.push_back({track.id, track.name});
     }
 
-    if (canAudio) {
-        menu.addSectionHeader("Audio Sidechain");
-        int itemId = 100;
-        for (const auto& entry : *trackEntries) {
-            const bool isSelected = currentSidechain.isActive() &&
-                                    currentSidechain.type == magda::SidechainConfig::Type::Audio &&
+    const auto addSources = [&](magda::SidechainConfig::Type type, const char* header) {
+        menu.addSectionHeader(header);
+        for (const auto& entry : trackEntries) {
+            const bool isSelected = currentSidechain.isActive() && currentSidechain.type == type &&
                                     currentSidechain.sourceTrackId == entry.id;
-            menu.addItem(itemId, entry.name, true, isSelected);
-            ++itemId;
+            const auto item = addAction(
+                *actions, {.kind = MenuAction::Kind::SetSource, .trackId = entry.id, .type = type});
+            menu.addItem(item, entry.name, true, isSelected);
         }
-    }
+    };
 
-    if (canMidi) {
-        menu.addSectionHeader("MIDI Source");
-        int itemId = 200;
-        for (const auto& entry : *trackEntries) {
-            const bool isSelected = currentSidechain.isActive() &&
-                                    currentSidechain.type == magda::SidechainConfig::Type::MIDI &&
-                                    currentSidechain.sourceTrackId == entry.id;
-            menu.addItem(itemId, entry.name, true, isSelected);
-            ++itemId;
-        }
-    }
+    if (canAudio)
+        addSources(magda::SidechainConfig::Type::Audio, "Audio Sidechain");
+    if (canMidi)
+        addSources(magda::SidechainConfig::Type::MIDI, "MIDI Source");
 
     // The rest of the source: where on the track the key is taken, what it is
-    // trimmed by, and whether the slot monitors it. Only for an audio key --
-    // a MIDI source has no fader to sit either side of and nothing to hear.
+    // trimmed by, and whether the slot monitors it. Only for an audio key -- a
+    // MIDI source has no fader to sit either side of and nothing to hear.
     if (currentSidechain.isActive() &&
         currentSidechain.type == magda::SidechainConfig::Type::Audio) {
         menu.addSeparator();
         menu.addSectionHeader("Key");
 
-        const bool preFx = currentSidechain.tapPoint == magda::ModTapPoint::PreFx;
-        menu.addItem(300, "Tap: Pre-FX", true, preFx);
-        menu.addItem(301, "Tap: Post-Fader", true, !preFx);
+        const auto addTapPoint = [&](magda::ModTapPoint point, const char* label) {
+            const auto item =
+                addAction(*actions, {.kind = MenuAction::Kind::SetTapPoint, .tapPoint = point});
+            menu.addItem(item, label, true, currentSidechain.tapPoint == point);
+        };
+        addTapPoint(magda::ModTapPoint::PreFx, "Tap: Pre-FX");
+        addTapPoint(magda::ModTapPoint::PostFader, "Tap: Post-Fader");
 
         juce::PopupMenu trim;
-        for (int step = 0; step < static_cast<int>(std::size(kTrimSteps)); ++step)
-            trim.addItem(400 + step, trimLabel(kTrimSteps[step]), true,
-                         juce::approximatelyEqual(currentSidechain.gainDb, kTrimSteps[step]));
+        for (const float step : kTrimSteps) {
+            const auto item =
+                addAction(*actions, {.kind = MenuAction::Kind::SetTrim, .gainDb = step});
+            trim.addItem(item, trimLabel(step), true,
+                         juce::approximatelyEqual(currentSidechain.gainDb, step));
+        }
         menu.addSubMenu("Trim", trim);
 
-        menu.addItem(310, "Listen", true, currentSidechain.listen);
+        const auto listenItem = addAction(
+            *actions, {.kind = MenuAction::Kind::ToggleListen, .listen = !currentSidechain.listen});
+        menu.addItem(listenItem, "Listen", true, currentSidechain.listen);
     }
 
     const auto deviceId = device.id;
-    const bool listening = currentSidechain.listen;
     menu.showMenuAsync(
         juce::PopupMenu::Options().withTargetComponent(targetButton),
-        [deviceId, listening, trackEntries,
-         onSidechainChanged = std::move(onSidechainChanged)](int result) {
-            if (result == 0)
+        [deviceId, actions, onSidechainChanged = std::move(onSidechainChanged)](int result) {
+            if (result <= 0 || result > static_cast<int>(actions->size()))
                 return;
 
             auto& trackManager = magda::TrackManager::getInstance();
+            const auto& action = (*actions)[static_cast<size_t>(result - 1)];
 
-            if (result == 1) {
-                trackManager.clearSidechain(deviceId);
-            } else if (result == 300 || result == 301) {
-                trackManager.setSidechainTapPoint(deviceId, result == 300
-                                                                ? magda::ModTapPoint::PreFx
-                                                                : magda::ModTapPoint::PostFader);
-            } else if (result == 310) {
-                trackManager.setSidechainListen(deviceId, !listening);
-            } else if (result >= 400 && result < 400 + static_cast<int>(std::size(kTrimSteps))) {
-                trackManager.setSidechainGainDb(deviceId,
-                                                kTrimSteps[static_cast<size_t>(result - 400)]);
-            } else if (result >= 100 && result < 200) {
-                const int index = result - 100;
-                if (index >= 0 && index < static_cast<int>(trackEntries->size())) {
-                    trackManager.setSidechainSource(deviceId,
-                                                    (*trackEntries)[static_cast<size_t>(index)].id,
-                                                    magda::SidechainConfig::Type::Audio);
-                }
-            } else if (result >= 200) {
-                const int index = result - 200;
-                if (index >= 0 && index < static_cast<int>(trackEntries->size())) {
-                    trackManager.setSidechainSource(deviceId,
-                                                    (*trackEntries)[static_cast<size_t>(index)].id,
-                                                    magda::SidechainConfig::Type::MIDI);
-                }
+            switch (action.kind) {
+                case MenuAction::Kind::Clear:
+                    trackManager.clearSidechain(deviceId);
+                    break;
+                case MenuAction::Kind::SetSource:
+                    trackManager.setSidechainSource(deviceId, action.trackId, action.type);
+                    break;
+                case MenuAction::Kind::SetTapPoint:
+                    trackManager.setSidechainTapPoint(deviceId, action.tapPoint);
+                    break;
+                case MenuAction::Kind::SetTrim:
+                    trackManager.setSidechainGainDb(deviceId, action.gainDb);
+                    break;
+                case MenuAction::Kind::ToggleListen:
+                    trackManager.setSidechainListen(deviceId, action.listen);
+                    break;
             }
 
             if (onSidechainChanged)

--- a/magda/daw/ui/components/chain/slot/DeviceSlotSidechainControls.cpp
+++ b/magda/daw/ui/components/chain/slot/DeviceSlotSidechainControls.cpp
@@ -1,5 +1,6 @@
 #include "slot/DeviceSlotSidechainControls.hpp"
 
+#include <iterator>
 #include <memory>
 #include <utility>
 #include <vector>
@@ -17,6 +18,15 @@ struct TrackEntry {
     juce::String name;
 };
 
+/// The trim steps the menu offers. A menu cannot drag a value, and a key's trim
+/// is a matching decision rather than a ride, so a handful of steps is what it
+/// is for; anything finer belongs to whoever automates it (#2329).
+constexpr float kTrimSteps[] = {-12.0f, -6.0f, -3.0f, 0.0f, 3.0f, 6.0f, 12.0f};
+
+juce::String trimLabel(float decibels) {
+    return (decibels > 0.0f ? "+" : "") + juce::String(decibels, 0) + " dB";
+}
+
 }  // namespace
 
 void showDeviceSlotSidechainMenu(const magda::DeviceInfo& device,
@@ -25,11 +35,11 @@ void showDeviceSlotSidechainMenu(const magda::DeviceInfo& device,
     juce::PopupMenu menu;
 
     magda::SidechainConfig currentSidechain;
-    bool canAudio = device.canSidechain;
+    bool canAudio = device.sidechainPort.takesAudio();
     bool canMidi = supportsMidiSidechainSource(device);
     if (auto* currentDevice = magda::TrackManager::getInstance().getDeviceInChainByPath(nodePath)) {
         currentSidechain = currentDevice->sidechain;
-        canAudio = currentDevice->canSidechain;
+        canAudio = currentDevice->sidechainPort.takesAudio();
         canMidi = supportsMidiSidechainSource(*currentDevice);
     }
 
@@ -69,28 +79,62 @@ void showDeviceSlotSidechainMenu(const magda::DeviceInfo& device,
         }
     }
 
+    // The rest of the source: where on the track the key is taken, what it is
+    // trimmed by, and whether the slot monitors it. Only for an audio key --
+    // a MIDI source has no fader to sit either side of and nothing to hear.
+    if (currentSidechain.isActive() &&
+        currentSidechain.type == magda::SidechainConfig::Type::Audio) {
+        menu.addSeparator();
+        menu.addSectionHeader("Key");
+
+        const bool preFx = currentSidechain.tapPoint == magda::ModTapPoint::PreFx;
+        menu.addItem(300, "Tap: Pre-FX", true, preFx);
+        menu.addItem(301, "Tap: Post-Fader", true, !preFx);
+
+        juce::PopupMenu trim;
+        for (int step = 0; step < static_cast<int>(std::size(kTrimSteps)); ++step)
+            trim.addItem(400 + step, trimLabel(kTrimSteps[step]), true,
+                         juce::approximatelyEqual(currentSidechain.gainDb, kTrimSteps[step]));
+        menu.addSubMenu("Trim", trim);
+
+        menu.addItem(310, "Listen", true, currentSidechain.listen);
+    }
+
     const auto deviceId = device.id;
+    const bool listening = currentSidechain.listen;
     menu.showMenuAsync(
         juce::PopupMenu::Options().withTargetComponent(targetButton),
-        [deviceId, trackEntries, onSidechainChanged = std::move(onSidechainChanged)](int result) {
+        [deviceId, listening, trackEntries,
+         onSidechainChanged = std::move(onSidechainChanged)](int result) {
             if (result == 0)
                 return;
 
+            auto& trackManager = magda::TrackManager::getInstance();
+
             if (result == 1) {
-                magda::TrackManager::getInstance().clearSidechain(deviceId);
+                trackManager.clearSidechain(deviceId);
+            } else if (result == 300 || result == 301) {
+                trackManager.setSidechainTapPoint(deviceId, result == 300
+                                                                ? magda::ModTapPoint::PreFx
+                                                                : magda::ModTapPoint::PostFader);
+            } else if (result == 310) {
+                trackManager.setSidechainListen(deviceId, !listening);
+            } else if (result >= 400 && result < 400 + static_cast<int>(std::size(kTrimSteps))) {
+                trackManager.setSidechainGainDb(deviceId,
+                                                kTrimSteps[static_cast<size_t>(result - 400)]);
             } else if (result >= 100 && result < 200) {
                 const int index = result - 100;
                 if (index >= 0 && index < static_cast<int>(trackEntries->size())) {
-                    magda::TrackManager::getInstance().setSidechainSource(
-                        deviceId, (*trackEntries)[static_cast<size_t>(index)].id,
-                        magda::SidechainConfig::Type::Audio);
+                    trackManager.setSidechainSource(deviceId,
+                                                    (*trackEntries)[static_cast<size_t>(index)].id,
+                                                    magda::SidechainConfig::Type::Audio);
                 }
             } else if (result >= 200) {
                 const int index = result - 200;
                 if (index >= 0 && index < static_cast<int>(trackEntries->size())) {
-                    magda::TrackManager::getInstance().setSidechainSource(
-                        deviceId, (*trackEntries)[static_cast<size_t>(index)].id,
-                        magda::SidechainConfig::Type::MIDI);
+                    trackManager.setSidechainSource(deviceId,
+                                                    (*trackEntries)[static_cast<size_t>(index)].id,
+                                                    magda::SidechainConfig::Type::MIDI);
                 }
             }
 
@@ -109,9 +153,12 @@ void updateDeviceSlotSidechainButtonState(magda::SvgButton* button,
     const bool active = sidechain.isActive();
     button->setActive(active);
     if (active) {
-        button->setTooltip(sidechain.type == magda::SidechainConfig::Type::MIDI
-                               ? "Sidechain: MIDI"
-                               : "Sidechain: audio");
+        // Listening is worth saying: a slot putting out its key instead of its
+        // own output looks like a broken device otherwise (#2329).
+        const auto source = sidechain.type == magda::SidechainConfig::Type::MIDI
+                                ? juce::String("Sidechain: MIDI")
+                                : juce::String("Sidechain: audio");
+        button->setTooltip(sidechain.listen ? source + " (listening)" : source);
     } else {
         button->setTooltip("Sidechain source");
     }

--- a/magda/engine/exec/PlanExecutor.cpp
+++ b/magda/engine/exec/PlanExecutor.cpp
@@ -1561,6 +1561,22 @@ void PlanExecutor::renderOp(OpId id, const OpValue& published, const BlockInfo& 
                 device->process(deviceBlock);
             }
 
+            // Monitoring the key: the slot puts out what it was handed instead
+            // of what the device made of it (#2329). After process(), so the
+            // device's own smoothing and metering carry on and switching back
+            // is not a click; an unconnected key monitors silence.
+            if (value.listensToSidechain) {
+                const auto key = deviceBlock.sidechain;
+                for (std::size_t channel = 0; channel < audio.getNumChannels(); ++channel) {
+                    auto side = audio.getSingleChannelBlock(channel);
+                    if (key.getNumChannels() == 0)
+                        side.clear();
+                    else
+                        side.copyFrom(
+                            key.getSingleChannelBlock(std::min(channel, key.getNumChannels() - 1)));
+                }
+            }
+
             // What the device left on its output, for whatever the port feeds.
             // A device that produces MIDI and says nothing drops the panic,
             // which is what the fork does with its fresh output buffer.

--- a/magda/engine/exec/PlanValues.cpp
+++ b/magda/engine/exec/PlanValues.cpp
@@ -389,6 +389,33 @@ void Resolver::resolveOp(OpId id, OpValue& value) {
             break;
         }
 
+        case OpRole::DeviceSidechainGain: {
+            const auto* device = findDevice(*track, key);
+            if (device == nullptr) {
+                report(id, "no device " + std::to_string(key.deviceId) +
+                               " in the model, leaving its sidechain trim at unity");
+                break;
+            }
+            // A plain multiply on the key, like the slot's own gain trim: no
+            // fader curve and no clamp, because this is a trim rather than a
+            // fader position.
+            const auto gain = decibelsToGain(std::clamp(device->sidechain.gainDb, -60.0f, 24.0f));
+            value.gainLeft = gain;
+            value.gainRight = gain;
+            break;
+        }
+
+        case OpRole::DeviceProcess: {
+            const auto* device = findDevice(*track, key);
+            if (device == nullptr) {
+                report(id, "no device " + std::to_string(key.deviceId) +
+                               " in the model, monitoring its own output");
+                break;
+            }
+            value.listensToSidechain = device->sidechain.listen && device->sidechain.isActive();
+            break;
+        }
+
         // The two ops the model toggles rather than recompiles. The subtract
         // and the delay feeding it are in every plan, so turning delta solo on
         // is a value away and the dry line has been running all along; what
@@ -457,9 +484,9 @@ void Resolver::resolveOp(OpId id, OpValue& value) {
             break;
         }
 
-        // Sources, sums, merges, differences, devices, meters and the output
-        // carry no value of their own: what they render comes from their
-        // bindings, and what they pass on is whatever reached them.
+        // Sources, sums, merges, differences, meters and the output carry no
+        // value of their own: what they render comes from their bindings, and
+        // what they pass on is whatever reached them.
         case OpRole::ClipAudio:
         case OpRole::ClipMidi:
         case OpRole::LiveAudioInput:
@@ -468,7 +495,6 @@ void Resolver::resolveOp(OpId id, OpValue& value) {
         case OpRole::SessionMidi:
         case OpRole::TrackAudioInput:
         case OpRole::TrackMidiInput:
-        case OpRole::DeviceProcess:
         case OpRole::DeviceMeter:
         case OpRole::ChainMidiMerge:
         // A note gate's range and transposition are topology, compiled into the

--- a/magda/engine/exec/PlanValues.cpp
+++ b/magda/engine/exec/PlanValues.cpp
@@ -412,7 +412,7 @@ void Resolver::resolveOp(OpId id, OpValue& value) {
                                " in the model, monitoring its own output");
                 break;
             }
-            value.listensToSidechain = device->sidechain.listen && device->sidechain.isActive();
+            value.listensToSidechain = device->sidechain.listensToKey();
             break;
         }
 

--- a/magda/engine/exec/PlanValues.hpp
+++ b/magda/engine/exec/PlanValues.hpp
@@ -52,6 +52,14 @@ struct OpValue {
     /// delta in the plan, which for a device that passes its input through is
     /// the whole track going quiet.
     bool subtractsDry = false;
+
+    /// Whether a Device op puts out the key it was handed instead of what it
+    /// made of its input (#2329). A value like the delta above, so monitoring a
+    /// sidechain rebuilds nothing; the device still runs, so its own metering
+    /// and smoothing carry on and switching back is not a click. Nothing to
+    /// listen to is silence, which is what a slot monitoring an unconnected key
+    /// should sound like.
+    bool listensToSidechain = false;
 };
 
 /**

--- a/magda/engine/plan/PlanCompiler.cpp
+++ b/magda/engine/plan/PlanCompiler.cpp
@@ -761,13 +761,27 @@ ChainSignal Compiler::emitDevice(const DeviceInfo& device, const ChainSite& site
 
     PortRef sidechainIn;
     if (device.sidechain.type == SidechainConfig::Type::Audio && device.sidechain.isActive()) {
-        const auto source = trackSidechainTap_.find(device.sidechain.sourceTrackId);
-        if (source != trackSidechainTap_.end())
-            sidechainIn = source->second;
-        else
+        // Two points on the source track, the same two a modifier chooses
+        // between: pre-FX is what the track played, post-fader is what it
+        // sends, and riding the source fader is the whole difference. The
+        // compiler keeps them apart already (#2329).
+        const auto preFx = device.sidechain.tapPoint == ModTapPoint::PreFx;
+        const auto& points = preFx ? trackTriggerTap_ : trackSidechainTap_;
+        const auto source = points.find(device.sidechain.sourceTrackId);
+        if (source != points.end()) {
+            // The key's trim, on the edge rather than inside the device.
+            // Emitted wherever a key is connected, so moving it is a value and
+            // never a recompile.
+            const OpKey gainKey{
+                site.trackId, site.rackId, site.chainId, device.id, OpRole::DeviceSidechainGain, 0,
+                site.segment};
+            sidechainIn =
+                PortRef{addOp(OpKind::Gain, gainKey, {source->second}, {SignalKind::Audio}), 0};
+        } else {
             diagnose("device " + std::to_string(device.id) + " on track " +
                      std::to_string(site.trackId) + ": audio sidechain source track " +
                      std::to_string(device.sidechain.sourceTrackId) + " is not routed");
+        }
     }
 
     const auto producesMidi = node.outputsPluginMidi();

--- a/magda/engine/plan/RenderPlan.cpp
+++ b/magda/engine/plan/RenderPlan.cpp
@@ -123,6 +123,8 @@ const char* toString(OpRole role) {
             return "deviceDelta";
         case OpRole::DeviceGain:
             return "deviceGain";
+        case OpRole::DeviceSidechainGain:
+            return "deviceSidechainGain";
         case OpRole::DeviceMeter:
             return "deviceMeter";
         case OpRole::ChainMidiMerge:

--- a/magda/engine/plan/RenderPlan.hpp
+++ b/magda/engine/plan/RenderPlan.hpp
@@ -146,34 +146,35 @@ enum class OpKind : std::uint8_t {
  * second half of the differ's identity key.
  */
 enum class OpRole : std::uint8_t {
-    ClipAudio,        ///< the track's audio clip source
-    ClipMidi,         ///< the track's MIDI clip source
-    LiveAudioInput,   ///< the track's live audio input
-    LiveMidiInput,    ///< the track's live MIDI input
-    SessionAudio,     ///< the track's session audio, whichever slot is playing
-    SessionMidi,      ///< the track's session MIDI
-    TrackAudioInput,  ///< sum of everything feeding the track's chain head
-    TrackMidiInput,   ///< merge of everything feeding the track's chain head
-    DeviceProcess,    ///< the device itself
-    DeviceInject,     ///< an instrument's output summing into the bus flowing past it
-    DeviceDelta,      ///< the device's output minus the dry input it was handed
-    DeviceGain,       ///< the device slot's gain trim
-    DeviceMeter,      ///< the device slot's level tap
-    ChainMidiMerge,   ///< raw chain MIDI merged with a device's MIDI output
-    PadNoteGate,      ///< one pad chain's note range and transposition
-    RackChainFader,   ///< one rack chain's volume + pan
-    RackMix,          ///< sum of a rack's chains
-    RackMidiMix,      ///< merge of a rack's chain MIDI outputs
-    RackFader,        ///< the rack's output volume + pan
-    RackDelta,        ///< the rack's output minus the dry input it was handed
-    TrackFader,       ///< the track fader
-    TrackMeter,       ///< the track's post-fader, pre-mute level tap
-    TrackMute,        ///< mute and solo, applied after the meter and sidechain tap
-    SendTap,          ///< one send slot
-    ModulationTap,    ///< one track's signal, read by the modifiers listening to it
-    HardwareOutput,   ///< the master's hardware output
-    InsertSend,       ///< one insert's send
-    InsertReturn,     ///< one insert's return
+    ClipAudio,            ///< the track's audio clip source
+    ClipMidi,             ///< the track's MIDI clip source
+    LiveAudioInput,       ///< the track's live audio input
+    LiveMidiInput,        ///< the track's live MIDI input
+    SessionAudio,         ///< the track's session audio, whichever slot is playing
+    SessionMidi,          ///< the track's session MIDI
+    TrackAudioInput,      ///< sum of everything feeding the track's chain head
+    TrackMidiInput,       ///< merge of everything feeding the track's chain head
+    DeviceProcess,        ///< the device itself
+    DeviceInject,         ///< an instrument's output summing into the bus flowing past it
+    DeviceDelta,          ///< the device's output minus the dry input it was handed
+    DeviceGain,           ///< the device slot's gain trim
+    DeviceSidechainGain,  ///< the trim on the key feeding the device's sidechain slot
+    DeviceMeter,          ///< the device slot's level tap
+    ChainMidiMerge,       ///< raw chain MIDI merged with a device's MIDI output
+    PadNoteGate,          ///< one pad chain's note range and transposition
+    RackChainFader,       ///< one rack chain's volume + pan
+    RackMix,              ///< sum of a rack's chains
+    RackMidiMix,          ///< merge of a rack's chain MIDI outputs
+    RackFader,            ///< the rack's output volume + pan
+    RackDelta,            ///< the rack's output minus the dry input it was handed
+    TrackFader,           ///< the track fader
+    TrackMeter,           ///< the track's post-fader, pre-mute level tap
+    TrackMute,            ///< mute and solo, applied after the meter and sidechain tap
+    SendTap,              ///< one send slot
+    ModulationTap,        ///< one track's signal, read by the modifiers listening to it
+    HardwareOutput,       ///< the master's hardware output
+    InsertSend,           ///< one insert's send
+    InsertReturn,         ///< one insert's return
 
     // Latency compensation. A delay sits on one edge, so its identity is the
     // op it feeds plus the input slot it fills: the role says which op that is,

--- a/tests/NullDiffHostedPlugin.cpp
+++ b/tests/NullDiffHostedPlugin.cpp
@@ -524,7 +524,11 @@ magda::DeviceInfo hostedDevice(magda::DeviceId id, HostedRole role) {
         description.isInstrument ? magda::DeviceType::Instrument : magda::DeviceType::Effect;
     device.canReceiveMidi = roleAcceptsMidi(role);
     device.producesMidi = roleProducesMidi(role);
-    device.canSidechain = role == HostedRole::Key;
+    // A stereo key, matching the second input bus busesFor() gives the Key role.
+    device.sidechainPort =
+        role == HostedRole::Key
+            ? magda::SidechainPort{.kind = magda::SidechainPort::Kind::Audio, .channels = 2}
+            : magda::SidechainPort{};
     device.audioInputChannels = roleInputChannels(role);
     device.audioOutputChannels = roleOutputChannels(role);
 

--- a/tests/PlanGoldenFixtures.cpp
+++ b/tests/PlanGoldenFixtures.cpp
@@ -235,6 +235,30 @@ Fixture sidechain() {
     return value;
 }
 
+/// The other tap point, which is the only part of a modelled sidechain source
+/// that is structure (#2329): a key taken pre-FX reads the source's trigger tap
+/// rather than its post-fader one. The trim is in both plans, because moving it
+/// is a value, and so is the listen switch.
+Fixture sidechainPreFx() {
+    Fixture value;
+    value.name = "sidechain-prefx";
+    value.covers = "a key taken before the source track's effects";
+
+    auto compressor = effect(7);
+    compressor.sidechain.type = SidechainConfig::Type::Audio;
+    compressor.sidechain.sourceTrackId = 2;
+    compressor.sidechain.tapPoint = ModTapPoint::PreFx;
+
+    // A device on the source, so its pre-FX point and its post-fader one are
+    // different ops rather than the same one twice.
+    value.tracks = {track(1), track(2)};
+    value.tracks[0].chain.fxChainElements.push_back(makeDeviceElement(compressor));
+    value.tracks[1].chain.fxChainElements.push_back(makeDeviceElement(effect(9)));
+    value.master = master();
+    value.options = withoutMeters();
+    return value;
+}
+
 /// Delta solo at both scopes at once (#2136): a device measured against what it
 /// was handed, inside a rack measured against what reached the rack. The device
 /// reports latency, so the dry edges have something to wait for and the golden
@@ -563,6 +587,7 @@ std::vector<Fixture> planFixtures() {
     fixtures.push_back(cascadedLatency());
     fixtures.push_back(rackChains());
     fixtures.push_back(sidechain());
+    fixtures.push_back(sidechainPreFx());
     fixtures.push_back(deltaSolo());
     fixtures.push_back(sectionLocalDeviceIds());
     fixtures.push_back(groupRouting());

--- a/tests/devices/test_persisted_enum_pins.cpp
+++ b/tests/devices/test_persisted_enum_pins.cpp
@@ -110,6 +110,10 @@ static_assert(static_cast<int>(SidechainConfig::Type::None) == 0);
 static_assert(static_cast<int>(SidechainConfig::Type::Audio) == 1);
 static_assert(static_cast<int>(SidechainConfig::Type::MIDI) == 2);
 
+static_assert(static_cast<int>(SidechainPort::Kind::None) == 0);
+static_assert(static_cast<int>(SidechainPort::Kind::Audio) == 1);
+static_assert(static_cast<int>(SidechainPort::Kind::MIDI) == 2);
+
 static_assert(static_cast<int>(ParameterScale::Linear) == 0);
 static_assert(static_cast<int>(ParameterScale::Logarithmic) == 1);
 static_assert(static_cast<int>(ParameterScale::Exponential) == 2);
@@ -308,6 +312,9 @@ std::vector<Pin> allPins() {
         PIN(SidechainConfig::Type, None, 0),
         PIN(SidechainConfig::Type, Audio, 1),
         PIN(SidechainConfig::Type, MIDI, 2),
+        PIN(SidechainPort::Kind, None, 0),
+        PIN(SidechainPort::Kind, Audio, 1),
+        PIN(SidechainPort::Kind, MIDI, 2),
         PIN(ParameterScale, Linear, 0),
         PIN(ParameterScale, Logarithmic, 1),
         PIN(ParameterScale, Exponential, 2),

--- a/tests/dsp/test_faust_sidechain_juce.cpp
+++ b/tests/dsp/test_faust_sidechain_juce.cpp
@@ -24,6 +24,7 @@ constexpr const char* kSidechainDsp = R"FAUST(
 // Self-contained test DSP. The literal "stdfaust.lib" in this comment is
 // load-bearing: compile() only skips its automatic import when the source
 // already mentions the library, and the test binary has no faustlibraries dir.
+declare magda_sidechain "audio";
 process(mainL, mainR, sideL, sideR) = mainL + sideL, mainR + sideR;
 )FAUST";
 
@@ -42,12 +43,19 @@ process = _, _;
 
 constexpr const char* kMonoSidechainDsp = R"FAUST(
 // Self-contained test DSP; see the load-bearing "stdfaust.lib" note above.
+declare magda_sidechain "audio";
 process(mainL, mainR, sidechain) = mainL + sidechain, mainR + sidechain;
 )FAUST";
 
 constexpr const char* kNineInputDsp = R"FAUST(
 // Self-contained test DSP; see the load-bearing "stdfaust.lib" note above.
 process(a, b, c, d, e, f, g, h, i) = a, b;
+)FAUST";
+
+/// Four inputs and no declaration: extra inputs are not a key on their own.
+constexpr const char* kUndeclaredWideDsp = R"FAUST(
+// Self-contained test DSP; see the load-bearing "stdfaust.lib" note above.
+process(mainL, mainR, extraL, extraR) = mainL + extraL, mainR + extraR;
 )FAUST";
 
 constexpr const char* kInvalidDsp = R"FAUST(
@@ -71,7 +79,7 @@ magda::DeviceInfo makeSavedFaust(magda::TrackId sourceTrackId, const juce::Strin
     device.name = "Faust";
     device.format = magda::PluginFormat::Internal;
     device.pluginId = audio::FaustPlugin::xmlTypeName;
-    device.canSidechain = true;
+    device.sidechainPort = {.kind = magda::SidechainPort::Kind::Audio, .channels = 2};
     device.sidechain.type = magda::SidechainConfig::Type::Audio;
     device.sidechain.sourceTrackId = sourceTrackId;
     if (auto xml = state.createXml())
@@ -118,10 +126,11 @@ class FaustSidechainTest final : public juce::UnitTest {
         expectEquals(inputs[3], juce::String("Sidechain Right"));
 
         magda::DeviceInfo device;
-        device.canSidechain = false;
         magda::FaustProcessor processor(1929, plugin);
         processor.populateParameters(device, magda::DeviceProcessor::ValueSource::Engine);
-        expect(device.canSidechain, "DeviceInfo should expose the live DSP capability");
+        expect(device.sidechainPort.takesAudio(), "DeviceInfo should expose the declared port");
+        expectEquals(device.sidechainPort.channels, 2,
+                     "The declared key is as wide as the inputs past the outputs");
 
         constexpr int kBlockSize = 64;
         te::PluginInitialisationInfo initInfo;
@@ -156,6 +165,19 @@ class FaustSidechainTest final : public juce::UnitTest {
         host->getChannelNames(&inputs, nullptr);
         expectEquals(inputs.size(), 3);
         expectEquals(inputs[2], juce::String("Sidechain"));
+
+        beginTest("Extra inputs without a declaration are not a key");
+
+        error.clear();
+        expect(faust->loadDspSource("Undeclared wide test", kUndeclaredWideDsp, error),
+               "Four-input DSP without a declaration should compile: " + error);
+        expect(!host->canSidechain(),
+               "More inputs than outputs is not by itself a request for a key");
+        inputs.clear();
+        host->getChannelNames(&inputs, nullptr);
+        expectEquals(inputs.size(), 4);
+        expectEquals(inputs[2], juce::String("Right"),
+                     "Undeclared inputs are the device's own, not a named key");
 
         beginTest("A runtime patch wider than scratch capacity fails safely");
 
@@ -195,9 +217,9 @@ class FaustSidechainTest final : public juce::UnitTest {
         host->getChannelNames(&inputs, nullptr);
         expectEquals(inputs.size(), 2);
 
-        device.canSidechain = true;
+        device.sidechainPort = magda::monoAudioSidechain;
         processor.populateParameters(device, magda::DeviceProcessor::ValueSource::Engine);
-        expect(!device.canSidechain, "DeviceInfo should remove the stale capability");
+        expect(!device.sidechainPort.declared(), "DeviceInfo should remove the stale declaration");
 
         beginTest("A recompile is visible on the host's own parameters");
 
@@ -264,8 +286,8 @@ class FaustSidechainTest final : public juce::UnitTest {
             auto* loadedDevice = trackManager.getDeviceInChainByPath(path);
             expect(loadedDevice != nullptr, "Loaded Faust DeviceInfo should resolve");
             if (loadedDevice) {
-                expect(!loadedDevice->canSidechain,
-                       "Stereo saved DSP should clear the serialized capability");
+                expect(!loadedDevice->sidechainPort.declared(),
+                       "Stereo saved DSP should clear the serialized declaration");
                 expect(!loadedDevice->sidechain.isActive(),
                        "Stereo saved DSP should clear the serialized sidechain");
             }

--- a/tests/engine/test_render_plan_compiler.cpp
+++ b/tests/engine/test_render_plan_compiler.cpp
@@ -73,9 +73,10 @@ int countRole(const RenderPlan& plan, OpRole role) {
 
 /// The op an input slot reads, or -1 when the slot is unconnected. The two ops
 /// every slot carries whatever the model says are looked through: a delay
-/// stands for the op behind it, and so does the subtract that would take a
-/// delta on it, which passes its wet side along until something is soloing
-/// that delta. These tests are about what is routed where; both have their own.
+/// stands for the op behind it, so does the subtract that would take a delta on
+/// it, which passes its wet side along until something is soloing that delta,
+/// and so does the trim on a sidechain edge, which is unity until somebody
+/// moves it. These tests are about what is routed where; each has its own.
 magda::engine::OpId inputOp(const RenderPlan& plan, magda::engine::OpId op, std::size_t slot) {
     const auto& inputs = plan.ops[static_cast<std::size_t>(op)].inputs;
     if (slot >= inputs.size())
@@ -84,8 +85,10 @@ magda::engine::OpId inputOp(const RenderPlan& plan, magda::engine::OpId op, std:
     auto source = inputs[slot].op;
     while (source != magda::engine::INVALID_OP_ID) {
         const auto& producer = plan.ops[static_cast<std::size_t>(source)];
-        if (producer.kind != magda::engine::OpKind::Delay &&
-            producer.kind != magda::engine::OpKind::Subtract)
+        const auto passesThrough = producer.kind == magda::engine::OpKind::Delay ||
+                                   producer.kind == magda::engine::OpKind::Subtract ||
+                                   producer.key.role == OpRole::DeviceSidechainGain;
+        if (!passesThrough)
             break;
         source = producer.inputs.front().op;
     }
@@ -680,7 +683,7 @@ TEST_CASE("Group children are summed into the group track", "[engine][plan][comp
 TEST_CASE("An audio sidechain wires the source track's output into the device",
           "[engine][plan][compiler]") {
     auto compressor = makeEffect(7);
-    compressor.canSidechain = true;
+    compressor.sidechainPort = magda::monoAudioSidechain;
     compressor.sidechain.type = SidechainConfig::Type::Audio;
     compressor.sidechain.sourceTrackId = 2;
 
@@ -700,6 +703,60 @@ TEST_CASE("An audio sidechain wires the source track's output into the device",
             sourceMeter = op;
     REQUIRE(sourceMeter != magda::engine::INVALID_OP_ID);
     CHECK(inputOp(plan, device, 2) == sourceMeter);
+}
+
+TEST_CASE("A pre-FX key reads the source's trigger tap, not its fader",
+          "[engine][plan][compiler]") {
+    auto compressor = makeEffect(7);
+    compressor.sidechainPort = magda::monoAudioSidechain;
+    compressor.sidechain.type = SidechainConfig::Type::Audio;
+    compressor.sidechain.sourceTrackId = 2;
+    compressor.sidechain.tapPoint = ModTapPoint::PreFx;
+
+    std::vector<TrackInfo> tracks{makeTrack(1), makeTrack(2)};
+    tracks[0].chain.fxChainElements.push_back(makeDeviceElement(compressor));
+    // A device on the source, so its two tap points are different ops.
+    tracks[1].chain.fxChainElements.push_back(makeDeviceElement(makeEffect(9)));
+
+    const auto plan = magda::engine::compileRenderPlan(tracks, makeMaster());
+    requireWellFormed(plan);
+    CHECK(plan.diagnostics.empty());
+
+    magda::engine::OpId sourceChainHead = magda::engine::INVALID_OP_ID;
+    for (const auto op : opsWithRole(plan, OpRole::TrackAudioInput))
+        if (plan.ops[static_cast<std::size_t>(op)].key.trackId == 2)
+            sourceChainHead = op;
+    REQUIRE(sourceChainHead != magda::engine::INVALID_OP_ID);
+
+    magda::engine::OpId device = magda::engine::INVALID_OP_ID;
+    for (const auto op : opsWithRole(plan, OpRole::DeviceProcess))
+        if (plan.ops[static_cast<std::size_t>(op)].key.deviceId == 7)
+            device = op;
+    REQUIRE(device != magda::engine::INVALID_OP_ID);
+    CHECK(inputOp(plan, device, 2) == sourceChainHead);
+}
+
+TEST_CASE("A key's trim is its own op, so moving it is a value", "[engine][plan][compiler]") {
+    auto compressor = makeEffect(7);
+    compressor.sidechainPort = magda::monoAudioSidechain;
+    compressor.sidechain.type = SidechainConfig::Type::Audio;
+    compressor.sidechain.sourceTrackId = 2;
+
+    std::vector<TrackInfo> tracks{makeTrack(1), makeTrack(2)};
+    tracks[0].chain.fxChainElements.push_back(makeDeviceElement(compressor));
+
+    const auto trimmed = [&](float gainDb) {
+        auto copy = tracks;
+        getDevice(copy[0].chain.fxChainElements[0]).sidechain.gainDb = gainDb;
+        return magda::engine::compileRenderPlan(copy, makeMaster());
+    };
+
+    // The trim op is in the plan whatever the trim is, and the two plans are
+    // the same structure: turning the trim up must not recompile anything.
+    const auto flat = trimmed(0.0f);
+    const auto cut = trimmed(-6.0f);
+    CHECK(opsWithRole(flat, OpRole::DeviceSidechainGain).size() == 1);
+    CHECK(magda::engine::planFingerprint(flat) == magda::engine::planFingerprint(cut));
 }
 
 TEST_CASE("Liveness propagates downstream from a live input", "[engine][plan][compiler]") {
@@ -993,7 +1050,7 @@ TEST_CASE("Mute is applied after the meter and the sidechain tap", "[engine][pla
     // the muting node, so a muted track still keys a compressor and still reads
     // on its own meter.
     auto compressor = makeEffect(7);
-    compressor.canSidechain = true;
+    compressor.sidechainPort = magda::monoAudioSidechain;
     compressor.sidechain.type = SidechainConfig::Type::Audio;
     compressor.sidechain.sourceTrackId = 2;
 
@@ -1043,7 +1100,7 @@ TEST_CASE("A sidechain on an inactive device is not an ordering dependency",
     // invent a cycle and cost the send.
     auto bypassed = makeEffect(7);
     bypassed.bypassed = true;
-    bypassed.canSidechain = true;
+    bypassed.sidechainPort = magda::monoAudioSidechain;
     bypassed.sidechain.type = SidechainConfig::Type::Audio;
     bypassed.sidechain.sourceTrackId = 2;
 
@@ -1068,7 +1125,7 @@ TEST_CASE("A sidechain on an inactive device is not an ordering dependency",
 
 TEST_CASE("Chain power gates sidechain dependencies too", "[engine][plan][compiler]") {
     auto compressor = makeEffect(7);
-    compressor.canSidechain = true;
+    compressor.sidechainPort = magda::monoAudioSidechain;
     compressor.sidechain.type = SidechainConfig::Type::Audio;
     compressor.sidechain.sourceTrackId = 2;
 
@@ -1119,7 +1176,7 @@ TEST_CASE("An inactive internal route is not an ordering dependency", "[engine][
     // it reads nothing. Track 1 sidechains from track 2. Counting the dead
     // route as a dependency would close a cycle and cost the live sidechain.
     auto compressor = makeEffect(7);
-    compressor.canSidechain = true;
+    compressor.sidechainPort = magda::monoAudioSidechain;
     compressor.sidechain.type = SidechainConfig::Type::Audio;
     compressor.sidechain.sourceTrackId = 2;
 
@@ -1594,12 +1651,12 @@ TEST_CASE("Only MIDI consumers the compiler emits pull in a MIDI source",
 }
 
 TEST_CASE("Sidechain discovery reaches every section emission does", "[engine][plan][compiler]") {
-    // Mixer-analysis devices are rail-managed and none sets canSidechain today,
+    // Mixer-analysis devices are rail-managed and none declares a sidechain today,
     // but emitDevice resolves a sidechain wherever it finds one, so collection
     // has to walk the same sections or ordering silently depends on luck.
     auto analysisWithSidechain = makeEffect(9);
     analysisWithSidechain.deviceType = DeviceType::Analysis;
-    analysisWithSidechain.canSidechain = true;
+    analysisWithSidechain.sidechainPort = magda::monoAudioSidechain;
     analysisWithSidechain.sidechain.type = SidechainConfig::Type::Audio;
     analysisWithSidechain.sidechain.sourceTrackId = 2;
 

--- a/tests/engine/test_render_plan_executor.cpp
+++ b/tests/engine/test_render_plan_executor.cpp
@@ -1386,6 +1386,44 @@ TEST_CASE("Listening puts the key out in place of the device's own output", "[en
     CHECK(harness.takeMeterForDevice(7) == approx(0.75f));
 }
 
+TEST_CASE("A key that is not audio is not listened to", "[engine][exec]") {
+    /// Writes a value nothing else in the plan produces, so a slot silenced by
+    /// monitoring an empty sidechain slot is unmistakable.
+    class Stamp final : public EngineDevice {
+      public:
+        void process(DeviceBlock& block) override {
+            for (std::size_t channel = 0; channel < block.audio.getNumChannels(); ++channel)
+                block.audio.getSingleChannelBlock(channel).fill(0.5f);
+        }
+    };
+
+    // Listen survives a change of source type, and a MIDI source is active, so
+    // the model legitimately holds both. The plan wires no sidechain for a MIDI
+    // source, so a slot that listened anyway would put out that empty slot.
+    auto device = makeEffect(7);
+    device.sidechain.type = SidechainConfig::Type::MIDI;
+    device.sidechain.sourceTrackId = 2;
+    device.sidechain.listen = true;
+
+    auto track = makeTrack(1);
+    track.chain.fxChainElements.push_back(makeDeviceElement(device));
+
+    Harness harness({makeTrack(2), track}, makeMaster());
+    ConstantSource main(1.0f);
+    ConstantSource key(0.75f);
+    NoteSource notes(64);
+    Stamp stamp;
+    harness.bindings.clipAudio[1] = &main;
+    harness.bindings.clipAudio[2] = &key;
+    harness.bindings.clipMidi[2] = &notes;
+    harness.bindings.devices[DeviceKey{7}] = &stamp;
+
+    harness.prepareCleanly();
+    harness.render();
+
+    CHECK(harness.takeMeterForDevice(7) == approx(0.5f));
+}
+
 TEST_CASE("Unbound ops are reported and render silence", "[engine][exec]") {
     auto track = makeTrack(1);
     track.chain.fxChainElements.push_back(makeDeviceElement(makeEffect(7)));

--- a/tests/engine/test_render_plan_executor.cpp
+++ b/tests/engine/test_render_plan_executor.cpp
@@ -1287,7 +1287,7 @@ TEST_CASE("An audio sidechain reaches the device that asked for it", "[engine][e
     };
 
     auto compressor = makeEffect(7);
-    compressor.canSidechain = true;
+    compressor.sidechainPort = magda::monoAudioSidechain;
     compressor.sidechain.type = SidechainConfig::Type::Audio;
     compressor.sidechain.sourceTrackId = 2;
 
@@ -1307,6 +1307,83 @@ TEST_CASE("An audio sidechain reaches the device that asked for it", "[engine][e
 
     CHECK(probe.sidechainChannels == 2);
     CHECK(probe.sidechainLevel == approx(0.75f));
+}
+
+TEST_CASE("The key's trim is applied on the edge, before the device sees it", "[engine][exec]") {
+    class SidechainProbe final : public EngineDevice {
+      public:
+        void process(DeviceBlock& block) override {
+            sidechainLevel =
+                block.sidechain.getNumChannels() > 0 ? block.sidechain.getSample(0, 0) : 0.0f;
+            block.audio.clear();
+        }
+
+        float sidechainLevel = 0.0f;
+    };
+
+    auto compressor = makeEffect(7);
+    compressor.sidechainPort = magda::monoAudioSidechain;
+    compressor.sidechain.type = SidechainConfig::Type::Audio;
+    compressor.sidechain.sourceTrackId = 2;
+    compressor.sidechain.gainDb = -6.0f;
+
+    auto track = makeTrack(1);
+    track.chain.fxChainElements.push_back(makeDeviceElement(compressor));
+
+    Harness harness({makeTrack(2), track}, makeMaster());
+    ConstantSource key(1.0f);
+    ConstantSource main(1.0f);
+    SidechainProbe probe;
+    harness.bindings.clipAudio[2] = &key;
+    harness.bindings.clipAudio[1] = &main;
+    harness.bindings.devices[DeviceKey{7}] = &probe;
+
+    harness.prepareCleanly();
+    harness.render();
+
+    // -6 dB is half the amplitude, near enough: the trim is a plain multiply.
+    CHECK(probe.sidechainLevel == approx(0.5011872f));
+}
+
+TEST_CASE("Listening puts the key out in place of the device's own output", "[engine][exec]") {
+    /// Writes a value nothing else in the plan produces, so hearing the key
+    /// rather than this is unambiguous.
+    class Stamp final : public EngineDevice {
+      public:
+        void process(DeviceBlock& block) override {
+            ran = true;
+            for (std::size_t channel = 0; channel < block.audio.getNumChannels(); ++channel)
+                block.audio.getSingleChannelBlock(channel).fill(-1.0f);
+        }
+
+        bool ran = false;
+    };
+
+    auto compressor = makeEffect(7);
+    compressor.sidechainPort = magda::monoAudioSidechain;
+    compressor.sidechain.type = SidechainConfig::Type::Audio;
+    compressor.sidechain.sourceTrackId = 2;
+    compressor.sidechain.listen = true;
+
+    auto track = makeTrack(1);
+    track.chain.fxChainElements.push_back(makeDeviceElement(compressor));
+
+    Harness harness({makeTrack(2), track}, makeMaster());
+    ConstantSource key(0.75f);
+    ConstantSource main(1.0f);
+    Stamp stamp;
+    harness.bindings.clipAudio[2] = &key;
+    harness.bindings.clipAudio[1] = &main;
+    harness.bindings.devices[DeviceKey{7}] = &stamp;
+
+    harness.prepareCleanly();
+    harness.render();
+
+    // The device still ran: listening is what leaves the slot, not whether the
+    // device is processing, so its own state does not stop and start. What the
+    // slot's own meter reads is the key rather than the stamp.
+    CHECK(stamp.ran);
+    CHECK(harness.takeMeterForDevice(7) == approx(0.75f));
 }
 
 TEST_CASE("Unbound ops are reported and render silence", "[engine][exec]") {

--- a/tests/goldens/plan/sidechain-prefx.txt
+++ b/tests/goldens/plan/sidechain-prefx.txt
@@ -1,0 +1,90 @@
+# sidechain-prefx
+# a key taken before the source track's effects
+#
+# Generated. See tests/test_plan_goldens.cpp to regenerate.
+
+== plan ==
+magda-render-plan v1
+ops=36 outputs=1
+[  0] ClipAudio   det   T2:clipAudio                   in=-                out=audio       deps=0
+[  1] SessionAudio det   T2:sessionAudio                in=-                out=audio       deps=0
+[  2] Delay       det   T2:mixInputDelay               in=0:0              out=audio       deps=1
+[  3] Delay       det   T2:mixInputDelay#1             in=1:0              out=audio       deps=1
+[  4] MixAudio    det   T2:trackAudioInput             in=2:0,3:0          out=audio       deps=2
+[  5] Device      det   T2/D9:deviceProcess            in=4:0,-,-          out=audio       deps=1
+[  6] Delay       det   T2/D9:subtractInputDelay       in=5:0              out=audio       deps=1
+[  7] Delay       det   T2/D9:subtractInputDelay#1     in=4:0              out=audio       deps=1
+[  8] Subtract    det   T2/D9:deviceDelta              in=6:0,7:0          out=audio       deps=2
+[  9] Gain        det   T2/D9:deviceGain               in=8:0              out=audio       deps=1
+[ 10] Fader       det   T2:trackFader                  in=9:0,-            out=audio       deps=1
+[ 11] Meter       det   T2:trackMeter                  in=10:0             out=audio       deps=1
+[ 12] Gain        det   T2:trackMute                   in=11:0             out=audio       deps=1
+[ 13] ClipAudio   det   T1:clipAudio                   in=-                out=audio       deps=0
+[ 14] SessionAudio det   T1:sessionAudio                in=-                out=audio       deps=0
+[ 15] Delay       det   T1:mixInputDelay               in=13:0             out=audio       deps=1
+[ 16] Delay       det   T1:mixInputDelay#1             in=14:0             out=audio       deps=1
+[ 17] MixAudio    det   T1:trackAudioInput             in=15:0,16:0        out=audio       deps=2
+[ 18] Gain        det   T1/D7:deviceSidechainGain      in=4:0              out=audio       deps=1
+[ 19] Delay       det   T1/D7:deviceInputDelay         in=17:0             out=audio       deps=1
+[ 20] Delay       det   T1/D7:deviceInputDelay#2       in=18:0             out=audio       deps=1
+[ 21] Device      det   T1/D7:deviceProcess            in=19:0,-,20:0      out=audio       deps=2
+[ 22] Delay       det   T1/D7:subtractInputDelay       in=21:0             out=audio       deps=1
+[ 23] Delay       det   T1/D7:subtractInputDelay#1     in=17:0             out=audio       deps=1
+[ 24] Subtract    det   T1/D7:deviceDelta              in=22:0,23:0        out=audio       deps=2
+[ 25] Gain        det   T1/D7:deviceGain               in=24:0             out=audio       deps=1
+[ 26] Fader       det   T1:trackFader                  in=25:0,-           out=audio       deps=1
+[ 27] Meter       det   T1:trackMeter                  in=26:0             out=audio       deps=1
+[ 28] Gain        det   T1:trackMute                   in=27:0             out=audio       deps=1
+[ 29] Delay       det   T-2:mixInputDelay              in=12:0             out=audio       deps=1
+[ 30] Delay       det   T-2:mixInputDelay#1            in=28:0             out=audio       deps=1
+[ 31] MixAudio    det   T-2:trackAudioInput            in=29:0,30:0        out=audio       deps=2
+[ 32] Fader       det   T-2:trackFader                 in=31:0,-           out=audio       deps=1
+[ 33] Meter       det   T-2:trackMeter                 in=32:0             out=audio       deps=1
+[ 34] Gain        det   T-2:trackMute                  in=33:0             out=audio       deps=1
+[ 35] Output      det   T-2:hardwareOutput             in=34:0             out=-           deps=1
+ready=0,1,13,14
+
+== layout ==
+magda-plan-layout v1
+audioSlots=5 midiSlots=0 outputLatency=0
+[  0] ClipAudio   T2:clipAudio                   lat=0       ports=a0
+[  1] SessionAudio T2:sessionAudio                lat=0       ports=a1
+[  2] Delay       T2:mixInputDelay               lat=0       ports=a0          hold=0 elided
+[  3] Delay       T2:mixInputDelay#1             lat=0       ports=a1          hold=0 elided
+[  4] MixAudio    T2:trackAudioInput             lat=0       ports=a0          inplace
+[  5] Device      T2/D9:deviceProcess            lat=0       ports=a1
+[  6] Delay       T2/D9:subtractInputDelay       lat=0       ports=a1          hold=0 elided
+[  7] Delay       T2/D9:subtractInputDelay#1     lat=0       ports=a0          hold=0 elided
+[  8] Subtract    T2/D9:deviceDelta              lat=0       ports=a1          inplace
+[  9] Gain        T2/D9:deviceGain               lat=0       ports=a1          inplace
+[ 10] Fader       T2:trackFader                  lat=0       ports=a1          inplace
+[ 11] Meter       T2:trackMeter                  lat=0       ports=a1          inplace
+[ 12] Gain        T2:trackMute                   lat=0       ports=a1          inplace
+[ 13] ClipAudio   T1:clipAudio                   lat=0       ports=a2
+[ 14] SessionAudio T1:sessionAudio                lat=0       ports=a3
+[ 15] Delay       T1:mixInputDelay               lat=0       ports=a2          hold=0 elided
+[ 16] Delay       T1:mixInputDelay#1             lat=0       ports=a3          hold=0 elided
+[ 17] MixAudio    T1:trackAudioInput             lat=0       ports=a2          inplace
+[ 18] Gain        T1/D7:deviceSidechainGain      lat=0       ports=a4
+[ 19] Delay       T1/D7:deviceInputDelay         lat=0       ports=a2          hold=0 elided
+[ 20] Delay       T1/D7:deviceInputDelay#2       lat=0       ports=a4          hold=0 elided
+[ 21] Device      T1/D7:deviceProcess            lat=0       ports=a3
+[ 22] Delay       T1/D7:subtractInputDelay       lat=0       ports=a3          hold=0 elided
+[ 23] Delay       T1/D7:subtractInputDelay#1     lat=0       ports=a2          hold=0 elided
+[ 24] Subtract    T1/D7:deviceDelta              lat=0       ports=a3          inplace
+[ 25] Gain        T1/D7:deviceGain               lat=0       ports=a3          inplace
+[ 26] Fader       T1:trackFader                  lat=0       ports=a3          inplace
+[ 27] Meter       T1:trackMeter                  lat=0       ports=a3          inplace
+[ 28] Gain        T1:trackMute                   lat=0       ports=a3          inplace
+[ 29] Delay       T-2:mixInputDelay              lat=0       ports=a1          hold=0 elided
+[ 30] Delay       T-2:mixInputDelay#1            lat=0       ports=a3          hold=0 elided
+[ 31] MixAudio    T-2:trackAudioInput            lat=0       ports=a1          inplace
+[ 32] Fader       T-2:trackFader                 lat=0       ports=a1          inplace
+[ 33] Meter       T-2:trackMeter                 lat=0       ports=a1          inplace
+[ 34] Gain        T-2:trackMute                  lat=0       ports=a1          inplace
+[ 35] Output      T-2:hardwareOutput             lat=-       ports=-
+
+== params ==
+magda-param-table v1
+params=0 modifiers=0 links=0
+order:

--- a/tests/goldens/plan/sidechain.txt
+++ b/tests/goldens/plan/sidechain.txt
@@ -5,7 +5,7 @@
 
 == plan ==
 magda-render-plan v1
-ops=30 outputs=1
+ops=31 outputs=1
 [  0] ClipAudio   det   T2:clipAudio                   in=-                out=audio       deps=0
 [  1] SessionAudio det   T2:sessionAudio                in=-                out=audio       deps=0
 [  2] Delay       det   T2:mixInputDelay               in=0:0              out=audio       deps=1
@@ -19,28 +19,29 @@ ops=30 outputs=1
 [ 10] Delay       det   T1:mixInputDelay               in=8:0              out=audio       deps=1
 [ 11] Delay       det   T1:mixInputDelay#1             in=9:0              out=audio       deps=1
 [ 12] MixAudio    det   T1:trackAudioInput             in=10:0,11:0        out=audio       deps=2
-[ 13] Delay       det   T1/D7:deviceInputDelay         in=12:0             out=audio       deps=1
-[ 14] Delay       det   T1/D7:deviceInputDelay#2       in=6:0              out=audio       deps=1
-[ 15] Device      det   T1/D7:deviceProcess            in=13:0,-,14:0      out=audio       deps=2
-[ 16] Delay       det   T1/D7:subtractInputDelay       in=15:0             out=audio       deps=1
-[ 17] Delay       det   T1/D7:subtractInputDelay#1     in=12:0             out=audio       deps=1
-[ 18] Subtract    det   T1/D7:deviceDelta              in=16:0,17:0        out=audio       deps=2
-[ 19] Gain        det   T1/D7:deviceGain               in=18:0             out=audio       deps=1
-[ 20] Fader       det   T1:trackFader                  in=19:0,-           out=audio       deps=1
-[ 21] Meter       det   T1:trackMeter                  in=20:0             out=audio       deps=1
-[ 22] Gain        det   T1:trackMute                   in=21:0             out=audio       deps=1
-[ 23] Delay       det   T-2:mixInputDelay              in=7:0              out=audio       deps=1
-[ 24] Delay       det   T-2:mixInputDelay#1            in=22:0             out=audio       deps=1
-[ 25] MixAudio    det   T-2:trackAudioInput            in=23:0,24:0        out=audio       deps=2
-[ 26] Fader       det   T-2:trackFader                 in=25:0,-           out=audio       deps=1
-[ 27] Meter       det   T-2:trackMeter                 in=26:0             out=audio       deps=1
-[ 28] Gain        det   T-2:trackMute                  in=27:0             out=audio       deps=1
-[ 29] Output      det   T-2:hardwareOutput             in=28:0             out=-           deps=1
+[ 13] Gain        det   T1/D7:deviceSidechainGain      in=6:0              out=audio       deps=1
+[ 14] Delay       det   T1/D7:deviceInputDelay         in=12:0             out=audio       deps=1
+[ 15] Delay       det   T1/D7:deviceInputDelay#2       in=13:0             out=audio       deps=1
+[ 16] Device      det   T1/D7:deviceProcess            in=14:0,-,15:0      out=audio       deps=2
+[ 17] Delay       det   T1/D7:subtractInputDelay       in=16:0             out=audio       deps=1
+[ 18] Delay       det   T1/D7:subtractInputDelay#1     in=12:0             out=audio       deps=1
+[ 19] Subtract    det   T1/D7:deviceDelta              in=17:0,18:0        out=audio       deps=2
+[ 20] Gain        det   T1/D7:deviceGain               in=19:0             out=audio       deps=1
+[ 21] Fader       det   T1:trackFader                  in=20:0,-           out=audio       deps=1
+[ 22] Meter       det   T1:trackMeter                  in=21:0             out=audio       deps=1
+[ 23] Gain        det   T1:trackMute                   in=22:0             out=audio       deps=1
+[ 24] Delay       det   T-2:mixInputDelay              in=7:0              out=audio       deps=1
+[ 25] Delay       det   T-2:mixInputDelay#1            in=23:0             out=audio       deps=1
+[ 26] MixAudio    det   T-2:trackAudioInput            in=24:0,25:0        out=audio       deps=2
+[ 27] Fader       det   T-2:trackFader                 in=26:0,-           out=audio       deps=1
+[ 28] Meter       det   T-2:trackMeter                 in=27:0             out=audio       deps=1
+[ 29] Gain        det   T-2:trackMute                  in=28:0             out=audio       deps=1
+[ 30] Output      det   T-2:hardwareOutput             in=29:0             out=-           deps=1
 ready=0,1,8,9
 
 == layout ==
 magda-plan-layout v1
-audioSlots=4 midiSlots=0 outputLatency=0
+audioSlots=5 midiSlots=0 outputLatency=0
 [  0] ClipAudio   T2:clipAudio                   lat=0       ports=a0
 [  1] SessionAudio T2:sessionAudio                lat=0       ports=a1
 [  2] Delay       T2:mixInputDelay               lat=0       ports=a0          hold=0 elided
@@ -54,23 +55,24 @@ audioSlots=4 midiSlots=0 outputLatency=0
 [ 10] Delay       T1:mixInputDelay               lat=0       ports=a2          hold=0 elided
 [ 11] Delay       T1:mixInputDelay#1             lat=0       ports=a3          hold=0 elided
 [ 12] MixAudio    T1:trackAudioInput             lat=0       ports=a2          inplace
-[ 13] Delay       T1/D7:deviceInputDelay         lat=0       ports=a2          hold=0 elided
-[ 14] Delay       T1/D7:deviceInputDelay#2       lat=0       ports=a0          hold=0 elided
-[ 15] Device      T1/D7:deviceProcess            lat=0       ports=a3
-[ 16] Delay       T1/D7:subtractInputDelay       lat=0       ports=a3          hold=0 elided
-[ 17] Delay       T1/D7:subtractInputDelay#1     lat=0       ports=a2          hold=0 elided
-[ 18] Subtract    T1/D7:deviceDelta              lat=0       ports=a3          inplace
-[ 19] Gain        T1/D7:deviceGain               lat=0       ports=a3          inplace
-[ 20] Fader       T1:trackFader                  lat=0       ports=a3          inplace
-[ 21] Meter       T1:trackMeter                  lat=0       ports=a3          inplace
-[ 22] Gain        T1:trackMute                   lat=0       ports=a3          inplace
-[ 23] Delay       T-2:mixInputDelay              lat=0       ports=a1          hold=0 elided
-[ 24] Delay       T-2:mixInputDelay#1            lat=0       ports=a3          hold=0 elided
-[ 25] MixAudio    T-2:trackAudioInput            lat=0       ports=a1          inplace
-[ 26] Fader       T-2:trackFader                 lat=0       ports=a1          inplace
-[ 27] Meter       T-2:trackMeter                 lat=0       ports=a1          inplace
-[ 28] Gain        T-2:trackMute                  lat=0       ports=a1          inplace
-[ 29] Output      T-2:hardwareOutput             lat=-       ports=-
+[ 13] Gain        T1/D7:deviceSidechainGain      lat=0       ports=a4
+[ 14] Delay       T1/D7:deviceInputDelay         lat=0       ports=a2          hold=0 elided
+[ 15] Delay       T1/D7:deviceInputDelay#2       lat=0       ports=a4          hold=0 elided
+[ 16] Device      T1/D7:deviceProcess            lat=0       ports=a3
+[ 17] Delay       T1/D7:subtractInputDelay       lat=0       ports=a3          hold=0 elided
+[ 18] Delay       T1/D7:subtractInputDelay#1     lat=0       ports=a2          hold=0 elided
+[ 19] Subtract    T1/D7:deviceDelta              lat=0       ports=a3          inplace
+[ 20] Gain        T1/D7:deviceGain               lat=0       ports=a3          inplace
+[ 21] Fader       T1:trackFader                  lat=0       ports=a3          inplace
+[ 22] Meter       T1:trackMeter                  lat=0       ports=a3          inplace
+[ 23] Gain        T1:trackMute                   lat=0       ports=a3          inplace
+[ 24] Delay       T-2:mixInputDelay              lat=0       ports=a1          hold=0 elided
+[ 25] Delay       T-2:mixInputDelay#1            lat=0       ports=a3          hold=0 elided
+[ 26] MixAudio    T-2:trackAudioInput            lat=0       ports=a1          inplace
+[ 27] Fader       T-2:trackFader                 lat=0       ports=a1          inplace
+[ 28] Meter       T-2:trackMeter                 lat=0       ports=a1          inplace
+[ 29] Gain        T-2:trackMute                  lat=0       ports=a1          inplace
+[ 30] Output      T-2:hardwareOutput             lat=-       ports=-
 
 == params ==
 magda-param-table v1

--- a/tests/project/test_project_serialization.cpp
+++ b/tests/project/test_project_serialization.cpp
@@ -2565,6 +2565,60 @@ TEST_CASE("A device with no channel counts written loads as stereo",
     CHECK(loaded.audioOutputChannels == 2);
 }
 
+TEST_CASE("A modelled sidechain source survives a roundtrip", "[project][serialization][device]") {
+    DeviceInfo device;
+    device.id = 41;
+    device.name = "Compressor";
+    device.pluginId = "magda_compressor";
+    device.format = PluginFormat::Internal;
+    device.sidechainPort = magda::monoAudioSidechain;
+    device.sidechain.type = SidechainConfig::Type::Audio;
+    device.sidechain.sourceTrackId = 7;
+    device.sidechain.tapPoint = ModTapPoint::PreFx;
+    device.sidechain.gainDb = -4.5f;
+    device.sidechain.listen = true;
+
+    const auto json = ProjectSerializer::serializeDeviceInfo(device);
+    REQUIRE(json.isObject());
+
+    DeviceInfo loaded;
+    REQUIRE(ProjectSerializer::deserializeDeviceInfo(json, loaded));
+    CHECK(loaded.sidechainPort == magda::monoAudioSidechain);
+    CHECK(loaded.sidechain.type == SidechainConfig::Type::Audio);
+    CHECK(loaded.sidechain.sourceTrackId == 7);
+    CHECK(loaded.sidechain.tapPoint == ModTapPoint::PreFx);
+    CHECK(loaded.sidechain.gainDb == Catch::Approx(-4.5f));
+    CHECK(loaded.sidechain.listen);
+}
+
+TEST_CASE("A sidechain saved before the source had a shape reads as it sounded",
+          "[project][serialization][device]") {
+    // What a project written before #2329 carries: a type, a track, and the
+    // capability flag that has since become a declared port. Everything the
+    // source grew has to read back as the behaviour that project had.
+    DeviceInfo device;
+    device.id = 42;
+    device.name = "Compressor";
+    device.pluginId = "magda_compressor";
+    device.format = PluginFormat::Internal;
+    device.sidechain.type = SidechainConfig::Type::Audio;
+    device.sidechain.sourceTrackId = 7;
+
+    auto json = ProjectSerializer::serializeDeviceInfo(device);
+    REQUIRE(json.isObject());
+    auto* object = json.getDynamicObject();
+    object->removeProperty("sidechainPortKind");
+    object->removeProperty("sidechainPortChannels");
+    object->setProperty("canSidechain", true);
+
+    DeviceInfo loaded;
+    REQUIRE(ProjectSerializer::deserializeDeviceInfo(json, loaded));
+    CHECK(loaded.sidechainPort == magda::monoAudioSidechain);
+    CHECK(loaded.sidechain.tapPoint == ModTapPoint::PostFader);
+    CHECK(loaded.sidechain.gainDb == 0.0f);
+    CHECK_FALSE(loaded.sidechain.listen);
+}
+
 TEST_CASE("Section-scoped device ids survive project roundtrip",
           "[project][serialization][devices]") {
     ProjectTestFixture fixture;

--- a/tests/remote/test_remote_api_contract.cpp
+++ b/tests/remote/test_remote_api_contract.cpp
@@ -123,7 +123,8 @@ TEST_CASE("Remote API input validation returns structured issues",
                                "internal",
                                true,
                                false,
-                               -3.0};
+                               -3.0,
+                               {}};
         auto json = toJson(device);
         // 5 - 2^32 decodes back to rack 5 if the id is truncated to 32 bits.
         json.getDynamicObject()->setProperty(
@@ -303,9 +304,12 @@ TEST_CASE("Remote API DTOs round-trip through JSON", "[remote-api][contract][dto
                        "next",    {{60, 110, 0.0, 0.5}, {64, 100, 1.0, 0.5}}};
     requireRoundTrip(clip, clipFromJson);
 
+    // Every sidechain field carries a non-default value: a decoder that dropped
+    // one would round-trip through the defaults and prove nothing.
+    const DeviceSidechainDto sidechain{"audio", 2, "audio", 4, "preFx", -4.5, true};
     const DeviceGraphDto graph{
         {{10, 3, 20, 30, makeDevicePathDto(ChainNodePath::chainDevice(3, 20, 30, 10)), "Synth",
-          "instrument", "internal", true, false, -3.0}},
+          "instrument", "internal", true, false, -3.0, sidechain}},
         {{20, 3, std::nullopt, std::nullopt, "Parallel", false, 0.0, 0.0, {30}}},
         {{30, 20, "Main", 0, false, false, false, 0.0, 0.0, {10}, {}}}};
     requireRoundTrip(graph, deviceGraphFromJson);
@@ -730,8 +734,18 @@ TEST_CASE("Device paths round-trip through nested racks and chains",
         // address back.
         const auto* get = OperationRegistry::instance().find("devices.list");
         REQUIRE(get != nullptr);
-        const DeviceGraphDto graph{{{6, 2, std::nullopt, std::nullopt, dto, "Kick", "instrument",
-                                     "internal", true, false, 0.0}},
+        const DeviceGraphDto graph{{{6,
+                                     2,
+                                     std::nullopt,
+                                     std::nullopt,
+                                     dto,
+                                     "Kick",
+                                     "instrument",
+                                     "internal",
+                                     true,
+                                     false,
+                                     0.0,
+                                     {}}},
                                    {},
                                    {}};
         REQUIRE(validateJson(toJson(graph), get->outputSchema).empty());


### PR DESCRIPTION
Sidechain was two facts and a convention: `DeviceInfo::canSidechain` inferred from a channel count, `SidechainConfig` a `{type, sourceTrackId}` pair, and the key reaching a `MagdaDevice` as extra channels of its own buffer. The native plan was already ahead of it — a `Device` op has three input slots and `DeviceBlock::sidechain` is its own block — and modifiers were ahead of devices, choosing their tap point per listener while a device sidechain always tapped post-fader.

Closes #2329. (Merges to `dev/0.20.0`, so the issue is closed by hand.)

## Declared, not inferred

`magda::SidechainPort` (`{None | Audio(channels) | MIDI}`) is what a device states in `DeviceProperties::sidechain`, and it replaces the `canSidechain` bool everywhere.

- **Faust** declares it in the dsp: `declare magda_sidechain "audio";`. The key's width is the inputs past the outputs, and the declaration is frozen into `FaustState` at compile time so `properties()` never reads the editable source off another thread. Extra inputs without the declaration are the device's own — there's a test for that, and the Faust agent's prompt says so now.
- **Compiled devices** override `MagdaCompiledEffect::sidechainPort()` instead of `wantsSidechain()`.
- **Externals** still read the bus layout, now for the key's width as well as its existence.
- `DeviceInfo::canSidechain` becomes `DeviceInfo::sidechainPort`, populated by the processor with the rest of the device's facts.

Ring Mod gains the declaration it never had. That also fixes its fork wiring: with only two declared inputs, `guessSidechainRouting` took the two-input branch and summed the track's own stereo into one channel.

## Delivered as a port

`DeviceProcessContext::sidechainInputChannel` is gone; `sidechain` (read-only channel pointers) and `numSidechainChannels` replace it, indexed from `startSample` like the audio.

- `MagdaCompiledEffect` copies the key into the dsp inputs after the device's own, so no dsp knows where a host keeps one.
- `FaustPlugin` does the same for the inputs its source declared.
- `TracktionMagdaDevicePlugin` splits the fork's buffer once, off a live channel split cached in two atomics and refreshed wherever the fork asks the plugin about its shape — the runtime Faust device recompiles into a different one.
- `EngineMagdaDevice` hands `DeviceBlock::sidechain` straight through: a port on both sides, with nothing in between deciding where in a buffer a key belongs.

## A source, not a track id

`SidechainConfig` grows three fields:

- **`tapPoint`**, reusing `ModTapPoint`. The compiler resolves it against `trackTriggerTap_` and `trackSidechainTap_`, which it already keeps apart — pre-FX is what the source played, post-fader is what it sends, and riding the source fader is the whole difference.
- **`gainDb`**, a `Gain` op (`OpRole::DeviceSidechainGain`) on the sidechain edge, emitted wherever a key is connected so moving the trim is a value and never a recompile. Pinned by a fingerprint test.
- **`listen`**, an `OpValue` flag like the delta solo: the device still runs, so its own metering and smoothing carry on, and what leaves the slot is the key it was handed.

Serialisation writes them only when they are not the defaults, and reads a legacy `canSidechain` as a mono port; an old project opens as post-fader, 0 dB, listen off, which is what it always sounded like. `RackInfo::sidechain` keeps `type` and `sourceTrackId` only — its serializer cannot carry the new fields.

## Reach

The slot's sidechain menu offers the tap point, a trim submenu and a listen toggle, through new `TrackManager` setters that share one walk with `setSidechainSource`. `DeviceDto` reports the declared port and the whole source over the remote API.

## Not in here

- No MCP **write** operation for sidechain. None exists today, and the issue says edits go through the existing sidechain commands.
- The TE leg still taps post-fader at unity. The new fields are native-engine behaviour, which is why their defaults are exactly what keeps null-diff parity.

## Testing

`make test` — 3750 passed, 13 skipped, 0 failed. `make test-juce` — all passed.

New coverage: the pre-FX tap and the trim's op identity in the compiler; the trim and listen in the executor (listen verified negatively — reverting the resolution makes it fail); a `sidechain-prefx` plan golden beside the existing `sidechain` one; the round trip of the new fields and of a pre-#2329 project; `SidechainPort::Kind` in the persisted enum pins; and, in the Faust suite, that four inputs without a declaration take no key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019sKH5X6HQ8WV82QriCbmLr
