### PR TITLE
Gate the native arranger on the track's playback mode (#2485)

### DIFF
--- a/magda/daw/core/TrackInfo.hpp
+++ b/magda/daw/core/TrackInfo.hpp
@@ -34,8 +34,6 @@ struct SendInfo {
 
 enum class InputMonitorMode { Off, In, Auto };
 
-enum class TrackPlaybackMode { Arrangement, Session };
-
 /**
  * @brief Track data structure containing all track properties
  */

--- a/magda/daw/core/TrackTypes.hpp
+++ b/magda/daw/core/TrackTypes.hpp
@@ -268,4 +268,8 @@ inline bool canHaveChildren(TrackType type) {
     return traitsOf(type).canHaveChildren;
 }
 
+/// Which of a track's two bodies of material plays: its arrangement, or its
+/// session slots. Persisted by ordinal; the engine gates on it (#2485).
+enum class TrackPlaybackMode { Arrangement, Session };
+
 }  // namespace magda

--- a/magda/engine/clip/ClipAudioSource.cpp
+++ b/magda/engine/clip/ClipAudioSource.cpp
@@ -151,17 +151,30 @@ void ClipAudioSource::render(const BlockInfo& block, juce::dsp::AudioBlock<float
 
     renderMaterial(block, out);
 
-    // Only a source that shares its track with a session has a section to lose
-    // it to. One built without the feed is the whole track.
-    if (section_ == Section::Arrangement && handles_ != nullptr)
+    // Every Arrangement source has a mode to check now (#2485), handles or not.
+    if (section_ == Section::Arrangement)
         applySectionHold(out);
 }
 
 void ClipAudioSource::applySectionHold(juce::dsp::AudioBlock<float> out) {
     const auto numSamples = static_cast<int>(out.getNumSamples());
 
-    const LaunchHandleFeed::Reader handles(*handles_);
-    const auto hold = sectionHold(handles.get(), trackId_, numSamples);
+    // A track missing from the snapshot is Arrangement: nothing to silence.
+    bool session = false;
+    const ClipSnapshotFeed::Reader snapshot(clips_);
+    if (const auto* track = snapshot ? snapshot->find(trackId_) : nullptr)
+        session = track->playbackMode == TrackPlaybackMode::Session;
+
+    const SectionMode mode{session, sessionModeBefore_};
+    sessionModeBefore_ = session;
+
+    SectionHold hold;
+    if (handles_ != nullptr) {
+        const LaunchHandleFeed::Reader handles(*handles_);
+        hold = sectionHold(handles.get(), trackId_, numSamples, mode);
+    } else {
+        hold = sectionHold(nullptr, trackId_, numSamples, mode);
+    }
 
     const auto until = std::clamp(hold.until.value, 0, numSamples);
 

--- a/magda/engine/clip/ClipAudioSource.cpp
+++ b/magda/engine/clip/ClipAudioSource.cpp
@@ -149,21 +149,25 @@ void ClipAudioSource::render(const BlockInfo& block, juce::dsp::AudioBlock<float
     // return before reaching: a stale edge would release a voice twice.
     stoppingCount_ = 0;
 
-    renderMaterial(block, out);
+    // One snapshot for the whole render: the material and the mode that gates
+    // it come from the same publish, or a swap between the two stages could
+    // gate one snapshot's clips with another's mode.
+    const ClipSnapshotFeed::Reader snapshot(clips_);
+    const auto* track = snapshot ? snapshot->find(trackId_) : nullptr;
 
-    // Every Arrangement source has a mode to check now (#2485), handles or not.
+    renderMaterial(block, out, snapshot.get(), track);
+
+    // Every Arrangement source has a mode to check (#2485), handles or not.
     if (section_ == Section::Arrangement)
-        applySectionHold(out);
+        applySectionHold(out, track);
 }
 
-void ClipAudioSource::applySectionHold(juce::dsp::AudioBlock<float> out) {
+void ClipAudioSource::applySectionHold(juce::dsp::AudioBlock<float> out,
+                                       const TrackClipPlayback* track) {
     const auto numSamples = static_cast<int>(out.getNumSamples());
 
     // A track missing from the snapshot is Arrangement: nothing to silence.
-    bool session = false;
-    const ClipSnapshotFeed::Reader snapshot(clips_);
-    if (const auto* track = snapshot ? snapshot->find(trackId_) : nullptr)
-        session = track->playbackMode == TrackPlaybackMode::Session;
+    const auto session = track != nullptr && track->playbackMode == TrackPlaybackMode::Session;
 
     const SectionMode mode{session, sessionModeBefore_};
     sessionModeBefore_ = session;
@@ -203,7 +207,8 @@ void ClipAudioSource::applySectionHold(juce::dsp::AudioBlock<float> out) {
         handOver_.advance(out);
 }
 
-void ClipAudioSource::renderMaterial(const BlockInfo& block, juce::dsp::AudioBlock<float> out) {
+void ClipAudioSource::renderMaterial(const BlockInfo& block, juce::dsp::AudioBlock<float> out,
+                                     const ClipSnapshot* snapshot, const TrackClipPlayback* track) {
     out.clear();
 
     const ClipStreamFeed::Reader streams(streams_);
@@ -231,8 +236,7 @@ void ClipAudioSource::renderMaterial(const BlockInfo& block, juce::dsp::AudioBlo
     if (!block.playing || lane.numSamples <= 0)
         return silence();
 
-    const ClipSnapshotFeed::Reader snapshot(clips_);
-    if (!snapshot)
+    if (snapshot == nullptr)
         return silence();
 
     // Compiled against a tempo map that has since changed: every second in it
@@ -260,7 +264,6 @@ void ClipAudioSource::renderMaterial(const BlockInfo& block, juce::dsp::AudioBlo
     if (block.tempo != nullptr && snapshot->tempoFingerprint != block.tempo->fingerprint())
         staleSnapshots_.fetch_add(1, std::memory_order_relaxed);
 
-    const auto* track = snapshot->find(trackId_);
     if (track == nullptr)
         return silence();
 

--- a/magda/engine/clip/ClipAudioSource.hpp
+++ b/magda/engine/clip/ClipAudioSource.hpp
@@ -190,11 +190,15 @@ class ClipAudioSource final : public EngineAudioSource {
     ClipStreamFeed& streams_;
 
     /// Sum this track's material for @p block, on whichever section this is.
-    void renderMaterial(const BlockInfo& block, juce::dsp::AudioBlock<float> out);
+    /// @p snapshot and @p track are render()'s one acquisition, shared with
+    /// applySectionHold so both stages read the same publish.
+    void renderMaterial(const BlockInfo& block, juce::dsp::AudioBlock<float> out,
+                        const ClipSnapshot* snapshot, const TrackClipPlayback* track);
 
     /// Drop what the arrangement rendered for as long as the session holds the
-    /// track, and de-click both edges of the hand-over (#2302).
-    void applySectionHold(juce::dsp::AudioBlock<float> out);
+    /// track, and de-click both edges of the hand-over (#2302). @p track is
+    /// null for one the snapshot does not carry, which is Arrangement mode.
+    void applySectionHold(juce::dsp::AudioBlock<float> out, const TrackClipPlayback* track);
 
     /// Null is the arrangement, which needs no handles.
     LaunchHandleFeed* handles_ = nullptr;

--- a/magda/engine/clip/ClipAudioSource.hpp
+++ b/magda/engine/clip/ClipAudioSource.hpp
@@ -200,6 +200,10 @@ class ClipAudioSource final : public EngineAudioSource {
     LaunchHandleFeed* handles_ = nullptr;
     Section section_ = Section::Arrangement;
 
+    /// The mode the last block rendered under (#2485). A mode flip has no
+    /// handle to say what came before, so this is the only place it's kept.
+    bool sessionModeBefore_ = false;
+
     /// The two edges of the arrangement's own playback: the step it carries
     /// down when the session takes the track, and the one it subtracts when it
     /// gets the track back mid-material.

--- a/magda/engine/clip/ClipMidiSource.cpp
+++ b/magda/engine/clip/ClipMidiSource.cpp
@@ -596,17 +596,26 @@ void ClipMidiSource::render(const BlockInfo& block, juce::MidiBuffer& out) {
         return;
     }
 
-    // A source built without the feed is the whole track and has no section to
-    // lose.
     // The arrangement's share, which is all of it on a track the session never
-    // took (#2302). The same fold the audio source reads.
+    // took, and none of it in Session mode (#2302, #2485). The same fold the
+    // audio source reads.
     auto lane = block;
     auto until = block.numSamples;
     auto lost = false;
 
-    if (handles_ != nullptr) {
-        const LaunchHandleFeed::Reader handles(*handles_);
-        const auto hold = sectionHold(handles.get(), trackId_, block.numSamples);
+    // Every Arrangement source has a mode to check now (#2485), handles or not.
+    const auto session = track->playbackMode == TrackPlaybackMode::Session;
+    const SectionMode mode{session, sessionModeBefore_};
+    sessionModeBefore_ = session;
+
+    {
+        SectionHold hold;
+        if (handles_ != nullptr) {
+            const LaunchHandleFeed::Reader handles(*handles_);
+            hold = sectionHold(handles.get(), trackId_, block.numSamples, mode);
+        } else {
+            hold = sectionHold(nullptr, trackId_, block.numSamples, mode);
+        }
 
         until = std::clamp(hold.until.value, 0, block.numSamples);
         lost = hold.lost;

--- a/magda/engine/clip/ClipMidiSource.hpp
+++ b/magda/engine/clip/ClipMidiSource.hpp
@@ -242,6 +242,10 @@ class ClipMidiSource final : public EngineMidiSource {
     LaunchHandleFeed* handles_ = nullptr;
     Section section_ = Section::Arrangement;
 
+    /// The mode the last block rendered under (#2485). A mode flip has no
+    /// handle to say what came before, so this is the only place it's kept.
+    bool sessionModeBefore_ = false;
+
     ActiveNoteList active_;
     int activeCount_ = 0;
 

--- a/magda/engine/clip/ClipSnapshot.hpp
+++ b/magda/engine/clip/ClipSnapshot.hpp
@@ -8,6 +8,7 @@
 #include "clip/MidiEventList.hpp"
 #include "clip/WarpMap.hpp"
 #include "core/ClipInfo.hpp"
+#include "core/TrackInfo.hpp"
 #include "core/TypeIds.hpp"
 #include "launch/FollowActions.hpp"
 #include "transport/TimeDomains.hpp"
@@ -298,6 +299,10 @@ struct TrackClipPlayback {
     std::vector<AudioClipPlayback> audio;
     std::vector<MidiClipPlayback> midi;
 
+    /// Gates the arrangement (#2485): Session mode silences it whether or not
+    /// anything is launched, the way the fork's playSlotClips does.
+    TrackPlaybackMode playbackMode = TrackPlaybackMode::Arrangement;
+
     /// Sorted by scene index, so two compiles of one model agree.
     std::vector<SessionSlotPlayback> session;
 
@@ -313,7 +318,7 @@ struct TrackClipPlayback {
  * testable and keeps a dump diff meaningful.
  */
 struct ClipSnapshot {
-    static constexpr int kVersion = 1;
+    static constexpr int kVersion = 2;
 
     int version = kVersion;
 

--- a/magda/engine/clip/ClipSnapshot.hpp
+++ b/magda/engine/clip/ClipSnapshot.hpp
@@ -299,8 +299,9 @@ struct TrackClipPlayback {
     std::vector<AudioClipPlayback> audio;
     std::vector<MidiClipPlayback> midi;
 
-    /// Gates the arrangement (#2485): Session mode silences it whether or not
-    /// anything is launched, the way the fork's playSlotClips does.
+    /// Whether the arrangement above sounds. Session mode silences it whether
+    /// or not a slot is launched, as the fork's playSlotClips does (#2485).
+    /// Read per block by the track's arrangement sources.
     TrackPlaybackMode playbackMode = TrackPlaybackMode::Arrangement;
 
     /// Sorted by scene index, so two compiles of one model agree.

--- a/magda/engine/clip/ClipSnapshot.hpp
+++ b/magda/engine/clip/ClipSnapshot.hpp
@@ -8,7 +8,7 @@
 #include "clip/MidiEventList.hpp"
 #include "clip/WarpMap.hpp"
 #include "core/ClipInfo.hpp"
-#include "core/TrackInfo.hpp"
+#include "core/TrackTypes.hpp"
 #include "core/TypeIds.hpp"
 #include "launch/FollowActions.hpp"
 #include "transport/TimeDomains.hpp"

--- a/magda/engine/clip/ClipSnapshotCompiler.cpp
+++ b/magda/engine/clip/ClipSnapshotCompiler.cpp
@@ -76,6 +76,7 @@ ClipSnapshot compileClipSnapshot(const std::vector<ClipLane>& lanes,
     for (const auto& lane : lanes) {
         TrackClipPlayback track;
         track.trackId = lane.trackId;
+        track.playbackMode = lane.playbackMode;
 
         // Rejected before anything is resolved, not while resolving. Occlusion
         // and the crossfade queries take every clip in the lane they are given

--- a/magda/engine/clip/ClipSnapshotCompiler.hpp
+++ b/magda/engine/clip/ClipSnapshotCompiler.hpp
@@ -58,7 +58,9 @@ struct ClipLane {
     /// decided at launch rather than at compile (#2301).
     std::vector<ClipInfo> session;
 
-    /// Gates the arrangement (#2485), carried onto TrackClipPlayback as is.
+    /// The track's TrackInfo::playbackMode. In Session mode the arrangement
+    /// clips above are silenced at render time (#2485); the compiler copies
+    /// it onto TrackClipPlayback unchanged.
     TrackPlaybackMode playbackMode = TrackPlaybackMode::Arrangement;
 };
 

--- a/magda/engine/clip/ClipSnapshotCompiler.hpp
+++ b/magda/engine/clip/ClipSnapshotCompiler.hpp
@@ -6,7 +6,7 @@
 #include "clip/ClipSnapshot.hpp"
 #include "clip/GrooveTemplate.hpp"
 #include "core/ClipInfo.hpp"
-#include "core/TrackInfo.hpp"
+#include "core/TrackTypes.hpp"
 #include "core/TypeIds.hpp"
 #include "transport/TempoMap.hpp"
 

--- a/magda/engine/clip/ClipSnapshotCompiler.hpp
+++ b/magda/engine/clip/ClipSnapshotCompiler.hpp
@@ -6,6 +6,7 @@
 #include "clip/ClipSnapshot.hpp"
 #include "clip/GrooveTemplate.hpp"
 #include "core/ClipInfo.hpp"
+#include "core/TrackInfo.hpp"
 #include "core/TypeIds.hpp"
 #include "transport/TempoMap.hpp"
 
@@ -56,6 +57,9 @@ struct ClipLane {
     /// can carry an arrangement and a session at once, and which one sounds is
     /// decided at launch rather than at compile (#2301).
     std::vector<ClipInfo> session;
+
+    /// Gates the arrangement (#2485), carried onto TrackClipPlayback as is.
+    TrackPlaybackMode playbackMode = TrackPlaybackMode::Arrangement;
 };
 
 /**

--- a/magda/engine/clip/ClipSnapshotDump.cpp
+++ b/magda/engine/clip/ClipSnapshotDump.cpp
@@ -160,7 +160,9 @@ std::string dumpClipSnapshot(const ClipSnapshot& snapshot) {
 
     for (const auto& track : snapshot.tracks) {
         out << "track " << track.trackId << " audio=" << track.audio.size()
-            << " midi=" << track.midi.size() << " session=" << track.session.size() << "\n";
+            << " midi=" << track.midi.size() << " session=" << track.session.size() << " mode="
+            << (track.playbackMode == TrackPlaybackMode::Session ? "session" : "arrangement")
+            << "\n";
         for (const auto& clip : track.audio)
             dumpAudioClip(out, clip);
         for (const auto& clip : track.midi)

--- a/magda/engine/clip/ClipSnapshotDump.hpp
+++ b/magda/engine/clip/ClipSnapshotDump.hpp
@@ -16,9 +16,9 @@ namespace magda::engine {
  *
  * Shape, with the long lines cut short here:
  *
- *     magda-clip-snapshot v1
+ *     magda-clip-snapshot v2
  *     tempo=8f3a1c02 tracks=1
- *     track 1 audio=1 midi=0
+ *     track 1 audio=1 midi=0 session=0 mode=arrangement
  *       audio clip=7 span=0.000..8.000b 0.000..4.000s fade=0.500/0.250 ...
  *         hole 2.000..3.000b 1.000..1.500s
  *         event 1 src=3 file=drums.wav rate=48000 span=... anchor=0 ...

--- a/magda/engine/clip/SessionPlayback.hpp
+++ b/magda/engine/clip/SessionPlayback.hpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <limits>
+#include <tuple>
 
 #include "clip/ClipSnapshot.hpp"
 #include "exec/RenderContext.hpp"
@@ -116,6 +117,8 @@ constexpr int kSectionDeClickSamples = 32;
  *
  * Derived per block from the table both of a track's sources read, so its audio
  * and its MIDI reach the same answer with nothing of their own to keep in step.
+ * The track's own mode is folded in beside the handles (#2485): Session mode
+ * gates the arrangement the way the fork's playSlotClips does, launched or not.
  */
 struct SectionHold {
     /// The edge past which the arrangement is silent. Zero for a block the
@@ -144,21 +147,30 @@ struct SectionHold {
     }
 };
 
+/// The track's mode this block and the block before (#2485). Carried by the
+/// caller, since a mode flip has no handle to remember the block before.
+struct SectionMode {
+    bool session = false;
+    bool sessionBefore = false;
+};
+
 /// @copydoc SectionHold
 /// @p handles is null until the store publishes one, which is legal: nothing
-/// can hold a track then, so the arrangement has all of it.
-inline SectionHold sectionHold(const LaunchHandleTable* handles, TrackId trackId, int numSamples) {
-    if (handles == nullptr)
-        return SectionHold::arrangement(numSamples);
-
-    const auto [first, last] = handles->rangeFor(trackId);
+/// can hold a track then, and only @p mode decides. Folded in as if the mode
+/// were a handle that holds the section for the whole block.
+inline SectionHold sectionHold(const LaunchHandleTable* handles, TrackId trackId, int numSamples,
+                               SectionMode mode = {}) {
+    const LaunchHandleTable::Entry* first = nullptr;
+    const LaunchHandleTable::Entry* last = nullptr;
+    if (handles != nullptr)
+        std::tie(first, last) = handles->rangeFor(trackId);
 
     // Before anything in this block, at its first sample once releases have
     // applied, and at its last.
-    auto sessionBefore = false;
-    auto sessionAtZero = false;
-    auto sessionAtEnd = false;
-    auto takenAt = std::numeric_limits<int>::max();
+    auto sessionBefore = mode.sessionBefore;
+    auto sessionAtZero = mode.session;
+    auto sessionAtEnd = mode.session;
+    auto takenAt = mode.session ? 0 : std::numeric_limits<int>::max();
 
     for (const auto* entry = first; entry != last; ++entry) {
         if (entry->handle == nullptr)

--- a/tests/DawProjectRoundTrip.cpp
+++ b/tests/DawProjectRoundTrip.cpp
@@ -373,6 +373,29 @@ Loss trackModulation() {
             }};
 }
 
+/// #2485: which of a track's two bodies is live is a MAGDA launcher concept,
+/// not a DAWproject one, so a track comes back in Arrangement mode whatever it
+/// went out in.
+Loss playbackMode() {
+    return {.field = "TrackInfo::playbackMode",
+            .reason = "the format has no attribute for session mode, which is player state "
+                      "rather than project data it was ever asked to carry",
+            .restore = [](Case& imported, const Case& original) {
+                bool restored = false;
+
+                for (auto& track : imported.tracks)
+                    for (const auto& source : original.tracks) {
+                        if (source.name != track.name || track.playbackMode == source.playbackMode)
+                            continue;
+
+                        track.playbackMode = source.playbackMode;
+                        restored = true;
+                    }
+
+                return restored;
+            }};
+}
+
 Loss multiOutRouting() {
     return {.field = "TrackInfo::type, TrackInfo::multiOutLink",
             .reason = "an instrument's further output pairs have no DAWproject representation, "
@@ -611,6 +634,11 @@ const std::map<std::string, std::vector<Loss>>& lossTable() {
         // either of them needs is the one every instrument track in the corpus
         // needs, and the audio one has no chain to lose.
         {"session.launch.midi", {internalDevices()}},
+        // #2485: the first case with an audible arrangement clip on a
+        // Session-mode track, which is what exposes playbackMode as a loss --
+        // session.launch's track has none, so the mode never had anything to
+        // gate.
+        {"session.mode.holds.slot", {playbackMode()}},
     };
 
     return table;

--- a/tests/MgdFixture.cpp
+++ b/tests/MgdFixture.cpp
@@ -521,6 +521,31 @@ FixtureLoad loadFixture(const MgdFixture& fixture, const juce::File& scratchDire
     if (staged.masterTrack != nullptr)
         result.value.master = *staged.masterTrack;
     result.value.clips = std::move(staged.clips);
+
+    // The app relaunches a track's active session clip on play
+    // (TracktionEngineWrapper::onTransportPlay ->
+    // SessionClipScheduler::relaunchActiveClips), so a render of the project as
+    // saved launches it too (#2485).
+    for (const auto& track : result.value.tracks) {
+        if (track.activeSessionClipId == INVALID_CLIP_ID)
+            continue;
+
+        const auto found = std::find_if(
+            result.value.clips.begin(), result.value.clips.end(),
+            [&](const ClipInfo& clip) { return clip.id == track.activeSessionClipId; });
+
+        if (found == result.value.clips.end() || found->view != ClipView::Session ||
+            found->sceneIndex < 0) {
+            result.failure = "track " + std::to_string(track.id) + "'s active session clip " +
+                             std::to_string(track.activeSessionClipId) +
+                             " is not a session clip in a scene";
+            return result;
+        }
+
+        result.value.launches.push_back(
+            LaunchInfo{track.id, found->sceneIndex, result.value.startBeat});
+    }
+
     result.value.lanes = std::move(staged.automationLanes);
     result.value.automationClips = std::move(staged.automationClips);
 

--- a/tests/MgdFixtures.cpp
+++ b/tests/MgdFixtures.cpp
@@ -480,11 +480,10 @@ std::vector<MgdFixture> build() {
              .covers = "its bounce on the fourth track, muted with it"},
             {.fileName = "TAMUZ_TD_90_drum_best_simple_trashy.wav",
              .material = toneFor(2.0, 660.0),
-             .covers = "a session clip in the first scene, which an arrangement render never "
-                       "launches"},
+             .covers = "the session clip the first track launches on play (#2485)"},
             {.fileName = "SLS_O_65_guitar_soul_serenade_Cmin.wav",
              .material = toneFor(2.0, 770.0),
-             .covers = "a session clip on the second track"},
+             .covers = "the session clip the second track launches on play (#2485)"},
             {.fileName = "BS_NCS3_140_bass_growl_leap_Dbmin.wav",
              .material = toneFor(2.0, 880.0),
              .covers = "a session clip in the fourth scene"},

--- a/tests/NullDiffCorpus.cpp
+++ b/tests/NullDiffCorpus.cpp
@@ -2449,6 +2449,38 @@ std::vector<Case> buildCorpus(const juce::File& scratchDirectory) {
         corpus.push_back(std::move(value));
     }
 
+    {
+        // #2485: Session mode holds the arrangement silent with nothing
+        // launched -- the retrospect fixture's shape. Track 1 alone would
+        // render silent on both legs, which the runner refuses
+        // (NullDiffRunner.cpp:577), so track 2's clip is the audible
+        // neighbour that keeps the case measurable.
+        //
+        // The incumbent derives Session mode from activeSessionClipId rather
+        // than from a settable flag (SessionClipScheduler::
+        // syncTrackPlaybackModes), so the track needs a session clip to point
+        // it at even though nothing launches it; a track with no session
+        // content at all is a mode the incumbent's own writer never holds,
+        // and only the native engine's is asserted for that shape (the
+        // SwitchRig{false} cases in test_session_playback.cpp).
+        auto track = launching(plainTrack());
+        track.activeSessionClipId = 423;
+
+        auto value =
+            newTrackCase("session.mode.holds.slot",
+                         "a Session-mode track's arrangement stays silent with an unlaunched slot",
+                         {std::move(track), mixTrack(2, "Neighbour")});
+        value.endBeat = 8.0;
+
+        const auto source = writeSource(scratchDirectory, "sessionmodeholdsslot", impulses());
+        value.sources.push_back(source);
+        value.clips.push_back(audioClipOn(kTrack, 422, 0.0, 4.0, source));
+        value.clips.push_back(inSlot(audioClip(423, 0.0, 4.0, source), 0));
+        value.clips.push_back(audioClipOn(2, 424, 0.0, 4.0, source));
+
+        corpus.push_back(std::move(value));
+    }
+
     // --- external plugins ------------------------------------------------------
     //
     // The first cases in the corpus that host a plugin rather than run a device

--- a/tests/NullDiffNativeLeg.cpp
+++ b/tests/NullDiffNativeLeg.cpp
@@ -445,6 +445,7 @@ NativeRender renderNative(const Case& value, const InstalledPlugins& installed) 
     for (const auto& track : value.tracks) {
         ClipLane lane;
         lane.trackId = track.id;
+        lane.playbackMode = track.playbackMode;
         for (const auto& clip : value.clips) {
             if (clip.trackId != track.id)
                 continue;

--- a/tests/engine/test_clip_snapshot.cpp
+++ b/tests/engine/test_clip_snapshot.cpp
@@ -78,9 +78,9 @@ ClipSnapshot compile(std::vector<ClipInfo> clips, const TempoMap& tempoMap) {
 /// What the fixture in the golden test has to compile to, line for line. A diff
 /// here is a change in what a track plays.
 const std::string kGoldenDump =
-    "magda-clip-snapshot v1\n"
+    "magda-clip-snapshot v2\n"
     "tempo=a95350905fc122eb tracks=1\n"
-    "track 1 audio=2 midi=1 session=0\n"
+    "track 1 audio=2 midi=1 session=0 mode=arrangement\n"
     "  audio clip=1 span=0.000..8.000b 0.000..4.000s fade=0.000/1.000 curve=lin/lin "
     "behaviour=0/0 gain=0.0 pan=0.00 launch=256\n"
     "    event 1 src=7 file=loop.wav rate=48000 span=0.000..8.000b 0.000..4.000s anchor=0 "
@@ -749,6 +749,28 @@ TEST_CASE("A track carrying both views keeps them apart", "[engine][clip][sessio
     CHECK(snapshot.diagnostics.empty());
 }
 
+TEST_CASE("A lane's playback mode reaches the track, and defaults to Arrangement (#2485)",
+          "[engine][clip]") {
+    ClipLane lane;
+    lane.trackId = kTrack;
+    lane.clips.push_back(makeAudioClip(1, 0.0, 4.0));
+
+    SECTION("default") {
+        const auto snapshot = compileClipSnapshot({lane}, makeSources(), makeTempoMap());
+        REQUIRE(snapshot.tracks.size() == 1);
+        CHECK(snapshot.tracks.front().playbackMode == magda::TrackPlaybackMode::Arrangement);
+        CHECK(dumpClipSnapshot(snapshot).find("mode=arrangement") != std::string::npos);
+    }
+
+    SECTION("session") {
+        lane.playbackMode = magda::TrackPlaybackMode::Session;
+        const auto snapshot = compileClipSnapshot({lane}, makeSources(), makeTempoMap());
+        REQUIRE(snapshot.tracks.size() == 1);
+        CHECK(snapshot.tracks.front().playbackMode == magda::TrackPlaybackMode::Session);
+        CHECK(dumpClipSnapshot(snapshot).find("mode=session") != std::string::npos);
+    }
+}
+
 TEST_CASE("A session slot is in the dump, in the arrangement's own detail",
           "[engine][clip][session]") {
     // The dump is the snapshot's canonical surface, so a session slot has to be
@@ -760,7 +782,7 @@ TEST_CASE("A session slot is in the dump, in the arrangement's own detail",
 
     INFO(text);
 
-    CHECK(text.find("track 1 audio=0 midi=0 session=1") != std::string::npos);
+    CHECK(text.find("track 1 audio=0 midi=0 session=1 mode=arrangement") != std::string::npos);
     CHECK(text.find("slot scene=3 length=8.000b audio=1 midi=0") != std::string::npos);
 
     // The slot's own material, not just its header: the clip, its span at the

--- a/tests/engine/test_null_diff_corpus.cpp
+++ b/tests/engine/test_null_diff_corpus.cpp
@@ -36,7 +36,7 @@ juce::File scratch() {
 TEST_CASE("The corpus builds and covers what the slice claims", "[nulldiff][corpus]") {
     const auto corpus = sharedCorpus(scratch());
 
-    REQUIRE(corpus.size() == 72);
+    REQUIRE(corpus.size() == 73);
 
     std::set<std::string> names;
     for (const auto& value : corpus)
@@ -103,6 +103,7 @@ TEST_CASE("The corpus builds and covers what the slice claims", "[nulldiff][corp
                                  "midi.offset",
                                  "session.launch",
                                  "session.launch.midi",
+                                 "session.mode.holds.slot",
                                  "plugin.wetdry",
                                  "plugin.wetdry.dry",
                                  "plugin.mono",

--- a/tests/engine/test_real_project_corpus_juce.cpp
+++ b/tests/engine/test_real_project_corpus_juce.cpp
@@ -226,14 +226,6 @@ class RealProjectCorpusTests : public juce::UnitTest {
             // through every decay.
             "project.fmchain",
             "project.sidechain",
-
-            // Two of its tracks were saved in Session playback mode. The
-            // incumbent honours that in a render and plays their slots, which
-            // nothing here launches, so it renders silence where the native leg
-            // renders the arrangement. The native engine has no concept of
-            // TrackPlaybackMode at all (#2485), and until it does there is no
-            // agreement to measure.
-            "project.retrospect",
         };
 
         const auto complaints =

--- a/tests/engine/test_session_playback.cpp
+++ b/tests/engine/test_session_playback.cpp
@@ -34,6 +34,7 @@
 using Catch::Approx;
 using magda::ClipInfo;
 using magda::MidiNote;
+using magda::TrackPlaybackMode;
 using magda::engine::AudioClipPlayback;
 using magda::engine::AudioEventPlayback;
 using magda::engine::BlockInfo;
@@ -475,11 +476,13 @@ struct MidiSwitchRig {
         session.prepare(context());
     }
 
-    void publish(std::vector<ClipInfo> arrangementClips, std::vector<ClipInfo> sessionClips) {
+    void publish(std::vector<ClipInfo> arrangementClips, std::vector<ClipInfo> sessionClips,
+                 TrackPlaybackMode mode = TrackPlaybackMode::Arrangement) {
         ClipLane lane;
         lane.trackId = kTrack;
         lane.clips = std::move(arrangementClips);
         lane.session = std::move(sessionClips);
+        lane.playbackMode = mode;
 
         auto compiled = std::make_shared<const ClipSnapshot>(
             magda::engine::compileClipSnapshot({lane}, {}, tempoMap(), {}));
@@ -2524,4 +2527,200 @@ TEST_CASE("Handing one track back does not touch the other", "[engine][clip][ses
 
     CHECK(rig.launchedAt(kBlockSize - 1) == Approx(1.0f));
     CHECK(rig.idleAt(kBlockSize - 1) == Approx(0.25f));
+}
+
+// =============================================================================
+// The track's playback mode gates the arrangement (#2485)
+// =============================================================================
+
+TEST_CASE("A Session-mode track with nothing launched sounds neither section",
+          "[engine][clip][session][section]") {
+    SECTION("handles published") {
+        SwitchRig rig;
+        rig.giveArrangement(1, 1.0f);
+        rig.lane.playbackMode = TrackPlaybackMode::Session;
+        rig.publish();
+
+        rig.roll(0, 3);
+
+        CHECK(rig.arrangementPeak() == 0.0f);
+        CHECK(rig.sessionPeak() == 0.0f);
+    }
+
+    SECTION("no handles published yet") {
+        SwitchRig rig{false};
+        rig.giveArrangement(1, 1.0f);
+        rig.lane.playbackMode = TrackPlaybackMode::Session;
+        rig.publish();
+
+        rig.roll(0, 3);
+
+        CHECK(rig.arrangementPeak() == 0.0f);
+        CHECK(rig.sessionPeak() == 0.0f);
+    }
+}
+
+TEST_CASE("A Session-mode track's MIDI sounds neither section with nothing launched",
+          "[engine][clip][session][section]") {
+    MidiSwitchRig rig;
+    rig.publish({arrangementMidiClip(1, 0.0, 1000.0, {MidiNote{60, 100, 0.0, 1000.0, 0, {}}})}, {},
+                TrackPlaybackMode::Session);
+
+    rig.roll(0, 3);
+
+    CHECK(rig.notesOn(rig.fromArrangement).empty());
+    CHECK(rig.notesOn(rig.fromSession).empty());
+    CHECK(MidiSwitchRig::hanging(rig.fromArrangement).empty());
+}
+
+TEST_CASE("Switching a track to Session mode mid-play carries the arrangement down",
+          "[engine][clip][session][section]") {
+    // No handle on this track at all: the flip has to silence the arrangement
+    // on its own, with no session material to take over from it.
+    SwitchRig rig;
+    rig.giveArrangement(1, 1.0f);
+    rig.publish();
+
+    rig.roll(0, 1);
+    REQUIRE(rig.arrangementAt(0) == Approx(1.0f));
+
+    rig.lane.playbackMode = TrackPlaybackMode::Session;
+    rig.publish();
+    rig.render(2);
+
+    SECTION("the flip block decays from where it was to zero within the ramp") {
+        CHECK(rig.arrangementAt(0) == Approx(1.0f));
+
+        for (auto sample = 1; sample < kSectionDeClickSamples; ++sample) {
+            INFO("sample " << sample);
+            REQUIRE(rig.arrangementAt(sample) <= rig.arrangementAt(sample - 1));
+        }
+
+        CHECK(rig.arrangementAt(kSectionDeClickSamples - 1) == Approx(0.0f).margin(1e-5));
+        CHECK(rig.arrangementAt(kBlockSize - 1) == Approx(0.0f));
+    }
+
+    SECTION("the block after is entirely zero, not re-triggering the ramp") {
+        rig.render(3);
+        CHECK(rig.arrangementPeak() == 0.0f);
+    }
+}
+
+TEST_CASE("Switching a track to Session mode mid-play owes a note-off at the flip",
+          "[engine][clip][session][section]") {
+    MidiSwitchRig rig;
+    rig.publish({arrangementMidiClip(1, 0.0, 1000.0, {MidiNote{60, 100, 0.0, 1000.0, 0, {}}})}, {});
+
+    rig.roll(0, 1);
+    REQUIRE(rig.notesOn(rig.fromArrangement).size() == 1);
+
+    rig.publish({arrangementMidiClip(1, 0.0, 1000.0, {MidiNote{60, 100, 0.0, 1000.0, 0, {}}})}, {},
+                TrackPlaybackMode::Session);
+    rig.roll(2, 2);
+
+    const auto offs = rig.notesOff(rig.fromArrangement);
+    REQUIRE(offs.size() == 1);
+    CHECK(offs.front().block == 2);
+    CHECK(offs.front().sample == 0);
+
+    rig.roll(3, 3);
+    CHECK(rig.notesOff(rig.fromArrangement).size() == 1);  // none more in the block after
+}
+
+TEST_CASE("Switching back to Arrangement mode resumes where the timeline is",
+          "[engine][clip][session][section]") {
+    SwitchRig rig;
+    rig.giveArrangement(1, 1.0f);
+    rig.publish();
+
+    rig.roll(0, 1);
+    rig.lane.playbackMode = TrackPlaybackMode::Session;
+    rig.publish();
+    rig.roll(2, 3);
+    REQUIRE(rig.arrangementPeak() == 0.0f);
+
+    rig.lane.playbackMode = TrackPlaybackMode::Arrangement;
+    rig.publish();
+    rig.render(4);
+
+    SECTION("it steps up out of silence over the ramp") {
+        CHECK(rig.arrangementAt(0) == Approx(0.0f).margin(1e-5));
+
+        for (auto sample = 1; sample < kSectionDeClickSamples; ++sample) {
+            INFO("sample " << sample);
+            REQUIRE(rig.arrangementAt(sample) >= rig.arrangementAt(sample - 1));
+        }
+    }
+
+    SECTION("and settles at the timeline's own level") {
+        CHECK(rig.arrangementAt(kSectionDeClickSamples) == Approx(1.0f));
+        CHECK(rig.arrangementAt(kBlockSize - 1) == Approx(1.0f));
+    }
+}
+
+TEST_CASE("Switching back to Arrangement mode re-chases the arrangement's MIDI",
+          "[engine][clip][session][section]") {
+    MidiSwitchRig rig;
+    const auto clip = arrangementMidiClip(1, 0.0, 1000.0, {MidiNote{60, 100, 0.0, 1000.0, 0, {}}});
+    rig.publish({clip}, {});
+
+    rig.roll(0, 1);
+    rig.publish({clip}, {}, TrackPlaybackMode::Session);
+    rig.roll(2, 3);
+
+    rig.publish({clip}, {});  // back to Arrangement, the default
+    rig.roll(4, 4);
+
+    // Two note-ons in all: the very first block's own chase, from before any
+    // of this, and the re-chase this case is about.
+    const auto ons = rig.notesOn(rig.fromArrangement);
+    REQUIRE(ons.size() == 2);
+    CHECK(ons.back().block == 4);
+    CHECK(ons.back().sample == 0);
+    CHECK(ons.back().message.getNoteNumber() == 60);
+
+    REQUIRE(rig.arrangementPanics.size() == 5);
+    CHECK(rig.arrangementPanics[4]);
+}
+
+TEST_CASE("A launched slot on a Session-mode track plays, and releasing it leaves the track silent",
+          "[engine][clip][session][section]") {
+    SwitchRig rig;
+    rig.giveArrangement(1, 1.0f);
+    rig.giveSlot(2, 4.0, 0.5f);
+    rig.lane.playbackMode = TrackPlaybackMode::Session;
+    rig.publish();
+
+    rig.handle.play(std::nullopt);
+    rig.roll(0, 2);
+    CHECK(rig.sessionAt(0) == Approx(0.5f));
+    CHECK(rig.arrangementPeak() == 0.0f);
+
+    // The same release that hands an Arrangement-mode track back (#2302): here
+    // the mode itself goes on silencing the arrangement.
+    rig.handle.releaseSection();
+    rig.render(3);
+    rig.render(4);
+
+    CHECK(rig.sessionPeak() == 0.0f);
+    CHECK(rig.arrangementPeak() == 0.0f);
+}
+
+TEST_CASE("A launched slot's MIDI plays on a Session-mode track, and releasing it leaves it silent",
+          "[engine][clip][session][section]") {
+    MidiSwitchRig rig;
+    rig.publish({arrangementMidiClip(1, 0.0, 1000.0, {MidiNote{60, 100, 0.0, 1000.0, 0, {}}})},
+                {sessionMidiClip(2, 8.0, {MidiNote{67, 100, 0.0, 8.0, 0, {}}})},
+                TrackPlaybackMode::Session);
+
+    rig.handle.play(std::nullopt);
+    rig.roll(0, 2);
+    CHECK(rig.notesOn(rig.fromArrangement).empty());
+    REQUIRE(rig.notesOn(rig.fromSession).size() == 1);
+
+    rig.handle.releaseSection();
+    rig.roll(3, 5);
+
+    CHECK(MidiSwitchRig::hanging(rig.fromSession).empty());
+    CHECK(rig.notesOn(rig.fromArrangement).empty());
 }


### PR DESCRIPTION
Closes #2485.

## What

The native engine had no concept of `TrackPlaybackMode`. `sectionHold` decided how much of a block the arrangement sounds from the launch handles alone, so a Session-mode track with nothing launched played its arrangement where the fork's `playSlotClips` drops it.

The rule now: a track's arrangement sounds a block only when the track is in Arrangement mode **and** no launch handle holds the section. Session mode silences it launched or not. Launched slots play through their handles exactly as before.

- The mode rides in the clip snapshot (`ClipLane` → `TrackClipPlayback`, printed by the dump, `kVersion` 2), so a flip applies at a block boundary.
- A flip has no handle to say what the block before was, so each arrangement source keeps the mode it last rendered under. Without that a Session-mode track fires its lost edge every callback, restarting the de-click and resending note-offs.
- Both sources apply the hold whether or not a handle feed exists; a null table is an empty handle range and the mode still decides.

## Corpus

`project.retrospect` was saved with two tracks in Session mode **and** active session clips. The app relaunches those on play; the corpus never did, which is why the incumbent rendered silence and native rendered the arrangement. `loadFixture` now derives a launch at the render's start beat from each track's `activeSessionClipId`, and refuses a saved active clip that names no session clip. `project.retrospect` comes off the calibration list #2486 put it on against this issue.

A code-built case, `session.mode.holds.slot`, pins the retrospect shape beside an audible neighbour so the runner has a comparison rather than two silences.

## Tests

- `test_session_playback.cpp`: Session mode with nothing launched sounds neither section (handles published and not); flipping to Session mid-play carries the arrangement down and owes one note-off, with the block after fully silent; flipping back ramps in and re-chases; a launched slot on a Session-mode track plays and releasing it leaves the track silent. Audio and MIDI.
- `test_clip_snapshot.cpp`: the lane's mode reaches the track and the dump.
- Negative check: with the `sectionHold` change reverted, the new engine cases and the new corpus case fail.
- `magda_tests` and `make test-juce` green on this tree.

**Not verified here:** Retrospect is not scanned on this Mac, so the corpus skipped `project.retrospect`. It needs one `make test-juce` on the Mac that has it; the expected outcome is the case rendering on both legs and the calibration list holding in both directions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012q17kwk7LKPovRoPtrBWjX
