### PR TITLE
Report the recording pass without a poll

### DIFF
--- a/magda/engine/CMakeLists.txt
+++ b/magda/engine/CMakeLists.txt
@@ -157,6 +157,7 @@ add_library(magda_engine STATIC
     io/RecordThread.hpp
     io/RecordingFeed.hpp
     io/TakeFileSink.hpp
+    io/TakeNotes.hpp
     io/TakePasses.hpp
     io/TakeRecorder.hpp
     io/SourceReaders.hpp

--- a/magda/engine/CMakeLists.txt
+++ b/magda/engine/CMakeLists.txt
@@ -102,6 +102,8 @@ add_library(magda_engine STATIC
     param/ModSources.hpp
     param/ModRuntime.hpp
     tap/LevelTap.hpp
+    tap/RecordTap.cpp
+    tap/RecordTap.hpp
     tap/SampleRing.hpp
     tap/ValueTap.hpp
     launch/FollowActions.cpp

--- a/magda/engine/io/MidiTakeRecorder.cpp
+++ b/magda/engine/io/MidiTakeRecorder.cpp
@@ -210,7 +210,8 @@ MidiTakeRecorder::MidiTakeRecorder(const LiveInputFeed& feed,
                                    const MidiTakeRecorderSettings& settings)
     : settings_(settings),
       input_(feed, settings_.source, settings_.latencySamples),
-      stream_(sink_, queueFor(settings_)) {
+      stream_(sink_, queueFor(settings_)),
+      tap_(RecordMaterial::midi, settings_.tap) {
     // Sized once, so a block's events are copied into it and never allocate.
     events_.ensureSize(static_cast<std::size_t>(kMaxMidiBytesPerPort));
 }
@@ -236,10 +237,11 @@ void MidiTakeRecorder::capture(const BlockInfo& block, bool countingIn, const Lo
             return;
         }
 
-        openPass(loop);
+        openPass(block, loop);
     }
 
     write(block);
+    publish(block);
     arrivals_ += block.numSamples;
 }
 
@@ -253,9 +255,13 @@ void MidiTakeRecorder::start(const BlockInfo& block, const LoopRange& loop) {
     sampleRate_ = block.rate();
     origin_ = block.materialOrigin;
     startedAtLoopStart_ = atLoopStart(block, loop);
+
+    passOrigin_ = 0;
+    passOriginBeat_ = startBeat_;
+    tap_.open(startBeat_);
 }
 
-void MidiTakeRecorder::openPass(const LoopRange& loop) {
+void MidiTakeRecorder::openPass(const BlockInfo& block, const LoopRange& loop) {
     loopStartBeat_ = loop.startBeat;
     loopEndBeat_ = loop.endBeat;
 
@@ -268,11 +274,19 @@ void MidiTakeRecorder::openPass(const LoopRange& loop) {
     }
 
     boundaries_[numBoundaries_++] = arrivals_;
+
+    // The pass the tap draws is the pass the clip will be, so it opens on the
+    // boundary that was taken: a pass end the take could not hold is two passes
+    // run together for the preview as well.
+    passOrigin_ = arrivals_;
+    passOriginBeat_ = liveBeatAt(block, arrivals_);
+    tap_.open(block.beats.start);
 }
 
 void MidiTakeRecorder::stop() {
     state_ = State::stopped;
     rolling_.store(false, std::memory_order_relaxed);
+    tap_.close();
 }
 
 void MidiTakeRecorder::write(const BlockInfo& block) {
@@ -287,6 +301,32 @@ void MidiTakeRecorder::write(const BlockInfo& block) {
     // The one head correction, applied on the way in.
     stream_.writeMidi(events_, arrivals_ - settings_.latencySamples);
     captured_.fetch_add(events_.getNumEvents(), std::memory_order_relaxed);
+}
+
+void MidiTakeRecorder::publish(const BlockInfo& block) {
+    const auto head = arrivals_ - settings_.latencySamples;
+
+    for (const auto metadata : events_) {
+        const auto sample = head + metadata.samplePosition;
+
+        // A latency can stamp an event before the pass it arrived in began,
+        // and the pass that owns it has already been drawn. finish() still
+        // places it, in the pass it belongs to.
+        if (sample < passOrigin_)
+            continue;
+
+        const auto message = metadata.getMessage();
+        const auto beat = liveBeatAt(block, sample) - passOriginBeat_;
+
+        // JUCE's own reading of a note on at zero velocity, which is the wire
+        // rule kindOf() keeps above.
+        if (message.isNoteOn())
+            tap_.noteOn(message.getChannel(), message.getNoteNumber(), message.getVelocity(), beat);
+        else if (message.isNoteOff())
+            tap_.noteOff(message.getChannel(), message.getNoteNumber(), beat);
+    }
+
+    tap_.extend(std::max(0.0, liveBeatAt(block, end_) - passOriginBeat_));
 }
 
 double MidiTakeRecorder::timeAt(std::int64_t sample) const {

--- a/magda/engine/io/MidiTakeRecorder.cpp
+++ b/magda/engine/io/MidiTakeRecorder.cpp
@@ -11,43 +11,13 @@ namespace magda::engine {
 
 namespace {
 
-constexpr std::size_t kMidiChannels = 16;
-constexpr std::size_t kNotesPerChannel = 128;
-constexpr std::size_t kHeldNotes = kMidiChannels * kNotesPerChannel;
-
-constexpr unsigned kTypeMask = 0xf0U;
 constexpr unsigned kChannelMask = 0x0fU;
 constexpr unsigned kDataMask = 0x7fU;
 
-/// What one channel message is, as far as the model has a field for it.
-enum class Kind : std::uint8_t { noteOn, noteOff, controller, pitchBend, unsupported };
-
-Kind kindOf(const RecordedMidiEvent& event) {
-    switch (static_cast<unsigned>(event.status) & kTypeMask) {
-        case 0x80U:
-            return Kind::noteOff;
-
-        // Note on at zero velocity is a note off: the wire rule, and most
-        // controllers never send 0x80 at all.
-        case 0x90U:
-            return event.data2 == 0 ? Kind::noteOff : Kind::noteOn;
-
-        case 0xb0U:
-            return Kind::controller;
-
-        case 0xe0U:
-            return Kind::pitchBend;
-
-        default:
-            return Kind::unsupported;
-    }
-}
-
-/// Where a channel's note sits in the held table.
-std::size_t heldIndex(const RecordedMidiEvent& event) {
-    const auto channel = static_cast<unsigned>(event.status) & kChannelMask;
-    const auto note = static_cast<unsigned>(event.data1) & kDataMask;
-    return (static_cast<std::size_t>(channel) * kNotesPerChannel) + note;
+/// Where a channel's note sits in the held table (io/TakeNotes.hpp).
+std::uint32_t entryOf(const RecordedMidiEvent& event) {
+    return HeldNotes::entryFor(static_cast<int>(static_cast<unsigned>(event.status) & kChannelMask),
+                               static_cast<int>(static_cast<unsigned>(event.data1) & kDataMask));
 }
 
 /// The 14 bits a pitch wheel splits across its two data bytes.
@@ -79,7 +49,10 @@ class PassWalk {
   public:
     /// @p beatOf gives the take-relative beat of a take position.
     PassWalk(std::span<const std::int64_t> edges, std::function<double(std::int64_t)> beatOf)
-        : edges_(edges), beatOf_(std::move(beatOf)), takes_(edges.size() - 1), held_(kHeldNotes) {
+        : edges_(edges),
+          beatOf_(std::move(beatOf)),
+          takes_(edges.size() - 1),
+          pending_(HeldNotes::kEntries) {
         passStart_.reserve(takes_.size());
 
         for (std::size_t pass = 0; pass < takes_.size(); ++pass)
@@ -101,45 +74,49 @@ class PassWalk {
         return beatOf_(sample) - passStart_[pass];
     }
 
-    void closeNote(std::size_t pass, std::size_t index, std::int64_t endSample);
+    void closeNote(std::size_t pass, std::uint32_t entry, std::int64_t endSample);
     void closePass(std::size_t pass);
 
     std::span<const std::int64_t> edges_;
     std::function<double(std::int64_t)> beatOf_;
     std::vector<double> passStart_;
     std::vector<MidiTake> takes_;
-    std::vector<HeldNote> held_;
+
+    /// Which pitches are down, and what a second strike does, shared with the
+    /// preview (io/TakeNotes.hpp). What each of them is stays here.
+    HeldNotes down_;
+    std::vector<HeldNote> pending_;
 
     std::size_t pass_ = 0;
     std::int64_t dropped_ = 0;
 };
 
 /// A note the pass owns, positioned against the pass it started in.
-void PassWalk::closeNote(std::size_t pass, std::size_t index, std::int64_t endSample) {
-    auto& note = held_[index];
-    if (note.start < 0)
-        return;
+void PassWalk::closeNote(std::size_t pass, std::uint32_t entry, std::int64_t endSample) {
+    const auto& note = pending_[entry];
 
     const auto from = beatIn(pass, note.start);
     const auto to = beatIn(pass, endSample);
 
     // A note whose length fell wholly outside the pass never sounded in it.
-    if (to > from) {
-        MidiNote played;
-        played.noteNumber = static_cast<int>(index % kNotesPerChannel);
-        played.velocity = note.velocity;
-        played.startBeat = from;
-        played.lengthBeats = to - from;
-        takes_[pass].notes.push_back(played);
-    }
+    if (to <= from)
+        return;
 
-    note = {};
+    MidiNote played;
+    played.noteNumber = HeldNotes::noteOf(entry);
+    played.velocity = note.velocity;
+    played.startBeat = from;
+    played.lengthBeats = to - from;
+    takes_[pass].notes.push_back(played);
 }
 
 // A note held across a wrap belongs to the pass it started in, once.
 void PassWalk::closePass(std::size_t pass) {
-    for (std::size_t index = 0; index < kHeldNotes; ++index)
-        closeNote(pass, index, edges_[pass + 1]);
+    while (!down_.down().empty()) {
+        const auto entry = down_.down().back();
+        down_.release(entry);
+        closeNote(pass, entry, edges_[pass + 1]);
+    }
 }
 
 void PassWalk::add(const RecordedMidiEvent& event) {
@@ -152,15 +129,22 @@ void PassWalk::add(const RecordedMidiEvent& event) {
     }
 
     switch (kindOf(event)) {
-        case Kind::noteOn:
-            held_[heldIndex(event)] = {.start = event.sample, .velocity = event.data2};
+        case MidiKind::noteOn: {
+            // A pitch already down is replaced rather than joined: nothing can
+            // close two of one pitch (io/TakeNotes.hpp).
+            const auto entry = entryOf(event);
+            down_.hold(entry);
+            pending_[entry] = {.start = event.sample, .velocity = event.data2};
             break;
+        }
 
-        case Kind::noteOff:
-            closeNote(pass_, heldIndex(event), event.sample);
+        case MidiKind::noteOff: {
+            if (const auto entry = entryOf(event); down_.release(entry))
+                closeNote(pass_, entry, event.sample);
             break;
+        }
 
-        case Kind::controller: {
+        case MidiKind::controller: {
             MidiCCData cc;
             cc.controller = event.data1;
             cc.value = event.data2;
@@ -170,7 +154,7 @@ void PassWalk::add(const RecordedMidiEvent& event) {
             break;
         }
 
-        case Kind::pitchBend: {
+        case MidiKind::pitchBend: {
             MidiPitchBendData bend;
             bend.value = pitchBendValue(event);
             bend.beatPosition = beatIn(pass_, event.sample);
@@ -181,7 +165,7 @@ void PassWalk::add(const RecordedMidiEvent& event) {
 
         // Program change, aftertouch, pressure, system: no field to put them
         // in, counted here rather than dropped inside a converter.
-        case Kind::unsupported:
+        case MidiKind::unsupported:
             ++dropped_;
             break;
     }
@@ -258,7 +242,7 @@ void MidiTakeRecorder::start(const BlockInfo& block, const LoopRange& loop) {
 
     passOrigin_ = 0;
     passOriginBeat_ = startBeat_;
-    tap_.open(startBeat_);
+    preview_.open(startBeat_);
 }
 
 void MidiTakeRecorder::openPass(const BlockInfo& block, const LoopRange& loop) {
@@ -280,7 +264,8 @@ void MidiTakeRecorder::openPass(const BlockInfo& block, const LoopRange& loop) {
     // run together for the preview as well.
     passOrigin_ = arrivals_;
     passOriginBeat_ = liveBeatAt(block, arrivals_);
-    tap_.open(block.beats.start);
+
+    preview_.open(block.beats.start);
 }
 
 void MidiTakeRecorder::stop() {
@@ -306,6 +291,10 @@ void MidiTakeRecorder::write(const BlockInfo& block) {
 void MidiTakeRecorder::publish(const BlockInfo& block) {
     const auto head = arrivals_ - settings_.latencySamples;
 
+    // One block is one transition, so a reader takes the pass before this block
+    // or after it and never partway through its events.
+    const RecordTap::Change change(tap_);
+
     for (const auto metadata : events_) {
         const auto sample = head + metadata.samplePosition;
 
@@ -316,17 +305,29 @@ void MidiTakeRecorder::publish(const BlockInfo& block) {
             continue;
 
         const auto message = metadata.getMessage();
+        const auto* bytes = message.getRawData();
+        const auto data2 = message.getRawDataSize() > 2 ? bytes[2] : 0;
         const auto beat = liveBeatAt(block, sample) - passOriginBeat_;
 
-        // JUCE's own reading of a note on at zero velocity, which is the wire
-        // rule kindOf() keeps above.
-        if (message.isNoteOn())
-            tap_.noteOn(message.getChannel(), message.getNoteNumber(), message.getVelocity(), beat);
-        else if (message.isNoteOff())
-            tap_.noteOff(message.getChannel(), message.getNoteNumber(), beat);
+        // The take's own reading of the message and of what a strike does to a
+        // pitch already down, so the overlay and the clip are the same notes
+        // rather than two answers about them (io/TakeNotes.hpp).
+        switch (kindOf(bytes[0], data2)) {
+            case MidiKind::noteOn:
+                preview_.strike(message.getChannel(), message.getNoteNumber(),
+                                message.getVelocity(), beat);
+                break;
+
+            case MidiKind::noteOff:
+                preview_.release(message.getChannel(), message.getNoteNumber(), beat);
+                break;
+
+            default:
+                break;
+        }
     }
 
-    tap_.extend(std::max(0.0, liveBeatAt(block, end_) - passOriginBeat_));
+    preview_.reaches(std::max(0.0, liveBeatAt(block, end_) - passOriginBeat_));
 }
 
 double MidiTakeRecorder::timeAt(std::int64_t sample) const {

--- a/magda/engine/io/MidiTakeRecorder.cpp
+++ b/magda/engine/io/MidiTakeRecorder.cpp
@@ -190,12 +190,12 @@ bool MidiTakeSink::writeMidi(std::span<const RecordedMidiEvent> events) {
     return true;
 }
 
-MidiTakeRecorder::MidiTakeRecorder(const LiveInputFeed& feed,
+MidiTakeRecorder::MidiTakeRecorder(const LiveInputFeed& feed, RecordTap& tap,
                                    const MidiTakeRecorderSettings& settings)
     : settings_(settings),
       input_(feed, settings_.source, settings_.latencySamples),
       stream_(sink_, queueFor(settings_)),
-      tap_(RecordMaterial::midi, settings_.tap) {
+      tap_(tap) {
     // Sized once, so a block's events are copied into it and never allocate.
     events_.ensureSize(static_cast<std::size_t>(kMaxMidiBytesPerPort));
 }

--- a/magda/engine/io/MidiTakeRecorder.hpp
+++ b/magda/engine/io/MidiTakeRecorder.hpp
@@ -75,9 +75,6 @@ struct MidiTakeRecorderSettings {
 
     /// How much the queue holds. Its channel count is always zero.
     RecordStreamSettings stream;
-
-    /// How much of the pass in flight is published (#2463).
-    RecordTapSettings tap;
 };
 
 /** @brief The record thread's end of a MIDI take: the events, in arrival order. */
@@ -103,7 +100,9 @@ class MidiTakeSink final : public RecordSink {
  */
 class MidiTakeRecorder final : public TakeCapture {
   public:
-    MidiTakeRecorder(const LiveInputFeed& feed, const MidiTakeRecorderSettings& settings);
+    /// @p tap is not owned and outlives the take (#2463).
+    MidiTakeRecorder(const LiveInputFeed& feed, RecordTap& tap,
+                     const MidiTakeRecorderSettings& settings);
 
     ~MidiTakeRecorder() override = default;
 
@@ -189,7 +188,7 @@ class MidiTakeRecorder final : public TakeCapture {
     LiveMidiInput input_;
     MidiTakeSink sink_;
     RecordStream stream_;
-    RecordTap tap_;
+    RecordTap& tap_;
 
     /// This block's events, sized once so a capture cannot allocate.
     juce::MidiBuffer events_;

--- a/magda/engine/io/MidiTakeRecorder.hpp
+++ b/magda/engine/io/MidiTakeRecorder.hpp
@@ -13,6 +13,7 @@
 #include "io/LiveInput.hpp"
 #include "io/RecordStream.hpp"
 #include "io/RecordingFeed.hpp"
+#include "io/TakeNotes.hpp"
 #include "io/TakePasses.hpp"
 #include "tap/RecordTap.hpp"
 #include "transport/TempoMap.hpp"
@@ -192,6 +193,10 @@ class MidiTakeRecorder final : public TakeCapture {
 
     /// This block's events, sized once so a capture cannot allocate.
     juce::MidiBuffer events_;
+
+    /// The pass's notes as the tap holds them, over the table the finished take
+    /// walks as well (io/TakeNotes.hpp).
+    PreviewNotes preview_{tap_};
 
     State state_ = State::waiting;
 

--- a/magda/engine/io/MidiTakeRecorder.hpp
+++ b/magda/engine/io/MidiTakeRecorder.hpp
@@ -14,6 +14,7 @@
 #include "io/RecordStream.hpp"
 #include "io/RecordingFeed.hpp"
 #include "io/TakePasses.hpp"
+#include "tap/RecordTap.hpp"
 #include "transport/TempoMap.hpp"
 #include "transport/TimeDomains.hpp"
 #include "transport/TransportState.hpp"
@@ -73,6 +74,9 @@ struct MidiTakeRecorderSettings {
 
     /// How much the queue holds. Its channel count is always zero.
     RecordStreamSettings stream;
+
+    /// How much of the pass in flight is published (#2463).
+    RecordTapSettings tap;
 };
 
 /** @brief The record thread's end of a MIDI take: the events, in arrival order. */
@@ -116,6 +120,11 @@ class MidiTakeRecorder final : public TakeCapture {
 
     void capture(const BlockInfo& block, bool countingIn, const LoopRange& loop) override;
 
+    /// Where the pass in flight is published (#2463).
+    const RecordTap& tap() const override {
+        return tap_;
+    }
+
     /// Events offered to the queue so far. Read from any thread (#2463).
     std::int64_t capturedEvents() const {
         return captured_.load(std::memory_order_relaxed);
@@ -145,12 +154,22 @@ class MidiTakeRecorder final : public TakeCapture {
     void start(const BlockInfo& block, const LoopRange& loop);
 
     /// A wrap: where the pass ended, in the take's own positions.
-    void openPass(const LoopRange& loop);
+    void openPass(const BlockInfo& block, const LoopRange& loop);
 
     void stop();
 
     /// This block's events, stamped and queued.
     void write(const BlockInfo& block);
+
+    /// This block's notes and the pass's length, as the block leaves them.
+    void publish(const BlockInfo& block);
+
+    /// The beat @p sample falls on, through the block's own map: the same
+    /// conversion finish() makes, so the preview and the clip place a note
+    /// alike unless the tempo is edited mid-take.
+    double liveBeatAt(const BlockInfo& block, std::int64_t sample) const {
+        return block.beatAtTime(timeAt(sample));
+    }
 
     /// The beat @p moment falls on, as BlockInfo::beatAtTime reads it.
     double beatAt(const TempoMap& tempo, double moment) const;
@@ -169,6 +188,7 @@ class MidiTakeRecorder final : public TakeCapture {
     LiveMidiInput input_;
     MidiTakeSink sink_;
     RecordStream stream_;
+    RecordTap tap_;
 
     /// This block's events, sized once so a capture cannot allocate.
     juce::MidiBuffer events_;
@@ -188,6 +208,12 @@ class MidiTakeRecorder final : public TakeCapture {
     double startBeat_ = 0.0;
     double startSeconds_ = 0.0;
     double sampleRate_ = 0.0;
+
+    /// Where the pass in flight began, in the take's own positions and in the
+    /// beats they resolve to. What the tap's notes are relative to, which is
+    /// what MidiTake holds them relative to.
+    std::int64_t passOrigin_ = 0;
+    double passOriginBeat_ = 0.0;
 
     /// The block's own beat origin, so a beat is read here as the render read it.
     MaterialOrigin origin_;

--- a/magda/engine/io/RecordingFeed.hpp
+++ b/magda/engine/io/RecordingFeed.hpp
@@ -5,6 +5,7 @@
 #include <vector>
 
 #include "exec/RenderContext.hpp"
+#include "tap/RecordTap.hpp"
 #include "transport/TransportState.hpp"
 
 /**
@@ -34,6 +35,10 @@ class TakeCapture {
      * else ends the take.
      */
     virtual void capture(const BlockInfo& block, bool countingIn, const LoopRange& loop) = 0;
+
+    /// Where the take publishes the pass in flight (#2463). Read from any
+    /// thread, for as long as whoever owns the take keeps it.
+    virtual const RecordTap& tap() const = 0;
 };
 
 /// The takes a callback feeds. Not owned: whoever publishes them keeps them

--- a/magda/engine/io/TakeFileSink.hpp
+++ b/magda/engine/io/TakeFileSink.hpp
@@ -65,6 +65,15 @@ class TakeFileSink final : public RecordSink {
      */
     bool markPassEnd(std::int64_t takeSample);
 
+    /// Pass ends asked for and not reached yet. The counterpart of the queue's
+    /// own capacity: that bounds how far behind the disk may fall in samples,
+    /// and this bounds it in passes. What will not fit is refused rather than
+    /// dropped, so a take can say its passes ran together (#2461).
+    ///
+    /// Public because the preview follows the same accepted boundaries and is
+    /// sized from this rather than from a number of its own (#2463).
+    static constexpr std::size_t kBoundaryCapacity = 256;
+
     bool writeAudio(juce::dsp::AudioBlock<const float> audio, int numSamples) override;
 
     void finish() override;
@@ -111,12 +120,6 @@ class TakeFileSink final : public RecordSink {
     std::int64_t written_ = 0;
 
     bool failed_ = false;
-
-    /// Pass ends asked for and not reached yet. The counterpart of the queue's
-    /// own capacity: that bounds how far behind the disk may fall in samples,
-    /// and this bounds it in passes. What will not fit is refused rather than
-    /// dropped, so a take can say its passes ran together (#2461).
-    static constexpr std::size_t kBoundaryCapacity = 256;
 
     std::array<std::int64_t, kBoundaryCapacity> boundaries_{};
     std::atomic<std::uint64_t> boundaryWrite_{0};

--- a/magda/engine/io/TakeNotes.hpp
+++ b/magda/engine/io/TakeNotes.hpp
@@ -1,0 +1,196 @@
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <span>
+#include <vector>
+
+#include "io/RecordStream.hpp"
+#include "tap/RecordTap.hpp"
+
+/**
+ * @file TakeNotes.hpp
+ * @brief What a pass of MIDI is made of, for everything that reads one (#2462, #2463).
+ *
+ * The sibling of TakePasses.hpp: that holds the loop rules a take keeps, this
+ * holds the note rules. The finished take and the pass in flight drive one of
+ * these each, so a clip and the overlay drawn while it was recorded cannot
+ * disagree about what a message is, which note a release closes, or what a
+ * second strike does -- which is what they did disagree about (#2527 review).
+ */
+
+namespace magda::engine {
+
+/// What one channel message is, as far as the model has a field for it.
+enum class MidiKind : std::uint8_t { noteOn, noteOff, controller, pitchBend, unsupported };
+
+/**
+ * @brief The kind of a channel message, from its status and second data byte.
+ *
+ * A note on at zero velocity is a note off: the wire rule, and most controllers
+ * never send 0x80 at all.
+ */
+constexpr MidiKind kindOf(std::uint8_t status, std::uint8_t data2) {
+    switch (status & 0xf0U) {
+        case 0x80U:
+            return MidiKind::noteOff;
+
+        case 0x90U:
+            return data2 == 0 ? MidiKind::noteOff : MidiKind::noteOn;
+
+        case 0xb0U:
+            return MidiKind::controller;
+
+        case 0xe0U:
+            return MidiKind::pitchBend;
+
+        default:
+            return MidiKind::unsupported;
+    }
+}
+
+inline MidiKind kindOf(const RecordedMidiEvent& event) {
+    return kindOf(event.status, event.data2);
+}
+
+/**
+ * @brief Which pitches are down, and what happens when one is struck again.
+ *
+ * An entry names a channel and a pitch; what a note *is* stays with the caller,
+ * keyed by that entry, because the take holds a pending sample position and the
+ * preview holds a published slot.
+ *
+ * The rule this exists for: a pitch already down is replaced rather than joined.
+ * Nothing can close two of one pitch, so the second of them would run to the end
+ * of the pass with no release able to reach it.
+ *
+ * Allocation-free once constructed, so the live half can drive one on the audio
+ * thread.
+ */
+class HeldNotes {
+  public:
+    static constexpr std::size_t kChannels = 16;
+    static constexpr std::size_t kNotesPerChannel = 128;
+    static constexpr std::size_t kEntries = kChannels * kNotesPerChannel;
+
+    HeldNotes() {
+        position_.fill(0);
+        down_.reserve(kEntries);
+    }
+
+    static std::uint32_t entryFor(int channel, int note) {
+        return static_cast<std::uint32_t>(
+            ((static_cast<std::size_t>(channel) % kChannels) * kNotesPerChannel) +
+            (static_cast<std::size_t>(note) & (kNotesPerChannel - 1)));
+    }
+
+    /// The pitch an entry names. The channel is deliberately not asked for:
+    /// MidiNote has no field for one.
+    static int noteOf(std::uint32_t entry) {
+        return static_cast<int>(entry % kNotesPerChannel);
+    }
+
+    bool isDown(std::uint32_t entry) const {
+        return down_.size() > position_[entry] && down_[position_[entry]] == entry;
+    }
+
+    /**
+     * @brief Mark the pitch down.
+     *
+     * True when it took over one that was already down, which is the second
+     * strike the caller has to replace rather than add to.
+     */
+    bool hold(std::uint32_t entry) {
+        if (isDown(entry))
+            return true;
+
+        position_[entry] = down_.size();
+        down_.push_back(entry);
+        return false;
+    }
+
+    /// @brief Lift the pitch. True when it was down, which is the only case
+    /// with a note to close.
+    bool release(std::uint32_t entry) {
+        if (!isDown(entry))
+            return false;
+
+        const auto at = position_[entry];
+        down_[at] = down_.back();
+        position_[down_[at]] = at;
+        down_.pop_back();
+        return true;
+    }
+
+    /// Every pitch still down, in no order. A pass end closes all of them.
+    std::span<const std::uint32_t> down() const {
+        return down_;
+    }
+
+    void clear() {
+        down_.clear();
+    }
+
+  private:
+    /// Where each entry sits in @ref down_, meaningful only while it is there.
+    std::array<std::size_t, kEntries> position_{};
+
+    std::vector<std::uint32_t> down_;
+};
+
+/**
+ * @brief A pass's notes as the tap holds them, over the table above.
+ *
+ * The one road from a MIDI transition to a published note. A take drives one of
+ * these and so does every case about one, so there is no second answer to what
+ * a strike on a pitch already down does, or to how far a held note has run.
+ */
+class PreviewNotes {
+  public:
+    explicit PreviewNotes(RecordTap& tap) : tap_(tap) {}
+
+    /// @brief A pass begins at @p startBeat. Nothing is down in a new one, and
+    /// a note held across the boundary belongs to the pass it started in.
+    void open(double startBeat) {
+        held_.clear();
+        tap_.open(startBeat);
+    }
+
+    /// @brief A pitch goes down at @p beat from the pass start.
+    void strike(int channel, int note, int velocity, double beat) {
+        const auto entry = HeldNotes::entryFor(channel, note);
+        auto& slot = slots_[entry];
+
+        if (held_.hold(entry))
+            tap_.replaceNote(slot, note, velocity, beat);
+        else
+            slot = tap_.addNote(note, velocity, beat);
+    }
+
+    /// @brief The pitch comes up at @p beat. A release with nothing down does
+    /// nothing, as it does in the finished take.
+    void release(int channel, int note, double beat) {
+        const auto entry = HeldNotes::entryFor(channel, note);
+        if (held_.release(entry))
+            tap_.noteReaches(slots_[entry], beat);
+    }
+
+    /// @brief The pass, and every note still down, reach @p lengthBeats.
+    void reaches(double lengthBeats) {
+        tap_.extend(lengthBeats);
+
+        for (const auto entry : held_.down())
+            tap_.noteReaches(slots_[entry], lengthBeats);
+    }
+
+  private:
+    RecordTap& tap_;
+
+    HeldNotes held_;
+
+    /// The slot each pitch is drawn in, meaningful while it is down.
+    std::array<std::size_t, HeldNotes::kEntries> slots_{};
+};
+
+}  // namespace magda::engine

--- a/magda/engine/io/TakeRecorder.cpp
+++ b/magda/engine/io/TakeRecorder.cpp
@@ -96,7 +96,7 @@ void TakeRecorder::start(const BlockInfo& block, const LoopRange& loop) {
 
     passOrigin_ = 0;
     passOriginBeat_ = startBeat_;
-    pendingBoundary_ = -1;
+    pendingCount_ = 0;
     tap_.open(startBeat_);
 
     // A negative latency asks for samples from before the take was armed.
@@ -131,16 +131,21 @@ void TakeRecorder::openPass(const BlockInfo& block, const LoopRange& loop) {
 
     // The pass the tap draws is the pass the file will be, so it turns over
     // where the sink does: at the boundary, not at the wrap that named it.
-    pendingBoundary_ = boundary;
-    pendingStartBeat_ = block.beats.start;
+    if (pendingCount_ < kPendingCapacity)
+        pending_[(pendingHead_ + pendingCount_++) % kPendingCapacity] = {boundary,
+                                                                         block.beats.start};
 }
 
 void TakeRecorder::openTapPass(const BlockInfo& block) {
-    passOrigin_ = pendingBoundary_;
+    const auto& pass = pending_[pendingHead_];
+
+    passOrigin_ = pass.boundary;
     passOriginBeat_ =
-        block.beatAtTime(startSeconds_ + (static_cast<double>(pendingBoundary_) / block.rate()));
-    pendingBoundary_ = -1;
-    tap_.open(pendingStartBeat_);
+        block.beatAtTime(startSeconds_ + (static_cast<double>(pass.boundary) / block.rate()));
+    tap_.open(pass.startBeat);
+
+    pendingHead_ = (pendingHead_ + 1) % kPendingCapacity;
+    --pendingCount_;
 }
 
 void TakeRecorder::stop() {
@@ -176,16 +181,20 @@ void TakeRecorder::write(const BlockInfo& block) {
     stream_.writeAudio(keptBlock, kept);
 
     // The pass's own audio, at the position it was written at, so a peak and
-    // the samples behind it are the same stretch. A block the pass boundary
-    // falls inside is split there, the way the sink splits it.
+    // the samples behind it are the same stretch. Every boundary this block
+    // reaches is taken, the way the sink takes them: a loop shorter than the
+    // block puts more than one inside it.
     auto from = 0;
-    if (pendingBoundary_ >= 0 && block.rate() > 0.0 && written_ + kept > pendingBoundary_) {
-        from = static_cast<int>(pendingBoundary_ - written_);
-        if (from > 0)
-            tap_.addPeaks(keptBlock.getSubBlock(0, static_cast<std::size_t>(from)), from,
-                          written_ - passOrigin_);
+    while (pendingCount_ > 0 && block.rate() > 0.0 &&
+           written_ + kept > pending_[pendingHead_].boundary) {
+        const auto at = static_cast<int>(pending_[pendingHead_].boundary - written_);
+        if (at > from)
+            tap_.addPeaks(keptBlock.getSubBlock(static_cast<std::size_t>(from),
+                                                static_cast<std::size_t>(at - from)),
+                          at - from, (written_ + from) - passOrigin_);
 
         openTapPass(block);
+        from = at;
     }
 
     tap_.addPeaks(keptBlock.getSubBlock(static_cast<std::size_t>(from),

--- a/magda/engine/io/TakeRecorder.cpp
+++ b/magda/engine/io/TakeRecorder.cpp
@@ -38,13 +38,13 @@ std::vector<std::int64_t> passLengths(std::span<const RecordedPass> passes) {
 
 }  // namespace
 
-TakeRecorder::TakeRecorder(const LiveInputFeed& feed, const RenderContext& context,
+TakeRecorder::TakeRecorder(const LiveInputFeed& feed, const RenderContext& context, RecordTap& tap,
                            TakeRecorderSettings settings)
     : settings_(std::move(settings)),
       input_(feed, settings_.channels, settings_.latencySamples),
       sink_(settings_.directory, settings_.name, settings_.file, fileContext(context, settings_)),
       stream_(sink_, queueFor(settings_)),
-      tap_(RecordMaterial::audio, settings_.tap) {
+      tap_(tap) {
     scratch_.setSize(takeChannels(settings_), std::max(1, context.maxBlockSize), false, true,
                      false);
 

--- a/magda/engine/io/TakeRecorder.cpp
+++ b/magda/engine/io/TakeRecorder.cpp
@@ -124,13 +124,16 @@ void TakeRecorder::openPass(const BlockInfo& block, const LoopRange& loop) {
     if (firstBoundary_ < 0)
         firstBoundary_ = boundary;
 
+    // One acceptance, and the file and the preview both follow it: a boundary
+    // refused here is refused for both, which is what keeps them the same
+    // passes rather than two opinions about where a pass ended.
     if (!sink_.markPassEnd(boundary)) {
         ++boundariesLost_;
         return;
     }
 
-    // The pass the tap draws is the pass the file will be, so it turns over
-    // where the sink does: at the boundary, not at the wrap that named it.
+    // The preview turns over where the sink does: at the boundary, not at the
+    // wrap that named it.
     if (pendingCount_ < kPendingCapacity)
         pending_[(pendingHead_ + pendingCount_++) % kPendingCapacity] = {boundary,
                                                                          block.beats.start};

--- a/magda/engine/io/TakeRecorder.cpp
+++ b/magda/engine/io/TakeRecorder.cpp
@@ -43,7 +43,8 @@ TakeRecorder::TakeRecorder(const LiveInputFeed& feed, const RenderContext& conte
     : settings_(std::move(settings)),
       input_(feed, settings_.channels, settings_.latencySamples),
       sink_(settings_.directory, settings_.name, settings_.file, fileContext(context, settings_)),
-      stream_(sink_, queueFor(settings_)) {
+      stream_(sink_, queueFor(settings_)),
+      tap_(RecordMaterial::audio, settings_.tap) {
     scratch_.setSize(takeChannels(settings_), std::max(1, context.maxBlockSize), false, true,
                      false);
 
@@ -72,7 +73,7 @@ void TakeRecorder::capture(const BlockInfo& block, bool countingIn, const LoopRa
             return;
         }
 
-        openPass(loop);
+        openPass(block, loop);
     }
 
     write(block);
@@ -93,6 +94,10 @@ void TakeRecorder::start(const BlockInfo& block, const LoopRange& loop) {
     startedAtLoopStart_ = atLoopStart(block, loop);
     headDrop_ = std::max(0, settings_.latencySamples);
 
+    passOrigin_ = 0;
+    passOriginBeat_ = startBeat_;
+    tap_.open(startBeat_);
+
     // A negative latency asks for samples from before the take was armed.
     // Silence stands in for them, which is what leaves the first real sample
     // where it happened.
@@ -103,7 +108,7 @@ void TakeRecorder::start(const BlockInfo& block, const LoopRange& loop) {
     }
 }
 
-void TakeRecorder::openPass(const LoopRange& loop) {
+void TakeRecorder::openPass(const BlockInfo& block, const LoopRange& loop) {
     loopStartBeat_ = loop.startBeat;
     loopEndBeat_ = loop.endBeat;
 
@@ -118,13 +123,24 @@ void TakeRecorder::openPass(const LoopRange& loop) {
     if (firstBoundary_ < 0)
         firstBoundary_ = boundary;
 
-    if (!sink_.markPassEnd(boundary))
+    if (!sink_.markPassEnd(boundary)) {
         ++boundariesLost_;
+        return;
+    }
+
+    // The pass the tap draws is the pass the file will be, so it opens on the
+    // boundary that was taken. It is counted from what has been written rather
+    // than from the boundary itself, so a peak and the length beside it are the
+    // same stretch of audio.
+    passOrigin_ = written_;
+    passOriginBeat_ = endBeat_;
+    tap_.open(block.beats.start);
 }
 
 void TakeRecorder::stop() {
     state_ = State::stopped;
     rolling_.store(false, std::memory_order_relaxed);
+    tap_.close();
 }
 
 void TakeRecorder::write(const BlockInfo& block) {
@@ -148,9 +164,15 @@ void TakeRecorder::write(const BlockInfo& block) {
     if (kept <= 0)
         return;
 
-    stream_.writeAudio(
-        captured.getSubBlock(static_cast<std::size_t>(offset), static_cast<std::size_t>(kept)),
-        kept);
+    const auto keptBlock =
+        captured.getSubBlock(static_cast<std::size_t>(offset), static_cast<std::size_t>(kept));
+
+    stream_.writeAudio(keptBlock, kept);
+
+    // The pass's own audio, at the position it was written at, so a peak and
+    // the samples behind it are the same stretch.
+    tap_.addPeaks(keptBlock, kept, written_ - passOrigin_);
+
     written_ += kept;
     captured_.store(written_, std::memory_order_relaxed);
 
@@ -159,6 +181,8 @@ void TakeRecorder::write(const BlockInfo& block) {
     // arrived, and across a tempo change the two are not the same length.
     if (const auto rate = block.rate(); rate > 0.0)
         endBeat_ = block.beatAtTime(startSeconds_ + (static_cast<double>(written_) / rate));
+
+    tap_.extend(std::max(0.0, endBeat_ - passOriginBeat_));
 }
 
 RecordedTake TakeRecorder::finish() {

--- a/magda/engine/io/TakeRecorder.cpp
+++ b/magda/engine/io/TakeRecorder.cpp
@@ -96,6 +96,7 @@ void TakeRecorder::start(const BlockInfo& block, const LoopRange& loop) {
 
     passOrigin_ = 0;
     passOriginBeat_ = startBeat_;
+    pendingBoundary_ = -1;
     tap_.open(startBeat_);
 
     // A negative latency asks for samples from before the take was armed.
@@ -128,13 +129,18 @@ void TakeRecorder::openPass(const BlockInfo& block, const LoopRange& loop) {
         return;
     }
 
-    // The pass the tap draws is the pass the file will be, so it opens on the
-    // boundary that was taken. It is counted from what has been written rather
-    // than from the boundary itself, so a peak and the length beside it are the
-    // same stretch of audio.
-    passOrigin_ = written_;
-    passOriginBeat_ = endBeat_;
-    tap_.open(block.beats.start);
+    // The pass the tap draws is the pass the file will be, so it turns over
+    // where the sink does: at the boundary, not at the wrap that named it.
+    pendingBoundary_ = boundary;
+    pendingStartBeat_ = block.beats.start;
+}
+
+void TakeRecorder::openTapPass(const BlockInfo& block) {
+    passOrigin_ = pendingBoundary_;
+    passOriginBeat_ =
+        block.beatAtTime(startSeconds_ + (static_cast<double>(pendingBoundary_) / block.rate()));
+    pendingBoundary_ = -1;
+    tap_.open(pendingStartBeat_);
 }
 
 void TakeRecorder::stop() {
@@ -170,8 +176,21 @@ void TakeRecorder::write(const BlockInfo& block) {
     stream_.writeAudio(keptBlock, kept);
 
     // The pass's own audio, at the position it was written at, so a peak and
-    // the samples behind it are the same stretch.
-    tap_.addPeaks(keptBlock, kept, written_ - passOrigin_);
+    // the samples behind it are the same stretch. A block the pass boundary
+    // falls inside is split there, the way the sink splits it.
+    auto from = 0;
+    if (pendingBoundary_ >= 0 && block.rate() > 0.0 && written_ + kept > pendingBoundary_) {
+        from = static_cast<int>(pendingBoundary_ - written_);
+        if (from > 0)
+            tap_.addPeaks(keptBlock.getSubBlock(0, static_cast<std::size_t>(from)), from,
+                          written_ - passOrigin_);
+
+        openTapPass(block);
+    }
+
+    tap_.addPeaks(keptBlock.getSubBlock(static_cast<std::size_t>(from),
+                                        static_cast<std::size_t>(kept - from)),
+                  kept - from, (written_ + from) - passOrigin_);
 
     written_ += kept;
     captured_.store(written_, std::memory_order_relaxed);

--- a/magda/engine/io/TakeRecorder.hpp
+++ b/magda/engine/io/TakeRecorder.hpp
@@ -123,9 +123,6 @@ struct TakeRecorderSettings {
 
     /// How much the queue holds. Its channel count is the take's.
     RecordStreamSettings stream;
-
-    /// How much of the pass in flight is published (#2463).
-    RecordTapSettings tap;
 };
 
 /**
@@ -138,7 +135,10 @@ struct TakeRecorderSettings {
  */
 class TakeRecorder final : public TakeCapture {
   public:
-    TakeRecorder(const LiveInputFeed& feed, const RenderContext& context,
+    /// @p tap is not owned and outlives the take: it is what the pass in
+    /// flight is published to, and what still holds it once the take is a clip
+    /// (#2463).
+    TakeRecorder(const LiveInputFeed& feed, const RenderContext& context, RecordTap& tap,
                  TakeRecorderSettings settings);
 
     ~TakeRecorder() override = default;
@@ -210,7 +210,7 @@ class TakeRecorder final : public TakeCapture {
     LiveAudioInput input_;
     TakeFileSink sink_;
     RecordStream stream_;
-    RecordTap tap_;
+    RecordTap& tap_;
 
     /// The block, narrowed to the channels the take holds.
     juce::AudioBuffer<float> scratch_;

--- a/magda/engine/io/TakeRecorder.hpp
+++ b/magda/engine/io/TakeRecorder.hpp
@@ -13,6 +13,7 @@
 #include "io/RecordingFeed.hpp"
 #include "io/TakeFileSink.hpp"
 #include "io/TakePasses.hpp"
+#include "tap/RecordTap.hpp"
 #include "transport/TransportState.hpp"
 
 /**
@@ -121,6 +122,9 @@ struct TakeRecorderSettings {
 
     /// How much the queue holds. Its channel count is the take's.
     RecordStreamSettings stream;
+
+    /// How much of the pass in flight is published (#2463).
+    RecordTapSettings tap;
 };
 
 /**
@@ -152,6 +156,11 @@ class TakeRecorder final : public TakeCapture {
 
     void capture(const BlockInfo& block, bool countingIn, const LoopRange& loop) override;
 
+    /// Where the pass in flight is published (#2463).
+    const RecordTap& tap() const override {
+        return tap_;
+    }
+
     /// Samples offered to the queue so far. Read from any thread; what a
     /// running take is drawn from (#2463).
     std::int64_t capturedSamples() const {
@@ -180,7 +189,7 @@ class TakeRecorder final : public TakeCapture {
 
     /// A wrap: where the pass ended, handed to the sink. The one place a
     /// boundary is named, so the rule above it holds everywhere.
-    void openPass(const LoopRange& loop);
+    void openPass(const BlockInfo& block, const LoopRange& loop);
 
     void stop();
 
@@ -196,6 +205,7 @@ class TakeRecorder final : public TakeCapture {
     LiveAudioInput input_;
     TakeFileSink sink_;
     RecordStream stream_;
+    RecordTap tap_;
 
     /// The block, narrowed to the channels the take holds.
     juce::AudioBuffer<float> scratch_;
@@ -226,6 +236,13 @@ class TakeRecorder final : public TakeCapture {
     double startBeat_ = 0.0;
     double startSeconds_ = 0.0;
     double endBeat_ = 0.0;
+
+    /// Where the pass in flight began, in samples written and in the beat they
+    /// reach. The tap counts a pass from what was written rather than from the
+    /// boundary the sink was given, so its peaks and its length are the same
+    /// stretch of audio.
+    std::int64_t passOrigin_ = 0;
+    double passOriginBeat_ = 0.0;
 
     /// Whether the take began on the loop start, which is what says its first
     /// pass is a pass rather than a lead-in.

--- a/magda/engine/io/TakeRecorder.hpp
+++ b/magda/engine/io/TakeRecorder.hpp
@@ -2,6 +2,7 @@
 
 #include <juce_audio_basics/juce_audio_basics.h>
 
+#include <array>
 #include <atomic>
 #include <cstdint>
 #include <vector>
@@ -197,6 +198,10 @@ class TakeRecorder final : public TakeCapture {
     /// sink's to act on, since only the sink knows what reached the disk.
     void write(const BlockInfo& block);
 
+    /// Open the pass the oldest pending boundary named, now the audio has
+    /// reached it, and retire it.
+    void openTapPass(const BlockInfo& block);
+
     /// Where the take is, once there is nothing more to add to it.
     void placeClip(RecordedTake& take) const;
 
@@ -242,15 +247,27 @@ class TakeRecorder final : public TakeCapture {
     std::int64_t passOrigin_ = 0;
     double passOriginBeat_ = 0.0;
 
-    /// The boundary a wrap named and the beat it named it at, until the written
+    /// A boundary a wrap named and the beat it named it at, until the written
     /// audio reaches it. The sink splits there, so a preview that turned over
     /// at the wrap instead would draw the tail of the previous file -- with a
     /// positive latency, a whole latency of it.
-    std::int64_t pendingBoundary_ = -1;
-    double pendingStartBeat_ = 0.0;
+    struct PendingPass {
+        std::int64_t boundary = 0;
+        double startBeat = 0.0;
+    };
 
-    /// The pass the boundary named, once the audio has reached it.
-    void openTapPass(const BlockInfo& block);
+    /// All of them, not the latest: a loop shorter than the latency wraps again
+    /// before the audio reaches the boundary before it, and a preview keeping
+    /// only the newest would never turn over at all.
+    ///
+    /// As deep as the sink's own lane, which it cannot outrun: a boundary is
+    /// dropped here only once the sink has refused it too, and the sink retires
+    /// one no earlier than this does.
+    static constexpr std::size_t kPendingCapacity = 256;
+
+    std::array<PendingPass, kPendingCapacity> pending_{};
+    std::size_t pendingHead_ = 0;
+    std::size_t pendingCount_ = 0;
 
     /// Whether the take began on the loop start, which is what says its first
     /// pass is a pass rather than a lead-in.

--- a/magda/engine/io/TakeRecorder.hpp
+++ b/magda/engine/io/TakeRecorder.hpp
@@ -260,10 +260,11 @@ class TakeRecorder final : public TakeCapture {
     /// before the audio reaches the boundary before it, and a preview keeping
     /// only the newest would never turn over at all.
     ///
-    /// As deep as the sink's own lane, which it cannot outrun: a boundary is
-    /// dropped here only once the sink has refused it too, and the sink retires
-    /// one no earlier than this does.
-    static constexpr std::size_t kPendingCapacity = 256;
+    /// The sink's own lane, not a second number. This retires a boundary when
+    /// the audio is offered past it and the sink no earlier, so what the sink
+    /// accepted always has room here and the two cannot end up describing
+    /// different passes.
+    static constexpr std::size_t kPendingCapacity = TakeFileSink::kBoundaryCapacity;
 
     std::array<PendingPass, kPendingCapacity> pending_{};
     std::size_t pendingHead_ = 0;

--- a/magda/engine/io/TakeRecorder.hpp
+++ b/magda/engine/io/TakeRecorder.hpp
@@ -237,12 +237,20 @@ class TakeRecorder final : public TakeCapture {
     double startSeconds_ = 0.0;
     double endBeat_ = 0.0;
 
-    /// Where the pass in flight began, in samples written and in the beat they
-    /// reach. The tap counts a pass from what was written rather than from the
-    /// boundary the sink was given, so its peaks and its length are the same
-    /// stretch of audio.
+    /// Where the pass the tap draws began, in samples written and in the beat
+    /// they reach.
     std::int64_t passOrigin_ = 0;
     double passOriginBeat_ = 0.0;
+
+    /// The boundary a wrap named and the beat it named it at, until the written
+    /// audio reaches it. The sink splits there, so a preview that turned over
+    /// at the wrap instead would draw the tail of the previous file -- with a
+    /// positive latency, a whole latency of it.
+    std::int64_t pendingBoundary_ = -1;
+    double pendingStartBeat_ = 0.0;
+
+    /// The pass the boundary named, once the audio has reached it.
+    void openTapPass(const BlockInfo& block);
 
     /// Whether the take began on the loop start, which is what says its first
     /// pass is a pass rather than a lead-in.

--- a/magda/engine/plan/PlanCompiler.cpp
+++ b/magda/engine/plan/PlanCompiler.cpp
@@ -1314,7 +1314,18 @@ void Compiler::emitTrack(const TrackInfo& track) {
                             INVALID_DEVICE_ID, OpRole::LiveAudioInput, 0};
             const auto op = addOp(OpKind::AudioInput, key, {}, {SignalKind::Audio});
             plan_.ops[static_cast<std::size_t>(op)].liveness = LivenessDomain::Live;
-            audioSources.push_back(PortRef{op, 0});
+
+            // What a monitoring track is hearing, which the incumbent reads off
+            // the input device rather than off the signal (#2463). Here it is
+            // the input op's own output, so an armed track that is not
+            // monitoring still meters what it is recording.
+            const OpKey meterKey{track.id,          INVALID_RACK_ID,        INVALID_CHAIN_ID,
+                                 INVALID_DEVICE_ID, OpRole::LiveInputMeter, 0};
+            const auto meter =
+                addOp(OpKind::Meter, meterKey, {PortRef{op, 0}}, {SignalKind::Audio});
+            plan_.ops[static_cast<std::size_t>(meter)].liveness = LivenessDomain::Live;
+
+            audioSources.push_back(PortRef{meter, 0});
             break;
         }
         case RouteKind::None:

--- a/magda/engine/plan/RenderPlan.cpp
+++ b/magda/engine/plan/RenderPlan.cpp
@@ -105,6 +105,8 @@ const char* toString(OpRole role) {
             return "clipMidi";
         case OpRole::LiveAudioInput:
             return "liveAudioInput";
+        case OpRole::LiveInputMeter:
+            return "liveInputMeter";
         case OpRole::LiveMidiInput:
             return "liveMidiInput";
         case OpRole::SessionAudio:

--- a/magda/engine/plan/RenderPlan.hpp
+++ b/magda/engine/plan/RenderPlan.hpp
@@ -149,6 +149,7 @@ enum class OpRole : std::uint8_t {
     ClipAudio,            ///< the track's audio clip source
     ClipMidi,             ///< the track's MIDI clip source
     LiveAudioInput,       ///< the track's live audio input
+    LiveInputMeter,       ///< the live audio input's level tap, read while monitoring
     LiveMidiInput,        ///< the track's live MIDI input
     SessionAudio,         ///< the track's session audio, whichever slot is playing
     SessionMidi,          ///< the track's session MIDI

--- a/magda/engine/tap/RecordTap.cpp
+++ b/magda/engine/tap/RecordTap.cpp
@@ -127,6 +127,12 @@ bool RecordTap::read(Reading& into) const {
         const auto notesLost = notesLost_.load(std::memory_order_relaxed);
         const auto numNotes = std::min(numNotes_.load(std::memory_order_relaxed), notes_.size());
 
+        // Inside the check, not after it. A length is only measured from a
+        // start while the pass that has both of them stands: a wrap taken
+        // between the two would put the next pass's length -- nothing, at the
+        // moment it opens -- against the last one's start.
+        const auto lengthBeats = lengthBeats_.load(std::memory_order_relaxed);
+
         into.staging.clear();
         for (std::size_t at = 0; at < numNotes; ++at) {
             const auto identity = notes_[at].identity.load(std::memory_order_relaxed);
@@ -147,12 +153,8 @@ bool RecordTap::read(Reading& into) const {
         into.pass = pass;
         into.startBeat = startBeat;
         into.notesLost = notesLost;
+        into.lengthBeats = lengthBeats;
         into.notes.swap(into.staging);
-
-        // Outside the snapshot on purpose. A length is the pass or a note as of
-        // some block, and neither can be attached to the wrong pass or the
-        // wrong note: the start it is measured from is in the snapshot.
-        into.lengthBeats = lengthBeats_.load(std::memory_order_relaxed);
 
         const auto needed = peaksNeeded_.load(std::memory_order_acquire);
         const auto numPeaks =

--- a/magda/engine/tap/RecordTap.cpp
+++ b/magda/engine/tap/RecordTap.cpp
@@ -1,0 +1,179 @@
+#include "tap/RecordTap.hpp"
+
+#include <algorithm>
+#include <cmath>
+
+namespace magda::engine {
+
+void RecordTap::open(double startBeat) {
+    // Outside the window below: the table is the writer's own, and filling it
+    // there would put two thousand stores between a reader and its retry.
+    held_.fill(kNotHeld);
+    heldSlots_.clear();
+    ++pass_;
+
+    seq_.fetch_add(kOpening, std::memory_order_release);
+
+    startBeat_.store(startBeat, std::memory_order_relaxed);
+    lengthBeats_.store(0.0, std::memory_order_relaxed);
+    numNotes_.store(0, std::memory_order_relaxed);
+    notesLost_.store(0, std::memory_order_relaxed);
+    peaksNeeded_.store(0, std::memory_order_relaxed);
+    recording_.store(true, std::memory_order_relaxed);
+
+    seq_.fetch_add(kOpening, std::memory_order_release);
+}
+
+void RecordTap::extend(double lengthBeats) {
+    lengthBeats_.store(lengthBeats, std::memory_order_relaxed);
+
+    for (const auto slot : heldSlots_) {
+        auto& note = notes_[slot];
+        const auto start = note.startBeat.load(std::memory_order_relaxed);
+        note.lengthBeats.store(std::max(0.0, lengthBeats - start), std::memory_order_relaxed);
+    }
+}
+
+void RecordTap::noteOn(int channel, int note, int velocity, double beat) {
+    // A tap nobody draws holds no notes and has lost none: what was never asked
+    // for is not a shortfall.
+    if (notes_.empty())
+        return;
+
+    const auto at = numNotes_.load(std::memory_order_relaxed);
+    if (at >= notes_.size()) {
+        notesLost_.fetch_add(1, std::memory_order_relaxed);
+        return;
+    }
+
+    auto& slot = notes_[at];
+    slot.startBeat.store(beat, std::memory_order_relaxed);
+    slot.lengthBeats.store(0.0, std::memory_order_relaxed);
+    slot.identity.store(packIdentity(pass_, note, velocity), std::memory_order_relaxed);
+
+    // The count is what publishes the slot, so it is stored last.
+    numNotes_.store(at + 1, std::memory_order_release);
+
+    held_[heldIndex(channel, note)] = static_cast<std::uint32_t>(at);
+    heldSlots_.push_back(static_cast<std::uint32_t>(at));
+}
+
+void RecordTap::noteOff(int channel, int note, double beat) {
+    const auto index = heldIndex(channel, note);
+    const auto slot = held_[index];
+    if (slot == kNotHeld)
+        return;
+
+    held_[index] = kNotHeld;
+    std::erase(heldSlots_, slot);
+
+    auto& held = notes_[slot];
+    const auto start = held.startBeat.load(std::memory_order_relaxed);
+    held.lengthBeats.store(std::max(0.0, beat - start), std::memory_order_relaxed);
+}
+
+void RecordTap::addPeaks(juce::dsp::AudioBlock<const float> audio, int numSamples,
+                         std::int64_t passSample) {
+    if (peaks_.empty() || numSamples <= 0 || audio.getNumChannels() == 0 ||
+        settings_.samplesPerPeak <= 0)
+        return;
+
+    const auto perPeak = static_cast<std::int64_t>(settings_.samplesPerPeak);
+    const auto capacity = static_cast<std::int64_t>(peaks_.size());
+
+    for (auto offset = 0; offset < numSamples;) {
+        const auto at = passSample + offset;
+        const auto slot = at / perPeak;
+
+        // Whatever is left of this tick, or of the block, whichever ends first.
+        const auto chunk = static_cast<int>(
+            std::min<std::int64_t>(numSamples - offset, ((slot + 1) * perPeak) - at));
+
+        const auto reached = peaksNeeded_.load(std::memory_order_relaxed);
+
+        if (slot < capacity)
+            writePeak(static_cast<std::size_t>(slot), audio, offset, chunk, slot >= reached);
+
+        if (slot >= reached)
+            peaksNeeded_.store(slot + 1, std::memory_order_release);
+
+        offset += chunk;
+    }
+}
+
+void RecordTap::writePeak(std::size_t slot, juce::dsp::AudioBlock<const float> audio, int offset,
+                          int numSamples, bool first) {
+    const auto channels = std::min<std::size_t>(audio.getNumChannels(), 2);
+
+    std::array<float, 2> peak{};
+    for (std::size_t channel = 0; channel < channels; ++channel) {
+        const auto range = juce::FloatVectorOperations::findMinAndMax(
+            audio.getChannelPointer(channel) + offset, numSamples);
+        peak[channel] = std::max(std::abs(range.getStart()), std::abs(range.getEnd()));
+    }
+
+    // A mono take reads as the same level on both, which is what it sounds
+    // like, the rule LevelTap keeps for the same case.
+    if (channels == 1)
+        peak[1] = peak[0];
+
+    if (!first) {
+        const auto held = unpackPeak(peaks_[slot].load(std::memory_order_relaxed));
+        peak[0] = std::max(held.left, peak[0]);
+        peak[1] = std::max(held.right, peak[1]);
+    }
+
+    peaks_[slot].store(packPeak(peak[0], peak[1]), std::memory_order_relaxed);
+}
+
+void RecordTap::read(Reading& into) const {
+    into.material = material_;
+    into.target = settings_.target;
+    into.scene = settings_.scene;
+
+    std::uint32_t seq = 0;
+    std::size_t numNotes = 0;
+    std::int64_t needed = 0;
+
+    for (auto attempt = 0; attempt < kReadAttempts; ++attempt) {
+        seq = seq_.load(std::memory_order_acquire);
+
+        into.recording = recording_.load(std::memory_order_relaxed);
+        into.startBeat = startBeat_.load(std::memory_order_relaxed);
+        into.lengthBeats = lengthBeats_.load(std::memory_order_relaxed);
+        into.notesLost = notesLost_.load(std::memory_order_relaxed);
+
+        numNotes = numNotes_.load(std::memory_order_acquire);
+        needed = peaksNeeded_.load(std::memory_order_acquire);
+
+        // An odd sequence is a reset in flight, and the reading above is half
+        // of one pass and half of the next whatever it compares to.
+        if ((seq & kOpening) == 0U && seq_.load(std::memory_order_acquire) == seq)
+            break;
+    }
+
+    into.pass = seq / 2;
+
+    // Only the notes this pass recorded. A wrap partway through leaves the
+    // slots holding the next pass's, which are not this reading's to draw.
+    into.notes.clear();
+    for (std::size_t at = 0; at < numNotes; ++at) {
+        const auto identity = notes_[at].identity.load(std::memory_order_relaxed);
+        if (static_cast<std::uint32_t>(identity >> 32U) != into.pass)
+            break;
+
+        into.notes.push_back({static_cast<int>(identity & 0x7fU),
+                              static_cast<int>((identity >> 8U) & 0x7fU),
+                              notes_[at].startBeat.load(std::memory_order_relaxed),
+                              notes_[at].lengthBeats.load(std::memory_order_relaxed)});
+    }
+
+    const auto numPeaks = static_cast<std::size_t>(std::min<std::int64_t>(needed, peaks_.size()));
+    into.peaks.resize(numPeaks);
+    for (std::size_t at = 0; at < numPeaks; ++at)
+        into.peaks[at] = unpackPeak(peaks_[at].load(std::memory_order_relaxed));
+
+    into.peaksLost = std::max<std::int64_t>(0, needed - static_cast<std::int64_t>(peaks_.size()));
+}
+
+}  // namespace magda::engine

--- a/magda/engine/tap/RecordTap.cpp
+++ b/magda/engine/tap/RecordTap.cpp
@@ -1,98 +1,64 @@
 #include "tap/RecordTap.hpp"
 
 #include <algorithm>
+#include <array>
 #include <cmath>
 
 namespace magda::engine {
 
 void RecordTap::open(double startBeat) {
-    // Outside the window below: the table is the writer's own, and filling it
-    // there would put two thousand stores between a reader and its retry.
-    held_.fill(kNotHeld);
-    heldSlots_.clear();
-    ++pass_;
+    const Change change(*this);
 
-    seq_.fetch_add(kOpening, std::memory_order_release);
-
+    pass_.fetch_add(1, std::memory_order_relaxed);
     startBeat_.store(startBeat, std::memory_order_relaxed);
     lengthBeats_.store(0.0, std::memory_order_relaxed);
     numNotes_.store(0, std::memory_order_relaxed);
     notesLost_.store(0, std::memory_order_relaxed);
     peaksNeeded_.store(0, std::memory_order_relaxed);
     recording_.store(true, std::memory_order_relaxed);
-
-    seq_.fetch_add(kOpening, std::memory_order_release);
 }
 
-void RecordTap::extend(double lengthBeats) {
-    lengthBeats_.store(lengthBeats, std::memory_order_relaxed);
-
-    for (const auto slot : heldSlots_) {
-        auto& note = notes_[slot];
-        const auto start = note.startBeat.load(std::memory_order_relaxed);
-        note.lengthBeats.store(std::max(0.0, lengthBeats - start), std::memory_order_relaxed);
-    }
+void RecordTap::writeSlot(std::size_t slot, int noteNumber, int velocity, double beat) {
+    auto& note = notes_[slot];
+    note.identity.store(packIdentity(noteNumber, velocity), std::memory_order_relaxed);
+    note.startBeat.store(beat, std::memory_order_relaxed);
+    note.lengthBeats.store(0.0, std::memory_order_relaxed);
 }
 
-void RecordTap::writeSlot(std::uint32_t at, int note, int velocity, double beat) {
-    auto& slot = notes_[at];
+std::size_t RecordTap::addNote(int noteNumber, int velocity, double beat) {
+    const auto at = numNotes_.load(std::memory_order_relaxed);
 
-    // Odd while the slot changes hands, even once it stands. The count is what
-    // a reader compares, because two strikes of one pitch at one velocity are
-    // the same identity and comparing those would accept one strike's beat
-    // beside the next one's length.
-    slot.revision.fetch_add(1, std::memory_order_release);
-
-    slot.identity.store(packIdentity(pass_, note, velocity), std::memory_order_relaxed);
-    slot.startBeat.store(beat, std::memory_order_relaxed);
-    slot.lengthBeats.store(0.0, std::memory_order_relaxed);
-
-    slot.revision.fetch_add(1, std::memory_order_release);
-}
-
-void RecordTap::noteOn(int channel, int note, int velocity, double beat) {
     // A tap nobody draws holds no notes and has lost none: what was never asked
     // for is not a shortfall.
     if (notes_.empty())
-        return;
+        return kNoSlot;
 
-    const auto index = heldIndex(channel, note);
-
-    // A second note on for a pitch already down replaces the first, which is
-    // what PassWalk::add does when it finishes the take. Appending instead
-    // would leave a note nothing can close, growing to the end of the pass.
-    if (const auto held = held_[index]; held != kNotHeld) {
-        writeSlot(held, note, velocity, beat);
-        return;
-    }
-
-    const auto at = numNotes_.load(std::memory_order_relaxed);
     if (at >= notes_.size()) {
         notesLost_.fetch_add(1, std::memory_order_relaxed);
-        return;
+        return kNoSlot;
     }
 
-    writeSlot(static_cast<std::uint32_t>(at), note, velocity, beat);
-
-    // The count is what publishes the slot, so it is stored last.
-    numNotes_.store(at + 1, std::memory_order_release);
-
-    held_[index] = static_cast<std::uint32_t>(at);
-    heldSlots_.push_back(static_cast<std::uint32_t>(at));
+    const Change change(*this);
+    writeSlot(at, noteNumber, velocity, beat);
+    numNotes_.store(at + 1, std::memory_order_relaxed);
+    return at;
 }
 
-void RecordTap::noteOff(int channel, int note, double beat) {
-    const auto index = heldIndex(channel, note);
-    const auto slot = held_[index];
-    if (slot == kNotHeld)
+void RecordTap::replaceNote(std::size_t slot, int noteNumber, int velocity, double beat) {
+    if (slot >= notes_.size())
         return;
 
-    held_[index] = kNotHeld;
-    std::erase(heldSlots_, slot);
+    const Change change(*this);
+    writeSlot(slot, noteNumber, velocity, beat);
+}
 
-    auto& held = notes_[slot];
-    const auto start = held.startBeat.load(std::memory_order_relaxed);
-    held.lengthBeats.store(std::max(0.0, beat - start), std::memory_order_relaxed);
+void RecordTap::noteReaches(std::size_t slot, double endBeat) {
+    if (slot >= notes_.size())
+        return;
+
+    auto& note = notes_[slot];
+    const auto start = note.startBeat.load(std::memory_order_relaxed);
+    note.lengthBeats.store(std::max(0.0, endBeat - start), std::memory_order_relaxed);
 }
 
 void RecordTap::addPeaks(juce::dsp::AudioBlock<const float> audio, int numSamples,
@@ -149,72 +115,59 @@ void RecordTap::writePeak(std::size_t slot, juce::dsp::AudioBlock<const float> a
     peaks_[slot].store(packPeak(peak[0], peak[1]), std::memory_order_relaxed);
 }
 
-void RecordTap::read(Reading& into) const {
-    into.material = material_;
-    into.target = settings_.target;
-    into.scene = settings_.scene;
-
-    std::uint32_t seq = 0;
-    std::size_t numNotes = 0;
-    std::int64_t needed = 0;
-
+bool RecordTap::read(Reading& into) const {
     for (auto attempt = 0; attempt < kReadAttempts; ++attempt) {
-        seq = seq_.load(std::memory_order_acquire);
-
-        into.recording = recording_.load(std::memory_order_relaxed);
-        into.startBeat = startBeat_.load(std::memory_order_relaxed);
-        into.lengthBeats = lengthBeats_.load(std::memory_order_relaxed);
-        into.notesLost = notesLost_.load(std::memory_order_relaxed);
-
-        numNotes = numNotes_.load(std::memory_order_acquire);
-        needed = peaksNeeded_.load(std::memory_order_acquire);
-
-        // An odd sequence is a reset in flight, and the reading above is half
-        // of one pass and half of the next whatever it compares to.
-        if ((seq & kOpening) == 0U && seq_.load(std::memory_order_acquire) == seq)
-            break;
-    }
-
-    into.pass = seq / 2;
-
-    // Only the notes this pass recorded. A wrap partway through leaves the
-    // slots holding the next pass's, which are not this reading's to draw.
-    into.notes.clear();
-    for (std::size_t at = 0; at < numNotes; ++at) {
-        const auto& slot = notes_[at];
-
-        const auto revision = slot.revision.load(std::memory_order_acquire);
-
-        // Mid-replacement. Skipped rather than ending the list, because a
-        // retrigger rewrites a slot the pass has already moved past.
-        if ((revision & 1U) != 0U)
+        const auto revision = revision_.load(std::memory_order_acquire);
+        if ((revision & kChanging) != 0U)
             continue;
 
-        const auto identity = slot.identity.load(std::memory_order_relaxed);
+        const auto recording = recording_.load(std::memory_order_relaxed);
+        const auto pass = pass_.load(std::memory_order_relaxed);
+        const auto startBeat = startBeat_.load(std::memory_order_relaxed);
+        const auto notesLost = notesLost_.load(std::memory_order_relaxed);
+        const auto numNotes = std::min(numNotes_.load(std::memory_order_relaxed), notes_.size());
 
-        // Past this pass's own notes: what follows was written by the next.
-        if (static_cast<std::uint32_t>(identity >> 32U) != into.pass)
-            break;
+        into.staging.clear();
+        for (std::size_t at = 0; at < numNotes; ++at) {
+            const auto identity = notes_[at].identity.load(std::memory_order_relaxed);
+            into.staging.push_back({static_cast<int>(identity & 0x7fU),
+                                    static_cast<int>((identity >> 8U) & 0x7fU),
+                                    notes_[at].startBeat.load(std::memory_order_relaxed),
+                                    notes_[at].lengthBeats.load(std::memory_order_relaxed)});
+        }
 
-        const auto startBeat = slot.startBeat.load(std::memory_order_relaxed);
-        const auto lengthBeats = slot.lengthBeats.load(std::memory_order_relaxed);
-
-        // The slot could have changed hands under the three loads above. A
-        // length that grew is the same note being held and turns nothing.
         std::atomic_thread_fence(std::memory_order_acquire);
-        if (slot.revision.load(std::memory_order_relaxed) != revision)
+        if (revision_.load(std::memory_order_relaxed) != revision)
             continue;
 
-        into.notes.push_back({static_cast<int>(identity & 0x7fU),
-                              static_cast<int>((identity >> 8U) & 0x7fU), startBeat, lengthBeats});
+        into.recording = recording;
+        into.material = material_;
+        into.target = settings_.target;
+        into.scene = settings_.scene;
+        into.pass = pass;
+        into.startBeat = startBeat;
+        into.notesLost = notesLost;
+        into.notes.swap(into.staging);
+
+        // Outside the snapshot on purpose. A length is the pass or a note as of
+        // some block, and neither can be attached to the wrong pass or the
+        // wrong note: the start it is measured from is in the snapshot.
+        into.lengthBeats = lengthBeats_.load(std::memory_order_relaxed);
+
+        const auto needed = peaksNeeded_.load(std::memory_order_acquire);
+        const auto numPeaks =
+            static_cast<std::size_t>(std::min<std::int64_t>(needed, peaks_.size()));
+
+        into.peaks.resize(numPeaks);
+        for (std::size_t at = 0; at < numPeaks; ++at)
+            into.peaks[at] = unpackPeak(peaks_[at].load(std::memory_order_relaxed));
+
+        into.peaksLost =
+            std::max<std::int64_t>(0, needed - static_cast<std::int64_t>(peaks_.size()));
+        return true;
     }
 
-    const auto numPeaks = static_cast<std::size_t>(std::min<std::int64_t>(needed, peaks_.size()));
-    into.peaks.resize(numPeaks);
-    for (std::size_t at = 0; at < numPeaks; ++at)
-        into.peaks[at] = unpackPeak(peaks_[at].load(std::memory_order_relaxed));
-
-    into.peaksLost = std::max<std::int64_t>(0, needed - static_cast<std::int64_t>(peaks_.size()));
+    return false;
 }
 
 }  // namespace magda::engine

--- a/magda/engine/tap/RecordTap.cpp
+++ b/magda/engine/tap/RecordTap.cpp
@@ -37,15 +37,17 @@ void RecordTap::extend(double lengthBeats) {
 void RecordTap::writeSlot(std::uint32_t at, int note, int velocity, double beat) {
     auto& slot = notes_[at];
 
-    // Nothing, then the position, then who is there: a reader that took the
-    // identity first would otherwise pair it with a position written after it,
-    // which is the last pass's pitch on this pass's beat.
-    slot.identity.store(0, std::memory_order_relaxed);
-    std::atomic_thread_fence(std::memory_order_release);
+    // Odd while the slot changes hands, even once it stands. The count is what
+    // a reader compares, because two strikes of one pitch at one velocity are
+    // the same identity and comparing those would accept one strike's beat
+    // beside the next one's length.
+    slot.revision.fetch_add(1, std::memory_order_release);
 
+    slot.identity.store(packIdentity(pass_, note, velocity), std::memory_order_relaxed);
     slot.startBeat.store(beat, std::memory_order_relaxed);
     slot.lengthBeats.store(0.0, std::memory_order_relaxed);
-    slot.identity.store(packIdentity(pass_, note, velocity), std::memory_order_release);
+
+    slot.revision.fetch_add(1, std::memory_order_release);
 }
 
 void RecordTap::noteOn(int channel, int note, int velocity, double beat) {
@@ -181,19 +183,27 @@ void RecordTap::read(Reading& into) const {
     for (std::size_t at = 0; at < numNotes; ++at) {
         const auto& slot = notes_[at];
 
-        const auto identity = slot.identity.load(std::memory_order_acquire);
+        const auto revision = slot.revision.load(std::memory_order_acquire);
+
+        // Mid-replacement. Skipped rather than ending the list, because a
+        // retrigger rewrites a slot the pass has already moved past.
+        if ((revision & 1U) != 0U)
+            continue;
+
+        const auto identity = slot.identity.load(std::memory_order_relaxed);
+
+        // Past this pass's own notes: what follows was written by the next.
         if (static_cast<std::uint32_t>(identity >> 32U) != into.pass)
             break;
 
         const auto startBeat = slot.startBeat.load(std::memory_order_relaxed);
         const auto lengthBeats = slot.lengthBeats.load(std::memory_order_relaxed);
 
-        // The slot could have been taken over between the identity and the two
-        // loads above. A length that grew under the read is the same note being
-        // held; a slot that changed hands is not this note at all.
+        // The slot could have changed hands under the three loads above. A
+        // length that grew is the same note being held and turns nothing.
         std::atomic_thread_fence(std::memory_order_acquire);
-        if (slot.identity.load(std::memory_order_relaxed) != identity)
-            break;
+        if (slot.revision.load(std::memory_order_relaxed) != revision)
+            continue;
 
         into.notes.push_back({static_cast<int>(identity & 0x7fU),
                               static_cast<int>((identity >> 8U) & 0x7fU), startBeat, lengthBeats});

--- a/magda/engine/tap/RecordTap.cpp
+++ b/magda/engine/tap/RecordTap.cpp
@@ -34,11 +34,35 @@ void RecordTap::extend(double lengthBeats) {
     }
 }
 
+void RecordTap::writeSlot(std::uint32_t at, int note, int velocity, double beat) {
+    auto& slot = notes_[at];
+
+    // Nothing, then the position, then who is there: a reader that took the
+    // identity first would otherwise pair it with a position written after it,
+    // which is the last pass's pitch on this pass's beat.
+    slot.identity.store(0, std::memory_order_relaxed);
+    std::atomic_thread_fence(std::memory_order_release);
+
+    slot.startBeat.store(beat, std::memory_order_relaxed);
+    slot.lengthBeats.store(0.0, std::memory_order_relaxed);
+    slot.identity.store(packIdentity(pass_, note, velocity), std::memory_order_release);
+}
+
 void RecordTap::noteOn(int channel, int note, int velocity, double beat) {
     // A tap nobody draws holds no notes and has lost none: what was never asked
     // for is not a shortfall.
     if (notes_.empty())
         return;
+
+    const auto index = heldIndex(channel, note);
+
+    // A second note on for a pitch already down replaces the first, which is
+    // what PassWalk::add does when it finishes the take. Appending instead
+    // would leave a note nothing can close, growing to the end of the pass.
+    if (const auto held = held_[index]; held != kNotHeld) {
+        writeSlot(held, note, velocity, beat);
+        return;
+    }
 
     const auto at = numNotes_.load(std::memory_order_relaxed);
     if (at >= notes_.size()) {
@@ -46,15 +70,12 @@ void RecordTap::noteOn(int channel, int note, int velocity, double beat) {
         return;
     }
 
-    auto& slot = notes_[at];
-    slot.startBeat.store(beat, std::memory_order_relaxed);
-    slot.lengthBeats.store(0.0, std::memory_order_relaxed);
-    slot.identity.store(packIdentity(pass_, note, velocity), std::memory_order_relaxed);
+    writeSlot(static_cast<std::uint32_t>(at), note, velocity, beat);
 
     // The count is what publishes the slot, so it is stored last.
     numNotes_.store(at + 1, std::memory_order_release);
 
-    held_[heldIndex(channel, note)] = static_cast<std::uint32_t>(at);
+    held_[index] = static_cast<std::uint32_t>(at);
     heldSlots_.push_back(static_cast<std::uint32_t>(at));
 }
 
@@ -158,14 +179,24 @@ void RecordTap::read(Reading& into) const {
     // slots holding the next pass's, which are not this reading's to draw.
     into.notes.clear();
     for (std::size_t at = 0; at < numNotes; ++at) {
-        const auto identity = notes_[at].identity.load(std::memory_order_relaxed);
+        const auto& slot = notes_[at];
+
+        const auto identity = slot.identity.load(std::memory_order_acquire);
         if (static_cast<std::uint32_t>(identity >> 32U) != into.pass)
             break;
 
+        const auto startBeat = slot.startBeat.load(std::memory_order_relaxed);
+        const auto lengthBeats = slot.lengthBeats.load(std::memory_order_relaxed);
+
+        // The slot could have been taken over between the identity and the two
+        // loads above. A length that grew under the read is the same note being
+        // held; a slot that changed hands is not this note at all.
+        std::atomic_thread_fence(std::memory_order_acquire);
+        if (slot.identity.load(std::memory_order_relaxed) != identity)
+            break;
+
         into.notes.push_back({static_cast<int>(identity & 0x7fU),
-                              static_cast<int>((identity >> 8U) & 0x7fU),
-                              notes_[at].startBeat.load(std::memory_order_relaxed),
-                              notes_[at].lengthBeats.load(std::memory_order_relaxed)});
+                              static_cast<int>((identity >> 8U) & 0x7fU), startBeat, lengthBeats});
     }
 
     const auto numPeaks = static_cast<std::size_t>(std::min<std::int64_t>(needed, peaks_.size()));

--- a/magda/engine/tap/RecordTap.hpp
+++ b/magda/engine/tap/RecordTap.hpp
@@ -1,0 +1,274 @@
+#pragma once
+
+#include <juce_audio_basics/juce_audio_basics.h>
+#include <juce_dsp/juce_dsp.h>
+
+#include <array>
+#include <atomic>
+#include <bit>
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+/**
+ * @file RecordTap.hpp
+ * @brief What the pass in flight has reached, for whoever draws it (#2463).
+ *
+ * The fourth tap, following LaunchTap.hpp. A level tap reports a block, a value
+ * tap a number, a launch tap a slot; this reports a recording pass: where it
+ * started, how much it covers, the notes it has captured and the peaks its
+ * audio reached.
+ *
+ * Written by the block that recorded the material, from the transport that
+ * stamped it, so what is drawn and what is written cannot disagree. Nothing
+ * polls, and no frame timer decides the length.
+ *
+ * A note is positioned here as io/MidiTakeRecorder.hpp positions it in the
+ * finished clip: the same conversion, off the same pass origin, so the preview
+ * and the clip do not resolve a beat differently.
+ *
+ * One writer, the audio thread. Any number of readers, none of them consuming.
+ */
+
+namespace magda::engine {
+
+/// Where the pass is going. Slice 6 (#2464) is what fills in the slot half.
+enum class RecordTarget : std::uint8_t { arrangement, slot };
+
+/// What the pass is made of, and so what a reader draws.
+enum class RecordMaterial : std::uint8_t { audio, midi };
+
+/** @brief One note of the pass, in the beats the take will hold it at. */
+struct RecordedNote {
+    int noteNumber = 0;
+    int velocity = 0;
+
+    /// From the pass start, the same origin MidiTake's notes are relative to.
+    double startBeat = 0.0;
+
+    /// Up to the pass end while the note is still down.
+    double lengthBeats = 0.0;
+};
+
+/** @brief One tick of the pass's audio, at RecordTap::samplesPerPeak(). */
+struct RecordedPeak {
+    float left = 0.0f;
+    float right = 0.0f;
+};
+
+/** @brief How much of a pass a tap can describe. */
+struct RecordTapSettings {
+    RecordTarget target = RecordTarget::arrangement;
+
+    /// Which slot, for a pass whose target is one.
+    int scene = -1;
+
+    /// Notes and peaks a pass may hold, sized here because the audio thread
+    /// cannot allocate. Zero is a take nobody draws, which still reports its
+    /// length.
+    std::size_t maxNotes = 0;
+    std::size_t maxPeaks = 0;
+
+    /// How much of the take one peak covers. A pass's peaks are evenly spaced
+    /// in its own samples, so a reader lays them across its length.
+    int samplesPerPeak = 1024;
+};
+
+/**
+ * @brief The pass in flight, published by the block that recorded it.
+ *
+ * The slots are atomic, relaxed on both sides, for the reason SampleRing.hpp
+ * gives: plain memory read beside a live writer is a data race rather than a
+ * ragged frame.
+ *
+ * Two things make a reading one pass's own rather than two.
+ *
+ * Where the pass is and how far it has got are the scalars a wrap resets
+ * together, so they are published behind a sequence the reader retries over.
+ * That window is those stores and nothing else, which is what makes the retry
+ * converge.
+ *
+ * The notes are not in it: an array is as long as the pass is, and a reader
+ * copying one inside a window would be racing the writer over a growing amount
+ * of work. Each note carries the pass that recorded it instead, and a reader
+ * takes the ones belonging to the pass it is reporting. A wrap during a read
+ * therefore costs notes off the end of the list, never a note in the wrong
+ * place.
+ *
+ * The peaks carry neither, and are the one thing here that can be ragged: a
+ * wrap landing inside a read redraws a few ticks of the previous pass's audio,
+ * for the frame it takes to ask again. Peaks are presentation and place
+ * nothing.
+ */
+class RecordTap {
+    static_assert(std::atomic<double>::is_always_lock_free,
+                  "a record tap is written on the audio thread and must not take a lock");
+
+  public:
+    RecordTap(RecordMaterial material, const RecordTapSettings& settings)
+        : material_(material),
+          settings_(settings),
+          notes_(settings.maxNotes),
+          peaks_(settings.maxPeaks) {
+        held_.fill(kNotHeld);
+        heldSlots_.reserve(settings.maxNotes);
+    }
+
+    /** @brief The pass as it stands. */
+    struct Reading {
+        bool recording = false;
+        RecordMaterial material = RecordMaterial::audio;
+        RecordTarget target = RecordTarget::arrangement;
+        int scene = -1;
+
+        /// Where the pass sits on the timeline, and how much of it it covers.
+        double startBeat = 0.0;
+        double lengthBeats = 0.0;
+
+        /// Which pass of the take this is. Zero until one has opened, which is
+        /// what tells an armed track with a stopped transport from a pass of no
+        /// length.
+        std::uint32_t pass = 0;
+
+        std::vector<RecordedNote> notes;
+        std::vector<RecordedPeak> peaks;
+
+        /// Notes and peaks the pass had no room for.
+        std::int64_t notesLost = 0;
+        std::int64_t peaksLost = 0;
+    };
+
+    /**
+     * @brief Read the pass into @p into. Off the audio thread.
+     *
+     * Reuses @p into's storage, so a repaint reading every frame allocates
+     * once.
+     */
+    void read(Reading& into) const;
+
+    Reading read() const {
+        Reading reading;
+        read(reading);
+        return reading;
+    }
+
+    int samplesPerPeak() const {
+        return settings_.samplesPerPeak;
+    }
+
+    /**
+     * @brief A pass begins at @p startBeat on the timeline. Audio thread.
+     *
+     * Leaves the notes and peaks of the pass it replaces behind: what is drawn
+     * is the pass in flight, and a loop wrap starts another one.
+     */
+    void open(double startBeat);
+
+    /// @brief The pass, and every note still down, reach @p lengthBeats.
+    void extend(double lengthBeats);
+
+    /// @brief No pass in flight. What the last one reached stands, so an
+    /// overlay holds until the clip it became appears.
+    void close() {
+        recording_.store(false, std::memory_order_relaxed);
+    }
+
+    /// @brief A note went down at @p beat from the pass start. Audio thread.
+    void noteOn(int channel, int note, int velocity, double beat);
+
+    /// @brief The note came up at @p beat from the pass start. Audio thread.
+    void noteOff(int channel, int note, double beat);
+
+    /**
+     * @brief Fold a block of the take's own audio into the pass's peaks.
+     *
+     * @p passSample is where the block's first sample sits in the pass, counted
+     * in the samples the take wrote, so a peak lands where the audio behind it
+     * did.
+     */
+    void addPeaks(juce::dsp::AudioBlock<const float> audio, int numSamples,
+                  std::int64_t passSample);
+
+  private:
+    /// Channels the held table spans. A note is published without one, as
+    /// MidiTake holds it, but two channels playing middle C are two notes.
+    static constexpr std::size_t kChannels = 16;
+    static constexpr std::size_t kNotesPerChannel = 128;
+
+    static constexpr std::uint32_t kNotHeld = 0xffffffffU;
+
+    /// Odd while the pass scalars are being replaced, even while they stand.
+    /// The pass ordinal is what is left once that bit is taken off.
+    static constexpr std::uint32_t kOpening = 1U;
+
+    /// A reader only ever retries over a handful of stores. Past this the audio
+    /// thread was preempted mid-open, and one frame of a start beside the next
+    /// pass's length is cheaper than spinning until it is rescheduled.
+    static constexpr int kReadAttempts = 64;
+
+    /// A note's identity and which pass recorded it, written once and never
+    /// revised.
+    struct NoteSlot {
+        std::atomic<std::uint64_t> identity{0};
+        std::atomic<double> startBeat{0.0};
+        std::atomic<double> lengthBeats{0.0};
+    };
+
+    static std::uint64_t packIdentity(std::uint32_t pass, int note, int velocity) {
+        return static_cast<std::uint64_t>(note & 0x7f) |
+               (static_cast<std::uint64_t>(velocity & 0x7f) << 8U) |
+               (static_cast<std::uint64_t>(pass) << 32U);
+    }
+
+    static std::uint64_t packPeak(float left, float right) {
+        return (static_cast<std::uint64_t>(std::bit_cast<std::uint32_t>(left)) << 32U) |
+               std::bit_cast<std::uint32_t>(right);
+    }
+
+    static RecordedPeak unpackPeak(std::uint64_t word) {
+        return {std::bit_cast<float>(static_cast<std::uint32_t>(word >> 32U)),
+                std::bit_cast<float>(static_cast<std::uint32_t>(word & 0xffffffffULL))};
+    }
+
+    static std::size_t heldIndex(int channel, int note) {
+        return ((static_cast<std::size_t>(channel) % kChannels) * kNotesPerChannel) +
+               (static_cast<std::size_t>(note) & (kNotesPerChannel - 1));
+    }
+
+    /// One tick's peak, folded into what the pass already put there. Assigned
+    /// on the tick's first touch instead, which is what leaves the last pass's
+    /// audio behind without clearing the array on every wrap.
+    void writePeak(std::size_t slot, juce::dsp::AudioBlock<const float> audio, int offset,
+                   int numSamples, bool first);
+
+    RecordMaterial material_;
+    RecordTapSettings settings_;
+
+    std::vector<NoteSlot> notes_;
+    std::vector<std::atomic<std::uint64_t>> peaks_;
+
+    /// Which slot holds each channel's note while it is down. Audio thread
+    /// only, like every index below it.
+    std::array<std::uint32_t, kChannels * kNotesPerChannel> held_{};
+
+    /// The slots still open, so extending them costs the chord rather than the
+    /// table.
+    std::vector<std::uint32_t> heldSlots_;
+
+    /// The pass the writer is on, so a note can be tagged without reading the
+    /// sequence back.
+    std::uint32_t pass_ = 0;
+
+    std::atomic<std::uint32_t> seq_{0};
+    std::atomic<bool> recording_{false};
+    std::atomic<double> startBeat_{0.0};
+    std::atomic<double> lengthBeats_{0.0};
+
+    std::atomic<std::size_t> numNotes_{0};
+    std::atomic<std::int64_t> notesLost_{0};
+
+    /// Peaks the pass has reached, which is what it holds once capped.
+    std::atomic<std::int64_t> peaksNeeded_{0};
+};
+
+}  // namespace magda::engine

--- a/magda/engine/tap/RecordTap.hpp
+++ b/magda/engine/tap/RecordTap.hpp
@@ -90,9 +90,11 @@ struct RecordTapSettings {
  *
  * The notes are not in it: an array is as long as the pass is, and a reader
  * copying one inside a window would be racing the writer over a growing amount
- * of work. Each note carries the pass that recorded it instead, and a reader
- * takes the ones belonging to the pass it is reporting. A wrap during a read
- * therefore costs notes off the end of the list, never a note in the wrong
+ * of work. Each slot is published by its own identity instead -- cleared before
+ * it is filled and written last -- and the identity carries the pass that
+ * recorded it. A reader takes the slots whose identity names the pass it is
+ * reporting and is unchanged either side of reading the position, so a wrap
+ * during a read costs notes off the end of the list, never a note in the wrong
  * place.
  *
  * The peaks carry neither, and are the one thing here that can be ragged: a
@@ -206,8 +208,9 @@ class RecordTap {
     /// pass's length is cheaper than spinning until it is rescheduled.
     static constexpr int kReadAttempts = 64;
 
-    /// A note's identity and which pass recorded it, written once and never
-    /// revised.
+    /// A note's identity and which pass recorded it. Zero while the slot is
+    /// being filled, which is what makes an overwrite visible to a reader
+    /// partway through one.
     struct NoteSlot {
         std::atomic<std::uint64_t> identity{0};
         std::atomic<double> startBeat{0.0};
@@ -234,6 +237,9 @@ class RecordTap {
         return ((static_cast<std::size_t>(channel) % kChannels) * kNotesPerChannel) +
                (static_cast<std::size_t>(note) & (kNotesPerChannel - 1));
     }
+
+    /// One note into @p at, published by the identity written last.
+    void writeSlot(std::uint32_t at, int note, int velocity, double beat);
 
     /// One tick's peak, folded into what the pass already put there. Assigned
     /// on the tick's first touch instead, which is what leaves the last pass's

--- a/magda/engine/tap/RecordTap.hpp
+++ b/magda/engine/tap/RecordTap.hpp
@@ -97,6 +97,13 @@ struct RecordTapSettings {
  * turns once per block rather than once per note (@ref Change), so a reader
  * retries at most once a block and settles in the gap after it.
  *
+ * The payload is read and written relaxed and the ordering is carried by a
+ * fence at each end: a release fence after the revision is turned odd, an
+ * acquire fence before the reader looks at it again. Observing any store from
+ * inside a change therefore forces that second look to see the change had
+ * begun. Release on the increment itself would not, since it orders what
+ * precedes it rather than what follows.
+ *
  * **Lengths grow without turning the revision, and are still read inside the
  * check.** A note still down, and the pass itself, reach further every block,
  * and turning the revision for that would send a reader round on every block it
@@ -142,10 +149,26 @@ class RecordTap {
     class Change {
       public:
         explicit Change(RecordTap& tap) : tap_(tap) {
-            if (tap_.changing_++ == 0)
-                tap_.revision_.fetch_add(kChanging, std::memory_order_release);
+            if (tap_.changing_++ != 0)
+                return;
+
+            tap_.revision_.fetch_add(kChanging, std::memory_order_release);
+
+            // The release on that increment orders what came before it, and
+            // nothing about what comes after: the payload stores below are
+            // relaxed and may be reordered ahead of it, and a reader seeing one
+            // of them could still load the old even revision and accept it.
+            //
+            // This fence is what stops that. It pairs with the acquire fence a
+            // reader takes before its second look at the revision
+            // ([atomics.fences]/2), so observing any payload store from inside
+            // the change forces that look to see the increment above.
+            std::atomic_thread_fence(std::memory_order_release);
         }
 
+        /// The closing increment needs no fence of its own: its release orders
+        /// the payload stores before it, which is what a reader's first look
+        /// acquires.
         ~Change() {
             if (--tap_.changing_ == 0)
                 tap_.revision_.fetch_add(kChanging, std::memory_order_release);

--- a/magda/engine/tap/RecordTap.hpp
+++ b/magda/engine/tap/RecordTap.hpp
@@ -97,10 +97,16 @@ struct RecordTapSettings {
  * turns once per block rather than once per note (@ref Change), so a reader
  * retries at most once a block and settles in the gap after it.
  *
- * **Lengths are the exception, deliberately.** A note still down grows every
- * block and the revision does not turn for it: its start cannot move while it
- * stands, so a length read a block later still belongs to that note. What a
- * reading does not promise is that two notes' lengths are from the same block.
+ * **Lengths grow without turning the revision, and are still read inside the
+ * check.** A note still down, and the pass itself, reach further every block,
+ * and turning the revision for that would send a reader round on every block it
+ * landed in. What makes it safe is that a length is only ever measured from a
+ * start that cannot move while the pass stands -- so a length taken inside the
+ * check belongs to the start beside it, and a wrap sends the reader round like
+ * any other change. Reading one afterwards would not: the pass that opened has
+ * no length yet, and that is an overlay collapsing to nothing.
+ *
+ * What a reading does not promise is that two lengths are from the same block.
  *
  * **The peaks are presentation and are not in the snapshot at all.** They place
  * nothing and drive nothing, and a wrap landing inside a read can redraw a few

--- a/magda/engine/tap/RecordTap.hpp
+++ b/magda/engine/tap/RecordTap.hpp
@@ -3,7 +3,6 @@
 #include <juce_audio_basics/juce_audio_basics.h>
 #include <juce_dsp/juce_dsp.h>
 
-#include <array>
 #include <atomic>
 #include <bit>
 #include <cstddef>
@@ -23,11 +22,9 @@
  * stamped it, so what is drawn and what is written cannot disagree. Nothing
  * polls, and no frame timer decides the length.
  *
- * A note is positioned here as io/MidiTakeRecorder.hpp positions it in the
- * finished clip: the same conversion, off the same pass origin, so the preview
- * and the clip do not resolve a beat differently.
- *
- * One writer, the audio thread. Any number of readers, none of them consuming.
+ * It publishes and nothing more. What a note is -- which release closes it,
+ * what a second strike does -- is io/TakeNotes.hpp, driven by the take as well,
+ * so the overlay and the clip are made of the same transitions.
  */
 
 namespace magda::engine {
@@ -77,43 +74,86 @@ struct RecordTapSettings {
 /**
  * @brief The pass in flight, published by the block that recorded it.
  *
- * The slots are atomic, relaxed on both sides, for the reason SampleRing.hpp
- * gives: plain memory read beside a live writer is a data race rather than a
- * ragged frame.
+ * ## What a reading promises
  *
- * Two things make a reading one pass's own rather than two.
+ * Two kinds of thing live here and they are not promised alike, which is the
+ * whole of the contract (#2527 review).
  *
- * Where the pass is and how far it has got are the scalars a wrap resets
- * together, so they are published behind a sequence the reader retries over.
- * That window is those stores and nothing else, which is what makes the retry
- * converge.
+ * **The pass and its notes are recording metadata, and a reading of them is one
+ * moment's.** Which pass it is, where it starts, how many notes it holds and
+ * what each of them is are published behind one revision, turned twice around
+ * every change to any of them. A reader copies them and checks the revision
+ * afterwards; if it moved, the copy is thrown away rather than handed over. So
+ * a reading never pairs one pass's start with another's notes, or a note's
+ * pitch with a different note's beat.
  *
- * The notes are not in it: an array is as long as the pass is, and a reader
- * copying one inside a window would be racing the writer over a growing amount
- * of work. Each slot carries its own revision instead, turned twice around
- * every replacement, and its identity carries the pass that recorded it. A
- * reader takes the slots naming the pass it is reporting whose revision is
- * unchanged either side of the position, so a wrap or a retrigger during a read
- * costs a note off the list, never a note in the wrong place.
+ * A read that cannot settle returns false and leaves the reader's own reading
+ * alone: the last good one is a better answer than a mixed one. The revision
+ * turns once per block rather than once per note (@ref Change), so a reader
+ * retries at most once a block and settles in the gap after it.
  *
- * The peaks carry neither, and are the one thing here that can be ragged: a
- * wrap landing inside a read redraws a few ticks of the previous pass's audio,
- * for the frame it takes to ask again. Peaks are presentation and place
- * nothing.
+ * **Lengths are the exception, deliberately.** A note still down grows every
+ * block and the revision does not turn for it: its start cannot move while it
+ * stands, so a length read a block later still belongs to that note. What a
+ * reading does not promise is that two notes' lengths are from the same block.
+ *
+ * **The peaks are presentation and are not in the snapshot at all.** They place
+ * nothing and drive nothing, and a wrap landing inside a read can redraw a few
+ * ticks of the previous pass's audio for the frame it takes to ask again. This
+ * is the approximation the contract admits to; everything above it is exact.
+ *
+ * ## What it costs the audio thread
+ *
+ * Bounded and allocation-free. A structural change is a handful of stores; a
+ * block's extension is one store per note still down. The arrays are sized at
+ * construction and never grow.
+ *
+ * One writer, the audio thread. Any number of readers, none of them consuming.
  */
 class RecordTap {
     static_assert(std::atomic<double>::is_always_lock_free,
                   "a record tap is written on the audio thread and must not take a lock");
 
   public:
+    /// A pass with no room for another note.
+    static constexpr std::size_t kNoSlot = static_cast<std::size_t>(-1);
+
+    /**
+     * @brief Everything one block does to the pass, published as one change.
+     *
+     * A block's events are one transition, so a reader sees the pass before it
+     * or after it and never inside it, and retries at most once a block rather
+     * than once a note. Nesting is the ordinary case -- the calls below take
+     * one each -- and only the outermost turns the revision.
+     *
+     * Audio thread, for the length of a block and no longer.
+     */
+    class Change {
+      public:
+        explicit Change(RecordTap& tap) : tap_(tap) {
+            if (tap_.changing_++ == 0)
+                tap_.revision_.fetch_add(kChanging, std::memory_order_release);
+        }
+
+        ~Change() {
+            if (--tap_.changing_ == 0)
+                tap_.revision_.fetch_add(kChanging, std::memory_order_release);
+        }
+
+        Change(const Change&) = delete;
+        Change& operator=(const Change&) = delete;
+        Change(Change&&) = delete;
+        Change& operator=(Change&&) = delete;
+
+      private:
+        RecordTap& tap_;
+    };
+
     RecordTap(RecordMaterial material, const RecordTapSettings& settings)
         : material_(material),
           settings_(settings),
           notes_(settings.maxNotes),
-          peaks_(settings.maxPeaks) {
-        held_.fill(kNotHeld);
-        heldSlots_.reserve(settings.maxNotes);
-    }
+          peaks_(settings.maxPeaks) {}
 
     /** @brief The pass as it stands. */
     struct Reading {
@@ -137,16 +177,28 @@ class RecordTap {
         /// Notes and peaks the pass had no room for.
         std::int64_t notesLost = 0;
         std::int64_t peaksLost = 0;
+
+      private:
+        friend class RecordTap;
+
+        /// Where a read is assembled. Swapped in only once it has been checked,
+        /// so a read that does not settle leaves @ref notes as it found them.
+        std::vector<RecordedNote> staging;
     };
 
     /**
      * @brief Read the pass into @p into. Off the audio thread.
      *
+     * True when @p into is one moment's reading. False leaves it exactly as it
+     * was, for a caller to keep drawing.
+     *
      * Reuses @p into's storage, so a repaint reading every frame allocates
      * once.
      */
-    void read(Reading& into) const;
+    bool read(Reading& into) const;
 
+    /// @brief The pass, for a caller with nothing to keep. A read that does not
+    /// settle comes back as a pass that never opened.
     Reading read() const {
         Reading reading;
         read(reading);
@@ -157,6 +209,10 @@ class RecordTap {
         return settings_.samplesPerPeak;
     }
 
+    std::size_t maxNotes() const {
+        return notes_.size();
+    }
+
     /**
      * @brief A pass begins at @p startBeat on the timeline. Audio thread.
      *
@@ -165,20 +221,32 @@ class RecordTap {
      */
     void open(double startBeat);
 
-    /// @brief The pass, and every note still down, reach @p lengthBeats.
-    void extend(double lengthBeats);
-
     /// @brief No pass in flight. What the last one reached stands, so an
     /// overlay holds until the clip it became appears.
     void close() {
         recording_.store(false, std::memory_order_relaxed);
     }
 
-    /// @brief A note went down at @p beat from the pass start. Audio thread.
-    void noteOn(int channel, int note, int velocity, double beat);
+    /// @brief The pass reaches @p lengthBeats. Not a change to what it holds,
+    /// so a reader in the middle of one is not sent round again.
+    void extend(double lengthBeats) {
+        lengthBeats_.store(lengthBeats, std::memory_order_relaxed);
+    }
 
-    /// @brief The note came up at @p beat from the pass start. Audio thread.
-    void noteOff(int channel, int note, double beat);
+    /**
+     * @brief A note begins at @p beat from the pass start. Audio thread.
+     *
+     * The slot it took, for the caller to name it by afterwards, or @ref
+     * kNoSlot when the pass is full.
+     */
+    std::size_t addNote(int noteNumber, int velocity, double beat);
+
+    /// @brief @p slot is struck again: the same slot, a new note. What
+    /// TakeNotes.hpp calls a replacement.
+    void replaceNote(std::size_t slot, int noteNumber, int velocity, double beat);
+
+    /// @brief The note in @p slot now runs to @p endBeat, held or released.
+    void noteReaches(std::size_t slot, double endBeat);
 
     /**
      * @brief Fold a block of the take's own audio into the pass's peaks.
@@ -191,43 +259,22 @@ class RecordTap {
                   std::int64_t passSample);
 
   private:
-    /// Channels the held table spans. A note is published without one, as
-    /// MidiTake holds it, but two channels playing middle C are two notes.
-    static constexpr std::size_t kChannels = 16;
-    static constexpr std::size_t kNotesPerChannel = 128;
+    /// Odd while the pass or its notes are changing, even while they stand.
+    static constexpr std::uint32_t kChanging = 1U;
 
-    static constexpr std::uint32_t kNotHeld = 0xffffffffU;
+    /// A reader retries over a handful of stores, and only while a block's
+    /// events are being taken. Past this it says so rather than spinning.
+    static constexpr int kReadAttempts = 16;
 
-    /// Odd while the pass scalars are being replaced, even while they stand.
-    /// The pass ordinal is what is left once that bit is taken off.
-    static constexpr std::uint32_t kOpening = 1U;
-
-    /// A reader only ever retries over a handful of stores. Past this the audio
-    /// thread was preempted mid-open, and one frame of a start beside the next
-    /// pass's length is cheaper than spinning until it is rescheduled.
-    static constexpr int kReadAttempts = 64;
-
-    /// One note, and the count that says which occupant of the slot it is.
-    ///
-    /// The count rather than the identity, because the identity is not unique:
-    /// a pitch retriggered at the same velocity within one pass packs the same
-    /// word, so a reader comparing identities would accept the strike before
-    /// the replacement paired with the length after it. It rises on every
-    /// replacement and is odd while one is in flight.
-    ///
-    /// A length that grows under a read is not a replacement -- it is the same
-    /// note being held -- and deliberately does not touch it.
     struct NoteSlot {
-        std::atomic<std::uint64_t> revision{0};
-        std::atomic<std::uint64_t> identity{0};
+        std::atomic<std::uint32_t> identity{0};
         std::atomic<double> startBeat{0.0};
         std::atomic<double> lengthBeats{0.0};
     };
 
-    static std::uint64_t packIdentity(std::uint32_t pass, int note, int velocity) {
-        return static_cast<std::uint64_t>(note & 0x7f) |
-               (static_cast<std::uint64_t>(velocity & 0x7f) << 8U) |
-               (static_cast<std::uint64_t>(pass) << 32U);
+    static std::uint32_t packIdentity(int note, int velocity) {
+        return static_cast<std::uint32_t>(note & 0x7f) |
+               (static_cast<std::uint32_t>(velocity & 0x7f) << 8U);
     }
 
     static std::uint64_t packPeak(float left, float right) {
@@ -240,13 +287,8 @@ class RecordTap {
                 std::bit_cast<float>(static_cast<std::uint32_t>(word & 0xffffffffULL))};
     }
 
-    static std::size_t heldIndex(int channel, int note) {
-        return ((static_cast<std::size_t>(channel) % kChannels) * kNotesPerChannel) +
-               (static_cast<std::size_t>(note) & (kNotesPerChannel - 1));
-    }
-
-    /// One note into @p at, published between two turns of its revision.
-    void writeSlot(std::uint32_t at, int note, int velocity, double beat);
+    /// One note into @p slot. Inside a @ref Change, which is what publishes it.
+    void writeSlot(std::size_t slot, int noteNumber, int velocity, double beat);
 
     /// One tick's peak, folded into what the pass already put there. Assigned
     /// on the tick's first touch instead, which is what leaves the last pass's
@@ -260,19 +302,12 @@ class RecordTap {
     std::vector<NoteSlot> notes_;
     std::vector<std::atomic<std::uint64_t>> peaks_;
 
-    /// Which slot holds each channel's note while it is down. Audio thread
-    /// only, like every index below it.
-    std::array<std::uint32_t, kChannels * kNotesPerChannel> held_{};
+    /// Changes open right now. Audio thread only, like everything a change
+    /// touches.
+    int changing_ = 0;
 
-    /// The slots still open, so extending them costs the chord rather than the
-    /// table.
-    std::vector<std::uint32_t> heldSlots_;
-
-    /// The pass the writer is on, so a note can be tagged without reading the
-    /// sequence back.
-    std::uint32_t pass_ = 0;
-
-    std::atomic<std::uint32_t> seq_{0};
+    std::atomic<std::uint32_t> revision_{0};
+    std::atomic<std::uint32_t> pass_{0};
     std::atomic<bool> recording_{false};
     std::atomic<double> startBeat_{0.0};
     std::atomic<double> lengthBeats_{0.0};

--- a/magda/engine/tap/RecordTap.hpp
+++ b/magda/engine/tap/RecordTap.hpp
@@ -13,6 +13,11 @@
  * @file RecordTap.hpp
  * @brief What the pass in flight has reached, for whoever draws it (#2463).
  *
+ * Owned by whoever set the recording up, not by the take, for the reason a
+ * LevelTap is owned by the host: it outlives what writes it. A take is closed
+ * and destroyed the moment it becomes a clip, and the overlay has to stand
+ * until the clip appears in its place.
+ *
  * The fourth tap, following LaunchTap.hpp. A level tap reports a block, a value
  * tap a number, a launch tap a slot; this reports a recording pass: where it
  * started, how much it covers, the notes it has captured and the peaks its
@@ -197,14 +202,6 @@ class RecordTap {
      */
     bool read(Reading& into) const;
 
-    /// @brief The pass, for a caller with nothing to keep. A read that does not
-    /// settle comes back as a pass that never opened.
-    Reading read() const {
-        Reading reading;
-        read(reading);
-        return reading;
-    }
-
     int samplesPerPeak() const {
         return settings_.samplesPerPeak;
     }
@@ -221,8 +218,9 @@ class RecordTap {
      */
     void open(double startBeat);
 
-    /// @brief No pass in flight. What the last one reached stands, so an
-    /// overlay holds until the clip it became appears.
+    /// @brief No pass in flight. What the last one reached stands, which the
+    /// tap outliving the take is what makes possible: an overlay holds until
+    /// the clip it became appears.
     void close() {
         recording_.store(false, std::memory_order_relaxed);
     }

--- a/magda/engine/tap/RecordTap.hpp
+++ b/magda/engine/tap/RecordTap.hpp
@@ -90,12 +90,11 @@ struct RecordTapSettings {
  *
  * The notes are not in it: an array is as long as the pass is, and a reader
  * copying one inside a window would be racing the writer over a growing amount
- * of work. Each slot is published by its own identity instead -- cleared before
- * it is filled and written last -- and the identity carries the pass that
- * recorded it. A reader takes the slots whose identity names the pass it is
- * reporting and is unchanged either side of reading the position, so a wrap
- * during a read costs notes off the end of the list, never a note in the wrong
- * place.
+ * of work. Each slot carries its own revision instead, turned twice around
+ * every replacement, and its identity carries the pass that recorded it. A
+ * reader takes the slots naming the pass it is reporting whose revision is
+ * unchanged either side of the position, so a wrap or a retrigger during a read
+ * costs a note off the list, never a note in the wrong place.
  *
  * The peaks carry neither, and are the one thing here that can be ragged: a
  * wrap landing inside a read redraws a few ticks of the previous pass's audio,
@@ -208,10 +207,18 @@ class RecordTap {
     /// pass's length is cheaper than spinning until it is rescheduled.
     static constexpr int kReadAttempts = 64;
 
-    /// A note's identity and which pass recorded it. Zero while the slot is
-    /// being filled, which is what makes an overwrite visible to a reader
-    /// partway through one.
+    /// One note, and the count that says which occupant of the slot it is.
+    ///
+    /// The count rather than the identity, because the identity is not unique:
+    /// a pitch retriggered at the same velocity within one pass packs the same
+    /// word, so a reader comparing identities would accept the strike before
+    /// the replacement paired with the length after it. It rises on every
+    /// replacement and is odd while one is in flight.
+    ///
+    /// A length that grows under a read is not a replacement -- it is the same
+    /// note being held -- and deliberately does not touch it.
     struct NoteSlot {
+        std::atomic<std::uint64_t> revision{0};
         std::atomic<std::uint64_t> identity{0};
         std::atomic<double> startBeat{0.0};
         std::atomic<double> lengthBeats{0.0};
@@ -238,7 +245,7 @@ class RecordTap {
                (static_cast<std::size_t>(note) & (kNotesPerChannel - 1));
     }
 
-    /// One note into @p at, published by the identity written last.
+    /// One note into @p at, published between two turns of its revision.
     void writeSlot(std::uint32_t at, int note, int velocity, double beat);
 
     /// One tick's peak, folded into what the pass already put there. Assigned

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -430,6 +430,9 @@ if(MAGDA_BUILD_NATIVE_ENGINE)
     # A MIDI take (#2462): where an event lands, what a held note gets for a
     # length, and which pass owns one that crossed a wrap.
     list(APPEND TEST_SOURCES engine/test_midi_take_recorder.cpp)
+    # The pass in flight, reported without a poll (#2463): its length off the
+    # transport that stamped it, and its notes where the finished clip holds them.
+    list(APPEND TEST_SOURCES engine/test_record_tap.cpp)
     list(APPEND TEST_SOURCES engine/test_engine_taps.cpp)
     list(APPEND TEST_SOURCES engine/test_clip_snapshot.cpp)
     list(APPEND TEST_SOURCES engine/test_clip_voice.cpp)

--- a/tests/engine/test_live_input.cpp
+++ b/tests/engine/test_live_input.cpp
@@ -12,6 +12,7 @@
 #include "io/LiveInput.hpp"
 #include "plan/PlanCompiler.hpp"
 #include "plan/RenderPlan.hpp"
+#include "tap/LevelTap.hpp"
 
 /**
  * @file test_live_input.cpp
@@ -33,7 +34,9 @@ using magda::engine::LiveAudioInput;
 using magda::engine::LiveInputFeed;
 using magda::engine::LiveMidiInput;
 using magda::engine::LiveMidiStream;
+using magda::engine::OpKey;
 using magda::engine::OpKind;
+using magda::engine::OpRole;
 using magda::engine::PlanValues;
 using magda::engine::RenderContext;
 using magda::engine::RenderPlan;
@@ -63,6 +66,26 @@ TrackInfo monitoringTrack(InputMonitorMode monitor, bool armed) {
     track.inputMonitor = monitor;
     track.recordArmed = armed;
     return track;
+}
+
+/// The op filling @p role on @p track, or -1. The master carries roles of the
+/// same name, so a search that ignored the track could answer about it.
+int findRole(const RenderPlan& plan, TrackId track, OpRole role) {
+    for (std::size_t at = 0; at < plan.ops.size(); ++at)
+        if (plan.ops[at].key.role == role && plan.ops[at].key.trackId == track)
+            return static_cast<int>(at);
+    return -1;
+}
+
+/// The ops reading @p producer, which is what tells a meter in the signal from
+/// one hanging beside it.
+std::vector<int> consumersOf(const RenderPlan& plan, int producer) {
+    std::vector<int> found;
+    for (std::size_t at = 0; at < plan.ops.size(); ++at)
+        for (const auto& input : plan.ops[at].inputs)
+            if (input.op == producer)
+                found.push_back(static_cast<int>(at));
+    return found;
 }
 
 int countKind(const RenderPlan& plan, OpKind kind) {
@@ -142,8 +165,21 @@ class LiveInputFactory final : public RuntimeStateFactory {
         return source;
     }
 
+    /// One meter, on the live input alone: a factory that took every Meter op
+    /// would report the track's output as well and prove nothing about where
+    /// this one sits.
+    std::unique_ptr<magda::engine::LevelTap> createMeter(const OpKey& key) override {
+        if (key.role != OpRole::LiveInputMeter)
+            return nullptr;
+
+        auto tap = std::make_unique<magda::engine::LevelTap>();
+        inputMeter = tap.get();
+        return tap;
+    }
+
     LiveInputFeed* feed = nullptr;
     TappedAudioInput* lastAudioInput = nullptr;
+    magda::engine::LevelTap* inputMeter = nullptr;
 };
 
 RenderContext context() {
@@ -404,6 +440,56 @@ TEST_CASE("A monitoring track hears its live input through the plan", "[engine][
     juce::AudioBuffer<float> afterwards(2, kBlockSize);
     tapped.render(blockInfo(kBlockSize), juce::dsp::AudioBlock<float>(afterwards));
     CHECK(afterwards.getMagnitude(0, kBlockSize) == 0.0f);
+}
+
+TEST_CASE("An input meter reads the input a monitoring track is hearing",
+          "[engine][live-input][2463]") {
+    // The incumbent reads this off the input device (WaveInputDevice's level
+    // measurer); here it is a meter on the input op, so it exists exactly while
+    // the op does and sits in the signal rather than beside it.
+    CHECK(inputOpsFor(InputMonitorMode::Off, false, OpKind::Meter) ==
+          inputOpsFor(InputMonitorMode::In, false, OpKind::Meter) - 1);
+
+    {
+        const std::vector<TrackInfo> monitoring{monitoringTrack(InputMonitorMode::In, false)};
+        const auto plan = compile(monitoring);
+        const auto& compiled = *plan;
+        const auto meter = findRole(compiled, monitoring.front().id, OpRole::LiveInputMeter);
+        const auto input = findRole(compiled, monitoring.front().id, OpRole::LiveAudioInput);
+        REQUIRE(meter >= 0);
+        REQUIRE(input >= 0);
+
+        REQUIRE(compiled.ops[static_cast<std::size_t>(meter)].inputs.size() == 1);
+        CHECK(compiled.ops[static_cast<std::size_t>(meter)].inputs[0].op == input);
+
+        // The input reaches the track through the meter and nowhere else, so
+        // what the meter reads is what the track hears.
+        CHECK(consumersOf(compiled, input) == std::vector<int>{meter});
+        CHECK_FALSE(consumersOf(compiled, meter).empty());
+    }
+
+    LiveInputFactory factory;
+    EngineSession session(factory);
+    factory.feed = &session.liveInputs();
+    session.liveInputs().prepare(2, kBlockSize);
+
+    const std::vector<TrackInfo> tracks{monitoringTrack(InputMonitorMode::In, false)};
+    const auto plan = compile(tracks);
+    REQUIRE(publish(session, plan, tracks).published);
+    REQUIRE(factory.inputMeter != nullptr);
+
+    juce::AudioBuffer<float> captured(2, kBlockSize);
+    captured.clear();
+    captured.setSample(0, 7, 0.5f);
+    captured.setSample(1, 9, -0.25f);
+
+    juce::AudioBuffer<float> output(2, kBlockSize);
+    output.clear();
+    session.process(kBlockSize, output, {blockOf(captured), {}});
+
+    const auto levels = factory.inputMeter->read();
+    CHECK(levels.peak[0] == Catch::Approx(0.5f));
+    CHECK(levels.peak[1] == Catch::Approx(0.25f));
 }
 
 TEST_CASE("Each piece of a callback the loop wraps inside reads its own input",

--- a/tests/engine/test_midi_take_recorder.cpp
+++ b/tests/engine/test_midi_take_recorder.cpp
@@ -11,6 +11,7 @@
 #include "exec/RenderContext.hpp"
 #include "io/LiveInput.hpp"
 #include "io/MidiTakeRecorder.hpp"
+#include "tap/RecordTap.hpp"
 #include "transport/TempoMap.hpp"
 #include "transport/TransportClock.hpp"
 #include "transport/TransportState.hpp"
@@ -107,7 +108,7 @@ class Rig {
         feed_.prepare(0, kBlockSize);
 
         if (records)
-            recorder_ = std::make_unique<MidiTakeRecorder>(feed_, std::move(settings));
+            recorder_ = std::make_unique<MidiTakeRecorder>(feed_, tap_, std::move(settings));
     }
 
     void schedule(std::vector<Played> events) {
@@ -200,6 +201,10 @@ class Rig {
     TransportClock clock_;
     LiveInputFeed feed_;
     LiveMidiInput monitor_;
+
+    /// Nothing here draws the pass; #2463 is where that is covered.
+    magda::engine::RecordTap tap_{magda::engine::RecordMaterial::midi, {}};
+
     std::unique_ptr<MidiTakeRecorder> recorder_;
 
     std::vector<Played> schedule_;

--- a/tests/engine/test_record_tap.cpp
+++ b/tests/engine/test_record_tap.cpp
@@ -663,3 +663,82 @@ TEST_CASE("An audio pass turns over where the file does, not where the wrap is",
         CHECK(reading.peaks[0].left == Catch::Approx(material(kFirstArrival + kPerPeak - 1, 0)));
     }
 }
+
+TEST_CASE("A later pass is drawn where the take will hold it too",
+          "[engine][io][record][midi][2463]") {
+    // The pass a wrap opened, where the preview's origin and the clip's are
+    // arrived at differently: the tap counts from the boundary as it goes, the
+    // take splits on it in finish().
+    MidiTakeRecorderSettings settings;
+    settings.tap = drawn();
+
+    MidiRig rig(settings);
+    rig.loop(0.0, 2.0);
+    rig.schedule({noteOn(kBeatSamples / 2, 60), noteOff(kBeatSamples, 60),
+                  noteOn(2 * kBeatSamples + (kBeatSamples / 2), 72),
+                  noteOff(3 * kBeatSamples, 72)});
+    rig.play();
+    rig.run((2 * kBeatSamples) + (3 * kBeatSamples) / 2);
+
+    const auto preview = rig.reading();
+    const auto take = rig.finish();
+
+    REQUIRE(take.clip.takes.size() == 2);
+    REQUIRE(take.clip.takes[1].notes.size() == 1);
+    REQUIRE(preview.notes.size() == 1);
+
+    CHECK(preview.pass == 2);
+    CHECK(preview.startBeat == beats(take.startBeat));
+    CHECK(preview.notes[0].noteNumber == take.clip.takes[1].notes[0].noteNumber);
+    CHECK(preview.notes[0].startBeat == beats(take.clip.takes[1].notes[0].startBeat));
+    CHECK(preview.notes[0].lengthBeats == beats(take.clip.takes[1].notes[0].lengthBeats));
+}
+
+TEST_CASE("A note held across a wrap is not drawn in the pass it did not start in",
+          "[engine][io][record][midi][2463]") {
+    MidiTakeRecorderSettings settings;
+    settings.tap = drawn();
+
+    MidiRig rig(settings);
+    rig.loop(0.0, 2.0);
+    rig.schedule(
+        {noteOn(3 * kBeatSamples / 2, 60), noteOff((2 * kBeatSamples) + kBeatSamples, 60)});
+    rig.play();
+    rig.run(3 * kBeatSamples);
+
+    const auto preview = rig.reading();
+    const auto take = rig.finish();
+
+    // The take gives it to the pass it started in, cut off at that pass's end,
+    // and the pass it ran into holds nothing.
+    REQUIRE(take.clip.takes.size() == 2);
+    CHECK(take.clip.takes[0].notes.size() == 1);
+    CHECK(take.clip.takes[1].notes.empty());
+    CHECK(preview.pass == 2);
+    CHECK(preview.notes.empty());
+}
+
+TEST_CASE("A loop shorter than the latency still turns the preview over",
+          "[engine][io][record][2463]") {
+    // Every wrap names a boundary the written audio has not reached yet, so a
+    // preview holding only the newest would sit on its first pass while the
+    // sink cut eight files.
+    constexpr int kLoopSamples = 64;
+    constexpr int kLatency = 128;
+
+    AudioRig rig(emptyDirectory("short_loop"), drawn(0, 64, 16), 64, kLatency);
+    rig.loop(0.0, static_cast<double>(kLoopSamples) / kBeatSamples);
+    rig.play();
+    rig.run(640);
+
+    const auto reading = rig.reading();
+
+    // Seven boundaries the written audio reached, after the pass the take
+    // opened with. The length is one loop rather than the eight the preview
+    // would have run together.
+    CHECK(reading.pass == 8);
+    CHECK(reading.lengthBeats == beats(static_cast<double>(kLoopSamples) / kBeatSamples));
+    CHECK(reading.peaks.size() == kLoopSamples / 16);
+
+    CHECK(rig.recorder().finish().clip.takes.size() > 1);
+}

--- a/tests/engine/test_record_tap.cpp
+++ b/tests/engine/test_record_tap.cpp
@@ -5,6 +5,7 @@
 #include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/generators/catch_generators.hpp>
+#include <cmath>
 #include <cstdint>
 #include <memory>
 #include <thread>
@@ -420,6 +421,46 @@ TEST_CASE("A note is read as one note, not two halves of a slot", "[engine][tap]
         const auto reading = tap.read();
         for (const auto& note : reading.notes)
             REQUIRE(note.startBeat == beats(static_cast<double>(note.velocity)));
+
+        ++readings;
+    }
+
+    writer.join();
+    CHECK(readings > 0);
+}
+
+TEST_CASE("A retrigger that restores the same note is still a replacement",
+          "[engine][tap][record][2463]") {
+    RecordTap tap(RecordMaterial::midi, drawn());
+    tap.open(0.0);
+
+    // One pitch at one velocity, struck over and over without coming up. Every
+    // strike packs the identity the last one did, so nothing about the note
+    // itself tells two of them apart and only a count can. The length says
+    // which strike a beat came from.
+    std::atomic<bool> writing{true};
+
+    std::thread writer([&] {
+        for (auto strike = 0; strike < 4000000; ++strike) {
+            const auto at = static_cast<double>(strike);
+            tap.noteOn(1, 60, 100, at);
+            tap.extend(at + 1.0 + static_cast<double>(strike % 7));
+        }
+        writing.store(false);
+    });
+
+    auto readings = 0;
+    while (writing.load()) {
+        const auto reading = tap.read();
+
+        for (const auto& note : reading.notes) {
+            // Zero is the strike itself, before the pass has extended it.
+            if (note.lengthBeats == 0.0)
+                continue;
+
+            REQUIRE(note.lengthBeats ==
+                    beats(1.0 + static_cast<double>(std::llround(note.startBeat) % 7)));
+        }
 
         ++readings;
     }

--- a/tests/engine/test_record_tap.cpp
+++ b/tests/engine/test_record_tap.cpp
@@ -515,6 +515,45 @@ TEST_CASE("A retrigger that restores the same note is still a replacement",
     CHECK(checked > 0);
 }
 
+TEST_CASE("A pass's length belongs to the pass that is reported", "[engine][tap][record][2463]") {
+    RecordTap tap(RecordMaterial::midi, drawn());
+    PreviewNotes played(tap);
+    std::atomic<bool> writing{true};
+
+    // Each pass says which it is twice: where it starts, and a length one beat
+    // past that. A wrap taken between the two is a length off the next pass
+    // against the last one's start, which on an overlay is one that collapses.
+    std::thread writer([&] {
+        for (auto pass = 1; pass <= 200000; ++pass) {
+            const auto origin = static_cast<double>(pass) * 1000.0;
+
+            {
+                const RecordTap::Change change(tap);
+                played.open(origin);
+                played.reaches(origin + 1.0);
+            }
+
+            std::this_thread::yield();
+        }
+
+        writing.store(false);
+    });
+
+    auto checked = 0;
+    RecordTap::Reading reading;
+
+    while (writing.load()) {
+        if (!tap.read(reading) || reading.pass == 0)
+            continue;
+
+        REQUIRE(reading.lengthBeats == beats(reading.startBeat + 1.0));
+        ++checked;
+    }
+
+    writer.join();
+    CHECK(checked > 0);
+}
+
 TEST_CASE("A read that cannot settle leaves the reader what it had",
           "[engine][tap][record][2463]") {
     RecordTap tap(RecordMaterial::midi, drawn());

--- a/tests/engine/test_record_tap.cpp
+++ b/tests/engine/test_record_tap.cpp
@@ -100,11 +100,12 @@ Played noteOff(std::int64_t arrival, int note, int channel = 1) {
 /** @brief A transport, a scheduled MIDI input and one take, a callback at a time. */
 class MidiRig {
   public:
-    explicit MidiRig(MidiTakeRecorderSettings settings, TempoMap tempo = flat(), int blockSize = 64)
-        : blockSize_(blockSize) {
+    explicit MidiRig(RecordTapSettings tap, MidiTakeRecorderSettings settings = {},
+                     TempoMap tempo = flat(), int blockSize = 64)
+        : tap_(RecordMaterial::midi, tap), blockSize_(blockSize) {
         transport_.tempo = std::move(tempo);
         feed_.prepare(0, blockSize_);
-        recorder_ = std::make_unique<MidiTakeRecorder>(feed_, std::move(settings));
+        recorder_ = std::make_unique<MidiTakeRecorder>(feed_, tap_, std::move(settings));
     }
 
     void schedule(std::vector<Played> events) {
@@ -136,11 +137,18 @@ class MidiRig {
     }
 
     RecordTap::Reading reading() const {
-        return recorder_->tap().read();
+        RecordTap::Reading into;
+        REQUIRE(tap_.read(into));
+        return into;
     }
 
     RecordedMidiTake finish() {
         return recorder_->finish(transport_.tempo);
+    }
+
+    /// What a host does once a take is a clip. The tap is not the take's.
+    void releaseTake() {
+        recorder_.reset();
     }
 
   private:
@@ -165,6 +173,7 @@ class MidiRig {
     TransportSnapshot transport_;
     TransportClock clock_;
     LiveInputFeed feed_;
+    RecordTap tap_;
     std::unique_ptr<MidiTakeRecorder> recorder_;
 
     std::vector<Played> schedule_;
@@ -192,7 +201,7 @@ class AudioRig {
   public:
     AudioRig(const juce::File& directory, RecordTapSettings tap, int blockSize = 64,
              int latencySamples = 0)
-        : input_(2, blockSize), blockSize_(blockSize) {
+        : input_(2, blockSize), tap_(RecordMaterial::audio, tap), blockSize_(blockSize) {
         transport_.tempo = flat();
         feed_.prepare(2, blockSize_);
 
@@ -202,10 +211,9 @@ class AudioRig {
         settings.directory = directory;
         settings.file.format = AudioFileFormat::wav;
         settings.file.bitDepth = 32;
-        settings.tap = std::move(tap);
 
         recorder_ = std::make_unique<TakeRecorder>(feed_, RenderContext{kSampleRate, blockSize_, 2},
-                                                   std::move(settings));
+                                                   tap_, std::move(settings));
     }
 
     void play(double fromBeat = 0.0) {
@@ -232,7 +240,9 @@ class AudioRig {
     }
 
     RecordTap::Reading reading() const {
-        return recorder_->tap().read();
+        RecordTap::Reading into;
+        REQUIRE(tap_.read(into));
+        return into;
     }
 
   private:
@@ -260,6 +270,7 @@ class AudioRig {
     TransportClock clock_;
     LiveInputFeed feed_;
     juce::AudioBuffer<float> input_;
+    RecordTap tap_;
     std::unique_ptr<TakeRecorder> recorder_;
 
     std::int64_t arrival_ = 0;
@@ -273,7 +284,8 @@ class AudioRig {
 TEST_CASE("A tap nothing has opened reports no pass", "[engine][tap][record][2463]") {
     const RecordTap tap(RecordMaterial::midi, drawn());
 
-    const auto reading = tap.read();
+    RecordTap::Reading reading;
+    REQUIRE(tap.read(reading));
     CHECK_FALSE(reading.recording);
     CHECK(reading.pass == 0);
     CHECK(reading.lengthBeats == 0.0);
@@ -291,7 +303,8 @@ TEST_CASE("A held note reaches the end of the pass and stops where it came up",
     SECTION("still down, it is as long as the pass") {
         played.reaches(2.5);
 
-        const auto reading = tap.read();
+        RecordTap::Reading reading;
+        REQUIRE(tap.read(reading));
         REQUIRE(reading.notes.size() == 1);
         CHECK(reading.notes[0].startBeat == beats(0.5));
         CHECK(reading.notes[0].lengthBeats == beats(2.0));
@@ -302,7 +315,8 @@ TEST_CASE("A held note reaches the end of the pass and stops where it came up",
         played.release(1, 60, 1.5);
         played.reaches(2.5);
 
-        const auto reading = tap.read();
+        RecordTap::Reading reading;
+        REQUIRE(tap.read(reading));
         REQUIRE(reading.notes.size() == 1);
         CHECK(reading.notes[0].lengthBeats == beats(1.0));
     }
@@ -320,7 +334,8 @@ TEST_CASE("A pass takes the last one's notes with it", "[engine][tap][record][24
     played.strike(1, 67, 100, 0.25);
     played.reaches(1.0);
 
-    const auto reading = tap.read();
+    RecordTap::Reading reading;
+    REQUIRE(tap.read(reading));
     CHECK(reading.pass == 2);
     CHECK(reading.startBeat == beats(4.0));
     REQUIRE(reading.notes.size() == 1);
@@ -335,7 +350,8 @@ TEST_CASE("A note the pass has no room for is counted", "[engine][tap][record][2
     for (auto note = 0; note < 5; ++note)
         played.strike(1, 60 + note, 100, static_cast<double>(note));
 
-    const auto reading = tap.read();
+    RecordTap::Reading reading;
+    REQUIRE(tap.read(reading));
     CHECK(reading.notes.size() == 2);
     CHECK(reading.notesLost == 3);
 }
@@ -347,7 +363,8 @@ TEST_CASE("A closed pass keeps what it reached", "[engine][tap][record][2463]") 
     played.reaches(1.5);
     tap.close();
 
-    const auto reading = tap.read();
+    RecordTap::Reading reading;
+    REQUIRE(tap.read(reading));
     CHECK_FALSE(reading.recording);
     CHECK(reading.startBeat == beats(2.0));
     CHECK(reading.lengthBeats == beats(1.5));
@@ -552,10 +569,7 @@ TEST_CASE("A note is drawn at the beat the finished clip holds it at",
           "[engine][io][record][midi][2463]") {
     const auto tempo = GENERATE_COPY(flat(), halvedAtBeatTwo());
 
-    MidiTakeRecorderSettings settings;
-    settings.tap = drawn();
-
-    MidiRig rig(settings, tempo);
+    MidiRig rig(drawn(), {}, tempo);
     rig.schedule({noteOn(kBeatSamples, 64), noteOff(3 * kBeatSamples, 64)});
     rig.play();
     rig.run(4 * kBeatSamples);
@@ -575,10 +589,7 @@ TEST_CASE("A pass reports the length it captured, whatever the block size",
           "[engine][io][record][midi][2463]") {
     const auto blockSize = GENERATE(16, 64, 100);
 
-    MidiTakeRecorderSettings settings;
-    settings.tap = drawn();
-
-    MidiRig rig(settings, flat(), blockSize);
+    MidiRig rig(drawn(), {}, flat(), blockSize);
     rig.play();
     rig.run(6 * kBeatSamples);
 
@@ -590,11 +601,8 @@ TEST_CASE("A pass reports the length it captured, whatever the block size",
 
 TEST_CASE("An armed track with a stopped transport reports nothing",
           "[engine][io][record][midi][2463]") {
-    MidiTakeRecorderSettings settings;
-    settings.tap = drawn();
-
     SECTION("never played") {
-        MidiRig rig(settings);
+        MidiRig rig(drawn());
         rig.run(2 * kBeatSamples);
 
         const auto reading = rig.reading();
@@ -604,7 +612,7 @@ TEST_CASE("An armed track with a stopped transport reports nothing",
     }
 
     SECTION("counting in") {
-        MidiRig rig(settings);
+        MidiRig rig(drawn());
         rig.play(0.0, 2.0);
         rig.run(2 * kBeatSamples);
 
@@ -616,10 +624,7 @@ TEST_CASE("An armed track with a stopped transport reports nothing",
 
 TEST_CASE("A loop wrap draws the pass it opened, not the one it ended",
           "[engine][io][record][midi][2463]") {
-    MidiTakeRecorderSettings settings;
-    settings.tap = drawn();
-
-    MidiRig rig(settings);
+    MidiRig rig(drawn());
     rig.loop(0.0, 2.0);
     rig.schedule({noteOn(kBeatSamples / 2, 60), noteOff(kBeatSamples, 60),
                   noteOn(2 * kBeatSamples + kBeatSamples / 2, 72), noteOff(3 * kBeatSamples, 72)});
@@ -634,13 +639,33 @@ TEST_CASE("A loop wrap draws the pass it opened, not the one it ended",
     CHECK(reading.notes[0].startBeat == beats(0.5));
 }
 
-TEST_CASE("A take says which target it is recording into", "[engine][io][record][midi][2463]") {
-    MidiTakeRecorderSettings settings;
-    settings.tap = drawn();
-    settings.tap.target = RecordTarget::slot;
-    settings.tap.scene = 3;
+TEST_CASE("The pass stands once the take that wrote it is gone",
+          "[engine][io][record][midi][2463]") {
+    MidiRig rig(drawn());
+    rig.schedule({noteOn(kBeatSamples, 60), noteOff(2 * kBeatSamples, 60)});
+    rig.play();
+    rig.run(3 * kBeatSamples);
 
-    MidiRig rig(settings);
+    const auto take = rig.finish();
+    rig.releaseTake();
+
+    // What the overlay holds until the clip appears in its place, which is only
+    // possible because the tap is not the take's to take with it.
+    const auto reading = rig.reading();
+    CHECK_FALSE(reading.recording);
+    CHECK(reading.pass == 1);
+    REQUIRE(reading.notes.size() == 1);
+    REQUIRE(take.active.notes.size() == 1);
+    CHECK(reading.notes[0].startBeat == beats(take.active.notes[0].startBeat));
+    CHECK(reading.notes[0].lengthBeats == beats(take.active.notes[0].lengthBeats));
+}
+
+TEST_CASE("A take says which target it is recording into", "[engine][io][record][midi][2463]") {
+    auto tap = drawn();
+    tap.target = RecordTarget::slot;
+    tap.scene = 3;
+
+    MidiRig rig(tap);
     rig.play();
     rig.run(kBeatSamples);
 
@@ -652,7 +677,7 @@ TEST_CASE("A take says which target it is recording into", "[engine][io][record]
 
 TEST_CASE("A take nobody draws publishes the pass and nothing else",
           "[engine][io][record][midi][2463]") {
-    MidiRig rig(MidiTakeRecorderSettings{});
+    MidiRig rig(RecordTapSettings{});
     rig.schedule({noteOn(kBeatSamples, 60)});
     rig.play();
     rig.run(2 * kBeatSamples);
@@ -729,10 +754,7 @@ TEST_CASE("A wrap starts the audio pass's peaks again", "[engine][io][record][24
 
 TEST_CASE("A pitch struck twice replaces the note that was already down",
           "[engine][io][record][midi][2463]") {
-    MidiTakeRecorderSettings settings;
-    settings.tap = drawn();
-
-    MidiRig rig(settings);
+    MidiRig rig(drawn());
     rig.schedule({noteOn(kBeatSamples, 60, 90), noteOn(2 * kBeatSamples, 60, 110),
                   noteOff(3 * kBeatSamples, 60)});
     rig.play();
@@ -787,10 +809,7 @@ TEST_CASE("A later pass is drawn where the take will hold it too",
     // The pass a wrap opened, where the preview's origin and the clip's are
     // arrived at differently: the tap counts from the boundary as it goes, the
     // take splits on it in finish().
-    MidiTakeRecorderSettings settings;
-    settings.tap = drawn();
-
-    MidiRig rig(settings);
+    MidiRig rig(drawn());
     rig.loop(0.0, 2.0);
     rig.schedule({noteOn(kBeatSamples / 2, 60), noteOff(kBeatSamples, 60),
                   noteOn(2 * kBeatSamples + (kBeatSamples / 2), 72),
@@ -814,10 +833,7 @@ TEST_CASE("A later pass is drawn where the take will hold it too",
 
 TEST_CASE("A note held across a wrap is not drawn in the pass it did not start in",
           "[engine][io][record][midi][2463]") {
-    MidiTakeRecorderSettings settings;
-    settings.tap = drawn();
-
-    MidiRig rig(settings);
+    MidiRig rig(drawn());
     rig.loop(0.0, 2.0);
     rig.schedule(
         {noteOn(3 * kBeatSamples / 2, 60), noteOff((2 * kBeatSamples) + kBeatSamples, 60)});

--- a/tests/engine/test_record_tap.cpp
+++ b/tests/engine/test_record_tap.cpp
@@ -1,0 +1,563 @@
+#include <juce_audio_basics/juce_audio_basics.h>
+
+#include <array>
+#include <atomic>
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators.hpp>
+#include <cstdint>
+#include <memory>
+#include <thread>
+#include <utility>
+#include <vector>
+
+#include "exec/RenderContext.hpp"
+#include "io/LiveInput.hpp"
+#include "io/MidiTakeRecorder.hpp"
+#include "io/TakeRecorder.hpp"
+#include "tap/RecordTap.hpp"
+#include "transport/TempoMap.hpp"
+#include "transport/TransportClock.hpp"
+#include "transport/TransportState.hpp"
+
+/**
+ * @file test_record_tap.cpp
+ * @brief The pass in flight, reported without a poll (#2463).
+ *
+ * Offline throughout: a driven transport, a scheduled input, and the tap read
+ * from the same thread that fed it. What a case asserts is that the reading and
+ * the take agree, which is the whole point of the tap being written by the
+ * block that recorded the material.
+ */
+
+using magda::engine::AudioFileFormat;
+using magda::engine::kAnyLiveMidiSource;
+using magda::engine::LiveInputBlock;
+using magda::engine::LiveInputFeed;
+using magda::engine::LiveMidiStream;
+using magda::engine::LoopRange;
+using magda::engine::MidiTakeRecorder;
+using magda::engine::MidiTakeRecorderSettings;
+using magda::engine::RecordedMidiTake;
+using magda::engine::RecordMaterial;
+using magda::engine::RecordTap;
+using magda::engine::RecordTapSettings;
+using magda::engine::RecordTarget;
+using magda::engine::RenderContext;
+using magda::engine::TakeRecorder;
+using magda::engine::TakeRecorderSettings;
+using magda::engine::TempoMap;
+using magda::engine::TransportClock;
+using magda::engine::TransportSnapshot;
+
+namespace {
+
+constexpr double kSampleRate = 8000.0;
+
+/// A beat at 120 bpm and this rate: every position here is a whole number of
+/// samples.
+constexpr int kBeatSamples = 4000;
+
+Catch::Approx beats(double value) {
+    return Catch::Approx(value).margin(1e-9);
+}
+
+TempoMap flat() {
+    return TempoMap({{0.0, 120.0, 0.0f}}, {{0.0, 4, 4}});
+}
+
+/// 120 bpm to beat 2, then 60 bpm. Two changes on one beat is a step.
+TempoMap halvedAtBeatTwo() {
+    return TempoMap({{0.0, 120.0, 0.0f}, {2.0, 120.0, 0.0f}, {2.0, 60.0, 0.0f}}, {{0.0, 4, 4}});
+}
+
+RecordTapSettings drawn(std::size_t maxNotes = 64, std::size_t maxPeaks = 0,
+                        int samplesPerPeak = 500) {
+    RecordTapSettings settings;
+    settings.maxNotes = maxNotes;
+    settings.maxPeaks = maxPeaks;
+    settings.samplesPerPeak = samplesPerPeak;
+    return settings;
+}
+
+/// One event, named by the arrival it was played on.
+struct Played {
+    std::int64_t arrival = 0;
+    juce::MidiMessage message;
+};
+
+Played noteOn(std::int64_t arrival, int note, int velocity = 100, int channel = 1) {
+    return {arrival, juce::MidiMessage::noteOn(channel, note, static_cast<juce::uint8>(velocity))};
+}
+
+Played noteOff(std::int64_t arrival, int note, int channel = 1) {
+    return {arrival, juce::MidiMessage::noteOff(channel, note)};
+}
+
+/** @brief A transport, a scheduled MIDI input and one take, a callback at a time. */
+class MidiRig {
+  public:
+    explicit MidiRig(MidiTakeRecorderSettings settings, TempoMap tempo = flat(), int blockSize = 64)
+        : blockSize_(blockSize) {
+        transport_.tempo = std::move(tempo);
+        feed_.prepare(0, blockSize_);
+        recorder_ = std::make_unique<MidiTakeRecorder>(feed_, std::move(settings));
+    }
+
+    void schedule(std::vector<Played> events) {
+        schedule_ = std::move(events);
+    }
+
+    void play(double fromBeat = 0.0, double countInBeats = 0.0) {
+        ++transport_.request.generation;
+        transport_.request.playing = true;
+        transport_.request.locate = true;
+        transport_.request.positionBeat = fromBeat;
+        transport_.request.countInBeats = countInBeats;
+    }
+
+    void loop(double startBeat, double endBeat) {
+        transport_.loop = LoopRange{true, startBeat, endBeat};
+    }
+
+    void run(int numSamples) {
+        for (auto left = numSamples; left > 0;) {
+            const auto callback = std::min(blockSize_, left);
+            deliver(callback);
+            left -= callback;
+        }
+    }
+
+    MidiTakeRecorder& recorder() {
+        return *recorder_;
+    }
+
+    RecordTap::Reading reading() const {
+        return recorder_->tap().read();
+    }
+
+    RecordedMidiTake finish() {
+        return recorder_->finish(transport_.tempo);
+    }
+
+  private:
+    void deliver(int numSamples) {
+        juce::MidiBuffer arriving;
+        for (const auto& event : schedule_)
+            if (event.arrival >= arrival_ && event.arrival < arrival_ + numSamples)
+                arriving.addEvent(event.message, static_cast<int>(event.arrival - arrival_));
+
+        const std::array streams{LiveMidiStream{0, &arriving}};
+        feed_.beginCallback(LiveInputBlock{{}, streams}, numSamples);
+
+        for (const auto& segment : clock_.advance(transport_, kSampleRate, numSamples)) {
+            feed_.beginSegment(segment.startSample, segment.block.numSamples);
+            recorder_->capture(segment.block, segment.countingIn, transport_.loop);
+        }
+
+        feed_.endCallback();
+        arrival_ += numSamples;
+    }
+
+    TransportSnapshot transport_;
+    TransportClock clock_;
+    LiveInputFeed feed_;
+    std::unique_ptr<MidiTakeRecorder> recorder_;
+
+    std::vector<Played> schedule_;
+    std::int64_t arrival_ = 0;
+    int blockSize_ = 64;
+};
+
+/// What arrival @p sample of @p channel carries, as the audio take's own cases
+/// number it: rising, so a window's peak is its last sample.
+float material(std::int64_t sample, int channel) {
+    return static_cast<float>(sample + 1 + (static_cast<std::int64_t>(channel) * 50000)) * 1.0e-5f;
+}
+
+juce::File emptyDirectory(const juce::String& name) {
+    auto directory = juce::File::getSpecialLocation(juce::File::tempDirectory)
+                         .getChildFile("magda_record_tap_test")
+                         .getChildFile(name);
+    directory.deleteRecursively();
+    directory.createDirectory();
+    return directory;
+}
+
+/** @brief A transport, a synthetic audio input and one take. */
+class AudioRig {
+  public:
+    AudioRig(const juce::File& directory, RecordTapSettings tap, int blockSize = 64)
+        : input_(2, blockSize), blockSize_(blockSize) {
+        transport_.tempo = flat();
+        feed_.prepare(2, blockSize_);
+
+        TakeRecorderSettings settings;
+        settings.channels = {0, 1};
+        settings.directory = directory;
+        settings.file.format = AudioFileFormat::wav;
+        settings.file.bitDepth = 32;
+        settings.tap = std::move(tap);
+
+        recorder_ = std::make_unique<TakeRecorder>(feed_, RenderContext{kSampleRate, blockSize_, 2},
+                                                   std::move(settings));
+    }
+
+    void play(double fromBeat = 0.0) {
+        ++transport_.request.generation;
+        transport_.request.playing = true;
+        transport_.request.locate = true;
+        transport_.request.positionBeat = fromBeat;
+    }
+
+    void loop(double startBeat, double endBeat) {
+        transport_.loop = LoopRange{true, startBeat, endBeat};
+    }
+
+    void run(int numSamples) {
+        for (auto left = numSamples; left > 0;) {
+            const auto callback = std::min(blockSize_, left);
+            deliver(callback);
+            left -= callback;
+        }
+    }
+
+    TakeRecorder& recorder() {
+        return *recorder_;
+    }
+
+    RecordTap::Reading reading() const {
+        return recorder_->tap().read();
+    }
+
+  private:
+    void deliver(int numSamples) {
+        for (auto channel = 0; channel < input_.getNumChannels(); ++channel)
+            for (auto at = 0; at < numSamples; ++at)
+                input_.setSample(channel, at, material(arrival_ + at, channel));
+
+        const LiveInputBlock block{juce::dsp::AudioBlock<const float>(input_).getSubBlock(
+                                       0, static_cast<std::size_t>(numSamples)),
+                                   {}};
+
+        feed_.beginCallback(block, numSamples);
+
+        for (const auto& segment : clock_.advance(transport_, kSampleRate, numSamples)) {
+            feed_.beginSegment(segment.startSample, segment.block.numSamples);
+            recorder_->capture(segment.block, segment.countingIn, transport_.loop);
+        }
+
+        feed_.endCallback();
+        arrival_ += numSamples;
+    }
+
+    TransportSnapshot transport_;
+    TransportClock clock_;
+    LiveInputFeed feed_;
+    juce::AudioBuffer<float> input_;
+    std::unique_ptr<TakeRecorder> recorder_;
+
+    std::int64_t arrival_ = 0;
+    int blockSize_ = 64;
+};
+
+}  // namespace
+
+// --- the tap on its own ---
+
+TEST_CASE("A tap nothing has opened reports no pass", "[engine][tap][record][2463]") {
+    const RecordTap tap(RecordMaterial::midi, drawn());
+
+    const auto reading = tap.read();
+    CHECK_FALSE(reading.recording);
+    CHECK(reading.pass == 0);
+    CHECK(reading.lengthBeats == 0.0);
+    CHECK(reading.notes.empty());
+}
+
+TEST_CASE("A held note reaches the end of the pass and stops where it came up",
+          "[engine][tap][record][2463]") {
+    RecordTap tap(RecordMaterial::midi, drawn());
+    tap.open(8.0);
+    tap.noteOn(1, 60, 100, 0.5);
+    tap.extend(1.0);
+
+    SECTION("still down, it is as long as the pass") {
+        tap.extend(2.5);
+
+        const auto reading = tap.read();
+        REQUIRE(reading.notes.size() == 1);
+        CHECK(reading.notes[0].startBeat == beats(0.5));
+        CHECK(reading.notes[0].lengthBeats == beats(2.0));
+        CHECK(reading.lengthBeats == beats(2.5));
+    }
+
+    SECTION("once it comes up, the pass grows past it") {
+        tap.noteOff(1, 60, 1.5);
+        tap.extend(2.5);
+
+        const auto reading = tap.read();
+        REQUIRE(reading.notes.size() == 1);
+        CHECK(reading.notes[0].lengthBeats == beats(1.0));
+    }
+}
+
+TEST_CASE("A pass takes the last one's notes with it", "[engine][tap][record][2463]") {
+    RecordTap tap(RecordMaterial::midi, drawn());
+    tap.open(0.0);
+    tap.noteOn(1, 60, 100, 0.5);
+    tap.noteOff(1, 60, 1.0);
+    tap.extend(4.0);
+
+    tap.open(4.0);
+    tap.noteOn(1, 67, 100, 0.25);
+    tap.extend(1.0);
+
+    const auto reading = tap.read();
+    CHECK(reading.pass == 2);
+    CHECK(reading.startBeat == beats(4.0));
+    REQUIRE(reading.notes.size() == 1);
+    CHECK(reading.notes[0].noteNumber == 67);
+}
+
+TEST_CASE("A note the pass has no room for is counted", "[engine][tap][record][2463]") {
+    RecordTap tap(RecordMaterial::midi, drawn(2));
+    tap.open(0.0);
+
+    for (auto note = 0; note < 5; ++note)
+        tap.noteOn(1, 60 + note, 100, static_cast<double>(note));
+
+    const auto reading = tap.read();
+    CHECK(reading.notes.size() == 2);
+    CHECK(reading.notesLost == 3);
+}
+
+TEST_CASE("A closed pass keeps what it reached", "[engine][tap][record][2463]") {
+    RecordTap tap(RecordMaterial::audio, drawn());
+    tap.open(2.0);
+    tap.extend(1.5);
+    tap.close();
+
+    const auto reading = tap.read();
+    CHECK_FALSE(reading.recording);
+    CHECK(reading.startBeat == beats(2.0));
+    CHECK(reading.lengthBeats == beats(1.5));
+}
+
+TEST_CASE("A reading is one pass's own, never two", "[engine][tap][record][2463]") {
+    RecordTap tap(RecordMaterial::midi, drawn());
+    std::atomic<bool> writing{true};
+
+    // Each pass is named twice over: by where it starts and by the note it
+    // holds. A reading that paired one pass's start with another's notes would
+    // disagree with itself.
+    std::thread writer([&] {
+        for (auto pass = 0; pass < 2000; ++pass) {
+            tap.open(static_cast<double>(pass) * 4.0);
+            for (auto note = 0; note < 8; ++note) {
+                tap.noteOn(1, 60 + (pass % 12), 100, static_cast<double>(note) * 0.5);
+                tap.extend(static_cast<double>(note + 1) * 0.5);
+            }
+        }
+        writing.store(false);
+    });
+
+    auto readings = 0;
+    while (writing.load()) {
+        const auto reading = tap.read();
+        if (reading.pass == 0)
+            continue;
+
+        const auto pass = static_cast<int>(reading.pass) - 1;
+        REQUIRE(reading.startBeat == beats(static_cast<double>(pass) * 4.0));
+
+        for (const auto& note : reading.notes)
+            REQUIRE(note.noteNumber == 60 + (pass % 12));
+
+        ++readings;
+    }
+
+    writer.join();
+    CHECK(readings > 0);
+}
+
+// --- the pass a MIDI take is recording ---
+
+TEST_CASE("A note is drawn at the beat the finished clip holds it at",
+          "[engine][io][record][midi][2463]") {
+    const auto tempo = GENERATE_COPY(flat(), halvedAtBeatTwo());
+
+    MidiTakeRecorderSettings settings;
+    settings.tap = drawn();
+
+    MidiRig rig(settings, tempo);
+    rig.schedule({noteOn(kBeatSamples, 64), noteOff(3 * kBeatSamples, 64)});
+    rig.play();
+    rig.run(4 * kBeatSamples);
+
+    const auto preview = rig.reading();
+    const auto take = rig.finish();
+
+    REQUIRE(preview.notes.size() == 1);
+    REQUIRE(take.active.notes.size() == 1);
+    CHECK(preview.notes[0].startBeat == beats(take.active.notes[0].startBeat));
+    CHECK(preview.notes[0].lengthBeats == beats(take.active.notes[0].lengthBeats));
+    CHECK(preview.notes[0].noteNumber == take.active.notes[0].noteNumber);
+    CHECK(preview.startBeat == beats(take.startBeat));
+}
+
+TEST_CASE("A pass reports the length it captured, whatever the block size",
+          "[engine][io][record][midi][2463]") {
+    const auto blockSize = GENERATE(16, 64, 100);
+
+    MidiTakeRecorderSettings settings;
+    settings.tap = drawn();
+
+    MidiRig rig(settings, flat(), blockSize);
+    rig.play();
+    rig.run(6 * kBeatSamples);
+
+    const auto reading = rig.reading();
+    CHECK(reading.recording);
+    CHECK(reading.pass == 1);
+    CHECK(reading.lengthBeats == beats(6.0));
+}
+
+TEST_CASE("An armed track with a stopped transport reports nothing",
+          "[engine][io][record][midi][2463]") {
+    MidiTakeRecorderSettings settings;
+    settings.tap = drawn();
+
+    SECTION("never played") {
+        MidiRig rig(settings);
+        rig.run(2 * kBeatSamples);
+
+        const auto reading = rig.reading();
+        CHECK_FALSE(reading.recording);
+        CHECK(reading.pass == 0);
+        CHECK(reading.lengthBeats == 0.0);
+    }
+
+    SECTION("counting in") {
+        MidiRig rig(settings);
+        rig.play(0.0, 2.0);
+        rig.run(2 * kBeatSamples);
+
+        const auto reading = rig.reading();
+        CHECK_FALSE(reading.recording);
+        CHECK(reading.pass == 0);
+    }
+}
+
+TEST_CASE("A loop wrap draws the pass it opened, not the one it ended",
+          "[engine][io][record][midi][2463]") {
+    MidiTakeRecorderSettings settings;
+    settings.tap = drawn();
+
+    MidiRig rig(settings);
+    rig.loop(0.0, 2.0);
+    rig.schedule({noteOn(kBeatSamples / 2, 60), noteOff(kBeatSamples, 60),
+                  noteOn(2 * kBeatSamples + kBeatSamples / 2, 72), noteOff(3 * kBeatSamples, 72)});
+    rig.play();
+    rig.run(3 * kBeatSamples + (kBeatSamples / 2));
+
+    const auto reading = rig.reading();
+    CHECK(reading.pass == 2);
+    CHECK(reading.startBeat == beats(0.0));
+    REQUIRE(reading.notes.size() == 1);
+    CHECK(reading.notes[0].noteNumber == 72);
+    CHECK(reading.notes[0].startBeat == beats(0.5));
+}
+
+TEST_CASE("A take says which target it is recording into", "[engine][io][record][midi][2463]") {
+    MidiTakeRecorderSettings settings;
+    settings.tap = drawn();
+    settings.tap.target = RecordTarget::slot;
+    settings.tap.scene = 3;
+
+    MidiRig rig(settings);
+    rig.play();
+    rig.run(kBeatSamples);
+
+    const auto reading = rig.reading();
+    CHECK(reading.target == RecordTarget::slot);
+    CHECK(reading.scene == 3);
+    CHECK(reading.material == RecordMaterial::midi);
+}
+
+TEST_CASE("A take nobody draws publishes the pass and nothing else",
+          "[engine][io][record][midi][2463]") {
+    MidiRig rig(MidiTakeRecorderSettings{});
+    rig.schedule({noteOn(kBeatSamples, 60)});
+    rig.play();
+    rig.run(2 * kBeatSamples);
+
+    const auto reading = rig.reading();
+    CHECK(reading.recording);
+    CHECK(reading.lengthBeats == beats(2.0));
+    CHECK(reading.notes.empty());
+
+    // Nothing was asked for, so nothing was lost.
+    CHECK(reading.notesLost == 0);
+    CHECK(reading.peaksLost == 0);
+}
+
+// --- the pass an audio take is recording ---
+
+TEST_CASE("A pass's peaks are the samples the take wrote", "[engine][io][record][2463]") {
+    AudioRig rig(emptyDirectory("peaks"), drawn(0, 32, 500));
+    rig.play();
+    rig.run(2000);
+
+    const auto reading = rig.reading();
+    CHECK(reading.material == RecordMaterial::audio);
+    REQUIRE(reading.peaks.size() == 4);
+
+    // Rising material, so a window's peak is its last sample.
+    for (std::size_t at = 0; at < reading.peaks.size(); ++at) {
+        const auto last = static_cast<std::int64_t>((at + 1) * 500) - 1;
+        CHECK(reading.peaks[at].left == Catch::Approx(material(last, 0)));
+        CHECK(reading.peaks[at].right == Catch::Approx(material(last, 1)));
+    }
+}
+
+TEST_CASE("An audio pass reports the length it wrote, whatever the block size",
+          "[engine][io][record][2463]") {
+    const auto blockSize = GENERATE(16, 64, 100);
+
+    AudioRig rig(emptyDirectory("length"), drawn(0, 64, 500), blockSize);
+    rig.play();
+    rig.run(5 * kBeatSamples);
+
+    const auto reading = rig.reading();
+    const auto written = static_cast<double>(rig.recorder().capturedSamples());
+    CHECK(reading.lengthBeats == beats(written / kBeatSamples));
+    CHECK(reading.lengthBeats == beats(5.0));
+}
+
+TEST_CASE("Peaks a pass has no room for are counted", "[engine][io][record][2463]") {
+    AudioRig rig(emptyDirectory("peaks_lost"), drawn(0, 2, 500));
+    rig.play();
+    rig.run(2000);
+
+    const auto reading = rig.reading();
+    CHECK(reading.peaks.size() == 2);
+    CHECK(reading.peaksLost == 2);
+}
+
+TEST_CASE("A wrap starts the audio pass's peaks again", "[engine][io][record][2463]") {
+    AudioRig rig(emptyDirectory("wrap"), drawn(0, 64, 500));
+    rig.loop(0.0, 1.0);
+    rig.play();
+    rig.run(kBeatSamples + 1000);
+
+    const auto reading = rig.reading();
+    CHECK(reading.pass == 2);
+    CHECK(reading.startBeat == beats(0.0));
+    CHECK(reading.lengthBeats == beats(0.25));
+    REQUIRE(reading.peaks.size() == 2);
+
+    // The second pass's first peak is the material that arrived after the wrap,
+    // not the first pass's.
+    CHECK(reading.peaks[0].left == Catch::Approx(material(kBeatSamples + 499, 0)));
+}

--- a/tests/engine/test_record_tap.cpp
+++ b/tests/engine/test_record_tap.cpp
@@ -15,6 +15,7 @@
 #include "exec/RenderContext.hpp"
 #include "io/LiveInput.hpp"
 #include "io/MidiTakeRecorder.hpp"
+#include "io/TakeNotes.hpp"
 #include "io/TakeRecorder.hpp"
 #include "tap/RecordTap.hpp"
 #include "transport/TempoMap.hpp"
@@ -39,6 +40,7 @@ using magda::engine::LiveMidiStream;
 using magda::engine::LoopRange;
 using magda::engine::MidiTakeRecorder;
 using magda::engine::MidiTakeRecorderSettings;
+using magda::engine::PreviewNotes;
 using magda::engine::RecordedMidiTake;
 using magda::engine::RecordMaterial;
 using magda::engine::RecordTap;
@@ -281,12 +283,13 @@ TEST_CASE("A tap nothing has opened reports no pass", "[engine][tap][record][246
 TEST_CASE("A held note reaches the end of the pass and stops where it came up",
           "[engine][tap][record][2463]") {
     RecordTap tap(RecordMaterial::midi, drawn());
-    tap.open(8.0);
-    tap.noteOn(1, 60, 100, 0.5);
-    tap.extend(1.0);
+    PreviewNotes played(tap);
+    played.open(8.0);
+    played.strike(1, 60, 100, 0.5);
+    played.reaches(1.0);
 
     SECTION("still down, it is as long as the pass") {
-        tap.extend(2.5);
+        played.reaches(2.5);
 
         const auto reading = tap.read();
         REQUIRE(reading.notes.size() == 1);
@@ -296,8 +299,8 @@ TEST_CASE("A held note reaches the end of the pass and stops where it came up",
     }
 
     SECTION("once it comes up, the pass grows past it") {
-        tap.noteOff(1, 60, 1.5);
-        tap.extend(2.5);
+        played.release(1, 60, 1.5);
+        played.reaches(2.5);
 
         const auto reading = tap.read();
         REQUIRE(reading.notes.size() == 1);
@@ -307,14 +310,15 @@ TEST_CASE("A held note reaches the end of the pass and stops where it came up",
 
 TEST_CASE("A pass takes the last one's notes with it", "[engine][tap][record][2463]") {
     RecordTap tap(RecordMaterial::midi, drawn());
-    tap.open(0.0);
-    tap.noteOn(1, 60, 100, 0.5);
-    tap.noteOff(1, 60, 1.0);
-    tap.extend(4.0);
+    PreviewNotes played(tap);
+    played.open(0.0);
+    played.strike(1, 60, 100, 0.5);
+    played.release(1, 60, 1.0);
+    played.reaches(4.0);
 
-    tap.open(4.0);
-    tap.noteOn(1, 67, 100, 0.25);
-    tap.extend(1.0);
+    played.open(4.0);
+    played.strike(1, 67, 100, 0.25);
+    played.reaches(1.0);
 
     const auto reading = tap.read();
     CHECK(reading.pass == 2);
@@ -325,10 +329,11 @@ TEST_CASE("A pass takes the last one's notes with it", "[engine][tap][record][24
 
 TEST_CASE("A note the pass has no room for is counted", "[engine][tap][record][2463]") {
     RecordTap tap(RecordMaterial::midi, drawn(2));
-    tap.open(0.0);
+    PreviewNotes played(tap);
+    played.open(0.0);
 
     for (auto note = 0; note < 5; ++note)
-        tap.noteOn(1, 60 + note, 100, static_cast<double>(note));
+        played.strike(1, 60 + note, 100, static_cast<double>(note));
 
     const auto reading = tap.read();
     CHECK(reading.notes.size() == 2);
@@ -337,8 +342,9 @@ TEST_CASE("A note the pass has no room for is counted", "[engine][tap][record][2
 
 TEST_CASE("A closed pass keeps what it reached", "[engine][tap][record][2463]") {
     RecordTap tap(RecordMaterial::audio, drawn());
-    tap.open(2.0);
-    tap.extend(1.5);
+    PreviewNotes played(tap);
+    played.open(2.0);
+    played.reaches(1.5);
     tap.close();
 
     const auto reading = tap.read();
@@ -349,6 +355,7 @@ TEST_CASE("A closed pass keeps what it reached", "[engine][tap][record][2463]") 
 
 TEST_CASE("A reading is one pass's own, never two", "[engine][tap][record][2463]") {
     RecordTap tap(RecordMaterial::midi, drawn());
+    PreviewNotes played(tap);
     std::atomic<bool> writing{true};
 
     // Every pass is named three times over: by where it starts, by the pitch it
@@ -358,23 +365,33 @@ TEST_CASE("A reading is one pass's own, never two", "[engine][tap][record][2463]
     constexpr double kPassSpan = 1000.0;
 
     std::thread writer([&] {
-        for (auto pass = 0; pass < 2000; ++pass) {
+        for (auto pass = 0; pass < 200000; ++pass) {
             const auto origin = static_cast<double>(pass) * kPassSpan;
-            tap.open(origin);
+
+            played.open(origin);
 
             for (auto note = 0; note < 8; ++note) {
                 const auto at = origin + static_cast<double>(note);
-                tap.noteOn(1, 60 + (pass % 12), 100, at);
-                tap.extend(at + 0.75);
-                tap.noteOff(1, 60 + (pass % 12), at + 0.25);
+                played.strike(1, 60 + (pass % 12), 100, at);
+                played.release(1, 60 + (pass % 12), at + 0.25);
             }
+
+            played.reaches(origin + 8.0);
+            std::this_thread::yield();
         }
+
         writing.store(false);
     });
 
-    auto readings = 0;
+    auto settled = 0;
+    auto checked = 0;
+    RecordTap::Reading reading;
+
     while (writing.load()) {
-        const auto reading = tap.read();
+        if (!tap.read(reading))
+            continue;
+
+        ++settled;
         if (reading.pass == 0)
             continue;
 
@@ -386,72 +403,85 @@ TEST_CASE("A reading is one pass's own, never two", "[engine][tap][record][2463]
             REQUIRE(note.noteNumber == 60 + (pass % 12));
             REQUIRE(note.startBeat >= origin);
             REQUIRE(note.startBeat < origin + 8.0);
-
-            // Held until the block that closed it, and never longer.
-            REQUIRE(note.lengthBeats <= beats(0.75));
+            REQUIRE(note.lengthBeats <= beats(0.25));
+            ++checked;
         }
-
-        ++readings;
     }
 
     writer.join();
-    CHECK(readings > 0);
+    CHECK(settled > 0);
+    CHECK(checked > 0);
 }
 
 TEST_CASE("A note is read as one note, not two halves of a slot", "[engine][tap][record][2463]") {
     RecordTap tap(RecordMaterial::midi, drawn());
-    tap.open(0.0);
+    PreviewNotes played(tap);
+    played.open(0.0);
 
-    // The tightest race the tap has: a pitch struck again rewrites the slot it
-    // is already in, so a reader can take the identity of one strike and the
-    // position of the next. The velocity says which strike a note is and its
-    // beat says the same thing, so the two disagreeing is the tear.
+    // A slot rewritten in place, one strike at a time rather than batched, so
+    // what is under test is the guard on the call itself. The velocity says
+    // which strike a note is and its beat says the same thing, so the two
+    // disagreeing is the tear.
     std::atomic<bool> writing{true};
 
     std::thread writer([&] {
-        for (auto strike = 0; strike < 4000000; ++strike) {
+        for (auto strike = 0; strike < 400000; ++strike) {
             const auto velocity = 1 + (strike % 126);
-            tap.noteOn(1, 60, velocity, static_cast<double>(velocity));
+
+            played.strike(1, 60, velocity, static_cast<double>(velocity));
+            std::this_thread::yield();
         }
+
         writing.store(false);
     });
 
-    auto readings = 0;
-    while (writing.load()) {
-        const auto reading = tap.read();
-        for (const auto& note : reading.notes)
-            REQUIRE(note.startBeat == beats(static_cast<double>(note.velocity)));
+    auto checked = 0;
+    RecordTap::Reading reading;
 
-        ++readings;
+    while (writing.load()) {
+        if (!tap.read(reading))
+            continue;
+
+        for (const auto& note : reading.notes) {
+            REQUIRE(note.startBeat == beats(static_cast<double>(note.velocity)));
+            ++checked;
+        }
     }
 
     writer.join();
-    CHECK(readings > 0);
+    CHECK(checked > 0);
 }
 
 TEST_CASE("A retrigger that restores the same note is still a replacement",
           "[engine][tap][record][2463]") {
     RecordTap tap(RecordMaterial::midi, drawn());
-    tap.open(0.0);
+    PreviewNotes played(tap);
+    played.open(0.0);
 
     // One pitch at one velocity, struck over and over without coming up. Every
     // strike packs the identity the last one did, so nothing about the note
-    // itself tells two of them apart and only a count can. The length says
-    // which strike a beat came from.
+    // itself tells two of them apart. The length says which strike a beat came
+    // from.
     std::atomic<bool> writing{true};
 
     std::thread writer([&] {
-        for (auto strike = 0; strike < 4000000; ++strike) {
+        for (auto strike = 0; strike < 400000; ++strike) {
             const auto at = static_cast<double>(strike);
-            tap.noteOn(1, 60, 100, at);
-            tap.extend(at + 1.0 + static_cast<double>(strike % 7));
+
+            played.strike(1, 60, 100, at);
+            played.reaches(at + 1.0 + static_cast<double>(strike % 7));
+            std::this_thread::yield();
         }
+
         writing.store(false);
     });
 
-    auto readings = 0;
+    auto checked = 0;
+    RecordTap::Reading reading;
+
     while (writing.load()) {
-        const auto reading = tap.read();
+        if (!tap.read(reading))
+            continue;
 
         for (const auto& note : reading.notes) {
             // Zero is the strike itself, before the pass has extended it.
@@ -460,13 +490,60 @@ TEST_CASE("A retrigger that restores the same note is still a replacement",
 
             REQUIRE(note.lengthBeats ==
                     beats(1.0 + static_cast<double>(std::llround(note.startBeat) % 7)));
+            ++checked;
         }
-
-        ++readings;
     }
 
     writer.join();
-    CHECK(readings > 0);
+    CHECK(checked > 0);
+}
+
+TEST_CASE("A read that cannot settle leaves the reader what it had",
+          "[engine][tap][record][2463]") {
+    RecordTap tap(RecordMaterial::midi, drawn());
+    PreviewNotes played(tap);
+
+    played.open(4.0);
+    played.strike(1, 60, 100, 0.5);
+    played.reaches(1.0);
+
+    RecordTap::Reading reading;
+    REQUIRE(tap.read(reading));
+    REQUIRE(reading.notes.size() == 1);
+
+    // A block still being taken. Nothing settles while one is open, and what
+    // the reader already had is a better answer than half of two passes.
+    const RecordTap::Change change(tap);
+    played.open(8.0);
+
+    CHECK_FALSE(tap.read(reading));
+    CHECK(reading.startBeat == beats(4.0));
+    REQUIRE(reading.notes.size() == 1);
+    CHECK(reading.notes[0].noteNumber == 60);
+}
+
+TEST_CASE("A block's events reach a reader together", "[engine][tap][record][2463]") {
+    RecordTap tap(RecordMaterial::midi, drawn());
+    PreviewNotes played(tap);
+    played.open(0.0);
+
+    RecordTap::Reading reading;
+    REQUIRE(tap.read(reading));
+    REQUIRE(reading.notes.empty());
+
+    {
+        const RecordTap::Change change(tap);
+        played.strike(1, 60, 100, 0.0);
+
+        // Halfway through the block, and not readable as such.
+        CHECK_FALSE(tap.read(reading));
+        CHECK(reading.notes.empty());
+
+        played.strike(1, 64, 100, 0.25);
+    }
+
+    REQUIRE(tap.read(reading));
+    CHECK(reading.notes.size() == 2);
 }
 
 // --- the pass a MIDI take is recording ---

--- a/tests/engine/test_record_tap.cpp
+++ b/tests/engine/test_record_tap.cpp
@@ -187,13 +187,15 @@ juce::File emptyDirectory(const juce::String& name) {
 /** @brief A transport, a synthetic audio input and one take. */
 class AudioRig {
   public:
-    AudioRig(const juce::File& directory, RecordTapSettings tap, int blockSize = 64)
+    AudioRig(const juce::File& directory, RecordTapSettings tap, int blockSize = 64,
+             int latencySamples = 0)
         : input_(2, blockSize), blockSize_(blockSize) {
         transport_.tempo = flat();
         feed_.prepare(2, blockSize_);
 
         TakeRecorderSettings settings;
         settings.channels = {0, 1};
+        settings.latencySamples = latencySamples;
         settings.directory = directory;
         settings.file.format = AudioFileFormat::wav;
         settings.file.bitDepth = 32;
@@ -348,15 +350,22 @@ TEST_CASE("A reading is one pass's own, never two", "[engine][tap][record][2463]
     RecordTap tap(RecordMaterial::midi, drawn());
     std::atomic<bool> writing{true};
 
-    // Each pass is named twice over: by where it starts and by the note it
-    // holds. A reading that paired one pass's start with another's notes would
-    // disagree with itself.
+    // Every pass is named three times over: by where it starts, by the pitch it
+    // holds and by the beat every one of its notes sits on. A reading that
+    // paired one pass's identity with another's coordinates would disagree with
+    // itself on at least one of them.
+    constexpr double kPassSpan = 1000.0;
+
     std::thread writer([&] {
         for (auto pass = 0; pass < 2000; ++pass) {
-            tap.open(static_cast<double>(pass) * 4.0);
+            const auto origin = static_cast<double>(pass) * kPassSpan;
+            tap.open(origin);
+
             for (auto note = 0; note < 8; ++note) {
-                tap.noteOn(1, 60 + (pass % 12), 100, static_cast<double>(note) * 0.5);
-                tap.extend(static_cast<double>(note + 1) * 0.5);
+                const auto at = origin + static_cast<double>(note);
+                tap.noteOn(1, 60 + (pass % 12), 100, at);
+                tap.extend(at + 0.75);
+                tap.noteOff(1, 60 + (pass % 12), at + 0.25);
             }
         }
         writing.store(false);
@@ -369,10 +378,48 @@ TEST_CASE("A reading is one pass's own, never two", "[engine][tap][record][2463]
             continue;
 
         const auto pass = static_cast<int>(reading.pass) - 1;
-        REQUIRE(reading.startBeat == beats(static_cast<double>(pass) * 4.0));
+        const auto origin = static_cast<double>(pass) * kPassSpan;
+        REQUIRE(reading.startBeat == beats(origin));
 
-        for (const auto& note : reading.notes)
+        for (const auto& note : reading.notes) {
             REQUIRE(note.noteNumber == 60 + (pass % 12));
+            REQUIRE(note.startBeat >= origin);
+            REQUIRE(note.startBeat < origin + 8.0);
+
+            // Held until the block that closed it, and never longer.
+            REQUIRE(note.lengthBeats <= beats(0.75));
+        }
+
+        ++readings;
+    }
+
+    writer.join();
+    CHECK(readings > 0);
+}
+
+TEST_CASE("A note is read as one note, not two halves of a slot", "[engine][tap][record][2463]") {
+    RecordTap tap(RecordMaterial::midi, drawn());
+    tap.open(0.0);
+
+    // The tightest race the tap has: a pitch struck again rewrites the slot it
+    // is already in, so a reader can take the identity of one strike and the
+    // position of the next. The velocity says which strike a note is and its
+    // beat says the same thing, so the two disagreeing is the tear.
+    std::atomic<bool> writing{true};
+
+    std::thread writer([&] {
+        for (auto strike = 0; strike < 4000000; ++strike) {
+            const auto velocity = 1 + (strike % 126);
+            tap.noteOn(1, 60, velocity, static_cast<double>(velocity));
+        }
+        writing.store(false);
+    });
+
+    auto readings = 0;
+    while (writing.load()) {
+        const auto reading = tap.read();
+        for (const auto& note : reading.notes)
+            REQUIRE(note.startBeat == beats(static_cast<double>(note.velocity)));
 
         ++readings;
     }
@@ -560,4 +607,59 @@ TEST_CASE("A wrap starts the audio pass's peaks again", "[engine][io][record][24
     // The second pass's first peak is the material that arrived after the wrap,
     // not the first pass's.
     CHECK(reading.peaks[0].left == Catch::Approx(material(kBeatSamples + 499, 0)));
+}
+
+TEST_CASE("A pitch struck twice replaces the note that was already down",
+          "[engine][io][record][midi][2463]") {
+    MidiTakeRecorderSettings settings;
+    settings.tap = drawn();
+
+    MidiRig rig(settings);
+    rig.schedule({noteOn(kBeatSamples, 60, 90), noteOn(2 * kBeatSamples, 60, 110),
+                  noteOff(3 * kBeatSamples, 60)});
+    rig.play();
+    rig.run(5 * kBeatSamples);
+
+    const auto preview = rig.reading();
+    const auto take = rig.finish();
+
+    // PassWalk drops the first strike, so the preview holds one note too, and
+    // the pass growing past it does not stretch it.
+    REQUIRE(take.active.notes.size() == 1);
+    REQUIRE(preview.notes.size() == 1);
+    CHECK(preview.notes[0].velocity == 110);
+    CHECK(preview.notes[0].startBeat == beats(take.active.notes[0].startBeat));
+    CHECK(preview.notes[0].lengthBeats == beats(take.active.notes[0].lengthBeats));
+    CHECK(preview.notes[0].lengthBeats == beats(1.0));
+}
+
+TEST_CASE("An audio pass turns over where the file does, not where the wrap is",
+          "[engine][io][record][2463]") {
+    // The boundary the sink took is an arrival, and with a positive latency the
+    // written audio is that far behind it: the samples in between are still the
+    // last pass's file.
+    constexpr int kLatency = 128;
+    constexpr int kPerPeak = 500;
+
+    AudioRig rig(emptyDirectory("latency_wrap"), drawn(0, 64, kPerPeak), 64, kLatency);
+    rig.loop(0.0, 1.0);
+    rig.play();
+
+    SECTION("the pass stands until the audio reaches the boundary") {
+        rig.run(kBeatSamples + 64);
+        CHECK(rig.reading().pass == 1);
+    }
+
+    SECTION("and its first peak is the audio the new file opens with") {
+        rig.run(kBeatSamples + kLatency + 1000);
+
+        const auto reading = rig.reading();
+        CHECK(reading.pass == 2);
+        REQUIRE(reading.peaks.size() == 2);
+
+        // Written sample 4000 is the arrival a latency later, and the peak
+        // covering it runs to the end of its tick.
+        constexpr auto kFirstArrival = kBeatSamples + kLatency;
+        CHECK(reading.peaks[0].left == Catch::Approx(material(kFirstArrival + kPerPeak - 1, 0)));
+    }
 }

--- a/tests/engine/test_take_recorder.cpp
+++ b/tests/engine/test_take_recorder.cpp
@@ -10,6 +10,7 @@
 #include "exec/RenderContext.hpp"
 #include "io/LiveInput.hpp"
 #include "io/TakeRecorder.hpp"
+#include "tap/RecordTap.hpp"
 #include "transport/TempoMap.hpp"
 #include "transport/TransportClock.hpp"
 #include "transport/TransportState.hpp"
@@ -106,7 +107,8 @@ class Rig {
 
         settings.directory = directory;
         recorder_ = std::make_unique<TakeRecorder>(
-            feed_, RenderContext{kSampleRate, kBlockSize, inputChannels}, std::move(settings));
+            feed_, RenderContext{kSampleRate, kBlockSize, inputChannels}, tap_,
+            std::move(settings));
     }
 
     void play(double fromBeat = 0.0, double countInBeats = 0.0) {
@@ -180,6 +182,10 @@ class Rig {
     TransportClock clock_;
     LiveInputFeed feed_;
     juce::AudioBuffer<float> input_;
+
+    /// Nothing here draws the pass; #2463 is where that is covered.
+    magda::engine::RecordTap tap_{magda::engine::RecordMaterial::audio, {}};
+
     std::unique_ptr<TakeRecorder> recorder_;
 
     /// Input samples delivered since the rig was made, which is what the


### PR DESCRIPTION
Slice 5 of #1895, closes #2463. The pass a take is recording, published by the block that recorded it rather than assembled a frame later out of three different clocks.

## What is here

**`tap/RecordTap.hpp`** is the fourth tap, following `LaunchTap`: where the pass started, how much it covers, the notes it has captured and the peaks its audio reached. Both takes own one and hand it out through `TakeCapture`, so a reader asks the take that was published rather than a table kept beside it.

- **The length is the take's own.** For audio, the beat its written samples reach; for MIDI, the beat its last block reached. Nothing counts frames, so what is drawn and what is written cannot come apart.
- **A note is converted the way `finish()` converts it** -- the block's own map, off the pass origin the take will use -- so the beat in the preview is the beat in the finished clip. A held note reaches the pass end and stops where it came up.
- **A wrap opens the next pass on the boundary the take actually took.** A pass end the take could not hold is two passes run together in the preview as well.
- **Peaks come off the samples the take wrote,** at the position it wrote them, rather than from a metering path alongside.
- **Both targets are on one reading.** Arrangement or slot, with the scene; slice 6 (#2464) fills in the slot half.

### The read protocol

This is the part worth naming, because the pass is bigger than a word and `ValueTap`'s one-load answer does not stretch to it.

The scalars a wrap resets together sit behind a sequence the reader retries over, and that window is those stores and nothing else, which is what makes the retry converge.

The notes are not in it: an array is as long as the pass is, and a reader copying one inside a window would be racing the writer over a growing amount of work. Each note carries the pass that recorded it instead, and a reader takes the ones belonging to the pass it is reporting. A wrap during a read therefore costs notes off the end of the list, never a note in the wrong place.

The peaks carry neither and are the one thing here that can be ragged -- a wrap inside a read redraws a few ticks of the last pass's audio, for the frame it takes to ask again. Peaks are presentation and place nothing.

### Input meters

`OpRole::LiveInputMeter` is a `Meter` op between the live input and the track's mix, so the level tap machinery that already exists covers it and the input reaches the track through the thing that measures it. The incumbent reads this off `WaveInputDevice::levelMeasurer`, which had no equivalent behind an input op.

## Verification

`tests/engine/test_record_tap.cpp`, offline throughout: the tap on its own, then both takes driven a callback at a time.

- a pass reports the length it captured, at three block sizes, audio and MIDI
- a note is drawn at the beat the finished clip holds it at, at a fixed tempo and across a tempo change inside the pass
- a held note is as long as the pass until it comes up
- an armed track with a stopped transport, and one counting in, report nothing rather than a pass of no length
- a wrap draws the pass it opened, and starts the peaks again
- a reader running beside the writer never sees one pass's start beside another's notes
- peaks are the samples the take wrote, and what a pass has no room for is counted
- a take nobody draws reports its length and nothing lost

The input meter case is in `test_live_input.cpp`, where the session rig already is: the meter is the input's only consumer, and it reads the level the monitoring track is hearing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X7rCviRzaXVzLAjNKwVCxN
