### PR TITLE
Fix the three ternaries worth fixing, stop the check crying wolf

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -46,7 +46,6 @@ Checks: >-
   readability-use-std-min-max,
   readability-use-anyofallof,
   readability-simplify-boolean-expr,
-  readability-avoid-nested-conditional-operator,
   readability-inconsistent-declaration-parameter-name
 
 # The old config disabled performance-noexcept-move-constructor and
@@ -91,6 +90,18 @@ Checks: >-
 #     iteration-order (2)        address; the other is listener registration order.
 #   macro-parentheses (2)        the argument is streamed, so parenthesising it
 #                                would evaluate the << chain before the string.
+#
+# readability-avoid-nested-conditional-operator is off. It cannot tell a chain
+# from a nesting: `a ? x : b ? y : z` is an else-if ladder, which clang-format
+# aligns here into exactly that shape, and it counts as nested because the
+# second operator sits in the first one's false branch. Of the 91 sites, all
+# but a handful are that ladder or a parenthesised sub-expression like
+# `sync ? "rateType" : "rate"`, and rewriting them as if/else or named
+# intermediates makes them longer and no clearer. The few that were genuinely
+# hard - a three-way compare written twice in MediaDbQuery, a bool folded
+# through `? 1 : 0` inside another ternary in MediaDbIndexer, and a
+# two-branches-each-nested size lookup in TrackCommands - are fixed rather than
+# suppressed.
 #
 # modernize-loop-convert is off. It found 19 sites across 2 files and both files
 # were hand-written that way on purpose. TrackManager's 13 notify methods index

--- a/magda/daw/core/TrackCommands.cpp
+++ b/magda/daw/core/TrackCommands.cpp
@@ -616,12 +616,17 @@ void PasteChainElementsCommand::execute() {
     const auto* destinationBefore =
         destinationChainPath_.steps.empty() ? nullptr : tm.getChainByPath(destinationChainPath_);
     const auto* trackBefore = tm.getTrack(destinationChainPath_.trackId);
-    const int destinationSizeBefore =
-        destinationChainPath_.steps.empty()
-            ? (trackBefore != nullptr ? static_cast<int>(trackBefore->chain.fxChainElements.size())
-                                      : 0)
-            : (destinationBefore != nullptr ? static_cast<int>(destinationBefore->elements.size())
-                                            : 0);
+    // A top-level path counts the track's own chain, a nested one counts the
+    // chain it names. Either can be gone, which counts the same as empty.
+    const int destinationSizeBefore = [&]() -> int {
+        if (!destinationChainPath_.steps.empty()) {
+            return destinationBefore != nullptr
+                       ? static_cast<int>(destinationBefore->elements.size())
+                       : 0;
+        }
+        return trackBefore != nullptr ? static_cast<int>(trackBefore->chain.fxChainElements.size())
+                                      : 0;
+    }();
     const int requestedIndex = std::clamp(insertIndex_, 0, destinationSizeBefore);
 
     executed_ = tm.insertChainElementsByPath(destinationChainPath_, std::move(elements),

--- a/magda/daw/media_db/MediaDbIndexer.cpp
+++ b/magda/daw/media_db/MediaDbIndexer.cpp
@@ -740,8 +740,9 @@ void processOneFile(sqlite3* sqlDb, const ScannedFile& f, MediaDbIndexer::Stats&
         const std::string shape = midiFeats
                                       ? deriveMidiShape(midiFeats->durationS)
                                       : (feats ? deriveShape(*feats) : std::string{"unknown"});
-        const int tonal =
-            midiFeats ? (midiFeats->hasNotes ? 1 : 0) : (feats ? deriveTonal(*feats) : 0);
+        const int tonal = midiFeats ? static_cast<int>(midiFeats->hasNotes)
+                          : feats   ? deriveTonal(*feats)
+                                    : 0;
         if (feats && f.kind == "audio") {
             applyPolicies(*feats, shape, family);
         }

--- a/magda/daw/media_db/MediaDbQuery.cpp
+++ b/magda/daw/media_db/MediaDbQuery.cpp
@@ -300,6 +300,16 @@ std::string lowerForSort(std::string value) {
     return value;
 }
 
+/**
+ * @brief Orders two values the way std::string::compare reports it.
+ */
+template <typename T> int compareForSort(const T& a, const T& b) {
+    if (a < b) {
+        return -1;
+    }
+    return b < a ? 1 : 0;
+}
+
 std::string keyForSort(const QueryResult& r) {
     std::string key = r.keyRoot.value_or("");
     if (r.keyScale && !r.keyScale->empty()) {
@@ -352,13 +362,13 @@ void sortResults(std::vector<QueryResult>& rows, QuerySort sort) {
                 cmp = lowerForSort(a.shape).compare(lowerForSort(b.shape));
                 break;
             case QuerySortField::Bpm:
-                cmp = (*a.bpm < *b.bpm) ? -1 : ((*a.bpm > *b.bpm) ? 1 : 0);
+                cmp = compareForSort(*a.bpm, *b.bpm);
                 break;
             case QuerySortField::Key:
                 cmp = keyForSort(a).compare(keyForSort(b));
                 break;
             case QuerySortField::Duration:
-                cmp = (*a.durationS < *b.durationS) ? -1 : ((*a.durationS > *b.durationS) ? 1 : 0);
+                cmp = compareForSort(*a.durationS, *b.durationS);
                 break;
             case QuerySortField::Tags:
                 cmp = tagsTextForSort(a).compare(tagsTextForSort(b));


### PR DESCRIPTION
The first authoring slice of the rollout, and mostly a judgment that 85 of the
91 sites should not change.

## What the check cannot see

`readability-avoid-nested-conditional-operator` does not distinguish a chain
from a nesting. `a ? x : b ? y : z` is an else-if ladder -- clang-format aligns
it here into exactly that shape -- and it counts as nested only because the
second operator sits in the first one's false branch:

```cpp
const auto action = secondary && fine ? GestureActionType::AdjustSecondaryValueFine
                    : secondary       ? GestureActionType::AdjustSecondaryValue
                    : fine            ? GestureActionType::AdjustValueFine
                                      : GestureActionType::AdjustValue;
```

Of 91 sites, all but a few are that, or a small parenthesised sub-expression
like `sync ? "rateType" : "rate"`. Rewriting them as if/else or named
intermediates makes them longer and no clearer, and risks a transcription
error for no gain.

## The three that were worth it

| site | what it was |
|---|---|
| `MediaDbQuery` | a three-way compare written out twice, `(a < b) ? -1 : ((a > b) ? 1 : 0)`; now one `compareForSort` used by both sort fields |
| `MediaDbIndexer` | a bool folded through `? 1 : 0` inside another ternary; the inner one was just `static_cast<int>` |
| `TrackCommands` | a size lookup nested in both branches at once, each with its own null guard, over five lines |

The check is then off, with the reason recorded in `.clang-tidy` beside the
others.

## Counts

91 sites across 58 files, not the 99 the rollout notes carried -- close enough
that the note was right. My own first measurement said 200, which was the same
headers counted once per relative include path (`core/ClipPropertyCommands.hpp`
and `ui/windows/../../core/ClipPropertyCommands.hpp` are one file).

## Verification

- builds clean
- JUCE: 80 suites, 0 failed, 0 hung
- Catch2: 3806 passed, 13 skipped, 2,424,607 assertions
- the pre-push gate passed on the three changed files

This is also the first push touching C++ under `magda/` since #2532 restored
the five version-dependent checks, so its gate run is the one that actually
exercises them -- #2532's own run had no C++ to analyse.

https://claude.ai/code/session_01VomqgBSXsWYdyHyec9DvPi
