### PR TITLE
Collapse daw/ui search loops to ranges algorithms

### DIFF
--- a/.pre-commit-hooks/clang_tidy.py
+++ b/.pre-commit-hooks/clang_tidy.py
@@ -396,6 +396,15 @@ def main() -> int:
               f"LLVM {required} and point CLANG_TIDY at it, or change "
               f"CLANG_TIDY_REQUIRE_MAJOR if the pin is meant to move.",
               file=sys.stderr)
+        # An advisory run does not block, and least of all on its own toolchain:
+        # a runner without the pinned keg is not a finding about the code under
+        # review. Homebrew moved `llvm` to 23 and the second macOS runner has no
+        # llvm@20, which blocked every PR on a step that cannot fail on findings.
+        # Binding runs still stop here, or the pin would mean nothing.
+        if advisory:
+            print("\nSKIPPED - wrong clang-tidy. ADVISORY ONLY - not failing.",
+                  file=sys.stderr)
+            return 0
         return 1
 
     database = args.build_dir / "compile_commands.json"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ All contributions require signing our [Contributor License Agreement (CLA)](CLA.
 ### Prerequisites
 
 - CMake 3.24+
-- C++23 compiler (Clang 15+ or GCC 13+)
+- C++23 compiler and standard library (GCC 13+, or Clang 16+ with libc++)
 - macOS: Xcode Command Line Tools
 - Linux: ALSA and X11 development headers
 

--- a/README.md
+++ b/README.md
@@ -48,8 +48,12 @@ See [Issues](https://github.com/Conceptual-Machines/magda-core/issues) for known
 
 ### Prerequisites
 
-- C++23 compiler: GCC 11.1+, Clang 12+, AppleClang 13+, or MSVC 19.29+
-  (CI builds with GCC 13, AppleClang 16 and MSVC 19.50)
+- C++23 compiler **and standard library**: GCC 13+, Clang 16+ with libc++,
+  AppleClang 16+, or MSVC 19.36+ (VS 2022 17.6). The floor is the library, not
+  the language: `std::views::zip` and `std::ranges::contains` are in use, and
+  libstdc++ only gained `views::zip` in GCC 13.1, so a GCC 12 build fails even
+  though CMake will select C++23 for it.
+  (CI builds with GCC 13.3, AppleClang 16.0 and MSVC 19.50.)
 - CMake 3.24+
 - [Git LFS](https://git-lfs.com/) — required to fetch bundled binary assets
   (CJK font, etc.). Install with `brew install git-lfs` (macOS),

--- a/README_CN.md
+++ b/README_CN.md
@@ -48,7 +48,10 @@ MAGDA是一款免费的, 深度集成 AI 的开源数字音频工作站（DAW）
 
 ### Prerequisites前置准备
 
-- C++23 标准编译器：GCC 11.1 及以上、Clang 12 及以上、AppleClang 13 及以上，或 MSVC 19.29 及以上（CI 使用 GCC 13、AppleClang 16 与 MSVC 19.50 构建）
+- C++23 编译器**及标准库**：GCC 13 及以上、Clang 16 及以上（配合 libc++）、AppleClang 16 及以上，或 MSVC 19.36 及以上（VS 2022 17.6）。
+  决定下限的是标准库而非语言：代码使用了 `std::views::zip` 与 `std::ranges::contains`，
+  而 libstdc++ 自 GCC 13.1 起才提供 `views::zip`，因此即便 CMake 能为 GCC 12 选择 C++23，构建仍会失败。
+  （CI 使用 GCC 13.3、AppleClang 16.0 与 MSVC 19.50 构建。）
 - CMake 3.24 及以上版本
 - [Git LFS](https://git-lfs.com/) ：必需，用于拉取项目内置二进制资源，如中日韩字体等
   (CJK font, etc.).

--- a/magda/daw/audio/plugins/DrumGridRoles.hpp
+++ b/magda/daw/audio/plugins/DrumGridRoles.hpp
@@ -1,7 +1,7 @@
 #pragma once
-
 #include <juce_core/juce_core.h>
 
+#include <algorithm>
 #include <array>
 
 // Closed vocabulary of drum-row roles used by the drummer agent (#859) and the
@@ -39,19 +39,14 @@ inline constexpr std::array<RoleInfo, 17> kRoles{{
 inline bool isValidRoleId(const juce::String& id) {
     if (id.isEmpty())
         return false;
-    for (const auto& r : kRoles) {
-        if (id == juce::String(r.id))
-            return true;
-    }
-    return false;
+    const auto hasThisId = [&id](const auto& role) { return id == juce::String(role.id); };
+    return std::ranges::any_of(kRoles, hasThisId);
 }
 
 inline juce::String displayLabelForRole(const juce::String& id) {
-    for (const auto& r : kRoles) {
-        if (id == juce::String(r.id))
-            return r.displayLabel;
-    }
-    return {};
+    const auto hasThisId = [&id](const auto& r) { return id == juce::String(r.id); };
+    const auto role = std::ranges::find_if(kRoles, hasThisId);
+    return role != std::ranges::end(kRoles) ? juce::String(role->displayLabel) : juce::String{};
 }
 
 inline juce::String shortTagForRole(const juce::String& id) {

--- a/magda/daw/ui/components/chain/ChainPanel.cpp
+++ b/magda/daw/ui/components/chain/ChainPanel.cpp
@@ -1,5 +1,8 @@
 #include "ChainPanel.hpp"
 
+#include <algorithm>
+#include <iterator>
+
 #include "ChainNodePathDrag.hpp"
 #include "DeviceSlotComponent.hpp"
 #include "NodeComponent.hpp"
@@ -593,25 +596,19 @@ void ChainPanel::rebuildElementSlots() {
         if (magda::isDevice(element)) {
             const auto& device = magda::getDevice(element);
 
-            // Check if we already have a slot for this device
-            DeviceSlotComponent* existingDeviceSlot = nullptr;
-            size_t existingIndex = 0;
-            for (size_t i = 0; i < elementSlots_.size(); ++i) {
-                if (auto* deviceSlot = dynamic_cast<DeviceSlotComponent*>(elementSlots_[i].get())) {
-                    if (deviceSlot->getDeviceId() == device.id) {
-                        existingDeviceSlot = deviceSlot;
-                        existingIndex = i;
-                        break;
-                    }
-                }
-            }
+            // Reuse the existing slot for this device rather than rebuilding it.
+            const auto showsThisDevice = [&device](const auto& slot) {
+                const auto* deviceSlot = dynamic_cast<const DeviceSlotComponent*>(slot.get());
+                return deviceSlot != nullptr && deviceSlot->getDeviceId() == device.id;
+            };
+            const auto existing = std::ranges::find_if(elementSlots_, showsThisDevice);
 
-            if (existingDeviceSlot) {
-                // Found existing slot - preserve it and update its data
+            if (existing != elementSlots_.end()) {
+                auto* existingDeviceSlot = static_cast<DeviceSlotComponent*>(existing->get());
                 existingDeviceSlot->updateFromDevice(device);
                 existingDeviceSlot->setNodePath(chainPath_.withDevice(device.id));
-                newSlots.push_back(std::move(elementSlots_[existingIndex]));
-                elementSlots_.erase(elementSlots_.begin() + static_cast<long>(existingIndex));
+                newSlots.push_back(std::move(*existing));
+                elementSlots_.erase(existing);
             } else {
                 // Create new slot for new device
                 auto slot = std::make_unique<DeviceSlotComponent>(device);
@@ -633,25 +630,19 @@ void ChainPanel::rebuildElementSlots() {
                                     << " steps, trackId=" << chainPath_.trackId);
             DBG("  nestedRackPath has " << nestedRackPath.steps.size() << " steps");
 
-            // Check if we already have a RackComponent for this rack
-            RackComponent* existingRackComp = nullptr;
-            size_t existingIndex = 0;
-            for (size_t i = 0; i < elementSlots_.size(); ++i) {
-                if (auto* rackComp = dynamic_cast<RackComponent*>(elementSlots_[i].get())) {
-                    if (rackComp->getRackId() == rack.id) {
-                        existingRackComp = rackComp;
-                        existingIndex = i;
-                        break;
-                    }
-                }
-            }
+            // Reuse the existing component for this rack rather than rebuilding it.
+            const auto showsThisRack = [&rack](const auto& slot) {
+                const auto* rackComp = dynamic_cast<const RackComponent*>(slot.get());
+                return rackComp != nullptr && rackComp->getRackId() == rack.id;
+            };
+            const auto existing = std::ranges::find_if(elementSlots_, showsThisRack);
 
-            if (existingRackComp) {
-                // Found existing RackComponent - preserve it and update its data
+            if (existing != elementSlots_.end()) {
+                auto* existingRackComp = static_cast<RackComponent*>(existing->get());
                 existingRackComp->updateFromRack(rack);
                 existingRackComp->setNodePath(nestedRackPath);
-                newSlots.push_back(std::move(elementSlots_[existingIndex]));
-                elementSlots_.erase(elementSlots_.begin() + static_cast<long>(existingIndex));
+                newSlots.push_back(std::move(*existing));
+                elementSlots_.erase(existing);
             } else {
                 // Create new RackComponent for nested rack (with path context)
                 auto rackComp = std::make_unique<RackComponent>(nestedRackPath, rack);
@@ -876,24 +867,20 @@ void ChainPanel::onDeviceSlotSelected(magda::DeviceId deviceId) {
 }
 
 int ChainPanel::findElementIndex(NodeComponent* element) const {
-    for (size_t i = 0; i < elementSlots_.size(); ++i) {
-        if (elementSlots_[i].get() == element) {
-            return static_cast<int>(i);
-        }
-    }
-    return -1;
+    const auto isElement = [element](const auto& slot) { return slot.get() == element; };
+    const auto match = std::ranges::find_if(elementSlots_, isElement);
+    return match == elementSlots_.end()
+               ? -1
+               : static_cast<int>(std::ranges::distance(elementSlots_.begin(), match));
 }
 
 int ChainPanel::calculateInsertIndex(int mouseX) const {
-    // Find insert position based on mouse X and element midpoints
-    for (size_t i = 0; i < elementSlots_.size(); ++i) {
-        int midX = elementSlots_[i]->getX() + elementSlots_[i]->getWidth() / 2;
-        if (mouseX < midX) {
-            return static_cast<int>(i);
-        }
-    }
-    // After last element
-    return static_cast<int>(elementSlots_.size());
+    // The first slot whose midpoint the mouse has not passed; else after the last.
+    const auto isPastMouse = [mouseX](const auto& slot) {
+        return mouseX < slot->getX() + slot->getWidth() / 2;
+    };
+    const auto match = std::ranges::find_if(elementSlots_, isPastMouse);
+    return static_cast<int>(std::ranges::distance(elementSlots_.begin(), match));
 }
 
 int ChainPanel::calculateIndicatorX(int index) const {

--- a/magda/daw/ui/components/chain/custom_ui/ImpulseResponseUI.cpp
+++ b/magda/daw/ui/components/chain/custom_ui/ImpulseResponseUI.cpp
@@ -1,9 +1,12 @@
 #include "custom_ui/ImpulseResponseUI.hpp"
 
+#include <algorithm>
+
 #include "BinaryData.h"
 #include "ui/components/common/InternalFileDrag.hpp"
 #include "ui/themes/DarkTheme.hpp"
 #include "ui/themes/FontManager.hpp"
+#include "ui/utils/AudioFileTypes.hpp"
 
 namespace magda::daw::ui {
 
@@ -175,13 +178,7 @@ void ImpulseResponseUI::resized() {
 }
 
 bool ImpulseResponseUI::isInterestedInFileDrag(const juce::StringArray& files) {
-    for (const auto& f : files) {
-        juce::File file(f);
-        auto ext = file.getFileExtension().toLowerCase();
-        if (ext == ".wav" || ext == ".aif" || ext == ".aiff" || ext == ".flac" || ext == ".ogg")
-            return true;
-    }
-    return false;
+    return std::ranges::any_of(files, isAudioFile);
 }
 
 void ImpulseResponseUI::filesDropped(const juce::StringArray& files, int /*x*/, int /*y*/) {

--- a/magda/daw/ui/components/chain/custom_ui/PolyStepSequencerUI.cpp
+++ b/magda/daw/ui/components/chain/custom_ui/PolyStepSequencerUI.cpp
@@ -1,5 +1,7 @@
 #include "custom_ui/PolyStepSequencerUI.hpp"
 
+#include <algorithm>
+
 #include "audio/AudioBridge.hpp"
 #include "audio/plugins/DrumGridPlugin.hpp"
 #include "core/GestureRouter.hpp"
@@ -809,21 +811,17 @@ class PolyStepSequencerUI::DrumLanesView : public PolyStepSequencerUI::PatternVi
             }
         }
 
-        std::sort(lanes_.begin(), lanes_.end(),
-                  [](const Lane& a, const Lane& b) { return a.note < b.note; });
-        lanes_.erase(std::unique(lanes_.begin(), lanes_.end(),
-                                 [](const Lane& a, const Lane& b) { return a.note == b.note; }),
-                     lanes_.end());
+        std::ranges::sort(lanes_, {}, &Lane::note);
+        const auto duplicates = std::ranges::unique(lanes_, {}, &Lane::note);
+        lanes_.erase(duplicates.begin(), duplicates.end());
 
         clampScrollOffset();
         repaint();
     }
 
     bool hasLaneForNote(int note) const {
-        for (const auto& lane : lanes_)
-            if (lane.note == note)
-                return true;
-        return false;
+        const auto hasNote = [note](const auto& lane) { return lane.note == note; };
+        return std::ranges::any_of(lanes_, hasNote);
     }
 
     /** Coalesced async lane refresh (ValueTree callbacks can fire mid-edit). */

--- a/magda/daw/ui/components/chain/custom_ui/SamplerUI.cpp
+++ b/magda/daw/ui/components/chain/custom_ui/SamplerUI.cpp
@@ -11,6 +11,7 @@
 #include "ui/themes/DarkTheme.hpp"
 #include "ui/themes/FontManager.hpp"
 #include "ui/themes/SmallButtonLookAndFeel.hpp"
+#include "ui/utils/AudioFileTypes.hpp"
 
 namespace magda::daw::ui {
 
@@ -551,13 +552,7 @@ void SamplerUI::buildWaveformPath(const juce::AudioBuffer<float>* buffer, int wi
 }
 
 bool SamplerUI::isInterestedInFileDrag(const juce::StringArray& files) {
-    for (const auto& f : files) {
-        if (f.endsWithIgnoreCase(".wav") || f.endsWithIgnoreCase(".aif") ||
-            f.endsWithIgnoreCase(".aiff") || f.endsWithIgnoreCase(".flac") ||
-            f.endsWithIgnoreCase(".ogg") || f.endsWithIgnoreCase(".mp3"))
-            return true;
-    }
-    return false;
+    return std::ranges::any_of(files, isAudioFile);
 }
 
 void SamplerUI::filesDropped(const juce::StringArray& files, int /*x*/, int /*y*/) {

--- a/magda/daw/ui/components/chain/custom_ui/StruckInstrumentUI.cpp
+++ b/magda/daw/ui/components/chain/custom_ui/StruckInstrumentUI.cpp
@@ -1,5 +1,6 @@
 #include "custom_ui/StruckInstrumentUI.hpp"
 
+#include <algorithm>
 #include <cmath>
 
 #include "audio/plugins/compiled/MagdaCompiledPolyInstrument.hpp"
@@ -46,19 +47,22 @@ juce::String displayLabel(const juce::String& hostName) {
 }  // namespace
 
 bool StruckInstrumentUI::handles(const juce::String& pluginId) {
-    for (const auto& d : kDevices)
-        if (pluginId.equalsIgnoreCase(d.pluginId))
-            return true;
-    return false;
+    const auto matchesPluginId = [&pluginId](const auto& d) {
+        return pluginId.equalsIgnoreCase(d.pluginId);
+    };
+    return std::ranges::any_of(kDevices, matchesPluginId);
 }
 
 StruckInstrumentUI::StruckInstrumentUI(const juce::String& pluginId)
     : kind_(pluginId.equalsIgnoreCase("magda_djembe") ? Kind::Djembe
             : pluginId.equalsIgnoreCase("magda_bell") ? Kind::Bell
                                                       : Kind::Marimba) {
-    for (const auto& d : kDevices)
-        if (pluginId.equalsIgnoreCase(d.pluginId))
-            title_ = d.title;
+    const auto matchesPluginId = [&pluginId](const auto& d) {
+        return pluginId.equalsIgnoreCase(d.pluginId);
+    };
+    const auto device = std::ranges::find_if(kDevices, matchesPluginId);
+    if (device != std::ranges::end(kDevices))
+        title_ = device->title;
 
     // Slot membership matches each device's voiceSlotInfos() order, with Gain
     // appended by MagdaCompiledPolyInstrument.

--- a/magda/daw/ui/components/chain/drum_grid/DrumGridUI.cpp
+++ b/magda/daw/ui/components/chain/drum_grid/DrumGridUI.cpp
@@ -3,6 +3,7 @@
 #include <BinaryData.h>
 #include <tracktion_engine/tracktion_engine.h>
 
+#include <algorithm>
 #include <cmath>
 #include <set>
 
@@ -14,6 +15,7 @@
 #include "ui/themes/DarkTheme.hpp"
 #include "ui/themes/FontManager.hpp"
 #include "ui/themes/SmallButtonLookAndFeel.hpp"
+#include "ui/utils/AudioFileTypes.hpp"
 
 namespace te = tracktion::engine;
 
@@ -564,25 +566,12 @@ void DrumGridUI::setSelectedPad(int padIndex) {
 // =============================================================================
 
 bool DrumGridUI::isInterestedInFileDrag(const juce::StringArray& files) {
-    for (const auto& f : files) {
-        if (f.endsWithIgnoreCase(".wav") || f.endsWithIgnoreCase(".aif") ||
-            f.endsWithIgnoreCase(".aiff") || f.endsWithIgnoreCase(".flac") ||
-            f.endsWithIgnoreCase(".ogg") || f.endsWithIgnoreCase(".mp3"))
-            return true;
-    }
-    return false;
+    return std::ranges::any_of(files, isAudioFile);
 }
 
 namespace {
 int countAudioFilesDG(const juce::StringArray& files) {
-    int n = 0;
-    for (const auto& f : files) {
-        if (f.endsWithIgnoreCase(".wav") || f.endsWithIgnoreCase(".aif") ||
-            f.endsWithIgnoreCase(".aiff") || f.endsWithIgnoreCase(".flac") ||
-            f.endsWithIgnoreCase(".ogg") || f.endsWithIgnoreCase(".mp3"))
-            ++n;
-    }
-    return n;
+    return static_cast<int>(std::ranges::count_if(files, isAudioFile));
 }
 }  // namespace
 

--- a/magda/daw/ui/components/chain/modulation/LFOCurveEditor.cpp
+++ b/magda/daw/ui/components/chain/modulation/LFOCurveEditor.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <ranges>
 #include <utility>
 
 #include "core/TrackManager.hpp"
@@ -182,23 +183,21 @@ void LFOCurveEditor::syncFromModInfo() {
 
     // Update local points from modInfo->curvePoints without rebuilding components
     // This is used for syncing with external editor during drag
-    for (size_t i = 0; i < points_.size() && i < modInfo_->curvePoints.size(); ++i) {
-        points_[i].x = static_cast<double>(modInfo_->curvePoints[i].phase);
-        points_[i].y = static_cast<double>(modInfo_->curvePoints[i].value);
-        points_[i].tension = static_cast<double>(modInfo_->curvePoints[i].tension);
-        points_[i].curveType = intToCurveType(modInfo_->curvePoints[i].curveType);
-        points_[i].inHandle.x = static_cast<double>(modInfo_->curvePoints[i].inHandleX);
-        points_[i].inHandle.y = static_cast<double>(modInfo_->curvePoints[i].inHandleY);
-        points_[i].outHandle.x = static_cast<double>(modInfo_->curvePoints[i].outHandleX);
-        points_[i].outHandle.y = static_cast<double>(modInfo_->curvePoints[i].outHandleY);
+    for (auto&& [point, source] : std::views::zip(points_, modInfo_->curvePoints)) {
+        point.x = static_cast<double>(source.phase);
+        point.y = static_cast<double>(source.value);
+        point.tension = static_cast<double>(source.tension);
+        point.curveType = intToCurveType(source.curveType);
+        point.inHandle.x = static_cast<double>(source.inHandleX);
+        point.inHandle.y = static_cast<double>(source.inHandleY);
+        point.outHandle.x = static_cast<double>(source.outHandleX);
+        point.outHandle.y = static_cast<double>(source.outHandleY);
     }
 
     // Update point component positions
-    for (size_t i = 0; i < pointComponents_.size() && i < points_.size(); ++i) {
-        pointComponents_[i]->updateFromPoint(points_[i]);
-        int px = xToPixel(points_[i].x);
-        int py = yToPixel(points_[i].y);
-        pointComponents_[i]->setCentrePosition(px, py);
+    for (auto&& [component, point] : std::views::zip(pointComponents_, points_)) {
+        component->updateFromPoint(point);
+        component->setCentrePosition(xToPixel(point.x), yToPixel(point.y));
     }
 
     updateTensionHandlePositions();
@@ -256,8 +255,7 @@ void LFOCurveEditor::setModInfo(ModInfo* mod) {
             points_.push_back(point);
         }
         // Sort by x position
-        std::sort(points_.begin(), points_.end(),
-                  [](const CurvePoint& a, const CurvePoint& b) { return a.x < b.x; });
+        std::ranges::sort(points_, {}, &CurvePoint::x);
         // Ensure first and last points are pinned to edges
         if (!points_.empty()) {
             points_.front().x = 0.0;
@@ -433,8 +431,7 @@ void LFOCurveEditor::onPointMoved(uint32_t pointId, double newX, double newY) {
     }
 
     // Re-sort points by x position
-    std::sort(points_.begin(), points_.end(),
-              [](const CurvePoint& a, const CurvePoint& b) { return a.x < b.x; });
+    std::ranges::sort(points_, {}, &CurvePoint::x);
 
     rebuildPointComponents();
     repaint();  // Force full repaint after structural change
@@ -1123,8 +1120,7 @@ void LFOCurveEditor::loadCurvePoints(const std::vector<CurvePointData>& points) 
         points_.push_back(point);
     }
 
-    std::sort(points_.begin(), points_.end(),
-              [](const CurvePoint& a, const CurvePoint& b) { return a.x < b.x; });
+    std::ranges::sort(points_, {}, &CurvePoint::x);
 
     if (points_.size() < 2) {
         loadPreset(CurvePreset::Triangle);

--- a/magda/daw/ui/components/chain/params/ParamLinkResolver.cpp
+++ b/magda/daw/ui/components/chain/params/ParamLinkResolver.cpp
@@ -1,5 +1,7 @@
 #include "params/ParamLinkResolver.hpp"
 
+#include <algorithm>
+
 namespace magda::daw::ui {
 
 std::vector<ResolvedModLink> getLinkedMods(const ParamLinkContext& ctx) {
@@ -101,66 +103,27 @@ bool hasActiveLinks(const ParamLinkContext& ctx) {
         return false;
     }
 
-    magda::ControlTarget modTarget =
-        magda::ControlTarget::pluginParam(ctx.devicePath, ctx.paramIndex);
+    // A mod link counts only when enabled; a macro link counts by existing.
+    const auto target = magda::ControlTarget::pluginParam(ctx.devicePath, ctx.paramIndex);
 
-    // Check device-level mods
-    if (ctx.deviceMods) {
-        for (const auto& mod : *ctx.deviceMods) {
-            if (const auto* link = mod.getLink(modTarget); link != nullptr && link->enabled) {
-                return true;
-            }
-        }
-    }
+    const auto drivesTarget = [&target](const auto& mod) {
+        const auto* link = mod.getLink(target);
+        return link != nullptr && link->enabled;
+    };
+    const auto linksTarget = [&target](const auto& macro) {
+        return macro.getLink(target) != nullptr;
+    };
 
-    // Check rack-level mods
-    if (ctx.rackMods) {
-        for (const auto& mod : *ctx.rackMods) {
-            if (const auto* link = mod.getLink(modTarget); link != nullptr && link->enabled) {
-                return true;
-            }
-        }
-    }
+    const auto anyEnabledMod = [&drivesTarget](const magda::ModArray* mods) {
+        return mods != nullptr && std::ranges::any_of(*mods, drivesTarget);
+    };
+    const auto anyMacro = [&linksTarget](const magda::MacroArray* macros) {
+        return macros != nullptr && std::ranges::any_of(*macros, linksTarget);
+    };
 
-    // Check device-level macros
-    magda::ControlTarget macroTarget =
-        magda::ControlTarget::pluginParam(ctx.devicePath, ctx.paramIndex);
-    if (ctx.deviceMacros) {
-        for (const auto& macro : *ctx.deviceMacros) {
-            if (macro.getLink(macroTarget) != nullptr) {
-                return true;
-            }
-        }
-    }
-
-    // Check rack-level macros
-    if (ctx.rackMacros) {
-        for (const auto& macro : *ctx.rackMacros) {
-            if (macro.getLink(macroTarget) != nullptr) {
-                return true;
-            }
-        }
-    }
-
-    // Check track-level mods
-    if (ctx.trackMods) {
-        for (const auto& mod : *ctx.trackMods) {
-            if (const auto* link = mod.getLink(modTarget); link != nullptr && link->enabled) {
-                return true;
-            }
-        }
-    }
-
-    // Check track-level macros
-    if (ctx.trackMacros) {
-        for (const auto& macro : *ctx.trackMacros) {
-            if (macro.getLink(macroTarget) != nullptr) {
-                return true;
-            }
-        }
-    }
-
-    return false;
+    return anyEnabledMod(ctx.deviceMods) || anyEnabledMod(ctx.rackMods) ||
+           anyEnabledMod(ctx.trackMods) || anyMacro(ctx.deviceMacros) || anyMacro(ctx.rackMacros) ||
+           anyMacro(ctx.trackMacros);
 }
 
 float computeTotalModModulation(const ParamLinkContext& ctx) {

--- a/magda/daw/ui/components/chain/slot/DeviceSlotHeaderControls.cpp
+++ b/magda/daw/ui/components/chain/slot/DeviceSlotHeaderControls.cpp
@@ -72,9 +72,8 @@ void layoutExpandedDeviceSlotHeader(juce::Rectangle<int>& headerArea,
     const auto visibility = getHeaderControlVisibility(traits, device, isInternalDevice);
     auto specs = buildHeaderControlSpecs(traits, device, isInternalDevice,
                                          getHeaderControlComponents(controls));
-    std::sort(specs.begin(), specs.end(), [](const auto& lhs, const auto& rhs) {
-        return lhs.expandedOrder < rhs.expandedOrder;
-    });
+    constexpr auto expandedOrder = [](const auto& spec) { return spec.expandedOrder; };
+    std::ranges::sort(specs, {}, expandedOrder);
 
     setVisibleIfPresent(controls.powerButton, visibility.power);
     setVisibleIfPresent(controls.presetButton, visibility.preset);
@@ -113,9 +112,8 @@ void layoutCollapsedDeviceSlotControls(juce::Rectangle<int>& area,
 
     auto specs = buildHeaderControlSpecs(traits, device, isInternalDevice,
                                          getHeaderControlComponents(controls.headerControls));
-    std::sort(specs.begin(), specs.end(), [](const auto& lhs, const auto& rhs) {
-        return lhs.collapsedOrder < rhs.collapsedOrder;
-    });
+    constexpr auto collapsedOrder = [](const auto& spec) { return spec.collapsedOrder; };
+    std::ranges::sort(specs, {}, collapsedOrder);
 
     for (auto& spec : specs) {
         placeCollapsedButtonIfVisible(area, spec.component, spec.collapsedVisible, buttonSize);

--- a/magda/daw/ui/components/common/curve/CurveEditorBase.cpp
+++ b/magda/daw/ui/components/common/curve/CurveEditorBase.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <functional>
 #include <limits>
 #include <map>
 #include <set>
@@ -19,6 +20,13 @@ CurveEditorBase::CurveEditorBase() {
 }
 
 CurveEditorBase::~CurveEditorBase() = default;
+
+void CurveEditorBase::setPointComponentSelected(uint32_t pointId, bool selected) {
+    const auto ownsPoint = [pointId](const auto& c) { return c->getPointId() == pointId; };
+    const auto it = std::ranges::find_if(pointComponents_, ownsPoint);
+    if (it != pointComponents_.end())
+        (*it)->setSelected(selected);
+}
 
 void CurveEditorBase::clearSelection() {
     selectedPointIds_.clear();
@@ -117,29 +125,13 @@ void CurveEditorBase::paintCurve(juce::Graphics& g) {
         return;
 
     // Clear stale preview state if the preview point no longer exists
-    if (previewPointId_ != INVALID_CURVE_POINT_ID) {
-        bool found = false;
-        for (const auto& p : points) {
-            if (p.id == previewPointId_) {
-                found = true;
-                break;
-            }
-        }
-        if (!found) {
-            previewPointId_ = INVALID_CURVE_POINT_ID;
-        }
+    if (previewPointId_ != INVALID_CURVE_POINT_ID &&
+        !std::ranges::contains(points, previewPointId_, &CurvePoint::id)) {
+        previewPointId_ = INVALID_CURVE_POINT_ID;
     }
-    if (tensionPreviewPointId_ != INVALID_CURVE_POINT_ID) {
-        bool found = false;
-        for (const auto& p : points) {
-            if (p.id == tensionPreviewPointId_) {
-                found = true;
-                break;
-            }
-        }
-        if (!found) {
-            tensionPreviewPointId_ = INVALID_CURVE_POINT_ID;
-        }
+    if (tensionPreviewPointId_ != INVALID_CURVE_POINT_ID &&
+        !std::ranges::contains(points, tensionPreviewPointId_, &CurvePoint::id)) {
+        tensionPreviewPointId_ = INVALID_CURVE_POINT_ID;
     }
 
     const auto renderPoints = getRenderOrderedPoints();
@@ -859,16 +851,10 @@ void CurveEditorBase::rebuildPointComponents() {
                 // Toggle this point in the selection
                 if (selectedPointIds_.count(pointId)) {
                     selectedPointIds_.erase(pointId);
-                    for (auto& p : pointComponents_) {
-                        if (p->getPointId() == pointId)
-                            p->setSelected(false);
-                    }
+                    setPointComponentSelected(pointId, false);
                 } else {
                     selectedPointIds_.insert(pointId);
-                    for (auto& p : pointComponents_) {
-                        if (p->getPointId() == pointId)
-                            p->setSelected(true);
-                    }
+                    setPointComponentSelected(pointId, true);
                 }
             } else {
                 // If clicking a point that's already part of a multi-selection,
@@ -879,10 +865,7 @@ void CurveEditorBase::rebuildPointComponents() {
                         p->setSelected(false);
                     }
                     selectedPointIds_.insert(pointId);
-                    for (auto& p : pointComponents_) {
-                        if (p->getPointId() == pointId)
-                            p->setSelected(true);
-                    }
+                    setPointComponentSelected(pointId, true);
                 }
             }
 

--- a/magda/daw/ui/components/common/curve/CurveEditorBase.hpp
+++ b/magda/daw/ui/components/common/curve/CurveEditorBase.hpp
@@ -150,6 +150,9 @@ class CurveEditorBase : public juce::Component {
     std::optional<ColourRole> curveColourRole_{DarkTheme::AUTOMATION_BEZIER};
     int padding_ = 5;  // Content area padding (>= half of point size)
 
+    /** @brief Flag the component owning @p pointId; ids are unique per editor. */
+    void setPointComponentSelected(uint32_t pointId, bool selected);
+
     // Components
     std::vector<std::unique_ptr<CurvePointComponent>> pointComponents_;
     std::vector<std::unique_ptr<CurveBezierHandle>> handleComponents_;

--- a/magda/daw/ui/components/mixer/RoutingSelector.cpp
+++ b/magda/daw/ui/components/mixer/RoutingSelector.cpp
@@ -1,5 +1,8 @@
 #include "RoutingSelector.hpp"
 
+#include <algorithm>
+#include <functional>
+
 #include "../../themes/DarkTheme.hpp"
 #include "../../themes/FontManager.hpp"
 
@@ -117,24 +120,17 @@ void RoutingSelector::setSelectedId(int id) {
 }
 
 juce::String RoutingSelector::getSelectedName() const {
-    for (const auto& opt : options_) {
-        if (opt.id == selectedId_) {
-            return opt.name;
-        }
-    }
-    return "None";
+    const auto opt = std::ranges::find(options_, selectedId_, &RoutingOption::id);
+    return opt != options_.end() ? opt->name : juce::String("None");
 }
 
 void RoutingSelector::setOptions(const std::vector<RoutingOption>& options) {
     options_ = options;
     // Auto-select first non-separator option if nothing selected
-    if (selectedId_ < 0 && !options_.empty()) {
-        for (const auto& opt : options_) {
-            if (!opt.isSeparator) {
-                selectedId_ = opt.id;
-                break;
-            }
-        }
+    if (selectedId_ < 0) {
+        const auto opt = std::ranges::find_if(options_, std::not_fn(&RoutingOption::isSeparator));
+        if (opt != options_.end())
+            selectedId_ = opt->id;
     }
 }
 
@@ -144,12 +140,9 @@ void RoutingSelector::clearOptions() {
 }
 
 int RoutingSelector::getFirstChannelOptionId() const {
-    for (const auto& opt : options_) {
-        if (!opt.isSeparator && opt.id >= 10) {
-            return opt.id;
-        }
-    }
-    return -1;
+    constexpr auto isChannelOption = [](const auto& o) { return !o.isSeparator && o.id >= 10; };
+    const auto opt = std::ranges::find_if(options_, isChannelOption);
+    return opt != options_.end() ? opt->id : -1;
 }
 
 juce::Rectangle<int> RoutingSelector::getMainButtonArea() const {

--- a/magda/daw/ui/components/pianoroll/PianoRollGridComponent.cpp
+++ b/magda/daw/ui/components/pianoroll/PianoRollGridComponent.cpp
@@ -25,6 +25,7 @@
 #include "core/TrackManager.hpp"
 #include "core/UndoManager.hpp"
 #include "ui/components/common/InternalFileDrag.hpp"
+#include "ui/utils/AudioFileTypes.hpp"
 
 namespace magda {
 
@@ -2757,24 +2758,18 @@ void PianoRollGridComponent::itemDropped(const SourceDetails& details) {
 }
 
 bool PianoRollGridComponent::isInterestedInFileDrag(const juce::StringArray& files) {
-    for (const auto& f : files)
-        if (f.endsWithIgnoreCase(".mid") || f.endsWithIgnoreCase(".midi"))
-            return true;
-    return false;
+    return std::ranges::any_of(files, isMidiFile);
 }
 
 void PianoRollGridComponent::filesDropped(const juce::StringArray& files, int x, int /*y*/) {
     if (clipId_ == INVALID_CLIP_ID && selectedClipIds_.empty())
         return;
 
-    // Find first .mid file
-    juce::File midiFile;
-    for (const auto& f : files) {
-        if (f.endsWithIgnoreCase(".mid") || f.endsWithIgnoreCase(".midi")) {
-            midiFile = juce::File(f);
-            break;
-        }
-    }
+    const auto first = std::ranges::find_if(files, isMidiFile);
+    if (first == files.end())
+        return;
+
+    const juce::File midiFile(*first);
     if (!midiFile.existsAsFile())
         return;
 

--- a/magda/daw/ui/components/tracks/TrackContentPanel.cpp
+++ b/magda/daw/ui/components/tracks/TrackContentPanel.cpp
@@ -31,20 +31,11 @@
 #include "core/TrackCommands.hpp"
 #include "core/UndoManager.hpp"
 #include "project/ProjectManager.hpp"
+#include "ui/utils/AudioFileTypes.hpp"
 
 namespace magda {
 
 namespace {
-
-bool isDraggedAudioFile(const juce::String& path) {
-    return path.endsWithIgnoreCase(".wav") || path.endsWithIgnoreCase(".aiff") ||
-           path.endsWithIgnoreCase(".aif") || path.endsWithIgnoreCase(".mp3") ||
-           path.endsWithIgnoreCase(".ogg") || path.endsWithIgnoreCase(".flac");
-}
-
-bool isDraggedMidiFile(const juce::String& path) {
-    return path.endsWithIgnoreCase(".mid") || path.endsWithIgnoreCase(".midi");
-}
 
 // Point the bottom panel at the right editor for a newly selected clip. It
 // deliberately never touches the panel's collapsed state: selecting a clip is
@@ -3297,12 +3288,10 @@ void TrackContentPanel::updateAutomationLanePositions() {
 // =============================================================================
 
 bool TrackContentPanel::isInterestedInFileDrag(const juce::StringArray& files) {
-    for (const auto& file : files) {
-        if (isDraggedAudioFile(file) || isDraggedMidiFile(file)) {
-            return true;
-        }
-    }
-    return false;
+    const auto isImportable = [](const auto& file) {
+        return isAudioFile(file) || isMidiFile(file);
+    };
+    return std::ranges::any_of(files, isImportable);
 }
 
 void TrackContentPanel::fileDragEnter(const juce::StringArray& files, int x, int y) {
@@ -3333,7 +3322,7 @@ void TrackContentPanel::beginFilesDropFeedback(const juce::StringArray& files, i
     juce::AudioFormatManager formatMgr;
     formatMgr.registerBasicFormats();
     for (const auto& f : files) {
-        if (isDraggedAudioFile(f)) {
+        if (isAudioFile(f)) {
             double duration = 4.0;
             juce::File audioFile(f);
             if (auto reader = std::unique_ptr<juce::AudioFormatReader>(
@@ -3342,7 +3331,7 @@ void TrackContentPanel::beginFilesDropFeedback(const juce::StringArray& files, i
                     duration = static_cast<double>(reader->lengthInSamples) / reader->sampleRate;
             }
             fileDropGhosts_.push_back({audioFile.getFileNameWithoutExtension(), duration});
-        } else if (isDraggedMidiFile(f)) {
+        } else if (isMidiFile(f)) {
             auto midiGhosts = makeMidiDropGhosts(juce::File(f), tempoBPM);
             fileDropGhosts_.insert(fileDropGhosts_.end(), midiGhosts.begin(), midiGhosts.end());
         }
@@ -3410,11 +3399,9 @@ void TrackContentPanel::importFilesAtPosition(const juce::StringArray& files, in
     // track accepts is per kind, so the check below needs to know what it has.
     juce::StringArray audioFiles, midiFiles;
     for (const auto& filePath : files) {
-        if (filePath.endsWithIgnoreCase(".mid") || filePath.endsWithIgnoreCase(".midi"))
+        if (isMidiFile(filePath))
             midiFiles.add(filePath);
-        else if (filePath.endsWithIgnoreCase(".wav") || filePath.endsWithIgnoreCase(".aiff") ||
-                 filePath.endsWithIgnoreCase(".aif") || filePath.endsWithIgnoreCase(".mp3") ||
-                 filePath.endsWithIgnoreCase(".ogg") || filePath.endsWithIgnoreCase(".flac"))
+        else if (isAudioFile(filePath))
             audioFiles.add(filePath);
     }
 

--- a/magda/daw/ui/components/tracks/TrackHeadersPanel.cpp
+++ b/magda/daw/ui/components/tracks/TrackHeadersPanel.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <cmath>
 #include <functional>
+#include <ranges>
 #include <utility>
 
 #include "../../../audio/AudioBridge.hpp"
@@ -1113,10 +1114,8 @@ void TrackHeadersPanel::trackPropertyChanged(int trackId) {
         // Update send labels from track data
         if (track->sends.size() == header.sendLabels.size()) {
             // Same count — update levels in-place (avoids destroying labels mid-drag)
-            for (size_t i = 0; i < header.sendLabels.size(); ++i) {
-                float levelDb = gainToDb(track->sends[i].level);
-                header.sendLabels[i]->setValue(levelDb, juce::dontSendNotification);
-            }
+            for (const auto& [label, send] : std::views::zip(header.sendLabels, track->sends))
+                label->setValue(gainToDb(send.level), juce::dontSendNotification);
         } else {
             // Send count changed — full rebuild
             rebuildSendLabels(header, trackId);
@@ -2005,9 +2004,9 @@ void TrackHeadersPanel::rebuildSendLabels(TrackHeader& header, TrackId trackId) 
             const auto* track = TrackManager::getInstance().getTrack(trackId);
             if (!track)
                 return;
-            for (size_t i = 0; i < header.sendLabels.size() && i < track->sends.size(); ++i) {
-                if (track->sends[i].busIndex == busIndex) {
-                    float newLevel = dbToGain(static_cast<float>(header.sendLabels[i]->getValue()));
+            for (const auto& [label, send] : std::views::zip(header.sendLabels, track->sends)) {
+                if (send.busIndex == busIndex) {
+                    const float newLevel = dbToGain(static_cast<float>(label->getValue()));
                     UndoManager::getInstance().executeCommand(
                         std::make_unique<SetSendLevelCommand>(trackId, busIndex, newLevel));
                     break;
@@ -2157,13 +2156,15 @@ juce::Rectangle<int> TrackHeadersPanel::getResizeHandleArea(int trackIndex) cons
 }
 
 bool TrackHeadersPanel::isResizeHandleArea(const juce::Point<int>& point, int& trackIndex) const {
-    for (int i = 0; i < static_cast<int>(trackHeaders.size()); ++i) {
-        if (getResizeHandleArea(i).contains(point)) {
-            trackIndex = i;
-            return true;
-        }
-    }
-    return false;
+    const auto handleContainsPoint = [this, point](int i) {
+        return getResizeHandleArea(i).contains(point);
+    };
+    const auto indices = std::views::iota(0, static_cast<int>(trackHeaders.size()));
+    const auto match = std::ranges::find_if(indices, handleContainsPoint);
+    if (match == indices.end())
+        return false;
+    trackIndex = *match;
+    return true;
 }
 
 void TrackHeadersPanel::layoutMeterColumn(TrackHeader& header, juce::Rectangle<int>& workArea,
@@ -3637,17 +3638,20 @@ bool TrackHeadersPanel::isInterestedInDragSource(const SourceDetails& details) {
     return false;
 }
 
+int TrackHeadersPanel::droppableHeaderIndexAt(juce::Point<int> point) const {
+    // Master is skipped: a drop there creates a new track, like empty space.
+    const auto acceptsDropAt = [this, point](int i) {
+        return !trackHeaders[static_cast<size_t>(i)]->isMaster &&
+               getTrackHeaderArea(i).contains(point);
+    };
+    const auto indices = std::views::iota(0, static_cast<int>(trackHeaders.size()));
+    const auto match = std::ranges::find_if(indices, acceptsDropAt);
+    return match == indices.end() ? -1 : *match;
+}
+
 void TrackHeadersPanel::itemDragEnter(const SourceDetails& details) {
     pluginDragActive_ = true;
-    pluginDropTrackIndex_ = -1;
-    for (int i = 0; i < static_cast<int>(trackHeaders.size()); ++i) {
-        if (trackHeaders[i]->isMaster)
-            continue;
-        if (getTrackHeaderArea(i).contains(details.localPosition)) {
-            pluginDropTrackIndex_ = i;
-            break;
-        }
-    }
+    pluginDropTrackIndex_ = droppableHeaderIndexAt(details.localPosition);
 
     // Ghost header for the new track that a drop on empty area would create.
     if (pluginDropTrackIndex_ < 0) {
@@ -3666,15 +3670,7 @@ void TrackHeadersPanel::itemDragEnter(const SourceDetails& details) {
 
 void TrackHeadersPanel::itemDragMove(const SourceDetails& details) {
     int prev = pluginDropTrackIndex_;
-    pluginDropTrackIndex_ = -1;
-    for (int i = 0; i < static_cast<int>(trackHeaders.size()); ++i) {
-        if (trackHeaders[i]->isMaster)
-            continue;
-        if (getTrackHeaderArea(i).contains(details.localPosition)) {
-            pluginDropTrackIndex_ = i;
-            break;
-        }
-    }
+    pluginDropTrackIndex_ = droppableHeaderIndexAt(details.localPosition);
 
     if (pluginDropTrackIndex_ < 0) {
         if (auto* obj = details.description.getDynamicObject()) {
@@ -3710,15 +3706,7 @@ void TrackHeadersPanel::itemDropped(const SourceDetails& details) {
 
     // Determine which track header was dropped on (skip master — dropping
     // on master area creates a new track, same as empty space)
-    int targetIndex = -1;
-    for (int i = 0; i < static_cast<int>(trackHeaders.size()); ++i) {
-        if (trackHeaders[i]->isMaster)
-            continue;
-        if (getTrackHeaderArea(i).contains(details.localPosition)) {
-            targetIndex = i;
-            break;
-        }
-    }
+    const int targetIndex = droppableHeaderIndexAt(details.localPosition);
 
     const auto type = obj->getProperty("type").toString();
     if (type == "chainElement" || type == "chainElements") {
@@ -3799,16 +3787,10 @@ bool TrackHeadersPanel::isIORoutingVisible() const {
 
 void TrackHeadersPanel::toggleIORouting() {
     // If any track has I/O visible, hide all; otherwise show all
-    bool anyVisible = false;
-    for (auto& h : trackHeaders) {
-        if (h->showIORouting) {
-            anyVisible = true;
-            break;
-        }
-    }
-    for (auto& h : trackHeaders) {
+    const auto showsIORouting = [](const auto& h) { return h->showIORouting; };
+    const bool anyVisible = std::ranges::any_of(trackHeaders, showsIORouting);
+    for (auto& h : trackHeaders)
         h->showIORouting = !anyVisible;
-    }
     showIORouting_ = !anyVisible;
     resized();
 }

--- a/magda/daw/ui/components/tracks/TrackHeadersPanel.hpp
+++ b/magda/daw/ui/components/tracks/TrackHeadersPanel.hpp
@@ -336,6 +336,9 @@ class TrackHeadersPanel : public juce::Component,
     int getVisibleHeaderIndex(TrackId trackId) const;
     juce::Rectangle<int> getTrackHeaderArea(int trackIndex) const;
     juce::Rectangle<int> getResizeHandleArea(int trackIndex) const;
+    /** @brief Non-master header under @p point, or -1; master drops make a new track. */
+    int droppableHeaderIndexAt(juce::Point<int> point) const;
+
     bool isResizeHandleArea(const juce::Point<int>& point, int& trackIndex) const;
     void updateTrackHeaderLayout();
     static void layoutMeterColumn(TrackHeader& header, juce::Rectangle<int>& workArea,

--- a/magda/daw/ui/interaction/ArrangementHitTester.cpp
+++ b/magda/daw/ui/interaction/ArrangementHitTester.cpp
@@ -1,5 +1,6 @@
 #include "ArrangementHitTester.hpp"
 
+#include <algorithm>
 #include <cmath>
 
 namespace magda::interaction {
@@ -30,10 +31,8 @@ bool selectionIncludesLane(int laneIndex, const PanelSnapshot& s) {
 
 // TrackContentPanel::isInSelectableArea — inside any lane rectangle.
 bool inSelectableArea(int x, int y, const PanelSnapshot& s) {
-    for (const auto& lane : s.lanes)
-        if (lane.area.contains(x, y))
-            return true;
-    return false;
+    const auto containsPoint = [x, y](const auto& lane) { return lane.area.contains(x, y); };
+    return std::ranges::any_of(s.lanes, containsPoint);
 }
 
 // TrackContentPanel::isOnSelectionEdge — near a selection boundary on a

--- a/magda/daw/ui/panels/FooterBar.cpp
+++ b/magda/daw/ui/panels/FooterBar.cpp
@@ -2,6 +2,8 @@
 
 #include <BinaryData.h>
 
+#include <ranges>
+
 #include "../../../agents/llama_model_manager.hpp"
 #include "../../scripting_app.hpp"
 #include "../themes/DarkTheme.hpp"
@@ -170,13 +172,13 @@ void FooterBar::paint(juce::Graphics& g) {
     }
 
     // Local model buttons use icons for identity and a small dot for state.
-    for (size_t i = 0; i < localModelButtons_.size(); ++i) {
-        const auto* button = localModelButtons_[i].get();
+    for (const auto& [buttonPtr, state] : std::views::zip(localModelButtons_, localModelStates_)) {
+        const auto* button = buttonPtr.get();
         if (button == nullptr || !button->isVisible())
             continue;
 
         juce::Colour dotColour;
-        switch (localModelStates_[i]) {
+        switch (state) {
             case LocalModelState::Loaded:
                 dotColour = DarkTheme::getColour(DarkTheme::ACCENT_POSITIVE).withAlpha(0.95f);
                 break;

--- a/magda/daw/ui/panels/content/AIChatConsoleContent.cpp
+++ b/magda/daw/ui/panels/content/AIChatConsoleContent.cpp
@@ -1932,11 +1932,8 @@ bool isDrummerTrack(magda::TrackId trackId) {
     const auto* device = magda::TrackManager::getInstance().getPrimaryInstrument(trackId);
     if (device == nullptr)
         return false;
-    for (const auto& row : device->kitRows) {
-        if (row.role.isNotEmpty())
-            return true;
-    }
-    return false;
+    constexpr auto hasRole = [](const auto& row) { return row.role.isNotEmpty(); };
+    return std::ranges::any_of(device->kitRows, hasRole);
 }
 
 // Format an existing drum clip's notes back into the grid grammar the agent

--- a/magda/daw/ui/panels/content/ChordClipContent.cpp
+++ b/magda/daw/ui/panels/content/ChordClipContent.cpp
@@ -18,6 +18,7 @@
 #include "ui/components/common/InternalFileDrag.hpp"
 #include "ui/themes/DarkTheme.hpp"
 #include "ui/themes/InspectorComboBoxLookAndFeel.hpp"
+#include "ui/utils/AudioFileTypes.hpp"
 
 namespace magda::daw::ui {
 
@@ -743,10 +744,7 @@ bool ChordClipContent::onChordRowClicked(double clipRelativeBeat) {
 }
 
 bool ChordClipContent::isInterestedInFileDrag(const juce::StringArray& files) {
-    for (const auto& f : files)
-        if (f.endsWithIgnoreCase(".mid") || f.endsWithIgnoreCase(".midi"))
-            return true;
-    return false;
+    return std::ranges::any_of(files, isMidiFile);
 }
 
 void ChordClipContent::filesDropped(const juce::StringArray& files, int x, int y) {
@@ -755,7 +753,7 @@ void ChordClipContent::filesDropped(const juce::StringArray& files, int x, int y
         return;
 
     for (const auto& f : files) {
-        if (!f.endsWithIgnoreCase(".mid") && !f.endsWithIgnoreCase(".midi"))
+        if (!isMidiFile(f))
             continue;
 
         juce::FileInputStream stream{juce::File(f)};

--- a/magda/daw/ui/panels/content/DrumGridClipContent.cpp
+++ b/magda/daw/ui/panels/content/DrumGridClipContent.cpp
@@ -1382,11 +1382,10 @@ class DrumGridClipGrid : public juce::Component,
         if (!clip)
             return false;
 
-        for (const auto& note : clip->midiNotes) {
-            if (note.noteNumber == noteNumber && std::abs(note.startBeat - beat) < 0.000001)
-                return true;
-        }
-        return false;
+        const auto isNoteAtBeat = [&](const auto& note) {
+            return note.noteNumber == noteNumber && std::abs(note.startBeat - beat) < 0.000001;
+        };
+        return std::ranges::any_of(clip->midiNotes, isNoteAtBeat);
     }
 
     void stampRepeatedNotes() {
@@ -2768,14 +2767,10 @@ void DrumGridClipContent::centerOnNotes() {
 
     int targetRow = -1;
     if (clip && !clip->midiNotes.empty()) {
-        // Find note range and center on midpoint
-        int minNote = 127;
-        int maxNote = 0;
-        for (const auto& note : clip->midiNotes) {
-            minNote = juce::jmin(minNote, note.noteNumber);
-            maxNote = juce::jmax(maxNote, note.noteNumber);
-        }
-        int midNote = (minNote + maxNote) / 2;
+        // Centre on the midpoint of the note range.
+        const auto [lowest, highest] =
+            std::ranges::minmax(clip->midiNotes, {}, &magda::MidiNote::noteNumber);
+        const int midNote = (lowest.noteNumber + highest.noteNumber) / 2;
 
         // Find the row index for this note (rows are reversed: high notes at top)
         for (int i = 0; i < static_cast<int>(padRows_.size()); ++i) {

--- a/magda/daw/ui/panels/content/MediaExplorerContent.cpp
+++ b/magda/daw/ui/panels/content/MediaExplorerContent.cpp
@@ -16,6 +16,7 @@
 #include "MediaDbBrowserContent.hpp"
 #include "MediaExplorerPreviewState.hpp"
 #include "media_db/MediaDbMetadata.hpp"
+#include "ui/utils/AudioFileTypes.hpp"
 
 namespace magda::daw::ui {
 
@@ -1699,17 +1700,6 @@ juce::String MediaExplorerContent::getMediaFilterPattern() const {
     }
 
     return patterns.joinIntoString(";");
-}
-
-bool MediaExplorerContent::isAudioFile(const juce::File& file) {
-    auto ext = file.getFileExtension().toLowerCase();
-    return ext == ".wav" || ext == ".aiff" || ext == ".aif" || ext == ".mp3" || ext == ".ogg" ||
-           ext == ".flac";
-}
-
-bool MediaExplorerContent::isMidiFile(const juce::File& file) {
-    auto ext = file.getFileExtension().toLowerCase();
-    return ext == ".mid" || ext == ".midi";
 }
 
 bool MediaExplorerContent::isMagdaClip(const juce::File& file) {

--- a/magda/daw/ui/panels/content/MediaExplorerContent.hpp
+++ b/magda/daw/ui/panels/content/MediaExplorerContent.hpp
@@ -222,8 +222,6 @@ class MediaExplorerContent : public PanelContent,
     void navigateToDirectory(const juce::File& directory);
     void updateMediaFilter();
     juce::String getMediaFilterPattern() const;
-    static bool isAudioFile(const juce::File& file);
-    static bool isMidiFile(const juce::File& file);
     static bool isMagdaClip(const juce::File& file);
     static bool isPresetFile(const juce::File& file);
     static juce::String formatFileSize(int64_t bytes);

--- a/magda/daw/ui/panels/content/PianoRollContent.cpp
+++ b/magda/daw/ui/panels/content/PianoRollContent.cpp
@@ -1,5 +1,6 @@
 #include "PianoRollContent.hpp"
 
+#include <algorithm>
 #include <cmath>
 #include <limits>
 #include <set>
@@ -2358,17 +2359,9 @@ void PianoRollContent::centerOnNotes() {
         return;
     }
 
-    // Find note range
-    int minNote = 127;
-    int maxNote = 0;
-    for (const auto& note : clip->midiNotes) {
-        minNote = juce::jmin(minNote, note.noteNumber);
-        maxNote = juce::jmax(maxNote, note.noteNumber);
-    }
-
-    // Center on the midpoint of the note range
-    int midNote = (minNote + maxNote) / 2;
-    centerOnNote(midNote);
+    const auto [lowest, highest] =
+        std::ranges::minmax(clip->midiNotes, {}, &magda::MidiNote::noteNumber);
+    centerOnNote((lowest.noteNumber + highest.noteNumber) / 2);
 }
 
 }  // namespace magda::daw::ui

--- a/magda/daw/ui/panels/content/PluginBrowserContent.cpp
+++ b/magda/daw/ui/panels/content/PluginBrowserContent.cpp
@@ -2,6 +2,8 @@
 
 #include <BinaryData.h>
 
+#include <algorithm>
+#include <ranges>
 #include <utility>
 
 #include "../../../../agents/sound_design_agent.hpp"
@@ -35,7 +37,7 @@ namespace magda::daw::ui {
 namespace {
 
 juce::String preferenceIdentifierForPlugin(const PluginBrowserInfo& plugin) {
-    return plugin.uniqueId.isNotEmpty() ? plugin.uniqueId : plugin.name;
+    return preferenceIdentifierForPlugin(plugin);
 }
 
 juce::String effectiveCategoryForPlugin(const PluginBrowserInfo& plugin) {
@@ -967,10 +969,11 @@ void PluginBrowserContent::showPluginContextMenu(const PluginBrowserInfo& plugin
                     prefs.setBrowserCategoryOverride(
                         pluginIdentifier,
                         currentOverride == "MIDI FX" ? juce::String() : juce::String("MIDI FX"));
-                    for (auto& p : plugins_) {
-                        if (preferenceIdentifierForPlugin(p) == pluginIdentifier)
-                            p.categoryOverride = prefs.browserCategoryOverride(pluginIdentifier);
-                    }
+                    const auto sameIdentifier = [&pluginIdentifier](const auto& p) {
+                        return preferenceIdentifierForPlugin(p) == pluginIdentifier;
+                    };
+                    for (auto& p : plugins_ | std::views::filter(sameIdentifier))
+                        p.categoryOverride = prefs.browserCategoryOverride(pluginIdentifier);
                     rebuildTree();
                     break;
                 }
@@ -1007,16 +1010,11 @@ void PluginBrowserContent::showParameterConfigDialog(const PluginBrowserInfo& pl
 }
 
 void PluginBrowserContent::toggleFavorite(const PluginBrowserInfo& plugin) {
-    // Find matching plugin in our list and toggle
-    juce::String key = plugin.uniqueId.isNotEmpty() ? plugin.uniqueId : plugin.name;
-
-    for (auto& p : plugins_) {
-        juce::String pKey = p.uniqueId.isNotEmpty() ? p.uniqueId : p.name;
-        if (pKey == key) {
-            p.isFavorite = !p.isFavorite;
-            DBG("Toggled favorite: " + p.name + " -> " + (p.isFavorite ? "true" : "false"));
-            break;
-        }
+    const auto match = std::ranges::find(plugins_, preferenceIdentifierForPlugin(plugin),
+                                         preferenceIdentifierForPlugin);
+    if (match != plugins_.end()) {
+        match->isFavorite = !match->isFavorite;
+        DBG("Toggled favorite: " + match->name + " -> " + (match->isFavorite ? "true" : "false"));
     }
 
     saveFavorites();
@@ -1033,7 +1031,7 @@ void PluginBrowserContent::saveFavorites() {
         std::vector<magda::PluginFavoriteUpdate> updates;
         updates.reserve(plugins_.size());
         for (const auto& plugin : plugins_) {
-            const auto key = plugin.uniqueId.isNotEmpty() ? plugin.uniqueId : plugin.name;
+            const auto key = preferenceIdentifierForPlugin(plugin);
             updates.push_back({key, plugin.name, plugin.isFavorite});
         }
         store.saveFavorites(updates);
@@ -1048,7 +1046,7 @@ void PluginBrowserContent::loadFavorites() {
         const auto favoriteKeys =
             magda::PluginMetadataStore::defaultForCurrentThread().favoriteKeys();
         for (auto& plugin : plugins_) {
-            const auto key = plugin.uniqueId.isNotEmpty() ? plugin.uniqueId : plugin.name;
+            const auto key = preferenceIdentifierForPlugin(plugin);
             plugin.isFavorite = favoriteKeys.contains(key);
         }
         favoritesLoaded_ = true;
@@ -1066,7 +1064,7 @@ void PluginBrowserContent::saveAliases() {
         auto& store = magda::PluginMetadataStore::defaultForCurrentThread();
         std::map<juce::String, juce::String> aliases;
         for (const auto& plugin : plugins_) {
-            const auto key = plugin.uniqueId.isNotEmpty() ? plugin.uniqueId : plugin.name;
+            const auto key = preferenceIdentifierForPlugin(plugin);
             const auto defaultAlias = PluginBrowserInfo::generateAlias(plugin.name);
             aliases[key] = plugin.alias == defaultAlias ? juce::String() : plugin.alias;
         }
@@ -1081,7 +1079,7 @@ void PluginBrowserContent::loadAliases() {
     try {
         const auto aliasMap = magda::PluginMetadataStore::defaultForCurrentThread().aliases();
         for (auto& plugin : plugins_) {
-            const auto key = plugin.uniqueId.isNotEmpty() ? plugin.uniqueId : plugin.name;
+            const auto key = preferenceIdentifierForPlugin(plugin);
             if (const auto it = aliasMap.find(key); it != aliasMap.end())
                 plugin.alias = it->second;
         }
@@ -1100,7 +1098,7 @@ void PluginBrowserContent::showEditAliasDialog(const PluginBrowserInfo& plugin) 
     alertWindow->addButton("Cancel", 0);
     alertWindow->addButton("Reset", 2);
 
-    juce::String pluginKey = plugin.uniqueId.isNotEmpty() ? plugin.uniqueId : plugin.name;
+    juce::String pluginKey = preferenceIdentifierForPlugin(plugin);
     juce::String pluginName = plugin.name;
 
     alertWindow->enterModalState(
@@ -1110,25 +1108,19 @@ void PluginBrowserContent::showEditAliasDialog(const PluginBrowserInfo& plugin) 
                 // OK — apply custom alias
                 auto newAlias = alertWindow->getTextEditorContents("alias").trim();
                 if (newAlias.isNotEmpty()) {
-                    for (auto& p : plugins_) {
-                        juce::String key = p.uniqueId.isNotEmpty() ? p.uniqueId : p.name;
-                        if (key == pluginKey) {
-                            p.alias = std::move(newAlias);
-                            break;
-                        }
-                    }
+                    const auto match =
+                        std::ranges::find(plugins_, pluginKey, preferenceIdentifierForPlugin);
+                    if (match != plugins_.end())
+                        match->alias = std::move(newAlias);
                     saveAliases();
                     rebuildTree();
                 }
             } else if (result == 2) {
                 // Reset to auto-generated
-                for (auto& p : plugins_) {
-                    juce::String key = p.uniqueId.isNotEmpty() ? p.uniqueId : p.name;
-                    if (key == pluginKey) {
-                        p.alias = PluginBrowserInfo::generateAlias(pluginName);
-                        break;
-                    }
-                }
+                const auto match =
+                    std::ranges::find(plugins_, pluginKey, preferenceIdentifierForPlugin);
+                if (match != plugins_.end())
+                    match->alias = PluginBrowserInfo::generateAlias(pluginName);
                 saveAliases();
                 rebuildTree();
             }

--- a/magda/daw/ui/panels/content/PluginBrowserContent.cpp
+++ b/magda/daw/ui/panels/content/PluginBrowserContent.cpp
@@ -37,7 +37,7 @@ namespace magda::daw::ui {
 namespace {
 
 juce::String preferenceIdentifierForPlugin(const PluginBrowserInfo& plugin) {
-    return preferenceIdentifierForPlugin(plugin);
+    return plugin.uniqueId.isNotEmpty() ? plugin.uniqueId : plugin.name;
 }
 
 juce::String effectiveCategoryForPlugin(const PluginBrowserInfo& plugin) {

--- a/magda/daw/ui/panels/content/TrackChainContent.cpp
+++ b/magda/daw/ui/panels/content/TrackChainContent.cpp
@@ -2,6 +2,7 @@
 
 #include <BinaryData.h>
 
+#include <algorithm>
 #include <cmath>
 #include <thread>
 #include <utility>
@@ -632,12 +633,8 @@ class TrackChainContent::ChainContainer : public juce::Component,
     }
 
     static bool anyDroppablePreset(const juce::StringArray& files) {
-        for (const auto& f : files) {
-            if (isDroppablePreset(f)) {
-                return true;
-            }
-        }
-        return false;
+        const auto isPreset = [](const auto& f) { return isDroppablePreset(f); };
+        return std::ranges::any_of(files, isPreset);
     }
 
     // Load each dropped preset onto the selected track: chain presets replace

--- a/magda/daw/ui/panels/content/inspector/clip/sections/ChordProgressionSection.cpp
+++ b/magda/daw/ui/panels/content/inspector/clip/sections/ChordProgressionSection.cpp
@@ -77,8 +77,8 @@ void ChordProgressionSection::paint(juce::Graphics& g) {
     // Display in time order.
     std::vector<ClipInfo::ChordAnnotation> chords(clip->chordAnnotations.begin(),
                                                   clip->chordAnnotations.end());
-    std::sort(chords.begin(), chords.end(),
-              [](const auto& a, const auto& b) { return a.beatPosition < b.beatPosition; });
+    constexpr auto beatPosition = [](const auto& chord) { return chord.beatPosition; };
+    std::ranges::sort(chords, {}, beatPosition);
 
     auto& notation = magda::music::NotationSettings::getInstance();
     for (const auto& c : chords) {

--- a/magda/daw/ui/panels/state/PanelController.cpp
+++ b/magda/daw/ui/panels/state/PanelController.cpp
@@ -307,17 +307,11 @@ void PanelController::handleReorderTabs(const ReorderTabsEvent& event) {
     if (event.newOrder.size() != panel.tabs.size())
         return;
 
-    for (const auto& type : panel.tabs) {
-        bool found = false;
-        for (const auto& newType : event.newOrder) {
-            if (type == newType) {
-                found = true;
-                break;
-            }
-        }
-        if (!found)
-            return;
-    }
+    const auto inNewOrder = [&event](const auto& type) {
+        return std::ranges::contains(event.newOrder, type);
+    };
+    if (!std::ranges::all_of(panel.tabs, inNewOrder))
+        return;
 
     // Remember current active type
     auto activeType = panel.getActiveContentType();

--- a/magda/daw/ui/panels/state/PanelState.hpp
+++ b/magda/daw/ui/panels/state/PanelState.hpp
@@ -1,5 +1,6 @@
 #pragma once
-
+#include <algorithm>
+#include <iterator>
 #include <vector>
 
 #include "../content/PanelContent.hpp"
@@ -35,22 +36,15 @@ struct PanelState {
      * @brief Check if this panel has a specific content type
      */
     bool hasContentType(PanelContentType type) const {
-        for (const auto& tab : tabs) {
-            if (tab == type)
-                return true;
-        }
-        return false;
+        return std::ranges::contains(tabs, type);
     }
 
     /**
      * @brief Get index of a content type, or -1 if not found
      */
     int getTabIndex(PanelContentType type) const {
-        for (size_t i = 0; i < tabs.size(); ++i) {
-            if (tabs[i] == type)
-                return static_cast<int>(i);
-        }
-        return -1;
+        const auto it = std::ranges::find(tabs, type);
+        return it == tabs.end() ? -1 : static_cast<int>(std::ranges::distance(tabs.begin(), it));
     }
 };
 

--- a/magda/daw/ui/state/TimelineController.cpp
+++ b/magda/daw/ui/state/TimelineController.cpp
@@ -1145,10 +1145,7 @@ TimelineController::ChangeFlags TimelineController::handleEvent(const UpdateMark
     it->setFromBeats(juce::jlimit(0.0, state.timelineLengthBeats, e.positionBeats),
                      state.tempo.bpm);
 
-    std::sort(state.markers.begin(), state.markers.end(),
-              [](const TimelineMarker& a, const TimelineMarker& b) {
-                  return a.positionBeats < b.positionBeats;
-              });
+    std::ranges::sort(state.markers, {}, &TimelineMarker::positionBeats);
     ProjectManager::getInstance().markDirty();
     return ChangeFlags::Markers;
 }
@@ -1167,10 +1164,7 @@ TimelineController::ChangeFlags TimelineController::handleEvent(const RemoveMark
 
 TimelineController::ChangeFlags TimelineController::handleEvent(const SetMarkersEvent& e) {
     state.markers = e.markers;
-    std::sort(state.markers.begin(), state.markers.end(),
-              [](const TimelineMarker& a, const TimelineMarker& b) {
-                  return a.positionBeats < b.positionBeats;
-              });
+    std::ranges::sort(state.markers, {}, &TimelineMarker::positionBeats);
     // Keep nextMarkerId ahead of every restored id so later adds don't collide.
     state.nextMarkerId = 1;
     for (const auto& marker : state.markers)
@@ -1379,10 +1373,7 @@ void TimelineController::restoreProjectState(double tempo, int timeSigNum, int t
         state.markers.push_back(marker);
         state.nextMarkerId = juce::jmax(state.nextMarkerId, marker.id + 1);
     }
-    std::sort(state.markers.begin(), state.markers.end(),
-              [](const TimelineMarker& a, const TimelineMarker& b) {
-                  return a.positionBeats < b.positionBeats;
-              });
+    std::ranges::sort(state.markers, {}, &TimelineMarker::positionBeats);
 
     // Notify audio engine unconditionally
     for (auto* listener : audioEngineListeners) {

--- a/magda/daw/ui/themes/DarkTheme.cpp
+++ b/magda/daw/ui/themes/DarkTheme.cpp
@@ -1,5 +1,8 @@
 #include "DarkTheme.hpp"
 
+#include <algorithm>
+#include <iterator>
+
 namespace magda {
 
 namespace {
@@ -688,11 +691,11 @@ const DarkTheme::SyntaxPalette& ThemeManager::builtInSyntaxPalette(const std::st
 std::optional<ColourRole> DarkTheme::findDarkPaletteRole(juce::Colour colour) {
     const auto rgb = colour.getARGB() & 0x00FFFFFFu;
     const auto findRole = [rgb](const Palette& palette) -> std::optional<ColourRole> {
-        for (std::size_t index = 0; index < palette.size(); ++index)
-            if ((palette[index] & 0x00FFFFFFu) == rgb)
-                return static_cast<ColourRole>(index);
-
-        return std::nullopt;
+        const auto hasThisRgb = [rgb](auto entry) { return (entry & 0x00FFFFFFu) == rgb; };
+        const auto match = std::ranges::find_if(palette, hasThisRgb);
+        if (match == palette.end())
+            return std::nullopt;
+        return static_cast<ColourRole>(std::ranges::distance(palette.begin(), match));
     };
 
     if (const auto activeRole = findRole(activePalette_))

--- a/magda/daw/ui/themes/ThemeSerialization.cpp
+++ b/magda/daw/ui/themes/ThemeSerialization.cpp
@@ -1,6 +1,8 @@
 #include "ThemeSerialization.hpp"
 
+#include <algorithm>
 #include <array>
+#include <iterator>
 
 namespace magda {
 
@@ -200,20 +202,23 @@ std::optional<ColourRole> findColourRole(const juce::String& key) {
     const auto norm = normalizeKey(key);
     if (norm.isEmpty())
         return std::nullopt;
-    for (std::size_t i = 0; i < kColourRoleNames.size(); ++i)
-        if (normalizeKey(kColourRoleNames[i]) == norm)
-            return static_cast<ColourRole>(i);
-    return std::nullopt;
+    const auto matchesKey = [&norm](const auto& name) { return normalizeKey(name) == norm; };
+    const auto match = std::ranges::find_if(kColourRoleNames, matchesKey);
+    if (match == kColourRoleNames.end())
+        return std::nullopt;
+    return static_cast<ColourRole>(std::ranges::distance(kColourRoleNames.begin(), match));
 }
 
 std::optional<SyntaxColourRole> findSyntaxColourRole(const juce::String& key) {
     const auto norm = normalizeKey(key);
     if (norm.isEmpty())
         return std::nullopt;
-    for (std::size_t i = 0; i < kSyntaxColourRoleNames.size(); ++i)
-        if (normalizeKey(kSyntaxColourRoleNames[i]) == norm)
-            return static_cast<SyntaxColourRole>(i);
-    return std::nullopt;
+    const auto matchesKey = [&norm](const auto& name) { return normalizeKey(name) == norm; };
+    const auto match = std::ranges::find_if(kSyntaxColourRoleNames, matchesKey);
+    if (match == kSyntaxColourRoleNames.end())
+        return std::nullopt;
+    return static_cast<SyntaxColourRole>(
+        std::ranges::distance(kSyntaxColourRoleNames.begin(), match));
 }
 
 std::optional<juce::Colour> parseColourString(const juce::String& text) {

--- a/magda/daw/ui/themes/UserTheme.cpp
+++ b/magda/daw/ui/themes/UserTheme.cpp
@@ -11,6 +11,12 @@ namespace magda {
 
 namespace {
 
+// Theme lists are presented alphabetically, case-insensitively, by display name.
+constexpr auto byNameIgnoringCase = [](const juce::String& a, const juce::String& b) {
+    return a.compareIgnoreCase(b) < 0;
+};
+constexpr auto themeName = [](const auto& entry) { return juce::String(entry.name); };
+
 std::string resolveBaseId(const juce::var& baseVar, std::vector<std::string>& warnings) {
     if (!baseVar.isString())
         return ThemeManager::kDarkThemeId;
@@ -128,10 +134,7 @@ const std::vector<FactoryThemeEntry>& factoryThemes() {
                 entry.name = loaded->name;
             list.push_back(std::move(entry));
         }
-        std::sort(list.begin(), list.end(),
-                  [](const FactoryThemeEntry& a, const FactoryThemeEntry& b) {
-                      return juce::String(a.name).compareIgnoreCase(juce::String(b.name)) < 0;
-                  });
+        std::ranges::sort(list, byNameIgnoringCase, themeName);
         return list;
     }();
     return entries;
@@ -170,9 +173,7 @@ std::vector<ThemeFileEntry> scanUserThemes() {
         entries.push_back(std::move(entry));
     }
 
-    std::sort(entries.begin(), entries.end(), [](const ThemeFileEntry& a, const ThemeFileEntry& b) {
-        return juce::String(a.name).compareIgnoreCase(juce::String(b.name)) < 0;
-    });
+    std::ranges::sort(entries, byNameIgnoringCase, themeName);
     return entries;
 }
 

--- a/magda/daw/ui/utils/AudioFileTypes.hpp
+++ b/magda/daw/ui/utils/AudioFileTypes.hpp
@@ -1,0 +1,54 @@
+#pragma once
+
+#include <juce_audio_formats/juce_audio_formats.h>
+
+#include <algorithm>
+#include <ranges>
+
+namespace magda {
+
+/**
+ * @brief What a drop target will accept, asked of JUCE rather than hardcoded.
+ *
+ * registerBasicFormats() adds CoreAudioFormat on macOS and
+ * WindowsMediaAudioFormat on Windows, so the readable set is platform
+ * dependent. The eight hand-written extension lists this replaces disagreed
+ * with each other and with what SourcePool can actually load (#2147).
+ */
+inline const juce::StringArray& audioFileExtensions() {
+    static const juce::StringArray extensions = [] {
+        juce::AudioFormatManager formats;
+        formats.registerBasicFormats();
+        juce::StringArray out;
+        for (const auto& wildcard :
+             juce::StringArray::fromTokens(formats.getWildcardForAllFormats(), ";", ""))
+            out.add(wildcard.fromFirstOccurrenceOf("*", false, false).toLowerCase());
+        return out;
+    }();
+    return extensions;
+}
+
+/** @brief Whether a path names an audio file this build can decode. */
+inline constexpr struct IsAudioFile {
+    bool operator()(const juce::String& path) const {
+        const auto matches = [&path](const juce::String& ext) {
+            return path.endsWithIgnoreCase(ext);
+        };
+        return std::ranges::any_of(audioFileExtensions(), matches);
+    }
+    bool operator()(const juce::File& file) const {
+        return (*this)(file.getFullPathName());
+    }
+} isAudioFile;
+
+/** @brief Whether a path names a Standard MIDI File. */
+inline constexpr struct IsMidiFile {
+    bool operator()(const juce::String& path) const {
+        return path.endsWithIgnoreCase(".mid") || path.endsWithIgnoreCase(".midi");
+    }
+    bool operator()(const juce::File& file) const {
+        return (*this)(file.getFullPathName());
+    }
+} isMidiFile;
+
+}  // namespace magda

--- a/magda/daw/ui/views/SessionView.cpp
+++ b/magda/daw/ui/views/SessionView.cpp
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include <cmath>
 #include <functional>
+#include <iterator>
 #include <set>
 #include <unordered_map>
 
@@ -41,6 +42,7 @@
 #include "core/TrackPropertyCommands.hpp"
 #include "core/UndoManager.hpp"
 #include "core/ViewModeController.hpp"
+#include "ui/utils/AudioFileTypes.hpp"
 
 namespace magda {
 
@@ -1726,14 +1728,7 @@ void SessionView::trackPropertyChanged(int trackId) {
     if (!track)
         return;
 
-    // Find index in visible track IDs
-    int index = -1;
-    for (size_t i = 0; i < visibleTrackIds_.size(); ++i) {
-        if (visibleTrackIds_[i] == trackId) {
-            index = static_cast<int>(i);
-            break;
-        }
-    }
+    const int index = trackIndexOf(trackId);
 
     if (index >= 0 && index < static_cast<int>(trackHeaders.size())) {
         // Update header text with collapse indicator for groups
@@ -2866,15 +2861,9 @@ void SessionView::rangeSelectSlots(int trackIndex, int sceneIndex, ClipId clicke
     // Anchor = last single-clicked clip; the range is the rectangle of slots
     // between the anchor's (track, scene) cell and the clicked cell
     const auto* anchorClip = clipManager.getClip(sel.getAnchorClip());
-    int anchorTrackIndex = -1;
-    if (anchorClip != nullptr && anchorClip->sceneIndex >= 0) {
-        for (size_t i = 0; i < visibleTrackIds_.size(); ++i) {
-            if (visibleTrackIds_[i] == anchorClip->trackId) {
-                anchorTrackIndex = static_cast<int>(i);
-                break;
-            }
-        }
-    }
+    const int anchorTrackIndex = (anchorClip != nullptr && anchorClip->sceneIndex >= 0)
+                                     ? trackIndexOf(anchorClip->trackId)
+                                     : -1;
 
     if (anchorTrackIndex < 0) {
         sel.selectClip(clickedClipId);
@@ -2939,17 +2928,14 @@ void SessionView::triggerGroupScene(TrackId groupId, int sceneIndex) {
 
     // Check if any descendant clip in this scene is playing — if so, stop all; else trigger all
     auto& cm = ClipManager::getInstance();
-    bool anyPlaying = false;
-    for (auto tid : descendants) {
-        ClipId cid = cm.getClipInSlot(tid, sceneIndex);
-        if (cid != INVALID_CLIP_ID && audioEngine_) {
-            auto state = audioEngine_->getSessionClipPlayState(cid);
-            if (state == SessionClipPlayState::Playing || state == SessionClipPlayState::Queued) {
-                anyPlaying = true;
-                break;
-            }
-        }
-    }
+    const auto isSoundingInThisScene = [&](TrackId tid) {
+        const ClipId cid = cm.getClipInSlot(tid, sceneIndex);
+        if (cid == INVALID_CLIP_ID || audioEngine_ == nullptr)
+            return false;
+        const auto state = audioEngine_->getSessionClipPlayState(cid);
+        return state == SessionClipPlayState::Playing || state == SessionClipPlayState::Queued;
+    };
+    const bool anyPlaying = std::ranges::any_of(descendants, isSoundingInThisScene);
 
     for (auto tid : descendants) {
         ClipId cid = cm.getClipInSlot(tid, sceneIndex);
@@ -3274,14 +3260,7 @@ void SessionView::clipPropertyChanged(ClipId clipId) {
     if (!clip || clip->sceneIndex < 0)
         return;
 
-    // Find track index
-    int trackIndex = -1;
-    for (size_t i = 0; i < visibleTrackIds_.size(); ++i) {
-        if (visibleTrackIds_[i] == clip->trackId) {
-            trackIndex = static_cast<int>(i);
-            break;
-        }
-    }
+    const int trackIndex = trackIndexOf(clip->trackId);
 
     if (trackIndex >= 0) {
         updateClipSlotAppearance(trackIndex, clip->sceneIndex);
@@ -3290,12 +3269,8 @@ void SessionView::clipPropertyChanged(ClipId clipId) {
     // Also update parent group slot
     const auto* track = TrackManager::getInstance().getTrack(clip->trackId);
     if (track && track->hasParent()) {
-        for (size_t i = 0; i < visibleTrackIds_.size(); ++i) {
-            if (visibleTrackIds_[i] == track->parentId) {
-                updateClipSlotAppearance(static_cast<int>(i), clip->sceneIndex);
-                break;
-            }
-        }
+        if (const int parentIndex = trackIndexOf(track->parentId); parentIndex >= 0)
+            updateClipSlotAppearance(parentIndex, clip->sceneIndex);
     }
 
     updateSceneButtonIcon(clip->sceneIndex);
@@ -3325,14 +3300,7 @@ void SessionView::clipPlaybackStateChanged(ClipId clipId) {
         << clipId << " playState=" << (int)playState
         << " sessionPlayheadPos=" << clip->sessionPlayheadPos);
 
-    // Find track index
-    int trackIndex = -1;
-    for (size_t i = 0; i < visibleTrackIds_.size(); ++i) {
-        if (visibleTrackIds_[i] == clip->trackId) {
-            trackIndex = static_cast<int>(i);
-            break;
-        }
-    }
+    const int trackIndex = trackIndexOf(clip->trackId);
 
     if (trackIndex >= 0) {
         updateClipSlotAppearance(trackIndex, clip->sceneIndex);
@@ -3341,12 +3309,8 @@ void SessionView::clipPlaybackStateChanged(ClipId clipId) {
     // Also update parent group slot if this track has a parent
     const auto* track = TrackManager::getInstance().getTrack(clip->trackId);
     if (track && track->hasParent()) {
-        for (size_t i = 0; i < visibleTrackIds_.size(); ++i) {
-            if (visibleTrackIds_[i] == track->parentId) {
-                updateClipSlotAppearance(static_cast<int>(i), clip->sceneIndex);
-                break;
-            }
-        }
+        if (const int parentIndex = trackIndexOf(track->parentId); parentIndex >= 0)
+            updateClipSlotAppearance(parentIndex, clip->sceneIndex);
     }
 
     updateSceneButtonIcon(clip->sceneIndex);
@@ -3791,14 +3755,15 @@ void SessionView::timerCallback() {
 // File Drag & Drop
 // ============================================================================
 
+int SessionView::trackIndexOf(TrackId trackId) const {
+    const auto it = std::ranges::find(visibleTrackIds_, trackId);
+    return it == visibleTrackIds_.end()
+               ? -1
+               : static_cast<int>(std::ranges::distance(visibleTrackIds_.begin(), it));
+}
+
 bool SessionView::isInterestedInFileDrag(const juce::StringArray& files) {
-    // Accept if at least one file is an audio file
-    for (const auto& file : files) {
-        if (isAudioFile(file)) {
-            return true;
-        }
-    }
-    return false;
+    return std::ranges::any_of(files, isAudioFile);
 }
 
 void SessionView::fileDragEnter(const juce::StringArray& files, int x, int y) {
@@ -4060,18 +4025,6 @@ void SessionView::clearDragGhost() {
     if (dragGhostLabel_) {
         dragGhostLabel_->setVisible(false);
     }
-}
-
-bool SessionView::isAudioFile(const juce::String& filename) {
-    static const juce::StringArray audioExtensions = {".wav",  ".aiff", ".aif", ".mp3", ".ogg",
-                                                      ".flac", ".m4a",  ".wma", ".opus"};
-
-    for (const auto& ext : audioExtensions) {
-        if (filename.endsWithIgnoreCase(ext)) {
-            return true;
-        }
-    }
-    return false;
 }
 
 // ============================================================================

--- a/magda/daw/ui/views/SessionView.hpp
+++ b/magda/daw/ui/views/SessionView.hpp
@@ -272,11 +272,13 @@ class SessionView : public juce::Component,
     int pluginDropTrackIndex_ = -1;
     bool showPluginDropOverlay_ = false;
     std::unique_ptr<juce::Label> dragGhostLabel_;
+    /** @brief Row of a track in the visible order, or -1 when it is not shown. */
+    int trackIndexOf(TrackId trackId) const;
+
     void updateDragHighlight(int x, int y);
     void clearDragHighlight();
     void updateDragGhost(const juce::StringArray& files, int trackIndex, int sceneIndex);
     void clearDragGhost();
-    static bool isAudioFile(const juce::String& filename);
 
     // The media browser delivers sample drags as an internal {type:"files"}
     // payload rather than an OS file-drag on Linux, where JUCE has no Wayland

--- a/magda/daw/ui/windows/MainWindowCommands.cpp
+++ b/magda/daw/ui/windows/MainWindowCommands.cpp
@@ -1,4 +1,5 @@
 #include <algorithm>
+#include <ranges>
 
 #include "../../core/AutomationCommands.hpp"
 #include "../../core/ClipCommands.hpp"
@@ -66,17 +67,23 @@ ViewMode getNextCycledViewMode(ViewMode mode, bool forward) {
 bool canNudgeSelectedClips() {
     auto& clipManager = ClipManager::getInstance();
     auto& trackManager = TrackManager::getInstance();
-    bool found = false;
-    for (ClipId clipId : SelectionManager::getInstance().getSelectedClips()) {
-        const auto* clip = clipManager.getClip(clipId);
-        if (clip == nullptr || clip->view != ClipView::Arrangement)
-            continue;
+
+    const auto toClip = [&clipManager](ClipId id) { return clipManager.getClip(id); };
+    const auto isArrangementClip = [](const ClipInfo* clip) {
+        return clip != nullptr && clip->view == ClipView::Arrangement;
+    };
+
+    const auto& selected = SelectionManager::getInstance().getSelectedClips();
+    auto arrangementClips =
+        selected | std::views::transform(toClip) | std::views::filter(isArrangementClip);
+
+    const auto onFrozenTrack = [&](const ClipInfo* clip) {
         const auto* track = trackManager.getTrack(clip->trackId);
-        if (track != nullptr && track->frozen)
-            return false;
-        found = true;
-    }
-    return found;
+        return track != nullptr && track->frozen;
+    };
+
+    return !std::ranges::empty(arrangementClips) &&
+           std::ranges::none_of(arrangementClips, onFrozenTrack);
 }
 
 bool containsTimelineTime(const ClipInfo& clip, double timeSeconds, double bpm) {


### PR DESCRIPTION
Part of #2147. Not the whole issue yet; the remaining sites are listed at the bottom and are coming as further commits on this branch.

Every call site takes a named predicate or projection, so the first layer reads as a sentence rather than as a lambda body:

```cpp
return anyEnabledMod(ctx.deviceMods) || anyEnabledMod(ctx.rackMods) ||
       anyEnabledMod(ctx.trackMods) || anyMacro(ctx.deviceMacros) ||
       anyMacro(ctx.rackMacros) || anyMacro(ctx.trackMacros);
```

## One predicate for droppable files

The eight hand-written extension lists disagreed with each other:

| site | extensions |
|---|---|
| `SessionView` | wav aiff aif mp3 ogg flac **m4a wma opus** |
| `TrackContentPanel`, `MediaExplorerContent`, `SamplerUI`, `DrumGridUI` | wav aiff aif mp3 ogg flac |
| `ImpulseResponseUI` | wav aif aiff flac ogg, **no mp3** |

No fixed list is right on every platform either, because `registerBasicFormats()` adds `CoreAudioFormat` on macOS and `WindowsMediaAudioFormat` on Windows. So `ui/utils/AudioFileTypes.hpp` asks the format manager. `isAudioFile` and `isMidiFile` are callable objects rather than overloaded functions, which is what lets them pass by name to `any_of` instead of through a wrapper lambda.

This fixes a real bug: `SessionView` was accepting `.opus` drops that no build can decode.

## The duplication the sweep exposed

Each of these is now behind one name:

- `SessionView::trackIndexOf`, six copies of the same index-of walk
- `TrackHeadersPanel::droppableHeaderIndexAt`, three copies of the same hit test
- `CurveEditorBase::setPointComponentSelected`, four copies
- `ParamLinkResolver::hasActiveLinks`, six loops plus two identical `ControlTarget` constructions
- `PluginBrowserContent`, nine re-inlined copies of the uniqueId-or-name key rule that `preferenceIdentifierForPlugin` already implemented

`ChainPanel::calculateInsertIndex` lost its trailing "after last element" branch: `find_if` plus `distance` already returns `size()` when nothing matches.

## Two things found on the way

`DrumGridRoles` is in `daw/audio`, not `daw/ui`. The core and audio sweep closed without it and it is the same two-loop shape, so it is fixed here.

Four files used `std::ranges::distance` without including `<iterator>`, relying on `<algorithm>` to pull it in. That is the same transitive-include trap that broke `std::inserter` on the C++23 bump, and it would compile here and fail on a different standard library.

## Verification

Debug build clean. Catch2: 3859 cases, 1946211 assertions, 0 failures. JUCE suite green, including all nine real-project corpus cases through both engines.

`readability-use-anyofallof` now reports nothing in `daw/ui`. Its one remaining hit is `daw/project/ProjectInfo.hpp`, which belongs to #2148.

## Still to come on this branch

`AISettingsDialog` (3), the `filter | ranges::to` pair in `SessionView`, `PianoRollContent`'s min/max trio, `ClipComponent`'s zip, the `AIChatConsoleContent` sorts, `DeviceSlotHeaderControls`' reverse loop, `PluginBrowserContent` spec filter/transform, and a few singles in `ChordClipContent`, `MidiEditorContent` and `TrackInspector`.

Deliberately not converted: the `ModulatorEditorPanel` sites the issue calls "the ParamLinkResolver twins" are nested accumulates over `m.links` with a per-outer-element `m.value` in today's code, not searches. That is a fold, and joining would lose the outer element.

https://claude.ai/code/session_01VomqgBSXsWYdyHyec9DvPi