### PR TITLE
Read the corpus step bound off the material it renders

### DIFF
--- a/tests/MgdFixtures.cpp
+++ b/tests/MgdFixtures.cpp
@@ -126,14 +126,14 @@ MaterialSpec toneFor(double seconds, double frequency) {
     return spec;
 }
 
-/// The steepest a full-scale copy of @p sources can be, per sample.
-///
-/// A limiter bounds amplitude and not slope, so a step bound read off its
-/// ceiling refuses the tones the project is made of. A full-scale sine steps
-/// 2*sin(pi*f/rate) between samples on its own, and a sum of them limited back
-/// to full scale lands above the steepest single one, which is what @p headroom
-/// carries. Derived rather than chosen so it cannot be set below the material
-/// again.
+/**
+ * @brief The steepest a full-scale copy of @p sources can be, per sample.
+ *
+ * A limiter bounds amplitude and not slope, so a bound read off its ceiling
+ * refuses the tones the project is made of. A full-scale sine steps
+ * 2*sin(pi*f/rate) on its own and a sum of them lands above the steepest one,
+ * which is what @p headroom carries.
+ */
 double fullScaleStepOf(const std::vector<FixtureSource>& sources, double headroom) {
     auto steepest = 0.0;
     for (const auto& source : sources)

--- a/tests/MgdFixtures.cpp
+++ b/tests/MgdFixtures.cpp
@@ -126,6 +126,25 @@ MaterialSpec toneFor(double seconds, double frequency) {
     return spec;
 }
 
+/// The steepest a full-scale copy of @p sources can be, per sample.
+///
+/// A limiter bounds amplitude and not slope, so a step bound read off its
+/// ceiling refuses the tones the project is made of. A full-scale sine steps
+/// 2*sin(pi*f/rate) between samples on its own, and a sum of them limited back
+/// to full scale lands above the steepest single one, which is what @p headroom
+/// carries. Derived rather than chosen so it cannot be set below the material
+/// again.
+double fullScaleStepOf(const std::vector<FixtureSource>& sources, double headroom) {
+    auto steepest = 0.0;
+    for (const auto& source : sources)
+        if (source.material.kind == MaterialKind::Tone)
+            steepest = std::max(steepest, 2.0 * std::sin(juce::MathConstants<double>::pi *
+                                                         source.material.frequency /
+                                                         source.material.sampleRate));
+
+    return steepest * headroom;
+}
+
 Case declarationFor(const char* name, const char* covers, double startBeat, double endBeat) {
     Case value;
     value.name = name;
@@ -548,11 +567,6 @@ std::vector<MgdFixture> build() {
         fixture.declaration.tier = AudioTier::Invariants;
         fixture.hostedPlugins = {"Pro-L 2"};
 
-        // A limiter's job is to not step: it is the one device here whose output
-        // is bounded by construction, and a bound this tight is what says the
-        // twenty-three summed stems went through it rather than around it.
-        fixture.declaration.maxStepPerSample = 0.1;
-
         // Eight beats of a five-hundred-and-ninety-seven-beat arrangement. Every
         // one of the twenty-three stems is still playing when the render stops.
         fixture.declaration.rendersPastItsMaterial = false;
@@ -641,6 +655,11 @@ std::vector<MgdFixture> build() {
              .material = toneFor(5.0, 1318.0),
              .covers = "a trumpet stem"},
         };
+
+        // Twenty-three tones into a limiter that puts the sum at full scale, so
+        // the bound is the material's own slope. Set after the sources because
+        // it is read off them.
+        fixture.declaration.maxStepPerSample = fullScaleStepOf(fixture.sources, 1.25);
 
         fixtures.push_back(std::move(fixture));
     }

--- a/tests/NullDiffRunner.cpp
+++ b/tests/NullDiffRunner.cpp
@@ -365,7 +365,8 @@ juce::File nullDiffScratchDirectory() {
 SuiteComplaints judgeSuite(const std::set<std::string>& asserted,
                            const std::set<std::string>& unmeasurable,
                            const std::set<std::string>& failing,
-                           const std::set<std::string>& underCalibration) {
+                           const std::set<std::string>& underCalibration,
+                           const std::set<std::string>& notRun) {
     SuiteComplaints complaints;
 
     complaints.asserted.assign(asserted.begin(), asserted.end());
@@ -378,8 +379,11 @@ SuiteComplaints judgeSuite(const std::set<std::string>& asserted,
         if (underCalibration.count(name) == 0)
             complaints.unexpectedFailures.push_back(name);
 
+    // A case that did not run cannot take itself off the list: it is not a pass
+    // and not a failure. Without this a machine that lacks the case's plugin
+    // reports every calibrated entry as holding, which is what CI is.
     for (const auto& name : underCalibration)
-        if (failing.count(name) == 0)
+        if (failing.count(name) == 0 && notRun.count(name) == 0)
             complaints.nowHolding.push_back(name);
 
     return complaints;

--- a/tests/NullDiffRunner.hpp
+++ b/tests/NullDiffRunner.hpp
@@ -95,7 +95,8 @@ struct SuiteComplaints {
 SuiteComplaints judgeSuite(const std::set<std::string>& asserted,
                            const std::set<std::string>& unmeasurable,
                            const std::set<std::string>& failing,
-                           const std::set<std::string>& underCalibration);
+                           const std::set<std::string>& underCalibration,
+                           const std::set<std::string>& notRun);
 
 /// One walk over a corpus, with everything a suite needs to judge itself.
 struct SuiteRun {

--- a/tests/engine/test_null_diff_juce.cpp
+++ b/tests/engine/test_null_diff_juce.cpp
@@ -274,7 +274,7 @@ class NullDiffCorpusTests : public juce::UnitTest {
         };
 
         const auto complaints =
-            judgeSuite(run.asserted, run.unmeasurable, run.failing, underCalibration);
+            judgeSuite(run.asserted, run.unmeasurable, run.failing, underCalibration, run.notRun);
 
         const auto join = [](const std::vector<std::string>& names) {
             juce::StringArray parts;
@@ -345,7 +345,7 @@ class NullDiffSuiteRuleTests : public juce::UnitTest {
             // membership check is satisfied and says nothing. The assertion has
             // to be what fails the suite, on its own.
             const auto complaints = judgeSuite({"tempo.auto"}, {"tempo.auto"},
-                                               {"tempo.auto", "warp.audio"}, calibrating);
+                                               {"tempo.auto", "warp.audio"}, calibrating, {});
 
             expect(complaints.asserted == std::vector<std::string>{"tempo.auto"});
             expect(complaints.unmeasurable.empty(),
@@ -364,7 +364,7 @@ class NullDiffSuiteRuleTests : public juce::UnitTest {
             // swallow. The list forgives a comparison without a bound, never the
             // absence of a comparison.
             const auto complaints =
-                judgeSuite({}, {"tempo.auto"}, {"tempo.auto", "warp.audio"}, calibrating);
+                judgeSuite({}, {"tempo.auto"}, {"tempo.auto", "warp.audio"}, calibrating, {});
 
             expect(complaints.unmeasurable == std::vector<std::string>{"tempo.auto"});
             expect(complaints.unexpectedFailures.empty(), "it is on the list, so not unexpected");
@@ -374,14 +374,15 @@ class NullDiffSuiteRuleTests : public juce::UnitTest {
 
         beginTest("A calibrating case that merely fails says nothing");
         {
-            const auto complaints = judgeSuite({}, {}, {"tempo.auto", "warp.audio"}, calibrating);
+            const auto complaints =
+                judgeSuite({}, {}, {"tempo.auto", "warp.audio"}, calibrating, {});
             expect(complaints.empty(), "the run everybody expects");
         }
 
         beginTest("A case that asserts outside the list fails too");
         {
             const auto complaints = judgeSuite(
-                {"mix.pan"}, {"mix.pan"}, {"mix.pan", "tempo.auto", "warp.audio"}, calibrating);
+                {"mix.pan"}, {"mix.pan"}, {"mix.pan", "tempo.auto", "warp.audio"}, calibrating, {});
 
             expect(complaints.asserted == std::vector<std::string>{"mix.pan"});
             expect(complaints.unexpectedFailures == std::vector<std::string>{"mix.pan"});
@@ -389,8 +390,18 @@ class NullDiffSuiteRuleTests : public juce::UnitTest {
 
         beginTest("A calibrating case that starts holding has to come off the list");
         {
-            const auto complaints = judgeSuite({}, {}, {"warp.audio"}, calibrating);
+            const auto complaints = judgeSuite({}, {}, {"warp.audio"}, calibrating, {});
             expect(complaints.nowHolding == std::vector<std::string>{"tempo.auto"});
+        }
+
+        beginTest("A calibrating case that did not run stays on the list");
+        {
+            // What a machine without the case's plugin sees, CI included. Not
+            // running is not holding, and reading it as holding would take the
+            // entry off wherever the corpus is thinnest.
+            const auto complaints = judgeSuite({}, {}, {"warp.audio"}, calibrating, {"tempo.auto"});
+            expect(complaints.nowHolding.empty(), "it did not run, so it did not hold");
+            expect(complaints.empty(), "and nothing else is wrong with that run");
         }
     }
 };

--- a/tests/engine/test_real_project_corpus_juce.cpp
+++ b/tests/engine/test_real_project_corpus_juce.cpp
@@ -226,6 +226,14 @@ class RealProjectCorpusTests : public juce::UnitTest {
             // through every decay.
             "project.fmchain",
             "project.sidechain",
+
+            // Two of its tracks were saved in Session playback mode. The
+            // incumbent honours that in a render and plays their slots, which
+            // nothing here launches, so it renders silence where the native leg
+            // renders the arrangement. The native engine has no concept of
+            // TrackPlaybackMode at all (#2485), and until it does there is no
+            // agreement to measure.
+            "project.retrospect",
         };
 
         const auto complaints =

--- a/tests/engine/test_real_project_corpus_juce.cpp
+++ b/tests/engine/test_real_project_corpus_juce.cpp
@@ -237,7 +237,7 @@ class RealProjectCorpusTests : public juce::UnitTest {
         };
 
         const auto complaints =
-            judgeSuite(run.asserted, run.unmeasurable, run.failing, underCalibration);
+            judgeSuite(run.asserted, run.unmeasurable, run.failing, underCalibration, run.notRun);
 
         // What this run did not cover, said out loud. A case that did not run is
         // not a pass and not a failure, and the one way that can go wrong is


### PR DESCRIPTION
`project.multitrack` bounded its per-sample step at 0.1, on the reasoning written beside it: "A limiter's job is to not step: it is the one device here whose output is bounded by construction."

A limiter bounds amplitude, not slope. This project's top tone is 1318 Hz, and at the full scale the limiter delivers, one sine that fast steps 0.1875 between samples on its own. The bound sat below what the material can physically do, so it could never pass. Both legs failed it, native at 0.172 and the incumbent at 0.219, which is the tell: two independently written engines do not share a bug, they share a threshold that is wrong.

`fullScaleStepOf` reads the bound off the fixture's own tones instead of taking a hand-picked number, so it cannot be set under the material again. The headroom multiplier carries twenty-three tones summing above the steepest single one.

`project.hostedinstrument` keeps its hand-set 0.1. It is a piano, it decays, and it has no tone sources to read a bound off.

Found while running `magda_juce_tests` against the clang-tidy batches, which turned out never to have been run for them. This failure predates every branch in flight: it reproduces with `magda/` reverted to `dev/0.20.0`. It is also invisible in CI, which has no Pro-L 2 installed and skips the case.

## Verification

Full JUCE suite green except `project.retrospect`, which is the unrelated engine parity gap filed as #2485.
