### PR TITLE
Record into a slot on the beat its launch fires

### DIFF
--- a/magda/engine/CMakeLists.txt
+++ b/magda/engine/CMakeLists.txt
@@ -111,7 +111,10 @@ add_library(magda_engine STATIC
     launch/LaunchHandle.cpp
     launch/LaunchHandle.hpp
     launch/LaunchRequests.hpp
+    launch/SlotRuns.hpp
     tap/LaunchTap.hpp
+    launch/SessionCapture.cpp
+    launch/SessionCapture.hpp
     launch/SessionLauncher.cpp
     launch/SessionLauncher.hpp
     transport/TempoMap.cpp

--- a/magda/engine/clip/ClipSnapshot.hpp
+++ b/magda/engine/clip/ClipSnapshot.hpp
@@ -278,6 +278,11 @@ struct MidiClipPlayback {
 struct SessionSlotPlayback {
     int sceneIndex = -1;
 
+    /// Whether this slot is armed to record into (#2464). An armed empty slot
+    /// is in the snapshot so that it gets a handle: its launch is quantized
+    /// like any other, and there is no clip to compile.
+    bool recordTarget = false;
+
     /// The slot's material, at most one of each. Empty means the slot holds
     /// a clip that compiled to nothing playable, a diagnostic rather than a
     /// slot that does nothing.

--- a/magda/engine/clip/ClipSnapshotCompiler.cpp
+++ b/magda/engine/clip/ClipSnapshotCompiler.cpp
@@ -42,6 +42,11 @@ std::string clipLabel(TrackId trackId, ClipId clipId) {
     return "track " + std::to_string(trackId) + " clip " + std::to_string(clipId) + ": ";
 }
 
+/// For what a track says about itself, where there is no clip to name.
+std::string trackLabel(TrackId trackId) {
+    return "track " + std::to_string(trackId) + ": ";
+}
+
 /// A fade curve is a pinned project-file integer, so a value outside the four
 /// that exist came from a file nothing in MAGDA wrote. Linear is what an
 /// unreadable curve plays as, and it is reported rather than assumed.
@@ -437,6 +442,34 @@ ClipSnapshot compileClipSnapshot(const std::vector<ClipLane>& lanes,
             track.session.push_back(std::move(slot));
         }
 
+        // The empty slots armed to record into (#2464). A slot needs an entry
+        // here to get a launch handle, and recording begins on the beat its
+        // launch fires; there is no clip, so there is nothing to compile.
+        for (const int scene : lane.recordSlots) {
+            const auto label = trackLabel(lane.trackId);
+
+            if (scene < 0) {
+                snapshot.diagnostics.push_back(label + "records into no scene");
+                continue;
+            }
+
+            const auto found = std::find_if(
+                track.session.begin(), track.session.end(),
+                [scene](const SessionSlotPlayback& slot) { return slot.sceneIndex == scene; });
+
+            if (found != track.session.end()) {
+                // Already a target means the same scene was armed twice, which
+                // is one slot. A clip in it means the slot is not empty.
+                if (!found->recordTarget)
+                    snapshot.diagnostics.push_back(label + "records into scene " +
+                                                   std::to_string(scene) +
+                                                   ", which already holds a clip");
+                continue;
+            }
+
+            track.session.push_back(SessionSlotPlayback{.sceneIndex = scene, .recordTarget = true});
+        }
+
         std::sort(track.session.begin(), track.session.end(),
                   [](const SessionSlotPlayback& a, const SessionSlotPlayback& b) {
                       return a.sceneIndex < b.sceneIndex;
@@ -444,7 +477,8 @@ ClipSnapshot compileClipSnapshot(const std::vector<ClipLane>& lanes,
 
         // A track earns an entry by having something to play, in either view. A
         // session-only track is a real one: nothing is in its arrangement and
-        // its slots are still waiting to be launched.
+        // its slots are still waiting to be launched. A record target counts:
+        // it is a slot the user is about to record into.
         if (!track.audio.empty() || !track.midi.empty() || !track.session.empty())
             snapshot.tracks.push_back(std::move(track));
     }

--- a/magda/engine/clip/ClipSnapshotCompiler.hpp
+++ b/magda/engine/clip/ClipSnapshotCompiler.hpp
@@ -58,6 +58,10 @@ struct ClipLane {
     /// decided at launch rather than at compile (#2301).
     std::vector<ClipInfo> session;
 
+    /// Scene indices of the empty slots this track records into (#2464). A
+    /// slot that already holds a clip is not a target and is left alone.
+    std::vector<int> recordSlots;
+
     /// The track's TrackInfo::playbackMode. In Session mode the arrangement
     /// clips above are silenced at render time (#2485); the compiler copies
     /// it onto TrackClipPlayback unchanged.

--- a/magda/engine/exec/EngineSession.cpp
+++ b/magda/engine/exec/EngineSession.cpp
@@ -169,7 +169,7 @@ void EngineSession::publishClips(std::shared_ptr<const ClipSnapshot> clips) {
     // A null snapshot publishes an empty table rather than skipping, or the
     // previous one would keep handles for slots the engine no longer knows.
     static const ClipSnapshot kNothing;
-    store_.publishHandles(clips != nullptr ? *clips : kNothing, handles_, requests_);
+    store_.publishHandles(clips != nullptr ? *clips : kNothing, handles_, requests_, &retired_);
 
     clips_.publish(std::move(clips));
 }

--- a/magda/engine/exec/EngineSession.cpp
+++ b/magda/engine/exec/EngineSession.cpp
@@ -239,6 +239,15 @@ void EngineSession::process(int numSamples, juce::AudioBuffer<float>& output,
 
         liveInputs_.beginSegment(segment.startSample, segment.block.numSamples);
 
+        // Before the plan, and over every handle rather than the ones this plan
+        // renders: a handle must see each block exactly once and a slot has two
+        // sources reading it. What has been asked since the last block is
+        // applied in the same pass, ahead of every advance (SessionLauncher.hpp).
+        //
+        // Before the takes as well, because a take following a slot starts on
+        // the sample its launch fired on and that is decided here (#2464).
+        advanceLaunchHandles(handles_, requests_, segment.block, &runs_);
+
         // Before the plan and outside it: a take holds the input the device
         // captured, not what the track's chain went on to make of it.
         if (takes)
@@ -251,12 +260,6 @@ void EngineSession::process(int numSamples, juce::AudioBuffer<float>& output,
         // round to be given a reader.
         if (voices_ != nullptr)
             voices_->setPosition(segment.block.seconds.start);
-
-        // Before the plan, and over every handle rather than the ones this plan
-        // renders: a handle must see each block exactly once and a slot has two
-        // sources reading it. What has been asked since the last block is
-        // applied in the same pass, ahead of every advance (SessionLauncher.hpp).
-        advanceLaunchHandles(handles_, requests_, segment.block);
 
         // The block's one acquisition of the clips, held while it renders
         // (#2490): a track's two sources play one publish rather than each

--- a/magda/engine/exec/EngineSession.hpp
+++ b/magda/engine/exec/EngineSession.hpp
@@ -254,6 +254,23 @@ class EngineSession {
         return clock_.positionBeats();
     }
 
+    /// The same instant on the count no wrap or locate takes back, which is
+    /// what a capture measures a run's length on (launch/SessionCapture.hpp).
+    double monotonicBeats() const {
+        return clock_.monotonicBeat();
+    }
+
+    /**
+     * @brief The run edges the launcher publishes, for the capture (#2464).
+     *
+     * Drained on the publishing thread by SessionCapture. Outside every epoch
+     * beside the request lane it answers: a launch made while a plan was
+     * compiling still has its edge reported when the new one is live.
+     */
+    SlotRunQueue& slotRuns() {
+        return runs_;
+    }
+
     /// Callbacks in which a loop was too short to render as separate blocks.
     int loopWrapOverflows() const {
         return clock_.loopWrapOverflows();
@@ -375,6 +392,9 @@ class EngineSession {
     /// epoch, like the feed it is read beside: a request made while a plan was
     /// being compiled is still a request when the new one is live.
     LaunchRequestQueue requests_;
+
+    /// What came of them: where each run began and ended, for the capture.
+    SlotRunQueue runs_;
 
     /// The cursor. Not published and not swapped: it's where the timeline
     /// is, a property of the session rather than of any plan, and a plan

--- a/magda/engine/exec/EngineSession.hpp
+++ b/magda/engine/exec/EngineSession.hpp
@@ -3,6 +3,7 @@
 #include <farbot/RealtimeObject.hpp>
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "clip/ClipSnapshotFeed.hpp"
@@ -254,12 +255,6 @@ class EngineSession {
         return clock_.positionBeats();
     }
 
-    /// The same instant on the count no wrap or locate takes back, which is
-    /// what a capture measures a run's length on (launch/SessionCapture.hpp).
-    double monotonicBeats() const {
-        return clock_.monotonicBeat();
-    }
-
     /**
      * @brief The run edges the launcher publishes, for the capture (#2464).
      *
@@ -269,6 +264,21 @@ class EngineSession {
      */
     SlotRunQueue& slotRuns() {
         return runs_;
+    }
+
+    /**
+     * @brief Ends no block could stamp, and forget them (#2464).
+     *
+     * A slot retired while it was sounding: publishClips() drops the handle,
+     * and the run it was playing ends there rather than at whatever the next
+     * thing to notice happens to be. Hand each to SessionCapture::apply. On the
+     * publishing thread, like the publish that produced them.
+     *
+     * Kept until asked for rather than dropped like a full lane: one per slot
+     * deleted while it played, which is a user's edit and not a rate.
+     */
+    std::vector<SlotRunEvent> takeRetiredRuns() {
+        return std::exchange(retired_, {});
     }
 
     /// Callbacks in which a loop was too short to render as separate blocks.
@@ -395,6 +405,10 @@ class EngineSession {
 
     /// What came of them: where each run began and ended, for the capture.
     SlotRunQueue runs_;
+
+    /// Ends this thread stamped rather than a block: a slot retired while it
+    /// was sounding (@ref takeRetiredRuns).
+    std::vector<SlotRunEvent> retired_;
 
     /// The cursor. Not published and not swapped: it's where the timeline
     /// is, a property of the session rather than of any plan, and a plan

--- a/magda/engine/exec/RuntimeStateStore.cpp
+++ b/magda/engine/exec/RuntimeStateStore.cpp
@@ -305,7 +305,8 @@ RuntimeStateIds collectRuntimeStateIds(const std::vector<TrackInfo>& tracks,
 }
 
 std::shared_ptr<const LaunchHandleTable> RuntimeStateStore::publishHandles(
-    const ClipSnapshot& clips, LaunchHandleFeed& feed, LaunchRequestQueue& requests) {
+    const ClipSnapshot& clips, LaunchHandleFeed& feed, LaunchRequestQueue& requests,
+    std::vector<SlotRunEvent>* retired) {
     auto table = std::make_shared<LaunchHandleTable>();
 
     for (const auto& track : clips.tracks)
@@ -352,6 +353,26 @@ std::shared_ptr<const LaunchHandleTable> RuntimeStateStore::publishHandles(
     // The swap waits for the block the callback is in, so afterwards a handle
     // this table does not name is unreachable from the audio thread.
     feed.publish(table);
+
+    // The runs those dropped handles were sounding. Their end is here, on this
+    // thread, because the handle goes before any block could report one; where
+    // it had been advanced to is the end it actually had (#2464).
+    if (retired != nullptr)
+        for (const auto& [key, made] : handles_) {
+            if (table->find(key) != nullptr || made.handle == nullptr)
+                continue;
+
+            const auto played = made.handle->playedMonotonicRange();
+            if (!played)
+                continue;
+
+            retired->push_back(SlotRunEvent{.key = key,
+                                            .kind = SlotRunEvent::Kind::ended,
+                                            .incarnation = made.incarnation,
+                                            .at = made.handle->playedSampleRange()->end,
+                                            .timelineBeat = made.handle->playedRange()->end,
+                                            .monotonicBeat = played->end});
+        }
 
     // So it can go, here, on this thread. The only thing that knows a slot was
     // emptied is the snapshot that stopped naming it; a plan publish would not

--- a/magda/engine/exec/RuntimeStateStore.hpp
+++ b/magda/engine/exec/RuntimeStateStore.hpp
@@ -258,10 +258,15 @@ class RuntimeStateStore {
      * @p requests is told the incarnations this publish assigns, so a launch
      * asked for against a handle that has gone is dropped rather than applied
      * to the one that replaced it (#2305).
+     *
+     * @p retired takes an end for every run that was sounding on a handle this
+     * publish drops. No block can report one -- the handle is gone before the
+     * next -- and a capture with no end for a run cannot say what played
+     * (#2464). Null for a caller that does not capture.
      */
-    std::shared_ptr<const LaunchHandleTable> publishHandles(const ClipSnapshot& clips,
-                                                            LaunchHandleFeed& feed,
-                                                            LaunchRequestQueue& requests);
+    std::shared_ptr<const LaunchHandleTable> publishHandles(
+        const ClipSnapshot& clips, LaunchHandleFeed& feed, LaunchRequestQueue& requests,
+        std::vector<SlotRunEvent>* retired = nullptr);
 
     /// @brief The handle for @p key, or null when no published snapshot names it.
     LaunchHandle* findHandle(const SlotKey& key) const;

--- a/magda/engine/io/MidiTakeRecorder.cpp
+++ b/magda/engine/io/MidiTakeRecorder.cpp
@@ -198,9 +198,17 @@ MidiTakeRecorder::MidiTakeRecorder(const LiveInputFeed& feed, RecordTap& tap,
       tap_(tap) {
     // Sized once, so a block's events are copied into it and never allocate.
     events_.ensureSize(static_cast<std::size_t>(kMaxMidiBytesPerPort));
+    incoming_.ensureSize(static_cast<std::size_t>(kMaxMidiBytesPerPort));
 }
 
 void MidiTakeRecorder::capture(const BlockInfo& block, bool countingIn, const LoopRange& loop) {
+    // A slot take is on its run's own time: neither the count-in nor the loop
+    // says anything about it (#2464).
+    if (settings_.slot) {
+        captureRun(block);
+        return;
+    }
+
     if (state_ == State::stopped)
         return;
 
@@ -224,18 +232,72 @@ void MidiTakeRecorder::capture(const BlockInfo& block, bool countingIn, const Lo
         openPass(block, loop);
     }
 
-    write(block);
+    write(block, 0, block.numSamples);
     publish(block);
     arrivals_ += block.numSamples;
 }
 
-void MidiTakeRecorder::start(const BlockInfo& block, const LoopRange& loop) {
+void MidiTakeRecorder::captureRun(const BlockInfo& block) {
+    if (state_ == State::stopped)
+        return;
+
+    // A stopped transport passes no timeline, so the run makes no progress and
+    // the take holds nothing. Not a stop: the run has not ended.
+    if (!block.playing)
+        return;
+
+    const auto run = slotRun(*settings_.slot);
+
+    // The slot was retired or refilled: the take ends where it stood.
+    if (run.gone) {
+        if (state_ == State::rolling)
+            stop();
+
+        return;
+    }
+
+    auto from = 0;
+    auto closing = false;
+
+    if (state_ == State::waiting) {
+        // An end in this block belongs to the run before this one.
+        if (!run.beganAt)
+            return;
+
+        from = run.beganAt->value;
+        start(block, LoopRange{}, from);
+    } else if (run.endedAt) {
+        // A launch in this block begins the next take, not this one.
+        closing = true;
+    }
+
+    const auto to = closing ? run.endedAt->value : block.numSamples;
+
+    if (to > from) {
+        write(block, from, to);
+        publish(block);
+        arrivals_ += to - from;
+    }
+
+    if (closing)
+        stop();
+}
+
+void MidiTakeRecorder::start(const BlockInfo& block, const LoopRange& loop, int from) {
     state_ = State::rolling;
     rolled_ = true;
     rolling_.store(true, std::memory_order_relaxed);
 
-    startBeat_ = block.beats.start;
     startSeconds_ = block.seconds.start;
+    startBeat_ = block.beats.start;
+
+    // A quantized launch begins the take inside the block rather than on its
+    // boundary.
+    if (from > 0 && block.rate() > 0.0) {
+        startSeconds_ = block.seconds.start + (static_cast<double>(from) / block.rate());
+        startBeat_ = block.beatAtTime(startSeconds_);
+    }
+
     sampleRate_ = block.rate();
     origin_ = block.materialOrigin;
     startedAtLoopStart_ = atLoopStart(block, loop);
@@ -274,11 +336,27 @@ void MidiTakeRecorder::stop() {
     tap_.close();
 }
 
-void MidiTakeRecorder::write(const BlockInfo& block) {
-    events_.clear();
-    input_.render(block, events_);
+void MidiTakeRecorder::collect(const BlockInfo& block, int from, int to) {
+    incoming_.clear();
+    input_.render(block, incoming_);
 
-    end_ = arrivals_ + block.numSamples - settings_.latencySamples;
+    // The whole block, which is every arrangement take: a swap rather than a
+    // copy, so the common path costs nothing.
+    if (from <= 0 && to >= block.numSamples) {
+        events_.swapWith(incoming_);
+        return;
+    }
+
+    events_.clear();
+    for (const auto metadata : incoming_)
+        if (metadata.samplePosition >= from && metadata.samplePosition < to)
+            events_.addEvent(metadata.data, metadata.numBytes, metadata.samplePosition - from);
+}
+
+void MidiTakeRecorder::write(const BlockInfo& block, int from, int to) {
+    collect(block, from, to);
+
+    end_ = arrivals_ + (to - from) - settings_.latencySamples;
 
     if (events_.isEmpty())
         return;

--- a/magda/engine/io/MidiTakeRecorder.cpp
+++ b/magda/engine/io/MidiTakeRecorder.cpp
@@ -241,11 +241,6 @@ void MidiTakeRecorder::captureRun(const BlockInfo& block) {
     if (state_ == State::stopped)
         return;
 
-    // A stopped transport passes no timeline, so the run makes no progress and
-    // the take holds nothing. Not a stop: the run has not ended.
-    if (!block.playing)
-        return;
-
     const auto run = slotRun(*settings_.slot);
 
     // The slot was retired or refilled: the take ends where it stood.
@@ -256,6 +251,11 @@ void MidiTakeRecorder::captureRun(const BlockInfo& block) {
         return;
     }
 
+    // A stopped transport passes no timeline, so the take holds none of this
+    // block. Its edges are still read: a request applied in a stopped block is
+    // reported by that block alone (#2464 review).
+    const auto samples = block.playing ? block.numSamples : 0;
+
     auto from = 0;
     auto closing = false;
 
@@ -264,14 +264,14 @@ void MidiTakeRecorder::captureRun(const BlockInfo& block) {
         if (!run.beganAt)
             return;
 
-        from = run.beganAt->value;
+        from = std::min(run.beganAt->value, samples);
         start(block, LoopRange{}, from);
     } else if (run.endedAt) {
         // A launch in this block begins the next take, not this one.
         closing = true;
     }
 
-    const auto to = closing ? run.endedAt->value : block.numSamples;
+    const auto to = closing ? std::min(run.endedAt->value, samples) : samples;
 
     if (to > from) {
         write(block, from, to);

--- a/magda/engine/io/MidiTakeRecorder.hpp
+++ b/magda/engine/io/MidiTakeRecorder.hpp
@@ -163,6 +163,8 @@ class MidiTakeRecorder final : public TakeCapture {
     void start(const BlockInfo& block, const LoopRange& loop, int from = 0);
 
     /// One block of a take that follows a slot's run rather than the transport.
+    /// A stopped block holds no events but still reports the run's edges, which
+    /// is the only block a paused request is reported by.
     void captureRun(const BlockInfo& block);
 
     /// A wrap: where the pass ended, in the take's own positions.

--- a/magda/engine/io/MidiTakeRecorder.hpp
+++ b/magda/engine/io/MidiTakeRecorder.hpp
@@ -5,6 +5,7 @@
 #include <array>
 #include <atomic>
 #include <cstdint>
+#include <optional>
 #include <span>
 #include <vector>
 
@@ -15,6 +16,7 @@
 #include "io/RecordingFeed.hpp"
 #include "io/TakeNotes.hpp"
 #include "io/TakePasses.hpp"
+#include "launch/SessionLauncher.hpp"
 #include "tap/RecordTap.hpp"
 #include "transport/TempoMap.hpp"
 #include "transport/TimeDomains.hpp"
@@ -75,6 +77,10 @@ struct MidiTakeRecorderSettings {
 
     /// How much the queue holds. Its channel count is always zero.
     RecordStreamSettings stream;
+
+    /// The slot whose run this take follows, instead of the transport (#2464).
+    /// Absent for an arrangement take.
+    std::optional<SlotRunTarget> slot;
 };
 
 /** @brief The record thread's end of a MIDI take: the events, in arrival order. */
@@ -95,8 +101,9 @@ class MidiTakeSink final : public RecordSink {
  * @brief One MIDI take: fed on the audio thread, closed on the thread that
  *        stops it.
  *
- * It captures from the first block the transport is rolling and not counting
- * in, and stops at the first block it is not.
+ * An arrangement take runs from the first block the transport is rolling and
+ * not counting in to the first block it is not. A slot take follows a session
+ * slot's run instead, beginning and ending on the samples the run did (#2464).
  */
 class MidiTakeRecorder final : public TakeCapture {
   public:
@@ -151,15 +158,23 @@ class MidiTakeRecorder final : public TakeCapture {
     /// fit is refused rather than dropped.
     static constexpr std::size_t kMaxPasses = 256;
 
-    void start(const BlockInfo& block, const LoopRange& loop);
+    /// @p from is where inside the block the take begins, which a quantized
+    /// launch puts off the block boundary.
+    void start(const BlockInfo& block, const LoopRange& loop, int from = 0);
+
+    /// One block of a take that follows a slot's run rather than the transport.
+    void captureRun(const BlockInfo& block);
 
     /// A wrap: where the pass ended, in the take's own positions.
     void openPass(const BlockInfo& block, const LoopRange& loop);
 
     void stop();
 
-    /// This block's events, stamped and queued.
-    void write(const BlockInfo& block);
+    /// This block's events over [@p from, @p to), stamped and queued.
+    void write(const BlockInfo& block, int from, int to);
+
+    /// The block's events, narrowed to [@p from, @p to) and re-based on @p from.
+    void collect(const BlockInfo& block, int from, int to);
 
     /// This block's notes and the pass's length, as the block leaves them.
     void publish(const BlockInfo& block);
@@ -192,6 +207,9 @@ class MidiTakeRecorder final : public TakeCapture {
 
     /// This block's events, sized once so a capture cannot allocate.
     juce::MidiBuffer events_;
+
+    /// What the input rendered, before it is narrowed into @ref events_.
+    juce::MidiBuffer incoming_;
 
     /// The pass's notes as the tap holds them, over the table the finished take
     /// walks as well (io/TakeNotes.hpp).

--- a/magda/engine/io/TakeRecorder.cpp
+++ b/magda/engine/io/TakeRecorder.cpp
@@ -53,6 +53,12 @@ TakeRecorder::TakeRecorder(const LiveInputFeed& feed, const RenderContext& conte
 }
 
 void TakeRecorder::capture(const BlockInfo& block, bool countingIn, const LoopRange& loop) {
+    // A slot take is on its run's clock, not the transport's (#2464).
+    if (settings_.slot) {
+        captureRun(block);
+        return;
+    }
+
     if (state_ == State::stopped)
         return;
 
@@ -76,7 +82,7 @@ void TakeRecorder::capture(const BlockInfo& block, bool countingIn, const LoopRa
         openPass(block, loop);
     }
 
-    write(block);
+    write(block, 0, block.numSamples);
 
     // Timeline the take has covered, which is what a pass boundary is counted
     // in. Not the samples written: those are the same stretch read a latency
@@ -84,12 +90,65 @@ void TakeRecorder::capture(const BlockInfo& block, bool countingIn, const LoopRa
     arrivals_ += block.numSamples;
 }
 
-void TakeRecorder::start(const BlockInfo& block, const LoopRange& loop) {
+void TakeRecorder::captureRun(const BlockInfo& block) {
+    if (state_ == State::stopped)
+        return;
+
+    // A stopped transport passes no timeline, so the run makes no progress and
+    // the take holds nothing. Not a stop: the run has not ended.
+    if (!block.playing)
+        return;
+
+    const auto run = slotRun(*settings_.slot);
+
+    // The slot was retired or refilled: the take ends where it stood.
+    if (run.gone) {
+        if (state_ == State::rolling)
+            stop();
+
+        return;
+    }
+
+    auto from = 0;
+    auto closing = false;
+
+    if (state_ == State::waiting) {
+        // An end in this block belongs to the run before this one.
+        if (!run.beganAt)
+            return;
+
+        from = run.beganAt->value;
+        start(block, LoopRange{}, from);
+    } else if (run.endedAt) {
+        // A launch in this block begins the next take, not this one.
+        closing = true;
+    }
+
+    const auto to = closing ? run.endedAt->value : block.numSamples;
+
+    if (to > from) {
+        write(block, from, to);
+        arrivals_ += to - from;
+    }
+
+    if (closing)
+        stop();
+}
+
+void TakeRecorder::start(const BlockInfo& block, const LoopRange& loop, int from) {
     state_ = State::rolling;
     rolling_.store(true, std::memory_order_relaxed);
 
     startBeat_ = block.beats.start;
     startSeconds_ = block.seconds.start;
+
+    // A take that begins inside the block begins where the launch fired, not
+    // at the block's own start (#2464).
+    if (from > 0 && block.rate() > 0.0) {
+        startSeconds_ = block.seconds.start + (static_cast<double>(from) / block.rate());
+        startBeat_ = block.beatAtTime(startSeconds_);
+    }
+
     endBeat_ = startBeat_;
     startedAtLoopStart_ = atLoopStart(block, loop);
     headDrop_ = std::max(0, settings_.latencySamples);
@@ -157,7 +216,7 @@ void TakeRecorder::stop() {
     tap_.close();
 }
 
-void TakeRecorder::write(const BlockInfo& block) {
+void TakeRecorder::write(const BlockInfo& block, int from, int to) {
     const auto numSamples = std::min(block.numSamples, scratch_.getNumSamples());
     if (numSamples <= 0)
         return;
@@ -167,14 +226,18 @@ void TakeRecorder::write(const BlockInfo& block) {
 
     const auto captured = juce::dsp::AudioBlock<const float>(std::as_const(scratch_));
 
-    auto offset = 0;
+    // The input is rendered whole; only what the take keeps of it is the
+    // window the caller named.
+    auto offset = std::clamp(from, 0, numSamples);
+    const auto end = std::clamp(to, offset, numSamples);
+
     if (headDrop_ > 0) {
-        const auto dropped = std::min(headDrop_, numSamples);
+        const auto dropped = std::min(headDrop_, end - offset);
         headDrop_ -= dropped;
         offset += dropped;
     }
 
-    const auto kept = numSamples - offset;
+    const auto kept = end - offset;
     if (kept <= 0)
         return;
 
@@ -187,22 +250,22 @@ void TakeRecorder::write(const BlockInfo& block) {
     // the samples behind it are the same stretch. Every boundary this block
     // reaches is taken, the way the sink takes them: a loop shorter than the
     // block puts more than one inside it.
-    auto from = 0;
+    auto drawn = 0;
     while (pendingCount_ > 0 && block.rate() > 0.0 &&
            written_ + kept > pending_[pendingHead_].boundary) {
         const auto at = static_cast<int>(pending_[pendingHead_].boundary - written_);
-        if (at > from)
-            tap_.addPeaks(keptBlock.getSubBlock(static_cast<std::size_t>(from),
-                                                static_cast<std::size_t>(at - from)),
-                          at - from, (written_ + from) - passOrigin_);
+        if (at > drawn)
+            tap_.addPeaks(keptBlock.getSubBlock(static_cast<std::size_t>(drawn),
+                                                static_cast<std::size_t>(at - drawn)),
+                          at - drawn, (written_ + drawn) - passOrigin_);
 
         openTapPass(block);
-        from = at;
+        drawn = at;
     }
 
-    tap_.addPeaks(keptBlock.getSubBlock(static_cast<std::size_t>(from),
-                                        static_cast<std::size_t>(kept - from)),
-                  kept - from, (written_ + from) - passOrigin_);
+    tap_.addPeaks(keptBlock.getSubBlock(static_cast<std::size_t>(drawn),
+                                        static_cast<std::size_t>(kept - drawn)),
+                  kept - drawn, (written_ + drawn) - passOrigin_);
 
     written_ += kept;
     captured_.store(written_, std::memory_order_relaxed);

--- a/magda/engine/io/TakeRecorder.cpp
+++ b/magda/engine/io/TakeRecorder.cpp
@@ -94,11 +94,6 @@ void TakeRecorder::captureRun(const BlockInfo& block) {
     if (state_ == State::stopped)
         return;
 
-    // A stopped transport passes no timeline, so the run makes no progress and
-    // the take holds nothing. Not a stop: the run has not ended.
-    if (!block.playing)
-        return;
-
     const auto run = slotRun(*settings_.slot);
 
     // The slot was retired or refilled: the take ends where it stood.
@@ -109,6 +104,11 @@ void TakeRecorder::captureRun(const BlockInfo& block) {
         return;
     }
 
+    // A stopped transport passes no timeline, so the take holds none of this
+    // block. Its edges are still read: a request applied in a stopped block is
+    // reported by that block alone (#2464 review).
+    const auto samples = block.playing ? block.numSamples : 0;
+
     auto from = 0;
     auto closing = false;
 
@@ -117,14 +117,14 @@ void TakeRecorder::captureRun(const BlockInfo& block) {
         if (!run.beganAt)
             return;
 
-        from = run.beganAt->value;
+        from = std::min(run.beganAt->value, samples);
         start(block, LoopRange{}, from);
     } else if (run.endedAt) {
         // A launch in this block begins the next take, not this one.
         closing = true;
     }
 
-    const auto to = closing ? run.endedAt->value : block.numSamples;
+    const auto to = closing ? std::min(run.endedAt->value, samples) : samples;
 
     if (to > from) {
         write(block, from, to);

--- a/magda/engine/io/TakeRecorder.hpp
+++ b/magda/engine/io/TakeRecorder.hpp
@@ -195,7 +195,8 @@ class TakeRecorder final : public TakeCapture {
     enum class State : std::uint8_t { waiting, rolling, stopped };
 
     /// A block of a take that follows a slot's run rather than the transport
-    /// (#2464).
+    /// (#2464). A stopped block holds no samples but still reports the run's
+    /// edges, which is the only block a paused request is reported by.
     void captureRun(const BlockInfo& block);
 
     /// The first block of the take: where it starts, and the head correction.

--- a/magda/engine/io/TakeRecorder.hpp
+++ b/magda/engine/io/TakeRecorder.hpp
@@ -5,6 +5,7 @@
 #include <array>
 #include <atomic>
 #include <cstdint>
+#include <optional>
 #include <vector>
 
 #include "core/ClipInfo.hpp"
@@ -14,12 +15,13 @@
 #include "io/RecordingFeed.hpp"
 #include "io/TakeFileSink.hpp"
 #include "io/TakePasses.hpp"
+#include "launch/SessionLauncher.hpp"
 #include "tap/RecordTap.hpp"
 #include "transport/TransportState.hpp"
 
 /**
  * @file TakeRecorder.hpp
- * @brief An arrangement audio take, from armed to clip (#2461).
+ * @brief An audio take, from armed to clip: the transport's or a slot's (#2461).
  *
  * One track's recording: the input slice 1 delivers, through the queue slice 2
  * drains, into the files a clip is made of. The rules it keeps are the model's
@@ -123,6 +125,10 @@ struct TakeRecorderSettings {
 
     /// How much the queue holds. Its channel count is the take's.
     RecordStreamSettings stream;
+
+    /// The slot whose run this take follows, instead of the transport (#2464).
+    /// Absent for an arrangement take.
+    std::optional<SlotRunTarget> slot;
 };
 
 /**
@@ -132,6 +138,9 @@ struct TakeRecorderSettings {
  * audio thread. It captures from the first block the transport is rolling and
  * not counting in, and stops at the first block it is not: a take is closed by
  * a stop, and a second play is a second take.
+ *
+ * A take with a slot follows that slot's run instead (#2464): it starts on the
+ * sample the launch fired on and ends where the run ended.
  */
 class TakeRecorder final : public TakeCapture {
   public:
@@ -185,8 +194,14 @@ class TakeRecorder final : public TakeCapture {
   private:
     enum class State : std::uint8_t { waiting, rolling, stopped };
 
+    /// A block of a take that follows a slot's run rather than the transport
+    /// (#2464).
+    void captureRun(const BlockInfo& block);
+
     /// The first block of the take: where it starts, and the head correction.
-    void start(const BlockInfo& block, const LoopRange& loop);
+    /// @p from is where inside the block it starts, which a launch quantized to
+    /// a beat lands on.
+    void start(const BlockInfo& block, const LoopRange& loop, int from = 0);
 
     /// A wrap: where the pass ended, handed to the sink. The one place a
     /// boundary is named, so the rule above it holds everywhere.
@@ -194,9 +209,10 @@ class TakeRecorder final : public TakeCapture {
 
     void stop();
 
-    /// This block's input, into the queue. Where a pass ends inside it is the
-    /// sink's to act on, since only the sink knows what reached the disk.
-    void write(const BlockInfo& block);
+    /// This block's input over `[from, to)`, into the queue. Where a pass ends
+    /// inside it is the sink's to act on, since only the sink knows what
+    /// reached the disk.
+    void write(const BlockInfo& block, int from, int to);
 
     /// Open the pass the oldest pending boundary named, now the audio has
     /// reached it, and retire it.

--- a/magda/engine/launch/LaunchHandle.cpp
+++ b/magda/engine/launch/LaunchHandle.cpp
@@ -5,6 +5,17 @@
 
 namespace magda::engine {
 
+void LaunchHandle::noteRunEdges(SplitStatus& status, const RunEdges& edges,
+                                const BlockInstant& at) {
+    // A run starts on a sample the block plays and ends at the bound after its
+    // last one (TimeDomains.hpp).
+    if (edges.ended)
+        status.runEndedAt = EdgeSample{at.sample};
+
+    if (edges.began)
+        status.runBeganAt = EventSample{at.sample};
+}
+
 double LaunchHandle::virtualStart(const SyncRange& piece) const {
     // Where the run would have begun on the timeline as it stands now, which
     // is not where it did begin once the timeline has wrapped or been located
@@ -249,8 +260,12 @@ void LaunchHandle::extendRun(const SyncRange& piece) {
     run_->through = piece.monotonicSamples.end;
 }
 
-void LaunchHandle::applyEvent(const SyncRange& range, bool fromPending, const BlockInstant& at,
-                              double scheduledBeat) {
+LaunchHandle::RunEdges LaunchHandle::applyEvent(const SyncRange& range, bool fromPending,
+                                                const BlockInstant& at, double scheduledBeat) {
+    // A run in progress ends here whatever the event is: a stop ends it, and a
+    // launch or a re-trigger ends it before beginning the next (#2464).
+    const RunEdges ending{.ended = run_.has_value(), .began = false};
+
     if (!fromPending) {
         // A loop re-trigger, which is a relaunch at the wrap: same handle, new
         // run, so the played range restarts and whatever reads it seeks.
@@ -260,7 +275,7 @@ void LaunchHandle::applyEvent(const SyncRange& range, bool fromPending, const Bl
         // from a rounded beat, and that error accumulates (Run::scheduleBeat).
         const auto schedule = run_ ? run_->scheduleBeat : scheduledBeat;
         beginRun(range, at, schedule);
-        return;
+        return {.ended = ending.ended, .began = true};
     }
 
     const auto pending = *pending_;
@@ -274,15 +289,16 @@ void LaunchHandle::applyEvent(const SyncRange& range, bool fromPending, const Bl
         if (pending.releasesSection)
             holdsSection_ = false;
 
-        return;
+        return ending;
     }
 
     if (!pending.synced) {
         beginRun(range, at, scheduledBeat);
-        return;
+        return {.ended = ending.ended, .began = true};
     }
 
     joinRun(range, at, *pending.synced);
+    return {.ended = ending.ended, .began = true};
 }
 
 SplitStatus LaunchHandle::advance(const SyncRange& range) {
@@ -384,7 +400,7 @@ SplitStatus LaunchHandle::advanceOver(const SyncRange& range) {
     // first half would be the same answer in a shape every caller has to
     // defend against.
     if (event.sample <= 0) {
-        applyEvent(range, fromPending, range.start(), *eventBeat);
+        noteRunEdges(status, applyEvent(range, fromPending, range.start(), *eventBeat), event);
 
         if (playState_ == PlayState::playing) {
             status.beforeEvent.origin =
@@ -405,7 +421,7 @@ SplitStatus LaunchHandle::advanceOver(const SyncRange& range) {
         extendRun(first);
     }
 
-    applyEvent(range, fromPending, event, *eventBeat);
+    noteRunEdges(status, applyEvent(range, fromPending, event, *eventBeat), event);
 
     BlockPiece after;
     after.range = second.timeline;

--- a/magda/engine/launch/LaunchHandle.hpp
+++ b/magda/engine/launch/LaunchHandle.hpp
@@ -272,6 +272,16 @@ struct SplitStatus {
     /// that was never taken.
     bool releasedSection = false;
 
+    /// Where a run began inside this block, if one did: a launch, a scene
+    /// join, or a loop re-trigger. The sample a take of that run starts on
+    /// (#2464).
+    std::optional<EventSample> runBeganAt;
+
+    /// Where the run sounding when the block opened ended, if it did. A stop
+    /// and a re-launch alike, since a re-launch ends one run before beginning
+    /// the next, and the two are different takes.
+    std::optional<EdgeSample> runEndedAt;
+
     /// Whether the slot is sounding when the block ends, which is what decides
     /// whether a stop owes note-offs.
     bool playingAtEnd() const {
@@ -529,6 +539,13 @@ class LaunchHandle {
         bool releasesSection = false;
     };
 
+    /// What one event did to the run in progress, which is what the two run
+    /// edges of a block are reported from.
+    struct RunEdges {
+        bool ended = false;
+        bool began = false;
+    };
+
     /// Begin a run at @p at, scheduled for @p scheduledBeat.
     void beginRun(const SyncRange& range, const BlockInstant& at, double scheduledBeat);
 
@@ -554,9 +571,12 @@ class LaunchHandle {
     /// playing, and the one a queued synced launch is waiting to join.
     void followRate(const SyncRange& piece);
 
+    /// Record where @p edges happened on @p status.
+    static void noteRunEdges(SplitStatus& status, const RunEdges& edges, const BlockInstant& at);
+
     /// Apply whatever the block ran into, at the instant it ran into it.
-    void applyEvent(const SyncRange& range, bool fromPending, const BlockInstant& at,
-                    double scheduledBeat);
+    RunEdges applyEvent(const SyncRange& range, bool fromPending, const BlockInstant& at,
+                        double scheduledBeat);
 
     /// The advance itself, wrapped so @ref blockStatus is stored in one place.
     SplitStatus advanceOver(const SyncRange& range);

--- a/magda/engine/launch/SessionCapture.cpp
+++ b/magda/engine/launch/SessionCapture.cpp
@@ -5,7 +5,12 @@
 namespace magda::engine {
 
 void SessionCapture::update() {
-    lane_.drain([this](const SlotRunEvent& event) { apply(event); });
+    reached_ = lane_.drain([this](const SlotRunEvent& event) { apply(event); });
+
+    // After the drain, because an end that overtook its own launch is waiting
+    // for it, and because two launches of one handle can arrive together: the
+    // end belongs to whichever run the lane left in flight.
+    reconcile();
 }
 
 void SessionCapture::apply(const SlotRunEvent& event) {
@@ -16,6 +21,11 @@ void SessionCapture::apply(const SlotRunEvent& event) {
     if (const auto found = inFlight_.find(of); found != inFlight_.end()) {
         finish(of, found->second, event.monotonicBeat);
         inFlight_.erase(found);
+    } else if (event.kind == SlotRunEvent::Kind::ended) {
+        // The end of a run whose launch is still in the lane. Kept: dropping it
+        // leaves the run sounding for ever once the launch arrives.
+        unmatchedEnds_[of] = event.monotonicBeat;
+        return;
     }
 
     if (event.kind == SlotRunEvent::Kind::began)
@@ -23,6 +33,20 @@ void SessionCapture::apply(const SlotRunEvent& event) {
                             .startBeat = event.timelineBeat,
                             .startMonotonicBeat = event.monotonicBeat,
                             .capturing = armed_};
+}
+
+void SessionCapture::reconcile() {
+    for (auto end = unmatchedEnds_.begin(); end != unmatchedEnds_.end();) {
+        const auto found = inFlight_.find(end->first);
+        if (found == inFlight_.end()) {
+            ++end;
+            continue;
+        }
+
+        finish(end->first, found->second, end->second);
+        inFlight_.erase(found);
+        end = unmatchedEnds_.erase(end);
+    }
 }
 
 void SessionCapture::arm() {
@@ -34,19 +58,17 @@ void SessionCapture::arm() {
 }
 
 void SessionCapture::disarm() {
-    // Before the boundary is read, so it cannot be a beat whose edges have not
-    // been folded in: a run that stopped on its own ends where it stopped
-    // rather than where the button was pressed.
+    // Which is where the boundary comes from: a drain hands out the beat every
+    // edge it took was reported by, so a run that stopped on its own ends where
+    // it stopped rather than where the button was pressed.
     update();
-
-    const auto until = lane_.reached();
     armed_ = false;
 
     for (auto& [of, run] : inFlight_) {
         if (!run.capturing)
             continue;
 
-        finish(of, run, until);
+        finish(of, run, reached_);
 
         // Still sounding: what stops is the capture, not the slot.
         run.capturing = false;

--- a/magda/engine/launch/SessionCapture.cpp
+++ b/magda/engine/launch/SessionCapture.cpp
@@ -4,52 +4,56 @@
 
 namespace magda::engine {
 
-void SessionCapture::update(SlotRunQueue& runs) {
-    runs.drain([this](const SlotRunEvent& event) {
-        // Any edge closes what was in flight. An end closes its own run; a
-        // launch closes one whose end a full queue dropped
-        // (SlotRunQueue::overflows), which ended here at the latest.
-        if (const auto found = runs_.find(event.key); found != runs_.end()) {
-            // Unless the slot was emptied and refilled while it sounded: that
-            // run ended when its handle was retired, which nothing stamped, so
-            // it is dropped rather than placed at a length nobody measured.
-            if (found->second.incarnation == event.incarnation)
-                finish(event.key, found->second, event.monotonicBeat);
+void SessionCapture::update() {
+    lane_.drain([this](const SlotRunEvent& event) { apply(event); });
+}
 
-            runs_.erase(found);
-        }
+void SessionCapture::apply(const SlotRunEvent& event) {
+    const RunKey of{event.key, event.incarnation};
 
-        if (event.kind == SlotRunEvent::Kind::began)
-            runs_[event.key] = Run{.incarnation = event.incarnation,
-                                   .origin = event.at,
-                                   .startBeat = event.timelineBeat,
-                                   .startMonotonicBeat = event.monotonicBeat,
-                                   .capturing = armed_};
-    });
+    // Held under the handle that played it, so a run whose end arrives after
+    // the next incarnation's launch is still the run that ended.
+    if (const auto found = inFlight_.find(of); found != inFlight_.end()) {
+        finish(of, found->second, event.monotonicBeat);
+        inFlight_.erase(found);
+    }
+
+    if (event.kind == SlotRunEvent::Kind::began)
+        inFlight_[of] = Run{.origin = event.at,
+                            .startBeat = event.timelineBeat,
+                            .startMonotonicBeat = event.monotonicBeat,
+                            .capturing = armed_};
 }
 
 void SessionCapture::arm() {
+    update();
     armed_ = true;
 
-    for (auto& [key, run] : runs_)
+    for (auto& [of, run] : inFlight_)
         run.capturing = true;
 }
 
-void SessionCapture::disarm(double monotonicBeat) {
+void SessionCapture::disarm() {
+    // Before the boundary is read, so it cannot be a beat whose edges have not
+    // been folded in: a run that stopped on its own ends where it stopped
+    // rather than where the button was pressed.
+    update();
+
+    const auto until = lane_.reached();
     armed_ = false;
 
-    for (auto& [key, run] : runs_) {
+    for (auto& [of, run] : inFlight_) {
         if (!run.capturing)
             continue;
 
-        finish(key, run, monotonicBeat);
+        finish(of, run, until);
 
         // Still sounding: what stops is the capture, not the slot.
         run.capturing = false;
     }
 }
 
-void SessionCapture::finish(const SlotKey& key, const Run& run, double monotonicBeat) {
+void SessionCapture::finish(const RunKey& of, const Run& run, double monotonicBeat) {
     if (!run.capturing)
         return;
 
@@ -59,8 +63,11 @@ void SessionCapture::finish(const SlotKey& key, const Run& run, double monotonic
     if (length <= 0.0)
         return;
 
-    captured_.push_back(CapturedRun{
-        .key = key, .startBeat = run.startBeat, .lengthBeats = length, .origin = run.origin});
+    captured_.push_back(CapturedRun{.key = of.key,
+                                    .incarnation = of.incarnation,
+                                    .startBeat = run.startBeat,
+                                    .lengthBeats = length,
+                                    .origin = run.origin});
 }
 
 std::vector<CapturedRun> SessionCapture::collect() {

--- a/magda/engine/launch/SessionCapture.cpp
+++ b/magda/engine/launch/SessionCapture.cpp
@@ -5,15 +5,25 @@
 namespace magda::engine {
 
 void SessionCapture::update() {
-    reached_ = lane_.drain([this](const SlotRunEvent& event) { apply(event); });
-
-    // After the drain, because an end that overtook its own launch is waiting
-    // for it, and because two launches of one handle can arrive together: the
-    // end belongs to whichever run the lane left in flight.
-    reconcile();
+    reached_ = lane_.drain([this](const SlotRunEvent& event) { fold(event); });
 }
 
 void SessionCapture::apply(const SlotRunEvent& event) {
+    // The lane first, always. An incarnation names the handle rather than one of
+    // its runs, so an end stamped on this thread can only be matched to a run
+    // once every transition that was queued when it arrived has been folded:
+    // otherwise it closes whichever earlier run the capture happens to hold
+    // (#2464 review).
+    //
+    // One drain is enough, and that is the publish's doing: retiring a handle
+    // waits for the block the callback is in, so by the time an end reaches
+    // here nothing more can ever be published for that handle. What the drain
+    // leaves in flight is the run this ends.
+    update();
+    fold(event);
+}
+
+void SessionCapture::fold(const SlotRunEvent& event) {
     const RunKey of{event.key, event.incarnation};
 
     // Held under the handle that played it, so a run whose end arrives after
@@ -21,11 +31,6 @@ void SessionCapture::apply(const SlotRunEvent& event) {
     if (const auto found = inFlight_.find(of); found != inFlight_.end()) {
         finish(of, found->second, event.monotonicBeat);
         inFlight_.erase(found);
-    } else if (event.kind == SlotRunEvent::Kind::ended) {
-        // The end of a run whose launch is still in the lane. Kept: dropping it
-        // leaves the run sounding for ever once the launch arrives.
-        unmatchedEnds_[of] = event.monotonicBeat;
-        return;
     }
 
     if (event.kind == SlotRunEvent::Kind::began)
@@ -33,20 +38,6 @@ void SessionCapture::apply(const SlotRunEvent& event) {
                             .startBeat = event.timelineBeat,
                             .startMonotonicBeat = event.monotonicBeat,
                             .capturing = armed_};
-}
-
-void SessionCapture::reconcile() {
-    for (auto end = unmatchedEnds_.begin(); end != unmatchedEnds_.end();) {
-        const auto found = inFlight_.find(end->first);
-        if (found == inFlight_.end()) {
-            ++end;
-            continue;
-        }
-
-        finish(end->first, found->second, end->second);
-        inFlight_.erase(found);
-        end = unmatchedEnds_.erase(end);
-    }
 }
 
 void SessionCapture::arm() {

--- a/magda/engine/launch/SessionCapture.cpp
+++ b/magda/engine/launch/SessionCapture.cpp
@@ -1,0 +1,70 @@
+#include "launch/SessionCapture.hpp"
+
+#include <utility>
+
+namespace magda::engine {
+
+void SessionCapture::update(SlotRunQueue& runs) {
+    runs.drain([this](const SlotRunEvent& event) {
+        // Any edge closes what was in flight. An end closes its own run; a
+        // launch closes one whose end a full queue dropped
+        // (SlotRunQueue::overflows), which ended here at the latest.
+        if (const auto found = runs_.find(event.key); found != runs_.end()) {
+            // Unless the slot was emptied and refilled while it sounded: that
+            // run ended when its handle was retired, which nothing stamped, so
+            // it is dropped rather than placed at a length nobody measured.
+            if (found->second.incarnation == event.incarnation)
+                finish(event.key, found->second, event.monotonicBeat);
+
+            runs_.erase(found);
+        }
+
+        if (event.kind == SlotRunEvent::Kind::began)
+            runs_[event.key] = Run{.incarnation = event.incarnation,
+                                   .origin = event.at,
+                                   .startBeat = event.timelineBeat,
+                                   .startMonotonicBeat = event.monotonicBeat,
+                                   .capturing = armed_};
+    });
+}
+
+void SessionCapture::arm() {
+    armed_ = true;
+
+    for (auto& [key, run] : runs_)
+        run.capturing = true;
+}
+
+void SessionCapture::disarm(double monotonicBeat) {
+    armed_ = false;
+
+    for (auto& [key, run] : runs_) {
+        if (!run.capturing)
+            continue;
+
+        finish(key, run, monotonicBeat);
+
+        // Still sounding: what stops is the capture, not the slot.
+        run.capturing = false;
+    }
+}
+
+void SessionCapture::finish(const SlotKey& key, const Run& run, double monotonicBeat) {
+    if (!run.capturing)
+        return;
+
+    const auto length = monotonicBeat - run.startMonotonicBeat;
+
+    // A run that ended on the sample it began on played nothing.
+    if (length <= 0.0)
+        return;
+
+    captured_.push_back(CapturedRun{
+        .key = key, .startBeat = run.startBeat, .lengthBeats = length, .origin = run.origin});
+}
+
+std::vector<CapturedRun> SessionCapture::collect() {
+    return std::exchange(captured_, {});
+}
+
+}  // namespace magda::engine

--- a/magda/engine/launch/SessionCapture.hpp
+++ b/magda/engine/launch/SessionCapture.hpp
@@ -72,8 +72,13 @@ class SessionCapture {
      *
      * A slot retired while it was sounding: its handle is gone before any block
      * could report the end, so the store says where the run had got to instead
-     * (EngineSession::takeRetiredRuns). Order against @ref update does not
-     * matter, because a run is held under the handle that played it.
+     * (EngineSession::takeRetiredRuns).
+     *
+     * Order against @ref update does not matter in either direction. A run is
+     * held under the handle that played it, so a replacement's launch cannot
+     * displace it; and an end for a run whose launch is still in the lane is
+     * kept until the next @ref update has caught up with it, rather than
+     * dropped (#2464 review).
      */
     void apply(const SlotRunEvent& event);
 
@@ -86,9 +91,15 @@ class SessionCapture {
      */
     void arm();
 
-    /// Stop, ending everything still being captured where the launcher has
-    /// reported to (SlotRunQueue::reached).
+    /// Stop, ending everything still being captured where the last drain said
+    /// the lane had reached (SlotRunQueue::drain).
     void disarm();
+
+    /// The beat the last @ref update was told the lane had reached. What a
+    /// disarm ends a run at, and what says how far this has been told.
+    double reached() const {
+        return reached_;
+    }
 
     bool armed() const {
         return armed_;
@@ -126,11 +137,28 @@ class SessionCapture {
     /// End @p run at @p monotonicBeat, keeping it if it was being captured.
     void finish(const RunKey& of, const Run& run, double monotonicBeat);
 
+    /// Close the runs an end was waiting for, now the lane has caught up.
+    void reconcile();
+
     SlotRunQueue& lane_;
 
     std::map<RunKey, Run> inFlight_;
 
+    /// Ends that arrived before the launch they belong to. A retirement is
+    /// stamped on this thread while a launch travels down the lane, so an end
+    /// can overtake its own start; it waits here rather than being dropped.
+    ///
+    /// Applied after a drain rather than at the first launch that matches, and
+    /// not cleared by a launch that ends a run of its own: two launches of one
+    /// handle can be queued together, and a retirement's end belongs to the run
+    /// the lane leaves in flight. It can only ever match a launch queued before
+    /// the retirement, since nothing can launch a handle that has gone.
+    std::map<RunKey, double> unmatchedEnds_;
+
     std::vector<CapturedRun> captured_;
+
+    /// The beat the last drain reported reaching.
+    double reached_ = 0.0;
 
     bool armed_ = false;
 };

--- a/magda/engine/launch/SessionCapture.hpp
+++ b/magda/engine/launch/SessionCapture.hpp
@@ -74,11 +74,11 @@ class SessionCapture {
      * could report the end, so the store says where the run had got to instead
      * (EngineSession::takeRetiredRuns).
      *
-     * Order against @ref update does not matter in either direction. A run is
-     * held under the handle that played it, so a replacement's launch cannot
-     * displace it; and an end for a run whose launch is still in the lane is
-     * kept until the next @ref update has caught up with it, rather than
-     * dropped (#2464 review).
+     * It drains the lane before it acts: an incarnation names the handle, not
+     * one of its runs, so an end from this thread can only be matched once
+     * every transition queued when it arrived has been folded. One drain
+     * suffices because retiring a handle waits for the block the callback is
+     * in, so nothing more can be published for it afterwards (#2464 review).
      */
     void apply(const SlotRunEvent& event);
 
@@ -134,26 +134,15 @@ class SessionCapture {
         bool capturing = false;
     };
 
+    /// Apply one edge to the runs in flight, whatever channel it came down.
+    void fold(const SlotRunEvent& event);
+
     /// End @p run at @p monotonicBeat, keeping it if it was being captured.
     void finish(const RunKey& of, const Run& run, double monotonicBeat);
-
-    /// Close the runs an end was waiting for, now the lane has caught up.
-    void reconcile();
 
     SlotRunQueue& lane_;
 
     std::map<RunKey, Run> inFlight_;
-
-    /// Ends that arrived before the launch they belong to. A retirement is
-    /// stamped on this thread while a launch travels down the lane, so an end
-    /// can overtake its own start; it waits here rather than being dropped.
-    ///
-    /// Applied after a drain rather than at the first launch that matches, and
-    /// not cleared by a launch that ends a run of its own: two launches of one
-    /// handle can be queued together, and a retirement's end belongs to the run
-    /// the lane leaves in flight. It can only ever match a launch queued before
-    /// the retirement, since nothing can launch a handle that has gone.
-    std::map<RunKey, double> unmatchedEnds_;
 
     std::vector<CapturedRun> captured_;
 

--- a/magda/engine/launch/SessionCapture.hpp
+++ b/magda/engine/launch/SessionCapture.hpp
@@ -1,0 +1,103 @@
+#pragma once
+
+#include <cstddef>
+#include <map>
+#include <vector>
+
+#include "launch/SlotRuns.hpp"
+
+/**
+ * @file SessionCapture.hpp
+ * @brief What the session played, as spans the arrangement can hold (#2464).
+ *
+ * The fork's SessionRecorder watches session clips play and writes arrangement
+ * clips from what it saw, asking a play state per clip and a launch time per
+ * track once a frame. Two clocks: what was heard and what was captured, and the
+ * difference between them is the drift.
+ *
+ * This is fed the launcher's own edges instead (SlotRuns.hpp), so a run is
+ * placed on the sample it began on however long ago the frame that collects it
+ * runs. A scene is one event for the same reason: its runs share an origin
+ * because they were launched on one sample, not because they were observed in
+ * one frame.
+ *
+ * Spans and not clips. What the material is, and what a clip made of it is
+ * called, is the model's; this says which slot sounded, from where, and for how
+ * long.
+ */
+
+namespace magda::engine {
+
+/** @brief One run of a slot, as the arrangement holds it. */
+struct CapturedRun {
+    SlotKey key;
+
+    /// Where the run began on the timeline: the beat the launch fired on, which
+    /// is where the clip goes.
+    double startBeat = 0.0;
+
+    /// How long it sounded, counted on the monotonic axis. A run the transport
+    /// looped inside is one span rather than a negative one.
+    double lengthBeats = 0.0;
+
+    /// The sample it began on. Runs launched together share it.
+    SamplePosition origin;
+};
+
+class SessionCapture {
+  public:
+    /**
+     * @brief Take everything the launcher has published. Publishing thread.
+     *
+     * As often as a frame, or less: an edge waits in the queue rather than
+     * expiring, so what a run was is not a function of when this is called.
+     */
+    void update(SlotRunQueue& runs);
+
+    /**
+     * @brief Capture from here.
+     *
+     * Runs already sounding are captured from the beat they were launched on,
+     * so arming after a launch keeps the bar it has already played rather than
+     * starting a span where the button was pressed.
+     */
+    void arm();
+
+    /// Stop, ending everything still being captured at @p monotonicBeat, which
+    /// is where the transport is (TransportClock::monotonicBeat).
+    void disarm(double monotonicBeat);
+
+    bool armed() const {
+        return armed_;
+    }
+
+    /// The runs captured since the last call, and forget them.
+    std::vector<CapturedRun> collect();
+
+    /// Slots sounding right now, whether or not they are being captured.
+    std::size_t sounding() const {
+        return runs_.size();
+    }
+
+  private:
+    /// A run in flight: where it began, and whether it is being captured.
+    struct Run {
+        std::uint64_t incarnation = 0;
+        SamplePosition origin;
+        double startBeat = 0.0;
+        double startMonotonicBeat = 0.0;
+        bool capturing = false;
+    };
+
+    /// End @p run at @p monotonicBeat, keeping it if it was being captured.
+    void finish(const SlotKey& key, const Run& run, double monotonicBeat);
+
+    /// One per slot: a slot has one run at a time, and a re-launch replaces it.
+    std::map<SlotKey, Run> runs_;
+
+    std::vector<CapturedRun> captured_;
+
+    bool armed_ = false;
+};
+
+}  // namespace magda::engine

--- a/magda/engine/launch/SessionCapture.hpp
+++ b/magda/engine/launch/SessionCapture.hpp
@@ -1,7 +1,9 @@
 #pragma once
 
 #include <cstddef>
+#include <cstdint>
 #include <map>
+#include <tuple>
 #include <vector>
 
 #include "launch/SlotRuns.hpp"
@@ -24,6 +26,9 @@
  * Spans and not clips. What the material is, and what a clip made of it is
  * called, is the model's; this says which slot sounded, from where, and for how
  * long.
+ *
+ * Publishing thread throughout, and it must not outlive the queue it was made
+ * with -- the session's, which outlives every plan.
  */
 
 namespace magda::engine {
@@ -31,6 +36,11 @@ namespace magda::engine {
 /** @brief One run of a slot, as the arrangement holds it. */
 struct CapturedRun {
     SlotKey key;
+
+    /// Which handle of @ref key played it. The slot can be refilled before this
+    /// is collected, so this rather than the slot is what says which material
+    /// sounded; the host resolves it against what it published (#2464 review).
+    std::uint64_t incarnation = 0;
 
     /// Where the run began on the timeline: the beat the launch fired on, which
     /// is where the clip goes.
@@ -46,13 +56,26 @@ struct CapturedRun {
 
 class SessionCapture {
   public:
+    /// @p lane is not owned and outlives this: the session's.
+    explicit SessionCapture(SlotRunQueue& lane) : lane_(lane) {}
+
     /**
-     * @brief Take everything the launcher has published. Publishing thread.
+     * @brief Take everything the launcher has published.
      *
-     * As often as a frame, or less: an edge waits in the queue rather than
+     * As often as a frame, or less: an edge waits in the lane rather than
      * expiring, so what a run was is not a function of when this is called.
      */
-    void update(SlotRunQueue& runs);
+    void update();
+
+    /**
+     * @brief Apply one edge that no block stamped.
+     *
+     * A slot retired while it was sounding: its handle is gone before any block
+     * could report the end, so the store says where the run had got to instead
+     * (EngineSession::takeRetiredRuns). Order against @ref update does not
+     * matter, because a run is held under the handle that played it.
+     */
+    void apply(const SlotRunEvent& event);
 
     /**
      * @brief Capture from here.
@@ -63,9 +86,9 @@ class SessionCapture {
      */
     void arm();
 
-    /// Stop, ending everything still being captured at @p monotonicBeat, which
-    /// is where the transport is (TransportClock::monotonicBeat).
-    void disarm(double monotonicBeat);
+    /// Stop, ending everything still being captured where the launcher has
+    /// reported to (SlotRunQueue::reached).
+    void disarm();
 
     bool armed() const {
         return armed_;
@@ -74,15 +97,26 @@ class SessionCapture {
     /// The runs captured since the last call, and forget them.
     std::vector<CapturedRun> collect();
 
-    /// Slots sounding right now, whether or not they are being captured.
+    /// Runs sounding right now, whether or not they are being captured.
     std::size_t sounding() const {
-        return runs_.size();
+        return inFlight_.size();
     }
 
   private:
+    /// Which handle a run belongs to. Not the slot alone: a slot emptied and
+    /// refilled while it sounded has two runs in flight for a moment, and the
+    /// end of the first can arrive after the launch of the second.
+    struct RunKey {
+        SlotKey key;
+        std::uint64_t incarnation = 0;
+
+        bool operator<(const RunKey& other) const {
+            return std::tie(key, incarnation) < std::tie(other.key, other.incarnation);
+        }
+    };
+
     /// A run in flight: where it began, and whether it is being captured.
     struct Run {
-        std::uint64_t incarnation = 0;
         SamplePosition origin;
         double startBeat = 0.0;
         double startMonotonicBeat = 0.0;
@@ -90,10 +124,11 @@ class SessionCapture {
     };
 
     /// End @p run at @p monotonicBeat, keeping it if it was being captured.
-    void finish(const SlotKey& key, const Run& run, double monotonicBeat);
+    void finish(const RunKey& of, const Run& run, double monotonicBeat);
 
-    /// One per slot: a slot has one run at a time, and a re-launch replaces it.
-    std::map<SlotKey, Run> runs_;
+    SlotRunQueue& lane_;
+
+    std::map<RunKey, Run> inFlight_;
 
     std::vector<CapturedRun> captured_;
 

--- a/magda/engine/launch/SessionLauncher.cpp
+++ b/magda/engine/launch/SessionLauncher.cpp
@@ -140,10 +140,40 @@ void applyDueFollowActions(const LaunchHandleTable& table, const SyncRange& rang
     }
 }
 
+/**
+ * @brief Publish what @p status said about @p entry's run. Audio thread.
+ *
+ * Ended before began, which is the order they happened in: a re-launch ends one
+ * run and begins another on the same sample, and they are two takes.
+ *
+ * Every face is taken from the sample the edge landed on, through the range
+ * that cut the block, so the capture places a run where the audio actually
+ * started rather than where a poll noticed it (#2464).
+ */
+void publishRunEdges(SlotRunQueue& runs, const LaunchHandleTable::Entry& entry,
+                     const SyncRange& range, const SplitStatus& status) {
+    const auto edge = [&](SlotRunEvent::Kind kind, int sample) {
+        const auto at = range.atSample(sample);
+
+        runs.push(SlotRunEvent{.key = entry.key,
+                               .kind = kind,
+                               .incarnation = entry.incarnation,
+                               .at = at.monotonic,
+                               .timelineBeat = range.timelineBeatAt(at),
+                               .monotonicBeat = range.monotonicBeatAt(at)});
+    };
+
+    if (status.runEndedAt)
+        edge(SlotRunEvent::Kind::ended, status.runEndedAt->value);
+
+    if (status.runBeganAt)
+        edge(SlotRunEvent::Kind::began, status.runBeganAt->value);
+}
+
 }  // namespace
 
 void advanceLaunchHandles(LaunchHandleFeed& handles, LaunchRequestQueue& requests,
-                          const BlockInfo& block) {
+                          const BlockInfo& block, SlotRunQueue* runs) {
     const LaunchHandleFeed::Reader table(handles);
 
     // Drained whether or not there is a table to apply it to: a queue left
@@ -166,13 +196,32 @@ void advanceLaunchHandles(LaunchHandleFeed& handles, LaunchRequestQueue& request
 
     for (const auto& entry : table->entries)
         if (entry.handle != nullptr) {
-            entry.handle->advance(range);
+            const auto status = entry.handle->advance(range);
 
             // Published by the block that decided it, so the UI is never a
             // frame behind the audio and has nothing to poll (#2303).
             if (entry.tap != nullptr)
                 entry.tap->write(*entry.handle);
+
+            if (runs != nullptr)
+                publishRunEdges(*runs, entry, range, status);
         }
+}
+
+SlotRun slotRun(const SlotRunTarget& target) {
+    if (target.handles == nullptr)
+        return {.gone = true};
+
+    const LaunchHandleFeed::Reader table(*target.handles);
+    if (!table)
+        return {.gone = true};
+
+    const auto* entry = table->findEntry(target.key);
+    if (entry == nullptr || entry->handle == nullptr || entry->incarnation != target.incarnation)
+        return {.gone = true};
+
+    const auto& status = entry->handle->blockStatus();
+    return {.endedAt = status.runEndedAt, .beganAt = status.runBeganAt};
 }
 
 }  // namespace magda::engine

--- a/magda/engine/launch/SessionLauncher.cpp
+++ b/magda/engine/launch/SessionLauncher.cpp
@@ -181,6 +181,12 @@ void advanceLaunchHandles(LaunchHandleFeed& handles, LaunchRequestQueue& request
     // session appeared.
     if (!table) {
         requests.drain([](const LaunchRequest&) {});
+
+        // Still reported: how far the lane has got is a property of the
+        // transport, not of there being anything to launch.
+        if (runs != nullptr)
+            runs->reachedBeat(block.monotonicBeats.end);
+
         return;
     }
 
@@ -206,6 +212,11 @@ void advanceLaunchHandles(LaunchHandleFeed& handles, LaunchRequestQueue& request
             if (runs != nullptr)
                 publishRunEdges(*runs, entry, range, status);
         }
+
+    // After every edge this block reported, which is what lets a capture end a
+    // run here without cutting one whose end it has not seen (SlotRuns.hpp).
+    if (runs != nullptr)
+        runs->reachedBeat(range.monotonic.end);
 }
 
 SlotRun slotRun(const SlotRunTarget& target) {

--- a/magda/engine/launch/SessionLauncher.hpp
+++ b/magda/engine/launch/SessionLauncher.hpp
@@ -3,6 +3,7 @@
 #include <cstdint>
 #include <farbot/RealtimeObject.hpp>
 #include <memory>
+#include <optional>
 #include <utility>
 #include <vector>
 
@@ -11,6 +12,7 @@
 #include "launch/FollowActions.hpp"
 #include "launch/LaunchHandle.hpp"
 #include "launch/LaunchRequests.hpp"
+#include "launch/SlotRuns.hpp"
 #include "tap/LaunchTap.hpp"
 
 /**
@@ -121,6 +123,41 @@ class LaunchHandleFeed {
     Published published_;
 };
 
+/// Which slot's run a take follows, instead of the transport (#2464).
+struct SlotRunTarget {
+    /// Not owned, and outlives the take: the session's, like the clip feed.
+    LaunchHandleFeed* handles = nullptr;
+
+    SlotKey key;
+
+    /// The handle the take was made for. A slot emptied and refilled is the
+    /// same key on a different clip, and the take does not follow it.
+    std::uint64_t incarnation = 0;
+};
+
+/// What one block of a slot's run gives a take.
+struct SlotRun {
+    /// Where the run sounding when the block opened ended, if it did.
+    std::optional<EdgeSample> endedAt;
+
+    /// Where a new run began, if one did. The take that starts here is not the
+    /// one that ended above: a re-launch is a second take, not a longer one.
+    std::optional<EventSample> beganAt;
+
+    /// Whether the slot is still published under the incarnation the take was
+    /// made for. A retired or refilled slot ends the take where it stood.
+    bool gone = false;
+};
+
+/**
+ * @brief @p target's run over the block the launcher last advanced.
+ *
+ * On the audio thread, after @ref advanceLaunchHandles has run over this block:
+ * a handle's block status is written there, once, and everything that acts on
+ * it reads that one answer.
+ */
+SlotRun slotRun(const SlotRunTarget& target);
+
 /// The block as the launcher names it, from the one place its faces were
 /// derived together (RenderContext.hpp).
 inline SyncRange syncRangeFor(const BlockInfo& block) {
@@ -137,8 +174,11 @@ inline SyncRange syncRangeFor(const BlockInfo& block) {
  * One call rather than two: @p requests is drained whole first, so a launch
  * lands in the block it was asked in and a scene reaches every handle before
  * any of them has moved.
+ *
+ * @p runs takes the edges each handle reported, for the capture off the audio
+ * thread (SlotRuns.hpp). Null for a caller that does not capture.
  */
 void advanceLaunchHandles(LaunchHandleFeed& handles, LaunchRequestQueue& requests,
-                          const BlockInfo& block);
+                          const BlockInfo& block, SlotRunQueue* runs = nullptr);
 
 }  // namespace magda::engine

--- a/magda/engine/launch/SlotRuns.hpp
+++ b/magda/engine/launch/SlotRuns.hpp
@@ -1,0 +1,114 @@
+#pragma once
+
+#include <array>
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+
+#include "launch/LaunchHandle.hpp"
+
+/**
+ * @file SlotRuns.hpp
+ * @brief A slot's runs as edges, stamped by the block that decided them (#2464).
+ *
+ * The launcher already cuts a block at the sample a launch fires on
+ * (LaunchHandle::advance). This is that edge published off the audio thread, so
+ * a capture places a run where it actually began rather than where a poll of
+ * play state happened to notice it: what was heard and what was captured come
+ * from one clock, which is what removes the drift between them as a class.
+ *
+ * The audio thread's own reader is `slotRun` in SessionLauncher.hpp, which
+ * needs no queue: a take reads the block status of the handle it follows.
+ */
+
+namespace magda::engine {
+
+/** @brief One edge of one slot's run. */
+struct SlotRunEvent {
+    enum class Kind : std::uint8_t { began, ended };
+
+    SlotKey key;
+    Kind kind = Kind::began;
+
+    /// Which handle of @ref key it happened on, so a capture cannot join a run
+    /// of the clip that replaced the one it was following.
+    std::uint64_t incarnation = 0;
+
+    /// The transport sample it happened on. Two runs that began on this sample
+    /// began together, whatever the timeline did in between.
+    SamplePosition at;
+
+    /// Where that sample sits on the timeline, and on the count no wrap takes
+    /// back. A run is placed by the first and measured by the second.
+    double timelineBeat = 0.0;
+    double monotonicBeat = 0.0;
+};
+
+/**
+ * @brief The lane those edges travel down, audio thread to publishing thread.
+ *
+ * A fixed ring, so neither side allocates. The reverse direction of
+ * LaunchRequests.hpp and the same shape: a full ring drops the edge and counts
+ * it rather than writing over one nobody has read.
+ */
+class SlotRunQueue {
+    static_assert(std::atomic<std::uint64_t>::is_always_lock_free,
+                  "a run lane's cursors are written on the audio thread and must not take a lock");
+
+  public:
+    /// Outstanding edges, not lifetime ones: a bound on what a scene launch and
+    /// the frame it lands in can put between two drains.
+    static constexpr int kCapacity = 512;
+
+    /// @brief Publish @p event. Audio thread.
+    void push(const SlotRunEvent& event) {
+        const auto at = written_.load(std::memory_order_relaxed);
+
+        if (at - consumed_.load(std::memory_order_acquire) >=
+            static_cast<std::uint64_t>(kCapacity)) {
+            overflows_.fetch_add(1, std::memory_order_relaxed);
+            return;
+        }
+
+        ring_[static_cast<std::size_t>(at % kCapacity)] = event;
+        written_.store(at + 1, std::memory_order_release);
+    }
+
+    /**
+     * @brief Read everything published since the last call, in order.
+     *
+     * On the publishing thread. @p fn is called once per edge.
+     */
+    template <typename Fn> void drain(const Fn& fn) {
+        const auto end = written_.load(std::memory_order_acquire);
+
+        for (auto at = read_; at != end; ++at)
+            fn(ring_[static_cast<std::size_t>(at % kCapacity)]);
+
+        read_ = end;
+        consumed_.store(read_, std::memory_order_release);
+    }
+
+    /// Edges the ring had no room for. Above zero and a capture is missing a
+    /// run; counted rather than left silent, like every other overflow here.
+    int overflows() const {
+        return overflows_.load(std::memory_order_relaxed);
+    }
+
+  private:
+    std::array<SlotRunEvent, kCapacity> ring_{};
+
+    /// Written by the audio thread, read by the publishing thread.
+    std::atomic<std::uint64_t> written_{0};
+
+    /// Published by the reader, and what stops the writer overwriting an edge
+    /// that has not been read.
+    std::atomic<std::uint64_t> consumed_{0};
+
+    /// The reader's own cursor.
+    std::uint64_t read_ = 0;
+
+    std::atomic<int> overflows_{0};
+};
+
+}  // namespace magda::engine

--- a/magda/engine/launch/SlotRuns.hpp
+++ b/magda/engine/launch/SlotRuns.hpp
@@ -54,6 +54,8 @@ struct SlotRunEvent {
 class SlotRunQueue {
     static_assert(std::atomic<std::uint64_t>::is_always_lock_free,
                   "a run lane's cursors are written on the audio thread and must not take a lock");
+    static_assert(std::atomic<double>::is_always_lock_free,
+                  "the lane's watermark is written on the audio thread as well");
 
   public:
     /// Outstanding edges, not lifetime ones: a bound on what a scene launch and
@@ -89,6 +91,24 @@ class SlotRunQueue {
         consumed_.store(read_, std::memory_order_release);
     }
 
+    /**
+     * @brief Say every edge up to @p monotonicBeat has been published.
+     *
+     * Audio thread, once a block, after that block's edges. What a capture ends
+     * a run at when it is disarmed: read after a drain, it cannot be a beat
+     * whose edges the capture has not seen, which is what makes a boundary
+     * ordered against the lane rather than a second clock to disagree with it
+     * (#2464 review).
+     */
+    void reachedBeat(double monotonicBeat) {
+        reached_.store(monotonicBeat, std::memory_order_release);
+    }
+
+    /// The beat @ref reachedBeat last named. Publishing thread, after a drain.
+    double reached() const {
+        return reached_.load(std::memory_order_acquire);
+    }
+
     /// Edges the ring had no room for. Above zero and a capture is missing a
     /// run; counted rather than left silent, like every other overflow here.
     int overflows() const {
@@ -107,6 +127,9 @@ class SlotRunQueue {
 
     /// The reader's own cursor.
     std::uint64_t read_ = 0;
+
+    /// How far the audio thread has reported, in monotonic beats.
+    std::atomic<double> reached_{0.0};
 
     std::atomic<int> overflows_{0};
 };

--- a/magda/engine/launch/SlotRuns.hpp
+++ b/magda/engine/launch/SlotRuns.hpp
@@ -77,11 +77,20 @@ class SlotRunQueue {
     }
 
     /**
-     * @brief Read everything published since the last call, in order.
+     * @brief Read everything published since the last call, and say how far the
+     *        lane has been reported.
      *
-     * On the publishing thread. @p fn is called once per edge.
+     * On the publishing thread. @p fn is called once per edge, in order.
+     *
+     * The beat comes back from here rather than being read beside a drain,
+     * because a drain takes its cursor once: a beat read after that cursor can
+     * be a block newer than what was consumed, and a capture ending a run at it
+     * would run past an end still queued. Read before the cursor, every edge up
+     * to it is taken by this same drain, and anything this drain missed happened
+     * after it (#2464 review).
      */
-    template <typename Fn> void drain(const Fn& fn) {
+    template <typename Fn> double drain(const Fn& fn) {
+        const auto until = reached_.load(std::memory_order_acquire);
         const auto end = written_.load(std::memory_order_acquire);
 
         for (auto at = read_; at != end; ++at)
@@ -89,24 +98,19 @@ class SlotRunQueue {
 
         read_ = end;
         consumed_.store(read_, std::memory_order_release);
+        return until;
     }
 
     /**
      * @brief Say every edge up to @p monotonicBeat has been published.
      *
      * Audio thread, once a block, after that block's edges. What a capture ends
-     * a run at when it is disarmed: read after a drain, it cannot be a beat
-     * whose edges the capture has not seen, which is what makes a boundary
-     * ordered against the lane rather than a second clock to disagree with it
-     * (#2464 review).
+     * a run at when it is disarmed, and it is handed out by @ref drain alone:
+     * pairing it with a drain is the whole of the contract, so there is no
+     * accessor for it to be paired with anything else.
      */
     void reachedBeat(double monotonicBeat) {
         reached_.store(monotonicBeat, std::memory_order_release);
-    }
-
-    /// The beat @ref reachedBeat last named. Publishing thread, after a drain.
-    double reached() const {
-        return reached_.load(std::memory_order_acquire);
     }
 
     /// Edges the ring had no room for. Above zero and a capture is missing a

--- a/magda/engine/tap/RecordTap.hpp
+++ b/magda/engine/tap/RecordTap.hpp
@@ -34,7 +34,7 @@
 
 namespace magda::engine {
 
-/// Where the pass is going. Slice 6 (#2464) is what fills in the slot half.
+/// Where the pass is going: an arrangement take, or a session slot's (#2464).
 enum class RecordTarget : std::uint8_t { arrangement, slot };
 
 /// What the pass is made of, and so what a reader draws.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -409,6 +409,9 @@ if(MAGDA_BUILD_NATIVE_ENGINE)
     # What ends a slot's run and what starts next (#2304), and that a launch
     # the engine made reads out exactly as a clicked one does.
     list(APPEND TEST_SOURCES engine/test_follow_actions.cpp)
+    # What the session played, placed from the launcher's own edges (#2464):
+    # the beat a run began on, a scene as one event, and a run across a wrap.
+    list(APPEND TEST_SOURCES engine/test_session_capture.cpp)
     list(APPEND TEST_SOURCES audio/test_click_generator.cpp)
     list(APPEND TEST_SOURCES audio/test_prefetch_stream.cpp)
     list(APPEND TEST_SOURCES audio/test_source_readers.cpp)

--- a/tests/engine/test_clip_snapshot.cpp
+++ b/tests/engine/test_clip_snapshot.cpp
@@ -849,3 +849,101 @@ TEST_CASE("Two session snapshots that differ do not dump alike", "[engine][clip]
     CHECK(inScene0 != inScene4);
     CHECK(inScene0 != shorter);
 }
+
+TEST_CASE("An armed empty slot is a record target of its own (#2464)", "[engine][clip][session]") {
+    // An empty slot is the only kind you can record into, and it needs an entry
+    // in the snapshot to get a launch handle at all.
+    ClipLane lane;
+    lane.trackId = kTrack;
+    lane.session.push_back(makeSessionClip(1, 0, 0.0, 4.0));
+    lane.session.push_back(makeSessionClip(2, 4, 0.0, 4.0));
+    lane.recordSlots = {2};
+
+    const auto snapshot = compileClipSnapshot({lane}, makeSources(), makeTempoMap());
+
+    REQUIRE(snapshot.tracks.size() == 1);
+    const auto& track = snapshot.tracks.front();
+    REQUIRE(track.session.size() == 3);
+
+    // Sorted in among the slots that hold clips, not appended behind them.
+    CHECK(track.session[0].sceneIndex == 0);
+    CHECK(track.session[1].sceneIndex == 2);
+    CHECK(track.session[2].sceneIndex == 4);
+
+    const auto* slot = track.slot(2);
+    REQUIRE(slot != nullptr);
+    CHECK(slot->recordTarget);
+    CHECK(slot->audio.empty());
+    CHECK(slot->midi.empty());
+
+    CHECK_FALSE(track.slot(0)->recordTarget);
+    CHECK_FALSE(track.slot(4)->recordTarget);
+    CHECK(snapshot.diagnostics.empty());
+}
+
+TEST_CASE("A track whose only content is a record target is still a track (#2464)",
+          "[engine][clip][session]") {
+    ClipLane lane;
+    lane.trackId = kTrack;
+    lane.recordSlots = {1};
+
+    const auto snapshot = compileClipSnapshot({lane}, makeSources(), makeTempoMap());
+
+    REQUIRE(snapshot.tracks.size() == 1);
+    const auto& track = snapshot.tracks.front();
+    CHECK(track.audio.empty());
+    CHECK(track.midi.empty());
+    REQUIRE(track.session.size() == 1);
+    CHECK(track.session.front().sceneIndex == 1);
+    CHECK(track.session.front().recordTarget);
+}
+
+TEST_CASE("A scene armed twice is one record target (#2464)", "[engine][clip][session]") {
+    ClipLane lane;
+    lane.trackId = kTrack;
+    lane.recordSlots = {2, 2};
+
+    const auto snapshot = compileClipSnapshot({lane}, makeSources(), makeTempoMap());
+
+    REQUIRE(snapshot.tracks.size() == 1);
+    REQUIRE(snapshot.tracks.front().session.size() == 1);
+    CHECK(snapshot.tracks.front().session.front().sceneIndex == 2);
+    CHECK(snapshot.tracks.front().session.front().recordTarget);
+    CHECK(snapshot.diagnostics.empty());
+}
+
+TEST_CASE("What a record target cannot be says so (#2464)", "[engine][clip][session]") {
+    SECTION("an armed slot that already holds a clip is left alone") {
+        ClipLane lane;
+        lane.trackId = kTrack;
+        lane.session.push_back(makeSessionClip(1, 3, 0.0, 4.0));
+        lane.recordSlots = {3};
+
+        const auto snapshot = compileClipSnapshot({lane}, makeSources(), makeTempoMap());
+
+        REQUIRE(snapshot.tracks.size() == 1);
+        const auto& track = snapshot.tracks.front();
+        REQUIRE(track.session.size() == 1);
+
+        const auto* slot = track.slot(3);
+        REQUIRE(slot != nullptr);
+        CHECK_FALSE(slot->recordTarget);
+        REQUIRE(slot->audio.size() == 1);
+        CHECK(slot->audio.front().clipId == 1);
+
+        REQUIRE(snapshot.diagnostics.size() == 1);
+        CHECK(snapshot.diagnostics.front().find("already holds a clip") != std::string::npos);
+    }
+
+    SECTION("an armed slot in no scene is reported") {
+        ClipLane lane;
+        lane.trackId = kTrack;
+        lane.recordSlots = {-1};
+
+        const auto snapshot = compileClipSnapshot({lane}, makeSources(), makeTempoMap());
+
+        CHECK(snapshot.tracks.empty());
+        REQUIRE(snapshot.diagnostics.size() == 1);
+        CHECK(snapshot.diagnostics.front().find("no scene") != std::string::npos);
+    }
+}

--- a/tests/engine/test_launch_handle.cpp
+++ b/tests/engine/test_launch_handle.cpp
@@ -693,3 +693,71 @@ TEST_CASE("A synced launch joins the run as the rate left it", "[launch][2336]")
     CHECK(following.afterEvent->origin->beat == Approx(leading.beforeEvent.origin->beat));
     CHECK(following.afterEvent->origin->seconds == Approx(leading.beforeEvent.origin->seconds));
 }
+
+TEST_CASE("A block reports where a run began and where one ended", "[launch]") {
+    // What a take of a slot starts and stops on (#2464). Both edges are on the
+    // sample the block ran into, which is what the split is cut at.
+    LaunchHandle handle;
+
+    SECTION("a launch inside a block begins a run there") {
+        handle.play(0.5);
+        const auto status = handle.advance(block(0.0, 1.0));
+
+        REQUIRE(status.runBeganAt.has_value());
+        CHECK(status.runBeganAt->value == status.event.sample);
+        CHECK(status.runBeganAt->value == samplesFor(0.5));
+        CHECK_FALSE(status.runEndedAt.has_value());
+    }
+
+    SECTION("a stop inside a block ends it there") {
+        handle.play(0.0);
+        handle.advance(block(0.0, 1.0));
+
+        handle.stop(1.5);
+        const auto status = handle.advance(block(1.0, 2.0));
+
+        REQUIRE(status.runEndedAt.has_value());
+        CHECK(status.runEndedAt->value == samplesFor(0.5));
+        CHECK_FALSE(status.runBeganAt.has_value());
+    }
+
+    SECTION("a re-launch ends one run and begins another on the same sample") {
+        handle.play(0.0);
+        handle.advance(block(0.0, 1.0));
+
+        handle.play(1.25);
+        const auto status = handle.advance(block(1.0, 2.0));
+
+        REQUIRE(status.runEndedAt.has_value());
+        REQUIRE(status.runBeganAt.has_value());
+        CHECK(status.runEndedAt->value == samplesFor(0.25));
+        CHECK(status.runBeganAt->value == samplesFor(0.25));
+
+        // Which is a second take rather than a longer one: the run it began is
+        // not the run it ended.
+        REQUIRE(handle.playedSampleRange().has_value());
+        CHECK(handle.playedSampleRange()->start == at(1.25));
+    }
+
+    SECTION("a loop re-trigger is a run ending and another beginning") {
+        handle.play(0.0);
+        handle.setLooping(2.0);
+        handle.advance(block(0.0, 1.0));
+
+        const auto status = handle.advance(block(1.0, 3.0));
+
+        REQUIRE(status.runEndedAt.has_value());
+        REQUIRE(status.runBeganAt.has_value());
+        CHECK(status.runBeganAt->value == samplesFor(1.0));
+    }
+
+    SECTION("a block that ran into nothing reports neither") {
+        handle.play(0.0);
+        handle.advance(block(0.0, 1.0));
+
+        const auto status = handle.advance(block(1.0, 2.0));
+
+        CHECK_FALSE(status.runBeganAt.has_value());
+        CHECK_FALSE(status.runEndedAt.has_value());
+    }
+}

--- a/tests/engine/test_launch_handle_lifetime.cpp
+++ b/tests/engine/test_launch_handle_lifetime.cpp
@@ -31,7 +31,7 @@ ClipSnapshot snapshotWithScenes(const std::vector<int>& scenes, TrackId trackId 
     TrackClipPlayback track;
     track.trackId = trackId;
     for (const auto scene : scenes)
-        track.session.push_back(SessionSlotPlayback{scene, {}, {}, 4.0});
+        track.session.push_back(SessionSlotPlayback{.sceneIndex = scene, .lengthBeats = 4.0});
     snapshot.tracks.push_back(std::move(track));
     return snapshot;
 }

--- a/tests/engine/test_launch_handle_lifetime.cpp
+++ b/tests/engine/test_launch_handle_lifetime.cpp
@@ -1,4 +1,5 @@
 #include <catch2/catch_test_macros.hpp>
+#include <vector>
 
 #include "clip/ClipSnapshot.hpp"
 #include "core/TrackInfo.hpp"
@@ -127,4 +128,33 @@ TEST_CASE("A plan publish is not what retires a handle", "[engine][session][laun
     CHECK(store.releaseDeleted(empty, nothing, nullptr) == 0);
     CHECK(store.size() == before);
     CHECK(store.findHandle(SlotKey{kTrack, 0}) != nullptr);
+}
+
+TEST_CASE("A retired handle's run ends where it had got to", "[engine][session][launch]") {
+    // The end no block can report (#2464): the handle goes with the publish, so
+    // a capture reading only the audio thread's edges would have a run that
+    // never ended.
+    NoFactory factory;
+    RuntimeStateStore store(factory);
+    LaunchHandleFeed feed;
+    LaunchRequestQueue requests;
+
+    std::vector<SlotRunEvent> retired;
+    store.publishHandles(snapshotWithScenes({0, 2}), feed, requests, &retired);
+
+    auto* playing = store.findHandle(SlotKey{kTrack, 0});
+    REQUIRE(playing != nullptr);
+    launch(*playing);
+
+    // Scene 0 is emptied, scene 2 is left alone and was never launched.
+    store.publishHandles(snapshotWithScenes({2}), feed, requests, &retired);
+
+    REQUIRE(retired.size() == 1);
+    CHECK(retired.front().key == SlotKey{kTrack, 0});
+    CHECK(retired.front().kind == SlotRunEvent::Kind::ended);
+    CHECK(retired.front().incarnation != 0);
+
+    // Where the run had been advanced to, on both faces.
+    CHECK(retired.front().monotonicBeat == 2.0);
+    CHECK(retired.front().at == SamplePosition{48000});
 }

--- a/tests/engine/test_midi_take_recorder.cpp
+++ b/tests/engine/test_midi_take_recorder.cpp
@@ -6,6 +6,7 @@
 #include <cstdint>
 #include <map>
 #include <memory>
+#include <optional>
 #include <utility>
 #include <vector>
 
@@ -266,8 +267,8 @@ class SlotRig {
         gesture.play(kSlot, beat);
     }
 
-    /// Stop it on monotonic beat @p beat.
-    void stopSlot(double beat) {
+    /// Stop it on monotonic beat @p beat, or nothing for the next sample.
+    void stopSlot(std::optional<double> beat = {}) {
         LaunchRequestQueue::Gesture gesture(requests_);
         gesture.stop(kSlot, beat);
     }
@@ -275,7 +276,14 @@ class SlotRig {
     /// Callbacks until the input has delivered @p sample samples.
     void runTo(std::int64_t sample) {
         while (arrival_ < sample)
-            deliver();
+            deliver(true);
+    }
+
+    /// @p blocks callbacks the transport does not roll: the input keeps
+    /// arriving and the timeline stands still.
+    void runStopped(int blocks) {
+        for (auto at = 0; at < blocks; ++at)
+            deliver(false);
     }
 
     MidiTakeRecorder& recorder() {
@@ -306,7 +314,20 @@ class SlotRig {
         return block;
     }
 
-    void deliver() {
+    /// The same block the transport would pass with nothing rolling: every
+    /// range empty at the cursor, so no face of it advances.
+    BlockInfo stoppedAt(std::int64_t startSample) const {
+        auto block = blockAt(startSample);
+        block.playing = false;
+        block.beats.end = block.beats.start;
+        block.monotonicBeats.end = block.monotonicBeats.start;
+        block.seconds.end = block.seconds.start;
+        block.monotonicSeconds.end = block.monotonicSeconds.start;
+        block.monotonicSamples.end = block.monotonicSamples.start;
+        return block;
+    }
+
+    void deliver(bool playing) {
         juce::MidiBuffer arriving;
         for (const auto& event : schedule_)
             if (event.arrival >= arrival_ && event.arrival < arrival_ + kBlockSize)
@@ -320,12 +341,16 @@ class SlotRig {
 
         // The order the audio thread runs them in: every handle is advanced
         // over the block before anything reads what its run did.
-        const auto block = blockAt(arrival_);
+        const auto block = playing ? blockAt(position_) : stoppedAt(position_);
         advanceLaunchHandles(handles_, requests_, block);
         recorder_->capture(block, false, {});
 
         feed_.endCallback();
         arrival_ += kBlockSize;
+
+        // Only a rolling block moves the timeline the blocks are cut from.
+        if (playing)
+            position_ += kBlockSize;
     }
 
     TempoMap tempo_ = flat();
@@ -342,6 +367,9 @@ class SlotRig {
 
     /// Input samples delivered so far, which the schedule is numbered by.
     std::int64_t arrival_ = 0;
+
+    /// Where the transport has rolled to, which a stopped block leaves alone.
+    std::int64_t position_ = 0;
 };
 
 }  // namespace
@@ -759,6 +787,32 @@ TEST_CASE("A note still down when the run ends is closed where it ended",
     REQUIRE(take.active.notes.size() == 1);
     CHECK(take.active.notes[0].startBeat == Catch::Approx(1.0));
     CHECK(take.active.notes[0].lengthBeats == Catch::Approx(0.5));
+}
+
+TEST_CASE("A slot stop asked for while the transport is stopped ends the take",
+          "[engine][io][record][midi][2464]") {
+    // The block that applies the stop is the only one that reports it, and a
+    // stopped transport is where that block is. A take that skipped stopped
+    // blocks would keep rolling and record again on the resume.
+    SlotRig rig;
+    rig.schedule({noteOn(kBeatSamples + 1000, 60), noteOff(kBeatSamples + 1500, 60),
+                  noteOn(kBeatSamples * 3, 64), noteOff((kBeatSamples * 3) + 500, 64)});
+    rig.launch(1.0);
+    rig.runTo(kBeatSamples * 2);
+
+    rig.stopSlot();
+    rig.runStopped(4);
+
+    CHECK_FALSE(rig.recorder().rolling());
+
+    rig.runTo(kBeatSamples * 4);
+
+    // The note played after the resume belongs to no run of this slot.
+    const auto take = rig.finish();
+    REQUIRE(take.active.notes.size() == 1);
+    CHECK(take.active.notes[0].noteNumber == 60);
+    CHECK(take.startBeat == Catch::Approx(1.0));
+    CHECK(take.lengthBeats == Catch::Approx(1.0));
 }
 
 TEST_CASE("A re-launch after the run ended does not extend the take",

--- a/tests/engine/test_midi_take_recorder.cpp
+++ b/tests/engine/test_midi_take_recorder.cpp
@@ -4,6 +4,7 @@
 #include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <cstdint>
+#include <map>
 #include <memory>
 #include <utility>
 #include <vector>
@@ -11,6 +12,7 @@
 #include "exec/RenderContext.hpp"
 #include "io/LiveInput.hpp"
 #include "io/MidiTakeRecorder.hpp"
+#include "launch/SessionLauncher.hpp"
 #include "tap/RecordTap.hpp"
 #include "transport/TempoMap.hpp"
 #include "transport/TransportClock.hpp"
@@ -25,7 +27,13 @@
  */
 
 using magda::MidiCurveType;
+using magda::engine::advanceLaunchHandles;
+using magda::engine::BlockInfo;
 using magda::engine::kAnyLiveMidiSource;
+using magda::engine::LaunchHandle;
+using magda::engine::LaunchHandleFeed;
+using magda::engine::LaunchHandleTable;
+using magda::engine::LaunchRequestQueue;
 using magda::engine::LiveInputBlock;
 using magda::engine::LiveInputFeed;
 using magda::engine::LiveMidiInput;
@@ -34,6 +42,9 @@ using magda::engine::LoopRange;
 using magda::engine::MidiTakeRecorder;
 using magda::engine::MidiTakeRecorderSettings;
 using magda::engine::RecordedMidiTake;
+using magda::engine::SamplePosition;
+using magda::engine::SlotKey;
+using magda::engine::SlotRunTarget;
 using magda::engine::TempoMap;
 using magda::engine::TransportClock;
 using magda::engine::TransportSnapshot;
@@ -214,6 +225,123 @@ class Rig {
     std::int64_t arrival_ = 0;
 
     bool drains_ = false;
+};
+
+/// The one slot every case below launches, and the handle it is published on.
+constexpr SlotKey kSlot{1, 0};
+constexpr std::uint64_t kIncarnation = 1;
+
+/**
+ * @brief A launcher over one slot, a scheduled input, and a take of its run.
+ *
+ * Blocks are hand-built and always kBlockSize long, so a launch quantized to a
+ * beat lands where the beat does rather than on a callback boundary (#2464).
+ */
+class SlotRig {
+  public:
+    explicit SlotRig(int latencySamples = 0) {
+        feed_.prepare(0, kBlockSize);
+
+        auto table = std::make_shared<LaunchHandleTable>();
+        table->entries.push_back(LaunchHandleTable::Entry{
+            .key = kSlot, .handle = &handle_, .incarnation = kIncarnation});
+
+        handles_.publish(std::move(table));
+        requests_.setIncarnations({{kSlot, kIncarnation}});
+
+        auto settings = takeOf(latencySamples);
+        settings.slot =
+            SlotRunTarget{.handles = &handles_, .key = kSlot, .incarnation = kIncarnation};
+
+        recorder_ = std::make_unique<MidiTakeRecorder>(feed_, tap_, settings);
+    }
+
+    void schedule(std::vector<Played> events) {
+        schedule_ = std::move(events);
+    }
+
+    /// Start the slot on monotonic beat @p beat.
+    void launch(double beat) {
+        LaunchRequestQueue::Gesture gesture(requests_);
+        gesture.play(kSlot, beat);
+    }
+
+    /// Stop it on monotonic beat @p beat.
+    void stopSlot(double beat) {
+        LaunchRequestQueue::Gesture gesture(requests_);
+        gesture.stop(kSlot, beat);
+    }
+
+    /// Callbacks until the input has delivered @p sample samples.
+    void runTo(std::int64_t sample) {
+        while (arrival_ < sample)
+            deliver();
+    }
+
+    MidiTakeRecorder& recorder() {
+        return *recorder_;
+    }
+
+    RecordedMidiTake finish() {
+        return recorder_->finish(tempo_);
+    }
+
+  private:
+    BlockInfo blockAt(std::int64_t startSample) const {
+        const auto endSample = startSample + kBlockSize;
+
+        BlockInfo block;
+        block.numSamples = kBlockSize;
+        block.sampleRate = kSampleRate;
+        block.playing = true;
+        block.continuous = startSample != 0;
+        block.tempo = &tempo_;
+        block.monotonicSamples = {SamplePosition{startSample}, SamplePosition{endSample}};
+        block.seconds = {static_cast<double>(startSample) / kSampleRate,
+                         static_cast<double>(endSample) / kSampleRate};
+        block.monotonicSeconds = block.seconds;
+        block.beats = {static_cast<double>(startSample) / kBeatSamples,
+                       static_cast<double>(endSample) / kBeatSamples};
+        block.monotonicBeats = block.beats;
+        return block;
+    }
+
+    void deliver() {
+        juce::MidiBuffer arriving;
+        for (const auto& event : schedule_)
+            if (event.arrival >= arrival_ && event.arrival < arrival_ + kBlockSize)
+                arriving.addEvent(event.message, static_cast<int>(event.arrival - arrival_));
+
+        const std::array streams{LiveMidiStream{0, &arriving}};
+        const LiveInputBlock input{{}, streams};
+
+        feed_.beginCallback(input, kBlockSize);
+        feed_.beginSegment(0, kBlockSize);
+
+        // The order the audio thread runs them in: every handle is advanced
+        // over the block before anything reads what its run did.
+        const auto block = blockAt(arrival_);
+        advanceLaunchHandles(handles_, requests_, block);
+        recorder_->capture(block, false, {});
+
+        feed_.endCallback();
+        arrival_ += kBlockSize;
+    }
+
+    TempoMap tempo_ = flat();
+
+    LiveInputFeed feed_;
+    LaunchHandle handle_;
+    LaunchHandleFeed handles_;
+    LaunchRequestQueue requests_;
+
+    magda::engine::RecordTap tap_{magda::engine::RecordMaterial::midi, {}};
+    std::unique_ptr<MidiTakeRecorder> recorder_;
+
+    std::vector<Played> schedule_;
+
+    /// Input samples delivered so far, which the schedule is numbered by.
+    std::int64_t arrival_ = 0;
 };
 
 }  // namespace
@@ -561,4 +689,97 @@ TEST_CASE("A take that never rolled is empty", "[engine][io][record][midi][2462]
     CHECK(take.active.notes.empty());
     CHECK(take.clip.takes.empty());
     CHECK(take.lengthBeats == 0.0);
+}
+
+TEST_CASE("A slot take begins on the beat its launch was quantized to",
+          "[engine][io][record][midi][2464]") {
+    // Beat 1 is 32 samples into the block that holds it, so a take starting on
+    // the block boundary is a different answer from one starting on the beat.
+    SlotRig rig;
+    rig.schedule({noteOn(kBeatSamples + 1000, 60), noteOff(kBeatSamples + 1500, 60)});
+    rig.launch(1.0);
+    rig.runTo(kBeatSamples * 3);
+
+    const auto take = rig.finish();
+    REQUIRE_FALSE(take.empty());
+    CHECK(take.startBeat == Catch::Approx(1.0));
+
+    REQUIRE(take.active.notes.size() == 1);
+    CHECK(take.active.notes[0].noteNumber == 60);
+    CHECK(take.active.notes[0].startBeat == Catch::Approx(0.25));
+    CHECK(take.active.notes[0].lengthBeats == Catch::Approx(0.125));
+}
+
+TEST_CASE("A note played before the launch instant is not in the slot take",
+          "[engine][io][record][midi][2464]") {
+    // Both in the block the launch cuts, on the side of it the run had not
+    // started on.
+    SlotRig rig;
+    rig.schedule({noteOn(kBeatSamples - 20, 60), noteOff(kBeatSamples - 10, 60),
+                  noteOn(kBeatSamples + 1000, 62), noteOff(kBeatSamples + 1500, 62)});
+    rig.launch(1.0);
+    rig.runTo(kBeatSamples * 3);
+
+    const auto take = rig.finish();
+    REQUIRE(take.active.notes.size() == 1);
+    CHECK(take.active.notes[0].noteNumber == 62);
+}
+
+TEST_CASE("A run that ends inside a block ends the take there",
+          "[engine][io][record][midi][2464]") {
+    // Beat 2.5 is 16 samples into its block: one note each side of it.
+    SlotRig rig;
+    rig.schedule({noteOn(9990, 60), noteOff(9995, 60), noteOn(10010, 64), noteOff(10020, 64)});
+    rig.launch(1.0);
+    rig.runTo(kBeatSamples * 2);
+    rig.stopSlot(2.5);
+    rig.runTo(kBeatSamples * 3);
+
+    CHECK_FALSE(rig.recorder().rolling());
+
+    const auto take = rig.finish();
+    REQUIRE(take.active.notes.size() == 1);
+    CHECK(take.active.notes[0].noteNumber == 60);
+
+    // Beat 1 to beat 2.5, rather than to the end of the block the run ended in.
+    CHECK(take.startBeat == Catch::Approx(1.0));
+    CHECK(take.lengthBeats == Catch::Approx(1.5));
+}
+
+TEST_CASE("A note still down when the run ends is closed where it ended",
+          "[engine][io][record][midi][2464]") {
+    SlotRig rig;
+    rig.schedule({noteOn(kBeatSamples * 2, 62)});
+    rig.launch(1.0);
+    rig.runTo(kBeatSamples * 2);
+    rig.stopSlot(2.5);
+    rig.runTo(kBeatSamples * 3);
+
+    const auto take = rig.finish();
+    REQUIRE(take.active.notes.size() == 1);
+    CHECK(take.active.notes[0].startBeat == Catch::Approx(1.0));
+    CHECK(take.active.notes[0].lengthBeats == Catch::Approx(0.5));
+}
+
+TEST_CASE("A re-launch after the run ended does not extend the take",
+          "[engine][io][record][midi][2464]") {
+    // Beat 3.5, which is a second run and so a second take.
+    constexpr int kRelaunch = kBeatSamples * 7 / 2;
+
+    SlotRig rig;
+    rig.schedule({noteOn(kBeatSamples + 1000, 60), noteOff(kBeatSamples + 1500, 60),
+                  noteOn(kRelaunch + 1000, 64), noteOff(kRelaunch + 1500, 64)});
+    rig.launch(1.0);
+    rig.runTo(kBeatSamples * 2);
+    rig.stopSlot(2.5);
+    rig.runTo(kBeatSamples * 3);
+    rig.launch(3.5);
+    rig.runTo(kBeatSamples * 5);
+
+    CHECK_FALSE(rig.recorder().rolling());
+
+    const auto take = rig.finish();
+    REQUIRE(take.active.notes.size() == 1);
+    CHECK(take.active.notes[0].noteNumber == 60);
+    CHECK(take.lengthBeats == Catch::Approx(1.5));
 }

--- a/tests/engine/test_session_capture.cpp
+++ b/tests/engine/test_session_capture.cpp
@@ -1,10 +1,12 @@
 #include <algorithm>
+#include <atomic>
 #include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <cstdint>
 #include <map>
 #include <memory>
 #include <ranges>
+#include <thread>
 #include <vector>
 
 #include "launch/SessionCapture.hpp"
@@ -254,6 +256,62 @@ TEST_CASE("arming after a launch keeps the beat the run began on", "[engine][cap
     CHECK(captured.front().lengthBeats == Approx(4.0).margin(2.0 / kBeatSamples));
 }
 
+TEST_CASE("an end that overtook its own launch still closes it", "[engine][capture]") {
+    // A slot launched on the audio thread and deleted before the capture drained
+    // the launch: the retirement is stamped on this thread and arrives first.
+    // Dropping it left the run sounding for ever (#2464 review).
+    Rig rig;
+    rig.capture().arm();
+    rig.play();
+    rig.launch(1, 1.0);
+    rig.roll(4.0, false);
+
+    rig.capture().apply(SlotRunEvent{.key = SlotKey{1, 0},
+                                     .kind = SlotRunEvent::Kind::ended,
+                                     .incarnation = 1,
+                                     .monotonicBeat = 4.0});
+
+    // Nothing to close yet: the launch is still in the lane.
+    CHECK(rig.capture().sounding() == 0);
+
+    rig.capture().update();
+
+    CHECK(rig.capture().sounding() == 0);
+
+    const auto captured = rig.capture().collect();
+    REQUIRE(captured.size() == 1);
+    CHECK(captured.front().startBeat == Approx(1.0).margin(1.0 / kBeatSamples));
+    CHECK(captured.front().lengthBeats == Approx(3.0).margin(1.0 / kBeatSamples));
+}
+
+TEST_CASE("a waiting end closes the run the lane left in flight", "[engine][capture]") {
+    // Two launches of one handle queued together, then the end of the second.
+    // Closing the first one instead would place a span over both runs and leave
+    // the second sounding.
+    Rig rig;
+    rig.capture().arm();
+    rig.play();
+    rig.launch(1, 1.0);
+    rig.roll(2.0, false);
+    rig.launch(1, 3.0);
+    rig.roll(2.0, false);
+
+    rig.capture().apply(SlotRunEvent{.key = SlotKey{1, 0},
+                                     .kind = SlotRunEvent::Kind::ended,
+                                     .incarnation = 1,
+                                     .monotonicBeat = 5.0});
+    rig.capture().update();
+
+    CHECK(rig.capture().sounding() == 0);
+
+    const auto captured = rig.capture().collect();
+    REQUIRE(captured.size() == 2);
+    CHECK(captured[0].startBeat == Approx(1.0).margin(1.0 / kBeatSamples));
+    CHECK(captured[0].lengthBeats == Approx(2.0).margin(1.0 / kBeatSamples));
+    CHECK(captured[1].startBeat == Approx(3.0).margin(1.0 / kBeatSamples));
+    CHECK(captured[1].lengthBeats == Approx(2.0).margin(1.0 / kBeatSamples));
+}
+
 TEST_CASE("disarming takes the edges before it reads the boundary", "[engine][capture]") {
     // The run stopped on its own two beats before the button was pressed, and
     // its end was still in the lane. A boundary read first would have stretched
@@ -370,4 +428,93 @@ TEST_CASE("disarming ends what is still sounding", "[engine][capture]") {
     rig.stopSlot(1, 6.0);
     rig.roll(3.0);
     CHECK(rig.capture().collect().empty());
+}
+
+TEST_CASE("A captured span never runs past the end its run had", "[engine][capture]") {
+    // The boundary a disarm ends a run at is handed out by the drain that took
+    // the edges, so it can never be a beat whose end is still queued. A beat
+    // read beside the drain instead can be a block newer than the cursor the
+    // drain took, and a run finished at it overshoots (#2464 review).
+    //
+    // One writer publishing runs of a known length while a reader disarms and
+    // re-arms, which is the interleaving that argument turns on. Following
+    // test_record_tap.cpp, which pins its own read protocol the same way.
+    constexpr int kRuns = 20000;
+
+    /// What each run sounds for, and how far apart their launches are.
+    constexpr double kSpan = 3.0;
+    constexpr double kApart = 10.0;
+
+    /// How far the writer may run ahead, in beats: well inside the ring, so no
+    /// edge is ever dropped and a missing end cannot be mistaken for a bug.
+    constexpr double kAhead = 100.0;
+
+    const SlotKey slot{1, 0};
+
+    SlotRunQueue lane;
+    SessionCapture capture(lane);
+    capture.arm();
+
+    std::atomic<bool> publishing{true};
+    std::atomic<double> taken{0.0};
+
+    std::thread audio([&] {
+        for (auto run = 0; run < kRuns; ++run) {
+            const auto at = static_cast<double>(run) * kApart;
+
+            while (at - taken.load(std::memory_order_relaxed) > kAhead)
+                std::this_thread::yield();
+
+            // A block's edges, then the beat that block reached: the order the
+            // launcher publishes them in.
+            lane.push(SlotRunEvent{.key = slot,
+                                   .kind = SlotRunEvent::Kind::began,
+                                   .incarnation = 1,
+                                   .timelineBeat = at,
+                                   .monotonicBeat = at});
+            lane.reachedBeat(at);
+            std::this_thread::yield();
+
+            lane.push(SlotRunEvent{.key = slot,
+                                   .kind = SlotRunEvent::Kind::ended,
+                                   .incarnation = 1,
+                                   .monotonicBeat = at + kSpan});
+            lane.reachedBeat(at + kSpan);
+            std::this_thread::yield();
+        }
+
+        publishing.store(false);
+    });
+
+    auto seen = 0;
+
+    // The longest span rather than an assertion per span: a failure while the
+    // writer is still running would take the whole binary down with it.
+    auto longest = 0.0;
+
+    const auto take = [&] {
+        for (const auto& span : capture.collect()) {
+            ++seen;
+            longest = std::max(longest, span.lengthBeats);
+        }
+    };
+
+    while (publishing.load()) {
+        capture.disarm();
+        capture.arm();
+        taken.store(capture.reached(), std::memory_order_relaxed);
+        take();
+    }
+
+    audio.join();
+
+    capture.update();
+    take();
+
+    CHECK(lane.overflows() == 0);
+    CHECK(seen > 0);
+
+    // A run sounded for kSpan and no longer, whether a span is the whole of it
+    // or the part a disarm cut off.
+    CHECK(longest <= kSpan);
 }

--- a/tests/engine/test_session_capture.cpp
+++ b/tests/engine/test_session_capture.cpp
@@ -1,0 +1,287 @@
+#include <algorithm>
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <vector>
+
+#include "launch/SessionCapture.hpp"
+#include "launch/SessionLauncher.hpp"
+#include "transport/TransportClock.hpp"
+#include "transport/TransportState.hpp"
+
+/**
+ * @file test_session_capture.cpp
+ * @brief What the session played, placed from the launcher's own edges (#2464).
+ *
+ * A driven transport and the real launcher: a case launches a slot and asks
+ * where the capture put it, so what is pinned here is that a span begins on the
+ * sample the run began on rather than on whatever boundary a poll would have
+ * noticed it at.
+ */
+
+using Catch::Approx;
+using namespace magda;
+using namespace magda::engine;
+
+namespace {
+
+constexpr double kSampleRate = 48000.0;
+constexpr int kBlockSize = 512;
+
+/// 120 bpm, so a beat is 24,000 samples and no launch position is a whole
+/// number of blocks.
+constexpr double kBeatSamples = 24000.0;
+
+SlotKey key(int track, int scene = 0) {
+    return SlotKey{static_cast<TrackId>(track), scene};
+}
+
+/**
+ * @brief A transport, a table of handles and a capture, driven a block at a time.
+ */
+class Rig {
+  public:
+    explicit Rig(int tracks = 1, SlotFollow follow = {}) {
+        transport_.tempo = TempoMap({{0.0, 120.0, 0.0f}}, {{0.0, 4, 4}});
+        handles_.resize(static_cast<std::size_t>(tracks));
+
+        auto table = std::make_shared<LaunchHandleTable>();
+        std::map<SlotKey, std::uint64_t> incarnations;
+
+        for (auto track = 0; track < tracks; ++track) {
+            table->entries.push_back(
+                LaunchHandleTable::Entry{.key = key(track + 1),
+                                         .handle = &handles_[static_cast<std::size_t>(track)],
+                                         .incarnation = 1,
+                                         .follow = follow});
+            incarnations[key(track + 1)] = 1;
+        }
+
+        feed_.publish(std::move(table));
+        requests_.setIncarnations(std::move(incarnations));
+    }
+
+    void play(double fromBeat = 0.0) {
+        ++transport_.request.generation;
+        transport_.request.playing = true;
+        transport_.request.locate = true;
+        transport_.request.positionBeat = fromBeat;
+    }
+
+    void loop(double startBeat, double endBeat) {
+        transport_.loop = LoopRange{true, startBeat, endBeat};
+    }
+
+    void launch(int track, double monotonicBeat) {
+        LaunchRequestQueue::Gesture gesture(requests_);
+        gesture.play(key(track), monotonicBeat);
+    }
+
+    /// Every slot of @p tracks in one gesture, which is what a scene is.
+    void launchScene(const std::vector<int>& tracks, double monotonicBeat) {
+        std::vector<SlotKey> followers;
+        for (auto track : tracks)
+            followers.push_back(key(track));
+
+        LaunchRequestQueue::Gesture gesture(requests_);
+        gesture.playScene(followers.front(), followers, monotonicBeat);
+    }
+
+    void stopSlot(int track, double monotonicBeat) {
+        LaunchRequestQueue::Gesture gesture(requests_);
+        gesture.stop(key(track), monotonicBeat);
+    }
+
+    /// Roll @p beats of transport, collecting what the launcher publishes.
+    void roll(double beats) {
+        const auto samples = static_cast<int>(beats * kBeatSamples);
+
+        for (auto left = samples; left > 0;) {
+            const auto callback = std::min(kBlockSize, left);
+
+            for (const auto& segment : clock_.advance(transport_, kSampleRate, callback))
+                advanceLaunchHandles(feed_, requests_, segment.block, &runs_);
+
+            capture_.update(runs_);
+            left -= callback;
+        }
+    }
+
+    SessionCapture& capture() {
+        return capture_;
+    }
+
+    double monotonicBeat() const {
+        return clock_.monotonicBeat();
+    }
+
+    SlotRunQueue& runs() {
+        return runs_;
+    }
+
+  private:
+    TransportSnapshot transport_;
+    TransportClock clock_;
+
+    std::vector<LaunchHandle> handles_;
+    LaunchHandleFeed feed_;
+    LaunchRequestQueue requests_;
+    SlotRunQueue runs_;
+    SessionCapture capture_;
+};
+
+}  // namespace
+
+TEST_CASE("a captured run begins on the beat its launch fired", "[engine][capture]") {
+    // A launch quantized to each of these lands inside a block rather than on a
+    // boundary, which is the whole point of taking the launcher's own stamp.
+    for (const auto quantized : {1.0, 1.5, 2.0, 3.25, 4.0}) {
+        Rig rig;
+        rig.capture().arm();
+        rig.play();
+        rig.launch(1, quantized);
+        rig.roll(quantized + 2.0);
+        rig.stopSlot(1, quantized + 2.0);
+        rig.roll(1.0);
+
+        const auto captured = rig.capture().collect();
+        REQUIRE(captured.size() == 1);
+        CHECK(captured.front().startBeat == Approx(quantized).margin(1.0 / kBeatSamples));
+        CHECK(captured.front().lengthBeats == Approx(2.0).margin(2.0 / kBeatSamples));
+
+        // The stamp is a sample, and it is the one the run began on.
+        CHECK(captured.front().origin.sample ==
+              static_cast<std::int64_t>(quantized * kBeatSamples));
+    }
+}
+
+TEST_CASE("a scene captures as one event across tracks", "[engine][capture]") {
+    Rig rig(4);
+    rig.capture().arm();
+    rig.play();
+    rig.launchScene({1, 2, 3, 4}, 2.0);
+    rig.roll(4.0);
+
+    for (auto track = 1; track <= 4; ++track)
+        rig.stopSlot(track, 6.0);
+
+    rig.roll(3.0);
+
+    const auto captured = rig.capture().collect();
+    REQUIRE(captured.size() == 4);
+    CHECK(rig.runs().overflows() == 0);
+
+    for (const auto& run : captured) {
+        CHECK(run.origin == captured.front().origin);
+        CHECK(run.startBeat == Approx(captured.front().startBeat));
+    }
+}
+
+TEST_CASE("a capture over a transport loop places each run once", "[engine][capture]") {
+    Rig rig;
+    rig.loop(0.0, 4.0);
+    rig.capture().arm();
+    rig.play();
+    rig.launch(1, 2.0);
+
+    // Three times round the loop, which the run plays straight through.
+    rig.roll(12.0);
+    rig.stopSlot(1, 14.0);
+    rig.roll(3.0);
+
+    const auto captured = rig.capture().collect();
+    REQUIRE(captured.size() == 1);
+
+    // Placed where it was launched, and as long as it actually sounded: the
+    // timeline went back to zero three times in between, and neither answer
+    // followed it.
+    CHECK(captured.front().startBeat == Approx(2.0).margin(1.0 / kBeatSamples));
+    CHECK(captured.front().lengthBeats == Approx(12.0).margin(2.0 / kBeatSamples));
+}
+
+TEST_CASE("a re-launch is a second span", "[engine][capture]") {
+    Rig rig;
+    rig.capture().arm();
+    rig.play();
+    rig.launch(1, 1.0);
+    rig.roll(3.0);
+    rig.launch(1, 3.0);
+    rig.roll(3.0);
+    rig.stopSlot(1, 6.0);
+    rig.roll(1.0);
+
+    const auto captured = rig.capture().collect();
+    REQUIRE(captured.size() == 2);
+    CHECK(captured[0].startBeat == Approx(1.0).margin(1.0 / kBeatSamples));
+    CHECK(captured[0].lengthBeats == Approx(2.0).margin(2.0 / kBeatSamples));
+    CHECK(captured[1].startBeat == Approx(3.0).margin(1.0 / kBeatSamples));
+    CHECK(captured[1].lengthBeats == Approx(3.0).margin(2.0 / kBeatSamples));
+}
+
+TEST_CASE("a run a follow action ended is captured to there", "[engine][capture]") {
+    // The third thing that ends a run, beside a stop and a re-launch (#2464).
+    Rig rig(1, SlotFollow{.action = SlotAction::stop, .lengthBeats = 4.0});
+    rig.capture().arm();
+    rig.play();
+    rig.launch(1, 2.0);
+    rig.roll(10.0);
+
+    const auto captured = rig.capture().collect();
+    REQUIRE(captured.size() == 1);
+    CHECK(captured.front().startBeat == Approx(2.0).margin(1.0 / kBeatSamples));
+    CHECK(captured.front().lengthBeats == Approx(4.0).margin(2.0 / kBeatSamples));
+}
+
+TEST_CASE("arming after a launch keeps the beat the run began on", "[engine][capture]") {
+    Rig rig;
+    rig.play();
+    rig.launch(1, 1.0);
+    rig.roll(3.0);
+
+    // The run has been sounding for two beats when Record is pressed.
+    REQUIRE(rig.capture().sounding() == 1);
+    rig.capture().arm();
+
+    rig.stopSlot(1, 5.0);
+    rig.roll(3.0);
+
+    const auto captured = rig.capture().collect();
+    REQUIRE(captured.size() == 1);
+    CHECK(captured.front().startBeat == Approx(1.0).margin(1.0 / kBeatSamples));
+    CHECK(captured.front().lengthBeats == Approx(4.0).margin(2.0 / kBeatSamples));
+}
+
+TEST_CASE("nothing is captured while disarmed", "[engine][capture]") {
+    Rig rig;
+    rig.play();
+    rig.launch(1, 1.0);
+    rig.roll(3.0);
+    rig.stopSlot(1, 3.0);
+    rig.roll(1.0);
+
+    CHECK(rig.capture().collect().empty());
+}
+
+TEST_CASE("disarming ends what is still sounding", "[engine][capture]") {
+    Rig rig;
+    rig.capture().arm();
+    rig.play();
+    rig.launch(1, 1.0);
+    rig.roll(4.0);
+
+    rig.capture().disarm(rig.monotonicBeat());
+
+    const auto captured = rig.capture().collect();
+    REQUIRE(captured.size() == 1);
+    CHECK(captured.front().startBeat == Approx(1.0).margin(1.0 / kBeatSamples));
+    CHECK(captured.front().lengthBeats == Approx(3.0).margin(1.0));
+
+    // The slot is still playing; what stopped is the capture.
+    CHECK(rig.capture().sounding() == 1);
+
+    rig.stopSlot(1, 6.0);
+    rig.roll(3.0);
+    CHECK(rig.capture().collect().empty());
+}

--- a/tests/engine/test_session_capture.cpp
+++ b/tests/engine/test_session_capture.cpp
@@ -4,6 +4,7 @@
 #include <cstdint>
 #include <map>
 #include <memory>
+#include <ranges>
 #include <vector>
 
 #include "launch/SessionCapture.hpp"
@@ -95,7 +96,9 @@ class Rig {
     }
 
     /// Roll @p beats of transport, collecting what the launcher publishes.
-    void roll(double beats) {
+    /// @p collecting false leaves the edges in the lane, which is a frame that
+    /// has not run yet.
+    void roll(double beats, bool collecting = true) {
         const auto samples = static_cast<int>(beats * kBeatSamples);
 
         for (auto left = samples; left > 0;) {
@@ -104,17 +107,15 @@ class Rig {
             for (const auto& segment : clock_.advance(transport_, kSampleRate, callback))
                 advanceLaunchHandles(feed_, requests_, segment.block, &runs_);
 
-            capture_.update(runs_);
+            if (collecting)
+                capture_.update();
+
             left -= callback;
         }
     }
 
     SessionCapture& capture() {
         return capture_;
-    }
-
-    double monotonicBeat() const {
-        return clock_.monotonicBeat();
     }
 
     SlotRunQueue& runs() {
@@ -129,7 +130,7 @@ class Rig {
     LaunchHandleFeed feed_;
     LaunchRequestQueue requests_;
     SlotRunQueue runs_;
-    SessionCapture capture_;
+    SessionCapture capture_{runs_};
 };
 
 }  // namespace
@@ -253,6 +254,27 @@ TEST_CASE("arming after a launch keeps the beat the run began on", "[engine][cap
     CHECK(captured.front().lengthBeats == Approx(4.0).margin(2.0 / kBeatSamples));
 }
 
+TEST_CASE("disarming takes the edges before it reads the boundary", "[engine][capture]") {
+    // The run stopped on its own two beats before the button was pressed, and
+    // its end was still in the lane. A boundary read first would have stretched
+    // the span to here, which is the drift a poll has (#2464 review).
+    Rig rig;
+    rig.capture().arm();
+    rig.play();
+    rig.launch(1, 1.0);
+    rig.roll(4.0);
+
+    rig.stopSlot(1, 5.0);
+    rig.roll(2.0, false);
+
+    rig.capture().disarm();
+
+    const auto captured = rig.capture().collect();
+    REQUIRE(captured.size() == 1);
+    CHECK(captured.front().lengthBeats == Approx(4.0).margin(1.0 / kBeatSamples));
+    CHECK(rig.capture().sounding() == 0);
+}
+
 TEST_CASE("nothing is captured while disarmed", "[engine][capture]") {
     Rig rig;
     rig.play();
@@ -264,6 +286,70 @@ TEST_CASE("nothing is captured while disarmed", "[engine][capture]") {
     CHECK(rig.capture().collect().empty());
 }
 
+TEST_CASE("an end no block stamped closes the run it belongs to", "[engine][capture]") {
+    // A slot deleted while it sounded: its handle goes before any block could
+    // report the end, so the store says where the run had got to instead
+    // (RuntimeStateStore::publishHandles).
+    Rig rig;
+    rig.capture().arm();
+    rig.play();
+    rig.launch(1, 1.0);
+    rig.roll(4.0);
+
+    REQUIRE(rig.capture().sounding() == 1);
+
+    rig.capture().apply(SlotRunEvent{.key = SlotKey{1, 0},
+                                     .kind = SlotRunEvent::Kind::ended,
+                                     .incarnation = 1,
+                                     .monotonicBeat = 4.0});
+
+    const auto captured = rig.capture().collect();
+    REQUIRE(captured.size() == 1);
+    CHECK(captured.front().startBeat == Approx(1.0).margin(1.0 / kBeatSamples));
+    CHECK(captured.front().lengthBeats == Approx(3.0).margin(1.0 / kBeatSamples));
+    CHECK(rig.capture().sounding() == 0);
+}
+
+TEST_CASE("a run is held under the handle that played it", "[engine][capture]") {
+    // The refill's launch reaches the capture before the retired run's end, and
+    // the two are different runs of the same slot: keying by slot alone would
+    // drop the first, which is what the fork's play-state poll cannot tell
+    // apart either.
+    Rig rig;
+    rig.capture().arm();
+    rig.play();
+    rig.launch(1, 1.0);
+    rig.roll(4.0);
+
+    // Incarnation two, launched where the first was still in flight.
+    rig.capture().apply(SlotRunEvent{.key = SlotKey{1, 0},
+                                     .kind = SlotRunEvent::Kind::began,
+                                     .incarnation = 2,
+                                     .timelineBeat = 4.0,
+                                     .monotonicBeat = 4.0});
+
+    // And only now the end of the first, out of order.
+    rig.capture().apply(SlotRunEvent{.key = SlotKey{1, 0},
+                                     .kind = SlotRunEvent::Kind::ended,
+                                     .incarnation = 1,
+                                     .monotonicBeat = 4.0});
+
+    rig.capture().apply(SlotRunEvent{.key = SlotKey{1, 0},
+                                     .kind = SlotRunEvent::Kind::ended,
+                                     .incarnation = 2,
+                                     .monotonicBeat = 6.0});
+
+    auto captured = rig.capture().collect();
+    REQUIRE(captured.size() == 2);
+    std::ranges::sort(captured, {}, &CapturedRun::incarnation);
+
+    // Both spans survive, and each says which material played it.
+    CHECK(captured[0].incarnation == 1);
+    CHECK(captured[0].lengthBeats == Approx(3.0).margin(1.0 / kBeatSamples));
+    CHECK(captured[1].incarnation == 2);
+    CHECK(captured[1].lengthBeats == Approx(2.0));
+}
+
 TEST_CASE("disarming ends what is still sounding", "[engine][capture]") {
     Rig rig;
     rig.capture().arm();
@@ -271,12 +357,12 @@ TEST_CASE("disarming ends what is still sounding", "[engine][capture]") {
     rig.launch(1, 1.0);
     rig.roll(4.0);
 
-    rig.capture().disarm(rig.monotonicBeat());
+    rig.capture().disarm();
 
     const auto captured = rig.capture().collect();
     REQUIRE(captured.size() == 1);
     CHECK(captured.front().startBeat == Approx(1.0).margin(1.0 / kBeatSamples));
-    CHECK(captured.front().lengthBeats == Approx(3.0).margin(1.0));
+    CHECK(captured.front().lengthBeats == Approx(3.0).margin(1.0 / kBeatSamples));
 
     // The slot is still playing; what stopped is the capture.
     CHECK(rig.capture().sounding() == 1);

--- a/tests/engine/test_session_capture.cpp
+++ b/tests/engine/test_session_capture.cpp
@@ -271,11 +271,8 @@ TEST_CASE("an end that overtook its own launch still closes it", "[engine][captu
                                      .incarnation = 1,
                                      .monotonicBeat = 4.0});
 
-    // Nothing to close yet: the launch is still in the lane.
-    CHECK(rig.capture().sounding() == 0);
-
-    rig.capture().update();
-
+    // Closed by the drain apply() makes for itself: the launch was still in the
+    // lane when it arrived.
     CHECK(rig.capture().sounding() == 0);
 
     const auto captured = rig.capture().collect();
@@ -300,7 +297,39 @@ TEST_CASE("a waiting end closes the run the lane left in flight", "[engine][capt
                                      .kind = SlotRunEvent::Kind::ended,
                                      .incarnation = 1,
                                      .monotonicBeat = 5.0});
-    rig.capture().update();
+
+    CHECK(rig.capture().sounding() == 0);
+
+    const auto captured = rig.capture().collect();
+    REQUIRE(captured.size() == 2);
+    CHECK(captured[0].startBeat == Approx(1.0).margin(1.0 / kBeatSamples));
+    CHECK(captured[0].lengthBeats == Approx(2.0).margin(1.0 / kBeatSamples));
+    CHECK(captured[1].startBeat == Approx(3.0).margin(1.0 / kBeatSamples));
+    CHECK(captured[1].lengthBeats == Approx(2.0).margin(1.0 / kBeatSamples));
+}
+
+TEST_CASE("a retirement end closes the run its handle was left on", "[engine][capture]") {
+    // The handle's history is partly consumed when the retirement arrives: the
+    // first run is already tracked, and the relaunch that ended it is still in
+    // the lane. An incarnation names the handle rather than one of its runs, so
+    // closing what the capture happens to hold would place one span over both
+    // runs and discard the second (#2464 review).
+    Rig rig;
+    rig.capture().arm();
+    rig.play();
+    rig.launch(1, 1.0);
+    rig.roll(2.0);
+
+    REQUIRE(rig.capture().sounding() == 1);
+
+    // The relaunch: an end and a launch on beat three, neither drained.
+    rig.launch(1, 3.0);
+    rig.roll(2.0, false);
+
+    rig.capture().apply(SlotRunEvent{.key = SlotKey{1, 0},
+                                     .kind = SlotRunEvent::Kind::ended,
+                                     .incarnation = 1,
+                                     .monotonicBeat = 5.0});
 
     CHECK(rig.capture().sounding() == 0);
 

--- a/tests/engine/test_take_recorder.cpp
+++ b/tests/engine/test_take_recorder.cpp
@@ -5,6 +5,7 @@
 #include <cstdint>
 #include <map>
 #include <memory>
+#include <optional>
 #include <utility>
 #include <vector>
 
@@ -132,7 +133,8 @@ class SlotLaunch {
         gesture.play(kKey, monotonicBeat);
     }
 
-    void stop(double monotonicBeat) {
+    /// Nothing for the next sample, which is what a stopped block applies.
+    void stop(std::optional<double> monotonicBeat = {}) {
         LaunchRequestQueue::Gesture gesture(requests_);
         gesture.stop(kKey, monotonicBeat);
     }
@@ -695,6 +697,37 @@ TEST_CASE("A slot take ends where its run ended", "[engine][io][record][2464]") 
         CHECK(arrivalAt(stored, stored.getNumSamples() - 1) == kStopArrival - 1);
         CHECK(directory.getNumberOfChildFiles(juce::File::findFiles) == 1);
     }
+}
+
+TEST_CASE("A slot stop asked for while the transport is stopped ends the take",
+          "[engine][io][record][2464]") {
+    // The block that applies the stop is the only one that reports it, and a
+    // stopped transport is where that block is. A take that skipped stopped
+    // blocks would keep rolling and take up the input again on the resume.
+    SlotLaunch launch;
+
+    Rig rig(emptyDirectory("slot_stop_paused"), slotTake(launch));
+    rig.follows(launch);
+    rig.play();
+
+    launch.launch(1.0);
+    rig.run(3 * kBeatSamples);
+
+    rig.stop();
+    launch.stop();
+    rig.run(4 * kBlockSize);
+
+    CHECK_FALSE(rig.recorder().rolling());
+
+    rig.play(0.0);
+    rig.run(2 * kBeatSamples);
+
+    // Only what played before the pause: the run ended while the transport was
+    // stopped, so nothing after it belongs to this take.
+    const auto stored = readBack(rig.recorder().finish().file);
+    REQUIRE(stored.getNumSamples() == 2 * kBeatSamples);
+    CHECK(arrivalAt(stored, 0) == kBeatSamples);
+    CHECK(arrivalAt(stored, stored.getNumSamples() - 1) == (3 * kBeatSamples) - 1);
 }
 
 TEST_CASE("A transport wrap inside a run does not split the slot take",

--- a/tests/engine/test_take_recorder.cpp
+++ b/tests/engine/test_take_recorder.cpp
@@ -3,6 +3,7 @@
 #include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <cstdint>
+#include <map>
 #include <memory>
 #include <utility>
 #include <vector>
@@ -10,6 +11,7 @@
 #include "exec/RenderContext.hpp"
 #include "io/LiveInput.hpp"
 #include "io/TakeRecorder.hpp"
+#include "launch/SessionLauncher.hpp"
 #include "tap/RecordTap.hpp"
 #include "transport/TempoMap.hpp"
 #include "transport/TransportClock.hpp"
@@ -25,14 +27,25 @@
  *
  * Every input sample says which arrival it is, which is what lets a case assert
  * on where a take begins rather than only on how long it is.
+ *
+ * A slot take is driven the same way, with one published handle the launcher
+ * advances over each block before the take sees it (#2464).
  */
 
+using magda::engine::advanceLaunchHandles;
 using magda::engine::AudioFileFormat;
+using magda::engine::BlockInfo;
+using magda::engine::LaunchHandle;
+using magda::engine::LaunchHandleFeed;
+using magda::engine::LaunchHandleTable;
+using magda::engine::LaunchRequestQueue;
 using magda::engine::LiveInputBlock;
 using magda::engine::LiveInputFeed;
 using magda::engine::LoopRange;
 using magda::engine::RecordedTake;
 using magda::engine::RenderContext;
+using magda::engine::SlotKey;
+using magda::engine::SlotRunTarget;
 using magda::engine::TakeRecorder;
 using magda::engine::TakeRecorderSettings;
 using magda::engine::TempoMap;
@@ -95,6 +108,55 @@ TakeRecorderSettings floatTake(std::vector<int> channels, int latencySamples = 0
 }
 
 /**
+ * @brief One slot's handle, published the way the session publishes them.
+ *
+ * What a take follows instead of the transport (#2464): a launch is asked for
+ * on a monotonic beat and fires wherever that beat lands, which is what a case
+ * needs to be inside a block rather than on its edge.
+ */
+class SlotLaunch {
+  public:
+    SlotLaunch() {
+        auto table = std::make_shared<LaunchHandleTable>();
+        table->entries.push_back(
+            LaunchHandleTable::Entry{.key = kKey, .handle = &handle_, .incarnation = kIncarnation});
+        feed_.publish(std::move(table));
+
+        // What the store does beside the publish: a request stamped with
+        // anything else is dropped as a slot that has been refilled.
+        requests_.setIncarnations({{kKey, kIncarnation}});
+    }
+
+    void launch(double monotonicBeat) {
+        LaunchRequestQueue::Gesture gesture(requests_);
+        gesture.play(kKey, monotonicBeat);
+    }
+
+    void stop(double monotonicBeat) {
+        LaunchRequestQueue::Gesture gesture(requests_);
+        gesture.stop(kKey, monotonicBeat);
+    }
+
+    /// What a take made for this slot follows.
+    SlotRunTarget target() {
+        return {.handles = &feed_, .key = kKey, .incarnation = kIncarnation};
+    }
+
+    /// The launcher's own pass over the block, before anything renders it.
+    void advance(const BlockInfo& block) {
+        advanceLaunchHandles(feed_, requests_, block);
+    }
+
+  private:
+    static constexpr SlotKey kKey{1, 0};
+    static constexpr std::uint64_t kIncarnation = 1;
+
+    LaunchHandle handle_;
+    LaunchHandleFeed feed_;
+    LaunchRequestQueue requests_;
+};
+
+/**
  * @brief A transport, an input and one take, driven a callback at a time.
  */
 class Rig {
@@ -149,6 +211,12 @@ class Rig {
         drains_ = true;
     }
 
+    /// Advance @p launch over every block before the take sees it, which is the
+    /// order the audio thread keeps (#2464).
+    void follows(SlotLaunch& launch) {
+        launch_ = &launch;
+    }
+
     TakeRecorder& recorder() {
         return *recorder_;
     }
@@ -167,6 +235,10 @@ class Rig {
 
         for (const auto& segment : clock_.advance(transport_, kSampleRate, numSamples)) {
             feed_.beginSegment(segment.startSample, segment.block.numSamples);
+
+            if (launch_ != nullptr)
+                launch_->advance(segment.block);
+
             recorder_->capture(segment.block, segment.countingIn, transport_.loop);
         }
 
@@ -192,12 +264,28 @@ class Rig {
     /// material is numbered by.
     std::int64_t arrival_ = 0;
 
+    /// The slot the take follows, for a case that has one.
+    SlotLaunch* launch_ = nullptr;
+
     bool drains_ = false;
 };
 
 /// The arrival the take's first sample came from, read out of the file itself.
 std::int64_t firstArrival(const juce::AudioBuffer<float>& stored) {
     return std::llround(static_cast<double>(stored.getSample(0, 0)) * 1.0e5) - 1;
+}
+
+/// The same for any sample of it, which is what says a take holds one
+/// unbroken stretch of the input.
+std::int64_t arrivalAt(const juce::AudioBuffer<float>& stored, int at) {
+    return std::llround(static_cast<double>(stored.getSample(0, at)) * 1.0e5) - 1;
+}
+
+/// A take of @p launch's run rather than of the transport.
+TakeRecorderSettings slotTake(SlotLaunch& launch, int latencySamples = 0) {
+    auto settings = floatTake({0, 1}, latencySamples);
+    settings.slot = launch.target();
+    return settings;
 }
 
 }  // namespace
@@ -541,4 +629,214 @@ TEST_CASE("An overrun reaches the finished take", "[engine][io][record][2461]") 
     const auto take = rig.recorder().finish();
     CHECK(take.samplesLost > 0);
     CHECK(readBack(take.file).getNumSamples() == 1024);
+}
+
+TEST_CASE("A slot take begins on the sample its launch fired on", "[engine][io][record][2464]") {
+    SlotLaunch launch;
+
+    Rig rig(emptyDirectory("slot_launch"), slotTake(launch));
+    rig.follows(launch);
+    rig.play();
+
+    // Beat one is 4000 samples in and a callback is 64, so the launch fires 32
+    // samples inside a block rather than on its edge.
+    launch.launch(1.0);
+    rig.run(3 * kBeatSamples);
+
+    const auto take = rig.recorder().finish();
+    const auto stored = readBack(take.file);
+    REQUIRE(stored.getNumSamples() == 2 * kBeatSamples);
+
+    // The arrival at the beat, not the one the block started on.
+    CHECK(arrivalAt(stored, 0) == kBeatSamples);
+    CHECK(arrivalAt(stored, stored.getNumSamples() - 1) == (3 * kBeatSamples) - 1);
+
+    CHECK(take.startBeat == Catch::Approx(1.0));
+    CHECK(take.lengthBeats == Catch::Approx(2.0));
+    CHECK(take.clip.takes.empty());
+}
+
+TEST_CASE("A slot take ends where its run ended", "[engine][io][record][2464]") {
+    // Beat two and a half, which lands 16 samples inside a callback.
+    constexpr int kStopArrival = (5 * kBeatSamples) / 2;
+
+    SlotLaunch launch;
+
+    const auto directory = emptyDirectory("slot_stop");
+    Rig rig(directory, slotTake(launch));
+    rig.follows(launch);
+    rig.play();
+
+    launch.launch(1.0);
+    rig.run(2 * kBeatSamples);
+
+    launch.stop(2.5);
+    rig.run(2 * kBeatSamples);
+
+    CHECK_FALSE(rig.recorder().rolling());
+    const auto stopped = rig.recorder().capturedSamples();
+
+    SECTION("the take holds the arrivals between the launch and the stop") {
+        const auto stored = readBack(rig.recorder().finish().file);
+        REQUIRE(stored.getNumSamples() == kStopArrival - kBeatSamples);
+        CHECK(arrivalAt(stored, 0) == kBeatSamples);
+        CHECK(arrivalAt(stored, stored.getNumSamples() - 1) == kStopArrival - 1);
+    }
+
+    SECTION("a re-launch after it is a second take, not a longer one") {
+        launch.launch(4.5);
+        rig.run(2 * kBeatSamples);
+
+        CHECK_FALSE(rig.recorder().rolling());
+        CHECK(rig.recorder().capturedSamples() == stopped);
+
+        const auto stored = readBack(rig.recorder().finish().file);
+        CHECK(stored.getNumSamples() == kStopArrival - kBeatSamples);
+        CHECK(arrivalAt(stored, stored.getNumSamples() - 1) == kStopArrival - 1);
+        CHECK(directory.getNumberOfChildFiles(juce::File::findFiles) == 1);
+    }
+}
+
+TEST_CASE("A transport wrap inside a run does not split the slot take",
+          "[engine][io][record][2464]") {
+    // A run is on monotonic time, so the loop the transport is playing is none
+    // of its business: three passes of the loop are one take.
+    SlotLaunch launch;
+
+    const auto directory = emptyDirectory("slot_loop_wrap");
+    Rig rig(directory, slotTake(launch));
+    rig.follows(launch);
+    rig.loop(0.0, 2.0);
+    rig.play();
+
+    launch.launch(1.0);
+    rig.run(3 * 2 * kBeatSamples);
+
+    const auto take = rig.recorder().finish();
+    CHECK(take.clip.takes.empty());
+    CHECK(directory.getNumberOfChildFiles(juce::File::findFiles) == 1);
+
+    const auto stored = readBack(take.file);
+    REQUIRE(stored.getNumSamples() == 5 * kBeatSamples);
+
+    // One unbroken stretch of the input across the first wrap, which is take
+    // sample 4000 and arrival 8000.
+    CHECK(arrivalAt(stored, 0) == kBeatSamples);
+    CHECK(arrivalAt(stored, kBeatSamples) == 2 * kBeatSamples);
+    CHECK(arrivalAt(stored, stored.getNumSamples() - 1) == (6 * kBeatSamples) - 1);
+
+    CHECK(take.startBeat == Catch::Approx(1.0));
+    CHECK(take.lengthBeats == Catch::Approx(5.0));
+}
+
+TEST_CASE("A slot take is corrected for the input's latency too", "[engine][io][record][2464]") {
+    SlotLaunch launch;
+
+    Rig rig(emptyDirectory("slot_latency"), slotTake(launch, 128));
+    rig.follows(launch);
+    rig.play();
+
+    launch.launch(1.0);
+    rig.run(3 * kBeatSamples);
+
+    const auto stored = readBack(rig.recorder().finish().file);
+    REQUIRE(stored.getNumSamples() == (2 * kBeatSamples) - 128);
+
+    // Dropped from the head of the run, not from the head of the block it
+    // fired in.
+    CHECK(arrivalAt(stored, 0) == kBeatSamples + 128);
+    CHECK(arrivalAt(stored, stored.getNumSamples() - 1) == (3 * kBeatSamples) - 1);
+}
+
+TEST_CASE("A scene's takes all begin on the same sample", "[engine][io][record][2464]") {
+    // The launcher cuts one block at one sample for every slot of the scene, so
+    // the takes agree about where they start rather than each rounding to its
+    // own callback (#2464).
+    constexpr int kTracks = 4;
+
+    std::vector<LaunchHandle> handles(kTracks);
+    LaunchHandleFeed feed;
+    LaunchRequestQueue requests;
+
+    auto table = std::make_shared<LaunchHandleTable>();
+    std::map<SlotKey, std::uint64_t> incarnations;
+
+    for (auto track = 0; track < kTracks; ++track) {
+        const SlotKey key{static_cast<magda::TrackId>(track + 1), 0};
+        table->entries.push_back(LaunchHandleTable::Entry{
+            .key = key, .handle = &handles[static_cast<std::size_t>(track)], .incarnation = 1});
+        incarnations[key] = 1;
+    }
+
+    feed.publish(std::move(table));
+    requests.setIncarnations(std::move(incarnations));
+
+    const auto directory = emptyDirectory("slot_scene");
+
+    LiveInputFeed input;
+    input.prepare(2, kBlockSize);
+
+    magda::engine::RecordTap taps[kTracks]{
+        {magda::engine::RecordMaterial::audio, {}},
+        {magda::engine::RecordMaterial::audio, {}},
+        {magda::engine::RecordMaterial::audio, {}},
+        {magda::engine::RecordMaterial::audio, {}},
+    };
+
+    std::vector<std::unique_ptr<TakeRecorder>> takes;
+    for (auto track = 0; track < kTracks; ++track) {
+        auto settings = floatTake({0, 1});
+        settings.directory = directory;
+        settings.name = "scene" + juce::String(track);
+        settings.slot = SlotRunTarget{.handles = &feed,
+                                      .key = SlotKey{static_cast<magda::TrackId>(track + 1), 0},
+                                      .incarnation = 1};
+
+        takes.push_back(std::make_unique<TakeRecorder>(
+            input, RenderContext{kSampleRate, kBlockSize, 2}, taps[track], std::move(settings)));
+    }
+
+    // Every slot in one gesture, which is what makes a scene one event.
+    {
+        LaunchRequestQueue::Gesture gesture(requests);
+        std::vector<SlotKey> slots;
+        for (auto track = 0; track < kTracks; ++track)
+            slots.push_back(SlotKey{static_cast<magda::TrackId>(track + 1), 0});
+
+        gesture.playScene(slots.front(), slots, 1.0);
+    }
+
+    TransportSnapshot transport;
+    transport.tempo = TempoMap({{0.0, 120.0, 0.0f}}, {{0.0, 4, 4}});
+    transport.request = {.generation = 1, .playing = true, .locate = true, .positionBeat = 0.0};
+
+    TransportClock clock;
+    juce::AudioBuffer<float> block(2, kBlockSize);
+
+    for (std::int64_t arrival = 0; arrival < 3 * kBeatSamples; arrival += kBlockSize) {
+        for (auto channel = 0; channel < block.getNumChannels(); ++channel)
+            for (auto at = 0; at < kBlockSize; ++at)
+                block.setSample(channel, at, material(arrival + at, channel));
+
+        input.beginCallback({juce::dsp::AudioBlock<const float>(block), {}}, kBlockSize);
+
+        for (const auto& segment : clock.advance(transport, kSampleRate, kBlockSize)) {
+            input.beginSegment(segment.startSample, segment.block.numSamples);
+            advanceLaunchHandles(feed, requests, segment.block);
+
+            for (auto& take : takes)
+                take->capture(segment.block, segment.countingIn, transport.loop);
+        }
+
+        input.endCallback();
+    }
+
+    for (auto& take : takes) {
+        const auto recorded = take->finish();
+        REQUIRE_FALSE(recorded.empty());
+
+        const auto stored = readBack(recorded.file);
+        CHECK(arrivalAt(stored, 0) == kBeatSamples);
+        CHECK(recorded.startBeat == Catch::Approx(1.0));
+    }
 }


### PR DESCRIPTION
Slice 6 of #1895, closes #2464. Session slot recording and the
session-to-arrangement capture, both off the launcher's own sample-stamped run
edges rather than off a poll of play state.

## The edge

`LaunchHandle::advance` already cuts a block at the sample a launch fires on.
`SplitStatus` now says so — `runBeganAt` and `runEndedAt`, an event sample and a
bound — and `advanceLaunchHandles` publishes both down `SlotRunQueue` for the
publishing thread. A re-launch reports an end and a begin on the same sample,
because the run it began is not the run it ended.

`slotRun()` is the audio thread's own reader of the same answer, off the block
status the launcher wrote. `EngineSession::process` therefore advances the
launcher before the takes capture: a take following a slot starts on the sample
its launch fired on, and that is decided there.

## The take

A take carrying a `SlotRunTarget` follows that slot's run instead of the
transport: it starts on the sample the launch fired on, ends where the run
ended, and ignores the count-in and the transport's loop, since a run is on
monotonic time — a wrap or a locate is none of its business. A re-launch closes
the take rather than extending it, which is the rule an arrangement take already
keeps for a second play. Audio and MIDI alike; the MIDI take narrows the block's
events to the run's window, so a note played before the launch instant in the
same block is not in it.

## The slot

An empty slot had no handle at all: the compiler only emitted a
`SessionSlotPlayback` for a slot holding a clip, so a launch on the one kind of
slot you can record into was dropped. `ClipLane::recordSlots` is how a host arms
one, and the compiler is where an occupied slot is refused — with a diagnostic,
its own clip untouched. That is where "a slot that already holds a clip is not a
recording target" now lives.

## The capture

`SessionCapture` folds the run edges into arrangement spans. A scene is one
event because its runs share an origin, not because they were observed in one
frame; a run the transport looped inside is placed once, at the beat it was
launched on, and measured on the monotonic axis where no wrap takes anything
back. Arming after a launch keeps the beat the run began on, as the fork's
`SessionRecorder` does.

## Verification

Offline, driving the launcher and the transport:

- a launch on a beat 32 samples inside a block records from that beat (audio);
  a note played before that instant in the same block is not in the take (MIDI)
- a scene of four tracks gives four takes whose first arrival is one sample, and
  four spans sharing one origin
- a run stopped mid-block keeps what played; a re-launch is a second take
- capture start beats over a corpus of quantizations (1, 1.5, 2, 3.25, 4)
- a run across three transport loop passes is placed once
- a run a follow action ended is captured to there
- an occupied armed slot keeps its clip and is not a target

Full non-JUCE suite: 3830 passed, 13 skipped, 0 failed. JUCE suite including the
real-project null-diff corpus: all passed.

## Not in this slice

Follow actions themselves, comping, overdubbing into an occupied slot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X7rCviRzaXVzLAjNKwVCxN
