### PR TITLE
Initialise locals where they are declared

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -34,7 +34,6 @@ Checks: >-
   modernize-concat-nested-namespaces,
   modernize-type-traits,
   modernize-raw-string-literal,
-  cppcoreguidelines-prefer-member-initializer,
   cppcoreguidelines-init-variables,
   readability-qualified-auto,
   readability-redundant-string-init,
@@ -89,6 +88,18 @@ Checks: >-
 #   macro-parentheses (2)        the argument is streamed, so parenthesising it
 #                                would evaluate the << chain before the string.
 #
+# cppcoreguidelines-prefer-member-initializer is off. It hoists an assignment into
+# the init list without seeing what the body did first, and this codebase's
+# dominant constructor idiom is exactly that dependency: every TE plugin calls
+# CachedValue::referTo() and then reads .get(). Hoisting the read leaves it
+# bound to nothing, so the four sidechain/MIDI-source plugins silently lost
+# their persisted track on load. Of 19 files it touched, 7 carried a defect -
+# three no longer compiled (a header fix stacked, once 21 deep), MixerDebugPanel
+# read rows.size() before the body filled rows, and ChordTypes moved chordName
+# into the init list ahead of three body reads of it. The remaining 12 are
+# cosmetic. Rewriting a constructor means checking declaration order and every
+# preceding statement, so it belongs with use-anyofallof as authoring work.
+#
 # modernize-use-integer-sign-comparison is off: its 656 hits were all deliberate
 # `x < static_cast<int>(v.size())` casts, and its fixer deletes the cast text but
 # leaves the closing paren - 572 of 632 rewrites did not compile.
@@ -120,6 +131,10 @@ CheckOptions:
     value: 'false'
   - key: performance-unnecessary-value-param.AllowedTypes
     value: 'juce::String;juce::var;std::shared_ptr;std::unique_ptr'
+  # Defaults to <math.h>, which it then adds next to the <cmath> these files
+  # already include. The inserter matches on spelling, so only <cmath> dedupes.
+  - key: cppcoreguidelines-init-variables.MathHeader
+    value: '<cmath>'
   - key: modernize-loop-convert.MaxCopySize
     value: '16'
   - key: modernize-loop-convert.MinConfidence

--- a/magda/agents/dsl_interpreter.cpp
+++ b/magda/agents/dsl_interpreter.cpp
@@ -57,8 +57,7 @@ juce::Colour parseDslColour(const std::string& value) {
 // Tokenizer Implementation
 // ============================================================================
 
-Tokenizer::Tokenizer(const char* input)
-    : input_(input), pos_(input), line_(1), col_(1), hasPeeked_(false) {}
+Tokenizer::Tokenizer(const char* input) : input_(input), pos_(input) {}
 
 void Tokenizer::skipWhitespace() {
     while (*pos_) {
@@ -908,7 +907,7 @@ bool Interpreter::executeNewClip(const Params& params) {
     }
 
     double lengthBars = params.getFloat("length_bars", 4.0);
-    double bar;
+    double bar = NAN;
 
     if (params.has("bar")) {
         bar = params.getFloat("bar", 1.0);
@@ -2829,7 +2828,7 @@ bool Interpreter::executeGrooveExtract(const Params& params) {
     int resolution = params.getInt("resolution", 16);  // 8 or 16
 
     // Get clip — use param or current selection
-    ClipId clipId;
+    ClipId clipId = INVALID_CLIP_ID;
     if (params.has("clip")) {
         int clipIndex = params.getInt("clip", 0);
         // Find clip by index on current track

--- a/magda/agents/dsl_interpreter.hpp
+++ b/magda/agents/dsl_interpreter.hpp
@@ -92,10 +92,10 @@ class Tokenizer {
 
     const char* input_;
     const char* pos_;
-    int line_;
-    int col_;
+    int line_{1};
+    int col_{1};
     Token peeked_;
-    bool hasPeeked_;
+    bool hasPeeked_{false};
 };
 
 // ============================================================================

--- a/magda/agents/generic_sound_design_agent.cpp
+++ b/magda/agents/generic_sound_design_agent.cpp
@@ -2,6 +2,7 @@
 
 #include <juce_events/juce_events.h>
 
+#include <cmath>
 #include <functional>
 #include <map>
 #include <unordered_set>
@@ -325,7 +326,7 @@ juce::String GenericSoundDesignAgent::generateAndApply(const juce::String& promp
                 continue;
             }
             const ParamSnapshot& p = *it->second;
-            float real;
+            float real = NAN;
             if (p.scale == ParameterScale::Discrete && !p.choices.empty())
                 real = discreteRealValue(p, value);
             else

--- a/magda/agents/mcp/MCPClient.cpp
+++ b/magda/agents/mcp/MCPClient.cpp
@@ -124,7 +124,7 @@ void MCPClient::stop() {
             stdinWrite_ = -1;
         }
 
-        int status;
+        int status = 0;
         if (waitpid(childPid_, &status, WNOHANG) == 0) {
             kill(childPid_, SIGTERM);
             waitpid(childPid_, &status, 0);
@@ -145,7 +145,7 @@ void MCPClient::stop() {
 bool MCPClient::isRunning() const {
     if (childPid_ <= 0)
         return false;
-    int status;
+    int status = 0;
     return waitpid(childPid_, &status, WNOHANG) == 0;
 }
 

--- a/magda/daw/api/remote_service.hpp
+++ b/magda/daw/api/remote_service.hpp
@@ -269,7 +269,7 @@ class RemoteApiService {
      * suppresses exactly those re-entrant callbacks and leaves genuine
      * concurrent UI edits alone.
      */
-    std::atomic<std::thread::id> executingThread_{};
+    std::atomic<std::thread::id> executingThread_;
 
     mutable std::mutex cacheMutex_;
     std::vector<CachedResponse> cache_;

--- a/magda/daw/audio/ClipCommands.cpp
+++ b/magda/daw/audio/ClipCommands.cpp
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 #include <array>
+#include <cmath>
 #include <limits>
 #include <utility>
 
@@ -2773,7 +2774,7 @@ void sliceClipAtWarpMarkers(ClipId clipId, double tempo, AudioBridge* bridge) {
     // the inverse of splitClip's offset formula.
     for (size_t i = 1; i + 1 < markers.size(); ++i) {
         double sourceDelta = markers[i].sourceTime - clipOffset;
-        double splitTime;
+        double splitTime = NAN;
         if (magda::audioEventRef(*clip).autoTempo && magda::audioEventRef(*clip).interpBpm > 0.0) {
             splitTime = clipStart + sourceDelta * magda::audioEventRef(*clip).interpBpm / bpm;
         } else {

--- a/magda/daw/audio/automation/ModulationBaker.cpp
+++ b/magda/daw/audio/automation/ModulationBaker.cpp
@@ -62,7 +62,7 @@ double ModulationBaker::beatsPerCycle(SyncDivision division) {
 }
 
 double ModulationBaker::phaseAtBeat(const ModInfo& mod, double beat, const TempoMap& tempoMap) {
-    double cycles;
+    double cycles = NAN;
     if (mod.tempoSync) {
         cycles = beat / beatsPerCycle(mod.syncDivision);
     } else {
@@ -110,7 +110,7 @@ std::vector<AutomationPoint> ModulationBaker::bake(
             continue;
         anyBakeable = true;
 
-        double cycleBeats;
+        double cycleBeats = NAN;
         if (source.mod.tempoSync) {
             cycleBeats = beatsPerCycle(source.mod.syncDivision);
         } else {

--- a/magda/daw/audio/controllers/ControllerRouter.cpp
+++ b/magda/daw/audio/controllers/ControllerRouter.cpp
@@ -1,6 +1,7 @@
 #include "controllers/ControllerRouter.hpp"
 
 #include <algorithm>
+#include <cmath>
 
 #include "../../core/aliases/AliasRegistry.hpp"
 #include "../../core/aliases/ChainContext.hpp"
@@ -347,7 +348,7 @@ void ControllerRouter::executeWrite(const BindingId& bindingId, int rawValue, in
     juce::String key = bindingId.toDashedString();
     auto& state = runtimeState_[key];
 
-    float finalValue;
+    float finalValue = NAN;
 
     if (binding.mode == BindingMode::Toggle) {
         float toggled = applyToggle(rawValue, state.toggleState);

--- a/magda/daw/audio/plugins/ArpeggiatorPlugin.cpp
+++ b/magda/daw/audio/plugins/ArpeggiatorPlugin.cpp
@@ -725,7 +725,7 @@ void ArpeggiatorPlugin::walkSteps(BlockScope& block, const Stretch& stretch) {
         }
 
         // Determine which note to play
-        int stepIdx;
+        int stepIdx = 0;
         if (block.pattern == Pattern::Random) {
             stepIdx = arpRandom_.nextInt(stretch.seq.length);
         } else {

--- a/magda/daw/audio/plugins/MidiChordEnginePlugin.cpp
+++ b/magda/daw/audio/plugins/MidiChordEnginePlugin.cpp
@@ -72,7 +72,7 @@ void MidiChordEnginePlugin::process(DeviceProcessContext& context) {
                 heldNoteCount_.store(count + 1, std::memory_order_release);
             }
             // Push to FIFO for message-thread processing
-            int start1, size1, start2, size2;
+            int start1 = 0, size1 = 0, start2 = 0, size2 = 0;
             noteFifo_.prepareToWrite(1, start1, size1, start2, size2);
             if (size1 > 0) {
                 noteBuffer_[static_cast<size_t>(start1)] = {msg.getNoteNumber(), true,
@@ -98,7 +98,7 @@ void MidiChordEnginePlugin::process(DeviceProcessContext& context) {
             }
 
             // Push to FIFO
-            int start1, size1, start2, size2;
+            int start1 = 0, size1 = 0, start2 = 0, size2 = 0;
             noteFifo_.prepareToWrite(1, start1, size1, start2, size2);
             if (size1 > 0) {
                 noteBuffer_[static_cast<size_t>(start1)] = {msg.getNoteNumber(), false,
@@ -135,7 +135,7 @@ void MidiChordEnginePlugin::timerCallback() {
 }
 
 void MidiChordEnginePlugin::processNoteEvents() {
-    int start1, size1, start2, size2;
+    int start1 = 0, size1 = 0, start2 = 0, size2 = 0;
     noteFifo_.prepareToRead(noteFifo_.getNumReady(), start1, size1, start2, size2);
 
     auto processRange = [this](int start, int count) {

--- a/magda/daw/audio/plugins/mutable/MutableCloudsPlugin.cpp
+++ b/magda/daw/audio/plugins/mutable/MutableCloudsPlugin.cpp
@@ -321,7 +321,7 @@ struct MutableCloudsPlugin::Impl {
                 hostIn_.push(inL, inR);
             }
 
-            float sL, sR;
+            float sL = NAN, sR = NAN;
             while (inResampler_.pull(hostIn_, sL, sR)) {
                 grainIn_[grainFill_].l = sL;
                 grainIn_[grainFill_].r = sR;

--- a/magda/daw/audio/session/ClipSynchronizer.cpp
+++ b/magda/daw/audio/session/ClipSynchronizer.cpp
@@ -1490,7 +1490,7 @@ static void interpolateCCEvents(te::MidiList& sequence, const std::vector<EventT
                 double t = (beat - beatStart) / span;
 
                 // Apply tension (same formula as CurveSnapshot::evaluate / CurveEditorBase)
-                double curvedT;
+                double curvedT = NAN;
                 if (std::abs(tension) < 0.001) {
                     curvedT = t;
                 } else if (tension > 0) {

--- a/magda/daw/audio/transport/RampCurve.hpp
+++ b/magda/daw/audio/transport/RampCurve.hpp
@@ -32,7 +32,7 @@ inline double applyRampCurve(double t, float depth, float skew, bool hardAngle =
 
     if (hardAngle) {
         // Piecewise linear: two straight segments through control point (s, cp)
-        double result;
+        double result = NAN;
         if (t <= s)
             result = t * cp / s;
         else
@@ -41,7 +41,7 @@ inline double applyRampCurve(double t, float depth, float skew, bool hardAngle =
     }
 
     // Quadratic bezier with control point (s, cp)
-    double u;
+    double u = NAN;
     double a = 1.0 - 2.0 * s;
     if (std::abs(a) < 1e-10) {
         u = t;

--- a/magda/daw/core/CurveMath.hpp
+++ b/magda/daw/core/CurveMath.hpp
@@ -25,7 +25,7 @@ inline float evalSegment(float y1, float y2, float controlY, float tension, bool
     if (std::abs(dy) < 1.0e-6f)
         return y1;  // flat segment
 
-    float r;  // curve value at t=0.5, normalised within [y1, y2]
+    float r = NAN;  // curve value at t=0.5, normalised within [y1, y2]
     if (hasStoredShaper) {
         // On-curve midpoint of the encoding quadratic: B(0.5) = 0.25 y1 + 0.5 C + 0.25 y2.
         const float midY = 0.25f * y1 + 0.5f * controlY + 0.25f * y2;

--- a/magda/daw/core/ModInfo.hpp
+++ b/magda/daw/core/ModInfo.hpp
@@ -433,7 +433,6 @@ struct ModInfo {
     explicit ModInfo(int index)
         : id(index),
           name(getDefaultName(index, ModType::LFO)),
-          type(ModType::LFO),
           tapPoint(defaultModTapPoint(ModType::LFO)) {}
 
     /// Become @p t, and take the tap point that goes with it. What

--- a/magda/daw/core/ModulatorEngine.hpp
+++ b/magda/daw/core/ModulatorEngine.hpp
@@ -214,7 +214,7 @@ class ModulatorEngine {
     // Timer instance - using composition instead of inheritance to allow early destruction
     std::unique_ptr<UpdateTimer> timer_;
 
-    std::chrono::steady_clock::time_point lastTickTime_{};
+    std::chrono::steady_clock::time_point lastTickTime_;
     bool lastTickValid_ = false;
 
     std::function<void()> postUpdateHook_;

--- a/magda/daw/core/ParameterDetector.cpp
+++ b/magda/daw/core/ParameterDetector.cpp
@@ -399,7 +399,7 @@ DetectedParameterInfo detectSingleParameter(const ParameterScanInput& input) {
         // Parse numeric values from display texts
         std::vector<float> parsedValues;
         for (const auto& text : input.displayTexts) {
-            float val;
+            float val = NAN;
             // Try bracketed value first: "50% [-9.0 dB]" → -9.0
             if (parseNumberFromBracketedUnit(text, displayUnit, val)) {
                 parsedValues.push_back(val);
@@ -469,7 +469,7 @@ DetectedParameterInfo detectSingleParameter(const ParameterScanInput& input) {
         if (displayTextsCompatible) {
             std::vector<float> parsedValues;
             for (const auto& text : input.displayTexts) {
-                float val;
+                float val = NAN;
                 // Try bracketed value first: "50% [-9.0 dB]" → -9.0
                 if (parseNumberFromBracketedUnit(text, nameUnit, val)) {
                     parsedValues.push_back(val);

--- a/magda/daw/core/ParameterUtils.cpp
+++ b/magda/daw/core/ParameterUtils.cpp
@@ -522,7 +522,7 @@ juce::String formatValue(float realValue, const ParameterInfo& info, int decimal
         const float teSpan = info.teMaxValue - info.teMinValue;
         const bool infoMatchesTeRange = std::abs(info.minValue - info.teMinValue) < 1e-6f &&
                                         std::abs(info.maxValue - info.teMaxValue) < 1e-6f;
-        float teRaw;
+        float teRaw = NAN;
         if (infoMatchesTeRange || teSpan <= 0.0f) {
             teRaw = realValue;
         } else {

--- a/magda/daw/music/ChordTypes.hpp
+++ b/magda/daw/music/ChordTypes.hpp
@@ -40,13 +40,7 @@ struct Chord {
     std::vector<int> missingIntervals;   // intervals present in ideal chord but absent in input
     std::vector<int> extraPitchClasses;  // pitch classes in input but not in ideal chord
 
-    Chord()
-        : root(ChordRoot::C),
-          quality(ChordQuality::Major),
-          inversion(0),
-          notes({}),
-          rootNoteNumber(-1),
-          degree(std::nullopt) {}
+    Chord() : notes({}), degree(std::nullopt) {}
 
     Chord(juce::String chordName) {  // NOLINT(google-explicit-constructor)
         auto parsedSpec = ChordUtils::stringToChordSpec(chordName);

--- a/magda/daw/profiling/PerformanceProfiler.hpp
+++ b/magda/daw/profiling/PerformanceProfiler.hpp
@@ -228,7 +228,7 @@ class PerformanceMonitor {
  */
 class MonitoredProfiler {
   public:
-    explicit MonitoredProfiler(juce::String category) : category_(std::move(category)), timer_() {}
+    explicit MonitoredProfiler(juce::String category) : category_(std::move(category)) {}
 
     ~MonitoredProfiler() {
         try {

--- a/magda/daw/project/serialization/DawProjectValidator.cpp
+++ b/magda/daw/project/serialization/DawProjectValidator.cpp
@@ -38,6 +38,9 @@ void appendLibXmlError(void* context, const char* message, ...) {
         return;
 
     char buffer[2048];
+    // va_list is an array type outside arm64, so `= nullptr` builds here and
+    // nowhere else.
+    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     va_list args;
     va_start(args, message);
     std::vsnprintf(buffer, sizeof(buffer), message, args);

--- a/magda/daw/ui/components/automation/AutomationLaneHeader.cpp
+++ b/magda/daw/ui/components/automation/AutomationLaneHeader.cpp
@@ -499,7 +499,7 @@ void paintAutomationLaneHeader(juce::Graphics& g, const AutomationLaneInfo& lane
                 const float teSpan = paramInfo.teMaxValue - paramInfo.teMinValue;
                 const float infoSpan = paramInfo.maxValue - paramInfo.minValue;
                 for (double norm : {0.0, 0.25, 0.5, 0.75, 1.0}) {
-                    float teRaw;
+                    float teRaw = NAN;
                     if (infoSpan > 0.0f) {
                         float real =
                             ParameterUtils::normalizedToReal(static_cast<float>(norm), paramInfo);

--- a/magda/daw/ui/components/chain/custom_ui/FourOscUI.cpp
+++ b/magda/daw/ui/components/chain/custom_ui/FourOscUI.cpp
@@ -581,7 +581,7 @@ FourOscUI::FilterTab::FilterTab(FourOscUI& owner) : owner_(owner) {
     });
     freqSlider_.setValueParser([](const juce::String& text) -> double {
         auto t = text.trim().toLowerCase();
-        float freq;
+        float freq = NAN;
         if (t.contains("khz"))
             freq = t.replace("khz", "").trim().getFloatValue() * 1000.0f;
         else

--- a/magda/daw/ui/components/chain/drum_grid/DrumGridUI.cpp
+++ b/magda/daw/ui/components/chain/drum_grid/DrumGridUI.cpp
@@ -3,6 +3,7 @@
 #include <BinaryData.h>
 #include <tracktion_engine/tracktion_engine.h>
 
+#include <cmath>
 #include <set>
 
 #include "audio/plugins/DrumGridPlugin.hpp"
@@ -100,7 +101,7 @@ void DrumGridUI::PadButton::paint(juce::Graphics& g) {
 
     // Background colour
     juce::Colour bg;
-    float borderThickness;
+    float borderThickness = NAN;
     if (triggered_) {
         bg = juce::Colour(0xFF5A5A2A);
         borderThickness = 1.5f;

--- a/magda/daw/ui/components/chain/slot/DeviceSlotAutomationControls.cpp
+++ b/magda/daw/ui/components/chain/slot/DeviceSlotAutomationControls.cpp
@@ -72,7 +72,7 @@ void applyDeviceSlotAutomationValueChange(magda::DeviceInfo& device, ParamHostCo
 
         for (int slotIndex = 0; slotIndex < paramsPerPage; ++slotIndex) {
             const int visibleParamIndex = pageOffset + slotIndex;
-            int actualParamIndex;
+            int actualParamIndex = 0;
             if (useVisibilityFilter) {
                 if (visibleParamIndex >= static_cast<int>(device.visibleParameters.size()))
                     continue;

--- a/magda/daw/ui/components/clips/ClipComponent.cpp
+++ b/magda/daw/ui/components/clips/ClipComponent.cpp
@@ -814,7 +814,7 @@ void ClipComponent::paintMidiNotes(juce::Graphics& g, const ClipInfo& clip,
     // and no source region to consult.
     double loopLengthBeats = clip.loopLengthBeats > 0.0 ? clip.loopLengthBeats : clipLengthInBeats;
 
-    double midiOffset;
+    double midiOffset = NAN;
     if (isDragging_ && dragMode_ == DragMode::ResizeLeft) {
         midiOffset =
             clip.loopEnabled ? resizePreviewClip_.midiOffset : resizePreviewClip_.midiTrimOffset;

--- a/magda/daw/ui/components/common/BarsBeatsTicksLabel.cpp
+++ b/magda/daw/ui/components/common/BarsBeatsTicksLabel.cpp
@@ -132,7 +132,7 @@ void BarsBeatsTicksLabel::onSegmentChanged() {
 }
 
 void BarsBeatsTicksLabel::updateSegmentTexts() {
-    int bars, beats, ticks;
+    int bars = 0, beats = 0, ticks = 0;
     decompose(bars, beats, ticks);
 
     int offset = barsBeatsIsPosition_ ? 1 : 0;

--- a/magda/daw/ui/components/common/DraggableValueLabel.cpp
+++ b/magda/daw/ui/components/common/DraggableValueLabel.cpp
@@ -339,7 +339,7 @@ void DraggableValueLabel::mouseDrag(const juce::MouseEvent& e) {
     // Calculate delta (dragging up increases value)
     int deltaY = dragStartY_ - e.y;
 
-    double deltaValue;
+    double deltaValue = NAN;
     if (format_ == Format::BarsBeats) {
         // BarsBeats: 1 beat per ~30px, shift = fine control (0.25 beats)
         double beatsPerPixel = 1.0 / 30.0;

--- a/magda/daw/ui/components/common/SvgButton.cpp
+++ b/magda/daw/ui/components/common/SvgButton.cpp
@@ -5,7 +5,7 @@
 namespace magda {
 
 SvgButton::SvgButton(const juce::String& buttonName, const char* svgData, size_t svgDataSize)
-    : juce::Button(buttonName), dualIconMode(false) {
+    : juce::Button(buttonName) {
     // Load SVG from binary data using RAII wrapper
     svgIcon = magda::ManagedDrawable::create(svgData, svgDataSize);
 

--- a/magda/daw/ui/components/common/TextSlider.hpp
+++ b/magda/daw/ui/components/common/TextSlider.hpp
@@ -3,6 +3,7 @@
 #include <juce_audio_basics/juce_audio_basics.h>
 #include <juce_gui_basics/juce_gui_basics.h>
 
+#include <cmath>
 #include <functional>
 #include <optional>
 
@@ -519,14 +520,14 @@ class TextSlider : public juce::Component,
                     effectiveInterval *= 0.01;
                 }
 
-                double pixelDelta;
+                double pixelDelta = NAN;
                 if (orientation_ == Orientation::Horizontal) {
                     pixelDelta = e.x - dragStartX_;
                 } else {
                     pixelDelta = dragStartY_ - e.y;
                 }
 
-                double newValue;
+                double newValue = NAN;
                 if (useLogProjection_) {
                     // Log slider: drag operates in log-normalised space
                     // [0,1] = log(val/min) / log(max/min). Equal pixel

--- a/magda/daw/ui/components/common/curve/CurveEditorBase.cpp
+++ b/magda/daw/ui/components/common/curve/CurveEditorBase.cpp
@@ -1,6 +1,7 @@
 #include "CurveEditorBase.hpp"
 
 #include <algorithm>
+#include <cmath>
 #include <limits>
 #include <map>
 #include <set>
@@ -652,7 +653,7 @@ std::pair<double, double> CurveEditorBase::getSegmentShaperPosition(const CurveP
     double sy = (p1y + p2y) * 0.5;
     if (std::abs(effectiveTension) > 0.001) {
         constexpr double t = 0.5;
-        double curvedT;
+        double curvedT = NAN;
         if (effectiveTension > 0)
             curvedT = std::pow(t, 1.0 + effectiveTension * 2.0);
         else
@@ -696,8 +697,8 @@ void CurveEditorBase::updateSegmentShaperFromPixel(uint32_t pointId, double pixe
         const auto& p2 = points[i + 1];
         const bool isHardCorner = (p1.curveType == CurveType::HardCorner);
 
-        double cx, cy;              // stored control (Linear) or apex (HardCorner)
-        double displayX, displayY;  // where the handle dot sits, always ON the curve
+        double cx = NAN, cy = NAN;              // stored control (Linear) or apex (HardCorner)
+        double displayX = NAN, displayY = NAN;  // where the handle dot sits, always ON the curve
 
         if (isHardCorner) {
             // Hard corner: the apex is a real point on the curve, so clamp it to
@@ -967,7 +968,7 @@ void CurveEditorBase::rebuildPointComponents() {
                     uint32_t pid = ptComp->getPointId();
                     if (!selectedPointIds_.count(pid))
                         continue;
-                    double fx, fy;
+                    double fx = NAN, fy = NAN;
                     if (pid == pointId) {
                         fx = newX;
                         fy = newY;

--- a/magda/daw/ui/components/pianoroll/PianoRollGridComponent.cpp
+++ b/magda/daw/ui/components/pianoroll/PianoRollGridComponent.cpp
@@ -1507,7 +1507,7 @@ void PianoRollGridComponent::updateNotePosition(NoteComponent* note, double beat
         note->setVisible(true);
     }
 
-    double displayBeat;
+    double displayBeat = NAN;
     const double visibleStart = clip ? ClipOperations::getMidiVisibleRange(*clip).startBeat : 0.0;
     if (relativeMode_) {
         if (clipIds_.size() > 1 && clip) {
@@ -2502,7 +2502,7 @@ void PianoRollGridComponent::updateNoteComponentBounds() {
 
         // Relative mode: notes at content-relative beats.
         // Absolute mode: midiTrimOffset compensates for left-resize.
-        double displayBeat;
+        double displayBeat = NAN;
 
         const double visibleStart = ClipOperations::getMidiVisibleRange(*clip).startBeat;
         if (relativeMode_) {
@@ -2520,7 +2520,7 @@ void PianoRollGridComponent::updateNoteComponentBounds() {
             // Absolute mode: use clipStartBeats_ which reflects the drag
             // preview position during clip moves, falling back to the clip's
             // actual timeline position otherwise.
-            double clipOffsetBeats;
+            double clipOffsetBeats = NAN;
             if (clipIds_.size() > 1) {
                 double tempo = 120.0;
                 if (auto* controller = TimelineController::getCurrent()) {

--- a/magda/daw/ui/components/timeline/TimelineComponent.cpp
+++ b/magda/daw/ui/components/timeline/TimelineComponent.cpp
@@ -442,7 +442,7 @@ void TimelineComponent::mouseDown(const juce::MouseEvent& event) {
             selectedSectionIndex = sectionIndex;
 
             // Check if clicking on section edge for resizing
-            bool isStartEdge;
+            bool isStartEdge = false;
             if (isOnSectionEdge(event.x, sectionIndex, isStartEdge)) {
                 isDraggingEdge = true;
                 isDraggingStart = isStartEdge;
@@ -476,7 +476,7 @@ void TimelineComponent::mouseMove(const juce::MouseEvent& event) {
         if (!arrangementLocked) {
             int sectionIndex = findSectionAtPosition(event.x, event.y);
             if (sectionIndex >= 0) {
-                bool isStartEdge;
+                bool isStartEdge = false;
                 if (isOnSectionEdge(event.x, sectionIndex, isStartEdge)) {
                     setMouseCursor(juce::MouseCursor::LeftRightResizeCursor);
                     return;

--- a/magda/daw/ui/components/timeline/ZoomScrollBar.cpp
+++ b/magda/daw/ui/components/timeline/ZoomScrollBar.cpp
@@ -290,7 +290,7 @@ ZoomScrollBar::DragMode ZoomScrollBar::getDragModeForPosition(int pos) const {
     auto thumbBounds = getThumbBounds();
 
     // Check if position is within thumb bounds (using the perpendicular center for hit test)
-    bool inThumb;
+    bool inThumb = false;
     if (orientation == Orientation::Horizontal) {
         inThumb = thumbBounds.contains(pos, thumbBounds.getCentreY());
     } else {

--- a/magda/daw/ui/components/tracks/TrackHeadersPanel.cpp
+++ b/magda/daw/ui/components/tracks/TrackHeadersPanel.cpp
@@ -2551,7 +2551,7 @@ void TrackHeadersPanel::mouseDown(const juce::MouseEvent& event) {
     }
 
     // Handle vertical track height resizing and track selection
-    int trackIndex;
+    int trackIndex = 0;
     if (isResizeHandleArea(pos, trackIndex)) {
         // Start resizing
         isResizing = true;
@@ -2756,7 +2756,7 @@ void TrackHeadersPanel::mouseMove(const juce::MouseEvent& event) {
     }
 
     // Handle vertical track height resizing
-    int trackIndex;
+    int trackIndex = 0;
     if (isResizeHandleArea(event.getPosition(), trackIndex)) {
         setMouseCursor(juce::MouseCursor::UpDownResizeCursor);
     } else {
@@ -3333,7 +3333,7 @@ void TrackHeadersPanel::executeDrop() {
         }
 
         // Calculate the initial target position in TrackManager order
-        int baseTargetIndex;
+        int baseTargetIndex = 0;
         if (dropTargetIndex_ >= static_cast<int>(visibleTrackIds_.size())) {
             baseTargetIndex = trackManager.getNumTracks();
         } else {
@@ -3452,7 +3452,7 @@ void TrackHeadersPanel::paintDropIndicatorLine(juce::Graphics& g) {
     if (dropTargetIndex_ < 0)
         return;
 
-    int indicatorY;
+    int indicatorY = 0;
     if (dropTargetIndex_ >= static_cast<int>(trackHeaders.size())) {
         // At the end
         indicatorY = getTotalTracksHeight();

--- a/magda/daw/ui/components/waveform/WaveformGridComponent.cpp
+++ b/magda/daw/ui/components/waveform/WaveformGridComponent.cpp
@@ -749,7 +749,7 @@ void WaveformGridComponent::paintClipBoundaries(juce::Graphics& g) {
         // In non-loop/non-beat mode, the right boundary is the active clip end
         // (offset + length), so the unselected source tail is greyed out while
         // the fixed source-file end marker remains visible.
-        int rightBoundaryX;
+        int rightBoundaryX = 0;
         if (isLooped) {
             rightBoundaryX = timeToPixel(baseTime + displayInfo_.loopEndPositionSeconds);
         } else if (canResizeClipEnd && clipLength_ > 0.0) {
@@ -765,7 +765,7 @@ void WaveformGridComponent::paintClipBoundaries(juce::Graphics& g) {
         // In loop mode: grey out before loop start (offset is phase, not trim)
         // In non-loop mode: grey out before clip start (offset)
         {
-            int leftBoundaryX;
+            int leftBoundaryX = 0;
             if (isLooped) {
                 leftBoundaryX = timeToPixel(baseTime + displayInfo_.loopStartPositionSeconds);
             } else if (canResizeClipEnd) {

--- a/magda/daw/ui/dialogs/ParameterConfigDialog.cpp
+++ b/magda/daw/ui/dialogs/ParameterConfigDialog.cpp
@@ -2,6 +2,7 @@
 
 #include <juce_audio_processors/juce_audio_processors.h>
 
+#include <cmath>
 #include <utility>
 
 #include "../themes/DarkTheme.hpp"
@@ -364,7 +365,7 @@ class ParameterConfigDialog::RangeCell : public juce::Component {
         }
 
         if (minStr.isNotEmpty() && maxStr.isNotEmpty()) {
-            float newMin, newMax;
+            float newMin = NAN, newMax = NAN;
             if (minStr.toLowerCase() == "-inf")
                 newMin = -std::numeric_limits<float>::infinity();
             else

--- a/magda/daw/ui/panels/content/inspector/clip/ClipInspectorSections.cpp
+++ b/magda/daw/ui/panels/content/inspector/clip/ClipInspectorSections.cpp
@@ -1164,7 +1164,7 @@ void ClipInspector::initClipPropertiesSection() {
         // Compute new loop length from loop end - loop start.
         double newLoopEndBeats = clipLoopEndValue_->getValue();
 
-        double newLoopLengthSeconds;
+        double newLoopLengthSeconds = NAN;
         if (clip->isAudio()) {
             const double newLoopEndSeconds =
                 displayBeatsToAudioSourceSeconds(*clip, newLoopEndBeats, bpm);

--- a/magda/daw/ui/state/TimelineEvents.hpp
+++ b/magda/daw/ui/state/TimelineEvents.hpp
@@ -497,7 +497,7 @@ struct SelectSectionEvent {
  */
 struct AddMarkerBeatsEvent {
     double positionBeats;
-    juce::String name = {};
+    juce::String name;
     juce::Colour colour = juce::Colour(0xFF9E9E9E);
 };
 
@@ -506,7 +506,7 @@ struct AddMarkerBeatsEvent {
  */
 struct AddMarkerEvent {
     double positionTime;
-    juce::String name = {};
+    juce::String name;
     juce::Colour colour = juce::Colour(0xFF9E9E9E);
 };
 

--- a/magda/daw/ui/views/MainView.cpp
+++ b/magda/daw/ui/views/MainView.cpp
@@ -82,11 +82,7 @@ double timelineEndSeconds(const ClipInfo& clip, double bpm) {
 
 }  // namespace
 
-MainView::MainView(AudioEngine* audioEngine)
-    : horizontalZoom(10.0),
-      playheadPosition(0.0),
-      initialZoomSet(false),
-      audioEngine_(audioEngine) {
+MainView::MainView(AudioEngine* audioEngine) : horizontalZoom(10.0), audioEngine_(audioEngine) {
     // Load configuration
     auto& config = magda::Config::getInstance();
     config.load();

--- a/magda/daw/ui/views/SessionView.cpp
+++ b/magda/daw/ui/views/SessionView.cpp
@@ -3153,7 +3153,7 @@ void SessionView::paintHeaderDragFeedback(juce::Graphics& g) {
     g.fillRect(dx, 0, dw, headerContainer->getHeight());
 
     if (headerDropType_ == HeaderDropType::BetweenTracks && headerDropIndex_ >= 0) {
-        int lineX;
+        int lineX = 0;
         if (headerDropIndex_ >= static_cast<int>(visibleTrackIds_.size()))
             lineX = getTotalTracksWidth() - trackHeaderScrollOffset;
         else
@@ -4036,7 +4036,7 @@ void SessionView::updateDragGhost(const juce::StringArray& files, int trackIndex
     // Position ghost at the target slot (in grid coordinates)
     int sceneRowHeight = CLIP_SLOT_HEIGHT + CLIP_SLOT_MARGIN;
 
-    int ghostX, ghostW;
+    int ghostX = 0, ghostW = 0;
     if (trackIndex >= 0) {
         ghostX = getTrackX(trackIndex);
         ghostW = (trackIndex < static_cast<int>(trackColumnWidths_.size()))

--- a/magda/daw/utils/ComponentManager.hpp
+++ b/magda/daw/utils/ComponentManager.hpp
@@ -200,7 +200,7 @@ template <typename ComponentType> class ManagedChild {
  */
 template <typename T> class ScopedComponentGuard {
   public:
-    explicit ScopedComponentGuard(T* component) : component_(component), released_(false) {}
+    explicit ScopedComponentGuard(T* component) : component_(component) {}
 
     static ScopedComponentGuard create(T* component) {
         return ScopedComponentGuard(component);
@@ -259,7 +259,7 @@ template <typename T> class ScopedComponentGuard {
 
   private:
     T* component_;
-    bool released_;
+    bool released_{false};
 };
 
 }  // namespace magda


### PR DESCRIPTION
Sixth clang-tidy batch: the member-init family, minus one check that turned out
to be unsafe here.

## What landed

`cppcoreguidelines-init-variables`, `modernize-use-default-member-init` and
`readability-redundant-member-init`, 43 files.

None of the 33 `init-variables` sites is a defect. The check has no flow
analysis, so every hit is a declare-then-assign-on-all-paths local. This is
blanket hardening ahead of turning `WarningsAsErrors` on, not a bug hunt.

## Fixer output I had to correct

`init-variables` writes `NAN` for floating-point locals and pulls in its
`MathHeader`, which defaults to `<math.h>`. It was adding that beside the
`<cmath>` 13 of these files already include, because the inserter dedupes on
spelling. `MathHeader: '<cmath>'` is now in the config and the additions drop to
the 7 files that genuinely lacked the header.

`DawProjectValidator.cpp` keeps an uninitialised `va_list` under a NOLINT.
`va_list` is `char*` on arm64 and an array type on x86-64 SysV and MSVC, so the
suggested `= nullptr` builds on my machine and on no CI runner. The marker has
to sit immediately above the declaration: my first attempt put a two-line
comment in between, which suppressed the comment instead, and the next run
reapplied the fix.

The `groove.extract` clip id defaults to `INVALID_CLIP_ID` rather than the
fixer's `0`, which is a real clip id sitting in front of an
`== INVALID_CLIP_ID` guard.

Two headers came back with stacked initialisers (`double x = NAN = NAN = NAN`),
the usual once-per-including-translation-unit problem. Collapsed, and there is a
grep for the form in the handoff's artifact scan now.

## prefer-member-initializer is disabled

Reason recorded in `.clang-tidy`. It hoists an assignment into the init list
without seeing what the constructor body did first, and the dominant constructor
idiom in this codebase is exactly that dependency: every TE plugin calls
`CachedValue::referTo()` and then reads `.get()`. Hoisting the read leaves it
bound to nothing, so `AudioSidechainMonitorPlugin`, `SidechainMonitorPlugin`,
`FollowerSourceTapPlugin` and `MidiReceivePlugin` silently lose their persisted
source track on load.

Of the 19 files it touched, 7 carried a defect:

- the four plugins above
- three no longer compiled, because a header fix stacks per including TU and it
  stacks whole init-list clauses; `positionTime(...)` repeated 21 times in
  `TimelineState.hpp`, and a second and third `:` introducer in `ChordTypes.hpp`
- `MixerDebugPanel` read `rows.size()` before the body filled `rows`
- `ChordTypes` moved `chordName` into the init list ahead of three body reads of
  it

The other 12 are cosmetic. Rewriting a constructor means checking declaration
order and every preceding statement, so it belongs with `use-anyofallof` as
authoring work rather than a generated batch. All 19 files are reverted here.

This is the one judgment call beyond the batch as scoped. Happy to re-enable the
check and hand-apply the 12 safe ones instead.

## Verification

Clean build, no `-Wreorder` or `-Wuninitialized`. Catch2 3768 passed, 13
skipped. JUCE suite all passed, including all nine real-project corpus cases
with the three real-plugin ones running locally.

https://claude.ai/code/session_01VomqgBSXsWYdyHyec9DvPi
