### PR TITLE
Give file-scope statics internal linkage by namespace

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -29,7 +29,6 @@ Checks: >-
   misc-use-anonymous-namespace,
   modernize-use-emplace,
   modernize-use-default-member-init,
-  modernize-loop-convert,
   modernize-pass-by-value,
   modernize-concat-nested-namespaces,
   modernize-type-traits,
@@ -87,6 +86,15 @@ Checks: >-
 #     iteration-order (2)        address; the other is listener registration order.
 #   macro-parentheses (2)        the argument is streamed, so parenthesising it
 #                                would evaluate the << chain before the string.
+#
+# modernize-loop-convert is off. It found 19 sites across 2 files and both files
+# were hand-written that way on purpose. TrackManager's 13 notify methods index
+# because addListener() push_backs unguarded: the index loop re-reads size() and
+# re-indexes, so a listener registering another mid-notification is fine, while a
+# range-for caches end() and walks a freed buffer when that push_back reallocates.
+# removeListener already nullifies rather than erases during notification "to keep
+# iterators valid", so the invariant was deliberate. ClipMidiSource is audio-thread
+# code carrying a comment that opens "By index rather than by iterator".
 #
 # cppcoreguidelines-prefer-member-initializer is off. It hoists an assignment into
 # the init list without seeing what the body did first, and this codebase's

--- a/magda/agents/command_agent.cpp
+++ b/magda/agents/command_agent.cpp
@@ -111,7 +111,8 @@ CommandAgent::GenerateResult CommandAgent::generateLocal(const std::string& mess
 
 /** Strip markdown code fences and surrounding prose from LLM output.
     Cloud providers (Anthropic, Gemini) often wrap DSL in ```blocks. */
-static std::string extractDSL(const juce::String& raw) {
+namespace {
+std::string extractDSL(const juce::String& raw) {
     auto text = raw.trim();
 
     // Strip ```dsl ... ``` or ``` ... ``` fences
@@ -132,17 +133,17 @@ static std::string extractDSL(const juce::String& raw) {
 }
 
 /** Check if provider supports CFG grammar (OpenAI Responses API, GPT-5+ only). */
-static bool usesCFG(const Config::AgentLLMConfig& config) {
+bool usesCFG(const Config::AgentLLMConfig& config) {
     return supportsOpenAICFG(config);
 }
 
 /** Build an LLM client for the command agent. */
-static std::unique_ptr<llm::LLMClient> createCommandClient(const Config::AgentLLMConfig& config) {
+std::unique_ptr<llm::LLMClient> createCommandClient(const Config::AgentLLMConfig& config) {
     return createLLMClient(config, "command");
 }
 
 /** Build the LLM request, adding CFG grammar when supported. */
-static llm::Request buildRequest(MagdaApi& api, const std::string& message, bool cfg) {
+llm::Request buildRequest(MagdaApi& api, const std::string& message, bool cfg) {
     auto stateJson = dsl::Interpreter::buildStateSnapshot(api);
     auto systemPrompt = juce::String::fromUTF8(CommandAgent::getSystemPrompt());
     systemPrompt += "\n\n" + getInternalPluginCatalogDescription();
@@ -162,6 +163,7 @@ static llm::Request buildRequest(MagdaApi& api, const std::string& message, bool
 
     return request;
 }
+}  // namespace
 
 CommandAgent::GenerateResult CommandAgent::generate(const std::string& message) {
     GenerateResult result;

--- a/magda/agents/music_helpers.hpp
+++ b/magda/agents/music_helpers.hpp
@@ -8,12 +8,10 @@
 #include <string>
 #include <vector>
 
-namespace magda {
-
 /**
  * @brief Shared music helpers used by both the DSL interpreter and compact executor.
  */
-namespace music {
+namespace magda::music {
 
 /** Parse note name (e.g. "C4", "C#4", "Bb3") or MIDI number to MIDI note number. Returns -1 on
  * error. */
@@ -160,5 +158,4 @@ inline bool resolveChordNotes(const std::string& root, const std::string& qualit
     return true;
 }
 
-}  // namespace music
-}  // namespace magda
+}  // namespace magda::music

--- a/magda/daw/api/remote_api_host.cpp
+++ b/magda/daw/api/remote_api_host.cpp
@@ -26,8 +26,7 @@
     #include <csignal>
 #endif
 
-namespace magda {
-namespace remote {
+namespace magda::remote {
 
 namespace {
 
@@ -557,5 +556,4 @@ RemoteAuditLog& RemoteApiHost::audit() {
     return *audit_;
 }
 
-}  // namespace remote
-}  // namespace magda
+}  // namespace magda::remote

--- a/magda/daw/api/remote_audit.hpp
+++ b/magda/daw/api/remote_audit.hpp
@@ -8,8 +8,7 @@
 #include <mutex>
 #include <vector>
 
-namespace magda {
-namespace remote {
+namespace magda::remote {
 
 /// How one audited request or connection ended.
 enum class AuditOutcome {
@@ -174,5 +173,4 @@ juce::String redactSecrets(const juce::String& text);
  */
 juce::String redactedFileName(const juce::File& file);
 
-}  // namespace remote
-}  // namespace magda
+}  // namespace magda::remote

--- a/magda/daw/api/remote_clients.hpp
+++ b/magda/daw/api/remote_clients.hpp
@@ -12,8 +12,7 @@
 
 #include "remote_scopes.hpp"
 
-namespace magda {
-namespace remote {
+namespace magda::remote {
 
 /// The two transport names, spelled once. They key the disconnect handlers, so
 /// a mismatch between what a server registers and what a connection reports is
@@ -186,5 +185,4 @@ class RemoteClientRegistry {
     std::function<void()> onChanged_;
 };
 
-}  // namespace remote
-}  // namespace magda
+}  // namespace magda::remote

--- a/magda/daw/api/remote_http_auth.cpp
+++ b/magda/daw/api/remote_http_auth.cpp
@@ -4,8 +4,7 @@
 #include <cstddef>
 #include <cstring>
 
-namespace magda {
-namespace remote {
+namespace magda::remote {
 
 bool secureEquals(const juce::String& a, const juce::String& b) {
     const auto* lhs = a.toRawUTF8();
@@ -35,5 +34,4 @@ bool isOriginAllowed(bool originPresent, const juce::String& origin,
     return std::find(allowedOrigins.begin(), allowedOrigins.end(), origin) != allowedOrigins.end();
 }
 
-}  // namespace remote
-}  // namespace magda
+}  // namespace magda::remote

--- a/magda/daw/api/remote_http_auth.hpp
+++ b/magda/daw/api/remote_http_auth.hpp
@@ -4,8 +4,7 @@
 
 #include <vector>
 
-namespace magda {
-namespace remote {
+namespace magda::remote {
 
 /**
  * @brief The admission rules every remote transport shares.
@@ -52,5 +51,4 @@ bool isAuthorised(const juce::String& authorizationHeader, const juce::String& t
 bool isOriginAllowed(bool originPresent, const juce::String& origin,
                      const std::vector<juce::String>& allowedOrigins);
 
-}  // namespace remote
-}  // namespace magda
+}  // namespace magda::remote

--- a/magda/daw/api/remote_mcp.cpp
+++ b/magda/daw/api/remote_mcp.cpp
@@ -9,8 +9,7 @@
 #include "remote_service.hpp"
 #include "remote_subscriptions.hpp"
 
-namespace magda {
-namespace remote {
+namespace magda::remote {
 
 namespace {
 
@@ -946,5 +945,4 @@ std::optional<RequestContext> McpEndpoint::requestContext(const Call& call, McpE
     return context;
 }
 
-}  // namespace remote
-}  // namespace magda
+}  // namespace magda::remote

--- a/magda/daw/api/remote_mcp.hpp
+++ b/magda/daw/api/remote_mcp.hpp
@@ -9,8 +9,7 @@
 #include "remote_api.hpp"
 #include "remote_changes.hpp"
 
-namespace magda {
-namespace remote {
+namespace magda::remote {
 
 class RemoteApiService;
 class SubscriptionHub;
@@ -396,5 +395,4 @@ class McpEndpoint {
     std::vector<McpResource> resources_;
 };
 
-}  // namespace remote
-}  // namespace magda
+}  // namespace magda::remote

--- a/magda/daw/api/remote_mcp_server.cpp
+++ b/magda/daw/api/remote_mcp_server.cpp
@@ -39,8 +39,7 @@
 #include "remote_service.hpp"
 #include "remote_subscriptions.hpp"
 
-namespace magda {
-namespace remote {
+namespace magda::remote {
 
 namespace {
 
@@ -1620,5 +1619,4 @@ void RemoteMcpServer::stop() {
     impl_->port.store(0);
 }
 
-}  // namespace remote
-}  // namespace magda
+}  // namespace magda::remote

--- a/magda/daw/api/remote_mcp_server.hpp
+++ b/magda/daw/api/remote_mcp_server.hpp
@@ -6,8 +6,7 @@
 
 #include "remote_mcp.hpp"
 
-namespace magda {
-namespace remote {
+namespace magda::remote {
 
 class RemoteApiService;
 class RemoteAuditLog;
@@ -230,5 +229,4 @@ class RemoteMcpServer {
     std::unique_ptr<Impl> impl_;
 };
 
-}  // namespace remote
-}  // namespace magda
+}  // namespace magda::remote

--- a/magda/daw/api/remote_scopes.hpp
+++ b/magda/daw/api/remote_scopes.hpp
@@ -8,8 +8,7 @@
 #include <optional>
 #include <vector>
 
-namespace magda {
-namespace remote {
+namespace magda::remote {
 
 /**
  * @brief What a remote client is allowed to reach (#1860).
@@ -195,5 +194,4 @@ inline constexpr const char* ANONYMOUS_CLIENT = "unknown";
 /// client chose.
 inline constexpr int MAX_CLIENT_NAME_LENGTH = 64;
 
-}  // namespace remote
-}  // namespace magda
+}  // namespace magda::remote

--- a/magda/daw/api/remote_websocket_server.cpp
+++ b/magda/daw/api/remote_websocket_server.cpp
@@ -39,8 +39,7 @@
 #include "remote_service.hpp"
 #include "remote_subscriptions.hpp"
 
-namespace magda {
-namespace remote {
+namespace magda::remote {
 
 namespace {
 
@@ -1056,5 +1055,4 @@ int RemoteWebSocketServer::connectionCount() const {
     return impl_->connectionCount();
 }
 
-}  // namespace remote
-}  // namespace magda
+}  // namespace magda::remote

--- a/magda/daw/api/remote_websocket_server.hpp
+++ b/magda/daw/api/remote_websocket_server.hpp
@@ -6,8 +6,7 @@
 
 #include "remote_api.hpp"
 
-namespace magda {
-namespace remote {
+namespace magda::remote {
 
 class RemoteApiService;
 class RemoteAuditLog;
@@ -288,5 +287,4 @@ class RemoteWebSocketServer {
     std::unique_ptr<Impl> impl_;
 };
 
-}  // namespace remote
-}  // namespace magda
+}  // namespace magda::remote

--- a/magda/daw/api/transport_api_live.hpp
+++ b/magda/daw/api/transport_api_live.hpp
@@ -6,11 +6,9 @@
 
 #include "transport_api.hpp"
 
-namespace tracktion {
-inline namespace engine {
+namespace tracktion::inline engine {
 class Edit;
 }
-}  // namespace tracktion
 
 namespace magda {
 

--- a/magda/daw/audio/ClipCommands.cpp
+++ b/magda/daw/audio/ClipCommands.cpp
@@ -1489,10 +1489,10 @@ void RenderTimeSelectionCommand::undo() {
 }
 
 // ============================================================================
-static bool trimLoopedClip(ClipManager& clipManager, const ClipInfo& clip, double selStart,
-                           double selEnd, bool ripple, double duration,
-                           std::vector<ClipId>& clipsToDelete, std::vector<ClipId>& clipsToResync,
-                           double tempo) {
+namespace {
+bool trimLoopedClip(ClipManager& clipManager, const ClipInfo& clip, double selStart, double selEnd,
+                    bool ripple, double duration, std::vector<ClipId>& clipsToDelete,
+                    std::vector<ClipId>& clipsToResync, double tempo) {
     if (!clip.loopEnabled)
         return false;
 
@@ -1547,6 +1547,7 @@ static bool trimLoopedClip(ClipManager& clipManager, const ClipInfo& clip, doubl
 
     return true;
 }
+}  // namespace
 
 // ============================================================================
 // DeleteTimeSelectionCommand (no ripple)

--- a/magda/daw/audio/ExternalInsertDeviceEnablement.hpp
+++ b/magda/daw/audio/ExternalInsertDeviceEnablement.hpp
@@ -4,11 +4,9 @@
 
 #include <set>
 
-namespace tracktion {
-inline namespace engine {
+namespace tracktion::inline engine {
 class Edit;
 }
-}  // namespace tracktion
 
 namespace magda {
 

--- a/magda/daw/audio/TrackController.cpp
+++ b/magda/daw/audio/TrackController.cpp
@@ -182,7 +182,8 @@ te::AudioTrack* TrackController::ensureTrackMapping(TrackId trackId, const juce:
 // Find the track's fader VolumeAndPanPlugin (not a Utility instance).
 // The fader is the VolumeAndPanPlugin whose only successors are LevelMeterPlugins.
 // This distinguishes it from Utility plugins which are also VolumeAndPanPlugins.
-static te::VolumeAndPanPlugin* getFaderPlugin(te::AudioTrack* track) {
+namespace {
+te::VolumeAndPanPlugin* getFaderPlugin(te::AudioTrack* track) {
     if (!track)
         return nullptr;
     auto& plugins = track->pluginList;
@@ -201,6 +202,7 @@ static te::VolumeAndPanPlugin* getFaderPlugin(te::AudioTrack* track) {
     // Fallback to TE's default
     return track->getVolumePlugin();
 }
+}  // namespace
 
 void TrackController::setTrackVolume(TrackId trackId, float volume) {
     auto* track = getAudioTrack(trackId);

--- a/magda/daw/audio/analysis/OfflineMixAnalysis.cpp
+++ b/magda/daw/audio/analysis/OfflineMixAnalysis.cpp
@@ -12,8 +12,7 @@
 #include "../../engine/AudioEngine.hpp"
 #include "MixAnalysisInput.hpp"
 
-namespace magda {
-namespace daw::audio {
+namespace magda::daw::audio {
 
 namespace {
 
@@ -454,5 +453,4 @@ OfflineMixAnalysis::CancelToken OfflineMixAnalysis::start(AudioEngine& engine, R
     return cancel;
 }
 
-}  // namespace daw::audio
-}  // namespace magda
+}  // namespace magda::daw::audio

--- a/magda/daw/audio/automation/AutomationRecordingEngine.cpp
+++ b/magda/daw/audio/automation/AutomationRecordingEngine.cpp
@@ -12,16 +12,19 @@
 namespace magda {
 
 // Convert linear gain to dB (same formula as AutomationManager.cpp)
-static float gainToDb(float gain) {
+namespace {
+float gainToDb(float gain) {
     constexpr float MIN_DB = -60.0f;
     if (gain <= 0.0f)
         return MIN_DB;
     return 20.0f * std::log10(gain);
 }
+}  // namespace
 
 AutomationRecordingEngine::AutomationRecordingEngine(te::Edit& edit) : edit_(edit) {}
 
-static const char* modeName(AutomationMode m) {
+namespace {
+const char* modeName(AutomationMode m) {
     switch (m) {
         case AutomationMode::Off:
             return "OFF";
@@ -34,6 +37,7 @@ static const char* modeName(AutomationMode m) {
     }
     return "?";
 }
+}  // namespace
 
 void AutomationRecordingEngine::setMode(AutomationMode mode) {
     if (mode == mode_)

--- a/magda/daw/audio/insert_capture/InsertRenderCaptureService.hpp
+++ b/magda/daw/audio/insert_capture/InsertRenderCaptureService.hpp
@@ -5,11 +5,9 @@
 #include <functional>
 #include <memory>
 
-namespace tracktion {
-inline namespace engine {
+namespace tracktion::inline engine {
 class Edit;
-}  // namespace engine
-}  // namespace tracktion
+}  // namespace tracktion::inline engine
 
 namespace magda {
 

--- a/magda/daw/audio/plugins/DrumGridRoles.hpp
+++ b/magda/daw/audio/plugins/DrumGridRoles.hpp
@@ -4,13 +4,11 @@
 
 #include <array>
 
-namespace magda::daw::audio {
-
 // Closed vocabulary of drum-row roles used by the drummer agent (#859) and the
 // Drum Grid templates. Role IDs are the canonical strings written to the
 // ValueTree and emitted by the agent as drum tokens. Display labels are for
 // menu UI; short tags are the small badge rendered next to the row label.
-namespace drum_grid_roles {
+namespace magda::daw::audio::drum_grid_roles {
 
 struct RoleInfo {
     const char* id;            // canonical ID, persisted + agent token
@@ -82,5 +80,4 @@ inline juce::String roleIdForToken(const juce::String& token) {
     return {};
 }
 
-}  // namespace drum_grid_roles
-}  // namespace magda::daw::audio
+}  // namespace magda::daw::audio::drum_grid_roles

--- a/magda/daw/audio/plugins/DrumGridTemplates.hpp
+++ b/magda/daw/audio/plugins/DrumGridTemplates.hpp
@@ -4,14 +4,12 @@
 
 #include <array>
 
-namespace magda::daw::audio {
-
 // Built-in row templates for the Drum Grid. Applying a template stamps
 // (label, role) pairs onto the kit's existing chains in low-note order; chains
 // beyond the template's row count are left untouched, and template rows beyond
 // the chain count are dropped. Chains are not created or deleted — only the
 // label (Chain.name) and role (Chain.role) are rewritten.
-namespace drum_grid_templates {
+namespace magda::daw::audio::drum_grid_templates {
 
 struct Row {
     const char* label;
@@ -66,5 +64,4 @@ inline constexpr std::array<Template, 3> kBuiltIn{{
     {"Classic 9-Pad", kNinePadRows.data(), static_cast<int>(kNinePadRows.size())},
 }};
 
-}  // namespace drum_grid_templates
-}  // namespace magda::daw::audio
+}  // namespace magda::daw::audio::drum_grid_templates

--- a/magda/daw/audio/session/ClipSynchronizer.cpp
+++ b/magda/daw/audio/session/ClipSynchronizer.cpp
@@ -247,8 +247,8 @@ void ClipSynchronizer::reallocateAndNotify() {
     }
 }
 
-static void syncAudioSourceInterpretationToLoopInfo(te::WaveAudioClip& audioClip,
-                                                    const ClipInfo& clip) {
+namespace {
+void syncAudioSourceInterpretationToLoopInfo(te::WaveAudioClip& audioClip, const ClipInfo& clip) {
     auto waveInfo = audioClip.getWaveInfo();
     auto& li = audioClip.getLoopInfo();
 
@@ -265,7 +265,7 @@ static void syncAudioSourceInterpretationToLoopInfo(te::WaveAudioClip& audioClip
 
 /// Seed the interpretation from Tracktion's loopInfo, filling gaps only. The
 /// file duration is a Source fact, so it lands on the pooled source.
-static void seedInterpretationFromLoopInfo(ClipInfo& clip, double numBeats, double bpm) {
+void seedInterpretationFromLoopInfo(ClipInfo& clip, double numBeats, double bpm) {
     auto* event = clip.primaryEvent();
     if (event == nullptr)
         return;
@@ -286,7 +286,7 @@ static void seedInterpretationFromLoopInfo(ClipInfo& clip, double numBeats, doub
 /// A session clip imported before its source beat domain was known carries a
 /// zero-length loop region, meaning "the whole source". Give it a real one now
 /// that the interpretation has arrived.
-static void initialiseSourceLoopRegionFromMetadata(ClipInfo& clip) {
+void initialiseSourceLoopRegionFromMetadata(ClipInfo& clip) {
     auto* event = clip.primaryEvent();
     if (event == nullptr || !event->autoTempo || event->loopLengthSamples > 0)
         return;
@@ -297,6 +297,7 @@ static void initialiseSourceLoopRegionFromMetadata(ClipInfo& clip) {
     event->setLoopStartBeats(startBeats);
     event->setLoopLengthBeats(juce::jmax(0.0, event->interpTotalBeats - startBeats));
 }
+}  // namespace
 
 ClipSynchronizer::ClipSynchronizer(te::Edit& edit, TrackController& trackController,
                                    WarpMarkerManager& warpMarkerManager)
@@ -1411,10 +1412,11 @@ void ClipSynchronizer::removeWarpMarker(ClipId clipId, int index) {
  * @param visibleEnd      End of visible range in beats
  * @param contentLengthBeats  Maximum beat position
  */
+namespace {
 template <typename EventType>
-static void interpolateCCEvents(te::MidiList& sequence, const std::vector<EventType>& events,
-                                int controllerType, double effectiveOffset, double visibleStart,
-                                double visibleEnd, double contentLengthBeats) {
+void interpolateCCEvents(te::MidiList& sequence, const std::vector<EventType>& events,
+                         int controllerType, double effectiveOffset, double visibleStart,
+                         double visibleEnd, double contentLengthBeats) {
     if (events.empty())
         return;
 
@@ -1545,8 +1547,8 @@ static void interpolateCCEvents(te::MidiList& sequence, const std::vector<EventT
 // clipShift accounts for the note having been clipped at the visible-range
 // left edge: expression beats are relative to the original note start, the
 // TE note starts at the clipped position.
-static void addPitchExpressionToTeNote(te::MidiNote& teNote, const MidiNote& note, double clipShift,
-                                       double visibleLengthBeats) {
+void addPitchExpressionToTeNote(te::MidiNote& teNote, const MidiNote& note, double clipShift,
+                                double visibleLengthBeats) {
     constexpr double kStepSize = 1.0 / 16.0;
     constexpr float kMaxSemitones = 48.0f;  // TE's fixed MPE pitchbend conversion range
 
@@ -1586,6 +1588,7 @@ static void addPitchExpressionToTeNote(te::MidiNote& teNote, const MidiNote& not
         addExpressionEvent(pointBeat, v2);
     }
 }
+}  // namespace
 
 // =============================================================================
 // Private Sync Helpers

--- a/magda/daw/core/AutomationCommands.cpp
+++ b/magda/daw/core/AutomationCommands.cpp
@@ -14,13 +14,11 @@ bool pointIsInDuplicateRange(double beatPosition, double startBeat, double endBe
     return beatPosition >= startBeat - epsilon && beatPosition <= endBeat + epsilon;
 }
 
-}  // namespace
-
 // ============================================================================
 // Helper: find a point in a lane or clip
 // ============================================================================
 
-static const AutomationPoint* findPointInLane(AutomationLaneId laneId, AutomationPointId pointId) {
+const AutomationPoint* findPointInLane(AutomationLaneId laneId, AutomationPointId pointId) {
     auto* lane = AutomationManager::getInstance().getLane(laneId);
     if (!lane)
         return nullptr;
@@ -29,7 +27,7 @@ static const AutomationPoint* findPointInLane(AutomationLaneId laneId, Automatio
     return found == lane->absolutePoints.end() ? nullptr : &(*found);
 }
 
-static const AutomationPoint* findPointInClip(AutomationClipId clipId, AutomationPointId pointId) {
+const AutomationPoint* findPointInClip(AutomationClipId clipId, AutomationPointId pointId) {
     auto* clip = AutomationManager::getInstance().getClip(clipId);
     if (!clip)
         return nullptr;
@@ -38,10 +36,11 @@ static const AutomationPoint* findPointInClip(AutomationClipId clipId, Automatio
     return found == clip->points.end() ? nullptr : &(*found);
 }
 
-static const AutomationPoint* findPoint(bool isClip, AutomationLaneId laneId,
-                                        AutomationClipId clipId, AutomationPointId pointId) {
+const AutomationPoint* findPoint(bool isClip, AutomationLaneId laneId, AutomationClipId clipId,
+                                 AutomationPointId pointId) {
     return isClip ? findPointInClip(clipId, pointId) : findPointInLane(laneId, pointId);
 }
+}  // namespace
 
 // ============================================================================
 // AddAutomationPointCommand

--- a/magda/daw/core/AutomationManager.cpp
+++ b/magda/daw/core/AutomationManager.cpp
@@ -34,18 +34,15 @@ bool isPostFxAutomationTarget(const AutomationTarget& target) {
     return false;
 }
 
-}  // namespace
-
 // Convert linear gain to dB
-static float gainToDb(float gain) {
+float gainToDb(float gain) {
     constexpr float MIN_DB = -60.0f;
     if (gain <= 0.0f)
         return MIN_DB;
     return 20.0f * std::log10(gain);
 }
 
-static double deviceCurrentValueToLaneNormalized(float currentValue,
-                                                 const ParameterInfo& paramInfo) {
+double deviceCurrentValueToLaneNormalized(float currentValue, const ParameterInfo& paramInfo) {
     // Symmetric inverse of the playback writeback (normalizedToModelValue), so
     // the seed point matches where the curve will drive the param. Crucially
     // this honours isDisplayMappedInternalValue: compiled/internal params whose
@@ -57,7 +54,7 @@ static double deviceCurrentValueToLaneNormalized(float currentValue,
 }
 
 // Get current normalized value for an automation target
-static std::optional<double> getCurrentTargetValueImpl(const AutomationTarget& target) {
+std::optional<double> getCurrentTargetValueImpl(const AutomationTarget& target) {
     // Get parameter info for proper conversion
     ParameterInfo paramInfo = getParameterInfoForTarget(target);
 
@@ -200,6 +197,7 @@ static std::optional<double> getCurrentTargetValueImpl(const AutomationTarget& t
             return std::nullopt;
     }
 }
+}  // namespace
 
 AutomationManager& AutomationManager::getInstance() {
     static AutomationManager instance;

--- a/magda/daw/core/Config.hpp
+++ b/magda/daw/core/Config.hpp
@@ -1527,7 +1527,7 @@ class Config {
 
     // Browser favorites and default directory
     std::vector<std::string> browserFavorites;
-    std::string browserDefaultDirectory = "";  // empty = user home
+    std::string browserDefaultDirectory;  // empty = user home
 
     // Which view the media explorer should restore on startup.
     // "filesystem" → file browser at browserDefaultDirectory.
@@ -1539,11 +1539,11 @@ class Config {
 
     // Optional override for the Sample Tagger ONNX bundle location.
     // Empty = use the default dataDir/MediaDB/models.
-    std::string sampleTaggerModelsDir = "";
+    std::string sampleTaggerModelsDir;
 
     // Optional override for the command-model ONNX bundle location.
     // Empty = use the default dataDir/CommandModel/models.
-    std::string commandModelModelsDir = "";
+    std::string commandModelModelsDir;
 
     // Eagerly load the Sample Tagger encoders + tokenizer at startup
     // (vs lazy on first query).
@@ -1551,10 +1551,10 @@ class Config {
 
     // Optional override for the media DB directory. Empty = default
     // (dataDir/MediaDB).
-    std::string mediaDbDir = "";
+    std::string mediaDbDir;
 
     // External sample editor executable/application path.
-    std::string externalAudioEditorPath = "";
+    std::string externalAudioEditorPath;
 
     // Auto-update check
     bool autoCheckUpdates = true;          // Check GitHub for newer releases on startup
@@ -1587,11 +1587,11 @@ class Config {
 
     // Configurable user-data path overrides (resolved by magda::paths).
     // Empty = OS default. Persisted in config.json.
-    std::string dataDir = "";     // userApplicationDataDirectory/MAGDA/
-    std::string presetsDir = "";  // userDocumentsDirectory/MAGDA/Presets/
+    std::string dataDir;     // userApplicationDataDirectory/MAGDA/
+    std::string presetsDir;  // userDocumentsDirectory/MAGDA/Presets/
 
     // Render settings
-    std::string renderFolder = "";  // Custom render output folder (empty = renders/ beside source)
+    std::string renderFolder;  // Custom render output folder (empty = renders/ beside source)
     double renderSampleRate = 44100.0;  // 44100, 48000, 96000, 192000
     int renderBitDepth = 24;            // 16, 24, 32
     // File naming pattern tokens: <project-name>, <clip-name>, <track-name>, <date-time>
@@ -1601,11 +1601,11 @@ class Config {
     int bounceBitDepth = 32;  // 16, 24, 32 — default 32-bit for internal bounces
 
     // Audio device settings
-    std::string preferredAudioDevice = "";   // Preferred audio interface (empty = system default)
-    std::string preferredInputDevice = "";   // Preferred input device (empty = system default)
-    std::string preferredOutputDevice = "";  // Preferred output device (empty = system default)
-    int preferredInputChannels = 0;   // Preferred input channel count (0 = use device default)
-    int preferredOutputChannels = 0;  // Preferred output channel count (0 = use device default)
+    std::string preferredAudioDevice;   // Preferred audio interface (empty = system default)
+    std::string preferredInputDevice;   // Preferred input device (empty = system default)
+    std::string preferredOutputDevice;  // Preferred output device (empty = system default)
+    int preferredInputChannels = 0;     // Preferred input channel count (0 = use device default)
+    int preferredOutputChannels = 0;    // Preferred output channel count (0 = use device default)
 
     // Language
     std::string language = "en";  // Language code, matches lang/<code>.json

--- a/magda/daw/core/ParameterUtils.cpp
+++ b/magda/daw/core/ParameterUtils.cpp
@@ -7,8 +7,7 @@
 #include "TechnicalText.hpp"
 #include "TempoUtils.hpp"
 
-namespace magda {
-namespace ParameterUtils {
+namespace magda::ParameterUtils {
 
 namespace {
 
@@ -824,5 +823,4 @@ juce::String getChoiceString(int index, const ParameterInfo& info) {
     return juce::String(index);
 }
 
-}  // namespace ParameterUtils
-}  // namespace magda
+}  // namespace magda::ParameterUtils

--- a/magda/daw/core/ParameterUtils.hpp
+++ b/magda/daw/core/ParameterUtils.hpp
@@ -8,8 +8,7 @@
 
 #include "ParameterInfo.hpp"
 
-namespace magda {
-namespace ParameterUtils {
+namespace magda::ParameterUtils {
 
 /**
  * @brief The part of a ParameterInfo that decides what a normalized position means.
@@ -289,5 +288,4 @@ juce::String getChoiceString(int index, const ParameterInfo& info);
  */
 double snapNormalizedToGrid(double normalized, const ParameterInfo& info);
 
-}  // namespace ParameterUtils
-}  // namespace magda
+}  // namespace magda::ParameterUtils

--- a/magda/daw/core/SessionLaunchService.hpp
+++ b/magda/daw/core/SessionLaunchService.hpp
@@ -4,8 +4,6 @@
 
 #include "TypeIds.hpp"
 
-namespace magda {
-
 /// Centralised scene-launch / stop-track / group-scene semantics.
 ///
 /// Both the SessionView (UI scene buttons) and SessionApi (Lua / scripts /
@@ -17,7 +15,7 @@ namespace magda {
 /// All entry points are stateless and read singletons (ClipManager,
 /// TrackManager) directly. Keep them small — this is glue, not a
 /// reimplementation of playback logic.
-namespace SessionLaunchService {
+namespace magda::SessionLaunchService {
 
 /// Apply scene-launch semantics to a specific list of tracks.
 /// For each track: trigger (track, sceneIndex) if a clip exists, else stop
@@ -29,6 +27,4 @@ void launchScene(const std::vector<TrackId>& trackIds, int sceneIndex);
 /// callers usually pass their visible-track subset to launchScene() above.
 void launchSceneAllTracks(int sceneIndex);
 
-}  // namespace SessionLaunchService
-
-}  // namespace magda
+}  // namespace magda::SessionLaunchService

--- a/magda/daw/core/TrackManagerDevices.cpp
+++ b/magda/daw/core/TrackManagerDevices.cpp
@@ -652,12 +652,13 @@ void TrackManager::setDeviceInChainBypassed(TrackId trackId, RackId rackId, Chai
  * (`toChainNodePath` builds them from whatever steps arrive). One body means
  * one set of rules for both.
  */
-static ChainInfo* getChainFromPath(TrackManager& tm, const ChainNodePath& chainPath) {
+namespace {
+ChainInfo* getChainFromPath(TrackManager& tm, const ChainNodePath& chainPath) {
     return tm.getChainByPath(chainPath);
 }
 
-static std::vector<ChainElement>* getElementContainerForChainPath(TrackManager& tm,
-                                                                  const ChainNodePath& chainPath) {
+std::vector<ChainElement>* getElementContainerForChainPath(TrackManager& tm,
+                                                           const ChainNodePath& chainPath) {
     if (chainPath.trackId == INVALID_TRACK_ID)
         return nullptr;
 
@@ -673,13 +674,15 @@ static std::vector<ChainElement>* getElementContainerForChainPath(TrackManager& 
     return nullptr;
 }
 
-static ChainNodePath getParentChainPathForElementPath(const ChainNodePath& elementPath) {
+ChainNodePath getParentChainPathForElementPath(const ChainNodePath& elementPath) {
     return elementPath.parentChain();
 }
+}  // namespace
 
 using DevicePathMap = std::map<DeviceId, ChainNodePath>;
 
-static void retargetMovedTarget(ControlTarget& target, const DevicePathMap& movedPaths) {
+namespace {
+void retargetMovedTarget(ControlTarget& target, const DevicePathMap& movedPaths) {
     const auto deviceId = target.devicePath.getDeviceId();
     if (deviceId == INVALID_DEVICE_ID)
         return;
@@ -689,8 +692,7 @@ static void retargetMovedTarget(ControlTarget& target, const DevicePathMap& move
         target.devicePath = it->second;
 }
 
-static void retargetMovedLinks(MacroArray& macros, ModArray& mods,
-                               const DevicePathMap& movedPaths) {
+void retargetMovedLinks(MacroArray& macros, ModArray& mods, const DevicePathMap& movedPaths) {
     for (auto& macro : macros) {
         for (auto& link : macro.links)
             retargetMovedTarget(link.target, movedPaths);
@@ -710,8 +712,8 @@ static void retargetMovedLinks(MacroArray& macros, ModArray& mods,
 /// holding the path it had on the track it came from -- a device id that
 /// `retargetMovedTarget` never found, so the whole address survived unchanged
 /// (#2204).
-static void collectMovedDevicePaths(const ChainElement& element, const ChainNodePath& elementPath,
-                                    DevicePathMap& movedPaths) {
+void collectMovedDevicePaths(const ChainElement& element, const ChainNodePath& elementPath,
+                             DevicePathMap& movedPaths) {
     const std::span<const ChainElement> subtree{&element, 1};
     const auto parentPath =
         magda::isDevice(element) ? elementPath.parentChain() : elementPath.parent();
@@ -728,9 +730,8 @@ static void collectMovedDevicePaths(const ChainElement& element, const ChainNode
 /// modifier on one pointing at its own parameter is the ordinary case. This
 /// descended only through racks, so such a link went on naming the track its
 /// grid came from (#2204).
-static void retargetLinksInElements(std::vector<ChainElement>& elements,
-                                    const ChainNodePath& parentPath,
-                                    const DevicePathMap& movedPaths) {
+void retargetLinksInElements(std::vector<ChainElement>& elements, const ChainNodePath& parentPath,
+                             const DevicePathMap& movedPaths) {
     // The real parent, not the track: these run over a nested chain's elements
     // as well as a track's own list, and a walk told the wrong parent spells
     // every device in it as top-level. Nothing here reads the address it
@@ -746,20 +747,18 @@ static void retargetLinksInElements(std::vector<ChainElement>& elements,
         });
 }
 
-static void retargetMovedLinksInTrack(TrackInfo& track, const DevicePathMap& movedPaths) {
+void retargetMovedLinksInTrack(TrackInfo& track, const DevicePathMap& movedPaths) {
     retargetMovedLinks(track.macros, track.mods, movedPaths);
     retargetLinksInElements(track.chain.fxChainElements, ChainNodePath::trackLevel(track.id),
                             movedPaths);
 }
 
-static bool targetPointsAtMovedDevice(const ControlTarget& target,
-                                      const DevicePathMap& movedPaths) {
+bool targetPointsAtMovedDevice(const ControlTarget& target, const DevicePathMap& movedPaths) {
     const auto deviceId = target.devicePath.getDeviceId();
     return deviceId != INVALID_DEVICE_ID && movedPaths.find(deviceId) != movedPaths.end();
 }
 
-static void removeMovedTargets(MacroArray& macros, ModArray& mods,
-                               const DevicePathMap& movedPaths) {
+void removeMovedTargets(MacroArray& macros, ModArray& mods, const DevicePathMap& movedPaths) {
     for (auto& macro : macros) {
         macro.links.erase(std::remove_if(macro.links.begin(), macro.links.end(),
                                          [&movedPaths](const MacroLink& link) {
@@ -783,9 +782,9 @@ static void removeMovedTargets(MacroArray& macros, ModArray& mods,
 ///
 /// The mirror of the above, and it skipped pads the same way: a pad device
 /// staying put kept a link to something no longer on its track (#2204).
-static void removeMovedTargetsInElements(std::vector<ChainElement>& elements,
-                                         const ChainNodePath& parentPath,
-                                         const DevicePathMap& movedPaths) {
+void removeMovedTargetsInElements(std::vector<ChainElement>& elements,
+                                  const ChainNodePath& parentPath,
+                                  const DevicePathMap& movedPaths) {
     chain_walk::forEachNode(
         elements, parentPath, chain_walk::Pads::Enter,
         [&movedPaths](DeviceInfo& device, const ChainNodePath&) {
@@ -797,14 +796,14 @@ static void removeMovedTargetsInElements(std::vector<ChainElement>& elements,
         });
 }
 
-static void removeMovedTargetsInTrack(TrackInfo& track, const DevicePathMap& movedPaths) {
+void removeMovedTargetsInTrack(TrackInfo& track, const DevicePathMap& movedPaths) {
     removeMovedTargets(track.macros, track.mods, movedPaths);
     removeMovedTargetsInElements(track.chain.fxChainElements, ChainNodePath::trackLevel(track.id),
                                  movedPaths);
 }
 
-static ChainNodePath getInsertedElementPath(const ChainNodePath& destinationChainPath,
-                                            const ChainElement& element) {
+ChainNodePath getInsertedElementPath(const ChainNodePath& destinationChainPath,
+                                     const ChainElement& element) {
     if (magda::isDevice(element)) {
         const auto deviceId = magda::getDevice(element).id;
         if (destinationChainPath.steps.empty())
@@ -815,8 +814,8 @@ static ChainNodePath getInsertedElementPath(const ChainNodePath& destinationChai
     return destinationChainPath.withRack(magda::getRack(element).id);
 }
 
-static void reassignCopiedElementIds(TrackManager& tm, std::vector<ChainElement>& elements,
-                                     TrackId targetTrackId) {
+void reassignCopiedElementIds(TrackManager& tm, std::vector<ChainElement>& elements,
+                              TrackId targetTrackId) {
     PresetIdRemap remap;
     remap.trackId = targetTrackId;
 
@@ -832,8 +831,8 @@ static void reassignCopiedElementIds(TrackManager& tm, std::vector<ChainElement>
     remapPresetLinksRecursive(elements, remap);
 }
 
-static bool chainPathContainsRack(const ChainNodePath& destinationChainPath,
-                                  const ChainNodePath& sourceRackPath) {
+bool chainPathContainsRack(const ChainNodePath& destinationChainPath,
+                           const ChainNodePath& sourceRackPath) {
     if (sourceRackPath.steps.empty() || sourceRackPath.steps.back().type != ChainStepType::Rack ||
         destinationChainPath.steps.size() <= sourceRackPath.steps.size()) {
         return false;
@@ -843,7 +842,7 @@ static bool chainPathContainsRack(const ChainNodePath& destinationChainPath,
                       destinationChainPath.steps.begin());
 }
 
-static bool elementContainsInstrument(const ChainElement& element) {
+bool elementContainsInstrument(const ChainElement& element) {
     if (magda::isDevice(element))
         return magda::getDevice(element).isInstrument;
 
@@ -856,6 +855,7 @@ static bool elementContainsInstrument(const ChainElement& element) {
     }
     return false;
 }
+}  // namespace
 
 /// The chain element @p path addresses, device or rack, or null.
 const ChainElement* findChainElement(TrackManager& tm, const ChainNodePath& path) {

--- a/magda/daw/core/aliases/AutoAliasGenerator.cpp
+++ b/magda/daw/core/aliases/AutoAliasGenerator.cpp
@@ -9,9 +9,11 @@ namespace magda {
 // pluginNameToAlias -- maps a plugin display name to a canonical alias key
 // ============================================================================
 
-static juce::String pluginNameToAlias(const juce::String& pluginName) {
+namespace {
+juce::String pluginNameToAlias(const juce::String& pluginName) {
     return normalizeParamName(pluginName);
 }
+}  // namespace
 
 // ============================================================================
 // computeForDevice

--- a/magda/daw/core/controllers/BindingRegistry.cpp
+++ b/magda/daw/core/controllers/BindingRegistry.cpp
@@ -18,18 +18,19 @@ BindingRegistry& BindingRegistry::getInstance() {
 // Internal helpers
 // ============================================================================
 
-static std::vector<Binding>& scopeVec(BindingScope scope, std::vector<Binding>& global,
-                                      std::vector<Binding>& project) {
+namespace {
+std::vector<Binding>& scopeVec(BindingScope scope, std::vector<Binding>& global,
+                               std::vector<Binding>& project) {
     return scope == BindingScope::Global ? global : project;
 }
 
 // NOLINTNEXTLINE(bugprone-return-const-ref-from-parameter) - the only caller
 // passes long-lived members, never a temporary
-static const std::vector<Binding>& scopeVecConst(BindingScope scope,
-                                                 const std::vector<Binding>& global,
-                                                 const std::vector<Binding>& project) {
+const std::vector<Binding>& scopeVecConst(BindingScope scope, const std::vector<Binding>& global,
+                                          const std::vector<Binding>& project) {
     return scope == BindingScope::Global ? global : project;
 }
+}  // namespace
 
 // ============================================================================
 // CRUD

--- a/magda/daw/engine/MagdaUIBehaviour.hpp
+++ b/magda/daw/engine/MagdaUIBehaviour.hpp
@@ -4,12 +4,10 @@
 
 #include "../ui/components/common/FloatingHostWindow.hpp"
 
-namespace tracktion {
-inline namespace engine {
+namespace tracktion::inline engine {
 class Plugin;
 struct PluginWindowState;
-}  // namespace engine
-}  // namespace tracktion
+}  // namespace tracktion::inline engine
 
 namespace magda {
 

--- a/magda/daw/engine/plugin_scanner_main.cpp
+++ b/magda/daw/engine/plugin_scanner_main.cpp
@@ -18,10 +18,11 @@
 
 // Global log file for debugging - scanner stdout isn't visible when run as child process
 // Uses juce::FileOutputStream for Unicode-safe paths on Windows
-static std::unique_ptr<juce::FileOutputStream> g_logStream;
-static juce::File g_logFile;
+namespace {
+std::unique_ptr<juce::FileOutputStream> g_logStream;
+juce::File g_logFile;
 
-static void initLog() {
+void initLog() {
     // Use a unique temp file per instance (random suffix)
     auto suffix = juce::String(juce::Random::getSystemRandom().nextInt64());
     auto tempDir = juce::File::getSpecialLocation(juce::File::tempDirectory);
@@ -29,13 +30,13 @@ static void initLog() {
     g_logStream = g_logFile.createOutputStream();
 }
 
-static void cleanupLog() {
+void cleanupLog() {
     g_logStream.reset();
     if (g_logFile.existsAsFile())
         g_logFile.deleteFile();
 }
 
-static void log(const std::string& msg) {
+void log(const std::string& msg) {
     if (g_logStream) {
         g_logStream->writeText(msg + "\n", false, false, nullptr);
         g_logStream->flush();
@@ -43,6 +44,7 @@ static void log(const std::string& msg) {
     std::cout << msg << std::endl;
     std::cout.flush();
 }
+}  // namespace
 
 namespace ScannerIPC {
 constexpr const char* MSG_SCAN_ONE = "SCNO";

--- a/magda/daw/magda.cpp
+++ b/magda/daw/magda.cpp
@@ -6,7 +6,9 @@
 #include "engine/TracktionEngineWrapper.hpp"
 
 // Global engine instance
-static std::unique_ptr<magda::TracktionEngineWrapper> g_engine;
+namespace {
+std::unique_ptr<magda::TracktionEngineWrapper> g_engine;
+}  // namespace
 
 bool magda_initialize() {
     DBG("MAGDA v" << MAGDA_VERSION << " - Multi-Agent Generative Interface for Creative Audio");

--- a/magda/daw/ui/code/DSLTokeniser.cpp
+++ b/magda/daw/ui/code/DSLTokeniser.cpp
@@ -60,7 +60,8 @@ bool DSLTokeniser::isNoteName(const juce::String& token) {
 
 // Consumes the digits of a number, plus a fractional part if one follows.
 // Assumes any sign has already been consumed.
-static void readNumberBody(juce::CodeDocument::Iterator& source) {
+namespace {
+void readNumberBody(juce::CodeDocument::Iterator& source) {
     while (juce::CharacterFunctions::isDigit(source.peekNextChar()))
         source.skip();
     if (source.peekNextChar() == '.') {
@@ -69,6 +70,7 @@ static void readNumberBody(juce::CodeDocument::Iterator& source) {
             source.skip();
     }
 }
+}  // namespace
 
 int DSLTokeniser::readNextToken(juce::CodeDocument::Iterator& source) {
     source.skipWhitespace();

--- a/magda/daw/ui/components/automation/AutomationLaneComponent.cpp
+++ b/magda/daw/ui/components/automation/AutomationLaneComponent.cpp
@@ -659,10 +659,12 @@ void AutomationLaneComponent::simplifyLane(AutomationLaneId laneId, double epsil
 }
 
 // Convert real value to normalized position using ParameterInfo
-static double realToNormalizedForTarget(double realValue, const ParameterInfo& info) {
+namespace {
+double realToNormalizedForTarget(double realValue, const ParameterInfo& info) {
     return static_cast<double>(
         ParameterUtils::realToNormalized(static_cast<float>(realValue), info));
 }
+}  // namespace
 
 void AutomationLaneComponent::paintScaleLabels(juce::Graphics& g, juce::Rectangle<int> area) {
     if (area.getHeight() <= 0 || area.getWidth() < 25)

--- a/magda/daw/ui/components/chain/RackComponent.cpp
+++ b/magda/daw/ui/components/chain/RackComponent.cpp
@@ -994,7 +994,7 @@ void RackComponent::showSaveRackPresetDialog() {
 
     auto* aw = new juce::AlertWindow(
         "Save MAGDA Rack Preset",
-        "Enter a name for this rack preset (use \"/\" to nest, e.g. \"Drums/808 Stack\"):",
+        R"(Enter a name for this rack preset (use "/" to nest, e.g. "Drums/808 Stack"):)",
         juce::MessageBoxIconType::NoIcon);
     aw->addTextEditor("name", defaultName, "Name:");
     aw->addButton("Save", 1, juce::KeyPress(juce::KeyPress::returnKey));

--- a/magda/daw/ui/components/chain/custom_ui/FourOscUI.cpp
+++ b/magda/daw/ui/components/chain/custom_ui/FourOscUI.cpp
@@ -189,8 +189,8 @@ std::vector<LinkableTextSlider*> FourOscUI::getLinkableSliders() {
 // Helper: setup a small label
 // =============================================================================
 
-static void setupLabelStatic(juce::Label& label, const juce::String& text,
-                             juce::Component* parent) {
+namespace {
+void setupLabelStatic(juce::Label& label, const juce::String& text, juce::Component* parent) {
     label.setText(text, juce::dontSendNotification);
     label.setFont(FontManager::getInstance().getUIFont(9.0f));
     label.setColour(juce::Label::textColourId, DarkTheme::getSecondaryTextColour());
@@ -206,7 +206,7 @@ static void setupLabelStatic(juce::Label& label, const juce::String& text,
 // Helper: populate waveform icon selector (shared by OscTab + LFOTab)
 // =============================================================================
 
-static void populateWaveSelector(IconSelector& selector) {
+void populateWaveSelector(IconSelector& selector) {
     // Matches Oscillator::Waves enum: none=0, sine=1, square=2, saw=3, triangle=4, noise=5
     selector.addTextOption("Off", "Off");
     selector.addOption(BinaryData::fadmodsine_svg, BinaryData::fadmodsine_svgSize, "Sine");
@@ -215,6 +215,7 @@ static void populateWaveSelector(IconSelector& selector) {
     selector.addOption(BinaryData::fadmodtri_svg, BinaryData::fadmodtri_svgSize, "Triangle");
     selector.addOption(BinaryData::fadmodrandom_svg, BinaryData::fadmodrandom_svgSize, "Noise");
 }
+}  // namespace
 
 // =============================================================================
 // OscTab

--- a/magda/daw/ui/components/chain/custom_ui/ImpulseResponseUI.cpp
+++ b/magda/daw/ui/components/chain/custom_ui/ImpulseResponseUI.cpp
@@ -9,14 +9,15 @@
 
 namespace magda::daw::ui {
 
-static void setupLabelStatic(juce::Label& label, const juce::String& text,
-                             juce::Component* parent) {
+namespace {
+void setupLabelStatic(juce::Label& label, const juce::String& text, juce::Component* parent) {
     label.setText(text, juce::dontSendNotification);
     label.setFont(FontManager::getInstance().getUIFont(9.0f));
     label.setColour(juce::Label::textColourId, DarkTheme::getSecondaryTextColour());
     label.setJustificationType(juce::Justification::centred);
     parent->addAndMakeVisible(label);
 }
+}  // namespace
 
 ImpulseResponseUI::ImpulseResponseUI() {
     // IR name label

--- a/magda/daw/ui/components/chain/custom_ui/StepSequencerUI.cpp
+++ b/magda/daw/ui/components/chain/custom_ui/StepSequencerUI.cpp
@@ -9,7 +9,9 @@ using SeqPlugin = daw::audio::StepSequencerPlugin;
 
 std::atomic<int> StepSequencerUI::nextPatternGesture_{magda::kNoStepPatternGesture + 1};
 
-static const char* NOTE_NAMES[] = {"C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"};
+namespace {
+const char* NOTE_NAMES[] = {"C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"};
+}  // namespace
 
 juce::String StepSequencerUI::noteNameShort(int noteNumber) {
     if (noteNumber < 0 || noteNumber > 127)

--- a/magda/daw/ui/components/chain/custom_ui/StruckInstrumentUI.cpp
+++ b/magda/daw/ui/components/chain/custom_ui/StruckInstrumentUI.cpp
@@ -186,9 +186,11 @@ float StruckInstrumentUI::decayNorm() const {
 }
 
 // The body graphic occupies the body panel minus padding and a caption strip.
-static juce::Rectangle<float> graphicRect(juce::Rectangle<int> bodyArea) {
+namespace {
+juce::Rectangle<float> graphicRect(juce::Rectangle<int> bodyArea) {
     return bodyArea.reduced(18).withTrimmedBottom(14).toFloat();
 }
+}  // namespace
 
 juce::Point<float> StruckInstrumentUI::strikePoint() const {
     const auto gr = graphicRect(bodyArea_);

--- a/magda/daw/ui/components/chain/drum_grid/DeviceSlotDrumGridBridge.hpp
+++ b/magda/daw/ui/components/chain/drum_grid/DeviceSlotDrumGridBridge.hpp
@@ -16,11 +16,9 @@
 #include "core/SelectionManager.hpp"
 #include "core/TypeIds.hpp"
 
-namespace tracktion {
-inline namespace engine {
+namespace tracktion::inline engine {
 class Plugin;
 }
-}  // namespace tracktion
 
 namespace magda::daw::ui {
 

--- a/magda/daw/ui/components/chain/drum_grid/DrumGridUI.cpp
+++ b/magda/daw/ui/components/chain/drum_grid/DrumGridUI.cpp
@@ -573,7 +573,8 @@ bool DrumGridUI::isInterestedInFileDrag(const juce::StringArray& files) {
     return false;
 }
 
-static int countAudioFilesDG(const juce::StringArray& files) {
+namespace {
+int countAudioFilesDG(const juce::StringArray& files) {
     int n = 0;
     for (const auto& f : files) {
         if (f.endsWithIgnoreCase(".wav") || f.endsWithIgnoreCase(".aif") ||
@@ -583,6 +584,7 @@ static int countAudioFilesDG(const juce::StringArray& files) {
     }
     return n;
 }
+}  // namespace
 
 void DrumGridUI::fileDragEnter(const juce::StringArray& files, int x, int y) {
     fileDropCount_ = countAudioFilesDG(files);

--- a/magda/daw/ui/components/chain/drum_grid/DrumGridUI.hpp
+++ b/magda/daw/ui/components/chain/drum_grid/DrumGridUI.hpp
@@ -16,11 +16,9 @@
 #include "ui/components/common/SvgButton.hpp"
 #include "ui/components/common/TextSlider.hpp"
 
-namespace tracktion {
-inline namespace engine {
+namespace tracktion::inline engine {
 class Plugin;
 }
-}  // namespace tracktion
 
 namespace magda::daw::audio {
 class DrumGridPlugin;

--- a/magda/daw/ui/components/chain/drum_grid/PadChainPanel.hpp
+++ b/magda/daw/ui/components/chain/drum_grid/PadChainPanel.hpp
@@ -14,11 +14,9 @@
 #include "core/TypeIds.hpp"
 #include "drum_grid/PadDeviceSlot.hpp"
 
-namespace tracktion {
-inline namespace engine {
+namespace tracktion::inline engine {
 class Plugin;
 }
-}  // namespace tracktion
 
 namespace magda::daw::audio {
 class MagdaSamplerPlugin;

--- a/magda/daw/ui/components/chain/drum_grid/PadDeviceSlot.hpp
+++ b/magda/daw/ui/components/chain/drum_grid/PadDeviceSlot.hpp
@@ -22,11 +22,9 @@
 #include "ui/components/common/TextSlider.hpp"
 #include "ui/components/mixer/LevelMeter.hpp"
 
-namespace tracktion {
-inline namespace engine {
+namespace tracktion::inline engine {
 class Plugin;
 }
-}  // namespace tracktion
 
 namespace magda::daw::audio {
 class MagdaSamplerPlugin;

--- a/magda/daw/ui/components/clips/ClipComponent.cpp
+++ b/magda/daw/ui/components/clips/ClipComponent.cpp
@@ -321,9 +321,7 @@ void logArrangeRangeSelect(const juce::String& message) {
     }
 }
 
-}  // namespace
-
-static float computeFadeGain(float alpha, FadeCurve curve) {
+float computeFadeGain(float alpha, FadeCurve curve) {
     const float a = alpha * juce::MathConstants<float>::halfPi;
     switch (curve) {
         case FadeCurve::Convex:
@@ -340,6 +338,7 @@ static float computeFadeGain(float alpha, FadeCurve curve) {
             return alpha;
     }
 }
+}  // namespace
 
 ClipComponent::ClipComponent(ClipId clipId, TrackContentPanel* parent)
     : clipId_(clipId), parentPanel_(parent) {

--- a/magda/daw/ui/components/mixer/RoutingSyncHelper.hpp
+++ b/magda/daw/ui/components/mixer/RoutingSyncHelper.hpp
@@ -13,15 +13,13 @@
 #include "core/TrackInfo.hpp"
 #include "core/TrackManager.hpp"
 
-namespace magda {
-
 /**
  * @brief Free functions for populating and syncing routing selectors.
  *
  * Shared by TrackHeadersPanel and TrackInspector to avoid duplicating
  * ~200 lines of routing UI logic.
  */
-namespace RoutingSyncHelper {
+namespace magda::RoutingSyncHelper {
 
 inline void populateAudioInputOptions(RoutingSelector* selector, juce::AudioIODevice* device,
                                       TrackId currentTrackId = INVALID_TRACK_ID,
@@ -637,5 +635,4 @@ inline void syncSelectorsFromTrack(
     }
 }
 
-}  // namespace RoutingSyncHelper
-}  // namespace magda
+}  // namespace magda::RoutingSyncHelper

--- a/magda/daw/ui/debug/DebugDialog.cpp
+++ b/magda/daw/ui/debug/DebugDialog.cpp
@@ -13,12 +13,14 @@ magda::MidiBridge* DebugDialog::midiBridge_ = nullptr;
 //==============================================================================
 // Helper: format MIDI note name
 //==============================================================================
-static juce::String midiNoteToName(int noteNumber) {
+namespace {
+juce::String midiNoteToName(int noteNumber) {
     static const char* noteNames[] = {"C",  "C#", "D",  "D#", "E",  "F",
                                       "F#", "G",  "G#", "A",  "A#", "B"};
     int octave = (noteNumber / 12) - 2;
     return juce::String(noteNames[noteNumber % 12]) + juce::String(octave);
 }
+}  // namespace
 
 //==============================================================================
 // Content component with sliders and MIDI monitor

--- a/magda/daw/ui/dialogs/ParameterConfigDialog.cpp
+++ b/magda/daw/ui/dialogs/ParameterConfigDialog.cpp
@@ -24,7 +24,9 @@ struct CachedPluginParams {
     std::vector<MockParameterInfo> parameters;
     std::vector<magda::ParameterScanInput> scanInputs;
 };
-static std::map<juce::String, CachedPluginParams> parameterCache_;
+namespace {
+std::map<juce::String, CachedPluginParams> parameterCache_;
+}  // namespace
 
 class AIPromptEditorComponent : public juce::Component {
   public:

--- a/magda/daw/ui/panels/content/AIChatConsoleContent.cpp
+++ b/magda/daw/ui/panels/content/AIChatConsoleContent.cpp
@@ -3552,7 +3552,8 @@ void AIChatConsoleContent::finishThemeGeneration(bool success, const juce::Strin
 
 // Format a seconds value as a compact human-readable string ("5ms",
 // "150ms", "1.2s", "12s"). Used for ADSR display in the pretty-print.
-static juce::String formatSeconds(float s) {
+namespace {
+juce::String formatSeconds(float s) {
     s = std::max(s, 0.0f);
     if (s < 1.0f)
         return juce::String(static_cast<int>(std::round(s * 1000.0f))) + "ms";
@@ -3562,14 +3563,14 @@ static juce::String formatSeconds(float s) {
 }
 
 // Format a normalized 0..1 value as 2-decimal text.
-static juce::String formatNorm(float v) {
+juce::String formatNorm(float v) {
     return {juce::jlimit(0.0f, 1.0f, v), 2};
 }
 
 // Render a parsed preset as a categorized multi-line summary suitable
 // for the chat. Hides empty/zero categories. Time params (ADSR) are
 // formatted as ms/s; everything else as 2-decimal normalized values.
-static juce::String prettyPrintPreset(const magda::FourOscAgent::Preset& preset) {
+juce::String prettyPrintPreset(const magda::FourOscAgent::Preset& preset) {
     // Lookup helper: preset.params is keyed on the alias suffix
     // ("amp_attack", "tune_1", …). Returns a sentinel when absent so
     // callers can decide whether to print or skip.
@@ -3730,8 +3731,8 @@ static juce::String prettyPrintPreset(const magda::FourOscAgent::Preset& preset)
 // instance and apply there — wasting the LLM's output to "no device
 // focused" was just bad UX. Returns a one-line status string for the
 // chat. Delegates the actual write to magda::applyFourOscPresetToPath.
-static juce::String applyFourOscPresetToFocusedDevice(magda::MagdaApi& api,
-                                                      const magda::FourOscAgent::Preset& preset) {
+juce::String applyFourOscPresetToFocusedDevice(magda::MagdaApi& api,
+                                               const magda::FourOscAgent::Preset& preset) {
     auto& sel = magda::SelectionManager::getInstance();
     auto& tm = magda::TrackManager::getInstance();
 
@@ -3778,6 +3779,7 @@ static juce::String applyFourOscPresetToFocusedDevice(magda::MagdaApi& api,
 
     return preamble + magda::applyFourOscPresetToPath(api.plugins(), preset, path);
 }
+}  // namespace
 
 void AIChatConsoleContent::finishPresetGeneration(bool success, const juce::String& errorOrPretty,
                                                   juce::String presetName) {

--- a/magda/daw/ui/panels/content/TrackChainContent.cpp
+++ b/magda/daw/ui/panels/content/TrackChainContent.cpp
@@ -3357,7 +3357,7 @@ void TrackChainContent::showSaveTrackPresetDialog() {
 
     auto* aw = new juce::AlertWindow(
         "Save MAGDA Track Preset",
-        "Enter a name for this track preset (use \"/\" to nest, e.g. \"Bass/808 Stack\"):",
+        R"(Enter a name for this track preset (use "/" to nest, e.g. "Bass/808 Stack"):)",
         juce::MessageBoxIconType::NoIcon);
     aw->addTextEditor("name", defaultName, "Name:");
     aw->addButton("Save", 1, juce::KeyPress(juce::KeyPress::returnKey));

--- a/magda/daw/ui/panels/content/TrackChainContent.hpp
+++ b/magda/daw/ui/panels/content/TrackChainContent.hpp
@@ -16,11 +16,9 @@
 #include "ui/components/common/DraggableValueLabel.hpp"
 #include "ui/components/common/SvgButton.hpp"
 
-namespace tracktion {
-inline namespace engine {
+namespace tracktion::inline engine {
 class Plugin;
 }
-}  // namespace tracktion
 
 namespace magda::daw::ui {
 

--- a/magda/daw/ui/utils/TimelineUtils.hpp
+++ b/magda/daw/ui/utils/TimelineUtils.hpp
@@ -5,15 +5,13 @@
 #include <cstdio>
 #include <string>
 
-namespace magda {
-
 /**
  * @brief Utility functions for timeline time/pixel conversions
  *
  * These are pure functions that can be used by any component.
  * Each component provides its own zoom and padding values.
  */
-namespace TimelineUtils {
+namespace magda::TimelineUtils {
 
 /**
  * Convert a time value to pixel position
@@ -268,6 +266,4 @@ inline std::string formatBeatsAsBarsBeats(double totalBeats, int beatsPerBar) {
     return {buffer};
 }
 
-}  // namespace TimelineUtils
-
-}  // namespace magda
+}  // namespace magda::TimelineUtils

--- a/magda/daw/ui/windows/CommandIDs.hpp
+++ b/magda/daw/ui/windows/CommandIDs.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
-namespace magda {
-namespace CommandIDs {
+namespace magda::CommandIDs {
 
 enum {
     // File menu
@@ -92,5 +91,4 @@ enum {
     about = 0x5001
 };
 
-}  // namespace CommandIDs
-}  // namespace magda
+}  // namespace magda::CommandIDs

--- a/magda/daw/utils/ComponentManager.hpp
+++ b/magda/daw/utils/ComponentManager.hpp
@@ -115,7 +115,7 @@ class ManagedDrawable {
  * @endcode
  */
 template <typename ComponentType> class ManagedChild {
-    static_assert(std::is_base_of<juce::Component, ComponentType>::value,
+    static_assert(std::is_base_of_v<juce::Component, ComponentType>,
                   "ManagedChild only works with JUCE Components");
 
   public:
@@ -208,7 +208,7 @@ template <typename T> class ScopedComponentGuard {
 
     ~ScopedComponentGuard() {
         if (!released_ && component_) {
-            if constexpr (std::is_base_of<juce::Component, T>::value) {
+            if constexpr (std::is_base_of_v<juce::Component, T>) {
                 auto* parent = component_->getParentComponent();
                 if (parent) {
                     parent->removeChildComponent(component_);


### PR DESCRIPTION
Seventh clang-tidy batch: the small checks, minus one that turned out to
contradict a documented invariant.

## What landed

`misc-use-anonymous-namespace`, `modernize-concat-nested-namespaces`,
`modernize-type-traits`, `modernize-raw-string-literal` and
`readability-redundant-string-init`, 59 files.

`misc-use-anonymous-namespace` has no fixer, so its 59 declarations are moved by
hand: drop the `static`, wrap each run of adjacent declarations in
`namespace { }`. That comes to 26 blocks across 23 files. Linkage is identical
either way and these files already use anonymous namespaces, so the statics were
the stragglers rather than a different convention. Three files had a block close
immediately before a new one opened; those are merged into one.

The rest are textual: nested namespace declarations collapse to `namespace a::b`,
`is_base_of<T, U>::value` becomes `is_base_of_v<T, U>`, `= ""` comes off
`std::string` members, and two escaped alert-window strings become raw literals
with byte-identical content.

## modernize-loop-convert is disabled

Reason recorded in `.clang-tidy`. It found 19 sites across 2 files and both were
written as index loops deliberately.

`TrackManager`'s 13 notify methods index because `addListener()` does an
unguarded `push_back`. The index loop re-reads `size()` and re-indexes every
iteration, so a listener that registers another one from inside a callback is
handled. A range-for caches `end()`, so that same registration reallocates the
vector and the loop walks a freed buffer. `removeListener()` already nullifies
instead of erasing while `notifyDepth_ > 0`, with a comment saying it does so "to
keep iterators valid", so the invariant was deliberate and already written down.

`ClipMidiSource` is audio-thread code, and the loop the fixer rewrote carries a
comment that opens "By index rather than by iterator".

Both files are reverted here. This is the second check disabled in this series
after `cppcoreguidelines-prefer-member-initializer` in #2497; both are
fixer-driven checks whose rewrites contradicted an invariant the code states
explicitly. Happy to re-enable either.

## Verification

Clean build. Catch2 3778 passed, 13 skipped. JUCE suite all passed, including all
nine real-project corpus cases with the three real-plugin ones running locally.

One `make debug` exited 1 at the "Staging MCP bridge" step with nothing in the
log and succeeded on re-run, so I am recording it as transient rather than
explained.

https://claude.ai/code/session_01VomqgBSXsWYdyHyec9DvPi
