### PR TITLE
Put back five checks that only a newer clang-tidy has

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -22,6 +22,11 @@ Checks: >-
   -bugprone-misplaced-widening-cast,
   -bugprone-nondeterministic-pointer-iteration-order,
   -bugprone-macro-parentheses,
+  -bugprone-signed-bitwise,
+  -bugprone-throwing-static-initialization,
+  -bugprone-derived-method-shadowing-base-method,
+  -bugprone-float-loop-counter,
+  -bugprone-unchecked-string-to-number-conversion,
   cert-oop54-cpp,
   performance-*,
   -performance-enum-size,
@@ -124,6 +129,15 @@ Checks: >-
 # copy happens while constructing the closure rather than inside the call
 # operator, which is outside the check's documented scope.
 
+# Five checks are excluded above because they exist only on a clang-tidy newer
+# than the LLVM 20.1.4 this was swept on, where signed-bitwise is spelled
+# hicpp-. #2530 removed them from the pre-push hook on the strength of a local
+# --list-checks saying the names were unknown, and the first push to dev failed
+# on them: an unknown check name is silently ignored, so a clean sweep and an
+# absent check look exactly alike. The findings are real where they report -
+# `1 << 11`, a file-scope juce::Identifier, a float loop counter - and want
+# triaging on that version before the exclusions come off.
+#
 # The bug-catching tier is at zero over all 705 magda/ translation units,
 # magda/engine included, so it is binding from here on.
 WarningsAsErrors: 'bugprone-*,cert-*'

--- a/.pre-commit-hooks/clang_tidy.py
+++ b/.pre-commit-hooks/clang_tidy.py
@@ -37,9 +37,22 @@ ROOT = Path.cwd()
 SHIPPING = Path("magda")
 ENGINE = SHIPPING / "engine"
 
-# The bugprone/cert half of .clang-tidy. Every check it enables is at zero over
-# magda/, so this list now matches the config's exactly and .clang-tidy carries
-# the same set in WarningsAsErrors.
+# The bugprone/cert half of .clang-tidy, minus five checks that do not exist on
+# every clang-tidy this runs on.
+#
+# #2530 deleted those five having "verified" against LLVM 20.1.4, where
+# `--checks=-*,bugprone-signed-bitwise` answers "no checks enabled" and the
+# check is spelled hicpp-signed-bitwise instead. A newer clang-tidy has them
+# under bugprone-, the CI runner has that newer one, and with WarningsAsErrors
+# now binding the first push to dev failed on findings the local sweep could
+# not see: `channel &= ~1` and `1 << 11` (signed-bitwise), a file-scope
+# juce::Identifier whose constructor can throw (throwing-static-initialization)
+# and `for (float db = ...; db -= 20.0f)` (float-loop-counter).
+#
+# A check name absent from one machine's --list-checks is not an absent check.
+# An unknown name is silently ignored, so a sweep that finds nothing looks
+# identical either way; the exclusions stay until the findings are triaged on
+# the version that actually reports them.
 CHECKS = ",".join([
     "-*",
     "bugprone-*",
@@ -57,6 +70,12 @@ CHECKS = ",".join([
     "-bugprone-misplaced-widening-cast",
     "-bugprone-nondeterministic-pointer-iteration-order",
     "-bugprone-macro-parentheses",
+    # Only on a clang-tidy new enough to carry them; see above.
+    "-bugprone-signed-bitwise",
+    "-bugprone-throwing-static-initialization",
+    "-bugprone-derived-method-shadowing-base-method",
+    "-bugprone-float-loop-counter",
+    "-bugprone-unchecked-string-to-number-conversion",
 ])
 
 # Sources in the tree but in no compile command, so an absent database entry is


### PR DESCRIPTION
Fixes dev, which is red on the clang-tidy gate.

## What broke

#2530 turned `WarningsAsErrors: 'bugprone-*,cert-*'` on and, in the same
change, deleted five exclusions from the pre-push hook. The first push to dev
after that failed on findings the sweep never saw:

| check | finding on dev |
|---|---|
| `bugprone-signed-bitwise` | `channel &= ~1` in `Config.hpp`, `1 << fftOrder_` and `1 << 11` in `SpectrumAnalyzerUI` |
| `bugprone-throwing-static-initialization` | `const juce::Identifier DRUM_CHAIN_TYPE("CHAIN")` -- the constructor can throw |
| `bugprone-float-loop-counter` | `for (float db = kMaxDb; db >= kMinDb; db -= 20.0f)` |

## Why the sweep missed them

The justification in #2530 was that no check exists by those names. Locally
that is true and checkable:

```
$ clang-tidy --checks='-*,bugprone-signed-bitwise' --list-checks
Error: no checks enabled.
$ clang-tidy --checks='-*,hicpp-signed-bitwise' x.cpp
warning: use of a signed integer operand with a binary bitwise operator [hicpp-signed-bitwise]
```

That is LLVM 20.1.4, where the check lives under `hicpp-`. The CI runner has a
clang-tidy new enough to carry the `bugprone-` spellings, which is where #2529
measured its 63/15/4/2/1 -- those counts were right and I read them as
measuring something else.

The trap underneath: **clang-tidy silently ignores an unknown check name.** A
sweep that reports zero and a check that is not there produce identical output,
so "I ran it and got nothing" is not evidence the name is wrong. Verifying a
check's existence against one machine's `--list-checks` is not enough when the
gate runs somewhere else.

## The fix

The five exclusions go back, in `.pre-commit-hooks/clang_tidy.py` and in
`.clang-tidy` both, so `make lint` and the editor agree with the gate rather
than diverging by LLVM version. The findings are real where they report and
deserve triaging on that version -- `1 << 11` on an int is idiomatic here and
the JUCE `Identifier` pattern is everywhere -- but that is a batch of its own,
not something to discover through a red dev.

https://claude.ai/code/session_01VomqgBSXsWYdyHyec9DvPi
