### PR TITLE
Return the condition, clamp with std::min and std::max

### DIFF
--- a/magda/agents/command_model.cpp
+++ b/magda/agents/command_model.cpp
@@ -187,7 +187,7 @@ bool splitGluedUnit(const std::string& tok, std::string& num, std::string& unit)
 // ---------------------------------------------------------------------------
 bool splitGluedTrack(const std::string& tok, std::string& word, std::string& digits) {
     size_t i = 0;
-    while (i < tok.size() && !(tok[i] >= '0' && tok[i] <= '9'))
+    while (i < tok.size() && (tok[i] < '0' || tok[i] > '9'))
         ++i;
     if (i == 0 || i == tok.size())
         return false;
@@ -195,7 +195,7 @@ bool splitGluedTrack(const std::string& tok, std::string& word, std::string& dig
     if (head != "track" && head != "tracks")
         return false;
     for (size_t j = i; j < tok.size(); ++j)
-        if (!(tok[j] >= '0' && tok[j] <= '9'))
+        if (tok[j] < '0' || tok[j] > '9')
             return false;
     word = tok.substr(0, i);
     digits = tok.substr(i);

--- a/magda/agents/dsl_interpreter.cpp
+++ b/magda/agents/dsl_interpreter.cpp
@@ -926,7 +926,7 @@ bool Interpreter::executeNewClip(const Params& params) {
             // assuming a four-beat bar through the legacy seconds cache.
             double clipEndBar = clip->placement.endBeat() / beatsPerBar + 1.0;
             double nextBar = std::ceil(clipEndBar - 0.001);  // tolerance for floating point
-            bar = std::max(nextBar, bar);
+            bar = std::max(bar, nextBar);
         }
     }
 

--- a/magda/agents/dsl_interpreter.cpp
+++ b/magda/agents/dsl_interpreter.cpp
@@ -926,8 +926,7 @@ bool Interpreter::executeNewClip(const Params& params) {
             // assuming a four-beat bar through the legacy seconds cache.
             double clipEndBar = clip->placement.endBeat() / beatsPerBar + 1.0;
             double nextBar = std::ceil(clipEndBar - 0.001);  // tolerance for floating point
-            if (nextBar > bar)
-                bar = nextBar;
+            bar = std::max(nextBar, bar);
         }
     }
 

--- a/magda/daw/api/osc_feedback_live.hpp
+++ b/magda/daw/api/osc_feedback_live.hpp
@@ -221,7 +221,7 @@ class OscFeedbackProjector : private ConfigListener, private BindingRegistryList
      */
     void bindingRegistryChanged(BindingScope scope) override;
 
-    void onChanges(const std::vector<remote::ChangeSource::Change>& changes);
+    void onChanges(const std::vector<remote::ChangeSource::Change>& changed);
 
     /**
      * @brief Bring the surfaces into line with the peers the router has heard.

--- a/magda/daw/audio/AudioThumbnailManager.cpp
+++ b/magda/daw/audio/AudioThumbnailManager.cpp
@@ -426,8 +426,8 @@ void AudioThumbnailManager::drawWaveformFromSamples(
                     const float* samples = buffer.getReadPointer(ch);
                     for (juce::int64 s = colStart; s < colEnd; ++s) {
                         const float v = samples[s];
-                        minVal = std::min(v, minVal);
-                        maxVal = std::max(v, maxVal);
+                        minVal = std::min(minVal, v);
+                        maxVal = std::max(maxVal, v);
                     }
                 } else {
                     int count = static_cast<int>(colEnd - colStart);
@@ -436,8 +436,8 @@ void AudioThumbnailManager::drawWaveformFromSamples(
                     const float* samples = chunkBuffer.getReadPointer(ch);
                     for (int s = 0; s < readCount; ++s) {
                         const float v = samples[s];
-                        minVal = std::min(v, minVal);
-                        maxVal = std::max(v, maxVal);
+                        minVal = std::min(minVal, v);
+                        maxVal = std::max(maxVal, v);
                     }
                 }
 

--- a/magda/daw/audio/AudioThumbnailManager.cpp
+++ b/magda/daw/audio/AudioThumbnailManager.cpp
@@ -4,6 +4,8 @@
 
 // clang-format off
 #include <tracktion_engine/tracktion_engine.h>
+
+#include <algorithm>
 // clang-format on
 
 namespace magda {
@@ -424,10 +426,8 @@ void AudioThumbnailManager::drawWaveformFromSamples(
                     const float* samples = buffer.getReadPointer(ch);
                     for (juce::int64 s = colStart; s < colEnd; ++s) {
                         const float v = samples[s];
-                        if (v < minVal)
-                            minVal = v;
-                        if (v > maxVal)
-                            maxVal = v;
+                        minVal = std::min(v, minVal);
+                        maxVal = std::max(v, maxVal);
                     }
                 } else {
                     int count = static_cast<int>(colEnd - colStart);
@@ -436,10 +436,8 @@ void AudioThumbnailManager::drawWaveformFromSamples(
                     const float* samples = chunkBuffer.getReadPointer(ch);
                     for (int s = 0; s < readCount; ++s) {
                         const float v = samples[s];
-                        if (v < minVal)
-                            minVal = v;
-                        if (v > maxVal)
-                            maxVal = v;
+                        minVal = std::min(v, minVal);
+                        maxVal = std::max(v, maxVal);
                     }
                 }
 

--- a/magda/daw/audio/ClipCommands.cpp
+++ b/magda/daw/audio/ClipCommands.cpp
@@ -961,10 +961,7 @@ bool JoinClipsCommand::canExecute() const {
 
     // Must be adjacent (left ends where right starts)
     const double bpm = resolveTimelineBpm(tempo_);
-    if (std::abs(left->getTimelineEnd(bpm) - right->getTimelineStart(bpm)) > 0.001)
-        return false;
-
-    return true;
+    return std::abs(left->getTimelineEnd(bpm) - right->getTimelineStart(bpm)) <= 0.001;
 }
 
 JoinClipsState JoinClipsCommand::captureState() {
@@ -1072,10 +1069,7 @@ bool JoinClipsCommand::validateState() const {
     if (!left)
         return false;
 
-    if (left->trackId == INVALID_TRACK_ID)
-        return false;
-
-    return true;
+    return left->trackId != INVALID_TRACK_ID;
 }
 
 // ============================================================================
@@ -2955,8 +2949,7 @@ void buildDrumGridFromSlices(const std::vector<SliceRegion>& slices, const ClipI
         return;
 
     int numSlices = static_cast<int>(slices.size());
-    if (numSlices > daw::audio::DrumGridPlugin::maxPads)
-        numSlices = daw::audio::DrumGridPlugin::maxPads;
+    numSlices = std::min(numSlices, daw::audio::DrumGridPlugin::maxPads);
 
     // Create Instrument track with DrumGridPlugin
     auto& trackManager = TrackManager::getInstance();
@@ -3061,8 +3054,7 @@ void buildDrumGridFromSlices(const std::vector<SliceRegion>& slices, const ClipI
         double noteDuration = nextTimeline - slice.timelinePos;
         double noteLengthBeats = noteDuration * beatsPerSecond;
 
-        if (noteStartBeat < 0.0)
-            noteStartBeat = 0.0;
+        noteStartBeat = std::max(noteStartBeat, 0.0);
         if (noteLengthBeats <= 0.0)
             noteLengthBeats = 0.01;
 

--- a/magda/daw/audio/WaveformPeakCache.cpp
+++ b/magda/daw/audio/WaveformPeakCache.cpp
@@ -150,8 +150,8 @@ std::unique_ptr<WaveformPeakCache> WaveformPeakCache::computeAndWrite(
                 float maxVal = -1.0f;
                 for (int k = s; k < bucketEnd; ++k) {
                     const float v = samples[k];
-                    minVal = std::min(v, minVal);
-                    maxVal = std::max(v, maxVal);
+                    minVal = std::min(minVal, v);
+                    maxVal = std::max(maxVal, v);
                 }
                 // Empty bucket (only at EOF) collapses to silence.
                 if (minVal > maxVal) {
@@ -239,8 +239,8 @@ WaveformPeakCache::MinMax WaveformPeakCache::getMinMaxForRange(int channel, juce
     for (juce::int64 b = firstBucket; b <= lastBucket; ++b) {
         const auto bMin = chPeaks[static_cast<size_t>(b * 2)];
         const auto bMax = chPeaks[static_cast<size_t>(b * 2 + 1)];
-        minI = std::min(bMin, minI);
-        maxI = std::max(bMax, maxI);
+        minI = std::min(minI, bMin);
+        maxI = std::max(maxI, bMax);
     }
 
     if (minI > maxI) {

--- a/magda/daw/audio/WaveformPeakCache.cpp
+++ b/magda/daw/audio/WaveformPeakCache.cpp
@@ -150,10 +150,8 @@ std::unique_ptr<WaveformPeakCache> WaveformPeakCache::computeAndWrite(
                 float maxVal = -1.0f;
                 for (int k = s; k < bucketEnd; ++k) {
                     const float v = samples[k];
-                    if (v < minVal)
-                        minVal = v;
-                    if (v > maxVal)
-                        maxVal = v;
+                    minVal = std::min(v, minVal);
+                    maxVal = std::max(v, maxVal);
                 }
                 // Empty bucket (only at EOF) collapses to silence.
                 if (minVal > maxVal) {
@@ -241,10 +239,8 @@ WaveformPeakCache::MinMax WaveformPeakCache::getMinMaxForRange(int channel, juce
     for (juce::int64 b = firstBucket; b <= lastBucket; ++b) {
         const auto bMin = chPeaks[static_cast<size_t>(b * 2)];
         const auto bMax = chPeaks[static_cast<size_t>(b * 2 + 1)];
-        if (bMin < minI)
-            minI = bMin;
-        if (bMax > maxI)
-            maxI = bMax;
+        minI = std::min(bMin, minI);
+        maxI = std::max(bMax, maxI);
     }
 
     if (minI > maxI) {

--- a/magda/daw/audio/analysis/MixAnalysisInput.hpp
+++ b/magda/daw/audio/analysis/MixAnalysisInput.hpp
@@ -44,7 +44,7 @@ class MixAnalysisInput {
      *                    sum of the track stems is used instead.
      * @param references  reference masters (genre targets), may be empty.
      */
-    static MixAnalysisData build(double sampleRate, const std::vector<Source>& tracks,
+    static MixAnalysisData build(double sr, const std::vector<Source>& tracks,
                                  const juce::AudioBuffer<float>* master,
                                  const std::vector<Source>& references, const Options& opts);
 
@@ -57,9 +57,8 @@ class MixAnalysisInput {
 
     /// Master-style fingerprint of one finished buffer (true-peak + tonal +
     /// spectral + whole-song correlation/width).
-    static MixAnalysisData::Track fingerprint(const juce::AudioBuffer<float>& buf,
-                                              double sampleRate, const juce::String& name,
-                                              const std::string& role);
+    static MixAnalysisData::Track fingerprint(const juce::AudioBuffer<float>& buf, double sr,
+                                              const juce::String& name, const std::string& role);
 };
 
 }  // namespace magda::daw::audio

--- a/magda/daw/audio/midi/MidiDeviceMatch.cpp
+++ b/magda/daw/audio/midi/MidiDeviceMatch.cpp
@@ -8,9 +8,7 @@ bool matches(const juce::String& storedKey, const juce::String& liveIdentifier,
         return false;
     if (storedKey == liveIdentifier)
         return true;
-    if (liveName.isNotEmpty() && storedKey.equalsIgnoreCase(liveName))
-        return true;
-    return false;
+    return liveName.isNotEmpty() && storedKey.equalsIgnoreCase(liveName);
 }
 
 bool matchedByNameOnly(const juce::String& storedKey, const juce::String& liveIdentifier,
@@ -19,9 +17,7 @@ bool matchedByNameOnly(const juce::String& storedKey, const juce::String& liveId
         return false;
     if (storedKey == liveIdentifier)
         return false;  // identifier match wins; not name-only
-    if (liveName.isNotEmpty() && storedKey.equalsIgnoreCase(liveName))
-        return true;
-    return false;
+    return liveName.isNotEmpty() && storedKey.equalsIgnoreCase(liveName);
 }
 
 std::optional<juce::MidiDeviceInfo> resolve(const juce::Array<juce::MidiDeviceInfo>& devices,

--- a/magda/daw/audio/plugin_manager/PluginManagerSidechain.cpp
+++ b/magda/daw/audio/plugin_manager/PluginManagerSidechain.cpp
@@ -145,10 +145,7 @@ bool PluginManager::trackNeedsSidechainMonitor(TrackId trackId) {
                                          SidechainConfig::Type::MIDI))
             usedAsSource = true;
     });
-    if (usedAsSource)
-        return true;
-
-    return false;
+    return usedAsSource;
 }
 
 void PluginManager::checkSidechainMonitor(TrackId trackId) {

--- a/magda/daw/audio/plugins/ArpeggiatorPlugin.cpp
+++ b/magda/daw/audio/plugins/ArpeggiatorPlugin.cpp
@@ -676,8 +676,7 @@ void ArpeggiatorPlugin::applyInputEvent(BlockScope& block, int index, double tim
             restartAt(block, timeInBlock);
     } else if (msg.isNoteOff()) {
         --physicallyHeldCount_;
-        if (physicallyHeldCount_ < 0)
-            physicallyHeldCount_ = 0;
+        physicallyHeldCount_ = std::max(physicallyHeldCount_, 0);
 
         // Latch keeps the note in the pattern and only marks the set stale once
         // every key is up.

--- a/magda/daw/audio/plugins/FaustInstrumentPlugin.hpp
+++ b/magda/daw/audio/plugins/FaustInstrumentPlugin.hpp
@@ -59,7 +59,7 @@ class FaustInstrumentPlugin : public MagdaDevice, public IFaustEditorModel {
     void setParameterValue(int index, float value) override;
 
     void flushState(juce::ValueTree& state) override;
-    void restoreState(const juce::ValueTree& state) override;
+    void restoreState(const juce::ValueTree& v) override;
 
     // Compile `source`, wrap it in a fresh poly voice allocator, swap it in,
     // and persist source+name to plugin state. Returns true on success; on

--- a/magda/daw/audio/plugins/FaustPlugin.hpp
+++ b/magda/daw/audio/plugins/FaustPlugin.hpp
@@ -51,7 +51,7 @@ class FaustPlugin : public MagdaDevice, public IFaustEditorModel {
     void setParameterValue(int index, float value) override;
 
     void flushState(juce::ValueTree& state) override;
-    void restoreState(const juce::ValueTree& state) override;
+    void restoreState(const juce::ValueTree& v) override;
 
   private:
     /// Re-cache the conversion domain of every pool slot. Called whenever the

--- a/magda/daw/audio/plugins/MagdaSamplerPlugin.cpp
+++ b/magda/daw/audio/plugins/MagdaSamplerPlugin.cpp
@@ -342,7 +342,7 @@ void SamplerVoice::renderNextBlock(juce::AudioBuffer<float>& outputBuffer, int s
         auto frac = static_cast<float>(sourceSamplePosition - pos0);
 
         // Stop at sample end (if set) or end of file — skip when looping
-        if (!(loopEnabled && loopEndSample > loopStartSample)) {
+        if (!loopEnabled || loopEndSample <= loopStartSample) {
             int endLimit =
                 (sampleEndSample > 0.0) ? static_cast<int>(sampleEndSample) : totalSamples - 1;
             if (pos0 >= endLimit) {

--- a/magda/daw/audio/racks/RackSyncManager.cpp
+++ b/magda/daw/audio/racks/RackSyncManager.cpp
@@ -1003,10 +1003,7 @@ bool RackSyncManager::structureChanged(const SyncedRack& synced, const RackInfo&
     const auto missingNestedRack = [&synced](const juce::String& key) {
         return !synced.nestedRackInstances.contains(key);
     };
-    if (std::ranges::any_of(expectedNestedRacks, missingNestedRack))
-        return true;
-
-    return false;
+    return std::ranges::any_of(expectedNestedRacks, missingNestedRack);
 }
 
 void RackSyncManager::updateProperties(SyncedRack& synced, const RackInfo& rackInfo) {

--- a/magda/daw/core/AutomationManager.cpp
+++ b/magda/daw/core/AutomationManager.cpp
@@ -1185,8 +1185,7 @@ void AutomationManager::restoreLane(AutomationLaneInfo& lane) {
 }
 
 void AutomationManager::insertLaneAt(AutomationLaneInfo& lane, size_t index) {
-    if (index > lanes_.size())
-        index = lanes_.size();
+    index = std::min(index, lanes_.size());
     lane.authorityState = automationAuthorityForPersistence(lane.authorityState);
     lanes_.insert(lanes_.begin() + static_cast<std::ptrdiff_t>(index), std::move(lane));
     notifyLanesChanged();
@@ -1215,27 +1214,22 @@ void AutomationManager::refreshIdCountersFromLanes() {
     int maxPointId = 0;
 
     for (const auto& lane : lanes_) {
-        if (lane.id > maxLaneId)
-            maxLaneId = lane.id;
+        maxLaneId = std::max(lane.id, maxLaneId);
 
         for (const auto& point : lane.absolutePoints) {
-            if (point.id > maxPointId)
-                maxPointId = point.id;
+            maxPointId = std::max(point.id, maxPointId);
         }
 
         for (auto clipId : lane.clipIds) {
-            if (clipId > maxClipId)
-                maxClipId = clipId;
+            maxClipId = std::max(clipId, maxClipId);
         }
     }
 
     for (const auto& clip : clips_) {
-        if (clip.id > maxClipId)
-            maxClipId = clip.id;
+        maxClipId = std::max(clip.id, maxClipId);
 
         for (const auto& point : clip.points) {
-            if (point.id > maxPointId)
-                maxPointId = point.id;
+            maxPointId = std::max(point.id, maxPointId);
         }
     }
 

--- a/magda/daw/core/AutomationManager.cpp
+++ b/magda/daw/core/AutomationManager.cpp
@@ -1214,22 +1214,22 @@ void AutomationManager::refreshIdCountersFromLanes() {
     int maxPointId = 0;
 
     for (const auto& lane : lanes_) {
-        maxLaneId = std::max(lane.id, maxLaneId);
+        maxLaneId = std::max(maxLaneId, lane.id);
 
         for (const auto& point : lane.absolutePoints) {
-            maxPointId = std::max(point.id, maxPointId);
+            maxPointId = std::max(maxPointId, point.id);
         }
 
         for (auto clipId : lane.clipIds) {
-            maxClipId = std::max(clipId, maxClipId);
+            maxClipId = std::max(maxClipId, clipId);
         }
     }
 
     for (const auto& clip : clips_) {
-        maxClipId = std::max(clip.id, maxClipId);
+        maxClipId = std::max(maxClipId, clip.id);
 
         for (const auto& point : clip.points) {
-            maxPointId = std::max(point.id, maxPointId);
+            maxPointId = std::max(maxPointId, point.id);
         }
     }
 

--- a/magda/daw/core/ClipFades.cpp
+++ b/magda/daw/core/ClipFades.cpp
@@ -87,8 +87,8 @@ std::optional<CrossfadeInfo> crossfadeAtEndOf(const ClipInfo& clip,
         const double oStart = other->placement.startBeat;
         const double oEnd = other->placement.endBeat();
         if (!(oStart < endB) ||
-            !(oStart > startB + kBeatTol ||
-              (std::abs(oStart - startB) <= kBeatTol && clipSitsBelow(clip, *other))))
+            (oStart <= startB + kBeatTol &&
+             (std::abs(oStart - startB) > kBeatTol || !clipSitsBelow(clip, *other))))
             continue;
         // Runs past this clip's end, or ends on the very same beat.
         if (oEnd > endB - kBeatTol) {

--- a/magda/daw/core/ClipManager.cpp
+++ b/magda/daw/core/ClipManager.cpp
@@ -1440,17 +1440,15 @@ ClipId ClipManager::splitClipAtBeat(ClipId clipId, double splitBeat, double temp
     if (clip->isMidi()) {
         if (clip->loopEnabled) {
             // Truncate each half's loop to its own portion.
-            if (clip->loopLengthBeats > leftLengthBeats)
-                clip->loopLengthBeats = leftLengthBeats;
-            if (rightClip.loopLengthBeats > rightLengthBeats)
-                rightClip.loopLengthBeats = rightLengthBeats;
+            clip->loopLengthBeats = std::min(clip->loopLengthBeats, leftLengthBeats);
+            rightClip.loopLengthBeats = std::min(rightClip.loopLengthBeats, rightLengthBeats);
         }
     } else if (leftEvent != nullptr && rightEvent != nullptr) {
         if (clip->loopEnabled) {
             // Beat-mode events keep the ORIGINAL source loop region: the right
             // half's anchor carries the playback phase, and truncating the
             // region to the split point makes the right side render silence.
-            if (!(leftEvent->autoTempo && leftEvent->interpBpm > 0.0)) {
+            if (!leftEvent->autoTempo || leftEvent->interpBpm <= 0.0) {
                 if (leftEvent->loopLengthBeats() > leftLengthBeats)
                     leftEvent->setLoopLengthBeats(leftLengthBeats);
                 if (rightEvent->loopLengthBeats() > rightLengthBeats) {

--- a/magda/daw/core/ClipOperations.hpp
+++ b/magda/daw/core/ClipOperations.hpp
@@ -2,6 +2,7 @@
 
 #include <juce_core/juce_core.h>
 
+#include <algorithm>
 #include <cmath>
 #include <utility>
 
@@ -100,10 +101,8 @@ class ClipOperations {
         if (noteEnd <= range.startBeat || noteStart >= range.endBeat())
             return false;
 
-        if (noteStart < range.startBeat)
-            noteStart = range.startBeat;
-        if (noteEnd > range.endBeat())
-            noteEnd = range.endBeat();
+        noteStart = std::max(noteStart, range.startBeat);
+        noteEnd = std::min(noteEnd, range.endBeat());
 
         if (noteEnd <= noteStart)
             return false;

--- a/magda/daw/core/Config.hpp
+++ b/magda/daw/core/Config.hpp
@@ -1234,8 +1234,7 @@ class Config {
         return previewOutputChannel;
     }
     void setPreviewOutputChannel(int channel) {
-        if (channel < 0)
-            channel = 0;
+        channel = std::max(channel, 0);
         // Snap to even (stereo pair boundary)
         channel &= ~1;
         previewOutputChannel = channel;

--- a/magda/daw/core/ModCurve.hpp
+++ b/magda/daw/core/ModCurve.hpp
@@ -44,7 +44,7 @@ float preset(CurvePreset shape, float phase);
  * modulator with a Custom waveform and no points would otherwise have to
  * invent for itself.
  */
-float points(std::span<const CurvePointData> points, float phase);
+float points(std::span<const CurvePointData> curve, float phase);
 
 /**
  * @brief The level a modulator of this shape has at @p phase.
@@ -52,7 +52,7 @@ float points(std::span<const CurvePointData> points, float phase);
  * The whole question in one call: a built-in waveform, or a drawn curve, or the
  * preset behind a Custom waveform nobody has drawn on yet.
  */
-float shapeAt(LFOWaveform wave, CurvePreset shape, std::span<const CurvePointData> points,
+float shapeAt(LFOWaveform wave, CurvePreset shape, std::span<const CurvePointData> curve,
               float phase);
 
 /**
@@ -63,6 +63,6 @@ float shapeAt(LFOWaveform wave, CurvePreset shape, std::span<const CurvePointDat
  * which is the run that closes the loop and not a place a one-shot ever
  * arrives at.
  */
-float endValue(LFOWaveform wave, CurvePreset shape, std::span<const CurvePointData> points);
+float endValue(LFOWaveform wave, CurvePreset shape, std::span<const CurvePointData> curve);
 
 }  // namespace magda::modcurve

--- a/magda/daw/core/ParameterDetector.cpp
+++ b/magda/daw/core/ParameterDetector.cpp
@@ -787,9 +787,7 @@ void detectWithAI(const juce::String& pluginName, const std::vector<ParameterSca
                     }
 
                     auto response = client->sendStreamingRequest(request, [&](const juce::String&) {
-                        if (cancelFlag && cancelFlag->load())
-                            return false;
-                        return true;
+                        return !(cancelFlag && cancelFlag->load());
                     });
 
                     if (cancelFlag && cancelFlag->load())

--- a/magda/daw/core/TrackManagerModulation.cpp
+++ b/magda/daw/core/TrackManagerModulation.cpp
@@ -106,9 +106,7 @@ bool shouldStopRunning(const ModInfo& mod, const ModTickInputs& in) {
         return false;
     if (mod.triggerMode == LFOTriggerMode::MIDI && in.midiNoteOff)
         return true;
-    if (mod.triggerMode == LFOTriggerMode::Audio && !mod.audioGateOpen)
-        return true;
-    return false;
+    return mod.triggerMode == LFOTriggerMode::Audio && !mod.audioGateOpen;
 }
 
 }  // namespace

--- a/magda/daw/core/UIScale.cpp
+++ b/magda/daw/core/UIScale.cpp
@@ -2,6 +2,7 @@
 
 #include <juce_gui_basics/juce_gui_basics.h>
 
+#include <algorithm>
 #include <cmath>
 #include <cstdlib>
 
@@ -93,8 +94,7 @@ double stepUIScale(double current, int direction) {
     }
 
     long next = static_cast<long>(nearest) + (direction > 0 ? 1 : -1);
-    if (next < 0)
-        next = 0;
+    next = std::max<long>(next, 0);
     if (next >= static_cast<long>(kUIScaleSteps.size()))
         next = static_cast<long>(kUIScaleSteps.size()) - 1;
     return kUIScaleSteps[static_cast<size_t>(next)];

--- a/magda/daw/core/UpdateChecker.cpp
+++ b/magda/daw/core/UpdateChecker.cpp
@@ -23,7 +23,7 @@ juce::String normalizeVersion(const juce::String& raw) {
     // "0.4.8-10-g83eb35e0" becomes "0.4.8" and "0.5.0-rc2" becomes "0.5.0".
     for (int i = 0; i < s.length(); ++i) {
         auto c = s[i];
-        if (!(juce::CharacterFunctions::isDigit(c) || c == '.')) {
+        if (!juce::CharacterFunctions::isDigit(c) && c != '.') {
             s = s.substring(0, i);
             break;
         }

--- a/magda/daw/core/controllers/BindingRegistry.cpp
+++ b/magda/daw/core/controllers/BindingRegistry.cpp
@@ -214,9 +214,7 @@ bool isFocusedDeviceMacroResolver(const Target& t) {
 bool isExplicitPluginParamTarget(const Target& t) {
     if (const auto* st = std::get_if<ControlTarget>(&t))
         return st->kind == ControlTarget::Kind::PluginParam;
-    if (std::holds_alternative<AliasRef>(t))
-        return true;
-    return false;
+    return std::holds_alternative<AliasRef>(t);
 }
 
 }  // namespace

--- a/magda/daw/core/controllers/BindingRegistry.hpp
+++ b/magda/daw/core/controllers/BindingRegistry.hpp
@@ -119,13 +119,13 @@ class BindingRegistry {
      *
      * @return All matching bindings from both Global and Project scopes.
      */
-    std::vector<Binding> findFor(const ControlTarget& target) const;
+    std::vector<Binding> findFor(const ControlTarget& query) const;
 
     /**
      * @brief Remove all bindings whose target resolves to the given ControlTarget.
      * @return Number of bindings removed.
      */
-    int removeFor(const ControlTarget& target);
+    int removeFor(const ControlTarget& query);
 
     /**
      * @brief True if any binding (Global + Project) resolves to a target on
@@ -180,7 +180,7 @@ class BindingRegistry {
      * `!findFor(...).empty()`, so the indicator drops when the binding's
      * controller is disabled.
      */
-    bool hasActiveBindingFor(const ControlTarget& target) const;
+    bool hasActiveBindingFor(const ControlTarget& query) const;
 
     /**
      * @brief True if any active binding for this macro is an explicit static

--- a/magda/daw/core/controllers/BindingTransform.hpp
+++ b/magda/daw/core/controllers/BindingTransform.hpp
@@ -41,7 +41,7 @@ TransformOutput applyMode(BindingMode mode, TransformInput input);
  * Exp:    y = expm1(x) / (e - 1)
  * SCurve: y = x * x * (3 - 2 * x)  (smoothstep)
  */
-float applyCurve(BindingCurve curve, float normalized);
+float applyCurve(BindingCurve curve, float x);
 
 /**
  * @brief Map a normalized-after-curve value into a BindingRange.
@@ -65,7 +65,7 @@ float applyRange(const BindingRange& range, float normalizedAfterCurve);
  * Every curve here is monotonic on [0,1], so each has one inverse and this is
  * total rather than a best effort.
  */
-float invertCurve(BindingCurve curve, float curved);
+float invertCurve(BindingCurve curve, float y);
 
 /**
  * @brief Recover the normalized-after-curve value that `applyRange` produced.

--- a/magda/daw/engine/TracktionEngineWrapper.hpp
+++ b/magda/daw/engine/TracktionEngineWrapper.hpp
@@ -457,7 +457,7 @@ class TracktionEngineWrapper : public AudioEngine,
     std::vector<std::string> getSystemPluginSearchPaths() const override;
     std::vector<ScannedPluginParameter> scanPluginParameters(const juce::String& pluginId,
                                                              bool internalPlugin) override;
-    bool upsertGrooveTemplate(const GrooveTemplateData& groove) override;
+    bool upsertGrooveTemplate(const GrooveTemplateData& data) override;
     juce::StringArray getGrooveTemplateNames() const override;
     std::unique_ptr<OfflineRenderSession> createOfflineRenderSession(
         bool resumePlaybackWhenFinished) override;

--- a/magda/daw/engine/TracktionEngineWrapperRecording.cpp
+++ b/magda/daw/engine/TracktionEngineWrapperRecording.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <cmath>
 
 #include "../audio/AudioBridge.hpp"
@@ -387,8 +388,7 @@ void TracktionEngineWrapper::drainRecordingNoteQueue() {
                     auto& n = preview.notes[static_cast<size_t>(i)];
                     if (n.noteNumber == evt.noteNumber && n.lengthBeats < 0.0) {
                         n.lengthBeats = eventBeat - n.startBeat;
-                        if (n.lengthBeats < 0.01)
-                            n.lengthBeats = 0.01;
+                        n.lengthBeats = std::max(n.lengthBeats, 0.01);
                         break;
                     }
                 }

--- a/magda/daw/media_db/MediaDbIndexer.cpp
+++ b/magda/daw/media_db/MediaDbIndexer.cpp
@@ -826,16 +826,12 @@ int decideThreadCount(int requested, size_t fileCount, const std::filesystem::pa
     if (n <= 0) {
         const unsigned hw = std::thread::hardware_concurrency();
         n = hw == 0 ? 2 : static_cast<int>(hw) - 1;
-        if (n < 1) {
-            n = 1;
-        }
+        n = std::max(n, 1);
     }
     // Never spawn more workers than there is work for, accounting for the
     // batch size (one worker per batch slot, capped).
     const int maxUseful = static_cast<int>((fileCount + kBatchSize - 1) / kBatchSize);
-    if (n > maxUseful) {
-        n = maxUseful;
-    }
+    n = std::min(n, maxUseful);
     return std::max(n, 1);
 }
 

--- a/magda/daw/media_db/MediaDbQuery.cpp
+++ b/magda/daw/media_db/MediaDbQuery.cpp
@@ -589,12 +589,8 @@ std::vector<QueryResult> MediaDbQuery::search(const std::optional<std::string>& 
                                               QueryWeights weights, QuerySort sort) const {
     sqlite3* sql = db_.handle();
     const BuiltWhere where = buildWhere(filters);
-    if (limit < 0) {
-        limit = 0;
-    }
-    if (offset < 0) {
-        offset = 0;
-    }
+    limit = std::max(limit, 0);
+    offset = std::max(offset, 0);
 
     if (!text || text->empty()) {
         return filterOnly(sql, where, limit, offset, sort);
@@ -708,12 +704,8 @@ std::vector<QueryResult> MediaDbQuery::similarTo(std::int64_t seedFileId,
                                                  const QueryFilters& filters, int limit, int offset,
                                                  QuerySort sort) const {
     sqlite3* sql = db_.handle();
-    if (limit < 0) {
-        limit = 0;
-    }
-    if (offset < 0) {
-        offset = 0;
-    }
+    limit = std::max(limit, 0);
+    offset = std::max(offset, 0);
 
     // Pull the seed's embedding. similarTo is a no-op if the seed wasn't
     // indexed with an audio model (no embedding row).

--- a/magda/daw/music/ChordEngine.cpp
+++ b/magda/daw/music/ChordEngine.cpp
@@ -119,7 +119,7 @@ Chord ChordEngine::detect(const std::vector<ChordNote>& heldNotes) {
 
     int actualBassNote = heldNotes[0].noteNumber;
     for (const auto& note : heldNotes)
-        actualBassNote = std::min(note.noteNumber, actualBassNote);
+        actualBassNote = std::min(actualBassNote, note.noteNumber);
 
     std::vector<int> pitchClasses;
     for (const auto& note : heldNotes) {

--- a/magda/daw/music/ChordEngine.cpp
+++ b/magda/daw/music/ChordEngine.cpp
@@ -119,8 +119,7 @@ Chord ChordEngine::detect(const std::vector<ChordNote>& heldNotes) {
 
     int actualBassNote = heldNotes[0].noteNumber;
     for (const auto& note : heldNotes)
-        if (note.noteNumber < actualBassNote)
-            actualBassNote = note.noteNumber;
+        actualBassNote = std::min(note.noteNumber, actualBassNote);
 
     std::vector<int> pitchClasses;
     for (const auto& note : heldNotes) {

--- a/magda/daw/music/ChordSuggestionEngine.cpp
+++ b/magda/daw/music/ChordSuggestionEngine.cpp
@@ -422,9 +422,7 @@ std::vector<ChordSuggestionEngine::SuggestionItem> ChordSuggestionEngine::genera
         if (!params.add13ths && is13thQuality(c.chord.quality))
             return false;
         // addSlashChords=false => exclude slash names
-        if (!params.addSlashChords && isSlashName(c.chord.getName()))
-            return false;
-        return true;
+        return !(!params.addSlashChords && isSlashName(c.chord.getName()));
     };
 
     std::vector<SuggestionItem> filtered;

--- a/magda/daw/project/serialization/AutomationModSerializer.cpp
+++ b/magda/daw/project/serialization/AutomationModSerializer.cpp
@@ -265,11 +265,7 @@ bool ProjectSerializer::deserializeAutomationPoint(const juce::var& json,
     if (!deserializeBezierHandle(obj->getProperty("inHandle"), outPoint.inHandle)) {
         return false;
     }
-    if (!deserializeBezierHandle(obj->getProperty("outHandle"), outPoint.outHandle)) {
-        return false;
-    }
-
-    return true;
+    return deserializeBezierHandle(obj->getProperty("outHandle"), outPoint.outHandle);
 }
 
 juce::var ProjectSerializer::serializeAutomationTarget(const AutomationTarget& target) {

--- a/magda/daw/transcription/BasicPitchPostprocess.cpp
+++ b/magda/daw/transcription/BasicPitchPostprocess.cpp
@@ -80,9 +80,7 @@ std::vector<float> getInferredOnsets(const std::vector<float>& onsets,
 
     // Clamp negatives to 0 and zero the first nDiff rows.
     for (float& v : frameDiff) {
-        if (v < 0.0F) {
-            v = 0.0F;
-        }
+        v = std::max(v, 0.0F);
     }
     for (int t = 0; t < std::min(nDiff, nFrames); ++t) {
         for (int f = 0; f < kNoteFreqBins; ++f) {

--- a/magda/daw/ui/components/chain/custom_ui/SamplerUI.cpp
+++ b/magda/daw/ui/components/chain/custom_ui/SamplerUI.cpp
@@ -520,7 +520,7 @@ void SamplerUI::buildWaveformPath(const juce::AudioBuffer<float>* buffer, int wi
         float maxVal = 0.0f;
         for (int s = startSample; s < endSample; ++s) {
             float absVal = std::abs(data[s]);
-            maxVal = std::max(absVal, maxVal);
+            maxVal = std::max(maxVal, absVal);
         }
         maxVal *= waveformGain_;
 
@@ -539,7 +539,7 @@ void SamplerUI::buildWaveformPath(const juce::AudioBuffer<float>* buffer, int wi
         float maxVal = 0.0f;
         for (int s = startSample; s < endSample; ++s) {
             float absVal = std::abs(data[s]);
-            maxVal = std::max(absVal, maxVal);
+            maxVal = std::max(maxVal, absVal);
         }
         maxVal *= waveformGain_;
 

--- a/magda/daw/ui/components/chain/custom_ui/SamplerUI.cpp
+++ b/magda/daw/ui/components/chain/custom_ui/SamplerUI.cpp
@@ -2,6 +2,7 @@
 
 #include <BinaryData.h>
 
+#include <algorithm>
 #include <cmath>
 
 #include "core/GestureRouter.hpp"
@@ -519,8 +520,7 @@ void SamplerUI::buildWaveformPath(const juce::AudioBuffer<float>* buffer, int wi
         float maxVal = 0.0f;
         for (int s = startSample; s < endSample; ++s) {
             float absVal = std::abs(data[s]);
-            if (absVal > maxVal)
-                maxVal = absVal;
+            maxVal = std::max(absVal, maxVal);
         }
         maxVal *= waveformGain_;
 
@@ -539,8 +539,7 @@ void SamplerUI::buildWaveformPath(const juce::AudioBuffer<float>* buffer, int wi
         float maxVal = 0.0f;
         for (int s = startSample; s < endSample; ++s) {
             float absVal = std::abs(data[s]);
-            if (absVal > maxVal)
-                maxVal = absVal;
+            maxVal = std::max(absVal, maxVal);
         }
         maxVal *= waveformGain_;
 
@@ -820,8 +819,7 @@ void SamplerUI::mouseDrag(const juce::MouseEvent& e) {
 
         // Clamp so region stays within sample bounds
         double newL = loopDragStartL_ + timeDelta;
-        if (newL < 0.0)
-            newL = 0.0;
+        newL = std::max(newL, 0.0);
         if (newL + regionLen > sampleLength_)
             newL = sampleLength_ - regionLen;
 
@@ -1158,8 +1156,7 @@ void SamplerUI::resized() {
         double minPPS = (sampleLength_ > 0.0)
                             ? static_cast<double>(waveBounds.getWidth()) / sampleLength_
                             : 100.0;
-        if (pixelsPerSecond_ < minPPS)
-            pixelsPerSecond_ = minPPS;
+        pixelsPerSecond_ = std::max(pixelsPerSecond_, minPPS);
         buildWaveformPath(waveformBuffer_, waveBounds.getWidth(), waveBounds.getHeight() - 4);
     }
 }

--- a/magda/daw/ui/components/chain/custom_ui/SpectrumAnalyzerUI.hpp
+++ b/magda/daw/ui/components/chain/custom_ui/SpectrumAnalyzerUI.hpp
@@ -69,9 +69,9 @@ class SpectrumAnalyzerUI : public juce::Component, private juce::Timer {
   private:
     void timerCallback() override;
     void updateTimerState();
-    void refreshOverlayList();                        // rebuild combo items from the track list
-    void selectOverlayTrack(magda::TrackId trackId);  // change selection + arm/disarm analysis
-    void releaseMeasurementArming();                  // undo only what this UI armed
+    void refreshOverlayList();                       // rebuild combo items from the track list
+    void selectOverlayTrack(magda::TrackId target);  // change selection + arm/disarm analysis
+    void releaseMeasurementArming();                 // undo only what this UI armed
     void pollOverlayData();      // fetch overlay band spectrum + pair-filtered findings
     void rebuildFft(int order);  // (re)allocate FFT + buffers for a 2^order transform
     static float freqToX(float hz, juce::Rectangle<float> area);

--- a/magda/daw/ui/components/chain/modulation/MacroEditorPanel.cpp
+++ b/magda/daw/ui/components/chain/modulation/MacroEditorPanel.cpp
@@ -266,9 +266,7 @@ void MacroEditorPanel::resized() {
 }
 
 bool MacroEditorPanel::keyPressed(const juce::KeyPress& key) {
-    if (key == juce::KeyPress::returnKey)
-        return true;
-    return false;
+    return key == juce::KeyPress::returnKey;
 }
 
 void MacroEditorPanel::mouseDown(const juce::MouseEvent& /*e*/) {

--- a/magda/daw/ui/components/chain/modulation/ModulatorEditorPanel.cpp
+++ b/magda/daw/ui/components/chain/modulation/ModulatorEditorPanel.cpp
@@ -1655,9 +1655,7 @@ void ModulatorEditorPanel::resized() {
 }
 
 bool ModulatorEditorPanel::keyPressed(const juce::KeyPress& key) {
-    if (key == juce::KeyPress::returnKey)
-        return true;
-    return false;
+    return key == juce::KeyPress::returnKey;
 }
 
 void ModulatorEditorPanel::mouseDown(const juce::MouseEvent& e) {

--- a/magda/daw/ui/components/chain/slot/DeviceSlotParameterPaging.cpp
+++ b/magda/daw/ui/components/chain/slot/DeviceSlotParameterPaging.cpp
@@ -1,5 +1,6 @@
 #include "slot/DeviceSlotParameterPaging.hpp"
 
+#include <algorithm>
 #include <utility>
 
 #include "compiled/CompiledPluginPresentation.hpp"
@@ -112,8 +113,7 @@ void updateDeviceSlotParameterPagination(const magda::DeviceInfo& device,
     int currentPage = device.currentParameterPage;
     if (currentPage >= totalPages)
         currentPage = totalPages - 1;
-    if (currentPage < 0)
-        currentPage = 0;
+    currentPage = std::max(currentPage, 0);
     paramGrid->updatePageControls(device, currentPage, totalPages);
 }
 

--- a/magda/daw/ui/components/common/BarsBeatsTicksLabel.cpp
+++ b/magda/daw/ui/components/common/BarsBeatsTicksLabel.cpp
@@ -1,5 +1,6 @@
 #include "BarsBeatsTicksLabel.hpp"
 
+#include <algorithm>
 #include <cmath>
 #include <cstdio>
 
@@ -94,13 +95,11 @@ void BarsBeatsTicksLabel::setBarsBeatsIsPosition(bool isPosition) {
 
 void BarsBeatsTicksLabel::decompose(int& bars, int& beats, int& ticks) const {
     double v = value_;
-    if (v < 0.0)
-        v = 0.0;
+    v = std::max(v, 0.0);
 
     bars = static_cast<int>(v / beatsPerBar_);
     double remaining = std::fmod(v, static_cast<double>(beatsPerBar_));
-    if (remaining < 0.0)
-        remaining = 0.0;
+    remaining = std::max(remaining, 0.0);
 
     beats = static_cast<int>(remaining);
     ticks = static_cast<int>(std::round((remaining - beats) * TICKS_PER_BEAT));
@@ -124,12 +123,9 @@ void BarsBeatsTicksLabel::onSegmentChanged() {
     int beats = beatsSegment_->getDisplayValue() - offset;
     int ticks = ticksSegment_->getDisplayValue();
 
-    if (bars < 0)
-        bars = 0;
-    if (beats < 0)
-        beats = 0;
-    if (ticks < 0)
-        ticks = 0;
+    bars = std::max(bars, 0);
+    beats = std::max(beats, 0);
+    ticks = std::max(ticks, 0);
 
     double newValue = recompose(bars, beats, ticks);
     setValue(newValue);

--- a/magda/daw/ui/components/common/DraggableValueLabel.cpp
+++ b/magda/daw/ui/components/common/DraggableValueLabel.cpp
@@ -1,5 +1,6 @@
 #include "DraggableValueLabel.hpp"
 
+#include <algorithm>
 #include <cmath>
 #include <cstdio>
 
@@ -130,8 +131,7 @@ juce::String DraggableValueLabel::formatValue(double val) const {
             constexpr int TICKS_PER_BEAT = 480;
             int wholeBars = static_cast<int>(val / beatsPerBar_);
             double remaining = std::fmod(val, static_cast<double>(beatsPerBar_));
-            if (remaining < 0.0)
-                remaining = 0.0;
+            remaining = std::max(remaining, 0.0);
             int wholeBeats = static_cast<int>(remaining);
             int ticks = static_cast<int>((remaining - wholeBeats) * TICKS_PER_BEAT);
             int offset = barsBeatsIsPosition_ ? 1 : 0;
@@ -253,12 +253,9 @@ double DraggableValueLabel::parseValue(const juce::String& text) const {
                 beat = parts[1].getIntValue() - offset;
             if (parts.size() >= 3)
                 ticks = parts[2].getIntValue();
-            if (bar < 0)
-                bar = 0;
-            if (beat < 0)
-                beat = 0;
-            if (ticks < 0)
-                ticks = 0;
+            bar = std::max(bar, 0);
+            beat = std::max(beat, 0);
+            ticks = std::max(ticks, 0);
             return bar * beatsPerBar_ + beat + ticks / static_cast<double>(TICKS_PER_BEAT);
         }
 

--- a/magda/daw/ui/components/pianoroll/MidiDrawerComponent.hpp
+++ b/magda/daw/ui/components/pianoroll/MidiDrawerComponent.hpp
@@ -151,7 +151,7 @@ class MidiDrawerComponent : public juce::Component {
     // Lane management
     void addCCTab(int ccNumber);
     void addPitchBendTab();
-    void removeTab(int tabIndex);
+    void removeTab(int ccIdx);
     void growDrawerForLanes();
 
     // Resize handle

--- a/magda/daw/ui/components/pianoroll/PianoRollGridComponent.cpp
+++ b/magda/daw/ui/components/pianoroll/PianoRollGridComponent.cpp
@@ -2915,8 +2915,7 @@ void PianoRollGridComponent::confirmPendingChord(double endBeat) {
         return;
 
     double length = endBeat - pendingChord_.startBeat;
-    if (length < gridResolutionBeats_)
-        length = gridResolutionBeats_;
+    length = std::max(length, gridResolutionBeats_);
 
     if (onChordDropped) {
         rememberAddedNoteLength(length);

--- a/magda/daw/ui/components/timeline/TimeRuler.cpp
+++ b/magda/daw/ui/components/timeline/TimeRuler.cpp
@@ -511,7 +511,7 @@ void TimeRuler::drawBarsBeatsMode(juce::Graphics& g) {
         (frac > 0.0) ? frac
                      : static_cast<double>(timeSigNumerator) *
                            GridConstants::findBarMultiple(zoom, timeSigNumerator, minPixelSpacing);
-    intervalBeats = std::max(gridResolutionBeats, intervalBeats);
+    intervalBeats = std::max(intervalBeats, gridResolutionBeats);
 
     double pixelsPerBeat = zoom;
     double pixelsPerBar = zoom * timeSigNumerator;

--- a/magda/daw/ui/components/timeline/TimeRuler.cpp
+++ b/magda/daw/ui/components/timeline/TimeRuler.cpp
@@ -1,5 +1,6 @@
 #include "TimeRuler.hpp"
 
+#include <algorithm>
 #include <cmath>
 
 #include "CursorManager.hpp"
@@ -460,8 +461,7 @@ void TimeRuler::drawSecondsMode(juce::Graphics& g) {
     // Find first visible time
     double startTime = pixelToTime(0);
     startTime = std::floor(startTime / interval) * interval;
-    if (startTime < 0)
-        startTime = 0;
+    startTime = std::max<double>(startTime, 0);
 
     // Draw markers
     g.setFont(11.0f);
@@ -511,8 +511,7 @@ void TimeRuler::drawBarsBeatsMode(juce::Graphics& g) {
         (frac > 0.0) ? frac
                      : static_cast<double>(timeSigNumerator) *
                            GridConstants::findBarMultiple(zoom, timeSigNumerator, minPixelSpacing);
-    if (gridResolutionBeats > intervalBeats)
-        intervalBeats = gridResolutionBeats;
+    intervalBeats = std::max(gridResolutionBeats, intervalBeats);
 
     double pixelsPerBeat = zoom;
     double pixelsPerBar = zoom * timeSigNumerator;
@@ -552,13 +551,11 @@ void TimeRuler::drawBarsBeatsMode(juce::Graphics& g) {
     double barOriginBeats = barOriginSeconds * tempo / 60.0;
 
     double firstVisibleBeat = (currentScrollOffset - leftPadding) / zoom + barOriginBeats;
-    if (firstVisibleBeat < barOriginBeats)
-        firstVisibleBeat = barOriginBeats;
+    firstVisibleBeat = std::max(firstVisibleBeat, barOriginBeats);
 
     auto startStep =
         static_cast<long long>(std::floor((firstVisibleBeat - barOriginBeats) / intervalBeats));
-    if (startStep < 0)
-        startStep = 0;
+    startStep = std::max<long long>(startStep, 0);
 
     double totalTimelineBeats = timelineLength * tempo / 60.0;
     // Determine which musical subdivision level to label (must be power-of-2 division of a beat).
@@ -633,8 +630,7 @@ void TimeRuler::drawBarsBeatsMode(juce::Graphics& g) {
         // Iterate by bar
         auto startBarStep = static_cast<long long>(
             std::floor((firstVisibleBeat - barOriginBeats) / barLengthBeats));
-        if (startBarStep < 0)
-            startBarStep = 0;
+        startBarStep = std::max<long long>(startBarStep, 0);
 
         for (long long barStep = startBarStep;; ++barStep) {
             double beat = barOriginBeats + barStep * barLengthBeats;
@@ -667,8 +663,7 @@ void TimeRuler::drawBarsBeatsMode(juce::Graphics& g) {
     // Pass 3: Beat labels (skip beat 1 = bar start, check overlap with bar labels)
     if (pixelsPerBeat >= 20) {
         auto startBeatStep = static_cast<long long>(std::floor(firstVisibleBeat - barOriginBeats));
-        if (startBeatStep < 0)
-            startBeatStep = 0;
+        startBeatStep = std::max<long long>(startBeatStep, 0);
 
         for (long long beatStep = startBeatStep;; ++beatStep) {
             double beat = barOriginBeats + static_cast<double>(beatStep);
@@ -720,8 +715,7 @@ void TimeRuler::drawBarsBeatsMode(juce::Graphics& g) {
         // Iterate at the subdivision label level (not at grid resolution)
         auto startSubdivStep = static_cast<long long>(
             std::floor((firstVisibleBeat - barOriginBeats) / subdivLabelBeats));
-        if (startSubdivStep < 0)
-            startSubdivStep = 0;
+        startSubdivStep = std::max<long long>(startSubdivStep, 0);
 
         for (long long subdivStep = startSubdivStep;; ++subdivStep) {
             double beatsFromOrigin = subdivStep * subdivLabelBeats;

--- a/magda/daw/ui/components/tracks/TrackContentPanel.cpp
+++ b/magda/daw/ui/components/tracks/TrackContentPanel.cpp
@@ -3,6 +3,7 @@
 #include <juce_audio_formats/juce_audio_formats.h>
 #include <tracktion_engine/tracktion_engine.h>
 
+#include <algorithm>
 #include <cmath>
 #include <functional>
 
@@ -868,8 +869,7 @@ void TrackContentPanel::paintRecordingPreviews(juce::Graphics& g) {
                 peak = juce::jmin(peak, 1.0f);
 
                 float lineHalf = peak * halfHeight;
-                if (lineHalf < 0.5f)
-                    lineHalf = 0.5f;
+                lineHalf = std::max(lineHalf, 0.5f);
 
                 g.drawVerticalLine(px, centerY - lineHalf, centerY + lineHalf);
             }
@@ -885,8 +885,7 @@ void TrackContentPanel::paintRecordingPreviews(juce::Graphics& g) {
                 if (noteLen < 0.0) {
                     // Open note (being held) — extend to clip end
                     noteLen = clipLengthInBeats - displayStart;
-                    if (noteLen < 0.05)
-                        noteLen = 0.05;
+                    noteLen = std::max(noteLen, 0.05);
                 }
                 double displayEnd = displayStart + noteLen;
 

--- a/magda/daw/ui/components/waveform/WaveformGridComponent.cpp
+++ b/magda/daw/ui/components/waveform/WaveformGridComponent.cpp
@@ -2,6 +2,7 @@
 
 #include <juce_audio_basics/juce_audio_basics.h>
 
+#include <algorithm>
 #include <cmath>
 #include <limits>
 
@@ -582,8 +583,7 @@ void WaveformGridComponent::paintBeatGrid(juce::Graphics& g, const magda::ClipIn
                 ? frac
                 : static_cast<double>(timeSigNum) * magda::GridConstants::findBarMultiple(
                                                         pixelsPerBeat, timeSigNum, kMinGridLinePx);
-        if (adaptiveBeats > gridBeats)
-            gridBeats = adaptiveBeats;
+        gridBeats = std::max(adaptiveBeats, gridBeats);
     }
     double secondsPerGrid = gridBeats * secondsPerBeat;
 
@@ -1408,8 +1408,7 @@ void WaveformGridComponent::mouseDrag(const juce::MouseEvent& event) {
         // Convert timeline delta to source time delta
         double sourceDelta = displayInfo_.displayDeltaToSourceDelta(timelineDelta);
         double newWarpTime = dragStartWarpTime_ + sourceDelta;
-        if (newWarpTime < 0.0)
-            newWarpTime = 0.0;
+        newWarpTime = std::max(newWarpTime, 0.0);
 
         // Snap to grid when snap is enabled and Alt is not held
         if (snapEnabled_ && !event.mods.isAltDown()) {
@@ -1437,10 +1436,8 @@ void WaveformGridComponent::mouseDrag(const juce::MouseEvent& event) {
         // This preserves the stretch relationship at this marker
         double newSourceTime = dragStartSourceTime_ + sourceDelta;
         double newWarpTime = dragStartWarpTime_ + sourceDelta;
-        if (newSourceTime < 0.0)
-            newSourceTime = 0.0;
-        if (newWarpTime < 0.0)
-            newWarpTime = 0.0;
+        newSourceTime = std::max(newSourceTime, 0.0);
+        newWarpTime = std::max(newWarpTime, 0.0);
 
         if (draggingMarkerIndex_ >= 0 && onWarpMarkerReposition) {
             onWarpMarkerReposition(draggingMarkerIndex_, newSourceTime, newWarpTime);

--- a/magda/daw/ui/components/waveform/WaveformGridComponent.cpp
+++ b/magda/daw/ui/components/waveform/WaveformGridComponent.cpp
@@ -583,7 +583,7 @@ void WaveformGridComponent::paintBeatGrid(juce::Graphics& g, const magda::ClipIn
                 ? frac
                 : static_cast<double>(timeSigNum) * magda::GridConstants::findBarMultiple(
                                                         pixelsPerBeat, timeSigNum, kMinGridLinePx);
-        gridBeats = std::max(adaptiveBeats, gridBeats);
+        gridBeats = std::max(gridBeats, adaptiveBeats);
     }
     double secondsPerGrid = gridBeats * secondsPerBeat;
 

--- a/magda/daw/ui/panels/content/AIChatConsoleContent.cpp
+++ b/magda/daw/ui/panels/content/AIChatConsoleContent.cpp
@@ -3553,8 +3553,7 @@ void AIChatConsoleContent::finishThemeGeneration(bool success, const juce::Strin
 // Format a seconds value as a compact human-readable string ("5ms",
 // "150ms", "1.2s", "12s"). Used for ADSR display in the pretty-print.
 static juce::String formatSeconds(float s) {
-    if (s < 0.0f)
-        s = 0.0f;
+    s = std::max(s, 0.0f);
     if (s < 1.0f)
         return juce::String(static_cast<int>(std::round(s * 1000.0f))) + "ms";
     if (s < 10.0f)

--- a/magda/daw/ui/panels/content/AIChatConsoleContent.hpp
+++ b/magda/daw/ui/panels/content/AIChatConsoleContent.hpp
@@ -247,7 +247,7 @@ class AIChatConsoleContent : public PanelContent,
     std::unique_ptr<ControllerRequestThread> controllerThread_;
 
     void startControllerGeneration(const juce::String& description);
-    void finishControllerGeneration(bool success, const juce::String& errorOrRawJson,
+    void finishControllerGeneration(bool success, const juce::String& errorOrJson,
                                     juce::String profileId, juce::String profileName);
 
     // /design <description> — kick the FourOscAgent on a background thread

--- a/magda/daw/ui/panels/content/ChordPanelContent.hpp
+++ b/magda/daw/ui/panels/content/ChordPanelContent.hpp
@@ -235,7 +235,7 @@ class ChordPanelContent : public juce::Component,
 
     // AI chord suggestion
     void requestAISuggestions();
-    static std::vector<AIProgression> parseAIResponse(const juce::String& json);
+    static std::vector<AIProgression> parseAIResponse(const juce::String& dsl);
 
     class AIRequestThread : public juce::Thread {
       public:

--- a/magda/daw/ui/panels/content/DrumGridClipContent.cpp
+++ b/magda/daw/ui/panels/content/DrumGridClipContent.cpp
@@ -897,8 +897,7 @@ class DrumGridClipGrid : public juce::Component,
         if (row >= 0 && row < static_cast<int>(padRows_->size())) {
             emptyClickRow_ = row;
             double rawBeat = displayBeatToClipBeat(pixelToBeat(e.x));
-            if (rawBeat < 0.0)
-                rawBeat = 0.0;
+            rawBeat = std::max(rawBeat, 0.0);
             emptyClickBeat_ = rawBeat;
             if (e.mods.isShiftDown()) {
                 isRepeatStamping_ = true;

--- a/magda/daw/ui/panels/content/MediaExplorerContent.cpp
+++ b/magda/daw/ui/panels/content/MediaExplorerContent.cpp
@@ -1,5 +1,6 @@
 #include "MediaExplorerContent.hpp"
 
+#include <algorithm>
 #include <filesystem>
 #include <system_error>
 
@@ -42,8 +43,7 @@ class MediaExplorerContent::PreviewAudioCallback : public juce::AudioIODeviceCal
         // Read offset from Config so changes in AudioSettingsDialog take effect immediately.
         // Config::getPreviewOutputChannel() is a plain member read — no locks or allocations.
         int offset = magda::Config::getInstance().getPreviewOutputChannel();
-        if (offset < 0)
-            offset = 0;
+        offset = std::max(offset, 0);
 
         // Check that the requested stereo pair fits within the available output channels
         if (offset + 1 < numOutputChannels) {

--- a/magda/daw/ui/panels/content/MidiEditorContent.cpp
+++ b/magda/daw/ui/panels/content/MidiEditorContent.cpp
@@ -970,8 +970,7 @@ void MidiEditorContent::updateGridResolution() {
         // Notify BottomPanel to update its num/den display
         if (onAutoGridDisplayChanged) {
             int den = static_cast<int>(std::round(4.0 / gridResolutionBeats_));
-            if (den < 1)
-                den = 1;
+            den = std::max(den, 1);
             onAutoGridDisplayChanged(1, den);
         }
     }

--- a/magda/daw/ui/panels/content/inspector/NoteInspector.cpp
+++ b/magda/daw/ui/panels/content/inspector/NoteInspector.cpp
@@ -1,5 +1,7 @@
 #include "NoteInspector.hpp"
 
+#include <algorithm>
+
 #include "../../themes/DarkTheme.hpp"
 #include "../../themes/FontManager.hpp"
 #include "core/ClipManager.hpp"
@@ -375,8 +377,7 @@ void NoteInspector::refreshMultiRangeDisplay() {
         constexpr int BEATS_PER_BAR = 4;
         int wholeBars = static_cast<int>(val / BEATS_PER_BAR);
         double remaining = std::fmod(val, static_cast<double>(BEATS_PER_BAR));
-        if (remaining < 0.0)
-            remaining = 0.0;
+        remaining = std::max(remaining, 0.0);
         int wholeBeats = static_cast<int>(remaining);
         int ticks = static_cast<int>((remaining - wholeBeats) * TICKS_PER_BEAT);
         int offset = isPosition ? 1 : 0;

--- a/magda/daw/ui/panels/content/inspector/clip/ClipInspectorSections.cpp
+++ b/magda/daw/ui/panels/content/inspector/clip/ClipInspectorSections.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <cmath>
 
 #include "../../../../../audio/AudioThumbnailManager.hpp"
@@ -1172,8 +1173,7 @@ void ClipInspector::initClipPropertiesSection() {
         } else {
             double loopStartBeats = clip->loopStartBeats;
             double newLoopLengthBeats = newLoopEndBeats - loopStartBeats;
-            if (newLoopLengthBeats < 0.25)
-                newLoopLengthBeats = 0.25;
+            newLoopLengthBeats = std::max(newLoopLengthBeats, 0.25);
             magda::UndoManager::getInstance().executeCommand(
                 std::make_unique<magda::SetMidiClipLoopLengthBeatsCommand>(
                     primaryClipId(), newLoopLengthBeats, bpm));

--- a/magda/daw/ui/panels/content/inspector/clip/ClipInspectorSections.cpp
+++ b/magda/daw/ui/panels/content/inspector/clip/ClipInspectorSections.cpp
@@ -1126,7 +1126,7 @@ void ClipInspector::initClipPropertiesSection() {
                               magda::audioEventRef(*clip).loopStartSeconds();
         double newLoopStartSeconds =
             displayBeatsToAudioSourceSeconds(*clip, newLoopStartBeats, bpm);
-        newLoopStartSeconds = std::max(0.0, newLoopStartSeconds);
+        newLoopStartSeconds = std::max(newLoopStartSeconds, 0.0);
         double newOffset = newLoopStartSeconds + currentPhase;
         // Atomic: change loopStart, then place offset to preserve phase. Undo
         // collapses both in a single step.

--- a/magda/daw/ui/panels/state/PanelController.cpp
+++ b/magda/daw/ui/panels/state/PanelController.cpp
@@ -47,8 +47,7 @@ void applyPersistedTabOrder(PanelState& panel, const std::vector<std::string>& s
     panel.tabs = std::move(ordered);
 
     panel.activeTabIndex = panel.getTabIndex(activeType);
-    if (panel.activeTabIndex < 0)
-        panel.activeTabIndex = 0;
+    panel.activeTabIndex = std::max(panel.activeTabIndex, 0);
 }
 
 void applyPersistedActiveTab(PanelState& panel, const std::string& savedActiveTab) {
@@ -328,8 +327,7 @@ void PanelController::handleReorderTabs(const ReorderTabsEvent& event) {
 
     // Restore active tab by type
     panel.activeTabIndex = panel.getTabIndex(activeType);
-    if (panel.activeTabIndex < 0)
-        panel.activeTabIndex = 0;
+    panel.activeTabIndex = std::max(panel.activeTabIndex, 0);
 
     notifyPanelChanged(event.panel);
 }

--- a/magda/daw/ui/views/MainView.cpp
+++ b/magda/daw/ui/views/MainView.cpp
@@ -2,6 +2,7 @@
 
 #include <BinaryData.h>
 
+#include <algorithm>
 #include <cmath>
 #include <ranges>
 #include <set>
@@ -2740,8 +2741,7 @@ void MainView::calculateSmartGridNumeratorDenominator(int& outNum, int& outDen,
         // beatFraction = 2^p, denominator = 4 / beatFraction
         outNum = 1;
         outDen = static_cast<int>(4.0 / frac);
-        if (outDen < 1)
-            outDen = 1;  // For frac > 4 (shouldn't happen)
+        outDen = std::max(outDen, 1);  // For frac > 4 (shouldn't happen)
         return;
     }
 

--- a/magda/daw/ui/views/MixerView.cpp
+++ b/magda/daw/ui/views/MixerView.cpp
@@ -1,5 +1,6 @@
 #include "MixerView.hpp"
 
+#include <algorithm>
 #include <cmath>
 #include <set>
 #include <unordered_map>
@@ -2268,8 +2269,7 @@ void MixerView::paint(juce::Graphics& g) {
             int indicatorWidth = DEFAULT_CHANNEL_WIDTH;
             int indicatorX = vpBounds.getRight() - indicatorWidth;
             // Clamp to viewport area
-            if (indicatorX < vpBounds.getX())
-                indicatorX = vpBounds.getX();
+            indicatorX = std::max(indicatorX, vpBounds.getX());
             auto indicatorBounds = juce::Rectangle<int>(indicatorX, vpBounds.getY(), indicatorWidth,
                                                         vpBounds.getHeight());
             g.setColour(DarkTheme::getColour(DarkTheme::ACCENT_PRIMARY).withAlpha(0.15f));

--- a/magda/daw/ui/windows/MainWindowCommands.cpp
+++ b/magda/daw/ui/windows/MainWindowCommands.cpp
@@ -1,3 +1,5 @@
+#include <algorithm>
+
 #include "../../core/AutomationCommands.hpp"
 #include "../../core/ClipCommands.hpp"
 #include "../../core/ClipManager.hpp"
@@ -715,8 +717,7 @@ bool MainWindow::MainComponent::perform(const InvocationInfo& info) {
                             double editCursorBeats = state.editCursorBeats;
                             double clipStartBeats = targetClip->getStartBeats(bpm);
                             pasteOffset = editCursorBeats - clipStartBeats;
-                            if (pasteOffset < 0)
-                                pasteOffset = 0;
+                            pasteOffset = std::max<double>(pasteOffset, 0);
                         }
                     }
                     const auto& clipboard = clipManager.getNoteClipboard();

--- a/magda/daw/ui/windows/MainWindowExport.cpp
+++ b/magda/daw/ui/windows/MainWindowExport.cpp
@@ -492,7 +492,7 @@ void MainWindow::performMidiExport(const ExportMidiDialog::Settings& settings) {
     for (const auto& clip : clips) {
         if (clip.isMidi()) {
             double endBeats = timelineEndBeats(clip, projectTempo);
-            rangeEndBeats = std::max(endBeats, rangeEndBeats);
+            rangeEndBeats = std::max(rangeEndBeats, endBeats);
         }
     }
 

--- a/magda/daw/ui/windows/MainWindowExport.cpp
+++ b/magda/daw/ui/windows/MainWindowExport.cpp
@@ -1,5 +1,6 @@
 #include <juce_audio_basics/juce_audio_basics.h>
 
+#include <algorithm>
 #include <utility>
 
 #include "../dialogs/ExportAudioDialog.hpp"
@@ -491,8 +492,7 @@ void MainWindow::performMidiExport(const ExportMidiDialog::Settings& settings) {
     for (const auto& clip : clips) {
         if (clip.isMidi()) {
             double endBeats = timelineEndBeats(clip, projectTempo);
-            if (endBeats > rangeEndBeats)
-                rangeEndBeats = endBeats;
+            rangeEndBeats = std::max(endBeats, rangeEndBeats);
         }
     }
 
@@ -623,12 +623,10 @@ void MainWindow::performMidiExport(const ExportMidiDialog::Settings& settings) {
             for (const auto& note : clip.midiNotes) {
                 double startTick = beatsToTicks(clipStartBeats + note.startBeat);
                 double endTick = beatsToTicks(clipStartBeats + note.startBeat + note.lengthBeats);
-                if (startTick < 0.0)
-                    startTick = 0.0;
+                startTick = std::max(startTick, 0.0);
                 if (startTick >= rangeEndTick)
                     continue;
-                if (endTick > rangeEndTick)
-                    endTick = rangeEndTick;
+                endTick = std::min(endTick, rangeEndTick);
 
                 auto noteOn = juce::MidiMessage::noteOn(channel, note.noteNumber,
                                                         static_cast<juce::uint8>(note.velocity));
@@ -644,8 +642,7 @@ void MainWindow::performMidiExport(const ExportMidiDialog::Settings& settings) {
 
             for (const auto& cc : clip.midiCCData) {
                 double tick = beatsToTicks(clipStartBeats + cc.beatPosition);
-                if (tick < 0.0)
-                    tick = 0.0;
+                tick = std::max(tick, 0.0);
                 if (tick >= rangeEndTick)
                     continue;
                 auto msg = juce::MidiMessage::controllerEvent(channel, cc.controller, cc.value);
@@ -656,8 +653,7 @@ void MainWindow::performMidiExport(const ExportMidiDialog::Settings& settings) {
 
             for (const auto& pb : clip.midiPitchBendData) {
                 double tick = beatsToTicks(clipStartBeats + pb.beatPosition);
-                if (tick < 0.0)
-                    tick = 0.0;
+                tick = std::max(tick, 0.0);
                 if (tick >= rangeEndTick)
                     continue;
                 auto msg = juce::MidiMessage::pitchWheel(channel, pb.value);


### PR DESCRIPTION
The fifth clang-tidy batch: `readability-simplify-boolean-expr`, `readability-use-std-min-max` and `readability-inconsistent-declaration-parameter-name`. An `if` that returns true or false returns the condition instead, a guarded assignment becomes a clamp, and a declaration's parameter names match the definition's.

Follows #2482, #2483, #2484 and #2487. 60 files.

## The clamps are not the identity they look like

An earlier version of this description claimed they were. They are not, and review caught it.

`std::min(a, b)` is `b < a ? b : a`, so argument order decides what happens to a NaN. The fixer wrote the incoming value first, which propagates NaN into the accumulator where the guarded assignment had dropped it. Over `[-0.8, 0.9, NaN, 0.1]` a peak pair came out `[0.1, 0.1]` instead of `[-0.8, 0.9]` — a persisted waveform cache losing real peaks, in `WaveformPeakCache`, `AudioThumbnailManager` and `SamplerUI`.

Fixed in 01448c292 by putting the accumulator first at all 21 sites, not only the float ones. The comparison is then the one the `if` performed whatever the type, rather than a rule that holds until something feeds it a NaN.

The boolean simplifications also include De Morgan on negated conjunctions, which changes how a line reads without changing what it does:

```
-if (!(loopEnabled && loopEndSample > loopStartSample))
+if (!loopEnabled || loopEndSample <= loopStartSample)
```

## Scope

`magda/engine/` is excluded. The native engine is being worked for #2485 and a mechanical rewrite of 100+ files underneath that costs more than it saves. It gets its own sweep once #2485 lands.

## Verification

- Catch2: 3772 cases, 998426 assertions, 0 failures.
- `magda_juce_tests`: all 453 groups pass, corpus included. This is the suite no earlier batch in this rollout was run against, which is how #2487's use-after-free reached review.
- Artifact scan (nested `std::move`, stacked `const`, `&&&`, repeated `static`) clean on all four counts.
- No build warning lands on any line this batch changed.
- Every new `std::min`/`std::max` checked for mixed argument types, since `size_t` is `unsigned long` here and `unsigned long long` on MSVC. The only two pairing distinct expressions are `size_t`/`size_t` and `int`/`int`.
