### PR TITLE
Make the clang-tidy pre-push hook actually fail

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -54,7 +54,7 @@ Checks: >-
 #   suspicious-include (31)      every hit is `#include "magda_*.generated.cpp"`,
 #                                the Faust DSP pipeline, which is deliberate.
 #   cert-err33-c (35)            ignored std::fprintf(stderr, ...) returns.
-#   exception-escape (33)        callback lambdas, as the note below already said.
+#   exception-escape (44)        callback lambdas, as the note below already said.
 #   unchecked-optional-access    guarded by ok()/failed() predicates it cannot see
 #     (10)                       through, and it drops the fact across any
 #                                non-const member call.
@@ -115,12 +115,14 @@ Checks: >-
 # bugprone-chained-comparison is off because Catch2's REQUIRE(a == b) expands to
 # `Decomposer() <= a == b`; it fired 311 times, every one of them in tests.
 #
-# bugprone-exception-escape stays enabled - it found 20 real
-# noexcept/destructor/main sites (#2395) and currently reports zero. If it ever
-# flags a plain callback lambda (juce::Button::onClick, callAsync, ...), that is
-# a false positive: the throwing capture-by-value copy happens while
-# constructing the closure, not inside the call operator, and such a lambda is
-# under none of the check's documented scope. Don't chase those.
+# bugprone-exception-escape earned its keep once, finding 20 real
+# noexcept/destructor/main sites (#2395), and this paragraph used to claim it
+# stayed enabled and reported zero. It is disabled above and reports 44, so the
+# claim was measured wrong or went stale. Re-enabling it means triaging those
+# 44 first: the ones to expect are plain callback lambdas
+# (juce::Button::onClick, callAsync, ...), where the throwing capture-by-value
+# copy happens while constructing the closure rather than inside the call
+# operator, which is outside the check's documented scope.
 
 # Warnings as errors - set once the bug-catching tier below is at zero.
 WarningsAsErrors: ''

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -329,14 +329,44 @@ jobs:
       run: |
         set -euo pipefail
         base="${{ github.event.pull_request.base.sha || github.event.before }}"
-        # Unset, or all-zeros on a branch's first push: nothing to compare against.
-        if [ -z "$base" ] || [ "$base" = "0000000000000000000000000000000000000000" ]; then
-          echo "No base commit to diff against; nothing to analyse."
-          exit 0
-        fi
 
-        # The checkout is depth-1, so the base commit is not in this clone yet.
-        git fetch --no-tags --depth=1 origin "$base"
+        # A branch's first push reports the all-zero SHA. Treating that as
+        # "nothing changed" would let a branch created, pushed once and merged
+        # carry findings the whole way: pull_request events only fire for PRs
+        # into main, so a PR into dev/0.X.0 never gets a second chance to lint.
+        # Find where this branch actually left the shared history instead.
+        if [ -z "$base" ] || [ "$base" = "0000000000000000000000000000000000000000" ]; then
+          git fetch --no-tags --depth=200 origin \
+            '+refs/heads/main:refs/remotes/origin/main' \
+            '+refs/heads/dev/*:refs/remotes/origin/dev/*'
+
+          # Only the shared branches above. Ranging over every remote ref would
+          # let this branch's own ref win the merge-base, and diffing a branch
+          # against itself reports nothing to do.
+          best="" best_count=""
+          head_sha=$(git rev-parse HEAD)
+          for ref in $(git for-each-ref --format='%(refname)' \
+                         refs/remotes/origin/main refs/remotes/origin/dev); do
+            mb=$(git merge-base HEAD "$ref" 2>/dev/null) || continue
+            # A ref that already contains HEAD gives no useful range.
+            [ "$mb" = "$head_sha" ] && continue
+            n=$(git rev-list --count "$mb..HEAD" 2>/dev/null) || continue
+            if [ -z "$best_count" ] || [ "$n" -lt "$best_count" ]; then
+              best_count="$n" best="$mb"
+            fi
+          done
+
+          if [ -z "$best" ]; then
+            echo "Could not find a branch point to diff against." >&2
+            echo "Refusing to report clean without having analysed anything." >&2
+            exit 1
+          fi
+          echo "First push; using branch point $best ($best_count commit(s) ahead)."
+          base="$best"
+        else
+          # The checkout is depth-1, so the base commit is not in this clone yet.
+          git fetch --no-tags --depth=1 origin "$base"
+        fi
 
         # Two dots rather than three: a merge base needs history neither side has
         # here. It can pull in commits that landed on the base branch meanwhile,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -340,17 +340,17 @@ jobs:
 
         if [ -n "$base" ]; then
           # The checkout is depth-1, so the base commit is not in this clone yet.
-          git fetch --no-tags --depth=1 origin "$base"
+          git fetch --no-tags --no-recurse-submodules --depth=1 origin "$base"
         elif [ "$shared" = true ]; then
           # A shared branch. Its commits arrived through PRs that were analysed
           # on their own branches, and diffing back to where dev left main would
           # re-analyse an entire release. Range over what this push added.
           base="${{ github.event.before }}"
           if [ -z "$base" ] || [ "$base" = "0000000000000000000000000000000000000000" ]; then
-            git fetch --no-tags --depth=2 origin "${{ github.ref_name }}"
+            git fetch --no-tags --no-recurse-submodules --depth=2 origin "${{ github.ref_name }}"
             base="HEAD~1"
           else
-            git fetch --no-tags --depth=1 origin "$base"
+            git fetch --no-tags --no-recurse-submodules --depth=1 origin "$base"
           fi
         else
           # A feature branch, where github.event.before cannot be trusted.
@@ -358,15 +358,21 @@ jobs:
           # in-flight runs: a push touching no C++ can cancel the only run that
           # would have analysed the C++ still sitting at HEAD, then find nothing
           # in its own narrow range. So diff the whole branch, every push.
+          # --no-recurse-submodules throughout: the checkout configures submodule
+          # recursion, so a plain fetch here went off to fetch faust's and
+          # tracktion's, some of which fail on refs their remotes no longer
+          # serve, and took the step down with them before clang-tidy ever ran.
+          #
           # HEAD first, and in its own fetch. checkout leaves it a shallow root,
           # and merge-base cannot walk a history that stops at the first commit,
           # so deepening only main/dev leaves every merge-base below failing and
           # the branch point unfindable. Adding this branch as another refspec to
           # the fetch below does not deepen HEAD either; it has to be its own
           # invocation.
-          git fetch --no-tags --deepen=200 origin
+          git fetch --no-tags --no-recurse-submodules --deepen=200 origin \
+            "${{ github.ref_name }}"
 
-          git fetch --no-tags --depth=200 origin \
+          git fetch --no-tags --no-recurse-submodules --depth=200 origin \
             '+refs/heads/main:refs/remotes/origin/main' \
             '+refs/heads/dev/*:refs/remotes/origin/dev/*'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -331,14 +331,33 @@ jobs:
         CLANG_TIDY_MAX_TUS: '40'
       run: |
         set -euo pipefail
-        base="${{ github.event.pull_request.base.sha || github.event.before }}"
+        base="${{ github.event.pull_request.base.sha }}"
 
-        # A branch's first push reports the all-zero SHA. Treating that as
-        # "nothing changed" would let a branch created, pushed once and merged
-        # carry findings the whole way: pull_request events only fire for PRs
-        # into main, so a PR into dev/0.X.0 never gets a second chance to lint.
-        # Find where this branch actually left the shared history instead.
-        if [ -z "$base" ] || [ "$base" = "0000000000000000000000000000000000000000" ]; then
+        case "${{ github.ref_name }}" in
+          main | dev/*) shared=true ;;
+          *)            shared=false ;;
+        esac
+
+        if [ -n "$base" ]; then
+          # The checkout is depth-1, so the base commit is not in this clone yet.
+          git fetch --no-tags --depth=1 origin "$base"
+        elif [ "$shared" = true ]; then
+          # A shared branch. Its commits arrived through PRs that were analysed
+          # on their own branches, and diffing back to where dev left main would
+          # re-analyse an entire release. Range over what this push added.
+          base="${{ github.event.before }}"
+          if [ -z "$base" ] || [ "$base" = "0000000000000000000000000000000000000000" ]; then
+            git fetch --no-tags --depth=2 origin "${{ github.ref_name }}"
+            base="HEAD~1"
+          else
+            git fetch --no-tags --depth=1 origin "$base"
+          fi
+        else
+          # A feature branch, where github.event.before cannot be trusted.
+          # The first push reports the all-zero SHA, and concurrency cancels
+          # in-flight runs: a push touching no C++ can cancel the only run that
+          # would have analysed the C++ still sitting at HEAD, then find nothing
+          # in its own narrow range. So diff the whole branch, every push.
           git fetch --no-tags --depth=200 origin \
             '+refs/heads/main:refs/remotes/origin/main' \
             '+refs/heads/dev/*:refs/remotes/origin/dev/*'
@@ -364,11 +383,8 @@ jobs:
             echo "Refusing to report clean without having analysed anything." >&2
             exit 1
           fi
-          echo "First push; using branch point $best ($best_count commit(s) ahead)."
+          echo "Branch point $best ($best_count commit(s) ahead)."
           base="$best"
-        else
-          # The checkout is depth-1, so the base commit is not in this clone yet.
-          git fetch --no-tags --depth=1 origin "$base"
         fi
 
         # Two dots rather than three: a merge base needs history neither side has

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -358,6 +358,14 @@ jobs:
           # in-flight runs: a push touching no C++ can cancel the only run that
           # would have analysed the C++ still sitting at HEAD, then find nothing
           # in its own narrow range. So diff the whole branch, every push.
+          # HEAD first, and in its own fetch. checkout leaves it a shallow root,
+          # and merge-base cannot walk a history that stops at the first commit,
+          # so deepening only main/dev leaves every merge-base below failing and
+          # the branch point unfindable. Adding this branch as another refspec to
+          # the fetch below does not deepen HEAD either; it has to be its own
+          # invocation.
+          git fetch --no-tags --deepen=200 origin
+
           git fetch --no-tags --depth=200 origin \
             '+refs/heads/main:refs/remotes/origin/main' \
             '+refs/heads/dev/*:refs/remotes/origin/dev/*'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -281,6 +281,13 @@ jobs:
         # link check here, without also building that second test executable.
         cmake --build build --config Debug --target magda_daw_app magda_tests -j"$(nproc)"
 
+    # Static analysis, reusing the compile database the configure step wrote and
+    # the generated sources the build produced. A separate job would have to
+    # rebuild both to learn anything.
+    #
+    # Pinned to 20 to match the pre-push hook: findings move between clang-tidy
+    # releases, and a job on whatever the runner image ships would fail pushes
+    # that were clean locally, which is how a lint gate gets switched off.
     - name: Populate prebuilt Faust/Mutable artifacts (R2)
       if: steps.r2-creds.outcome == 'success'
       continue-on-error: true
@@ -307,6 +314,49 @@ jobs:
           put "${{ runner.os }}-mutable-artifact-${{ steps.dsp-cache-keys.outputs.eurorack_sha }}-${{ steps.dsp-cache-keys.outputs.compiler }}-debug" \
             third_party/eurorack/build/lib
         fi
+
+    - name: Install clang-tidy
+      run: |
+        wget -qO /tmp/llvm.sh https://apt.llvm.org/llvm.sh
+        chmod +x /tmp/llvm.sh
+        sudo /tmp/llvm.sh 20
+        sudo apt-get install -y clang-tidy-20
+
+    - name: Run clang-tidy on changed files
+      env:
+        CLANG_TIDY: clang-tidy-20
+        BUILD_DIR: build
+      run: |
+        set -euo pipefail
+        base="${{ github.event.pull_request.base.sha || github.event.before }}"
+        # Unset, or all-zeros on a branch's first push: nothing to compare against.
+        if [ -z "$base" ] || [ "$base" = "0000000000000000000000000000000000000000" ]; then
+          echo "No base commit to diff against; nothing to analyse."
+          exit 0
+        fi
+
+        # The checkout is depth-1, so the base commit is not in this clone yet.
+        git fetch --no-tags --depth=1 origin "$base"
+
+        # Two dots rather than three: a merge base needs history neither side has
+        # here. It can pull in commits that landed on the base branch meanwhile,
+        # which only ever costs a few extra already-clean files.
+        #
+        # magda/engine is excluded while the native engine is still being written,
+        # matching the hook's own exclude.
+        mapfile -t files < <(
+          git diff --name-only --diff-filter=d "$base" HEAD -- magda \
+            | grep '\.cpp$' | grep -v '^magda/engine/' || true
+        )
+
+        if [ ${#files[@]} -eq 0 ]; then
+          echo "No changed .cpp files under magda/ to analyse."
+          exit 0
+        fi
+
+        printf 'Analysing %d file(s):\n' "${#files[@]}"
+        printf '  %s\n' "${files[@]}"
+        ./.pre-commit-hooks/clang-tidy.sh "${files[@]}"
 
     - name: Check build artifacts
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -344,13 +344,15 @@ jobs:
         #
         # magda/engine is excluded while the native engine is still being written,
         # matching the hook's own exclude.
+        # Headers included: the hook maps each to the translation units that
+        # include it, so a header-only change is still analysed.
         mapfile -t files < <(
           git diff --name-only --diff-filter=d "$base" HEAD -- magda \
-            | grep '\.cpp$' | grep -v '^magda/engine/' || true
+            | grep -E '\.(cpp|hpp|h)$' | grep -v '^magda/engine/' || true
         )
 
         if [ ${#files[@]} -eq 0 ]; then
-          echo "No changed .cpp files under magda/ to analyse."
+          echo "No changed C++ files under magda/ to analyse."
           exit 0
         fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -326,6 +326,9 @@ jobs:
       env:
         CLANG_TIDY: clang-tidy-20
         BUILD_DIR: build
+        # Higher than the hook's 8: a push waits on the hook, nobody waits on
+        # this, and a change to a widely included header deserves the coverage.
+        CLANG_TIDY_MAX_TUS: '40'
       run: |
         set -euo pipefail
         base="${{ github.event.pull_request.base.sha || github.event.before }}"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -81,7 +81,10 @@ repos:
         name: Clang-Tidy Check
         entry: .pre-commit-hooks/clang-tidy.sh
         language: system
-        files: \.cpp$
+        # Headers too: a push that changes only an inline or template-heavy
+        # header would otherwise go unanalysed. The script maps each one to the
+        # translation units that include it.
+        files: \.(cpp|hpp|h)$
         exclude: ^magda/engine/
         pass_filenames: true
         stages: [pre-push]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -69,27 +69,21 @@ repos:
         pass_filenames: false
         stages: [pre-push]
 
-      # Run basic linting on changed files
+      # Static analysis on changed files, after build-check has written the
+      # compile database it reads. Local rather than pocc/pre-commit-hooks:
+      # that hook decides pass/fail from whether clang-tidy wrote anything to
+      # stderr, and clang-tidy always writes an "N warnings generated." tally,
+      # which its filter fails to strip because the regex matches only the
+      # singular "warning generated". Every file here would fail it.
+      #
+      # magda/engine is excluded while the native engine is still being written.
       - id: clang-tidy-check
         name: Clang-Tidy Check
-        entry: bash
-        args:
-          - -c
-          - |
-            if command -v /opt/homebrew/opt/llvm/bin/clang-tidy >/dev/null 2>&1; then
-              echo "Running clang-tidy on changed files..."
-              # Only run on .cpp files that were changed
-              for file in "$@"; do
-                if [[ "$file" == *.cpp ]]; then
-                  echo "Checking $file..."
-                  /opt/homebrew/opt/llvm/bin/clang-tidy "$file" -p=cmake-build-debug --config-file=.clang-tidy --format-style=file || true
-                fi
-              done
-            else
-              echo "clang-tidy not found, skipping..."
-            fi
+        entry: .pre-commit-hooks/clang-tidy.sh
         language: system
-        files: \.(cpp|hpp|h)$
+        files: \.cpp$
+        exclude: ^magda/engine/
+        pass_filenames: true
         stages: [pre-push]
 
       # Ensure tests still pass

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -101,4 +101,8 @@ repos:
 
 # Configuration
 default_stages: [pre-commit]
+# `pre-commit install` installs only the pre-commit hook unless told otherwise,
+# so the build, clang-tidy and test hooks below, all of them pre-push, were
+# never installed by the documented setup and had never run for anyone.
+default_install_hook_types: [pre-commit, pre-push]
 minimum_pre_commit_version: 2.20.0

--- a/.pre-commit-hooks/clang-tidy.sh
+++ b/.pre-commit-hooks/clang-tidy.sh
@@ -47,10 +47,10 @@ UNBUILT_OK=(
 
 # A header changed on its own still has to be analysed, and clang-tidy only
 # analyses translation units, so headers map to the TUs that compile them via
-# ninja's recorded dependencies. tus-for-headers.py applies CLANG_TIDY_MAX_TUS
-# itself: the budget has to be spread across the changed headers, and only it
-# knows which TU came from which header.
-export CLANG_TIDY_MAX_TUS="${CLANG_TIDY_MAX_TUS:-8}"
+# ninja's recorded dependencies. tus-for-headers.py applies the ceiling itself:
+# the budget has to be spread across the changed headers, and only it knows
+# which TU came from which header.
+MAX_TUS="${CLANG_TIDY_MAX_TUS:-8}"
 
 BUILD_DIR="${BUILD_DIR:-cmake-build-debug}"
 
@@ -75,10 +75,8 @@ if [ ! -f "$DB" ]; then
     exit 1
 fi
 
-in_db() {
-    # pre-commit passes repo-relative paths, the database records absolute ones.
-    grep -q "/$1\"" "$DB" 2>/dev/null
-}
+hook_dir=$(cd "$(dirname "$0")" && pwd)
+resolver="$hook_dir/tus-for-headers.py"
 
 is_unbuilt_ok() {
     local candidate="$1" known
@@ -94,10 +92,25 @@ declare -a changed=()
 declare -a expanded=()
 declare -a headers=()
 
+declare -a sources=()
 for file in "$@"; do
     case "$file" in
-    *.cpp)
-        if in_db "$file"; then
+    *.cpp) sources+=("$file") ;;
+    *.h | *.hpp) headers+=("$file") ;;
+    esac
+done
+
+# Database membership is resolved by the same code that reads it, rather than a
+# grep here: the file records absolute native paths, so matching a relative one
+# by string has to assume a separator, and on Windows that marks every file
+# missing and passes the lot.
+if [ ${#sources[@]} -gt 0 ]; then
+    if ! absent=$(python3 "$resolver" --missing --build-dir "$BUILD_DIR" "${sources[@]}"); then
+        echo "Could not read $DB." >&2
+        exit 1
+    fi
+    for file in "${sources[@]}"; do
+        if ! printf '%s\n' "$absent" | grep -qxF "$file"; then
             changed+=("$file")
         elif is_unbuilt_ok "$file"; then
             echo "note: $file is in no compile command, which is expected for it."
@@ -107,19 +120,15 @@ for file in "$@"; do
             echo "UNBUILT_OK in $0 rather than leaving it unanalysed." >&2
             status=1
         fi
-        ;;
-    *.h | *.hpp)
-        headers+=("$file")
-        ;;
-    esac
-done
+    done
+fi
 
 if [ ${#headers[@]} -gt 0 ]; then
-    hook_dir=$(cd "$(dirname "$0")" && pwd)
     # Command substitution, not `mapfile < <(...)`: mapfile reports its own
     # status, so a process substitution's exit code is lost and a failing
     # mapping reads as success.
-    if header_tus=$(BUILD_DIR="$BUILD_DIR" python3 "$hook_dir/tus-for-headers.py" "${headers[@]}"); then
+    if header_tus=$(python3 "$resolver" --build-dir "$BUILD_DIR" \
+                      --max-tus "$MAX_TUS" "${headers[@]}"); then
         [ -n "$header_tus" ] && mapfile -t expanded <<<"$header_tus"
     else
         # Either the dependency data is unreadable or a header compiles into

--- a/.pre-commit-hooks/clang-tidy.sh
+++ b/.pre-commit-hooks/clang-tidy.sh
@@ -37,12 +37,12 @@ UNBUILT_OK=(
     'magda/daw/ui/components/automation/TensionHandleComponent.cpp'
 )
 
-# A header changed on its own still has to be analysed, and clang-tidy can only
-# analyse a translation unit, so each one maps to the TUs that include it. Direct
-# includes only: the real graph lives in .ninja_deps and reading it is not worth
-# the coupling. Capped because a widely included header maps to hundreds of TUs
-# and a pre-push hook has to finish.
-MAX_TUS_PER_HEADER="${CLANG_TIDY_MAX_TUS:-8}"
+# A header changed on its own still has to be analysed, and clang-tidy only
+# analyses translation units, so headers map to the TUs that compile them via
+# ninja's recorded dependencies. Capped because one widely included header
+# reaches dozens of TUs at ~20s each and a pre-push hook has to finish; the cap
+# is reported rather than applied quietly. 0 means no cap.
+MAX_TUS="${CLANG_TIDY_MAX_TUS:-8}"
 
 BUILD_DIR="${BUILD_DIR:-cmake-build-debug}"
 
@@ -82,6 +82,7 @@ is_unbuilt_ok() {
 
 status=0
 declare -a targets=()
+declare -a headers=()
 
 for file in "$@"; do
     case "$file" in
@@ -98,24 +99,38 @@ for file in "$@"; do
         fi
         ;;
     *.h | *.hpp)
-        mapfile -t includers < <(
-            grep -rl --include='*.cpp' "include.*$(basename "$file")" magda 2>/dev/null | head -n "$MAX_TUS_PER_HEADER"
-        )
-        if [ ${#includers[@]} -eq 0 ]; then
-            echo "note: no translation unit includes $(basename "$file"); nothing to analyse."
-            continue
-        fi
-        for tu in "${includers[@]}"; do
-            in_db "$tu" && targets+=("$tu")
-        done
+        headers+=("$file")
         ;;
     esac
 done
+
+if [ ${#headers[@]} -gt 0 ]; then
+    hook_dir=$(cd "$(dirname "$0")" && pwd)
+    # Command substitution, not `mapfile < <(...)`: mapfile reports its own
+    # status, so a process substitution's exit code is lost and a failing
+    # mapping reads as success.
+    if header_tus=$(BUILD_DIR="$BUILD_DIR" python3 "$hook_dir/tus-for-headers.py" "${headers[@]}"); then
+        [ -n "$header_tus" ] && mapfile -t -O "${#targets[@]}" targets <<<"$header_tus"
+    else
+        # Either the dependency data is unreadable or a header compiles into
+        # nothing. Reporting clean off the back of either is the failure this
+        # gate exists to prevent.
+        echo "Could not map changed headers to translation units (see above)." >&2
+        echo "Run 'make debug' so ninja has recorded their dependencies." >&2
+        status=1
+    fi
+fi
 
 # One header can pull in a TU another already did, and so can a .cpp alongside
 # its own header.
 if [ ${#targets[@]} -gt 0 ]; then
     mapfile -t targets < <(printf '%s\n' "${targets[@]}" | sort -u)
+fi
+
+if [ "$MAX_TUS" -gt 0 ] && [ ${#targets[@]} -gt "$MAX_TUS" ]; then
+    echo "note: ${#targets[@]} translation units affected, analysing the first $MAX_TUS."
+    echo "      Set CLANG_TIDY_MAX_TUS=0 to analyse all of them."
+    targets=("${targets[@]:0:$MAX_TUS}")
 fi
 
 for file in "${targets[@]:-}"; do

--- a/.pre-commit-hooks/clang-tidy.sh
+++ b/.pre-commit-hooks/clang-tidy.sh
@@ -9,6 +9,14 @@
 # wrong (its filter matches the singular "warning generated" only).
 set -uo pipefail
 
+# mapfile is bash 4. macOS still ships 3.2 as /bin/bash, where this would fail
+# on a missing builtin rather than on anything to do with the code.
+if [ "${BASH_VERSINFO[0]:-0}" -lt 4 ]; then
+    echo "This hook needs bash 4 or newer; found ${BASH_VERSION:-unknown}." >&2
+    echo "On macOS: brew install bash (Homebrew's comes first on PATH)." >&2
+    exit 1
+fi
+
 # The bugprone/cert half of .clang-tidy, minus the five checks that still report
 # findings. Sweeping those is what unblocks WarningsAsErrors in .clang-tidy;
 # delete them from here as each reaches zero.
@@ -81,14 +89,16 @@ is_unbuilt_ok() {
 }
 
 status=0
-declare -a targets=()
+# Kept apart so the cap can never drop a file the push actually changed.
+declare -a changed=()
+declare -a expanded=()
 declare -a headers=()
 
 for file in "$@"; do
     case "$file" in
     *.cpp)
         if in_db "$file"; then
-            targets+=("$file")
+            changed+=("$file")
         elif is_unbuilt_ok "$file"; then
             echo "note: $file is in no compile command, which is expected for it."
         else
@@ -110,7 +120,7 @@ if [ ${#headers[@]} -gt 0 ]; then
     # status, so a process substitution's exit code is lost and a failing
     # mapping reads as success.
     if header_tus=$(BUILD_DIR="$BUILD_DIR" python3 "$hook_dir/tus-for-headers.py" "${headers[@]}"); then
-        [ -n "$header_tus" ] && mapfile -t -O "${#targets[@]}" targets <<<"$header_tus"
+        [ -n "$header_tus" ] && mapfile -t expanded <<<"$header_tus"
     else
         # Either the dependency data is unreadable or a header compiles into
         # nothing. Reporting clean off the back of either is the failure this
@@ -121,17 +131,31 @@ if [ ${#headers[@]} -gt 0 ]; then
     fi
 fi
 
-# One header can pull in a TU another already did, and so can a .cpp alongside
-# its own header.
-if [ ${#targets[@]} -gt 0 ]; then
-    mapfile -t targets < <(printf '%s\n' "${targets[@]}" | sort -u)
+if [ ${#changed[@]} -gt 0 ]; then
+    mapfile -t changed < <(printf '%s\n' "${changed[@]}" | sort -u)
 fi
 
-if [ "$MAX_TUS" -gt 0 ] && [ ${#targets[@]} -gt "$MAX_TUS" ]; then
-    echo "note: ${#targets[@]} translation units affected, analysing the first $MAX_TUS."
-    echo "      Set CLANG_TIDY_MAX_TUS=0 to analyse all of them."
-    targets=("${targets[@]:0:$MAX_TUS}")
+# Header expansion only. A file the push actually changed is never dropped:
+# capping the merged set meant a ninth changed .cpp went unanalysed and the gate
+# still reported clean.
+if [ ${#expanded[@]} -gt 0 ]; then
+    if [ ${#changed[@]} -gt 0 ]; then
+        mapfile -t expanded < <(
+            printf '%s\n' "${expanded[@]}" | sort -u |
+                grep -vxF -f <(printf '%s\n' "${changed[@]}") || true
+        )
+    else
+        mapfile -t expanded < <(printf '%s\n' "${expanded[@]}" | sort -u)
+    fi
 fi
+
+if [ "$MAX_TUS" -gt 0 ] && [ ${#expanded[@]} -gt "$MAX_TUS" ]; then
+    echo "note: changed headers reach ${#expanded[@]} further translation units,"
+    echo "      analysing the first $MAX_TUS. Set CLANG_TIDY_MAX_TUS=0 for all."
+    expanded=("${expanded[@]:0:$MAX_TUS}")
+fi
+
+declare -a targets=("${changed[@]}" "${expanded[@]}")
 
 for file in "${targets[@]:-}"; do
     [ -n "$file" ] || continue

--- a/.pre-commit-hooks/clang-tidy.sh
+++ b/.pre-commit-hooks/clang-tidy.sh
@@ -78,6 +78,22 @@ fi
 hook_dir=$(cd "$(dirname "$0")" && pwd)
 resolver="$hook_dir/tus-for-headers.py"
 
+# python3 then python, the fallback setup.sh accepts when it installs this hook.
+# Hardcoding python3 meant a machine that only has `python`, which is a common
+# Windows shape, installed the hook and then failed every C++ push on a missing
+# interpreter. The resolver is always run through this, never its shebang.
+if [ -n "${PYTHON:-}" ]; then
+    :
+elif command -v python3 >/dev/null 2>&1; then
+    PYTHON=python3
+elif command -v python >/dev/null 2>&1; then
+    PYTHON=python
+else
+    echo "Neither python3 nor python found; cannot resolve translation units." >&2
+    echo "Install Python, or set PYTHON=/path/to/python." >&2
+    exit 1
+fi
+
 is_unbuilt_ok() {
     local candidate="$1" known
     for known in "${UNBUILT_OK[@]}"; do
@@ -105,7 +121,7 @@ done
 # by string has to assume a separator, and on Windows that marks every file
 # missing and passes the lot.
 if [ ${#sources[@]} -gt 0 ]; then
-    if ! absent=$(python3 "$resolver" --missing --build-dir "$BUILD_DIR" "${sources[@]}"); then
+    if ! absent=$($PYTHON "$resolver" --missing --build-dir "$BUILD_DIR" "${sources[@]}"); then
         echo "Could not read $DB." >&2
         exit 1
     fi
@@ -127,7 +143,7 @@ if [ ${#headers[@]} -gt 0 ]; then
     # Command substitution, not `mapfile < <(...)`: mapfile reports its own
     # status, so a process substitution's exit code is lost and a failing
     # mapping reads as success.
-    if header_tus=$(python3 "$resolver" --build-dir "$BUILD_DIR" \
+    if header_tus=$($PYTHON "$resolver" --build-dir "$BUILD_DIR" \
                       --max-tus "$MAX_TUS" "${headers[@]}"); then
         [ -n "$header_tus" ] && mapfile -t expanded <<<"$header_tus"
     else

--- a/.pre-commit-hooks/clang-tidy.sh
+++ b/.pre-commit-hooks/clang-tidy.sh
@@ -47,10 +47,10 @@ UNBUILT_OK=(
 
 # A header changed on its own still has to be analysed, and clang-tidy only
 # analyses translation units, so headers map to the TUs that compile them via
-# ninja's recorded dependencies. Capped because one widely included header
-# reaches dozens of TUs at ~20s each and a pre-push hook has to finish; the cap
-# is reported rather than applied quietly. 0 means no cap.
-MAX_TUS="${CLANG_TIDY_MAX_TUS:-8}"
+# ninja's recorded dependencies. tus-for-headers.py applies CLANG_TIDY_MAX_TUS
+# itself: the budget has to be spread across the changed headers, and only it
+# knows which TU came from which header.
+export CLANG_TIDY_MAX_TUS="${CLANG_TIDY_MAX_TUS:-8}"
 
 BUILD_DIR="${BUILD_DIR:-cmake-build-debug}"
 
@@ -147,12 +147,6 @@ if [ ${#expanded[@]} -gt 0 ]; then
     else
         mapfile -t expanded < <(printf '%s\n' "${expanded[@]}" | sort -u)
     fi
-fi
-
-if [ "$MAX_TUS" -gt 0 ] && [ ${#expanded[@]} -gt "$MAX_TUS" ]; then
-    echo "note: changed headers reach ${#expanded[@]} further translation units,"
-    echo "      analysing the first $MAX_TUS. Set CLANG_TIDY_MAX_TUS=0 for all."
-    expanded=("${expanded[@]:0:$MAX_TUS}")
 fi
 
 declare -a targets=("${changed[@]}" "${expanded[@]}")

--- a/.pre-commit-hooks/clang-tidy.sh
+++ b/.pre-commit-hooks/clang-tidy.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 #
-# Run clang-tidy over the .cpp files a push touches and fail on findings.
+# Run clang-tidy over what a push touches and fail on findings.
 #
 # clang-tidy exits 0 for a plain warning, so --warnings-as-errors is what makes
 # a check binding. Exit code is the whole signal here: clang-tidy also writes an
-# unconditional "N warnings generated." tally to stderr, so deciding pass/fail by
-# looking at output rather than status is how pocc/pre-commit-hooks v1.4.0 gets
-# this wrong (its filter matches the singular "warning generated" only).
+# unconditional "N warnings generated." tally to stderr, so deciding pass/fail
+# from output rather than status is how pocc/pre-commit-hooks v1.4.0 gets this
+# wrong (its filter matches the singular "warning generated" only).
 set -uo pipefail
 
 # The bugprone/cert half of .clang-tidy, minus the five checks that still report
@@ -24,6 +24,25 @@ CHECKS+=',-bugprone-implicit-widening-of-multiplication-result,-bugprone-incorre
 CHECKS+=',-bugprone-unused-return-value,-bugprone-return-const-ref-from-parameter'
 CHECKS+=',-bugprone-reserved-identifier'
 CHECKS+=',cert-oop54-cpp'
+
+# Sources that are in the tree but in no compile command, so an absent database
+# entry is expected rather than a stale build. Anything else missing is an error.
+UNBUILT_OK=(
+    # Built only when MAGDA_PRO_DEVICES is OFF, where the real pack replaces them.
+    'magda/daw/device_packs/pro_stub/ProDevicePack.cpp'
+    'magda/daw/device_packs/pro_stub/ProStubPlugin.cpp'
+    # In no CMake target and referenced only by each other.
+    'magda/daw/ui/components/automation/AutomationPointComponent.cpp'
+    'magda/daw/ui/components/automation/BezierHandleComponent.cpp'
+    'magda/daw/ui/components/automation/TensionHandleComponent.cpp'
+)
+
+# A header changed on its own still has to be analysed, and clang-tidy can only
+# analyse a translation unit, so each one maps to the TUs that include it. Direct
+# includes only: the real graph lives in .ninja_deps and reading it is not worth
+# the coupling. Capped because a widely included header maps to hundreds of TUs
+# and a pre-push hook has to finish.
+MAX_TUS_PER_HEADER="${CLANG_TIDY_MAX_TUS:-8}"
 
 BUILD_DIR="${BUILD_DIR:-cmake-build-debug}"
 
@@ -48,26 +67,62 @@ if [ ! -f "$DB" ]; then
     exit 1
 fi
 
+in_db() {
+    # pre-commit passes repo-relative paths, the database records absolute ones.
+    grep -q "/$1\"" "$DB" 2>/dev/null
+}
+
+is_unbuilt_ok() {
+    local candidate="$1" known
+    for known in "${UNBUILT_OK[@]}"; do
+        [ "$candidate" = "$known" ] && return 0
+    done
+    return 1
+}
+
 status=0
-checked=0
+declare -a targets=()
+
 for file in "$@"; do
     case "$file" in
-    *.cpp) ;;
-    *) continue ;;  # headers are analysed through the TUs that include them
+    *.cpp)
+        if in_db "$file"; then
+            targets+=("$file")
+        elif is_unbuilt_ok "$file"; then
+            echo "note: $file is in no compile command, which is expected for it."
+        else
+            echo "$file has no compile_commands.json entry." >&2
+            echo "Run 'make debug'. If it belongs to no target, say so in" >&2
+            echo "UNBUILT_OK in $0 rather than leaving it unanalysed." >&2
+            status=1
+        fi
+        ;;
+    *.h | *.hpp)
+        mapfile -t includers < <(
+            grep -rl --include='*.cpp' "include.*$(basename "$file")" magda 2>/dev/null | head -n "$MAX_TUS_PER_HEADER"
+        )
+        if [ ${#includers[@]} -eq 0 ]; then
+            echo "note: no translation unit includes $(basename "$file"); nothing to analyse."
+            continue
+        fi
+        for tu in "${includers[@]}"; do
+            in_db "$tu" && targets+=("$tu")
+        done
+        ;;
     esac
+done
 
-    # A file added since the last configure has no database entry, and clang-tidy
-    # would guess at the flags rather than say so. pre-commit passes repo-relative
-    # paths while the database records absolute ones, so match on the suffix.
-    if ! grep -q "/$file\"" "$DB" 2>/dev/null; then
-        echo "skipping $file: no compile_commands.json entry, run 'make debug'"
-        continue
-    fi
+# One header can pull in a TU another already did, and so can a .cpp alongside
+# its own header.
+if [ ${#targets[@]} -gt 0 ]; then
+    mapfile -t targets < <(printf '%s\n' "${targets[@]}" | sort -u)
+fi
 
+for file in "${targets[@]:-}"; do
+    [ -n "$file" ] || continue
     # The tally counts compiler warnings in the TU, not findings, and reads as a
     # contradiction next to a passing hook. Dropping it is safe because pass/fail
     # is the exit code here, never the output.
-    checked=$((checked + 1))
     if ! "$CLANG_TIDY" "$file" \
         --checks="$CHECKS" \
         --warnings-as-errors="$CHECKS" \
@@ -80,9 +135,9 @@ done
 
 if [ "$status" -ne 0 ]; then
     echo "" >&2
-    echo "clang-tidy found problems in the enforced tier." >&2
-    echo "Fix them, or add a NOLINT with a reason if it is a false positive." >&2
+    echo "clang-tidy gate failed; see above." >&2
+    echo "For a finding, fix it or add a NOLINT with a reason if it is wrong." >&2
 fi
 
-[ "$checked" -gt 0 ] && echo "clang-tidy: $checked file(s) checked"
+[ ${#targets[@]} -gt 0 ] && echo "clang-tidy: ${#targets[@]} translation unit(s) checked"
 exit "$status"

--- a/.pre-commit-hooks/clang-tidy.sh
+++ b/.pre-commit-hooks/clang-tidy.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+#
+# Run clang-tidy over the .cpp files a push touches and fail on findings.
+#
+# clang-tidy exits 0 for a plain warning, so --warnings-as-errors is what makes
+# a check binding. Exit code is the whole signal here: clang-tidy also writes an
+# unconditional "N warnings generated." tally to stderr, so deciding pass/fail by
+# looking at output rather than status is how pocc/pre-commit-hooks v1.4.0 gets
+# this wrong (its filter matches the singular "warning generated" only).
+set -uo pipefail
+
+# The bugprone/cert half of .clang-tidy, minus the five checks that still report
+# findings. Sweeping those is what unblocks WarningsAsErrors in .clang-tidy;
+# delete them from here as each reaches zero.
+CHECKS='-*,bugprone-*'
+CHECKS+=',-bugprone-easily-swappable-parameters,-bugprone-narrowing-conversions'
+CHECKS+=',-bugprone-chained-comparison,-bugprone-suspicious-include'
+CHECKS+=',-bugprone-exception-escape,-bugprone-unchecked-optional-access'
+CHECKS+=',-bugprone-swapped-arguments,-bugprone-branch-clone,-bugprone-empty-catch'
+CHECKS+=',-bugprone-signed-char-misuse,-bugprone-misplaced-widening-cast'
+CHECKS+=',-bugprone-nondeterministic-pointer-iteration-order,-bugprone-macro-parentheses'
+# Still to sweep: 31, 4 (deliberate pixel roundings), 2, 2 and 1 findings.
+CHECKS+=',-bugprone-implicit-widening-of-multiplication-result,-bugprone-incorrect-roundings'
+CHECKS+=',-bugprone-unused-return-value,-bugprone-return-const-ref-from-parameter'
+CHECKS+=',-bugprone-reserved-identifier'
+CHECKS+=',cert-oop54-cpp'
+
+BUILD_DIR="${BUILD_DIR:-cmake-build-debug}"
+
+# Homebrew's LLVM is newer than Apple's, so prefer it. Same lookup as the Makefile.
+if [ -n "${CLANG_TIDY:-}" ]; then
+    :
+elif [ -x /opt/homebrew/opt/llvm/bin/clang-tidy ]; then
+    CLANG_TIDY=/opt/homebrew/opt/llvm/bin/clang-tidy
+else
+    CLANG_TIDY=$(command -v clang-tidy 2>/dev/null || true)
+fi
+
+if [ -z "${CLANG_TIDY:-}" ]; then
+    echo "clang-tidy not found on PATH or at /opt/homebrew/opt/llvm/bin." >&2
+    echo "Install it (brew install llvm) or set CLANG_TIDY=/path/to/clang-tidy." >&2
+    exit 1
+fi
+
+DB="$BUILD_DIR/compile_commands.json"
+if [ ! -f "$DB" ]; then
+    echo "$DB not found. Run 'make debug' first." >&2
+    exit 1
+fi
+
+status=0
+checked=0
+for file in "$@"; do
+    case "$file" in
+    *.cpp) ;;
+    *) continue ;;  # headers are analysed through the TUs that include them
+    esac
+
+    # A file added since the last configure has no database entry, and clang-tidy
+    # would guess at the flags rather than say so. pre-commit passes repo-relative
+    # paths while the database records absolute ones, so match on the suffix.
+    if ! grep -q "/$file\"" "$DB" 2>/dev/null; then
+        echo "skipping $file: no compile_commands.json entry, run 'make debug'"
+        continue
+    fi
+
+    # The tally counts compiler warnings in the TU, not findings, and reads as a
+    # contradiction next to a passing hook. Dropping it is safe because pass/fail
+    # is the exit code here, never the output.
+    checked=$((checked + 1))
+    if ! "$CLANG_TIDY" "$file" \
+        --checks="$CHECKS" \
+        --warnings-as-errors="$CHECKS" \
+        --quiet \
+        -p="$BUILD_DIR" \
+        2> >(grep -Ev '^[0-9,]+ warnings? generated\.$' >&2); then
+        status=1
+    fi
+done
+
+if [ "$status" -ne 0 ]; then
+    echo "" >&2
+    echo "clang-tidy found problems in the enforced tier." >&2
+    echo "Fix them, or add a NOLINT with a reason if it is a false positive." >&2
+fi
+
+[ "$checked" -gt 0 ] && echo "clang-tidy: $checked file(s) checked"
+exit "$status"

--- a/.pre-commit-hooks/tus-for-headers.py
+++ b/.pre-commit-hooks/tus-for-headers.py
@@ -21,7 +21,7 @@ from pathlib import Path
 ROOT = Path.cwd()
 
 
-def leaf(path):
+def leaf(path: str) -> str:
     """Last component, whichever separator ninja wrote.
 
     A string slice rather than Path(path).name: this runs on every one of a few
@@ -31,10 +31,10 @@ def leaf(path):
     return path[max(path.rfind("/"), path.rfind("\\")) + 1:]
 
 
-def output_to_source(build_dir):
+def output_to_source(build_dir: Path) -> dict[str, str]:
     """Ninja target name -> repo-relative source, from the compile database."""
     db = json.loads((build_dir / "compile_commands.json").read_text())
-    mapping = {}
+    mapping: dict[str, str] = {}
     for entry in db:
         if not entry.get("output"):
             continue
@@ -48,7 +48,7 @@ def output_to_source(build_dir):
     return mapping
 
 
-def dependents(build_dir, wanted):
+def dependents(build_dir: Path, wanted: dict[Path, str]) -> dict[str, set[str]] | None:
     """Ninja outputs whose recorded dependencies include any of `wanted`."""
     proc = subprocess.run(["ninja", "-C", str(build_dir), "-t", "deps"],
                           capture_output=True, text=True, check=False)
@@ -56,7 +56,9 @@ def dependents(build_dir, wanted):
         return None
 
     names = {leaf(str(path)) for path in wanted}
-    found, current, stale = {}, None, False
+    found: dict[str, set[str]] = {}
+    current: str | None = None
+    stale = False
     for line in proc.stdout.splitlines():
         if not line:
             continue
@@ -83,7 +85,7 @@ def dependents(build_dir, wanted):
     return found
 
 
-def select(per_header, max_tus):
+def select(per_header: dict[str, list[str]], max_tus: int) -> tuple[list[str], int]:
     """Pick TUs under a budget without starving any one header.
 
     Flattening every header's candidates and truncating let one broadly included
@@ -92,7 +94,8 @@ def select(per_header, max_tus):
     alone exceeds the budget - analysing every changed header matters more than
     the ceiling - and only the fan-out beyond that is rationed, round robin.
     """
-    chosen, seen = [], set()
+    chosen: list[str] = []
+    seen: set[str] = set()
     for tus in per_header.values():
         for tu in tus:
             if tu not in seen:
@@ -118,12 +121,12 @@ def select(per_header, max_tus):
     return chosen, total
 
 
-def in_scope(source):
+def in_scope(source: str) -> bool:
     """Shipping code, matching .clang-tidy's own scope."""
     return source.startswith("magda/") and not source.startswith("magda/engine/")
 
 
-def main():
+def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("paths", nargs="*", metavar="FILE")
     parser.add_argument("--missing", action="store_true")
@@ -152,9 +155,10 @@ def main():
 
     mapping = output_to_source(args.build_dir)
 
-    per_header, unanalysable = {}, []
+    per_header: dict[str, list[str]] = {}
+    unanalysable: list[str] = []
     for header in args.paths:
-        sources = {mapping.get(o) for o in found.get(header, ())} - {None}
+        sources = {tu for o in found.get(header, ()) if (tu := mapping.get(o))}
         # Scoping has to be judged per header, after mapping. Deciding it from
         # the raw dependency set counted a header reached only through a test TU
         # as mapped, then filtered every candidate away and chose nothing.

--- a/.pre-commit-hooks/tus-for-headers.py
+++ b/.pre-commit-hooks/tus-for-headers.py
@@ -8,97 +8,91 @@ without a single .cpp naming it.
 Prints one repo-relative TU path per line, and exits non-zero only when the
 dependency data cannot be read at all. A header no translation unit compiles
 produces a note instead: nothing found in it could reach a binary.
+
+`--missing` answers a different question with the same path handling: which of
+these files does no compile command mention.
 """
+import argparse
 import json
-import os
 import subprocess
 import sys
+from pathlib import Path
+
+ROOT = Path.cwd()
 
 
-def basename(path):
-    """Last component, whichever separator ninja used.
+def leaf(path):
+    """Last component, whichever separator ninja wrote.
 
-    os.path.basename only knows the host's separator, and ninja on Windows
-    writes backslashes, so a dependency would be compared whole against a bare
-    file name, match nothing, and take the "nothing compiles this" path.
+    A string slice rather than Path(path).name: this runs on every one of a few
+    million dependency lines, and building a Path for each is far slower than
+    rejecting on a substring.
     """
     return path[max(path.rfind("/"), path.rfind("\\")) + 1:]
 
 
-def load_output_to_source(build_dir):
-    """Ninja target name -> repo-relative source, via the compile database."""
-    with open(os.path.join(build_dir, "compile_commands.json")) as handle:
-        db = json.load(handle)
-    root = os.path.normpath(os.getcwd())
+def output_to_source(build_dir):
+    """Ninja target name -> repo-relative source, from the compile database."""
+    db = json.loads((build_dir / "compile_commands.json").read_text())
     mapping = {}
     for entry in db:
-        output = entry.get("output")
-        if not output:
+        if not entry.get("output"):
             continue
-        source = os.path.normpath(os.path.abspath(entry["file"]))
-        if source.startswith(root + os.sep):
-            # Forward slashes throughout: these are matched against "magda/" and
-            # handed to clang-tidy, which takes them on Windows too.
-            mapping[output] = os.path.relpath(source, root).replace(os.sep, "/")
+        # No resolve(): the database already records absolute paths, and a
+        # syscall per entry costs more than the whole ninja dump.
+        source = Path(entry["file"])
+        if source.is_relative_to(ROOT):
+            # Posix throughout: matched against "magda/" and handed to
+            # clang-tidy, which takes forward slashes on Windows too.
+            mapping[entry["output"]] = source.relative_to(ROOT).as_posix()
     return mapping
 
 
 def dependents(build_dir, wanted):
-    """Ninja outputs whose recorded dependencies include any of `wanted`.
-
-    The dump runs to millions of lines, so the hot loop does no syscalls: reject
-    on basename first, and only then normalise a path. Resolving every line with
-    realpath() instead took 150s against ninja's own 10.
-    """
-    proc = subprocess.run(
-        ["ninja", "-C", build_dir, "-t", "deps"],
-        capture_output=True, text=True, check=False,
-    )
+    """Ninja outputs whose recorded dependencies include any of `wanted`."""
+    proc = subprocess.run(["ninja", "-C", str(build_dir), "-t", "deps"],
+                          capture_output=True, text=True, check=False)
     if proc.returncode != 0 or not proc.stdout:
         return None
 
-    names = {basename(path) for path in wanted}
-    found = {}
-    current = None
-    stale = False
+    names = {leaf(str(path)) for path in wanted}
+    found, current, stale = {}, None, False
     for line in proc.stdout.splitlines():
         if not line:
             continue
         if line[0] != " ":
-            # "target: #deps N, deps mtime M (VALID|STALE)". Split on the marker,
-            # not the first colon, which on Windows is the drive letter's.
+            # "target: #deps N, deps mtime M (VALID|STALE)". Split on the
+            # marker, not the first colon, which on Windows is the drive's.
             marker = line.find(": #deps ")
-            if marker == -1:
-                current = None
-                continue
-            current = line[:marker]
+            current = None if marker == -1 else line[:marker]
             stale = line.endswith("(STALE)")
             continue
         if current is None or stale:
             continue
         dep = line.strip()
-        if basename(dep) not in names:
+        if leaf(dep) not in names:
             continue
-        if not os.path.isabs(dep):
-            dep = os.path.join(build_dir, dep)
-        dep = os.path.normpath(dep)
-        if dep in wanted:
-            found.setdefault(wanted[dep], set()).add(current)
+        resolved = Path(dep)
+        if not resolved.is_absolute():
+            resolved = build_dir / resolved
+        # Only reached by the handful of lines the name filter let through, so
+        # resolve()'s syscalls do not matter here.
+        resolved = resolved.resolve()
+        if resolved in wanted:
+            found.setdefault(wanted[resolved], set()).add(current)
     return found
 
 
 def select(per_header, max_tus):
     """Pick TUs under a budget without starving any one header.
 
-    Flattening every header's candidates and truncating let one broadly
-    included header spend the whole budget, leaving another changed header with
-    nothing that compiles it. So each header gets a representative first, even
-    if that alone exceeds the budget - analysing every changed header matters
-    more than the ceiling - and only the fan-out beyond that is rationed, round
-    robin so no single header takes it all.
+    Flattening every header's candidates and truncating let one broadly included
+    header spend the whole budget, leaving another changed header with nothing
+    that compiles it. So each header gets a representative first, even if that
+    alone exceeds the budget - analysing every changed header matters more than
+    the ceiling - and only the fan-out beyond that is rationed, round robin.
     """
     chosen, seen = [], set()
-
     for tus in per_header.values():
         for tu in tus:
             if tu not in seen:
@@ -121,69 +115,71 @@ def select(per_header, max_tus):
                 remaining.remove(tus)
             if max_tus > 0 and len(chosen) >= max_tus:
                 break
-
     return chosen, total
 
 
-def main(argv):
-    build_dir = os.environ.get("BUILD_DIR", "cmake-build-debug")
-    max_tus = int(os.environ.get("CLANG_TIDY_MAX_TUS", "8"))
-    headers = argv[1:]
-    if not headers:
+def in_scope(source):
+    """Shipping code, matching .clang-tidy's own scope."""
+    return source.startswith("magda/") and not source.startswith("magda/engine/")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("paths", nargs="*", metavar="FILE")
+    parser.add_argument("--missing", action="store_true")
+    parser.add_argument("--build-dir", type=Path, default=Path("cmake-build-debug"))
+    parser.add_argument("--max-tus", type=int, default=8)
+    args = parser.parse_args()
+
+    if not args.paths:
         return 0
 
-    wanted = {os.path.normpath(os.path.abspath(h)): h for h in headers}
+    if args.missing:
+        # Resolved by the code that reads the database, not by a grep in the
+        # hook: it records absolute native paths, so matching a relative one by
+        # string has to assume a separator.
+        known = set(output_to_source(args.build_dir).values())
+        for path in args.paths:
+            if Path(path).as_posix() not in known:
+                print(path)
+        return 0
 
-    found = dependents(build_dir, wanted)
+    wanted = {Path(h).resolve(): h for h in args.paths}
+    found = dependents(args.build_dir, wanted)
     if found is None:
         print("could not read ninja dependency data", file=sys.stderr)
         return 1
 
-    mapping = load_output_to_source(build_dir)
+    mapping = output_to_source(args.build_dir)
 
-    def in_scope(source):
-        # Shipping code, matching .clang-tidy's own scope.
-        return source.startswith("magda/") and not source.startswith("magda/engine/")
-
-    per_header = {}
-    unanalysable = []
-    for header in headers:
-        sources = {mapping.get(o) for o in found.get(header, ())}
-        sources.discard(None)
-
-        eligible = {s for s in sources if in_scope(s)}
-        if not eligible:
-            # Scoping has to be judged per header, after mapping. Deciding it
-            # from the raw dependency set counted a header reached only through
-            # a test TU as mapped, then filtered every candidate away and
-            # returned success having chosen nothing.
-            #
-            # A header only tests compile is still analysed, through the test
-            # TU: HeaderFilterRegex decides which headers get diagnostics, so
-            # the header's own findings are reported either way.
-            eligible = sources
-
-        if not eligible:
+    per_header, unanalysable = {}, []
+    for header in args.paths:
+        sources = {mapping.get(o) for o in found.get(header, ())} - {None}
+        # Scoping has to be judged per header, after mapping. Deciding it from
+        # the raw dependency set counted a header reached only through a test TU
+        # as mapped, then filtered every candidate away and chose nothing.
+        # Falling back to that test TU still analyses the header itself, since
+        # HeaderFilterRegex decides which headers get diagnostics.
+        eligible = {s for s in sources if in_scope(s)} or sources
+        if eligible:
+            per_header[header] = sorted(eligible)
+        else:
             unanalysable.append(header)
-            continue
-        per_header[header] = sorted(eligible)
 
-    if unanalysable:
-        # No translation unit compiles these, so nothing that could be found in
-        # them reaches a binary. Worth saying, not worth blocking a push over.
-        for header in unanalysable:
-            print(f"note: nothing compiles {header}; not analysed", file=sys.stderr)
+    for header in unanalysable:
+        # Nothing compiles it, so nothing found in it reaches a binary. Worth
+        # saying, not worth blocking a push over.
+        print(f"note: nothing compiles {header}; not analysed", file=sys.stderr)
 
-    chosen, total = select(per_header, max_tus)
+    chosen, total = select(per_header, args.max_tus)
     if total > len(chosen):
         print(f"note: changed headers reach {total} translation units, "
               f"analysing {len(chosen)}. Set CLANG_TIDY_MAX_TUS=0 for all.",
               file=sys.stderr)
 
-    for tu in chosen:
-        print(tu)
+    print("\n".join(chosen))
     return 0
 
 
 if __name__ == "__main__":
-    sys.exit(main(sys.argv))
+    sys.exit(main())

--- a/.pre-commit-hooks/tus-for-headers.py
+++ b/.pre-commit-hooks/tus-for-headers.py
@@ -19,6 +19,8 @@ import sys
 from pathlib import Path
 
 ROOT = Path.cwd()
+SHIPPING = Path("magda")
+ENGINE = SHIPPING / "engine"
 
 
 def leaf(path: str) -> str:
@@ -139,8 +141,7 @@ def select(per_header: dict[str, list[Path]], max_tus: int) -> tuple[list[Path],
 
 def in_scope(source: Path) -> bool:
     """Shipping code, matching .clang-tidy's own scope."""
-    return (source.is_relative_to("magda")
-            and not source.is_relative_to("magda/engine"))
+    return source.is_relative_to(SHIPPING) and not source.is_relative_to(ENGINE)
 
 
 def build_parser() -> argparse.ArgumentParser:

--- a/.pre-commit-hooks/tus-for-headers.py
+++ b/.pre-commit-hooks/tus-for-headers.py
@@ -26,9 +26,9 @@ ENGINE = SHIPPING / "engine"
 def leaf(path: str) -> str:
     """Last component, whichever separator ninja wrote.
 
-    A string slice rather than Path(path).name: this runs on every one of a few
-    million dependency lines, and building a Path for each is far slower than
-    rejecting on a substring.
+    A slice rather than Path(path).name because this is the one hot line here:
+    over the 2.64M dependency lines of a full dump, 1.1s against 7.6s, on a run
+    that otherwise takes 12s and that somebody is waiting on to push.
     """
     return path[max(path.rfind("/"), path.rfind("\\")) + 1:]
 

--- a/.pre-commit-hooks/tus-for-headers.py
+++ b/.pre-commit-hooks/tus-for-headers.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Map changed headers to the translation units that compile them.
+
+`ninja -t deps` holds what the compiler itself recorded, so it covers transitive
+includes. Grepping for direct includes does not: ChordTypes.hpp reaches many TUs
+without a single .cpp naming it.
+
+Prints one repo-relative TU path per line. Exit 0 with output, 1 when the
+dependency data cannot be read, 2 when a header maps to nothing.
+"""
+import json
+import os
+import subprocess
+import sys
+
+
+def load_output_to_source(build_dir):
+    """Ninja target name -> repo-relative source, via the compile database."""
+    with open(os.path.join(build_dir, "compile_commands.json")) as handle:
+        db = json.load(handle)
+    root = os.path.normpath(os.getcwd())
+    mapping = {}
+    for entry in db:
+        output = entry.get("output")
+        if not output:
+            continue
+        source = os.path.normpath(os.path.abspath(entry["file"]))
+        if source.startswith(root + os.sep):
+            mapping[output] = os.path.relpath(source, root)
+    return mapping
+
+
+def dependents(build_dir, wanted):
+    """Ninja outputs whose recorded dependencies include any of `wanted`.
+
+    The dump runs to millions of lines, so the hot loop does no syscalls: reject
+    on basename first, and only then normalise a path. Resolving every line with
+    realpath() instead took 150s against ninja's own 10.
+    """
+    proc = subprocess.run(
+        ["ninja", "-C", build_dir, "-t", "deps"],
+        capture_output=True, text=True, check=False,
+    )
+    if proc.returncode != 0 or not proc.stdout:
+        return None
+
+    names = {os.path.basename(path) for path in wanted}
+    found = {}
+    current = None
+    stale = False
+    for line in proc.stdout.splitlines():
+        if not line:
+            continue
+        if line[0] != " ":
+            # "target: #deps N, deps mtime M (VALID|STALE)"
+            current = line.split(":", 1)[0]
+            stale = line.endswith("(STALE)")
+            continue
+        if current is None or stale:
+            continue
+        dep = line.strip()
+        if dep[dep.rfind("/") + 1:] not in names:
+            continue
+        if dep[0] != "/":
+            dep = os.path.join(build_dir, dep)
+        dep = os.path.normpath(dep)
+        if dep in wanted:
+            found.setdefault(wanted[dep], set()).add(current)
+    return found
+
+
+def main(argv):
+    build_dir = os.environ.get("BUILD_DIR", "cmake-build-debug")
+    headers = argv[1:]
+    if not headers:
+        return 0
+
+    wanted = {os.path.normpath(os.path.abspath(h)): h for h in headers}
+
+    found = dependents(build_dir, wanted)
+    if found is None:
+        print("could not read ninja dependency data", file=sys.stderr)
+        return 1
+
+    mapping = load_output_to_source(build_dir)
+
+    unmapped = [h for h in headers if h not in found]
+    if unmapped:
+        for header in unmapped:
+            print(f"no built translation unit depends on {header}", file=sys.stderr)
+        return 2
+
+    tus = set()
+    for outputs in found.values():
+        for output in outputs:
+            source = mapping.get(output)
+            # Tests and third_party compile these headers too, but the checks
+            # here target shipping code, matching .clang-tidy's own scope.
+            if source and source.startswith("magda/") and not source.startswith("magda/engine/"):
+                tus.add(source)
+
+    for tu in sorted(tus):
+        print(tu)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/.pre-commit-hooks/tus-for-headers.py
+++ b/.pre-commit-hooks/tus-for-headers.py
@@ -15,6 +15,16 @@ import subprocess
 import sys
 
 
+def basename(path):
+    """Last component, whichever separator ninja used.
+
+    os.path.basename only knows the host's separator, and ninja on Windows
+    writes backslashes, so a dependency would be compared whole against a bare
+    file name, match nothing, and take the "nothing compiles this" path.
+    """
+    return path[max(path.rfind("/"), path.rfind("\\")) + 1:]
+
+
 def load_output_to_source(build_dir):
     """Ninja target name -> repo-relative source, via the compile database."""
     with open(os.path.join(build_dir, "compile_commands.json")) as handle:
@@ -27,7 +37,9 @@ def load_output_to_source(build_dir):
             continue
         source = os.path.normpath(os.path.abspath(entry["file"]))
         if source.startswith(root + os.sep):
-            mapping[output] = os.path.relpath(source, root)
+            # Forward slashes throughout: these are matched against "magda/" and
+            # handed to clang-tidy, which takes them on Windows too.
+            mapping[output] = os.path.relpath(source, root).replace(os.sep, "/")
     return mapping
 
 
@@ -45,7 +57,7 @@ def dependents(build_dir, wanted):
     if proc.returncode != 0 or not proc.stdout:
         return None
 
-    names = {os.path.basename(path) for path in wanted}
+    names = {basename(path) for path in wanted}
     found = {}
     current = None
     stale = False
@@ -53,16 +65,21 @@ def dependents(build_dir, wanted):
         if not line:
             continue
         if line[0] != " ":
-            # "target: #deps N, deps mtime M (VALID|STALE)"
-            current = line.split(":", 1)[0]
+            # "target: #deps N, deps mtime M (VALID|STALE)". Split on the marker,
+            # not the first colon, which on Windows is the drive letter's.
+            marker = line.find(": #deps ")
+            if marker == -1:
+                current = None
+                continue
+            current = line[:marker]
             stale = line.endswith("(STALE)")
             continue
         if current is None or stale:
             continue
         dep = line.strip()
-        if dep[dep.rfind("/") + 1:] not in names:
+        if basename(dep) not in names:
             continue
-        if dep[0] != "/":
+        if not os.path.isabs(dep):
             dep = os.path.join(build_dir, dep)
         dep = os.path.normpath(dep)
         if dep in wanted:

--- a/.pre-commit-hooks/tus-for-headers.py
+++ b/.pre-commit-hooks/tus-for-headers.py
@@ -70,8 +70,47 @@ def dependents(build_dir, wanted):
     return found
 
 
+def select(per_header, max_tus):
+    """Pick TUs under a budget without starving any one header.
+
+    Flattening every header's candidates and truncating let one broadly
+    included header spend the whole budget, leaving another changed header with
+    nothing that compiles it. So each header gets a representative first, even
+    if that alone exceeds the budget - analysing every changed header matters
+    more than the ceiling - and only the fan-out beyond that is rationed, round
+    robin so no single header takes it all.
+    """
+    chosen, seen = [], set()
+
+    for tus in per_header.values():
+        for tu in tus:
+            if tu not in seen:
+                seen.add(tu)
+                chosen.append(tu)
+                break
+
+    total = len({tu for tus in per_header.values() for tu in tus})
+
+    remaining = [list(tus) for tus in per_header.values()]
+    while remaining and (max_tus <= 0 or len(chosen) < max_tus):
+        for tus in list(remaining):
+            while tus:
+                tu = tus.pop(0)
+                if tu not in seen:
+                    seen.add(tu)
+                    chosen.append(tu)
+                    break
+            if not tus:
+                remaining.remove(tus)
+            if max_tus > 0 and len(chosen) >= max_tus:
+                break
+
+    return chosen, total
+
+
 def main(argv):
     build_dir = os.environ.get("BUILD_DIR", "cmake-build-debug")
+    max_tus = int(os.environ.get("CLANG_TIDY_MAX_TUS", "8"))
     headers = argv[1:]
     if not headers:
         return 0
@@ -89,7 +128,7 @@ def main(argv):
         # Shipping code, matching .clang-tidy's own scope.
         return source.startswith("magda/") and not source.startswith("magda/engine/")
 
-    tus = set()
+    per_header = {}
     unanalysable = []
     for header in headers:
         sources = {mapping.get(o) for o in found.get(header, ())}
@@ -110,7 +149,7 @@ def main(argv):
         if not eligible:
             unanalysable.append(header)
             continue
-        tus |= eligible
+        per_header[header] = sorted(eligible)
 
     if unanalysable:
         # No translation unit compiles these, so nothing that could be found in
@@ -118,7 +157,13 @@ def main(argv):
         for header in unanalysable:
             print(f"note: nothing compiles {header}; not analysed", file=sys.stderr)
 
-    for tu in sorted(tus):
+    chosen, total = select(per_header, max_tus)
+    if total > len(chosen):
+        print(f"note: changed headers reach {total} translation units, "
+              f"analysing {len(chosen)}. Set CLANG_TIDY_MAX_TUS=0 for all.",
+              file=sys.stderr)
+
+    for tu in chosen:
         print(tu)
     return 0
 

--- a/.pre-commit-hooks/tus-for-headers.py
+++ b/.pre-commit-hooks/tus-for-headers.py
@@ -31,10 +31,10 @@ def leaf(path: str) -> str:
     return path[max(path.rfind("/"), path.rfind("\\")) + 1:]
 
 
-def output_to_source(build_dir: Path) -> dict[str, str]:
+def output_to_source(build_dir: Path) -> dict[str, Path]:
     """Ninja target name -> repo-relative source, from the compile database."""
     db = json.loads((build_dir / "compile_commands.json").read_text())
-    mapping: dict[str, str] = {}
+    mapping: dict[str, Path] = {}
     for entry in db:
         if not entry.get("output"):
             continue
@@ -42,9 +42,7 @@ def output_to_source(build_dir: Path) -> dict[str, str]:
         # syscall per entry costs more than the whole ninja dump.
         source = Path(entry["file"])
         if source.is_relative_to(ROOT):
-            # Posix throughout: matched against "magda/" and handed to
-            # clang-tidy, which takes forward slashes on Windows too.
-            mapping[entry["output"]] = source.relative_to(ROOT).as_posix()
+            mapping[entry["output"]] = source.relative_to(ROOT)
     return mapping
 
 
@@ -85,79 +83,98 @@ def dependents(build_dir: Path, wanted: dict[Path, str]) -> dict[str, set[str]] 
     return found
 
 
-def select(per_header: dict[str, list[str]], max_tus: int) -> tuple[list[str], int]:
-    """Pick TUs under a budget without starving any one header.
-
-    Flattening every header's candidates and truncating let one broadly included
-    header spend the whole budget, leaving another changed header with nothing
-    that compiles it. So each header gets a representative first, even if that
-    alone exceeds the budget - analysing every changed header matters more than
-    the ceiling - and only the fan-out beyond that is rationed, round robin.
-    """
-    chosen: list[str] = []
-    seen: set[str] = set()
+def one_per_header(per_header: dict[str, list[Path]]) -> list[Path]:
+    """One TU for each header, distinct where the candidates allow it."""
+    chosen: list[Path] = []
+    seen: set[Path] = set()
     for tus in per_header.values():
         for tu in tus:
             if tu not in seen:
                 seen.add(tu)
                 chosen.append(tu)
                 break
+    return chosen
 
-    total = len({tu for tus in per_header.values() for tu in tus})
 
-    remaining = [list(tus) for tus in per_header.values()]
-    while remaining and (max_tus <= 0 or len(chosen) < max_tus):
+def fan_out(per_header: dict[str, list[Path]], already: list[Path],
+            budget: int) -> list[Path]:
+    """Further TUs, round robin so no one header spends the whole budget.
+
+    A negative budget means no ceiling.
+    """
+    seen = set(already)
+    extra: list[Path] = []
+    remaining = [[tu for tu in tus if tu not in seen] for tus in per_header.values()]
+    remaining = [tus for tus in remaining if tus]
+
+    while remaining and (budget < 0 or len(extra) < budget):
         for tus in list(remaining):
             while tus:
                 tu = tus.pop(0)
                 if tu not in seen:
                     seen.add(tu)
-                    chosen.append(tu)
+                    extra.append(tu)
                     break
             if not tus:
                 remaining.remove(tus)
-            if max_tus > 0 and len(chosen) >= max_tus:
+            if 0 <= budget <= len(extra):
                 break
-    return chosen, total
+    return extra
 
 
-def in_scope(source: str) -> bool:
+def select(per_header: dict[str, list[Path]], max_tus: int) -> tuple[list[Path], int]:
+    """Pick TUs under a budget without starving any one header.
+
+    Flattening every header's candidates and truncating let one broadly included
+    header spend the whole budget, leaving another changed header with nothing
+    that compiles it. So the representatives are taken first and never capped -
+    analysing every changed header matters more than the ceiling - and only the
+    fan-out beyond them is rationed.
+    """
+    chosen = one_per_header(per_header)
+    total = len({tu for tus in per_header.values() for tu in tus})
+    budget = -1 if max_tus <= 0 else max(0, max_tus - len(chosen))
+    return chosen + fan_out(per_header, chosen, budget), total
+
+
+def in_scope(source: Path) -> bool:
     """Shipping code, matching .clang-tidy's own scope."""
-    return source.startswith("magda/") and not source.startswith("magda/engine/")
+    return (source.is_relative_to("magda")
+            and not source.is_relative_to("magda/engine"))
 
 
-def main() -> int:
+def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("paths", nargs="*", metavar="FILE")
     parser.add_argument("--missing", action="store_true")
     parser.add_argument("--build-dir", type=Path, default=Path("cmake-build-debug"))
     parser.add_argument("--max-tus", type=int, default=8)
-    args = parser.parse_args()
+    return parser
 
-    if not args.paths:
-        return 0
 
-    if args.missing:
-        # Resolved by the code that reads the database, not by a grep in the
-        # hook: it records absolute native paths, so matching a relative one by
-        # string has to assume a separator.
-        known = set(output_to_source(args.build_dir).values())
-        for path in args.paths:
-            if Path(path).as_posix() not in known:
-                print(path)
-        return 0
+def report_missing(build_dir: Path, paths: list[str]) -> int:
+    """Print the given paths that no compile command mentions.
 
-    wanted = {Path(h).resolve(): h for h in args.paths}
-    found = dependents(args.build_dir, wanted)
-    if found is None:
-        print("could not read ninja dependency data", file=sys.stderr)
-        return 1
+    Answered here rather than by a grep in the hook: the database records
+    absolute native paths, so matching a relative one by string has to assume a
+    separator, and on Windows guessing wrong marks every file missing.
+    """
+    known = set(output_to_source(build_dir).values())
+    for path in paths:
+        if Path(path) not in known:
+            print(path)
+    return 0
 
-    mapping = output_to_source(args.build_dir)
 
-    per_header: dict[str, list[str]] = {}
+def group_by_header(
+    headers: list[str],
+    found: dict[str, set[str]],
+    mapping: dict[str, Path],
+) -> tuple[dict[str, list[Path]], list[str]]:
+    """Candidate TUs per header, and the headers nothing compiles."""
+    per_header: dict[str, list[Path]] = {}
     unanalysable: list[str] = []
-    for header in args.paths:
+    for header in headers:
         sources = {tu for o in found.get(header, ()) if (tu := mapping.get(o))}
         # Scoping has to be judged per header, after mapping. Deciding it from
         # the raw dependency set counted a header reached only through a test TU
@@ -169,6 +186,24 @@ def main() -> int:
             per_header[header] = sorted(eligible)
         else:
             unanalysable.append(header)
+    return per_header, unanalysable
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    if not args.paths:
+        return 0
+    if args.missing:
+        return report_missing(args.build_dir, args.paths)
+
+    wanted = {Path(h).resolve(): h for h in args.paths}
+    found = dependents(args.build_dir, wanted)
+    if found is None:
+        print("could not read ninja dependency data", file=sys.stderr)
+        return 1
+
+    per_header, unanalysable = group_by_header(
+        args.paths, found, output_to_source(args.build_dir))
 
     for header in unanalysable:
         # Nothing compiles it, so nothing found in it reaches a binary. Worth
@@ -181,7 +216,9 @@ def main() -> int:
               f"analysing {len(chosen)}. Set CLANG_TIDY_MAX_TUS=0 for all.",
               file=sys.stderr)
 
-    print("\n".join(chosen))
+    # Posix at the boundary: these go to clang-tidy and are matched against
+    # "magda/" in the hook, and str(Path) would give backslashes on Windows.
+    print("\n".join(tu.as_posix() for tu in chosen))
     return 0
 
 

--- a/.pre-commit-hooks/tus-for-headers.py
+++ b/.pre-commit-hooks/tus-for-headers.py
@@ -5,8 +5,9 @@
 includes. Grepping for direct includes does not: ChordTypes.hpp reaches many TUs
 without a single .cpp naming it.
 
-Prints one repo-relative TU path per line. Exit 0 with output, 1 when the
-dependency data cannot be read, 2 when a header maps to nothing.
+Prints one repo-relative TU path per line, and exits non-zero only when the
+dependency data cannot be read at all. A header no translation unit compiles
+produces a note instead: nothing found in it could reach a binary.
 """
 import json
 import os
@@ -84,20 +85,38 @@ def main(argv):
 
     mapping = load_output_to_source(build_dir)
 
-    unmapped = [h for h in headers if h not in found]
-    if unmapped:
-        for header in unmapped:
-            print(f"no built translation unit depends on {header}", file=sys.stderr)
-        return 2
+    def in_scope(source):
+        # Shipping code, matching .clang-tidy's own scope.
+        return source.startswith("magda/") and not source.startswith("magda/engine/")
 
     tus = set()
-    for outputs in found.values():
-        for output in outputs:
-            source = mapping.get(output)
-            # Tests and third_party compile these headers too, but the checks
-            # here target shipping code, matching .clang-tidy's own scope.
-            if source and source.startswith("magda/") and not source.startswith("magda/engine/"):
-                tus.add(source)
+    unanalysable = []
+    for header in headers:
+        sources = {mapping.get(o) for o in found.get(header, ())}
+        sources.discard(None)
+
+        eligible = {s for s in sources if in_scope(s)}
+        if not eligible:
+            # Scoping has to be judged per header, after mapping. Deciding it
+            # from the raw dependency set counted a header reached only through
+            # a test TU as mapped, then filtered every candidate away and
+            # returned success having chosen nothing.
+            #
+            # A header only tests compile is still analysed, through the test
+            # TU: HeaderFilterRegex decides which headers get diagnostics, so
+            # the header's own findings are reported either way.
+            eligible = sources
+
+        if not eligible:
+            unanalysable.append(header)
+            continue
+        tus |= eligible
+
+    if unanalysable:
+        # No translation unit compiles these, so nothing that could be found in
+        # them reaches a binary. Worth saying, not worth blocking a push over.
+        for header in unanalysable:
+            print(f"note: nothing compiles {header}; not analysed", file=sys.stderr)
 
     for tu in sorted(tus):
         print(tu)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,18 @@ if(APPLE AND NOT DEFINED CMAKE_OSX_DEPLOYMENT_TARGET)
     set(CMAKE_OSX_DEPLOYMENT_TARGET "11.0" CACHE STRING "Minimum macOS version")
 endif()
 
+# Naming the SDK puts -isysroot into compile_commands.json. Apple's /usr/bin/c++
+# finds the SDK through xcrun and so records nothing, which leaves Homebrew's
+# clang-tidy unable to find <vector>. Tools that read the database cannot compute
+# the path themselves, so it has to be written down here.
+# Empty rather than undefined is the normal state here: CMake declares the cache
+# entry and leaves it blank when the compiler resolves the SDK by itself, so a
+# plain NOT DEFINED guard never fires and a non-FORCE set() cannot fill it in.
+# Only fills a blank value, so an explicitly chosen SDK still wins.
+if(APPLE AND NOT CMAKE_OSX_SYSROOT)
+    set(CMAKE_OSX_SYSROOT "macosx" CACHE STRING "macOS SDK for the compile database" FORCE)
+endif()
+
 # Windows has no system libxml2 (see vcpkg.json); it comes from vcpkg, which CI
 # wires in via -DCMAKE_TOOLCHAIN_FILE. For local dev (CLion, plain cmake, the
 # Makefile) auto-detect a vcpkg install from the VCPKG_ROOT environment variable

--- a/docs/development/code-style.md
+++ b/docs/development/code-style.md
@@ -159,19 +159,31 @@ Install pre-commit hooks for automatic quality checks:
 # Install pre-commit (if not already installed)
 pip install pre-commit
 
-# Install hooks
-pre-commit install
+# Install hooks, both stages
+pre-commit install --hook-type pre-commit --hook-type pre-push
 
 # Run hooks on all files
 pre-commit run --all-files
 ```
 
-The pre-commit configuration includes:
+Existing clones need that command again: plain `pre-commit install` writes only
+`.git/hooks/pre-commit`, so the pre-push checks below stay uninstalled until you
+re-run it. A hand-written `pre-push` hook already in the clone is moved to
+`pre-push.legacy` and still runs, so the guard against pushing to main and the
+git-lfs handoff are kept. Do not pass `-f`, which deletes it instead.
+
+On commit:
 - Automatic formatting with clang-format
 - Trailing whitespace removal
 - End-of-file fixes
 - YAML validation
 - Large file checks
+
+On push:
+- A debug build
+- clang-tidy over the changed files, which fails on a finding in the enforced
+  tier (see `.pre-commit-hooks/clang-tidy.sh`)
+- The test suite
 
 ## CI Integration
 

--- a/setup.sh
+++ b/setup.sh
@@ -117,10 +117,12 @@ if command -v python3 &> /dev/null || command -v python &> /dev/null; then
     fi
 
     if command -v pre-commit &> /dev/null; then
-        pre-commit install 2>/dev/null || true
-        print_success "Pre-commit hooks installed"
+        # Both types: the build, clang-tidy and test hooks are pre-push, and an
+        # older pre-commit without default_install_hook_types would skip them.
+        pre-commit install --hook-type pre-commit --hook-type pre-push 2>/dev/null || true
+        print_success "Pre-commit and pre-push hooks installed"
     else
-        print_warning "pre-commit not found. Run 'pip install pre-commit && pre-commit install' to enable quality checks."
+        print_warning "pre-commit not found. Run 'pip install pre-commit && pre-commit install --hook-type pre-commit --hook-type pre-push' to enable quality checks."
     fi
 else
     print_warning "Python not found. Pre-commit hooks will not be installed."


### PR DESCRIPTION
Seven clang-tidy sweeps have landed and nothing was enforcing any of them. The
hook that existed could not fail: it ended its command with `|| true`, and
clang-tidy exits 0 for a plain warning regardless. It also hardcoded the Homebrew
path and printed "clang-tidy not found, skipping" everywhere else.

## What changes

The hook now lives in `.pre-commit-hooks/clang-tidy.sh` and takes pass/fail from
the exit code, which `--warnings-as-errors` is what makes meaningful.

`CMAKE_OSX_SYSROOT` is named so the compile database carries `-isysroot`. Apple's
`/usr/bin/c++` resolves the SDK through xcrun and records nothing, which left
Homebrew's clang-tidy unable to find `TargetConditionals.h`. The Makefile worked
around it by computing the path per invocation; a hook cannot. Only a blank value
is filled, so an explicitly chosen SDK still wins, and every database consumer
benefits, editors included.

## Why not pocc/pre-commit-hooks

It was the obvious choice and it does not work here. Its clang-tidy hook decides
pass/fail from whether stderr is empty, and clang-tidy always writes an
"N warnings generated." tally. The regex meant to strip that matches the singular
"warning generated" only:

```python
re.sub(rb"[\d,]+ warning \S+\s+", b"", self.stderr)   # vs "214 warnings generated."
```

So every file in this codebase fails it. pre-commit cannot set the `CLANG_TIDY`
environment variable, so a wrapper cannot be interposed either.

## What is enforced

The bugprone/cert half of `.clang-tidy`, minus five checks that still report,
measured over `magda/` without engine:

| check | findings |
|---|---|
| implicit-widening-of-multiplication-result | 31 |
| incorrect-roundings | 4 (the deliberate ClipWaveformPainter pixel roundings) |
| unused-return-value | 2 |
| return-const-ref-from-parameter | 2 |
| reserved-identifier | 1 |

The rest of that tier is at zero. Sweeping these five is the next batch and is
what unblocks `WarningsAsErrors`.

Verified both directions: a clean file passes, and a file with a real finding
exits 1 with the diagnostic.

## One correction to .clang-tidy

It claimed `bugprone-exception-escape` "stays enabled and currently reports zero"
while disabling it fourteen lines above. It reports 44, so the disable was right
and the paragraph was not. Rewritten to say what re-enabling would cost; the
noise table's count corrected from 33 to 44.

`magda/engine` is excluded while the native engine is still being written.

## Note

The hook runs at `pre-push`, where `build-check` and `test-check` already sit,
because clang-tidy compiles a full TU per file and is too slow for every commit.
Easy to move if you would rather have it on commit.

https://claude.ai/code/session_01VomqgBSXsWYdyHyec9DvPi
