### PR TITLE
Drop 37 unused includes

### DIFF
--- a/magda/daw/audio/plugins/MagdaConvolutionPlugin.cpp
+++ b/magda/daw/audio/plugins/MagdaConvolutionPlugin.cpp
@@ -3,7 +3,6 @@
 #include <juce_audio_formats/juce_audio_formats.h>
 
 #include <algorithm>
-#include <cmath>
 #include <memory>
 
 namespace magda::daw::audio {

--- a/magda/daw/audio/plugins/MidiStrumPlugin.cpp
+++ b/magda/daw/audio/plugins/MidiStrumPlugin.cpp
@@ -1,7 +1,6 @@
 #include "plugins/MidiStrumPlugin.hpp"
 
 #include <algorithm>
-#include <cmath>
 
 namespace magda::daw::audio {
 

--- a/magda/daw/audio/processors/internal/MidiDeviceProcessors.cpp
+++ b/magda/daw/audio/processors/internal/MidiDeviceProcessors.cpp
@@ -2,11 +2,6 @@
 
 #include <utility>
 
-#include "plugins/ArpeggiatorPlugin.hpp"
-#include "plugins/DrumGridPlugin.hpp"
-#include "plugins/MidiStrumPlugin.hpp"
-#include "plugins/StepSequencerPlugin.hpp"
-
 namespace magda {
 
 // =============================================================================

--- a/magda/daw/audio/processors/internal/StockDeviceProcessors.cpp
+++ b/magda/daw/audio/processors/internal/StockDeviceProcessors.cpp
@@ -7,7 +7,6 @@
 #include "plugins/ToneGeneratorPlugin.hpp"
 #include "plugins/compiled/tracktion/CompiledFaustTracktionAdapter.hpp"
 #include "plugins/tracktion/TracktionMagdaDevicePlugin.hpp"
-#include "processors/ParameterInfoBuilder.hpp"
 
 namespace magda {
 

--- a/magda/daw/core/AppPaths.cpp
+++ b/magda/daw/core/AppPaths.cpp
@@ -1,6 +1,5 @@
 #include "AppPaths.hpp"
 
-#include <atomic>
 #include <cstdlib>
 #include <memory>
 #include <mutex>

--- a/magda/daw/core/AutomationManager.cpp
+++ b/magda/daw/core/AutomationManager.cpp
@@ -6,7 +6,6 @@
 
 #include "AutomationCurve.hpp"
 #include "ClipLaneFlattener.hpp"
-#include "CurveMath.hpp"
 #include "GridDivision.hpp"
 #include "ParameterInfo.hpp"
 #include "ParameterUtils.hpp"

--- a/magda/daw/core/ClipManager.cpp
+++ b/magda/daw/core/ClipManager.cpp
@@ -8,7 +8,6 @@
 #include <unordered_map>
 
 #include "../project/ProjectManager.hpp"
-#include "ClipOcclusion.hpp"
 #include "ClipOperations.hpp"
 #include "CompSectionMath.hpp"
 #include "Config.hpp"

--- a/magda/daw/core/GainStagingManager.cpp
+++ b/magda/daw/core/GainStagingManager.cpp
@@ -11,7 +11,6 @@
 #include "../engine/AudioEngine.hpp"
 #include "ChainWalk.hpp"
 #include "DeviceInfo.hpp"
-#include "RackInfo.hpp"
 #include "TrackInfo.hpp"
 #include "TrackManager.hpp"
 #include "UndoManager.hpp"

--- a/magda/daw/core/LegacyDeviceAliases.cpp
+++ b/magda/daw/core/LegacyDeviceAliases.cpp
@@ -2,7 +2,6 @@
 
 #include <juce_data_structures/juce_data_structures.h>
 
-#include <algorithm>
 #include <cmath>
 #include <map>
 #include <optional>

--- a/magda/daw/core/ParameterDetector.cpp
+++ b/magda/daw/core/ParameterDetector.cpp
@@ -1,7 +1,6 @@
 #include "ParameterDetector.hpp"
 
 #include <juce_events/juce_events.h>
-#include <juce_llm/juce_llm.h>
 
 #include <cmath>
 #include <mutex>

--- a/magda/daw/core/TrackManager.cpp
+++ b/magda/daw/core/TrackManager.cpp
@@ -16,7 +16,6 @@
 #include "DeviceState.hpp"
 #include "DrumGridPads.hpp"
 #include "LegacyDeviceAliases.hpp"
-#include "ModulatorEngine.hpp"
 #include "PluginCapabilities.hpp"
 #include "PluginPreferences.hpp"
 #include "RackInfo.hpp"

--- a/magda/daw/core/TrackManagerDevices.cpp
+++ b/magda/daw/core/TrackManagerDevices.cpp
@@ -1,7 +1,6 @@
 #include <algorithm>
 #include <map>
 #include <ranges>
-#include <set>
 #include <span>
 
 #include "../audio/AudioBridge.hpp"

--- a/magda/daw/core/TrackManagerPads.cpp
+++ b/magda/daw/core/TrackManagerPads.cpp
@@ -1,6 +1,5 @@
 #include <algorithm>
 #include <cmath>
-#include <map>
 
 #include "DrumGridPads.hpp"
 #include "RackInfo.hpp"

--- a/magda/daw/core/controllers/BindingRegistry.cpp
+++ b/magda/daw/core/controllers/BindingRegistry.cpp
@@ -5,7 +5,6 @@
 #include "../aliases/ChainContext.hpp"
 #include "../aliases/ResolverRegistry.hpp"
 #include "../aliases/TargetResolver.hpp"
-#include "ControllerRegistry.hpp"
 
 namespace magda {
 

--- a/magda/daw/engine/PluginMetadataStore.cpp
+++ b/magda/daw/engine/PluginMetadataStore.cpp
@@ -2,7 +2,6 @@
 
 #include <memory>
 #include <mutex>
-#include <stdexcept>
 #include <string>
 #include <utility>
 

--- a/magda/daw/engine/TracktionEngineWrapperPlugins.cpp
+++ b/magda/daw/engine/TracktionEngineWrapperPlugins.cpp
@@ -1,8 +1,6 @@
-#include <fstream>
 #include <map>
 #include <optional>
 #include <set>
-#include <sstream>
 #include <thread>
 #include <utility>
 
@@ -11,7 +9,6 @@
 #endif
 
 #include "../audio/plugins/InternalPluginRegistry.hpp"
-#include "../audio/plugins/compiled/CompiledPluginRegistry.hpp"
 #include "../audio/plugins/tracktion/TracktionInternalPluginAdapter.hpp"
 #include "../core/AppPaths.hpp"
 #include "PluginMetadataStore.hpp"

--- a/magda/daw/engine/TracktionEngineWrapperPlugins.cpp
+++ b/magda/daw/engine/TracktionEngineWrapperPlugins.cpp
@@ -1,6 +1,8 @@
+#include <fstream>
 #include <map>
 #include <optional>
 #include <set>
+#include <sstream>
 #include <thread>
 #include <utility>
 

--- a/magda/daw/engine/TracktionEngineWrapperTracks.cpp
+++ b/magda/daw/engine/TracktionEngineWrapperTracks.cpp
@@ -1,5 +1,4 @@
 #include "../audio/AudioBridge.hpp"
-#include "../core/TrackManager.hpp"
 #include "TracktionEngineWrapper.hpp"
 
 namespace magda {

--- a/magda/daw/music/ChordEngine.cpp
+++ b/magda/daw/music/ChordEngine.cpp
@@ -1,9 +1,7 @@
 #include "ChordEngine.hpp"
 
 #include <algorithm>
-#include <cmath>
 #include <mutex>
-#include <set>
 
 namespace magda::music {
 

--- a/magda/daw/music/ChordSuggestionEngine.cpp
+++ b/magda/daw/music/ChordSuggestionEngine.cpp
@@ -4,7 +4,6 @@
 #include <cmath>
 #include <map>
 #include <numeric>
-#include <random>
 #include <set>
 #include <unordered_set>
 

--- a/magda/daw/ui/components/chain/compiled/CompiledClipperCurveView.cpp
+++ b/magda/daw/ui/components/chain/compiled/CompiledClipperCurveView.cpp
@@ -1,12 +1,10 @@
 #include "compiled/CompiledClipperCurveView.hpp"
 
-#include <algorithm>
 #include <cmath>
 
 #include "audio/plugins/compiled/MagdaClipperCompiledPlugin.hpp"
 #include "audio/plugins/tracktion/TracktionMagdaDevicePlugin.hpp"
 #include "ui/themes/DarkTheme.hpp"
-#include "ui/themes/FontManager.hpp"
 
 namespace magda::daw::ui {
 

--- a/magda/daw/ui/components/chain/compiled/CompiledLimiterCurveView.cpp
+++ b/magda/daw/ui/components/chain/compiled/CompiledLimiterCurveView.cpp
@@ -1,6 +1,5 @@
 #include "compiled/CompiledLimiterCurveView.hpp"
 
-#include <algorithm>
 #include <cmath>
 
 #include "audio/plugins/compiled/MagdaLimiterCompiledPlugin.hpp"

--- a/magda/daw/ui/components/chain/compiled/CompiledPluginPresentation.cpp
+++ b/magda/daw/ui/components/chain/compiled/CompiledPluginPresentation.cpp
@@ -1,7 +1,5 @@
 #include "compiled/CompiledPluginPresentation.hpp"
 
-#include <algorithm>
-
 namespace magda::daw::ui {
 
 // Per-device presentation specs live next to each curve view (or the

--- a/magda/daw/ui/components/chain/custom_ui/FMUI.cpp
+++ b/magda/daw/ui/components/chain/custom_ui/FMUI.cpp
@@ -1,6 +1,5 @@
 #include "custom_ui/FMUI.hpp"
 
-#include <algorithm>
 #include <cmath>
 
 #include "BinaryData.h"

--- a/magda/daw/ui/components/chain/custom_ui/FaustUI.cpp
+++ b/magda/daw/ui/components/chain/custom_ui/FaustUI.cpp
@@ -1,7 +1,6 @@
 #include "custom_ui/FaustUI.hpp"
 
 #include <BinaryData.h>
-#include <tracktion_engine/tracktion_engine.h>
 
 #include "audio/AudioBridge.hpp"
 #include "audio/FaustResources.hpp"

--- a/magda/daw/ui/components/chain/custom_ui/ImpulseResponseUI.cpp
+++ b/magda/daw/ui/components/chain/custom_ui/ImpulseResponseUI.cpp
@@ -1,7 +1,5 @@
 #include "custom_ui/ImpulseResponseUI.hpp"
 
-#include <juce_audio_basics/juce_audio_basics.h>
-
 #include "BinaryData.h"
 #include "ui/components/common/InternalFileDrag.hpp"
 #include "ui/themes/DarkTheme.hpp"

--- a/magda/daw/ui/components/chain/custom_ui/LevelsUI.cpp
+++ b/magda/daw/ui/components/chain/custom_ui/LevelsUI.cpp
@@ -1,7 +1,5 @@
 #include "LevelsUI.hpp"
 
-#include <cmath>
-
 #include "audio/analysis/TrackMeasurer.hpp"
 #include "ui/themes/DarkTheme.hpp"
 #include "ui/themes/SmallButtonLookAndFeel.hpp"

--- a/magda/daw/ui/components/chain/custom_ui/PolyStepSequencerUI.cpp
+++ b/magda/daw/ui/components/chain/custom_ui/PolyStepSequencerUI.cpp
@@ -2,7 +2,6 @@
 
 #include "audio/AudioBridge.hpp"
 #include "audio/plugins/DrumGridPlugin.hpp"
-#include "audio/sequencer/StepClock.hpp"
 #include "core/GestureRouter.hpp"
 #include "core/TrackManager.hpp"
 #include "engine/AudioEngine.hpp"

--- a/magda/daw/ui/components/chain/custom_ui/SpectrumAnalyzerUI.cpp
+++ b/magda/daw/ui/components/chain/custom_ui/SpectrumAnalyzerUI.cpp
@@ -4,7 +4,6 @@
 
 #include <algorithm>
 #include <cmath>
-#include <cstdint>
 #include <iterator>
 #include <limits>
 

--- a/magda/daw/ui/components/chain/custom_ui/StepSequencerUI.cpp
+++ b/magda/daw/ui/components/chain/custom_ui/StepSequencerUI.cpp
@@ -1,6 +1,5 @@
 #include "custom_ui/StepSequencerUI.hpp"
 
-#include "audio/sequencer/StepClock.hpp"
 #include "ui/themes/SmallComboBoxLookAndFeel.hpp"
 
 namespace magda::daw::ui {

--- a/magda/daw/ui/components/chain/custom_ui/ToneGeneratorUI.cpp
+++ b/magda/daw/ui/components/chain/custom_ui/ToneGeneratorUI.cpp
@@ -1,7 +1,6 @@
 #include "custom_ui/ToneGeneratorUI.hpp"
 
 #include "ui/themes/DarkTheme.hpp"
-#include "ui/themes/SmallButtonLookAndFeel.hpp"
 
 namespace magda::daw::ui {
 


### PR DESCRIPTION
The last mechanical batch of the clang-tidy rollout, and the one that mostly
did not survive contact.

`misc-include-cleaner` reports **357** unused-include findings across 159 files
in `magda/` without engine, against 11,098 in the missing direction. **35**
survive. The rest are false positives, so every deletion here was verified by
building -- on all three platforms, which turned out to matter.

## Why the yield is 10%

Five classes, and only a compiler distinguishes them:

| class | example |
|---|---|
| `.cpp` textually includes a generated `.cpp` | the 28 files in `audio/plugins/compiled/` need `faust/gui/UI.h` and `meta.h` for `magda_*.generated.cpp`, and name neither themselves |
| header provides a macro | `magda.hpp` provides `MAGDA_VERSION` |
| module umbrella header | the used name arrives transitively |
| incomplete type | a forward declaration is visible; the definition came through the include being removed |
| **another standard header is the provider on this platform** | `TracktionEngineWrapperPlugins.cpp` uses `std::ifstream`, but on libc++ `<fstream>` arrives through something else, so the direct include reads as redundant |

The first class is the sharp one: removing those two includes broke every
compiled Faust device at once.

The last class is the one a local build cannot catch, and it is why this PR has
a second commit. libstdc++ does not hand over `<fstream>` and `<sstream>` the
way libc++ does, so Linux failed on an incomplete `std::ifstream` after macOS
had been green -- clangd here still reports both includes as unused with the
file open. Rather than fix the file CI named and wait to find the next, every
removed standard header was matched against the names it owns, qualified and
unqualified; that one file was the only hit.

## Method

Apply all deletions, then build in a loop reverting whole files that fail,
until it builds. Whole-file reverts are what converged; they also discard good
deletions in a file that had one bad one, so 35 is a floor rather than the true
safe set. A per-include bisect would recover a few more and is not worth the
build cycles.

Before any of that, includes inside a `#if` block were skipped outright. A
sweep that read one macOS build says nothing about the branch it did not
compile -- that guard is what kept `Accelerate/Accelerate.h`, `unistd.h` and
`sys/stat.h` from going.

## Verification

- Linux, macOS and Windows all build
- JUCE: 80 suites, 0 failed, 0 hung
- Catch2: 3806 passed, 13 skipped, 1,863,436 assertions
- the pre-push clang-tidy gate passed on the changed files

With this the rollout has no mechanical batches left. What remains is authoring
work -- `use-anyofallof` and `avoid-nested-conditional-operator` -- plus
`magda/engine/`, which every sweep has excluded while the native engine is
being written.

https://claude.ai/code/session_01VomqgBSXsWYdyHyec9DvPi
