### PR TITLE
Construct in place, take large parameters by reference

### DIFF
--- a/magda/agents/agent_runtime.cpp
+++ b/magda/agents/agent_runtime.cpp
@@ -50,7 +50,7 @@ AgentRuntime::AgentRuntime(Model& model, ToolExecutor& executor, ApprovalHook ap
       fastInferencePolicy_(fastInferencePolicy) {}
 
 RunResult AgentRuntime::run(const AgentDefinition& definition, AgentRunInput input,
-                            CancellationToken cancellation) {
+                            const CancellationToken& cancellation) {
     RunResult result;
     result.state = RunState::Running;
     result.finalRevision = input.projectRevision;

--- a/magda/agents/agent_runtime.hpp
+++ b/magda/agents/agent_runtime.hpp
@@ -211,7 +211,7 @@ class AgentRuntime {
                  Now now = Clock::now, FastInferencePolicy* fastInferencePolicy = nullptr);
 
     RunResult run(const AgentDefinition& definition, AgentRunInput input,
-                  CancellationToken cancellation = {});
+                  const CancellationToken& cancellation = {});
 
   private:
     Model& model_;

--- a/magda/agents/automation_parser.cpp
+++ b/magda/agents/automation_parser.cpp
@@ -195,7 +195,7 @@ std::vector<AutoInstruction> AutomationParser::parse(const juce::String& text) {
             return {};
         }
 
-        auto shapeStr = tokens[1];
+        const auto& shapeStr = tokens[1];
 
         AutoClipAction clipAction;
         if (parseClipAction(shapeStr, clipAction)) {

--- a/magda/agents/command_model.cpp
+++ b/magda/agents/command_model.cpp
@@ -535,6 +535,7 @@ int subseq(const std::vector<std::string>& lower, const std::vector<std::string>
 
 std::string renameTargetFromTokens(const std::vector<std::string>& tokens) {
     std::vector<std::string> lower;
+    lower.reserve(tokens.size());
     for (const auto& t : tokens)
         lower.push_back(toLower(t));
     static const std::vector<std::vector<std::string>> phrases = {
@@ -901,6 +902,7 @@ std::string CommandModel::renderPrediction(const Prediction& p) {
             groupName = "Group";
         int anchor = ids.empty() ? 0 : ids[0];
         std::vector<std::string> idStrs;
+        idStrs.reserve(ids.size());
         for (int x : ids)
             idStrs.push_back(std::to_string(x));
         lines.push_back("track(id=" + std::to_string(anchor) + ").track.group(name=" +
@@ -1000,7 +1002,7 @@ std::string CommandModel::renderPrediction(const Prediction& p) {
         lines.push_back("groove.set(template=" + q(tmpl) +
                         ", strength=" + fmtG(valueOrFirstNumber(s, tokens)) + ")");
     } else if (intent == "groove_list") {
-        lines.push_back("groove.list()");
+        lines.emplace_back("groove.list()");
     } else {
         return "";  // unknown intent
     }

--- a/magda/agents/command_model_downloader.cpp
+++ b/magda/agents/command_model_downloader.cpp
@@ -174,7 +174,7 @@ class CommandModelDownloader::Worker : public juce::Thread {
         return true;
     }
 
-    void postProgress(Progress p) {
+    void postProgress(const Progress& p) {
         if (!onProgress_)
             return;
         auto cb = onProgress_;

--- a/magda/agents/compact_parser.cpp
+++ b/magda/agents/compact_parser.cpp
@@ -54,7 +54,7 @@ bool parseGridLine(const juce::String& line, std::vector<Instruction>& out,
 
         const double step = kBarBeats / static_cast<double>(cells.size());
         for (int i = 0; i < cells.size(); ++i) {
-            const auto cell = cells[i];
+            const auto& cell = cells[i];
             if (cell == ".")
                 continue;
             HitOp h;
@@ -206,7 +206,7 @@ std::vector<Instruction> CompactParser::parse(const juce::String& compact) {
                 kvStart = 2;
             }
             for (int i = kvStart; i < parts.size(); ++i) {
-                auto kv = parts[i];
+                const auto& kv = parts[i];
                 auto eqIdx = kv.indexOfChar('=');
                 if (eqIdx > 0)
                     payload.props.set(kv.substring(0, eqIdx), kv.substring(eqIdx + 1));

--- a/magda/agents/console_agent_orchestrator.cpp
+++ b/magda/agents/console_agent_orchestrator.cpp
@@ -149,8 +149,8 @@ ConsoleAgentOrchestrator::ConsoleAgentOrchestrator(Workflows workflows)
     : workflows_(std::move(workflows)) {}
 
 ConsoleRunOutput ConsoleAgentOrchestrator::run(const ConsoleRunRequest& request,
-                                               ConsoleRunObserver observer,
-                                               CancellationToken cancellation) {
+                                               const ConsoleRunObserver& observer,
+                                               const CancellationToken& cancellation) {
     const CancellationToken combined([this, cancellation] {
         return cancelled_.load() || cancellation.isCancellationRequested();
     });

--- a/magda/agents/console_agent_orchestrator.hpp
+++ b/magda/agents/console_agent_orchestrator.hpp
@@ -86,8 +86,8 @@ class ConsoleAgentOrchestrator {
                              DrummerAgent& drummer);
     explicit ConsoleAgentOrchestrator(Workflows workflows);
 
-    ConsoleRunOutput run(const ConsoleRunRequest& request, ConsoleRunObserver observer = {},
-                         CancellationToken cancellation = {});
+    ConsoleRunOutput run(const ConsoleRunRequest& request, const ConsoleRunObserver& observer = {},
+                         const CancellationToken& cancellation = {});
 
     void cancel();
     void resetCancellation();

--- a/magda/agents/dsl_interpreter.cpp
+++ b/magda/agents/dsl_interpreter.cpp
@@ -2642,6 +2642,7 @@ bool Interpreter::executeSetVelocity(const Params& params) {
     const auto& noteSelIndices = sm.getNoteSelectionIndices();
 
     std::vector<std::pair<size_t, int>> noteVelocities;
+    noteVelocities.reserve(noteSelIndices.size());
     for (auto idx : noteSelIndices)
         noteVelocities.emplace_back(idx, velocity);
 
@@ -2700,6 +2701,7 @@ bool Interpreter::executeResizeNotes(const Params& params) {
     const auto& noteSelIndices = sm.getNoteSelectionIndices();
 
     std::vector<std::pair<size_t, double>> noteLengths;
+    noteLengths.reserve(noteSelIndices.size());
     for (auto idx : noteSelIndices)
         noteLengths.emplace_back(idx, length);
 

--- a/magda/agents/dsl_interpreter.hpp
+++ b/magda/agents/dsl_interpreter.hpp
@@ -4,6 +4,7 @@
 
 #include <map>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "../daw/core/ClipTypes.hpp"
@@ -49,8 +50,8 @@ struct Token {
     int col;
 
     Token() : type(TokenType::END_OF_INPUT), line(0), col(0) {}
-    Token(TokenType t, const std::string& v, int l = 0, int c = 0)
-        : type(t), value(v), line(l), col(c) {}
+    Token(TokenType t, std::string v, int l = 0, int c = 0)
+        : type(t), value(std::move(v)), line(l), col(c) {}
 
     bool is(TokenType t) const {
         return type == t;

--- a/magda/agents/faust_agent.cpp
+++ b/magda/agents/faust_agent.cpp
@@ -471,8 +471,8 @@ FaustAgent::Result FaustAgent::runConversational(const std::string& message,
         if (compileCheck(result.name, result.source, compileErr, verified)) {
             // Success — commit the clean turns (original prompt + working reply)
             // to the persistent conversation and chain off the good response.
-            conversation.messages.push_back({"user", originalPrompt});
-            conversation.messages.push_back({"assistant", response.text.trim()});
+            conversation.messages.emplace_back("user", originalPrompt);
+            conversation.messages.emplace_back("assistant", response.text.trim());
             conversation.lastResponseId = working.lastResponseId;
             result.mcpVerified = verified;
             logFaustAgentResult(result);

--- a/magda/agents/llama_model_manager.cpp
+++ b/magda/agents/llama_model_manager.cpp
@@ -155,7 +155,7 @@ std::string LlamaModelManager::applyTemplate(const std::string& systemPrompt,
 }
 
 LlamaModelManager::InferenceResult LlamaModelManager::infer(const InferenceRequest& req,
-                                                            TokenCallback onToken) {
+                                                            const TokenCallback& onToken) {
     std::scoped_lock lock(mutex_);
     InferenceResult result;
 

--- a/magda/agents/llama_model_manager.hpp
+++ b/magda/agents/llama_model_manager.hpp
@@ -50,7 +50,7 @@ class LlamaModelManager {
 
     using TokenCallback = std::function<bool(const std::string& token)>;
 
-    InferenceResult infer(const InferenceRequest& req, TokenCallback onToken = nullptr);
+    InferenceResult infer(const InferenceRequest& req, const TokenCallback& onToken = nullptr);
 
   private:
 #ifdef MAGDA_ENABLE_TEST_HOOKS

--- a/magda/agents/mcp/MCPClient.cpp
+++ b/magda/agents/mcp/MCPClient.cpp
@@ -11,12 +11,13 @@
     #include <unistd.h>
 
     #include <cerrno>
+    #include <utility>
 #endif
 
 namespace magda {
 
-MCPClient::MCPClient(const juce::String& command, const juce::StringArray& args)
-    : command_(command), args_(args) {}
+MCPClient::MCPClient(juce::String command, juce::StringArray args)
+    : command_(std::move(command)), args_(std::move(args)) {}
 
 MCPClient::~MCPClient() {
     stop();
@@ -70,6 +71,7 @@ bool MCPClient::start() {
             argStrings.push_back(a.toStdString());
 
         std::vector<char*> argv;
+        argv.reserve(argStrings.size());
         for (auto& s : argStrings)
             argv.push_back(s.data());
         argv.push_back(nullptr);

--- a/magda/agents/mcp/MCPClient.hpp
+++ b/magda/agents/mcp/MCPClient.hpp
@@ -8,7 +8,7 @@ namespace magda {
 
 class MCPClient {
   public:
-    MCPClient(const juce::String& command, const juce::StringArray& args);
+    MCPClient(juce::String command, juce::StringArray args);
     ~MCPClient();
 
     MCPClient(const MCPClient&) = delete;

--- a/magda/agents/model_downloader.cpp
+++ b/magda/agents/model_downloader.cpp
@@ -44,7 +44,7 @@ void ModelDownloader::startDownload(const juce::String& url, const juce::File& t
             .withResponseHeaders(&responseHeaders));
     if (probeStream) {
         // Content-Range: bytes 0-0/<total>
-        auto contentRange = responseHeaders["Content-Range"];
+        const auto& contentRange = responseHeaders["Content-Range"];
         if (contentRange.contains("/")) {
             auto totalStr = contentRange.fromLastOccurrenceOf("/", false, false).trim();
             auto parsed = totalStr.getLargeIntValue();

--- a/magda/daw/api/remote_api.cpp
+++ b/magda/daw/api/remote_api.cpp
@@ -807,7 +807,7 @@ int readInt(const juce::var& object, const char* property) {
 
 template <typename Id>
 std::optional<Id> readNullableId(const juce::var& object, const char* property) {
-    const auto value = object[property];
+    const auto& value = object[property];
     if (value.isVoid())
         return std::nullopt;
     return decodeBoundedInt<Id>(value);
@@ -1464,9 +1464,9 @@ std::optional<AutomationLaneDto> automationLaneFromJson(const juce::var& json, E
     dto.id = readInt(json, "id");
     dto.type = json["type"].toString();
     dto.name = json["name"].toString();
-    const auto target = json["target"];
+    const auto& target = json["target"];
     dto.target.kind = target["kind"].toString();
-    if (const auto path = target["devicePath"]; path.isObject())
+    if (const auto& path = target["devicePath"]; path.isObject())
         dto.target.devicePath = devicePathFromJson(path);
     dto.target.parameterIndex = readInt(target, "parameterIndex");
     dto.target.modId = readInt(target, "modId");

--- a/magda/daw/api/remote_handlers.cpp
+++ b/magda/daw/api/remote_handlers.cpp
@@ -174,7 +174,7 @@ std::optional<AutomationTarget> toAutomationTarget(const juce::var& json) {
     // Edit-scoped kinds (tempo) carry no path — the schema permits null there.
     // For everything else the path must resolve, or the target would name a
     // device that does not exist and the lane would be created against nothing.
-    if (const auto path = json["devicePath"]; path.isObject()) {
+    if (const auto& path = json["devicePath"]; path.isObject()) {
         const auto resolved = toChainNodePath(devicePathFromJson(path));
         if (!resolved)
             return std::nullopt;
@@ -503,7 +503,7 @@ HandlerResult devicesAdd(MagdaApi& api, const juce::var& input, const RequestCon
         return HandlerResult::fail(ErrorCode::NotFound, "no catalogue entry " + catalogId);
 
     ChainNodePath parent;
-    if (const auto parentPath = input["parentPath"]; parentPath.isObject()) {
+    if (const auto& parentPath = input["parentPath"]; parentPath.isObject()) {
         const auto resolved = toChainNodePath(devicePathFromJson(parentPath));
         if (!resolved)
             return HandlerResult::fail(ErrorCode::ValidationFailed, "parentPath does not resolve");
@@ -1294,7 +1294,7 @@ HandlerResult tracksMove(MagdaApi& api, const juce::var& input, const RequestCon
 HandlerResult groovesList(MagdaApi& api, const juce::var&, const RequestContext&) {
     std::vector<juce::var> items;
     for (const auto& name : api.grooves().getTemplateNames())
-        items.push_back(name);
+        items.emplace_back(name);
     return HandlerResult::ok(toJsonArray(items));
 }
 
@@ -1377,7 +1377,7 @@ std::vector<juce::uint8> readByteArray(const juce::var& value) {
 HandlerResult midiListOutputPorts(MagdaApi& api, const juce::var&, const RequestContext&) {
     std::vector<juce::var> items;
     for (const auto& name : api.midi().getOutputPortNames())
-        items.push_back(name);
+        items.emplace_back(name);
     return HandlerResult::ok(toJsonArray(items));
 }
 

--- a/magda/daw/api/remote_mcp.cpp
+++ b/magda/daw/api/remote_mcp.cpp
@@ -494,7 +494,7 @@ bool McpEndpoint::ListenFilter::wantsAnything() const {
 
 McpEndpoint::ListenFilter McpEndpoint::parseListenFilter(const juce::var& params) const {
     ListenFilter filter;
-    const auto notifications = params["notifications"];
+    const auto& notifications = params["notifications"];
     if (notifications.getDynamicObject() == nullptr)
         return filter;
 
@@ -738,7 +738,7 @@ void McpEndpoint::handle(const Call& call, Completion onComplete) {
         McpReply::fail(MCP_METHOD_NOT_FOUND, "Unknown method: " + call.method, modern ? 404 : 200));
 }
 
-void McpEndpoint::callTool(const Call& call, Completion onComplete) {
+void McpEndpoint::callTool(const Call& call, const Completion& onComplete) {
     const auto nameValue = call.params["name"];
     if (!nameValue.isString() || nameValue.toString().isEmpty()) {
         onComplete(McpReply::fail(MCP_INVALID_PARAMS, "tools/call requires a string params.name"));
@@ -776,7 +776,8 @@ void McpEndpoint::callTool(const Call& call, Completion onComplete) {
     const auto wrapResult = hasArrayOutput(*operation);
 
     service_.dispatch(
-        name, arguments, *context, [onComplete, modern, info, wrapResult](Response response) {
+        name, arguments, *context,
+        [onComplete, modern, info, wrapResult](const Response& response) {
             auto result = makeObject();
             if (modern)
                 setProperty(result, "resultType", "complete");
@@ -826,7 +827,7 @@ void McpEndpoint::callTool(const Call& call, Completion onComplete) {
         });
 }
 
-void McpEndpoint::readResource(const Call& call, Completion onComplete) {
+void McpEndpoint::readResource(const Call& call, const Completion& onComplete) {
     const auto uriValue = call.params["uri"];
     if (!uriValue.isString() || uriValue.toString().isEmpty()) {
         onComplete(
@@ -855,7 +856,7 @@ void McpEndpoint::readResource(const Call& call, Completion onComplete) {
 
     service_.dispatch(
         resolved->operation, resolved->input, *context,
-        [onComplete, uri, modern, info](Response response) {
+        [onComplete, uri, modern, info](const Response& response) {
             if (!response.ok) {
                 // A read has no `isError` channel, so a failure is
                 // a JSON-RPC error whatever caused it. The MAGDA
@@ -905,7 +906,7 @@ std::optional<RequestContext> McpEndpoint::requestContext(const Call& call, McpE
     if (meta.getDynamicObject() == nullptr)
         return context;
 
-    if (const auto expected = meta[MAGDA_META_EXPECTED_REVISION]; !expected.isVoid()) {
+    if (const auto& expected = meta[MAGDA_META_EXPECTED_REVISION]; !expected.isVoid()) {
         const auto revision = jsonInteger(expected, 0, std::numeric_limits<juce::int64>::max());
         if (!revision) {
             error = McpError{MCP_INVALID_PARAMS,
@@ -931,7 +932,7 @@ std::optional<RequestContext> McpEndpoint::requestContext(const Call& call, McpE
     // So a client that wants retry safety supplies its own key and is
     // responsible for its uniqueness (a UUID). The `mcp:` prefix keeps this
     // namespace clear of the WebSocket's in the shared cache.
-    if (const auto requestId = meta[MAGDA_META_REQUEST_ID]; !requestId.isVoid()) {
+    if (const auto& requestId = meta[MAGDA_META_REQUEST_ID]; !requestId.isVoid()) {
         if (!requestId.isString() || requestId.toString().isEmpty()) {
             error = McpError{MCP_INVALID_PARAMS,
                              juce::String(MAGDA_META_REQUEST_ID) + " must be a non-empty string",

--- a/magda/daw/api/remote_mcp.hpp
+++ b/magda/daw/api/remote_mcp.hpp
@@ -380,8 +380,8 @@ class McpEndpoint {
     }
 
   private:
-    void callTool(const Call& call, Completion onComplete);
-    void readResource(const Call& call, Completion onComplete);
+    void callTool(const Call& call, const Completion& onComplete);
+    void readResource(const Call& call, const Completion& onComplete);
 
     /// Build the dispatcher context from `_meta`. Nullopt when a field is
     /// present but unusable, which is a client error rather than a default to

--- a/magda/daw/api/remote_mcp_server.cpp
+++ b/magda/daw/api/remote_mcp_server.cpp
@@ -713,7 +713,7 @@ struct RemoteMcpServer::Impl {
         setProperty(params, "snapshot", false);
 
         subscriptions->handle(stream->subscriber, "subscriptions.subscribe", params,
-                              [](Response) {});
+                              [](const Response&) {});
     }
 
     /// Replace what a stream watches. The legacy era needs this because
@@ -726,7 +726,7 @@ struct RemoteMcpServer::Impl {
         // topic, so this converges on the new set whether the change added or
         // removed a resource — no diff to compute and none to get wrong.
         subscriptions->handle(stream->subscriber, "subscriptions.unsubscribe", makeObject(),
-                              [](Response) {});
+                              [](const Response&) {});
         subscribeStream(stream);
     }
 
@@ -826,7 +826,7 @@ struct RemoteMcpServer::Impl {
      * Refusing would break every conforming host that simply does not send it.
      */
     static juce::String modernClientName(const juce::var& params) {
-        const auto meta = params["_meta"];
+        const auto& meta = params["_meta"];
         if (meta.getDynamicObject() == nullptr)
             return normaliseClientName({});
         return normaliseClientName(meta[MCP_META_CLIENT_INFO]["name"].toString());
@@ -843,7 +843,7 @@ struct RemoteMcpServer::Impl {
      */
     std::optional<McpError> resolveEra(const httplib::Request& request, const juce::String& method,
                                        const juce::var& params, Resolution& resolution) {
-        const auto meta = params["_meta"];
+        const auto& meta = params["_meta"];
         const auto declared = meta.getDynamicObject() != nullptr
                                   ? meta[MCP_META_PROTOCOL_VERSION].toString()
                                   : juce::String();
@@ -971,7 +971,7 @@ struct RemoteMcpServer::Impl {
     /// The `_meta` fields a modern request must carry. `clientInfo` is optional
     /// and, being self-reported, is never read for anything but logging.
     static std::optional<McpError> validateModernMeta(const juce::var& params) {
-        const auto meta = params["_meta"];
+        const auto& meta = params["_meta"];
         if (meta[MCP_META_CLIENT_CAPABILITIES].getDynamicObject() == nullptr) {
             return McpError{MCP_INVALID_PARAMS,
                             juce::String(MCP_META_CLIENT_CAPABILITIES) +

--- a/magda/daw/api/remote_subscriptions.cpp
+++ b/magda/daw/api/remote_subscriptions.cpp
@@ -937,7 +937,7 @@ Response SubscriptionHub::execute(ClientId client, const juce::String& method,
             // continuity would need a second, per-topic cursor on the wire, and
             // being wrong about it leaves a client silently stale, which is the
             // failure this whole design is meant to make impossible.
-            const auto wanted = params["snapshot"];
+            const auto& wanted = params["snapshot"];
             const bool asked = wanted.isVoid() || static_cast<bool>(wanted);
 
             if (asked)

--- a/magda/daw/api/remote_websocket_server.cpp
+++ b/magda/daw/api/remote_websocket_server.cpp
@@ -754,7 +754,7 @@ struct RemoteWebSocketServer::Impl {
             // connections are live. Everything else it needs is copied.
             subscriptions->handle(
                 connection->subscriber, method, params,
-                [log = options.audit, connection, id, method, idKey](Response response) {
+                [log = options.audit, connection, id, method, idKey](const Response& response) {
                     recordAudit(log, connection, method, idKey,
                                 response.ok ? AuditOutcome::Ok : AuditOutcome::Failed,
                                 response.ok ? juce::String() : toString(response.error.code));
@@ -774,7 +774,7 @@ struct RemoteWebSocketServer::Impl {
         const auto meta = parsed["meta"];
         auto deadlineMs = options.defaultDeadlineMs;
         if (meta.getDynamicObject() != nullptr) {
-            if (const auto key = meta["idempotencyKey"]; !key.isVoid()) {
+            if (const auto& key = meta["idempotencyKey"]; !key.isVoid()) {
                 if (!key.isString() || key.toString().isEmpty() || key.toString().length() > 256) {
                     refuse(connection, id, kInvalidRequest,
                            "meta.idempotencyKey must be a non-empty string of at most 256 "
@@ -785,7 +785,7 @@ struct RemoteWebSocketServer::Impl {
                 // reused and therefore cannot safely double as retry keys.
                 context.requestId = key.toString();
             }
-            if (const auto expected = meta["expectedRevision"]; !expected.isVoid()) {
+            if (const auto& expected = meta["expectedRevision"]; !expected.isVoid()) {
                 const auto revision =
                     jsonInteger(expected, 0, std::numeric_limits<juce::int64>::max());
                 if (!revision.has_value()) {
@@ -800,7 +800,7 @@ struct RemoteWebSocketServer::Impl {
             // more — and never for none. Taking the minimum without checking the
             // sign lets -1 win it, after which a non-positive deadline is read as
             // "no deadline" and the request outlives every bound there is.
-            if (const auto requested = meta["deadlineMs"]; !requested.isVoid()) {
+            if (const auto& requested = meta["deadlineMs"]; !requested.isVoid()) {
                 const auto milliseconds =
                     jsonInteger(requested, 1, std::numeric_limits<int>::max());
                 if (!milliseconds.has_value()) {
@@ -813,7 +813,7 @@ struct RemoteWebSocketServer::Impl {
         }
         context.deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(deadlineMs);
 
-        service.dispatch(method, params, context, [connection, id](Response response) {
+        service.dispatch(method, params, context, [connection, id](const Response& response) {
             connection->complete(replyFor(id, response));
         });
     }

--- a/magda/daw/audio/AudioBridge.cpp
+++ b/magda/daw/audio/AudioBridge.cpp
@@ -851,7 +851,7 @@ DeviceProcessor* AudioBridge::getDeviceProcessor(const ChainNodePath& devicePath
 }
 
 namespace {
-te::ExternalPlugin* asExternalPlugin(te::Plugin::Ptr plugin) {
+te::ExternalPlugin* asExternalPlugin(const te::Plugin::Ptr& plugin) {
     return dynamic_cast<te::ExternalPlugin*>(plugin.get());
 }
 

--- a/magda/daw/audio/AudioThumbnailManager.cpp
+++ b/magda/daw/audio/AudioThumbnailManager.cpp
@@ -196,7 +196,7 @@ void AudioThumbnailManager::cacheBPM(const juce::String& filePath, double bpm) {
 }
 
 void AudioThumbnailManager::requestBPMDetection(const juce::String& filePath,
-                                                std::function<void(double)> onComplete) {
+                                                const std::function<void(double)>& onComplete) {
     // Caches are message-thread only (no locks).
     JUCE_ASSERT_MESSAGE_THREAD;
 

--- a/magda/daw/audio/AudioThumbnailManager.hpp
+++ b/magda/daw/audio/AudioThumbnailManager.hpp
@@ -115,7 +115,8 @@ class AudioThumbnailManager {
      *
      * Must be called from the message thread.
      */
-    void requestBPMDetection(const juce::String& filePath, std::function<void(double)> onComplete);
+    void requestBPMDetection(const juce::String& filePath,
+                             const std::function<void(double)>& onComplete);
 
     /**
      * @brief Get cached transient times for an audio file

--- a/magda/daw/audio/ClipCommands.cpp
+++ b/magda/daw/audio/ClipCommands.cpp
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include <array>
 #include <limits>
+#include <utility>
 
 #include "../engine/AudioEngine.hpp"
 #include "../project/ProjectManager.hpp"
@@ -636,13 +637,13 @@ bool DeleteClipCommand::validateState() const {
 // ============================================================================
 
 CreateClipCommand::CreateClipCommand(ClipType type, TrackId trackId, BeatPosition startBeat,
-                                     BeatDuration lengthBeats, const juce::String& audioFilePath,
+                                     BeatDuration lengthBeats, juce::String audioFilePath,
                                      ClipView view, double tempo, ClipOverlapPolicy overlapPolicy)
     : type_(type),
       trackId_(trackId),
       startBeat_(startBeat.value),
       lengthBeats_(lengthBeats.value),
-      audioFilePath_(audioFilePath),
+      audioFilePath_(std::move(audioFilePath)),
       view_(view),
       tempo_(tempo),
       overlapPolicy_(overlapPolicy) {}
@@ -1081,8 +1082,8 @@ bool JoinClipsCommand::validateState() const {
 // StretchClipCommand
 // ============================================================================
 
-StretchClipCommand::StretchClipCommand(ClipId clipId, const ClipInfo& beforeState)
-    : clipId_(clipId), beforeState_(beforeState) {}
+StretchClipCommand::StretchClipCommand(ClipId clipId, ClipInfo beforeState)
+    : clipId_(clipId), beforeState_(std::move(beforeState)) {}
 
 void StretchClipCommand::execute() {
     auto& clipManager = ClipManager::getInstance();
@@ -1113,8 +1114,8 @@ void StretchClipCommand::undo() {
 // SetFadeCommand
 // ============================================================================
 
-SetFadeCommand::SetFadeCommand(ClipId clipId, const ClipInfo& beforeState)
-    : clipId_(clipId), beforeState_(beforeState) {}
+SetFadeCommand::SetFadeCommand(ClipId clipId, ClipInfo beforeState)
+    : clipId_(clipId), beforeState_(std::move(beforeState)) {}
 
 void SetFadeCommand::execute() {
     auto& clipManager = ClipManager::getInstance();
@@ -1180,8 +1181,8 @@ void SetCrossfadeCommand::undo() {
 // SetVolumeCommand
 // ============================================================================
 
-SetVolumeCommand::SetVolumeCommand(ClipId clipId, const ClipInfo& beforeState)
-    : clipId_(clipId), beforeState_(beforeState) {}
+SetVolumeCommand::SetVolumeCommand(ClipId clipId, ClipInfo beforeState)
+    : clipId_(clipId), beforeState_(std::move(beforeState)) {}
 
 void SetVolumeCommand::execute() {
     auto& clipManager = ClipManager::getInstance();

--- a/magda/daw/audio/PluginWindowBridge.cpp
+++ b/magda/daw/audio/PluginWindowBridge.cpp
@@ -4,26 +4,26 @@
 
 namespace magda {
 
-void PluginWindowBridge::showPluginWindow(DeviceId deviceId, te::Plugin::Ptr plugin) {
+void PluginWindowBridge::showPluginWindow(DeviceId deviceId, const te::Plugin::Ptr& plugin) {
     if (windowManager_ && plugin) {
         windowManager_->showPluginWindow(deviceId, plugin);
     }
 }
 
-void PluginWindowBridge::hidePluginWindow(DeviceId deviceId, te::Plugin::Ptr plugin) {
+void PluginWindowBridge::hidePluginWindow(DeviceId deviceId, const te::Plugin::Ptr& plugin) {
     if (windowManager_ && plugin) {
         windowManager_->hidePluginWindow(deviceId, plugin);
     }
 }
 
-bool PluginWindowBridge::isPluginWindowOpen(te::Plugin::Ptr plugin) const {
+bool PluginWindowBridge::isPluginWindowOpen(const te::Plugin::Ptr& plugin) const {
     if (windowManager_ && plugin) {
         return windowManager_->isPluginWindowOpen(plugin);
     }
     return false;
 }
 
-bool PluginWindowBridge::togglePluginWindow(DeviceId deviceId, te::Plugin::Ptr plugin) {
+bool PluginWindowBridge::togglePluginWindow(DeviceId deviceId, const te::Plugin::Ptr& plugin) {
     if (windowManager_ && plugin) {
         return windowManager_->togglePluginWindow(deviceId, plugin);
     }

--- a/magda/daw/audio/PluginWindowBridge.hpp
+++ b/magda/daw/audio/PluginWindowBridge.hpp
@@ -41,21 +41,21 @@ class PluginWindowBridge {
      * @param plugin The Tracktion plugin
      * @param deviceId MAGDA device ID of the plugin
      */
-    void showPluginWindow(DeviceId deviceId, te::Plugin::Ptr plugin);
+    void showPluginWindow(DeviceId deviceId, const te::Plugin::Ptr& plugin);
 
     /**
      * @brief Hide/close the plugin's native editor window
      * @param plugin The Tracktion plugin
      * @param deviceId MAGDA device ID of the plugin
      */
-    void hidePluginWindow(DeviceId deviceId, te::Plugin::Ptr plugin);
+    void hidePluginWindow(DeviceId deviceId, const te::Plugin::Ptr& plugin);
 
     /**
      * @brief Check if a plugin window is currently open
      * @param plugin The Tracktion plugin
      * @return true if the plugin window is visible
      */
-    bool isPluginWindowOpen(te::Plugin::Ptr plugin) const;
+    bool isPluginWindowOpen(const te::Plugin::Ptr& plugin) const;
 
     /**
      * @brief Toggle the plugin's native editor window (open if closed, close if open)
@@ -63,7 +63,7 @@ class PluginWindowBridge {
      * @param deviceId MAGDA device ID of the plugin
      * @return true if the window is now open, false if now closed
      */
-    bool togglePluginWindow(DeviceId deviceId, te::Plugin::Ptr plugin);
+    bool togglePluginWindow(DeviceId deviceId, const te::Plugin::Ptr& plugin);
 
     /**
      * @brief Close all windows for a specific device

--- a/magda/daw/audio/TrackController.cpp
+++ b/magda/daw/audio/TrackController.cpp
@@ -586,7 +586,7 @@ void TrackController::clearAllMappings() {
 }
 
 void TrackController::withTrackMapping(
-    std::function<void(const std::map<TrackId, te::AudioTrack*>&)> callback) const {
+    const std::function<void(const std::map<TrackId, te::AudioTrack*>&)>& callback) const {
     juce::ScopedLock lock(trackLock_);
     callback(trackMapping_);
 }
@@ -629,7 +629,7 @@ void TrackController::removeMeterClient(TrackId trackId) {
 }
 
 void TrackController::withMeterClients(
-    std::function<void(std::map<TrackId, MeterClientEntry>&)> callback) {
+    const std::function<void(std::map<TrackId, MeterClientEntry>&)>& callback) {
     juce::ScopedLock lock(trackLock_);
     callback(meterClients_);
 }

--- a/magda/daw/audio/TrackController.hpp
+++ b/magda/daw/audio/TrackController.hpp
@@ -187,7 +187,7 @@ class TrackController {
      * Usage: trackController.withTrackMapping([&](const auto& mapping) { ... });
      */
     void withTrackMapping(
-        std::function<void(const std::map<TrackId, te::AudioTrack*>&)> callback) const;
+        const std::function<void(const std::map<TrackId, te::AudioTrack*>&)>& callback) const;
 
     // =========================================================================
     // Metering Coordination (for PluginManager)
@@ -220,7 +220,8 @@ class TrackController {
      * Used by AudioBridge for meter updates in timer thread.
      * Provides mutable access so callers can call getAndClearAudioLevel().
      */
-    void withMeterClients(std::function<void(std::map<TrackId, MeterClientEntry>&)> callback);
+    void withMeterClients(
+        const std::function<void(std::map<TrackId, MeterClientEntry>&)>& callback);
 
   private:
     // References to Tracktion Engine (not owned)

--- a/magda/daw/audio/controllers/ControllerRouter.cpp
+++ b/magda/daw/audio/controllers/ControllerRouter.cpp
@@ -321,7 +321,7 @@ void ControllerRouter::scheduleWrite(const BindingId& bindingId, int rawValue, i
         return;
 
     auto pwShared = pwIt->second;
-    Binding bindingCopy = binding;
+    const Binding& bindingCopy = binding;
 
     // If we're already on the message thread (or no message manager -- test context),
     // execute synchronously to avoid deadlock and allow tests to run without a

--- a/magda/daw/audio/midi/MidiInputRouter.cpp
+++ b/magda/daw/audio/midi/MidiInputRouter.cpp
@@ -337,7 +337,7 @@ void MidiInputRouter::setTrackMidiInput(TrackId trackId, const juce::String& mid
 
     auto* playbackContext = edit_.getCurrentPlaybackContext();
     if (!playbackContext) {
-        pendingMidiRoutes_.push_back({trackId, midiDeviceId});
+        pendingMidiRoutes_.emplace_back(trackId, midiDeviceId);
         return;
     }
 

--- a/magda/daw/audio/plugin_manager/PluginManager.cpp
+++ b/magda/daw/audio/plugin_manager/PluginManager.cpp
@@ -317,7 +317,8 @@ void PluginManager::ensureMidiReceive(const ChainNodePath& devicePath, TrackId s
         return plugin;
     };
 
-    auto configureSidechainDependency = [&](te::Plugin::Ptr plugin, TrackId midiSourceTrackId) {
+    auto configureSidechainDependency = [&](const te::Plugin::Ptr& plugin,
+                                            TrackId midiSourceTrackId) {
         if (!plugin || midiSourceTrackId == trackId)
             return;
 
@@ -572,7 +573,8 @@ void PluginManager::detachRackRuntimeForChainMove(RackId rackId) {
     rackSyncManager_.removeRackForMove(rackId);
 }
 
-void PluginManager::restorePluginState(const ChainNodePath& devicePath, te::Plugin::Ptr plugin) {
+void PluginManager::restorePluginState(const ChainNodePath& devicePath,
+                                       const te::Plugin::Ptr& plugin) {
     auto& tm = TrackManager::getInstance();
     auto* devInfo = tm.getDeviceInChainByPath(devicePath);
     if (!devInfo || devInfo->pluginState.isEmpty()) {

--- a/magda/daw/audio/plugin_manager/PluginManager.hpp
+++ b/magda/daw/audio/plugin_manager/PluginManager.hpp
@@ -257,7 +257,7 @@ class PluginManager : public daw::audio::DrumGridPlugin::Listener,
     /// by path. A pad device is reached through the Drum Grid that owns it: its
     /// path's rack component is a DeviceId, which a Rack step cannot tell from
     /// a rack of the same number (#2207).
-    void registerRackPluginProcessor(const ChainNodePath& devicePath, te::Plugin::Ptr plugin,
+    void registerRackPluginProcessor(const ChainNodePath& devicePath, const te::Plugin::Ptr& plugin,
                                      const DeviceInfo& device, DeviceInfo* canonical);
 
     /// The model's device for a pad plugin path, through @p drumGridPath.
@@ -333,7 +333,7 @@ class PluginManager : public daw::audio::DrumGridPlugin::Listener,
      * @param devicePath The device whose state to restore
      * @param plugin The TE plugin to apply state to
      */
-    static void restorePluginState(const ChainNodePath& devicePath, te::Plugin::Ptr plugin);
+    static void restorePluginState(const ChainNodePath& devicePath, const te::Plugin::Ptr& plugin);
 
     // =========================================================================
     // Utilities
@@ -661,7 +661,7 @@ class PluginManager : public daw::audio::DrumGridPlugin::Listener,
     bool isDrumGridPadPathLocked(const ChainNodePath& devicePath) const;
 
     // Poll for async plugin load completion (TE's background thread instantiation)
-    void pollAsyncPluginLoad(const ChainNodePath& devicePath, te::Plugin::Ptr plugin);
+    void pollAsyncPluginLoad(const ChainNodePath& devicePath, const te::Plugin::Ptr& plugin);
 
     // Create a TE internal plugin, restoring saved ValueTree state if available.
     // Falls back to creating a fresh plugin from xmlTypeName when no saved state exists.

--- a/magda/daw/audio/plugin_manager/PluginManagerSync.cpp
+++ b/magda/daw/audio/plugin_manager/PluginManagerSync.cpp
@@ -2,6 +2,7 @@
 #include <map>
 #include <set>
 #include <unordered_set>
+#include <utility>
 #include <vector>
 
 #include "../../core/ChainRoutingModel.hpp"
@@ -539,7 +540,7 @@ void PluginManager::syncTrackPlugins(TrackId trackId) {
 
     // Delete plugins outside lock to avoid blocking other threads
     for (size_t i = 0; i < toRemove.size(); ++i) {
-        const auto devicePath = toRemove[i];
+        const auto& devicePath = toRemove[i];
         const auto deviceId = devicePath.getDeviceId();
         pluginWindowBridge_.closeWindowsForDevice(deviceId);
 
@@ -1243,7 +1244,8 @@ te::Plugin::Ptr PluginManager::addLevelMeterToTrack(TrackId trackId) {
     return plugin;
 }
 
-void PluginManager::pollAsyncPluginLoad(const ChainNodePath& devicePath, te::Plugin::Ptr plugin) {
+void PluginManager::pollAsyncPluginLoad(const ChainNodePath& devicePath,
+                                        const te::Plugin::Ptr& plugin) {
     auto* extPlugin = dynamic_cast<te::ExternalPlugin*>(plugin.get());
     if (!extPlugin)
         return;
@@ -2173,13 +2175,13 @@ te::Plugin::Ptr PluginManager::createPluginOnly(TrackId trackId, const DeviceInf
 
 void PluginManager::registerRackPluginProcessor(const ChainNodePath& devicePath,
                                                 te::Plugin::Ptr plugin, const DeviceInfo& device) {
-    registerRackPluginProcessor(devicePath, plugin, device,
+    registerRackPluginProcessor(devicePath, std::move(plugin), device,
                                 TrackManager::getInstance().getDeviceInChainByPath(devicePath));
 }
 
 void PluginManager::registerRackPluginProcessor(const ChainNodePath& devicePath,
-                                                te::Plugin::Ptr plugin, const DeviceInfo& device,
-                                                DeviceInfo* canonical) {
+                                                const te::Plugin::Ptr& plugin,
+                                                const DeviceInfo& device, DeviceInfo* canonical) {
     const auto deviceId = devicePath.getDeviceId();
     if (!plugin)
         return;
@@ -2731,7 +2733,7 @@ std::vector<std::pair<ChainNodePath, daw::audio::DrumGridPlugin*>> PluginManager
         if (sd.trackId != trackId)
             continue;
         if (auto* dg = dynamic_cast<daw::audio::DrumGridPlugin*>(sd.plugin.get()))
-            drumGrids.push_back({devicePath, dg});
+            drumGrids.emplace_back(devicePath, dg);
     }
 
     return drumGrids;

--- a/magda/daw/audio/plugins/BaseDevicePack.cpp
+++ b/magda/daw/audio/plugins/BaseDevicePack.cpp
@@ -161,7 +161,7 @@ DevicePluginPtr createLevelMeterPlugin(const InternalPluginSpec&, DeviceSessionK
 }
 
 void add(InternalPluginRegistry& registry, InternalPluginSpec spec) {
-    const bool registered = registry.registerPlugin(std::move(spec));
+    const bool registered = registry.registerPlugin(spec);
     jassert(registered);
     juce::ignoreUnused(registered);
 }

--- a/magda/daw/audio/plugins/FaustParamInfo.cpp
+++ b/magda/daw/audio/plugins/FaustParamInfo.cpp
@@ -157,7 +157,7 @@ magda::ParameterInfo discreteInfo(const FaustParamSlot& slot) {
         // an empty choice list for a menu/radio style, but if it does
         // we degrade to a single "(empty)" option so the slot is still
         // selectable.
-        info.choices.push_back("(empty)");
+        info.choices.emplace_back("(empty)");
     }
     info.minValue = 0.0f;
     info.maxValue = static_cast<float>(info.choices.size() - 1);

--- a/magda/daw/audio/plugins/InternalPluginRegistry.cpp
+++ b/magda/daw/audio/plugins/InternalPluginRegistry.cpp
@@ -57,7 +57,7 @@ bool InternalPluginRegistry::registerPlugin(InternalPluginSpec spec) {
             return false;
     }
 
-    auto owned = std::make_unique<InternalPluginSpec>(std::move(spec));
+    auto owned = std::make_unique<InternalPluginSpec>(spec);
     pointers_.push_back(owned.get());
     specs_.push_back(std::move(owned));
     return true;

--- a/magda/daw/audio/plugins/MidiChordEnginePlugin.cpp
+++ b/magda/daw/audio/plugins/MidiChordEnginePlugin.cpp
@@ -234,7 +234,7 @@ void MidiChordEnginePlugin::runDetection() {
 
     for (int i = 0; i < count; ++i) {
         int noteNum = heldNotes_[static_cast<size_t>(i)].load(std::memory_order_relaxed);
-        heldNotes.push_back({noteNum, 100});
+        heldNotes.emplace_back(noteNum, 100);
     }
 
     if (heldNotes.empty()) {

--- a/magda/daw/audio/plugins/compiled/tracktion/CompiledFaustTracktionAdapter.cpp
+++ b/magda/daw/audio/plugins/compiled/tracktion/CompiledFaustTracktionAdapter.cpp
@@ -38,7 +38,7 @@ te::AutomatableParameter* tracktionParameterForSlot(te::Plugin* plugin, int slot
 
 std::unique_ptr<magda::DeviceProcessor> createTracktionProcessor(const CompiledPluginSpec& spec,
                                                                  DeviceId deviceId,
-                                                                 te::Plugin::Ptr plugin) {
+                                                                 const te::Plugin::Ptr& plugin) {
     juce::ignoreUnused(spec);
 
     if (tracktion_adapter::deviceFromPlugin<ICompiledFaustPlugin>(plugin.get()) == nullptr)

--- a/magda/daw/audio/plugins/compiled/tracktion/CompiledFaustTracktionAdapter.hpp
+++ b/magda/daw/audio/plugins/compiled/tracktion/CompiledFaustTracktionAdapter.hpp
@@ -28,6 +28,6 @@ te::AutomatableParameter* tracktionParameterForSlot(te::Plugin* plugin, int slot
 
 std::unique_ptr<magda::DeviceProcessor> createTracktionProcessor(const CompiledPluginSpec& spec,
                                                                  DeviceId deviceId,
-                                                                 te::Plugin::Ptr plugin);
+                                                                 const te::Plugin::Ptr& plugin);
 
 }  // namespace magda::daw::audio::compiled

--- a/magda/daw/audio/plugins/tracktion/TracktionMagdaDevicePlugin.cpp
+++ b/magda/daw/audio/plugins/tracktion/TracktionMagdaDevicePlugin.cpp
@@ -57,7 +57,7 @@ class DeviceParameter final : public te::AutomatableParameter {
     DeviceParameter(const juce::String& paramID, const juce::String& name, te::Plugin& plugin,
                     juce::NormalisableRange<float> range,
                     std::shared_ptr<MagdaDevice*> deviceHandle, int index)
-        : te::AutomatableParameter(paramID, name, plugin, range),
+        : te::AutomatableParameter(paramID, name, plugin, std::move(range)),
           deviceHandle_(std::move(deviceHandle)),
           index_(index) {}
 

--- a/magda/daw/audio/processors/CompiledFaustProcessor.cpp
+++ b/magda/daw/audio/processors/CompiledFaustProcessor.cpp
@@ -19,7 +19,7 @@ auto* compiledDevice(te::Plugin* plugin) {
 }  // namespace
 
 CompiledFaustProcessor::CompiledFaustProcessor(DeviceId deviceId, te::Plugin::Ptr plugin)
-    : DeviceProcessor(deviceId, plugin) {}
+    : DeviceProcessor(deviceId, std::move(plugin)) {}
 
 int CompiledFaustProcessor::getParameterCount() const {
     const auto* host = compiledDevice(plugin_.get());

--- a/magda/daw/audio/processors/DeviceProcessorFactory.cpp
+++ b/magda/daw/audio/processors/DeviceProcessorFactory.cpp
@@ -11,7 +11,7 @@
 namespace magda {
 
 std::unique_ptr<DeviceProcessor> createDeviceProcessorForPlugin(
-    DeviceId deviceId, tracktion::engine::Plugin::Ptr plugin, const juce::String& pluginId,
+    DeviceId deviceId, const tracktion::engine::Plugin::Ptr& plugin, const juce::String& pluginId,
     daw::audio::DeviceTrackContext* trackContext) {
     if (!plugin)
         return nullptr;

--- a/magda/daw/audio/processors/DeviceProcessorFactory.hpp
+++ b/magda/daw/audio/processors/DeviceProcessorFactory.hpp
@@ -12,7 +12,7 @@ namespace magda {
 class DeviceProcessor;
 
 std::unique_ptr<DeviceProcessor> createDeviceProcessorForPlugin(
-    DeviceId deviceId, tracktion::engine::Plugin::Ptr plugin, const juce::String& pluginId,
+    DeviceId deviceId, const tracktion::engine::Plugin::Ptr& plugin, const juce::String& pluginId,
     daw::audio::DeviceTrackContext* trackContext = nullptr);
 
 }  // namespace magda

--- a/magda/daw/audio/racks/InstrumentRackManager.cpp
+++ b/magda/daw/audio/racks/InstrumentRackManager.cpp
@@ -1,5 +1,7 @@
 #include "racks/InstrumentRackManager.hpp"
 
+#include <utility>
+
 #include "plugins/InstrumentMeterTapPlugin.hpp"
 
 namespace magda {
@@ -13,7 +15,7 @@ te::Plugin::Ptr createMeterTapPlugin(te::Edit& edit) {
     return edit.getPluginCache().createNewPlugin(pluginState);
 }
 
-te::Plugin::Ptr findMeterTapPlugin(te::RackType::Ptr rackType) {
+te::Plugin::Ptr findMeterTapPlugin(const te::RackType::Ptr& rackType) {
     if (!rackType)
         return nullptr;
 
@@ -29,7 +31,7 @@ te::Plugin::Ptr findMeterTapPlugin(te::RackType::Ptr rackType) {
 
 InstrumentRackManager::InstrumentRackManager(te::Edit& edit) : edit_(edit) {}
 
-te::Plugin::Ptr InstrumentRackManager::wrapInstrument(te::Plugin::Ptr instrument,
+te::Plugin::Ptr InstrumentRackManager::wrapInstrument(const te::Plugin::Ptr& instrument,
                                                       const routing::ChainRoutingNode& routing) {
     if (!instrument) {
         return nullptr;
@@ -125,7 +127,8 @@ te::Plugin::Ptr InstrumentRackManager::wrapInstrument(te::Plugin::Ptr instrument
 }
 
 te::Plugin::Ptr InstrumentRackManager::wrapMultiOutInstrument(
-    te::Plugin::Ptr instrument, int numOutputChannels, const routing::ChainRoutingNode& routing) {
+    const te::Plugin::Ptr& instrument, int numOutputChannels,
+    const routing::ChainRoutingNode& routing) {
     if (!instrument || numOutputChannels <= 2) {
         return wrapInstrument(instrument, routing);  // Fallback to normal wrapping
     }
@@ -311,8 +314,9 @@ void InstrumentRackManager::unwrap(DeviceId deviceId) {
 }
 
 void InstrumentRackManager::recordWrapping(const ChainNodePath& devicePath,
-                                           te::RackType::Ptr rackType, te::Plugin::Ptr innerPlugin,
-                                           te::Plugin::Ptr rackInstance, bool isMultiOut,
+                                           const te::RackType::Ptr& rackType,
+                                           te::Plugin::Ptr innerPlugin,
+                                           const te::Plugin::Ptr& rackInstance, bool isMultiOut,
                                            int numOutputChannels) {
     const auto deviceId = devicePath.getDeviceId();
     te::Plugin::Ptr meterTap;
@@ -335,8 +339,9 @@ void InstrumentRackManager::recordWrapping(const ChainNodePath& devicePath,
             << deviceId);
     }
 
-    wrapped_[deviceId] = {rackType,          innerPlugin, rackInstance, meterTap, isMultiOut,
-                          numOutputChannels, {}};
+    wrapped_[deviceId] = {
+        rackType, std::move(innerPlugin), rackInstance, meterTap, isMultiOut, numOutputChannels,
+        {}};
 }
 
 te::Plugin* InstrumentRackManager::getInnerPlugin(DeviceId deviceId) const {

--- a/magda/daw/audio/racks/InstrumentRackManager.hpp
+++ b/magda/daw/audio/racks/InstrumentRackManager.hpp
@@ -43,7 +43,7 @@ class InstrumentRackManager {
      *                wired (see the class comment).
      * @return The RackInstance plugin to insert on the track (or nullptr on failure)
      */
-    te::Plugin::Ptr wrapInstrument(te::Plugin::Ptr instrument,
+    te::Plugin::Ptr wrapInstrument(const te::Plugin::Ptr& instrument,
                                    const routing::ChainRoutingNode& routing);
 
     /**
@@ -53,7 +53,7 @@ class InstrumentRackManager {
      * @param routing See wrapInstrument().
      * @return The main RackInstance plugin (outputs 1,2) to insert on the track
      */
-    te::Plugin::Ptr wrapMultiOutInstrument(te::Plugin::Ptr instrument, int numOutputChannels,
+    te::Plugin::Ptr wrapMultiOutInstrument(const te::Plugin::Ptr& instrument, int numOutputChannels,
                                            const routing::ChainRoutingNode& routing);
 
     /**
@@ -85,8 +85,8 @@ class InstrumentRackManager {
      * @param innerPlugin The actual instrument plugin inside the rack
      * @param rackInstance The RackInstance plugin on the track
      */
-    void recordWrapping(const ChainNodePath& devicePath, te::RackType::Ptr rackType,
-                        te::Plugin::Ptr innerPlugin, te::Plugin::Ptr rackInstance,
+    void recordWrapping(const ChainNodePath& devicePath, const te::RackType::Ptr& rackType,
+                        te::Plugin::Ptr innerPlugin, const te::Plugin::Ptr& rackInstance,
                         bool isMultiOut = false, int numOutputChannels = 2);
 
     /**

--- a/magda/daw/audio/racks/RackSyncManager.cpp
+++ b/magda/daw/audio/racks/RackSyncManager.cpp
@@ -35,7 +35,7 @@ std::pair<float, float> outputDbForVolumePan(float volumeDb, float pan) {
                                         static_cast<double>(rightDb)))};
 }
 
-void applyRackInstanceState(te::Plugin::Ptr rackPlugin, const RackInfo& rackInfo) {
+void applyRackInstanceState(const te::Plugin::Ptr& rackPlugin, const RackInfo& rackInfo) {
     auto* rackInstance = dynamic_cast<te::RackInstance*>(rackPlugin.get());
     if (!rackInstance)
         return;

--- a/magda/daw/audio/session/ClipEngineIdMap.cpp
+++ b/magda/daw/audio/session/ClipEngineIdMap.cpp
@@ -23,7 +23,7 @@ std::optional<ClipId> ClipEngineIdMap::getClipId(const std::string& engineId) co
     return it->second;
 }
 
-void ClipEngineIdMap::set(ClipId clipId, std::string engineId) {
+void ClipEngineIdMap::set(ClipId clipId, const std::string& engineId) {
     juce::ScopedLock lock(lock_);
 
     if (auto existing = clipIdToEngineId_.find(clipId); existing != clipIdToEngineId_.end())

--- a/magda/daw/audio/session/ClipEngineIdMap.hpp
+++ b/magda/daw/audio/session/ClipEngineIdMap.hpp
@@ -18,7 +18,7 @@ class ClipEngineIdMap {
     std::optional<std::string> getEngineId(ClipId clipId) const;
     std::optional<ClipId> getClipId(const std::string& engineId) const;
 
-    void set(ClipId clipId, std::string engineId);
+    void set(ClipId clipId, const std::string& engineId);
     void erase(ClipId clipId);
     Snapshot snapshot() const;
 

--- a/magda/daw/cli/magda_cli_main.cpp
+++ b/magda/daw/cli/magda_cli_main.cpp
@@ -200,7 +200,7 @@ class CommandDispatcher {
         if (index >= static_cast<size_t>(tokens.size()))
             return {};
 
-        const auto command = tokens[static_cast<int>(index++)];
+        const auto& command = tokens[static_cast<int>(index++)];
         for (const auto& spec : commandSpecs())
             if (command == spec.name)
                 return (this->*spec.handler)(tokens, index);
@@ -228,7 +228,7 @@ class CommandDispatcher {
         if (index >= static_cast<size_t>(tokens.size()))
             return fail("add-track requires <audio|group|aux|chord>");
 
-        const auto typeToken = tokens[static_cast<int>(index++)];
+        const auto& typeToken = tokens[static_cast<int>(index++)];
         auto type = parseTrackType(typeToken);
         if (!type)
             return fail("Unsupported track type: " + typeToken);
@@ -364,7 +364,7 @@ class CommandDispatcher {
         if (index >= static_cast<size_t>(tokens.size()))
             return fail("add-internal-instrument requires <plugin-id>");
 
-        const auto pluginId = tokens[static_cast<int>(index++)];
+        const auto& pluginId = tokens[static_cast<int>(index++)];
         auto name = pluginId;
         if (index < static_cast<size_t>(tokens.size()) &&
             !isCommand(tokens[static_cast<int>(index)]))

--- a/magda/daw/command.cpp
+++ b/magda/daw/command.cpp
@@ -1,9 +1,10 @@
 #include "command.hpp"
 
 #include <stdexcept>
+#include <utility>
 
 // Command implementation
-Command::Command(const std::string& command_type) : type_(command_type) {}
+Command::Command(std::string command_type) : type_(std::move(command_type)) {}
 
 Command::Command(const juce::var& json) {
     if (!json.hasProperty("command")) {
@@ -114,8 +115,8 @@ std::string Command::toJsonString() const {
 }
 
 // CommandResponse implementation
-CommandResponse::CommandResponse(Status status, const std::string& message)
-    : status_(status), message_(message) {}
+CommandResponse::CommandResponse(Status status, std::string message)
+    : status_(status), message_(std::move(message)) {}
 
 juce::var CommandResponse::toJson() const {
     juce::DynamicObject::Ptr obj = new juce::DynamicObject();

--- a/magda/daw/command.hpp
+++ b/magda/daw/command.hpp
@@ -21,7 +21,7 @@ class Command {
     /**
      * @brief Construct a command with the given type
      */
-    explicit Command(const std::string& command_type);
+    explicit Command(std::string command_type);
 
     /**
      * @brief Construct a command from JSON
@@ -91,7 +91,7 @@ class CommandResponse {
   public:
     enum class Status { Success, Error, Pending };
 
-    CommandResponse(Status status, const std::string& message = "");
+    CommandResponse(Status status, std::string message = "");
 
     Status getStatus() const {
         return status_;

--- a/magda/daw/core/AutomationCommands.hpp
+++ b/magda/daw/core/AutomationCommands.hpp
@@ -404,8 +404,8 @@ class MoveAutomationClipCommand : public UndoableCommand {
  */
 class RenameAutomationClipCommand : public UndoableCommand {
   public:
-    RenameAutomationClipCommand(AutomationClipId clipId, const juce::String& newName)
-        : clipId_(clipId), newName_(newName) {
+    RenameAutomationClipCommand(AutomationClipId clipId, juce::String newName)
+        : clipId_(clipId), newName_(std::move(newName)) {
         captureOldName();
     }
 

--- a/magda/daw/core/ChordProgressionConverter.cpp
+++ b/magda/daw/core/ChordProgressionConverter.cpp
@@ -26,7 +26,7 @@ std::vector<ExtractedChord> extractChordsFromNotes(const std::vector<MidiNote>& 
         for (size_t i = 0; i < notes.size(); ++i) {
             const auto& note = notes[i];
             if (note.startBeat <= beat && (note.startBeat + note.lengthBeats) > beat) {
-                chordNotes.push_back({note.noteNumber, note.velocity});
+                chordNotes.emplace_back(note.noteNumber, note.velocity);
                 indices.push_back(i);
             }
         }

--- a/magda/daw/core/ClipCommands.hpp
+++ b/magda/daw/core/ClipCommands.hpp
@@ -258,7 +258,7 @@ class DeleteClipCommand : public SnapshotCommand<ClipInfo> {
 class CreateClipCommand : public ValidatedCommand {
   public:
     CreateClipCommand(ClipType type, TrackId trackId, BeatPosition startBeat,
-                      BeatDuration lengthBeats, const juce::String& audioFilePath = {},
+                      BeatDuration lengthBeats, juce::String audioFilePath = {},
                       ClipView view = ClipView::Arrangement, double tempo = 0.0,
                       ClipOverlapPolicy overlapPolicy = ClipOverlapPolicy::PreserveExisting);
 
@@ -427,7 +427,7 @@ class JoinClipsCommand : public SnapshotCommand<JoinClipsState> {
  */
 class StretchClipCommand : public UndoableCommand {
   public:
-    StretchClipCommand(ClipId clipId, const ClipInfo& beforeState);
+    StretchClipCommand(ClipId clipId, ClipInfo beforeState);
 
     juce::String getDescription() const override {
         return "Stretch Clip";
@@ -452,7 +452,7 @@ class StretchClipCommand : public UndoableCommand {
  */
 class SetFadeCommand : public UndoableCommand {
   public:
-    SetFadeCommand(ClipId clipId, const ClipInfo& beforeState);
+    SetFadeCommand(ClipId clipId, ClipInfo beforeState);
 
     juce::String getDescription() const override {
         return "Adjust Fade";
@@ -521,7 +521,7 @@ class SetCrossfadeCommand : public UndoableCommand {
  */
 class SetVolumeCommand : public UndoableCommand {
   public:
-    SetVolumeCommand(ClipId clipId, const ClipInfo& beforeState);
+    SetVolumeCommand(ClipId clipId, ClipInfo beforeState);
 
     juce::String getDescription() const override {
         return "Adjust Volume";

--- a/magda/daw/core/ClipManager.cpp
+++ b/magda/daw/core/ClipManager.cpp
@@ -155,7 +155,7 @@ class ExternalEditPoller : private juce::Timer {
             return;
         }
 
-        const auto path = file.getFullPathName();
+        const auto& path = file.getFullPathName();
         const auto mtime = file.getLastModificationTime();
         for (auto& item : watched_) {
             if (item.path == path) {
@@ -892,6 +892,7 @@ void ClipManager::deleteClipTake(ClipId clipId, int takeIndex) {
         const int newCurrent = activeAfterDelete(a.currentTakeIndex, takeIndex, newSize);
 
         std::vector<CompSpan> spans;
+        spans.reserve(a.comp.size());
         for (const auto& s : a.comp)
             spans.push_back({s.startSeconds, s.endSeconds, s.takeIndex});
         remapCompSpansAfterDelete(spans, takeIndex, newCurrent);
@@ -932,6 +933,7 @@ void ClipManager::deleteClipTake(ClipId clipId, int takeIndex) {
         const int newCurrent = activeAfterDelete(m.currentTakeIndex, takeIndex, newSize);
 
         std::vector<CompSpan> spans;
+        spans.reserve(m.comp.size());
         for (const auto& s : m.comp)
             spans.push_back({s.startBeat, s.endBeat, s.takeIndex});
         remapCompSpansAfterDelete(spans, takeIndex, newCurrent);
@@ -2367,6 +2369,7 @@ ClipManager::EffectiveFades ClipManager::getEffectiveFades(ClipId clipId, double
         return {};
 
     std::vector<const ClipInfo*> lane;
+    lane.reserve(clips_.size());
     for (const auto& [cid, other] : clips_)
         lane.push_back(&other);
     return effectiveFadesOf(*clip, lane, bpm);
@@ -2378,6 +2381,7 @@ std::optional<ClipManager::CrossfadeInfo> ClipManager::getCrossfadeAtStart(ClipI
         return std::nullopt;
 
     std::vector<const ClipInfo*> lane;
+    lane.reserve(clips_.size());
     for (const auto& [cid, other] : clips_)
         lane.push_back(&other);
     return crossfadeAtStartOf(*clip, lane);
@@ -2389,6 +2393,7 @@ std::optional<ClipManager::CrossfadeInfo> ClipManager::getCrossfadeAtEnd(ClipId 
         return std::nullopt;
 
     std::vector<const ClipInfo*> lane;
+    lane.reserve(clips_.size());
     for (const auto& [cid, other] : clips_)
         lane.push_back(&other);
     return crossfadeAtEndOf(*clip, lane);

--- a/magda/daw/core/ClipPropertyCommands.hpp
+++ b/magda/daw/core/ClipPropertyCommands.hpp
@@ -14,8 +14,8 @@ namespace magda {
  */
 class SetClipNameCommand : public UndoableCommand {
   public:
-    SetClipNameCommand(ClipId clipId, const juce::String& newName)
-        : clipId_(clipId), newName_(newName) {
+    SetClipNameCommand(ClipId clipId, juce::String newName)
+        : clipId_(clipId), newName_(std::move(newName)) {
         auto* clip = ClipManager::getInstance().getClip(clipId);
         if (clip)
             oldName_ = clip->name;
@@ -912,8 +912,8 @@ class SetClipColourCommand : public UndoableCommand {
  */
 class SetClipGrooveTemplateCommand : public UndoableCommand {
   public:
-    SetClipGrooveTemplateCommand(ClipId clipId, const juce::String& newTemplate)
-        : clipId_(clipId), newTemplate_(newTemplate) {
+    SetClipGrooveTemplateCommand(ClipId clipId, juce::String newTemplate)
+        : clipId_(clipId), newTemplate_(std::move(newTemplate)) {
         auto* clip = ClipManager::getInstance().getClip(clipId);
         if (clip)
             oldTemplate_ = clip->grooveTemplate;

--- a/magda/daw/core/DeviceStateCommands.cpp
+++ b/magda/daw/core/DeviceStateCommands.cpp
@@ -1,15 +1,17 @@
 #include "DeviceStateCommands.hpp"
 
+#include <utility>
+
 #include "DeviceState.hpp"
 #include "ProjectManager.hpp"
 #include "TrackManager.hpp"
 
 namespace magda {
 
-LoadImpulseResponseCommand::LoadImpulseResponseCommand(const ChainNodePath& devicePath,
-                                                       const juce::String& irName,
+LoadImpulseResponseCommand::LoadImpulseResponseCommand(ChainNodePath devicePath,
+                                                       juce::String irName,
                                                        juce::MemoryBlock irData)
-    : devicePath_(devicePath), irName_(irName), irData_(std::move(irData)) {}
+    : devicePath_(std::move(devicePath)), irName_(std::move(irName)), irData_(std::move(irData)) {}
 
 juce::String LoadImpulseResponseCommand::getDescription() const {
     return "Load Impulse Response";

--- a/magda/daw/core/DeviceStateCommands.hpp
+++ b/magda/daw/core/DeviceStateCommands.hpp
@@ -28,7 +28,7 @@ namespace magda {
  */
 class LoadImpulseResponseCommand : public SnapshotCommand<juce::String> {
   public:
-    LoadImpulseResponseCommand(const ChainNodePath& devicePath, const juce::String& irName,
+    LoadImpulseResponseCommand(ChainNodePath devicePath, juce::String irName,
                                juce::MemoryBlock irData);
 
     juce::String getDescription() const override;

--- a/magda/daw/core/DrumGridPads.cpp
+++ b/magda/daw/core/DrumGridPads.cpp
@@ -286,7 +286,7 @@ ChainInfo chainFromNode(const ds::Node& node) {
 
     for (const auto& child : node.children)
         if (child.type == kPlugin.toString())
-            chain.elements.push_back(deviceFromNode(child));
+            chain.elements.emplace_back(deviceFromNode(child));
 
     return chain;
 }

--- a/magda/daw/core/MacroInfo.hpp
+++ b/magda/daw/core/MacroInfo.hpp
@@ -90,7 +90,7 @@ inline MacroArray createDefaultMacros(int numMacros = NUM_MACROS) {
     MacroArray macros;
     macros.reserve(numMacros);
     for (int i = 0; i < numMacros; ++i) {
-        macros.push_back(MacroInfo(i));
+        macros.emplace_back(i);
     }
     return macros;
 }
@@ -101,7 +101,7 @@ inline MacroArray createDefaultMacros(int numMacros = NUM_MACROS) {
 inline void addMacroPage(MacroArray& macros) {
     int startIndex = static_cast<int>(macros.size());
     for (int i = 0; i < MACROS_PER_PAGE; ++i) {
-        macros.push_back(MacroInfo(startIndex + i));
+        macros.emplace_back(startIndex + i);
     }
 }
 

--- a/magda/daw/core/MidiNoteCommands.cpp
+++ b/magda/daw/core/MidiNoteCommands.cpp
@@ -428,7 +428,7 @@ void SetMidiNoteVelocityCommand::mergeWith(const UndoableCommand* other) {
 // ============================================================================
 
 SetMultipleMidiNoteVelocitiesCommand::SetMultipleMidiNoteVelocitiesCommand(
-    ClipId clipId, std::vector<Entry> entries)
+    ClipId clipId, const std::vector<Entry>& entries)
     : clipId_(clipId) {
     const auto* clip = ClipManager::getInstance().getClip(clipId_);
     for (const auto& e : entries) {

--- a/magda/daw/core/MidiNoteCommands.hpp
+++ b/magda/daw/core/MidiNoteCommands.hpp
@@ -162,7 +162,7 @@ class SetMultipleMidiNoteVelocitiesCommand : public UndoableCommand {
         int newVelocity;
     };
 
-    SetMultipleMidiNoteVelocitiesCommand(ClipId clipId, std::vector<Entry> entries);
+    SetMultipleMidiNoteVelocitiesCommand(ClipId clipId, const std::vector<Entry>& entries);
 
     void execute() override;
     void undo() override;

--- a/magda/daw/core/MidiTypes.hpp
+++ b/magda/daw/core/MidiTypes.hpp
@@ -2,6 +2,8 @@
 
 #include <juce_core/juce_core.h>
 
+#include <utility>
+
 namespace magda {
 
 /**
@@ -46,9 +48,12 @@ struct MidiDeviceInfo {
 
     MidiDeviceInfo() = default;
 
-    MidiDeviceInfo(const juce::String& deviceId, const juce::String& deviceName,
-                   bool enabled = false, bool available = true)
-        : id(deviceId), name(deviceName), isEnabled(enabled), isAvailable(available) {}
+    MidiDeviceInfo(juce::String deviceId, juce::String deviceName, bool enabled = false,
+                   bool available = true)
+        : id(std::move(deviceId)),
+          name(std::move(deviceName)),
+          isEnabled(enabled),
+          isAvailable(available) {}
 };
 
 }  // namespace magda

--- a/magda/daw/core/MixAnalysisService.cpp
+++ b/magda/daw/core/MixAnalysisService.cpp
@@ -110,7 +110,7 @@ void MixAnalysisService::runOffline() {
             progressText_ = msg;
             listeners_.call(&Listener::mixAnalysisChanged);
         },
-        [this, runId](mix::OfflineMixAnalysis::Result result) {
+        [this, runId](const mix::OfflineMixAnalysis::Result& result) {
             if (runId != runId_)
                 return;  // cancelled / superseded
             if (result.hasError)

--- a/magda/daw/core/ModInfo.hpp
+++ b/magda/daw/core/ModInfo.hpp
@@ -522,7 +522,7 @@ inline ModArray createDefaultMods(int numMods = NUM_MODS) {
     ModArray mods;
     mods.reserve(numMods);
     for (int i = 0; i < numMods; ++i) {
-        mods.push_back(ModInfo(i));
+        mods.emplace_back(i);
     }
     return mods;
 }
@@ -533,7 +533,7 @@ inline ModArray createDefaultMods(int numMods = NUM_MODS) {
 inline void addModPage(ModArray& mods) {
     int startIndex = static_cast<int>(mods.size());
     for (int i = 0; i < MODS_PER_PAGE; ++i) {
-        mods.push_back(ModInfo(startIndex + i));
+        mods.emplace_back(startIndex + i);
     }
 }
 

--- a/magda/daw/core/PadCommands.cpp
+++ b/magda/daw/core/PadCommands.cpp
@@ -34,9 +34,11 @@ PadRack snapshotPads(const ChainNodePath& gridPath) {
 
 }  // namespace
 
-EditPadsCommand::EditPadsCommand(const ChainNodePath& gridPath, juce::String description,
+EditPadsCommand::EditPadsCommand(ChainNodePath gridPath, juce::String description,
                                  std::function<void()> edit)
-    : gridPath_(gridPath), description_(std::move(description)), edit_(std::move(edit)) {}
+    : gridPath_(std::move(gridPath)),
+      description_(std::move(description)),
+      edit_(std::move(edit)) {}
 
 void EditPadsCommand::execute() {
     auto& tm = TrackManager::getInstance();
@@ -81,9 +83,9 @@ void editPads(const ChainNodePath& gridPath, const juce::String& description,
 // SetPadFaderCommand
 // ============================================================================
 
-SetPadFaderCommand::SetPadFaderCommand(const ChainNodePath& gridPath, int padIndex, Target target,
+SetPadFaderCommand::SetPadFaderCommand(ChainNodePath gridPath, int padIndex, Target target,
                                        float value, int gesture)
-    : gridPath_(gridPath),
+    : gridPath_(std::move(gridPath)),
       padIndex_(padIndex),
       target_(target),
       newValue_(value),

--- a/magda/daw/core/PadCommands.hpp
+++ b/magda/daw/core/PadCommands.hpp
@@ -38,8 +38,7 @@ class EditPadsCommand : public UndoableCommand {
   public:
     /// @p edit runs against the live model, addressed by @p gridPath. It runs
     /// once: redo restores the snapshot it produced.
-    EditPadsCommand(const ChainNodePath& gridPath, juce::String description,
-                    std::function<void()> edit);
+    EditPadsCommand(ChainNodePath gridPath, juce::String description, std::function<void()> edit);
 
     void execute() override;
     void undo() override;
@@ -82,7 +81,7 @@ class SetPadFaderCommand : public UndoableCommand {
     /// same fader is another. `UndoManager` merges adjacent commands with no
     /// timeout of its own, so without this one Undo would walk back every
     /// gesture since something else last intervened.
-    SetPadFaderCommand(const ChainNodePath& gridPath, int padIndex, Target target, float value,
+    SetPadFaderCommand(ChainNodePath gridPath, int padIndex, Target target, float value,
                        int gesture);
 
     void execute() override;

--- a/magda/daw/core/ParameterDetector.cpp
+++ b/magda/daw/core/ParameterDetector.cpp
@@ -670,8 +670,8 @@ int parseAIResponse(const juce::String& responseText, const std::vector<Ambiguou
 void detectWithAI(const juce::String& pluginName, const std::vector<ParameterScanInput>& params,
                   const std::vector<DetectedParameterInfo>& deterministicResults,
                   float confidenceThreshold, std::shared_ptr<std::atomic<bool>> cancelFlag,
-                  std::function<void(int resolved, int total)> onProgress,
-                  std::function<void(std::vector<DetectedParameterInfo>)> onComplete) {
+                  const std::function<void(int resolved, int total)>& onProgress,
+                  const std::function<void(std::vector<DetectedParameterInfo>)>& onComplete) {
     // Collect ambiguous parameters
     std::vector<AmbiguousParam> ambiguous;
     for (size_t i = 0; i < deterministicResults.size(); ++i) {
@@ -689,8 +689,8 @@ void detectWithAI(const juce::String& pluginName, const std::vector<ParameterSca
     auto batches = std::make_shared<std::vector<std::vector<AmbiguousParam>>>();
     for (size_t i = 0; i < ambiguous.size(); i += batchSize) {
         auto end = std::min(i + batchSize, ambiguous.size());
-        batches->push_back({ambiguous.begin() + static_cast<ptrdiff_t>(i),
-                            ambiguous.begin() + static_cast<ptrdiff_t>(end)});
+        batches->emplace_back(ambiguous.begin() + static_cast<ptrdiff_t>(i),
+                              ambiguous.begin() + static_cast<ptrdiff_t>(end));
     }
 
     auto totalAmbiguous = static_cast<int>(ambiguous.size());

--- a/magda/daw/core/ParameterDetector.hpp
+++ b/magda/daw/core/ParameterDetector.hpp
@@ -45,8 +45,8 @@ std::vector<DetectedParameterInfo> detect(const std::vector<ParameterScanInput>&
 void detectWithAI(const juce::String& pluginName, const std::vector<ParameterScanInput>& params,
                   const std::vector<DetectedParameterInfo>& deterministicResults,
                   float confidenceThreshold, std::shared_ptr<std::atomic<bool>> cancelFlag,
-                  std::function<void(int resolved, int total)> onProgress,
-                  std::function<void(std::vector<DetectedParameterInfo>)> onComplete);
+                  const std::function<void(int resolved, int total)>& onProgress,
+                  const std::function<void(std::vector<DetectedParameterInfo>)>& onComplete);
 
 }  // namespace ParameterDetector
 

--- a/magda/daw/core/ParameterInfo.hpp
+++ b/magda/daw/core/ParameterInfo.hpp
@@ -3,6 +3,7 @@
 #include <juce_core/juce_core.h>
 
 #include <memory>
+#include <utility>
 #include <vector>
 
 #include "ChainNodePath.hpp"
@@ -186,11 +187,11 @@ struct ParameterInfo {
     ParameterInfo() = default;
 
     // Constructor with basic info
-    ParameterInfo(int index, const juce::String& n, const juce::String& u, float min, float max,
-                  float def, ParameterScale s = ParameterScale::Linear)
+    ParameterInfo(int index, juce::String n, juce::String u, float min, float max, float def,
+                  ParameterScale s = ParameterScale::Linear)
         : paramIndex(index),
-          name(n),
-          unit(u),
+          name(std::move(n)),
+          unit(std::move(u)),
           minValue(min),
           maxValue(max),
           defaultValue(def),

--- a/magda/daw/core/PluginPresetScanner.cpp
+++ b/magda/daw/core/PluginPresetScanner.cpp
@@ -50,7 +50,7 @@ std::vector<juce::File> systemRootsFor(PluginFormat format) {
     std::vector<juce::File> roots;
 #if JUCE_MAC
     if (format == PluginFormat::VST3 || format == PluginFormat::AU)
-        roots.push_back(juce::File("/Library/Audio/Presets"));
+        roots.emplace_back("/Library/Audio/Presets");
 #elif JUCE_WINDOWS
     if (format == PluginFormat::VST3) {
         auto common = juce::File::getSpecialLocation(juce::File::commonApplicationDataDirectory);

--- a/magda/daw/core/StepPatternCommands.cpp
+++ b/magda/daw/core/StepPatternCommands.cpp
@@ -64,11 +64,11 @@ step_pattern::PolyPattern currentPolyPattern(const ChainNodePath& devicePath) {
 // Mono
 // =============================================================================
 
-SetMonoStepPatternCommand::SetMonoStepPatternCommand(const ChainNodePath& devicePath,
+SetMonoStepPatternCommand::SetMonoStepPatternCommand(ChainNodePath devicePath,
                                                      step_pattern::MonoPattern pattern,
                                                      juce::String description,
                                                      StepPatternGesture gesture, int gestureId)
-    : devicePath_(devicePath),
+    : devicePath_(std::move(devicePath)),
       pattern_(pattern),
       description_(std::move(description)),
       gesture_(gesture),
@@ -117,11 +117,11 @@ void SetMonoStepPatternCommand::performAction() {
 // Poly
 // =============================================================================
 
-SetPolyStepPatternCommand::SetPolyStepPatternCommand(const ChainNodePath& devicePath,
+SetPolyStepPatternCommand::SetPolyStepPatternCommand(ChainNodePath devicePath,
                                                      step_pattern::PolyPattern pattern,
                                                      juce::String description,
                                                      StepPatternGesture gesture, int gestureId)
-    : devicePath_(devicePath),
+    : devicePath_(std::move(devicePath)),
       pattern_(pattern),
       description_(std::move(description)),
       gesture_(gesture),

--- a/magda/daw/core/StepPatternCommands.hpp
+++ b/magda/daw/core/StepPatternCommands.hpp
@@ -59,7 +59,7 @@ inline constexpr int kNoStepPatternGesture = 0;
 /// Replace a monophonic step sequencer's whole pattern.
 class SetMonoStepPatternCommand : public SnapshotCommand<juce::String> {
   public:
-    SetMonoStepPatternCommand(const ChainNodePath& devicePath, step_pattern::MonoPattern pattern,
+    SetMonoStepPatternCommand(ChainNodePath devicePath, step_pattern::MonoPattern pattern,
                               juce::String description,
                               StepPatternGesture gesture = StepPatternGesture::Discrete,
                               int gestureId = kNoStepPatternGesture);
@@ -85,7 +85,7 @@ class SetMonoStepPatternCommand : public SnapshotCommand<juce::String> {
 /// Replace a polyphonic step sequencer's whole pattern.
 class SetPolyStepPatternCommand : public SnapshotCommand<juce::String> {
   public:
-    SetPolyStepPatternCommand(const ChainNodePath& devicePath, step_pattern::PolyPattern pattern,
+    SetPolyStepPatternCommand(ChainNodePath devicePath, step_pattern::PolyPattern pattern,
                               juce::String description,
                               StepPatternGesture gesture = StepPatternGesture::Discrete,
                               int gestureId = kNoStepPatternGesture);

--- a/magda/daw/core/TrackCommands.cpp
+++ b/magda/daw/core/TrackCommands.cpp
@@ -4,6 +4,7 @@
 #include <functional>
 #include <limits>
 #include <ranges>
+#include <utility>
 
 #include "../audio/AudioBridge.hpp"
 #include "../engine/AudioEngine.hpp"
@@ -125,9 +126,8 @@ int dropIndexForHome(TrackManager& tm, const ChainNodePath& elementPath,
 // CreateTrackCommand
 // ============================================================================
 
-CreateTrackCommand::CreateTrackCommand(TrackType type, const juce::String& name,
-                                       TrackId afterTrackId)
-    : type_(type), name_(name), afterTrackId_(afterTrackId) {}
+CreateTrackCommand::CreateTrackCommand(TrackType type, juce::String name, TrackId afterTrackId)
+    : type_(type), name_(std::move(name)), afterTrackId_(afterTrackId) {}
 
 void CreateTrackCommand::execute() {
     auto& trackManager = TrackManager::getInstance();
@@ -366,8 +366,8 @@ void DuplicateTrackCommand::undo() {
 // AddDeviceToTrackCommand
 // ============================================================================
 
-AddDeviceToTrackCommand::AddDeviceToTrackCommand(TrackId trackId, const DeviceInfo& device)
-    : trackId_(trackId), device_(device) {}
+AddDeviceToTrackCommand::AddDeviceToTrackCommand(TrackId trackId, DeviceInfo device)
+    : trackId_(trackId), device_(std::move(device)) {}
 
 void AddDeviceToTrackCommand::execute() {
     auto& trackManager = TrackManager::getInstance();
@@ -389,11 +389,11 @@ void AddDeviceToTrackCommand::undo() {
 // MoveChainElementCommand
 // ============================================================================
 
-MoveChainElementCommand::MoveChainElementCommand(const ChainNodePath& sourceElementPath,
-                                                 const ChainNodePath& destinationChainPath,
+MoveChainElementCommand::MoveChainElementCommand(ChainNodePath sourceElementPath,
+                                                 ChainNodePath destinationChainPath,
                                                  int insertIndex)
-    : sourceElementPath_(sourceElementPath),
-      destinationChainPath_(destinationChainPath),
+    : sourceElementPath_(std::move(sourceElementPath)),
+      destinationChainPath_(std::move(destinationChainPath)),
       insertIndex_(insertIndex) {}
 
 ChainNodePath MoveChainElementCommand::buildMovedPath(
@@ -452,10 +452,10 @@ void MoveChainElementCommand::undo() {
 // ============================================================================
 
 MoveChainElementsCommand::MoveChainElementsCommand(std::vector<ChainNodePath> sourceElementPaths,
-                                                   const ChainNodePath& destinationChainPath,
+                                                   ChainNodePath destinationChainPath,
                                                    int insertIndex)
     : sourceElementPaths_(std::move(sourceElementPaths)),
-      destinationChainPath_(destinationChainPath),
+      destinationChainPath_(std::move(destinationChainPath)),
       insertIndex_(insertIndex) {}
 
 void MoveChainElementsCommand::execute() {
@@ -587,10 +587,10 @@ void MoveChainElementsCommand::undo() {
 // PasteChainElementsCommand
 // ============================================================================
 
-PasteChainElementsCommand::PasteChainElementsCommand(const ChainNodePath& destinationChainPath,
+PasteChainElementsCommand::PasteChainElementsCommand(ChainNodePath destinationChainPath,
                                                      std::vector<ChainElement> elements,
                                                      int insertIndex)
-    : destinationChainPath_(destinationChainPath),
+    : destinationChainPath_(std::move(destinationChainPath)),
       templateElements_(std::move(elements)),
       insertIndex_(insertIndex) {}
 
@@ -773,9 +773,8 @@ void WrapChainElementsInRackCommand::undo() {
 // SetMacroNameCommand / SetModNameCommand
 // ============================================================================
 
-SetMacroNameCommand::SetMacroNameCommand(const ChainNodePath& path, int macroIndex,
-                                         const juce::String& newName)
-    : path_(path), macroIndex_(macroIndex), newName_(newName) {
+SetMacroNameCommand::SetMacroNameCommand(ChainNodePath path, int macroIndex, juce::String newName)
+    : path_(std::move(path)), macroIndex_(macroIndex), newName_(std::move(newName)) {
     const auto& trackManager = TrackManager::getInstance();
     auto node = trackManager.resolveChainNode(path_);
     if (!node.valid() || node.macros == nullptr || macroIndex_ < 0 ||
@@ -802,9 +801,8 @@ void SetMacroNameCommand::applyName(const juce::String& name) {
     TrackManager::getInstance().notifyModulationNamesChanged(path_.trackId);
 }
 
-SetModNameCommand::SetModNameCommand(const ChainNodePath& path, int modIndex,
-                                     const juce::String& newName)
-    : path_(path), modIndex_(modIndex), newName_(newName) {
+SetModNameCommand::SetModNameCommand(ChainNodePath path, int modIndex, juce::String newName)
+    : path_(std::move(path)), modIndex_(modIndex), newName_(std::move(newName)) {
     const auto& trackManager = TrackManager::getInstance();
     auto node = trackManager.resolveChainNode(path_);
     if (!node.valid() || node.mods == nullptr || modIndex_ < 0 ||
@@ -835,9 +833,9 @@ void SetModNameCommand::applyName(const juce::String& name) {
 // CreateTrackWithDeviceCommand
 // ============================================================================
 
-CreateTrackWithDeviceCommand::CreateTrackWithDeviceCommand(const juce::String& trackName,
-                                                           TrackType type, const DeviceInfo& device)
-    : trackName_(trackName), type_(type), device_(device) {}
+CreateTrackWithDeviceCommand::CreateTrackWithDeviceCommand(juce::String trackName, TrackType type,
+                                                           DeviceInfo device)
+    : trackName_(std::move(trackName)), type_(type), device_(std::move(device)) {}
 
 void CreateTrackWithDeviceCommand::execute() {
     auto& trackManager = TrackManager::getInstance();
@@ -919,9 +917,9 @@ void capturePluginStatesUnder(const std::vector<ChainElement>& elements,
 
 }  // namespace
 
-AddDeviceByPathCommand::AddDeviceByPathCommand(const ChainNodePath& parentPath,
-                                               const DeviceInfo& device, int insertIndex)
-    : parentPath_(parentPath), device_(device), insertIndex_(insertIndex) {}
+AddDeviceByPathCommand::AddDeviceByPathCommand(ChainNodePath parentPath, DeviceInfo device,
+                                               int insertIndex)
+    : parentPath_(std::move(parentPath)), device_(std::move(device)), insertIndex_(insertIndex) {}
 
 void AddDeviceByPathCommand::execute() {
     auto& tm = TrackManager::getInstance();

--- a/magda/daw/core/TrackCommands.hpp
+++ b/magda/daw/core/TrackCommands.hpp
@@ -12,7 +12,7 @@ namespace magda {
 class CreateTrackCommand : public UndoableCommand {
   public:
     explicit CreateTrackCommand(TrackType type = TrackType::Media,
-                                const juce::String& name = juce::String(),
+                                juce::String name = juce::String(),
                                 TrackId afterTrackId = INVALID_TRACK_ID);
 
     void execute() override;
@@ -121,7 +121,7 @@ class DuplicateTrackCommand : public UndoableCommand {
  */
 class AddDeviceToTrackCommand : public UndoableCommand {
   public:
-    AddDeviceToTrackCommand(TrackId trackId, const DeviceInfo& device);
+    AddDeviceToTrackCommand(TrackId trackId, DeviceInfo device);
 
     void execute() override;
     void undo() override;
@@ -145,8 +145,8 @@ class AddDeviceToTrackCommand : public UndoableCommand {
  */
 class MoveChainElementCommand : public UndoableCommand {
   public:
-    MoveChainElementCommand(const ChainNodePath& sourceElementPath,
-                            const ChainNodePath& destinationChainPath, int insertIndex);
+    MoveChainElementCommand(ChainNodePath sourceElementPath, ChainNodePath destinationChainPath,
+                            int insertIndex);
 
     void execute() override;
     void undo() override;
@@ -178,7 +178,7 @@ class MoveChainElementCommand : public UndoableCommand {
 class MoveChainElementsCommand : public UndoableCommand {
   public:
     MoveChainElementsCommand(std::vector<ChainNodePath> sourceElementPaths,
-                             const ChainNodePath& destinationChainPath, int insertIndex);
+                             ChainNodePath destinationChainPath, int insertIndex);
 
     void execute() override;
     void undo() override;
@@ -209,7 +209,7 @@ class MoveChainElementsCommand : public UndoableCommand {
 
 class PasteChainElementsCommand : public UndoableCommand {
   public:
-    PasteChainElementsCommand(const ChainNodePath& destinationChainPath,
+    PasteChainElementsCommand(ChainNodePath destinationChainPath,
                               std::vector<ChainElement> elements, int insertIndex);
 
     void execute() override;
@@ -270,7 +270,7 @@ class WrapChainElementsInRackCommand : public UndoableCommand {
 
 class SetMacroNameCommand : public UndoableCommand {
   public:
-    SetMacroNameCommand(const ChainNodePath& path, int macroIndex, const juce::String& newName);
+    SetMacroNameCommand(ChainNodePath path, int macroIndex, juce::String newName);
 
     void execute() override;
     void undo() override;
@@ -290,7 +290,7 @@ class SetMacroNameCommand : public UndoableCommand {
 
 class SetModNameCommand : public UndoableCommand {
   public:
-    SetModNameCommand(const ChainNodePath& path, int modIndex, const juce::String& newName);
+    SetModNameCommand(ChainNodePath path, int modIndex, juce::String newName);
 
     void execute() override;
     void undo() override;
@@ -313,8 +313,7 @@ class SetModNameCommand : public UndoableCommand {
  */
 class CreateTrackWithDeviceCommand : public UndoableCommand {
   public:
-    CreateTrackWithDeviceCommand(const juce::String& trackName, TrackType type,
-                                 const DeviceInfo& device);
+    CreateTrackWithDeviceCommand(juce::String trackName, TrackType type, DeviceInfo device);
 
     void execute() override;
     void undo() override;
@@ -346,8 +345,7 @@ class CreateTrackWithDeviceCommand : public UndoableCommand {
  */
 class AddDeviceByPathCommand : public UndoableCommand {
   public:
-    AddDeviceByPathCommand(const ChainNodePath& parentPath, const DeviceInfo& device,
-                           int insertIndex = -1);
+    AddDeviceByPathCommand(ChainNodePath parentPath, DeviceInfo device, int insertIndex = -1);
 
     void execute() override;
     void undo() override;

--- a/magda/daw/core/TrackManager.cpp
+++ b/magda/daw/core/TrackManager.cpp
@@ -211,22 +211,6 @@ void remapDuplicatedElements(std::vector<ChainElement>& elements, const ChainNod
         });
 }
 
-void setChainElementsBypassed(std::vector<ChainElement>& elements, const ChainNodePath& parentPath,
-                              bool bypassed, std::vector<ChainNodePath>& affectedDevices) {
-    // Racks and devices are two walks rather than one that visits both, which
-    // costs a second descent and buys the two orders being independent: the
-    // devices come out in signal order for the caller to announce.
-    chain_walk::forEachRack(
-        elements, parentPath, chain_walk::Pads::Skip,
-        [bypassed](RackInfo& rack, const ChainNodePath&) { rack.bypassed = bypassed; });
-    chain_walk::forEachDevice(
-        elements, parentPath, chain_walk::Pads::Skip,
-        [bypassed, &affectedDevices](DeviceInfo& device, const ChainNodePath& path) {
-            device.bypassed = bypassed;
-            affectedDevices.push_back(path);
-        });
-}
-
 void enforcePostFxAnalysisDeviceOrder(std::vector<PostFxChainElement>& elements) {
     // Keep the analysis devices (oscilloscope, spectrum, levels) in a stable,
     // canonical order among themselves without disturbing any non-analysis
@@ -1320,7 +1304,8 @@ void TrackManager::moveTrackToPosition(TrackId trackId, int oneBasedPosition) {
     auto self = std::ranges::find_if(tracks_, matchesId);
     if (self == tracks_.end())
         return;
-    const TrackInfo& info = *self;
+    // Copy, not a reference: the erase below destroys the element it would bind to.
+    const TrackInfo info = *self;
     tracks_.erase(self);
 
     if (anchor == INVALID_TRACK_ID) {

--- a/magda/daw/core/TrackManager.cpp
+++ b/magda/daw/core/TrackManager.cpp
@@ -1320,7 +1320,7 @@ void TrackManager::moveTrackToPosition(TrackId trackId, int oneBasedPosition) {
     auto self = std::ranges::find_if(tracks_, matchesId);
     if (self == tracks_.end())
         return;
-    const TrackInfo info = *self;
+    const TrackInfo& info = *self;
     tracks_.erase(self);
 
     if (anchor == INVALID_TRACK_ID) {

--- a/magda/daw/core/TrackManager.hpp
+++ b/magda/daw/core/TrackManager.hpp
@@ -998,13 +998,13 @@ class TrackManager : public daw::audio::DeviceIdAllocator, public daw::audio::De
 
     // Unified macro management — works for Track, Rack, and Device scopes.
     void setMacroValue(const ChainNodePath& path, int macroIndex, float value);
-    void setMacroTarget(const ChainNodePath& path, int macroIndex, ControlTarget target);
-    void setMacroLinkAmount(const ChainNodePath& path, int macroIndex, ControlTarget target,
+    void setMacroTarget(const ChainNodePath& path, int macroIndex, const ControlTarget& target);
+    void setMacroLinkAmount(const ChainNodePath& path, int macroIndex, const ControlTarget& target,
                             float amount);
-    void setMacroLinkBipolar(const ChainNodePath& path, int macroIndex, ControlTarget target,
+    void setMacroLinkBipolar(const ChainNodePath& path, int macroIndex, const ControlTarget& target,
                              bool bipolar);
     void setMacroName(const ChainNodePath& path, int macroIndex, const juce::String& name);
-    void removeMacroLink(const ChainNodePath& path, int macroIndex, ControlTarget target);
+    void removeMacroLink(const ChainNodePath& path, int macroIndex, const ControlTarget& target);
     void clearAllMacroLinks(const ChainNodePath& path, int macroIndex);
     void addMacroPage(const ChainNodePath& path);
     void removeMacroPage(const ChainNodePath& path);
@@ -1013,12 +1013,12 @@ class TrackManager : public daw::audio::DeviceIdAllocator, public daw::audio::De
     void addMod(const ChainNodePath& path, int slotIndex, ModType type,
                 LFOWaveform waveform = LFOWaveform::Sine);
     void removeMod(const ChainNodePath& path, int modIndex);
-    void setModTarget(const ChainNodePath& path, int modIndex, ControlTarget target);
-    void setModLinkAmount(const ChainNodePath& path, int modIndex, ControlTarget target,
+    void setModTarget(const ChainNodePath& path, int modIndex, const ControlTarget& target);
+    void setModLinkAmount(const ChainNodePath& path, int modIndex, const ControlTarget& target,
                           float amount);
-    void setModLinkBipolar(const ChainNodePath& path, int modIndex, ControlTarget target,
+    void setModLinkBipolar(const ChainNodePath& path, int modIndex, const ControlTarget& target,
                            bool bipolar);
-    void setModLinkEnabled(const ChainNodePath& path, int modIndex, ControlTarget target,
+    void setModLinkEnabled(const ChainNodePath& path, int modIndex, const ControlTarget& target,
                            bool enabled);
     void setModName(const ChainNodePath& path, int modIndex, const juce::String& name);
     void setModType(const ChainNodePath& path, int modIndex, ModType type);
@@ -1048,7 +1048,7 @@ class TrackManager : public daw::audio::DeviceIdAllocator, public daw::audio::De
     // Copies the envelope follower fields (gain/attack/hold/release) from `src`
     // into the stored mod and re-syncs the TE modifier.
     void setModFollower(const ChainNodePath& path, int modIndex, const ModInfo& src);
-    void removeModLink(const ChainNodePath& path, int modIndex, ControlTarget target);
+    void removeModLink(const ChainNodePath& path, int modIndex, const ControlTarget& target);
     void clearAllModLinks(const ChainNodePath& path, int modIndex);
     void setModEnabled(const ChainNodePath& path, int modIndex, bool enabled);
     void addModPage(const ChainNodePath& path);

--- a/magda/daw/core/TrackManagerDevices.cpp
+++ b/magda/daw/core/TrackManagerDevices.cpp
@@ -1160,7 +1160,7 @@ RackId TrackManager::wrapChainElementsInRack(const std::vector<ChainNodePath>& p
 
         const int index = getChainElementIndex(path);
         if (index >= 0)
-            orderedPaths.push_back({index, path});
+            orderedPaths.emplace_back(index, path);
     }
 
     if (orderedPaths.empty())

--- a/magda/daw/core/TrackManagerModulation.cpp
+++ b/magda/daw/core/TrackManagerModulation.cpp
@@ -241,7 +241,8 @@ void TrackManager::setMacroValue(const ChainNodePath& path, int macroIndex, floa
     notifyMacroValueChanged(path.trackId, node.scope, node.notifyId(), macroIndex, clampedValue);
 }
 
-void TrackManager::setMacroTarget(const ChainNodePath& path, int macroIndex, ControlTarget target) {
+void TrackManager::setMacroTarget(const ChainNodePath& path, int macroIndex,
+                                  const ControlTarget& target) {
     auto node = resolveChainNode(path);
     if (!indexInRange(node.macros, macroIndex))
         return;
@@ -261,7 +262,7 @@ void TrackManager::setMacroTarget(const ChainNodePath& path, int macroIndex, Con
 }
 
 void TrackManager::setMacroLinkAmount(const ChainNodePath& path, int macroIndex,
-                                      ControlTarget target, float amount) {
+                                      const ControlTarget& target, float amount) {
     auto node = resolveChainNode(path);
     if (!indexInRange(node.macros, macroIndex))
         return;
@@ -289,7 +290,7 @@ void TrackManager::setMacroLinkAmount(const ChainNodePath& path, int macroIndex,
 }
 
 void TrackManager::setMacroLinkBipolar(const ChainNodePath& path, int macroIndex,
-                                       ControlTarget target, bool bipolar) {
+                                       const ControlTarget& target, bool bipolar) {
     auto node = resolveChainNode(path);
     if (!indexInRange(node.macros, macroIndex))
         return;
@@ -309,7 +310,7 @@ void TrackManager::setMacroName(const ChainNodePath& path, int macroIndex,
 }
 
 void TrackManager::removeMacroLink(const ChainNodePath& path, int macroIndex,
-                                   ControlTarget target) {
+                                   const ControlTarget& target) {
     auto node = resolveChainNode(path);
     if (!indexInRange(node.macros, macroIndex))
         return;
@@ -398,7 +399,8 @@ void TrackManager::removeMod(const ChainNodePath& path, int modIndex) {
     });
 }
 
-void TrackManager::setModTarget(const ChainNodePath& path, int modIndex, ControlTarget target) {
+void TrackManager::setModTarget(const ChainNodePath& path, int modIndex,
+                                const ControlTarget& target) {
     auto node = resolveChainNode(path);
     if (!indexInRange(node.mods, modIndex))
         return;
@@ -411,8 +413,8 @@ void TrackManager::setModTarget(const ChainNodePath& path, int modIndex, Control
     notifyDeviceModifiersChanged(path.trackId);
 }
 
-void TrackManager::setModLinkAmount(const ChainNodePath& path, int modIndex, ControlTarget target,
-                                    float amount) {
+void TrackManager::setModLinkAmount(const ChainNodePath& path, int modIndex,
+                                    const ControlTarget& target, float amount) {
     auto node = resolveChainNode(path);
     if (!indexInRange(node.mods, modIndex))
         return;
@@ -425,8 +427,8 @@ void TrackManager::setModLinkAmount(const ChainNodePath& path, int modIndex, Con
     notifyDeviceModifiersChanged(path.trackId);
 }
 
-void TrackManager::setModLinkBipolar(const ChainNodePath& path, int modIndex, ControlTarget target,
-                                     bool bipolar) {
+void TrackManager::setModLinkBipolar(const ChainNodePath& path, int modIndex,
+                                     const ControlTarget& target, bool bipolar) {
     auto node = resolveChainNode(path);
     if (!indexInRange(node.mods, modIndex))
         return;
@@ -436,8 +438,8 @@ void TrackManager::setModLinkBipolar(const ChainNodePath& path, int modIndex, Co
     }
 }
 
-void TrackManager::setModLinkEnabled(const ChainNodePath& path, int modIndex, ControlTarget target,
-                                     bool enabled) {
+void TrackManager::setModLinkEnabled(const ChainNodePath& path, int modIndex,
+                                     const ControlTarget& target, bool enabled) {
     auto node = resolveChainNode(path);
     if (!indexInRange(node.mods, modIndex))
         return;
@@ -635,7 +637,8 @@ void TrackManager::setModFollower(const ChainNodePath& path, int modIndex, const
     notifyDeviceModifiersChanged(path.trackId);
 }
 
-void TrackManager::removeModLink(const ChainNodePath& path, int modIndex, ControlTarget target) {
+void TrackManager::removeModLink(const ChainNodePath& path, int modIndex,
+                                 const ControlTarget& target) {
     auto node = resolveChainNode(path);
     if (!indexInRange(node.mods, modIndex))
         return;

--- a/magda/daw/core/TrackPropertyCommands.hpp
+++ b/magda/daw/core/TrackPropertyCommands.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <algorithm>
+#include <utility>
 
 #include "TrackManager.hpp"
 #include "UndoManager.hpp"
@@ -487,8 +488,8 @@ class RemoveTrackFromGroupCommand : public UndoableCommand {
  */
 class SetTrackNameCommand : public UndoableCommand {
   public:
-    SetTrackNameCommand(TrackId trackId, const juce::String& newName)
-        : trackId_(trackId), newName_(newName) {
+    SetTrackNameCommand(TrackId trackId, juce::String newName)
+        : trackId_(trackId), newName_(std::move(newName)) {
         auto* track = TrackManager::getInstance().getTrack(trackId);
         if (track)
             oldName_ = track->name;

--- a/magda/daw/core/UndoManager.cpp
+++ b/magda/daw/core/UndoManager.cpp
@@ -1,6 +1,7 @@
 #include "UndoManager.hpp"
 
 #include <ranges>
+#include <utility>
 
 #include "../project/ProjectManager.hpp"
 
@@ -203,9 +204,9 @@ void UndoManager::updateProjectDirtyState() {
 // CompoundCommand Implementation
 // ============================================================================
 
-CompoundCommand::CompoundCommand(const juce::String& description,
+CompoundCommand::CompoundCommand(juce::String description,
                                  std::vector<std::unique_ptr<UndoableCommand>> commands)
-    : description_(description), commands_(std::move(commands)) {}
+    : description_(std::move(description)), commands_(std::move(commands)) {}
 
 void CompoundCommand::execute() {
     // Execute all commands in order

--- a/magda/daw/core/UndoManager.hpp
+++ b/magda/daw/core/UndoManager.hpp
@@ -213,7 +213,7 @@ class UndoManager {
  */
 class CompoundCommand : public UndoableCommand {
   public:
-    explicit CompoundCommand(const juce::String& description,
+    explicit CompoundCommand(juce::String description,
                              std::vector<std::unique_ptr<UndoableCommand>> commands);
 
     void execute() override;

--- a/magda/daw/core/controllers/MidiLearnCoordinator.cpp
+++ b/magda/daw/core/controllers/MidiLearnCoordinator.cpp
@@ -202,7 +202,7 @@ void MidiLearnCoordinator::onCapture(const LearnCapture& capture) {
         if (bestAlias.has_value()) {
             // Extract pluginType from the canonical name: format is "pluginType.paramName"
             // e.g. "serum.filter_cutoff" -> pluginType = "serum"
-            juce::String canonicalName = *bestAlias;
+            const juce::String& canonicalName = *bestAlias;
             juce::String pluginType;
             int dotPos = canonicalName.indexOfChar('.');
             if (dotPos > 0)

--- a/magda/daw/engine/OfflineRenderHelper.cpp
+++ b/magda/daw/engine/OfflineRenderHelper.cpp
@@ -1,5 +1,7 @@
 #include "OfflineRenderHelper.hpp"
 
+#include <utility>
+
 #include "../audio/AudioBridge.hpp"
 #include "TracktionEngineWrapper.hpp"
 
@@ -67,9 +69,8 @@ void restorePluginsAfterOfflineRender(TracktionEngineWrapper& engine) {
 class TracktionOfflineRenderTask final : public OfflineRenderTask {
   public:
     TracktionOfflineRenderTask(TracktionEngineWrapper& engine, tracktion::Edit& edit,
-                               const OfflineRenderRequest& request,
-                               const juce::BigInteger& tracksToDo)
-        : request_(request), params_(edit) {
+                               OfflineRenderRequest request, const juce::BigInteger& tracksToDo)
+        : request_(std::move(request)), params_(edit) {
         params_.destFile = request_.destination;
         auto& formats = engine.getEngine()->getAudioFileFormatManager();
         params_.audioFormat = request_.format == OfflineRenderFormat::Flac ? formats.getFlacFormat()

--- a/magda/daw/engine/PluginMetadataStore.cpp
+++ b/magda/daw/engine/PluginMetadataStore.cpp
@@ -63,8 +63,8 @@ PluginMetadataStore::PluginMetadataStore(const juce::File& databaseFile)
                          databaseFile.getParentDirectory().getChildFile("plugin_exclusions.txt")}) {
 }
 
-PluginMetadataStore::PluginMetadataStore(const juce::File& databaseFile, LegacyFiles legacyFiles)
-    : file_(databaseFile), legacyFiles_(std::move(legacyFiles)) {
+PluginMetadataStore::PluginMetadataStore(juce::File databaseFile, LegacyFiles legacyFiles)
+    : file_(std::move(databaseFile)), legacyFiles_(std::move(legacyFiles)) {
     (void)file_.getParentDirectory().createDirectory();
     db_.open(utf8(file_.getFullPathName()), "open plugin metadata database");
 

--- a/magda/daw/engine/PluginMetadataStore.hpp
+++ b/magda/daw/engine/PluginMetadataStore.hpp
@@ -89,7 +89,7 @@ class PluginMetadataStore {
         juce::File exclusions;
     };
 
-    PluginMetadataStore(const juce::File& databaseFile, LegacyFiles legacyFiles);
+    PluginMetadataStore(juce::File databaseFile, LegacyFiles legacyFiles);
     void createSchema();
     void importLegacyFilesOnce();
 

--- a/magda/daw/engine/PluginScanCoordinator.cpp
+++ b/magda/daw/engine/PluginScanCoordinator.cpp
@@ -39,7 +39,7 @@ juce::File PluginScanCoordinator::getScannerExecutable() {
     auto appBundle = juce::File::getSpecialLocation(juce::File::currentApplicationFile);
 
     juce::StringArray triedPaths;
-    auto tryCandidate = [&triedPaths](juce::File candidate) -> juce::File {
+    auto tryCandidate = [&triedPaths](const juce::File& candidate) -> juce::File {
         triedPaths.add(candidate.getFullPathName());
         return candidate.existsAsFile() ? candidate : juce::File();
     };

--- a/magda/daw/engine/PluginWindowManager.cpp
+++ b/magda/daw/engine/PluginWindowManager.cpp
@@ -153,7 +153,7 @@ void PluginWindowManager::closeAllWindows() {
         juce::ScopedLock lock(windowLock_);
         for (const auto& [deviceId, info] : trackedWindows_) {
             if (info.plugin) {
-                windowsToClose.push_back({deviceId, info.plugin});
+                windowsToClose.emplace_back(deviceId, info.plugin);
             }
         }
     }
@@ -231,11 +231,11 @@ void PluginWindowManager::timerCallback() {
             bool currentlyShowing = extPlugin->windowState->isWindowShowing();
             if (!info.wasOpen && currentlyShowing) {
                 info.wasOpen = true;
-                stateChanges.push_back({deviceId, true});
+                stateChanges.emplace_back(deviceId, true);
             } else if (info.wasOpen && !currentlyShowing) {
                 // Window was closed (via closeButtonPressed or other means)
                 info.wasOpen = false;
-                stateChanges.push_back({deviceId, false});
+                stateChanges.emplace_back(deviceId, false);
             }
         }
     }

--- a/magda/daw/engine/ScanWorker.cpp
+++ b/magda/daw/engine/ScanWorker.cpp
@@ -1,9 +1,13 @@
 #include "ScanWorker.hpp"
 
+#include <utility>
+
 namespace magda {
 
-ScanWorker::ScanWorker(int index, const juce::File& scannerExe, ResultCallback callback)
-    : workerIndex_(index), scannerExe_(scannerExe), resultCallback_(std::move(callback)) {}
+ScanWorker::ScanWorker(int index, juce::File scannerExe, ResultCallback callback)
+    : workerIndex_(index),
+      scannerExe_(std::move(scannerExe)),
+      resultCallback_(std::move(callback)) {}
 
 ScanWorker::~ScanWorker() {
     busy_ = false;

--- a/magda/daw/engine/ScanWorker.hpp
+++ b/magda/daw/engine/ScanWorker.hpp
@@ -29,7 +29,7 @@ class ScanWorker : private juce::ChildProcessCoordinator {
 
     using ResultCallback = std::function<void(int workerIndex, const Result& result)>;
 
-    ScanWorker(int index, const juce::File& scannerExe, ResultCallback callback);
+    ScanWorker(int index, juce::File scannerExe, ResultCallback callback);
     ~ScanWorker() override;
 
     void scanPlugin(const juce::String& formatName, const juce::String& pluginPath);

--- a/magda/daw/engine/TracktionEngineWrapperDevices.cpp
+++ b/magda/daw/engine/TracktionEngineWrapperDevices.cpp
@@ -176,7 +176,7 @@ juce::BigInteger TracktionEngineWrapper::getEnabledWaveChannels(bool input) cons
     if (engine_ == nullptr)
         return channels;
 
-    const auto addEnabledChannels = [&channels](auto devices) {
+    const auto addEnabledChannels = [&channels](const auto& devices) {
         for (auto* device : devices) {
             if (device == nullptr || !device->isEnabled())
                 continue;
@@ -195,7 +195,7 @@ void TracktionEngineWrapper::setEnabledWaveChannels(bool input, const juce::BigI
     if (engine_ == nullptr)
         return;
 
-    const auto applyChannels = [&channels](auto devices) {
+    const auto applyChannels = [&channels](const auto& devices) {
         for (auto* device : devices) {
             if (device == nullptr)
                 continue;

--- a/magda/daw/engine/TracktionEngineWrapperTracks.cpp
+++ b/magda/daw/engine/TracktionEngineWrapperTracks.cpp
@@ -121,6 +121,7 @@ void TracktionEngineWrapper::setTrackColor(const std::string& track_id, int r, i
 
 std::vector<std::string> TracktionEngineWrapper::getAllTrackIds() const {
     std::vector<std::string> ids;
+    ids.reserve(trackMap_.size());
     for (const auto& pair : trackMap_) {
         ids.push_back(pair.first);
     }

--- a/magda/daw/media_db/MediaDbMetadata.cpp
+++ b/magda/daw/media_db/MediaDbMetadata.cpp
@@ -10,6 +10,7 @@
 #include <sstream>
 #include <string>
 #include <unordered_map>
+#include <utility>
 
 #include "MediaDatabase.hpp"
 #include "MediaDbContext.hpp"
@@ -415,7 +416,7 @@ void setUserKeyRootForFile(const std::filesystem::path& path, std::optional<std:
     if (!ctx.ensureInitialized()) {
         return;
     }
-    setUserKeyRoot(ctx.db(), path, root);
+    setUserKeyRoot(ctx.db(), path, std::move(root));
 }
 
 void setUserKeyForFile(const std::filesystem::path& path, std::optional<std::string> root,

--- a/magda/daw/media_db/SampleTaggerDownloader.cpp
+++ b/magda/daw/media_db/SampleTaggerDownloader.cpp
@@ -217,7 +217,7 @@ class SampleTaggerDownloader::Worker : public juce::Thread {
         return hash.toHexString();
     }
 
-    void postProgress(Progress p) {
+    void postProgress(const Progress& p) {
         if (!onProgress_) {
             return;
         }

--- a/magda/daw/music/ChordEngine.cpp
+++ b/magda/daw/music/ChordEngine.cpp
@@ -169,6 +169,7 @@ Chord ChordEngine::detect(const std::vector<ChordNote>& heldNotes) {
             auto intervals = ChordUtils::getChordIntervals(quality);
 
             std::vector<int> chordPitches;
+            chordPitches.reserve(intervals.size());
             for (int interval : intervals)
                 chordPitches.push_back((rootOffset + interval) % 12);
             std::sort(chordPitches.begin(), chordPitches.end());
@@ -391,6 +392,7 @@ Chord ChordEngine::buildChordInRootPosition(ChordRoot root, ChordQuality quality
 
     int rootMidiNote = static_cast<int>(root) + ((octave + 1) * 12);
 
+    notes.reserve(intervals.size());
     for (int interval : intervals)
         notes.emplace_back(rootMidiNote + interval, 100);
 
@@ -406,6 +408,7 @@ std::vector<Chord> ChordEngine::buildChordInversions(ChordRoot root, ChordQualit
                                                      int octave) const {
     std::vector<Chord> inversions;
     int maxInv = getMaxInversions(quality);
+    inversions.reserve(maxInv);
     for (int inv = 0; inv < maxInv; ++inv)
         inversions.push_back(buildChordInversion(root, quality, inv, octave));
     return inversions;
@@ -418,6 +421,7 @@ Chord ChordEngine::buildChordInversion(ChordRoot root, ChordQuality quality, int
 
     const int rootMidiNote = static_cast<int>(root) + ((octave + 1) * 12);
 
+    notes.reserve(intervals.size());
     for (int interval : intervals)
         notes.emplace_back(rootMidiNote + interval, 100);
 
@@ -484,6 +488,7 @@ std::vector<std::pair<juce::String, float>> ChordEngine::findChordsFromNotes(
         for (ChordQuality quality : qualities) {
             auto intervals = ChordUtils::getChordIntervals(quality);
             std::vector<int> chordPitches;
+            chordPitches.reserve(intervals.size());
             for (int interval : intervals)
                 chordPitches.push_back((rootOffset + interval) % 12);
             std::sort(chordPitches.begin(), chordPitches.end());

--- a/magda/daw/music/ChordSuggestionEngine.cpp
+++ b/magda/daw/music/ChordSuggestionEngine.cpp
@@ -220,7 +220,7 @@ std::pair<juce::String, juce::String> ChordSuggestionEngine::inferKeyModeFromCon
 
         // Count root notes
         if (chord.rootNoteNumber >= 0) {
-            const juce::String rootName = NOTE_NAMES[chord.rootNoteNumber % 12];
+            const juce::String& rootName = NOTE_NAMES[chord.rootNoteNumber % 12];
             rootCounts[rootName]++;
         }
 
@@ -498,7 +498,7 @@ std::vector<ChordSuggestionEngine::SuggestionItem> ChordSuggestionEngine::genera
         // Final safety: synthesize only when novelty allows non-diatonic/fallback content
         if (params.novelty > 0.0f) {
             for (int i = 0; i < 12 && static_cast<int>(suggestions.size()) < minDesired; ++i) {
-                juce::String rootName = NOTE_NAMES[i];
+                const juce::String& rootName = NOTE_NAMES[i];
                 juce::String quality = (i % 2 == 0) ? "maj" : "min";
                 auto chord = buildChordObject(rootName, quality, targetOctave, effectiveInversions,
                                               recentChords);
@@ -910,9 +910,9 @@ ChordSuggestionEngine::generateNonDiatonicCandidates(const juce::String& key,
             std::vector<ChordNote> notes;
             notes.reserve(lowerNotes.size() + upperNotes.size());
             for (int n : lowerNotes)
-                notes.push_back({n, 100});
+                notes.emplace_back(n, 100);
             for (int n : upperNotes)
-                notes.push_back({n, 100});
+                notes.emplace_back(n, 100);
             std::sort(notes.begin(), notes.end(),
                       [](auto& a, auto& b) { return a.noteNumber < b.noteNumber; });
 
@@ -1124,7 +1124,7 @@ Chord ChordSuggestionEngine::buildChordInRootPosition(const juce::String& root,
     // Helpers
     auto addNote = [&](int midi) {
         if (midi >= 0)
-            notes.push_back({midi, 100});
+            notes.emplace_back(midi, 100);
     };
     auto ensureSorted = [&]() {
         std::sort(notes.begin(), notes.end(),
@@ -1996,7 +1996,7 @@ juce::String ChordSuggestionEngine::getDetectedScalesString(float /*novelty*/) c
             // Only show scales with good confidence
             if (matchScore.matchedNotes.size() >= 3) {
                 // Format scale name without duplicating root note
-                juce::String rootNote = NOTE_NAMES[scale.rootNote % 12];
+                const juce::String& rootNote = NOTE_NAMES[scale.rootNote % 12];
                 juce::String scaleName = juce::String(scale.name);
 
                 // Check if scale name already starts with the root note
@@ -2124,7 +2124,7 @@ std::vector<std::pair<juce::String, juce::String>> ChordSuggestionEngine::getTop
                     scaleName = scaleName.replace("Aeolian", "Minor");
                 }
 
-                topScales.push_back({rootNote, scaleName});
+                topScales.emplace_back(rootNote, scaleName);
             }
         }
 

--- a/magda/daw/profiling/PerformanceProfiler.hpp
+++ b/magda/daw/profiling/PerformanceProfiler.hpp
@@ -6,6 +6,7 @@
 #include <limits>
 #include <string>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 namespace magda {
@@ -60,8 +61,8 @@ class HighResTimer {
  */
 class ScopedProfiler {
   public:
-    explicit ScopedProfiler(const juce::String& name, bool enabled = true)
-        : name_(name), enabled_(enabled) {
+    explicit ScopedProfiler(juce::String name, bool enabled = true)
+        : name_(std::move(name)), enabled_(enabled) {
         if (enabled_) {
             timer_.reset();
         }
@@ -227,7 +228,7 @@ class PerformanceMonitor {
  */
 class MonitoredProfiler {
   public:
-    explicit MonitoredProfiler(const juce::String& category) : category_(category), timer_() {}
+    explicit MonitoredProfiler(juce::String category) : category_(std::move(category)), timer_() {}
 
     ~MonitoredProfiler() {
         try {

--- a/magda/daw/project/MediaCollector.cpp
+++ b/magda/daw/project/MediaCollector.cpp
@@ -98,7 +98,7 @@ MediaCollector::Plan MediaCollector::scan() {
             return -1;
         }
 
-        const auto key = file.getFullPathName();
+        const auto& key = file.getFullPathName();
         auto it = indexByPath.find(key);
         if (it != indexByPath.end())
             return static_cast<long>(it->second);

--- a/magda/daw/project/ProjectManager.cpp
+++ b/magda/daw/project/ProjectManager.cpp
@@ -425,7 +425,7 @@ bool ProjectManager::saveProjectAs(const juce::File& file) {
 }
 
 bool ProjectManager::loadProject(const juce::File& file,
-                                 std::function<void(const ProjectInfo&)> onBeforeCommit) {
+                                 const std::function<void(const ProjectInfo&)>& onBeforeCommit) {
     // Check for unsaved changes in current project
     if (isDirty_ && !showUnsavedChangesDialog()) {
         return false;
@@ -521,8 +521,8 @@ bool ProjectManager::exportDawProject(const juce::File& file) {
 }
 
 void ProjectManager::importDawProjectAsync(
-    const juce::File& file, std::function<void(const ProjectInfo&)> onBeforeCommit,
-    std::function<void(bool, const juce::String&)> onComplete) {
+    const juce::File& file, const std::function<void(const ProjectInfo&)>& onBeforeCommit,
+    const std::function<void(bool, const juce::String&)>& onComplete) {
     // Pre-flight checks on the message thread.
     if (isDirty_ && !showUnsavedChangesDialog()) {
         if (onComplete)
@@ -548,7 +548,7 @@ void ProjectManager::importDawProjectAsync(
     joinBackgroundThread();
 
     const auto startingRevision = mutationRevision_;
-    auto fileCopy = file;
+    const auto& fileCopy = file;
     loadThread_ =
         std::thread([fileCopy, importedDir, startingRevision, onBeforeCommit, onComplete, this]() {
             auto staged = std::make_shared<StagedProjectData>();
@@ -599,9 +599,9 @@ void ProjectManager::importDawProjectAsync(
         });
 }
 
-void ProjectManager::loadProjectAsync(const juce::File& file,
-                                      std::function<void(const ProjectInfo&)> onBeforeCommit,
-                                      std::function<void(bool, const juce::String&)> onComplete) {
+void ProjectManager::loadProjectAsync(
+    const juce::File& file, const std::function<void(const ProjectInfo&)>& onBeforeCommit,
+    const std::function<void(bool, const juce::String&)>& onComplete) {
     // Pre-flight checks on the message thread
     if (isDirty_ && !showUnsavedChangesDialog()) {
         if (onComplete)
@@ -635,7 +635,7 @@ void ProjectManager::loadProjectAsync(const juce::File& file,
     joinBackgroundThread();
 
     const auto startingRevision = mutationRevision_;
-    auto originalFile = file;
+    const auto& originalFile = file;
 
     // Launch background thread for I/O + parse + staging
     loadThread_ = std::thread([fileCopy, originalFile, recoveredFromAutosave, onBeforeCommit,

--- a/magda/daw/project/ProjectManager.hpp
+++ b/magda/daw/project/ProjectManager.hpp
@@ -97,7 +97,7 @@ class ProjectManager {
      * @return true on success
      */
     bool loadProject(const juce::File& file,
-                     std::function<void(const ProjectInfo&)> onBeforeCommit = nullptr);
+                     const std::function<void(const ProjectInfo&)>& onBeforeCommit = nullptr);
 
     /**
      * @brief Export the current project to a .dawproject interchange archive.
@@ -113,8 +113,8 @@ class ProjectManager {
      * @param onComplete (success, errorMessage); empty error on user cancel.
      */
     void importDawProjectAsync(const juce::File& file,
-                               std::function<void(const ProjectInfo&)> onBeforeCommit,
-                               std::function<void(bool, const juce::String&)> onComplete);
+                               const std::function<void(const ProjectInfo&)>& onBeforeCommit,
+                               const std::function<void(bool, const juce::String&)>& onComplete);
 
     /**
      * @brief Load project asynchronously (heavy I/O on background thread, commit on message thread)
@@ -125,8 +125,8 @@ class ProjectManager {
      * @param onComplete Callback invoked on message thread after commit: (success, errorMessage)
      */
     void loadProjectAsync(const juce::File& file,
-                          std::function<void(const ProjectInfo&)> onBeforeCommit,
-                          std::function<void(bool, const juce::String&)> onComplete);
+                          const std::function<void(const ProjectInfo&)>& onBeforeCommit,
+                          const std::function<void(bool, const juce::String&)>& onComplete);
 
     /**
      * @brief Close current project

--- a/magda/daw/project/serialization/DawProjectXmlAdapter.cpp
+++ b/magda/daw/project/serialization/DawProjectXmlAdapter.cpp
@@ -558,7 +558,7 @@ void addBuiltinParam(DeviceInfo& device, int slot, juce::StringRef name, double 
 // explicit ms unit just in case a host writes one.
 double dawSecondsToMs(const juce::XmlElement& e) {
     const double v = e.getDoubleAttribute("value");
-    const auto unit = e.getStringAttribute("unit");
+    const auto& unit = e.getStringAttribute("unit");
     return (unit == "milliseconds" || unit == "ms") ? v : v * 1000.0;
 }
 
@@ -1164,7 +1164,7 @@ bool DawProjectXmlAdapter::fromProjectXml(const juce::String& xml, ProjectDocume
                 track.name =
                     trackElement->getStringAttribute("name", "Track " + juce::String(track.id));
                 track.colour = colourFromDawProject(trackElement->getStringAttribute("color"));
-                const auto contentType = trackElement->getStringAttribute("contentType");
+                const auto& contentType = trackElement->getStringAttribute("contentType");
                 track.type = contentType.contains("tracks") ? TrackType::Group : TrackType::Media;
                 track.parentId = parentId;
                 const size_t trackIndex = document.tracks.size();
@@ -1252,7 +1252,7 @@ bool DawProjectXmlAdapter::fromProjectXml(const juce::String& xml, ProjectDocume
                                     parseEqualizerDevice(*devEl, device);
                                 if (auto* enabled = devEl->getChildByName("Enabled"))
                                     device.bypassed = !enabled->getBoolAttribute("value", true);
-                                track.chain.fxChainElements.push_back(std::move(device));
+                                track.chain.fxChainElements.emplace_back(std::move(device));
                                 continue;
                             }
 
@@ -1283,7 +1283,7 @@ bool DawProjectXmlAdapter::fromProjectXml(const juce::String& xml, ProjectDocume
                             if (auto* state = devEl->getChildByName("State"))
                                 device.pluginState = state->getStringAttribute("path");
 
-                            track.chain.fxChainElements.push_back(std::move(device));
+                            track.chain.fxChainElements.emplace_back(std::move(device));
                         }
                     }
                 }

--- a/magda/daw/stem_separation/StemModelDownloader.cpp
+++ b/magda/daw/stem_separation/StemModelDownloader.cpp
@@ -303,7 +303,7 @@ class StemModelDownloader::Worker : public juce::Thread {
         return hash.toHexString();
     }
 
-    void postProgress(Progress p) {
+    void postProgress(const Progress& p) {
         if (!onProgress_)
             return;
         auto cb = onProgress_;

--- a/magda/daw/ui/components/automation/AutomationLaneComponent.cpp
+++ b/magda/daw/ui/components/automation/AutomationLaneComponent.cpp
@@ -681,7 +681,7 @@ void AutomationLaneComponent::paintScaleLabels(juce::Graphics& g, juce::Rectangl
     if (!lane)
         return;
 
-    paintScaleLabelsFor(g, area, lane->target, [this, &area](double normalized) {
+    paintScaleLabelsFor(g, area, lane->target, [&area](double normalized) {
         return valueToPixel(normalized, area.getHeight());
     });
 }

--- a/magda/daw/ui/components/automation/AutomationLaneHeader.cpp
+++ b/magda/daw/ui/components/automation/AutomationLaneHeader.cpp
@@ -419,27 +419,25 @@ void paintAutomationLaneHeader(juce::Graphics& g, const AutomationLaneInfo& lane
                 for (const auto& [db, label] : dbValues) {
                     float norm =
                         ParameterUtils::realToNormalized(static_cast<float>(db), paramInfo);
-                    gridValues.push_back({static_cast<double>(norm), label});
+                    gridValues.emplace_back(static_cast<double>(norm), label);
                 }
             } else if (lane.target.kind == ControlTarget::Kind::TrackPan) {
-                gridValues.push_back(
-                    {static_cast<double>(ParameterUtils::realToNormalized(1.0f, paramInfo)), "R"});
-                gridValues.push_back(
-                    {static_cast<double>(ParameterUtils::realToNormalized(0.5f, paramInfo)),
-                     "50R"});
-                gridValues.push_back(
-                    {static_cast<double>(ParameterUtils::realToNormalized(0.0f, paramInfo)), "C"});
-                gridValues.push_back(
-                    {static_cast<double>(ParameterUtils::realToNormalized(-0.5f, paramInfo)),
-                     "50L"});
-                gridValues.push_back(
-                    {static_cast<double>(ParameterUtils::realToNormalized(-1.0f, paramInfo)), "L"});
+                gridValues.emplace_back(
+                    static_cast<double>(ParameterUtils::realToNormalized(1.0f, paramInfo)), "R");
+                gridValues.emplace_back(
+                    static_cast<double>(ParameterUtils::realToNormalized(0.5f, paramInfo)), "50R");
+                gridValues.emplace_back(
+                    static_cast<double>(ParameterUtils::realToNormalized(0.0f, paramInfo)), "C");
+                gridValues.emplace_back(
+                    static_cast<double>(ParameterUtils::realToNormalized(-0.5f, paramInfo)), "50L");
+                gridValues.emplace_back(
+                    static_cast<double>(ParameterUtils::realToNormalized(-1.0f, paramInfo)), "L");
             } else if (paramInfo.scale == ParameterScale::Boolean) {
                 // A switch has exactly two meaningful positions. Without
                 // this it falls through to the 10% grid at the bottom of
                 // the chain and reads as a continuous percentage.
-                gridValues.push_back({1.0, "On"});
-                gridValues.push_back({0.0, "Off"});
+                gridValues.emplace_back(1.0, "On");
+                gridValues.emplace_back(0.0, "Off");
             } else if (paramInfo.isBipolar()) {
                 // Bipolar params (EQ gain, pitch, etc): symmetric labels
                 // around zero so the 0 line lands mid-lane. Use the larger
@@ -457,7 +455,7 @@ void paintAutomationLaneHeader(juce::Graphics& g, const AutomationLaneInfo& lane
                     else
                         label = juce::String(rounded);
                     label += paramInfo.unit;
-                    gridValues.push_back({static_cast<double>(norm), label});
+                    gridValues.emplace_back(static_cast<double>(norm), label);
                 }
             } else if (paramInfo.scale == ParameterScale::Discrete && !paramInfo.choices.empty()) {
                 // Discrete: use the choices array as label source. Each
@@ -471,15 +469,15 @@ void paintAutomationLaneHeader(juce::Graphics& g, const AutomationLaneInfo& lane
                 if (!paramInfo.labelTicks.empty()) {
                     for (const auto& [realValue, label] : paramInfo.labelTicks) {
                         float norm = ParameterUtils::realToNormalized(realValue, paramInfo);
-                        gridValues.push_back({static_cast<double>(norm), label});
+                        gridValues.emplace_back(static_cast<double>(norm), label);
                     }
                 } else {
                     int numChoices = static_cast<int>(paramInfo.choices.size());
                     for (int i = 0; i < numChoices; ++i) {
                         float norm =
                             ParameterUtils::realToNormalized(static_cast<float>(i), paramInfo);
-                        gridValues.push_back(
-                            {static_cast<double>(norm), paramInfo.choices[static_cast<size_t>(i)]});
+                        gridValues.emplace_back(static_cast<double>(norm),
+                                                paramInfo.choices[static_cast<size_t>(i)]);
                     }
                 }
             } else if (paramInfo.unit.isNotEmpty()) {
@@ -490,7 +488,7 @@ void paintAutomationLaneHeader(juce::Graphics& g, const AutomationLaneInfo& lane
                         ParameterUtils::normalizedToReal(static_cast<float>(norm), paramInfo);
                     juce::String label =
                         juce::String(static_cast<int>(std::round(real))) + paramInfo.unit;
-                    gridValues.push_back({norm, label});
+                    gridValues.emplace_back(norm, label);
                 }
             } else if (paramInfo.displayText) {
                 // displayText wraps TE's valueToString, which expects a
@@ -511,22 +509,21 @@ void paintAutomationLaneHeader(juce::Graphics& g, const AutomationLaneInfo& lane
                         teRaw = paramInfo.teMinValue + static_cast<float>(norm) * teSpan;
                     }
                     auto text = paramInfo.displayText->format(teRaw);
-                    gridValues.push_back(
-                        {norm, text.isNotEmpty()
-                                   ? text
-                                   : juce::String(static_cast<int>(norm * 100)) + "%"});
+                    gridValues.emplace_back(
+                        norm, text.isNotEmpty() ? text
+                                                : juce::String(static_cast<int>(norm * 100)) + "%");
                 }
             } else if (!paramInfo.valueTable.empty()) {
                 for (double norm : {0.0, 0.25, 0.5, 0.75, 1.0}) {
                     int idx = juce::jlimit(
                         0, static_cast<int>(paramInfo.valueTable.size()) - 1,
                         static_cast<int>(std::round(norm * (paramInfo.valueTable.size() - 1))));
-                    gridValues.push_back(
-                        {norm, paramInfo.valueTable[static_cast<size_t>(idx)].trim()});
+                    gridValues.emplace_back(norm,
+                                            paramInfo.valueTable[static_cast<size_t>(idx)].trim());
                 }
             } else {
                 for (int i = 1; i < 10; ++i)
-                    gridValues.push_back({i / 10.0, juce::String(i * 10) + "%"});
+                    gridValues.emplace_back(i / 10.0, juce::String(i * 10) + "%");
             }
 
             g.setFont(FontManager::getInstance().getUIFont(8.0f));

--- a/magda/daw/ui/components/automation/AutomationMenu.cpp
+++ b/magda/daw/ui/components/automation/AutomationMenu.cpp
@@ -13,8 +13,9 @@
 
 namespace magda {
 
-void showAutomationMenu(TrackId trackId, juce::Component* relativeTo,
-                        std::function<void(TrackId, AutomationLaneId)> onShowAutomationLane) {
+void showAutomationMenu(
+    TrackId trackId, juce::Component* relativeTo,
+    const std::function<void(TrackId, AutomationLaneId)>& onShowAutomationLane) {
     auto& automationManager = AutomationManager::getInstance();
 
     juce::PopupMenu menu;

--- a/magda/daw/ui/components/automation/AutomationMenu.hpp
+++ b/magda/daw/ui/components/automation/AutomationMenu.hpp
@@ -23,7 +23,8 @@ namespace magda {
  *        the host can scroll it into view. The master band updates via its own
  *        AutomationManager listener, so it can pass an empty callback.
  */
-void showAutomationMenu(TrackId trackId, juce::Component* relativeTo,
-                        std::function<void(TrackId, AutomationLaneId)> onShowAutomationLane = {});
+void showAutomationMenu(
+    TrackId trackId, juce::Component* relativeTo,
+    const std::function<void(TrackId, AutomationLaneId)>& onShowAutomationLane = {});
 
 }  // namespace magda

--- a/magda/daw/ui/components/chain/DeviceSlotComponent.cpp
+++ b/magda/daw/ui/components/chain/DeviceSlotComponent.cpp
@@ -73,27 +73,27 @@ void DeviceSlotComponent::wireSharedModMacroLinkCallbacks(LinkTarget& target,
 
     DeviceLinkCallbackContext context;
     context.getNodePath = [safeThis]() {
-        auto self = safeThis;
+        const auto& self = safeThis;
         return self ? self->nodePath_ : magda::ChainNodePath{};
     };
     context.onMacroTargetChanged = [safeThis](int macroIndex, magda::ControlTarget target) {
-        if (auto self = safeThis)
-            self->onMacroTargetChangedInternal(macroIndex, target);
+        if (const auto& self = safeThis)
+            self->onMacroTargetChangedInternal(macroIndex, std::move(target));
     };
     context.updateParamModulation = [safeThis]() {
-        if (auto self = safeThis)
+        if (const auto& self = safeThis)
             self->updateParamModulation();
     };
     context.updateModsPanel = [safeThis]() {
-        if (auto self = safeThis)
+        if (const auto& self = safeThis)
             self->updateModsPanel();
     };
     context.updateMacroPanel = [safeThis]() {
-        if (auto self = safeThis)
+        if (const auto& self = safeThis)
             self->updateMacroPanel();
     };
     context.expandModPanelForDirectLink = [safeThis]() {
-        auto self = safeThis;
+        const auto& self = safeThis;
         if (!self || self->modPanelVisible_)
             return;
 
@@ -102,7 +102,7 @@ void DeviceSlotComponent::wireSharedModMacroLinkCallbacks(LinkTarget& target,
         self->setModPanelVisible(true);
     };
     context.expandMacroPanelForDirectLink = [safeThis]() {
-        auto self = safeThis;
+        const auto& self = safeThis;
         if (!self || self->paramPanelVisible_)
             return;
 
@@ -509,8 +509,8 @@ DeviceSlotComponent::DeviceSlotComponent(const magda::DeviceInfo& device) : devi
 
         // Wire up mod/macro linking callbacks
         paramSlot->onModLinked = [safeThis = juce::Component::SafePointer(this)](
-                                     int modIndex, magda::ControlTarget target) {
-            auto self = safeThis;
+                                     int modIndex, const magda::ControlTarget& target) {
+            const auto& self = safeThis;
             if (!self)
                 return;
             self->onModTargetChangedInternal(modIndex, target);
@@ -520,7 +520,7 @@ DeviceSlotComponent::DeviceSlotComponent(const magda::DeviceInfo& device) : devi
         wireSharedModMacroLinkCallbacks(*paramSlot, true);
         paramSlot->onMacroValueChanged = [safeThis = juce::Component::SafePointer(this)](
                                              int macroIndex, float value) {
-            auto self = safeThis;
+            const auto& self = safeThis;
             if (!self)
                 return;
             magda::TrackManager::getInstance().setMacroValue(self->nodePath_, macroIndex, value);
@@ -528,7 +528,7 @@ DeviceSlotComponent::DeviceSlotComponent(const magda::DeviceInfo& device) : devi
                 self->updateParamModulation();
         };
         paramSlot->onShowAutomationLane = [safeThis = juce::Component::SafePointer(this), i]() {
-            if (auto self = safeThis)
+            if (const auto& self = safeThis)
                 if (auto* slot = self->paramGrid_->getSlot(i))
                     self->showAutomationLaneForParam(slot->getParamIndex());
         };
@@ -1798,7 +1798,7 @@ void DeviceSlotComponent::wirePadChainLinkCallbacks() {
     };
     callbacks.onMacroTargetChanged = [safeThis](int macroIndex, magda::ControlTarget target) {
         if (safeThis != nullptr)
-            safeThis->onMacroTargetChangedInternal(macroIndex, target);
+            safeThis->onMacroTargetChangedInternal(macroIndex, std::move(target));
     };
     callbacks.showAutomationLaneForParam = [safeThis](int paramIndex) {
         if (safeThis != nullptr)
@@ -1818,14 +1818,14 @@ void DeviceSlotComponent::setupCustomUILinking() {
     configureDeviceSlotLinkableSliders(
         sliders, device_, nodePath_, context,
         [safeThis = juce::Component::SafePointer(this)](LinkableTextSlider& slider) {
-            auto self = safeThis;
+            const auto& self = safeThis;
             if (!self)
                 return;
 
             self->wireSharedModMacroLinkCallbacks(slider, false);
             auto* sliderPtr = &slider;
             slider.onShowAutomationLane = [safeThis, sliderPtr]() {
-                auto self = safeThis;
+                const auto& self = safeThis;
                 if (!self || sliderPtr == nullptr)
                     return;
                 self->showAutomationLaneForParam(sliderPtr->getParamIndex());

--- a/magda/daw/ui/components/chain/NodeComponent.cpp
+++ b/magda/daw/ui/components/chain/NodeComponent.cpp
@@ -2,6 +2,8 @@
 
 #include <BinaryData.h>
 
+#include <utility>
+
 #include "../../utils/SelectionPolicy.hpp"
 #include "ChainNodePathDrag.hpp"
 #include "ai/AIPanelComponent.hpp"
@@ -72,7 +74,7 @@ struct NodeComponent::PanelFadeTimer : private juce::Timer {
                 continue;
             component->setAlpha(startAlpha_);
             component->setVisible(true);
-            targets_.push_back(component);
+            targets_.emplace_back(component);
         }
 
         if (targets_.empty()) {
@@ -102,7 +104,7 @@ struct NodeComponent::PanelFadeTimer : private juce::Timer {
                 continue;
             component->setAlpha(startAlpha_);
             component->setVisible(true);
-            targets_.push_back(component);
+            targets_.emplace_back(component);
         }
 
         if (targets_.empty()) {
@@ -1441,10 +1443,10 @@ void NodeComponent::initializeModsMacrosPanels() {
     // Create mods panel
     modsPanel_ = std::make_unique<ModsPanelComponent>();
     modsPanel_->onModTargetChanged = [this](int modIndex, magda::ControlTarget target) {
-        onModTargetChangedInternal(modIndex, target);
+        onModTargetChangedInternal(modIndex, std::move(target));
     };
     modsPanel_->onModLinkRemoved = [this](int modIndex, magda::ControlTarget target) {
-        onModLinkRemovedInternal(modIndex, target);
+        onModLinkRemovedInternal(modIndex, std::move(target));
         updateModsPanel();
         updateModulatorEditor();
     };
@@ -1490,13 +1492,13 @@ void NodeComponent::initializeModsMacrosPanels() {
         onMacroValueChangedInternal(macroIndex, value);
     };
     macroPanel_->onMacroTargetChanged = [this](int macroIndex, magda::ControlTarget target) {
-        onMacroTargetChangedInternal(macroIndex, target);
+        onMacroTargetChangedInternal(macroIndex, std::move(target));
     };
     macroPanel_->onMacroNameChanged = [this](int macroIndex, juce::String name) {
         onMacroNameChangedInternal(macroIndex, name);
     };
     macroPanel_->onMacroLinkRemoved = [this](int macroIndex, magda::ControlTarget target) {
-        onMacroLinkRemovedInternal(macroIndex, target);
+        onMacroLinkRemovedInternal(macroIndex, std::move(target));
         updateMacroPanel();
         updateMacroEditor();
     };
@@ -1694,32 +1696,32 @@ void NodeComponent::initializeModsMacrosPanels() {
 
     // Mod matrix: delete link
     modulatorEditorPanel_->onModLinkDeleted = [this](int modIndex, magda::ControlTarget target) {
-        magda::TrackManager::getInstance().removeModLink(nodePath_, modIndex, target);
+        magda::TrackManager::getInstance().removeModLink(nodePath_, modIndex, std::move(target));
         updateModulatorEditor();
     };
 
     // Mod matrix: toggle bipolar
-    modulatorEditorPanel_->onModLinkBipolarChanged = [this](int modIndex,
-                                                            magda::ControlTarget target,
-                                                            bool bipolar) {
-        magda::TrackManager::getInstance().setModLinkBipolar(nodePath_, modIndex, target, bipolar);
-        updateModulatorEditor();
-    };
+    modulatorEditorPanel_->onModLinkBipolarChanged =
+        [this](int modIndex, magda::ControlTarget target, bool bipolar) {
+            magda::TrackManager::getInstance().setModLinkBipolar(nodePath_, modIndex,
+                                                                 std::move(target), bipolar);
+            updateModulatorEditor();
+        };
 
     // Mod matrix: enable/disable link without losing its amount
-    modulatorEditorPanel_->onModLinkEnabledChanged = [this](int modIndex,
-                                                            magda::ControlTarget target,
-                                                            bool enabled) {
-        magda::TrackManager::getInstance().setModLinkEnabled(nodePath_, modIndex, target, enabled);
-        updateModulatorEditor();
-    };
+    modulatorEditorPanel_->onModLinkEnabledChanged =
+        [this](int modIndex, magda::ControlTarget target, bool enabled) {
+            magda::TrackManager::getInstance().setModLinkEnabled(nodePath_, modIndex,
+                                                                 std::move(target), enabled);
+            updateModulatorEditor();
+        };
 
     // Mod matrix: change link amount
-    modulatorEditorPanel_->onModLinkAmountChanged = [this](int modIndex,
-                                                           magda::ControlTarget target,
-                                                           float amount) {
-        magda::TrackManager::getInstance().setModLinkAmount(nodePath_, modIndex, target, amount);
-    };
+    modulatorEditorPanel_->onModLinkAmountChanged =
+        [this](int modIndex, magda::ControlTarget target, float amount) {
+            magda::TrackManager::getInstance().setModLinkAmount(nodePath_, modIndex,
+                                                                std::move(target), amount);
+        };
 
     addChildComponent(*modulatorEditorPanel_);
 
@@ -1737,18 +1739,18 @@ void NodeComponent::initializeModsMacrosPanels() {
     };
     macroEditorPanel_->onLinkAmountChanged = [this](magda::ControlTarget target, float amount) {
         if (selectedMacroIndex_ >= 0) {
-            onMacroLinkAmountChangedInternal(selectedMacroIndex_, target, amount);
+            onMacroLinkAmountChangedInternal(selectedMacroIndex_, std::move(target), amount);
         }
     };
     macroEditorPanel_->onLinkRemoved = [this](magda::ControlTarget target) {
         if (selectedMacroIndex_ >= 0) {
-            onMacroLinkRemovedInternal(selectedMacroIndex_, target);
+            onMacroLinkRemovedInternal(selectedMacroIndex_, std::move(target));
             updateMacroEditor();
         }
     };
     macroEditorPanel_->onLinkBipolarToggled = [this](magda::ControlTarget target, bool bipolar) {
         if (selectedMacroIndex_ >= 0) {
-            onMacroLinkBipolarChangedInternal(selectedMacroIndex_, target, bipolar);
+            onMacroLinkBipolarChangedInternal(selectedMacroIndex_, std::move(target), bipolar);
             updateMacroEditor();
         }
     };

--- a/magda/daw/ui/components/chain/RackComponent.cpp
+++ b/magda/daw/ui/components/chain/RackComponent.cpp
@@ -24,7 +24,7 @@ namespace {
 /// that follows destroys the button whose click is still on the stack; the path
 /// is taken by value for the same reason. Both constructors below share this,
 /// so the top-level and nested X do the same thing (#2232).
-void requestRackDeletion(magda::ChainNodePath rackPath) {
+void requestRackDeletion(const magda::ChainNodePath& rackPath) {
     juce::MessageManager::callAsync([rackPath]() {
         magda::UndoManager::getInstance().executeCommand(
             std::make_unique<magda::RemoveRackByPathCommand>(rackPath));

--- a/magda/daw/ui/components/chain/ai/AIPanelComponent.cpp
+++ b/magda/daw/ui/components/chain/ai/AIPanelComponent.cpp
@@ -4,6 +4,7 @@
 #include <juce_llm/juce_llm.h>
 
 #include <ranges>
+#include <utility>
 
 #include "../../../../agents/internal_plugins.hpp"
 #include "../../../../agents/llm_presets.hpp"
@@ -24,7 +25,7 @@ class AIPanelComponent::GenerateThread : public juce::Thread {
           owner_(owner),
           agent_(std::move(agent)),
           prompt_(std::move(prompt)),
-          path_(path),
+          path_(std::move(path)),
           conversation_(std::move(conversation)) {}
 
     void run() override {
@@ -62,8 +63,8 @@ class AIPanelComponent::GenerateThread : public juce::Thread {
     }
 
   private:
-    static void postResult(juce::WeakReference<AIPanelComponent> safeOwner, juce::String status,
-                           juce::String conversationJson) {
+    static void postResult(const juce::WeakReference<AIPanelComponent>& safeOwner,
+                           juce::String status, juce::String conversationJson) {
         juce::MessageManager::callAsync([safeOwner, status, conversationJson]() {
             if (auto* p = safeOwner.get())
                 p->onGenerationFinished(status, conversationJson);

--- a/magda/daw/ui/components/chain/compiled/CompiledUtilityView.cpp
+++ b/magda/daw/ui/components/chain/compiled/CompiledUtilityView.cpp
@@ -203,23 +203,24 @@ void CompiledUtilityView::configureLinkSlots() {
         slot.setParamIndex(slotIndex);
         slot.setParamName(name);
 
-        slot.onModLinkedWithAmount = [this](int, magda::ControlTarget target, float amount) {
+        slot.onModLinkedWithAmount = [this](int, const magda::ControlTarget& target, float amount) {
             if (onLinkRequested)
                 onLinkRequested(target.paramIndex, amount);
         };
-        slot.onModAmountChanged = [this](int, magda::ControlTarget target, float amount) {
+        slot.onModAmountChanged = [this](int, const magda::ControlTarget& target, float amount) {
             if (onLinkAmountChanged)
                 onLinkAmountChanged(target.paramIndex, amount);
         };
-        slot.onMacroLinked = [this](int, magda::ControlTarget target) {
+        slot.onMacroLinked = [this](int, const magda::ControlTarget& target) {
             if (onLinkRequested)
                 onLinkRequested(target.paramIndex, 0.3f);
         };
-        slot.onMacroLinkedWithAmount = [this](int, magda::ControlTarget target, float amount) {
+        slot.onMacroLinkedWithAmount = [this](int, const magda::ControlTarget& target,
+                                              float amount) {
             if (onLinkRequested)
                 onLinkRequested(target.paramIndex, amount);
         };
-        slot.onMacroAmountChanged = [this](int, magda::ControlTarget target, float amount) {
+        slot.onMacroAmountChanged = [this](int, const magda::ControlTarget& target, float amount) {
             if (onLinkAmountChanged)
                 onLinkAmountChanged(target.paramIndex, amount);
         };

--- a/magda/daw/ui/components/chain/drum_grid/DeviceSlotDrumGridBridge.cpp
+++ b/magda/daw/ui/components/chain/drum_grid/DeviceSlotDrumGridBridge.cpp
@@ -1,5 +1,7 @@
 #include "drum_grid/DeviceSlotDrumGridBridge.hpp"
 
+#include <utility>
+
 #include "NodeComponent.hpp"
 #include "audio/plugins/DrumGridPlugin.hpp"
 #include "core/LinkModeManager.hpp"
@@ -39,8 +41,8 @@ void refreshMacroUi(const PadChainLinkCallbacks& callbacks) {
 }
 
 template <typename Control>
-void wireLinkableControl(Control& control, PadChainLinkCallbacks callbacks) {
-    control.onModLinkedWithAmount = [callbacks](int modIndex, magda::ControlTarget target,
+void wireLinkableControl(Control& control, const PadChainLinkCallbacks& callbacks) {
+    control.onModLinkedWithAmount = [callbacks](int modIndex, const magda::ControlTarget& target,
                                                 float amount) {
         const auto nodePath =
             callbacks.getNodePath ? callbacks.getNodePath() : magda::ChainNodePath{};
@@ -73,7 +75,7 @@ void wireLinkableControl(Control& control, PadChainLinkCallbacks callbacks) {
     control.onModUnlinked = [callbacks](int modIndex, magda::ControlTarget target) {
         const auto nodePath =
             callbacks.getNodePath ? callbacks.getNodePath() : magda::ChainNodePath{};
-        magda::TrackManager::getInstance().removeModLink(nodePath, modIndex, target);
+        magda::TrackManager::getInstance().removeModLink(nodePath, modIndex, std::move(target));
         refreshModUi(callbacks);
     };
 
@@ -82,7 +84,7 @@ void wireLinkableControl(Control& control, PadChainLinkCallbacks callbacks) {
             callbacks.getNodePath ? callbacks.getNodePath() : magda::ChainNodePath{};
         auto rackPath = nearestRackPathForDevicePath(nodePath);
         if (rackPath.isValid())
-            magda::TrackManager::getInstance().removeModLink(rackPath, modIndex, target);
+            magda::TrackManager::getInstance().removeModLink(rackPath, modIndex, std::move(target));
         refreshModUi(callbacks);
     };
 
@@ -92,11 +94,11 @@ void wireLinkableControl(Control& control, PadChainLinkCallbacks callbacks) {
         auto trackId = nodePath.trackId;
         if (trackId != magda::INVALID_TRACK_ID)
             magda::TrackManager::getInstance().removeModLink(
-                magda::ChainNodePath::trackLevel(trackId), modIndex, target);
+                magda::ChainNodePath::trackLevel(trackId), modIndex, std::move(target));
         refreshModUi(callbacks);
     };
 
-    control.onModAmountChanged = [callbacks](int modIndex, magda::ControlTarget target,
+    control.onModAmountChanged = [callbacks](int modIndex, const magda::ControlTarget& target,
                                              float amount) {
         const auto nodePath =
             callbacks.getNodePath ? callbacks.getNodePath() : magda::ChainNodePath{};
@@ -118,7 +120,8 @@ void wireLinkableControl(Control& control, PadChainLinkCallbacks callbacks) {
             callbacks.updateParamModulation();
     };
 
-    control.onMacroLinkedWithAmount = [callbacks](int macroIndex, magda::ControlTarget target,
+    control.onMacroLinkedWithAmount = [callbacks](int macroIndex,
+                                                  const magda::ControlTarget& target,
                                                   float amount) {
         const auto nodePath =
             callbacks.getNodePath ? callbacks.getNodePath() : magda::ChainNodePath{};
@@ -152,7 +155,7 @@ void wireLinkableControl(Control& control, PadChainLinkCallbacks callbacks) {
 
     control.onMacroLinked = [callbacks](int macroIndex, magda::ControlTarget target) {
         if (callbacks.onMacroTargetChanged)
-            callbacks.onMacroTargetChanged(macroIndex, target);
+            callbacks.onMacroTargetChanged(macroIndex, std::move(target));
         if (callbacks.updateParamModulation)
             callbacks.updateParamModulation();
     };
@@ -160,7 +163,7 @@ void wireLinkableControl(Control& control, PadChainLinkCallbacks callbacks) {
     control.onMacroUnlinked = [callbacks](int macroIndex, magda::ControlTarget target) {
         const auto nodePath =
             callbacks.getNodePath ? callbacks.getNodePath() : magda::ChainNodePath{};
-        magda::TrackManager::getInstance().removeMacroLink(nodePath, macroIndex, target);
+        magda::TrackManager::getInstance().removeMacroLink(nodePath, macroIndex, std::move(target));
         refreshMacroUi(callbacks);
     };
 
@@ -170,11 +173,11 @@ void wireLinkableControl(Control& control, PadChainLinkCallbacks callbacks) {
         auto trackId = nodePath.trackId;
         if (trackId != magda::INVALID_TRACK_ID)
             magda::TrackManager::getInstance().removeMacroLink(
-                magda::ChainNodePath::trackLevel(trackId), macroIndex, target);
+                magda::ChainNodePath::trackLevel(trackId), macroIndex, std::move(target));
         refreshMacroUi(callbacks);
     };
 
-    control.onMacroAmountChanged = [callbacks](int macroIndex, magda::ControlTarget target,
+    control.onMacroAmountChanged = [callbacks](int macroIndex, const magda::ControlTarget& target,
                                                float amount) {
         const auto nodePath =
             callbacks.getNodePath ? callbacks.getNodePath() : magda::ChainNodePath{};
@@ -354,9 +357,9 @@ void appendAvailableDevices(const DrumGridUI* drumGridUI,
             for (int pi = 0; pi < static_cast<int>(chain->plugins.size()); ++pi) {
                 int devId = dg->getPluginDeviceId(chain->index, pi);
                 if (devId >= 0) {
-                    devices.push_back(
-                        {devId,
-                         chain->name + ": " + chain->plugins[static_cast<size_t>(pi)]->getName()});
+                    devices.emplace_back(devId,
+                                         chain->name + ": " +
+                                             chain->plugins[static_cast<size_t>(pi)]->getName());
                 }
             }
         }

--- a/magda/daw/ui/components/chain/modulation/DeviceLinkCallbacks.hpp
+++ b/magda/daw/ui/components/chain/modulation/DeviceLinkCallbacks.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <functional>
+#include <utility>
 
 #include "core/ChainNodePath.hpp"
 #include "core/ControlTarget.hpp"
@@ -42,8 +43,8 @@ inline void updateDeviceLinkMacroPanel(const DeviceLinkCallbackContext& context)
 }
 
 template <typename LinkTarget>
-void wireDeviceModMacroLinkCallbacks(LinkTarget& target, DeviceLinkCallbackContext context) {
-    target.onModLinkedWithAmount = [context](int modIndex, magda::ControlTarget target,
+void wireDeviceModMacroLinkCallbacks(LinkTarget& target, const DeviceLinkCallbackContext& context) {
+    target.onModLinkedWithAmount = [context](int modIndex, const magda::ControlTarget& target,
                                              float amount) {
         auto nodePath = currentDeviceLinkNodePath(context);
         auto activeModSelection = magda::LinkModeManager::getInstance().getModInLinkMode();
@@ -73,7 +74,7 @@ void wireDeviceModMacroLinkCallbacks(LinkTarget& target, DeviceLinkCallbackConte
 
     target.onModUnlinked = [context](int modIndex, magda::ControlTarget target) {
         const auto nodePath = currentDeviceLinkNodePath(context);
-        magda::TrackManager::getInstance().removeModLink(nodePath, modIndex, target);
+        magda::TrackManager::getInstance().removeModLink(nodePath, modIndex, std::move(target));
         updateDeviceLinkParamModulation(context);
         updateDeviceLinkModsPanel(context);
     };
@@ -81,7 +82,7 @@ void wireDeviceModMacroLinkCallbacks(LinkTarget& target, DeviceLinkCallbackConte
     target.onRackModUnlinked = [context](int modIndex, magda::ControlTarget target) {
         auto rackPath = nearestRackPathForDevicePath(currentDeviceLinkNodePath(context));
         if (rackPath.isValid())
-            magda::TrackManager::getInstance().removeModLink(rackPath, modIndex, target);
+            magda::TrackManager::getInstance().removeModLink(rackPath, modIndex, std::move(target));
         updateDeviceLinkParamModulation(context);
         updateDeviceLinkModsPanel(context);
     };
@@ -91,12 +92,13 @@ void wireDeviceModMacroLinkCallbacks(LinkTarget& target, DeviceLinkCallbackConte
         auto trackId = nodePath.trackId;
         if (trackId != magda::INVALID_TRACK_ID)
             magda::TrackManager::getInstance().removeModLink(
-                magda::ChainNodePath::trackLevel(trackId), modIndex, target);
+                magda::ChainNodePath::trackLevel(trackId), modIndex, std::move(target));
         updateDeviceLinkParamModulation(context);
         updateDeviceLinkModsPanel(context);
     };
 
-    target.onModAmountChanged = [context](int modIndex, magda::ControlTarget target, float amount) {
+    target.onModAmountChanged = [context](int modIndex, const magda::ControlTarget& target,
+                                          float amount) {
         auto nodePath = currentDeviceLinkNodePath(context);
         auto activeModSelection = magda::LinkModeManager::getInstance().getModInLinkMode();
         if (activeModSelection.isValid() && activeModSelection.parentPath == nodePath) {
@@ -115,7 +117,7 @@ void wireDeviceModMacroLinkCallbacks(LinkTarget& target, DeviceLinkCallbackConte
         updateDeviceLinkParamModulation(context);
     };
 
-    target.onMacroLinkedWithAmount = [context](int macroIndex, magda::ControlTarget target,
+    target.onMacroLinkedWithAmount = [context](int macroIndex, const magda::ControlTarget& target,
                                                float amount) {
         auto nodePath = currentDeviceLinkNodePath(context);
         auto activeMacroSelection = magda::LinkModeManager::getInstance().getMacroInLinkMode();
@@ -142,7 +144,7 @@ void wireDeviceModMacroLinkCallbacks(LinkTarget& target, DeviceLinkCallbackConte
         updateDeviceLinkParamModulation(context);
     };
 
-    target.onMacroLinked = [context](int macroIndex, magda::ControlTarget target) {
+    target.onMacroLinked = [context](int macroIndex, const magda::ControlTarget& target) {
         if (context.onMacroTargetChanged)
             context.onMacroTargetChanged(macroIndex, target);
 
@@ -160,7 +162,7 @@ void wireDeviceModMacroLinkCallbacks(LinkTarget& target, DeviceLinkCallbackConte
 
     target.onMacroUnlinked = [context](int macroIndex, magda::ControlTarget target) {
         magda::TrackManager::getInstance().removeMacroLink(currentDeviceLinkNodePath(context),
-                                                           macroIndex, target);
+                                                           macroIndex, std::move(target));
         updateDeviceLinkParamModulation(context);
         updateDeviceLinkMacroPanel(context);
     };
@@ -170,7 +172,7 @@ void wireDeviceModMacroLinkCallbacks(LinkTarget& target, DeviceLinkCallbackConte
         auto trackId = nodePath.trackId;
         if (trackId != magda::INVALID_TRACK_ID)
             magda::TrackManager::getInstance().removeMacroLink(
-                magda::ChainNodePath::trackLevel(trackId), macroIndex, target);
+                magda::ChainNodePath::trackLevel(trackId), macroIndex, std::move(target));
         updateDeviceLinkParamModulation(context);
         updateDeviceLinkMacroPanel(context);
     };
@@ -178,7 +180,8 @@ void wireDeviceModMacroLinkCallbacks(LinkTarget& target, DeviceLinkCallbackConte
     target.onRackMacroLinked = [context](int macroIndex, magda::ControlTarget target) {
         auto rackPath = nearestRackPathForDevicePath(currentDeviceLinkNodePath(context));
         if (rackPath.isValid())
-            magda::TrackManager::getInstance().setMacroTarget(rackPath, macroIndex, target);
+            magda::TrackManager::getInstance().setMacroTarget(rackPath, macroIndex,
+                                                              std::move(target));
         updateDeviceLinkParamModulation(context);
     };
 
@@ -187,19 +190,20 @@ void wireDeviceModMacroLinkCallbacks(LinkTarget& target, DeviceLinkCallbackConte
         auto trackId = nodePath.trackId;
         if (trackId != magda::INVALID_TRACK_ID)
             magda::TrackManager::getInstance().setMacroTarget(
-                magda::ChainNodePath::trackLevel(trackId), macroIndex, target);
+                magda::ChainNodePath::trackLevel(trackId), macroIndex, std::move(target));
         updateDeviceLinkParamModulation(context);
     };
 
     target.onRackMacroUnlinked = [context](int macroIndex, magda::ControlTarget target) {
         auto rackPath = nearestRackPathForDevicePath(currentDeviceLinkNodePath(context));
         if (rackPath.isValid())
-            magda::TrackManager::getInstance().removeMacroLink(rackPath, macroIndex, target);
+            magda::TrackManager::getInstance().removeMacroLink(rackPath, macroIndex,
+                                                               std::move(target));
         updateDeviceLinkParamModulation(context);
         updateDeviceLinkMacroPanel(context);
     };
 
-    target.onMacroAmountChanged = [context](int macroIndex, magda::ControlTarget target,
+    target.onMacroAmountChanged = [context](int macroIndex, const magda::ControlTarget& target,
                                             float amount) {
         auto nodePath = currentDeviceLinkNodePath(context);
         auto activeMacroSelection = magda::LinkModeManager::getInstance().getMacroInLinkMode();

--- a/magda/daw/ui/components/chain/modulation/FollowerEditorPanel.cpp
+++ b/magda/daw/ui/components/chain/modulation/FollowerEditorPanel.cpp
@@ -1,5 +1,7 @@
 #include "modulation/FollowerEditorPanel.hpp"
 
+#include <utility>
+
 #include "audio/modifiers/ADSRDebugLog.hpp"
 #include "core/AutomationInfo.hpp"
 #include "ui/themes/DarkTheme.hpp"
@@ -38,7 +40,7 @@ FollowerEditorPanel::FollowerEditorPanel() {
 
     // Time sliders fold their label into the value text (e.g. "A 100 ms").
     auto setupTimeSlider = [this](TextSlider& s, const juce::String& tag, double def,
-                                  std::function<float&()> field) {
+                                  const std::function<float&()>& field) {
         s.setRange(0.0, 5000.0, 1.0);
         s.setSkewForCentre(250.0);
         s.setValue(def, juce::dontSendNotification);
@@ -80,7 +82,7 @@ FollowerEditorPanel::FollowerEditorPanel() {
     // Band-limit detection: a toggle + cutoff slider per band. Filtering the raw
     // source before peak detection lets the follower track just the bass or just
     // the highs of its source.
-    auto setupBandToggle = [this](juce::TextButton& b, std::function<bool&()> field,
+    auto setupBandToggle = [this](juce::TextButton& b, const std::function<bool&()>& field,
                                   TextSlider& freq) {
         b.setClickingTogglesState(true);
         b.setLookAndFeel(&SmallButtonLookAndFeel::getInstance());
@@ -102,7 +104,7 @@ FollowerEditorPanel::FollowerEditorPanel() {
         };
         addAndMakeVisible(b);
     };
-    auto setupFreqSlider = [this](TextSlider& s, double def, std::function<float&()> field) {
+    auto setupFreqSlider = [this](TextSlider& s, double def, const std::function<float&()>& field) {
         s.setRange(20.0, 20000.0, 1.0);
         s.setSkewForCentre(1000.0);
         s.setValue(def, juce::dontSendNotification);
@@ -139,19 +141,19 @@ FollowerEditorPanel::FollowerEditorPanel() {
 
     modMatrixContent_.onDeleteLink = [this](magda::ControlTarget target) {
         if (selectedModIndex_ >= 0 && onModLinkDeleted)
-            onModLinkDeleted(selectedModIndex_, target);
+            onModLinkDeleted(selectedModIndex_, std::move(target));
     };
     modMatrixContent_.onToggleBipolar = [this](magda::ControlTarget target, bool bipolar) {
         if (selectedModIndex_ >= 0 && onModLinkBipolarChanged)
-            onModLinkBipolarChanged(selectedModIndex_, target, bipolar);
+            onModLinkBipolarChanged(selectedModIndex_, std::move(target), bipolar);
     };
     modMatrixContent_.onToggleEnabled = [this](magda::ControlTarget target, bool enabled) {
         if (selectedModIndex_ >= 0 && onModLinkEnabledChanged)
-            onModLinkEnabledChanged(selectedModIndex_, target, enabled);
+            onModLinkEnabledChanged(selectedModIndex_, std::move(target), enabled);
     };
     modMatrixContent_.onAmountChanged = [this](magda::ControlTarget target, float amount) {
         if (selectedModIndex_ >= 0 && onModLinkAmountChanged)
-            onModLinkAmountChanged(selectedModIndex_, target, amount);
+            onModLinkAmountChanged(selectedModIndex_, std::move(target), amount);
     };
 }
 

--- a/magda/daw/ui/components/chain/modulation/MacroEditorPanel.cpp
+++ b/magda/daw/ui/components/chain/modulation/MacroEditorPanel.cpp
@@ -1,5 +1,7 @@
 #include "modulation/MacroEditorPanel.hpp"
 
+#include <utility>
+
 #include "core/AutomationInfo.hpp"
 #include "ui/themes/DarkTheme.hpp"
 #include "ui/themes/FontManager.hpp"
@@ -148,15 +150,15 @@ MacroEditorPanel::MacroEditorPanel() {
     // Link matrix viewport + content
     linkMatrixContent_.onDeleteLink = [this](magda::ControlTarget target) {
         if (onLinkRemoved)
-            onLinkRemoved(target);
+            onLinkRemoved(std::move(target));
     };
     linkMatrixContent_.onAmountChanged = [this](magda::ControlTarget target, float amount) {
         if (onLinkAmountChanged)
-            onLinkAmountChanged(target, amount);
+            onLinkAmountChanged(std::move(target), amount);
     };
     linkMatrixContent_.onToggleBipolar = [this](magda::ControlTarget target, bool bipolar) {
         if (onLinkBipolarToggled)
-            onLinkBipolarToggled(target, bipolar);
+            onLinkBipolarToggled(std::move(target), bipolar);
     };
     linkMatrixViewport_.setViewedComponent(&linkMatrixContent_, false);
     linkMatrixViewport_.setScrollBarsShown(true, false);

--- a/magda/daw/ui/components/chain/modulation/MacroKnobComponent.cpp
+++ b/magda/daw/ui/components/chain/modulation/MacroKnobComponent.cpp
@@ -686,7 +686,7 @@ void MacroKnobComponent::showLinkMenu() {
         // Individual unlink
         int unlinkIdx = result - unlinkBaseId;
         if (unlinkIdx >= 0 && unlinkIdx < static_cast<int>(unlinkTargets.size())) {
-            auto target = unlinkTargets[static_cast<size_t>(unlinkIdx)];
+            const auto& target = unlinkTargets[static_cast<size_t>(unlinkIdx)];
             safeThis->currentMacro_.removeLink(target);
             safeThis->repaint();
             if (safeThis->onLinkRemoved) {

--- a/magda/daw/ui/components/chain/modulation/MacroPanelComponent.cpp
+++ b/magda/daw/ui/components/chain/modulation/MacroPanelComponent.cpp
@@ -25,13 +25,13 @@ void MacroPanelComponent::ensureKnobCount(int count) {
             }
         };
 
-        knob->onTargetChanged = [this, i](magda::ControlTarget target) {
+        knob->onTargetChanged = [this, i](const magda::ControlTarget& target) {
             if (onMacroTargetChanged) {
                 onMacroTargetChanged(i, target);
             }
         };
 
-        knob->onLinkRemoved = [this, i](magda::ControlTarget target) {
+        knob->onLinkRemoved = [this, i](const magda::ControlTarget& target) {
             if (onMacroLinkRemoved) {
                 onMacroLinkRemoved(i, target);
             }

--- a/magda/daw/ui/components/chain/modulation/ModKnobComponent.cpp
+++ b/magda/daw/ui/components/chain/modulation/ModKnobComponent.cpp
@@ -522,7 +522,7 @@ void ModKnobComponent::showContextMenu() {
 
         int unlinkIdx = result - kUnlinkBaseId;
         if (unlinkIdx >= 0 && unlinkIdx < static_cast<int>(unlinkTargets.size())) {
-            auto target = unlinkTargets[static_cast<size_t>(unlinkIdx)];
+            const auto& target = unlinkTargets[static_cast<size_t>(unlinkIdx)];
             safeThis->currentMod_.removeLink(target);
             safeThis->repaint();
             if (safeThis->onLinkRemoved)

--- a/magda/daw/ui/components/chain/modulation/ModsPanelComponent.cpp
+++ b/magda/daw/ui/components/chain/modulation/ModsPanelComponent.cpp
@@ -124,13 +124,13 @@ void ModsPanelComponent::ensureKnobCount(int count) {
         auto knob = std::make_unique<ModKnobComponent>(i);
 
         // Wire up callbacks with mod index
-        knob->onTargetChanged = [this, i](magda::ControlTarget target) {
+        knob->onTargetChanged = [this, i](const magda::ControlTarget& target) {
             if (onModTargetChanged) {
                 onModTargetChanged(i, target);
             }
         };
 
-        knob->onLinkRemoved = [this, i](magda::ControlTarget target) {
+        knob->onLinkRemoved = [this, i](const magda::ControlTarget& target) {
             if (onModLinkRemoved) {
                 onModLinkRemoved(i, target);
             }

--- a/magda/daw/ui/components/chain/modulation/ModulatorEditorPanel.cpp
+++ b/magda/daw/ui/components/chain/modulation/ModulatorEditorPanel.cpp
@@ -1,5 +1,7 @@
 #include "modulation/ModulatorEditorPanel.hpp"
 
+#include <utility>
+
 #include "BinaryData.h"
 #include "core/AutomationInfo.hpp"
 #include "core/AutomationManager.hpp"
@@ -27,8 +29,8 @@ void ModMatrixContent::setLinks(const std::vector<LinkRow>& links) {
     repaint();
 }
 
-bool ModMatrixContent::updateLinkState(magda::ControlTarget target, float amount, bool bipolar,
-                                       bool enabled) {
+bool ModMatrixContent::updateLinkState(const magda::ControlTarget& target, float amount,
+                                       bool bipolar, bool enabled) {
     for (auto& link : links_) {
         if (link.target == target) {
             bool changed =
@@ -511,7 +513,7 @@ ModulatorEditorPanel::ModulatorEditorPanel() {
     // Time sliders fold their label into the value text (e.g. "A 10 ms") so
     // they don't need separate label components or hand-painted captions.
     auto setupEnvTimeSlider = [this](TextSlider& s, const juce::String& tag, double def,
-                                     std::function<float&()> field) {
+                                     const std::function<float&()>& field) {
         s.setRange(0.0, 30000.0, 1.0);
         s.setSkewForCentre(500.0);
         s.setValue(def, juce::dontSendNotification);
@@ -544,7 +546,7 @@ ModulatorEditorPanel::ModulatorEditorPanel() {
     addChildComponent(envSustainSlider_);
 
     auto setupCurveSlider = [this](TextSlider& s, const juce::String& tag,
-                                   std::function<float&()> field) {
+                                   const std::function<float&()>& field) {
         s.setRange(-0.5, 0.5, 0.01);
         s.setValue(0.0, juce::dontSendNotification);
         s.setFont(FontManager::getInstance().getUIFont(9.0f));
@@ -587,7 +589,7 @@ ModulatorEditorPanel::ModulatorEditorPanel() {
 
     // Random 0..1 sliders fold their label into the value text (e.g. "Shp 0.50").
     auto setupRandomSlider = [this](TextSlider& s, const juce::String& tag,
-                                    std::function<float&()> field) {
+                                    const std::function<float&()>& field) {
         s.setRange(0.0, 1.0, 0.01);
         s.setFont(FontManager::getInstance().getUIFont(9.0f));
         s.setShowFillIndicator(false);
@@ -623,22 +625,22 @@ ModulatorEditorPanel::ModulatorEditorPanel() {
 
     modMatrixContent_.onDeleteLink = [this](magda::ControlTarget target) {
         if (selectedModIndex_ >= 0 && onModLinkDeleted) {
-            onModLinkDeleted(selectedModIndex_, target);
+            onModLinkDeleted(selectedModIndex_, std::move(target));
         }
     };
     modMatrixContent_.onToggleBipolar = [this](magda::ControlTarget target, bool bipolar) {
         if (selectedModIndex_ >= 0 && onModLinkBipolarChanged) {
-            onModLinkBipolarChanged(selectedModIndex_, target, bipolar);
+            onModLinkBipolarChanged(selectedModIndex_, std::move(target), bipolar);
         }
     };
     modMatrixContent_.onToggleEnabled = [this](magda::ControlTarget target, bool enabled) {
         if (selectedModIndex_ >= 0 && onModLinkEnabledChanged) {
-            onModLinkEnabledChanged(selectedModIndex_, target, enabled);
+            onModLinkEnabledChanged(selectedModIndex_, std::move(target), enabled);
         }
     };
     modMatrixContent_.onAmountChanged = [this](magda::ControlTarget target, float amount) {
         if (selectedModIndex_ >= 0 && onModLinkAmountChanged) {
-            onModLinkAmountChanged(selectedModIndex_, target, amount);
+            onModLinkAmountChanged(selectedModIndex_, std::move(target), amount);
         }
     };
 
@@ -661,22 +663,22 @@ ModulatorEditorPanel::ModulatorEditorPanel() {
     };
     followerEditorPanel_->onModLinkDeleted = [this](int idx, magda::ControlTarget target) {
         if (onModLinkDeleted)
-            onModLinkDeleted(idx, target);
+            onModLinkDeleted(idx, std::move(target));
     };
     followerEditorPanel_->onModLinkBipolarChanged = [this](int idx, magda::ControlTarget target,
                                                            bool bipolar) {
         if (onModLinkBipolarChanged)
-            onModLinkBipolarChanged(idx, target, bipolar);
+            onModLinkBipolarChanged(idx, std::move(target), bipolar);
     };
     followerEditorPanel_->onModLinkEnabledChanged = [this](int idx, magda::ControlTarget target,
                                                            bool enabled) {
         if (onModLinkEnabledChanged)
-            onModLinkEnabledChanged(idx, target, enabled);
+            onModLinkEnabledChanged(idx, std::move(target), enabled);
     };
     followerEditorPanel_->onModLinkAmountChanged = [this](int idx, magda::ControlTarget target,
                                                           float amount) {
         if (onModLinkAmountChanged)
-            onModLinkAmountChanged(idx, target, amount);
+            onModLinkAmountChanged(idx, std::move(target), amount);
     };
     addChildComponent(*followerEditorPanel_);
 }

--- a/magda/daw/ui/components/chain/modulation/ModulatorEditorPanel.hpp
+++ b/magda/daw/ui/components/chain/modulation/ModulatorEditorPanel.hpp
@@ -374,7 +374,8 @@ class ModMatrixContent : public juce::Component {
     bool isDragging() const {
         return draggingRow_ >= 0;
     }
-    bool updateLinkState(magda::ControlTarget target, float amount, bool bipolar, bool enabled);
+    bool updateLinkState(const magda::ControlTarget& target, float amount, bool bipolar,
+                         bool enabled);
 
     // Callbacks
     std::function<void(magda::ControlTarget target)> onDeleteLink;

--- a/magda/daw/ui/components/chain/params/ParamHostComponent.cpp
+++ b/magda/daw/ui/components/chain/params/ParamHostComponent.cpp
@@ -190,7 +190,7 @@ ParamHostComponent::~ParamHostComponent() = default;
 
 void ParamHostComponent::updateParameterSlots(
     const magda::DeviceInfo& device, int currentPage,
-    std::function<void(int paramIndex, double value)> onValueChanged) {
+    const std::function<void(int paramIndex, double value)>& onValueChanged) {
     const auto previousSpans = cellSpans_;
     cellSpans_.assign(static_cast<size_t>(std::max(0, cellCount_)), 1);
     usedRows_ = 0;

--- a/magda/daw/ui/components/chain/params/ParamHostComponent.hpp
+++ b/magda/daw/ui/components/chain/params/ParamHostComponent.hpp
@@ -46,8 +46,9 @@ class ParamHostComponent : public juce::Component {
     }
 
     // Parameter data updates.
-    void updateParameterSlots(const magda::DeviceInfo& device, int currentPage,
-                              std::function<void(int paramIndex, double value)> onValueChanged);
+    void updateParameterSlots(
+        const magda::DeviceInfo& device, int currentPage,
+        const std::function<void(int paramIndex, double value)>& onValueChanged);
     void updateParameterValues(const magda::DeviceInfo& device, int currentPage);
 
     void updateParamModulation(const magda::ModArray* mods, const magda::MacroArray* macros,

--- a/magda/daw/ui/components/chain/params/ParamLinkMenu.cpp
+++ b/magda/daw/ui/components/chain/params/ParamLinkMenu.cpp
@@ -193,7 +193,7 @@ void showParamLinkMenu(juce::Component* anchor, const ParamLinkContext& ctx,
     auto safeAnchor = juce::Component::SafePointer<juce::Component>(anchor);
     auto paramIdx = ctx.paramIndex;
     auto devicePath = ctx.devicePath;
-    auto cbs = callbacks;
+    const auto& cbs = callbacks;
 
     menu.showMenuAsync(juce::PopupMenu::Options(), [safeAnchor, paramIdx, devicePath, cbs,
                                                     bakeable](int result) {

--- a/magda/daw/ui/components/chain/params/ParamSlotComponent.cpp
+++ b/magda/daw/ui/components/chain/params/ParamSlotComponent.cpp
@@ -158,12 +158,12 @@ ParamSlotComponent::ParamSlotComponent(int paramIndex) : paramIndex_(paramIndex)
     addAndMakeVisible(valueSlider_);
 
     // Default MIDI Learn wiring: delegate to MidiLearnCoordinator singleton
-    onMidiLearn = [this](magda::ChainNodePath path, int paramIdx, juce::String paramName) {
+    onMidiLearn = [this](const magda::ChainNodePath& path, int paramIdx, juce::String paramName) {
         juce::String displayName = paramName.isNotEmpty() ? paramName : nameLabel_.getText();
         magda::MidiLearnCoordinator::getInstance().beginLearn(
             magda::ControlTarget::pluginParam(path, paramIdx), displayName);
     };
-    onMidiClear = [](magda::ChainNodePath path, int paramIdx) {
+    onMidiClear = [](const magda::ChainNodePath& path, int paramIdx) {
         magda::MidiLearnCoordinator::getInstance().clearMappings(
             magda::ControlTarget::pluginParam(path, paramIdx));
     };

--- a/magda/daw/ui/components/chain/params/ParamWidgetSetup.cpp
+++ b/magda/daw/ui/components/chain/params/ParamWidgetSetup.cpp
@@ -20,7 +20,7 @@ void configureSliderFormatting(TextSlider& slider, const magda::ParameterInfo& i
     // to TE raw so typed plugin display values can be matched by probing.
     if (info.displayText) {
         auto provider = info.displayText;
-        const magda::ParameterInfo infoCopy = info;
+        const magda::ParameterInfo& infoCopy = info;
         const float teMin = info.teMinValue;
         const float teSpan = info.teMaxValue - info.teMinValue;
         const bool infoMatchesTeRange = std::abs(info.minValue - info.teMinValue) < 1e-6f &&

--- a/magda/daw/ui/components/chain/slot/DeviceCustomUIManager.cpp
+++ b/magda/daw/ui/components/chain/slot/DeviceCustomUIManager.cpp
@@ -397,7 +397,7 @@ magda::PluginFormat pluginFormatFromDescription(const juce::PluginDescription& d
 }
 
 magda::DeviceInfo projectPadPluginDevice(magda::DeviceId deviceId,
-                                         tracktion::engine::Plugin::Ptr plugin) {
+                                         const tracktion::engine::Plugin::Ptr& plugin) {
     magda::DeviceInfo device;
     device.id = deviceId;
     device.name = plugin ? plugin->getName() : juce::String();
@@ -786,8 +786,9 @@ void DeviceCustomUIManager::readAndPushModMatrix(magda::DeviceId /*deviceId*/) {
 
     // Build parameter name list for the add-popup destination dropdown
     std::vector<std::pair<int, juce::String>> paramNames;
+    paramNames.reserve(autoParams.size());
     for (int pi = 0; pi < autoParams.size(); ++pi)
-        paramNames.push_back({pi, autoParams[pi]->getParameterName()});
+        paramNames.emplace_back(pi, autoParams[pi]->getParameterName());
     fourOscUI_->setModMatrixParameterNames(paramNames);
 
     // Read mod matrix entries
@@ -1016,7 +1017,7 @@ bool DeviceCustomUIManager::createMidiUtilityUI(const magda::DeviceInfo& device,
         };
         polyStepSequencerUI_->onPatternEdited =
             [this](const juce::String& description,
-                   std::function<void(magda::step_pattern::PolyPattern&)> edit,
+                   const std::function<void(magda::step_pattern::PolyPattern&)>& edit,
                    magda::StepPatternGesture gesture) {
                 // The faceplate's token says which drag a continuous edit
                 // belongs to, so two drags never merge into one undo (#2335).
@@ -1048,7 +1049,7 @@ bool DeviceCustomUIManager::createMidiUtilityUI(const magda::DeviceInfo& device,
         };
         stepSequencerUI_->onPatternEdited =
             [this](const juce::String& description,
-                   std::function<void(magda::step_pattern::MonoPattern&)> edit,
+                   const std::function<void(magda::step_pattern::MonoPattern&)>& edit,
                    magda::StepPatternGesture gesture) {
                 // See the poly sequencer above.
                 const int gestureId = stepSequencerUI_ != nullptr

--- a/magda/daw/ui/components/chain/slot/DevicePresetMenu.cpp
+++ b/magda/daw/ui/components/chain/slot/DevicePresetMenu.cpp
@@ -282,7 +282,7 @@ void showSaveMagdaPresetDialog(const magda::DeviceInfo& device,
 }
 
 void saveCurrentMagdaPreset(const juce::String& currentPresetName,
-                            PresetSnapshotProvider snapshotProvider) {
+                            const PresetSnapshotProvider& snapshotProvider) {
     if (currentPresetName.isEmpty() || !snapshotProvider)
         return;
 
@@ -295,11 +295,10 @@ void saveCurrentMagdaPreset(const juce::String& currentPresetName,
         showPresetErrorAsync("Save Preset Failed", presetManager.getLastError());
 }
 
-void loadMagdaPreset(
-    const juce::String& pluginFolder, const magda::ChainNodePath& nodePath,
-    const juce::String& presetRelativePath,
-    std::function<void(const magda::DeviceInfo& liveDevice, const juce::String& presetName)>
-        onLoaded) {
+void loadMagdaPreset(const juce::String& pluginFolder, const magda::ChainNodePath& nodePath,
+                     const juce::String& presetRelativePath,
+                     const std::function<void(const magda::DeviceInfo& liveDevice,
+                                              const juce::String& presetName)>& onLoaded) {
     magda::DeviceInfo preset;
     auto& presetManager = magda::PresetManager::getInstance();
     if (!presetManager.loadDevicePreset(pluginFolder, presetRelativePath, preset)) {
@@ -389,7 +388,7 @@ void PluginDevicePresetPresenter::showMenu(juce::Component* targetComponent,
                                            const magda::DeviceInfo& device,
                                            const magda::ChainNodePath& devicePath,
                                            bool isInternalDevice,
-                                           std::function<void()> onSelectionChanged) {
+                                           const std::function<void()>& onSelectionChanged) {
     auto state = state_;
     PluginPresetMenuActions actions;
     actions.saveAs = [this, device, devicePath, onSelectionChanged]() {
@@ -412,7 +411,7 @@ void PluginDevicePresetPresenter::showMenu(juce::Component* targetComponent,
 
 void PluginDevicePresetPresenter::loadFile(const magda::ChainNodePath& devicePath,
                                            const juce::File& file,
-                                           std::function<void()> onSelectionChanged) {
+                                           const std::function<void()>& onSelectionChanged) {
     auto state = state_;
     loadPluginPresetFile(devicePath, file,
                          [state, onSelectionChanged](const juce::File& currentFile,
@@ -426,7 +425,7 @@ void PluginDevicePresetPresenter::loadFile(const magda::ChainNodePath& devicePat
 
 void PluginDevicePresetPresenter::showSaveDialog(const magda::DeviceInfo& device,
                                                  const magda::ChainNodePath& devicePath,
-                                                 std::function<void()> onSelectionChanged) {
+                                                 const std::function<void()>& onSelectionChanged) {
     auto state = state_;
     showSavePluginPresetDialog(device, devicePath, state->presetName,
                                [state, onSelectionChanged](const juce::File& currentFile,
@@ -542,9 +541,9 @@ void showPluginPresetMenu(juce::Component* targetComponent, const magda::DeviceI
         });
 }
 
-void loadPluginPresetFile(
-    const magda::ChainNodePath& devicePath, const juce::File& file,
-    std::function<void(const juce::File& currentFile, const juce::String& displayName)> onLoaded) {
+void loadPluginPresetFile(const magda::ChainNodePath& devicePath, const juce::File& file,
+                          const std::function<void(const juce::File& currentFile,
+                                                   const juce::String& displayName)>& onLoaded) {
     auto* bridge = getAudioBridge();
     if (bridge == nullptr)
         return;

--- a/magda/daw/ui/components/chain/slot/DevicePresetMenu.hpp
+++ b/magda/daw/ui/components/chain/slot/DevicePresetMenu.hpp
@@ -31,13 +31,12 @@ void showSaveMagdaPresetDialog(const magda::DeviceInfo& device,
                                std::function<void(const juce::String& presetName)> onSaved);
 
 void saveCurrentMagdaPreset(const juce::String& currentPresetName,
-                            PresetSnapshotProvider snapshotProvider);
+                            const PresetSnapshotProvider& snapshotProvider);
 
-void loadMagdaPreset(
-    const juce::String& pluginFolder, const magda::ChainNodePath& nodePath,
-    const juce::String& presetRelativePath,
-    std::function<void(const magda::DeviceInfo& liveDevice, const juce::String& presetName)>
-        onLoaded);
+void loadMagdaPreset(const juce::String& pluginFolder, const magda::ChainNodePath& nodePath,
+                     const juce::String& presetRelativePath,
+                     const std::function<void(const magda::DeviceInfo& liveDevice,
+                                              const juce::String& presetName)>& onLoaded);
 
 class MagdaDevicePresetPresenter {
   public:
@@ -61,11 +60,11 @@ class PluginDevicePresetPresenter {
     juce::String getCurrentPresetLabel() const;
     void showMenu(juce::Component* targetComponent, const magda::DeviceInfo& device,
                   const magda::ChainNodePath& devicePath, bool isInternalDevice,
-                  std::function<void()> onSelectionChanged);
+                  const std::function<void()>& onSelectionChanged);
     void loadFile(const magda::ChainNodePath& devicePath, const juce::File& file,
-                  std::function<void()> onSelectionChanged);
+                  const std::function<void()>& onSelectionChanged);
     void showSaveDialog(const magda::DeviceInfo& device, const magda::ChainNodePath& devicePath,
-                        std::function<void()> onSelectionChanged);
+                        const std::function<void()>& onSelectionChanged);
 
   private:
     struct State;
@@ -88,9 +87,9 @@ void showPluginPresetMenu(juce::Component* targetComponent, const magda::DeviceI
                           const juce::File& currentPluginPresetFile,
                           PluginPresetMenuActions actions);
 
-void loadPluginPresetFile(
-    const magda::ChainNodePath& devicePath, const juce::File& file,
-    std::function<void(const juce::File& currentFile, const juce::String& displayName)> onLoaded);
+void loadPluginPresetFile(const magda::ChainNodePath& devicePath, const juce::File& file,
+                          const std::function<void(const juce::File& currentFile,
+                                                   const juce::String& displayName)>& onLoaded);
 
 void showSavePluginPresetDialog(
     const magda::DeviceInfo& device, const magda::ChainNodePath& devicePath,

--- a/magda/daw/ui/components/chain/slot/DeviceSlotGainMeterControls.cpp
+++ b/magda/daw/ui/components/chain/slot/DeviceSlotGainMeterControls.cpp
@@ -14,7 +14,7 @@ namespace magda::daw::ui {
 void setupDeviceSlotGainMeterControls(
     juce::Component& parent, magda::DraggableValueLabel& gainLabel, magda::LevelMeter& levelMeter,
     std::unique_ptr<juce::Slider>& gainSlider, std::unique_ptr<juce::Slider>& mixKnob,
-    const magda::DeviceInfo& device, std::function<magda::ChainNodePath()> getNodePath) {
+    const magda::DeviceInfo& device, const std::function<magda::ChainNodePath()>& getNodePath) {
     // Gain label in header (dB format, draggable)
     gainLabel.setRange(-60.0, 12.0, 0.0);
     gainLabel.setValue(device.gainDb, juce::dontSendNotification);
@@ -131,7 +131,7 @@ void syncDeviceSlotMixKnobFromDevice(juce::Slider* mixKnob, const magda::DeviceI
 
 void refreshDeviceSlotMixKnobFromDevice(juce::Slider* mixKnob, const magda::DeviceInfo& device,
                                         bool relayoutOnVisibilityChange,
-                                        std::function<void()> relayout) {
+                                        const std::function<void()>& relayout) {
     if (mixKnob == nullptr)
         return;
 

--- a/magda/daw/ui/components/chain/slot/DeviceSlotGainMeterControls.hpp
+++ b/magda/daw/ui/components/chain/slot/DeviceSlotGainMeterControls.hpp
@@ -18,7 +18,7 @@ namespace magda::daw::ui {
 void setupDeviceSlotGainMeterControls(
     juce::Component& parent, magda::DraggableValueLabel& gainLabel, magda::LevelMeter& levelMeter,
     std::unique_ptr<juce::Slider>& gainSlider, std::unique_ptr<juce::Slider>& mixKnob,
-    const magda::DeviceInfo& device, std::function<magda::ChainNodePath()> getNodePath);
+    const magda::DeviceInfo& device, const std::function<magda::ChainNodePath()>& getNodePath);
 
 void syncDeviceSlotGainControlsFromDevice(magda::DraggableValueLabel& gainLabel,
                                           juce::Slider* gainSlider,
@@ -29,6 +29,6 @@ double currentMixPosition(const magda::DeviceInfo& device);
 void syncDeviceSlotMixKnobFromDevice(juce::Slider* mixKnob, const magda::DeviceInfo& device);
 void refreshDeviceSlotMixKnobFromDevice(juce::Slider* mixKnob, const magda::DeviceInfo& device,
                                         bool relayoutOnVisibilityChange,
-                                        std::function<void()> relayout);
+                                        const std::function<void()>& relayout);
 
 }  // namespace magda::daw::ui

--- a/magda/daw/ui/components/chain/slot/DeviceSlotInlineUiFactory.cpp
+++ b/magda/daw/ui/components/chain/slot/DeviceSlotInlineUiFactory.cpp
@@ -116,7 +116,7 @@ void linkCompiledParameter(int paramIndex, float amount,
 }  // namespace
 
 DeviceSlotInlineUiCallbacks makeDeviceSlotInlineUiCallbacks(
-    DeviceSlotInlineUiCallbackContext context) {
+    const DeviceSlotInlineUiCallbackContext& context) {
     DeviceSlotInlineUiCallbacks callbacks;
     callbacks.onParameterChanged = [context](int paramIndex, float value) {
         if (!context.getNodePath)
@@ -269,7 +269,7 @@ void readAndPushDeviceSlotInlineUiModMatrix(magda::DeviceId deviceId,
 void configureDeviceSlotLinkableSliders(
     const std::vector<LinkableTextSlider*>& sliders, const magda::DeviceInfo& device,
     const magda::ChainNodePath& nodePath, const DeviceSlotModulationContext& context,
-    std::function<void(LinkableTextSlider&)> configureCallbacks) {
+    const std::function<void(LinkableTextSlider&)>& configureCallbacks) {
     for (int i = 0; i < static_cast<int>(sliders.size()); ++i) {
         auto* slider = sliders[static_cast<size_t>(i)];
         if (slider == nullptr)

--- a/magda/daw/ui/components/chain/slot/DeviceSlotInlineUiFactory.hpp
+++ b/magda/daw/ui/components/chain/slot/DeviceSlotInlineUiFactory.hpp
@@ -63,7 +63,7 @@ struct DeviceSlotInlineUiCallbackContext {
 };
 
 DeviceSlotInlineUiCallbacks makeDeviceSlotInlineUiCallbacks(
-    DeviceSlotInlineUiCallbackContext context);
+    const DeviceSlotInlineUiCallbackContext& context);
 
 DeviceSlotInlineUiKind createDeviceSlotInlineUi(const magda::DeviceInfo& device,
                                                 const DeviceSlotTraits& traits,
@@ -96,6 +96,6 @@ void readAndPushDeviceSlotInlineUiModMatrix(magda::DeviceId deviceId,
 void configureDeviceSlotLinkableSliders(
     const std::vector<LinkableTextSlider*>& sliders, const magda::DeviceInfo& device,
     const magda::ChainNodePath& nodePath, const DeviceSlotModulationContext& context,
-    std::function<void(LinkableTextSlider&)> configureCallbacks);
+    const std::function<void(LinkableTextSlider&)>& configureCallbacks);
 
 }  // namespace magda::daw::ui

--- a/magda/daw/ui/components/chain/slot/DeviceSlotModMacroCommands.cpp
+++ b/magda/daw/ui/components/chain/slot/DeviceSlotModMacroCommands.cpp
@@ -1,5 +1,7 @@
 #include "slot/DeviceSlotModMacroCommands.hpp"
 
+#include <utility>
+
 #include "core/LinkModeManager.hpp"
 #include "core/SelectionManager.hpp"
 #include "core/TrackCommands.hpp"
@@ -34,7 +36,7 @@ void refreshPanels(const DeviceSlotModMacroCommandCallbacks& callbacks) {
 
 void setDeviceSlotModTarget(const magda::ChainNodePath& nodePath, int modIndex,
                             magda::ControlTarget target) {
-    magda::TrackManager::getInstance().setModTarget(nodePath, modIndex, target);
+    magda::TrackManager::getInstance().setModTarget(nodePath, modIndex, std::move(target));
 }
 
 void renameDeviceSlotMod(const magda::ChainNodePath& nodePath, int modIndex,
@@ -112,7 +114,7 @@ void setDeviceSlotMacroValue(const magda::ChainNodePath& nodePath, int macroInde
 }
 
 void setDeviceSlotMacroTarget(const magda::ChainNodePath& nodePath, int macroIndex,
-                              magda::ControlTarget target,
+                              const magda::ControlTarget& target,
                               const DeviceSlotModMacroCommandCallbacks& callbacks) {
     // Check if the active macro is from this device or a parent rack.
     auto activeMacroSelection = magda::LinkModeManager::getInstance().getMacroInLinkMode();
@@ -143,12 +145,13 @@ void clearAllDeviceSlotMacroLinks(const magda::ChainNodePath& nodePath, int macr
 void setDeviceSlotMacroLinkAmount(const magda::ChainNodePath& nodePath, int macroIndex,
                                   magda::ControlTarget target, float amount,
                                   const DeviceSlotModMacroCommandCallbacks& callbacks) {
-    magda::TrackManager::getInstance().setMacroLinkAmount(nodePath, macroIndex, target, amount);
+    magda::TrackManager::getInstance().setMacroLinkAmount(nodePath, macroIndex, std::move(target),
+                                                          amount);
     updateParamModulation(callbacks);
 }
 
 void createDeviceSlotMacroLink(const magda::ChainNodePath& nodePath, int macroIndex,
-                               magda::ControlTarget target, float amount,
+                               const magda::ControlTarget& target, float amount,
                                const DeviceSlotModMacroCommandCallbacks& callbacks) {
     magda::TrackManager::getInstance().setMacroTarget(nodePath, macroIndex, target);
     magda::TrackManager::getInstance().setMacroLinkAmount(nodePath, macroIndex, target, amount);
@@ -161,7 +164,7 @@ void createDeviceSlotMacroLink(const magda::ChainNodePath& nodePath, int macroIn
 void removeDeviceSlotMacroLink(const magda::ChainNodePath& nodePath, int macroIndex,
                                magda::ControlTarget target,
                                const DeviceSlotModMacroCommandCallbacks& callbacks) {
-    magda::TrackManager::getInstance().removeMacroLink(nodePath, macroIndex, target);
+    magda::TrackManager::getInstance().removeMacroLink(nodePath, macroIndex, std::move(target));
     updateMacroPanel(callbacks);
     updateParamModulation(callbacks);
 }
@@ -169,7 +172,8 @@ void removeDeviceSlotMacroLink(const magda::ChainNodePath& nodePath, int macroIn
 void setDeviceSlotMacroLinkBipolar(const magda::ChainNodePath& nodePath, int macroIndex,
                                    magda::ControlTarget target, bool bipolar,
                                    const DeviceSlotModMacroCommandCallbacks& callbacks) {
-    magda::TrackManager::getInstance().setMacroLinkBipolar(nodePath, macroIndex, target, bipolar);
+    magda::TrackManager::getInstance().setMacroLinkBipolar(nodePath, macroIndex, std::move(target),
+                                                           bipolar);
     updateParamModulation(callbacks);
 }
 
@@ -184,19 +188,21 @@ void selectDeviceSlotMacro(const magda::ChainNodePath& nodePath, int macroIndex)
 void setDeviceSlotModLinkAmount(const magda::ChainNodePath& nodePath, int modIndex,
                                 magda::ControlTarget target, float amount,
                                 const DeviceSlotModMacroCommandCallbacks& callbacks) {
-    magda::TrackManager::getInstance().setModLinkAmount(nodePath, modIndex, target, amount);
+    magda::TrackManager::getInstance().setModLinkAmount(nodePath, modIndex, std::move(target),
+                                                        amount);
     updateParamModulation(callbacks);
 }
 
 void setDeviceSlotModLinkEnabled(const magda::ChainNodePath& nodePath, int modIndex,
                                  magda::ControlTarget target, bool enabled,
                                  const DeviceSlotModMacroCommandCallbacks& callbacks) {
-    magda::TrackManager::getInstance().setModLinkEnabled(nodePath, modIndex, target, enabled);
+    magda::TrackManager::getInstance().setModLinkEnabled(nodePath, modIndex, std::move(target),
+                                                         enabled);
     updateParamModulation(callbacks);
 }
 
 void createDeviceSlotModLink(const magda::ChainNodePath& nodePath, int modIndex,
-                             magda::ControlTarget target, float amount,
+                             const magda::ControlTarget& target, float amount,
                              const DeviceSlotModMacroCommandCallbacks& callbacks) {
     magda::TrackManager::getInstance().setModTarget(nodePath, modIndex, target);
     magda::TrackManager::getInstance().setModLinkAmount(nodePath, modIndex, target, amount);
@@ -209,7 +215,7 @@ void createDeviceSlotModLink(const magda::ChainNodePath& nodePath, int modIndex,
 void removeDeviceSlotModLink(const magda::ChainNodePath& nodePath, int modIndex,
                              magda::ControlTarget target,
                              const DeviceSlotModMacroCommandCallbacks& callbacks) {
-    magda::TrackManager::getInstance().removeModLink(nodePath, modIndex, target);
+    magda::TrackManager::getInstance().removeModLink(nodePath, modIndex, std::move(target));
     updateModsPanel(callbacks);
     updateParamModulation(callbacks);
 }

--- a/magda/daw/ui/components/chain/slot/DeviceSlotModMacroCommands.hpp
+++ b/magda/daw/ui/components/chain/slot/DeviceSlotModMacroCommands.hpp
@@ -45,7 +45,7 @@ void notifyDeviceSlotModCurveChanged(const magda::ChainNodePath& nodePath);
 void setDeviceSlotMacroValue(const magda::ChainNodePath& nodePath, int macroIndex, float value,
                              const DeviceSlotModMacroCommandCallbacks& callbacks);
 void setDeviceSlotMacroTarget(const magda::ChainNodePath& nodePath, int macroIndex,
-                              magda::ControlTarget target,
+                              const magda::ControlTarget& target,
                               const DeviceSlotModMacroCommandCallbacks& callbacks);
 void renameDeviceSlotMacro(const magda::ChainNodePath& nodePath, int macroIndex,
                            const juce::String& name);
@@ -55,7 +55,7 @@ void setDeviceSlotMacroLinkAmount(const magda::ChainNodePath& nodePath, int macr
                                   magda::ControlTarget target, float amount,
                                   const DeviceSlotModMacroCommandCallbacks& callbacks);
 void createDeviceSlotMacroLink(const magda::ChainNodePath& nodePath, int macroIndex,
-                               magda::ControlTarget target, float amount,
+                               const magda::ControlTarget& target, float amount,
                                const DeviceSlotModMacroCommandCallbacks& callbacks);
 void removeDeviceSlotMacroLink(const magda::ChainNodePath& nodePath, int macroIndex,
                                magda::ControlTarget target,
@@ -74,7 +74,7 @@ void setDeviceSlotModLinkEnabled(const magda::ChainNodePath& nodePath, int modIn
                                  magda::ControlTarget target, bool enabled,
                                  const DeviceSlotModMacroCommandCallbacks& callbacks);
 void createDeviceSlotModLink(const magda::ChainNodePath& nodePath, int modIndex,
-                             magda::ControlTarget target, float amount,
+                             const magda::ControlTarget& target, float amount,
                              const DeviceSlotModMacroCommandCallbacks& callbacks);
 void removeDeviceSlotModLink(const magda::ChainNodePath& nodePath, int modIndex,
                              magda::ControlTarget target,

--- a/magda/daw/ui/components/chain/slot/DeviceSlotParameterPaging.cpp
+++ b/magda/daw/ui/components/chain/slot/DeviceSlotParameterPaging.cpp
@@ -13,7 +13,7 @@ namespace magda::daw::ui {
 
 namespace {
 
-void reloadPage(DeviceSlotParameterPagingCallbacks callbacks) {
+void reloadPage(const DeviceSlotParameterPagingCallbacks& callbacks) {
     if (callbacks.reloadParameterSlots)
         callbacks.reloadParameterSlots();
     if (callbacks.updateParamModulation)
@@ -28,7 +28,7 @@ void updateDeviceSlotParameterSlots(magda::DeviceInfo& device, const magda::Chai
                                     ParamHostComponent& paramGrid,
                                     CompiledDevicePanel* compiledPanel,
                                     const DeviceSlotTraits& traits,
-                                    DeviceSlotParameterPagingCallbacks callbacks) {
+                                    const DeviceSlotParameterPagingCallbacks& callbacks) {
     // Each parameter slot stores a copy of this callback and invokes it on a
     // later mouse drag, so it must NOT capture the function-local `compiledPanel`
     // pointer / `callbacks` struct by reference - those die when this function

--- a/magda/daw/ui/components/chain/slot/DeviceSlotParameterPaging.hpp
+++ b/magda/daw/ui/components/chain/slot/DeviceSlotParameterPaging.hpp
@@ -21,7 +21,7 @@ void updateDeviceSlotParameterSlots(magda::DeviceInfo& device, const magda::Chai
                                     ParamHostComponent& paramGrid,
                                     CompiledDevicePanel* compiledPanel,
                                     const DeviceSlotTraits& traits,
-                                    DeviceSlotParameterPagingCallbacks callbacks);
+                                    const DeviceSlotParameterPagingCallbacks& callbacks);
 
 void updateDeviceSlotParameterValues(const magda::DeviceInfo& device,
                                      ParamHostComponent& paramGrid);

--- a/magda/daw/ui/components/chord/ChordBlockComponent.cpp
+++ b/magda/daw/ui/components/chord/ChordBlockComponent.cpp
@@ -1,5 +1,7 @@
 #include "ChordBlockComponent.hpp"
 
+#include <utility>
+
 #include "core/MidiFileWriter.hpp"
 #include "music/NotationSettings.hpp"
 #include "project/ProjectManager.hpp"
@@ -9,7 +11,7 @@
 
 namespace magda::daw::ui {
 
-ChordBlockComponent::ChordBlockComponent(const magda::music::Chord& chord) : chord_(chord) {
+ChordBlockComponent::ChordBlockComponent(magda::music::Chord chord) : chord_(std::move(chord)) {
     setName("ChordBlock");
 }
 

--- a/magda/daw/ui/components/chord/ChordBlockComponent.hpp
+++ b/magda/daw/ui/components/chord/ChordBlockComponent.hpp
@@ -20,7 +20,7 @@ namespace magda::daw::ui {
  */
 class ChordBlockComponent : public juce::Component {
   public:
-    explicit ChordBlockComponent(const magda::music::Chord& chord);
+    explicit ChordBlockComponent(magda::music::Chord chord);
 
     void paint(juce::Graphics& g) override;
     void mouseDown(const juce::MouseEvent& e) override;

--- a/magda/daw/ui/components/common/LinkableTextSlider.cpp
+++ b/magda/daw/ui/components/common/LinkableTextSlider.cpp
@@ -144,11 +144,11 @@ LinkableTextSlider::LinkableTextSlider(TextSlider::Format format) : slider_(form
         }
     };
     // Default MIDI Learn wiring: delegate to MidiLearnCoordinator singleton
-    onMidiLearn = [](magda::ChainNodePath path, int paramIdx, juce::String paramName) {
+    onMidiLearn = [](const magda::ChainNodePath& path, int paramIdx, juce::String paramName) {
         magda::MidiLearnCoordinator::getInstance().beginLearn(
             magda::ControlTarget::pluginParam(path, paramIdx), paramName);
     };
-    onMidiClear = [](magda::ChainNodePath path, int paramIdx) {
+    onMidiClear = [](const magda::ChainNodePath& path, int paramIdx) {
         magda::MidiLearnCoordinator::getInstance().clearMappings(
             magda::ControlTarget::pluginParam(path, paramIdx));
     };

--- a/magda/daw/ui/components/mixer/RoutingSyncHelper.hpp
+++ b/magda/daw/ui/components/mixer/RoutingSyncHelper.hpp
@@ -26,7 +26,7 @@ namespace RoutingSyncHelper {
 inline void populateAudioInputOptions(RoutingSelector* selector, juce::AudioIODevice* device,
                                       TrackId currentTrackId = INVALID_TRACK_ID,
                                       std::map<int, TrackId>* outInputTrackMapping = nullptr,
-                                      juce::BigInteger enabledInputChannels = {},
+                                      const juce::BigInteger& enabledInputChannels = {},
                                       std::map<int, juce::String>* outChannelMapping = nullptr,
                                       const std::map<int, juce::String>& teDeviceNames = {}) {
     if (!selector)
@@ -139,7 +139,7 @@ inline void populateAudioInputOptions(RoutingSelector* selector, juce::AudioIODe
 inline void populateAudioOutputOptions(RoutingSelector* selector, TrackId currentTrackId,
                                        juce::AudioIODevice* device,
                                        std::map<int, TrackId>& outTrackMapping,
-                                       juce::BigInteger enabledOutputChannels = {},
+                                       const juce::BigInteger& enabledOutputChannels = {},
                                        std::map<int, juce::String>* outChannelMapping = nullptr,
                                        const std::map<int, juce::String>& teDeviceNames = {}) {
     if (!selector)
@@ -464,7 +464,8 @@ inline void syncSelectorsFromTrack(
         // options are available before any track input is selected — otherwise
         // the first "track:" selection could never be made.
         populateAudioInputOptions(audioInSelector, device, currentTrackId, inputTrackMapping,
-                                  enabledInputChannels, inputChannelMapping, teDeviceNames);
+                                  std::move(enabledInputChannels), inputChannelMapping,
+                                  teDeviceNames);
         if (hasAudioInput) {
             if (track.audioInputDevice.startsWith("track:") && inputTrackMapping) {
                 // Track-as-input: find the matching option ID
@@ -545,7 +546,7 @@ inline void syncSelectorsFromTrack(
     // Update Audio Output selector
     if (audioOutSelector) {
         populateAudioOutputOptions(audioOutSelector, currentTrackId, device, outputTrackMapping,
-                                   enabledOutputChannels, outputChannelMapping,
+                                   std::move(enabledOutputChannels), outputChannelMapping,
                                    teOutputDeviceNames);
         juce::String currentAudioOutput = track.audioOutputDevice;
         if (currentAudioOutput.isEmpty()) {

--- a/magda/daw/ui/components/tracks/TrackHeadersPanel.cpp
+++ b/magda/daw/ui/components/tracks/TrackHeadersPanel.cpp
@@ -1715,7 +1715,7 @@ void TrackHeadersPanel::setupTrackHeaderWithId(TrackHeader& header, int trackId)
 
     // Right-click the volume / pan readouts to show (or create) their
     // automation lane, mirroring the send-label menu in the inspector.
-    auto showAutomationLaneMenu = [](AutomationTarget target) {
+    auto showAutomationLaneMenu = [](const AutomationTarget& target) {
         auto& autoMgr = AutomationManager::getInstance();
         const bool hasLane = autoMgr.getLaneForTarget(target) != magda::INVALID_AUTOMATION_LANE_ID;
         juce::PopupMenu menu;

--- a/magda/daw/ui/components/waveform/WaveformGridComponent.cpp
+++ b/magda/daw/ui/components/waveform/WaveformGridComponent.cpp
@@ -1252,8 +1252,9 @@ void WaveformGridComponent::mouseDown(const juce::MouseEvent& event) {
             if (warpMarkers_.size() >= 2) {
                 // Sort markers by warpTime to find the segment containing our click
                 std::vector<std::pair<double, double>> sorted;  // (warpTime, sourceTime)
+                sorted.reserve(warpMarkers_.size());
                 for (const auto& m : warpMarkers_) {
-                    sorted.push_back({m.warpTime, m.sourceTime});
+                    sorted.emplace_back(m.warpTime, m.sourceTime);
                 }
                 std::sort(sorted.begin(), sorted.end());
 

--- a/magda/daw/ui/debug/DebugSettings.hpp
+++ b/magda/daw/ui/debug/DebugSettings.hpp
@@ -62,7 +62,7 @@ class DebugSettings {
 
     // Listener for settings changes
     using Listener = std::function<void()>;
-    void addListener(Listener listener) {
+    void addListener(const Listener& listener) {
         listeners_.push_back(listener);
     }
 

--- a/magda/daw/ui/dialogs/AISettingsDialog.cpp
+++ b/magda/daw/ui/dialogs/AISettingsDialog.cpp
@@ -471,7 +471,7 @@ class AISettingsDialog::CloudPage : public juce::Component {
         // Remove button
         auto removeBtn =
             std::make_unique<juce::TextButton>(juce::String::charToString(0x2715));  // ✕
-        auto pid = providerId;
+        const auto& pid = providerId;
         removeBtn->onClick = [this, pid]() { removeProvider(pid); };
         listContainer_.addAndMakeVisible(*removeBtn);
         entry.removeBtn = removeBtn.get();

--- a/magda/daw/ui/dialogs/ChainTreeDialog.cpp
+++ b/magda/daw/ui/dialogs/ChainTreeDialog.cpp
@@ -1,5 +1,7 @@
 #include "ChainTreeDialog.hpp"
 
+#include <utility>
+
 #include "../themes/DarkTheme.hpp"
 #include "../themes/FontManager.hpp"
 #include "core/SelectionManager.hpp"
@@ -16,9 +18,8 @@ namespace magda {
  */
 class ChainTreeItemBase : public juce::TreeViewItem {
   public:
-    explicit ChainTreeItemBase(const juce::String& text, const juce::String& icon = "",
-                               const ChainNodePath& path = {})
-        : text_(text), icon_(icon), path_(path) {}
+    explicit ChainTreeItemBase(juce::String text, juce::String icon = "", ChainNodePath path = {})
+        : text_(std::move(text)), icon_(std::move(icon)), path_(std::move(path)) {}
 
     bool mightContainSubItems() override {
         return false;  // Override in containers

--- a/magda/daw/ui/dialogs/ControllersDialog.cpp
+++ b/magda/daw/ui/dialogs/ControllersDialog.cpp
@@ -783,7 +783,7 @@ class LuaScriptsPage : public juce::Component {
             menu.addItem(static_cast<int>(i + 1), available[i].getFileName());
 
         juce::Component::SafePointer<LuaScriptsPage> self(this);
-        const auto availableCopy = available;
+        const auto& availableCopy = available;
         menu.showMenuAsync(juce::PopupMenu::Options().withTargetComponent(&addScriptButton_),
                            [self, availableCopy](int result) {
                                if (result <= 0)

--- a/magda/daw/ui/dialogs/ParameterConfigDialog.cpp
+++ b/magda/daw/ui/dialogs/ParameterConfigDialog.cpp
@@ -2,6 +2,8 @@
 
 #include <juce_audio_processors/juce_audio_processors.h>
 
+#include <utility>
+
 #include "../themes/DarkTheme.hpp"
 #include "../themes/DialogLookAndFeel.hpp"
 #include "../themes/FontManager.hpp"
@@ -390,8 +392,8 @@ ParameterConfigDialog::~ParameterConfigDialog() {
     setLookAndFeel(nullptr);
 }
 
-ParameterConfigDialog::ParameterConfigDialog(const juce::String& pluginName)
-    : pluginName_(pluginName) {
+ParameterConfigDialog::ParameterConfigDialog(juce::String pluginName)
+    : pluginName_(std::move(pluginName)) {
     // Use the shared dialog look-and-feel so every button / combo /
     // text editor in the dialog picks up the theme font (Inter) instead
     // of JUCE's platform default. Children inherit unless they set their
@@ -1183,7 +1185,7 @@ void ParameterConfigDialog::runDetection() {
                     safeThis->aiResolved_ = resolved;
                 },
                 // onComplete
-                [safeThis](std::vector<magda::DetectedParameterInfo> aiResults) {
+                [safeThis](const std::vector<magda::DetectedParameterInfo>& aiResults) {
                     if (!safeThis)
                         return;
                     safeThis->applyDetectionResults(aiResults);

--- a/magda/daw/ui/dialogs/ParameterConfigDialog.hpp
+++ b/magda/daw/ui/dialogs/ParameterConfigDialog.hpp
@@ -49,7 +49,7 @@ class ParameterConfigDialog : public juce::Component,
                               public juce::TableListBoxModel,
                               private juce::Timer {
   public:
-    ParameterConfigDialog(const juce::String& pluginName);
+    ParameterConfigDialog(juce::String pluginName);
     ~ParameterConfigDialog() override;
 
     void paint(juce::Graphics& g) override;

--- a/magda/daw/ui/dialogs/PreferencesDialog.cpp
+++ b/magda/daw/ui/dialogs/PreferencesDialog.cpp
@@ -343,7 +343,7 @@ class GeneralPage : public juce::Component {
         }
 
         if (availableLanguages_.empty())
-            availableLanguages_.push_back("en");
+            availableLanguages_.emplace_back("en");
 
         auto currentLang = juce::String(config.getLanguage());
         initialLanguage_ = currentLang;
@@ -1215,7 +1215,7 @@ class AppearancePage : public juce::Component {
         swatch->setPaintingIsUnclipped(true);
         addAndMakeVisible(*swatch);
         colourSwatches_.push_back(std::move(swatch));
-        swatchColours_.push_back(juce::Colour(colour));
+        swatchColours_.emplace_back(colour);
 
         // Hex editor (RGB only, no alpha — we force 0xFF)
         auto hex = std::make_unique<juce::TextEditor>();
@@ -2089,7 +2089,7 @@ class PathsPage : public juce::Component {
             (kind == Kind::Data) ? magda::paths::alwaysOSDefault() : presetsDefaultDir();
         juce::String oldPath =
             original.empty() ? defaultDir.getFullPathName() : juce::String(original);
-        juce::String newPath = picked.getFullPathName();
+        const juce::String& newPath = picked.getFullPathName();
 
         const juce::String titleKey = (kind == Kind::Data)
                                           ? "preferences.paths.migration.data_title"
@@ -3285,7 +3285,7 @@ void scaleExplicitFonts(juce::Component& component, double ratio) {
     if (magda::resolvesOwnFonts(component))
         return;
 
-    const auto scaleFont = [ratio](juce::Font font) {
+    const auto scaleFont = [ratio](const juce::Font& font) {
         return font.withHeight(font.getHeight() * static_cast<float>(ratio));
     };
 

--- a/magda/daw/ui/panels/content/AIChatConsoleContent.cpp
+++ b/magda/daw/ui/panels/content/AIChatConsoleContent.cpp
@@ -834,12 +834,12 @@ void AIChatConsoleContent::RequestThread::run() {
             const bool hadError = !error.empty();
 
             magda::agent::ConsoleRunOutput output{
-                .dslCode = std::move(dsl),
-                .musicInstructions = std::move(musicIR),
-                .musicDescription = std::move(musicDesc),
-                .automationInstructions = std::move(autoIR),
+                .dslCode = dsl,
+                .musicInstructions = musicIR,
+                .musicDescription = musicDesc,
+                .automationInstructions = autoIR,
                 .prose = mixAnalysis,
-                .error = std::move(error),
+                .error = error,
             };
             magda::agent::ConsoleAgentResultExecutor executor(*safeThis->magdaApi_);
             auto execution = executor.execute(std::move(output), reviseTargetClipId);
@@ -3260,9 +3260,9 @@ void AIChatConsoleContent::finishControllerGeneration(bool success, const juce::
         menu.addSeparator();
         menu.addItem(9999, "Cancel");
 
-        auto rawJson = errorOrJson;  // contains the JSON when success == true
-        auto baseId = profileId;
-        auto displayName = profileName;
+        const auto& rawJson = errorOrJson;  // contains the JSON when success == true
+        const auto& baseId = profileId;
+        const auto& displayName = profileName;
 
         menu.showMenuAsync(juce::PopupMenu::Options().withTargetComponent(inputBox_.get()),
                            [safeThis, writeAndPromptPort, rawJson, baseId, displayName](int r) {

--- a/magda/daw/ui/panels/content/ChordClipContent.cpp
+++ b/magda/daw/ui/panels/content/ChordClipContent.cpp
@@ -327,6 +327,7 @@ void ChordClipContent::commitBlockDrag() {
     if (copyDrag_) {
         if (moved) {
             std::vector<int> pitches;
+            pitches.reserve(dragNotes_.size());
             for (const auto& dn : dragNotes_)
                 pitches.push_back(dn.note);
             insertChordAtBeat(dragNewStart_, pitches);
@@ -528,6 +529,7 @@ void ChordClipContent::openChordEditor(int annIndex) {
         const auto chord =
             magda::music::ChordEngine::getInstance().buildChordInversion(r, q, inv, oct);
         std::vector<int> pitches;
+        pitches.reserve(chord.notes.size());
         for (const auto& note : chord.notes)
             pitches.push_back(note.noteNumber);
         const int idx = annotationIndexAtBeat(bar + 0.001);
@@ -732,6 +734,7 @@ bool ChordClipContent::onChordRowClicked(double clipRelativeBeat) {
     const auto chord = magda::music::ChordEngine::getInstance().buildChordInRootPosition(
         magda::music::ChordRoot::C, magda::music::ChordQuality::Major, 4);
     std::vector<int> pitches;
+    pitches.reserve(chord.notes.size());
     for (const auto& note : chord.notes)
         pitches.push_back(note.noteNumber);
 

--- a/magda/daw/ui/panels/content/ChordPanelContent.cpp
+++ b/magda/daw/ui/panels/content/ChordPanelContent.cpp
@@ -1,5 +1,7 @@
 #include "ChordPanelContent.hpp"
 
+#include <utility>
+
 #include "../../../../agents/chord_agent.hpp"
 #include "BinaryData.h"
 #include "core/ChordProgressionContext.hpp"
@@ -23,8 +25,8 @@ namespace magda::daw::ui {
 // ScaleBlockComponent
 // ============================================================================
 
-ScaleBlockComponent::ScaleBlockComponent(const magda::music::ScaleWithChords& scale)
-    : scale_(scale) {
+ScaleBlockComponent::ScaleBlockComponent(magda::music::ScaleWithChords scale)
+    : scale_(std::move(scale)) {
     setName("ScaleBlock");
     setRepaintsOnMouseActivity(true);
 }
@@ -80,7 +82,7 @@ void ScaleBlockComponent::mouseExit(const juce::MouseEvent& /*e*/) {
 // ScaleChordsPopup
 // ============================================================================
 
-ScaleChordsPopup::ScaleChordsPopup(const magda::music::ScaleWithChords& scale) : scale_(scale) {
+ScaleChordsPopup::ScaleChordsPopup(magda::music::ScaleWithChords scale) : scale_(std::move(scale)) {
     setName("ScaleChordsPopup");
 
     // Build chord blocks for each diatonic triad
@@ -203,8 +205,8 @@ void ScaleChordsPopup::showAt(juce::Component* parent, juce::Rectangle<int> targ
 // BrowseScaleRowComponent
 // ============================================================================
 
-BrowseScaleRowComponent::BrowseScaleRowComponent(const magda::music::ScaleWithChords& scale)
-    : scale_(scale) {
+BrowseScaleRowComponent::BrowseScaleRowComponent(magda::music::ScaleWithChords scale)
+    : scale_(std::move(scale)) {
     setName("BrowseScaleRow");
     setRepaintsOnMouseActivity(true);
 }
@@ -1385,7 +1387,7 @@ IDENTIFIER: /[a-zA-Z_#][a-zA-Z0-9_#]*/
                 return false;
 
             // Post token to UI thread for live display
-            auto tokenCopy = token;
+            const auto& tokenCopy = token;
             juce::MessageManager::callAsync([safeThis, tokenCopy]() {
                 if (!safeThis)
                     return;

--- a/magda/daw/ui/panels/content/ChordPanelContent.hpp
+++ b/magda/daw/ui/panels/content/ChordPanelContent.hpp
@@ -29,7 +29,7 @@ class ChordBlockComponent;
  */
 class ScaleBlockComponent : public juce::Component {
   public:
-    explicit ScaleBlockComponent(const magda::music::ScaleWithChords& scale);
+    explicit ScaleBlockComponent(magda::music::ScaleWithChords scale);
 
     void paint(juce::Graphics& g) override;
     void mouseDown(const juce::MouseEvent& e) override;
@@ -59,7 +59,7 @@ class ScaleBlockComponent : public juce::Component {
  */
 class ScaleChordsPopup : public juce::Component {
   public:
-    ScaleChordsPopup(const magda::music::ScaleWithChords& scale);
+    ScaleChordsPopup(magda::music::ScaleWithChords scale);
 
     void paint(juce::Graphics& g) override;
     void resized() override;
@@ -86,7 +86,7 @@ using AIProgression = magda::daw::audio::MidiChordEnginePlugin::AIProgression;
  */
 class BrowseScaleRowComponent : public juce::Component {
   public:
-    explicit BrowseScaleRowComponent(const magda::music::ScaleWithChords& scale);
+    explicit BrowseScaleRowComponent(magda::music::ScaleWithChords scale);
 
     void paint(juce::Graphics& g) override;
     void resized() override;

--- a/magda/daw/ui/panels/content/DrumGridClipContent.cpp
+++ b/magda/daw/ui/panels/content/DrumGridClipContent.cpp
@@ -2272,7 +2272,7 @@ DrumGridClipContent::DrumGridClipContent() {
     };
 
     gridComponent_->onNoteSelectionChanged = [this](magda::ClipId clipId,
-                                                    std::vector<size_t> noteIndices) {
+                                                    const std::vector<size_t>& noteIndices) {
         if (noteIndices.empty()) {
             magda::SelectionManager::getInstance().clearNoteSelection();
         } else {
@@ -2290,7 +2290,7 @@ DrumGridClipContent::DrumGridClipContent() {
     };
 
     // Handle copy from context menu
-    gridComponent_->onCopyNotes = [](magda::ClipId clipId, std::vector<size_t> noteIndices) {
+    gridComponent_->onCopyNotes = [](magda::ClipId clipId, const std::vector<size_t>& noteIndices) {
         magda::ClipManager::getInstance().copyNotesToClipboard(clipId, noteIndices);
     };
 
@@ -2328,7 +2328,7 @@ DrumGridClipContent::DrumGridClipContent() {
 
     // Handle duplicate from context menu
     gridComponent_->onDuplicateNotes = [this](magda::ClipId clipId,
-                                              std::vector<size_t> noteIndices) {
+                                              const std::vector<size_t>& noteIndices) {
         auto& clipManager = magda::ClipManager::getInstance();
         const auto* clip = clipManager.getClip(clipId);
         if (!clip || !clip->isMidi())

--- a/magda/daw/ui/panels/content/MediaDbBrowserContent.cpp
+++ b/magda/daw/ui/panels/content/MediaDbBrowserContent.cpp
@@ -696,7 +696,7 @@ class MediaDbBrowserContent::ResultsTableModel : public juce::TableListBoxModel 
             }
             const juce::Component::SafePointer<MediaDbBrowserContent> self(&owner_);
             const auto seedId = r.fileId;
-            const auto seedName = fileName;
+            const auto& seedName = fileName;
             menu.showMenuAsync(
                 juce::PopupMenu::Options{},
                 [self, seedId, seedName, selectedIds = std::move(selectedIds)](int choice) mutable {
@@ -1502,7 +1502,7 @@ void MediaDbBrowserContent::showBulkEditRowsDialog(std::vector<std::int64_t> fil
         }));
 }
 
-void MediaDbBrowserContent::resetRowsToDetected(std::vector<std::int64_t> fileIds) {
+void MediaDbBrowserContent::resetRowsToDetected(const std::vector<std::int64_t>& fileIds) {
     if (indexing_ || fileIds.empty()) {
         return;
     }

--- a/magda/daw/ui/panels/content/MediaDbBrowserContent.hpp
+++ b/magda/daw/ui/panels/content/MediaDbBrowserContent.hpp
@@ -144,7 +144,7 @@ class MediaDbBrowserContent : public juce::Component, private juce::Timer {
     void startAnalyzingFileIds(std::vector<std::int64_t> fileIds);
     void showEditRowDialog(std::int64_t fileId);
     void showBulkEditRowsDialog(std::vector<std::int64_t> fileIds);
-    void resetRowsToDetected(std::vector<std::int64_t> fileIds);
+    void resetRowsToDetected(const std::vector<std::int64_t>& fileIds);
     void saveMatchingClipValuesToLibrary(std::int64_t fileId);
     void recoverMissingFile(std::int64_t fileId);
     // When `fileIds` has more than one entry the family/shape choice is

--- a/magda/daw/ui/panels/content/MediaExplorerContent.cpp
+++ b/magda/daw/ui/panels/content/MediaExplorerContent.cpp
@@ -1229,7 +1229,7 @@ juce::File MediaExplorerContent::pickStartupFilesystemRoot() {
     return juce::File::getSpecialLocation(juce::File::userHomeDirectory);
 }
 
-void MediaExplorerContent::applyView(ViewState target) {
+void MediaExplorerContent::applyView(const ViewState& target) {
     // The ONE writer of view state. Touches everything that depends on the
     // mode/sidebar/root so nothing can drift out of sync:
     //   1. Sidebar visual selection

--- a/magda/daw/ui/panels/content/MediaExplorerContent.hpp
+++ b/magda/daw/ui/panels/content/MediaExplorerContent.hpp
@@ -153,7 +153,7 @@ class MediaExplorerContent : public PanelContent,
         juce::File filesystemRoot;  // meaningful when mode == Filesystem
     };
     ViewState currentView_;
-    void applyView(ViewState target);
+    void applyView(const ViewState& target);
 
     // Helper: best initial Filesystem root — saved default, then Music,
     // then Home. Always returns an existing directory.

--- a/magda/daw/ui/panels/content/PianoRollContent.cpp
+++ b/magda/daw/ui/panels/content/PianoRollContent.cpp
@@ -657,7 +657,7 @@ void PianoRollContent::setupGridCallbacks() {
 
     // Handle batch note selection changes (lasso, deselect-all, Cmd+click toggle)
     gridComponent_->onNoteSelectionChanged = [this](magda::ClipId clipId,
-                                                    std::vector<size_t> noteIndices) {
+                                                    const std::vector<size_t>& noteIndices) {
         if (noteIndices.empty()) {
             // Clear note selection — preserve clip selection
             magda::SelectionManager::getInstance().clearNoteSelection();
@@ -692,7 +692,8 @@ void PianoRollContent::setupGridCallbacks() {
 
     // Handle legato from right-click context menu: stretch each selected note to
     // the next selected onset (one undo step via the batch resize command).
-    gridComponent_->onLegatoNotes = [](magda::ClipId clipId, std::vector<size_t> noteIndices) {
+    gridComponent_->onLegatoNotes = [](magda::ClipId clipId,
+                                       const std::vector<size_t>& noteIndices) {
         const auto* clip = magda::ClipManager::getInstance().getClip(clipId);
         if (!clip || !clip->isMidi())
             return;
@@ -705,7 +706,7 @@ void PianoRollContent::setupGridCallbacks() {
     };
 
     // Handle copy from context menu
-    gridComponent_->onCopyNotes = [](magda::ClipId clipId, std::vector<size_t> noteIndices) {
+    gridComponent_->onCopyNotes = [](magda::ClipId clipId, const std::vector<size_t>& noteIndices) {
         magda::ClipManager::getInstance().copyNotesToClipboard(clipId, noteIndices);
     };
 
@@ -743,7 +744,7 @@ void PianoRollContent::setupGridCallbacks() {
 
     // Handle duplicate from context menu
     gridComponent_->onDuplicateNotes = [this](magda::ClipId clipId,
-                                              std::vector<size_t> noteIndices) {
+                                              const std::vector<size_t>& noteIndices) {
         auto& clipManager = magda::ClipManager::getInstance();
         const auto* clip = clipManager.getClip(clipId);
         if (!clip || !clip->isMidi())
@@ -805,7 +806,7 @@ void PianoRollContent::setupGridCallbacks() {
 
     // Handle chord block drops from the chord panel
     gridComponent_->onChordDropped = [](magda::ClipId clipId, double beat, double noteLength,
-                                        std::vector<std::pair<int, int>> notes,
+                                        const std::vector<std::pair<int, int>>& notes,
                                         juce::String chordName) {
         if (notes.empty())
             return;
@@ -2091,7 +2092,7 @@ void PianoRollContent::syncChordAnnotations(magda::ClipId clipId) {
 
         for (const auto& note : clip->midiNotes) {
             if (note.chordGroup == it->chordGroup) {
-                chordNotes.push_back({note.noteNumber, note.velocity});
+                chordNotes.emplace_back(note.noteNumber, note.velocity);
                 minBeat = std::min(minBeat, note.startBeat);
                 maxEnd = std::max(maxEnd, note.startBeat + note.lengthBeats);
             }

--- a/magda/daw/ui/panels/content/PluginBrowserContent.cpp
+++ b/magda/daw/ui/panels/content/PluginBrowserContent.cpp
@@ -2,6 +2,8 @@
 
 #include <BinaryData.h>
 
+#include <utility>
+
 #include "../../../../agents/sound_design_agent.hpp"
 #include "../../dialogs/ParameterConfigDialog.hpp"
 #include "../../themes/DarkTheme.hpp"
@@ -169,8 +171,8 @@ juce::String PluginBrowserInfo::generateAlias(const juce::String& pluginName) {
 //==============================================================================
 class PluginBrowserContent::PluginTreeItem : public juce::TreeViewItem {
   public:
-    PluginTreeItem(const PluginBrowserInfo& plugin, PluginBrowserContent& owner)
-        : plugin_(plugin), owner_(owner) {}
+    PluginTreeItem(PluginBrowserInfo plugin, PluginBrowserContent& owner)
+        : plugin_(std::move(plugin)), owner_(owner) {}
 
     bool mightContainSubItems() override {
         return false;
@@ -290,8 +292,8 @@ class PluginBrowserContent::PluginTreeItem : public juce::TreeViewItem {
 //==============================================================================
 class PluginBrowserContent::CategoryTreeItem : public juce::TreeViewItem {
   public:
-    CategoryTreeItem(const juce::String& name, const juce::String& icon = "")
-        : name_(name), icon_(icon) {}
+    CategoryTreeItem(juce::String name, juce::String icon = "")
+        : name_(std::move(name)), icon_(std::move(icon)) {}
 
     bool mightContainSubItems() override {
         return true;
@@ -723,7 +725,7 @@ void PluginBrowserContent::rebuildTree() {
         // For nested categories (e.g., "Effect/EQ")
         if (currentViewMode_ == ViewMode::ByCategory) {
             auto parts = juce::StringArray::fromTokens(groupKey, "/", "");
-            juce::String parentKey = parts[0];
+            const juce::String& parentKey = parts[0];
             juce::String childKey = parts.size() > 1 ? parts[1] : "";
 
             // Create parent category if needed

--- a/magda/daw/ui/panels/content/TrackChainContent.cpp
+++ b/magda/daw/ui/panels/content/TrackChainContent.cpp
@@ -4,6 +4,7 @@
 
 #include <cmath>
 #include <thread>
+#include <utility>
 
 #include "../../../../agents/gain_staging_agent.hpp"
 #include "../../components/chain/ChainNodePathDrag.hpp"
@@ -1209,12 +1210,12 @@ void TrackChainContent::initGlobalModsPanel() {
     globalModsPanel_->onModTargetChanged = [this](int modIndex, magda::ControlTarget target) {
         if (selectedTrackId_ != magda::INVALID_TRACK_ID)
             magda::TrackManager::getInstance().setModTarget(
-                ChainNodePath::trackLevel(selectedTrackId_), modIndex, target);
+                ChainNodePath::trackLevel(selectedTrackId_), modIndex, std::move(target));
     };
     globalModsPanel_->onModLinkRemoved = [this](int modIndex, magda::ControlTarget target) {
         if (selectedTrackId_ != magda::INVALID_TRACK_ID) {
             magda::TrackManager::getInstance().removeModLink(
-                ChainNodePath::trackLevel(selectedTrackId_), modIndex, target);
+                ChainNodePath::trackLevel(selectedTrackId_), modIndex, std::move(target));
             updateGlobalModsPanel();
         }
     };
@@ -1347,26 +1348,29 @@ void TrackChainContent::initGlobalModsPanel() {
     globalModEditorPanel_->onModLinkDeleted = [this](int modIndex, magda::ControlTarget target) {
         if (selectedTrackId_ != magda::INVALID_TRACK_ID)
             magda::TrackManager::getInstance().removeModLink(
-                ChainNodePath::trackLevel(selectedTrackId_), modIndex, target);
+                ChainNodePath::trackLevel(selectedTrackId_), modIndex, std::move(target));
     };
-    globalModEditorPanel_->onModLinkBipolarChanged =
-        [this](int modIndex, magda::ControlTarget target, bool bipolar) {
-            if (selectedTrackId_ != magda::INVALID_TRACK_ID)
-                magda::TrackManager::getInstance().setModLinkBipolar(
-                    ChainNodePath::trackLevel(selectedTrackId_), modIndex, target, bipolar);
-        };
-    globalModEditorPanel_->onModLinkEnabledChanged =
-        [this](int modIndex, magda::ControlTarget target, bool enabled) {
-            if (selectedTrackId_ != magda::INVALID_TRACK_ID)
-                magda::TrackManager::getInstance().setModLinkEnabled(
-                    ChainNodePath::trackLevel(selectedTrackId_), modIndex, target, enabled);
-        };
-    globalModEditorPanel_->onModLinkAmountChanged =
-        [this](int modIndex, magda::ControlTarget target, float amount) {
-            if (selectedTrackId_ != magda::INVALID_TRACK_ID)
-                magda::TrackManager::getInstance().setModLinkAmount(
-                    ChainNodePath::trackLevel(selectedTrackId_), modIndex, target, amount);
-        };
+    globalModEditorPanel_->onModLinkBipolarChanged = [this](int modIndex,
+                                                            magda::ControlTarget target,
+                                                            bool bipolar) {
+        if (selectedTrackId_ != magda::INVALID_TRACK_ID)
+            magda::TrackManager::getInstance().setModLinkBipolar(
+                ChainNodePath::trackLevel(selectedTrackId_), modIndex, std::move(target), bipolar);
+    };
+    globalModEditorPanel_->onModLinkEnabledChanged = [this](int modIndex,
+                                                            magda::ControlTarget target,
+                                                            bool enabled) {
+        if (selectedTrackId_ != magda::INVALID_TRACK_ID)
+            magda::TrackManager::getInstance().setModLinkEnabled(
+                ChainNodePath::trackLevel(selectedTrackId_), modIndex, std::move(target), enabled);
+    };
+    globalModEditorPanel_->onModLinkAmountChanged = [this](int modIndex,
+                                                           magda::ControlTarget target,
+                                                           float amount) {
+        if (selectedTrackId_ != magda::INVALID_TRACK_ID)
+            magda::TrackManager::getInstance().setModLinkAmount(
+                ChainNodePath::trackLevel(selectedTrackId_), modIndex, std::move(target), amount);
+    };
     globalModEditorPanel_->setParamNameResolver(
         [this](magda::DeviceId deviceId, int paramIndex) -> juce::String {
             if (selectedTrackId_ == magda::INVALID_TRACK_ID)
@@ -1419,7 +1423,7 @@ void TrackChainContent::initGlobalMacrosPanel() {
     globalMacrosPanel_->onMacroTargetChanged = [this](int macroIndex, magda::ControlTarget target) {
         if (selectedTrackId_ != magda::INVALID_TRACK_ID)
             magda::TrackManager::getInstance().setMacroTarget(
-                ChainNodePath::trackLevel(selectedTrackId_), macroIndex, target);
+                ChainNodePath::trackLevel(selectedTrackId_), macroIndex, std::move(target));
     };
     globalMacrosPanel_->onMacroNameChanged = [this](int macroIndex, juce::String name) {
         if (selectedTrackId_ != magda::INVALID_TRACK_ID)
@@ -1430,7 +1434,7 @@ void TrackChainContent::initGlobalMacrosPanel() {
     globalMacrosPanel_->onMacroLinkRemoved = [this](int macroIndex, magda::ControlTarget target) {
         if (selectedTrackId_ != magda::INVALID_TRACK_ID) {
             magda::TrackManager::getInstance().removeMacroLink(
-                ChainNodePath::trackLevel(selectedTrackId_), macroIndex, target);
+                ChainNodePath::trackLevel(selectedTrackId_), macroIndex, std::move(target));
             updateGlobalMacrosPanel();
         }
     };
@@ -1478,13 +1482,14 @@ void TrackChainContent::initGlobalMacrosPanel() {
                                                           float amount) {
         if (selectedTrackId_ != magda::INVALID_TRACK_ID && selectedGlobalMacroIndex_ >= 0)
             magda::TrackManager::getInstance().setMacroLinkAmount(
-                ChainNodePath::trackLevel(selectedTrackId_), selectedGlobalMacroIndex_, target,
-                amount);
+                ChainNodePath::trackLevel(selectedTrackId_), selectedGlobalMacroIndex_,
+                std::move(target), amount);
     };
     globalMacroEditorPanel_->onLinkRemoved = [this](magda::ControlTarget target) {
         if (selectedTrackId_ != magda::INVALID_TRACK_ID && selectedGlobalMacroIndex_ >= 0) {
             magda::TrackManager::getInstance().removeMacroLink(
-                ChainNodePath::trackLevel(selectedTrackId_), selectedGlobalMacroIndex_, target);
+                ChainNodePath::trackLevel(selectedTrackId_), selectedGlobalMacroIndex_,
+                std::move(target));
             updateGlobalMacrosPanel();
         }
     };
@@ -1492,8 +1497,8 @@ void TrackChainContent::initGlobalMacrosPanel() {
                                                            bool bipolar) {
         if (selectedTrackId_ != magda::INVALID_TRACK_ID && selectedGlobalMacroIndex_ >= 0) {
             magda::TrackManager::getInstance().setMacroLinkBipolar(
-                ChainNodePath::trackLevel(selectedTrackId_), selectedGlobalMacroIndex_, target,
-                bipolar);
+                ChainNodePath::trackLevel(selectedTrackId_), selectedGlobalMacroIndex_,
+                std::move(target), bipolar);
             updateGlobalMacrosPanel();
         }
     };
@@ -1574,7 +1579,7 @@ void TrackChainContent::updateGlobalModsPanel() {
         for (const auto& element : elements) {
             if (magda::isDevice(element)) {
                 const auto& device = magda::getDevice(element);
-                allDevices.push_back({device.id, device.name});
+                allDevices.emplace_back(device.id, device.name);
                 std::vector<juce::String> names;
                 names.reserve(device.parameters.size());
                 for (const auto& p : device.parameters)
@@ -1636,7 +1641,7 @@ void TrackChainContent::updateGlobalMacrosPanel() {
         for (const auto& element : elements) {
             if (magda::isDevice(element)) {
                 const auto& device = magda::getDevice(element);
-                allDevices.push_back({device.id, device.name});
+                allDevices.emplace_back(device.id, device.name);
                 std::vector<juce::String> names;
                 names.reserve(device.parameters.size());
                 for (const auto& p : device.parameters) {
@@ -2278,7 +2283,7 @@ void TrackChainContent::runAiGainStagingPass() {
                 std::vector<std::pair<magda::ChainNodePath, float>> moves;
                 for (const auto& d : result.decisions)
                     if (d.index >= 0 && d.index < static_cast<int>(paths.size()))
-                        moves.push_back({paths[static_cast<size_t>(d.index)], d.newGainDb});
+                        moves.emplace_back(paths[static_cast<size_t>(d.index)], d.newGainDb);
                 m.applyAiMoves(moves);
                 juce::Logger::writeToLog("[GainStaging] AI: " + juce::String(result.summary));
             }

--- a/magda/daw/ui/state/TimelineState.hpp
+++ b/magda/daw/ui/state/TimelineState.hpp
@@ -3,6 +3,7 @@
 #include <juce_gui_basics/juce_gui_basics.h>
 
 #include <set>
+#include <utility>
 #include <vector>
 
 #include "../layout/LayoutConfig.hpp"
@@ -406,14 +407,13 @@ struct ArrangementSection {
     juce::String name;
     juce::Colour colour;
 
-    ArrangementSection(double start = 0.0, double end = 0.0,
-                       const juce::String& sectionName = "Section",
+    ArrangementSection(double start = 0.0, double end = 0.0, juce::String sectionName = "Section",
                        juce::Colour sectionColour = juce::Colours::blue)
         : startTime(start),
           endTime(end),
           startBeats(start * DEFAULT_BPM / 60.0),
           endBeats(end * DEFAULT_BPM / 60.0),
-          name(sectionName),
+          name(std::move(sectionName)),
           colour(sectionColour) {}
 
     double getDuration() const {
@@ -452,9 +452,9 @@ struct TimelineMarker {
     juce::String name;
     juce::Colour colour;
 
-    TimelineMarker(int markerId = 0, double beats = 0.0, const juce::String& markerName = "Marker",
+    TimelineMarker(int markerId = 0, double beats = 0.0, juce::String markerName = "Marker",
                    juce::Colour markerColour = juce::Colour(0xFF9E9E9E))
-        : id(markerId), positionBeats(beats), name(markerName), colour(markerColour) {
+        : id(markerId), positionBeats(beats), name(std::move(markerName)), colour(markerColour) {
         positionTime = beats * 60.0 / DEFAULT_BPM;
     }
 

--- a/magda/daw/ui/themes/LocalizedText.hpp
+++ b/magda/daw/ui/themes/LocalizedText.hpp
@@ -23,7 +23,7 @@ inline bool containsLocalizedUIFontText(const juce::String& text) {
     return false;
 }
 
-inline juce::Font withLocalizedUIFontScale(juce::Font font) {
+inline juce::Font withLocalizedUIFontScale(const juce::Font& font) {
     return font.withHeight(font.getHeight() *
                            static_cast<float>(Config::getInstance().getLocalizedUIFontScale()));
 }

--- a/magda/daw/ui/themes/MainLookAndFeel.hpp
+++ b/magda/daw/ui/themes/MainLookAndFeel.hpp
@@ -2,6 +2,8 @@
 
 #include <juce_gui_basics/juce_gui_basics.h>
 
+#include <utility>
+
 #include "DarkTheme.hpp"
 #include "FontManager.hpp"
 
@@ -104,9 +106,11 @@ class MainLookAndFeel : public juce::LookAndFeel_V4 {
   private:
     class GlyphButton : public juce::Button {
       public:
-        GlyphButton(const juce::String& name, juce::Colour c, const juce::Path& normal,
-                    const juce::Path& toggled)
-            : juce::Button(name), colour(c), normalShape(normal), toggledShape(toggled) {}
+        GlyphButton(const juce::String& name, juce::Colour c, juce::Path normal, juce::Path toggled)
+            : juce::Button(name),
+              colour(c),
+              normalShape(std::move(normal)),
+              toggledShape(std::move(toggled)) {}
 
         void paintButton(juce::Graphics& g, bool isHighlighted, bool isDown) override {
             auto background = juce::Colours::grey;

--- a/magda/daw/ui/views/MainView.cpp
+++ b/magda/daw/ui/views/MainView.cpp
@@ -5,6 +5,7 @@
 #include <cmath>
 #include <ranges>
 #include <set>
+#include <utility>
 
 #include "../components/automation/AutomationMenu.hpp"
 #include "../components/automation/MasterAutomationLanes.hpp"
@@ -2148,7 +2149,7 @@ void MainView::setupSelectionCallbacks() {
             timelineController->dispatch(ClearTimeSelectionEvent{});
         } else {
             timelineController->dispatch(
-                SetTimeSelectionBeatsEvent{startBeats, endBeats, trackIndices});
+                SetTimeSelectionBeatsEvent{startBeats, endBeats, std::move(trackIndices)});
             // Move playhead to follow the left side of selection
             timelineController->dispatch(SetPlayheadPositionBeatsEvent{startBeats});
         }
@@ -2161,7 +2162,7 @@ void MainView::setupSelectionCallbacks() {
                 timelineController->dispatch(ClearTimeSelectionEvent{});
             } else {
                 timelineController->dispatch(SetTimeSelectionBeatsEvent{
-                    startBeats, endBeats, trackIndices, false, std::move(laneIds)});
+                    startBeats, endBeats, std::move(trackIndices), false, std::move(laneIds)});
                 timelineController->dispatch(SetPlayheadPositionBeatsEvent{startBeats});
             }
         };
@@ -2173,7 +2174,7 @@ void MainView::setupSelectionCallbacks() {
                 timelineController->dispatch(ClearTimeSelectionEvent{});
             } else {
                 timelineController->dispatch(SetTimeSelectionBeatsEvent{
-                    startBeats, endBeats, trackIndices, true, std::move(laneIds)});
+                    startBeats, endBeats, std::move(trackIndices), true, std::move(laneIds)});
                 timelineController->dispatch(SetPlayheadPositionBeatsEvent{startBeats});
             }
         };

--- a/magda/daw/ui/windows/MainWindowCommands.cpp
+++ b/magda/daw/ui/windows/MainWindowCommands.cpp
@@ -1453,6 +1453,7 @@ bool MainWindow::MainComponent::perform(const InvocationInfo& info) {
                 const auto* clip = clipManager.getClip(clipId);
                 if (clip && clip->isMidi()) {
                     std::vector<size_t> allIndices;
+                    allIndices.reserve(clip->midiNotes.size());
                     for (size_t i = 0; i < clip->midiNotes.size(); ++i)
                         allIndices.push_back(i);
                     selectionManager.selectNotes(clipId, allIndices);

--- a/magda/daw/ui/windows/MainWindowExport.cpp
+++ b/magda/daw/ui/windows/MainWindowExport.cpp
@@ -1,5 +1,7 @@
 #include <juce_audio_basics/juce_audio_basics.h>
 
+#include <utility>
+
 #include "../dialogs/ExportAudioDialog.hpp"
 #include "../dialogs/ExportMidiDialog.hpp"
 #include "MainWindow.hpp"
@@ -36,13 +38,13 @@ double timelineEndBeats(const ClipInfo& clip, double bpm) {
 class ExportProgressWindow : public juce::ThreadWithProgressWindow {
   public:
     ExportProgressWindow(std::unique_ptr<OfflineRenderSession> renderSession,
-                         const OfflineRenderRequest& request, const juce::File& outputFile,
+                         const OfflineRenderRequest& request, juce::File outputFile,
                          std::function<void()> onComplete, double prerollSeconds = 0.0,
                          double leadInSilence = 0.0)
         : ThreadWithProgressWindow(trEllipsis("export.progress.exporting_audio"), true, true),
           renderSession_(std::move(renderSession)),
           renderTask_(renderSession_ ? renderSession_->createTask(request) : nullptr),
-          outputFile_(outputFile),
+          outputFile_(std::move(outputFile)),
           onComplete_(std::move(onComplete)),
           prerollSeconds_(prerollSeconds),
           leadInSilence_(leadInSilence),

--- a/magda/engine/exec/EngineSession.cpp
+++ b/magda/engine/exec/EngineSession.cpp
@@ -74,7 +74,7 @@ EngineSession::Result EngineSession::publish(std::shared_ptr<const RenderPlan> p
     // why. Asked of the executor rather than worked out here, so that the
     // answer cannot differ from the one the block itself will get.
     if (!prepared->executor.appliesValues(prepared->values)) {
-        messages.push_back(
+        messages.emplace_back(
             "the values published with this plan are not values it can render: they were "
             "resolved against a different plan, or against this one before it was whole. "
             "It is not published, because it would have rendered at unity");

--- a/magda/engine/exec/ParallelPlanExecutor.cpp
+++ b/magda/engine/exec/ParallelPlanExecutor.cpp
@@ -75,7 +75,7 @@ std::vector<std::string> ParallelPlanExecutor::prepare(const RenderPlan& plan,
     // constants disagree with its ops did not come from the compiler.
     if (!carriesSchedule(plan)) {
         core_.reset();
-        messages.push_back(
+        messages.emplace_back(
             "plan does not carry the schedule its topology implies: its dependency counts, "
             "consumer edges or initially-ready set are missing or disagree with its ops, so it "
             "cannot be scheduled");

--- a/magda/engine/io/SourceLoopInfo.cpp
+++ b/magda/engine/io/SourceLoopInfo.cpp
@@ -10,7 +10,7 @@ namespace {
 /// counts as not written: a writer that emitted the key and left it blank said
 /// no more than one that left it out.
 std::optional<juce::String> valueOf(const juce::StringPairArray& metadata, const char* key) {
-    const auto value = metadata[key];
+    const auto& value = metadata[key];
     return value.isNotEmpty() ? std::optional<juce::String>(value) : std::nullopt;
 }
 

--- a/magda/engine/param/ParamTableCompiler.cpp
+++ b/magda/engine/param/ParamTableCompiler.cpp
@@ -830,7 +830,7 @@ std::vector<int> stronglyConnectedComponents(const std::vector<std::vector<int>>
         if (index[root] >= 0)
             continue;
 
-        work.push_back({root, 0});
+        work.emplace_back(root, 0);
         while (!work.empty()) {
             auto& [node, edge] = work.back();
 
@@ -847,7 +847,7 @@ std::vector<int> stronglyConnectedComponents(const std::vector<std::vector<int>>
                 ++edge;
 
                 if (index[next] < 0) {
-                    work.push_back({next, 0});
+                    work.emplace_back(next, 0);
                 } else if (onStack[next] != 0) {
                     lowlink[node] = std::min(lowlink[node], index[next]);
                 }

--- a/magda/engine/plan/PlanCompiler.cpp
+++ b/magda/engine/plan/PlanCompiler.cpp
@@ -805,7 +805,7 @@ ChainSignal Compiler::emitDevice(const DeviceInfo& device, const ChainSite& site
     std::vector<PortDesc> outputs{
         PortDesc{SignalKind::Audio, static_cast<std::uint8_t>(outputWidth)}};
     if (producesMidi)
-        outputs.push_back(SignalKind::Midi);
+        outputs.emplace_back(SignalKind::Midi);
 
     // The further pairs are ports on the same op, after the main audio and any
     // MIDI. They carry the device's raw output: the slot's gain trim and meter
@@ -815,8 +815,8 @@ ChainSignal Compiler::emitDevice(const DeviceInfo& device, const ChainSite& site
     const auto firstMultiOutPort = static_cast<int>(outputs.size());
     for (int pair = 0; pair < multiOutPairCount; ++pair) {
         const auto& declared = device.multiOut.outputPairs[static_cast<std::size_t>(pair) + 1];
-        outputs.push_back(
-            {SignalKind::Audio, static_cast<std::uint8_t>(std::clamp(declared.numChannels, 0, 2))});
+        outputs.emplace_back(SignalKind::Audio,
+                             static_cast<std::uint8_t>(std::clamp(declared.numChannels, 0, 2)));
     }
 
     // Only a device that reads the bus is connected to it.
@@ -1007,7 +1007,7 @@ ChainSignal Compiler::emitRack(const RackInfo& rack, const ChainSite& site, Chai
                              OpRole::RackChainFader, 0,       site.segment};
         std::vector<PortDesc> faderOutputs{SignalKind::Audio};
         if (generatesMidi)
-            faderOutputs.push_back(SignalKind::Midi);
+            faderOutputs.emplace_back(SignalKind::Midi);
 
         const auto faderOp =
             addOp(OpKind::Fader, faderKey,

--- a/magda/mcp_bridge/main.cpp
+++ b/magda/mcp_bridge/main.cpp
@@ -267,7 +267,7 @@ class Bridge {
     }
 
     void forward(const juce::var& message) {
-        const auto id = message["id"];
+        const auto& id = message["id"];
         const auto method = message["method"].toString();
         const auto body = juce::JSON::toString(message, true).toStdString();
 

--- a/magda/scripting/LuaScriptStore.cpp
+++ b/magda/scripting/LuaScriptStore.cpp
@@ -1,6 +1,7 @@
 #include "magda/scripting/LuaScriptStore.hpp"
 
 #include <algorithm>
+#include <utility>
 
 #include "magda/daw/core/AppPaths.hpp"
 
@@ -8,7 +9,7 @@ namespace magda::scripting {
 
 LuaScriptStore::LuaScriptStore() : root_(magda::paths::controllerScriptsDir()) {}
 
-LuaScriptStore::LuaScriptStore(const juce::File& root) : root_(root) {}
+LuaScriptStore::LuaScriptStore(juce::File root) : root_(std::move(root)) {}
 
 bool LuaScriptStore::ensureExists() const {
     if (root_.exists())

--- a/magda/scripting/LuaScriptStore.hpp
+++ b/magda/scripting/LuaScriptStore.hpp
@@ -27,7 +27,7 @@ class LuaScriptStore {
     LuaScriptStore();
 
     /** Test seam: redirect to a custom directory. */
-    explicit LuaScriptStore(const juce::File& root);
+    explicit LuaScriptStore(juce::File root);
 
     /** Filesystem root the store enumerates. Created on demand by ensureExists(). */
     const juce::File& root() const noexcept {


### PR DESCRIPTION
The fourth clang-tidy batch: `modernize-use-emplace`, `modernize-pass-by-value` and the `performance-*` checks across `magda/`. `push_back(T(...))` becomes `emplace_back(...)`, constructor parameters that are stored take their argument by value and move it, large read-only parameters bind by const reference, and containers reserve before a known-size fill.

Follows #2482, #2483 and #2484.

## The one real defect the fixer introduced

`performance-unnecessary-copy-initialization` rewrote the `TrackInfo` copy in `TrackManager::moveTrackToPosition` as a reference, and the next line erases the element it binds to, so the reinsert read freed memory. The whole `[reorder]` test case segfaulted. The copy is load-bearing and now says so in a comment, because a later run will flag it again.

Two leftovers from the static-members batch go with it: the dead `this` capture in `AutomationLaneComponent`, left behind when `valueToPixel` became static, and `setChainElementsBypassed`, which no caller has and which mass-writes the bypassed flags that `TrackChain::enabled` replaced.

## Fixer suggestions not taken

- `makeProcessor` keeps its by-value `DevicePluginPtr`. `InternalPluginSpec` stores its address in a field typed `(DeviceId, DevicePluginPtr)`, so narrowing the parameter unmatched every designated initialiser in the pack.
- The loop copies in `DeviceStateHydration` and `AutomationCommands` stay copies: their bodies mutate the element or hand it to a non-const reference.

Applying a header fix once per including translation unit also left repeated edits behind, 162 nested `std::move` wrappers and 43 lines of stacked `const`/`&` qualifiers. Both are collapsed here to the single edit intended.

## Verification

- Catch2 green: 3772 cases, 998028 assertions, 0 failures.
- All 179 changed files force-recompiled; no warning lands on any line this batch changed.
- Every other new `const&` binding audited for the same use-after-free shape. The rest are captured by value into lambdas or bind to temporaries.

The `magda_juce_tests` corpus failures visible on this branch are pre-existing on `dev` and unrelated; they are fixed in #2486 and tracked in #2485.
