### PR TITLE
Rework the clang-tidy config and clear the mechanical findings

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,182 +1,119 @@
 # Clang-Tidy Configuration for MAGDA DAW
 # Static analysis and linting rules for C++ audio development
 
-# Enable checks - comprehensive but practical set
+# Allow-list, not a deny-list. `Checks: *` meant every LLVM upgrade silently
+# added checks and the noise buried the findings: on LLVM 20 the top three by
+# volume were misc-include-cleaner (532), performance-enum-size (466) and
+# special-member-functions (311), none of them defects. Enable a family only
+# when its findings are worth acting on.
 Checks: >-
-  *,
-  -android-*,
-  -fuchsia-*,
-  -llvm-*,
-  -zircon-*,
-  -altera-*,
-  -llvmlibc-*,
-  -abseil-*,
-  -boost-*,
-  -google-build-using-namespace,
-  -google-readability-todo,
-  -hicpp-use-auto,
-  -hicpp-vararg,
-  -modernize-use-trailing-return-type,
-  -modernize-use-ranges,
-  -readability-container-contains,
-  -readability-redundant-casting,
-  -readability-make-member-function-const,
-  -readability-identifier-naming,
-  -readability-else-after-return,
-  -readability-implicit-bool-conversion,
-  -readability-named-parameter,
-  -readability-uppercase-literal-suffix,
-  -hicpp-uppercase-literal-suffix,
-  -cppcoreguidelines-avoid-magic-numbers,
-  -readability-magic-numbers,
-  -cert-err58-cpp,
-  -misc-non-private-member-variables-in-classes,
-  -cppcoreguidelines-non-private-member-variables-in-classes,
-  -modernize-avoid-c-arrays,
-  -cppcoreguidelines-avoid-c-arrays,
-  -hicpp-avoid-c-arrays,
-  -readability-isolate-declaration,
-  -cppcoreguidelines-pro-bounds-constant-array-index,
-  -cppcoreguidelines-pro-type-vararg,
-  -hicpp-vararg,
-  -modernize-use-nodiscard,
+  -*,
+  bugprone-*,
   -bugprone-easily-swappable-parameters,
   -bugprone-narrowing-conversions,
-  -cppcoreguidelines-narrowing-conversions,
-  -misc-const-correctness,
-  -readability-identifier-length,
-  -cppcoreguidelines-avoid-do-while,
-  -clang-analyzer-deadcode.*,
-  -clang-analyzer-core.*,
-  -clang-diagnostic-unreachable-code,
+  -bugprone-chained-comparison,
+  -bugprone-suspicious-include,
+  -bugprone-exception-escape,
+  -bugprone-unchecked-optional-access,
+  -bugprone-swapped-arguments,
+  -bugprone-branch-clone,
+  cert-oop54-cpp,
+  performance-*,
+  -performance-enum-size,
   -performance-avoid-endl,
-  -readability-braces-around-statements,
-  -hicpp-braces-around-statements,
-  -google-readability-braces-around-statements,
-  -readability-function-cognitive-complexity,
-  -performance-noexcept-move-constructor,
-  -cppcoreguidelines-noexcept-move-operations,
-  -hicpp-noexcept-move,
-  -bugprone-pointer-arithmetic-on-polymorphic-object,
-  -cert-ctr56-cpp
+  misc-use-anonymous-namespace,
+  modernize-use-emplace,
+  modernize-use-default-member-init,
+  modernize-loop-convert,
+  modernize-pass-by-value,
+  modernize-concat-nested-namespaces,
+  modernize-type-traits,
+  modernize-raw-string-literal,
+  cppcoreguidelines-prefer-member-initializer,
+  cppcoreguidelines-init-variables,
+  readability-qualified-auto,
+  readability-redundant-string-init,
+  readability-redundant-member-init,
+  readability-convert-member-functions-to-static,
+  readability-use-std-min-max,
+  readability-use-anyofallof,
+  readability-simplify-boolean-expr,
+  readability-avoid-nested-conditional-operator,
+  readability-inconsistent-declaration-parameter-name
 
-# The five above are off because they crash rather than report. On Homebrew
-# LLVM 20.1.4, `performance-noexcept-move-constructor` dies with SIGILL and
-# `bugprone-pointer-arithmetic-on-polymorphic-object` with SIGSEGV, on any file
-# in this project, silently and with no backtrace. Their aliases are listed
-# separately because clang-tidy treats an alias as its own check name, so
-# disabling the primary does not disable the alias.
+# The old config disabled performance-noexcept-move-constructor and
+# bugprone-pointer-arithmetic-on-polymorphic-object as crashers, reporting SIGILL
+# and SIGSEGV on any file here. Not reproducible on LLVM 20.1.4: a sweep of all
+# 885 magda/ TUs ran to completion with both enabled, no crash, zero findings.
 #
-# `Checks: *` above is what pulled them in, and a crashing check takes the
-# whole run down — so with these enabled `make lint` and `make lint-changed`
-# exited 132/139 on every file and reported nothing at all. Worth re-testing
-# when the toolchain moves.
+# Eight checks are off because they were noise here, not because their findings
+# were inconvenient - 237 sites, with only branch-clone yielding any defects:
+#   suspicious-include (31)      every hit is `#include "magda_*.generated.cpp"`,
+#                                the Faust DSP pipeline, which is deliberate.
+#   cert-err33-c (35)            ignored std::fprintf(stderr, ...) returns.
+#   exception-escape (33)        callback lambdas, as the note below already said.
+#   unchecked-optional-access    guarded by ok()/failed() predicates it cannot see
+#     (10)                       through, and it drops the fact across any
+#                                non-const member call.
+#   swapped-arguments (10)       all drawVerticalLine(int, float, float), which is
+#                                JUCE's actual signature.
+#   branch-clone (55)            5 were real and are fixed; the other 50 are switch
+#                                arms and condition chains whose cases are
+#                                distinct and whose bodies coincide. RenderPlan
+#                                returns 2 for Fader, Crossfade and Subtract, each
+#                                with its own reason - merging them would delete
+#                                the explanation.
+#   use-internal-linkage (58)    its fix does not link. It reads one translation
+#                                unit, so a definition whose declaring header that
+#                                .cpp does not itself include looks file-local;
+#                                marking createInternalPluginProcessor and the
+#                                compiled-device getMagda*Spec() functions static
+#                                left every caller in another TU undefined.
+#   suspicious-call-argument     parameter-name similarity only; the calls match
+#     (10)                       their declarations.
 #
-# bugprone-exception-escape stays enabled — it correctly found 20 real
-# noexcept/destructor/main sites (#2395) — but on LLVM 23 it also flags ~41
-# plain, non-noexcept UI/agent lambdas. The reported trace is a genuine false
-# positive at the diagnostic site itself: the throwing std::string/std::vector
-# copy happens while constructing the closure (a by-value capture), not inside
-# the lambda's non-noexcept call operator, and a lambda handed to a
-# std::function-typed callback setter (juce::Button::onClick,
-# PopupMenu::showMenuAsync, MessageManager::callAsync, ...) is under none of
-# this check's documented scope (noexcept functions, destructors, main) and is
-# free to throw. Don't chase these as a to-do list.
+# modernize-use-integer-sign-comparison is off: its 656 hits were all deliberate
+# `x < static_cast<int>(v.size())` casts, and its fixer deletes the cast text but
+# leaves the closing paren - 572 of 632 rewrites did not compile.
 #
-# That said, "free to throw" doesn't mean the throw is harmless: a handful of
-# these callAsync lambdas (magda/agents/coder_agent.cpp,
-# magda/agents/sound_design_agent.cpp x3) ran an apply step and then
-# unconditionally signalled a WaitableEvent the caller was blocked on. An
-# exception mid-apply skipped the signal (the caller then just timed out) and,
-# uncaught on the message thread, would have propagated into JUCE's dispatch
-# loop instead of failing only that one apply. Those four now catch and report
-# the error through the same `status`/signal path instead of skipping it.
+# bugprone-chained-comparison is off because Catch2's REQUIRE(a == b) expands to
+# `Decomposer() <= a == b`; it fired 311 times, every one of them in tests.
+#
+# bugprone-exception-escape stays enabled - it found 20 real
+# noexcept/destructor/main sites (#2395) and currently reports zero. If it ever
+# flags a plain callback lambda (juce::Button::onClick, callAsync, ...), that is
+# a false positive: the throwing capture-by-value copy happens while
+# constructing the closure, not inside the call operator, and such a lambda is
+# under none of the check's documented scope. Don't chase those.
 
-# Warnings as errors (can be adjusted based on team preference)
+# Warnings as errors - set once the bug-catching tier below is at zero.
 WarningsAsErrors: ''
 
-# Header filter - analyze headers in project
-HeaderFilterRegex: '(daw|agents|tests)/.*\.(h|hpp)$'
+# Header filter. Anchored on a leading slash: the old unanchored `tests` matched
+# third_party/JUCE/.../unit_tests/*.h, and it never covered magda/engine at all.
+# Tests are out of scope entirely - the checks here target shipping code.
+HeaderFilterRegex: '/magda/.*\.(h|hpp)$'
+ExcludeHeaderFilterRegex: '/third_party/'
 
-# Analysis options
-# AnalyzeTemporaryDtors: false  # Not supported in this version
-
-# Check options for fine-tuning specific rules
 CheckOptions:
-  # Naming conventions
-  - key: readability-identifier-naming.NamespaceCase
-    value: lower_case
-  - key: readability-identifier-naming.ClassCase
-    value: CamelCase
-  - key: readability-identifier-naming.StructCase
-    value: CamelCase
-  - key: readability-identifier-naming.FunctionCase
-    value: camelBack
-  - key: readability-identifier-naming.VariableCase
-    value: camelBack
-  - key: readability-identifier-naming.ParameterCase
-    value: camelBack
-  - key: readability-identifier-naming.MemberCase
-    value: camelBack
-  - key: readability-identifier-naming.MemberSuffix
-    value: '_'
-  - key: readability-identifier-naming.ConstantCase
-    value: UPPER_CASE
-  - key: readability-identifier-naming.EnumCase
-    value: CamelCase
-  - key: readability-identifier-naming.EnumConstantCase
-    value: CamelCase
-  - key: readability-identifier-naming.MacroDefinitionCase
-    value: UPPER_CASE
-
-  # Function length limits
-  - key: readability-function-size.LineThreshold
-    value: '80'
-  - key: readability-function-size.StatementThreshold
-    value: '50'
-  - key: readability-function-size.BranchThreshold
-    value: '10'
-  - key: readability-function-size.ParameterThreshold
-    value: '8'
-
-  # Complexity limits
-  - key: readability-function-cognitive-complexity.Threshold
-    value: '15'
-
-  # Include sorting
-  - key: llvm-include-order.Priority
-    value: '1'
-
-  # Performance
+  # 'true' flags every auto copy in a range-for, mutated or not: of six rewrites
+  # it produced, four did not compile - three loops assign to the element and one
+  # passes it to a non-const reference.
   - key: performance-for-range-copy.WarnOnAllAutoCopies
-    value: 'true'
+    value: 'false'
   - key: performance-unnecessary-value-param.AllowedTypes
     value: 'juce::String;juce::var;std::shared_ptr;std::unique_ptr'
-
-  # Modernization
   - key: modernize-loop-convert.MaxCopySize
     value: '16'
   - key: modernize-loop-convert.MinConfidence
     value: 'reasonable'
-  - key: modernize-use-auto.MinTypeNameLength
-    value: '5'
-
-  # Readability
-  - key: readability-braces-around-statements.ShortStatementLines
-    value: '1'
   - key: readability-simplify-boolean-expr.ChainedConditionalReturn
     value: 'true'
   - key: readability-simplify-boolean-expr.ChainedConditionalAssignment
     value: 'true'
-
-  # Bugprone
   - key: bugprone-argument-comment.StrictMode
     value: 'false'
   - key: bugprone-suspicious-string-compare.WarnOnImplicitComparison
     value: 'true'
-
-  # CERT rules
-  - key: cert-dcl16-c.NewSuffixes # gitleaks:allow
-    value: 'L;LL;LU;LLU'
   - key: cert-oop54-cpp.WarnOnlyIfThisHasSuspiciousField
     value: 'false'

--- a/Makefile
+++ b/Makefile
@@ -453,8 +453,8 @@ lint:
 		echo "              apt install clang-tidy   (Debian/Ubuntu)"; \
 		exit 1; \
 	fi
-	@echo "📋 Analyzing magda/daw sources..."
-	@find magda/daw -name "*.cpp" -type f -exec \
+	@echo "📋 Analyzing magda sources (tests are out of scope)..."
+	@find magda -name "*.cpp" -type f -exec \
 		$(CLANG_TIDY) \
 		{} \
 		--config-file=.clang-tidy \
@@ -508,7 +508,7 @@ lint-fix:
 	read REPLY; \
 	case "$$REPLY" in \
 		[Yy]*) \
-			find magda/daw -name "*.cpp" -type f -exec \
+			find magda -name "*.cpp" -type f -exec \
 				$(CLANG_TIDY) \
 				{} \
 				--config-file=.clang-tidy \

--- a/magda/agents/agent_runtime.cpp
+++ b/magda/agents/agent_runtime.cpp
@@ -50,7 +50,7 @@ AgentRuntime::AgentRuntime(Model& model, ToolExecutor& executor, ApprovalHook ap
       fastInferencePolicy_(fastInferencePolicy) {}
 
 RunResult AgentRuntime::run(const AgentDefinition& definition, AgentRunInput input,
-                            CancellationToken cancellation) {
+                            const CancellationToken& cancellation) {
     RunResult result;
     result.state = RunState::Running;
     result.finalRevision = input.projectRevision;

--- a/magda/agents/agent_runtime.hpp
+++ b/magda/agents/agent_runtime.hpp
@@ -211,7 +211,7 @@ class AgentRuntime {
                  Now now = Clock::now, FastInferencePolicy* fastInferencePolicy = nullptr);
 
     RunResult run(const AgentDefinition& definition, AgentRunInput input,
-                  CancellationToken cancellation = {});
+                  const CancellationToken& cancellation = {});
 
   private:
     Model& model_;

--- a/magda/agents/automation_executor.cpp
+++ b/magda/agents/automation_executor.cpp
@@ -377,7 +377,7 @@ bool AutomationExecutor::execute(const std::vector<AutoInstruction>& instruction
         }
 
         if (std::holds_alternative<AutoClearOp>(inst.payload)) {
-            auto& op = std::get<AutoClearOp>(inst.payload);
+            const auto& op = std::get<AutoClearOp>(inst.payload);
             auto laneId = resolveTarget(api_, op.target, err);
             if (laneId == INVALID_AUTOMATION_LANE_ID) {
                 error_ = std::move(err);
@@ -389,7 +389,7 @@ bool AutomationExecutor::execute(const std::vector<AutoInstruction>& instruction
         }
 
         if (std::holds_alternative<AutoFreeformOp>(inst.payload)) {
-            auto& op = std::get<AutoFreeformOp>(inst.payload);
+            const auto& op = std::get<AutoFreeformOp>(inst.payload);
             auto laneId = resolveTarget(api_, op.target, err);
             if (laneId == INVALID_AUTOMATION_LANE_ID) {
                 error_ = std::move(err);
@@ -404,7 +404,7 @@ bool AutomationExecutor::execute(const std::vector<AutoInstruction>& instruction
         }
 
         if (std::holds_alternative<AutoShapeOp>(inst.payload)) {
-            auto& op = std::get<AutoShapeOp>(inst.payload);
+            const auto& op = std::get<AutoShapeOp>(inst.payload);
             auto laneId = resolveTarget(api_, op.target, err);
             if (laneId == INVALID_AUTOMATION_LANE_ID) {
                 error_ = std::move(err);

--- a/magda/agents/automation_parser.cpp
+++ b/magda/agents/automation_parser.cpp
@@ -195,7 +195,7 @@ std::vector<AutoInstruction> AutomationParser::parse(const juce::String& text) {
             return {};
         }
 
-        auto shapeStr = tokens[1];
+        const auto& shapeStr = tokens[1];
 
         AutoClipAction clipAction;
         if (parseClipAction(shapeStr, clipAction)) {

--- a/magda/agents/chord_agent.cpp
+++ b/magda/agents/chord_agent.cpp
@@ -243,7 +243,7 @@ ChordAgent::Result ChordAgent::parseResponse(const juce::String& dsl) {
 }
 
 ChordAgent::Result ChordAgent::generate(const Input& input, TokenCallback onToken,
-                                        CancelCallback shouldCancel) const {
+                                        CancelCallback shouldCancel) {
     const auto cancelled = [&] { return shouldCancel && shouldCancel(); };
     if (cancelled())
         return {{}, {}, "Cancelled", true, true};

--- a/magda/agents/chord_agent.hpp
+++ b/magda/agents/chord_agent.hpp
@@ -59,8 +59,8 @@ class ChordAgent {
 
     /// Resolve the dedicated Chord agent role (with Config's Music fallback), send
     /// the request, stream when supported, and parse the structured result.
-    Result generate(const Input& input, TokenCallback onToken = {},
-                    CancelCallback shouldCancel = {}) const;
+    static Result generate(const Input& input, TokenCallback onToken = {},
+                           CancelCallback shouldCancel = {});
 };
 
 }  // namespace magda

--- a/magda/agents/command_model.cpp
+++ b/magda/agents/command_model.cpp
@@ -535,6 +535,7 @@ int subseq(const std::vector<std::string>& lower, const std::vector<std::string>
 
 std::string renameTargetFromTokens(const std::vector<std::string>& tokens) {
     std::vector<std::string> lower;
+    lower.reserve(tokens.size());
     for (const auto& t : tokens)
         lower.push_back(toLower(t));
     static const std::vector<std::vector<std::string>> phrases = {
@@ -901,6 +902,7 @@ std::string CommandModel::renderPrediction(const Prediction& p) {
             groupName = "Group";
         int anchor = ids.empty() ? 0 : ids[0];
         std::vector<std::string> idStrs;
+        idStrs.reserve(ids.size());
         for (int x : ids)
             idStrs.push_back(std::to_string(x));
         lines.push_back("track(id=" + std::to_string(anchor) + ").track.group(name=" +
@@ -1000,7 +1002,7 @@ std::string CommandModel::renderPrediction(const Prediction& p) {
         lines.push_back("groove.set(template=" + q(tmpl) +
                         ", strength=" + fmtG(valueOrFirstNumber(s, tokens)) + ")");
     } else if (intent == "groove_list") {
-        lines.push_back("groove.list()");
+        lines.emplace_back("groove.list()");
     } else {
         return "";  // unknown intent
     }

--- a/magda/agents/command_model_downloader.cpp
+++ b/magda/agents/command_model_downloader.cpp
@@ -174,7 +174,7 @@ class CommandModelDownloader::Worker : public juce::Thread {
         return true;
     }
 
-    void postProgress(Progress p) {
+    void postProgress(const Progress& p) {
         if (!onProgress_)
             return;
         auto cb = onProgress_;

--- a/magda/agents/compact_parser.cpp
+++ b/magda/agents/compact_parser.cpp
@@ -54,7 +54,7 @@ bool parseGridLine(const juce::String& line, std::vector<Instruction>& out,
 
         const double step = kBarBeats / static_cast<double>(cells.size());
         for (int i = 0; i < cells.size(); ++i) {
-            const auto cell = cells[i];
+            const auto& cell = cells[i];
             if (cell == ".")
                 continue;
             HitOp h;
@@ -206,7 +206,7 @@ std::vector<Instruction> CompactParser::parse(const juce::String& compact) {
                 kvStart = 2;
             }
             for (int i = kvStart; i < parts.size(); ++i) {
-                auto kv = parts[i];
+                const auto& kv = parts[i];
                 auto eqIdx = kv.indexOfChar('=');
                 if (eqIdx > 0)
                     payload.props.set(kv.substring(0, eqIdx), kv.substring(eqIdx + 1));

--- a/magda/agents/console_agent_orchestrator.cpp
+++ b/magda/agents/console_agent_orchestrator.cpp
@@ -149,8 +149,8 @@ ConsoleAgentOrchestrator::ConsoleAgentOrchestrator(Workflows workflows)
     : workflows_(std::move(workflows)) {}
 
 ConsoleRunOutput ConsoleAgentOrchestrator::run(const ConsoleRunRequest& request,
-                                               ConsoleRunObserver observer,
-                                               CancellationToken cancellation) {
+                                               const ConsoleRunObserver& observer,
+                                               const CancellationToken& cancellation) {
     const CancellationToken combined([this, cancellation] {
         return cancelled_.load() || cancellation.isCancellationRequested();
     });

--- a/magda/agents/console_agent_orchestrator.hpp
+++ b/magda/agents/console_agent_orchestrator.hpp
@@ -95,7 +95,7 @@ class ConsoleAgentOrchestrator {
     static std::string composePrompt(const ConsoleRunRequest& request);
 
   private:
-    ConsoleRunOutput runWorkflow(
+    static ConsoleRunOutput runWorkflow(
         const std::function<ConsoleRunOutput(const ConsoleRunRequest&, const ConsoleRunObserver&,
                                              const CancellationToken&)>& workflow,
         const ConsoleRunRequest& request, const ConsoleRunObserver& observer,

--- a/magda/agents/console_agent_orchestrator.hpp
+++ b/magda/agents/console_agent_orchestrator.hpp
@@ -86,8 +86,8 @@ class ConsoleAgentOrchestrator {
                              DrummerAgent& drummer);
     explicit ConsoleAgentOrchestrator(Workflows workflows);
 
-    ConsoleRunOutput run(const ConsoleRunRequest& request, ConsoleRunObserver observer = {},
-                         CancellationToken cancellation = {});
+    ConsoleRunOutput run(const ConsoleRunRequest& request, const ConsoleRunObserver& observer = {},
+                         const CancellationToken& cancellation = {});
 
     void cancel();
     void resetCancellation();

--- a/magda/agents/dsl_interpreter.cpp
+++ b/magda/agents/dsl_interpreter.cpp
@@ -2642,6 +2642,7 @@ bool Interpreter::executeSetVelocity(const Params& params) {
     const auto& noteSelIndices = sm.getNoteSelectionIndices();
 
     std::vector<std::pair<size_t, int>> noteVelocities;
+    noteVelocities.reserve(noteSelIndices.size());
     for (auto idx : noteSelIndices)
         noteVelocities.emplace_back(idx, velocity);
 
@@ -2700,6 +2701,7 @@ bool Interpreter::executeResizeNotes(const Params& params) {
     const auto& noteSelIndices = sm.getNoteSelectionIndices();
 
     std::vector<std::pair<size_t, double>> noteLengths;
+    noteLengths.reserve(noteSelIndices.size());
     for (auto idx : noteSelIndices)
         noteLengths.emplace_back(idx, length);
 

--- a/magda/agents/dsl_interpreter.hpp
+++ b/magda/agents/dsl_interpreter.hpp
@@ -4,6 +4,7 @@
 
 #include <map>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "../daw/core/ClipTypes.hpp"
@@ -49,8 +50,8 @@ struct Token {
     int col;
 
     Token() : type(TokenType::END_OF_INPUT), line(0), col(0) {}
-    Token(TokenType t, const std::string& v, int l = 0, int c = 0)
-        : type(t), value(v), line(l), col(c) {}
+    Token(TokenType t, std::string v, int l = 0, int c = 0)
+        : type(t), value(std::move(v)), line(l), col(c) {}
 
     bool is(TokenType t) const {
         return type == t;

--- a/magda/agents/faust_agent.cpp
+++ b/magda/agents/faust_agent.cpp
@@ -471,8 +471,8 @@ FaustAgent::Result FaustAgent::runConversational(const std::string& message,
         if (compileCheck(result.name, result.source, compileErr, verified)) {
             // Success — commit the clean turns (original prompt + working reply)
             // to the persistent conversation and chain off the good response.
-            conversation.messages.push_back({"user", originalPrompt});
-            conversation.messages.push_back({"assistant", response.text.trim()});
+            conversation.messages.emplace_back("user", originalPrompt);
+            conversation.messages.emplace_back("assistant", response.text.trim());
             conversation.lastResponseId = working.lastResponseId;
             result.mcpVerified = verified;
             logFaustAgentResult(result);

--- a/magda/agents/faust_agent.hpp
+++ b/magda/agents/faust_agent.hpp
@@ -54,13 +54,13 @@ class FaustAgent {
     }
 
   private:
-    Result parseJson(const juce::String& text);
+    static Result parseJson(const juce::String& text);
 
     // Compile through faust-mcp. A disabled server intentionally stages code
     // for manual editing; an enabled server that cannot start or verify fails
     // closed and never reaches the live apply path.
-    bool compileCheck(const std::string& name, const std::string& source, std::string& errorOut,
-                      bool& verified);
+    static bool compileCheck(const std::string& name, const std::string& source,
+                             std::string& errorOut, bool& verified);
 
     // Shared body for generate / generateStreaming. Runs the conversational
     // generate-and-auto-fix loop: on a compile failure the broken reply is

--- a/magda/agents/four_osc_agent.hpp
+++ b/magda/agents/four_osc_agent.hpp
@@ -93,7 +93,7 @@ class FourOscAgent {
     /** Parse a JSON string into a Preset. Returns empty Preset + sets
      *  outError on malformed input. Tolerant of LLM markdown fences
      *  ("```json ... ```") around the payload. */
-    Preset parseJson(const juce::String& text, std::string& outError);
+    static Preset parseJson(const juce::String& text, std::string& outError);
 
     std::atomic<bool> shouldStop_{false};
 };

--- a/magda/agents/gain_staging_agent.cpp
+++ b/magda/agents/gain_staging_agent.cpp
@@ -98,7 +98,7 @@ const char* GainStagingAgent::getSystemPrompt() {
 }
 
 juce::String GainStagingAgent::buildUserMessage(float targetPeakDb,
-                                                const std::vector<DeviceLevel>& devices) const {
+                                                const std::vector<DeviceLevel>& devices) {
     juce::Array<juce::var> arr;
     for (int i = 0; i < static_cast<int>(devices.size()); ++i) {
         const auto& d = devices[static_cast<size_t>(i)];
@@ -132,8 +132,7 @@ juce::String GainStagingAgent::buildUserMessage(float targetPeakDb,
 }
 
 void GainStagingAgent::parseDecisions(const juce::String& rawText,
-                                      const std::vector<DeviceLevel>& devices,
-                                      Result& result) const {
+                                      const std::vector<DeviceLevel>& devices, Result& result) {
     result.rawOutput = rawText.toStdString();
 
     const int deviceCount = static_cast<int>(devices.size());

--- a/magda/agents/gain_staging_agent.hpp
+++ b/magda/agents/gain_staging_agent.hpp
@@ -65,10 +65,10 @@ class GainStagingAgent {
     static const char* getSystemPrompt();
 
   private:
-    juce::String buildUserMessage(float targetPeakDb,
-                                  const std::vector<DeviceLevel>& devices) const;
-    void parseDecisions(const juce::String& rawText, const std::vector<DeviceLevel>& devices,
-                        Result& result) const;
+    static juce::String buildUserMessage(float targetPeakDb,
+                                         const std::vector<DeviceLevel>& devices);
+    static void parseDecisions(const juce::String& rawText, const std::vector<DeviceLevel>& devices,
+                               Result& result);
 };
 
 }  // namespace magda

--- a/magda/agents/instruction_executor.cpp
+++ b/magda/agents/instruction_executor.cpp
@@ -250,7 +250,7 @@ bool InstructionExecutor::execute(const std::vector<Instruction>& instructions) 
     }
 
     // Multi-clip selection → populate selectedClips_ so SET/DEL apply to all
-    auto& uiClips = sm.getSelectedClips();
+    const auto& uiClips = sm.getSelectedClips();
     if (!uiClips.empty()) {
         selectedClips_.insert(uiClips.begin(), uiClips.end());
         // Derive track from first clip if no track selected

--- a/magda/agents/llama_model_manager.cpp
+++ b/magda/agents/llama_model_manager.cpp
@@ -155,7 +155,7 @@ std::string LlamaModelManager::applyTemplate(const std::string& systemPrompt,
 }
 
 LlamaModelManager::InferenceResult LlamaModelManager::infer(const InferenceRequest& req,
-                                                            TokenCallback onToken) {
+                                                            const TokenCallback& onToken) {
     std::scoped_lock lock(mutex_);
     InferenceResult result;
 

--- a/magda/agents/llama_model_manager.cpp
+++ b/magda/agents/llama_model_manager.cpp
@@ -2,6 +2,8 @@
 // Apple's libc++ does not ship the std::atomic<std::shared_ptr> replacement, so
 // they remain the only portable option. Silence MSVC's STL4029 deprecation
 // warning; must be defined before any standard header is included.
+// NOLINTNEXTLINE(bugprone-reserved-identifier) - MSVC defines this name; it has to be spelled
+// exactly
 #define _SILENCE_CXX20_OLD_SHARED_PTR_ATOMIC_SUPPORT_DEPRECATION_WARNING
 
 #include "llama_model_manager.hpp"

--- a/magda/agents/llama_model_manager.hpp
+++ b/magda/agents/llama_model_manager.hpp
@@ -50,7 +50,7 @@ class LlamaModelManager {
 
     using TokenCallback = std::function<bool(const std::string& token)>;
 
-    InferenceResult infer(const InferenceRequest& req, TokenCallback onToken = nullptr);
+    InferenceResult infer(const InferenceRequest& req, const TokenCallback& onToken = nullptr);
 
   private:
 #ifdef MAGDA_ENABLE_TEST_HOOKS

--- a/magda/agents/mcp/MCPClient.cpp
+++ b/magda/agents/mcp/MCPClient.cpp
@@ -11,12 +11,13 @@
     #include <unistd.h>
 
     #include <cerrno>
+    #include <utility>
 #endif
 
 namespace magda {
 
-MCPClient::MCPClient(const juce::String& command, const juce::StringArray& args)
-    : command_(command), args_(args) {}
+MCPClient::MCPClient(juce::String command, juce::StringArray args)
+    : command_(std::move(command)), args_(std::move(args)) {}
 
 MCPClient::~MCPClient() {
     stop();
@@ -70,6 +71,7 @@ bool MCPClient::start() {
             argStrings.push_back(a.toStdString());
 
         std::vector<char*> argv;
+        argv.reserve(argStrings.size());
         for (auto& s : argStrings)
             argv.push_back(s.data());
         argv.push_back(nullptr);

--- a/magda/agents/mcp/MCPClient.hpp
+++ b/magda/agents/mcp/MCPClient.hpp
@@ -8,7 +8,7 @@ namespace magda {
 
 class MCPClient {
   public:
-    MCPClient(const juce::String& command, const juce::StringArray& args);
+    MCPClient(juce::String command, juce::StringArray args);
     ~MCPClient();
 
     MCPClient(const MCPClient&) = delete;

--- a/magda/agents/mixing_agent.cpp
+++ b/magda/agents/mixing_agent.cpp
@@ -76,7 +76,7 @@ juce::String MixAnalysisAgent::buildUserMessage(const Input& input) {
             const auto& labels = MixAnalysisData::Track::tonalBandLabels;
             for (size_t i = 0; i < t.tonalDb.size(); ++i)
                 r << " "
-                  << (i < labels.size() ? juce::String(labels[i].data())
+                  << (i < labels.size() ? juce::String(labels[i].data(), labels[i].size())
                                         : juce::String(static_cast<int>(i)))
                   << "=" << juce::String(t.tonalDb[i], 1);
             r << " | centroid=" << juce::String(juce::roundToInt(t.spectralCentroidHz)) << "Hz"

--- a/magda/agents/mixing_agent.hpp
+++ b/magda/agents/mixing_agent.hpp
@@ -54,7 +54,7 @@ class MixAnalysisAgent {
 
     /** Streaming variant of generate(): calls onToken for each token as it
      *  arrives, otherwise identical. Run off the message thread. */
-    Result generateStreaming(const Input& input, TokenCallback onToken);
+    static Result generateStreaming(const Input& input, TokenCallback onToken);
 
     /** Exposed so a harness can measure payload size without an LLM call. */
     static juce::String buildUserMessage(const Input& input);

--- a/magda/agents/model_downloader.cpp
+++ b/magda/agents/model_downloader.cpp
@@ -44,7 +44,7 @@ void ModelDownloader::startDownload(const juce::String& url, const juce::File& t
             .withResponseHeaders(&responseHeaders));
     if (probeStream) {
         // Content-Range: bytes 0-0/<total>
-        auto contentRange = responseHeaders["Content-Range"];
+        const auto& contentRange = responseHeaders["Content-Range"];
         if (contentRange.contains("/")) {
             auto totalStr = contentRange.fromLastOccurrenceOf("/", false, false).trim();
             auto parsed = totalStr.getLargeIntValue();

--- a/magda/agents/music_agent.hpp
+++ b/magda/agents/music_agent.hpp
@@ -45,7 +45,7 @@ class MusicAgent {
     static const char* getDSLSystemPrompt();
 
     /** Parse DSL note operations into IR instructions. */
-    std::vector<Instruction> parseDSL(const juce::String& text, std::string& outDescription);
+    static std::vector<Instruction> parseDSL(const juce::String& text, std::string& outDescription);
 
     CompactParser parser_;
     std::atomic<bool> shouldStop_{false};

--- a/magda/agents/poly_step_sequencer_agent.hpp
+++ b/magda/agents/poly_step_sequencer_agent.hpp
@@ -78,7 +78,7 @@ class PolyStepSequencerAgent {
     /** Parse a JSON string into a Preset. Returns empty Preset + sets
      *  outError on malformed input. Tolerant of LLM markdown fences
      *  ("```json ... ```") around the payload. */
-    Preset parseJson(const juce::String& text, std::string& outError);
+    static Preset parseJson(const juce::String& text, std::string& outError);
 
     std::atomic<bool> shouldStop_{false};
 };

--- a/magda/agents/step_sequencer_agent.hpp
+++ b/magda/agents/step_sequencer_agent.hpp
@@ -73,7 +73,7 @@ class StepSequencerAgent {
     /** Parse a JSON string into a Preset. Returns empty Preset + sets
      *  outError on malformed input. Tolerant of LLM markdown fences
      *  ("```json ... ```") around the payload. */
-    Preset parseJson(const juce::String& text, std::string& outError);
+    static Preset parseJson(const juce::String& text, std::string& outError);
 
     std::atomic<bool> shouldStop_{false};
 };

--- a/magda/daw/api/device_api_live.cpp
+++ b/magda/daw/api/device_api_live.cpp
@@ -329,11 +329,11 @@ bool DeviceApiLive::setDeviceParameterConfig(const ChainNodePath& devicePath,
             if (override_.unit)
                 entry.unit = *override_.unit;
             if (override_.scale)
-                entry.scale = *override_.scale;
+                entry.scale = override_.scale;
             if (override_.minValue)
-                entry.rangeMin = *override_.minValue;
+                entry.rangeMin = override_.minValue;
             if (override_.maxValue)
-                entry.rangeMax = *override_.maxValue;
+                entry.rangeMax = override_.maxValue;
             // A new display range moves the anchor the way a fresh AI-Detect
             // would: to its midpoint.
             if (override_.minValue || override_.maxValue) {

--- a/magda/daw/api/osc_feedback_live.hpp
+++ b/magda/daw/api/osc_feedback_live.hpp
@@ -260,7 +260,7 @@ class OscFeedbackProjector : private ConfigListener, private BindingRegistryList
 
     /// Feed one surface's copy of a bound address, given the position its target
     /// currently implies.
-    void publishBinding(Surface& surface, const juce::String& address, float position);
+    static void publishBinding(Surface& surface, const juce::String& address, float position);
 
     /// The entry for `address` on `surface`, created if this is the first time
     /// it has been seen. Linear: bindings number in the tens, and an OSC address

--- a/magda/daw/api/remote_api.cpp
+++ b/magda/daw/api/remote_api.cpp
@@ -102,7 +102,7 @@ juce::var emptyObjectSchema() {
 }
 
 juce::var arraySchema(const juce::var& itemSchema) {
-    auto schema = new juce::DynamicObject();
+    auto* schema = new juce::DynamicObject();
     schema->setProperty("type", "array");
     schema->setProperty("items", itemSchema);
     return schema;
@@ -890,12 +890,12 @@ juce::String toString(ErrorCode code) {
 }
 
 juce::var toJson(const Error& error) {
-    auto object = new juce::DynamicObject();
+    auto* object = new juce::DynamicObject();
     object->setProperty("code", toString(error.code));
     object->setProperty("message", error.message);
     juce::Array<juce::var> issues;
     for (const auto& issue : error.issues) {
-        auto issueObject = new juce::DynamicObject();
+        auto* issueObject = new juce::DynamicObject();
         issueObject->setProperty("path", issue.path);
         issueObject->setProperty("code", issue.code);
         issueObject->setProperty("message", issue.message);
@@ -906,7 +906,7 @@ juce::var toJson(const Error& error) {
 }
 
 juce::var successEnvelope(const juce::var& result) {
-    auto object = new juce::DynamicObject();
+    auto* object = new juce::DynamicObject();
     object->setProperty("ok", true);
     object->setProperty("apiVersion", juce::String(API_VERSION.data(), API_VERSION.size()));
     object->setProperty("result", result);
@@ -914,7 +914,7 @@ juce::var successEnvelope(const juce::var& result) {
 }
 
 juce::var errorEnvelope(const Error& error) {
-    auto object = new juce::DynamicObject();
+    auto* object = new juce::DynamicObject();
     object->setProperty("ok", false);
     object->setProperty("apiVersion", juce::String(API_VERSION.data(), API_VERSION.size()));
     object->setProperty("error", toJson(error));
@@ -969,7 +969,7 @@ std::optional<Error> validateOperationInput(const OperationDescriptor& operation
 }
 
 juce::var toJson(const MidiNoteDto& dto) {
-    auto object = new juce::DynamicObject();
+    auto* object = new juce::DynamicObject();
     object->setProperty("note", dto.note);
     object->setProperty("velocity", dto.velocity);
     object->setProperty("startBeat", dto.startBeat);
@@ -978,7 +978,7 @@ juce::var toJson(const MidiNoteDto& dto) {
 }
 
 juce::var toJson(const ProjectDto& dto) {
-    auto object = new juce::DynamicObject();
+    auto* object = new juce::DynamicObject();
     object->setProperty("name", dto.name);
     object->setProperty("tempo", dto.tempo);
     object->setProperty("timeSignatureNumerator", dto.timeSignatureNumerator);
@@ -994,7 +994,7 @@ juce::var toJson(const ProjectDto& dto) {
 }
 
 juce::var toJson(const TrackDto& dto) {
-    auto object = new juce::DynamicObject();
+    auto* object = new juce::DynamicObject();
     object->setProperty("id", dto.id);
     object->setProperty("type", dto.type);
     object->setProperty("name", dto.name);
@@ -1015,7 +1015,7 @@ juce::var toJson(const TrackDto& dto) {
 }
 
 juce::var toJson(const ClipDto& dto) {
-    auto object = new juce::DynamicObject();
+    auto* object = new juce::DynamicObject();
     object->setProperty("id", dto.id);
     object->setProperty("trackId", dto.trackId);
     object->setProperty("type", dto.type);
@@ -1037,7 +1037,7 @@ juce::var toJson(const ClipDto& dto) {
 }
 
 juce::var toJson(const DeviceDto& dto) {
-    auto object = new juce::DynamicObject();
+    auto* object = new juce::DynamicObject();
     object->setProperty("id", dto.id);
     object->setProperty("trackId", dto.trackId);
     object->setProperty("rackId", nullableId(dto.rackId));
@@ -1053,7 +1053,7 @@ juce::var toJson(const DeviceDto& dto) {
 }
 
 juce::var toJson(const ChainDto& dto) {
-    auto object = new juce::DynamicObject();
+    auto* object = new juce::DynamicObject();
     object->setProperty("id", dto.id);
     object->setProperty("rackId", dto.rackId);
     object->setProperty("name", dto.name);
@@ -1069,7 +1069,7 @@ juce::var toJson(const ChainDto& dto) {
 }
 
 juce::var toJson(const RackDto& dto) {
-    auto object = new juce::DynamicObject();
+    auto* object = new juce::DynamicObject();
     object->setProperty("id", dto.id);
     object->setProperty("trackId", dto.trackId);
     object->setProperty("parentRackId", nullableId(dto.parentRackId));
@@ -1083,7 +1083,7 @@ juce::var toJson(const RackDto& dto) {
 }
 
 juce::var toJson(const DeviceGraphDto& dto) {
-    auto object = new juce::DynamicObject();
+    auto* object = new juce::DynamicObject();
     juce::Array<juce::var> devices;
     juce::Array<juce::var> racks;
     juce::Array<juce::var> chains;
@@ -1100,7 +1100,7 @@ juce::var toJson(const DeviceGraphDto& dto) {
 }
 
 juce::var toJson(const DeviceCatalogEntryDto& dto) {
-    auto object = new juce::DynamicObject();
+    auto* object = new juce::DynamicObject();
     object->setProperty("catalogId", dto.catalogId);
     object->setProperty("name", dto.name);
     object->setProperty("manufacturer", dto.manufacturer);
@@ -1113,7 +1113,7 @@ juce::var toJson(const DeviceCatalogEntryDto& dto) {
 }
 
 juce::var toJson(const DeviceParameterDto& dto) {
-    auto object = new juce::DynamicObject();
+    auto* object = new juce::DynamicObject();
     object->setProperty("index", dto.index);
     object->setProperty("stableId", dto.stableId);
     object->setProperty("name", dto.name);
@@ -1135,7 +1135,7 @@ juce::var toJson(const DeviceParameterDto& dto) {
 }
 
 juce::var toJson(const SelectionDto& dto) {
-    auto object = new juce::DynamicObject();
+    auto* object = new juce::DynamicObject();
     object->setProperty("trackId", nullableId(dto.trackId));
     object->setProperty("clipId", nullableId(dto.clipId));
     object->setProperty("clipIds", integerArray(dto.clipIds));
@@ -1147,7 +1147,7 @@ juce::var toJson(const SelectionDto& dto) {
 }
 
 juce::var toJson(const TransportDto& dto) {
-    auto object = new juce::DynamicObject();
+    auto* object = new juce::DynamicObject();
     object->setProperty("playing", dto.playing);
     object->setProperty("recording", dto.recording);
     object->setProperty("loopEnabled", dto.loopEnabled);
@@ -1156,7 +1156,7 @@ juce::var toJson(const TransportDto& dto) {
 }
 
 juce::var toJson(const SessionSlotDto& dto) {
-    auto object = new juce::DynamicObject();
+    auto* object = new juce::DynamicObject();
     object->setProperty("trackId", dto.trackId);
     object->setProperty("sceneIndex", dto.sceneIndex);
     object->setProperty("clipId", dto.clipId);
@@ -1165,7 +1165,7 @@ juce::var toJson(const SessionSlotDto& dto) {
 }
 
 juce::var toJson(const SessionDto& dto) {
-    auto object = new juce::DynamicObject();
+    auto* object = new juce::DynamicObject();
     juce::Array<juce::var> slots;
     for (const auto& slot : dto.slots)
         slots.add(toJson(slot));
@@ -1174,7 +1174,7 @@ juce::var toJson(const SessionDto& dto) {
 }
 
 juce::var toJson(const AutomationPointDto& dto) {
-    auto object = new juce::DynamicObject();
+    auto* object = new juce::DynamicObject();
     object->setProperty("id", dto.id);
     object->setProperty("beatPosition", dto.beatPosition);
     object->setProperty("value", dto.value);
@@ -1183,7 +1183,7 @@ juce::var toJson(const AutomationPointDto& dto) {
 }
 
 juce::var toJson(const DevicePathDto& dto) {
-    auto object = new juce::DynamicObject();
+    auto* object = new juce::DynamicObject();
     object->setProperty("trackId", dto.trackId);
     object->setProperty("section", dto.section);
     object->setProperty("trackLevel", dto.trackLevel);
@@ -1201,7 +1201,7 @@ juce::var toJson(const DevicePathDto& dto) {
 }
 
 juce::var toJson(const AutomationTargetDto& dto) {
-    auto object = new juce::DynamicObject();
+    auto* object = new juce::DynamicObject();
     object->setProperty("kind", dto.kind);
     object->setProperty("devicePath",
                         dto.devicePath.has_value() ? toJson(*dto.devicePath) : juce::var());
@@ -1213,7 +1213,7 @@ juce::var toJson(const AutomationTargetDto& dto) {
 }
 
 juce::var toJson(const AutomationLaneDto& dto) {
-    auto object = new juce::DynamicObject();
+    auto* object = new juce::DynamicObject();
     object->setProperty("id", dto.id);
     object->setProperty("type", dto.type);
     object->setProperty("name", dto.name);
@@ -2215,11 +2215,11 @@ const OperationDescriptor* OperationRegistry::find(const juce::String& name) con
 }
 
 juce::var OperationRegistry::describe() const {
-    auto result = new juce::DynamicObject();
+    auto* result = new juce::DynamicObject();
     result->setProperty("apiVersion", juce::String(API_VERSION.data(), API_VERSION.size()));
     juce::Array<juce::var> operations;
     for (const auto& operation : operations_) {
-        auto object = new juce::DynamicObject();
+        auto* object = new juce::DynamicObject();
         object->setProperty("name", operation.name);
         object->setProperty("summary", operation.summary);
         object->setProperty("access", operation.access == OperationAccess::Read ? "read" : "write");

--- a/magda/daw/api/remote_api.cpp
+++ b/magda/daw/api/remote_api.cpp
@@ -807,7 +807,7 @@ int readInt(const juce::var& object, const char* property) {
 
 template <typename Id>
 std::optional<Id> readNullableId(const juce::var& object, const char* property) {
-    const auto value = object[property];
+    const auto& value = object[property];
     if (value.isVoid())
         return std::nullopt;
     return decodeBoundedInt<Id>(value);
@@ -1464,9 +1464,9 @@ std::optional<AutomationLaneDto> automationLaneFromJson(const juce::var& json, E
     dto.id = readInt(json, "id");
     dto.type = json["type"].toString();
     dto.name = json["name"].toString();
-    const auto target = json["target"];
+    const auto& target = json["target"];
     dto.target.kind = target["kind"].toString();
-    if (const auto path = target["devicePath"]; path.isObject())
+    if (const auto& path = target["devicePath"]; path.isObject())
         dto.target.devicePath = devicePathFromJson(path);
     dto.target.parameterIndex = readInt(target, "parameterIndex");
     dto.target.modId = readInt(target, "modId");

--- a/magda/daw/api/remote_api.cpp
+++ b/magda/daw/api/remote_api.cpp
@@ -908,7 +908,7 @@ juce::var toJson(const Error& error) {
 juce::var successEnvelope(const juce::var& result) {
     auto object = new juce::DynamicObject();
     object->setProperty("ok", true);
-    object->setProperty("apiVersion", juce::String(API_VERSION.data()));
+    object->setProperty("apiVersion", juce::String(API_VERSION.data(), API_VERSION.size()));
     object->setProperty("result", result);
     return object;
 }
@@ -916,7 +916,7 @@ juce::var successEnvelope(const juce::var& result) {
 juce::var errorEnvelope(const Error& error) {
     auto object = new juce::DynamicObject();
     object->setProperty("ok", false);
-    object->setProperty("apiVersion", juce::String(API_VERSION.data()));
+    object->setProperty("apiVersion", juce::String(API_VERSION.data(), API_VERSION.size()));
     object->setProperty("error", toJson(error));
     return object;
 }
@@ -2216,7 +2216,7 @@ const OperationDescriptor* OperationRegistry::find(const juce::String& name) con
 
 juce::var OperationRegistry::describe() const {
     auto result = new juce::DynamicObject();
-    result->setProperty("apiVersion", juce::String(API_VERSION.data()));
+    result->setProperty("apiVersion", juce::String(API_VERSION.data(), API_VERSION.size()));
     juce::Array<juce::var> operations;
     for (const auto& operation : operations_) {
         auto object = new juce::DynamicObject();

--- a/magda/daw/api/remote_api_host.cpp
+++ b/magda/daw/api/remote_api_host.cpp
@@ -536,7 +536,7 @@ int RemoteApiHost::mcpPort() const {
     return mcpServer_ != nullptr ? mcpServer_->boundPort() : 0;
 }
 
-juce::File RemoteApiHost::tokenFile() const {
+juce::File RemoteApiHost::tokenFile() {
     return paths::dataDir().getChildFile(juce::String(kTokenFilePrefix) +
                                          juce::String(currentProcessId()) + kTokenFileSuffix);
 }

--- a/magda/daw/api/remote_api_host.hpp
+++ b/magda/daw/api/remote_api_host.hpp
@@ -139,7 +139,7 @@ class RemoteApiHost {
     int mcpPort() const;
 
     /// Where the token was published, whether or not it currently exists.
-    juce::File tokenFile() const;
+    static juce::File tokenFile();
 
     /// The dispatcher, shared by both transports so revisions, undo grouping,
     /// and idempotency each exist once per project, not twice.

--- a/magda/daw/api/remote_handlers.cpp
+++ b/magda/daw/api/remote_handlers.cpp
@@ -174,7 +174,7 @@ std::optional<AutomationTarget> toAutomationTarget(const juce::var& json) {
     // Edit-scoped kinds (tempo) carry no path — the schema permits null there.
     // For everything else the path must resolve, or the target would name a
     // device that does not exist and the lane would be created against nothing.
-    if (const auto path = json["devicePath"]; path.isObject()) {
+    if (const auto& path = json["devicePath"]; path.isObject()) {
         const auto resolved = toChainNodePath(devicePathFromJson(path));
         if (!resolved)
             return std::nullopt;
@@ -503,7 +503,7 @@ HandlerResult devicesAdd(MagdaApi& api, const juce::var& input, const RequestCon
         return HandlerResult::fail(ErrorCode::NotFound, "no catalogue entry " + catalogId);
 
     ChainNodePath parent;
-    if (const auto parentPath = input["parentPath"]; parentPath.isObject()) {
+    if (const auto& parentPath = input["parentPath"]; parentPath.isObject()) {
         const auto resolved = toChainNodePath(devicePathFromJson(parentPath));
         if (!resolved)
             return HandlerResult::fail(ErrorCode::ValidationFailed, "parentPath does not resolve");
@@ -1294,7 +1294,7 @@ HandlerResult tracksMove(MagdaApi& api, const juce::var& input, const RequestCon
 HandlerResult groovesList(MagdaApi& api, const juce::var&, const RequestContext&) {
     std::vector<juce::var> items;
     for (const auto& name : api.grooves().getTemplateNames())
-        items.push_back(name);
+        items.emplace_back(name);
     return HandlerResult::ok(toJsonArray(items));
 }
 
@@ -1377,7 +1377,7 @@ std::vector<juce::uint8> readByteArray(const juce::var& value) {
 HandlerResult midiListOutputPorts(MagdaApi& api, const juce::var&, const RequestContext&) {
     std::vector<juce::var> items;
     for (const auto& name : api.midi().getOutputPortNames())
-        items.push_back(name);
+        items.emplace_back(name);
     return HandlerResult::ok(toJsonArray(items));
 }
 

--- a/magda/daw/api/remote_mcp.cpp
+++ b/magda/daw/api/remote_mcp.cpp
@@ -494,7 +494,7 @@ bool McpEndpoint::ListenFilter::wantsAnything() const {
 
 McpEndpoint::ListenFilter McpEndpoint::parseListenFilter(const juce::var& params) const {
     ListenFilter filter;
-    const auto notifications = params["notifications"];
+    const auto& notifications = params["notifications"];
     if (notifications.getDynamicObject() == nullptr)
         return filter;
 
@@ -738,7 +738,7 @@ void McpEndpoint::handle(const Call& call, Completion onComplete) {
         McpReply::fail(MCP_METHOD_NOT_FOUND, "Unknown method: " + call.method, modern ? 404 : 200));
 }
 
-void McpEndpoint::callTool(const Call& call, Completion onComplete) {
+void McpEndpoint::callTool(const Call& call, const Completion& onComplete) {
     const auto nameValue = call.params["name"];
     if (!nameValue.isString() || nameValue.toString().isEmpty()) {
         onComplete(McpReply::fail(MCP_INVALID_PARAMS, "tools/call requires a string params.name"));
@@ -776,7 +776,8 @@ void McpEndpoint::callTool(const Call& call, Completion onComplete) {
     const auto wrapResult = hasArrayOutput(*operation);
 
     service_.dispatch(
-        name, arguments, *context, [onComplete, modern, info, wrapResult](Response response) {
+        name, arguments, *context,
+        [onComplete, modern, info, wrapResult](const Response& response) {
             auto result = makeObject();
             if (modern)
                 setProperty(result, "resultType", "complete");
@@ -826,7 +827,7 @@ void McpEndpoint::callTool(const Call& call, Completion onComplete) {
         });
 }
 
-void McpEndpoint::readResource(const Call& call, Completion onComplete) {
+void McpEndpoint::readResource(const Call& call, const Completion& onComplete) {
     const auto uriValue = call.params["uri"];
     if (!uriValue.isString() || uriValue.toString().isEmpty()) {
         onComplete(
@@ -855,7 +856,7 @@ void McpEndpoint::readResource(const Call& call, Completion onComplete) {
 
     service_.dispatch(
         resolved->operation, resolved->input, *context,
-        [onComplete, uri, modern, info](Response response) {
+        [onComplete, uri, modern, info](const Response& response) {
             if (!response.ok) {
                 // A read has no `isError` channel, so a failure is
                 // a JSON-RPC error whatever caused it. The MAGDA
@@ -905,7 +906,7 @@ std::optional<RequestContext> McpEndpoint::requestContext(const Call& call, McpE
     if (meta.getDynamicObject() == nullptr)
         return context;
 
-    if (const auto expected = meta[MAGDA_META_EXPECTED_REVISION]; !expected.isVoid()) {
+    if (const auto& expected = meta[MAGDA_META_EXPECTED_REVISION]; !expected.isVoid()) {
         const auto revision = jsonInteger(expected, 0, std::numeric_limits<juce::int64>::max());
         if (!revision) {
             error = McpError{MCP_INVALID_PARAMS,
@@ -931,7 +932,7 @@ std::optional<RequestContext> McpEndpoint::requestContext(const Call& call, McpE
     // So a client that wants retry safety supplies its own key and is
     // responsible for its uniqueness (a UUID). The `mcp:` prefix keeps this
     // namespace clear of the WebSocket's in the shared cache.
-    if (const auto requestId = meta[MAGDA_META_REQUEST_ID]; !requestId.isVoid()) {
+    if (const auto& requestId = meta[MAGDA_META_REQUEST_ID]; !requestId.isVoid()) {
         if (!requestId.isString() || requestId.toString().isEmpty()) {
             error = McpError{MCP_INVALID_PARAMS,
                              juce::String(MAGDA_META_REQUEST_ID) + " must be a non-empty string",

--- a/magda/daw/api/remote_mcp.cpp
+++ b/magda/daw/api/remote_mcp.cpp
@@ -546,8 +546,7 @@ std::vector<juce::String> McpEndpoint::urisAffectedBy(Topic topic,
     return uris;
 }
 
-juce::var McpEndpoint::acknowledgment(const ListenFilter& filter,
-                                      const juce::var& subscriptionId) const {
+juce::var McpEndpoint::acknowledgment(const ListenFilter& filter, const juce::var& subscriptionId) {
     juce::Array<juce::var> uris;
     for (const auto& uri : filter.resourceSubscriptions)
         uris.add(uri);

--- a/magda/daw/api/remote_mcp.hpp
+++ b/magda/daw/api/remote_mcp.hpp
@@ -362,7 +362,7 @@ class McpEndpoint {
     std::vector<Topic> topicsFor(const ListenFilter& filter) const;
 
     /// `notifications/subscriptions/acknowledged`, carrying the honoured filter.
-    juce::var acknowledgment(const ListenFilter& filter, const juce::var& subscriptionId) const;
+    static juce::var acknowledgment(const ListenFilter& filter, const juce::var& subscriptionId);
 
     /// `notifications/resources/updated` for one URI. `subscriptionId` is void
     /// in the legacy era, which has no such correlation.

--- a/magda/daw/api/remote_mcp.hpp
+++ b/magda/daw/api/remote_mcp.hpp
@@ -380,8 +380,8 @@ class McpEndpoint {
     }
 
   private:
-    void callTool(const Call& call, Completion onComplete);
-    void readResource(const Call& call, Completion onComplete);
+    void callTool(const Call& call, const Completion& onComplete);
+    void readResource(const Call& call, const Completion& onComplete);
 
     /// Build the dispatcher context from `_meta`. Nullopt when a field is
     /// present but unusable, which is a client error rather than a default to

--- a/magda/daw/api/remote_mcp_server.cpp
+++ b/magda/daw/api/remote_mcp_server.cpp
@@ -765,7 +765,7 @@ struct RemoteMcpServer::Impl {
         response.set_header("X-Accel-Buffering", "no");
 
         const auto keepAlive = std::chrono::milliseconds(options.keepAliveIntervalMs);
-        auto self = this;
+        auto* self = this;
 
         response.set_chunked_content_provider(
             "text/event-stream",

--- a/magda/daw/api/remote_mcp_server.cpp
+++ b/magda/daw/api/remote_mcp_server.cpp
@@ -713,7 +713,7 @@ struct RemoteMcpServer::Impl {
         setProperty(params, "snapshot", false);
 
         subscriptions->handle(stream->subscriber, "subscriptions.subscribe", params,
-                              [](Response) {});
+                              [](const Response&) {});
     }
 
     /// Replace what a stream watches. The legacy era needs this because
@@ -726,7 +726,7 @@ struct RemoteMcpServer::Impl {
         // topic, so this converges on the new set whether the change added or
         // removed a resource — no diff to compute and none to get wrong.
         subscriptions->handle(stream->subscriber, "subscriptions.unsubscribe", makeObject(),
-                              [](Response) {});
+                              [](const Response&) {});
         subscribeStream(stream);
     }
 
@@ -826,7 +826,7 @@ struct RemoteMcpServer::Impl {
      * Refusing would break every conforming host that simply does not send it.
      */
     static juce::String modernClientName(const juce::var& params) {
-        const auto meta = params["_meta"];
+        const auto& meta = params["_meta"];
         if (meta.getDynamicObject() == nullptr)
             return normaliseClientName({});
         return normaliseClientName(meta[MCP_META_CLIENT_INFO]["name"].toString());
@@ -843,7 +843,7 @@ struct RemoteMcpServer::Impl {
      */
     std::optional<McpError> resolveEra(const httplib::Request& request, const juce::String& method,
                                        const juce::var& params, Resolution& resolution) {
-        const auto meta = params["_meta"];
+        const auto& meta = params["_meta"];
         const auto declared = meta.getDynamicObject() != nullptr
                                   ? meta[MCP_META_PROTOCOL_VERSION].toString()
                                   : juce::String();
@@ -971,7 +971,7 @@ struct RemoteMcpServer::Impl {
     /// The `_meta` fields a modern request must carry. `clientInfo` is optional
     /// and, being self-reported, is never read for anything but logging.
     static std::optional<McpError> validateModernMeta(const juce::var& params) {
-        const auto meta = params["_meta"];
+        const auto& meta = params["_meta"];
         if (meta[MCP_META_CLIENT_CAPABILITIES].getDynamicObject() == nullptr) {
             return McpError{MCP_INVALID_PARAMS,
                             juce::String(MCP_META_CLIENT_CAPABILITIES) +

--- a/magda/daw/api/remote_mcp_server.cpp
+++ b/magda/daw/api/remote_mcp_server.cpp
@@ -793,7 +793,7 @@ struct RemoteMcpServer::Impl {
     // Era selection
     // -----------------------------------------------------------------------
 
-    McpError unsupportedVersion(const juce::String& requested) const {
+    static McpError unsupportedVersion(const juce::String& requested) {
         juce::Array<juce::var> supported;
         for (const auto& version : mcpProtocolVersions())
             supported.add(version);
@@ -920,9 +920,10 @@ struct RemoteMcpServer::Impl {
      * two components acting on two different requests. Rejecting the
      * disagreement is what keeps that from being exploitable.
      */
-    std::optional<McpError> validateHeaders(const httplib::Request& request,
-                                            const juce::String& method, const juce::var& params,
-                                            const juce::String& version) const {
+    static std::optional<McpError> validateHeaders(const httplib::Request& request,
+                                                   const juce::String& method,
+                                                   const juce::var& params,
+                                                   const juce::String& version) {
         const auto mismatch = [](const juce::String& message) {
             return McpError{MCP_HEADER_MISMATCH, message, {}, httplib::StatusCode::BadRequest_400};
         };

--- a/magda/daw/api/remote_subscriptions.cpp
+++ b/magda/daw/api/remote_subscriptions.cpp
@@ -937,7 +937,7 @@ Response SubscriptionHub::execute(ClientId client, const juce::String& method,
             // continuity would need a second, per-topic cursor on the wire, and
             // being wrong about it leaves a client silently stale, which is the
             // failure this whole design is meant to make impossible.
-            const auto wanted = params["snapshot"];
+            const auto& wanted = params["snapshot"];
             const bool asked = wanted.isVoid() || static_cast<bool>(wanted);
 
             if (asked)

--- a/magda/daw/api/remote_subscriptions.hpp
+++ b/magda/daw/api/remote_subscriptions.hpp
@@ -260,7 +260,7 @@ class SubscriptionHub {
                      const std::vector<Topic>& requested, bool topicsGiven);
 
     void publishTopicLocked(Topic topic, Revision revision);
-    void deliverLocked(Client& client, const SubscriptionEvent& event);
+    static void deliverLocked(Client& client, const SubscriptionEvent& event);
     void foldFlushOutcomesLocked();
     void sendSnapshotsLocked(Client& client, const std::vector<Topic>& topics, Revision revision,
                              juce::Array<juce::var>& into);

--- a/magda/daw/api/remote_websocket_server.cpp
+++ b/magda/daw/api/remote_websocket_server.cpp
@@ -185,7 +185,7 @@ std::string replyFor(const juce::var& id, const Response& response) {
 
     auto meta = makeObject();
     setProperty(meta, "revision", static_cast<juce::int64>(response.revision));
-    setProperty(meta, "apiVersion", juce::String(API_VERSION.data()));
+    setProperty(meta, "apiVersion", juce::String(API_VERSION.data(), API_VERSION.size()));
 
     auto reply = makeObject();
     setProperty(reply, "jsonrpc", "2.0");

--- a/magda/daw/api/remote_websocket_server.cpp
+++ b/magda/daw/api/remote_websocket_server.cpp
@@ -754,7 +754,7 @@ struct RemoteWebSocketServer::Impl {
             // connections are live. Everything else it needs is copied.
             subscriptions->handle(
                 connection->subscriber, method, params,
-                [log = options.audit, connection, id, method, idKey](Response response) {
+                [log = options.audit, connection, id, method, idKey](const Response& response) {
                     recordAudit(log, connection, method, idKey,
                                 response.ok ? AuditOutcome::Ok : AuditOutcome::Failed,
                                 response.ok ? juce::String() : toString(response.error.code));
@@ -774,7 +774,7 @@ struct RemoteWebSocketServer::Impl {
         const auto meta = parsed["meta"];
         auto deadlineMs = options.defaultDeadlineMs;
         if (meta.getDynamicObject() != nullptr) {
-            if (const auto key = meta["idempotencyKey"]; !key.isVoid()) {
+            if (const auto& key = meta["idempotencyKey"]; !key.isVoid()) {
                 if (!key.isString() || key.toString().isEmpty() || key.toString().length() > 256) {
                     refuse(connection, id, kInvalidRequest,
                            "meta.idempotencyKey must be a non-empty string of at most 256 "
@@ -785,7 +785,7 @@ struct RemoteWebSocketServer::Impl {
                 // reused and therefore cannot safely double as retry keys.
                 context.requestId = key.toString();
             }
-            if (const auto expected = meta["expectedRevision"]; !expected.isVoid()) {
+            if (const auto& expected = meta["expectedRevision"]; !expected.isVoid()) {
                 const auto revision =
                     jsonInteger(expected, 0, std::numeric_limits<juce::int64>::max());
                 if (!revision.has_value()) {
@@ -800,7 +800,7 @@ struct RemoteWebSocketServer::Impl {
             // more — and never for none. Taking the minimum without checking the
             // sign lets -1 win it, after which a non-positive deadline is read as
             // "no deadline" and the request outlives every bound there is.
-            if (const auto requested = meta["deadlineMs"]; !requested.isVoid()) {
+            if (const auto& requested = meta["deadlineMs"]; !requested.isVoid()) {
                 const auto milliseconds =
                     jsonInteger(requested, 1, std::numeric_limits<int>::max());
                 if (!milliseconds.has_value()) {
@@ -813,7 +813,7 @@ struct RemoteWebSocketServer::Impl {
         }
         context.deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(deadlineMs);
 
-        service.dispatch(method, params, context, [connection, id](Response response) {
+        service.dispatch(method, params, context, [connection, id](const Response& response) {
             connection->complete(replyFor(id, response));
         });
     }

--- a/magda/daw/audio/AudioBridge.cpp
+++ b/magda/daw/audio/AudioBridge.cpp
@@ -1619,7 +1619,7 @@ void AudioBridge::ensureSessionMonitorPlugin() {
     auto& masterList = edit_.getMasterPluginList();
 
     // Check if a SessionMonitorPlugin already exists
-    for (auto i : masterList) {
+    for (auto* i : masterList) {
         if (auto* existing = dynamic_cast<SessionMonitorPlugin*>(i)) {
             sessionMonitorPlugin_ = existing;
             sessionMonitorPlugin_->setSessionContext(&sessionAudioMonitor_);
@@ -1633,7 +1633,7 @@ void AudioBridge::ensureSessionMonitorPlugin() {
     masterList.insertPlugin(pluginState, 0);
 
     // Find the newly created plugin
-    for (auto i : masterList) {
+    for (auto* i : masterList) {
         if (auto* mon = dynamic_cast<SessionMonitorPlugin*>(i)) {
             sessionMonitorPlugin_ = mon;
             sessionMonitorPlugin_->setSessionContext(&sessionAudioMonitor_);

--- a/magda/daw/audio/AudioBridge.cpp
+++ b/magda/daw/audio/AudioBridge.cpp
@@ -851,7 +851,7 @@ DeviceProcessor* AudioBridge::getDeviceProcessor(const ChainNodePath& devicePath
 }
 
 namespace {
-te::ExternalPlugin* asExternalPlugin(te::Plugin::Ptr plugin) {
+te::ExternalPlugin* asExternalPlugin(const te::Plugin::Ptr& plugin) {
     return dynamic_cast<te::ExternalPlugin*>(plugin.get());
 }
 

--- a/magda/daw/audio/AudioDriverUtils.hpp
+++ b/magda/daw/audio/AudioDriverUtils.hpp
@@ -20,7 +20,7 @@ inline juce::AudioIODeviceType* activeDeviceTypeFor(juce::AudioDeviceManager& de
     if (auto* current = deviceManager.getCurrentDeviceTypeObject())
         return current;
 
-    auto& types = deviceManager.getAvailableDeviceTypes();
+    const auto& types = deviceManager.getAvailableDeviceTypes();
     return types.isEmpty() ? nullptr : types.getFirst();
 }
 

--- a/magda/daw/audio/AudioEngineOptimizer.hpp
+++ b/magda/daw/audio/AudioEngineOptimizer.hpp
@@ -25,7 +25,7 @@ class AudioEngineOptimizer final : public ViewModeListener {
     /**
      * Apply an audio profile to the engine
      */
-    void applyProfile(const AudioEngineProfile& profile);
+    static void applyProfile(const AudioEngineProfile& profile);
 
   private:
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(AudioEngineOptimizer)

--- a/magda/daw/audio/AudioThumbnailManager.cpp
+++ b/magda/daw/audio/AudioThumbnailManager.cpp
@@ -196,7 +196,7 @@ void AudioThumbnailManager::cacheBPM(const juce::String& filePath, double bpm) {
 }
 
 void AudioThumbnailManager::requestBPMDetection(const juce::String& filePath,
-                                                std::function<void(double)> onComplete) {
+                                                const std::function<void(double)>& onComplete) {
     // Caches are message-thread only (no locks).
     JUCE_ASSERT_MESSAGE_THREAD;
 

--- a/magda/daw/audio/AudioThumbnailManager.hpp
+++ b/magda/daw/audio/AudioThumbnailManager.hpp
@@ -115,7 +115,8 @@ class AudioThumbnailManager {
      *
      * Must be called from the message thread.
      */
-    void requestBPMDetection(const juce::String& filePath, std::function<void(double)> onComplete);
+    void requestBPMDetection(const juce::String& filePath,
+                             const std::function<void(double)>& onComplete);
 
     /**
      * @brief Get cached transient times for an audio file

--- a/magda/daw/audio/AudioThumbnailManager.hpp
+++ b/magda/daw/audio/AudioThumbnailManager.hpp
@@ -226,11 +226,11 @@ class AudioThumbnailManager {
     // Draw waveform directly from raw samples (used when zoomed in). When
     // @p peakCache is non-null and the zoom level is coarse enough to use it,
     // peak data short-circuits the per-column reader read.
-    void drawWaveformFromSamples(juce::Graphics& g, const juce::Rectangle<int>& bounds,
-                                 juce::AudioFormatReader* reader,
-                                 const WaveformPeakCache* peakCache, double startTime,
-                                 double endTime, const juce::Colour& colour, float verticalZoom,
-                                 bool thick = false);
+    static void drawWaveformFromSamples(juce::Graphics& g, const juce::Rectangle<int>& bounds,
+                                        juce::AudioFormatReader* reader,
+                                        const WaveformPeakCache* peakCache, double startTime,
+                                        double endTime, const juce::Colour& colour,
+                                        float verticalZoom, bool thick = false);
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(AudioThumbnailManager)
 };

--- a/magda/daw/audio/ClipCommands.cpp
+++ b/magda/daw/audio/ClipCommands.cpp
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include <array>
 #include <limits>
+#include <utility>
 
 #include "../engine/AudioEngine.hpp"
 #include "../project/ProjectManager.hpp"
@@ -636,13 +637,13 @@ bool DeleteClipCommand::validateState() const {
 // ============================================================================
 
 CreateClipCommand::CreateClipCommand(ClipType type, TrackId trackId, BeatPosition startBeat,
-                                     BeatDuration lengthBeats, const juce::String& audioFilePath,
+                                     BeatDuration lengthBeats, juce::String audioFilePath,
                                      ClipView view, double tempo, ClipOverlapPolicy overlapPolicy)
     : type_(type),
       trackId_(trackId),
       startBeat_(startBeat.value),
       lengthBeats_(lengthBeats.value),
-      audioFilePath_(audioFilePath),
+      audioFilePath_(std::move(audioFilePath)),
       view_(view),
       tempo_(tempo),
       overlapPolicy_(overlapPolicy) {}
@@ -1081,8 +1082,8 @@ bool JoinClipsCommand::validateState() const {
 // StretchClipCommand
 // ============================================================================
 
-StretchClipCommand::StretchClipCommand(ClipId clipId, const ClipInfo& beforeState)
-    : clipId_(clipId), beforeState_(beforeState) {}
+StretchClipCommand::StretchClipCommand(ClipId clipId, ClipInfo beforeState)
+    : clipId_(clipId), beforeState_(std::move(beforeState)) {}
 
 void StretchClipCommand::execute() {
     auto& clipManager = ClipManager::getInstance();
@@ -1113,8 +1114,8 @@ void StretchClipCommand::undo() {
 // SetFadeCommand
 // ============================================================================
 
-SetFadeCommand::SetFadeCommand(ClipId clipId, const ClipInfo& beforeState)
-    : clipId_(clipId), beforeState_(beforeState) {}
+SetFadeCommand::SetFadeCommand(ClipId clipId, ClipInfo beforeState)
+    : clipId_(clipId), beforeState_(std::move(beforeState)) {}
 
 void SetFadeCommand::execute() {
     auto& clipManager = ClipManager::getInstance();
@@ -1180,8 +1181,8 @@ void SetCrossfadeCommand::undo() {
 // SetVolumeCommand
 // ============================================================================
 
-SetVolumeCommand::SetVolumeCommand(ClipId clipId, const ClipInfo& beforeState)
-    : clipId_(clipId), beforeState_(beforeState) {}
+SetVolumeCommand::SetVolumeCommand(ClipId clipId, ClipInfo beforeState)
+    : clipId_(clipId), beforeState_(std::move(beforeState)) {}
 
 void SetVolumeCommand::execute() {
     auto& clipManager = ClipManager::getInstance();

--- a/magda/daw/audio/ClipCommands.cpp
+++ b/magda/daw/audio/ClipCommands.cpp
@@ -126,7 +126,7 @@ class RenderProgressWindow : public juce::ThreadWithProgressWindow {
 // return set — its hardware return only exists live, so an offline bounce
 // needs the real-time capture pass first (#1623).
 bool trackNeedsInsertCapture(te::Track& track) {
-    for (auto plugin : track.pluginList) {
+    for (auto* plugin : track.pluginList) {
         if (auto* insert = dynamic_cast<te::InsertPlugin*>(plugin))
             if (insert->isEnabled() && insert->outputDevice.get().isNotEmpty() &&
                 insert->inputDevice.get().isNotEmpty())
@@ -456,12 +456,12 @@ void MoveClipCommand::undo() {
 }
 
 bool MoveClipCommand::canMergeWith(const UndoableCommand* other) const {
-    auto* otherMove = dynamic_cast<const MoveClipCommand*>(other);
+    const auto* otherMove = dynamic_cast<const MoveClipCommand*>(other);
     return otherMove != nullptr && otherMove->clipId_ == clipId_;
 }
 
 void MoveClipCommand::mergeWith(const UndoableCommand* other) {
-    auto* otherMove = dynamic_cast<const MoveClipCommand*>(other);
+    const auto* otherMove = dynamic_cast<const MoveClipCommand*>(other);
     if (otherMove) {
         // Keep our original snapshot, just update the target position
         newStartBeat_ = otherMove->newStartBeat_;
@@ -593,13 +593,13 @@ void ResizeClipCommand::performAction() {
 }
 
 bool ResizeClipCommand::canMergeWith(const UndoableCommand* other) const {
-    auto* otherResize = dynamic_cast<const ResizeClipCommand*>(other);
+    const auto* otherResize = dynamic_cast<const ResizeClipCommand*>(other);
     return otherResize != nullptr && otherResize->clipId_ == clipId_ &&
            otherResize->fromStart_ == fromStart_;
 }
 
 void ResizeClipCommand::mergeWith(const UndoableCommand* other) {
-    auto* otherResize = dynamic_cast<const ResizeClipCommand*>(other);
+    const auto* otherResize = dynamic_cast<const ResizeClipCommand*>(other);
     if (otherResize) {
         // Update to their new length
         newLengthBeats_ = otherResize->newLengthBeats_;
@@ -2158,7 +2158,7 @@ void BounceInPlaceCommand::execute() {
     };
     std::vector<PluginState> savedStates;
 
-    for (auto plugin : teTrack->pluginList) {
+    for (auto* plugin : teTrack->pluginList) {
         if (rackManager.isWrapperRack(plugin) ||
             dynamic_cast<te::InsertPlugin*>(plugin) != nullptr ||
             dynamic_cast<InsertCapturePlugin*>(plugin) != nullptr)

--- a/magda/daw/audio/CompService.cpp
+++ b/magda/daw/audio/CompService.cpp
@@ -158,7 +158,7 @@ double stitchComp(const CompSnapshot& snap) {
         stream.get(), sampleRate, static_cast<unsigned>(numChannels), 24, {}, 0));
     if (!writer)
         return 0.0;
-    stream.release();  // writer owns it now
+    static_cast<void>(stream.release());  // writer owns it now
     writer->writeFromAudioSampleBuffer(out, 0, total);
     writer.reset();
     return total / sampleRate;

--- a/magda/daw/audio/CompService.hpp
+++ b/magda/daw/audio/CompService.hpp
@@ -31,7 +31,7 @@ class CompService {
     void setSection(ClipId clipId, double startSeconds, double endSeconds, int takeIndex);
 
     /** Drop the comp and revert the clip to its active take. */
-    void clearComp(ClipId clipId);
+    static void clearComp(ClipId clipId);
 
     /** Re-render the clip's existing comp (e.g. after project load). */
     void renderComp(ClipId clipId);

--- a/magda/daw/audio/ExternalInsertDeviceEnablement.cpp
+++ b/magda/daw/audio/ExternalInsertDeviceEnablement.cpp
@@ -64,7 +64,7 @@ bool ExternalInsertDeviceEnablement::refresh() {
     // return is one of TE's input devices; its send is an output device.
     std::set<juce::String> usedInputs, usedOutputs;
     const auto allPlugins = te::getAllPlugins(edit_, false);
-    for (auto plugin : allPlugins) {
+    for (auto* plugin : allPlugins) {
         auto* insert = dynamic_cast<te::InsertPlugin*>(plugin);
         if (insert == nullptr || !insert->isEnabled())
             continue;
@@ -106,7 +106,7 @@ bool ExternalInsertDeviceEnablement::refresh() {
     if (changed) {
         // A just-enabled device only resolves in the inserts after
         // updateDeviceTypes() re-runs against the new device lists.
-        for (auto plugin : allPlugins)
+        for (auto* plugin : allPlugins)
             if (auto* insert = dynamic_cast<te::InsertPlugin*>(plugin))
                 insert->updateDeviceTypes();
     }

--- a/magda/daw/audio/MidiBridge.cpp
+++ b/magda/daw/audio/MidiBridge.cpp
@@ -92,7 +92,7 @@ std::vector<MidiDeviceInfo> MidiBridge::getAvailableMidiInputs() const {
     return devices;
 }
 
-std::vector<MidiDeviceInfo> MidiBridge::getAvailableMidiOutputs() const {
+std::vector<MidiDeviceInfo> MidiBridge::getAvailableMidiOutputs() {
     std::vector<MidiDeviceInfo> devices;
 
     auto midiOutputs = juce::MidiOutput::getAvailableDevices();

--- a/magda/daw/audio/MidiBridge.hpp
+++ b/magda/daw/audio/MidiBridge.hpp
@@ -119,7 +119,7 @@ class MidiBridge : public juce::MidiInputCallback {
      * @brief Get all available MIDI output devices
      * @return Vector of device info
      */
-    std::vector<MidiDeviceInfo> getAvailableMidiOutputs() const;
+    static std::vector<MidiDeviceInfo> getAvailableMidiOutputs();
 
     // =========================================================================
     // MIDI Output (host → device)

--- a/magda/daw/audio/PluginWindowBridge.cpp
+++ b/magda/daw/audio/PluginWindowBridge.cpp
@@ -4,26 +4,26 @@
 
 namespace magda {
 
-void PluginWindowBridge::showPluginWindow(DeviceId deviceId, te::Plugin::Ptr plugin) {
+void PluginWindowBridge::showPluginWindow(DeviceId deviceId, const te::Plugin::Ptr& plugin) {
     if (windowManager_ && plugin) {
         windowManager_->showPluginWindow(deviceId, plugin);
     }
 }
 
-void PluginWindowBridge::hidePluginWindow(DeviceId deviceId, te::Plugin::Ptr plugin) {
+void PluginWindowBridge::hidePluginWindow(DeviceId deviceId, const te::Plugin::Ptr& plugin) {
     if (windowManager_ && plugin) {
         windowManager_->hidePluginWindow(deviceId, plugin);
     }
 }
 
-bool PluginWindowBridge::isPluginWindowOpen(te::Plugin::Ptr plugin) const {
+bool PluginWindowBridge::isPluginWindowOpen(const te::Plugin::Ptr& plugin) const {
     if (windowManager_ && plugin) {
         return windowManager_->isPluginWindowOpen(plugin);
     }
     return false;
 }
 
-bool PluginWindowBridge::togglePluginWindow(DeviceId deviceId, te::Plugin::Ptr plugin) {
+bool PluginWindowBridge::togglePluginWindow(DeviceId deviceId, const te::Plugin::Ptr& plugin) {
     if (windowManager_ && plugin) {
         return windowManager_->togglePluginWindow(deviceId, plugin);
     }

--- a/magda/daw/audio/PluginWindowBridge.hpp
+++ b/magda/daw/audio/PluginWindowBridge.hpp
@@ -41,21 +41,21 @@ class PluginWindowBridge {
      * @param plugin The Tracktion plugin
      * @param deviceId MAGDA device ID of the plugin
      */
-    void showPluginWindow(DeviceId deviceId, te::Plugin::Ptr plugin);
+    void showPluginWindow(DeviceId deviceId, const te::Plugin::Ptr& plugin);
 
     /**
      * @brief Hide/close the plugin's native editor window
      * @param plugin The Tracktion plugin
      * @param deviceId MAGDA device ID of the plugin
      */
-    void hidePluginWindow(DeviceId deviceId, te::Plugin::Ptr plugin);
+    void hidePluginWindow(DeviceId deviceId, const te::Plugin::Ptr& plugin);
 
     /**
      * @brief Check if a plugin window is currently open
      * @param plugin The Tracktion plugin
      * @return true if the plugin window is visible
      */
-    bool isPluginWindowOpen(te::Plugin::Ptr plugin) const;
+    bool isPluginWindowOpen(const te::Plugin::Ptr& plugin) const;
 
     /**
      * @brief Toggle the plugin's native editor window (open if closed, close if open)
@@ -63,7 +63,7 @@ class PluginWindowBridge {
      * @param deviceId MAGDA device ID of the plugin
      * @return true if the window is now open, false if now closed
      */
-    bool togglePluginWindow(DeviceId deviceId, te::Plugin::Ptr plugin);
+    bool togglePluginWindow(DeviceId deviceId, const te::Plugin::Ptr& plugin);
 
     /**
      * @brief Close all windows for a specific device

--- a/magda/daw/audio/TrackController.cpp
+++ b/magda/daw/audio/TrackController.cpp
@@ -586,7 +586,7 @@ void TrackController::clearAllMappings() {
 }
 
 void TrackController::withTrackMapping(
-    std::function<void(const std::map<TrackId, te::AudioTrack*>&)> callback) const {
+    const std::function<void(const std::map<TrackId, te::AudioTrack*>&)>& callback) const {
     juce::ScopedLock lock(trackLock_);
     callback(trackMapping_);
 }
@@ -629,7 +629,7 @@ void TrackController::removeMeterClient(TrackId trackId) {
 }
 
 void TrackController::withMeterClients(
-    std::function<void(std::map<TrackId, MeterClientEntry>&)> callback) {
+    const std::function<void(std::map<TrackId, MeterClientEntry>&)>& callback) {
     juce::ScopedLock lock(trackLock_);
     callback(meterClients_);
 }

--- a/magda/daw/audio/TrackController.hpp
+++ b/magda/daw/audio/TrackController.hpp
@@ -187,7 +187,7 @@ class TrackController {
      * Usage: trackController.withTrackMapping([&](const auto& mapping) { ... });
      */
     void withTrackMapping(
-        std::function<void(const std::map<TrackId, te::AudioTrack*>&)> callback) const;
+        const std::function<void(const std::map<TrackId, te::AudioTrack*>&)>& callback) const;
 
     // =========================================================================
     // Metering Coordination (for PluginManager)
@@ -220,7 +220,8 @@ class TrackController {
      * Used by AudioBridge for meter updates in timer thread.
      * Provides mutable access so callers can call getAndClearAudioLevel().
      */
-    void withMeterClients(std::function<void(std::map<TrackId, MeterClientEntry>&)> callback);
+    void withMeterClients(
+        const std::function<void(std::map<TrackId, MeterClientEntry>&)>& callback);
 
   private:
     // References to Tracktion Engine (not owned)

--- a/magda/daw/audio/TrackController.hpp
+++ b/magda/daw/audio/TrackController.hpp
@@ -146,7 +146,7 @@ class TrackController {
      * @param trackId The MAGDA track ID
      * @param deviceId MIDI output device ID, "track:NNN" for track destination, empty to disable
      */
-    void setTrackMidiOutput(TrackId trackId, const juce::String& deviceId);
+    static void setTrackMidiOutput(TrackId trackId, const juce::String& deviceId);
 
     /**
      * @brief Set audio input source for a track

--- a/magda/daw/audio/TrackMeasurementManager.cpp
+++ b/magda/daw/audio/TrackMeasurementManager.cpp
@@ -124,8 +124,7 @@ std::vector<daw::audio::MaskingFinding> TrackMeasurementManager::getMaskingFindi
 }
 
 size_t TrackMeasurementManager::readTrackSpectrumSamples(TrackId trackId, float* dest,
-                                                         int numSamples,
-                                                         double& sampleRateOut) const {
+                                                         int numSamples, double& sampleRateOut) {
     auto* pm = pluginManager();
     if (pm == nullptr)
         return 0;

--- a/magda/daw/audio/WarpMarkerManager.cpp
+++ b/magda/daw/audio/WarpMarkerManager.cpp
@@ -227,7 +227,7 @@ void WarpMarkerManager::enableWarp(te::Edit& edit,
     double clipOffset = event->anchorSeconds();
 
     // Get cached transients from AudioThumbnailManager
-    auto* cachedTransients =
+    const auto* cachedTransients =
         AudioThumbnailManager::getInstance().getCachedTransients(event->sourceFilePath());
     DBG("WarpMarkerManager::enableWarp cachedTransients="
         << (cachedTransients ? juce::String(cachedTransients->size()) : "null")

--- a/magda/daw/audio/WarpMarkerManager.hpp
+++ b/magda/daw/audio/WarpMarkerManager.hpp
@@ -75,8 +75,8 @@ class WarpMarkerManager : private te::WarpTimeManager::Listener, private juce::T
      * @param clipIdToEngineId Mapping from MAGDA clip ID to TE clip ID
      * @param clipId The MAGDA clip ID
      */
-    void enableWarp(te::Edit& edit, const std::map<ClipId, std::string>& clipIdToEngineId,
-                    ClipId clipId);
+    static void enableWarp(te::Edit& edit, const std::map<ClipId, std::string>& clipIdToEngineId,
+                           ClipId clipId);
 
     /**
      * @brief Disable warping: remove all warp markers
@@ -84,8 +84,8 @@ class WarpMarkerManager : private te::WarpTimeManager::Listener, private juce::T
      * @param clipIdToEngineId Mapping from MAGDA clip ID to TE clip ID
      * @param clipId The MAGDA clip ID
      */
-    void disableWarp(te::Edit& edit, const std::map<ClipId, std::string>& clipIdToEngineId,
-                     ClipId clipId);
+    static void disableWarp(te::Edit& edit, const std::map<ClipId, std::string>& clipIdToEngineId,
+                            ClipId clipId);
 
     /**
      * @brief Get current warp marker positions for display
@@ -94,7 +94,7 @@ class WarpMarkerManager : private te::WarpTimeManager::Listener, private juce::T
      * @param clipId The MAGDA clip ID
      * @return Vector of warp marker info
      */
-    std::vector<WarpMarkerInfo> getWarpMarkers(
+    static std::vector<WarpMarkerInfo> getWarpMarkers(
         te::Edit& edit, const std::map<ClipId, std::string>& clipIdToEngineId, ClipId clipId);
 
     /**
@@ -106,8 +106,8 @@ class WarpMarkerManager : private te::WarpTimeManager::Listener, private juce::T
      * @param warpTime Warped time position
      * @return Index of inserted marker, or -1 on failure
      */
-    int addWarpMarker(te::Edit& edit, const std::map<ClipId, std::string>& clipIdToEngineId,
-                      ClipId clipId, double sourceTime, double warpTime);
+    static int addWarpMarker(te::Edit& edit, const std::map<ClipId, std::string>& clipIdToEngineId,
+                             ClipId clipId, double sourceTime, double warpTime);
 
     /**
      * @brief Move a warp marker's warp time
@@ -118,8 +118,9 @@ class WarpMarkerManager : private te::WarpTimeManager::Listener, private juce::T
      * @param newWarpTime New warped time position
      * @return Actual position (clamped by TE)
      */
-    double moveWarpMarker(te::Edit& edit, const std::map<ClipId, std::string>& clipIdToEngineId,
-                          ClipId clipId, int index, double newWarpTime);
+    static double moveWarpMarker(te::Edit& edit,
+                                 const std::map<ClipId, std::string>& clipIdToEngineId,
+                                 ClipId clipId, int index, double newWarpTime);
 
     /**
      * @brief Remove a warp marker at index
@@ -128,8 +129,9 @@ class WarpMarkerManager : private te::WarpTimeManager::Listener, private juce::T
      * @param clipId The MAGDA clip ID
      * @param index Marker index
      */
-    void removeWarpMarker(te::Edit& edit, const std::map<ClipId, std::string>& clipIdToEngineId,
-                          ClipId clipId, int index);
+    static void removeWarpMarker(te::Edit& edit,
+                                 const std::map<ClipId, std::string>& clipIdToEngineId,
+                                 ClipId clipId, int index);
 
   private:
     // -------- In-flight guard for transient detection --------

--- a/magda/daw/audio/automation/AutomationPlaybackEngine.cpp
+++ b/magda/daw/audio/automation/AutomationPlaybackEngine.cpp
@@ -471,7 +471,7 @@ te::AutomatableParameter* AutomationPlaybackEngine::resolveParameter(
 
 double AutomationPlaybackEngine::convertFromTEValue(const AutomationTarget& target,
                                                     te::AutomatableParameter* param,
-                                                    float teValue) const {
+                                                    float teValue) {
     return laneNormalizedFromTEValue(target, param, teValue);
 }
 

--- a/magda/daw/audio/automation/AutomationPlaybackEngine.cpp
+++ b/magda/daw/audio/automation/AutomationPlaybackEngine.cpp
@@ -511,6 +511,8 @@ void AutomationPlaybackEngine::syncParameterListeners() {
 
     // Add listeners for new params; refresh info for existing ones so the
     // lane id tracks target re-binds.
+    // NOLINTNEXTLINE(bugprone-nondeterministic-pointer-iteration-order) - listener registration
+    // order is immaterial
     for (auto& [param, info] : desired) {
         auto [it, inserted] = listenedParams_.insert({param, info});
         if (inserted) {

--- a/magda/daw/audio/automation/AutomationPlaybackEngine.cpp
+++ b/magda/daw/audio/automation/AutomationPlaybackEngine.cpp
@@ -621,7 +621,7 @@ void AutomationPlaybackEngine::writeMacroValueFromCurve(const AutomationTarget& 
         }
 
         auto position = edit_.getTransport().getPosition();
-        for (auto param : te::getAllParametersBeingModifiedBy(edit_, *macroParam))
+        for (auto* param : te::getAllParametersBeingModifiedBy(edit_, *macroParam))
             if (param)
                 param->updateFromAutomationSources(position);
     }

--- a/magda/daw/audio/automation/AutomationPlaybackEngine.hpp
+++ b/magda/daw/audio/automation/AutomationPlaybackEngine.hpp
@@ -97,14 +97,14 @@ class AutomationPlaybackEngine : public AutomationManagerListener,
     // parameter's real value → MAGDA 0..1.
     // Used by currentValueChanged to translate TE-driven parameter writes back
     // into the normalized form UI listeners expect.
-    double convertFromTEValue(const AutomationTarget& target, te::AutomatableParameter* param,
-                              float teValue) const;
+    static double convertFromTEValue(const AutomationTarget& target,
+                                     te::AutomatableParameter* param, float teValue);
 
     // Push a normalized rate-curve value back into MAGDA's modulator state.
     // The lane is mode-aware: tempoSync=false → setXxxModRate (Hz), true →
     // setXxxModSyncDivision. Used by both drag-preview and TE-driven
     // currentValueChanged writeback so the two paths agree.
-    void writeModRateFromCurve(const AutomationTarget& target, double normalized);
+    static void writeModRateFromCurve(const AutomationTarget& target, double normalized);
 
     // Push a macro curve value into MAGDA state and update linked TE targets.
     // Drag preview also seeds the TE macro param; playback callbacks skip that

--- a/magda/daw/audio/automation/AutomationRecordingEngine.hpp
+++ b/magda/daw/audio/automation/AutomationRecordingEngine.hpp
@@ -86,7 +86,7 @@ class AutomationRecordingEngine {
     // here because shouldRecord() already returns false.
     bool requiresUserTouched() const;
     double getCurrentBeatTime() const;
-    double normalizeDeviceParam(const AutomationTarget& target, float rawValue);
+    static double normalizeDeviceParam(const AutomationTarget& target, float rawValue);
     bool shouldThinPoint(AutomationLaneId laneId, double beatTime, double value);
     void recordPoint(AutomationLaneId laneId, double beatTime, double normalizedValue);
     void flushFinalPoints();

--- a/magda/daw/audio/controllers/ControllerParamWriter.hpp
+++ b/magda/daw/audio/controllers/ControllerParamWriter.hpp
@@ -54,10 +54,10 @@ class DefaultControllerParamWriter : public ControllerParamWriter {
 
   private:
     void writePluginParam(const ControlTarget& target, float clamped);
-    void writeMacro(const ControlTarget& target, float clamped);
-    void writeModParam(const ControlTarget& target, float clamped);
-    void writeTrackLevel(const ControlTarget& target, float clamped);
-    void writeSendLevel(const ControlTarget& target, float clamped);
+    static void writeMacro(const ControlTarget& target, float clamped);
+    static void writeModParam(const ControlTarget& target, float clamped);
+    static void writeTrackLevel(const ControlTarget& target, float clamped);
+    static void writeSendLevel(const ControlTarget& target, float clamped);
 
     AudioBridge& bridge_;
 };

--- a/magda/daw/audio/controllers/ControllerRouter.cpp
+++ b/magda/daw/audio/controllers/ControllerRouter.cpp
@@ -279,7 +279,7 @@ void ControllerRouter::onMidiFromControllerPort(const juce::String& portId,
     if (hasExplicitOverride) {
         bindings.erase(std::remove_if(bindings.begin(), bindings.end(),
                                       [](const Binding& b) {
-                                          if (auto* rr = std::get_if<ResolverRef>(&b.target))
+                                          if (const auto* rr = std::get_if<ResolverRef>(&b.target))
                                               return rr->kind == "focused.macro";
                                           return false;
                                       }),

--- a/magda/daw/audio/controllers/ControllerRouter.cpp
+++ b/magda/daw/audio/controllers/ControllerRouter.cpp
@@ -321,7 +321,7 @@ void ControllerRouter::scheduleWrite(const BindingId& bindingId, int rawValue, i
         return;
 
     auto pwShared = pwIt->second;
-    Binding bindingCopy = binding;
+    const Binding& bindingCopy = binding;
 
     // If we're already on the message thread (or no message manager -- test context),
     // execute synchronously to avoid deadlock and allow tests to run without a

--- a/magda/daw/audio/insert_capture/InsertRenderCaptureService.cpp
+++ b/magda/daw/audio/insert_capture/InsertRenderCaptureService.cpp
@@ -26,7 +26,7 @@ constexpr int kProgressTimerHz = 10;
 // the ones whose returns the offline render cannot produce.
 std::vector<te::InsertPlugin*> routedInserts(te::Edit& edit) {
     std::vector<te::InsertPlugin*> result;
-    for (auto plugin : te::getAllPlugins(edit, false)) {
+    for (auto* plugin : te::getAllPlugins(edit, false)) {
         auto* insert = dynamic_cast<te::InsertPlugin*>(plugin);
         if (insert != nullptr && insert->isEnabled() && insert->outputDevice.get().isNotEmpty() &&
             insert->inputDevice.get().isNotEmpty())

--- a/magda/daw/audio/midi/MidiInputRouter.cpp
+++ b/magda/daw/audio/midi/MidiInputRouter.cpp
@@ -300,7 +300,7 @@ void MidiInputRouter::removeSurfaceOnlyMidiInputTargets() {
 }
 
 bool MidiInputRouter::isExternalInstrumentSendbackInput(TrackId trackId,
-                                                        const juce::String& inputName) const {
+                                                        const juce::String& inputName) {
     // Arm-gated: a record-armed track re-admits the synth's own ports so its
     // keyboard can be captured (Local Control off on the synth is the no-
     // double-trigger companion). Un-armed, the ports stay dropped so playback

--- a/magda/daw/audio/midi/MidiInputRouter.cpp
+++ b/magda/daw/audio/midi/MidiInputRouter.cpp
@@ -337,7 +337,7 @@ void MidiInputRouter::setTrackMidiInput(TrackId trackId, const juce::String& mid
 
     auto* playbackContext = edit_.getCurrentPlaybackContext();
     if (!playbackContext) {
-        pendingMidiRoutes_.push_back({trackId, midiDeviceId});
+        pendingMidiRoutes_.emplace_back(trackId, midiDeviceId);
         return;
     }
 

--- a/magda/daw/audio/midi/MidiInputRouter.cpp
+++ b/magda/daw/audio/midi/MidiInputRouter.cpp
@@ -442,7 +442,7 @@ void MidiInputRouter::setTrackMidiInput(TrackId trackId, const juce::String& mid
             const auto matchesIdentifier = [&midiDeviceId](const auto& d) {
                 return d.identifier == midiDeviceId;
             };
-            if (const auto found = std::ranges::find_if(juceDevices, matchesIdentifier);
+            if (auto* const found = std::ranges::find_if(juceDevices, matchesIdentifier);
                 found != juceDevices.end())
                 deviceName = found->name;
 
@@ -467,7 +467,7 @@ void MidiInputRouter::setTrackMidiInput(TrackId trackId, const juce::String& mid
                     return &inputDeviceInstance->owner == midiDevice;
                 };
                 const auto allInputs = playbackContext->getAllInputs();
-                if (const auto found = std::ranges::find_if(allInputs, matchesOwner);
+                if (const auto* const found = std::ranges::find_if(allInputs, matchesOwner);
                     found != allInputs.end())
                     removedAnyRouting = (*found)->removeTarget(track->itemID, nullptr);
                 if (removedAnyRouting && playbackContext->isPlaybackGraphAllocated())
@@ -487,7 +487,7 @@ void MidiInputRouter::setTrackMidiInput(TrackId trackId, const juce::String& mid
                 return &inputDeviceInstance->owner == midiDevice;
             };
             const auto allInputs = playbackContext->getAllInputs();
-            if (const auto found = std::ranges::find_if(allInputs, matchesOwner);
+            if (const auto* const found = std::ranges::find_if(allInputs, matchesOwner);
                 found != allInputs.end()) {
                 auto result = (*found)->setTarget(track->itemID, true, nullptr);
                 if (result.has_value()) {

--- a/magda/daw/audio/midi/MidiInputRouter.hpp
+++ b/magda/daw/audio/midi/MidiInputRouter.hpp
@@ -146,7 +146,7 @@ class MidiInputRouter : private juce::AsyncUpdater {
     /// port naming ("monologue KBD/KNOB" vs "monologue MIDI OUT"). Applied to
     /// "All Inputs" routing only — an explicitly selected port is respected,
     /// so the synth's keyboard can still be recorded (Local Control off).
-    bool isExternalInstrumentSendbackInput(TrackId trackId, const juce::String& inputName) const;
+    static bool isExternalInstrumentSendbackInput(TrackId trackId, const juce::String& inputName);
 
     void handleAsyncUpdate() override;
 

--- a/magda/daw/audio/midi/QwertyMidiKeyboard.cpp
+++ b/magda/daw/audio/midi/QwertyMidiKeyboard.cpp
@@ -186,6 +186,7 @@ bool QwertyMidiKeyboard::keyStateChanged(bool /*isKeyDown*/, juce::Component*) {
         bool stillDown = false;
 
         // Build reverse map inline — check each key that maps to this note
+        // NOLINTNEXTLINE(bugprone-signed-char-misuse) - ASCII key codes are positive
         for (int kc :
              {'A', 'S', 'D', 'F', 'G', 'H', 'J', 'W', 'E', 'T', 'Y', 'U', 'K', 'L', 'O', 'P'}) {
             if (keyToNote(kc) != note)

--- a/magda/daw/audio/modifiers/ADSRDebugLog.hpp
+++ b/magda/daw/audio/modifiers/ADSRDebugLog.hpp
@@ -33,9 +33,12 @@ inline void logAdsrAudio(const juce::String& message) {
 
 }  // namespace magda
 
+// NOLINTBEGIN(bugprone-macro-parentheses) - the argument is streamed, so
+// parenthesising it would evaluate the << chain before it reaches the string
 #define MAGDA_ADSR_AUDIO_LOG(expr)                                                                 \
     do {                                                                                           \
         juce::String magdaAdsrAudioLogMessage;                                                     \
         magdaAdsrAudioLogMessage << expr;                                                          \
         ::magda::logAdsrAudio(magdaAdsrAudioLogMessage);                                           \
     } while (false)
+// NOLINTEND(bugprone-macro-parentheses)

--- a/magda/daw/audio/modifiers/ModifierHelpers.hpp
+++ b/magda/daw/audio/modifiers/ModifierHelpers.hpp
@@ -415,7 +415,7 @@ inline void triggerLFONoteOnWithReset(te::LFOModifier* lfo, bool forceZeroValue 
  * from dereferencing a dangling userData pointer in evaluateCallback.
  */
 inline void clearLFOCustomWaveCallbacks(const std::vector<te::Modifier::Ptr>& modifiers) {
-    for (auto& mod : modifiers) {
+    for (const auto& mod : modifiers) {
         if (auto* lfo = dynamic_cast<te::LFOModifier*>(mod.get())) {
             lfo->customWaveFunction.store(nullptr, std::memory_order_release);
             lfo->customWaveUserData.store(nullptr, std::memory_order_release);

--- a/magda/daw/audio/plugin_manager/PluginManager.cpp
+++ b/magda/daw/audio/plugin_manager/PluginManager.cpp
@@ -317,7 +317,8 @@ void PluginManager::ensureMidiReceive(const ChainNodePath& devicePath, TrackId s
         return plugin;
     };
 
-    auto configureSidechainDependency = [&](te::Plugin::Ptr plugin, TrackId midiSourceTrackId) {
+    auto configureSidechainDependency = [&](const te::Plugin::Ptr& plugin,
+                                            TrackId midiSourceTrackId) {
         if (!plugin || midiSourceTrackId == trackId)
             return;
 
@@ -572,7 +573,8 @@ void PluginManager::detachRackRuntimeForChainMove(RackId rackId) {
     rackSyncManager_.removeRackForMove(rackId);
 }
 
-void PluginManager::restorePluginState(const ChainNodePath& devicePath, te::Plugin::Ptr plugin) {
+void PluginManager::restorePluginState(const ChainNodePath& devicePath,
+                                       const te::Plugin::Ptr& plugin) {
     auto& tm = TrackManager::getInstance();
     auto* devInfo = tm.getDeviceInChainByPath(devicePath);
     if (!devInfo || devInfo->pluginState.isEmpty()) {

--- a/magda/daw/audio/plugin_manager/PluginManager.hpp
+++ b/magda/daw/audio/plugin_manager/PluginManager.hpp
@@ -257,7 +257,7 @@ class PluginManager : public daw::audio::DrumGridPlugin::Listener,
     /// by path. A pad device is reached through the Drum Grid that owns it: its
     /// path's rack component is a DeviceId, which a Rack step cannot tell from
     /// a rack of the same number (#2207).
-    void registerRackPluginProcessor(const ChainNodePath& devicePath, te::Plugin::Ptr plugin,
+    void registerRackPluginProcessor(const ChainNodePath& devicePath, const te::Plugin::Ptr& plugin,
                                      const DeviceInfo& device, DeviceInfo* canonical);
 
     /// The model's device for a pad plugin path, through @p drumGridPath.
@@ -333,7 +333,7 @@ class PluginManager : public daw::audio::DrumGridPlugin::Listener,
      * @param devicePath The device whose state to restore
      * @param plugin The TE plugin to apply state to
      */
-    static void restorePluginState(const ChainNodePath& devicePath, te::Plugin::Ptr plugin);
+    static void restorePluginState(const ChainNodePath& devicePath, const te::Plugin::Ptr& plugin);
 
     // =========================================================================
     // Utilities
@@ -661,7 +661,7 @@ class PluginManager : public daw::audio::DrumGridPlugin::Listener,
     bool isDrumGridPadPathLocked(const ChainNodePath& devicePath) const;
 
     // Poll for async plugin load completion (TE's background thread instantiation)
-    void pollAsyncPluginLoad(const ChainNodePath& devicePath, te::Plugin::Ptr plugin);
+    void pollAsyncPluginLoad(const ChainNodePath& devicePath, const te::Plugin::Ptr& plugin);
 
     // Create a TE internal plugin, restoring saved ValueTree state if available.
     // Falls back to creating a fresh plugin from xmlTypeName when no saved state exists.

--- a/magda/daw/audio/plugin_manager/PluginManager.hpp
+++ b/magda/daw/audio/plugin_manager/PluginManager.hpp
@@ -333,7 +333,7 @@ class PluginManager : public daw::audio::DrumGridPlugin::Listener,
      * @param devicePath The device whose state to restore
      * @param plugin The TE plugin to apply state to
      */
-    void restorePluginState(const ChainNodePath& devicePath, te::Plugin::Ptr plugin);
+    static void restorePluginState(const ChainNodePath& devicePath, te::Plugin::Ptr plugin);
 
     // =========================================================================
     // Utilities
@@ -694,11 +694,11 @@ class PluginManager : public daw::audio::DrumGridPlugin::Listener,
     void updateDeviceModifierProperties(TrackId trackId);
 
     // Compute (activeModCount, totalLinkCount) fingerprint across device+track mods.
-    std::pair<int, int> computeModLinkFingerprint(TrackId trackId,
-                                                  const TrackInfo* trackInfo) const;
+    static std::pair<int, int> computeModLinkFingerprint(TrackId trackId,
+                                                         const TrackInfo* trackInfo);
 
     // Check whether a track needs a SidechainMonitorPlugin (MIDI sidechain source).
-    bool trackNeedsSidechainMonitor(TrackId trackId) const;
+    static bool trackNeedsSidechainMonitor(TrackId trackId);
 
     // Check whether a track needs an AudioSidechainMonitorPlugin (audio sidechain source).
     bool trackNeedsAudioSidechainMonitor(TrackId trackId) const;

--- a/magda/daw/audio/plugin_manager/PluginManagerMeasurement.cpp
+++ b/magda/daw/audio/plugin_manager/PluginManagerMeasurement.cpp
@@ -38,7 +38,7 @@ daw::audio::TrackMeasurementPlugin* PluginManager::ensureTrackMeasurementTap(Tra
         return nullptr;
 
     // Adopt an existing tap if one is already on the chain (e.g. after restore).
-    for (auto i : *list) {
+    for (auto* i : *list) {
         if (auto* existing = dynamic_cast<daw::audio::TrackMeasurementPlugin*>(i)) {
             trackMeasurementTaps_[trackId] = i;
             return existing;

--- a/magda/daw/audio/plugin_manager/PluginManagerModifiers.cpp
+++ b/magda/daw/audio/plugin_manager/PluginManagerModifiers.cpp
@@ -1006,7 +1006,7 @@ void PluginManager::rebuildSidechainLFOCache() {
 
 // =============================================================================
 std::pair<int, int> PluginManager::computeModLinkFingerprint(TrackId trackId,
-                                                             const TrackInfo* trackInfo) const {
+                                                             const TrackInfo* trackInfo) {
     if (!trackInfo)
         return {0, 0};
 

--- a/magda/daw/audio/plugin_manager/PluginManagerModifiers.cpp
+++ b/magda/daw/audio/plugin_manager/PluginManagerModifiers.cpp
@@ -74,7 +74,7 @@ void PluginManager::updateDeviceModifierProperties(TrackId trackId) {
     std::function<void(const std::function<void(te::Plugin*)>&)> visitHostPlugins;
     if (teTrack) {
         visitHostPlugins = [teTrack](const std::function<void(te::Plugin*)>& visit) {
-            for (auto plugin : teTrack->pluginList) {
+            for (auto* plugin : teTrack->pluginList) {
                 if (plugin)
                     visit(plugin);
             }
@@ -82,7 +82,7 @@ void PluginManager::updateDeviceModifierProperties(TrackId trackId) {
     } else if (trackId == MASTER_TRACK_ID && edit_.getMasterTrack()) {
         visitHostPlugins = [this](const std::function<void(te::Plugin*)>& visit) {
             const auto& masterList = edit_.getMasterPluginList();
-            for (auto plugin : masterList) {
+            for (auto* plugin : masterList) {
                 if (plugin)
                     visit(plugin);
             }
@@ -1077,7 +1077,7 @@ void PluginManager::resyncDeviceModifiers(TrackId trackId) {
         defaultModifierList = teTrack->getModifierList();
         macroList = &teTrack->getMacroParameterListForWriting();
         visitHostPlugins = [teTrack](const std::function<void(te::Plugin*)>& visit) {
-            for (auto plugin : teTrack->pluginList) {
+            for (auto* plugin : teTrack->pluginList) {
                 if (plugin)
                     visit(plugin);
             }
@@ -1090,7 +1090,7 @@ void PluginManager::resyncDeviceModifiers(TrackId trackId) {
             // null macro host as unsupported master macros.
             visitHostPlugins = [this](const std::function<void(te::Plugin*)>& visit) {
                 const auto& masterList = edit_.getMasterPluginList();
-                for (auto plugin : masterList) {
+                for (auto* plugin : masterList) {
                     if (plugin)
                         visit(plugin);
                 }

--- a/magda/daw/audio/plugin_manager/PluginManagerSidechain.cpp
+++ b/magda/daw/audio/plugin_manager/PluginManagerSidechain.cpp
@@ -174,7 +174,7 @@ void PluginManager::ensureSidechainMonitor(TrackId sourceTrackId) {
     }
 
     // Check if a SidechainMonitorPlugin already exists on the track
-    for (auto i : teTrack->pluginList) {
+    for (auto* i : teTrack->pluginList) {
         if (dynamic_cast<SidechainMonitorPlugin*>(i)) {
             DBG("PluginManager::ensureSidechainMonitor - track "
                 << sourceTrackId << " found existing monitor plugin on TE track");

--- a/magda/daw/audio/plugin_manager/PluginManagerSidechain.cpp
+++ b/magda/daw/audio/plugin_manager/PluginManagerSidechain.cpp
@@ -109,7 +109,7 @@ void PluginManager::syncSidechains(TrackId trackId, te::AudioTrack* teTrack) {
 // Sidechain Monitor Lifecycle
 // =============================================================================
 
-bool PluginManager::trackNeedsSidechainMonitor(TrackId trackId) const {
+bool PluginManager::trackNeedsSidechainMonitor(TrackId trackId) {
     // The master owns modifiers but has no AudioTrack/plugin list to host a
     // MIDI monitor. It can be a sidechain destination, never a source.
     if (trackId == MASTER_TRACK_ID)

--- a/magda/daw/audio/plugin_manager/PluginManagerSync.cpp
+++ b/magda/daw/audio/plugin_manager/PluginManagerSync.cpp
@@ -2,6 +2,7 @@
 #include <map>
 #include <set>
 #include <unordered_set>
+#include <utility>
 #include <vector>
 
 #include "../../core/ChainRoutingModel.hpp"
@@ -539,7 +540,7 @@ void PluginManager::syncTrackPlugins(TrackId trackId) {
 
     // Delete plugins outside lock to avoid blocking other threads
     for (size_t i = 0; i < toRemove.size(); ++i) {
-        const auto devicePath = toRemove[i];
+        const auto& devicePath = toRemove[i];
         const auto deviceId = devicePath.getDeviceId();
         pluginWindowBridge_.closeWindowsForDevice(deviceId);
 
@@ -1243,7 +1244,8 @@ te::Plugin::Ptr PluginManager::addLevelMeterToTrack(TrackId trackId) {
     return plugin;
 }
 
-void PluginManager::pollAsyncPluginLoad(const ChainNodePath& devicePath, te::Plugin::Ptr plugin) {
+void PluginManager::pollAsyncPluginLoad(const ChainNodePath& devicePath,
+                                        const te::Plugin::Ptr& plugin) {
     auto* extPlugin = dynamic_cast<te::ExternalPlugin*>(plugin.get());
     if (!extPlugin)
         return;
@@ -2173,13 +2175,13 @@ te::Plugin::Ptr PluginManager::createPluginOnly(TrackId trackId, const DeviceInf
 
 void PluginManager::registerRackPluginProcessor(const ChainNodePath& devicePath,
                                                 te::Plugin::Ptr plugin, const DeviceInfo& device) {
-    registerRackPluginProcessor(devicePath, plugin, device,
+    registerRackPluginProcessor(devicePath, std::move(plugin), device,
                                 TrackManager::getInstance().getDeviceInChainByPath(devicePath));
 }
 
 void PluginManager::registerRackPluginProcessor(const ChainNodePath& devicePath,
-                                                te::Plugin::Ptr plugin, const DeviceInfo& device,
-                                                DeviceInfo* canonical) {
+                                                const te::Plugin::Ptr& plugin,
+                                                const DeviceInfo& device, DeviceInfo* canonical) {
     const auto deviceId = devicePath.getDeviceId();
     if (!plugin)
         return;
@@ -2731,7 +2733,7 @@ std::vector<std::pair<ChainNodePath, daw::audio::DrumGridPlugin*>> PluginManager
         if (sd.trackId != trackId)
             continue;
         if (auto* dg = dynamic_cast<daw::audio::DrumGridPlugin*>(sd.plugin.get()))
-            drumGrids.push_back({devicePath, dg});
+            drumGrids.emplace_back(devicePath, dg);
     }
 
     return drumGrids;

--- a/magda/daw/audio/plugin_manager/PluginManagerSync.cpp
+++ b/magda/daw/audio/plugin_manager/PluginManagerSync.cpp
@@ -253,13 +253,15 @@ bool savedPluginStateMatchesRequestedType(const juce::ValueTree& savedState,
     if (savedType.equalsIgnoreCase(requestedType))
         return true;
 
-    if (auto* requestedCompiled = daw::audio::compiled::findCompiledPluginSpec(requestedType)) {
-        auto* savedCompiled = daw::audio::compiled::findCompiledPluginSpec(savedType);
+    if (const auto* requestedCompiled =
+            daw::audio::compiled::findCompiledPluginSpec(requestedType)) {
+        const auto* savedCompiled = daw::audio::compiled::findCompiledPluginSpec(savedType);
         return savedCompiled == requestedCompiled;
     }
 
-    if (auto* requestedInternal = daw::audio::findInternalPluginSpecForLoadType(requestedType)) {
-        auto* savedInternal = daw::audio::findInternalPluginSpecForLoadType(savedType);
+    if (const auto* requestedInternal =
+            daw::audio::findInternalPluginSpecForLoadType(requestedType)) {
+        const auto* savedInternal = daw::audio::findInternalPluginSpecForLoadType(savedType);
         return savedInternal == requestedInternal;
     }
 
@@ -759,7 +761,7 @@ void PluginManager::syncTrackPlugins(TrackId trackId) {
     syncDeviceModifiers(trackId, teTrack->getModifierList(),
                         &teTrack->getMacroParameterListForWriting(),
                         [teTrack](const std::function<void(te::Plugin*)>& visit) {
-                            for (auto plugin : teTrack->pluginList) {
+                            for (auto* plugin : teTrack->pluginList) {
                                 if (plugin)
                                     visit(plugin);
                             }
@@ -1107,13 +1109,13 @@ te::Plugin::Ptr PluginManager::loadBuiltInPlugin(TrackId trackId, const juce::St
 
     te::Plugin::Ptr plugin;
 
-    if (auto* spec = daw::audio::compiled::findCompiledPluginSpec(type)) {
+    if (const auto* spec = daw::audio::compiled::findCompiledPluginSpec(type)) {
         juce::ValueTree pluginState(te::IDs::PLUGIN);
         pluginState.setProperty(te::IDs::type, spec->pluginId, nullptr);
         plugin = edit_.getPluginCache().createNewPlugin(pluginState);
         if (plugin)
             track->pluginList.insertPlugin(plugin, -1, nullptr);
-    } else if (auto* spec = daw::audio::findInternalPluginSpecForLoadType(type)) {
+    } else if (const auto* spec = daw::audio::findInternalPluginSpecForLoadType(type)) {
         if (spec->canCreateOnTrack) {
             plugin = daw::audio::tracktion_adapter::createInternalPlugin(*spec, edit_);
             if (plugin)
@@ -1377,7 +1379,7 @@ void PluginManager::reconcileSends(const TrackInfo& trackInfo, te::AudioTrack& t
     // appendStripOrder could not show, because it can only order plugins that
     // are already there.
     std::vector<int> existingSendBuses;
-    for (auto i : track.pluginList)
+    for (auto* i : track.pluginList)
         if (auto* auxSend = dynamic_cast<te::AuxSendPlugin*>(i))
             existingSendBuses.push_back(auxSend->getBusNumber());
 
@@ -1413,7 +1415,7 @@ void PluginManager::reconcileSends(const TrackInfo& trackInfo, te::AudioTrack& t
     }
 
     for (const auto& send : trackInfo.sends) {
-        for (auto i : track.pluginList) {
+        for (auto* i : track.pluginList) {
             if (auto* auxSend = dynamic_cast<te::AuxSendPlugin*>(i);
                 auxSend != nullptr && auxSend->getBusNumber() == send.busIndex) {
                 auxSend->setGainDb(juce::Decibels::gainToDecibels(send.level));
@@ -1467,7 +1469,7 @@ void PluginManager::appendStripOrder(TrackId trackId, const TrackInfo& trackInfo
                 auto* aux = dynamic_cast<te::AuxSendPlugin*>(p);
                 return aux != nullptr && aux->getBusNumber() == busIndex;
             };
-            const auto found = std::ranges::find_if(track.pluginList, matchesBus);
+            auto* const found = std::ranges::find_if(track.pluginList, matchesBus);
             if (found != track.pluginList.end())
                 desiredOrder.push_back(*found);
         }
@@ -1527,7 +1529,7 @@ void PluginManager::ensureVolumePluginPosition(TrackId trackId, te::AudioTrack* 
     const auto isPostFader = [volPanRaw, &postFaderPlugins](auto* p) {
         return p != volPanRaw && postFaderPlugins.count(p) != 0;
     };
-    const auto firstPostFaderIt = std::ranges::find_if(plugins, isPostFader);
+    auto* const firstPostFaderIt = std::ranges::find_if(plugins, isPostFader);
     const int firstPostFader =
         firstPostFaderIt == plugins.end() ? -1 : plugins.indexOf(*firstPostFaderIt);
 
@@ -1593,7 +1595,7 @@ std::unordered_set<te::Plugin*> PluginManager::collectPostFaderPlugins(
     for (const auto& send : trackInfo->sends) {
         if (send.preFader)
             continue;
-        for (auto i : track.pluginList)
+        for (auto* i : track.pluginList)
             if (auto* aux = dynamic_cast<te::AuxSendPlugin*>(i);
                 aux != nullptr && aux->getBusNumber() == send.busIndex)
                 result.insert(aux);
@@ -1920,7 +1922,7 @@ void PluginManager::syncMasterPlugins() {
         deferredHolders_.clear();  // Drain previous cycle's deferred holders
         std::vector<te::Plugin*> scopePlugins;
         scopePlugins.reserve(masterList.size());
-        for (auto plugin : masterList) {
+        for (auto* plugin : masterList) {
             if (plugin)
                 scopePlugins.push_back(plugin);
         }
@@ -2099,9 +2101,10 @@ te::Plugin::Ptr PluginManager::createPluginOnly(TrackId trackId, const DeviceInf
     if (device.format == PluginFormat::Internal) {
         const auto& ps = device.pluginState;
 
-        if (auto* compiledSpec = daw::audio::compiled::findCompiledPluginSpec(device.pluginId)) {
+        if (const auto* compiledSpec =
+                daw::audio::compiled::findCompiledPluginSpec(device.pluginId)) {
             plugin = createInternalPlugin(compiledSpec->pluginId, ps);
-        } else if (auto* internalSpec = daw::audio::findInternalPluginSpec(device.pluginId)) {
+        } else if (const auto* internalSpec = daw::audio::findInternalPluginSpec(device.pluginId)) {
             if (internalSpec->canCreateDetached)
                 plugin =
                     daw::audio::tracktion_adapter::createInternalPlugin(*internalSpec, edit_, ps);
@@ -2261,11 +2264,12 @@ te::Plugin::Ptr PluginManager::loadDeviceAsPlugin(const ChainNodePath& devicePat
     std::unique_ptr<DeviceProcessor> processor;
 
     if (device.format == PluginFormat::Internal) {
-        if (auto* compiledSpec = daw::audio::compiled::findCompiledPluginSpec(device.pluginId)) {
+        if (const auto* compiledSpec =
+                daw::audio::compiled::findCompiledPluginSpec(device.pluginId)) {
             plugin = createInternalPlugin(compiledSpec->pluginId, device.pluginState);
             if (plugin)
                 track->pluginList.insertPlugin(plugin, insertIndex, nullptr);
-        } else if (auto* internalSpec = daw::audio::findInternalPluginSpec(device.pluginId)) {
+        } else if (const auto* internalSpec = daw::audio::findInternalPluginSpec(device.pluginId)) {
             if (internalSpec->canCreateOnTrack) {
                 plugin = daw::audio::tracktion_adapter::createInternalPlugin(*internalSpec, edit_,
                                                                              device.pluginState);

--- a/magda/daw/audio/plugins/AudioSidechainMonitorPlugin.cpp
+++ b/magda/daw/audio/plugins/AudioSidechainMonitorPlugin.cpp
@@ -8,7 +8,7 @@ const char* AudioSidechainMonitorPlugin::xmlTypeName = "audiosidechainmonitor";
 
 AudioSidechainMonitorPlugin::AudioSidechainMonitorPlugin(const te::PluginCreationInfo& info)
     : te::Plugin(info) {
-    auto um = getUndoManager();
+    auto* um = getUndoManager();
     sourceTrackIdValue.referTo(state, juce::Identifier("sourceTrackId"), um, INVALID_TRACK_ID);
     sourceTrackId_ = sourceTrackIdValue.get();
 }

--- a/magda/daw/audio/plugins/BaseDevicePack.cpp
+++ b/magda/daw/audio/plugins/BaseDevicePack.cpp
@@ -161,7 +161,7 @@ DevicePluginPtr createLevelMeterPlugin(const InternalPluginSpec&, DeviceSessionK
 }
 
 void add(InternalPluginRegistry& registry, InternalPluginSpec spec) {
-    const bool registered = registry.registerPlugin(std::move(spec));
+    const bool registered = registry.registerPlugin(spec);
     jassert(registered);
     juce::ignoreUnused(registered);
 }

--- a/magda/daw/audio/plugins/DrumGridPlugin.cpp
+++ b/magda/daw/audio/plugins/DrumGridPlugin.cpp
@@ -245,7 +245,7 @@ void DrumGridPlugin::processChain(const AudioChainEntry& entry,
     chainMidi_.clear();
     chainMidi_.isAllNotesOff = inputMidi.isAllNotesOff;
 
-    for (auto& msg : inputMidi) {
+    for (const auto& msg : inputMidi) {
         if (msg.isNoteOnOrOff()) {
             int note = msg.getNoteNumber();
             if (note >= lowNote && note <= entry.highNote) {
@@ -614,7 +614,7 @@ const std::vector<std::unique_ptr<DrumGridPlugin::Chain>>& DrumGridPlugin::getCh
 }
 
 int DrumGridPlugin::getPluginDeviceId(int chainIndex, int pluginIndex) const {
-    auto* chain = getChainByIndex(chainIndex);
+    const auto* chain = getChainByIndex(chainIndex);
     if (!chain || pluginIndex < 0 || pluginIndex >= static_cast<int>(chain->plugins.size()))
         return -1;
     return chain->plugins[static_cast<size_t>(pluginIndex)]->state.getProperty(pluginDeviceIdProp,
@@ -646,13 +646,13 @@ DrumGridPlugin::Chain* DrumGridPlugin::getChainByIndexMutable(int chainIndex) {
 }
 
 int DrumGridPlugin::getChainPluginCount(int chainIndex) const {
-    if (auto* chain = getChainByIndex(chainIndex))
+    if (const auto* chain = getChainByIndex(chainIndex))
         return static_cast<int>(chain->plugins.size());
     return 0;
 }
 
 te::Plugin* DrumGridPlugin::getChainPlugin(int chainIndex, int pluginIndex) const {
-    if (auto* chain = getChainByIndex(chainIndex)) {
+    if (const auto* chain = getChainByIndex(chainIndex)) {
         if (pluginIndex >= 0 && pluginIndex < static_cast<int>(chain->plugins.size()))
             return chain->plugins[static_cast<size_t>(pluginIndex)].get();
     }
@@ -667,7 +667,7 @@ int DrumGridPlugin::getPadPluginCount(int padIndex) const {
     if (padIndex < 0 || padIndex >= maxPads)
         return 0;
     int midiNote = baseNote + padIndex;
-    if (auto* chain = getChainForNote(midiNote))
+    if (const auto* chain = getChainForNote(midiNote))
         return static_cast<int>(chain->plugins.size());
     return 0;
 }
@@ -676,7 +676,7 @@ te::Plugin* DrumGridPlugin::getPadPlugin(int padIndex, int pluginIndex) const {
     if (padIndex < 0 || padIndex >= maxPads)
         return nullptr;
     int midiNote = baseNote + padIndex;
-    if (auto* chain = getChainForNote(midiNote)) {
+    if (const auto* chain = getChainForNote(midiNote)) {
         if (pluginIndex >= 0 && pluginIndex < static_cast<int>(chain->plugins.size()))
             return chain->plugins[static_cast<size_t>(pluginIndex)].get();
     }
@@ -695,7 +695,7 @@ bool DrumGridPlugin::consumePadTrigger(int padIndex) {
 }
 
 std::pair<float, float> DrumGridPlugin::consumeChainPeak(int chainIndex) {
-    auto* chain = getChainByIndex(chainIndex);
+    const auto* chain = getChainByIndex(chainIndex);
     if (!chain)
         return {0.0f, 0.0f};
     int padIdx = padIndexFor(*chain);
@@ -708,7 +708,7 @@ std::pair<float, float> DrumGridPlugin::consumeChainPeak(int chainIndex) {
 }
 
 float DrumGridPlugin::getChainPluginGain(int chainIndex, int pluginIndex) const {
-    auto* chain = getChainByIndex(chainIndex);
+    const auto* chain = getChainByIndex(chainIndex);
     if (!chain || pluginIndex < 0 || pluginIndex >= static_cast<int>(chain->pluginGains.size()))
         return 1.0f;
     return chain->pluginGains[static_cast<size_t>(pluginIndex)];
@@ -717,7 +717,7 @@ float DrumGridPlugin::getChainPluginGain(int chainIndex, int pluginIndex) const 
 std::pair<float, float> DrumGridPlugin::consumeChainPluginPeak(int chainIndex, int pluginIndex) {
     if (pluginIndex < 0 || pluginIndex >= maxFxPerChain)
         return {0.0f, 0.0f};
-    auto* chain = getChainByIndex(chainIndex);
+    const auto* chain = getChainByIndex(chainIndex);
     if (!chain)
         return {0.0f, 0.0f};
     int padIdx = padIndexFor(*chain);

--- a/magda/daw/audio/plugins/DrumGridPlugin.hpp
+++ b/magda/daw/audio/plugins/DrumGridPlugin.hpp
@@ -207,7 +207,7 @@ class DrumGridPlugin : public te::Plugin, private juce::Timer {
     // multi-out child track. There is no second switch in front of that: the
     // `multiOutEnabled` flag that used to be here gated `assignBusOutputs()`,
     // which #2207 removed, and nothing ever wrote or read either (#2211).
-    int getNumOutputChannels() const {
+    static int getNumOutputChannels() {
         return maxBusOutputs * 2;
     }
 
@@ -308,7 +308,7 @@ class DrumGridPlugin : public te::Plugin, private juce::Timer {
     // Runs on every pass: neither changes the structure the rebuild keys on.
     // Returns true when a gain moved, which the published snapshot carries and
     // so has to be republished.
-    bool applyPadPluginState(Chain& chain, const magda::ChainInfo& pad);
+    static bool applyPadPluginState(Chain& chain, const magda::ChainInfo& pad);
 
     // What the mirror was last built from, so a sync pass that changes nothing
     // does nothing. Structure only: pad ids, their devices, and the order of
@@ -350,7 +350,7 @@ class DrumGridPlugin : public te::Plugin, private juce::Timer {
     int blockSize_ = 512;
 
     // Internal helper: pad-array index for a chain (lowNote - baseNote), or -1 if out of range
-    int padIndexFor(const Chain& chain) const {
+    static int padIndexFor(const Chain& chain) {
         int p = chain.lowNote - baseNote;
         return (p >= 0 && p < maxPads) ? p : -1;
     }

--- a/magda/daw/audio/plugins/FaustInstrumentPlugin.hpp
+++ b/magda/daw/audio/plugins/FaustInstrumentPlugin.hpp
@@ -208,7 +208,7 @@ class FaustInstrumentPlugin : public MagdaDevice, public IFaustEditorModel {
     // Rewrite every sounding poly voice's freq zone for `ratio`. The allocator
     // writes an unbent freq on keyOn, so this also has to run after a note
     // starts, not only when the wheel moves.
-    void applyBendToPolyVoices(const std::shared_ptr<FaustState>& state, float ratio);
+    static void applyBendToPolyVoices(const std::shared_ptr<FaustState>& state, float ratio);
     // Silence everything: poly voices, the mono voice, and the held-note stack.
     void resetAllVoices(const std::shared_ptr<FaustState>& state);
     // Release EVERY poly voice sounding (or legato-targeting) this pitch.
@@ -217,7 +217,7 @@ class FaustInstrumentPlugin : public MagdaDevice, public IFaustEditorModel {
     // self-heals orphans. Duplicate on/off streams for one pitch are legitimate
     // - a freshly recorded clip playing back while the live input that fed it
     // is still monitored - so an unbalanced delivery must never strand a voice.
-    void releasePolyVoicesForPitch(const std::shared_ptr<FaustState>& state, int pitch);
+    static void releasePolyVoicesForPitch(const std::shared_ptr<FaustState>& state, int pitch);
     // Returns true when the caller must render one sample of gate-low before
     // raising the gate again, which is how Mono retriggers an envelope.
     bool handleMonoNoteOn(const std::shared_ptr<FaustState>& state, int note, int velocity,

--- a/magda/daw/audio/plugins/FaustParamInfo.cpp
+++ b/magda/daw/audio/plugins/FaustParamInfo.cpp
@@ -157,7 +157,7 @@ magda::ParameterInfo discreteInfo(const FaustParamSlot& slot) {
         // an empty choice list for a menu/radio style, but if it does
         // we degrade to a single "(empty)" option so the slot is still
         // selectable.
-        info.choices.push_back("(empty)");
+        info.choices.emplace_back("(empty)");
     }
     info.minValue = 0.0f;
     info.maxValue = static_cast<float>(info.choices.size() - 1);

--- a/magda/daw/audio/plugins/FollowerSourceTapPlugin.cpp
+++ b/magda/daw/audio/plugins/FollowerSourceTapPlugin.cpp
@@ -6,7 +6,7 @@ const char* FollowerSourceTapPlugin::xmlTypeName = "followersourcetap";
 
 FollowerSourceTapPlugin::FollowerSourceTapPlugin(const te::PluginCreationInfo& info)
     : te::Plugin(info) {
-    auto um = getUndoManager();
+    auto* um = getUndoManager();
     sourceTrackIdValue.referTo(state, juce::Identifier("sourceTrackId"), um, INVALID_TRACK_ID);
     sourceTrackId_ = sourceTrackIdValue.get();
 }

--- a/magda/daw/audio/plugins/InternalPluginRegistry.cpp
+++ b/magda/daw/audio/plugins/InternalPluginRegistry.cpp
@@ -57,7 +57,7 @@ bool InternalPluginRegistry::registerPlugin(InternalPluginSpec spec) {
             return false;
     }
 
-    auto owned = std::make_unique<InternalPluginSpec>(std::move(spec));
+    auto owned = std::make_unique<InternalPluginSpec>(spec);
     pointers_.push_back(owned.get());
     specs_.push_back(std::move(owned));
     return true;

--- a/magda/daw/audio/plugins/MidiChordEnginePlugin.cpp
+++ b/magda/daw/audio/plugins/MidiChordEnginePlugin.cpp
@@ -234,7 +234,7 @@ void MidiChordEnginePlugin::runDetection() {
 
     for (int i = 0; i < count; ++i) {
         int noteNum = heldNotes_[static_cast<size_t>(i)].load(std::memory_order_relaxed);
-        heldNotes.push_back({noteNum, 100});
+        heldNotes.emplace_back(noteNum, 100);
     }
 
     if (heldNotes.empty()) {

--- a/magda/daw/audio/plugins/MidiReceivePlugin.cpp
+++ b/magda/daw/audio/plugins/MidiReceivePlugin.cpp
@@ -9,7 +9,7 @@ const char* MidiReceivePlugin::xmlTypeName = "midireceive";
 MidiReceivePlugin::MidiReceivePlugin(const te::PluginCreationInfo& info,
                                      const daw::audio::DevicePluginDefaults::MidiReceive& defaults)
     : te::Plugin(info) {
-    auto um = getUndoManager();
+    auto* um = getUndoManager();
     sourceTrackIdValue.referTo(state, juce::Identifier("sourceTrackId"), um,
                                defaults.sourceTrackId);
     replaceExistingMidiValue.referTo(state, juce::Identifier("replaceExistingMidi"), um,

--- a/magda/daw/audio/plugins/MidiStrumPlugin.cpp
+++ b/magda/daw/audio/plugins/MidiStrumPlugin.cpp
@@ -302,8 +302,8 @@ void MidiStrumPlugin::scheduleStrum() {
     // between them, and one hung voice each (#2363).
     scheduleReleaseAll();
 
-    auto begin = ordered_.begin();
-    auto end = begin + heldCount_;
+    auto* begin = ordered_.begin();
+    auto* end = begin + heldCount_;
     std::copy(held_.begin(), held_.begin() + heldCount_, begin);
 
     const int ord = displayIndex(kOrder);

--- a/magda/daw/audio/plugins/SidechainMonitorPlugin.cpp
+++ b/magda/daw/audio/plugins/SidechainMonitorPlugin.cpp
@@ -9,7 +9,7 @@ const char* SidechainMonitorPlugin::xmlTypeName = "midisidechainmonitor";
 
 SidechainMonitorPlugin::SidechainMonitorPlugin(const te::PluginCreationInfo& info)
     : te::Plugin(info) {
-    auto um = getUndoManager();
+    auto* um = getUndoManager();
     sourceTrackIdValue.referTo(state, juce::Identifier("sourceTrackId"), um, INVALID_TRACK_ID);
     sourceTrackId_ = sourceTrackIdValue.get();
 }

--- a/magda/daw/audio/plugins/SidechainPlugin.cpp
+++ b/magda/daw/audio/plugins/SidechainPlugin.cpp
@@ -140,7 +140,7 @@ void SidechainPlugin::process(DeviceProcessContext& context) {
 
     const int numChannels = context.audio->getNumChannels();
     const int numSamples = context.numSamples;
-    auto channels = context.audio->getArrayOfWritePointers();
+    const auto* channels = context.audio->getArrayOfWritePointers();
     const int offset = context.startSample;
 
     // The modifier writes the gain target at a coarse quantum (one hop per

--- a/magda/daw/audio/plugins/compiled/CompiledFaustInterface.hpp
+++ b/magda/daw/audio/plugins/compiled/CompiledFaustInterface.hpp
@@ -88,6 +88,7 @@ class CompiledParameterValue {
 
     CompiledParameterValue(const CompiledParameterValue& other) : value_(other.getCurrentValue()) {}
 
+    // NOLINTNEXTLINE(cert-oop54-cpp) - self-assignment reloads and stores the same value
     CompiledParameterValue& operator=(const CompiledParameterValue& other) {
         setCurrentValue(other.getCurrentValue());
         return *this;

--- a/magda/daw/audio/plugins/compiled/CompiledPluginRegistry.cpp
+++ b/magda/daw/audio/plugins/compiled/CompiledPluginRegistry.cpp
@@ -80,7 +80,7 @@ const CompiledPluginSpec* findCompiledPluginSpec(const juce::String& pluginId) {
         return std::ranges::any_of(std::views::iota(0, std::max(0, spec->loadAliasCount)),
                                    matchesLoadAlias);
     };
-    const auto found = std::ranges::find_if(kAllSpecs, matchesSpec);
+    const auto* const found = std::ranges::find_if(kAllSpecs, matchesSpec);
     return found == std::end(kAllSpecs) ? nullptr : *found;
 }
 

--- a/magda/daw/audio/plugins/compiled/MagdaFilterCompiledPlugin.cpp
+++ b/magda/daw/audio/plugins/compiled/MagdaFilterCompiledPlugin.cpp
@@ -124,7 +124,7 @@ int MagdaFilterCompiledPlugin::slotForDspIdx(int idx) const {
     }
 }
 
-std::vector<juce::String> MagdaFilterCompiledPlugin::modeChoicesForEngine(int engineIndex) const {
+std::vector<juce::String> MagdaFilterCompiledPlugin::modeChoicesForEngine(int engineIndex) {
     switch (static_cast<FilterFamily>(engineIndex)) {
         case FilterFamily::SVF:
             return {"LP", "BP", "HP", "Notch"};

--- a/magda/daw/audio/plugins/compiled/MagdaFilterCompiledPlugin.hpp
+++ b/magda/daw/audio/plugins/compiled/MagdaFilterCompiledPlugin.hpp
@@ -49,7 +49,7 @@ class MagdaFilterCompiledPlugin : public MagdaCompiledEffect {
     /// The modes @p engineIndex can actually produce. Each family's Faust
     /// source declares only its own set, and the host's dropdown mirrors that
     /// so it never offers a mode with no branch behind it.
-    std::vector<juce::String> modeChoicesForEngine(int engineIndex) const;
+    static std::vector<juce::String> modeChoicesForEngine(int engineIndex);
 
     int engineAwareModeSlot() const override {
         return kModeSlot;

--- a/magda/daw/audio/plugins/compiled/tracktion/CompiledFaustTracktionAdapter.cpp
+++ b/magda/daw/audio/plugins/compiled/tracktion/CompiledFaustTracktionAdapter.cpp
@@ -38,7 +38,7 @@ te::AutomatableParameter* tracktionParameterForSlot(te::Plugin* plugin, int slot
 
 std::unique_ptr<magda::DeviceProcessor> createTracktionProcessor(const CompiledPluginSpec& spec,
                                                                  DeviceId deviceId,
-                                                                 te::Plugin::Ptr plugin) {
+                                                                 const te::Plugin::Ptr& plugin) {
     juce::ignoreUnused(spec);
 
     if (tracktion_adapter::deviceFromPlugin<ICompiledFaustPlugin>(plugin.get()) == nullptr)

--- a/magda/daw/audio/plugins/compiled/tracktion/CompiledFaustTracktionAdapter.hpp
+++ b/magda/daw/audio/plugins/compiled/tracktion/CompiledFaustTracktionAdapter.hpp
@@ -28,6 +28,6 @@ te::AutomatableParameter* tracktionParameterForSlot(te::Plugin* plugin, int slot
 
 std::unique_ptr<magda::DeviceProcessor> createTracktionProcessor(const CompiledPluginSpec& spec,
                                                                  DeviceId deviceId,
-                                                                 te::Plugin::Ptr plugin);
+                                                                 const te::Plugin::Ptr& plugin);
 
 }  // namespace magda::daw::audio::compiled

--- a/magda/daw/audio/plugins/tracktion/TracktionMagdaDevicePlugin.cpp
+++ b/magda/daw/audio/plugins/tracktion/TracktionMagdaDevicePlugin.cpp
@@ -57,7 +57,7 @@ class DeviceParameter final : public te::AutomatableParameter {
     DeviceParameter(const juce::String& paramID, const juce::String& name, te::Plugin& plugin,
                     juce::NormalisableRange<float> range,
                     std::shared_ptr<MagdaDevice*> deviceHandle, int index)
-        : te::AutomatableParameter(paramID, name, plugin, range),
+        : te::AutomatableParameter(paramID, name, plugin, std::move(range)),
           deviceHandle_(std::move(deviceHandle)),
           index_(index) {}
 

--- a/magda/daw/audio/plugins/tracktion/TracktionMagdaDevicePlugin.hpp
+++ b/magda/daw/audio/plugins/tracktion/TracktionMagdaDevicePlugin.hpp
@@ -99,7 +99,7 @@ template <typename DeviceType> const DeviceType* deviceFromPlugin(const te::Plug
     if (auto* device = dynamic_cast<const DeviceType*>(plugin))
         return device;
 
-    const const const const auto* adapter = dynamic_cast<const TracktionMagdaDevicePlugin*>(plugin);
+    const auto* adapter = dynamic_cast<const TracktionMagdaDevicePlugin*>(plugin);
     return adapter != nullptr ? dynamic_cast<const DeviceType*>(&adapter->device()) : nullptr;
 }
 

--- a/magda/daw/audio/plugins/tracktion/TracktionMagdaDevicePlugin.hpp
+++ b/magda/daw/audio/plugins/tracktion/TracktionMagdaDevicePlugin.hpp
@@ -99,7 +99,7 @@ template <typename DeviceType> const DeviceType* deviceFromPlugin(const te::Plug
     if (auto* device = dynamic_cast<const DeviceType*>(plugin))
         return device;
 
-    auto* adapter = dynamic_cast<const TracktionMagdaDevicePlugin*>(plugin);
+    const const const const auto* adapter = dynamic_cast<const TracktionMagdaDevicePlugin*>(plugin);
     return adapter != nullptr ? dynamic_cast<const DeviceType*>(&adapter->device()) : nullptr;
 }
 

--- a/magda/daw/audio/processors/CompiledFaustProcessor.cpp
+++ b/magda/daw/audio/processors/CompiledFaustProcessor.cpp
@@ -19,7 +19,7 @@ auto* compiledDevice(te::Plugin* plugin) {
 }  // namespace
 
 CompiledFaustProcessor::CompiledFaustProcessor(DeviceId deviceId, te::Plugin::Ptr plugin)
-    : DeviceProcessor(deviceId, plugin) {}
+    : DeviceProcessor(deviceId, std::move(plugin)) {}
 
 int CompiledFaustProcessor::getParameterCount() const {
     const auto* host = compiledDevice(plugin_.get());

--- a/magda/daw/audio/processors/DeviceProcessorFactory.cpp
+++ b/magda/daw/audio/processors/DeviceProcessorFactory.cpp
@@ -23,10 +23,10 @@ std::unique_ptr<DeviceProcessor> createDeviceProcessorForPlugin(
         return processor;
     }
 
-    if (auto* compiledSpec = daw::audio::compiled::findCompiledPluginSpec(pluginId))
+    if (const auto* compiledSpec = daw::audio::compiled::findCompiledPluginSpec(pluginId))
         return daw::audio::compiled::createTracktionProcessor(*compiledSpec, deviceId, plugin);
 
-    if (auto* internalSpec = daw::audio::findInternalPluginSpec(pluginId))
+    if (const auto* internalSpec = daw::audio::findInternalPluginSpec(pluginId))
         return daw::audio::tracktion_adapter::createInternalPluginProcessor(
             *internalSpec, deviceId, daw::audio::tracktion_adapter::pluginHandle(plugin));
 

--- a/magda/daw/audio/processors/DeviceProcessorFactory.cpp
+++ b/magda/daw/audio/processors/DeviceProcessorFactory.cpp
@@ -11,7 +11,7 @@
 namespace magda {
 
 std::unique_ptr<DeviceProcessor> createDeviceProcessorForPlugin(
-    DeviceId deviceId, tracktion::engine::Plugin::Ptr plugin, const juce::String& pluginId,
+    DeviceId deviceId, const tracktion::engine::Plugin::Ptr& plugin, const juce::String& pluginId,
     daw::audio::DeviceTrackContext* trackContext) {
     if (!plugin)
         return nullptr;

--- a/magda/daw/audio/processors/DeviceProcessorFactory.hpp
+++ b/magda/daw/audio/processors/DeviceProcessorFactory.hpp
@@ -12,7 +12,7 @@ namespace magda {
 class DeviceProcessor;
 
 std::unique_ptr<DeviceProcessor> createDeviceProcessorForPlugin(
-    DeviceId deviceId, tracktion::engine::Plugin::Ptr plugin, const juce::String& pluginId,
+    DeviceId deviceId, const tracktion::engine::Plugin::Ptr& plugin, const juce::String& pluginId,
     daw::audio::DeviceTrackContext* trackContext = nullptr);
 
 }  // namespace magda

--- a/magda/daw/audio/racks/InstrumentRackManager.cpp
+++ b/magda/daw/audio/racks/InstrumentRackManager.cpp
@@ -1,5 +1,7 @@
 #include "racks/InstrumentRackManager.hpp"
 
+#include <utility>
+
 #include "plugins/InstrumentMeterTapPlugin.hpp"
 
 namespace magda {
@@ -13,7 +15,7 @@ te::Plugin::Ptr createMeterTapPlugin(te::Edit& edit) {
     return edit.getPluginCache().createNewPlugin(pluginState);
 }
 
-te::Plugin::Ptr findMeterTapPlugin(te::RackType::Ptr rackType) {
+te::Plugin::Ptr findMeterTapPlugin(const te::RackType::Ptr& rackType) {
     if (!rackType)
         return nullptr;
 
@@ -29,7 +31,7 @@ te::Plugin::Ptr findMeterTapPlugin(te::RackType::Ptr rackType) {
 
 InstrumentRackManager::InstrumentRackManager(te::Edit& edit) : edit_(edit) {}
 
-te::Plugin::Ptr InstrumentRackManager::wrapInstrument(te::Plugin::Ptr instrument,
+te::Plugin::Ptr InstrumentRackManager::wrapInstrument(const te::Plugin::Ptr& instrument,
                                                       const routing::ChainRoutingNode& routing) {
     if (!instrument) {
         return nullptr;
@@ -125,7 +127,8 @@ te::Plugin::Ptr InstrumentRackManager::wrapInstrument(te::Plugin::Ptr instrument
 }
 
 te::Plugin::Ptr InstrumentRackManager::wrapMultiOutInstrument(
-    te::Plugin::Ptr instrument, int numOutputChannels, const routing::ChainRoutingNode& routing) {
+    const te::Plugin::Ptr& instrument, int numOutputChannels,
+    const routing::ChainRoutingNode& routing) {
     if (!instrument || numOutputChannels <= 2) {
         return wrapInstrument(instrument, routing);  // Fallback to normal wrapping
     }
@@ -311,8 +314,9 @@ void InstrumentRackManager::unwrap(DeviceId deviceId) {
 }
 
 void InstrumentRackManager::recordWrapping(const ChainNodePath& devicePath,
-                                           te::RackType::Ptr rackType, te::Plugin::Ptr innerPlugin,
-                                           te::Plugin::Ptr rackInstance, bool isMultiOut,
+                                           const te::RackType::Ptr& rackType,
+                                           te::Plugin::Ptr innerPlugin,
+                                           const te::Plugin::Ptr& rackInstance, bool isMultiOut,
                                            int numOutputChannels) {
     const auto deviceId = devicePath.getDeviceId();
     te::Plugin::Ptr meterTap;
@@ -335,8 +339,9 @@ void InstrumentRackManager::recordWrapping(const ChainNodePath& devicePath,
             << deviceId);
     }
 
-    wrapped_[deviceId] = {rackType,          innerPlugin, rackInstance, meterTap, isMultiOut,
-                          numOutputChannels, {}};
+    wrapped_[deviceId] = {
+        rackType, std::move(innerPlugin), rackInstance, meterTap, isMultiOut, numOutputChannels,
+        {}};
 }
 
 te::Plugin* InstrumentRackManager::getInnerPlugin(DeviceId deviceId) const {

--- a/magda/daw/audio/racks/InstrumentRackManager.hpp
+++ b/magda/daw/audio/racks/InstrumentRackManager.hpp
@@ -43,7 +43,7 @@ class InstrumentRackManager {
      *                wired (see the class comment).
      * @return The RackInstance plugin to insert on the track (or nullptr on failure)
      */
-    te::Plugin::Ptr wrapInstrument(te::Plugin::Ptr instrument,
+    te::Plugin::Ptr wrapInstrument(const te::Plugin::Ptr& instrument,
                                    const routing::ChainRoutingNode& routing);
 
     /**
@@ -53,7 +53,7 @@ class InstrumentRackManager {
      * @param routing See wrapInstrument().
      * @return The main RackInstance plugin (outputs 1,2) to insert on the track
      */
-    te::Plugin::Ptr wrapMultiOutInstrument(te::Plugin::Ptr instrument, int numOutputChannels,
+    te::Plugin::Ptr wrapMultiOutInstrument(const te::Plugin::Ptr& instrument, int numOutputChannels,
                                            const routing::ChainRoutingNode& routing);
 
     /**
@@ -85,8 +85,8 @@ class InstrumentRackManager {
      * @param innerPlugin The actual instrument plugin inside the rack
      * @param rackInstance The RackInstance plugin on the track
      */
-    void recordWrapping(const ChainNodePath& devicePath, te::RackType::Ptr rackType,
-                        te::Plugin::Ptr innerPlugin, te::Plugin::Ptr rackInstance,
+    void recordWrapping(const ChainNodePath& devicePath, const te::RackType::Ptr& rackType,
+                        te::Plugin::Ptr innerPlugin, const te::Plugin::Ptr& rackInstance,
                         bool isMultiOut = false, int numOutputChannels = 2);
 
     /**

--- a/magda/daw/audio/racks/RackSyncManager.cpp
+++ b/magda/daw/audio/racks/RackSyncManager.cpp
@@ -70,7 +70,7 @@ te::Plugin* findRackPlugin(te::RackType& rackType, te::EditItemID id) {
     const auto matchesId = [id](const te::Plugin* plugin) {
         return plugin && plugin->itemID == id;
     };
-    const auto found = std::ranges::find_if(plugins, matchesId);
+    const auto* const found = std::ranges::find_if(plugins, matchesId);
     return found == plugins.end() ? nullptr : *found;
 }
 
@@ -203,7 +203,7 @@ void RackSyncManager::resyncRack(TrackId trackId, const RackInfo& rackInfo) {
     {
         auto connections = rackType->getConnections();
         for (int i = connections.size(); --i >= 0;) {
-            auto* conn = connections[i];
+            const auto* conn = connections[i];
             rackType->removeConnection(conn->sourceID, conn->sourcePin, conn->destID,
                                        conn->destPin);
         }
@@ -650,7 +650,7 @@ te::AutomatableParameter* RackSyncManager::findRackModifierParameter(RackId rack
     const auto matchesParamId = [&wantedID](const te::AutomatableParameter* p) {
         return p && p->paramID == wantedID;
     };
-    const auto foundParam = std::ranges::find_if(params, matchesParamId);
+    const auto* const foundParam = std::ranges::find_if(params, matchesParamId);
     return foundParam == params.end() ? nullptr : *foundParam;
 }
 
@@ -665,7 +665,7 @@ void RackSyncManager::resyncAllModifiers(TrackId trackId) {
             if (track.id != trackId)
                 continue;
             for (const auto& element : track.chain.fxChainElements) {
-                if (auto* rackPtr = std::get_if<std::unique_ptr<RackInfo>>(&element)) {
+                if (const auto* rackPtr = std::get_if<std::unique_ptr<RackInfo>>(&element)) {
                     if (!*rackPtr || (*rackPtr)->id != rackId)
                         continue;
                     const auto& rackInfo = **rackPtr;
@@ -704,7 +704,7 @@ void RackSyncManager::updateAllModifierProperties(TrackId trackId) {
             if (track.id != trackId)
                 continue;
             for (const auto& element : track.chain.fxChainElements) {
-                if (auto* rackPtr = std::get_if<std::unique_ptr<RackInfo>>(&element)) {
+                if (const auto* rackPtr = std::get_if<std::unique_ptr<RackInfo>>(&element)) {
                     if (!*rackPtr || (*rackPtr)->id != rackId)
                         continue;
                     updateRackModulationProperties(synced, **rackPtr);
@@ -1024,7 +1024,7 @@ void RackSyncManager::updateProperties(SyncedRack& synced, const RackInfo& rackI
         if (rackType) {
             auto connections = rackType->getConnections();
             for (int i = connections.size(); --i >= 0;) {
-                auto* conn = connections[i];
+                const auto* conn = connections[i];
                 rackType->removeConnection(conn->sourceID, conn->sourcePin, conn->destID,
                                            conn->destPin);
             }
@@ -1085,7 +1085,7 @@ void RackSyncManager::rebuildConnectionsRecursive(SyncedRack& synced, const Rack
 
             auto connections = typeIt->second->getConnections();
             for (int i = connections.size(); --i >= 0;) {
-                auto* conn = connections[i];
+                const auto* conn = connections[i];
                 typeIt->second->removeConnection(conn->sourceID, conn->sourcePin, conn->destID,
                                                  conn->destPin);
             }
@@ -1095,7 +1095,7 @@ void RackSyncManager::rebuildConnectionsRecursive(SyncedRack& synced, const Rack
 
     auto connections = rackType.getConnections();
     for (int i = connections.size(); --i >= 0;) {
-        auto* conn = connections[i];
+        const auto* conn = connections[i];
         rackType.removeConnection(conn->sourceID, conn->sourcePin, conn->destID, conn->destPin);
     }
     buildConnectionsForRack(synced, rackInfo, rackPath, rackType);

--- a/magda/daw/audio/racks/RackSyncManager.cpp
+++ b/magda/daw/audio/racks/RackSyncManager.cpp
@@ -35,7 +35,7 @@ std::pair<float, float> outputDbForVolumePan(float volumeDb, float pan) {
                                         static_cast<double>(rightDb)))};
 }
 
-void applyRackInstanceState(te::Plugin::Ptr rackPlugin, const RackInfo& rackInfo) {
+void applyRackInstanceState(const te::Plugin::Ptr& rackPlugin, const RackInfo& rackInfo) {
     auto* rackInstance = dynamic_cast<te::RackInstance*>(rackPlugin.get());
     if (!rackInstance)
         return;

--- a/magda/daw/audio/racks/RackSyncManager.cpp
+++ b/magda/daw/audio/racks/RackSyncManager.cpp
@@ -958,7 +958,7 @@ te::Plugin::Ptr RackSyncManager::createPluginForRack(TrackId trackId, const Devi
     return pluginManager_.createPluginOnly(trackId, device);
 }
 
-bool RackSyncManager::structureChanged(const SyncedRack& synced, const RackInfo& rackInfo) const {
+bool RackSyncManager::structureChanged(const SyncedRack& synced, const RackInfo& rackInfo) {
     std::set<juce::String> expectedChains;
     std::set<DeviceId> expectedDevices;
     std::set<juce::String> expectedNestedRacks;

--- a/magda/daw/audio/racks/RackSyncManager.hpp
+++ b/magda/daw/audio/racks/RackSyncManager.hpp
@@ -291,7 +291,7 @@ class RackSyncManager {
      * @brief Check if rack structure changed (devices/chains added/removed/reordered)
      * vs only properties changed (bypass, volume, mute/solo)
      */
-    bool structureChanged(const SyncedRack& synced, const RackInfo& rackInfo) const;
+    static bool structureChanged(const SyncedRack& synced, const RackInfo& rackInfo);
 
     /**
      * @brief Update only properties (bypass, volume, chain mute/solo) without rebuilding plugins
@@ -305,8 +305,8 @@ class RackSyncManager {
 
     void loadRackContents(SyncedRack& synced, TrackId trackId, const RackInfo& rackInfo,
                           const ChainNodePath& rackPath, te::RackType& rackType);
-    void buildConnectionsForRack(SyncedRack& synced, const RackInfo& rackInfo,
-                                 const ChainNodePath& rackPath, te::RackType& rackType);
+    static void buildConnectionsForRack(SyncedRack& synced, const RackInfo& rackInfo,
+                                        const ChainNodePath& rackPath, te::RackType& rackType);
     void rebuildConnectionsRecursive(SyncedRack& synced, const RackInfo& rackInfo,
                                      const ChainNodePath& rackPath, te::RackType& rackType);
     void updateElementPropertiesRecursive(SyncedRack& synced, const RackInfo& rackInfo,
@@ -343,7 +343,7 @@ class RackSyncManager {
     /**
      * @brief Apply rack bypass state via wet/dry gains
      */
-    void applyBypassState(SyncedRack& synced, const RackInfo& rackInfo);
+    static void applyBypassState(SyncedRack& synced, const RackInfo& rackInfo);
 
     /**
      * @brief Capture plugin states for a single rack back to TrackManager DeviceInfo

--- a/magda/daw/audio/session/ClipEngineIdMap.cpp
+++ b/magda/daw/audio/session/ClipEngineIdMap.cpp
@@ -23,7 +23,7 @@ std::optional<ClipId> ClipEngineIdMap::getClipId(const std::string& engineId) co
     return it->second;
 }
 
-void ClipEngineIdMap::set(ClipId clipId, std::string engineId) {
+void ClipEngineIdMap::set(ClipId clipId, const std::string& engineId) {
     juce::ScopedLock lock(lock_);
 
     if (auto existing = clipIdToEngineId_.find(clipId); existing != clipIdToEngineId_.end())

--- a/magda/daw/audio/session/ClipEngineIdMap.hpp
+++ b/magda/daw/audio/session/ClipEngineIdMap.hpp
@@ -18,7 +18,7 @@ class ClipEngineIdMap {
     std::optional<std::string> getEngineId(ClipId clipId) const;
     std::optional<ClipId> getClipId(const std::string& engineId) const;
 
-    void set(ClipId clipId, std::string engineId);
+    void set(ClipId clipId, const std::string& engineId);
     void erase(ClipId clipId);
     Snapshot snapshot() const;
 

--- a/magda/daw/audio/session/ClipSynchronizer.cpp
+++ b/magda/daw/audio/session/ClipSynchronizer.cpp
@@ -1203,7 +1203,7 @@ void ClipSynchronizer::launchSessionClip(ClipId clipId, bool forceImmediate) {
                 auto otherPlayState = otherLH->getPlayingStatus();
                 auto otherQueuedState = otherLH->getQueuedStatus();
                 if (otherPlayState == te::LaunchHandle::PlayState::playing) {
-                    otherLH->stop(targetBeat ? *targetBeat : std::optional<te::MonotonicBeat>{});
+                    otherLH->stop(targetBeat);
                 } else if (otherQueuedState &&
                            *otherQueuedState == te::LaunchHandle::QueueState::playQueued) {
                     otherLH->stop(std::nullopt);
@@ -1223,7 +1223,7 @@ void ClipSynchronizer::launchSessionClip(ClipId clipId, bool forceImmediate) {
     } else {
         DBG("ClipSync: play(beat " << targetBeat->v.inBeats() << ") - quantized launch for clip "
                                    << clipId << " qType=" << static_cast<int>(qType));
-        launchHandle->play(*targetBeat);
+        launchHandle->play(targetBeat);
     }
 }
 
@@ -1242,7 +1242,7 @@ void ClipSynchronizer::stopSessionClipQueued(ClipId clipId, LaunchQuantize quant
         return;
 
     auto targetBeat = clip_launch::computeQuantizedBeat(edit_, quantize);
-    launchHandle->stop(targetBeat ? *targetBeat : std::optional<te::MonotonicBeat>{});
+    launchHandle->stop(targetBeat);
 
     // Reset synth plugins to prevent stuck MIDI notes
     const auto* clip = ClipManager::getInstance().getClip(clipId);

--- a/magda/daw/audio/session/ClipSynchronizer.cpp
+++ b/magda/daw/audio/session/ClipSynchronizer.cpp
@@ -192,7 +192,7 @@ bool restoreWarpMarkersIfNeeded(te::WarpTimeManager& warpManager,
     // inserting the complete saved list would duplicate both boundaries.
     warpManager.removeAllMarkers();
 
-    auto& defaultMarkers = warpManager.getMarkers();
+    const auto& defaultMarkers = warpManager.getMarkers();
     warpManager.moveMarker(0, te::TimePosition::fromSeconds(markers.front().warpTime));
     warpManager.moveMarker(defaultMarkers.size() - 1,
                            te::TimePosition::fromSeconds(markers.back().warpTime));

--- a/magda/daw/audio/session/ClipSynchronizer.hpp
+++ b/magda/daw/audio/session/ClipSynchronizer.hpp
@@ -325,7 +325,7 @@ class ClipSynchronizer : public ClipManagerListener, public TrackManagerListener
      * clip's source already points at takes[currentTakeIndex]; the others are
      * preserved as alternates.
      */
-    void applyModelTakesToTeClip(tracktion::WaveAudioClip& teClip, const ClipInfo& clip);
+    static void applyModelTakesToTeClip(tracktion::WaveAudioClip& teClip, const ClipInfo& clip);
 
     /**
      * @brief Configure autoTempo on a session audio clip in TE

--- a/magda/daw/audio/session/SessionClipScheduler.cpp
+++ b/magda/daw/audio/session/SessionClipScheduler.cpp
@@ -190,7 +190,7 @@ SessionClipPlayState SessionClipScheduler::getClipPlayState(ClipId clipId) const
     return SessionClipPlayState::Stopped;
 }
 
-bool SessionClipScheduler::hasActiveClips() const {
+bool SessionClipScheduler::hasActiveClips() {
     auto& tm = TrackManager::getInstance();
     for (const auto& track : tm.getTracks()) {
         if (track.activeSessionClipId != INVALID_CLIP_ID)

--- a/magda/daw/audio/session/SessionClipScheduler.hpp
+++ b/magda/daw/audio/session/SessionClipScheduler.hpp
@@ -60,7 +60,7 @@ class SessionClipScheduler : public ClipManagerListener {
     void relaunchActiveClips();
 
     /** Returns true if any track has an activeSessionClipId set. */
-    bool hasActiveClips() const;
+    static bool hasActiveClips();
 
     /** Returns the looped session playhead position (seconds), or -1.0 if no session clips active.
         This tracks the most recently launched clip (used by clip editors). */
@@ -96,7 +96,7 @@ class SessionClipScheduler : public ClipManagerListener {
 
     /** Derive and sync TrackPlaybackMode for all tracks from activeSessionClipId.
         Tracks with an active session clip → Session, others → Arrangement. */
-    void syncTrackPlaybackModes();
+    static void syncTrackPlaybackModes();
 
     /** Ensure a LaunchHandle shared_ptr is held for a clip (keeps it alive for audio thread). */
     void retainLaunchHandle(ClipId clipId);

--- a/magda/daw/audio/sidechain/SidechainRoutingManager.hpp
+++ b/magda/daw/audio/sidechain/SidechainRoutingManager.hpp
@@ -14,8 +14,8 @@ class SidechainRoutingManager {
 
     void refreshAllSourceMonitors();
     void handleDeviceSidechainChanged(TrackId destinationTrackId, const DeviceInfo& device);
-    void triggerMidiActivity(TrackId trackId);
-    void publishAudioPeak(TrackId trackId, float peak);
+    static void triggerMidiActivity(TrackId trackId);
+    static void publishAudioPeak(TrackId trackId, float peak);
 
   private:
     PluginManager& pluginManager_;

--- a/magda/daw/cli/magda_cli_main.cpp
+++ b/magda/daw/cli/magda_cli_main.cpp
@@ -200,7 +200,7 @@ class CommandDispatcher {
         if (index >= static_cast<size_t>(tokens.size()))
             return {};
 
-        const auto command = tokens[static_cast<int>(index++)];
+        const auto& command = tokens[static_cast<int>(index++)];
         for (const auto& spec : commandSpecs())
             if (command == spec.name)
                 return (this->*spec.handler)(tokens, index);
@@ -228,7 +228,7 @@ class CommandDispatcher {
         if (index >= static_cast<size_t>(tokens.size()))
             return fail("add-track requires <audio|group|aux|chord>");
 
-        const auto typeToken = tokens[static_cast<int>(index++)];
+        const auto& typeToken = tokens[static_cast<int>(index++)];
         auto type = parseTrackType(typeToken);
         if (!type)
             return fail("Unsupported track type: " + typeToken);
@@ -364,7 +364,7 @@ class CommandDispatcher {
         if (index >= static_cast<size_t>(tokens.size()))
             return fail("add-internal-instrument requires <plugin-id>");
 
-        const auto pluginId = tokens[static_cast<int>(index++)];
+        const auto& pluginId = tokens[static_cast<int>(index++)];
         auto name = pluginId;
         if (index < static_cast<size_t>(tokens.size()) &&
             !isCommand(tokens[static_cast<int>(index)]))

--- a/magda/daw/command.cpp
+++ b/magda/daw/command.cpp
@@ -1,9 +1,10 @@
 #include "command.hpp"
 
 #include <stdexcept>
+#include <utility>
 
 // Command implementation
-Command::Command(const std::string& command_type) : type_(command_type) {}
+Command::Command(std::string command_type) : type_(std::move(command_type)) {}
 
 Command::Command(const juce::var& json) {
     if (!json.hasProperty("command")) {
@@ -114,8 +115,8 @@ std::string Command::toJsonString() const {
 }
 
 // CommandResponse implementation
-CommandResponse::CommandResponse(Status status, const std::string& message)
-    : status_(status), message_(message) {}
+CommandResponse::CommandResponse(Status status, std::string message)
+    : status_(status), message_(std::move(message)) {}
 
 juce::var CommandResponse::toJson() const {
     juce::DynamicObject::Ptr obj = new juce::DynamicObject();

--- a/magda/daw/command.cpp
+++ b/magda/daw/command.cpp
@@ -15,7 +15,7 @@ Command::Command(const juce::var& json) {
     // Parse parameters
     auto* obj = json.getDynamicObject();
     if (obj) {
-        for (auto& prop : obj->getProperties()) {
+        for (const auto& prop : obj->getProperties()) {
             std::string key = prop.name.toString().toStdString();
             if (key == "command")
                 continue;

--- a/magda/daw/command.hpp
+++ b/magda/daw/command.hpp
@@ -21,7 +21,7 @@ class Command {
     /**
      * @brief Construct a command with the given type
      */
-    explicit Command(const std::string& command_type);
+    explicit Command(std::string command_type);
 
     /**
      * @brief Construct a command from JSON
@@ -91,7 +91,7 @@ class CommandResponse {
   public:
     enum class Status { Success, Error, Pending };
 
-    CommandResponse(Status status, const std::string& message = "");
+    CommandResponse(Status status, std::string message = "");
 
     Status getStatus() const {
         return status_;

--- a/magda/daw/core/AutomationCommands.hpp
+++ b/magda/daw/core/AutomationCommands.hpp
@@ -120,14 +120,12 @@ class MoveAutomationPointCommand : public UndoableCommand {
     }
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (const const const const const const auto* o =
-                dynamic_cast<const MoveAutomationPointCommand*>(other))
+        if (const auto* o = dynamic_cast<const MoveAutomationPointCommand*>(other))
             return o->pointId_ == pointId_ && o->laneId_ == laneId_ && o->clipId_ == clipId_;
         return false;
     }
     void mergeWith(const UndoableCommand* other) override {
-        const const const const const const auto* o =
-            static_cast<const MoveAutomationPointCommand*>(other);
+        const auto* o = static_cast<const MoveAutomationPointCommand*>(other);
         newBeatPosition_ = o->newBeatPosition_;
         newValue_ = o->newValue_;
     }
@@ -165,8 +163,7 @@ class SetAutomationPointTensionCommand : public UndoableCommand {
     }
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (const const const const const const auto* o =
-                dynamic_cast<const SetAutomationPointTensionCommand*>(other))
+        if (const auto* o = dynamic_cast<const SetAutomationPointTensionCommand*>(other))
             return o->pointId_ == pointId_ && o->laneId_ == laneId_ && o->clipId_ == clipId_;
         return false;
     }
@@ -209,14 +206,12 @@ class SetAutomationPointHandlesCommand : public UndoableCommand {
     }
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (const const const const const const auto* o =
-                dynamic_cast<const SetAutomationPointHandlesCommand*>(other))
+        if (const auto* o = dynamic_cast<const SetAutomationPointHandlesCommand*>(other))
             return o->pointId_ == pointId_ && o->laneId_ == laneId_ && o->clipId_ == clipId_;
         return false;
     }
     void mergeWith(const UndoableCommand* other) override {
-        const const const const const const auto* o =
-            static_cast<const SetAutomationPointHandlesCommand*>(other);
+        const auto* o = static_cast<const SetAutomationPointHandlesCommand*>(other);
         newInHandle_ = o->newInHandle_;
         newOutHandle_ = o->newOutHandle_;
     }
@@ -388,8 +383,7 @@ class MoveAutomationClipCommand : public UndoableCommand {
     }
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (const const const const const const auto* o =
-                dynamic_cast<const MoveAutomationClipCommand*>(other))
+        if (const auto* o = dynamic_cast<const MoveAutomationClipCommand*>(other))
             return o->clipId_ == clipId_;
         return false;
     }
@@ -410,8 +404,8 @@ class MoveAutomationClipCommand : public UndoableCommand {
  */
 class RenameAutomationClipCommand : public UndoableCommand {
   public:
-    RenameAutomationClipCommand(AutomationClipId clipId, const juce::String& newName)
-        : clipId_(clipId), newName_(newName) {
+    RenameAutomationClipCommand(AutomationClipId clipId, juce::String newName)
+        : clipId_(clipId), newName_(std::move(newName)) {
         captureOldName();
     }
 
@@ -470,8 +464,7 @@ class ResizeAutomationClipCommand : public UndoableCommand {
     }
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (const const const const const const auto* o =
-                dynamic_cast<const ResizeAutomationClipCommand*>(other))
+        if (const auto* o = dynamic_cast<const ResizeAutomationClipCommand*>(other))
             return o->clipId_ == clipId_ && o->fromStart_ == fromStart_;
         return false;
     }

--- a/magda/daw/core/AutomationCommands.hpp
+++ b/magda/daw/core/AutomationCommands.hpp
@@ -120,12 +120,14 @@ class MoveAutomationPointCommand : public UndoableCommand {
     }
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (auto* o = dynamic_cast<const MoveAutomationPointCommand*>(other))
+        if (const const const const const const auto* o =
+                dynamic_cast<const MoveAutomationPointCommand*>(other))
             return o->pointId_ == pointId_ && o->laneId_ == laneId_ && o->clipId_ == clipId_;
         return false;
     }
     void mergeWith(const UndoableCommand* other) override {
-        auto* o = static_cast<const MoveAutomationPointCommand*>(other);
+        const const const const const const auto* o =
+            static_cast<const MoveAutomationPointCommand*>(other);
         newBeatPosition_ = o->newBeatPosition_;
         newValue_ = o->newValue_;
     }
@@ -163,7 +165,8 @@ class SetAutomationPointTensionCommand : public UndoableCommand {
     }
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (auto* o = dynamic_cast<const SetAutomationPointTensionCommand*>(other))
+        if (const const const const const const auto* o =
+                dynamic_cast<const SetAutomationPointTensionCommand*>(other))
             return o->pointId_ == pointId_ && o->laneId_ == laneId_ && o->clipId_ == clipId_;
         return false;
     }
@@ -206,12 +209,14 @@ class SetAutomationPointHandlesCommand : public UndoableCommand {
     }
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (auto* o = dynamic_cast<const SetAutomationPointHandlesCommand*>(other))
+        if (const const const const const const auto* o =
+                dynamic_cast<const SetAutomationPointHandlesCommand*>(other))
             return o->pointId_ == pointId_ && o->laneId_ == laneId_ && o->clipId_ == clipId_;
         return false;
     }
     void mergeWith(const UndoableCommand* other) override {
-        auto* o = static_cast<const SetAutomationPointHandlesCommand*>(other);
+        const const const const const const auto* o =
+            static_cast<const SetAutomationPointHandlesCommand*>(other);
         newInHandle_ = o->newInHandle_;
         newOutHandle_ = o->newOutHandle_;
     }
@@ -383,7 +388,8 @@ class MoveAutomationClipCommand : public UndoableCommand {
     }
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (auto* o = dynamic_cast<const MoveAutomationClipCommand*>(other))
+        if (const const const const const const auto* o =
+                dynamic_cast<const MoveAutomationClipCommand*>(other))
             return o->clipId_ == clipId_;
         return false;
     }
@@ -464,7 +470,8 @@ class ResizeAutomationClipCommand : public UndoableCommand {
     }
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (auto* o = dynamic_cast<const ResizeAutomationClipCommand*>(other))
+        if (const const const const const const auto* o =
+                dynamic_cast<const ResizeAutomationClipCommand*>(other))
             return o->clipId_ == clipId_ && o->fromStart_ == fromStart_;
         return false;
     }

--- a/magda/daw/core/AutomationInfo.cpp
+++ b/magda/daw/core/AutomationInfo.cpp
@@ -163,7 +163,7 @@ ParameterInfo getParameterInfoForTarget(const AutomationTarget& target) {
             // based on the modifier's tempoSync flag.
             if (target.modParamIndex == 0) {
                 juce::String name("Rate");
-                if (auto* mod = resolveModInfoForTarget(target); mod && mod->tempoSync)
+                if (const auto* mod = resolveModInfoForTarget(target); mod && mod->tempoSync)
                     return makeSyncDivisionInfo(name);
                 return makeHzRateInfo(name);
             }
@@ -207,12 +207,12 @@ juce::String getDisplayNameForTarget(const AutomationTarget& target) {
         }
         case ControlTarget::Kind::DeviceMacro: {
             auto defaultName = getMacroDefaultDisplayName(target.paramIndex);
-            if (auto* macro = resolveMacroInfoForTarget(target))
+            if (const auto* macro = resolveMacroInfoForTarget(target))
                 return formatCustomNameWithDefault(macro->name, defaultName);
             return defaultName;
         }
         case ControlTarget::Kind::ModParam: {
-            if (auto* mod = resolveModInfoForTarget(target))
+            if (const auto* mod = resolveModInfoForTarget(target))
                 return getModParameterDisplayName(*mod, target.modParamIndex);
             return "Mod " + juce::String(target.modId) + " Param " +
                    juce::String(target.modParamIndex);

--- a/magda/daw/core/AutomationManager.cpp
+++ b/magda/daw/core/AutomationManager.cpp
@@ -569,7 +569,7 @@ void AutomationManager::endTargetGesture(const AutomationTarget& target) {
         dispatchAuthorityEvent(laneId, AutomationAuthorityEvent::EndGesture);
 }
 
-bool AutomationManager::isWriteModeEnabled() const {
+bool AutomationManager::isWriteModeEnabled() {
     auto* audioEngine = TrackManager::getInstance().getAudioEngine();
     if (!audioEngine)
         return false;
@@ -577,8 +577,7 @@ bool AutomationManager::isWriteModeEnabled() const {
     return bridge && bridge->isAutomationWriteEnabled();
 }
 
-std::optional<double> AutomationManager::getCurrentTargetValue(
-    const AutomationTarget& target) const {
+std::optional<double> AutomationManager::getCurrentTargetValue(const AutomationTarget& target) {
     return getCurrentTargetValueImpl(target);
 }
 
@@ -1083,7 +1082,7 @@ double AutomationManager::getClipValueAtBeat(AutomationClipId clipId,
 }
 
 double AutomationManager::interpolatePoints(const std::vector<AutomationPoint>& points,
-                                            double beatPosition) const {
+                                            double beatPosition) {
     return automation::valueAtBeat(points, beatPosition);
 }
 
@@ -1259,7 +1258,7 @@ AutomationPoint* AutomationManager::findPoint(std::vector<AutomationPoint>& poin
 }
 
 const AutomationPoint* AutomationManager::findPoint(const std::vector<AutomationPoint>& points,
-                                                    AutomationPointId pointId) const {
+                                                    AutomationPointId pointId) {
     for (const auto& point : points) {
         if (point.id == pointId)
             return &point;

--- a/magda/daw/core/AutomationManager.hpp
+++ b/magda/daw/core/AutomationManager.hpp
@@ -226,12 +226,12 @@ class AutomationManager : public TrackManagerListener {
 
     // Query the real automation-write mode from AudioBridge so controls don't
     // depend on a duplicated UI-side cache that can drift out of sync.
-    bool isWriteModeEnabled() const;
+    static bool isWriteModeEnabled();
 
     // Current live normalized value for a target, independent of whether its
     // automation lane is active. Used by disabled lanes to show where the
     // manual value sits against the stored curve.
-    std::optional<double> getCurrentTargetValue(const AutomationTarget& target) const;
+    static std::optional<double> getCurrentTargetValue(const AutomationTarget& target);
 
     using AuthorityStateListener =
         std::function<void(AutomationLaneId, AutomationAuthorityState, AutomationAuthorityState)>;
@@ -426,7 +426,8 @@ class AutomationManager : public TrackManagerListener {
      *        (linear/tension, bezier, step, hard corner) — the model's exact
      *        curve for renderers working outside lane/clip lookups.
      */
-    double interpolatePoints(const std::vector<AutomationPoint>& points, double beatPosition) const;
+    static double interpolatePoints(const std::vector<AutomationPoint>& points,
+                                    double beatPosition);
 
     // ========================================================================
     // Listener Management
@@ -597,10 +598,11 @@ class AutomationManager : public TrackManagerListener {
     // Interpolation helpers
 
     // Point management helpers
-    AutomationPoint* findPoint(std::vector<AutomationPoint>& points, AutomationPointId pointId);
-    const AutomationPoint* findPoint(const std::vector<AutomationPoint>& points,
-                                     AutomationPointId pointId) const;
-    void sortPoints(std::vector<AutomationPoint>& points);
+    static AutomationPoint* findPoint(std::vector<AutomationPoint>& points,
+                                      AutomationPointId pointId);
+    static const AutomationPoint* findPoint(const std::vector<AutomationPoint>& points,
+                                            AutomationPointId pointId);
+    static void sortPoints(std::vector<AutomationPoint>& points);
 };
 
 }  // namespace magda

--- a/magda/daw/core/ChordProgressionConverter.cpp
+++ b/magda/daw/core/ChordProgressionConverter.cpp
@@ -26,7 +26,7 @@ std::vector<ExtractedChord> extractChordsFromNotes(const std::vector<MidiNote>& 
         for (size_t i = 0; i < notes.size(); ++i) {
             const auto& note = notes[i];
             if (note.startBeat <= beat && (note.startBeat + note.lengthBeats) > beat) {
-                chordNotes.push_back({note.noteNumber, note.velocity});
+                chordNotes.emplace_back(note.noteNumber, note.velocity);
                 indices.push_back(i);
             }
         }

--- a/magda/daw/core/ClipBatchEdit.hpp
+++ b/magda/daw/core/ClipBatchEdit.hpp
@@ -29,7 +29,7 @@ class ClipBatchEdit {
     ClipBatchEdit(const ClipBatchEdit&) = delete;
     ClipBatchEdit& operator=(const ClipBatchEdit&) = delete;
 
-    void execute(std::unique_ptr<UndoableCommand> command) {
+    static void execute(std::unique_ptr<UndoableCommand> command) {
         UndoManager::getInstance().executeCommand(std::move(command));
     }
 

--- a/magda/daw/core/ClipCommands.hpp
+++ b/magda/daw/core/ClipCommands.hpp
@@ -489,12 +489,12 @@ class SetCrossfadeCommand : public UndoableCommand {
     void undo() override;
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (auto* o = dynamic_cast<const SetCrossfadeCommand*>(other))
+        if (const const const const auto* o = dynamic_cast<const SetCrossfadeCommand*>(other))
             return o->leftId_ == leftId_ && o->rightId_ == rightId_;
         return false;
     }
     void mergeWith(const UndoableCommand* other) override {
-        auto* o = static_cast<const SetCrossfadeCommand*>(other);
+        const const const const auto* o = static_cast<const SetCrossfadeCommand*>(other);
         startBeat_ = o->startBeat_;
         endBeat_ = o->endBeat_;
         tempo_ = o->tempo_;

--- a/magda/daw/core/ClipCommands.hpp
+++ b/magda/daw/core/ClipCommands.hpp
@@ -258,7 +258,7 @@ class DeleteClipCommand : public SnapshotCommand<ClipInfo> {
 class CreateClipCommand : public ValidatedCommand {
   public:
     CreateClipCommand(ClipType type, TrackId trackId, BeatPosition startBeat,
-                      BeatDuration lengthBeats, const juce::String& audioFilePath = {},
+                      BeatDuration lengthBeats, juce::String audioFilePath = {},
                       ClipView view = ClipView::Arrangement, double tempo = 0.0,
                       ClipOverlapPolicy overlapPolicy = ClipOverlapPolicy::PreserveExisting);
 
@@ -427,7 +427,7 @@ class JoinClipsCommand : public SnapshotCommand<JoinClipsState> {
  */
 class StretchClipCommand : public UndoableCommand {
   public:
-    StretchClipCommand(ClipId clipId, const ClipInfo& beforeState);
+    StretchClipCommand(ClipId clipId, ClipInfo beforeState);
 
     juce::String getDescription() const override {
         return "Stretch Clip";
@@ -452,7 +452,7 @@ class StretchClipCommand : public UndoableCommand {
  */
 class SetFadeCommand : public UndoableCommand {
   public:
-    SetFadeCommand(ClipId clipId, const ClipInfo& beforeState);
+    SetFadeCommand(ClipId clipId, ClipInfo beforeState);
 
     juce::String getDescription() const override {
         return "Adjust Fade";
@@ -489,12 +489,12 @@ class SetCrossfadeCommand : public UndoableCommand {
     void undo() override;
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (const const const const auto* o = dynamic_cast<const SetCrossfadeCommand*>(other))
+        if (const auto* o = dynamic_cast<const SetCrossfadeCommand*>(other))
             return o->leftId_ == leftId_ && o->rightId_ == rightId_;
         return false;
     }
     void mergeWith(const UndoableCommand* other) override {
-        const const const const auto* o = static_cast<const SetCrossfadeCommand*>(other);
+        const auto* o = static_cast<const SetCrossfadeCommand*>(other);
         startBeat_ = o->startBeat_;
         endBeat_ = o->endBeat_;
         tempo_ = o->tempo_;
@@ -521,7 +521,7 @@ class SetCrossfadeCommand : public UndoableCommand {
  */
 class SetVolumeCommand : public UndoableCommand {
   public:
-    SetVolumeCommand(ClipId clipId, const ClipInfo& beforeState);
+    SetVolumeCommand(ClipId clipId, ClipInfo beforeState);
 
     juce::String getDescription() const override {
         return "Adjust Volume";

--- a/magda/daw/core/ClipManager.cpp
+++ b/magda/daw/core/ClipManager.cpp
@@ -155,7 +155,7 @@ class ExternalEditPoller : private juce::Timer {
             return;
         }
 
-        const auto path = file.getFullPathName();
+        const auto& path = file.getFullPathName();
         const auto mtime = file.getLastModificationTime();
         for (auto& item : watched_) {
             if (item.path == path) {
@@ -892,6 +892,7 @@ void ClipManager::deleteClipTake(ClipId clipId, int takeIndex) {
         const int newCurrent = activeAfterDelete(a.currentTakeIndex, takeIndex, newSize);
 
         std::vector<CompSpan> spans;
+        spans.reserve(a.comp.size());
         for (const auto& s : a.comp)
             spans.push_back({s.startSeconds, s.endSeconds, s.takeIndex});
         remapCompSpansAfterDelete(spans, takeIndex, newCurrent);
@@ -932,6 +933,7 @@ void ClipManager::deleteClipTake(ClipId clipId, int takeIndex) {
         const int newCurrent = activeAfterDelete(m.currentTakeIndex, takeIndex, newSize);
 
         std::vector<CompSpan> spans;
+        spans.reserve(m.comp.size());
         for (const auto& s : m.comp)
             spans.push_back({s.startBeat, s.endBeat, s.takeIndex});
         remapCompSpansAfterDelete(spans, takeIndex, newCurrent);
@@ -2367,6 +2369,7 @@ ClipManager::EffectiveFades ClipManager::getEffectiveFades(ClipId clipId, double
         return {};
 
     std::vector<const ClipInfo*> lane;
+    lane.reserve(clips_.size());
     for (const auto& [cid, other] : clips_)
         lane.push_back(&other);
     return effectiveFadesOf(*clip, lane, bpm);
@@ -2378,6 +2381,7 @@ std::optional<ClipManager::CrossfadeInfo> ClipManager::getCrossfadeAtStart(ClipI
         return std::nullopt;
 
     std::vector<const ClipInfo*> lane;
+    lane.reserve(clips_.size());
     for (const auto& [cid, other] : clips_)
         lane.push_back(&other);
     return crossfadeAtStartOf(*clip, lane);
@@ -2389,6 +2393,7 @@ std::optional<ClipManager::CrossfadeInfo> ClipManager::getCrossfadeAtEnd(ClipId 
         return std::nullopt;
 
     std::vector<const ClipInfo*> lane;
+    lane.reserve(clips_.size());
     for (const auto& [cid, other] : clips_)
         lane.push_back(&other);
     return crossfadeAtEndOf(*clip, lane);

--- a/magda/daw/core/ClipManager.cpp
+++ b/magda/daw/core/ClipManager.cpp
@@ -2434,7 +2434,7 @@ ClipId ClipManager::findCrossfadeNeighbour(ClipId clipId, bool atStart) const {
     return bestId;
 }
 
-double ClipManager::availableLeftExtensionBeats(const ClipInfo& clip, double bpm) const {
+double ClipManager::availableLeftExtensionBeats(const ClipInfo& clip, double bpm) {
     const auto* event = clip.primaryEvent();
     if (event == nullptr)
         return 0.0;
@@ -2448,7 +2448,7 @@ double ClipManager::availableLeftExtensionBeats(const ClipInfo& clip, double bpm
     return (juce::jmax(0.0, event->anchorSeconds()) / speed) * bpm / 60.0;
 }
 
-double ClipManager::availableRightExtensionBeats(const ClipInfo& clip, double bpm) const {
+double ClipManager::availableRightExtensionBeats(const ClipInfo& clip, double bpm) {
     const auto* event = clip.primaryEvent();
     if (event == nullptr)
         return 0.0;

--- a/magda/daw/core/ClipManager.hpp
+++ b/magda/daw/core/ClipManager.hpp
@@ -191,7 +191,7 @@ class ClipManager {
      * captured before the edit; the current (post-edit) state is the redo state.
      * Used by audio comp edits in CompService.
      */
-    void pushClipTakeUndo(const juce::String& desc, const ClipInfo& before);
+    static void pushClipTakeUndo(const juce::String& desc, const ClipInfo& before);
 
     /**
      * @brief Force a clips changed notification (used by undo system)
@@ -918,7 +918,7 @@ class ClipManager {
     void resolveOverlaps(ClipId dominantClipId);
 
     /// Reset a looped clip's length to its base loop length and disable looping
-    void resetLoopedClipLength(ClipInfo& clip);
+    static void resetLoopedClipLength(ClipInfo& clip);
 
     /// Move every event off @p from and onto @p to. Used when a relink target
     /// turns out to be pooled already, so one file keeps one source.
@@ -948,8 +948,8 @@ class ClipManager {
     // (bounded by the source read offset), right = past its current end
     // (bounded by the source duration). Unbounded (infinity) for looping
     // clips and when the source duration is unknown.
-    double availableLeftExtensionBeats(const ClipInfo& clip, double bpm) const;
-    double availableRightExtensionBeats(const ClipInfo& clip, double bpm) const;
+    static double availableLeftExtensionBeats(const ClipInfo& clip, double bpm);
+    static double availableRightExtensionBeats(const ClipInfo& clip, double bpm);
 
     // Unified clip storage — ClipView is a property, not storage identity
     std::unordered_map<ClipId, ClipInfo> clips_;
@@ -1041,7 +1041,7 @@ class ClipManager {
     void notifyClipPlaybackRequested(ClipId clipId, ClipPlaybackRequest request);
 
     // Clamp audio clip properties (offset, loopStart, loopLength) to file bounds
-    void sanitizeAudioClip(ClipInfo& clip);
+    static void sanitizeAudioClip(ClipInfo& clip);
 
     // Helper to generate unique clip name
     juce::String generateClipName(ClipType type) const;

--- a/magda/daw/core/ClipOcclusion.cpp
+++ b/magda/daw/core/ClipOcclusion.cpp
@@ -65,6 +65,8 @@ std::unordered_map<ClipId, AudibleSpan> computeAudibleSpans(
     ordered.reserve(trackClips.size());
     for (const auto& clip : trackClips)
         ordered.push_back(&clip);
+    // NOLINTNEXTLINE(bugprone-nondeterministic-pointer-iteration-order) - the comparator orders by
+    // value, not by address
     std::sort(ordered.begin(), ordered.end(),
               [](const ClipInfo* a, const ClipInfo* b) { return clipSitsBelow(*a, *b); });
 

--- a/magda/daw/core/ClipPropertyCommands.hpp
+++ b/magda/daw/core/ClipPropertyCommands.hpp
@@ -14,8 +14,8 @@ namespace magda {
  */
 class SetClipNameCommand : public UndoableCommand {
   public:
-    SetClipNameCommand(ClipId clipId, const juce::String& newName)
-        : clipId_(clipId), newName_(newName) {
+    SetClipNameCommand(ClipId clipId, juce::String newName)
+        : clipId_(clipId), newName_(std::move(newName)) {
         auto* clip = ClipManager::getInstance().getClip(clipId);
         if (clip)
             oldName_ = clip->name;
@@ -113,7 +113,7 @@ class SetClipOffsetCommand : public UndoableCommand {
     }
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (const const const const auto* o = dynamic_cast<const SetClipOffsetCommand*>(other))
+        if (const auto* o = dynamic_cast<const SetClipOffsetCommand*>(other))
             return o->clipId_ == clipId_;
         return false;
     }
@@ -165,7 +165,7 @@ class SetClipLoopPhaseCommand : public UndoableCommand {
     }
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (const const const const auto* o = dynamic_cast<const SetClipLoopPhaseCommand*>(other))
+        if (const auto* o = dynamic_cast<const SetClipLoopPhaseCommand*>(other))
             return o->clipId_ == clipId_;
         return false;
     }
@@ -205,12 +205,12 @@ class SetClipLoopStartCommand : public UndoableCommand {
     }
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (const const const const auto* o = dynamic_cast<const SetClipLoopStartCommand*>(other))
+        if (const auto* o = dynamic_cast<const SetClipLoopStartCommand*>(other))
             return o->clipId_ == clipId_;
         return false;
     }
     void mergeWith(const UndoableCommand* other) override {
-        const const const const auto* o = static_cast<const SetClipLoopStartCommand*>(other);
+        const auto* o = static_cast<const SetClipLoopStartCommand*>(other);
         newLoopStart_ = o->newLoopStart_;
         bpm_ = o->bpm_;
     }
@@ -244,12 +244,12 @@ class SetClipLoopLengthCommand : public UndoableCommand {
     }
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (const const const const auto* o = dynamic_cast<const SetClipLoopLengthCommand*>(other))
+        if (const auto* o = dynamic_cast<const SetClipLoopLengthCommand*>(other))
             return o->clipId_ == clipId_;
         return false;
     }
     void mergeWith(const UndoableCommand* other) override {
-        const const const const auto* o = static_cast<const SetClipLoopLengthCommand*>(other);
+        const auto* o = static_cast<const SetClipLoopLengthCommand*>(other);
         newLoopLength_ = o->newLoopLength_;
         bpm_ = o->bpm_;
     }
@@ -280,14 +280,12 @@ class SetMidiClipLoopStartBeatsCommand : public UndoableCommand {
     }
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (const const const const auto* o =
-                dynamic_cast<const SetMidiClipLoopStartBeatsCommand*>(other))
+        if (const auto* o = dynamic_cast<const SetMidiClipLoopStartBeatsCommand*>(other))
             return o->clipId_ == clipId_;
         return false;
     }
     void mergeWith(const UndoableCommand* other) override {
-        const const const const auto* o =
-            static_cast<const SetMidiClipLoopStartBeatsCommand*>(other);
+        const auto* o = static_cast<const SetMidiClipLoopStartBeatsCommand*>(other);
         newLoopStartBeats_ = o->newLoopStartBeats_;
         bpm_ = o->bpm_;
     }
@@ -318,14 +316,12 @@ class SetMidiClipLoopLengthBeatsCommand : public UndoableCommand {
     }
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (const const const const auto* o =
-                dynamic_cast<const SetMidiClipLoopLengthBeatsCommand*>(other))
+        if (const auto* o = dynamic_cast<const SetMidiClipLoopLengthBeatsCommand*>(other))
             return o->clipId_ == clipId_;
         return false;
     }
     void mergeWith(const UndoableCommand* other) override {
-        const const const const auto* o =
-            static_cast<const SetMidiClipLoopLengthBeatsCommand*>(other);
+        const auto* o = static_cast<const SetMidiClipLoopLengthBeatsCommand*>(other);
         newLoopLengthBeats_ = o->newLoopLengthBeats_;
         bpm_ = o->bpm_;
     }
@@ -374,12 +370,12 @@ class SetClipLoopRangeCommand : public UndoableCommand {
     }
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (const const const const auto* o = dynamic_cast<const SetClipLoopRangeCommand*>(other))
+        if (const auto* o = dynamic_cast<const SetClipLoopRangeCommand*>(other))
             return o->clipId_ == clipId_;
         return false;
     }
     void mergeWith(const UndoableCommand* other) override {
-        const const const const auto* o = static_cast<const SetClipLoopRangeCommand*>(other);
+        const auto* o = static_cast<const SetClipLoopRangeCommand*>(other);
         newLoopStart_ = o->newLoopStart_;
         newLoopLength_ = o->newLoopLength_;
         bpm_ = o->bpm_;
@@ -416,7 +412,7 @@ class SetClipPitchCommand : public UndoableCommand {
     }
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (const const const const auto* o = dynamic_cast<const SetClipPitchCommand*>(other))
+        if (const auto* o = dynamic_cast<const SetClipPitchCommand*>(other))
             return o->clipId_ == clipId_;
         return false;
     }
@@ -453,7 +449,7 @@ class SetClipSpeedRatioCommand : public UndoableCommand {
     }
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (const const const const auto* o = dynamic_cast<const SetClipSpeedRatioCommand*>(other))
+        if (const auto* o = dynamic_cast<const SetClipSpeedRatioCommand*>(other))
             return o->clipId_ == clipId_;
         return false;
     }
@@ -515,7 +511,7 @@ class SetClipVolumeDBCommand : public UndoableCommand {
     }
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (const const const const auto* o = dynamic_cast<const SetClipVolumeDBCommand*>(other))
+        if (const auto* o = dynamic_cast<const SetClipVolumeDBCommand*>(other))
             return o->clipId_ == clipId_;
         return false;
     }
@@ -550,7 +546,7 @@ class SetClipGainDBCommand : public UndoableCommand {
     }
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (const const const const auto* o = dynamic_cast<const SetClipGainDBCommand*>(other))
+        if (const auto* o = dynamic_cast<const SetClipGainDBCommand*>(other))
             return o->clipId_ == clipId_;
         return false;
     }
@@ -585,7 +581,7 @@ class SetClipPanCommand : public UndoableCommand {
     }
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (const const const const auto* o = dynamic_cast<const SetClipPanCommand*>(other))
+        if (const auto* o = dynamic_cast<const SetClipPanCommand*>(other))
             return o->clipId_ == clipId_;
         return false;
     }
@@ -649,7 +645,7 @@ class SetClipFadeInCommand : public UndoableCommand {
     }
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (const const const const auto* o = dynamic_cast<const SetClipFadeInCommand*>(other))
+        if (const auto* o = dynamic_cast<const SetClipFadeInCommand*>(other))
             return o->clipId_ == clipId_;
         return false;
     }
@@ -686,7 +682,7 @@ class SetClipFadeOutCommand : public UndoableCommand {
     }
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (const const const const auto* o = dynamic_cast<const SetClipFadeOutCommand*>(other))
+        if (const auto* o = dynamic_cast<const SetClipFadeOutCommand*>(other))
             return o->clipId_ == clipId_;
         return false;
     }
@@ -722,8 +718,7 @@ class SetClipLaunchFadeSamplesCommand : public UndoableCommand {
     }
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (const const const const auto* o =
-                dynamic_cast<const SetClipLaunchFadeSamplesCommand*>(other))
+        if (const auto* o = dynamic_cast<const SetClipLaunchFadeSamplesCommand*>(other))
             return o->clipId_ == clipId_;
         return false;
     }
@@ -759,12 +754,12 @@ class SetClipLengthBeatsCommand : public UndoableCommand {
     }
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (const const const const auto* o = dynamic_cast<const SetClipLengthBeatsCommand*>(other))
+        if (const auto* o = dynamic_cast<const SetClipLengthBeatsCommand*>(other))
             return o->clipId_ == clipId_;
         return false;
     }
     void mergeWith(const UndoableCommand* other) override {
-        const const const const auto* o = static_cast<const SetClipLengthBeatsCommand*>(other);
+        const auto* o = static_cast<const SetClipLengthBeatsCommand*>(other);
         newBeats_ = o->newBeats_;
         bpm_ = o->bpm_;
     }
@@ -917,8 +912,8 @@ class SetClipColourCommand : public UndoableCommand {
  */
 class SetClipGrooveTemplateCommand : public UndoableCommand {
   public:
-    SetClipGrooveTemplateCommand(ClipId clipId, const juce::String& newTemplate)
-        : clipId_(clipId), newTemplate_(newTemplate) {
+    SetClipGrooveTemplateCommand(ClipId clipId, juce::String newTemplate)
+        : clipId_(clipId), newTemplate_(std::move(newTemplate)) {
         auto* clip = ClipManager::getInstance().getClip(clipId);
         if (clip)
             oldTemplate_ = clip->grooveTemplate;
@@ -962,8 +957,7 @@ class SetClipGrooveStrengthCommand : public UndoableCommand {
     }
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (const const const const auto* o =
-                dynamic_cast<const SetClipGrooveStrengthCommand*>(other))
+        if (const auto* o = dynamic_cast<const SetClipGrooveStrengthCommand*>(other))
             return o->clipId_ == clipId_;
         return false;
     }

--- a/magda/daw/core/ClipPropertyCommands.hpp
+++ b/magda/daw/core/ClipPropertyCommands.hpp
@@ -113,7 +113,7 @@ class SetClipOffsetCommand : public UndoableCommand {
     }
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (auto* o = dynamic_cast<const SetClipOffsetCommand*>(other))
+        if (const const const const auto* o = dynamic_cast<const SetClipOffsetCommand*>(other))
             return o->clipId_ == clipId_;
         return false;
     }
@@ -165,7 +165,7 @@ class SetClipLoopPhaseCommand : public UndoableCommand {
     }
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (auto* o = dynamic_cast<const SetClipLoopPhaseCommand*>(other))
+        if (const const const const auto* o = dynamic_cast<const SetClipLoopPhaseCommand*>(other))
             return o->clipId_ == clipId_;
         return false;
     }
@@ -205,12 +205,12 @@ class SetClipLoopStartCommand : public UndoableCommand {
     }
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (auto* o = dynamic_cast<const SetClipLoopStartCommand*>(other))
+        if (const const const const auto* o = dynamic_cast<const SetClipLoopStartCommand*>(other))
             return o->clipId_ == clipId_;
         return false;
     }
     void mergeWith(const UndoableCommand* other) override {
-        auto* o = static_cast<const SetClipLoopStartCommand*>(other);
+        const const const const auto* o = static_cast<const SetClipLoopStartCommand*>(other);
         newLoopStart_ = o->newLoopStart_;
         bpm_ = o->bpm_;
     }
@@ -244,12 +244,12 @@ class SetClipLoopLengthCommand : public UndoableCommand {
     }
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (auto* o = dynamic_cast<const SetClipLoopLengthCommand*>(other))
+        if (const const const const auto* o = dynamic_cast<const SetClipLoopLengthCommand*>(other))
             return o->clipId_ == clipId_;
         return false;
     }
     void mergeWith(const UndoableCommand* other) override {
-        auto* o = static_cast<const SetClipLoopLengthCommand*>(other);
+        const const const const auto* o = static_cast<const SetClipLoopLengthCommand*>(other);
         newLoopLength_ = o->newLoopLength_;
         bpm_ = o->bpm_;
     }
@@ -280,12 +280,14 @@ class SetMidiClipLoopStartBeatsCommand : public UndoableCommand {
     }
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (auto* o = dynamic_cast<const SetMidiClipLoopStartBeatsCommand*>(other))
+        if (const const const const auto* o =
+                dynamic_cast<const SetMidiClipLoopStartBeatsCommand*>(other))
             return o->clipId_ == clipId_;
         return false;
     }
     void mergeWith(const UndoableCommand* other) override {
-        auto* o = static_cast<const SetMidiClipLoopStartBeatsCommand*>(other);
+        const const const const auto* o =
+            static_cast<const SetMidiClipLoopStartBeatsCommand*>(other);
         newLoopStartBeats_ = o->newLoopStartBeats_;
         bpm_ = o->bpm_;
     }
@@ -316,12 +318,14 @@ class SetMidiClipLoopLengthBeatsCommand : public UndoableCommand {
     }
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (auto* o = dynamic_cast<const SetMidiClipLoopLengthBeatsCommand*>(other))
+        if (const const const const auto* o =
+                dynamic_cast<const SetMidiClipLoopLengthBeatsCommand*>(other))
             return o->clipId_ == clipId_;
         return false;
     }
     void mergeWith(const UndoableCommand* other) override {
-        auto* o = static_cast<const SetMidiClipLoopLengthBeatsCommand*>(other);
+        const const const const auto* o =
+            static_cast<const SetMidiClipLoopLengthBeatsCommand*>(other);
         newLoopLengthBeats_ = o->newLoopLengthBeats_;
         bpm_ = o->bpm_;
     }
@@ -370,12 +374,12 @@ class SetClipLoopRangeCommand : public UndoableCommand {
     }
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (auto* o = dynamic_cast<const SetClipLoopRangeCommand*>(other))
+        if (const const const const auto* o = dynamic_cast<const SetClipLoopRangeCommand*>(other))
             return o->clipId_ == clipId_;
         return false;
     }
     void mergeWith(const UndoableCommand* other) override {
-        auto* o = static_cast<const SetClipLoopRangeCommand*>(other);
+        const const const const auto* o = static_cast<const SetClipLoopRangeCommand*>(other);
         newLoopStart_ = o->newLoopStart_;
         newLoopLength_ = o->newLoopLength_;
         bpm_ = o->bpm_;
@@ -412,7 +416,7 @@ class SetClipPitchCommand : public UndoableCommand {
     }
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (auto* o = dynamic_cast<const SetClipPitchCommand*>(other))
+        if (const const const const auto* o = dynamic_cast<const SetClipPitchCommand*>(other))
             return o->clipId_ == clipId_;
         return false;
     }
@@ -449,7 +453,7 @@ class SetClipSpeedRatioCommand : public UndoableCommand {
     }
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (auto* o = dynamic_cast<const SetClipSpeedRatioCommand*>(other))
+        if (const const const const auto* o = dynamic_cast<const SetClipSpeedRatioCommand*>(other))
             return o->clipId_ == clipId_;
         return false;
     }
@@ -511,7 +515,7 @@ class SetClipVolumeDBCommand : public UndoableCommand {
     }
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (auto* o = dynamic_cast<const SetClipVolumeDBCommand*>(other))
+        if (const const const const auto* o = dynamic_cast<const SetClipVolumeDBCommand*>(other))
             return o->clipId_ == clipId_;
         return false;
     }
@@ -546,7 +550,7 @@ class SetClipGainDBCommand : public UndoableCommand {
     }
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (auto* o = dynamic_cast<const SetClipGainDBCommand*>(other))
+        if (const const const const auto* o = dynamic_cast<const SetClipGainDBCommand*>(other))
             return o->clipId_ == clipId_;
         return false;
     }
@@ -581,7 +585,7 @@ class SetClipPanCommand : public UndoableCommand {
     }
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (auto* o = dynamic_cast<const SetClipPanCommand*>(other))
+        if (const const const const auto* o = dynamic_cast<const SetClipPanCommand*>(other))
             return o->clipId_ == clipId_;
         return false;
     }
@@ -645,7 +649,7 @@ class SetClipFadeInCommand : public UndoableCommand {
     }
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (auto* o = dynamic_cast<const SetClipFadeInCommand*>(other))
+        if (const const const const auto* o = dynamic_cast<const SetClipFadeInCommand*>(other))
             return o->clipId_ == clipId_;
         return false;
     }
@@ -682,7 +686,7 @@ class SetClipFadeOutCommand : public UndoableCommand {
     }
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (auto* o = dynamic_cast<const SetClipFadeOutCommand*>(other))
+        if (const const const const auto* o = dynamic_cast<const SetClipFadeOutCommand*>(other))
             return o->clipId_ == clipId_;
         return false;
     }
@@ -718,7 +722,8 @@ class SetClipLaunchFadeSamplesCommand : public UndoableCommand {
     }
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (auto* o = dynamic_cast<const SetClipLaunchFadeSamplesCommand*>(other))
+        if (const const const const auto* o =
+                dynamic_cast<const SetClipLaunchFadeSamplesCommand*>(other))
             return o->clipId_ == clipId_;
         return false;
     }
@@ -754,12 +759,12 @@ class SetClipLengthBeatsCommand : public UndoableCommand {
     }
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (auto* o = dynamic_cast<const SetClipLengthBeatsCommand*>(other))
+        if (const const const const auto* o = dynamic_cast<const SetClipLengthBeatsCommand*>(other))
             return o->clipId_ == clipId_;
         return false;
     }
     void mergeWith(const UndoableCommand* other) override {
-        auto* o = static_cast<const SetClipLengthBeatsCommand*>(other);
+        const const const const auto* o = static_cast<const SetClipLengthBeatsCommand*>(other);
         newBeats_ = o->newBeats_;
         bpm_ = o->bpm_;
     }
@@ -957,7 +962,8 @@ class SetClipGrooveStrengthCommand : public UndoableCommand {
     }
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (auto* o = dynamic_cast<const SetClipGrooveStrengthCommand*>(other))
+        if (const const const const auto* o =
+                dynamic_cast<const SetClipGrooveStrengthCommand*>(other))
             return o->clipId_ == clipId_;
         return false;
     }

--- a/magda/daw/core/Config.cpp
+++ b/magda/daw/core/Config.cpp
@@ -607,7 +607,7 @@ void Config::load() {
                         // Flat provider/baseUrl/apiKey/model is the pre-profile
                         // on-disk shape. Read it as the LLM backend payload.
                         auto& cfg = profile.llm;
-                        const auto read = llmObj != nullptr ? llmObj : agentObj;
+                        auto* const read = llmObj != nullptr ? llmObj : agentObj;
                         cfg.provider = read->getProperty("provider").toString().toStdString();
                         cfg.baseUrl = read->getProperty("baseUrl").toString().toStdString();
                         cfg.apiKey = read->getProperty("apiKey").toString().toStdString();

--- a/magda/daw/core/DeviceStateCommands.cpp
+++ b/magda/daw/core/DeviceStateCommands.cpp
@@ -1,15 +1,17 @@
 #include "DeviceStateCommands.hpp"
 
+#include <utility>
+
 #include "DeviceState.hpp"
 #include "ProjectManager.hpp"
 #include "TrackManager.hpp"
 
 namespace magda {
 
-LoadImpulseResponseCommand::LoadImpulseResponseCommand(const ChainNodePath& devicePath,
-                                                       const juce::String& irName,
+LoadImpulseResponseCommand::LoadImpulseResponseCommand(ChainNodePath devicePath,
+                                                       juce::String irName,
                                                        juce::MemoryBlock irData)
-    : devicePath_(devicePath), irName_(irName), irData_(std::move(irData)) {}
+    : devicePath_(std::move(devicePath)), irName_(std::move(irName)), irData_(std::move(irData)) {}
 
 juce::String LoadImpulseResponseCommand::getDescription() const {
     return "Load Impulse Response";

--- a/magda/daw/core/DeviceStateCommands.hpp
+++ b/magda/daw/core/DeviceStateCommands.hpp
@@ -28,7 +28,7 @@ namespace magda {
  */
 class LoadImpulseResponseCommand : public SnapshotCommand<juce::String> {
   public:
-    LoadImpulseResponseCommand(const ChainNodePath& devicePath, const juce::String& irName,
+    LoadImpulseResponseCommand(ChainNodePath devicePath, juce::String irName,
                                juce::MemoryBlock irData);
 
     juce::String getDescription() const override;

--- a/magda/daw/core/DrumGridPads.cpp
+++ b/magda/daw/core/DrumGridPads.cpp
@@ -286,7 +286,7 @@ ChainInfo chainFromNode(const ds::Node& node) {
 
     for (const auto& child : node.children)
         if (child.type == kPlugin.toString())
-            chain.elements.push_back(deviceFromNode(child));
+            chain.elements.emplace_back(deviceFromNode(child));
 
     return chain;
 }

--- a/magda/daw/core/DrumkitManager.cpp
+++ b/magda/daw/core/DrumkitManager.cpp
@@ -89,7 +89,7 @@ DrumkitManager::DrumkitManager() {
     }
 }
 
-juce::File DrumkitManager::getDrumkitsDirectory() const {
+juce::File DrumkitManager::getDrumkitsDirectory() {
     return magda::paths::drumkitsDir();
 }
 

--- a/magda/daw/core/DrumkitManager.hpp
+++ b/magda/daw/core/DrumkitManager.hpp
@@ -27,7 +27,7 @@ class DrumkitManager {
 
     static DrumkitManager& getInstance();
 
-    juce::File getDrumkitsDirectory() const;
+    static juce::File getDrumkitsDirectory();
 
     /** Save the given rows under `name`. Existing kits with the same name are
      *  overwritten. Returns false on filesystem failure. */

--- a/magda/daw/core/GainStagingManager.cpp
+++ b/magda/daw/core/GainStagingManager.cpp
@@ -383,7 +383,7 @@ void GainStagingManager::buildStagedDeviceList(TrackId trackId) {
 }
 
 bool GainStagingManager::readDevicePeakLinear(const ChainNodePath& devicePath,
-                                              float& peakLinearOut) const {
+                                              float& peakLinearOut) {
     auto* engine = TrackManager::getInstance().getAudioEngine();
     if (engine == nullptr)
         return false;

--- a/magda/daw/core/GainStagingManager.hpp
+++ b/magda/daw/core/GainStagingManager.hpp
@@ -238,7 +238,7 @@ class GainStagingManager : private juce::Timer {
 
     // Reads max(peakL, peakR) for a device from live metering. Returns false
     // if metering is unavailable or the device has no meter entry.
-    bool readDevicePeakLinear(const ChainNodePath& devicePath, float& peakLinearOut) const;
+    static bool readDevicePeakLinear(const ChainNodePath& devicePath, float& peakLinearOut);
 
     void notifyMode();
     void notifyDevice(const ChainNodePath& devicePath);

--- a/magda/daw/core/GestureRouter.cpp
+++ b/magda/daw/core/GestureRouter.cpp
@@ -394,7 +394,7 @@ ResolvedGesture GestureRouter::resolve(GestureContext context, GestureArea area,
 
     GestureInput input{wheel.isSmooth ? GestureInputKind::SmoothWheel : GestureInputKind::Wheel,
                        area, axis, gestureModifierMaskFrom(mods)};
-    auto* binding = findBinding(context, input);
+    const auto* binding = findBinding(context, input);
     // Existing contexts intentionally need no duplicate smooth rows. They use
     // the ordinary wheel binding unless a context provides a distinct smooth
     // default/override (currently the EQ curve editor).

--- a/magda/daw/core/MacroInfo.hpp
+++ b/magda/daw/core/MacroInfo.hpp
@@ -90,7 +90,7 @@ inline MacroArray createDefaultMacros(int numMacros = NUM_MACROS) {
     MacroArray macros;
     macros.reserve(numMacros);
     for (int i = 0; i < numMacros; ++i) {
-        macros.push_back(MacroInfo(i));
+        macros.emplace_back(i);
     }
     return macros;
 }
@@ -101,7 +101,7 @@ inline MacroArray createDefaultMacros(int numMacros = NUM_MACROS) {
 inline void addMacroPage(MacroArray& macros) {
     int startIndex = static_cast<int>(macros.size());
     for (int i = 0; i < MACROS_PER_PAGE; ++i) {
-        macros.push_back(MacroInfo(startIndex + i));
+        macros.emplace_back(startIndex + i);
     }
 }
 

--- a/magda/daw/core/MidiNoteCommands.cpp
+++ b/magda/daw/core/MidiNoteCommands.cpp
@@ -246,12 +246,12 @@ void MoveMidiNoteCommand::undo() {
 }
 
 bool MoveMidiNoteCommand::canMergeWith(const UndoableCommand* other) const {
-    auto* otherMove = dynamic_cast<const MoveMidiNoteCommand*>(other);
+    const auto* otherMove = dynamic_cast<const MoveMidiNoteCommand*>(other);
     return otherMove && otherMove->clipId_ == clipId_ && otherMove->noteIndex_ == noteIndex_;
 }
 
 void MoveMidiNoteCommand::mergeWith(const UndoableCommand* other) {
-    auto* otherMove = dynamic_cast<const MoveMidiNoteCommand*>(other);
+    const auto* otherMove = dynamic_cast<const MoveMidiNoteCommand*>(other);
     if (otherMove) {
         newStartBeat_ = otherMove->newStartBeat_;
         newNoteNumber_ = otherMove->newNoteNumber_;
@@ -308,12 +308,12 @@ void ResizeMidiNoteCommand::undo() {
 }
 
 bool ResizeMidiNoteCommand::canMergeWith(const UndoableCommand* other) const {
-    auto* otherResize = dynamic_cast<const ResizeMidiNoteCommand*>(other);
+    const auto* otherResize = dynamic_cast<const ResizeMidiNoteCommand*>(other);
     return otherResize && otherResize->clipId_ == clipId_ && otherResize->noteIndex_ == noteIndex_;
 }
 
 void ResizeMidiNoteCommand::mergeWith(const UndoableCommand* other) {
-    auto* otherResize = dynamic_cast<const ResizeMidiNoteCommand*>(other);
+    const auto* otherResize = dynamic_cast<const ResizeMidiNoteCommand*>(other);
     if (otherResize) {
         newLengthBeats_ = otherResize->newLengthBeats_;
     }
@@ -411,13 +411,13 @@ void SetMidiNoteVelocityCommand::undo() {
 }
 
 bool SetMidiNoteVelocityCommand::canMergeWith(const UndoableCommand* other) const {
-    auto* otherVelocity = dynamic_cast<const SetMidiNoteVelocityCommand*>(other);
+    const auto* otherVelocity = dynamic_cast<const SetMidiNoteVelocityCommand*>(other);
     return otherVelocity && otherVelocity->clipId_ == clipId_ &&
            otherVelocity->noteIndex_ == noteIndex_;
 }
 
 void SetMidiNoteVelocityCommand::mergeWith(const UndoableCommand* other) {
-    auto* otherVelocity = dynamic_cast<const SetMidiNoteVelocityCommand*>(other);
+    const auto* otherVelocity = dynamic_cast<const SetMidiNoteVelocityCommand*>(other);
     if (otherVelocity) {
         newVelocity_ = otherVelocity->newVelocity_;
     }
@@ -470,7 +470,7 @@ void SetMultipleMidiNoteVelocitiesCommand::undo() {
 }
 
 bool SetMultipleMidiNoteVelocitiesCommand::canMergeWith(const UndoableCommand* other) const {
-    auto* o = dynamic_cast<const SetMultipleMidiNoteVelocitiesCommand*>(other);
+    const auto* o = dynamic_cast<const SetMultipleMidiNoteVelocitiesCommand*>(other);
     if (!o || o->clipId_ != clipId_ || o->entries_.size() != entries_.size())
         return false;
     // Same note set (same order, which the gesture builds deterministically).
@@ -478,7 +478,7 @@ bool SetMultipleMidiNoteVelocitiesCommand::canMergeWith(const UndoableCommand* o
 }
 
 void SetMultipleMidiNoteVelocitiesCommand::mergeWith(const UndoableCommand* other) {
-    auto* o = dynamic_cast<const SetMultipleMidiNoteVelocitiesCommand*>(other);
+    const auto* o = dynamic_cast<const SetMultipleMidiNoteVelocitiesCommand*>(other);
     if (!o || o->entries_.size() != entries_.size())
         return;
     // Keep our captured old velocities; adopt the newer target velocities.
@@ -1131,12 +1131,12 @@ void TransposeMidiClipCommand::undo() {
 }
 
 bool TransposeMidiClipCommand::canMergeWith(const UndoableCommand* other) const {
-    auto* otherTranspose = dynamic_cast<const TransposeMidiClipCommand*>(other);
+    const auto* otherTranspose = dynamic_cast<const TransposeMidiClipCommand*>(other);
     return otherTranspose && otherTranspose->clipId_ == clipId_;
 }
 
 void TransposeMidiClipCommand::mergeWith(const UndoableCommand* other) {
-    auto* otherTranspose = dynamic_cast<const TransposeMidiClipCommand*>(other);
+    const auto* otherTranspose = dynamic_cast<const TransposeMidiClipCommand*>(other);
     if (otherTranspose) {
         semitones_ += otherTranspose->semitones_;
     }
@@ -1208,12 +1208,12 @@ void EditMidiCCEventCommand::undo() {
 }
 
 bool EditMidiCCEventCommand::canMergeWith(const UndoableCommand* other) const {
-    auto* o = dynamic_cast<const EditMidiCCEventCommand*>(other);
+    const auto* o = dynamic_cast<const EditMidiCCEventCommand*>(other);
     return o && o->clipId_ == clipId_ && o->eventIndex_ == eventIndex_;
 }
 
 void EditMidiCCEventCommand::mergeWith(const UndoableCommand* other) {
-    auto* o = dynamic_cast<const EditMidiCCEventCommand*>(other);
+    const auto* o = dynamic_cast<const EditMidiCCEventCommand*>(other);
     if (o)
         newValue_ = o->newValue_;
 }
@@ -1335,12 +1335,12 @@ void MoveMidiCCEventCommand::undo() {
 }
 
 bool MoveMidiCCEventCommand::canMergeWith(const UndoableCommand* other) const {
-    auto* o = dynamic_cast<const MoveMidiCCEventCommand*>(other);
+    const auto* o = dynamic_cast<const MoveMidiCCEventCommand*>(other);
     return o && o->clipId_ == clipId_ && o->eventIndex_ == eventIndex_;
 }
 
 void MoveMidiCCEventCommand::mergeWith(const UndoableCommand* other) {
-    auto* o = dynamic_cast<const MoveMidiCCEventCommand*>(other);
+    const auto* o = dynamic_cast<const MoveMidiCCEventCommand*>(other);
     if (o) {
         newBeatPosition_ = o->newBeatPosition_;
         newValue_ = o->newValue_;
@@ -1390,12 +1390,12 @@ void MoveMidiPitchBendEventCommand::undo() {
 }
 
 bool MoveMidiPitchBendEventCommand::canMergeWith(const UndoableCommand* other) const {
-    auto* o = dynamic_cast<const MoveMidiPitchBendEventCommand*>(other);
+    const auto* o = dynamic_cast<const MoveMidiPitchBendEventCommand*>(other);
     return o && o->clipId_ == clipId_ && o->eventIndex_ == eventIndex_;
 }
 
 void MoveMidiPitchBendEventCommand::mergeWith(const UndoableCommand* other) {
-    auto* o = dynamic_cast<const MoveMidiPitchBendEventCommand*>(other);
+    const auto* o = dynamic_cast<const MoveMidiPitchBendEventCommand*>(other);
     if (o) {
         newBeatPosition_ = o->newBeatPosition_;
         newValue_ = o->newValue_;
@@ -1524,12 +1524,12 @@ void EditMidiPitchBendEventCommand::undo() {
 }
 
 bool EditMidiPitchBendEventCommand::canMergeWith(const UndoableCommand* other) const {
-    auto* o = dynamic_cast<const EditMidiPitchBendEventCommand*>(other);
+    const auto* o = dynamic_cast<const EditMidiPitchBendEventCommand*>(other);
     return o && o->clipId_ == clipId_ && o->eventIndex_ == eventIndex_;
 }
 
 void EditMidiPitchBendEventCommand::mergeWith(const UndoableCommand* other) {
-    auto* o = dynamic_cast<const EditMidiPitchBendEventCommand*>(other);
+    const auto* o = dynamic_cast<const EditMidiPitchBendEventCommand*>(other);
     if (o)
         newValue_ = o->newValue_;
 }
@@ -1694,12 +1694,12 @@ void SetMidiCCEventTensionCommand::undo() {
 }
 
 bool SetMidiCCEventTensionCommand::canMergeWith(const UndoableCommand* other) const {
-    auto* o = dynamic_cast<const SetMidiCCEventTensionCommand*>(other);
+    const auto* o = dynamic_cast<const SetMidiCCEventTensionCommand*>(other);
     return o && o->clipId_ == clipId_ && o->eventIndex_ == eventIndex_;
 }
 
 void SetMidiCCEventTensionCommand::mergeWith(const UndoableCommand* other) {
-    auto* o = dynamic_cast<const SetMidiCCEventTensionCommand*>(other);
+    const auto* o = dynamic_cast<const SetMidiCCEventTensionCommand*>(other);
     if (o)
         newTension_ = o->newTension_;
 }
@@ -1765,12 +1765,12 @@ void SetMidiPitchBendEventTensionCommand::undo() {
 }
 
 bool SetMidiPitchBendEventTensionCommand::canMergeWith(const UndoableCommand* other) const {
-    auto* o = dynamic_cast<const SetMidiPitchBendEventTensionCommand*>(other);
+    const auto* o = dynamic_cast<const SetMidiPitchBendEventTensionCommand*>(other);
     return o && o->clipId_ == clipId_ && o->eventIndex_ == eventIndex_;
 }
 
 void SetMidiPitchBendEventTensionCommand::mergeWith(const UndoableCommand* other) {
-    auto* o = dynamic_cast<const SetMidiPitchBendEventTensionCommand*>(other);
+    const auto* o = dynamic_cast<const SetMidiPitchBendEventTensionCommand*>(other);
     if (o)
         newTension_ = o->newTension_;
 }

--- a/magda/daw/core/MidiNoteCommands.cpp
+++ b/magda/daw/core/MidiNoteCommands.cpp
@@ -428,7 +428,7 @@ void SetMidiNoteVelocityCommand::mergeWith(const UndoableCommand* other) {
 // ============================================================================
 
 SetMultipleMidiNoteVelocitiesCommand::SetMultipleMidiNoteVelocitiesCommand(
-    ClipId clipId, std::vector<Entry> entries)
+    ClipId clipId, const std::vector<Entry>& entries)
     : clipId_(clipId) {
     const auto* clip = ClipManager::getInstance().getClip(clipId_);
     for (const auto& e : entries) {

--- a/magda/daw/core/MidiNoteCommands.hpp
+++ b/magda/daw/core/MidiNoteCommands.hpp
@@ -162,7 +162,7 @@ class SetMultipleMidiNoteVelocitiesCommand : public UndoableCommand {
         int newVelocity;
     };
 
-    SetMultipleMidiNoteVelocitiesCommand(ClipId clipId, std::vector<Entry> entries);
+    SetMultipleMidiNoteVelocitiesCommand(ClipId clipId, const std::vector<Entry>& entries);
 
     void execute() override;
     void undo() override;

--- a/magda/daw/core/MidiTypes.hpp
+++ b/magda/daw/core/MidiTypes.hpp
@@ -2,6 +2,8 @@
 
 #include <juce_core/juce_core.h>
 
+#include <utility>
+
 namespace magda {
 
 /**
@@ -46,9 +48,12 @@ struct MidiDeviceInfo {
 
     MidiDeviceInfo() = default;
 
-    MidiDeviceInfo(const juce::String& deviceId, const juce::String& deviceName,
-                   bool enabled = false, bool available = true)
-        : id(deviceId), name(deviceName), isEnabled(enabled), isAvailable(available) {}
+    MidiDeviceInfo(juce::String deviceId, juce::String deviceName, bool enabled = false,
+                   bool available = true)
+        : id(std::move(deviceId)),
+          name(std::move(deviceName)),
+          isEnabled(enabled),
+          isAvailable(available) {}
 };
 
 }  // namespace magda

--- a/magda/daw/core/MixAnalysisService.cpp
+++ b/magda/daw/core/MixAnalysisService.cpp
@@ -110,7 +110,7 @@ void MixAnalysisService::runOffline() {
             progressText_ = msg;
             listeners_.call(&Listener::mixAnalysisChanged);
         },
-        [this, runId](mix::OfflineMixAnalysis::Result result) {
+        [this, runId](const mix::OfflineMixAnalysis::Result& result) {
             if (runId != runId_)
                 return;  // cancelled / superseded
             if (result.hasError)

--- a/magda/daw/core/MixAnalysisService.cpp
+++ b/magda/daw/core/MixAnalysisService.cpp
@@ -174,7 +174,7 @@ void MixAnalysisService::restoreCaptureState() {
     captureAddedGlobal_ = false;
 }
 
-MixAnalysisData MixAnalysisService::buildLiveInput() const {
+MixAnalysisData MixAnalysisService::buildLiveInput() {
     auto& tmm = TrackMeasurementManager::getInstance();
     auto& tmgr = TrackManager::getInstance();
     auto trackName = [&tmgr](TrackId id) -> juce::String {
@@ -235,7 +235,7 @@ void MixAnalysisService::stopLiveCapture() {
     listeners_.call(&Listener::mixAnalysisChanged);
 }
 
-juce::String MixAnalysisService::scopeDescription() const {
+juce::String MixAnalysisService::scopeDescription() {
     const auto n = selectedTrackSet().size();
     if (n == 0)
         return "the full mix";
@@ -243,7 +243,7 @@ juce::String MixAnalysisService::scopeDescription() const {
            (n == 1 ? " selected channel" : " selected channels");
 }
 
-juce::String MixAnalysisService::rangeDescription() const {
+juce::String MixAnalysisService::rangeDescription() {
     auto* engine = TrackManager::getInstance().getAudioEngine();
     return (engine != nullptr && engine->isLooping()) ? "loop region" : "whole song";
 }

--- a/magda/daw/core/MixAnalysisService.hpp
+++ b/magda/daw/core/MixAnalysisService.hpp
@@ -65,10 +65,10 @@ class MixAnalysisService {
 
     /// Human-readable scope from the current mixer selection: "the full mix"
     /// (nothing or the master selected) or "N selected channels". For menus.
-    juce::String scopeDescription() const;
+    static juce::String scopeDescription();
     /// Human-readable time range an offline run will cover: "loop region" when the
     /// transport is looping (only that part is rendered), else "whole song".
-    juce::String rangeDescription() const;
+    static juce::String rangeDescription();
 
     bool isBusy() const {
         return busy_;
@@ -101,7 +101,7 @@ class MixAnalysisService {
     void store(Mode mode, MixAnalysisData input);
     void setBusy(bool busy, Mode mode);
     void restoreCaptureState();  // undo what startLiveCapture armed
-    MixAnalysisData buildLiveInput() const;
+    static MixAnalysisData buildLiveInput();
 
     bool busy_ = false;
     Mode busyMode_ = Mode::Offline;

--- a/magda/daw/core/ModInfo.hpp
+++ b/magda/daw/core/ModInfo.hpp
@@ -522,7 +522,7 @@ inline ModArray createDefaultMods(int numMods = NUM_MODS) {
     ModArray mods;
     mods.reserve(numMods);
     for (int i = 0; i < numMods; ++i) {
-        mods.push_back(ModInfo(i));
+        mods.emplace_back(i);
     }
     return mods;
 }
@@ -533,7 +533,7 @@ inline ModArray createDefaultMods(int numMods = NUM_MODS) {
 inline void addModPage(ModArray& mods) {
     int startIndex = static_cast<int>(mods.size());
     for (int i = 0; i < MODS_PER_PAGE; ++i) {
-        mods.push_back(ModInfo(startIndex + i));
+        mods.emplace_back(startIndex + i);
     }
 }
 

--- a/magda/daw/core/ModulatorEngine.hpp
+++ b/magda/daw/core/ModulatorEngine.hpp
@@ -209,7 +209,7 @@ class ModulatorEngine {
             postUpdateHook_();
     }
 
-    void updateAllMods(double deltaTime);
+    static void updateAllMods(double deltaTime);
 
     // Timer instance - using composition instead of inheritance to allow early destruction
     std::unique_ptr<UpdateTimer> timer_;

--- a/magda/daw/core/PadCommands.cpp
+++ b/magda/daw/core/PadCommands.cpp
@@ -34,9 +34,11 @@ PadRack snapshotPads(const ChainNodePath& gridPath) {
 
 }  // namespace
 
-EditPadsCommand::EditPadsCommand(const ChainNodePath& gridPath, juce::String description,
+EditPadsCommand::EditPadsCommand(ChainNodePath gridPath, juce::String description,
                                  std::function<void()> edit)
-    : gridPath_(gridPath), description_(std::move(description)), edit_(std::move(edit)) {}
+    : gridPath_(std::move(gridPath)),
+      description_(std::move(description)),
+      edit_(std::move(edit)) {}
 
 void EditPadsCommand::execute() {
     auto& tm = TrackManager::getInstance();
@@ -81,9 +83,9 @@ void editPads(const ChainNodePath& gridPath, const juce::String& description,
 // SetPadFaderCommand
 // ============================================================================
 
-SetPadFaderCommand::SetPadFaderCommand(const ChainNodePath& gridPath, int padIndex, Target target,
+SetPadFaderCommand::SetPadFaderCommand(ChainNodePath gridPath, int padIndex, Target target,
                                        float value, int gesture)
-    : gridPath_(gridPath),
+    : gridPath_(std::move(gridPath)),
       padIndex_(padIndex),
       target_(target),
       newValue_(value),

--- a/magda/daw/core/PadCommands.hpp
+++ b/magda/daw/core/PadCommands.hpp
@@ -38,8 +38,7 @@ class EditPadsCommand : public UndoableCommand {
   public:
     /// @p edit runs against the live model, addressed by @p gridPath. It runs
     /// once: redo restores the snapshot it produced.
-    EditPadsCommand(const ChainNodePath& gridPath, juce::String description,
-                    std::function<void()> edit);
+    EditPadsCommand(ChainNodePath gridPath, juce::String description, std::function<void()> edit);
 
     void execute() override;
     void undo() override;
@@ -82,7 +81,7 @@ class SetPadFaderCommand : public UndoableCommand {
     /// same fader is another. `UndoManager` merges adjacent commands with no
     /// timeout of its own, so without this one Undo would walk back every
     /// gesture since something else last intervened.
-    SetPadFaderCommand(const ChainNodePath& gridPath, int padIndex, Target target, float value,
+    SetPadFaderCommand(ChainNodePath gridPath, int padIndex, Target target, float value,
                        int gesture);
 
     void execute() override;

--- a/magda/daw/core/ParameterDetector.cpp
+++ b/magda/daw/core/ParameterDetector.cpp
@@ -33,12 +33,15 @@ void logDetector(const juce::String& msg) {
     f.appendText(msg + "\n");
 }
 
+// NOLINTBEGIN(bugprone-macro-parentheses) - the argument is streamed, so
+// parenthesising it would evaluate the << chain before it reaches the string
 #define DETECT_LOG(msg)                                                                            \
     do {                                                                                           \
         juce::String _s;                                                                           \
         _s << msg;                                                                                 \
         logDetector(_s);                                                                           \
     } while (0)
+// NOLINTEND(bugprone-macro-parentheses)
 
 // Strip leading numeric value from display text to extract unit suffix
 // e.g. "440.00 Hz" → "Hz", "-12.5 dB" → "dB", "50%" → "%"

--- a/magda/daw/core/ParameterDetector.cpp
+++ b/magda/daw/core/ParameterDetector.cpp
@@ -673,8 +673,8 @@ int parseAIResponse(const juce::String& responseText, const std::vector<Ambiguou
 void detectWithAI(const juce::String& pluginName, const std::vector<ParameterScanInput>& params,
                   const std::vector<DetectedParameterInfo>& deterministicResults,
                   float confidenceThreshold, std::shared_ptr<std::atomic<bool>> cancelFlag,
-                  std::function<void(int resolved, int total)> onProgress,
-                  std::function<void(std::vector<DetectedParameterInfo>)> onComplete) {
+                  const std::function<void(int resolved, int total)>& onProgress,
+                  const std::function<void(std::vector<DetectedParameterInfo>)>& onComplete) {
     // Collect ambiguous parameters
     std::vector<AmbiguousParam> ambiguous;
     for (size_t i = 0; i < deterministicResults.size(); ++i) {
@@ -692,8 +692,8 @@ void detectWithAI(const juce::String& pluginName, const std::vector<ParameterSca
     auto batches = std::make_shared<std::vector<std::vector<AmbiguousParam>>>();
     for (size_t i = 0; i < ambiguous.size(); i += batchSize) {
         auto end = std::min(i + batchSize, ambiguous.size());
-        batches->push_back({ambiguous.begin() + static_cast<ptrdiff_t>(i),
-                            ambiguous.begin() + static_cast<ptrdiff_t>(end)});
+        batches->emplace_back(ambiguous.begin() + static_cast<ptrdiff_t>(i),
+                              ambiguous.begin() + static_cast<ptrdiff_t>(end));
     }
 
     auto totalAmbiguous = static_cast<int>(ambiguous.size());

--- a/magda/daw/core/ParameterDetector.hpp
+++ b/magda/daw/core/ParameterDetector.hpp
@@ -45,8 +45,8 @@ std::vector<DetectedParameterInfo> detect(const std::vector<ParameterScanInput>&
 void detectWithAI(const juce::String& pluginName, const std::vector<ParameterScanInput>& params,
                   const std::vector<DetectedParameterInfo>& deterministicResults,
                   float confidenceThreshold, std::shared_ptr<std::atomic<bool>> cancelFlag,
-                  std::function<void(int resolved, int total)> onProgress,
-                  std::function<void(std::vector<DetectedParameterInfo>)> onComplete);
+                  const std::function<void(int resolved, int total)>& onProgress,
+                  const std::function<void(std::vector<DetectedParameterInfo>)>& onComplete);
 
 }  // namespace ParameterDetector
 

--- a/magda/daw/core/ParameterInfo.hpp
+++ b/magda/daw/core/ParameterInfo.hpp
@@ -3,6 +3,7 @@
 #include <juce_core/juce_core.h>
 
 #include <memory>
+#include <utility>
 #include <vector>
 
 #include "ChainNodePath.hpp"
@@ -186,11 +187,11 @@ struct ParameterInfo {
     ParameterInfo() = default;
 
     // Constructor with basic info
-    ParameterInfo(int index, const juce::String& n, const juce::String& u, float min, float max,
-                  float def, ParameterScale s = ParameterScale::Linear)
+    ParameterInfo(int index, juce::String n, juce::String u, float min, float max, float def,
+                  ParameterScale s = ParameterScale::Linear)
         : paramIndex(index),
-          name(n),
-          unit(u),
+          name(std::move(n)),
+          unit(std::move(u)),
           minValue(min),
           maxValue(max),
           defaultValue(def),

--- a/magda/daw/core/PluginPresetScanner.cpp
+++ b/magda/daw/core/PluginPresetScanner.cpp
@@ -142,15 +142,15 @@ PluginPresetScanner& PluginPresetScanner::getInstance() {
     return instance;
 }
 
-juce::String PluginPresetScanner::makeCacheKey(const DeviceInfo& device) const {
+juce::String PluginPresetScanner::makeCacheKey(const DeviceInfo& device) {
     return device.getFormatString() + "|" + device.manufacturer + "|" + device.name;
 }
 
-juce::String PluginPresetScanner::getPresetExtension(const DeviceInfo& device) const {
+juce::String PluginPresetScanner::getPresetExtension(const DeviceInfo& device) {
     return extensionFor(device.format);
 }
 
-std::vector<juce::File> PluginPresetScanner::getScanRoots(const DeviceInfo& device) const {
+std::vector<juce::File> PluginPresetScanner::getScanRoots(const DeviceInfo& device) {
     std::vector<juce::File> out;
     auto vendor = sanitiseFolderName(device.manufacturer);
     auto plugin = sanitiseFolderName(device.name);
@@ -169,7 +169,7 @@ std::vector<juce::File> PluginPresetScanner::getScanRoots(const DeviceInfo& devi
     return out;
 }
 
-juce::File PluginPresetScanner::getUserPresetDirectory(const DeviceInfo& device) const {
+juce::File PluginPresetScanner::getUserPresetDirectory(const DeviceInfo& device) {
     auto vendor = sanitiseFolderName(device.manufacturer);
     auto plugin = sanitiseFolderName(device.name);
     if (vendor.isEmpty() || plugin.isEmpty())

--- a/magda/daw/core/PluginPresetScanner.cpp
+++ b/magda/daw/core/PluginPresetScanner.cpp
@@ -50,7 +50,7 @@ std::vector<juce::File> systemRootsFor(PluginFormat format) {
     std::vector<juce::File> roots;
 #if JUCE_MAC
     if (format == PluginFormat::VST3 || format == PluginFormat::AU)
-        roots.push_back(juce::File("/Library/Audio/Presets"));
+        roots.emplace_back("/Library/Audio/Presets");
 #elif JUCE_WINDOWS
     if (format == PluginFormat::VST3) {
         auto common = juce::File::getSpecialLocation(juce::File::commonApplicationDataDirectory);

--- a/magda/daw/core/PluginPresetScanner.hpp
+++ b/magda/daw/core/PluginPresetScanner.hpp
@@ -63,24 +63,24 @@ class PluginPresetScanner {
      * @brief The user-writable directory where MAGDA writes new presets for
      *        this plugin. Created on demand (only when actually written to).
      */
-    juce::File getUserPresetDirectory(const DeviceInfo& device) const;
+    static juce::File getUserPresetDirectory(const DeviceInfo& device);
 
     /**
      * @brief Filesystem extension expected for the device's plugin format
      *        (".vstpreset", ".aupreset", or empty for unsupported formats).
      */
-    juce::String getPresetExtension(const DeviceInfo& device) const;
+    static juce::String getPresetExtension(const DeviceInfo& device);
 
     /**
      * @brief All directories (user + system) scanned for the device. Useful
      *        for exposing a "Reveal in Finder" action for the user dir.
      */
-    std::vector<juce::File> getScanRoots(const DeviceInfo& device) const;
+    static std::vector<juce::File> getScanRoots(const DeviceInfo& device);
 
   private:
     PluginPresetScanner() = default;
 
-    juce::String makeCacheKey(const DeviceInfo& device) const;
+    static juce::String makeCacheKey(const DeviceInfo& device);
     PresetTree scanPlugin(const DeviceInfo& device) const;
 
     std::unordered_map<std::string, PresetTree> cache_;

--- a/magda/daw/core/PresetManager.cpp
+++ b/magda/daw/core/PresetManager.cpp
@@ -197,7 +197,7 @@ PresetManager::PresetManager() {
 // Preset Directories
 // ============================================================================
 
-juce::File PresetManager::getPresetsDirectory() const {
+juce::File PresetManager::getPresetsDirectory() {
     return magda::paths::presetsDir();
 }
 
@@ -534,7 +534,7 @@ bool PresetManager::ensureDirectoryExists(const juce::File& directory) {
     return true;
 }
 
-juce::StringArray PresetManager::getPresetList(const juce::File& directory) const {
+juce::StringArray PresetManager::getPresetList(const juce::File& directory) {
     juce::StringArray presets;
 
     if (!directory.exists())

--- a/magda/daw/core/PresetManager.hpp
+++ b/magda/daw/core/PresetManager.hpp
@@ -37,7 +37,7 @@ class PresetManager {
      * @brief Get the root presets directory
      * @return ~/Documents/MAGDA/Presets/
      */
-    juce::File getPresetsDirectory() const;
+    static juce::File getPresetsDirectory();
 
     /**
      * @brief Get the chains presets directory
@@ -236,7 +236,7 @@ class PresetManager {
     /**
      * @brief Get list of preset files in a directory
      */
-    juce::StringArray getPresetList(const juce::File& directory) const;
+    static juce::StringArray getPresetList(const juce::File& directory);
 
     juce::String lastError_;
     std::unordered_map<DeviceId, juce::String> suggestedNames_;

--- a/magda/daw/core/StepPatternCommands.cpp
+++ b/magda/daw/core/StepPatternCommands.cpp
@@ -64,11 +64,11 @@ step_pattern::PolyPattern currentPolyPattern(const ChainNodePath& devicePath) {
 // Mono
 // =============================================================================
 
-SetMonoStepPatternCommand::SetMonoStepPatternCommand(const ChainNodePath& devicePath,
+SetMonoStepPatternCommand::SetMonoStepPatternCommand(ChainNodePath devicePath,
                                                      step_pattern::MonoPattern pattern,
                                                      juce::String description,
                                                      StepPatternGesture gesture, int gestureId)
-    : devicePath_(devicePath),
+    : devicePath_(std::move(devicePath)),
       pattern_(pattern),
       description_(std::move(description)),
       gesture_(gesture),
@@ -117,11 +117,11 @@ void SetMonoStepPatternCommand::performAction() {
 // Poly
 // =============================================================================
 
-SetPolyStepPatternCommand::SetPolyStepPatternCommand(const ChainNodePath& devicePath,
+SetPolyStepPatternCommand::SetPolyStepPatternCommand(ChainNodePath devicePath,
                                                      step_pattern::PolyPattern pattern,
                                                      juce::String description,
                                                      StepPatternGesture gesture, int gestureId)
-    : devicePath_(devicePath),
+    : devicePath_(std::move(devicePath)),
       pattern_(pattern),
       description_(std::move(description)),
       gesture_(gesture),

--- a/magda/daw/core/StepPatternCommands.hpp
+++ b/magda/daw/core/StepPatternCommands.hpp
@@ -59,7 +59,7 @@ inline constexpr int kNoStepPatternGesture = 0;
 /// Replace a monophonic step sequencer's whole pattern.
 class SetMonoStepPatternCommand : public SnapshotCommand<juce::String> {
   public:
-    SetMonoStepPatternCommand(const ChainNodePath& devicePath, step_pattern::MonoPattern pattern,
+    SetMonoStepPatternCommand(ChainNodePath devicePath, step_pattern::MonoPattern pattern,
                               juce::String description,
                               StepPatternGesture gesture = StepPatternGesture::Discrete,
                               int gestureId = kNoStepPatternGesture);
@@ -85,7 +85,7 @@ class SetMonoStepPatternCommand : public SnapshotCommand<juce::String> {
 /// Replace a polyphonic step sequencer's whole pattern.
 class SetPolyStepPatternCommand : public SnapshotCommand<juce::String> {
   public:
-    SetPolyStepPatternCommand(const ChainNodePath& devicePath, step_pattern::PolyPattern pattern,
+    SetPolyStepPatternCommand(ChainNodePath devicePath, step_pattern::PolyPattern pattern,
                               juce::String description,
                               StepPatternGesture gesture = StepPatternGesture::Discrete,
                               int gestureId = kNoStepPatternGesture);

--- a/magda/daw/core/TrackCommands.cpp
+++ b/magda/daw/core/TrackCommands.cpp
@@ -4,6 +4,7 @@
 #include <functional>
 #include <limits>
 #include <ranges>
+#include <utility>
 
 #include "../audio/AudioBridge.hpp"
 #include "../engine/AudioEngine.hpp"
@@ -125,9 +126,8 @@ int dropIndexForHome(TrackManager& tm, const ChainNodePath& elementPath,
 // CreateTrackCommand
 // ============================================================================
 
-CreateTrackCommand::CreateTrackCommand(TrackType type, const juce::String& name,
-                                       TrackId afterTrackId)
-    : type_(type), name_(name), afterTrackId_(afterTrackId) {}
+CreateTrackCommand::CreateTrackCommand(TrackType type, juce::String name, TrackId afterTrackId)
+    : type_(type), name_(std::move(name)), afterTrackId_(afterTrackId) {}
 
 void CreateTrackCommand::execute() {
     auto& trackManager = TrackManager::getInstance();
@@ -366,8 +366,8 @@ void DuplicateTrackCommand::undo() {
 // AddDeviceToTrackCommand
 // ============================================================================
 
-AddDeviceToTrackCommand::AddDeviceToTrackCommand(TrackId trackId, const DeviceInfo& device)
-    : trackId_(trackId), device_(device) {}
+AddDeviceToTrackCommand::AddDeviceToTrackCommand(TrackId trackId, DeviceInfo device)
+    : trackId_(trackId), device_(std::move(device)) {}
 
 void AddDeviceToTrackCommand::execute() {
     auto& trackManager = TrackManager::getInstance();
@@ -389,11 +389,11 @@ void AddDeviceToTrackCommand::undo() {
 // MoveChainElementCommand
 // ============================================================================
 
-MoveChainElementCommand::MoveChainElementCommand(const ChainNodePath& sourceElementPath,
-                                                 const ChainNodePath& destinationChainPath,
+MoveChainElementCommand::MoveChainElementCommand(ChainNodePath sourceElementPath,
+                                                 ChainNodePath destinationChainPath,
                                                  int insertIndex)
-    : sourceElementPath_(sourceElementPath),
-      destinationChainPath_(destinationChainPath),
+    : sourceElementPath_(std::move(sourceElementPath)),
+      destinationChainPath_(std::move(destinationChainPath)),
       insertIndex_(insertIndex) {}
 
 ChainNodePath MoveChainElementCommand::buildMovedPath(
@@ -452,10 +452,10 @@ void MoveChainElementCommand::undo() {
 // ============================================================================
 
 MoveChainElementsCommand::MoveChainElementsCommand(std::vector<ChainNodePath> sourceElementPaths,
-                                                   const ChainNodePath& destinationChainPath,
+                                                   ChainNodePath destinationChainPath,
                                                    int insertIndex)
     : sourceElementPaths_(std::move(sourceElementPaths)),
-      destinationChainPath_(destinationChainPath),
+      destinationChainPath_(std::move(destinationChainPath)),
       insertIndex_(insertIndex) {}
 
 void MoveChainElementsCommand::execute() {
@@ -587,10 +587,10 @@ void MoveChainElementsCommand::undo() {
 // PasteChainElementsCommand
 // ============================================================================
 
-PasteChainElementsCommand::PasteChainElementsCommand(const ChainNodePath& destinationChainPath,
+PasteChainElementsCommand::PasteChainElementsCommand(ChainNodePath destinationChainPath,
                                                      std::vector<ChainElement> elements,
                                                      int insertIndex)
-    : destinationChainPath_(destinationChainPath),
+    : destinationChainPath_(std::move(destinationChainPath)),
       templateElements_(std::move(elements)),
       insertIndex_(insertIndex) {}
 
@@ -773,9 +773,8 @@ void WrapChainElementsInRackCommand::undo() {
 // SetMacroNameCommand / SetModNameCommand
 // ============================================================================
 
-SetMacroNameCommand::SetMacroNameCommand(const ChainNodePath& path, int macroIndex,
-                                         const juce::String& newName)
-    : path_(path), macroIndex_(macroIndex), newName_(newName) {
+SetMacroNameCommand::SetMacroNameCommand(ChainNodePath path, int macroIndex, juce::String newName)
+    : path_(std::move(path)), macroIndex_(macroIndex), newName_(std::move(newName)) {
     const auto& trackManager = TrackManager::getInstance();
     auto node = trackManager.resolveChainNode(path_);
     if (!node.valid() || node.macros == nullptr || macroIndex_ < 0 ||
@@ -802,9 +801,8 @@ void SetMacroNameCommand::applyName(const juce::String& name) {
     TrackManager::getInstance().notifyModulationNamesChanged(path_.trackId);
 }
 
-SetModNameCommand::SetModNameCommand(const ChainNodePath& path, int modIndex,
-                                     const juce::String& newName)
-    : path_(path), modIndex_(modIndex), newName_(newName) {
+SetModNameCommand::SetModNameCommand(ChainNodePath path, int modIndex, juce::String newName)
+    : path_(std::move(path)), modIndex_(modIndex), newName_(std::move(newName)) {
     const auto& trackManager = TrackManager::getInstance();
     auto node = trackManager.resolveChainNode(path_);
     if (!node.valid() || node.mods == nullptr || modIndex_ < 0 ||
@@ -835,9 +833,9 @@ void SetModNameCommand::applyName(const juce::String& name) {
 // CreateTrackWithDeviceCommand
 // ============================================================================
 
-CreateTrackWithDeviceCommand::CreateTrackWithDeviceCommand(const juce::String& trackName,
-                                                           TrackType type, const DeviceInfo& device)
-    : trackName_(trackName), type_(type), device_(device) {}
+CreateTrackWithDeviceCommand::CreateTrackWithDeviceCommand(juce::String trackName, TrackType type,
+                                                           DeviceInfo device)
+    : trackName_(std::move(trackName)), type_(type), device_(std::move(device)) {}
 
 void CreateTrackWithDeviceCommand::execute() {
     auto& trackManager = TrackManager::getInstance();
@@ -919,9 +917,9 @@ void capturePluginStatesUnder(const std::vector<ChainElement>& elements,
 
 }  // namespace
 
-AddDeviceByPathCommand::AddDeviceByPathCommand(const ChainNodePath& parentPath,
-                                               const DeviceInfo& device, int insertIndex)
-    : parentPath_(parentPath), device_(device), insertIndex_(insertIndex) {}
+AddDeviceByPathCommand::AddDeviceByPathCommand(ChainNodePath parentPath, DeviceInfo device,
+                                               int insertIndex)
+    : parentPath_(std::move(parentPath)), device_(std::move(device)), insertIndex_(insertIndex) {}
 
 void AddDeviceByPathCommand::execute() {
     auto& tm = TrackManager::getInstance();

--- a/magda/daw/core/TrackCommands.hpp
+++ b/magda/daw/core/TrackCommands.hpp
@@ -12,7 +12,7 @@ namespace magda {
 class CreateTrackCommand : public UndoableCommand {
   public:
     explicit CreateTrackCommand(TrackType type = TrackType::Media,
-                                const juce::String& name = juce::String(),
+                                juce::String name = juce::String(),
                                 TrackId afterTrackId = INVALID_TRACK_ID);
 
     void execute() override;
@@ -121,7 +121,7 @@ class DuplicateTrackCommand : public UndoableCommand {
  */
 class AddDeviceToTrackCommand : public UndoableCommand {
   public:
-    AddDeviceToTrackCommand(TrackId trackId, const DeviceInfo& device);
+    AddDeviceToTrackCommand(TrackId trackId, DeviceInfo device);
 
     void execute() override;
     void undo() override;
@@ -145,8 +145,8 @@ class AddDeviceToTrackCommand : public UndoableCommand {
  */
 class MoveChainElementCommand : public UndoableCommand {
   public:
-    MoveChainElementCommand(const ChainNodePath& sourceElementPath,
-                            const ChainNodePath& destinationChainPath, int insertIndex);
+    MoveChainElementCommand(ChainNodePath sourceElementPath, ChainNodePath destinationChainPath,
+                            int insertIndex);
 
     void execute() override;
     void undo() override;
@@ -178,7 +178,7 @@ class MoveChainElementCommand : public UndoableCommand {
 class MoveChainElementsCommand : public UndoableCommand {
   public:
     MoveChainElementsCommand(std::vector<ChainNodePath> sourceElementPaths,
-                             const ChainNodePath& destinationChainPath, int insertIndex);
+                             ChainNodePath destinationChainPath, int insertIndex);
 
     void execute() override;
     void undo() override;
@@ -209,7 +209,7 @@ class MoveChainElementsCommand : public UndoableCommand {
 
 class PasteChainElementsCommand : public UndoableCommand {
   public:
-    PasteChainElementsCommand(const ChainNodePath& destinationChainPath,
+    PasteChainElementsCommand(ChainNodePath destinationChainPath,
                               std::vector<ChainElement> elements, int insertIndex);
 
     void execute() override;
@@ -270,7 +270,7 @@ class WrapChainElementsInRackCommand : public UndoableCommand {
 
 class SetMacroNameCommand : public UndoableCommand {
   public:
-    SetMacroNameCommand(const ChainNodePath& path, int macroIndex, const juce::String& newName);
+    SetMacroNameCommand(ChainNodePath path, int macroIndex, juce::String newName);
 
     void execute() override;
     void undo() override;
@@ -290,7 +290,7 @@ class SetMacroNameCommand : public UndoableCommand {
 
 class SetModNameCommand : public UndoableCommand {
   public:
-    SetModNameCommand(const ChainNodePath& path, int modIndex, const juce::String& newName);
+    SetModNameCommand(ChainNodePath path, int modIndex, juce::String newName);
 
     void execute() override;
     void undo() override;
@@ -313,8 +313,7 @@ class SetModNameCommand : public UndoableCommand {
  */
 class CreateTrackWithDeviceCommand : public UndoableCommand {
   public:
-    CreateTrackWithDeviceCommand(const juce::String& trackName, TrackType type,
-                                 const DeviceInfo& device);
+    CreateTrackWithDeviceCommand(juce::String trackName, TrackType type, DeviceInfo device);
 
     void execute() override;
     void undo() override;
@@ -346,8 +345,7 @@ class CreateTrackWithDeviceCommand : public UndoableCommand {
  */
 class AddDeviceByPathCommand : public UndoableCommand {
   public:
-    AddDeviceByPathCommand(const ChainNodePath& parentPath, const DeviceInfo& device,
-                           int insertIndex = -1);
+    AddDeviceByPathCommand(ChainNodePath parentPath, DeviceInfo device, int insertIndex = -1);
 
     void execute() override;
     void undo() override;

--- a/magda/daw/core/TrackManager.cpp
+++ b/magda/daw/core/TrackManager.cpp
@@ -1320,7 +1320,7 @@ void TrackManager::moveTrackToPosition(TrackId trackId, int oneBasedPosition) {
     auto self = std::ranges::find_if(tracks_, matchesId);
     if (self == tracks_.end())
         return;
-    const TrackInfo info = *self;
+    const TrackInfo& info = *self;
     tracks_.erase(self);
 
     if (anchor == INVALID_TRACK_ID) {

--- a/magda/daw/core/TrackManager.hpp
+++ b/magda/daw/core/TrackManager.hpp
@@ -998,13 +998,13 @@ class TrackManager : public daw::audio::DeviceIdAllocator, public daw::audio::De
 
     // Unified macro management — works for Track, Rack, and Device scopes.
     void setMacroValue(const ChainNodePath& path, int macroIndex, float value);
-    void setMacroTarget(const ChainNodePath& path, int macroIndex, ControlTarget target);
-    void setMacroLinkAmount(const ChainNodePath& path, int macroIndex, ControlTarget target,
+    void setMacroTarget(const ChainNodePath& path, int macroIndex, const ControlTarget& target);
+    void setMacroLinkAmount(const ChainNodePath& path, int macroIndex, const ControlTarget& target,
                             float amount);
-    void setMacroLinkBipolar(const ChainNodePath& path, int macroIndex, ControlTarget target,
+    void setMacroLinkBipolar(const ChainNodePath& path, int macroIndex, const ControlTarget& target,
                              bool bipolar);
     void setMacroName(const ChainNodePath& path, int macroIndex, const juce::String& name);
-    void removeMacroLink(const ChainNodePath& path, int macroIndex, ControlTarget target);
+    void removeMacroLink(const ChainNodePath& path, int macroIndex, const ControlTarget& target);
     void clearAllMacroLinks(const ChainNodePath& path, int macroIndex);
     void addMacroPage(const ChainNodePath& path);
     void removeMacroPage(const ChainNodePath& path);
@@ -1013,12 +1013,12 @@ class TrackManager : public daw::audio::DeviceIdAllocator, public daw::audio::De
     void addMod(const ChainNodePath& path, int slotIndex, ModType type,
                 LFOWaveform waveform = LFOWaveform::Sine);
     void removeMod(const ChainNodePath& path, int modIndex);
-    void setModTarget(const ChainNodePath& path, int modIndex, ControlTarget target);
-    void setModLinkAmount(const ChainNodePath& path, int modIndex, ControlTarget target,
+    void setModTarget(const ChainNodePath& path, int modIndex, const ControlTarget& target);
+    void setModLinkAmount(const ChainNodePath& path, int modIndex, const ControlTarget& target,
                           float amount);
-    void setModLinkBipolar(const ChainNodePath& path, int modIndex, ControlTarget target,
+    void setModLinkBipolar(const ChainNodePath& path, int modIndex, const ControlTarget& target,
                            bool bipolar);
-    void setModLinkEnabled(const ChainNodePath& path, int modIndex, ControlTarget target,
+    void setModLinkEnabled(const ChainNodePath& path, int modIndex, const ControlTarget& target,
                            bool enabled);
     void setModName(const ChainNodePath& path, int modIndex, const juce::String& name);
     void setModType(const ChainNodePath& path, int modIndex, ModType type);
@@ -1048,7 +1048,7 @@ class TrackManager : public daw::audio::DeviceIdAllocator, public daw::audio::De
     // Copies the envelope follower fields (gain/attack/hold/release) from `src`
     // into the stored mod and re-syncs the TE modifier.
     void setModFollower(const ChainNodePath& path, int modIndex, const ModInfo& src);
-    void removeModLink(const ChainNodePath& path, int modIndex, ControlTarget target);
+    void removeModLink(const ChainNodePath& path, int modIndex, const ControlTarget& target);
     void clearAllModLinks(const ChainNodePath& path, int modIndex);
     void setModEnabled(const ChainNodePath& path, int modIndex, bool enabled);
     void addModPage(const ChainNodePath& path);

--- a/magda/daw/core/TrackManager.hpp
+++ b/magda/daw/core/TrackManager.hpp
@@ -653,7 +653,7 @@ class TrackManager : public daw::audio::DeviceIdAllocator, public daw::audio::De
     bool setPadOutput(const ChainNodePath& gridPath, int padIndex, int outputIndex);
 
     /// Whether a bus can be assigned to @p gridPath's pads at all.
-    bool padBusesAvailable(const ChainNodePath& gridPath) const;
+    static bool padBusesAvailable(const ChainNodePath& gridPath);
 
     /// Put every pad back on the grid's own mix. True when any of them moved.
     ///
@@ -1350,7 +1350,7 @@ class TrackManager : public daw::audio::DeviceIdAllocator, public daw::audio::De
     void syncMultiOutChildOutputsForSource(TrackId sourceTrackId);
 
     // Helper for recursive mod updates
-    void updateRackMods(const RackInfo& rack, double deltaTime);
+    static void updateRackMods(const RackInfo& rack, double deltaTime);
 
     juce::String generateTrackName() const;
 };

--- a/magda/daw/core/TrackManagerDevices.cpp
+++ b/magda/daw/core/TrackManagerDevices.cpp
@@ -1160,7 +1160,7 @@ RackId TrackManager::wrapChainElementsInRack(const std::vector<ChainNodePath>& p
 
         const int index = getChainElementIndex(path);
         if (index >= 0)
-            orderedPaths.push_back({index, path});
+            orderedPaths.emplace_back(index, path);
     }
 
     if (orderedPaths.empty())

--- a/magda/daw/core/TrackManagerModulation.cpp
+++ b/magda/daw/core/TrackManagerModulation.cpp
@@ -241,7 +241,8 @@ void TrackManager::setMacroValue(const ChainNodePath& path, int macroIndex, floa
     notifyMacroValueChanged(path.trackId, node.scope, node.notifyId(), macroIndex, clampedValue);
 }
 
-void TrackManager::setMacroTarget(const ChainNodePath& path, int macroIndex, ControlTarget target) {
+void TrackManager::setMacroTarget(const ChainNodePath& path, int macroIndex,
+                                  const ControlTarget& target) {
     auto node = resolveChainNode(path);
     if (!indexInRange(node.macros, macroIndex))
         return;
@@ -261,7 +262,7 @@ void TrackManager::setMacroTarget(const ChainNodePath& path, int macroIndex, Con
 }
 
 void TrackManager::setMacroLinkAmount(const ChainNodePath& path, int macroIndex,
-                                      ControlTarget target, float amount) {
+                                      const ControlTarget& target, float amount) {
     auto node = resolveChainNode(path);
     if (!indexInRange(node.macros, macroIndex))
         return;
@@ -289,7 +290,7 @@ void TrackManager::setMacroLinkAmount(const ChainNodePath& path, int macroIndex,
 }
 
 void TrackManager::setMacroLinkBipolar(const ChainNodePath& path, int macroIndex,
-                                       ControlTarget target, bool bipolar) {
+                                       const ControlTarget& target, bool bipolar) {
     auto node = resolveChainNode(path);
     if (!indexInRange(node.macros, macroIndex))
         return;
@@ -309,7 +310,7 @@ void TrackManager::setMacroName(const ChainNodePath& path, int macroIndex,
 }
 
 void TrackManager::removeMacroLink(const ChainNodePath& path, int macroIndex,
-                                   ControlTarget target) {
+                                   const ControlTarget& target) {
     auto node = resolveChainNode(path);
     if (!indexInRange(node.macros, macroIndex))
         return;
@@ -398,7 +399,8 @@ void TrackManager::removeMod(const ChainNodePath& path, int modIndex) {
     });
 }
 
-void TrackManager::setModTarget(const ChainNodePath& path, int modIndex, ControlTarget target) {
+void TrackManager::setModTarget(const ChainNodePath& path, int modIndex,
+                                const ControlTarget& target) {
     auto node = resolveChainNode(path);
     if (!indexInRange(node.mods, modIndex))
         return;
@@ -411,8 +413,8 @@ void TrackManager::setModTarget(const ChainNodePath& path, int modIndex, Control
     notifyDeviceModifiersChanged(path.trackId);
 }
 
-void TrackManager::setModLinkAmount(const ChainNodePath& path, int modIndex, ControlTarget target,
-                                    float amount) {
+void TrackManager::setModLinkAmount(const ChainNodePath& path, int modIndex,
+                                    const ControlTarget& target, float amount) {
     auto node = resolveChainNode(path);
     if (!indexInRange(node.mods, modIndex))
         return;
@@ -425,8 +427,8 @@ void TrackManager::setModLinkAmount(const ChainNodePath& path, int modIndex, Con
     notifyDeviceModifiersChanged(path.trackId);
 }
 
-void TrackManager::setModLinkBipolar(const ChainNodePath& path, int modIndex, ControlTarget target,
-                                     bool bipolar) {
+void TrackManager::setModLinkBipolar(const ChainNodePath& path, int modIndex,
+                                     const ControlTarget& target, bool bipolar) {
     auto node = resolveChainNode(path);
     if (!indexInRange(node.mods, modIndex))
         return;
@@ -436,8 +438,8 @@ void TrackManager::setModLinkBipolar(const ChainNodePath& path, int modIndex, Co
     }
 }
 
-void TrackManager::setModLinkEnabled(const ChainNodePath& path, int modIndex, ControlTarget target,
-                                     bool enabled) {
+void TrackManager::setModLinkEnabled(const ChainNodePath& path, int modIndex,
+                                     const ControlTarget& target, bool enabled) {
     auto node = resolveChainNode(path);
     if (!indexInRange(node.mods, modIndex))
         return;
@@ -635,7 +637,8 @@ void TrackManager::setModFollower(const ChainNodePath& path, int modIndex, const
     notifyDeviceModifiersChanged(path.trackId);
 }
 
-void TrackManager::removeModLink(const ChainNodePath& path, int modIndex, ControlTarget target) {
+void TrackManager::removeModLink(const ChainNodePath& path, int modIndex,
+                                 const ControlTarget& target) {
     auto node = resolveChainNode(path);
     if (!indexInRange(node.mods, modIndex))
         return;

--- a/magda/daw/core/TrackManagerPads.cpp
+++ b/magda/daw/core/TrackManagerPads.cpp
@@ -323,7 +323,7 @@ void TrackManager::setPadBypassed(const ChainNodePath& gridPath, int padIndex, b
     }
 }
 
-bool TrackManager::padBusesAvailable(const ChainNodePath& gridPath) const {
+bool TrackManager::padBusesAvailable(const ChainNodePath& gridPath) {
     // A multi-out child track is fed by the output instance
     // InstrumentRackManager makes when it wraps a top-level instrument. A grid
     // inside a MAGDA rack is loaded by RackSyncManager instead and has no entry

--- a/magda/daw/core/TrackMeasurementManager.hpp
+++ b/magda/daw/core/TrackMeasurementManager.hpp
@@ -77,8 +77,8 @@ class TrackMeasurementManager : private juce::Timer {
     /// spectrum ring) into dest, for a full-resolution overlay FFT (#1400). The
     /// overlay runs the same pipeline as the device's own trace on these samples.
     /// Returns the ring's running sample count (0 if no live tap / no audio yet).
-    size_t readTrackSpectrumSamples(TrackId trackId, float* dest, int numSamples,
-                                    double& sampleRateOut) const;
+    static size_t readTrackSpectrumSamples(TrackId trackId, float* dest, int numSamples,
+                                           double& sampleRateOut);
 
     void addListener(TrackMeasurementListener* l) {
         listeners_.add(l);

--- a/magda/daw/core/TrackPropertyCommands.hpp
+++ b/magda/daw/core/TrackPropertyCommands.hpp
@@ -51,7 +51,8 @@ class SetTrackVolumeCommand : public UndoableCommand {
     }
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (auto* o = dynamic_cast<const SetTrackVolumeCommand*>(other))
+        if (const const const const const auto* o =
+                dynamic_cast<const SetTrackVolumeCommand*>(other))
             return o->trackId_ == trackId_;
         return false;
     }
@@ -88,7 +89,7 @@ class SetTrackPanCommand : public UndoableCommand {
     }
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (auto* o = dynamic_cast<const SetTrackPanCommand*>(other))
+        if (const const const const const auto* o = dynamic_cast<const SetTrackPanCommand*>(other))
             return o->trackId_ == trackId_;
         return false;
     }
@@ -122,7 +123,8 @@ class SetTrackMixerChannelWidthCommand : public UndoableCommand {
     }
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (auto* o = dynamic_cast<const SetTrackMixerChannelWidthCommand*>(other))
+        if (const const const const const auto* o =
+                dynamic_cast<const SetTrackMixerChannelWidthCommand*>(other))
             return o->trackId_ == trackId_;
         return false;
     }
@@ -157,7 +159,8 @@ class SetTrackMixerFaderTopInsetCommand : public UndoableCommand {
     }
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (auto* o = dynamic_cast<const SetTrackMixerFaderTopInsetCommand*>(other))
+        if (const const const const const auto* o =
+                dynamic_cast<const SetTrackMixerFaderTopInsetCommand*>(other))
             return o->trackId_ == trackId_;
         return false;
     }
@@ -538,7 +541,7 @@ class SetSendLevelCommand : public UndoableCommand {
     }
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (auto* o = dynamic_cast<const SetSendLevelCommand*>(other))
+        if (const const const const const auto* o = dynamic_cast<const SetSendLevelCommand*>(other))
             return o->trackId_ == trackId_ && o->busIndex_ == busIndex_;
         return false;
     }

--- a/magda/daw/core/TrackPropertyCommands.hpp
+++ b/magda/daw/core/TrackPropertyCommands.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <algorithm>
+#include <utility>
 
 #include "TrackManager.hpp"
 #include "UndoManager.hpp"
@@ -51,8 +52,7 @@ class SetTrackVolumeCommand : public UndoableCommand {
     }
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (const const const const const auto* o =
-                dynamic_cast<const SetTrackVolumeCommand*>(other))
+        if (const auto* o = dynamic_cast<const SetTrackVolumeCommand*>(other))
             return o->trackId_ == trackId_;
         return false;
     }
@@ -89,7 +89,7 @@ class SetTrackPanCommand : public UndoableCommand {
     }
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (const const const const const auto* o = dynamic_cast<const SetTrackPanCommand*>(other))
+        if (const auto* o = dynamic_cast<const SetTrackPanCommand*>(other))
             return o->trackId_ == trackId_;
         return false;
     }
@@ -123,8 +123,7 @@ class SetTrackMixerChannelWidthCommand : public UndoableCommand {
     }
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (const const const const const auto* o =
-                dynamic_cast<const SetTrackMixerChannelWidthCommand*>(other))
+        if (const auto* o = dynamic_cast<const SetTrackMixerChannelWidthCommand*>(other))
             return o->trackId_ == trackId_;
         return false;
     }
@@ -159,8 +158,7 @@ class SetTrackMixerFaderTopInsetCommand : public UndoableCommand {
     }
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (const const const const const auto* o =
-                dynamic_cast<const SetTrackMixerFaderTopInsetCommand*>(other))
+        if (const auto* o = dynamic_cast<const SetTrackMixerFaderTopInsetCommand*>(other))
             return o->trackId_ == trackId_;
         return false;
     }
@@ -490,8 +488,8 @@ class RemoveTrackFromGroupCommand : public UndoableCommand {
  */
 class SetTrackNameCommand : public UndoableCommand {
   public:
-    SetTrackNameCommand(TrackId trackId, const juce::String& newName)
-        : trackId_(trackId), newName_(newName) {
+    SetTrackNameCommand(TrackId trackId, juce::String newName)
+        : trackId_(trackId), newName_(std::move(newName)) {
         auto* track = TrackManager::getInstance().getTrack(trackId);
         if (track)
             oldName_ = track->name;
@@ -541,7 +539,7 @@ class SetSendLevelCommand : public UndoableCommand {
     }
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (const const const const const auto* o = dynamic_cast<const SetSendLevelCommand*>(other))
+        if (const auto* o = dynamic_cast<const SetSendLevelCommand*>(other))
             return o->trackId_ == trackId_ && o->busIndex_ == busIndex_;
         return false;
     }

--- a/magda/daw/core/UndoManager.cpp
+++ b/magda/daw/core/UndoManager.cpp
@@ -1,6 +1,7 @@
 #include "UndoManager.hpp"
 
 #include <ranges>
+#include <utility>
 
 #include "../project/ProjectManager.hpp"
 
@@ -203,9 +204,9 @@ void UndoManager::updateProjectDirtyState() {
 // CompoundCommand Implementation
 // ============================================================================
 
-CompoundCommand::CompoundCommand(const juce::String& description,
+CompoundCommand::CompoundCommand(juce::String description,
                                  std::vector<std::unique_ptr<UndoableCommand>> commands)
-    : description_(description), commands_(std::move(commands)) {}
+    : description_(std::move(description)), commands_(std::move(commands)) {}
 
 void CompoundCommand::execute() {
     // Execute all commands in order

--- a/magda/daw/core/UndoManager.hpp
+++ b/magda/daw/core/UndoManager.hpp
@@ -213,7 +213,7 @@ class UndoManager {
  */
 class CompoundCommand : public UndoableCommand {
   public:
-    explicit CompoundCommand(const juce::String& description,
+    explicit CompoundCommand(juce::String description,
                              std::vector<std::unique_ptr<UndoableCommand>> commands);
 
     void execute() override;

--- a/magda/daw/core/WarpMarkerCommands.cpp
+++ b/magda/daw/core/WarpMarkerCommands.cpp
@@ -59,7 +59,7 @@ void MoveWarpMarkerCommand::undo() {
 }
 
 bool MoveWarpMarkerCommand::canMergeWith(const UndoableCommand* other) const {
-    auto* otherMove = dynamic_cast<const MoveWarpMarkerCommand*>(other);
+    const auto* otherMove = dynamic_cast<const MoveWarpMarkerCommand*>(other);
     if (!otherMove)
         return false;
 
@@ -68,7 +68,7 @@ bool MoveWarpMarkerCommand::canMergeWith(const UndoableCommand* other) const {
 }
 
 void MoveWarpMarkerCommand::mergeWith(const UndoableCommand* other) {
-    auto* otherMove = dynamic_cast<const MoveWarpMarkerCommand*>(other);
+    const auto* otherMove = dynamic_cast<const MoveWarpMarkerCommand*>(other);
     if (otherMove) {
         // Keep our oldWarpTime_, update newWarpTime_ to the latest
         newWarpTime_ = otherMove->newWarpTime_;

--- a/magda/daw/core/controllers/BindingRegistry.cpp
+++ b/magda/daw/core/controllers/BindingRegistry.cpp
@@ -23,6 +23,8 @@ static std::vector<Binding>& scopeVec(BindingScope scope, std::vector<Binding>& 
     return scope == BindingScope::Global ? global : project;
 }
 
+// NOLINTNEXTLINE(bugprone-return-const-ref-from-parameter) - the only caller
+// passes long-lived members, never a temporary
 static const std::vector<Binding>& scopeVecConst(BindingScope scope,
                                                  const std::vector<Binding>& global,
                                                  const std::vector<Binding>& project) {

--- a/magda/daw/core/controllers/BindingRegistry.cpp
+++ b/magda/daw/core/controllers/BindingRegistry.cpp
@@ -198,7 +198,7 @@ bool sourcesOverlap(const BindingSource& a, const BindingSource& b) {
 }
 
 bool isFocusedDeviceMacroResolver(const Target& t) {
-    if (auto* rr = std::get_if<ResolverRef>(&t))
+    if (const auto* rr = std::get_if<ResolverRef>(&t))
         return rr->kind == "focused.macro";
     return false;
 }
@@ -212,7 +212,7 @@ bool isFocusedDeviceMacroResolver(const Target& t) {
 // (focused.macro and any future kinds) are profile-driven defaults and
 // do not count.
 bool isExplicitPluginParamTarget(const Target& t) {
-    if (auto* st = std::get_if<ControlTarget>(&t))
+    if (const auto* st = std::get_if<ControlTarget>(&t))
         return st->kind == ControlTarget::Kind::PluginParam;
     if (std::holds_alternative<AliasRef>(t))
         return true;
@@ -327,7 +327,7 @@ bool BindingRegistry::hasActiveStaticBindingForMacro(const ChainNodePath& device
                                                      int macroIndex) const {
     const auto check = [&](const std::vector<Binding>& vec) -> bool {
         const auto matchesMacro = [&](const Binding& b) {
-            auto* st = std::get_if<ControlTarget>(&b.target);
+            const auto* st = std::get_if<ControlTarget>(&b.target);
             return st != nullptr && st->kind == ControlTarget::Kind::DeviceMacro &&
                    st->devicePath == devicePath && st->paramIndex == macroIndex;
         };
@@ -341,7 +341,7 @@ int BindingRegistry::removeStaticBindingsForMacro(const ChainNodePath& devicePat
     std::vector<BindingId> toRemoveProject;
     auto collect = [&](const std::vector<Binding>& vec, std::vector<BindingId>& out) {
         for (const auto& b : vec) {
-            auto* st = std::get_if<ControlTarget>(&b.target);
+            const auto* st = std::get_if<ControlTarget>(&b.target);
             if (st == nullptr)
                 continue;
             if (st->kind != ControlTarget::Kind::DeviceMacro)

--- a/magda/daw/core/controllers/ControllerProfileRegistry.cpp
+++ b/magda/daw/core/controllers/ControllerProfileRegistry.cpp
@@ -65,7 +65,7 @@ juce::File ControllerProfileRegistry::userFileForProfileId(const juce::String& i
     return userControllersDirectory().getChildFile(filenameForProfileId(id));
 }
 
-juce::File ControllerProfileRegistry::findSourceFileForProfileId(const juce::String& id) const {
+juce::File ControllerProfileRegistry::findSourceFileForProfileId(const juce::String& id) {
     // Try the canonical filename in the user dir first — fast path for
     // user-imported profiles (matches load() precedence: user wins over bundled).
     auto direct = userFileForProfileId(id);

--- a/magda/daw/core/controllers/ControllerProfileRegistry.hpp
+++ b/magda/daw/core/controllers/ControllerProfileRegistry.hpp
@@ -70,7 +70,7 @@ class ControllerProfileRegistry {
      * exist. This walks the user directory and returns the file whose parsed
      * id matches. Returns an invalid juce::File when no match.
      */
-    juce::File findSourceFileForProfileId(const juce::String& id) const;
+    static juce::File findSourceFileForProfileId(const juce::String& id);
 
   private:
     ControllerProfileRegistry() = default;

--- a/magda/daw/core/controllers/ControllerRegistry.cpp
+++ b/magda/daw/core/controllers/ControllerRegistry.cpp
@@ -59,7 +59,7 @@ bool ControllerRegistry::rematchInputPorts(const juce::Array<juce::MidiDeviceInf
         const auto matchesName = [&c](const juce::MidiDeviceInfo& dev) {
             return dev.name == c.inputPortName;
         };
-        if (const auto found = std::ranges::find_if(liveInputs, matchesName);
+        if (const auto* const found = std::ranges::find_if(liveInputs, matchesName);
             found != liveInputs.end()) {
             c.inputPort = found->identifier;
             changed = true;

--- a/magda/daw/core/controllers/MidiLearnCoordinator.cpp
+++ b/magda/daw/core/controllers/MidiLearnCoordinator.cpp
@@ -202,7 +202,7 @@ void MidiLearnCoordinator::onCapture(const LearnCapture& capture) {
         if (bestAlias.has_value()) {
             // Extract pluginType from the canonical name: format is "pluginType.paramName"
             // e.g. "serum.filter_cutoff" -> pluginType = "serum"
-            juce::String canonicalName = *bestAlias;
+            const juce::String& canonicalName = *bestAlias;
             juce::String pluginType;
             int dotPos = canonicalName.indexOfChar('.');
             if (dotPos > 0)

--- a/magda/daw/engine/MagdaEngineBehaviour.hpp
+++ b/magda/daw/engine/MagdaEngineBehaviour.hpp
@@ -76,7 +76,7 @@ class MagdaEngineBehaviour : public tracktion::EngineBehaviour {
             return plugin;
 
         const auto type = info.state[tracktion::IDs::type].toString();
-        if (auto* spec = daw::audio::compiled::findCompiledPluginSpec(type)) {
+        if (const auto* spec = daw::audio::compiled::findCompiledPluginSpec(type)) {
             return daw::audio::compiled::createTracktionPlugin(*spec, info);
         }
         DBG("MagdaEngineBehaviour::createCustomPlugin - unknown type: " << type);

--- a/magda/daw/engine/OfflineRenderHelper.cpp
+++ b/magda/daw/engine/OfflineRenderHelper.cpp
@@ -1,5 +1,7 @@
 #include "OfflineRenderHelper.hpp"
 
+#include <utility>
+
 #include "../audio/AudioBridge.hpp"
 #include "TracktionEngineWrapper.hpp"
 
@@ -67,9 +69,8 @@ void restorePluginsAfterOfflineRender(TracktionEngineWrapper& engine) {
 class TracktionOfflineRenderTask final : public OfflineRenderTask {
   public:
     TracktionOfflineRenderTask(TracktionEngineWrapper& engine, tracktion::Edit& edit,
-                               const OfflineRenderRequest& request,
-                               const juce::BigInteger& tracksToDo)
-        : request_(request), params_(edit) {
+                               OfflineRenderRequest request, const juce::BigInteger& tracksToDo)
+        : request_(std::move(request)), params_(edit) {
         params_.destFile = request_.destination;
         auto& formats = engine.getEngine()->getAudioFileFormatManager();
         params_.audioFormat = request_.format == OfflineRenderFormat::Flac ? formats.getFlacFormat()

--- a/magda/daw/engine/PluginMetadataStore.cpp
+++ b/magda/daw/engine/PluginMetadataStore.cpp
@@ -63,8 +63,8 @@ PluginMetadataStore::PluginMetadataStore(const juce::File& databaseFile)
                          databaseFile.getParentDirectory().getChildFile("plugin_exclusions.txt")}) {
 }
 
-PluginMetadataStore::PluginMetadataStore(const juce::File& databaseFile, LegacyFiles legacyFiles)
-    : file_(databaseFile), legacyFiles_(std::move(legacyFiles)) {
+PluginMetadataStore::PluginMetadataStore(juce::File databaseFile, LegacyFiles legacyFiles)
+    : file_(std::move(databaseFile)), legacyFiles_(std::move(legacyFiles)) {
     (void)file_.getParentDirectory().createDirectory();
     db_.open(utf8(file_.getFullPathName()), "open plugin metadata database");
 

--- a/magda/daw/engine/PluginMetadataStore.hpp
+++ b/magda/daw/engine/PluginMetadataStore.hpp
@@ -89,7 +89,7 @@ class PluginMetadataStore {
         juce::File exclusions;
     };
 
-    PluginMetadataStore(const juce::File& databaseFile, LegacyFiles legacyFiles);
+    PluginMetadataStore(juce::File databaseFile, LegacyFiles legacyFiles);
     void createSchema();
     void importLegacyFilesOnce();
 

--- a/magda/daw/engine/PluginScanCoordinator.cpp
+++ b/magda/daw/engine/PluginScanCoordinator.cpp
@@ -39,7 +39,7 @@ juce::File PluginScanCoordinator::getScannerExecutable() {
     auto appBundle = juce::File::getSpecialLocation(juce::File::currentApplicationFile);
 
     juce::StringArray triedPaths;
-    auto tryCandidate = [&triedPaths](juce::File candidate) -> juce::File {
+    auto tryCandidate = [&triedPaths](const juce::File& candidate) -> juce::File {
         triedPaths.add(candidate.getFullPathName());
         return candidate.existsAsFile() ? candidate : juce::File();
     };

--- a/magda/daw/engine/PluginScanCoordinator.cpp
+++ b/magda/daw/engine/PluginScanCoordinator.cpp
@@ -35,7 +35,7 @@ PluginScanCoordinator::~PluginScanCoordinator() {
     workers_.clear();
 }
 
-juce::File PluginScanCoordinator::getScannerExecutable() const {
+juce::File PluginScanCoordinator::getScannerExecutable() {
     auto appBundle = juce::File::getSpecialLocation(juce::File::currentApplicationFile);
 
     juce::StringArray triedPaths;
@@ -523,7 +523,7 @@ void PluginScanCoordinator::saveExclusions() {
     }
 }
 
-juce::File PluginScanCoordinator::getScanReportFile() const {
+juce::File PluginScanCoordinator::getScanReportFile() {
     return magda::paths::lastScanReportFile();
 }
 

--- a/magda/daw/engine/PluginScanCoordinator.hpp
+++ b/magda/daw/engine/PluginScanCoordinator.hpp
@@ -107,7 +107,7 @@ class PluginScanCoordinator : private juce::Timer {
         return pluginTimeoutMs_;
     }
 
-    juce::File getScanReportFile() const;
+    static juce::File getScanReportFile();
 
   private:
     static constexpr int NUM_WORKERS = 4;
@@ -128,10 +128,10 @@ class PluginScanCoordinator : private juce::Timer {
     void writeScanReport();
 
     // Find the scanner executable
-    juce::File getScannerExecutable() const;
+    static juce::File getScannerExecutable();
 
     // Orphan process cleanup
-    void killOrphanScannerProcesses();
+    static void killOrphanScannerProcesses();
 
     // Exclusion management
     void loadExclusions();

--- a/magda/daw/engine/PluginWindowManager.cpp
+++ b/magda/daw/engine/PluginWindowManager.cpp
@@ -153,7 +153,7 @@ void PluginWindowManager::closeAllWindows() {
         juce::ScopedLock lock(windowLock_);
         for (const auto& [deviceId, info] : trackedWindows_) {
             if (info.plugin) {
-                windowsToClose.push_back({deviceId, info.plugin});
+                windowsToClose.emplace_back(deviceId, info.plugin);
             }
         }
     }
@@ -231,11 +231,11 @@ void PluginWindowManager::timerCallback() {
             bool currentlyShowing = extPlugin->windowState->isWindowShowing();
             if (!info.wasOpen && currentlyShowing) {
                 info.wasOpen = true;
-                stateChanges.push_back({deviceId, true});
+                stateChanges.emplace_back(deviceId, true);
             } else if (info.wasOpen && !currentlyShowing) {
                 // Window was closed (via closeButtonPressed or other means)
                 info.wasOpen = false;
-                stateChanges.push_back({deviceId, false});
+                stateChanges.emplace_back(deviceId, false);
             }
         }
     }

--- a/magda/daw/engine/ScanWorker.cpp
+++ b/magda/daw/engine/ScanWorker.cpp
@@ -1,9 +1,13 @@
 #include "ScanWorker.hpp"
 
+#include <utility>
+
 namespace magda {
 
-ScanWorker::ScanWorker(int index, const juce::File& scannerExe, ResultCallback callback)
-    : workerIndex_(index), scannerExe_(scannerExe), resultCallback_(std::move(callback)) {}
+ScanWorker::ScanWorker(int index, juce::File scannerExe, ResultCallback callback)
+    : workerIndex_(index),
+      scannerExe_(std::move(scannerExe)),
+      resultCallback_(std::move(callback)) {}
 
 ScanWorker::~ScanWorker() {
     busy_ = false;

--- a/magda/daw/engine/ScanWorker.hpp
+++ b/magda/daw/engine/ScanWorker.hpp
@@ -29,7 +29,7 @@ class ScanWorker : private juce::ChildProcessCoordinator {
 
     using ResultCallback = std::function<void(int workerIndex, const Result& result)>;
 
-    ScanWorker(int index, const juce::File& scannerExe, ResultCallback callback);
+    ScanWorker(int index, juce::File scannerExe, ResultCallback callback);
     ~ScanWorker() override;
 
     void scanPlugin(const juce::String& formatName, const juce::String& pluginPath);

--- a/magda/daw/engine/TracktionEngineWrapper.cpp
+++ b/magda/daw/engine/TracktionEngineWrapper.cpp
@@ -13,7 +13,7 @@ namespace magda {
 // PDC Query Methods
 // =============================================================================
 
-double TracktionEngineWrapper::getPluginLatencySeconds(const std::string& effect_id) const {
+double TracktionEngineWrapper::getPluginLatencySeconds(const std::string& effect_id) {
     // TODO: Implement when we have effect tracking
     // For now, iterate all tracks and their plugins to find by ID
     juce::ignoreUnused(effect_id);

--- a/magda/daw/engine/TracktionEngineWrapper.cpp
+++ b/magda/daw/engine/TracktionEngineWrapper.cpp
@@ -120,7 +120,7 @@ std::vector<SamplerMediaReference> TracktionEngineWrapper::getSamplerMediaRefere
                               }});
     };
 
-    for (auto plugin : tracktion::getAllPlugins(*currentEdit_, true)) {
+    for (auto* plugin : tracktion::getAllPlugins(*currentEdit_, true)) {
         addSampler(plugin);
         if (auto* drumGrid = dynamic_cast<daw::audio::DrumGridPlugin*>(plugin))
             for (const auto& chain : drumGrid->getChains())

--- a/magda/daw/engine/TracktionEngineWrapper.hpp
+++ b/magda/daw/engine/TracktionEngineWrapper.hpp
@@ -514,7 +514,7 @@ class TracktionEngineWrapper : public AudioEngine,
      * @brief Get the database path where plugin metadata is stored
      * @return Path to plugin_metadata.db
      */
-    juce::File getPluginListFile() const;
+    static juce::File getPluginListFile();
 
     // =========================================================================
     // PDC (Plugin Delay Compensation) Query
@@ -525,7 +525,7 @@ class TracktionEngineWrapper : public AudioEngine,
      * @param effect_id The effect/plugin ID
      * @return Latency in seconds, or 0 if plugin not found
      */
-    double getPluginLatencySeconds(const std::string& effect_id) const;
+    static double getPluginLatencySeconds(const std::string& effect_id);
 
     /**
      * @brief Get the maximum latency across all tracks in the playback graph

--- a/magda/daw/engine/TracktionEngineWrapperClips.cpp
+++ b/magda/daw/engine/TracktionEngineWrapperClips.cpp
@@ -4,7 +4,7 @@ namespace magda {
 
 std::string TracktionEngineWrapper::addMidiClip(const std::string& track_id, double start_time,
                                                 double length, const std::vector<MidiNote>& notes) {
-    auto track = findTrackById(track_id);
+    auto* track = findTrackById(track_id);
     if (!track || !currentEdit_) {
         DBG("addMidiClip: Track not found or no edit: " << track_id);
         return "";
@@ -287,7 +287,7 @@ std::vector<MidiNote> TracktionEngineWrapper::getMidiClipNotes(const std::string
 }
 
 std::vector<std::string> TracktionEngineWrapper::getTrackClips(const std::string& track_id) const {
-    auto track = findTrackById(track_id);
+    auto* track = findTrackById(track_id);
     if (!track) {
         DBG("getTrackClips: Track not found: " << track_id);
         return {};

--- a/magda/daw/engine/TracktionEngineWrapperDevices.cpp
+++ b/magda/daw/engine/TracktionEngineWrapperDevices.cpp
@@ -176,7 +176,7 @@ juce::BigInteger TracktionEngineWrapper::getEnabledWaveChannels(bool input) cons
     if (engine_ == nullptr)
         return channels;
 
-    const auto addEnabledChannels = [&channels](auto devices) {
+    const auto addEnabledChannels = [&channels](const auto& devices) {
         for (auto* device : devices) {
             if (device == nullptr || !device->isEnabled())
                 continue;
@@ -195,7 +195,7 @@ void TracktionEngineWrapper::setEnabledWaveChannels(bool input, const juce::BigI
     if (engine_ == nullptr)
         return;
 
-    const auto applyChannels = [&channels](auto devices) {
+    const auto applyChannels = [&channels](const auto& devices) {
         for (auto* device : devices) {
             if (device == nullptr)
                 continue;

--- a/magda/daw/engine/TracktionEngineWrapperInit.cpp
+++ b/magda/daw/engine/TracktionEngineWrapperInit.cpp
@@ -184,7 +184,7 @@ void TracktionEngineWrapper::configureAudioDevices() {
 
     auto& dm = engine_->getDeviceManager();
     auto& juceDeviceManager = dm.deviceManager;
-    auto& deviceTypes = juceDeviceManager.getAvailableDeviceTypes();
+    const auto& deviceTypes = juceDeviceManager.getAvailableDeviceTypes();
 
     if (deviceTypes.isEmpty()) {
         return;
@@ -336,7 +336,7 @@ void TracktionEngineWrapper::createEditAndBridges() {
     // Set default tempo
     auto& tempoSeq = currentEdit_->tempoSequence;
     if (tempoSeq.getNumTempos() > 0) {
-        auto tempo = tempoSeq.getTempo(0);
+        auto* tempo = tempoSeq.getTempo(0);
         if (tempo) {
             tempo->setBpm(120.0);
         }
@@ -402,7 +402,7 @@ void TracktionEngineWrapper::createEditAndBridges() {
         // Capture zoom/scroll state
         if (auto* tc = TimelineController::getCurrent()) {
             const auto& timelineState = tc->getState();
-            auto& zoom = timelineState.zoom;
+            const auto& zoom = timelineState.zoom;
             auto& proj = ProjectManager::getInstance().getMutableProjectInfo();
             proj.horizontalZoom = zoom.horizontalZoom;
             proj.verticalZoom = zoom.verticalZoom;

--- a/magda/daw/engine/TracktionEngineWrapperPlugins.cpp
+++ b/magda/daw/engine/TracktionEngineWrapperPlugins.cpp
@@ -331,7 +331,7 @@ juce::Array<juce::PluginDescription> TracktionEngineWrapper::getPreferredPluginT
         getKnownPluginList().getTypes());
 }
 
-juce::File TracktionEngineWrapper::getPluginListFile() const {
+juce::File TracktionEngineWrapper::getPluginListFile() {
     // Routed via paths::pluginMetadataFile() — respects MAGDA_DATA_DIR /
     // Config::getDataDir() override. Defaults to userApplicationDataDirectory.
     auto file = magda::paths::pluginMetadataFile();

--- a/magda/daw/engine/TracktionEngineWrapperTracks.cpp
+++ b/magda/daw/engine/TracktionEngineWrapperTracks.cpp
@@ -122,6 +122,7 @@ void TracktionEngineWrapper::setTrackColor(const std::string& track_id, int r, i
 
 std::vector<std::string> TracktionEngineWrapper::getAllTrackIds() const {
     std::vector<std::string> ids;
+    ids.reserve(trackMap_.size());
     for (const auto& pair : trackMap_) {
         ids.push_back(pair.first);
     }

--- a/magda/daw/engine/TracktionEngineWrapperTracks.cpp
+++ b/magda/daw/engine/TracktionEngineWrapperTracks.cpp
@@ -57,45 +57,45 @@ void TracktionEngineWrapper::deleteTrack(const std::string& track_id) {
 }
 
 void TracktionEngineWrapper::setTrackName(const std::string& track_id, const std::string& name) {
-    auto track = findTrackById(track_id);
+    auto* track = findTrackById(track_id);
     if (track) {
         track->setName(name);
     }
 }
 
 std::string TracktionEngineWrapper::getTrackName(const std::string& track_id) const {
-    auto track = findTrackById(track_id);
+    auto* track = findTrackById(track_id);
     return track ? track->getName().toStdString() : "";
 }
 
 void TracktionEngineWrapper::setTrackMuted(const std::string& track_id, bool muted) {
-    auto track = findTrackById(track_id);
+    auto* track = findTrackById(track_id);
     if (track) {
         track->setMute(muted);
     }
 }
 
 bool TracktionEngineWrapper::isTrackMuted(const std::string& track_id) const {
-    auto track = findTrackById(track_id);
+    auto* track = findTrackById(track_id);
     return track ? track->isMuted(false) : false;
 }
 
 void TracktionEngineWrapper::setTrackSolo(const std::string& track_id, bool solo) {
-    auto track = findTrackById(track_id);
+    auto* track = findTrackById(track_id);
     if (track) {
         track->setSolo(solo);
     }
 }
 
 bool TracktionEngineWrapper::isTrackSolo(const std::string& track_id) const {
-    auto track = findTrackById(track_id);
+    auto* track = findTrackById(track_id);
     return track ? track->isSolo(false) : false;
 }
 
 void TracktionEngineWrapper::setTrackArmed(const std::string& track_id, bool armed) {
-    auto track = findTrackById(track_id);
+    auto* track = findTrackById(track_id);
     if (track) {
-        if (auto audioTrack = dynamic_cast<tracktion::AudioTrack*>(track)) {
+        if (auto* audioTrack = dynamic_cast<tracktion::AudioTrack*>(track)) {
             // Simplified - in real implementation would set input recording
             DBG("Set track armed (stub): " << track_id << " = " << (int)armed);
         }
@@ -103,9 +103,9 @@ void TracktionEngineWrapper::setTrackArmed(const std::string& track_id, bool arm
 }
 
 bool TracktionEngineWrapper::isTrackArmed(const std::string& track_id) const {
-    auto track = findTrackById(track_id);
+    auto* track = findTrackById(track_id);
     if (track) {
-        if (auto audioTrack = dynamic_cast<tracktion::AudioTrack*>(track)) {
+        if (auto* audioTrack = dynamic_cast<tracktion::AudioTrack*>(track)) {
             // Simplified - in real implementation would check input recording
             return false;
         }
@@ -114,7 +114,7 @@ bool TracktionEngineWrapper::isTrackArmed(const std::string& track_id) const {
 }
 
 void TracktionEngineWrapper::setTrackColor(const std::string& track_id, int r, int g, int b) {
-    auto track = findTrackById(track_id);
+    auto* track = findTrackById(track_id);
     if (track) {
         track->setColour(juce::Colour::fromRGB(r, g, b));
     }
@@ -171,10 +171,10 @@ void TracktionEngineWrapper::previewNoteOnTrack(const std::string& track_id, int
 }
 
 void TracktionEngineWrapper::setTrackVolume(const std::string& track_id, double volume) {
-    auto track = findTrackById(track_id);
+    auto* track = findTrackById(track_id);
     if (track) {
         // Find VolumeAndPanPlugin on track
-        if (auto volPan =
+        if (auto* volPan =
                 track->pluginList.findFirstPluginOfType<tracktion::VolumeAndPanPlugin>()) {
             // Convert linear gain to dB for the plugin
             float db =
@@ -188,9 +188,9 @@ void TracktionEngineWrapper::setTrackVolume(const std::string& track_id, double 
 }
 
 double TracktionEngineWrapper::getTrackVolume(const std::string& track_id) const {
-    auto track = findTrackById(track_id);
+    auto* track = findTrackById(track_id);
     if (track) {
-        if (auto volPan =
+        if (auto* volPan =
                 track->pluginList.findFirstPluginOfType<tracktion::VolumeAndPanPlugin>()) {
             float db = volPan->getVolumeDb();
             return juce::Decibels::decibelsToGain(db);
@@ -200,9 +200,9 @@ double TracktionEngineWrapper::getTrackVolume(const std::string& track_id) const
 }
 
 void TracktionEngineWrapper::setTrackPan(const std::string& track_id, double pan) {
-    auto track = findTrackById(track_id);
+    auto* track = findTrackById(track_id);
     if (track) {
-        if (auto volPan =
+        if (auto* volPan =
                 track->pluginList.findFirstPluginOfType<tracktion::VolumeAndPanPlugin>()) {
             // Pan is -1.0 (left) to 1.0 (right)
             volPan->setPan(static_cast<float>(pan));
@@ -211,9 +211,9 @@ void TracktionEngineWrapper::setTrackPan(const std::string& track_id, double pan
 }
 
 double TracktionEngineWrapper::getTrackPan(const std::string& track_id) const {
-    auto track = findTrackById(track_id);
+    auto* track = findTrackById(track_id);
     if (track) {
-        if (auto volPan =
+        if (auto* volPan =
                 track->pluginList.findFirstPluginOfType<tracktion::VolumeAndPanPlugin>()) {
             return volPan->getPan();
         }

--- a/magda/daw/engine/TracktionEngineWrapperTracks.cpp
+++ b/magda/daw/engine/TracktionEngineWrapperTracks.cpp
@@ -47,6 +47,7 @@ void TracktionEngineWrapper::deleteTrack(const std::string& track_id) {
             auto magdaTrackId = static_cast<TrackId>(std::stoi(track_id));
             recordingPreviews_.erase(magdaTrackId);
             sessionSlotRecordingTargets_.erase(magdaTrackId);
+            // NOLINTNEXTLINE(bugprone-empty-catch) - the body documents the deliberate ignore
         } catch (const std::exception&) {
             // Non-numeric id: no MAGDA-keyed state to clean up.
         }

--- a/magda/daw/engine/TracktionEngineWrapperTransport.cpp
+++ b/magda/daw/engine/TracktionEngineWrapperTransport.cpp
@@ -111,7 +111,7 @@ void TracktionEngineWrapper::sendAllNotesOffToExternalInserts() {
 
     // Deliberately not gated on isEnabled(): a just-disabled insert may
     // still have a note-on in flight on its hardware synth.
-    for (auto plugin : tracktion::getAllPlugins(*currentEdit_, false)) {
+    for (auto* plugin : tracktion::getAllPlugins(*currentEdit_, false)) {
         auto* insert = dynamic_cast<tracktion::InsertPlugin*>(plugin);
         if (insert == nullptr)
             continue;
@@ -273,7 +273,7 @@ void TracktionEngineWrapper::setTempo(double bpm) {
     if (currentEdit_) {
         auto& tempoSeq = currentEdit_->tempoSequence;
         if (tempoSeq.getNumTempos() > 0) {
-            auto tempo = tempoSeq.getTempo(0);
+            auto* tempo = tempoSeq.getTempo(0);
             if (tempo) {
                 tempo->setBpm(bpm);
             }

--- a/magda/daw/magda_daw_main.cpp
+++ b/magda/daw/magda_daw_main.cpp
@@ -134,7 +134,7 @@ class MagdaDAWApplication : public JUCEApplication {
     bool loadLuaScript(const juce::File& file);
     void unloadLuaScript();
     juce::String activeLuaScriptName() const;
-    void revealLuaScriptsFolder();
+    static void revealLuaScriptsFolder();
 
     /// Handles for the OSC section of ControllersDialog (osc_app.hpp), which
     /// only reads through them. Null before deferred init has run, and after

--- a/magda/daw/media_db/AudioFeatures.cpp
+++ b/magda/daw/media_db/AudioFeatures.cpp
@@ -301,6 +301,8 @@ SpectralAnalysis computeSpectralAnalysis(const juce::AudioBuffer<float>& mono, i
 
         if (analyseKey) {
             for (int bin = 1; bin < kFftBins; ++bin) {
+                // NOLINTNEXTLINE(bugprone-signed-char-misuse) - the sign carries the no-pitch-class
+                // sentinel
                 const int pitchClass = pitchClasses[bin];
                 if (pitchClass >= 0) {
                     chroma[static_cast<std::size_t>(pitchClass)] += fftData[bin];

--- a/magda/daw/media_db/AudioFeatures.cpp
+++ b/magda/daw/media_db/AudioFeatures.cpp
@@ -357,11 +357,11 @@ std::optional<AudioFeatures> extractFeatures(const std::filesystem::path& path) 
 
     // --- BPM: filename > metadata ---
     if (auto p = parseBpmFromPath(path)) {
-        f.bpm = *p;
+        f.bpm = p;
     } else if (auto m = metadataBpm(decoded->metadata)) {
-        f.bpm = *m;
+        f.bpm = m;
     } else if (auto d = dspBpm(path)) {
-        f.bpm = *d;
+        f.bpm = d;
     }
 
     // --- Key: filename > DSP ---

--- a/magda/daw/media_db/MediaDbContext.cpp
+++ b/magda/daw/media_db/MediaDbContext.cpp
@@ -180,6 +180,7 @@ bool MediaDbContext::wipeAll() {
         juce::Logger::writeToLog(juce::String("[wipeAll] failed: ") + e.what());
         try {
             db_->execute("ROLLBACK");
+            // NOLINTNEXTLINE(bugprone-empty-catch) - the body documents the deliberate ignore
         } catch (...) {
             // best-effort cleanup; nothing to do if rollback also fails
         }

--- a/magda/daw/media_db/MediaDbContext.cpp
+++ b/magda/daw/media_db/MediaDbContext.cpp
@@ -28,7 +28,7 @@ MediaDbContext& MediaDbContext::getInstance() {
 MediaDbContext::MediaDbContext() = default;
 MediaDbContext::~MediaDbContext() = default;
 
-std::filesystem::path MediaDbContext::dbPath() const {
+std::filesystem::path MediaDbContext::dbPath() {
     // User override: same fall-back semantics as modelsDir(). Lets users
     // park the (potentially large) index on a different drive without
     // symlinking. If the override directory has gone missing (drive
@@ -48,7 +48,7 @@ std::filesystem::path MediaDbContext::dbPath() const {
            "db" / "media.db";
 }
 
-std::filesystem::path MediaDbContext::modelsDir() const {
+std::filesystem::path MediaDbContext::modelsDir() {
     // User override: if Config has a non-empty path AND it points at a
     // real directory, use it. Lets the user keep the ~600 MB Sample
     // Tagger bundle on an external drive. Falls back to the default

--- a/magda/daw/media_db/MediaDbContext.hpp
+++ b/magda/daw/media_db/MediaDbContext.hpp
@@ -91,8 +91,8 @@ class MediaDbContext {
     // Path helpers. The DB file is fixed at dataDir/MediaDB/media.db; model
     // files live in dataDir/MediaDB/models/ (Phase F's download UI will place
     // them there).
-    [[nodiscard]] std::filesystem::path dbPath() const;
-    [[nodiscard]] std::filesystem::path modelsDir() const;
+    [[nodiscard]] static std::filesystem::path dbPath();
+    [[nodiscard]] static std::filesystem::path modelsDir();
     [[nodiscard]] std::filesystem::path midiClipsDir() const;
     [[nodiscard]] std::filesystem::path progressionsDir() const;
     [[nodiscard]] std::filesystem::path audioModelPath() const;

--- a/magda/daw/media_db/MediaDbMetadata.cpp
+++ b/magda/daw/media_db/MediaDbMetadata.cpp
@@ -10,6 +10,7 @@
 #include <sstream>
 #include <string>
 #include <unordered_map>
+#include <utility>
 
 #include "MediaDatabase.hpp"
 #include "MediaDbContext.hpp"
@@ -415,7 +416,7 @@ void setUserKeyRootForFile(const std::filesystem::path& path, std::optional<std:
     if (!ctx.ensureInitialized()) {
         return;
     }
-    setUserKeyRoot(ctx.db(), path, root);
+    setUserKeyRoot(ctx.db(), path, std::move(root));
 }
 
 void setUserKeyForFile(const std::filesystem::path& path, std::optional<std::string> root,

--- a/magda/daw/media_db/MediaDbQuery.cpp
+++ b/magda/daw/media_db/MediaDbQuery.cpp
@@ -631,6 +631,7 @@ std::vector<QueryResult> MediaDbQuery::search(const std::optional<std::string>& 
                 if (!qvec.empty()) {
                     audio = audioScoresOnCandidates(sql, qvec, cosineCandidates);
                 }
+                // NOLINTNEXTLINE(bugprone-empty-catch) - the body documents the deliberate ignore
             } catch (const ClapTextEncoderError&) {
                 // Treat semantic side as unavailable for this query.
             }

--- a/magda/daw/media_db/PathRules.cpp
+++ b/magda/daw/media_db/PathRules.cpp
@@ -301,6 +301,7 @@ std::optional<double> parseBpmFromPath(const std::filesystem::path& path) {
             if (bpm >= 30.0 && bpm <= 300.0) {
                 result = bpm;  // last sensible match wins
             }
+            // NOLINTNEXTLINE(bugprone-empty-catch) - the body documents the deliberate ignore
         } catch (...) {
             // unparseable group, ignore
         }

--- a/magda/daw/media_db/SampleTaggerDownloader.cpp
+++ b/magda/daw/media_db/SampleTaggerDownloader.cpp
@@ -217,7 +217,7 @@ class SampleTaggerDownloader::Worker : public juce::Thread {
         return hash.toHexString();
     }
 
-    void postProgress(Progress p) {
+    void postProgress(const Progress& p) {
         if (!onProgress_) {
             return;
         }

--- a/magda/daw/media_db/Scan.cpp
+++ b/magda/daw/media_db/Scan.cpp
@@ -124,6 +124,8 @@ void walk(const std::filesystem::path& root, const std::function<void(const Scan
                     if (auto sf = classify(entry.path())) {
                         try {
                             visit(*sf);
+                            // NOLINTNEXTLINE(bugprone-empty-catch) - the body documents the
+                            // deliberate ignore
                         } catch (...) {
                             // A single file's processing failure must not
                             // sink the whole scan; the indexer does its own
@@ -136,6 +138,7 @@ void walk(const std::filesystem::path& root, const std::function<void(const Scan
                         stack.push_back(entry.path());
                     }
                 }
+                // NOLINTNEXTLINE(bugprone-empty-catch) - the body documents the deliberate ignore
             } catch (const std::exception&) {
                 // Bad entry — skip and try to keep going in this directory.
             }

--- a/magda/daw/music/ChordEngine.cpp
+++ b/magda/daw/music/ChordEngine.cpp
@@ -107,7 +107,7 @@ ChordEngine::~ChordEngine() = default;
 
 // === CHORD DETECTION ===
 
-Chord ChordEngine::detect(const std::vector<ChordNote>& heldNotes) const {
+Chord ChordEngine::detect(const std::vector<ChordNote>& heldNotes) {
     if (heldNotes.empty())
         return {"none"};
 
@@ -379,14 +379,13 @@ Chord ChordEngine::detectPolychord(const std::vector<ChordNote>& notes) const {
     return detect(notes);
 }
 
-bool ChordEngine::isPolychordCandidate(const std::vector<ChordNote>& notes) const {
+bool ChordEngine::isPolychordCandidate(const std::vector<ChordNote>& notes) {
     return notes.size() >= 6;
 }
 
 // === CHORD CREATION ===
 
-Chord ChordEngine::buildChordInRootPosition(ChordRoot root, ChordQuality quality,
-                                            int octave) const {
+Chord ChordEngine::buildChordInRootPosition(ChordRoot root, ChordQuality quality, int octave) {
     std::vector<int> intervals = ChordUtils::getChordIntervals(quality);
     std::vector<ChordNote> notes;
 
@@ -413,7 +412,7 @@ std::vector<Chord> ChordEngine::buildChordInversions(ChordRoot root, ChordQualit
 }
 
 Chord ChordEngine::buildChordInversion(ChordRoot root, ChordQuality quality, int inversion,
-                                       int octave) const {
+                                       int octave) {
     std::vector<int> intervals = ChordUtils::getChordIntervals(quality);
     std::vector<ChordNote> notes;
 
@@ -466,7 +465,7 @@ juce::String ChordEngine::chordSpecToString(const ChordSpec& spec, bool includeI
 }
 
 std::vector<std::pair<juce::String, float>> ChordEngine::findChordsFromNotes(
-    const std::vector<int>& pitchClasses) const {
+    const std::vector<int>& pitchClasses) {
     std::vector<std::pair<juce::String, float>> results;
     if (pitchClasses.empty())
         return results;

--- a/magda/daw/music/ChordEngine.cpp
+++ b/magda/daw/music/ChordEngine.cpp
@@ -169,6 +169,7 @@ Chord ChordEngine::detect(const std::vector<ChordNote>& heldNotes) {
             auto intervals = ChordUtils::getChordIntervals(quality);
 
             std::vector<int> chordPitches;
+            chordPitches.reserve(intervals.size());
             for (int interval : intervals)
                 chordPitches.push_back((rootOffset + interval) % 12);
             std::sort(chordPitches.begin(), chordPitches.end());
@@ -391,6 +392,7 @@ Chord ChordEngine::buildChordInRootPosition(ChordRoot root, ChordQuality quality
 
     int rootMidiNote = static_cast<int>(root) + ((octave + 1) * 12);
 
+    notes.reserve(intervals.size());
     for (int interval : intervals)
         notes.emplace_back(rootMidiNote + interval, 100);
 
@@ -406,6 +408,7 @@ std::vector<Chord> ChordEngine::buildChordInversions(ChordRoot root, ChordQualit
                                                      int octave) const {
     std::vector<Chord> inversions;
     int maxInv = getMaxInversions(quality);
+    inversions.reserve(maxInv);
     for (int inv = 0; inv < maxInv; ++inv)
         inversions.push_back(buildChordInversion(root, quality, inv, octave));
     return inversions;
@@ -418,6 +421,7 @@ Chord ChordEngine::buildChordInversion(ChordRoot root, ChordQuality quality, int
 
     const int rootMidiNote = static_cast<int>(root) + ((octave + 1) * 12);
 
+    notes.reserve(intervals.size());
     for (int interval : intervals)
         notes.emplace_back(rootMidiNote + interval, 100);
 
@@ -484,6 +488,7 @@ std::vector<std::pair<juce::String, float>> ChordEngine::findChordsFromNotes(
         for (ChordQuality quality : qualities) {
             auto intervals = ChordUtils::getChordIntervals(quality);
             std::vector<int> chordPitches;
+            chordPitches.reserve(intervals.size());
             for (int interval : intervals)
                 chordPitches.push_back((rootOffset + interval) % 12);
             std::sort(chordPitches.begin(), chordPitches.end());

--- a/magda/daw/music/ChordEngine.hpp
+++ b/magda/daw/music/ChordEngine.hpp
@@ -51,17 +51,17 @@ class ChordEngine {
     ~ChordEngine();
 
     // Detection
-    [[nodiscard]] Chord detect(const std::vector<ChordNote>& heldNotes) const;
+    [[nodiscard]] static Chord detect(const std::vector<ChordNote>& heldNotes);
     Chord smartDetect(const std::vector<ChordNote>& notes) const;
     Chord detectPolychord(const std::vector<ChordNote>& notes) const;
-    bool isPolychordCandidate(const std::vector<ChordNote>& notes) const;
+    static bool isPolychordCandidate(const std::vector<ChordNote>& notes);
 
     // Creation
-    Chord buildChordInRootPosition(ChordRoot root, ChordQuality quality, int octave = 4) const;
+    static Chord buildChordInRootPosition(ChordRoot root, ChordQuality quality, int octave = 4);
     std::vector<Chord> buildChordInversions(ChordRoot root, ChordQuality quality,
                                             int octave = 4) const;
-    Chord buildChordInversion(ChordRoot root, ChordQuality quality, int inversion,
-                              int octave = 4) const;
+    static Chord buildChordInversion(ChordRoot root, ChordQuality quality, int inversion,
+                                     int octave = 4);
 
     // Utility
     static std::vector<int> getChordIntervals(ChordQuality quality);
@@ -69,8 +69,8 @@ class ChordEngine {
     static int getChordNoteCount(ChordQuality quality);
     static ChordSpec parseChordName(const juce::String& chordString);
     static juce::String chordSpecToString(const ChordSpec& spec, bool includeInversion = true);
-    std::vector<std::pair<juce::String, float>> findChordsFromNotes(
-        const std::vector<int>& pitchClasses) const;
+    static std::vector<std::pair<juce::String, float>> findChordsFromNotes(
+        const std::vector<int>& pitchClasses);
 
     // Finalize chord (sort notes, detect inversion, set displayName)
     static void finalizeChord(Chord& c);

--- a/magda/daw/music/ChordSuggestionEngine.cpp
+++ b/magda/daw/music/ChordSuggestionEngine.cpp
@@ -220,7 +220,7 @@ std::pair<juce::String, juce::String> ChordSuggestionEngine::inferKeyModeFromCon
 
         // Count root notes
         if (chord.rootNoteNumber >= 0) {
-            const juce::String rootName = NOTE_NAMES[chord.rootNoteNumber % 12];
+            const juce::String& rootName = NOTE_NAMES[chord.rootNoteNumber % 12];
             rootCounts[rootName]++;
         }
 
@@ -498,7 +498,7 @@ std::vector<ChordSuggestionEngine::SuggestionItem> ChordSuggestionEngine::genera
         // Final safety: synthesize only when novelty allows non-diatonic/fallback content
         if (params.novelty > 0.0f) {
             for (int i = 0; i < 12 && static_cast<int>(suggestions.size()) < minDesired; ++i) {
-                juce::String rootName = NOTE_NAMES[i];
+                const juce::String& rootName = NOTE_NAMES[i];
                 juce::String quality = (i % 2 == 0) ? "maj" : "min";
                 auto chord = buildChordObject(rootName, quality, targetOctave, effectiveInversions,
                                               recentChords);
@@ -910,9 +910,9 @@ ChordSuggestionEngine::generateNonDiatonicCandidates(const juce::String& key,
             std::vector<ChordNote> notes;
             notes.reserve(lowerNotes.size() + upperNotes.size());
             for (int n : lowerNotes)
-                notes.push_back({n, 100});
+                notes.emplace_back(n, 100);
             for (int n : upperNotes)
-                notes.push_back({n, 100});
+                notes.emplace_back(n, 100);
             std::sort(notes.begin(), notes.end(),
                       [](auto& a, auto& b) { return a.noteNumber < b.noteNumber; });
 
@@ -1124,7 +1124,7 @@ Chord ChordSuggestionEngine::buildChordInRootPosition(const juce::String& root,
     // Helpers
     auto addNote = [&](int midi) {
         if (midi >= 0)
-            notes.push_back({midi, 100});
+            notes.emplace_back(midi, 100);
     };
     auto ensureSorted = [&]() {
         std::sort(notes.begin(), notes.end(),
@@ -1996,7 +1996,7 @@ juce::String ChordSuggestionEngine::getDetectedScalesString(float /*novelty*/) c
             // Only show scales with good confidence
             if (matchScore.matchedNotes.size() >= 3) {
                 // Format scale name without duplicating root note
-                juce::String rootNote = NOTE_NAMES[scale.rootNote % 12];
+                const juce::String& rootNote = NOTE_NAMES[scale.rootNote % 12];
                 juce::String scaleName = juce::String(scale.name);
 
                 // Check if scale name already starts with the root note
@@ -2124,7 +2124,7 @@ std::vector<std::pair<juce::String, juce::String>> ChordSuggestionEngine::getTop
                     scaleName = scaleName.replace("Aeolian", "Minor");
                 }
 
-                topScales.push_back({rootNote, scaleName});
+                topScales.emplace_back(rootNote, scaleName);
             }
         }
 

--- a/magda/daw/music/ChordSuggestionEngine.cpp
+++ b/magda/daw/music/ChordSuggestionEngine.cpp
@@ -201,7 +201,7 @@ ChordSuggestionEngine::inferKeyModeFromHistogram() const {
 }
 
 std::pair<juce::String, juce::String> ChordSuggestionEngine::inferKeyModeFromContext(
-    const std::vector<Chord>& recentChords) const {
+    const std::vector<Chord>& recentChords) {
     if (recentChords.empty()) {
         return {"C", "major"};
     }
@@ -256,7 +256,7 @@ std::pair<juce::String, juce::String> ChordSuggestionEngine::inferKeyModeFromCon
 }
 
 double ChordSuggestionEngine::dotProduct(const std::array<double, 12>& a,
-                                         const std::array<double, 12>& b) const {
+                                         const std::array<double, 12>& b) {
     double sum = 0.0;
     for (int i = 0; i < 12; ++i) {
         sum += a[i] * b[i];
@@ -265,7 +265,7 @@ double ChordSuggestionEngine::dotProduct(const std::array<double, 12>& a,
 }
 
 std::array<double, 12> ChordSuggestionEngine::rotateProfile(const std::array<double, 12>& profile,
-                                                            int shift) const {
+                                                            int shift) {
     std::array<double, 12> rotated{};
     shift = shift % 12;
     if (shift < 0)
@@ -945,7 +945,7 @@ ChordSuggestionEngine::generateNonDiatonicCandidates(const juce::String& key,
 
 std::vector<ChordSuggestionEngine::SuggestionItem> ChordSuggestionEngine::mixCandidates(
     const std::vector<SuggestionItem>& diatonic, const std::vector<SuggestionItem>& nonDiatonic,
-    float novelty, int topK) const {
+    float novelty, int topK) {
     std::vector<SuggestionItem> result;
 
     if (novelty <= 0.0f) {
@@ -1086,7 +1086,7 @@ juce::String ChordSuggestionEngine::noteAtSemitone(const juce::String& root, int
     return NOTE_NAMES[targetIdx];
 }
 
-int ChordSuggestionEngine::noteToSemitone(const juce::String& note) const {
+int ChordSuggestionEngine::noteToSemitone(const juce::String& note) {
     // Handle enharmonic equivalents
     static const std::map<juce::String, int> noteMap = {
         {"C", 0},  {"C#", 1}, {"Db", 1},  {"D", 2},   {"D#", 3}, {"Eb", 3},
@@ -1228,7 +1228,7 @@ Chord ChordSuggestionEngine::buildChordInRootPosition(const juce::String& root,
     return chord;
 }
 
-int ChordSuggestionEngine::calculateTargetOctave(const std::vector<Chord>& recentChords) const {
+int ChordSuggestionEngine::calculateTargetOctave(const std::vector<Chord>& recentChords) {
     if (recentChords.empty()) {
         return 4;  // Default to octave 4 (C4 = 60)
     }
@@ -1450,7 +1450,7 @@ Chord ChordSuggestionEngine::optimizeVoicing(const Chord& chord, float inversion
     return result;
 }
 
-std::vector<Chord> ChordSuggestionEngine::generateInversions(const Chord& chord) const {
+std::vector<Chord> ChordSuggestionEngine::generateInversions(const Chord& chord) {
     std::vector<Chord> inversions;
 
     if (chord.notes.size() < 2) {
@@ -1669,7 +1669,7 @@ std::vector<Chord> ChordSuggestionEngine::generateInversions(const Chord& chord)
     return inversions;
 }
 
-double ChordSuggestionEngine::calculateCentroid(const Chord& chord) const {
+double ChordSuggestionEngine::calculateCentroid(const Chord& chord) {
     if (chord.notes.empty()) {
         return 60.0;  // Default to C4
     }
@@ -1687,7 +1687,7 @@ double ChordSuggestionEngine::calculateCentroid(const Chord& chord) const {
     return count > 0 ? (total / count) : 60.0;
 }
 
-bool ChordSuggestionEngine::chordsAreEquivalent(const Chord& a, const Chord& b) const {
+bool ChordSuggestionEngine::chordsAreEquivalent(const Chord& a, const Chord& b) {
     // First check if they have the same pitch classes (notes)
     if (!magda::music::chordsAreEquivalent(a, b)) {
         return false;
@@ -1778,7 +1778,7 @@ juce::String ChordSuggestionEngine::getContextTailString(int maxChords) const {
 }
 
 std::vector<ChordSuggestionEngine::SuggestionItem> ChordSuggestionEngine::filterRecentChords(
-    const std::vector<SuggestionItem>& candidates, const std::vector<Chord>& recentChords) const {
+    const std::vector<SuggestionItem>& candidates, const std::vector<Chord>& recentChords) {
     std::vector<SuggestionItem> filtered;
 
     // Get last 2 chords to avoid (reduced from 3 to give more variety and prevent stale

--- a/magda/daw/music/ChordSuggestionEngine.cpp
+++ b/magda/daw/music/ChordSuggestionEngine.cpp
@@ -2128,6 +2128,7 @@ std::vector<std::pair<juce::String, juce::String>> ChordSuggestionEngine::getTop
             }
         }
 
+        // NOLINTNEXTLINE(bugprone-empty-catch) - the body documents the deliberate ignore
     } catch (const std::exception& e) {
         // Return empty vector on error
     }

--- a/magda/daw/music/ChordSuggestionEngine.hpp
+++ b/magda/daw/music/ChordSuggestionEngine.hpp
@@ -48,15 +48,15 @@ class ChordSuggestionEngine {
     juce::String getContextTailString(int maxChords = 8) const;
 
     std::optional<std::pair<juce::String, juce::String>> inferKeyModeFromHistogram() const;
-    std::pair<juce::String, juce::String> inferKeyModeFromContext(
-        const std::vector<Chord>& recentChords) const;
+    static std::pair<juce::String, juce::String> inferKeyModeFromContext(
+        const std::vector<Chord>& recentChords);
     std::optional<std::pair<juce::String, juce::String>> inferKeyModeFromScaleDetection() const;
 
     juce::String getDetectedScalesString(float novelty = 0.3f) const;
     std::vector<std::pair<juce::String, juce::String>> getTopDetectedScales(
         int maxScales = 3, float novelty = 0.3f) const;
 
-    int calculateTargetOctave(const std::vector<Chord>& recentChords) const;
+    static int calculateTargetOctave(const std::vector<Chord>& recentChords);
 
     Chord buildChordObject(const juce::String& root, const juce::String& quality, int targetOctave,
                            float inversionStrength, const std::vector<Chord>& recentChords) const;
@@ -83,11 +83,11 @@ class ChordSuggestionEngine {
     static const std::array<juce::String, 12> NOTE_NAMES;
 
     std::array<double, 12> getDecayedHistogram(double currentTimeSeconds) const;
-    double dotProduct(const std::array<double, 12>& a, const std::array<double, 12>& b) const;
-    std::array<double, 12> rotateProfile(const std::array<double, 12>& profile, int shift) const;
+    static double dotProduct(const std::array<double, 12>& a, const std::array<double, 12>& b);
+    static std::array<double, 12> rotateProfile(const std::array<double, 12>& profile, int shift);
 
-    std::vector<SuggestionItem> filterRecentChords(const std::vector<SuggestionItem>& candidates,
-                                                   const std::vector<Chord>& recentChords) const;
+    static std::vector<SuggestionItem> filterRecentChords(
+        const std::vector<SuggestionItem>& candidates, const std::vector<Chord>& recentChords);
 
     std::vector<SuggestionItem> generateDiatonicCandidates(
         const juce::String& key, const juce::String& mode, bool add7ths, bool add9ths,
@@ -98,18 +98,18 @@ class ChordSuggestionEngine {
         const juce::String& key, const juce::String& mode, bool addAlterations, bool addSlashChords,
         int targetOctave, float inversionStrength, const std::vector<Chord>& recentChords) const;
 
-    std::vector<SuggestionItem> mixCandidates(const std::vector<SuggestionItem>& diatonic,
-                                              const std::vector<SuggestionItem>& nonDiatonic,
-                                              float novelty, int topK) const;
+    static std::vector<SuggestionItem> mixCandidates(const std::vector<SuggestionItem>& diatonic,
+                                                     const std::vector<SuggestionItem>& nonDiatonic,
+                                                     float novelty, int topK);
 
     juce::String noteAtSemitone(const juce::String& root, int semitones) const;
-    int noteToSemitone(const juce::String& note) const;
-    bool chordsAreEquivalent(const Chord& a, const Chord& b) const;
+    static int noteToSemitone(const juce::String& note);
+    static bool chordsAreEquivalent(const Chord& a, const Chord& b);
 
     Chord optimizeVoicing(const Chord& chord, float inversionStrength,
                           const std::vector<Chord>& recentChords) const;
-    std::vector<Chord> generateInversions(const Chord& chord) const;
-    double calculateCentroid(const Chord& chord) const;
+    static std::vector<Chord> generateInversions(const Chord& chord);
+    static double calculateCentroid(const Chord& chord);
 };
 
 }  // namespace magda::music

--- a/magda/daw/profiling/PerformanceProfiler.hpp
+++ b/magda/daw/profiling/PerformanceProfiler.hpp
@@ -6,6 +6,7 @@
 #include <limits>
 #include <string>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 namespace magda {
@@ -60,8 +61,8 @@ class HighResTimer {
  */
 class ScopedProfiler {
   public:
-    explicit ScopedProfiler(const juce::String& name, bool enabled = true)
-        : name_(name), enabled_(enabled) {
+    explicit ScopedProfiler(juce::String name, bool enabled = true)
+        : name_(std::move(name)), enabled_(enabled) {
         if (enabled_) {
             timer_.reset();
         }
@@ -227,7 +228,7 @@ class PerformanceMonitor {
  */
 class MonitoredProfiler {
   public:
-    explicit MonitoredProfiler(const juce::String& category) : category_(category), timer_() {}
+    explicit MonitoredProfiler(juce::String category) : category_(std::move(category)), timer_() {}
 
     ~MonitoredProfiler() {
         try {

--- a/magda/daw/project/MediaCollector.cpp
+++ b/magda/daw/project/MediaCollector.cpp
@@ -98,7 +98,7 @@ MediaCollector::Plan MediaCollector::scan() {
             return -1;
         }
 
-        const auto key = file.getFullPathName();
+        const auto& key = file.getFullPathName();
         auto it = indexByPath.find(key);
         if (it != indexByPath.end())
             return static_cast<long>(it->second);

--- a/magda/daw/project/ProjectManager.cpp
+++ b/magda/daw/project/ProjectManager.cpp
@@ -922,7 +922,7 @@ void ProjectManager::createTempMediaDirectory() {
 void ProjectManager::ensureMediaSubdirectories(const juce::File& mediaRoot) {
     if (mediaRoot == juce::File())
         return;
-    for (auto* subdir : kMediaSubdirs) {
+    for (const auto* subdir : kMediaSubdirs) {
         mediaRoot.getChildFile(subdir).createDirectory();
     }
 }
@@ -936,7 +936,7 @@ void ProjectManager::migrateMediaFiles(const juce::File& oldDir, const juce::Fil
     // recorded correctly, and nothing may be stranded in the directory being
     // left behind.
     std::map<juce::String, juce::String> moves;
-    for (auto* subdir : kMediaSubdirs)
+    for (const auto* subdir : kMediaSubdirs)
         moveMediaTree(oldDir.getChildFile(subdir), newDir.getChildFile(subdir), moves,
                       OnCollision::Uniquify);
 

--- a/magda/daw/project/ProjectManager.cpp
+++ b/magda/daw/project/ProjectManager.cpp
@@ -425,7 +425,7 @@ bool ProjectManager::saveProjectAs(const juce::File& file) {
 }
 
 bool ProjectManager::loadProject(const juce::File& file,
-                                 std::function<void(const ProjectInfo&)> onBeforeCommit) {
+                                 const std::function<void(const ProjectInfo&)>& onBeforeCommit) {
     // Check for unsaved changes in current project
     if (isDirty_ && !showUnsavedChangesDialog()) {
         return false;
@@ -521,8 +521,8 @@ bool ProjectManager::exportDawProject(const juce::File& file) {
 }
 
 void ProjectManager::importDawProjectAsync(
-    const juce::File& file, std::function<void(const ProjectInfo&)> onBeforeCommit,
-    std::function<void(bool, const juce::String&)> onComplete) {
+    const juce::File& file, const std::function<void(const ProjectInfo&)>& onBeforeCommit,
+    const std::function<void(bool, const juce::String&)>& onComplete) {
     // Pre-flight checks on the message thread.
     if (isDirty_ && !showUnsavedChangesDialog()) {
         if (onComplete)
@@ -548,7 +548,7 @@ void ProjectManager::importDawProjectAsync(
     joinBackgroundThread();
 
     const auto startingRevision = mutationRevision_;
-    auto fileCopy = file;
+    const auto& fileCopy = file;
     loadThread_ =
         std::thread([fileCopy, importedDir, startingRevision, onBeforeCommit, onComplete, this]() {
             auto staged = std::make_shared<StagedProjectData>();
@@ -599,9 +599,9 @@ void ProjectManager::importDawProjectAsync(
         });
 }
 
-void ProjectManager::loadProjectAsync(const juce::File& file,
-                                      std::function<void(const ProjectInfo&)> onBeforeCommit,
-                                      std::function<void(bool, const juce::String&)> onComplete) {
+void ProjectManager::loadProjectAsync(
+    const juce::File& file, const std::function<void(const ProjectInfo&)>& onBeforeCommit,
+    const std::function<void(bool, const juce::String&)>& onComplete) {
     // Pre-flight checks on the message thread
     if (isDirty_ && !showUnsavedChangesDialog()) {
         if (onComplete)
@@ -635,7 +635,7 @@ void ProjectManager::loadProjectAsync(const juce::File& file,
     joinBackgroundThread();
 
     const auto startingRevision = mutationRevision_;
-    auto originalFile = file;
+    const auto& originalFile = file;
 
     // Launch background thread for I/O + parse + staging
     loadThread_ = std::thread([fileCopy, originalFile, recoveredFromAutosave, onBeforeCommit,

--- a/magda/daw/project/ProjectManager.hpp
+++ b/magda/daw/project/ProjectManager.hpp
@@ -379,7 +379,7 @@ class ProjectManager {
     /**
      * @brief Migrate media files from old directory to new, updating clip paths
      */
-    void migrateMediaFiles(const juce::File& oldDir, const juce::File& newDir);
+    static void migrateMediaFiles(const juce::File& oldDir, const juce::File& newDir);
 
     /**
      * @brief Fold the media roots retired by #2170 into the surviving three.

--- a/magda/daw/project/ProjectManager.hpp
+++ b/magda/daw/project/ProjectManager.hpp
@@ -97,7 +97,7 @@ class ProjectManager {
      * @return true on success
      */
     bool loadProject(const juce::File& file,
-                     std::function<void(const ProjectInfo&)> onBeforeCommit = nullptr);
+                     const std::function<void(const ProjectInfo&)>& onBeforeCommit = nullptr);
 
     /**
      * @brief Export the current project to a .dawproject interchange archive.
@@ -113,8 +113,8 @@ class ProjectManager {
      * @param onComplete (success, errorMessage); empty error on user cancel.
      */
     void importDawProjectAsync(const juce::File& file,
-                               std::function<void(const ProjectInfo&)> onBeforeCommit,
-                               std::function<void(bool, const juce::String&)> onComplete);
+                               const std::function<void(const ProjectInfo&)>& onBeforeCommit,
+                               const std::function<void(bool, const juce::String&)>& onComplete);
 
     /**
      * @brief Load project asynchronously (heavy I/O on background thread, commit on message thread)
@@ -125,8 +125,8 @@ class ProjectManager {
      * @param onComplete Callback invoked on message thread after commit: (success, errorMessage)
      */
     void loadProjectAsync(const juce::File& file,
-                          std::function<void(const ProjectInfo&)> onBeforeCommit,
-                          std::function<void(bool, const juce::String&)> onComplete);
+                          const std::function<void(const ProjectInfo&)>& onBeforeCommit,
+                          const std::function<void(bool, const juce::String&)>& onComplete);
 
     /**
      * @brief Close current project

--- a/magda/daw/project/serialization/DawProjectXmlAdapter.cpp
+++ b/magda/daw/project/serialization/DawProjectXmlAdapter.cpp
@@ -164,12 +164,12 @@ void addAutomationPoints(juce::XmlElement& parent, const juce::String& id,
 void addTrackAutomation(juce::XmlElement& trackLanes, const ProjectDocument& document,
                         const TrackInfo& track) {
     const auto volumeTarget = ControlTarget::trackVolume(track.id);
-    if (auto* lane = findAbsoluteLane(document, volumeTarget))
+    if (const auto* lane = findAbsoluteLane(document, volumeTarget))
         addAutomationPoints(trackLanes, idFor("volumeAutomation", track.id),
                             idFor("volume", track.id), *lane);
 
     const auto panTarget = ControlTarget::trackPan(track.id);
-    if (auto* lane = findAbsoluteLane(document, panTarget))
+    if (const auto* lane = findAbsoluteLane(document, panTarget))
         addAutomationPoints(trackLanes, idFor("panAutomation", track.id), idFor("pan", track.id),
                             *lane);
 }

--- a/magda/daw/project/serialization/DawProjectXmlAdapter.cpp
+++ b/magda/daw/project/serialization/DawProjectXmlAdapter.cpp
@@ -558,7 +558,7 @@ void addBuiltinParam(DeviceInfo& device, int slot, juce::StringRef name, double 
 // explicit ms unit just in case a host writes one.
 double dawSecondsToMs(const juce::XmlElement& e) {
     const double v = e.getDoubleAttribute("value");
-    const auto unit = e.getStringAttribute("unit");
+    const auto& unit = e.getStringAttribute("unit");
     return (unit == "milliseconds" || unit == "ms") ? v : v * 1000.0;
 }
 
@@ -1164,7 +1164,7 @@ bool DawProjectXmlAdapter::fromProjectXml(const juce::String& xml, ProjectDocume
                 track.name =
                     trackElement->getStringAttribute("name", "Track " + juce::String(track.id));
                 track.colour = colourFromDawProject(trackElement->getStringAttribute("color"));
-                const auto contentType = trackElement->getStringAttribute("contentType");
+                const auto& contentType = trackElement->getStringAttribute("contentType");
                 track.type = contentType.contains("tracks") ? TrackType::Group : TrackType::Media;
                 track.parentId = parentId;
                 const size_t trackIndex = document.tracks.size();
@@ -1252,7 +1252,7 @@ bool DawProjectXmlAdapter::fromProjectXml(const juce::String& xml, ProjectDocume
                                     parseEqualizerDevice(*devEl, device);
                                 if (auto* enabled = devEl->getChildByName("Enabled"))
                                     device.bypassed = !enabled->getBoolAttribute("value", true);
-                                track.chain.fxChainElements.push_back(std::move(device));
+                                track.chain.fxChainElements.emplace_back(std::move(device));
                                 continue;
                             }
 
@@ -1283,7 +1283,7 @@ bool DawProjectXmlAdapter::fromProjectXml(const juce::String& xml, ProjectDocume
                             if (auto* state = devEl->getChildByName("State"))
                                 device.pluginState = state->getStringAttribute("path");
 
-                            track.chain.fxChainElements.push_back(std::move(device));
+                            track.chain.fxChainElements.emplace_back(std::move(device));
                         }
                     }
                 }

--- a/magda/daw/stem_separation/StemModelDownloader.cpp
+++ b/magda/daw/stem_separation/StemModelDownloader.cpp
@@ -303,7 +303,7 @@ class StemModelDownloader::Worker : public juce::Thread {
         return hash.toHexString();
     }
 
-    void postProgress(Progress p) {
+    void postProgress(const Progress& p) {
         if (!onProgress_)
             return;
         auto cb = onProgress_;

--- a/magda/daw/stem_separation/StemSeparationService.cpp
+++ b/magda/daw/stem_separation/StemSeparationService.cpp
@@ -97,7 +97,7 @@ juce::File writeStemWav(const juce::File& dir, const juce::String& baseName, con
                             static_cast<unsigned int>(stem.audio.getNumChannels()), 32, {}, 0));
     if (writer == nullptr)
         return {};
-    stream.release();  // writer owns it now
+    static_cast<void>(stream.release());  // writer owns it now
 
     if (!writer->writeFromAudioSampleBuffer(stem.audio, 0, stem.audio.getNumSamples()))
         return {};

--- a/magda/daw/stem_separation/StemSeparationService.hpp
+++ b/magda/daw/stem_separation/StemSeparationService.hpp
@@ -42,7 +42,7 @@ class StemSeparationService {
     // True when the engine can run right now (backend compiled in and, for
     // model-based engines, weights installed). UI uses this to enable items
     // or deep-link to the model download instead.
-    [[nodiscard]] bool isEngineAvailable(Engine engine);
+    [[nodiscard]] static bool isEngineAvailable(Engine engine);
 
     // True while a split is running or queued; the UI shows progress for it.
     [[nodiscard]] bool isBusy() const;

--- a/magda/daw/transcription/TranscriptionService.cpp
+++ b/magda/daw/transcription/TranscriptionService.cpp
@@ -149,8 +149,12 @@ bool TranscriptionService::isAvailable() {
 }
 
 void TranscriptionService::transcribeAudioClip(ClipId sourceClipId, Completion onComplete) {
-    auto fail = [onComplete = std::move(onComplete)](const juce::String& msg) mutable {
-        auto cb = std::move(onComplete);
+    // Shared so the failure path and the pool job draw on the same callback:
+    // moving it into `fail` left the success path below with an empty one.
+    auto completion = std::make_shared<Completion>(std::move(onComplete));
+
+    auto fail = [completion](const juce::String& msg) {
+        auto cb = std::move(*completion);
         juce::MessageManager::callAsync([cb = std::move(cb), msg]() mutable {
             if (cb)
                 cb(INVALID_CLIP_ID, msg);
@@ -181,9 +185,6 @@ void TranscriptionService::transcribeAudioClip(ClipId sourceClipId, Completion o
     const double lengthBeats = clip->placement.lengthBeats;
     const double offsetSec = audioEventRef(*clip).anchorSeconds();
     const double bpm = projectBpm();
-
-    // onComplete needs to survive the lambda copy into the pool.
-    auto completion = std::make_shared<Completion>(std::move(onComplete));
 
     pool_->addJob([this, filePath, sourceName, sourceTrackId, view, startBeat, lengthBeats,
                    offsetSec, bpm, completion]() {

--- a/magda/daw/ui/components/automation/AutomationClipComponent.cpp
+++ b/magda/daw/ui/components/automation/AutomationClipComponent.cpp
@@ -417,7 +417,7 @@ AutomationLaneComponent* AutomationClipComponent::getLane() const {
     return findParentComponentOfClass<AutomationLaneComponent>();
 }
 
-bool AutomationClipComponent::copyGestureHeld() const {
+bool AutomationClipComponent::copyGestureHeld() {
     return GestureRouter::getInstance().isDuplicateOnDrag(
         GestureContext::Arrangement, juce::ModifierKeys::getCurrentModifiers());
 }

--- a/magda/daw/ui/components/automation/AutomationClipComponent.hpp
+++ b/magda/daw/ui/components/automation/AutomationClipComponent.hpp
@@ -82,7 +82,7 @@ class AutomationClipComponent : public juce::Component,
   private:
     class AutomationLaneComponent* getLane() const;
     /// True while the copy-on-drag gesture (default Alt) is held.
-    bool copyGestureHeld() const;
+    static bool copyGestureHeld();
 
     AutomationClipId clipId_;
     double pixelsPerBeat_ = 10.0;
@@ -112,7 +112,7 @@ class AutomationClipComponent : public juce::Component,
     // Helpers
     void showContextMenu();
     void updateCursor(int x);
-    bool isOnLeftEdge(int x) const {
+    static static static bool isOnLeftEdge(int x) {
         return x < RESIZE_EDGE_WIDTH;
     }
     bool isOnRightEdge(int x) const {

--- a/magda/daw/ui/components/automation/AutomationLaneComponent.cpp
+++ b/magda/daw/ui/components/automation/AutomationLaneComponent.cpp
@@ -915,7 +915,7 @@ juce::String AutomationLaneComponent::formatScaleValue(double normalizedValue) c
     return juce::String(static_cast<int>(normalizedValue * 100)) + "%";
 }
 
-int AutomationLaneComponent::valueToPixel(double value, int areaHeight) const {
+int AutomationLaneComponent::valueToPixel(double value, int areaHeight) {
     return static_cast<int>((1.0 - value) * areaHeight);
 }
 

--- a/magda/daw/ui/components/automation/AutomationLaneComponent.hpp
+++ b/magda/daw/ui/components/automation/AutomationLaneComponent.hpp
@@ -187,7 +187,7 @@ class AutomationLaneComponent : public juce::Component,
     // Scale label helpers
     void paintScaleLabels(juce::Graphics& g, juce::Rectangle<int> area);
     juce::String formatScaleValue(double normalizedValue) const;
-    int valueToPixel(double value, int areaHeight) const;
+    static int valueToPixel(double value, int areaHeight);
 };
 
 }  // namespace magda

--- a/magda/daw/ui/components/automation/AutomationLaneHeader.cpp
+++ b/magda/daw/ui/components/automation/AutomationLaneHeader.cpp
@@ -419,27 +419,25 @@ void paintAutomationLaneHeader(juce::Graphics& g, const AutomationLaneInfo& lane
                 for (const auto& [db, label] : dbValues) {
                     float norm =
                         ParameterUtils::realToNormalized(static_cast<float>(db), paramInfo);
-                    gridValues.push_back({static_cast<double>(norm), label});
+                    gridValues.emplace_back(static_cast<double>(norm), label);
                 }
             } else if (lane.target.kind == ControlTarget::Kind::TrackPan) {
-                gridValues.push_back(
-                    {static_cast<double>(ParameterUtils::realToNormalized(1.0f, paramInfo)), "R"});
-                gridValues.push_back(
-                    {static_cast<double>(ParameterUtils::realToNormalized(0.5f, paramInfo)),
-                     "50R"});
-                gridValues.push_back(
-                    {static_cast<double>(ParameterUtils::realToNormalized(0.0f, paramInfo)), "C"});
-                gridValues.push_back(
-                    {static_cast<double>(ParameterUtils::realToNormalized(-0.5f, paramInfo)),
-                     "50L"});
-                gridValues.push_back(
-                    {static_cast<double>(ParameterUtils::realToNormalized(-1.0f, paramInfo)), "L"});
+                gridValues.emplace_back(
+                    static_cast<double>(ParameterUtils::realToNormalized(1.0f, paramInfo)), "R");
+                gridValues.emplace_back(
+                    static_cast<double>(ParameterUtils::realToNormalized(0.5f, paramInfo)), "50R");
+                gridValues.emplace_back(
+                    static_cast<double>(ParameterUtils::realToNormalized(0.0f, paramInfo)), "C");
+                gridValues.emplace_back(
+                    static_cast<double>(ParameterUtils::realToNormalized(-0.5f, paramInfo)), "50L");
+                gridValues.emplace_back(
+                    static_cast<double>(ParameterUtils::realToNormalized(-1.0f, paramInfo)), "L");
             } else if (paramInfo.scale == ParameterScale::Boolean) {
                 // A switch has exactly two meaningful positions. Without
                 // this it falls through to the 10% grid at the bottom of
                 // the chain and reads as a continuous percentage.
-                gridValues.push_back({1.0, "On"});
-                gridValues.push_back({0.0, "Off"});
+                gridValues.emplace_back(1.0, "On");
+                gridValues.emplace_back(0.0, "Off");
             } else if (paramInfo.isBipolar()) {
                 // Bipolar params (EQ gain, pitch, etc): symmetric labels
                 // around zero so the 0 line lands mid-lane. Use the larger
@@ -457,7 +455,7 @@ void paintAutomationLaneHeader(juce::Graphics& g, const AutomationLaneInfo& lane
                     else
                         label = juce::String(rounded);
                     label += paramInfo.unit;
-                    gridValues.push_back({static_cast<double>(norm), label});
+                    gridValues.emplace_back(static_cast<double>(norm), label);
                 }
             } else if (paramInfo.scale == ParameterScale::Discrete && !paramInfo.choices.empty()) {
                 // Discrete: use the choices array as label source. Each
@@ -471,15 +469,15 @@ void paintAutomationLaneHeader(juce::Graphics& g, const AutomationLaneInfo& lane
                 if (!paramInfo.labelTicks.empty()) {
                     for (const auto& [realValue, label] : paramInfo.labelTicks) {
                         float norm = ParameterUtils::realToNormalized(realValue, paramInfo);
-                        gridValues.push_back({static_cast<double>(norm), label});
+                        gridValues.emplace_back(static_cast<double>(norm), label);
                     }
                 } else {
                     int numChoices = static_cast<int>(paramInfo.choices.size());
                     for (int i = 0; i < numChoices; ++i) {
                         float norm =
                             ParameterUtils::realToNormalized(static_cast<float>(i), paramInfo);
-                        gridValues.push_back(
-                            {static_cast<double>(norm), paramInfo.choices[static_cast<size_t>(i)]});
+                        gridValues.emplace_back(static_cast<double>(norm),
+                                                paramInfo.choices[static_cast<size_t>(i)]);
                     }
                 }
             } else if (paramInfo.unit.isNotEmpty()) {
@@ -490,7 +488,7 @@ void paintAutomationLaneHeader(juce::Graphics& g, const AutomationLaneInfo& lane
                         ParameterUtils::normalizedToReal(static_cast<float>(norm), paramInfo);
                     juce::String label =
                         juce::String(static_cast<int>(std::round(real))) + paramInfo.unit;
-                    gridValues.push_back({norm, label});
+                    gridValues.emplace_back(norm, label);
                 }
             } else if (paramInfo.displayText) {
                 // displayText wraps TE's valueToString, which expects a
@@ -511,22 +509,21 @@ void paintAutomationLaneHeader(juce::Graphics& g, const AutomationLaneInfo& lane
                         teRaw = paramInfo.teMinValue + static_cast<float>(norm) * teSpan;
                     }
                     auto text = paramInfo.displayText->format(teRaw);
-                    gridValues.push_back(
-                        {norm, text.isNotEmpty()
-                                   ? text
-                                   : juce::String(static_cast<int>(norm * 100)) + "%"});
+                    gridValues.emplace_back(
+                        norm, text.isNotEmpty() ? text
+                                                : juce::String(static_cast<int>(norm * 100)) + "%");
                 }
             } else if (!paramInfo.valueTable.empty()) {
                 for (double norm : {0.0, 0.25, 0.5, 0.75, 1.0}) {
                     int idx = juce::jlimit(
                         0, static_cast<int>(paramInfo.valueTable.size()) - 1,
                         static_cast<int>(std::round(norm * (paramInfo.valueTable.size() - 1))));
-                    gridValues.push_back(
-                        {norm, paramInfo.valueTable[static_cast<size_t>(idx)].trim()});
+                    gridValues.emplace_back(norm,
+                                            paramInfo.valueTable[static_cast<size_t>(idx)].trim());
                 }
             } else {
                 for (int i = 1; i < 10; ++i)
-                    gridValues.push_back({i / 10.0, juce::String(i * 10) + "%"});
+                    gridValues.emplace_back(i / 10.0, juce::String(i * 10) + "%");
             }
 
             g.setFont(FontManager::getInstance().getUIFont(8.0f));

--- a/magda/daw/ui/components/automation/AutomationMenu.cpp
+++ b/magda/daw/ui/components/automation/AutomationMenu.cpp
@@ -13,8 +13,9 @@
 
 namespace magda {
 
-void showAutomationMenu(TrackId trackId, juce::Component* relativeTo,
-                        std::function<void(TrackId, AutomationLaneId)> onShowAutomationLane) {
+void showAutomationMenu(
+    TrackId trackId, juce::Component* relativeTo,
+    const std::function<void(TrackId, AutomationLaneId)>& onShowAutomationLane) {
     auto& automationManager = AutomationManager::getInstance();
 
     juce::PopupMenu menu;

--- a/magda/daw/ui/components/automation/AutomationMenu.hpp
+++ b/magda/daw/ui/components/automation/AutomationMenu.hpp
@@ -23,7 +23,8 @@ namespace magda {
  *        the host can scroll it into view. The master band updates via its own
  *        AutomationManager listener, so it can pass an empty callback.
  */
-void showAutomationMenu(TrackId trackId, juce::Component* relativeTo,
-                        std::function<void(TrackId, AutomationLaneId)> onShowAutomationLane = {});
+void showAutomationMenu(
+    TrackId trackId, juce::Component* relativeTo,
+    const std::function<void(TrackId, AutomationLaneId)>& onShowAutomationLane = {});
 
 }  // namespace magda

--- a/magda/daw/ui/components/chain/ChainRowComponent.cpp
+++ b/magda/daw/ui/components/chain/ChainRowComponent.cpp
@@ -344,7 +344,7 @@ void ChainRowComponent::resized() {
     panLabel_.setBounds(bounds.removeFromLeft(panWidth));
 }
 
-int ChainRowComponent::getPreferredHeight() const {
+int ChainRowComponent::getPreferredHeight() {
     return ROW_HEIGHT;
 }
 

--- a/magda/daw/ui/components/chain/ChainRowComponent.hpp
+++ b/magda/daw/ui/components/chain/ChainRowComponent.hpp
@@ -58,7 +58,7 @@ class ChainRowComponent : public juce::Component,
     void mouseUp(const juce::MouseEvent& event) override;
     void mouseDoubleClick(const juce::MouseEvent& event) override;
 
-    int getPreferredHeight() const;
+    static int getPreferredHeight();
     magda::ChainId getChainId() const {
         return chainId_;
     }

--- a/magda/daw/ui/components/chain/DeviceSlotComponent.cpp
+++ b/magda/daw/ui/components/chain/DeviceSlotComponent.cpp
@@ -73,27 +73,27 @@ void DeviceSlotComponent::wireSharedModMacroLinkCallbacks(LinkTarget& target,
 
     DeviceLinkCallbackContext context;
     context.getNodePath = [safeThis]() {
-        auto self = safeThis;
+        const auto& self = safeThis;
         return self ? self->nodePath_ : magda::ChainNodePath{};
     };
     context.onMacroTargetChanged = [safeThis](int macroIndex, magda::ControlTarget target) {
-        if (auto self = safeThis)
-            self->onMacroTargetChangedInternal(macroIndex, target);
+        if (const auto& self = safeThis)
+            self->onMacroTargetChangedInternal(macroIndex, std::move(target));
     };
     context.updateParamModulation = [safeThis]() {
-        if (auto self = safeThis)
+        if (const auto& self = safeThis)
             self->updateParamModulation();
     };
     context.updateModsPanel = [safeThis]() {
-        if (auto self = safeThis)
+        if (const auto& self = safeThis)
             self->updateModsPanel();
     };
     context.updateMacroPanel = [safeThis]() {
-        if (auto self = safeThis)
+        if (const auto& self = safeThis)
             self->updateMacroPanel();
     };
     context.expandModPanelForDirectLink = [safeThis]() {
-        auto self = safeThis;
+        const auto& self = safeThis;
         if (!self || self->modPanelVisible_)
             return;
 
@@ -102,7 +102,7 @@ void DeviceSlotComponent::wireSharedModMacroLinkCallbacks(LinkTarget& target,
         self->setModPanelVisible(true);
     };
     context.expandMacroPanelForDirectLink = [safeThis]() {
-        auto self = safeThis;
+        const auto& self = safeThis;
         if (!self || self->paramPanelVisible_)
             return;
 
@@ -509,8 +509,8 @@ DeviceSlotComponent::DeviceSlotComponent(const magda::DeviceInfo& device) : devi
 
         // Wire up mod/macro linking callbacks
         paramSlot->onModLinked = [safeThis = juce::Component::SafePointer(this)](
-                                     int modIndex, magda::ControlTarget target) {
-            auto self = safeThis;
+                                     int modIndex, const magda::ControlTarget& target) {
+            const auto& self = safeThis;
             if (!self)
                 return;
             self->onModTargetChangedInternal(modIndex, target);
@@ -520,7 +520,7 @@ DeviceSlotComponent::DeviceSlotComponent(const magda::DeviceInfo& device) : devi
         wireSharedModMacroLinkCallbacks(*paramSlot, true);
         paramSlot->onMacroValueChanged = [safeThis = juce::Component::SafePointer(this)](
                                              int macroIndex, float value) {
-            auto self = safeThis;
+            const auto& self = safeThis;
             if (!self)
                 return;
             magda::TrackManager::getInstance().setMacroValue(self->nodePath_, macroIndex, value);
@@ -528,7 +528,7 @@ DeviceSlotComponent::DeviceSlotComponent(const magda::DeviceInfo& device) : devi
                 self->updateParamModulation();
         };
         paramSlot->onShowAutomationLane = [safeThis = juce::Component::SafePointer(this), i]() {
-            if (auto self = safeThis)
+            if (const auto& self = safeThis)
                 if (auto* slot = self->paramGrid_->getSlot(i))
                     self->showAutomationLaneForParam(slot->getParamIndex());
         };
@@ -1798,7 +1798,7 @@ void DeviceSlotComponent::wirePadChainLinkCallbacks() {
     };
     callbacks.onMacroTargetChanged = [safeThis](int macroIndex, magda::ControlTarget target) {
         if (safeThis != nullptr)
-            safeThis->onMacroTargetChangedInternal(macroIndex, target);
+            safeThis->onMacroTargetChangedInternal(macroIndex, std::move(target));
     };
     callbacks.showAutomationLaneForParam = [safeThis](int paramIndex) {
         if (safeThis != nullptr)
@@ -1818,14 +1818,14 @@ void DeviceSlotComponent::setupCustomUILinking() {
     configureDeviceSlotLinkableSliders(
         sliders, device_, nodePath_, context,
         [safeThis = juce::Component::SafePointer(this)](LinkableTextSlider& slider) {
-            auto self = safeThis;
+            const auto& self = safeThis;
             if (!self)
                 return;
 
             self->wireSharedModMacroLinkCallbacks(slider, false);
             auto* sliderPtr = &slider;
             slider.onShowAutomationLane = [safeThis, sliderPtr]() {
-                auto self = safeThis;
+                const auto& self = safeThis;
                 if (!self || sliderPtr == nullptr)
                     return;
                 self->showAutomationLaneForParam(sliderPtr->getParamIndex());

--- a/magda/daw/ui/components/chain/NodeComponent.cpp
+++ b/magda/daw/ui/components/chain/NodeComponent.cpp
@@ -388,8 +388,8 @@ void NodeComponent::paint(juce::Graphics& g) {
                                                        center.x, center.y));
         // Swapped width/height due to rotation
         juce::Rectangle<int> textBounds(
-            static_cast<int>(center.x - collapsedTextArea_.getHeight() / 2),
-            static_cast<int>(center.y - collapsedTextArea_.getWidth() / 2),
+            static_cast<int>(center.x - collapsedTextArea_.getHeight() / 2.0f),
+            static_cast<int>(center.y - collapsedTextArea_.getWidth() / 2.0f),
             collapsedTextArea_.getHeight(), collapsedTextArea_.getWidth());
         g.drawText(getCollapsedName(), textBounds, juce::Justification::centred);
         g.restoreState();

--- a/magda/daw/ui/components/chain/NodeComponent.cpp
+++ b/magda/daw/ui/components/chain/NodeComponent.cpp
@@ -2,6 +2,8 @@
 
 #include <BinaryData.h>
 
+#include <utility>
+
 #include "../../utils/SelectionPolicy.hpp"
 #include "ChainNodePathDrag.hpp"
 #include "ai/AIPanelComponent.hpp"
@@ -72,7 +74,7 @@ struct NodeComponent::PanelFadeTimer : private juce::Timer {
                 continue;
             component->setAlpha(startAlpha_);
             component->setVisible(true);
-            targets_.push_back(component);
+            targets_.emplace_back(component);
         }
 
         if (targets_.empty()) {
@@ -102,7 +104,7 @@ struct NodeComponent::PanelFadeTimer : private juce::Timer {
                 continue;
             component->setAlpha(startAlpha_);
             component->setVisible(true);
-            targets_.push_back(component);
+            targets_.emplace_back(component);
         }
 
         if (targets_.empty()) {
@@ -1441,10 +1443,10 @@ void NodeComponent::initializeModsMacrosPanels() {
     // Create mods panel
     modsPanel_ = std::make_unique<ModsPanelComponent>();
     modsPanel_->onModTargetChanged = [this](int modIndex, magda::ControlTarget target) {
-        onModTargetChangedInternal(modIndex, target);
+        onModTargetChangedInternal(modIndex, std::move(target));
     };
     modsPanel_->onModLinkRemoved = [this](int modIndex, magda::ControlTarget target) {
-        onModLinkRemovedInternal(modIndex, target);
+        onModLinkRemovedInternal(modIndex, std::move(target));
         updateModsPanel();
         updateModulatorEditor();
     };
@@ -1490,13 +1492,13 @@ void NodeComponent::initializeModsMacrosPanels() {
         onMacroValueChangedInternal(macroIndex, value);
     };
     macroPanel_->onMacroTargetChanged = [this](int macroIndex, magda::ControlTarget target) {
-        onMacroTargetChangedInternal(macroIndex, target);
+        onMacroTargetChangedInternal(macroIndex, std::move(target));
     };
     macroPanel_->onMacroNameChanged = [this](int macroIndex, juce::String name) {
         onMacroNameChangedInternal(macroIndex, name);
     };
     macroPanel_->onMacroLinkRemoved = [this](int macroIndex, magda::ControlTarget target) {
-        onMacroLinkRemovedInternal(macroIndex, target);
+        onMacroLinkRemovedInternal(macroIndex, std::move(target));
         updateMacroPanel();
         updateMacroEditor();
     };
@@ -1694,32 +1696,32 @@ void NodeComponent::initializeModsMacrosPanels() {
 
     // Mod matrix: delete link
     modulatorEditorPanel_->onModLinkDeleted = [this](int modIndex, magda::ControlTarget target) {
-        magda::TrackManager::getInstance().removeModLink(nodePath_, modIndex, target);
+        magda::TrackManager::getInstance().removeModLink(nodePath_, modIndex, std::move(target));
         updateModulatorEditor();
     };
 
     // Mod matrix: toggle bipolar
-    modulatorEditorPanel_->onModLinkBipolarChanged = [this](int modIndex,
-                                                            magda::ControlTarget target,
-                                                            bool bipolar) {
-        magda::TrackManager::getInstance().setModLinkBipolar(nodePath_, modIndex, target, bipolar);
-        updateModulatorEditor();
-    };
+    modulatorEditorPanel_->onModLinkBipolarChanged =
+        [this](int modIndex, magda::ControlTarget target, bool bipolar) {
+            magda::TrackManager::getInstance().setModLinkBipolar(nodePath_, modIndex,
+                                                                 std::move(target), bipolar);
+            updateModulatorEditor();
+        };
 
     // Mod matrix: enable/disable link without losing its amount
-    modulatorEditorPanel_->onModLinkEnabledChanged = [this](int modIndex,
-                                                            magda::ControlTarget target,
-                                                            bool enabled) {
-        magda::TrackManager::getInstance().setModLinkEnabled(nodePath_, modIndex, target, enabled);
-        updateModulatorEditor();
-    };
+    modulatorEditorPanel_->onModLinkEnabledChanged =
+        [this](int modIndex, magda::ControlTarget target, bool enabled) {
+            magda::TrackManager::getInstance().setModLinkEnabled(nodePath_, modIndex,
+                                                                 std::move(target), enabled);
+            updateModulatorEditor();
+        };
 
     // Mod matrix: change link amount
-    modulatorEditorPanel_->onModLinkAmountChanged = [this](int modIndex,
-                                                           magda::ControlTarget target,
-                                                           float amount) {
-        magda::TrackManager::getInstance().setModLinkAmount(nodePath_, modIndex, target, amount);
-    };
+    modulatorEditorPanel_->onModLinkAmountChanged =
+        [this](int modIndex, magda::ControlTarget target, float amount) {
+            magda::TrackManager::getInstance().setModLinkAmount(nodePath_, modIndex,
+                                                                std::move(target), amount);
+        };
 
     addChildComponent(*modulatorEditorPanel_);
 
@@ -1737,18 +1739,18 @@ void NodeComponent::initializeModsMacrosPanels() {
     };
     macroEditorPanel_->onLinkAmountChanged = [this](magda::ControlTarget target, float amount) {
         if (selectedMacroIndex_ >= 0) {
-            onMacroLinkAmountChangedInternal(selectedMacroIndex_, target, amount);
+            onMacroLinkAmountChangedInternal(selectedMacroIndex_, std::move(target), amount);
         }
     };
     macroEditorPanel_->onLinkRemoved = [this](magda::ControlTarget target) {
         if (selectedMacroIndex_ >= 0) {
-            onMacroLinkRemovedInternal(selectedMacroIndex_, target);
+            onMacroLinkRemovedInternal(selectedMacroIndex_, std::move(target));
             updateMacroEditor();
         }
     };
     macroEditorPanel_->onLinkBipolarToggled = [this](magda::ControlTarget target, bool bipolar) {
         if (selectedMacroIndex_ >= 0) {
-            onMacroLinkBipolarChangedInternal(selectedMacroIndex_, target, bipolar);
+            onMacroLinkBipolarChangedInternal(selectedMacroIndex_, std::move(target), bipolar);
             updateMacroEditor();
         }
     };

--- a/magda/daw/ui/components/chain/NodeComponent.cpp
+++ b/magda/daw/ui/components/chain/NodeComponent.cpp
@@ -1694,29 +1694,17 @@ void NodeComponent::initializeModsMacrosPanels() {
 
     // Mod matrix: delete link
     modulatorEditorPanel_->onModLinkDeleted = [this](int modIndex, magda::ControlTarget target) {
-        auto* device = magda::TrackManager::getInstance().getDeviceInChainByPath(nodePath_);
-        if (device) {
-            magda::TrackManager::getInstance().removeModLink(nodePath_, modIndex, target);
-        } else {
-            // Rack mod
-            magda::TrackManager::getInstance().removeModLink(nodePath_, modIndex, target);
-        }
+        magda::TrackManager::getInstance().removeModLink(nodePath_, modIndex, target);
         updateModulatorEditor();
     };
 
     // Mod matrix: toggle bipolar
-    modulatorEditorPanel_->onModLinkBipolarChanged =
-        [this](int modIndex, magda::ControlTarget target, bool bipolar) {
-            auto* device = magda::TrackManager::getInstance().getDeviceInChainByPath(nodePath_);
-            if (device) {
-                magda::TrackManager::getInstance().setModLinkBipolar(nodePath_, modIndex, target,
-                                                                     bipolar);
-            } else {
-                magda::TrackManager::getInstance().setModLinkBipolar(nodePath_, modIndex, target,
-                                                                     bipolar);
-            }
-            updateModulatorEditor();
-        };
+    modulatorEditorPanel_->onModLinkBipolarChanged = [this](int modIndex,
+                                                            magda::ControlTarget target,
+                                                            bool bipolar) {
+        magda::TrackManager::getInstance().setModLinkBipolar(nodePath_, modIndex, target, bipolar);
+        updateModulatorEditor();
+    };
 
     // Mod matrix: enable/disable link without losing its amount
     modulatorEditorPanel_->onModLinkEnabledChanged = [this](int modIndex,
@@ -1727,17 +1715,11 @@ void NodeComponent::initializeModsMacrosPanels() {
     };
 
     // Mod matrix: change link amount
-    modulatorEditorPanel_->onModLinkAmountChanged =
-        [this](int modIndex, magda::ControlTarget target, float amount) {
-            auto* device = magda::TrackManager::getInstance().getDeviceInChainByPath(nodePath_);
-            if (device) {
-                magda::TrackManager::getInstance().setModLinkAmount(nodePath_, modIndex, target,
-                                                                    amount);
-            } else {
-                magda::TrackManager::getInstance().setModLinkAmount(nodePath_, modIndex, target,
-                                                                    amount);
-            }
-        };
+    modulatorEditorPanel_->onModLinkAmountChanged = [this](int modIndex,
+                                                           magda::ControlTarget target,
+                                                           float amount) {
+        magda::TrackManager::getInstance().setModLinkAmount(nodePath_, modIndex, target, amount);
+    };
 
     addChildComponent(*modulatorEditorPanel_);
 

--- a/magda/daw/ui/components/chain/RackComponent.cpp
+++ b/magda/daw/ui/components/chain/RackComponent.cpp
@@ -24,7 +24,7 @@ namespace {
 /// that follows destroys the button whose click is still on the stack; the path
 /// is taken by value for the same reason. Both constructors below share this,
 /// so the top-level and nested X do the same thing (#2232).
-void requestRackDeletion(magda::ChainNodePath rackPath) {
+void requestRackDeletion(const magda::ChainNodePath& rackPath) {
     juce::MessageManager::callAsync([rackPath]() {
         magda::UndoManager::getInstance().executeCommand(
             std::make_unique<magda::RemoveRackByPathCommand>(rackPath));

--- a/magda/daw/ui/components/chain/ai/AIPanelComponent.cpp
+++ b/magda/daw/ui/components/chain/ai/AIPanelComponent.cpp
@@ -4,6 +4,7 @@
 #include <juce_llm/juce_llm.h>
 
 #include <ranges>
+#include <utility>
 
 #include "../../../../agents/internal_plugins.hpp"
 #include "../../../../agents/llm_presets.hpp"
@@ -24,7 +25,7 @@ class AIPanelComponent::GenerateThread : public juce::Thread {
           owner_(owner),
           agent_(std::move(agent)),
           prompt_(std::move(prompt)),
-          path_(path),
+          path_(std::move(path)),
           conversation_(std::move(conversation)) {}
 
     void run() override {
@@ -62,8 +63,8 @@ class AIPanelComponent::GenerateThread : public juce::Thread {
     }
 
   private:
-    static void postResult(juce::WeakReference<AIPanelComponent> safeOwner, juce::String status,
-                           juce::String conversationJson) {
+    static void postResult(const juce::WeakReference<AIPanelComponent>& safeOwner,
+                           juce::String status, juce::String conversationJson) {
         juce::MessageManager::callAsync([safeOwner, status, conversationJson]() {
             if (auto* p = safeOwner.get())
                 p->onGenerationFinished(status, conversationJson);

--- a/magda/daw/ui/components/chain/compiled/CompiledBitcrusherEditorView.hpp
+++ b/magda/daw/ui/components/chain/compiled/CompiledBitcrusherEditorView.hpp
@@ -24,7 +24,7 @@ class CompiledBitcrusherEditorView final : public juce::Component,
   public:
     explicit CompiledBitcrusherEditorView(juce::String pluginId);
 
-    int getPreferredHeight() const {
+    static int getPreferredHeight() {
         return 56;
     }
 

--- a/magda/daw/ui/components/chain/compiled/CompiledChorusCurveView.hpp
+++ b/magda/daw/ui/components/chain/compiled/CompiledChorusCurveView.hpp
@@ -27,7 +27,7 @@ class CompiledChorusCurveView final : public juce::Component,
   public:
     explicit CompiledChorusCurveView(juce::String pluginId);
 
-    int getPreferredHeight() const {
+    static int getPreferredHeight() {
         return 120;
     }
 

--- a/magda/daw/ui/components/chain/compiled/CompiledClipperCurveView.hpp
+++ b/magda/daw/ui/components/chain/compiled/CompiledClipperCurveView.hpp
@@ -27,7 +27,7 @@ class CompiledClipperCurveView final : public juce::Component,
   public:
     explicit CompiledClipperCurveView(juce::String pluginId);
 
-    int getPreferredHeight() const {
+    static int getPreferredHeight() {
         return 120;
     }
 

--- a/magda/daw/ui/components/chain/compiled/CompiledCompressorCurveView.hpp
+++ b/magda/daw/ui/components/chain/compiled/CompiledCompressorCurveView.hpp
@@ -19,7 +19,7 @@ class CompiledCompressorCurveView final : public juce::Component,
   public:
     explicit CompiledCompressorCurveView(juce::String pluginId);
 
-    int getPreferredHeight() const {
+    static int getPreferredHeight() {
         return 146;
     }
 

--- a/magda/daw/ui/components/chain/compiled/CompiledDelayCurveView.hpp
+++ b/magda/daw/ui/components/chain/compiled/CompiledDelayCurveView.hpp
@@ -31,7 +31,7 @@ class CompiledDelayCurveView final : public juce::Component,
   public:
     explicit CompiledDelayCurveView(juce::String pluginId);
 
-    int getPreferredHeight() const {
+    static int getPreferredHeight() {
         return 140;
     }
 

--- a/magda/daw/ui/components/chain/compiled/CompiledDimensionView.hpp
+++ b/magda/daw/ui/components/chain/compiled/CompiledDimensionView.hpp
@@ -24,7 +24,7 @@ class CompiledDimensionView final : public juce::Component,
   public:
     explicit CompiledDimensionView(juce::String pluginId);
 
-    int getPreferredHeight() const {
+    static int getPreferredHeight() {
         return 56;
     }
 

--- a/magda/daw/ui/components/chain/compiled/CompiledEqCurveView.hpp
+++ b/magda/daw/ui/components/chain/compiled/CompiledEqCurveView.hpp
@@ -29,7 +29,7 @@ class CompiledEqCurveView final : public juce::Component,
   public:
     explicit CompiledEqCurveView(juce::String pluginId);
 
-    int getPreferredHeight() const {
+    static int getPreferredHeight() {
         return 90;
     }
 

--- a/magda/daw/ui/components/chain/compiled/CompiledFilterCurveView.hpp
+++ b/magda/daw/ui/components/chain/compiled/CompiledFilterCurveView.hpp
@@ -18,7 +18,7 @@ class CompiledFilterCurveView final : public juce::Component,
   public:
     explicit CompiledFilterCurveView(juce::String pluginId);
 
-    int getPreferredHeight() const {
+    static int getPreferredHeight() {
         return 140;
     }
 

--- a/magda/daw/ui/components/chain/compiled/CompiledFlangerCurveView.hpp
+++ b/magda/daw/ui/components/chain/compiled/CompiledFlangerCurveView.hpp
@@ -28,7 +28,7 @@ class CompiledFlangerCurveView final : public juce::Component,
   public:
     explicit CompiledFlangerCurveView(juce::String pluginId);
 
-    int getPreferredHeight() const {
+    static int getPreferredHeight() {
         return 130;
     }
 

--- a/magda/daw/ui/components/chain/compiled/CompiledFreqShiftCurveView.hpp
+++ b/magda/daw/ui/components/chain/compiled/CompiledFreqShiftCurveView.hpp
@@ -28,7 +28,7 @@ class CompiledFreqShiftCurveView final : public juce::Component,
   public:
     explicit CompiledFreqShiftCurveView(juce::String pluginId);
 
-    int getPreferredHeight() const {
+    static int getPreferredHeight() {
         return 120;
     }
 

--- a/magda/daw/ui/components/chain/compiled/CompiledGateCurveView.hpp
+++ b/magda/daw/ui/components/chain/compiled/CompiledGateCurveView.hpp
@@ -19,7 +19,7 @@ class CompiledGateCurveView final : public juce::Component,
   public:
     explicit CompiledGateCurveView(juce::String pluginId);
 
-    int getPreferredHeight() const {
+    static int getPreferredHeight() {
         return 146;
     }
 

--- a/magda/daw/ui/components/chain/compiled/CompiledGrainDelayCurveView.hpp
+++ b/magda/daw/ui/components/chain/compiled/CompiledGrainDelayCurveView.hpp
@@ -25,7 +25,7 @@ class CompiledGrainDelayCurveView final : public juce::Component,
   public:
     explicit CompiledGrainDelayCurveView(juce::String pluginId);
 
-    int getPreferredHeight() const {
+    static int getPreferredHeight() {
         return 140;
     }
 

--- a/magda/daw/ui/components/chain/compiled/CompiledGritCurveView.hpp
+++ b/magda/daw/ui/components/chain/compiled/CompiledGritCurveView.hpp
@@ -26,7 +26,7 @@ class CompiledGritCurveView final : public juce::Component,
   public:
     explicit CompiledGritCurveView(juce::String pluginId);
 
-    int getPreferredHeight() const {
+    static int getPreferredHeight() {
         return 140;
     }
 

--- a/magda/daw/ui/components/chain/compiled/CompiledLimiterCurveView.hpp
+++ b/magda/daw/ui/components/chain/compiled/CompiledLimiterCurveView.hpp
@@ -27,7 +27,7 @@ class CompiledLimiterCurveView final : public juce::Component,
   public:
     explicit CompiledLimiterCurveView(juce::String pluginId);
 
-    int getPreferredHeight() const {
+    static int getPreferredHeight() {
         return 146;
     }
 

--- a/magda/daw/ui/components/chain/compiled/CompiledModCurveView.hpp
+++ b/magda/daw/ui/components/chain/compiled/CompiledModCurveView.hpp
@@ -26,7 +26,7 @@ class CompiledModCurveView final : public juce::Component,
   public:
     explicit CompiledModCurveView(juce::String pluginId);
 
-    int getPreferredHeight() const {
+    static int getPreferredHeight() {
         return 110;
     }
 

--- a/magda/daw/ui/components/chain/compiled/CompiledMultibandCurveView.cpp
+++ b/magda/daw/ui/components/chain/compiled/CompiledMultibandCurveView.cpp
@@ -364,7 +364,7 @@ bool CompiledMultibandCurveView::isReleaseTimingHandle(Handle h) {
     return h == Handle::LowRelease || h == Handle::MidRelease || h == Handle::HighRelease;
 }
 
-int CompiledMultibandCurveView::slotForHandle(Handle h) const {
+int CompiledMultibandCurveView::slotForHandle(Handle h) {
     const int band = bandForHandle(h);
     if (band < 0)
         return -1;

--- a/magda/daw/ui/components/chain/compiled/CompiledMultibandCurveView.hpp
+++ b/magda/daw/ui/components/chain/compiled/CompiledMultibandCurveView.hpp
@@ -20,7 +20,7 @@ class CompiledMultibandCurveView final : public juce::Component,
   public:
     explicit CompiledMultibandCurveView(juce::String pluginId);
 
-    int getPreferredHeight() const {
+    static int getPreferredHeight() {
         return 140;
     }
 
@@ -182,7 +182,7 @@ class CompiledMultibandCurveView final : public juce::Component,
     static bool isAboveRatioHandle(Handle h);
     static bool isTimingHandle(Handle h);
     static bool isReleaseTimingHandle(Handle h);
-    int slotForHandle(Handle h) const;
+    static int slotForHandle(Handle h);
     Handle pickHandle(float x, float y) const;
 
     magda::daw::audio::compiled::MagdaMultibandCompiledPlugin* compiledPlugin_ = nullptr;

--- a/magda/daw/ui/components/chain/compiled/CompiledPhaserCurveView.hpp
+++ b/magda/daw/ui/components/chain/compiled/CompiledPhaserCurveView.hpp
@@ -26,7 +26,7 @@ class CompiledPhaserCurveView final : public juce::Component,
   public:
     explicit CompiledPhaserCurveView(juce::String pluginId);
 
-    int getPreferredHeight() const {
+    static int getPreferredHeight() {
         return 130;
     }
 

--- a/magda/daw/ui/components/chain/compiled/CompiledPitchEditorView.hpp
+++ b/magda/daw/ui/components/chain/compiled/CompiledPitchEditorView.hpp
@@ -28,7 +28,7 @@ class CompiledPitchEditorView final : public juce::Component,
   public:
     explicit CompiledPitchEditorView(juce::String pluginId);
 
-    int getPreferredHeight() const {
+    static int getPreferredHeight() {
         return 56;
     }
 

--- a/magda/daw/ui/components/chain/compiled/CompiledReverbCurveView.cpp
+++ b/magda/daw/ui/components/chain/compiled/CompiledReverbCurveView.cpp
@@ -61,7 +61,7 @@ void CompiledReverbCurveView::updateFromDevice(const magda::DeviceInfo& device) 
     repaint();
 }
 
-float CompiledReverbCurveView::t60SecondsForEngine(int engineIndex, float decayDisplay) const {
+float CompiledReverbCurveView::t60SecondsForEngine(int engineIndex, float decayDisplay) {
     // Mirrors the time mappings inside each engine .dsp so the visual
     // matches what the user hears at a given Decay slot value.
     const float d01 = juce::jlimit(0.0f, 1.0f, decayDisplay / 100.0f);

--- a/magda/daw/ui/components/chain/compiled/CompiledReverbCurveView.hpp
+++ b/magda/daw/ui/components/chain/compiled/CompiledReverbCurveView.hpp
@@ -28,7 +28,7 @@ class CompiledReverbCurveView final : public juce::Component,
   public:
     explicit CompiledReverbCurveView(juce::String pluginId);
 
-    int getPreferredHeight() const {
+    static int getPreferredHeight() {
         return 120;
     }
 
@@ -52,7 +52,7 @@ class CompiledReverbCurveView final : public juce::Component,
 
     // Approximate t60 (seconds) for the active engine, derived from the
     // engine-aware mapping that lives in each magda_reverb_*.dsp.
-    float t60SecondsForEngine(int engineIndex, float decayDisplay) const;
+    static float t60SecondsForEngine(int engineIndex, float decayDisplay);
 
     magda::daw::audio::compiled::MagdaReverbCompiledPlugin* compiledPlugin_ = nullptr;
     magda::DeviceInfo deviceSnapshot_;

--- a/magda/daw/ui/components/chain/compiled/CompiledRingModCurveView.hpp
+++ b/magda/daw/ui/components/chain/compiled/CompiledRingModCurveView.hpp
@@ -31,7 +31,7 @@ class CompiledRingModCurveView final : public juce::Component,
   public:
     explicit CompiledRingModCurveView(juce::String pluginId);
 
-    int getPreferredHeight() const {
+    static int getPreferredHeight() {
         return 120;
     }
 

--- a/magda/daw/ui/components/chain/compiled/CompiledSaturatorCurveView.hpp
+++ b/magda/daw/ui/components/chain/compiled/CompiledSaturatorCurveView.hpp
@@ -31,7 +31,7 @@ class CompiledSaturatorCurveView final : public juce::Component,
   public:
     explicit CompiledSaturatorCurveView(juce::String pluginId);
 
-    int getPreferredHeight() const {
+    static int getPreferredHeight() {
         return 140;
     }
 

--- a/magda/daw/ui/components/chain/compiled/CompiledUtilityView.cpp
+++ b/magda/daw/ui/components/chain/compiled/CompiledUtilityView.cpp
@@ -286,7 +286,7 @@ void CompiledUtilityView::updateLinkSlotValues() {
 
     auto update = [this](ParamSlotComponent& slot, int slotIndex, float fallback, bool& infoSet) {
         if (!infoSet) {
-            if (auto* param = parameterForSlot(deviceSnapshot_, slotIndex)) {
+            if (const auto* param = parameterForSlot(deviceSnapshot_, slotIndex)) {
                 infoSet = true;
                 slot.setParameterInfo(*param);
             }

--- a/magda/daw/ui/components/chain/compiled/CompiledUtilityView.cpp
+++ b/magda/daw/ui/components/chain/compiled/CompiledUtilityView.cpp
@@ -203,23 +203,24 @@ void CompiledUtilityView::configureLinkSlots() {
         slot.setParamIndex(slotIndex);
         slot.setParamName(name);
 
-        slot.onModLinkedWithAmount = [this](int, magda::ControlTarget target, float amount) {
+        slot.onModLinkedWithAmount = [this](int, const magda::ControlTarget& target, float amount) {
             if (onLinkRequested)
                 onLinkRequested(target.paramIndex, amount);
         };
-        slot.onModAmountChanged = [this](int, magda::ControlTarget target, float amount) {
+        slot.onModAmountChanged = [this](int, const magda::ControlTarget& target, float amount) {
             if (onLinkAmountChanged)
                 onLinkAmountChanged(target.paramIndex, amount);
         };
-        slot.onMacroLinked = [this](int, magda::ControlTarget target) {
+        slot.onMacroLinked = [this](int, const magda::ControlTarget& target) {
             if (onLinkRequested)
                 onLinkRequested(target.paramIndex, 0.3f);
         };
-        slot.onMacroLinkedWithAmount = [this](int, magda::ControlTarget target, float amount) {
+        slot.onMacroLinkedWithAmount = [this](int, const magda::ControlTarget& target,
+                                              float amount) {
             if (onLinkRequested)
                 onLinkRequested(target.paramIndex, amount);
         };
-        slot.onMacroAmountChanged = [this](int, magda::ControlTarget target, float amount) {
+        slot.onMacroAmountChanged = [this](int, const magda::ControlTarget& target, float amount) {
             if (onLinkAmountChanged)
                 onLinkAmountChanged(target.paramIndex, amount);
         };

--- a/magda/daw/ui/components/chain/custom_ui/FourOscUI.cpp
+++ b/magda/daw/ui/components/chain/custom_ui/FourOscUI.cpp
@@ -57,7 +57,7 @@ void FourOscUI::updateModMatrix(const std::vector<ModMatrixEntry>& entries) {
     // Split entries by source: LFO sources -> LFO tab, Env sources -> ModEnv tab
     // ModSource enum: lfo1=0, lfo2=1, env1=2, env2=3
     std::vector<ModMatrixEntry> lfoEntries, envEntries;
-    for (auto& e : entries) {
+    for (const auto& e : entries) {
         if (e.modSourceId == 0 || e.modSourceId == 1)
             lfoEntries.push_back(e);
         else if (e.modSourceId == 2 || e.modSourceId == 3)

--- a/magda/daw/ui/components/chain/custom_ui/PolyStepSequencerUI.cpp
+++ b/magda/daw/ui/components/chain/custom_ui/PolyStepSequencerUI.cpp
@@ -1544,7 +1544,7 @@ void PolyStepSequencerUI::drawBarLane(juce::Graphics& g, juce::Rectangle<int> ar
 // Mouse interaction (per-step lanes; the grid handles its own mouse)
 // =============================================================================
 
-int PolyStepSequencerUI::getStepAtX(int x, int areaX, int areaWidth, int numSteps) const {
+int PolyStepSequencerUI::getStepAtX(int x, int areaX, int areaWidth, int numSteps) {
     if (numSteps <= 0 || areaWidth <= 0)
         return -1;
     int relX = x - areaX;

--- a/magda/daw/ui/components/chain/custom_ui/PolyStepSequencerUI.hpp
+++ b/magda/daw/ui/components/chain/custom_ui/PolyStepSequencerUI.hpp
@@ -218,7 +218,7 @@ class PolyStepSequencerUI : public juce::Component, private juce::Timer {
                      bool isProbability);
 
     // --- Hit testing ---
-    int getStepAtX(int x, int areaX, int areaWidth, int numSteps) const;
+    static int getStepAtX(int x, int areaX, int areaWidth, int numSteps);
     void applyLaneDrag(const juce::MouseEvent& e);
 
     // --- Layout bounds (computed in resized, used in paint/mouse handlers) ---

--- a/magda/daw/ui/components/chain/custom_ui/SpectrumAnalyzerUI.cpp
+++ b/magda/daw/ui/components/chain/custom_ui/SpectrumAnalyzerUI.cpp
@@ -628,12 +628,12 @@ void SpectrumAnalyzerUI::updateTimerState() {
         stopTimer();
 }
 
-float SpectrumAnalyzerUI::freqToX(float hz, juce::Rectangle<float> area) const {
+float SpectrumAnalyzerUI::freqToX(float hz, juce::Rectangle<float> area) {
     const float t = std::log(juce::jmax(kMinHz, hz) / kMinHz) / std::log(kMaxHz / kMinHz);
     return area.getX() + juce::jlimit(0.0f, 1.0f, t) * area.getWidth();
 }
 
-float SpectrumAnalyzerUI::dbToY(float db, juce::Rectangle<float> area) const {
+float SpectrumAnalyzerUI::dbToY(float db, juce::Rectangle<float> area) {
     const float t = (db - kMinDb) / (kMaxDb - kMinDb);
     return area.getBottom() - juce::jlimit(0.0f, 1.0f, t) * area.getHeight();
 }

--- a/magda/daw/ui/components/chain/custom_ui/SpectrumAnalyzerUI.hpp
+++ b/magda/daw/ui/components/chain/custom_ui/SpectrumAnalyzerUI.hpp
@@ -74,8 +74,8 @@ class SpectrumAnalyzerUI : public juce::Component, private juce::Timer {
     void releaseMeasurementArming();                  // undo only what this UI armed
     void pollOverlayData();      // fetch overlay band spectrum + pair-filtered findings
     void rebuildFft(int order);  // (re)allocate FFT + buffers for a 2^order transform
-    float freqToX(float hz, juce::Rectangle<float> area) const;
-    float dbToY(float db, juce::Rectangle<float> area) const;
+    static float freqToX(float hz, juce::Rectangle<float> area);
+    static float dbToY(float db, juce::Rectangle<float> area);
     juce::Rectangle<float> plotArea() const;  // plot region (excludes the control row)
     void updateControlVisibility();
     void startControlsFade(bool expanding);

--- a/magda/daw/ui/components/chain/custom_ui/StepSequencerUI.cpp
+++ b/magda/daw/ui/components/chain/custom_ui/StepSequencerUI.cpp
@@ -864,7 +864,7 @@ void StepSequencerUI::mouseUp(const juce::MouseEvent&) {
 // Hit testing helpers
 // =============================================================================
 
-int StepSequencerUI::getStepAtX(int x, int areaX, int areaWidth, int numSteps) const {
+int StepSequencerUI::getStepAtX(int x, int areaX, int areaWidth, int numSteps) {
     if (numSteps <= 0 || areaWidth <= 0)
         return -1;
     int relX = x - areaX;

--- a/magda/daw/ui/components/chain/custom_ui/StepSequencerUI.hpp
+++ b/magda/daw/ui/components/chain/custom_ui/StepSequencerUI.hpp
@@ -157,7 +157,7 @@ class StepSequencerUI : public juce::Component, private juce::Timer {
     void drawOctaveArrow(juce::Graphics& g, juce::Rectangle<int> area, bool isLeft);
 
     // --- Hit testing ---
-    int getStepAtX(int x, int areaX, int areaWidth, int numSteps) const;
+    static int getStepAtX(int x, int areaX, int areaWidth, int numSteps);
     int getKeyboardNoteAtPosition(juce::Point<int> pos, juce::Rectangle<int> area) const;
 
     // --- Layout bounds (computed in resized, used in paint/mouseDown) ---

--- a/magda/daw/ui/components/chain/custom_ui/StruckInstrumentUI.cpp
+++ b/magda/daw/ui/components/chain/custom_ui/StruckInstrumentUI.cpp
@@ -132,7 +132,7 @@ std::vector<LinkableTextSlider*> StruckInstrumentUI::getLinkableSliders() {
     return out;
 }
 
-int StruckInstrumentUI::preferredContentWidth() const {
+int StruckInstrumentUI::preferredContentWidth() {
     return 560;  // body panel + EXCITER | RESONATOR columns
 }
 

--- a/magda/daw/ui/components/chain/custom_ui/StruckInstrumentUI.hpp
+++ b/magda/daw/ui/components/chain/custom_ui/StruckInstrumentUI.hpp
@@ -39,7 +39,7 @@ class StruckInstrumentUI : public juce::Component, private juce::Timer {
 
     void updateFromParameters(const std::vector<magda::ParameterInfo>& params);
     std::vector<LinkableTextSlider*> getLinkableSliders();
-    int preferredContentWidth() const;
+    static int preferredContentWidth();
 
     /// Bind the live plugin so the body can flash on note-on (nullptr unbinds).
     void setLivePlugin(magda::daw::audio::compiled::MagdaCompiledPolyInstrument* plugin);

--- a/magda/daw/ui/components/chain/drum_grid/DeviceSlotDrumGridBridge.cpp
+++ b/magda/daw/ui/components/chain/drum_grid/DeviceSlotDrumGridBridge.cpp
@@ -1,5 +1,7 @@
 #include "drum_grid/DeviceSlotDrumGridBridge.hpp"
 
+#include <utility>
+
 #include "NodeComponent.hpp"
 #include "audio/plugins/DrumGridPlugin.hpp"
 #include "core/LinkModeManager.hpp"
@@ -39,8 +41,8 @@ void refreshMacroUi(const PadChainLinkCallbacks& callbacks) {
 }
 
 template <typename Control>
-void wireLinkableControl(Control& control, PadChainLinkCallbacks callbacks) {
-    control.onModLinkedWithAmount = [callbacks](int modIndex, magda::ControlTarget target,
+void wireLinkableControl(Control& control, const PadChainLinkCallbacks& callbacks) {
+    control.onModLinkedWithAmount = [callbacks](int modIndex, const magda::ControlTarget& target,
                                                 float amount) {
         const auto nodePath =
             callbacks.getNodePath ? callbacks.getNodePath() : magda::ChainNodePath{};
@@ -73,7 +75,7 @@ void wireLinkableControl(Control& control, PadChainLinkCallbacks callbacks) {
     control.onModUnlinked = [callbacks](int modIndex, magda::ControlTarget target) {
         const auto nodePath =
             callbacks.getNodePath ? callbacks.getNodePath() : magda::ChainNodePath{};
-        magda::TrackManager::getInstance().removeModLink(nodePath, modIndex, target);
+        magda::TrackManager::getInstance().removeModLink(nodePath, modIndex, std::move(target));
         refreshModUi(callbacks);
     };
 
@@ -82,7 +84,7 @@ void wireLinkableControl(Control& control, PadChainLinkCallbacks callbacks) {
             callbacks.getNodePath ? callbacks.getNodePath() : magda::ChainNodePath{};
         auto rackPath = nearestRackPathForDevicePath(nodePath);
         if (rackPath.isValid())
-            magda::TrackManager::getInstance().removeModLink(rackPath, modIndex, target);
+            magda::TrackManager::getInstance().removeModLink(rackPath, modIndex, std::move(target));
         refreshModUi(callbacks);
     };
 
@@ -92,11 +94,11 @@ void wireLinkableControl(Control& control, PadChainLinkCallbacks callbacks) {
         auto trackId = nodePath.trackId;
         if (trackId != magda::INVALID_TRACK_ID)
             magda::TrackManager::getInstance().removeModLink(
-                magda::ChainNodePath::trackLevel(trackId), modIndex, target);
+                magda::ChainNodePath::trackLevel(trackId), modIndex, std::move(target));
         refreshModUi(callbacks);
     };
 
-    control.onModAmountChanged = [callbacks](int modIndex, magda::ControlTarget target,
+    control.onModAmountChanged = [callbacks](int modIndex, const magda::ControlTarget& target,
                                              float amount) {
         const auto nodePath =
             callbacks.getNodePath ? callbacks.getNodePath() : magda::ChainNodePath{};
@@ -118,7 +120,8 @@ void wireLinkableControl(Control& control, PadChainLinkCallbacks callbacks) {
             callbacks.updateParamModulation();
     };
 
-    control.onMacroLinkedWithAmount = [callbacks](int macroIndex, magda::ControlTarget target,
+    control.onMacroLinkedWithAmount = [callbacks](int macroIndex,
+                                                  const magda::ControlTarget& target,
                                                   float amount) {
         const auto nodePath =
             callbacks.getNodePath ? callbacks.getNodePath() : magda::ChainNodePath{};
@@ -152,7 +155,7 @@ void wireLinkableControl(Control& control, PadChainLinkCallbacks callbacks) {
 
     control.onMacroLinked = [callbacks](int macroIndex, magda::ControlTarget target) {
         if (callbacks.onMacroTargetChanged)
-            callbacks.onMacroTargetChanged(macroIndex, target);
+            callbacks.onMacroTargetChanged(macroIndex, std::move(target));
         if (callbacks.updateParamModulation)
             callbacks.updateParamModulation();
     };
@@ -160,7 +163,7 @@ void wireLinkableControl(Control& control, PadChainLinkCallbacks callbacks) {
     control.onMacroUnlinked = [callbacks](int macroIndex, magda::ControlTarget target) {
         const auto nodePath =
             callbacks.getNodePath ? callbacks.getNodePath() : magda::ChainNodePath{};
-        magda::TrackManager::getInstance().removeMacroLink(nodePath, macroIndex, target);
+        magda::TrackManager::getInstance().removeMacroLink(nodePath, macroIndex, std::move(target));
         refreshMacroUi(callbacks);
     };
 
@@ -170,11 +173,11 @@ void wireLinkableControl(Control& control, PadChainLinkCallbacks callbacks) {
         auto trackId = nodePath.trackId;
         if (trackId != magda::INVALID_TRACK_ID)
             magda::TrackManager::getInstance().removeMacroLink(
-                magda::ChainNodePath::trackLevel(trackId), macroIndex, target);
+                magda::ChainNodePath::trackLevel(trackId), macroIndex, std::move(target));
         refreshMacroUi(callbacks);
     };
 
-    control.onMacroAmountChanged = [callbacks](int macroIndex, magda::ControlTarget target,
+    control.onMacroAmountChanged = [callbacks](int macroIndex, const magda::ControlTarget& target,
                                                float amount) {
         const auto nodePath =
             callbacks.getNodePath ? callbacks.getNodePath() : magda::ChainNodePath{};
@@ -354,9 +357,9 @@ void appendAvailableDevices(const DrumGridUI* drumGridUI,
             for (int pi = 0; pi < static_cast<int>(chain->plugins.size()); ++pi) {
                 int devId = dg->getPluginDeviceId(chain->index, pi);
                 if (devId >= 0) {
-                    devices.push_back(
-                        {devId,
-                         chain->name + ": " + chain->plugins[static_cast<size_t>(pi)]->getName()});
+                    devices.emplace_back(devId,
+                                         chain->name + ": " +
+                                             chain->plugins[static_cast<size_t>(pi)]->getName());
                 }
             }
         }

--- a/magda/daw/ui/components/chain/drum_grid/DrumGridUI.hpp
+++ b/magda/daw/ui/components/chain/drum_grid/DrumGridUI.hpp
@@ -342,7 +342,7 @@ class DrumGridUI : public juce::Component,
     int padButtonIndexAtPoint(juce::Point<int> point) const;
 
     void setupLabel(juce::Label& label, const juce::String& text, float fontSize);
-    void setupButton(juce::TextButton& button);
+    static void setupButton(juce::TextButton& button);
     void showPadContextMenu(int padIndex, juce::Point<int> screenPos);
     void showChainContextMenu(int padIndex, juce::Point<int> screenPos);
 

--- a/magda/daw/ui/components/chain/drum_grid/PadChainPanel.cpp
+++ b/magda/daw/ui/components/chain/drum_grid/PadChainPanel.cpp
@@ -65,7 +65,7 @@ void PadChainPanel::refresh() {
 
 std::vector<tracktion::engine::Plugin*> PadChainPanel::getCollapsedPlugins() const {
     std::vector<tracktion::engine::Plugin*> result;
-    for (auto& slot : slots_) {
+    for (const auto& slot : slots_) {
         if (slot->isCollapsed() && slot->getPlugin())
             result.push_back(slot->getPlugin());
     }
@@ -146,7 +146,7 @@ int PadChainPanel::getContentWidth() const {
     // Must match resized() calculation: 2px left padding + slots + arrows + 2px right padding
     // plus DROP_ZONE_WIDTH (reserved outside the viewport)
     int width = 2;
-    for (auto& slot : slots_) {
+    for (const auto& slot : slots_) {
         if (width > 2)
             width += ARROW_WIDTH;
         width += slot->getPreferredWidth();
@@ -403,7 +403,7 @@ int PadChainPanel::calculateInsertIndex(int mouseX) const {
     int containerX = mouseX + viewport_.getViewPositionX() - viewport_.getX();
 
     for (size_t i = 0; i < slots_.size(); ++i) {
-        auto& slot = slots_[i];
+        const auto& slot = slots_[i];
         int slotMid = slot->getX() + slot->getWidth() / 2;
         if (containerX < slotMid)
             return static_cast<int>(i);

--- a/magda/daw/ui/components/chain/drum_grid/PadDeviceSlot.hpp
+++ b/magda/daw/ui/components/chain/drum_grid/PadDeviceSlot.hpp
@@ -111,7 +111,7 @@ class PadDeviceSlot : public juce::Component, private juce::Timer {
         return (i >= 0 && i < PLUGIN_PARAM_SLOTS) ? paramSlots_[static_cast<size_t>(i)].get()
                                                   : nullptr;
     }
-    int getParamSlotCount() const {
+    static int getParamSlotCount() {
         return PLUGIN_PARAM_SLOTS;
     }
     int getVisibleParamCount() const {

--- a/magda/daw/ui/components/chain/modulation/DeviceLinkCallbacks.hpp
+++ b/magda/daw/ui/components/chain/modulation/DeviceLinkCallbacks.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <functional>
+#include <utility>
 
 #include "core/ChainNodePath.hpp"
 #include "core/ControlTarget.hpp"
@@ -42,8 +43,8 @@ inline void updateDeviceLinkMacroPanel(const DeviceLinkCallbackContext& context)
 }
 
 template <typename LinkTarget>
-void wireDeviceModMacroLinkCallbacks(LinkTarget& target, DeviceLinkCallbackContext context) {
-    target.onModLinkedWithAmount = [context](int modIndex, magda::ControlTarget target,
+void wireDeviceModMacroLinkCallbacks(LinkTarget& target, const DeviceLinkCallbackContext& context) {
+    target.onModLinkedWithAmount = [context](int modIndex, const magda::ControlTarget& target,
                                              float amount) {
         auto nodePath = currentDeviceLinkNodePath(context);
         auto activeModSelection = magda::LinkModeManager::getInstance().getModInLinkMode();
@@ -73,7 +74,7 @@ void wireDeviceModMacroLinkCallbacks(LinkTarget& target, DeviceLinkCallbackConte
 
     target.onModUnlinked = [context](int modIndex, magda::ControlTarget target) {
         const auto nodePath = currentDeviceLinkNodePath(context);
-        magda::TrackManager::getInstance().removeModLink(nodePath, modIndex, target);
+        magda::TrackManager::getInstance().removeModLink(nodePath, modIndex, std::move(target));
         updateDeviceLinkParamModulation(context);
         updateDeviceLinkModsPanel(context);
     };
@@ -81,7 +82,7 @@ void wireDeviceModMacroLinkCallbacks(LinkTarget& target, DeviceLinkCallbackConte
     target.onRackModUnlinked = [context](int modIndex, magda::ControlTarget target) {
         auto rackPath = nearestRackPathForDevicePath(currentDeviceLinkNodePath(context));
         if (rackPath.isValid())
-            magda::TrackManager::getInstance().removeModLink(rackPath, modIndex, target);
+            magda::TrackManager::getInstance().removeModLink(rackPath, modIndex, std::move(target));
         updateDeviceLinkParamModulation(context);
         updateDeviceLinkModsPanel(context);
     };
@@ -91,12 +92,13 @@ void wireDeviceModMacroLinkCallbacks(LinkTarget& target, DeviceLinkCallbackConte
         auto trackId = nodePath.trackId;
         if (trackId != magda::INVALID_TRACK_ID)
             magda::TrackManager::getInstance().removeModLink(
-                magda::ChainNodePath::trackLevel(trackId), modIndex, target);
+                magda::ChainNodePath::trackLevel(trackId), modIndex, std::move(target));
         updateDeviceLinkParamModulation(context);
         updateDeviceLinkModsPanel(context);
     };
 
-    target.onModAmountChanged = [context](int modIndex, magda::ControlTarget target, float amount) {
+    target.onModAmountChanged = [context](int modIndex, const magda::ControlTarget& target,
+                                          float amount) {
         auto nodePath = currentDeviceLinkNodePath(context);
         auto activeModSelection = magda::LinkModeManager::getInstance().getModInLinkMode();
         if (activeModSelection.isValid() && activeModSelection.parentPath == nodePath) {
@@ -115,7 +117,7 @@ void wireDeviceModMacroLinkCallbacks(LinkTarget& target, DeviceLinkCallbackConte
         updateDeviceLinkParamModulation(context);
     };
 
-    target.onMacroLinkedWithAmount = [context](int macroIndex, magda::ControlTarget target,
+    target.onMacroLinkedWithAmount = [context](int macroIndex, const magda::ControlTarget& target,
                                                float amount) {
         auto nodePath = currentDeviceLinkNodePath(context);
         auto activeMacroSelection = magda::LinkModeManager::getInstance().getMacroInLinkMode();
@@ -142,7 +144,7 @@ void wireDeviceModMacroLinkCallbacks(LinkTarget& target, DeviceLinkCallbackConte
         updateDeviceLinkParamModulation(context);
     };
 
-    target.onMacroLinked = [context](int macroIndex, magda::ControlTarget target) {
+    target.onMacroLinked = [context](int macroIndex, const magda::ControlTarget& target) {
         if (context.onMacroTargetChanged)
             context.onMacroTargetChanged(macroIndex, target);
 
@@ -160,7 +162,7 @@ void wireDeviceModMacroLinkCallbacks(LinkTarget& target, DeviceLinkCallbackConte
 
     target.onMacroUnlinked = [context](int macroIndex, magda::ControlTarget target) {
         magda::TrackManager::getInstance().removeMacroLink(currentDeviceLinkNodePath(context),
-                                                           macroIndex, target);
+                                                           macroIndex, std::move(target));
         updateDeviceLinkParamModulation(context);
         updateDeviceLinkMacroPanel(context);
     };
@@ -170,7 +172,7 @@ void wireDeviceModMacroLinkCallbacks(LinkTarget& target, DeviceLinkCallbackConte
         auto trackId = nodePath.trackId;
         if (trackId != magda::INVALID_TRACK_ID)
             magda::TrackManager::getInstance().removeMacroLink(
-                magda::ChainNodePath::trackLevel(trackId), macroIndex, target);
+                magda::ChainNodePath::trackLevel(trackId), macroIndex, std::move(target));
         updateDeviceLinkParamModulation(context);
         updateDeviceLinkMacroPanel(context);
     };
@@ -178,7 +180,8 @@ void wireDeviceModMacroLinkCallbacks(LinkTarget& target, DeviceLinkCallbackConte
     target.onRackMacroLinked = [context](int macroIndex, magda::ControlTarget target) {
         auto rackPath = nearestRackPathForDevicePath(currentDeviceLinkNodePath(context));
         if (rackPath.isValid())
-            magda::TrackManager::getInstance().setMacroTarget(rackPath, macroIndex, target);
+            magda::TrackManager::getInstance().setMacroTarget(rackPath, macroIndex,
+                                                              std::move(target));
         updateDeviceLinkParamModulation(context);
     };
 
@@ -187,19 +190,20 @@ void wireDeviceModMacroLinkCallbacks(LinkTarget& target, DeviceLinkCallbackConte
         auto trackId = nodePath.trackId;
         if (trackId != magda::INVALID_TRACK_ID)
             magda::TrackManager::getInstance().setMacroTarget(
-                magda::ChainNodePath::trackLevel(trackId), macroIndex, target);
+                magda::ChainNodePath::trackLevel(trackId), macroIndex, std::move(target));
         updateDeviceLinkParamModulation(context);
     };
 
     target.onRackMacroUnlinked = [context](int macroIndex, magda::ControlTarget target) {
         auto rackPath = nearestRackPathForDevicePath(currentDeviceLinkNodePath(context));
         if (rackPath.isValid())
-            magda::TrackManager::getInstance().removeMacroLink(rackPath, macroIndex, target);
+            magda::TrackManager::getInstance().removeMacroLink(rackPath, macroIndex,
+                                                               std::move(target));
         updateDeviceLinkParamModulation(context);
         updateDeviceLinkMacroPanel(context);
     };
 
-    target.onMacroAmountChanged = [context](int macroIndex, magda::ControlTarget target,
+    target.onMacroAmountChanged = [context](int macroIndex, const magda::ControlTarget& target,
                                             float amount) {
         auto nodePath = currentDeviceLinkNodePath(context);
         auto activeMacroSelection = magda::LinkModeManager::getInstance().getMacroInLinkMode();

--- a/magda/daw/ui/components/chain/modulation/FollowerEditorPanel.cpp
+++ b/magda/daw/ui/components/chain/modulation/FollowerEditorPanel.cpp
@@ -1,5 +1,7 @@
 #include "modulation/FollowerEditorPanel.hpp"
 
+#include <utility>
+
 #include "audio/modifiers/ADSRDebugLog.hpp"
 #include "core/AutomationInfo.hpp"
 #include "ui/themes/DarkTheme.hpp"
@@ -38,7 +40,7 @@ FollowerEditorPanel::FollowerEditorPanel() {
 
     // Time sliders fold their label into the value text (e.g. "A 100 ms").
     auto setupTimeSlider = [this](TextSlider& s, const juce::String& tag, double def,
-                                  std::function<float&()> field) {
+                                  const std::function<float&()>& field) {
         s.setRange(0.0, 5000.0, 1.0);
         s.setSkewForCentre(250.0);
         s.setValue(def, juce::dontSendNotification);
@@ -80,7 +82,7 @@ FollowerEditorPanel::FollowerEditorPanel() {
     // Band-limit detection: a toggle + cutoff slider per band. Filtering the raw
     // source before peak detection lets the follower track just the bass or just
     // the highs of its source.
-    auto setupBandToggle = [this](juce::TextButton& b, std::function<bool&()> field,
+    auto setupBandToggle = [this](juce::TextButton& b, const std::function<bool&()>& field,
                                   TextSlider& freq) {
         b.setClickingTogglesState(true);
         b.setLookAndFeel(&SmallButtonLookAndFeel::getInstance());
@@ -102,7 +104,7 @@ FollowerEditorPanel::FollowerEditorPanel() {
         };
         addAndMakeVisible(b);
     };
-    auto setupFreqSlider = [this](TextSlider& s, double def, std::function<float&()> field) {
+    auto setupFreqSlider = [this](TextSlider& s, double def, const std::function<float&()>& field) {
         s.setRange(20.0, 20000.0, 1.0);
         s.setSkewForCentre(1000.0);
         s.setValue(def, juce::dontSendNotification);
@@ -139,19 +141,19 @@ FollowerEditorPanel::FollowerEditorPanel() {
 
     modMatrixContent_.onDeleteLink = [this](magda::ControlTarget target) {
         if (selectedModIndex_ >= 0 && onModLinkDeleted)
-            onModLinkDeleted(selectedModIndex_, target);
+            onModLinkDeleted(selectedModIndex_, std::move(target));
     };
     modMatrixContent_.onToggleBipolar = [this](magda::ControlTarget target, bool bipolar) {
         if (selectedModIndex_ >= 0 && onModLinkBipolarChanged)
-            onModLinkBipolarChanged(selectedModIndex_, target, bipolar);
+            onModLinkBipolarChanged(selectedModIndex_, std::move(target), bipolar);
     };
     modMatrixContent_.onToggleEnabled = [this](magda::ControlTarget target, bool enabled) {
         if (selectedModIndex_ >= 0 && onModLinkEnabledChanged)
-            onModLinkEnabledChanged(selectedModIndex_, target, enabled);
+            onModLinkEnabledChanged(selectedModIndex_, std::move(target), enabled);
     };
     modMatrixContent_.onAmountChanged = [this](magda::ControlTarget target, float amount) {
         if (selectedModIndex_ >= 0 && onModLinkAmountChanged)
-            onModLinkAmountChanged(selectedModIndex_, target, amount);
+            onModLinkAmountChanged(selectedModIndex_, std::move(target), amount);
     };
 }
 

--- a/magda/daw/ui/components/chain/modulation/LFOCurveEditorWindow.hpp
+++ b/magda/daw/ui/components/chain/modulation/LFOCurveEditorWindow.hpp
@@ -64,7 +64,7 @@ class LFOCurveEditorContent : public juce::Component {
     void rebuildPresetCombo(const juce::String& selectedUserPreset = {});
     void showSaveCurvePresetDialog();
     void saveCurvePreset(const juce::String& presetName);
-    void showPresetError(const juce::String& title, const juce::String& message);
+    static void showPresetError(const juce::String& title, const juce::String& message);
 
     static constexpr int HEADER_HEIGHT = 24;
     static constexpr int FOOTER_HEIGHT = 28;

--- a/magda/daw/ui/components/chain/modulation/LFOPhaseOverlay.cpp
+++ b/magda/daw/ui/components/chain/modulation/LFOPhaseOverlay.cpp
@@ -156,7 +156,7 @@ void LFOPhaseOverlay::paintPhaseIndicator(juce::Graphics& g) {
                   dotSize, 1.0f);
 }
 
-double LFOPhaseOverlay::applyTension(double t, double tension) const {
+double LFOPhaseOverlay::applyTension(double t, double tension) {
     if (tension > 0) {
         return std::pow(t, 1.0 + tension * 2.0);
     } else {

--- a/magda/daw/ui/components/chain/modulation/LFOPhaseOverlay.hpp
+++ b/magda/daw/ui/components/chain/modulation/LFOPhaseOverlay.hpp
@@ -58,7 +58,7 @@ class LFOPhaseOverlay : public juce::Component, private juce::Timer {
     void paintPhaseIndicator(juce::Graphics& g);
 
     // Apply tension curve interpolation
-    double applyTension(double t, double tension) const;
+    static double applyTension(double t, double tension);
 
     const ModInfo* modInfo_ = nullptr;
     juce::Colour curveColour_{DarkTheme::getColour(DarkTheme::AUTOMATION_BEZIER)};

--- a/magda/daw/ui/components/chain/modulation/MacroEditorPanel.cpp
+++ b/magda/daw/ui/components/chain/modulation/MacroEditorPanel.cpp
@@ -1,5 +1,7 @@
 #include "modulation/MacroEditorPanel.hpp"
 
+#include <utility>
+
 #include "core/AutomationInfo.hpp"
 #include "ui/themes/DarkTheme.hpp"
 #include "ui/themes/FontManager.hpp"
@@ -148,15 +150,15 @@ MacroEditorPanel::MacroEditorPanel() {
     // Link matrix viewport + content
     linkMatrixContent_.onDeleteLink = [this](magda::ControlTarget target) {
         if (onLinkRemoved)
-            onLinkRemoved(target);
+            onLinkRemoved(std::move(target));
     };
     linkMatrixContent_.onAmountChanged = [this](magda::ControlTarget target, float amount) {
         if (onLinkAmountChanged)
-            onLinkAmountChanged(target, amount);
+            onLinkAmountChanged(std::move(target), amount);
     };
     linkMatrixContent_.onToggleBipolar = [this](magda::ControlTarget target, bool bipolar) {
         if (onLinkBipolarToggled)
-            onLinkBipolarToggled(target, bipolar);
+            onLinkBipolarToggled(std::move(target), bipolar);
     };
     linkMatrixViewport_.setViewedComponent(&linkMatrixContent_, false);
     linkMatrixViewport_.setScrollBarsShown(true, false);

--- a/magda/daw/ui/components/chain/modulation/MacroKnobComponent.cpp
+++ b/magda/daw/ui/components/chain/modulation/MacroKnobComponent.cpp
@@ -686,7 +686,7 @@ void MacroKnobComponent::showLinkMenu() {
         // Individual unlink
         int unlinkIdx = result - unlinkBaseId;
         if (unlinkIdx >= 0 && unlinkIdx < static_cast<int>(unlinkTargets.size())) {
-            auto target = unlinkTargets[static_cast<size_t>(unlinkIdx)];
+            const auto& target = unlinkTargets[static_cast<size_t>(unlinkIdx)];
             safeThis->currentMacro_.removeLink(target);
             safeThis->repaint();
             if (safeThis->onLinkRemoved) {

--- a/magda/daw/ui/components/chain/modulation/MacroKnobComponent.hpp
+++ b/magda/daw/ui/components/chain/modulation/MacroKnobComponent.hpp
@@ -127,7 +127,7 @@ class MacroKnobComponent : public juce::Component,
     void endAutomationGesture();
 
     void showLinkMenu();
-    void paintLinkIndicator(juce::Graphics& g, juce::Rectangle<int> area);
+    static void paintLinkIndicator(juce::Graphics& g, juce::Rectangle<int> area);
     void onNameLabelEdited();
     void onLinkButtonClicked();
 

--- a/magda/daw/ui/components/chain/modulation/MacroPanelComponent.cpp
+++ b/magda/daw/ui/components/chain/modulation/MacroPanelComponent.cpp
@@ -25,13 +25,13 @@ void MacroPanelComponent::ensureKnobCount(int count) {
             }
         };
 
-        knob->onTargetChanged = [this, i](magda::ControlTarget target) {
+        knob->onTargetChanged = [this, i](const magda::ControlTarget& target) {
             if (onMacroTargetChanged) {
                 onMacroTargetChanged(i, target);
             }
         };
 
-        knob->onLinkRemoved = [this, i](magda::ControlTarget target) {
+        knob->onLinkRemoved = [this, i](const magda::ControlTarget& target) {
             if (onMacroLinkRemoved) {
                 onMacroLinkRemoved(i, target);
             }

--- a/magda/daw/ui/components/chain/modulation/ModKnobComponent.cpp
+++ b/magda/daw/ui/components/chain/modulation/ModKnobComponent.cpp
@@ -522,7 +522,7 @@ void ModKnobComponent::showContextMenu() {
 
         int unlinkIdx = result - kUnlinkBaseId;
         if (unlinkIdx >= 0 && unlinkIdx < static_cast<int>(unlinkTargets.size())) {
-            auto target = unlinkTargets[static_cast<size_t>(unlinkIdx)];
+            const auto& target = unlinkTargets[static_cast<size_t>(unlinkIdx)];
             safeThis->currentMod_.removeLink(target);
             safeThis->repaint();
             if (safeThis->onLinkRemoved)

--- a/magda/daw/ui/components/chain/modulation/ModKnobComponent.hpp
+++ b/magda/daw/ui/components/chain/modulation/ModKnobComponent.hpp
@@ -274,7 +274,7 @@ class ModKnobComponent : public juce::Component, public magda::LinkModeManagerLi
     void modLinkModeChanged(bool active, const magda::ModSelection& selection) override;
 
     void showContextMenu();
-    void paintLinkIndicator(juce::Graphics& g, juce::Rectangle<int> area);
+    static void paintLinkIndicator(juce::Graphics& g, juce::Rectangle<int> area);
     void onNameLabelEdited();
     void onLinkButtonClicked();
 

--- a/magda/daw/ui/components/chain/modulation/ModsPanelComponent.cpp
+++ b/magda/daw/ui/components/chain/modulation/ModsPanelComponent.cpp
@@ -124,13 +124,13 @@ void ModsPanelComponent::ensureKnobCount(int count) {
         auto knob = std::make_unique<ModKnobComponent>(i);
 
         // Wire up callbacks with mod index
-        knob->onTargetChanged = [this, i](magda::ControlTarget target) {
+        knob->onTargetChanged = [this, i](const magda::ControlTarget& target) {
             if (onModTargetChanged) {
                 onModTargetChanged(i, target);
             }
         };
 
-        knob->onLinkRemoved = [this, i](magda::ControlTarget target) {
+        knob->onLinkRemoved = [this, i](const magda::ControlTarget& target) {
             if (onModLinkRemoved) {
                 onModLinkRemoved(i, target);
             }

--- a/magda/daw/ui/components/chain/modulation/ModulatorEditorPanel.cpp
+++ b/magda/daw/ui/components/chain/modulation/ModulatorEditorPanel.cpp
@@ -1712,27 +1712,29 @@ void ModulatorEditorPanel::mouseDown(const juce::MouseEvent& e) {
 
             if (lmm.getLinkModeType() == magda::LinkModeType::Macro) {
                 const auto& sel = lmm.getMacroInLinkMode();
-                if (auto* macros = findMacrosAt(sel.parentPath)) {
+                if (const auto* macros = findMacrosAt(sel.parentPath)) {
                     if (sel.macroIndex >= 0 && sel.macroIndex < static_cast<int>(macros->size())) {
                         magda::ControlTarget t;
                         t.kind = magda::ControlTarget::Kind::ModParam;
                         t.devicePath = ownerDevicePath_;
                         t.modId = currentMod_.id;
                         t.modParamIndex = 0;
-                        if (auto* link = (*macros)[static_cast<size_t>(sel.macroIndex)].getLink(t))
+                        if (const auto* link =
+                                (*macros)[static_cast<size_t>(sel.macroIndex)].getLink(t))
                             initialAmount = link->amount;
                     }
                 }
             } else if (lmm.getLinkModeType() == magda::LinkModeType::Mod) {
                 const auto& sel = lmm.getModInLinkMode();
-                if (auto* mods = findModsAt(sel.parentPath)) {
+                if (const auto* mods = findModsAt(sel.parentPath)) {
                     if (sel.modIndex >= 0 && sel.modIndex < static_cast<int>(mods->size())) {
                         magda::ControlTarget t;
                         t.kind = magda::ControlTarget::Kind::ModParam;
                         t.devicePath = ownerDevicePath_;
                         t.modId = currentMod_.id;
                         t.modParamIndex = 0;
-                        if (auto* link = (*mods)[static_cast<size_t>(sel.modIndex)].getLink(t))
+                        if (const auto* link =
+                                (*mods)[static_cast<size_t>(sel.modIndex)].getLink(t))
                             initialAmount = link->amount;
                     }
                 }

--- a/magda/daw/ui/components/chain/modulation/ModulatorEditorPanel.cpp
+++ b/magda/daw/ui/components/chain/modulation/ModulatorEditorPanel.cpp
@@ -1,5 +1,7 @@
 #include "modulation/ModulatorEditorPanel.hpp"
 
+#include <utility>
+
 #include "BinaryData.h"
 #include "core/AutomationInfo.hpp"
 #include "core/AutomationManager.hpp"
@@ -27,8 +29,8 @@ void ModMatrixContent::setLinks(const std::vector<LinkRow>& links) {
     repaint();
 }
 
-bool ModMatrixContent::updateLinkState(magda::ControlTarget target, float amount, bool bipolar,
-                                       bool enabled) {
+bool ModMatrixContent::updateLinkState(const magda::ControlTarget& target, float amount,
+                                       bool bipolar, bool enabled) {
     for (auto& link : links_) {
         if (link.target == target) {
             bool changed =
@@ -511,7 +513,7 @@ ModulatorEditorPanel::ModulatorEditorPanel() {
     // Time sliders fold their label into the value text (e.g. "A 10 ms") so
     // they don't need separate label components or hand-painted captions.
     auto setupEnvTimeSlider = [this](TextSlider& s, const juce::String& tag, double def,
-                                     std::function<float&()> field) {
+                                     const std::function<float&()>& field) {
         s.setRange(0.0, 30000.0, 1.0);
         s.setSkewForCentre(500.0);
         s.setValue(def, juce::dontSendNotification);
@@ -544,7 +546,7 @@ ModulatorEditorPanel::ModulatorEditorPanel() {
     addChildComponent(envSustainSlider_);
 
     auto setupCurveSlider = [this](TextSlider& s, const juce::String& tag,
-                                   std::function<float&()> field) {
+                                   const std::function<float&()>& field) {
         s.setRange(-0.5, 0.5, 0.01);
         s.setValue(0.0, juce::dontSendNotification);
         s.setFont(FontManager::getInstance().getUIFont(9.0f));
@@ -587,7 +589,7 @@ ModulatorEditorPanel::ModulatorEditorPanel() {
 
     // Random 0..1 sliders fold their label into the value text (e.g. "Shp 0.50").
     auto setupRandomSlider = [this](TextSlider& s, const juce::String& tag,
-                                    std::function<float&()> field) {
+                                    const std::function<float&()>& field) {
         s.setRange(0.0, 1.0, 0.01);
         s.setFont(FontManager::getInstance().getUIFont(9.0f));
         s.setShowFillIndicator(false);
@@ -623,22 +625,22 @@ ModulatorEditorPanel::ModulatorEditorPanel() {
 
     modMatrixContent_.onDeleteLink = [this](magda::ControlTarget target) {
         if (selectedModIndex_ >= 0 && onModLinkDeleted) {
-            onModLinkDeleted(selectedModIndex_, target);
+            onModLinkDeleted(selectedModIndex_, std::move(target));
         }
     };
     modMatrixContent_.onToggleBipolar = [this](magda::ControlTarget target, bool bipolar) {
         if (selectedModIndex_ >= 0 && onModLinkBipolarChanged) {
-            onModLinkBipolarChanged(selectedModIndex_, target, bipolar);
+            onModLinkBipolarChanged(selectedModIndex_, std::move(target), bipolar);
         }
     };
     modMatrixContent_.onToggleEnabled = [this](magda::ControlTarget target, bool enabled) {
         if (selectedModIndex_ >= 0 && onModLinkEnabledChanged) {
-            onModLinkEnabledChanged(selectedModIndex_, target, enabled);
+            onModLinkEnabledChanged(selectedModIndex_, std::move(target), enabled);
         }
     };
     modMatrixContent_.onAmountChanged = [this](magda::ControlTarget target, float amount) {
         if (selectedModIndex_ >= 0 && onModLinkAmountChanged) {
-            onModLinkAmountChanged(selectedModIndex_, target, amount);
+            onModLinkAmountChanged(selectedModIndex_, std::move(target), amount);
         }
     };
 
@@ -661,22 +663,22 @@ ModulatorEditorPanel::ModulatorEditorPanel() {
     };
     followerEditorPanel_->onModLinkDeleted = [this](int idx, magda::ControlTarget target) {
         if (onModLinkDeleted)
-            onModLinkDeleted(idx, target);
+            onModLinkDeleted(idx, std::move(target));
     };
     followerEditorPanel_->onModLinkBipolarChanged = [this](int idx, magda::ControlTarget target,
                                                            bool bipolar) {
         if (onModLinkBipolarChanged)
-            onModLinkBipolarChanged(idx, target, bipolar);
+            onModLinkBipolarChanged(idx, std::move(target), bipolar);
     };
     followerEditorPanel_->onModLinkEnabledChanged = [this](int idx, magda::ControlTarget target,
                                                            bool enabled) {
         if (onModLinkEnabledChanged)
-            onModLinkEnabledChanged(idx, target, enabled);
+            onModLinkEnabledChanged(idx, std::move(target), enabled);
     };
     followerEditorPanel_->onModLinkAmountChanged = [this](int idx, magda::ControlTarget target,
                                                           float amount) {
         if (onModLinkAmountChanged)
-            onModLinkAmountChanged(idx, target, amount);
+            onModLinkAmountChanged(idx, std::move(target), amount);
     };
     addChildComponent(*followerEditorPanel_);
 }

--- a/magda/daw/ui/components/chain/modulation/ModulatorEditorPanel.hpp
+++ b/magda/daw/ui/components/chain/modulation/ModulatorEditorPanel.hpp
@@ -374,7 +374,8 @@ class ModMatrixContent : public juce::Component {
     bool isDragging() const {
         return draggingRow_ >= 0;
     }
-    bool updateLinkState(magda::ControlTarget target, float amount, bool bipolar, bool enabled);
+    bool updateLinkState(const magda::ControlTarget& target, float amount, bool bipolar,
+                         bool enabled);
 
     // Callbacks
     std::function<void(magda::ControlTarget target)> onDeleteLink;

--- a/magda/daw/ui/components/chain/params/ParamHostComponent.cpp
+++ b/magda/daw/ui/components/chain/params/ParamHostComponent.cpp
@@ -190,7 +190,7 @@ ParamHostComponent::~ParamHostComponent() = default;
 
 void ParamHostComponent::updateParameterSlots(
     const magda::DeviceInfo& device, int currentPage,
-    std::function<void(int paramIndex, double value)> onValueChanged) {
+    const std::function<void(int paramIndex, double value)>& onValueChanged) {
     const auto previousSpans = cellSpans_;
     cellSpans_.assign(static_cast<size_t>(std::max(0, cellCount_)), 1);
     usedRows_ = 0;

--- a/magda/daw/ui/components/chain/params/ParamHostComponent.hpp
+++ b/magda/daw/ui/components/chain/params/ParamHostComponent.hpp
@@ -46,8 +46,9 @@ class ParamHostComponent : public juce::Component {
     }
 
     // Parameter data updates.
-    void updateParameterSlots(const magda::DeviceInfo& device, int currentPage,
-                              std::function<void(int paramIndex, double value)> onValueChanged);
+    void updateParameterSlots(
+        const magda::DeviceInfo& device, int currentPage,
+        const std::function<void(int paramIndex, double value)>& onValueChanged);
     void updateParameterValues(const magda::DeviceInfo& device, int currentPage);
 
     void updateParamModulation(const magda::ModArray* mods, const magda::MacroArray* macros,

--- a/magda/daw/ui/components/chain/params/ParamLinkMenu.cpp
+++ b/magda/daw/ui/components/chain/params/ParamLinkMenu.cpp
@@ -193,7 +193,7 @@ void showParamLinkMenu(juce::Component* anchor, const ParamLinkContext& ctx,
     auto safeAnchor = juce::Component::SafePointer<juce::Component>(anchor);
     auto paramIdx = ctx.paramIndex;
     auto devicePath = ctx.devicePath;
-    auto cbs = callbacks;
+    const auto& cbs = callbacks;
 
     menu.showMenuAsync(juce::PopupMenu::Options(), [safeAnchor, paramIdx, devicePath, cbs,
                                                     bakeable](int result) {

--- a/magda/daw/ui/components/chain/params/ParamSlotComponent.cpp
+++ b/magda/daw/ui/components/chain/params/ParamSlotComponent.cpp
@@ -158,12 +158,12 @@ ParamSlotComponent::ParamSlotComponent(int paramIndex) : paramIndex_(paramIndex)
     addAndMakeVisible(valueSlider_);
 
     // Default MIDI Learn wiring: delegate to MidiLearnCoordinator singleton
-    onMidiLearn = [this](magda::ChainNodePath path, int paramIdx, juce::String paramName) {
+    onMidiLearn = [this](const magda::ChainNodePath& path, int paramIdx, juce::String paramName) {
         juce::String displayName = paramName.isNotEmpty() ? paramName : nameLabel_.getText();
         magda::MidiLearnCoordinator::getInstance().beginLearn(
             magda::ControlTarget::pluginParam(path, paramIdx), displayName);
     };
-    onMidiClear = [](magda::ChainNodePath path, int paramIdx) {
+    onMidiClear = [](const magda::ChainNodePath& path, int paramIdx) {
         magda::MidiLearnCoordinator::getInstance().clearMappings(
             magda::ControlTarget::pluginParam(path, paramIdx));
     };

--- a/magda/daw/ui/components/chain/params/ParamWidgetSetup.cpp
+++ b/magda/daw/ui/components/chain/params/ParamWidgetSetup.cpp
@@ -20,7 +20,7 @@ void configureSliderFormatting(TextSlider& slider, const magda::ParameterInfo& i
     // to TE raw so typed plugin display values can be matched by probing.
     if (info.displayText) {
         auto provider = info.displayText;
-        const magda::ParameterInfo infoCopy = info;
+        const magda::ParameterInfo& infoCopy = info;
         const float teMin = info.teMinValue;
         const float teSpan = info.teMaxValue - info.teMinValue;
         const bool infoMatchesTeRange = std::abs(info.minValue - info.teMinValue) < 1e-6f &&

--- a/magda/daw/ui/components/chain/slot/DeviceCustomUIManager.cpp
+++ b/magda/daw/ui/components/chain/slot/DeviceCustomUIManager.cpp
@@ -397,7 +397,7 @@ magda::PluginFormat pluginFormatFromDescription(const juce::PluginDescription& d
 }
 
 magda::DeviceInfo projectPadPluginDevice(magda::DeviceId deviceId,
-                                         tracktion::engine::Plugin::Ptr plugin) {
+                                         const tracktion::engine::Plugin::Ptr& plugin) {
     magda::DeviceInfo device;
     device.id = deviceId;
     device.name = plugin ? plugin->getName() : juce::String();
@@ -786,8 +786,9 @@ void DeviceCustomUIManager::readAndPushModMatrix(magda::DeviceId /*deviceId*/) {
 
     // Build parameter name list for the add-popup destination dropdown
     std::vector<std::pair<int, juce::String>> paramNames;
+    paramNames.reserve(autoParams.size());
     for (int pi = 0; pi < autoParams.size(); ++pi)
-        paramNames.push_back({pi, autoParams[pi]->getParameterName()});
+        paramNames.emplace_back(pi, autoParams[pi]->getParameterName());
     fourOscUI_->setModMatrixParameterNames(paramNames);
 
     // Read mod matrix entries
@@ -1016,7 +1017,7 @@ bool DeviceCustomUIManager::createMidiUtilityUI(const magda::DeviceInfo& device,
         };
         polyStepSequencerUI_->onPatternEdited =
             [this](const juce::String& description,
-                   std::function<void(magda::step_pattern::PolyPattern&)> edit,
+                   const std::function<void(magda::step_pattern::PolyPattern&)>& edit,
                    magda::StepPatternGesture gesture) {
                 // The faceplate's token says which drag a continuous edit
                 // belongs to, so two drags never merge into one undo (#2335).
@@ -1048,7 +1049,7 @@ bool DeviceCustomUIManager::createMidiUtilityUI(const magda::DeviceInfo& device,
         };
         stepSequencerUI_->onPatternEdited =
             [this](const juce::String& description,
-                   std::function<void(magda::step_pattern::MonoPattern&)> edit,
+                   const std::function<void(magda::step_pattern::MonoPattern&)>& edit,
                    magda::StepPatternGesture gesture) {
                 // See the poly sequencer above.
                 const int gestureId = stepSequencerUI_ != nullptr

--- a/magda/daw/ui/components/chain/slot/DeviceCustomUIManager.cpp
+++ b/magda/daw/ui/components/chain/slot/DeviceCustomUIManager.cpp
@@ -418,7 +418,7 @@ magda::DeviceInfo projectPadPluginDevice(magda::DeviceId deviceId,
         device.isInstrument = ext->desc.isInstrument;
         device.deviceType =
             device.isInstrument ? magda::DeviceType::Instrument : magda::DeviceType::Effect;
-    } else if (auto* internalSpec =
+    } else if (const auto* internalSpec =
                    daw::audio::findInternalPluginSpecForLoadType(device.pluginId)) {
         device.pluginId = internalSpec->pluginId;
         device.name =
@@ -1323,7 +1323,7 @@ bool DeviceCustomUIManager::createDrumGridUI(const magda::DeviceInfo& device,
     auto getChainDisplayName = [](const daw::audio::DrumGridPlugin::Chain& chain) -> juce::String {
         if (chain.plugins.empty())
             return {};
-        auto& firstPlugin = chain.plugins[0];
+        const auto& firstPlugin = chain.plugins[0];
         if (firstPlugin == nullptr)
             return {};
         if (auto* sampler =
@@ -1341,7 +1341,7 @@ bool DeviceCustomUIManager::createDrumGridUI(const magda::DeviceInfo& device,
     auto updatePadFromChain = [this, getChainDisplayName](daw::audio::DrumGridPlugin* dg,
                                                           int padIndex) {
         int midiNote = daw::audio::DrumGridPlugin::baseNote + padIndex;
-        if (auto* chain = dg->getChainForNote(midiNote)) {
+        if (const auto* chain = dg->getChainForNote(midiNote)) {
             drumGridUI_->updatePadInfo(padIndex, getChainDisplayName(*chain), chain->mute.get(),
                                        chain->solo.get(), chain->level.get(), chain->pan.get(),
                                        chain->index, chain->bypassed.get(), chain->busOutput.get());
@@ -1706,7 +1706,7 @@ bool DeviceCustomUIManager::createDrumGridUI(const magda::DeviceInfo& device,
             return result;
 
         int midiNote = daw::audio::DrumGridPlugin::baseNote + padIndex;
-        auto* chain = dg->getChainForNote(midiNote);
+        const auto* chain = dg->getChainForNote(midiNote);
         if (!chain)
             return result;
 
@@ -1728,7 +1728,7 @@ bool DeviceCustomUIManager::createDrumGridUI(const magda::DeviceInfo& device,
 
         for (int pluginIndex = 0; pluginIndex < static_cast<int>(chain->plugins.size());
              ++pluginIndex) {
-            auto& plugin = chain->plugins[static_cast<size_t>(pluginIndex)];
+            const auto& plugin = chain->plugins[static_cast<size_t>(pluginIndex)];
             if (!plugin)
                 continue;
             PadChainPanel::PluginSlotInfo info;

--- a/magda/daw/ui/components/chain/slot/DevicePresetMenu.cpp
+++ b/magda/daw/ui/components/chain/slot/DevicePresetMenu.cpp
@@ -282,7 +282,7 @@ void showSaveMagdaPresetDialog(const magda::DeviceInfo& device,
 }
 
 void saveCurrentMagdaPreset(const juce::String& currentPresetName,
-                            PresetSnapshotProvider snapshotProvider) {
+                            const PresetSnapshotProvider& snapshotProvider) {
     if (currentPresetName.isEmpty() || !snapshotProvider)
         return;
 
@@ -295,11 +295,10 @@ void saveCurrentMagdaPreset(const juce::String& currentPresetName,
         showPresetErrorAsync("Save Preset Failed", presetManager.getLastError());
 }
 
-void loadMagdaPreset(
-    const juce::String& pluginFolder, const magda::ChainNodePath& nodePath,
-    const juce::String& presetRelativePath,
-    std::function<void(const magda::DeviceInfo& liveDevice, const juce::String& presetName)>
-        onLoaded) {
+void loadMagdaPreset(const juce::String& pluginFolder, const magda::ChainNodePath& nodePath,
+                     const juce::String& presetRelativePath,
+                     const std::function<void(const magda::DeviceInfo& liveDevice,
+                                              const juce::String& presetName)>& onLoaded) {
     magda::DeviceInfo preset;
     auto& presetManager = magda::PresetManager::getInstance();
     if (!presetManager.loadDevicePreset(pluginFolder, presetRelativePath, preset)) {
@@ -389,7 +388,7 @@ void PluginDevicePresetPresenter::showMenu(juce::Component* targetComponent,
                                            const magda::DeviceInfo& device,
                                            const magda::ChainNodePath& devicePath,
                                            bool isInternalDevice,
-                                           std::function<void()> onSelectionChanged) {
+                                           const std::function<void()>& onSelectionChanged) {
     auto state = state_;
     PluginPresetMenuActions actions;
     actions.saveAs = [this, device, devicePath, onSelectionChanged]() {
@@ -412,7 +411,7 @@ void PluginDevicePresetPresenter::showMenu(juce::Component* targetComponent,
 
 void PluginDevicePresetPresenter::loadFile(const magda::ChainNodePath& devicePath,
                                            const juce::File& file,
-                                           std::function<void()> onSelectionChanged) {
+                                           const std::function<void()>& onSelectionChanged) {
     auto state = state_;
     loadPluginPresetFile(devicePath, file,
                          [state, onSelectionChanged](const juce::File& currentFile,
@@ -426,7 +425,7 @@ void PluginDevicePresetPresenter::loadFile(const magda::ChainNodePath& devicePat
 
 void PluginDevicePresetPresenter::showSaveDialog(const magda::DeviceInfo& device,
                                                  const magda::ChainNodePath& devicePath,
-                                                 std::function<void()> onSelectionChanged) {
+                                                 const std::function<void()>& onSelectionChanged) {
     auto state = state_;
     showSavePluginPresetDialog(device, devicePath, state->presetName,
                                [state, onSelectionChanged](const juce::File& currentFile,
@@ -542,9 +541,9 @@ void showPluginPresetMenu(juce::Component* targetComponent, const magda::DeviceI
         });
 }
 
-void loadPluginPresetFile(
-    const magda::ChainNodePath& devicePath, const juce::File& file,
-    std::function<void(const juce::File& currentFile, const juce::String& displayName)> onLoaded) {
+void loadPluginPresetFile(const magda::ChainNodePath& devicePath, const juce::File& file,
+                          const std::function<void(const juce::File& currentFile,
+                                                   const juce::String& displayName)>& onLoaded) {
     auto* bridge = getAudioBridge();
     if (bridge == nullptr)
         return;

--- a/magda/daw/ui/components/chain/slot/DevicePresetMenu.hpp
+++ b/magda/daw/ui/components/chain/slot/DevicePresetMenu.hpp
@@ -31,13 +31,12 @@ void showSaveMagdaPresetDialog(const magda::DeviceInfo& device,
                                std::function<void(const juce::String& presetName)> onSaved);
 
 void saveCurrentMagdaPreset(const juce::String& currentPresetName,
-                            PresetSnapshotProvider snapshotProvider);
+                            const PresetSnapshotProvider& snapshotProvider);
 
-void loadMagdaPreset(
-    const juce::String& pluginFolder, const magda::ChainNodePath& nodePath,
-    const juce::String& presetRelativePath,
-    std::function<void(const magda::DeviceInfo& liveDevice, const juce::String& presetName)>
-        onLoaded);
+void loadMagdaPreset(const juce::String& pluginFolder, const magda::ChainNodePath& nodePath,
+                     const juce::String& presetRelativePath,
+                     const std::function<void(const magda::DeviceInfo& liveDevice,
+                                              const juce::String& presetName)>& onLoaded);
 
 class MagdaDevicePresetPresenter {
   public:
@@ -61,11 +60,11 @@ class PluginDevicePresetPresenter {
     juce::String getCurrentPresetLabel() const;
     void showMenu(juce::Component* targetComponent, const magda::DeviceInfo& device,
                   const magda::ChainNodePath& devicePath, bool isInternalDevice,
-                  std::function<void()> onSelectionChanged);
+                  const std::function<void()>& onSelectionChanged);
     void loadFile(const magda::ChainNodePath& devicePath, const juce::File& file,
-                  std::function<void()> onSelectionChanged);
+                  const std::function<void()>& onSelectionChanged);
     void showSaveDialog(const magda::DeviceInfo& device, const magda::ChainNodePath& devicePath,
-                        std::function<void()> onSelectionChanged);
+                        const std::function<void()>& onSelectionChanged);
 
   private:
     struct State;
@@ -88,9 +87,9 @@ void showPluginPresetMenu(juce::Component* targetComponent, const magda::DeviceI
                           const juce::File& currentPluginPresetFile,
                           PluginPresetMenuActions actions);
 
-void loadPluginPresetFile(
-    const magda::ChainNodePath& devicePath, const juce::File& file,
-    std::function<void(const juce::File& currentFile, const juce::String& displayName)> onLoaded);
+void loadPluginPresetFile(const magda::ChainNodePath& devicePath, const juce::File& file,
+                          const std::function<void(const juce::File& currentFile,
+                                                   const juce::String& displayName)>& onLoaded);
 
 void showSavePluginPresetDialog(
     const magda::DeviceInfo& device, const magda::ChainNodePath& devicePath,

--- a/magda/daw/ui/components/chain/slot/DeviceSlotGainMeterControls.cpp
+++ b/magda/daw/ui/components/chain/slot/DeviceSlotGainMeterControls.cpp
@@ -14,7 +14,7 @@ namespace magda::daw::ui {
 void setupDeviceSlotGainMeterControls(
     juce::Component& parent, magda::DraggableValueLabel& gainLabel, magda::LevelMeter& levelMeter,
     std::unique_ptr<juce::Slider>& gainSlider, std::unique_ptr<juce::Slider>& mixKnob,
-    const magda::DeviceInfo& device, std::function<magda::ChainNodePath()> getNodePath) {
+    const magda::DeviceInfo& device, const std::function<magda::ChainNodePath()>& getNodePath) {
     // Gain label in header (dB format, draggable)
     gainLabel.setRange(-60.0, 12.0, 0.0);
     gainLabel.setValue(device.gainDb, juce::dontSendNotification);
@@ -131,7 +131,7 @@ void syncDeviceSlotMixKnobFromDevice(juce::Slider* mixKnob, const magda::DeviceI
 
 void refreshDeviceSlotMixKnobFromDevice(juce::Slider* mixKnob, const magda::DeviceInfo& device,
                                         bool relayoutOnVisibilityChange,
-                                        std::function<void()> relayout) {
+                                        const std::function<void()>& relayout) {
     if (mixKnob == nullptr)
         return;
 

--- a/magda/daw/ui/components/chain/slot/DeviceSlotGainMeterControls.hpp
+++ b/magda/daw/ui/components/chain/slot/DeviceSlotGainMeterControls.hpp
@@ -18,7 +18,7 @@ namespace magda::daw::ui {
 void setupDeviceSlotGainMeterControls(
     juce::Component& parent, magda::DraggableValueLabel& gainLabel, magda::LevelMeter& levelMeter,
     std::unique_ptr<juce::Slider>& gainSlider, std::unique_ptr<juce::Slider>& mixKnob,
-    const magda::DeviceInfo& device, std::function<magda::ChainNodePath()> getNodePath);
+    const magda::DeviceInfo& device, const std::function<magda::ChainNodePath()>& getNodePath);
 
 void syncDeviceSlotGainControlsFromDevice(magda::DraggableValueLabel& gainLabel,
                                           juce::Slider* gainSlider,
@@ -29,6 +29,6 @@ double currentMixPosition(const magda::DeviceInfo& device);
 void syncDeviceSlotMixKnobFromDevice(juce::Slider* mixKnob, const magda::DeviceInfo& device);
 void refreshDeviceSlotMixKnobFromDevice(juce::Slider* mixKnob, const magda::DeviceInfo& device,
                                         bool relayoutOnVisibilityChange,
-                                        std::function<void()> relayout);
+                                        const std::function<void()>& relayout);
 
 }  // namespace magda::daw::ui

--- a/magda/daw/ui/components/chain/slot/DeviceSlotInlineUiFactory.cpp
+++ b/magda/daw/ui/components/chain/slot/DeviceSlotInlineUiFactory.cpp
@@ -116,7 +116,7 @@ void linkCompiledParameter(int paramIndex, float amount,
 }  // namespace
 
 DeviceSlotInlineUiCallbacks makeDeviceSlotInlineUiCallbacks(
-    DeviceSlotInlineUiCallbackContext context) {
+    const DeviceSlotInlineUiCallbackContext& context) {
     DeviceSlotInlineUiCallbacks callbacks;
     callbacks.onParameterChanged = [context](int paramIndex, float value) {
         if (!context.getNodePath)
@@ -269,7 +269,7 @@ void readAndPushDeviceSlotInlineUiModMatrix(magda::DeviceId deviceId,
 void configureDeviceSlotLinkableSliders(
     const std::vector<LinkableTextSlider*>& sliders, const magda::DeviceInfo& device,
     const magda::ChainNodePath& nodePath, const DeviceSlotModulationContext& context,
-    std::function<void(LinkableTextSlider&)> configureCallbacks) {
+    const std::function<void(LinkableTextSlider&)>& configureCallbacks) {
     for (int i = 0; i < static_cast<int>(sliders.size()); ++i) {
         auto* slider = sliders[static_cast<size_t>(i)];
         if (slider == nullptr)

--- a/magda/daw/ui/components/chain/slot/DeviceSlotInlineUiFactory.hpp
+++ b/magda/daw/ui/components/chain/slot/DeviceSlotInlineUiFactory.hpp
@@ -63,7 +63,7 @@ struct DeviceSlotInlineUiCallbackContext {
 };
 
 DeviceSlotInlineUiCallbacks makeDeviceSlotInlineUiCallbacks(
-    DeviceSlotInlineUiCallbackContext context);
+    const DeviceSlotInlineUiCallbackContext& context);
 
 DeviceSlotInlineUiKind createDeviceSlotInlineUi(const magda::DeviceInfo& device,
                                                 const DeviceSlotTraits& traits,
@@ -96,6 +96,6 @@ void readAndPushDeviceSlotInlineUiModMatrix(magda::DeviceId deviceId,
 void configureDeviceSlotLinkableSliders(
     const std::vector<LinkableTextSlider*>& sliders, const magda::DeviceInfo& device,
     const magda::ChainNodePath& nodePath, const DeviceSlotModulationContext& context,
-    std::function<void(LinkableTextSlider&)> configureCallbacks);
+    const std::function<void(LinkableTextSlider&)>& configureCallbacks);
 
 }  // namespace magda::daw::ui

--- a/magda/daw/ui/components/chain/slot/DeviceSlotModMacroCommands.cpp
+++ b/magda/daw/ui/components/chain/slot/DeviceSlotModMacroCommands.cpp
@@ -1,5 +1,7 @@
 #include "slot/DeviceSlotModMacroCommands.hpp"
 
+#include <utility>
+
 #include "core/LinkModeManager.hpp"
 #include "core/SelectionManager.hpp"
 #include "core/TrackCommands.hpp"
@@ -34,7 +36,7 @@ void refreshPanels(const DeviceSlotModMacroCommandCallbacks& callbacks) {
 
 void setDeviceSlotModTarget(const magda::ChainNodePath& nodePath, int modIndex,
                             magda::ControlTarget target) {
-    magda::TrackManager::getInstance().setModTarget(nodePath, modIndex, target);
+    magda::TrackManager::getInstance().setModTarget(nodePath, modIndex, std::move(target));
 }
 
 void renameDeviceSlotMod(const magda::ChainNodePath& nodePath, int modIndex,
@@ -112,7 +114,7 @@ void setDeviceSlotMacroValue(const magda::ChainNodePath& nodePath, int macroInde
 }
 
 void setDeviceSlotMacroTarget(const magda::ChainNodePath& nodePath, int macroIndex,
-                              magda::ControlTarget target,
+                              const magda::ControlTarget& target,
                               const DeviceSlotModMacroCommandCallbacks& callbacks) {
     // Check if the active macro is from this device or a parent rack.
     auto activeMacroSelection = magda::LinkModeManager::getInstance().getMacroInLinkMode();
@@ -143,12 +145,13 @@ void clearAllDeviceSlotMacroLinks(const magda::ChainNodePath& nodePath, int macr
 void setDeviceSlotMacroLinkAmount(const magda::ChainNodePath& nodePath, int macroIndex,
                                   magda::ControlTarget target, float amount,
                                   const DeviceSlotModMacroCommandCallbacks& callbacks) {
-    magda::TrackManager::getInstance().setMacroLinkAmount(nodePath, macroIndex, target, amount);
+    magda::TrackManager::getInstance().setMacroLinkAmount(nodePath, macroIndex, std::move(target),
+                                                          amount);
     updateParamModulation(callbacks);
 }
 
 void createDeviceSlotMacroLink(const magda::ChainNodePath& nodePath, int macroIndex,
-                               magda::ControlTarget target, float amount,
+                               const magda::ControlTarget& target, float amount,
                                const DeviceSlotModMacroCommandCallbacks& callbacks) {
     magda::TrackManager::getInstance().setMacroTarget(nodePath, macroIndex, target);
     magda::TrackManager::getInstance().setMacroLinkAmount(nodePath, macroIndex, target, amount);
@@ -161,7 +164,7 @@ void createDeviceSlotMacroLink(const magda::ChainNodePath& nodePath, int macroIn
 void removeDeviceSlotMacroLink(const magda::ChainNodePath& nodePath, int macroIndex,
                                magda::ControlTarget target,
                                const DeviceSlotModMacroCommandCallbacks& callbacks) {
-    magda::TrackManager::getInstance().removeMacroLink(nodePath, macroIndex, target);
+    magda::TrackManager::getInstance().removeMacroLink(nodePath, macroIndex, std::move(target));
     updateMacroPanel(callbacks);
     updateParamModulation(callbacks);
 }
@@ -169,7 +172,8 @@ void removeDeviceSlotMacroLink(const magda::ChainNodePath& nodePath, int macroIn
 void setDeviceSlotMacroLinkBipolar(const magda::ChainNodePath& nodePath, int macroIndex,
                                    magda::ControlTarget target, bool bipolar,
                                    const DeviceSlotModMacroCommandCallbacks& callbacks) {
-    magda::TrackManager::getInstance().setMacroLinkBipolar(nodePath, macroIndex, target, bipolar);
+    magda::TrackManager::getInstance().setMacroLinkBipolar(nodePath, macroIndex, std::move(target),
+                                                           bipolar);
     updateParamModulation(callbacks);
 }
 
@@ -184,19 +188,21 @@ void selectDeviceSlotMacro(const magda::ChainNodePath& nodePath, int macroIndex)
 void setDeviceSlotModLinkAmount(const magda::ChainNodePath& nodePath, int modIndex,
                                 magda::ControlTarget target, float amount,
                                 const DeviceSlotModMacroCommandCallbacks& callbacks) {
-    magda::TrackManager::getInstance().setModLinkAmount(nodePath, modIndex, target, amount);
+    magda::TrackManager::getInstance().setModLinkAmount(nodePath, modIndex, std::move(target),
+                                                        amount);
     updateParamModulation(callbacks);
 }
 
 void setDeviceSlotModLinkEnabled(const magda::ChainNodePath& nodePath, int modIndex,
                                  magda::ControlTarget target, bool enabled,
                                  const DeviceSlotModMacroCommandCallbacks& callbacks) {
-    magda::TrackManager::getInstance().setModLinkEnabled(nodePath, modIndex, target, enabled);
+    magda::TrackManager::getInstance().setModLinkEnabled(nodePath, modIndex, std::move(target),
+                                                         enabled);
     updateParamModulation(callbacks);
 }
 
 void createDeviceSlotModLink(const magda::ChainNodePath& nodePath, int modIndex,
-                             magda::ControlTarget target, float amount,
+                             const magda::ControlTarget& target, float amount,
                              const DeviceSlotModMacroCommandCallbacks& callbacks) {
     magda::TrackManager::getInstance().setModTarget(nodePath, modIndex, target);
     magda::TrackManager::getInstance().setModLinkAmount(nodePath, modIndex, target, amount);
@@ -209,7 +215,7 @@ void createDeviceSlotModLink(const magda::ChainNodePath& nodePath, int modIndex,
 void removeDeviceSlotModLink(const magda::ChainNodePath& nodePath, int modIndex,
                              magda::ControlTarget target,
                              const DeviceSlotModMacroCommandCallbacks& callbacks) {
-    magda::TrackManager::getInstance().removeModLink(nodePath, modIndex, target);
+    magda::TrackManager::getInstance().removeModLink(nodePath, modIndex, std::move(target));
     updateModsPanel(callbacks);
     updateParamModulation(callbacks);
 }

--- a/magda/daw/ui/components/chain/slot/DeviceSlotModMacroCommands.hpp
+++ b/magda/daw/ui/components/chain/slot/DeviceSlotModMacroCommands.hpp
@@ -45,7 +45,7 @@ void notifyDeviceSlotModCurveChanged(const magda::ChainNodePath& nodePath);
 void setDeviceSlotMacroValue(const magda::ChainNodePath& nodePath, int macroIndex, float value,
                              const DeviceSlotModMacroCommandCallbacks& callbacks);
 void setDeviceSlotMacroTarget(const magda::ChainNodePath& nodePath, int macroIndex,
-                              magda::ControlTarget target,
+                              const magda::ControlTarget& target,
                               const DeviceSlotModMacroCommandCallbacks& callbacks);
 void renameDeviceSlotMacro(const magda::ChainNodePath& nodePath, int macroIndex,
                            const juce::String& name);
@@ -55,7 +55,7 @@ void setDeviceSlotMacroLinkAmount(const magda::ChainNodePath& nodePath, int macr
                                   magda::ControlTarget target, float amount,
                                   const DeviceSlotModMacroCommandCallbacks& callbacks);
 void createDeviceSlotMacroLink(const magda::ChainNodePath& nodePath, int macroIndex,
-                               magda::ControlTarget target, float amount,
+                               const magda::ControlTarget& target, float amount,
                                const DeviceSlotModMacroCommandCallbacks& callbacks);
 void removeDeviceSlotMacroLink(const magda::ChainNodePath& nodePath, int macroIndex,
                                magda::ControlTarget target,
@@ -74,7 +74,7 @@ void setDeviceSlotModLinkEnabled(const magda::ChainNodePath& nodePath, int modIn
                                  magda::ControlTarget target, bool enabled,
                                  const DeviceSlotModMacroCommandCallbacks& callbacks);
 void createDeviceSlotModLink(const magda::ChainNodePath& nodePath, int modIndex,
-                             magda::ControlTarget target, float amount,
+                             const magda::ControlTarget& target, float amount,
                              const DeviceSlotModMacroCommandCallbacks& callbacks);
 void removeDeviceSlotModLink(const magda::ChainNodePath& nodePath, int modIndex,
                              magda::ControlTarget target,

--- a/magda/daw/ui/components/chain/slot/DeviceSlotParameterPaging.cpp
+++ b/magda/daw/ui/components/chain/slot/DeviceSlotParameterPaging.cpp
@@ -13,7 +13,7 @@ namespace magda::daw::ui {
 
 namespace {
 
-void reloadPage(DeviceSlotParameterPagingCallbacks callbacks) {
+void reloadPage(const DeviceSlotParameterPagingCallbacks& callbacks) {
     if (callbacks.reloadParameterSlots)
         callbacks.reloadParameterSlots();
     if (callbacks.updateParamModulation)
@@ -28,7 +28,7 @@ void updateDeviceSlotParameterSlots(magda::DeviceInfo& device, const magda::Chai
                                     ParamHostComponent& paramGrid,
                                     CompiledDevicePanel* compiledPanel,
                                     const DeviceSlotTraits& traits,
-                                    DeviceSlotParameterPagingCallbacks callbacks) {
+                                    const DeviceSlotParameterPagingCallbacks& callbacks) {
     // Each parameter slot stores a copy of this callback and invokes it on a
     // later mouse drag, so it must NOT capture the function-local `compiledPanel`
     // pointer / `callbacks` struct by reference - those die when this function

--- a/magda/daw/ui/components/chain/slot/DeviceSlotParameterPaging.hpp
+++ b/magda/daw/ui/components/chain/slot/DeviceSlotParameterPaging.hpp
@@ -21,7 +21,7 @@ void updateDeviceSlotParameterSlots(magda::DeviceInfo& device, const magda::Chai
                                     ParamHostComponent& paramGrid,
                                     CompiledDevicePanel* compiledPanel,
                                     const DeviceSlotTraits& traits,
-                                    DeviceSlotParameterPagingCallbacks callbacks);
+                                    const DeviceSlotParameterPagingCallbacks& callbacks);
 
 void updateDeviceSlotParameterValues(const magda::DeviceInfo& device,
                                      ParamHostComponent& paramGrid);

--- a/magda/daw/ui/components/chord/ChordBlockComponent.cpp
+++ b/magda/daw/ui/components/chord/ChordBlockComponent.cpp
@@ -1,5 +1,7 @@
 #include "ChordBlockComponent.hpp"
 
+#include <utility>
+
 #include "core/MidiFileWriter.hpp"
 #include "music/NotationSettings.hpp"
 #include "project/ProjectManager.hpp"
@@ -9,7 +11,7 @@
 
 namespace magda::daw::ui {
 
-ChordBlockComponent::ChordBlockComponent(const magda::music::Chord& chord) : chord_(chord) {
+ChordBlockComponent::ChordBlockComponent(magda::music::Chord chord) : chord_(std::move(chord)) {
     setName("ChordBlock");
 }
 

--- a/magda/daw/ui/components/chord/ChordBlockComponent.hpp
+++ b/magda/daw/ui/components/chord/ChordBlockComponent.hpp
@@ -20,7 +20,7 @@ namespace magda::daw::ui {
  */
 class ChordBlockComponent : public juce::Component {
   public:
-    explicit ChordBlockComponent(const magda::music::Chord& chord);
+    explicit ChordBlockComponent(magda::music::Chord chord);
 
     void paint(juce::Graphics& g) override;
     void mouseDown(const juce::MouseEvent& e) override;

--- a/magda/daw/ui/components/clips/ClipComponent.cpp
+++ b/magda/daw/ui/components/clips/ClipComponent.cpp
@@ -922,7 +922,7 @@ void ClipComponent::paintMidiNotes(juce::Graphics& g, const ClipInfo& clip,
     }
 }
 
-bool ClipComponent::isChordClip(const ClipInfo& clip) const {
+bool ClipComponent::isChordClip(const ClipInfo& clip) {
     const auto* track = TrackManager::getInstance().getTrack(clip.trackId);
     return track != nullptr && track->type == TrackType::Chord;
 }
@@ -3220,7 +3220,7 @@ bool ClipComponent::isPartOfMultiSelection() const {
 // Helpers
 // ============================================================================
 
-bool ClipComponent::isOnLeftEdge(int x) const {
+bool ClipComponent::isOnLeftEdge(int x) {
     return x < RESIZE_HANDLE_WIDTH;
 }
 

--- a/magda/daw/ui/components/clips/ClipComponent.hpp
+++ b/magda/daw/ui/components/clips/ClipComponent.hpp
@@ -276,17 +276,18 @@ class ClipComponent : public juce::Component,
     // Chord-track clips render their chordAnnotations as named blocks instead of
     // a MIDI-note preview.
     void paintChordClip(juce::Graphics& g, const ClipInfo& clip, juce::Rectangle<int> bounds);
-    bool isChordClip(const ClipInfo& clip) const;
+    static bool isChordClip(const ClipInfo& clip);
     void paintClipHeader(juce::Graphics& g, const ClipInfo& clip, juce::Rectangle<int> bounds);
     void paintResizeHandles(juce::Graphics& g, juce::Rectangle<int> bounds);
-    void paintFadeOverlays(juce::Graphics& g, const ClipInfo& clip, const EffectiveFades& fades,
-                           juce::Rectangle<int> waveformArea, double pixelsPerSecond);
+    static void paintFadeOverlays(juce::Graphics& g, const ClipInfo& clip,
+                                  const EffectiveFades& fades, juce::Rectangle<int> waveformArea,
+                                  double pixelsPerSecond);
     void paintFadeHandles(juce::Graphics& g, const ClipInfo& clip, juce::Rectangle<int> bounds);
     void paintVolumeLine(juce::Graphics& g, const ClipInfo& clip,
                          juce::Rectangle<int> waveformArea);
 
     // Interaction helpers
-    bool isOnLeftEdge(int x) const;
+    static bool isOnLeftEdge(int x);
     bool isOnRightEdge(int x) const;
     bool isOnFadeInHandle(int x, int y) const;
     bool isOnFadeOutHandle(int x, int y) const;

--- a/magda/daw/ui/components/common/LinkableTextSlider.cpp
+++ b/magda/daw/ui/components/common/LinkableTextSlider.cpp
@@ -144,11 +144,11 @@ LinkableTextSlider::LinkableTextSlider(TextSlider::Format format) : slider_(form
         }
     };
     // Default MIDI Learn wiring: delegate to MidiLearnCoordinator singleton
-    onMidiLearn = [](magda::ChainNodePath path, int paramIdx, juce::String paramName) {
+    onMidiLearn = [](const magda::ChainNodePath& path, int paramIdx, juce::String paramName) {
         magda::MidiLearnCoordinator::getInstance().beginLearn(
             magda::ControlTarget::pluginParam(path, paramIdx), paramName);
     };
-    onMidiClear = [](magda::ChainNodePath path, int paramIdx) {
+    onMidiClear = [](const magda::ChainNodePath& path, int paramIdx) {
         magda::MidiLearnCoordinator::getInstance().clearMappings(
             magda::ControlTarget::pluginParam(path, paramIdx));
     };

--- a/magda/daw/ui/components/common/MixerDebugPanel.cpp
+++ b/magda/daw/ui/components/common/MixerDebugPanel.cpp
@@ -97,11 +97,11 @@ void MixerDebugPanel::resized() {
         viewport_->getWidth() - (viewport_->isVerticalScrollBarShown() ? 8 : 0), contentHeight_);
 }
 
-bool MixerDebugPanel::isInResizeZone(const juce::Point<int>& pos) const {
+bool MixerDebugPanel::isInResizeZone(const juce::Point<int>& pos) {
     return pos.y < resizeZoneHeight_;
 }
 
-bool MixerDebugPanel::isInDragZone(const juce::Point<int>& pos) const {
+bool MixerDebugPanel::isInDragZone(const juce::Point<int>& pos) {
     return pos.y >= resizeZoneHeight_ && pos.y < titleBarHeight_;
 }
 

--- a/magda/daw/ui/components/common/MixerDebugPanel.hpp
+++ b/magda/daw/ui/components/common/MixerDebugPanel.hpp
@@ -56,8 +56,8 @@ class MixerDebugPanel : public juce::Component {
     int dragStartHeight_ = 0;
     int contentHeight_ = 0;
 
-    bool isInResizeZone(const juce::Point<int>& pos) const;
-    bool isInDragZone(const juce::Point<int>& pos) const;
+    static bool isInResizeZone(const juce::Point<int>& pos);
+    static bool isInDragZone(const juce::Point<int>& pos);
 
     void addIntSlider(const juce::String& name, int* valuePtr, int min, int max);
     void addFloatSlider(const juce::String& name, float* valuePtr, float min, float max,

--- a/magda/daw/ui/components/common/ZoomControls.hpp
+++ b/magda/daw/ui/components/common/ZoomControls.hpp
@@ -50,7 +50,7 @@ class ZoomControls : public juce::Component {
     void handleSliderChange();
 
     // Styling
-    void setupButton(juce::TextButton& button, const juce::String& text);
+    static void setupButton(juce::TextButton& button, const juce::String& text);
     void setupSlider();
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(ZoomControls)

--- a/magda/daw/ui/components/common/curve/CurveBezierHandle.cpp
+++ b/magda/daw/ui/components/common/curve/CurveBezierHandle.cpp
@@ -54,7 +54,7 @@ void CurveBezierHandle::mouseDrag(const juce::MouseEvent& e) {
         return;
 
     // Calculate delta in parent coordinates
-    auto parentComponent = getParentComponent();
+    auto* parentComponent = getParentComponent();
     if (!parentComponent)
         return;
 

--- a/magda/daw/ui/components/common/curve/CurvePointComponent.cpp
+++ b/magda/daw/ui/components/common/curve/CurvePointComponent.cpp
@@ -101,17 +101,10 @@ void CurvePointComponent::mouseDown(const juce::MouseEvent& e) {
     isRightClickPending_ = false;
 
     if (e.mods.isLeftButtonDown()) {
-        // Handle selection
-        if (e.mods.isCommandDown() || e.mods.isShiftDown()) {
-            // Toggle/add to selection
-            if (onPointSelected) {
-                onPointSelected(pointId_);
-            }
-        } else {
-            // Normal click - select this point
-            if (onPointSelected) {
-                onPointSelected(pointId_);
-            }
+        // Cmd/shift-click is meant to extend the selection, but the callback
+        // carries no modifier, so every click selects the one point for now.
+        if (onPointSelected) {
+            onPointSelected(pointId_);
         }
 
         // Start drag

--- a/magda/daw/ui/components/common/curve/CurveTensionHandle.hpp
+++ b/magda/daw/ui/components/common/curve/CurveTensionHandle.hpp
@@ -39,7 +39,7 @@ class CurveTensionHandle : public juce::Component {
         return tension_;
     }
 
-    void setSlopeGoesDown(bool goesDown) {
+    static void setSlopeGoesDown(bool goesDown) {
         juce::ignoreUnused(goesDown);
     }
 

--- a/magda/daw/ui/components/mixer/RoutingSyncHelper.hpp
+++ b/magda/daw/ui/components/mixer/RoutingSyncHelper.hpp
@@ -26,7 +26,7 @@ namespace RoutingSyncHelper {
 inline void populateAudioInputOptions(RoutingSelector* selector, juce::AudioIODevice* device,
                                       TrackId currentTrackId = INVALID_TRACK_ID,
                                       std::map<int, TrackId>* outInputTrackMapping = nullptr,
-                                      juce::BigInteger enabledInputChannels = {},
+                                      const juce::BigInteger& enabledInputChannels = {},
                                       std::map<int, juce::String>* outChannelMapping = nullptr,
                                       const std::map<int, juce::String>& teDeviceNames = {}) {
     if (!selector)
@@ -139,7 +139,7 @@ inline void populateAudioInputOptions(RoutingSelector* selector, juce::AudioIODe
 inline void populateAudioOutputOptions(RoutingSelector* selector, TrackId currentTrackId,
                                        juce::AudioIODevice* device,
                                        std::map<int, TrackId>& outTrackMapping,
-                                       juce::BigInteger enabledOutputChannels = {},
+                                       const juce::BigInteger& enabledOutputChannels = {},
                                        std::map<int, juce::String>* outChannelMapping = nullptr,
                                        const std::map<int, juce::String>& teDeviceNames = {}) {
     if (!selector)
@@ -464,7 +464,8 @@ inline void syncSelectorsFromTrack(
         // options are available before any track input is selected — otherwise
         // the first "track:" selection could never be made.
         populateAudioInputOptions(audioInSelector, device, currentTrackId, inputTrackMapping,
-                                  enabledInputChannels, inputChannelMapping, teDeviceNames);
+                                  std::move(enabledInputChannels), inputChannelMapping,
+                                  teDeviceNames);
         if (hasAudioInput) {
             if (track.audioInputDevice.startsWith("track:") && inputTrackMapping) {
                 // Track-as-input: find the matching option ID
@@ -545,7 +546,7 @@ inline void syncSelectorsFromTrack(
     // Update Audio Output selector
     if (audioOutSelector) {
         populateAudioOutputOptions(audioOutSelector, currentTrackId, device, outputTrackMapping,
-                                   enabledOutputChannels, outputChannelMapping,
+                                   std::move(enabledOutputChannels), outputChannelMapping,
                                    teOutputDeviceNames);
         juce::String currentAudioOutput = track.audioOutputDevice;
         if (currentAudioOutput.isEmpty()) {

--- a/magda/daw/ui/components/pianoroll/CCLaneComponent.cpp
+++ b/magda/daw/ui/components/pianoroll/CCLaneComponent.cpp
@@ -290,7 +290,7 @@ void CCLaneComponent::updatePointsCache() const {
     pointsCacheDirty_ = false;
 }
 
-size_t CCLaneComponent::pointIdToEventIndex(uint32_t pointId) const {
+size_t CCLaneComponent::pointIdToEventIndex(uint32_t pointId) {
     // The point ID is the original index into the clip's CC/PB data vector
     return static_cast<size_t>(pointId);
 }

--- a/magda/daw/ui/components/pianoroll/CCLaneComponent.hpp
+++ b/magda/daw/ui/components/pianoroll/CCLaneComponent.hpp
@@ -128,7 +128,7 @@ class CCLaneComponent : public CurveEditorBase {
     double valueToNormalized(int value) const;
 
     // Find the index of a CC/PB event by its point ID
-    size_t pointIdToEventIndex(uint32_t pointId) const;
+    static size_t pointIdToEventIndex(uint32_t pointId);
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(CCLaneComponent)
 };

--- a/magda/daw/ui/components/pianoroll/NoteComponent.cpp
+++ b/magda/daw/ui/components/pianoroll/NoteComponent.cpp
@@ -465,7 +465,7 @@ void NoteComponent::timerCallback() {
     }
 }
 
-bool NoteComponent::isOnLeftEdge(int x) const {
+bool NoteComponent::isOnLeftEdge(int x) {
     return x < RESIZE_HANDLE_WIDTH;
 }
 

--- a/magda/daw/ui/components/pianoroll/NoteComponent.hpp
+++ b/magda/daw/ui/components/pianoroll/NoteComponent.hpp
@@ -149,7 +149,7 @@ class NoteComponent : public juce::Component, private juce::Timer {
     void timerCallback() override;
 
     // Interaction helpers
-    bool isOnLeftEdge(int x) const;
+    static bool isOnLeftEdge(int x);
     bool isOnRightEdge(int x) const;
     void updateCursor();
 

--- a/magda/daw/ui/components/pianoroll/PianoRollGridComponent.cpp
+++ b/magda/daw/ui/components/pianoroll/PianoRollGridComponent.cpp
@@ -2566,7 +2566,7 @@ void PianoRollGridComponent::rebuildSelectedPitchRows() {
     }
 }
 
-bool PianoRollGridComponent::isBlackKey(int noteNumber) const {
+bool PianoRollGridComponent::isBlackKey(int noteNumber) {
     int note = noteNumber % 12;
     return note == 1 || note == 3 || note == 6 || note == 8 || note == 10;
 }

--- a/magda/daw/ui/components/pianoroll/PianoRollGridComponent.cpp
+++ b/magda/daw/ui/components/pianoroll/PianoRollGridComponent.cpp
@@ -2806,7 +2806,7 @@ void PianoRollGridComponent::filesDropped(const juce::StringArray& files, int x,
     std::vector<std::pair<int, int>> simpleNotes;
 
     for (int t = 0; t < midi.getNumTracks(); ++t) {
-        auto* track = midi.getTrack(t);
+        const auto* track = midi.getTrack(t);
         if (!track)
             continue;
         for (int i = 0; i < track->getNumEvents(); ++i) {

--- a/magda/daw/ui/components/pianoroll/PianoRollGridComponent.hpp
+++ b/magda/daw/ui/components/pianoroll/PianoRollGridComponent.hpp
@@ -566,7 +566,7 @@ class PianoRollGridComponent : public juce::Component,
     double clipBeatForDisplayX(ClipId clipId, int mouseX, bool floorToCell = false) const;
     double absolutePlayheadBeatForDisplayX(int mouseX) const;
     void updateEmptyGridCursor(const juce::ModifierKeys& mods, int mouseX);
-    bool isBlackKey(int noteNumber) const;
+    static bool isBlackKey(int noteNumber);
     juce::Colour getClipColour() const;
     juce::Colour getColourForClip(ClipId clipId) const;
     bool isClipSelected(ClipId clipId) const;

--- a/magda/daw/ui/components/pianoroll/PianoRollKeyboard.cpp
+++ b/magda/daw/ui/components/pianoroll/PianoRollKeyboard.cpp
@@ -133,12 +133,12 @@ void PianoRollKeyboard::clearPressedNotes() {
         repaint();
 }
 
-bool PianoRollKeyboard::isBlackKey(int noteNumber) const {
+bool PianoRollKeyboard::isBlackKey(int noteNumber) {
     int note = noteNumber % 12;
     return note == 1 || note == 3 || note == 6 || note == 8 || note == 10;
 }
 
-juce::String PianoRollKeyboard::getNoteName(int noteNumber) const {
+juce::String PianoRollKeyboard::getNoteName(int noteNumber) {
     static const char* noteNames[] = {"C",  "C#", "D",  "D#", "E",  "F",
                                       "F#", "G",  "G#", "A",  "A#", "B"};
     int octave = (noteNumber / 12) - 2;  // C-2 convention (note 0 = C-2, note 60 = C3)

--- a/magda/daw/ui/components/pianoroll/PianoRollKeyboard.hpp
+++ b/magda/daw/ui/components/pianoroll/PianoRollKeyboard.hpp
@@ -84,8 +84,8 @@ class PianoRollKeyboard : public juce::Component {
     int currentPlayingNote_ = -1;
     bool isPlayingNote_ = false;
 
-    bool isBlackKey(int noteNumber) const;
-    juce::String getNoteName(int noteNumber) const;
+    static bool isBlackKey(int noteNumber);
+    static juce::String getNoteName(int noteNumber);
     int yToNoteNumber(int y) const;
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(PianoRollKeyboard)

--- a/magda/daw/ui/components/timeline/MarkerLaneComponent.cpp
+++ b/magda/daw/ui/components/timeline/MarkerLaneComponent.cpp
@@ -60,9 +60,10 @@ void MarkerLaneComponent::paint(juce::Graphics& g) {
         auto colour = marker.colour;
 
         juce::Path flag;
-        flag.addTriangle(static_cast<float>(x - kFlagWidth / 2), static_cast<float>(kLaneTopInset),
-                         static_cast<float>(x + kFlagWidth / 2), static_cast<float>(kLaneTopInset),
-                         static_cast<float>(x), static_cast<float>(kLaneTopInset + 12));
+        flag.addTriangle(
+            static_cast<float>(x) - kFlagWidth / 2.0f, static_cast<float>(kLaneTopInset),
+            static_cast<float>(x) + kFlagWidth / 2.0f, static_cast<float>(kLaneTopInset),
+            static_cast<float>(x), static_cast<float>(kLaneTopInset + 12));
         g.setColour(colour.withAlpha(selected || hovered ? 1.0f : 0.82f));
         g.fillPath(flag);
 

--- a/magda/daw/ui/components/timeline/TimeRuler.cpp
+++ b/magda/daw/ui/components/timeline/TimeRuler.cpp
@@ -191,7 +191,7 @@ void TimeRuler::timerCallback() {
     }
 }
 
-int TimeRuler::getPreferredHeight() const {
+int TimeRuler::getPreferredHeight() {
     return LayoutConfig::getInstance().timeRulerHeight;
 }
 
@@ -899,7 +899,7 @@ double TimeRuler::calculateMarkerInterval() const {
     return 600.0;  // 10 minutes
 }
 
-juce::String TimeRuler::formatTimeLabel(double time, double interval) const {
+juce::String TimeRuler::formatTimeLabel(double time, double interval) {
     int totalSeconds = static_cast<int>(time);
     int minutes = totalSeconds / 60;
     int seconds = totalSeconds % 60;

--- a/magda/daw/ui/components/timeline/TimeRuler.hpp
+++ b/magda/daw/ui/components/timeline/TimeRuler.hpp
@@ -117,7 +117,7 @@ class TimeRuler : public juce::Component, private juce::Timer {
     }
 
     // Get preferred height (from LayoutConfig)
-    int getPreferredHeight() const;
+    static int getPreferredHeight();
 
     // Mouse interaction - click to set playhead, drag to zoom, wheel to scroll
     void mouseDown(const juce::MouseEvent& event) override;
@@ -189,10 +189,10 @@ class TimeRuler : public juce::Component, private juce::Timer {
     static constexpr int LOOP_STRIP_HEIGHT = LayoutConfig::loopStripHeight;
 
     // Tick heights sourced from LayoutConfig for consistency with TimelineComponent
-    int tickHeightMajor() const {
+    static static static int tickHeightMajor() {
         return LayoutConfig::getInstance().rulerMajorTickHeight;
     }
-    int tickHeightMinor() const {
+    static static static int tickHeightMinor() {
         return LayoutConfig::getInstance().rulerMinorTickHeight;
     }
 
@@ -200,7 +200,7 @@ class TimeRuler : public juce::Component, private juce::Timer {
     void drawSecondsMode(juce::Graphics& g);
     void drawBarsBeatsMode(juce::Graphics& g);
     double calculateMarkerInterval() const;
-    juce::String formatTimeLabel(double time, double interval) const;
+    static juce::String formatTimeLabel(double time, double interval);
     juce::String formatBarsBeatsLabel(double time) const;
 
     // Coordinate conversion

--- a/magda/daw/ui/components/tracks/TrackContentPanel.cpp
+++ b/magda/daw/ui/components/tracks/TrackContentPanel.cpp
@@ -2197,6 +2197,8 @@ void TrackContentPanel::showEmptySpaceContextMenu(const juce::MouseEvent& event)
                 if (safeThis && safeThis->onPasteRippleRequested)
                     safeThis->onPasteRippleRequested();
                 break;
+            default:  // menu dismissed
+                break;
         }
     });
 }

--- a/magda/daw/ui/components/tracks/TrackContentPanel.cpp
+++ b/magda/daw/ui/components/tracks/TrackContentPanel.cpp
@@ -897,8 +897,10 @@ void TrackContentPanel::paintRecordingPreviews(juce::Graphics& g) {
                 double visibleEnd = juce::jmin(clipLengthInBeats, displayEnd);
                 double visibleLength = visibleEnd - visibleStart;
 
-                float noteY = noteArea.getY() + (MIDI_MAX - note.noteNumber) *
-                                                    noteArea.getHeight() / (MIDI_RANGE + 1);
+                float noteY =
+                    static_cast<float>(noteArea.getY()) +
+                    static_cast<float>((MIDI_MAX - note.noteNumber) * noteArea.getHeight()) /
+                        static_cast<float>(MIDI_RANGE + 1);
                 float noteHeight =
                     juce::jmax(1.5f, static_cast<float>(noteArea.getHeight()) / (MIDI_RANGE + 1));
                 float noteX = noteArea.getX() +

--- a/magda/daw/ui/components/tracks/TrackContentPanel.hpp
+++ b/magda/daw/ui/components/tracks/TrackContentPanel.hpp
@@ -153,8 +153,8 @@ class TrackContentPanel : public juce::Component,
     }
 
     // Automation lane management
-    void showAutomationLane(TrackId trackId, AutomationLaneId laneId);
-    void hideAutomationLane(TrackId trackId, AutomationLaneId laneId);
+    static void showAutomationLane(TrackId trackId, AutomationLaneId laneId);
+    static void hideAutomationLane(TrackId trackId, AutomationLaneId laneId);
     void toggleAutomationLane(TrackId trackId, AutomationLaneId laneId);
     bool isAutomationLaneVisible(TrackId trackId, AutomationLaneId laneId) const;
     bool getAutomationLaneBounds(AutomationLaneId laneId, juce::Rectangle<int>& bounds) const;

--- a/magda/daw/ui/components/tracks/TrackHeadersPanel.cpp
+++ b/magda/daw/ui/components/tracks/TrackHeadersPanel.cpp
@@ -2240,7 +2240,7 @@ void TrackHeadersPanel::hideControlAreaComponents(TrackHeader& header) {
         sendLabel->setVisible(false);
 }
 
-track_controls::MixControls TrackHeadersPanel::mixControlsFor(TrackHeader& header) const {
+track_controls::MixControls TrackHeadersPanel::mixControlsFor(TrackHeader& header) {
     const auto& p = header.policy;
     track_controls::MixControls c;
     if (p.gain)

--- a/magda/daw/ui/components/tracks/TrackHeadersPanel.cpp
+++ b/magda/daw/ui/components/tracks/TrackHeadersPanel.cpp
@@ -1715,7 +1715,7 @@ void TrackHeadersPanel::setupTrackHeaderWithId(TrackHeader& header, int trackId)
 
     // Right-click the volume / pan readouts to show (or create) their
     // automation lane, mirroring the send-label menu in the inspector.
-    auto showAutomationLaneMenu = [](AutomationTarget target) {
+    auto showAutomationLaneMenu = [](const AutomationTarget& target) {
         auto& autoMgr = AutomationManager::getInstance();
         const bool hasLane = autoMgr.getLaneForTarget(target) != magda::INVALID_AUTOMATION_LANE_ID;
         juce::PopupMenu menu;

--- a/magda/daw/ui/components/tracks/TrackHeadersPanel.cpp
+++ b/magda/daw/ui/components/tracks/TrackHeadersPanel.cpp
@@ -3790,7 +3790,7 @@ void TrackHeadersPanel::itemDropped(const SourceDetails& details) {
 bool TrackHeadersPanel::isIORoutingVisible() const {
     if (trackHeaders.empty())
         return showIORouting_;
-    for (auto& h : trackHeaders) {
+    for (const auto& h : trackHeaders) {
         if (h->showIORouting)
             return true;
     }

--- a/magda/daw/ui/components/tracks/TrackHeadersPanel.hpp
+++ b/magda/daw/ui/components/tracks/TrackHeadersPanel.hpp
@@ -331,27 +331,27 @@ class TrackHeadersPanel : public juce::Component,
     void rebuildSendLabels(TrackHeader& header, TrackId trackId);
     void paintTrackHeader(juce::Graphics& g, const TrackHeader& header, juce::Rectangle<int> area,
                           bool isSelected);
-    void paintResizeHandle(juce::Graphics& g, juce::Rectangle<int> area);
-    void updateCollapseButtonIcon(TrackHeader& header);
+    static void paintResizeHandle(juce::Graphics& g, juce::Rectangle<int> area);
+    static void updateCollapseButtonIcon(TrackHeader& header);
     int getVisibleHeaderIndex(TrackId trackId) const;
     juce::Rectangle<int> getTrackHeaderArea(int trackIndex) const;
     juce::Rectangle<int> getResizeHandleArea(int trackIndex) const;
     bool isResizeHandleArea(const juce::Point<int>& point, int& trackIndex) const;
     void updateTrackHeaderLayout();
-    void layoutMeterColumn(TrackHeader& header, juce::Rectangle<int>& workArea,
-                           const SideColumn& outer);
+    static void layoutMeterColumn(TrackHeader& header, juce::Rectangle<int>& workArea,
+                                  const SideColumn& outer);
     void layoutControlArea(TrackHeader& header, juce::Rectangle<int>& tcpArea,
                            const SideColumn& inner, int trackHeight);
     // Master-only compact block: volume + speaker mute, horizontal meter with
     // the back-to-arrangement button, peak readout.
-    void layoutMasterControlArea(TrackHeader& header, juce::Rectangle<int>& tcpArea,
-                                 const SideColumn& inner);
+    static void layoutMasterControlArea(TrackHeader& header, juce::Rectangle<int>& tcpArea,
+                                        const SideColumn& inner);
     // Hides every control the control-area layout may place, so each layout
     // pass starts from a clean slate and only shows what fits.
-    void hideControlAreaComponents(TrackHeader& header);
+    static void hideControlAreaComponents(TrackHeader& header);
     // Builds the policy-driven mix cluster (gain/pan/buttons/automation) for
     // the shared track_controls layout.
-    track_controls::MixControls mixControlsFor(TrackHeader& header) const;
+    static track_controls::MixControls mixControlsFor(TrackHeader& header);
 
     // Automation lane height helpers
     int getTrackTotalHeight(int trackIndex) const;

--- a/magda/daw/ui/components/waveform/ClipWaveformPainter.cpp
+++ b/magda/daw/ui/components/waveform/ClipWaveformPainter.cpp
@@ -117,11 +117,11 @@ void paintClipWaveform(juce::Graphics& g, const ClipInfo& clip, ClipId clipId,
         }
 
         daw::ui::WarpedWaveformSpec wspec;
-        wspec.clipArea = juce::Rectangle<int>(
-            waveformArea.getX(), waveformArea.getY(),
-            juce::jmin(waveformArea.getWidth(),
-                       static_cast<int>(clipDisplayLength * pixelsPerSecond + 0.5)),
-            waveformArea.getHeight());
+        wspec.clipArea =
+            juce::Rectangle<int>(waveformArea.getX(), waveformArea.getY(),
+                                 juce::jmin(waveformArea.getWidth(),
+                                            juce::roundToInt(clipDisplayLength * pixelsPerSecond)),
+                                 waveformArea.getHeight());
         wspec.warpToPixelX = [&](double warpSeconds) {
             return waveformArea.getX() +
                    di.sourceToTimeline(warpSeconds - displayOffset) * pixelsPerSecond;
@@ -219,9 +219,9 @@ void paintClipWaveform(juce::Graphics& g, const ClipInfo& clip, ClipId clipId,
                 double segmentDuration = juce::jmin(remainingTileDuration, fullSegmentDuration);
                 double segmentEnd = segmentTime + segmentDuration;
                 int segmentX =
-                    waveformArea.getX() + static_cast<int>(segmentTime * pixelsPerSecond + 0.5);
+                    waveformArea.getX() + juce::roundToInt(segmentTime * pixelsPerSecond);
                 int segmentRight =
-                    waveformArea.getX() + static_cast<int>(segmentEnd * pixelsPerSecond + 0.5);
+                    waveformArea.getX() + juce::roundToInt(segmentEnd * pixelsPerSecond);
                 auto segmentRect =
                     juce::Rectangle<int>(segmentX, waveformArea.getY(), segmentRight - segmentX,
                                          waveformArea.getHeight());
@@ -249,7 +249,7 @@ void paintClipWaveform(juce::Graphics& g, const ClipInfo& clip, ClipId clipId,
         if (fileDuration > 0.0 && fileEnd > fileDuration)
             fileEnd = fileDuration;
         double clampedTimelineDuration = di.sourceToTimeline(fileEnd - fileStart);
-        int drawWidth = static_cast<int>(clampedTimelineDuration * pixelsPerSecond + 0.5);
+        int drawWidth = juce::roundToInt(clampedTimelineDuration * pixelsPerSecond);
         drawWidth = juce::jmin(drawWidth, waveformArea.getWidth());
         auto drawRect = juce::Rectangle<int>(waveformArea.getX(), waveformArea.getY(), drawWidth,
                                              waveformArea.getHeight());

--- a/magda/daw/ui/components/waveform/WaveformGridComponent.cpp
+++ b/magda/daw/ui/components/waveform/WaveformGridComponent.cpp
@@ -365,7 +365,7 @@ void WaveformGridComponent::paintWaveformThumbnail(juce::Graphics& g, const magd
     }
 }
 
-int WaveformGridComponent::takeLaneAtY(int y, const WaveformLayout& layout, int takeCount) const {
+int WaveformGridComponent::takeLaneAtY(int y, const WaveformLayout& layout, int takeCount) {
     if (takeCount <= 0)
         return -1;
     const auto& rect = layout.rect;
@@ -1156,7 +1156,7 @@ double WaveformGridComponent::getDrawableTimelineLength() const {
     return clipLength_;
 }
 
-void WaveformGridComponent::debugLogGeometry(const char* context) const {
+void WaveformGridComponent::debugLogGeometry(const char* context) {
     juce::ignoreUnused(context);
 }
 

--- a/magda/daw/ui/components/waveform/WaveformGridComponent.cpp
+++ b/magda/daw/ui/components/waveform/WaveformGridComponent.cpp
@@ -1252,8 +1252,9 @@ void WaveformGridComponent::mouseDown(const juce::MouseEvent& event) {
             if (warpMarkers_.size() >= 2) {
                 // Sort markers by warpTime to find the segment containing our click
                 std::vector<std::pair<double, double>> sorted;  // (warpTime, sourceTime)
+                sorted.reserve(warpMarkers_.size());
                 for (const auto& m : warpMarkers_) {
-                    sorted.push_back({m.warpTime, m.sourceTime});
+                    sorted.emplace_back(m.warpTime, m.sourceTime);
                 }
                 std::sort(sorted.begin(), sorted.end());
 

--- a/magda/daw/ui/components/waveform/WaveformGridComponent.hpp
+++ b/magda/daw/ui/components/waveform/WaveformGridComponent.hpp
@@ -320,7 +320,7 @@ class WaveformGridComponent : public juce::Component, public juce::ChangeListene
     void paintTakeLanes(juce::Graphics& g, const magda::ClipInfo& clip,
                         const WaveformLayout& layout);
     // Returns the take lane index under y (multi-take clip), or -1.
-    int takeLaneAtY(int y, const WaveformLayout& layout, int takeCount) const;
+    static int takeLaneAtY(int y, const WaveformLayout& layout, int takeCount);
     void paintWaveformOverlays(juce::Graphics& g, const magda::ClipInfo& clip,
                                const WaveformLayout& layout);
     void paintBeatGrid(juce::Graphics& g, const magda::ClipInfo& clip);
@@ -348,7 +348,7 @@ class WaveformGridComponent : public juce::Component, public juce::ChangeListene
     double getSampleStartPositionSeconds() const;
     double getDisplayStartTime() const;
     double getDrawableTimelineLength() const;
-    void debugLogGeometry(const char* context) const;
+    static void debugLogGeometry(const char* context);
 
     // Get current clip
     const magda::ClipInfo* getClip() const;

--- a/magda/daw/ui/debug/DebugSettings.hpp
+++ b/magda/daw/ui/debug/DebugSettings.hpp
@@ -62,7 +62,7 @@ class DebugSettings {
 
     // Listener for settings changes
     using Listener = std::function<void()>;
-    void addListener(Listener listener) {
+    void addListener(const Listener& listener) {
         listeners_.push_back(listener);
     }
 

--- a/magda/daw/ui/dialogs/AISettingsDialog.cpp
+++ b/magda/daw/ui/dialogs/AISettingsDialog.cpp
@@ -434,7 +434,7 @@ class AISettingsDialog::CloudPage : public juce::Component {
     }
 
     void addListEntry(const std::string& providerId) {
-        auto* info = findProviderInfo(providerId);
+        const auto* info = findProviderInfo(providerId);
         if (!info)
             return;
 
@@ -509,7 +509,7 @@ class AISettingsDialog::CloudPage : public juce::Component {
             return;
         }
 
-        auto* info = findProviderInfo(providerId);
+        const auto* info = findProviderInfo(providerId);
         if (!info)
             return;
 
@@ -1142,7 +1142,7 @@ class AISettingsDialog::ConfigPage : public juce::Component {
         int nextId = 1;
         if (cloudPage) {
             for (const auto& pid : cloudPage->getConfiguredProviders()) {
-                auto* info = findProviderInfo(pid);
+                const auto* info = findProviderInfo(pid);
                 if (info)
                     providerCombo_.addItem(info->displayName, nextId++);
             }
@@ -1168,7 +1168,7 @@ class AISettingsDialog::ConfigPage : public juce::Component {
         std::vector<std::pair<std::string, juce::String>> opts;
         if (cloudPage) {
             for (const auto& pid : cloudPage->getConfiguredProviders())
-                if (auto* info = findProviderInfo(pid))
+                if (const auto* info = findProviderInfo(pid))
                     opts.emplace_back(pid, juce::String(info->displayName));
         }
         opts.emplace_back(magda::provider::LLAMA_LOCAL, juce::String("Local"));
@@ -1558,13 +1558,13 @@ class AISettingsDialog::ConfigPage : public juce::Component {
             // Local: embedded GGUF or OpenAI-compatible server.
             outPresetId = (localSourceCombo_.getSelectedId() == 2) ? magda::preset::LOCAL_SERVER
                                                                    : magda::preset::LOCAL_EMBEDDED;
-            if (auto* preset = magda::findPreset(outPresetId))
+            if (const auto* preset = magda::findPreset(outPresetId))
                 for (const auto& [role, cfg] : preset->agents)
                     out[role] = cfg;
         } else if (mode == 2) {
             // Cloud
             outPresetId = presetId;
-            if (auto* preset = magda::findPreset(presetId)) {
+            if (const auto* preset = magda::findPreset(presetId)) {
                 for (const auto& [role, presetCfg] : preset->agents) {
                     auto cfg = presetCfg;
                     cfg.apiKey = "";
@@ -1672,7 +1672,7 @@ class AISettingsDialog::ConfigPage : public juce::Component {
 
     static Config::AgentLLMConfig makeCloudConfig(const std::string& role,
                                                   const std::string& presetId) {
-        if (auto* preset = magda::findPreset(presetId)) {
+        if (const auto* preset = magda::findPreset(presetId)) {
             auto it = preset->agents.find(role);
             if (it != preset->agents.end()) {
                 auto cfg = it->second;

--- a/magda/daw/ui/dialogs/AISettingsDialog.cpp
+++ b/magda/daw/ui/dialogs/AISettingsDialog.cpp
@@ -471,7 +471,7 @@ class AISettingsDialog::CloudPage : public juce::Component {
         // Remove button
         auto removeBtn =
             std::make_unique<juce::TextButton>(juce::String::charToString(0x2715));  // ✕
-        auto pid = providerId;
+        const auto& pid = providerId;
         removeBtn->onClick = [this, pid]() { removeProvider(pid); };
         listContainer_.addAndMakeVisible(*removeBtn);
         entry.removeBtn = removeBtn.get();

--- a/magda/daw/ui/dialogs/AISettingsDialog.cpp
+++ b/magda/daw/ui/dialogs/AISettingsDialog.cpp
@@ -704,7 +704,7 @@ class AISettingsDialog::LocalPage : public juce::Component {
         config.setLoadModelOnStartup(loadOnStartupToggle_.getToggleState());
     }
 
-    bool isModelLoaded() const {
+    static bool isModelLoaded() {
         return LlamaModelManager::getInstance().isLoaded();
     }
 
@@ -1180,7 +1180,7 @@ class AISettingsDialog::ConfigPage : public juce::Component {
                id == magda::provider::FAST_INFERENCE;
     }
 
-    std::string rowProviderGroupId(const AgentRow& row) const {
+    static std::string rowProviderGroupId(const AgentRow& row) {
         int idx = row.providerCombo.getSelectedId() - 1;
         if (idx >= 0 && idx < static_cast<int>(row.providerIds.size()))
             return row.providerIds[static_cast<size_t>(idx)];
@@ -1202,7 +1202,7 @@ class AISettingsDialog::ConfigPage : public juce::Component {
     // Select the combo item matching a provider id. openai_responses and
     // openai_chat share one "OpenAI" entry, and all local backends share one
     // "Local" entry.
-    void selectRowProviderById(AgentRow& row, std::string id) {
+    static void selectRowProviderById(AgentRow& row, std::string id) {
         if (id == magda::provider::OPENAI_RESPONSES)
             id = magda::provider::OPENAI_CHAT;
         if (isLocalProviderId(id))

--- a/magda/daw/ui/dialogs/AudioSettingsDialog.cpp
+++ b/magda/daw/ui/dialogs/AudioSettingsDialog.cpp
@@ -13,7 +13,7 @@ namespace {
 
 bool comboItemsMatchDriverTypes(const juce::ComboBox& comboBox,
                                 juce::AudioDeviceManager& deviceManager) {
-    auto& deviceTypes = deviceManager.getAvailableDeviceTypes();
+    const auto& deviceTypes = deviceManager.getAvailableDeviceTypes();
     if (comboBox.getNumItems() != deviceTypes.size())
         return false;
 

--- a/magda/daw/ui/dialogs/AudioSettingsDialog.hpp
+++ b/magda/daw/ui/dialogs/AudioSettingsDialog.hpp
@@ -30,7 +30,7 @@ class CustomChannelSelector : public juce::Component {
     AudioEngine* audioEngine_;
     bool isInput_;
 
-    void onPreviewToggled(int startChannel);
+    static void onPreviewToggled(int startChannel);
 
     struct ChannelToggle {
         std::unique_ptr<juce::ToggleButton> button;

--- a/magda/daw/ui/dialogs/ChainTreeDialog.cpp
+++ b/magda/daw/ui/dialogs/ChainTreeDialog.cpp
@@ -1,5 +1,7 @@
 #include "ChainTreeDialog.hpp"
 
+#include <utility>
+
 #include "../themes/DarkTheme.hpp"
 #include "../themes/FontManager.hpp"
 #include "core/SelectionManager.hpp"
@@ -16,9 +18,8 @@ namespace magda {
  */
 class ChainTreeItemBase : public juce::TreeViewItem {
   public:
-    explicit ChainTreeItemBase(const juce::String& text, const juce::String& icon = "",
-                               const ChainNodePath& path = {})
-        : text_(text), icon_(icon), path_(path) {}
+    explicit ChainTreeItemBase(juce::String text, juce::String icon = "", ChainNodePath path = {})
+        : text_(std::move(text)), icon_(std::move(icon)), path_(std::move(path)) {}
 
     bool mightContainSubItems() override {
         return false;  // Override in containers

--- a/magda/daw/ui/dialogs/ConnectionsDialog.cpp
+++ b/magda/daw/ui/dialogs/ConnectionsDialog.cpp
@@ -1154,7 +1154,7 @@ class OscSurfacesPage : public juce::Component, private juce::Timer {
         addAndMakeVisible(label);
     }
 
-    void layoutRow(juce::Rectangle<int>& area, juce::Label& label, juce::Component& field) {
+    static void layoutRow(juce::Rectangle<int>& area, juce::Label& label, juce::Component& field) {
         auto row = area.removeFromTop(kRowHeight);
         label.setBounds(row.removeFromLeft(kLabelWidth));
         field.setBounds(row.removeFromLeft(kFieldWidth));

--- a/magda/daw/ui/dialogs/ControllersDialog.cpp
+++ b/magda/daw/ui/dialogs/ControllersDialog.cpp
@@ -783,7 +783,7 @@ class LuaScriptsPage : public juce::Component {
             menu.addItem(static_cast<int>(i + 1), available[i].getFileName());
 
         juce::Component::SafePointer<LuaScriptsPage> self(this);
-        const auto availableCopy = available;
+        const auto& availableCopy = available;
         menu.showMenuAsync(juce::PopupMenu::Options().withTargetComponent(&addScriptButton_),
                            [self, availableCopy](int result) {
                                if (result <= 0)

--- a/magda/daw/ui/dialogs/ParameterConfigDialog.cpp
+++ b/magda/daw/ui/dialogs/ParameterConfigDialog.cpp
@@ -2,6 +2,8 @@
 
 #include <juce_audio_processors/juce_audio_processors.h>
 
+#include <utility>
+
 #include "../themes/DarkTheme.hpp"
 #include "../themes/DialogLookAndFeel.hpp"
 #include "../themes/FontManager.hpp"
@@ -390,8 +392,8 @@ ParameterConfigDialog::~ParameterConfigDialog() {
     setLookAndFeel(nullptr);
 }
 
-ParameterConfigDialog::ParameterConfigDialog(const juce::String& pluginName)
-    : pluginName_(pluginName) {
+ParameterConfigDialog::ParameterConfigDialog(juce::String pluginName)
+    : pluginName_(std::move(pluginName)) {
     // Use the shared dialog look-and-feel so every button / combo /
     // text editor in the dialog picks up the theme font (Inter) instead
     // of JUCE's platform default. Children inherit unless they set their
@@ -1183,7 +1185,7 @@ void ParameterConfigDialog::runDetection() {
                     safeThis->aiResolved_ = resolved;
                 },
                 // onComplete
-                [safeThis](std::vector<magda::DetectedParameterInfo> aiResults) {
+                [safeThis](const std::vector<magda::DetectedParameterInfo>& aiResults) {
                     if (!safeThis)
                         return;
                     safeThis->applyDetectionResults(aiResults);

--- a/magda/daw/ui/dialogs/ParameterConfigDialog.hpp
+++ b/magda/daw/ui/dialogs/ParameterConfigDialog.hpp
@@ -49,7 +49,7 @@ class ParameterConfigDialog : public juce::Component,
                               public juce::TableListBoxModel,
                               private juce::Timer {
   public:
-    ParameterConfigDialog(const juce::String& pluginName);
+    ParameterConfigDialog(juce::String pluginName);
     ~ParameterConfigDialog() override;
 
     void paint(juce::Graphics& g) override;

--- a/magda/daw/ui/dialogs/PluginSettingsDialog.cpp
+++ b/magda/daw/ui/dialogs/PluginSettingsDialog.cpp
@@ -80,6 +80,8 @@ void PluginSettingsDialog::ExcludedTableModel::paintCell(juce::Graphics& g, int 
         case 3:
             text = entry.timestamp;
             break;
+        default:  // dismissed, or a column with no text
+            break;
     }
 
     g.drawText(text, 4, 0, width - 8, height, juce::Justification::centredLeft);

--- a/magda/daw/ui/dialogs/PreferencesDialog.cpp
+++ b/magda/daw/ui/dialogs/PreferencesDialog.cpp
@@ -161,7 +161,7 @@ juce::Rectangle<int> getPreferencesDialogContentSize() {
     constexpr int minW = 520;
     constexpr int minH = 380;
 
-    if (auto* display = juce::Desktop::getInstance().getDisplays().getPrimaryDisplay()) {
+    if (const auto* display = juce::Desktop::getInstance().getDisplays().getPrimaryDisplay()) {
         const int maxW = display->userArea.getWidth() - 48;
         const int maxH = display->userArea.getHeight() - 96;
         return {juce::jmax(minW, juce::jmin(preferredW, maxW)),

--- a/magda/daw/ui/dialogs/PreferencesDialog.cpp
+++ b/magda/daw/ui/dialogs/PreferencesDialog.cpp
@@ -272,7 +272,7 @@ class GeneralPage : public juce::Component {
         };
     }
 
-    int getPreferredHeight(int width) const {
+    static int getPreferredHeight(int width) {
         const int height =
             shouldUseSingleColumnLayout(width)
                 ? getSingleColumnPreferredHeight()
@@ -765,7 +765,7 @@ class AppearancePage : public juce::Component {
         addAndMakeVisible(clipColourModeCombo);
     }
 
-    int getPreferredHeight(int width) const {
+    static int getPreferredHeight(int width) {
         constexpr int padding = 16;
         if (shouldUseSingleColumnLayout(width))
             return getSingleColumnPreferredHeight();
@@ -1600,7 +1600,7 @@ class RenderingPage : public juce::Component {
         addAndMakeVisible(patternHint);
     }
 
-    int getPreferredHeight(int) const {
+    static int getPreferredHeight(int) {
         constexpr int padding = 16;
         constexpr int rowH = 32;
         constexpr int headerH = 28;
@@ -1874,7 +1874,7 @@ class PathsPage : public juce::Component {
         addAndMakeVisible(indexPresetsButton_);
     }
 
-    int getPreferredHeight(int) const {
+    static int getPreferredHeight(int) {
         constexpr int padding = 20;
         constexpr int rowH = 28;
         constexpr int gap = 6;
@@ -3006,7 +3006,7 @@ class ShortcutsPage : public juce::Component {
             setCapturingRow(nullptr);
         }
 
-        void setRowInput(GestureRow& row, GestureInput input) {
+        static void setRowInput(GestureRow& row, GestureInput input) {
             const auto tuned =
                 tunedBindingForInput(row.context, input, row.action,
                                      {row.action, static_cast<float>(row.sensitivity.getValue()),
@@ -3019,7 +3019,7 @@ class ShortcutsPage : public juce::Component {
             row.learnButton.setButtonText(learnButtonText());
         }
 
-        GestureArea learnedDragAreaFor(const GestureRow& row) const {
+        static GestureArea learnedDragAreaFor(const GestureRow& row) {
             if (row.currentInput.area != GestureArea::Main)
                 return row.currentInput.area;
             if (row.input.area != GestureArea::Main)

--- a/magda/daw/ui/dialogs/PreferencesDialog.cpp
+++ b/magda/daw/ui/dialogs/PreferencesDialog.cpp
@@ -343,7 +343,7 @@ class GeneralPage : public juce::Component {
         }
 
         if (availableLanguages_.empty())
-            availableLanguages_.push_back("en");
+            availableLanguages_.emplace_back("en");
 
         auto currentLang = juce::String(config.getLanguage());
         initialLanguage_ = currentLang;
@@ -1215,7 +1215,7 @@ class AppearancePage : public juce::Component {
         swatch->setPaintingIsUnclipped(true);
         addAndMakeVisible(*swatch);
         colourSwatches_.push_back(std::move(swatch));
-        swatchColours_.push_back(juce::Colour(colour));
+        swatchColours_.emplace_back(colour);
 
         // Hex editor (RGB only, no alpha — we force 0xFF)
         auto hex = std::make_unique<juce::TextEditor>();
@@ -2089,7 +2089,7 @@ class PathsPage : public juce::Component {
             (kind == Kind::Data) ? magda::paths::alwaysOSDefault() : presetsDefaultDir();
         juce::String oldPath =
             original.empty() ? defaultDir.getFullPathName() : juce::String(original);
-        juce::String newPath = picked.getFullPathName();
+        const juce::String& newPath = picked.getFullPathName();
 
         const juce::String titleKey = (kind == Kind::Data)
                                           ? "preferences.paths.migration.data_title"
@@ -3285,7 +3285,7 @@ void scaleExplicitFonts(juce::Component& component, double ratio) {
     if (magda::resolvesOwnFonts(component))
         return;
 
-    const auto scaleFont = [ratio](juce::Font font) {
+    const auto scaleFont = [ratio](const juce::Font& font) {
         return font.withHeight(font.getHeight() * static_cast<float>(ratio));
     };
 

--- a/magda/daw/ui/dialogs/TrackManagerDialog.cpp
+++ b/magda/daw/ui/dialogs/TrackManagerDialog.cpp
@@ -143,7 +143,7 @@ class TrackManagerDialog::ContentComponent : public juce::Component,
         }
     }
 
-    void drawCheckbox(juce::Graphics& g, int width, int height, bool isChecked) {
+    static void drawCheckbox(juce::Graphics& g, int width, int height, bool isChecked) {
         auto checkBounds = juce::Rectangle<int>((width - 16) / 2, (height - 16) / 2, 16, 16);
 
         // Checkbox border

--- a/magda/daw/ui/panels/BottomPanel.hpp
+++ b/magda/daw/ui/panels/BottomPanel.hpp
@@ -55,7 +55,7 @@ class BottomPanel : public daw::ui::TabbedPanel,
     void lookAndFeelChanged() override;
 
     // Legacy API for compatibility
-    void setCollapsed(bool collapsed);
+    static void setCollapsed(bool collapsed);
 
     // Get the current content type being displayed
     daw::ui::PanelContentType getActiveContentType() const;
@@ -152,7 +152,7 @@ class BottomPanel : public daw::ui::TabbedPanel,
     ClipId lastEditorClipId_ = INVALID_CLIP_ID;  // Track which clip we auto-defaulted for
 
     void onEditorTabChanged(int tabIndex);
-    void showDrumGridTabContextMenu(juce::Point<int> screenPos);
+    static void showDrumGridTabContextMenu(juce::Point<int> screenPos);
 
     // Mouse listener attached to drumGridTab_ to forward right-clicks to the
     // context-menu handler. SvgButton's onClick is left-click only.

--- a/magda/daw/ui/panels/LeftPanel.hpp
+++ b/magda/daw/ui/panels/LeftPanel.hpp
@@ -17,7 +17,7 @@ class LeftPanel : public daw::ui::TabbedPanel {
     ~LeftPanel() override = default;
 
     // Legacy API for compatibility
-    void setCollapsed(bool collapsed);
+    static void setCollapsed(bool collapsed);
 
   private:
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(LeftPanel)

--- a/magda/daw/ui/panels/RightPanel.hpp
+++ b/magda/daw/ui/panels/RightPanel.hpp
@@ -17,7 +17,7 @@ class RightPanel : public daw::ui::TabbedPanel {
     ~RightPanel() override = default;
 
     // Legacy API for compatibility
-    void setCollapsed(bool collapsed);
+    static void setCollapsed(bool collapsed);
 
   private:
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(RightPanel)

--- a/magda/daw/ui/panels/TransportPanel.hpp
+++ b/magda/daw/ui/panels/TransportPanel.hpp
@@ -207,8 +207,8 @@ class TransportPanel : public juce::Component, public MixAnalysisService::Listen
     daw::ui::transport::Layout layout_;
 
     // Button styling
-    void styleTransportButton(SvgButton& button, ColourRole accentRole,
-                              bool activeGlyphUsesAccent = false);
+    static void styleTransportButton(SvgButton& button, ColourRole accentRole,
+                                     bool activeGlyphUsesAccent = false);
     void setupTransportButtons();
     void setupTimeDisplayBoxes();
     void setupTempoAndQuantize();

--- a/magda/daw/ui/panels/content/AIChatConsoleContent.cpp
+++ b/magda/daw/ui/panels/content/AIChatConsoleContent.cpp
@@ -496,7 +496,7 @@ class AIChatConsoleContent::MidiContextPopup : public juce::Component, private j
 
         const int indent = row.kind == Row::Kind::Clip ? 24 : 8;
         auto tick = juce::Rectangle<float>(static_cast<float>(indent),
-                                           static_cast<float>((height - 13) / 2), 13.0f, 13.0f);
+                                           static_cast<float>(height - 13) / 2.0f, 13.0f, 13.0f);
         g.setColour(DarkTheme::getBorderColour());
         g.drawRoundedRectangle(tick, 2.0f, 1.0f);
         if (checked || partial) {
@@ -829,6 +829,10 @@ void AIChatConsoleContent::RequestThread::run() {
             // even while the thread is occupied (a spinner couldn't animate).
             juce::MouseCursor::showWaitCursor();
 
+            // Read before the move below; the caveat check further down used to
+            // test `error` after it had been moved into `output`.
+            const bool hadError = !error.empty();
+
             magda::agent::ConsoleRunOutput output{
                 .dslCode = std::move(dsl),
                 .musicInstructions = std::move(musicIR),
@@ -888,7 +892,7 @@ void AIChatConsoleContent::RequestThread::run() {
             // Append the mixing-agent caveat in a dim secondary colour after the
             // main response. Inserted after setText so it does not enter the plain
             // text that gets stored in conversation history (display-only).
-            if (!mixAnalysis.empty() && error.empty()) {
+            if (!mixAnalysis.empty() && !hadError) {
                 safeThis->chatHistory_.moveCaretToEnd();
                 safeThis->chatHistory_.setColour(
                     juce::TextEditor::textColourId,

--- a/magda/daw/ui/panels/content/AIChatConsoleContent.cpp
+++ b/magda/daw/ui/panels/content/AIChatConsoleContent.cpp
@@ -2429,7 +2429,7 @@ void AIChatConsoleContent::updateConfigStatus() {
     resized();
 }
 
-bool AIChatConsoleContent::isLocalPreset() const {
+bool AIChatConsoleContent::isLocalPreset() {
     auto& config = magda::Config::getInstance();
     auto preset = config.getAIPreset();
     auto commandCfg = config.getAgentLLMConfig(magda::role::COMMAND);
@@ -2529,7 +2529,7 @@ void AIChatConsoleContent::hideAutocomplete() {
 }
 
 std::vector<AIChatConsoleContent::ParamAliasEntry> AIChatConsoleContent::collectParamAliases(
-    const juce::String& pluginAlias) const {
+    const juce::String& pluginAlias) {
     std::vector<ParamAliasEntry> out;
     if (pluginAlias.isEmpty())
         return out;

--- a/magda/daw/ui/panels/content/AIChatConsoleContent.cpp
+++ b/magda/daw/ui/panels/content/AIChatConsoleContent.cpp
@@ -2693,19 +2693,19 @@ bool AIChatConsoleContent::keyPressed(const juce::KeyPress& key, juce::Component
         if (popupVisible) {
             switch (autocompletePopup_->getMode()) {
                 case AutocompletePopup::Mode::SlashCommand:
-                    if (auto* cmd = autocompletePopup_->getSelectedCommand()) {
+                    if (const auto* cmd = autocompletePopup_->getSelectedCommand()) {
                         insertSlashCommand(cmd->name);
                         return true;
                     }
                     break;
                 case AutocompletePopup::Mode::Param:
-                    if (auto* entry = autocompletePopup_->getSelectedParamEntry()) {
+                    if (const auto* entry = autocompletePopup_->getSelectedParamEntry()) {
                         insertParamAlias(entry->pluginAlias, entry->paramAlias);
                         return true;
                     }
                     break;
                 case AutocompletePopup::Mode::Alias:
-                    if (auto* entry = autocompletePopup_->getSelectedEntry()) {
+                    if (const auto* entry = autocompletePopup_->getSelectedEntry()) {
                         insertAlias(entry->alias);
                         return true;
                     }
@@ -2732,19 +2732,19 @@ bool AIChatConsoleContent::keyPressed(const juce::KeyPress& key, juce::Component
     if (key == juce::KeyPress::tabKey) {
         switch (autocompletePopup_->getMode()) {
             case AutocompletePopup::Mode::SlashCommand:
-                if (auto* cmd = autocompletePopup_->getSelectedCommand()) {
+                if (const auto* cmd = autocompletePopup_->getSelectedCommand()) {
                     insertSlashCommand(cmd->name);
                     return true;
                 }
                 break;
             case AutocompletePopup::Mode::Param:
-                if (auto* entry = autocompletePopup_->getSelectedParamEntry()) {
+                if (const auto* entry = autocompletePopup_->getSelectedParamEntry()) {
                     insertParamAlias(entry->pluginAlias, entry->paramAlias);
                     return true;
                 }
                 break;
             case AutocompletePopup::Mode::Alias:
-                if (auto* entry = autocompletePopup_->getSelectedEntry()) {
+                if (const auto* entry = autocompletePopup_->getSelectedEntry()) {
                     insertAlias(entry->alias);
                     return true;
                 }

--- a/magda/daw/ui/panels/content/AIChatConsoleContent.cpp
+++ b/magda/daw/ui/panels/content/AIChatConsoleContent.cpp
@@ -834,12 +834,12 @@ void AIChatConsoleContent::RequestThread::run() {
             const bool hadError = !error.empty();
 
             magda::agent::ConsoleRunOutput output{
-                .dslCode = std::move(dsl),
-                .musicInstructions = std::move(musicIR),
-                .musicDescription = std::move(musicDesc),
-                .automationInstructions = std::move(autoIR),
+                .dslCode = dsl,
+                .musicInstructions = musicIR,
+                .musicDescription = musicDesc,
+                .automationInstructions = autoIR,
                 .prose = mixAnalysis,
-                .error = std::move(error),
+                .error = error,
             };
             magda::agent::ConsoleAgentResultExecutor executor(*safeThis->magdaApi_);
             auto execution = executor.execute(std::move(output), reviseTargetClipId);
@@ -3260,9 +3260,9 @@ void AIChatConsoleContent::finishControllerGeneration(bool success, const juce::
         menu.addSeparator();
         menu.addItem(9999, "Cancel");
 
-        auto rawJson = errorOrJson;  // contains the JSON when success == true
-        auto baseId = profileId;
-        auto displayName = profileName;
+        const auto& rawJson = errorOrJson;  // contains the JSON when success == true
+        const auto& baseId = profileId;
+        const auto& displayName = profileName;
 
         menu.showMenuAsync(juce::PopupMenu::Options().withTargetComponent(inputBox_.get()),
                            [safeThis, writeAndPromptPort, rawJson, baseId, displayName](int r) {

--- a/magda/daw/ui/panels/content/AIChatConsoleContent.hpp
+++ b/magda/daw/ui/panels/content/AIChatConsoleContent.hpp
@@ -126,8 +126,8 @@ class AIChatConsoleContent : public PanelContent,
     void sendMessage(const juce::String& text);
     void cancelRequest();
     void restoreSendIcon();
-    void setThemedButtonIcon(juce::DrawableButton& button, const void* svgData,
-                             std::size_t svgDataSize);
+    static void setThemedButtonIcon(juce::DrawableButton& button, const void* svgData,
+                                    std::size_t svgDataSize);
     void appendToChat(const juce::String& text);
     void updateContextBar();
     void showMidiContextPicker();
@@ -308,7 +308,7 @@ class AIChatConsoleContent : public PanelContent,
     juce::Label configStatusLabel_;
     std::unique_ptr<magda::SvgButton> serverToggleButton_;
     void updateConfigStatus();
-    bool isLocalPreset() const;
+    static bool isLocalPreset();
 
     // Plugin alias autocomplete
     struct AliasEntry {
@@ -339,9 +339,9 @@ class AIChatConsoleContent : public PanelContent,
     std::vector<AliasEntry> allAliases_;
 
     void buildAliasList();
-    std::vector<ParamAliasEntry> collectParamAliases(const juce::String& pluginAlias) const;
+    static std::vector<ParamAliasEntry> collectParamAliases(const juce::String& pluginAlias);
     juce::String resolveAliases(const juce::String& text);
-    juce::String rewriteSlashCommand(const juce::String& text);
+    static juce::String rewriteSlashCommand(const juce::String& text);
 
     // Slash commands live in their own module (SlashCommands.{hpp,cpp})
     // so they can be tested without standing up the full chat panel. The

--- a/magda/daw/ui/panels/content/AutomationClipEditorContent.cpp
+++ b/magda/daw/ui/panels/content/AutomationClipEditorContent.cpp
@@ -281,7 +281,7 @@ const magda::AutomationClipInfo* AutomationClipEditorContent::getClip() const {
     return magda::AutomationManager::getInstance().getClip(selection_.clipId);
 }
 
-double AutomationClipEditorContent::viewSpanBeats(const magda::AutomationClipInfo& clip) const {
+double AutomationClipEditorContent::viewSpanBeats(const magda::AutomationClipInfo& clip) {
     // Looped -> one loop cycle (the clip's own timeline); else content length.
     const bool looped = clip.looping && clip.loopLengthBeats > 0.0;
     return juce::jmax(looped ? clip.loopLengthBeats : clip.lengthBeats, 0.25);

--- a/magda/daw/ui/panels/content/AutomationClipEditorContent.hpp
+++ b/magda/daw/ui/panels/content/AutomationClipEditorContent.hpp
@@ -108,7 +108,7 @@ class AutomationClipEditorContent : public PanelContent,
     bool showTrackGhost_ = true;
 
     const magda::AutomationClipInfo* getClip() const;
-    double viewSpanBeats(const magda::AutomationClipInfo& clip) const;
+    static double viewSpanBeats(const magda::AutomationClipInfo& clip);
     double gridResolutionBeats() const;
     void gridSettingsChanged();
     void buildHeaderControls();

--- a/magda/daw/ui/panels/content/ChordClipContent.cpp
+++ b/magda/daw/ui/panels/content/ChordClipContent.cpp
@@ -327,6 +327,7 @@ void ChordClipContent::commitBlockDrag() {
     if (copyDrag_) {
         if (moved) {
             std::vector<int> pitches;
+            pitches.reserve(dragNotes_.size());
             for (const auto& dn : dragNotes_)
                 pitches.push_back(dn.note);
             insertChordAtBeat(dragNewStart_, pitches);
@@ -528,6 +529,7 @@ void ChordClipContent::openChordEditor(int annIndex) {
         const auto chord =
             magda::music::ChordEngine::getInstance().buildChordInversion(r, q, inv, oct);
         std::vector<int> pitches;
+        pitches.reserve(chord.notes.size());
         for (const auto& note : chord.notes)
             pitches.push_back(note.noteNumber);
         const int idx = annotationIndexAtBeat(bar + 0.001);
@@ -732,6 +734,7 @@ bool ChordClipContent::onChordRowClicked(double clipRelativeBeat) {
     const auto chord = magda::music::ChordEngine::getInstance().buildChordInRootPosition(
         magda::music::ChordRoot::C, magda::music::ChordQuality::Major, 4);
     std::vector<int> pitches;
+    pitches.reserve(chord.notes.size());
     for (const auto& note : chord.notes)
         pitches.push_back(note.noteNumber);
 

--- a/magda/daw/ui/panels/content/ChordPanelContent.cpp
+++ b/magda/daw/ui/panels/content/ChordPanelContent.cpp
@@ -989,7 +989,7 @@ void ChordPanelContent::layoutAIProgressionRows() {
         chordPlugin_ ? chordPlugin_->getAIProgressions() : std::vector<AIProgression>{};
     for (size_t i = 0; i < aiRows_.size() && i < aiProgsLayout.size(); ++i) {
         auto& row = aiRows_[i];
-        auto& prog = aiProgsLayout[i];
+        const auto& prog = aiProgsLayout[i];
 
         AIContainerPaintData::Row paintRow;
         paintRow.name = prog.name;

--- a/magda/daw/ui/panels/content/ChordPanelContent.cpp
+++ b/magda/daw/ui/panels/content/ChordPanelContent.cpp
@@ -243,7 +243,7 @@ void BrowseScaleRowComponent::mouseExit(const juce::MouseEvent&) {
     repaint();
 }
 
-int BrowseScaleRowComponent::getRowHeight() const {
+int BrowseScaleRowComponent::getRowHeight() {
     return ROW_HEIGHT;
 }
 

--- a/magda/daw/ui/panels/content/ChordPanelContent.cpp
+++ b/magda/daw/ui/panels/content/ChordPanelContent.cpp
@@ -1033,8 +1033,9 @@ void ChordPanelContent::layoutAIProgressionRows() {
     if (container) {
         container->paintData = std::move(paintData);
 
-        // If loading with no rows, account for prompt + "Generating..." height
-        if (container->loading && paintData.rows.empty()) {
+        // If loading with no rows, account for prompt + "Generating..." height.
+        // Read through the container: `paintData` has just been moved from.
+        if (container->loading && container->paintData.rows.empty()) {
             int promptHeight = 8;  // top padding
             if (container->promptText.isNotEmpty())
                 promptHeight += 24;  // prompt text line

--- a/magda/daw/ui/panels/content/ChordPanelContent.cpp
+++ b/magda/daw/ui/panels/content/ChordPanelContent.cpp
@@ -1,5 +1,7 @@
 #include "ChordPanelContent.hpp"
 
+#include <utility>
+
 #include "../../../../agents/chord_agent.hpp"
 #include "BinaryData.h"
 #include "core/ChordProgressionContext.hpp"
@@ -23,8 +25,8 @@ namespace magda::daw::ui {
 // ScaleBlockComponent
 // ============================================================================
 
-ScaleBlockComponent::ScaleBlockComponent(const magda::music::ScaleWithChords& scale)
-    : scale_(scale) {
+ScaleBlockComponent::ScaleBlockComponent(magda::music::ScaleWithChords scale)
+    : scale_(std::move(scale)) {
     setName("ScaleBlock");
     setRepaintsOnMouseActivity(true);
 }
@@ -80,7 +82,7 @@ void ScaleBlockComponent::mouseExit(const juce::MouseEvent& /*e*/) {
 // ScaleChordsPopup
 // ============================================================================
 
-ScaleChordsPopup::ScaleChordsPopup(const magda::music::ScaleWithChords& scale) : scale_(scale) {
+ScaleChordsPopup::ScaleChordsPopup(magda::music::ScaleWithChords scale) : scale_(std::move(scale)) {
     setName("ScaleChordsPopup");
 
     // Build chord blocks for each diatonic triad
@@ -203,8 +205,8 @@ void ScaleChordsPopup::showAt(juce::Component* parent, juce::Rectangle<int> targ
 // BrowseScaleRowComponent
 // ============================================================================
 
-BrowseScaleRowComponent::BrowseScaleRowComponent(const magda::music::ScaleWithChords& scale)
-    : scale_(scale) {
+BrowseScaleRowComponent::BrowseScaleRowComponent(magda::music::ScaleWithChords scale)
+    : scale_(std::move(scale)) {
     setName("BrowseScaleRow");
     setRepaintsOnMouseActivity(true);
 }
@@ -1385,7 +1387,7 @@ IDENTIFIER: /[a-zA-Z_#][a-zA-Z0-9_#]*/
                 return false;
 
             // Post token to UI thread for live display
-            auto tokenCopy = token;
+            const auto& tokenCopy = token;
             juce::MessageManager::callAsync([safeThis, tokenCopy]() {
                 if (!safeThis)
                     return;

--- a/magda/daw/ui/panels/content/ChordPanelContent.hpp
+++ b/magda/daw/ui/panels/content/ChordPanelContent.hpp
@@ -94,7 +94,7 @@ class BrowseScaleRowComponent : public juce::Component {
     void mouseEnter(const juce::MouseEvent& e) override;
     void mouseExit(const juce::MouseEvent& e) override;
 
-    int getRowHeight() const;
+    static int getRowHeight();
     const magda::music::ScaleWithChords& getScale() const {
         return scale_;
     }
@@ -235,7 +235,7 @@ class ChordPanelContent : public juce::Component,
 
     // AI chord suggestion
     void requestAISuggestions();
-    std::vector<AIProgression> parseAIResponse(const juce::String& json);
+    static std::vector<AIProgression> parseAIResponse(const juce::String& json);
 
     class AIRequestThread : public juce::Thread {
       public:

--- a/magda/daw/ui/panels/content/ChordPanelContent.hpp
+++ b/magda/daw/ui/panels/content/ChordPanelContent.hpp
@@ -29,7 +29,7 @@ class ChordBlockComponent;
  */
 class ScaleBlockComponent : public juce::Component {
   public:
-    explicit ScaleBlockComponent(const magda::music::ScaleWithChords& scale);
+    explicit ScaleBlockComponent(magda::music::ScaleWithChords scale);
 
     void paint(juce::Graphics& g) override;
     void mouseDown(const juce::MouseEvent& e) override;
@@ -59,7 +59,7 @@ class ScaleBlockComponent : public juce::Component {
  */
 class ScaleChordsPopup : public juce::Component {
   public:
-    ScaleChordsPopup(const magda::music::ScaleWithChords& scale);
+    ScaleChordsPopup(magda::music::ScaleWithChords scale);
 
     void paint(juce::Graphics& g) override;
     void resized() override;
@@ -86,7 +86,7 @@ using AIProgression = magda::daw::audio::MidiChordEnginePlugin::AIProgression;
  */
 class BrowseScaleRowComponent : public juce::Component {
   public:
-    explicit BrowseScaleRowComponent(const magda::music::ScaleWithChords& scale);
+    explicit BrowseScaleRowComponent(magda::music::ScaleWithChords scale);
 
     void paint(juce::Graphics& g) override;
     void resized() override;

--- a/magda/daw/ui/panels/content/DrumGridClipContent.cpp
+++ b/magda/daw/ui/panels/content/DrumGridClipContent.cpp
@@ -1861,7 +1861,7 @@ class DrumGridRowLabels : public juce::Component {
                         const int pillW = juce::jmax(18, shortTag.length() * 8 + 8);
                         juce::Rectangle<float> pill(
                             static_cast<float>(textX),
-                            static_cast<float>(y + (rowHeight_ - pillH) / 2),
+                            static_cast<float>(y) + static_cast<float>(rowHeight_ - pillH) / 2.0f,
                             static_cast<float>(pillW), static_cast<float>(pillH));
                         g.setColour(
                             DarkTheme::getColour(DarkTheme::ACCENT_PRIMARY).withAlpha(0.85f));

--- a/magda/daw/ui/panels/content/DrumGridClipContent.cpp
+++ b/magda/daw/ui/panels/content/DrumGridClipContent.cpp
@@ -2272,7 +2272,7 @@ DrumGridClipContent::DrumGridClipContent() {
     };
 
     gridComponent_->onNoteSelectionChanged = [this](magda::ClipId clipId,
-                                                    std::vector<size_t> noteIndices) {
+                                                    const std::vector<size_t>& noteIndices) {
         if (noteIndices.empty()) {
             magda::SelectionManager::getInstance().clearNoteSelection();
         } else {
@@ -2290,7 +2290,7 @@ DrumGridClipContent::DrumGridClipContent() {
     };
 
     // Handle copy from context menu
-    gridComponent_->onCopyNotes = [](magda::ClipId clipId, std::vector<size_t> noteIndices) {
+    gridComponent_->onCopyNotes = [](magda::ClipId clipId, const std::vector<size_t>& noteIndices) {
         magda::ClipManager::getInstance().copyNotesToClipboard(clipId, noteIndices);
     };
 
@@ -2328,7 +2328,7 @@ DrumGridClipContent::DrumGridClipContent() {
 
     // Handle duplicate from context menu
     gridComponent_->onDuplicateNotes = [this](magda::ClipId clipId,
-                                              std::vector<size_t> noteIndices) {
+                                              const std::vector<size_t>& noteIndices) {
         auto& clipManager = magda::ClipManager::getInstance();
         const auto* clip = clipManager.getClip(clipId);
         if (!clip || !clip->isMidi())

--- a/magda/daw/ui/panels/content/MediaDbBrowserContent.cpp
+++ b/magda/daw/ui/panels/content/MediaDbBrowserContent.cpp
@@ -696,7 +696,7 @@ class MediaDbBrowserContent::ResultsTableModel : public juce::TableListBoxModel 
             }
             const juce::Component::SafePointer<MediaDbBrowserContent> self(&owner_);
             const auto seedId = r.fileId;
-            const auto seedName = fileName;
+            const auto& seedName = fileName;
             menu.showMenuAsync(
                 juce::PopupMenu::Options{},
                 [self, seedId, seedName, selectedIds = std::move(selectedIds)](int choice) mutable {
@@ -1502,7 +1502,7 @@ void MediaDbBrowserContent::showBulkEditRowsDialog(std::vector<std::int64_t> fil
         }));
 }
 
-void MediaDbBrowserContent::resetRowsToDetected(std::vector<std::int64_t> fileIds) {
+void MediaDbBrowserContent::resetRowsToDetected(const std::vector<std::int64_t>& fileIds) {
     if (indexing_ || fileIds.empty()) {
         return;
     }

--- a/magda/daw/ui/panels/content/MediaDbBrowserContent.cpp
+++ b/magda/daw/ui/panels/content/MediaDbBrowserContent.cpp
@@ -2018,6 +2018,7 @@ void MediaDbBrowserContent::runSearch() {
                 }
                 magda::media::MediaDbQuery query(*self->searchDb_, nullptr, nullptr);
                 results = query.similarTo(seedId, filters, kPageSize, offset, sort);
+                // NOLINTNEXTLINE(bugprone-empty-catch) - the body documents the deliberate ignore
             } catch (...) {
                 // Empty result -> UI shows the "No results" empty state.
             }
@@ -2097,6 +2098,7 @@ void MediaDbBrowserContent::runSearch() {
             magda::media::MediaDbQuery query(*self->searchDb_, textEnc, tok);
             results = query.search(std::optional<std::string>{text}, filters, kPageSize, offset, {},
                                    sort);
+            // NOLINTNEXTLINE(bugprone-empty-catch) - the body documents the deliberate ignore
         } catch (...) {
             // Swallow — empty result set bounces back to the UI either way.
         }

--- a/magda/daw/ui/panels/content/MediaDbBrowserContent.hpp
+++ b/magda/daw/ui/panels/content/MediaDbBrowserContent.hpp
@@ -144,7 +144,7 @@ class MediaDbBrowserContent : public juce::Component, private juce::Timer {
     void startAnalyzingFileIds(std::vector<std::int64_t> fileIds);
     void showEditRowDialog(std::int64_t fileId);
     void showBulkEditRowsDialog(std::vector<std::int64_t> fileIds);
-    void resetRowsToDetected(std::vector<std::int64_t> fileIds);
+    void resetRowsToDetected(const std::vector<std::int64_t>& fileIds);
     void saveMatchingClipValuesToLibrary(std::int64_t fileId);
     void recoverMissingFile(std::int64_t fileId);
     // When `fileIds` has more than one entry the family/shape choice is

--- a/magda/daw/ui/panels/content/MediaExplorerContent.cpp
+++ b/magda/daw/ui/panels/content/MediaExplorerContent.cpp
@@ -1212,7 +1212,7 @@ MediaExplorerContent::~MediaExplorerContent() {
     previewCallback_.reset();
 }
 
-juce::File MediaExplorerContent::pickStartupFilesystemRoot() const {
+juce::File MediaExplorerContent::pickStartupFilesystemRoot() {
     // Saved default → user's Music folder → home. Returns the first that
     // exists as a directory.
     auto defaultDir = magda::Config::getInstance().getBrowserDefaultDirectory();
@@ -1701,23 +1701,23 @@ juce::String MediaExplorerContent::getMediaFilterPattern() const {
     return patterns.joinIntoString(";");
 }
 
-bool MediaExplorerContent::isAudioFile(const juce::File& file) const {
+bool MediaExplorerContent::isAudioFile(const juce::File& file) {
     auto ext = file.getFileExtension().toLowerCase();
     return ext == ".wav" || ext == ".aiff" || ext == ".aif" || ext == ".mp3" || ext == ".ogg" ||
            ext == ".flac";
 }
 
-bool MediaExplorerContent::isMidiFile(const juce::File& file) const {
+bool MediaExplorerContent::isMidiFile(const juce::File& file) {
     auto ext = file.getFileExtension().toLowerCase();
     return ext == ".mid" || ext == ".midi";
 }
 
-bool MediaExplorerContent::isMagdaClip(const juce::File& file) const {
+bool MediaExplorerContent::isMagdaClip(const juce::File& file) {
     auto ext = file.getFileExtension().toLowerCase();
     return ext == ".magdaclip";
 }
 
-bool MediaExplorerContent::isPresetFile(const juce::File& file) const {
+bool MediaExplorerContent::isPresetFile(const juce::File& file) {
     auto ext = file.getFileExtension().toLowerCase();
     return ext == ".magdapreset";
 }

--- a/magda/daw/ui/panels/content/MediaExplorerContent.cpp
+++ b/magda/daw/ui/panels/content/MediaExplorerContent.cpp
@@ -1229,7 +1229,7 @@ juce::File MediaExplorerContent::pickStartupFilesystemRoot() {
     return juce::File::getSpecialLocation(juce::File::userHomeDirectory);
 }
 
-void MediaExplorerContent::applyView(ViewState target) {
+void MediaExplorerContent::applyView(const ViewState& target) {
     // The ONE writer of view state. Touches everything that depends on the
     // mode/sidebar/root so nothing can drift out of sync:
     //   1. Sidebar visual selection

--- a/magda/daw/ui/panels/content/MediaExplorerContent.hpp
+++ b/magda/daw/ui/panels/content/MediaExplorerContent.hpp
@@ -153,7 +153,7 @@ class MediaExplorerContent : public PanelContent,
         juce::File filesystemRoot;  // meaningful when mode == Filesystem
     };
     ViewState currentView_;
-    void applyView(ViewState target);
+    void applyView(const ViewState& target);
 
     // Helper: best initial Filesystem root — saved default, then Music,
     // then Home. Always returns an existing directory.

--- a/magda/daw/ui/panels/content/MediaExplorerContent.hpp
+++ b/magda/daw/ui/panels/content/MediaExplorerContent.hpp
@@ -157,7 +157,7 @@ class MediaExplorerContent : public PanelContent,
 
     // Helper: best initial Filesystem root — saved default, then Music,
     // then Home. Always returns an existing directory.
-    [[nodiscard]] juce::File pickStartupFilesystemRoot() const;
+    [[nodiscard]] static juce::File pickStartupFilesystemRoot();
 
     // Public-facing query equivalent of the old libraryMode_ flag, used by
     // the type-icon click handler to know whether it's driving DB kind or
@@ -222,12 +222,12 @@ class MediaExplorerContent : public PanelContent,
     void navigateToDirectory(const juce::File& directory);
     void updateMediaFilter();
     juce::String getMediaFilterPattern() const;
-    bool isAudioFile(const juce::File& file) const;
-    bool isMidiFile(const juce::File& file) const;
-    bool isMagdaClip(const juce::File& file) const;
-    bool isPresetFile(const juce::File& file) const;
-    juce::String formatFileSize(int64_t bytes);
-    juce::String formatDuration(double seconds);
+    static bool isAudioFile(const juce::File& file);
+    static bool isMidiFile(const juce::File& file);
+    static bool isMagdaClip(const juce::File& file);
+    static bool isPresetFile(const juce::File& file);
+    static juce::String formatFileSize(int64_t bytes);
+    static juce::String formatDuration(double seconds);
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(MediaExplorerContent)
 };

--- a/magda/daw/ui/panels/content/MidiEditorContent.hpp
+++ b/magda/daw/ui/panels/content/MidiEditorContent.hpp
@@ -146,7 +146,7 @@ class MidiEditorContent : public PanelContent,
     // --- Multi-track overlay (ghost notes from other tracks, #1281) ---
     // Shared between piano roll and drum grid; each editor renders the
     // overlay in its own grid via applyOverlayTracks().
-    bool hasOverlayTracks() const {
+    static bool hasOverlayTracks() {
         return !overlayTrackIds_.empty();
     }
     // Sticky multi-select menu of other MIDI tracks (anchored at `anchor`);
@@ -161,7 +161,7 @@ class MidiEditorContent : public PanelContent,
     static bool isNotePreviewEnabled() {
         return notePreviewEnabled_;
     }
-    void setNotePreviewEnabled(bool enabled) {
+    static void setNotePreviewEnabled(bool enabled) {
         notePreviewEnabled_ = enabled;
     }
     // Update a gutter preview toggle to reflect `on`: crossed speaker in dimmed
@@ -222,7 +222,7 @@ class MidiEditorContent : public PanelContent,
     static bool velocityDrawerOpen_;
     static bool velocityLaneVisible_;
     void setVelocityDrawerVisible(bool visible);
-    bool isVelocityDrawerVisible() const {
+    static bool isVelocityDrawerVisible() {
         return velocityDrawerOpen_;
     }
     // Push the velocity-visible flag into the drawer, recompute drawer-open, and

--- a/magda/daw/ui/panels/content/PanelContentFactory.cpp
+++ b/magda/daw/ui/panels/content/PanelContentFactory.cpp
@@ -91,7 +91,7 @@ std::vector<PanelContentType> PanelContentFactory::getAvailableTypes() const {
     return types;
 }
 
-PanelContentInfo PanelContentFactory::getContentInfo(PanelContentType type) const {
+PanelContentInfo PanelContentFactory::getContentInfo(PanelContentType type) {
     return PanelContentInfo{type, getContentTypeName(type), getContentTypeName(type),
                             getContentTypeIcon(type)};
 }

--- a/magda/daw/ui/panels/content/PanelContentFactory.hpp
+++ b/magda/daw/ui/panels/content/PanelContentFactory.hpp
@@ -54,7 +54,7 @@ class PanelContentFactory {
     /**
      * @brief Get the info for a content type
      */
-    PanelContentInfo getContentInfo(PanelContentType type) const;
+    static PanelContentInfo getContentInfo(PanelContentType type);
 
   private:
     PanelContentFactory();

--- a/magda/daw/ui/panels/content/PianoRollContent.cpp
+++ b/magda/daw/ui/panels/content/PianoRollContent.cpp
@@ -657,7 +657,7 @@ void PianoRollContent::setupGridCallbacks() {
 
     // Handle batch note selection changes (lasso, deselect-all, Cmd+click toggle)
     gridComponent_->onNoteSelectionChanged = [this](magda::ClipId clipId,
-                                                    std::vector<size_t> noteIndices) {
+                                                    const std::vector<size_t>& noteIndices) {
         if (noteIndices.empty()) {
             // Clear note selection — preserve clip selection
             magda::SelectionManager::getInstance().clearNoteSelection();
@@ -692,7 +692,8 @@ void PianoRollContent::setupGridCallbacks() {
 
     // Handle legato from right-click context menu: stretch each selected note to
     // the next selected onset (one undo step via the batch resize command).
-    gridComponent_->onLegatoNotes = [](magda::ClipId clipId, std::vector<size_t> noteIndices) {
+    gridComponent_->onLegatoNotes = [](magda::ClipId clipId,
+                                       const std::vector<size_t>& noteIndices) {
         const auto* clip = magda::ClipManager::getInstance().getClip(clipId);
         if (!clip || !clip->isMidi())
             return;
@@ -705,7 +706,7 @@ void PianoRollContent::setupGridCallbacks() {
     };
 
     // Handle copy from context menu
-    gridComponent_->onCopyNotes = [](magda::ClipId clipId, std::vector<size_t> noteIndices) {
+    gridComponent_->onCopyNotes = [](magda::ClipId clipId, const std::vector<size_t>& noteIndices) {
         magda::ClipManager::getInstance().copyNotesToClipboard(clipId, noteIndices);
     };
 
@@ -743,7 +744,7 @@ void PianoRollContent::setupGridCallbacks() {
 
     // Handle duplicate from context menu
     gridComponent_->onDuplicateNotes = [this](magda::ClipId clipId,
-                                              std::vector<size_t> noteIndices) {
+                                              const std::vector<size_t>& noteIndices) {
         auto& clipManager = magda::ClipManager::getInstance();
         const auto* clip = clipManager.getClip(clipId);
         if (!clip || !clip->isMidi())
@@ -805,7 +806,7 @@ void PianoRollContent::setupGridCallbacks() {
 
     // Handle chord block drops from the chord panel
     gridComponent_->onChordDropped = [](magda::ClipId clipId, double beat, double noteLength,
-                                        std::vector<std::pair<int, int>> notes,
+                                        const std::vector<std::pair<int, int>>& notes,
                                         juce::String chordName) {
         if (notes.empty())
             return;
@@ -2091,7 +2092,7 @@ void PianoRollContent::syncChordAnnotations(magda::ClipId clipId) {
 
         for (const auto& note : clip->midiNotes) {
             if (note.chordGroup == it->chordGroup) {
-                chordNotes.push_back({note.noteNumber, note.velocity});
+                chordNotes.emplace_back(note.noteNumber, note.velocity);
                 minBeat = std::min(minBeat, note.startBeat);
                 maxEnd = std::max(maxEnd, note.startBeat + note.lengthBeats);
             }

--- a/magda/daw/ui/panels/content/PianoRollContent.hpp
+++ b/magda/daw/ui/panels/content/PianoRollContent.hpp
@@ -241,12 +241,13 @@ class PianoRollContent : public MidiEditorContent,
     void setupGridCallbacks();
     void drawSidebar(juce::Graphics& g, juce::Rectangle<int> area);
     void drawChordRow(juce::Graphics& g, juce::Rectangle<int> area);
-    void drawVelocityHeader(juce::Graphics& g, juce::Rectangle<int> area);
+    static void drawVelocityHeader(juce::Graphics& g, juce::Rectangle<int> area);
     void detectChordsFromNotes();
     // Play a note then stop it after its length elapses, for double-click note
     // creation (#1705). Gated by the preview toggle; the note-off is scheduled
     // against the engine so it fires even if this panel is torn down first.
-    void auditionNoteOnce(magda::ClipId clipId, int noteNumber, int velocity, double lengthBeats);
+    static void auditionNoteOnce(magda::ClipId clipId, int noteNumber, int velocity,
+                                 double lengthBeats);
     void syncChordAnnotations(magda::ClipId clipId);
     void setNoteHeight(int height, bool persist);
     void setNoteHeightAnchored(int height, int anchorNote, int anchorScreenY, bool persist);

--- a/magda/daw/ui/panels/content/PluginBrowserContent.cpp
+++ b/magda/daw/ui/panels/content/PluginBrowserContent.cpp
@@ -1245,7 +1245,7 @@ void PluginBrowserContent::showRenameFolderDialog(const juce::String& folderName
         true);
 }
 
-juce::File PluginBrowserContent::getFoldersFile() const {
+juce::File PluginBrowserContent::getFoldersFile() {
     return magda::paths::pluginFoldersFile();
 }
 

--- a/magda/daw/ui/panels/content/PluginBrowserContent.cpp
+++ b/magda/daw/ui/panels/content/PluginBrowserContent.cpp
@@ -728,7 +728,7 @@ void PluginBrowserContent::rebuildTree() {
 
             // Create parent category if needed
             if (categories.find(parentKey) == categories.end()) {
-                auto parentItem = new CategoryTreeItem(parentKey);
+                auto* parentItem = new CategoryTreeItem(parentKey);
                 root->addSubItem(parentItem);
                 categories[parentKey] = parentItem;
             }
@@ -737,7 +737,7 @@ void PluginBrowserContent::rebuildTree() {
             if (childKey.isNotEmpty()) {
                 juce::String fullKey = parentKey + "/" + childKey;
                 if (categories.find(fullKey) == categories.end()) {
-                    auto childItem = new CategoryTreeItem(childKey);
+                    auto* childItem = new CategoryTreeItem(childKey);
                     categories[parentKey]->addSubItem(childItem);
                     categories[fullKey] = childItem;
                 }
@@ -748,7 +748,7 @@ void PluginBrowserContent::rebuildTree() {
         } else {
             // Single-level grouping
             if (categories.find(groupKey) == categories.end()) {
-                auto item = new CategoryTreeItem(groupKey);
+                auto* item = new CategoryTreeItem(groupKey);
                 root->addSubItem(item);
                 categories[groupKey] = item;
             }

--- a/magda/daw/ui/panels/content/PluginBrowserContent.cpp
+++ b/magda/daw/ui/panels/content/PluginBrowserContent.cpp
@@ -2,6 +2,8 @@
 
 #include <BinaryData.h>
 
+#include <utility>
+
 #include "../../../../agents/sound_design_agent.hpp"
 #include "../../dialogs/ParameterConfigDialog.hpp"
 #include "../../themes/DarkTheme.hpp"
@@ -169,8 +171,8 @@ juce::String PluginBrowserInfo::generateAlias(const juce::String& pluginName) {
 //==============================================================================
 class PluginBrowserContent::PluginTreeItem : public juce::TreeViewItem {
   public:
-    PluginTreeItem(const PluginBrowserInfo& plugin, PluginBrowserContent& owner)
-        : plugin_(plugin), owner_(owner) {}
+    PluginTreeItem(PluginBrowserInfo plugin, PluginBrowserContent& owner)
+        : plugin_(std::move(plugin)), owner_(owner) {}
 
     bool mightContainSubItems() override {
         return false;
@@ -290,8 +292,8 @@ class PluginBrowserContent::PluginTreeItem : public juce::TreeViewItem {
 //==============================================================================
 class PluginBrowserContent::CategoryTreeItem : public juce::TreeViewItem {
   public:
-    CategoryTreeItem(const juce::String& name, const juce::String& icon = "")
-        : name_(name), icon_(icon) {}
+    CategoryTreeItem(juce::String name, juce::String icon = "")
+        : name_(std::move(name)), icon_(std::move(icon)) {}
 
     bool mightContainSubItems() override {
         return true;
@@ -723,7 +725,7 @@ void PluginBrowserContent::rebuildTree() {
         // For nested categories (e.g., "Effect/EQ")
         if (currentViewMode_ == ViewMode::ByCategory) {
             auto parts = juce::StringArray::fromTokens(groupKey, "/", "");
-            juce::String parentKey = parts[0];
+            const juce::String& parentKey = parts[0];
             juce::String childKey = parts.size() > 1 ? parts[1] : "";
 
             // Create parent category if needed

--- a/magda/daw/ui/panels/content/PluginBrowserContent.cpp
+++ b/magda/daw/ui/panels/content/PluginBrowserContent.cpp
@@ -1202,6 +1202,8 @@ void PluginBrowserContent::showFolderContextMenu(const juce::String& folderName,
                 case 3:
                     deleteFolder(folderName);
                     break;
+                default:  // menu dismissed
+                    break;
             }
         });
 }

--- a/magda/daw/ui/panels/content/PluginBrowserContent.hpp
+++ b/magda/daw/ui/panels/content/PluginBrowserContent.hpp
@@ -162,7 +162,7 @@ class PluginBrowserContent : public PanelContent,
     void showRenameFolderDialog(const juce::String& folderName);
     void saveFolders();
     void loadFolders();
-    juce::File getFoldersFile() const;
+    static juce::File getFoldersFile();
 
     juce::StringArray folderNames_;                           // in creation order
     std::map<juce::String, juce::String> pluginFolderByKey_;  // plugin key -> folder name

--- a/magda/daw/ui/panels/content/PostFxPanelContent.hpp
+++ b/magda/daw/ui/panels/content/PostFxPanelContent.hpp
@@ -59,7 +59,7 @@ class PostFxPanelContent : public juce::Component, public magda::TrackManagerLis
     int indicatorX(int insertIndex) const;
     int contentWidth() const;  // container width: max(content, viewport)
     int appendZoneX() const;   // x of the "+" add strip, pinned to the right
-    void applyReorder(magda::TrackId trackId, int fromIndex, int insertIndex);
+    static void applyReorder(magda::TrackId trackId, int fromIndex, int insertIndex);
     static magda::DeviceInfo deviceInfoFromDragObject(const juce::DynamicObject& obj);
 
     magda::TrackId trackId_ = magda::INVALID_TRACK_ID;

--- a/magda/daw/ui/panels/content/TrackChainContent.cpp
+++ b/magda/daw/ui/panels/content/TrackChainContent.cpp
@@ -4,6 +4,7 @@
 
 #include <cmath>
 #include <thread>
+#include <utility>
 
 #include "../../../../agents/gain_staging_agent.hpp"
 #include "../../components/chain/ChainNodePathDrag.hpp"
@@ -1209,12 +1210,12 @@ void TrackChainContent::initGlobalModsPanel() {
     globalModsPanel_->onModTargetChanged = [this](int modIndex, magda::ControlTarget target) {
         if (selectedTrackId_ != magda::INVALID_TRACK_ID)
             magda::TrackManager::getInstance().setModTarget(
-                ChainNodePath::trackLevel(selectedTrackId_), modIndex, target);
+                ChainNodePath::trackLevel(selectedTrackId_), modIndex, std::move(target));
     };
     globalModsPanel_->onModLinkRemoved = [this](int modIndex, magda::ControlTarget target) {
         if (selectedTrackId_ != magda::INVALID_TRACK_ID) {
             magda::TrackManager::getInstance().removeModLink(
-                ChainNodePath::trackLevel(selectedTrackId_), modIndex, target);
+                ChainNodePath::trackLevel(selectedTrackId_), modIndex, std::move(target));
             updateGlobalModsPanel();
         }
     };
@@ -1347,26 +1348,29 @@ void TrackChainContent::initGlobalModsPanel() {
     globalModEditorPanel_->onModLinkDeleted = [this](int modIndex, magda::ControlTarget target) {
         if (selectedTrackId_ != magda::INVALID_TRACK_ID)
             magda::TrackManager::getInstance().removeModLink(
-                ChainNodePath::trackLevel(selectedTrackId_), modIndex, target);
+                ChainNodePath::trackLevel(selectedTrackId_), modIndex, std::move(target));
     };
-    globalModEditorPanel_->onModLinkBipolarChanged =
-        [this](int modIndex, magda::ControlTarget target, bool bipolar) {
-            if (selectedTrackId_ != magda::INVALID_TRACK_ID)
-                magda::TrackManager::getInstance().setModLinkBipolar(
-                    ChainNodePath::trackLevel(selectedTrackId_), modIndex, target, bipolar);
-        };
-    globalModEditorPanel_->onModLinkEnabledChanged =
-        [this](int modIndex, magda::ControlTarget target, bool enabled) {
-            if (selectedTrackId_ != magda::INVALID_TRACK_ID)
-                magda::TrackManager::getInstance().setModLinkEnabled(
-                    ChainNodePath::trackLevel(selectedTrackId_), modIndex, target, enabled);
-        };
-    globalModEditorPanel_->onModLinkAmountChanged =
-        [this](int modIndex, magda::ControlTarget target, float amount) {
-            if (selectedTrackId_ != magda::INVALID_TRACK_ID)
-                magda::TrackManager::getInstance().setModLinkAmount(
-                    ChainNodePath::trackLevel(selectedTrackId_), modIndex, target, amount);
-        };
+    globalModEditorPanel_->onModLinkBipolarChanged = [this](int modIndex,
+                                                            magda::ControlTarget target,
+                                                            bool bipolar) {
+        if (selectedTrackId_ != magda::INVALID_TRACK_ID)
+            magda::TrackManager::getInstance().setModLinkBipolar(
+                ChainNodePath::trackLevel(selectedTrackId_), modIndex, std::move(target), bipolar);
+    };
+    globalModEditorPanel_->onModLinkEnabledChanged = [this](int modIndex,
+                                                            magda::ControlTarget target,
+                                                            bool enabled) {
+        if (selectedTrackId_ != magda::INVALID_TRACK_ID)
+            magda::TrackManager::getInstance().setModLinkEnabled(
+                ChainNodePath::trackLevel(selectedTrackId_), modIndex, std::move(target), enabled);
+    };
+    globalModEditorPanel_->onModLinkAmountChanged = [this](int modIndex,
+                                                           magda::ControlTarget target,
+                                                           float amount) {
+        if (selectedTrackId_ != magda::INVALID_TRACK_ID)
+            magda::TrackManager::getInstance().setModLinkAmount(
+                ChainNodePath::trackLevel(selectedTrackId_), modIndex, std::move(target), amount);
+    };
     globalModEditorPanel_->setParamNameResolver(
         [this](magda::DeviceId deviceId, int paramIndex) -> juce::String {
             if (selectedTrackId_ == magda::INVALID_TRACK_ID)
@@ -1419,7 +1423,7 @@ void TrackChainContent::initGlobalMacrosPanel() {
     globalMacrosPanel_->onMacroTargetChanged = [this](int macroIndex, magda::ControlTarget target) {
         if (selectedTrackId_ != magda::INVALID_TRACK_ID)
             magda::TrackManager::getInstance().setMacroTarget(
-                ChainNodePath::trackLevel(selectedTrackId_), macroIndex, target);
+                ChainNodePath::trackLevel(selectedTrackId_), macroIndex, std::move(target));
     };
     globalMacrosPanel_->onMacroNameChanged = [this](int macroIndex, juce::String name) {
         if (selectedTrackId_ != magda::INVALID_TRACK_ID)
@@ -1430,7 +1434,7 @@ void TrackChainContent::initGlobalMacrosPanel() {
     globalMacrosPanel_->onMacroLinkRemoved = [this](int macroIndex, magda::ControlTarget target) {
         if (selectedTrackId_ != magda::INVALID_TRACK_ID) {
             magda::TrackManager::getInstance().removeMacroLink(
-                ChainNodePath::trackLevel(selectedTrackId_), macroIndex, target);
+                ChainNodePath::trackLevel(selectedTrackId_), macroIndex, std::move(target));
             updateGlobalMacrosPanel();
         }
     };
@@ -1478,13 +1482,14 @@ void TrackChainContent::initGlobalMacrosPanel() {
                                                           float amount) {
         if (selectedTrackId_ != magda::INVALID_TRACK_ID && selectedGlobalMacroIndex_ >= 0)
             magda::TrackManager::getInstance().setMacroLinkAmount(
-                ChainNodePath::trackLevel(selectedTrackId_), selectedGlobalMacroIndex_, target,
-                amount);
+                ChainNodePath::trackLevel(selectedTrackId_), selectedGlobalMacroIndex_,
+                std::move(target), amount);
     };
     globalMacroEditorPanel_->onLinkRemoved = [this](magda::ControlTarget target) {
         if (selectedTrackId_ != magda::INVALID_TRACK_ID && selectedGlobalMacroIndex_ >= 0) {
             magda::TrackManager::getInstance().removeMacroLink(
-                ChainNodePath::trackLevel(selectedTrackId_), selectedGlobalMacroIndex_, target);
+                ChainNodePath::trackLevel(selectedTrackId_), selectedGlobalMacroIndex_,
+                std::move(target));
             updateGlobalMacrosPanel();
         }
     };
@@ -1492,8 +1497,8 @@ void TrackChainContent::initGlobalMacrosPanel() {
                                                            bool bipolar) {
         if (selectedTrackId_ != magda::INVALID_TRACK_ID && selectedGlobalMacroIndex_ >= 0) {
             magda::TrackManager::getInstance().setMacroLinkBipolar(
-                ChainNodePath::trackLevel(selectedTrackId_), selectedGlobalMacroIndex_, target,
-                bipolar);
+                ChainNodePath::trackLevel(selectedTrackId_), selectedGlobalMacroIndex_,
+                std::move(target), bipolar);
             updateGlobalMacrosPanel();
         }
     };
@@ -1574,7 +1579,7 @@ void TrackChainContent::updateGlobalModsPanel() {
         for (const auto& element : elements) {
             if (magda::isDevice(element)) {
                 const auto& device = magda::getDevice(element);
-                allDevices.push_back({device.id, device.name});
+                allDevices.emplace_back(device.id, device.name);
                 std::vector<juce::String> names;
                 names.reserve(device.parameters.size());
                 for (const auto& p : device.parameters)
@@ -1636,7 +1641,7 @@ void TrackChainContent::updateGlobalMacrosPanel() {
         for (const auto& element : elements) {
             if (magda::isDevice(element)) {
                 const auto& device = magda::getDevice(element);
-                allDevices.push_back({device.id, device.name});
+                allDevices.emplace_back(device.id, device.name);
                 std::vector<juce::String> names;
                 names.reserve(device.parameters.size());
                 for (const auto& p : device.parameters) {
@@ -2278,7 +2283,7 @@ void TrackChainContent::runAiGainStagingPass() {
                 std::vector<std::pair<magda::ChainNodePath, float>> moves;
                 for (const auto& d : result.decisions)
                     if (d.index >= 0 && d.index < static_cast<int>(paths.size()))
-                        moves.push_back({paths[static_cast<size_t>(d.index)], d.newGainDb});
+                        moves.emplace_back(paths[static_cast<size_t>(d.index)], d.newGainDb);
                 m.applyAiMoves(moves);
                 juce::Logger::writeToLog("[GainStaging] AI: " + juce::String(result.summary));
             }

--- a/magda/daw/ui/panels/content/WaveformEditorContent.cpp
+++ b/magda/daw/ui/panels/content/WaveformEditorContent.cpp
@@ -966,7 +966,7 @@ void WaveformEditorContent::clipPropertyChanged(magda::ClipId clipId) {
 
         // Check if cached transients were invalidated (e.g. sensitivity changed)
         if (clip->isAudio() && !magda::audioEventRef(*clip).sourceFilePath().isEmpty()) {
-            auto* cached = magda::AudioThumbnailManager::getInstance().getCachedTransients(
+            const auto* cached = magda::AudioThumbnailManager::getInstance().getCachedTransients(
                 magda::audioEventRef(*clip).sourceFilePath());
             if (cached) {
                 gridComponent_->setTransientTimes(*cached);
@@ -997,7 +997,7 @@ void WaveformEditorContent::transientsChanged(const juce::String& filePath) {
     }
     if (magda::audioEventRef(*clip).sourceFilePath() != filePath)
         return;
-    auto* cached = magda::AudioThumbnailManager::getInstance().getCachedTransients(filePath);
+    const auto* cached = magda::AudioThumbnailManager::getInstance().getCachedTransients(filePath);
     if (cached) {
         double bpm = 120.0;
         if (auto* controller = magda::TimelineController::getCurrent())
@@ -1199,7 +1199,7 @@ void WaveformEditorContent::setClip(magda::ClipId clipId) {
 
         // Check for cached transients or request async detection.
         if (clip && clip->isAudio() && !magda::audioEventRef(*clip).sourceFilePath().isEmpty()) {
-            auto* cached = magda::AudioThumbnailManager::getInstance().getCachedTransients(
+            const auto* cached = magda::AudioThumbnailManager::getInstance().getCachedTransients(
                 magda::audioEventRef(*clip).sourceFilePath());
             if (cached) {
                 gridComponent_->setTransientTimes(*cached);
@@ -1517,7 +1517,7 @@ void WaveformEditorContent::requestTransientDetection() {
     if (bridge->getTransientTimes(editingClipId_)) {
         const auto* clip = magda::ClipManager::getInstance().getClip(editingClipId_);
         if (clip && !magda::audioEventRef(*clip).sourceFilePath().isEmpty()) {
-            auto* cached = magda::AudioThumbnailManager::getInstance().getCachedTransients(
+            const auto* cached = magda::AudioThumbnailManager::getInstance().getCachedTransients(
                 magda::audioEventRef(*clip).sourceFilePath());
             if (cached) {
                 gridComponent_->setTransientTimes(*cached);

--- a/magda/daw/ui/panels/content/WaveformEditorContent.hpp
+++ b/magda/daw/ui/panels/content/WaveformEditorContent.hpp
@@ -94,7 +94,7 @@ class WaveformEditorContent : public PanelContent,
 
     // Waveform editor is always source-relative.
     void setRelativeTimeMode(bool relative);
-    bool isRelativeTimeMode() const {
+    static bool isRelativeTimeMode() {
         return true;
     }
     void setSnapEnabledFromUI(bool enabled);
@@ -180,7 +180,7 @@ class WaveformEditorContent : public PanelContent,
 
     // Warp marker helpers
     void refreshWarpMarkers();
-    magda::AudioBridge* getBridge();
+    static magda::AudioBridge* getBridge();
 
     // Slice helpers
     void sliceAtWarpMarkers();

--- a/magda/daw/ui/panels/content/inspector/clip/ClipInspectorSections.cpp
+++ b/magda/daw/ui/panels/content/inspector/clip/ClipInspectorSections.cpp
@@ -97,7 +97,7 @@ class ClipInspector::GroovePickerPopup : public juce::Component {
 
         // Click on template → select and close
         templateModel_.onItemClicked = [this](int row) {
-            auto& items = templateModel_.getItems();
+            const auto& items = templateModel_.getItems();
             if (row >= 0 && row < static_cast<int>(items.size())) {
                 owner_.onGrooveTemplateSelected(items[static_cast<size_t>(row)]);
                 // Dismiss the callout box we're hosted in

--- a/magda/daw/ui/state/TimelineController.cpp
+++ b/magda/daw/ui/state/TimelineController.cpp
@@ -432,17 +432,11 @@ TimelineController::ChangeFlags TimelineController::handleEvent(const SetPlaybac
 
     if (state.playhead.isPlaying != e.isPlaying) {
         state.playhead.isPlaying = e.isPlaying;
-        // If starting playback, sync playbackPosition to editPosition
-        if (e.isPlaying) {
-            state.playhead.playbackPositionBeats = state.playhead.editPositionBeats;
-            state.playhead.playbackPosition =
-                state.beatsToSeconds(state.playhead.playbackPositionBeats);
-        } else {
-            // If stopping, reset playbackPosition to editPosition
-            state.playhead.playbackPositionBeats = state.playhead.editPositionBeats;
-            state.playhead.playbackPosition =
-                state.beatsToSeconds(state.playhead.playbackPositionBeats);
-        }
+        // Both edges do the same thing: starting syncs the playback position to
+        // the edit position, stopping resets it back to the same place.
+        state.playhead.playbackPositionBeats = state.playhead.editPositionBeats;
+        state.playhead.playbackPosition =
+            state.beatsToSeconds(state.playhead.playbackPositionBeats);
         changed = true;
     }
 

--- a/magda/daw/ui/state/TimelineState.hpp
+++ b/magda/daw/ui/state/TimelineState.hpp
@@ -3,6 +3,7 @@
 #include <juce_gui_basics/juce_gui_basics.h>
 
 #include <set>
+#include <utility>
 #include <vector>
 
 #include "../layout/LayoutConfig.hpp"
@@ -406,14 +407,13 @@ struct ArrangementSection {
     juce::String name;
     juce::Colour colour;
 
-    ArrangementSection(double start = 0.0, double end = 0.0,
-                       const juce::String& sectionName = "Section",
+    ArrangementSection(double start = 0.0, double end = 0.0, juce::String sectionName = "Section",
                        juce::Colour sectionColour = juce::Colours::blue)
         : startTime(start),
           endTime(end),
           startBeats(start * DEFAULT_BPM / 60.0),
           endBeats(end * DEFAULT_BPM / 60.0),
-          name(sectionName),
+          name(std::move(sectionName)),
           colour(sectionColour) {}
 
     double getDuration() const {
@@ -452,9 +452,9 @@ struct TimelineMarker {
     juce::String name;
     juce::Colour colour;
 
-    TimelineMarker(int markerId = 0, double beats = 0.0, const juce::String& markerName = "Marker",
+    TimelineMarker(int markerId = 0, double beats = 0.0, juce::String markerName = "Marker",
                    juce::Colour markerColour = juce::Colour(0xFF9E9E9E))
-        : id(markerId), positionBeats(beats), name(markerName), colour(markerColour) {
+        : id(markerId), positionBeats(beats), name(std::move(markerName)), colour(markerColour) {
         positionTime = beats * 60.0 / DEFAULT_BPM;
     }
 

--- a/magda/daw/ui/themes/FileBrowserLookAndFeel.hpp
+++ b/magda/daw/ui/themes/FileBrowserLookAndFeel.hpp
@@ -207,7 +207,8 @@ class FileBrowserLookAndFeel : public juce::LookAndFeel_V4 {
                                   juce::RectanglePlacement::onlyReduceInSize,
                               false);
         } else {
-            if (auto* d = isDirectory ? getDefaultFolderImage() : getDefaultDocumentFileImage())
+            if (const const auto* d =
+                    isDirectory ? getDefaultFolderImage() : getDefaultDocumentFileImage())
                 d->drawWithin(
                     g,
                     juce::Rectangle<float>(2.0f, 2.0f, x - 4.0f, static_cast<float>(height) - 4.0f),

--- a/magda/daw/ui/themes/FileBrowserLookAndFeel.hpp
+++ b/magda/daw/ui/themes/FileBrowserLookAndFeel.hpp
@@ -207,7 +207,7 @@ class FileBrowserLookAndFeel : public juce::LookAndFeel_V4 {
                                   juce::RectanglePlacement::onlyReduceInSize,
                               false);
         } else {
-            if (const const auto* d =
+            if (const auto* d =
                     isDirectory ? getDefaultFolderImage() : getDefaultDocumentFileImage())
                 d->drawWithin(
                     g,

--- a/magda/daw/ui/themes/LocalizedText.hpp
+++ b/magda/daw/ui/themes/LocalizedText.hpp
@@ -23,7 +23,7 @@ inline bool containsLocalizedUIFontText(const juce::String& text) {
     return false;
 }
 
-inline juce::Font withLocalizedUIFontScale(juce::Font font) {
+inline juce::Font withLocalizedUIFontScale(const juce::Font& font) {
     return font.withHeight(font.getHeight() *
                            static_cast<float>(Config::getInstance().getLocalizedUIFontScale()));
 }

--- a/magda/daw/ui/themes/MainLookAndFeel.hpp
+++ b/magda/daw/ui/themes/MainLookAndFeel.hpp
@@ -2,6 +2,8 @@
 
 #include <juce_gui_basics/juce_gui_basics.h>
 
+#include <utility>
+
 #include "DarkTheme.hpp"
 #include "FontManager.hpp"
 
@@ -104,9 +106,11 @@ class MainLookAndFeel : public juce::LookAndFeel_V4 {
   private:
     class GlyphButton : public juce::Button {
       public:
-        GlyphButton(const juce::String& name, juce::Colour c, const juce::Path& normal,
-                    const juce::Path& toggled)
-            : juce::Button(name), colour(c), normalShape(normal), toggledShape(toggled) {}
+        GlyphButton(const juce::String& name, juce::Colour c, juce::Path normal, juce::Path toggled)
+            : juce::Button(name),
+              colour(c),
+              normalShape(std::move(normal)),
+              toggledShape(std::move(toggled)) {}
 
         void paintButton(juce::Graphics& g, bool isHighlighted, bool isDown) override {
             auto background = juce::Colours::grey;

--- a/magda/daw/ui/themes/MixerLookAndFeel.hpp
+++ b/magda/daw/ui/themes/MixerLookAndFeel.hpp
@@ -39,7 +39,7 @@ class MixerLookAndFeel : public juce::LookAndFeel_V4 {
     void positionComboBoxText(juce::ComboBox& box, juce::Label& label) override;
 
     // Smaller arrow button for ComboBox
-    void drawComboBoxArrow(juce::Graphics& g, juce::Rectangle<int> arrowZone);
+    static void drawComboBoxArrow(juce::Graphics& g, juce::Rectangle<int> arrowZone);
 
   private:
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(MixerLookAndFeel)

--- a/magda/daw/ui/themes/MixerMetrics.hpp
+++ b/magda/daw/ui/themes/MixerMetrics.hpp
@@ -31,7 +31,7 @@ struct MixerMetrics {
     float tickWidth() const {
         return thumbHeight * tickWidthMultiplier;
     }
-    float tickHeight() const {
+    static static static static static static float tickHeight() {
         return 1.0f;
     }
     float trackPadding() const {

--- a/magda/daw/ui/views/MainView.cpp
+++ b/magda/daw/ui/views/MainView.cpp
@@ -5,6 +5,7 @@
 #include <cmath>
 #include <ranges>
 #include <set>
+#include <utility>
 
 #include "../components/automation/AutomationMenu.hpp"
 #include "../components/automation/MasterAutomationLanes.hpp"
@@ -2148,7 +2149,7 @@ void MainView::setupSelectionCallbacks() {
             timelineController->dispatch(ClearTimeSelectionEvent{});
         } else {
             timelineController->dispatch(
-                SetTimeSelectionBeatsEvent{startBeats, endBeats, trackIndices});
+                SetTimeSelectionBeatsEvent{startBeats, endBeats, std::move(trackIndices)});
             // Move playhead to follow the left side of selection
             timelineController->dispatch(SetPlayheadPositionBeatsEvent{startBeats});
         }
@@ -2161,7 +2162,7 @@ void MainView::setupSelectionCallbacks() {
                 timelineController->dispatch(ClearTimeSelectionEvent{});
             } else {
                 timelineController->dispatch(SetTimeSelectionBeatsEvent{
-                    startBeats, endBeats, trackIndices, false, std::move(laneIds)});
+                    startBeats, endBeats, std::move(trackIndices), false, std::move(laneIds)});
                 timelineController->dispatch(SetPlayheadPositionBeatsEvent{startBeats});
             }
         };
@@ -2173,7 +2174,7 @@ void MainView::setupSelectionCallbacks() {
                 timelineController->dispatch(ClearTimeSelectionEvent{});
             } else {
                 timelineController->dispatch(SetTimeSelectionBeatsEvent{
-                    startBeats, endBeats, trackIndices, true, std::move(laneIds)});
+                    startBeats, endBeats, std::move(trackIndices), true, std::move(laneIds)});
                 timelineController->dispatch(SetPlayheadPositionBeatsEvent{startBeats});
             }
         };

--- a/magda/daw/ui/views/MainView.cpp
+++ b/magda/daw/ui/views/MainView.cpp
@@ -2400,7 +2400,7 @@ void MainView::SelectionOverlayComponent::drawRecordingRegion(juce::Graphics& g)
     endX = juce::jmin(getWidth(), endX);
 
     int scrollY = owner.trackContentViewport->getViewPositionY();
-    auto& tracks = TrackManager::getInstance().getTracks();
+    const auto& tracks = TrackManager::getInstance().getTracks();
 
     for (int trackIndex = 0; trackIndex < static_cast<int>(tracks.size()); ++trackIndex) {
         if (!tracks[trackIndex].recordArmed) {

--- a/magda/daw/ui/views/MainView.hpp
+++ b/magda/daw/ui/views/MainView.hpp
@@ -430,7 +430,7 @@ class MainView::MasterHeaderPanel : public juce::Component,
   private:
     // Opens the master automation menu (mirrors the per-track automation
     // button). Shared by the icon button and the header right-click.
-    void showMasterAutomationMenu(juce::Component* anchor);
+    static void showMasterAutomationMenu(juce::Component* anchor);
 
     std::unique_ptr<SvgButton> speakerButton;          // Speaker on/off toggle
     std::unique_ptr<SvgButton> automationButton;       // Show master automation lane
@@ -473,7 +473,7 @@ class MainView::AuxHeadersPanel : public juce::Component, public TrackManagerLis
     void tracksChanged() override;
 
     // Metering
-    void updateMetering(AudioEngine* engine);
+    static void updateMetering(AudioEngine* engine);
 
     // Get number of aux tracks
     int getAuxTrackCount() const {

--- a/magda/daw/ui/views/MixerView.cpp
+++ b/magda/daw/ui/views/MixerView.cpp
@@ -956,7 +956,7 @@ void MixerView::ChannelStrip::setupRoutingCallbacks() {
 }
 
 std::vector<MixerView::ChannelStrip::MiniChainRowSignatureEntry>
-MixerView::ChannelStrip::buildMiniChainSignature(const TrackInfo& track) const {
+MixerView::ChannelStrip::buildMiniChainSignature(const TrackInfo& track) {
     std::vector<MiniChainRowSignatureEntry> signature;
     signature.reserve(track.chain.fxChainElements.size());
     for (const auto& element : track.chain.fxChainElements) {
@@ -2286,7 +2286,7 @@ void MixerView::paint(juce::Graphics& g) {
     }
 }
 
-int MixerView::getTopLevelStripWidth(const ChannelStrip& strip) const {
+int MixerView::getTopLevelStripWidth(const ChannelStrip& strip) {
     int width = strip.preferredChannelWidth();
     for (auto* child : strip.groupChildren_) {
         if (auto* childStrip = dynamic_cast<ChannelStrip*>(child))
@@ -2685,7 +2685,7 @@ bool MixerView::keyPressed(const juce::KeyPress& /*key*/) {
     return false;
 }
 
-bool MixerView::isInChannelResizeZone(const juce::Point<int>& /*pos*/) const {
+bool MixerView::isInChannelResizeZone(const juce::Point<int>& /*pos*/) {
     // Not used anymore - resize handle component handles this
     return false;
 }

--- a/magda/daw/ui/views/MixerView.hpp
+++ b/magda/daw/ui/views/MixerView.hpp
@@ -241,8 +241,8 @@ class MixerView : public juce::Component,
 
         std::vector<std::unique_ptr<MiniChainRow>> miniChainRows_;
         std::vector<MiniChainRowSignatureEntry> miniChainSignature_;
-        std::vector<MiniChainRowSignatureEntry> buildMiniChainSignature(
-            const TrackInfo& track) const;
+        static std::vector<MiniChainRowSignatureEntry> buildMiniChainSignature(
+            const TrackInfo& track);
         void syncMiniChainRows(const TrackInfo& track);
         void rebuildMiniChainRows(const TrackInfo& track,
                                   std::vector<MiniChainRowSignatureEntry> signature);
@@ -349,14 +349,14 @@ class MixerView : public juce::Component,
     std::vector<std::unique_ptr<ChannelResizeHandle>> channelResizeHandles_;
     void wireChannelResizeHandle(ChannelResizeHandle& handle);
     void layoutChannelResizeHandles(int containerHeight);
-    int getTopLevelStripWidth(const ChannelStrip& strip) const;
+    static int getTopLevelStripWidth(const ChannelStrip& strip);
     std::vector<TrackId> getLayoutEditTargets(TrackId clickedId, bool allVisible) const;
     void applyChannelWidthDelta(TrackId clickedId, int deltaX, const juce::ModifierKeys& mods);
     void finishChannelWidthResize(const juce::ModifierKeys& mods);
     void resetChannelWidths(TrackId clickedId, const juce::ModifierKeys& mods);
     void commitChannelWidthResize();
-    void executeMixerLayoutCommands(const juce::String& description,
-                                    std::vector<std::unique_ptr<UndoableCommand>> commands);
+    static void executeMixerLayoutCommands(const juce::String& description,
+                                           std::vector<std::unique_ptr<UndoableCommand>> commands);
 
     // Left-edge vertical rail of view-toggle buttons (sends, routing, monitor,
     // mini oscilloscope, mini spectrum, mini FX chain). State persisted via
@@ -368,7 +368,7 @@ class MixerView : public juce::Component,
     void relayoutAllStrips();
     // Ensure every non-master track has (or lacks) the Oscilloscope /
     // Spectrum Analyzer post-FX device to match the mixer rail toggles.
-    void reconcileAnalysisDevices();
+    static void reconcileAnalysisDevices();
     bool isResizeDragging_ = false;
     bool wasPlaying_ = false;  // tracks transport edge to auto-reset peak holds
     bool pendingResizeUpdate_ = false;
@@ -402,7 +402,7 @@ class MixerView : public juce::Component,
     // Audio engine for metering
     AudioEngine* audioEngine_ = nullptr;
 
-    bool isInChannelResizeZone(const juce::Point<int>& pos) const;
+    static bool isInChannelResizeZone(const juce::Point<int>& pos);
 
     // Plugin drag-and-drop state
     bool showPluginDropOverlay_ = false;

--- a/magda/daw/ui/views/SessionView.cpp
+++ b/magda/daw/ui/views/SessionView.cpp
@@ -4062,7 +4062,7 @@ void SessionView::clearDragGhost() {
     }
 }
 
-bool SessionView::isAudioFile(const juce::String& filename) const {
+bool SessionView::isAudioFile(const juce::String& filename) {
     static const juce::StringArray audioExtensions = {".wav",  ".aiff", ".aif", ".mp3", ".ogg",
                                                       ".flac", ".m4a",  ".wma", ".opus"};
 

--- a/magda/daw/ui/views/SessionView.cpp
+++ b/magda/daw/ui/views/SessionView.cpp
@@ -626,7 +626,8 @@ class SessionView::BeatBandContainer : public juce::Component {
 
         const int yCentre = getHeight() / 2;
         // Dot sits in the centre of the column.
-        out.dotCentre = {static_cast<float>(cursor + w / 2), static_cast<float>(yCentre)};
+        out.dotCentre = {static_cast<float>(cursor) + static_cast<float>(w) / 2.0f,
+                         static_cast<float>(yCentre)};
 
         // Icons stacked in the right half, derived from band height.
         constexpr int kGap = 2;

--- a/magda/daw/ui/views/SessionView.hpp
+++ b/magda/daw/ui/views/SessionView.hpp
@@ -245,14 +245,14 @@ class SessionView : public juce::Component,
     void openClipEditor(int trackIndex, int sceneIndex);
     void onCreateMidiClipClicked(int trackIndex, int sceneIndex);
     ClipId duplicateSessionClipToNextEmptyScene(ClipId clipId);
-    bool deleteSelectedSessionClips();
+    static bool deleteSelectedSessionClips();
 
     // View mode state
     ViewMode currentViewMode_ = ViewMode::Live;
     std::vector<TrackId> visibleTrackIds_;
 
     // Selection
-    void selectTrack(TrackId trackId);
+    static void selectTrack(TrackId trackId);
     void updateHeaderSelectionVisuals();
 
     // Clip slot display
@@ -276,7 +276,7 @@ class SessionView : public juce::Component,
     void clearDragHighlight();
     void updateDragGhost(const juce::StringArray& files, int trackIndex, int sceneIndex);
     void clearDragGhost();
-    bool isAudioFile(const juce::String& filename) const;
+    static bool isAudioFile(const juce::String& filename);
 
     // The media browser delivers sample drags as an internal {type:"files"}
     // payload rather than an OS file-drag on Linux, where JUCE has no Wayland

--- a/magda/daw/ui/windows/MainWindow.cpp
+++ b/magda/daw/ui/windows/MainWindow.cpp
@@ -268,7 +268,7 @@ MainWindow::MainWindow(AudioEngine* audioEngine)
     juce::Logger::writeToLog("[MainWindow] Menu bar ready");
 
     // Size and position the window within the display's work area
-    auto display = juce::Desktop::getInstance().getDisplays().getPrimaryDisplay();
+    const auto* display = juce::Desktop::getInstance().getDisplays().getPrimaryDisplay();
     if (display != nullptr) {
         auto workArea = display->userArea;  // Excludes taskbar
         // Leave some margin so the title bar and window frame are fully visible
@@ -604,7 +604,7 @@ MainWindow::MainComponent::MainComponent(AudioEngine* externalEngine) {
     transportHeight = layout.defaultTransportHeight;
 
     // Scale side panel defaults based on screen width
-    if (auto* display = juce::Desktop::getInstance().getDisplays().getPrimaryDisplay()) {
+    if (const auto* display = juce::Desktop::getInstance().getDisplays().getPrimaryDisplay()) {
         int screenWidth = display->userArea.getWidth();
         if (screenWidth >= 2560) {  // Large display (1440p+)
             leftPanelWidth = rightPanelWidth = 400;
@@ -1231,7 +1231,7 @@ void MainWindow::MainComponent::setupAudioEngineCallbacks(AudioEngine* engine) {
         mainView->getTimelineController().dispatch(SetEditPositionEvent{0.0});
     };
     transportPanel->onGoToNext = [this]() {
-        auto& state = mainView->getTimelineController().getState();
+        const auto& state = mainView->getTimelineController().getState();
         mainView->getTimelineController().dispatch(SetEditPositionEvent{state.timelineLength});
     };
     transportPanel->onPlayheadEdit = [this](double beats) {

--- a/magda/daw/ui/windows/MainWindow.hpp
+++ b/magda/daw/ui/windows/MainWindow.hpp
@@ -83,7 +83,7 @@ class MainWindow : public juce::DocumentWindow,
     // Re-applies the active palette to every shared LookAndFeel and broadcasts
     // a look-and-feel change to all top-level windows. Shared by the config
     // switch and hot-reload.
-    void refreshThemedLookAndFeels();
+    static void refreshThemedLookAndFeels();
     // Hot-reload callback: the active user theme file changed on disk.
     void onActiveThemeFileChanged();
     class MainComponent;
@@ -111,8 +111,8 @@ class MainWindow : public juce::DocumentWindow,
     // The actual chooser + render flow, after performExport's pre-checks pass.
     void launchAudioExport(const ExportAudioDialog::Settings& settings, AudioEngine* engine);
     void performMidiExport(const ExportMidiDialog::Settings& settings);
-    juce::String getFileExtensionForFormat(const juce::String& format) const;
-    int getBitDepthForFormat(const juce::String& format) const;
+    static juce::String getFileExtensionForFormat(const juce::String& format);
+    static int getBitDepthForFormat(const juce::String& format);
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(MainWindow)
 };

--- a/magda/daw/ui/windows/MainWindowCommands.cpp
+++ b/magda/daw/ui/windows/MainWindowCommands.cpp
@@ -1453,6 +1453,7 @@ bool MainWindow::MainComponent::perform(const InvocationInfo& info) {
                 const auto* clip = clipManager.getClip(clipId);
                 if (clip && clip->isMidi()) {
                     std::vector<size_t> allIndices;
+                    allIndices.reserve(clip->midiNotes.size());
                     for (size_t i = 0; i < clip->midiNotes.size(); ++i)
                         allIndices.push_back(i);
                     selectionManager.selectNotes(clipId, allIndices);

--- a/magda/daw/ui/windows/MainWindowExport.cpp
+++ b/magda/daw/ui/windows/MainWindowExport.cpp
@@ -1,5 +1,7 @@
 #include <juce_audio_basics/juce_audio_basics.h>
 
+#include <utility>
+
 #include "../dialogs/ExportAudioDialog.hpp"
 #include "../dialogs/ExportMidiDialog.hpp"
 #include "MainWindow.hpp"
@@ -36,13 +38,13 @@ double timelineEndBeats(const ClipInfo& clip, double bpm) {
 class ExportProgressWindow : public juce::ThreadWithProgressWindow {
   public:
     ExportProgressWindow(std::unique_ptr<OfflineRenderSession> renderSession,
-                         const OfflineRenderRequest& request, const juce::File& outputFile,
+                         const OfflineRenderRequest& request, juce::File outputFile,
                          std::function<void()> onComplete, double prerollSeconds = 0.0,
                          double leadInSilence = 0.0)
         : ThreadWithProgressWindow(trEllipsis("export.progress.exporting_audio"), true, true),
           renderSession_(std::move(renderSession)),
           renderTask_(renderSession_ ? renderSession_->createTask(request) : nullptr),
-          outputFile_(outputFile),
+          outputFile_(std::move(outputFile)),
           onComplete_(std::move(onComplete)),
           prerollSeconds_(prerollSeconds),
           leadInSilence_(leadInSilence),

--- a/magda/daw/ui/windows/MainWindowExport.cpp
+++ b/magda/daw/ui/windows/MainWindowExport.cpp
@@ -437,7 +437,7 @@ void MainWindow::launchAudioExport(const ExportAudioDialog::Settings& settings,
         });
 }
 
-juce::String MainWindow::getFileExtensionForFormat(const juce::String& format) const {
+juce::String MainWindow::getFileExtensionForFormat(const juce::String& format) {
     if (format.startsWith("WAV"))
         return ".wav";
     else if (format == "FLAC")
@@ -445,7 +445,7 @@ juce::String MainWindow::getFileExtensionForFormat(const juce::String& format) c
     return ".wav";  // Default
 }
 
-int MainWindow::getBitDepthForFormat(const juce::String& format) const {
+int MainWindow::getBitDepthForFormat(const juce::String& format) {
     if (format == "WAV16")
         return 16;
     if (format == "WAV24")

--- a/magda/engine/clip/ActiveNoteList.hpp
+++ b/magda/engine/clip/ActiveNoteList.hpp
@@ -79,6 +79,8 @@ class ActiveNoteList {
     };
 
     static std::size_t index(int channel, int note) {
+        // NOLINTNEXTLINE(bugprone-misplaced-widening-cast) - channel 1-16 and note 0-127 cannot
+        // overflow int
         return static_cast<std::size_t>((channel - 1) * kNotes + note);
     }
 

--- a/magda/engine/clip/ClipMidiSource.hpp
+++ b/magda/engine/clip/ClipMidiSource.hpp
@@ -170,6 +170,8 @@ class ClipMidiSource final : public EngineMidiSource {
 
       private:
         static std::size_t index(int channel, int note) {
+            // NOLINTNEXTLINE(bugprone-misplaced-widening-cast) - channel 1-16 and note 0-127 cannot
+            // overflow int
             return static_cast<std::size_t>(((channel - 1) * ActiveNoteList::kNotes) + note);
         }
 

--- a/magda/engine/clip/ClipVoice.cpp
+++ b/magda/engine/clip/ClipVoice.cpp
@@ -166,7 +166,7 @@ bool ClipVoice::renderThroughCells(const AudioClipPlayback& clip, const AudioEve
 
 void ClipVoice::applyFade(juce::dsp::AudioBlock<float> region, EdgeSample regionFirstSample,
                           const BlockInfo& block, double startSeconds, double endSeconds,
-                          FadeCurve curve, bool rising) const {
+                          FadeCurve curve, bool rising) {
     const auto length = endSeconds - startSeconds;
     if (!(length > 0.0) || block.numSamples <= 0)
         return;

--- a/magda/engine/clip/ClipVoice.hpp
+++ b/magda/engine/clip/ClipVoice.hpp
@@ -144,9 +144,9 @@ class ClipVoice {
 
     /// Multiply the part of @p region inside [@p startSeconds, @p endSeconds)
     /// by a curve running across it, rising or falling.
-    void applyFade(juce::dsp::AudioBlock<float> region, EdgeSample regionFirstSample,
-                   const BlockInfo& block, double startSeconds, double endSeconds, FadeCurve curve,
-                   bool rising) const;
+    static void applyFade(juce::dsp::AudioBlock<float> region, EdgeSample regionFirstSample,
+                          const BlockInfo& block, double startSeconds, double endSeconds,
+                          FadeCurve curve, bool rising);
 
     /// How much timeline one cell covers. Small enough that a curved rate is
     /// still nearly straight across one, and that is the only thing it has to

--- a/magda/engine/exec/EngineSession.cpp
+++ b/magda/engine/exec/EngineSession.cpp
@@ -74,7 +74,7 @@ EngineSession::Result EngineSession::publish(std::shared_ptr<const RenderPlan> p
     // why. Asked of the executor rather than worked out here, so that the
     // answer cannot differ from the one the block itself will get.
     if (!prepared->executor.appliesValues(prepared->values)) {
-        messages.push_back(
+        messages.emplace_back(
             "the values published with this plan are not values it can render: they were "
             "resolved against a different plan, or against this one before it was whole. "
             "It is not published, because it would have rendered at unity");

--- a/magda/engine/exec/ParallelPlanExecutor.cpp
+++ b/magda/engine/exec/ParallelPlanExecutor.cpp
@@ -75,7 +75,7 @@ std::vector<std::string> ParallelPlanExecutor::prepare(const RenderPlan& plan,
     // constants disagree with its ops did not come from the compiler.
     if (!carriesSchedule(plan)) {
         core_.reset();
-        messages.push_back(
+        messages.emplace_back(
             "plan does not carry the schedule its topology implies: its dependency counts, "
             "consumer edges or initially-ready set are missing or disagree with its ops, so it "
             "cannot be scheduled");

--- a/magda/engine/exec/PlanExecutor.cpp
+++ b/magda/engine/exec/PlanExecutor.cpp
@@ -1422,6 +1422,7 @@ void PlanExecutor::renderOp(OpId id, const OpValue& published, const BlockInfo& 
 
             const int low = op.noteGateLow;
             const int high = op.noteGateHigh;
+            // NOLINTNEXTLINE(bugprone-signed-char-misuse) - the sign carries a downward transpose
             const int transpose = op.noteGateTranspose;
 
             for (const auto metadata : midiIn(op.inputs[0])) {

--- a/magda/engine/exec/PlanExecutor.hpp
+++ b/magda/engine/exec/PlanExecutor.hpp
@@ -490,6 +490,8 @@ class PlanExecutor {
     /// Where an op's output port keeps its buffer. Ports are flattened in
     /// op order so a PortRef resolves with two array reads and no branching.
     int slotFor(const PortRef& ref) const {
+        // NOLINTNEXTLINE(bugprone-misplaced-widening-cast) - port offsets are bounded by the plan
+        // size
         return portSlots_[static_cast<std::size_t>(portOffsets_[static_cast<std::size_t>(ref.op)] +
                                                    ref.port)];
     }

--- a/magda/engine/exec/PlanValues.cpp
+++ b/magda/engine/exec/PlanValues.cpp
@@ -130,7 +130,7 @@ class Resolver {
     ///
     /// Pads entered: a pad rack hangs off its device rather than sitting in the
     /// chain, and its chains carry mute, solo and a fader like any other's.
-    const RackInfo* findRack(const TrackInfo& track, RackId rackId) const {
+    static const RackInfo* findRack(const TrackInfo& track, RackId rackId) {
         return chain_walk::findRack(
             track.chain.fxChainElements, ChainNodePath::trackLevel(track.id),
             chain_walk::Pads::Enter,

--- a/magda/engine/io/SourceLoopInfo.cpp
+++ b/magda/engine/io/SourceLoopInfo.cpp
@@ -10,7 +10,7 @@ namespace {
 /// counts as not written: a writer that emitted the key and left it blank said
 /// no more than one that left it out.
 std::optional<juce::String> valueOf(const juce::StringPairArray& metadata, const char* key) {
-    const auto value = metadata[key];
+    const auto& value = metadata[key];
     return value.isNotEmpty() ? std::optional<juce::String>(value) : std::nullopt;
 }
 

--- a/magda/engine/launch/LaunchHandle.cpp
+++ b/magda/engine/launch/LaunchHandle.cpp
@@ -324,7 +324,7 @@ SplitStatus LaunchHandle::advanceOver(const SyncRange& range) {
             eventBeat = range.monotonic.start;
             fromPending = true;
         } else if (*position < range.monotonic.end) {
-            eventBeat = *position;
+            eventBeat = position;
             fromPending = true;
         }
 

--- a/magda/engine/launch/SessionLauncher.cpp
+++ b/magda/engine/launch/SessionLauncher.cpp
@@ -133,10 +133,10 @@ void applyDueFollowActions(const LaunchHandleTable& table, const SyncRange& rang
         // the user's outranks this one.
         const auto spokenFor = target != nullptr && target->queuedState().has_value();
 
-        entry.handle->stop(*due);
+        entry.handle->stop(due);
 
         if (target != nullptr && !spokenFor)
-            target->play(*due);
+            target->play(due);
     }
 }
 

--- a/magda/engine/param/ModRuntime.cpp
+++ b/magda/engine/param/ModRuntime.cpp
@@ -218,14 +218,14 @@ std::span<const int> ModRuntime::listenersOf(magda::TrackId track) const {
     return std::span<const int>{listeners_}.subspan(first, last - first);
 }
 
-bool ModRuntime::drivenFromElsewhere(int index, const ParamTable& table) const {
+bool ModRuntime::drivenFromElsewhere(int index, const ParamTable& table) {
     if (index < 0 || index >= static_cast<int>(table.modifiers.size()))
         return false;
 
     return isDrivenFromElsewhere(table.modifiers[static_cast<std::size_t>(index)]);
 }
 
-ModListen ModRuntime::listensFor(int index, const ParamTable& table) const {
+ModListen ModRuntime::listensFor(int index, const ParamTable& table) {
     if (index < 0 || index >= static_cast<int>(table.modifiers.size()))
         return ModListen::Nothing;
 

--- a/magda/engine/param/ModRuntime.hpp
+++ b/magda/engine/param/ModRuntime.hpp
@@ -150,7 +150,7 @@ class ModRuntime {
     /// note-waiting modifiers and a level reaches level-waiting ones. One
     /// listener list per track plus this to sort them, rather than three
     /// lists that could disagree about who is on which.
-    ModListen listensFor(int index, const ParamTable& table) const;
+    static ModListen listensFor(int index, const ParamTable& table);
 
     /**
      * @brief Whether modifier @p index is driven by a track other than its own.
@@ -163,7 +163,7 @@ class ModRuntime {
      * fires triggerSidechain and ignores note-off). Exposed because the
      * executor holds the tap and cannot otherwise tell the two apart.
      */
-    bool drivenFromElsewhere(int index, const ParamTable& table) const;
+    static bool drivenFromElsewhere(int index, const ParamTable& table);
 
     /// What modifier @p index published this block, or the model's own
     /// value for one nothing has advanced.

--- a/magda/engine/param/ParamTableCompiler.cpp
+++ b/magda/engine/param/ParamTableCompiler.cpp
@@ -830,7 +830,7 @@ std::vector<int> stronglyConnectedComponents(const std::vector<std::vector<int>>
         if (index[root] >= 0)
             continue;
 
-        work.push_back({root, 0});
+        work.emplace_back(root, 0);
         while (!work.empty()) {
             auto& [node, edge] = work.back();
 
@@ -847,7 +847,7 @@ std::vector<int> stronglyConnectedComponents(const std::vector<std::vector<int>>
                 ++edge;
 
                 if (index[next] < 0) {
-                    work.push_back({next, 0});
+                    work.emplace_back(next, 0);
                 } else if (onStack[next] != 0) {
                     lowlink[node] = std::min(lowlink[node], index[next]);
                 }

--- a/magda/engine/param/ParamTableDump.cpp
+++ b/magda/engine/param/ParamTableDump.cpp
@@ -138,7 +138,7 @@ std::string dumpParamTable(const ParamTable& table) {
 
         for (const auto& link : links) {
             std::ostringstream detail;
-            const auto source =
+            const auto* const source =
                 link.source.kind == ParamSourceRef::Kind::Parameter ? "param" : "mod";
             detail << "      <- " << source << "[" << rightAligned(link.source.index, 3) << "]"
                    << " amount=" << number(link.amount) << " bipolar=" << (link.bipolar ? 1 : 0);

--- a/magda/engine/plan/PlanCompiler.cpp
+++ b/magda/engine/plan/PlanCompiler.cpp
@@ -805,7 +805,7 @@ ChainSignal Compiler::emitDevice(const DeviceInfo& device, const ChainSite& site
     std::vector<PortDesc> outputs{
         PortDesc{SignalKind::Audio, static_cast<std::uint8_t>(outputWidth)}};
     if (producesMidi)
-        outputs.push_back(SignalKind::Midi);
+        outputs.emplace_back(SignalKind::Midi);
 
     // The further pairs are ports on the same op, after the main audio and any
     // MIDI. They carry the device's raw output: the slot's gain trim and meter
@@ -815,8 +815,8 @@ ChainSignal Compiler::emitDevice(const DeviceInfo& device, const ChainSite& site
     const auto firstMultiOutPort = static_cast<int>(outputs.size());
     for (int pair = 0; pair < multiOutPairCount; ++pair) {
         const auto& declared = device.multiOut.outputPairs[static_cast<std::size_t>(pair) + 1];
-        outputs.push_back(
-            {SignalKind::Audio, static_cast<std::uint8_t>(std::clamp(declared.numChannels, 0, 2))});
+        outputs.emplace_back(SignalKind::Audio,
+                             static_cast<std::uint8_t>(std::clamp(declared.numChannels, 0, 2)));
     }
 
     // Only a device that reads the bus is connected to it.
@@ -1007,7 +1007,7 @@ ChainSignal Compiler::emitRack(const RackInfo& rack, const ChainSite& site, Chai
                              OpRole::RackChainFader, 0,       site.segment};
         std::vector<PortDesc> faderOutputs{SignalKind::Audio};
         if (generatesMidi)
-            faderOutputs.push_back(SignalKind::Midi);
+            faderOutputs.emplace_back(SignalKind::Midi);
 
         const auto faderOp =
             addOp(OpKind::Fader, faderKey,

--- a/magda/engine/plan/PlanCompiler.cpp
+++ b/magda/engine/plan/PlanCompiler.cpp
@@ -197,7 +197,7 @@ class Compiler {
     TrackRoute activeMidiInputRoute(const TrackInfo& track) const;
 
     /// The track this track's audio output feeds; the master by default.
-    TrackId resolveAudioDestination(const TrackInfo& track) const;
+    static TrackId resolveAudioDestination(const TrackInfo& track);
 
     void emitTrack(const TrackInfo& track);
 
@@ -385,7 +385,7 @@ TrackRoute Compiler::activeMidiInputRoute(const TrackInfo& track) const {
     return parseTrackRoute(track.midiInputDevice);
 }
 
-TrackId Compiler::resolveAudioDestination(const TrackInfo& track) const {
+TrackId Compiler::resolveAudioDestination(const TrackInfo& track) {
     const auto route = parseTrackRoute(track.audioOutputDevice);
     return route.namesTrack() ? route.trackId : MASTER_TRACK_ID;
 }

--- a/magda/mcp_bridge/main.cpp
+++ b/magda/mcp_bridge/main.cpp
@@ -267,7 +267,7 @@ class Bridge {
     }
 
     void forward(const juce::var& message) {
-        const auto id = message["id"];
+        const auto& id = message["id"];
         const auto method = message["method"].toString();
         const auto body = juce::JSON::toString(message, true).toStdString();
 

--- a/magda/scripting/LuaController.cpp
+++ b/magda/scripting/LuaController.cpp
@@ -97,7 +97,7 @@ void pushMidiEvent(lua_State* L, const juce::String& deviceName, const juce::Mid
         lua_setfield(L, -2, "bytes");
     }
 
-    auto raw = deviceName.toRawUTF8();
+    const auto* raw = deviceName.toRawUTF8();
     lua_pushlstring(L, raw, static_cast<size_t>(deviceName.getNumBytesAsUTF8()));
     lua_setfield(L, -2, "port");
 }

--- a/magda/scripting/LuaRuntime.cpp
+++ b/magda/scripting/LuaRuntime.cpp
@@ -106,8 +106,8 @@ bool LuaRuntime::eval(const juce::String& chunk, const juce::String& chunkName) 
         return false;
 
     lastError_ = {};
-    auto chunkUtf8 = chunk.toRawUTF8();
-    auto nameUtf8 = chunkName.toRawUTF8();
+    const auto* chunkUtf8 = chunk.toRawUTF8();
+    const auto* nameUtf8 = chunkName.toRawUTF8();
     auto chunkLen = static_cast<std::size_t>(chunk.getNumBytesAsUTF8());
 
     int rc = luaL_loadbuffer(L_, chunkUtf8, chunkLen, nameUtf8);
@@ -141,7 +141,7 @@ std::optional<long long> LuaRuntime::evalToInt(const juce::String& chunk) {
     juce::String wrapped = "return (" + chunk + ")";
     lastError_ = {};
 
-    auto src = wrapped.toRawUTF8();
+    const auto* src = wrapped.toRawUTF8();
     auto srcLen = static_cast<std::size_t>(wrapped.getNumBytesAsUTF8());
     if (luaL_loadbuffer(L_, src, srcLen, "=eval") != LUA_OK) {
         size_t len = 0;
@@ -183,7 +183,7 @@ std::optional<juce::String> LuaRuntime::evalToString(const juce::String& chunk) 
     juce::String wrapped = "return (" + chunk + ")";
     lastError_ = {};
 
-    auto src = wrapped.toRawUTF8();
+    const auto* src = wrapped.toRawUTF8();
     auto srcLen = static_cast<std::size_t>(wrapped.getNumBytesAsUTF8());
     if (luaL_loadbuffer(L_, src, srcLen, "=eval") != LUA_OK) {
         size_t len = 0;

--- a/magda/scripting/LuaScriptStore.cpp
+++ b/magda/scripting/LuaScriptStore.cpp
@@ -1,6 +1,7 @@
 #include "magda/scripting/LuaScriptStore.hpp"
 
 #include <algorithm>
+#include <utility>
 
 #include "magda/daw/core/AppPaths.hpp"
 
@@ -8,7 +9,7 @@ namespace magda::scripting {
 
 LuaScriptStore::LuaScriptStore() : root_(magda::paths::controllerScriptsDir()) {}
 
-LuaScriptStore::LuaScriptStore(const juce::File& root) : root_(root) {}
+LuaScriptStore::LuaScriptStore(juce::File root) : root_(std::move(root)) {}
 
 bool LuaScriptStore::ensureExists() const {
     if (root_.exists())

--- a/magda/scripting/LuaScriptStore.hpp
+++ b/magda/scripting/LuaScriptStore.hpp
@@ -27,7 +27,7 @@ class LuaScriptStore {
     LuaScriptStore();
 
     /** Test seam: redirect to a custom directory. */
-    explicit LuaScriptStore(const juce::File& root);
+    explicit LuaScriptStore(juce::File root);
 
     /** Filesystem root the store enumerates. Created on demand by ensureExists(). */
     const juce::File& root() const noexcept {

--- a/magda/scripting/MagdaApiLuaBindings.cpp
+++ b/magda/scripting/MagdaApiLuaBindings.cpp
@@ -55,7 +55,7 @@ MagdaApi* getApi(lua_State* L) {
 
 // Push a `juce::String` as a Lua string (UTF-8).
 void pushJuceString(lua_State* L, const juce::String& s) {
-    auto raw = s.toRawUTF8();
+    const auto* raw = s.toRawUTF8();
     lua_pushlstring(L, raw, static_cast<size_t>(s.getNumBytesAsUTF8()));
 }
 


### PR DESCRIPTION
Turns clang-tidy into something that can be run and acted on, then clears
everything it found that is mechanical.

**Config.** `Checks: *` meant every LLVM upgrade added checks unasked and the
noise buried the findings, so it is an allow-list now. Scope is `magda/` only:
`bugprone-chained-comparison` fired 311 times in tests, every one of them
Catch2's `REQUIRE(a == b)` decomposing to `Decomposer() <= a == b`. The header
filter was unanchored, so `tests` matched `third_party/JUCE/.../unit_tests/*.h`
while `magda/engine` was never covered at all. The lint targets only ever
walked `magda/daw`, silently skipping engine, agents and scripting.

Eight checks are off, 237 sites, with the reason recorded against each in
`.clang-tidy` - Faust `.generated.cpp` includes, ignored `fprintf` returns,
`drawVerticalLine(int, float, float)` which is JUCE's real signature, and
`use-internal-linkage`, whose fix does not link: it reads one translation unit,
so a definition whose declaring header that `.cpp` does not include looks
file-local, and marking those static left every cross-TU caller undefined.

**Defects fixed.** Three use-after-move bugs that changed behaviour: a
transcription completion callback that never fired, an error caveat shown on
failed runs, and a layout branch that was always taken. Plus integer divisions
truncating sub-pixel offsets, `static_cast<int>(x + 0.5)` roundings that are
wrong for negatives, redundant optional unwrapping, dead branches whose then
and else were identical, and `string_view::data()` conversions that assumed a
NUL the type does not promise.

**Mechanical.** Qualified `auto` on pointers, member functions made static
where they touch no member, in-place construction, and by-reference parameters.

Three fixer suggestions are deliberately not taken and are explained in their
commits - a signature whose address is stored in a function-pointer field, and
two loop copies whose bodies mutate the element.

https://claude.ai/code/session_01VomqgBSXsWYdyHyec9DvPi