### PR TITLE
Sweep the last five bugprone checks and make the tier binding

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -124,8 +124,9 @@ Checks: >-
 # copy happens while constructing the closure rather than inside the call
 # operator, which is outside the check's documented scope.
 
-# Warnings as errors - set once the bug-catching tier below is at zero.
-WarningsAsErrors: ''
+# The bug-catching tier is at zero over all 705 magda/ translation units,
+# magda/engine included, so it is binding from here on.
+WarningsAsErrors: 'bugprone-*,cert-*'
 
 # Header filter. Anchored on a leading slash: the old unanchored `tests` matched
 # third_party/JUCE/.../unit_tests/*.h, and it never covered magda/engine at all.
@@ -145,6 +146,17 @@ CheckOptions:
   # already include. The inserter matches on spelling, so only <cmath> dedupes.
   - key: cppcoreguidelines-init-variables.MathHeader
     value: '<cmath>'
+  # 7 of the 19 findings were literal products that fit in int and are folded at
+  # compile time - 64 * 1024, 2 * 1024 * 1024, 24 * 60 * 60. Widening those means
+  # writing std::size_t{64} * 1024 for a constant that cannot overflow, so the
+  # check keeps only the cases where a runtime int product is widened.
+  - key: bugprone-implicit-widening-of-multiplication-result.IgnoreConstantIntExpr
+    value: 'true'
+  # static_cast<void>(p.release()) is how this codebase says the discard is
+  # deliberate, and both sites carry a comment saying the writer took ownership.
+  # The check ignores a void cast only with this set.
+  - key: bugprone-unused-return-value.AllowCastToVoid
+    value: 'true'
   - key: modernize-loop-convert.MaxCopySize
     value: '16'
   - key: modernize-loop-convert.MinConfidence

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,7 +159,15 @@ jobs:
         R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
       run: |
         SCCACHE_VERSION=v0.17.0
-        curl -fsSL "https://github.com/mozilla/sccache/releases/download/${SCCACHE_VERSION}/sccache-${SCCACHE_VERSION}-x86_64-unknown-linux-musl.tar.gz" | tar xz
+        archive="sccache-${SCCACHE_VERSION}-x86_64-unknown-linux-musl.tar.gz"
+        # To a file, then extract. Piped straight into tar, a connection reset
+        # mid-stream hands tar a truncated archive and takes the build down
+        # before it compiles anything, and --retry cannot recall what has
+        # already gone down the pipe.
+        curl -fsSL --retry 3 --retry-all-errors --connect-timeout 30 --max-time 180 \
+          -o "$archive" \
+          "https://github.com/mozilla/sccache/releases/download/${SCCACHE_VERSION}/${archive}"
+        tar xzf "$archive"
         sudo mv sccache-*/sccache /usr/local/bin/sccache
         sccache --version
         # sccache reads R2 through its S3 backend: bucket + custom endpoint,
@@ -1189,7 +1197,7 @@ jobs:
         # Into RUNNER_TEMP, not the checkout: the self-hosted workspace persists.
         $dest = Join-Path $env:RUNNER_TEMP "sccache"
         New-Item -ItemType Directory -Force -Path $dest | Out-Null
-        curl.exe -fsSL "https://github.com/mozilla/sccache/releases/download/$SCCACHE_VERSION/$archive" -o (Join-Path $dest $archive)
+        curl.exe -fsSL --retry 3 --retry-all-errors --connect-timeout 30 --max-time 180 "https://github.com/mozilla/sccache/releases/download/$SCCACHE_VERSION/$archive" -o (Join-Path $dest $archive)
         tar.exe xf (Join-Path $dest $archive) -C $dest
         $sccacheDir = (Get-ChildItem -Path $dest -Directory -Filter "sccache-$SCCACHE_VERSION-*").FullName
         Add-Content -Path $env:GITHUB_PATH -Value $sccacheDir

--- a/.github/workflows/juce-tests-linux.yml
+++ b/.github/workflows/juce-tests-linux.yml
@@ -87,7 +87,13 @@ jobs:
         R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
       run: |
         SCCACHE_VERSION=v0.8.1
-        curl -fsSL "https://github.com/mozilla/sccache/releases/download/${SCCACHE_VERSION}/sccache-${SCCACHE_VERSION}-x86_64-unknown-linux-musl.tar.gz" | tar xz
+        archive="sccache-${SCCACHE_VERSION}-x86_64-unknown-linux-musl.tar.gz"
+        # To a file, then extract. See the same step in ci.yml: piped into tar,
+        # a reset mid-stream is an unrecoverable truncated archive.
+        curl -fsSL --retry 3 --retry-all-errors --connect-timeout 30 --max-time 180 \
+          -o "$archive" \
+          "https://github.com/mozilla/sccache/releases/download/${SCCACHE_VERSION}/${archive}"
+        tar xzf "$archive"
         sudo mv sccache-*/sccache /usr/local/bin/sccache
         sccache --version
         # sccache reads R2 through its S3 backend: bucket + custom endpoint,

--- a/.pre-commit-hooks/clang_tidy.py
+++ b/.pre-commit-hooks/clang_tidy.py
@@ -37,9 +37,9 @@ ROOT = Path.cwd()
 SHIPPING = Path("magda")
 ENGINE = SHIPPING / "engine"
 
-# The bugprone/cert half of .clang-tidy, minus the checks that still report
-# findings. Sweeping those is what unblocks WarningsAsErrors in .clang-tidy;
-# delete one from here as it reaches zero.
+# The bugprone/cert half of .clang-tidy. Every check it enables is at zero over
+# magda/, so this list now matches the config's exactly and .clang-tidy carries
+# the same set in WarningsAsErrors.
 CHECKS = ",".join([
     "-*",
     "bugprone-*",
@@ -57,23 +57,6 @@ CHECKS = ",".join([
     "-bugprone-misplaced-widening-cast",
     "-bugprone-nondeterministic-pointer-iteration-order",
     "-bugprone-macro-parentheses",
-    # Still to sweep: 31, 4 (deliberate pixel roundings), 2, 2 and 1 findings.
-    "-bugprone-implicit-widening-of-multiplication-result",
-    "-bugprone-incorrect-roundings",
-    "-bugprone-unused-return-value",
-    "-bugprone-return-const-ref-from-parameter",
-    "-bugprone-reserved-identifier",
-    # Four the gate had never reached, because the header half joined to nothing
-    # and no C++ push had gone through the hook since it landed. Every masked
-    # index in a lock-free queue is one of the first -- `(at + 1) & (size - 1)`
-    # over ints -- so they fire on ordinary sources too, and left in they would
-    # refuse every push rather than catch anything. Counts are off a 60
-    # translation unit sample rather than a tree sweep: 63, 15, 4, 2 and 1.
-    "-bugprone-signed-bitwise",
-    "-bugprone-throwing-static-initialization",
-    "-bugprone-derived-method-shadowing-base-method",
-    "-bugprone-float-loop-counter",
-    "-bugprone-unchecked-string-to-number-conversion",
 ])
 
 # Sources in the tree but in no compile command, so an absent database entry is

--- a/magda/agents/command_model.cpp
+++ b/magda/agents/command_model.cpp
@@ -6,6 +6,7 @@
 #include <array>
 #include <cctype>
 #include <cmath>
+#include <cstddef>
 #include <cstdio>
 #include <cstdlib>
 #include <stdexcept>
@@ -650,16 +651,16 @@ CommandModel::Prediction CommandModel::predict(const std::string& text) const {
     // Embedding → [E][ML] (channel-major, matching the .transpose(1,2)).
     std::vector<float> e(E * ML, 0.0f);
     for (int t = 0; t < ML; ++t) {
-        const float* row = &d::kEmbedWeight[ids[t] * E];
+        const float* row = &d::kEmbedWeight[static_cast<std::size_t>(ids[t]) * E];
         for (int c = 0; c < E; ++c)
             e[c * ML + t] = row[c];
     }
 
     auto conv = [&](const std::vector<float>& in, int ci, int co, const float* W, const float* B,
                     int dilation) {
-        std::vector<float> out(co * ML, 0.0f);
+        std::vector<float> out(static_cast<std::size_t>(co) * ML, 0.0f);
         for (int oc = 0; oc < co; ++oc) {
-            const float* wOc = &W[oc * ci * 3];
+            const float* wOc = &W[static_cast<std::size_t>(oc) * ci * 3];
             for (int t = 0; t < ML; ++t) {
                 float acc = B[oc];
                 for (int k = 0; k < 3; ++k) {
@@ -686,7 +687,7 @@ CommandModel::Prediction CommandModel::predict(const std::string& text) const {
         float bestVal = 0.0f;
         for (int tag = 0; tag < d::kNumTags; ++tag) {
             float acc = d::kSlotBias[tag];
-            const float* w = &d::kSlotWeight[tag * H];
+            const float* w = &d::kSlotWeight[static_cast<std::size_t>(tag) * H];
             for (int c = 0; c < H; ++c)
                 acc += w[c] * h[c * ML + t];
             if (tag == 0 || acc > bestVal) {
@@ -709,7 +710,7 @@ CommandModel::Prediction CommandModel::predict(const std::string& text) const {
     float bestIntentVal = 0.0f;
     for (int i = 0; i < d::kNumIntents; ++i) {
         float acc = d::kIntentBias[i];
-        const float* w = &d::kIntentWeight[i * H];
+        const float* w = &d::kIntentWeight[static_cast<std::size_t>(i) * H];
         for (int c = 0; c < H; ++c)
             acc += w[c] * pooled[c];
         if (i == 0 || acc > bestIntentVal) {

--- a/magda/agents/llama_model_manager.cpp
+++ b/magda/agents/llama_model_manager.cpp
@@ -2,8 +2,8 @@
 // Apple's libc++ does not ship the std::atomic<std::shared_ptr> replacement, so
 // they remain the only portable option. Silence MSVC's STL4029 deprecation
 // warning; must be defined before any standard header is included.
-// NOLINTNEXTLINE(bugprone-reserved-identifier) - MSVC defines this name; it has to be spelled
-// exactly
+// MSVC defines this name, so it has to be spelled exactly.
+// NOLINTNEXTLINE(bugprone-reserved-identifier)
 #define _SILENCE_CXX20_OLD_SHARED_PTR_ATOMIC_SUPPORT_DEPRECATION_WARNING
 
 #include "llama_model_manager.hpp"

--- a/magda/daw/core/controllers/BindingRegistry.cpp
+++ b/magda/daw/core/controllers/BindingRegistry.cpp
@@ -24,10 +24,10 @@ std::vector<Binding>& scopeVec(BindingScope scope, std::vector<Binding>& global,
     return scope == BindingScope::Global ? global : project;
 }
 
-// NOLINTNEXTLINE(bugprone-return-const-ref-from-parameter) - the only caller
-// passes long-lived members, never a temporary
 const std::vector<Binding>& scopeVecConst(BindingScope scope, const std::vector<Binding>& global,
                                           const std::vector<Binding>& project) {
+    // Callers pass long-lived members, never a temporary.
+    // NOLINTNEXTLINE(bugprone-return-const-ref-from-parameter)
     return scope == BindingScope::Global ? global : project;
 }
 }  // namespace

--- a/magda/daw/engine/TracktionEngineWrapperTransport.cpp
+++ b/magda/daw/engine/TracktionEngineWrapperTransport.cpp
@@ -69,13 +69,18 @@ void TracktionEngineWrapper::play() {
                     ++zeroCount;
             }
             if (zeroCount >= AUDIO_DEVICE_CHECK_THRESHOLD) {
+                // The empty callback is what keeps this asynchronous. Given a null
+                // one, showUnmanaged() takes runSync() wherever modal loops are
+                // permitted, so "Async" runs a modal loop on the message thread --
+                // which in a headless test binary waits forever for an OK nobody
+                // can press.
                 juce::AlertWindow::showMessageBoxAsync(
                     juce::MessageBoxIconType::WarningIcon, "Audio Device Not Responding",
                     "The audio device '" + device->getName() +
                         "' is not processing audio.\n\n"
                         "Try disconnecting and reconnecting your audio interface, "
                         "or restarting the audio driver.",
-                    "OK");
+                    "OK", nullptr, juce::ModalCallbackFunction::create([](int) {}));
             }
         }
 

--- a/magda/daw/ui/components/chain/custom_ui/FMUI.cpp
+++ b/magda/daw/ui/components/chain/custom_ui/FMUI.cpp
@@ -309,8 +309,9 @@ void FMUI::resized() {
         for (int src = 0; src < kNumOps; ++src)
             for (int dst = 0; dst < kNumOps; ++dst) {
                 juce::Rectangle<int> cell(a.getX() + dst * cw, a.getY() + src * chh, cw, chh);
-                controls_[static_cast<size_t>(kMatrixBase) + src * kNumOps + dst].slider->setBounds(
-                    cell.reduced(kCellPad));
+                controls_[static_cast<size_t>(kMatrixBase) + static_cast<size_t>(src) * kNumOps +
+                          dst]
+                    .slider->setBounds(cell.reduced(kCellPad));
             }
     }
 

--- a/magda/daw/ui/components/chain/custom_ui/PolySynthUI.cpp
+++ b/magda/daw/ui/components/chain/custom_ui/PolySynthUI.cpp
@@ -218,8 +218,9 @@ PolySynthUI::PolySynthUI() {
     for (int osc = 0; osc < kNumOscillators; ++osc) {
         // Icon selector / enable + reset toggles replace the value boxes; hide the
         // underlying sliders and the wave/reset labels (the toggles are labelled).
-        controls_[osc * kOscSlotCount].slider->setVisible(false);
-        controls_[osc * kOscSlotCount].label->setVisible(false);
+        const auto waveSlot = static_cast<std::size_t>(osc) * kOscSlotCount;
+        controls_[waveSlot].slider->setVisible(false);
+        controls_[waveSlot].label->setVisible(false);
         controls_[kOscResetBaseSlot + osc].slider->setVisible(false);
         controls_[kOscResetBaseSlot + osc].label->setVisible(false);
         controls_[kOscEnableBaseSlot + osc].slider->setVisible(false);
@@ -403,8 +404,9 @@ void PolySynthUI::setOscWave(int osc, int wave) {
 
 void PolySynthUI::updateWaveSelectors() {
     for (int osc = 0; osc < kNumOscillators; ++osc) {
+        const auto waveSlot = static_cast<std::size_t>(osc) * kOscSlotCount;
         const int wave = juce::jlimit(
-            0, 3, static_cast<int>(std::round(controls_[osc * kOscSlotCount].slider->getValue())));
+            0, 3, static_cast<int>(std::round(controls_[waveSlot].slider->getValue())));
         waveSelectors_[static_cast<size_t>(osc)].setSelectedIndex(wave, juce::dontSendNotification);
     }
 }

--- a/magda/daw/ui/components/waveform/ClipWaveformPainter.cpp
+++ b/magda/daw/ui/components/waveform/ClipWaveformPainter.cpp
@@ -15,6 +15,18 @@
 
 namespace magda::daw::ui {
 
+namespace {
+/**
+ * @brief Converts a time offset to a pixel position, rounding half up.
+ */
+int secondsToPixels(double seconds, double pixelsPerSecond) {
+    // Half up, not juce::roundToInt's half to even. These are non-negative pixel
+    // positions, and the two disagree at tile edges.
+    // NOLINTNEXTLINE(bugprone-incorrect-roundings)
+    return static_cast<int>(seconds * pixelsPerSecond + 0.5);
+}
+}  // namespace
+
 void paintClipWaveform(juce::Graphics& g, const ClipInfo& clip, ClipId clipId,
                        juce::Rectangle<int> waveformArea, double clipDisplayLength,
                        const ClipWaveformSpec& spec) {
@@ -117,11 +129,11 @@ void paintClipWaveform(juce::Graphics& g, const ClipInfo& clip, ClipId clipId,
         }
 
         daw::ui::WarpedWaveformSpec wspec;
-        wspec.clipArea = juce::Rectangle<int>(
-            waveformArea.getX(), waveformArea.getY(),
-            juce::jmin(waveformArea.getWidth(),
-                       static_cast<int>(clipDisplayLength * pixelsPerSecond + 0.5)),
-            waveformArea.getHeight());
+        wspec.clipArea =
+            juce::Rectangle<int>(waveformArea.getX(), waveformArea.getY(),
+                                 juce::jmin(waveformArea.getWidth(),
+                                            secondsToPixels(clipDisplayLength, pixelsPerSecond)),
+                                 waveformArea.getHeight());
         wspec.warpToPixelX = [&](double warpSeconds) {
             return waveformArea.getX() +
                    di.sourceToTimeline(warpSeconds - displayOffset) * pixelsPerSecond;
@@ -218,10 +230,9 @@ void paintClipWaveform(juce::Graphics& g, const ClipInfo& clip, ClipId clipId,
 
                 double segmentDuration = juce::jmin(remainingTileDuration, fullSegmentDuration);
                 double segmentEnd = segmentTime + segmentDuration;
-                int segmentX =
-                    waveformArea.getX() + static_cast<int>(segmentTime * pixelsPerSecond + 0.5);
+                int segmentX = waveformArea.getX() + secondsToPixels(segmentTime, pixelsPerSecond);
                 int segmentRight =
-                    waveformArea.getX() + static_cast<int>(segmentEnd * pixelsPerSecond + 0.5);
+                    waveformArea.getX() + secondsToPixels(segmentEnd, pixelsPerSecond);
                 auto segmentRect =
                     juce::Rectangle<int>(segmentX, waveformArea.getY(), segmentRight - segmentX,
                                          waveformArea.getHeight());
@@ -249,7 +260,7 @@ void paintClipWaveform(juce::Graphics& g, const ClipInfo& clip, ClipId clipId,
         if (fileDuration > 0.0 && fileEnd > fileDuration)
             fileEnd = fileDuration;
         double clampedTimelineDuration = di.sourceToTimeline(fileEnd - fileStart);
-        int drawWidth = static_cast<int>(clampedTimelineDuration * pixelsPerSecond + 0.5);
+        int drawWidth = secondsToPixels(clampedTimelineDuration, pixelsPerSecond);
         drawWidth = juce::jmin(drawWidth, waveformArea.getWidth());
         auto drawRect = juce::Rectangle<int>(waveformArea.getX(), waveformArea.getY(), drawWidth,
                                              waveformArea.getHeight());

--- a/tests/SharedTestEngine.hpp
+++ b/tests/SharedTestEngine.hpp
@@ -45,6 +45,14 @@ inline TracktionEngineWrapper& getSharedEngine() {
         // test asserts is there on a desktop platform -- correctly, because
         // that is real behaviour and not an artefact of being a test. What is
         // wanted is narrower: keep the engine, close the output.
+        // Free the context before closing the device, the order shutdown already
+        // uses. closeDevices() asserts activeContexts.isEmpty(), and initialize()
+        // has just called ensureContextAllocated(), so closing first fires a
+        // jassert that the corpus harness reads as "the engine asserted while
+        // rendering" against whichever case happened to trigger the lazy init.
+        if (auto* edit = engine.getEdit())
+            edit->getTransport().freePlaybackContext();
+
         if (auto* wrapped = engine.getEngine())
             wrapped->getDeviceManager().closeDevices();
 


### PR DESCRIPTION
Closes the clang-tidy rollout's enforcement gap: the bugprone/cert tier is at
zero over all 705 `magda/` translation units, `magda/engine` included, so
`WarningsAsErrors: 'bugprone-*,cert-*'` is on and the pre-push gate no longer
excludes anything.

## The five checks

| check | findings | how |
|---|---|---|
| implicit-widening-of-multiplication-result | 19 sites | 7 config, 12 casts |
| incorrect-roundings | 4 | one named helper, one suppression |
| unused-return-value | 2 | config |
| return-const-ref-from-parameter | 2 | NOLINT that never applied |
| reserved-identifier | 1 | NOLINT that never applied |

Seven widening findings were literal products that fit in `int` and fold at
compile time (`64 * 1024`, `2 * 1024 * 1024`, `24 * 60 * 60`). Widening those
means writing `std::size_t{64} * 1024` for something that cannot overflow, so
they are `IgnoreConstantIntExpr` instead. The remaining twelve are runtime
`int` products widened to an index and take a cast.

`unused-return-value` is `AllowCastToVoid`: `static_cast<void>(p.release())`
is how both sites already said the discard was deliberate, and the check
ignores a void cast only with that set.

## Two NOLINTs that were doing nothing

Both the `reserved-identifier` and `return-const-ref-from-parameter`
suppressions were dead. Each `NOLINTNEXTLINE` sat above a comment that wrapped
onto a second line, so it suppressed the comment rather than the code -- the
trap the rollout notes already record. `return-const-ref` compounded it by
reporting on the return statement, not the declaration the marker sat above.

The four deliberate `ClipWaveformPainter` roundings stay half-up; they now go
through one named `secondsToPixels` helper carrying a single suppression
rather than four scattered ones.

## #2529's exclusion list

The five checks #2529 added are removed: no check by any of those names
exists. The real spellings are `hicpp-signed-bitwise`, `cert-flp30-c` and
`cert-err34-c`, none reachable from a `bugprone-*` allow-list, so those lines
excluded nothing and the counts recorded against them (63, 15, 4, 2, 1)
measured something else. If the concern behind them is real, enabling
`hicpp-*` is a separate decision.

## Two test-suite defects, both pre-existing on dev

Verified by reproducing on the base commit before touching anything.

**The corpus failures.** `placement.grid` and `project.v1bounces` were failing
for one reason, in the harness rather than in either case:
`getSharedEngine()` closes the audio device to keep test binaries silent, but
`initialize()` has just called `ensureContextAllocated()`, and
`closeDevices()` asserts `activeContexts.isEmpty()`. The corpus harness never
forgives an assertion during a case, so an init-time jassert surfaced as two
unrelated looking case failures against whichever case triggered the lazy
init. Shutdown already frees the context first; the helper now does the same.

**The hang.** `TracktionEngineWrapper::play()` passed no callback to
`showMessageBoxAsync`, and `showUnmanaged()` takes `runSync()` when the
callback is null -- so the "async" warning ran a modal loop on the message
thread, waiting for an OK that a headless run cannot press. `play()` is not
only a user action: tests, controllers and the MCP `transport_play` API all
call it. It needs an earlier suite to have left a device playing, so it hung
the single-process run while suite-by-suite passed, and CI never saw it
because a Linux runner has no device at all.

## Verification

- clang-tidy: 0 findings for the whole enabled bugprone/cert tier over 705 TUs
- gate still fails: reintroduced the BindingRegistry defect, exit 1 as `error:`
- JUCE single-process: `All tests PASSED!`, 454 suite results, exit 0 -- the
  invocation that previously hung indefinitely
- JUCE suite-by-suite: 80 suites, 0 failed, 0 hung
- Catch2: 3806 passed, 13 skipped, 2,417,661 assertions

https://claude.ai/code/session_01VomqgBSXsWYdyHyec9DvPi
