### PR TITLE
Make member functions static where they never touch the object

### DIFF
--- a/magda/agents/chord_agent.cpp
+++ b/magda/agents/chord_agent.cpp
@@ -243,7 +243,7 @@ ChordAgent::Result ChordAgent::parseResponse(const juce::String& dsl) {
 }
 
 ChordAgent::Result ChordAgent::generate(const Input& input, TokenCallback onToken,
-                                        CancelCallback shouldCancel) const {
+                                        CancelCallback shouldCancel) {
     const auto cancelled = [&] { return shouldCancel && shouldCancel(); };
     if (cancelled())
         return {{}, {}, "Cancelled", true, true};

--- a/magda/agents/chord_agent.hpp
+++ b/magda/agents/chord_agent.hpp
@@ -59,8 +59,8 @@ class ChordAgent {
 
     /// Resolve the dedicated Chord agent role (with Config's Music fallback), send
     /// the request, stream when supported, and parse the structured result.
-    Result generate(const Input& input, TokenCallback onToken = {},
-                    CancelCallback shouldCancel = {}) const;
+    static Result generate(const Input& input, TokenCallback onToken = {},
+                           CancelCallback shouldCancel = {});
 };
 
 }  // namespace magda

--- a/magda/agents/console_agent_orchestrator.hpp
+++ b/magda/agents/console_agent_orchestrator.hpp
@@ -95,7 +95,7 @@ class ConsoleAgentOrchestrator {
     static std::string composePrompt(const ConsoleRunRequest& request);
 
   private:
-    ConsoleRunOutput runWorkflow(
+    static ConsoleRunOutput runWorkflow(
         const std::function<ConsoleRunOutput(const ConsoleRunRequest&, const ConsoleRunObserver&,
                                              const CancellationToken&)>& workflow,
         const ConsoleRunRequest& request, const ConsoleRunObserver& observer,

--- a/magda/agents/faust_agent.hpp
+++ b/magda/agents/faust_agent.hpp
@@ -54,13 +54,13 @@ class FaustAgent {
     }
 
   private:
-    Result parseJson(const juce::String& text);
+    static Result parseJson(const juce::String& text);
 
     // Compile through faust-mcp. A disabled server intentionally stages code
     // for manual editing; an enabled server that cannot start or verify fails
     // closed and never reaches the live apply path.
-    bool compileCheck(const std::string& name, const std::string& source, std::string& errorOut,
-                      bool& verified);
+    static bool compileCheck(const std::string& name, const std::string& source,
+                             std::string& errorOut, bool& verified);
 
     // Shared body for generate / generateStreaming. Runs the conversational
     // generate-and-auto-fix loop: on a compile failure the broken reply is

--- a/magda/agents/four_osc_agent.hpp
+++ b/magda/agents/four_osc_agent.hpp
@@ -93,7 +93,7 @@ class FourOscAgent {
     /** Parse a JSON string into a Preset. Returns empty Preset + sets
      *  outError on malformed input. Tolerant of LLM markdown fences
      *  ("```json ... ```") around the payload. */
-    Preset parseJson(const juce::String& text, std::string& outError);
+    static Preset parseJson(const juce::String& text, std::string& outError);
 
     std::atomic<bool> shouldStop_{false};
 };

--- a/magda/agents/gain_staging_agent.cpp
+++ b/magda/agents/gain_staging_agent.cpp
@@ -98,7 +98,7 @@ const char* GainStagingAgent::getSystemPrompt() {
 }
 
 juce::String GainStagingAgent::buildUserMessage(float targetPeakDb,
-                                                const std::vector<DeviceLevel>& devices) const {
+                                                const std::vector<DeviceLevel>& devices) {
     juce::Array<juce::var> arr;
     for (int i = 0; i < static_cast<int>(devices.size()); ++i) {
         const auto& d = devices[static_cast<size_t>(i)];
@@ -132,8 +132,7 @@ juce::String GainStagingAgent::buildUserMessage(float targetPeakDb,
 }
 
 void GainStagingAgent::parseDecisions(const juce::String& rawText,
-                                      const std::vector<DeviceLevel>& devices,
-                                      Result& result) const {
+                                      const std::vector<DeviceLevel>& devices, Result& result) {
     result.rawOutput = rawText.toStdString();
 
     const int deviceCount = static_cast<int>(devices.size());

--- a/magda/agents/gain_staging_agent.hpp
+++ b/magda/agents/gain_staging_agent.hpp
@@ -65,10 +65,10 @@ class GainStagingAgent {
     static const char* getSystemPrompt();
 
   private:
-    juce::String buildUserMessage(float targetPeakDb,
-                                  const std::vector<DeviceLevel>& devices) const;
-    void parseDecisions(const juce::String& rawText, const std::vector<DeviceLevel>& devices,
-                        Result& result) const;
+    static juce::String buildUserMessage(float targetPeakDb,
+                                         const std::vector<DeviceLevel>& devices);
+    static void parseDecisions(const juce::String& rawText, const std::vector<DeviceLevel>& devices,
+                               Result& result);
 };
 
 }  // namespace magda

--- a/magda/agents/mixing_agent.hpp
+++ b/magda/agents/mixing_agent.hpp
@@ -54,7 +54,7 @@ class MixAnalysisAgent {
 
     /** Streaming variant of generate(): calls onToken for each token as it
      *  arrives, otherwise identical. Run off the message thread. */
-    Result generateStreaming(const Input& input, TokenCallback onToken);
+    static Result generateStreaming(const Input& input, TokenCallback onToken);
 
     /** Exposed so a harness can measure payload size without an LLM call. */
     static juce::String buildUserMessage(const Input& input);

--- a/magda/agents/music_agent.hpp
+++ b/magda/agents/music_agent.hpp
@@ -45,7 +45,7 @@ class MusicAgent {
     static const char* getDSLSystemPrompt();
 
     /** Parse DSL note operations into IR instructions. */
-    std::vector<Instruction> parseDSL(const juce::String& text, std::string& outDescription);
+    static std::vector<Instruction> parseDSL(const juce::String& text, std::string& outDescription);
 
     CompactParser parser_;
     std::atomic<bool> shouldStop_{false};

--- a/magda/agents/poly_step_sequencer_agent.hpp
+++ b/magda/agents/poly_step_sequencer_agent.hpp
@@ -78,7 +78,7 @@ class PolyStepSequencerAgent {
     /** Parse a JSON string into a Preset. Returns empty Preset + sets
      *  outError on malformed input. Tolerant of LLM markdown fences
      *  ("```json ... ```") around the payload. */
-    Preset parseJson(const juce::String& text, std::string& outError);
+    static Preset parseJson(const juce::String& text, std::string& outError);
 
     std::atomic<bool> shouldStop_{false};
 };

--- a/magda/agents/step_sequencer_agent.hpp
+++ b/magda/agents/step_sequencer_agent.hpp
@@ -73,7 +73,7 @@ class StepSequencerAgent {
     /** Parse a JSON string into a Preset. Returns empty Preset + sets
      *  outError on malformed input. Tolerant of LLM markdown fences
      *  ("```json ... ```") around the payload. */
-    Preset parseJson(const juce::String& text, std::string& outError);
+    static Preset parseJson(const juce::String& text, std::string& outError);
 
     std::atomic<bool> shouldStop_{false};
 };

--- a/magda/daw/api/osc_feedback_live.hpp
+++ b/magda/daw/api/osc_feedback_live.hpp
@@ -260,7 +260,7 @@ class OscFeedbackProjector : private ConfigListener, private BindingRegistryList
 
     /// Feed one surface's copy of a bound address, given the position its target
     /// currently implies.
-    void publishBinding(Surface& surface, const juce::String& address, float position);
+    static void publishBinding(Surface& surface, const juce::String& address, float position);
 
     /// The entry for `address` on `surface`, created if this is the first time
     /// it has been seen. Linear: bindings number in the tens, and an OSC address

--- a/magda/daw/api/remote_api_host.cpp
+++ b/magda/daw/api/remote_api_host.cpp
@@ -536,7 +536,7 @@ int RemoteApiHost::mcpPort() const {
     return mcpServer_ != nullptr ? mcpServer_->boundPort() : 0;
 }
 
-juce::File RemoteApiHost::tokenFile() const {
+juce::File RemoteApiHost::tokenFile() {
     return paths::dataDir().getChildFile(juce::String(kTokenFilePrefix) +
                                          juce::String(currentProcessId()) + kTokenFileSuffix);
 }

--- a/magda/daw/api/remote_api_host.hpp
+++ b/magda/daw/api/remote_api_host.hpp
@@ -139,7 +139,7 @@ class RemoteApiHost {
     int mcpPort() const;
 
     /// Where the token was published, whether or not it currently exists.
-    juce::File tokenFile() const;
+    static juce::File tokenFile();
 
     /// The dispatcher, shared by both transports so revisions, undo grouping,
     /// and idempotency each exist once per project, not twice.

--- a/magda/daw/api/remote_mcp.cpp
+++ b/magda/daw/api/remote_mcp.cpp
@@ -546,8 +546,7 @@ std::vector<juce::String> McpEndpoint::urisAffectedBy(Topic topic,
     return uris;
 }
 
-juce::var McpEndpoint::acknowledgment(const ListenFilter& filter,
-                                      const juce::var& subscriptionId) const {
+juce::var McpEndpoint::acknowledgment(const ListenFilter& filter, const juce::var& subscriptionId) {
     juce::Array<juce::var> uris;
     for (const auto& uri : filter.resourceSubscriptions)
         uris.add(uri);

--- a/magda/daw/api/remote_mcp.hpp
+++ b/magda/daw/api/remote_mcp.hpp
@@ -362,7 +362,7 @@ class McpEndpoint {
     std::vector<Topic> topicsFor(const ListenFilter& filter) const;
 
     /// `notifications/subscriptions/acknowledged`, carrying the honoured filter.
-    juce::var acknowledgment(const ListenFilter& filter, const juce::var& subscriptionId) const;
+    static juce::var acknowledgment(const ListenFilter& filter, const juce::var& subscriptionId);
 
     /// `notifications/resources/updated` for one URI. `subscriptionId` is void
     /// in the legacy era, which has no such correlation.

--- a/magda/daw/api/remote_mcp_server.cpp
+++ b/magda/daw/api/remote_mcp_server.cpp
@@ -793,7 +793,7 @@ struct RemoteMcpServer::Impl {
     // Era selection
     // -----------------------------------------------------------------------
 
-    McpError unsupportedVersion(const juce::String& requested) const {
+    static McpError unsupportedVersion(const juce::String& requested) {
         juce::Array<juce::var> supported;
         for (const auto& version : mcpProtocolVersions())
             supported.add(version);
@@ -920,9 +920,10 @@ struct RemoteMcpServer::Impl {
      * two components acting on two different requests. Rejecting the
      * disagreement is what keeps that from being exploitable.
      */
-    std::optional<McpError> validateHeaders(const httplib::Request& request,
-                                            const juce::String& method, const juce::var& params,
-                                            const juce::String& version) const {
+    static std::optional<McpError> validateHeaders(const httplib::Request& request,
+                                                   const juce::String& method,
+                                                   const juce::var& params,
+                                                   const juce::String& version) {
         const auto mismatch = [](const juce::String& message) {
             return McpError{MCP_HEADER_MISMATCH, message, {}, httplib::StatusCode::BadRequest_400};
         };

--- a/magda/daw/api/remote_subscriptions.hpp
+++ b/magda/daw/api/remote_subscriptions.hpp
@@ -260,7 +260,7 @@ class SubscriptionHub {
                      const std::vector<Topic>& requested, bool topicsGiven);
 
     void publishTopicLocked(Topic topic, Revision revision);
-    void deliverLocked(Client& client, const SubscriptionEvent& event);
+    static void deliverLocked(Client& client, const SubscriptionEvent& event);
     void foldFlushOutcomesLocked();
     void sendSnapshotsLocked(Client& client, const std::vector<Topic>& topics, Revision revision,
                              juce::Array<juce::var>& into);

--- a/magda/daw/audio/AudioEngineOptimizer.hpp
+++ b/magda/daw/audio/AudioEngineOptimizer.hpp
@@ -25,7 +25,7 @@ class AudioEngineOptimizer final : public ViewModeListener {
     /**
      * Apply an audio profile to the engine
      */
-    void applyProfile(const AudioEngineProfile& profile);
+    static void applyProfile(const AudioEngineProfile& profile);
 
   private:
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(AudioEngineOptimizer)

--- a/magda/daw/audio/AudioThumbnailManager.hpp
+++ b/magda/daw/audio/AudioThumbnailManager.hpp
@@ -226,11 +226,11 @@ class AudioThumbnailManager {
     // Draw waveform directly from raw samples (used when zoomed in). When
     // @p peakCache is non-null and the zoom level is coarse enough to use it,
     // peak data short-circuits the per-column reader read.
-    void drawWaveformFromSamples(juce::Graphics& g, const juce::Rectangle<int>& bounds,
-                                 juce::AudioFormatReader* reader,
-                                 const WaveformPeakCache* peakCache, double startTime,
-                                 double endTime, const juce::Colour& colour, float verticalZoom,
-                                 bool thick = false);
+    static void drawWaveformFromSamples(juce::Graphics& g, const juce::Rectangle<int>& bounds,
+                                        juce::AudioFormatReader* reader,
+                                        const WaveformPeakCache* peakCache, double startTime,
+                                        double endTime, const juce::Colour& colour,
+                                        float verticalZoom, bool thick = false);
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(AudioThumbnailManager)
 };

--- a/magda/daw/audio/CompService.hpp
+++ b/magda/daw/audio/CompService.hpp
@@ -31,7 +31,7 @@ class CompService {
     void setSection(ClipId clipId, double startSeconds, double endSeconds, int takeIndex);
 
     /** Drop the comp and revert the clip to its active take. */
-    void clearComp(ClipId clipId);
+    static void clearComp(ClipId clipId);
 
     /** Re-render the clip's existing comp (e.g. after project load). */
     void renderComp(ClipId clipId);

--- a/magda/daw/audio/MidiBridge.cpp
+++ b/magda/daw/audio/MidiBridge.cpp
@@ -92,7 +92,7 @@ std::vector<MidiDeviceInfo> MidiBridge::getAvailableMidiInputs() const {
     return devices;
 }
 
-std::vector<MidiDeviceInfo> MidiBridge::getAvailableMidiOutputs() const {
+std::vector<MidiDeviceInfo> MidiBridge::getAvailableMidiOutputs() {
     std::vector<MidiDeviceInfo> devices;
 
     auto midiOutputs = juce::MidiOutput::getAvailableDevices();

--- a/magda/daw/audio/MidiBridge.hpp
+++ b/magda/daw/audio/MidiBridge.hpp
@@ -119,7 +119,7 @@ class MidiBridge : public juce::MidiInputCallback {
      * @brief Get all available MIDI output devices
      * @return Vector of device info
      */
-    std::vector<MidiDeviceInfo> getAvailableMidiOutputs() const;
+    static std::vector<MidiDeviceInfo> getAvailableMidiOutputs();
 
     // =========================================================================
     // MIDI Output (host → device)

--- a/magda/daw/audio/TrackController.hpp
+++ b/magda/daw/audio/TrackController.hpp
@@ -146,7 +146,7 @@ class TrackController {
      * @param trackId The MAGDA track ID
      * @param deviceId MIDI output device ID, "track:NNN" for track destination, empty to disable
      */
-    void setTrackMidiOutput(TrackId trackId, const juce::String& deviceId);
+    static void setTrackMidiOutput(TrackId trackId, const juce::String& deviceId);
 
     /**
      * @brief Set audio input source for a track

--- a/magda/daw/audio/TrackMeasurementManager.cpp
+++ b/magda/daw/audio/TrackMeasurementManager.cpp
@@ -124,8 +124,7 @@ std::vector<daw::audio::MaskingFinding> TrackMeasurementManager::getMaskingFindi
 }
 
 size_t TrackMeasurementManager::readTrackSpectrumSamples(TrackId trackId, float* dest,
-                                                         int numSamples,
-                                                         double& sampleRateOut) const {
+                                                         int numSamples, double& sampleRateOut) {
     auto* pm = pluginManager();
     if (pm == nullptr)
         return 0;

--- a/magda/daw/audio/WarpMarkerManager.hpp
+++ b/magda/daw/audio/WarpMarkerManager.hpp
@@ -75,8 +75,8 @@ class WarpMarkerManager : private te::WarpTimeManager::Listener, private juce::T
      * @param clipIdToEngineId Mapping from MAGDA clip ID to TE clip ID
      * @param clipId The MAGDA clip ID
      */
-    void enableWarp(te::Edit& edit, const std::map<ClipId, std::string>& clipIdToEngineId,
-                    ClipId clipId);
+    static void enableWarp(te::Edit& edit, const std::map<ClipId, std::string>& clipIdToEngineId,
+                           ClipId clipId);
 
     /**
      * @brief Disable warping: remove all warp markers
@@ -84,8 +84,8 @@ class WarpMarkerManager : private te::WarpTimeManager::Listener, private juce::T
      * @param clipIdToEngineId Mapping from MAGDA clip ID to TE clip ID
      * @param clipId The MAGDA clip ID
      */
-    void disableWarp(te::Edit& edit, const std::map<ClipId, std::string>& clipIdToEngineId,
-                     ClipId clipId);
+    static void disableWarp(te::Edit& edit, const std::map<ClipId, std::string>& clipIdToEngineId,
+                            ClipId clipId);
 
     /**
      * @brief Get current warp marker positions for display
@@ -94,7 +94,7 @@ class WarpMarkerManager : private te::WarpTimeManager::Listener, private juce::T
      * @param clipId The MAGDA clip ID
      * @return Vector of warp marker info
      */
-    std::vector<WarpMarkerInfo> getWarpMarkers(
+    static std::vector<WarpMarkerInfo> getWarpMarkers(
         te::Edit& edit, const std::map<ClipId, std::string>& clipIdToEngineId, ClipId clipId);
 
     /**
@@ -106,8 +106,8 @@ class WarpMarkerManager : private te::WarpTimeManager::Listener, private juce::T
      * @param warpTime Warped time position
      * @return Index of inserted marker, or -1 on failure
      */
-    int addWarpMarker(te::Edit& edit, const std::map<ClipId, std::string>& clipIdToEngineId,
-                      ClipId clipId, double sourceTime, double warpTime);
+    static int addWarpMarker(te::Edit& edit, const std::map<ClipId, std::string>& clipIdToEngineId,
+                             ClipId clipId, double sourceTime, double warpTime);
 
     /**
      * @brief Move a warp marker's warp time
@@ -118,8 +118,9 @@ class WarpMarkerManager : private te::WarpTimeManager::Listener, private juce::T
      * @param newWarpTime New warped time position
      * @return Actual position (clamped by TE)
      */
-    double moveWarpMarker(te::Edit& edit, const std::map<ClipId, std::string>& clipIdToEngineId,
-                          ClipId clipId, int index, double newWarpTime);
+    static double moveWarpMarker(te::Edit& edit,
+                                 const std::map<ClipId, std::string>& clipIdToEngineId,
+                                 ClipId clipId, int index, double newWarpTime);
 
     /**
      * @brief Remove a warp marker at index
@@ -128,8 +129,9 @@ class WarpMarkerManager : private te::WarpTimeManager::Listener, private juce::T
      * @param clipId The MAGDA clip ID
      * @param index Marker index
      */
-    void removeWarpMarker(te::Edit& edit, const std::map<ClipId, std::string>& clipIdToEngineId,
-                          ClipId clipId, int index);
+    static void removeWarpMarker(te::Edit& edit,
+                                 const std::map<ClipId, std::string>& clipIdToEngineId,
+                                 ClipId clipId, int index);
 
   private:
     // -------- In-flight guard for transient detection --------

--- a/magda/daw/audio/automation/AutomationPlaybackEngine.cpp
+++ b/magda/daw/audio/automation/AutomationPlaybackEngine.cpp
@@ -471,7 +471,7 @@ te::AutomatableParameter* AutomationPlaybackEngine::resolveParameter(
 
 double AutomationPlaybackEngine::convertFromTEValue(const AutomationTarget& target,
                                                     te::AutomatableParameter* param,
-                                                    float teValue) const {
+                                                    float teValue) {
     return laneNormalizedFromTEValue(target, param, teValue);
 }
 

--- a/magda/daw/audio/automation/AutomationPlaybackEngine.hpp
+++ b/magda/daw/audio/automation/AutomationPlaybackEngine.hpp
@@ -97,14 +97,14 @@ class AutomationPlaybackEngine : public AutomationManagerListener,
     // parameter's real value → MAGDA 0..1.
     // Used by currentValueChanged to translate TE-driven parameter writes back
     // into the normalized form UI listeners expect.
-    double convertFromTEValue(const AutomationTarget& target, te::AutomatableParameter* param,
-                              float teValue) const;
+    static double convertFromTEValue(const AutomationTarget& target,
+                                     te::AutomatableParameter* param, float teValue);
 
     // Push a normalized rate-curve value back into MAGDA's modulator state.
     // The lane is mode-aware: tempoSync=false → setXxxModRate (Hz), true →
     // setXxxModSyncDivision. Used by both drag-preview and TE-driven
     // currentValueChanged writeback so the two paths agree.
-    void writeModRateFromCurve(const AutomationTarget& target, double normalized);
+    static void writeModRateFromCurve(const AutomationTarget& target, double normalized);
 
     // Push a macro curve value into MAGDA state and update linked TE targets.
     // Drag preview also seeds the TE macro param; playback callbacks skip that

--- a/magda/daw/audio/automation/AutomationRecordingEngine.hpp
+++ b/magda/daw/audio/automation/AutomationRecordingEngine.hpp
@@ -86,7 +86,7 @@ class AutomationRecordingEngine {
     // here because shouldRecord() already returns false.
     bool requiresUserTouched() const;
     double getCurrentBeatTime() const;
-    double normalizeDeviceParam(const AutomationTarget& target, float rawValue);
+    static double normalizeDeviceParam(const AutomationTarget& target, float rawValue);
     bool shouldThinPoint(AutomationLaneId laneId, double beatTime, double value);
     void recordPoint(AutomationLaneId laneId, double beatTime, double normalizedValue);
     void flushFinalPoints();

--- a/magda/daw/audio/controllers/ControllerParamWriter.hpp
+++ b/magda/daw/audio/controllers/ControllerParamWriter.hpp
@@ -54,10 +54,10 @@ class DefaultControllerParamWriter : public ControllerParamWriter {
 
   private:
     void writePluginParam(const ControlTarget& target, float clamped);
-    void writeMacro(const ControlTarget& target, float clamped);
-    void writeModParam(const ControlTarget& target, float clamped);
-    void writeTrackLevel(const ControlTarget& target, float clamped);
-    void writeSendLevel(const ControlTarget& target, float clamped);
+    static void writeMacro(const ControlTarget& target, float clamped);
+    static void writeModParam(const ControlTarget& target, float clamped);
+    static void writeTrackLevel(const ControlTarget& target, float clamped);
+    static void writeSendLevel(const ControlTarget& target, float clamped);
 
     AudioBridge& bridge_;
 };

--- a/magda/daw/audio/midi/MidiInputRouter.cpp
+++ b/magda/daw/audio/midi/MidiInputRouter.cpp
@@ -300,7 +300,7 @@ void MidiInputRouter::removeSurfaceOnlyMidiInputTargets() {
 }
 
 bool MidiInputRouter::isExternalInstrumentSendbackInput(TrackId trackId,
-                                                        const juce::String& inputName) const {
+                                                        const juce::String& inputName) {
     // Arm-gated: a record-armed track re-admits the synth's own ports so its
     // keyboard can be captured (Local Control off on the synth is the no-
     // double-trigger companion). Un-armed, the ports stay dropped so playback

--- a/magda/daw/audio/midi/MidiInputRouter.hpp
+++ b/magda/daw/audio/midi/MidiInputRouter.hpp
@@ -146,7 +146,7 @@ class MidiInputRouter : private juce::AsyncUpdater {
     /// port naming ("monologue KBD/KNOB" vs "monologue MIDI OUT"). Applied to
     /// "All Inputs" routing only — an explicitly selected port is respected,
     /// so the synth's keyboard can still be recorded (Local Control off).
-    bool isExternalInstrumentSendbackInput(TrackId trackId, const juce::String& inputName) const;
+    static bool isExternalInstrumentSendbackInput(TrackId trackId, const juce::String& inputName);
 
     void handleAsyncUpdate() override;
 

--- a/magda/daw/audio/plugin_manager/PluginManager.hpp
+++ b/magda/daw/audio/plugin_manager/PluginManager.hpp
@@ -333,7 +333,7 @@ class PluginManager : public daw::audio::DrumGridPlugin::Listener,
      * @param devicePath The device whose state to restore
      * @param plugin The TE plugin to apply state to
      */
-    void restorePluginState(const ChainNodePath& devicePath, te::Plugin::Ptr plugin);
+    static void restorePluginState(const ChainNodePath& devicePath, te::Plugin::Ptr plugin);
 
     // =========================================================================
     // Utilities
@@ -694,11 +694,11 @@ class PluginManager : public daw::audio::DrumGridPlugin::Listener,
     void updateDeviceModifierProperties(TrackId trackId);
 
     // Compute (activeModCount, totalLinkCount) fingerprint across device+track mods.
-    std::pair<int, int> computeModLinkFingerprint(TrackId trackId,
-                                                  const TrackInfo* trackInfo) const;
+    static std::pair<int, int> computeModLinkFingerprint(TrackId trackId,
+                                                         const TrackInfo* trackInfo);
 
     // Check whether a track needs a SidechainMonitorPlugin (MIDI sidechain source).
-    bool trackNeedsSidechainMonitor(TrackId trackId) const;
+    static bool trackNeedsSidechainMonitor(TrackId trackId);
 
     // Check whether a track needs an AudioSidechainMonitorPlugin (audio sidechain source).
     bool trackNeedsAudioSidechainMonitor(TrackId trackId) const;

--- a/magda/daw/audio/plugin_manager/PluginManagerModifiers.cpp
+++ b/magda/daw/audio/plugin_manager/PluginManagerModifiers.cpp
@@ -1006,7 +1006,7 @@ void PluginManager::rebuildSidechainLFOCache() {
 
 // =============================================================================
 std::pair<int, int> PluginManager::computeModLinkFingerprint(TrackId trackId,
-                                                             const TrackInfo* trackInfo) const {
+                                                             const TrackInfo* trackInfo) {
     if (!trackInfo)
         return {0, 0};
 

--- a/magda/daw/audio/plugin_manager/PluginManagerSidechain.cpp
+++ b/magda/daw/audio/plugin_manager/PluginManagerSidechain.cpp
@@ -109,7 +109,7 @@ void PluginManager::syncSidechains(TrackId trackId, te::AudioTrack* teTrack) {
 // Sidechain Monitor Lifecycle
 // =============================================================================
 
-bool PluginManager::trackNeedsSidechainMonitor(TrackId trackId) const {
+bool PluginManager::trackNeedsSidechainMonitor(TrackId trackId) {
     // The master owns modifiers but has no AudioTrack/plugin list to host a
     // MIDI monitor. It can be a sidechain destination, never a source.
     if (trackId == MASTER_TRACK_ID)

--- a/magda/daw/audio/plugins/DrumGridPlugin.hpp
+++ b/magda/daw/audio/plugins/DrumGridPlugin.hpp
@@ -207,7 +207,7 @@ class DrumGridPlugin : public te::Plugin, private juce::Timer {
     // multi-out child track. There is no second switch in front of that: the
     // `multiOutEnabled` flag that used to be here gated `assignBusOutputs()`,
     // which #2207 removed, and nothing ever wrote or read either (#2211).
-    int getNumOutputChannels() const {
+    static int getNumOutputChannels() {
         return maxBusOutputs * 2;
     }
 
@@ -308,7 +308,7 @@ class DrumGridPlugin : public te::Plugin, private juce::Timer {
     // Runs on every pass: neither changes the structure the rebuild keys on.
     // Returns true when a gain moved, which the published snapshot carries and
     // so has to be republished.
-    bool applyPadPluginState(Chain& chain, const magda::ChainInfo& pad);
+    static bool applyPadPluginState(Chain& chain, const magda::ChainInfo& pad);
 
     // What the mirror was last built from, so a sync pass that changes nothing
     // does nothing. Structure only: pad ids, their devices, and the order of
@@ -350,7 +350,7 @@ class DrumGridPlugin : public te::Plugin, private juce::Timer {
     int blockSize_ = 512;
 
     // Internal helper: pad-array index for a chain (lowNote - baseNote), or -1 if out of range
-    int padIndexFor(const Chain& chain) const {
+    static int padIndexFor(const Chain& chain) {
         int p = chain.lowNote - baseNote;
         return (p >= 0 && p < maxPads) ? p : -1;
     }

--- a/magda/daw/audio/plugins/FaustInstrumentPlugin.hpp
+++ b/magda/daw/audio/plugins/FaustInstrumentPlugin.hpp
@@ -208,7 +208,7 @@ class FaustInstrumentPlugin : public MagdaDevice, public IFaustEditorModel {
     // Rewrite every sounding poly voice's freq zone for `ratio`. The allocator
     // writes an unbent freq on keyOn, so this also has to run after a note
     // starts, not only when the wheel moves.
-    void applyBendToPolyVoices(const std::shared_ptr<FaustState>& state, float ratio);
+    static void applyBendToPolyVoices(const std::shared_ptr<FaustState>& state, float ratio);
     // Silence everything: poly voices, the mono voice, and the held-note stack.
     void resetAllVoices(const std::shared_ptr<FaustState>& state);
     // Release EVERY poly voice sounding (or legato-targeting) this pitch.
@@ -217,7 +217,7 @@ class FaustInstrumentPlugin : public MagdaDevice, public IFaustEditorModel {
     // self-heals orphans. Duplicate on/off streams for one pitch are legitimate
     // - a freshly recorded clip playing back while the live input that fed it
     // is still monitored - so an unbalanced delivery must never strand a voice.
-    void releasePolyVoicesForPitch(const std::shared_ptr<FaustState>& state, int pitch);
+    static void releasePolyVoicesForPitch(const std::shared_ptr<FaustState>& state, int pitch);
     // Returns true when the caller must render one sample of gate-low before
     // raising the gate again, which is how Mono retriggers an envelope.
     bool handleMonoNoteOn(const std::shared_ptr<FaustState>& state, int note, int velocity,

--- a/magda/daw/audio/plugins/compiled/MagdaFilterCompiledPlugin.cpp
+++ b/magda/daw/audio/plugins/compiled/MagdaFilterCompiledPlugin.cpp
@@ -124,7 +124,7 @@ int MagdaFilterCompiledPlugin::slotForDspIdx(int idx) const {
     }
 }
 
-std::vector<juce::String> MagdaFilterCompiledPlugin::modeChoicesForEngine(int engineIndex) const {
+std::vector<juce::String> MagdaFilterCompiledPlugin::modeChoicesForEngine(int engineIndex) {
     switch (static_cast<FilterFamily>(engineIndex)) {
         case FilterFamily::SVF:
             return {"LP", "BP", "HP", "Notch"};

--- a/magda/daw/audio/plugins/compiled/MagdaFilterCompiledPlugin.hpp
+++ b/magda/daw/audio/plugins/compiled/MagdaFilterCompiledPlugin.hpp
@@ -49,7 +49,7 @@ class MagdaFilterCompiledPlugin : public MagdaCompiledEffect {
     /// The modes @p engineIndex can actually produce. Each family's Faust
     /// source declares only its own set, and the host's dropdown mirrors that
     /// so it never offers a mode with no branch behind it.
-    std::vector<juce::String> modeChoicesForEngine(int engineIndex) const;
+    static std::vector<juce::String> modeChoicesForEngine(int engineIndex);
 
     int engineAwareModeSlot() const override {
         return kModeSlot;

--- a/magda/daw/audio/racks/RackSyncManager.cpp
+++ b/magda/daw/audio/racks/RackSyncManager.cpp
@@ -958,7 +958,7 @@ te::Plugin::Ptr RackSyncManager::createPluginForRack(TrackId trackId, const Devi
     return pluginManager_.createPluginOnly(trackId, device);
 }
 
-bool RackSyncManager::structureChanged(const SyncedRack& synced, const RackInfo& rackInfo) const {
+bool RackSyncManager::structureChanged(const SyncedRack& synced, const RackInfo& rackInfo) {
     std::set<juce::String> expectedChains;
     std::set<DeviceId> expectedDevices;
     std::set<juce::String> expectedNestedRacks;

--- a/magda/daw/audio/racks/RackSyncManager.hpp
+++ b/magda/daw/audio/racks/RackSyncManager.hpp
@@ -291,7 +291,7 @@ class RackSyncManager {
      * @brief Check if rack structure changed (devices/chains added/removed/reordered)
      * vs only properties changed (bypass, volume, mute/solo)
      */
-    bool structureChanged(const SyncedRack& synced, const RackInfo& rackInfo) const;
+    static bool structureChanged(const SyncedRack& synced, const RackInfo& rackInfo);
 
     /**
      * @brief Update only properties (bypass, volume, chain mute/solo) without rebuilding plugins
@@ -305,8 +305,8 @@ class RackSyncManager {
 
     void loadRackContents(SyncedRack& synced, TrackId trackId, const RackInfo& rackInfo,
                           const ChainNodePath& rackPath, te::RackType& rackType);
-    void buildConnectionsForRack(SyncedRack& synced, const RackInfo& rackInfo,
-                                 const ChainNodePath& rackPath, te::RackType& rackType);
+    static void buildConnectionsForRack(SyncedRack& synced, const RackInfo& rackInfo,
+                                        const ChainNodePath& rackPath, te::RackType& rackType);
     void rebuildConnectionsRecursive(SyncedRack& synced, const RackInfo& rackInfo,
                                      const ChainNodePath& rackPath, te::RackType& rackType);
     void updateElementPropertiesRecursive(SyncedRack& synced, const RackInfo& rackInfo,
@@ -343,7 +343,7 @@ class RackSyncManager {
     /**
      * @brief Apply rack bypass state via wet/dry gains
      */
-    void applyBypassState(SyncedRack& synced, const RackInfo& rackInfo);
+    static void applyBypassState(SyncedRack& synced, const RackInfo& rackInfo);
 
     /**
      * @brief Capture plugin states for a single rack back to TrackManager DeviceInfo

--- a/magda/daw/audio/session/ClipSynchronizer.hpp
+++ b/magda/daw/audio/session/ClipSynchronizer.hpp
@@ -325,7 +325,7 @@ class ClipSynchronizer : public ClipManagerListener, public TrackManagerListener
      * clip's source already points at takes[currentTakeIndex]; the others are
      * preserved as alternates.
      */
-    void applyModelTakesToTeClip(tracktion::WaveAudioClip& teClip, const ClipInfo& clip);
+    static void applyModelTakesToTeClip(tracktion::WaveAudioClip& teClip, const ClipInfo& clip);
 
     /**
      * @brief Configure autoTempo on a session audio clip in TE

--- a/magda/daw/audio/session/SessionClipScheduler.cpp
+++ b/magda/daw/audio/session/SessionClipScheduler.cpp
@@ -190,7 +190,7 @@ SessionClipPlayState SessionClipScheduler::getClipPlayState(ClipId clipId) const
     return SessionClipPlayState::Stopped;
 }
 
-bool SessionClipScheduler::hasActiveClips() const {
+bool SessionClipScheduler::hasActiveClips() {
     auto& tm = TrackManager::getInstance();
     for (const auto& track : tm.getTracks()) {
         if (track.activeSessionClipId != INVALID_CLIP_ID)

--- a/magda/daw/audio/session/SessionClipScheduler.hpp
+++ b/magda/daw/audio/session/SessionClipScheduler.hpp
@@ -60,7 +60,7 @@ class SessionClipScheduler : public ClipManagerListener {
     void relaunchActiveClips();
 
     /** Returns true if any track has an activeSessionClipId set. */
-    bool hasActiveClips() const;
+    static bool hasActiveClips();
 
     /** Returns the looped session playhead position (seconds), or -1.0 if no session clips active.
         This tracks the most recently launched clip (used by clip editors). */
@@ -96,7 +96,7 @@ class SessionClipScheduler : public ClipManagerListener {
 
     /** Derive and sync TrackPlaybackMode for all tracks from activeSessionClipId.
         Tracks with an active session clip → Session, others → Arrangement. */
-    void syncTrackPlaybackModes();
+    static void syncTrackPlaybackModes();
 
     /** Ensure a LaunchHandle shared_ptr is held for a clip (keeps it alive for audio thread). */
     void retainLaunchHandle(ClipId clipId);

--- a/magda/daw/audio/sidechain/SidechainRoutingManager.hpp
+++ b/magda/daw/audio/sidechain/SidechainRoutingManager.hpp
@@ -14,8 +14,8 @@ class SidechainRoutingManager {
 
     void refreshAllSourceMonitors();
     void handleDeviceSidechainChanged(TrackId destinationTrackId, const DeviceInfo& device);
-    void triggerMidiActivity(TrackId trackId);
-    void publishAudioPeak(TrackId trackId, float peak);
+    static void triggerMidiActivity(TrackId trackId);
+    static void publishAudioPeak(TrackId trackId, float peak);
 
   private:
     PluginManager& pluginManager_;

--- a/magda/daw/core/AutomationManager.cpp
+++ b/magda/daw/core/AutomationManager.cpp
@@ -569,7 +569,7 @@ void AutomationManager::endTargetGesture(const AutomationTarget& target) {
         dispatchAuthorityEvent(laneId, AutomationAuthorityEvent::EndGesture);
 }
 
-bool AutomationManager::isWriteModeEnabled() const {
+bool AutomationManager::isWriteModeEnabled() {
     auto* audioEngine = TrackManager::getInstance().getAudioEngine();
     if (!audioEngine)
         return false;
@@ -577,8 +577,7 @@ bool AutomationManager::isWriteModeEnabled() const {
     return bridge && bridge->isAutomationWriteEnabled();
 }
 
-std::optional<double> AutomationManager::getCurrentTargetValue(
-    const AutomationTarget& target) const {
+std::optional<double> AutomationManager::getCurrentTargetValue(const AutomationTarget& target) {
     return getCurrentTargetValueImpl(target);
 }
 
@@ -1083,7 +1082,7 @@ double AutomationManager::getClipValueAtBeat(AutomationClipId clipId,
 }
 
 double AutomationManager::interpolatePoints(const std::vector<AutomationPoint>& points,
-                                            double beatPosition) const {
+                                            double beatPosition) {
     return automation::valueAtBeat(points, beatPosition);
 }
 
@@ -1259,7 +1258,7 @@ AutomationPoint* AutomationManager::findPoint(std::vector<AutomationPoint>& poin
 }
 
 const AutomationPoint* AutomationManager::findPoint(const std::vector<AutomationPoint>& points,
-                                                    AutomationPointId pointId) const {
+                                                    AutomationPointId pointId) {
     for (const auto& point : points) {
         if (point.id == pointId)
             return &point;

--- a/magda/daw/core/AutomationManager.hpp
+++ b/magda/daw/core/AutomationManager.hpp
@@ -226,12 +226,12 @@ class AutomationManager : public TrackManagerListener {
 
     // Query the real automation-write mode from AudioBridge so controls don't
     // depend on a duplicated UI-side cache that can drift out of sync.
-    bool isWriteModeEnabled() const;
+    static bool isWriteModeEnabled();
 
     // Current live normalized value for a target, independent of whether its
     // automation lane is active. Used by disabled lanes to show where the
     // manual value sits against the stored curve.
-    std::optional<double> getCurrentTargetValue(const AutomationTarget& target) const;
+    static std::optional<double> getCurrentTargetValue(const AutomationTarget& target);
 
     using AuthorityStateListener =
         std::function<void(AutomationLaneId, AutomationAuthorityState, AutomationAuthorityState)>;
@@ -426,7 +426,8 @@ class AutomationManager : public TrackManagerListener {
      *        (linear/tension, bezier, step, hard corner) — the model's exact
      *        curve for renderers working outside lane/clip lookups.
      */
-    double interpolatePoints(const std::vector<AutomationPoint>& points, double beatPosition) const;
+    static double interpolatePoints(const std::vector<AutomationPoint>& points,
+                                    double beatPosition);
 
     // ========================================================================
     // Listener Management
@@ -597,10 +598,11 @@ class AutomationManager : public TrackManagerListener {
     // Interpolation helpers
 
     // Point management helpers
-    AutomationPoint* findPoint(std::vector<AutomationPoint>& points, AutomationPointId pointId);
-    const AutomationPoint* findPoint(const std::vector<AutomationPoint>& points,
-                                     AutomationPointId pointId) const;
-    void sortPoints(std::vector<AutomationPoint>& points);
+    static AutomationPoint* findPoint(std::vector<AutomationPoint>& points,
+                                      AutomationPointId pointId);
+    static const AutomationPoint* findPoint(const std::vector<AutomationPoint>& points,
+                                            AutomationPointId pointId);
+    static void sortPoints(std::vector<AutomationPoint>& points);
 };
 
 }  // namespace magda

--- a/magda/daw/core/ClipBatchEdit.hpp
+++ b/magda/daw/core/ClipBatchEdit.hpp
@@ -29,7 +29,7 @@ class ClipBatchEdit {
     ClipBatchEdit(const ClipBatchEdit&) = delete;
     ClipBatchEdit& operator=(const ClipBatchEdit&) = delete;
 
-    void execute(std::unique_ptr<UndoableCommand> command) {
+    static void execute(std::unique_ptr<UndoableCommand> command) {
         UndoManager::getInstance().executeCommand(std::move(command));
     }
 

--- a/magda/daw/core/ClipManager.cpp
+++ b/magda/daw/core/ClipManager.cpp
@@ -2434,7 +2434,7 @@ ClipId ClipManager::findCrossfadeNeighbour(ClipId clipId, bool atStart) const {
     return bestId;
 }
 
-double ClipManager::availableLeftExtensionBeats(const ClipInfo& clip, double bpm) const {
+double ClipManager::availableLeftExtensionBeats(const ClipInfo& clip, double bpm) {
     const auto* event = clip.primaryEvent();
     if (event == nullptr)
         return 0.0;
@@ -2448,7 +2448,7 @@ double ClipManager::availableLeftExtensionBeats(const ClipInfo& clip, double bpm
     return (juce::jmax(0.0, event->anchorSeconds()) / speed) * bpm / 60.0;
 }
 
-double ClipManager::availableRightExtensionBeats(const ClipInfo& clip, double bpm) const {
+double ClipManager::availableRightExtensionBeats(const ClipInfo& clip, double bpm) {
     const auto* event = clip.primaryEvent();
     if (event == nullptr)
         return 0.0;

--- a/magda/daw/core/ClipManager.hpp
+++ b/magda/daw/core/ClipManager.hpp
@@ -191,7 +191,7 @@ class ClipManager {
      * captured before the edit; the current (post-edit) state is the redo state.
      * Used by audio comp edits in CompService.
      */
-    void pushClipTakeUndo(const juce::String& desc, const ClipInfo& before);
+    static void pushClipTakeUndo(const juce::String& desc, const ClipInfo& before);
 
     /**
      * @brief Force a clips changed notification (used by undo system)
@@ -918,7 +918,7 @@ class ClipManager {
     void resolveOverlaps(ClipId dominantClipId);
 
     /// Reset a looped clip's length to its base loop length and disable looping
-    void resetLoopedClipLength(ClipInfo& clip);
+    static void resetLoopedClipLength(ClipInfo& clip);
 
     /// Move every event off @p from and onto @p to. Used when a relink target
     /// turns out to be pooled already, so one file keeps one source.
@@ -948,8 +948,8 @@ class ClipManager {
     // (bounded by the source read offset), right = past its current end
     // (bounded by the source duration). Unbounded (infinity) for looping
     // clips and when the source duration is unknown.
-    double availableLeftExtensionBeats(const ClipInfo& clip, double bpm) const;
-    double availableRightExtensionBeats(const ClipInfo& clip, double bpm) const;
+    static double availableLeftExtensionBeats(const ClipInfo& clip, double bpm);
+    static double availableRightExtensionBeats(const ClipInfo& clip, double bpm);
 
     // Unified clip storage — ClipView is a property, not storage identity
     std::unordered_map<ClipId, ClipInfo> clips_;
@@ -1041,7 +1041,7 @@ class ClipManager {
     void notifyClipPlaybackRequested(ClipId clipId, ClipPlaybackRequest request);
 
     // Clamp audio clip properties (offset, loopStart, loopLength) to file bounds
-    void sanitizeAudioClip(ClipInfo& clip);
+    static void sanitizeAudioClip(ClipInfo& clip);
 
     // Helper to generate unique clip name
     juce::String generateClipName(ClipType type) const;

--- a/magda/daw/core/DrumkitManager.cpp
+++ b/magda/daw/core/DrumkitManager.cpp
@@ -89,7 +89,7 @@ DrumkitManager::DrumkitManager() {
     }
 }
 
-juce::File DrumkitManager::getDrumkitsDirectory() const {
+juce::File DrumkitManager::getDrumkitsDirectory() {
     return magda::paths::drumkitsDir();
 }
 

--- a/magda/daw/core/DrumkitManager.hpp
+++ b/magda/daw/core/DrumkitManager.hpp
@@ -27,7 +27,7 @@ class DrumkitManager {
 
     static DrumkitManager& getInstance();
 
-    juce::File getDrumkitsDirectory() const;
+    static juce::File getDrumkitsDirectory();
 
     /** Save the given rows under `name`. Existing kits with the same name are
      *  overwritten. Returns false on filesystem failure. */

--- a/magda/daw/core/GainStagingManager.cpp
+++ b/magda/daw/core/GainStagingManager.cpp
@@ -383,7 +383,7 @@ void GainStagingManager::buildStagedDeviceList(TrackId trackId) {
 }
 
 bool GainStagingManager::readDevicePeakLinear(const ChainNodePath& devicePath,
-                                              float& peakLinearOut) const {
+                                              float& peakLinearOut) {
     auto* engine = TrackManager::getInstance().getAudioEngine();
     if (engine == nullptr)
         return false;

--- a/magda/daw/core/GainStagingManager.hpp
+++ b/magda/daw/core/GainStagingManager.hpp
@@ -238,7 +238,7 @@ class GainStagingManager : private juce::Timer {
 
     // Reads max(peakL, peakR) for a device from live metering. Returns false
     // if metering is unavailable or the device has no meter entry.
-    bool readDevicePeakLinear(const ChainNodePath& devicePath, float& peakLinearOut) const;
+    static bool readDevicePeakLinear(const ChainNodePath& devicePath, float& peakLinearOut);
 
     void notifyMode();
     void notifyDevice(const ChainNodePath& devicePath);

--- a/magda/daw/core/MixAnalysisService.cpp
+++ b/magda/daw/core/MixAnalysisService.cpp
@@ -174,7 +174,7 @@ void MixAnalysisService::restoreCaptureState() {
     captureAddedGlobal_ = false;
 }
 
-MixAnalysisData MixAnalysisService::buildLiveInput() const {
+MixAnalysisData MixAnalysisService::buildLiveInput() {
     auto& tmm = TrackMeasurementManager::getInstance();
     auto& tmgr = TrackManager::getInstance();
     auto trackName = [&tmgr](TrackId id) -> juce::String {
@@ -235,7 +235,7 @@ void MixAnalysisService::stopLiveCapture() {
     listeners_.call(&Listener::mixAnalysisChanged);
 }
 
-juce::String MixAnalysisService::scopeDescription() const {
+juce::String MixAnalysisService::scopeDescription() {
     const auto n = selectedTrackSet().size();
     if (n == 0)
         return "the full mix";
@@ -243,7 +243,7 @@ juce::String MixAnalysisService::scopeDescription() const {
            (n == 1 ? " selected channel" : " selected channels");
 }
 
-juce::String MixAnalysisService::rangeDescription() const {
+juce::String MixAnalysisService::rangeDescription() {
     auto* engine = TrackManager::getInstance().getAudioEngine();
     return (engine != nullptr && engine->isLooping()) ? "loop region" : "whole song";
 }

--- a/magda/daw/core/MixAnalysisService.hpp
+++ b/magda/daw/core/MixAnalysisService.hpp
@@ -65,10 +65,10 @@ class MixAnalysisService {
 
     /// Human-readable scope from the current mixer selection: "the full mix"
     /// (nothing or the master selected) or "N selected channels". For menus.
-    juce::String scopeDescription() const;
+    static juce::String scopeDescription();
     /// Human-readable time range an offline run will cover: "loop region" when the
     /// transport is looping (only that part is rendered), else "whole song".
-    juce::String rangeDescription() const;
+    static juce::String rangeDescription();
 
     bool isBusy() const {
         return busy_;
@@ -101,7 +101,7 @@ class MixAnalysisService {
     void store(Mode mode, MixAnalysisData input);
     void setBusy(bool busy, Mode mode);
     void restoreCaptureState();  // undo what startLiveCapture armed
-    MixAnalysisData buildLiveInput() const;
+    static MixAnalysisData buildLiveInput();
 
     bool busy_ = false;
     Mode busyMode_ = Mode::Offline;

--- a/magda/daw/core/ModulatorEngine.hpp
+++ b/magda/daw/core/ModulatorEngine.hpp
@@ -209,7 +209,7 @@ class ModulatorEngine {
             postUpdateHook_();
     }
 
-    void updateAllMods(double deltaTime);
+    static void updateAllMods(double deltaTime);
 
     // Timer instance - using composition instead of inheritance to allow early destruction
     std::unique_ptr<UpdateTimer> timer_;

--- a/magda/daw/core/PluginPresetScanner.cpp
+++ b/magda/daw/core/PluginPresetScanner.cpp
@@ -142,15 +142,15 @@ PluginPresetScanner& PluginPresetScanner::getInstance() {
     return instance;
 }
 
-juce::String PluginPresetScanner::makeCacheKey(const DeviceInfo& device) const {
+juce::String PluginPresetScanner::makeCacheKey(const DeviceInfo& device) {
     return device.getFormatString() + "|" + device.manufacturer + "|" + device.name;
 }
 
-juce::String PluginPresetScanner::getPresetExtension(const DeviceInfo& device) const {
+juce::String PluginPresetScanner::getPresetExtension(const DeviceInfo& device) {
     return extensionFor(device.format);
 }
 
-std::vector<juce::File> PluginPresetScanner::getScanRoots(const DeviceInfo& device) const {
+std::vector<juce::File> PluginPresetScanner::getScanRoots(const DeviceInfo& device) {
     std::vector<juce::File> out;
     auto vendor = sanitiseFolderName(device.manufacturer);
     auto plugin = sanitiseFolderName(device.name);
@@ -169,7 +169,7 @@ std::vector<juce::File> PluginPresetScanner::getScanRoots(const DeviceInfo& devi
     return out;
 }
 
-juce::File PluginPresetScanner::getUserPresetDirectory(const DeviceInfo& device) const {
+juce::File PluginPresetScanner::getUserPresetDirectory(const DeviceInfo& device) {
     auto vendor = sanitiseFolderName(device.manufacturer);
     auto plugin = sanitiseFolderName(device.name);
     if (vendor.isEmpty() || plugin.isEmpty())

--- a/magda/daw/core/PluginPresetScanner.hpp
+++ b/magda/daw/core/PluginPresetScanner.hpp
@@ -63,24 +63,24 @@ class PluginPresetScanner {
      * @brief The user-writable directory where MAGDA writes new presets for
      *        this plugin. Created on demand (only when actually written to).
      */
-    juce::File getUserPresetDirectory(const DeviceInfo& device) const;
+    static juce::File getUserPresetDirectory(const DeviceInfo& device);
 
     /**
      * @brief Filesystem extension expected for the device's plugin format
      *        (".vstpreset", ".aupreset", or empty for unsupported formats).
      */
-    juce::String getPresetExtension(const DeviceInfo& device) const;
+    static juce::String getPresetExtension(const DeviceInfo& device);
 
     /**
      * @brief All directories (user + system) scanned for the device. Useful
      *        for exposing a "Reveal in Finder" action for the user dir.
      */
-    std::vector<juce::File> getScanRoots(const DeviceInfo& device) const;
+    static std::vector<juce::File> getScanRoots(const DeviceInfo& device);
 
   private:
     PluginPresetScanner() = default;
 
-    juce::String makeCacheKey(const DeviceInfo& device) const;
+    static juce::String makeCacheKey(const DeviceInfo& device);
     PresetTree scanPlugin(const DeviceInfo& device) const;
 
     std::unordered_map<std::string, PresetTree> cache_;

--- a/magda/daw/core/PresetManager.cpp
+++ b/magda/daw/core/PresetManager.cpp
@@ -197,7 +197,7 @@ PresetManager::PresetManager() {
 // Preset Directories
 // ============================================================================
 
-juce::File PresetManager::getPresetsDirectory() const {
+juce::File PresetManager::getPresetsDirectory() {
     return magda::paths::presetsDir();
 }
 
@@ -534,7 +534,7 @@ bool PresetManager::ensureDirectoryExists(const juce::File& directory) {
     return true;
 }
 
-juce::StringArray PresetManager::getPresetList(const juce::File& directory) const {
+juce::StringArray PresetManager::getPresetList(const juce::File& directory) {
     juce::StringArray presets;
 
     if (!directory.exists())

--- a/magda/daw/core/PresetManager.hpp
+++ b/magda/daw/core/PresetManager.hpp
@@ -37,7 +37,7 @@ class PresetManager {
      * @brief Get the root presets directory
      * @return ~/Documents/MAGDA/Presets/
      */
-    juce::File getPresetsDirectory() const;
+    static juce::File getPresetsDirectory();
 
     /**
      * @brief Get the chains presets directory
@@ -236,7 +236,7 @@ class PresetManager {
     /**
      * @brief Get list of preset files in a directory
      */
-    juce::StringArray getPresetList(const juce::File& directory) const;
+    static juce::StringArray getPresetList(const juce::File& directory);
 
     juce::String lastError_;
     std::unordered_map<DeviceId, juce::String> suggestedNames_;

--- a/magda/daw/core/TrackManager.hpp
+++ b/magda/daw/core/TrackManager.hpp
@@ -653,7 +653,7 @@ class TrackManager : public daw::audio::DeviceIdAllocator, public daw::audio::De
     bool setPadOutput(const ChainNodePath& gridPath, int padIndex, int outputIndex);
 
     /// Whether a bus can be assigned to @p gridPath's pads at all.
-    bool padBusesAvailable(const ChainNodePath& gridPath) const;
+    static bool padBusesAvailable(const ChainNodePath& gridPath);
 
     /// Put every pad back on the grid's own mix. True when any of them moved.
     ///
@@ -1350,7 +1350,7 @@ class TrackManager : public daw::audio::DeviceIdAllocator, public daw::audio::De
     void syncMultiOutChildOutputsForSource(TrackId sourceTrackId);
 
     // Helper for recursive mod updates
-    void updateRackMods(const RackInfo& rack, double deltaTime);
+    static void updateRackMods(const RackInfo& rack, double deltaTime);
 
     juce::String generateTrackName() const;
 };

--- a/magda/daw/core/TrackManagerPads.cpp
+++ b/magda/daw/core/TrackManagerPads.cpp
@@ -323,7 +323,7 @@ void TrackManager::setPadBypassed(const ChainNodePath& gridPath, int padIndex, b
     }
 }
 
-bool TrackManager::padBusesAvailable(const ChainNodePath& gridPath) const {
+bool TrackManager::padBusesAvailable(const ChainNodePath& gridPath) {
     // A multi-out child track is fed by the output instance
     // InstrumentRackManager makes when it wraps a top-level instrument. A grid
     // inside a MAGDA rack is loaded by RackSyncManager instead and has no entry

--- a/magda/daw/core/TrackMeasurementManager.hpp
+++ b/magda/daw/core/TrackMeasurementManager.hpp
@@ -77,8 +77,8 @@ class TrackMeasurementManager : private juce::Timer {
     /// spectrum ring) into dest, for a full-resolution overlay FFT (#1400). The
     /// overlay runs the same pipeline as the device's own trace on these samples.
     /// Returns the ring's running sample count (0 if no live tap / no audio yet).
-    size_t readTrackSpectrumSamples(TrackId trackId, float* dest, int numSamples,
-                                    double& sampleRateOut) const;
+    static size_t readTrackSpectrumSamples(TrackId trackId, float* dest, int numSamples,
+                                           double& sampleRateOut);
 
     void addListener(TrackMeasurementListener* l) {
         listeners_.add(l);

--- a/magda/daw/core/controllers/ControllerProfileRegistry.cpp
+++ b/magda/daw/core/controllers/ControllerProfileRegistry.cpp
@@ -65,7 +65,7 @@ juce::File ControllerProfileRegistry::userFileForProfileId(const juce::String& i
     return userControllersDirectory().getChildFile(filenameForProfileId(id));
 }
 
-juce::File ControllerProfileRegistry::findSourceFileForProfileId(const juce::String& id) const {
+juce::File ControllerProfileRegistry::findSourceFileForProfileId(const juce::String& id) {
     // Try the canonical filename in the user dir first — fast path for
     // user-imported profiles (matches load() precedence: user wins over bundled).
     auto direct = userFileForProfileId(id);

--- a/magda/daw/core/controllers/ControllerProfileRegistry.hpp
+++ b/magda/daw/core/controllers/ControllerProfileRegistry.hpp
@@ -70,7 +70,7 @@ class ControllerProfileRegistry {
      * exist. This walks the user directory and returns the file whose parsed
      * id matches. Returns an invalid juce::File when no match.
      */
-    juce::File findSourceFileForProfileId(const juce::String& id) const;
+    static juce::File findSourceFileForProfileId(const juce::String& id);
 
   private:
     ControllerProfileRegistry() = default;

--- a/magda/daw/engine/PluginScanCoordinator.cpp
+++ b/magda/daw/engine/PluginScanCoordinator.cpp
@@ -35,7 +35,7 @@ PluginScanCoordinator::~PluginScanCoordinator() {
     workers_.clear();
 }
 
-juce::File PluginScanCoordinator::getScannerExecutable() const {
+juce::File PluginScanCoordinator::getScannerExecutable() {
     auto appBundle = juce::File::getSpecialLocation(juce::File::currentApplicationFile);
 
     juce::StringArray triedPaths;
@@ -523,7 +523,7 @@ void PluginScanCoordinator::saveExclusions() {
     }
 }
 
-juce::File PluginScanCoordinator::getScanReportFile() const {
+juce::File PluginScanCoordinator::getScanReportFile() {
     return magda::paths::lastScanReportFile();
 }
 

--- a/magda/daw/engine/PluginScanCoordinator.hpp
+++ b/magda/daw/engine/PluginScanCoordinator.hpp
@@ -107,7 +107,7 @@ class PluginScanCoordinator : private juce::Timer {
         return pluginTimeoutMs_;
     }
 
-    juce::File getScanReportFile() const;
+    static juce::File getScanReportFile();
 
   private:
     static constexpr int NUM_WORKERS = 4;
@@ -128,10 +128,10 @@ class PluginScanCoordinator : private juce::Timer {
     void writeScanReport();
 
     // Find the scanner executable
-    juce::File getScannerExecutable() const;
+    static juce::File getScannerExecutable();
 
     // Orphan process cleanup
-    void killOrphanScannerProcesses();
+    static void killOrphanScannerProcesses();
 
     // Exclusion management
     void loadExclusions();

--- a/magda/daw/engine/TracktionEngineWrapper.cpp
+++ b/magda/daw/engine/TracktionEngineWrapper.cpp
@@ -13,7 +13,7 @@ namespace magda {
 // PDC Query Methods
 // =============================================================================
 
-double TracktionEngineWrapper::getPluginLatencySeconds(const std::string& effect_id) const {
+double TracktionEngineWrapper::getPluginLatencySeconds(const std::string& effect_id) {
     // TODO: Implement when we have effect tracking
     // For now, iterate all tracks and their plugins to find by ID
     juce::ignoreUnused(effect_id);

--- a/magda/daw/engine/TracktionEngineWrapper.hpp
+++ b/magda/daw/engine/TracktionEngineWrapper.hpp
@@ -514,7 +514,7 @@ class TracktionEngineWrapper : public AudioEngine,
      * @brief Get the database path where plugin metadata is stored
      * @return Path to plugin_metadata.db
      */
-    juce::File getPluginListFile() const;
+    static juce::File getPluginListFile();
 
     // =========================================================================
     // PDC (Plugin Delay Compensation) Query
@@ -525,7 +525,7 @@ class TracktionEngineWrapper : public AudioEngine,
      * @param effect_id The effect/plugin ID
      * @return Latency in seconds, or 0 if plugin not found
      */
-    double getPluginLatencySeconds(const std::string& effect_id) const;
+    static double getPluginLatencySeconds(const std::string& effect_id);
 
     /**
      * @brief Get the maximum latency across all tracks in the playback graph

--- a/magda/daw/engine/TracktionEngineWrapperPlugins.cpp
+++ b/magda/daw/engine/TracktionEngineWrapperPlugins.cpp
@@ -331,7 +331,7 @@ juce::Array<juce::PluginDescription> TracktionEngineWrapper::getPreferredPluginT
         getKnownPluginList().getTypes());
 }
 
-juce::File TracktionEngineWrapper::getPluginListFile() const {
+juce::File TracktionEngineWrapper::getPluginListFile() {
     // Routed via paths::pluginMetadataFile() — respects MAGDA_DATA_DIR /
     // Config::getDataDir() override. Defaults to userApplicationDataDirectory.
     auto file = magda::paths::pluginMetadataFile();

--- a/magda/daw/magda_daw_main.cpp
+++ b/magda/daw/magda_daw_main.cpp
@@ -134,7 +134,7 @@ class MagdaDAWApplication : public JUCEApplication {
     bool loadLuaScript(const juce::File& file);
     void unloadLuaScript();
     juce::String activeLuaScriptName() const;
-    void revealLuaScriptsFolder();
+    static void revealLuaScriptsFolder();
 
     /// Handles for the OSC section of ControllersDialog (osc_app.hpp), which
     /// only reads through them. Null before deferred init has run, and after

--- a/magda/daw/media_db/MediaDbContext.cpp
+++ b/magda/daw/media_db/MediaDbContext.cpp
@@ -28,7 +28,7 @@ MediaDbContext& MediaDbContext::getInstance() {
 MediaDbContext::MediaDbContext() = default;
 MediaDbContext::~MediaDbContext() = default;
 
-std::filesystem::path MediaDbContext::dbPath() const {
+std::filesystem::path MediaDbContext::dbPath() {
     // User override: same fall-back semantics as modelsDir(). Lets users
     // park the (potentially large) index on a different drive without
     // symlinking. If the override directory has gone missing (drive
@@ -48,7 +48,7 @@ std::filesystem::path MediaDbContext::dbPath() const {
            "db" / "media.db";
 }
 
-std::filesystem::path MediaDbContext::modelsDir() const {
+std::filesystem::path MediaDbContext::modelsDir() {
     // User override: if Config has a non-empty path AND it points at a
     // real directory, use it. Lets the user keep the ~600 MB Sample
     // Tagger bundle on an external drive. Falls back to the default

--- a/magda/daw/media_db/MediaDbContext.hpp
+++ b/magda/daw/media_db/MediaDbContext.hpp
@@ -91,8 +91,8 @@ class MediaDbContext {
     // Path helpers. The DB file is fixed at dataDir/MediaDB/media.db; model
     // files live in dataDir/MediaDB/models/ (Phase F's download UI will place
     // them there).
-    [[nodiscard]] std::filesystem::path dbPath() const;
-    [[nodiscard]] std::filesystem::path modelsDir() const;
+    [[nodiscard]] static std::filesystem::path dbPath();
+    [[nodiscard]] static std::filesystem::path modelsDir();
     [[nodiscard]] std::filesystem::path midiClipsDir() const;
     [[nodiscard]] std::filesystem::path progressionsDir() const;
     [[nodiscard]] std::filesystem::path audioModelPath() const;

--- a/magda/daw/music/ChordEngine.cpp
+++ b/magda/daw/music/ChordEngine.cpp
@@ -107,7 +107,7 @@ ChordEngine::~ChordEngine() = default;
 
 // === CHORD DETECTION ===
 
-Chord ChordEngine::detect(const std::vector<ChordNote>& heldNotes) const {
+Chord ChordEngine::detect(const std::vector<ChordNote>& heldNotes) {
     if (heldNotes.empty())
         return {"none"};
 
@@ -379,14 +379,13 @@ Chord ChordEngine::detectPolychord(const std::vector<ChordNote>& notes) const {
     return detect(notes);
 }
 
-bool ChordEngine::isPolychordCandidate(const std::vector<ChordNote>& notes) const {
+bool ChordEngine::isPolychordCandidate(const std::vector<ChordNote>& notes) {
     return notes.size() >= 6;
 }
 
 // === CHORD CREATION ===
 
-Chord ChordEngine::buildChordInRootPosition(ChordRoot root, ChordQuality quality,
-                                            int octave) const {
+Chord ChordEngine::buildChordInRootPosition(ChordRoot root, ChordQuality quality, int octave) {
     std::vector<int> intervals = ChordUtils::getChordIntervals(quality);
     std::vector<ChordNote> notes;
 
@@ -413,7 +412,7 @@ std::vector<Chord> ChordEngine::buildChordInversions(ChordRoot root, ChordQualit
 }
 
 Chord ChordEngine::buildChordInversion(ChordRoot root, ChordQuality quality, int inversion,
-                                       int octave) const {
+                                       int octave) {
     std::vector<int> intervals = ChordUtils::getChordIntervals(quality);
     std::vector<ChordNote> notes;
 
@@ -466,7 +465,7 @@ juce::String ChordEngine::chordSpecToString(const ChordSpec& spec, bool includeI
 }
 
 std::vector<std::pair<juce::String, float>> ChordEngine::findChordsFromNotes(
-    const std::vector<int>& pitchClasses) const {
+    const std::vector<int>& pitchClasses) {
     std::vector<std::pair<juce::String, float>> results;
     if (pitchClasses.empty())
         return results;

--- a/magda/daw/music/ChordEngine.hpp
+++ b/magda/daw/music/ChordEngine.hpp
@@ -51,17 +51,17 @@ class ChordEngine {
     ~ChordEngine();
 
     // Detection
-    [[nodiscard]] Chord detect(const std::vector<ChordNote>& heldNotes) const;
+    [[nodiscard]] static Chord detect(const std::vector<ChordNote>& heldNotes);
     Chord smartDetect(const std::vector<ChordNote>& notes) const;
     Chord detectPolychord(const std::vector<ChordNote>& notes) const;
-    bool isPolychordCandidate(const std::vector<ChordNote>& notes) const;
+    static bool isPolychordCandidate(const std::vector<ChordNote>& notes);
 
     // Creation
-    Chord buildChordInRootPosition(ChordRoot root, ChordQuality quality, int octave = 4) const;
+    static Chord buildChordInRootPosition(ChordRoot root, ChordQuality quality, int octave = 4);
     std::vector<Chord> buildChordInversions(ChordRoot root, ChordQuality quality,
                                             int octave = 4) const;
-    Chord buildChordInversion(ChordRoot root, ChordQuality quality, int inversion,
-                              int octave = 4) const;
+    static Chord buildChordInversion(ChordRoot root, ChordQuality quality, int inversion,
+                                     int octave = 4);
 
     // Utility
     static std::vector<int> getChordIntervals(ChordQuality quality);
@@ -69,8 +69,8 @@ class ChordEngine {
     static int getChordNoteCount(ChordQuality quality);
     static ChordSpec parseChordName(const juce::String& chordString);
     static juce::String chordSpecToString(const ChordSpec& spec, bool includeInversion = true);
-    std::vector<std::pair<juce::String, float>> findChordsFromNotes(
-        const std::vector<int>& pitchClasses) const;
+    static std::vector<std::pair<juce::String, float>> findChordsFromNotes(
+        const std::vector<int>& pitchClasses);
 
     // Finalize chord (sort notes, detect inversion, set displayName)
     static void finalizeChord(Chord& c);

--- a/magda/daw/music/ChordSuggestionEngine.cpp
+++ b/magda/daw/music/ChordSuggestionEngine.cpp
@@ -201,7 +201,7 @@ ChordSuggestionEngine::inferKeyModeFromHistogram() const {
 }
 
 std::pair<juce::String, juce::String> ChordSuggestionEngine::inferKeyModeFromContext(
-    const std::vector<Chord>& recentChords) const {
+    const std::vector<Chord>& recentChords) {
     if (recentChords.empty()) {
         return {"C", "major"};
     }
@@ -256,7 +256,7 @@ std::pair<juce::String, juce::String> ChordSuggestionEngine::inferKeyModeFromCon
 }
 
 double ChordSuggestionEngine::dotProduct(const std::array<double, 12>& a,
-                                         const std::array<double, 12>& b) const {
+                                         const std::array<double, 12>& b) {
     double sum = 0.0;
     for (int i = 0; i < 12; ++i) {
         sum += a[i] * b[i];
@@ -265,7 +265,7 @@ double ChordSuggestionEngine::dotProduct(const std::array<double, 12>& a,
 }
 
 std::array<double, 12> ChordSuggestionEngine::rotateProfile(const std::array<double, 12>& profile,
-                                                            int shift) const {
+                                                            int shift) {
     std::array<double, 12> rotated{};
     shift = shift % 12;
     if (shift < 0)
@@ -945,7 +945,7 @@ ChordSuggestionEngine::generateNonDiatonicCandidates(const juce::String& key,
 
 std::vector<ChordSuggestionEngine::SuggestionItem> ChordSuggestionEngine::mixCandidates(
     const std::vector<SuggestionItem>& diatonic, const std::vector<SuggestionItem>& nonDiatonic,
-    float novelty, int topK) const {
+    float novelty, int topK) {
     std::vector<SuggestionItem> result;
 
     if (novelty <= 0.0f) {
@@ -1086,7 +1086,7 @@ juce::String ChordSuggestionEngine::noteAtSemitone(const juce::String& root, int
     return NOTE_NAMES[targetIdx];
 }
 
-int ChordSuggestionEngine::noteToSemitone(const juce::String& note) const {
+int ChordSuggestionEngine::noteToSemitone(const juce::String& note) {
     // Handle enharmonic equivalents
     static const std::map<juce::String, int> noteMap = {
         {"C", 0},  {"C#", 1}, {"Db", 1},  {"D", 2},   {"D#", 3}, {"Eb", 3},
@@ -1228,7 +1228,7 @@ Chord ChordSuggestionEngine::buildChordInRootPosition(const juce::String& root,
     return chord;
 }
 
-int ChordSuggestionEngine::calculateTargetOctave(const std::vector<Chord>& recentChords) const {
+int ChordSuggestionEngine::calculateTargetOctave(const std::vector<Chord>& recentChords) {
     if (recentChords.empty()) {
         return 4;  // Default to octave 4 (C4 = 60)
     }
@@ -1450,7 +1450,7 @@ Chord ChordSuggestionEngine::optimizeVoicing(const Chord& chord, float inversion
     return result;
 }
 
-std::vector<Chord> ChordSuggestionEngine::generateInversions(const Chord& chord) const {
+std::vector<Chord> ChordSuggestionEngine::generateInversions(const Chord& chord) {
     std::vector<Chord> inversions;
 
     if (chord.notes.size() < 2) {
@@ -1669,7 +1669,7 @@ std::vector<Chord> ChordSuggestionEngine::generateInversions(const Chord& chord)
     return inversions;
 }
 
-double ChordSuggestionEngine::calculateCentroid(const Chord& chord) const {
+double ChordSuggestionEngine::calculateCentroid(const Chord& chord) {
     if (chord.notes.empty()) {
         return 60.0;  // Default to C4
     }
@@ -1687,7 +1687,7 @@ double ChordSuggestionEngine::calculateCentroid(const Chord& chord) const {
     return count > 0 ? (total / count) : 60.0;
 }
 
-bool ChordSuggestionEngine::chordsAreEquivalent(const Chord& a, const Chord& b) const {
+bool ChordSuggestionEngine::chordsAreEquivalent(const Chord& a, const Chord& b) {
     // First check if they have the same pitch classes (notes)
     if (!magda::music::chordsAreEquivalent(a, b)) {
         return false;
@@ -1778,7 +1778,7 @@ juce::String ChordSuggestionEngine::getContextTailString(int maxChords) const {
 }
 
 std::vector<ChordSuggestionEngine::SuggestionItem> ChordSuggestionEngine::filterRecentChords(
-    const std::vector<SuggestionItem>& candidates, const std::vector<Chord>& recentChords) const {
+    const std::vector<SuggestionItem>& candidates, const std::vector<Chord>& recentChords) {
     std::vector<SuggestionItem> filtered;
 
     // Get last 2 chords to avoid (reduced from 3 to give more variety and prevent stale

--- a/magda/daw/music/ChordSuggestionEngine.hpp
+++ b/magda/daw/music/ChordSuggestionEngine.hpp
@@ -48,15 +48,15 @@ class ChordSuggestionEngine {
     juce::String getContextTailString(int maxChords = 8) const;
 
     std::optional<std::pair<juce::String, juce::String>> inferKeyModeFromHistogram() const;
-    std::pair<juce::String, juce::String> inferKeyModeFromContext(
-        const std::vector<Chord>& recentChords) const;
+    static std::pair<juce::String, juce::String> inferKeyModeFromContext(
+        const std::vector<Chord>& recentChords);
     std::optional<std::pair<juce::String, juce::String>> inferKeyModeFromScaleDetection() const;
 
     juce::String getDetectedScalesString(float novelty = 0.3f) const;
     std::vector<std::pair<juce::String, juce::String>> getTopDetectedScales(
         int maxScales = 3, float novelty = 0.3f) const;
 
-    int calculateTargetOctave(const std::vector<Chord>& recentChords) const;
+    static int calculateTargetOctave(const std::vector<Chord>& recentChords);
 
     Chord buildChordObject(const juce::String& root, const juce::String& quality, int targetOctave,
                            float inversionStrength, const std::vector<Chord>& recentChords) const;
@@ -83,11 +83,11 @@ class ChordSuggestionEngine {
     static const std::array<juce::String, 12> NOTE_NAMES;
 
     std::array<double, 12> getDecayedHistogram(double currentTimeSeconds) const;
-    double dotProduct(const std::array<double, 12>& a, const std::array<double, 12>& b) const;
-    std::array<double, 12> rotateProfile(const std::array<double, 12>& profile, int shift) const;
+    static double dotProduct(const std::array<double, 12>& a, const std::array<double, 12>& b);
+    static std::array<double, 12> rotateProfile(const std::array<double, 12>& profile, int shift);
 
-    std::vector<SuggestionItem> filterRecentChords(const std::vector<SuggestionItem>& candidates,
-                                                   const std::vector<Chord>& recentChords) const;
+    static std::vector<SuggestionItem> filterRecentChords(
+        const std::vector<SuggestionItem>& candidates, const std::vector<Chord>& recentChords);
 
     std::vector<SuggestionItem> generateDiatonicCandidates(
         const juce::String& key, const juce::String& mode, bool add7ths, bool add9ths,
@@ -98,18 +98,18 @@ class ChordSuggestionEngine {
         const juce::String& key, const juce::String& mode, bool addAlterations, bool addSlashChords,
         int targetOctave, float inversionStrength, const std::vector<Chord>& recentChords) const;
 
-    std::vector<SuggestionItem> mixCandidates(const std::vector<SuggestionItem>& diatonic,
-                                              const std::vector<SuggestionItem>& nonDiatonic,
-                                              float novelty, int topK) const;
+    static std::vector<SuggestionItem> mixCandidates(const std::vector<SuggestionItem>& diatonic,
+                                                     const std::vector<SuggestionItem>& nonDiatonic,
+                                                     float novelty, int topK);
 
     juce::String noteAtSemitone(const juce::String& root, int semitones) const;
-    int noteToSemitone(const juce::String& note) const;
-    bool chordsAreEquivalent(const Chord& a, const Chord& b) const;
+    static int noteToSemitone(const juce::String& note);
+    static bool chordsAreEquivalent(const Chord& a, const Chord& b);
 
     Chord optimizeVoicing(const Chord& chord, float inversionStrength,
                           const std::vector<Chord>& recentChords) const;
-    std::vector<Chord> generateInversions(const Chord& chord) const;
-    double calculateCentroid(const Chord& chord) const;
+    static std::vector<Chord> generateInversions(const Chord& chord);
+    static double calculateCentroid(const Chord& chord);
 };
 
 }  // namespace magda::music

--- a/magda/daw/project/ProjectManager.hpp
+++ b/magda/daw/project/ProjectManager.hpp
@@ -379,7 +379,7 @@ class ProjectManager {
     /**
      * @brief Migrate media files from old directory to new, updating clip paths
      */
-    void migrateMediaFiles(const juce::File& oldDir, const juce::File& newDir);
+    static void migrateMediaFiles(const juce::File& oldDir, const juce::File& newDir);
 
     /**
      * @brief Fold the media roots retired by #2170 into the surviving three.

--- a/magda/daw/stem_separation/StemSeparationService.hpp
+++ b/magda/daw/stem_separation/StemSeparationService.hpp
@@ -42,7 +42,7 @@ class StemSeparationService {
     // True when the engine can run right now (backend compiled in and, for
     // model-based engines, weights installed). UI uses this to enable items
     // or deep-link to the model download instead.
-    [[nodiscard]] bool isEngineAvailable(Engine engine);
+    [[nodiscard]] static bool isEngineAvailable(Engine engine);
 
     // True while a split is running or queued; the UI shows progress for it.
     [[nodiscard]] bool isBusy() const;

--- a/magda/daw/ui/components/automation/AutomationClipComponent.cpp
+++ b/magda/daw/ui/components/automation/AutomationClipComponent.cpp
@@ -417,7 +417,7 @@ AutomationLaneComponent* AutomationClipComponent::getLane() const {
     return findParentComponentOfClass<AutomationLaneComponent>();
 }
 
-bool AutomationClipComponent::copyGestureHeld() const {
+bool AutomationClipComponent::copyGestureHeld() {
     return GestureRouter::getInstance().isDuplicateOnDrag(
         GestureContext::Arrangement, juce::ModifierKeys::getCurrentModifiers());
 }

--- a/magda/daw/ui/components/automation/AutomationClipComponent.hpp
+++ b/magda/daw/ui/components/automation/AutomationClipComponent.hpp
@@ -82,7 +82,7 @@ class AutomationClipComponent : public juce::Component,
   private:
     class AutomationLaneComponent* getLane() const;
     /// True while the copy-on-drag gesture (default Alt) is held.
-    bool copyGestureHeld() const;
+    static bool copyGestureHeld();
 
     AutomationClipId clipId_;
     double pixelsPerBeat_ = 10.0;
@@ -112,7 +112,7 @@ class AutomationClipComponent : public juce::Component,
     // Helpers
     void showContextMenu();
     void updateCursor(int x);
-    bool isOnLeftEdge(int x) const {
+    static static static bool isOnLeftEdge(int x) {
         return x < RESIZE_EDGE_WIDTH;
     }
     bool isOnRightEdge(int x) const {

--- a/magda/daw/ui/components/automation/AutomationClipComponent.hpp
+++ b/magda/daw/ui/components/automation/AutomationClipComponent.hpp
@@ -112,7 +112,7 @@ class AutomationClipComponent : public juce::Component,
     // Helpers
     void showContextMenu();
     void updateCursor(int x);
-    static static static bool isOnLeftEdge(int x) {
+    static bool isOnLeftEdge(int x) {
         return x < RESIZE_EDGE_WIDTH;
     }
     bool isOnRightEdge(int x) const {

--- a/magda/daw/ui/components/automation/AutomationLaneComponent.cpp
+++ b/magda/daw/ui/components/automation/AutomationLaneComponent.cpp
@@ -915,7 +915,7 @@ juce::String AutomationLaneComponent::formatScaleValue(double normalizedValue) c
     return juce::String(static_cast<int>(normalizedValue * 100)) + "%";
 }
 
-int AutomationLaneComponent::valueToPixel(double value, int areaHeight) const {
+int AutomationLaneComponent::valueToPixel(double value, int areaHeight) {
     return static_cast<int>((1.0 - value) * areaHeight);
 }
 

--- a/magda/daw/ui/components/automation/AutomationLaneComponent.hpp
+++ b/magda/daw/ui/components/automation/AutomationLaneComponent.hpp
@@ -187,7 +187,7 @@ class AutomationLaneComponent : public juce::Component,
     // Scale label helpers
     void paintScaleLabels(juce::Graphics& g, juce::Rectangle<int> area);
     juce::String formatScaleValue(double normalizedValue) const;
-    int valueToPixel(double value, int areaHeight) const;
+    static int valueToPixel(double value, int areaHeight);
 };
 
 }  // namespace magda

--- a/magda/daw/ui/components/chain/ChainRowComponent.cpp
+++ b/magda/daw/ui/components/chain/ChainRowComponent.cpp
@@ -344,7 +344,7 @@ void ChainRowComponent::resized() {
     panLabel_.setBounds(bounds.removeFromLeft(panWidth));
 }
 
-int ChainRowComponent::getPreferredHeight() const {
+int ChainRowComponent::getPreferredHeight() {
     return ROW_HEIGHT;
 }
 

--- a/magda/daw/ui/components/chain/ChainRowComponent.hpp
+++ b/magda/daw/ui/components/chain/ChainRowComponent.hpp
@@ -58,7 +58,7 @@ class ChainRowComponent : public juce::Component,
     void mouseUp(const juce::MouseEvent& event) override;
     void mouseDoubleClick(const juce::MouseEvent& event) override;
 
-    int getPreferredHeight() const;
+    static int getPreferredHeight();
     magda::ChainId getChainId() const {
         return chainId_;
     }

--- a/magda/daw/ui/components/chain/compiled/CompiledBitcrusherEditorView.hpp
+++ b/magda/daw/ui/components/chain/compiled/CompiledBitcrusherEditorView.hpp
@@ -24,7 +24,7 @@ class CompiledBitcrusherEditorView final : public juce::Component,
   public:
     explicit CompiledBitcrusherEditorView(juce::String pluginId);
 
-    int getPreferredHeight() const {
+    static int getPreferredHeight() {
         return 56;
     }
 

--- a/magda/daw/ui/components/chain/compiled/CompiledChorusCurveView.hpp
+++ b/magda/daw/ui/components/chain/compiled/CompiledChorusCurveView.hpp
@@ -27,7 +27,7 @@ class CompiledChorusCurveView final : public juce::Component,
   public:
     explicit CompiledChorusCurveView(juce::String pluginId);
 
-    int getPreferredHeight() const {
+    static int getPreferredHeight() {
         return 120;
     }
 

--- a/magda/daw/ui/components/chain/compiled/CompiledClipperCurveView.hpp
+++ b/magda/daw/ui/components/chain/compiled/CompiledClipperCurveView.hpp
@@ -27,7 +27,7 @@ class CompiledClipperCurveView final : public juce::Component,
   public:
     explicit CompiledClipperCurveView(juce::String pluginId);
 
-    int getPreferredHeight() const {
+    static int getPreferredHeight() {
         return 120;
     }
 

--- a/magda/daw/ui/components/chain/compiled/CompiledCompressorCurveView.hpp
+++ b/magda/daw/ui/components/chain/compiled/CompiledCompressorCurveView.hpp
@@ -19,7 +19,7 @@ class CompiledCompressorCurveView final : public juce::Component,
   public:
     explicit CompiledCompressorCurveView(juce::String pluginId);
 
-    int getPreferredHeight() const {
+    static int getPreferredHeight() {
         return 146;
     }
 

--- a/magda/daw/ui/components/chain/compiled/CompiledDelayCurveView.hpp
+++ b/magda/daw/ui/components/chain/compiled/CompiledDelayCurveView.hpp
@@ -31,7 +31,7 @@ class CompiledDelayCurveView final : public juce::Component,
   public:
     explicit CompiledDelayCurveView(juce::String pluginId);
 
-    int getPreferredHeight() const {
+    static int getPreferredHeight() {
         return 140;
     }
 

--- a/magda/daw/ui/components/chain/compiled/CompiledDimensionView.hpp
+++ b/magda/daw/ui/components/chain/compiled/CompiledDimensionView.hpp
@@ -24,7 +24,7 @@ class CompiledDimensionView final : public juce::Component,
   public:
     explicit CompiledDimensionView(juce::String pluginId);
 
-    int getPreferredHeight() const {
+    static int getPreferredHeight() {
         return 56;
     }
 

--- a/magda/daw/ui/components/chain/compiled/CompiledEqCurveView.hpp
+++ b/magda/daw/ui/components/chain/compiled/CompiledEqCurveView.hpp
@@ -29,7 +29,7 @@ class CompiledEqCurveView final : public juce::Component,
   public:
     explicit CompiledEqCurveView(juce::String pluginId);
 
-    int getPreferredHeight() const {
+    static int getPreferredHeight() {
         return 90;
     }
 

--- a/magda/daw/ui/components/chain/compiled/CompiledFilterCurveView.hpp
+++ b/magda/daw/ui/components/chain/compiled/CompiledFilterCurveView.hpp
@@ -18,7 +18,7 @@ class CompiledFilterCurveView final : public juce::Component,
   public:
     explicit CompiledFilterCurveView(juce::String pluginId);
 
-    int getPreferredHeight() const {
+    static int getPreferredHeight() {
         return 140;
     }
 

--- a/magda/daw/ui/components/chain/compiled/CompiledFlangerCurveView.hpp
+++ b/magda/daw/ui/components/chain/compiled/CompiledFlangerCurveView.hpp
@@ -28,7 +28,7 @@ class CompiledFlangerCurveView final : public juce::Component,
   public:
     explicit CompiledFlangerCurveView(juce::String pluginId);
 
-    int getPreferredHeight() const {
+    static int getPreferredHeight() {
         return 130;
     }
 

--- a/magda/daw/ui/components/chain/compiled/CompiledFreqShiftCurveView.hpp
+++ b/magda/daw/ui/components/chain/compiled/CompiledFreqShiftCurveView.hpp
@@ -28,7 +28,7 @@ class CompiledFreqShiftCurveView final : public juce::Component,
   public:
     explicit CompiledFreqShiftCurveView(juce::String pluginId);
 
-    int getPreferredHeight() const {
+    static int getPreferredHeight() {
         return 120;
     }
 

--- a/magda/daw/ui/components/chain/compiled/CompiledGateCurveView.hpp
+++ b/magda/daw/ui/components/chain/compiled/CompiledGateCurveView.hpp
@@ -19,7 +19,7 @@ class CompiledGateCurveView final : public juce::Component,
   public:
     explicit CompiledGateCurveView(juce::String pluginId);
 
-    int getPreferredHeight() const {
+    static int getPreferredHeight() {
         return 146;
     }
 

--- a/magda/daw/ui/components/chain/compiled/CompiledGrainDelayCurveView.hpp
+++ b/magda/daw/ui/components/chain/compiled/CompiledGrainDelayCurveView.hpp
@@ -25,7 +25,7 @@ class CompiledGrainDelayCurveView final : public juce::Component,
   public:
     explicit CompiledGrainDelayCurveView(juce::String pluginId);
 
-    int getPreferredHeight() const {
+    static int getPreferredHeight() {
         return 140;
     }
 

--- a/magda/daw/ui/components/chain/compiled/CompiledGritCurveView.hpp
+++ b/magda/daw/ui/components/chain/compiled/CompiledGritCurveView.hpp
@@ -26,7 +26,7 @@ class CompiledGritCurveView final : public juce::Component,
   public:
     explicit CompiledGritCurveView(juce::String pluginId);
 
-    int getPreferredHeight() const {
+    static int getPreferredHeight() {
         return 140;
     }
 

--- a/magda/daw/ui/components/chain/compiled/CompiledLimiterCurveView.hpp
+++ b/magda/daw/ui/components/chain/compiled/CompiledLimiterCurveView.hpp
@@ -27,7 +27,7 @@ class CompiledLimiterCurveView final : public juce::Component,
   public:
     explicit CompiledLimiterCurveView(juce::String pluginId);
 
-    int getPreferredHeight() const {
+    static int getPreferredHeight() {
         return 146;
     }
 

--- a/magda/daw/ui/components/chain/compiled/CompiledModCurveView.hpp
+++ b/magda/daw/ui/components/chain/compiled/CompiledModCurveView.hpp
@@ -26,7 +26,7 @@ class CompiledModCurveView final : public juce::Component,
   public:
     explicit CompiledModCurveView(juce::String pluginId);
 
-    int getPreferredHeight() const {
+    static int getPreferredHeight() {
         return 110;
     }
 

--- a/magda/daw/ui/components/chain/compiled/CompiledMultibandCurveView.cpp
+++ b/magda/daw/ui/components/chain/compiled/CompiledMultibandCurveView.cpp
@@ -364,7 +364,7 @@ bool CompiledMultibandCurveView::isReleaseTimingHandle(Handle h) {
     return h == Handle::LowRelease || h == Handle::MidRelease || h == Handle::HighRelease;
 }
 
-int CompiledMultibandCurveView::slotForHandle(Handle h) const {
+int CompiledMultibandCurveView::slotForHandle(Handle h) {
     const int band = bandForHandle(h);
     if (band < 0)
         return -1;

--- a/magda/daw/ui/components/chain/compiled/CompiledMultibandCurveView.hpp
+++ b/magda/daw/ui/components/chain/compiled/CompiledMultibandCurveView.hpp
@@ -20,7 +20,7 @@ class CompiledMultibandCurveView final : public juce::Component,
   public:
     explicit CompiledMultibandCurveView(juce::String pluginId);
 
-    int getPreferredHeight() const {
+    static int getPreferredHeight() {
         return 140;
     }
 
@@ -182,7 +182,7 @@ class CompiledMultibandCurveView final : public juce::Component,
     static bool isAboveRatioHandle(Handle h);
     static bool isTimingHandle(Handle h);
     static bool isReleaseTimingHandle(Handle h);
-    int slotForHandle(Handle h) const;
+    static int slotForHandle(Handle h);
     Handle pickHandle(float x, float y) const;
 
     magda::daw::audio::compiled::MagdaMultibandCompiledPlugin* compiledPlugin_ = nullptr;

--- a/magda/daw/ui/components/chain/compiled/CompiledPhaserCurveView.hpp
+++ b/magda/daw/ui/components/chain/compiled/CompiledPhaserCurveView.hpp
@@ -26,7 +26,7 @@ class CompiledPhaserCurveView final : public juce::Component,
   public:
     explicit CompiledPhaserCurveView(juce::String pluginId);
 
-    int getPreferredHeight() const {
+    static int getPreferredHeight() {
         return 130;
     }
 

--- a/magda/daw/ui/components/chain/compiled/CompiledPitchEditorView.hpp
+++ b/magda/daw/ui/components/chain/compiled/CompiledPitchEditorView.hpp
@@ -28,7 +28,7 @@ class CompiledPitchEditorView final : public juce::Component,
   public:
     explicit CompiledPitchEditorView(juce::String pluginId);
 
-    int getPreferredHeight() const {
+    static int getPreferredHeight() {
         return 56;
     }
 

--- a/magda/daw/ui/components/chain/compiled/CompiledReverbCurveView.cpp
+++ b/magda/daw/ui/components/chain/compiled/CompiledReverbCurveView.cpp
@@ -61,7 +61,7 @@ void CompiledReverbCurveView::updateFromDevice(const magda::DeviceInfo& device) 
     repaint();
 }
 
-float CompiledReverbCurveView::t60SecondsForEngine(int engineIndex, float decayDisplay) const {
+float CompiledReverbCurveView::t60SecondsForEngine(int engineIndex, float decayDisplay) {
     // Mirrors the time mappings inside each engine .dsp so the visual
     // matches what the user hears at a given Decay slot value.
     const float d01 = juce::jlimit(0.0f, 1.0f, decayDisplay / 100.0f);

--- a/magda/daw/ui/components/chain/compiled/CompiledReverbCurveView.hpp
+++ b/magda/daw/ui/components/chain/compiled/CompiledReverbCurveView.hpp
@@ -28,7 +28,7 @@ class CompiledReverbCurveView final : public juce::Component,
   public:
     explicit CompiledReverbCurveView(juce::String pluginId);
 
-    int getPreferredHeight() const {
+    static int getPreferredHeight() {
         return 120;
     }
 
@@ -52,7 +52,7 @@ class CompiledReverbCurveView final : public juce::Component,
 
     // Approximate t60 (seconds) for the active engine, derived from the
     // engine-aware mapping that lives in each magda_reverb_*.dsp.
-    float t60SecondsForEngine(int engineIndex, float decayDisplay) const;
+    static float t60SecondsForEngine(int engineIndex, float decayDisplay);
 
     magda::daw::audio::compiled::MagdaReverbCompiledPlugin* compiledPlugin_ = nullptr;
     magda::DeviceInfo deviceSnapshot_;

--- a/magda/daw/ui/components/chain/compiled/CompiledRingModCurveView.hpp
+++ b/magda/daw/ui/components/chain/compiled/CompiledRingModCurveView.hpp
@@ -31,7 +31,7 @@ class CompiledRingModCurveView final : public juce::Component,
   public:
     explicit CompiledRingModCurveView(juce::String pluginId);
 
-    int getPreferredHeight() const {
+    static int getPreferredHeight() {
         return 120;
     }
 

--- a/magda/daw/ui/components/chain/compiled/CompiledSaturatorCurveView.hpp
+++ b/magda/daw/ui/components/chain/compiled/CompiledSaturatorCurveView.hpp
@@ -31,7 +31,7 @@ class CompiledSaturatorCurveView final : public juce::Component,
   public:
     explicit CompiledSaturatorCurveView(juce::String pluginId);
 
-    int getPreferredHeight() const {
+    static int getPreferredHeight() {
         return 140;
     }
 

--- a/magda/daw/ui/components/chain/custom_ui/PolyStepSequencerUI.cpp
+++ b/magda/daw/ui/components/chain/custom_ui/PolyStepSequencerUI.cpp
@@ -1544,7 +1544,7 @@ void PolyStepSequencerUI::drawBarLane(juce::Graphics& g, juce::Rectangle<int> ar
 // Mouse interaction (per-step lanes; the grid handles its own mouse)
 // =============================================================================
 
-int PolyStepSequencerUI::getStepAtX(int x, int areaX, int areaWidth, int numSteps) const {
+int PolyStepSequencerUI::getStepAtX(int x, int areaX, int areaWidth, int numSteps) {
     if (numSteps <= 0 || areaWidth <= 0)
         return -1;
     int relX = x - areaX;

--- a/magda/daw/ui/components/chain/custom_ui/PolyStepSequencerUI.hpp
+++ b/magda/daw/ui/components/chain/custom_ui/PolyStepSequencerUI.hpp
@@ -218,7 +218,7 @@ class PolyStepSequencerUI : public juce::Component, private juce::Timer {
                      bool isProbability);
 
     // --- Hit testing ---
-    int getStepAtX(int x, int areaX, int areaWidth, int numSteps) const;
+    static int getStepAtX(int x, int areaX, int areaWidth, int numSteps);
     void applyLaneDrag(const juce::MouseEvent& e);
 
     // --- Layout bounds (computed in resized, used in paint/mouse handlers) ---

--- a/magda/daw/ui/components/chain/custom_ui/SpectrumAnalyzerUI.cpp
+++ b/magda/daw/ui/components/chain/custom_ui/SpectrumAnalyzerUI.cpp
@@ -628,12 +628,12 @@ void SpectrumAnalyzerUI::updateTimerState() {
         stopTimer();
 }
 
-float SpectrumAnalyzerUI::freqToX(float hz, juce::Rectangle<float> area) const {
+float SpectrumAnalyzerUI::freqToX(float hz, juce::Rectangle<float> area) {
     const float t = std::log(juce::jmax(kMinHz, hz) / kMinHz) / std::log(kMaxHz / kMinHz);
     return area.getX() + juce::jlimit(0.0f, 1.0f, t) * area.getWidth();
 }
 
-float SpectrumAnalyzerUI::dbToY(float db, juce::Rectangle<float> area) const {
+float SpectrumAnalyzerUI::dbToY(float db, juce::Rectangle<float> area) {
     const float t = (db - kMinDb) / (kMaxDb - kMinDb);
     return area.getBottom() - juce::jlimit(0.0f, 1.0f, t) * area.getHeight();
 }

--- a/magda/daw/ui/components/chain/custom_ui/SpectrumAnalyzerUI.hpp
+++ b/magda/daw/ui/components/chain/custom_ui/SpectrumAnalyzerUI.hpp
@@ -74,8 +74,8 @@ class SpectrumAnalyzerUI : public juce::Component, private juce::Timer {
     void releaseMeasurementArming();                  // undo only what this UI armed
     void pollOverlayData();      // fetch overlay band spectrum + pair-filtered findings
     void rebuildFft(int order);  // (re)allocate FFT + buffers for a 2^order transform
-    float freqToX(float hz, juce::Rectangle<float> area) const;
-    float dbToY(float db, juce::Rectangle<float> area) const;
+    static float freqToX(float hz, juce::Rectangle<float> area);
+    static float dbToY(float db, juce::Rectangle<float> area);
     juce::Rectangle<float> plotArea() const;  // plot region (excludes the control row)
     void updateControlVisibility();
     void startControlsFade(bool expanding);

--- a/magda/daw/ui/components/chain/custom_ui/StepSequencerUI.cpp
+++ b/magda/daw/ui/components/chain/custom_ui/StepSequencerUI.cpp
@@ -864,7 +864,7 @@ void StepSequencerUI::mouseUp(const juce::MouseEvent&) {
 // Hit testing helpers
 // =============================================================================
 
-int StepSequencerUI::getStepAtX(int x, int areaX, int areaWidth, int numSteps) const {
+int StepSequencerUI::getStepAtX(int x, int areaX, int areaWidth, int numSteps) {
     if (numSteps <= 0 || areaWidth <= 0)
         return -1;
     int relX = x - areaX;

--- a/magda/daw/ui/components/chain/custom_ui/StepSequencerUI.hpp
+++ b/magda/daw/ui/components/chain/custom_ui/StepSequencerUI.hpp
@@ -157,7 +157,7 @@ class StepSequencerUI : public juce::Component, private juce::Timer {
     void drawOctaveArrow(juce::Graphics& g, juce::Rectangle<int> area, bool isLeft);
 
     // --- Hit testing ---
-    int getStepAtX(int x, int areaX, int areaWidth, int numSteps) const;
+    static int getStepAtX(int x, int areaX, int areaWidth, int numSteps);
     int getKeyboardNoteAtPosition(juce::Point<int> pos, juce::Rectangle<int> area) const;
 
     // --- Layout bounds (computed in resized, used in paint/mouseDown) ---

--- a/magda/daw/ui/components/chain/custom_ui/StruckInstrumentUI.cpp
+++ b/magda/daw/ui/components/chain/custom_ui/StruckInstrumentUI.cpp
@@ -132,7 +132,7 @@ std::vector<LinkableTextSlider*> StruckInstrumentUI::getLinkableSliders() {
     return out;
 }
 
-int StruckInstrumentUI::preferredContentWidth() const {
+int StruckInstrumentUI::preferredContentWidth() {
     return 560;  // body panel + EXCITER | RESONATOR columns
 }
 

--- a/magda/daw/ui/components/chain/custom_ui/StruckInstrumentUI.hpp
+++ b/magda/daw/ui/components/chain/custom_ui/StruckInstrumentUI.hpp
@@ -39,7 +39,7 @@ class StruckInstrumentUI : public juce::Component, private juce::Timer {
 
     void updateFromParameters(const std::vector<magda::ParameterInfo>& params);
     std::vector<LinkableTextSlider*> getLinkableSliders();
-    int preferredContentWidth() const;
+    static int preferredContentWidth();
 
     /// Bind the live plugin so the body can flash on note-on (nullptr unbinds).
     void setLivePlugin(magda::daw::audio::compiled::MagdaCompiledPolyInstrument* plugin);

--- a/magda/daw/ui/components/chain/drum_grid/DrumGridUI.hpp
+++ b/magda/daw/ui/components/chain/drum_grid/DrumGridUI.hpp
@@ -342,7 +342,7 @@ class DrumGridUI : public juce::Component,
     int padButtonIndexAtPoint(juce::Point<int> point) const;
 
     void setupLabel(juce::Label& label, const juce::String& text, float fontSize);
-    void setupButton(juce::TextButton& button);
+    static void setupButton(juce::TextButton& button);
     void showPadContextMenu(int padIndex, juce::Point<int> screenPos);
     void showChainContextMenu(int padIndex, juce::Point<int> screenPos);
 

--- a/magda/daw/ui/components/chain/drum_grid/PadDeviceSlot.hpp
+++ b/magda/daw/ui/components/chain/drum_grid/PadDeviceSlot.hpp
@@ -111,7 +111,7 @@ class PadDeviceSlot : public juce::Component, private juce::Timer {
         return (i >= 0 && i < PLUGIN_PARAM_SLOTS) ? paramSlots_[static_cast<size_t>(i)].get()
                                                   : nullptr;
     }
-    int getParamSlotCount() const {
+    static int getParamSlotCount() {
         return PLUGIN_PARAM_SLOTS;
     }
     int getVisibleParamCount() const {

--- a/magda/daw/ui/components/chain/modulation/LFOCurveEditorWindow.hpp
+++ b/magda/daw/ui/components/chain/modulation/LFOCurveEditorWindow.hpp
@@ -64,7 +64,7 @@ class LFOCurveEditorContent : public juce::Component {
     void rebuildPresetCombo(const juce::String& selectedUserPreset = {});
     void showSaveCurvePresetDialog();
     void saveCurvePreset(const juce::String& presetName);
-    void showPresetError(const juce::String& title, const juce::String& message);
+    static void showPresetError(const juce::String& title, const juce::String& message);
 
     static constexpr int HEADER_HEIGHT = 24;
     static constexpr int FOOTER_HEIGHT = 28;

--- a/magda/daw/ui/components/chain/modulation/LFOPhaseOverlay.cpp
+++ b/magda/daw/ui/components/chain/modulation/LFOPhaseOverlay.cpp
@@ -156,7 +156,7 @@ void LFOPhaseOverlay::paintPhaseIndicator(juce::Graphics& g) {
                   dotSize, 1.0f);
 }
 
-double LFOPhaseOverlay::applyTension(double t, double tension) const {
+double LFOPhaseOverlay::applyTension(double t, double tension) {
     if (tension > 0) {
         return std::pow(t, 1.0 + tension * 2.0);
     } else {

--- a/magda/daw/ui/components/chain/modulation/LFOPhaseOverlay.hpp
+++ b/magda/daw/ui/components/chain/modulation/LFOPhaseOverlay.hpp
@@ -58,7 +58,7 @@ class LFOPhaseOverlay : public juce::Component, private juce::Timer {
     void paintPhaseIndicator(juce::Graphics& g);
 
     // Apply tension curve interpolation
-    double applyTension(double t, double tension) const;
+    static double applyTension(double t, double tension);
 
     const ModInfo* modInfo_ = nullptr;
     juce::Colour curveColour_{DarkTheme::getColour(DarkTheme::AUTOMATION_BEZIER)};

--- a/magda/daw/ui/components/chain/modulation/MacroKnobComponent.hpp
+++ b/magda/daw/ui/components/chain/modulation/MacroKnobComponent.hpp
@@ -127,7 +127,7 @@ class MacroKnobComponent : public juce::Component,
     void endAutomationGesture();
 
     void showLinkMenu();
-    void paintLinkIndicator(juce::Graphics& g, juce::Rectangle<int> area);
+    static void paintLinkIndicator(juce::Graphics& g, juce::Rectangle<int> area);
     void onNameLabelEdited();
     void onLinkButtonClicked();
 

--- a/magda/daw/ui/components/chain/modulation/ModKnobComponent.hpp
+++ b/magda/daw/ui/components/chain/modulation/ModKnobComponent.hpp
@@ -274,7 +274,7 @@ class ModKnobComponent : public juce::Component, public magda::LinkModeManagerLi
     void modLinkModeChanged(bool active, const magda::ModSelection& selection) override;
 
     void showContextMenu();
-    void paintLinkIndicator(juce::Graphics& g, juce::Rectangle<int> area);
+    static void paintLinkIndicator(juce::Graphics& g, juce::Rectangle<int> area);
     void onNameLabelEdited();
     void onLinkButtonClicked();
 

--- a/magda/daw/ui/components/clips/ClipComponent.cpp
+++ b/magda/daw/ui/components/clips/ClipComponent.cpp
@@ -922,7 +922,7 @@ void ClipComponent::paintMidiNotes(juce::Graphics& g, const ClipInfo& clip,
     }
 }
 
-bool ClipComponent::isChordClip(const ClipInfo& clip) const {
+bool ClipComponent::isChordClip(const ClipInfo& clip) {
     const auto* track = TrackManager::getInstance().getTrack(clip.trackId);
     return track != nullptr && track->type == TrackType::Chord;
 }
@@ -3220,7 +3220,7 @@ bool ClipComponent::isPartOfMultiSelection() const {
 // Helpers
 // ============================================================================
 
-bool ClipComponent::isOnLeftEdge(int x) const {
+bool ClipComponent::isOnLeftEdge(int x) {
     return x < RESIZE_HANDLE_WIDTH;
 }
 

--- a/magda/daw/ui/components/clips/ClipComponent.hpp
+++ b/magda/daw/ui/components/clips/ClipComponent.hpp
@@ -276,17 +276,18 @@ class ClipComponent : public juce::Component,
     // Chord-track clips render their chordAnnotations as named blocks instead of
     // a MIDI-note preview.
     void paintChordClip(juce::Graphics& g, const ClipInfo& clip, juce::Rectangle<int> bounds);
-    bool isChordClip(const ClipInfo& clip) const;
+    static bool isChordClip(const ClipInfo& clip);
     void paintClipHeader(juce::Graphics& g, const ClipInfo& clip, juce::Rectangle<int> bounds);
     void paintResizeHandles(juce::Graphics& g, juce::Rectangle<int> bounds);
-    void paintFadeOverlays(juce::Graphics& g, const ClipInfo& clip, const EffectiveFades& fades,
-                           juce::Rectangle<int> waveformArea, double pixelsPerSecond);
+    static void paintFadeOverlays(juce::Graphics& g, const ClipInfo& clip,
+                                  const EffectiveFades& fades, juce::Rectangle<int> waveformArea,
+                                  double pixelsPerSecond);
     void paintFadeHandles(juce::Graphics& g, const ClipInfo& clip, juce::Rectangle<int> bounds);
     void paintVolumeLine(juce::Graphics& g, const ClipInfo& clip,
                          juce::Rectangle<int> waveformArea);
 
     // Interaction helpers
-    bool isOnLeftEdge(int x) const;
+    static bool isOnLeftEdge(int x);
     bool isOnRightEdge(int x) const;
     bool isOnFadeInHandle(int x, int y) const;
     bool isOnFadeOutHandle(int x, int y) const;

--- a/magda/daw/ui/components/common/MixerDebugPanel.cpp
+++ b/magda/daw/ui/components/common/MixerDebugPanel.cpp
@@ -97,11 +97,11 @@ void MixerDebugPanel::resized() {
         viewport_->getWidth() - (viewport_->isVerticalScrollBarShown() ? 8 : 0), contentHeight_);
 }
 
-bool MixerDebugPanel::isInResizeZone(const juce::Point<int>& pos) const {
+bool MixerDebugPanel::isInResizeZone(const juce::Point<int>& pos) {
     return pos.y < resizeZoneHeight_;
 }
 
-bool MixerDebugPanel::isInDragZone(const juce::Point<int>& pos) const {
+bool MixerDebugPanel::isInDragZone(const juce::Point<int>& pos) {
     return pos.y >= resizeZoneHeight_ && pos.y < titleBarHeight_;
 }
 

--- a/magda/daw/ui/components/common/MixerDebugPanel.hpp
+++ b/magda/daw/ui/components/common/MixerDebugPanel.hpp
@@ -56,8 +56,8 @@ class MixerDebugPanel : public juce::Component {
     int dragStartHeight_ = 0;
     int contentHeight_ = 0;
 
-    bool isInResizeZone(const juce::Point<int>& pos) const;
-    bool isInDragZone(const juce::Point<int>& pos) const;
+    static bool isInResizeZone(const juce::Point<int>& pos);
+    static bool isInDragZone(const juce::Point<int>& pos);
 
     void addIntSlider(const juce::String& name, int* valuePtr, int min, int max);
     void addFloatSlider(const juce::String& name, float* valuePtr, float min, float max,

--- a/magda/daw/ui/components/common/ZoomControls.hpp
+++ b/magda/daw/ui/components/common/ZoomControls.hpp
@@ -50,7 +50,7 @@ class ZoomControls : public juce::Component {
     void handleSliderChange();
 
     // Styling
-    void setupButton(juce::TextButton& button, const juce::String& text);
+    static void setupButton(juce::TextButton& button, const juce::String& text);
     void setupSlider();
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(ZoomControls)

--- a/magda/daw/ui/components/common/curve/CurveTensionHandle.hpp
+++ b/magda/daw/ui/components/common/curve/CurveTensionHandle.hpp
@@ -39,7 +39,7 @@ class CurveTensionHandle : public juce::Component {
         return tension_;
     }
 
-    void setSlopeGoesDown(bool goesDown) {
+    static void setSlopeGoesDown(bool goesDown) {
         juce::ignoreUnused(goesDown);
     }
 

--- a/magda/daw/ui/components/pianoroll/CCLaneComponent.cpp
+++ b/magda/daw/ui/components/pianoroll/CCLaneComponent.cpp
@@ -290,7 +290,7 @@ void CCLaneComponent::updatePointsCache() const {
     pointsCacheDirty_ = false;
 }
 
-size_t CCLaneComponent::pointIdToEventIndex(uint32_t pointId) const {
+size_t CCLaneComponent::pointIdToEventIndex(uint32_t pointId) {
     // The point ID is the original index into the clip's CC/PB data vector
     return static_cast<size_t>(pointId);
 }

--- a/magda/daw/ui/components/pianoroll/CCLaneComponent.hpp
+++ b/magda/daw/ui/components/pianoroll/CCLaneComponent.hpp
@@ -128,7 +128,7 @@ class CCLaneComponent : public CurveEditorBase {
     double valueToNormalized(int value) const;
 
     // Find the index of a CC/PB event by its point ID
-    size_t pointIdToEventIndex(uint32_t pointId) const;
+    static size_t pointIdToEventIndex(uint32_t pointId);
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(CCLaneComponent)
 };

--- a/magda/daw/ui/components/pianoroll/NoteComponent.cpp
+++ b/magda/daw/ui/components/pianoroll/NoteComponent.cpp
@@ -465,7 +465,7 @@ void NoteComponent::timerCallback() {
     }
 }
 
-bool NoteComponent::isOnLeftEdge(int x) const {
+bool NoteComponent::isOnLeftEdge(int x) {
     return x < RESIZE_HANDLE_WIDTH;
 }
 

--- a/magda/daw/ui/components/pianoroll/NoteComponent.hpp
+++ b/magda/daw/ui/components/pianoroll/NoteComponent.hpp
@@ -149,7 +149,7 @@ class NoteComponent : public juce::Component, private juce::Timer {
     void timerCallback() override;
 
     // Interaction helpers
-    bool isOnLeftEdge(int x) const;
+    static bool isOnLeftEdge(int x);
     bool isOnRightEdge(int x) const;
     void updateCursor();
 

--- a/magda/daw/ui/components/pianoroll/PianoRollGridComponent.cpp
+++ b/magda/daw/ui/components/pianoroll/PianoRollGridComponent.cpp
@@ -2566,7 +2566,7 @@ void PianoRollGridComponent::rebuildSelectedPitchRows() {
     }
 }
 
-bool PianoRollGridComponent::isBlackKey(int noteNumber) const {
+bool PianoRollGridComponent::isBlackKey(int noteNumber) {
     int note = noteNumber % 12;
     return note == 1 || note == 3 || note == 6 || note == 8 || note == 10;
 }

--- a/magda/daw/ui/components/pianoroll/PianoRollGridComponent.hpp
+++ b/magda/daw/ui/components/pianoroll/PianoRollGridComponent.hpp
@@ -566,7 +566,7 @@ class PianoRollGridComponent : public juce::Component,
     double clipBeatForDisplayX(ClipId clipId, int mouseX, bool floorToCell = false) const;
     double absolutePlayheadBeatForDisplayX(int mouseX) const;
     void updateEmptyGridCursor(const juce::ModifierKeys& mods, int mouseX);
-    bool isBlackKey(int noteNumber) const;
+    static bool isBlackKey(int noteNumber);
     juce::Colour getClipColour() const;
     juce::Colour getColourForClip(ClipId clipId) const;
     bool isClipSelected(ClipId clipId) const;

--- a/magda/daw/ui/components/pianoroll/PianoRollKeyboard.cpp
+++ b/magda/daw/ui/components/pianoroll/PianoRollKeyboard.cpp
@@ -133,12 +133,12 @@ void PianoRollKeyboard::clearPressedNotes() {
         repaint();
 }
 
-bool PianoRollKeyboard::isBlackKey(int noteNumber) const {
+bool PianoRollKeyboard::isBlackKey(int noteNumber) {
     int note = noteNumber % 12;
     return note == 1 || note == 3 || note == 6 || note == 8 || note == 10;
 }
 
-juce::String PianoRollKeyboard::getNoteName(int noteNumber) const {
+juce::String PianoRollKeyboard::getNoteName(int noteNumber) {
     static const char* noteNames[] = {"C",  "C#", "D",  "D#", "E",  "F",
                                       "F#", "G",  "G#", "A",  "A#", "B"};
     int octave = (noteNumber / 12) - 2;  // C-2 convention (note 0 = C-2, note 60 = C3)

--- a/magda/daw/ui/components/pianoroll/PianoRollKeyboard.hpp
+++ b/magda/daw/ui/components/pianoroll/PianoRollKeyboard.hpp
@@ -84,8 +84,8 @@ class PianoRollKeyboard : public juce::Component {
     int currentPlayingNote_ = -1;
     bool isPlayingNote_ = false;
 
-    bool isBlackKey(int noteNumber) const;
-    juce::String getNoteName(int noteNumber) const;
+    static bool isBlackKey(int noteNumber);
+    static juce::String getNoteName(int noteNumber);
     int yToNoteNumber(int y) const;
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(PianoRollKeyboard)

--- a/magda/daw/ui/components/timeline/TimeRuler.cpp
+++ b/magda/daw/ui/components/timeline/TimeRuler.cpp
@@ -191,7 +191,7 @@ void TimeRuler::timerCallback() {
     }
 }
 
-int TimeRuler::getPreferredHeight() const {
+int TimeRuler::getPreferredHeight() {
     return LayoutConfig::getInstance().timeRulerHeight;
 }
 
@@ -899,7 +899,7 @@ double TimeRuler::calculateMarkerInterval() const {
     return 600.0;  // 10 minutes
 }
 
-juce::String TimeRuler::formatTimeLabel(double time, double interval) const {
+juce::String TimeRuler::formatTimeLabel(double time, double interval) {
     int totalSeconds = static_cast<int>(time);
     int minutes = totalSeconds / 60;
     int seconds = totalSeconds % 60;

--- a/magda/daw/ui/components/timeline/TimeRuler.hpp
+++ b/magda/daw/ui/components/timeline/TimeRuler.hpp
@@ -189,10 +189,10 @@ class TimeRuler : public juce::Component, private juce::Timer {
     static constexpr int LOOP_STRIP_HEIGHT = LayoutConfig::loopStripHeight;
 
     // Tick heights sourced from LayoutConfig for consistency with TimelineComponent
-    static static static int tickHeightMajor() {
+    static int tickHeightMajor() {
         return LayoutConfig::getInstance().rulerMajorTickHeight;
     }
-    static static static int tickHeightMinor() {
+    static int tickHeightMinor() {
         return LayoutConfig::getInstance().rulerMinorTickHeight;
     }
 

--- a/magda/daw/ui/components/timeline/TimeRuler.hpp
+++ b/magda/daw/ui/components/timeline/TimeRuler.hpp
@@ -117,7 +117,7 @@ class TimeRuler : public juce::Component, private juce::Timer {
     }
 
     // Get preferred height (from LayoutConfig)
-    int getPreferredHeight() const;
+    static int getPreferredHeight();
 
     // Mouse interaction - click to set playhead, drag to zoom, wheel to scroll
     void mouseDown(const juce::MouseEvent& event) override;
@@ -189,10 +189,10 @@ class TimeRuler : public juce::Component, private juce::Timer {
     static constexpr int LOOP_STRIP_HEIGHT = LayoutConfig::loopStripHeight;
 
     // Tick heights sourced from LayoutConfig for consistency with TimelineComponent
-    int tickHeightMajor() const {
+    static static static int tickHeightMajor() {
         return LayoutConfig::getInstance().rulerMajorTickHeight;
     }
-    int tickHeightMinor() const {
+    static static static int tickHeightMinor() {
         return LayoutConfig::getInstance().rulerMinorTickHeight;
     }
 
@@ -200,7 +200,7 @@ class TimeRuler : public juce::Component, private juce::Timer {
     void drawSecondsMode(juce::Graphics& g);
     void drawBarsBeatsMode(juce::Graphics& g);
     double calculateMarkerInterval() const;
-    juce::String formatTimeLabel(double time, double interval) const;
+    static juce::String formatTimeLabel(double time, double interval);
     juce::String formatBarsBeatsLabel(double time) const;
 
     // Coordinate conversion

--- a/magda/daw/ui/components/tracks/TrackContentPanel.hpp
+++ b/magda/daw/ui/components/tracks/TrackContentPanel.hpp
@@ -153,8 +153,8 @@ class TrackContentPanel : public juce::Component,
     }
 
     // Automation lane management
-    void showAutomationLane(TrackId trackId, AutomationLaneId laneId);
-    void hideAutomationLane(TrackId trackId, AutomationLaneId laneId);
+    static void showAutomationLane(TrackId trackId, AutomationLaneId laneId);
+    static void hideAutomationLane(TrackId trackId, AutomationLaneId laneId);
     void toggleAutomationLane(TrackId trackId, AutomationLaneId laneId);
     bool isAutomationLaneVisible(TrackId trackId, AutomationLaneId laneId) const;
     bool getAutomationLaneBounds(AutomationLaneId laneId, juce::Rectangle<int>& bounds) const;

--- a/magda/daw/ui/components/tracks/TrackHeadersPanel.cpp
+++ b/magda/daw/ui/components/tracks/TrackHeadersPanel.cpp
@@ -2240,7 +2240,7 @@ void TrackHeadersPanel::hideControlAreaComponents(TrackHeader& header) {
         sendLabel->setVisible(false);
 }
 
-track_controls::MixControls TrackHeadersPanel::mixControlsFor(TrackHeader& header) const {
+track_controls::MixControls TrackHeadersPanel::mixControlsFor(TrackHeader& header) {
     const auto& p = header.policy;
     track_controls::MixControls c;
     if (p.gain)

--- a/magda/daw/ui/components/tracks/TrackHeadersPanel.hpp
+++ b/magda/daw/ui/components/tracks/TrackHeadersPanel.hpp
@@ -331,27 +331,27 @@ class TrackHeadersPanel : public juce::Component,
     void rebuildSendLabels(TrackHeader& header, TrackId trackId);
     void paintTrackHeader(juce::Graphics& g, const TrackHeader& header, juce::Rectangle<int> area,
                           bool isSelected);
-    void paintResizeHandle(juce::Graphics& g, juce::Rectangle<int> area);
-    void updateCollapseButtonIcon(TrackHeader& header);
+    static void paintResizeHandle(juce::Graphics& g, juce::Rectangle<int> area);
+    static void updateCollapseButtonIcon(TrackHeader& header);
     int getVisibleHeaderIndex(TrackId trackId) const;
     juce::Rectangle<int> getTrackHeaderArea(int trackIndex) const;
     juce::Rectangle<int> getResizeHandleArea(int trackIndex) const;
     bool isResizeHandleArea(const juce::Point<int>& point, int& trackIndex) const;
     void updateTrackHeaderLayout();
-    void layoutMeterColumn(TrackHeader& header, juce::Rectangle<int>& workArea,
-                           const SideColumn& outer);
+    static void layoutMeterColumn(TrackHeader& header, juce::Rectangle<int>& workArea,
+                                  const SideColumn& outer);
     void layoutControlArea(TrackHeader& header, juce::Rectangle<int>& tcpArea,
                            const SideColumn& inner, int trackHeight);
     // Master-only compact block: volume + speaker mute, horizontal meter with
     // the back-to-arrangement button, peak readout.
-    void layoutMasterControlArea(TrackHeader& header, juce::Rectangle<int>& tcpArea,
-                                 const SideColumn& inner);
+    static void layoutMasterControlArea(TrackHeader& header, juce::Rectangle<int>& tcpArea,
+                                        const SideColumn& inner);
     // Hides every control the control-area layout may place, so each layout
     // pass starts from a clean slate and only shows what fits.
-    void hideControlAreaComponents(TrackHeader& header);
+    static void hideControlAreaComponents(TrackHeader& header);
     // Builds the policy-driven mix cluster (gain/pan/buttons/automation) for
     // the shared track_controls layout.
-    track_controls::MixControls mixControlsFor(TrackHeader& header) const;
+    static track_controls::MixControls mixControlsFor(TrackHeader& header);
 
     // Automation lane height helpers
     int getTrackTotalHeight(int trackIndex) const;

--- a/magda/daw/ui/components/waveform/WaveformGridComponent.cpp
+++ b/magda/daw/ui/components/waveform/WaveformGridComponent.cpp
@@ -365,7 +365,7 @@ void WaveformGridComponent::paintWaveformThumbnail(juce::Graphics& g, const magd
     }
 }
 
-int WaveformGridComponent::takeLaneAtY(int y, const WaveformLayout& layout, int takeCount) const {
+int WaveformGridComponent::takeLaneAtY(int y, const WaveformLayout& layout, int takeCount) {
     if (takeCount <= 0)
         return -1;
     const auto& rect = layout.rect;
@@ -1156,7 +1156,7 @@ double WaveformGridComponent::getDrawableTimelineLength() const {
     return clipLength_;
 }
 
-void WaveformGridComponent::debugLogGeometry(const char* context) const {
+void WaveformGridComponent::debugLogGeometry(const char* context) {
     juce::ignoreUnused(context);
 }
 

--- a/magda/daw/ui/components/waveform/WaveformGridComponent.hpp
+++ b/magda/daw/ui/components/waveform/WaveformGridComponent.hpp
@@ -320,7 +320,7 @@ class WaveformGridComponent : public juce::Component, public juce::ChangeListene
     void paintTakeLanes(juce::Graphics& g, const magda::ClipInfo& clip,
                         const WaveformLayout& layout);
     // Returns the take lane index under y (multi-take clip), or -1.
-    int takeLaneAtY(int y, const WaveformLayout& layout, int takeCount) const;
+    static int takeLaneAtY(int y, const WaveformLayout& layout, int takeCount);
     void paintWaveformOverlays(juce::Graphics& g, const magda::ClipInfo& clip,
                                const WaveformLayout& layout);
     void paintBeatGrid(juce::Graphics& g, const magda::ClipInfo& clip);
@@ -348,7 +348,7 @@ class WaveformGridComponent : public juce::Component, public juce::ChangeListene
     double getSampleStartPositionSeconds() const;
     double getDisplayStartTime() const;
     double getDrawableTimelineLength() const;
-    void debugLogGeometry(const char* context) const;
+    static void debugLogGeometry(const char* context);
 
     // Get current clip
     const magda::ClipInfo* getClip() const;

--- a/magda/daw/ui/dialogs/AISettingsDialog.cpp
+++ b/magda/daw/ui/dialogs/AISettingsDialog.cpp
@@ -704,7 +704,7 @@ class AISettingsDialog::LocalPage : public juce::Component {
         config.setLoadModelOnStartup(loadOnStartupToggle_.getToggleState());
     }
 
-    bool isModelLoaded() const {
+    static bool isModelLoaded() {
         return LlamaModelManager::getInstance().isLoaded();
     }
 
@@ -1180,7 +1180,7 @@ class AISettingsDialog::ConfigPage : public juce::Component {
                id == magda::provider::FAST_INFERENCE;
     }
 
-    std::string rowProviderGroupId(const AgentRow& row) const {
+    static std::string rowProviderGroupId(const AgentRow& row) {
         int idx = row.providerCombo.getSelectedId() - 1;
         if (idx >= 0 && idx < static_cast<int>(row.providerIds.size()))
             return row.providerIds[static_cast<size_t>(idx)];
@@ -1202,7 +1202,7 @@ class AISettingsDialog::ConfigPage : public juce::Component {
     // Select the combo item matching a provider id. openai_responses and
     // openai_chat share one "OpenAI" entry, and all local backends share one
     // "Local" entry.
-    void selectRowProviderById(AgentRow& row, std::string id) {
+    static void selectRowProviderById(AgentRow& row, std::string id) {
         if (id == magda::provider::OPENAI_RESPONSES)
             id = magda::provider::OPENAI_CHAT;
         if (isLocalProviderId(id))

--- a/magda/daw/ui/dialogs/AudioSettingsDialog.hpp
+++ b/magda/daw/ui/dialogs/AudioSettingsDialog.hpp
@@ -30,7 +30,7 @@ class CustomChannelSelector : public juce::Component {
     AudioEngine* audioEngine_;
     bool isInput_;
 
-    void onPreviewToggled(int startChannel);
+    static void onPreviewToggled(int startChannel);
 
     struct ChannelToggle {
         std::unique_ptr<juce::ToggleButton> button;

--- a/magda/daw/ui/dialogs/ConnectionsDialog.cpp
+++ b/magda/daw/ui/dialogs/ConnectionsDialog.cpp
@@ -1154,7 +1154,7 @@ class OscSurfacesPage : public juce::Component, private juce::Timer {
         addAndMakeVisible(label);
     }
 
-    void layoutRow(juce::Rectangle<int>& area, juce::Label& label, juce::Component& field) {
+    static void layoutRow(juce::Rectangle<int>& area, juce::Label& label, juce::Component& field) {
         auto row = area.removeFromTop(kRowHeight);
         label.setBounds(row.removeFromLeft(kLabelWidth));
         field.setBounds(row.removeFromLeft(kFieldWidth));

--- a/magda/daw/ui/dialogs/PreferencesDialog.cpp
+++ b/magda/daw/ui/dialogs/PreferencesDialog.cpp
@@ -272,7 +272,7 @@ class GeneralPage : public juce::Component {
         };
     }
 
-    int getPreferredHeight(int width) const {
+    static int getPreferredHeight(int width) {
         const int height =
             shouldUseSingleColumnLayout(width)
                 ? getSingleColumnPreferredHeight()
@@ -765,7 +765,7 @@ class AppearancePage : public juce::Component {
         addAndMakeVisible(clipColourModeCombo);
     }
 
-    int getPreferredHeight(int width) const {
+    static int getPreferredHeight(int width) {
         constexpr int padding = 16;
         if (shouldUseSingleColumnLayout(width))
             return getSingleColumnPreferredHeight();
@@ -1600,7 +1600,7 @@ class RenderingPage : public juce::Component {
         addAndMakeVisible(patternHint);
     }
 
-    int getPreferredHeight(int) const {
+    static int getPreferredHeight(int) {
         constexpr int padding = 16;
         constexpr int rowH = 32;
         constexpr int headerH = 28;
@@ -1874,7 +1874,7 @@ class PathsPage : public juce::Component {
         addAndMakeVisible(indexPresetsButton_);
     }
 
-    int getPreferredHeight(int) const {
+    static int getPreferredHeight(int) {
         constexpr int padding = 20;
         constexpr int rowH = 28;
         constexpr int gap = 6;
@@ -3006,7 +3006,7 @@ class ShortcutsPage : public juce::Component {
             setCapturingRow(nullptr);
         }
 
-        void setRowInput(GestureRow& row, GestureInput input) {
+        static void setRowInput(GestureRow& row, GestureInput input) {
             const auto tuned =
                 tunedBindingForInput(row.context, input, row.action,
                                      {row.action, static_cast<float>(row.sensitivity.getValue()),
@@ -3019,7 +3019,7 @@ class ShortcutsPage : public juce::Component {
             row.learnButton.setButtonText(learnButtonText());
         }
 
-        GestureArea learnedDragAreaFor(const GestureRow& row) const {
+        static GestureArea learnedDragAreaFor(const GestureRow& row) {
             if (row.currentInput.area != GestureArea::Main)
                 return row.currentInput.area;
             if (row.input.area != GestureArea::Main)

--- a/magda/daw/ui/dialogs/TrackManagerDialog.cpp
+++ b/magda/daw/ui/dialogs/TrackManagerDialog.cpp
@@ -143,7 +143,7 @@ class TrackManagerDialog::ContentComponent : public juce::Component,
         }
     }
 
-    void drawCheckbox(juce::Graphics& g, int width, int height, bool isChecked) {
+    static void drawCheckbox(juce::Graphics& g, int width, int height, bool isChecked) {
         auto checkBounds = juce::Rectangle<int>((width - 16) / 2, (height - 16) / 2, 16, 16);
 
         // Checkbox border

--- a/magda/daw/ui/panels/BottomPanel.hpp
+++ b/magda/daw/ui/panels/BottomPanel.hpp
@@ -55,7 +55,7 @@ class BottomPanel : public daw::ui::TabbedPanel,
     void lookAndFeelChanged() override;
 
     // Legacy API for compatibility
-    void setCollapsed(bool collapsed);
+    static void setCollapsed(bool collapsed);
 
     // Get the current content type being displayed
     daw::ui::PanelContentType getActiveContentType() const;
@@ -152,7 +152,7 @@ class BottomPanel : public daw::ui::TabbedPanel,
     ClipId lastEditorClipId_ = INVALID_CLIP_ID;  // Track which clip we auto-defaulted for
 
     void onEditorTabChanged(int tabIndex);
-    void showDrumGridTabContextMenu(juce::Point<int> screenPos);
+    static void showDrumGridTabContextMenu(juce::Point<int> screenPos);
 
     // Mouse listener attached to drumGridTab_ to forward right-clicks to the
     // context-menu handler. SvgButton's onClick is left-click only.

--- a/magda/daw/ui/panels/LeftPanel.hpp
+++ b/magda/daw/ui/panels/LeftPanel.hpp
@@ -17,7 +17,7 @@ class LeftPanel : public daw::ui::TabbedPanel {
     ~LeftPanel() override = default;
 
     // Legacy API for compatibility
-    void setCollapsed(bool collapsed);
+    static void setCollapsed(bool collapsed);
 
   private:
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(LeftPanel)

--- a/magda/daw/ui/panels/RightPanel.hpp
+++ b/magda/daw/ui/panels/RightPanel.hpp
@@ -17,7 +17,7 @@ class RightPanel : public daw::ui::TabbedPanel {
     ~RightPanel() override = default;
 
     // Legacy API for compatibility
-    void setCollapsed(bool collapsed);
+    static void setCollapsed(bool collapsed);
 
   private:
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(RightPanel)

--- a/magda/daw/ui/panels/TransportPanel.hpp
+++ b/magda/daw/ui/panels/TransportPanel.hpp
@@ -207,8 +207,8 @@ class TransportPanel : public juce::Component, public MixAnalysisService::Listen
     daw::ui::transport::Layout layout_;
 
     // Button styling
-    void styleTransportButton(SvgButton& button, ColourRole accentRole,
-                              bool activeGlyphUsesAccent = false);
+    static void styleTransportButton(SvgButton& button, ColourRole accentRole,
+                                     bool activeGlyphUsesAccent = false);
     void setupTransportButtons();
     void setupTimeDisplayBoxes();
     void setupTempoAndQuantize();

--- a/magda/daw/ui/panels/content/AIChatConsoleContent.cpp
+++ b/magda/daw/ui/panels/content/AIChatConsoleContent.cpp
@@ -2429,7 +2429,7 @@ void AIChatConsoleContent::updateConfigStatus() {
     resized();
 }
 
-bool AIChatConsoleContent::isLocalPreset() const {
+bool AIChatConsoleContent::isLocalPreset() {
     auto& config = magda::Config::getInstance();
     auto preset = config.getAIPreset();
     auto commandCfg = config.getAgentLLMConfig(magda::role::COMMAND);
@@ -2529,7 +2529,7 @@ void AIChatConsoleContent::hideAutocomplete() {
 }
 
 std::vector<AIChatConsoleContent::ParamAliasEntry> AIChatConsoleContent::collectParamAliases(
-    const juce::String& pluginAlias) const {
+    const juce::String& pluginAlias) {
     std::vector<ParamAliasEntry> out;
     if (pluginAlias.isEmpty())
         return out;

--- a/magda/daw/ui/panels/content/AIChatConsoleContent.hpp
+++ b/magda/daw/ui/panels/content/AIChatConsoleContent.hpp
@@ -126,8 +126,8 @@ class AIChatConsoleContent : public PanelContent,
     void sendMessage(const juce::String& text);
     void cancelRequest();
     void restoreSendIcon();
-    void setThemedButtonIcon(juce::DrawableButton& button, const void* svgData,
-                             std::size_t svgDataSize);
+    static void setThemedButtonIcon(juce::DrawableButton& button, const void* svgData,
+                                    std::size_t svgDataSize);
     void appendToChat(const juce::String& text);
     void updateContextBar();
     void showMidiContextPicker();
@@ -308,7 +308,7 @@ class AIChatConsoleContent : public PanelContent,
     juce::Label configStatusLabel_;
     std::unique_ptr<magda::SvgButton> serverToggleButton_;
     void updateConfigStatus();
-    bool isLocalPreset() const;
+    static bool isLocalPreset();
 
     // Plugin alias autocomplete
     struct AliasEntry {
@@ -339,9 +339,9 @@ class AIChatConsoleContent : public PanelContent,
     std::vector<AliasEntry> allAliases_;
 
     void buildAliasList();
-    std::vector<ParamAliasEntry> collectParamAliases(const juce::String& pluginAlias) const;
+    static std::vector<ParamAliasEntry> collectParamAliases(const juce::String& pluginAlias);
     juce::String resolveAliases(const juce::String& text);
-    juce::String rewriteSlashCommand(const juce::String& text);
+    static juce::String rewriteSlashCommand(const juce::String& text);
 
     // Slash commands live in their own module (SlashCommands.{hpp,cpp})
     // so they can be tested without standing up the full chat panel. The

--- a/magda/daw/ui/panels/content/AutomationClipEditorContent.cpp
+++ b/magda/daw/ui/panels/content/AutomationClipEditorContent.cpp
@@ -281,7 +281,7 @@ const magda::AutomationClipInfo* AutomationClipEditorContent::getClip() const {
     return magda::AutomationManager::getInstance().getClip(selection_.clipId);
 }
 
-double AutomationClipEditorContent::viewSpanBeats(const magda::AutomationClipInfo& clip) const {
+double AutomationClipEditorContent::viewSpanBeats(const magda::AutomationClipInfo& clip) {
     // Looped -> one loop cycle (the clip's own timeline); else content length.
     const bool looped = clip.looping && clip.loopLengthBeats > 0.0;
     return juce::jmax(looped ? clip.loopLengthBeats : clip.lengthBeats, 0.25);

--- a/magda/daw/ui/panels/content/AutomationClipEditorContent.hpp
+++ b/magda/daw/ui/panels/content/AutomationClipEditorContent.hpp
@@ -108,7 +108,7 @@ class AutomationClipEditorContent : public PanelContent,
     bool showTrackGhost_ = true;
 
     const magda::AutomationClipInfo* getClip() const;
-    double viewSpanBeats(const magda::AutomationClipInfo& clip) const;
+    static double viewSpanBeats(const magda::AutomationClipInfo& clip);
     double gridResolutionBeats() const;
     void gridSettingsChanged();
     void buildHeaderControls();

--- a/magda/daw/ui/panels/content/ChordPanelContent.cpp
+++ b/magda/daw/ui/panels/content/ChordPanelContent.cpp
@@ -243,7 +243,7 @@ void BrowseScaleRowComponent::mouseExit(const juce::MouseEvent&) {
     repaint();
 }
 
-int BrowseScaleRowComponent::getRowHeight() const {
+int BrowseScaleRowComponent::getRowHeight() {
     return ROW_HEIGHT;
 }
 

--- a/magda/daw/ui/panels/content/ChordPanelContent.hpp
+++ b/magda/daw/ui/panels/content/ChordPanelContent.hpp
@@ -94,7 +94,7 @@ class BrowseScaleRowComponent : public juce::Component {
     void mouseEnter(const juce::MouseEvent& e) override;
     void mouseExit(const juce::MouseEvent& e) override;
 
-    int getRowHeight() const;
+    static int getRowHeight();
     const magda::music::ScaleWithChords& getScale() const {
         return scale_;
     }
@@ -235,7 +235,7 @@ class ChordPanelContent : public juce::Component,
 
     // AI chord suggestion
     void requestAISuggestions();
-    std::vector<AIProgression> parseAIResponse(const juce::String& json);
+    static std::vector<AIProgression> parseAIResponse(const juce::String& json);
 
     class AIRequestThread : public juce::Thread {
       public:

--- a/magda/daw/ui/panels/content/MediaExplorerContent.cpp
+++ b/magda/daw/ui/panels/content/MediaExplorerContent.cpp
@@ -1212,7 +1212,7 @@ MediaExplorerContent::~MediaExplorerContent() {
     previewCallback_.reset();
 }
 
-juce::File MediaExplorerContent::pickStartupFilesystemRoot() const {
+juce::File MediaExplorerContent::pickStartupFilesystemRoot() {
     // Saved default → user's Music folder → home. Returns the first that
     // exists as a directory.
     auto defaultDir = magda::Config::getInstance().getBrowserDefaultDirectory();
@@ -1701,23 +1701,23 @@ juce::String MediaExplorerContent::getMediaFilterPattern() const {
     return patterns.joinIntoString(";");
 }
 
-bool MediaExplorerContent::isAudioFile(const juce::File& file) const {
+bool MediaExplorerContent::isAudioFile(const juce::File& file) {
     auto ext = file.getFileExtension().toLowerCase();
     return ext == ".wav" || ext == ".aiff" || ext == ".aif" || ext == ".mp3" || ext == ".ogg" ||
            ext == ".flac";
 }
 
-bool MediaExplorerContent::isMidiFile(const juce::File& file) const {
+bool MediaExplorerContent::isMidiFile(const juce::File& file) {
     auto ext = file.getFileExtension().toLowerCase();
     return ext == ".mid" || ext == ".midi";
 }
 
-bool MediaExplorerContent::isMagdaClip(const juce::File& file) const {
+bool MediaExplorerContent::isMagdaClip(const juce::File& file) {
     auto ext = file.getFileExtension().toLowerCase();
     return ext == ".magdaclip";
 }
 
-bool MediaExplorerContent::isPresetFile(const juce::File& file) const {
+bool MediaExplorerContent::isPresetFile(const juce::File& file) {
     auto ext = file.getFileExtension().toLowerCase();
     return ext == ".magdapreset";
 }

--- a/magda/daw/ui/panels/content/MediaExplorerContent.hpp
+++ b/magda/daw/ui/panels/content/MediaExplorerContent.hpp
@@ -157,7 +157,7 @@ class MediaExplorerContent : public PanelContent,
 
     // Helper: best initial Filesystem root — saved default, then Music,
     // then Home. Always returns an existing directory.
-    [[nodiscard]] juce::File pickStartupFilesystemRoot() const;
+    [[nodiscard]] static juce::File pickStartupFilesystemRoot();
 
     // Public-facing query equivalent of the old libraryMode_ flag, used by
     // the type-icon click handler to know whether it's driving DB kind or
@@ -222,12 +222,12 @@ class MediaExplorerContent : public PanelContent,
     void navigateToDirectory(const juce::File& directory);
     void updateMediaFilter();
     juce::String getMediaFilterPattern() const;
-    bool isAudioFile(const juce::File& file) const;
-    bool isMidiFile(const juce::File& file) const;
-    bool isMagdaClip(const juce::File& file) const;
-    bool isPresetFile(const juce::File& file) const;
-    juce::String formatFileSize(int64_t bytes);
-    juce::String formatDuration(double seconds);
+    static bool isAudioFile(const juce::File& file);
+    static bool isMidiFile(const juce::File& file);
+    static bool isMagdaClip(const juce::File& file);
+    static bool isPresetFile(const juce::File& file);
+    static juce::String formatFileSize(int64_t bytes);
+    static juce::String formatDuration(double seconds);
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(MediaExplorerContent)
 };

--- a/magda/daw/ui/panels/content/MidiEditorContent.hpp
+++ b/magda/daw/ui/panels/content/MidiEditorContent.hpp
@@ -146,7 +146,7 @@ class MidiEditorContent : public PanelContent,
     // --- Multi-track overlay (ghost notes from other tracks, #1281) ---
     // Shared between piano roll and drum grid; each editor renders the
     // overlay in its own grid via applyOverlayTracks().
-    bool hasOverlayTracks() const {
+    static bool hasOverlayTracks() {
         return !overlayTrackIds_.empty();
     }
     // Sticky multi-select menu of other MIDI tracks (anchored at `anchor`);
@@ -161,7 +161,7 @@ class MidiEditorContent : public PanelContent,
     static bool isNotePreviewEnabled() {
         return notePreviewEnabled_;
     }
-    void setNotePreviewEnabled(bool enabled) {
+    static void setNotePreviewEnabled(bool enabled) {
         notePreviewEnabled_ = enabled;
     }
     // Update a gutter preview toggle to reflect `on`: crossed speaker in dimmed
@@ -222,7 +222,7 @@ class MidiEditorContent : public PanelContent,
     static bool velocityDrawerOpen_;
     static bool velocityLaneVisible_;
     void setVelocityDrawerVisible(bool visible);
-    bool isVelocityDrawerVisible() const {
+    static bool isVelocityDrawerVisible() {
         return velocityDrawerOpen_;
     }
     // Push the velocity-visible flag into the drawer, recompute drawer-open, and

--- a/magda/daw/ui/panels/content/PanelContentFactory.cpp
+++ b/magda/daw/ui/panels/content/PanelContentFactory.cpp
@@ -91,7 +91,7 @@ std::vector<PanelContentType> PanelContentFactory::getAvailableTypes() const {
     return types;
 }
 
-PanelContentInfo PanelContentFactory::getContentInfo(PanelContentType type) const {
+PanelContentInfo PanelContentFactory::getContentInfo(PanelContentType type) {
     return PanelContentInfo{type, getContentTypeName(type), getContentTypeName(type),
                             getContentTypeIcon(type)};
 }

--- a/magda/daw/ui/panels/content/PanelContentFactory.hpp
+++ b/magda/daw/ui/panels/content/PanelContentFactory.hpp
@@ -54,7 +54,7 @@ class PanelContentFactory {
     /**
      * @brief Get the info for a content type
      */
-    PanelContentInfo getContentInfo(PanelContentType type) const;
+    static PanelContentInfo getContentInfo(PanelContentType type);
 
   private:
     PanelContentFactory();

--- a/magda/daw/ui/panels/content/PianoRollContent.hpp
+++ b/magda/daw/ui/panels/content/PianoRollContent.hpp
@@ -241,12 +241,13 @@ class PianoRollContent : public MidiEditorContent,
     void setupGridCallbacks();
     void drawSidebar(juce::Graphics& g, juce::Rectangle<int> area);
     void drawChordRow(juce::Graphics& g, juce::Rectangle<int> area);
-    void drawVelocityHeader(juce::Graphics& g, juce::Rectangle<int> area);
+    static void drawVelocityHeader(juce::Graphics& g, juce::Rectangle<int> area);
     void detectChordsFromNotes();
     // Play a note then stop it after its length elapses, for double-click note
     // creation (#1705). Gated by the preview toggle; the note-off is scheduled
     // against the engine so it fires even if this panel is torn down first.
-    void auditionNoteOnce(magda::ClipId clipId, int noteNumber, int velocity, double lengthBeats);
+    static void auditionNoteOnce(magda::ClipId clipId, int noteNumber, int velocity,
+                                 double lengthBeats);
     void syncChordAnnotations(magda::ClipId clipId);
     void setNoteHeight(int height, bool persist);
     void setNoteHeightAnchored(int height, int anchorNote, int anchorScreenY, bool persist);

--- a/magda/daw/ui/panels/content/PluginBrowserContent.cpp
+++ b/magda/daw/ui/panels/content/PluginBrowserContent.cpp
@@ -1245,7 +1245,7 @@ void PluginBrowserContent::showRenameFolderDialog(const juce::String& folderName
         true);
 }
 
-juce::File PluginBrowserContent::getFoldersFile() const {
+juce::File PluginBrowserContent::getFoldersFile() {
     return magda::paths::pluginFoldersFile();
 }
 

--- a/magda/daw/ui/panels/content/PluginBrowserContent.hpp
+++ b/magda/daw/ui/panels/content/PluginBrowserContent.hpp
@@ -162,7 +162,7 @@ class PluginBrowserContent : public PanelContent,
     void showRenameFolderDialog(const juce::String& folderName);
     void saveFolders();
     void loadFolders();
-    juce::File getFoldersFile() const;
+    static juce::File getFoldersFile();
 
     juce::StringArray folderNames_;                           // in creation order
     std::map<juce::String, juce::String> pluginFolderByKey_;  // plugin key -> folder name

--- a/magda/daw/ui/panels/content/PostFxPanelContent.hpp
+++ b/magda/daw/ui/panels/content/PostFxPanelContent.hpp
@@ -59,7 +59,7 @@ class PostFxPanelContent : public juce::Component, public magda::TrackManagerLis
     int indicatorX(int insertIndex) const;
     int contentWidth() const;  // container width: max(content, viewport)
     int appendZoneX() const;   // x of the "+" add strip, pinned to the right
-    void applyReorder(magda::TrackId trackId, int fromIndex, int insertIndex);
+    static void applyReorder(magda::TrackId trackId, int fromIndex, int insertIndex);
     static magda::DeviceInfo deviceInfoFromDragObject(const juce::DynamicObject& obj);
 
     magda::TrackId trackId_ = magda::INVALID_TRACK_ID;

--- a/magda/daw/ui/panels/content/WaveformEditorContent.hpp
+++ b/magda/daw/ui/panels/content/WaveformEditorContent.hpp
@@ -94,7 +94,7 @@ class WaveformEditorContent : public PanelContent,
 
     // Waveform editor is always source-relative.
     void setRelativeTimeMode(bool relative);
-    bool isRelativeTimeMode() const {
+    static bool isRelativeTimeMode() {
         return true;
     }
     void setSnapEnabledFromUI(bool enabled);
@@ -180,7 +180,7 @@ class WaveformEditorContent : public PanelContent,
 
     // Warp marker helpers
     void refreshWarpMarkers();
-    magda::AudioBridge* getBridge();
+    static magda::AudioBridge* getBridge();
 
     // Slice helpers
     void sliceAtWarpMarkers();

--- a/magda/daw/ui/themes/MixerLookAndFeel.hpp
+++ b/magda/daw/ui/themes/MixerLookAndFeel.hpp
@@ -39,7 +39,7 @@ class MixerLookAndFeel : public juce::LookAndFeel_V4 {
     void positionComboBoxText(juce::ComboBox& box, juce::Label& label) override;
 
     // Smaller arrow button for ComboBox
-    void drawComboBoxArrow(juce::Graphics& g, juce::Rectangle<int> arrowZone);
+    static void drawComboBoxArrow(juce::Graphics& g, juce::Rectangle<int> arrowZone);
 
   private:
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(MixerLookAndFeel)

--- a/magda/daw/ui/themes/MixerMetrics.hpp
+++ b/magda/daw/ui/themes/MixerMetrics.hpp
@@ -31,7 +31,7 @@ struct MixerMetrics {
     float tickWidth() const {
         return thumbHeight * tickWidthMultiplier;
     }
-    static static static static static static float tickHeight() {
+    static float tickHeight() {
         return 1.0f;
     }
     float trackPadding() const {

--- a/magda/daw/ui/themes/MixerMetrics.hpp
+++ b/magda/daw/ui/themes/MixerMetrics.hpp
@@ -31,7 +31,7 @@ struct MixerMetrics {
     float tickWidth() const {
         return thumbHeight * tickWidthMultiplier;
     }
-    float tickHeight() const {
+    static static static static static static float tickHeight() {
         return 1.0f;
     }
     float trackPadding() const {

--- a/magda/daw/ui/views/MainView.hpp
+++ b/magda/daw/ui/views/MainView.hpp
@@ -430,7 +430,7 @@ class MainView::MasterHeaderPanel : public juce::Component,
   private:
     // Opens the master automation menu (mirrors the per-track automation
     // button). Shared by the icon button and the header right-click.
-    void showMasterAutomationMenu(juce::Component* anchor);
+    static void showMasterAutomationMenu(juce::Component* anchor);
 
     std::unique_ptr<SvgButton> speakerButton;          // Speaker on/off toggle
     std::unique_ptr<SvgButton> automationButton;       // Show master automation lane
@@ -473,7 +473,7 @@ class MainView::AuxHeadersPanel : public juce::Component, public TrackManagerLis
     void tracksChanged() override;
 
     // Metering
-    void updateMetering(AudioEngine* engine);
+    static void updateMetering(AudioEngine* engine);
 
     // Get number of aux tracks
     int getAuxTrackCount() const {

--- a/magda/daw/ui/views/MixerView.cpp
+++ b/magda/daw/ui/views/MixerView.cpp
@@ -956,7 +956,7 @@ void MixerView::ChannelStrip::setupRoutingCallbacks() {
 }
 
 std::vector<MixerView::ChannelStrip::MiniChainRowSignatureEntry>
-MixerView::ChannelStrip::buildMiniChainSignature(const TrackInfo& track) const {
+MixerView::ChannelStrip::buildMiniChainSignature(const TrackInfo& track) {
     std::vector<MiniChainRowSignatureEntry> signature;
     signature.reserve(track.chain.fxChainElements.size());
     for (const auto& element : track.chain.fxChainElements) {
@@ -2286,7 +2286,7 @@ void MixerView::paint(juce::Graphics& g) {
     }
 }
 
-int MixerView::getTopLevelStripWidth(const ChannelStrip& strip) const {
+int MixerView::getTopLevelStripWidth(const ChannelStrip& strip) {
     int width = strip.preferredChannelWidth();
     for (auto* child : strip.groupChildren_) {
         if (auto* childStrip = dynamic_cast<ChannelStrip*>(child))
@@ -2685,7 +2685,7 @@ bool MixerView::keyPressed(const juce::KeyPress& /*key*/) {
     return false;
 }
 
-bool MixerView::isInChannelResizeZone(const juce::Point<int>& /*pos*/) const {
+bool MixerView::isInChannelResizeZone(const juce::Point<int>& /*pos*/) {
     // Not used anymore - resize handle component handles this
     return false;
 }

--- a/magda/daw/ui/views/MixerView.hpp
+++ b/magda/daw/ui/views/MixerView.hpp
@@ -241,8 +241,8 @@ class MixerView : public juce::Component,
 
         std::vector<std::unique_ptr<MiniChainRow>> miniChainRows_;
         std::vector<MiniChainRowSignatureEntry> miniChainSignature_;
-        std::vector<MiniChainRowSignatureEntry> buildMiniChainSignature(
-            const TrackInfo& track) const;
+        static std::vector<MiniChainRowSignatureEntry> buildMiniChainSignature(
+            const TrackInfo& track);
         void syncMiniChainRows(const TrackInfo& track);
         void rebuildMiniChainRows(const TrackInfo& track,
                                   std::vector<MiniChainRowSignatureEntry> signature);
@@ -349,14 +349,14 @@ class MixerView : public juce::Component,
     std::vector<std::unique_ptr<ChannelResizeHandle>> channelResizeHandles_;
     void wireChannelResizeHandle(ChannelResizeHandle& handle);
     void layoutChannelResizeHandles(int containerHeight);
-    int getTopLevelStripWidth(const ChannelStrip& strip) const;
+    static int getTopLevelStripWidth(const ChannelStrip& strip);
     std::vector<TrackId> getLayoutEditTargets(TrackId clickedId, bool allVisible) const;
     void applyChannelWidthDelta(TrackId clickedId, int deltaX, const juce::ModifierKeys& mods);
     void finishChannelWidthResize(const juce::ModifierKeys& mods);
     void resetChannelWidths(TrackId clickedId, const juce::ModifierKeys& mods);
     void commitChannelWidthResize();
-    void executeMixerLayoutCommands(const juce::String& description,
-                                    std::vector<std::unique_ptr<UndoableCommand>> commands);
+    static void executeMixerLayoutCommands(const juce::String& description,
+                                           std::vector<std::unique_ptr<UndoableCommand>> commands);
 
     // Left-edge vertical rail of view-toggle buttons (sends, routing, monitor,
     // mini oscilloscope, mini spectrum, mini FX chain). State persisted via
@@ -368,7 +368,7 @@ class MixerView : public juce::Component,
     void relayoutAllStrips();
     // Ensure every non-master track has (or lacks) the Oscilloscope /
     // Spectrum Analyzer post-FX device to match the mixer rail toggles.
-    void reconcileAnalysisDevices();
+    static void reconcileAnalysisDevices();
     bool isResizeDragging_ = false;
     bool wasPlaying_ = false;  // tracks transport edge to auto-reset peak holds
     bool pendingResizeUpdate_ = false;
@@ -402,7 +402,7 @@ class MixerView : public juce::Component,
     // Audio engine for metering
     AudioEngine* audioEngine_ = nullptr;
 
-    bool isInChannelResizeZone(const juce::Point<int>& pos) const;
+    static bool isInChannelResizeZone(const juce::Point<int>& pos);
 
     // Plugin drag-and-drop state
     bool showPluginDropOverlay_ = false;

--- a/magda/daw/ui/views/SessionView.cpp
+++ b/magda/daw/ui/views/SessionView.cpp
@@ -4062,7 +4062,7 @@ void SessionView::clearDragGhost() {
     }
 }
 
-bool SessionView::isAudioFile(const juce::String& filename) const {
+bool SessionView::isAudioFile(const juce::String& filename) {
     static const juce::StringArray audioExtensions = {".wav",  ".aiff", ".aif", ".mp3", ".ogg",
                                                       ".flac", ".m4a",  ".wma", ".opus"};
 

--- a/magda/daw/ui/views/SessionView.hpp
+++ b/magda/daw/ui/views/SessionView.hpp
@@ -245,14 +245,14 @@ class SessionView : public juce::Component,
     void openClipEditor(int trackIndex, int sceneIndex);
     void onCreateMidiClipClicked(int trackIndex, int sceneIndex);
     ClipId duplicateSessionClipToNextEmptyScene(ClipId clipId);
-    bool deleteSelectedSessionClips();
+    static bool deleteSelectedSessionClips();
 
     // View mode state
     ViewMode currentViewMode_ = ViewMode::Live;
     std::vector<TrackId> visibleTrackIds_;
 
     // Selection
-    void selectTrack(TrackId trackId);
+    static void selectTrack(TrackId trackId);
     void updateHeaderSelectionVisuals();
 
     // Clip slot display
@@ -276,7 +276,7 @@ class SessionView : public juce::Component,
     void clearDragHighlight();
     void updateDragGhost(const juce::StringArray& files, int trackIndex, int sceneIndex);
     void clearDragGhost();
-    bool isAudioFile(const juce::String& filename) const;
+    static bool isAudioFile(const juce::String& filename);
 
     // The media browser delivers sample drags as an internal {type:"files"}
     // payload rather than an OS file-drag on Linux, where JUCE has no Wayland

--- a/magda/daw/ui/windows/MainWindow.hpp
+++ b/magda/daw/ui/windows/MainWindow.hpp
@@ -83,7 +83,7 @@ class MainWindow : public juce::DocumentWindow,
     // Re-applies the active palette to every shared LookAndFeel and broadcasts
     // a look-and-feel change to all top-level windows. Shared by the config
     // switch and hot-reload.
-    static void refreshThemedLookAndFeels();
+    void refreshThemedLookAndFeels();
     // Hot-reload callback: the active user theme file changed on disk.
     void onActiveThemeFileChanged();
     class MainComponent;

--- a/magda/daw/ui/windows/MainWindow.hpp
+++ b/magda/daw/ui/windows/MainWindow.hpp
@@ -83,7 +83,7 @@ class MainWindow : public juce::DocumentWindow,
     // Re-applies the active palette to every shared LookAndFeel and broadcasts
     // a look-and-feel change to all top-level windows. Shared by the config
     // switch and hot-reload.
-    void refreshThemedLookAndFeels();
+    static void refreshThemedLookAndFeels();
     // Hot-reload callback: the active user theme file changed on disk.
     void onActiveThemeFileChanged();
     class MainComponent;
@@ -111,8 +111,8 @@ class MainWindow : public juce::DocumentWindow,
     // The actual chooser + render flow, after performExport's pre-checks pass.
     void launchAudioExport(const ExportAudioDialog::Settings& settings, AudioEngine* engine);
     void performMidiExport(const ExportMidiDialog::Settings& settings);
-    juce::String getFileExtensionForFormat(const juce::String& format) const;
-    int getBitDepthForFormat(const juce::String& format) const;
+    static juce::String getFileExtensionForFormat(const juce::String& format);
+    static int getBitDepthForFormat(const juce::String& format);
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(MainWindow)
 };

--- a/magda/daw/ui/windows/MainWindowExport.cpp
+++ b/magda/daw/ui/windows/MainWindowExport.cpp
@@ -437,7 +437,7 @@ void MainWindow::launchAudioExport(const ExportAudioDialog::Settings& settings,
         });
 }
 
-juce::String MainWindow::getFileExtensionForFormat(const juce::String& format) const {
+juce::String MainWindow::getFileExtensionForFormat(const juce::String& format) {
     if (format.startsWith("WAV"))
         return ".wav";
     else if (format == "FLAC")
@@ -445,7 +445,7 @@ juce::String MainWindow::getFileExtensionForFormat(const juce::String& format) c
     return ".wav";  // Default
 }
 
-int MainWindow::getBitDepthForFormat(const juce::String& format) const {
+int MainWindow::getBitDepthForFormat(const juce::String& format) {
     if (format == "WAV16")
         return 16;
     if (format == "WAV24")

--- a/magda/engine/clip/ClipVoice.cpp
+++ b/magda/engine/clip/ClipVoice.cpp
@@ -166,7 +166,7 @@ bool ClipVoice::renderThroughCells(const AudioClipPlayback& clip, const AudioEve
 
 void ClipVoice::applyFade(juce::dsp::AudioBlock<float> region, EdgeSample regionFirstSample,
                           const BlockInfo& block, double startSeconds, double endSeconds,
-                          FadeCurve curve, bool rising) const {
+                          FadeCurve curve, bool rising) {
     const auto length = endSeconds - startSeconds;
     if (!(length > 0.0) || block.numSamples <= 0)
         return;

--- a/magda/engine/clip/ClipVoice.hpp
+++ b/magda/engine/clip/ClipVoice.hpp
@@ -144,9 +144,9 @@ class ClipVoice {
 
     /// Multiply the part of @p region inside [@p startSeconds, @p endSeconds)
     /// by a curve running across it, rising or falling.
-    void applyFade(juce::dsp::AudioBlock<float> region, EdgeSample regionFirstSample,
-                   const BlockInfo& block, double startSeconds, double endSeconds, FadeCurve curve,
-                   bool rising) const;
+    static void applyFade(juce::dsp::AudioBlock<float> region, EdgeSample regionFirstSample,
+                          const BlockInfo& block, double startSeconds, double endSeconds,
+                          FadeCurve curve, bool rising);
 
     /// How much timeline one cell covers. Small enough that a curved rate is
     /// still nearly straight across one, and that is the only thing it has to

--- a/magda/engine/exec/PlanValues.cpp
+++ b/magda/engine/exec/PlanValues.cpp
@@ -130,7 +130,7 @@ class Resolver {
     ///
     /// Pads entered: a pad rack hangs off its device rather than sitting in the
     /// chain, and its chains carry mute, solo and a fader like any other's.
-    const RackInfo* findRack(const TrackInfo& track, RackId rackId) const {
+    static const RackInfo* findRack(const TrackInfo& track, RackId rackId) {
         return chain_walk::findRack(
             track.chain.fxChainElements, ChainNodePath::trackLevel(track.id),
             chain_walk::Pads::Enter,

--- a/magda/engine/param/ModRuntime.cpp
+++ b/magda/engine/param/ModRuntime.cpp
@@ -218,14 +218,14 @@ std::span<const int> ModRuntime::listenersOf(magda::TrackId track) const {
     return std::span<const int>{listeners_}.subspan(first, last - first);
 }
 
-bool ModRuntime::drivenFromElsewhere(int index, const ParamTable& table) const {
+bool ModRuntime::drivenFromElsewhere(int index, const ParamTable& table) {
     if (index < 0 || index >= static_cast<int>(table.modifiers.size()))
         return false;
 
     return isDrivenFromElsewhere(table.modifiers[static_cast<std::size_t>(index)]);
 }
 
-ModListen ModRuntime::listensFor(int index, const ParamTable& table) const {
+ModListen ModRuntime::listensFor(int index, const ParamTable& table) {
     if (index < 0 || index >= static_cast<int>(table.modifiers.size()))
         return ModListen::Nothing;
 

--- a/magda/engine/param/ModRuntime.hpp
+++ b/magda/engine/param/ModRuntime.hpp
@@ -150,7 +150,7 @@ class ModRuntime {
     /// note-waiting modifiers and a level reaches level-waiting ones. One
     /// listener list per track plus this to sort them, rather than three
     /// lists that could disagree about who is on which.
-    ModListen listensFor(int index, const ParamTable& table) const;
+    static ModListen listensFor(int index, const ParamTable& table);
 
     /**
      * @brief Whether modifier @p index is driven by a track other than its own.
@@ -163,7 +163,7 @@ class ModRuntime {
      * fires triggerSidechain and ignores note-off). Exposed because the
      * executor holds the tap and cannot otherwise tell the two apart.
      */
-    bool drivenFromElsewhere(int index, const ParamTable& table) const;
+    static bool drivenFromElsewhere(int index, const ParamTable& table);
 
     /// What modifier @p index published this block, or the model's own
     /// value for one nothing has advanced.

--- a/magda/engine/plan/PlanCompiler.cpp
+++ b/magda/engine/plan/PlanCompiler.cpp
@@ -197,7 +197,7 @@ class Compiler {
     TrackRoute activeMidiInputRoute(const TrackInfo& track) const;
 
     /// The track this track's audio output feeds; the master by default.
-    TrackId resolveAudioDestination(const TrackInfo& track) const;
+    static TrackId resolveAudioDestination(const TrackInfo& track);
 
     void emitTrack(const TrackInfo& track);
 
@@ -385,7 +385,7 @@ TrackRoute Compiler::activeMidiInputRoute(const TrackInfo& track) const {
     return parseTrackRoute(track.midiInputDevice);
 }
 
-TrackId Compiler::resolveAudioDestination(const TrackInfo& track) const {
+TrackId Compiler::resolveAudioDestination(const TrackInfo& track) {
     const auto route = parseTrackRoute(track.audioOutputDevice);
     return route.namesTrack() ? route.trackId : MASTER_TRACK_ID;
 }


### PR DESCRIPTION
readability-convert-member-functions-to-static across `magda/`. 185 files.

Methods that read no member and call nothing non-static are now static, which
says at the declaration that they are pure functions of their arguments and
lets callers use them without an instance.

119 of the files are headers, because the declaration changes and not just the
definition. Verified by a full build - every target and both test binaries
link, so no call site relied on these being pointer-to-member.

https://claude.ai/code/session_01VomqgBSXsWYdyHyec9DvPi