### PR TITLE
Qualify auto on pointers and const-bind read-only references

### DIFF
--- a/magda/agents/automation_executor.cpp
+++ b/magda/agents/automation_executor.cpp
@@ -377,7 +377,7 @@ bool AutomationExecutor::execute(const std::vector<AutoInstruction>& instruction
         }
 
         if (std::holds_alternative<AutoClearOp>(inst.payload)) {
-            auto& op = std::get<AutoClearOp>(inst.payload);
+            const auto& op = std::get<AutoClearOp>(inst.payload);
             auto laneId = resolveTarget(api_, op.target, err);
             if (laneId == INVALID_AUTOMATION_LANE_ID) {
                 error_ = std::move(err);
@@ -389,7 +389,7 @@ bool AutomationExecutor::execute(const std::vector<AutoInstruction>& instruction
         }
 
         if (std::holds_alternative<AutoFreeformOp>(inst.payload)) {
-            auto& op = std::get<AutoFreeformOp>(inst.payload);
+            const auto& op = std::get<AutoFreeformOp>(inst.payload);
             auto laneId = resolveTarget(api_, op.target, err);
             if (laneId == INVALID_AUTOMATION_LANE_ID) {
                 error_ = std::move(err);
@@ -404,7 +404,7 @@ bool AutomationExecutor::execute(const std::vector<AutoInstruction>& instruction
         }
 
         if (std::holds_alternative<AutoShapeOp>(inst.payload)) {
-            auto& op = std::get<AutoShapeOp>(inst.payload);
+            const auto& op = std::get<AutoShapeOp>(inst.payload);
             auto laneId = resolveTarget(api_, op.target, err);
             if (laneId == INVALID_AUTOMATION_LANE_ID) {
                 error_ = std::move(err);

--- a/magda/agents/instruction_executor.cpp
+++ b/magda/agents/instruction_executor.cpp
@@ -250,7 +250,7 @@ bool InstructionExecutor::execute(const std::vector<Instruction>& instructions) 
     }
 
     // Multi-clip selection → populate selectedClips_ so SET/DEL apply to all
-    auto& uiClips = sm.getSelectedClips();
+    const auto& uiClips = sm.getSelectedClips();
     if (!uiClips.empty()) {
         selectedClips_.insert(uiClips.begin(), uiClips.end());
         // Derive track from first clip if no track selected

--- a/magda/daw/api/remote_api.cpp
+++ b/magda/daw/api/remote_api.cpp
@@ -102,7 +102,7 @@ juce::var emptyObjectSchema() {
 }
 
 juce::var arraySchema(const juce::var& itemSchema) {
-    auto schema = new juce::DynamicObject();
+    auto* schema = new juce::DynamicObject();
     schema->setProperty("type", "array");
     schema->setProperty("items", itemSchema);
     return schema;
@@ -890,12 +890,12 @@ juce::String toString(ErrorCode code) {
 }
 
 juce::var toJson(const Error& error) {
-    auto object = new juce::DynamicObject();
+    auto* object = new juce::DynamicObject();
     object->setProperty("code", toString(error.code));
     object->setProperty("message", error.message);
     juce::Array<juce::var> issues;
     for (const auto& issue : error.issues) {
-        auto issueObject = new juce::DynamicObject();
+        auto* issueObject = new juce::DynamicObject();
         issueObject->setProperty("path", issue.path);
         issueObject->setProperty("code", issue.code);
         issueObject->setProperty("message", issue.message);
@@ -906,7 +906,7 @@ juce::var toJson(const Error& error) {
 }
 
 juce::var successEnvelope(const juce::var& result) {
-    auto object = new juce::DynamicObject();
+    auto* object = new juce::DynamicObject();
     object->setProperty("ok", true);
     object->setProperty("apiVersion", juce::String(API_VERSION.data(), API_VERSION.size()));
     object->setProperty("result", result);
@@ -914,7 +914,7 @@ juce::var successEnvelope(const juce::var& result) {
 }
 
 juce::var errorEnvelope(const Error& error) {
-    auto object = new juce::DynamicObject();
+    auto* object = new juce::DynamicObject();
     object->setProperty("ok", false);
     object->setProperty("apiVersion", juce::String(API_VERSION.data(), API_VERSION.size()));
     object->setProperty("error", toJson(error));
@@ -969,7 +969,7 @@ std::optional<Error> validateOperationInput(const OperationDescriptor& operation
 }
 
 juce::var toJson(const MidiNoteDto& dto) {
-    auto object = new juce::DynamicObject();
+    auto* object = new juce::DynamicObject();
     object->setProperty("note", dto.note);
     object->setProperty("velocity", dto.velocity);
     object->setProperty("startBeat", dto.startBeat);
@@ -978,7 +978,7 @@ juce::var toJson(const MidiNoteDto& dto) {
 }
 
 juce::var toJson(const ProjectDto& dto) {
-    auto object = new juce::DynamicObject();
+    auto* object = new juce::DynamicObject();
     object->setProperty("name", dto.name);
     object->setProperty("tempo", dto.tempo);
     object->setProperty("timeSignatureNumerator", dto.timeSignatureNumerator);
@@ -994,7 +994,7 @@ juce::var toJson(const ProjectDto& dto) {
 }
 
 juce::var toJson(const TrackDto& dto) {
-    auto object = new juce::DynamicObject();
+    auto* object = new juce::DynamicObject();
     object->setProperty("id", dto.id);
     object->setProperty("type", dto.type);
     object->setProperty("name", dto.name);
@@ -1015,7 +1015,7 @@ juce::var toJson(const TrackDto& dto) {
 }
 
 juce::var toJson(const ClipDto& dto) {
-    auto object = new juce::DynamicObject();
+    auto* object = new juce::DynamicObject();
     object->setProperty("id", dto.id);
     object->setProperty("trackId", dto.trackId);
     object->setProperty("type", dto.type);
@@ -1037,7 +1037,7 @@ juce::var toJson(const ClipDto& dto) {
 }
 
 juce::var toJson(const DeviceDto& dto) {
-    auto object = new juce::DynamicObject();
+    auto* object = new juce::DynamicObject();
     object->setProperty("id", dto.id);
     object->setProperty("trackId", dto.trackId);
     object->setProperty("rackId", nullableId(dto.rackId));
@@ -1053,7 +1053,7 @@ juce::var toJson(const DeviceDto& dto) {
 }
 
 juce::var toJson(const ChainDto& dto) {
-    auto object = new juce::DynamicObject();
+    auto* object = new juce::DynamicObject();
     object->setProperty("id", dto.id);
     object->setProperty("rackId", dto.rackId);
     object->setProperty("name", dto.name);
@@ -1069,7 +1069,7 @@ juce::var toJson(const ChainDto& dto) {
 }
 
 juce::var toJson(const RackDto& dto) {
-    auto object = new juce::DynamicObject();
+    auto* object = new juce::DynamicObject();
     object->setProperty("id", dto.id);
     object->setProperty("trackId", dto.trackId);
     object->setProperty("parentRackId", nullableId(dto.parentRackId));
@@ -1083,7 +1083,7 @@ juce::var toJson(const RackDto& dto) {
 }
 
 juce::var toJson(const DeviceGraphDto& dto) {
-    auto object = new juce::DynamicObject();
+    auto* object = new juce::DynamicObject();
     juce::Array<juce::var> devices;
     juce::Array<juce::var> racks;
     juce::Array<juce::var> chains;
@@ -1100,7 +1100,7 @@ juce::var toJson(const DeviceGraphDto& dto) {
 }
 
 juce::var toJson(const DeviceCatalogEntryDto& dto) {
-    auto object = new juce::DynamicObject();
+    auto* object = new juce::DynamicObject();
     object->setProperty("catalogId", dto.catalogId);
     object->setProperty("name", dto.name);
     object->setProperty("manufacturer", dto.manufacturer);
@@ -1113,7 +1113,7 @@ juce::var toJson(const DeviceCatalogEntryDto& dto) {
 }
 
 juce::var toJson(const DeviceParameterDto& dto) {
-    auto object = new juce::DynamicObject();
+    auto* object = new juce::DynamicObject();
     object->setProperty("index", dto.index);
     object->setProperty("stableId", dto.stableId);
     object->setProperty("name", dto.name);
@@ -1135,7 +1135,7 @@ juce::var toJson(const DeviceParameterDto& dto) {
 }
 
 juce::var toJson(const SelectionDto& dto) {
-    auto object = new juce::DynamicObject();
+    auto* object = new juce::DynamicObject();
     object->setProperty("trackId", nullableId(dto.trackId));
     object->setProperty("clipId", nullableId(dto.clipId));
     object->setProperty("clipIds", integerArray(dto.clipIds));
@@ -1147,7 +1147,7 @@ juce::var toJson(const SelectionDto& dto) {
 }
 
 juce::var toJson(const TransportDto& dto) {
-    auto object = new juce::DynamicObject();
+    auto* object = new juce::DynamicObject();
     object->setProperty("playing", dto.playing);
     object->setProperty("recording", dto.recording);
     object->setProperty("loopEnabled", dto.loopEnabled);
@@ -1156,7 +1156,7 @@ juce::var toJson(const TransportDto& dto) {
 }
 
 juce::var toJson(const SessionSlotDto& dto) {
-    auto object = new juce::DynamicObject();
+    auto* object = new juce::DynamicObject();
     object->setProperty("trackId", dto.trackId);
     object->setProperty("sceneIndex", dto.sceneIndex);
     object->setProperty("clipId", dto.clipId);
@@ -1165,7 +1165,7 @@ juce::var toJson(const SessionSlotDto& dto) {
 }
 
 juce::var toJson(const SessionDto& dto) {
-    auto object = new juce::DynamicObject();
+    auto* object = new juce::DynamicObject();
     juce::Array<juce::var> slots;
     for (const auto& slot : dto.slots)
         slots.add(toJson(slot));
@@ -1174,7 +1174,7 @@ juce::var toJson(const SessionDto& dto) {
 }
 
 juce::var toJson(const AutomationPointDto& dto) {
-    auto object = new juce::DynamicObject();
+    auto* object = new juce::DynamicObject();
     object->setProperty("id", dto.id);
     object->setProperty("beatPosition", dto.beatPosition);
     object->setProperty("value", dto.value);
@@ -1183,7 +1183,7 @@ juce::var toJson(const AutomationPointDto& dto) {
 }
 
 juce::var toJson(const DevicePathDto& dto) {
-    auto object = new juce::DynamicObject();
+    auto* object = new juce::DynamicObject();
     object->setProperty("trackId", dto.trackId);
     object->setProperty("section", dto.section);
     object->setProperty("trackLevel", dto.trackLevel);
@@ -1201,7 +1201,7 @@ juce::var toJson(const DevicePathDto& dto) {
 }
 
 juce::var toJson(const AutomationTargetDto& dto) {
-    auto object = new juce::DynamicObject();
+    auto* object = new juce::DynamicObject();
     object->setProperty("kind", dto.kind);
     object->setProperty("devicePath",
                         dto.devicePath.has_value() ? toJson(*dto.devicePath) : juce::var());
@@ -1213,7 +1213,7 @@ juce::var toJson(const AutomationTargetDto& dto) {
 }
 
 juce::var toJson(const AutomationLaneDto& dto) {
-    auto object = new juce::DynamicObject();
+    auto* object = new juce::DynamicObject();
     object->setProperty("id", dto.id);
     object->setProperty("type", dto.type);
     object->setProperty("name", dto.name);
@@ -2215,11 +2215,11 @@ const OperationDescriptor* OperationRegistry::find(const juce::String& name) con
 }
 
 juce::var OperationRegistry::describe() const {
-    auto result = new juce::DynamicObject();
+    auto* result = new juce::DynamicObject();
     result->setProperty("apiVersion", juce::String(API_VERSION.data(), API_VERSION.size()));
     juce::Array<juce::var> operations;
     for (const auto& operation : operations_) {
-        auto object = new juce::DynamicObject();
+        auto* object = new juce::DynamicObject();
         object->setProperty("name", operation.name);
         object->setProperty("summary", operation.summary);
         object->setProperty("access", operation.access == OperationAccess::Read ? "read" : "write");

--- a/magda/daw/api/remote_mcp_server.cpp
+++ b/magda/daw/api/remote_mcp_server.cpp
@@ -765,7 +765,7 @@ struct RemoteMcpServer::Impl {
         response.set_header("X-Accel-Buffering", "no");
 
         const auto keepAlive = std::chrono::milliseconds(options.keepAliveIntervalMs);
-        auto self = this;
+        auto* self = this;
 
         response.set_chunked_content_provider(
             "text/event-stream",

--- a/magda/daw/audio/AudioBridge.cpp
+++ b/magda/daw/audio/AudioBridge.cpp
@@ -1619,7 +1619,7 @@ void AudioBridge::ensureSessionMonitorPlugin() {
     auto& masterList = edit_.getMasterPluginList();
 
     // Check if a SessionMonitorPlugin already exists
-    for (auto i : masterList) {
+    for (auto* i : masterList) {
         if (auto* existing = dynamic_cast<SessionMonitorPlugin*>(i)) {
             sessionMonitorPlugin_ = existing;
             sessionMonitorPlugin_->setSessionContext(&sessionAudioMonitor_);
@@ -1633,7 +1633,7 @@ void AudioBridge::ensureSessionMonitorPlugin() {
     masterList.insertPlugin(pluginState, 0);
 
     // Find the newly created plugin
-    for (auto i : masterList) {
+    for (auto* i : masterList) {
         if (auto* mon = dynamic_cast<SessionMonitorPlugin*>(i)) {
             sessionMonitorPlugin_ = mon;
             sessionMonitorPlugin_->setSessionContext(&sessionAudioMonitor_);

--- a/magda/daw/audio/AudioDriverUtils.hpp
+++ b/magda/daw/audio/AudioDriverUtils.hpp
@@ -20,7 +20,7 @@ inline juce::AudioIODeviceType* activeDeviceTypeFor(juce::AudioDeviceManager& de
     if (auto* current = deviceManager.getCurrentDeviceTypeObject())
         return current;
 
-    auto& types = deviceManager.getAvailableDeviceTypes();
+    const auto& types = deviceManager.getAvailableDeviceTypes();
     return types.isEmpty() ? nullptr : types.getFirst();
 }
 

--- a/magda/daw/audio/ClipCommands.cpp
+++ b/magda/daw/audio/ClipCommands.cpp
@@ -126,7 +126,7 @@ class RenderProgressWindow : public juce::ThreadWithProgressWindow {
 // return set — its hardware return only exists live, so an offline bounce
 // needs the real-time capture pass first (#1623).
 bool trackNeedsInsertCapture(te::Track& track) {
-    for (auto plugin : track.pluginList) {
+    for (auto* plugin : track.pluginList) {
         if (auto* insert = dynamic_cast<te::InsertPlugin*>(plugin))
             if (insert->isEnabled() && insert->outputDevice.get().isNotEmpty() &&
                 insert->inputDevice.get().isNotEmpty())
@@ -456,12 +456,12 @@ void MoveClipCommand::undo() {
 }
 
 bool MoveClipCommand::canMergeWith(const UndoableCommand* other) const {
-    auto* otherMove = dynamic_cast<const MoveClipCommand*>(other);
+    const auto* otherMove = dynamic_cast<const MoveClipCommand*>(other);
     return otherMove != nullptr && otherMove->clipId_ == clipId_;
 }
 
 void MoveClipCommand::mergeWith(const UndoableCommand* other) {
-    auto* otherMove = dynamic_cast<const MoveClipCommand*>(other);
+    const auto* otherMove = dynamic_cast<const MoveClipCommand*>(other);
     if (otherMove) {
         // Keep our original snapshot, just update the target position
         newStartBeat_ = otherMove->newStartBeat_;
@@ -593,13 +593,13 @@ void ResizeClipCommand::performAction() {
 }
 
 bool ResizeClipCommand::canMergeWith(const UndoableCommand* other) const {
-    auto* otherResize = dynamic_cast<const ResizeClipCommand*>(other);
+    const auto* otherResize = dynamic_cast<const ResizeClipCommand*>(other);
     return otherResize != nullptr && otherResize->clipId_ == clipId_ &&
            otherResize->fromStart_ == fromStart_;
 }
 
 void ResizeClipCommand::mergeWith(const UndoableCommand* other) {
-    auto* otherResize = dynamic_cast<const ResizeClipCommand*>(other);
+    const auto* otherResize = dynamic_cast<const ResizeClipCommand*>(other);
     if (otherResize) {
         // Update to their new length
         newLengthBeats_ = otherResize->newLengthBeats_;
@@ -2158,7 +2158,7 @@ void BounceInPlaceCommand::execute() {
     };
     std::vector<PluginState> savedStates;
 
-    for (auto plugin : teTrack->pluginList) {
+    for (auto* plugin : teTrack->pluginList) {
         if (rackManager.isWrapperRack(plugin) ||
             dynamic_cast<te::InsertPlugin*>(plugin) != nullptr ||
             dynamic_cast<InsertCapturePlugin*>(plugin) != nullptr)

--- a/magda/daw/audio/ExternalInsertDeviceEnablement.cpp
+++ b/magda/daw/audio/ExternalInsertDeviceEnablement.cpp
@@ -64,7 +64,7 @@ bool ExternalInsertDeviceEnablement::refresh() {
     // return is one of TE's input devices; its send is an output device.
     std::set<juce::String> usedInputs, usedOutputs;
     const auto allPlugins = te::getAllPlugins(edit_, false);
-    for (auto plugin : allPlugins) {
+    for (auto* plugin : allPlugins) {
         auto* insert = dynamic_cast<te::InsertPlugin*>(plugin);
         if (insert == nullptr || !insert->isEnabled())
             continue;
@@ -106,7 +106,7 @@ bool ExternalInsertDeviceEnablement::refresh() {
     if (changed) {
         // A just-enabled device only resolves in the inserts after
         // updateDeviceTypes() re-runs against the new device lists.
-        for (auto plugin : allPlugins)
+        for (auto* plugin : allPlugins)
             if (auto* insert = dynamic_cast<te::InsertPlugin*>(plugin))
                 insert->updateDeviceTypes();
     }

--- a/magda/daw/audio/WarpMarkerManager.cpp
+++ b/magda/daw/audio/WarpMarkerManager.cpp
@@ -227,7 +227,7 @@ void WarpMarkerManager::enableWarp(te::Edit& edit,
     double clipOffset = event->anchorSeconds();
 
     // Get cached transients from AudioThumbnailManager
-    auto* cachedTransients =
+    const auto* cachedTransients =
         AudioThumbnailManager::getInstance().getCachedTransients(event->sourceFilePath());
     DBG("WarpMarkerManager::enableWarp cachedTransients="
         << (cachedTransients ? juce::String(cachedTransients->size()) : "null")

--- a/magda/daw/audio/automation/AutomationPlaybackEngine.cpp
+++ b/magda/daw/audio/automation/AutomationPlaybackEngine.cpp
@@ -619,7 +619,7 @@ void AutomationPlaybackEngine::writeMacroValueFromCurve(const AutomationTarget& 
         }
 
         auto position = edit_.getTransport().getPosition();
-        for (auto param : te::getAllParametersBeingModifiedBy(edit_, *macroParam))
+        for (auto* param : te::getAllParametersBeingModifiedBy(edit_, *macroParam))
             if (param)
                 param->updateFromAutomationSources(position);
     }

--- a/magda/daw/audio/controllers/ControllerRouter.cpp
+++ b/magda/daw/audio/controllers/ControllerRouter.cpp
@@ -279,7 +279,7 @@ void ControllerRouter::onMidiFromControllerPort(const juce::String& portId,
     if (hasExplicitOverride) {
         bindings.erase(std::remove_if(bindings.begin(), bindings.end(),
                                       [](const Binding& b) {
-                                          if (auto* rr = std::get_if<ResolverRef>(&b.target))
+                                          if (const auto* rr = std::get_if<ResolverRef>(&b.target))
                                               return rr->kind == "focused.macro";
                                           return false;
                                       }),

--- a/magda/daw/audio/insert_capture/InsertRenderCaptureService.cpp
+++ b/magda/daw/audio/insert_capture/InsertRenderCaptureService.cpp
@@ -26,7 +26,7 @@ constexpr int kProgressTimerHz = 10;
 // the ones whose returns the offline render cannot produce.
 std::vector<te::InsertPlugin*> routedInserts(te::Edit& edit) {
     std::vector<te::InsertPlugin*> result;
-    for (auto plugin : te::getAllPlugins(edit, false)) {
+    for (auto* plugin : te::getAllPlugins(edit, false)) {
         auto* insert = dynamic_cast<te::InsertPlugin*>(plugin);
         if (insert != nullptr && insert->isEnabled() && insert->outputDevice.get().isNotEmpty() &&
             insert->inputDevice.get().isNotEmpty())

--- a/magda/daw/audio/midi/MidiInputRouter.cpp
+++ b/magda/daw/audio/midi/MidiInputRouter.cpp
@@ -442,7 +442,7 @@ void MidiInputRouter::setTrackMidiInput(TrackId trackId, const juce::String& mid
             const auto matchesIdentifier = [&midiDeviceId](const auto& d) {
                 return d.identifier == midiDeviceId;
             };
-            if (const auto found = std::ranges::find_if(juceDevices, matchesIdentifier);
+            if (auto* const found = std::ranges::find_if(juceDevices, matchesIdentifier);
                 found != juceDevices.end())
                 deviceName = found->name;
 
@@ -467,7 +467,7 @@ void MidiInputRouter::setTrackMidiInput(TrackId trackId, const juce::String& mid
                     return &inputDeviceInstance->owner == midiDevice;
                 };
                 const auto allInputs = playbackContext->getAllInputs();
-                if (const auto found = std::ranges::find_if(allInputs, matchesOwner);
+                if (const auto* const found = std::ranges::find_if(allInputs, matchesOwner);
                     found != allInputs.end())
                     removedAnyRouting = (*found)->removeTarget(track->itemID, nullptr);
                 if (removedAnyRouting && playbackContext->isPlaybackGraphAllocated())
@@ -487,7 +487,7 @@ void MidiInputRouter::setTrackMidiInput(TrackId trackId, const juce::String& mid
                 return &inputDeviceInstance->owner == midiDevice;
             };
             const auto allInputs = playbackContext->getAllInputs();
-            if (const auto found = std::ranges::find_if(allInputs, matchesOwner);
+            if (const auto* const found = std::ranges::find_if(allInputs, matchesOwner);
                 found != allInputs.end()) {
                 auto result = (*found)->setTarget(track->itemID, true, nullptr);
                 if (result.has_value()) {

--- a/magda/daw/audio/modifiers/ModifierHelpers.hpp
+++ b/magda/daw/audio/modifiers/ModifierHelpers.hpp
@@ -415,7 +415,7 @@ inline void triggerLFONoteOnWithReset(te::LFOModifier* lfo, bool forceZeroValue 
  * from dereferencing a dangling userData pointer in evaluateCallback.
  */
 inline void clearLFOCustomWaveCallbacks(const std::vector<te::Modifier::Ptr>& modifiers) {
-    for (auto& mod : modifiers) {
+    for (const auto& mod : modifiers) {
         if (auto* lfo = dynamic_cast<te::LFOModifier*>(mod.get())) {
             lfo->customWaveFunction.store(nullptr, std::memory_order_release);
             lfo->customWaveUserData.store(nullptr, std::memory_order_release);

--- a/magda/daw/audio/plugin_manager/PluginManagerMeasurement.cpp
+++ b/magda/daw/audio/plugin_manager/PluginManagerMeasurement.cpp
@@ -38,7 +38,7 @@ daw::audio::TrackMeasurementPlugin* PluginManager::ensureTrackMeasurementTap(Tra
         return nullptr;
 
     // Adopt an existing tap if one is already on the chain (e.g. after restore).
-    for (auto i : *list) {
+    for (auto* i : *list) {
         if (auto* existing = dynamic_cast<daw::audio::TrackMeasurementPlugin*>(i)) {
             trackMeasurementTaps_[trackId] = i;
             return existing;

--- a/magda/daw/audio/plugin_manager/PluginManagerModifiers.cpp
+++ b/magda/daw/audio/plugin_manager/PluginManagerModifiers.cpp
@@ -74,7 +74,7 @@ void PluginManager::updateDeviceModifierProperties(TrackId trackId) {
     std::function<void(const std::function<void(te::Plugin*)>&)> visitHostPlugins;
     if (teTrack) {
         visitHostPlugins = [teTrack](const std::function<void(te::Plugin*)>& visit) {
-            for (auto plugin : teTrack->pluginList) {
+            for (auto* plugin : teTrack->pluginList) {
                 if (plugin)
                     visit(plugin);
             }
@@ -82,7 +82,7 @@ void PluginManager::updateDeviceModifierProperties(TrackId trackId) {
     } else if (trackId == MASTER_TRACK_ID && edit_.getMasterTrack()) {
         visitHostPlugins = [this](const std::function<void(te::Plugin*)>& visit) {
             const auto& masterList = edit_.getMasterPluginList();
-            for (auto plugin : masterList) {
+            for (auto* plugin : masterList) {
                 if (plugin)
                     visit(plugin);
             }
@@ -1077,7 +1077,7 @@ void PluginManager::resyncDeviceModifiers(TrackId trackId) {
         defaultModifierList = teTrack->getModifierList();
         macroList = &teTrack->getMacroParameterListForWriting();
         visitHostPlugins = [teTrack](const std::function<void(te::Plugin*)>& visit) {
-            for (auto plugin : teTrack->pluginList) {
+            for (auto* plugin : teTrack->pluginList) {
                 if (plugin)
                     visit(plugin);
             }
@@ -1090,7 +1090,7 @@ void PluginManager::resyncDeviceModifiers(TrackId trackId) {
             // null macro host as unsupported master macros.
             visitHostPlugins = [this](const std::function<void(te::Plugin*)>& visit) {
                 const auto& masterList = edit_.getMasterPluginList();
-                for (auto plugin : masterList) {
+                for (auto* plugin : masterList) {
                     if (plugin)
                         visit(plugin);
                 }

--- a/magda/daw/audio/plugin_manager/PluginManagerSidechain.cpp
+++ b/magda/daw/audio/plugin_manager/PluginManagerSidechain.cpp
@@ -174,7 +174,7 @@ void PluginManager::ensureSidechainMonitor(TrackId sourceTrackId) {
     }
 
     // Check if a SidechainMonitorPlugin already exists on the track
-    for (auto i : teTrack->pluginList) {
+    for (auto* i : teTrack->pluginList) {
         if (dynamic_cast<SidechainMonitorPlugin*>(i)) {
             DBG("PluginManager::ensureSidechainMonitor - track "
                 << sourceTrackId << " found existing monitor plugin on TE track");

--- a/magda/daw/audio/plugin_manager/PluginManagerSync.cpp
+++ b/magda/daw/audio/plugin_manager/PluginManagerSync.cpp
@@ -253,13 +253,15 @@ bool savedPluginStateMatchesRequestedType(const juce::ValueTree& savedState,
     if (savedType.equalsIgnoreCase(requestedType))
         return true;
 
-    if (auto* requestedCompiled = daw::audio::compiled::findCompiledPluginSpec(requestedType)) {
-        auto* savedCompiled = daw::audio::compiled::findCompiledPluginSpec(savedType);
+    if (const auto* requestedCompiled =
+            daw::audio::compiled::findCompiledPluginSpec(requestedType)) {
+        const auto* savedCompiled = daw::audio::compiled::findCompiledPluginSpec(savedType);
         return savedCompiled == requestedCompiled;
     }
 
-    if (auto* requestedInternal = daw::audio::findInternalPluginSpecForLoadType(requestedType)) {
-        auto* savedInternal = daw::audio::findInternalPluginSpecForLoadType(savedType);
+    if (const auto* requestedInternal =
+            daw::audio::findInternalPluginSpecForLoadType(requestedType)) {
+        const auto* savedInternal = daw::audio::findInternalPluginSpecForLoadType(savedType);
         return savedInternal == requestedInternal;
     }
 
@@ -759,7 +761,7 @@ void PluginManager::syncTrackPlugins(TrackId trackId) {
     syncDeviceModifiers(trackId, teTrack->getModifierList(),
                         &teTrack->getMacroParameterListForWriting(),
                         [teTrack](const std::function<void(te::Plugin*)>& visit) {
-                            for (auto plugin : teTrack->pluginList) {
+                            for (auto* plugin : teTrack->pluginList) {
                                 if (plugin)
                                     visit(plugin);
                             }
@@ -1107,13 +1109,13 @@ te::Plugin::Ptr PluginManager::loadBuiltInPlugin(TrackId trackId, const juce::St
 
     te::Plugin::Ptr plugin;
 
-    if (auto* spec = daw::audio::compiled::findCompiledPluginSpec(type)) {
+    if (const auto* spec = daw::audio::compiled::findCompiledPluginSpec(type)) {
         juce::ValueTree pluginState(te::IDs::PLUGIN);
         pluginState.setProperty(te::IDs::type, spec->pluginId, nullptr);
         plugin = edit_.getPluginCache().createNewPlugin(pluginState);
         if (plugin)
             track->pluginList.insertPlugin(plugin, -1, nullptr);
-    } else if (auto* spec = daw::audio::findInternalPluginSpecForLoadType(type)) {
+    } else if (const auto* spec = daw::audio::findInternalPluginSpecForLoadType(type)) {
         if (spec->canCreateOnTrack) {
             plugin = daw::audio::tracktion_adapter::createInternalPlugin(*spec, edit_);
             if (plugin)
@@ -1377,7 +1379,7 @@ void PluginManager::reconcileSends(const TrackInfo& trackInfo, te::AudioTrack& t
     // appendStripOrder could not show, because it can only order plugins that
     // are already there.
     std::vector<int> existingSendBuses;
-    for (auto i : track.pluginList)
+    for (auto* i : track.pluginList)
         if (auto* auxSend = dynamic_cast<te::AuxSendPlugin*>(i))
             existingSendBuses.push_back(auxSend->getBusNumber());
 
@@ -1413,7 +1415,7 @@ void PluginManager::reconcileSends(const TrackInfo& trackInfo, te::AudioTrack& t
     }
 
     for (const auto& send : trackInfo.sends) {
-        for (auto i : track.pluginList) {
+        for (auto* i : track.pluginList) {
             if (auto* auxSend = dynamic_cast<te::AuxSendPlugin*>(i);
                 auxSend != nullptr && auxSend->getBusNumber() == send.busIndex) {
                 auxSend->setGainDb(juce::Decibels::gainToDecibels(send.level));
@@ -1467,7 +1469,7 @@ void PluginManager::appendStripOrder(TrackId trackId, const TrackInfo& trackInfo
                 auto* aux = dynamic_cast<te::AuxSendPlugin*>(p);
                 return aux != nullptr && aux->getBusNumber() == busIndex;
             };
-            const auto found = std::ranges::find_if(track.pluginList, matchesBus);
+            auto* const found = std::ranges::find_if(track.pluginList, matchesBus);
             if (found != track.pluginList.end())
                 desiredOrder.push_back(*found);
         }
@@ -1527,7 +1529,7 @@ void PluginManager::ensureVolumePluginPosition(TrackId trackId, te::AudioTrack* 
     const auto isPostFader = [volPanRaw, &postFaderPlugins](auto* p) {
         return p != volPanRaw && postFaderPlugins.count(p) != 0;
     };
-    const auto firstPostFaderIt = std::ranges::find_if(plugins, isPostFader);
+    auto* const firstPostFaderIt = std::ranges::find_if(plugins, isPostFader);
     const int firstPostFader =
         firstPostFaderIt == plugins.end() ? -1 : plugins.indexOf(*firstPostFaderIt);
 
@@ -1593,7 +1595,7 @@ std::unordered_set<te::Plugin*> PluginManager::collectPostFaderPlugins(
     for (const auto& send : trackInfo->sends) {
         if (send.preFader)
             continue;
-        for (auto i : track.pluginList)
+        for (auto* i : track.pluginList)
             if (auto* aux = dynamic_cast<te::AuxSendPlugin*>(i);
                 aux != nullptr && aux->getBusNumber() == send.busIndex)
                 result.insert(aux);
@@ -1920,7 +1922,7 @@ void PluginManager::syncMasterPlugins() {
         deferredHolders_.clear();  // Drain previous cycle's deferred holders
         std::vector<te::Plugin*> scopePlugins;
         scopePlugins.reserve(masterList.size());
-        for (auto plugin : masterList) {
+        for (auto* plugin : masterList) {
             if (plugin)
                 scopePlugins.push_back(plugin);
         }
@@ -2099,9 +2101,10 @@ te::Plugin::Ptr PluginManager::createPluginOnly(TrackId trackId, const DeviceInf
     if (device.format == PluginFormat::Internal) {
         const auto& ps = device.pluginState;
 
-        if (auto* compiledSpec = daw::audio::compiled::findCompiledPluginSpec(device.pluginId)) {
+        if (const auto* compiledSpec =
+                daw::audio::compiled::findCompiledPluginSpec(device.pluginId)) {
             plugin = createInternalPlugin(compiledSpec->pluginId, ps);
-        } else if (auto* internalSpec = daw::audio::findInternalPluginSpec(device.pluginId)) {
+        } else if (const auto* internalSpec = daw::audio::findInternalPluginSpec(device.pluginId)) {
             if (internalSpec->canCreateDetached)
                 plugin =
                     daw::audio::tracktion_adapter::createInternalPlugin(*internalSpec, edit_, ps);
@@ -2261,11 +2264,12 @@ te::Plugin::Ptr PluginManager::loadDeviceAsPlugin(const ChainNodePath& devicePat
     std::unique_ptr<DeviceProcessor> processor;
 
     if (device.format == PluginFormat::Internal) {
-        if (auto* compiledSpec = daw::audio::compiled::findCompiledPluginSpec(device.pluginId)) {
+        if (const auto* compiledSpec =
+                daw::audio::compiled::findCompiledPluginSpec(device.pluginId)) {
             plugin = createInternalPlugin(compiledSpec->pluginId, device.pluginState);
             if (plugin)
                 track->pluginList.insertPlugin(plugin, insertIndex, nullptr);
-        } else if (auto* internalSpec = daw::audio::findInternalPluginSpec(device.pluginId)) {
+        } else if (const auto* internalSpec = daw::audio::findInternalPluginSpec(device.pluginId)) {
             if (internalSpec->canCreateOnTrack) {
                 plugin = daw::audio::tracktion_adapter::createInternalPlugin(*internalSpec, edit_,
                                                                              device.pluginState);

--- a/magda/daw/audio/plugins/AudioSidechainMonitorPlugin.cpp
+++ b/magda/daw/audio/plugins/AudioSidechainMonitorPlugin.cpp
@@ -8,7 +8,7 @@ const char* AudioSidechainMonitorPlugin::xmlTypeName = "audiosidechainmonitor";
 
 AudioSidechainMonitorPlugin::AudioSidechainMonitorPlugin(const te::PluginCreationInfo& info)
     : te::Plugin(info) {
-    auto um = getUndoManager();
+    auto* um = getUndoManager();
     sourceTrackIdValue.referTo(state, juce::Identifier("sourceTrackId"), um, INVALID_TRACK_ID);
     sourceTrackId_ = sourceTrackIdValue.get();
 }

--- a/magda/daw/audio/plugins/DrumGridPlugin.cpp
+++ b/magda/daw/audio/plugins/DrumGridPlugin.cpp
@@ -245,7 +245,7 @@ void DrumGridPlugin::processChain(const AudioChainEntry& entry,
     chainMidi_.clear();
     chainMidi_.isAllNotesOff = inputMidi.isAllNotesOff;
 
-    for (auto& msg : inputMidi) {
+    for (const auto& msg : inputMidi) {
         if (msg.isNoteOnOrOff()) {
             int note = msg.getNoteNumber();
             if (note >= lowNote && note <= entry.highNote) {
@@ -614,7 +614,7 @@ const std::vector<std::unique_ptr<DrumGridPlugin::Chain>>& DrumGridPlugin::getCh
 }
 
 int DrumGridPlugin::getPluginDeviceId(int chainIndex, int pluginIndex) const {
-    auto* chain = getChainByIndex(chainIndex);
+    const auto* chain = getChainByIndex(chainIndex);
     if (!chain || pluginIndex < 0 || pluginIndex >= static_cast<int>(chain->plugins.size()))
         return -1;
     return chain->plugins[static_cast<size_t>(pluginIndex)]->state.getProperty(pluginDeviceIdProp,
@@ -646,13 +646,13 @@ DrumGridPlugin::Chain* DrumGridPlugin::getChainByIndexMutable(int chainIndex) {
 }
 
 int DrumGridPlugin::getChainPluginCount(int chainIndex) const {
-    if (auto* chain = getChainByIndex(chainIndex))
+    if (const auto* chain = getChainByIndex(chainIndex))
         return static_cast<int>(chain->plugins.size());
     return 0;
 }
 
 te::Plugin* DrumGridPlugin::getChainPlugin(int chainIndex, int pluginIndex) const {
-    if (auto* chain = getChainByIndex(chainIndex)) {
+    if (const auto* chain = getChainByIndex(chainIndex)) {
         if (pluginIndex >= 0 && pluginIndex < static_cast<int>(chain->plugins.size()))
             return chain->plugins[static_cast<size_t>(pluginIndex)].get();
     }
@@ -667,7 +667,7 @@ int DrumGridPlugin::getPadPluginCount(int padIndex) const {
     if (padIndex < 0 || padIndex >= maxPads)
         return 0;
     int midiNote = baseNote + padIndex;
-    if (auto* chain = getChainForNote(midiNote))
+    if (const auto* chain = getChainForNote(midiNote))
         return static_cast<int>(chain->plugins.size());
     return 0;
 }
@@ -676,7 +676,7 @@ te::Plugin* DrumGridPlugin::getPadPlugin(int padIndex, int pluginIndex) const {
     if (padIndex < 0 || padIndex >= maxPads)
         return nullptr;
     int midiNote = baseNote + padIndex;
-    if (auto* chain = getChainForNote(midiNote)) {
+    if (const auto* chain = getChainForNote(midiNote)) {
         if (pluginIndex >= 0 && pluginIndex < static_cast<int>(chain->plugins.size()))
             return chain->plugins[static_cast<size_t>(pluginIndex)].get();
     }
@@ -695,7 +695,7 @@ bool DrumGridPlugin::consumePadTrigger(int padIndex) {
 }
 
 std::pair<float, float> DrumGridPlugin::consumeChainPeak(int chainIndex) {
-    auto* chain = getChainByIndex(chainIndex);
+    const auto* chain = getChainByIndex(chainIndex);
     if (!chain)
         return {0.0f, 0.0f};
     int padIdx = padIndexFor(*chain);
@@ -708,7 +708,7 @@ std::pair<float, float> DrumGridPlugin::consumeChainPeak(int chainIndex) {
 }
 
 float DrumGridPlugin::getChainPluginGain(int chainIndex, int pluginIndex) const {
-    auto* chain = getChainByIndex(chainIndex);
+    const auto* chain = getChainByIndex(chainIndex);
     if (!chain || pluginIndex < 0 || pluginIndex >= static_cast<int>(chain->pluginGains.size()))
         return 1.0f;
     return chain->pluginGains[static_cast<size_t>(pluginIndex)];
@@ -717,7 +717,7 @@ float DrumGridPlugin::getChainPluginGain(int chainIndex, int pluginIndex) const 
 std::pair<float, float> DrumGridPlugin::consumeChainPluginPeak(int chainIndex, int pluginIndex) {
     if (pluginIndex < 0 || pluginIndex >= maxFxPerChain)
         return {0.0f, 0.0f};
-    auto* chain = getChainByIndex(chainIndex);
+    const auto* chain = getChainByIndex(chainIndex);
     if (!chain)
         return {0.0f, 0.0f};
     int padIdx = padIndexFor(*chain);

--- a/magda/daw/audio/plugins/FollowerSourceTapPlugin.cpp
+++ b/magda/daw/audio/plugins/FollowerSourceTapPlugin.cpp
@@ -6,7 +6,7 @@ const char* FollowerSourceTapPlugin::xmlTypeName = "followersourcetap";
 
 FollowerSourceTapPlugin::FollowerSourceTapPlugin(const te::PluginCreationInfo& info)
     : te::Plugin(info) {
-    auto um = getUndoManager();
+    auto* um = getUndoManager();
     sourceTrackIdValue.referTo(state, juce::Identifier("sourceTrackId"), um, INVALID_TRACK_ID);
     sourceTrackId_ = sourceTrackIdValue.get();
 }

--- a/magda/daw/audio/plugins/MidiReceivePlugin.cpp
+++ b/magda/daw/audio/plugins/MidiReceivePlugin.cpp
@@ -9,7 +9,7 @@ const char* MidiReceivePlugin::xmlTypeName = "midireceive";
 MidiReceivePlugin::MidiReceivePlugin(const te::PluginCreationInfo& info,
                                      const daw::audio::DevicePluginDefaults::MidiReceive& defaults)
     : te::Plugin(info) {
-    auto um = getUndoManager();
+    auto* um = getUndoManager();
     sourceTrackIdValue.referTo(state, juce::Identifier("sourceTrackId"), um,
                                defaults.sourceTrackId);
     replaceExistingMidiValue.referTo(state, juce::Identifier("replaceExistingMidi"), um,

--- a/magda/daw/audio/plugins/MidiStrumPlugin.cpp
+++ b/magda/daw/audio/plugins/MidiStrumPlugin.cpp
@@ -302,8 +302,8 @@ void MidiStrumPlugin::scheduleStrum() {
     // between them, and one hung voice each (#2363).
     scheduleReleaseAll();
 
-    auto* begin = ordered_.begin();
-    auto* end = begin + heldCount_;
+    auto begin = ordered_.begin();
+    auto end = begin + heldCount_;
     std::copy(held_.begin(), held_.begin() + heldCount_, begin);
 
     const int ord = displayIndex(kOrder);

--- a/magda/daw/audio/plugins/MidiStrumPlugin.cpp
+++ b/magda/daw/audio/plugins/MidiStrumPlugin.cpp
@@ -302,8 +302,8 @@ void MidiStrumPlugin::scheduleStrum() {
     // between them, and one hung voice each (#2363).
     scheduleReleaseAll();
 
-    auto begin = ordered_.begin();
-    auto end = begin + heldCount_;
+    auto* begin = ordered_.begin();
+    auto* end = begin + heldCount_;
     std::copy(held_.begin(), held_.begin() + heldCount_, begin);
 
     const int ord = displayIndex(kOrder);

--- a/magda/daw/audio/plugins/SidechainMonitorPlugin.cpp
+++ b/magda/daw/audio/plugins/SidechainMonitorPlugin.cpp
@@ -9,7 +9,7 @@ const char* SidechainMonitorPlugin::xmlTypeName = "midisidechainmonitor";
 
 SidechainMonitorPlugin::SidechainMonitorPlugin(const te::PluginCreationInfo& info)
     : te::Plugin(info) {
-    auto um = getUndoManager();
+    auto* um = getUndoManager();
     sourceTrackIdValue.referTo(state, juce::Identifier("sourceTrackId"), um, INVALID_TRACK_ID);
     sourceTrackId_ = sourceTrackIdValue.get();
 }

--- a/magda/daw/audio/plugins/SidechainPlugin.cpp
+++ b/magda/daw/audio/plugins/SidechainPlugin.cpp
@@ -140,7 +140,7 @@ void SidechainPlugin::process(DeviceProcessContext& context) {
 
     const int numChannels = context.audio->getNumChannels();
     const int numSamples = context.numSamples;
-    auto channels = context.audio->getArrayOfWritePointers();
+    const auto* channels = context.audio->getArrayOfWritePointers();
     const int offset = context.startSample;
 
     // The modifier writes the gain target at a coarse quantum (one hop per

--- a/magda/daw/audio/plugins/compiled/CompiledPluginRegistry.cpp
+++ b/magda/daw/audio/plugins/compiled/CompiledPluginRegistry.cpp
@@ -80,7 +80,7 @@ const CompiledPluginSpec* findCompiledPluginSpec(const juce::String& pluginId) {
         return std::ranges::any_of(std::views::iota(0, std::max(0, spec->loadAliasCount)),
                                    matchesLoadAlias);
     };
-    const auto found = std::ranges::find_if(kAllSpecs, matchesSpec);
+    const auto* const found = std::ranges::find_if(kAllSpecs, matchesSpec);
     return found == std::end(kAllSpecs) ? nullptr : *found;
 }
 

--- a/magda/daw/audio/plugins/tracktion/TracktionMagdaDevicePlugin.hpp
+++ b/magda/daw/audio/plugins/tracktion/TracktionMagdaDevicePlugin.hpp
@@ -99,7 +99,7 @@ template <typename DeviceType> const DeviceType* deviceFromPlugin(const te::Plug
     if (auto* device = dynamic_cast<const DeviceType*>(plugin))
         return device;
 
-    const const const const auto* adapter = dynamic_cast<const TracktionMagdaDevicePlugin*>(plugin);
+    const auto* adapter = dynamic_cast<const TracktionMagdaDevicePlugin*>(plugin);
     return adapter != nullptr ? dynamic_cast<const DeviceType*>(&adapter->device()) : nullptr;
 }
 

--- a/magda/daw/audio/plugins/tracktion/TracktionMagdaDevicePlugin.hpp
+++ b/magda/daw/audio/plugins/tracktion/TracktionMagdaDevicePlugin.hpp
@@ -99,7 +99,7 @@ template <typename DeviceType> const DeviceType* deviceFromPlugin(const te::Plug
     if (auto* device = dynamic_cast<const DeviceType*>(plugin))
         return device;
 
-    auto* adapter = dynamic_cast<const TracktionMagdaDevicePlugin*>(plugin);
+    const const const const auto* adapter = dynamic_cast<const TracktionMagdaDevicePlugin*>(plugin);
     return adapter != nullptr ? dynamic_cast<const DeviceType*>(&adapter->device()) : nullptr;
 }
 

--- a/magda/daw/audio/processors/DeviceProcessorFactory.cpp
+++ b/magda/daw/audio/processors/DeviceProcessorFactory.cpp
@@ -23,10 +23,10 @@ std::unique_ptr<DeviceProcessor> createDeviceProcessorForPlugin(
         return processor;
     }
 
-    if (auto* compiledSpec = daw::audio::compiled::findCompiledPluginSpec(pluginId))
+    if (const auto* compiledSpec = daw::audio::compiled::findCompiledPluginSpec(pluginId))
         return daw::audio::compiled::createTracktionProcessor(*compiledSpec, deviceId, plugin);
 
-    if (auto* internalSpec = daw::audio::findInternalPluginSpec(pluginId))
+    if (const auto* internalSpec = daw::audio::findInternalPluginSpec(pluginId))
         return daw::audio::tracktion_adapter::createInternalPluginProcessor(
             *internalSpec, deviceId, daw::audio::tracktion_adapter::pluginHandle(plugin));
 

--- a/magda/daw/audio/racks/RackSyncManager.cpp
+++ b/magda/daw/audio/racks/RackSyncManager.cpp
@@ -70,7 +70,7 @@ te::Plugin* findRackPlugin(te::RackType& rackType, te::EditItemID id) {
     const auto matchesId = [id](const te::Plugin* plugin) {
         return plugin && plugin->itemID == id;
     };
-    const auto found = std::ranges::find_if(plugins, matchesId);
+    const auto* const found = std::ranges::find_if(plugins, matchesId);
     return found == plugins.end() ? nullptr : *found;
 }
 
@@ -203,7 +203,7 @@ void RackSyncManager::resyncRack(TrackId trackId, const RackInfo& rackInfo) {
     {
         auto connections = rackType->getConnections();
         for (int i = connections.size(); --i >= 0;) {
-            auto* conn = connections[i];
+            const auto* conn = connections[i];
             rackType->removeConnection(conn->sourceID, conn->sourcePin, conn->destID,
                                        conn->destPin);
         }
@@ -650,7 +650,7 @@ te::AutomatableParameter* RackSyncManager::findRackModifierParameter(RackId rack
     const auto matchesParamId = [&wantedID](const te::AutomatableParameter* p) {
         return p && p->paramID == wantedID;
     };
-    const auto foundParam = std::ranges::find_if(params, matchesParamId);
+    const auto* const foundParam = std::ranges::find_if(params, matchesParamId);
     return foundParam == params.end() ? nullptr : *foundParam;
 }
 
@@ -665,7 +665,7 @@ void RackSyncManager::resyncAllModifiers(TrackId trackId) {
             if (track.id != trackId)
                 continue;
             for (const auto& element : track.chain.fxChainElements) {
-                if (auto* rackPtr = std::get_if<std::unique_ptr<RackInfo>>(&element)) {
+                if (const auto* rackPtr = std::get_if<std::unique_ptr<RackInfo>>(&element)) {
                     if (!*rackPtr || (*rackPtr)->id != rackId)
                         continue;
                     const auto& rackInfo = **rackPtr;
@@ -704,7 +704,7 @@ void RackSyncManager::updateAllModifierProperties(TrackId trackId) {
             if (track.id != trackId)
                 continue;
             for (const auto& element : track.chain.fxChainElements) {
-                if (auto* rackPtr = std::get_if<std::unique_ptr<RackInfo>>(&element)) {
+                if (const auto* rackPtr = std::get_if<std::unique_ptr<RackInfo>>(&element)) {
                     if (!*rackPtr || (*rackPtr)->id != rackId)
                         continue;
                     updateRackModulationProperties(synced, **rackPtr);
@@ -1024,7 +1024,7 @@ void RackSyncManager::updateProperties(SyncedRack& synced, const RackInfo& rackI
         if (rackType) {
             auto connections = rackType->getConnections();
             for (int i = connections.size(); --i >= 0;) {
-                auto* conn = connections[i];
+                const auto* conn = connections[i];
                 rackType->removeConnection(conn->sourceID, conn->sourcePin, conn->destID,
                                            conn->destPin);
             }
@@ -1085,7 +1085,7 @@ void RackSyncManager::rebuildConnectionsRecursive(SyncedRack& synced, const Rack
 
             auto connections = typeIt->second->getConnections();
             for (int i = connections.size(); --i >= 0;) {
-                auto* conn = connections[i];
+                const auto* conn = connections[i];
                 typeIt->second->removeConnection(conn->sourceID, conn->sourcePin, conn->destID,
                                                  conn->destPin);
             }
@@ -1095,7 +1095,7 @@ void RackSyncManager::rebuildConnectionsRecursive(SyncedRack& synced, const Rack
 
     auto connections = rackType.getConnections();
     for (int i = connections.size(); --i >= 0;) {
-        auto* conn = connections[i];
+        const auto* conn = connections[i];
         rackType.removeConnection(conn->sourceID, conn->sourcePin, conn->destID, conn->destPin);
     }
     buildConnectionsForRack(synced, rackInfo, rackPath, rackType);

--- a/magda/daw/audio/session/ClipSynchronizer.cpp
+++ b/magda/daw/audio/session/ClipSynchronizer.cpp
@@ -192,7 +192,7 @@ bool restoreWarpMarkersIfNeeded(te::WarpTimeManager& warpManager,
     // inserting the complete saved list would duplicate both boundaries.
     warpManager.removeAllMarkers();
 
-    auto& defaultMarkers = warpManager.getMarkers();
+    const auto& defaultMarkers = warpManager.getMarkers();
     warpManager.moveMarker(0, te::TimePosition::fromSeconds(markers.front().warpTime));
     warpManager.moveMarker(defaultMarkers.size() - 1,
                            te::TimePosition::fromSeconds(markers.back().warpTime));

--- a/magda/daw/command.cpp
+++ b/magda/daw/command.cpp
@@ -15,7 +15,7 @@ Command::Command(const juce::var& json) {
     // Parse parameters
     auto* obj = json.getDynamicObject();
     if (obj) {
-        for (auto& prop : obj->getProperties()) {
+        for (const auto& prop : obj->getProperties()) {
             std::string key = prop.name.toString().toStdString();
             if (key == "command")
                 continue;

--- a/magda/daw/core/AutomationCommands.hpp
+++ b/magda/daw/core/AutomationCommands.hpp
@@ -120,14 +120,12 @@ class MoveAutomationPointCommand : public UndoableCommand {
     }
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (const const const const const const auto* o =
-                dynamic_cast<const MoveAutomationPointCommand*>(other))
+        if (const auto* o = dynamic_cast<const MoveAutomationPointCommand*>(other))
             return o->pointId_ == pointId_ && o->laneId_ == laneId_ && o->clipId_ == clipId_;
         return false;
     }
     void mergeWith(const UndoableCommand* other) override {
-        const const const const const const auto* o =
-            static_cast<const MoveAutomationPointCommand*>(other);
+        const auto* o = static_cast<const MoveAutomationPointCommand*>(other);
         newBeatPosition_ = o->newBeatPosition_;
         newValue_ = o->newValue_;
     }
@@ -165,8 +163,7 @@ class SetAutomationPointTensionCommand : public UndoableCommand {
     }
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (const const const const const const auto* o =
-                dynamic_cast<const SetAutomationPointTensionCommand*>(other))
+        if (const auto* o = dynamic_cast<const SetAutomationPointTensionCommand*>(other))
             return o->pointId_ == pointId_ && o->laneId_ == laneId_ && o->clipId_ == clipId_;
         return false;
     }
@@ -209,14 +206,12 @@ class SetAutomationPointHandlesCommand : public UndoableCommand {
     }
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (const const const const const const auto* o =
-                dynamic_cast<const SetAutomationPointHandlesCommand*>(other))
+        if (const auto* o = dynamic_cast<const SetAutomationPointHandlesCommand*>(other))
             return o->pointId_ == pointId_ && o->laneId_ == laneId_ && o->clipId_ == clipId_;
         return false;
     }
     void mergeWith(const UndoableCommand* other) override {
-        const const const const const const auto* o =
-            static_cast<const SetAutomationPointHandlesCommand*>(other);
+        const auto* o = static_cast<const SetAutomationPointHandlesCommand*>(other);
         newInHandle_ = o->newInHandle_;
         newOutHandle_ = o->newOutHandle_;
     }
@@ -388,8 +383,7 @@ class MoveAutomationClipCommand : public UndoableCommand {
     }
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (const const const const const const auto* o =
-                dynamic_cast<const MoveAutomationClipCommand*>(other))
+        if (const auto* o = dynamic_cast<const MoveAutomationClipCommand*>(other))
             return o->clipId_ == clipId_;
         return false;
     }
@@ -470,8 +464,7 @@ class ResizeAutomationClipCommand : public UndoableCommand {
     }
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (const const const const const const auto* o =
-                dynamic_cast<const ResizeAutomationClipCommand*>(other))
+        if (const auto* o = dynamic_cast<const ResizeAutomationClipCommand*>(other))
             return o->clipId_ == clipId_ && o->fromStart_ == fromStart_;
         return false;
     }

--- a/magda/daw/core/AutomationCommands.hpp
+++ b/magda/daw/core/AutomationCommands.hpp
@@ -120,12 +120,14 @@ class MoveAutomationPointCommand : public UndoableCommand {
     }
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (auto* o = dynamic_cast<const MoveAutomationPointCommand*>(other))
+        if (const const const const const const auto* o =
+                dynamic_cast<const MoveAutomationPointCommand*>(other))
             return o->pointId_ == pointId_ && o->laneId_ == laneId_ && o->clipId_ == clipId_;
         return false;
     }
     void mergeWith(const UndoableCommand* other) override {
-        auto* o = static_cast<const MoveAutomationPointCommand*>(other);
+        const const const const const const auto* o =
+            static_cast<const MoveAutomationPointCommand*>(other);
         newBeatPosition_ = o->newBeatPosition_;
         newValue_ = o->newValue_;
     }
@@ -163,7 +165,8 @@ class SetAutomationPointTensionCommand : public UndoableCommand {
     }
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (auto* o = dynamic_cast<const SetAutomationPointTensionCommand*>(other))
+        if (const const const const const const auto* o =
+                dynamic_cast<const SetAutomationPointTensionCommand*>(other))
             return o->pointId_ == pointId_ && o->laneId_ == laneId_ && o->clipId_ == clipId_;
         return false;
     }
@@ -206,12 +209,14 @@ class SetAutomationPointHandlesCommand : public UndoableCommand {
     }
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (auto* o = dynamic_cast<const SetAutomationPointHandlesCommand*>(other))
+        if (const const const const const const auto* o =
+                dynamic_cast<const SetAutomationPointHandlesCommand*>(other))
             return o->pointId_ == pointId_ && o->laneId_ == laneId_ && o->clipId_ == clipId_;
         return false;
     }
     void mergeWith(const UndoableCommand* other) override {
-        auto* o = static_cast<const SetAutomationPointHandlesCommand*>(other);
+        const const const const const const auto* o =
+            static_cast<const SetAutomationPointHandlesCommand*>(other);
         newInHandle_ = o->newInHandle_;
         newOutHandle_ = o->newOutHandle_;
     }
@@ -383,7 +388,8 @@ class MoveAutomationClipCommand : public UndoableCommand {
     }
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (auto* o = dynamic_cast<const MoveAutomationClipCommand*>(other))
+        if (const const const const const const auto* o =
+                dynamic_cast<const MoveAutomationClipCommand*>(other))
             return o->clipId_ == clipId_;
         return false;
     }
@@ -464,7 +470,8 @@ class ResizeAutomationClipCommand : public UndoableCommand {
     }
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (auto* o = dynamic_cast<const ResizeAutomationClipCommand*>(other))
+        if (const const const const const const auto* o =
+                dynamic_cast<const ResizeAutomationClipCommand*>(other))
             return o->clipId_ == clipId_ && o->fromStart_ == fromStart_;
         return false;
     }

--- a/magda/daw/core/AutomationInfo.cpp
+++ b/magda/daw/core/AutomationInfo.cpp
@@ -163,7 +163,7 @@ ParameterInfo getParameterInfoForTarget(const AutomationTarget& target) {
             // based on the modifier's tempoSync flag.
             if (target.modParamIndex == 0) {
                 juce::String name("Rate");
-                if (auto* mod = resolveModInfoForTarget(target); mod && mod->tempoSync)
+                if (const auto* mod = resolveModInfoForTarget(target); mod && mod->tempoSync)
                     return makeSyncDivisionInfo(name);
                 return makeHzRateInfo(name);
             }
@@ -207,12 +207,12 @@ juce::String getDisplayNameForTarget(const AutomationTarget& target) {
         }
         case ControlTarget::Kind::DeviceMacro: {
             auto defaultName = getMacroDefaultDisplayName(target.paramIndex);
-            if (auto* macro = resolveMacroInfoForTarget(target))
+            if (const auto* macro = resolveMacroInfoForTarget(target))
                 return formatCustomNameWithDefault(macro->name, defaultName);
             return defaultName;
         }
         case ControlTarget::Kind::ModParam: {
-            if (auto* mod = resolveModInfoForTarget(target))
+            if (const auto* mod = resolveModInfoForTarget(target))
                 return getModParameterDisplayName(*mod, target.modParamIndex);
             return "Mod " + juce::String(target.modId) + " Param " +
                    juce::String(target.modParamIndex);

--- a/magda/daw/core/ClipCommands.hpp
+++ b/magda/daw/core/ClipCommands.hpp
@@ -489,12 +489,12 @@ class SetCrossfadeCommand : public UndoableCommand {
     void undo() override;
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (auto* o = dynamic_cast<const SetCrossfadeCommand*>(other))
+        if (const const const const auto* o = dynamic_cast<const SetCrossfadeCommand*>(other))
             return o->leftId_ == leftId_ && o->rightId_ == rightId_;
         return false;
     }
     void mergeWith(const UndoableCommand* other) override {
-        auto* o = static_cast<const SetCrossfadeCommand*>(other);
+        const const const const auto* o = static_cast<const SetCrossfadeCommand*>(other);
         startBeat_ = o->startBeat_;
         endBeat_ = o->endBeat_;
         tempo_ = o->tempo_;

--- a/magda/daw/core/ClipCommands.hpp
+++ b/magda/daw/core/ClipCommands.hpp
@@ -489,12 +489,12 @@ class SetCrossfadeCommand : public UndoableCommand {
     void undo() override;
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (const const const const auto* o = dynamic_cast<const SetCrossfadeCommand*>(other))
+        if (const auto* o = dynamic_cast<const SetCrossfadeCommand*>(other))
             return o->leftId_ == leftId_ && o->rightId_ == rightId_;
         return false;
     }
     void mergeWith(const UndoableCommand* other) override {
-        const const const const auto* o = static_cast<const SetCrossfadeCommand*>(other);
+        const auto* o = static_cast<const SetCrossfadeCommand*>(other);
         startBeat_ = o->startBeat_;
         endBeat_ = o->endBeat_;
         tempo_ = o->tempo_;

--- a/magda/daw/core/ClipPropertyCommands.hpp
+++ b/magda/daw/core/ClipPropertyCommands.hpp
@@ -113,7 +113,7 @@ class SetClipOffsetCommand : public UndoableCommand {
     }
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (const const const const auto* o = dynamic_cast<const SetClipOffsetCommand*>(other))
+        if (const auto* o = dynamic_cast<const SetClipOffsetCommand*>(other))
             return o->clipId_ == clipId_;
         return false;
     }
@@ -165,7 +165,7 @@ class SetClipLoopPhaseCommand : public UndoableCommand {
     }
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (const const const const auto* o = dynamic_cast<const SetClipLoopPhaseCommand*>(other))
+        if (const auto* o = dynamic_cast<const SetClipLoopPhaseCommand*>(other))
             return o->clipId_ == clipId_;
         return false;
     }
@@ -205,12 +205,12 @@ class SetClipLoopStartCommand : public UndoableCommand {
     }
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (const const const const auto* o = dynamic_cast<const SetClipLoopStartCommand*>(other))
+        if (const auto* o = dynamic_cast<const SetClipLoopStartCommand*>(other))
             return o->clipId_ == clipId_;
         return false;
     }
     void mergeWith(const UndoableCommand* other) override {
-        const const const const auto* o = static_cast<const SetClipLoopStartCommand*>(other);
+        const auto* o = static_cast<const SetClipLoopStartCommand*>(other);
         newLoopStart_ = o->newLoopStart_;
         bpm_ = o->bpm_;
     }
@@ -244,12 +244,12 @@ class SetClipLoopLengthCommand : public UndoableCommand {
     }
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (const const const const auto* o = dynamic_cast<const SetClipLoopLengthCommand*>(other))
+        if (const auto* o = dynamic_cast<const SetClipLoopLengthCommand*>(other))
             return o->clipId_ == clipId_;
         return false;
     }
     void mergeWith(const UndoableCommand* other) override {
-        const const const const auto* o = static_cast<const SetClipLoopLengthCommand*>(other);
+        const auto* o = static_cast<const SetClipLoopLengthCommand*>(other);
         newLoopLength_ = o->newLoopLength_;
         bpm_ = o->bpm_;
     }
@@ -280,14 +280,12 @@ class SetMidiClipLoopStartBeatsCommand : public UndoableCommand {
     }
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (const const const const auto* o =
-                dynamic_cast<const SetMidiClipLoopStartBeatsCommand*>(other))
+        if (const auto* o = dynamic_cast<const SetMidiClipLoopStartBeatsCommand*>(other))
             return o->clipId_ == clipId_;
         return false;
     }
     void mergeWith(const UndoableCommand* other) override {
-        const const const const auto* o =
-            static_cast<const SetMidiClipLoopStartBeatsCommand*>(other);
+        const auto* o = static_cast<const SetMidiClipLoopStartBeatsCommand*>(other);
         newLoopStartBeats_ = o->newLoopStartBeats_;
         bpm_ = o->bpm_;
     }
@@ -318,14 +316,12 @@ class SetMidiClipLoopLengthBeatsCommand : public UndoableCommand {
     }
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (const const const const auto* o =
-                dynamic_cast<const SetMidiClipLoopLengthBeatsCommand*>(other))
+        if (const auto* o = dynamic_cast<const SetMidiClipLoopLengthBeatsCommand*>(other))
             return o->clipId_ == clipId_;
         return false;
     }
     void mergeWith(const UndoableCommand* other) override {
-        const const const const auto* o =
-            static_cast<const SetMidiClipLoopLengthBeatsCommand*>(other);
+        const auto* o = static_cast<const SetMidiClipLoopLengthBeatsCommand*>(other);
         newLoopLengthBeats_ = o->newLoopLengthBeats_;
         bpm_ = o->bpm_;
     }
@@ -374,12 +370,12 @@ class SetClipLoopRangeCommand : public UndoableCommand {
     }
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (const const const const auto* o = dynamic_cast<const SetClipLoopRangeCommand*>(other))
+        if (const auto* o = dynamic_cast<const SetClipLoopRangeCommand*>(other))
             return o->clipId_ == clipId_;
         return false;
     }
     void mergeWith(const UndoableCommand* other) override {
-        const const const const auto* o = static_cast<const SetClipLoopRangeCommand*>(other);
+        const auto* o = static_cast<const SetClipLoopRangeCommand*>(other);
         newLoopStart_ = o->newLoopStart_;
         newLoopLength_ = o->newLoopLength_;
         bpm_ = o->bpm_;
@@ -416,7 +412,7 @@ class SetClipPitchCommand : public UndoableCommand {
     }
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (const const const const auto* o = dynamic_cast<const SetClipPitchCommand*>(other))
+        if (const auto* o = dynamic_cast<const SetClipPitchCommand*>(other))
             return o->clipId_ == clipId_;
         return false;
     }
@@ -453,7 +449,7 @@ class SetClipSpeedRatioCommand : public UndoableCommand {
     }
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (const const const const auto* o = dynamic_cast<const SetClipSpeedRatioCommand*>(other))
+        if (const auto* o = dynamic_cast<const SetClipSpeedRatioCommand*>(other))
             return o->clipId_ == clipId_;
         return false;
     }
@@ -515,7 +511,7 @@ class SetClipVolumeDBCommand : public UndoableCommand {
     }
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (const const const const auto* o = dynamic_cast<const SetClipVolumeDBCommand*>(other))
+        if (const auto* o = dynamic_cast<const SetClipVolumeDBCommand*>(other))
             return o->clipId_ == clipId_;
         return false;
     }
@@ -550,7 +546,7 @@ class SetClipGainDBCommand : public UndoableCommand {
     }
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (const const const const auto* o = dynamic_cast<const SetClipGainDBCommand*>(other))
+        if (const auto* o = dynamic_cast<const SetClipGainDBCommand*>(other))
             return o->clipId_ == clipId_;
         return false;
     }
@@ -585,7 +581,7 @@ class SetClipPanCommand : public UndoableCommand {
     }
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (const const const const auto* o = dynamic_cast<const SetClipPanCommand*>(other))
+        if (const auto* o = dynamic_cast<const SetClipPanCommand*>(other))
             return o->clipId_ == clipId_;
         return false;
     }
@@ -649,7 +645,7 @@ class SetClipFadeInCommand : public UndoableCommand {
     }
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (const const const const auto* o = dynamic_cast<const SetClipFadeInCommand*>(other))
+        if (const auto* o = dynamic_cast<const SetClipFadeInCommand*>(other))
             return o->clipId_ == clipId_;
         return false;
     }
@@ -686,7 +682,7 @@ class SetClipFadeOutCommand : public UndoableCommand {
     }
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (const const const const auto* o = dynamic_cast<const SetClipFadeOutCommand*>(other))
+        if (const auto* o = dynamic_cast<const SetClipFadeOutCommand*>(other))
             return o->clipId_ == clipId_;
         return false;
     }
@@ -722,8 +718,7 @@ class SetClipLaunchFadeSamplesCommand : public UndoableCommand {
     }
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (const const const const auto* o =
-                dynamic_cast<const SetClipLaunchFadeSamplesCommand*>(other))
+        if (const auto* o = dynamic_cast<const SetClipLaunchFadeSamplesCommand*>(other))
             return o->clipId_ == clipId_;
         return false;
     }
@@ -759,12 +754,12 @@ class SetClipLengthBeatsCommand : public UndoableCommand {
     }
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (const const const const auto* o = dynamic_cast<const SetClipLengthBeatsCommand*>(other))
+        if (const auto* o = dynamic_cast<const SetClipLengthBeatsCommand*>(other))
             return o->clipId_ == clipId_;
         return false;
     }
     void mergeWith(const UndoableCommand* other) override {
-        const const const const auto* o = static_cast<const SetClipLengthBeatsCommand*>(other);
+        const auto* o = static_cast<const SetClipLengthBeatsCommand*>(other);
         newBeats_ = o->newBeats_;
         bpm_ = o->bpm_;
     }
@@ -962,8 +957,7 @@ class SetClipGrooveStrengthCommand : public UndoableCommand {
     }
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (const const const const auto* o =
-                dynamic_cast<const SetClipGrooveStrengthCommand*>(other))
+        if (const auto* o = dynamic_cast<const SetClipGrooveStrengthCommand*>(other))
             return o->clipId_ == clipId_;
         return false;
     }

--- a/magda/daw/core/ClipPropertyCommands.hpp
+++ b/magda/daw/core/ClipPropertyCommands.hpp
@@ -113,7 +113,7 @@ class SetClipOffsetCommand : public UndoableCommand {
     }
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (auto* o = dynamic_cast<const SetClipOffsetCommand*>(other))
+        if (const const const const auto* o = dynamic_cast<const SetClipOffsetCommand*>(other))
             return o->clipId_ == clipId_;
         return false;
     }
@@ -165,7 +165,7 @@ class SetClipLoopPhaseCommand : public UndoableCommand {
     }
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (auto* o = dynamic_cast<const SetClipLoopPhaseCommand*>(other))
+        if (const const const const auto* o = dynamic_cast<const SetClipLoopPhaseCommand*>(other))
             return o->clipId_ == clipId_;
         return false;
     }
@@ -205,12 +205,12 @@ class SetClipLoopStartCommand : public UndoableCommand {
     }
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (auto* o = dynamic_cast<const SetClipLoopStartCommand*>(other))
+        if (const const const const auto* o = dynamic_cast<const SetClipLoopStartCommand*>(other))
             return o->clipId_ == clipId_;
         return false;
     }
     void mergeWith(const UndoableCommand* other) override {
-        auto* o = static_cast<const SetClipLoopStartCommand*>(other);
+        const const const const auto* o = static_cast<const SetClipLoopStartCommand*>(other);
         newLoopStart_ = o->newLoopStart_;
         bpm_ = o->bpm_;
     }
@@ -244,12 +244,12 @@ class SetClipLoopLengthCommand : public UndoableCommand {
     }
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (auto* o = dynamic_cast<const SetClipLoopLengthCommand*>(other))
+        if (const const const const auto* o = dynamic_cast<const SetClipLoopLengthCommand*>(other))
             return o->clipId_ == clipId_;
         return false;
     }
     void mergeWith(const UndoableCommand* other) override {
-        auto* o = static_cast<const SetClipLoopLengthCommand*>(other);
+        const const const const auto* o = static_cast<const SetClipLoopLengthCommand*>(other);
         newLoopLength_ = o->newLoopLength_;
         bpm_ = o->bpm_;
     }
@@ -280,12 +280,14 @@ class SetMidiClipLoopStartBeatsCommand : public UndoableCommand {
     }
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (auto* o = dynamic_cast<const SetMidiClipLoopStartBeatsCommand*>(other))
+        if (const const const const auto* o =
+                dynamic_cast<const SetMidiClipLoopStartBeatsCommand*>(other))
             return o->clipId_ == clipId_;
         return false;
     }
     void mergeWith(const UndoableCommand* other) override {
-        auto* o = static_cast<const SetMidiClipLoopStartBeatsCommand*>(other);
+        const const const const auto* o =
+            static_cast<const SetMidiClipLoopStartBeatsCommand*>(other);
         newLoopStartBeats_ = o->newLoopStartBeats_;
         bpm_ = o->bpm_;
     }
@@ -316,12 +318,14 @@ class SetMidiClipLoopLengthBeatsCommand : public UndoableCommand {
     }
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (auto* o = dynamic_cast<const SetMidiClipLoopLengthBeatsCommand*>(other))
+        if (const const const const auto* o =
+                dynamic_cast<const SetMidiClipLoopLengthBeatsCommand*>(other))
             return o->clipId_ == clipId_;
         return false;
     }
     void mergeWith(const UndoableCommand* other) override {
-        auto* o = static_cast<const SetMidiClipLoopLengthBeatsCommand*>(other);
+        const const const const auto* o =
+            static_cast<const SetMidiClipLoopLengthBeatsCommand*>(other);
         newLoopLengthBeats_ = o->newLoopLengthBeats_;
         bpm_ = o->bpm_;
     }
@@ -370,12 +374,12 @@ class SetClipLoopRangeCommand : public UndoableCommand {
     }
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (auto* o = dynamic_cast<const SetClipLoopRangeCommand*>(other))
+        if (const const const const auto* o = dynamic_cast<const SetClipLoopRangeCommand*>(other))
             return o->clipId_ == clipId_;
         return false;
     }
     void mergeWith(const UndoableCommand* other) override {
-        auto* o = static_cast<const SetClipLoopRangeCommand*>(other);
+        const const const const auto* o = static_cast<const SetClipLoopRangeCommand*>(other);
         newLoopStart_ = o->newLoopStart_;
         newLoopLength_ = o->newLoopLength_;
         bpm_ = o->bpm_;
@@ -412,7 +416,7 @@ class SetClipPitchCommand : public UndoableCommand {
     }
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (auto* o = dynamic_cast<const SetClipPitchCommand*>(other))
+        if (const const const const auto* o = dynamic_cast<const SetClipPitchCommand*>(other))
             return o->clipId_ == clipId_;
         return false;
     }
@@ -449,7 +453,7 @@ class SetClipSpeedRatioCommand : public UndoableCommand {
     }
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (auto* o = dynamic_cast<const SetClipSpeedRatioCommand*>(other))
+        if (const const const const auto* o = dynamic_cast<const SetClipSpeedRatioCommand*>(other))
             return o->clipId_ == clipId_;
         return false;
     }
@@ -511,7 +515,7 @@ class SetClipVolumeDBCommand : public UndoableCommand {
     }
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (auto* o = dynamic_cast<const SetClipVolumeDBCommand*>(other))
+        if (const const const const auto* o = dynamic_cast<const SetClipVolumeDBCommand*>(other))
             return o->clipId_ == clipId_;
         return false;
     }
@@ -546,7 +550,7 @@ class SetClipGainDBCommand : public UndoableCommand {
     }
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (auto* o = dynamic_cast<const SetClipGainDBCommand*>(other))
+        if (const const const const auto* o = dynamic_cast<const SetClipGainDBCommand*>(other))
             return o->clipId_ == clipId_;
         return false;
     }
@@ -581,7 +585,7 @@ class SetClipPanCommand : public UndoableCommand {
     }
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (auto* o = dynamic_cast<const SetClipPanCommand*>(other))
+        if (const const const const auto* o = dynamic_cast<const SetClipPanCommand*>(other))
             return o->clipId_ == clipId_;
         return false;
     }
@@ -645,7 +649,7 @@ class SetClipFadeInCommand : public UndoableCommand {
     }
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (auto* o = dynamic_cast<const SetClipFadeInCommand*>(other))
+        if (const const const const auto* o = dynamic_cast<const SetClipFadeInCommand*>(other))
             return o->clipId_ == clipId_;
         return false;
     }
@@ -682,7 +686,7 @@ class SetClipFadeOutCommand : public UndoableCommand {
     }
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (auto* o = dynamic_cast<const SetClipFadeOutCommand*>(other))
+        if (const const const const auto* o = dynamic_cast<const SetClipFadeOutCommand*>(other))
             return o->clipId_ == clipId_;
         return false;
     }
@@ -718,7 +722,8 @@ class SetClipLaunchFadeSamplesCommand : public UndoableCommand {
     }
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (auto* o = dynamic_cast<const SetClipLaunchFadeSamplesCommand*>(other))
+        if (const const const const auto* o =
+                dynamic_cast<const SetClipLaunchFadeSamplesCommand*>(other))
             return o->clipId_ == clipId_;
         return false;
     }
@@ -754,12 +759,12 @@ class SetClipLengthBeatsCommand : public UndoableCommand {
     }
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (auto* o = dynamic_cast<const SetClipLengthBeatsCommand*>(other))
+        if (const const const const auto* o = dynamic_cast<const SetClipLengthBeatsCommand*>(other))
             return o->clipId_ == clipId_;
         return false;
     }
     void mergeWith(const UndoableCommand* other) override {
-        auto* o = static_cast<const SetClipLengthBeatsCommand*>(other);
+        const const const const auto* o = static_cast<const SetClipLengthBeatsCommand*>(other);
         newBeats_ = o->newBeats_;
         bpm_ = o->bpm_;
     }
@@ -957,7 +962,8 @@ class SetClipGrooveStrengthCommand : public UndoableCommand {
     }
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (auto* o = dynamic_cast<const SetClipGrooveStrengthCommand*>(other))
+        if (const const const const auto* o =
+                dynamic_cast<const SetClipGrooveStrengthCommand*>(other))
             return o->clipId_ == clipId_;
         return false;
     }

--- a/magda/daw/core/Config.cpp
+++ b/magda/daw/core/Config.cpp
@@ -607,7 +607,7 @@ void Config::load() {
                         // Flat provider/baseUrl/apiKey/model is the pre-profile
                         // on-disk shape. Read it as the LLM backend payload.
                         auto& cfg = profile.llm;
-                        const auto read = llmObj != nullptr ? llmObj : agentObj;
+                        auto* const read = llmObj != nullptr ? llmObj : agentObj;
                         cfg.provider = read->getProperty("provider").toString().toStdString();
                         cfg.baseUrl = read->getProperty("baseUrl").toString().toStdString();
                         cfg.apiKey = read->getProperty("apiKey").toString().toStdString();

--- a/magda/daw/core/GestureRouter.cpp
+++ b/magda/daw/core/GestureRouter.cpp
@@ -394,7 +394,7 @@ ResolvedGesture GestureRouter::resolve(GestureContext context, GestureArea area,
 
     GestureInput input{wheel.isSmooth ? GestureInputKind::SmoothWheel : GestureInputKind::Wheel,
                        area, axis, gestureModifierMaskFrom(mods)};
-    auto* binding = findBinding(context, input);
+    const auto* binding = findBinding(context, input);
     // Existing contexts intentionally need no duplicate smooth rows. They use
     // the ordinary wheel binding unless a context provides a distinct smooth
     // default/override (currently the EQ curve editor).

--- a/magda/daw/core/MidiNoteCommands.cpp
+++ b/magda/daw/core/MidiNoteCommands.cpp
@@ -246,12 +246,12 @@ void MoveMidiNoteCommand::undo() {
 }
 
 bool MoveMidiNoteCommand::canMergeWith(const UndoableCommand* other) const {
-    auto* otherMove = dynamic_cast<const MoveMidiNoteCommand*>(other);
+    const auto* otherMove = dynamic_cast<const MoveMidiNoteCommand*>(other);
     return otherMove && otherMove->clipId_ == clipId_ && otherMove->noteIndex_ == noteIndex_;
 }
 
 void MoveMidiNoteCommand::mergeWith(const UndoableCommand* other) {
-    auto* otherMove = dynamic_cast<const MoveMidiNoteCommand*>(other);
+    const auto* otherMove = dynamic_cast<const MoveMidiNoteCommand*>(other);
     if (otherMove) {
         newStartBeat_ = otherMove->newStartBeat_;
         newNoteNumber_ = otherMove->newNoteNumber_;
@@ -308,12 +308,12 @@ void ResizeMidiNoteCommand::undo() {
 }
 
 bool ResizeMidiNoteCommand::canMergeWith(const UndoableCommand* other) const {
-    auto* otherResize = dynamic_cast<const ResizeMidiNoteCommand*>(other);
+    const auto* otherResize = dynamic_cast<const ResizeMidiNoteCommand*>(other);
     return otherResize && otherResize->clipId_ == clipId_ && otherResize->noteIndex_ == noteIndex_;
 }
 
 void ResizeMidiNoteCommand::mergeWith(const UndoableCommand* other) {
-    auto* otherResize = dynamic_cast<const ResizeMidiNoteCommand*>(other);
+    const auto* otherResize = dynamic_cast<const ResizeMidiNoteCommand*>(other);
     if (otherResize) {
         newLengthBeats_ = otherResize->newLengthBeats_;
     }
@@ -411,13 +411,13 @@ void SetMidiNoteVelocityCommand::undo() {
 }
 
 bool SetMidiNoteVelocityCommand::canMergeWith(const UndoableCommand* other) const {
-    auto* otherVelocity = dynamic_cast<const SetMidiNoteVelocityCommand*>(other);
+    const auto* otherVelocity = dynamic_cast<const SetMidiNoteVelocityCommand*>(other);
     return otherVelocity && otherVelocity->clipId_ == clipId_ &&
            otherVelocity->noteIndex_ == noteIndex_;
 }
 
 void SetMidiNoteVelocityCommand::mergeWith(const UndoableCommand* other) {
-    auto* otherVelocity = dynamic_cast<const SetMidiNoteVelocityCommand*>(other);
+    const auto* otherVelocity = dynamic_cast<const SetMidiNoteVelocityCommand*>(other);
     if (otherVelocity) {
         newVelocity_ = otherVelocity->newVelocity_;
     }
@@ -470,7 +470,7 @@ void SetMultipleMidiNoteVelocitiesCommand::undo() {
 }
 
 bool SetMultipleMidiNoteVelocitiesCommand::canMergeWith(const UndoableCommand* other) const {
-    auto* o = dynamic_cast<const SetMultipleMidiNoteVelocitiesCommand*>(other);
+    const auto* o = dynamic_cast<const SetMultipleMidiNoteVelocitiesCommand*>(other);
     if (!o || o->clipId_ != clipId_ || o->entries_.size() != entries_.size())
         return false;
     // Same note set (same order, which the gesture builds deterministically).
@@ -478,7 +478,7 @@ bool SetMultipleMidiNoteVelocitiesCommand::canMergeWith(const UndoableCommand* o
 }
 
 void SetMultipleMidiNoteVelocitiesCommand::mergeWith(const UndoableCommand* other) {
-    auto* o = dynamic_cast<const SetMultipleMidiNoteVelocitiesCommand*>(other);
+    const auto* o = dynamic_cast<const SetMultipleMidiNoteVelocitiesCommand*>(other);
     if (!o || o->entries_.size() != entries_.size())
         return;
     // Keep our captured old velocities; adopt the newer target velocities.
@@ -1131,12 +1131,12 @@ void TransposeMidiClipCommand::undo() {
 }
 
 bool TransposeMidiClipCommand::canMergeWith(const UndoableCommand* other) const {
-    auto* otherTranspose = dynamic_cast<const TransposeMidiClipCommand*>(other);
+    const auto* otherTranspose = dynamic_cast<const TransposeMidiClipCommand*>(other);
     return otherTranspose && otherTranspose->clipId_ == clipId_;
 }
 
 void TransposeMidiClipCommand::mergeWith(const UndoableCommand* other) {
-    auto* otherTranspose = dynamic_cast<const TransposeMidiClipCommand*>(other);
+    const auto* otherTranspose = dynamic_cast<const TransposeMidiClipCommand*>(other);
     if (otherTranspose) {
         semitones_ += otherTranspose->semitones_;
     }
@@ -1208,12 +1208,12 @@ void EditMidiCCEventCommand::undo() {
 }
 
 bool EditMidiCCEventCommand::canMergeWith(const UndoableCommand* other) const {
-    auto* o = dynamic_cast<const EditMidiCCEventCommand*>(other);
+    const auto* o = dynamic_cast<const EditMidiCCEventCommand*>(other);
     return o && o->clipId_ == clipId_ && o->eventIndex_ == eventIndex_;
 }
 
 void EditMidiCCEventCommand::mergeWith(const UndoableCommand* other) {
-    auto* o = dynamic_cast<const EditMidiCCEventCommand*>(other);
+    const auto* o = dynamic_cast<const EditMidiCCEventCommand*>(other);
     if (o)
         newValue_ = o->newValue_;
 }
@@ -1335,12 +1335,12 @@ void MoveMidiCCEventCommand::undo() {
 }
 
 bool MoveMidiCCEventCommand::canMergeWith(const UndoableCommand* other) const {
-    auto* o = dynamic_cast<const MoveMidiCCEventCommand*>(other);
+    const auto* o = dynamic_cast<const MoveMidiCCEventCommand*>(other);
     return o && o->clipId_ == clipId_ && o->eventIndex_ == eventIndex_;
 }
 
 void MoveMidiCCEventCommand::mergeWith(const UndoableCommand* other) {
-    auto* o = dynamic_cast<const MoveMidiCCEventCommand*>(other);
+    const auto* o = dynamic_cast<const MoveMidiCCEventCommand*>(other);
     if (o) {
         newBeatPosition_ = o->newBeatPosition_;
         newValue_ = o->newValue_;
@@ -1390,12 +1390,12 @@ void MoveMidiPitchBendEventCommand::undo() {
 }
 
 bool MoveMidiPitchBendEventCommand::canMergeWith(const UndoableCommand* other) const {
-    auto* o = dynamic_cast<const MoveMidiPitchBendEventCommand*>(other);
+    const auto* o = dynamic_cast<const MoveMidiPitchBendEventCommand*>(other);
     return o && o->clipId_ == clipId_ && o->eventIndex_ == eventIndex_;
 }
 
 void MoveMidiPitchBendEventCommand::mergeWith(const UndoableCommand* other) {
-    auto* o = dynamic_cast<const MoveMidiPitchBendEventCommand*>(other);
+    const auto* o = dynamic_cast<const MoveMidiPitchBendEventCommand*>(other);
     if (o) {
         newBeatPosition_ = o->newBeatPosition_;
         newValue_ = o->newValue_;
@@ -1524,12 +1524,12 @@ void EditMidiPitchBendEventCommand::undo() {
 }
 
 bool EditMidiPitchBendEventCommand::canMergeWith(const UndoableCommand* other) const {
-    auto* o = dynamic_cast<const EditMidiPitchBendEventCommand*>(other);
+    const auto* o = dynamic_cast<const EditMidiPitchBendEventCommand*>(other);
     return o && o->clipId_ == clipId_ && o->eventIndex_ == eventIndex_;
 }
 
 void EditMidiPitchBendEventCommand::mergeWith(const UndoableCommand* other) {
-    auto* o = dynamic_cast<const EditMidiPitchBendEventCommand*>(other);
+    const auto* o = dynamic_cast<const EditMidiPitchBendEventCommand*>(other);
     if (o)
         newValue_ = o->newValue_;
 }
@@ -1694,12 +1694,12 @@ void SetMidiCCEventTensionCommand::undo() {
 }
 
 bool SetMidiCCEventTensionCommand::canMergeWith(const UndoableCommand* other) const {
-    auto* o = dynamic_cast<const SetMidiCCEventTensionCommand*>(other);
+    const auto* o = dynamic_cast<const SetMidiCCEventTensionCommand*>(other);
     return o && o->clipId_ == clipId_ && o->eventIndex_ == eventIndex_;
 }
 
 void SetMidiCCEventTensionCommand::mergeWith(const UndoableCommand* other) {
-    auto* o = dynamic_cast<const SetMidiCCEventTensionCommand*>(other);
+    const auto* o = dynamic_cast<const SetMidiCCEventTensionCommand*>(other);
     if (o)
         newTension_ = o->newTension_;
 }
@@ -1765,12 +1765,12 @@ void SetMidiPitchBendEventTensionCommand::undo() {
 }
 
 bool SetMidiPitchBendEventTensionCommand::canMergeWith(const UndoableCommand* other) const {
-    auto* o = dynamic_cast<const SetMidiPitchBendEventTensionCommand*>(other);
+    const auto* o = dynamic_cast<const SetMidiPitchBendEventTensionCommand*>(other);
     return o && o->clipId_ == clipId_ && o->eventIndex_ == eventIndex_;
 }
 
 void SetMidiPitchBendEventTensionCommand::mergeWith(const UndoableCommand* other) {
-    auto* o = dynamic_cast<const SetMidiPitchBendEventTensionCommand*>(other);
+    const auto* o = dynamic_cast<const SetMidiPitchBendEventTensionCommand*>(other);
     if (o)
         newTension_ = o->newTension_;
 }

--- a/magda/daw/core/TrackPropertyCommands.hpp
+++ b/magda/daw/core/TrackPropertyCommands.hpp
@@ -51,7 +51,8 @@ class SetTrackVolumeCommand : public UndoableCommand {
     }
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (auto* o = dynamic_cast<const SetTrackVolumeCommand*>(other))
+        if (const const const const const auto* o =
+                dynamic_cast<const SetTrackVolumeCommand*>(other))
             return o->trackId_ == trackId_;
         return false;
     }
@@ -88,7 +89,7 @@ class SetTrackPanCommand : public UndoableCommand {
     }
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (auto* o = dynamic_cast<const SetTrackPanCommand*>(other))
+        if (const const const const const auto* o = dynamic_cast<const SetTrackPanCommand*>(other))
             return o->trackId_ == trackId_;
         return false;
     }
@@ -122,7 +123,8 @@ class SetTrackMixerChannelWidthCommand : public UndoableCommand {
     }
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (auto* o = dynamic_cast<const SetTrackMixerChannelWidthCommand*>(other))
+        if (const const const const const auto* o =
+                dynamic_cast<const SetTrackMixerChannelWidthCommand*>(other))
             return o->trackId_ == trackId_;
         return false;
     }
@@ -157,7 +159,8 @@ class SetTrackMixerFaderTopInsetCommand : public UndoableCommand {
     }
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (auto* o = dynamic_cast<const SetTrackMixerFaderTopInsetCommand*>(other))
+        if (const const const const const auto* o =
+                dynamic_cast<const SetTrackMixerFaderTopInsetCommand*>(other))
             return o->trackId_ == trackId_;
         return false;
     }
@@ -538,7 +541,7 @@ class SetSendLevelCommand : public UndoableCommand {
     }
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (auto* o = dynamic_cast<const SetSendLevelCommand*>(other))
+        if (const const const const const auto* o = dynamic_cast<const SetSendLevelCommand*>(other))
             return o->trackId_ == trackId_ && o->busIndex_ == busIndex_;
         return false;
     }

--- a/magda/daw/core/TrackPropertyCommands.hpp
+++ b/magda/daw/core/TrackPropertyCommands.hpp
@@ -51,8 +51,7 @@ class SetTrackVolumeCommand : public UndoableCommand {
     }
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (const const const const const auto* o =
-                dynamic_cast<const SetTrackVolumeCommand*>(other))
+        if (const auto* o = dynamic_cast<const SetTrackVolumeCommand*>(other))
             return o->trackId_ == trackId_;
         return false;
     }
@@ -89,7 +88,7 @@ class SetTrackPanCommand : public UndoableCommand {
     }
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (const const const const const auto* o = dynamic_cast<const SetTrackPanCommand*>(other))
+        if (const auto* o = dynamic_cast<const SetTrackPanCommand*>(other))
             return o->trackId_ == trackId_;
         return false;
     }
@@ -123,8 +122,7 @@ class SetTrackMixerChannelWidthCommand : public UndoableCommand {
     }
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (const const const const const auto* o =
-                dynamic_cast<const SetTrackMixerChannelWidthCommand*>(other))
+        if (const auto* o = dynamic_cast<const SetTrackMixerChannelWidthCommand*>(other))
             return o->trackId_ == trackId_;
         return false;
     }
@@ -159,8 +157,7 @@ class SetTrackMixerFaderTopInsetCommand : public UndoableCommand {
     }
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (const const const const const auto* o =
-                dynamic_cast<const SetTrackMixerFaderTopInsetCommand*>(other))
+        if (const auto* o = dynamic_cast<const SetTrackMixerFaderTopInsetCommand*>(other))
             return o->trackId_ == trackId_;
         return false;
     }
@@ -541,7 +538,7 @@ class SetSendLevelCommand : public UndoableCommand {
     }
 
     bool canMergeWith(const UndoableCommand* other) const override {
-        if (const const const const const auto* o = dynamic_cast<const SetSendLevelCommand*>(other))
+        if (const auto* o = dynamic_cast<const SetSendLevelCommand*>(other))
             return o->trackId_ == trackId_ && o->busIndex_ == busIndex_;
         return false;
     }

--- a/magda/daw/core/WarpMarkerCommands.cpp
+++ b/magda/daw/core/WarpMarkerCommands.cpp
@@ -59,7 +59,7 @@ void MoveWarpMarkerCommand::undo() {
 }
 
 bool MoveWarpMarkerCommand::canMergeWith(const UndoableCommand* other) const {
-    auto* otherMove = dynamic_cast<const MoveWarpMarkerCommand*>(other);
+    const auto* otherMove = dynamic_cast<const MoveWarpMarkerCommand*>(other);
     if (!otherMove)
         return false;
 
@@ -68,7 +68,7 @@ bool MoveWarpMarkerCommand::canMergeWith(const UndoableCommand* other) const {
 }
 
 void MoveWarpMarkerCommand::mergeWith(const UndoableCommand* other) {
-    auto* otherMove = dynamic_cast<const MoveWarpMarkerCommand*>(other);
+    const auto* otherMove = dynamic_cast<const MoveWarpMarkerCommand*>(other);
     if (otherMove) {
         // Keep our oldWarpTime_, update newWarpTime_ to the latest
         newWarpTime_ = otherMove->newWarpTime_;

--- a/magda/daw/core/controllers/BindingRegistry.cpp
+++ b/magda/daw/core/controllers/BindingRegistry.cpp
@@ -198,7 +198,7 @@ bool sourcesOverlap(const BindingSource& a, const BindingSource& b) {
 }
 
 bool isFocusedDeviceMacroResolver(const Target& t) {
-    if (auto* rr = std::get_if<ResolverRef>(&t))
+    if (const auto* rr = std::get_if<ResolverRef>(&t))
         return rr->kind == "focused.macro";
     return false;
 }
@@ -212,7 +212,7 @@ bool isFocusedDeviceMacroResolver(const Target& t) {
 // (focused.macro and any future kinds) are profile-driven defaults and
 // do not count.
 bool isExplicitPluginParamTarget(const Target& t) {
-    if (auto* st = std::get_if<ControlTarget>(&t))
+    if (const auto* st = std::get_if<ControlTarget>(&t))
         return st->kind == ControlTarget::Kind::PluginParam;
     if (std::holds_alternative<AliasRef>(t))
         return true;
@@ -327,7 +327,7 @@ bool BindingRegistry::hasActiveStaticBindingForMacro(const ChainNodePath& device
                                                      int macroIndex) const {
     const auto check = [&](const std::vector<Binding>& vec) -> bool {
         const auto matchesMacro = [&](const Binding& b) {
-            auto* st = std::get_if<ControlTarget>(&b.target);
+            const auto* st = std::get_if<ControlTarget>(&b.target);
             return st != nullptr && st->kind == ControlTarget::Kind::DeviceMacro &&
                    st->devicePath == devicePath && st->paramIndex == macroIndex;
         };
@@ -341,7 +341,7 @@ int BindingRegistry::removeStaticBindingsForMacro(const ChainNodePath& devicePat
     std::vector<BindingId> toRemoveProject;
     auto collect = [&](const std::vector<Binding>& vec, std::vector<BindingId>& out) {
         for (const auto& b : vec) {
-            auto* st = std::get_if<ControlTarget>(&b.target);
+            const auto* st = std::get_if<ControlTarget>(&b.target);
             if (st == nullptr)
                 continue;
             if (st->kind != ControlTarget::Kind::DeviceMacro)

--- a/magda/daw/core/controllers/ControllerRegistry.cpp
+++ b/magda/daw/core/controllers/ControllerRegistry.cpp
@@ -59,7 +59,7 @@ bool ControllerRegistry::rematchInputPorts(const juce::Array<juce::MidiDeviceInf
         const auto matchesName = [&c](const juce::MidiDeviceInfo& dev) {
             return dev.name == c.inputPortName;
         };
-        if (const auto found = std::ranges::find_if(liveInputs, matchesName);
+        if (const auto* const found = std::ranges::find_if(liveInputs, matchesName);
             found != liveInputs.end()) {
             c.inputPort = found->identifier;
             changed = true;

--- a/magda/daw/engine/MagdaEngineBehaviour.hpp
+++ b/magda/daw/engine/MagdaEngineBehaviour.hpp
@@ -76,7 +76,7 @@ class MagdaEngineBehaviour : public tracktion::EngineBehaviour {
             return plugin;
 
         const auto type = info.state[tracktion::IDs::type].toString();
-        if (auto* spec = daw::audio::compiled::findCompiledPluginSpec(type)) {
+        if (const auto* spec = daw::audio::compiled::findCompiledPluginSpec(type)) {
             return daw::audio::compiled::createTracktionPlugin(*spec, info);
         }
         DBG("MagdaEngineBehaviour::createCustomPlugin - unknown type: " << type);

--- a/magda/daw/engine/TracktionEngineWrapper.cpp
+++ b/magda/daw/engine/TracktionEngineWrapper.cpp
@@ -120,7 +120,7 @@ std::vector<SamplerMediaReference> TracktionEngineWrapper::getSamplerMediaRefere
                               }});
     };
 
-    for (auto plugin : tracktion::getAllPlugins(*currentEdit_, true)) {
+    for (auto* plugin : tracktion::getAllPlugins(*currentEdit_, true)) {
         addSampler(plugin);
         if (auto* drumGrid = dynamic_cast<daw::audio::DrumGridPlugin*>(plugin))
             for (const auto& chain : drumGrid->getChains())

--- a/magda/daw/engine/TracktionEngineWrapperClips.cpp
+++ b/magda/daw/engine/TracktionEngineWrapperClips.cpp
@@ -4,7 +4,7 @@ namespace magda {
 
 std::string TracktionEngineWrapper::addMidiClip(const std::string& track_id, double start_time,
                                                 double length, const std::vector<MidiNote>& notes) {
-    auto track = findTrackById(track_id);
+    auto* track = findTrackById(track_id);
     if (!track || !currentEdit_) {
         DBG("addMidiClip: Track not found or no edit: " << track_id);
         return "";
@@ -287,7 +287,7 @@ std::vector<MidiNote> TracktionEngineWrapper::getMidiClipNotes(const std::string
 }
 
 std::vector<std::string> TracktionEngineWrapper::getTrackClips(const std::string& track_id) const {
-    auto track = findTrackById(track_id);
+    auto* track = findTrackById(track_id);
     if (!track) {
         DBG("getTrackClips: Track not found: " << track_id);
         return {};

--- a/magda/daw/engine/TracktionEngineWrapperInit.cpp
+++ b/magda/daw/engine/TracktionEngineWrapperInit.cpp
@@ -184,7 +184,7 @@ void TracktionEngineWrapper::configureAudioDevices() {
 
     auto& dm = engine_->getDeviceManager();
     auto& juceDeviceManager = dm.deviceManager;
-    auto& deviceTypes = juceDeviceManager.getAvailableDeviceTypes();
+    const auto& deviceTypes = juceDeviceManager.getAvailableDeviceTypes();
 
     if (deviceTypes.isEmpty()) {
         return;
@@ -336,7 +336,7 @@ void TracktionEngineWrapper::createEditAndBridges() {
     // Set default tempo
     auto& tempoSeq = currentEdit_->tempoSequence;
     if (tempoSeq.getNumTempos() > 0) {
-        auto tempo = tempoSeq.getTempo(0);
+        auto* tempo = tempoSeq.getTempo(0);
         if (tempo) {
             tempo->setBpm(120.0);
         }
@@ -402,7 +402,7 @@ void TracktionEngineWrapper::createEditAndBridges() {
         // Capture zoom/scroll state
         if (auto* tc = TimelineController::getCurrent()) {
             const auto& timelineState = tc->getState();
-            auto& zoom = timelineState.zoom;
+            const auto& zoom = timelineState.zoom;
             auto& proj = ProjectManager::getInstance().getMutableProjectInfo();
             proj.horizontalZoom = zoom.horizontalZoom;
             proj.verticalZoom = zoom.verticalZoom;

--- a/magda/daw/engine/TracktionEngineWrapperTracks.cpp
+++ b/magda/daw/engine/TracktionEngineWrapperTracks.cpp
@@ -56,45 +56,45 @@ void TracktionEngineWrapper::deleteTrack(const std::string& track_id) {
 }
 
 void TracktionEngineWrapper::setTrackName(const std::string& track_id, const std::string& name) {
-    auto track = findTrackById(track_id);
+    auto* track = findTrackById(track_id);
     if (track) {
         track->setName(name);
     }
 }
 
 std::string TracktionEngineWrapper::getTrackName(const std::string& track_id) const {
-    auto track = findTrackById(track_id);
+    auto* track = findTrackById(track_id);
     return track ? track->getName().toStdString() : "";
 }
 
 void TracktionEngineWrapper::setTrackMuted(const std::string& track_id, bool muted) {
-    auto track = findTrackById(track_id);
+    auto* track = findTrackById(track_id);
     if (track) {
         track->setMute(muted);
     }
 }
 
 bool TracktionEngineWrapper::isTrackMuted(const std::string& track_id) const {
-    auto track = findTrackById(track_id);
+    auto* track = findTrackById(track_id);
     return track ? track->isMuted(false) : false;
 }
 
 void TracktionEngineWrapper::setTrackSolo(const std::string& track_id, bool solo) {
-    auto track = findTrackById(track_id);
+    auto* track = findTrackById(track_id);
     if (track) {
         track->setSolo(solo);
     }
 }
 
 bool TracktionEngineWrapper::isTrackSolo(const std::string& track_id) const {
-    auto track = findTrackById(track_id);
+    auto* track = findTrackById(track_id);
     return track ? track->isSolo(false) : false;
 }
 
 void TracktionEngineWrapper::setTrackArmed(const std::string& track_id, bool armed) {
-    auto track = findTrackById(track_id);
+    auto* track = findTrackById(track_id);
     if (track) {
-        if (auto audioTrack = dynamic_cast<tracktion::AudioTrack*>(track)) {
+        if (auto* audioTrack = dynamic_cast<tracktion::AudioTrack*>(track)) {
             // Simplified - in real implementation would set input recording
             DBG("Set track armed (stub): " << track_id << " = " << (int)armed);
         }
@@ -102,9 +102,9 @@ void TracktionEngineWrapper::setTrackArmed(const std::string& track_id, bool arm
 }
 
 bool TracktionEngineWrapper::isTrackArmed(const std::string& track_id) const {
-    auto track = findTrackById(track_id);
+    auto* track = findTrackById(track_id);
     if (track) {
-        if (auto audioTrack = dynamic_cast<tracktion::AudioTrack*>(track)) {
+        if (auto* audioTrack = dynamic_cast<tracktion::AudioTrack*>(track)) {
             // Simplified - in real implementation would check input recording
             return false;
         }
@@ -113,7 +113,7 @@ bool TracktionEngineWrapper::isTrackArmed(const std::string& track_id) const {
 }
 
 void TracktionEngineWrapper::setTrackColor(const std::string& track_id, int r, int g, int b) {
-    auto track = findTrackById(track_id);
+    auto* track = findTrackById(track_id);
     if (track) {
         track->setColour(juce::Colour::fromRGB(r, g, b));
     }
@@ -170,10 +170,10 @@ void TracktionEngineWrapper::previewNoteOnTrack(const std::string& track_id, int
 }
 
 void TracktionEngineWrapper::setTrackVolume(const std::string& track_id, double volume) {
-    auto track = findTrackById(track_id);
+    auto* track = findTrackById(track_id);
     if (track) {
         // Find VolumeAndPanPlugin on track
-        if (auto volPan =
+        if (auto* volPan =
                 track->pluginList.findFirstPluginOfType<tracktion::VolumeAndPanPlugin>()) {
             // Convert linear gain to dB for the plugin
             float db =
@@ -187,9 +187,9 @@ void TracktionEngineWrapper::setTrackVolume(const std::string& track_id, double 
 }
 
 double TracktionEngineWrapper::getTrackVolume(const std::string& track_id) const {
-    auto track = findTrackById(track_id);
+    auto* track = findTrackById(track_id);
     if (track) {
-        if (auto volPan =
+        if (auto* volPan =
                 track->pluginList.findFirstPluginOfType<tracktion::VolumeAndPanPlugin>()) {
             float db = volPan->getVolumeDb();
             return juce::Decibels::decibelsToGain(db);
@@ -199,9 +199,9 @@ double TracktionEngineWrapper::getTrackVolume(const std::string& track_id) const
 }
 
 void TracktionEngineWrapper::setTrackPan(const std::string& track_id, double pan) {
-    auto track = findTrackById(track_id);
+    auto* track = findTrackById(track_id);
     if (track) {
-        if (auto volPan =
+        if (auto* volPan =
                 track->pluginList.findFirstPluginOfType<tracktion::VolumeAndPanPlugin>()) {
             // Pan is -1.0 (left) to 1.0 (right)
             volPan->setPan(static_cast<float>(pan));
@@ -210,9 +210,9 @@ void TracktionEngineWrapper::setTrackPan(const std::string& track_id, double pan
 }
 
 double TracktionEngineWrapper::getTrackPan(const std::string& track_id) const {
-    auto track = findTrackById(track_id);
+    auto* track = findTrackById(track_id);
     if (track) {
-        if (auto volPan =
+        if (auto* volPan =
                 track->pluginList.findFirstPluginOfType<tracktion::VolumeAndPanPlugin>()) {
             return volPan->getPan();
         }

--- a/magda/daw/engine/TracktionEngineWrapperTransport.cpp
+++ b/magda/daw/engine/TracktionEngineWrapperTransport.cpp
@@ -111,7 +111,7 @@ void TracktionEngineWrapper::sendAllNotesOffToExternalInserts() {
 
     // Deliberately not gated on isEnabled(): a just-disabled insert may
     // still have a note-on in flight on its hardware synth.
-    for (auto plugin : tracktion::getAllPlugins(*currentEdit_, false)) {
+    for (auto* plugin : tracktion::getAllPlugins(*currentEdit_, false)) {
         auto* insert = dynamic_cast<tracktion::InsertPlugin*>(plugin);
         if (insert == nullptr)
             continue;
@@ -273,7 +273,7 @@ void TracktionEngineWrapper::setTempo(double bpm) {
     if (currentEdit_) {
         auto& tempoSeq = currentEdit_->tempoSequence;
         if (tempoSeq.getNumTempos() > 0) {
-            auto tempo = tempoSeq.getTempo(0);
+            auto* tempo = tempoSeq.getTempo(0);
             if (tempo) {
                 tempo->setBpm(bpm);
             }

--- a/magda/daw/project/ProjectManager.cpp
+++ b/magda/daw/project/ProjectManager.cpp
@@ -922,7 +922,7 @@ void ProjectManager::createTempMediaDirectory() {
 void ProjectManager::ensureMediaSubdirectories(const juce::File& mediaRoot) {
     if (mediaRoot == juce::File())
         return;
-    for (auto* subdir : kMediaSubdirs) {
+    for (const auto* subdir : kMediaSubdirs) {
         mediaRoot.getChildFile(subdir).createDirectory();
     }
 }
@@ -936,7 +936,7 @@ void ProjectManager::migrateMediaFiles(const juce::File& oldDir, const juce::Fil
     // recorded correctly, and nothing may be stranded in the directory being
     // left behind.
     std::map<juce::String, juce::String> moves;
-    for (auto* subdir : kMediaSubdirs)
+    for (const auto* subdir : kMediaSubdirs)
         moveMediaTree(oldDir.getChildFile(subdir), newDir.getChildFile(subdir), moves,
                       OnCollision::Uniquify);
 

--- a/magda/daw/project/serialization/DawProjectXmlAdapter.cpp
+++ b/magda/daw/project/serialization/DawProjectXmlAdapter.cpp
@@ -164,12 +164,12 @@ void addAutomationPoints(juce::XmlElement& parent, const juce::String& id,
 void addTrackAutomation(juce::XmlElement& trackLanes, const ProjectDocument& document,
                         const TrackInfo& track) {
     const auto volumeTarget = ControlTarget::trackVolume(track.id);
-    if (auto* lane = findAbsoluteLane(document, volumeTarget))
+    if (const auto* lane = findAbsoluteLane(document, volumeTarget))
         addAutomationPoints(trackLanes, idFor("volumeAutomation", track.id),
                             idFor("volume", track.id), *lane);
 
     const auto panTarget = ControlTarget::trackPan(track.id);
-    if (auto* lane = findAbsoluteLane(document, panTarget))
+    if (const auto* lane = findAbsoluteLane(document, panTarget))
         addAutomationPoints(trackLanes, idFor("panAutomation", track.id), idFor("pan", track.id),
                             *lane);
 }

--- a/magda/daw/ui/components/chain/compiled/CompiledUtilityView.cpp
+++ b/magda/daw/ui/components/chain/compiled/CompiledUtilityView.cpp
@@ -286,7 +286,7 @@ void CompiledUtilityView::updateLinkSlotValues() {
 
     auto update = [this](ParamSlotComponent& slot, int slotIndex, float fallback, bool& infoSet) {
         if (!infoSet) {
-            if (auto* param = parameterForSlot(deviceSnapshot_, slotIndex)) {
+            if (const auto* param = parameterForSlot(deviceSnapshot_, slotIndex)) {
                 infoSet = true;
                 slot.setParameterInfo(*param);
             }

--- a/magda/daw/ui/components/chain/custom_ui/FourOscUI.cpp
+++ b/magda/daw/ui/components/chain/custom_ui/FourOscUI.cpp
@@ -57,7 +57,7 @@ void FourOscUI::updateModMatrix(const std::vector<ModMatrixEntry>& entries) {
     // Split entries by source: LFO sources -> LFO tab, Env sources -> ModEnv tab
     // ModSource enum: lfo1=0, lfo2=1, env1=2, env2=3
     std::vector<ModMatrixEntry> lfoEntries, envEntries;
-    for (auto& e : entries) {
+    for (const auto& e : entries) {
         if (e.modSourceId == 0 || e.modSourceId == 1)
             lfoEntries.push_back(e);
         else if (e.modSourceId == 2 || e.modSourceId == 3)

--- a/magda/daw/ui/components/chain/drum_grid/PadChainPanel.cpp
+++ b/magda/daw/ui/components/chain/drum_grid/PadChainPanel.cpp
@@ -65,7 +65,7 @@ void PadChainPanel::refresh() {
 
 std::vector<tracktion::engine::Plugin*> PadChainPanel::getCollapsedPlugins() const {
     std::vector<tracktion::engine::Plugin*> result;
-    for (auto& slot : slots_) {
+    for (const auto& slot : slots_) {
         if (slot->isCollapsed() && slot->getPlugin())
             result.push_back(slot->getPlugin());
     }
@@ -146,7 +146,7 @@ int PadChainPanel::getContentWidth() const {
     // Must match resized() calculation: 2px left padding + slots + arrows + 2px right padding
     // plus DROP_ZONE_WIDTH (reserved outside the viewport)
     int width = 2;
-    for (auto& slot : slots_) {
+    for (const auto& slot : slots_) {
         if (width > 2)
             width += ARROW_WIDTH;
         width += slot->getPreferredWidth();
@@ -403,7 +403,7 @@ int PadChainPanel::calculateInsertIndex(int mouseX) const {
     int containerX = mouseX + viewport_.getViewPositionX() - viewport_.getX();
 
     for (size_t i = 0; i < slots_.size(); ++i) {
-        auto& slot = slots_[i];
+        const auto& slot = slots_[i];
         int slotMid = slot->getX() + slot->getWidth() / 2;
         if (containerX < slotMid)
             return static_cast<int>(i);

--- a/magda/daw/ui/components/chain/modulation/ModulatorEditorPanel.cpp
+++ b/magda/daw/ui/components/chain/modulation/ModulatorEditorPanel.cpp
@@ -1712,27 +1712,29 @@ void ModulatorEditorPanel::mouseDown(const juce::MouseEvent& e) {
 
             if (lmm.getLinkModeType() == magda::LinkModeType::Macro) {
                 const auto& sel = lmm.getMacroInLinkMode();
-                if (auto* macros = findMacrosAt(sel.parentPath)) {
+                if (const auto* macros = findMacrosAt(sel.parentPath)) {
                     if (sel.macroIndex >= 0 && sel.macroIndex < static_cast<int>(macros->size())) {
                         magda::ControlTarget t;
                         t.kind = magda::ControlTarget::Kind::ModParam;
                         t.devicePath = ownerDevicePath_;
                         t.modId = currentMod_.id;
                         t.modParamIndex = 0;
-                        if (auto* link = (*macros)[static_cast<size_t>(sel.macroIndex)].getLink(t))
+                        if (const auto* link =
+                                (*macros)[static_cast<size_t>(sel.macroIndex)].getLink(t))
                             initialAmount = link->amount;
                     }
                 }
             } else if (lmm.getLinkModeType() == magda::LinkModeType::Mod) {
                 const auto& sel = lmm.getModInLinkMode();
-                if (auto* mods = findModsAt(sel.parentPath)) {
+                if (const auto* mods = findModsAt(sel.parentPath)) {
                     if (sel.modIndex >= 0 && sel.modIndex < static_cast<int>(mods->size())) {
                         magda::ControlTarget t;
                         t.kind = magda::ControlTarget::Kind::ModParam;
                         t.devicePath = ownerDevicePath_;
                         t.modId = currentMod_.id;
                         t.modParamIndex = 0;
-                        if (auto* link = (*mods)[static_cast<size_t>(sel.modIndex)].getLink(t))
+                        if (const auto* link =
+                                (*mods)[static_cast<size_t>(sel.modIndex)].getLink(t))
                             initialAmount = link->amount;
                     }
                 }

--- a/magda/daw/ui/components/chain/slot/DeviceCustomUIManager.cpp
+++ b/magda/daw/ui/components/chain/slot/DeviceCustomUIManager.cpp
@@ -418,7 +418,7 @@ magda::DeviceInfo projectPadPluginDevice(magda::DeviceId deviceId,
         device.isInstrument = ext->desc.isInstrument;
         device.deviceType =
             device.isInstrument ? magda::DeviceType::Instrument : magda::DeviceType::Effect;
-    } else if (auto* internalSpec =
+    } else if (const auto* internalSpec =
                    daw::audio::findInternalPluginSpecForLoadType(device.pluginId)) {
         device.pluginId = internalSpec->pluginId;
         device.name =
@@ -1323,7 +1323,7 @@ bool DeviceCustomUIManager::createDrumGridUI(const magda::DeviceInfo& device,
     auto getChainDisplayName = [](const daw::audio::DrumGridPlugin::Chain& chain) -> juce::String {
         if (chain.plugins.empty())
             return {};
-        auto& firstPlugin = chain.plugins[0];
+        const auto& firstPlugin = chain.plugins[0];
         if (firstPlugin == nullptr)
             return {};
         if (auto* sampler =
@@ -1341,7 +1341,7 @@ bool DeviceCustomUIManager::createDrumGridUI(const magda::DeviceInfo& device,
     auto updatePadFromChain = [this, getChainDisplayName](daw::audio::DrumGridPlugin* dg,
                                                           int padIndex) {
         int midiNote = daw::audio::DrumGridPlugin::baseNote + padIndex;
-        if (auto* chain = dg->getChainForNote(midiNote)) {
+        if (const auto* chain = dg->getChainForNote(midiNote)) {
             drumGridUI_->updatePadInfo(padIndex, getChainDisplayName(*chain), chain->mute.get(),
                                        chain->solo.get(), chain->level.get(), chain->pan.get(),
                                        chain->index, chain->bypassed.get(), chain->busOutput.get());
@@ -1706,7 +1706,7 @@ bool DeviceCustomUIManager::createDrumGridUI(const magda::DeviceInfo& device,
             return result;
 
         int midiNote = daw::audio::DrumGridPlugin::baseNote + padIndex;
-        auto* chain = dg->getChainForNote(midiNote);
+        const auto* chain = dg->getChainForNote(midiNote);
         if (!chain)
             return result;
 
@@ -1728,7 +1728,7 @@ bool DeviceCustomUIManager::createDrumGridUI(const magda::DeviceInfo& device,
 
         for (int pluginIndex = 0; pluginIndex < static_cast<int>(chain->plugins.size());
              ++pluginIndex) {
-            auto& plugin = chain->plugins[static_cast<size_t>(pluginIndex)];
+            const auto& plugin = chain->plugins[static_cast<size_t>(pluginIndex)];
             if (!plugin)
                 continue;
             PadChainPanel::PluginSlotInfo info;

--- a/magda/daw/ui/components/common/curve/CurveBezierHandle.cpp
+++ b/magda/daw/ui/components/common/curve/CurveBezierHandle.cpp
@@ -54,7 +54,7 @@ void CurveBezierHandle::mouseDrag(const juce::MouseEvent& e) {
         return;
 
     // Calculate delta in parent coordinates
-    auto parentComponent = getParentComponent();
+    auto* parentComponent = getParentComponent();
     if (!parentComponent)
         return;
 

--- a/magda/daw/ui/components/pianoroll/PianoRollGridComponent.cpp
+++ b/magda/daw/ui/components/pianoroll/PianoRollGridComponent.cpp
@@ -2806,7 +2806,7 @@ void PianoRollGridComponent::filesDropped(const juce::StringArray& files, int x,
     std::vector<std::pair<int, int>> simpleNotes;
 
     for (int t = 0; t < midi.getNumTracks(); ++t) {
-        auto* track = midi.getTrack(t);
+        const auto* track = midi.getTrack(t);
         if (!track)
             continue;
         for (int i = 0; i < track->getNumEvents(); ++i) {

--- a/magda/daw/ui/components/tracks/TrackHeadersPanel.cpp
+++ b/magda/daw/ui/components/tracks/TrackHeadersPanel.cpp
@@ -3790,7 +3790,7 @@ void TrackHeadersPanel::itemDropped(const SourceDetails& details) {
 bool TrackHeadersPanel::isIORoutingVisible() const {
     if (trackHeaders.empty())
         return showIORouting_;
-    for (auto& h : trackHeaders) {
+    for (const auto& h : trackHeaders) {
         if (h->showIORouting)
             return true;
     }

--- a/magda/daw/ui/dialogs/AISettingsDialog.cpp
+++ b/magda/daw/ui/dialogs/AISettingsDialog.cpp
@@ -434,7 +434,7 @@ class AISettingsDialog::CloudPage : public juce::Component {
     }
 
     void addListEntry(const std::string& providerId) {
-        auto* info = findProviderInfo(providerId);
+        const auto* info = findProviderInfo(providerId);
         if (!info)
             return;
 
@@ -509,7 +509,7 @@ class AISettingsDialog::CloudPage : public juce::Component {
             return;
         }
 
-        auto* info = findProviderInfo(providerId);
+        const auto* info = findProviderInfo(providerId);
         if (!info)
             return;
 
@@ -1142,7 +1142,7 @@ class AISettingsDialog::ConfigPage : public juce::Component {
         int nextId = 1;
         if (cloudPage) {
             for (const auto& pid : cloudPage->getConfiguredProviders()) {
-                auto* info = findProviderInfo(pid);
+                const auto* info = findProviderInfo(pid);
                 if (info)
                     providerCombo_.addItem(info->displayName, nextId++);
             }
@@ -1168,7 +1168,7 @@ class AISettingsDialog::ConfigPage : public juce::Component {
         std::vector<std::pair<std::string, juce::String>> opts;
         if (cloudPage) {
             for (const auto& pid : cloudPage->getConfiguredProviders())
-                if (auto* info = findProviderInfo(pid))
+                if (const auto* info = findProviderInfo(pid))
                     opts.emplace_back(pid, juce::String(info->displayName));
         }
         opts.emplace_back(magda::provider::LLAMA_LOCAL, juce::String("Local"));
@@ -1558,13 +1558,13 @@ class AISettingsDialog::ConfigPage : public juce::Component {
             // Local: embedded GGUF or OpenAI-compatible server.
             outPresetId = (localSourceCombo_.getSelectedId() == 2) ? magda::preset::LOCAL_SERVER
                                                                    : magda::preset::LOCAL_EMBEDDED;
-            if (auto* preset = magda::findPreset(outPresetId))
+            if (const auto* preset = magda::findPreset(outPresetId))
                 for (const auto& [role, cfg] : preset->agents)
                     out[role] = cfg;
         } else if (mode == 2) {
             // Cloud
             outPresetId = presetId;
-            if (auto* preset = magda::findPreset(presetId)) {
+            if (const auto* preset = magda::findPreset(presetId)) {
                 for (const auto& [role, presetCfg] : preset->agents) {
                     auto cfg = presetCfg;
                     cfg.apiKey = "";
@@ -1672,7 +1672,7 @@ class AISettingsDialog::ConfigPage : public juce::Component {
 
     static Config::AgentLLMConfig makeCloudConfig(const std::string& role,
                                                   const std::string& presetId) {
-        if (auto* preset = magda::findPreset(presetId)) {
+        if (const auto* preset = magda::findPreset(presetId)) {
             auto it = preset->agents.find(role);
             if (it != preset->agents.end()) {
                 auto cfg = it->second;

--- a/magda/daw/ui/dialogs/AudioSettingsDialog.cpp
+++ b/magda/daw/ui/dialogs/AudioSettingsDialog.cpp
@@ -13,7 +13,7 @@ namespace {
 
 bool comboItemsMatchDriverTypes(const juce::ComboBox& comboBox,
                                 juce::AudioDeviceManager& deviceManager) {
-    auto& deviceTypes = deviceManager.getAvailableDeviceTypes();
+    const auto& deviceTypes = deviceManager.getAvailableDeviceTypes();
     if (comboBox.getNumItems() != deviceTypes.size())
         return false;
 

--- a/magda/daw/ui/dialogs/PreferencesDialog.cpp
+++ b/magda/daw/ui/dialogs/PreferencesDialog.cpp
@@ -161,7 +161,7 @@ juce::Rectangle<int> getPreferencesDialogContentSize() {
     constexpr int minW = 520;
     constexpr int minH = 380;
 
-    if (auto* display = juce::Desktop::getInstance().getDisplays().getPrimaryDisplay()) {
+    if (const auto* display = juce::Desktop::getInstance().getDisplays().getPrimaryDisplay()) {
         const int maxW = display->userArea.getWidth() - 48;
         const int maxH = display->userArea.getHeight() - 96;
         return {juce::jmax(minW, juce::jmin(preferredW, maxW)),

--- a/magda/daw/ui/panels/content/AIChatConsoleContent.cpp
+++ b/magda/daw/ui/panels/content/AIChatConsoleContent.cpp
@@ -2693,19 +2693,19 @@ bool AIChatConsoleContent::keyPressed(const juce::KeyPress& key, juce::Component
         if (popupVisible) {
             switch (autocompletePopup_->getMode()) {
                 case AutocompletePopup::Mode::SlashCommand:
-                    if (auto* cmd = autocompletePopup_->getSelectedCommand()) {
+                    if (const auto* cmd = autocompletePopup_->getSelectedCommand()) {
                         insertSlashCommand(cmd->name);
                         return true;
                     }
                     break;
                 case AutocompletePopup::Mode::Param:
-                    if (auto* entry = autocompletePopup_->getSelectedParamEntry()) {
+                    if (const auto* entry = autocompletePopup_->getSelectedParamEntry()) {
                         insertParamAlias(entry->pluginAlias, entry->paramAlias);
                         return true;
                     }
                     break;
                 case AutocompletePopup::Mode::Alias:
-                    if (auto* entry = autocompletePopup_->getSelectedEntry()) {
+                    if (const auto* entry = autocompletePopup_->getSelectedEntry()) {
                         insertAlias(entry->alias);
                         return true;
                     }
@@ -2732,19 +2732,19 @@ bool AIChatConsoleContent::keyPressed(const juce::KeyPress& key, juce::Component
     if (key == juce::KeyPress::tabKey) {
         switch (autocompletePopup_->getMode()) {
             case AutocompletePopup::Mode::SlashCommand:
-                if (auto* cmd = autocompletePopup_->getSelectedCommand()) {
+                if (const auto* cmd = autocompletePopup_->getSelectedCommand()) {
                     insertSlashCommand(cmd->name);
                     return true;
                 }
                 break;
             case AutocompletePopup::Mode::Param:
-                if (auto* entry = autocompletePopup_->getSelectedParamEntry()) {
+                if (const auto* entry = autocompletePopup_->getSelectedParamEntry()) {
                     insertParamAlias(entry->pluginAlias, entry->paramAlias);
                     return true;
                 }
                 break;
             case AutocompletePopup::Mode::Alias:
-                if (auto* entry = autocompletePopup_->getSelectedEntry()) {
+                if (const auto* entry = autocompletePopup_->getSelectedEntry()) {
                     insertAlias(entry->alias);
                     return true;
                 }

--- a/magda/daw/ui/panels/content/ChordPanelContent.cpp
+++ b/magda/daw/ui/panels/content/ChordPanelContent.cpp
@@ -989,7 +989,7 @@ void ChordPanelContent::layoutAIProgressionRows() {
         chordPlugin_ ? chordPlugin_->getAIProgressions() : std::vector<AIProgression>{};
     for (size_t i = 0; i < aiRows_.size() && i < aiProgsLayout.size(); ++i) {
         auto& row = aiRows_[i];
-        auto& prog = aiProgsLayout[i];
+        const auto& prog = aiProgsLayout[i];
 
         AIContainerPaintData::Row paintRow;
         paintRow.name = prog.name;

--- a/magda/daw/ui/panels/content/PluginBrowserContent.cpp
+++ b/magda/daw/ui/panels/content/PluginBrowserContent.cpp
@@ -728,7 +728,7 @@ void PluginBrowserContent::rebuildTree() {
 
             // Create parent category if needed
             if (categories.find(parentKey) == categories.end()) {
-                auto parentItem = new CategoryTreeItem(parentKey);
+                auto* parentItem = new CategoryTreeItem(parentKey);
                 root->addSubItem(parentItem);
                 categories[parentKey] = parentItem;
             }
@@ -737,7 +737,7 @@ void PluginBrowserContent::rebuildTree() {
             if (childKey.isNotEmpty()) {
                 juce::String fullKey = parentKey + "/" + childKey;
                 if (categories.find(fullKey) == categories.end()) {
-                    auto childItem = new CategoryTreeItem(childKey);
+                    auto* childItem = new CategoryTreeItem(childKey);
                     categories[parentKey]->addSubItem(childItem);
                     categories[fullKey] = childItem;
                 }
@@ -748,7 +748,7 @@ void PluginBrowserContent::rebuildTree() {
         } else {
             // Single-level grouping
             if (categories.find(groupKey) == categories.end()) {
-                auto item = new CategoryTreeItem(groupKey);
+                auto* item = new CategoryTreeItem(groupKey);
                 root->addSubItem(item);
                 categories[groupKey] = item;
             }

--- a/magda/daw/ui/panels/content/WaveformEditorContent.cpp
+++ b/magda/daw/ui/panels/content/WaveformEditorContent.cpp
@@ -966,7 +966,7 @@ void WaveformEditorContent::clipPropertyChanged(magda::ClipId clipId) {
 
         // Check if cached transients were invalidated (e.g. sensitivity changed)
         if (clip->isAudio() && !magda::audioEventRef(*clip).sourceFilePath().isEmpty()) {
-            auto* cached = magda::AudioThumbnailManager::getInstance().getCachedTransients(
+            const auto* cached = magda::AudioThumbnailManager::getInstance().getCachedTransients(
                 magda::audioEventRef(*clip).sourceFilePath());
             if (cached) {
                 gridComponent_->setTransientTimes(*cached);
@@ -997,7 +997,7 @@ void WaveformEditorContent::transientsChanged(const juce::String& filePath) {
     }
     if (magda::audioEventRef(*clip).sourceFilePath() != filePath)
         return;
-    auto* cached = magda::AudioThumbnailManager::getInstance().getCachedTransients(filePath);
+    const auto* cached = magda::AudioThumbnailManager::getInstance().getCachedTransients(filePath);
     if (cached) {
         double bpm = 120.0;
         if (auto* controller = magda::TimelineController::getCurrent())
@@ -1199,7 +1199,7 @@ void WaveformEditorContent::setClip(magda::ClipId clipId) {
 
         // Check for cached transients or request async detection.
         if (clip && clip->isAudio() && !magda::audioEventRef(*clip).sourceFilePath().isEmpty()) {
-            auto* cached = magda::AudioThumbnailManager::getInstance().getCachedTransients(
+            const auto* cached = magda::AudioThumbnailManager::getInstance().getCachedTransients(
                 magda::audioEventRef(*clip).sourceFilePath());
             if (cached) {
                 gridComponent_->setTransientTimes(*cached);
@@ -1517,7 +1517,7 @@ void WaveformEditorContent::requestTransientDetection() {
     if (bridge->getTransientTimes(editingClipId_)) {
         const auto* clip = magda::ClipManager::getInstance().getClip(editingClipId_);
         if (clip && !magda::audioEventRef(*clip).sourceFilePath().isEmpty()) {
-            auto* cached = magda::AudioThumbnailManager::getInstance().getCachedTransients(
+            const auto* cached = magda::AudioThumbnailManager::getInstance().getCachedTransients(
                 magda::audioEventRef(*clip).sourceFilePath());
             if (cached) {
                 gridComponent_->setTransientTimes(*cached);

--- a/magda/daw/ui/panels/content/inspector/clip/ClipInspectorSections.cpp
+++ b/magda/daw/ui/panels/content/inspector/clip/ClipInspectorSections.cpp
@@ -97,7 +97,7 @@ class ClipInspector::GroovePickerPopup : public juce::Component {
 
         // Click on template → select and close
         templateModel_.onItemClicked = [this](int row) {
-            auto& items = templateModel_.getItems();
+            const auto& items = templateModel_.getItems();
             if (row >= 0 && row < static_cast<int>(items.size())) {
                 owner_.onGrooveTemplateSelected(items[static_cast<size_t>(row)]);
                 // Dismiss the callout box we're hosted in

--- a/magda/daw/ui/themes/FileBrowserLookAndFeel.hpp
+++ b/magda/daw/ui/themes/FileBrowserLookAndFeel.hpp
@@ -207,7 +207,8 @@ class FileBrowserLookAndFeel : public juce::LookAndFeel_V4 {
                                   juce::RectanglePlacement::onlyReduceInSize,
                               false);
         } else {
-            if (auto* d = isDirectory ? getDefaultFolderImage() : getDefaultDocumentFileImage())
+            if (const const auto* d =
+                    isDirectory ? getDefaultFolderImage() : getDefaultDocumentFileImage())
                 d->drawWithin(
                     g,
                     juce::Rectangle<float>(2.0f, 2.0f, x - 4.0f, static_cast<float>(height) - 4.0f),

--- a/magda/daw/ui/themes/FileBrowserLookAndFeel.hpp
+++ b/magda/daw/ui/themes/FileBrowserLookAndFeel.hpp
@@ -207,7 +207,7 @@ class FileBrowserLookAndFeel : public juce::LookAndFeel_V4 {
                                   juce::RectanglePlacement::onlyReduceInSize,
                               false);
         } else {
-            if (const const auto* d =
+            if (const auto* d =
                     isDirectory ? getDefaultFolderImage() : getDefaultDocumentFileImage())
                 d->drawWithin(
                     g,

--- a/magda/daw/ui/views/MainView.cpp
+++ b/magda/daw/ui/views/MainView.cpp
@@ -2400,7 +2400,7 @@ void MainView::SelectionOverlayComponent::drawRecordingRegion(juce::Graphics& g)
     endX = juce::jmin(getWidth(), endX);
 
     int scrollY = owner.trackContentViewport->getViewPositionY();
-    auto& tracks = TrackManager::getInstance().getTracks();
+    const auto& tracks = TrackManager::getInstance().getTracks();
 
     for (int trackIndex = 0; trackIndex < static_cast<int>(tracks.size()); ++trackIndex) {
         if (!tracks[trackIndex].recordArmed) {

--- a/magda/daw/ui/windows/MainWindow.cpp
+++ b/magda/daw/ui/windows/MainWindow.cpp
@@ -268,7 +268,7 @@ MainWindow::MainWindow(AudioEngine* audioEngine)
     juce::Logger::writeToLog("[MainWindow] Menu bar ready");
 
     // Size and position the window within the display's work area
-    auto display = juce::Desktop::getInstance().getDisplays().getPrimaryDisplay();
+    const auto* display = juce::Desktop::getInstance().getDisplays().getPrimaryDisplay();
     if (display != nullptr) {
         auto workArea = display->userArea;  // Excludes taskbar
         // Leave some margin so the title bar and window frame are fully visible
@@ -604,7 +604,7 @@ MainWindow::MainComponent::MainComponent(AudioEngine* externalEngine) {
     transportHeight = layout.defaultTransportHeight;
 
     // Scale side panel defaults based on screen width
-    if (auto* display = juce::Desktop::getInstance().getDisplays().getPrimaryDisplay()) {
+    if (const auto* display = juce::Desktop::getInstance().getDisplays().getPrimaryDisplay()) {
         int screenWidth = display->userArea.getWidth();
         if (screenWidth >= 2560) {  // Large display (1440p+)
             leftPanelWidth = rightPanelWidth = 400;
@@ -1231,7 +1231,7 @@ void MainWindow::MainComponent::setupAudioEngineCallbacks(AudioEngine* engine) {
         mainView->getTimelineController().dispatch(SetEditPositionEvent{0.0});
     };
     transportPanel->onGoToNext = [this]() {
-        auto& state = mainView->getTimelineController().getState();
+        const auto& state = mainView->getTimelineController().getState();
         mainView->getTimelineController().dispatch(SetEditPositionEvent{state.timelineLength});
     };
     transportPanel->onPlayheadEdit = [this](double beats) {

--- a/magda/engine/param/ParamTableDump.cpp
+++ b/magda/engine/param/ParamTableDump.cpp
@@ -138,7 +138,7 @@ std::string dumpParamTable(const ParamTable& table) {
 
         for (const auto& link : links) {
             std::ostringstream detail;
-            const auto source =
+            const auto* const source =
                 link.source.kind == ParamSourceRef::Kind::Parameter ? "param" : "mod";
             detail << "      <- " << source << "[" << rightAligned(link.source.index, 3) << "]"
                    << " amount=" << number(link.amount) << " bipolar=" << (link.bipolar ? 1 : 0);

--- a/magda/scripting/LuaController.cpp
+++ b/magda/scripting/LuaController.cpp
@@ -97,7 +97,7 @@ void pushMidiEvent(lua_State* L, const juce::String& deviceName, const juce::Mid
         lua_setfield(L, -2, "bytes");
     }
 
-    auto raw = deviceName.toRawUTF8();
+    const auto* raw = deviceName.toRawUTF8();
     lua_pushlstring(L, raw, static_cast<size_t>(deviceName.getNumBytesAsUTF8()));
     lua_setfield(L, -2, "port");
 }

--- a/magda/scripting/LuaRuntime.cpp
+++ b/magda/scripting/LuaRuntime.cpp
@@ -106,8 +106,8 @@ bool LuaRuntime::eval(const juce::String& chunk, const juce::String& chunkName) 
         return false;
 
     lastError_ = {};
-    auto chunkUtf8 = chunk.toRawUTF8();
-    auto nameUtf8 = chunkName.toRawUTF8();
+    const auto* chunkUtf8 = chunk.toRawUTF8();
+    const auto* nameUtf8 = chunkName.toRawUTF8();
     auto chunkLen = static_cast<std::size_t>(chunk.getNumBytesAsUTF8());
 
     int rc = luaL_loadbuffer(L_, chunkUtf8, chunkLen, nameUtf8);
@@ -141,7 +141,7 @@ std::optional<long long> LuaRuntime::evalToInt(const juce::String& chunk) {
     juce::String wrapped = "return (" + chunk + ")";
     lastError_ = {};
 
-    auto src = wrapped.toRawUTF8();
+    const auto* src = wrapped.toRawUTF8();
     auto srcLen = static_cast<std::size_t>(wrapped.getNumBytesAsUTF8());
     if (luaL_loadbuffer(L_, src, srcLen, "=eval") != LUA_OK) {
         size_t len = 0;
@@ -183,7 +183,7 @@ std::optional<juce::String> LuaRuntime::evalToString(const juce::String& chunk) 
     juce::String wrapped = "return (" + chunk + ")";
     lastError_ = {};
 
-    auto src = wrapped.toRawUTF8();
+    const auto* src = wrapped.toRawUTF8();
     auto srcLen = static_cast<std::size_t>(wrapped.getNumBytesAsUTF8());
     if (luaL_loadbuffer(L_, src, srcLen, "=eval") != LUA_OK) {
         size_t len = 0;

--- a/magda/scripting/MagdaApiLuaBindings.cpp
+++ b/magda/scripting/MagdaApiLuaBindings.cpp
@@ -55,7 +55,7 @@ MagdaApi* getApi(lua_State* L) {
 
 // Push a `juce::String` as a Lua string (UTF-8).
 void pushJuceString(lua_State* L, const juce::String& s) {
-    auto raw = s.toRawUTF8();
+    const auto* raw = s.toRawUTF8();
     lua_pushlstring(L, raw, static_cast<size_t>(s.getNumBytesAsUTF8()));
 }
 


### PR DESCRIPTION
readability-qualified-auto across `magda/`. 73 files, no behaviour change.

`auto` deducing a pointer now says `auto*`, so a reader can tell a pointer from
a value without going to the initialiser, and references that are never written
bind as `const auto&`.

Built clean locally on top of #2482.

clang-tidy formatted its own edits (`-format -style=file`), so the pointers came
out matching the project's `PointerAlignment: Left` rather than being reflowed
by the commit hook afterwards.

https://claude.ai/code/session_01VomqgBSXsWYdyHyec9DvPi