### PR TITLE
Carry a take across a plan swap

### DIFF
--- a/magda/engine/exec/EngineSession.cpp
+++ b/magda/engine/exec/EngineSession.cpp
@@ -111,10 +111,9 @@ EngineSession::Result EngineSession::publish(std::shared_ptr<const RenderPlan> p
     // it would be counting from one again by its next block (#2122).
     live_->executor.clearUnboundValueTaps();
 
-    // After the swap, because until it the plan playing was the one the edit
-    // has not happened to yet, and before the release below, because that is
-    // what frees a tap a take still writes to. A take the edit did not reach is
-    // not touched at all -- no publish, no wait, nothing moved (#2465).
+    // The takes this edit ended (#2465). After the swap, since the edit only
+    // counts once its plan is playing. Before releaseDeleted, since that frees
+    // the tap a take writes to as it closes.
     closeUnnamedTakes(modelIds);
 
     // Safe only now: before the swap, everything about to be destroyed was
@@ -134,9 +133,8 @@ void EngineSession::publishTakes() {
 
 void EngineSession::startTake(const TakeKey& key, const RecordTapSettings& settings,
                               const std::function<std::unique_ptr<TakeCapture>(RecordTap&)>& make) {
-    // First, and before the tap: what this key was recording leaves with its
-    // own tap, so the take about to be built gets a fresh one rather than the
-    // one somebody is about to be handed.
+    // Whatever this key was already recording, closed first. Its tap leaves
+    // with it, so the take built below gets a fresh one.
     if (auto displaced = stopTake(key); displaced.take != nullptr)
         closed_.push_back(std::move(displaced));
 
@@ -153,8 +151,8 @@ ClosedTake EngineSession::stopTake(const TakeKey& key) {
     if (released.take == nullptr)
         return {};
 
-    // After the release and before the caller has it: the set published here is
-    // the one without it, so when this returns the callback is out of it.
+    // The set without it, published before the caller has it. Once this
+    // returns the callback is out of the take, so finishing it is safe.
     publishTakes();
     return ClosedTake{key, std::move(released.take), std::move(released.tap)};
 }
@@ -164,8 +162,8 @@ void EngineSession::closeUnnamedTakes(const RuntimeStateIds& modelIds) {
     if (unnamed.empty())
         return;
 
-    // Every one of them out of the store first, then one publish for the lot:
-    // a scene of armed tracks deleted together is one wait, not one each.
+    // All of them out of the store, then one publish: a scene of armed tracks
+    // deleted together costs one wait rather than one each.
     std::vector<ClosedTake> closed;
     closed.reserve(unnamed.size());
     for (const auto& key : unnamed) {

--- a/magda/engine/exec/EngineSession.cpp
+++ b/magda/engine/exec/EngineSession.cpp
@@ -115,6 +115,9 @@ EngineSession::Result EngineSession::publish(std::shared_ptr<const RenderPlan> p
     // it would be counting from one again by its next block (#2122).
     live_->executor.clearUnboundValueTaps();
 
+    if (betweenPlanAndTakesForTest)
+        betweenPlanAndTakesForTest();
+
     // The takes this edit ended (#2465). After the swap, since the edit only
     // counts once its plan is playing.
     closeUnnamedTakes(modelIds);

--- a/magda/engine/exec/EngineSession.cpp
+++ b/magda/engine/exec/EngineSession.cpp
@@ -112,8 +112,7 @@ EngineSession::Result EngineSession::publish(std::shared_ptr<const RenderPlan> p
     live_->executor.clearUnboundValueTaps();
 
     // The takes this edit ended (#2465). After the swap, since the edit only
-    // counts once its plan is playing. Before releaseDeleted, since that frees
-    // the tap a take writes to as it closes.
+    // counts once its plan is playing.
     closeUnnamedTakes(modelIds);
 
     // Safe only now: before the swap, everything about to be destroyed was

--- a/magda/engine/exec/EngineSession.cpp
+++ b/magda/engine/exec/EngineSession.cpp
@@ -37,6 +37,10 @@ EngineSession::Result EngineSession::publish(std::shared_ptr<const RenderPlan> p
     prepared->values = std::move(values);
     prepared->context = context;
 
+    // Sorted already: a std::set of them is ordered by the same operator< the
+    // block's lookup uses.
+    prepared->takes.assign(modelIds.takes.begin(), modelIds.takes.end());
+
     // The metronome is prepared against the device, not the plan, so it is
     // shared with the epoch it replaces unless the device changed. Sharing is
     // what keeps a click that is sounding from being cut in half by an edit
@@ -304,9 +308,16 @@ void EngineSession::process(int numSamples, juce::AudioBuffer<float>& output,
 
         // Before the plan and outside it: a take holds the input the device
         // captured, not what the track's chain went on to make of it.
+        //
+        // The set says which takes exist and the epoch says which may record,
+        // and the epoch is the one this block is rendering. So an edit that
+        // ended a take stops feeding it on the block that first renders its
+        // plan, rather than on whichever later block the publishing thread got
+        // the reduced set out by (#2465).
         if (takes)
-            for (auto* recorder : *takes.get())
-                recorder->capture(segment.block, segment.countingIn, transport->loop);
+            for (const auto& entry : *takes.get())
+                if (std::binary_search((*render)->takes.begin(), (*render)->takes.end(), entry.key))
+                    entry.take->capture(segment.block, segment.countingIn, transport->loop);
 
         // Where the transport is, for the thread that reads ahead of it. A
         // relaxed store of a double, before the block rather than after: the

--- a/magda/engine/exec/EngineSession.cpp
+++ b/magda/engine/exec/EngineSession.cpp
@@ -111,6 +111,12 @@ EngineSession::Result EngineSession::publish(std::shared_ptr<const RenderPlan> p
     // it would be counting from one again by its next block (#2122).
     live_->executor.clearUnboundValueTaps();
 
+    // After the swap, because until it the plan playing was the one the edit
+    // has not happened to yet, and before the release below, because that is
+    // what frees a tap a take still writes to. A take the edit did not reach is
+    // not touched at all -- no publish, no wait, nothing moved (#2465).
+    closeUnnamedTakes(modelIds);
+
     // Safe only now: before the swap, everything about to be destroyed was
     // still reachable from the plan the audio thread was rendering. The plan
     // that is live goes in as well, so what it names survives however stale
@@ -120,6 +126,57 @@ EngineSession::Result EngineSession::publish(std::shared_ptr<const RenderPlan> p
     store_.releaseDeleted(*livePlan_, modelIds, live_->values.params.get());
 
     return {true, std::move(messages)};
+}
+
+void EngineSession::publishTakes() {
+    recording_.publish(std::make_shared<const RecordingTakes>(store_.liveTakes()));
+}
+
+void EngineSession::startTake(const TakeKey& key, const RecordTapSettings& settings,
+                              const std::function<std::unique_ptr<TakeCapture>(RecordTap&)>& make) {
+    // First, and before the tap: what this key was recording leaves with its
+    // own tap, so the take about to be built gets a fresh one rather than the
+    // one somebody is about to be handed.
+    if (auto displaced = stopTake(key); displaced.take != nullptr)
+        closed_.push_back(std::move(displaced));
+
+    auto take = make(store_.realiseTakeTap(key, settings));
+    if (take == nullptr)
+        return;
+
+    store_.holdTake(key, std::move(take));
+    publishTakes();
+}
+
+ClosedTake EngineSession::stopTake(const TakeKey& key) {
+    auto released = store_.releaseTake(key);
+    if (released.take == nullptr)
+        return {};
+
+    // After the release and before the caller has it: the set published here is
+    // the one without it, so when this returns the callback is out of it.
+    publishTakes();
+    return ClosedTake{key, std::move(released.take), std::move(released.tap)};
+}
+
+void EngineSession::closeUnnamedTakes(const RuntimeStateIds& modelIds) {
+    const auto unnamed = store_.unnamedTakes(modelIds);
+    if (unnamed.empty())
+        return;
+
+    // Every one of them out of the store first, then one publish for the lot:
+    // a scene of armed tracks deleted together is one wait, not one each.
+    std::vector<ClosedTake> closed;
+    closed.reserve(unnamed.size());
+    for (const auto& key : unnamed) {
+        auto released = store_.releaseTake(key);
+        closed.push_back(ClosedTake{key, std::move(released.take), std::move(released.tap)});
+    }
+
+    publishTakes();
+
+    for (auto& take : closed)
+        closed_.push_back(std::move(take));
 }
 
 EngineSession::Result EngineSession::publishValues(PlanValues values) {

--- a/magda/engine/exec/EngineSession.hpp
+++ b/magda/engine/exec/EngineSession.hpp
@@ -47,10 +47,11 @@ class ClipVoicePool;
 /**
  * @brief A take that has stopped, on its way to being a clip (#2465).
  *
- * The recorder rather than what it recorded, since what a finished take becomes
- * is typed by its material and the key says which to ask for. The tap comes
- * with it: finish() closes the pass through it, and an overlay drawn from it
- * has to stand until the clip appears in its place.
+ * The recorder, not what it recorded: an audio take and a MIDI take finish into
+ * different types, and the key says which one this is.
+ *
+ * The tap comes with it, because finish() writes to it and an overlay drawn
+ * from it has to stand until the clip appears.
  */
 struct ClosedTake {
     TakeKey key;
@@ -254,9 +255,8 @@ class EngineSession {
     /**
      * @brief Where take @p key publishes its pass, or null (#2463).
      *
-     * On the publishing thread, both to look up and to read: a tap leaves with
-     * the take that writes it, so a pointer cached across a publish may be to
-     * something the caller has already been handed. Ask again after every one.
+     * On the publishing thread. A tap leaves with the take that writes it, so
+     * ask again after each publish rather than holding on to the pointer.
      */
     const RecordTap* takeTap(const TakeKey& key) const {
         return store_.takeTap(key);
@@ -270,11 +270,11 @@ class EngineSession {
      * plan: arming a track compiles a plan, but a recording in flight is
      * history rather than topology, and no recompile moves it.
      *
-     * @p make is handed the tap rather than the caller building the recorder
-     * and passing it in, because nothing else orders the two: whatever @p key
-     * was already recording is closed first -- it leaves through
-     * @ref takeClosedTakes, since the callback can still reach it -- and that
-     * takes its tap with it.
+     * @p make builds the recorder against the tap it is handed, rather than
+     * the caller building one and passing it in. Anything @p key was already
+     * recording is closed first and takes that key's tap with it, so the tap
+     * to build against does not exist until then. The displaced take leaves
+     * through @ref takeClosedTakes.
      *
      * Registering the take's @ref TakeCapture::stream with a RecordThread is
      * the caller's, and so is unregistering it after @ref stopTake.
@@ -294,12 +294,12 @@ class EngineSession {
      * @brief Takes an edit closed, and forget them (#2465).
      *
      * A publish whose model IDs stopped naming a take: the arm switched off,
-     * the input taken away, the track deleted. Each is out of the callback's
-     * set already and is finished by whoever collects it, so what was recorded
-     * up to the edit becomes a clip rather than being dropped.
+     * the input taken away, the track deleted. Each is already out of the
+     * callback's set, so whoever collects it can finish it, and what was
+     * recorded up to the edit becomes a clip instead of being dropped.
      *
-     * Kept until asked for rather than dropped like a full lane, as
-     * @ref takeRetiredRuns is: one per edit that ended a recording.
+     * Kept until asked for rather than dropped, like @ref takeRetiredRuns:
+     * one per edit that ended a recording.
      */
     std::vector<ClosedTake> takeClosedTakes() {
         return std::exchange(closed_, {});
@@ -395,14 +395,12 @@ class EngineSession {
     }
 
   private:
-    /// The callback's set, rebuilt from the store. Blocks until the audio
-    /// thread is out of its block, which is what makes a take this drops safe
-    /// to close.
+    /// The callback's set, rebuilt from the store. Waits for the block the
+    /// callback is in, so a take this drops is safe to close afterwards.
     void publishTakes();
 
-    /// Takes @p modelIds has stopped naming, out of the callback's set and
-    /// into @ref takeClosedTakes. After the plan swap, since until then the
-    /// edit that ended them was not the one playing.
+    /// Close the takes @p modelIds has stopped naming, into
+    /// @ref takeClosedTakes.
     void closeUnnamedTakes(const RuntimeStateIds& modelIds);
 
     /**

--- a/magda/engine/exec/EngineSession.hpp
+++ b/magda/engine/exec/EngineSession.hpp
@@ -346,6 +346,19 @@ class EngineSession {
         return clock_.loopWrapOverflows();
     }
 
+    /**
+     * @brief The one window in a publish a test can stand a callback in.
+     *
+     * Called on the publishing thread after the plan is live and before the
+     * takes the edit ended leave the callback's set. Everything else about the
+     * two is a wait, and a wait cannot be observed from outside; this is a gap,
+     * and it is the gap the eligibility gate exists to make harmless, so a
+     * regression for it has to be able to hold the publisher here.
+     *
+     * Empty otherwise, at one null check per publish.
+     */
+    std::function<void()> betweenPlanAndTakesForTest;
+
     /// Runtime objects the store owns right now. On the publishing thread.
     std::size_t runtimeObjectCount() const {
         return store_.size();

--- a/magda/engine/exec/EngineSession.hpp
+++ b/magda/engine/exec/EngineSession.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <farbot/RealtimeObject.hpp>
+#include <functional>
 #include <memory>
 #include <string>
 #include <utility>
@@ -42,6 +43,20 @@ namespace magda::engine {
 /// Only ever held as a pointer here, and only ever used from the .cpp, so
 /// the session does not hand its own includers a thread and a stream pool.
 class ClipVoicePool;
+
+/**
+ * @brief A take that has stopped, on its way to being a clip (#2465).
+ *
+ * The recorder rather than what it recorded, since what a finished take becomes
+ * is typed by its material and the key says which to ask for. The tap comes
+ * with it: finish() closes the pass through it, and an overlay drawn from it
+ * has to stand until the clip appears in its place.
+ */
+struct ClosedTake {
+    TakeKey key;
+    std::unique_ptr<TakeCapture> take;
+    std::unique_ptr<RecordTap> tap;
+};
 
 class EngineSession {
   public:
@@ -237,16 +252,57 @@ class EngineSession {
     }
 
     /**
-     * @brief The takes the callback writes into (#2461, #2462).
+     * @brief Where take @p key publishes its pass, or null (#2463).
      *
-     * Published like the clips are, and outside every plan for the same
-     * reason: arming a track compiles a plan, but starting a recording is not
-     * a structural edit and must not cost one. A take taken out of the set is
-     * one nothing is writing to by the time publish returns, which is what
-     * makes it safe to close.
+     * On the publishing thread, both to look up and to read: a tap leaves with
+     * the take that writes it, so a pointer cached across a publish may be to
+     * something the caller has already been handed. Ask again after every one.
      */
-    RecordingFeed& recordingFeed() {
-        return recording_;
+    const RecordTap* takeTap(const TakeKey& key) const {
+        return store_.takeTap(key);
+    }
+
+    /**
+     * @brief Record @p key, through a take built against a tap made here
+     *        (#2465).
+     *
+     * On the publishing thread. The session owns both from here, outside every
+     * plan: arming a track compiles a plan, but a recording in flight is
+     * history rather than topology, and no recompile moves it.
+     *
+     * @p make is handed the tap rather than the caller building the recorder
+     * and passing it in, because nothing else orders the two: whatever @p key
+     * was already recording is closed first -- it leaves through
+     * @ref takeClosedTakes, since the callback can still reach it -- and that
+     * takes its tap with it.
+     *
+     * Registering the take's @ref TakeCapture::stream with a RecordThread is
+     * the caller's, and so is unregistering it after @ref stopTake.
+     */
+    void startTake(const TakeKey& key, const RecordTapSettings& settings,
+                   const std::function<std::unique_ptr<TakeCapture>(RecordTap&)>& make);
+
+    /**
+     * @brief Take it back out of the callback's set and hand it over.
+     *
+     * On the publishing thread. Returns once nothing can reach it, which is
+     * what makes finishing it safe. Empty for a key nothing is recording.
+     */
+    ClosedTake stopTake(const TakeKey& key);
+
+    /**
+     * @brief Takes an edit closed, and forget them (#2465).
+     *
+     * A publish whose model IDs stopped naming a take: the arm switched off,
+     * the input taken away, the track deleted. Each is out of the callback's
+     * set already and is finished by whoever collects it, so what was recorded
+     * up to the edit becomes a clip rather than being dropped.
+     *
+     * Kept until asked for rather than dropped like a full lane, as
+     * @ref takeRetiredRuns is: one per edit that ended a recording.
+     */
+    std::vector<ClosedTake> takeClosedTakes() {
+        return std::exchange(closed_, {});
     }
 
     /// Where the transport is, in beats. Readable from any thread; what a
@@ -339,6 +395,16 @@ class EngineSession {
     }
 
   private:
+    /// The callback's set, rebuilt from the store. Blocks until the audio
+    /// thread is out of its block, which is what makes a take this drops safe
+    /// to close.
+    void publishTakes();
+
+    /// Takes @p modelIds has stopped naming, out of the callback's set and
+    /// into @ref takeClosedTakes. After the plan swap, since until then the
+    /// edit that ended them was not the one playing.
+    void closeUnnamedTakes(const RuntimeStateIds& modelIds);
+
     /**
      * @brief One epoch: a plan, the executor prepared for it, and the
      * values it was published with.
@@ -423,6 +489,9 @@ class EngineSession {
     /// The takes that input is written to. Outside every epoch beside it, and
     /// for the same reason.
     RecordingFeed recording_;
+
+    /// Takes an edit ended, until someone collects them (@ref takeClosedTakes).
+    std::vector<ClosedTake> closed_;
 
     /// What the model held at the last publish. Kept so a values publish
     /// escalated into a structural one has a set to publish with; retention

--- a/magda/engine/exec/EngineSession.hpp
+++ b/magda/engine/exec/EngineSession.hpp
@@ -278,6 +278,10 @@ class EngineSession {
      *
      * Registering the take's @ref TakeCapture::stream with a RecordThread is
      * the caller's, and so is unregistering it after @ref stopTake.
+     *
+     * A take is fed only while the live plan's model IDs name its key, so
+     * arming is what makes one record: this says what exists, and the epoch
+     * says what may record into it.
      */
     void startTake(const TakeKey& key, const RecordTapSettings& settings,
                    const std::function<std::unique_ptr<TakeCapture>(RecordTap&)>& make);
@@ -427,6 +431,13 @@ class EngineSession {
         PlanValues values;
         RenderContext context;
         std::shared_ptr<ClickGenerator> click;
+
+        /// The takes the model named when this plan was published, sorted
+        /// (#2465). Here rather than beside the recording feed so that one
+        /// edit is one boundary: the block that first renders this plan is the
+        /// first block that stops feeding a take the edit ended, whatever the
+        /// publishing thread has got round to since the swap.
+        std::vector<TakeKey> takes;
     };
 
     using PublishedRender =

--- a/magda/engine/exec/RuntimeStateStore.cpp
+++ b/magda/engine/exec/RuntimeStateStore.cpp
@@ -280,12 +280,15 @@ std::size_t RuntimeStateStore::releaseDeleted(const RenderPlan& livePlan,
                  isNamed(entry.first, keep));
     });
 
-    // Taps whose track is gone and whose take never started. A take that did
-    // start took its tap with it.
+    // Taps whose track is gone and whose take never started.
     //
-    // No take is erased here. Everything else this function frees is already
-    // unreachable from the audio thread; a take stays reachable until the
-    // caller publishes a set without it (@ref unnamedTakes).
+    // A tap a take is still holding is kept whatever the model says, on the
+    // same reading the live plan gets above: the callback can reach that take
+    // until the caller publishes a set without it, and closing it writes to
+    // the tap. So the rule is the store's rather than an order the caller has
+    // to call in.
+    //
+    // No take is erased here either, for the same reason.
     removed += std::erase_if(takeTaps_, [&](const auto& entry) {
         return !keep.tracks.contains(entry.first.trackId) && !takes_.contains(entry.first);
     });

--- a/magda/engine/exec/RuntimeStateStore.cpp
+++ b/magda/engine/exec/RuntimeStateStore.cpp
@@ -440,7 +440,7 @@ RecordingTakes RuntimeStateStore::liveTakes() const {
     RecordingTakes live;
     live.reserve(takes_.size());
     for (const auto& [key, take] : takes_)
-        live.push_back(take.get());
+        live.push_back(RecordingTake{key, take.get()});
     return live;
 }
 

--- a/magda/engine/exec/RuntimeStateStore.cpp
+++ b/magda/engine/exec/RuntimeStateStore.cpp
@@ -280,14 +280,12 @@ std::size_t RuntimeStateStore::releaseDeleted(const RenderPlan& livePlan,
                  isNamed(entry.first, keep));
     });
 
-    // A tap made for a take that never started, once its track is gone. One
-    // that did start left with it, so what is left here is a recording asked
-    // for and abandoned.
+    // Taps whose track is gone and whose take never started. A take that did
+    // start took its tap with it.
     //
-    // No take is touched here, and none can be. Everything else in this
-    // function is unreachable from the audio thread by the time it runs; a
-    // take is reachable until a publish of the callback's set says otherwise,
-    // and that publish is the caller's (@ref unnamedTakes).
+    // No take is erased here. Everything else this function frees is already
+    // unreachable from the audio thread; a take stays reachable until the
+    // caller publishes a set without it (@ref unnamedTakes).
     removed += std::erase_if(takeTaps_, [&](const auto& entry) {
         return !keep.tracks.contains(entry.first.trackId) && !takes_.contains(entry.first);
     });
@@ -302,10 +300,10 @@ RuntimeStateIds collectRuntimeStateIds(const std::vector<TrackInfo>& tracks,
     const auto collectTrack = [&ids](const TrackInfo& track) {
         ids.tracks.insert(track.id);
 
-        // A take may run while the track is armed and still has an input of
-        // that material. Arm rather than monitorsInput(), which is also true of
-        // a track only listening: disarming ends a take and stops nothing else,
-        // so the plan cannot answer this and the model has to (#2465).
+        // A take may run while the track is armed and has an input of that
+        // material. Arm, not monitorsInput(): a track that is only listening
+        // compiles the same input op, so the plan cannot say when a take ends
+        // (#2465).
         if (track.takesExternalInput() && track.recordArmed) {
             if (!track.audioInputDevice.isEmpty())
                 ids.takes.insert(TakeKey{track.id, RecordMaterial::audio});

--- a/magda/engine/exec/RuntimeStateStore.cpp
+++ b/magda/engine/exec/RuntimeStateStore.cpp
@@ -280,6 +280,18 @@ std::size_t RuntimeStateStore::releaseDeleted(const RenderPlan& livePlan,
                  isNamed(entry.first, keep));
     });
 
+    // A tap made for a take that never started, once its track is gone. One
+    // that did start left with it, so what is left here is a recording asked
+    // for and abandoned.
+    //
+    // No take is touched here, and none can be. Everything else in this
+    // function is unreachable from the audio thread by the time it runs; a
+    // take is reachable until a publish of the callback's set says otherwise,
+    // and that publish is the caller's (@ref unnamedTakes).
+    removed += std::erase_if(takeTaps_, [&](const auto& entry) {
+        return !keep.tracks.contains(entry.first.trackId) && !takes_.contains(entry.first);
+    });
+
     return removed;
 }
 
@@ -289,6 +301,18 @@ RuntimeStateIds collectRuntimeStateIds(const std::vector<TrackInfo>& tracks,
 
     const auto collectTrack = [&ids](const TrackInfo& track) {
         ids.tracks.insert(track.id);
+
+        // A take may run while the track is armed and still has an input of
+        // that material. Arm rather than monitorsInput(), which is also true of
+        // a track only listening: disarming ends a take and stops nothing else,
+        // so the plan cannot answer this and the model has to (#2465).
+        if (track.takesExternalInput() && track.recordArmed) {
+            if (!track.audioInputDevice.isEmpty())
+                ids.takes.insert(TakeKey{track.id, RecordMaterial::audio});
+            if (!track.midiInputDevice.isEmpty())
+                ids.takes.insert(TakeKey{track.id, RecordMaterial::midi});
+        }
+
         // Every section, and bypass is not consulted anywhere here: a bypassed
         // device is still a device the user owns.
         collectDeviceIds(track.chain.fxChainElements, track.id, ChainSegment::Fx, ids.devices);
@@ -393,6 +417,57 @@ const LaunchTap* RuntimeStateStore::launchTap(const SlotKey& key) const {
     return it == handles_.end() ? nullptr : it->second.tap.get();
 }
 
+RecordTap& RuntimeStateStore::realiseTakeTap(const TakeKey& key,
+                                             const RecordTapSettings& settings) {
+    auto& tap = takeTaps_[key];
+    if (tap == nullptr)
+        tap = std::make_unique<RecordTap>(key.material, settings);
+    return *tap;
+}
+
+const RecordTap* RuntimeStateStore::takeTap(const TakeKey& key) const {
+    const auto found = takeTaps_.find(key);
+    return found == takeTaps_.end() ? nullptr : found->second.get();
+}
+
+void RuntimeStateStore::holdTake(const TakeKey& key, std::unique_ptr<TakeCapture> take) {
+    jassert(!takes_.contains(key));
+    takes_[key] = std::move(take);
+}
+
+RecordingTakes RuntimeStateStore::liveTakes() const {
+    RecordingTakes live;
+    live.reserve(takes_.size());
+    for (const auto& [key, take] : takes_)
+        live.push_back(take.get());
+    return live;
+}
+
+std::vector<TakeKey> RuntimeStateStore::unnamedTakes(const RuntimeStateIds& modelIds) const {
+    std::vector<TakeKey> unnamed;
+    for (const auto& [key, take] : takes_)
+        if (!modelIds.takes.contains(key))
+            unnamed.push_back(key);
+    return unnamed;
+}
+
+RuntimeStateStore::ReleasedTake RuntimeStateStore::releaseTake(const TakeKey& key) {
+    const auto found = takes_.find(key);
+    if (found == takes_.end())
+        return {};
+
+    ReleasedTake released;
+    released.take = std::move(found->second);
+    takes_.erase(found);
+
+    if (const auto tap = takeTaps_.find(key); tap != takeTaps_.end()) {
+        released.tap = std::move(tap->second);
+        takeTaps_.erase(tap);
+    }
+
+    return released;
+}
+
 ValueTap* RuntimeStateStore::valueTap(const ParamKey& key) const {
     const auto found = valueTaps_.find(key);
     return found == valueTaps_.end() ? nullptr : found->second.get();
@@ -401,7 +476,7 @@ ValueTap* RuntimeStateStore::valueTap(const ParamKey& key) const {
 std::size_t RuntimeStateStore::size() const {
     return devices_.size() + clipAudio_.size() + clipMidi_.size() + sessionAudio_.size() +
            sessionMidi_.size() + handles_.size() + audioInputs_.size() + midiInputs_.size() +
-           meters_.size() + valueTaps_.size();
+           meters_.size() + valueTaps_.size() + takes_.size() + takeTaps_.size();
 }
 
 }  // namespace magda::engine

--- a/magda/engine/exec/RuntimeStateStore.hpp
+++ b/magda/engine/exec/RuntimeStateStore.hpp
@@ -9,10 +9,12 @@
 
 #include "clip/ClipSnapshot.hpp"
 #include "exec/PlanBindings.hpp"
+#include "io/RecordingFeed.hpp"
 #include "launch/LaunchHandle.hpp"
 #include "launch/SessionLauncher.hpp"
 #include "plan/RenderPlan.hpp"
 #include "tap/LevelTap.hpp"
+#include "tap/RecordTap.hpp"
 #include "tap/ValueTap.hpp"
 
 namespace magda {
@@ -29,6 +31,11 @@ struct TrackInfo;
  * rebuild-click problem in miniature. The store owns them instead, keyed by
  * section-aware model identity the way OpKey is, so the same edit that
  * recompiles the plan leaves the objects it names untouched.
+ *
+ * A take is here for the same reason with more at stake (#2465). An instrument
+ * rebuilt mid-note clicks; a take rebuilt mid-pass is a split file or a hole,
+ * and it is not recomputable from anything -- it is a file handle, a write
+ * position and a queue holding samples nobody has written yet.
  *
  * Everything here runs off the audio thread.
  */
@@ -136,6 +143,12 @@ class RuntimeStateFactory {
 struct RuntimeStateIds {
     std::set<DeviceKey> devices;
     std::set<TrackId> tracks;
+
+    /// Takes the model still says may run: a track armed, with an input of
+    /// that material (#2465). The one entry here that names a thing allowed to
+    /// continue rather than a thing that exists, because a plan cannot answer
+    /// it -- disarming ends a take and changes no topology at all.
+    std::set<TakeKey> takes;
 };
 
 // Launch handles are deliberately not tracked here: a slot is a clip, so
@@ -272,6 +285,51 @@ class RuntimeStateStore {
     LaunchHandle* findHandle(const SlotKey& key) const;
 
     /**
+     * @brief The tap take @p key publishes its pass to, made if there is none.
+     *
+     * On the publishing thread, and before the take, since a recorder is built
+     * against it. @p settings is ignored for a tap that already exists:
+     * resizing its arrays would be an allocation beneath a reader.
+     */
+    RecordTap& realiseTakeTap(const TakeKey& key, const RecordTapSettings& settings);
+
+    /// @brief The tap for @p key, or null. On the publishing thread.
+    const RecordTap* takeTap(const TakeKey& key) const;
+
+    /// @brief Own @p take as @p key's, from now until something ends it.
+    ///
+    /// On the publishing thread, and only for a key nothing is recording: a
+    /// take the callback can still reach has to leave the published set through
+    /// @ref releaseTake before anything may destroy it.
+    void holdTake(const TakeKey& key, std::unique_ptr<TakeCapture> take);
+
+    /// @brief Every take being fed, in key order. What the callback's set is
+    ///        built from, on the publishing thread.
+    RecordingTakes liveTakes() const;
+
+    /// @brief Takes @p modelIds has stopped naming: the arm switched off, the
+    ///        input taken away, the track deleted (#2465). Named here and
+    ///        released separately, because a take has to leave the callback's
+    ///        set before anything may close it.
+    std::vector<TakeKey> unnamedTakes(const RuntimeStateIds& modelIds) const;
+
+    /// A take on its way out, with the tap it writes to.
+    struct ReleasedTake {
+        std::unique_ptr<TakeCapture> take;
+        std::unique_ptr<RecordTap> tap;
+    };
+
+    /**
+     * @brief Hand @p key's take over, empty if there is none.
+     *
+     * On the publishing thread, and only once the callback can no longer reach
+     * it. The tap goes with it: finish() closes the pass through it, so it has
+     * to outlive the take, and an overlay drawn from it has to stand until the
+     * clip appears in its place.
+     */
+    ReleasedTake releaseTake(const TakeKey& key);
+
+    /**
      * @brief Where @p key's state is published, or null (#2303).
      *
      * Made and retired with the handle beside it, and on the publishing thread
@@ -322,6 +380,12 @@ class RuntimeStateStore {
     /// Never reused, so an incarnation names one handle for the life of the
     /// session.
     std::uint64_t nextIncarnation_ = 0;
+
+    /// The takes being fed, and the taps they publish through. Two maps
+    /// because they do not begin together: the tap is made first, since the
+    /// recorder is built against it (#2465).
+    std::map<TakeKey, std::unique_ptr<TakeCapture>> takes_;
+    std::map<TakeKey, std::unique_ptr<RecordTap>> takeTaps_;
 
     /// What was last published, so a publish that changes nothing is skipped.
     std::shared_ptr<const LaunchHandleTable> publishedHandles_;

--- a/magda/engine/exec/RuntimeStateStore.hpp
+++ b/magda/engine/exec/RuntimeStateStore.hpp
@@ -32,10 +32,10 @@ struct TrackInfo;
  * section-aware model identity the way OpKey is, so the same edit that
  * recompiles the plan leaves the objects it names untouched.
  *
- * A take is here for the same reason with more at stake (#2465). An instrument
- * rebuilt mid-note clicks; a take rebuilt mid-pass is a split file or a hole,
- * and it is not recomputable from anything -- it is a file handle, a write
- * position and a queue holding samples nobody has written yet.
+ * A take is here for the same reason, with more at stake (#2465). An instrument
+ * rebuilt mid-note clicks; a take rebuilt mid-pass is a split file or a hole.
+ * Nothing can recompute one either: it is a file handle, a write position, and
+ * a queue holding samples nobody has written yet.
  *
  * Everything here runs off the audio thread.
  */
@@ -145,9 +145,9 @@ struct RuntimeStateIds {
     std::set<TrackId> tracks;
 
     /// Takes the model still says may run: a track armed, with an input of
-    /// that material (#2465). The one entry here that names a thing allowed to
-    /// continue rather than a thing that exists, because a plan cannot answer
-    /// it -- disarming ends a take and changes no topology at all.
+    /// that material (#2465). Alone here in naming what is allowed to continue
+    /// rather than what exists, because disarming ends a take without changing
+    /// any topology the plan could be asked about.
     std::set<TakeKey> takes;
 };
 
@@ -287,20 +287,20 @@ class RuntimeStateStore {
     /**
      * @brief The tap take @p key publishes its pass to, made if there is none.
      *
-     * On the publishing thread, and before the take, since a recorder is built
-     * against it. @p settings is ignored for a tap that already exists:
-     * resizing its arrays would be an allocation beneath a reader.
+     * On the publishing thread, and before the take, since the recorder is
+     * built against it. @p settings is ignored for a tap that already exists:
+     * resizing its arrays would allocate underneath a reader.
      */
     RecordTap& realiseTakeTap(const TakeKey& key, const RecordTapSettings& settings);
 
     /// @brief The tap for @p key, or null. On the publishing thread.
     const RecordTap* takeTap(const TakeKey& key) const;
 
-    /// @brief Own @p take as @p key's, from now until something ends it.
+    /// @brief Own @p take as @p key's, until something ends it.
     ///
     /// On the publishing thread, and only for a key nothing is recording: a
-    /// take the callback can still reach has to leave the published set through
-    /// @ref releaseTake before anything may destroy it.
+    /// take the callback can still reach has to go through @ref releaseTake
+    /// before anything may destroy it.
     void holdTake(const TakeKey& key, std::unique_ptr<TakeCapture> take);
 
     /// @brief Every take being fed, in key order. What the callback's set is
@@ -308,9 +308,10 @@ class RuntimeStateStore {
     RecordingTakes liveTakes() const;
 
     /// @brief Takes @p modelIds has stopped naming: the arm switched off, the
-    ///        input taken away, the track deleted (#2465). Named here and
-    ///        released separately, because a take has to leave the callback's
-    ///        set before anything may close it.
+    ///        input taken away, the track deleted (#2465).
+    ///
+    /// Named here and released separately, because a take has to leave the
+    /// callback's set before anything may close it.
     std::vector<TakeKey> unnamedTakes(const RuntimeStateIds& modelIds) const;
 
     /// A take on its way out, with the tap it writes to.
@@ -323,9 +324,8 @@ class RuntimeStateStore {
      * @brief Hand @p key's take over, empty if there is none.
      *
      * On the publishing thread, and only once the callback can no longer reach
-     * it. The tap goes with it: finish() closes the pass through it, so it has
-     * to outlive the take, and an overlay drawn from it has to stand until the
-     * clip appears in its place.
+     * it. The tap goes with it: finish() writes to it, and an overlay drawn
+     * from it has to stand until the clip appears.
      */
     ReleasedTake releaseTake(const TakeKey& key);
 

--- a/magda/engine/exec/RuntimeStateStore.hpp
+++ b/magda/engine/exec/RuntimeStateStore.hpp
@@ -148,6 +148,11 @@ struct RuntimeStateIds {
     /// that material (#2465). Alone here in naming what is allowed to continue
     /// rather than what exists, because disarming ends a take without changing
     /// any topology the plan could be asked about.
+    ///
+    /// A slot take is retained by the same arm, being the same track's input.
+    /// ClipLane::recordSlots says which slot a take goes into and not whether
+    /// one may run, so a host that arms a slot without arming its track has a
+    /// recording the next edit ends.
     std::set<TakeKey> takes;
 };
 

--- a/magda/engine/io/MidiTakeRecorder.hpp
+++ b/magda/engine/io/MidiTakeRecorder.hpp
@@ -121,7 +121,7 @@ class MidiTakeRecorder final : public TakeCapture {
 
     /// The queue the record thread drains. Registered by whoever owns the
     /// thread, and unregistered before @ref finish.
-    RecordStream& stream() {
+    RecordStream& stream() override {
         return stream_;
     }
 

--- a/magda/engine/io/RecordingFeed.hpp
+++ b/magda/engine/io/RecordingFeed.hpp
@@ -68,9 +68,16 @@ class TakeCapture {
     virtual RecordStream& stream() = 0;
 };
 
+/// One take in the callback's set, beside the key that says whether the epoch
+/// being rendered still allows it to record (#2465).
+struct RecordingTake {
+    TakeKey key;
+    TakeCapture* take = nullptr;
+};
+
 /// The takes a callback feeds. Not owned: whoever publishes them keeps them
 /// alive until it has published something that does not name them.
-using RecordingTakes = std::vector<TakeCapture*>;
+using RecordingTakes = std::vector<RecordingTake>;
 
 /**
  * @brief What the audio thread records into, replaced on the publishing thread.

--- a/magda/engine/io/RecordingFeed.hpp
+++ b/magda/engine/io/RecordingFeed.hpp
@@ -2,8 +2,10 @@
 
 #include <farbot/RealtimeObject.hpp>
 #include <memory>
+#include <tuple>
 #include <vector>
 
+#include "core/TypeIds.hpp"
 #include "exec/RenderContext.hpp"
 #include "tap/RecordTap.hpp"
 #include "transport/TransportState.hpp"
@@ -17,6 +19,27 @@
  */
 
 namespace magda::engine {
+
+class RecordStream;
+
+/**
+ * @brief Which take: whose input it records, and what kind (#2465).
+ *
+ * The identity the differ matches an input op on, minus the op: a track has
+ * one live audio input and one live MIDI input, so a track recording both is
+ * two takes and never more. What the store keys a take on, so a recompile
+ * naming the same track carries the take it was already feeding.
+ */
+struct TakeKey {
+    TrackId trackId = INVALID_TRACK_ID;
+    RecordMaterial material = RecordMaterial::audio;
+
+    bool operator==(const TakeKey&) const = default;
+
+    bool operator<(const TakeKey& other) const {
+        return std::tie(trackId, material) < std::tie(other.trackId, other.material);
+    }
+};
 
 /**
  * @brief One take being fed, block by block, on the audio thread.
@@ -39,6 +62,11 @@ class TakeCapture {
     /// Where the take publishes the pass in flight (#2463). Read from any
     /// thread, for as long as whoever owns the take keeps it.
     virtual const RecordTap& tap() const = 0;
+
+    /// The queue the record thread drains. Here rather than on each kind of
+    /// take so that whoever registered one can unregister it again knowing
+    /// only that it is a take (#2465).
+    virtual RecordStream& stream() = 0;
 };
 
 /// The takes a callback feeds. Not owned: whoever publishes them keeps them

--- a/magda/engine/io/RecordingFeed.hpp
+++ b/magda/engine/io/RecordingFeed.hpp
@@ -25,10 +25,9 @@ class RecordStream;
 /**
  * @brief Which take: whose input it records, and what kind (#2465).
  *
- * The identity the differ matches an input op on, minus the op: a track has
- * one live audio input and one live MIDI input, so a track recording both is
- * two takes and never more. What the store keys a take on, so a recompile
- * naming the same track carries the take it was already feeding.
+ * A track has one live audio input and one live MIDI input, so it has at most
+ * two takes. That makes this the same identity the differ matches an input op
+ * on, which is what lets a recompile carry the take it was already feeding.
  */
 struct TakeKey {
     TrackId trackId = INVALID_TRACK_ID;
@@ -63,9 +62,9 @@ class TakeCapture {
     /// thread, for as long as whoever owns the take keeps it.
     virtual const RecordTap& tap() const = 0;
 
-    /// The queue the record thread drains. Here rather than on each kind of
-    /// take so that whoever registered one can unregister it again knowing
-    /// only that it is a take (#2465).
+    /// The queue the record thread drains. On the base rather than on each
+    /// kind of take, so whoever registered one can unregister it without
+    /// knowing which kind it is (#2465).
     virtual RecordStream& stream() = 0;
 };
 

--- a/magda/engine/io/TakeRecorder.hpp
+++ b/magda/engine/io/TakeRecorder.hpp
@@ -160,7 +160,7 @@ class TakeRecorder final : public TakeCapture {
 
     /// The queue the record thread drains. Registered by whoever owns the
     /// thread, and unregistered before @ref finish.
-    RecordStream& stream() {
+    RecordStream& stream() override {
         return stream_;
     }
 

--- a/tests/AllocationWatch.cpp
+++ b/tests/AllocationWatch.cpp
@@ -1,0 +1,202 @@
+#include "AllocationWatch.hpp"
+
+#include <algorithm>
+#include <cstdlib>
+#include <memory>
+#include <new>
+
+/**
+ * @file AllocationWatch.cpp
+ * @brief The replacement operators behind AllocationWatch.hpp.
+ *
+ * Global, so every C++ allocation in the test binary is counted, including the
+ * ones inside the engine. Everything forwards to malloc and free, which is what
+ * the default operators do, so no other test behaves differently for this being
+ * linked in.
+ *
+ * The counters are `thread_local` scalars and are therefore constant
+ * initialised: reaching one cannot allocate, which it would have to not do
+ * anyway, since it is reached from inside the allocator.
+ */
+
+namespace {
+
+thread_local std::size_t g_allocations = 0;
+thread_local std::size_t g_frees = 0;
+
+void* rawAllocate(std::size_t size) {
+    // Zero is a legal request and must still hand back something a matching
+    // free can take.
+    return std::malloc(size == 0 ? 1 : size);
+}
+
+void* rawAllocateAligned(std::size_t size, std::size_t alignment) {
+    if (size == 0)
+        size = 1;
+
+#if defined(_WIN32)
+    return _aligned_malloc(size, alignment);
+#else
+    // posix_memalign refuses an alignment below a pointer's, which an
+    // over-aligned type smaller than one can still ask for.
+    void* memory = nullptr;
+    if (posix_memalign(&memory, std::max(alignment, sizeof(void*)), size) != 0)
+        return nullptr;
+    return memory;
+#endif
+}
+
+void rawFreeAligned(void* memory) {
+#if defined(_WIN32)
+    _aligned_free(memory);
+#else
+    std::free(memory);
+#endif
+}
+
+void* allocateOrThrow(std::size_t size) {
+    if (auto* memory = rawAllocate(size))
+        return memory;
+    throw std::bad_alloc();
+}
+
+void* allocateAlignedOrThrow(std::size_t size, std::size_t alignment) {
+    if (auto* memory = rawAllocateAligned(size, alignment))
+        return memory;
+    throw std::bad_alloc();
+}
+
+}  // namespace
+
+// The standard's own declarations name these parameters differently, and
+// matching a standard library's internal spelling is not worth the trade.
+// NOLINTBEGIN(readability-inconsistent-declaration-parameter-name)
+
+void* operator new(std::size_t size) {
+    ++g_allocations;
+    return allocateOrThrow(size);
+}
+
+void* operator new[](std::size_t size) {
+    ++g_allocations;
+    return allocateOrThrow(size);
+}
+
+void* operator new(std::size_t size, std::align_val_t alignment) {
+    ++g_allocations;
+    return allocateAlignedOrThrow(size, static_cast<std::size_t>(alignment));
+}
+
+void* operator new[](std::size_t size, std::align_val_t alignment) {
+    ++g_allocations;
+    return allocateAlignedOrThrow(size, static_cast<std::size_t>(alignment));
+}
+
+void* operator new(std::size_t size, const std::nothrow_t&) noexcept {
+    ++g_allocations;
+    return rawAllocate(size);
+}
+
+void* operator new[](std::size_t size, const std::nothrow_t&) noexcept {
+    ++g_allocations;
+    return rawAllocate(size);
+}
+
+void* operator new(std::size_t size, std::align_val_t alignment, const std::nothrow_t&) noexcept {
+    ++g_allocations;
+    return rawAllocateAligned(size, static_cast<std::size_t>(alignment));
+}
+
+void* operator new[](std::size_t size, std::align_val_t alignment, const std::nothrow_t&) noexcept {
+    ++g_allocations;
+    return rawAllocateAligned(size, static_cast<std::size_t>(alignment));
+}
+
+void operator delete(void* memory) noexcept {
+    ++g_frees;
+    std::free(memory);
+}
+
+void operator delete[](void* memory) noexcept {
+    ++g_frees;
+    std::free(memory);
+}
+
+void operator delete(void* memory, std::size_t) noexcept {
+    ++g_frees;
+    std::free(memory);
+}
+
+void operator delete[](void* memory, std::size_t) noexcept {
+    ++g_frees;
+    std::free(memory);
+}
+
+void operator delete(void* memory, const std::nothrow_t&) noexcept {
+    ++g_frees;
+    std::free(memory);
+}
+
+void operator delete[](void* memory, const std::nothrow_t&) noexcept {
+    ++g_frees;
+    std::free(memory);
+}
+
+void operator delete(void* memory, std::align_val_t) noexcept {
+    ++g_frees;
+    rawFreeAligned(memory);
+}
+
+void operator delete[](void* memory, std::align_val_t) noexcept {
+    ++g_frees;
+    rawFreeAligned(memory);
+}
+
+void operator delete(void* memory, std::size_t, std::align_val_t) noexcept {
+    ++g_frees;
+    rawFreeAligned(memory);
+}
+
+void operator delete[](void* memory, std::size_t, std::align_val_t) noexcept {
+    ++g_frees;
+    rawFreeAligned(memory);
+}
+
+void operator delete(void* memory, std::align_val_t, const std::nothrow_t&) noexcept {
+    ++g_frees;
+    rawFreeAligned(memory);
+}
+
+void operator delete[](void* memory, std::align_val_t, const std::nothrow_t&) noexcept {
+    ++g_frees;
+    rawFreeAligned(memory);
+}
+
+// NOLINTEND(readability-inconsistent-declaration-parameter-name)
+
+namespace magda::test {
+
+AllocationWatch::AllocationWatch() : allocationsAtStart_(g_allocations), freesAtStart_(g_frees) {}
+
+AllocationWatch::~AllocationWatch() = default;
+
+std::size_t AllocationWatch::allocations() const {
+    return g_allocations - allocationsAtStart_;
+}
+
+std::size_t AllocationWatch::frees() const {
+    return g_frees - freesAtStart_;
+}
+
+bool allocationWatchWorks() {
+    const AllocationWatch watch;
+
+    // Sized past any small-buffer optimisation and used afterwards, so the
+    // allocation cannot be optimised out.
+    std::unique_ptr<char[]> probe(new char[4096]);
+    probe[0] = 1;
+
+    return watch.allocations() > 0;
+}
+
+}  // namespace magda::test

--- a/tests/AllocationWatch.cpp
+++ b/tests/AllocationWatch.cpp
@@ -14,9 +14,9 @@
  * the default operators do, so no other test behaves differently for this being
  * linked in.
  *
- * The counters are `thread_local` scalars and are therefore constant
- * initialised: reaching one cannot allocate, which it would have to not do
- * anyway, since it is reached from inside the allocator.
+ * The counters are `thread_local` scalars, so they are constant initialised.
+ * That matters because they are read from inside the allocator, where an
+ * initialisation that allocated would recurse.
  */
 
 namespace {

--- a/tests/AllocationWatch.hpp
+++ b/tests/AllocationWatch.hpp
@@ -1,0 +1,62 @@
+#pragma once
+
+#include <cstddef>
+
+/**
+ * @file AllocationWatch.hpp
+ * @brief Heap traffic on one thread, for the blocks that must not have any.
+ *
+ * The engine's claim is that nothing on the callback allocates, locks or frees
+ * (exec/EngineSession.hpp), and a plan swap is where it is easiest to break:
+ * the block after one renders through objects that were built a moment ago on
+ * another thread. A case that only checked the audio would not notice.
+ *
+ * Counts `operator new` and `operator delete`, which is every C++ allocation in
+ * the binary and not a raw `std::malloc` underneath one. So a zero is not proof
+ * that nothing was allocated at all; it is proof that nothing the language
+ * allocated was, which is what the code under it is written in.
+ *
+ * Per thread, so a background thread doing its own work while a case runs is
+ * not counted against the block.
+ */
+
+namespace magda::test {
+
+/**
+ * @brief Counts allocations and frees on this thread while it stands.
+ *
+ * Nesting is allowed and each watch counts what happened inside its own scope.
+ */
+class AllocationWatch {
+  public:
+    AllocationWatch();
+    ~AllocationWatch();
+
+    AllocationWatch(const AllocationWatch&) = delete;
+    AllocationWatch& operator=(const AllocationWatch&) = delete;
+    AllocationWatch(AllocationWatch&&) = delete;
+    AllocationWatch& operator=(AllocationWatch&&) = delete;
+
+    std::size_t allocations() const;
+    std::size_t frees() const;
+
+    /// Both, which is what a case asserting on neither of them wants.
+    std::size_t total() const {
+        return allocations() + frees();
+    }
+
+  private:
+    std::size_t allocationsAtStart_ = 0;
+    std::size_t freesAtStart_ = 0;
+};
+
+/**
+ * @brief Whether the counters are wired to this binary's operator new.
+ *
+ * Asked rather than assumed: a sanitizer runtime supplies its own, and a case
+ * that asserted on a watch counting nothing would pass for the wrong reason.
+ * Answered by allocating and seeing whether the count moved.
+ */
+bool allocationWatchWorks();
+
+}  // namespace magda::test

--- a/tests/AllocationWatch.hpp
+++ b/tests/AllocationWatch.hpp
@@ -11,10 +11,9 @@
  * the block after one renders through objects that were built a moment ago on
  * another thread. A case that only checked the audio would not notice.
  *
- * Counts `operator new` and `operator delete`, which is every C++ allocation in
- * the binary and not a raw `std::malloc` underneath one. So a zero is not proof
- * that nothing was allocated at all; it is proof that nothing the language
- * allocated was, which is what the code under it is written in.
+ * Counts `operator new` and `operator delete`. That is every C++ allocation in
+ * the binary, but not a bare `std::malloc` underneath one, so a zero says the
+ * code allocated nothing rather than that no byte was taken from the heap.
  *
  * Per thread, so a background thread doing its own work while a case runs is
  * not counted against the block.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -436,6 +436,10 @@ if(MAGDA_BUILD_NATIVE_ENGINE)
     # The pass in flight, reported without a poll (#2463): its length off the
     # transport that stamped it, and its notes where the finished clip holds them.
     list(APPEND TEST_SOURCES engine/test_record_tap.cpp)
+    # A take carried across a plan swap (#2465): what an unrelated edit does to
+    # a recording in flight, and what the three that end one leave behind.
+    list(APPEND TEST_SOURCES AllocationWatch.cpp)
+    list(APPEND TEST_SOURCES engine/test_take_across_swap.cpp)
     list(APPEND TEST_SOURCES engine/test_engine_taps.cpp)
     list(APPEND TEST_SOURCES engine/test_clip_snapshot.cpp)
     list(APPEND TEST_SOURCES engine/test_clip_voice.cpp)

--- a/tests/engine/test_take_across_swap.cpp
+++ b/tests/engine/test_take_across_swap.cpp
@@ -526,6 +526,29 @@ TEST_CASE("The store keeps the tap of a take it is still holding",
     REQUIRE(store.takeTap(kTakeKey) == nullptr);
 }
 
+TEST_CASE("A take the live plan's model does not name is not fed",
+          "[engine][exec][session][record][2465]") {
+    Rig rig(emptyDirectory("ineligible"));
+    rig.play();
+    rig.run(128);
+
+    // Disarming closes the take the rig started and leaves an epoch whose model
+    // names no take on this key.
+    rig.disarm(kArmed);
+    REQUIRE(rig.publish());
+    REQUIRE(rig.session().takeClosedTakes().size() == 1);
+
+    // A take started afterwards is in the callback's set and is still not fed.
+    // Which is the point: eligibility rides with the epoch, so the block that
+    // first renders an edit's plan is already the block that stops feeding a
+    // take that edit ended -- whatever the publishing thread has reached.
+    rig.startTake();
+    rig.run(256);
+
+    auto closed = rig.session().stopTake(kTakeKey);
+    REQUIRE(finish(closed).empty());
+}
+
 TEST_CASE("A swap during a pass neither allocates nor frees on the audio thread",
           "[engine][exec][session][record][2465]") {
     if (!magda::test::allocationWatchWorks())

--- a/tests/engine/test_take_across_swap.cpp
+++ b/tests/engine/test_take_across_swap.cpp
@@ -14,8 +14,11 @@
 #include "EngineSessionScaffold.hpp"
 #include "core/TrackInfo.hpp"
 #include "exec/EngineSession.hpp"
+#include "exec/RuntimeStateStore.hpp"
 #include "io/LiveInput.hpp"
+#include "io/RecordStream.hpp"
 #include "io/TakeRecorder.hpp"
+#include "plan/RenderPlan.hpp"
 #include "tap/RecordTap.hpp"
 #include "transport/TempoMap.hpp"
 #include "transport/TransportState.hpp"
@@ -303,6 +306,31 @@ void requireUnbroken(const juce::AudioBuffer<float>& stored) {
         }
 }
 
+/// A take that records nothing, for the store-level case: what matters there
+/// is that one is held, not what it holds.
+class StubTake final : public magda::engine::TakeCapture {
+  public:
+    void capture(const magda::engine::BlockInfo&, bool, const magda::engine::LoopRange&) override {}
+
+    const RecordTap& tap() const override {
+        return tap_;
+    }
+
+    magda::engine::RecordStream& stream() override {
+        return stream_;
+    }
+
+  private:
+    class NullSink final : public magda::engine::RecordSink {};
+
+    RecordTap tap_{RecordMaterial::audio, {}};
+    NullSink sink_;
+    magda::engine::RecordStream stream_{sink_};
+};
+
+/// A factory that builds nothing, for a store driven without a session.
+class NoFactory final : public RuntimeStateFactory {};
+
 /// What a closed take became, for a case that reads it back.
 RecordedTake finish(ClosedTake& closed) {
     REQUIRE(closed.take != nullptr);
@@ -473,6 +501,29 @@ TEST_CASE("A second take on the same key closes the one it displaces",
     const auto stored = readBack(take.file);
     REQUIRE(stored.getNumSamples() == 128);
     REQUIRE(arrivalAt(stored, 0) == 128);
+}
+
+TEST_CASE("The store keeps the tap of a take it is still holding",
+          "[engine][exec][store][record][2465]") {
+    NoFactory factory;
+    magda::engine::RuntimeStateStore store(factory);
+
+    store.realiseTakeTap(kTakeKey, {});
+    store.holdTake(kTakeKey, std::make_unique<StubTake>());
+
+    // The model has lost the track and the plan never named it, which is the
+    // eviction that would free a tap the take is about to write to. The take
+    // is still the callback's, so neither may go.
+    const magda::engine::RenderPlan empty;
+    store.releaseDeleted(empty, {}, nullptr);
+
+    REQUIRE(store.takeTap(kTakeKey) != nullptr);
+    REQUIRE(store.releaseTake(kTakeKey).tap != nullptr);
+
+    // Once it has, the abandoned tap is the store's to drop.
+    store.realiseTakeTap(kTakeKey, {});
+    store.releaseDeleted(empty, {}, nullptr);
+    REQUIRE(store.takeTap(kTakeKey) == nullptr);
 }
 
 TEST_CASE("A swap during a pass neither allocates nor frees on the audio thread",

--- a/tests/engine/test_take_across_swap.cpp
+++ b/tests/engine/test_take_across_swap.cpp
@@ -202,8 +202,7 @@ class Rig {
         return magda::test::publishProject(session_, tracks_, master_, context_).published;
     }
 
-    /// The edits the cases perform, named for what they are rather than for
-    /// what they touch.
+    /// The edits the cases perform.
     void addDeviceTo(TrackId id) {
         auto& track = trackFor(id);
 
@@ -290,8 +289,8 @@ class Rig {
     int takes_ = 0;
 };
 
-/// Every sample of @p stored follows the one before it, from wherever it began.
-/// The whole of what "the file is continuous across the swap" means.
+/// Every sample of @p stored follows the one before it, from wherever it
+/// began. A rebuilt writer shows up here as a repeat or a gap.
 void requireUnbroken(const juce::AudioBuffer<float>& stored) {
     REQUIRE(stored.getNumSamples() > 0);
 

--- a/tests/engine/test_take_across_swap.cpp
+++ b/tests/engine/test_take_across_swap.cpp
@@ -2,11 +2,14 @@
 
 #include <algorithm>
 #include <array>
+#include <atomic>
 #include <catch2/catch_test_macros.hpp>
+#include <chrono>
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
 #include <memory>
+#include <thread>
 #include <utility>
 #include <vector>
 
@@ -193,6 +196,44 @@ class Rig {
         }
     }
 
+    /**
+     * @brief Run callbacks on a thread of their own until @ref stopCallbacks.
+     *
+     * What a publish actually races. Driven blocks put every edit between two
+     * callbacks of the test's choosing; this puts them wherever the scheduler
+     * does, which is the only way a case sees the gap between the plan going
+     * live and the recording set following it.
+     */
+    void runInBackground() {
+        running_ = true;
+        callbacks_ = std::thread([this] {
+            while (running_.load(std::memory_order_relaxed)) {
+                deliver(kBlockSize);
+                std::this_thread::sleep_for(std::chrono::microseconds(200));
+            }
+        });
+    }
+
+    /// Let the callbacks run on while the test does something else.
+    static void keepRunning(std::chrono::milliseconds how_long) {
+        std::this_thread::sleep_for(how_long);
+    }
+
+    void stopCallbacks() {
+        running_ = false;
+        if (callbacks_.joinable())
+            callbacks_.join();
+    }
+
+    ~Rig() {
+        stopCallbacks();
+    }
+
+    Rig(const Rig&) = delete;
+    Rig& operator=(const Rig&) = delete;
+    Rig(Rig&&) = delete;
+    Rig& operator=(Rig&&) = delete;
+
     /// One callback, with the heap watched. What the swap claim is measured on.
     std::size_t runWatched(int numSamples) {
         const AllocationWatch watch;
@@ -287,7 +328,12 @@ class Rig {
     /// Owned by the session; kept here to say whether it is the same one.
     TakeRecorder* recorder_ = nullptr;
 
+    /// Touched only by whichever thread is delivering callbacks.
     std::int64_t arrival_ = 0;
+
+    std::thread callbacks_;
+    std::atomic<bool> running_{false};
+
     DeviceId nextDeviceId_ = 100;
     int takes_ = 0;
 };
@@ -547,6 +593,47 @@ TEST_CASE("A take the live plan's model does not name is not fed",
 
     auto closed = rig.session().stopTake(kTakeKey);
     REQUIRE(finish(closed).empty());
+}
+
+TEST_CASE("A take carried and then stopped against a running callback",
+          "[engine][exec][session][record][2465]") {
+    Rig rig(emptyDirectory("threaded"));
+    rig.play();
+    rig.runInBackground();
+
+    for (auto edit = 0; edit < 20; ++edit) {
+        rig.addDeviceTo(kOther);
+        REQUIRE(rig.publish());
+    }
+
+    // Stopped with callbacks still running, and stopped rather than disarmed:
+    // the live epoch still names this take, so blocks are being fed to it right
+    // up to the publish inside stopTake. That publish waiting for the block is
+    // the only thing between finish() closing the file and a callback writing
+    // to it.
+    auto closed = rig.session().stopTake(kTakeKey);
+    auto* recorder = dynamic_cast<TakeRecorder*>(closed.take.get());
+    REQUIRE(recorder != nullptr);
+
+    // The take is out of the set before stopTake returns, so hundreds of
+    // callbacks later it has not taken another sample. This is what makes
+    // finishing it below safe, and it is the assertion that fails if the
+    // publish inside stopTake stops waiting.
+    const auto captured = recorder->capturedSamples();
+    REQUIRE(captured > 0);
+
+    Rig::keepRunning(std::chrono::milliseconds(20));
+    REQUIRE(recorder->capturedSamples() == captured);
+
+    const auto take = finish(closed);
+    rig.stopCallbacks();
+
+    // Whatever the interleaving was, the take holds one unbroken stretch of the
+    // input. Where each publish landed inside a callback is the scheduler's,
+    // and none of this depends on it.
+    REQUIRE_FALSE(take.failed);
+    REQUIRE(take.samplesLost == 0);
+    requireUnbroken(readBack(take.file));
 }
 
 TEST_CASE("A swap during a pass neither allocates nor frees on the audio thread",

--- a/tests/engine/test_take_across_swap.cpp
+++ b/tests/engine/test_take_across_swap.cpp
@@ -6,9 +6,12 @@
 #include <catch2/catch_test_macros.hpp>
 #include <chrono>
 #include <cmath>
+#include <condition_variable>
 #include <cstddef>
 #include <cstdint>
+#include <future>
 #include <memory>
+#include <mutex>
 #include <thread>
 #include <utility>
 #include <vector>
@@ -74,6 +77,13 @@ constexpr TrackId kOther = 2;
 
 constexpr TakeKey kTakeKey{kArmed, RecordMaterial::audio};
 
+/// The device a case parks the callback in, on the armed track from the start
+/// so that every plan carries it.
+constexpr DeviceId kParkingDeviceId = 99;
+
+/// The device an edit adds to say which blocks are the new plan's.
+constexpr DeviceId kWitnessDeviceId = 98;
+
 /// What arrival @p sample of @p channel carries, as test_take_recorder numbers
 /// it: inside full scale and far enough apart that two arrivals cannot round
 /// onto one float.
@@ -117,6 +127,126 @@ TrackInfo armedTrack(TrackId id) {
     return track;
 }
 
+/// A device an edit adds, which does nothing to the signal. What the carry
+/// cases recompile the plan with.
+class InertDevice final : public magda::engine::EngineDevice {
+  public:
+    void process(magda::engine::DeviceBlock&) override {}
+};
+
+/**
+ * @brief Says whether the block being rendered is one of the new plan's.
+ *
+ * A device only the edit's plan contains, so its first block is that plan's
+ * first block. Placed ahead of the parking device in the chain, so a callback
+ * stopped there has already said which plan it belongs to.
+ */
+class WitnessDevice final : public magda::engine::EngineDevice {
+  public:
+    explicit WitnessDevice(WitnessDevice** slot) : slot_(slot) {}
+
+    ~WitnessDevice() override {
+        if (slot_ != nullptr && *slot_ == this)
+            *slot_ = nullptr;
+    }
+
+    WitnessDevice(const WitnessDevice&) = delete;
+    WitnessDevice& operator=(const WitnessDevice&) = delete;
+    WitnessDevice(WitnessDevice&&) = delete;
+    WitnessDevice& operator=(WitnessDevice&&) = delete;
+
+    void process(magda::engine::DeviceBlock&) override {
+        rendered_.store(true, std::memory_order_release);
+    }
+
+    bool hasRendered() const {
+        return rendered_.load(std::memory_order_acquire);
+    }
+
+  private:
+    WitnessDevice** slot_ = nullptr;
+    std::atomic<bool> rendered_{false};
+};
+
+/**
+ * @brief A device that stops the callback inside its block until let through.
+ *
+ * What makes the gap between the plan going live and the recording set catching
+ * up reachable on purpose rather than by luck. A callback holds the recording
+ * feed for the whole of process(), so a callback parked in here is one the
+ * publishing thread has to wait for, parked exactly where a real one would be.
+ *
+ * Blocks are let through one at a time, which is what lets a case say "the
+ * block after the swap" and mean it.
+ */
+class ParkingDevice final : public magda::engine::EngineDevice {
+  public:
+    /// @p slot is where the factory keeps its pointer to this, cleared here so
+    /// that deleting the track this sits on does not leave one behind.
+    explicit ParkingDevice(ParkingDevice** slot) : slot_(slot) {}
+
+    ~ParkingDevice() override {
+        if (slot_ != nullptr && *slot_ == this)
+            *slot_ = nullptr;
+    }
+
+    ParkingDevice(const ParkingDevice&) = delete;
+    ParkingDevice& operator=(const ParkingDevice&) = delete;
+    ParkingDevice(ParkingDevice&&) = delete;
+    ParkingDevice& operator=(ParkingDevice&&) = delete;
+
+    void process(magda::engine::DeviceBlock&) override {
+        std::unique_lock<std::mutex> lock(mutex_);
+        if (!parking_)
+            return;
+
+        ++parked_;
+        arrived_.notify_all();
+        released_.wait(lock, [this] { return permits_ > 0 || !parking_; });
+
+        if (permits_ > 0)
+            --permits_;
+    }
+
+    void park() {
+        const std::lock_guard<std::mutex> lock(mutex_);
+        parking_ = true;
+    }
+
+    /// Wait until @p count blocks have entered and stopped here.
+    void waitForBlocks(int count) {
+        std::unique_lock<std::mutex> lock(mutex_);
+        arrived_.wait(lock, [this, count] { return parked_ >= count; });
+    }
+
+    void letOneThrough() {
+        {
+            const std::lock_guard<std::mutex> lock(mutex_);
+            ++permits_;
+        }
+        released_.notify_all();
+    }
+
+    void stopParking() {
+        {
+            const std::lock_guard<std::mutex> lock(mutex_);
+            parking_ = false;
+        }
+        released_.notify_all();
+    }
+
+  private:
+    ParkingDevice** slot_ = nullptr;
+
+    std::mutex mutex_;
+    std::condition_variable arrived_;
+    std::condition_variable released_;
+
+    bool parking_ = false;
+    int parked_ = 0;
+    int permits_ = 0;
+};
+
 /// Binds the live input ops so the armed track's chain is a chain the plan can
 /// render. The take reads the feed itself and not this, which is the point: an
 /// input op is topology and a take is not.
@@ -130,8 +260,31 @@ class InputFactory final : public RuntimeStateFactory {
         return std::make_unique<LiveAudioInput>(*feed, kChannels);
     }
 
+    /// One device is the parking one, for the case that needs the callback
+    /// held; the rest are the plain instances an edit adds.
+    std::unique_ptr<magda::engine::EngineDevice> createDevice(
+        magda::engine::DeviceKey key) override {
+        if (key.deviceId == kParkingDeviceId) {
+            auto device = std::make_unique<ParkingDevice>(&parking);
+            parking = device.get();
+            return device;
+        }
+
+        if (key.deviceId == kWitnessDeviceId) {
+            auto device = std::make_unique<WitnessDevice>(&witness);
+            witness = device.get();
+            return device;
+        }
+
+        return std::make_unique<InertDevice>();
+    }
+
     /// Set once the session exists, since the feed is the session's.
     const LiveInputFeed* feed = nullptr;
+
+    /// Owned by the store; kept here so a case can drive them.
+    ParkingDevice* parking = nullptr;
+    WitnessDevice* witness = nullptr;
 };
 
 /**
@@ -150,6 +303,7 @@ class Rig {
           output_(kNumChannels, kBlockSize) {
         tracks_.push_back(armedTrack(kArmed));
         tracks_.push_back(magda::test::makeTrack(kOther));
+        addDeviceTo(kArmed, kParkingDeviceId);
 
         factory_.feed = &session_.liveInputs();
         session_.liveInputs().prepare(kNumChannels, kBlockSize);
@@ -204,12 +358,18 @@ class Rig {
      * does, which is the only way a case sees the gap between the plan going
      * live and the recording set following it.
      */
-    void runInBackground() {
+    void runInBackground(bool backToBack = false) {
+        backToBack_ = backToBack;
         running_ = true;
         callbacks_ = std::thread([this] {
             while (running_.load(std::memory_order_relaxed)) {
                 deliver(kBlockSize);
-                std::this_thread::sleep_for(std::chrono::microseconds(200));
+
+                // Back to back when a case is forcing an interleaving: the gap
+                // between two callbacks is the one place the publishing thread
+                // could slip past without the window ever opening.
+                if (!backToBack_)
+                    std::this_thread::sleep_for(std::chrono::microseconds(200));
             }
         });
     }
@@ -220,6 +380,12 @@ class Rig {
     }
 
     void stopCallbacks() {
+        // Parking first, always: a callback stopped inside the device is a
+        // callback that never returns to see the flag, and a case that failed
+        // an assertion would hang here rather than report it.
+        if (factory_.parking != nullptr)
+            factory_.parking->stopParking();
+
         running_ = false;
         if (callbacks_.joinable())
             callbacks_.join();
@@ -247,15 +413,39 @@ class Rig {
     }
 
     /// The edits the cases perform.
-    void addDeviceTo(TrackId id) {
+    void addDeviceTo(TrackId id, DeviceId use = INVALID_DEVICE_ID) {
         auto& track = trackFor(id);
 
         DeviceInfo device;
-        device.id = nextDeviceId_++;
-        device.name = "Gain " + juce::String(device.id);
+        device.id = use == INVALID_DEVICE_ID ? nextDeviceId_++ : use;
+        device.name = "Device " + juce::String(device.id);
         device.format = PluginFormat::Internal;
 
         track.chain.fxChainElements.emplace_back(std::move(device));
+    }
+
+    /// The device a case parks the callback in. Null until a plan naming it has
+    /// been realised, which the constructor's publish does.
+    ParkingDevice& parking() {
+        REQUIRE(factory_.parking != nullptr);
+        return *factory_.parking;
+    }
+
+    /// Put the witness at the head of the armed track's chain, so it renders
+    /// before the parking device stops the block.
+    void witnessNextPlan() {
+        DeviceInfo device;
+        device.id = kWitnessDeviceId;
+        device.name = "Witness";
+        device.format = PluginFormat::Internal;
+
+        auto& chain = trackFor(kArmed).chain.fxChainElements;
+        chain.insert(chain.begin(), ChainElement{std::move(device)});
+    }
+
+    /// Whether the plan the witness belongs to has rendered a block yet.
+    bool witnessHasRendered() const {
+        return factory_.witness != nullptr && factory_.witness->hasRendered();
     }
 
     void rename(TrackId id) {
@@ -333,6 +523,7 @@ class Rig {
 
     std::thread callbacks_;
     std::atomic<bool> running_{false};
+    bool backToBack_ = false;
 
     DeviceId nextDeviceId_ = 100;
     int takes_ = 0;
@@ -351,6 +542,17 @@ void requireUnbroken(const juce::AudioBuffer<float>& stored) {
             FAIL();
         }
 }
+
+/// Lets a parked callback go however the case ends. Declared after the publish
+/// it is racing, so an assertion that fails between the two unwinds through
+/// this before the publish's own destructor waits on it.
+struct ReleaseParking {
+    ParkingDevice& device;
+
+    ~ReleaseParking() {
+        device.stopParking();
+    }
+};
 
 /// A take that records nothing, for the store-level case: what matters there
 /// is that one is held, not what it holds.
@@ -633,6 +835,61 @@ TEST_CASE("A take carried and then stopped against a running callback",
     // and none of this depends on it.
     REQUIRE_FALSE(take.failed);
     REQUIRE(take.samplesLost == 0);
+    requireUnbroken(readBack(take.file));
+}
+
+TEST_CASE("The block that first renders an edit does not feed the take it ended",
+          "[engine][exec][session][record][2465]") {
+    Rig rig(emptyDirectory("forced-window"));
+    rig.play();
+    rig.runInBackground(true);
+
+    // A callback stopped inside its block, holding the recording set for as
+    // long as it stands there. Its own capture() has already run.
+    rig.parking().park();
+    rig.parking().waitForBlocks(1);
+
+    auto* recorder = &rig.recorder();
+    const auto captured = recorder->capturedSamples();
+    REQUIRE(captured > 0);
+
+    // The publish cannot get past its swap while that callback is parked, so
+    // this thread is now stopped in exactly the place the race lives.
+    rig.disarm(kArmed);
+    rig.witnessNextPlan();
+    auto publishing = std::async(std::launch::async, [&rig] { return rig.publish(); });
+    const ReleaseParking release{rig.parking()};
+    Rig::keepRunning(std::chrono::milliseconds(20));
+
+    // Blocks through one at a time until one of them is the edit's. Which
+    // block that is depends on how far the publishing thread got, so the case
+    // finds it rather than assuming it: the witness renders ahead of the
+    // parking device, so a callback stopped there has already said.
+    auto before = captured;
+    for (auto parked = 2; !rig.witnessHasRendered(); ++parked) {
+        before = recorder->capturedSamples();
+        rig.parking().letOneThrough();
+        rig.parking().waitForBlocks(parked);
+    }
+
+    // That block rendered the edit's plan, and the publishing thread is still
+    // stopped at its own wait for it, so the recording set it was holding is
+    // the one from before the edit. It fed the take nothing: eligibility came
+    // off the epoch, not off the set.
+    REQUIRE(recorder->capturedSamples() == before);
+
+    // The publish is still stopped at its own wait for this callback, so let
+    // everything through before asking it for an answer. The guard above is for
+    // the path where the line before this one failed.
+    rig.parking().stopParking();
+    REQUIRE(publishing.get());
+    rig.stopCallbacks();
+
+    auto closed = rig.session().takeClosedTakes();
+    REQUIRE(closed.size() == 1);
+
+    const auto take = finish(closed.front());
+    REQUIRE_FALSE(take.failed);
     requireUnbroken(readBack(take.file));
 }
 

--- a/tests/engine/test_take_across_swap.cpp
+++ b/tests/engine/test_take_across_swap.cpp
@@ -9,7 +9,6 @@
 #include <condition_variable>
 #include <cstddef>
 #include <cstdint>
-#include <future>
 #include <memory>
 #include <mutex>
 #include <thread>
@@ -81,9 +80,6 @@ constexpr TakeKey kTakeKey{kArmed, RecordMaterial::audio};
 /// so that every plan carries it.
 constexpr DeviceId kParkingDeviceId = 99;
 
-/// The device an edit adds to say which blocks are the new plan's.
-constexpr DeviceId kWitnessDeviceId = 98;
-
 /// What arrival @p sample of @p channel carries, as test_take_recorder numbers
 /// it: inside full scale and far enough apart that two arrivals cannot round
 /// onto one float.
@@ -135,40 +131,6 @@ class InertDevice final : public magda::engine::EngineDevice {
 };
 
 /**
- * @brief Says whether the block being rendered is one of the new plan's.
- *
- * A device only the edit's plan contains, so its first block is that plan's
- * first block. Placed ahead of the parking device in the chain, so a callback
- * stopped there has already said which plan it belongs to.
- */
-class WitnessDevice final : public magda::engine::EngineDevice {
-  public:
-    explicit WitnessDevice(WitnessDevice** slot) : slot_(slot) {}
-
-    ~WitnessDevice() override {
-        if (slot_ != nullptr && *slot_ == this)
-            *slot_ = nullptr;
-    }
-
-    WitnessDevice(const WitnessDevice&) = delete;
-    WitnessDevice& operator=(const WitnessDevice&) = delete;
-    WitnessDevice(WitnessDevice&&) = delete;
-    WitnessDevice& operator=(WitnessDevice&&) = delete;
-
-    void process(magda::engine::DeviceBlock&) override {
-        rendered_.store(true, std::memory_order_release);
-    }
-
-    bool hasRendered() const {
-        return rendered_.load(std::memory_order_acquire);
-    }
-
-  private:
-    WitnessDevice** slot_ = nullptr;
-    std::atomic<bool> rendered_{false};
-};
-
-/**
  * @brief A device that stops the callback inside its block until let through.
  *
  * What makes the gap between the plan going live and the recording set catching
@@ -183,11 +145,13 @@ class ParkingDevice final : public magda::engine::EngineDevice {
   public:
     /// @p slot is where the factory keeps its pointer to this, cleared here so
     /// that deleting the track this sits on does not leave one behind.
-    explicit ParkingDevice(ParkingDevice** slot) : slot_(slot) {}
+    explicit ParkingDevice(std::atomic<ParkingDevice*>* slot) : slot_(slot) {}
 
     ~ParkingDevice() override {
-        if (slot_ != nullptr && *slot_ == this)
-            *slot_ = nullptr;
+        if (slot_ != nullptr) {
+            auto* self = this;
+            slot_->compare_exchange_strong(self, nullptr);
+        }
     }
 
     ParkingDevice(const ParkingDevice&) = delete;
@@ -236,7 +200,7 @@ class ParkingDevice final : public magda::engine::EngineDevice {
     }
 
   private:
-    ParkingDevice** slot_ = nullptr;
+    std::atomic<ParkingDevice*>* slot_ = nullptr;
 
     std::mutex mutex_;
     std::condition_variable arrived_;
@@ -270,21 +234,16 @@ class InputFactory final : public RuntimeStateFactory {
             return device;
         }
 
-        if (key.deviceId == kWitnessDeviceId) {
-            auto device = std::make_unique<WitnessDevice>(&witness);
-            witness = device.get();
-            return device;
-        }
-
         return std::make_unique<InertDevice>();
     }
 
     /// Set once the session exists, since the feed is the session's.
     const LiveInputFeed* feed = nullptr;
 
-    /// Owned by the store; kept here so a case can drive them.
-    ParkingDevice* parking = nullptr;
-    WitnessDevice* witness = nullptr;
+    /// Owned by the store; kept here so a case can drive it. Atomic because
+    /// createDevice runs on whichever thread published the plan that needed
+    /// one, which is not always the thread reading this.
+    std::atomic<ParkingDevice*> parking{nullptr};
 };
 
 /**
@@ -302,7 +261,7 @@ class Rig {
           input_(kNumChannels, kBlockSize),
           output_(kNumChannels, kBlockSize) {
         tracks_.push_back(armedTrack(kArmed));
-        tracks_.push_back(magda::test::makeTrack(kOther));
+        tracks_.push_back(armedTrack(kOther));
         addDeviceTo(kArmed, kParkingDeviceId);
 
         factory_.feed = &session_.liveInputs();
@@ -315,9 +274,9 @@ class Rig {
         startTake();
     }
 
-    /// Start a take on the armed track, named apart from any before it so a
-    /// case can tell two files from each other.
-    void startTake() {
+    /// Start a take on @p track, named apart from any before it so a case can
+    /// tell two files from each other.
+    TakeRecorder& startTakeOn(TrackId track) {
         TakeRecorderSettings settings;
         settings.channels = {0, 1};
         settings.directory = directory_;
@@ -325,12 +284,23 @@ class Rig {
         settings.file.format = AudioFileFormat::wav;
         settings.file.bitDepth = 32;
 
-        session_.startTake(kTakeKey, {}, [this, &settings](RecordTap& tap) {
-            auto recorder = std::make_unique<TakeRecorder>(session_.liveInputs(), context_, tap,
-                                                           std::move(settings));
-            recorder_ = recorder.get();
-            return recorder;
-        });
+        TakeRecorder* made = nullptr;
+        session_.startTake(TakeKey{track, RecordMaterial::audio}, {},
+                           [this, &settings, &made](RecordTap& tap) {
+                               auto recorder = std::make_unique<TakeRecorder>(
+                                   session_.liveInputs(), context_, tap, std::move(settings));
+                               made = recorder.get();
+                               return recorder;
+                           });
+
+        REQUIRE(made != nullptr);
+        if (track == kArmed)
+            recorder_ = made;
+        return *made;
+    }
+
+    void startTake() {
+        startTakeOn(kArmed);
     }
 
     void play() {
@@ -383,8 +353,8 @@ class Rig {
         // Parking first, always: a callback stopped inside the device is a
         // callback that never returns to see the flag, and a case that failed
         // an assertion would hang here rather than report it.
-        if (factory_.parking != nullptr)
-            factory_.parking->stopParking();
+        if (auto* device = factory_.parking.load())
+            device->stopParking();
 
         running_ = false;
         if (callbacks_.joinable())
@@ -427,25 +397,9 @@ class Rig {
     /// The device a case parks the callback in. Null until a plan naming it has
     /// been realised, which the constructor's publish does.
     ParkingDevice& parking() {
-        REQUIRE(factory_.parking != nullptr);
-        return *factory_.parking;
-    }
-
-    /// Put the witness at the head of the armed track's chain, so it renders
-    /// before the parking device stops the block.
-    void witnessNextPlan() {
-        DeviceInfo device;
-        device.id = kWitnessDeviceId;
-        device.name = "Witness";
-        device.format = PluginFormat::Internal;
-
-        auto& chain = trackFor(kArmed).chain.fxChainElements;
-        chain.insert(chain.begin(), ChainElement{std::move(device)});
-    }
-
-    /// Whether the plan the witness belongs to has rendered a block yet.
-    bool witnessHasRendered() const {
-        return factory_.witness != nullptr && factory_.witness->hasRendered();
+        auto* device = factory_.parking.load();
+        REQUIRE(device != nullptr);
+        return *device;
     }
 
     void rename(TrackId id) {
@@ -542,17 +496,6 @@ void requireUnbroken(const juce::AudioBuffer<float>& stored) {
             FAIL();
         }
 }
-
-/// Lets a parked callback go however the case ends. Declared after the publish
-/// it is racing, so an assertion that fails between the two unwinds through
-/// this before the publish's own destructor waits on it.
-struct ReleaseParking {
-    ParkingDevice& device;
-
-    ~ReleaseParking() {
-        device.stopParking();
-    }
-};
 
 /// A take that records nothing, for the store-level case: what matters there
 /// is that one is held, not what it holds.
@@ -838,59 +781,65 @@ TEST_CASE("A take carried and then stopped against a running callback",
     requireUnbroken(readBack(take.file));
 }
 
-TEST_CASE("The block that first renders an edit does not feed the take it ended",
+TEST_CASE("A callback inside the window between the plan and the takes it ended",
           "[engine][exec][session][record][2465]") {
     Rig rig(emptyDirectory("forced-window"));
     rig.play();
+
+    auto& ended = rig.recorder();
+    auto& continuing = rig.startTakeOn(kOther);
+    auto& parking = rig.parking();
+
     rig.runInBackground(true);
 
-    // A callback stopped inside its block, holding the recording set for as
-    // long as it stands there. Its own capture() has already run.
-    rig.parking().park();
-    rig.parking().waitForBlocks(1);
+    // Read from inside the publish, with a callback parked: the plan is live
+    // and the recording set is still the one from before the edit, which is
+    // the only interval in which the two disagree. Standing here is what the
+    // hook is for -- everything else about the two is a wait, and a wait
+    // cannot be observed from outside.
+    std::int64_t endedBefore = 0;
+    std::int64_t endedAfter = 0;
+    std::int64_t continuingBefore = 0;
+    std::int64_t continuingAfter = 0;
 
-    auto* recorder = &rig.recorder();
-    const auto captured = recorder->capturedSamples();
-    REQUIRE(captured > 0);
+    rig.session().betweenPlanAndTakesForTest = [&] {
+        parking.park();
 
-    // The publish cannot get past its swap while that callback is parked, so
-    // this thread is now stopped in exactly the place the race lives.
+        parking.waitForBlocks(1);
+        endedBefore = ended.capturedSamples();
+        continuingBefore = continuing.capturedSamples();
+
+        parking.letOneThrough();
+        parking.waitForBlocks(2);
+        endedAfter = ended.capturedSamples();
+        continuingAfter = continuing.capturedSamples();
+
+        parking.stopParking();
+    };
+
     rig.disarm(kArmed);
-    rig.witnessNextPlan();
-    auto publishing = std::async(std::launch::async, [&rig] { return rig.publish(); });
-    const ReleaseParking release{rig.parking()};
-    Rig::keepRunning(std::chrono::milliseconds(20));
+    REQUIRE(rig.publish());
 
-    // Blocks through one at a time until one of them is the edit's. Which
-    // block that is depends on how far the publishing thread got, so the case
-    // finds it rather than assuming it: the witness renders ahead of the
-    // parking device, so a callback stopped there has already said.
-    auto before = captured;
-    for (auto parked = 2; !rig.witnessHasRendered(); ++parked) {
-        before = recorder->capturedSamples();
-        rig.parking().letOneThrough();
-        rig.parking().waitForBlocks(parked);
-    }
-
-    // That block rendered the edit's plan, and the publishing thread is still
-    // stopped at its own wait for it, so the recording set it was holding is
-    // the one from before the edit. It fed the take nothing: eligibility came
-    // off the epoch, not off the set.
-    REQUIRE(recorder->capturedSamples() == before);
-
-    // The publish is still stopped at its own wait for this callback, so let
-    // everything through before asking it for an answer. The guard above is for
-    // the path where the line before this one failed.
-    rig.parking().stopParking();
-    REQUIRE(publishing.get());
+    rig.session().betweenPlanAndTakesForTest = nullptr;
     rig.stopCallbacks();
+
+    // Two callbacks, back to back, both rendering the edit's plan and both
+    // holding the recording set from before it. The take the edit ended gained
+    // nothing across them; the take it did not touch kept going.
+    REQUIRE(endedBefore > 0);
+    REQUIRE(endedAfter == endedBefore);
+    REQUIRE(continuingAfter > continuingBefore);
 
     auto closed = rig.session().takeClosedTakes();
     REQUIRE(closed.size() == 1);
+    REQUIRE(closed.front().key == kTakeKey);
 
     const auto take = finish(closed.front());
     REQUIRE_FALSE(take.failed);
     requireUnbroken(readBack(take.file));
+
+    auto other = rig.session().stopTake(TakeKey{kOther, RecordMaterial::audio});
+    finish(other);
 }
 
 TEST_CASE("A swap during a pass neither allocates nor frees on the audio thread",

--- a/tests/engine/test_take_across_swap.cpp
+++ b/tests/engine/test_take_across_swap.cpp
@@ -1,0 +1,501 @@
+#include <juce_audio_formats/juce_audio_formats.h>
+
+#include <algorithm>
+#include <array>
+#include <catch2/catch_test_macros.hpp>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "AllocationWatch.hpp"
+#include "EngineSessionScaffold.hpp"
+#include "core/TrackInfo.hpp"
+#include "exec/EngineSession.hpp"
+#include "io/LiveInput.hpp"
+#include "io/TakeRecorder.hpp"
+#include "tap/RecordTap.hpp"
+#include "transport/TempoMap.hpp"
+#include "transport/TransportState.hpp"
+
+/**
+ * @file test_take_across_swap.cpp
+ * @brief A take that survives a plan swap (#2465).
+ *
+ * Every other slice of recording fails loudly. This one fails by losing a
+ * performance, so the cases are about what an edit does to a recording it has
+ * nothing to do with -- a device added to another track, a rename, a clip moved
+ * -- and about the three edits that genuinely end one.
+ *
+ * A real EngineSession rather than a take driven by hand, because the swap is
+ * the session's: the plan, the executor and everything the store holds are
+ * replaced between two callbacks, and the claim is that the take is not.
+ *
+ * Every input sample says which arrival it is, so a file read back afterwards
+ * says where the take began and whether anything is missing from the middle of
+ * it -- a rebuilt writer shows up as a repeat or a gap, not as a wrong length.
+ */
+
+using namespace magda;
+using magda::engine::AudioFileFormat;
+using magda::engine::ClosedTake;
+using magda::engine::EngineAudioSource;
+using magda::engine::EngineSession;
+using magda::engine::LiveAudioInput;
+using magda::engine::LiveInputBlock;
+using magda::engine::LiveInputFeed;
+using magda::engine::RecordedTake;
+using magda::engine::RecordMaterial;
+using magda::engine::RecordTap;
+using magda::engine::RenderContext;
+using magda::engine::RuntimeStateFactory;
+using magda::engine::TakeKey;
+using magda::engine::TakeRecorder;
+using magda::engine::TakeRecorderSettings;
+using magda::engine::TransportSnapshot;
+using magda::test::AllocationWatch;
+
+namespace {
+
+constexpr double kSampleRate = 8000.0;
+constexpr int kBlockSize = 64;
+constexpr int kNumChannels = 2;
+
+constexpr TrackId kArmed = 1;
+constexpr TrackId kOther = 2;
+
+constexpr TakeKey kTakeKey{kArmed, RecordMaterial::audio};
+
+/// What arrival @p sample of @p channel carries, as test_take_recorder numbers
+/// it: inside full scale and far enough apart that two arrivals cannot round
+/// onto one float.
+float material(std::int64_t sample, int channel) {
+    return static_cast<float>(sample + 1 + (static_cast<std::int64_t>(channel) * 50000)) * 1.0e-5f;
+}
+
+/// The arrival a stored sample came from, which is what makes a file readable
+/// as a stretch of the input rather than as a length.
+std::int64_t arrivalAt(const juce::AudioBuffer<float>& stored, int at) {
+    return std::llround(static_cast<double>(stored.getSample(0, at)) * 1.0e5) - 1;
+}
+
+juce::File emptyDirectory(const juce::String& name) {
+    auto directory = juce::File::getSpecialLocation(juce::File::tempDirectory)
+                         .getChildFile("magda_take_swap_test")
+                         .getChildFile(name);
+    directory.deleteRecursively();
+    directory.createDirectory();
+    return directory;
+}
+
+juce::AudioBuffer<float> readBack(const juce::File& file) {
+    juce::AudioFormatManager formats;
+    formats.registerBasicFormats();
+
+    const std::unique_ptr<juce::AudioFormatReader> reader(formats.createReaderFor(file));
+    REQUIRE(reader != nullptr);
+
+    juce::AudioBuffer<float> buffer(static_cast<int>(reader->numChannels),
+                                    static_cast<int>(reader->lengthInSamples));
+    reader->read(&buffer, 0, buffer.getNumSamples(), 0, true, true);
+    return buffer;
+}
+
+/// A track pointed at hardware, which is what makes its input route external.
+TrackInfo armedTrack(TrackId id) {
+    auto track = magda::test::makeTrack(id);
+    track.audioInputDevice = "In 1 + 2";
+    track.recordArmed = true;
+    return track;
+}
+
+/// Binds the live input ops so the armed track's chain is a chain the plan can
+/// render. The take reads the feed itself and not this, which is the point: an
+/// input op is topology and a take is not.
+class InputFactory final : public RuntimeStateFactory {
+  public:
+    std::unique_ptr<EngineAudioSource> createAudioInput(TrackId) override {
+        if (feed == nullptr)
+            return nullptr;
+
+        static constexpr std::array<int, 2> kChannels{0, 1};
+        return std::make_unique<LiveAudioInput>(*feed, kChannels);
+    }
+
+    /// Set once the session exists, since the feed is the session's.
+    const LiveInputFeed* feed = nullptr;
+};
+
+/**
+ * @brief One session, one armed track, one take, driven a callback at a time.
+ *
+ * An edit is a mutation of the track list followed by a republish, which is
+ * what an edit is from the session's side and the only thing this rig does
+ * differently from any other engine test.
+ */
+class Rig {
+  public:
+    explicit Rig(const juce::File& directory)
+        : directory_(directory),
+          session_(factory_),
+          input_(kNumChannels, kBlockSize),
+          output_(kNumChannels, kBlockSize) {
+        tracks_.push_back(armedTrack(kArmed));
+        tracks_.push_back(magda::test::makeTrack(kOther));
+
+        factory_.feed = &session_.liveInputs();
+        session_.liveInputs().prepare(kNumChannels, kBlockSize);
+
+        transport_.tempo = magda::engine::TempoMap({{0.0, 120.0, 0.0f}}, {{0.0, 4, 4}});
+        session_.publishTransport(transport_);
+
+        REQUIRE(publish());
+        startTake();
+    }
+
+    /// Start a take on the armed track, named apart from any before it so a
+    /// case can tell two files from each other.
+    void startTake() {
+        TakeRecorderSettings settings;
+        settings.channels = {0, 1};
+        settings.directory = directory_;
+        settings.name = "take" + juce::String(++takes_);
+        settings.file.format = AudioFileFormat::wav;
+        settings.file.bitDepth = 32;
+
+        session_.startTake(kTakeKey, {}, [this, &settings](RecordTap& tap) {
+            auto recorder = std::make_unique<TakeRecorder>(session_.liveInputs(), context_, tap,
+                                                           std::move(settings));
+            recorder_ = recorder.get();
+            return recorder;
+        });
+    }
+
+    void play() {
+        ++transport_.request.generation;
+        transport_.request.playing = true;
+        transport_.request.locate = true;
+        transport_.request.positionBeat = 0.0;
+        session_.publishTransport(transport_);
+    }
+
+    /// Feed @p numSamples of callbacks through the session.
+    void run(int numSamples) {
+        for (auto left = numSamples; left > 0;) {
+            const auto callback = std::min(kBlockSize, left);
+            deliver(callback);
+            left -= callback;
+        }
+    }
+
+    /// One callback, with the heap watched. What the swap claim is measured on.
+    std::size_t runWatched(int numSamples) {
+        const AllocationWatch watch;
+        deliver(numSamples);
+        return watch.total();
+    }
+
+    /// An edit: mutate the project, compile it again, swap it in.
+    bool publish() {
+        return magda::test::publishProject(session_, tracks_, master_, context_).published;
+    }
+
+    /// The edits the cases perform, named for what they are rather than for
+    /// what they touch.
+    void addDeviceTo(TrackId id) {
+        auto& track = trackFor(id);
+
+        DeviceInfo device;
+        device.id = nextDeviceId_++;
+        device.name = "Gain " + juce::String(device.id);
+        device.format = PluginFormat::Internal;
+
+        track.chain.fxChainElements.emplace_back(std::move(device));
+    }
+
+    void rename(TrackId id) {
+        trackFor(id).name += " (edited)";
+    }
+
+    void disarm(TrackId id) {
+        trackFor(id).recordArmed = false;
+    }
+
+    void removeInputFrom(TrackId id) {
+        trackFor(id).audioInputDevice = {};
+    }
+
+    void deleteTrack(TrackId id) {
+        std::erase_if(tracks_, [id](const auto& track) { return track.id == id; });
+    }
+
+    EngineSession& session() {
+        return session_;
+    }
+
+    TakeRecorder& recorder() {
+        return *recorder_;
+    }
+
+    /// The take the session is feeding, as the callback would reach it, or
+    /// null. What says a swap moved nothing.
+    const TakeRecorder* held() const {
+        return recorder_;
+    }
+
+  private:
+    TrackInfo& trackFor(TrackId id) {
+        for (auto& track : tracks_)
+            if (track.id == id)
+                return track;
+
+        FAIL("no such track");
+        return tracks_.front();
+    }
+
+    void deliver(int numSamples) {
+        for (auto channel = 0; channel < input_.getNumChannels(); ++channel)
+            for (auto at = 0; at < numSamples; ++at)
+                input_.setSample(channel, at, material(arrival_ + at, channel));
+
+        const LiveInputBlock block{juce::dsp::AudioBlock<const float>(input_).getSubBlock(
+                                       0, static_cast<std::size_t>(numSamples)),
+                                   {}};
+
+        session_.process(numSamples, output_, block);
+        arrival_ += numSamples;
+    }
+
+    juce::File directory_;
+
+    InputFactory factory_;
+    EngineSession session_;
+
+    std::vector<TrackInfo> tracks_;
+    TrackInfo master_ = magda::test::makeMaster();
+
+    RenderContext context_{kSampleRate, kBlockSize, kNumChannels};
+    TransportSnapshot transport_;
+
+    juce::AudioBuffer<float> input_;
+    juce::AudioBuffer<float> output_;
+
+    /// Owned by the session; kept here to say whether it is the same one.
+    TakeRecorder* recorder_ = nullptr;
+
+    std::int64_t arrival_ = 0;
+    DeviceId nextDeviceId_ = 100;
+    int takes_ = 0;
+};
+
+/// Every sample of @p stored follows the one before it, from wherever it began.
+/// The whole of what "the file is continuous across the swap" means.
+void requireUnbroken(const juce::AudioBuffer<float>& stored) {
+    REQUIRE(stored.getNumSamples() > 0);
+
+    const auto first = arrivalAt(stored, 0);
+    for (auto at = 0; at < stored.getNumSamples(); ++at)
+        if (arrivalAt(stored, at) != first + at) {
+            INFO("sample " << at << " came from arrival " << arrivalAt(stored, at) << ", not "
+                           << first + at);
+            FAIL();
+        }
+}
+
+/// What a closed take became, for a case that reads it back.
+RecordedTake finish(ClosedTake& closed) {
+    REQUIRE(closed.take != nullptr);
+    REQUIRE(closed.tap != nullptr);
+
+    auto* recorder = dynamic_cast<TakeRecorder*>(closed.take.get());
+    REQUIRE(recorder != nullptr);
+    return recorder->finish();
+}
+
+}  // namespace
+
+TEST_CASE("A recompile during a pass leaves the take one unbroken file",
+          "[engine][exec][session][record][2465]") {
+    Rig rig(emptyDirectory("swaps"));
+    rig.play();
+
+    const auto* before = rig.held();
+
+    // Ten edits, none of them about the armed track, spread through the pass.
+    for (auto edit = 0; edit < 10; ++edit) {
+        rig.run(128);
+
+        if (edit % 2 == 0)
+            rig.addDeviceTo(kOther);
+        else
+            rig.rename(kOther);
+
+        REQUIRE(rig.publish());
+    }
+
+    rig.run(128);
+
+    // The same object throughout: a swap that rebuilt it would be a file split
+    // in two whatever the audio looked like.
+    REQUIRE(rig.held() == before);
+    REQUIRE(rig.recorder().rolling());
+
+    auto closed = rig.session().stopTake(kTakeKey);
+    const auto take = finish(closed);
+
+    REQUIRE_FALSE(take.failed);
+    REQUIRE(take.samplesLost == 0);
+
+    const auto stored = readBack(take.file);
+    REQUIRE(stored.getNumSamples() == 11 * 128);
+    requireUnbroken(stored);
+}
+
+TEST_CASE("An edit to the armed track's own chain carries the take",
+          "[engine][exec][session][record][2465]") {
+    Rig rig(emptyDirectory("armed-chain"));
+    rig.play();
+
+    const auto* before = rig.held();
+
+    rig.run(256);
+    rig.addDeviceTo(kArmed);
+    REQUIRE(rig.publish());
+    rig.run(256);
+
+    REQUIRE(rig.held() == before);
+
+    auto closed = rig.session().stopTake(kTakeKey);
+    const auto take = finish(closed);
+
+    const auto stored = readBack(take.file);
+    REQUIRE(stored.getNumSamples() == 512);
+    requireUnbroken(stored);
+}
+
+TEST_CASE("Disarming mid-pass closes the take and materialises it",
+          "[engine][exec][session][record][2465]") {
+    Rig rig(emptyDirectory("disarm"));
+    rig.play();
+    rig.run(256);
+
+    rig.disarm(kArmed);
+    REQUIRE(rig.publish());
+
+    // Out of the callback's set, and nothing else in the session is recording.
+    auto closed = rig.session().takeClosedTakes();
+    REQUIRE(closed.size() == 1);
+    REQUIRE(closed.front().key == kTakeKey);
+
+    // Blocks after the edit reach no take, so nothing is added to it.
+    rig.run(256);
+
+    const auto take = finish(closed.front());
+    REQUIRE_FALSE(take.failed);
+
+    const auto stored = readBack(take.file);
+    REQUIRE(stored.getNumSamples() == 256);
+    requireUnbroken(stored);
+    REQUIRE(arrivalAt(stored, 0) == 0);
+}
+
+TEST_CASE("A track that loses its input closes the take it was feeding",
+          "[engine][exec][session][record][2465]") {
+    Rig rig(emptyDirectory("input-gone"));
+    rig.play();
+    rig.run(192);
+
+    rig.removeInputFrom(kArmed);
+    REQUIRE(rig.publish());
+
+    auto closed = rig.session().takeClosedTakes();
+    REQUIRE(closed.size() == 1);
+
+    const auto take = finish(closed.front());
+    REQUIRE_FALSE(take.failed);
+    REQUIRE(readBack(take.file).getNumSamples() == 192);
+}
+
+TEST_CASE("Deleting the recording track closes the file and loses nothing",
+          "[engine][exec][session][record][2465]") {
+    Rig rig(emptyDirectory("deleted"));
+    rig.play();
+    rig.run(320);
+
+    rig.deleteTrack(kArmed);
+    REQUIRE(rig.publish());
+
+    auto closed = rig.session().takeClosedTakes();
+    REQUIRE(closed.size() == 1);
+
+    const auto take = finish(closed.front());
+    REQUIRE_FALSE(take.failed);
+    REQUIRE(take.samplesLost == 0);
+
+    const auto stored = readBack(take.file);
+    REQUIRE(stored.getNumSamples() == 320);
+    requireUnbroken(stored);
+    REQUIRE(arrivalAt(stored, 0) == 0);
+}
+
+TEST_CASE("An edit that ends no take publishes nothing to the callback",
+          "[engine][exec][session][record][2465]") {
+    Rig rig(emptyDirectory("untouched"));
+    rig.play();
+    rig.run(128);
+
+    rig.addDeviceTo(kOther);
+    REQUIRE(rig.publish());
+
+    REQUIRE(rig.session().takeClosedTakes().empty());
+    REQUIRE(rig.recorder().rolling());
+}
+
+TEST_CASE("A second take on the same key closes the one it displaces",
+          "[engine][exec][session][record][2465]") {
+    Rig rig(emptyDirectory("displaced"));
+    rig.play();
+    rig.run(128);
+
+    rig.startTake();
+    rig.run(128);
+
+    auto closed = rig.session().takeClosedTakes();
+    REQUIRE(closed.size() == 1);
+
+    const auto first = finish(closed.front());
+    REQUIRE(readBack(first.file).getNumSamples() == 128);
+
+    auto second = rig.session().stopTake(kTakeKey);
+    const auto take = finish(second);
+
+    const auto stored = readBack(take.file);
+    REQUIRE(stored.getNumSamples() == 128);
+    REQUIRE(arrivalAt(stored, 0) == 128);
+}
+
+TEST_CASE("A swap during a pass neither allocates nor frees on the audio thread",
+          "[engine][exec][session][record][2465]") {
+    if (!magda::test::allocationWatchWorks())
+        SKIP("this build's operator new is somebody else's, so nothing would be counted");
+
+    Rig rig(emptyDirectory("no-alloc"));
+    rig.play();
+    rig.run(256);
+
+    // Warm: the first callbacks of a session touch things a later one does not.
+    REQUIRE(rig.runWatched(kBlockSize) == 0);
+
+    rig.addDeviceTo(kOther);
+    REQUIRE(rig.publish());
+
+    // The first block on the new epoch, with the take still in flight.
+    REQUIRE(rig.runWatched(kBlockSize) == 0);
+    REQUIRE(rig.runWatched(kBlockSize) == 0);
+
+    auto closed = rig.session().stopTake(kTakeKey);
+    const auto take = finish(closed);
+    requireUnbroken(readBack(take.file));
+}


### PR DESCRIPTION
Slice 7 of #1895, closes #2465. A recording in flight is carried across a plan
swap, and the edits that end one end it cleanly.

## Why it is in the store

An in-flight take is not recomputable from the model, the transport or the
parameter lanes. It is a file handle, a write position, the take's start and a
queue holding samples nobody has written yet. So it goes where a device instance
goes: `RuntimeStateStore`, keyed by `TakeKey` — the identity the differ matches
an input op on, minus the op, since a track has one live audio input and one
live MIDI input and so at most two takes.

Any edit recompiles. Adding a device to another track, a rename, a clip moved:
none of them are about the armed track, and all of them swap the plan under it.
None of them touch the take, so the writer, the queue and the position are the
same objects on both sides and the file is continuous across the swap sample.

## What ends a take

`RuntimeStateIds` gains the takes the model still says may run: a track armed,
with an input of that material. It is the one entry there naming something
*allowed to continue* rather than something that exists, because the plan cannot
answer it — a track with monitoring on still compiles the same input op after
you disarm it.

The three edits that end a take each have one outcome: disarm, the input taken
away, the track deleted. Each closes the take and hands it back through
`takeClosedTakes()` with the tap it was writing to, so what was recorded up to
the edit becomes a clip. A file is never left open and a partial take is never
dropped. A second take started on a key that already has one displaces the first
the same way rather than destroying it under the callback.

## Ordering

- **An edit is one boundary for the plan and for the takes.** `PreparedRender`
  carries the model's eligible `TakeKey`s, so a block feeds a take only when the
  epoch it is rendering names it. The recording set says what exists; the epoch
  says what may record. Without that, a callback could hold the new plan and the
  old set at once and go on feeding a take the edit had ended — for more than
  one callback if the publishing thread was descheduled.
- A take leaves the callback's set first, in a publish that waits for the block,
  and only then is it released from the store.
- Takes are closed after the plan swap, since the edit only counts once its plan
  is playing.
- The tap travels with the take, because `finish()` writes to it. `startTake`
  therefore takes a factory rather than a built recorder: closing whatever the
  key was already recording takes that key's tap away, so the tap to build
  against does not exist until the close has happened.
- A take no edit reached is not touched at all — no publish, no wait.

Retention is the store's rather than an order its caller has to keep:
`releaseDeleted` will not evict a take or a tap the store still holds, whatever
the model IDs say, on the same reading the live plan already gets there. A
store-level case drives that eviction directly and fails without it.

`EngineSession::recordingFeed()` is gone. The session is the only thing that
publishes the callback's set now, which is what makes the ordering above an
invariant rather than a convention.

## Verification

`tests/engine/test_take_across_swap.cpp`, driving a real `EngineSession`:

- a pass over ten swaps is one file whose every sample follows the one before it,
  with no gap, no repeat and no discontinuity at any swap sample
- a device added in front of the armed track's own input still carries the take
- disarming mid-pass closes it and materialises 256 samples
- a track that loses its input closes the take it was feeding
- deleting the recording track closes the file with nothing lost
- an edit that ends no take publishes nothing to the callback
- a second take on the same key closes the one it displaces
- a swap during a pass neither allocates nor frees on the audio thread
- the store keeps the tap of a take it is still holding
- a take the live plan's model does not name is not fed
- a take carried and then stopped against callbacks running on their own thread
  takes no further sample once `stopTake` has returned
- a callback standing inside the window between the plan going live and the
  takes the edit ended leaving the set: the ended take gains nothing, a take on
  an untouched track keeps going

The last one is new machinery: `tests/AllocationWatch` replaces the global
`operator new`/`delete` with counters armed per thread, so a case can assert that
a block allocates and frees nothing. It forwards to malloc and free, so nothing
else in the binary behaves differently for it being linked in, and it self-tests
(`allocationWatchWorks()`) rather than passing vacuously where a sanitizer
runtime supplies its own.

All twelve were checked against a broken engine: naming no take at all fails the
four carry cases, naming every take fails disarm and input-gone, one deliberate
allocation in `process()` fails the allocation case, dropping the eviction guard
fails the store case, dropping the eligibility gate fails both the gate case and
the in-window one (20 of 20), and removing the wait from `stopTake` fails the
concurrent stop 12 of 12.

Full non-JUCE suite: 3852 passed, 13 skipped, 0 failed. JUCE suite including the
real-project corpus: all passed.

The last two run callbacks on a thread of their own and publish against them.

One stops the take rather than disarming it, deliberately: with the gate in place
a disarmed take goes quiet at the swap, so only an explicit stop leaves blocks
being fed right up to the publish inside `stopTake`, where the wait is still the
only thing between `finish()` closing the file and a callback writing to it.

The other stands inside the window rather than racing it. `EngineSession` carries
one hook, `betweenPlanAndTakesForTest`, called after the plan is live and before
`closeUnnamedTakes` — empty otherwise, one null check per publish. It is the only
one, and deliberately: every other ordering in `publish()` is a wait, and a wait
cannot be observed from outside, while this is a gap. The case parks a callback
from within the hook, so the recording set is still the pre-edit one by
construction, and reads two consecutive blocks. Clean over 30 consecutive runs of
the tag.

## Not in this slice

The swap-to-self null test #2465 hands to #1896. Nothing here starts a recording
from the model — the host side of arm-and-roll is still ahead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X7rCviRzaXVzLAjNKwVCxN
